### PR TITLE
group_side - unify look with forumlist

### DIFF
--- a/include/group.php
+++ b/include/group.php
@@ -213,9 +213,20 @@ function mini_group_select($uid,$gid = 0) {
 }
 
 
-
-
-function group_side($every="contacts",$each="group",$edit = false, $group_id = 0, $cid = 0) {
+/**
+ * @brief Create group sidebar widget
+ * 
+ * @param string $every
+ * @param string $each
+ * @param string $editmode
+ *	'standard' => include link 'Edit groups'
+ *	'extended' => include link 'Create new group'
+ *	'full' => include link 'Create new group' and provide for each group a link to edit this group
+ * @param int $group_id
+ * @param int $cid
+ * @return string
+ */
+function group_side($every="contacts",$each="group",$editmode = "standard", $group_id = 0, $cid = 0) {
 
 	$o = '';
 
@@ -239,13 +250,13 @@ function group_side($every="contacts",$each="group",$edit = false, $group_id = 0
 	$member_of = array();
 	if($cid) {
 		$member_of = groups_containing(local_user(),$cid);
-	} 
+	}
 
 	if(count($r)) {
 		foreach($r as $rr) {
 			$selected = (($group_id == $rr['id']) ? ' group-selected' : '');
 			
-			if ($edit) {
+			if ($editmode == "full") {
 				$groupedit = array(
 					'href' => "group/".$rr['id'],
 					'title' => t('edit'),
@@ -269,14 +280,17 @@ function group_side($every="contacts",$each="group",$edit = false, $group_id = 0
 
 	$tpl = get_markup_template("group_side.tpl");
 	$o = replace_macros($tpl, array(
-		'$title'		=> t('Groups'),
+		'$title'	=> t('Groups'),
+		'newgroup'	=> (($editmode == "extended") || ($editmode == "full") ? 1 : ''),
+		'$editgroupstext' => t('Edit groups'),
+		'grouppage'	=> "group/",
 		'$edittext'     => t('Edit group'),
 		'$createtext' 	=> t('Create a new group'),
-    '$creategroup' => t('Group Name: '),
-    '$form_security_token' => get_form_security_token("group_edit"),
+		'$creategroup'  => t('Group Name: '),
+		'$form_security_token' => get_form_security_token("group_edit"),
 		'$ungrouped'    => (($every === 'contacts') ? t('Contacts not in any group') : ''),
-		'$groups'		=> $groups,
-		'$add'			=> t('add'),
+		'$groups'	=> $groups,
+		'$add'		=> t('add'),
 	));
 
 

--- a/mod/contacts.php
+++ b/mod/contacts.php
@@ -55,7 +55,7 @@ function contacts_init(&$a) {
 		$findpeople_widget .= findpeople_widget();
 	}
 
-	$groups_widget .= group_side('contacts','group',false,0,$contact_id);
+	$groups_widget .= group_side('contacts','group','full',0,$contact_id);
 	
 	$a->page['aside'] .= replace_macros(get_markup_template("contacts-widget-sidebar.tpl"),array(
 		'$vcard_widget' => $vcard_widget,

--- a/mod/group.php
+++ b/mod/group.php
@@ -7,7 +7,7 @@ function validate_members(&$item) {
 function group_init(&$a) {
 	if(local_user()) {
 		require_once('include/group.php');
-		$a->page['aside'] = group_side('contacts','group',false,(($a->argc > 1) ? intval($a->argv[1]) : 0));
+		$a->page['aside'] = group_side('contacts','group','extended',(($a->argc > 1) ? intval($a->argv[1]) : 0));
 	}
 }
 

--- a/mod/network.php
+++ b/mod/network.php
@@ -145,7 +145,7 @@ function network_init(&$a) {
 		));
 	}
 
-	$a->page['aside'] .= (feature_enabled(local_user(),'groups') ? group_side('network/0','network',true,$group_id) : '');
+	$a->page['aside'] .= (feature_enabled(local_user(),'groups') ? group_side('network/0','network','standard',$group_id) : '');
 	$a->page['aside'] .= (feature_enabled(local_user(),'forumlist_widget') ? widget_forumlist($a) : '');
 	$a->page['aside'] .= posted_date_widget($a->get_baseurl() . '/network',local_user(),false);
 	$a->page['aside'] .= networks_widget($a->get_baseurl(true) . '/network',(x($_GET, 'nets') ? $_GET['nets'] : ''));

--- a/mod/nogroup.php
+++ b/mod/nogroup.php
@@ -15,7 +15,7 @@ function nogroup_init(&$a) {
 	if(! x($a->page,'aside'))
 		$a->page['aside'] = '';
 
-	$a->page['aside'] .= group_side('contacts','group',false,0,$contact_id);
+	$a->page['aside'] .= group_side('contacts','group','extended',0,$contact_id);
 }
 
 

--- a/view/templates/group_side.tpl
+++ b/view/templates/group_side.tpl
@@ -1,38 +1,42 @@
 <div class="widget" id="group-sidebar">
-<h3>{{$title}}</h3>
+	<h3>{{$title}}</h3>
 
-<div id="sidebar-group-list">
-	<ul role="menu" id="sidebar-group-ul">
-		{{foreach $groups as $group}}
-			<li role="menuitem" class="sidebar-group-li group-{{$group.id}}">
-				{{if $group.cid}}
-					<input type="checkbox"
-						class="{{if $group.selected}}ticked{{else}}unticked {{/if}} action"
-						onclick="contactgroupChangeMember('{{$group.id}}','{{$group.cid}}');return true;"
-						{{if $group.ismember}}checked="checked"{{/if}}
-					/>
-				{{/if}}
-				{{if $group.edit}}
-					<a class="groupsideedit" href="{{$group.edit.href}}" title="{{$edittext}}"><span id="edit-sidebar-group-element-{{$group.id}}" class="group-edit-icon iconspacer small-pencil"><span class="sr-only">{{$edittext}}</span></span></a>
-				{{/if}}
-				<a id="sidebar-group-element-{{$group.id}}" class="sidebar-group-element {{if $group.selected}}group-selected{{/if}}" href="{{$group.href}}">{{$group.text}}</a>
-				<span class="notify"></span>
-			</li>
-		{{/foreach}}
-	</ul>
+	<div id="sidebar-group-list">
+		<ul role="menu" id="sidebar-group-ul">
+			{{foreach $groups as $group}}
+				<li role="menuitem" class="sidebar-group-li group-{{$group.id}}">
+					{{if ! $newgroup}}<span class="notify badge pull-right"></span>{{/if}}
+					{{if $group.cid}}
+						<input type="checkbox"
+							class="{{if $group.selected}}ticked{{else}}unticked {{/if}} action"
+							onclick="contactgroupChangeMember('{{$group.id}}','{{$group.cid}}');return true;"
+							{{if $group.ismember}}checked="checked"{{/if}}
+						/>
+					{{/if}}
+					{{if $group.edit}}
+						<a class="groupsideedit" href="{{$group.edit.href}}" title="{{$edittext}}">
+							<span id="edit-sidebar-group-element-{{$group.id}}" class="group-edit-icon iconspacer small-pencil"><span class="sr-only">{{$edittext}}</span></span>
+						</a>
+					{{/if}}
+					<a id="sidebar-group-element-{{$group.id}}" class="sidebar-group-element {{if $group.selected}}group-selected{{/if}}" href="{{$group.href}}">{{$group.text}}</a>
+				</li>
+			{{/foreach}}
+		</ul>
 	</div>
-  <div id="sidebar-new-group">
-  <a onclick="javascript:$('#group-new-form').fadeIn('fast');return false;">{{$createtext}}</a>
-  <form id="group-new-form" action="group/new" method="post" style="display:none;">
-   <input type="hidden" name="form_security_token" value="{{$form_security_token}}">
-   <input name="groupname" id="id_groupname" placeholder="{{$creategroup}}">
-  </form>
-  </div>
-  {{if $ungrouped}}
-  <div id="sidebar-ungrouped">
-  <a href="nogroup">{{$ungrouped}}</a>
-  </div>
-  {{/if}}
+
+	{{if $newgroup}}
+	<div id="sidebar-new-group">
+		<a onclick="javascript:$('#group-new-form').fadeIn('fast');return false;">{{$createtext}}</a>
+		<form id="group-new-form" action="group/new" method="post" style="display:none;">
+			<input type="hidden" name="form_security_token" value="{{$form_security_token}}">
+			<input name="groupname" id="id_groupname" placeholder="{{$creategroup}}">
+		</form>
+	</div>
+	{{else}}
+	<div id="sidebar-edit-groups"><a href="{{$grouppage}}">{{$editgroupstext}}</a></div>
+	{{/if}}
+
+	{{if $ungrouped}}<div id="sidebar-ungrouped"><a href="nogroup">{{$ungrouped}}</a></div>{{/if}}
 </div>
 
 

--- a/view/theme/smoothly/style.css
+++ b/view/theme/smoothly/style.css
@@ -854,7 +854,8 @@ li.widget-list {
    	padding: 3px 24px;
 }
 
-#sidebar-new-group {
+#sidebar-new-group,
+#sidebar-edit-groups {
 	padding: 7px;
 	width: 165px;
 	margin: auto;

--- a/view/theme/vier/style.css
+++ b/view/theme/vier/style.css
@@ -347,7 +347,7 @@ code {
   display: inline-block;
   min-width: 10px;
   padding: 3px 7px;
-  font-size: 12px;
+  font-size: 10px;
   font-weight: 700;
   line-height: 1;
   color: #fff;
@@ -382,7 +382,7 @@ code {
 #sidebar-group-list .tool:hover {
 	background: #EEE;
 }
-#sidebar-group-list .notify {
+/*#sidebar-group-list .notify {
 	min-width: 10px;
 	text-align: center;
 	color: #FFF;
@@ -391,6 +391,9 @@ code {
 	padding: 3px;
 	border-radius: 10px;
 	display: none;
+}*/
+#sidebar-group-list .notify {
+  display: none;
 }
 #sidebar-group-list .notify.show { display: inline-block; }
 .tool .label {
@@ -416,7 +419,7 @@ code {
   opacity: 1;
 }
 
-.sidebar-group-li:hover, #sidebar-new-group:hover, #forum-widget-collapse:hover,
+.sidebar-group-li:hover, #sidebar-new-group:hover, #sidebar-edit-groups:hover, #forum-widget-collapse:hover,
 #sidebar-ungrouped:hover, .side-link:hover, .nets-ul li:hover, #forumlist-sidebar li:hover, #forumlist-sidebar-right li:hover,
 .nets-all:hover, .saved-search-li:hover, li.tool:hover, .admin.link:hover, aside h4 a:hover, right_aside h4 a:hover, #message-new:hover {
   /* background-color: #ddd; */
@@ -436,7 +439,7 @@ code {
   font-weight: bold;
 }
 
-#forum-widget-showmore, #sidebar-new-group, #forum-widget-collapse, #forumlist-rsidebar-right, #sidebar-ungrouped,
+#forum-widget-showmore, #sidebar-new-group, #sidebar-edit-groups, #forum-widget-collapse, #forumlist-rsidebar-right, #sidebar-ungrouped,
 .side-link, #peoplefind-desc, #connect-desc, .nets-all, .admin.link, #message-new {
   padding-left: 10px;
   padding-top: 3px;
@@ -464,7 +467,7 @@ code {
   display: inline-block;
 }
 
-a.nets-link, .side-link a, #sidebar-new-group a, a.savedsearchterm, a.fileas-link, aside h4 a, right_aside h4 a {
+a.nets-link, .side-link a, #sidebar-new-group a, #sidebar-edit-groups a, a.savedsearchterm, a.fileas-link, aside h4 a, right_aside h4 a {
   display: block;
   color: #737373;
 }


### PR DESCRIPTION
for this the "edit_group" id hided on networkpage. Instead there is a general link "edit_groups" which points to the page groups/

Maybe some further css work have to be done in cases of very long group names. I will do some tests and if needed send a seperate PR for this. Testing in cases of long group names is welcome.

@annando 
At this point the color of the badge is in vier also a light blue. I hope this is not too problematic because it can be change easily.