### PR TITLE
Add link to issue tracker to README

### DIFF
--- a/README
+++ b/README
@@ -8,4 +8,6 @@ Welcome to the free social web.
 
 Friendica is a communications platform for integrated social communications utilising decentralised communications and linkage to several indie social projects - as well as popular mainstream providers.
 
-Our mission is to free our friends and families from the clutches of data-harvesting corporations, and pave the way to a future where social communications are free and open and flow between alternate providers as easily as email does today.  
+Our mission is to free our friends and families from the clutches of data-harvesting corporations, and pave the way to a future where social communications are free and open and flow between alternate providers as easily as email does today.
+
+Report issues at http://bugs.friendica.com/


### PR DESCRIPTION
Since the README is shown on the GitHub page, this makes the issue tracking more accessible (at least) from there.

Also, I think the GH issue tracker it the old friendika/Free-Friendika project should be disabled. (This is misleading, too: people familiar with GitHub will first look for its issue tracker in the project itself, and then in the one it was officially "forked from".)
