### PR TITLE
stuff for the installer and htconfig template

### DIFF
--- a/mod/install.php
+++ b/mod/install.php
@@ -79,6 +79,14 @@ function install_post(&$a) {
 			$timezone = notags(trim($_POST['timezone']));
 			$language = notags(trim($_POST['language']));
 			$adminmail = notags(trim($_POST['adminmail']));
+			// In step 4 of the installer, we passed the  check for mcrypt
+			// already, so we can activate RINO, make RINO2 the default
+			// and only fall back if the mcrypt_create_iv function is
+			// not available on the system.
+			$rino = 2;
+			if (! function_exists('mcrypt_create_iv')) {
+				$rino = 1;
+			]
 
 			// connect to db
 			$db = new dba($dbhost, $dbuser, $dbpass, $dbdata, true);
@@ -93,7 +101,8 @@ function install_post(&$a) {
 				'$language' => $language,
 				'$urlpath' => $urlpath,
 				'$phpath' => $phpath,
-				'$adminmail' => $adminmail
+				'$adminmail' => $adminmail,
+				'$rino' => $rino
 			));
 
 
@@ -449,7 +458,7 @@ function check_funcs(&$checks) {
 	if ($ck_funcs[5]['status']) {
 		if (function_exists('mcrypt_create_iv')) {
 			$__status = true;
-			$__help = "If you are using php_cli, please make sure that mcrypt module is enabled in its config file";
+			$__help = t("If you are using php_cli, please make sure that mcrypt module is enabled in its config file");
 		} else {
 			$__status = false;
 			$__help = t('Function mcrypt_create_iv() is not defined. This is needed to enable RINO2 encryption layer.');

--- a/view/templates/htconfig.tpl
+++ b/view/templates/htconfig.tpl
@@ -59,7 +59,7 @@ $a->config['system']['huburl'] = '[internal]';
 // Encryption will only be provided if this setting is true and the
 // PHP mcrypt extension is installed on both systems
 
-$a->config['system']['rino_encrypt'] = true;
+$a->config['system']['rino_encrypt'] = {{$rino}};
 
 // default system theme
 

--- a/view/templates/htconfig.tpl
+++ b/view/templates/htconfig.tpl
@@ -1,5 +1,12 @@
 <?php
 
+/**********************************************************************
+ *  The following configuration has to be within the .htconfig file
+ *  and will not be overruled by decisions made in the admin panel.
+ * 
+ *  See below for variables that may be overruled by the admin panel.
+ **********************************************************************/
+
 // Set the following for your MySQL installation
 // Copy or rename this file to .htconfig.php
 
@@ -8,12 +15,26 @@ $db_user = '{{$dbuser}}';
 $db_pass = '{{$dbpass}}';
 $db_data = '{{$dbdata}}';
 
+// email adress for the system admin
+
+$a->config['admin_email'] = '{{$adminmail}}';
+
+// Location of PHP command line processor
+
+$a->config['php_path'] = '{{$phpath}}';
+
 // If you are using a subdirectory of your domain you will need to put the
 // relative path (from the root of your domain) here.
 // For instance if your URL is 'http://example.com/directory/subdirectory',
 // set path to 'directory/subdirectory'.
 
 $a->path = '{{$urlpath}}';
+
+/***********************************************************************
+ *  The configuration below will be overruled by the admin panel.
+ *  Changes made below will only have an effect if the database does
+ *  not contain any configuration for the friendica system.
+ ***********************************************************************/
  
 // Choose a legal default timezone. If you are unsure, use "America/Los_Angeles".
 // It can be changed later and only applies to timestamps for anonymous viewers.
@@ -37,7 +58,6 @@ $a->config['sitename'] = "My Friend Network";
 
 $a->config['register_policy'] = REGISTER_OPEN;
 $a->config['register_text'] = '';
-$a->config['admin_email'] = '{{$adminmail}}';
 
 // Maximum size of an imported message, 0 is unlimited
 
@@ -46,10 +66,6 @@ $a->config['max_import_size'] = 200000;
 // maximum size of uploaded photos
 
 $a->config['system']['maximagesize'] = 800000;
-
-// Location of PHP command line processor
-
-$a->config['php_path'] = '{{$phpath}}';
 
 // PuSH - aka pubsubhubbub URL. This makes delivery of public posts as fast as private posts
 

--- a/view/templates/htconfig.tpl
+++ b/view/templates/htconfig.tpl
@@ -1,11 +1,11 @@
 <?php
 
-/**********************************************************************
+/* ********************************************************************
  *  The following configuration has to be within the .htconfig file
  *  and will not be overruled by decisions made in the admin panel.
  * 
  *  See below for variables that may be overruled by the admin panel.
- **********************************************************************/
+ * ********************************************************************/
 
 // Set the following for your MySQL installation
 // Copy or rename this file to .htconfig.php

--- a/view/templates/htconfig.tpl
+++ b/view/templates/htconfig.tpl
@@ -30,11 +30,11 @@ $a->config['php_path'] = '{{$phpath}}';
 
 $a->path = '{{$urlpath}}';
 
-/***********************************************************************
+/* *********************************************************************
  *  The configuration below will be overruled by the admin panel.
  *  Changes made below will only have an effect if the database does
  *  not contain any configuration for the friendica system.
- ***********************************************************************/
+ * *********************************************************************/
  
 // Choose a legal default timezone. If you are unsure, use "America/Los_Angeles".
 // It can be changed later and only applies to timestamps for anonymous viewers.


### PR DESCRIPTION
Three small things:

1. the installation wizard now puts the RINO version into the template that is supported. So far it only enabled it. This should fix #2242 
2. the template for the htconfig was reorganized to separate the settings which will be overruled by the admin panel from the others. Part of #2194 
3. there was a untranslateable string in the installer