### PR TITLE
Performance improvements when searching for existing GUIDs

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -18,7 +18,7 @@ define ( 'FRIENDICA_PLATFORM',     'Friendica');
 define ( 'FRIENDICA_CODENAME',     'Lily of the valley');
 define ( 'FRIENDICA_VERSION',      '3.4.0' );
 define ( 'DFRN_PROTOCOL_VERSION',  '2.23'    );
-define ( 'DB_UPDATE_VERSION',      1184      );
+define ( 'DB_UPDATE_VERSION',      1185      );
 define ( 'EOL',                    "<br />\r\n"     );
 define ( 'ATOM_TIME',              'Y-m-d\TH:i:s\Z' );
 

--- a/database.sql
+++ b/database.sql
@@ -1,6 +1,6 @@
 -- ------------------------------------------
 -- Friendica 3.4.0 (Lily of the valley)
--- DB_UPDATE_VERSION 1183
+-- DB_UPDATE_VERSION 1185
 -- ------------------------------------------
 
 
@@ -358,7 +358,12 @@ CREATE TABLE IF NOT EXISTS `group_member` (
 CREATE TABLE IF NOT EXISTS `guid` (
 	`id` int(10) unsigned NOT NULL auto_increment PRIMARY KEY,
 	`guid` varchar(255) NOT NULL DEFAULT '',
-	 INDEX `guid` (`guid`)
+	`plink` varchar(255) NOT NULL DEFAULT '',
+	`uri` varchar(255) NOT NULL DEFAULT '',
+	`network` varchar(32) NOT NULL DEFAULT '',
+	 INDEX `guid` (`guid`),
+	 INDEX `plink` (`plink`),
+	 INDEX `uri` (`uri`)
 ) DEFAULT CHARSET=utf8;
 
 --
@@ -587,6 +592,7 @@ CREATE TABLE IF NOT EXISTS `notify` (
 	`msg` mediumtext NOT NULL,
 	`uid` int(11) NOT NULL DEFAULT 0,
 	`link` varchar(255) NOT NULL DEFAULT '',
+	`iid` int(11) NOT NULL DEFAULT 0,
 	`parent` int(11) NOT NULL DEFAULT 0,
 	`seen` tinyint(1) NOT NULL DEFAULT 0,
 	`verb` varchar(255) NOT NULL DEFAULT '',

--- a/include/dbstructure.php
+++ b/include/dbstructure.php
@@ -687,10 +687,15 @@ function db_definition() {
 			"fields" => array(
 					"id" => array("type" => "int(10) unsigned", "not null" => "1", "extra" => "auto_increment", "primary" => "1"),
 					"guid" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
+					"plink" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
+					"uri" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
+					"network" => array("type" => "varchar(32)", "not null" => "1", "default" => ""),
 					),
 			"indexes" => array(
 					"PRIMARY" => array("id"),
 					"guid" => array("guid"),
+					"plink" => array("plink"),
+					"uri" => array("uri"),
 					)
 			);
 	$database["hook"] = array(

--- a/include/items.php
+++ b/include/items.php
@@ -1166,7 +1166,7 @@ function item_store($arr,$force_parent = false, $notify = false, $dontcache = fa
 			}
 		}
 	}
-
+/*
 	// If there is no guid then take the same guid that was taken before for the same uri
 	if ((trim($arr['guid']) == "") AND (trim($arr['uri']) != "")) {
 		logger('item_store: checking for an existing guid for uri '.$arr['uri'], LOGGER_DEBUG);
@@ -1192,7 +1192,7 @@ function item_store($arr,$force_parent = false, $notify = false, $dontcache = fa
 			logger('item_store: found guid '.$arr['guid'].' for plink '.$arr['plink'], LOGGER_DEBUG);
 		}
 	}
-
+*/
 	// Shouldn't happen but we want to make absolutely sure it doesn't leak from a plugin.
 	// Deactivated, since the bbcode parser can handle with it - and it destroys posts with some smileys that contain "<"
 	//if((strpos($arr['body'],'<') !== false) || (strpos($arr['body'],'>') !== false))

--- a/include/items.php
+++ b/include/items.php
@@ -1099,7 +1099,15 @@ function encode_rel_links($links) {
 	return xmlify($o);
 }
 
+function add_guid($item) {
+	$r = q("SELECT `guid` FROM `guid` WHERE `guid` = '%s' LIMIT 1", dbesc($item["guid"]));
+	if ($r)
+		return;
 
+	q("INSERT INTO `guid` (`guid`,`plink`,`uri`,`network`) VALUES ('%s','%s','%s','%s')",
+		dbesc($item["guid"]), dbesc($item["plink"]),
+		dbesc($item["uri"]), dbesc($item["network"]));
+}
 
 function item_store($arr,$force_parent = false, $notify = false, $dontcache = false) {
 
@@ -1166,13 +1174,12 @@ function item_store($arr,$force_parent = false, $notify = false, $dontcache = fa
 			}
 		}
 	}
