### PR TITLE
The "scrape" bugfix lead to partly damaged encodings. This is fixed now

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -18,7 +18,7 @@ define ( 'FRIENDICA_PLATFORM',     'Friendica');
 define ( 'FRIENDICA_CODENAME',     'Ginger');
 define ( 'FRIENDICA_VERSION',      '3.3.2' );
 define ( 'DFRN_PROTOCOL_VERSION',  '2.23'    );
-define ( 'DB_UPDATE_VERSION',      1175      );
+define ( 'DB_UPDATE_VERSION',      1176      );
 define ( 'EOL',                    "<br />\r\n"     );
 define ( 'ATOM_TIME',              'Y-m-d\TH:i:s\Z' );
 

--- a/include/dbstructure.php
+++ b/include/dbstructure.php
@@ -823,6 +823,7 @@ function db_definition() {
 					"id" => array("type" => "int(11)", "not null" => "1", "extra" => "auto_increment", "primary" => "1"),
 					"name" => array("type" => "varchar(128)", "not null" => "1", "default" => ""),
 					"locked" => array("type" => "tinyint(1)", "not null" => "1", "default" => "0"),
+					"created" => array("type" => "datetime", "default" => "0000-00-00 00:00:00"),
 					),
 			"indexes" => array(
 					"PRIMARY" => array("id"),

--- a/include/lock.php
+++ b/include/lock.php
@@ -11,20 +11,22 @@ function lock_function($fn_name, $block = true, $wait_sec = 2, $timeout = 30) {
 	$start = time();
 
 	do {
-		q("LOCK TABLE locks WRITE");
-		$r = q("SELECT locked FROM locks WHERE name = '%s' LIMIT 1",
+		q("LOCK TABLE `locks` WRITE");
+		$r = q("SELECT `locked`, `created` FROM `locks` WHERE `name` = '%s' LIMIT 1",
 			dbesc($fn_name)
 		);
 
-		if((count($r)) && (! $r[0]['locked'])) {
-			q("UPDATE locks SET locked = 1 WHERE name = '%s'",
+		if((count($r)) AND (!$r[0]['locked'] OR (strtotime($r[0]['created']) < time() - 3600))) {
+			q("UPDATE `locks` SET `locked` = 1, `created` = '%s' WHERE `name` = '%s'",
+				dbesc(datetime_convert()),
 				dbesc($fn_name)
 			);
 			$got_lock = true;
 		}
 		elseif(! $r) { // the Boolean value for count($r) should be equivalent to the Boolean value of $r
-			q("INSERT INTO locks ( name, locked ) VALUES ( '%s', 1 )",
-				dbesc($fn_name)
+			q("INSERT INTO `locks` (`name`, `created`, `locked`) VALUES ('%s', '%s', 1)",
+				dbesc($fn_name),
+				dbesc(datetime_convert())
 			);
 			$got_lock = true;
 		}
@@ -37,7 +39,7 @@ function lock_function($fn_name, $block = true, $wait_sec = 2, $timeout = 30) {
 	} while(($block) && (! $got_lock) && ((time() - $start) < $timeout));
 
 	logger('lock_function: function ' . $fn_name . ' with blocking = ' . $block . ' got_lock = ' . $got_lock . ' time = ' . (time() - $start), LOGGER_DEBUG);
-	
+
 	return $got_lock;
 }}
 
@@ -65,7 +67,7 @@ function block_on_function_lock($fn_name, $wait_sec = 2, $timeout = 30) {
 
 if(! function_exists('unlock_function')) {
 function unlock_function($fn_name) {
-	$r = q("UPDATE locks SET locked = 0 WHERE name = '%s'",
+	$r = q("UPDATE `locks` SET `locked` = 0, `created` = '0000-00-00 00:00:00' WHERE `name` = '%s'",
 			dbesc($fn_name)
 	     );
 

--- a/library/HTML5/Parser.php
+++ b/library/HTML5/Parser.php
@@ -20,7 +20,12 @@ class HTML5_Parser
 
 	// Cleanup invalid HTML
 	$doc = new DOMDocument();
-	@$doc->loadHTML($text);
+
+	if (mb_detect_encoding($text, "UTF-8", true) == "UTF-8")
+		@$doc->loadHTML('<?xml encoding="UTF-8" ?>'.$text);
+	else
+		@$doc->loadHTML($text);
+
 	$text = $doc->saveHTML();
 
         $tokenizer = new HTML5_Tokenizer($text, $builder);

--- a/update.php
+++ b/update.php
@@ -1,6 +1,6 @@
 <?php
 
-define( 'UPDATE_VERSION' , 1175 );
+define( 'UPDATE_VERSION' , 1176 );
 
 /**
  *


### PR DESCRIPTION
The fix for the bug that "scrape" took endlessly time had a side effect. The "loadHTML" function assumes that the text always is ISO-8859-1. Now the systems tries to detect if the text is UTF-8 (which it mostly will be) and then handles it that way.

While working at that issue I recognized a flaw at the lock function. It doesn't detect if a process was killed during the lock process. Now old locks will be removed when they are older than one hour.