### PR TITLE
Update the name in the "self" contact when it is changed.

### DIFF
--- a/mod/profiles.php
+++ b/mod/profiles.php
@@ -470,7 +470,8 @@ function profiles_post(&$a) {
 
 
 		if($namechanged && $is_default) {
-			$r = q("UPDATE `contact` SET `name-date` = '%s' WHERE `self` = 1 AND `uid` = %d",
+			$r = q("UPDATE `contact` SET `name` = '%s', `name-date` = '%s' WHERE `self` = 1 AND `uid` = %d",
+				dbesc($name),
 				dbesc(datetime_convert()),
 				intval(local_user())
 			);


### PR DESCRIPTION
When a user changed his name in the profile, then the changes were stored in the profile and the user table - but not in the contacts. 