### PR TITLE
Network view updates

### DIFF
--- a/mod/lockview.php
+++ b/mod/lockview.php
@@ -28,17 +28,17 @@ function lockview_content(&$a) {
 		killme();
 
 
-	$allowed_users = expand_acl($item['allow_cid']);
-	$allowed_groups = expand_acl($item['allow_gid']);
-	$deny_users = expand_acl($item['deny_cid']);
-	$deny_groups = expand_acl($item['deny_gid']);
-
 	if(($item['private'] == 1) && (! strlen($item['allow_cid'])) && (! strlen($item['allow_gid'])) 
 		&& (! strlen($item['deny_cid'])) && (! strlen($item['deny_gid']))) {
 
 		echo t('Remote privacy information not available.') . '<br />';
 		killme();
 	}
+
+	$allowed_users = expand_acl($item['allow_cid']);
+	$allowed_groups = expand_acl($item['allow_gid']);
+	$deny_users = expand_acl($item['deny_cid']);
+	$deny_groups = expand_acl($item['deny_gid']);
 
 	$o = t('Visible to:') . '<br />';
 	$l = array();

--- a/view/nets.tpl
+++ b/view/nets.tpl
@@ -1,7 +1,7 @@
 <div id="nets-sidebar" class="widget">
 	<h3>$title</h3>
 	<div id="nets-desc">$desc</div>
-	<a href="$base" class="nets-link{{ if $sel_all }} nets-selected{{ endif }} nets-all">$all</a>
+	<a href="$base?nets=all" class="nets-link{{ if $sel_all }} nets-selected{{ endif }} nets-all">$all</a>
 	<ul class="nets-ul">
 	{{ for $nets as $net }}
 	<li><a href="$base?nets=$net.ref" class="nets-link{{ if $net.selected }} nets-selected{{ endif }}">$net.name</a></li>


### PR DESCRIPTION
Remember not only the last tab selected, but also the last group and network selected. All three are allowed to interact fully.

Also, only update unseen items in the table when the items are displayed with the currently selected filters.
