### PR TITLE
Unsupported themes aren't displayed anymore

### DIFF
--- a/mod/admin.php
+++ b/mod/admin.php
@@ -1179,9 +1179,11 @@ function admin_page_themes(&$a){
 		foreach($files as $file) {
 			$f = basename($file);
 			$is_experimental = intval(file_exists($file . '/experimental'));
-			$is_supported = 1-(intval(file_exists($file . '/unsupported'))); // Is not used yet
+			$is_supported = 1-(intval(file_exists($file . '/unsupported')));
 			$is_allowed = intval(in_array($f,$allowed_themes));
-			$themes[] = array('name' => $f, 'experimental' => $is_experimental, 'supported' => $is_supported, 'allowed' => $is_allowed);
+
+			if ($is_allowed OR $is_supported OR get_config("system", "show_unsupported_themes"))
+				$themes[] = array('name' => $f, 'experimental' => $is_experimental, 'supported' => $is_supported, 'allowed' => $is_allowed);
 		}
 	}
 


### PR DESCRIPTION
Unsupported themes aren't displayed anymore in the admin settings. They are only shown if they are allowed or if the following setting is enabled in the .htconfig.php

```
$a->config['system']['show_unsupported_themes'] = true;
```
