### PR TITLE
Issue 1197: New hook for "oembed_fetch_url"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,11 @@ report/
 #ignore cache folders
 /privacy_image_cache/
 /photo/
+/proxy/
 nbproject
 
 #ignore vagrant dir
 .vagrant/
+
+#ignore test folder
+/test/

--- a/.gitignore
+++ b/.gitignore
@@ -40,5 +40,5 @@ nbproject
 #ignore vagrant dir
 .vagrant/
 
-#ignore test folder
-/test/
+#ignore local folder
+/local/

--- a/include/oembed.php
+++ b/include/oembed.php
@@ -110,6 +110,8 @@ function oembed_fetch_url($embedurl, $no_rich_type = false){
 		}
 	}
 
+	call_hooks('oembed_fetch_url', $embedurl, $j);
+
 	return $j;
 }
 

--- a/view/theme/vier/theme.php
+++ b/view/theme/vier/theme.php
@@ -22,14 +22,14 @@ if ($style == "")
 
 if ($style == "flat")
 	$a->page['htmlhead'] .= '<link rel="stylesheet" href="view/theme/vier/flat.css" type="text/css" media="screen"/>'."\n";
-if ($style == "dark")
-	$a->page['htmlhead'] .= '<link rel="stylesheet" href="view/theme/vier/dark.css" type="text/css" media="screen"/>'."\n";
 else if ($style == "netcolour")
 	$a->page['htmlhead'] .= '<link rel="stylesheet" href="view/theme/vier/netcolour.css" type="text/css" media="screen"/>'."\n";
 else if ($style == "breathe")
 	$a->page['htmlhead'] .= '<link rel="stylesheet" href="view/theme/vier/breathe.css" type="text/css" media="screen"/>'."\n";
 else if ($style == "plus")
 	$a->page['htmlhead'] .= '<link rel="stylesheet" href="view/theme/vier/plus.css" type="text/css" media="screen"/>'."\n";
+else if ($style == "dark")
+	$a->page['htmlhead'] .= '<link rel="stylesheet" href="view/theme/vier/dark.css" type="text/css" media="screen"/>'."\n";
 
 $a->page['htmlhead'] .= <<< EOT
 <script type="text/javascript">


### PR DESCRIPTION
This pull requests addresses issue https://github.com/friendica/friendica/issues/1197. There is now a new hook that could be used to write addons to support oembed stuff for pages that don't support oembed.

Additionally there is a small change to "vier" and to the ignored folders in .gitignore.