### PR TITLE
api: fix call-time pass-by-reference error

### DIFF
--- a/include/api.php
+++ b/include/api.php
@@ -76,7 +76,7 @@
 			logger('API_login: ' . print_r($_SERVER,true), LOGGER_DEBUG);
 			header('WWW-Authenticate: Basic realm="Friendica"');
 			header('HTTP/1.0 401 Unauthorized');
-			die((api_error(&$a, 'json', "This api requires login")));
+			die((api_error($a, 'json', "This api requires login")));
 
 			//die('This api requires login');
 		}
@@ -176,7 +176,7 @@
 		}
 		header("HTTP/1.1 404 Not Found");
 		logger('API call not implemented: '.$a->query_string." - ".print_r($_REQUEST,true));
-		return(api_error(&$a, $type, "not implemented"));
+		return(api_error($a, $type, "not implemented"));
 
 	}
 


### PR DESCRIPTION
call-time pass-by-reference is a fatal error now (tested with php 5.5.6)
