### PR TITLE
polishing the installer

### DIFF
--- a/doc/Home.md
+++ b/doc/Home.md
@@ -40,6 +40,7 @@ Friendica Documentation and Resources
 * [Help on Vagrant](help/Vagrant)
 * [How to translate Friendica](help/translations)
 * [Bugs and Issues](help/Bugs-and-Issues)
+* [Smarty 3 Templates](help/smarty3-templates)
 
 **External Resources**
 

--- a/doc/snarty3-templates.md
+++ b/doc/snarty3-templates.md
@@ -19,7 +19,7 @@ Templates that are only used by addons shall be placed in the
 
 directory.
 
-To render a template use the function *get_markup_template* to load the template and *replace_macros* to replace the markros/variables in the just loaded template file.
+To render a template use the function *get_markup_template* to load the template and *replace_macros* to replace the macros/variables in the just loaded template file.
 
 		$tpl = get_markup_template('install_settings.tpl');
         $o .= replace_macros($tpl, array( ... ));
@@ -105,7 +105,7 @@ An input box (see above) but prepared for special CSS styling for openID input. 
 
 ### field_password.tpl
 
-A single line input field (see above) for texttual input. The characters typed in will not be shown by the browser. Field parameter:
+A single line input field (see above) for textual input. The characters typed in will not be shown by the browser. Field parameter:
 
 0. Name of the field,
 1. Label for the field,

