### PR TITLE
Use more cookies to allow processing of the NYT feed

### DIFF
--- a/include/Scrape.php
+++ b/include/Scrape.php
@@ -235,7 +235,9 @@ function scrape_feed($url) {
 	$a = get_app();
 
 	$ret = array();
-	$s = fetch_url($url);
+	$cookiejar = tempnam('/tmp', 'cookiejar-scrape-feed-');
+	$s = fetch_url($url, false, $redirects, 0, Null, $cookiejar);
+	unlink($cookiejar);
 
 	$headers = $a->get_curl_headers();
 	$code = $a->get_curl_code();
@@ -662,7 +664,9 @@ function probe_url($url, $mode = PROBE_NORMAL, $level = 1) {
 				$vcard['photo'] = $feedret['photo'];
 			require_once('library/simplepie/simplepie.inc');
 			$feed = new SimplePie();
-			$xml = fetch_url($poll);
+			$cookiejar = tempnam('/tmp', 'cookiejar-scrape-feed-');
+			$xml = fetch_url($poll, false, $redirects, 0, Null, $cookiejar);
+			unlink($cookiejar);
 
 			logger('probe_url: fetch feed: ' . $poll . ' returns: ' . $xml, LOGGER_DATA);
 			$a = get_app();

--- a/include/Scrape.php
+++ b/include/Scrape.php
@@ -235,7 +235,7 @@ function scrape_feed($url) {
 	$a = get_app();
 
 	$ret = array();
-	$cookiejar = tempnam('/tmp', 'cookiejar-scrape-feed-');
+	$cookiejar = tempnam(get_temppath(), 'cookiejar-scrape-feed-');
 	$s = fetch_url($url, false, $redirects, 0, Null, $cookiejar);
 	unlink($cookiejar);
 
@@ -664,7 +664,7 @@ function probe_url($url, $mode = PROBE_NORMAL, $level = 1) {
 				$vcard['photo'] = $feedret['photo'];
 			require_once('library/simplepie/simplepie.inc');
 			$feed = new SimplePie();
-			$cookiejar = tempnam('/tmp', 'cookiejar-scrape-feed-');
+			$cookiejar = tempnam(get_temppath(), 'cookiejar-scrape-feed-');
 			$xml = fetch_url($poll, false, $redirects, 0, Null, $cookiejar);
 			unlink($cookiejar);
 

--- a/include/onepoll.php
+++ b/include/onepoll.php
@@ -335,7 +335,9 @@ function onepoll_run(&$argv, &$argc){
 		if($contact['rel'] == CONTACT_IS_FOLLOWER || $contact['blocked'] || $contact['readonly'])
 			return;
 
-		$xml = fetch_url($contact['poll']);
+		$cookiejar = tempnam('/tmp', 'cookiejar-onepoll-');
+		$xml = fetch_url($contact['poll'], false, $redirects, 0, Null, $cookiejar);
+		unlink($cookiejar);
 	}
 	elseif($contact['network'] === NETWORK_MAIL || $contact['network'] === NETWORK_MAIL2) {
 

--- a/include/onepoll.php
+++ b/include/onepoll.php
@@ -335,7 +335,7 @@ function onepoll_run(&$argv, &$argc){
 		if($contact['rel'] == CONTACT_IS_FOLLOWER || $contact['blocked'] || $contact['readonly'])
 			return;
 
-		$cookiejar = tempnam('/tmp', 'cookiejar-onepoll-');
+		$cookiejar = tempnam(get_temppath(), 'cookiejar-onepoll-');
 		$xml = fetch_url($contact['poll'], false, $redirects, 0, Null, $cookiejar);
 		unlink($cookiejar);
 	}


### PR DESCRIPTION
The New York Times uses cookies and a redirect to track users.  Without storing cookies you can't get access to the content.  So use a one-off cookiejar for all feed requests.

Conflicts:

	include/Scrape.php