### PR TITLE
add missing info about if contact is forum to contact related pages

### DIFF
--- a/mod/dirfind.php
+++ b/mod/dirfind.php
@@ -205,6 +205,7 @@ function dirfind_content(&$a, $prefix = "") {
 					'details'       => $contact_details['location'],
 					'tags'          => $contact_details['keywords'],
 					'about'         => $contact_details['about'],
+					'account_type'  => (($contact_details['community']) ? t('Forum') : ''),
 					'network' => network_to_name($jj->network, $jj->url),
 					'id' => ++$id,
 				);

--- a/mod/match.php
+++ b/mod/match.php
@@ -79,6 +79,7 @@ function match_content(&$a) {
 						'details'       => $contact_details['location'],
 						'tags'          => $contact_details['keywords'],
 						'about'         => $contact_details['about'],
+						'account_type'  => (($contact_details['community']) ? t('Forum') : ''),
 						'thumb' => proxy_url($jj->photo, false, PROXY_SIZE_THUMB),
 						'inttxt' => ' ' . t('is interested in:'),
 						'conntxt' => t('Connect'),

--- a/mod/suggest.php
+++ b/mod/suggest.php
@@ -36,7 +36,7 @@ function suggest_init(&$a) {
 		}
 		// Now check how the user responded to the confirmation query
 		if(!$_REQUEST['canceled']) {
-			q("insert into gcign ( uid, gcid ) values ( %d, %d ) ",
+			q("INSERT INTO `gcign` ( `uid`, `gcid` ) VALUES ( %d, %d ) ",
 				intval(local_user()),
 				intval($_GET['ignore'])
 			);
@@ -90,8 +90,9 @@ function suggest_content(&$a) {
 			'name' => $rr['name'],
 			'thumb' => proxy_url($rr['photo'], false, PROXY_SIZE_THUMB),
 			'details'       => $contact_details['location'],
-                        'tags'          => $contact_details['keywords'],
-                        'about'         => $contact_details['about'],
+			'tags'          => $contact_details['keywords'],
+			'about'         => $contact_details['about'],
+			'account_type'  => (($contact_details['community']) ? t('Forum') : ''),
 			'ignlnk' => $ignlnk,
 			'ignid' => $rr['id'],
 			'conntxt' => t('Connect'),

--- a/mod/viewcontacts.php
+++ b/mod/viewcontacts.php
@@ -26,7 +26,7 @@ function viewcontacts_content(&$a) {
 	}
 
 
-	$r = q("SELECT COUNT(*) as `total` FROM `contact` WHERE `uid` = %d AND `blocked` = 0 AND `pending` = 0 AND `hidden` = 0 AND `archive` = 0 ",
+	$r = q("SELECT COUNT(*) AS `total` FROM `contact` WHERE `uid` = %d AND `blocked` = 0 AND `pending` = 0 AND `hidden` = 0 AND `archive` = 0 ",
 		intval($a->profile['uid'])
 	);
 	if(count($r))
@@ -68,8 +68,9 @@ function viewcontacts_content(&$a) {
 			'name' => htmlentities(substr($rr['name'],0,20)),
 			'username' => htmlentities($rr['name']),
 			'details'       => $contact_details['location'],
-                        'tags'          => $contact_details['keywords'],
-                        'about'         => $contact_details['about'],
+			'tags'          => $contact_details['keywords'],
+			'about'         => $contact_details['about'],
+			'account_type'  => (($contact_details['community']) ? t('Forum') : ''),
 			'url' => $url,
 			'sparkle' => '',
 			'itemurl' => (($contact_details['addr'] != "") ? $contact_details['addr'] : $rr['url']),


### PR DESCRIPTION
dirfind, match, suggest, viewcontacts didn't display the info if contact is forum. I added this.

I stopped converting `$a->get_baseurl()` into `z_root()` as long as https://github.com/friendica/friendica/pull/2099#issuecomment-160232770 is unclear