### PR TITLE
fix events_reminder popup

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -160,7 +160,9 @@
 			'inline' : true,
 			'transition' : 'elastic'
 		});
-
+		$("a.ajax-popupbox").colorbox({
+			'transition' : 'elastic'
+		});
 
 		/* notifications template */
 		var notifications_tpl= unescape($("#nav-notifications-template[rel=template]").html());

--- a/view/templates/events_reminder.tpl
+++ b/view/templates/events_reminder.tpl
@@ -4,7 +4,7 @@
 <div id="event-wrapper" style="display: none;" ><div id="event-title">{{$event_title}}</div>
 <div id="event-title-end"></div>
 {{foreach $events as $event}}
-<div class="event-list" id="event-{{$event.id}}"> <a class="cboxElement" href="events/?id={{$event.id}}">{{$event.title}}</a> - {{$event.date}} </div>
+<div class="event-list" id="event-{{$event.id}}"> <a class="ajax-popupbox" href="events/?id={{$event.id}}">{{$event.title}}</a> - {{$event.date}} </div>
 {{/foreach}}
 </div>
 {{/if}}


### PR DESCRIPTION
since the colorbox update events won't popup in the events_reminder because the class "cboxElements" don't execute colorbox automatically.

Now there we will have the class "ajax-popupbox" to do this.