### PR TITLE
Prevention for DDoS attach through gprobe

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -2184,13 +2184,13 @@ function zrl_init(&$a) {
 
 		// Is it a DDoS attempt?
 		// The check fetches the cached value from gprobe to reduce the load for this system
-		$urlparts = parse_url($url);
+		$urlparts = parse_url($tmp_str);
 
 		$result = Cache::get("gprobe:".$urlparts["host"]);
 		if (!is_null($result)) {
 			$result = unserialize($result);
 			if ($result["network"] == NETWORK_FEED) {
-				logger("DDoS attempt detected for ".$urlparts["host"], LOGGER_DEBUG);
+				logger("DDoS attempt detected for ".$urlparts["host"]." by ".$_SERVER["REMOTE_ADDR"].". server data: ".print_r($_SERVER, true), LOGGER_DEBUG);
 				return;
 			}
 		}

--- a/boot.php
+++ b/boot.php
@@ -2181,6 +2181,20 @@ function get_my_url() {
 function zrl_init(&$a) {
 	$tmp_str = get_my_url();
 	if(validate_url($tmp_str)) {
+
+		// Is it a DDoS attempt?
+		// The check fetches the cached value from gprobe to reduce the load for this system
+		$urlparts = parse_url($url);
+
+		$result = Cache::get("gprobe:".$urlparts["host"]);
+		if (!is_null($result)) {
+			$result = unserialize($result);
+			if ($result["network"] == NETWORK_FEED) {
+				logger("DDoS attempt detected for ".$urlparts["host"], LOGGER_DEBUG);
+				return;
+			}
+		}
+
 		proc_run('php','include/gprobe.php',bin2hex($tmp_str));
 		$arr = array('zrl' => $tmp_str, 'url' => $a->cmd);
 		call_hooks('zrl_init',$arr);

--- a/include/gprobe.php
+++ b/include/gprobe.php
@@ -48,7 +48,7 @@ function gprobe_run(&$argv, &$argc){
 		if (!is_null($result)) {
 			$result = unserialize($result);
 			if ($result["network"] == NETWORK_FEED) {
-				logger("DDoS attempt detected for ".$urlparts["host"], LOGGER_DEBUG);
+				logger("DDoS attempt detected for ".$urlparts["host"]." by ".$_SERVER["REMOTE_ADDR"].". server data: ".print_r($_SERVER, true), LOGGER_DEBUG);
 				return;
 			}
 		}


### PR DESCRIPTION
By adding "zrl=domain.tld" it was possible for an attacker to do an attack to a remote website. The cache that was introduced in 3.3.3 improved this situation. But then an attacker simply had to make variations to the requested url. This change here should prevent that.

Further checks could be possible in future (checking of the referrer, the remote ip, ...)

This pull request addresses issue https://github.com/friendica/friendica/issues/1326