### PR TITLE
Issue1329

### DIFF
--- a/include/enotify.php
+++ b/include/enotify.php
@@ -28,7 +28,6 @@ function notification($params) {
 	if(strpos($hostname,':'))
 		$hostname = substr($hostname,0,strpos($hostname,':'));
 	
-	// $sender_email = t('noreply') . '@' . $hostname;
 	$sender_email = $a->config['sender_email'];
 	if (empty($sender_email)) {
 		$sender_email = t('noreply') . '@' . $hostname;

--- a/include/enotify.php
+++ b/include/enotify.php
@@ -23,7 +23,7 @@ function notification($params) {
 	$site_admin = sprintf( t('%s Administrator'), $sitename);
 	$nickname = "";
 
-	$sender_name = $product;
+	$sender_name = $sitename;
 	$hostname = $a->get_hostname();
 	if(strpos($hostname,':'))
 		$hostname = substr($hostname,0,strpos($hostname,':'));

--- a/include/enotify.php
+++ b/include/enotify.php
@@ -27,8 +27,12 @@ function notification($params) {
 	$hostname = $a->get_hostname();
 	if(strpos($hostname,':'))
 		$hostname = substr($hostname,0,strpos($hostname,':'));
-
-	$sender_email = t('noreply') . '@' . $hostname;
+	
+	// $sender_email = t('noreply') . '@' . $hostname;
+	$sender_email = $a->config['sender_email'];
+	if (empty($sender_email)) {
+		$sender_email = t('noreply') . '@' . $hostname;
+	}
 
 	$user = q("SELECT `nickname` FROM `user` WHERE `uid` = %d", intval($params['uid']));
 	if ($user)

--- a/mod/admin.php
+++ b/mod/admin.php
@@ -607,7 +607,7 @@ function admin_page_site(&$a) {
 		// name, label, value, help string, extra data...
 		'$sitename' 		=> array('sitename', t("Site name"), htmlentities($a->config['sitename'], ENT_QUOTES), 'UTF-8'),
 		'$hostname' 		=> array('hostname', t("Host name"), $a->config['hostname'], ""),
-		'$sender_email'		=> array('sender_email', t("Sender Email"), $a->config['sender_email'], ""),
+		'$sender_email'		=> array('sender_email', t("Sender Email"), $a->config['sender_email'], "The email address your server shall use to send notification emails from."),
 		'$banner'		=> array('banner', t("Banner/Logo"), $banner, ""),
 		'$info'	=> array('info',t('Additional Info'), $info, t('For public servers: you can add additional information here that will be listed at dir.friendica.com/siteinfo.')),
 		'$language' 		=> array('language', t("System language"), get_config('system','language'), "", $lang_choices),

--- a/mod/admin.php
+++ b/mod/admin.php
@@ -309,6 +309,7 @@ function admin_page_site_post(&$a){
 
 	$sitename 		=	((x($_POST,'sitename'))			? notags(trim($_POST['sitename']))		: '');
 	$hostname 		=	((x($_POST,'hostname'))			? notags(trim($_POST['hostname']))		: '');
+	$sender_email	=	((x($_POST,'sender_email'))		? notags(trim($_POST['sender_email']))		: '');
 	$banner			=	((x($_POST,'banner'))      		? trim($_POST['banner'])			: false);
 	$info			=	((x($_POST,'info'))      		? trim($_POST['info'])			: false);
 	$language		=	((x($_POST,'language'))			? notags(trim($_POST['language']))		: '');
@@ -415,6 +416,7 @@ function admin_page_site_post(&$a){
 	set_config('system','maxloadavg',$maxloadavg);
 	set_config('config','sitename',$sitename);
 	set_config('config','hostname',$hostname);
+	set_config('config','sender_email', $sender_email);
 	set_config('system','suppress_language',$suppress_language);
 	if ($banner==""){
 		// don't know why, but del_config doesn't work...
@@ -605,6 +607,7 @@ function admin_page_site(&$a) {
 		// name, label, value, help string, extra data...
 		'$sitename' 		=> array('sitename', t("Site name"), htmlentities($a->config['sitename'], ENT_QUOTES), 'UTF-8'),
 		'$hostname' 		=> array('hostname', t("Host name"), $a->config['hostname'], ""),
+		'$sender_email'		=> array('sender_email', t("Sender Email"), $a->config['sender_email'], ""),
 		'$banner'		=> array('banner', t("Banner/Logo"), $banner, ""),
 		'$info'	=> array('info',t('Additional Info'), $info, t('For public servers: you can add additional information here that will be listed at dir.friendica.com/siteinfo.')),
 		'$language' 		=> array('language', t("System language"), get_config('system','language'), "", $lang_choices),

--- a/mod/admin.php
+++ b/mod/admin.php
@@ -607,7 +607,7 @@ function admin_page_site(&$a) {
 		// name, label, value, help string, extra data...
 		'$sitename' 		=> array('sitename', t("Site name"), htmlentities($a->config['sitename'], ENT_QUOTES), 'UTF-8'),
 		'$hostname' 		=> array('hostname', t("Host name"), $a->config['hostname'], ""),
-		'$sender_email'		=> array('sender_email', t("Sender Email"), $a->config['sender_email'], "The email address your server shall use to send notification emails from."),
+		'$sender_email'		=> array('sender_email', t("Sender Email"), $a->config['sender_email'], "The email address your server shall use to send notification emails from.", "", "", "email"),
 		'$banner'		=> array('banner', t("Banner/Logo"), $banner, ""),
 		'$info'	=> array('info',t('Additional Info'), $info, t('For public servers: you can add additional information here that will be listed at dir.friendica.com/siteinfo.')),
 		'$language' 		=> array('language', t("System language"), get_config('system','language'), "", $lang_choices),

--- a/mod/admin.php
+++ b/mod/admin.php
@@ -278,7 +278,7 @@ function admin_page_site_post(&$a){
 			$q = sprintf("UPDATE %s SET %s;", $table_name, $upds);
 			$r = q($q);
 			if (!$r) {
-				notice( "Falied updating '$table_name': " . $db->error );
+				notice( "Failed updating '$table_name': " . $db->error );
 				goaway($a->get_baseurl(true) . '/admin/site' );
 			}
 		}

--- a/view/templates/admin_site.tpl
+++ b/view/templates/admin_site.tpl
@@ -46,6 +46,7 @@
 
 	{{include file="field_input.tpl" field=$sitename}}
 	{{include file="field_input.tpl" field=$hostname}}
+	{{include file="field_input.tpl" field=$sender_email}}
 	{{include file="field_textarea.tpl" field=$banner}}
 	{{include file="field_textarea.tpl" field=$info}}
 	{{include file="field_select.tpl" field=$language}}


### PR DESCRIPTION
Please check! This adds a setting to the admin settings. It modifies the sender information for email notifications: The "from" field now is the sitename. The email address system notifications come from are now customizable. If empty it should stay noreply@example.org as before.