### PR TITLE
improved contrast in acl selector, and preview (darkzero)

### DIFF
--- a/view/theme/darkzero/style.css
+++ b/view/theme/darkzero/style.css
@@ -92,3 +92,11 @@ blockquote {
 	background: #ddd;
 	color: #000;
 }
+
+.acl-list-item p, #profile-jot-email-label, div#jot-preview-content, div.profile-jot-net {
+        color: #000000;
+}
+
+input#acl-search {
+        background-color: #aaa;
+}


### PR DESCRIPTION
Added some contrast to the darkzero theme. I filed this bug report for the issue: http://bugs.friendica.com/view.php?id=310
