### PR TITLE
API: Show shared messages as repeated messages, improvements with nick names

### DIFF
--- a/include/bbcode.php
+++ b/include/bbcode.php
@@ -378,7 +378,7 @@ function GetProfileUsername($profile, $username) {
 	// BBcode 2 HTML was written by WAY2WEB.net
 	// extended to work with Mistpark/Friendica - Mike Macgirvin
 
-function bbcode($Text,$preserve_nl = false, $tryoembed = true, $simplehtml = false) {
+function bbcode($Text,$preserve_nl = false, $tryoembed = true, $simplehtml = false, $forplaintext = false) {
 
 	$stamp1 = microtime(true);
 
@@ -462,8 +462,11 @@ function bbcode($Text,$preserve_nl = false, $tryoembed = true, $simplehtml = fal
 
 
 	// Perform URL Search
-
-	$Text = preg_replace("/([^\]\='".'"'."]|^)(https?\:\/\/[a-zA-Z0-9\:\/\-\?\&\;\.\=\_\~\#\%\$\!\+\,]+)/ism", '$1<a href="$2" target="external-link">$2</a>', $Text);
+	// if the HTML is used to generate plain text, then don't do this search, but replace all URL of that kind to text
+	if (!$forplaintext)
+		$Text = preg_replace("/([^\]\='".'"'."]|^)(https?\:\/\/[a-zA-Z0-9\:\/\-\?\&\;\.\=\_\~\#\%\$\!\+\,]+)/ism", '$1<a href="$2" target="external-link">$2</a>', $Text);
+	else
+		$Text = preg_replace("(\[url\](.*?)\[\/url\])ism","$1",$Text);
 
 	if ($tryoembed)
 		$Text = preg_replace_callback("/\[bookmark\=([^\]]*)\].*?\[\/bookmark\]/ism",'tryoembed',$Text);

--- a/include/html2bbcode.php
+++ b/include/html2bbcode.php
@@ -156,11 +156,17 @@ function html2bbcode($message)
 	//node2bbcode($doc, 'span', array('style'=>'/.*font-size:\s*(.+?)[,;].*/'), '[size=$1]', '[/size]');
 
 	node2bbcode($doc, 'span', array('style'=>'/.*color:\s*(.+?)[,;].*/'), '[color="$1"]', '[/color]');
+
 	//node2bbcode($doc, 'span', array('style'=>'/.*font-family:\s*(.+?)[,;].*/'), '[font=$1]', '[/font]');
 
 	//node2bbcode($doc, 'div', array('style'=>'/.*font-family:\s*(.+?)[,;].*font-size:\s*(\d+?)pt.*/'), '[font=$1][size=$2]', '[/size][/font]');
 	//node2bbcode($doc, 'div', array('style'=>'/.*font-family:\s*(.+?)[,;].*font-size:\s*(\d+?)px.*/'), '[font=$1][size=$2]', '[/size][/font]');
 	//node2bbcode($doc, 'div', array('style'=>'/.*font-family:\s*(.+?)[,;].*/'), '[font=$1]', '[/font]');
+
+	// Importing the classes - interesting for importing of posts from third party networks that were exported from friendica
+	// Test
+	//node2bbcode($doc, 'span', array('class'=>'/([\w ]+)/'), '[class=$1]', '[/class]');
+	node2bbcode($doc, 'span', array('class'=>'type-link'), '[class=type-link]', '[/class]');
 
 	node2bbcode($doc, 'strong', array(), '[b]', '[/b]');
 	node2bbcode($doc, 'em', array(), '[i]', '[/i]');


### PR DESCRIPTION
Futher improvements for the API. 
- Now the nicknames are fetched from the known profile addresses when they aren't present.
- Shared messages are shown as repeated messages if they only consist of the shared part with no further comment.
- In text mode the content of a post is reduced (removed quotes and pictures of posted links) to make the text output more readable.
