### PR TITLE
SQL improvements. New parameter for a maximum amount of comments per thread

### DIFF
--- a/include/items.php
+++ b/include/items.php
@@ -2108,11 +2108,20 @@ function consume_feed($xml,$importer,&$contact, &$hub, $datedir = 0, $pass = 0) 
 					$datarray['type'] = 'activity';
 					$datarray['gravity'] = GRAVITY_LIKE;
 					// only one like or dislike per person
-					$r = q("select id from item where uid = %d and `contact-id` = %d and verb ='%s' and deleted = 0 and (`parent-uri` = '%s' OR `thr-parent` = '%s') limit 1",
+					// splitted into two queries for performance issues
+					$r = q("select id from item where uid = %d and `contact-id` = %d and verb ='%s' and deleted = 0 and (`parent-uri` = '%s') limit 1",
 						intval($datarray['uid']),
 						intval($datarray['contact-id']),
 						dbesc($datarray['verb']),
-						dbesc($parent_uri),
+						dbesc($parent_uri)
+					);
+					if($r && count($r))
+						continue;
+
+					$r = q("select id from item where uid = %d and `contact-id` = %d and verb ='%s' and deleted = 0 and (`thr-parent` = '%s') limit 1",
+						intval($datarray['uid']),
+						intval($datarray['contact-id']),
+						dbesc($datarray['verb']),
 						dbesc($parent_uri)
 					);
 					if($r && count($r))
@@ -3009,11 +3018,21 @@ function local_delivery($importer,$data) {
 					$datarray['gravity'] = GRAVITY_LIKE;
 					$datarray['last-child'] = 0;
 					// only one like or dislike per person
-					$r = q("select id from item where uid = %d and `contact-id` = %d and verb = '%s' and (`thr-parent` = '%s' or `parent-uri` = '%s') and deleted = 0 limit 1",
+					// splitted into two queries for performance issues
+					$r = q("select id from item where uid = %d and `contact-id` = %d and verb = '%s' and (`parent-uri` = '%s') and deleted = 0 limit 1",
 						intval($datarray['uid']),
 						intval($datarray['contact-id']),
 						dbesc($datarray['verb']),
-						dbesc($datarray['parent-uri']),
+						dbesc($datarray['parent-uri'])
+
+					);
+					if($r && count($r))
+						continue;
+
+					$r = q("select id from item where uid = %d and `contact-id` = %d and verb = '%s' and (`thr-parent` = '%s') and deleted = 0 limit 1",
+						intval($datarray['uid']),
+						intval($datarray['contact-id']),
+						dbesc($datarray['verb']),
 						dbesc($datarray['parent-uri'])
 
 					);
@@ -3181,11 +3200,20 @@ function local_delivery($importer,$data) {
 					$datarray['type'] = 'activity';
 					$datarray['gravity'] = GRAVITY_LIKE;
 					// only one like or dislike per person
-					$r = q("select id from item where uid = %d and `contact-id` = %d and verb ='%s' and deleted = 0 and (`parent-uri` = '%s' OR `thr-parent` = '%s') limit 1",
+					// splitted into two queries for performance issues
+					$r = q("select id from item where uid = %d and `contact-id` = %d and verb ='%s' and deleted = 0 and (`parent-uri` = '%s') limit 1",
 						intval($datarray['uid']),
 						intval($datarray['contact-id']),
 						dbesc($datarray['verb']),
-						dbesc($parent_uri),
+						dbesc($parent_uri)
+					);
+					if($r && count($r))
+						continue;
+
+					$r = q("select id from item where uid = %d and `contact-id` = %d and verb ='%s' and deleted = 0 and (`thr-parent` = '%s') limit 1",
+						intval($datarray['uid']),
+						intval($datarray['contact-id']),
+						dbesc($datarray['verb']),
 						dbesc($parent_uri)
 					);
 					if($r && count($r))

--- a/mod/regmod.php
+++ b/mod/regmod.php
@@ -17,19 +17,19 @@ function user_allow($hash) {
 	$user = q("SELECT * FROM `user` WHERE `uid` = %d LIMIT 1",
 		intval($register[0]['uid'])
 	);
-	
+
 	if(! count($user))
 		killme();
 
-	$r = q("DELETE FROM `register` WHERE `hash` = '%s' LIMIT 1",
+	$r = q("DELETE FROM `register` WHERE `hash` = '%s'",
 		dbesc($register[0]['hash'])
 	);
 
 
-	$r = q("UPDATE `user` SET `blocked` = 0, `verified` = 1 WHERE `uid` = %d LIMIT 1",
+	$r = q("UPDATE `user` SET `blocked` = 0, `verified` = 1 WHERE `uid` = %d",
 		intval($register[0]['uid'])
 	);
-	
+
 	$r = q("SELECT * FROM `profile` WHERE `uid` = %d AND `is-default` = 1",
 		intval($user[0]['uid'])
 	);
@@ -62,7 +62,7 @@ function user_allow($hash) {
 	if($res) {
 		info( t('Account approved.') . EOL );
 		return true;
-	}	
+	}
 
 }
 
@@ -83,23 +83,23 @@ function user_deny($hash) {
 	$user = q("SELECT * FROM `user` WHERE `uid` = %d LIMIT 1",
 		intval($register[0]['uid'])
 	);
-	
-	$r = q("DELETE FROM `user` WHERE `uid` = %d LIMIT 1",
+
+	$r = q("DELETE FROM `user` WHERE `uid` = %d",
 		intval($register[0]['uid'])
 	);
-	$r = q("DELETE FROM `contact` WHERE `uid` = %d LIMIT 1",
+	$r = q("DELETE FROM `contact` WHERE `uid` = %d",
 		intval($register[0]['uid'])
-	); 
-	$r = q("DELETE FROM `profile` WHERE `uid` = %d LIMIT 1",
+	);
+	$r = q("DELETE FROM `profile` WHERE `uid` = %d",
 		intval($register[0]['uid'])
-	); 
+	);
 
-	$r = q("DELETE FROM `register` WHERE `hash` = '%s' LIMIT 1",
+	$r = q("DELETE FROM `register` WHERE `hash` = '%s'",
 		dbesc($register[0]['hash'])
 	);
 	notice( sprintf(t('Registration revoked for %s'), $user[0]['username']) . EOL);
 	return true;
-	
+
 }
 
 function regmod_content(&$a) {


### PR DESCRIPTION
There is a new configuration parameter:

$a->config['system']['max_comments'] = ...

It configures how much comments should be visible in per post. When you are using the facebook connector you can import posts with several thousands of comments. This kills the memory :)

This parameter limits the comments to the last X comments. Per standard it is set to 1,000. On my own machine i set it to 100.

Additionally I found some more "limit" statements where they don't belong.

And finally I found some statements that were always in my slow query log. Now they aren't anymore :)
