### PR TITLE
Auto discovery of contacts from GNU Social

### DIFF
--- a/include/discover_poco.php
+++ b/include/discover_poco.php
@@ -78,8 +78,14 @@ function discover_poco_run(&$argv, &$argc){
 		discover_users();
 	elseif (($mode == 1) AND ($search != "") and get_config('system','poco_local_search'))
 		discover_directory($search);
-	elseif (($mode == 0) AND ($search == "") and (get_config('system','poco_discovery') > 0))
+	elseif (($mode == 0) AND ($search == "") and (get_config('system','poco_discovery') > 0)) {
+		// Query Friendica and Hubzilla servers for their users
 		poco_discover();
+
+		// Query GNU Social servers for their users ("statistics" addon has to be enabled on the GS server)
+		if (!get_config('system','ostatus_disabled'))
+			gs_discover();
+	}
 
 	logger('end '.$search);
 
@@ -128,7 +134,7 @@ function discover_users() {
 		else
 			$server_url = poco_detect_server($user["url"]);
 
-		if (poco_check_server($server_url, $gcontacts[0]["network"])) {
+		if (($server_url == "") OR poco_check_server($server_url, $gcontacts[0]["network"])) {
 			logger('Check user '.$user["url"]);
 			poco_last_updated($user["url"], true);
 


### PR DESCRIPTION
There is a plugin for GNU Social that generates statistic data: http://gstools.org/

If the plugin is enabled on a GNU Social server then the public profiles of the users of this server is published. We now crawl for this data like we already do for Friendica servers.

Additionally we are crawling the list of servers at http://gstools.org/ to add possible new servers to our list of GNU Social servers (Which will be used for crawling for users)

