### PR TITLE
add links to the plugin config pages for active plugins

### DIFF
--- a/view/templates/admin_summary.tpl
+++ b/view/templates/admin_summary.tpl
@@ -27,7 +27,7 @@
 		<dt>{{$plugins.0}}</dt>
 		
 		{{foreach $plugins.1 as $p}}
-			<dd>{{$p}}</dd>
+			<dd><a href="/admin/plugins/{{$p}}/">{{$p}}</a></dd>
 		{{/foreach}}
 		
 	</dl>


### PR DESCRIPTION
This adds links in the list of activated addons to the respective config page for that addon in the admin panel thus admins reach the config pages faster.