### PR TITLE
insidious set_config bug

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -808,7 +808,7 @@ function check_db() {
 	$build = get_config('system','build');
 	if(! x($build)) {
 		set_config('system','build',DB_UPDATE_VERSION);
-		$buid = DB_UPDATE_VERSION;
+		$build = DB_UPDATE_VERSION;
 	}
 	if($build != DB_UPDATE_VERSION)
 		proc_run('php', 'include/dbupdate.php');
@@ -818,13 +818,11 @@ function check_db() {
 
 
 
-// Primarily involved with database upgrade, but also sets the
-// base url for use in cmdline programs which don't have
+// Sets the base url for use in cmdline programs which don't have
 // $_SERVER variables
 
-
-if(! function_exists('check_config')) {
-	function check_config(&$a) {
+if(! function_exists('check_url')) {
+	function check_url(&$a) {
 
 		$url = get_config('system','url');
 
@@ -839,6 +837,15 @@ if(! function_exists('check_config')) {
 		if((! link_compare($url,$a->get_baseurl())) && (! preg_match("/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/",$a->get_hostname)))
 			$url = set_config('system','url',$a->get_baseurl());
 
+		return;
+	}
+}
+
+
+// Automatic database updates
+
+if(! function_exists('update_db')) {
+	function update_db(&$a) {
 
 		$build = get_config('system','build');
 		if(! x($build))

--- a/include/config.php
+++ b/include/config.php
@@ -85,6 +85,15 @@ function get_config($family, $key, $instore = false) {
 if(! function_exists('set_config')) {
 function set_config($family,$key,$value) {
 	global $a;
+
+	// If $a->config[$family] has been previously set to '!<unset>!', then
+	// $a->config[$family][$key] will evaluate to $a->config[$family][0], and
+	// $a->config[$family][$key] = $value will be equivalent to
+	// $a->config[$family][0] = $value[0] (this causes infuriating bugs),
+	// so unset the family before assigning a value to a family's key
+	if($a->config[$family] === '!<unset>!')
+		unset($a->config[$family]);
+
 	// manage array value
 	$dbvalue = (is_array($value)?serialize($value):$value);
 	$dbvalue = (is_bool($dbvalue) ? intval($dbvalue) : $dbvalue);

--- a/include/dbupdate.php
+++ b/include/dbupdate.php
@@ -19,7 +19,7 @@ function dbupdate_run(&$argv, &$argc) {
 	load_config('config');
 	load_config('system');
 
-	check_config($a);
+	update_db($a);
 }
 
 if (array_search(__file__,get_included_files())===0){

--- a/index.php
+++ b/index.php
@@ -58,9 +58,9 @@ if(!$install) {
 	require_once("include/session.php");
 	load_hooks();
 	call_hooks('init_1');
-}
 
-$maintenance = get_config('system', 'maintenance');
+	$maintenance = get_config('system', 'maintenance');
+}
 
 
 /**
@@ -141,6 +141,7 @@ if($install)
 elseif($maintenance)
 	$a->module = 'maintenance';
 else {
+	check_url($a);
 	check_db();
 	check_plugins($a);
 }


### PR DESCRIPTION
This should fix the "update database on a fresh install" bug. Essentially, if in the `set_config` function $a->config[$family] has been previously set to `!<unset>!`, then $a->config[$family][$key] will evaluate to $a->config[$family][0]. Then when you try to set $a->config[$family][$key] = $value, it will be equivalent to $a->config[$family][0] = $value[0]. So let's unset the family before assigning a value to a family's key.

Test case:

``` php
$a = array('system' => '!<unset>!');
echo $a['system'] . "\n";
$a['system']['url'] = 'http://www.stupid.com';
echo $a['system']['url'] . "\n";

echo $a['system']['build'] . "\n";
echo $a['system'] . "\n";

unset($a['system']);

$a['system']['url'] = 'http://www.stupid.com';
echo $a['system']['url'] . "\n";
```

Output:

```
!<unset>!
h
h
h<unset>!
http://www.stupid.com
```
