### PR TITLE
fix check for parent of StatusNet API post

### DIFF
--- a/include/api.php
+++ b/include/api.php
@@ -565,18 +565,19 @@
 		if(requestdata('lat') && requestdata('long'))
 			$_REQUEST['coord'] = sprintf("%s %s",requestdata('lat'),requestdata('long'));
 		$_REQUEST['profile_uid'] = local_user();
-		if(requestdata('parent'))
+//		if(requestdata('parent'))
+		if($parent)
 			$_REQUEST['type'] = 'net-comment';
 		else {
 			$_REQUEST['type'] = 'wall';
-                        if(x($_FILES,'media')) {
-		                // upload the image if we have one
-		                $_REQUEST['hush']='yeah'; //tell wall_upload function to return img info instead of echo
-			        require_once('mod/wall_upload.php');
-			        $media = wall_upload_post($a);
-		                if(strlen($media)>0)
-				        $_REQUEST['body'] .= "\n\n".$media;
-			        }
+			if(x($_FILES,'media')) {
+				// upload the image if we have one
+				$_REQUEST['hush']='yeah'; //tell wall_upload function to return img info instead of echo
+				require_once('mod/wall_upload.php');
+				$media = wall_upload_post($a);
+				if(strlen($media)>0)
+					$_REQUEST['body'] .= "\n\n".$media;
+			}
 		}
 
 		// set this so that the item_post() function is quiet and doesn't redirect or emit json

--- a/include/onepoll.php
+++ b/include/onepoll.php
@@ -449,7 +449,7 @@ function onepoll_run($argv, $argc){
 
 	if($xml) {
 		logger('poller: received xml : ' . $xml, LOGGER_DATA);
-			if((! strstr($xml,'<?xml')) && (! strstr($xml,'<rss'))) {
+		if((! strstr($xml,'<?xml')) && (! strstr($xml,'<rss'))) {
 			logger('poller: post_handshake: response from ' . $url . ' did not contain XML.');
 			$r = q("UPDATE `contact` SET `last-update` = '%s' WHERE `id` = %d LIMIT 1",
 				dbesc(datetime_convert()),

--- a/mod/item.php
+++ b/mod/item.php
@@ -108,7 +108,7 @@ function item_post(&$a) {
 		}
 	}
 
-	if($parent) logger('mod_post: parent=' . $parent);
+	if($parent) logger('mod_item: item_post parent=' . $parent);
 
 	$profile_uid = ((x($_REQUEST,'profile_uid')) ? intval($_REQUEST['profile_uid']) : 0);
 	$post_id     = ((x($_REQUEST,'post_id'))     ? intval($_REQUEST['post_id'])     : 0);


### PR DESCRIPTION
Current code results in comments made through API showing up in DB as "wall" posts, which can make them show up to people twice in certain situations
