### PR TITLE
don't block private posts to logged in users on the local hub

### DIFF
--- a/include/security.php
+++ b/include/security.php
@@ -266,14 +266,8 @@ function item_permissions_sql($owner_id,$remote_verified = false,$groups = null)
 	 * Profile owner - everything is visible
 	 */
 
-	if($local_user) {
-		if($local_user == $owner_id) {
-			$sql = '';
-		}
-		else {
-			/* logged in user can see hidden walls and feeds that are blocked to unknown users (private == 2) */
-			$sql = " AND private != 1 "; 
-		}
+	if($local_user && ($local_user == $owner_id)) {
+		$sql = '';
 	}
 
 	/**


### PR DESCRIPTION
The recent update to allow logged-in users to see private posts on a profile page marked either as private=1 or private=2 ended up blocked users of the same hub from viewing private content on each other's pages. The lines

``` php
    if($local_user) {
        if($local_user == $owner_id) {
            $sql = '';
        }
        else {
            /* logged in user can see hidden walls and feeds that are blocked to unknown users (private == 2) */
            $sql = " AND private != 1 "; 
        }
    }
```

say: if you're logged in locally, and you are not the owner of this profile page, then only show posts that have private != 1, i.e. either 0 or 2. Most private posts are currently set to 1, so this effectively blocks all private posts to a locally-logged in contact. If this section of code is restored to what it was before, then the `private in (1,2)` in the `elseif($remote_contact)` section seems to be sufficient to allow authenticated contacts to see the profile page, whether on a remote hub or the local one.