-/*
+
 	// If there is no guid then take the same guid that was taken before for the same uri
-	if ((trim($arr['guid']) == "") AND (trim($arr['uri']) != "")) {
+	if ((trim($arr['guid']) == "") AND (trim($arr['uri']) != "") AND (trim($arr['network']) != "")) {
 		logger('item_store: checking for an existing guid for uri '.$arr['uri'], LOGGER_DEBUG);
-		$r = q("SELECT `guid` FROM `item` WHERE `uri` = '%s' AND `guid` != '' LIMIT 1",
-			dbesc(trim($arr['uri']))
-		);
+		$r = q("SELECT `guid` FROM `guid` WHERE `uri` = '%s' AND `network` = '%s' LIMIT 1",
+			dbesc(trim($arr['uri'])), dbesc(trim($arr['network'])));
 
 		if(count($r)) {
 			$arr['guid'] = $r[0]["guid"];
@@ -1181,18 +1188,17 @@ function item_store($arr,$force_parent = false, $notify = false, $dontcache = fa
 	}
 
 	// If there is no guid then take the same guid that was taken before for the same plink
-	if ((trim($arr['guid']) == "") AND (trim($arr['plink']) != "")) {
+	if ((trim($arr['guid']) == "") AND (trim($arr['plink']) != "") AND (trim($arr['network']) != "")) {
 		logger('item_store: checking for an existing guid for plink '.$arr['plink'], LOGGER_DEBUG);
-		$r = q("SELECT `guid` FROM `item` WHERE `plink` = '%s' AND `guid` != '' LIMIT 1",
-			dbesc(trim($arr['plink']))
-		);
+		$r = q("SELECT `guid` FROM `guid` WHERE `plink` = '%s' AND `network` = '%s' LIMIT 1",
+			dbesc(trim($arr['plink'])), dbesc(trim($arr['network'])));
 
 		if(count($r)) {
 			$arr['guid'] = $r[0]["guid"];
 			logger('item_store: found guid '.$arr['guid'].' for plink '.$arr['plink'], LOGGER_DEBUG);
 		}
 	}
-*/
+
 	// Shouldn't happen but we want to make absolutely sure it doesn't leak from a plugin.
 	// Deactivated, since the bbcode parser can handle with it - and it destroys posts with some smileys that contain "<"
 	//if((strpos($arr['body'],'<') !== false) || (strpos($arr['body'],'>') !== false))
@@ -1476,6 +1482,10 @@ function item_store($arr,$force_parent = false, $notify = false, $dontcache = fa
 	);
 
 	if(count($r)) {
+
+		// Store the guid and other relevant data
+		add_guid($arr);
+
 		$current_post = $r[0]['id'];
 		logger('item_store: created item ' . $current_post);
 

--- a/mod/item.php
+++ b/mod/item.php
@@ -864,6 +864,9 @@ function item_post(&$a) {
 		// NOTREACHED
 	}
 
+	// Store the guid and other relevant data
+	add_guid($datarray);
+
 	$post_id = $r[0]['id'];
 	logger('mod_item: saved item ' . $post_id);
 

--- a/update.php
+++ b/update.php
@@ -1,6 +1,6 @@
 <?php
 
-define( 'UPDATE_VERSION' , 1184 );
+define( 'UPDATE_VERSION' , 1185 );
 
 /**
  *


### PR DESCRIPTION
One of the last pull requests added the functionality to search for a GUID for a post with the same "plink". Due to missing indexes this slowed down the system extremely. 

This programming here now has the same goal - but solves the problem in another way.