### PR TITLE
Optional text only email

### DIFF
--- a/include/Emailer.php
+++ b/include/Emailer.php
@@ -30,8 +30,8 @@ class Emailer {
 
 		// generate a mime boundary
 		$mimeBoundary   =rand(0,9)."-"
-				.rand(10000000000,9999999999)."-"
-				.rand(10000000000,9999999999)."=:"
+				.rand(10000000000,99999999999)."-"
+				.rand(10000000000,99999999999)."=:"
 				.rand(10000,99999);
 
 		// generate a multipart/alternative message header

--- a/mod/settings.php
+++ b/mod/settings.php
@@ -1184,7 +1184,7 @@ function settings_content(&$a) {
 
 		'$email_textonly' => array('email_textonly', t('Text-only notification emails'),
 									get_pconfig(local_user(),'system','email_textonly'),
-									t('Send only text notification emails body, without the html part')),
+									t('Send text only notification emails, without the html part')),
 
 		'$h_advn' => t('Advanced Account/Page Type Settings'),
 		'$h_descadvn' => t('Change the behaviour of this account for special situations'),

--- a/mod/settings.php
+++ b/mod/settings.php
@@ -395,6 +395,8 @@ function settings_post(&$a) {
 	$post_joingroup   = (($_POST['post_joingroup'] == 1) ? 1: 0);
 	$post_profilechange   = (($_POST['post_profilechange'] == 1) ? 1: 0);
 
+	$email_textonly   = (($_POST['email_textonly'] == 1) ? 1 : 0);
+
 	$notify = 0;
 
 	if(x($_POST,'notify1'))
@@ -495,6 +497,7 @@ function settings_post(&$a) {
 	set_pconfig(local_user(),'system','post_joingroup', $post_joingroup);
 	set_pconfig(local_user(),'system','post_profilechange', $post_profilechange);
 
+	set_pconfig(local_user(),'system','email_textonly', $email_textonly);
 
 	if($page_flags == PAGE_PRVGROUP) {
 		$hidewall = 1;
@@ -505,7 +508,7 @@ function settings_post(&$a) {
 			}
 			else {
 				notice( t('Private forum has no privacy permissions and no default privacy group.') . EOL);
-			} 
+			}
 		}
 	}
 
@@ -656,7 +659,7 @@ function settings_content(&$a) {
 		}
 
 
-		$r = q("SELECT clients.*, tokens.id as oauth_token, (clients.uid=%d) AS my 
+		$r = q("SELECT clients.*, tokens.id as oauth_token, (clients.uid=%d) AS my
 				FROM clients
 				LEFT JOIN tokens ON clients.client_id=tokens.client_id
 				WHERE clients.uid IN (%d,0)",
@@ -830,7 +833,7 @@ function settings_content(&$a) {
 				$is_experimental = file_exists('view/theme/' . $th . '/experimental');
 				$unsupported = file_exists('view/theme/' . $th . '/unsupported');
 				$is_mobile = file_exists('view/theme/' . $th . '/mobile');
-				if (!$is_experimental or ($is_experimental && (get_config('experimentals','exp_themes')==1 or get_config('experimentals','exp_themes')===false))){ 
+				if (!$is_experimental or ($is_experimental && (get_config('experimentals','exp_themes')==1 or get_config('experimentals','exp_themes')===false))){
 					$theme_name = (($is_experimental) ?  sprintf("%s - \x28Experimental\x29", $f) : $f);
 					if($is_mobile) {
 						$mobile_themes[$f]=$theme_name;
@@ -1078,8 +1081,8 @@ function settings_content(&$a) {
 		'items' => array('expire_items',  t("Expire posts:"), $expire_items, '', array(t('No'),t('Yes'))),
 		'notes' => array('expire_notes',  t("Expire personal notes:"), $expire_notes, '', array(t('No'),t('Yes'))),
 		'starred' => array('expire_starred',  t("Expire starred posts:"), $expire_starred, '', array(t('No'),t('Yes'))),
-		'photos' => array('expire_photos',  t("Expire photos:"), $expire_photos, '', array(t('No'),t('Yes'))),		
-		'network_only' => array('expire_network_only',  t("Only expire posts by others:"), $expire_network_only, '', array(t('No'),t('Yes'))),		
+		'photos' => array('expire_photos',  t("Expire photos:"), $expire_photos, '', array(t('No'),t('Yes'))),
+		'network_only' => array('expire_network_only',  t("Only expire posts by others:"), $expire_network_only, '', array(t('No'),t('Yes'))),
 	);
 
 	require_once('include/group.php');
@@ -1175,10 +1178,13 @@ function settings_content(&$a) {
 		'$notify3'	=> array('notify3', t('Someone writes on your profile wall'), ($notify & NOTIFY_WALL), NOTIFY_WALL, ''),
 		'$notify4'	=> array('notify4', t('Someone writes a followup comment'), ($notify & NOTIFY_COMMENT), NOTIFY_COMMENT, ''),
 		'$notify5'	=> array('notify5', t('You receive a private message'), ($notify & NOTIFY_MAIL), NOTIFY_MAIL, ''),
-		'$notify6'  => array('notify6', t('You receive a friend suggestion'), ($notify & NOTIFY_SUGGEST), NOTIFY_SUGGEST, ''),		
-		'$notify7'  => array('notify7', t('You are tagged in a post'), ($notify & NOTIFY_TAGSELF), NOTIFY_TAGSELF, ''),		
-		'$notify8'  => array('notify8', t('You are poked/prodded/etc. in a post'), ($notify & NOTIFY_POKE), NOTIFY_POKE, ''),		
+		'$notify6'  => array('notify6', t('You receive a friend suggestion'), ($notify & NOTIFY_SUGGEST), NOTIFY_SUGGEST, ''),
+		'$notify7'  => array('notify7', t('You are tagged in a post'), ($notify & NOTIFY_TAGSELF), NOTIFY_TAGSELF, ''),
+		'$notify8'  => array('notify8', t('You are poked/prodded/etc. in a post'), ($notify & NOTIFY_POKE), NOTIFY_POKE, ''),
 
+		'$email_textonly' => array('email_textonly', t('Text-only notification emails'),
+									get_pconfig(local_user(),'system','email_textonly'),
+									t('Send only text notification emails body, without the html part')),
 
 		'$h_advn' => t('Advanced Account/Page Type Settings'),
 		'$h_descadvn' => t('Change the behaviour of this account for special situations'),

--- a/view/templates/settings.tpl
+++ b/view/templates/settings.tpl
@@ -86,7 +86,7 @@
 	<div id="settings-default-perms-menu-end"></div>
 
 	<div id="settings-default-perms-select" style="display: none; margin-bottom: 20px" >
-	
+
 	<div style="display: none;">
 		<div id="profile-jot-acl-wrapper" style="width:auto;height:auto;overflow:auto;">
 			{{$aclselect}}
@@ -132,6 +132,8 @@
 {{include file="field_intcheckbox.tpl" field=$notify7}}
 {{include file="field_intcheckbox.tpl" field=$notify8}}
 </div>
+
+{{include file="field_checkbox.tpl" field=$email_textonly}}
 
 </div>
 

--- a/view/theme/decaf-mobile/templates/settings.tpl
+++ b/view/theme/decaf-mobile/templates/settings.tpl
@@ -87,7 +87,7 @@
 	<div id="settings-default-perms-menu-end"></div>
 
 	<div id="settings-default-perms-select" style="display: none; margin-bottom: 20px" >
-	
+
 	<div style="display: none;">-->*}}
 		<div id="settings-jot-acl-wrapper" style="width:auto;height:auto;overflow:auto;margin-bottom: 20px">
 			{{*<!--{{$aclselect}}-->*}}
@@ -132,6 +132,8 @@
 {{include file="field_intcheckbox.tpl" field=$notify7}}
 {{include file="field_intcheckbox.tpl" field=$notify8}}
 </div>
+
+{{include file="field_checkbox.tpl" field=$email_textonly}}
 
 </div>
 

--- a/view/theme/frost-mobile/templates/settings.tpl
+++ b/view/theme/frost-mobile/templates/settings.tpl
@@ -85,7 +85,7 @@
 	<div id="settings-default-perms-menu-end"></div>
 
 {{*<!--	<div id="settings-default-perms-select" style="display: none; margin-bottom: 20px" >-->*}}
-	
+
 	<div style="display: none;">
 		<div id="settings-jot-acl-wrapper" style="width:auto;height:auto;overflow:auto;margin-bottom: 20px">
 			{{$aclselect}}
@@ -128,6 +128,8 @@
 {{include file="field_intcheckbox.tpl" field=$notify7}}
 {{include file="field_intcheckbox.tpl" field=$notify8}}
 </div>
+
+{{include file="field_checkbox.tpl" field=$email_textonly}}
 
 </div>
 


### PR DESCRIPTION
Add a checkbok to notification settings. if checked, html body is not added to email.
Someone don't like html emails :-)

Please, review the string in mod/settings.php.

And, fix random mime boundary generation.
a '9' was missin in rand() function, like `rand(10, 9)`
 