### PR TITLE
making the ignore button in contact suggestions visible in quattro

### DIFF
--- a/view/theme/quattro/dark/style.css
+++ b/view/theme/quattro/dark/style.css
@@ -1283,6 +1283,9 @@ section {
     opacity: 0.5;
 }*/
 .wwto {
+  position: absolute !important;
+  width: 25px;
+  height: 25px;
   background: #FFFFFF;
   border: 2px solid #364e59;
   height: 25px;
@@ -2093,9 +2096,19 @@ ul.tabs li .active {
 /* profile match wrapper */
 .profile-match-wrapper {
   float: left;
-  width: 90px;
-  height: 90px;
+  width: 110px;
+  height: 110px;
   margin-bottom: 20px;
+}
+.profile-match-wrapper .drophide {
+  background-image: url('../../../images/icons/22/delete.png');
+  display: block;
+  width: 22px;
+  height: 22px;
+  opacity: 0.3;
+  position: relative;
+  top: 10px;
+  left: -10px;
 }
 .profile-match-wrapper .contact-photo {
   width: 80px;

--- a/view/theme/quattro/dark/style.css
+++ b/view/theme/quattro/dark/style.css
@@ -2100,6 +2100,15 @@ ul.tabs li .active {
   height: 110px;
   margin-bottom: 20px;
 }
+.profile-match-wrapper .drop {
+  background-image: url('../../../images/icons/22/delete.png');
+  display: block;
+  width: 22px;
+  height: 22px;
+  position: relative;
+  top: 10px;
+  left: -10px;
+}
 .profile-match-wrapper .drophide {
   background-image: url('../../../images/icons/22/delete.png');
   display: block;

--- a/view/theme/quattro/green/style.css
+++ b/view/theme/quattro/green/style.css
@@ -1283,6 +1283,9 @@ section {
     opacity: 0.5;
 }*/
 .wwto {
+  position: absolute !important;
+  width: 25px;
+  height: 25px;
   background: #FFFFFF;
   border: 2px solid #364e59;
   height: 25px;
@@ -2093,9 +2096,19 @@ ul.tabs li .active {
 /* profile match wrapper */
 .profile-match-wrapper {
   float: left;
-  width: 90px;
-  height: 90px;
+  width: 110px;
+  height: 110px;
   margin-bottom: 20px;
+}
+.profile-match-wrapper .drophide {
+  background-image: url('../../../images/icons/22/delete.png');
+  display: block;
+  width: 22px;
+  height: 22px;
+  opacity: 0.3;
+  position: relative;
+  top: 10px;
+  left: -10px;
 }
 .profile-match-wrapper .contact-photo {
   width: 80px;

--- a/view/theme/quattro/green/style.css
+++ b/view/theme/quattro/green/style.css
@@ -2100,6 +2100,15 @@ ul.tabs li .active {
   height: 110px;
   margin-bottom: 20px;
 }
+.profile-match-wrapper .drop {
+  background-image: url('../../../images/icons/22/delete.png');
+  display: block;
+  width: 22px;
+  height: 22px;
+  position: relative;
+  top: 10px;
+  left: -10px;
+}
 .profile-match-wrapper .drophide {
   background-image: url('../../../images/icons/22/delete.png');
   display: block;

--- a/view/theme/quattro/lilac/style.css
+++ b/view/theme/quattro/lilac/style.css
@@ -1283,6 +1283,9 @@ section {
     opacity: 0.5;
 }*/
 .wwto {
+  position: absolute !important;
+  width: 25px;
+  height: 25px;
   background: #FFFFFF;
   border: 2px solid #364e59;
   height: 25px;
@@ -2093,9 +2096,19 @@ ul.tabs li .active {
 /* profile match wrapper */
 .profile-match-wrapper {
   float: left;
-  width: 90px;
-  height: 90px;
+  width: 110px;
+  height: 110px;
   margin-bottom: 20px;
+}
+.profile-match-wrapper .drophide {
+  background-image: url('../../../images/icons/22/delete.png');
+  display: block;
+  width: 22px;
+  height: 22px;
+  opacity: 0.3;
+  position: relative;
+  top: 10px;
+  left: -10px;
 }
 .profile-match-wrapper .contact-photo {
   width: 80px;

--- a/view/theme/quattro/lilac/style.css
+++ b/view/theme/quattro/lilac/style.css
@@ -2100,6 +2100,15 @@ ul.tabs li .active {
   height: 110px;
   margin-bottom: 20px;
 }
+.profile-match-wrapper .drop {
+  background-image: url('../../../images/icons/22/delete.png');
+  display: block;
+  width: 22px;
+  height: 22px;
+  position: relative;
+  top: 10px;
+  left: -10px;
+}
 .profile-match-wrapper .drophide {
   background-image: url('../../../images/icons/22/delete.png');
   display: block;

--- a/view/theme/quattro/quattro.less
+++ b/view/theme/quattro/quattro.less
@@ -1426,6 +1426,13 @@ ul.tabs {
 	width: 110px;
 	height: 110px;
         margin-bottom: 20px;
+        .drop {
+            background-image: url('../../../images/icons/22/delete.png');
+            display: block; width: 22px; height: 22px;
+            position: relative;
+            top: 10px;
+	    left: -10px;
+        }
         .drophide {
             background-image: url('../../../images/icons/22/delete.png');
             display: block; width: 22px; height: 22px;

--- a/view/theme/quattro/quattro.less
+++ b/view/theme/quattro/quattro.less
@@ -1423,9 +1423,17 @@ ul.tabs {
 /* profile match wrapper */
 .profile-match-wrapper {
 	float: left;
-	width: 90px;
-	height: 90px;
+	width: 110px;
+	height: 110px;
         margin-bottom: 20px;
+        .drophide {
+            background-image: url('../../../images/icons/22/delete.png');
+            display: block; width: 22px; height: 22px;
+            opacity: 0.3;
+            position: relative;
+            top: 10px;
+	    left: -10px;
+        }
 	.contact-photo { 
 		width: 80px; height: 80px;
 		img { width: 80px; height: 80px; }


### PR DESCRIPTION
while playing around with the contact suggestion page, comparing clean and vier theme I noticed that quattro does not show the ignore button for suggestions. It is now included, but needs more work, as it vanishes when mouseover the button. Any hints on that?

Also the place each suggestion may fill is now a bit bigger to let the avatars some space for breathing.