### PR TITLE
Vier: Pictures in the side bar shouldn't be larger than the side bar

### DIFF
--- a/view/theme/vier/style.css
+++ b/view/theme/vier/style.css
@@ -1141,6 +1141,10 @@ aside h4, right_aside h4 {
   font-size: 1.17em;
 }
 
+aside img {
+  max-width: 175px;
+}
+
 .nets-ul {
   margin-top: 0px;
 }


### PR DESCRIPTION
When a profile image in the side bar is larger than 175 pixel then it broke the design.