### PR TITLE
Better detection for the mobile client to avoid "{0}" in notifications

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -379,6 +379,7 @@ if(! class_exists('App')) {
 		public  $identities;
 		public	$is_mobile;
 		public	$is_tablet;
+		public	$is_friendica_app;
 		public	$performance = array();
 
 		public $nav_sel;
@@ -595,6 +596,9 @@ if(! class_exists('App')) {
 			$mobile_detect = new Mobile_Detect();
 			$this->is_mobile = $mobile_detect->isMobile();
 			$this->is_tablet = $mobile_detect->isTablet();
+
+			// Friendica-Client
+			$this->is_friendica_app = ($_SERVER['HTTP_USER_AGENT'] == "Apache-HttpClient/UNAVAILABLE (java 1.4)");
 
 			/**
 			 * register template engines
@@ -904,6 +908,10 @@ if(! class_exists('App')) {
 
 		function get_useragent() {
 			return(FRIENDICA_PLATFORM." '".FRIENDICA_CODENAME."' ".FRIENDICA_VERSION."-".DB_UPDATE_VERSION."; ".$this->get_baseurl());
+		}
+
+		function is_friendica_app() {
+			return($this->is_friendica_app);
 		}
 
 	}

--- a/mod/notify.php
+++ b/mod/notify.php
@@ -18,11 +18,8 @@ function notify_init(&$a) {
 				intval(local_user())
 			);
 
-			// Friendica-Client
-			$friendicamobile = ($_SERVER['HTTP_USER_AGENT'] == "Apache-HttpClient/UNAVAILABLE (java 1.4)");
-
 			// The friendica client has problems with the GUID. this is some workaround
-			if ($friendicamobile) {
+			if ($a->is_friendica_app()) {
 				require_once("include/items.php");
 				$urldata = parse_url($r[0]['link']);
 				$guid = basename($urldata["path"]);

--- a/mod/ping.php
+++ b/mod/ping.php
@@ -316,6 +316,8 @@ function ping_get_notifications($uid, $regularnotifications) {
 	$order = "";
 	$quit = false;
 
+	$a = get_app();
+
 	do {
 		$r = q("SELECT `notify`.*, `item`.`visible`, `item`.`spam`, `item`.`deleted`
 			FROM `notify` LEFT JOIN `item` ON `item`.`id` = `notify`.`iid`
@@ -354,8 +356,9 @@ function ping_get_notifications($uid, $regularnotifications) {
 			// Replace the name with {0} but ensure to make that only once
 			// The {0} is used later and prints the name in bold.
 			// But don't do it for the android app.
+
 			$pos = strpos($notification["msg"],$notification['name']);
-			if (($pos !== false) AND $regularnotifications)
+			if (($pos !== false) AND $regularnotifications AND !$a->is_friendica_app())
 				$notification["msg"] = substr_replace($notification["msg"],"{0}",$pos,strlen($notification["name"]));
 			else
 				$notification["msg"] = str_replace("{0}", $notification["name"], $notification["msg"]);


### PR DESCRIPTION
See issue https://github.com/friendica/friendica/issues/1642.

Hopefully this helps for the Friendica app. It won't help for the desktop notifications.