### PR TITLE
Remove duplicated contacts with uid=0

### DIFF
--- a/include/Contact.php
+++ b/include/Contact.php
@@ -410,12 +410,12 @@ function get_contact($url, $uid = 0) {
 			return 0;
 	}
 
-	$contact = q("SELECT `id`, `avatar-date` FROM `contact` WHERE `nurl` = '%s' AND `uid` = %d",
+	$contact = q("SELECT `id`, `avatar-date` FROM `contact` WHERE `nurl` = '%s' AND `uid` = %d ORDER BY `id` LIMIT 2",
 			dbesc(normalise_link($url)),
 			intval($uid));
 
 	if (!$contact)
-		$contact = q("SELECT `id`, `avatar-date` FROM `contact` WHERE `alias` IN ('%s', '%s') AND `uid` = %d",
+		$contact = q("SELECT `id`, `avatar-date` FROM `contact` WHERE `alias` IN ('%s', '%s') AND `uid` = %d ORDER BY `id` LIMIT 1",
 				dbesc($url),
 				dbesc(normalise_link($url)),
 				intval($uid));
@@ -439,9 +439,7 @@ function get_contact($url, $uid = 0) {
 	if (!in_array($data["network"], array(NETWORK_DFRN, NETWORK_OSTATUS, NETWORK_DIASPORA)))
 		return 0;
 
-	// tempory programming. Can be deleted after 2015-02-07
-	if (($data["alias"] == "") AND (normalise_link($data["url"]) != normalise_link($url)))
-		$data["alias"] = normalise_link($url);
+	$url = $data["url"];
 
 	if ($contactid == 0) {
 		q("INSERT INTO `contact` (`uid`, `created`, `url`, `nurl`, `addr`, `alias`, `notify`, `poll`,
@@ -470,7 +468,7 @@ function get_contact($url, $uid = 0) {
 			dbesc($data["poco"])
 		);
 
-		$contact = q("SELECT `id` FROM `contact` WHERE `nurl` = '%s' AND `uid` = %d",
+		$contact = q("SELECT `id` FROM `contact` WHERE `nurl` = '%s' AND `uid` = %d ORDER BY `id` LIMIT 2",
 				dbesc(normalise_link($data["url"])),
 				intval($uid));
 		if (!$contact)
@@ -478,6 +476,11 @@ function get_contact($url, $uid = 0) {
 
 		$contactid = $contact[0]["id"];
 	}
+
+	if ((count($contact) > 1) AND ($uid == 0) AND ($contactid != 0) AND ($url != ""))
+		q("DELETE FROM `contact` WHERE `nurl` = '%s' AND `id` != %d",
+			dbesc(normalise_link($url)),
+			intval($contactid));
 
 	require_once("Photo.php");
 

--- a/include/cron.php
+++ b/include/cron.php
@@ -431,7 +431,6 @@ function cron_repair_database() {
 	q("UPDATE `item` INNER JOIN `item` AS `parent` ON `parent`.`uri` = `item`.`parent-uri` AND `parent`.`uid` = `item`.`uid` SET `item`.`parent` = `parent`.`id` WHERE `item`.`parent` = 0");
 
 	/// @todo
-	/// - remove duplicated contacts with uid=0 (We could do this at the place where the contacts are stored)
 	/// - remove thread entries without item
 	/// - remove sign entries without item
 	/// - remove children when parent got lost


### PR DESCRIPTION
Sometimes there are duplicated contacts with the "uid" 0 in the contact table. They are added automatically. It seems as if it caused by some timing problems. We are now handling this situation. 