### PR TITLE
Show the profile in the network view when viewing single contacts

### DIFF
--- a/mod/network.php
+++ b/mod/network.php
@@ -150,6 +150,14 @@ function network_init(&$a) {
 	$a->page['aside'] .= saved_searches($search);
 	$a->page['aside'] .= fileas_widget($a->get_baseurl(true) . '/network',(x($_GET, 'file') ? $_GET['file'] : ''));
 
+	if(x($_GET['cid']) && intval($_GET['cid']) != 0) {
+		$r = q("SELECT * FROM `contact` WHERE `id` = %d",
+			intval($_GET['cid']));
+		if ($r) {
+			$a->page['aside'] = "";
+			profile_load($a, "", 0, $r[0]);
+		}
+	}
 }
 
 function saved_searches($search) {


### PR DESCRIPTION
The network view now shows the profile on the left side when viewing posts from a single contact.