### PR TITLE
Remove hashtag links when exporting to other networks

### DIFF
--- a/include/bbcode.php
+++ b/include/bbcode.php
@@ -673,7 +673,7 @@ function bbcode($Text,$preserve_nl = false, $tryoembed = true, $simplehtml = fal
 	//}
 
 	// Remove all hashtag addresses
-	if (!$tryoembed) {
+	if (!$tryoembed AND get_config("system", "remove_hashtags_on_export")) {
 		$pattern = '/#<a.*?href="(.*?)".*?>(.*?)<\/a>/is';
 		$Text = preg_replace($pattern, '#$2', $Text);
 	}
@@ -684,4 +684,3 @@ function bbcode($Text,$preserve_nl = false, $tryoembed = true, $simplehtml = fal
 
 	return $Text;
 }
-

--- a/include/html2plain.php
+++ b/include/html2plain.php
@@ -108,8 +108,10 @@ function html2plain($html, $wraplength = 75, $compact = false)
 	$message = str_replace("\r", "", $html);
 
 	// replace all hashtag addresses
-	$pattern = '/#<a.*?href="(.*?)".*?>(.*?)<\/a>/is';
-	$message = preg_replace($pattern, '#$2', $message);
+	if (get_config("system", "remove_hashtags_on_export")) {
+		$pattern = '/#<a.*?href="(.*?)".*?>(.*?)<\/a>/is';
+		$message = preg_replace($pattern, '#$2', $message);
+	}
 
 	$doc = new DOMDocument();
 	$doc->preserveWhiteSpace = false;


### PR DESCRIPTION
When HTML code is generated to export a message to other networks there should be no link attached to the hashtag that points to the friendica server.
