### PR TITLE
Moved <meta viewport> to theme; Diabook style

### DIFF
--- a/view/head.tpl
+++ b/view/head.tpl
@@ -6,7 +6,6 @@
 <link rel="stylesheet" href="$baseurl/library/jgrowl/jquery.jgrowl.css" type="text/css" media="screen" />
 
 <link rel="stylesheet" type="text/css" href="$stylesheet" media="all" />
-<meta name="viewport" content="width=800, initial-scale=1, maximum-scale=3" />
 
 <link rel="shortcut icon" href="$baseurl/images/friendica-32.png" />
 <link rel="search"

--- a/view/theme/diabook/style.css
+++ b/view/theme/diabook/style.css
@@ -558,6 +558,7 @@ code {
   text-decoration: none;
 }
 /* popup notifications */
+div.jGrowl.top-right { top: 30px; /* put it below header/nav bar */ }
 div.jGrowl div.notice {
   background: #511919 url("../../../images/icons/48/notice.png") no-repeat 5px center;
   color: #ffffff;

--- a/view/theme/diabook/theme.php
+++ b/view/theme/diabook/theme.php
@@ -26,6 +26,14 @@ $resolution=false;
 $resolution = get_pconfig(local_user(), "diabook", "resolution");
 if ($resolution===false) $resolution="normal";
 
+//Add META viewport tag respecting the resolution to header for tablets
+if ($resolution=="wide") {
+  $a->page['htmlhead'] .= '<meta name="viewport" content="width=1200" />';
+} else {
+  $a->page['htmlhead'] .= '<meta name="viewport" content="width=980" />';
+}
+
+
 $color = false;
 $site_color = get_config("diabook", "color" );
 if (local_user()) {$color = get_pconfig(local_user(), "diabook", "color");}


### PR DESCRIPTION
Moved Meta Viewport from global head.tpl to diabook's header
I mistakenly added this <meta> tag to the global header, but it
causes problems for other themes, as they have other optimal widths.
So propably this <meta> tag should be added to all themes, but with
individual parameters.

Now I also added a style to diabook which makes the jGrowl messages
appear below the header bar, so you can still click the menu items
without having to close messages first.
