### PR TITLE
added aria describedby elements to input templates

### DIFF
--- a/view/templates/field_checkbox.tpl
+++ b/view/templates/field_checkbox.tpl
@@ -1,5 +1,5 @@
 	<div class='field checkbox' id='div_id_{{$field.0}}'>
 		<label for='id_{{$field.0}}'>{{$field.1}}</label>
-		<input type="checkbox" name='{{$field.0}}' id='id_{{$field.0}}' value="1" {{if $field.2}}checked="checked"{{/if}}>
-		<span class='field_help'>{{$field.3}}</span>
+		<input type="checkbox" name='{{$field.0}}' id='id_{{$field.0}}' aria-describedby='{{$field.0}}_tip' value="1" {{if $field.2}}checked="checked"{{/if}}>
+		<span class='field_help' role='tooltip' id='{{$field.0}}_tip'>{{$field.3}}</span>
 	</div>

--- a/view/templates/field_combobox.tpl
+++ b/view/templates/field_combobox.tpl
@@ -7,12 +7,12 @@
 		   {{foreach $field.4 as $opt=>$val}}<option value="{{$val|escape:'html'}}">{{/foreach}}
 		</datalist> *}}
 		
-		<input id="id_{{$field.0}}" type="text" value="{{$field.2}}">
+		<input id="id_{{$field.0}}" type="text" value="{{$field.2}}" aria-describedby='{{$field.0}}_tip'>
 		<select id="select_{{$field.0}}" onChange="$('#id_{{$field.0}}').val($(this).val())">
 			<option value="">{{$field.5}}</option>
 			{{foreach $field.4 as $opt=>$val}}<option value="{{$val|escape:'html'}}">{{$val}}</option>{{/foreach}}
 		</select>
 		
-		<span class='field_help'>{{$field.3}}</span>
+		<span class='field_help' role='tooltip' id='{{$field.0}}_tip'>{{$field.3}}</span>
 	</div>
 

--- a/view/templates/field_input.tpl
+++ b/view/templates/field_input.tpl
@@ -1,6 +1,6 @@
 	
 	<div class='field input' id='wrapper_{{$field.0}}'>
 		<label for='id_{{$field.0}}'>{{$field.1}}</label>
-		<input{{if $field.6 eq 'email'}} type='email'{{elseif $field.6 eq 'url'}} type='url'{{/if}} name='{{$field.0}}' id='id_{{$field.0}}' value="{{$field.2|escape:'html'}}"{{if $field.4 eq 'required'}} required{{/if}}{{if $field.5 eq 'autofocus'}} autofocus{{/if}}>
-		<span class='field_help'>{{$field.3}}</span>
+		<input{{if $field.6 eq 'email'}} type='email'{{elseif $field.6 eq 'url'}} type='url'{{/if}} name='{{$field.0}}' id='id_{{$field.0}}' value="{{$field.2|escape:'html'}}"{{if $field.4 eq 'required'}} required{{/if}}{{if $field.5 eq 'autofocus'}} autofocus{{/if}} aria-describedby='{{$field.0}}_tip'>
+		<span class='field_help' role='tooltip' id='{{$field.0}}_tip'>{{$field.3}}</span>
 	</div>

--- a/view/templates/field_intcheckbox.tpl
+++ b/view/templates/field_intcheckbox.tpl
@@ -2,6 +2,6 @@
 	
 	<div class='field checkbox'>
 		<label for='id_{{$field.0}}'>{{$field.1}}</label>
-		<input type="checkbox" name='{{$field.0}}' id='id_{{$field.0}}' value="{{$field.3|escape:'html'}}" {{if $field.2}}checked="true"{{/if}}>
-		<span class='field_help'>{{$field.4}}</span>
+		<input type="checkbox" name='{{$field.0}}' id='id_{{$field.0}}' value="{{$field.3|escape:'html'}}" {{if $field.2}}checked="true"{{/if}} aria-describedby='{{$field.0}}_tip'>
+		<span class='field_help' role='tooltip' id='{{$field.0}}_tip'>{{$field.4}}</span>
 	</div>

--- a/view/templates/field_openid.tpl
+++ b/view/templates/field_openid.tpl
@@ -1,6 +1,6 @@
 	
 	<div class='field input openid' id='wrapper_{{$field.0}}'>
 		<label for='id_{{$field.0}}'>{{$field.1}}</label>
