### PR TITLE
New BBCode element "abstract" for network depending messages.

### DIFF
--- a/include/bbcode.php
+++ b/include/bbcode.php
@@ -851,9 +851,6 @@ function bbcode($Text,$preserve_nl = false, $tryoembed = true, $simplehtml = fal
 
 	$a = get_app();
 
-	// Remove the abstract element. It is a non visible element.
-	$Text = remove_abstract($Text);
-
 	// Hide all [noparse] contained bbtags by spacefying them
 	// POSSIBLE BUG --> Will the 'preg' functions crash if there's an embedded image?
 
@@ -861,6 +858,8 @@ function bbcode($Text,$preserve_nl = false, $tryoembed = true, $simplehtml = fal
 	$Text = preg_replace_callback("/\[nobb\](.*?)\[\/nobb\]/ism", 'bb_spacefy',$Text);
 	$Text = preg_replace_callback("/\[pre\](.*?)\[\/pre\]/ism", 'bb_spacefy',$Text);
 
+	// Remove the abstract element. It is a non visible element.
+	$Text = remove_abstract($Text);
 
 	// Move all spaces out of the tags
 	$Text = preg_replace("/\[(\w*)\](\s*)/ism", '$2[$1]', $Text);

--- a/include/bbcode.php
+++ b/include/bbcode.php
@@ -851,6 +851,9 @@ function bbcode($Text,$preserve_nl = false, $tryoembed = true, $simplehtml = fal
 
 	$a = get_app();
 
+	// Remove the abstract element. It is a non visible element.
+	$Text = remove_abstract($Text);
+
 	// Hide all [noparse] contained bbtags by spacefying them
 	// POSSIBLE BUG --> Will the 'preg' functions crash if there's an embedded image?
 
@@ -1299,5 +1302,44 @@ function bbcode($Text,$preserve_nl = false, $tryoembed = true, $simplehtml = fal
 	call_hooks('bbcode',$Text);
 
 	return trim($Text);
+}
+
+/**
+ * @brief Removes the "abstract" element from the text
+ *
+ * @param string $text The text with BBCode
+ * @return string The same text - but without "abstract" element
+ */
+function remove_abstract($text) {
+	$text = preg_replace("/[\s|\n]*\[abstract\].*?\[\/abstract\][\s|\n]*/ism", '', $text);
+	$text = preg_replace("/[\s|\n]*\[abstract=.*?\].*?\[\/abstract][\s|\n]*/ism", '', $text);
+
+	return $text;
+}
+
+/**
+ * @brief Returns the value of the "abstract" element
+ *
+ * @param string $text The text that maybe contains the element
+ * @param string $addon The addon for which the abstract is meant for
+ * @return string The abstract
+ */
+function fetch_abstract($text, $addon = "") {
+	$abstract = "";
+	$abstracts = array();
+	$addon = strtolower($addon);
+
+	if (preg_match_all("/\[abstract=(.*?)\](.*?)\[\/abstract\]/ism",$text, $results, PREG_SET_ORDER))
+		foreach ($results AS $result)
+			$abstracts[strtolower($result[1])] = $result[2];
+
+	if (isset($abstracts[$addon]))
+		$abstract = $abstracts[$addon];
+
+	if ($abstract == "")
+		if (preg_match("/\[abstract\](.*?)\[\/abstract\]/ism",$text, $result))
+			$abstract = $result[1];
+
+	return $abstract;
 }
 ?>

--- a/include/dfrn.php
+++ b/include/dfrn.php
@@ -18,6 +18,7 @@ require_once("include/event.php");
 require_once("include/text.php");
 require_once("include/oembed.php");
 require_once("include/html2bbcode.php");
+require_once("include/bbcode.php");
 
 /**
  * @brief This class contain functions to create and send DFRN XML files
@@ -719,6 +720,9 @@ class dfrn {
 			$body = fix_private_photos($item['body'],$owner['uid'],$item,$cid);
 		else
 			$body = $item['body'];
+
+		// Remove the abstract element. It is only locally important.
+		$body = remove_abstract($body);
 
 		if ($type == 'html') {
 			$htmlbody = $body;

--- a/include/plaintext.php
+++ b/include/plaintext.php
@@ -132,6 +132,18 @@ function shortenmsg($msg, $limit, $twitter = false) {
 	return($msg);
 }
 
+/**
+ * @brief Convert a message into plaintext for connectors to other networks
+ *
+ * @param App $a The application class
+ * @param array $b The message array that is about to be posted
+ * @param int $limit The maximum number of characters when posting to that network
+ * @param bool $includedlinks Has an attached link to be included into the message?
+ * @param int $htmlmode This triggers the behaviour of the bbcode conversion
+ * @param string $target_network Name of the network where the post should go to.
+ *
+ * @return string The converted message
+ */
 function plaintext($a, $b, $limit = 0, $includedlinks = false, $htmlmode = 2, $target_network = "") {
 	require_once("include/bbcode.php");
 	require_once("include/html2plain.php");


### PR DESCRIPTION
Crossposts to other (length restricted) networks can now have different texts. So you can be brief to Twitter, less brief to ADN and really long to Friendica:

````
[abstract]This is a short text[/abstract]
[abstract=twit]This is a short test for Twitter[/abstract]
[abstract=stac]This is a short test for the "statusnet" connector[/abstract]
[abstract=apdn]This is a short test for app.net[/abstract]
This is my really long text that will appear on Friendica, GNU Social (via OStatus) and Diaspora.
````