### PR TITLE
Do not attempt to create itemcache directory if it already exist.

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -2175,7 +2175,7 @@ function zrl_init(&$a) {
 	}
 }
 
-function zrl($s,$force = false) {
+function zrl($s,$force = false) {i
 	if(! strlen($s))
 		return $s;
 	if((! strpos($s,'/profile/')) && (! $force))
@@ -2335,7 +2335,9 @@ function get_itemcachepath() {
 
 	if ($temppath != "") {
 		$itemcache = $temppath."/itemcache";
-		mkdir($itemcache);
+		if(!file_exists($itemcache) && !is_dir($itemcache)) {
+			mkdir($itemcache);
+		}
 
 		if (is_dir($itemcache) AND is_writable($itemcache)) {
 			set_config("system", "itemcache", $itemcache);

--- a/boot.php
+++ b/boot.php
@@ -2175,7 +2175,7 @@ function zrl_init(&$a) {
 	}
 }
 
-function zrl($s,$force = false) {i
+function zrl($s,$force = false) {
 	if(! strlen($s))
 		return $s;
 	if((! strpos($s,'/profile/')) && (! $force))


### PR DESCRIPTION
I'm running friendica on FreeBSD, with more-or-less default PHP configuration (just changed memory limits). While cronjob is executed - it prints out warnings about $itemcache directory that already exist. This pull request will help get rid of them, and directory will be created only if neccessary.