### PR TITLE
Bugfix: Duplicate check for likes wasn't reliable

### DIFF
--- a/include/delivery.php
+++ b/include/delivery.php
@@ -276,7 +276,7 @@ function delivery_run(&$argv, &$argc){
 		switch($contact['network']) {
 
 			case NETWORK_DFRN:
-				logger('notifier: dfrndelivery: ' . $contact['name']);
+				logger('notifier: '.$target_item["guid"].' dfrndelivery: ' . $contact['name']);
 
 				$feed_template = get_markup_template('atom_feed.tpl');
 				$mail_template = get_markup_template('atom_mail.tpl');
@@ -402,14 +402,14 @@ function delivery_run(&$argv, &$argc){
 						if($normal_mode) {
 							if($item_id == $item['id'] || $item['id'] == $item['parent'])
 								$atom .= atom_entry($item,'text',null,$owner,true,(($top_level) ? $contact['id'] : 0));
-						}
-						else
+						} else
 							$atom .= atom_entry($item,'text',null,$owner,true);
-
 					}
 				}
 
 				$atom .= '</feed>' . "\r\n";
+
+				logger('notifier: '.$contact["url"].' '.$target_item["guid"].' entry: '.$atom, LOGGER_DEBUG);
 
 				logger('notifier: ' . $atom, LOGGER_DATA);
 				$basepath =  implode('/', array_slice(explode('/',$contact['url']),0,3));
