### PR TITLE
make viewcontacts part of the profile tab

### DIFF
--- a/doc/Accesskeys.md
+++ b/doc/Accesskeys.md
@@ -19,6 +19,7 @@ General
 * v: Videos
 * e: Events and Calendar
 * t: Personal Notes
+* k: View Contacts
 
 /contacts (contact list)
 ---------

--- a/include/identity.php
+++ b/include/identity.php
@@ -707,7 +707,7 @@ if(! function_exists('profile_tabs')){
 				'sel'	=> ((!isset($tab)&&$a->argv[0]=='viewcontacts')?'active':''),
 				'title' => t('Contacts'),
 				'id' => 'viewcontacts-tab',
-				'accesskey' => 's',
+				'accesskey' => 'k',
 			);
 		}
 

--- a/include/identity.php
+++ b/include/identity.php
@@ -700,6 +700,16 @@ if(! function_exists('profile_tabs')){
 			);
 		}
 
+		if ((! $is_owner) && ((count($a->profile)) || (! $a->profile['hide-friends']))) {
+			$tabs[] = array(
+				'label' => t('Contacts'),
+				'url'	=> $a->get_baseurl() . '/viewcontacts/' . $nickname,
+				'sel'	=> ((!isset($tab)&&$a->argv[0]=='viewcontacts')?'active':''),
+				'title' => t('Contacts'),
+				'id' => 'viewcontacts-tab',
+				'accesskey' => 's',
+			);
+		}
 
 		$arr = array('is_owner' => $is_owner, 'nickname' => $nickname, 'tab' => (($tab) ? $tab : false), 'tabs' => $tabs);
 		call_hooks('profile_tabs', $arr);

--- a/mod/viewcontacts.php
+++ b/mod/viewcontacts.php
@@ -8,7 +8,23 @@ function viewcontacts_init(&$a) {
 		return;
 	}
 
-	profile_load($a,$a->argv[1]);
+	nav_set_selected('home');
+
+	if($a->argc > 1) {
+		$nick = $a->argv[1];
+		$r = q("SELECT * FROM `user` WHERE `nickname` = '%s' AND `blocked` = 0 LIMIT 1",
+			dbesc($nick)
+		);
+
+		if(! count($r))
+			return;
+
+		$a->data['user'] = $r[0];
+		$a->profile_uid = $r[0]['uid'];
+		$is_owner = (local_user() && (local_user() == $a->profile_uid));
+
+		profile_load($a,$a->argv[1]);
+	}
 }
 
 
@@ -25,6 +41,10 @@ function viewcontacts_content(&$a) {
 		return;
 	}
 
+	$o = "";
+
+	// tabs
+	$o .= profile_tabs($a,$is_owner, $a->data['user']['nickname']);
 
 	$r = q("SELECT COUNT(*) AS `total` FROM `contact`
 		WHERE `uid` = %d AND `blocked` = 0 AND `pending` = 0 AND `hidden` = 0 AND `archive` = 0
@@ -93,7 +113,7 @@ function viewcontacts_content(&$a) {
 
 	$tpl = get_markup_template("viewcontact_template.tpl");
 	$o .= replace_macros($tpl, array(
-		'$title' => t('View Contacts'),
+		'$title' => t('Contacts'),
 		'$contacts' => $contacts,
 		'$paginate' => paginate($a),
 	));


### PR DESCRIPTION
Viewcontacts is now  part of the profile tab bar and is only visible on foreign profiles (because own contacts are reachable through the user menu).
With this step we eliminate one "dead end" while visiting foreign profile pages

One remark: Is there a list of the used shortcuts? I have chosen "s" as tab shortcut, but I don't know if it's used anywhere else. Is there a logic behind the selection of a certain letter for a certain shortcut? 