### PR TITLE
add home_init hook to manage to call startpage plugin

### DIFF
--- a/mod/manage.php
+++ b/mod/manage.php
@@ -75,7 +75,10 @@ function manage_post(&$a) {
 	if($limited_id)
 		$_SESSION['submanage'] = $original_id;
 
-	goaway($a->get_baseurl(true) . '/profile/' . $a->user['nickname']);
+	$ret = array();
+	call_hooks('home_init',$ret);
+
+	goaway( $a->get_baseurl() . "/profile/" . $a->user['nickname'] );
 	// NOTREACHED
 }
 


### PR DESCRIPTION
I wasn't sure whether to create a new hook or just use the home_init one. Since manage is directing you to your home page, I think it makes sense to use the same hook.
