### PR TITLE
Prevent long delays in Diaspora delivery

### DIFF
--- a/include/diaspora.php
+++ b/include/diaspora.php
@@ -2517,7 +2517,7 @@ function diaspora_send_mail($item,$owner,$contact) {
 
 }
 
-function diaspora_transmit($owner,$contact,$slap,$public_batch) {
+function diaspora_transmit($owner,$contact,$slap,$public_batch,$queue_run=false) {
 
 	$enabled = intval(get_config('system','diaspora_enabled'));
 	if(! $enabled) {
@@ -2534,7 +2534,7 @@ function diaspora_transmit($owner,$contact,$slap,$public_batch) {
 
 	logger('diaspora_transmit: ' . $logid . ' ' . $dest_url);
 
-	if(was_recently_delayed($contact['id'])) {
+	if( (! $queue_run) && (was_recently_delayed($contact['id'])) ) {
 		$return_code = 0;
 	}
 	else {

--- a/include/lock.php
+++ b/include/lock.php
@@ -73,5 +73,3 @@ function unlock_function($fn_name) {
 
 	return;
 }}
-
-?>

--- a/include/queue.php
+++ b/include/queue.php
@@ -161,7 +161,7 @@ function queue_run($argv, $argc){
 			case NETWORK_DIASPORA:
 				if($contact['notify']) {
 					logger('queue: diaspora_delivery: item ' . $q_item['id'] . ' for ' . $contact['name']);
-					$deliver_status = diaspora_transmit($owner,$contact,$data,$public);
+					$deliver_status = diaspora_transmit($owner,$contact,$data,$public,true);
 
 					if($deliver_status == (-1))
 						update_queue_time($q_item['id']);


### PR DESCRIPTION
I have on several occasions encountered a situation where posts to Diaspora get hung up in limbo and don't get delivered for over a day, or even days. I was able to examine one of these and I believe it's due to the fact that `was_recently_delayed` gets called (in `diaspora_transmit`) during the queue run.

By way of explanation: my cron job runs every 10 minutes. Say that message A gets sent to Diaspora, but fails for some reason. It gets queued. At the next cron job, since the message was created less than 15 minutes ago, it gets ignored. Now say that message B gets sent by the same person:

`|-------|----`
`---A--------B`

At the next cron job, B is ignored, but the queue run tries to deliver A, since it's now been more than 15 minutes since it was created. However, since B, created by the same contact, was created less than 15 minutes ago, `was_recently_delayed` causes `diaspora_transmit` to give up and A gets re-queued:

`|-------|-------|`
`------------B---A`

Then at the next cron job, the queue tries to deliver B, but `was_recently_delayed` sees that A was last updated in the previous 15 minutes and causes `diaspora_transmit` to give up and B gets re-queued:

`|-------|-------|-------|`
`----------------A-------B`

Etc.

`|-------|-------|-------|-------|`
`------------------------B-------A`

It appears that this continues until 12 hours have elapsed, when the queue run starts to wait an hour before delivery attempts. However, it can be delayed further if the contact tries to send more messages in the mean time.

This pull allows `diaspora_transmit` to ignore `was_recently_delayed` during queue runs, which should fix the problem.
