### PR TITLE
use local theme settings for visitors

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -1451,7 +1451,7 @@ if(! function_exists('current_theme')) {
 		
 		// Find the theme that belongs to the user whose stuff we are looking at
 
-		if($a->profile_uid && $a->profile_uid != local_user()) {
+		if($a->profile_uid && ($a->profile_uid != local_user())) {
 			$r = q("select theme from user where uid = %d limit 1",
 				intval($a->profile_uid)
 			);
@@ -1462,7 +1462,7 @@ if(! function_exists('current_theme')) {
 		// Allow folks to over-rule user themes and always use their own on their own site.
 		// This works only if the user is on the same server
 
-		if($page_theme && local_user() && local_user() != $a->profile_url) {
+		if($page_theme && local_user() && (local_user() != $a->profile_uid)) {
 			if(get_pconfig(local_user(),'system','always_my_theme'))
 				$page_theme = null;
 		}

--- a/include/identity.php
+++ b/include/identity.php
@@ -90,14 +90,15 @@ if(! function_exists('profile_load')) {
 		}
 
 		$a->profile = $r[0];
+		$a->profile_uid = $r[0]['profile_uid'];
 
 		$a->profile['mobile-theme'] = get_pconfig($a->profile['profile_uid'], 'system', 'mobile_theme');
 		$a->profile['network'] = NETWORK_DFRN;
 
 		$a->page['title'] = $a->profile['name'] . " @ " . $a->config['sitename'];
 
-		if (!$profiledata)
-			$_SESSION['theme'] = $a->profile['theme'];
+//		if (!$profiledata)
+//			$_SESSION['theme'] = $a->profile['theme'];
 
 		$_SESSION['mobile-theme'] = $a->profile['mobile-theme'];
 
@@ -725,4 +726,20 @@ function zrl($s,$force = false) {
 	if($mine and ! link_compare($mine,$s))
 		return $s . $achar . 'zrl=' . urlencode($mine);
 	return $s;
+}
+
+// Used from within PCSS themes to set theme parameters. If there's a
+// puid request variable, that is the "page owner" and normally their theme
+// settings take precedence; unless a local user sets the "always_my_theme" 
+// system pconfig, which means they don't want to see anybody else's theme 
+// settings except their own while on this site.
+
+function get_theme_uid() {
+	$uid = (($_REQUEST['puid']) ? intval($_REQUEST['puid']) : 0);
+	if(local_user()) {
+		if((get_pconfig(local_user(),'system','always_my_theme')) || (! $uid))
+			return local_user();
+	}
+
+	return $uid;
 }

--- a/mod/photos.php
+++ b/mod/photos.php
@@ -29,71 +29,72 @@ function photos_init(&$a) {
 			return;
 
 		$a->data['user'] = $r[0];
+		$a->profile_uid = $r[0]['uid'];
 
-                $profilephoto = $a->get_cached_avatar_image($a->get_baseurl() . '/photo/profile/' . $a->data['user']['uid'] . '.jpg');
+		$profilephoto = $a->get_cached_avatar_image($a->get_baseurl() . '/photo/profile/' . $a->data['user']['uid'] . '.jpg');
 
-                $tpl = get_markup_template("vcard-widget.tpl");
+		$tpl = get_markup_template("vcard-widget.tpl");
 
 		$vcard_widget .= replace_macros($tpl, array(
-                        '$name' => $a->data['user']['username'],
-                        '$photo' => $profilephoto
-                ));
+			'$name' => $a->data['user']['username'],
+			'$photo' => $profilephoto
+		));
 
 
 		$sql_extra = permissions_sql($a->data['user']['uid']);
 
 		$albums = q("SELECT count(distinct `resource-id`) AS `total`, `album` FROM `photo` WHERE `uid` = %d  AND `album` != '%s' AND `album` != '%s'
-                        $sql_extra group by album order by created desc",
+			$sql_extra group by album order by created desc",
 			intval($a->data['user']['uid']),
-                        dbesc('Contact Photos'),
-                        dbesc( t('Contact Photos'))
+			dbesc('Contact Photos'),
+			dbesc( t('Contact Photos'))
 		);
 
-                $albums_visible = ((intval($a->data['user']['hidewall']) && (! local_user()) && (! remote_user())) ? false : true);
+		$albums_visible = ((intval($a->data['user']['hidewall']) && (! local_user()) && (! remote_user())) ? false : true);
 
-                // add various encodings to the array so we can just loop through and pick them out in a template
-                $ret = array('success' => false);
+		// add various encodings to the array so we can just loop through and pick them out in a template
+		$ret = array('success' => false);
 
-                if($albums) {
-                        $a->data['albums'] = $albums;
-                        if ($albums_visible)
-                                $ret['success'] = true;
+		if($albums) {
+			$a->data['albums'] = $albums;
+			if ($albums_visible)
+				$ret['success'] = true;
 
-                        $ret['albums'] = array();
-                        foreach($albums as $k => $album) {
-                                $entry = array(
-                                        'text'      => $album['album'],
-                                        'total'     => $album['total'],
-                                        'url'       => z_root() . '/photos/' . $a->data['user']['nickname'] . '/album/' . bin2hex($album['album']),
-                                        'urlencode' => urlencode($album['album']),
-                                        'bin2hex'   => bin2hex($album['album'])
-                                );
-                                $ret['albums'][] = $entry;
-                        }
-                }
+			$ret['albums'] = array();
+			foreach($albums as $k => $album) {
+				$entry = array(
+					'text'      => $album['album'],
+					'total'     => $album['total'],
+					'url'       => z_root() . '/photos/' . $a->data['user']['nickname'] . '/album/' . bin2hex($album['album']),
+					'urlencode' => urlencode($album['album']),
+					'bin2hex'   => bin2hex($album['album'])
+				);
+				$ret['albums'][] = $entry;
+			}
+		}
 
-                $albums = $ret;
+		$albums = $ret;
 
-                if(local_user() && $a->data['user']['uid'] == local_user())
-                        $can_post = true;
+		if(local_user() && $a->data['user']['uid'] == local_user())
+			$can_post = true;
 
-                if($albums['success']) {
-                        $photo_albums_widget = replace_macros(get_markup_template('photo_albums.tpl'),array(
-                                '$nick'     => $a->data['user']['nickname'],
-                                '$title'    => t('Photo Albums'),
-                                'recent'    => t('Recent Photos'),
-                                '$albums'   => $albums['albums'],
-                                '$baseurl'  => z_root(),
-                                '$upload'   => array( t('Upload New Photos'), $a->get_baseurl() . '/photos/' . $a->data['user']['nickname'] . '/upload'),
-                                '$can_post' => $can_post
-                        ));
-                }
+		if($albums['success']) {
+			$photo_albums_widget = replace_macros(get_markup_template('photo_albums.tpl'),array(
+				'$nick'     => $a->data['user']['nickname'],
+				'$title'    => t('Photo Albums'),
+				'recent'    => t('Recent Photos'),
+				'$albums'   => $albums['albums'],
+				'$baseurl'  => z_root(),
+				'$upload'   => array( t('Upload New Photos'), $a->get_baseurl() . '/photos/' . $a->data['user']['nickname'] . '/upload'),
+				'$can_post' => $can_post
+			));
+		}
 
 
 		if(! x($a->page,'aside'))
 			$a->page['aside'] = '';
-                $a->page['aside'] .= $vcard_widget;
-                $a->page['aside'] .= $photo_albums_widget;
+		$a->page['aside'] .= $vcard_widget;
+		$a->page['aside'] .= $photo_albums_widget;
 
 
 		$tpl = get_markup_template("photos_head.tpl");

--- a/mod/videos.php
+++ b/mod/videos.php
@@ -27,15 +27,16 @@ function videos_init(&$a) {
 			return;
 
 		$a->data['user'] = $r[0];
+		$a->profile_uid = $r[0]['uid'];
 
-                $profilephoto = $a->get_cached_avatar_image($a->get_baseurl() . '/photo/profile/' . $a->data['user']['uid'] . '.jpg');
+		$profilephoto = $a->get_cached_avatar_image($a->get_baseurl() . '/photo/profile/' . $a->data['user']['uid'] . '.jpg');
 
-                $tpl = get_markup_template("vcard-widget.tpl");
+		$tpl = get_markup_template("vcard-widget.tpl");
 
 		$vcard_widget = replace_macros($tpl, array(
-                        '$name' => $a->data['user']['username'],
-                        '$photo' => $profilephoto
-                ));
+			'$name' => $a->data['user']['username'],
+			'$photo' => $profilephoto
+		));
 
 
 		/*$sql_extra = permissions_sql($a->data['user']['uid']);

--- a/view/theme/duepuntozero/style.php
+++ b/view/theme/duepuntozero/style.php
@@ -2,10 +2,28 @@
 if (file_exists("$THEMEPATH/style.css")){
     echo file_get_contents("$THEMEPATH/style.css");
 }
+$uid = get_theme_uid();
+
 $s_colorset = get_config('duepuntozero','colorset');
-$uid = local_user();
 $colorset = get_pconfig( $uid, 'duepuntozero', 'colorset');
 if (!x($colorset)) 
     $colorset = $s_colorset;
+
+if ($colorset) {
+    if ($colorset == 'greenzero')
+	$setcss = file_get_contents('view/theme/duepuntozero/deriv/greenzero.css');
+    if ($colorset == 'purplezero')
+	$setcss = file_get_contents('view/theme/duepuntozero/deriv/purplezero.css');
+    if ($colorset == 'easterbunny')
+	$setcss = file_get_contents('view/theme/duepuntozero/deriv/easterbunny.css');
+    if ($colorset == 'darkzero')
+	$setcss = file_get_contents('view/theme/duepuntozero/deriv/darkzero.css');
+    if ($colorset == 'comix')
+	$setcss = file_get_contents('view/theme/duepuntozero/deriv/comix.css');
+    if ($colorset == 'slackr')
+	$setcss = file_get_contents('view/theme/duepuntozero/deriv/slackr.css');
+}
+
+echo $setcss;
 
 ?>

--- a/view/theme/quattro/style.php
+++ b/view/theme/quattro/style.php
@@ -1,12 +1,14 @@
 <?php
+	$uid = get_theme_uid();
+
 	$color=false;
 	$quattro_align=false;
 	$site_color = get_config("quattro","color");
 	$site_quattro_align = get_config("quattro", "align" );
 	
-	if (local_user()) {
-		$color = get_pconfig(local_user(), "quattro","color");
-		$quattro_align = get_pconfig(local_user(), 'quattro', 'align' );
+	if ($uid) {
+		$color = get_pconfig( $uid, "quattro","color");
+		$quattro_align = get_pconfig( $uid, 'quattro', 'align' );
 	}
 	
 	if ($color===false) $color=$site_color;
@@ -39,9 +41,9 @@
     if ($site_textarea_font_size===false) $site_textarea_font_size="20";
     if ($site_post_font_size===false) $site_post_font_size="12";
     
-   	if (local_user()) {
-        $textarea_font_size = get_pconfig(local_user(), "quattro","tfs");
-        $post_font_size = get_pconfig(local_user(), "quattro","pfs");    
+   	if ($uid) {
+        $textarea_font_size = get_pconfig( $uid, "quattro","tfs");
+        $post_font_size = get_pconfig( $uid, "quattro","pfs");    
 	} 
     
     if ($textarea_font_size===false) $textarea_font_size = $site_textarea_font_size;

--- a/view/theme/vier/style.php
+++ b/view/theme/vier/style.php
@@ -1,0 +1,30 @@
+<?php
+
+if (file_exists("$THEMEPATH//style.css")){
+	echo file_get_contents("$THEMEPATH//style.css");
+}
+
+$uid = get_theme_uid();
+
+$style = get_pconfig( $uid, 'vier', 'style');
+
+if ($style == "")
+	$style = get_config('vier', 'style');
+
+if ($style == "")
+	$style = "plus";
+
+if ($style == "flat")
+	$stylecss = file_get_contents('view/theme/vier/flat.css');
+else if ($style == "netcolour")
+	$stylecss = file_get_contents('view/theme/vier/netcolour.css');
+else if ($style == "breathe")
+	$stylecss = file_get_contents('view/theme/vier/breathe.css');
+else if ($style == "plus")
+	$stylecss = file_get_contents('view/theme/vier/plus.css');
+else if ($style == "dark")
+	$stylecss = file_get_contents('view/theme/vier/dark.css');
+
+echo $stylecss;
+
+

--- a/view/theme/vier/theme.php
+++ b/view/theme/vier/theme.php
@@ -16,25 +16,6 @@ $baseurl = $a->get_baseurl();
 
 $a->theme_info = array();
 
-$style = get_pconfig(local_user(), 'vier', 'style');
-
-if ($style == "")
-	$style = get_config('vier', 'style');
-
-if ($style == "")
-	$style = "plus";
-
-if ($style == "flat")
-	$a->page['htmlhead'] .= '<link rel="stylesheet" href="view/theme/vier/flat.css" type="text/css" media="screen"/>'."\n";
-else if ($style == "netcolour")
-	$a->page['htmlhead'] .= '<link rel="stylesheet" href="view/theme/vier/netcolour.css" type="text/css" media="screen"/>'."\n";
-else if ($style == "breathe")
-	$a->page['htmlhead'] .= '<link rel="stylesheet" href="view/theme/vier/breathe.css" type="text/css" media="screen"/>'."\n";
-else if ($style == "plus")
-	$a->page['htmlhead'] .= '<link rel="stylesheet" href="view/theme/vier/plus.css" type="text/css" media="screen"/>'."\n";
-else if ($style == "dark")
-	$a->page['htmlhead'] .= '<link rel="stylesheet" href="view/theme/vier/dark.css" type="text/css" media="screen"/>'."\n";
-
 $a->page['htmlhead'] .= <<< EOT
 <script type="text/javascript">
 


### PR DESCRIPTION
Now the theme settings of the profile owner will be respected if someone visit a profile page. With this behavior the user can create a personal profile page.
Theme developers can now use get_theme_uid() to get the uid of the profile owner.

Note for theme developers:
All css related requests have to be placed in style.php (not in theme.php)

The pconfig setting 'system' 'always_my_theme' does only work if both users are on the same friendica instance.