### PR TITLE
Don't create lock files if the process is called from the poller

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -1098,6 +1098,11 @@ class App {
 		return($this->is_friendica_app);
 	}
 
+	/**
+	 * @brief Checks if the maximum load is reached
+	 *
+	 * @return bool Is the load reached?
+	 */
 	function maxload_reached() {
 
 		$maxsysload = intval(get_config('system', 'maxloadavg'));
@@ -1114,6 +1119,15 @@ class App {
 		return false;
 	}
 
+	/**
+	 * @brief Checks if the process is already running
+	 *
+	 * @param string $taskname The name of the task that will be used for the name of the lockfile
+	 * @param string $task The path and name of the php script
+	 * @param int $timeout The timeout after which a task should be killed
+	 *
+	 * @return bool Is the process running?
+	 */
 	function is_already_running($taskname, $task = "", $timeout = 540) {
 
 		$lockpath = get_lockpath();

--- a/boot.php
+++ b/boot.php
@@ -30,7 +30,7 @@ require_once('include/cache.php');
 require_once('library/Mobile_Detect/Mobile_Detect.php');
 require_once('include/features.php');
 require_once('include/identity.php');
-
+require_once('include/pidfile.php');
 require_once('update.php');
 require_once('include/dbstructure.php');
 
@@ -1098,6 +1098,41 @@ class App {
 		return($this->is_friendica_app);
 	}
 
+	function maxload_reached() {
+
+		$maxsysload = intval(get_config('system', 'maxloadavg'));
+		if ($maxsysload < 1)
+			$maxsysload = 50;
+
+		$load = current_load();
+		if ($load) {
+			if (intval($load) > $maxsysload) {
+				logger('system: load '.$load.' too high.');
+				return true;
+			}
+		}
+		return false;
+	}
+
+	function is_already_running($task, $taskname, $timeout = 540) {
+
+		$lockpath = get_lockpath();
+		if ($lockpath != '') {
+			$pidfile = new pidfile($lockpath, $taskname);
+			if ($pidfile->is_already_running()) {
+				logger("Already running");
+				if ($pidfile->running_time() > $timeout) {
+					$pidfile->kill();
+					logger("killed stale process");
+					// Calling a new instance
+					if ($task != "")
+						proc_run('php', $task);
+				}
+				return true;
+			}
+		}
+		return false;
+	}
 }
 
 /**

--- a/boot.php
+++ b/boot.php
@@ -1114,7 +1114,7 @@ class App {
 		return false;
 	}
 
-	function is_already_running($task, $taskname, $timeout = 540) {
+	function is_already_running($taskname, $task = "", $timeout = 540) {
 
 		$lockpath = get_lockpath();
 		if ($lockpath != '') {

--- a/include/cron.php
+++ b/include/cron.php
@@ -43,7 +43,7 @@ function cron_run(&$argv, &$argc){
 	if (App::callstack() != "poller_run") {
 		if (App::maxload_reached())
 			return;
-		if (App::is_already_running('include/cron.php', 'cron', 540))
+		if (App::is_already_running('cron', 'include/cron.php', 540))
 			return;
 	}
 

--- a/include/cronhooks.php
+++ b/include/cronhooks.php
@@ -27,7 +27,7 @@ function cronhooks_run(&$argv, &$argc){
 	if (App::callstack() != "poller_run") {
 		if (App::maxload_reached())
 			return;
-		if (App::is_already_running('include/cronhooks.php', 'cronhooks', 1140))
+		if (App::is_already_running('cronhooks', 'include/cronhooks.php', 1140))
 			return;
 	}
 

--- a/include/delivery.php
+++ b/include/delivery.php
@@ -57,17 +57,8 @@ function delivery_run(&$argv, &$argc){
 			continue;
 		}
 
-		$maxsysload = intval(get_config('system','maxloadavg'));
-		if($maxsysload < 1)
-			$maxsysload = 50;
-
-		$load = current_load();
-		if($load) {
-			if(intval($load) > $maxsysload) {
-				logger('system: load ' . $load . ' too high. Delivery deferred to next queue run.');
-				return;
-			}
-		}
+		if (App::maxload_reached())
+			return;
 
 		// It's ours to deliver. Remove it from the queue.
 

--- a/include/discover_poco.php
+++ b/include/discover_poco.php
@@ -20,25 +20,14 @@ function discover_poco_run(&$argv, &$argc){
 
 	require_once('include/session.php');
 	require_once('include/datetime.php');
-	require_once('include/pidfile.php');
 
 	load_config('config');
 	load_config('system');
 
 	// Don't check this stuff if the function is called by the poller
-	if (App::callstack() != "poller_run") {
-		$maxsysload = intval(get_config('system','maxloadavg'));
-		if($maxsysload < 1)
-			$maxsysload = 50;
-
-		$load = current_load();
-		if($load) {
-			if(intval($load) > $maxsysload) {
-				logger('system: load '.$load.' too high. discover_poco deferred to next scheduled run.');
-				return;
-			}
-		}
-	}
+	if (App::callstack() != "poller_run")
+		if (App::maxload_reached())
+			return;
 
 	if(($argc > 2) && ($argv[1] == "dirsearch")) {
 		$search = urldecode($argv[2]);
@@ -54,23 +43,9 @@ function discover_poco_run(&$argv, &$argc){
 		die("Unknown or missing parameter ".$argv[1]."\n");
 
 	// Don't check this stuff if the function is called by the poller
-	if (App::callstack() != "poller_run") {
-		$lockpath = get_lockpath();
-		if ($lockpath != '') {
-			$pidfile = new pidfile($lockpath, 'discover_poco'.$mode.urlencode($search));
-			if($pidfile->is_already_running()) {
-				logger("discover_poco: Already running");
-				if ($pidfile->running_time() > 19*60) {
-					$pidfile->kill();
-					logger("discover_poco: killed stale process");
-					// Calling a new instance
-					if ($mode == 0)
-						proc_run('php','include/discover_poco.php');
-				}
-				exit;
-			}
-		}
-	}
+	if (App::callstack() != "poller_run")
+		if (App::is_already_running('include/discover_poco.php', 'discover_poco'.$mode.urlencode($search), 1140))
+			return;
 
 	$a->set_baseurl(get_config('system','url'));
 

--- a/include/discover_poco.php
+++ b/include/discover_poco.php
@@ -44,7 +44,7 @@ function discover_poco_run(&$argv, &$argc){
 
 	// Don't check this stuff if the function is called by the poller
 	if (App::callstack() != "poller_run")
-		if (App::is_already_running('include/discover_poco.php', 'discover_poco'.$mode.urlencode($search), 1140))
+		if (App::is_already_running('discover_poco'.$mode.urlencode($search), 'include/discover_poco.php', 1140))
 			return;
 
 	$a->set_baseurl(get_config('system','url'));

--- a/include/onepoll.php
+++ b/include/onepoll.php
@@ -60,16 +60,19 @@ function onepoll_run(&$argv, &$argc){
 		return;
 	}
 
-	$lockpath = get_lockpath();
-	if ($lockpath != '') {
-		$pidfile = new pidfile($lockpath, 'onepoll'.$contact_id);
-		if ($pidfile->is_already_running()) {
-			logger("onepoll: Already running for contact ".$contact_id);
-			if ($pidfile->running_time() > 9*60) {
-				$pidfile->kill();
-				logger("killed stale process");
+	// Don't check this stuff if the function is called by the poller
+	if (App::callstack() != "poller_run") {
+		$lockpath = get_lockpath();
+		if ($lockpath != '') {
+			$pidfile = new pidfile($lockpath, 'onepoll'.$contact_id);
+			if ($pidfile->is_already_running()) {
+				logger("onepoll: Already running for contact ".$contact_id);
+				if ($pidfile->running_time() > 9*60) {
+					$pidfile->kill();
+					logger("killed stale process");
+				}
+				exit;
 			}
-			exit;
 		}
 	}
 

--- a/include/onepoll.php
+++ b/include/onepoll.php
@@ -31,7 +31,6 @@ function onepoll_run(&$argv, &$argc){
 	require_once('include/Contact.php');
 	require_once('include/email.php');
 	require_once('include/socgraph.php');
-	require_once('include/pidfile.php');
 	require_once('include/queue_fn.php');
 
 	load_config('config');
@@ -61,20 +60,9 @@ function onepoll_run(&$argv, &$argc){
 	}
 
 	// Don't check this stuff if the function is called by the poller
-	if (App::callstack() != "poller_run") {
-		$lockpath = get_lockpath();
-		if ($lockpath != '') {
-			$pidfile = new pidfile($lockpath, 'onepoll'.$contact_id);
-			if ($pidfile->is_already_running()) {
-				logger("onepoll: Already running for contact ".$contact_id);
-				if ($pidfile->running_time() > 9*60) {
-					$pidfile->kill();
-					logger("killed stale process");
-				}
-				exit;
-			}
-		}
-	}
+	if (App::callstack() != "poller_run")
+		if (App::is_already_running('', 'onepoll'.$contact_id, 540))
+			return;
 
 	$d = datetime_convert();
 

--- a/include/onepoll.php
+++ b/include/onepoll.php
@@ -61,7 +61,7 @@ function onepoll_run(&$argv, &$argc){
 
 	// Don't check this stuff if the function is called by the poller
 	if (App::callstack() != "poller_run")
-		if (App::is_already_running('', 'onepoll'.$contact_id, 540))
+		if (App::is_already_running('onepoll'.$contact_id, '', 540))
 			return;
 
 	$d = datetime_convert();

--- a/include/poller.php
+++ b/include/poller.php
@@ -29,17 +29,8 @@ function poller_run(&$argv, &$argc){
 	if (poller_max_connections_reached())
 		return;
 
-	$load = current_load();
-	if($load) {
-		$maxsysload = intval(get_config('system','maxloadavg'));
-		if($maxsysload < 1)
-			$maxsysload = 50;
-
-		if(intval($load) > $maxsysload) {
-			logger('system: load ' . $load . ' too high. poller deferred to next scheduled run.');
-			return;
-		}
-	}
+	if (App::maxload_reached())
+		return;
 
 	// Checking the number of workers
 	if (poller_too_much_workers(1)) {

--- a/include/pubsubpublish.php
+++ b/include/pubsubpublish.php
@@ -79,18 +79,21 @@ function pubsubpublish_run(&$argv, &$argc){
 	load_config('config');
 	load_config('system');
 
-	$lockpath = get_lockpath();
-	if ($lockpath != '') {
-		$pidfile = new pidfile($lockpath, 'pubsubpublish');
-		if($pidfile->is_already_running()) {
-			logger("Already running");
-			if ($pidfile->running_time() > 9*60) {
-				$pidfile->kill();
-				logger("killed stale process");
-				// Calling a new instance
-				proc_run('php',"include/pubsubpublish.php");
+	// Don't check this stuff if the function is called by the poller
+	if (App::callstack() != "poller_run") {
+		$lockpath = get_lockpath();
+		if ($lockpath != '') {
+			$pidfile = new pidfile($lockpath, 'pubsubpublish');
+			if($pidfile->is_already_running()) {
+				logger("Already running");
+				if ($pidfile->running_time() > 9*60) {
+					$pidfile->kill();
+					logger("killed stale process");
+					// Calling a new instance
+					proc_run('php',"include/pubsubpublish.php");
+				}
+				return;
 			}
-			return;
 		}
 	}
 

--- a/include/pubsubpublish.php
+++ b/include/pubsubpublish.php
@@ -74,28 +74,14 @@ function pubsubpublish_run(&$argv, &$argc){
 	};
 
 	require_once('include/items.php');
-	require_once('include/pidfile.php');
 
 	load_config('config');
 	load_config('system');
 
 	// Don't check this stuff if the function is called by the poller
-	if (App::callstack() != "poller_run") {
-		$lockpath = get_lockpath();
-		if ($lockpath != '') {
-			$pidfile = new pidfile($lockpath, 'pubsubpublish');
-			if($pidfile->is_already_running()) {
-				logger("Already running");
-				if ($pidfile->running_time() > 9*60) {
-					$pidfile->kill();
-					logger("killed stale process");
-					// Calling a new instance
-					proc_run('php',"include/pubsubpublish.php");
-				}
-				return;
-			}
-		}
-	}
+	if (App::callstack() != "poller_run")
+		if (App::is_already_running("include/pubsubpublish.php", 'pubsubpublish', 540))
+			return;
 
 	$a->set_baseurl(get_config('system','url'));
 

--- a/include/pubsubpublish.php
+++ b/include/pubsubpublish.php
@@ -80,7 +80,7 @@ function pubsubpublish_run(&$argv, &$argc){
 
 	// Don't check this stuff if the function is called by the poller
 	if (App::callstack() != "poller_run")
-		if (App::is_already_running("include/pubsubpublish.php", 'pubsubpublish', 540))
+		if (App::is_already_running("pubsubpublish", "include/pubsubpublish.php", 540))
 			return;
 
 	$a->set_baseurl(get_config('system','url'));

--- a/include/queue.php
+++ b/include/queue.php
@@ -22,29 +22,15 @@ function queue_run(&$argv, &$argc){
 	require_once("include/datetime.php");
 	require_once('include/items.php');
 	require_once('include/bbcode.php');
-	require_once('include/pidfile.php');
 	require_once('include/socgraph.php');
 
 	load_config('config');
 	load_config('system');
 
 	// Don't check this stuff if the function is called by the poller
-	if (App::callstack() != "poller_run") {
-		$lockpath = get_lockpath();
-		if ($lockpath != '') {
-			$pidfile = new pidfile($lockpath, 'queue');
-			if($pidfile->is_already_running()) {
-				logger("queue: Already running");
-				if ($pidfile->running_time() > 9*60) {
-					$pidfile->kill();
-					logger("queue: killed stale process");
-					// Calling a new instance
-					proc_run('php',"include/queue.php");
-				}
-				return;
-			}
-		}
-	}
+	if (App::callstack() != "poller_run")
+		if (App::is_already_running('include/queue.php', 'queue', 540))
+			return;
 
 	$a->set_baseurl(get_config('system','url'));
 

--- a/include/queue.php
+++ b/include/queue.php
@@ -29,7 +29,7 @@ function queue_run(&$argv, &$argc){
 
 	// Don't check this stuff if the function is called by the poller
 	if (App::callstack() != "poller_run")
-		if (App::is_already_running('include/queue.php', 'queue', 540))
+		if (App::is_already_running('queue', 'include/queue.php', 540))
 			return;
 
 	$a->set_baseurl(get_config('system','url'));

--- a/include/queue.php
+++ b/include/queue.php
@@ -28,18 +28,21 @@ function queue_run(&$argv, &$argc){
 	load_config('config');
 	load_config('system');
 
-	$lockpath = get_lockpath();
-	if ($lockpath != '') {
-		$pidfile = new pidfile($lockpath, 'queue');
-		if($pidfile->is_already_running()) {
-			logger("queue: Already running");
-			if ($pidfile->running_time() > 9*60) {
-				$pidfile->kill();
-				logger("queue: killed stale process");
-				// Calling a new instance
-				proc_run('php',"include/queue.php");
+	// Don't check this stuff if the function is called by the poller
+	if (App::callstack() != "poller_run") {
+		$lockpath = get_lockpath();
+		if ($lockpath != '') {
+			$pidfile = new pidfile($lockpath, 'queue');
+			if($pidfile->is_already_running()) {
+				logger("queue: Already running");
+				if ($pidfile->running_time() > 9*60) {
+					$pidfile->kill();
+					logger("queue: killed stale process");
+					// Calling a new instance
+					proc_run('php',"include/queue.php");
+				}
+				return;
 			}
-			return;
 		}
 	}
 

--- a/include/update_gcontact.php
+++ b/include/update_gcontact.php
@@ -37,16 +37,19 @@ function update_gcontact_run(&$argv, &$argc){
 		return;
 	}
 
-	$lockpath = get_lockpath();
-	if ($lockpath != '') {
-		$pidfile = new pidfile($lockpath, 'update_gcontact'.$contact_id);
-		if ($pidfile->is_already_running()) {
-			logger("update_gcontact: Already running for contact ".$contact_id);
-			if ($pidfile->running_time() > 9*60) {
-				$pidfile->kill();
-				logger("killed stale process");
+	// Don't check this stuff if the function is called by the poller
+	if (App::callstack() != "poller_run") {
+		$lockpath = get_lockpath();
+		if ($lockpath != '') {
+			$pidfile = new pidfile($lockpath, 'update_gcontact'.$contact_id);
+			if ($pidfile->is_already_running()) {
+				logger("update_gcontact: Already running for contact ".$contact_id);
+				if ($pidfile->running_time() > 9*60) {
+					$pidfile->kill();
+					logger("killed stale process");
+				}
+				exit;
 			}
-			exit;
 		}
 	}
 

--- a/include/update_gcontact.php
+++ b/include/update_gcontact.php
@@ -38,7 +38,7 @@ function update_gcontact_run(&$argv, &$argc){
 
 	// Don't check this stuff if the function is called by the poller
 	if (App::callstack() != "poller_run")
-		if (App::is_already_running('', 'update_gcontact'.$contact_id, 540))
+		if (App::is_already_running('update_gcontact'.$contact_id, '', 540))
 			return;
 
 	$r = q("SELECT * FROM `gcontact` WHERE `id` = %d", intval($contact_id));

--- a/include/update_gcontact.php
+++ b/include/update_gcontact.php
@@ -16,7 +16,6 @@ function update_gcontact_run(&$argv, &$argc){
 		unset($db_host, $db_user, $db_pass, $db_data);
 	};
 
-	require_once('include/pidfile.php');
 	require_once('include/Scrape.php');
 	require_once("include/socgraph.php");
 
@@ -38,20 +37,9 @@ function update_gcontact_run(&$argv, &$argc){
 	}
 
 	// Don't check this stuff if the function is called by the poller
-	if (App::callstack() != "poller_run") {
-		$lockpath = get_lockpath();
-		if ($lockpath != '') {
-			$pidfile = new pidfile($lockpath, 'update_gcontact'.$contact_id);
-			if ($pidfile->is_already_running()) {
-				logger("update_gcontact: Already running for contact ".$contact_id);
-				if ($pidfile->running_time() > 9*60) {
-					$pidfile->kill();
-					logger("killed stale process");
-				}
-				exit;
-			}
-		}
-	}
+	if (App::callstack() != "poller_run")
+		if (App::is_already_running('', 'update_gcontact'.$contact_id, 540))
+			return;
 
 	$r = q("SELECT * FROM `gcontact` WHERE `id` = %d", intval($contact_id));
 


### PR DESCRIPTION
The lock files were created in the past to prevent that multiple instances of the same process ran at the same time. This check isn't needed when the worker is used, since the worker does this check on its own.

Accidentally there is a little fix for the OStatus thread completion included.