### PR TITLE
OStatus and Diaspora improvements

### DIFF
--- a/include/diaspora.php
+++ b/include/diaspora.php
@@ -1138,7 +1138,6 @@ function diaspora_reshare($importer,$xml,$msg) {
 			$orig_created = $r[0]["created"];
 			$orig_plink = $r[0]["plink"];
 			$orig_uri = $r[0]["uri"];
-			$create_original_post = ($body != "");
 			$object = $r[0]["object"];
 			$objecttype = $r[0]["object-type"];
 		}
@@ -1239,8 +1238,9 @@ function diaspora_reshare($importer,$xml,$msg) {
 		$datarray2['uid'] = 0;
 		$datarray2['contact-id'] = get_contact($person['url'], 0);
 		$datarray2['guid'] = $orig_guid;
-		$datarray2['uri'] = $orig_uri;
+		$datarray2['uri'] = $datarray2['parent-uri'] = $orig_uri;
 		$datarray2['changed'] = $datarray2['created'] = $datarray2['edited'] = $datarray2['commented'] = $datarray2['received'] = datetime_convert('UTC','UTC',$orig_created);
+		$datarray2['parent'] = 0;
 		$datarray2['plink'] = $orig_plink;
 
 		$datarray2['author-name'] = $person['name'];

--- a/include/items.php
+++ b/include/items.php
@@ -1351,9 +1351,22 @@ function item_store($arr,$force_parent = false, $notify = false, $dontcache = fa
 		dbesc($arr['uri']),
 		intval($arr['uid'])
 	);
+
 	if($r && count($r)) {
-		logger('item-store: duplicate item ignored. ' . print_r($arr,true));
+		logger('duplicated item with the same uri found. ' . print_r($arr,true));
 		return 0;
+	} else {
+		// Check for an existing post with the same content. There seems to be a problem with OStatus.
+		$r = q("SELECT `id` FROM `item` WHERE `body` = '%s' AND `created` = '%s' AND `contact-id` = %d AND `uid` = %d LIMIT 1",
+			dbesc($arr['body']),
+			dbesc($arr['created']),
+			intval($arr['contact-id']),
+			intval($arr['uid'])
+		);
+		if($r && count($r)) {
+			logger('duplicated item with the same body found. ' . print_r($arr,true));
+			return 0;
+		}
 	}
 
 	// Is this item available in the global items (with uid=0)?

--- a/include/items.php
+++ b/include/items.php
@@ -864,7 +864,7 @@ function get_atom_elements($feed, $item, $contact = array()) {
 			$conversation = array_shift($link["attribs"]);
 
 			if ($conversation["rel"] == "ostatus:conversation") {
-				$res["ostatus_conversation"] = $conversation["href"];
+				$res["ostatus_conversation"] = ostatus_convert_href($conversation["href"]);
 				logger('get_atom_elements: found conversation url '.$res["ostatus_conversation"]);
 			}
 		};
@@ -1090,6 +1090,14 @@ function item_store($arr,$force_parent = false, $notify = false, $dontcache = fa
 		unset($arr['dsprsig']);
 	}
 
+	// Converting the plink
+	if ($arr['network'] == NETWORK_OSTATUS) {
+		if (isset($arr['plink']))
+			$arr['plink'] = ostatus_convert_href($arr['plink']);
+		elseif (isset($arr['uri']))
+			$arr['plink'] = ostatus_convert_href($arr['uri']);
+	}
+
 	// if an OStatus conversation url was passed in, it is stored and then
 	// removed from the array.
 	$ostatus_conversation = null;
@@ -1115,7 +1123,7 @@ function item_store($arr,$force_parent = false, $notify = false, $dontcache = fa
 
 	/* check for create  date and expire time */
 	$uid = intval($arr['uid']);
-	$r = q("SELECT expire FROM user WHERE uid = %d", $uid);
+	$r = q("SELECT expire FROM user WHERE uid = %d", intval($uid));
 	if(count($r)) {
 		$expire_interval = $r[0]['expire'];
 		if ($expire_interval>0) {

--- a/include/ostatus_conversation.php
+++ b/include/ostatus_conversation.php
@@ -2,7 +2,30 @@
 define('OSTATUS_DEFAULT_POLL_INTERVAL', 30); // given in minutes
 define('OSTATUS_DEFAULT_POLL_TIMEFRAME', 1440); // given in minutes
 
-function check_conversations() {
+function ostatus_convert_href($href) {
+	$elements = explode(":",$href);
+
+	if ((count($elements) <= 2) OR ($elements[0] != "tag"))
+		return $href;
+
+	$server = explode(",", $elements[1]);
+	$conversation = explode("=", $elements[2]);
+
+	if ((count($elements) == 4) AND ($elements[2] == "post"))
+		return "http://".$server[0]."/notice/".$elements[3];
+
+	if ((count($conversation) != 2) OR ($conversation[1] ==""))
+		return $href;
+
+	if ($elements[3] == "objectType=thread")
+		return "http://".$server[0]."/conversation/".$conversation[1];
+	else
+		return "http://".$server[0]."/notice/".$conversation[1];
+
+	return $href;
+}
+
+function check_conversations($override = false) {
         $last = get_config('system','ostatus_last_poll');
 
         $poll_interval = intval(get_config('system','ostatus_poll_interval'));
@@ -10,16 +33,16 @@ function check_conversations() {
                 $poll_interval = OSTATUS_DEFAULT_POLL_INTERVAL;
 
 	// Don't poll if the interval is set negative
-	if ($poll_interval < 0)
+	if (($poll_interval < 0) AND !$override)
 		return;
 
         $poll_timeframe = intval(get_config('system','ostatus_poll_timeframe'));
-        if(! $poll_timeframe)
+        if (!$poll_timeframe)
                 $poll_timeframe = OSTATUS_DEFAULT_POLL_TIMEFRAME;
 
-        if($last) {
+        if ($last AND !$override) {
                 $next = $last + ($poll_interval * 60);
-                if($next > time()) {
+                if ($next > time()) {
                         logger('poll interval not reached');
                         return;
                 }
@@ -36,13 +59,15 @@ function check_conversations() {
                 complete_conversation($id, $url);
         }
 
-        logger(' cron_end');
+        logger('cron_end');
 
         set_config('system','ostatus_last_poll', time());
 }
 
 function complete_conversation($itemid, $conversation_url, $only_add_conversation = false) {
 	global $a;
+
+	$conversation_url = ostatus_convert_href($conversation_url);
 
 	if (intval(get_config('system','ostatus_poll_interval')) == -2)
 		return;
@@ -107,15 +132,23 @@ function complete_conversation($itemid, $conversation_url, $only_add_conversatio
 	$items = array_reverse($items);
 
 	foreach ($items as $single_conv) {
-		// status.net changed the format of the activity streams. This is a quick fix.
-		if (@is_string($single_conv->object->id))
+		if (!isset($single_conv->id) AND isset($single_conv->object->id))
 			$single_conv->id = $single_conv->object->id;
+		elseif (!isset($single_conv->id) AND isset($single_conv->object->url))
+			$single_conv->id = $single_conv->object->url;
 
-		if (@!$single_conv->id AND $single_conv->provider->url AND $single_conv->statusnet_notice_info->local_id)
-			$single_conv->id = $single_conv->provider->url."notice/".$single_conv->statusnet_notice_info->local_id;
+		$plink = ostatus_convert_href($single_conv->id);
+
+		if (isset($single_conv->provider->url) AND isset($single_conv->statusnet_notice_info->local_id))
+			$plink = $single_conv->provider->url."notice/".$single_conv->statusnet_notice_info->local_id;
+		elseif (isset($single_conv->provider->url) AND isset($single_conv->statusnet->notice_info->local_id))
+			$plink = $single_conv->provider->url."notice/".$single_conv->statusnet->notice_info->local_id;
 
 		if (@!$single_conv->id)
 			continue;
+
+		//logger("OStatus conversation id ".$single_conv->id, LOGGER_DEBUG);
+		//logger("OStatus conversation data ".print_r($single_conv, true), LOGGER_DEBUG);
 
 		if ($first_id == "") {
 			$first_id = $single_conv->id;
@@ -136,8 +169,13 @@ function complete_conversation($itemid, $conversation_url, $only_add_conversatio
 		else
 			$parent_uri = $parent["uri"];
 
-		$message_exists = q("SELECT `id` FROM `item` WHERE `uid` = %d AND `uri` = '%s' LIMIT 1",
+		$message_exists = q("SELECT `id` FROM `item` WHERE `uid` = %d AND `plink` = '%s' LIMIT 1",
+							intval($message["uid"]), dbesc($plink));
+
+		if (!$message_exists)
+			$message_exists = q("SELECT `id` FROM `item` WHERE `uid` = %d AND `uri` = '%s' LIMIT 1",
 							intval($message["uid"]), dbesc($single_conv->id));
+
 		if ($message_exists) {
 			if ($parent["id"] != 0) {
 				$existing_message = $message_exists[0];
@@ -166,7 +204,7 @@ function complete_conversation($itemid, $conversation_url, $only_add_conversatio
 		$arr = array();
 		$arr["network"] = NETWORK_OSTATUS;
 		$arr["uri"] = $single_conv->id;
-		$arr["plink"] = $single_conv->id;
+		$arr["plink"] = $plink;
 		$arr["uid"] = $message["uid"];
 		$arr["contact-id"] = $contact_id;
 		if ($parent["id"] != 0)
@@ -190,9 +228,16 @@ function complete_conversation($itemid, $conversation_url, $only_add_conversatio
 		$arr["author-link"] = $single_conv->actor->id;
 		$arr["author-avatar"] = $single_conv->actor->image->url;
 		$arr["body"] = html2bbcode($single_conv->content);
-		$arr["app"] = strip_tags($single_conv->statusnet_notice_info->source);
-		if ($arr["app"] == "")
+
+		if (isset($single_conv->statusnet->notice_info->source))
+			$arr["app"] = strip_tags($single_conv->statusnet->notice_info->source);
+		elseif (isset($single_conv->statusnet_notice_info->source))
+			$arr["app"] = strip_tags($single_conv->statusnet_notice_info->source);
+		elseif (isset($single_conv->provider->displayName))
 			$arr["app"] = $single_conv->provider->displayName;
+		else
+			$arr["app"] = "OStatus";
+
 		$arr["verb"] = $parent["verb"];
 		$arr["visible"] = $parent["visible"];
 		$arr["location"] = $single_conv->location->displayName;
@@ -205,6 +250,8 @@ function complete_conversation($itemid, $conversation_url, $only_add_conversatio
 			unset($arr["coord"]);
 
 		$newitem = item_store($arr);
+
+		logger('Stored new item '.$plink.' under id '.$newitem, LOGGER_DEBUG);
 
 		// Add the conversation entry (but don't fetch the whole conversation)
 		complete_conversation($newitem, $conversation_url, true);

--- a/include/ostatus_conversation.php
+++ b/include/ostatus_conversation.php
@@ -139,29 +139,14 @@ function complete_conversation($itemid, $conversation_url, $only_add_conversatio
 
 		logger("Got id ".$single_conv->id, LOGGER_DEBUG);
 
-		//if (!isset($single_conv->id) AND isset($single_conv->object->id))
-		//	$single_conv->id = $single_conv->object->id;
-		//elseif (!isset($single_conv->id) AND isset($single_conv->object->url))
-		//	$single_conv->id = $single_conv->object->url;
-
 		$plink = ostatus_convert_href($single_conv->id);
 		if (isset($single_conv->object->url))
 			$plink = ostatus_convert_href($single_conv->object->url);
 
 		logger("Got url ".$plink, LOGGER_DEBUG);
 
-		//if (isset($single_conv->provider->url) AND isset($single_conv->statusnet_notice_info->local_id))
-		//	$plink = $single_conv->provider->url."notice/".$single_conv->statusnet_notice_info->local_id;
-		//elseif (isset($single_conv->provider->url) AND isset($single_conv->statusnet->notice_info->local_id))
-		//	$plink = $single_conv->provider->url."notice/".$single_conv->statusnet->notice_info->local_id;
-		//elseif (isset($single_conv->provider->url) AND isset($single_conv->status_net->notice_info->local_id))
-		//	$plink = $single_conv->provider->url."notice/".$single_conv->status_net->notice_info->local_id;
-
 		if (@!$single_conv->id)
 			continue;
-
-		//logger("OStatus conversation id ".$single_conv->id, LOGGER_DEBUG);
-		//logger("OStatus conversation data ".print_r($single_conv, true), LOGGER_DEBUG);
 
 		if ($first_id == "") {
 			$first_id = $single_conv->id;


### PR DESCRIPTION
This is a bigger pull request. It started with some small changes to Diaspora:
* the plink path for Friendica contacts that are transported via Diaspora protocol is now correct
* photo posts now are treated differently when fetching additional data. This should reduce the problem that the fetching of additional data duplicated the picture.

While working at Diaspora I recognized several OStatus issues and started working at it :)

First of all: I realized that we should move the parsing of OStatus messages to a separate function. This should reduce complexity. I guess I will start working at it in a different pull request in the next days.

The improvements to OStatus:
* There should be no duplicates anymore, see issue https://github.com/friendica/friendica/issues/1552 - but: It will still happen that repeated items got multiplicated one time. This will be fixed when there is a new function to read the OStatus XML.
* The values for uri and plink are now set correctly at any situation (with the exception of repeated items)
* The author link is now set to the format that we normally use (servername.tld/username). This fixes the problem that OStatus messages were always recognized as repeated items by some mobile clients
* Completing OStatus threads should now work more reliable. There was a protocol change in the OStatus protocol that changed the format of the conversation uri.
* There are some additional checks for duplicated posts