### PR TITLE
allow users to set categories on their posts

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -293,6 +293,8 @@ class App {
 	
 	public $nav_sel;
 
+	public $category;
+
 	private $scheme;
 	private $hostname;
 	private $baseurl;
@@ -377,6 +379,9 @@ class App {
 		$this->argc = count($this->argv);
 		if((array_key_exists('0',$this->argv)) && strlen($this->argv[0])) {
 			$this->module = str_replace(".", "_", $this->argv[0]);
+			if(array_key_exists('2',$this->argv)) {
+			    $this->category = $this->argv[2];
+			}
 		}
 		else {
 			$this->argc = 1;

--- a/include/contact_widgets.php
+++ b/include/contact_widgets.php
@@ -103,3 +103,31 @@ function fileas_widget($baseurl,$selected = '') {
 	));
 }
 
+function categories_widget($baseurl,$selected = '') {
+	$a = get_app();
+
+	$saved = get_pconfig($a->profile['profile_uid'],'system','filetags');
+	if(! strlen($saved))
+		return;
+
+	$matches = false;
+	$terms = array();
+        $cnt = preg_match_all('/<(.*?)>/',$saved,$matches,PREG_SET_ORDER);
+        if($cnt) {
+                foreach($matches as $mtch) {
+		        $unescaped = xmlify(file_tag_decode($mtch[1]));
+			$terms[] = array('name' => $unescaped,'selected' => (($selected == $unescaped) ? 'selected' : ''));
+		}
+	}
+
+	return replace_macros(get_markup_template('categories_widget.tpl'),array(
+		'$title' => t('Categories'),
+		'$desc' => '',
+		'$sel_all' => (($selected == '') ? 'selected' : ''),
+		'$all' => t('Everything'),
+		'$terms' => $terms,
+		'$base' => $baseurl,
+
+	));
+}
+

--- a/include/conversation.php
+++ b/include/conversation.php
@@ -974,6 +974,8 @@ function status_editor($a,$x, $notes_cid = 0, $popup=false) {
 		'$shortnoloc' => t('clear location'),
 		'$title' => "",
 		'$placeholdertitle' => t('Set title'),
+		'$category' => "",
+		'$placeholdercategory' => t('Categories (comma-separated list)'),
 		'$wait' => t('Please wait'),
 		'$permset' => t('Permission settings'),
 		'$shortpermset' => t('permissions'),

--- a/include/text.php
+++ b/include/text.php
@@ -1314,6 +1314,118 @@ function file_tag_file_query($table,$s,$type = 'file') {
 	return " AND " . (($table) ? dbesc($table) . '.' : '') . "file regexp '" . dbesc($str) . "' ";
 }
 
+// ex. given music,video return <music><video> or [music][video]
+function file_tag_list_to_file($list,$type = 'file') {
+        $tag_list = '';
+        if(strlen($list)) {
+                $list_array = explode(",",$list);
+                if($type == 'file') {
+	                $lbracket = '[';
+	                $rbracket = ']';
+	        }
+                else {
+	                $lbracket = '<';
+        	        $rbracket = '>';
+	        }
+
+                foreach($list_array as $item) {
+		  if(strlen($item)) {
+		                $tag_list .= $lbracket . file_tag_encode(trim($item))  . $rbracket;
+			}
+                }
+	}
+        return $tag_list;
+}
+
+// ex. given <music><video>[friends], return music,video or friends
+function file_tag_file_to_list($file,$type = 'file') {
+        $matches = false;
+        $list = '';
+        if($type == 'file') {
+                $cnt = preg_match_all('/\[(.*?)\]/',$file,$matches,PREG_SET_ORDER);
+	}
+        else {
+                $cnt = preg_match_all('/<(.*?)>/',$file,$matches,PREG_SET_ORDER);
+	}
+	if($cnt) {
+		foreach($matches as $mtch) {
+			if(strlen($list))
+				$list .= ',';
+			$list .= file_tag_decode($mtch[1]);
+		}
+	}
+
+        return $list;
+}
+
+function file_tag_update_pconfig($uid,$file_old,$file_new,$type = 'file') {
+        // $file_old - categories previously associated with an item
+        // $file_new - new list of categories for an item
+
+	if(! intval($uid))
+		return false;
+
+        if($file_old == $file_new)
+	        return true;
+
+	$saved = get_pconfig($uid,'system','filetags');
+        if(strlen($saved)) {
+                if($type == 'file') {
+	                $lbracket = '[';
+	                $rbracket = ']';
+	        }
+                else {
+	                $lbracket = '<';
+        	        $rbracket = '>';
+	        }
+
+                $filetags_updated = $saved;
+
+		// check for new tags to be added as filetags in pconfig
+                $new_tags = array();
+                $check_new_tags = explode(",",file_tag_file_to_list($file_new,$type));
+
+	        foreach($check_new_tags as $tag) {
+		        if(! stristr($saved,$lbracket . file_tag_encode($tag) . $rbracket))
+			        $new_tags[] = $tag;
+	        }
+
+		$filetags_updated .= file_tag_list_to_file(implode(",",$new_tags),$type);
+
+		// check for deleted tags to be removed from filetags in pconfig
+                $deleted_tags = array();
+                $check_deleted_tags = explode(",",file_tag_file_to_list($file_old,$type));
+
+	        foreach($check_deleted_tags as $tag) {
+		        if(! stristr($file_new,$lbracket . file_tag_encode($tag) . $rbracket))
+		                $deleted_tags[] = $tag;
+	        }
+
+                foreach($deleted_tags as $key => $tag) {
+		        $r = q("select file from item where uid = %d " . file_tag_file_query('item',$tag,$type),
+		                intval($uid)
+	                );
+
+	                if(count($r)) {
+			        unset($deleted_tags[$key]);
+	                }
+			else {
+			        $filetags_updated = str_replace($lbracket . file_tag_encode($tag) . $rbracket,'',$filetags_updated);
+			}
+		}
+
+                if($saved != $filetags_updated) {
+		        set_pconfig($uid,'system','filetags', $filetags_updated);
+                }
+		return true;
+	}
+        else
+                if(strlen($file_new)) {
+		        set_pconfig($uid,'system','filetags', $file_new);
+                }
+		return true;
+}
+
 function file_tag_save_file($uid,$item,$file) {
 	$result = false;
 	if(! intval($uid))

--- a/mod/editpost.php
+++ b/mod/editpost.php
@@ -115,6 +115,8 @@ function editpost_content(&$a) {
 		'$jotnets' => $jotnets,
 		'$title' => $itm[0]['title'],
 		'$placeholdertitle' => t('Set title'),
+                '$category' => file_tag_file_to_list($itm[0]['file'], 'category'),
+                '$placeholdercategory' => t('Categories (comma-separated list)'),
 		'$emtitle' => t('Example: bob@example.com, mary@example.com'),
 		'$lockstate' => $lockstate,
 		'$acl' => '', // populate_acl((($group) ? $group_acl : $a->user), $celeb),

--- a/mod/item.php
+++ b/mod/item.php
@@ -216,8 +216,6 @@ function item_post(&$a) {
 		$emailcc           = notags(trim($_REQUEST['emailcc']));
 		$body              = escape_tags(trim($_REQUEST['body']));
 
-		// $categories = TODO
-
 		$private = ((strlen($str_group_allow) || strlen($str_contact_allow) || strlen($str_group_deny) || strlen($str_contact_deny)) ? 1 : 0);
 
 		if(($parent_item) && 
@@ -253,6 +251,19 @@ function item_post(&$a) {
 				goaway($a->get_baseurl() . "/" . $return_path );
 			killme();
 		}
+	}
+
+        if(strlen($categories)) {
+	        // get the "fileas" tags for this post
+                $filedas = file_tag_file_to_list($categories, 'file');
+	}
+        // save old and new categories, so we can determine what needs to be deleted from pconfig
+        $categories_old = $categories;
+        $categories = file_tag_list_to_file(trim($_REQUEST['category']), 'category');
+        $categories_new = $categories;
+        if(strlen($filedas)) {
+	        // append the fileas stuff to the new categories list
+	        $categories .= file_tag_list_to_file($filedas, 'file');
 	}
 
 	// Work around doubled linefeeds in Tinymce 3.5b2
@@ -572,6 +583,9 @@ function item_post(&$a) {
 			intval($profile_uid)
 		);
 
+		// update filetags in pconfig
+                file_tag_update_pconfig($uid,$categories_old,$categories_new,'category');
+
 		proc_run('php', "include/notifier.php", 'edit_post', "$post_id");
 		if((x($_REQUEST,'return')) && strlen($return_path)) {
 			logger('return: ' . $return_path);
@@ -585,8 +599,8 @@ function item_post(&$a) {
 
 	$r = q("INSERT INTO `item` (`guid`, `uid`,`type`,`wall`,`gravity`,`contact-id`,`owner-name`,`owner-link`,`owner-avatar`, 
 		`author-name`, `author-link`, `author-avatar`, `created`, `edited`, `commented`, `received`, `changed`, `uri`, `thr-parent`, `title`, `body`, `app`, `location`, `coord`, 
-		`tag`, `inform`, `verb`, `postopts`, `allow_cid`, `allow_gid`, `deny_cid`, `deny_gid`, `private`, `pubmail`, `attach`, `bookmark`,`origin`, `moderated` )
-		VALUES( '%s', %d, '%s', %d, %d, %d, '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', %d, %d, '%s', %d, %d, %d )",
+		`tag`, `inform`, `verb`, `postopts`, `allow_cid`, `allow_gid`, `deny_cid`, `deny_gid`, `private`, `pubmail`, `attach`, `bookmark`,`origin`, `moderated`, `file` )
+		VALUES( '%s', %d, '%s', %d, %d, %d, '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', %d, %d, '%s', %d, %d, %d, '%s' )",
 		dbesc($datarray['guid']),
 		intval($datarray['uid']),
 		dbesc($datarray['type']),
@@ -624,14 +638,18 @@ function item_post(&$a) {
 		dbesc($datarray['attach']),
 		intval($datarray['bookmark']),
 		intval($datarray['origin']),
-		intval($datarray['moderated'])
-	);
+	        intval($datarray['moderated']),
+	        dbesc($datarray['file'])
+	       );
 
 	$r = q("SELECT `id` FROM `item` WHERE `uri` = '%s' LIMIT 1",
 		dbesc($datarray['uri']));
 	if(count($r)) {
 		$post_id = $r[0]['id'];
 		logger('mod_item: saved item ' . $post_id);
+
+		// update filetags in pconfig
+                file_tag_update_pconfig($uid,$categories_old,$categories_new,'category');
 
 		if($parent) {
 

--- a/mod/profile.php
+++ b/mod/profile.php
@@ -2,6 +2,11 @@
 
 function profile_init(&$a) {
 
+	require_once('include/contact_widgets.php');
+
+	if(! x($a->page,'aside'))
+		$a->page['aside'] = '';
+
 	$blocked = (((get_config('system','block_public')) && (! local_user()) && (! remote_user())) ? true : false);
 
 	if($a->argc > 1)
@@ -59,6 +64,13 @@ function profile_init(&$a) {
 
 function profile_content(&$a, $update = 0) {
 
+        if (x($a->category)) {
+	        $category = $a->category;
+	}
+        else {
+	        $category = ((x($_GET,'category')) ? $_GET['category'] : '');
+	}
+
 	if(get_config('system','block_public') && (! local_user()) && (! remote_user())) {
 		return login();
 	}
@@ -112,7 +124,8 @@ function profile_content(&$a, $update = 0) {
 		return;
 	}
 
-	
+	$a->page['aside'] .= categories_widget($a->get_baseurl(true) . '/profile/' . $a->profile['nickname'],(x($category) ? xmlify($category) : ''));
+
 	if(! $update) {
 		if(x($_GET,'tab'))
 			$tab = notags(trim($_GET['tab']));
@@ -134,6 +147,7 @@ function profile_content(&$a, $update = 0) {
 		$commvisitor = (($commpage && $remote_contact == true) ? true : false);
 
 		$celeb = ((($a->profile['page-flags'] == PAGE_SOAPBOX) || ($a->profile['page-flags'] == PAGE_COMMUNITY)) ? true : false);
+
 
 		if(can_write_wall($a,$a->profile['profile_uid'])) {
 
@@ -178,6 +192,10 @@ function profile_content(&$a, $update = 0) {
 	}
 	else {
 
+                if(x($category)) {
+		        $sql_extra .= file_tag_file_query('item',$category,'category');
+		}
+
 		$r = q("SELECT COUNT(*) AS `total`
 			FROM `item` LEFT JOIN `contact` ON `contact`.`id` = `item`.`contact-id`
 			WHERE `item`.`uid` = %d AND `item`.`visible` = 1 AND `item`.`deleted` = 0
@@ -204,6 +222,7 @@ function profile_content(&$a, $update = 0) {
 			intval($a->profile['profile_uid'])
 
 		);
+
 	}
 
 	$parents_arr = array();

--- a/view/categories_widget.tpl
+++ b/view/categories_widget.tpl
@@ -1,0 +1,13 @@
+<div class="clear"></div>
+<div id="categories-sidebar" class="widget">
+	<h3>$title</h3>
+	<div id="nets-desc">$desc</div>
+	
+	<ul class="categories-ul">
+		<li class="tool"><a href="$base" class="categories-link categories-all{{ if $sel_all }} categories-selected{{ endif }}">$all</a></li>
+		{{ for $terms as $term }}
+			<li class="tool"><a href="$base?f=&category=$term.name" class="categories-link{{ if $term.selected }} categories-selected{{ endif }}">$term.name</a></li>
+		{{ endfor }}
+	</ul>
+	
+</div>

--- a/view/jot.tpl
+++ b/view/jot.tpl
@@ -15,6 +15,7 @@
 		<input type="hidden" name="post_id" value="$post_id" />
 		<input type="hidden" name="preview" id="jot-preview" value="0" />
 		<div id="jot-title-wrap"><input name="title" id="jot-title" type="text" placeholder="$placeholdertitle" value="$title" class="jothidden" style="display:none"></div>
+		<div id="jot-category-wrap"><input name="category" id="jot-category" type="text" placeholder="$placeholdercategory" value="$category" class="jothidden" style="display:none" /></div>
 		<div id="jot-text-wrap">
 		<img id="profile-jot-text-loading" src="images/rotator.gif" alt="$wait" title="$wait" style="display: none;" />
 		<textarea rows="5" cols="64" class="profile-jot-text" id="profile-jot-text" name="body" >{{ if $content }}$content{{ else }}$share{{ endif }}</textarea>

--- a/view/theme/darkzero/style.css
+++ b/view/theme/darkzero/style.css
@@ -76,17 +76,21 @@ input#dfrn-url {
 }
 
 
-#jot-title {
+#jot-title, #jot-category {
 	background-color: #333333;
 	border: 1px solid #333333;
 }
 
 #jot-title::-webkit-input-placeholder{ color: #555555!important;}
 #jot-title:-moz-placeholder{color: #555555!important;}
+#jot-category::-webkit-input-placeholder{ color: #555555!important;}
+#jot-category:-moz-placeholder{color: #555555!important;}
 		
 	
 #jot-title:hover,
-#jot-title:focus {
+#jot-title:focus,
+#jot-category:hover,
+#jot-category:focus {
 	border: 1px solid #cccccc; 
 }
 blockquote {

--- a/view/theme/duepuntozero/style.css
+++ b/view/theme/duepuntozero/style.css
@@ -285,7 +285,7 @@ div.wall-item-content-wrapper.shiny {
 	float: left;
 }
 
-#jot-title {
+#jot-title, #jot-category {
 	border: 0px;
 	margin: 0px;
 	height: 20px;
@@ -296,11 +296,15 @@ div.wall-item-content-wrapper.shiny {
 }
 
 #jot-title::-webkit-input-placeholder{font-weight: normal;}
+#jot-category::-webkit-input-placeholder{font-weight: normal;}
 #jot-title:-moz-placeholder{font-weight: normal;}
+#jot-category:-moz-placeholder{font-weight: normal;}
 		
 	
 #jot-title:hover,
-#jot-title:focus {
+#jot-title:focus,
+#jot-category:hover,
+#jot-category:focus {
 	border: 1px solid #cccccc; 
 }
 
@@ -322,7 +326,7 @@ div.wall-item-content-wrapper.shiny {
 	margin-bottom: 10px;
 }
 
-.group-selected, .nets-selected, .fileas-selected {
+.group-selected, .nets-selected, .fileas-selected, .categories-selected {
 	padding: 3px;
 	-moz-border-radius: 3px;
 	border-radius: 3px;	
@@ -1881,11 +1885,11 @@ a.mail-list-link {
 	margin-top: 10px;
 }
 
-.nets-ul, .fileas-ul {
+.nets-ul, .fileas-ul, .categories-ul {
 	list-style-type: none;
 }
 
-.nets-ul li, .fileas-ul li {
+.nets-ul li, .fileas-ul li, .categories-ul li {
 	margin-top: 10px;
 }
 
@@ -1896,11 +1900,11 @@ a.mail-list-link {
 	margin-left: 42px;
 }
 
-.fileas-link {
+.fileas-link, .categories-link {
 	margin-left: 24px;
 }
 
-.fileas-all {
+.fileas-all, .categories-all {
 	margin-left: 0px;
 }
 
@@ -2628,12 +2632,12 @@ aside input[type='text'] {
 	margin-top: 10px;
 }
 
-.body-tag, .filesavetags {
+.body-tag, .filesavetags, .categorytags {
 	opacity: 0.5;
 	filter:alpha(opacity=50);
 }
 
-.body-tag:hover, .filesavetags:hover {
+.body-tag:hover, .filesavetags:hover, .categorytags:hover {
 	opacity: 1.0 !important;
 	filter:alpha(opacity=100) !important;
 }


### PR DESCRIPTION
Ok, so I have the basics done for "categories." I figured it was about time I submit what I have.

Some possible points for discussion:
- All category tags themselves are public (even if the associated posts remain private).
- When a post is edited, and the categories changed, we have to query item for each to see if there are any other items that still have this category associated with them. We do this so we can remove them from pconfig if they're no longer used at all. Could this be an issue?

I'm completely open to feedback, so let me know if there are any concerns at all.

Thanks.
