### PR TITLE
regarding issue 1429

### DIFF
--- a/mod/profile.php
+++ b/mod/profile.php
@@ -44,7 +44,7 @@ function profile_init(&$a) {
 	if(x($a->profile,'openidserver'))
 		$a->page['htmlhead'] .= '<link rel="openid.server" href="' . $a->profile['openidserver'] . '" />' . "\r\n";
 	if(x($a->profile,'openid')) {
-		$delegate = ((strstr($a->profile['openid'],'://')) ? $a->profile['openid'] : 'http://' . $a->profile['openid']);
+		$delegate = ((strstr($a->profile['openid'],'://')) ? $a->profile['openid'] : 'https://' . $a->profile['openid']);
 		$a->page['htmlhead'] .= '<link rel="openid.delegate" href="' . $delegate . '" />' . "\r\n";
 	}
 	// site block

--- a/mod/settings.php
+++ b/mod/settings.php
@@ -474,7 +474,7 @@ function settings_post(&$a) {
 	$str_contact_deny  = perms2str($_POST['contact_deny']);
 
 	$openidserver = $a->user['openidserver'];
-	$openid = normalise_openid($openid);
+	//$openid = normalise_openid($openid);
 
 	// If openid has changed or if there's an openid but no openidserver, try and discover it.
 
@@ -1002,7 +1002,7 @@ function settings_content(&$a) {
 		$openid_field = false;
 	}
 	else {
-		$openid_field = array('openid_url', t('OpenID:'),$openid, t("\x28Optional\x29 Allow this OpenID to login to this account."));
+		$openid_field = array('openid_url', t('OpenID:'),$openid, t("\x28Optional\x29 Allow this OpenID to login to this account."), "", "", "url");
 	}
 
 


### PR DESCRIPTION
This patch removes the normalisation of OpenID URLs and adds a HTML5/browser check to the URL field to ensure it is a valid URL. Additionally the fallback protocol, in case of no defined protocol, for the notation of OpenID delegation on the profile page is changed from http to https.

This addresses #1429 