### PR TITLE
Only show supported networks in sidebar and contact list

### DIFF
--- a/include/acl_selectors.php
+++ b/include/acl_selectors.php
@@ -1,6 +1,7 @@
 <?php
 
 require_once("include/contact_selectors.php");
+require_once("include/contact_widgets.php");
 require_once("include/features.php");
 require_once("mod/proxy.php");
 
@@ -424,6 +425,8 @@ function acl_lookup(&$a, $out_type = 'json') {
 	} else {
 		$group_count = 0;
 	}
+
+	$sql_extra2 .= " ".unavailable_networks();
 
 	if ($type=='' || $type=='c'){
 		$r = q("SELECT COUNT(*) AS c FROM `contact`

--- a/include/contact_widgets.php
+++ b/include/contact_widgets.php
@@ -40,18 +40,55 @@ function findpeople_widget() {
 
 }
 
+function unavailable_networks() {
+	$network_filter = "";
+
+	$networks = array();
+
+	if (!plugin_enabled("appnet"))
+		$networks[] = NETWORK_APPNET;
+
+	if (!plugin_enabled("fbpost"))
+		$networks[] = NETWORK_FACEBOOK;
+
+	if (!plugin_enabled("statusnet"))
+		$networks[] = NETWORK_STATUSNET;
+
+	if (!plugin_enabled("pumpio"))
+		$networks[] = NETWORK_PUMPIO;
+
+	if (!plugin_enabled("twitter"))
+		$networks[] = NETWORK_TWITTER;
+
+	if (get_config("system","ostatus_disabled"))
+		$networks[] = NETWORK_OSTATUS;
+
+	if (!get_config("system","diaspora_enabled"))
+		$networks[] = NETWORK_DIASPORA;
+
+	if (!sizeof($networks))
+		return "";
+
+	$network_filter = implode("','", $networks);
+
+	$network_filter = "AND `network` NOT IN ('$network_filter')";
+
+	return $network_filter;
+}
 
 function networks_widget($baseurl,$selected = '') {
 
 	$a = get_app();
 
-	if(! local_user())
+	if(!local_user())
 		return '';
 
-	if(! feature_enabled(local_user(),'networks'))
+	if(!feature_enabled(local_user(),'networks'))
 		return '';
 
-	$r = q("SELECT DISTINCT(`network`) FROM `contact` WHERE `uid` = %d AND `self` = 0 ORDER BY `network`",
+	$extra_sql = unavailable_networks();
+
+	$r = q("SELECT DISTINCT(`network`) FROM `contact` WHERE `uid` = %d AND NOT `self` $extra_sql ORDER BY `network`",
 		intval(local_user())
 	);
 

--- a/include/contact_widgets.php
+++ b/include/contact_widgets.php
@@ -20,12 +20,12 @@ function findpeople_widget() {
 	if(get_config('system','invitation_only')) {
 		$x = get_pconfig(local_user(),'system','invites_remaining');
 		if($x || is_site_admin()) {
-			$a->page['aside'] .= '<div class="side-link" id="side-invite-remain">' 
-			. sprintf( tt('%d invitation available','%d invitations available',$x), $x) 
+			$a->page['aside'] .= '<div class="side-link" id="side-invite-remain">'
+			. sprintf( tt('%d invitation available','%d invitations available',$x), $x)
 			. '</div>' . $inv;
 		}
 	}
- 
+
 	return replace_macros(get_markup_template('peoplefind.tpl'),array(
 		'$findpeople' => t('Find People'),
 		'$desc' => t('Enter name or interest'),
@@ -48,7 +48,7 @@ function unavailable_networks() {
 	if (!plugin_enabled("appnet"))
 		$networks[] = NETWORK_APPNET;
 
-	if (!plugin_enabled("fbpost"))
+	if (!plugin_enabled("fbpost") AND !plugin_enabled("facebook"))
 		$networks[] = NETWORK_FACEBOOK;
 
 	if (!plugin_enabled("statusnet"))
@@ -217,7 +217,7 @@ function common_friends_visitor_widget($profile_uid) {
 	}
 
 	if($cid == 0 && $zcid == 0)
-		return; 
+		return;
 
 	require_once('include/socgraph.php');
 
@@ -241,6 +241,6 @@ function common_friends_visitor_widget($profile_uid) {
 		'$linkmore' => (($t > 5) ? 'true' : ''),
 		'$more' => t('show more'),
 		'$items' => $r
-	)); 
+	));
 
 };

--- a/mod/contacts.php
+++ b/mod/contacts.php
@@ -56,7 +56,7 @@ function contacts_init(&$a) {
 	}
 
 	$groups_widget .= group_side('contacts','group','full',0,$contact_id);
-	
+
 	$a->page['aside'] .= replace_macros(get_markup_template("contacts-widget-sidebar.tpl"),array(
 		'$vcard_widget' => $vcard_widget,
 		'$findpeople_widget' => $findpeople_widget,
@@ -786,8 +786,9 @@ function contacts_content(&$a) {
 		$total = $r[0]['total'];
 	}
 
+	$sql_extra3 = unavailable_networks();
 
-	$r = q("SELECT * FROM `contact` WHERE `uid` = %d AND `self` = 0 AND `pending` = 0 $sql_extra $sql_extra2 ORDER BY `name` ASC LIMIT %d , %d ",
+	$r = q("SELECT * FROM `contact` WHERE `uid` = %d AND `self` = 0 AND `pending` = 0 $sql_extra $sql_extra2 $sql_extra3 ORDER BY `name` ASC LIMIT %d , %d ",
 		intval($_SESSION['uid']),
 		intval($a->pager['start']),
 		intval($a->pager['itemspage'])


### PR DESCRIPTION
When an admin deactivated a previously activated network connector (like Facebook) then it doesn't make sense to show old contacts and posts from that network anymore.