### PR TITLE
Appending URLs in case of redirect is incorrect

### DIFF
--- a/include/network.php
+++ b/include/network.php
@@ -188,7 +188,7 @@ function post_url($url,$params, $headers = null, &$redirects = 0, $timeout = 0) 
         preg_match('/(Location:|URI:)(.*?)\n/', $header, $matches);
         $newurl = trim(array_pop($matches));
 		if(strpos($newurl,'/') === 0)
-			$newurl = $url . $newurl;
+			$newurl = $old_location_info["scheme"] . "://" . $old_location_info["host"] . $newurl;
         if (filter_var($newurl, FILTER_VALIDATE_URL)) {
             $redirects++;
             return fetch_url($newurl,false,$redirects,$timeout);


### PR DESCRIPTION
If the header returns an absolute path as a redirect, don't simply append the path to the old URL, remove the old absolute path first.

For example, original URL:

http://www.theregister.co.uk/2013/07/28/birmingham_uni_car_cracker_muzzled_by_lords/print.html

Redirect from header:

/Print/2013/07/28/birmingham_uni_car_cracker_muzzled_by_lords/

Incorrect result:

http://www.theregister.co.uk/2013/07/28/birmingham_uni_car_cracker_muzzled_by_lords/print.html/Print/2013/07/28/birmingham_uni_car_cracker_muzzled_by_lords/

Correct result after this patch:

http://www.theregister.co.uk/Print/2013/07/28/birmingham_uni_car_cracker_muzzled_by_lords/
