### PR TITLE
Desktop notifications

### DIFF
--- a/include/datetime.php
+++ b/include/datetime.php
@@ -262,10 +262,12 @@ function relative_date($posted_date,$format = null) {
 		return t('less than a second ago');
 	}
     
+	/*
 	$time_append = '';
 	if ($etime >= 86400) {
 		$time_append = ' ('.$localtime.')';
 	}
+	*/
 	
 	$a = array( 12 * 30 * 24 * 60 * 60  =>  array( t('year'),   t('years')),
 				30 * 24 * 60 * 60       =>  array( t('month'),  t('months')),
@@ -283,7 +285,7 @@ function relative_date($posted_date,$format = null) {
 			// translators - e.g. 22 hours ago, 1 minute ago
 			if(! $format)
 				$format = t('%1$d %2$s ago');
-			return sprintf( $format,$r, (($r == 1) ? $str[0] : $str[1])).$time_append;
+			return sprintf( $format,$r, (($r == 1) ? $str[0] : $str[1]));
         }
     }
 }}

--- a/js/main.js
+++ b/js/main.js
@@ -182,42 +182,32 @@
 				nnm.html(notifications_all + notifications_mark);
 				//nnm.attr('popup','true');
 
-				var notification_lastitem = localStorage.getItem("notification-lastitem");
-				var notification_first_id = 0;
-				var notification_id;
+				var notification_lastitem = parseInt(localStorage.getItem("notification-lastitem"));
+				var notification_id = 0;
 				eNotif.children("note").each(function(){
 					e = $(this);
 					text = e.text().format("<span class='contactname'>"+e.attr('name')+"</span>");
 					html = notifications_tpl.format(e.attr('href'),e.attr('photo'), text, e.attr('date'), e.attr('seen'));
 					nnm.append(html);
-					
-					notification_id = e.attr('href').match(/\d+$/)[0];
-					if (notification_lastitem!== null && notification_id!=notification_lastitem) {
-						if (notification_first_id===0) notification_first_id = notification_id;
+				});
+				$(eNotif.children("note").get().reverse()).each(function(){
+					e = $(this);
+					notification_id = parseInt(e.attr('href').match(/\d+$/)[0]);
+					if (notification_lastitem!== null && notification_id > notification_lastitem) {
 						if (getNotificationPermission()==="granted") {
-							console.log("notification", e.text().replace('&rarr; ','').format(e.attr('name')));
 							var notification = new Notification(document.title, {
 											  body: e.text().replace('&rarr; ','').format(e.attr('name')),
 											  icon: e.attr('photo'),
-											  data: e.attr('href')
 											 });
-							// close notification after 5 secs.
-							// see https://developer.mozilla.org/en-US/docs/Web/API/Notifications_API/Using_the_Notifications_API#Closing_notifications
-							//setTimeout(notification.close.bind(notification), 5000);
-							
+							notification['url'] = e.attr('href');
 							notification.addEventListener("click", function(ev){
-								window.location = ev.target.data;
+								window.location = ev.target.url;
 							});
 						}
 					}
-					if (notification_id == notification_lastitem) {
-						if (notification_first_id===0) notification_first_id = notification_id;
-						notification_lastitem = null;
-					}
-				
 					
 				});
-				if (notification_first_id!==0) notification_lastitem = notification_first_id;
+				notification_lastitem = notification_id;
 				localStorage.setItem("notification-lastitem", notification_lastitem)
 
 				$("img[data-src]", nnm).each(function(i, el){

--- a/js/main.js
+++ b/js/main.js
@@ -181,33 +181,45 @@
 				nnm = $("#nav-notifications-menu");
 				nnm.html(notifications_all + notifications_mark);
 				//nnm.attr('popup','true');
-                
-                var notification_lastitem = localStorage.getItem("notification-lastitem");
-                var notification_id = 0;
+
+				var notification_lastitem = localStorage.getItem("notification-lastitem");
+				var notification_first_id = 0;
 				
-                eNotif.children("note").each(function(){
+				eNotif.children("note").each(function(){
 					e = $(this);
 					text = e.text().format("<span class='contactname'>"+e.attr('name')+"</span>");
 					html = notifications_tpl.format(e.attr('href'),e.attr('photo'), text, e.attr('date'), e.attr('seen'));
 					nnm.append(html);
 					
-                    notification_id = e.attr('href').match(/\d+$/)[0];
-                        
-                    if (notification_lastitem!== null && notification_id>notification_lastitem) {
-                        notification_lastitem = notification_id;
+					var notification_id = e.attr('href').match(/\d+$/)[0];
+					console.log(notification_lastitem, notification_id);
+					if (notification_lastitem!== null && notification_id!=notification_lastitem) {
+						console.log( "eh!",getNotificationPermission() );
+						if (notification_first_id===0) notification_first_id = notification_id;
 						if (getNotificationPermission()==="granted") {
 							var notification = new Notification(document.title, {
 											  body: e.text().replace('&rarr; ','').format(e.attr('name')),
-											  icon: e.attr('photo')
+											  icon: e.attr('photo'),
 											 });
-							// TODO (yet unsupported by most browsers): 
-							// Implement notification.onclick()
+							// close notification after 5 secs.
+							// see https://developer.mozilla.org/en-US/docs/Web/API/Notifications_API/Using_the_Notifications_API#Closing_notifications
+							setTimeout(notification.close.bind(notification), 5000);
+							
+							notification.addEventListener("click", function(ev){
+								window.location = ev.target.data;
+							});
 						}
-                    }
-                    
+					}
+					if (notification_id == notification_lastitem) {
+						if (notification_first_id===0) notification_first_id = notification_id;
+						notification_lastitem = null;
+					}
+				
+					
 				});
-                if (notification_lastitem===null) notification_lastitem = notification_id;
-                localStorage.setItem("notification-lastitem", notification_lastitem)
+				if (notification_first_id!==0) notification_lastitem = notification_first_id;
+				console.log("end:", notification_lastitem, notification_first_id);
+				localStorage.setItem("notification-lastitem", notification_lastitem)
 
 				$("img[data-src]", nnm).each(function(i, el){
 					// Add src attribute for images with a data-src attribute

--- a/js/main.js
+++ b/js/main.js
@@ -186,13 +186,20 @@
 				var notification_id = 0;
 				eNotif.children("note").each(function(){
 					e = $(this);
-					text = e.text().format("<span class='contactname'>"+e.attr('name')+"</span>");
-					html = notifications_tpl.format(e.attr('href'),e.attr('photo'), text, e.attr('date'), e.attr('seen'));
+					var text = e.text().format("<span class='contactname'>"+e.attr('name')+"</span>");
+					var seenclass = (e.attr('seen')==1)?"notify-seen":"notify-unseen";
+					var html = notifications_tpl.format(e.attr('href'),
+						e.attr('photo'),                    // {0}
+						text,                               // {1}
+						e.attr('date'),                     // {2}
+						seenclass,                          // {3}
+						new Date(e.attr('timestamp')*1000)  // {4}
+					);
 					nnm.append(html);
 				});
 				$(eNotif.children("note").get().reverse()).each(function(){
 					e = $(this);
-					notification_id = parseInt(e.attr('href').match(/\d+$/)[0]);
+					notification_id = parseInt(e.attr('timestamp'));
 					if (notification_lastitem!== null && notification_id > notification_lastitem) {
 						if (getNotificationPermission()==="granted") {
 							var notification = new Notification(document.title, {

--- a/js/main.js
+++ b/js/main.js
@@ -192,9 +192,7 @@
 					nnm.append(html);
 					
 					var notification_id = e.attr('href').match(/\d+$/)[0];
-					console.log(notification_lastitem, notification_id);
 					if (notification_lastitem!== null && notification_id!=notification_lastitem) {
-						console.log( "eh!",getNotificationPermission() );
 						if (notification_first_id===0) notification_first_id = notification_id;
 						if (getNotificationPermission()==="granted") {
 							var notification = new Notification(document.title, {
@@ -218,7 +216,6 @@
 					
 				});
 				if (notification_first_id!==0) notification_lastitem = notification_first_id;
-				console.log("end:", notification_lastitem, notification_first_id);
 				localStorage.setItem("notification-lastitem", notification_lastitem)
 
 				$("img[data-src]", nnm).each(function(i, el){
@@ -787,7 +784,7 @@ function previewTheme(elm) {
 // notification permission settings in localstorage
 // set by settings page
 function getNotificationPermission() {
-	if (window.Notification === undefined) {
+	if (window["Notification"] === undefined) {
 		return null;
 	}
     if (Notification.permission === 'granted') {

--- a/js/main.js
+++ b/js/main.js
@@ -75,14 +75,14 @@
 		setupFieldRichtext();
 
 		/* popup menus */
-	function close_last_popup_menu() {
- 		if(last_popup_menu) {
- 		last_popup_menu.hide();
- 		last_popup_button.removeClass("selected");
- 		last_popup_menu = null;
- 		last_popup_button = null;
- 		}
- 		}
+		function close_last_popup_menu() {
+			if(last_popup_menu) {
+				last_popup_menu.hide();
+				last_popup_button.removeClass("selected");
+				last_popup_menu = null;
+				last_popup_button = null;
+			}
+		}
 		$('a[rel^=#]').click(function(e){
 			e.preventDefault();
 			var parent = $(this).parent();
@@ -105,7 +105,7 @@
 			return false;
 		});
 		$('html').click(function() {
-						close_last_popup_menu();
+			close_last_popup_menu();
 		});
 		
 		// fancyboxes
@@ -181,24 +181,33 @@
 				nnm = $("#nav-notifications-menu");
 				nnm.html(notifications_all + notifications_mark);
 				//nnm.attr('popup','true');
-				eNotif.children("note").each(function(){
+                
+                var notification_lastitem = localStorage.getItem("notification-lastitem");
+                var notification_id = 0;
+				
+                eNotif.children("note").each(function(){
 					e = $(this);
 					text = e.text().format("<span class='contactname'>"+e.attr('name')+"</span>");
 					html = notifications_tpl.format(e.attr('href'),e.attr('photo'), text, e.attr('date'), e.attr('seen'));
 					nnm.append(html);
 					
-					if(e.text().search('&rarr;') == 0) {
-                                         var notification = new Notification(document.title, {
-                                          body: e.text().replace('&rarr; ',''),
-                                          icon: e.attr('photo')
-                                         });
-   
-                                         // TODO (yet unsupported by most browsers): 
-                                         // Implement notification.onclick()
-                                         
-                                         // notifyMarkAll();
-                                       }
+                    notification_id = e.attr('href').match(/\d+$/)[0];
+                        
+                    if (notification_lastitem!== null && notification_id>notification_lastitem) {
+                        notification_lastitem = notification_id;
+						if (getNotificationPermission()==="granted") {
+							var notification = new Notification(document.title, {
+											  body: e.text().replace('&rarr; ','').format(e.attr('name')),
+											  icon: e.attr('photo')
+											 });
+							// TODO (yet unsupported by most browsers): 
+							// Implement notification.onclick()
+						}
+                    }
+                    
 				});
+                if (notification_lastitem===null) notification_lastitem = notification_id;
+                localStorage.setItem("notification-lastitem", notification_lastitem)
 
 				$("img[data-src]", nnm).each(function(i, el){
 					// Add src attribute for images with a data-src attribute
@@ -761,4 +770,17 @@ function previewTheme(elm) {
 			$('#theme-preview').html('<div id="theme-desc">' + data.desc + '</div><div id="theme-version">' + data.version + '</div><div id="theme-credits">' + data.credits + '</div><a href="' + data.img + '"><img src="' + data.img + '" width="320" height="240" alt="' + theme + '" /></a>');
 	});
 
+}
+
+// notification permission settings in localstorage
+// set by settings page
+function getNotificationPermission() {
+	if (window.Notification === undefined) {
+		return null;
+	}
+    if (Notification.permission === 'granted') {
+        return localStorage.getItem('notification-permissions');
+    } else {
+        return Notification.permission;
+    }
 }

--- a/js/main.js
+++ b/js/main.js
@@ -184,24 +184,26 @@
 
 				var notification_lastitem = localStorage.getItem("notification-lastitem");
 				var notification_first_id = 0;
-				
+				var notification_id;
 				eNotif.children("note").each(function(){
 					e = $(this);
 					text = e.text().format("<span class='contactname'>"+e.attr('name')+"</span>");
 					html = notifications_tpl.format(e.attr('href'),e.attr('photo'), text, e.attr('date'), e.attr('seen'));
 					nnm.append(html);
 					
-					var notification_id = e.attr('href').match(/\d+$/)[0];
+					notification_id = e.attr('href').match(/\d+$/)[0];
 					if (notification_lastitem!== null && notification_id!=notification_lastitem) {
 						if (notification_first_id===0) notification_first_id = notification_id;
 						if (getNotificationPermission()==="granted") {
+							console.log("notification", e.text().replace('&rarr; ','').format(e.attr('name')));
 							var notification = new Notification(document.title, {
 											  body: e.text().replace('&rarr; ','').format(e.attr('name')),
 											  icon: e.attr('photo'),
+											  data: e.attr('href')
 											 });
 							// close notification after 5 secs.
 							// see https://developer.mozilla.org/en-US/docs/Web/API/Notifications_API/Using_the_Notifications_API#Closing_notifications
-							setTimeout(notification.close.bind(notification), 5000);
+							//setTimeout(notification.close.bind(notification), 5000);
 							
 							notification.addEventListener("click", function(ev){
 								window.location = ev.target.data;
@@ -788,7 +790,9 @@ function getNotificationPermission() {
 		return null;
 	}
     if (Notification.permission === 'granted') {
-        return localStorage.getItem('notification-permissions');
+        var val = localStorage.getItem('notification-permissions');
+		if (val === null) return 'denied';
+		return val;
     } else {
         return Notification.permission;
     }

--- a/mod/ping.php
+++ b/mod/ping.php
@@ -21,9 +21,7 @@ function ping_init(&$a) {
 			killme();
 		}
 
-		$firehose = intval(get_pconfig(local_user(),'system','notify_full'));
-
-		$z = ping_get_notifications(local_user());
+		$notifs = ping_get_notifications(local_user());
 		$sysnotify = 0; // we will update this in a moment
 
 		$tags = array();
@@ -162,12 +160,23 @@ function ping_init(&$a) {
 		}
 
 
+		/**
+		 * return xml from notification array
+		 *
+		 * @param array $n Notification array:
+		 *		'href' => notification link
+		 *		'name' => subject name
+		 *		'url' => subject url
+		 *		'photo' => subject photo
+		 *		'date' => notification date
+		 *		'seen' => bool true/false
+		 *		'message' => notification message. "{0}" will be replaced by subject name
+		 **/
+		function xmlize($n){
+			$n['photo'] = proxy_url($n['photo']);
 
-		function xmlize($href, $name, $url, $photo, $date, $seen, $message){
-			$photo = proxy_url($photo);
-
-			$message = html_entity_decode($message, ENT_COMPAT | ENT_HTML401, "UTF-8");
-			$name = html_entity_decode($name, ENT_COMPAT | ENT_HTML401, "UTF-8");
+			$n['message'] = html_entity_decode($n['message'], ENT_COMPAT | ENT_HTML401, "UTF-8");
+			$n['name'] = html_entity_decode($n['name'], ENT_COMPAT | ENT_HTML401, "UTF-8");
 
 			// Are the nofications calles from the regular process or via the friendica app?
 			$regularnotifications = (intval($_GET['uid']) AND intval($_GET['_']));
@@ -175,13 +184,16 @@ function ping_init(&$a) {
 			$a = get_app();
 
 			if ($a->is_friendica_app() OR !$regularnotifications)
-				$message = str_replace("{0}", $name, $message);
+				$n['message'] = str_replace("{0}", $n['name'], $n['message']);
 
-			$data = array('href' => &$href, 'name' => &$name, 'url'=>&$url, 'photo'=>&$photo, 'date'=>&$date, 'seen'=>&$seen, 'messsage'=>&$message);
-			call_hooks('ping_xmlize', $data);
-			$notsxml = '<note href="%s" name="%s" url="%s" photo="%s" date="%s" seen="%s" >%s</note>'."\n";
+			$local_time = datetime_convert('UTC',date_default_timezone_get(),$n['date']); 
+				
+			call_hooks('ping_xmlize', $n);
+			$notsxml = '<note href="%s" name="%s" url="%s" photo="%s" date="%s" seen="%s" timestamp="%s" >%s</note>'."\n";
 			return sprintf ( $notsxml,
-				xmlify($href), xmlify($name), xmlify($url), xmlify($photo), xmlify($date), xmlify($seen), xmlify($message)
+				xmlify($n['href']), xmlify($n['name']), xmlify($n['url']), xmlify($n['photo']),
+				xmlify(relative_date($n['date'])), xmlify($n['seen']), xmlify(strtotime($local_time)),
+				xmlify($n['message'])
 			);
 		}
 
@@ -198,98 +210,78 @@ function ping_init(&$a) {
 			<birthdays>$birthdays</birthdays>
 			<birthdays-today>$birthdays_today</birthdays-today>\r\n";
 
-		$tot = $mail+$intro+$register+count($comments)+count($likes)+count($dislikes)+count($friends)+count($posts)+count($tags);
 
-		if($firehose) {
-			echo '	<notif count="'.$tot.'">';
-		}
-		else {
-			if(count($z) && (! $sysnotify)) {
-				foreach($z as $zz) {
-					if($zz['seen'] == 0)
-						$sysnotify ++;
-				}
-			}
-
-			echo '	<notif count="'. ($sysnotify + $intro + $mail + $register) .'">';
-
-			if ($intro>0){
-				foreach ($intros as $i) {
-					echo xmlize($a->get_baseurl().'/notifications/intros/'.$i['id'], $i['name'], $i['url'], $i['photo'], relative_date($i['datetime']), 'notify-unseen', t("{0} wants to be your friend"));
-				};
-			}
-			if ($mail>0){
-				foreach ($mails as $i) {
-					echo xmlize($a->get_baseurl().'/message/'.$i['id'], $i['from-name'], $i['from-url'], $i['from-photo'], relative_date($i['created']), 'notify-unseen', t("{0} sent you a message"));
-				};
-			}
-			if ($register>0){
-				foreach ($regs as $i) {
-					echo xmlize($a->get_baseurl().'/admin/users/', $i['name'], $i['url'], $i['micro'], relative_date($i['created']), 'notify-unseen', t("{0} requested registration"));
-				};
-			}
-
-			if(count($z)) {
-				foreach($z as $zz) {
-					echo xmlize($a->get_baseurl() . '/notify/view/' . $zz['id'], $zz['name'],$zz['url'],$zz['photo'],relative_date($zz['date']), ($zz['seen'] ? 'notify-seen' : 'notify-unseen'), strip_tags(bbcode($zz['msg'])));
-				}
+		if(count($notifs) && (! $sysnotify)) {
+			foreach($notifs as $zz) {
+				if($zz['seen'] == 0)
+					$sysnotify ++;
 			}
 		}
 
-		if($firehose) {
-			if ($intro>0){
-				foreach ($intros as $i) {
-					echo xmlize( $a->get_baseurl().'/notifications/intros/'.$i['id'], $i['name'], $i['url'], $i['photo'], relative_date($i['datetime']), 'notify-unseen',t("{0} wants to be your friend") );
-				};
-			}
-			if ($mail>0){
-				foreach ($mails as $i) {
-					echo xmlize( $a->get_baseurl().'/message/'.$i['id'], $i['from-name'], $i['from-url'], $i['from-photo'], relative_date($i['created']), 'notify-unseen',t("{0} sent you a message") );
-				};
-			}
-			if ($register>0){
-				foreach ($regs as $i) {
-					echo xmlize( $a->get_baseurl().'/admin/users/', $i['name'], $i['url'], $i['micro'], relative_date($i['created']), 'notify-unseen',t("{0} requested registration") );
-				};
-			}
+		echo '	<notif count="'. ($sysnotify + $intro + $mail + $register) .'">';
 
-			if (count($comments)){
-				foreach ($comments as $i) {
-					echo xmlize( $a->get_baseurl().'/display/'.$a->user['nickname']."/".$i['parent'], $i['author-name'], $i['author-link'], $i['author-avatar'], relative_date($i['created']), 'notify-unseen',sprintf( t("{0} commented %s's post"), $i['pname'] ) );
-				};
-			}
-			if (count($likes)){
-				foreach ($likes as $i) {
-					echo xmlize( $a->get_baseurl().'/display/'.$a->user['nickname']."/".$i['parent'], $i['author-name'], $i['author-link'], $i['author-avatar'], relative_date($i['created']), 'notify-unseen',sprintf( t("{0} liked %s's post"), $i['pname'] ) );
-				};
-			}
-			if (count($dislikes)){
-				foreach ($dislikes as $i) {
-					echo xmlize( $a->get_baseurl().'/display/'.$a->user['nickname']."/".$i['parent'], $i['author-name'], $i['author-link'], $i['author-avatar'], relative_date($i['created']), 'notify-unseen',sprintf( t("{0} disliked %s's post"), $i['pname'] ) );
-				};
-			}
-			if (count($friends)){
-				foreach ($friends as $i) {
-					echo xmlize($a->get_baseurl().'/display/'.$a->user['nickname']."/".$i['parent'],$i['author-name'],$i['author-link'], $i['author-avatar'], relative_date($i['created']), 'notify-unseen',sprintf( t("{0} is now friends with %s"), $i['fname'] ) );
-				};
-			}
-			if (count($posts)){
-				foreach ($posts as $i) {
-					echo xmlize( $a->get_baseurl().'/display/'.$a->user['nickname']."/".$i['parent'], $i['author-name'], $i['author-link'], $i['author-avatar'], relative_date($i['created']), 'notify-unseen',sprintf( t("{0} posted") ) );
-				};
-			}
-			if (count($tags)){
-				foreach ($tags as $i) {
-					echo xmlize( $a->get_baseurl().'/display/'.$a->user['nickname']."/".$i['parent'], $i['author-name'], $i['author-link'], $i['author-avatar'], relative_date($i['created']), 'notify-unseen',sprintf( t("{0} tagged %s's post with #%s"), $i['pname'], $i['tname'] ) );
-				};
-			}
-
-			if (count($cit)){
-				foreach ($cit as $i) {
-					echo xmlize( $a->get_baseurl().'/display/'.$a->user['nickname']."/".$i['parent'], $i['author-name'], $i['author-link'], $i['author-avatar'], relative_date($i['created']), 'notify-unseen',t("{0} mentioned you in a post") );
-				};
+		// merge all notification types in one array
+		if ($intro>0){
+			foreach ($intros as $i) {
+				$n = array(
+					'href' => $a->get_baseurl().'/notifications/intros/'.$i['id'],
+					'name' => $i['name'],
+					'url' => $i['url'], 
+					'photo' => $i['photo'],
+					'date' => $i['datetime'],
+					'seen' => false,
+					'message' => t("{0} wants to be your friend"),				
+				);
+				$notifs[] = $n;
 			}
 		}
+		
+		if ($mail>0){
+			foreach ($mails as $i) {
+				$n = array(
+					'href' => $a->get_baseurl().'/message/'.$i['id'],
+					'name' => $i['from-name'],
+					'url' => $i['from-url'], 
+					'photo' => $i['from-photo'],
+					'date' => $i['created'],
+					'seen' => false,
+					'message' => t("{0} sent you a message"),				
+				);
+				$notifs[] = $n;
+			}
+		}
+		
+		if ($register>0){
+			foreach ($regs as $i) {
+				$n = array(
+					'href' => $a->get_baseurl().'/admin/users/',
+					'name' => $i['name'],
+					'url' => $i['url'], 
+					'photo' => $i['micro'],
+					'date' => $i['created'],
+					'seen' => false,
+					'message' => t("{0} requested registration"),				
+				);
+				$notifs[] = $n;
+			}
+		}
+		// sort notifications by $[]['date']
+		$sort_function = function($a, $b) {
+			$adate = date($a['date']);
+			$bdate = date($b['date']);
+			if ($adate == $bdate) {
+				return 0;
+			}
+			return ($adate < $bdate) ? 1 : -1;
+		};
+		usort($notifs, $sort_function);
+
+		if(count($notifs)) {
+			foreach($notifs as $n) {
+				echo xmlize($n);
+			}
+		}
+
 
 		echo "  </notif>";
 	}
@@ -359,16 +351,18 @@ function ping_get_notifications($uid) {
 			if (is_null($notification["deleted"]))
 				$notification["deleted"] = 0;
 
-			$notification["msg"] = strip_tags(bbcode($notification["msg"]));
+			$notification["message"] = strip_tags(bbcode($notification["msg"]));
 			$notification["name"] = strip_tags(bbcode($notification["name"]));
 
 			// Replace the name with {0} but ensure to make that only once
 			// The {0} is used later and prints the name in bold.
 
-			$pos = strpos($notification["msg"],$notification['name']);
+			$pos = strpos($notification["message"],$notification['name']);
 			if ($pos !== false)
-				$notification["msg"] = substr_replace($notification["msg"],"{0}",$pos,strlen($notification["name"]));
+				$notification["message"] = substr_replace($notification["message"],"{0}",$pos,strlen($notification["name"]));
 
+			$notification['href'] = $a->get_baseurl() . '/notify/view/' . $notification['id'];
+				
 			if ($notification["visible"] AND !$notification["spam"] AND
 				!$notification["deleted"] AND !is_array($result[$notification["parent"]])) {
 				$result[$notification["parent"]] = $notification;
@@ -377,14 +371,6 @@ function ping_get_notifications($uid) {
 
 	} while ((count($result) < 50) AND !$quit);
 
-	// sort result by $[]['id'], inversed
-	$sort_function = function($a, $b) {
-		if ($a['id'] == $b['id']) {
-			return 0;
-		}
-		return ($a['id'] < $b['id']) ? 1 : -1;
-	};
-	usort($result, $sort_function);
 	
 	return($result);
 }

--- a/mod/settings.php
+++ b/mod/settings.php
@@ -1207,9 +1207,7 @@ function settings_content(&$a) {
 		'$notify7'  => array('notify7', t('You are tagged in a post'), ($notify & NOTIFY_TAGSELF), NOTIFY_TAGSELF, ''),
 		'$notify8'  => array('notify8', t('You are poked/prodded/etc. in a post'), ($notify & NOTIFY_POKE), NOTIFY_POKE, ''),
 
-		'$desktop_notifications' => t('Activate desktop notifications'),
-                '$desktop_notifications_note' => t('Note: This is an experimental feature, as being not supported by each browser'),
-                '$desktop_notifications_success_message' => t('You will now receive desktop notifications!'),
+        '$desktop_notifications' => array('desktop_notifications', t('Activate desktop notifications') , false, t('Show desktop popup on new notifications')),
                 
 		'$email_textonly' => array('email_textonly', t('Text-only notification emails'),
 									get_pconfig(local_user(),'system','email_textonly'),

--- a/view/global.css
+++ b/view/global.css
@@ -169,3 +169,8 @@ h6 {
 span.oembed, h4 {
   margin: 0px 0px 0px 0px;
 }
+
+/* fields help text */
+.field .field_help {
+    clear: left;
+}

--- a/view/global.css
+++ b/view/global.css
@@ -174,3 +174,6 @@ span.oembed, h4 {
 .field .field_help {
     clear: left;
 }
+
+/* notifications unseen */
+.notify-unseen { background-color: #cceeFF; }

--- a/view/templates/nav.tpl
+++ b/view/templates/nav.tpl
@@ -65,5 +65,5 @@
 </nav>
 
 <ul id="nav-notifications-template" style="display:none;" rel="template">
-	<li class="{4}"><a href="{0}"><img data-src="{1}" height="24" width="24" alt="" />{2} <span class="notif-when">{3}</span></a></li>
+	<li class="{4}"><a href="{0}" title="{5}"><img data-src="{1}" height="24" width="24" alt="" />{2} <span class="notif-when">{3}</span></a></li>
 </ul>

--- a/view/templates/settings.tpl
+++ b/view/templates/settings.tpl
@@ -133,12 +133,61 @@
 {{include file="field_intcheckbox.tpl" field=$notify8}}
 </div>
 
+{{include file="field_checkbox.tpl" field=$email_textonly}}
+
+
+<!--
 <div class="field">
  <button onclick="javascript:Notification.requestPermission(function(perm){if(perm === 'granted')alert('{{$desktop_notifications_success_message}}');});return false;">{{$desktop_notifications}}</button>
  <span class="field_help">{{$desktop_notifications_note}}</span>
 </div>
+-->
+{{include file="field_yesno.tpl" field=$desktop_notifications}}
+<script>
+(function(){
+    var elm = $("#id_{{$desktop_notifications.0}}_onoff");
+    var ckbox = $("#id_{{$desktop_notifications.0}}");
+    
+    if (getNotificationPermission() === 'granted') {
+        ckbox.val(1);
+        elm.find(".off").addClass("hidden");
+        elm.find(".on").removeClass("hidden");
+    }
+	if (getNotificationPermission() === null) {
+		elm.parent(".field.yesno").hide();
+	}
+    
+    $("#id_{{$desktop_notifications.0}}_onoff").on("click", function(e){
+        
+        if (Notification.permission === 'granted') {
+            localStorage.setItem('notification-permissions', ckbox.val()==1 ? 'granted' : 'denied');
+        } else if (Notification.permission === 'denied') {
+            localStorage.setItem('notification-permissions', 'denied');
+            
+            ckbox.val(0);
+            elm.find(".on").addClass("hidden");
+            elm.find(".off").removeClass("hidden");
+            
+        } else if (Notification.permission === 'default') {
+            Notification.requestPermission(function(choice) {
+                if (choice === 'granted') {
+                    localStorage.setItem('notification-permissions', ckbox.val()==1 ? 'granted' : 'denied');
 
-{{include file="field_checkbox.tpl" field=$email_textonly}}
+                } else {
+                    localStorage.setItem('notification-permissions', 'denied');
+                    ckbox.val(0);
+                    elm.find(".on").addClass("hidden");
+                    elm.find(".off").removeClass("hidden");
+                }
+            });
+        }
+		
+		//console.log(getNotificationPermission());
+		
+        
+    })
+})();
+</script>
 
 </div>
 

--- a/view/theme/duepuntozero/templates/nav.tpl
+++ b/view/theme/duepuntozero/templates/nav.tpl
@@ -67,5 +67,5 @@
 </nav>
 
 <ul id="nav-notifications-template" style="display:none;" rel="template">
-	<li class="{4}"><a href="{0}"><img data-src="{1}" height="24" width="24" alt="" />{2} <span class="notif-when">{3}</span></a></li>
+	<li class="{4}"><a href="{0}" title="{5}"><img data-src="{1}" height="24" width="24" alt="" />{2} <span class="notif-when">{3}</span></a></li>
 </ul>

--- a/view/theme/quattro/dark/style.css
+++ b/view/theme/quattro/dark/style.css
@@ -1852,7 +1852,6 @@ ul.tabs li .active {
   display: block;
   margin-left: 200px;
   color: #999999;
-  clear: left;
 }
 .field .onoff {
   float: left;

--- a/view/theme/quattro/dark/style.css
+++ b/view/theme/quattro/dark/style.css
@@ -514,6 +514,7 @@ header {
   margin: 0px;
   padding: 0px;
   /*width: 100%; height: 12px; */
+
   z-index: 110;
   color: #ffffff;
 }
@@ -846,6 +847,7 @@ aside .posted-date-selector-months {
   overflow: auto;
   height: auto;
   /*.contact-block-div { width:60px; height: 60px; }*/
+
 }
 #contact-block .contact-block-h4 {
   float: left;
@@ -927,6 +929,7 @@ aside .posted-date-selector-months {
   margin-bottom: 2em;
   /*.action .s10 { width: 10px; overflow: hidden; padding: 0px;}
 	.action .s16 { width: 16px; overflow: hidden; padding: 0px;}*/
+
 }
 .widget h3 {
   padding: 0px;
@@ -1208,6 +1211,7 @@ section {
   height: 32px;
   margin-left: 16px;
   /*background: url(../../../images/icons/22/user.png) no-repeat center center;*/
+
 }
 .comment-edit-preview .contact-photo-menu-button {
   top: 15px !important;
@@ -1848,6 +1852,7 @@ ul.tabs li .active {
   display: block;
   margin-left: 200px;
   color: #999999;
+  clear: left;
 }
 .field .onoff {
   float: left;
@@ -2077,6 +2082,7 @@ ul.tabs li .active {
   min-height: 22px;
   padding-top: 6px;
   /* a { display: block;}*/
+
 }
 #photo-caption {
   display: block;

--- a/view/theme/quattro/green/style.css
+++ b/view/theme/quattro/green/style.css
@@ -1852,7 +1852,6 @@ ul.tabs li .active {
   display: block;
   margin-left: 200px;
   color: #999999;
-  clear: left;
 }
 .field .onoff {
   float: left;

--- a/view/theme/quattro/green/style.css
+++ b/view/theme/quattro/green/style.css
@@ -514,6 +514,7 @@ header {
   margin: 0px;
   padding: 0px;
   /*width: 100%; height: 12px; */
+
   z-index: 110;
   color: #ffffff;
 }
@@ -846,6 +847,7 @@ aside .posted-date-selector-months {
   overflow: auto;
   height: auto;
   /*.contact-block-div { width:60px; height: 60px; }*/
+
 }
 #contact-block .contact-block-h4 {
   float: left;
@@ -927,6 +929,7 @@ aside .posted-date-selector-months {
   margin-bottom: 2em;
   /*.action .s10 { width: 10px; overflow: hidden; padding: 0px;}
 	.action .s16 { width: 16px; overflow: hidden; padding: 0px;}*/
+
 }
 .widget h3 {
   padding: 0px;
@@ -1208,6 +1211,7 @@ section {
   height: 32px;
   margin-left: 16px;
   /*background: url(../../../images/icons/22/user.png) no-repeat center center;*/
+
 }
 .comment-edit-preview .contact-photo-menu-button {
   top: 15px !important;
@@ -1848,6 +1852,7 @@ ul.tabs li .active {
   display: block;
   margin-left: 200px;
   color: #999999;
+  clear: left;
 }
 .field .onoff {
   float: left;
@@ -2077,6 +2082,7 @@ ul.tabs li .active {
   min-height: 22px;
   padding-top: 6px;
   /* a { display: block;}*/
+
 }
 #photo-caption {
   display: block;

--- a/view/theme/quattro/lilac/style.css
+++ b/view/theme/quattro/lilac/style.css
@@ -1852,7 +1852,6 @@ ul.tabs li .active {
   display: block;
   margin-left: 200px;
   color: #999999;
-  clear: left;
 }
 .field .onoff {
   float: left;

--- a/view/theme/quattro/lilac/style.css
+++ b/view/theme/quattro/lilac/style.css
@@ -514,6 +514,7 @@ header {
   margin: 0px;
   padding: 0px;
   /*width: 100%; height: 12px; */
+
   z-index: 110;
   color: #ffffff;
 }
@@ -846,6 +847,7 @@ aside .posted-date-selector-months {
   overflow: auto;
   height: auto;
   /*.contact-block-div { width:60px; height: 60px; }*/
+
 }
 #contact-block .contact-block-h4 {
   float: left;
@@ -927,6 +929,7 @@ aside .posted-date-selector-months {
   margin-bottom: 2em;
   /*.action .s10 { width: 10px; overflow: hidden; padding: 0px;}
 	.action .s16 { width: 16px; overflow: hidden; padding: 0px;}*/
+
 }
 .widget h3 {
   padding: 0px;
@@ -1208,6 +1211,7 @@ section {
   height: 32px;
   margin-left: 16px;
   /*background: url(../../../images/icons/22/user.png) no-repeat center center;*/
+
 }
 .comment-edit-preview .contact-photo-menu-button {
   top: 15px !important;
@@ -1848,6 +1852,7 @@ ul.tabs li .active {
   display: block;
   margin-left: 200px;
   color: #999999;
+  clear: left;
 }
 .field .onoff {
   float: left;
@@ -2077,6 +2082,7 @@ ul.tabs li .active {
   min-height: 22px;
   padding-top: 6px;
   /* a { display: block;}*/
+
 }
 #photo-caption {
   display: block;

--- a/view/theme/quattro/quattro.less
+++ b/view/theme/quattro/quattro.less
@@ -1197,7 +1197,6 @@ ul.tabs {
 		display: block;
 		margin-left: 200px;
 		color: @FieldHelpColor;
-        clear: left;
 	}
 
 

--- a/view/theme/quattro/quattro.less
+++ b/view/theme/quattro/quattro.less
@@ -1197,7 +1197,7 @@ ul.tabs {
 		display: block;
 		margin-left: 200px;
 		color: @FieldHelpColor;
-
+        clear: left;
 	}
 
 

--- a/view/theme/quattro/templates/nav.tpl
+++ b/view/theme/quattro/templates/nav.tpl
@@ -109,7 +109,7 @@
 
 </nav>
 <ul id="nav-notifications-template" style="display:none;" rel="template">
-	<li><a href="{0}"><img data-src="{1}">{2} <span class="notif-when">{3}</span></a></li>
+	<li class="{4}"><a href="{0}"><img data-src="{1}">{2} <span class="notif-when">{3}</span></a></li>
 </ul>
 
 <div style="position: fixed; top: 3px; left: 5px; z-index:9999">{{$langselector}}</div>

--- a/view/theme/quattro/templates/nav.tpl
+++ b/view/theme/quattro/templates/nav.tpl
@@ -109,7 +109,7 @@
 
 </nav>
 <ul id="nav-notifications-template" style="display:none;" rel="template">
-	<li class="{4}"><a href="{0}"><img data-src="{1}">{2} <span class="notif-when">{3}</span></a></li>
+	<li class="{4}"><a href="{0}" title="{5}"><img data-src="{1}">{2} <span class="notif-when">{3}</span></a></li>
 </ul>
 
 <div style="position: fixed; top: 3px; left: 5px; z-index:9999">{{$langselector}}</div>

--- a/view/theme/vier/templates/nav.tpl
+++ b/view/theme/vier/templates/nav.tpl
@@ -97,44 +97,8 @@
 
 </nav>
 <ul id="nav-notifications-template" style="display:none;" rel="template">
-	<li class="{4}"><a href="{0}"><img data-src="{1}">{2} <span class="notif-when">{3}</span></a></li>
+	<li class="{4}"><a href="{0}" title="{5}"><img data-src="{1}">{2} <span class="notif-when">{3}</span></a></li>
 </ul>
 <!--
 <div class="icon-flag" style="position: fixed; bottom: 10px; left: 20px; z-index:9;">{{$langselector}}</div>
 -->
-{{*
-
-{{if $nav.logout}}<a id="nav-logout-link" class="nav-link {{$nav.logout.2}}" href="{{$nav.logout.0}}" title="{{$nav.logout.3}}" >{{$nav.logout.1}}</a> {{/if}}
-{{if $nav.login}}<a id="nav-login-link" class="nav-login-link {{$nav.login.2}}" href="{{$nav.login.0}}" title="{{$nav.login.3}}" >{{$nav.login.1}}</a> {{/if}}
-
-<span id="nav-link-wrapper" >
-
-{{if $nav.register}}<a id="nav-register-link" class="nav-commlink {{$nav.register.2}}" href="{{$nav.register.0}}" title="{{$nav.register.3}}" >{{$nav.register.1}}</a>{{/if}}
-
-<a id="nav-help-link" class="nav-link {{$nav.help.2}}" target="friendica-help" href="{{$nav.help.0}}" title="{{$nav.help.3}}" >{{$nav.help.1}}</a>
-	
-{{if $nav.apps}}<a id="nav-apps-link" class="nav-link {{$nav.apps.2}}" href="{{$nav.apps.0}}" title="{{$nav.apps.3}}" >{{$nav.apps.1}}</a>{{/if}}
-
-<a id="nav-search-link" class="nav-link {{$nav.search.2}}" href="{{$nav.search.0}}" title="{{$nav.search.3}}" >{{$nav.search.1}}</a>
-<a id="nav-directory-link" class="nav-link {{$nav.directory.2}}" href="{{$nav.directory.0}}" title="{{$nav.directory.3}}" >{{$nav.directory.1}}</a>
-
-{{if $nav.admin}}<a id="nav-admin-link" class="nav-link {{$nav.admin.2}}" href="{{$nav.admin.0}}" title="{{$nav.admin.3}}" >{{$nav.admin.1}}</a>{{/if}}
-
-{{if $nav.notifications}}
-<a id="nav-notify-link" class="nav-commlink {{$nav.notifications.2}}" href="{{$nav.notifications.0}}" title="{{$nav.notifications.3}}" >{{$nav.notifications.1}}</a>
-<span id="notify-update" class="nav-ajax-left"></span>
-{{/if}}
-{{if $nav.messages}}
-<a id="nav-messages-link" class="nav-commlink {{$nav.messages.2}}" href="{{$nav.messages.0}}" title="{{$nav.messages.3}}" >{{$nav.messages.1}}</a>
-<span id="mail-update" class="nav-ajax-left"></span>
-{{/if}}
-
-{{if $nav.manage}}<a id="nav-manage-link" class="nav-commlink {{$nav.manage.2}}" href="{{$nav.manage.0}}" title="{{$nav.manage.3}}">{{$nav.manage.1}}</a>{{/if}}
-{{if $nav.settings}}<a id="nav-settings-link" class="nav-link {{$nav.settings.2}}" href="{{$nav.settings.0}}" title="{{$nav.settings.3}}">{{$nav.settings.1}}</a>{{/if}}
-{{if $nav.profiles}}<a id="nav-profiles-link" class="nav-link {{$nav.profiles.2}}" href="{{$nav.profiles.0}}" title="{{$nav.profiles.3}}" >{{$nav.profiles.1}}</a>{{/if}}
-
-
-</span>
-<span id="nav-end"></span>
-<span id="banner">{{$banner}}</span>
-*}}

--- a/view/theme/vier/templates/nav.tpl
+++ b/view/theme/vier/templates/nav.tpl
@@ -97,7 +97,7 @@
 
 </nav>
 <ul id="nav-notifications-template" style="display:none;" rel="template">
-	<li><a href="{0}"><img data-src="{1}">{2} <span class="notif-when">{3}</span></a></li>
+	<li class="{4}"><a href="{0}"><img data-src="{1}">{2} <span class="notif-when">{3}</span></a></li>
 </ul>
 <!--
 <div class="icon-flag" style="position: fixed; bottom: 10px; left: 20px; z-index:9;">{{$langselector}}</div>


### PR DESCRIPTION
Again, and this time should work as intended :-)
I had to modify `mod/ping.php` to returns all notifications ordered by date, and I added a timestamp to `<note>` tag.

a quick summary of changes:

- use on/off field for enable/disable desktop notification in settings page
- show only new notifications after enable
- use localstorage to save enabled/disalbed and last notification shown
- hide settings on browsers without desktop notification support
- `onclick` on supported browser, navigate to notification url
- reworked `/ping` returns all `<note>` elements ordered by date, max to min.
- `<note>` attribute `"seen"` as boolean value "1"/"0" instead of css class name
- new attribute to `<note>` element: `"timestamp"` : notification date as unix timestamp
- removed full date from value returned by `relative_date()`. Full notification date is shown in a tooltip
