### PR TITLE
use title in events-reminder

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -1852,12 +1852,6 @@ if(! function_exists('get_events')) {
 			$skip = 0;
 
 			foreach($r as &$rr) {
-				if($rr['adjust'])
-					$md = datetime_convert('UTC',$a->timezone,$rr['start'],'Y/m');
-				else
-					$md = datetime_convert('UTC','UTC',$rr['start'],'Y/m');
-				$md .= "/#link-".$rr['id'];
-
 				$title = strip_tags(html_entity_decode(bbcode($rr['summary']),ENT_QUOTES,'UTF-8'));
 
 				if(strlen($title) > 35)
@@ -1875,8 +1869,7 @@ if(! function_exists('get_events')) {
 				}
 
 				$today = ((substr($strt,0,10) === datetime_convert('UTC',$a->timezone,'now','Y-m-d')) ? true : false);
-
-				$rr['link'] = $md;
+				
 				$rr['title'] = $title;
 				$rr['description'] = $desciption;
 				$rr['date'] = day_translate(datetime_convert('UTC', $rr['adjust'] ? $a->timezone : 'UTC', $rr['start'], $bd_format)) . (($today) ?  ' ' . t('[today]') : '');

--- a/boot.php
+++ b/boot.php
@@ -1877,7 +1877,7 @@ if(! function_exists('get_events')) {
 				$today = ((substr($strt,0,10) === datetime_convert('UTC',$a->timezone,'now','Y-m-d')) ? true : false);
 
 				$rr['link'] = $md;
-				$rr['title'] =$title;
+				$rr['title'] = $title;
 				$rr['description'] = $desciption;
 				$rr['date'] = day_translate(datetime_convert('UTC', $rr['adjust'] ? $a->timezone : 'UTC', $rr['start'], $bd_format)) . (($today) ?  ' ' . t('[today]') : '');
 				$rr['startime'] = $strt;

--- a/boot.php
+++ b/boot.php
@@ -1858,7 +1858,10 @@ if(! function_exists('get_events')) {
 					$md = datetime_convert('UTC','UTC',$rr['start'],'Y/m');
 				$md .= "/#link-".$rr['id'];
 
-				$title = substr($rr['summary'],0,32) . '... ';
+				$title = strip_tags(html_entity_decode(bbcode($rr['summary']),ENT_QUOTES,'UTF-8'));
+
+				if(strlen($title) > 35)
+					$title = substr($title,0,32) . '... ';
 
 				$description = substr(strip_tags(bbcode($rr['desc'])),0,32) . '... ';
 				if(! $description)

--- a/boot.php
+++ b/boot.php
@@ -1858,9 +1858,11 @@ if(! function_exists('get_events')) {
 					$md = datetime_convert('UTC','UTC',$rr['start'],'Y/m');
 				$md .= "/#link-".$rr['id'];
 
-				$title = substr(strip_tags(bbcode($rr['desc'])),0,32) . '... ';
-				if(! $title)
-					$title = t('[No description]');
+				$title = substr($rr['summary'],0,32) . '... ';
+
+				$description = substr(strip_tags(bbcode($rr['desc'])),0,32) . '... ';
+				if(! $description)
+					$description = t('[No description]');
 
 				$strt = datetime_convert('UTC',$rr['convert'] ? $a->timezone : 'UTC',$rr['start']);
 
@@ -1872,7 +1874,8 @@ if(! function_exists('get_events')) {
 				$today = ((substr($strt,0,10) === datetime_convert('UTC',$a->timezone,'now','Y-m-d')) ? true : false);
 
 				$rr['link'] = $md;
-				$rr['title'] = $title;
+				$rr['title'] =$title;
+				$rr['description'] = $desciption;
 				$rr['date'] = day_translate(datetime_convert('UTC', $rr['adjust'] ? $a->timezone : 'UTC', $rr['start'], $bd_format)) . (($today) ?  ' ' . t('[today]') : '');
 				$rr['startime'] = $strt;
 				$rr['today'] = $today;

--- a/view/templates/events_reminder.tpl
+++ b/view/templates/events_reminder.tpl
@@ -4,7 +4,7 @@
 <div id="event-wrapper" style="display: none;" ><div id="event-title">{{$event_title}}</div>
 <div id="event-title-end"></div>
 {{foreach $events as $event}}
-<div class="event-list" id="event-{{$event.id}}"> <a href="events/{{$event.link}}">{{$event.title}}</a> {{$event.date}} </div>
+<div class="event-list" id="event-{{$event.id}}"> <a class="cboxElement" href="events/?id={{$event.id}}">{{$event.title}}</a> - {{$event.date}} </div>
 {{/foreach}}
 </div>
 {{/if}}


### PR DESCRIPTION
The events-reminder shows now the title of an event instead of the event description. Also the events-reminder links now to the event-id which makes the event load faster (and you don't have to go back to the network/status page)

I'm unsure if I should delete the the $md variable (the event links) in function get_events because it isn't needed anymore.