### PR TITLE
Use the "attachment" element instead of a mixture of several elements

### DIFF
--- a/include/bbcode.php
+++ b/include/bbcode.php
@@ -73,9 +73,13 @@ function bb_attachment($Text, $simplehtml = false, $tryoembed = true) {
 			elseif (($data["preview"] != "") AND !strstr(strtolower($oembed), "<img "))
 				$text .= sprintf('<a href="%s" target="_blank"><img src="%s" alt="" title="%s" class="attachment-preview" /></a><br />', $data["url"], proxy_url($data["preview"]), $data["title"]);
 
-			$text .= $oembed;
+			if (($data["type"] == "photo") AND ($data["url"] != "") AND ($data["image"] != ""))
+				$text .= sprintf('<a href="%s" target="_blank"><img src="%s" alt="" title="%s" class="attachment-image" /></a>', $data["url"], proxy_url($data["image"]), $data["title"]);
+			else
+				$text .= $oembed;
 
-			$text .= sprintf('<blockquote>%s</blockquote></span>', trim($data["description"]));
+			if (trim($data["description"]) != "")
+				$text .= sprintf('<blockquote>%s</blockquote></span>', trim($data["description"]));
 		}
 	}
 	return $data["text"].$text.$data["after"];

--- a/include/bbcode.php
+++ b/include/bbcode.php
@@ -31,237 +31,85 @@ function bb_map_location($match) {
 }
 
 function bb_attachment($Text, $simplehtml = false, $tryoembed = true) {
-	$Text = preg_replace_callback("/(.*?)\[attachment(.*?)\](.*?)\[\/attachment\]/ism",
-		function ($match) use ($simplehtml, $tryoembed){
 
-			$attributes = $match[2];
+	$data = get_attachment_data($Text);
 
-			$type = "";
-			preg_match("/type='(.*?)'/ism", $attributes, $matches);
-			if ($matches[1] != "")
-				$type = strtolower($matches[1]);
+	if (!$data)
+		return $Text;
 
-			preg_match('/type="(.*?)"/ism', $attributes, $matches);
-			if ($matches[1] != "")
-				$type = strtolower($matches[1]);
-
-			if ($type == "")
-				return($match[0]);
-
-			if (!in_array($type, array("link", "audio", "video")))
-				return($match[0]);
-
-			$url = "";
-			preg_match("/url='(.*?)'/ism", $attributes, $matches);
-			if ($matches[1] != "")
-				$url = $matches[1];
-
-			preg_match('/url="(.*?)"/ism', $attributes, $matches);
-			if ($matches[1] != "")
-				$url = $matches[1];
-
-			$title = "";
-			preg_match("/title='(.*?)'/ism", $attributes, $matches);
-			if ($matches[1] != "")
-				$title = $matches[1];
-
-			preg_match('/title="(.*?)"/ism', $attributes, $matches);
-			if ($matches[1] != "")
-				$title = $matches[1];
-
-			//$title = htmlentities($title, ENT_QUOTES, 'UTF-8', false);
-			$title = bbcode(html_entity_decode($title, ENT_QUOTES, 'UTF-8'), false, false, true);
-			$title = str_replace(array("[", "]"), array("&#91;", "&#93;"), $title);
-
-			$image = "";
-			if ($type != "video") {
-				preg_match("/image='(.*?)'/ism", $attributes, $matches);
-				if ($matches[1] != "")
-					$image = $matches[1];
-
-				preg_match('/image="(.*?)"/ism', $attributes, $matches);
-				if ($matches[1] != "")
-					$image = $matches[1];
-			}
-
-			$preview = "";
-			if ($type != "video") {
-				preg_match("/preview='(.*?)'/ism", $attributes, $matches);
-				if ($matches[1] != "")
-					$preview = $matches[1];
-
-				preg_match('/preview="(.*?)"/ism', $attributes, $matches);
-				if ($matches[1] != "")
-					$preview = $matches[1];
-			}
-
-			if (((strpos($match[1], "[img=") !== false) OR (strpos($match[1], "[img]") !== false)) AND ($image != "")) {
-				$preview = $image;
-				$image = "";
-			}
-
-			if ($simplehtml == 7) {
-				$title2 = $title;
-
-				$test1 = trim(html_entity_decode($match[1],ENT_QUOTES,'UTF-8'));
-				$test2 = trim(html_entity_decode($title,ENT_QUOTES,'UTF-8'));
-
-				// If the link description is similar to the text above then don't add the link description
-				if (($title != "") AND ((strpos($test1,$test2) !== false) OR
-					(similar_text($test1,$test2) / strlen($title)) > 0.9))
-					$title2 = $url;
-				$text = sprintf('<a href="%s" title="%s" class="attachment thumbnail" rel="nofollow external">%s</a><br />',
-						$url, $title, $title2);
-			} elseif (($simplehtml != 4) AND ($simplehtml != 0))
-				$text = sprintf('<a href="%s" target="_blank">%s</a><br>', $url, $title);
-			else {
-				$text = sprintf('<span class="type-%s">', $type);
-
-				$bookmark = array(sprintf('[bookmark=%s]%s[/bookmark]', $url, $title), $url, $title);
-				if ($tryoembed)
-					$oembed = tryoembed($bookmark);
-				else
-					$oembed = $bookmark[0];
-
-				if (strstr(strtolower($oembed), "<iframe "))
-					$text = $oembed;
-				else {
-					if (($image != "") AND !strstr(strtolower($oembed), "<img "))
-						$text .= sprintf('<a href="%s" target="_blank"><img src="%s" alt="" title="%s" class="attachment-image" /></a><br />', $url, proxy_url($image), $title);
-					elseif (($preview != "") AND !strstr(strtolower($oembed), "<img "))
-						$text .= sprintf('<a href="%s" target="_blank"><img src="%s" alt="" title="%s" class="attachment-preview" /></a><br />', $url, proxy_url($preview), $title);
-
-					$text .= $oembed;
-
-					$text .= sprintf('<blockquote>%s</blockquote></span>', trim($match[3]));
-				}
-			}
-
-			return($match[1].$text);
-		},$Text);
-
-	return($Text);
-}
-
-function bb_rearrange_share($shared) {
-	if (!in_array(strtolower($shared[2]), array("type-link", "type-audio", "type-video")))
-		return($shared[0]);
-
-	if (!preg_match_all("/\[bookmark\=([^\]]*)\](.*?)\[\/bookmark\]/ism",$shared[3], $bookmark))
-		return($shared[0]);
-
-	$type = substr(trim(strtolower($shared[2])), 5);
-
-	$title = "";
-	$url = "";
-	$preview = "";
-	$description = "";
-
-	if (isset($bookmark[2][0]))
-		$title = $bookmark[2][0];
-
-	if (isset($bookmark[1][0]))
-		$url = $bookmark[1][0];
-
-	$cleanedshare = trim($shared[3]);
-	$cleanedshare = preg_replace("/\[img\=([0-9]*)x([0-9]*)\](.*?)\[\/img\]/ism", '[img]$3[/img]', $cleanedshare);
-	preg_match("/\[img\](.*?)\[\/img\]/ism", $cleanedshare, $matches);
-
-	if ($matches)
-		$preview = trim($matches[1]);
-
-	preg_match("/\[quote\](.*?)\[\/quote\]/ism", $cleanedshare, $matches);
-	if ($matches)
-		$description = trim($matches[1]);
-
-	$url = str_replace(array("[", "]"), array("&#91;", "&#93;"), htmlentities($url, ENT_QUOTES, 'UTF-8', false));
-	$title = str_replace(array("[", "]"), array("&#91;", "&#93;"), htmlentities($title, ENT_QUOTES, 'UTF-8', false));
-	$preview = str_replace(array("[", "]"), array("&#91;", "&#93;"), htmlentities($preview, ENT_QUOTES, 'UTF-8', false));
-
-	$Text = trim($shared[1])."\n[attachment type='".$type."'";
-
-	if ($url != "")
-		$Text .= " url='".$url."'";
-	if ($title != "")
-		$Text .= " title='".$title."'";
-	if ($preview != "") {
-		require_once("include/Photo.php");
-		$picturedata = get_photo_info($preview);
-
-		if (count($picturedata) > 0) {
-			// if the preview picture is larger than 500 pixels then show it in a larger mode
-			// But only, if the picture isn't higher than large (To prevent huge posts)
-			if (($picturedata[0] >= 500) AND ($picturedata[0] >= $picturedata[1]))
-				$Text .= " image='".$preview."'";
-			else
-				$Text .= " preview='".$preview."'";
-		} else
-			$Text .= " preview='".$preview."'";
+	if (((strpos($data["text"], "[img=") !== false) OR (strpos($data["text"], "[img]") !== false)) AND ($data["image"] != "")) {
+		$data["preview"] = $data["image"];
+		$data["image"] = "";
 	}
-	$Text .= "]".$description."[/attachment]";
 
-	return($Text);
+	if ($simplehtml == 7) {
+		$title2 = $data["title"];
+
+		$test1 = trim(html_entity_decode($data["text"],ENT_QUOTES,'UTF-8'));
+		$test2 = trim(html_entity_decode($data["title"],ENT_QUOTES,'UTF-8'));
+
+		// If the link description is similar to the text above then don't add the link description
+		if (($data["title"] != "") AND ((strpos($test1,$test2) !== false) OR
+			(similar_text($test1,$test2) / strlen($data["title"])) > 0.9))
+			$title2 = $data["url"];
+		$text = sprintf('<a href="%s" title="%s" class="attachment thumbnail" rel="nofollow external">%s</a><br />',
+				$data["url"], $data["title"], $title2);
+	} elseif (($simplehtml != 4) AND ($simplehtml != 0))
+		$text = sprintf('<a href="%s" target="_blank">%s</a><br>', $data["url"], $data["title"]);
+	else {
+		$text = sprintf('<span class="type-%s">', $data["type"]);
+
+		$bookmark = array(sprintf('[bookmark=%s]%s[/bookmark]', $data["url"], $data["title"]), $data["url"], $data["title"]);
+		if ($tryoembed)
+			$oembed = tryoembed($bookmark);
+		else
+			$oembed = $bookmark[0];
+
+		if (strstr(strtolower($oembed), "<iframe "))
+			$text = $oembed;
+		else {
+			if (($data["image"] != "") AND !strstr(strtolower($oembed), "<img "))
+				$text .= sprintf('<a href="%s" target="_blank"><img src="%s" alt="" title="%s" class="attachment-image" /></a><br />', $data["url"], proxy_url($data["image"]), $data["title"]);
+			elseif (($data["preview"] != "") AND !strstr(strtolower($oembed), "<img "))
+				$text .= sprintf('<a href="%s" target="_blank"><img src="%s" alt="" title="%s" class="attachment-preview" /></a><br />', $data["url"], proxy_url($data["preview"]), $data["title"]);
+
+			$text .= $oembed;
+
+			$text .= sprintf('<blockquote>%s</blockquote></span>', trim($data["description"]));
+		}
+	}
+	return $data["text"].$text.$data["after"];
 }
 
 function bb_remove_share_information($Text, $plaintext = false, $nolink = false) {
-	$Text = preg_replace_callback("((.*?)\[class=(.*?)\](.*?)\[\/class\])ism",
-		function ($match) use ($plaintext, $nolink){
-			return(bb_cleanup_share($match, $plaintext, $nolink));
-		},$Text);
-	return($Text);
-}
 
-function bb_cleanup_share($shared, $plaintext, $nolink) {
-	$shared[1] = trim($shared[1]);
+	$data = get_attachment_data($Text);
 
-	if (!in_array($shared[2], array("type-link", "type-video")))
-		return($shared[0]);
-
-	if ($plaintext)
-		$shared[3] = preg_replace("/\[bookmark\=([^\]]*)\](.*?)\[\/bookmark\]/ism","[bookmark=$1]$1[/bookmark]", $shared[3]);
-
-	if (!preg_match_all("/\[bookmark\=([^\]]*)\](.*?)\[\/bookmark\]/ism",$shared[3], $bookmark))
-		return($shared[0]);
+	if (!$data)
+		return $Text;
 
 	if ($nolink)
-		return($shared[1]);
+		return $data["text"];
 
-	$title = "";
-	$link = "";
+	if ($plaintext)
+		$data["title"] = $data["url"];
 
-	if (isset($bookmark[2][0]))
-		$title = $bookmark[2][0];
-
-	if (isset($bookmark[1][0]))
-		$link = $bookmark[1][0];
-
-	if (($shared[1] != "") AND (strpos($title, $shared[1]) !== false))
-		$shared[1] = $title;
-
-	if (($title != "") AND ((strpos($shared[1],$title) !== false) OR
-		(similar_text($shared[1],$title) / strlen($title)) > 0.9))
-		$title = "";
-
-//        if (strpos($shared[1],$link) !== false)
-//                $link = "";
-
-	$text = trim($shared[1]);
-
-	if (($text == "") AND ($title != "") AND ($link == ""))
-		$text .= "\n\n".trim($title);
+	if (($data["text"] == "") AND ($data["title"] != "") AND ($data["url"] == ""))
+		return $data["title"];
 
 	// If the link already is included in the post, don't add it again
-	if (($link != "") AND strpos($text, $link))
-		return(trim($text));
+	if (($data["url"] != "") AND strpos($data["text"], $data["url"]))
+		return $data["text"];
 
-	if (($link != "") AND ($title != ""))
-		$text .= "\n[url=".trim($link)."]".trim($title)."[/url]";
+	$text = $data["text"];
+
+	if (($data["url"] != "") AND ($data["title"] != ""))
+		$text .= "\n[url=".$data["url"]."]".$data["title"]."[/url]";
 	elseif (($link != ""))
-		$text .= "\n".trim($link);
+		$text .= "\n".$data["url"];
 
-	return(trim($text));
+	return $text;
 }
-
 
 function bb_cleanstyle($st) {
   return "<span style=\"".cleancss($st[1]).";\">".$st[2]."</span>";
@@ -894,9 +742,6 @@ function bbcode($Text,$preserve_nl = false, $tryoembed = true, $simplehtml = fal
 
 	$Text = preg_replace("/\n\[code\]/ism", "[code]", $Text);
 	$Text = preg_replace("/\[\/code\]\n/ism", "[/code]", $Text);
-
-	// Rearrange shares to attachments
-	$Text = preg_replace_callback("((.*?)\[class=(.*?)\](.*?)\[\/class\])ism", "bb_rearrange_share",$Text);
 
 	// when the content is meant exporting to other systems then remove the avatar picture since this doesn't really look good on these systems
 	if (!$tryoembed)

--- a/include/plaintext.php
+++ b/include/plaintext.php
@@ -1,4 +1,16 @@
 <?php
+/**
+ * @brief Fetches attachment data that were generated the old way
+ *
+ * @param string $body Message body
+ * @return array
+ * 'type' -> Message type ("link", "video", "photo")
+ * 'text' -> Text outside of the shared message
+ * 'image' -> Preview image of the message
+ * 'url' -> Url to the attached message
+ * 'title' -> Title of the attachment
+ * 'description' -> Description of the attachment
+ */
 function get_old_attachment_data($body) {
 
 	$post = array();
@@ -37,6 +49,19 @@ function get_old_attachment_data($body) {
 	return $post;
 }
 
+/**
+ * @brief Fetches attachment data that were generated with the "attachment" element
+ *
+ * @param string $body Message body
+ * @return array
+ * 'type' -> Message type ("link", "video", "photo")
+ * 'text' -> Text before the shared message
+ * 'after' -> Text after the shared message
+ * 'image' -> Preview image of the message
+ * 'url' -> Url to the attached message
+ * 'title' -> Title of the attachment
+ * 'description' -> Description of the attachment
+ */
 function get_attachment_data($body) {
 
 	$data = array();

--- a/include/plaintext.php
+++ b/include/plaintext.php
@@ -85,7 +85,7 @@ function get_attachment_data($body) {
 	if ($type == "")
 		return(array());
 
-	if (!in_array($type, array("link", "audio", "video")))
+	if (!in_array($type, array("link", "audio", "photo", "video")))
 		return(array());
 
 	if ($type != "")

--- a/include/plaintext.php
+++ b/include/plaintext.php
@@ -1,19 +1,10 @@
 <?php
-function get_attached_data($body) {
-/*
- - text:
- - type: link, video, photo
- - title:
- - url:
- - image:
- - description:
- - (thumbnail)
-*/
+function get_old_attachment_data($body) {
+
+	$post = array();
 
 	// Simplify image codes
 	$body = preg_replace("/\[img\=([0-9]*)x([0-9]*)\](.*?)\[\/img\]/ism", '[img]$3[/img]', $body);
-
-	$post = array();
 
 	if (preg_match_all("(\[class=(.*?)\](.*?)\[\/class\])ism",$body, $attached,  PREG_SET_ORDER)) {
 		foreach ($attached AS $data) {
@@ -42,6 +33,116 @@ function get_attached_data($body) {
 
 		}
 	}
+
+	return $post;
+}
+
+function get_attachment_data($body) {
+
+	$data = array();
+
+	if (!preg_match("/(.*)\[attachment(.*)\](.*?)\[\/attachment\](.*)/ism", $body, $match))
+		return get_old_attachment_data($body);
+
+	$attributes = $match[2];
+
+	$data["text"] = trim($match[1]);
+
+	$type = "";
+	preg_match("/type='(.*?)'/ism", $attributes, $matches);
+	if ($matches[1] != "")
+		$type = strtolower($matches[1]);
+
+	preg_match('/type="(.*?)"/ism', $attributes, $matches);
+	if ($matches[1] != "")
+		$type = strtolower($matches[1]);
+
+	if ($type == "")
+		return(array());
+
+	if (!in_array($type, array("link", "audio", "video")))
+		return(array());
+
+	if ($type != "")
+		$data["type"] = $type;
+
+	$url = "";
+	preg_match("/url='(.*?)'/ism", $attributes, $matches);
+	if ($matches[1] != "")
+		$url = $matches[1];
+
+	preg_match('/url="(.*?)"/ism', $attributes, $matches);
+	if ($matches[1] != "")
+		$url = $matches[1];
+
+	if ($url != "")
+		$data["url"] = $url;
+
+	$title = "";
+	preg_match("/title='(.*?)'/ism", $attributes, $matches);
+	if ($matches[1] != "")
+		$title = $matches[1];
+
+	preg_match('/title="(.*?)"/ism', $attributes, $matches);
+	if ($matches[1] != "")
+		$title = $matches[1];
+
+	//$title = htmlentities($title, ENT_QUOTES, 'UTF-8', false);
+	$title = bbcode(html_entity_decode($title, ENT_QUOTES, 'UTF-8'), false, false, true);
+	$title = str_replace(array("[", "]"), array("&#91;", "&#93;"), $title);
+
+	if ($title != "")
+		$data["title"] = $title;
+
+	$image = "";
+	if ($type != "video") {
+		preg_match("/image='(.*?)'/ism", $attributes, $matches);
+		if ($matches[1] != "")
+			$image = $matches[1];
+
+		preg_match('/image="(.*?)"/ism', $attributes, $matches);
+		if ($matches[1] != "")
+			$image = $matches[1];
+	}
+
+	if ($image != "")
+		$data["image"] = $image;
+
+	$preview = "";
+	if ($type != "video") {
+		preg_match("/preview='(.*?)'/ism", $attributes, $matches);
+		if ($matches[1] != "")
+			$preview = $matches[1];
+
+		preg_match('/preview="(.*?)"/ism', $attributes, $matches);
+		if ($matches[1] != "")
+			$preview = $matches[1];
+	}
+
+	if (($image == "") AND ($preview != ""))
+		$data["image"] = $preview;
+	else
+		$data["preview"] = $preview;
+
+	$data["description"] = trim($match[3]);
+
+	$data["after"] = trim($match[4]);
+
+	return($data);
+}
+
+function get_attached_data($body) {
+/*
+ - text:
+ - type: link, video, photo
+ - title:
+ - url:
+ - image:
+ - description:
+ - (thumbnail)
+*/
+
+	$post = get_attachment_data($body);
 
 	// if nothing is found, it maybe having an image.
 	if (!isset($post["type"])) {

--- a/mod/parse_url.php
+++ b/mod/parse_url.php
@@ -407,6 +407,8 @@ function arr_add_hashes(&$item,$k) {
 
 function parse_url_content(&$a) {
 
+	require_once("include/items.php");
+
 	$text = null;
 	$str_tags = '';
 
@@ -484,78 +486,9 @@ function parse_url_content(&$a) {
 
 	$siteinfo = parseurl_getsiteinfo($url);
 
-//	if ($textmode) {
-//		require_once("include/items.php");
-//
-//		echo add_page_info_data($siteinfo);
-//		killme();
-//	}
+	unset($siteinfo["keywords"]);
 
-	$url= $siteinfo["url"];
-
-	// If the link contains BBCode stuff, make a short link out of this to avoid parsing problems
-	if (strpos($url, '[') OR strpos($url, ']')) {
-		require_once("include/network.php");
-		$url = short_link($url);
-	}
-
-	$sitedata = "";
-
-	if($siteinfo["title"] != "") {
-		$text = $siteinfo["text"];
-		$title = $siteinfo["title"];
-	}
-
-	$image = "";
-
-	if (($siteinfo["type"] != "video") AND (sizeof($siteinfo["images"]) > 0)){
-		/* Execute below code only if image is present in siteinfo */
-
-		$total_images = 0;
-		$max_images = get_config('system','max_bookmark_images');
-		if($max_images === false)
-			$max_images = 2;
-		else
-			$max_images = intval($max_images);
-
-		foreach ($siteinfo["images"] as $imagedata) {
-			if($textmode)
-				$image .= '[img='.$imagedata["width"].'x'.$imagedata["height"].']'.$imagedata["src"].'[/img]' . "\n";
-			else
-				$image .= '<img height="'.$imagedata["height"].'" width="'.$imagedata["width"].'" src="'.$imagedata["src"].'" alt="photo" /><br />';
-			$total_images ++;
-			if($max_images && $max_images >= $total_images)
-				break;
-		}
-	}
-
-	if(strlen($text)) {
-		if($textmode)
-			$text = '[quote]'.trim($text).'[/quote]';
-		else
-			$text = '<blockquote>'.htmlspecialchars(trim($text)).'</blockquote>';
-	}
-
-	if($image)
-		$text = $br.$br.$image.$text;
-	else
-		$text = $br.$text;
-
-	$title = str_replace(array("\r","\n"),array('',''),$title);
-
-	$result = sprintf($template,$url,($title) ? $title : $url,$text) . $str_tags;
-
-	logger('parse_url: returns: ' . $result);
-
-	$sitedata .=  trim($result);
-
-	if (($siteinfo["type"] == "video") AND ($url != ""))
-		echo "[class=type-video]".$sitedata."[/class]";
-	elseif (($siteinfo["type"] != "photo"))
-		echo "[class=type-link]".$sitedata."[/class]";
-	else
-		echo "[class=type-photo]".$title.$br.$image."[/class]";
-
+	echo add_page_info_data($siteinfo);
 	killme();
 }
 ?>


### PR DESCRIPTION
For several versions we supported the "attachment" element - but we had used it only internally. Now we are using this element whenever we are sharing links.

This new code has a single disadvantage: The wysiwyg editor won't show pictures of shared links anymore. But the advantage is that the whole code is cleaned up and we aren't using a mixture of several bbcode elements anymore.