### PR TITLE
Issue 1163: Feature allowing desktop-notifications

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -182,6 +182,18 @@
 					text = e.text().format("<span class='contactname'>"+e.attr('name')+"</span>");
 					html = notifications_tpl.format(e.attr('href'),e.attr('photo'), text, e.attr('date'), e.attr('seen'));
 					nnm.append(html);
+					
+					if(e.text().search('&rarr;') == 0) {
+                                         var notification = new Notification(document.title, {
+                                          body: e.text().replace('&rarr; ',''),
+                                          icon: e.attr('photo')
+                                         });
+   
+                                         // TODO (yet unsupported by most browsers): 
+                                         // Implement notification.onclick()
+                                         
+                                        notifyMarkAll();
+                                       }
 				});
 
 				$("img[data-src]", nnm).each(function(i, el){

--- a/mod/settings.php
+++ b/mod/settings.php
@@ -1182,6 +1182,10 @@ function settings_content(&$a) {
 		'$notify7'  => array('notify7', t('You are tagged in a post'), ($notify & NOTIFY_TAGSELF), NOTIFY_TAGSELF, ''),
 		'$notify8'  => array('notify8', t('You are poked/prodded/etc. in a post'), ($notify & NOTIFY_POKE), NOTIFY_POKE, ''),
 
+		'$desktop_notifications' => t('Activate desktop notifications'),
+                '$desktop_notifications_note' => t('Note: This is an experimental feature, as being not supported by each browser'),
+                '$desktop_notifications_success_message' => t('You will now receive desktop notifications!'),
+                
 		'$email_textonly' => array('email_textonly', t('Text-only notification emails'),
 									get_pconfig(local_user(),'system','email_textonly'),
 									t('Send text only notification emails, without the html part')),

--- a/view/templates/settings.tpl
+++ b/view/templates/settings.tpl
@@ -133,6 +133,11 @@
 {{include file="field_intcheckbox.tpl" field=$notify8}}
 </div>
 
+<div class="field">
+ <button onclick="javascript:Notification.requestPermission(function(perm){if(perm === 'granted')alert('{{$desktop_notifications_success_message}}');});return false;">{{$desktop_notifications}}</button>
+ <span class="field_help">{{$desktop_notifications_note}}</span>
+</div>
+
 {{include file="field_checkbox.tpl" field=$email_textonly}}
 
 </div>


### PR DESCRIPTION
See issue #1163 by annando.

This feature implements desktop-notifications and has (so far) worked on the latest version of my opera- & firefox-browser. A notification will be shown after this option has been activated by clicking the button in the settings-menu... Can you confirm that it's working? Is the user-icon shown?

Will implement notification.onclick() as soon as this function has been implemented browser-wide.

Thx, Felix