### PR TITLE
fix small typo for logging command in api.php

### DIFF
--- a/include/api.php
+++ b/include/api.php
@@ -245,7 +245,7 @@
 			
 		}
 		
-		logger('api_user: ' . $extra_query . ' ' , $user);
+		logger('api_user: ' . $extra_query . ', user: ' . $user);
 		// user info		
 		$uinfo = q("SELECT *, `contact`.`id` as `cid` FROM `contact`
 				WHERE 1


### PR DESCRIPTION
Logging command had a comma instead of a period so the variable wasn't logged
