### PR TITLE
"Vier" comes now with the right column from Diabook

### DIFF
--- a/view/theme/vier/config.php
+++ b/view/theme/vier/config.php
@@ -17,7 +17,15 @@ function theme_content(&$a){
 	if ($style == "")
 		$style = "plus";
 
-	return vier_form($a,$style);
+        $show_pages = get_vier_config('show_pages', true);
+        $show_profiles = get_vier_config('show_profiles', true);
+        $show_helpers = get_vier_config('show_helpers', true);
+        $show_services = get_vier_config('show_services', true);
+        $show_friends = get_vier_config('show_friends', true);
+        $show_lastusers = get_vier_config('show_lastusers', true);
+
+	return vier_form($a,$style, $show_pages, $show_profiles, $show_helpers,
+			$show_services, $show_friends, $show_lastusers);
 }
 
 function theme_post(&$a){
@@ -26,23 +34,56 @@ function theme_post(&$a){
 
 	if (isset($_POST['vier-settings-submit'])){
 		set_pconfig(local_user(), 'vier', 'style', $_POST['vier_style']);
+        	set_pconfig(local_user(), 'vier', 'show_pages', $_POST['vier_show_pages']);
+                set_pconfig(local_user(), 'vier', 'show_profiles', $_POST['vier_show_profiles']);
+                set_pconfig(local_user(), 'vier', 'show_helpers', $_POST['vier_show_helpers']);
+                set_pconfig(local_user(), 'vier', 'show_services', $_POST['vier_show_services']);
+                set_pconfig(local_user(), 'vier', 'show_friends', $_POST['vier_show_friends']);
+                set_pconfig(local_user(), 'vier', 'show_lastusers', $_POST['vier_show_lastusers']);
 	}
 }
 
 
 function theme_admin(&$a){
 	$style = get_config('vier', 'style');
-	return vier_form($a,$style);
+
+	$helperlist = get_config('vier', 'helperlist');
+
+	if ($helperlist == "")
+		$helperlist = "https://helpers.pyxis.uberspace.de/profile/helpers";
+
+	$t = get_markup_template("theme_admin_settings.tpl");
+	$o .= replace_macros($t, array(
+		'$helperlist' => array('vier_helperlist', t('Comma separated list of helper forums'), $helperlist, '', ''),
+		));
+
+        $show_pages = get_vier_config('show_pages', true, true);
+        $show_profiles = get_vier_config('show_profiles', true, true);
+        $show_helpers = get_vier_config('show_helpers', true, true);
+        $show_services = get_vier_config('show_services', true, true);
+        $show_friends = get_vier_config('show_friends', true, true);
+        $show_lastusers = get_vier_config('show_lastusers', true, true);
+	$o .= vier_form($a,$style, $show_pages, $show_profiles, $show_helpers, $show_services,
+			$show_friends, $show_lastusers);
+
+	return $o;
 }
 
 function theme_admin_post(&$a){
 	if (isset($_POST['vier-settings-submit'])){
 		set_config('vier', 'style', $_POST['vier_style']);
+		set_config('vier', 'show_pages', $_POST['vier_show_pages']);
+                set_config('vier', 'show_profiles', $_POST['vier_show_profiles']);
+                set_config('vier', 'show_helpers', $_POST['vier_show_helpers']);
+                set_config('vier', 'show_services', $_POST['vier_show_services']);
+                set_config('vier', 'show_friends', $_POST['vier_show_friends']);
+                set_config('vier', 'show_lastusers', $_POST['vier_show_lastusers']);
+		set_config('vier', 'helperlist', $_POST['vier_helperlist']);
 	}
 }
 
 
-function vier_form(&$a, $style){
+function vier_form(&$a, $style, $show_pages, $show_profiles, $show_helpers, $show_services, $show_friends, $show_lastusers){
 	$styles = array(
 		"plus"=>"Plus",
 		"breathe"=>"Breathe",
@@ -51,12 +92,21 @@ function vier_form(&$a, $style){
 		"netcolour"=>"Coloured Networks",
 		"flat"=>"Flat"
 	);
-	$t = get_markup_template("theme_settings.tpl" );
+
+        $show_or_not = array('0'=>t("don't show"),     '1'=>t("show"),);
+
+	$t = get_markup_template("theme_settings.tpl");
 	$o .= replace_macros($t, array(
 		'$submit' => t('Submit'),
 		'$baseurl' => $a->get_baseurl(),
 		'$title' => t("Theme settings"),
 		'$style' => array('vier_style',t ('Set style'),$style,'',$styles),
+		'$show_pages' => array('vier_show_pages', t('Community Pages'), $show_pages, '', $show_or_not),
+                '$show_profiles' => array('vier_show_profiles', t('Community Profiles'), $show_profiles, '', $show_or_not),
+                '$show_helpers' => array('vier_show_helpers', t('Help or @NewHere ?'), $show_helpers, '', $show_or_not),
+                '$show_services' => array('vier_show_services', t('Connect Services'), $show_services, '', $show_or_not),
+                '$show_friends' => array('vier_show_friends', t('Find Friends'), $show_friends, '', $show_or_not),
+                '$show_lastusers' => array('vier_show_lastusers', t('Last users'), $show_lastusers, '', $show_or_not)
 	));
 	return $o;
 }

--- a/view/theme/vier/hide.css
+++ b/view/theme/vier/hide.css
@@ -1,0 +1,3 @@
+aside {
+  display: none;
+}

--- a/view/theme/vier/shadow.css
+++ b/view/theme/vier/shadow.css
@@ -1,0 +1,154 @@
+nav {
+  background: rgb(36, 76, 94);
+  box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.7);
+  padding: 0px;
+  padding-left: 0px;
+}
+
+nav a:active,
+nav a:link,
+nav a:visited,
+nav a {
+  color: #ccc;
+}
+
+nav a:hover,
+#nav-messages-see-all a:hover {
+  color: #fff;
+}
+
+nav .nav-notify {
+  background-color: #F80;
+  top: 0px;
+  right: -5px;
+  padding: 1px 3px;
+  border-radius: 5px 5px 5px 5px;
+}
+// -----
+nav .nav-menu-icon .nav-notify {
+  top: 0px;
+}
+
+nav .nav-menu.selected a {
+  color: #000;
+/*  font-weight: bold; */
+}
+
+nav .nav-menu:hover,
+nav .nav-menu.selected {
+  border-bottom: 2px solid #427FED;
+}
+
+nav .nav-menu {
+  height: 23px;
+  font-size: 14px;
+  font-weight: initial;
+}
+
+#nav-site-menu,
+#nav-notifications-menu,
+#nav-user-menu {
+  top: 35px;
+}
+
+#nav-messages-menu {
+  top: 32px;
+}
+
+#nav-messages-see-all a {
+  color: #737373;
+}
+
+ul.tabs li .active, span.pager_current a {
+  border-bottom: 2px solid #427FED;
+}
+
+span.pager_current, span.pager_n a:hover, 
+span.pager_first a:hover, span.pager_last a:hover, 
+span.pager_prev a:hover, span.pager_next a:hover,
+ul.tabs a:hover {
+  border-bottom: 2px solid #427FED;
+}
+
+nav #nav-notifications-linkmenu.on .icon.s22.notify, nav #nav-notifications-linkmenu.selected .icon.s22.notify {
+  color: #737373;
+}
+
+nav #nav-messages-linkmenu.selected,
+nav #nav-user-linklabel.selected,
+nav #nav-apps-link.selected {
+  background-color: #fff;
+  border-bottom-style: none;
+}
+
+div.jGrowl div.info {
+  background: #fff url("../../../images/icons/48/info.png") no-repeat 5px center;
+}
+
+div.jGrowl div.notice {
+  color: #737373;
+}
+div.jGrowl div.info {
+  color: #737373;
+}
+
+.birthday-notice, .event-notice {
+  font-weight: initial;
+}
+
+div.pager, ul.tabs {
+  font-weight: initial;
+}
+
+nav .nav-menu-icon.selected {
+  background-color: #fff;
+}
+
+#jot #jot-tools li:hover {
+  background-color: #fff;
+}
+
+nav .icon {
+  color: #737373;
+}
+
+nav a:hover .icon {
+  color: #000;
+}
+
+ul.menu-popup {
+  border: 0px solid #FFF;
+  margin-top: 0px;
+}
+
+header #banner a, header #banner a:active, header #banner a:visited, header #banner a:link, header #banner a:hover {
+  color: #737373;
+}
+
+header {
+  left: 10px;
+}
+
+header #banner {
+  margin-top: 6px;
+}
+
+#banner #logo-text {
+  margin-left: 5px;
+}
+
+aside {
+  top: 44px;
+  height: calc(100% - 54px);
+}
+
+section {
+  top: 44px;
+}
+
+nav #search-box #search-text {
+  background-color: initial;
+  border-style: solid;
+  border-width: 1px;
+  border-color: rgba(0, 0, 0, 0.15);
+}

