### PR TITLE
Bugfix: The function "exif_imagetype" doesn't seem to be available at every system. So we emulate it.

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -2176,26 +2176,8 @@ function set_template_engine(&$a, $engine = 'internal') {
 }
 
 if(!function_exists('exif_imagetype')) {
-	function exif_imagetype($file) {
-		$size = getimagesize($file);
-
-		switch ($size["mime"]) {
-			case "image/jpeg":
-				$imagetype = IMAGETYPE_JPEG;
-				break;
-			case "image/gif":
-				$imagetype = IMAGETYPE_GIF;
-				break;
-			case "image/png":
-				$imagetype = IMAGETYPE_PNG;
-				break;
-			case "":
-				$imagetype = "";
-				break;
-			default:
-				$imagetype = 99;
-		}
-
-		return($imagetype);
-	}
+        function exif_imagetype($file) {
+                $size = getimagesize($file);
+                return($size[2]);
+        }
 }


### PR DESCRIPTION
There was a reporting that the "fromgplus" addon and the new twitter connector don't work at a system at "uberspace". We found out that the function "exif_imagetype" isn't available there.

There is a function that is doing nearly the same. The missing function is now emulated.
