### PR TITLE
add ability to set maximum pixel length of uploaded pictures

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -34,6 +34,24 @@ define ( 'JPEG_QUALITY',            100  );
  */
 define ( 'PNG_QUALITY',             8  );
 
+/**
+ *
+ * An alternate way of limiting picture upload sizes. Specify the maximum pixel
+ * length that pictures are allowed to be (for non-square pictures, it will apply
+ * to the longest side). Pictures longer than this length will be resized to be
+ * this length (on the longest side, the other side will be scaled appropriately).
+ * Modify this value using
+ *
+ *    $a->config['system']['max_image_length'] = n;
+ *
+ * in .htconfig.php
+ *
+ * If you don't want to set a maximum length, set to -1. The default value is
+ * defined by 'MAX_IMAGE_LENGTH' below.
+ *
+ */
+define ( 'MAX_IMAGE_LENGTH',        -1  );
+
 
 /**
  * Not yet used

--- a/mod/photos.php
+++ b/mod/photos.php
@@ -743,6 +743,12 @@ function photos_post(&$a) {
 	$ph->orient($src);
 	@unlink($src);
 
+	$max_length = get_config('system','max_image_length');
+	if(! $max_length)
+		$max_length = MAX_IMAGE_LENGTH;
+	if($max_length > 0)
+		$ph->scaleImage($max_length);
+
 	$width  = $ph->getWidth();
 	$height = $ph->getHeight();
 


### PR DESCRIPTION
This pull allows admins to set a maximum length (for the longest side) they want to allow uploaded pictures to be. The benefit of this is that instead of blocking users from uploading images past a certain size and forcing them to fix it themselves, it allows users to upload very large images and then does the resizing for them. This makes things easier on users while still keeping the images at a low footprint.

Admins may still choose to set no limit on pixel length and use the other existing limits as they desire.
