### PR TITLE
personalise emails send from the server

### DIFF
--- a/doc/htconfig.md
+++ b/doc/htconfig.md
@@ -77,3 +77,22 @@ line to your .htconfig.php:
 ## theme ##
 
 * hide_eventlist (Boolean) - Don't show the birthdays and events on the profile and network page
+
+# Administrator Options #
+
+Enabling the admin panel for an account, and thus making the account holder
+admin of the node, is done by setting the variable
+
+    $a->config['admin_email'] = "someone@example.com";
+
+where you have to match the email address used for the account with the one you
+enter to the .htconfig file. If more then one account should be able to access
+the admin panel, seperate the email addresses with a comma.
+
+    $a->config['admin_email'] = "someone@example.com,someonelese@example.com";
+
+If you want to have a more personalized closing line for the notification
+emails you can set a variable for the admin_name.
+
+    $a->config['admin_name'] = "Marvin";
+

--- a/include/enotify.php
+++ b/include/enotify.php
@@ -20,7 +20,11 @@ function notification($params) {
 	$siteurl = $a->get_baseurl(true);
 	$thanks = t('Thank You,');
 	$sitename = $a->config['sitename'];
-	$site_admin = sprintf( t('%s Administrator'), $sitename);
+	if (!x($a->config['admin_name'])) {
+	    $site_admin = sprintf( t('%s Administrator'), $sitename);
+	} else {
+	    $site_admin = sprintf( t('%1$s, %2$s Administrator'), $a->config['admin_name'], $sitename);
+	}
 	$nickname = "";
 
 	$sender_name = $sitename;


### PR DESCRIPTION
This introduces the config variable ```$a->config['admin_name']`` which allows you to customize the closing line for email notification. If the variable is not set, the old string is used, if it is set the closing line now reads ``%1$s, %2$s Administrator`` where 1$s is the name of the admin and 2$s the name of the node.

The variable name in the config array was choosen to accompany ``$a->config['admin_email']`` if there is a better one, let me know. If it is ok as well, I'll add the variable to the documentation before merging the PR, so let me know in this case too.