### PR TITLE
There is now two different checks for the completion of conversations

### DIFF
--- a/include/ostatus.php
+++ b/include/ostatus.php
@@ -10,6 +10,7 @@ require_once("include/Photo.php");
 
 define('OSTATUS_DEFAULT_POLL_INTERVAL', 30); // given in minutes
 define('OSTATUS_DEFAULT_POLL_TIMEFRAME', 1440); // given in minutes
+define('OSTATUS_DEFAULT_POLL_TIMEFRAME_MENTIONS', 14400); // given in minutes
 
 function ostatus_fetchauthor($xpath, $context, $importer, &$contact) {
 
@@ -468,7 +469,7 @@ function ostatus_convert_href($href) {
 	return $href;
 }
 
-function check_conversations($override = false) {
+function check_conversations($mentions = false, $override = false) {
 	$last = get_config('system','ostatus_last_poll');
 
 	$poll_interval = intval(get_config('system','ostatus_poll_interval'));
@@ -479,9 +480,16 @@ function check_conversations($override = false) {
 	if (($poll_interval < 0) AND !$override)
 		return;
 
-	$poll_timeframe = intval(get_config('system','ostatus_poll_timeframe'));
-	if (!$poll_timeframe)
-		$poll_timeframe = OSTATUS_DEFAULT_POLL_TIMEFRAME;
+	if (!$mentions) {
+		$poll_timeframe = intval(get_config('system','ostatus_poll_timeframe'));
+		if (!$poll_timeframe)
+			$poll_timeframe = OSTATUS_DEFAULT_POLL_TIMEFRAME;
+	} else {
+		$poll_timeframe = intval(get_config('system','ostatus_poll_timeframe'));
+		if (!$poll_timeframe)
+			$poll_timeframe = OSTATUS_DEFAULT_POLL_TIMEFRAME_MENTIONS;
+	}
+
 
 	if ($last AND !$override) {
 		$next = $last + ($poll_interval * 60);
@@ -494,8 +502,16 @@ function check_conversations($override = false) {
 	logger('cron_start');
 
 	$start = date("Y-m-d H:i:s", time() - ($poll_timeframe * 60));
-	$conversations = q("SELECT `oid`, `url`, `uid` FROM `term` WHERE `type` = 7 AND `term` > '%s' GROUP BY `url`, `uid` ORDER BY `term` DESC",
-				dbesc($start));
+
+	if ($mentions)
+		$conversations = q("SELECT `term`.`oid`, `term`.`url`, `term`.`uid` FROM `term`
+					STRAIGHT_JOIN `thread` ON `thread`.`iid` = `term`.`oid` AND `thread`.`uid` = `term`.`uid`
+					WHERE `term`.`type` = 7 AND `term`.`term` > '%s' AND `thread`.`mention`
+					GROUP BY `term`.`url`, `term`.`uid` ORDER BY `term`.`term` DESC", dbesc($start));
+	else
+		$conversations = q("SELECT `oid`, `url`, `uid` FROM `term`
+					WHERE `type` = 7 AND `term` > '%s'
+					GROUP BY `url`, `uid` ORDER BY `term` DESC", dbesc($start));
 
 	foreach ($conversations AS $conversation) {
 		ostatus_completion($conversation['url'], $conversation['uid']);

--- a/include/poller.php
+++ b/include/poller.php
@@ -103,7 +103,11 @@ function poller_run(&$argv, &$argc){
 		$abandon_days = 0;
 
 	// Check OStatus conversations
-	check_conversations();
+	// Check only conversations with mentions (for a longer time)
+	check_conversations(true);
+
+	// Check every conversation
+	check_conversations(false);
 
 	// To-Do: Regenerate usage statistics
 	// q("ANALYZE TABLE `item`");


### PR DESCRIPTION
Until now we checked the OStatus items of the last 24 hours if there were missing posts. The behaviour is now changed so that additionally all conversations are checked for a period of ten days if a user interacted in it.