### PR TITLE
send less messages to server; remove delete option

### DIFF
--- a/include/Scrape.php
+++ b/include/Scrape.php
@@ -458,10 +458,10 @@ function probe_url($url, $mode = PROBE_NORMAL) {
 						$poll = 'email ' . random_string();
 						$priority = 0;
 						$x = email_msg_meta($mbox,$msgs[0]);
-						if(stristr($x->from,$orig_url))
-							$adr = imap_rfc822_parse_adrlist($x->from,'');
-						elseif(stristr($x->to,$orig_url))
-							$adr = imap_rfc822_parse_adrlist($x->to,'');
+						if(stristr($x[0]->from,$orig_url))
+							$adr = imap_rfc822_parse_adrlist($x[0]->from,'');
+						elseif(stristr($x[0]->to,$orig_url))
+							$adr = imap_rfc822_parse_adrlist($x[0]->to,'');
 						if(isset($adr)) {
 							foreach($adr as $feadr) {
 								if((strcasecmp($feadr->mailbox,$name) == 0)
@@ -552,6 +552,13 @@ function probe_url($url, $mode = PROBE_NORMAL) {
 			}
 		
 			logger('probe_url: scrape_vcard: ' . print_r($vcard,true), LOGGER_DATA);
+		}
+
+		if($diaspora && $addr) {
+			// Diaspora returns the name as the nick. As the nick will never be updated,
+			// let's use the Diaspora nickname (the first part of the handle) as the nick instead
+			$addr_parts = explode('@', $addr);
+			$vcard['nick'] = $addr_parts[0];
 		}
 
 		if($twitter) {		

--- a/include/email.php
+++ b/include/email.php
@@ -48,8 +48,8 @@ function construct_mailbox_name($mailacct) {
 
 
 function email_msg_meta($mbox,$uid) {
-	$ret = (($mbox && $uid) ? @imap_fetch_overview($mbox,$uid,FT_UID) : array(array()));
-	return ((count($ret)) ? $ret[0] : array());
+	$ret = (($mbox && $uid) ? @imap_fetch_overview($mbox,$uid,FT_UID) : array(array())); // POSSIBLE CLEANUP --> array(array()) is probably redundant now
+	return ((count($ret)) ? $ret : array());
 }
 
 function email_msg_headers($mbox,$uid) {

--- a/include/onepoll.php
+++ b/include/onepoll.php
@@ -291,35 +291,16 @@ function onepoll_run($argv, $argc){
 			if(count($msgs)) {
 				logger("Mail: Parsing ".count($msgs)." mails for ".$mailconf[0]['user'], LOGGER_DEBUG);
 
-				foreach($msgs as $msg_uid) {
+				$metas = email_msg_meta($mbox,implode(',',$msgs));
+				$msgs = array_combine($msgs, $metas);
+				foreach($msgs as $msg_uid => $meta) {
 					logger("Mail: Parsing mail ".$msg_uid, LOGGER_DATA);
 
 					$datarray = array();
-					$meta = email_msg_meta($mbox,$msg_uid);
-					$headers = email_msg_headers($mbox,$msg_uid);
+//					$meta = email_msg_meta($mbox,$msg_uid);
+//					$headers = email_msg_headers($mbox,$msg_uid);
 
-					// look for a 'references' header and try and match with a parent item we have locally.
-
-					$raw_refs = ((x($headers,'references')) ? str_replace("\t",'',$headers['references']) : '');
 					$datarray['uri'] = msgid2iri(trim($meta->message_id,'<>'));
-
-					if($raw_refs) {
-						$refs_arr = explode(' ', $raw_refs);
-						if(count($refs_arr)) {
-							for($x = 0; $x < count($refs_arr); $x ++)
-								$refs_arr[$x] = "'" . msgid2iri(str_replace(array('<','>',' '),array('','',''),dbesc($refs_arr[$x]))) . "'";
-						}
-						$qstr = implode(',',$refs_arr);
-						$r = q("SELECT `uri` , `parent-uri` FROM `item` WHERE `uri` IN ( $qstr ) AND `uid` = %d LIMIT 1",
-							intval($importer_uid)
-						);
-						if(count($r))
-							$datarray['parent-uri'] = $r[0]['uri'];
-					}
-
-
-					if(! x($datarray,'parent-uri'))
-						$datarray['parent-uri'] = $datarray['uri'];
 
 					// Have we seen it before?
 					$r = q("SELECT * FROM `item` WHERE `uid` = %d AND `uri` = '%s' LIMIT 1",
@@ -328,15 +309,16 @@ function onepoll_run($argv, $argc){
 					);
 
 					if(count($r)) {
-//						logger("Mail: Seen before ".$msg_uid);
+						logger("Mail: Seen before ".$msg_uid." for ".$mailconf[0]['user']);
 						if($meta->deleted && ! $r[0]['deleted']) {
 							q("UPDATE `item` SET `deleted` = 1, `changed` = '%s' WHERE `id` = %d LIMIT 1",
 								dbesc(datetime_convert()),
 								intval($r[0]['id'])
 							);
 						}
-						switch ($mailconf[0]['action']) {
+						/*switch ($mailconf[0]['action']) {
 							case 0:
+								logger("Mail: Seen before ".$msg_uid." for ".$mailconf[0]['user'].". Doing nothing.", LOGGER_DEBUG);
 								break;
 							case 1:
 								logger("Mail: Deleting ".$msg_uid." for ".$mailconf[0]['user']);
@@ -352,9 +334,37 @@ function onepoll_run($argv, $argc){
 								if ($mailconf[0]['movetofolder'] != "")
 									imap_mail_move($mbox, $msg_uid, $mailconf[0]['movetofolder'], FT_UID);
 								break;
-						}
+						}*/
 						continue;
 					}
+
+
+					// look for a 'references' or an 'in-reply-to' header and try to match with a parent item we have locally.
+
+//					$raw_refs = ((x($headers,'references')) ? str_replace("\t",'',$headers['references']) : '');
+					$raw_refs = ((property_exists($meta,'references')) ? str_replace("\t",'',$meta->references) : '');
+					if(! trim($raw_refs))
+						$raw_refs = ((property_exists($meta,'in_reply_to')) ? str_replace("\t",'',$meta->in_reply_to) : '');
+					$raw_refs = trim($raw_refs);  // Don't allow a blank reference in $refs_arr
+
+					if($raw_refs) {
+						$refs_arr = explode(' ', $raw_refs);
+						if(count($refs_arr)) {
+							for($x = 0; $x < count($refs_arr); $x ++)
+								$refs_arr[$x] = "'" . msgid2iri(str_replace(array('<','>',' '),array('','',''),dbesc($refs_arr[$x]))) . "'";
+						}
+						$qstr = implode(',',$refs_arr);
+						$r = q("SELECT `uri` , `parent-uri` FROM `item` WHERE `uri` IN ( $qstr ) AND `uid` = %d LIMIT 1",
+							intval($importer_uid)
+						);
+						if(count($r))
+							$datarray['parent-uri'] = $r[0]['parent-uri'];  // Set the parent as the top-level item
+//							$datarray['parent-uri'] = $r[0]['uri'];
+					}
+
+
+					if(! x($datarray,'parent-uri'))
+						$datarray['parent-uri'] = $datarray['uri'];
 
 					// Decoding the header
 					$subject = imap_mime_header_decode($meta->subject);
@@ -421,6 +431,7 @@ function onepoll_run($argv, $argc){
 					);
 					switch ($mailconf[0]['action']) {
 						case 0:
+							logger("Mail: Seen before ".$msg_uid." for ".$mailconf[0]['user'].". Doing nothing.", LOGGER_DEBUG);
 							break;
 						case 1:
 							logger("Mail: Deleting ".$msg_uid." for ".$mailconf[0]['user']);

--- a/mod/settings.php
+++ b/mod/settings.php
@@ -692,7 +692,7 @@ function settings_content(&$a) {
 			'$mail_pass'	=> array('mail_pass', 	 t('Email password:'), '', ''),
 			'$mail_replyto'	=> array('mail_replyto', t('Reply-to address:'), '', 'Optional'),
 			'$mail_pubmail'	=> array('mail_pubmail', t('Send public posts to all email contacts:'), $mail_pubmail, ''),
-			'$mail_action'	=> array('mail_action',	 t('Action after import:'), $mail_action, '', array(0=>t('None'), 1=>t('Delete'), 2=>t('Mark as seen'), 3=>t('Move to folder'))),
+			'$mail_action'	=> array('mail_action',	 t('Action after import:'), $mail_action, '', array(0=>t('None'), /*1=>t('Delete'),*/ 2=>t('Mark as seen'), 3=>t('Move to folder'))),
 			'$mail_movetofolder'	=> array('mail_movetofolder',	 t('Move to folder:'), $mail_movetofolder, ''),
 			'$submit' => t('Submit'),
 


### PR DESCRIPTION
Made some changes to optimize the email polling:
- Only ask the server for META information for all emails once
- Separate request for all headers is unnecessary
- We should not perform the specified action every time we poll. For example, if the user later moves an email to another folder, we should not move it back to the folder they specified in the email connector settings. That will make for annoyed users.
