### PR TITLE
OEmbed: Automatic height, changed behaviour in attachments

### DIFF
--- a/include/bbcode.php
+++ b/include/bbcode.php
@@ -4,7 +4,7 @@ require_once('include/event.php');
 
 function bb_attachment($Text, $plaintext = false, $tryoembed = true) {
 	$Text = preg_replace_callback("/(.*?)\[attachment(.*?)\](.*?)\[\/attachment\]/ism",
-		function ($match) use ($plaintext){
+		function ($match) use ($plaintext, $tryoembed){
 
 			$attributes = $match[2];
 
@@ -83,14 +83,18 @@ function bb_attachment($Text, $plaintext = false, $tryoembed = true) {
 				else
 					$oembed = $bookmark[0];
 
-				if (($image != "") AND !strstr(strtolower($oembed), "<img "))
-					$text .= sprintf('<a href="%s" target="_blank"><img src="%s" alt="" title="%s" class="attachment-image" /></a><br />', $url, $image, $title);
-				elseif (($preview != "") AND !strstr(strtolower($oembed), "<img "))
-					$text .= sprintf('<a href="%s" target="_blank"><img src="%s" alt="" title="%s" class="attachment-preview" /></a><br />', $url, $preview, $title);
+				if (strstr(strtolower($oembed), "<iframe "))
+					$text = $oembed;
+				else {
+					if (($image != "") AND !strstr(strtolower($oembed), "<img "))
+						$text .= sprintf('<a href="%s" target="_blank"><img src="%s" alt="" title="%s" class="attachment-image" /></a><br />', $url, $image, $title);
+					elseif (($preview != "") AND !strstr(strtolower($oembed), "<img "))
+						$text .= sprintf('<a href="%s" target="_blank"><img src="%s" alt="" title="%s" class="attachment-preview" /></a><br />', $url, $preview, $title);
 
-				$text .= $oembed;
+					$text .= $oembed;
 
-				$text .= sprintf('<blockquote>%s</blockquote></span>', trim($match[3]));
+					$text .= sprintf('<blockquote>%s</blockquote></span>', trim($match[3]));
+				}
 			}
 
 			return($match[1].$text);

--- a/include/oembed.php
+++ b/include/oembed.php
@@ -199,10 +199,15 @@ function oembed_format_object($j){
 }
 
 function oembed_iframe($src,$width,$height) {
+
 	if(! $width || strstr($width,'%'))
 		$width = '640';
-	if(! $height || strstr($height,'%'))
+	if(! $height || strstr($height,'%')) {
 		$height = '300';
+		$resize = 'onload="resizeIframe(this);"';
+	} else
+		$resize = '';
+
 	// try and leave some room for the description line.
 	$height = intval($height) + 80;
 	$width  = intval($width) + 40;
@@ -210,7 +215,7 @@ function oembed_iframe($src,$width,$height) {
 	$a = get_app();
 
 	$s = $a->get_baseurl()."/oembed/".base64url_encode($src);
-	return '<iframe class="embed_rich" height="' . $height . '" width="' . $width . '" src="' . $s . '" frameborder="no" >' . t('Embedded content') . '</iframe>';
+	return '<iframe '.$resize.' class="embed_rich" height="'.$height.'" width="'.$width.'" src="'.$s.'" frameborder="no">'.t('Embedded content').'</iframe>';
 
 }
 

--- a/js/main.js
+++ b/js/main.js
@@ -1,3 +1,7 @@
+  function resizeIframe(obj) {
+    obj.style.height = 0;
+    obj.style.height = obj.contentWindow.document.body.scrollHeight + 'px';
+  }
 
   function openClose(theID) {
     if(document.getElementById(theID).style.display == "block") { 


### PR DESCRIPTION
- IFrames are now resized automatically if there is no height specified in the OEmbed data.
- In attachments the system now displays **either** the OEmbed data **or** the attachment data. (Previous behaviour: data from both sources were displayed)