### PR TITLE
Private image failure

### DIFF
--- a/mod/item.php
+++ b/mod/item.php
@@ -373,7 +373,7 @@ function item_post(&$a) {
 
 	$match = null;
 
-	if((! $preview) && preg_match_all("/\[img([\=0-9x]*)\](.*?)\[\/img\]/",$body,$match)) {
+	if((! $preview) && preg_match_all("/\[img([\=0-9x]*?)\](.*?)\[\/img\]/",$body,$match)) {
 		$images = $match[2];
 		if(count($images)) {
 			foreach($images as $image) {


### PR DESCRIPTION
Some private images uploaded have permissions set so only the owner can see them. It appears that this is related to setting a size for the uploaded image, which then doesn't get caught by the regular expression. This pull allows a size specification to exist in the regular expression.
