### PR TITLE
Don't store unknown networks

### DIFF
--- a/include/socgraph.php
+++ b/include/socgraph.php
@@ -1387,6 +1387,9 @@ function get_gcontact_id($contact) {
 
 	$gcontact_id = 0;
 
+	if ($contact["network"] == NETWORK_PHANTOM)
+		return false;
+
 	if ($contact["network"] == NETWORK_STATUSNET)
 		$contact["network"] = NETWORK_OSTATUS;
 


### PR DESCRIPTION
We shouldn't store unknown networks in the gcontact table.