### PR TITLE
"location" and "about" for contacts, improved suggestions, improved contacts exchange

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -1649,8 +1649,10 @@ if(! function_exists('profile_sidebar')) {
 
 		$homepage = ((x($profile,'homepage') == 1) ?  t('Homepage:') : False);
 
+		$about = ((x($profile,'about') == 1) ?  t('About:') : False);
+
 		if(($profile['hidewall'] || $block) && (! local_user()) && (! remote_user())) {
-			$location = $pdesc = $gender = $marital = $homepage = False;
+			$location = $pdesc = $gender = $marital = $homepage = $about = False;
 		}
 
 		$firstname = ((strpos($profile['name'],' '))
@@ -1695,6 +1697,7 @@ if(! function_exists('profile_sidebar')) {
 			'$pdesc'	=> $pdesc,
 			'$marital'  => $marital,
 			'$homepage' => $homepage,
+			'$about' => $about,
 			'$network' =>  t('Network:'),
 			'$diaspora' => $diaspora,
 			'$contact_block' => $contact_block,

--- a/boot.php
+++ b/boot.php
@@ -18,7 +18,7 @@ define ( 'FRIENDICA_PLATFORM',     'Friendica');
 define ( 'FRIENDICA_CODENAME',     'Ginger');
 define ( 'FRIENDICA_VERSION',      '3.3.2' );
 define ( 'DFRN_PROTOCOL_VERSION',  '2.23'    );
-define ( 'DB_UPDATE_VERSION',      1175      );
+define ( 'DB_UPDATE_VERSION',      1177      );
 define ( 'EOL',                    "<br />\r\n"     );
 define ( 'ATOM_TIME',              'Y-m-d\TH:i:s\Z' );
 

--- a/include/Scrape.php
+++ b/include/Scrape.php
@@ -750,5 +750,14 @@ function probe_url($url, $mode = PROBE_NORMAL) {
 
 	logger('probe_url: ' . print_r($result,true), LOGGER_DEBUG);
 
+	// Trying if it maybe a diaspora account
+	if ($result['network'] == NETWORK_FEED) {
+		require_once('include/bbcode.php');
+		$address = GetProfileUsername($url, "", true);
+		$result2 = probe_url($address, $mode);
+		if ($result2['network'] != "")
+			$result = $result2;
+	}
+
 	return $result;
 }

--- a/include/dbstructure.php
+++ b/include/dbstructure.php
@@ -616,6 +616,7 @@ function db_definition() {
 					"nurl" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
 					"photo" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
 					"connect" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
+					"updated" => array("type" => "datetime", "default" => "0000-00-00 00:00:00"),
 					),
 			"indexes" => array(
 					"PRIMARY" => array("id"),

--- a/include/dbstructure.php
+++ b/include/dbstructure.php
@@ -1251,6 +1251,8 @@ function db_definition() {
 					"nick" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
 					"name" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
 					"avatar" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
+					"location" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
+					"about" => array("type" => "text", "not null" => "1"),
 					),
 			"indexes" => array(
 					"PRIMARY" => array("id"),

--- a/include/dbstructure.php
+++ b/include/dbstructure.php
@@ -619,6 +619,7 @@ function db_definition() {
 					"photo" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
 					"connect" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
 					"updated" => array("type" => "datetime", "default" => "0000-00-00 00:00:00"),
+					"network" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
 					),
 			"indexes" => array(
 					"PRIMARY" => array("id"),

--- a/include/dbstructure.php
+++ b/include/dbstructure.php
@@ -413,6 +413,8 @@ function db_definition() {
 					"network" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
 					"name" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
 					"nick" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
+					"location" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
+					"about" => array("type" => "text", "not null" => "1"),
 					"attag" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
 					"photo" => array("type" => "text", "not null" => "1"),
 					"thumb" => array("type" => "text", "not null" => "1"),

--- a/include/diaspora.php
+++ b/include/diaspora.php
@@ -2161,7 +2161,7 @@ function diaspora_profile($importer,$xml,$msg) {
 	$name = unxmlify($xml->first_name) . ((strlen($xml->last_name)) ? ' ' . unxmlify($xml->last_name) : '');
 	$image_url = unxmlify($xml->image_url);
 	$birthday = unxmlify($xml->birthday);
-	$location = unxmlify($xml->location);
+	$location = diaspora2bb(unxmlify($xml->location));
 	$about = diaspora2bb(unxmlify($xml->bio));
 
 

--- a/include/diaspora.php
+++ b/include/diaspora.php
@@ -2028,7 +2028,7 @@ function diaspora_retraction($importer,$xml) {
 					dbesc(datetime_convert()),
 					intval($r[0]['id'])
 				);
-				delete_thread($r[0]['id']);
+				delete_thread($r[0]['id'], $r[0]['parent-uri']);
 			}
 		}
 	}
@@ -2101,7 +2101,7 @@ function diaspora_signed_retraction($importer,$xml,$msg) {
 					dbesc(datetime_convert()),
 					intval($r[0]['id'])
 				);
-				delete_thread($r[0]['id']);
+				delete_thread($r[0]['id'], $r[0]['parent-uri']);
 
 				// Now check if the retraction needs to be relayed by us
 				//
@@ -2161,14 +2161,15 @@ function diaspora_profile($importer,$xml,$msg) {
 	$name = unxmlify($xml->first_name) . ((strlen($xml->last_name)) ? ' ' . unxmlify($xml->last_name) : '');
 	$image_url = unxmlify($xml->image_url);
 	$birthday = unxmlify($xml->birthday);
+	$location = unxmlify($xml->location);
+	$about = diaspora2bb(unxmlify($xml->bio));
 
 
 	$handle_parts = explode("@", $diaspora_handle);
 	if($name === '') {
 		$name = $handle_parts[0];
 	}
-	
-	 
+
 	if( preg_match("|^https?://|", $image_url) === 0) {
 		$image_url = "http://" . $handle_parts[1] . $image_url;
 	}
@@ -2182,8 +2183,8 @@ function diaspora_profile($importer,$xml,$msg) {
 	require_once('include/Photo.php');
 
 	$images = import_profile_photo($image_url,$importer['uid'],$contact['id']);
-	
-	// Generic birthday. We don't know the timezone. The year is irrelevant. 
+
+	// Generic birthday. We don't know the timezone. The year is irrelevant.
 
 	$birthday = str_replace('1000','1901',$birthday);
 
@@ -2196,9 +2197,9 @@ function diaspora_profile($importer,$xml,$msg) {
 		$birthday = $contact['bd'];
 
 	// TODO: update name on item['author-name'] if the name changed. See consume_feed()
-	// Not doing this currently because D* protocol is scheduled for revision soon. 
+	// Not doing this currently because D* protocol is scheduled for revision soon.
 
-	$r = q("UPDATE `contact` SET `name` = '%s', `name-date` = '%s', `photo` = '%s', `thumb` = '%s', `micro` = '%s', `avatar-date` = '%s' , `bd` = '%s' WHERE `id` = %d AND `uid` = %d",
+	$r = q("UPDATE `contact` SET `name` = '%s', `name-date` = '%s', `photo` = '%s', `thumb` = '%s', `micro` = '%s', `avatar-date` = '%s' , `bd` = '%s', `location` = '%s', `about` = '%s' WHERE `id` = %d AND `uid` = %d",
 		dbesc($name),
 		dbesc(datetime_convert()),
 		dbesc($images[0]),
@@ -2206,9 +2207,11 @@ function diaspora_profile($importer,$xml,$msg) {
 		dbesc($images[2]),
 		dbesc(datetime_convert()),
 		dbesc($birthday),
+		dbesc($location),
+		dbesc($about),
 		intval($contact['id']),
 		intval($importer['uid'])
-	); 
+	);
 
 /*	if($r) {
 		if($oldphotos) {

--- a/include/diaspora.php
+++ b/include/diaspora.php
@@ -2213,6 +2213,21 @@ function diaspora_profile($importer,$xml,$msg) {
 		intval($importer['uid'])
 	);
 
+	$profileurl = "";
+	$author = q("SELECT * FROM `unique_contacts` WHERE `url`='%s' LIMIT 1",
+			dbesc(normalise_link($contact['url'])));
+
+	if (count($author) == 0) {
+		q("INSERT INTO `unique_contacts` (`url`, `name`, `avatar`, `location`, `about`) VALUES ('%s', '%s', '%s', '%s', '%s')",
+			dbesc(normalise_link($contact['url'])), dbesc($name), dbesc($location), dbesc($about), dbesc($images[0]));
+
+		$author = q("SELECT id FROM unique_contacts WHERE url='%s' LIMIT 1",
+			dbesc(normalise_link($contact['url'])));
+	} else if (normalise_link($contact['url']).$name.$location.$about != normalise_link($author[0]["url"]).$author[0]["name"].$author[0]["location"].$author[0]["about"]) {
+		q("UPDATE unique_contacts SET name = '%s', avatar = '%s', `location` = '%s', `about` = '%s' WHERE url = '%s'",
+		dbesc($name), dbesc($images[0]), dbesc($location), dbesc($about), dbesc(normalise_link($contact['url'])));
+	}
+
 /*	if($r) {
 		if($oldphotos) {
 			foreach($oldphotos as $ph) {

--- a/include/items.php
+++ b/include/items.php
@@ -11,6 +11,7 @@ require_once('include/text.php');
 require_once('include/email.php');
 require_once('include/ostatus_conversation.php');
 require_once('include/threads.php');
+require_once('include/socgraph.php');
 
 function get_feed_for(&$a, $dfrn_id, $owner_nick, $last_update, $direction = 0) {
 
@@ -1342,6 +1343,12 @@ function item_store($arr,$force_parent = false, $notify = false, $dontcache = fa
 	if(count($r)) {
 		$current_post = $r[0]['id'];
 		logger('item_store: created item ' . $current_post);
+
+		// Add every contact to the global contact table
+		// Contacts from the statusnet connector are also added since you could add them in OStatus as well.
+		if (!$arr['private'] AND in_array($arr["network"],
+			array(NETWORK_DFRN, NETWORK_DIASPORA, NETWORK_OSTATUS, NETWORK_STATUSNET, "")))
+			poco_check($arr["author-link"], $arr["author-name"], $arr["author-avatar"], "", $arr["received"]);
 
 		// Set "success_update" to the date of the last time we heard from this contact
 		// This can be used to filter for inactive contacts and poco.

--- a/include/items.php
+++ b/include/items.php
@@ -1348,7 +1348,7 @@ function item_store($arr,$force_parent = false, $notify = false, $dontcache = fa
 		// Contacts from the statusnet connector are also added since you could add them in OStatus as well.
 		if (!$arr['private'] AND in_array($arr["network"],
 			array(NETWORK_DFRN, NETWORK_DIASPORA, NETWORK_OSTATUS, NETWORK_STATUSNET, "")))
-			poco_check($arr["author-link"], $arr["author-name"], $arr["author-avatar"], "", $arr["received"]);
+			poco_check($arr["author-link"], $arr["author-name"], $arr["author-avatar"], "", $arr["received"], $arr['contact-id'], $arr['uid']);
 
 		// Set "success_update" to the date of the last time we heard from this contact
 		// This can be used to filter for inactive contacts and poco.

--- a/include/items.php
+++ b/include/items.php
@@ -1343,6 +1343,16 @@ function item_store($arr,$force_parent = false, $notify = false, $dontcache = fa
 		$current_post = $r[0]['id'];
 		logger('item_store: created item ' . $current_post);
 
+		// Set "success_update" to the date of the last time we heard from this contact
+		// This can be used to filter for inactive contacts and poco.
+		// Only do this for public postings to avoid privacy problems, since poco data is public.
+		// Don't set this value if it isn't from the owner (could be an author that we don't know)
+		if (!$arr['private'] AND (($arr["author-link"] === $arr["owner-link"]) OR ($arr["parent-uri"] === $arr["uri"])))
+			$r = q("UPDATE `contact` SET `success_update` = '%s' WHERE `id` = %d",
+				dbesc($arr['received']),
+				intval($arr['contact-id'])
+			);
+
 		// Only check for notifications on start posts
 		if ($arr['parent-uri'] === $arr['uri']) {
 			add_thread($r[0]['id']);

--- a/include/items.php
+++ b/include/items.php
@@ -4509,7 +4509,7 @@ function drop_item($id,$interactive = true) {
 		);
 		create_tags_from_item($item['id']);
 		create_files_from_item($item['id']);
-		delete_thread($item['id']);
+		delete_thread($item['id'], $item['parent-uri']);
 
 		// clean up categories and tags so they don't end up as orphans
 

--- a/include/items.php
+++ b/include/items.php
@@ -1348,7 +1348,7 @@ function item_store($arr,$force_parent = false, $notify = false, $dontcache = fa
 		// Contacts from the statusnet connector are also added since you could add them in OStatus as well.
 		if (!$arr['private'] AND in_array($arr["network"],
 			array(NETWORK_DFRN, NETWORK_DIASPORA, NETWORK_OSTATUS, NETWORK_STATUSNET, "")))
-			poco_check($arr["author-link"], $arr["author-name"], $arr["author-avatar"], "", $arr["received"], $arr['contact-id'], $arr['uid']);
+			poco_check($arr["author-link"], $arr["author-name"], $arr["network"], $arr["author-avatar"], "", $arr["received"], $arr['contact-id'], $arr['uid']);
 
 		// Set "success_update" to the date of the last time we heard from this contact
 		// This can be used to filter for inactive contacts and poco.

--- a/include/items.php
+++ b/include/items.php
@@ -1348,7 +1348,7 @@ function item_store($arr,$force_parent = false, $notify = false, $dontcache = fa
 		// Only do this for public postings to avoid privacy problems, since poco data is public.
 		// Don't set this value if it isn't from the owner (could be an author that we don't know)
 		if (!$arr['private'] AND (($arr["author-link"] === $arr["owner-link"]) OR ($arr["parent-uri"] === $arr["uri"])))
-			$r = q("UPDATE `contact` SET `success_update` = '%s' WHERE `id` = %d",
+			q("UPDATE `contact` SET `success_update` = '%s' WHERE `id` = %d",
 				dbesc($arr['received']),
 				intval($arr['contact-id'])
 			);

--- a/include/socgraph.php
+++ b/include/socgraph.php
@@ -316,7 +316,7 @@ function suggestion_query($uid, $start = 0, $limit = 80) {
 	if(! $uid)
 		return array();
 
-	$network = array("", NETWORK_DFRN);
+	$network = array(NETWORK_DFRN);
 
 	if (get_config('system','diaspora_enabled'))
 		$network[] = NETWORK_DIASPORA;
@@ -325,7 +325,8 @@ function suggestion_query($uid, $start = 0, $limit = 80) {
 		$network[] = NETWORK_OSTATUS;
 
 	$sql_network = implode("', '", $network);
-	$sql_network = substr($sql_network, 2)."', ''";
+	//$sql_network = "'".$sql_network."', ''";
+	$sql_network = "'".$sql_network."'";
 
 	$r = q("SELECT count(glink.gcid) as `total`, gcontact.* from gcontact
 		INNER JOIN glink on glink.gcid = gcontact.id

--- a/include/threads.php
+++ b/include/threads.php
@@ -149,28 +149,26 @@ function delete_thread_uri($itemuri, $uid) {
 
 	if(count($messages))
 		foreach ($messages as $message)
-			delete_thread($message["id"]);
+			delete_thread($message["id"], $itemuri);
 }
 
-function delete_thread($itemid) {
-	// To-Do:
-	// There is no "uri" in the thread table ...
-	$item = q("SELECT `uri`, `uid` FROM `thread` WHERE `iid` = %d", intval($itemid));
+function delete_thread($itemid, $itemuri = "") {
+	$item = q("SELECT `uid` FROM `thread` WHERE `iid` = %d", intval($itemid));
 
 	$result = q("DELETE FROM `thread` WHERE `iid` = %d", intval($itemid));
 
 	logger("delete_thread: Deleted thread for item ".$itemid." - ".print_r($result, true), LOGGER_DEBUG);
 
-	if (count($item)) {
+	if ($itemuri != "") {
 		$r = q("SELECT `id` FROM `item` WHERE `uri` = '%s' AND NOT (`uid` IN (%d, 0))",
-				dbesc($item["uri"]),
+				dbesc($itemuri),
 				intval($item["uid"])
 			);
 		if (!count($r)) {
 			$r = q("DELETE FROM `item` WHERE `uri` = '%s' AND `uid` = 0)",
-				dbesc($item["uri"])
+				dbesc($itemuri)
 			);
-			logger("delete_thread: Deleted shadow for item ".$item["uri"]." - ".print_r($result, true), LOGGER_DEBUG);
+			logger("delete_thread: Deleted shadow for item ".$itemuri." - ".print_r($result, true), LOGGER_DEBUG);
 		}
 	}
 }

--- a/include/threads.php
+++ b/include/threads.php
@@ -153,6 +153,8 @@ function delete_thread_uri($itemuri, $uid) {
 }
 
 function delete_thread($itemid) {
+	// To-Do:
+	// There is no "uri" in the thread table ...
 	$item = q("SELECT `uri`, `uid` FROM `thread` WHERE `iid` = %d", intval($itemid));
 
 	$result = q("DELETE FROM `thread` WHERE `iid` = %d", intval($itemid));

--- a/mod/display.php
+++ b/mod/display.php
@@ -98,14 +98,19 @@ function display_fetchauthor($a, $item) {
 		$profiledata["about"] = bbcode($r[0]["about"]);
 		if ($r[0]["nick"] != "")
 			$profiledata["nickname"] = $r[0]["nick"];
-	} else {
-		// Fetching profile data from unique contacts
-		$r = q("SELECT `avatar`, `nick` FROM `unique_contacts` WHERE `url` = '%s'", normalise_link($profiledata["url"]));
-		if (count($r)) {
+	}
+
+	// Fetching profile data from unique contacts
+	$r = q("SELECT `avatar`, `nick`, `location`, `about` FROM `unique_contacts` WHERE `url` = '%s'", normalise_link($profiledata["url"]));
+	if (count($r)) {
+		if ($profiledata["photo"] == "")
 			$profiledata["photo"] = proxy_url($r[0]["avatar"]);
-			if ($r[0]["nick"] != "")
-				$profiledata["nickname"] = $r[0]["nick"];
-		}
+		if ($profiledata["address"] == "")
+			$profiledata["address"] = bbcode($r[0]["location"]);
+		if ($profiledata["about"] == "")
+			$profiledata["about"] = bbcode($r[0]["about"]);
+		if (($profiledata["nickname"] == "") AND ($r[0]["nick"] != ""))
+			$profiledata["nickname"] = $r[0]["nick"];
 	}
 
 	// Check for a repeated message
@@ -158,6 +163,21 @@ function display_fetchauthor($a, $item) {
 
 		$profiledata["nickname"] = $profiledata["name"];
 		$profiledata["network"] = GetProfileUsername($profiledata["url"], "", false, true);
+
+		$profiledata["address"] = "";
+		$profiledata["about"] = "";
+
+		// Fetching profile data from unique contacts
+		if ($profiledata["url"] != "") {
+			$r = q("SELECT `avatar`, `nick`, `location`, `about` FROM `unique_contacts` WHERE `url` = '%s'", normalise_link($profiledata["url"]));
+			if (count($r)) {
+				$profiledata["photo"] = proxy_url($r[0]["avatar"]);
+				$profiledata["address"] = bbcode($r[0]["location"]);
+				$profiledata["about"] = bbcode($r[0]["about"]);
+				if ($r[0]["nick"] != "")
+					$profiledata["nickname"] = $r[0]["nick"];
+			}
+		}
 	}
 
 	if (local_user()) {

--- a/mod/display.php
+++ b/mod/display.php
@@ -88,7 +88,6 @@ function display_fetchauthor($a, $item) {
 	$profiledata["photo"] = proxy_url($item["author-avatar"]);
 	$profiledata["url"] = $item["author-link"];
 	$profiledata["network"] = $item["network"];
-	$profiledata["address"] = "Ort".print_r($item, true);
 
 	// Fetching further contact data from the contact table
 	$r = q("SELECT `photo`, `nick`, `location`, `about` FROM `contact` WHERE `nurl` = '%s' AND `uid` = %d",
@@ -96,7 +95,7 @@ function display_fetchauthor($a, $item) {
 	if (count($r)) {
 		$profiledata["photo"] = proxy_url($r[0]["photo"]);
 		$profiledata["address"] = $r[0]["location"];
-		$profiledata["about"] = $r[0]["about"];
+		$profiledata["about"] = bbcode($r[0]["about"]);
 		if ($r[0]["nick"] != "")
 			$profiledata["nickname"] = $r[0]["nick"];
 	} else {

--- a/mod/display.php
+++ b/mod/display.php
@@ -94,7 +94,7 @@ function display_fetchauthor($a, $item) {
 		normalise_link($profiledata["url"]), $item["uid"]);
 	if (count($r)) {
 		$profiledata["photo"] = proxy_url($r[0]["photo"]);
-		$profiledata["address"] = $r[0]["location"];
+		$profiledata["address"] = bbcode($r[0]["location"]);
 		$profiledata["about"] = bbcode($r[0]["about"]);
 		if ($r[0]["nick"] != "")
 			$profiledata["nickname"] = $r[0]["nick"];

--- a/mod/parse_url.php
+++ b/mod/parse_url.php
@@ -93,6 +93,15 @@ function parseurl_getsiteinfo($url, $no_guessing = false, $do_oembed = true, $co
 		return($siteinfo);
 	}
 
+	if ($do_oembed) {
+		require_once("include/oembed.php");
+
+		$oembed_data = oembed_fetch_url($url);
+
+		if ($oembed_data->type != "error")
+			$siteinfo["type"] = $oembed_data->type;
+	}
+
 	// if the file is too large then exit
 	if ($curl_info["download_content_length"] > 1000000)
 		return($siteinfo);
@@ -114,15 +123,6 @@ function parseurl_getsiteinfo($url, $no_guessing = false, $do_oembed = true, $co
 	$curl_info = @curl_getinfo($ch);
         $http_code = $curl_info['http_code'];
 	curl_close($ch);
-
-	if ($do_oembed) {
-		require_once("include/oembed.php");
-
-		$oembed_data = oembed_fetch_url($url);
-
-		if ($oembed_data->type != "error")
-			$siteinfo["type"] = $oembed_data->type;
-	}
 
 	// Fetch the first mentioned charset. Can be in body or header
 	$charset = "";

--- a/mod/poco.php
+++ b/mod/poco.php
@@ -30,7 +30,7 @@ function poco_init(&$a) {
 		$justme = true;
 	if($a->argc > 4 && intval($a->argv[4]) && $justme == false)
 		$cid = intval($a->argv[4]);
- 		
+ 
 
 	if(! $system_mode) {
 		$r = q("SELECT `user`.*,`profile`.`hide-friends` from user left join profile on `user`.`uid` = `profile`.`uid`
@@ -106,6 +106,7 @@ function poco_init(&$a) {
 		'id' => false,
 		'displayName' => false,
 		'urls' => false,
+		'updated' => false,
 		'preferredUsername' => false,
 		'photos' => false
 	);
@@ -130,10 +131,24 @@ function poco_init(&$a) {
 				if($fields_ret['urls']) {
 					$entry['urls'] = array(array('value' => $rr['url'], 'type' => 'profile'));
 					if($rr['addr'] && ($rr['network'] !== NETWORK_MAIL))
-						$entry['urls'][] = array('value' => 'acct:' . $rr['addr'], 'type' => 'webfinger');  
+						$entry['urls'][] = array('value' => 'acct:' . $rr['addr'], 'type' => 'webfinger');
 				}
 				if($fields_ret['preferredUsername'])
 					$entry['preferredUsername'] = $rr['nick'];
+				if($fields_ret['updated']) {
+					$entry['updated'] = $rr['success_update'];
+
+					if ($rr['name-date'] > $entry['updated'])
+						$entry['updated'] = $rr['name-date'];
+
+					if ($rr['uri-date'] > $entry['updated'])
+						$entry['updated'] = $rr['uri-date'];
+
+					if ($rr['avatar-date'] > $entry['updated'])
+						$entry['updated'] = $rr['avatar-date'];
+
+					$entry['updated'] = date("c", strtotime($entry['updated']));
+				}
 				if($fields_ret['photos'])
 					$entry['photos'] = array(array('value' => $rr['photo'], 'type' => 'profile'));
 				$ret['entry'][] = $entry;
@@ -153,7 +168,7 @@ function poco_init(&$a) {
 	if($format === 'json') {
 		header('Content-type: application/json');
 		echo json_encode($ret);
-		killme();	
+		killme();
 	}
 	else
 		http_status_exit(500);

--- a/mod/poco.php
+++ b/mod/poco.php
@@ -52,20 +52,22 @@ function poco_init(&$a) {
 		$sql_extra = sprintf(" AND `contact`.`id` = %d ",intval($cid));
 
 	if($system_mode) {
-		$r = q("SELECT count(*) AS `total` FROM `contact` WHERE `self` = 1 AND `network` IN ('%s', '%s', '%s', '')
+		$r = q("SELECT count(*) AS `total` FROM `contact` WHERE `self` = 1 AND `network` IN ('%s', '%s', '%s', '%s', '')
 			AND `uid` IN (SELECT `uid` FROM `pconfig` WHERE `cat` = 'system' AND `k` = 'suggestme' AND `v` = 1) ",
 			dbesc(NETWORK_DFRN),
 			dbesc(NETWORK_DIASPORA),
-			dbesc(NETWORK_OSTATUS)
+			dbesc(NETWORK_OSTATUS),
+			dbesc(NETWORK_STATUSNET)
 			);
 	}
 	else {
 		$r = q("SELECT count(*) AS `total` FROM `contact` WHERE `uid` = %d AND `blocked` = 0 AND `pending` = 0 AND `hidden` = 0 AND `archive` = 0
-			AND `network` IN ('%s', '%s', '%s', '') $sql_extra",
+			AND `network` IN ('%s', '%s', '%s', '%s', '') $sql_extra",
 			intval($user['uid']),
 			dbesc(NETWORK_DFRN),
 			dbesc(NETWORK_DIASPORA),
-			dbesc(NETWORK_OSTATUS)
+			dbesc(NETWORK_OSTATUS),
+			dbesc(NETWORK_STATUSNET)
 		);
 	}
 	if(count($r))
@@ -80,22 +82,24 @@ function poco_init(&$a) {
 
 
 	if($system_mode) {
-		$r = q("SELECT * FROM `contact` WHERE `self` = 1 AND `network` IN ('%s', '%s', '%s', '')
+		$r = q("SELECT * FROM `contact` WHERE `self` = 1 AND `network` IN ('%s', '%s', '%s', '%s', '')
 			AND `uid` IN (SELECT `uid` FROM `pconfig` WHERE `cat` = 'system' AND `k` = 'suggestme' AND `v` = 1) LIMIT %d, %d",
 			dbesc(NETWORK_DFRN),
 			dbesc(NETWORK_DIASPORA),
 			dbesc(NETWORK_OSTATUS),
+			dbesc(NETWORK_STATUSNET),
 			intval($startIndex),
 			intval($itemsPerPage)
 		);
 	}
 	else {
 		$r = q("SELECT * FROM `contact` WHERE `uid` = %d AND `blocked` = 0 AND `pending` = 0 AND `hidden` = 0 AND `archive` = 0
-			AND `network` IN ('%s', '%s', '%s', '') $sql_extra LIMIT %d, %d",
+			AND `network` IN ('%s', '%s', '%s', '%s', '') $sql_extra LIMIT %d, %d",
 			intval($user['uid']),
 			dbesc(NETWORK_DFRN),
 			dbesc(NETWORK_DIASPORA),
 			dbesc(NETWORK_OSTATUS),
+			dbesc(NETWORK_STATUSNET),
 			intval($startIndex),
 			intval($itemsPerPage)
 		);
@@ -120,7 +124,8 @@ function poco_init(&$a) {
 		'urls' => false,
 		'updated' => false,
 		'preferredUsername' => false,
-		'photos' => false
+		'photos' => false,
+		'network' => false
 	);
 
 	if((! x($_GET,'fields')) || ($_GET['fields'] === '@all'))
@@ -163,6 +168,11 @@ function poco_init(&$a) {
 				}
 				if($fields_ret['photos'])
 					$entry['photos'] = array(array('value' => $rr['photo'], 'type' => 'profile'));
+				if($fields_ret['network']) {
+					$entry['network'] = $rr['network'];
+					if ($entry['network'] == NETWORK_STATUSNET)
+						$entry['network'] = NETWORK_OSTATUS;
+				}
 				$ret['entry'][] = $entry;
 			}
 		}

--- a/mod/suggest.php
+++ b/mod/suggest.php
@@ -44,12 +44,14 @@ function suggest_init(&$a) {
 	}
 
 }
-		
+
 
 
 
 
 function suggest_content(&$a) {
+
+	require_once("mod/proxy.php");
 
 	$o = '';
 	if(! local_user()) {
@@ -82,7 +84,7 @@ function suggest_content(&$a) {
 		$o .= replace_macros($tpl,array(
 			'$url' => zrl($rr['url']),
 			'$name' => $rr['name'],
-			'$photo' => $rr['photo'],
+			'$photo' => proxy_url($rr['photo']),
 			'$ignlnk' => $a->get_baseurl() . '/suggest?ignore=' . $rr['id'],
 			'$ignid' => $rr['id'],
 			'$conntxt' => t('Connect'),

--- a/update.php
+++ b/update.php
@@ -1,6 +1,6 @@
 <?php
 
-define( 'UPDATE_VERSION' , 1175 );
+define( 'UPDATE_VERSION' , 1177 );
 
 /**
  *

--- a/view/templates/profile_vcard.tpl
+++ b/view/templates/profile_vcard.tpl
@@ -35,6 +35,8 @@
 
 	{{if $homepage}}<dl class="homepage"><dt class="homepage-label">{{$homepage}}</dt><dd class="homepage-url u-url"><a href="{{$profile.homepage}}" rel="me" target="_blank">{{$profile.homepage}}</a></dd></dl>{{/if}}
 
+	{{if $about}}<dl class="about"><dt class="about-label">{{$about}}</dt><dd class="x-network">{{$profile.about}}</dd></dl>{{/if}}
+
 	{{include file="diaspora_vcard.tpl"}}
 	
 	<div id="profile-extra-links">

--- a/view/theme/vier/templates/profile_vcard.tpl
+++ b/view/theme/vier/templates/profile_vcard.tpl
@@ -55,6 +55,8 @@
 
 	{{if $homepage}}<dl class="homepage"><dt class="homepage-label">{{$homepage}}</dt><dd class="homepage-url"><a href="{{$profile.homepage}}" class="u-url" rel="me" target="_blank">{{$profile.homepage}}</a></dd></dl>{{/if}}
 
+	{{if $about}}<dl class="about"><dt class="about-label">{{$about}}</dt><dd class="x-network">{{$profile.about}}</dd></dl>{{/if}}
+
 	{{include file="diaspora_vcard.tpl"}}
 	
 	<div id="profile-extra-links">


### PR DESCRIPTION
The method to exchange contacts via "poco" is improved. The servers now also exchange the date when the contact was last active (last public message or last date, the contact was changed) and the network.

The suggestions that are based upon this data are using this date to show only active users. Additionally only contacts are shown that can be added. In the past every contact was suggested (facebook, twitter, ...). Now the system filters if OStatus is active or Diaspora is active. If not, then contacts from these networks aren't shown.

In the contacts there are two new fields: "about" and "location". This data is shown if a message is displayed. It is filled in the connectors (a pull request for that will follow) and in the diaspora section. It is yet not exchanged via DFRN ans OStatus. I will cover that in a future pull request.