### PR TITLE
Check if Diaspora and OStatus can be enabled at all

### DIFF
--- a/mod/admin.php
+++ b/mod/admin.php
@@ -416,6 +416,11 @@ function admin_page_site_post(&$a){
 	$rino			=	((x($_POST,'rino'))				? intval($_POST['rino'])				: 0);
 	$embedly		=	((x($_POST,'embedly'))			? notags(trim($_POST['embedly']))		: '');
 
+	if ($a->get_path() != "")
+		$diaspora_enabled = false;
+
+	if (!$thread_allow)
+		$ostatus_disabled = true;
 
 	if($ssl_policy != intval(get_config('system','ssl_policy'))) {
 		if($ssl_policy == SSL_POLICY_FULL) {
@@ -535,6 +540,7 @@ function admin_page_site_post(&$a){
 	set_config('system','ostatus_disabled', $ostatus_disabled);
 	set_config('system','ostatus_poll_interval', $ostatus_poll_interval);
 	set_config('system','diaspora_enabled', $diaspora_enabled);
+
 	set_config('config','private_addons', $private_addons);
 
 	set_config('system','force_ssl', $force_ssl);
@@ -681,6 +687,8 @@ function admin_page_site(&$a) {
 	if ($a->config['hostname'] == "")
 		$a->config['hostname'] = $a->get_hostname();
 
+	$diaspora_able = ($a->get_path() == "");
+
 	$t = get_markup_template("admin_site.tpl");
 	return replace_macros($t, array(
 		'$title' => t('Administration'),
@@ -737,6 +745,9 @@ function admin_page_site(&$a) {
 		'$max_author_posts_community_page' => array('max_author_posts_community_page', t("Posts per user on community page"), get_config('system','max_author_posts_community_page'), t("The maximum number of posts per user on the community page. (Not valid for 'Global Community')")),
 		'$ostatus_disabled' 	=> array('ostatus_disabled', t("Enable OStatus support"), !get_config('system','ostatus_disabled'), t("Provide built-in OStatus \x28StatusNet, GNU Social etc.\x29 compatibility. All communications in OStatus are public, so privacy warnings will be occasionally displayed.")),
 		'$ostatus_poll_interval'	=> array('ostatus_poll_interval', t("OStatus conversation completion interval"), (string) intval(get_config('system','ostatus_poll_interval')), t("How often shall the poller check for new entries in OStatus conversations? This can be a very ressource task."), $ostatus_poll_choices),
+		'$ostatus_not_able'	=> t("OStatus support can only be enabled if threading is enabled."),
+		'$diaspora_able'	=> $diaspora_able,
+		'$diaspora_not_able'	=> t("Diaspora support can't be enabled because Friendica was installed into a sub directory."),
 		'$diaspora_enabled' 	=> array('diaspora_enabled', t("Enable Diaspora support"), get_config('system','diaspora_enabled'), t("Provide built-in Diaspora network compatibility.")),
 		'$dfrn_only'        	=> array('dfrn_only', t('Only allow Friendica contacts'), get_config('system','dfrn_only'), t("All contacts must use Friendica protocols. All other built-in communication protocols disabled.")),
 		'$verifyssl' 		=> array('verifyssl', t("Verify SSL"), get_config('system','verifyssl'), t("If you wish, you can turn on strict certificate checking. This will mean you cannot connect (at all) to self-signed SSL sites.")),

--- a/mod/dirfind.php
+++ b/mod/dirfind.php
@@ -52,10 +52,20 @@ function dirfind_content(&$a, $prefix = "") {
 			$perpage = 80;
 			$startrec = (($a->pager['page']) * $perpage) - $perpage;
 
+			if (get_config('system','diaspora_enabled'))
+				$diaspora = NETWORK_DIASPORA;
+			else
+				$diaspora = NETWORK_DFRN;
+
+			if (!get_config('system','ostatus_disabled'))
+				$ostatus = NETWORK_OSTATUS;
+			else
+				$ostatus = NETWORK_DFRN;
+
 			$count = q("SELECT count(*) AS `total` FROM `gcontact` WHERE `network` IN ('%s', '%s', '%s') AND
 					(`url` REGEXP '%s' OR `name` REGEXP '%s' OR `location` REGEXP '%s' OR
 						`about` REGEXP '%s' OR `keywords` REGEXP '%s')".$extra_sql,
-					dbesc(NETWORK_DFRN), dbesc(NETWORK_OSTATUS), dbesc(NETWORK_DIASPORA),
+					dbesc(NETWORK_DFRN), dbesc($ostatus), dbesc($diaspora),
 					dbesc(escape_tags($search)), dbesc(escape_tags($search)), dbesc(escape_tags($search)),
 					dbesc(escape_tags($search)), dbesc(escape_tags($search)));
 
@@ -71,7 +81,7 @@ function dirfind_content(&$a, $prefix = "") {
 						GROUP BY `gcontact`.`nurl`
 						ORDER BY `gcontact`.`updated` DESC LIMIT %d, %d",
 					intval(local_user()), dbesc(CONTACT_IS_SHARING), dbesc(CONTACT_IS_FRIEND),
-					dbesc(NETWORK_DFRN), dbesc(NETWORK_OSTATUS), dbesc(NETWORK_DIASPORA),
+					dbesc(NETWORK_DFRN), dbesc($ostatus), dbesc($diaspora),
 					dbesc(escape_tags($search)), dbesc(escape_tags($search)), dbesc(escape_tags($search)),
 					dbesc(escape_tags($search)), dbesc(escape_tags($search)),
 					intval($startrec), intval($perpage));

--- a/mod/follow.php
+++ b/mod/follow.php
@@ -15,6 +15,8 @@ function follow_content(&$a) {
 	$uid = local_user();
 	$url = notags(trim($_REQUEST['url']));
 
+	$submit = t('Submit Request');
+
 	// There is a current issue. It seems as if you can't start following a Friendica that is following you
 	// With Diaspora this works - but Friendica is special, it seems ...
 	$r = q("SELECT `url` FROM `contact` WHERE `uid` = %d AND ((`rel` != %d) OR (`network` = '%s')) AND
@@ -25,15 +27,31 @@ function follow_content(&$a) {
 
 	if ($r) {
 		notice(t('You already added this contact.').EOL);
-		goaway($_SESSION['return_url']);
+		$submit = "";
+		//goaway($_SESSION['return_url']);
 		// NOTREACHED
 	}
 
 	$ret = probe_url($url);
 
+	if (($ret["network"] == NETWORK_DIASPORA) AND !get_config('system','diaspora_enabled')) {
+		notice( t("Diaspora support isn't enabled. Contact can't be added.") . EOL);
+		$submit = "";
+		//goaway($_SESSION['return_url']);
+		// NOTREACHED
+	}
+
+	if (($ret["network"] == NETWORK_OSTATUS) AND get_config('system','ostatus_disabled')) {
+		notice( t("OStatus support is disabled. Contact can't be added.") . EOL);
+		$submit = "";
+		//goaway($_SESSION['return_url']);
+		// NOTREACHED
+	}
+
 	if ($ret["network"] == NETWORK_PHANTOM) {
 		notice( t("The network type couldn't be detected. Contact can't be added.") . EOL);
-		goaway($_SESSION['return_url']);
+		$submit = "";
+		//goaway($_SESSION['return_url']);
 		// NOTREACHED
 	}
 
@@ -94,7 +112,7 @@ function follow_content(&$a) {
 			'$your_address' => t('Your Identity Address:'),
 			'$invite_desc' => "",
 			'$emailnet' => "",
-			'$submit' => t('Submit Request'),
+			'$submit' => $submit,
 			'$cancel' => t('Cancel'),
 			'$nickname' => "",
 			'$name' => $ret["name"],

--- a/view/templates/admin_site.tpl
+++ b/view/templates/admin_site.tpl
@@ -83,9 +83,25 @@
 	{{include file="field_checkbox.tpl" field=$force_publish}}
 	{{include file="field_select.tpl" field=$community_page_style}}
 	{{include file="field_input.tpl" field=$max_author_posts_community_page}}
-	{{include file="field_checkbox.tpl" field=$ostatus_disabled}}
-	{{include file="field_select.tpl" field=$ostatus_poll_interval}}
-	{{include file="field_checkbox.tpl" field=$diaspora_enabled}}
+
+	{{if $thread_allow.2}}
+		{{include file="field_checkbox.tpl" field=$ostatus_disabled}}
+		{{include file="field_select.tpl" field=$ostatus_poll_interval}}
+	{{else}}
+		<div class='field checkbox' id='div_id_{{$ostatus_disabled.0}}'>
+			<label for='id_{{$ostatus_disabled.0}}'>{{$ostatus_disabled.1}}</label>
+			<span id='id_{{$ostatus_disabled.0}}'>{{$ostatus_not_able}}</span>
+		</div>
+	{{/if}}
+
+	{{if $diaspora_able}}
+		{{include file="field_checkbox.tpl" field=$diaspora_enabled}}
+	{{else}}
+		<div class='field checkbox' id='div_id_{{$diaspora_enabled.0}}'>
+			<label for='id_{{$diaspora_enabled.0}}'>{{$diaspora_enabled.1}}</label>
+			<span id='id_{{$diaspora_enabled.0}}'>{{$diaspora_not_able}}</span>
+		</div>
+	{{/if}}
 	{{include file="field_checkbox.tpl" field=$dfrn_only}}
 	{{include file="field_input.tpl" field=$global_directory}}
 	{{include file="field_checkbox.tpl" field=$thread_allow}}

--- a/view/templates/auto_request.tpl
+++ b/view/templates/auto_request.tpl
@@ -53,7 +53,9 @@
 </div>
 
 	<div id="dfrn-request-submit-wrapper">
-		<input type="submit" name="submit" id="dfrn-request-submit-button" value="{{$submit|escape:'html'}}" />
+		{{if $submit}}
+			<input type="submit" name="submit" id="dfrn-request-submit-button" value="{{$submit|escape:'html'}}" />
+		{{/if}}
 		<input type="submit" name="cancel" id="dfrn-request-cancel-button" value="{{$cancel|escape:'html'}}" />
 	</div>
 </form>

--- a/view/templates/dfrn_request.tpl
+++ b/view/templates/dfrn_request.tpl
@@ -83,7 +83,9 @@
 </div>
 
 	<div id="dfrn-request-submit-wrapper">
-		<input type="submit" name="submit" id="dfrn-request-submit-button" value="{{$submit|escape:'html'}}" />
+		{{if $submit}}
+			<input type="submit" name="submit" id="dfrn-request-submit-button" value="{{$submit|escape:'html'}}" />
+		{{/if}}
 		<input type="submit" name="cancel" id="dfrn-request-cancel-button" value="{{$cancel|escape:'html'}}" />
 	</div>
 </form>

--- a/view/templates/field_checkbox.tpl
+++ b/view/templates/field_checkbox.tpl
@@ -1,5 +1,3 @@
-
-	
 	<div class='field checkbox' id='div_id_{{$field.0}}'>
 		<label for='id_{{$field.0}}'>{{$field.1}}</label>
 		<input type="checkbox" name='{{$field.0}}' id='id_{{$field.0}}' value="1" {{if $field.2}}checked="checked"{{/if}}>


### PR DESCRIPTION
Diaspora support does only work when Friendica is installed in the main directory. OStatus support makes only sense when threading is enabled (otherwise you can't comment correctly)

The system now checks these parameters and will disable the possibility to activate support for these networks if the system isn't capable for it.

Additionally there are now some checks so that you cannot add Diaspora- and OStatus contacts if the system isn't enabled for it. The local search is showing only contacts from supported networks as well.