### PR TITLE
Fix diaspora contacts profile image

### DIFF
--- a/include/diaspora.php
+++ b/include/diaspora.php
@@ -2119,7 +2119,7 @@ function diaspora_profile($importer,$xml,$msg) {
 	}
 	
 	 
-	if( preg_match("|^https?://|", $url1) === 0) {
+	if( preg_match("|^https?://|", $image_url) === 0) {
 		$image_url = "http://" . $handle_parts[1] . $image_url;
 	}
 


### PR DESCRIPTION
joindiaspora serves images from another domain.
We just check if $image_url is missing "http" in front and add domain from user id if is the case.
should fix issue 728
