### PR TITLE
Diaspora: Comments and Likes are now signed at any time

### DIFF
--- a/include/diaspora.php
+++ b/include/diaspora.php
@@ -3122,12 +3122,6 @@ class diaspora {
 	 */
 	public static function store_like_signature($contact, $post_id) {
 
-		$enabled = intval(get_config('system','diaspora_enabled'));
-		if (!$enabled) {
-			logger('Diaspora support disabled, not storing like signature', LOGGER_DEBUG);
-			return false;
-		}
-
 		// Is the contact the owner? Then fetch the private key
 		if (!$contact['self'] OR ($contact['uid'] == 0)) {
 			logger("No owner post, so not storing signature", LOGGER_DEBUG);
@@ -3188,12 +3182,6 @@ class diaspora {
 
 		if ($uprvkey == "") {
 			logger('No private key, so not storing comment signature', LOGGER_DEBUG);
-			return false;
-		}
-
-		$enabled = intval(get_config('system','diaspora_enabled'));
-		if (!$enabled) {
-			logger('Diaspora support disabled, not storing comment signature', LOGGER_DEBUG);
 			return false;
 		}
 

--- a/mod/xrd.php
+++ b/mod/xrd.php
@@ -29,16 +29,12 @@ function xrd_init(&$a) {
 	header('Access-Control-Allow-Origin: *');
 	header("Content-type: text/xml");
 
-	if(get_config('system','diaspora_enabled')) {
-		$tpl = get_markup_template('xrd_diaspora.tpl');
-		$dspr = replace_macros($tpl,array(
-			'$baseurl' => $a->get_baseurl(),
-			'$dspr_guid' => $r[0]['guid'],
-			'$dspr_key' => base64_encode(pemtorsa($r[0]['pubkey']))
-		));
-	}
-	else
-		$dspr = '';
+	$tpl = get_markup_template('xrd_diaspora.tpl');
+	$dspr = replace_macros($tpl,array(
+		'$baseurl' => $a->get_baseurl(),
+		'$dspr_guid' => $r[0]['guid'],
+		'$dspr_key' => base64_encode(pemtorsa($r[0]['pubkey']))
+	));
 
 	$tpl = get_markup_template('xrd_person.tpl');
 


### PR DESCRIPTION
Several weeks ago there was a discussion about the fact that friendica only stores the Diaspora signature of a like or a comment when Diaspora is enabled on that system. At that time there was the agreement to change this behaviour. I totally forgot about it. (Until now)