### PR TITLE
preserve local indexes of friendica database when updating

### DIFF
--- a/include/dbstructure.php
+++ b/include/dbstructure.php
@@ -151,15 +151,15 @@ function update_structure($verbose, $action, $tables=null, $definition=null) {
                         if(false === $r)
 				$errors .=  t('Errors encountered creating database tables.').$name.EOL;
 		} else {
-			// Drop the index if it isn't present in the definition
+			// Drop the index if it isn't present in the definition and index name doesn't start with "local_"
 			foreach ($database[$name]["indexes"] AS $indexname => $fieldnames)
-				if (!isset($structure["indexes"][$indexname])) {
+				if (!isset($structure["indexes"][$indexname]) && substring($indexname, 0, 5) != 'local_') {
 					$sql2=db_drop_index($indexname);
 					if ($sql3 == "")
 						$sql3 = "ALTER TABLE `".$name."` ".$sql2;
 					else
 						$sql3 .= ", ".$sql2;
-				}
+			}
 
 			// Compare the field structure field by field
 			foreach ($structure["fields"] AS $fieldname => $parameters) {

--- a/include/dbstructure.php
+++ b/include/dbstructure.php
@@ -159,7 +159,7 @@ function update_structure($verbose, $action, $tables=null, $definition=null) {
 						$sql3 = "ALTER TABLE `".$name."` ".$sql2;
 					else
 						$sql3 .= ", ".$sql2;
-			}
+				}
 
 			// Compare the field structure field by field
 			foreach ($structure["fields"] AS $fieldname => $parameters) {


### PR DESCRIPTION
When updating friendica deletes all unknown indexes in the friendica database. This patch preserves those that start with 'local_', so friendica admins can decide if they want to add some extra indexes and keep them after update.