### PR TITLE
Bugfix: Picture import from Diaspora often failed

### DIFF
--- a/include/dsprphotoq.php
+++ b/include/dsprphotoq.php
@@ -28,9 +28,14 @@ function dsprphotoq_run($argv, $argc){
 
 	foreach($dphotos as $dphoto) {
 
-		$r = q("SELECT * FROM user WHERE uid = %d",
-			intval($dphoto['uid'])
-		);
+		$r = array();
+
+		if ($dphoto['uid'] == 0)
+			$r[0] = array("uid" => 0, "page-flags" => PAGE_FREELOVE);
+		else
+			$r = q("SELECT * FROM user WHERE uid = %d",
+				intval($dphoto['uid']));
+
 		if(!$r) {
 			logger("diaspora photo queue: user " . $dphoto['uid'] . " not found");
 			return;


### PR DESCRIPTION
There was a problem with pictures that arrived as public pictures. They were stored under the UID 0. The process that would add these pictures to the posts failed because of that. This bug was introduced with one of the last commits for Diaspora.