### PR TITLE
Scrape: Changed detection for the profile link

### DIFF
--- a/include/Scrape.php
+++ b/include/Scrape.php
@@ -705,10 +705,14 @@ function probe_url($url, $mode = PROBE_NORMAL, $level = 1) {
 					if (($vcard["nick"] == "") AND ($data["header"]["author-nick"] != ""))
 						$vcard["nick"] = $data["header"]["author-nick"];
 
-					if (($network == NETWORK_OSTATUS) AND ($data["header"]["author-id"] != ""))
-						$alias = $data["header"]["author-id"];
+					if ($network == NETWORK_OSTATUS) {
+						if ($data["header"]["author-id"] != "")
+							$alias = $data["header"]["author-id"];
 
-					if(!$profile AND ($data["header"]["author-link"] != "") AND !in_array($network, array("", NETWORK_FEED)))
+						if ($data["header"]["author-link"] != "")
+							$profile = $data["header"]["author-link"];
+
+					} elseif(!$profile AND ($data["header"]["author-link"] != "") AND !in_array($network, array("", NETWORK_FEED)))
 						$profile = $data["header"]["author-link"];
 				}
 			}


### PR DESCRIPTION
See the discussion here: https://git.gnu.io/gnu/gnu-social/issues/176#note_4238

Hopefully we now finally have found the correct way to detect the values.