### PR TITLE
Emailer: fix text-only email

### DIFF
--- a/include/Emailer.php
+++ b/include/Emailer.php
@@ -51,7 +51,7 @@ class Emailer {
 			"Content-Transfer-Encoding: base64\n\n" .
 			$textBody . "\n";
 
-		if (!$email_textonly && !is_null($htmlBody)){
+		if (!$email_textonly && !is_null($params['htmlVersion'])){
 			$multipartMessageBody .=
 				"--" . $mimeBoundary . "\n" .				// text/html section
 				"Content-Type: text/html; charset=UTF-8\n" .


### PR DESCRIPTION
If a plugin nullify htmlVersion of the message, an empty html part was sent.