### PR TITLE
Security issue: Encoding of GUID in itemcache to avoid directory bypassing with a malificious formatted GUID.

### DIFF
--- a/include/items.php
+++ b/include/items.php
@@ -1412,7 +1412,7 @@ function item_store($arr,$force_parent = false, $notify = false) {
 	if (!$deleted) {
 
 		// Store the fresh generated item into the cache
-		$cachefile = get_cachefile($arr["guid"]."-".hash("md5", $arr['body']));
+		$cachefile = get_cachefile(urlencode($arr["guid"])."-".hash("md5", $arr['body']));
 
 		if (($cachefile != '') AND !file_exists($cachefile)) {
 			$s = prepare_text($arr['body']);

--- a/include/tags.php
+++ b/include/tags.php
@@ -26,7 +26,7 @@ function create_tags_from_item($itemid) {
 	if ($message["deleted"])
 		return;
 
-	$cachefile = get_cachefile($message["guid"]."-".hash("md5", $message['body']));
+	$cachefile = get_cachefile(urlencode($message["guid"])."-".hash("md5", $message['body']));
 
 	if (($cachefile != '') AND !file_exists($cachefile)) {
 		$s = prepare_text($message['body']);

--- a/include/text.php
+++ b/include/text.php
@@ -1330,8 +1330,7 @@ function prepare_body(&$item,$attach = false, $preview = false) {
 	$item['mentions'] = $mentions;
 
 
-	//$cachefile = get_cachefile($item["guid"]."-".strtotime($item["edited"])."-".hash("crc32", $item['body']));
-	$cachefile = get_cachefile($item["guid"]."-".hash("md5", $item['body']));
+	$cachefile = get_cachefile(urlencode($item["guid"])."-".hash("md5", $item['body']));
 
 	if (($cachefile != '')) {
 		if (file_exists($cachefile)) {

--- a/mod/item.php
+++ b/mod/item.php
@@ -807,7 +807,7 @@ function item_post(&$a) {
 		file_tag_update_pconfig($uid,$categories_old,$categories_new,'category');
 
 		// Store the fresh generated item into the cache
-		$cachefile = get_cachefile($datarray["guid"]."-".hash("md5", $datarray['body']));
+		$cachefile = get_cachefile(urlencode($datarray["guid"])."-".hash("md5", $datarray['body']));
 
 		if (($cachefile != '') AND !file_exists($cachefile)) {
 			$s = prepare_text($datarray['body']);

--- a/mod/parse_url.php
+++ b/mod/parse_url.php
@@ -186,6 +186,9 @@ function parseurl_getsiteinfo($url, $no_guessing = false, $do_oembed = true, $co
 				case "twitter:image":
 					$siteinfo["image"] = $attr["content"];
 					break;
+				case "twitter:image:src":
+					$siteinfo["image"] = $attr["content"];
+					break;
 				case "twitter:card":
 					if (($siteinfo["type"] == "") OR ($attr["content"] == "photo"))
 						$siteinfo["type"] = $attr["content"];


### PR DESCRIPTION
The GUID is used to create the file name for the item cache. Until now there was no checking for critical characters in the GUID.

Another thing included here: There is a new possibility in the twitter card specification for embedded pictures.
