### PR TITLE
Support feeds without XML headers

### DIFF
--- a/include/onepoll.php
+++ b/include/onepoll.php
@@ -174,7 +174,7 @@ function onepoll_run(&$argv, &$argc){
 			return;
 		}
 
-		if(! strstr($handshake_xml,'<?xml')) {
+		if(! strstr($handshake_xml,'<')) {
 			logger('poller: response from ' . $url . ' did not contain XML.');
 
 			mark_for_death($contact);
@@ -535,7 +535,7 @@ function onepoll_run(&$argv, &$argc){
 
 	if($xml) {
 		logger('poller: received xml : ' . $xml, LOGGER_DATA);
-		if((! strstr($xml,'<?xml')) && (! strstr($xml,'<rss'))) {
+		if(! strstr($xml,'<')) {
 			logger('poller: post_handshake: response from ' . $url . ' did not contain XML.');
 			$r = q("UPDATE `contact` SET `last-update` = '%s' WHERE `id` = %d",
 				dbesc(datetime_convert()),


### PR DESCRIPTION
I've come across one otherwise valid atom feed which doesn't include the <?xml...> header.  Seems a bit harsh to just ignore it.