### PR TITLE
Diaspora/Libertree: problems with repeated posts

### DIFF
--- a/include/bbcode.php
+++ b/include/bbcode.php
@@ -509,9 +509,7 @@ function bb_ShareAttributes($share, $simplehtml) {
 			$text = $preshare.html_entity_decode("&#x2672; ", ENT_QUOTES, 'UTF-8').' '.$userid_compact.": <br />".$share[3];
 			break;
 		case 3: // Diaspora
-			$headline = '<div class="shared_header">';
-			$headline .= '<span><b>'.html_entity_decode("&#x2672; ", ENT_QUOTES, 'UTF-8').$userid.':</b></span>';
-			$headline .= "</div>";
+			$headline .= '<b>'.html_entity_decode("&#x2672; ", ENT_QUOTES, 'UTF-8').$userid.':</b><br />';
 
 			$text = trim($share[1]);
 
@@ -519,7 +517,7 @@ function bb_ShareAttributes($share, $simplehtml) {
 				$text .= "<hr />";
 
 			if (substr(normalise_link($link), 0, 19) != "http://twitter.com/") {
-				$text .= $headline.'<blockquote class="shared_content">'.trim($share[3])."</blockquote><br />";
+				$text .= $headline.'<blockquote>'.trim($share[3])."</blockquote><br />";
 
 				if ($link != "")
 					$text .= '<br /><a href="'.$link.'">[l]</a>';

--- a/include/diaspora.php
+++ b/include/diaspora.php
@@ -2512,6 +2512,26 @@ function diaspora_is_reshare($body) {
         if ($body == $attributes)
                 return(false);
 
+        $guid = "";
+        preg_match("/guid='(.*?)'/ism", $attributes, $matches);
+        if ($matches[1] != "")
+                $guid = $matches[1];
+
+        preg_match('/guid="(.*?)"/ism', $attributes, $matches);
+        if ($matches[1] != "")
+                $guid = $matches[1];
+
+	if ($guid != "") {
+		$r = q("SELECT `contact-id` FROM `item` WHERE `guid` = '%s' AND `network` IN ('%s', '%s') LIMIT 1",
+			dbesc($guid), NETWORK_DFRN, NETWORK_DIASPORA);
+		if ($r) {
+			$ret= array();
+			$ret["root_handle"] = diaspora_handle_from_contact($r[0]["contact-id"]);
+			$ret["root_guid"] = $guid;
+			return($ret);
+		}
+	}
+
         $profile = "";
         preg_match("/profile='(.*?)'/ism", $attributes, $matches);
         if ($matches[1] != "")


### PR DESCRIPTION
The conversion of Repeated posts to markdown had a problem with a missing linefeed before the quote.

See here:
https://pod.geraspora.de/posts/ec054ce714551e3835f1809861818844

Additionally there was a problem with the detection of posts that could be reshared with the Diaspora reshare function.