--- a/doc/snarty3-templates.md
+++ b/doc/snarty3-templates.md
@@ -1,0 +1,173 @@
+Friendica Templating Documentation
+==================================
+
+* [Home](help)
+
+Friendica uses [Smarty 3](http://www.smarty.net/) as PHP templating engine. The main templates are found in
+
+		/view/templates
+
+theme authors may overwrite the default templates by putting a files with the same name into the
+
+		/view/themes/$themename/templates
+
+directory.
+
+Templates that are only used by addons shall be placed in the
+
+		/addon/$addonname/templates
+
+directory.
+
+To render a template use the function *get_markup_template* to load the template and *replace_macros* to replace the markros/variables in the just loaded template file.
+
+		$tpl = get_markup_template('install_settings.tpl');
+        $o .= replace_macros($tpl, array( ... ));
+
+the array consists of an association of an identifier and the value for that identifier, i.e.
+
+		'$title' => $install_title,
+
+where the value may as well be an array by its own.
+
+Form Templates
+--------------
+
+To guarantee a consistent look and feel for input forms, i.e. in the settings sections, there are templates for the basic form fields. They are initialized with an array of data, depending on the tyle of the field.
+
+All of these take an array for holding the values, i.e. for an one line text input field, which is required and should be used to type email addesses use something along
+
+		'$adminmail' => array('adminmail', t('Site administrator email address'), $adminmail, t('Your account email address must match this in order to use the web admin panel.'), 'required', '', 'email'),
+
+To evaluate the input value, you can then use the $_POST array, more precisely the $_POST['adminemail'] variable.
+
+Listed below are the template file names, the general purpose of the template and their field parameters.
+
+### field_checkbox.tpl
+
+A checkbox. If the checkbox is checked its value is **1**. Field parameter:
+
+0. Name of the checkbox,
+1. Label for the checkbox,
+2. State checked? if true then the checkbox will be marked as checked,
+3. Help text for the checkbox.
+
+### field_combobox.tpl
+
+A combobox, combining a pull down selection and a textual input field. Field parameter:
+
+0. Name of the combobox,
+1. Label for the combobox,
+2. Current value of the variable,
+3. Help text for the combobox,
+4. Array holding the possible values for the textual input,
+5. Array holding the possible values for the pull down selection.
+
+### field_custom.tpl
+
+A customizeable template to include a custom element in the form with the usual surroundings, Field parameter:
+
+0. Name of the field,
+1. Label for the field,
+2. the field,
+3. Help text for the field.
+
+### field_input.tpl
+
+A single line input field for textual input. Field parameter:
+
+0. Name of the field,
+1. Label for the input box,
+2. Current value of the variable,
+3. Help text for the input box,
+4. if set to "required" modern browser will check that this input box is filled when submitting the form,
+5. if set to "autofocus" modern browser will put the cursur into this box once the page is loaded,
+6. if set to "email" or "url" modern browser will check that the filled in value corresponds to an email address or URL.
+
+### field_intcheckbox.tpl
+
+A checkbox (see above) but you can define the value of it. Field parameter:
+
+0. Name of the checkbox,
+1. Label for the checkbox,
+2. State checked? if true then the checkbox will be marked as checked,
+3. Value of the checkbox,
+4. Help text for the checkbox.
+
+### field_openid.tpl
+
+An input box (see above) but prepared for special CSS styling for openID input. Field parameter:
+
+0. Name of the field,
+1. Label for the input box,
+2. Current value of the variable,
+3. Help text for the input field.
+
+### field_password.tpl
+
+A single line input field (see above) for texttual input. The characters typed in will not be shown by the browser. Field parameter:
+
+0. Name of the field,
+1. Label for the field,
+2. Value for the field, e.g. the old password,
+3. Help text for the input field,
+4. if set to "required" modern browser will check that this field is filled out,
+5. if set to "autofocus" modern browser will put the cursor automatically into this input field.
+
+### field_radio.tpl
+
+A radio button. Field parameter:
+
+0. Name of the radio button,
+1. Label for the radio button,
+2. Current value of the variable,
+3. Help text for the button,
+4. if set, the radio button will be checked.
+
+### field_richtext.tpl
+
+A multi-line input field for *rich* textual content. Field parameter:
+
+0. Name of the input field,
+1. Label for the input box,
+2. Current text for the box,
+3. Help text for the input box.
+
+### field_select.tpl
+
+A drop down selection box. Field parameter:
+
+0. Name of the field,
+1. Label of the selection box,
+2. Current selected value,
+3. Help text for the selection box,
+4. Array holding the possible values of the selection drop down.
+
+### field_select_raw.tpl
+
+A drop down selection box (see above) but you have to prepare the values yourself. Field parameter:
+
+0. Name of the field,
+1. Label of the selection box,
+2. Current selected value,
+3. Help text for the selection box,
+4. Possible values of the selection drop down.
+
+### field_textarea.tpl
+
+A multi-line input field for (plain) textual content. Field parameter:
+
+0. Name of the input field,
+1. Label for the input box,
+2. Current text for the box,
+3. Help text for the input box.
+
+### field_yesno.tpl
+
+A button that has two states *yes* or *no*. Field parameter:
+
+0. Name of the input field,
+1. Label for the button,
+2. Current value,
+3. Help text for the button
+4. if set to an array of two values, these two will be used, otherwise "off" and "on".

--- a/mod/install.php
+++ b/mod/install.php
@@ -231,11 +231,11 @@ function install_content(&$a) {
 
 				'$status' => $wizard_status,
 
-				'$dbhost' => array('dbhost', t('Database Server Name'), $dbhost, ''),
-				'$dbuser' => array('dbuser', t('Database Login Name'), $dbuser, ''),
-				'$dbpass' => array('dbpass', t('Database Login Password'), $dbpass, ''),
-				'$dbdata' => array('dbdata', t('Database Name'), $dbdata, ''),
-				'$adminmail' => array('adminmail', t('Site administrator email address'), $adminmail, t('Your account email address must match this in order to use the web admin panel.')),
+				'$dbhost' => array('dbhost', t('Database Server Name'), $dbhost, '', 'required'),
+				'$dbuser' => array('dbuser', t('Database Login Name'), $dbuser, '', 'required', 'autofocus'),
+				'$dbpass' => array('dbpass', t('Database Login Password'), $dbpass, '', 'required'),
+				'$dbdata' => array('dbdata', t('Database Name'), $dbdata, '', 'required'),
+				'$adminmail' => array('adminmail', t('Site administrator email address'), $adminmail, t('Your account email address must match this in order to use the web admin panel.'), 'required', 'autofocus', 'email'),
 
 
 
@@ -274,7 +274,7 @@ function install_content(&$a) {
 				'$dbdata' => $dbdata,
 				'$phpath' => $phpath,
 
-				'$adminmail' => array('adminmail', t('Site administrator email address'), $adminmail, t('Your account email address must match this in order to use the web admin panel.')),
+				'$adminmail' => array('adminmail', t('Site administrator email address'), $adminmail, t('Your account email address must match this in order to use the web admin panel.'), 'required', 'autofocus', 'email'),
 
 
 				'$timezone' => field_timezone('timezone', t('Please select a default timezone for your website'), $timezone, ''),

--- a/view/templates/field_input.tpl
+++ b/view/templates/field_input.tpl
@@ -1,6 +1,6 @@
 	
 	<div class='field input' id='wrapper_{{$field.0}}'>
 		<label for='id_{{$field.0}}'>{{$field.1}}</label>
-		<input name='{{$field.0}}' id='id_{{$field.0}}' value="{{$field.2}}">
+		<input{{if $field.6 eq 'email'}} type='email'{{elseif $field.6 eq 'url'}} type='url'{{/if}} name='{{$field.0}}' id='id_{{$field.0}}' value="{{$field.2}}" {{if $field.4 eq 'required'}}required{{/if}} {{if $field.5 eq 'autofocus'}}autofocus{{/if}}>
 		<span class='field_help'>{{$field.3}}</span>
 	</div>

--- a/view/templates/field_input.tpl
+++ b/view/templates/field_input.tpl
@@ -1,6 +1,6 @@
 	
 	<div class='field input' id='wrapper_{{$field.0}}'>
 		<label for='id_{{$field.0}}'>{{$field.1}}</label>
-		<input{{if $field.6 eq 'email'}} type='email'{{elseif $field.6 eq 'url'}} type='url'{{/if}} name='{{$field.0}}' id='id_{{$field.0}}' value="{{$field.2}}" {{if $field.4 eq 'required'}}required{{/if}} {{if $field.5 eq 'autofocus'}}autofocus{{/if}}>
+		<input{{if $field.6 eq 'email'}} type='email'{{elseif $field.6 eq 'url'}} type='url'{{/if}} name='{{$field.0}}' id='id_{{$field.0}}' value="{{$field.2}}"{{if $field.4 eq 'required'}} required{{/if}}{{if $field.5 eq 'autofocus'}} autofocus{{/if}}>
 		<span class='field_help'>{{$field.3}}</span>
 	</div>

--- a/view/templates/field_password.tpl
+++ b/view/templates/field_password.tpl
@@ -1,6 +1,6 @@
 	
 	<div class='field password' id='wrapper_{{$field.0}}'>
 		<label for='id_{{$field.0}}'>{{$field.1}}</label>
-		<input type='password' name='{{$field.0}}' id='id_{{$field.0}}' value="{{$field.2}}">
+		<input type='password' name='{{$field.0}}' id='id_{{$field.0}}' value="{{$field.2}}"{{if $field.4 eq 'required'}} required{{/if}}{{if $field.5 eq 'autofocus'}} autofocus{{/if}}>
 		<span class='field_help'>{{$field.3}}</span>
 	</div>

--- a/view/templates/profile_edit.tpl
+++ b/view/templates/profile_edit.tpl
@@ -131,7 +131,7 @@
 
 <div id="profile-edit-homepage-wrapper" >
 <label id="profile-edit-homepage-label" for="profile-edit-homepage" >{{$lbl_homepage}} </label>
-<input type="text" size="32" name="homepage" id="profile-edit-homepage" value="{{$homepage}}" />
+<input type="url" size="32" name="homepage" id="profile-edit-homepage" value="{{$homepage}}" />
 </div>
 <div id="profile-edit-homepage-end"></div>
 


### PR DESCRIPTION
Added some HTML5 attributes to the input fields during the installation process so modern browsers are now able to check that

* required fields are filled, and
* that the entered email address of the admin is actually an email address.

To make this possible, I've extended the templates for input fields and password fields with the required smarty code to check if the attributes should be added or not. With these changes the order of field parameters is now

1. field name
2. field label
3. default value
4. help text
5. is the field required, set to 'required' if it is
6. set the focus into this field, set to 'autofocus' if desired
7. type of the field, set either to 'email' or 'url' to ask the browser to check.