### PR TITLE
Add the guid to items that we create locally

### DIFF
--- a/include/like.php
+++ b/include/like.php
@@ -196,6 +196,7 @@ EOT;
 
 	$arr = array();
 
+	$arr['guid'] = get_guid(32);
 	$arr['uri'] = $uri;
 	$arr['uid'] = $owner_uid;
 	$arr['contact-id'] = $contact['id'];

--- a/mod/dfrn_confirm.php
+++ b/mod/dfrn_confirm.php
@@ -448,6 +448,7 @@ function dfrn_confirm_post(&$a,$handsfree = null) {
 				if(count($self)) {
 
 					$arr = array();
+					$arr['guid'] = get_guid(32);
 					$arr['uri'] = $arr['parent-uri'] = item_new_uri($a->get_hostname(), $uid);
 					$arr['uid'] = $uid;
 					$arr['contact-id'] = $self[0]['id'];
@@ -466,7 +467,7 @@ function dfrn_confirm_post(&$a,$handsfree = null) {
 					$BPhoto = '[url=' . $contact['url'] . ']' . '[img]' . $contact['thumb'] . '[/img][/url]';
 
 					$arr['verb'] = ACTIVITY_FRIEND;
-				    $arr['object-type'] = ACTIVITY_OBJ_PERSON;
+					$arr['object-type'] = ACTIVITY_OBJ_PERSON;
 					$arr['body'] =  sprintf( t('%1$s is now friends with %2$s'), $A, $B)."\n\n\n".$BPhoto;
 
 					$arr['object'] = '<object><type>' . ACTIVITY_OBJ_PERSON . '</type><title>' . $contact['name'] . '</title>'

--- a/mod/mood.php
+++ b/mod/mood.php
@@ -62,7 +62,7 @@ function mood_init(&$a) {
 	$action = sprintf( t('%1$s is currently %2$s'), '[url=' . $poster['url'] . ']' . $poster['name'] . '[/url]' , $verbs[$verb]); 
 
 	$arr = array();
-
+	$arr['guid']          = get_guid(32);
 	$arr['uid']           = $uid;
 	$arr['uri']           = $uri;
 	$arr['parent-uri']    = (($parent_uri) ? $parent_uri : $uri);

--- a/mod/photos.php
+++ b/mod/photos.php
@@ -488,7 +488,7 @@ function photos_post(&$a) {
 			$uri = item_new_uri($a->get_hostname(),$page_owner_uid);
 
 			$arr = array();
-
+			$arr['guid']          = get_guid(32);
 			$arr['uid']           = $page_owner_uid;
 			$arr['uri']           = $uri;
 			$arr['parent-uri']    = $uri;
@@ -677,7 +677,7 @@ function photos_post(&$a) {
 					$uri = item_new_uri($a->get_hostname(),$page_owner_uid);
 
 					$arr = array();
-
+					$arr['guid']          = get_guid(32);
 					$arr['uid']           = $page_owner_uid;
 					$arr['uri']           = $uri;
 					$arr['parent-uri']    = $uri;
@@ -904,6 +904,7 @@ function photos_post(&$a) {
 	if($lat && $lon)
 		$arr['coord'] = $lat . ' ' . $lon;
 
+	$arr['guid']          = get_guid(32);
 	$arr['uid']           = $page_owner_uid;
 	$arr['uri']           = $uri;
 	$arr['parent-uri']    = $uri;

--- a/mod/poke.php
+++ b/mod/poke.php
@@ -91,6 +91,7 @@ function poke_init(&$a) {
 
 	$arr = array();
 
+	$arr['guid']          = get_guid(32);
 	$arr['uid']           = $uid;
 	$arr['uri']           = $uri;
 	$arr['parent-uri']    = (($parent_uri) ? $parent_uri : $uri);

--- a/mod/profiles.php
+++ b/mod/profiles.php
@@ -526,6 +526,8 @@ function profile_activity($changed, $value) {
 		return;
 
 	$arr = array();
+
+	$arr['guid'] = get_guid(32);
 	$arr['uri'] = $arr['parent-uri'] = item_new_uri($a->get_hostname(), local_user());
 	$arr['uid'] = local_user();
 	$arr['contact-id'] = $self[0]['id'];

--- a/mod/subthread.php
+++ b/mod/subthread.php
@@ -103,10 +103,11 @@ EOT;
 	$bodyverb = t('%1$s is following %2$s\'s %3$s');
 
 	if(! isset($bodyverb))
-			return; 
+			return;
 
 	$arr = array();
 
+	$arr['guid'] = get_guid(32);
 	$arr['uri'] = $uri;
 	$arr['uid'] = $owner_uid;
 	$arr['contact-id'] = $contact['id'];
@@ -123,7 +124,7 @@ EOT;
 	$arr['author-name'] = $contact['name'];
 	$arr['author-link'] = $contact['url'];
 	$arr['author-avatar'] = $contact['thumb'];
-	
+
 	$ulink = '[url=' . $contact['url'] . ']' . $contact['name'] . '[/url]';
 	$alink = '[url=' . $item['author-link'] . ']' . $item['author-name'] . '[/url]';
 	$plink = '[url=' . $a->get_baseurl() . '/display/' . $owner['nickname'] . '/' . $item['id'] . ']' . $post_type . '[/url]';

--- a/mod/tagger.php
+++ b/mod/tagger.php
@@ -95,12 +95,13 @@ EOT;
 	$bodyverb = t('%1$s tagged %2$s\'s %3$s with %4$s');
 
 	if(! isset($bodyverb))
-			return; 
+			return;
 
 	$termlink = html_entity_decode('&#x2317;') . '[url=' . $a->get_baseurl() . '/search?tag=' . urlencode($term) . ']'. $term . '[/url]';
 
 	$arr = array();
 
+	$arr['guid'] = get_guid(32);
 	$arr['uri'] = $uri;
 	$arr['uid'] = $owner_uid;
 	$arr['contact-id'] = $contact['id'];
@@ -115,7 +116,7 @@ EOT;
 	$arr['author-name'] = $contact['name'];
 	$arr['author-link'] = $contact['url'];
 	$arr['author-avatar'] = $contact['thumb'];
-	
+
 	$ulink = '[url=' . $contact['url'] . ']' . $contact['name'] . '[/url]';
 	$alink = '[url=' . $item['author-link'] . ']' . $item['author-name'] . '[/url]';
 	$plink = '[url=' . $item['plink'] . ']' . $post_type . '[/url]';


### PR DESCRIPTION
There are several items that we create locally and distribute to remote systems. The guid format for these items should follow the rule from mod/item.php - that differs from the guid format for items that come from remote systems that don't send guids.