### PR TITLE
Show contact posts by searching for "contact-id" - not "gcontact-id"

### DIFF
--- a/mod/contacts.php
+++ b/mod/contacts.php
@@ -903,7 +903,10 @@ function contact_posts($a, $contact_id) {
 
 	$o .= $tab_str;
 
-	if ($contact["url"]) {
+	$r = q("SELECT `id` FROM `item` WHERE `contact-id` = %d LIMIT 1", intval($contact_id));
+	if ($r)
+		$o .= posts_from_contact($a, $contact_id);
+	elseif ($contact["url"]) {
 		$r = q("SELECT `id` FROM `gcontact` WHERE `nurl` = '%s' LIMIT 1",
 			dbesc(normalise_link($contact["url"])));
 


### PR DESCRIPTION
I'm not totally happy with this fix but it will solve a problem that @tobiasd reported. He told that he often doesn't see contact posts under /posts/(contact-id)

Before this pull request we queried the new "gcontact-id" entry in the item table. Now - if we have entries - we are querying the "contact-id". Only if there are no entries we will now have a look at the other field.