### PR TITLE
Set global redirect URL to original URL in case it succeeds immediately

### DIFF
--- a/include/network.php
+++ b/include/network.php
@@ -156,6 +156,7 @@ function z_fetch_url($url,$binary = false, &$redirects = 0, $opts=array()) {
 	}
 
 
+	$a->set_curl_redirect_url($url);
 	$a->set_curl_code($http_code);
 	$a->set_curl_content_type($curl_info['content_type']);
 


### PR DESCRIPTION
The idea of the curl redirect url was to allow a caller to find out the final URL that was used in a successful request.  Seems I forgot about the case where the requested URL succeeds without any redirects.  This change fixes that.