### PR TITLE
Diaspora dont check more signatures than diaspora does

### DIFF
--- a/include/diaspora.php
+++ b/include/diaspora.php
@@ -1866,21 +1866,6 @@ function diaspora_signed_retraction($importer,$xml,$msg) {
 	}
 	else {
 
-/*		if(strcasecmp($diaspora_handle,$msg['author']) == 0) {
-			$person = $contact;
-			$key = $msg['key'];
-		}
-		else {
-			$person = find_diaspora_person_by_handle($diaspora_handle);	
-
-			if(is_array($person) && x($person,'pubkey'))
-				$key = $person['pubkey'];
-			else {
-				logger('diaspora_signed_retraction: unable to find author details');
-				return;
-			}
-		}*/
-
 		$sig_decode = base64_decode($sig);
 
 		if(! rsa_verify($signed_data,$sig_decode,$key,'sha256')) {


### PR DESCRIPTION
Currently, when Friendica receives a comment, like, or relayable retraction from Diaspora, it always checks the author signature, and it also checks the parent-author signature if it exists.

However, in Diaspora, only the signature of the person that you directly received the item from is checked. Thus, the parent-author checks the author signature, but the relay recipients only check the parent-author signature. Since the parent-author has already checked the author signature, there's no need for each recipient to check it as well.

This also means that no person has to check a signature for a person who is not his/her contact.
