### PR TITLE
after pull 1460 all notifications got marked read

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -192,7 +192,7 @@
                                          // TODO (yet unsupported by most browsers): 
                                          // Implement notification.onclick()
                                          
-                                        notifyMarkAll();
+                                         // notifyMarkAll();
                                        }
 				});
 


### PR DESCRIPTION
After pull request #1460 was merged (and tested in Firefox) no browser shows the notification counter (or rather short and is then nulled again). With this change the notifications wont get set read automatically.