### PR TITLE
Missing exit() after header('Location: bla') is bad news

### DIFF
--- a/index.php
+++ b/index.php
@@ -72,7 +72,8 @@ if(!$install) {
 		(intval(get_config('system','ssl_policy')) == SSL_POLICY_FULL) AND
 		(substr($a->get_baseurl(), 0, 8) == "https://")) {
 		header("HTTP/1.1 302 Moved Temporarily");
-		header("location: ".$a->get_baseurl()."/".$a->query_string);
+		header("Location: ".$a->get_baseurl()."/".$a->query_string);
+		exit();
 	}
 
 	require_once("include/session.php");


### PR DESCRIPTION
Don't miss to add exit() after header('Location: bla') as header() does *NOT* exit the script quickly enough, so some lines are executed because the redirect may take some time to finish (and then to abort the script). Always use an explicit exit() or you get real trouble.

Plus HTTP headers are capitalized (_Location_, not _location_).