### PR TITLE
Poller: The maximum number of connections can now be configured

### DIFF
--- a/doc/htconfig.md
+++ b/doc/htconfig.md
@@ -34,6 +34,7 @@ line to your .htconfig.php:
 * like_no_comment (Boolean) - Don't update the "commented" value of an item when it is liked.
 * local_block (Boolean) - Used in conjunction with "block_public".
 * local_search (Boolean) - Blocks the search for not logged in users to prevent crawlers from blocking your system.
+* max_connections - The poller process isn't started when 3/4 of the possible database connections are used. When the system can't detect the maximum numbers of connection then this value can be used.
 * max_contact_queue - Default value is 500.
 * max_batch_queue - Default value is 1000.
 * no_oembed (Boolean) - Don't use OEmbed to fetch more information about a link.

--- a/include/dfrn.php
+++ b/include/dfrn.php
@@ -1252,8 +1252,10 @@ class dfrn {
 			 // Update check for this field has to be done differently
 			$datefields = array("name-date", "uri-date");
 			foreach ($datefields AS $field)
-				if (strtotime($contact[$field]) > strtotime($r[0][$field]))
+				if (strtotime($contact[$field]) > strtotime($r[0][$field])) {
+					logger("Difference for contact ".$contact["id"]." in field '".$field."'. Old value: '".$contact[$field]."', new value '".$r[0][$field]."'", LOGGER_DEBUG);
 					$update = true;
+				}
 
 			foreach ($fields AS $field => $data)
 				if ($contact[$field] != $r[0][$field]) {

--- a/include/poller.php
+++ b/include/poller.php
@@ -130,9 +130,14 @@ function poller_max_connections_reached() {
 	if (!$r)
 		return false;
 
-	$max = intval($r[0]["Value"]);
-	if ($max == 0)
-		return false;
+	// Fetch the max value from the config. This is needed when the system cannot detect the correct value by itself.
+	$max = get_config("system", "max_connections");
+
+	if ($max == 0) {
+		$max = intval($r[0]["Value"]);
+		if ($max == 0)
+			return false;
+	}
 
 	$r = q("SHOW STATUS WHERE `variable_name` = 'Threads_connected'");
 	if (!$r)


### PR DESCRIPTION
This has to be done with shared hosters like Uberspace where the system restricts the number of connections although the database could handle some more.