### PR TITLE
Improvements to OStatus subscriptions

### DIFF
--- a/include/follow.php
+++ b/include/follow.php
@@ -170,6 +170,11 @@ function new_contact($uid,$url,$interactive = false) {
 		dbesc($ret['network'])
 	);
 
+	if(!count($r))
+		$r = q("SELECT * FROM `contact` WHERE `uid` = %d AND `nurl` = '%s' AND `network` = '%s' LIMIT 1",
+			intval($uid), dbesc(normalise_link($url)), dbesc($ret['network'])
+	);
+
 	if(count($r)) {
 		// update contact
 		if($r[0]['rel'] == CONTACT_IS_FOLLOWER || ($network === NETWORK_DIASPORA && $r[0]['rel'] == CONTACT_IS_SHARING)) {
@@ -180,7 +185,6 @@ function new_contact($uid,$url,$interactive = false) {
 				intval($uid)
 			);
 		}
-
 	} else {
 
 
@@ -285,7 +289,7 @@ function new_contact($uid,$url,$interactive = false) {
 
 	// pull feed and consume it, which should subscribe to the hub.
 
-	proc_run('php',"include/poller.php","$contact_id");
+	proc_run('php',"include/onepoll.php","$contact_id", "force");
 
 	// create a follow slap
 

--- a/include/items.php
+++ b/include/items.php
@@ -4300,7 +4300,7 @@ function subscribe_to_hub($url,$importer,$contact,$hubmode = 'subscribe') {
 
 	logger('subscribe_to_hub: ' . $hubmode . ' ' . $contact['name'] . ' to hub ' . $url . ' endpoint: '  . $push_url . ' with verifier ' . $verify_token);
 
-	if(! strlen($contact['hub-verify'])) {
+	if(!strlen($contact['hub-verify']) OR ($contact['hub-verify'] != $verify_token)) {
 		$r = q("UPDATE `contact` SET `hub-verify` = '%s' WHERE `id` = %d",
 			dbesc($verify_token),
 			intval($contact['id'])

--- a/include/notifier.php
+++ b/include/notifier.php
@@ -295,7 +295,7 @@ function notifier_run(&$argv, &$argc){
 			$relay_to_owner = false;
 
 		if($relay_to_owner) {
-			logger('notifier: followup', LOGGER_DEBUG);
+			logger('notifier: followup '.$target_item["guid"], LOGGER_DEBUG);
 			// local followup to remote post
 			$followup = true;
 			$public_message = false; // not public
@@ -330,6 +330,8 @@ function notifier_run(&$argv, &$argc){
 			}
 		} else {
 			$followup = false;
+
+			logger('Distributing directly '.$target_item["guid"], LOGGER_DEBUG);
 
 			// don't send deletions onward for other people's stuff
 
@@ -378,7 +380,7 @@ function notifier_run(&$argv, &$argc){
 			}
 
 			if (count($url_recipients))
-				logger('notifier: url_recipients ' . print_r($url_recipients,true));
+				logger('notifier: '.$target_item["guid"].' url_recipients ' . print_r($url_recipients,true));
 
 			$conversants = array_unique($conversants);
 
@@ -393,6 +395,8 @@ function notifier_run(&$argv, &$argc){
 		// If the thread parent is OStatus then do some magic to distribute the messages.
 		// We have not only to look at the parent, since it could be a Friendica thread.
 		if (($thr_parent AND ($thr_parent[0]['network'] == NETWORK_OSTATUS)) OR ($parent['network'] == NETWORK_OSTATUS)) {
+
+			logger('Some parent is OStatus for '.$target_item["guid"], LOGGER_DEBUG);
 
 			// Send a salmon notification to every person we mentioned in the post
 			$arr = explode(',',$target_item['tag']);
@@ -650,7 +654,7 @@ function notifier_run(&$argv, &$argc){
 			if($contact['self'])
 				continue;
 
-			logger("Deliver to ".$contact['url'], LOGGER_DEBUG);
+			logger("Deliver ".$target_item["guid"]." to ".$contact['url'], LOGGER_DEBUG);
 
 			// potentially more than one recipient. Start a new process and space them out a bit.
 			// we will deliver single recipient types of message and email recipients here.

--- a/include/onepoll.php
+++ b/include/onepoll.php
@@ -53,6 +53,9 @@ function onepoll_run(&$argv, &$argc){
 	if(($argc > 1) && (intval($argv[1])))
 		$contact_id = intval($argv[1]);
 
+	if(($argc > 2) && ($argv[2] == "force"))
+		$force = true;
+
 	if(! $contact_id) {
 		logger('onepoll: no contact');
 		return;
@@ -595,8 +598,10 @@ function onepoll_run(&$argv, &$argc){
 			return;
 		}
 
-		consume_feed($xml,$importer,$contact,$hub,1,1);
 
+		logger("Consume feed of contact ".$contact['id']);
+
+		consume_feed($xml,$importer,$contact,$hub,1,1);
 
 		// do it twice. Ensures that children of parents which may be later in the stream aren't tossed
 
@@ -608,6 +613,11 @@ function onepoll_run(&$argv, &$argc){
 
 		if(($contact['network'] === NETWORK_OSTATUS ||  $contact['network'] == NETWORK_FEED) && (! $contact['hub-verify']))
 			$hub_update = true;
+
+		if ($force)
+			$hub_update = true;
+
+		logger("Contact ".$contact['id']." returned hub: ".$hub." Network: ".$contact['network']." Relation: ".$contact['rel']." Update: ".$hub_update);
 
 		if((strlen($hub)) && ($hub_update) && (($contact['rel'] != CONTACT_IS_FOLLOWER) || $contact['network'] == NETWORK_FEED) ) {
 			logger('poller: hub ' . $hubmode . ' : ' . $hub . ' contact name : ' . $contact['name'] . ' local user : ' . $importer['name']);

--- a/mod/ostatus_subscribe.php
+++ b/mod/ostatus_subscribe.php
@@ -1,0 +1,78 @@
+<?php
+
+require_once('include/Scrape.php');
+require_once('include/follow.php');
+
+function ostatus_subscribe_content(&$a) {
+
+	if(! local_user()) {
+		notice( t('Permission denied.') . EOL);
+		goaway($_SESSION['return_url']);
+		// NOTREACHED
+	}
+
+	$o = "<h2>".t("Subsribing to OStatus contacts")."</h2>";
+
+	$uid = local_user();
+
+	$a = get_app();
+
+	$counter = intval($_REQUEST['counter']);
+
+	if (get_pconfig($uid, "ostatus", "legacy_friends") == "") {
+
+		if ($_REQUEST["url"] == "")
+			return $o.t("No contact provided.");
+
+		$contact = probe_url($_REQUEST["url"]);
+
+		if (!$contact)
+			return $o.t("Couldn't fetch information for contact.");
+
+		$api = $contact["baseurl"]."/api/";
+
+		// Fetching friends
+		$data = z_fetch_url($api."statuses/friends.json?screen_name=".$contact["nick"]);
+
+		if (!$data["success"])
+			return $o.t("Couldn't fetch friends for contact.");
+
+		set_pconfig($uid, "ostatus", "legacy_friends", $data["body"]);
+	}
+
+	$friends = json_decode(get_pconfig($uid, "ostatus", "legacy_friends"));
+
+	$total = sizeof($friends);
+
+	if ($counter >= $total) {
+		$a->page['htmlhead'] = '<meta http-equiv="refresh" content="0; URL='.$a->get_baseurl().'/settings/connectors">';
+		del_pconfig($uid, "ostatus", "legacy_friends");
+		del_pconfig($uid, "ostatus", "legacy_contact");
+		$o .= t("Done");
+		return $o;
+	}
+
+	$friend = $friends[$counter++];
+
+	$url = $friend->statusnet_profile_url;
+
+	$o .= "<p>".$counter."/".$total.": ".$url;
+
+	$data = probe_url($url);
+	if ($data["network"] == NETWORK_OSTATUS) {
+		$result = new_contact($uid,$url,true);
+		if ($result["success"])
+			$o .= " - ".t("success");
+		else
+			$o .= " - ".t("failed");
+	} else
+		$o .= " - ".t("ignored");
+
+	$o .= "</p>";
+
+	$o .= "<p>".t("Keep this window open until done.")."</p>";
+
+	$a->page['htmlhead'] = '<meta http-equiv="refresh" content="0; URL='.$a->get_baseurl().'/ostatus_subscribe?counter='.$counter.'">';
+
+	return $o;
+}

--- a/mod/repair_ostatus.php
+++ b/mod/repair_ostatus.php
@@ -38,7 +38,7 @@ function repair_ostatus_content(&$a) {
                 intval($uid),
                 dbesc(NETWORK_OSTATUS),
                 intval(CONTACT_IS_FRIEND),
-                intval(CONTACT_IS_SHARING), ++$counter);
+                intval(CONTACT_IS_SHARING), $counter++);
 
 	if (!$r) {
 		$o .= t("Done");

--- a/mod/repair_ostatus.php
+++ b/mod/repair_ostatus.php
@@ -1,0 +1,57 @@
+<?php
+
+require_once('include/Scrape.php');
+require_once('include/follow.php');
+
+function repair_ostatus_content(&$a) {
+
+	if(! local_user()) {
+		notice( t('Permission denied.') . EOL);
+		goaway($_SESSION['return_url']);
+		// NOTREACHED
+	}
+
+	$o = "<h2>".t("Resubsribing to OStatus contacts")."</h2>";
+
+	$uid = local_user();
+
+	$a = get_app();
+
+	$counter = intval($_REQUEST['counter']);
+
+        $r = q("SELECT COUNT(*) AS `total` FROM `contact` WHERE
+                `uid` = %d AND `network` = '%s' AND `rel` IN (%d, %d)",
+                intval($uid),
+                dbesc(NETWORK_OSTATUS),
+                intval(CONTACT_IS_FRIEND),
+                intval(CONTACT_IS_SHARING));
+
+	if (!$r)
+		return($o.t("Error"));
+
+	$total = $r[0]["total"];
+
+        $r = q("SELECT `url` FROM `contact` WHERE
+                `uid` = %d AND `network` = '%s' AND `rel` IN (%d, %d)
+		ORDER BY `url`
+		LIMIT %d, 1",
+                intval($uid),
+                dbesc(NETWORK_OSTATUS),
+                intval(CONTACT_IS_FRIEND),
+                intval(CONTACT_IS_SHARING), ++$counter);
+
+	if (!$r) {
+		$o .= t("Done");
+		return $o;
+	}
+
+	$o .= "<p>".$counter."/".$total.": ".$r[0]["url"]."</p>";
+
+	$o .= "<p>".t("Keep this window open until done.")."</p>";
+
+	$result = new_contact($uid,$r[0]["url"],true);
+
+	$a->page['htmlhead'] = '<meta http-equiv="refresh" content="1; URL='.$a->get_baseurl().'/repair_ostatus?counter='.$counter.'">';
+
+	return $o;
+}

--- a/mod/settings.php
+++ b/mod/settings.php
@@ -189,7 +189,7 @@ function settings_post(&$a) {
 		if(x($_POST, 'general-submit')) {
 			set_pconfig(local_user(), 'system', 'no_intelligent_shortening', intval($_POST['no_intelligent_shortening']));
 			set_pconfig(local_user(), 'system', 'ostatus_autofriend', intval($_POST['snautofollow']));
-			//set_pconfig(local_user(), 'system', 'ostatus_legacy_contact', $_POST['legacy_contact']);
+			set_pconfig(local_user(), 'ostatus', 'legacy_contact', $_POST['legacy_contact']);
 		} elseif(x($_POST, 'imap-submit')) {
 
 			$mail_server       = ((x($_POST,'mail_server')) ? $_POST['mail_server'] : '');
@@ -770,18 +770,18 @@ function settings_content(&$a) {
 		$settings_connectors .= '<span class="field_help">'.t('If you receive a message from an unknown OStatus user, this option decides what to do. If it is checked, a new contact will be created for every unknown user.').'</span>';
 		$settings_connectors .= '</div>';
 
-		$settings_connectors .= '<p><a href="'.$a->get_baseurl().'/repair_ostatus">'.t("Repair OStatus subscriptions").'</a></p>';
+		$legacy_contact = get_pconfig(local_user(), 'ostatus', 'legacy_contact');
 
-		/*
-		// Deactivated by now - it doesn't seem to work reliable
-		$legacy_contact = get_pconfig(local_user(), 'system', 'ostatus_legacy_contact');
+		if ($legacy_contact != "")
+			$a->page['htmlhead'] = '<meta http-equiv="refresh" content="0; URL='.$a->get_baseurl().'/ostatus_subscribe?url='.urlencode($legacy_contact).'">';
 
 		$settings_connectors .= '<div id="legacy-contact-wrapper" class="field input">';
 		$settings_connectors .= '<label id="legacy-contact-label" for="snautofollow-checkbox">'. t('Your legacy GNU Social account'). '</label>';
 		$settings_connectors .= '<input id="legacy-contact-checkbox" name="legacy_contact" value="'.$legacy_contact.'"/>';
 		$settings_connectors .= '<span class="field_help">'.t('If you enter your old GNU Social/Statusnet account name here (in the format user@domain.tld), your contacts will be added automatically. The field will be emptied when done.').'</span>';
 		$settings_connectors .= '</div>';
-		*/
+
+		$settings_connectors .= '<p><a href="'.$a->get_baseurl().'/repair_ostatus">'.t("Repair OStatus subscriptions").'</a></p>';
 
 		$settings_connectors .= '<div class="settings-submit-wrapper" ><input type="submit" name="general-submit" class="settings-submit" value="' . t('Save Settings') . '" /></div>';
 

--- a/mod/settings.php
+++ b/mod/settings.php
@@ -770,6 +770,8 @@ function settings_content(&$a) {
 		$settings_connectors .= '<span class="field_help">'.t('If you receive a message from an unknown OStatus user, this option decides what to do. If it is checked, a new contact will be created for every unknown user.').'</span>';
 		$settings_connectors .= '</div>';
 
+		$settings_connectors .= '<p><a href="'.$a->get_baseurl().'/repair_ostatus">'.t("Repair OStatus subscriptions").'</a></p>';
+
 		/*
 		// Deactivated by now - it doesn't seem to work reliable
 		$legacy_contact = get_pconfig(local_user(), 'system', 'ostatus_legacy_contact');


### PR DESCRIPTION
In the past it happened that subscribing to OStatus contacts wasn't successful (although it seemed so). There is now a repair option in the social network settings. Additionally the option to subscribe the friends of a legacy GNU Social account is reactivated again.