### PR TITLE
No processing if error or empty array

### DIFF
--- a/include/poller.php
+++ b/include/poller.php
@@ -205,6 +205,12 @@ function poller_max_connections_reached() {
  */
 function poller_kill_stale_workers() {
 	$r = q("SELECT `pid`, `executed` FROM `workerqueue` WHERE `executed` != '0000-00-00 00:00:00'");
+
+	if (!is_array($r) || count($r) == 0) {
+		// No processing here needed
+		return;
+	}
+
 	foreach($r AS $pid)
 		if (!posix_kill($pid["pid"], 0))
 			q("UPDATE `workerqueue` SET `executed` = '0000-00-00 00:00:00', `pid` = 0 WHERE `pid` = %d",


### PR DESCRIPTION
Skip the whole processing if error occurs or no entry in array, this fixes a warning:

````
Warning: Invalid argument supplied for foreach() in /home/.../public_html/friendica/include/poller.php on line 208

Call Stack:
    0.0004     278056   1. {main}() /home/.../public_html/friendica/include/poller.php:0
    0.0228    5116232   2. poller_run() /home/.../public_html/friendica/include/poller.php:265
    0.0309    5149744   3. poller_kill_stale_workers() /home/.../public_html/friendica/include/poller.php:58
````