### PR TITLE
Detect the namespace uri from token name

### DIFF
--- a/library/HTML5/TreeBuilder.php
+++ b/library/HTML5/TreeBuilder.php
@@ -127,7 +127,6 @@ class HTML5_TreeBuilder {
     const NS_XLINK  = 'http://www.w3.org/1999/xlink';
     const NS_XML    = 'http://www.w3.org/XML/1998/namespace';
     const NS_XMLNS  = 'http://www.w3.org/2000/xmlns/';
-    const NS_GOOGLE = 'http://base.google.com/ns/1.0';
 
     public function __construct() {
         $this->mode = self::INITIAL;
@@ -159,6 +158,8 @@ class HTML5_TreeBuilder {
 
         if ($this->ignore_lf_token) $this->ignore_lf_token--;
         $this->ignored = false;
+
+        $token['name'] = str_replace(':', '-', $token['name']);
         // indenting is a little wonky, this can be changed later on
         switch ($mode) {
 
@@ -1430,15 +1431,7 @@ class HTML5_TreeBuilder {
                 case 'tbody': case 'td': case 'tfoot': case 'th': case 'thead': case 'tr':
                     // parse error
                 break;
-
-                /* Google */
-                case 'g:plusone':
-					/* Reconstruct the active formatting elements, if any. */
-                    $this->reconstructActiveFormattingElements();
-
-                    $this->insertForeignElement($token, self::NS_GOOGLE);
-                break;
-
+                
                 /* A start tag token not covered by the previous entries */
                 default:
                     /* Reconstruct the active formatting elements, if any. */


### PR DESCRIPTION
So, i don't know if this is an external lib or friendica code, but tags in a different namespace than html produced an error.

I've introduce namespace detection with a simple switch, but since self::NS_HTML exists, there may be others already available via self:: , i'm looking into it.

This pull request is not to be merged now, but to start a discussion:
What should we do? Ignore non-html tags (simply return) or use them?
What namespaces can we introduce? (found the one for google)
