### PR TITLE
update items seen in DB when using API

### DIFF
--- a/include/api.php
+++ b/include/api.php
@@ -755,6 +755,15 @@
 
 		$ret = api_format_items($r,$user_info);
 
+		// We aren't going to try to figure out at the item, group, and page
+		// level which items you've seen and which you haven't. If you're looking
+		// at the network timeline just mark everything seen. 
+	
+		$r = q("UPDATE `item` SET `unseen` = 0 
+			WHERE `unseen` = 1 AND `uid` = %d",
+			intval($user_info['uid'])
+		);
+
 
 		$data = array('$statuses' => $ret);
 		switch($type){


### PR DESCRIPTION
A user complained that when using the Friendica for Android app, the number of new items for the timeline doesn't go to zero after you've looked at your timeline. This seems to fix it (well, partly, but it's the part that Friendica controls).
