### PR TITLE
Visible search options

### DIFF
--- a/include/nav.php
+++ b/include/nav.php
@@ -26,7 +26,7 @@ function nav(&$a) {
 	$tpl = get_markup_template('nav.tpl');
 
 	$a->page['nav'] .= replace_macros($tpl, array(
-        '$baseurl' => $a->get_baseurl(),
+		'$baseurl' => $a->get_baseurl(),
 		'$langselector' => lang_selector(),
 		'$sitelocation' => $nav_info['sitelocation'],
 		'$nav' => $nav_info['nav'],
@@ -117,6 +117,12 @@ function nav_info(&$a) {
 		$nav['apps'] = array('apps', t('Apps'), "", t('Addon applications, utilities, games'));
 
 	$nav['search'] = array('search', t('Search'), "", t('Search site content'));
+
+	$nav['searchoption'] = array(
+					t("Full Text"),
+					t("Tags"),
+					t("Contacts"),
+					t("Forums"));
 
 	$gdirpath = 'directory';
 

--- a/include/text.php
+++ b/include/text.php
@@ -986,21 +986,26 @@ if(! function_exists('search')) {
  * @param string $url search url
  * @param boolean $savedsearch show save search button
  */
-function search($s,$id='search-box',$url='/search',$save = false) {
+function search($s,$id='search-box',$url='/search',$save = false, $aside = true) {
 	$a = get_app();
-        return replace_macros(get_markup_template('searchbox.tpl'), array(
-		'$s' => $s,
-		'$id' => $id,
-		'$action_url' => $a->get_baseurl((stristr($url,'network')) ? true : false) . $url,
-		'$search_label' => t('Search'),
-		'$save_label' => t('Save'),
-		'$savedsearch' => feature_enabled(local_user(),'savedsearch'),
-		'$searchoption' => array(
+
+	$values = array(
+			'$s' => $s,
+			'$id' => $id,
+			'$action_url' => $a->get_baseurl((stristr($url,'network')) ? true : false) . $url,
+			'$search_label' => t('Search'),
+			'$save_label' => t('Save'),
+			'$savedsearch' => feature_enabled(local_user(),'savedsearch'),
+		);
+
+	if (!$aside)
+		$values['$searchoption'] = array(
 					t("Full Text"),
 					t("Tags"),
 					t("Contacts"),
-					t("Forums"))
-	));
+					t("Forums"));
+
+        return replace_macros(get_markup_template('searchbox.tpl'), $values);
 }}
 
 if(! function_exists('valid_email')) {

--- a/include/text.php
+++ b/include/text.php
@@ -995,6 +995,11 @@ function search($s,$id='search-box',$url='/search',$save = false) {
 		'$search_label' => t('Search'),
 		'$save_label' => t('Save'),
 		'$savedsearch' => feature_enabled(local_user(),'savedsearch'),
+		'$searchoption' => array(
+					t("Full Text"),
+					t("Tags"),
+					t("Contacts"),
+					t("Forums"))
 	));
 }}
 

--- a/mod/dirfind.php
+++ b/mod/dirfind.php
@@ -14,13 +14,13 @@ function dirfind_init(&$a) {
 
 
 
-function dirfind_content(&$a) {
+function dirfind_content(&$a, $prefix = "") {
 
 	$community = false;
 
 	$local = get_config('system','poco_local_search');
 
-	$search = notags(trim($_REQUEST['search']));
+	$search = $prefix.notags(trim($_REQUEST['search']));
 
 	if(strpos($search,'@') === 0)
 		$search = substr($search,1);

--- a/mod/search.php
+++ b/mod/search.php
@@ -111,7 +111,7 @@ function search_content(&$a) {
 	}
 
 
-	$o .= search($search,'search-box','/search',((local_user()) ? true : false));
+	$o .= search($search,'search-box','/search',((local_user()) ? true : false), false);
 
 	if(strpos($search,'#') === 0) {
 		$tag = true;

--- a/mod/search.php
+++ b/mod/search.php
@@ -1,4 +1,8 @@
 <?php
+require_once("include/bbcode.php");
+require_once('include/security.php');
+require_once('include/conversation.php');
+require_once('mod/dirfind.php');
 
 function search_saved_searches() {
 
@@ -92,9 +96,6 @@ function search_content(&$a) {
 
 	nav_set_selected('search');
 
-	require_once("include/bbcode.php");
-	require_once('include/security.php');
-	require_once('include/conversation.php');
 
 	$o = '<h3>' . t('Search') . '</h3>';
 
@@ -117,13 +118,26 @@ function search_content(&$a) {
 		$search = substr($search,1);
 	}
 	if(strpos($search,'@') === 0) {
-		require_once('mod/dirfind.php');
 		return dirfind_content($a);
 	}
 	if(strpos($search,'!') === 0) {
-		require_once('mod/dirfind.php');
 		return dirfind_content($a);
 	}
+
+        if(x($_GET,'search-option'))
+		switch($_GET['search-option']) {
+			case 'fulltext':
+				break;
+			case 'tags':
+				$tag = true;
+				break;
+			case 'contacts':
+				return dirfind_content($a, "@");
+				break;
+			case 'forums':
+				return dirfind_content($a, "!");
+				break;
+		}
 
 	if(! $search)
 		return $o;

--- a/view/templates/searchbox.tpl
+++ b/view/templates/searchbox.tpl
@@ -2,6 +2,13 @@
         <form action="{{$action_url}}" method="get" >
                 {{strip}}
                 <input type="text" name="search" id="search-text" placeholder="{{$search_label}}" value="{{$s}}" />
+		<select name="search-option">
+			<option value="fulltext">{{$searchoption.0}}</option>
+			<option value="tags">{{$searchoption.1}}</option>
+			<option value="contacts">{{$searchoption.2}}</option>
+			<option value="forums">{{$searchoption.3}}</option>
+		</select>
+
                 <input type="submit" name="submit" id="search-submit" value="{{$search_label}}" />
                 {{if $savedsearch}}
                 <input type="submit" name="save" id="search-save" value="{{$save_label}}" />

--- a/view/templates/searchbox.tpl
+++ b/view/templates/searchbox.tpl
@@ -2,12 +2,14 @@
         <form action="{{$action_url}}" method="get" >
                 {{strip}}
                 <input type="text" name="search" id="search-text" placeholder="{{$search_label}}" value="{{$s}}" />
-		<select name="search-option">
+                {{if $searchoption}}
+		<select name="search-option" id="search-options">
 			<option value="fulltext">{{$searchoption.0}}</option>
 			<option value="tags">{{$searchoption.1}}</option>
 			<option value="contacts">{{$searchoption.2}}</option>
 			<option value="forums">{{$searchoption.3}}</option>
 		</select>
+		{{/if}}
 
                 <input type="submit" name="submit" id="search-submit" value="{{$search_label}}" />
                 {{if $savedsearch}}

--- a/view/theme/vier/templates/nav.tpl
+++ b/view/theme/vier/templates/nav.tpl
@@ -72,6 +72,12 @@
 			<li role="search" id="search-box">
 				<form method="get" action="{{$nav.search.0}}">
 					<input accesskey="s" id="search-text" class="nav-menu-search" type="text" value="" name="search">
+					<select name="search-option">
+						<option value="fulltext">{{$nav.searchoption.0}}</option>
+						<option value="tags">{{$nav.searchoption.1}}</option>
+						<option value="contacts">{{$nav.searchoption.2}}</option>
+						<option value="forums">{{$nav.searchoption.3}}</option>
+					</select>
 				</form>
 			</li>
 		{{/if}}


### PR DESCRIPTION
It has always bothered me that searching for tags and contacts seemed to be some kind of "occult science" (How should one know that you have to set a prefix like "#" or "@" to the search expression?)

Now the options are visible to everybody.