### PR TITLE
Do a linebreak before the output of rendertime

### DIFF
--- a/view/global.css
+++ b/view/global.css
@@ -313,3 +313,7 @@ ul.credits li {
         float: left;
         width: 200px;
 }
+
+.renderinfo {
+	clear: both;
+}


### PR DESCRIPTION
This will avoid the problem that the rendertime data is printed without any linebreak