### PR TITLE
use getWidth and getHeight, which are agnostic to Imagick being enabled

### DIFF
--- a/include/Photo.php
+++ b/include/Photo.php
@@ -129,11 +129,12 @@ class Photo {
                     $this->image->setCompressionQuality($quality);
             }
 
-            $this->width  = $this->image->getImageWidth();
+			// The 'width' and 'height' properties are only used by non-Imagick routines.
+			$this->width  = $this->image->getImageWidth();
 			$this->height = $this->image->getImageHeight();
 			$this->valid  = true;
 
-            return true;
+			return true;
 		}
 
 		$this->valid = false;
@@ -205,8 +206,8 @@ class Photo {
         if(!$this->is_valid())
             return FALSE;
 
-        $width = $this->width;
-        $height = $this->height;
+        $width = $this->getWidth();
+        $height = $this->getHeight();
 
         $dest_width = $dest_height = 0;
 
@@ -263,24 +264,25 @@ class Photo {
 
 
         if($this->is_imagick()) {
-            /**
-             * If it is not animated, there will be only one iteration here,
-             * so don't bother checking
-             */
-            // Don't forget to go back to the first frame
-            $this->image->setFirstIterator();
-            do {
+			/**
+			 * If it is not animated, there will be only one iteration here,
+			 * so don't bother checking
+			 */
+			// Don't forget to go back to the first frame
+			$this->image->setFirstIterator();
+			do {
 
 				// FIXME - implement horizantal bias for scaling as in followin GD functions
 				// to allow very tall images to be constrained only horizontally. 
 
-                $this->image->scaleImage($dest_width, $dest_height);
-            } while ($this->image->nextImage());
+				$this->image->scaleImage($dest_width, $dest_height);
+			} while ($this->image->nextImage());
 
-			// FIXME - also we need to copy the new dimensions to $this->height, $this->width as other functions
-			// may rely on it.
+			// These may not be necessary any more
+			$this->width  = $this->image->getImageWidth();
+			$this->height = $this->image->getImageHeight();
 
-            return;
+			return;
         }
 
 
@@ -402,8 +404,8 @@ class Photo {
             return FALSE;
 
 
-        $width = $this->width;
-        $height = $this->height;
+        $width = $this->getWidth();
+        $height = $this->getHeight();
 
         $dest_width = $dest_height = 0;
 
@@ -483,19 +485,19 @@ class Photo {
         if(!$this->is_valid())
             return FALSE;
 
-        if($this->is_imagick()) {
-            $this->image->setFirstIterator();
-            do {
-                $this->image->cropImage($w, $h, $x, $y);
-                /**
-                 * We need to remove the canva,
-                 * or the image is not resized to the crop:
-                 * http://php.net/manual/en/imagick.cropimage.php#97232
-                 */
-                $this->image->setImagePage(0, 0, 0, 0);
-            } while ($this->image->nextImage());
-            return $this->scaleImage($max);
-        }
+		if($this->is_imagick()) {
+			$this->image->setFirstIterator();
+			do {
+				$this->image->cropImage($w, $h, $x, $y);
+				/**
+				 * We need to remove the canva,
+				 * or the image is not resized to the crop:
+				 * http://php.net/manual/en/imagick.cropimage.php#97232
+				 */
+				$this->image->setImagePage(0, 0, 0, 0);
+			} while ($this->image->nextImage());
+			return $this->scaleImage($max);
+		}
 
         $dest = imagecreatetruecolor( $max, $max );
         imagealphablending($dest, false);


### PR DESCRIPTION
With Imagick enabled, the square profile photos were being scaled to the original photo's dimensions. By using this->getWidth and this->getHeight instead of this->width and this->height for the scaling functions, the Imagick-based routines don't need to make sure this->width and this->height are always updated
