### PR TITLE
probe_url: Only cache successful results

### DIFF
--- a/include/Scrape.php
+++ b/include/Scrape.php
@@ -831,7 +831,7 @@ function probe_url($url, $mode = PROBE_NORMAL, $level = 1) {
 	}
 
 	// Only store into the cache if the value seems to be valid
-	if ($result['network'] != NETWORK_FEED)
+	if ($result['network'] != NETWORK_PHANTOM)
 		Cache::set("probe_url:".$mode.":".$url,serialize($result), CACHE_DAY);
 
 	return $result;


### PR DESCRIPTION
In the past the function returned that it is a feed when it was a feed - or the address was invalid. We changed that some time before but forgot to adopt this change in the caching section.