### PR TITLE
Solving the "Disallow public access to addons listed in the apps menu" h...

### DIFF
--- a/include/plugin.php
+++ b/include/plugin.php
@@ -185,6 +185,21 @@ function call_hooks($name, &$data = null) {
 	}
 }}
 
+//check if an app_menu hook exist for plugin $name.
+//Return true if the plugin is an app
+if(! function_exists('plugin_is_app')) {
+function plugin_is_app($name) {
+	$a = get_app();
+
+	if(is_array($a->hooks) && (array_key_exists('app_menu',$a->hooks))) {
+		foreach($a->hooks['app_menu'] as $hook) {
+			if($hook[0] == 'addon/'.$name.'/'.$name.'.php')
+				return true;
+		}
+	}
+	
+	return false;
+}}
 
 /*
  * parse plugin comment in search of plugin infos.

--- a/index.php
+++ b/index.php
@@ -149,11 +149,16 @@ else {
 
 nav_set_selected('nothing');
 
-$arr = array('app_menu' => $a->apps);
+//Don't populate apps_menu if apps are private
+$privateapps = get_config('config','private_addons');
+if((local_user()) || (! $privateapps === "1"))
+{
+	$arr = array('app_menu' => $a->apps);
 
-call_hooks('app_menu', $arr);
+	call_hooks('app_menu', $arr);
 
-$a->apps = $arr['app_menu'];
+	$a->apps = $arr['app_menu'];
+}
 
 /**
  *
@@ -186,11 +191,19 @@ if(strlen($a->module)) {
 	// Compatibility with the Android Diaspora client
 	if ($a->module == "stream")
 		$a->module = "network";
+	
+	$privateapps = get_config('config','private_addons');
 
 	if(is_array($a->plugins) && in_array($a->module,$a->plugins) && file_exists("addon/{$a->module}/{$a->module}.php")) {
-		include_once("addon/{$a->module}/{$a->module}.php");
-		if(function_exists($a->module . '_module'))
-			$a->module_loaded = true;
+		//Check if module is an app and if public access to apps is allowed or not
+		if((!local_user()) && plugin_is_app($a->module) && $privateapps === "1") {
+			info( t("You must be logged in to use addons. "));
+		}
+		else {
+			include_once("addon/{$a->module}/{$a->module}.php");
+			if(function_exists($a->module . '_module'))
+				$a->module_loaded = true;
+		}
 	}
 
 	/**


### PR DESCRIPTION
Fixes friendica/friendica#741

Add plugin_is_app function in include/plugin.php to check if a plugin is an app or not (check the existence of an 'app_menu' hook)

Populate the app menu conditionally ( is the user logged or not, are apps private ) and disallow apps execution if apps are private and the user is not logged.
