### PR TITLE
add support for oneline,in-text code tag

### DIFF
--- a/include/bb2diaspora.php
+++ b/include/bb2diaspora.php
@@ -152,22 +152,22 @@ function format_event_diaspora($ev) {
 	$o .= '**' . (($ev['summary']) ? bb2diaspora($ev['summary']) : bb2diaspora($ev['desc'])) .  '**' . "\n";
 
 	$o .= t('Starts:') . ' ' . '['
-		. (($ev['adjust']) ? day_translate(datetime_convert('UTC', 'UTC', 
+		. (($ev['adjust']) ? day_translate(datetime_convert('UTC', 'UTC',
 			$ev['start'] , $bd_format ))
-			:  day_translate(datetime_convert('UTC', 'UTC', 
+			:  day_translate(datetime_convert('UTC', 'UTC',
 			$ev['start'] , $bd_format)))
 		.  '](' . $a->get_baseurl() . '/localtime/?f=&time=' . urlencode(datetime_convert('UTC','UTC',$ev['start'])) . ")\n";
 
 	if(! $ev['nofinish'])
-		$o .= t('Finishes:') . ' ' . '[' 
-			. (($ev['adjust']) ? day_translate(datetime_convert('UTC', 'UTC', 
+		$o .= t('Finishes:') . ' ' . '['
+			. (($ev['adjust']) ? day_translate(datetime_convert('UTC', 'UTC',
 				$ev['finish'] , $bd_format ))
-				:  day_translate(datetime_convert('UTC', 'UTC', 
+				:  day_translate(datetime_convert('UTC', 'UTC',
 				$ev['finish'] , $bd_format )))
 			. '](' . $a->get_baseurl() . '/localtime/?f=&time=' . urlencode(datetime_convert('UTC','UTC',$ev['finish'])) . ")\n";
 
 	if(strlen($ev['location']))
-		$o .= t('Location:') . bb2diaspora($ev['location']) 
+		$o .= t('Location:') . bb2diaspora($ev['location'])
 			. "\n";
 
 	$o .= "\n";

--- a/include/bbcode.php
+++ b/include/bbcode.php
@@ -268,6 +268,13 @@ function stripcode_br_cb($s) {
 	return '[code]' . str_replace('<br />', '', $s[1]) . '[/code]';
 }
 
+function bb_onelinecode_cb($match) {
+	if (strpos($match[1],"<br>")===false){
+		return "<key>".$match[1]."</key>";
+	}
+	return "<code>".$match[1]."</code>";
+}
+
 function tryoembed($match){
 	//$url = ((count($match)==2)?$match[1]:$match[2]);
 	$url = $match[1];
@@ -1179,7 +1186,7 @@ function bbcode($Text,$preserve_nl = false, $tryoembed = true, $simplehtml = fal
 
 	// If we found an event earlier, strip out all the event code and replace with a reformatted version.
 	// Replace the event-start section with the entire formatted event. The other bbcode is stripped.
-	// Summary (e.g. title) is required, earlier revisions only required description (in addition to 
+	// Summary (e.g. title) is required, earlier revisions only required description (in addition to
 	// start which is always required). Allow desc with a missing summary for compatibility.
 
 	if((x($ev,'desc') || x($ev,'summary')) && x($ev,'start')) {
@@ -1192,6 +1199,10 @@ function bbcode($Text,$preserve_nl = false, $tryoembed = true, $simplehtml = fal
 		$Text = preg_replace("/\[event\-location\](.*?)\[\/event\-location\]/ism",'',$Text);
 		$Text = preg_replace("/\[event\-adjust\](.*?)\[\/event\-adjust\]/ism",'',$Text);
 	}
+
+
+	//replace oneliner <code> with <key>
+	$Text = preg_replace_callback("|(?!<br[^>]*>)<code>([^<]*)</code>(?!<br[^>]*>)|ism", 'bb_onelinecode_cb', $Text);
 
 	// Unhide all [noparse] contained bbtags unspacefying them
 	// and triming the [noparse] tag.

--- a/include/html2bbcode.php
+++ b/include/html2bbcode.php
@@ -90,12 +90,18 @@ function html2bbcode($message)
 
 	$message = str_replace("\r", "", $message);
 
+	$message = preg_replace_callback("|<pre><code>([^<]*)</code></pre>|ism", function($m) {
+		return "<code>".str_replace("\n","<br>\n",$m[1]). "</code>";
+	}, $message);
+
 	$message = str_replace(array(
 					"<li><p>",
-					"</p></li>"),
+					"</p></li>",
+				),
 				array(
 					"<li>",
-					"</li>"),
+					"</li>",
+				),
 				$message);
 
 	// remove namespaces
@@ -187,6 +193,7 @@ function html2bbcode($message)
 
 	node2bbcode($doc, 'span', array(), "", "");
 	node2bbcode($doc, 'pre', array(), "", "");
+
 	node2bbcode($doc, 'div', array(), "\r", "\r");
 	node2bbcode($doc, 'p', array(), "\n", "\n");
 
@@ -230,6 +237,7 @@ function html2bbcode($message)
 	node2bbcode($doc, 'iframe', array('src'=>'/(.+)/'), '[iframe]$1', '[/iframe]');
 
 	node2bbcode($doc, 'code', array(), '[code]', '[/code]');
+    node2bbcode($doc, 'key', array(), '[code]', '[/code]');
 
 	$message = $doc->saveHTML();
 

--- a/view/global.css
+++ b/view/global.css
@@ -170,6 +170,9 @@ span.oembed, h4 {
   margin: 0px 0px 0px 0px;
 }
 
+code { display: block; background-color: #eee; color: #666; padding:1em; font-size: 0.8em; font-family: monospace; }
+key { display: inline; background-color: #eee; color: #666; padding:0.2em; font-size: 0.8em; font-family: monospace; }
+
 /* fields help text */
 .field .field_help {
     clear: left;
@@ -177,7 +180,6 @@ span.oembed, h4 {
 
 /* notifications unseen */
 .notify-unseen { background-color: #cceeFF; }
-
 
 /* plain text editor upload/select popup */
 


### PR DESCRIPTION
this is related to issue #1796 

There is an issue when a post contains only `[code]...[/code]` with no newline at the end it's rendered as inline.

Please test it before merge.
