### PR TITLE
simple photo_menu for directory

### DIFF
--- a/mod/directory.php
+++ b/mod/directory.php
@@ -152,6 +152,8 @@ function directory_content(&$a) {
 			else {
 				$location_e = $location;
 			}
+			
+			$photo_menu = array(array(t("View Profile"), zrl($profile_link)));
 
 			$entry = array(
 				'id' => $rr['id'],
@@ -168,6 +170,7 @@ function directory_content(&$a) {
 				'marital'  => $marital,
 				'homepage' => $homepage,
 				'about' => $about,
+				'photo_menu' => $photo_menu,
 
 			);
 


### PR DESCRIPTION
Now the directory page has a simple photo_menu. This is needed for vier theme.
At the moment the photo_menu only includes 'Show Profile'.

Maybe it's possible to find a way to distinguish between already connected contacts and non-connected contacts. This would make it possible to have to sorts of menus. One full featured and on with Show Profile and Connect. 