@@ -470,7 +470,7 @@ function delivery_run(&$argv, &$argc){
 				else
 					$deliver_status = (-1);
 
-				logger('notifier: dfrn_delivery returns ' . $deliver_status);
+				logger('notifier: dfrn_delivery to '.$contact["url"].' with guid '.$target_item["guid"].' returns '.$deliver_status);
 
 				if($deliver_status == (-1)) {
 					logger('notifier: delivery failed: queuing message');

--- a/include/items.php
+++ b/include/items.php
@@ -3717,7 +3717,7 @@ function local_delivery($importer,$data) {
 				$datarray['owner-avatar'] = $own[0]['thumb'];
 				$datarray['contact-id'] = $importer['id'];
 
-				if(($datarray['verb'] === ACTIVITY_LIKE) 
+				if(($datarray['verb'] === ACTIVITY_LIKE)
 					|| ($datarray['verb'] === ACTIVITY_DISLIKE)
 					|| ($datarray['verb'] === ACTIVITY_ATTEND)
 					|| ($datarray['verb'] === ACTIVITY_ATTENDNO)
@@ -3728,9 +3728,9 @@ function local_delivery($importer,$data) {
 					$datarray['last-child'] = 0;
 					// only one like or dislike per person
 					// splitted into two queries for performance issues
-					$r = q("select id from item where uid = %d and `contact-id` = %d and verb = '%s' and (`parent-uri` = '%s') and deleted = 0 limit 1",
+					$r = q("SELECT `id` FROM `item` WHERE `uid` = %d AND `author-link` = '%s' AND `verb` = '%s' AND `parent-uri` = '%s' AND NOT `deleted` LIMIT 1",
 						intval($datarray['uid']),
-						intval($datarray['contact-id']),
+						dbesc($datarray['author-link']),
 						dbesc($datarray['verb']),
 						dbesc($datarray['parent-uri'])
 
@@ -3738,9 +3738,9 @@ function local_delivery($importer,$data) {
 					if($r && count($r))
 						continue;
 
-					$r = q("select id from item where uid = %d and `contact-id` = %d and verb = '%s' and (`thr-parent` = '%s') and deleted = 0 limit 1",
+					$r = q("SELECT `id` FROM `item` WHERE `uid` = %d AND `author-link` = '%s' AND `verb` = '%s' AND `thr-parent` = '%s' AND NOT `deleted` LIMIT 1",
 						intval($datarray['uid']),
-						intval($datarray['contact-id']),
+						dbesc($datarray['author-link']),
 						dbesc($datarray['verb']),
 						dbesc($datarray['parent-uri'])
 

--- a/include/items.php
+++ b/include/items.php
@@ -2768,20 +2768,20 @@ function consume_feed($xml,$importer,&$contact, &$hub, $datedir = 0, $pass = 0) 
 					$datarray['gravity'] = GRAVITY_LIKE;
 					// only one like or dislike per person
 					// splitted into two queries for performance issues
-					$r = q("select id from item where uid = %d and `contact-id` = %d and verb ='%s' and deleted = 0 and (`parent-uri` = '%s') limit 1",
+					$r = q("SELECT `id` FROM `item` WHERE `uid` = %d AND `author-link` = '%s' AND `verb` = '%s' AND `parent-uri` = '%s' AND NOT `deleted` LIMIT 1",
 						intval($datarray['uid']),
-						intval($datarray['contact-id']),
+						dbesc($datarray['author-link']),
 						dbesc($datarray['verb']),
-						dbesc($parent_uri)
+						dbesc($datarray['parent-uri'])
 					);
 					if($r && count($r))
 						continue;
 
-					$r = q("select id from item where uid = %d and `contact-id` = %d and verb ='%s' and deleted = 0 and (`thr-parent` = '%s') limit 1",
+					$r = q("SELECT `id` FROM `item` WHERE `uid` = %d AND `author-link` = '%s' AND `verb` = '%s' AND `thr-parent` = '%s' AND NOT `deleted` LIMIT 1",
 						intval($datarray['uid']),
-						intval($datarray['contact-id']),
+						dbesc($datarray['author-link']),
 						dbesc($datarray['verb']),
-						dbesc($parent_uri)
+						dbesc($datarray['parent-uri'])
 					);
 					if($r && count($r))
 						continue;
@@ -3733,7 +3733,6 @@ function local_delivery($importer,$data) {
 						dbesc($datarray['author-link']),
 						dbesc($datarray['verb']),
 						dbesc($datarray['parent-uri'])
-
 					);
 					if($r && count($r))
 						continue;
@@ -3910,7 +3909,7 @@ function local_delivery($importer,$data) {
 				$datarray['parent-uri'] = $parent_uri;
 				$datarray['uid'] = $importer['importer_uid'];
 				$datarray['contact-id'] = $importer['id'];
-				if(($datarray['verb'] === ACTIVITY_LIKE) 
+				if(($datarray['verb'] === ACTIVITY_LIKE)
 					|| ($datarray['verb'] === ACTIVITY_DISLIKE)
 					|| ($datarray['verb'] === ACTIVITY_ATTEND)
 					|| ($datarray['verb'] === ACTIVITY_ATTENDNO)
@@ -3919,20 +3918,20 @@ function local_delivery($importer,$data) {
 					$datarray['gravity'] = GRAVITY_LIKE;
 					// only one like or dislike per person
 					// splitted into two queries for performance issues
-					$r = q("select id from item where uid = %d and `contact-id` = %d and verb ='%s' and deleted = 0 and (`parent-uri` = '%s') limit 1",
+					$r = q("SELECT `id` FROM `item` WHERE `uid` = %d AND `author-link` = '%s' AND `verb` = '%s' AND `parent-uri` = '%s' AND NOT `deleted` LIMIT 1",
 						intval($datarray['uid']),
-						intval($datarray['contact-id']),
+						dbesc($datarray['author-link']),
 						dbesc($datarray['verb']),
-						dbesc($parent_uri)
+						dbesc($datarray['parent-uri'])
 					);
 					if($r && count($r))
 						continue;
 
-					$r = q("select id from item where uid = %d and `contact-id` = %d and verb ='%s' and deleted = 0 and (`thr-parent` = '%s') limit 1",
+					$r = q("SELECT `id` FROM `item` WHERE `uid` = %d AND `author-link` = '%s' AND `verb` = '%s' AND `thr-parent` = '%s' AND NOT `deleted` LIMIT 1",
 						intval($datarray['uid']),
-						intval($datarray['contact-id']),
+						dbesc($datarray['author-link']),
 						dbesc($datarray['verb']),
-						dbesc($parent_uri)
+						dbesc($datarray['parent-uri'])
 					);
 					if($r && count($r))
 						continue;

--- a/include/notifier.php
+++ b/include/notifier.php
@@ -559,7 +559,7 @@ function notifier_run(&$argv, &$argc){
 		$r = array_merge($r2,$r1,$r0);
 
 		if(count($r)) {
-			logger('pubdeliver: ' . print_r($r,true), LOGGER_DEBUG);
+			logger('pubdeliver '.$target_item["guid"].': '.print_r($r,true), LOGGER_DEBUG);
 
 			// throw everything into the queue in case we get killed
 
@@ -584,7 +584,7 @@ function notifier_run(&$argv, &$argc){
 				}
 
 				if((! $mail) && (! $fsuggest) && (! $followup)) {
-					logger('notifier: delivery agent: ' . $rr['name'] . ' ' . $rr['id']);
+					logger('notifier: delivery agent: '.$rr['name'].' '.$rr['id'].' '.$rr['network'].' '.$target_item["guid"]);
 					proc_run('php','include/delivery.php',$cmd,$item_id,$rr['id']);
 					if($interval)
 						@time_sleep_until(microtime(true) + (float) $interval);


### PR DESCRIPTION
The check for existing likes had a problem: It only looked for the contact id - which isn't reliable. This is now changed to the author-link.