### PR TITLE
queue inspector

### DIFF
--- a/mod/admin.php
+++ b/mod/admin.php
@@ -105,7 +105,8 @@ function admin_content(&$a) {
 		'users'	 =>	Array($a->get_baseurl(true)."/admin/users/", t("Users") , "users"),
 		'plugins'=>	Array($a->get_baseurl(true)."/admin/plugins/", t("Plugins") , "plugins"),
 		'themes' =>	Array($a->get_baseurl(true)."/admin/themes/", t("Themes") , "themes"),
-		'dbsync' => Array($a->get_baseurl(true)."/admin/dbsync/", t('DB updates'), "dbsync"),
+		'dbsync' => 	Array($a->get_baseurl(true)."/admin/dbsync/", t('DB updates'), "dbsync"),
+		'queue'	 =>	Array($a->get_baseurl(true)."/admin/queue/", t('Inspect Queue'), "queue"),
 		//'update' =>	Array($a->get_baseurl(true)."/admin/update/", t("Software Update") , "update")
 	);
 
@@ -165,6 +166,9 @@ function admin_content(&$a) {
 			case 'update':
 				$o = admin_page_remoteupdate($a);
 				break;
+			case 'queue':
+			    	$o = admin_page_queue($a);
+				break;
 			default:
 				notice( t("Item not found.") );
 		}
@@ -181,7 +185,30 @@ function admin_content(&$a) {
 	}
 }
 
+/**
+ * Admin Inspect Queue Page
+ * @param App $a
+ * return string
+ */
+function admin_page_queue(&$a) {
+    	// get content from the queue table
+    	$r = q("SELECT c.name,c.nurl,q.id,q.network,q.created,q.last from queue as q, contact as c where c.id=q.cid order by q.cid, q.created;");
 
+	$t = get_markup_template("admin_queue.tpl");
+	return replace_macros($t, array(
+		'$title' => t('Administration'),
+		'$page' => t('Inspect Queue'),
+		'$count' => sizeof($r),
+		'id_header' => t('ID'),
+		'$to_header' => t('Recipient Name'),
+		'$url_header' => t('Recipient Profile'),
+		'$network_header' => t('Network'),
+		'$created_header' => t('Created'),
+		'$last_header' => t('Last Tried'),
+		'$info' => t('This page lists the content of the queue for outgoing postings. These are postings the initial delivery failed for. They will be resend later and eventually deleted if the delivery fails permanently.'),
+		'$entries' => $r,
+	));
+}
 /**
  * Admin Summary Page
  * @param App $a

--- a/mod/admin.php
+++ b/mod/admin.php
@@ -253,6 +253,7 @@ function admin_page_summary(&$a) {
 		'$accounts' => $accounts,
 		'$pending' => Array( t('Pending registrations'), $pending),
 		'$version' => Array( t('Version'), FRIENDICA_VERSION),
+		'$baseurl' => $a->get_baseurl(),
 		'$platform' => FRIENDICA_PLATFORM,
 		'$codename' => FRIENDICA_CODENAME,
 		'$build' =>  get_config('system','build'),

--- a/view/templates/admin_aside.tpl
+++ b/view/templates/admin_aside.tpl
@@ -17,6 +17,7 @@
 	<li class='admin link button {{$admin.plugins.2}}'><a href='{{$admin.plugins.0}}'>{{$admin.plugins.1}}</a></li>
 	<li class='admin link button {{$admin.themes.2}}'><a href='{{$admin.themes.0}}'>{{$admin.themes.1}}</a></li>
 	<li class='admin link button {{$admin.dbsync.2}}'><a href='{{$admin.dbsync.0}}'>{{$admin.dbsync.1}}</a></li>
+	<li class='admin link button {{$admin.queue.2}}'><a href='{{$admin.queue.0}}'>{{$admin.queue.1}}</a></li>
 </ul>
 
 {{if $admin.update}}

--- a/view/templates/admin_queue.tpl
+++ b/view/templates/admin_queue.tpl
@@ -1,0 +1,25 @@
+<div id='adminpage'>
+	<h1>{{$title}} - {{$page}} ({{$count}})</h1>
+	
+	<p>{{$info}}</p>
+	<table>
+		<tr>
+			<th>{{$id_header}}</th>
+			<th>{{$to_header}}</th>
+			<th>{{$url_header}}</th>
+			<th>{{$network_header}}</th>
+			<th>{{$created_header}}</th>
+			<th>{{$last_header}}</th>
+		</tr>
+		{{foreach $entries as $e}}
+		<tr>
+			<td>{{$e.id}}</td>
+			<td>{{$e.name}}</td>
+			<td><a href="{{$e.nurl}}">{{$e.nurl}}</a></td>
+			<td>{{$e.network}}</td>
+			<td>{{$e.created}}</td>
+			<td>{{$e.last}}</td>
+		</tr>
+		{{/foreach}}
+	</table>
+</div>

--- a/view/templates/admin_summary.tpl
+++ b/view/templates/admin_summary.tpl
@@ -4,7 +4,7 @@
 
 	<dl>
 		<dt>{{$queues.label}}</dt>
-		<dd>{{$queues.deliverq}} - {{$queues.queue}}</dd>
+		<dd>{{$queues.deliverq}} - <a href="/admin/queue">{{$queues.queue}}</a></dd>
 	</dl>
 	<dl>
 		<dt>{{$pending.0}}</dt>

--- a/view/templates/admin_summary.tpl
+++ b/view/templates/admin_summary.tpl
@@ -4,7 +4,7 @@
 
 	<dl>
 		<dt>{{$queues.label}}</dt>
-		<dd>{{$queues.deliverq}} - <a href="/admin/queue">{{$queues.queue}}</a></dd>
+		<dd>{{$queues.deliverq}} - <a href="{{$baseurl}}/admin/queue">{{$queues.queue}}</a></dd>
 	</dl>
 	<dl>
 		<dt>{{$pending.0}}</dt>


### PR DESCRIPTION
this adds a new page to the admin panel which allows to have a quick look into the queued messages. ATM only some information about the queued items is listed, no further actions possible (recipient info, dates when created, when last tried).