### PR TITLE
DFRN-Bugfix: Forums should work now

### DIFF
--- a/include/dfrn.php
+++ b/include/dfrn.php
@@ -2053,6 +2053,10 @@ class dfrn {
 			if (($item["network"] != $author["network"]) AND ($author["network"] != ""))
 				$item["network"] = $author["network"];
 
+			// This code was taken from the old DFRN code
+			// When activated, forums don't work.
+			// And: Why should we disallow commenting by followers?
+			// the behaviour is now similar to the Diaspora part.
 			//if($importer["rel"] == CONTACT_IS_FOLLOWER) {
 			//	logger("Contact ".$importer["id"]." is only follower. Quitting", LOGGER_DEBUG);
 			//	return;

--- a/include/dfrn.php
+++ b/include/dfrn.php
@@ -2053,10 +2053,10 @@ class dfrn {
 			if (($item["network"] != $author["network"]) AND ($author["network"] != ""))
 				$item["network"] = $author["network"];
 
-			if($importer["rel"] == CONTACT_IS_FOLLOWER) {
-				logger("Contact ".$importer["id"]." is only follower. Quitting", LOGGER_DEBUG);
-				return;
-			}
+			//if($importer["rel"] == CONTACT_IS_FOLLOWER) {
+			//	logger("Contact ".$importer["id"]." is only follower. Quitting", LOGGER_DEBUG);
+			//	return;
+			//}
 		}
 
 		if ($entrytype == DFRN_REPLY_RC) {


### PR DESCRIPTION
There was a problem with forums that ran with the new dfrn code. I do not understand why it worked in the old code :-)

But: I think that deactivating the check was a good decision in any way. Only because people are only following us (and we don't want to read their posts) we shouldn't forbid them to make replies. (This is the same behaviour like from Diaspora)