### PR TITLE
Hubzilla comments are now federated

### DIFF
--- a/include/diaspora.php
+++ b/include/diaspora.php
@@ -827,6 +827,10 @@ function diaspora_plink($addr, $guid) {
 }
 
 function diaspora_repair_signature($signature, $handle = "", $level = 1) {
+
+	if ($signature == "")
+		return($signature);
+
 	if (base64_encode(base64_decode(base64_decode($signature))) == base64_decode($signature)) {
 		$signature = base64_decode($signature);
 		logger("Repaired double encoded signature from Diaspora/Hubzilla handle ".$handle." - level ".$level, LOGGER_DEBUG);
@@ -2974,7 +2978,7 @@ function diaspora_send_relay($item,$owner,$contact,$public_batch = false) {
 		'$handle' => xmlify($handle)
 	));
 
-	logger('diaspora_send_relay: base message: ' . $msg, LOGGER_DEBUG);
+	logger('diaspora_send_relay: base message: ' . $msg, LOGGER_DATA);
 	logger('send guid '.$item['guid'], LOGGER_DEBUG);
 
 	$slap = 'xml=' . urlencode(urlencode(diaspora_msg_build($msg,$owner,$contact,$owner['uprvkey'],$contact['pubkey'],$public_batch)));

--- a/include/diaspora.php
+++ b/include/diaspora.php
@@ -1488,7 +1488,8 @@ function diaspora_comment($importer,$xml,$msg) {
 			logger('diaspora_comment: top-level owner verification failed.');
 			return;
 		}
-	} elseif($author_signature) {
+	}
+	else {
 		// If there's no parent_author_signature, then we've received the comment
 		// from the comment creator. In that case, the person is commenting on
 		// our post, so he/she must be a contact of ours and his/her public key
@@ -1500,11 +1501,6 @@ function diaspora_comment($importer,$xml,$msg) {
 			logger('diaspora_comment: comment author verification failed.');
 			return;
 		}
-	}
-
-	if (!$parent_author_signature AND !$author_signature) {
-		logger("No signature in comment. Comment will be rejected.");
-		return;
 	}
 
 	// Phew! Everything checks out. Now create an item.
@@ -2131,7 +2127,7 @@ function diaspora_like($importer,$xml,$msg) {
 			logger('diaspora_like: top-level owner verification failed.');
 			return;
 		}
-	} elseif($author_signature) {
+	} else {
 		// If there's no parent_author_signature, then we've received the like
 		// from the like creator. In that case, the person is "like"ing
 		// our post, so he/she must be a contact of ours and his/her public key
@@ -2145,11 +2141,6 @@ function diaspora_like($importer,$xml,$msg) {
 			logger('diaspora_like: like creator verification failed.');
 			return;
 		}
-	}
-
-	if (!$parent_author_signature AND !$author_signature) {
-		logger("No signature in like. Like will be rejected.");
-		return;
 	}
 
 	// Phew! Everything checks out. Now create an item.

--- a/include/diaspora.php
+++ b/include/diaspora.php
@@ -2836,7 +2836,7 @@ function diaspora_send_followup($item,$owner,$contact,$public_batch = false) {
 	// sign it
 
 	if($like)
-		$signed_text = $item['guid'] . ';' . $target_type . ';' . $parent['guid'] . ';' . $positive . ';' . $myaddr;
+		$signed_text =  $positive . ';' . $item['guid'] . ';' . $target_type . ';' . $parent['guid'] . ';' . $myaddr;
 	else
 		$signed_text = $item['guid'] . ';' . $parent['guid'] . ';' . $text . ';' . $myaddr;
 

--- a/include/threads.php
+++ b/include/threads.php
@@ -66,6 +66,7 @@ function add_thread($itemid, $onlyshadow = false) {
 
 			unset($item[0]['id']);
 			$item[0]['uid'] = 0;
+			$item[0]['origin'] = 0;
 			$item[0]['contact-id'] = get_contact($item[0]['author-link'], 0);
 			$public_shadow = item_store($item[0], false, false, true);
 


### PR DESCRIPTION
There was a problem with comments from Hubzilla on Friendica posts. The Hubzilla XML behaves a little bit different than Diaspora does. It always sends a "parent_author_signature".

We can now cope with this.