### PR TITLE
We have to disable the SSL checks for the network communication

### DIFF
--- a/include/network.php
+++ b/include/network.php
@@ -34,11 +34,6 @@ function fetch_url($url,$binary = false, &$redirects = 0, $timeout = 0, $accept_
 		));
 	}
 
-	// There are many servers out there that don't have valid certificates
-	// We have to disable the checks :-(
-	@curl_setopt($ch, CURLOPT_SSL_VERIFYPEER,false);
-	@curl_setopt($ch, CURLOPT_SSL_VERIFYHOST,false);
-
 	@curl_setopt($ch, CURLOPT_RETURNTRANSFER,true);
 	@curl_setopt($ch, CURLOPT_USERAGENT, $a->get_useragent());
 
@@ -55,6 +50,7 @@ function fetch_url($url,$binary = false, &$redirects = 0, $timeout = 0, $accept_
 
 	$check_cert = get_config('system','verifyssl');
 	@curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, (($check_cert) ? true : false));
+	@curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, (($check_cert) ? 2 : false));
 
 	$prx = get_config('system','proxy');
 	if(strlen($prx)) {
@@ -163,6 +159,7 @@ function post_url($url,$params, $headers = null, &$redirects = 0, $timeout = 0) 
 
 	$check_cert = get_config('system','verifyssl');
 	curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, (($check_cert) ? true : false));
+	curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, (($check_cert) ? 2 : false));
 	$prx = get_config('system','proxy');
 	if(strlen($prx)) {
 		curl_setopt($ch, CURLOPT_HTTPPROXYTUNNEL, 1);

--- a/include/network.php
+++ b/include/network.php
@@ -34,6 +34,11 @@ function fetch_url($url,$binary = false, &$redirects = 0, $timeout = 0, $accept_
 		));
 	}
 
+	// There are many servers out there that don't have valid certificates
+	// We have to disable the checks :-(
+	@curl_setopt($ch, CURLOPT_SSL_VERIFYPEER,false);
+	@curl_setopt($ch, CURLOPT_SSL_VERIFYHOST,false);
+
 	@curl_setopt($ch, CURLOPT_RETURNTRANSFER,true);
 	@curl_setopt($ch, CURLOPT_USERAGENT, $a->get_useragent());
 


### PR DESCRIPTION
The server to server communication doesn't work correctly if there is a check for valid certificates. It is bad. But as long as we are having servers with self-signed or otherwise bad certificates, the communication with them will fail.