### PR TITLE
Vier: Fix for the display of long text event entries

### DIFF
--- a/view/theme/vier/style.css
+++ b/view/theme/vier/style.css
@@ -2317,10 +2317,10 @@ a.mail-list-link {
 }
 
 .vevent {
-	border: 1px solid #CCCCCC;
-	max-width: 600px;
-	position: relative;
-	margin-top: 4px;
+        border: 1px solid #CCCCCC;
+        max-width: 600px;
+        position: relative;
+        margin-top: 4px;
         margin-right: 4px;
         margin-bottom: 15px;
 }


### PR DESCRIPTION
Event entries with long text didn't look good in the colorbox popup in vier as the text did not wrap. 
