### PR TITLE
New function that detects red matrix accounts

### DIFF
--- a/include/diaspora.php
+++ b/include/diaspora.php
@@ -779,6 +779,10 @@ function diaspora_post_allow($importer,$contact) {
 	return false;
 }
 
+function diaspora_is_redmatrix($url) {
+	return(strstr($url, "/channel/"));
+}
+
 function diaspora_plink($addr, $guid) {
 	$r = q("SELECT `url`, `nick` FROM `fcontact` WHERE `addr`='%s' LIMIT 1", $addr);
 
@@ -786,7 +790,7 @@ function diaspora_plink($addr, $guid) {
 	if (!$r)
 		return 'https://'.substr($addr,strpos($addr,'@')+1).'/posts/'.$guid;
 
-	if (strstr($r[0]["url"], "/channel/"))
+	if (diaspora_is_redmatrix($r[0]["url"]))
 		return $r[0]["url"]."/?f=&mid=".$guid;
 
 	return 'https://'.substr($addr,strpos($addr,'@')+1).'/posts/'.$guid;
@@ -841,7 +845,8 @@ function diaspora_post($importer,$xml,$msg) {
 	$body = diaspora2bb($xml->raw_message);
 
 	// Add OEmbed and other information to the body
-	$body = add_page_info_to_body($body, false, true);
+	if (!diaspora_is_redmatrix($contact['url']))
+		$body = add_page_info_to_body($body, false, true);
 
 	$datarray = array();
 

--- a/object/Item.php
+++ b/object/Item.php
@@ -82,6 +82,7 @@ class Item extends BaseObject {
 	 */
 	public function get_template_data($alike, $dlike, $thread_level=1) {
 		require_once("mod/proxy.php");
+		require_once("include/diaspora.php");
 
 		$result = array();
 
@@ -300,7 +301,7 @@ class Item extends BaseObject {
 
 		// Diaspora isn't able to do likes on comments - but red does
 		if (($item["item_network"] == NETWORK_DIASPORA) AND ($indent == 'comment') AND
-			!strstr($item["owner-link"], "/channel/") AND isset($buttons["like"]))
+			!diaspora_is_redmatrix($item["owner-link"]) AND isset($buttons["like"]))
 			unset($buttons["like"]);
 
 		// Facebook can like comments - but it isn't programmed in the connector yet.


### PR DESCRIPTION
There were some hardcoded checks for red matrix accounts that are now exchanged with a new function.

Additionally the function "add_page_info_to_body" is now only called with "real" Diaspora accounts. 