### PR TITLE
Bugfix: The duplicate check sometimes seemed to have scrambled the posts

### DIFF
--- a/include/feed.php
+++ b/include/feed.php
@@ -203,8 +203,8 @@ function feed_import($xml,$importer,&$contact, &$hub) {
 
 		//$item["object"] = $xml;
 
-		$r = q("SELECT `id` FROM `item` WHERE `uid` = %d AND `uri` = '%s' AND `network` = '%s'",
-			intval($importer["uid"]), dbesc($item["uri"]), dbesc(NETWORK_FEED));
+		$r = q("SELECT `id` FROM `item` WHERE `uid` = %d AND `uri` = '%s' AND `network` IN ('%s', '%s')",
+			intval($importer["uid"]), dbesc($item["uri"]), dbesc(NETWORK_FEED), dbesc(NETWORK_DFRN));
 		if ($r) {
 			logger("Item with uri ".$item["uri"]." for user ".$importer["uid"]." already existed under id ".$r[0]["id"], LOGGER_DEBUG);
 			continue;

--- a/include/threads.php
+++ b/include/threads.php
@@ -87,7 +87,6 @@ function add_shadow_entry($item) {
 
 	// Is there already a shadow entry?
 	$r = q("SELECT `id` FROM `item` WHERE `uri` = '%s' AND `uid` = 0 LIMIT 1", dbesc($item['uri']));
-
 	if (count($r))
 		return;
 


### PR DESCRIPTION
There was a really complicated issue:
* A Friendica user posts an item that is transferred via OStatus
* An OStatus user that this user doesn't follow is repeating the post
* Another OStatus user is responding to that post
* The thread completion is posting all posts again
* The new post (with the same URI) is posted again
* Since the completion thinks that this is the main post, it changes the parent to the new post
* Some other magic happens in between

=> Result: The thread disappears

The duplicate check is now improved so that posts with the same URI in different networks are detected, so that this scenario shouldn't happen again.

Additionally some other parts of the duplication checks were improved (When storing feeds that are stored via "remote self") and when a duplicate was found the the oldest one is kept. (Which should be better in any case since it prevents orphans)