### PR TITLE
Bugfix: Public posts to Diaspora could fail

### DIFF
--- a/include/Scrape.php
+++ b/include/Scrape.php
@@ -559,10 +559,11 @@ function probe_url($url, $mode = PROBE_NORMAL, $level = 1) {
 				$pubkey = $hcard_key;
 		}
 	}
-
 	if($diaspora && $diaspora_base && $diaspora_guid) {
-		if($mode == PROBE_DIASPORA || ! $notify) {
-			$notify = $diaspora_base . 'receive/users/' . $diaspora_guid;
+		$diaspora_notify = $diaspora_base.'receive/users/'.$diaspora_guid;
+
+		if($mode == PROBE_DIASPORA || ! $notify || ($notify == $diaspora_notify)) {
+			$notify = $diaspora_notify;
 			$batch  = $diaspora_base . 'receive/public' ;
 		}
 		if(strpos($url,'@'))


### PR DESCRIPTION
There was a problem with Diaspora contacts. The probe_url function was unable to fetch the value for "batch" - which is needed for public posts.

I'm not totally sure when the bug was introduced. I now added a functionality to repair the contacts.