### PR TITLE
API: The "conversation" function can now be called with every message id

### DIFF
--- a/include/api.php
+++ b/include/api.php
@@ -1369,6 +1369,10 @@
 
 		logger('API: api_conversation_show: '.$id);
 
+		$r = q("SELECT `parent` FROM `item` WHERE `id` = %d", intval($id));
+		if ($r)
+			$id = $r[0]["parent"];
+
 		$sql_extra = '';
 
 		if ($max_id > 0)


### PR DESCRIPTION
The "conversation" api call is implemented for a better Twidere support. It is an undocumented Twitter API call that we copied since Twidere is using it. It seems as if it is intended to work not only with the thread id as parameter but with the id of any item in the conversation. That is changed now.