### PR TITLE
use author handle instead of sender handle

### DIFF
--- a/include/diaspora.php
+++ b/include/diaspora.php
@@ -5,6 +5,7 @@ require_once('include/items.php');
 require_once('include/bb2diaspora.php');
 require_once('include/contact_selectors.php');
 require_once('include/queue_fn.php');
+require_once('include/lock.php');
 
 
 function diaspora_dispatch_public($msg) {
@@ -113,27 +114,83 @@ function diaspora_get_contact_by_handle($uid,$handle) {
 }
 
 function find_diaspora_person_by_handle($handle) {
+
+	$person = false;
 	$update = false;
-	$r = q("select * from fcontact where network = '%s' and addr = '%s' limit 1",
-		dbesc(NETWORK_DIASPORA),
-		dbesc($handle)
-	);
-	if(count($r)) {
-		logger('find_diaspora_person_by handle: in cache ' . print_r($r,true), LOGGER_DEBUG);
-		// update record occasionally so it doesn't get stale
-		$d = strtotime($r[0]['updated'] . ' +00:00');
-		if($d > strtotime('now - 14 days'))
-			return $r[0];
-		$update = true;
-	}
-	logger('find_diaspora_person_by_handle: refresh',LOGGER_DEBUG);
-	require_once('include/Scrape.php');
-	$r = probe_url($handle, PROBE_DIASPORA);
-	if((count($r)) && ($r['network'] === NETWORK_DIASPORA)) {
-		add_fcontact($r,$update);
-		return ($r);
-	}
-	return false;
+	$got_lock = false;
+
+	do {
+		$r = q("select * from fcontact where network = '%s' and addr = '%s' limit 1",
+			dbesc(NETWORK_DIASPORA),
+			dbesc($handle)
+		);
+		if(count($r)) {
+			$person = $r[0];
+			logger('find_diaspora_person_by handle: in cache ' . print_r($r,true), LOGGER_DEBUG);
+
+			// update record occasionally so it doesn't get stale
+			$d = strtotime($person['updated'] . ' +00:00');
+			if($d < strtotime('now - 14 days'))
+				$update = true;
+		}
+
+
+		// FETCHING PERSON INFORMATION FROM REMOTE SERVER
+		//
+		// If the person isn't in our 'fcontact' table, or if he/she is but
+		// his/her information hasn't been updated for more than 14 days, then
+		// we want to fetch the person's information from the remote server.
+		//
+		// Note that $person isn't changed by this block of code unless the
+		// person's information has been successfully fetched from the remote
+		// server. So if $person was 'false' to begin with (because he/she wasn't
+		// in the local cache), it'll stay false, and if $person held the local
+		// cache information to begin with, it'll keep that information. That way
+		// if there's a problem with the remote fetch, we can at least use our
+		// cached information--it's better than nothing.
+
+		if((! $person) || ($update))  {
+			// Lock the function to prevent race conditions if multiple items
+			// come in at the same time from a person who doesn't exist in
+			// fcontact
+			$got_lock = lock_function('find_diaspora_person_by_handle', false);
+
+			if($got_lock) {
+				logger('find_diaspora_person_by_handle: create or refresh', LOGGER_DEBUG);
+				require_once('include/Scrape.php');
+				$r = probe_url($handle, PROBE_DIASPORA);
+
+				// Note that Friendica contacts can return a "Diaspora person"
+				// if Diaspora connectivity is enabled on their server
+				if((count($r)) && ($r['network'] === NETWORK_DIASPORA)) {
+					add_fcontact($r,$update);
+					$person = ($r);
+				}
+
+				unlock_function('find_diaspora_person_by_handle');
+			}
+			else {
+				logger('find_diaspora_person_by_handle: couldn\'t lock function', LOGGER_DEBUG);
+				if(! $person)
+					block_on_function_lock('find_diaspora_person_by_handle');
+			}
+		}
+	} while((! $person) && (! $got_lock));
+	// We need to try again if the person wasn't in 'fcontact' but the function was locked.
+	// The fact that the function was locked may mean that another process was creating the
+	// person's record. It could also mean another process was creating or updating an unrelated
+	// person.
+	//
+	// At any rate, we need to keep trying until we've either got the person or had a chance to
+	// try to fetch his/her remote information. But we don't want to block on locking the
+	// function, because if the other process is creating the record, then when we acquire the lock
+	// we'll dive right into creating another, duplicate record. We DO want to at least wait
+	// until the lock is released, so we don't flood the database with requests.
+	//
+	// If the person was in the 'fcontact' table, don't try again. It's not worth the time, since
+	// we do have some information for the person
+
+	return $person;
 }
 
 
@@ -2252,7 +2309,6 @@ function diaspora_send_relay($item,$owner,$contact,$public_batch = false) {
 		$relay_retract = true;
 
 		$target_type = ( ($item['verb'] === ACTIVITY_LIKE) ? 'Like' : 'Comment');
-		$sender_signed_text = $item['guid'] . ';' . $target_type ;
 
 		$sql_sign_id = 'retract_iid';
 		$tpl = get_markup_template('diaspora_relayable_retraction.tpl');
@@ -2263,13 +2319,10 @@ function diaspora_send_relay($item,$owner,$contact,$public_batch = false) {
 		$target_type = 'Post';
 //		$positive = (($item['deleted']) ? 'false' : 'true');
 		$positive = 'true';
-		$sender_signed_text = $item['guid'] . ';' . $target_type . ';' . $parent_guid . ';' . $positive . ';' . $myaddr;
 
 		$tpl = get_markup_template('diaspora_like_relay.tpl');
 	}
 	else { // item is a comment
-		$sender_signed_text = $item['guid'] . ';' . $parent_guid . ';' . $text . ';' . $myaddr;
-
 		$tpl = get_markup_template('diaspora_comment_relay.tpl');
 	}
 
@@ -2294,6 +2347,13 @@ function diaspora_send_relay($item,$owner,$contact,$public_batch = false) {
 		logger('diaspora_send_relay: original author signature not found, cannot send relayable');
 		return;
 	}
+
+	if($relay_retract)
+		$sender_signed_text = $item['guid'] . ';' . $target_type;
+	elseif($like)
+		$sender_signed_text = $item['guid'] . ';' . $target_type . ';' . $parent_guid . ';' . $positive . ';' . $handle;
+	else
+		$sender_signed_text = $item['guid'] . ';' . $parent_guid . ';' . $text . ';' . $handle;
 
 	// Sign the relayable with the top-level owner's signature
 	//


### PR DESCRIPTION
Another oversight on relayable signed text creation: the signed text needs to use the text author's handle, not the top-level post author's handle.
