### PR TITLE
add pager to common friends and allfriends

### DIFF
--- a/mod/allfriends.php
+++ b/mod/allfriends.php
@@ -32,7 +32,12 @@ function allfriends_content(&$a) {
 	$a->page['aside'] = "";
 	profile_load($a, "", 0, get_contact_details_by_url($c[0]["url"]));
 
-	$r = all_friends(local_user(),$cid);
+	$total = count_all_friends(local_user(), $cid);
+
+	if(count($total))
+		$a->set_pager_total($total);
+
+	$r = all_friends(local_user(), $cid, $a->pager['start'], $a->pager['itemspage']);
 
 	if(! count($r)) {
 		$o .= t('No friends to display.');
@@ -87,8 +92,8 @@ function allfriends_content(&$a) {
 		//'$title' => sprintf( t('Friends of %s'), htmlentities($c[0]['name'])),
 		'$tab_str' => $tab_str,
 		'$contacts' => $entries,
+		'$paginate' => paginate($a),
 	));
 
-//	$o .= paginate($a);
 	return $o;
 }

--- a/mod/common.php
+++ b/mod/common.php
@@ -76,23 +76,22 @@ function common_content(&$a) {
 
 
 	if($cid)
-		$t = count_common_friends($uid,$cid);
+		$t = count_common_friends($uid, $cid);
 	else
-		$t = count_common_friends_zcid($uid,$zcid);
+		$t = count_common_friends_zcid($uid, $zcid);
 
-
-	$a->set_pager_total($t);
-
-	if(! $t) {
+	if(count($t))
+		$a->set_pager_total($t);
+	else {
 		notice( t('No contacts in common.') . EOL);
 		return $o;
 	}
 
 
 	if($cid)
-		$r = common_friends($uid,$cid);
+		$r = common_friends($uid, $cid, $a->pager['start'], $a->pager['itemspage']);
 	else
-		$r = common_friends_zcid($uid,$zcid);
+		$r = common_friends_zcid($uid, $zcid, $a->pager['start'], $a->pager['itemspage']);
 
 
 	if(! count($r)) {
@@ -140,8 +139,8 @@ function common_content(&$a) {
 		'$title' => $title,
 		'$tab_str' => $tab_str,
 		'$contacts' => $entries,
+		'$paginate' => paginate($a),
 	));
 
-//	$o .= paginate($a);
 	return $o;
 }


### PR DESCRIPTION
There was no pager for allfriends. So the user could only see the first 80 contacts. This solves the issue.

I also added pager for common friends. It should work because it's the same logic like in allfriends, but this have to test someone who has many contacts with somebody in common 