### PR TITLE
add event-id index to prevent large CPU loads when visiting the events page

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -14,7 +14,7 @@ require_once('include/features.php');
 define ( 'FRIENDICA_PLATFORM',     'Friendica');
 define ( 'FRIENDICA_VERSION',      '3.1.1601' );
 define ( 'DFRN_PROTOCOL_VERSION',  '2.23'    );
-define ( 'DB_UPDATE_VERSION',      1158      );
+define ( 'DB_UPDATE_VERSION',      1159      );
 
 define ( 'EOL',                    "<br />\r\n"     );
 define ( 'ATOM_TIME',              'Y-m-d\TH:i:s\Z' );

--- a/database.sql
+++ b/database.sql
@@ -589,6 +589,7 @@ CREATE TABLE IF NOT EXISTS `item` (
   KEY `uid_commented` (`uid`, `commented`),
   KEY `uid_created` (`uid`, `created`),
   KEY `uid_unseen` (`uid`, `unseen`),
+  KEY `event_id` (`event-id`),
   FULLTEXT KEY `title` (`title`),
   FULLTEXT KEY `body` (`body`),
   FULLTEXT KEY `allow_cid` (`allow_cid`),

--- a/update.php
+++ b/update.php
@@ -1,6 +1,6 @@
 <?php
 
-define( 'UPDATE_VERSION' , 1158 );
+define( 'UPDATE_VERSION' , 1159 );
 
 /**
  *
@@ -1379,6 +1379,22 @@ function update_1157() {
 	  PRIMARY KEY (`id`)
 	  ) ENGINE=MyISAM DEFAULT CHARSET=utf8"
 	);
+
+	if($r)
+		return UPDATE_SUCCESS;
+
+	return UPDATE_FAILED;
+}
+
+function update_1158() {
+	set_config('system', 'maintenance', 1);
+
+	// Wait for 15 seconds for current requests to
+	// clear before locking up the database
+	sleep(15);
+
+	$r = q("CREATE INDEX event_id ON item(`event-id`)");
+	set_config('system', 'maintenance', 0);
 
 	if($r)
 		return UPDATE_SUCCESS;


### PR DESCRIPTION
I discovered that when I visited my Events page, the DB used 100% of the CPU for about 15 s. Upon investigation, I discovered the problem: there's no index for event-id in the item table. After creating the index, the DB query drops to 2 ms.
