### PR TITLE
Access a contact directly from the contact-manager-page

### DIFF
--- a/mod/contacts.php
+++ b/mod/contacts.php
@@ -32,7 +32,8 @@ function contacts_init(&$a) {
 			$a->data['contact'] = $r[0];
 			$vcard_widget = replace_macros(get_markup_template("vcard-widget.tpl"),array(
 				'$name' => $a->data['contact']['name'],
-				'$photo' => $a->data['contact']['photo']
+				'$photo' => $a->data['contact']['photo'],
+			        '$url' => $a->data['contact']['url']
 			));
 			$follow_widget = '';
 	}

--- a/view/templates/vcard-widget.tpl
+++ b/view/templates/vcard-widget.tpl
@@ -1,6 +1,6 @@
 
 	<div class="vcard">
-		<div class="fn">{{$name}}</div>
-		<div id="profile-photo-wrapper"><img class="photo" style="width: 175px; height: 175px;" src="{{$photo}}" alt="{{$name}}" /></div>
+		<div class="fn"><a href="{{$url}}">{{$name}}</a></div>
+		<div id="profile-photo-wrapper"><a href="{{$url}}"><img class="photo" style="width: 175px; height: 175px;" src="{{$photo}}" alt="{{$name}}" /></a></div>
 	</div>
 


### PR DESCRIPTION
Several times, after adding or editing a contact, I missed a link which refers to his profile-page. This is now fixed