### PR TITLE
remove groups from default permissions when removed; bug in group_add_member

### DIFF
--- a/include/group.php
+++ b/include/group.php
@@ -40,7 +40,7 @@ function group_add($uid,$name) {
 function group_rmv($uid,$name) {
 	$ret = false;
 	if(x($uid) && x($name)) {
-		$r = q("SELECT * FROM `group` WHERE `uid` = %d AND `name` = '%s' LIMIT 1",
+		$r = q("SELECT id FROM `group` WHERE `uid` = %d AND `name` = '%s' LIMIT 1",
 			intval($uid),
 			dbesc($name)
 		);
@@ -48,6 +48,37 @@ function group_rmv($uid,$name) {
 			$group_id = $r[0]['id'];
 		if(! $group_id)
 			return false;
+
+		// remove group from default posting lists
+		$r = q("SELECT def_gid, allow_gid, deny_gid FROM user WHERE uid = %d LIMIT 1",
+		       intval($uid)
+		);
+		if($r) {
+			$user_info = $r[0];
+			$change = false;
+
+			if($user_info['def_gid'] == $group_id) {
+				$user_info['def_gid'] = 0;
+				$change = true;
+			}
+			if(strpos($user_info['allow_gid'], '<' . $group_id . '>') !== false) {
+				$user_info['allow_gid'] = str_replace('<' . $group_id . '>', '', $user_info['allow_gid']);
+				$change = true;
+			}
+			if(strpos($user_info['deny_gid'], '<' . $group_id . '>') !== false) {
+				$user_info['deny_gid'] = str_replace('<' . $group_id . '>', '', $user_info['deny_gid']);
+				$change = true;
+			}
+
+			if($change) {
+				q("UPDATE user SET def_gid = %d, allow_gid = '%s', deny_gid = '%s' WHERE uid = %d",
+				  intval($user_info['def_gid']),
+				  dbesc($user_info['allow_gid']),
+				  dbesc($user_info['deny_gid']),
+				  intval($uid)
+				);
+			}
+		}
 
 		// remove all members
 		$r = q("DELETE FROM `group_member` WHERE `uid` = %d AND `gid` = %d ",
@@ -103,7 +134,7 @@ function group_add_member($uid,$name,$member,$gid = 0) {
 	if((! $gid) || (! $uid) || (! $member))
 		return false;
 
-	$r = q("SELECT * FROM `group_member` WHERE `uid` = %d AND `id` = %d AND `contact-id` = %d LIMIT 1",	
+	$r = q("SELECT * FROM `group_member` WHERE `uid` = %d AND `gid` = %d AND `contact-id` = %d LIMIT 1",	
 		intval($uid),
 		intval($gid),
 		intval($member)


### PR DESCRIPTION
Groups weren't being deleted from a user's default permissions when the group was removed. That made it look like new posts were continuing to be posted to the old group.

Also, one of the DB fields was wrong in group_add_member, which occasionally caused a weird bug where a contact could be added to a group multiple times
