### PR TITLE
VirtualDocumentRoot and mod_rewrite

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -15,6 +15,16 @@ Deny from all
   # Also place auth information into REMOTE_USER for sites running
   # in CGI mode.
 
+  # If you have troubles or use VirtualDocumentRoot
+  # uncomment this and set it to the path where your friendica installation is
+  # i.e.:
+  # Friendica url: http://some.example.com
+  # RewriteBase /
+  # Friendica url: http://some.example.com/friendica
+  # RewriteBase /firendica/
+  #
+  #RewriteBase /
+
   RewriteCond %{REQUEST_FILENAME} !-f
   RewriteCond %{REQUEST_FILENAME} !-d
   RewriteRule ^(.*)$ index.php?q=$1 [E=REMOTE_USER:%{HTTP:Authorization},L,QSA]


### PR DESCRIPTION
When using VirtualDocumentRoot, the rewrite rules in .htaccess creates an infinite rewrite loop (DOCUMENT_ROOT is not set to the value expanded by VirtualDocumentRoot, but is still the one set by DocumentRoot, see: https://issues.apache.org/bugzilla/show_bug.cgi?id=26052).
Setting RewriteBase to a correct value solves it.

Sorry for the previous pull request, i understand now that when i create a branch from another one, it is like forking this one, not master, and so it gets all its commits.
I'll get used to git (and VCS in general), promised :)
That's the main reason i don't accept my own pull requests, i prefer someone to double-check me until i'm familiar with community development.
