### PR TITLE
Fix for issue 1191 - Embedded Youtube video isn't playing when SSL is active

### DIFF
--- a/include/oembed.php
+++ b/include/oembed.php
@@ -78,6 +78,11 @@ function oembed_fetch_url($embedurl, $no_rich_type = false){
 	if (!is_object($j))
 		return false;
 
+	// Always embed the SSL version
+	if (isset($j->html))
+		$j->html = str_replace(array("http://www.youtube.com/", "http://player.vimeo.com/"),
+			array("https://www.youtube.com/", "https://player.vimeo.com/"), $j->html);
+
 	$j->embedurl = $embedurl;
 
 	// If fetching information doesn't work, then improve via internal functions

--- a/mod/oembed.php
+++ b/mod/oembed.php
@@ -9,17 +9,18 @@ function oembed_content(&$a){
 		echo oembed_replacecb($url);
 		killme();
 	}
-	
+
 	if ($a->argv[1]=='h2b'){
 		$text = trim(hex2bin($_REQUEST['text']));
 		echo oembed_html2bbcode($text);
 		killme();
 	}
-	
+
 	if ($a->argc == 2){
 		echo "<html><body>";
 		$url = base64url_decode($a->argv[1]);
 		$j = oembed_fetch_url($url);
+
 		echo $j->html;
 //		logger('mod-oembed ' . $j->html, LOGGER_ALL);
 		echo "</body></html>";


### PR DESCRIPTION
This pull request handles the problem that was described here: https://github.com/friendica/friendica/issues/1191
