### PR TITLE
For very large posts (~18k) with lots of markup, these regexes were caus...

### DIFF
--- a/include/bbcode.php
+++ b/include/bbcode.php
@@ -642,8 +642,8 @@ function bbcode($Text,$preserve_nl = false, $tryoembed = true, $simplehtml = fal
 	$Text = preg_replace('/\&quot\;/','"',$Text);
 
 	// fix any escaped ampersands that may have been converted into links
-	$Text = preg_replace("/\<(.*?)(src|href)=(.*?)\&amp\;(.*?)\>/ism",'<$1$2=$3&$4>',$Text);
-	$Text = preg_replace("/\<(.*?)(src|href)=\"[^hfm](.*?)\>/ism",'<$1$2="">',$Text);
+	$Text = preg_replace("/\<([^>]*?)(src|href)=(.*?)\&amp\;(.*?)\>/ism",'<$1$2=$3&$4>',$Text);
+	$Text = preg_replace("/\<([^>]*?)(src|href)=\"[^hfm](.*?)\>/ism",'<$1$2="">',$Text);
 
 	if($saved_image)
 		$Text = bb_replace_images($Text, $saved_image);


### PR DESCRIPTION
...ing enough backtracking for php to run out of memory, silently generating an empty entry.  This tightens up the regexes so they do less backtracking.
