### PR TITLE
event_form: use [map] tag to embedd a map

### DIFF
--- a/include/event.php
+++ b/include/event.php
@@ -61,7 +61,7 @@ function format_event_html($ev, $simple = false) {
 			. bbcode($ev['location'])
 			. '</span></p>' . "\r\n";
 
-		if (strpos($ev['location'], "[map")===False) {
+		if (strpos($ev['location'], "[map") !== False) {
 			$map = generate_named_map($ev['location']);
 			if ($map!==$ev['location']) $o.=$map;
 		}


### PR DESCRIPTION
little fix: now the tag [map] beaves the way it was originally intended.

To have an embedded map you need to write `[map]Street City[/map]`


remark:
We need a tool button for this for the average user