### PR TITLE
don't change to string in prune_deadguys()

### DIFF
--- a/include/acl_selectors.php
+++ b/include/acl_selectors.php
@@ -239,7 +239,7 @@ function prune_deadguys($arr) {
 	if($r) {
 		$ret = array();
 		foreach($r as $rr) 
-			$ret[] = $rr['id'];
+			$ret[] = intval($rr['id']);
 		return $ret;
 	}
 	return array();


### PR DESCRIPTION
It appears that one of my recent changes to the ACL stuff made selecting individual contacts to Show to stop working. I traced it down to the fact that the individual contact permissions were getting sent as strings to acl.js, while everything else was getting set as integers. Individual contact permissions get switched from integers to strings in prune_deadguys(), so I made sure that doesn't happen anymore.

But that's not what changed. I'm not sure what did, but it seems like a prudent place to fix it.
