### PR TITLE
Vier mobile

### DIFF
--- a/view/theme/vier/mobile.css
+++ b/view/theme/vier/mobile.css
@@ -115,3 +115,28 @@ aside {
 aside.show {
 	left: 0;
 }
+
+/* tabs */
+.tabs { position: relative; height: 25px!important; }
+.tabs li { width: 100%; }
+.tabs .tab { display: none;}
+.tabs .tab.active { display: block; }
+.tabs::after {
+	content: " ";
+	display: block;
+	position: absolute;
+	left: 0; right:0; top: 0; bottom: 0;
+}
+
+.tabs.show {
+	position: fixed;
+	z-index: 1000;
+	left: 10px;
+	right: 10px;
+	top: 0px;
+	bottom: 10px;
+	height: auto !important;
+	border: 1px solid #ccc;
+}
+.tabs.show::after { display: none; }
+.tabs.show .tab { display: block; }

--- a/view/theme/vier/mobile.css
+++ b/view/theme/vier/mobile.css
@@ -122,10 +122,13 @@ aside.show {
 .tabs .tab { display: none;}
 .tabs .tab.active { display: block; }
 .tabs::after {
-	content: " ";
+	font-family: FontAwesome;
+	text-align: right;
+	content: "\f13a";
 	display: block;
 	position: absolute;
 	left: 0; right:0; top: 0; bottom: 0;
+	padding: 8px 2px 0 0;
 }
 
 .tabs.show {

--- a/view/theme/vier/mobile.css
+++ b/view/theme/vier/mobile.css
@@ -108,6 +108,9 @@ aside {
 	max-width: 400px;
 	width: 80%;
 	left: -100%;
+	-webkit-transition: left 0.5s;
+	-moz-transition: left 0.5s;
+	-o-transition: left 0.5s;
 	transition: left 0.5s;
 }
 

--- a/view/theme/vier/mobile.css
+++ b/view/theme/vier/mobile.css
@@ -104,7 +104,6 @@ nav ul {
 
 aside {
 	display: block;
-	/* position: absolute; */
 	position: fixed;
 	max-width: 400px;
 	width: 80%;

--- a/view/theme/vier/templates/nav.tpl
+++ b/view/theme/vier/templates/nav.tpl
@@ -9,7 +9,7 @@
 	<ul>
 		<li class="mobile-aside-toggle" style="display:none;">
 			<a href="#">
-				<i class="icons icon-list"></i>
+				<i class="icons icon-reorder"></i>
 			</a>
 		</li>
 		{{if $nav.home}}

--- a/view/theme/vier/theme.php
+++ b/view/theme/vier/theme.php
@@ -87,18 +87,28 @@ function cmtBbClose(id) {
 	$("#comment-edit-bb-" + id).hide();
 }
 
-$(document).ready(function() {
-	$(".mobile-aside-toggle a").click(function(e){
-		e.preventDefault();
-		$("aside").toggleClass("show");
-	});
-	$(".tabs").click(function(e){
-		$(this).toggleClass("show");
-	});
-});
+
 
 </script>
 EOT;
+
+
+if ($a->is_mobile || $a->is_tablet){
+	$a->page['htmlhead'] .= <<< EOT
+<script>
+	$(document).ready(function() {
+		$(".mobile-aside-toggle a").click(function(e){
+			e.preventDefault();
+			$("aside").toggleClass("show");
+		});
+		$(".tabs").click(function(e){
+			$(this).toggleClass("show");
+		});
+	});
+</script>
+EOT;
+}
+
 
 	// Hide the left menu bar
 	if (($a->page['aside'] == "") AND in_array($a->argv[0], array("community", "events", "help", "manage", "notifications",

--- a/view/theme/vier/theme.php
+++ b/view/theme/vier/theme.php
@@ -33,7 +33,7 @@ function vier_init(&$a) {
 		$a->page['htmlhead'] .= '<meta name=viewport content="width=device-width, initial-scale=1">'."\n";
 		$a->page['htmlhead'] .= '<link rel="stylesheet" type="text/css" href="view/theme/vier/mobile.css" media="screen"/>'."\n";
 	}
-		$a->page['htmlhead'] .= '<link rel="stylesheet" type="text/css" href="view/theme/vier/mobile.css" media="screen and (max-width: 1000px)"/>'."\n";
+		#$a->page['htmlhead'] .= '<link rel="stylesheet" type="text/css" href="view/theme/vier/mobile.css" media="screen and (max-width: 1000px)"/>'."\n";
 
 $a->page['htmlhead'] .= <<< EOT
 <link rel='stylesheet' type='text/css' href='view/theme/vier/narrow.css' media='screen and (max-width: 1100px)' />
@@ -91,6 +91,9 @@ $(document).ready(function() {
 	$(".mobile-aside-toggle a").click(function(e){
 		e.preventDefault();
 		$("aside").toggleClass("show");
+	});
+	$(".tabs").click(function(e){
+		$(this).toggleClass("show");
 	});
 });
 


### PR DESCRIPTION
- prefixed aside transition (to make it work on more browsers)
- include mobile.css only if we think we are on mobile or tablet (this could replaced with a media query in css...)
- add mobile-related javascript only if we think we are on mobile or tablet 
- mobile friendly css/js for standard tabs
- change "menu" icon in navbar with a more 'standard' one
