### PR TITLE
move html from paginate functions to template

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -635,7 +635,11 @@ if(! class_exists('App')) {
 		function set_pager_itemspage($n) {
 			$this->pager['itemspage'] = ((intval($n) > 0) ? intval($n) : 0);
 			$this->pager['start'] = ($this->pager['page'] * $this->pager['itemspage']) - $this->pager['itemspage'];
-
+		}
+		
+		function set_pager_page($n) {
+			$this->pager['page'] = $n;
+			$this->pager['start'] = ($this->pager['page'] * $this->pager['itemspage']) - $this->pager['itemspage'];
 		}
 
 		function init_pagehead() {

--- a/view/templates/paginate.tpl
+++ b/view/templates/paginate.tpl
@@ -1,0 +1,13 @@
+<div class="pager">
+	{{if $pager}}
+	{{ if $pager.prev }}<span class="pager_prev {{ $pager.prev.class }}"><a href="{{ $pager.prev.url }}">{{ $pager.prev.text }}</a></span>{{ /if }}
+
+	{{ if $pager.first }}<span class="pager_first $pager.first.class"><a href="{{ $pager.first.url }}">{{ $pager.first.text }}</a></span>{{ /if }}
+
+	{{ foreach $pager.pages as $p }}<span class="pager_{{ $p.class }}"><a href="{{ $p.url }}">{{ $p.text }}</a></span>{{ /foreach }}
+
+	{{ if $pager.last }}<span class="pager_last {{ $pager.last.class }}"><a href="{{ $pager.last.url }}">{{ $pager.last.text }}</a></span>{{ /if }}
+
+	{{ if $pager.next }}<span class="pager_next {{ $pager.next.class }}"><a href="{{ $pager.next.url }}">{{ $pager.next.text }}</a></span>{{ /if }}
+	{{/if}}
+</div>


### PR DESCRIPTION
- add new `paginate.tpl` template
- add new `paginate_data(&$a, $count=null)` function wich returns data as array for template
-  `paginate()` and `alt_pager()` use `paginate_data()` and template to return html

with this is possible also to insert pagination in page without append it to output string in view function:

``` php
function mymod_content(&$a){

   $pager = paginate_data($a);

   $tpl = get_markup_template('mymod.tpl');
   return replace_macros($tpl, array(
        'pager' => $pager
   ));
}
```

(in mymod.tpl : )

``` tpl
<h1>MyMod</h1>
{{include "paginator.tpl"}}

<p>Look Ma! Paginator on top!</p>
```
