### PR TITLE
vier: some fixes for mobile view

### DIFF
--- a/include/text.php
+++ b/include/text.php
@@ -1504,7 +1504,7 @@ function prepare_body(&$item,$attach = false, $preview = false) {
 
 		$pos = strpos($s, $spoilersearch);
 		$rnd = random_string(8);
-		$spoilerreplace = '<br /> <span id="spoiler-wrap-'.$rnd.'" style="white-space:nowrap;" class="fakelink" onclick="openClose(\'spoiler-'.$rnd.'\');">'.sprintf(t('Click to open/close')).'</span>'.
+		$spoilerreplace = '<br /> <span id="spoiler-wrap-'.$rnd.'" class="spoiler-wrap fakelink" onclick="openClose(\'spoiler-'.$rnd.'\');">'.sprintf(t('Click to open/close')).'</span>'.
 					'<blockquote class="spoiler" id="spoiler-'.$rnd.'" style="display: none;">';
 		$s = substr($s, 0, $pos).$spoilerreplace.substr($s, $pos+strlen($spoilersearch));
 	}
@@ -1516,7 +1516,7 @@ function prepare_body(&$item,$attach = false, $preview = false) {
 
 		$pos = strpos($s, $authorsearch);
 		$rnd = random_string(8);
-		$authorreplace = '<br /> <span id="author-wrap-'.$rnd.'" style="white-space:nowrap;" class="fakelink" onclick="openClose(\'author-'.$rnd.'\');">'.sprintf(t('Click to open/close')).'</span>'.
+		$authorreplace = '<br /> <span id="author-wrap-'.$rnd.'" class="author-wrap fakelink" onclick="openClose(\'author-'.$rnd.'\');">'.sprintf(t('Click to open/close')).'</span>'.
 					'<blockquote class="author" id="author-'.$rnd.'" style="display: block;">';
 		$s = substr($s, 0, $pos).$authorreplace.substr($s, $pos+strlen($authorsearch));
 	}

--- a/view/theme/vier/mobile.css
+++ b/view/theme/vier/mobile.css
@@ -67,9 +67,22 @@ nav ul {
 
 @media screen and (max-width: 480px) {
   .wall-item-container .wall-item-content img,
-  .children .wall-item-container .wall-item-item .wall-item-content img,
   .wall-item-container .wall-item-content .type-link img.attachment-image, .type-link img.attachment-image, .type-video img.attachment-image {
     max-width: 200px;
+  }
+  /* fix img width in threaded view - maybe there exists a better possibility to do this 
+    maybe this needs also to be done for tablet view*/
+  .children .wall-item-container .wall-item-item .wall-item-content img {
+    max-width: 100%;
+  }
+  iframe {
+    max-width: 100%;
+  }
+
+  /* the top-nav notfication menu
+    Note: the device needs a min display width of 320px */
+  #nav-notifications-menu {
+    width: 270px;
   }
 }
 

--- a/view/theme/vier/style.css
+++ b/view/theme/vier/style.css
@@ -1783,7 +1783,8 @@ section.minimal {
 }
 
 #jot-preview-content {
-  padding-top: 25px;
+  padding-top: 4px;
+  clear: both;
 }
 
 #jot-preview-content .tread-wrapper {


### PR DESCRIPTION
Some little work to make vier more mobile friendly
* images in the thread shouldn't break anymore
* fix for the notification menu issue https://github.com/friendica/friendica/issues/2254 (mobile view is using now smaller fixed width for the notification menu)
* remove hardcoded style (white-space:nowrap) for spoiler-wrap and author-wrap and adding new classes instead (so it can be styled with the theme)
* embedded iframes should break the theme anymore
* post previews should now displayed correctly

Things which are still left:
* the colorbox acl popup - I really don't know how to get this mobile friendly. Maybe @fabrixxm can have a look at this. One possible solution would be to edit colorbox.js (https://github.com/jackmoore/colorbox/issues/158) but I don't like this because we have to remember it if someone wants to update colorbox
* event items are still breaking the theme. To get this in a good way we need to edit `format_event_html()`. I will write something about this at friendica developer forum soon. Maybe I will add a quick&dirty fix in the meantime
* there are many very small other issues left (e.g. the textarea of threaded comments could break mobile view). It's hard to get this small things fixed because vier uses very often fixed width.