### PR TITLE
OStatus: Make sure that mentions are always accepted

### DIFF
--- a/include/ostatus.php
+++ b/include/ostatus.php
@@ -1386,6 +1386,8 @@ function ostatus_entry($doc, $item, $owner, $toplevel = false) {
 	xml_add_element($doc, $entry, "published", datetime_convert("UTC","UTC",$item["created"]."+00:00",ATOM_TIME));
 	xml_add_element($doc, $entry, "updated", datetime_convert("UTC","UTC",$item["edited"]."+00:00",ATOM_TIME));
 
+	$mentioned = array();
+
 	if (($item['parent'] != $item['id']) || ($item['parent-uri'] !== $item['uri']) || (($item['thr-parent'] !== '') && ($item['thr-parent'] !== $item['uri']))) {
 		$parent = q("SELECT `guid` FROM `item` WHERE `id` = %d", intval($item["parent"]));
 		$parent_item = (($item['thr-parent']) ? $item['thr-parent'] : $item['parent-uri']);
@@ -1400,7 +1402,18 @@ function ostatus_entry($doc, $item, $owner, $toplevel = false) {
 				"rel" => "related",
 				"href" => $a->get_baseurl()."/display/".$parent[0]["guid"]);
 		xml_add_element($doc, $entry, "link", "", $attributes);
-        }
+
+		$mentioned[$parent[0]["author-link"]] = $parent[0]["author-link"];
+		$mentioned[$parent[0]["owner-link"]] = $parent[0]["owner-link"];
+
+		$thrparent = q("SELECT `guid`, `author-link`, `owner-link` FROM `item` WHERE `uid` = %d AND `uri` = '%s'",
+				intval($owner["uid"]),
+				dbesc($parent_item));
+		if ($thrparent) {
+			$mentioned[$thrparent[0]["author-link"]] = $thrparent[0]["author-link"];
+			$mentioned[$thrparent[0]["owner-link"]] = $thrparent[0]["owner-link"];
+		}
+	}
 
 	xml_add_element($doc, $entry, "link", "", array("rel" => "ostatus:conversation",
 							"href" => $a->get_baseurl()."/display/".$owner["nick"]."/".$item["parent"]));
@@ -1411,9 +1424,29 @@ function ostatus_entry($doc, $item, $owner, $toplevel = false) {
 	if(count($tags))
 		foreach($tags as $t)
 			if ($t[0] == "@")
-				xml_add_element($doc, $entry, "link", "", array("rel" => "mentioned",
+				$mentioned[$t[1]] = $t[1];
+
+	// Make sure that mentions are accepted (GNU Social has problems with mixing HTTP and HTTPS)
+	$newmentions = array();
+	foreach ($mentioned AS $mention) {
+		$newmentions[str_replace("http://", "https://", $mention)] = str_replace("http://", "https://", $mention);
+		$newmentions[str_replace("https://", "http://", $mention)] = str_replace("https://", "http://", $mention);
+	}
+	$mentioned = $newmentions;
+
+	foreach ($mentioned AS $mention) {
+		$r = q("SELECT `forum`, `prv` FROM `contact` WHERE `uid` = %d AND `nurl` = '%s'",
+			intval($owner["uid"]),
+			dbesc(normalise_link($mention)));
+		if ($r[0]["forum"] OR $r[0]["prv"])
+			xml_add_element($doc, $entry, "link", "", array("rel" => "mentioned",
+										"ostatus:object-type" => ACTIVITY_OBJ_GROUP,
+										"href" => $mention));
+		else
+			xml_add_element($doc, $entry, "link", "", array("rel" => "mentioned",
 										"ostatus:object-type" => ACTIVITY_OBJ_PERSON,
-										"href" => $t[1]));
+										"href" => $mention));
+	}
 
 	if (!$item["private"])
 		xml_add_element($doc, $entry, "link", "", array("rel" => "mentioned",


### PR DESCRIPTION
We are experiencing the problem that notifications to OStatus contacts not work all the time. Sometimes the slapper returns the HTTP error "400". It seems as if the problems lies in the difference of mentioning OStatus contacts with SSL and Non-SSL links.

We will now address the contacts with both styles. This seems to work better.