### PR TITLE
fix logic for nested lists--should be OR, not AND

### DIFF
--- a/include/bb2diaspora.php
+++ b/include/bb2diaspora.php
@@ -113,9 +113,9 @@ function bb2diaspora($Text,$preserve_nl = false) {
 	// to define the closing tag for the list elements. So nested lists
 	// are going to be flattened out in Diaspora for now
 	$endlessloop = 0;
-	while ((strpos($Text, "[/list]") !== false) && (strpos($Text, "[list") !== false) &&
-	       (strpos($Text, "[/ol]") !== false) && (strpos($Text, "[ol]") !== false) && 
-	       (strpos($Text, "[/ul]") !== false) && (strpos($Text, "[ul]") !== false) && (++$endlessloop < 20)) {
+	while ((((strpos($Text, "[/list]") !== false) && (strpos($Text, "[list") !== false)) ||
+	       ((strpos($Text, "[/ol]") !== false) && (strpos($Text, "[ol]") !== false)) || 
+	       ((strpos($Text, "[/ul]") !== false) && (strpos($Text, "[ul]") !== false))) && (++$endlessloop < 20)) {
 		$Text = preg_replace_callback("/\[list\](.*?)\[\/list\]/is", 'diaspora_ul', $Text);
 		$Text = preg_replace_callback("/\[list=1\](.*?)\[\/list\]/is", 'diaspora_ol', $Text);
 		$Text = preg_replace_callback("/\[list=i\](.*?)\[\/list\]/s",'diaspora_ol', $Text);

--- a/include/bbcode.php
+++ b/include/bbcode.php
@@ -163,9 +163,9 @@ function bbcode($Text,$preserve_nl = false, $tryoembed = true) {
  	// handle nested lists
 	$endlessloop = 0;
 
-	while ((strpos($Text, "[/list]") !== false) && (strpos($Text, "[list") !== false) &&
-	       (strpos($Text, "[/ol]") !== false) && (strpos($Text, "[ol]") !== false) && 
-	       (strpos($Text, "[/ul]") !== false) && (strpos($Text, "[ul]") !== false) && (++$endlessloop < 20)) {
+	while ((((strpos($Text, "[/list]") !== false) && (strpos($Text, "[list") !== false)) ||
+	       ((strpos($Text, "[/ol]") !== false) && (strpos($Text, "[ol]") !== false)) || 
+	       ((strpos($Text, "[/ul]") !== false) && (strpos($Text, "[ul]") !== false))) && (++$endlessloop < 20)) {
 		$Text = preg_replace("/\[list\](.*?)\[\/list\]/ism", '<ul class="listbullet" style="list-style-type: circle;">$1</ul>' ,$Text);
 		$Text = preg_replace("/\[list=\](.*?)\[\/list\]/ism", '<ul class="listnone" style="list-style-type: none;">$1</ul>' ,$Text);
 		$Text = preg_replace("/\[list=1\](.*?)\[\/list\]/ism", '<ul class="listdecimal" style="list-style-type: decimal;">$1</ul>' ,$Text);


### PR DESCRIPTION
In the `bbcode()` function, when looking for nested lists, 'AND'ing everything together requires that ALL those list elements exist in order for the loop to even run once. The different lists need to be 'OR'ed together to achieve the desired effect.
