### PR TITLE
Some settings to control the system load

### DIFF
--- a/include/socgraph.php
+++ b/include/socgraph.php
@@ -1259,8 +1259,8 @@ function poco_discover($complete = false) {
 
 	$no_of_queries = 5;
 
-	$last_update = date("c", time() - (60 * 60 * 6)); // 24
-	$last_update = date("c", time() - (60 * 60 * 24)); // 24
+	//$last_update = date("c", time() - (60 * 60 * 24)); // 24
+	$last_update = date("c", time() - (60 * 60 * 24 * 7));
 
 	$r = q("SELECT `poco`, `nurl`, `url`, `network` FROM `gserver` WHERE `last_contact` >= `last_failure` AND `poco` != '' AND `last_poco_query` < '%s' ORDER BY RAND()", dbesc($last_update));
 	if ($r)

--- a/include/socgraph.php
+++ b/include/socgraph.php
@@ -1259,8 +1259,12 @@ function poco_discover($complete = false) {
 
 	$no_of_queries = 5;
 
-	//$last_update = date("c", time() - (60 * 60 * 24)); // 24
-	$last_update = date("c", time() - (60 * 60 * 24 * 7));
+	$requery_days = intval(get_config("system", "poco_requery_days"));
+
+	if ($requery_days == 0)
+		$requery_days = 7;
+
+	$last_update = date("c", time() - (60 * 60 * 24 * $requery_days));
 
 	$r = q("SELECT `poco`, `nurl`, `url`, `network` FROM `gserver` WHERE `last_contact` >= `last_failure` AND `poco` != '' AND `last_poco_query` < '%s' ORDER BY RAND()", dbesc($last_update));
 	if ($r)

--- a/mod/admin.php
+++ b/mod/admin.php
@@ -387,6 +387,7 @@ function admin_page_site_post(&$a){
 	$maxloadavg		=	((x($_POST,'maxloadavg'))		? intval(trim($_POST['maxloadavg']))		: 50);
 	$maxloadavg_frontend	=	((x($_POST,'maxloadavg_frontend'))	? intval(trim($_POST['maxloadavg_frontend']))	: 50);
 	$poco_completion	=	((x($_POST,'poco_completion'))		? intval(trim($_POST['poco_completion']))	: false);
+	$poco_requery_days	=	((x($_POST,'poco_requery_days'))	? intval(trim($_POST['poco_requery_days']))	: 7);
 	$poco_discovery		=	((x($_POST,'poco_discovery'))		? intval(trim($_POST['poco_discovery']))	: 0);
 	$poco_discovery_since	=	((x($_POST,'poco_discovery_since'))	? intval(trim($_POST['poco_discovery_since']))	: 30);
 	$poco_local_search	=	((x($_POST,'poco_local_search'))	? intval(trim($_POST['poco_local_search']))	: false);
@@ -462,6 +463,7 @@ function admin_page_site_post(&$a){
 	set_config('system','maxloadavg',$maxloadavg);
 	set_config('system','maxloadavg_frontend',$maxloadavg_frontend);
 	set_config('system','poco_completion',$poco_completion);
+	set_config('system','poco_requery_days',$poco_requery_days);
 	set_config('system','poco_discovery',$poco_discovery);
 	set_config('system','poco_discovery_since',$poco_discovery_since);
 	set_config('system','poco_local_search',$poco_local_search);
@@ -744,6 +746,7 @@ function admin_page_site(&$a) {
 		'$maxloadavg_frontend'	=> array('maxloadavg_frontend', t("Maximum Load Average (Frontend)"), ((intval(get_config('system','maxloadavg_frontend')) > 0)?get_config('system','maxloadavg_frontend'):50), t("Maximum system load before the frontend quits service - default 50.")),
 
 		'$poco_completion'	=> array('poco_completion', t("Periodical check of global contacts"), get_config('system','poco_completion'), t("If enabled, the global contacts are checked periodically for missing or outdated data and the vitality of the contacts and servers.")),
+		'$poco_requery_days'	=> array('poco_requery_days', t("Days between requery"), get_config('system','poco_requery_days'), t("Number of days after which a server is requeried for his contacts.")),
 		'$poco_discovery'	=> array('poco_discovery', t("Discover contacts from other servers"), (string) intval(get_config('system','poco_discovery')), t("Periodically query other servers for contacts. You can choose between 'users': the users on the remote system, 'Global Contacts': active contacts that are known on the system. The fallback is meant for Redmatrix servers and older friendica servers, where global contacts weren't available. The fallback increases the server load, so the recommened setting is 'Users, Global Contacts'."), $poco_discovery_choices),
 		'$poco_discovery_since'	=> array('poco_discovery_since', t("Timeframe for fetching global contacts"), (string) intval(get_config('system','poco_discovery_since')), t("When the discovery is activated, this value defines the timeframe for the activity of the global contacts that are fetched from other servers."), $poco_discovery_since_choices),
 		'$poco_local_search'	=> array('poco_local_search', t("Search the local directory"), get_config('system','poco_local_search'), t("Search the local directory instead of the global directory. When searching locally, every search will be executed on the global directory in the background. This improves the search results when the search is repeated.")),

--- a/mod/search.php
+++ b/mod/search.php
@@ -94,6 +94,13 @@ function search_content(&$a) {
 		return;
 	}
 
+	if(get_config('system','local_search') AND !local_user()) {
+		notice(t('Public access denied.').EOL);
+		return;
+		//http_status_exit(403);
+		//killme();
+	}
+
 	nav_set_selected('search');
 
 

--- a/view/templates/admin_site.tpl
+++ b/view/templates/admin_site.tpl
@@ -119,6 +119,7 @@
 
 	<h3>{{$portable_contacts}}</h3>
 	{{include file="field_checkbox.tpl" field=$poco_completion}}
+	{{include file="field_input.tpl" field=$poco_requery_days}}
 	{{include file="field_select.tpl" field=$poco_discovery}}
 	{{include file="field_select.tpl" field=$poco_discovery_since}}
 	{{include file="field_checkbox.tpl" field=$poco_local_search}}


### PR DESCRIPTION
There are two new settings (one is a hidden one):

1. The days after which a server should be requeried for new contacts can now be set in the admin interface. The default value changed from 1 to 7 days
2. There is a hidden setting that controls whether a not logged in user can use the search. This is important when a site is often queried by (search engine) bots that follow every link. The setting is:
````
$a->config['system']['local_search'] = true;
````