-		<input name='{{$field.0}}' id='id_{{$field.0}}' value="{{$field.2|escape:'html'}}">
-		<span class='field_help'>{{$field.3}}</span>
+		<input name='{{$field.0}}' id='id_{{$field.0}}' value="{{$field.2|escape:'html'}}" aria-describedby='{{$field.0}}_tip'>
+		<span class='field_help' role='tooltip' id='{{$field.0}}_tip'>{{$field.3}}</span>
 	</div>

--- a/view/templates/field_password.tpl
+++ b/view/templates/field_password.tpl
@@ -1,6 +1,6 @@
 	
 	<div class='field password' id='wrapper_{{$field.0}}'>
 		<label for='id_{{$field.0}}'>{{$field.1}}</label>
-		<input type='password' name='{{$field.0}}' id='id_{{$field.0}}' value="{{$field.2|escape:'html'}}"{{if $field.4 eq 'required'}} required{{/if}}{{if $field.5 eq 'autofocus'}} autofocus{{/if}}>
-		<span class='field_help'>{{$field.3}}</span>
+		<input type='password' name='{{$field.0}}' id='id_{{$field.0}}' value="{{$field.2|escape:'html'}}"{{if $field.4 eq 'required'}} required{{/if}}{{if $field.5 eq 'autofocus'}} autofocus{{/if}} aria-describedby='{{$field.0}}_tip'>
+		<span class='field_help' role='tooltip' id='{{$field.0}}_tip'>{{$field.3}}</span>
 	</div>

--- a/view/templates/field_radio.tpl
+++ b/view/templates/field_radio.tpl
@@ -2,6 +2,6 @@
 	
 	<div class='field radio'>
 		<label for='id_{{$field.0}}_{{$field.2}}'>{{$field.1}}</label>
-		<input type="radio" name='{{$field.0}}' id='id_{{$field.0}}_{{$field.2}}' value="{{$field.2|escape:'html'}}" {{if $field.4}}checked="true"{{/if}}>
-		<span class='field_help'>{{$field.3}}</span>
+		<input type="radio" name='{{$field.0}}' id='id_{{$field.0}}_{{$field.2}}' value="{{$field.2|escape:'html'}}" {{if $field.4}}checked="true"{{/if}} aria-describedby={{$field.0}}_tip'>
+		<span class='field_help' role='tooltip' id='{{$field.0}}_tip'>{{$field.3}}</span>
 	</div>

--- a/view/templates/field_richtext.tpl
+++ b/view/templates/field_richtext.tpl
@@ -2,6 +2,6 @@
 	
 	<div class='field richtext'>
 		<label for='id_{{$field.0}}'>{{$field.1}}</label>
-		<textarea name='{{$field.0}}' id='id_{{$field.0}}' class="fieldRichtext">{{$field.2}}</textarea>
-		<span class='field_help'>{{$field.3}}</span>
+		<textarea name='{{$field.0}}' id='id_{{$field.0}}' class="fieldRichtext" aria-describedby='{{$field.0}}_tip'>{{$field.2}}</textarea>
+		<span class='field_help' role='tooltip' id='{{$field.0}}_tip'>{{$field.3}}</span>
 	</div>

--- a/view/templates/field_select.tpl
+++ b/view/templates/field_select.tpl
@@ -2,8 +2,8 @@
 	
 	<div class='field select'>
 		<label for='id_{{$field.0}}'>{{$field.1}}</label>
-		<select name='{{$field.0}}' id='id_{{$field.0}}'>
+		<select name='{{$field.0}}' id='id_{{$field.0}}' aria-describedby='{{$field.0}}_tip'>
 			{{foreach $field.4 as $opt=>$val}}<option value="{{$opt|escape:'html'}}" {{if $opt==$field.2}}selected="selected"{{/if}}>{{$val}}</option>{{/foreach}}
 		</select>
-		<span class='field_help'>{{$field.3}}</span>
+		<span class='field_help' role='tooltip' id='{{$field.0}}_tip'>{{$field.3}}</span>
 	</div>

--- a/view/templates/field_select_raw.tpl
+++ b/view/templates/field_select_raw.tpl
@@ -2,8 +2,8 @@
 	
 	<div class='field select'>
 		<label for='id_{{$field.0}}'>{{$field.1}}</label>
