### PR TITLE
$a->theme_info = array() should be avoided

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -465,11 +465,12 @@ class App {
 	public  $plugins;
 	public  $apps = array();
 	public  $identities;
-	public	$is_mobile;
-	public	$is_tablet;
+	public	$is_mobile = false;
+	public	$is_tablet = false;
 	public	$is_friendica_app;
 	public	$performance = array();
 	public	$callstack = array();
+	public	$theme_info = array();
 
 	public $nav_sel;
 

--- a/view/theme/decaf-mobile/theme.php
+++ b/view/theme/decaf-mobile/theme.php
@@ -10,7 +10,6 @@
  */
 
 function decaf_mobile_init(&$a) {
-	$a->theme_info = array();
 	$a->sourcename = 'Friendica mobile web';
 	$a->videowidth = 250;
 	$a->videoheight = 200;

--- a/view/theme/duepuntozero/theme.php
+++ b/view/theme/duepuntozero/theme.php
@@ -2,7 +2,6 @@
 
 function duepuntozero_init(&$a) {
 
-$a->theme_info = array();
 set_template_engine($a, 'smarty3');
 
     $colorset = get_pconfig( local_user(), 'duepuntozero','colorset');

--- a/view/theme/facepark/theme.php
+++ b/view/theme/facepark/theme.php
@@ -1,7 +1,6 @@
 <?php
 
 function facepark_init(&$a) {
-$a->theme_info = array();
 set_template_engine($a, 'smarty3');
 
 $a->page['htmlhead'] .= <<< EOT

--- a/view/theme/frost-mobile/theme.php
+++ b/view/theme/frost-mobile/theme.php
@@ -10,7 +10,6 @@
  */
 
 function frost_mobile_init(&$a) {
-	$a->theme_info = array();
 	$a->sourcename = 'Friendica mobile web';
 	$a->videowidth = 250;
 	$a->videoheight = 200;

--- a/view/theme/frost/theme.php
+++ b/view/theme/frost/theme.php
@@ -10,7 +10,6 @@
  */
 
 function frost_init(&$a) {
-	$a->theme_info = array();
 	$a->videowidth = 400;
 	$a->videoheight = 330;
 	$a->theme_thread_allow = false;

--- a/view/theme/quattro/theme.php
+++ b/view/theme/quattro/theme.php
@@ -8,8 +8,6 @@
  */
 
 function quattro_init(&$a) {
-	$a->theme_info = array();
-
 	$a->page['htmlhead'] .= '<script src="'.$a->get_baseurl().'/view/theme/quattro/tinycon.min.js"></script>';
 	$a->page['htmlhead'] .= '<script src="'.$a->get_baseurl().'/view/theme/quattro/js/quattro.js"></script>';;
 }

--- a/view/theme/smoothly/theme.php
+++ b/view/theme/smoothly/theme.php
@@ -11,7 +11,6 @@
  */
 
 function smoothly_init(&$a) {
-	$a->theme_info = array();
 	set_template_engine($a, 'smarty3');
 
 	$cssFile = null;

--- a/view/theme/vier/theme.php
+++ b/view/theme/vier/theme.php
@@ -19,8 +19,6 @@ function vier_init(&$a) {
 
 	set_template_engine($a, 'smarty3');
 
-	$a->theme_info = array();
-
 	if ($a->argv[0].$a->argv[1] === "profile".$a->user['nickname'] or $a->argv[0] === "network" && local_user()) {
 		vier_community_info();
 


### PR DESCRIPTION
$a is an instance of App, there $theme_info was never created as a class field. This should be avoided and theme_info can be initialized with array() to save same initialization in theme.php files.

Plus this commit also initialized $is_mobile and $is_tablet with default value to FALSE.