### PR TITLE
allow admin to prevent private image embedding on hub

### DIFF
--- a/include/items.php
+++ b/include/items.php
@@ -3644,9 +3644,13 @@ function atom_entry($item,$type,$author,$owner,$comment = false,$cid = 0) {
 }
 
 function fix_private_photos($s, $uid, $item = null, $cid = 0) {
+
+	if(get_config('system','disable_embedded'))
+		return $s;
+
 	$a = get_app();
 
-	logger('fix_private_photos', LOGGER_DEBUG);
+	logger('fix_private_photos: check for photos', LOGGER_DEBUG);
 	$site = substr($a->get_baseurl(),strpos($a->get_baseurl(),'://'));
 
 	$orig_body = $s;

--- a/mod/admin.php
+++ b/mod/admin.php
@@ -256,7 +256,8 @@ function admin_page_site_post(&$a){
 	$thread_allow		=	((x($_POST,'thread_allow'))		? True						: False);
 	$newuser_private		=	((x($_POST,'newuser_private'))		? True						: False);
 	$enotify_no_content		=	((x($_POST,'enotify_no_content'))	? True						: False);
-	$private_addons		=	((x($_POST,'private_addons'))		? True						: False);
+	$private_addons			=	((x($_POST,'private_addons'))		? True						: False);
+	$disable_embedded		=	((x($_POST,'disable_embedded'))		? True						: False);
 	
 	$no_multi_reg		=	((x($_POST,'no_multi_reg'))		? True						: False);
 	$no_openid		=	!((x($_POST,'no_openid'))		? True						: False);
@@ -374,6 +375,7 @@ function admin_page_site_post(&$a){
 	set_config('system','thread_allow', $thread_allow);
 	set_config('system','newuser_private', $newuser_private);
 	set_config('system','enotify_no_content', $enotify_no_content);
+	set_config('system','disable_embedded', $disable_embedded);
 
 	set_config('system','block_extended_register', $no_multi_reg);
 	set_config('system','no_openid', $no_openid);
@@ -510,6 +512,7 @@ function admin_page_site(&$a) {
 		'$newuser_private'	=> array('newuser_private', t("Private posts by default for new users"), get_config('system','newuser_private'), t("Set default post permissions for all new members to the default privacy group rather than public.")),
 		'$enotify_no_content'	=> array('enotify_no_content', t("Don't include post content in email notifications"), get_config('system','enotify_no_content'), t("Don't include the content of a post/comment/private message/etc. in the email notifications that are sent out from this site, as a privacy measure.")),
 		'$private_addons'	=> array('private_addons', t("Disallow public access to addons listed in the apps menu."), get_config('config','private_addons'), t("Checking this box will restrict addons listed in the apps menu to members only.")),
+		'$disable_embedded'	=> array('disable_embedded', t("Don't embed private images in posts"), get_config('system','disable_embedded'), t("Don't replace locally-hosted private photos in posts with an embedded copy of the image. This means that contacts who receive posts containing private photos won't be able to see them unless they first visit the owner's profile page, or unless they have the redir_private_img plugin enabled.")),
 		
 		'$no_multi_reg'		=> array('no_multi_reg', t("Block multiple registrations"),  get_config('system','block_extended_register'), t("Disallow users to register additional accounts for use as pages.")),
 		'$no_openid'		=> array('no_openid', t("OpenID support"), !get_config('system','no_openid'), t("OpenID support for registration and logins.")),

--- a/view/admin_site.tpl
+++ b/view/admin_site.tpl
@@ -86,6 +86,7 @@
 	{{ inc field_checkbox.tpl with $field=$newuser_private }}{{ endinc }}
 	{{ inc field_checkbox.tpl with $field=$enotify_no_content }}{{ endinc }}
 	{{ inc field_checkbox.tpl with $field=$private_addons }}{{ endinc }}	
+	{{ inc field_checkbox.tpl with $field=$disable_embedded }}{{ endinc }}
 	<div class="submit"><input type="submit" name="page_site" value="$submit" /></div>
 	
 	<h3>$advanced</h3>

--- a/view/smarty3/admin_site.tpl
+++ b/view/smarty3/admin_site.tpl
@@ -91,6 +91,7 @@
 	{{include file="field_checkbox.tpl" field=$newuser_private}}
 	{{include file="field_checkbox.tpl" field=$enotify_no_content}}
 	{{include file="field_checkbox.tpl" field=$private_addons}}	
+	{{include file="field_checkbox.tpl" field=$disable_embedded}}
 	<div class="submit"><input type="submit" name="page_site" value="{{$submit}}" /></div>
 	
 	<h3>{{$advanced}}</h3>

--- a/view/theme/decaf-mobile/admin_site.tpl
+++ b/view/theme/decaf-mobile/admin_site.tpl
@@ -42,7 +42,8 @@
 	{{ inc field_checkbox.tpl with $field=$thread_allow }}{{ endinc }}
 	{{ inc field_checkbox.tpl with $field=$newuser_private }}{{ endinc }}
 	{{ inc field_checkbox.tpl with $field=$enotify_no_content }}{{ endinc }}
-	
+	{{ inc field_checkbox.tpl with $field=$private_addons }}{{ endinc }}	
+	{{ inc field_checkbox.tpl with $field=$disable_embedded }}{{ endinc }}	
 	<div class="submit"><input type="submit" name="page_site" value="$submit" /></div>
 	
 	<h3>$advanced</h3>

--- a/view/theme/decaf-mobile/smarty3/admin_site.tpl
+++ b/view/theme/decaf-mobile/smarty3/admin_site.tpl
@@ -47,7 +47,8 @@
 	{{include file="field_checkbox.tpl" field=$thread_allow}}
 	{{include file="field_checkbox.tpl" field=$newuser_private}}
 	{{include file="field_checkbox.tpl" field=$enotify_no_content}}
-	
+	{{include file="field_checkbox.tpl" field=$private_addons}}	
+	{{include file="field_checkbox.tpl" field=$disable_embedded}}	
 	<div class="submit"><input type="submit" name="page_site" value="{{$submit}}" /></div>
 	
 	<h3>{{$advanced}}</h3>

--- a/view/theme/frost-mobile/admin_site.tpl
+++ b/view/theme/frost-mobile/admin_site.tpl
@@ -42,7 +42,8 @@
 	{{ inc field_checkbox.tpl with $field=$thread_allow }}{{ endinc }}
 	{{ inc field_checkbox.tpl with $field=$newuser_private }}{{ endinc }}
 	{{ inc field_checkbox.tpl with $field=$enotify_no_content }}{{ endinc }}
-	
+	{{ inc field_checkbox.tpl with $field=$private_addons }}{{ endinc }}	
+	{{ inc field_checkbox.tpl with $field=$disable_embedded }}{{ endinc }}	
 	<div class="submit"><input type="submit" name="page_site" value="$submit" /></div>
 	
 	<h3>$advanced</h3>

--- a/view/theme/frost-mobile/smarty3/admin_site.tpl
+++ b/view/theme/frost-mobile/smarty3/admin_site.tpl
@@ -47,7 +47,8 @@
 	{{include file="field_checkbox.tpl" field=$thread_allow}}
 	{{include file="field_checkbox.tpl" field=$newuser_private}}
 	{{include file="field_checkbox.tpl" field=$enotify_no_content}}
-	
+	{{include file="field_checkbox.tpl" field=$private_addons}}	
+	{{include file="field_checkbox.tpl" field=$disable_embedded}}	
 	<div class="submit"><input type="submit" name="page_site" value="{{$submit}}" /></div>
 	
 	<h3>{{$advanced}}</h3>

--- a/view/theme/frost/admin_site.tpl
+++ b/view/theme/frost/admin_site.tpl
@@ -44,7 +44,8 @@
 	{{ inc field_checkbox.tpl with $field=$thread_allow }}{{ endinc }}
 	{{ inc field_checkbox.tpl with $field=$newuser_private }}{{ endinc }}
 	{{ inc field_checkbox.tpl with $field=$enotify_no_content }}{{ endinc }}
-	
+	{{ inc field_checkbox.tpl with $field=$private_addons }}{{ endinc }}	
+	{{ inc field_checkbox.tpl with $field=$disable_embedded }}{{ endinc }}	
 	<div class="submit"><input type="submit" name="page_site" value="$submit" /></div>
 	
 	<h3>$advanced</h3>

--- a/view/theme/frost/smarty3/admin_site.tpl
+++ b/view/theme/frost/smarty3/admin_site.tpl
@@ -49,7 +49,8 @@
 	{{include file="field_checkbox.tpl" field=$thread_allow}}
 	{{include file="field_checkbox.tpl" field=$newuser_private}}
 	{{include file="field_checkbox.tpl" field=$enotify_no_content}}
-	
+	{{include file="field_checkbox.tpl" field=$private_addons}}	
+	{{include file="field_checkbox.tpl" field=$disable_embedded}}	
 	<div class="submit"><input type="submit" name="page_site" value="{{$submit}}" /></div>
 	
 	<h3>{{$advanced}}</h3>


### PR DESCRIPTION
There are some privacy and database size drawbacks to embedding private images in posts. This pull allows the admin of a hub to prevent that embedding from happening.

In order for private images to still display, a function has been added to add redir/ links to all images with Friendica-style photo URLs found in private posts or comments. Note that this functionality can't depend on the option to prevent private image embedding, because it's the _receiving_ hosts that need to deal with the lack of embedding.

I've run this on my hub for a while, and it works pretty well (sometimes you need to refresh to see all the private images on a post, particularly if there are a large number attached). I don't know how well it will work between two physically separate hubs. If it doesn't work well in the latter case, it may be more useful for community-based hubs, where people who sign up mostly connect to other people on the same hub. In that case, it will decrease the database size significantly.
