### PR TITLE
Bugfix: "remote self" items weren't posted by connectors

### DIFF
--- a/include/items.php
+++ b/include/items.php
@@ -1209,8 +1209,13 @@ function item_store($arr,$force_parent = false, $notify = false, $dontcache = fa
 		}
 	}
 
+	if ($notify)
+		$guid_prefix = "";
+	else
+		$guid_prefix = $arr['network'];
+
 	$arr['wall']          = ((x($arr,'wall'))          ? intval($arr['wall'])                : 0);
-	$arr['guid']          = ((x($arr,'guid'))          ? notags(trim($arr['guid']))          : get_guid(32, $arr['network']));
+	$arr['guid']          = ((x($arr,'guid'))          ? notags(trim($arr['guid']))          : get_guid(32, $guid_prefix));
 	$arr['uri']           = ((x($arr,'uri'))           ? notags(trim($arr['uri']))           : $arr['guid']);
 	$arr['extid']         = ((x($arr,'extid'))         ? notags(trim($arr['extid']))         : '');
 	$arr['author-name']   = ((x($arr,'author-name'))   ? notags(trim($arr['author-name']))   : '');

--- a/include/items.php
+++ b/include/items.php
@@ -1423,7 +1423,10 @@ function item_store($arr,$force_parent = false, $notify = false, $dontcache = fa
 	// Fill the cache field
 	put_item_in_cache($arr);
 
-	call_hooks('post_remote',$arr);
+	if ($notify)
+		call_hooks('post_local',$arr);
+	else
+		call_hooks('post_remote',$arr);
 
 	if(x($arr,'cancel')) {
 		logger('item_store: post cancelled by plugin.');
@@ -1569,7 +1572,10 @@ function item_store($arr,$force_parent = false, $notify = false, $dontcache = fa
 
 		$r = q('SELECT * FROM `item` WHERE id = %d', intval($current_post));
 		if (count($r) == 1) {
-			call_hooks('post_remote_end', $r[0]);
+			if ($notify)
+				call_hooks('post_local_end', $r[0]);
+			else
+				call_hooks('post_remote_end', $r[0]);
 		} else
 			logger('item_store: new item not found in DB, id ' . $current_post);
 	}


### PR DESCRIPTION
"remote self" are posted with another function than the one that is used for regular postings. To make connectors work, we have to call different addons.