### PR TITLE
New option to permit crawlers

### DIFF
--- a/include/network.php
+++ b/include/network.php
@@ -309,16 +309,25 @@ function xml_status($st, $message = '') {
 
 
 if(! function_exists('http_status_exit')) {
-function http_status_exit($val) {
-
+function http_status_exit($val, $description = array()) {
     $err = '';
-	if($val >= 400)
+	if($val >= 400) {
 		$err = 'Error';
+		if (!isset($description["title"]))
+			$description["title"] = $err." ".$val;
+	}
 	if($val >= 200 && $val < 300)
 		$err = 'OK';
 
 	logger('http_status_exit ' . $val);
 	header($_SERVER["SERVER_PROTOCOL"] . ' ' . $val . ' ' . $err);
+
+	if (isset($description["title"])) {
+		$tpl = get_markup_template('http_status.tpl');
+		echo replace_macros($tpl, array('$title' => $description["title"],
+						'$description' => $description["description"]));
+	}
+
 	killme();
 
 }}

--- a/view/templates/http_status.tpl
+++ b/view/templates/http_status.tpl
@@ -1,0 +1,9 @@
+<html>
+	<head>
+		<title>{{$title}}</title>
+	</head>
+	<body>
+		<h1>{{$title}}</h1>
+		<p>{{$description}}</p>
+	</body>
+</html>


### PR DESCRIPTION
When the option
````

$a->config['system']['permit_crawling'] = true;
````
is set in the .htconfig.php then a not logged in user can only perform one search per minute. This should prevent crawlers from blocking the system.

This addresses the issue https://github.com/friendica/friendica/issues/1924