### PR TITLE
dont insert images larger than scale level 2

### DIFF
--- a/mod/fbrowser.php
+++ b/mod/fbrowser.php
@@ -46,7 +46,7 @@ function fbrowser_content($a){
 			}
 				
 			$r = q("SELECT `resource-id`, `id`, `filename`, type, min(`scale`) AS `hiq`,max(`scale`) AS `loq`, `desc`  
-					FROM `photo` WHERE `uid` = %d AND scale > 1 $sql_extra
+					FROM `photo` WHERE `uid` = %d AND (height <= 320 AND width <= 320) $sql_extra
 					GROUP BY `resource-id` $sql_extra2",
 				intval(local_user())					
 			);


### PR DESCRIPTION
Images that have scales 0, 1, and 2 by default use scale 2 when uploading a new wall picture. However, when the picture is inserted from one's albums, the scale 0 version is inserted, which is very large and not usually desired. This changes makes insertion act like uploading, limiting the inserted picture to be no larger than scale 2.