--- a/view/theme/vier/style.css
+++ b/view/theme/vier/style.css
@@ -390,7 +390,7 @@ code {
 }
 
 .sidebar-group-li:hover, #sidebar-new-group:hover, #hide-forum-list:hover,
-#sidebar-ungrouped:hover, .side-link:hover, .nets-ul li:hover, #forum-list div:hover,
+#sidebar-ungrouped:hover, .side-link:hover, .nets-ul li:hover, #forum-list div:hover, #forum-list-right div:hover,
 .nets-all:hover, .saved-search-li:hover, li.tool:hover, .admin.link:hover, aside h4 a:hover, right_aside h4 a:hover, #message-new:hover {
   /* background-color: #ddd; */
 /*  background-color: #e5e5e5; */
@@ -409,7 +409,7 @@ code {
   font-weight: bold;
 }
 
-#sidebar-new-group, #hide-forum-list, #forum-list, #sidebar-ungrouped,
+#sidebar-new-group, #hide-forum-list, #forum-list, #forum-list-right, #sidebar-ungrouped,
 .side-link, #peoplefind-desc, #connect-desc, .nets-all, .admin.link, #message-new {
   padding-left: 10px;
   padding-top: 3px;
@@ -445,11 +445,11 @@ a.sidebar-group-element {
   color: black;
 }
 
-#forum-list a, .tool a, .admin.link a {
+#forum-list a, #forum-list-right a, .tool a, .admin.link a {
   color: #737373;
 }
 
-#forum-list {
+#forum-list, #forum-list-right {
   margin-top: 2px;
 }
 
@@ -970,7 +970,7 @@ aside #profiles-menu {
   left: 10px;
 }
 
-aside #search-text, aside #side-follow-url, aside #side-peoplefind-url {
+aside #search-text, aside #side-follow-url, aside #side-peoplefind-url, right_aside input {
   width: 140px;
   height: 17px;
   padding-left: 10px;

--- a/view/theme/vier/style.css
+++ b/view/theme/vier/style.css
@@ -375,7 +375,7 @@ code {
 .tool a {
 /*  color: #000; */
 }
-.tool a:hover, .widget a:hover, #nets-sidear a:hover, #hide-forum-list:hover, .admin.link a:hover, aside h4 a:hover {
+.tool a:hover, .widget a:hover, #nets-sidear a:hover, #hide-forum-list:hover, .admin.link a:hover, aside h4 a:hover, right_aside h4 a:hover {
   /* text-decoration: underline; */
   text-decoration: none;
   color: black;
@@ -391,7 +391,7 @@ code {
 
 .sidebar-group-li:hover, #sidebar-new-group:hover, #hide-forum-list:hover,
 #sidebar-ungrouped:hover, .side-link:hover, .nets-ul li:hover, #forum-list div:hover,
-.nets-all:hover, .saved-search-li:hover, li.tool:hover, .admin.link:hover, aside h4 a:hover, #message-new:hover {
+.nets-all:hover, .saved-search-li:hover, li.tool:hover, .admin.link:hover, aside h4 a:hover, right_aside h4 a:hover, #message-new:hover {
   /* background-color: #ddd; */
 /*  background-color: #e5e5e5; */
   background-color: #F5F5F5;
@@ -418,7 +418,7 @@ code {
   display: block;
 }
 
-a.nets-link, .side-link a, #sidebar-new-group a, a.savedsearchterm, a.fileas-link, aside h4 a {
+a.nets-link, .side-link a, #sidebar-new-group a, a.savedsearchterm, a.fileas-link, aside h4 a, right_aside h4 a {
   display: block;
   color: #737373;
 }
@@ -984,7 +984,7 @@ aside #search-text, aside #side-follow-url, aside #side-peoplefind-url {
   -moz-border-right-colors: #dbdbdb;*/
 }
 
