### PR TITLE
Couple of Diaspora fixes

### DIFF
--- a/include/bb2diaspora.php
+++ b/include/bb2diaspora.php
@@ -196,6 +196,14 @@ function bb2diaspora($Text,$preserve_nl = false, $fordiaspora = true) {
 	// The bbcode parser now handles youtube-links (and the other stuff) correctly.
 	// Additionally the html code is now fixed so that lists are now working.
 
+	/**
+	 * Transform #tags, strip off the [url] and replace spaces with underscore
+	 */
+	$Text = preg_replace_callback('/#\[url\=(\w+.*?)\](\w+.*?)\[\/url\]/i', create_function('$match',
+		'return \'#\'. str_replace(\' \', \'_\', $match[2]);'
+	), $Text);
+
+
 	// Converting images with size parameters to simple images. Markdown doesn't know it.
 	$Text = preg_replace("/\[img\=([0-9]*)x([0-9]*)\](.*?)\[\/img\]/ism", '[img]$3[/img]', $Text);
 

--- a/include/items.php
+++ b/include/items.php
@@ -2459,6 +2459,7 @@ function local_delivery($importer,$data) {
 
 					$is_a_remote_delete = false;
 
+					// POSSIBLE CLEANUP --> Why select so many fields when only forum_mode and wall are used?
 					$r = q("select `item`.`id`, `item`.`uri`, `item`.`tag`, `item`.`forum_mode`,`item`.`origin`,`item`.`wall`, 
 						`contact`.`name`, `contact`.`url`, `contact`.`thumb` from `item` 
 						LEFT JOIN `contact` ON `contact`.`id` = `item`.`contact-id` 
@@ -2472,7 +2473,7 @@ function local_delivery($importer,$data) {
 						intval($importer['importer_uid'])
 					);
 					if($r && count($r))
-						$is_a_remote_delete = true;			
+						$is_a_remote_delete = true;
 
 					// Does this have the characteristics of a community or private group comment?
 					// If it's a reply to a wall post on a community/prvgroup page it's a 
@@ -2799,7 +2800,7 @@ function local_delivery($importer,$data) {
 					}
 
 					if($posted_id && $parent) {
-				
+
 						proc_run('php',"include/notifier.php","comment-import","$posted_id");
 					
 						if((! $is_like) && (! $importer['self'])) {

--- a/include/notifier.php
+++ b/include/notifier.php
@@ -18,6 +18,31 @@ require_once('include/html2plain.php');
  * us by hosting providers. 
  */
 
+/*
+ * The notifier is typically called with:
+ *
+ *		proc_run('php', "include/notifier.php", COMMAND, ITEM_ID);
+ *
+ * where COMMAND is one of the following:
+ *
+ *		activity				(in diaspora.php, dfrn_confirm.php, profiles.php)
+ *		comment-import			(in diaspora.php, items.php)
+ *		comment-new				(in item.php)
+ *		drop					(in diaspora.php, items.php, photos.php)
+ *		edit_post				(in item.php)
+ *		event					(in events.php)
+ *		expire					(in items.php)
+ *		like					(in like.php, poke.php)
+ *		mail					(in message.php)
+ *		suggest					(in fsuggest.php)
+ *		tag						(in photos.php, poke.php, tagger.php)
+ *		tgroup					(in items.php)
+ *		wall-new				(in photos.php, item.php)
+ *
+ * and ITEM_ID is the id of the item in the database that needs to be sent to others.
+ */
+
+
 function notifier_run($argv, $argc){
 	global $a, $db;
 


### PR DESCRIPTION
First, move the "Transform tags" code into `bb2diaspora` so that it happens for comments as well (whether or not Diaspora uses tags in comments is up to them).

Second: there was another particular situation where relayable retractions weren't working (for Diaspora). There were a couple of ways of fixing it. One way allows possible simplification of Friendica's code and de-coupling, to a great extent, of the Diaspora handling code from the main Friendica code.

It relies on the fact that Diaspora currently (and historically) doesn't check the author_signature of a relayable if it has a parent_author_signature. Thus, anything that Friendica acts as the final relay for doesn't need an author_signature. We only need it in the "followup" situation, when we should always (?) have access to the private key of interest. (A possible exception to this statement is when someone likes a comment, but the main Diaspora code doesn't support that currently, and there are some other fairly thorny problems with getting it to work for pods using the older code.)

It should be possible to remove a lot of the Diaspora signature handling that Friendica does on the basis of this approach and move almost all the Diaspora handling into the Diaspora library, separate from the rest of the Friendica code. That is my goal, but I'm going about it slowly to avoid introducing a lot of bugs.
