### PR TITLE
Some gcontact stuff and DDoS/Spam prevention

### DIFF
--- a/include/socgraph.php
+++ b/include/socgraph.php
@@ -174,8 +174,6 @@ function poco_check($profile_url, $name, $network, $profile_photo, $about, $loca
 
 	$gcid = "";
 
-	$alternate = poco_alternate_ostatus_url($profile_url);
-
 	if ($profile_url == "")
 		return $gcid;
 
@@ -187,12 +185,18 @@ function poco_check($profile_url, $name, $network, $profile_photo, $about, $loca
 						"identi.ca", "alpha.app.net")))
 		return $gcid;
 
-	$orig_updated = $updated;
-
 	// Don't store the statusnet connector as network
 	// We can't simply set this to NETWORK_OSTATUS since the connector could have fetched posts from friendica as well
 	if ($network == NETWORK_STATUSNET)
 		$network = "";
+
+	// Assure that there are no parameter fragments in the profile url
+	if (in_array($network, array(NETWORK_DFRN, NETWORK_DIASPORA, NETWORK_OSTATUS, "")))
+		$profile_url = clean_contact_url($profile_url);
+
+	$alternate = poco_alternate_ostatus_url($profile_url);
+
+	$orig_updated = $updated;
 
 	// The global contacts should contain the original picture, not the cached one
 	if (($generation != 1) AND stristr(normalise_link($profile_photo), normalise_link($a->get_baseurl()."/photo/")))

--- a/include/socgraph.php
+++ b/include/socgraph.php
@@ -1448,8 +1448,15 @@ function get_gcontact_id($contact) {
 		$r = q("SELECT `id` FROM `gcontact` WHERE `nurl` = '%s' ORDER BY `id` LIMIT 2",
 			dbesc(normalise_link($contact["url"])));
 
-		if ($r)
+		if ($r) {
 			$gcontact_id = $r[0]["id"];
+
+			// Complete newly added contacts from "probable" accounts
+			if (in_array($contact["network"], array(NETWORK_DFRN, NETWORK_OSTATUS, NETWORK_DIASPORA, NETWORK_FEED))) {
+				logger("Probing ".$contact["url"], LOGGER_DEBUG);
+				proc_run('php', 'include/gprobe.php', bin2hex($contact["url"]));
+			}
+		}
 	}
 
 	if ((count($r) > 1) AND ($gcontact_id > 0) AND ($contact["url"] != ""))

--- a/index.php
+++ b/index.php
@@ -118,14 +118,20 @@ if((x($_SESSION,'language')) && ($_SESSION['language'] !== $lang)) {
 
 if((x($_GET,'zrl')) && (!$install && !$maintenance)) {
 	// Only continue when the given profile link seems valid
-	// Valid profile links contain a path and no query parameters
+	// Valid profile links contain a path with "/profile/" and no query parameters
 	if ((parse_url($_GET['zrl'], PHP_URL_QUERY) == "") AND
-		(parse_url($_GET['zrl'],  PHP_URL_PATH) != "")) {
+		strstr(parse_url($_GET['zrl'], PHP_URL_PATH), "/profile/")) {
 		$_SESSION['my_url'] = $_GET['zrl'];
 		$a->query_string = preg_replace('/[\?&]zrl=(.*?)([\?&]|$)/is','',$a->query_string);
 		zrl_init($a);
-	} else
+	} else {
+		// Someone came with an invalid parameter, maybe as a DDoS attempt
+		// We simply stop processing here
 		logger("Invalid ZRL parameter ".$_GET['zrl'], LOGGER_DEBUG);
+		header('HTTP/1.1 403 Forbidden');
+		echo "<h1>403 Forbidden</h1>";
+		killme();
+	}
 }
 
 /**

--- a/index.php
+++ b/index.php
@@ -117,9 +117,15 @@ if((x($_SESSION,'language')) && ($_SESSION['language'] !== $lang)) {
 }
 
 if((x($_GET,'zrl')) && (!$install && !$maintenance)) {
-	$_SESSION['my_url'] = $_GET['zrl'];
-	$a->query_string = preg_replace('/[\?&]zrl=(.*?)([\?&]|$)/is','',$a->query_string);
-	zrl_init($a);
+	// Only continue when the given profile link seems valid
+	// Valid profile links contain a path and no query parameters
+	if ((parse_url($_GET['zrl'], PHP_URL_QUERY) == "") AND
+		(parse_url($_GET['zrl'],  PHP_URL_PATH) != "")) {
+		$_SESSION['my_url'] = $_GET['zrl'];
+		$a->query_string = preg_replace('/[\?&]zrl=(.*?)([\?&]|$)/is','',$a->query_string);
+		zrl_init($a);
+	} else
+		logger("Invalid ZRL parameter ".$_GET['zrl'], LOGGER_DEBUG);
 }
 
 /**


### PR DESCRIPTION
When we now add a new global contact we start a "gprobe" run for it. This ensures that we are having good data for it.

Additionally we now check the validity of the "zrl" parameter before we start processing it. This parameter seemed to be used for spamming or DDoS attempts. Now we quit very early so that these attempts will fail.