### PR TITLE
Automatic contact update

### DIFF
--- a/include/follow.php
+++ b/include/follow.php
@@ -6,7 +6,7 @@ function update_contact($id) {
 	This will reliably kill your communication with Friendica contacts.
 	*/
 
-	$r = q("SELECT `url`, `nurl`, `addr`, `alias`, `batch`, `notify`, `poll`, `poco`, `name`, `nick`, `network` FROM `contact` WHERE `id` = %d", intval($id));
+	$r = q("SELECT `url`, `nurl`, `addr`, `alias`, `batch`, `notify`, `poll`, `poco`, `network` FROM `contact` WHERE `id` = %d", intval($id));
 	if (!$r)
 		return;
 
@@ -16,12 +16,21 @@ function update_contact($id) {
 	if ($ret["network"] != $r[0]["network"])
 		return;
 
+	$update = false;
+
 	// make sure to not overwrite existing values with blank entries
-	foreach ($ret AS $key => $val)
+	foreach ($ret AS $key => $val) {
 		if (isset($r[0][$key]) AND ($r[0][$key] != "") AND ($val == ""))
 			$ret[$key] = $r[0][$key];
 
-	q("UPDATE `contact` SET `url` = '%s', `nurl` = '%s', `addr` = '%s', `alias` = '%s', `batch` = '%s', `notify` = '%s', `poll` = '%s', `poco` = '%s', `name` = '%s', `nick` = '%s' WHERE `id` = %d",
+		if (isset($r[0][$key]) AND ($ret[$key] != $r[0][$key]))
+			$update = true;
+	}
+
+	if (!$update)
+		return;
+
+	q("UPDATE `contact` SET `url` = '%s', `nurl` = '%s', `addr` = '%s', `alias` = '%s', `batch` = '%s', `notify` = '%s', `poll` = '%s', `poco` = '%s' WHERE `id` = %d",
 		dbesc($ret['url']),
 		dbesc(normalise_link($ret['url'])),
 		dbesc($ret['addr']),
@@ -30,8 +39,6 @@ function update_contact($id) {
 		dbesc($ret['notify']),
 		dbesc($ret['poll']),
 		dbesc($ret['poco']),
-		dbesc($ret['name']),
-		dbesc($ret['nick']),
 		intval($id)
 	);
 }

--- a/include/follow.php
+++ b/include/follow.php
@@ -1,4 +1,5 @@
 <?php
+require_once("include/Scrape.php");
 
 function update_contact($id) {
 	/*

--- a/include/follow.php
+++ b/include/follow.php
@@ -1,7 +1,12 @@
 <?php
 
 function update_contact($id) {
-	$r = q("SELECT `url`, `network` FROM `contact` WHERE `id` = %d", intval($id));
+	/*
+	Warning: Never ever fetch the public key via probe_url and write it into the contacts.
+	This will reliably kill your communication with Friendica contacts.
+	*/
+
+	$r = q("SELECT `url`, `nurl`, `addr`, `alias`, `batch`, `notify`, `poll`, `poco`, `name`, `nick`, `network` FROM `contact` WHERE `id` = %d", intval($id));
 	if (!$r)
 		return;
 
@@ -10,6 +15,11 @@ function update_contact($id) {
 	// If probe_url fails the network code will be different
 	if ($ret["network"] != $r[0]["network"])
 		return;
+
+	// make sure to not overwrite existing values with blank entries
+	foreach ($ret AS $key => $val)
+		if (isset($r[0][$key]) AND ($r[0][$key] != "") AND ($val == ""))
+			$ret[$key] = $r[0][$key];
 
 	q("UPDATE `contact` SET `url` = '%s', `nurl` = '%s', `addr` = '%s', `alias` = '%s', `batch` = '%s', `notify` = '%s', `poll` = '%s', `poco` = '%s', `name` = '%s', `nick` = '%s' WHERE `id` = %d",
 		dbesc($ret['url']),

--- a/include/items.php
+++ b/include/items.php
@@ -2064,11 +2064,11 @@ function dfrn_deliver($owner,$contact,$atom, $dissolve = false) {
 		|| ($contact['rel'] == CONTACT_IS_SHARING && strlen($contact['pubkey']))) {
 		openssl_public_decrypt($sent_dfrn_id,$final_dfrn_id,$contact['pubkey']);
 		openssl_public_decrypt($challenge,$postvars['challenge'],$contact['pubkey']);
-	} elseif($contact['prvkey']) {
+	}
+	else {
 		openssl_private_decrypt($sent_dfrn_id,$final_dfrn_id,$contact['prvkey']);
 		openssl_private_decrypt($challenge,$postvars['challenge'],$contact['prvkey']);
-	} else
-		logger("No private or public key for contact ".$contact['id']." ".$contact['url']);
+	}
 
 	$final_dfrn_id = substr($final_dfrn_id, 0, strpos($final_dfrn_id, '.'));
 

--- a/include/items.php
+++ b/include/items.php
@@ -2064,11 +2064,11 @@ function dfrn_deliver($owner,$contact,$atom, $dissolve = false) {
 		|| ($contact['rel'] == CONTACT_IS_SHARING && strlen($contact['pubkey']))) {
 		openssl_public_decrypt($sent_dfrn_id,$final_dfrn_id,$contact['pubkey']);
 		openssl_public_decrypt($challenge,$postvars['challenge'],$contact['pubkey']);
-	}
-	else {
+	} elseif($contact['prvkey']) {
 		openssl_private_decrypt($sent_dfrn_id,$final_dfrn_id,$contact['prvkey']);
 		openssl_private_decrypt($challenge,$postvars['challenge'],$contact['prvkey']);
-	}
+	} else
+		logger("No private or public key for contact ".$contact['id']." ".$contact['url']);
 
 	$final_dfrn_id = substr($final_dfrn_id, 0, strpos($final_dfrn_id, '.'));
 
@@ -2076,7 +2076,7 @@ function dfrn_deliver($owner,$contact,$atom, $dissolve = false) {
 		$final_dfrn_id = substr($final_dfrn_id,2);
 
 	if($final_dfrn_id != $orig_id) {
-		logger('dfrn_deliver: wrong dfrn_id.');
+		logger('dfrn_deliver: wrong dfrn_id. Original: '.$orig_id.' Target: '.$final_dfrn_id.' Test: '.$test);
 		// did not decode properly - cannot trust this site
 		return 3;
 	}

--- a/include/items.php
+++ b/include/items.php
@@ -2076,7 +2076,7 @@ function dfrn_deliver($owner,$contact,$atom, $dissolve = false) {
 		$final_dfrn_id = substr($final_dfrn_id,2);
 
 	if($final_dfrn_id != $orig_id) {
-		logger('dfrn_deliver: wrong dfrn_id. Original: '.$orig_id.' Target: '.$final_dfrn_id.' Test: '.$test);
+		logger('dfrn_deliver: wrong dfrn_id.');
 		// did not decode properly - cannot trust this site
 		return 3;
 	}

--- a/include/onepoll.php
+++ b/include/onepoll.php
@@ -2,7 +2,6 @@
 
 require_once("boot.php");
 require_once("include/follow.php");
-require_once("include/Scrape.php");
 
 function RemoveReply($subject) {
 	while (in_array(strtolower(substr($subject, 0, 3)), array("re:", "aw:")))

--- a/include/onepoll.php
+++ b/include/onepoll.php
@@ -237,11 +237,11 @@ function onepoll_run(&$argv, &$argc){
 		if(($contact['duplex']) && strlen($contact['prvkey'])) {
 			openssl_private_decrypt($sent_dfrn_id,$final_dfrn_id,$contact['prvkey']);
 			openssl_private_decrypt($challenge,$postvars['challenge'],$contact['prvkey']);
-		} elseif($contact['pubkey']) {
+		}
+		else {
 			openssl_public_decrypt($sent_dfrn_id,$final_dfrn_id,$contact['pubkey']);
 			openssl_public_decrypt($challenge,$postvars['challenge'],$contact['pubkey']);
-		} else
-			logger("No private or public key for contact ".$contact['id']." ".$contact['url']);
+		}
 
 		$final_dfrn_id = substr($final_dfrn_id, 0, strpos($final_dfrn_id, '.'));
 

--- a/include/onepoll.php
+++ b/include/onepoll.php
@@ -1,6 +1,8 @@
 <?php
 
 require_once("boot.php");
+require_once("include/follow.php");
+require_once("include/Scrape.php");
 
 function RemoveReply($subject) {
 	while (in_array(strtolower(substr($subject, 0, 3)), array("re:", "aw:")))
@@ -129,6 +131,10 @@ function onepoll_run(&$argv, &$argc){
 		: datetime_convert('UTC','UTC',$contact['last-update'], ATOM_TIME)
 	);
 
+	// Update the contact entry
+	if(($contact['network'] === NETWORK_OSTATUS) || ($contact['network'] === NETWORK_DIASPORA) || ($contact['network'] === NETWORK_DFRN))
+		update_contact($contact["id"]);
+
 	if($contact['network'] === NETWORK_DFRN) {
 
 
@@ -231,11 +237,11 @@ function onepoll_run(&$argv, &$argc){
 		if(($contact['duplex']) && strlen($contact['prvkey'])) {
 			openssl_private_decrypt($sent_dfrn_id,$final_dfrn_id,$contact['prvkey']);
 			openssl_private_decrypt($challenge,$postvars['challenge'],$contact['prvkey']);
-		}
-		else {
+		} elseif($contact['pubkey']) {
 			openssl_public_decrypt($sent_dfrn_id,$final_dfrn_id,$contact['pubkey']);
 			openssl_public_decrypt($challenge,$postvars['challenge'],$contact['pubkey']);
-		}
+		} else
+			logger("No private or public key for contact ".$contact['id']." ".$contact['url']);
 
 		$final_dfrn_id = substr($final_dfrn_id, 0, strpos($final_dfrn_id, '.'));
 
@@ -243,8 +249,8 @@ function onepoll_run(&$argv, &$argc){
 			$final_dfrn_id = substr($final_dfrn_id,2);
 
 		if($final_dfrn_id != $orig_id) {
-			logger('poller: ID did not decode: ' . $contact['id'] . ' orig: ' . $orig_id . ' final: ' . $final_dfrn_id);	
-			// did not decode properly - cannot trust this site 
+			logger('poller: ID did not decode: ' . $contact['id'] . ' orig: ' . $orig_id . ' final: ' . $final_dfrn_id);
+			// did not decode properly - cannot trust this site
 			return;
 		}
 
@@ -255,7 +261,7 @@ function onepoll_run(&$argv, &$argc){
 		$xml = post_url($contact['poll'],$postvars);
 
 	}
-	elseif(($contact['network'] === NETWORK_OSTATUS) 
+	elseif(($contact['network'] === NETWORK_OSTATUS)
 		|| ($contact['network'] === NETWORK_DIASPORA)
 		|| ($contact['network'] === NETWORK_FEED) ) {
 
@@ -265,7 +271,8 @@ function onepoll_run(&$argv, &$argc){
 
 		$stat_writeable = ((($contact['notify']) && ($contact['rel'] == CONTACT_IS_FOLLOWER || $contact['rel'] == CONTACT_IS_FRIEND)) ? 1 : 0);
 
-		if($contact['network'] === NETWORK_OSTATUS && get_pconfig($importer_uid,'system','ostatus_autofriend'))
+		// Contacts from OStatus are always writable
+		if($contact['network'] === NETWORK_OSTATUS)
 			$stat_writeable = 1;
 
 		if($stat_writeable != $contact['writable']) {

--- a/mod/receive.php
+++ b/mod/receive.php
@@ -9,7 +9,7 @@ require_once('include/salmon.php');
 require_once('include/crypto.php');
 require_once('include/diaspora.php');
 
-	
+
 function receive_post(&$a) {
 
 

--- a/object/Item.php
+++ b/object/Item.php
@@ -308,10 +308,6 @@ class Item extends BaseObject {
 		if (($item["item_network"] == NETWORK_FACEBOOK) AND ($indent == 'comment') AND isset($buttons["like"]))
 			unset($buttons["like"]);
 
-		// Likes don't federate at OStatus
-		if (($item["item_network"] == NETWORK_OSTATUS) AND isset($buttons["like"]))
-			unset($buttons["like"]);
-
 		$tmp_item = array(
 			'template' => $this->get_template(),
 

--- a/object/Item.php
+++ b/object/Item.php
@@ -308,6 +308,9 @@ class Item extends BaseObject {
 		if (($item["item_network"] == NETWORK_FACEBOOK) AND ($indent == 'comment') AND isset($buttons["like"]))
 			unset($buttons["like"]);
 
+		// Likes don't federate at OStatus
+		if (($item["item_network"] == NETWORK_OSTATUS) AND isset($buttons["like"]))
+			unset($buttons["like"]);
 
 		$tmp_item = array(
 			'template' => $this->get_template(),


### PR DESCRIPTION
It can happen that communication relevant values are changing. For example if someone is switching from non-ssl to ssl-only. Additionally values like "addr" weren't fetched reliably in the past.

Now every time the contact is polled (that happens once a day), the contact data is checked and updated.

Additionally there are two small OStatus changes:
* Now you can always comment on OStatus posts. There is no checking if the person follows you or not. This reflects the common practice at that network.
* Since "like" (favourites) doesn't federate at OStatus, you now can't like OStatus posts any more.