### PR TITLE
Soapbox-Improvements

### DIFF
--- a/include/diaspora.php
+++ b/include/diaspora.php
@@ -590,7 +590,7 @@ function diaspora_request($importer,$xml) {
 		// perhaps we were already sharing with this person. Now they're sharing with us.
 		// That makes us friends.
 
-		if($contact['rel'] == CONTACT_IS_FOLLOWER && $importer['page-flags'] != PAGE_COMMUNITY) {
+		if($contact['rel'] == CONTACT_IS_FOLLOWER && !in_array($importer['page-flags'], array(PAGE_COMMUNITY, PAGE_SOAPBOX))) {
 			q("UPDATE `contact` SET `rel` = %d, `writable` = 1 WHERE `id` = %d AND `uid` = %d",
 				intval(CONTACT_IS_FRIEND),
 				intval($contact['id']),
@@ -767,12 +767,12 @@ function diaspora_request($importer,$xml) {
 	return;
 }
 
-function diaspora_post_allow($importer,$contact) {
+function diaspora_post_allow($importer,$contact, $is_comment = false) {
 
 	// perhaps we were already sharing with this person. Now they're sharing with us.
 	// That makes us friends.
 	// Normally this should have handled by getting a request - but this could get lost
-	if($contact['rel'] == CONTACT_IS_FOLLOWER && $importer['page-flags'] != PAGE_COMMUNITY) {
+	if($contact['rel'] == CONTACT_IS_FOLLOWER && !in_array($importer['page-flags'], array(PAGE_COMMUNITY, PAGE_SOAPBOX))) {
 		q("UPDATE `contact` SET `rel` = %d, `writable` = 1 WHERE `id` = %d AND `uid` = %d",
 			intval(CONTACT_IS_FRIEND),
 			intval($contact['id']),
@@ -787,7 +787,7 @@ function diaspora_post_allow($importer,$contact) {
 	if($contact['rel'] == CONTACT_IS_SHARING || $contact['rel'] == CONTACT_IS_FRIEND)
 		return true;
 	if($contact['rel'] == CONTACT_IS_FOLLOWER)
-		if($importer['page-flags'] == PAGE_COMMUNITY)
+		if(($importer['page-flags'] == PAGE_COMMUNITY) OR $is_comment)
 			return true;
 
 	// Messages for the global users are always accepted
@@ -840,7 +840,7 @@ function diaspora_post($importer,$xml,$msg) {
 		return 203;
 	}
 
-	if(! diaspora_post_allow($importer,$contact)) {
+	if(! diaspora_post_allow($importer,$contact, false)) {
 		logger('diaspora_post: Ignoring this author.');
 		return 202;
 	}
@@ -1117,7 +1117,7 @@ function diaspora_reshare($importer,$xml,$msg) {
 	if(! $contact)
 		return;
 
-	if(! diaspora_post_allow($importer,$contact)) {
+	if(! diaspora_post_allow($importer,$contact, false)) {
 		logger('diaspora_reshare: Ignoring this author: ' . $diaspora_handle . ' ' . print_r($xml,true));
 		return 202;
 	}
@@ -1303,7 +1303,7 @@ function diaspora_asphoto($importer,$xml,$msg) {
 	if(! $contact)
 		return;
 
-	if(! diaspora_post_allow($importer,$contact)) {
+	if(! diaspora_post_allow($importer,$contact, false)) {
 		logger('diaspora_asphoto: Ignoring this author.');
 		return 202;
 	}
@@ -1399,7 +1399,7 @@ function diaspora_comment($importer,$xml,$msg) {
 		return;
 	}
 
-	if(! diaspora_post_allow($importer,$contact)) {
+	if(! diaspora_post_allow($importer,$contact, true)) {
 		logger('diaspora_comment: Ignoring this author.');
 		return 202;
 	}
@@ -1903,7 +1903,7 @@ function diaspora_photo($importer,$xml,$msg,$attempt=1) {
 		return;
 	}
 
-	if(! diaspora_post_allow($importer,$contact)) {
+	if(! diaspora_post_allow($importer,$contact, false)) {
 		logger('diaspora_photo: Ignoring this author.');
 		return 202;
 	}
@@ -1990,7 +1990,7 @@ function diaspora_like($importer,$xml,$msg) {
 		return;
 	}
 
-	if(! diaspora_post_allow($importer,$contact)) {
+	if(! diaspora_post_allow($importer,$contact, false)) {
 		logger('diaspora_like: Ignoring this author.');
 		return 202;
 	}

--- a/mod/dfrn_notify.php
+++ b/mod/dfrn_notify.php
@@ -130,9 +130,10 @@ function dfrn_notify_post(&$a) {
 
 
 	// If we are setup as a soapbox we aren't accepting input from this person
-
-	if($importer['page-flags'] == PAGE_SOAPBOX)
-		xml_status(0);
+	// This behaviour is deactivated since it really doesn't make sense to even disallow comments
+	// The check if someone is a friend or simply a follower is done in a later place so it needn't to be done here
+	//if($importer['page-flags'] == PAGE_SOAPBOX)
+	//	xml_status(0);
 
 	$rino = get_config('system','rino_encrypt');
 	$rino = intval($rino);

--- a/mod/follow.php
+++ b/mod/follow.php
@@ -14,10 +14,12 @@ function follow_content(&$a) {
 	$uid = local_user();
 	$url = notags(trim($_REQUEST['url']));
 
-	$r = q("SELECT `url` FROM `contact` WHERE `uid` = %d AND
+	// There is a current issue. It seems as if you can't start following a Friendica that is following you
+	// With Diaspora this works - but Friendica is special, it seems ...
+	$r = q("SELECT `url` FROM `contact` WHERE `uid` = %d AND ((`rel` != %d) OR (`network` = '%s')) AND
 		(`nurl` = '%s' OR `alias` = '%s' OR `alias` = '%s') AND
 		`network` != '%s' LIMIT 1",
-		intval(local_user()), dbesc(normalise_link($url)),
+		intval(local_user()), dbesc(CONTACT_IS_FOLLOWER), dbesc(NETWORK_DFRN), dbesc(normalise_link($url)),
 		dbesc(normalise_link($url)), dbesc($url), dbesc(NETWORK_STATUSNET));
 
 	if ($r) {

--- a/view/templates/manage.tpl
+++ b/view/templates/manage.tpl
@@ -4,7 +4,7 @@
 <div id="identity-manage-choose">{{$choose}}</div>
 <div id="identity-selector-wrapper">
 	<form action="manage" method="post" >
-	<select name="identity" size="4" onchange="this.form.submit();" >
+	<select name="identity" size="10" onchange="this.form.submit();" >
 
 	{{foreach $identities as $id}}
 		<option {{$id.selected}} value="{{$id.uid}}">{{$id.username}} ({{$id.nickname}})</option>


### PR DESCRIPTION
The soapbox account hadn't worked very well. There were especially two problems:

1. Followers from Diaspora were automatically converted into friends. So Diaspora accounts had been able to comment and their items were accepted as well.
2. Followers from Friendica hadn't been able to comment nor their posts weren't accepted.

Now the behavior is changed:

1. Followers can always comment
2. Followers can't post new items

Additionally it is now able to establish a bidirectional contact (aka "Frienship") if it was a unidirectional contact (aka "Follower") before. But: This doesn't work with Friendica. There seems to be an issue with the keys which we have to address in a separate pull request.