### PR TITLE
move mb_strlen call out of for loop definition

### DIFF
--- a/include/text.php
+++ b/include/text.php
@@ -173,7 +173,7 @@ function autoname($len) {
 
 if(! function_exists('xmlify')) {
 function xmlify($str) {
-	$buffer = '';
+/*	$buffer = '';
 	
 	$len = mb_strlen($str);
 	for($x = 0; $x < $len; $x ++) {
@@ -205,7 +205,14 @@ function xmlify($str) {
 				$buffer .= $char;
 				break;
 		}	
-	}
+	}*/
+
+	$buffer = mb_ereg_replace("&", "&amp;", $str);
+	$buffer = mb_ereg_replace("'", "&apos;", $buffer);
+	$buffer = mb_ereg_replace("\"", "&quot;", $buffer);
+	$buffer = mb_ereg_replace("<", "&lt;", $buffer);
+	$buffer = mb_ereg_replace(">", "&gt;", $buffer);
+
 	$buffer = trim($buffer);
 	return($buffer);
 }}
@@ -215,8 +222,13 @@ function xmlify($str) {
 
 if(! function_exists('unxmlify')) {
 function unxmlify($s) {
-	$ret = str_replace('&amp;','&', $s);
-	$ret = str_replace(array('&lt;','&gt;','&quot;','&apos;'),array('<','>','"',"'"),$ret);
+//	$ret = str_replace('&amp;','&', $s);
+//	$ret = str_replace(array('&lt;','&gt;','&quot;','&apos;'),array('<','>','"',"'"),$ret);
+	$ret = mb_ereg_replace('&amp;', '&', $s);
+	$ret = mb_ereg_replace('&apos;', "'", $ret);
+	$ret = mb_ereg_replace('&quot;', '"', $ret);
+	$ret = mb_ereg_replace('&lt;', "<", $ret);
+	$ret = mb_ereg_replace('&gt;', ">", $ret);
 	return $ret;	
 }}
 


### PR DESCRIPTION
I was getting php-fpm processes that would use 100% of the CPU for an hour or more frequently after the poller ran for a user who posted a huge post (~1,000,000 characters -- it had a lot of embedded photos in it). I traced it to the `mb_strlen()` call in the `xmlify()` function, but couldn't figure out exactly what the problem was further than that.

I tried moving the call to `mb_strlen()` out of the for loop definition into a variable and that seemed to fix it. I'm not sure why; my best guess (which I've been unable to confirm with a quick look on Startpage) is that the exit condition of the for loop is checked on every loop, which would be a very large hit for a large post. At any rate, there shouldn't be any harm in doing this and it seems to have fixed it--I haven't seen any 100% loops since I made the change, anyway.
