### PR TITLE
a credits page

### DIFF
--- a/doc/Home.md
+++ b/doc/Home.md
@@ -54,4 +54,5 @@ Friendica Documentation and Resources
 **About**
 
 * [Site/Version Info](friendica)
+* [Friendica Credits](credits)
 

--- a/doc/de/Home.md
+++ b/doc/de/Home.md
@@ -59,4 +59,5 @@ Friendica - Dokumentation und Ressourcen
 **Über diese Seite**
 
 * [Seite/Friendica-Version](friendica)
+* [Mitwirkenden bei Friendica](credits)
 

--- a/mod/credits.php
+++ b/mod/credits.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Show a credits page for all the developers who helped with the project
+ * (only contributors to the git repositories for friendica core and the
+ * addons repository will be listed though ATM)
+ */
+
+function credits_content (&$a) {
+    /* fill the page with credits */
+    $f = fopen('util/credits.txt','r');
+    $names = fread($f, filesize('util/credits.txt'));
+    $arr = explode("\n", htmlspecialchars($names));
+    fclose($f);
+    $tpl = get_markup_template('credits.tpl');
+    return replace_macros( $tpl, array(
+       '$pagetitle'		=> t('Credits'),
+       '$thanks'		=> t('Friendica is a community project, that would not be possible without the help of many people. Here is a list of those who have contributed to the code or the translation of Friendica. Thank you all!'),
+       '$names'         => $arr,
+    ));
+}

