### PR TITLE
Reworked guid function

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -1196,35 +1196,24 @@ if(! function_exists('check_plugins')) {
 	}
 }
 
-function get_guid($size=16) {
-	$exists = true; // assume by default that we don't have a unique guid
-	do {
-		$prefix = "";
-		while (strlen($prefix) < ($size - 13))
-			$prefix .= mt_rand();
+function get_guid($size=16, $prefix = "") {
 
-		$s = substr(uniqid($prefix), -$size);
+	if ($prefix == "") {
+		$a = get_app();
+		$prefix = hash("crc32", $a->get_hostname());
+	}
 
-		$r = q("select id from guid where guid = '%s' limit 1", dbesc($s));
-		if(! count($r))
-			$exists = false;
-	} while($exists);
-	q("insert into guid (guid) values ('%s') ", dbesc($s));
-	return $s;
+	while (strlen($prefix) < ($size - 13))
+		$prefix .= mt_rand();
+
+	if ($size >= 24) {
+		$prefix = substr($prefix, 0, $size - 22);
+		return(str_replace(".", "", uniqid($prefix, true)));
+	} else {
+		$prefix = substr($prefix, 0, $size - 13);
+		return(uniqid($prefix));
+	}
 }
-
-/*function get_guid($size=16) {
-	$exists = true; // assume by default that we don't have a unique guid
-	do {
-		$s = random_string($size);
-		$r = q("select id from guid where guid = '%s' limit 1", dbesc($s));
-		if(! count($r))
-			$exists = false;
-	} while($exists);
-	q("insert into guid ( guid ) values ( '%s' ) ", dbesc($s));
-	return $s;
-}*/
-
 
 // wrapper for adding a login box. If $register == true provide a registration
 // link. This will most always depend on the value of $a->config['register_policy'].

--- a/include/items.php
+++ b/include/items.php
@@ -1210,8 +1210,8 @@ function item_store($arr,$force_parent = false, $notify = false, $dontcache = fa
 	$arr['attach']        = ((x($arr,'attach'))        ? notags(trim($arr['attach']))        : '');
 	$arr['app']           = ((x($arr,'app'))           ? notags(trim($arr['app']))           : '');
 	$arr['origin']        = ((x($arr,'origin'))        ? intval($arr['origin'])              : 0 );
-	$arr['guid']          = ((x($arr,'guid'))          ? notags(trim($arr['guid']))          : get_guid(30));
 	$arr['network']       = ((x($arr,'network'))       ? trim($arr['network'])               : '');
+	$arr['guid']          = ((x($arr,'guid'))          ? notags(trim($arr['guid']))          : get_guid(32, $arr['network']));
 	$arr['postopts']      = ((x($arr,'postopts'))      ? trim($arr['postopts'])              : '');
 	$arr['resource-id']   = ((x($arr,'resource-id'))   ? trim($arr['resource-id'])           : '');
 	$arr['event-id']      = ((x($arr,'event-id'))      ? intval($arr['event-id'])            : 0 );


### PR DESCRIPTION
The function to create the guid is reworked. The storing of the guid into the database is removed since the uniqid function with "more_entropy" is really enough. The value depends upon the time, so it only could be identical if it would have been generated in the same microsecond - but with "more_entropy" even this wouldn't be a problem.

Posts from other networks (that are only stored locally) now contain the network name as the first 4 characters. Otherwise the CRC32 checksum of the hostname is used. This should decrease the possibility of duplicates even more.