### PR TITLE
Workaround for misconfigured Friendica servers with probe_url

### DIFF
--- a/include/Scrape.php
+++ b/include/Scrape.php
@@ -632,7 +632,9 @@ function probe_url($url, $mode = PROBE_NORMAL, $level = 1) {
 
 		if ($connectornetworks)
 			$check_feed = false;
+
 		if($check_feed) {
+
 			$feedret = scrape_feed(($poll) ? $poll : $url);
 
 			logger('probe_url: scrape_feed ' . (($poll)? $poll : $url) . ' returns: ' . print_r($feedret,true), LOGGER_DATA);
@@ -760,7 +762,6 @@ function probe_url($url, $mode = PROBE_NORMAL, $level = 1) {
 					if (isset($noscrapedata["dfrn-poll"]))
 						$poll = $noscrapedata["dfrn-poll"];
 
-//					print_r($noscrapedata);
 				}
 			}
 

--- a/include/Scrape.php
+++ b/include/Scrape.php
@@ -632,9 +632,7 @@ function probe_url($url, $mode = PROBE_NORMAL, $level = 1) {
 
 		if ($connectornetworks)
 			$check_feed = false;
-
 		if($check_feed) {
-
 			$feedret = scrape_feed(($poll) ? $poll : $url);
 
 			logger('probe_url: scrape_feed ' . (($poll)? $poll : $url) . ' returns: ' . print_r($feedret,true), LOGGER_DATA);
@@ -723,6 +721,46 @@ function probe_url($url, $mode = PROBE_NORMAL, $level = 1) {
 								$vcard['photo'] = $elems['link'][0]['attribs']['']['href'];
 						}
 					}
+				}
+			}
+
+			// Workaround for misconfigured Friendica servers
+			if (($network == "") AND (strstr($url, "/profile/"))) {
+				$noscrape = str_replace("/profile/", "/noscrape/", $url);
+				$noscrapejson = fetch_url($noscrape);
+				if ($noscrapejson) {
+
+					$network = NETWORK_DFRN;
+
+					$poco = str_replace("/profile/", "/poco/", $url);
+
+					$noscrapedata = json_decode($noscrapejson, true);
+
+					if (isset($noscrapedata["addr"]))
+						$addr = $noscrapedata["addr"];
+
+					if (isset($noscrapedata["fn"]))
+						$vcard["fn"] = $noscrapedata["fn"];
+
+					if (isset($noscrapedata["key"]))
+						$pubkey = $noscrapedata["key"];
+
+					if (isset($noscrapedata["photo"]))
+						$vcard["photo"] = $noscrapedata["photo"];
+
+					if (isset($noscrapedata["dfrn-request"]))
+						$request = $noscrapedata["dfrn-request"];
+
+					if (isset($noscrapedata["dfrn-confirm"]))
+						$confirm = $noscrapedata["dfrn-confirm"];
+
+					if (isset($noscrapedata["dfrn-notify"]))
+						$notify = $noscrapedata["dfrn-notify"];
+
+					if (isset($noscrapedata["dfrn-poll"]))
+						$poll = $noscrapedata["dfrn-poll"];
+
+//					print_r($noscrapedata);
 				}
 			}
 

--- a/mod/noscrape.php
+++ b/mod/noscrape.php
@@ -24,6 +24,7 @@ function noscrape_init(&$a) {
 
 	$json_info = array(
 		'fn' => $a->profile['name'],
+		'addr' => $a->profile['addr'],
 		'key' => $a->profile['pubkey'],
 		'homepage' => $a->get_baseurl()."/profile/{$which}",
 		'comm' => (x($a->profile,'page-flags')) && ($a->profile['page-flags'] == PAGE_COMMUNITY),


### PR DESCRIPTION
If you are running Friendica with nginx then a small misconfiguration can lead to an unusable or only partly usable installation.

This workaround should fix it.