### PR TITLE
for profile and photos, detect contacts from local hub and auto-redir

### DIFF
--- a/include/redir.php
+++ b/include/redir.php
@@ -1,0 +1,60 @@
+<?php
+
+function auto_redir(&$a, $contact_nick) {
+
+	if(local_user()) {
+
+		$r = q("SELECT id FROM contact WHERE uid = ( SELECT uid FROM user WHERE nickname = '%s' LIMIT 1 ) AND nick = '%s' AND network = '%s' LIMIT 1",
+			   dbesc($contact_nick),
+			   dbesc($a->user['nickname']),
+			   dbesc(NETWORK_DFRN)
+		);
+		if(!$r || $r[0]['id'] == remote_user())
+			return;
+
+
+		$r = q("SELECT * FROM contact WHERE nick = '%s' AND network = '%s' AND uid = %d LIMIT 1",
+		       dbesc($contact_nick),
+		       dbesc(NETWORK_DFRN),
+		       intval(local_user())
+		);
+
+		if(! $r)
+			return;
+
+		$cid = $r[0]['id'];
+
+		$dfrn_id = $orig_id = (($r[0]['issued-id']) ? $r[0]['issued-id'] : $r[0]['dfrn-id']);
+
+		if($r[0]['duplex'] && $r[0]['issued-id']) {
+			$orig_id = $r[0]['issued-id'];
+			$dfrn_id = '1:' . $orig_id;
+		}
+		if($r[0]['duplex'] && $r[0]['dfrn-id']) {
+			$orig_id = $r[0]['dfrn-id'];
+			$dfrn_id = '0:' . $orig_id;
+		}
+
+		$sec = random_string();
+
+		q("INSERT INTO `profile_check` ( `uid`, `cid`, `dfrn_id`, `sec`, `expire`)
+			VALUES( %d, %s, '%s', '%s', %d )",
+			intval(local_user()),
+			intval($cid),
+			dbesc($dfrn_id),
+			dbesc($sec),
+			intval(time() + 45)
+		);
+
+		$url = curPageURL();
+
+		logger('check_redir: ' . $r[0]['name'] . ' ' . $sec, LOGGER_DEBUG); 
+		$dest = (($url) ? '&destination_url=' . $url : '');
+		goaway ($r[0]['poll'] . '?dfrn_id=' . $dfrn_id 
+			. '&dfrn_version=' . DFRN_PROTOCOL_VERSION . '&type=profile&sec=' . $sec . $dest );
+	}
+
+	return;
+}
+
+

--- a/mod/photos.php
+++ b/mod/photos.php
@@ -4,14 +4,18 @@ require_once('include/items.php');
 require_once('include/acl_selectors.php');
 require_once('include/bbcode.php');
 require_once('include/security.php');
+require_once('include/redir.php');
 
 
 function photos_init(&$a) {
 
+	if($a->argc > 1)
+		auto_redir($a, $a->argv[1]);
 
 	if((get_config('system','block_public')) && (! local_user()) && (! remote_user())) {
 		return;
 	}
+
 	$o = '';
 
 	if($a->argc > 1) {

--- a/mod/profile.php
+++ b/mod/profile.php
@@ -1,6 +1,7 @@
 <?php
 
 require_once('include/contact_widgets.php');
+require_once('include/redir.php');
 
 
 function profile_init(&$a) {
@@ -29,6 +30,9 @@ function profile_init(&$a) {
 	if((local_user()) && ($a->argc > 2) && ($a->argv[2] === 'view')) {
 		$which = $a->user['nickname'];
 		$profile = $a->argv[1];		
+	}
+	else {
+		auto_redir($a, $which);
 	}
 
 	profile_load($a,$which,$profile);


### PR DESCRIPTION
This allows, e.g., the local hub directory to automatically redir for contacts on the local hub without needing to modify all links to load the redir script.
