### PR TITLE
Event improvements

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -408,6 +408,7 @@ if(! class_exists('App')) {
 		public	$videoheight = 350;
 		public	$force_max_items = 0;
 		public	$theme_thread_allow = true;
+		public	$theme_events_in_profile = true;
 
 		// An array for all theme-controllable parameters
 		// Mostly unimplemented yet. Only options 'stylesheet' and

--- a/include/identity.php
+++ b/include/identity.php
@@ -501,7 +501,7 @@ if(! function_exists('get_events')) {
 				}
 
 				$today = ((substr($strt,0,10) === datetime_convert('UTC',$a->timezone,'now','Y-m-d')) ? true : false);
-				
+
 				$rr['title'] = $title;
 				$rr['description'] = $desciption;
 				$rr['date'] = day_translate(datetime_convert('UTC', $rr['adjust'] ? $a->timezone : 'UTC', $rr['start'], $bd_format)) . (($today) ?  ' ' . t('[today]') : '');
@@ -533,21 +533,21 @@ function advanced_profile(&$a) {
 	if($a->profile['name']) {
 
 		$tpl = get_markup_template('profile_advanced.tpl');
-		
+
 		$profile = array();
-		
+
 		$profile['fullname'] = array( t('Full Name:'), $a->profile['name'] ) ;
-		
+
 		if($a->profile['gender']) $profile['gender'] = array( t('Gender:'),  $a->profile['gender'] );
-		
+
 
 		if(($a->profile['dob']) && ($a->profile['dob'] != '0000-00-00')) {
-		
+
 			$year_bd_format = t('j F, Y');
 			$short_bd_format = t('j F');
 
-		
-			$val = ((intval($a->profile['dob'])) 
+
+			$val = ((intval($a->profile['dob']))
 				? day_translate(datetime_convert('UTC','UTC',$a->profile['dob'] . ' 00:00 +00:00',$year_bd_format))
 				: day_translate(datetime_convert('UTC','UTC','2001-' . substr($a->profile['dob'],5) . ' 00:00 +00:00',$short_bd_format)));
 
@@ -556,7 +556,7 @@ function advanced_profile(&$a) {
 		}
 
 		if($age = age($a->profile['dob'],$a->profile['timezone'],''))  $profile['age'] = array( t('Age:'), $age );
-			
+
 
 		if($a->profile['marital']) $profile['marital'] = array( t('Status:'), $a->profile['marital']);
 
@@ -591,7 +591,7 @@ function advanced_profile(&$a) {
 		if($txt = prepare_text($a->profile['contact'])) $profile['contact'] = array( t('Contact information and Social Networks:'), $txt);
 
 		if($txt = prepare_text($a->profile['music'])) $profile['music'] = array( t('Musical interests:'), $txt);
-		
+
 		if($txt = prepare_text($a->profile['book'])) $profile['book'] = array( t('Books, literature:'), $txt);
 
 		if($txt = prepare_text($a->profile['tv'])) $profile['tv'] = array( t('Television:'), $txt);
@@ -599,14 +599,14 @@ function advanced_profile(&$a) {
 		if($txt = prepare_text($a->profile['film'])) $profile['film'] = array( t('Film/dance/culture/entertainment:'), $txt);
 
 		if($txt = prepare_text($a->profile['romance'])) $profile['romance'] = array( t('Love/Romance:'), $txt);
-		
+
 		if($txt = prepare_text($a->profile['work'])) $profile['work'] = array( t('Work/employment:'), $txt);
 
 		if($txt = prepare_text($a->profile['education'])) $profile['education'] = array( t('School/education:'), $txt );
-		
+
 		if ($a->profile['uid'] == local_user())
 			$profile['edit'] = array($a->get_baseurl(). '/profiles/'.$a->profile['id'], t('Edit profile'),"", t('Edit profile'));
-		
+
 		return replace_macros($tpl, array(
 			'$title' => t('Profile'),
 			'$profile' => $profile
@@ -664,14 +664,15 @@ if(! function_exists('profile_tabs')){
 		);
 
 		if ($is_owner){
-			$tabs[] = array(
-				'label' => t('Events'),
-				'url'	=> $a->get_baseurl() . '/events',
-				'sel' 	=>((!isset($tab)&&$a->argv[0]=='events')?'active':''),
-				'title' => t('Events and Calendar'),
-				'id' => 'events-tab',
-				'accesskey' => 'e',
-			);
+			if ($a->theme_events_in_profile)
+				$tabs[] = array(
+					'label' => t('Events'),
+					'url'	=> $a->get_baseurl() . '/events',
+					'sel' 	=>((!isset($tab)&&$a->argv[0]=='events')?'active':''),
+					'title' => t('Events and Calendar'),
+					'id' => 'events-tab',
+					'accesskey' => 'e',
+				);
 			$tabs[] = array(
 				'label' => t('Personal Notes'),
 				'url'	=> $a->get_baseurl() . '/notes',
@@ -737,8 +738,8 @@ function zrl($s,$force = false) {
 
 // Used from within PCSS themes to set theme parameters. If there's a
 // puid request variable, that is the "page owner" and normally their theme
-// settings take precedence; unless a local user sets the "always_my_theme" 
-// system pconfig, which means they don't want to see anybody else's theme 
+// settings take precedence; unless a local user sets the "always_my_theme"
+// system pconfig, which means they don't want to see anybody else's theme
 // settings except their own while on this site.
 
 function get_theme_uid() {

--- a/include/nav.php
+++ b/include/nav.php
@@ -240,6 +240,7 @@ function nav_set_selected($item){
 		'settings'		=> null,
 		'contacts'		=> null,
 		'manage'        => null,
+		'events'        => null,
 		'register'      => null,
 	);
 	$a->nav_sel[$item] = 'selected';

--- a/mod/events.php
+++ b/mod/events.php
@@ -189,8 +189,7 @@ function events_content(&$a) {
 		$editselect = 'textareas';
 
 	// First day of the week (0 = Sunday)
-	// To-Do: Needs to be configurable
-	$firstDay = 0;
+	$firstDay = get_pconfig(local_user(),'system','first_day_of_week');
 
 	$i18n = array(
 			"firstDay" => $firstDay,

--- a/mod/events.php
+++ b/mod/events.php
@@ -179,6 +179,10 @@ function events_content(&$a) {
 		);
 	}
 
+	if ($a->theme_events_in_profile)
+		nav_set_selected('home');
+	else
+		nav_set_selected('events');
 
 	$editselect = 'none';
 	if( feature_enabled(local_user(), 'richtext') )
@@ -249,7 +253,8 @@ function events_content(&$a) {
 
 	$o ="";
 	// tabs
-	$tabs = profile_tabs($a, True);
+	if ($a->theme_events_in_profile)
+		$tabs = profile_tabs($a, True);
 
 
 

--- a/mod/notes.php
+++ b/mod/notes.php
@@ -9,6 +9,8 @@ function notes_init(&$a) {
 
 	$which = $a->user['nickname'];
 
+	nav_set_selected('home');
+
 //	profile_load($a,$which,$profile);
 
 }

--- a/mod/photos.php
+++ b/mod/photos.php
@@ -17,6 +17,8 @@ function photos_init(&$a) {
 		return;
 	}
 
+	nav_set_selected('home');
+
 	$o = '';
 
 	if($a->argc > 1) {

--- a/mod/settings.php
+++ b/mod/settings.php
@@ -284,6 +284,7 @@ function settings_post(&$a) {
 		$theme = ((x($_POST,'theme')) ? notags(trim($_POST['theme']))  : $a->user['theme']);
 		$mobile_theme = ((x($_POST,'mobile_theme')) ? notags(trim($_POST['mobile_theme']))  : '');
 		$nosmile = ((x($_POST,'nosmile')) ? intval($_POST['nosmile'])  : 0);
+		$first_day_of_week = ((x($_POST,'first_day_of_week')) ? intval($_POST['first_day_of_week'])  : 0);
 		$noinfo = ((x($_POST,'noinfo')) ? intval($_POST['noinfo'])  : 0);
 		$infinite_scroll = ((x($_POST,'infinite_scroll')) ? intval($_POST['infinite_scroll'])  : 0);
 		$no_auto_update = ((x($_POST,'no_auto_update')) ? intval($_POST['no_auto_update'])  : 0);
@@ -308,6 +309,7 @@ function settings_post(&$a) {
 		set_pconfig(local_user(),'system','itemspage_network', $itemspage_network);
 		set_pconfig(local_user(),'system','itemspage_mobile_network', $itemspage_mobile_network);
 		set_pconfig(local_user(),'system','no_smilies',$nosmile);
+		set_pconfig(local_user(),'system','first_day_of_week',$first_day_of_week);
 		set_pconfig(local_user(),'system','ignore_info',$noinfo);
 		set_pconfig(local_user(),'system','infinite_scroll',$infinite_scroll);
 		set_pconfig(local_user(),'system','no_auto_update',$no_auto_update);
@@ -915,6 +917,10 @@ function settings_content(&$a) {
 		$nosmile = get_pconfig(local_user(),'system','no_smilies');
 		$nosmile = (($nosmile===false)? '0': $nosmile); // default if not set: 0
 
+		$first_day_of_week = get_pconfig(local_user(),'system','first_day_of_week');
+		$first_day_of_week = (($first_day_of_week===false)? '0': $first_day_of_week); // default if not set: 0
+		$weekdays = array(0 => t("Sunday"), 1 => t("Monday"));
+
 		$noinfo = get_pconfig(local_user(),'system','ignore_info');
 		$noinfo = (($noinfo===false)? '0': $noinfo); // default if not set: 0
 
@@ -944,6 +950,7 @@ function settings_content(&$a) {
 			'$itemspage_network'   => array('itemspage_network',  t("Number of items to display per page:"), $itemspage_network, t('Maximum of 100 items')),
 			'$itemspage_mobile_network'   => array('itemspage_mobile_network',  t("Number of items to display per page when viewed from mobile device:"), $itemspage_mobile_network, t('Maximum of 100 items')),
 			'$nosmile'	=> array('nosmile', t("Don't show emoticons"), $nosmile, ''),
+			'$first_day_of_week'	=> array('first_day_of_week', t('Beginning of week:'), $first_day_of_week, '', $weekdays, false),
 			'$noinfo'	=> array('noinfo', t("Don't show notices"), $noinfo, ''),
 			'$infinite_scroll'	=> array('infinite_scroll', t("Infinite scroll"), $infinite_scroll, ''),
 			'$no_auto_update'	=> array('no_auto_update', t("Automatic updates only at the top of the network page"), $no_auto_update, 'When disabled, the network page is updated all the time, which could be confusing while reading.'),

--- a/mod/videos.php
+++ b/mod/videos.php
@@ -15,6 +15,8 @@ function videos_init(&$a) {
 		return;
 	}
 
+	nav_set_selected('home');
+
 	$o = '';
 
 	if($a->argc > 1) {

--- a/view/templates/settings_display.tpl
+++ b/view/templates/settings_display.tpl
@@ -13,6 +13,7 @@
 {{include file="field_checkbox.tpl" field=$nosmile}}
 {{include file="field_checkbox.tpl" field=$noinfo}}
 {{include file="field_checkbox.tpl" field=$infinite_scroll}}
+{{include file="field_select.tpl" field=$first_day_of_week}}
 
 
 <div class="settings-submit-wrapper" >

--- a/view/theme/vier/narrow.css
+++ b/view/theme/vier/narrow.css
@@ -1,0 +1,12 @@
+#nav-user-linklabel {
+  display: none;
+}
+
+nav ul li .menu-popup {
+  left: auto;
+  right: 0px;
+}
+
+nav #search-box #search-text {
+  width: 100px;
+}

--- a/view/theme/vier/style.php
+++ b/view/theme/vier/style.php
@@ -26,5 +26,3 @@ else if ($style == "dark")
 	$stylecss = file_get_contents('view/theme/vier/dark.css');
 
 echo $stylecss;
-
-

--- a/view/theme/vier/theme.php
+++ b/view/theme/vier/theme.php
@@ -20,6 +20,7 @@ $baseurl = $a->get_baseurl();
 $a->theme_info = array();
 
 $a->page['htmlhead'] .= <<< EOT
+<link rel='stylesheet' media='screen and (max-width: 1100px)' href='view/theme/vier/narrow.css' />
 <script type="text/javascript">
 
 function insertFormatting(comment,BBcode,id) {

--- a/view/theme/vier/theme.php
+++ b/view/theme/vier/theme.php
@@ -10,6 +10,9 @@
  */
 
 function vier_init(&$a) {
+
+$a->theme_events_in_profile = false;
+
 set_template_engine($a, 'smarty3');
 
 $baseurl = $a->get_baseurl();


### PR DESCRIPTION
The beginning of the week in the calendar is now configurable.

Additionally there is a theme setting where a theme developer can decide if the events should be linked from the profile or the navigation bar. In "vier" this is now enabled. This setting is made to not break other themes.

Personally I think that events don't belong to the profile since they contain not only the own stuff but also stuff from other persons. So it belongs on the same level like the network or the community page.