### PR TITLE
use explicit include paths

### DIFF
--- a/include/api.php
+++ b/include/api.php
@@ -1,9 +1,9 @@
 <?php
-	require_once("bbcode.php");
-	require_once("datetime.php");
-	require_once("conversation.php");
-	require_once("oauth.php");
-	require_once("html2plain.php");
+	require_once("include/bbcode.php");
+	require_once("include/datetime.php");
+	require_once("include/conversation.php");
+	require_once("include/oauth.php");
+	require_once("include/html2plain.php");
 	/*
 	 * Twitter-Like API
 	 *

--- a/include/conversation.php
+++ b/include/conversation.php
@@ -369,7 +369,7 @@ if(!function_exists('conversation')) {
 function conversation(&$a, $items, $mode, $update, $preview = false) {
 
 
-	require_once('bbcode.php');
+	require_once('include/bbcode.php');
 
 	$ssl_state = ((local_user()) ? true : false);
 

--- a/include/cronhooks.php
+++ b/include/cronhooks.php
@@ -12,7 +12,7 @@ function cronhooks_run(&$argv, &$argc){
   
 	if(is_null($db)) {
 	    @include(".htconfig.php");
-    	require_once("dba.php");
+    	require_once("include/dba.php");
 	    $db = new dba($db_host, $db_user, $db_pass, $db_data);
     	unset($db_host, $db_user, $db_pass, $db_data);
   	};

--- a/include/delivery.php
+++ b/include/delivery.php
@@ -12,13 +12,13 @@ function delivery_run(&$argv, &$argc){
 
 	if(is_null($db)) {
 		@include(".htconfig.php");
-		require_once("dba.php");
+		require_once("include/dba.php");
 		$db = new dba($db_host, $db_user, $db_pass, $db_data);
 		        unset($db_host, $db_user, $db_pass, $db_data);
 	}
 
-	require_once("session.php");
-	require_once("datetime.php");
+	require_once("include/session.php");
+	require_once("include/datetime.php");
 	require_once('include/items.php');
 	require_once('include/bbcode.php');
 	require_once('include/diaspora.php');

--- a/include/directory.php
+++ b/include/directory.php
@@ -10,7 +10,7 @@ function directory_run(&$argv, &$argc){
   
 	if(is_null($db)) {
 		@include(".htconfig.php");
-		require_once("dba.php");
+		require_once("include/dba.php");
 		$db = new dba($db_host, $db_user, $db_pass, $db_data);
 				unset($db_host, $db_user, $db_pass, $db_data);
 	};

--- a/include/enotify.php
+++ b/include/enotify.php
@@ -310,7 +310,7 @@ function notification($params) {
 
 	// send email notification if notification preferences permit
 
-	require_once('bbcode.php');
+	require_once('include/bbcode.php');
 	if((intval($params['notify_flags']) & intval($params['type'])) || $params['type'] == NOTIFY_SYSTEM) {
 
 		logger('notification: sending notification email');

--- a/include/expire.php
+++ b/include/expire.php
@@ -11,7 +11,7 @@ function expire_run(&$argv, &$argc){
   
 	if(is_null($db)) {
 	    @include(".htconfig.php");
-    	require_once("dba.php");
+    	require_once("include/dba.php");
 	    $db = new dba($db_host, $db_user, $db_pass, $db_data);
     	unset($db_host, $db_user, $db_pass, $db_data);
   	};

--- a/include/follow.php
+++ b/include/follow.php
@@ -218,7 +218,7 @@ function new_contact($uid,$url,$interactive = false) {
 		group_add_member($uid,'',$contact_id,$g[0]['def_gid']);
 	}
 
-	require_once("Photo.php");
+	require_once("include/Photo.php");
 
 	$photos = import_profile_photo($ret['photo'],$uid,$contact_id);
 

--- a/include/gprobe.php
+++ b/include/gprobe.php
@@ -13,7 +13,7 @@ function gprobe_run(&$argv, &$argc){
   
 	if(is_null($db)) {
 	    @include(".htconfig.php");
-    	require_once("dba.php");
+    	require_once("include/dba.php");
 	    $db = new dba($db_host, $db_user, $db_pass, $db_data);
     	unset($db_host, $db_user, $db_pass, $db_data);
   	};

--- a/include/html2plain.php
+++ b/include/html2plain.php
@@ -1,5 +1,5 @@
 <?php
-require_once "html2bbcode.php";
+require_once("include/html2bbcode.php");
 
 function breaklines($line, $level, $wraplength = 75)
 {

--- a/include/items.php
+++ b/include/items.php
@@ -1607,7 +1607,7 @@ function consume_feed($xml,$importer,&$contact, &$hub, $datedir = 0, $pass = 0) 
 
 	if((is_array($contact)) && ($photo_timestamp) && (strlen($photo_url)) && ($photo_timestamp > $contact['avatar-date'])) {
 		logger('consume_feed: Updating photo for ' . $contact['name']);
-		require_once("Photo.php");
+		require_once("include/Photo.php");
 		$photo_failure = false;
 		$have_photo = false;
 
@@ -2240,7 +2240,7 @@ function local_delivery($importer,$data) {
 
 	if(($photo_timestamp) && (strlen($photo_url)) && ($photo_timestamp > $importer['avatar-date'])) {
 		logger('local_delivery: Updating photo for ' . $importer['name']);
-		require_once("Photo.php");
+		require_once("include/Photo.php");
 		$photo_failure = false;
 		$have_photo = false;
 

--- a/include/notifier.php
+++ b/include/notifier.php
@@ -51,13 +51,13 @@ function notifier_run(&$argv, &$argc){
   
 	if(is_null($db)) {
 		@include(".htconfig.php");
-		require_once("dba.php");
+		require_once("include/dba.php");
 		$db = new dba($db_host, $db_user, $db_pass, $db_data);
 		        unset($db_host, $db_user, $db_pass, $db_data);
 	}
 
-	require_once("session.php");
-	require_once("datetime.php");
+	require_once("include/session.php");
+	require_once("include/datetime.php");
 	require_once('include/items.php');
 	require_once('include/bbcode.php');
 	require_once('include/email.php');

--- a/include/onepoll.php
+++ b/include/onepoll.php
@@ -18,7 +18,7 @@ function onepoll_run(&$argv, &$argc){
   
 	if(is_null($db)) {
 	    @include(".htconfig.php");
-    	require_once("dba.php");
+    	require_once("include/dba.php");
 	    $db = new dba($db_host, $db_user, $db_pass, $db_data);
     	unset($db_host, $db_user, $db_pass, $db_data);
   	};

--- a/include/poller.php
+++ b/include/poller.php
@@ -12,7 +12,7 @@ function poller_run(&$argv, &$argc){
   
 	if(is_null($db)) {
 	    @include(".htconfig.php");
-    	require_once("dba.php");
+    	require_once("include/dba.php");
 	    $db = new dba($db_host, $db_user, $db_pass, $db_data);
     	unset($db_host, $db_user, $db_pass, $db_data);
   	};

--- a/include/queue.php
+++ b/include/queue.php
@@ -11,14 +11,14 @@ function queue_run(&$argv, &$argc){
   
 	if(is_null($db)){
 		@include(".htconfig.php");
-		require_once("dba.php");
+		require_once("include/dba.php");
 		$db = new dba($db_host, $db_user, $db_pass, $db_data);
 		unset($db_host, $db_user, $db_pass, $db_data);
 	};
 
 
-	require_once("session.php");
-	require_once("datetime.php");
+	require_once("include/session.php");
+	require_once("include/datetime.php");
 	require_once('include/items.php');
 	require_once('include/bbcode.php');
 

--- a/index.php
+++ b/index.php
@@ -41,7 +41,7 @@ load_translation_table($lang);
  *
  */
 
