### PR TITLE
Poller: Check the number of used database connections

### DIFF
--- a/include/items.php
+++ b/include/items.php
@@ -509,6 +509,16 @@ function item_store($arr,$force_parent = false, $notify = false, $dontcache = fa
 	$arr['inform']        = ((x($arr,'inform'))        ? trim($arr['inform'])                : '');
 	$arr['file']          = ((x($arr,'file'))          ? trim($arr['file'])                  : '');
 
+
+	if (($arr['author-link'] == "") AND ($arr['owner-link'] == "")) {
+		$trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 5);
+		foreach ($trace AS $func)
+		        $function[] = $func["function"];
+
+		$function = implode(", ", $function);
+		logger("Both author-link and owner-link are empty. Called by: ".$function, LOGGER_DEBUG);
+	}
+
 	if ($arr['plink'] == "") {
 		$a = get_app();
 		$arr['plink'] = $a->get_baseurl().'/display/'.urlencode($arr['guid']);


### PR DESCRIPTION
The poller.php now quits if 3/4 of the maximum database connections are reached. This is especially important when using friendica on a shared hoster where you may have only 30 database connections at a time.

Additionally there is an additional (and unrelated) logging for another situation that I have to pin down.