### PR TITLE
On OStatus and Diaspora the usernames mustn't contain "-"

### DIFF
--- a/include/user.php
+++ b/include/user.php
@@ -136,8 +136,8 @@ function create_user($arr) {
 
 	$nickname = $arr['nickname'] = strtolower($nickname);
 
-	if(! preg_match("/^[a-z][a-z0-9\-\_]*$/",$nickname))
-		$result['message'] .= t('Your "nickname" can only contain "a-z", "0-9", "-", and "_", and must also begin with a letter.') . EOL;
+	if(! preg_match("/^[a-z0-9][a-z0-9\_]*$/",$nickname))
+		$result['message'] .= t('Your "nickname" can only contain "a-z", "0-9" and "_".') . EOL;
 	$r = q("SELECT `uid` FROM `user`
                	WHERE `nickname` = '%s' LIMIT 1",
                	dbesc($nickname)


### PR DESCRIPTION
Additionally we are dropping the rule that the username must start with a letter - see issue https://github.com/friendica/friendica/issues/1604