### PR TITLE
fix small bug to oauth authentication

### DIFF
--- a/include/oauth.php
+++ b/include/oauth.php
@@ -150,6 +150,7 @@ class FKOAuth1 extends OAuthServer {
 		$_SESSION['page_flags'] = $record['page-flags'];
 		$_SESSION['my_url'] = $a->get_baseurl() . '/profile/' . $record['nickname'];
 		$_SESSION['addr'] = $_SERVER['REMOTE_ADDR'];
+		$_SESSION["allow_api"] = true;
 
 		//notice( t("Welcome back ") . $record['username'] . EOL);
 		$a->user = $record;


### PR DESCRIPTION
o-authorized users can't use api without 'allow_api'
