### PR TITLE
Accept lowercase location header

### DIFF
--- a/include/network.php
+++ b/include/network.php
@@ -94,7 +94,7 @@ function fetch_url($url,$binary = false, &$redirects = 0, $timeout = 0, $accept_
 			$newurl = $new_location_info["scheme"]."://".$new_location_info["host"].$old_location_info["path"];
 
 		$matches = array();
-		if (preg_match('/(Location:|URI:)(.*?)\n/', $header, $matches)) {
+		if (preg_match('/(Location:|URI:)(.*?)\n/i', $header, $matches)) {
 			$newurl = trim(array_pop($matches));
 		}
 		if(strpos($newurl,'/') === 0)


### PR DESCRIPTION
I found this necessary for the New York Times.  For example:

    mat@rei:~$ curl -D headers 'http://krugman.blogs.nytimes.com/2015/02/09/insiders-and-outsiders-redux/'
    mat@rei:~$ cat headers
    HTTP/1.1 303 See Other
    Server: Varnish
    x-r: 0
    location: http://www.nytimes.com/glogin?URI=http%3A%2F%2Fkrugman.blogs.nytimes.com%2F2015%2F02%2F09%2Finsiders-and-outsiders-redux%2F%3F_r%3D0
    Accept-Ranges: bytes
    Date: Tue, 10 Feb 2015 03:10:39 GMT
    X-Varnish: 726317537
    Age: 0
    Via: 1.1 varnish
    X-Cache: MISS
    X-API-Version: 5-5b
    X-PageType: blog
    Connection: close
    Set-Cookie: RMID=007f01016ac454d976af0008;Path=/; Domain=.nytimes.com;Expires=Wed, 10 Feb 2016 03:10:39 UTC
