### PR TITLE
Fix for issue 2060: Redirection after registration

### DIFF
--- a/mod/register.php
+++ b/mod/register.php
@@ -100,6 +100,9 @@ function register_post(&$a) {
 						 ). EOL
 				);
 			}
+		} else {
+			info( t('Registration successful.') . EOL ) ;
+			goaway(z_root());
 		}
 	}
 	elseif($a->config['register_policy'] == REGISTER_APPROVE) {


### PR DESCRIPTION
This is a fix for issue https://github.com/friendica/friendica/issues/2060

The first user of a fresh Friendica installation can register an account with a self defined password (without an auto generated mail that normally would be send via mail). This is a special treatment for small installations without a mail server.

In that case the register process hadn't done a redirection to the front page after a successful redirection.