### PR TITLE
Added an alternate link to the profile in the atom feeds (feature request #925)

### DIFF
--- a/include/items.php
+++ b/include/items.php
@@ -163,6 +163,11 @@ function get_feed_for(&$a, $dfrn_id, $owner_nick, $last_update, $direction = 0) 
 
 	$salmon = feed_salmonlinks($owner_nick);
 
+	$alternatelink = $owner['url'];
+
+	if(isset($category))
+		$alternatelink .= "/category/".$category;
+
 	$atom .= replace_macros($feed_template, array(
 		'$version'      => xmlify(FRIENDICA_VERSION),
 		'$feed_id'      => xmlify($a->get_baseurl() . '/profile/' . $owner_nick),
@@ -170,6 +175,7 @@ function get_feed_for(&$a, $dfrn_id, $owner_nick, $last_update, $direction = 0) 
 		'$feed_updated' => xmlify(datetime_convert('UTC', 'UTC', 'now' , ATOM_TIME)) ,
 		'$hub'          => $hubxml,
 		'$salmon'       => $salmon,
+		'$alternatelink' => xmlify($alternatelink),
 		'$name'         => xmlify($owner['name']),
 		'$profile_page' => xmlify($owner['url']),
 		'$photo'        => xmlify($owner['photo']),

--- a/view/templates/atom_feed.tpl
+++ b/view/templates/atom_feed.tpl
@@ -19,6 +19,7 @@
   <title>{{$feed_title}}</title>
   <generator uri="http://friendica.com" version="{{$version}}">Friendica</generator>
   <link rel="license" href="http://creativecommons.org/licenses/by/3.0/" />
+  <link rel="alternate" type="text/html" href="{{$alternatelink}}" />
   {{$hub}}
   {{$salmon}}
   {{$community}}

--- a/view/templates/atom_feed_dfrn.tpl
+++ b/view/templates/atom_feed_dfrn.tpl
@@ -19,6 +19,7 @@
   <title>{{$feed_title}}</title>
   <generator uri="http://friendica.com" version="{{$version}}">Friendica</generator>
   <link rel="license" href="http://creativecommons.org/licenses/by/3.0/" />
+  <link rel="alternate" type="text/html" href="{{$alternatelink}}" />
   {{$hub}}
   {{$salmon}}
   {{$community}}


### PR DESCRIPTION
There feature request https://github.com/friendica/friendica/issues/925 asked for a link to to the regular profile page in the feed.

Here it is.
