### PR TITLE
Bugfix: The "keywords" field in the gcontact table wasn't set correctly

### DIFF
--- a/include/socgraph.php
+++ b/include/socgraph.php
@@ -139,15 +139,16 @@ function poco_load($cid,$uid = 0,$zcid = 0,$url = null) {
 		poco_check($profile_url, $name, $network, $profile_photo, $about, $location, $gender, $keywords, $connect_url, $updated, $generation, $cid, $uid, $zcid);
 
 		// Update the Friendica contacts. Diaspora is doing it via a message. (See include/diaspora.php)
-		if (($location != "") OR ($about != "") OR ($keywords != "") OR ($gender != ""))
-			q("UPDATE `contact` SET `location` = '%s', `about` = '%s', `keywords` = '%s', `gender` = '%s'
-				WHERE `nurl` = '%s' AND NOT `self` AND `network` = '%s'",
-				dbesc($location),
-				dbesc($about),
-				dbesc($keywords),
-				dbesc($gender),
-				dbesc(normalise_link($profile_url)),
-				dbesc(NETWORK_DFRN));
+		// Deactivated because we now update Friendica contacts in dfrn.php
+		//if (($location != "") OR ($about != "") OR ($keywords != "") OR ($gender != ""))
+		//	q("UPDATE `contact` SET `location` = '%s', `about` = '%s', `keywords` = '%s', `gender` = '%s'
+		//		WHERE `nurl` = '%s' AND NOT `self` AND `network` = '%s'",
+		//		dbesc($location),
+		//		dbesc($about),
+		//		dbesc($keywords),
+		//		dbesc($gender),
+		//		dbesc(normalise_link($profile_url)),
+		//		dbesc(NETWORK_DFRN));
 	}
 	logger("poco_load: loaded $total entries",LOGGER_DEBUG);
 
@@ -1554,7 +1555,7 @@ function update_gcontact($contact) {
 
 	if ($update) {
 		q("UPDATE `gcontact` SET `photo` = '%s', `name` = '%s', `nick` = '%s', `addr` = '%s', `network` = '%s',
-					`birthday` = '%s', `gender` = '%s', `keywords` = %d, `hide` = %d, `nsfw` = %d,
+					`birthday` = '%s', `gender` = '%s', `keywords` = '%s', `hide` = %d, `nsfw` = %d,
 					`alias` = '%s', `notify` = '%s', `url` = '%s',
 					`location` = '%s', `about` = '%s', `generation` = %d, `updated` = '%s',
 					`server_url` = '%s', `connect` = '%s'

--- a/mod/pubsub.php
+++ b/mod/pubsub.php
@@ -122,8 +122,8 @@ function pubsub_post(&$a) {
 
 	$importer = $r[0];
 
-	$r = q("SELECT * FROM `contact` WHERE `subhub` = 1 AND `id` = %d AND `uid` = %d
-		AND ( `rel` = %d OR `rel` = %d OR network = '%s' ) AND `blocked` = 0 AND `readonly` = 0 LIMIT 1",
+	$r = q("SELECT * FROM `contact` WHERE `subhub` AND `id` = %d AND `uid` = %d
+		AND (`rel` = %d OR `rel` = %d OR network = '%s') AND NOT `blocked` LIMIT 1",
 		intval($contact_id),
 		intval($importer['uid']),
 		intval(CONTACT_IS_SHARING),


### PR DESCRIPTION
Additionally I removed the automatic updating of the contact table from the "poco" functionality. We now do this in dfrn.php - this should be enough.

Finally there is a small fix for pubsub: Checking for "readonly" doesn't make sense in this place.