### PR TITLE
Bugfix for stale gprobe.php

### DIFF
--- a/include/Scrape.php
+++ b/include/Scrape.php
@@ -263,11 +263,6 @@ function scrape_feed($url) {
 	}
 
 	try {
-		// Cleanup invalid HTML
-		$doc = new DOMDocument();
-		@$doc->loadHTML($s);
-                $s = $doc->saveHTML();
-
 		$dom = HTML5_Parser::parse($s);
 	} catch (DOMException $e) {
 		logger('scrape_feed: parse error: ' . $e);

--- a/library/HTML5/Parser.php
+++ b/library/HTML5/Parser.php
@@ -17,6 +17,12 @@ class HTML5_Parser
      * @return Parsed HTML as DOMDocument
      */
     static public function parse($text, $builder = null) {
+
+	// Cleanup invalid HTML
+	$doc = new DOMDocument();
+	@$doc->loadHTML($text);
+	$text = $doc->saveHTML();
+
         $tokenizer = new HTML5_Tokenizer($text, $builder);
         $tokenizer->parse();
         return $tokenizer->save();


### PR DESCRIPTION
There was the issue that sometimes the gprobe.php stales and gets 100% CPU. This seems to happen with invalid HTML. To solve this issue, the HTML code for the parser is now cleaned before sending it through the parser.

Best solution would be to remove the parser class and to replace it with the build in functions - but that would be a larger step.
