### PR TITLE
Importing feed with hashtags from keywords

### DIFF
--- a/include/items.php
+++ b/include/items.php
@@ -908,7 +908,7 @@ function add_page_info($url, $no_photos = false, $photo = "", $keywords = false)
 		return("");
 
 	if (($data["type"] != "photo") AND is_string($data["title"]))
-		$text .= "[bookmark=".$url."]".trim($data["title"])."[/bookmark]";
+		$text .= "[bookmark=".$data["url"]."]".trim($data["title"])."[/bookmark]";
 
 	if (($data["type"] != "video") AND ($photo != ""))
 		$text .= '[img]'.$photo.'[/img]';
@@ -921,9 +921,14 @@ function add_page_info($url, $no_photos = false, $photo = "", $keywords = false)
 		$text .= "[quote]".$data["text"]."[/quote]";
 
 	$hashtags = "";
-	if ($keywords AND isset($data["keywords"]))
-		foreach ($data["keywords"] AS $keyword)
-			$hashtags .= "#".str_replace(" ", "", $keyword)." ";
+	if ($keywords AND isset($data["keywords"])) {
+		$a = get_app();
+		$hashtags = "\n";
+		foreach ($data["keywords"] AS $keyword) {
+			$hashtag = str_replace(" ", "", $keyword);
+			$hashtags .= "#[url=".$a->get_baseurl()."/search?tag=".rawurlencode($hashtag)."]".$hashtag."[/url] ";
+		}
+	}
 
 	return("\n[class=type-".$data["type"]."]".$text."[/class]".$hashtags);
 }

--- a/mod/parse_url.php
+++ b/mod/parse_url.php
@@ -51,6 +51,7 @@ function completeurl($url, $scheme) {
 }
 
 function parseurl_getsiteinfo($url, $no_guessing = false, $do_oembed = true, $count = 1) {
+	require_once("include/network.php");
 
 	$a = get_app();
 
@@ -63,6 +64,9 @@ function parseurl_getsiteinfo($url, $no_guessing = false, $do_oembed = true, $co
 
 	$url = trim($url, "'");
 	$url = trim($url, '"');
+
+	$url = original_url($url);
+
 	$siteinfo["url"] = $url;
 	$siteinfo["type"] = "link";
 


### PR DESCRIPTION
When importing a feed and "fetch further information" is selected, then the keywords of the page are added as hashtags. This is especially useful when "remote self" is activated.