--- a/mod/credits.php
+++ b/mod/credits.php
@@ -13,7 +13,7 @@ function credits_content (&$a) {
     fclose($f);
     $tpl = get_markup_template('credits.tpl');
     return replace_macros( $tpl, array(
-       '$pagetitle'		=> t('Credits'),
+       '$title'		=> t('Credits'),
        '$thanks'		=> t('Friendica is a community project, that would not be possible without the help of many people. Here is a list of those who have contributed to the code or the translation of Friendica. Thank you all!'),
        '$names'         => $arr,
     ));

--- a/util/credits.txt
+++ b/util/credits.txt
@@ -1,0 +1,164 @@
+23n
+Abinoam P. Marques Jr.
+Abrax
+Adam Jurkiewicz
+Alex
+Alexander Kampmann
+AlfredSK
+André Lohan
+Anthronaut
+Arian - Cazare Muncitori
+aweiher
+axelt
+balderino
+Beanow
+bufalo1973
+Calango Jr
+Carlos Solís
+Carsten Pfeiffer
+Cat Gray
+Chris Case
+Christian M. Grube
+Christian Vogeley
+Cohan Robinson
+Cyboulette
+Cyryl Sochacki
+czarnystokrotek
+Damien Goutte-Gattat
+Daniel Dupriest
+Daria Początek
+David
+David Martín Miranda
+Devlon Duthie
+Diego Souza
+Domovoy
+Doru  DEACONU
+Dylan Thiedeke
+Développeur égaré
+eddy2508
+effex7
+Elena
+emilia.krawczyk
+Eric Côté
+erik
+Erkan Yilmaz
+Fabian Dost
+Fabio Comuni
+felixgilles
+Filip Bugaj
+FlxAlbroscheit
+foss
+Francesco Apruzzese
+Frank Dieckmann
+Frederico Gonçalves Guimarães
+gerhard6380
+Gert Cauwenberg
+greeneyedred
+Gregory Smith
+Haakon Meland Eriksen
+Hans Meine
+hauke
+Hauke Altmann
+Hauke Zühl
+Hubert Kościański
+Jak
+Jakob
+jensp
+jeroenpraat
+Johannes Schwab
+John Brazil
+Josef Moravek
+juanman
+julia.domagalska
+Karel Vandecandelaere
+Karolina
+Keith Fernie
+Klaus Weidenbach
+Lea1995polish
+Leberwurscht
+Leonard Lausen
+Lionel Triay
+Ludovic Grossard
+maase2
+Magdalena Gazda
+Mai Anh Nguyen
+Manuel Pérez Monís
+Marcin Klessa
+Mariusz Pisz
+marmor
+Marquis_de_Carabas
+Martin Schmitt
+Mateusz Mikos
+Mats Sjöberg
+Matthew Exon
+Matthias
+Matthias Moritz
+Max Weller
+mhnxo
+Michael Johnston
+Michael Vogel
+Michal Šupler
+Michalina
+Mike Macgirvin
+Nicola Spanti
+Olaf Conradi
+Oliver
+Olivier
+Olivier Migeot
+Pavel Morozov
+peturisfeld
+Piotr Blonkowski
+pokerazor
+Rabuzarus
+Radek
+Rafael
+Rainulf Pineda
+rcmaniac
+rebeka-catalina
+repat
+Ricardo Pereira
+Rui Andrada
+Sam
+Sandro Santilli
+Sebastian Egbers
+sella
+Sennewood
+Seth
+Silke Meyer
+Simon L'nu
+Simó Albert i Beltran
+Stanislav N.
+StefOfficiel
+Sveinn í Felli
+Sven Anders
+Sylvain Lagacé
+szymon.filip
+Sérgio Lima
+Taekus
+Tazman DeVille
+Thomas
+Thomas Willingham
+thorsten23
+Tino
+Tobias Diekershoff
+Tobias Hößl
+tomamplius
+tomtom84
+Tony Baldwin
+TORminator
+tschlotfeldt
+Tubuntu
+tupambae
+tuscanhobbit
+U-SOUND\mike
+ufic
+Vasudev Kamath
+Vasya Novikov
+vislav
+Yasen Pramatarov
+ylms
+Zach Prezkuta
+Zered
+zottel
+Zvi ben Yaakov (a.k.a rdc)
+Михаил

--- a/util/credits.txt
+++ b/util/credits.txt
@@ -5,6 +5,7 @@ Adam Jurkiewicz
 Alex
 Alexander Kampmann
 AlfredSK
+Andi Stadler
 André Lohan
 Anthronaut
 Arian - Cazare Muncitori

--- a/util/make_credits.py
+++ b/util/make_credits.py
@@ -25,13 +25,14 @@ dontinclude = ['root', 'friendica', 'bavatar', 'tony baldwin', 'Taek', 'silke m'
                'leberwurscht', 'abinoam', 'fabrixxm', 'FULL NAME', 'Hauke Zuehl',
                'Michal Supler', 'michal_s', 'Manuel Pérez']
 
+
 #  this script is in the /util sub-directory of the friendica installation
 #  so the friendica path is the 0th argument of calling this script but we
 #  need to remove the name of the file and the name of the directory
 path = os.path.abspath(argv[0].split('util/make_credits.py')[0])
 print('> base directory is assumed to be: '+path)
 #  a place to store contributors
-contributors = []
+contributors = ['Andi Stadler']
 #  get the contributors
 print('> getting contributors to the friendica core repository')
 p = subprocess.Popen(['git', 'shortlog', '--no-merges', '-s'],

--- a/util/make_credits.py
+++ b/util/make_credits.py
@@ -9,7 +9,7 @@ The collected names will be saved in /util/credits.txt which is also parsed from
 yourfriendica.tld/credits.
 
 The output is not perfect, so remember to open a fresh (re)created credits.txt file
-in your fav editor to check for obvious mistakes.
+in your fav editor to check for obvious mistakes and doubled entries.
 
 Initially written by Tobias Diekershoff for the Friendica Project. Released under
 the terms of the AGPL version 3 or later, same as Friendica.

--- a/util/make_credits.py
+++ b/util/make_credits.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+This script will collect the contributors to friendica and its translations from
+  * the git log of the friendica core and addons repositories
+  * the translated messages.po from core and the addons.
+The collected names will be saved in /util/credits.txt which is also parsed from
+yourfriendica.tld/credits.
+
+The output is not perfect, so remember to open a fresh (re)created credits.txt file
+in your fav editor to check for obvious mistakes.
+
+Initially written by Tobias Diekershoff for the Friendica Project. Released under
+the terms of the AGPL version 3 or later, same as Friendica.
+"""
+
+from sys import argv
+import os, glob, subprocess
+
+#  a list of names to not include, those people get into the list by other names
+#  but they use different names on different systems and automatical mapping does
+#  not work in some cases.
+dontinclude = ['root', 'friendica', 'bavatar', 'tony baldwin', 'Taek', 'silke m',
+               'leberwurscht', 'abinoam', 'fabrixxm', 'FULL NAME', 'Hauke Zuehl',
+               'Michal Supler', 'michal_s', 'Manuel Pérez']
+
+#  this script is in the /util sub-directory of the friendica installation
+#  so the friendica path is the 0th argument of calling this script but we
+#  need to remove the name of the file and the name of the directory
+path = os.path.abspath(argv[0].split('util/make_credits.py')[0])
+print('> base directory is assumed to be: '+path)
+#  a place to store contributors
+contributors = []
+#  get the contributors
+print('> getting contributors to the friendica core repository')
+p = subprocess.Popen(['git', 'shortlog', '--no-merges', '-s'],
+                         stdout=subprocess.PIPE,
+                         stderr=subprocess.STDOUT)
+c = iter(p.stdout.readline, b'')
+for i in c:
+    name = i.decode().split('\t')[1].split('\n')[0]
+    if not name in contributors and name not in dontinclude:
+        contributors.append(name)
+n1 = len(contributors)
+print('  > found %d contributors' % n1)
+#  get the contributors to the addons
+os.chdir(path+'/addon')
+#  get the contributors
+print('> getting contributors to the addons')
+p = subprocess.Popen(['git', 'shortlog', '--no-merges', '-s'],
+                         stdout=subprocess.PIPE,
+                         stderr=subprocess.STDOUT)
+c = iter(p.stdout.readline, b'')
+for i in c:
+    name = i.decode().split('\t')[1].split('\n')[0]
+    if not name in contributors and name not in dontinclude:
+        contributors.append(name)
+n2 = len(contributors)
+print('  > found %d new contributors' % (n2-n1))
+print('> total of %d contributors to the repositories of friendica' % n2)
+os.chdir(path)
+#  get the translators
+print('> getting translators')
+intrans = False
+for f in glob.glob(path+'/view/*/messages.po'):
+    i = open(f, 'r')
+    l = i.readlines()
+    i.close()
+    for ll in l:
+        if intrans and ll.strip()=='':
+            intrans = False;
+        if intrans and ll[0]=='#':
+            name = ll.split('# ')[1].split(',')[0].split(' <')[0]
+            if not name in contributors and name not in dontinclude:
+                contributors.append(name)
+        if "# Translators:" in ll:
+            intrans = True
+#  get the translators from the addons
+for f in glob.glob(path+'/addon/*/lang/*/messages.po'):
+    i = open(f, 'r')
+    l = i.readlines()
+    i.close()
+    for ll in l:
+        if intrans and ll.strip()=='':
+            intrans = False;
+        if intrans and ll[0]=='#':
+            name = ll.split('# ')[1].split(',')[0].split(' <')[0]
+            if not name in contributors and name not in dontinclude:
+                contributors.append(name)
+        if "# Translators:" in ll:
+            intrans = True
+#  done with the translators
+
+n3 = len(contributors)
+print('  > found %d translators' % (n3-n2))
+print('> found a total of %d contributors and translators' % n3)
+contributors.sort(key=str.lower)
+
+f = open(path+'/util/credits.txt', 'w')
+f.write("\n".join(contributors))
+f.close()
+print('> list saved to util/credits.txt')

--- a/view/global.css
+++ b/view/global.css
@@ -260,19 +260,26 @@ a {
 }
 /* poke */
 #poke-desc {
-	margin: 5px 0 10px;
+    margin: 5px 0 10px;
 }
 
 #poke-wrapper  {
-	padding: 10px 0 0px;
+    padding: 10px 0 0px;
 }
 
 #poke-recipient, #poke-action, #poke-privacy-settings {
-	margin: 10px 0 30px;
+    margin: 10px 0 30px;
 }
 
 #poke-recip-label, #poke-action-label, #prvmail-message-label {
-	margin: 10px 0 10px;
+    margin: 10px 0 10px;
+}
+ul.credits {
+    list-style: none;
+}
+ul.credits li {
+    float: left;
+    width: 240px;
 }
 
 .contact-entry-photo img {

--- a/view/templates/credits.tpl
+++ b/view/templates/credits.tpl
@@ -1,4 +1,4 @@
-<h1>{{$pagetitle}}</h1>
+{{include file="section_title.tpl"}}
 <p>{{$thanks}}</p>
 
 <ul class="credits">

--- a/view/templates/credits.tpl
+++ b/view/templates/credits.tpl
@@ -1,0 +1,8 @@
+<h1>{{$pagetitle}}</h1>
+<p>{{$thanks}}</p>
+
+<ul class="credits">
+{{foreach $names as $name}}
+ <li>{{$name}}</li>
+{{/foreach}}
+</ul>


### PR DESCRIPTION
This PR adds a small script to the util collection to create a credits.txt file which is then displayed at /credits on friendica. The credits list is linked from the /help overview page. Once regenerated, the credits file needs some manual care to remove duplicates from inconsistent configurations on differend contributor systems.