### PR TITLE
Decode entities in item IDs in XML feeds

### DIFF
--- a/include/items.php
+++ b/include/items.php
@@ -2387,7 +2387,7 @@ function consume_feed($xml,$importer,&$contact, &$hub, $datedir = 0, $pass = 0) 
 		foreach($items as $item) {
 
 			$is_reply = false;
-			$item_id = $item->get_id();
+			$item_id = unxmlify($item->get_id());
 			$rawthread = $item->get_item_tags( NAMESPACE_THREAD,'in-reply-to');
 			if(isset($rawthread[0]['attribs']['']['ref'])) {
 				$is_reply = true;
@@ -2407,7 +2407,7 @@ function consume_feed($xml,$importer,&$contact, &$hub, $datedir = 0, $pass = 0) 
 
 				// Have we seen it? If not, import it.
 
-				$item_id  = $item->get_id();
+				$item_id  = unxmlify($item->get_id());
 				$datarray = get_atom_elements($feed, $item, $contact);
 
 				if((! x($datarray,'author-name')) && ($contact['network'] != NETWORK_DFRN))
@@ -2551,7 +2551,7 @@ function consume_feed($xml,$importer,&$contact, &$hub, $datedir = 0, $pass = 0) 
 
 				// Head post of a conversation. Have we seen it? If not, import it.
 
-				$item_id  = $item->get_id();
+				$item_id  = unxmlify($item->get_id());
 
 				$datarray = get_atom_elements($feed, $item, $contact);
 
@@ -3357,7 +3357,7 @@ function local_delivery($importer,$data) {
 	foreach($feed->get_items() as $item) {
 
 		$is_reply = false;
-		$item_id = $item->get_id();
+		$item_id = unxmlify($item->get_id());
 		$rawthread = $item->get_item_tags( NAMESPACE_THREAD, 'in-reply-to');
 		if(isset($rawthread[0]['attribs']['']['ref'])) {
 			$is_reply = true;
@@ -3607,7 +3607,7 @@ function local_delivery($importer,$data) {
 
 				// regular comment that is part of this total conversation. Have we seen it? If not, import it.
 
-				$item_id  = $item->get_id();
+				$item_id  = unxmlify($item->get_id());
 				$datarray = get_atom_elements($feed,$item);
 
 				if($importer['rel'] == CONTACT_IS_FOLLOWER)
@@ -3776,7 +3776,7 @@ function local_delivery($importer,$data) {
 			// Head post of a conversation. Have we seen it? If not, import it.
 
 
-			$item_id  = $item->get_id();
+			$item_id  = unxmlify($item->get_id());
 			$datarray = get_atom_elements($feed,$item);
 
 			if((x($datarray,'object-type')) && ($datarray['object-type'] === ACTIVITY_OBJ_EVENT)) {


### PR DESCRIPTION
I found this necessary for <http://zaomengshe.com/feed> (which is the site I administer).  This is a Wordpress site which happens to be configured to use GUIDs of the form &lt;guid
isPermaLink="false"><http://zaomengshe.com/?post_type=download&#038;p=36773>&lt;/guid>, i.e using an entity for the ampersand instead of a literal ampersand.  Which is valid unless I'm mistaken (I didn't write the code that generates the feed, it's core Wordpress).

The problem in Friendica is that the post UID is automatically copied to the parent UID and then compared for equality.  If they're not the same, the post is rejected.  But the parent UID is unxmlified, whereas the post UID is not.  So any GUIDs with entities will be rejected.  They should be processed consistently.