### PR TITLE
fixed issue with network hiding posts in certain situations

### DIFF
--- a/mod/network.php
+++ b/mod/network.php
@@ -470,7 +470,7 @@ function network_content(&$a, $update = 0) {
 
 		if(count($r)) {
 			foreach($r as $rr)
-				if(! array_key_exists($rr['item_id'],$parents_arr))
+				if(! array_key_exists($rr['item_id'],array_keys($parents_arr,'item_id',true)))
 					$parents_arr[] = $rr['item_id'];
 			$parents_str = implode(', ', $parents_arr);
 


### PR DESCRIPTION
Please have a look at this one, as I'm still new to the code base (and PHP for that matter). I discovered a bug where the network page will, under certain circumstances, fail to show you all of the items that you should see. I described this in a little more detail on the bug report here:
http://bugs.friendica.com/view.php?id=323
