### PR TITLE
Beautifiying export of shared posts to other networks

### DIFF
--- a/include/bb2diaspora.php
+++ b/include/bb2diaspora.php
@@ -133,6 +133,10 @@ function diaspora_ol($s) {
 
 function bb2diaspora($Text,$preserve_nl = false, $fordiaspora = true) {
 
+	// Since Diaspora is creating a summary for links, this function removes them before posting
+	if ($fordiaspora)
+		$Text = bb_remove_share_information($Text);
+
 	// Re-enabling the converter again.
 	// The bbcode parser now handles youtube-links (and the other stuff) correctly.
 	// Additionally the html code is now fixed so that lists are now working.
@@ -159,7 +163,10 @@ function bb2diaspora($Text,$preserve_nl = false, $fordiaspora = true) {
 	//$Text = preg_replace("/\[share(.*?)avatar\s?=\s?'.*?'\s?(.*?)\]\s?(.*?)\s?\[\/share\]\s?/ism","\n[share$1$2]$3[/share]",$Text);
 
 	// Convert it to HTML - don't try oembed
-	$Text = bbcode($Text, $preserve_nl, false);
+	if ($fordiaspora)
+		$Text = bbcode($Text, $preserve_nl, false, 3);
+	else
+		$Text = bbcode($Text, $preserve_nl, false, 4);
 
 	// Now convert HTML to Markdown
 	$md = new Markdownify(false, false, false);
@@ -179,7 +186,7 @@ function bb2diaspora($Text,$preserve_nl = false, $fordiaspora = true) {
 
 		$count++;
 		$pos = bb_find_open_close($Text, '[', ']', $count);
-	}	
+	}
 
 	// If the text going into bbcode() has a plain URL in it, i.e.
 	// with no [url] tags around it, it will come out of parseString()

--- a/view/theme/vier/style.css
+++ b/view/theme/vier/style.css
@@ -1127,6 +1127,18 @@ border-bottom: 1px solid #D2D2D2;
   display: table;
   width: 745px;
 }
+
+.wall-item-content hr {
+  background: none repeat scroll 0% 0% rgb(221, 221, 221);
+  color: rgb(221, 221, 221);
+  clear: both;
+  float: none;
+  width: 100%;
+  height: 0.1em;
+  /* margin: 0px 0px 1.45em; */
+  border: medium none;
+}
+
 .wall-item-container .wall-item-item, .wall-item-container .wall-item-bottom {
   display: table-row;
 }
@@ -2135,7 +2147,8 @@ blockquote {
 }
 
 .oembed {
-    font-size: large;
+    /* font-size: large; */
+    font-size: larger;
     font-weight: bold;
 }
 


### PR DESCRIPTION
Shared posts to other networks hadn't looked always great and especially made problems with Diaspora. There was an update to Diaspora several time ago, so that Diaspora takes the OpenGraph information from the first link it gets in the message. That means that the first link shouldn't be the link to the user profile or the original post - but to the first link in the shared part of the shared post.

So the format changed to:

```
♲ User Name (nick@network.tld):
```

When exporting the messages to other networks (like Wordpress, Libertree, Tumblr, ...) the format is the same - but the username is a link to the original message.

When a shared item is commented, then there is a horizontal ruler between the comment and the shared message.

Once this pull request is accepted, there will be a pull request for the addons that are using this.
