### PR TITLE
Delete all APC values before showing them in the settings and admin section

### DIFF
--- a/mod/admin.php
+++ b/mod/admin.php
@@ -87,6 +87,11 @@ function admin_content(&$a) {
 	if(x($_SESSION,'submanage') && intval($_SESSION['submanage']))
 		return "";
 
+	if (function_exists("apc_delete")) {
+		$toDelete = new APCIterator('user', APC_ITER_VALUE);
+		apc_delete($toDelete);
+	}
+
 	/**
 	 * Side bar links
 	 */

--- a/mod/settings.php
+++ b/mod/settings.php
@@ -16,6 +16,11 @@ function get_theme_config_file($theme){
 
 function settings_init(&$a) {
 
+	if (function_exists("apc_delete")) {
+		$toDelete = new APCIterator('user', APC_ITER_VALUE);
+		apc_delete($toDelete);
+	}
+
 	// These lines provide the javascript needed by the acl selector
 
 	$tpl = get_markup_template("settings-head.tpl");


### PR DESCRIPTION
When using APC it can happen that values are changed at the database side - but are cached through APC. That generates the problem that sometimes you see old settings in the "settings" and "admin" section.

Now the cached APC values are deleted before they are fetched. That means that it is guaranteed that you see the current values.
