### PR TITLE
Liking of "red" comments is now possible

### DIFF
--- a/object/Item.php
+++ b/object/Item.php
@@ -287,22 +287,24 @@ class Item extends BaseObject {
 		}
 
 		// Disable features that aren't available in several networks
-		if (($item["item_network"] != "dfrn") AND isset($buttons["dislike"])) {
+		if (($item["item_network"] != NETWORK_DFRN) AND isset($buttons["dislike"])) {
 			unset($buttons["dislike"]);
 			$tagger = '';
 		}
 
-		if (($item["item_network"] == "feed") AND isset($buttons["like"]))
+		if (($item["item_network"] == NETWORK_FEED) AND isset($buttons["like"]))
 			unset($buttons["like"]);
 
-		if (($item["item_network"] == "mail") AND isset($buttons["like"]))
+		if (($item["item_network"] == NETWORK_MAIL) AND isset($buttons["like"]))
 			unset($buttons["like"]);
 
-		if (($item["item_network"] == "dspr") AND ($indent == 'comment') AND isset($buttons["like"]))
+		// Diaspora isn't able to do likes on comments - but red does
+		if (($item["item_network"] == NETWORK_DIASPORA) AND ($indent == 'comment') AND
+			!strstr($item["owner-link"], "/channel/") AND isset($buttons["like"]))
 			unset($buttons["like"]);
 
 		// Facebook can like comments - but it isn't programmed in the connector yet.
-		if (($item["item_network"] == "face") AND ($indent == 'comment') AND isset($buttons["like"]))
+		if (($item["item_network"] == NETWORK_FACEBOOK) AND ($indent == 'comment') AND isset($buttons["like"]))
 			unset($buttons["like"]);
 
 


### PR DESCRIPTION
"red" allows to like comments over the Diaspora federation. So we enable that.