### PR TITLE
OStatus: Likes do work more reliable, alias should be okay now

### DIFF
--- a/include/Scrape.php
+++ b/include/Scrape.php
@@ -23,13 +23,15 @@ function scrape_dfrn($url, $dont_probe = false) {
 		if (is_array($noscrapedata)) {
 			if ($noscrapedata["nick"] != "")
 				return($noscrapedata);
+			else
+				unset($noscrapedata["nick"]);
 		} else
 			$noscrapedata = array();
 	}
 
 	$s = fetch_url($url);
 
-	if(! $s)
+	if (!$s)
 		return $ret;
 
 	if (!$dont_probe) {
@@ -703,6 +705,9 @@ function probe_url($url, $mode = PROBE_NORMAL, $level = 1) {
 					if (($vcard["nick"] == "") AND ($data["header"]["author-nick"] != ""))
 						$vcard["nick"] = $data["header"]["author-nick"];
 
+					if (($network == NETWORK_OSTATUS) AND ($data["header"]["author-id"] != ""))
+						$alias = $data["header"]["author-id"];
+
 					if(!$profile AND ($data["header"]["author-link"] != "") AND !in_array($network, array("", NETWORK_FEED)))
 						$profile = $data["header"]["author-link"];
 				}
@@ -844,13 +849,17 @@ function probe_url($url, $mode = PROBE_NORMAL, $level = 1) {
 		/// The biggest problem is the avatar picture that could have a reduced image size.
 		/// It should only be updated if the existing picture isn't existing anymore.
 		if (($result['network'] != NETWORK_FEED) AND ($mode == PROBE_NORMAL) AND
-			$result["addr"] AND $result["name"] AND $result["nick"])
-			q("UPDATE `contact` SET `addr` = '%s', `alias` = '%s', `name` = '%s', `nick` = '%s',
-				`success_update` = '%s' WHERE `nurl` = '%s' AND NOT `self` AND `uid` = 0",
-				dbesc($result["addr"]),
-				dbesc($result["alias"]),
+			$result["name"] AND $result["nick"] AND $result["url"] AND $result["addr"] AND $result["poll"])
+			q("UPDATE `contact` SET `name` = '%s', `nick` = '%s', `url` = '%s', `addr` = '%s',
+					`notify` = '%s', `poll` = '%s', `alias` = '%s', `success_update` = '%s'
+				WHERE `nurl` = '%s' AND NOT `self` AND `uid` = 0",
 				dbesc($result["name"]),
 				dbesc($result["nick"]),
+				dbesc($result["url"]),
+				dbesc($result["addr"]),
+				dbesc($result["notify"]),
+				dbesc($result["poll"]),
+				dbesc($result["alias"]),
 				dbesc(datetime_convert()),
 				dbesc(normalise_link($result['url']))
 		);

--- a/include/cron.php
+++ b/include/cron.php
@@ -405,6 +405,9 @@ function cron_repair_database() {
 	// This call is very "cheap" so we can do it at any time without a problem
 	q("UPDATE `item` INNER JOIN `item` AS `parent` ON `parent`.`uri` = `item`.`parent-uri` AND `parent`.`uid` = `item`.`uid` SET `item`.`parent` = `parent`.`id` WHERE `item`.`parent` = 0");
 
+	// There was an issue where the nick vanishes from the contact table
+	q("UPDATE `contact` INNER JOIN `user` ON `contact`.`uid` = `user`.`uid` SET `nick` = `nickname` WHERE `self` AND `nick`=''");
+
 	/// @todo
 	/// - remove thread entries without item
 	/// - remove sign entries without item

--- a/include/feed.php
+++ b/include/feed.php
@@ -54,8 +54,10 @@ function feed_import($xml,$importer,&$contact, &$hub, $simulate = false) {
 				if ($attributes->name == "href")
 					$author["author-link"] = $attributes->textContent;
 
+		$author["author-id"] = $xpath->evaluate('/atom:feed/atom:author/atom:uri/text()')->item(0)->nodeValue;
+
 		if ($author["author-link"] == "")
-			$author["author-link"] = $xpath->evaluate('/atom:feed/atom:author/atom:uri/text()')->item(0)->nodeValue;
+			$author["author-link"] = $author["author-id"];
 
 		if ($author["author-link"] == "") {
 			$self = $xpath->query("atom:link[@rel='self']")->item(0)->attributes;
@@ -127,6 +129,7 @@ function feed_import($xml,$importer,&$contact, &$hub, $simulate = false) {
 
 		// This is no field in the item table. So we have to unset it.
 		unset($author["author-nick"]);
+		unset($author["author-id"]);
 	}
 
 	$header = array();

--- a/include/ostatus.php
+++ b/include/ostatus.php
@@ -149,12 +149,11 @@ class ostatus {
 			if ($cid) {
 				// Update it with the current values
 				q("UPDATE `contact` SET `url` = '%s', `name` = '%s', `nick` = '%s', `alias` = '%s',
-						`about` = '%s', `location` = '%s', `notify` = '%s', `poll` = '%s',
+						`about` = '%s', `location` = '%s',
 						`success_update` = '%s', `last-update` = '%s'
 					WHERE `id` = %d",
 					dbesc($author["author-link"]), dbesc($contact["name"]), dbesc($contact["nick"]),
 					dbesc($contact["alias"]), dbesc($contact["about"]), dbesc($contact["location"]),
-					dbesc($contact["notify"]), dbesc($contact["poll"]),
 					dbesc(datetime_convert()), dbesc(datetime_convert()), intval($cid));
 
 				// Update the avatar

--- a/include/ostatus.php
+++ b/include/ostatus.php
@@ -44,8 +44,7 @@ class ostatus {
 		$author["author-link"] = $xpath->evaluate('atom:author/atom:uri/text()', $context)->item(0)->nodeValue;
 		$author["author-name"] = $xpath->evaluate('atom:author/atom:name/text()', $context)->item(0)->nodeValue;
 
-		// Preserve the value
-		$authorlink = $author["author-link"];
+		$aliaslink = $author["author-link"];
 
 		$alternate = $xpath->query("atom:author/atom:link[@rel='alternate']", $context)->item(0)->attributes;
 		if (is_object($alternate))
@@ -55,7 +54,7 @@ class ostatus {
 
 		$r = q("SELECT * FROM `contact` WHERE `uid` = %d AND `nurl` IN ('%s', '%s') AND `network` != '%s'",
 			intval($importer["uid"]), dbesc(normalise_link($author["author-link"])),
-			dbesc(normalise_link($authorlink)), dbesc(NETWORK_STATUSNET));
+			dbesc(normalise_link($aliaslink)), dbesc(NETWORK_STATUSNET));
 		if ($r) {
 			$contact = $r[0];
 			$author["contact-id"] = $r[0]["id"];
@@ -117,12 +116,14 @@ class ostatus {
 			if ($value != "")
 				$contact["location"] = $value;
 
-			if (($contact["name"] != $r[0]["name"]) OR ($contact["nick"] != $r[0]["nick"]) OR ($contact["about"] != $r[0]["about"]) OR ($contact["location"] != $r[0]["location"])) {
+			if (($contact["name"] != $r[0]["name"]) OR ($contact["nick"] != $r[0]["nick"]) OR ($contact["about"] != $r[0]["about"]) OR
+				($contact["alias"] != $r[0]["alias"]) OR ($contact["location"] != $r[0]["location"])) {
 
 				logger("Update contact data for contact ".$contact["id"], LOGGER_DEBUG);
 
-				q("UPDATE `contact` SET `name` = '%s', `nick` = '%s', `about` = '%s', `location` = '%s', `name-date` = '%s' WHERE `id` = %d",
-					dbesc($contact["name"]), dbesc($contact["nick"]), dbesc($contact["about"]), dbesc($contact["location"]),
+				q("UPDATE `contact` SET `name` = '%s', `nick` = '%s', `alias` = '%s', `about` = '%s', `location` = '%s', `name-date` = '%s' WHERE `id` = %d",
+					dbesc($contact["name"]), dbesc($contact["nick"]), dbesc($contact["alias"]),
+					dbesc($contact["about"]), dbesc($contact["location"]),
 					dbesc(datetime_convert()), intval($contact["id"]));
 
 				poco_check($contact["url"], $contact["name"], $contact["network"], $author["author-avatar"], $contact["about"], $contact["location"],

--- a/mod/noscrape.php
+++ b/mod/noscrape.php
@@ -28,7 +28,7 @@ function noscrape_init(&$a) {
 	$json_info = array(
 		'fn' => $a->profile['name'],
 		'addr' => $a->profile['addr'],
-		'nick' => $a->user['nickname'],
+		'nick' => $which,
 		'key' => $a->profile['pubkey'],
 		'homepage' => $a->get_baseurl()."/profile/{$which}",
 		'comm' => (x($a->profile,'page-flags')) && ($a->profile['page-flags'] == PAGE_COMMUNITY),


### PR DESCRIPTION
The "alias" field is now fetched more reliable. Instead of having the choices between different aliases, we now take the field from the feed and when we receive messages.

The other part concerns "Likes" that now seems to work fine. We transport them now via "salmon".

And there was some bug concerning the nickname in "noscrape" which is fixed now as well.