### PR TITLE
Fix Diaspora list formatting

### DIFF
--- a/include/bb2diaspora.php
+++ b/include/bb2diaspora.php
@@ -113,18 +113,16 @@ function bb2diaspora($Text,$preserve_nl = false) {
 	// text with opening and closing tags, so nested lists may make things
 	// wonky
 	$endlessloop = 0;
-	while ((strpos($Text, "[/list]") !== false) && (strpos($Text, "[list") !== false) &&
-	       (strpos($Text, "[/ul]") !== false) && (strpos($Text, "[ul]") !== false) && 
-	       (strpos($Text, "[/ol]") !== false) && (strpos($Text, "[ol]") !== false) && (++$endlessloop < 20)) {
+	while ((strpos($Text, "[/list]") !== false) && (strpos($Text, "[list") !== false) && (++$endlessloop < 20)) {
 		$Text = preg_replace_callback("/\[list\](.*?)\[\/list\]/is", 'diaspora_ul', $Text);
-		$Text = preg_replace_callback("/\[ul\](.*?)\[\/ul\]/is", 'diaspora_ul', $Text);
 		$Text = preg_replace_callback("/\[list=1\](.*?)\[\/list\]/is", 'diaspora_ol', $Text);
 		$Text = preg_replace_callback("/\[list=i\](.*?)\[\/list\]/s",'diaspora_ol', $Text);
 		$Text = preg_replace_callback("/\[list=I\](.*?)\[\/list\]/s", 'diaspora_ol', $Text);
 		$Text = preg_replace_callback("/\[list=a\](.*?)\[\/list\]/s", 'diaspora_ol', $Text);
 		$Text = preg_replace_callback("/\[list=A\](.*?)\[\/list\]/s", 'diaspora_ol', $Text);
-		$Text = preg_replace_callback("/\[ol\](.*?)\[\/ol\]/is", 'diaspora_ol', $Text);
 	}
+	$Text = preg_replace_callback("/\[ul\](.*?)\[\/ul\]/is", 'diaspora_ul', $Text);
+	$Text = preg_replace_callback("/\[ol\](.*?)\[\/ol\]/is", 'diaspora_ol', $Text);
 
 	// Convert it to HTML - don't try oembed
 	$Text = bbcode($Text, $preserve_nl, false);


### PR DESCRIPTION
The `bbcode()` function that converts BB code into HTML converts the `[*]` list elements into `<li>` elements with no closing `</li>`. Markdownify is not able to handle these, and it doesn't appear possible to determine where to place a closing `</li>` using regular expressions--it requires a PECL or PEAR extension to PHP.

So the lists need to be pre-formatted as Diaspora expressions before the text is sent to `bbcode()`, which this pull implements.
