### PR TITLE
Vagrant: Fix for potentially missing admin account

### DIFF
--- a/doc/Vagrant.md
+++ b/doc/Vagrant.md
@@ -17,7 +17,7 @@ Inside, you'll find a "Vagrantfile" and some scripts in the utils folder.
 3. Run "vagrant up" from inside the friendica clone.
 Be patient: When it runs for the first time, it downloads an Ubuntu Server image.
 4. Run "vagrant ssh" to log into the virtual machine to log in to the VM.
-5. Open 192.168.22.10 in a browser to finish the Friendica installation.
+5. Open 192.168.22.10 in a browser.
 The mysql database is called "friendica", the mysql user and password both are "root".
 6. Work on Friendica's code in your git clone on your machine (not in the VM).
 7. Check the changes in your browser in the VM.
@@ -30,13 +30,7 @@ If you want to stop vagrant after finishing your work, run the following command
 
 in the development directory.
 
-Import test data
-----------------
-
-If you want some test data in your vagrant Friendica instance import the database dump friendica_test_data.sql like so (inside the VM):
-
-		$> mysql -u root -p friendica < /vagrant/friendica_test_data.sql
-
+The vagrant Friendica instance contains a test database.
 You will then have the following accounts to login:
 
   * admin, password admin

--- a/util/htconfig.vagrant.php
+++ b/util/htconfig.vagrant.php
@@ -1,0 +1,71 @@
+<?php
+
+// Set the following for your MySQL installation
+// Copy or rename this file to .htconfig.php
+
+$db_host = 'localhost';
+$db_user = 'root';
+$db_pass = 'root';
+$db_data = 'friendica';
+
+// If you are using a subdirectory of your domain you will need to put the
+// relative path (from the root of your domain) here.
+// For instance if your URL is 'http://example.com/directory/subdirectory',
+// set path to 'directory/subdirectory'. 
+
+$a->path = '';
+ 
+// Choose a legal default timezone. If you are unsure, use "America/Los_Angeles".
+// It can be changed later and only applies to timestamps for anonymous viewers.
+
+$default_timezone = 'Europe/Berlin';
+
+// What is your site name?
+
+$a->config['sitename'] = "My Friend Network";
+
+// Your choices are REGISTER_OPEN, REGISTER_APPROVE, or REGISTER_CLOSED.
+// Be certain to create your own personal account before setting 
+// REGISTER_CLOSED. 'register_text' (if set) will be displayed prominently on 
+// the registration page. REGISTER_APPROVE requires you set 'admin_email'
+// to the email address of an already registered person who can authorise
+// and/or approve/deny the request.
+
+$a->config['register_policy'] = REGISTER_OPEN;
+$a->config['register_text'] = '';
+$a->config['admin_email'] = 'vagrant@friendica.dev';
+
+// Maximum size of an imported message, 0 is unlimited
+
+$a->config['max_import_size'] = 200000;
+
+// maximum size of uploaded photos
+
+$a->config['system']['maximagesize'] = 800000;
+
+// Location of PHP command line processor
+
+$a->config['php_path'] = '/usr/bin/php';
+
+// Location of global directory submission page.
+
+$a->config['system']['directory_submit_url'] = 'http://dir.friendica.com/submit';
+$a->config['system']['directory_search_url'] = 'http://dir.friendica.com/directory?search=';
+
+// PuSH - aka pubsubhubbub URL. This makes delivery of public posts as fast as private posts
+
+$a->config['system']['huburl'] = '[internal]';
+
+// Server-to-server private message encryption (RINO) is allowed by default. 
+// Encryption will only be provided if this setting is true and the
+// PHP mcrypt extension is installed on both systems 
+
+$a->config['system']['rino_encrypt'] = true;
+
+// default system theme
+
+$a->config['system']['theme'] = 'duepuntozero';
+
+// By default allow pseudonyms
+
+$a->config['system']['no_regfullname'] = true;

--- a/util/vagrant_provision.sh
+++ b/util/vagrant_provision.sh
@@ -63,6 +63,7 @@ SQL="${Q1}${Q2}"
 $MYSQL -uroot -proot -e "$SQL"
 service mysql restart
 
+
 #configure rudimentary mail server (local delivery only)
 #add Friendica accounts for local user accounts, use email address like vagrant@friendica.dev, read the email with 'mail'.
 debconf-set-selections <<< "postfix postfix/mailname string friendica.dev"
@@ -74,15 +75,13 @@ sudo echo -e "friendica1:	vagrant\nfriendica2:	vagrant\nfriendica3:	vagrant\nfri
 sudo rm -rf /var/www/
 sudo ln -fs /vagrant /var/www
 
-#delete .htconfig.php file if it exists to have a fresh friendica 
-#installation
-if [ -f /vagrant/.htconfig.php ]
-  then
-    sudo rm /vagrant/.htconfig.php
-fi
+# initial config file for friendica in vagrant
+cp /vagrant/util/htconfig.vagrant.php /vagrant/.htconfig.php
 
-#create the friendica database
+# create the friendica database
 echo "create database friendica" | mysql -u root -proot
+# import test database
+$MYSQL -uroot -proot friendica < /vagrant/friendica_test_data.sql
 
 #create cronjob
 echo "*/10 * * * * cd /vagrant; /usr/bin/php include/poller.php" >> friendicacron


### PR DESCRIPTION
Fix for #1556: I changed the vagrant machine so that you don't have to run the installation any more. Instead, you get a ready Friendica installation with the test database so that you are sure you don't get the admin address wrong during installation (and end up with no admin account).