### PR TITLE
allow linking to Diaspora's scaled-down images

### DIFF
--- a/include/diaspora.php
+++ b/include/diaspora.php
@@ -1560,7 +1560,8 @@ function diaspora_photo($importer,$xml,$msg) {
 
 	$link_text = '[img]' . $remote_photo_path . $remote_photo_name . '[/img]' . "\n";
 
-	$link_text = scale_external_images($link_text);
+	$link_text = scale_external_images($link_text, true,
+	                                   array($remote_photo_name, 'scaled_full_' . $remote_photo_name));
 
 	if(strpos($parent_item['body'],$link_text) === false) {
 		$r = q("update item set `body` = '%s', `visible` = 1 where `id` = %d and `uid` = %d limit 1",

--- a/include/network.php
+++ b/include/network.php
@@ -793,7 +793,7 @@ function add_fcontact($arr,$update = false) {
 }
 
 
-function scale_external_images($s,$include_link = true) {
+function scale_external_images($s, $include_link = true, $scale_replace = false) {
 
 	$a = get_app();
 
@@ -803,10 +803,22 @@ function scale_external_images($s,$include_link = true) {
 		require_once('include/Photo.php');
 		foreach($matches as $mtch) {
 			logger('scale_external_image: ' . $mtch[1]);
+
 			$hostname = str_replace('www.','',substr($a->get_baseurl(),strpos($a->get_baseurl(),'://')+3));
 			if(stristr($mtch[1],$hostname))
 				continue;
-			$i = fetch_url($mtch[1]);
+
+			// $scale_replace, if passed, is an array of two elements. The
+			// first is the name of the full-size image. The second is the
+			// name of a remote, scaled-down version of the full size image.
+			// This allows Friendica to display the smaller remote image if
+			// one exists, while still linking to the full-size image
+			if($scale_replace)
+				$scaled = str_replace($scale_replace[0], $scale_replace[1], $mtch[1]);
+			else
+				$scaled = $mtch[1];
+			$i = fetch_url($scaled);
+
 			// guess mimetype from headers or filename
 			$type = guess_image_type($mtch[1],true);
 			
@@ -822,7 +834,7 @@ function scale_external_images($s,$include_link = true) {
 						$new_width = $ph->getWidth();
 						$new_height = $ph->getHeight();
 						logger('scale_external_images: ' . $orig_width . '->' . $new_width . 'w ' . $orig_height . '->' . $new_height . 'h' . ' match: ' . $mtch[0], LOGGER_DEBUG);
-						$s = str_replace($mtch[0],'[img=' . $new_width . 'x' . $new_height. ']' . $mtch[1] . '[/img]'
+						$s = str_replace($mtch[0],'[img=' . $new_width . 'x' . $new_height. ']' . $scaled . '[/img]'
 							. "\n" . (($include_link) 
 								? '[url=' . $mtch[1] . ']' . t('view full size') . '[/url]' . "\n"
 								: ''),$s);


### PR DESCRIPTION
Diaspora's default is to allow image uploads up to 4 MB in size. When Friendica receives a Diaspora post with a photo, it displays the full-size image scaled down to 640 pixels on a side maximum. For several 4 MB images, this can cause the Network page to load and scroll slowly and unevenly.

Diaspora displays a scaled-down version of the image in its stream which is a maximum of 700 pixels on a side. Displaying this image instead of the full-size image on the Network page makes loading and scrolling much faster.

A link to the full-size image is still preserved.