-aside h4 {
+aside h4, right_aside h4 {
   margin-bottom: 0px;
   margin-top: 0px;
   font-size: 1.17em;

--- a/view/theme/vier/templates/ch_connectors.tpl
+++ b/view/theme/vier/templates/ch_connectors.tpl
@@ -1,0 +1,2 @@
+<a href="{{$url}}/settings/connectors"><img alt="{{$alt_text}}" src="{{$photo}}" title="{{$alt_text}}"></a>
+

--- a/view/theme/vier/templates/ch_directory_item.tpl
+++ b/view/theme/vier/templates/ch_directory_item.tpl
@@ -1,0 +1,11 @@
+
+
+<div class="directory-item" id="directory-item-{{$id}}" >
+	<div class="directory-photo-wrapper" id="directory-photo-wrapper-{{$id}}" > 
+		<div class="directory-photo" id="directory-photo-{{$id}}" >
+			<a href="{{$profile_link}}" class="directory-profile-link" id="directory-profile-link-{{$id}}" >
+				<img class="directory-photo-img" src="{{$photo}}" alt="{{$alt_text}}" title="{{$alt_text}}" />
+			</a>
+		</div>
+	</div>
+</div>

--- a/view/theme/vier/templates/ch_helpers.tpl
+++ b/view/theme/vier/templates/ch_helpers.tpl
@@ -1,0 +1,1 @@
+<li class="tool" role="menuitem"><a href="{{$url}}" title="{{$title}}" target="blank">{{$title}}</a></li>

--- a/view/theme/vier/templates/communityhome.tpl
+++ b/view/theme/vier/templates/communityhome.tpl
@@ -1,76 +1,66 @@
-<div id="pos_null" style="margin-bottom:-30px;">
-</div>
-
-<div id="sortable_boxes">
-
-<div id="close_pages" style="margin-top:30px;" class="widget">
 {{if $page}}
+<div id="right_pages" class="widget">
 <div>{{$page}}</div>
-{{/if}}
 </div>
+{{/if}}
 
-<div id="close_profiles" class="widget">
 {{if $comunity_profiles_title}}
+<div id="right_profiles" class="widget">
 <h3>{{$comunity_profiles_title}}</h3>
 <div id='lastusers-wrapper' class='items-wrapper'>
 {{foreach $comunity_profiles_items as $i}}
 	{{$i}}
 {{/foreach}}
 </div>
-{{/if}}
 </div>
+{{/if}}
 
-<div id="close_helpers" class="widget">
 {{if $helpers}}
+<div id="right_helpers" class="widget">
 <h3>{{$helpers.title.1}}</h3>
 <ul role="menu">
-<li class="tool" role="menuitem"><a href="http://friendica.com/resources" title="How-tos" style="margin-left: 10px; " target="blank">How-To Guides</a></li>
-<li class="tool" role="menuitem"><a href="http://kakste.com/profile/newhere" title="@NewHere" style="margin-left: 10px; " target="blank">NewHere</a></li>
-<li class="tool" role="menuitem"><a href="https://helpers.pyxis.uberspace.de/profile/helpers" style="margin-left: 10px; " title="Friendica Support" target="blank">Friendica Support</a></li>
+{{foreach $helpers_items as $i}}
+	{{$i}}
+{{/foreach}}
 </ul>
-{{/if}}
 </div>
+{{/if}}
 
-<div id="close_services" class="widget">
 {{if $con_services}}
+<div id="right_services" class="widget">
 <h3>{{$con_services.title.1}}</h3>
-<div id="right_service_icons" style="margin-left: 16px; margin-top: 5px;">
-<a href="{{$url}}/facebook"><img alt="Facebook" src="view/theme/diabook/icons/facebook.png" title="Facebook"></a>
-<a href="{{$url}}/settings/connectors"><img alt="StatusNet" src="view/theme/diabook/icons/StatusNet.png?" title="StatusNet"></a>
-<a href="{{$url}}/settings/connectors"><img alt="LiveJournal" src="view/theme/diabook/icons/livejournal.png?" title="LiveJournal"></a>
-<a href="{{$url}}/settings/connectors"><img alt="Posterous" src="view/theme/diabook/icons/posterous.png?" title="Posterous"></a>
-<a href="{{$url}}/settings/connectors"><img alt="Tumblr" src="view/theme/diabook/icons/tumblr.png?" title="Tumblr"></a>
-<a href="{{$url}}/settings/connectors"><img alt="Twitter" src="view/theme/diabook/icons/twitter.png?" title="Twitter"></a>
-<a href="{{$url}}/settings/connectors"><img alt="WordPress" src="view/theme/diabook/icons/wordpress.png?" title="WordPress"></a>
-<a href="{{$url}}/settings/connectors"><img alt="E-Mail" src="view/theme/diabook/icons/email.png?" title="E-Mail"></a>
+<div id="right_services_icons">
+{{foreach $connector_items as $i}}
+	{{$i}}
+{{/foreach}}
+</div>
 </div>
 {{/if}}
-</div>
 
-<div id="close_friends" style="margin-bottom:53px;" class="widget">
 {{if $nv}}
+<div id="right_friends" class="widget">
 <h3>{{$nv.title.1}}</h3>
 <ul role="menu">
-<li class="tool" role="menuitem"><a class="{{$nv.directory.2}}" href="{{$nv.directory.0}}" style="margin-left: 10px; " title="{{$nv.directory.3}}" >{{$nv.directory.1}}</a></li>
-<li class="tool" role="menuitem"><a class="{{$nv.global_directory.2}}" href="{{$nv.global_directory.0}}" target="blank" style="margin-left: 10px; " title="{{$nv.global_directory.3}}" >{{$nv.global_directory.1}}</a></li>
-<li class="tool" role="menuitem"><a class="{{$nv.match.2}}" href="{{$nv.match.0}}" style="margin-left: 10px; " title="{{$nv.match.3}}" >{{$nv.match.1}}</a></li>
-<li class="tool" role="menuitem"><a class="{{$nv.suggest.2}}" href="{{$nv.suggest.0}}" style="margin-left: 10px; " title="{{$nv.suggest.3}}" >{{$nv.suggest.1}}</a></li>
-<li class="tool" role="menuitem"><a class="{{$nv.invite.2}}" href="{{$nv.invite.0}}" style="margin-left: 10px; " title="{{$nv.invite.3}}" >{{$nv.invite.1}}</a></li>
+<li class="tool" role="menuitem"><a class="{{$nv.directory.2}}" href="{{$nv.directory.0}}" title="{{$nv.directory.3}}" >{{$nv.directory.1}}</a></li>
+<li class="tool" role="menuitem"><a class="{{$nv.global_directory.2}}" href="{{$nv.global_directory.0}}" target="blank" title="{{$nv.global_directory.3}}" >{{$nv.global_directory.1}}</a></li>
+<li class="tool" role="menuitem"><a class="{{$nv.match.2}}" href="{{$nv.match.0}}" title="{{$nv.match.3}}" >{{$nv.match.1}}</a></li>
+<li class="tool" role="menuitem"><a class="{{$nv.suggest.2}}" href="{{$nv.suggest.0}}" title="{{$nv.suggest.3}}" >{{$nv.suggest.1}}</a></li>
+<li class="tool" role="menuitem"><a class="{{$nv.invite.2}}" href="{{$nv.invite.0}}" title="{{$nv.invite.3}}" >{{$nv.invite.1}}</a></li>
 </ul>
 {{$nv.search}}
-{{/if}}
 </div>
+{{/if}}
 
-<div id="close_lastusers" class="widget">
 {{if $lastusers_title}}
+<div id="right_lastusers" class="widget">
 <h3>{{$lastusers_title}}</h3>
 <div id='lastusers-wrapper' class='items-wrapper'>
 {{foreach $lastusers_items as $i}}
 	{{$i}}
 {{/foreach}}
 </div>
-{{/if}}
 </div>
+{{/if}}
 
 {{if $activeusers_title}}
 <h3>{{$activeusers_title}}</h3>
@@ -80,28 +70,3 @@
 {{/foreach}}
 </div>
 {{/if}}
-
-<div id="close_lastphotos">
-{{if $photos_title}}
-<h3>{{$photos_title}}</h3>
-<div id='ra-photos-wrapper' class='items-wrapper'>
-{{foreach $photos_items as $i}}
-	{{$i}}
-{{/foreach}}
-</div>
-{{/if}}
-</div>
-
-<div id="close_lastlikes">
-{{if $like_title}}
-<h3>{{$like_title}}</h3>
-<ul id='likes'>
-{{foreach $like_items as $i}}
-	<li id='ra-photos-wrapper'>{{$i}}</li>
-{{/foreach}}
-</ul>
-{{/if}}
-</div>
-
-</div>
-</div>

--- a/view/theme/vier/templates/communityhome.tpl
+++ b/view/theme/vier/templates/communityhome.tpl
@@ -1,0 +1,107 @@
+<div id="pos_null" style="margin-bottom:-30px;">
+</div>
+
+<div id="sortable_boxes">
+
+<div id="close_pages" style="margin-top:30px;" class="widget">
+{{if $page}}
+<div>{{$page}}</div>
+{{/if}}
+</div>
+
+<div id="close_profiles" class="widget">
+{{if $comunity_profiles_title}}
+<h3>{{$comunity_profiles_title}}</h3>
+<div id='lastusers-wrapper' class='items-wrapper'>
+{{foreach $comunity_profiles_items as $i}}
+	{{$i}}
+{{/foreach}}
+</div>
+{{/if}}
+</div>
+
+<div id="close_helpers" class="widget">
+{{if $helpers}}
+<h3>{{$helpers.title.1}}</h3>
+<ul role="menu">
+<li class="tool" role="menuitem"><a href="http://friendica.com/resources" title="How-tos" style="margin-left: 10px; " target="blank">How-To Guides</a></li>
+<li class="tool" role="menuitem"><a href="http://kakste.com/profile/newhere" title="@NewHere" style="margin-left: 10px; " target="blank">NewHere</a></li>
+<li class="tool" role="menuitem"><a href="https://helpers.pyxis.uberspace.de/profile/helpers" style="margin-left: 10px; " title="Friendica Support" target="blank">Friendica Support</a></li>
+</ul>
+{{/if}}
+</div>
+
+<div id="close_services" class="widget">
+{{if $con_services}}
+<h3>{{$con_services.title.1}}</h3>
+<div id="right_service_icons" style="margin-left: 16px; margin-top: 5px;">
+<a href="{{$url}}/facebook"><img alt="Facebook" src="view/theme/diabook/icons/facebook.png" title="Facebook"></a>
+<a href="{{$url}}/settings/connectors"><img alt="StatusNet" src="view/theme/diabook/icons/StatusNet.png?" title="StatusNet"></a>
+<a href="{{$url}}/settings/connectors"><img alt="LiveJournal" src="view/theme/diabook/icons/livejournal.png?" title="LiveJournal"></a>
+<a href="{{$url}}/settings/connectors"><img alt="Posterous" src="view/theme/diabook/icons/posterous.png?" title="Posterous"></a>
+<a href="{{$url}}/settings/connectors"><img alt="Tumblr" src="view/theme/diabook/icons/tumblr.png?" title="Tumblr"></a>
+<a href="{{$url}}/settings/connectors"><img alt="Twitter" src="view/theme/diabook/icons/twitter.png?" title="Twitter"></a>
+<a href="{{$url}}/settings/connectors"><img alt="WordPress" src="view/theme/diabook/icons/wordpress.png?" title="WordPress"></a>
+<a href="{{$url}}/settings/connectors"><img alt="E-Mail" src="view/theme/diabook/icons/email.png?" title="E-Mail"></a>
+</div>
+{{/if}}
+</div>
+
+<div id="close_friends" style="margin-bottom:53px;" class="widget">
+{{if $nv}}
+<h3>{{$nv.title.1}}</h3>
+<ul role="menu">
+<li class="tool" role="menuitem"><a class="{{$nv.directory.2}}" href="{{$nv.directory.0}}" style="margin-left: 10px; " title="{{$nv.directory.3}}" >{{$nv.directory.1}}</a></li>
+<li class="tool" role="menuitem"><a class="{{$nv.global_directory.2}}" href="{{$nv.global_directory.0}}" target="blank" style="margin-left: 10px; " title="{{$nv.global_directory.3}}" >{{$nv.global_directory.1}}</a></li>
+<li class="tool" role="menuitem"><a class="{{$nv.match.2}}" href="{{$nv.match.0}}" style="margin-left: 10px; " title="{{$nv.match.3}}" >{{$nv.match.1}}</a></li>
+<li class="tool" role="menuitem"><a class="{{$nv.suggest.2}}" href="{{$nv.suggest.0}}" style="margin-left: 10px; " title="{{$nv.suggest.3}}" >{{$nv.suggest.1}}</a></li>
+<li class="tool" role="menuitem"><a class="{{$nv.invite.2}}" href="{{$nv.invite.0}}" style="margin-left: 10px; " title="{{$nv.invite.3}}" >{{$nv.invite.1}}</a></li>
+</ul>
+{{$nv.search}}
+{{/if}}
+</div>
+
+<div id="close_lastusers" class="widget">
+{{if $lastusers_title}}
+<h3>{{$lastusers_title}}</h3>
+<div id='lastusers-wrapper' class='items-wrapper'>
+{{foreach $lastusers_items as $i}}
+	{{$i}}
+{{/foreach}}
+</div>
+{{/if}}
+</div>
+
+{{if $activeusers_title}}
+<h3>{{$activeusers_title}}</h3>
+<div class='items-wrapper'>
+{{foreach $activeusers_items as $i}}
+	{{$i}}
+{{/foreach}}
+</div>
+{{/if}}
+
+<div id="close_lastphotos">
+{{if $photos_title}}
+<h3>{{$photos_title}}</h3>
+<div id='ra-photos-wrapper' class='items-wrapper'>
+{{foreach $photos_items as $i}}
+	{{$i}}
+{{/foreach}}
+</div>
+{{/if}}
+</div>
+
+<div id="close_lastlikes">
+{{if $like_title}}
+<h3>{{$like_title}}</h3>
+<ul id='likes'>
+{{foreach $like_items as $i}}
+	<li id='ra-photos-wrapper'>{{$i}}</li>
+{{/foreach}}
+</ul>
+{{/if}}
+</div>
+
+</div>
+</div>

--- a/view/theme/vier/templates/theme_admin_settings.tpl
+++ b/view/theme/vier/templates/theme_admin_settings.tpl
@@ -1,0 +1,1 @@
+{{include file="field_input.tpl" field=$helperlist}}

--- a/view/theme/vier/templates/theme_settings.tpl
+++ b/view/theme/vier/templates/theme_settings.tpl
@@ -1,5 +1,11 @@
 
 {{include file="field_select.tpl" field=$style}}
+{{include file="field_select.tpl" field=$show_pages}}
+{{include file="field_select.tpl" field=$show_profiles}}
+{{include file="field_select.tpl" field=$show_helpers}}
+{{include file="field_select.tpl" field=$show_services}}
+{{include file="field_select.tpl" field=$show_friends}}
+{{include file="field_select.tpl" field=$show_lastusers}}
 
 <div class="settings-submit-wrapper">
 	<input type="submit" value="{{$submit}}" class="settings-submit" name="vier-settings-submit" />

--- a/view/theme/vier/theme.php
+++ b/view/theme/vier/theme.php
@@ -11,13 +11,19 @@
 
 function vier_init(&$a) {
 
-$a->theme_events_in_profile = false;
+	$a->theme_events_in_profile = false;
 
-set_template_engine($a, 'smarty3');
+	set_template_engine($a, 'smarty3');
 
-$baseurl = $a->get_baseurl();
+	$baseurl = $a->get_baseurl();
 
-$a->theme_info = array();
+	$a->theme_info = array();
+
+	if ($a->argv[0].$a->argv[1] === "profile".$a->user['nickname'] or $a->argv[0] === "network" && local_user()) {
+		vier_community_info();
+
+		$a->page['htmlhead'] .= "<link rel='stylesheet' media='screen and (min-width: 1300px)' href='view/theme/vier/wide.css' />";
+	}
 
 $a->page['htmlhead'] .= <<< EOT
 <link rel='stylesheet' media='screen and (max-width: 1100px)' href='view/theme/vier/narrow.css' />
@@ -72,5 +78,291 @@ function cmtBbClose(id) {
 }
 </script>
 EOT;
+
+	// Hide the left menu bar
+	if (($a->page['aside'] == "") AND in_array($a->argv[0], array("community", "events", "help", "manage", "notifications", "probe", "webfinger", "login")))
+		$a->page['htmlhead'] .= "<link rel='stylesheet' href='view/theme/vier/hide.css' />";
 }
 
+function get_vier_config($key, $default = false) {
+	if (local_user()) {
+		$result = get_pconfig(local_user(), "vier", $key);
+		if ($result !== false)
+			return $result;
+	}
+
+	$result = get_config("vier", $key);
+	if ($result !== false)
+		return $result;
+
+	return $default;
+}
+
+function vier_community_info() {
+	$a = get_app();
+/*
+	$close_pages      = get_vier_config("close_pages", 1);
+	$close_profiles   = get_vier_config("close_profiles", 0);
+	$close_helpers    = get_vier_config("close_helpers", 0);
+	$close_services   = get_vier_config("close_services", 0);
+	$close_friends    = get_vier_config("close_friends", 0);
+	$close_lastusers  = get_vier_config("close_lastusers", 0);
+	$close_lastphotos = get_vier_config("close_lastphotos", 0);
+	$close_lastlikes  = get_vier_config("close_lastlikes", 0);
+*/
+	$close_pages      = false;
+	$close_profiles   = true;
+	$close_helpers    = false;
+	$close_services   = false;
+	$close_friends    = false;
+	$close_lastusers  = true;
+	$close_lastphotos = true;
+	$close_lastlikes  = true;
+
+	// comunity_profiles
+	if(!$close_profiles) {
+		$aside['$comunity_profiles_title'] = t('Community Profiles');
+		$aside['$comunity_profiles_items'] = array();
+		$r = q("select gcontact.* from gcontact left join glink on glink.gcid = gcontact.id
+			  where glink.cid = 0 and glink.uid = 0 order by rand() limit 9");
+		$tpl = get_markup_template('ch_directory_item.tpl');
+		if(count($r)) {
+			$photo = 'photo';
+			foreach($r as $rr) {
+				$profile_link = $a->get_baseurl() . '/profile/' . ((strlen($rr['nickname'])) ? $rr['nickname'] : $rr['profile_uid']);
+				$entry = replace_macros($tpl,array(
+					'$id' => $rr['id'],
+					'$profile_link' => zrl($rr['url']),
+					'$photo' => $rr[$photo],
+					'$alt_text' => $rr['name'],
+				));
+				$aside['$comunity_profiles_items'][] = $entry;
+			}
+		}
+	}
+
+	// last 12 users
+	if(!$close_lastusers) {
+		$aside['$lastusers_title'] = t('Last users');
+		$aside['$lastusers_items'] = array();
+		$sql_extra = "";
+		$publish = (get_config('system','publish_all') ? '' : " AND `publish` = 1 ");
+		$order = " ORDER BY `register_date` DESC ";
+
+		$r = q("SELECT `profile`.*, `profile`.`uid` AS `profile_uid`, `user`.`nickname`
+				FROM `profile` LEFT JOIN `user` ON `user`.`uid` = `profile`.`uid`
+				WHERE `is-default` = 1 $publish AND `user`.`blocked` = 0 $sql_extra $order LIMIT %d , %d ",
+				0, 9);
+
+		$tpl = get_markup_template('ch_directory_item.tpl');
+		if(count($r)) {
+			$photo = 'thumb';
+			foreach($r as $rr) {
+				$profile_link = $a->get_baseurl() . '/profile/' . ((strlen($rr['nickname'])) ? $rr['nickname'] : $rr['profile_uid']);
+				$entry = replace_macros($tpl,array(
+					'$id' => $rr['id'],
+					'$profile_link' => $profile_link,
+					'$photo' => $a->get_cached_avatar_image($rr[$photo]),
+					'$alt_text' => $rr['name']));
+				$aside['$lastusers_items'][] = $entry;
+			}
+		}
+	}
+
+	// last 10 liked items
+/*
+	if(!$close_lastlikes) {
+		$aside['$like_title'] = t('Last likes');
+		$aside['$like_items'] = array();
+		$r = q("SELECT `T1`.`created`, `T1`.`liker`, `T1`.`liker-link`, `item`.* FROM
+				(SELECT `parent-uri`, `created`, `author-name` AS `liker`,`author-link` AS `liker-link`
+					FROM `item` WHERE `verb`='http://activitystrea.ms/schema/1.0/like' GROUP BY `parent-uri` ORDER BY `created` DESC) AS T1
+				INNER JOIN `item` ON `item`.`uri`=`T1`.`parent-uri`
+				WHERE `T1`.`liker-link` LIKE '%s%%' OR `item`.`author-link` LIKE '%s%%'
+				GROUP BY `uri`
+				ORDER BY `T1`.`created` DESC
+				LIMIT 0,5",
+				$a->get_baseurl(),$a->get_baseurl());
+
+		foreach ($r as $rr) {
+			$author	 = '<a href="' . $rr['liker-link'] . '">' . $rr['liker'] . '</a>';
+			$objauthor =  '<a href="' . $rr['author-link'] . '">' . $rr['author-name'] . '</a>';
+
+			//var_dump($rr['verb'],$rr['object-type']); killme();
+			switch($rr['verb']){
+				case 'http://activitystrea.ms/schema/1.0/post':
+					switch ($rr['object-type']){
+						case 'http://activitystrea.ms/schema/1.0/event':
+							$post_type = t('event');
+							break;
+						default:
+							$post_type = t('status');
+					}
+					break;
+				default:
+					if ($rr['resource-id']){
+						$post_type = t('photo');
+						$m=array();
+						preg_match("/\[url=([^]]*)\]/", $rr['body'], $m);
+						$rr['plink'] = $m[1];
+					} else
+						$post_type = t('status');
+			}
+			$plink = '<a href="' . $rr['plink'] . '">' . $post_type . '</a>';
+
+			$aside['$like_items'][] = sprintf( t('%1$s likes %2$s\'s %3$s'), $author, $objauthor, $plink);
+
+		}
+	}
+
+	// last 12 photos
+	if(!$close_lastphotos) {
+		$aside['$photos_title'] = t('Last photos');
+		$aside['$photos_items'] = array();
+		$r = q("SELECT `photo`.`id`, `photo`.`resource-id`, `photo`.`scale`, `photo`.`desc`, `user`.`nickname`, `user`.`username` FROM
+				(SELECT `resource-id`, MAX(`scale`) as maxscale FROM `photo`
+					WHERE `profile`=0 AND `contact-id`=0 AND `album` NOT IN ('Contact Photos', '%s', 'Profile Photos', '%s')
+						AND `allow_cid`='' AND `allow_gid`='' AND `deny_cid`='' AND `deny_gid`='' GROUP BY `resource-id`) AS `t1`
+				INNER JOIN `photo` ON `photo`.`resource-id`=`t1`.`resource-id` AND `photo`.`scale` = `t1`.`maxscale`,
+				`user`
+				WHERE `user`.`uid` = `photo`.`uid`
+				AND `user`.`blockwall`=0
+				AND `user`.`hidewall`=0
+				ORDER BY `photo`.`edited` DESC
+				LIMIT 0, 9",
+				dbesc(t('Contact Photos')),
+				dbesc(t('Profile Photos'))
+				);
+		if(count($r)) {
+			$tpl = get_markup_template('ch_directory_item.tpl');
+			foreach($r as $rr) {
+				$photo_page = $a->get_baseurl() . '/photos/' . $rr['nickname'] . '/image/' . $rr['resource-id'];
+				$photo_url = $a->get_baseurl() . '/photo/' .  $rr['resource-id'] . '-' . $rr['scale'] .'.jpg';
+
+				$entry = replace_macros($tpl,array(
+					'$id' => $rr['id'],
+					'$profile_link' => $photo_page,
+					'$photo' => $photo_url,
+					'$alt_text' => $rr['username']." : ".$rr['desc']));
+
+				$aside['$photos_items'][] = $entry;
+			}
+		}
+	}
+*/
+	//right_aside FIND FRIENDS
+	if (!$close_friends AND local_user()) {
+		$nv = array();
+		$nv['title'] = Array("", t('Find Friends'), "", "");
+		$nv['directory'] = Array('directory', t('Local Directory'), "", "");
+		$nv['global_directory'] = Array('http://dir.friendica.com/', t('Global Directory'), "", "");
+		$nv['match'] = Array('match', t('Similar Interests'), "", "");
+		$nv['suggest'] = Array('suggest', t('Friend Suggestions'), "", "");
+		$nv['invite'] = Array('invite', t('Invite Friends'), "", "");
+
+		$nv['search'] = '<form name="simple_bar" method="get" action="http://dir.friendica.com/directory">
+						<span class="sbox_l"></span>
+						<span class="sbox">
+						<input type="text" name="search" size="13" maxlength="50">
+						</span>
+						<span class="sbox_r" id="srch_clear"></span>';
+
+		$aside['$nv'] = $nv;
+	}
+
+	//Community_Pages at right_aside
+	if(!$close_pages AND local_user()) {
+		$page = '
+			<h3 style="margin-top:0px;">'.t("Community Pages").'<a id="closeicon" href="#boxsettings" onClick="open_boxsettings(); return false;" style="text-decoration:none;" class="icon close_box" title="'.t("Settings").'"></a></h3>
+			<div id=""><ul style="margin-left: 7px;margin-top: 0px;padding-left: 0px;padding-top: 0px;">';
+
+		$pagelist = array();
+
+		$contacts = q("SELECT `id`, `url`, `name`, `micro`FROM `contact`
+				WHERE `network`= 'dfrn' AND `forum` = 1 AND `uid` = %d
+				ORDER BY `name` ASC",
+				intval($a->user['uid']));
+
+		$pageD = array();
+
+		// Look if the profile is a community page
+		foreach($contacts as $contact) {
+			$pageD[] = array("url"=>$contact["url"], "name"=>$contact["name"], "id"=>$contact["id"], "micro"=>$contact['micro']);
+		};
+
+
+		$contacts = $pageD;
+
+		foreach($contacts as $contact) {
+			$page .= '<li style="list-style-type: none;" class="tool"><img height="20" width="20" style="float: left; margin-right: 3px;" src="' . $contact['micro'] .'" alt="' . $contact['url'] . '" /> <a href="'.$a->get_baseurl().'/redir/'.$contact["id"].'" style="margin-top: 2px; word-wrap: break-word; width: 132px;" title="' . $contact['url'] . '" class="label" target="external-link">'.
+					$contact["name"]."</a></li>";
+		}
+		$page .= '</ul></div>';
+		//if (sizeof($contacts) > 0)
+			$aside['$page'] = $page;
+	}
+	//END Community Page
+
+	//helpers
+	if(!$close_helpers) {
+		$helpers = array();
+		$helpers['title'] = Array("", t('Help or @NewHere ?'), "", "");
+		$aside['$helpers'] = $helpers;
+	}
+	//end helpers
+
+	//connectable services
+	if (!$close_services) {
+		$con_services = array();
+		$con_services['title'] = Array("", t('Connect Services'), "", "");
+		$aside['$con_services'] = $con_services;
+	}
+	//end connectable services
+
+/*
+	if($ccCookie != "9") {
+		$close_pages      = get_vier_config( "close_pages", 1 );
+		$close_profiles   = get_vier_config( "close_profiles", 0 );
+		$close_helpers    = get_vier_config( "close_helpers", 0 );
+		$close_services   = get_vier_config( "close_services", 0 );
+		$close_friends    = get_vier_config( "close_friends", 0 );
+		$close_lastusers  = get_vier_config( "close_lastusers", 0 );
+		$close_lastphotos = get_vier_config( "close_lastphotos", 0 );
+		$close_lastlikes  = get_vier_config( "close_lastlikes", 0 );
+		$close_or_not = array('1'=>t("don't show"),	'0'=>t("show"),);
+		$boxsettings['title'] = Array("", t('Show/hide boxes at right-hand column:'), "", "");
+		$aside['$boxsettings'] = $boxsettings;
+		$aside['$close_pages'] = array('vier_close_pages', t('Community Pages'), $close_pages, '', $close_or_not);
+		$aside['$close_profiles'] = array('vier_close_profiles', t('Community Profiles'), $close_profiles, '', $close_or_not);
+		$aside['$close_helpers'] = array('vier_close_helpers', t('Help or @NewHere ?'), $close_helpers, '', $close_or_not);
+		$aside['$close_services'] = array('vier_close_services', t('Connect Services'), $close_services, '', $close_or_not);
+		$aside['$close_friends'] = array('vier_close_friends', t('Find Friends'), $close_friends, '', $close_or_not);
+		$aside['$close_lastusers'] = array('vier_close_lastusers', t('Last users'), $close_lastusers, '', $close_or_not);
+		$aside['$close_lastphotos'] = array('vier_close_lastphotos', t('Last photos'), $close_lastphotos, '', $close_or_not);
+		$aside['$close_lastlikes'] = array('vier_close_lastlikes', t('Last likes'), $close_lastlikes, '', $close_or_not);
+		$aside['$sub'] = t('Submit');
+		$baseurl = $a->get_baseurl($ssl_state);
+		$aside['$baseurl'] = $baseurl;
+
+		if (isset($_POST['vier-settings-box-sub']) && $_POST['vier-settings-box-sub']!=''){
+			set_pconfig(local_user(), 'vier', 'close_pages', $_POST['vier_close_pages']);
+			set_pconfig(local_user(), 'vier', 'close_profiles', $_POST['vier_close_profiles']);
+			set_pconfig(local_user(), 'vier', 'close_helpers', $_POST['vier_close_helpers']);
+			set_pconfig(local_user(), 'vier', 'close_services', $_POST['vier_close_services']);
+			set_pconfig(local_user(), 'vier', 'close_friends', $_POST['vier_close_friends']);
+			set_pconfig(local_user(), 'vier', 'close_lastusers', $_POST['vier_close_lastusers']);
+			set_pconfig(local_user(), 'vier', 'close_lastphotos', $_POST['vier_close_lastphotos']);
+			set_pconfig(local_user(), 'vier', 'close_lastlikes', $_POST['vier_close_lastlikes']);
+		}
+	}
+	$close = t('Settings');
+	$aside['$close'] = $close;
+*/
+	//get_baseurl
+	$url = $a->get_baseurl($ssl_state);
+	$aside['$url'] = $url;
+
+	//print right_aside
+	$tpl = get_markup_template('communityhome.tpl');
+	$a->page['right_aside'] = replace_macros($tpl, $aside);
+}

--- a/view/theme/vier/theme.php
+++ b/view/theme/vier/theme.php
@@ -9,6 +9,10 @@
  * Description: "Vier" is a very compact and modern theme. It uses the font awesome font library: http://fortawesome.github.com/Font-Awesome/
  */
 
+require_once("mod/nodeinfo.php");
+require_once("mod/proxy.php");
+require_once("include/socgraph.php");
+
 function vier_init(&$a) {
 
 	$a->theme_events_in_profile = false;
@@ -84,8 +88,8 @@ EOT;
 		$a->page['htmlhead'] .= "<link rel='stylesheet' href='view/theme/vier/hide.css' />";
 }
 
-function get_vier_config($key, $default = false) {
-	if (local_user()) {
+function get_vier_config($key, $default = false, $admin = false) {
+	if (local_user() AND !$admin) {
 		$result = get_pconfig(local_user(), "vier", $key);
 		if ($result !== false)
 			return $result;
@@ -100,40 +104,34 @@ function get_vier_config($key, $default = false) {
 
 function vier_community_info() {
 	$a = get_app();
-/*
-	$close_pages      = get_vier_config("close_pages", 1);
-	$close_profiles   = get_vier_config("close_profiles", 0);
-	$close_helpers    = get_vier_config("close_helpers", 0);
-	$close_services   = get_vier_config("close_services", 0);
-	$close_friends    = get_vier_config("close_friends", 0);
-	$close_lastusers  = get_vier_config("close_lastusers", 0);
-	$close_lastphotos = get_vier_config("close_lastphotos", 0);
-	$close_lastlikes  = get_vier_config("close_lastlikes", 0);
-*/
-	$close_pages      = false;
-	$close_profiles   = true;
-	$close_helpers    = false;
-	$close_services   = false;
-	$close_friends    = false;
-	$close_lastusers  = true;
-	$close_lastphotos = true;
-	$close_lastlikes  = true;
+
+	$show_pages      = get_vier_config("show_pages", 1);
+	$show_profiles   = get_vier_config("show_profiles", 1);
+	$show_helpers    = get_vier_config("show_helpers", 1);
+	$show_services   = get_vier_config("show_services", 1);
+	$show_friends    = get_vier_config("show_friends", 1);
+	$show_lastusers  = get_vier_config("show_lastusers", 1);
+
+	//get_baseurl
+	$url = $a->get_baseurl($ssl_state);
+	$aside['$url'] = $url;
 
 	// comunity_profiles
-	if(!$close_profiles) {
-		$aside['$comunity_profiles_title'] = t('Community Profiles');
-		$aside['$comunity_profiles_items'] = array();
-		$r = q("select gcontact.* from gcontact left join glink on glink.gcid = gcontact.id
-			  where glink.cid = 0 and glink.uid = 0 order by rand() limit 9");
+	if($show_profiles) {
+
+		$r = suggestion_query(local_user(), 0, 9);
+
 		$tpl = get_markup_template('ch_directory_item.tpl');
 		if(count($r)) {
-			$photo = 'photo';
+
+			$aside['$comunity_profiles_title'] = t('Community Profiles');
+			$aside['$comunity_profiles_items'] = array();
+
 			foreach($r as $rr) {
-				$profile_link = $a->get_baseurl() . '/profile/' . ((strlen($rr['nickname'])) ? $rr['nickname'] : $rr['profile_uid']);
 				$entry = replace_macros($tpl,array(
 					'$id' => $rr['id'],
 					'$profile_link' => zrl($rr['url']),
-					'$photo' => $rr[$photo],
+					'$photo' => proxy_url($rr['photo']),
 					'$alt_text' => $rr['name'],
 				));
 				$aside['$comunity_profiles_items'][] = $entry;
@@ -141,126 +139,45 @@ function vier_community_info() {
 		}
 	}
 
-	// last 12 users
-	if(!$close_lastusers) {
-		$aside['$lastusers_title'] = t('Last users');
-		$aside['$lastusers_items'] = array();
-		$sql_extra = "";
+	// last 9 users
+	if($show_lastusers) {
 		$publish = (get_config('system','publish_all') ? '' : " AND `publish` = 1 ");
 		$order = " ORDER BY `register_date` DESC ";
 
 		$r = q("SELECT `profile`.*, `profile`.`uid` AS `profile_uid`, `user`.`nickname`
 				FROM `profile` LEFT JOIN `user` ON `user`.`uid` = `profile`.`uid`
-				WHERE `is-default` = 1 $publish AND `user`.`blocked` = 0 $sql_extra $order LIMIT %d , %d ",
+				WHERE `is-default` = 1 $publish AND `user`.`blocked` = 0 $order LIMIT %d , %d ",
 				0, 9);
 
 		$tpl = get_markup_template('ch_directory_item.tpl');
 		if(count($r)) {
-			$photo = 'thumb';
+
+			$aside['$lastusers_title'] = t('Last users');
+			$aside['$lastusers_items'] = array();
+
 			foreach($r as $rr) {
 				$profile_link = $a->get_baseurl() . '/profile/' . ((strlen($rr['nickname'])) ? $rr['nickname'] : $rr['profile_uid']);
 				$entry = replace_macros($tpl,array(
 					'$id' => $rr['id'],
 					'$profile_link' => $profile_link,
-					'$photo' => $a->get_cached_avatar_image($rr[$photo]),
+					'$photo' => $a->get_cached_avatar_image($rr['thumb']),
 					'$alt_text' => $rr['name']));
 				$aside['$lastusers_items'][] = $entry;
 			}
 		}
 	}
 
-	// last 10 liked items
-/*
-	if(!$close_lastlikes) {
-		$aside['$like_title'] = t('Last likes');
-		$aside['$like_items'] = array();
-		$r = q("SELECT `T1`.`created`, `T1`.`liker`, `T1`.`liker-link`, `item`.* FROM
-				(SELECT `parent-uri`, `created`, `author-name` AS `liker`,`author-link` AS `liker-link`
-					FROM `item` WHERE `verb`='http://activitystrea.ms/schema/1.0/like' GROUP BY `parent-uri` ORDER BY `created` DESC) AS T1
-				INNER JOIN `item` ON `item`.`uri`=`T1`.`parent-uri`
-				WHERE `T1`.`liker-link` LIKE '%s%%' OR `item`.`author-link` LIKE '%s%%'
-				GROUP BY `uri`
-				ORDER BY `T1`.`created` DESC
-				LIMIT 0,5",
-				$a->get_baseurl(),$a->get_baseurl());
-
-		foreach ($r as $rr) {
-			$author	 = '<a href="' . $rr['liker-link'] . '">' . $rr['liker'] . '</a>';
-			$objauthor =  '<a href="' . $rr['author-link'] . '">' . $rr['author-name'] . '</a>';
-
-			//var_dump($rr['verb'],$rr['object-type']); killme();
-			switch($rr['verb']){
-				case 'http://activitystrea.ms/schema/1.0/post':
-					switch ($rr['object-type']){
-						case 'http://activitystrea.ms/schema/1.0/event':
-							$post_type = t('event');
-							break;
-						default:
-							$post_type = t('status');
-					}
-					break;
-				default:
-					if ($rr['resource-id']){
-						$post_type = t('photo');
-						$m=array();
-						preg_match("/\[url=([^]]*)\]/", $rr['body'], $m);
-						$rr['plink'] = $m[1];
-					} else
-						$post_type = t('status');
-			}
-			$plink = '<a href="' . $rr['plink'] . '">' . $post_type . '</a>';
-
-			$aside['$like_items'][] = sprintf( t('%1$s likes %2$s\'s %3$s'), $author, $objauthor, $plink);
-
-		}
-	}
-
-	// last 12 photos
-	if(!$close_lastphotos) {
-		$aside['$photos_title'] = t('Last photos');
-		$aside['$photos_items'] = array();
-		$r = q("SELECT `photo`.`id`, `photo`.`resource-id`, `photo`.`scale`, `photo`.`desc`, `user`.`nickname`, `user`.`username` FROM
-				(SELECT `resource-id`, MAX(`scale`) as maxscale FROM `photo`
-					WHERE `profile`=0 AND `contact-id`=0 AND `album` NOT IN ('Contact Photos', '%s', 'Profile Photos', '%s')
-						AND `allow_cid`='' AND `allow_gid`='' AND `deny_cid`='' AND `deny_gid`='' GROUP BY `resource-id`) AS `t1`
-				INNER JOIN `photo` ON `photo`.`resource-id`=`t1`.`resource-id` AND `photo`.`scale` = `t1`.`maxscale`,
-				`user`
-				WHERE `user`.`uid` = `photo`.`uid`
-				AND `user`.`blockwall`=0
-				AND `user`.`hidewall`=0
-				ORDER BY `photo`.`edited` DESC
-				LIMIT 0, 9",
-				dbesc(t('Contact Photos')),
-				dbesc(t('Profile Photos'))
-				);
-		if(count($r)) {
-			$tpl = get_markup_template('ch_directory_item.tpl');
-			foreach($r as $rr) {
-				$photo_page = $a->get_baseurl() . '/photos/' . $rr['nickname'] . '/image/' . $rr['resource-id'];
-				$photo_url = $a->get_baseurl() . '/photo/' .  $rr['resource-id'] . '-' . $rr['scale'] .'.jpg';
-
-				$entry = replace_macros($tpl,array(
-					'$id' => $rr['id'],
-					'$profile_link' => $photo_page,
-					'$photo' => $photo_url,
-					'$alt_text' => $rr['username']." : ".$rr['desc']));
-
-				$aside['$photos_items'][] = $entry;
-			}
-		}
-	}
-*/
 	//right_aside FIND FRIENDS
-	if (!$close_friends AND local_user()) {
+	if ($show_friends AND local_user()) {
 		$nv = array();
 		$nv['title'] = Array("", t('Find Friends'), "", "");
 		$nv['directory'] = Array('directory', t('Local Directory'), "", "");
-		$nv['global_directory'] = Array('http://dir.friendica.com/', t('Global Directory'), "", "");
+		$nv['global_directory'] = Array(get_server(), t('Global Directory'), "", "");
 		$nv['match'] = Array('match', t('Similar Interests'), "", "");
 		$nv['suggest'] = Array('suggest', t('Friend Suggestions'), "", "");
 		$nv['invite'] = Array('invite', t('Invite Friends'), "", "");
 
-		$nv['search'] = '<form name="simple_bar" method="get" action="http://dir.friendica.com/directory">
+		$nv['search'] = '<form name="simple_bar" method="get" action="'.$a->get_baseurl().'/dirfind">
 						<span class="sbox_l"></span>
 						<span class="sbox">
 						<input type="text" name="search" size="13" maxlength="50">
@@ -271,17 +188,17 @@ function vier_community_info() {
 	}
 
 	//Community_Pages at right_aside
-	if(!$close_pages AND local_user()) {
-		$page = '
-			<h3 style="margin-top:0px;">'.t("Community Pages").'<a id="closeicon" href="#boxsettings" onClick="open_boxsettings(); return false;" style="text-decoration:none;" class="icon close_box" title="'.t("Settings").'"></a></h3>
-			<div id=""><ul style="margin-left: 7px;margin-top: 0px;padding-left: 0px;padding-top: 0px;">';
+	if($show_pages AND local_user()) {
 
 		$pagelist = array();
 
-		$contacts = q("SELECT `id`, `url`, `name`, `micro`FROM `contact`
-				WHERE `network`= 'dfrn' AND `forum` = 1 AND `uid` = %d
+		$contacts = q("SELECT `id`, `url`, `name`, `micro` FROM `contact`
+				WHERE `network`= '%s' AND `forum` AND `uid` = %d AND
+					NOT `hidden` AND NOT `blocked` AND
+					NOT `archive` AND NOT `pending` AND
+					`success_update` > `failure_update`
 				ORDER BY `name` ASC",
-				intval($a->user['uid']));
+				dbesc(NETWORK_DFRN), intval($a->user['uid']));
 
 		$pageD = array();
 
@@ -290,77 +207,140 @@ function vier_community_info() {
 			$pageD[] = array("url"=>$contact["url"], "name"=>$contact["name"], "id"=>$contact["id"], "micro"=>$contact['micro']);
 		};
 
-
 		$contacts = $pageD;
 
-		foreach($contacts as $contact) {
-			$page .= '<li style="list-style-type: none;" class="tool"><img height="20" width="20" style="float: left; margin-right: 3px;" src="' . $contact['micro'] .'" alt="' . $contact['url'] . '" /> <a href="'.$a->get_baseurl().'/redir/'.$contact["id"].'" style="margin-top: 2px; word-wrap: break-word; width: 132px;" title="' . $contact['url'] . '" class="label" target="external-link">'.
-					$contact["name"]."</a></li>";
-		}
-		$page .= '</ul></div>';
-		//if (sizeof($contacts) > 0)
+		if ($contacts) {
+			$page = '
+				<h3>'.t("Community Pages").'</h3>
+				<div id="forum-list-right">';
+
+			foreach($contacts as $contact) {
+				$page .= '<div role="menuitem"><a href="' . $a->get_baseurl() . '/redir/' . $contact["id"] . '" title="'.t('External link to forum').'" class="label sparkle" target="_blank"><img class="forumlist-img" height="20" width="20" src="' . $contact['micro'] .'" alt="'.t('External link to forum').'" /></a> <a href="' . $a->get_baseurl() . '/network?f=&cid=' . $contact['id'] . '" >' . $contact["name"]."</a></div>";
+			}
+
+			$page .= '</div>';
 			$aside['$page'] = $page;
+		}
 	}
 	//END Community Page
 
 	//helpers
-	if(!$close_helpers) {
-		$helpers = array();
-		$helpers['title'] = Array("", t('Help or @NewHere ?'), "", "");
-		$aside['$helpers'] = $helpers;
+	if($show_helpers) {
+		$r = array();
+
+		$helperlist = get_config("vier", "helperlist");
+
+		$helpers = explode(",",$helperlist);
+
+		if ($helpers) {
+			$query = "";
+			foreach ($helpers AS $index=>$helper) {
+				if ($query != "")
+					$query .= ",";
+
+				$query .= "'".dbesc(normalise_link(trim($helper)))."'";
+			}
+
+			$r = q("SELECT `url`, `name` FROM `gcontact` WHERE `nurl` IN (%s)", $query);
+		}
+
+		foreach ($r AS $index => $helper)
+			$r[$index]["url"] = zrl($helper["url"]);
+
+		$r[] = Array("url" => "help/Quick-Start-guide", "name" => t("Quick Start"));
+
+		$tpl = get_markup_template('ch_helpers.tpl');
+
+		if ($r) {
+
+			$helpers = array();
+			$helpers['title'] = Array("", t('Help'), "", "");
+
+			$aside['$helpers_items'] = array();
+
+			foreach($r as $rr) {
+				$entry = replace_macros($tpl,array(
+					'$url' => $rr['url'],
+					'$title' => $rr['name'],
+				));
+				$aside['$helpers_items'][] = $entry;
+			}
+
+			$aside['$helpers'] = $helpers;
+		}
 	}
 	//end helpers
 
 	//connectable services
-	if (!$close_services) {
-		$con_services = array();
-		$con_services['title'] = Array("", t('Connect Services'), "", "");
-		$aside['$con_services'] = $con_services;
+	if ($show_services) {
+
+		$r = array();
+
+		if (nodeinfo_plugin_enabled("appnet"))
+			$r[] = array("photo" => "images/appnet.png", "name" => "App.net");
+
+		if (nodeinfo_plugin_enabled("buffer"))
+			$r[] = array("photo" => "images/buffer.png", "name" => "Buffer");
+
+		if (nodeinfo_plugin_enabled("blogger"))
+			$r[] = array("photo" => "images/blogger.png", "name" => "Blogger");
+
+		if (nodeinfo_plugin_enabled("dwpost"))
+			$r[] = array("photo" => "images/dreamwidth.png", "name" => "Dreamwidth");
+
+		if (nodeinfo_plugin_enabled("fbpost"))
+			$r[] = array("photo" => "images/facebook.png", "name" => "Facebook");
+
+		if (nodeinfo_plugin_enabled("statusnet"))
+			$r[] = array("photo" => "images/gnusocial.png", "name" => "GNU Social");
+
+		if (nodeinfo_plugin_enabled("gpluspost"))
+			$r[] = array("photo" => "images/googleplus.png", "name" => "Google+");
+
+		//if (nodeinfo_plugin_enabled("ijpost"))
+		//	$r[] = array("photo" => "images/", "name" => "");
+
+		if (nodeinfo_plugin_enabled("libertree"))
+			$r[] = array("photo" => "images/libertree.png", "name" => "Libertree");
+
+		//if (nodeinfo_plugin_enabled("ljpost"))
+		//	$r[] = array("photo" => "images/", "name" => "");
+
+		if (nodeinfo_plugin_enabled("pumpio"))
+			$r[] = array("photo" => "images/pumpio.png", "name" => "pump.io");
+
+		if (nodeinfo_plugin_enabled("tumblr"))
+			$r[] = array("photo" => "images/tumblr.png", "name" => "Tumblr");
+
+		if (nodeinfo_plugin_enabled("twitter"))
+			$r[] = array("photo" => "images/twitter.png", "name" => "Twitter");
+
+		if (nodeinfo_plugin_enabled("wppost"))
+			$r[] = array("photo" => "images/wordpress", "name" => "Wordpress");
+
+		if(function_exists("imap_open") AND !get_config("system","imap_disabled") AND !get_config("system","dfrn_only"))
+			$r[] = array("photo" => "images/mail", "name" => "E-Mail");
+
+		$tpl = get_markup_template('ch_connectors.tpl');
+
+		if(count($r)) {
+
+			$con_services = array();
+			$con_services['title'] = Array("", t('Connect Services'), "", "");
+			$aside['$con_services'] = $con_services;
+
+			foreach($r as $rr) {
+				$entry = replace_macros($tpl,array(
+					'$url' => $url,
+					'$photo' => $rr['photo'],
+					'$alt_text' => $rr['name'],
+				));
+				$aside['$connector_items'][] = $entry;
+			}
+		}
+
 	}
 	//end connectable services
-
-/*
-	if($ccCookie != "9") {
-		$close_pages      = get_vier_config( "close_pages", 1 );
-		$close_profiles   = get_vier_config( "close_profiles", 0 );
-		$close_helpers    = get_vier_config( "close_helpers", 0 );
-		$close_services   = get_vier_config( "close_services", 0 );
-		$close_friends    = get_vier_config( "close_friends", 0 );
-		$close_lastusers  = get_vier_config( "close_lastusers", 0 );
-		$close_lastphotos = get_vier_config( "close_lastphotos", 0 );
-		$close_lastlikes  = get_vier_config( "close_lastlikes", 0 );
-		$close_or_not = array('1'=>t("don't show"),	'0'=>t("show"),);
-		$boxsettings['title'] = Array("", t('Show/hide boxes at right-hand column:'), "", "");
-		$aside['$boxsettings'] = $boxsettings;
-		$aside['$close_pages'] = array('vier_close_pages', t('Community Pages'), $close_pages, '', $close_or_not);
-		$aside['$close_profiles'] = array('vier_close_profiles', t('Community Profiles'), $close_profiles, '', $close_or_not);
-		$aside['$close_helpers'] = array('vier_close_helpers', t('Help or @NewHere ?'), $close_helpers, '', $close_or_not);
-		$aside['$close_services'] = array('vier_close_services', t('Connect Services'), $close_services, '', $close_or_not);
-		$aside['$close_friends'] = array('vier_close_friends', t('Find Friends'), $close_friends, '', $close_or_not);
-		$aside['$close_lastusers'] = array('vier_close_lastusers', t('Last users'), $close_lastusers, '', $close_or_not);
-		$aside['$close_lastphotos'] = array('vier_close_lastphotos', t('Last photos'), $close_lastphotos, '', $close_or_not);
-		$aside['$close_lastlikes'] = array('vier_close_lastlikes', t('Last likes'), $close_lastlikes, '', $close_or_not);
-		$aside['$sub'] = t('Submit');
-		$baseurl = $a->get_baseurl($ssl_state);
-		$aside['$baseurl'] = $baseurl;
-
-		if (isset($_POST['vier-settings-box-sub']) && $_POST['vier-settings-box-sub']!=''){
-			set_pconfig(local_user(), 'vier', 'close_pages', $_POST['vier_close_pages']);
-			set_pconfig(local_user(), 'vier', 'close_profiles', $_POST['vier_close_profiles']);
-			set_pconfig(local_user(), 'vier', 'close_helpers', $_POST['vier_close_helpers']);
-			set_pconfig(local_user(), 'vier', 'close_services', $_POST['vier_close_services']);
-			set_pconfig(local_user(), 'vier', 'close_friends', $_POST['vier_close_friends']);
-			set_pconfig(local_user(), 'vier', 'close_lastusers', $_POST['vier_close_lastusers']);
-			set_pconfig(local_user(), 'vier', 'close_lastphotos', $_POST['vier_close_lastphotos']);
-			set_pconfig(local_user(), 'vier', 'close_lastlikes', $_POST['vier_close_lastlikes']);
-		}
-	}
-	$close = t('Settings');
-	$aside['$close'] = $close;
-*/
-	//get_baseurl
-	$url = $a->get_baseurl($ssl_state);
-	$aside['$url'] = $url;
 
 	//print right_aside
 	$tpl = get_markup_template('communityhome.tpl');

--- a/view/theme/vier/wide.css
+++ b/view/theme/vier/wide.css
@@ -1,0 +1,23 @@
+right_aside {
+  vertical-align: top;
+  width: 185px;
+  padding-top: 10px;
+  padding-right: 20px;
+  padding-bottom: 0px;
+  padding-left: 10px;
+  background-color: #FFFFFF;
+  font-size: 13px;
+  overflow-y: auto;
+  z-index: 2;
+  line-height: 17px;
+  position: fixed;
+  color: #737373;
+    top: 44px;
+  height: calc(100% - 54px);
+  display: block;
+  margin-left: calc(100% - 215px);
+}
+
+#forumlist-sidebar {
+  display: none;
+}

--- a/view/theme/vier/wide.css
+++ b/view/theme/vier/wide.css
@@ -10,14 +10,41 @@ right_aside {
   overflow-y: auto;
   z-index: 2;
   line-height: 17px;
-  position: fixed;
   color: #737373;
-    top: 44px;
-  height: calc(100% - 54px);
+  top: 44px;
+  position: absolute;
+/*  position: fixed;
+  height: calc(100% - 54px); */
   display: block;
   margin-left: calc(100% - 215px);
+  box-shadow: 1px 2px 0px 0px #D8D8D8;
 }
 
 #forumlist-sidebar {
   display: none;
+}
+
+right_aside span.sbox {
+  margin-left: 10px;
+}
+
+right_aside .directory-item {
+  width: 50px;
+  height: 50px;
+}
+
+right_aside img.directory-photo-img {
+  width: 45px;
+  height: 45px;
+}
+
+right_aside #right_services img {
+  width: 32px;
+}
+
+right_aside #lastusers-wrapper,
+right_aside div.itens-wrapper,
+right_aside #right_services_icons {
+  margin-left: 10px;
+  margin-top: 5px;
 }


### PR DESCRIPTION
Diabook has a three column design where the right column mostly shows interesting content for beginners. Since Diabook is deprecated, this functionality is now usable in "vier" as well. It is a complete rework. The third column automatically disappears on smaller displays. 

The values aren't static like in Diabook. The list of connectors only shows the active connectors. The community profiles are using the same function like the "suggest" function. The link to the helpers can be modified to show several forums. The list to the global directory is taken from the config value.

Some functions had not been transferred to "vier" since they caused massive SQL queries.