### PR TITLE
vier event_form: include bb-tags for editing

### DIFF
--- a/view/templates/event_form.tpl
+++ b/view/templates/event_form.tpl
@@ -29,15 +29,15 @@
 <div id="event-adjust-break"></div>
 
 <div id="event-summary-text">{{$t_text}}</div>
-<input type="text" id="event-summary" name="summary" value="{{$t_orig|escape:'html'}}" />
+<input type="text" size="65" id="event-summary" name="summary" value="{{$t_orig|escape:'html'}}" />
 
 
 <div id="event-desc-text">{{$d_text}}</div>
-<textarea id="event-desc-textarea" name="desc">{{$d_orig}}</textarea>
+<textarea rows="8" cols="64" id="event-desc-textarea" name="desc">{{$d_orig}}</textarea>
 
 
 <div id="event-location-text">{{$l_text}}</div>
-<textarea id="event-location-textarea" name="location">{{$l_orig}}</textarea>
+<textarea rows="4" cols="64" id="event-location-textarea" name="location">{{$l_orig}}</textarea>
 
 <div id="event-location-break"></div>
 

--- a/view/templates/event_form.tpl
+++ b/view/templates/event_form.tpl
@@ -29,15 +29,15 @@
 <div id="event-adjust-break"></div>
 
 <div id="event-summary-text">{{$t_text}}</div>
-<input type="text" size="65" id="event-summary" name="summary" value="{{$t_orig|escape:'html'}}" />
+<input type="text" id="event-summary" name="summary" value="{{$t_orig|escape:'html'}}" />
 
 
 <div id="event-desc-text">{{$d_text}}</div>
-<textarea rows="8" cols="64" id="event-desc-textarea" name="desc">{{$d_orig}}</textarea>
+<textarea id="event-desc-textarea" name="desc">{{$d_orig}}</textarea>
 
 
 <div id="event-location-text">{{$l_text}}</div>
-<textarea rows="4" cols="64" id="event-location-textarea" name="location">{{$l_orig}}</textarea>
+<textarea id="event-location-textarea" name="location">{{$l_orig}}</textarea>
 
 <div id="event-location-break"></div>
 
@@ -50,5 +50,4 @@
 <input id="event-edit-preview" type="submit" name="preview" value="{{$preview|escape:'html'}}" onclick="doEventPreview(); return false;" />
 <input id="event-submit" type="submit" name="submit" value="{{$submit|escape:'html'}}" />
 </form>
-
 

--- a/view/templates/event_head.tpl
+++ b/view/templates/event_head.tpl
@@ -138,6 +138,10 @@
 		}
 
 	});
+
+	$(document).ready(function() { 
+		$('.comment-edit-bb').hide();
+	});
 	{{else}}
 	<script language="javascript" type="text/javascript">
 	{{/if}}

--- a/view/theme/vier/style.css
+++ b/view/theme/vier/style.css
@@ -2671,6 +2671,13 @@ a.mail-list-link {
         font-weight: bold;
         color: #FF0000;
 }
