### PR TITLE
Make the content type available after calling fetch_url

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -401,6 +401,7 @@ if(! class_exists('App')) {
 		private $db;
 
 		private $curl_code;
+		private $curl_content_type;
 		private $curl_headers;
 
 		private $cached_profile_image;
@@ -671,6 +672,14 @@ if(! class_exists('App')) {
 
 		function get_curl_code() {
 			return $this->curl_code;
+		}
+
+		function set_curl_content_type($content_type) {
+			$this->curl_content_type = $content_type;
+		}
+
+		function get_curl_content_type() {
+			return $this->curl_content_type;
 		}
 
 		function set_curl_headers($headers) {

--- a/include/network.php
+++ b/include/network.php
@@ -101,6 +101,7 @@ function fetch_url($url,$binary = false, &$redirects = 0, $timeout = 0, $accept_
 	}
 
 	$a->set_curl_code($http_code);
+	$a->set_curl_content_type($curl_info['content_type']);
 
 	$body = substr($s,strlen($header));
 	$a->set_curl_headers($header);


### PR DESCRIPTION
I need this for my retriever plugin, but it seems like this is information that shouldn't just be thrown away in any case.
