### PR TITLE
Bug in StatusNet API

### DIFF
--- a/include/api.php
+++ b/include/api.php
@@ -380,7 +380,7 @@
 			$nick = $name;
 
 		// Generating a random ID
-		if (!array_key_exists($nick, $usercache))
+		if (is_null($usercache[$nick]) or !array_key_exists($nick, $usercache))
 			$usercache[$nick] = mt_rand(2000000, 2100000);
 
 		$ret = array(


### PR DESCRIPTION
There was a bug in function api_item_get_user during random ID generation that prevented Mustard from updating one's private stream.

Change api.php in function api_item_get_user to check if $usercache is NULL before checking an element in it.
