### PR TITLE
Add ttf and svg to skip the front controller

### DIFF
--- a/mods/sample-nginx.config
+++ b/mods/sample-nginx.config
@@ -79,7 +79,7 @@ server {
   # otherwise fall back to front controller
   # allow browser to cache them
   # added .htm for advanced source code editor library
-  location ~* \.(jpg|jpeg|gif|png|css|js|htm|html)$ {
+  location ~* \.(jpg|jpeg|gif|png|ico|css|js|htm|html|ttf|svg)$ {
     expires 30d;
     try_files $uri /index.php?q=$uri&$args;
   }


### PR DESCRIPTION
This makes themes that rely on the correct mimetype work.
Also serves favicon.ico directly
