### PR TITLE
New Global setting: like shouldn't set "commented"

### DIFF
--- a/include/items.php
+++ b/include/items.php
@@ -1435,7 +1435,7 @@ function item_store($arr,$force_parent = false, $notify = false, $dontcache = fa
 
 	// update the commented timestamp on the parent
 	// Only update "commented" if it is really a comment
-	if ($arr['verb'] == ACTIVITY_POST)
+	if (($arr['verb'] == ACTIVITY_POST) OR !get_config("system", "like_no_comment"))
 		q("UPDATE `item` SET `commented` = '%s', `changed` = '%s' WHERE `id` = %d",
 			dbesc(datetime_convert()),
 			dbesc(datetime_convert()),

--- a/include/items.php
+++ b/include/items.php
@@ -1434,12 +1434,18 @@ function item_store($arr,$force_parent = false, $notify = false, $dontcache = fa
 	$arr['deleted'] = $parent_deleted;
 
 	// update the commented timestamp on the parent
-
-	q("UPDATE `item` set `commented` = '%s', `changed` = '%s' WHERE `id` = %d",
-		dbesc(datetime_convert()),
-		dbesc(datetime_convert()),
-		intval($parent_id)
-	);
+	// Only update "commented" if it is really a comment
+	if ($arr['verb'] == ACTIVITY_POST)
+		q("UPDATE `item` SET `commented` = '%s', `changed` = '%s' WHERE `id` = %d",
+			dbesc(datetime_convert()),
+			dbesc(datetime_convert()),
+			intval($parent_id)
+		);
+	else
+		q("UPDATE `item` SET `changed` = '%s' WHERE `id` = %d",
+			dbesc(datetime_convert()),
+			intval($parent_id)
+		);
 
 	if($dsprsig) {
 		q("insert into sign (`iid`,`signed_text`,`signature`,`signer`) values (%d,'%s','%s','%s') ",

--- a/mod/network.php
+++ b/mod/network.php
@@ -705,15 +705,19 @@ die("ss");
 
 		// Fetch a page full of parent items for this page
 		if($update) {
+			if (!get_config("system", "like_no_comment"))
+				$sql_extra4 = "(`item`.`deleted` = 0 OR `item`.`verb` = '".ACTIVITY_LIKE."' OR `item`.`verb` = '".ACTIVITY_DISLIKE."')";
+			else
+				$sql_extra4 = "`item`.`deleted` = 0";
+
 			$r = q("SELECT `item`.`parent` AS `item_id`, `item`.`network` AS `item_network`, `contact`.`uid` AS `contact_uid`
 				FROM $sql_table $sql_post_table INNER JOIN `contact` ON `contact`.`id` = `item`.`contact-id`
 				AND `contact`.`blocked` = 0 AND `contact`.`pending` = 0
-				WHERE `item`.`uid` = %d AND `item`.`visible` = 1 AND `item`.`deleted` = 0
-				and `item`.`moderated` = 0 and `item`.`unseen` = 1
+				WHERE `item`.`uid` = %d AND `item`.`visible` = 1 AND $sql_extra4
+				AND `item`.`moderated` = 0 AND `item`.`unseen` = 1
 				$sql_extra3 $sql_extra $sql_nets ORDER BY `item_id` DESC LIMIT 100",
 				intval(local_user())
 			);
-			//	(`item`.`deleted` = 0 OR `item`.`verb` = '" . ACTIVITY_LIKE ."' OR `item`.`verb` = '" . ACTIVITY_DISLIKE . "')
 		} else {
 			$r = q("SELECT `thread`.`iid` AS `item_id`, `thread`.`network` AS `item_network`, `contact`.`uid` AS `contact_uid`
 				FROM $sql_table $sql_post_table STRAIGHT_JOIN `contact` ON `contact`.`id` = `thread`.`contact-id`

--- a/mod/network.php
+++ b/mod/network.php
@@ -22,7 +22,7 @@ function network_init(&$a) {
 	parse_str($query_string, $query_array);
 	array_shift($query_array);
 
-	
+
 	// fetch last used network view and redirect if needed
 	if(! $is_a_date_query) {
 		$sel_tabs = network_query_get_sel_tab($a);
@@ -708,12 +708,12 @@ die("ss");
 			$r = q("SELECT `item`.`parent` AS `item_id`, `item`.`network` AS `item_network`, `contact`.`uid` AS `contact_uid`
 				FROM $sql_table $sql_post_table INNER JOIN `contact` ON `contact`.`id` = `item`.`contact-id`
 				AND `contact`.`blocked` = 0 AND `contact`.`pending` = 0
-				WHERE `item`.`uid` = %d AND `item`.`visible` = 1 AND
-				(`item`.`deleted` = 0 OR `item`.`verb` = '" . ACTIVITY_LIKE ."' OR `item`.`verb` = '" . ACTIVITY_DISLIKE . "')
+				WHERE `item`.`uid` = %d AND `item`.`visible` = 1 AND `item`.`deleted` = 0
 				and `item`.`moderated` = 0 and `item`.`unseen` = 1
 				$sql_extra3 $sql_extra $sql_nets ORDER BY `item_id` DESC LIMIT 100",
 				intval(local_user())
 			);
+			//	(`item`.`deleted` = 0 OR `item`.`verb` = '" . ACTIVITY_LIKE ."' OR `item`.`verb` = '" . ACTIVITY_DISLIKE . "')
 		} else {
 			$r = q("SELECT `thread`.`iid` AS `item_id`, `thread`.`network` AS `item_network`, `contact`.`uid` AS `contact_uid`
 				FROM $sql_table $sql_post_table STRAIGHT_JOIN `contact` ON `contact`.`id` = `thread`.`contact-id`


### PR DESCRIPTION
There is a new global setting that prevents that a new like updates the "commented" value of the thread. By now this setting can only be set in the .htconfig.php