### PR TITLE
vier: mobile view - fix word breaking

### DIFF
--- a/view/global.css
+++ b/view/global.css
@@ -93,7 +93,7 @@ span.connector {
 
 /* Shared Messages */
 .shared_header {
-  height: 32px;
+  min-height: 32px;
   color: #999;
   border-top: 1px solid #D2D2D2;
   padding-top: 5px;
@@ -118,10 +118,12 @@ span.connector {
   -moz-border-radius: 4px;
   border-radius: 4px;
   float: left;
+  margin-right: 9px;
 }
 
 .shared_header span {
-  margin-left: 9px;
+  display: table-cell;
+  float: none;
 }
 
 blockquote.shared_content {

--- a/view/theme/vier/style.css
+++ b/view/theme/vier/style.css
@@ -1055,6 +1055,7 @@ aside .vcard .title {
 aside .vcard dl {
   height: auto;
   overflow: auto;
+  word-break: break-word;
 }
 aside .vcard .account-type {
   margin-bottom: 13px;
@@ -1412,6 +1413,7 @@ section.minimal {
   /* font-size: 14px; */
   max-width: 660px;
   word-wrap: break-word;
+  word-break: break-word;
   /* line-height: 1.36; */
   padding-bottom: 6px;
 }


### PR DESCRIPTION
some fixes for vier mobile where word breaking wasn't working correct.

Things which are left:
* size of content img
* event posts could break mobile view