### PR TITLE
Make uimport URL work for Sites with subfolder

### DIFF
--- a/view/templates/register.tpl
+++ b/view/templates/register.tpl
@@ -61,7 +61,7 @@
 
 <h3>{{$importh}}</h3>
 	<div id ="import-profile">
-		<a href="/uimport">{{$importt}}</a>
+		<a href="uimport">{{$importt}}</a>
 	</div>
 </form>
 


### PR DESCRIPTION
BUGFIX: If you have a site like http://exmaple.com/friendica you will get a wrong url