+#event-desc-text-edit-bb, #event-location-text-edit-bb {
+  float: none;
+}
+#event-start-text, #event-finish-text, #event-summary-text, #event-desc-text, #event-location-text {
+  margin-bottom: 10px;
+  margin-top: 20px;
+}
 
 .settings-block {
         /* border: 1px solid #AAA; */

--- a/view/theme/vier/templates/event_form.tpl
+++ b/view/theme/vier/templates/event_form.tpl
@@ -1,0 +1,74 @@
+
+
+<h3>{{$title}}</h3>
+
+<p>
+{{$desc}}
+</p>
+
+<form id="event-edit-form" action="{{$post}}" method="post" >
+
+<input type="hidden" name="event_id" value="{{$eid}}" />
+<input type="hidden" name="cid" value="{{$cid}}" />
+<input type="hidden" name="uri" value="{{$uri}}" />
+<input type="hidden" name="preview" id="event-edit-preview" value="0" />
+
+<div id="event-start-text">{{$s_text}}</div>
+{{$s_dsel}}
+
+<div id="event-finish-text">{{$f_text}}</div>
+{{$f_dsel}}
+
+<div id="event-datetime-break"></div>
+
+<input type="checkbox" name="nofinish" value="1" id="event-nofinish-checkbox" {{$n_checked}} /> <div id="event-nofinish-text">{{$n_text}}</div>
+
+<div id="event-nofinish-break"></div>
+
+<input type="checkbox" name="adjust" value="1" id="event-adjust-checkbox" {{$a_checked}} /> <div id="event-adjust-text">{{$a_text}}</div>
+
+<div id="event-adjust-break"></div>
+
+<div id="event-summary-text">{{$t_text}}</div>
+<input type="text" size="65" id="event-summary" name="summary" value="{{$t_orig|escape:'html'}}" />
+
+
+<div id="event-desc-text">{{$d_text}}</div>
+<textarea id="comment-edit-text-desc" rows="8" cols="64" name="desc">{{$d_orig}}</textarea>
+<div id="event-desc-text-edit-bb" class="comment-edit-bb">
+	<a title="{{$edimg}}" data-role="insert-formatting" data-comment="{{$comment}}" data-bbcode="img" data-id="desc"><i class="icon-picture"></i></a>      
+	<a title="{{$edurl}}" data-role="insert-formatting" data-comment="{{$comment}}" data-bbcode="url" data-id="desc"><i class="icon-link"></i></a>
+	<a title="{{$edvideo}}" data-role="insert-formatting" data-comment="{{$comment}}" data-bbcode="video" data-id="desc"><i class="icon-film"></i></a>
+
+	<a title="{{$eduline}}" data-role="insert-formatting" data-comment="{{$comment}}" data-bbcode="u" data-id="desc"><i class="icon-underline"></i></a>
+	<a title="{{$editalic}}" data-role="insert-formatting" data-comment="{{$comment}}" data-bbcode="i" data-id="desc"><i class="icon-italic"></i></a>
+	<a title="{{$edbold}}" data-role="insert-formatting" data-comment="{{$comment}}" data-bbcode="b" data-id="desc"><i class="icon-bold"></i></a>
+	<a title="{{$edquote}}" data-role="insert-formatting" data-comment="{{$comment}}" data-bbcode="quote" data-id="desc"><i class="icon-quote-left"></i></a>
+</div>
+
+<div id="event-location-text">{{$l_text}}</div>
+<textarea id="comment-edit-text-location" rows="4" cols="64" name="location">{{$l_orig}}</textarea>
+<div id="event-location-text-edit-bb" class="comment-edit-bb">
+	<a title="{{$edimg}}" data-role="insert-formatting" data-comment="{{$comment}}" data-bbcode="img" data-id="location"><i class="icon-picture"></i></a>      
+	<a title="{{$edurl}}" data-role="insert-formatting" data-comment="{{$comment}}" data-bbcode="url" data-id="location"><i class="icon-link"></i></a>
+	<a title="{{$edvideo}}" data-role="insert-formatting" data-comment="{{$comment}}" data-bbcode="video" data-id="location"><i class="icon-film"></i></a>
+
+	<a title="{{$eduline}}" data-role="insert-formatting" data-comment="{{$comment}}" data-bbcode="u" data-id="location"><i class="icon-underline"></i></a>
+	<a title="{{$editalic}}" data-role="insert-formatting" data-comment="{{$comment}}" data-bbcode="i" data-id="location"><i class="icon-italic"></i></a>
+	<a title="{{$edbold}}" data-role="insert-formatting" data-comment="{{$comment}}" data-bbcode="b" data-id="location"><i class="icon-bold"></i></a>
+	<a title="{{$edquote}}" data-role="insert-formatting" data-comment="{{$comment}}" data-bbcode="quote" data-id="location"><i class="icon-quote-left"></i></a>
+</div>
+
+<div id="event-location-break"></div>
+
+<input type="checkbox" name="share" value="1" id="event-share-checkbox" {{$sh_checked}} /> <div id="event-share-text">{{$sh_text}}</div>
+<div id="event-share-break"></div>
+
+{{$acl}}
+
+<div class="clear"></div>
+<input id="event-edit-preview" type="submit" name="preview" value="{{$preview|escape:'html'}}" onclick="doEventPreview(); return false;" />
+<input id="event-submit" type="submit" name="submit" value="{{$submit|escape:'html'}}" />
+</form>
+
+


### PR DESCRIPTION
In the form "new event" bb-tags can now be uses to format event description and event location.
Additionally some visual polishing has be done 

This is done only for vier theme. Because almost every theme uses it's own icons for presenting the bbcode. If I get some more time I will step into this again and will look if there would be an easy realization for the other themes.

Ahhh one little bug: the formatting bbcodes (b,u,i)) will only work if there is already some text in the textbox