### PR TITLE
Events from the past aren't shown anymore (hopefully)

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -1830,11 +1830,11 @@ if(! function_exists('get_events')) {
 		$bd_short = t('F d');
 
 		$r = q("SELECT `event`.* FROM `event`
-				WHERE `event`.`uid` = %d AND `type` != 'birthday' AND `start` < '%s' AND `start` > '%s'
+				WHERE `event`.`uid` = %d AND `type` != 'birthday' AND `start` < '%s' AND `start` >= '%s'
 				ORDER BY `start` ASC ",
 				intval(local_user()),
 				dbesc(datetime_convert('UTC','UTC','now + 6 days')),
-				dbesc(datetime_convert('UTC','UTC','now - 1 days'))
+				dbesc(date("Y-m-d 00:00:00"))
 		);
 
 		if($r && count($r)) {

--- a/boot.php
+++ b/boot.php
@@ -1833,8 +1833,8 @@ if(! function_exists('get_events')) {
 				WHERE `event`.`uid` = %d AND `type` != 'birthday' AND `start` < '%s' AND `start` >= '%s'
 				ORDER BY `start` ASC ",
 				intval(local_user()),
-				dbesc(datetime_convert('UTC','UTC','now + 6 days')),
-				dbesc(date("Y-m-d 00:00:00"))
+				dbesc(datetime_convert('UTC','UTC','now + 7 days')),
+				dbesc(datetime_convert('UTC','UTC','now - 1 days'))
 		);
 
 		if($r && count($r)) {
@@ -1850,6 +1850,7 @@ if(! function_exists('get_events')) {
 			}
 			$classtoday = (($istoday) ? 'event-today' : '');
 
+			$skip = 0;
 
 			foreach($r as &$rr) {
 				if($rr['adjust'])
@@ -1863,6 +1864,12 @@ if(! function_exists('get_events')) {
 					$title = t('[No description]');
 
 				$strt = datetime_convert('UTC',$rr['convert'] ? $a->timezone : 'UTC',$rr['start']);
+
+				if(substr($strt,0,10) < datetime_convert('UTC',$a->timezone,'now','Y-m-d')) {
+					$skip++;
+					continue;
+				}
+
 				$today = ((substr($strt,0,10) === datetime_convert('UTC',$a->timezone,'now','Y-m-d')) ? true : false);
 
 				$rr['link'] = $md;
@@ -1877,7 +1884,7 @@ if(! function_exists('get_events')) {
 		return replace_macros($tpl, array(
 			'$baseurl' => $a->get_baseurl(),
 			'$classtoday' => $classtoday,
-			'$count' => count($r),
+			'$count' => count($r) - $skip,
 			'$event_reminders' => t('Event Reminders'),
 			'$event_title' => t('Events this week:'),
 			'$events' => $r,


### PR DESCRIPTION
See issue https://github.com/friendica/friendica/issues/1306

It still can happen that events from the past are shown. This will happen because of the timezones. The events in the database are stored as UTC. But the amount of past events should be reduced.