### PR TITLE
Reworked contact relations between Diaspora and Friendica

### DIFF
--- a/include/conversation.php
+++ b/include/conversation.php
@@ -897,7 +897,8 @@ function item_photo_menu($item){
 	if ($a->contacts[$clean_url]['network'] === NETWORK_DFRN)
 		$menu[t("Poke")] = $poke_link;
 
-	if (($cid == 0) AND in_array($item['network'], array(NETWORK_DFRN, NETWORK_OSTATUS, NETWORK_DIASPORA)))
+	if (($cid == 0) AND
+		in_array($item['network'], array(NETWORK_DFRN, NETWORK_OSTATUS, NETWORK_DIASPORA)))
 		$menu[t("Connect/Follow")] = $a->get_baseurl($ssl_state)."/follow?url=".urlencode($item['author-link']);
 
 	$args = array('item' => $item, 'menu' => $menu);

--- a/include/diaspora.php
+++ b/include/diaspora.php
@@ -592,7 +592,7 @@ function diaspora_request($importer,$xml) {
 		// perhaps we were already sharing with this person. Now they're sharing with us.
 		// That makes us friends.
 
-		if($contact['rel'] == CONTACT_IS_FOLLOWER && !in_array($importer['page-flags'], array(PAGE_COMMUNITY, PAGE_SOAPBOX))) {
+		if($contact['rel'] == CONTACT_IS_FOLLOWER && in_array($importer['page-flags'], array(PAGE_FREELOVE))) {
 			q("UPDATE `contact` SET `rel` = %d, `writable` = 1 WHERE `id` = %d AND `uid` = %d",
 				intval(CONTACT_IS_FRIEND),
 				intval($contact['id']),
@@ -774,7 +774,7 @@ function diaspora_post_allow($importer,$contact, $is_comment = false) {
 	// perhaps we were already sharing with this person. Now they're sharing with us.
 	// That makes us friends.
 	// Normally this should have handled by getting a request - but this could get lost
-	if($contact['rel'] == CONTACT_IS_FOLLOWER && !in_array($importer['page-flags'], array(PAGE_COMMUNITY, PAGE_SOAPBOX))) {
+	if($contact['rel'] == CONTACT_IS_FOLLOWER && in_array($importer['page-flags'], array(PAGE_FREELOVE))) {
 		q("UPDATE `contact` SET `rel` = %d, `writable` = 1 WHERE `id` = %d AND `uid` = %d",
 			intval(CONTACT_IS_FRIEND),
 			intval($contact['id']),

--- a/include/follow.php
+++ b/include/follow.php
@@ -154,11 +154,7 @@ function new_contact($uid,$url,$interactive = false) {
 
 	$hidden = (($ret['network'] === NETWORK_MAIL) ? 1 : 0);
 
-	if($ret['network'] === NETWORK_MAIL) {
-		$writeable = 1;
-
-	}
-	if($ret['network'] === NETWORK_DIASPORA)
+	if(in_array($ret['network'], array(NETWORK_MAIL, NETWORK_DIASPORA)))
 		$writeable = 1;
 
 	// check if we already have a contact
@@ -215,9 +211,7 @@ function new_contact($uid,$url,$interactive = false) {
 			return $result;
 		}
 
-		$new_relation = (($ret['network'] === NETWORK_MAIL) ? CONTACT_IS_FRIEND : CONTACT_IS_SHARING);
-		if($ret['network'] === NETWORK_DIASPORA)
-			$new_relation = CONTACT_IS_FOLLOWER;
+		$new_relation = ((in_array($ret['network'], array(NETWORK_MAIL, NETWORK_DIASPORA))) ? CONTACT_IS_FRIEND : CONTACT_IS_SHARING);
 
 		// create contact record
 		$r = q("INSERT INTO `contact` ( `uid`, `created`, `url`, `nurl`, `addr`, `alias`, `batch`, `notify`, `poll`, `poco`, `name`, `nick`, `network`, `pubkey`, `rel`, `priority`,

--- a/mod/contacts.php
+++ b/mod/contacts.php
@@ -590,6 +590,10 @@ function contacts_content(&$a) {
 		if ($contact['network'] == NETWORK_DFRN)
 			$profile_select = contact_profile_assign($contact['profile-id'],(($contact['network'] !== NETWORK_DFRN) ? true : false));
 
+		if (in_array($contact['network'], array(NETWORK_DIASPORA, NETWORK_OSTATUS)) AND
+			($contact['rel'] == CONTACT_IS_FOLLOWER))
+			$follow = $a->get_baseurl(true)."/follow?url=".urlencode($contact["url"]);
+
 		$o .= replace_macros($tpl, array(
 			'$header' => t('Contact Editor'),
 			'$tab_str' => $tab_str,
@@ -617,6 +621,8 @@ function contacts_content(&$a) {
 			'$updpub' => t('Update public posts'),
 			'$last_update' => $last_update,
 			'$udnow' => t('Update now'),
+			'$follow' => $follow,
+			'$follow_text' => t("Connect/Follow"),
 			'$profile_select' => $profile_select,
 			'$contact_id' => $contact['id'],
 			'$block_text' => (($contact['blocked']) ? t('Unblock') : t('Block') ),

--- a/mod/dfrn_confirm.php
+++ b/mod/dfrn_confirm.php
@@ -382,7 +382,7 @@ function dfrn_confirm_post(&$a,$handsfree = null) {
 				if($duplex)
 					$new_relation = CONTACT_IS_FRIEND;
 				else
-					$new_relation = CONTACT_IS_SHARING;
+					$new_relation = CONTACT_IS_FOLLOWER;
 
 				if($new_relation != CONTACT_IS_FOLLOWER)
 					$writable = 1;

--- a/view/templates/contact_edit.tpl
+++ b/view/templates/contact_edit.tpl
@@ -51,6 +51,9 @@
 				{{if $lblsuggest}}
 					<li><a href="fsuggest/{{$contact_id}}" id="contact-edit-suggest">{{$lblsuggest}}</a></li>
 				{{/if}}
+				{{if $follow}}
+					<li><div id="contact-edit-follow"><a href="{{$follow}}">{{$follow_text}}</a></div></li>
+				{{/if}}
 
 			</ul>
 		</div>


### PR DESCRIPTION
Unidirectional contact relations between Diaspora and Friendica behaved unexpected:

* If you accepted someone only as a follower then this contact automatically upgraded as "friend" when this contact wrote an item
* Additionally the "accepting as follower" in fact didn't worked as expected: The contact was added as "sharer" (Means: The relation was in the wrong direction)

This is now changed: When someone is accepted as follower then the contact relation is in the correct state. Additionally it only changes to "Friend" if you actively follow this contact.

And to make the whole process clean, there is another change: If you adds a Diaspora contact then the relation is automatically set to "Friend". This is a correct value since it corresponds with the way Diaspora is working. In Diaspora you can share with a person that doesn't follow you. This person won't see your posts unless he searches for your contact - but then he would see all posts that you have written, including the non public posts.