-require_once("dba.php");
+require_once("include/dba.php");
 
 if(! $install) {
 	$db = new dba($db_host, $db_user, $db_pass, $db_data, $install);
@@ -54,7 +54,7 @@ if(! $install) {
 	load_config('config');
 	load_config('system');
 
-	require_once("session.php");
+	require_once("include/session.php");
 	load_hooks();
 	call_hooks('init_1');
 }

--- a/mod/_well_known.php
+++ b/mod/_well_known.php
@@ -1,5 +1,5 @@
 <?php
-require_once("hostxrd.php");
+require_once("mod/hostxrd.php");
 
 function _well_known_init(&$a){
     if ($a->argc > 1) {

--- a/mod/content.php
+++ b/mod/content.php
@@ -309,7 +309,7 @@ function content_content(&$a, $update = 0) {
 function render_content(&$a, $items, $mode, $update, $preview = false) {
 
 
-	require_once('bbcode.php');
+	require_once('include/bbcode.php');
 
 	$ssl_state = ((local_user()) ? true : false);
 

--- a/mod/crepair.php
+++ b/mod/crepair.php
@@ -76,7 +76,7 @@ function crepair_post(&$a) {
 
 	if($photo) {
 		logger('mod-crepair: updating photo from ' . $photo);
-		require_once("Photo.php");
+		require_once("include/Photo.php");
 
 		$photos = import_profile_photo($photo,local_user(),$contact['id']);
 

--- a/mod/dfrn_confirm.php
+++ b/mod/dfrn_confirm.php
@@ -671,7 +671,7 @@ function dfrn_confirm_post(&$a,$handsfree = null) {
 		else
 			$photo = $a->get_baseurl() . '/images/person-175.jpg';
 				
-		require_once("Photo.php");
+		require_once("include/Photo.php");
 
 		$photos = import_profile_photo($photo,$local_uid,$dfrn_record);
 

--- a/mod/dfrn_request.php
+++ b/mod/dfrn_request.php
@@ -110,7 +110,7 @@ function dfrn_request_post(&$a) {
 					 * Scrape the other site's profile page to pick up the dfrn links, key, fn, and photo
 					 */
 
-					require_once('Scrape.php');
+					require_once('include/Scrape.php');
 	
 					$parms = scrape_dfrn($dfrn_url);
 	
@@ -505,7 +505,7 @@ function dfrn_request_post(&$a) {
 				}
 			
 
-				require_once('Scrape.php');
+				require_once('include/Scrape.php');
 
 				$parms = scrape_dfrn(($hcard) ? $hcard : $url);
 

--- a/mod/editpost.php
+++ b/mod/editpost.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once('acl_selectors.php');
+require_once('include/acl_selectors.php');
 
 function editpost_content(&$a) {
 

--- a/mod/follow.php
+++ b/mod/follow.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once('Scrape.php');
+require_once('include/Scrape.php');
 require_once('include/follow.php');
 
 function follow_init(&$a) {

--- a/mod/install.php
+++ b/mod/install.php
@@ -32,7 +32,7 @@ function install_post(&$a) {
 			$dbdata = notags(trim($_POST['dbdata']));
 			$phpath = notags(trim($_POST['phpath']));
 
-			require_once("dba.php");
+			require_once("include/dba.php");
 			unset($db);
 			$db = new dba($dbhost, $dbuser, $dbpass, $dbdata, true);
 			/*if(get_db_errno()) {
@@ -251,7 +251,7 @@ function install_content(&$a) {
 			return $o;
 		}; break;
 		case 3: { // Site settings
-			require_once('datetime.php');
+			require_once('include/datetime.php');
 			$dbhost = ((x($_POST,'dbhost')) ? notags(trim($_POST['dbhost'])) : 'localhost');
 			$dbuser = notags(trim($_POST['dbuser']));
 			$dbpass = notags(trim($_POST['dbpass']));

--- a/mod/profile_photo.php
+++ b/mod/profile_photo.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once("Photo.php");
+require_once("include/Photo.php");
 
 function profile_photo_init(&$a) {
 

--- a/mod/share.php
+++ b/mod/share.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once('bbcode.php');
+require_once('include/bbcode.php');
 
 function share_init(&$a) {
 

--- a/mod/tagrm.php
+++ b/mod/tagrm.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once('bbcode.php');
+require_once('include/bbcode.php');
 
 function tagrm_post(&$a) {
 

--- a/mod/wall_upload.php
+++ b/mod/wall_upload.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once('Photo.php');
+require_once('include/Photo.php');
 
 function wall_upload_post(&$a) {
 

--- a/util/db_update.php
+++ b/util/db_update.php
@@ -14,7 +14,7 @@ $a = new App;
 $lang = get_browser_language();
 load_translation_table($lang);
 
-require_once("dba.php");
+require_once("include/dba.php");
 $db = new dba($db_host, $db_user, $db_pass, $db_data, false);
         unset($db_host, $db_user, $db_pass, $db_data);
 


### PR DESCRIPTION
It looks like the PHP on some hosting platforms doesn't allow setting an include path (via set_include_path()). Use explicit include paths to prevent problems.

This shouldn't be a significant problem for allowing sites to define custom scripts that automatically replace the built-in ones, we can just write a wrapper for require_once that does this.
