### PR TITLE
moved include Scape to top of the file

### DIFF
--- a/mod/dfrn_request.php
+++ b/mod/dfrn_request.php
@@ -10,6 +10,7 @@
  */
 
 require_once('include/enotify.php');
+require_once('include/Scrape.php');
 
 if(! function_exists('dfrn_request_init')) {
 function dfrn_request_init(&$a) {
@@ -111,8 +112,6 @@ function dfrn_request_post(&$a) {
 					/**
 					 * Scrape the other site's profile page to pick up the dfrn links, key, fn, and photo
 					 */
-
-					require_once('include/Scrape.php');
 
 					$parms = scrape_dfrn($dfrn_url);
 


### PR DESCRIPTION
There was a problem from a friendica user connecting to me with

    Fatal error: Call to unde­fined func­tion probe_​url() in /.../mod/dfrn_request.php on line 446

moving the include call for the Scrape.php to the top of the file solved the problem.