### PR TITLE
Generate preview pictures from enclosed data from feeds

### DIFF
--- a/include/items.php
+++ b/include/items.php
@@ -872,9 +872,18 @@ function get_atom_elements($feed, $item, $contact = array()) {
 	}
 
 	if (isset($contact["network"]) AND ($contact["network"] == NETWORK_FEED) AND $contact['fetch_further_information']) {
-		$res["body"] = $res["title"].add_page_info($res['plink'], false, "", ($contact['fetch_further_information'] == 2), $contact['ffi_keyword_blacklist']);
+		$preview = "";
+
+		// Handle enclosures and treat them as preview picture
+		if (isset($attach))
+			foreach ($attach AS $attachment)
+				if ($attachment->type == "image/jpeg")
+					$preview = $attachment->link;
+
+		$res["body"] = $res["title"].add_page_info($res['plink'], false, $preview, ($contact['fetch_further_information'] == 2), $contact['ffi_keyword_blacklist']);
 		$res["title"] = "";
 		$res["object-type"] = ACTIVITY_OBJ_BOOKMARK;
+		unset($res["attach"]);
 	} elseif (isset($contact["network"]) AND ($contact["network"] == NETWORK_OSTATUS))
 		$res["body"] = add_page_info_to_body($res["body"]);
 	elseif (isset($contact["network"]) AND ($contact["network"] == NETWORK_FEED) AND strstr($res['plink'], ".app.net/")) {
@@ -940,6 +949,9 @@ function add_page_info($url, $no_photos = false, $photo = "", $keywords = false,
 	require_once("mod/parse_url.php");
 
 	$data = parseurl_getsiteinfo($url, true);
+
+	if ($photo != "")
+		$data["images"][0]["src"] = $photo;
 
 	logger('add_page_info: fetch page info for '.$url.' '.print_r($data, true), LOGGER_DEBUG);
 


### PR DESCRIPTION
Feeds sometimes have enclosed pictures. (Example: http://ticker.gulli.com/rss) These pictures are now used for the generated preview.
