### PR TITLE
Improvement for the "new friend" notification with Diaspora and "remote self"

### DIFF
--- a/include/diaspora.php
+++ b/include/diaspora.php
@@ -589,7 +589,7 @@ function diaspora_request($importer,$xml) {
 			intval($importer['uid'])
 		);
 
-		if((count($r)) && (! $r[0]['hide-friends']) && (! $contact['hidden'])) {
+		if((count($r)) && (!$r[0]['hide-friends']) && (!$contact['hidden']) && intval(get_pconfig($importer['uid'],'system','post_newfriend'))) {
 			require_once('include/items.php');
 
 			$self = q("SELECT * FROM `contact` WHERE `self` = 1 AND `uid` = %d LIMIT 1",

--- a/include/items.php
+++ b/include/items.php
@@ -2715,6 +2715,10 @@ function item_is_remote_self($contact, &$datarray) {
 	if ($datarray["app"] == $a->get_hostname())
 		return false;
 
+	// Only forward posts
+	if ($datarray["verb"] != ACTIVITY_POST)
+		return false;
+
 	if (($contact['network'] != NETWORK_FEED) AND $datarray['private'])
 		return false;
 


### PR DESCRIPTION
* The setting "post_newfriend" is now working with Diaspora as well.
* The "new friend" notification isn't send via "remote self" anymore.