### PR TITLE
vier: fix for 2205

### DIFF
--- a/view/theme/vier/style.css
+++ b/view/theme/vier/style.css
@@ -342,6 +342,7 @@ code {
   padding: 10px;
   margin-top: 20px;
   max-width: 640px;
+  white-space: pre-wrap;
 }
 .badge {
   display: inline-block;
@@ -1348,6 +1349,10 @@ section.minimal {
   float: right;
 }
 
+.wall-item-network-end {
+  clear: both;
+}
+
 .wall-item-location {
   width: 350px;
   float: left;
@@ -1446,6 +1451,7 @@ section.minimal {
   transition: all 0.2s ease-in-out;
   /* color: darkblue; */
   /* color: #3E3E8C; */
+  word-break: break-word;
 }
 
 .toplevel_item:hover .fakelink,

--- a/view/theme/vier/templates/wall_thread.tpl
+++ b/view/theme/vier/templates/wall_thread.tpl
@@ -56,6 +56,7 @@
 			<span class="wall-item-network" title="{{$item.app}}">
 				{{$item.network_name}}
 			</span>
+			<div class="wall-item-network-end"></div>
 		</div>
 
 		<div itemprop="description" class="wall-item-content">


### PR DESCRIPTION
this should fix https://github.com/friendica/friendica/issues/2205 

while testing the fix I noticed another problem.

The `<abbr>` element in vevent posts doesn't break. Maybe @fabrixxm can have a look at it since I don't get it solved