### PR TITLE
Use old style array declaration

### DIFF
--- a/include/friendica_smarty.php
+++ b/include/friendica_smarty.php
@@ -62,10 +62,10 @@ class FriendicaSmartyEngine implements ITemplateEngine {
 		}
 
 		// "middleware": inject variables into templates
-		$arr = [
+		$arr = array(
 			"template"=> basename($s->filename),
 			"vars" => $r
-		];
+		);
 		call_hooks("template_vars", $arr);
 		$r = $arr['vars'];
 


### PR DESCRIPTION
We supports php from 5.2, 5.3 for Diaspora connections.
Vagrant machine is using old LTS ubuntu server with php 5.3
