### PR TITLE
remote self: There is now an option if the keyswords should be used as tags or not

### DIFF
--- a/include/items.php
+++ b/include/items.php
@@ -872,7 +872,7 @@ function get_atom_elements($feed, $item, $contact = array()) {
 	}
 
 	if (isset($contact["network"]) AND ($contact["network"] == NETWORK_FEED) AND $contact['fetch_further_information']) {
-		$res["body"] = $res["title"].add_page_info($res['plink'], false, "", true);
+		$res["body"] = $res["title"].add_page_info($res['plink'], false, "", ($contact['fetch_further_information'] == 2));
 		$res["title"] = "";
 		$res["object-type"] = ACTIVITY_OBJ_BOOKMARK;
 	} elseif (isset($contact["network"]) AND ($contact["network"] == NETWORK_OSTATUS))

--- a/mod/contacts.php
+++ b/mod/contacts.php
@@ -502,7 +502,8 @@ function contacts_content(&$a) {
 			'$archived' => (($contact['archive']) ? t('Currently archived') : ''),
 			'$hidden' => array('hidden', t('Hide this contact from others'), ($contact['hidden'] == 1), t('Replies/likes to your public posts <strong>may</strong> still be visible')),
 			'$notify' => array('notify', t('Notification for new posts'), ($contact['notify_new_posts'] == 1), t('Send a notification of every new post of this contact')),
-			'$fetch_further_information' => array('fetch_further_information', t('Fetch further information for feeds'), ($contact['fetch_further_information'] == 1), t('Fetch further information for feeds')),
+			'$fetch_further_information' => array('fetch_further_information', t('Fetch further information for feeds'), $contact['fetch_further_information'], t('Fetch further information for feeds'),
+								array('0'=>t('Disabled'), '1'=>t('Fetch information'), '2'=>t('Fetch information and keywords'))),
 			'$photo' => $contact['photo'],
 			'$name' => $contact['name'],
 			'$dir_icon' => $dir_icon,
@@ -684,10 +685,10 @@ function contacts_content(&$a) {
 			);
 		}
 
-		
+
 
 	}
-	
+
 	$tpl = get_markup_template("contacts-template.tpl");
 	$o .= replace_macros($tpl, array(
 		'$baseurl' => $a->get_baseurl(),

--- a/view/templates/contact_edit.tpl
+++ b/view/templates/contact_edit.tpl
@@ -66,7 +66,7 @@
 	{{/if}}
 	<div id="contact-edit-end" ></div>
 	{{include file="field_checkbox.tpl" field=$notify}}
-	{{include file="field_checkbox.tpl" field=$fetch_further_information}}
+	{{include file="field_select.tpl" field=$fetch_further_information}}
 	{{include file="field_checkbox.tpl" field=$hidden}}
 
 <div id="contact-edit-info-wrapper">


### PR DESCRIPTION
Some commits before, the feature was added that keywords were added as hashtags. Sometimes the hashtags aren't very good. With these lines it is now possible to chose if the keywords should be used for hashtags or not.
