### PR TITLE
Bugfix: Avoid SQL warnings because of empty id list

### DIFF
--- a/include/api.php
+++ b/include/api.php
@@ -1186,7 +1186,8 @@
 
 		$idlist = implode(",", $idarray);
 
-		$r = q("UPDATE `item` SET `unseen` = 0 WHERE `unseen` AND `id` IN (%s)", $idlist);
+		if ($idlist != "")
+			$r = q("UPDATE `item` SET `unseen` = 0 WHERE `unseen` AND `id` IN (%s)", $idlist);
 
 
 		$data = array('$statuses' => $ret);


### PR DESCRIPTION
If an API call returns an empty result then this resulted in an SQL warning. The bug was introduced with the changed code for the "unseen" marker.