### PR TITLE
Allow plugins to modify the contact photo menu

### DIFF
--- a/include/Contact.php
+++ b/include/Contact.php
@@ -209,7 +209,7 @@ function contact_photo_menu($contact) {
 	);
 	
 	
-	$args = array('contact' => $contact, 'menu' => $menu);
+	$args = array('contact' => $contact, 'menu' => &$menu);
 	
 	call_hooks('contact_photo_menu', $args);
 	


### PR DESCRIPTION
I'm using this to add a "Retriever" menu item for RSS feeds, but I imagine various connectors will have their own specialised things you can do with a contact.
