### PR TITLE
Moved several configuration values to the admin page

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -127,6 +127,11 @@ define ( 'PAGE_FREELOVE',          3 );
 define ( 'PAGE_BLOG',              4 );
 define ( 'PAGE_PRVGROUP',          5 );
 
+// Type of the community page
+define ( 'CP_NO_COMMUNITY_PAGE',   -1 );
+define ( 'CP_USERS_ON_SERVER',     0 );
+define ( 'CP_GLOBAL_COMMUNITY',    1 );
+
 /**
  * Network and protocol family types
  */

--- a/boot.php
+++ b/boot.php
@@ -18,7 +18,7 @@ define ( 'FRIENDICA_PLATFORM',     'Friendica');
 define ( 'FRIENDICA_CODENAME',     'Ginger');
 define ( 'FRIENDICA_VERSION',      '3.3.3-RC' );
 define ( 'DFRN_PROTOCOL_VERSION',  '2.23'    );
-define ( 'DB_UPDATE_VERSION',      1178      );
+define ( 'DB_UPDATE_VERSION',      1179      );
 define ( 'EOL',                    "<br />\r\n"     );
 define ( 'ATOM_TIME',              'Y-m-d\TH:i:s\Z' );
 

--- a/include/bbcode.php
+++ b/include/bbcode.php
@@ -1183,12 +1183,6 @@ function bbcode($Text,$preserve_nl = false, $tryoembed = true, $simplehtml = fal
 	//$Text = str_replace('<br /><li>','<li>', $Text);
 	//	$Text = str_replace('<br /><ul','<ul ', $Text);
 
-	// Remove all hashtag addresses
-/*	if (!$tryoembed AND get_config("system", "remove_hashtags_on_export")) {
-		$pattern = '/#<a.*?href="(.*?)".*?>(.*?)<\/a>/is';
-		$Text = preg_replace($pattern, '#$2', $Text);
-	}
-*/
 	call_hooks('bbcode',$Text);
 
 	$a->save_timestamp($stamp1, "parser");

--- a/include/html2plain.php
+++ b/include/html2plain.php
@@ -113,12 +113,6 @@ function html2plain($html, $wraplength = 75, $compact = false)
 
 	$message = str_replace("\r", "", $html);
 
-	// replace all hashtag addresses
-/*	if (get_config("system", "remove_hashtags_on_export")) {
-		$pattern = '/#<a.*?href="(.*?)".*?>(.*?)<\/a>/is';
-		$message = preg_replace($pattern, '#$2', $message);
-	}
-*/
 	$doc = new DOMDocument();
 	$doc->preserveWhiteSpace = false;
 

--- a/include/nav.php
+++ b/include/nav.php
@@ -125,8 +125,10 @@ function nav_info(&$a) {
 		if(strlen($gdir))
 			$gdirpath = $gdir;
 	}
-	elseif(! get_config('system','no_community_page'))
+	elseif(get_config('system','community_page_style') == CP_USERS_ON_SERVER)
 		$nav['community'] = array('community', t('Community'), "", t('Conversations on this site'));
+	elseif(get_config('system','community_page_style') == CP_GLOBAL_COMMUNITY)
+		$nav['community'] = array('community', t('Community'), "", t('Conversations on the network'));
 
 	$nav['directory'] = array($gdirpath, t('Directory'), "", t('People directory'));
 

--- a/include/threads.php
+++ b/include/threads.php
@@ -19,10 +19,6 @@ function add_thread($itemid, $onlyshadow = false) {
 		logger("add_thread: Add thread for item ".$itemid." - ".print_r($result, true), LOGGER_DEBUG);
 	}
 
-	// Store a shadow copy of public items for displaying a global community page?
-	//if (!get_config('system', 'global_community'))
-	//	return;
-
 	// is it already a copy?
 	if (($itemid == 0) OR ($item['uid'] == 0))
 		return;

--- a/include/threads.php
+++ b/include/threads.php
@@ -20,8 +20,8 @@ function add_thread($itemid, $onlyshadow = false) {
 	}
 
 	// Store a shadow copy of public items for displaying a global community page?
-	if (!get_config('system', 'global_community'))
-		return;
+	//if (!get_config('system', 'global_community'))
+	//	return;
 
 	// is it already a copy?
 	if (($itemid == 0) OR ($item['uid'] == 0))

--- a/mod/admin.php
+++ b/mod/admin.php
@@ -312,8 +312,10 @@ function admin_page_site_post(&$a){
 
 	$sitename 		=	((x($_POST,'sitename'))			? notags(trim($_POST['sitename']))		: '');
 	$hostname 		=	((x($_POST,'hostname'))			? notags(trim($_POST['hostname']))		: '');
-	$sender_email	=	((x($_POST,'sender_email'))		? notags(trim($_POST['sender_email']))		: '');
+	$sender_email		=	((x($_POST,'sender_email'))		? notags(trim($_POST['sender_email']))		: '');
 	$banner			=	((x($_POST,'banner'))      		? trim($_POST['banner'])			: false);
+	$shortcut_icon 		=	((x($_POST,'shortcut_icon'))		? notags(trim($_POST['shortcut_icon']))		: '');
+	$touch_icon 		=	((x($_POST,'touch_icon'))		? notags(trim($_POST['touch_icon']))		: '');
 	$info			=	((x($_POST,'info'))      		? trim($_POST['info'])			: false);
 	$language		=	((x($_POST,'language'))			? notags(trim($_POST['language']))		: '');
 	$theme			=	((x($_POST,'theme'))			? notags(trim($_POST['theme']))			: '');
@@ -345,7 +347,8 @@ function admin_page_site_post(&$a){
 	$no_openid		=	!((x($_POST,'no_openid'))		? True						: False);
 	$no_regfullname		=	!((x($_POST,'no_regfullname'))		? True						: False);
 	$no_utf			=	!((x($_POST,'no_utf'))			? True						: False);
-	$no_community_page	=	!((x($_POST,'no_community_page'))	? True						: False);
+	$community_page_style	=	((x($_POST,'community_page_style'))	? intval(trim($_POST['community_page_style']))	: 0);
+	$max_author_posts_community_page	=	((x($_POST,'max_author_posts_community_page'))	? intval(trim($_POST['max_author_posts_community_page']))	: 0);
 
 	$verifyssl		=	((x($_POST,'verifyssl'))		? True						: False);
 	$proxyuser		=	((x($_POST,'proxyuser'))		? notags(trim($_POST['proxyuser']))		: '');
@@ -356,13 +359,14 @@ function admin_page_site_post(&$a){
 	$maxloadavg		=	((x($_POST,'maxloadavg'))		? intval(trim($_POST['maxloadavg']))		: 50);
 	$dfrn_only		=	((x($_POST,'dfrn_only'))		? True						: False);
 	$ostatus_disabled	=	!((x($_POST,'ostatus_disabled'))	? True  					: False);
-	$ostatus_poll_interval	=	((x($_POST,'ostatus_poll_interval'))	? intval(trim($_POST['ostatus_poll_interval']))		:  0);
+	$ostatus_poll_interval	=	((x($_POST,'ostatus_poll_interval'))	? intval(trim($_POST['ostatus_poll_interval']))	:  0);
 	$diaspora_enabled	=	((x($_POST,'diaspora_enabled'))		? True   					: False);
 	$ssl_policy		=	((x($_POST,'ssl_policy'))		? intval($_POST['ssl_policy']) 			: 0);
 	$force_ssl		=	((x($_POST,'force_ssl'))		? True   					: False);
 	$old_share		=	((x($_POST,'old_share'))		? True   					: False);
 	$hide_help		=	((x($_POST,'hide_help'))		? True   					: False);
 	$suppress_language	=	((x($_POST,'suppress_language'))	? True   					: False);
+	$suppress_tags		=	((x($_POST,'suppress_tags'))		? True   					: False);
 	$use_fulltext_engine	=	((x($_POST,'use_fulltext_engine'))	? True   					: False);
 	$itemcache		=	((x($_POST,'itemcache'))		? notags(trim($_POST['itemcache']))		: '');
 	$itemcache_duration	=	((x($_POST,'itemcache_duration'))	? intval($_POST['itemcache_duration'])		: 0);
@@ -373,6 +377,7 @@ function admin_page_site_post(&$a){
 	$singleuser		=	((x($_POST,'singleuser'))		? notags(trim($_POST['singleuser']))		: '');
 	$proxy_disabled		=	((x($_POST,'proxy_disabled'))		? True						: False);
 	$old_pager		=	((x($_POST,'old_pager'))		? True						: False);
+	$only_tag_search	=	((x($_POST,'only_tag_search'))		? True						: False);
 
 	if($ssl_policy != intval(get_config('system','ssl_policy'))) {
 		if($ssl_policy == SSL_POLICY_FULL) {
@@ -422,6 +427,9 @@ function admin_page_site_post(&$a){
 	set_config('config','hostname',$hostname);
 	set_config('config','sender_email', $sender_email);
 	set_config('system','suppress_language',$suppress_language);
+	set_config('system','suppress_tags',$suppress_tags);
+	set_config('system','shortcut_icon',$shortcut_icon);
+	set_config('system','touch_icon',$touch_icon);
 	if ($banner==""){
 		// don't know why, but del_config doesn't work...
 		q("DELETE FROM `config` WHERE `cat` = '%s' AND `k` = '%s' LIMIT 1",
@@ -478,7 +486,8 @@ function admin_page_site_post(&$a){
 	set_config('system','block_extended_register', $no_multi_reg);
 	set_config('system','no_openid', $no_openid);
 	set_config('system','no_regfullname', $no_regfullname);
-	set_config('system','no_community_page', $no_community_page);
+	set_config('system','community_page_style', $community_page_style);
+	set_config('system','max_author_posts_community_page', $max_author_posts_community_page);
 	set_config('system','no_utf', $no_utf);
 	set_config('system','verifyssl', $verifyssl);
 	set_config('system','proxyuser', $proxyuser);
@@ -486,7 +495,7 @@ function admin_page_site_post(&$a){
 	set_config('system','curl_timeout', $timeout);
 	set_config('system','dfrn_only', $dfrn_only);
 	set_config('system','ostatus_disabled', $ostatus_disabled);
-		set_config('system','ostatus_poll_interval', $ostatus_poll_interval);
+	set_config('system','ostatus_poll_interval', $ostatus_poll_interval);
 	set_config('system','diaspora_enabled', $diaspora_enabled);
 	set_config('config','private_addons', $private_addons);
 
@@ -502,6 +511,7 @@ function admin_page_site_post(&$a){
 	set_config('system','basepath', $basepath);
 	set_config('system','proxy_disabled', $proxy_disabled);
 	set_config('system','old_pager', $old_pager);
+	set_config('system','only_tag_search', $only_tag_search);
 
 	info( t('Site settings updated.') . EOL);
 	goaway($a->get_baseurl(true) . '/admin/site' );
@@ -547,14 +557,21 @@ function admin_page_site(&$a) {
 		}
 		}
 
+		/* Community page style */
+		$community_page_style_choices = array(
+			CP_NO_COMMUNITY_PAGE => t("No community page"),
+			CP_USERS_ON_SERVER => t("Public postings from users of this site"),
+			CP_GLOBAL_COMMUNITY => t("Global community page")
+			);
+
 		/* OStatus conversation poll choices */
 		$ostatus_poll_choices = array(
-		"-2" => t("Never"),
-		"-1" => t("At post arrival"),
-		"0" => t("Frequently"),
-		"60" => t("Hourly"),
-		"720" => t("Twice daily"),
-		"1440" => t("Daily")
+			"-2" => t("Never"),
+			"-1" => t("At post arrival"),
+			"0" => t("Frequently"),
+			"60" => t("Hourly"),
+			"720" => t("Twice daily"),
+			"1440" => t("Daily")
 			);
 
 		/* get user names to make the install a personal install of X */
@@ -613,6 +630,8 @@ function admin_page_site(&$a) {
 		'$hostname' 		=> array('hostname', t("Host name"), $a->config['hostname'], ""),
 		'$sender_email'		=> array('sender_email', t("Sender Email"), $a->config['sender_email'], "The email address your server shall use to send notification emails from.", "", "", "email"),
 		'$banner'		=> array('banner', t("Banner/Logo"), $banner, ""),
+		'$shortcut_icon'	=> array('shortcut_icon', t("Shortcut icon"), get_config('system','shortcut_icon'),  "Link to an icon that will be used for browsers."),
+		'$touch_icon'		=> array('touch_icon', t("Touch icon"), get_config('system','touch_icon'),  "Link to an icon that will be used for tablets and mobiles."),
 		'$info'	=> array('info',t('Additional Info'), $info, t('For public servers: you can add additional information here that will be listed at dir.friendica.com/siteinfo.')),
 		'$language' 		=> array('language', t("System language"), get_config('system','language'), "", $lang_choices),
 		'$theme' 		=> array('theme', t("System theme"), get_config('system','theme'), t("Default system theme - may be over-ridden by user profiles - <a href='#' id='cnftheme'>change theme settings</a>"), $theme_choices),
@@ -645,7 +664,8 @@ function admin_page_site(&$a) {
 		'$no_openid'		=> array('no_openid', t("OpenID support"), !get_config('system','no_openid'), t("OpenID support for registration and logins.")),
 		'$no_regfullname'	=> array('no_regfullname', t("Fullname check"), !get_config('system','no_regfullname'), t("Force users to register with a space between firstname and lastname in Full name, as an antispam measure")),
 		'$no_utf'		=> array('no_utf', t("UTF-8 Regular expressions"), !get_config('system','no_utf'), t("Use PHP UTF8 regular expressions")),
-		'$no_community_page' 	=> array('no_community_page', t("Show Community Page"), !get_config('system','no_community_page'), t("Display a Community page showing all recent public postings on this site.")),
+		'$community_page_style' => array('community_page_style', t("Community Page Style"), get_config('system','community_page_style'), t("Type of community page to show. 'Global community' shows every public posting from an open distributed network that arrived on this server."), $community_page_style_choices),
+		'$max_author_posts_community_page' => array('max_author_posts_community_page', t("Posts per user on community page"), get_config('system','max_author_posts_community_page'), t("The maximum number of posts per user on the community page. (Not valid for 'Global Community')")),
 		'$ostatus_disabled' 	=> array('ostatus_disabled', t("Enable OStatus support"), !get_config('system','ostatus_disabled'), t("Provide built-in OStatus \x28StatusNet, GNU Social etc.\x29 compatibility. All communications in OStatus are public, so privacy warnings will be occasionally displayed.")),
 		'$ostatus_poll_interval'	=> array('ostatus_poll_interval', t("OStatus conversation completion interval"), (string) intval(get_config('system','ostatus_poll_interval')), t("How often shall the poller check for new entries in OStatus conversations? This can be a very ressource task."), $ostatus_poll_choices),
 		'$diaspora_enabled' 	=> array('diaspora_enabled', t("Enable Diaspora support"), get_config('system','diaspora_enabled'), t("Provide built-in Diaspora network compatibility.")),
@@ -660,6 +680,7 @@ function admin_page_site(&$a) {
 
 		'$use_fulltext_engine'	=> array('use_fulltext_engine', t("Use MySQL full text engine"), get_config('system','use_fulltext_engine'), t("Activates the full text engine. Speeds up search - but can only search for four and more characters.")),
 		'$suppress_language'	=> array('suppress_language', t("Suppress Language"), get_config('system','suppress_language'), t("Suppress language information in meta information about a posting.")),
+		'$suppress_tags'	=> array('suppress_tags', t("Suppress Tags"), get_config('system','suppress_tags'), t("Suppress showing a list of hashtags at the end of the posting.")),
 		'$itemcache'		=> array('itemcache', t("Path to item cache"), get_config('system','itemcache'), "The item caches buffers generated bbcode and external images."),
 		'$itemcache_duration' 	=> array('itemcache_duration', t("Cache duration in seconds"), get_config('system','itemcache_duration'), t("How long should the cache files be hold? Default value is 86400 seconds (One day). To disable the item cache, set the value to -1.")),
 		'$max_comments' 	=> array('max_comments', t("Maximum numbers of comments per post"), get_config('system','max_comments'), t("How much comments should be shown for each post? Default value is 100.")),
@@ -668,6 +689,7 @@ function admin_page_site(&$a) {
 		'$basepath'		=> array('basepath', t("Base path to installation"), get_config('system','basepath'), "If the system cannot detect the correct path to your installation, enter the correct path here. This setting should only be set if you are using a restricted system and symbolic links to your webroot."),
 		'$proxy_disabled'	=> array('proxy_disabled', t("Disable picture proxy"), get_config('system','proxy_disabled'), t("The picture proxy increases performance and privacy. It shouldn't be used on systems with very low bandwith.")),
 		'$old_pager'		=> array('old_pager', t("Enable old style pager"), get_config('system','old_pager'), t("The old style pager has page numbers but slows down massively the page speed.")),
+		'$only_tag_search'	=> array('only_tag_search', t("Only search in tags"), get_config('system','only_tag_search'), t("On large systems the text search can slow down the system extremely.")),
 
 		'$relocate_url'     => array('relocate_url', t("New base url"), $a->get_baseurl(), "Change base url for this server. Sends relocate message to all DFRN contacts of all users."),
 	'$form_security_token' => get_form_security_token("admin_site")

--- a/mod/community.php
+++ b/mod/community.php
@@ -113,8 +113,7 @@ function community_content(&$a, $update = 0) {
 }
 
 function community_getitems($start, $itemspage) {
-	// Work in progress
-	if (get_config('system', 'global_community'))
+	if (get_config('system','community_page_style') == CP_GLOBAL_COMMUNITY)
 		return(community_getpublicitems($start, $itemspage));
 
 	$r = q("SELECT `item`.`uri`, `item`.*, `item`.`id` AS `item_id`,

--- a/mod/community.php
+++ b/mod/community.php
@@ -19,7 +19,7 @@ function community_content(&$a, $update = 0) {
 		return;
 	}
 
-	if(get_config('system','no_community_page')) {
+	if(get_config('system','community_page_style') == CP_NO_COMMUNITY_PAGE) {
 		notice( t('Not available.') . EOL);
 		return;
 	}

--- a/mod/search.php
+++ b/mod/search.php
@@ -151,18 +151,6 @@ function search_content(&$a) {
 	// No items will be shown if the member has a blocked profile wall.
 
 	if(get_config('system', 'old_pager')) {
-/*
-	        $r = q("SELECT distinct(`item`.`uri`) as `total`
-		        FROM $sql_table INNER JOIN `contact` ON `contact`.`id` = `item`.`contact-id`
-		        AND `contact`.`blocked` = 0 AND `contact`.`pending` = 0
-			INNER JOIN `user` ON `user`.`uid` = `item`.`uid`
-		        WHERE `item`.`visible` = 1 AND `item`.`deleted` = 0 and `item`.`moderated` = 0
-		        AND (( `item`.`allow_cid` = ''  AND `item`.`allow_gid` = '' AND `item`.`deny_cid`  = '' AND `item`.`deny_gid`  = '' AND `item`.`private` = 0 AND `user`.`hidewall` = 0)
-			        OR ( `item`.`uid` = %d ))
-		        $sql_extra ",
-		        intval(local_user())
-	        );
-*/
 	        $r = q("SELECT distinct(`item`.`uri`) as `total`
 		        FROM $sql_table INNER JOIN `contact` ON `contact`.`id` = `item`.`contact-id`
 		        AND `contact`.`blocked` = 0 AND `contact`.`pending` = 0
@@ -182,27 +170,6 @@ function search_content(&$a) {
 	        }
 	}
 
-/*
-	$r = q("SELECT `item`.`uri`, `item`.*, `item`.`id` AS `item_id`,
-		`contact`.`name`, `contact`.`photo`, `contact`.`url`, `contact`.`alias`, `contact`.`rel`,
-		`contact`.`network`, `contact`.`thumb`, `contact`.`self`, `contact`.`writable`,
-		`contact`.`id` AS `cid`, `contact`.`uid` AS `contact-uid`,
-		`user`.`nickname`, `user`.`uid`, `user`.`hidewall`
-		FROM $sql_table INNER JOIN `contact` ON `contact`.`id` = `item`.`contact-id`
-		AND `contact`.`blocked` = 0 AND `contact`.`pending` = 0
-		INNER JOIN `user` ON `user`.`uid` = `item`.`uid`
-		WHERE `item`.`visible` = 1 AND `item`.`deleted` = 0 and `item`.`moderated` = 0
-		AND ((`item`.`allow_cid` = ''  AND `item`.`allow_gid` = '' AND `item`.`deny_cid`  = '' AND `item`.`deny_gid`  = '' AND `item`.`private` = 0 AND `user`.`hidewall` = 0)
-			OR (`item`.`uid` = %d))
-		$sql_extra
-		GROUP BY `item`.`uri`
-		ORDER BY $sql_order DESC LIMIT %d , %d ",
-		intval(local_user()),
-		intval($a->pager['start']),
-		intval($a->pager['itemspage'])
-
-	);
-*/
 	$r = q("SELECT `item`.`uri`, `item`.*, `item`.`id` AS `item_id`,
 		`contact`.`name`, `contact`.`photo`, `contact`.`url`, `contact`.`alias`, `contact`.`rel`,
 		`contact`.`network`, `contact`.`thumb`, `contact`.`self`, `contact`.`writable`,

--- a/mod/search.php
+++ b/mod/search.php
@@ -151,6 +151,7 @@ function search_content(&$a) {
 	// No items will be shown if the member has a blocked profile wall.
 
 	if(get_config('system', 'old_pager')) {
+/*
 	        $r = q("SELECT distinct(`item`.`uri`) as `total`
 		        FROM $sql_table INNER JOIN `contact` ON `contact`.`id` = `item`.`contact-id`
 		        AND `contact`.`blocked` = 0 AND `contact`.`pending` = 0
@@ -161,7 +162,16 @@ function search_content(&$a) {
 		        $sql_extra ",
 		        intval(local_user())
 	        );
-//		        $sql_extra group by `item`.`uri` ",
+*/
+	        $r = q("SELECT distinct(`item`.`uri`) as `total`
+		        FROM $sql_table INNER JOIN `contact` ON `contact`.`id` = `item`.`contact-id`
+		        AND `contact`.`blocked` = 0 AND `contact`.`pending` = 0
+		        WHERE `item`.`visible` = 1 AND `item`.`deleted` = 0 and `item`.`moderated` = 0
+		        AND ((`item`.`allow_cid` = '' AND `item`.`allow_gid` = '' AND `item`.`deny_cid` = '' AND `item`.`deny_gid`  = '' AND `item`.`private` = 0 AND `item`.`uid` = 0)
+			        OR (`item`.`uid` = %d))
+		        $sql_extra ",
+		        intval(local_user())
+	        );
 
 	        if(count($r))
 		        $a->set_pager_total(count($r));
@@ -172,25 +182,44 @@ function search_content(&$a) {
 	        }
 	}
 
+/*
 	$r = q("SELECT `item`.`uri`, `item`.*, `item`.`id` AS `item_id`,
 		`contact`.`name`, `contact`.`photo`, `contact`.`url`, `contact`.`alias`, `contact`.`rel`,
-		`contact`.`network`, `contact`.`thumb`, `contact`.`self`, `contact`.`writable`, 
+		`contact`.`network`, `contact`.`thumb`, `contact`.`self`, `contact`.`writable`,
 		`contact`.`id` AS `cid`, `contact`.`uid` AS `contact-uid`,
 		`user`.`nickname`, `user`.`uid`, `user`.`hidewall`
 		FROM $sql_table INNER JOIN `contact` ON `contact`.`id` = `item`.`contact-id`
 		AND `contact`.`blocked` = 0 AND `contact`.`pending` = 0
 		INNER JOIN `user` ON `user`.`uid` = `item`.`uid`
 		WHERE `item`.`visible` = 1 AND `item`.`deleted` = 0 and `item`.`moderated` = 0
-		AND (( `item`.`allow_cid` = ''  AND `item`.`allow_gid` = '' AND `item`.`deny_cid`  = '' AND `item`.`deny_gid`  = '' AND `item`.`private` = 0 AND `user`.`hidewall` = 0 ) 
-			OR ( `item`.`uid` = %d ))
-		$sql_extra GROUP BY `item`.`uri`
+		AND ((`item`.`allow_cid` = ''  AND `item`.`allow_gid` = '' AND `item`.`deny_cid`  = '' AND `item`.`deny_gid`  = '' AND `item`.`private` = 0 AND `user`.`hidewall` = 0)
+			OR (`item`.`uid` = %d))
+		$sql_extra
+		GROUP BY `item`.`uri`
 		ORDER BY $sql_order DESC LIMIT %d , %d ",
 		intval(local_user()),
 		intval($a->pager['start']),
 		intval($a->pager['itemspage'])
 
 	);
-//		group by `item`.`uri`
+*/
+	$r = q("SELECT `item`.`uri`, `item`.*, `item`.`id` AS `item_id`,
+		`contact`.`name`, `contact`.`photo`, `contact`.`url`, `contact`.`alias`, `contact`.`rel`,
+		`contact`.`network`, `contact`.`thumb`, `contact`.`self`, `contact`.`writable`,
+		`contact`.`id` AS `cid`, `contact`.`uid` AS `contact-uid`
+		FROM $sql_table INNER JOIN `contact` ON `contact`.`id` = `item`.`contact-id`
+		AND `contact`.`blocked` = 0 AND `contact`.`pending` = 0
+		WHERE `item`.`visible` = 1 AND `item`.`deleted` = 0 and `item`.`moderated` = 0
+		AND ((`item`.`allow_cid` = '' AND `item`.`allow_gid` = '' AND `item`.`deny_cid` = '' AND `item`.`deny_gid`  = '' AND `item`.`private` = 0 AND `item`.`uid`=0)
+			OR `item`.`uid` = %d)
+		$sql_extra
+		GROUP BY `item`.`uri`
+		ORDER BY $sql_order DESC LIMIT %d , %d ",
+		intval(local_user()),
+		intval($a->pager['start']),
+		intval($a->pager['itemspage'])
+
+	);
 
 	if(! count($r)) {
 		info( t('No results.') . EOL);

--- a/mod/search.php
+++ b/mod/search.php
@@ -130,8 +130,8 @@ function search_content(&$a) {
 	if($tag) {
 		$sql_extra = "";
 
-		$sql_table = sprintf("`item` INNER JOIN (SELECT `oid` FROM `term` WHERE `term` = '%s' AND `otype` = %d AND `type` = %d) AS `term` ON `item`.`id` = `term`.`oid` ",
-					dbesc(protect_sprintf($search)), intval(TERM_OBJ_POST), intval(TERM_HASHTAG));
+		$sql_table = sprintf("`item` INNER JOIN (SELECT `oid` FROM `term` WHERE `term` = '%s' AND `otype` = %d AND `type` = %d AND `uid` IN (%d, 0)) AS `term` ON `item`.`id` = `term`.`oid` ",
+					dbesc(protect_sprintf($search)), intval(TERM_OBJ_POST), intval(TERM_HASHTAG), intval(local_user()));
 
 		$sql_order = "`item`.`id`";
 	} else {

--- a/update.php
+++ b/update.php
@@ -1,6 +1,6 @@
 <?php
 
-define( 'UPDATE_VERSION' , 1178 );
+define( 'UPDATE_VERSION' , 1179 );
 
 /**
  *
@@ -1629,4 +1629,11 @@ function update_1177() {
 				intval($profile["uid"])
 			);
 	}
+}
+
+function update_1178() {
+	// Update the central item storage with uid=0
+	proc_run('php',"include/threadupdate.php");
+
+	return UPDATE_SUCCESS;
 }

--- a/update.php
+++ b/update.php
@@ -1632,6 +1632,9 @@ function update_1177() {
 }
 
 function update_1178() {
+	if (get_config('system','no_community_page'))
+		set_config('system','community_page_style', CP_NO_COMMUNITY_PAGE);
+
 	// Update the central item storage with uid=0
 	proc_run('php',"include/threadupdate.php");
 

--- a/view/templates/admin_site.tpl
+++ b/view/templates/admin_site.tpl
@@ -48,6 +48,8 @@
 	{{include file="field_input.tpl" field=$hostname}}
 	{{include file="field_input.tpl" field=$sender_email}}
 	{{include file="field_textarea.tpl" field=$banner}}
+	{{include file="field_input.tpl" field=$shortcut_icon}}
+	{{include file="field_input.tpl" field=$touch_icon}}
 	{{include file="field_textarea.tpl" field=$info}}
 	{{include file="field_select.tpl" field=$language}}
 	{{include file="field_select.tpl" field=$theme}}
@@ -81,7 +83,8 @@
 	{{include file="field_input.tpl" field=$allowed_email}}
 	{{include file="field_checkbox.tpl" field=$block_public}}
 	{{include file="field_checkbox.tpl" field=$force_publish}}
-	{{include file="field_checkbox.tpl" field=$no_community_page}}
+	{{include file="field_select.tpl" field=$community_page_style}}
+	{{include file="field_input.tpl" field=$max_author_posts_community_page}}
 	{{include file="field_checkbox.tpl" field=$ostatus_disabled}}
 	{{include file="field_select.tpl" field=$ostatus_poll_interval}}
 	{{include file="field_checkbox.tpl" field=$diaspora_enabled}}
@@ -109,9 +112,11 @@
 	{{include file="field_input.tpl" field=$temppath}}
 	{{include file="field_input.tpl" field=$basepath}}
 	{{include file="field_checkbox.tpl" field=$suppress_language}}
+	{{include file="field_checkbox.tpl" field=$suppress_tags}}
 
 	<h3>{{$performance}}</h3>
 	{{include file="field_checkbox.tpl" field=$use_fulltext_engine}}
+	{{include file="field_checkbox.tpl" field=$only_tag_search}}
 	{{include file="field_input.tpl" field=$itemcache}}
 	{{include file="field_input.tpl" field=$itemcache_duration}}
 	{{include file="field_input.tpl" field=$max_comments}}


### PR DESCRIPTION
Several configuration values that could only be set in the .htconfig.php can now be set on the admin page. 

This pull request contains a code so that every public post from Diaspora, Friendica and GNU Social is duplicated with the user id value "0". That can be used for the global community page and an increased search speed.