### PR TITLE
Bugfix: The portable contacts send data as html

### DIFF
--- a/include/socgraph.php
+++ b/include/socgraph.php
@@ -20,6 +20,9 @@ require_once('include/datetime.php');
 
 
 function poco_load($cid,$uid = 0,$zcid = 0,$url = null) {
+
+	require_once("include/html2bbcode.php");
+
 	$a = get_app();
 
 	if($cid) {
@@ -107,7 +110,7 @@ function poco_load($cid,$uid = 0,$zcid = 0,$url = null) {
 			$location = $entry->currentLocation;
 
 		if(isset($entry->aboutMe))
-			$about = $entry->aboutMe;
+			$about = html2bbcode($entry->aboutMe);
 
 		if(isset($entry->gender))
 			$gender = $entry->gender;


### PR DESCRIPTION
The problem was that the code was stored directly without conversion. Now the html is converted to bbcode.