### PR TITLE
Issue #1504: Creating groups directly from the sidebar in contacts-page

### DIFF
--- a/include/group.php
+++ b/include/group.php
@@ -270,6 +270,8 @@ function group_side($every="contacts",$each="group",$edit = false, $group_id = 0
 		'$title'		=> t('Groups'),
 		'$edittext'     => t('Edit group'),
 		'$createtext' 	=> t('Create a new group'),
+    '$creategroup' => t('Group Name: '),
+    '$form_security_token' => get_form_security_token("group_edit"),
 		'$ungrouped'    => (($every === 'contacts') ? t('Contacts not in any group') : ''),
 		'$groups'		=> $groups,
 		'$add'			=> t('add'),

--- a/view/templates/group_side.tpl
+++ b/view/templates/group_side.tpl
@@ -1,4 +1,3 @@
-
 <div class="widget" id="group-sidebar">
 <h3>{{$title}}</h3>
 
@@ -22,7 +21,11 @@
 	</ul>
 	</div>
   <div id="sidebar-new-group">
-  <a href="group/new">{{$createtext}}</a>
+  <a onclick="javascript:$('#group-new-form').fadeIn('fast');return false;">{{$createtext}}</a>
+  <form id="group-new-form" action="group/new" method="post" style="display:none;">
+   <input type="hidden" name="form_security_token" value="{{$form_security_token}}">
+   <input name="groupname" id="id_groupname" placeholder="{{$creategroup}}">
+  </form>
   </div>
   {{if $ungrouped}}
   <div id="sidebar-ungrouped">


### PR DESCRIPTION
A group can now be created without the need of accessing group/new/. 