### PR TITLE
Avoid problems with wrong configured server variables

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -635,13 +635,13 @@ if(! class_exists('App')) {
 			$basepath = get_config("system", "basepath");
 
 			if ($basepath == "")
+				$basepath = dirname(__FILE__);
+
+			if ($basepath == "")
 				$basepath = $_SERVER["DOCUMENT_ROOT"];
 
 			if ($basepath == "")
 				$basepath = $_SERVER["PWD"];
-
-			if ($basepath == "")
-				$basepath = dirname(__FILE__);
 
 			return($basepath);
 		}


### PR DESCRIPTION
The server variable DOCUMENT_ROOT sometimes doesn't point to the document root, for example at uberspace: https://wiki.uberspace.de/domain:verwalten

This should avoid such problems.