-		<select name='{{$field.0}}' id='id_{{$field.0}}'>
+		<select name='{{$field.0}}' id='id_{{$field.0}}' aria-describedby='{{$field.0}}_tip'>
 			{{$field.4}}
 		</select>
-		<span class='field_help'>{{$field.3}}</span>
+		<span class='field_help' role='tooltip' id='{{$field.0}}_tip'>{{$field.3}}</span>
 	</div>

--- a/view/templates/field_textarea.tpl
+++ b/view/templates/field_textarea.tpl
@@ -2,6 +2,6 @@
 	
 	<div class='field textarea'>
 		<label for='id_{{$field.0}}'>{{$field.1}}</label>
-		<textarea name='{{$field.0}}' id='id_{{$field.0}}'>{{$field.2}}</textarea>
-		<span class='field_help'>{{$field.3}}</span>
+		<textarea name='{{$field.0}}' id='id_{{$field.0}}' aria-describedby='{{$field.0}}_tip'>{{$field.2}}</textarea>
+		<span class='field_help' role='tooltip' id='{{$field.0}}_tip'>{{$field.3}}</span>
 	</div>

--- a/view/templates/field_themeselect.tpl
+++ b/view/templates/field_themeselect.tpl
@@ -2,9 +2,9 @@
 	{{if $field.5}}<script>$(function(){ previewTheme($("#id_{{$field.0}}")[0]); });</script>{{/if}}
 	<div class='field select'>
 		<label for='id_{{$field.0}}'>{{$field.1}}</label>
-		<select name='{{$field.0}}' id='id_{{$field.0}}' {{if $field.5}}onchange="previewTheme(this);"{{/if}} >
+		<select name='{{$field.0}}' id='id_{{$field.0}}' {{if $field.5}}onchange="previewTheme(this);"{{/if}} aria-describedby='{{$field.0}}_tip'>
 			{{foreach $field.4 as $opt=>$val}}<option value="{{$opt|escape:'html'}}" {{if $opt==$field.2}}selected="selected"{{/if}}>{{$val}}</option>{{/foreach}}
 		</select>
-		<span class='field_help'>{{$field.3}}</span>
+		<span class='field_help' role='tooltip' id='{{$field.0}}_tip'>{{$field.3}}</span>
 		{{if $field.5}}<div id="theme-preview"></div>{{/if}}
 	</div>

--- a/view/templates/field_yesno.tpl
+++ b/view/templates/field_yesno.tpl
@@ -2,7 +2,7 @@
 	<div class='field yesno'>
 		<label for='id_{{$field.0}}'>{{$field.1}}</label>
 		<div class='onoff' id="id_{{$field.0}}_onoff">
-			<input  type="hidden" name='{{$field.0}}' id='id_{{$field.0}}' value="{{$field.2|escape:'html'}}">
+			<input  type="hidden" name='{{$field.0}}' id='id_{{$field.0}}' value="{{$field.2|escape:'html'}}" aria-describedby='{{$field.0}}_tip'>
 			<a href="#" class='off'>
 				{{if $field.4}}{{$field.4.0}}{{else}}OFF{{/if}}
 			</a>
@@ -10,5 +10,5 @@
 				{{if $field.4}}{{$field.4.1}}{{else}}ON{{/if}}
 			</a>
 		</div>
-		<span class='field_help'>{{$field.3}}</span>
+		<span class='field_help' role='tooltip' id='{{$field.0}}_tip'>{{$field.3}}</span>
 	</div>

--- a/view/templates/login.tpl
+++ b/view/templates/login.tpl
@@ -1,6 +1,7 @@
 
 
 <form action="{{$dest_url}}" method="post" >
+<fieldset>
 	<input type="hidden" name="auth-params" value="login" />
 
 	<div id="login_standard">
@@ -29,7 +30,7 @@
 		<input type="hidden" name="{{$k}}" value="{{$v|escape:'html'}}" />
 	{{/foreach}}
 	
-	
+</fieldset>
 </form>
 
 


### PR DESCRIPTION
In the input templates the `field_help` elements got an aria role (tooltip) and an id, which is referenced by the new `aria-describedby` property of the input for which the help is.

part of #1743 