### PR TITLE
Only proxy URLs using HTTP or HTTPS

### DIFF
--- a/mod/proxy.php
+++ b/mod/proxy.php
@@ -238,6 +238,10 @@ function proxy_url($url, $writemode = false, $size = "") {
 
 	$a = get_app();
 
+	if (substr($url, 0, strlen('http')) !== 'http') {
+		return($url);
+	}
+
 	// Only continue if it isn't a local image and the isn't deactivated
 	if (proxy_is_local_image($url)) {
 		$url = str_replace(normalise_link($a->get_baseurl())."/", $a->get_baseurl()."/", $url);


### PR DESCRIPTION
I found the proxy function was trying to proxy "cid:" URLs, references to attachments in messages sent by the mailstream plugin.  I can't imagine any use for trying to proxy any URL type apart from HTTP and HTTPS - correct me if I'm wrong!