### PR TITLE
Reworked check for double encoded Diaspora signatures

### DIFF
--- a/include/diaspora.php
+++ b/include/diaspora.php
@@ -2911,10 +2911,6 @@ function diaspora_send_relay($item,$owner,$contact,$public_batch = false) {
 		$authorsig = $orig_sign['signature'];
 		$handle = $orig_sign['signer'];
 
-		// Friendica servers lower than 3.5 had double encoded the signature ...
-		if (substr($authorsig, -1, 1) != "=")
-			$authorsig = base64_decode($authorsig);
-
 		// Split the signed text
 		$signed_parts = explode(";", $signed_text);
 

--- a/include/items.php
+++ b/include/items.php
@@ -1609,6 +1609,14 @@ function item_store($arr,$force_parent = false, $notify = false, $dontcache = fa
 		);
 
 	if($dsprsig) {
+
+                // Friendica servers lower than 3.4.3-2 had double encoded the signature ...
+		// We can check for this condition when we decode and encode the stuff again.
+		if (base64_encode(base64_decode(base64_decode($dsprsig->signature))) == base64_decode($dsprsig->signature)) {
+			$dsprsig->signature = base64_decode($dsprsig->signature);
+			logger("Repaired double encoded signature from handle ".$dsprsig->signer, LOGGER_DEBUG);
+		}
+
 		q("insert into sign (`iid`,`signed_text`,`signature`,`signer`) values (%d,'%s','%s','%s') ",
 			intval($current_post),
 			dbesc($dsprsig->signed_text),


### PR DESCRIPTION
This is better way and place to check for doubled encoded Diaspora signatures that are transmitted via Friendica.