### PR TITLE
Improved OEmbed detection

### DIFF
--- a/include/oembed.php
+++ b/include/oembed.php
@@ -37,9 +37,14 @@ function oembed_fetch_url($embedurl, $no_rich_type = false){
 				if ($dom){
 					$xpath = new DOMXPath($dom);
 					$attr = "oembed";
-
 					$xattr = oe_build_xpath("class","oembed");
 					$entries = $xpath->query("//link[@type='application/json+oembed']");
+					foreach($entries as $e){
+						$href = $e->getAttributeNode("href")->nodeValue;
+						$txt = fetch_url($href . '&maxwidth=' . $a->videowidth);
+						break;
+					}
+					$entries = $xpath->query("//link[@type='text/json+oembed']");
 					foreach($entries as $e){
 						$href = $e->getAttributeNode("href")->nodeValue;
 						$txt = fetch_url($href . '&maxwidth=' . $a->videowidth);


### PR DESCRIPTION
While checking issue https://github.com/friendica/friendica/issues/1640 it was detected that the free OEmbed service "oohembed.com" isn't working anymore. Admins now have to fetch an API key at embed.ly. This can be done with the following parameter in .htconfig.php:

````
$a->config['system']['embedly'] = "yourembedlykey";
````

This was already possible. This pull request improves the detection for OEmbed data, so that we don't need that service.