### PR TITLE
remove check for event description in bb2diaspora

### DIFF
--- a/include/bb2diaspora.php
+++ b/include/bb2diaspora.php
@@ -346,7 +346,7 @@ function bb2diaspora($Text,$preserve_nl = false) {
 
 	// If we found an event earlier, strip out all the event code and replace with a reformatted version.
 
-	if(x($ev,'desc') && x($ev,'start')) {
+	if(x($ev,'start')) {
 
 		$sub = format_event_diaspora($ev);
 


### PR DESCRIPTION
Friendica currently doesn't require an event description to create an event. However, `bb2diaspora` required one to exist before it would convert the event to Diaspora formatting. The result is that description-less events showed up in Diaspora with all the BB code tags, instead of formatted. This pull removes the requirement for event descriptions in `bb2diaspora`, allowing all events to show up properly.
