### PR TITLE
Avoid write operations if not needed

### DIFF
--- a/mod/display.php
+++ b/mod/display.php
@@ -437,10 +437,14 @@ function display_content(&$a, $update = 0) {
 	if($r) {
 
 		if((local_user()) && (local_user() == $a->profile['uid'])) {
-			q("UPDATE `item` SET `unseen` = 0
-				WHERE `parent` = %d AND `unseen`",
-				intval($r[0]['parent'])
-			);
+			$unseen = q("SELECT `id` FROM `item` WHERE `unseen` AND `parent` = %d",
+					intval($r[0]['parent']));
+
+			if ($unseen)
+				q("UPDATE `item` SET `unseen` = 0
+					WHERE `parent` = %d AND `unseen`",
+					intval($r[0]['parent'])
+				);
 		}
 
 		$items = conv_sort($r,"`commented`");

--- a/mod/network.php
+++ b/mod/network.php
@@ -857,14 +857,24 @@ function network_content(&$a, $update = 0) {
 
 
 	if((! $group) && (! $cid) && (! $star)) {
-		$r = q("UPDATE `item` SET `unseen` = 0
-			WHERE `unseen` = 1 AND `uid` = %d",
-			intval(local_user())
-		);
+
+		$unseen = q("SELECT `id` FROM `item` WHERE `unseen` AND `uid` = %d",
+				intval(local_user()));
+
+		if ($unseen)
+			$r = q("UPDATE `item` SET `unseen` = 0
+				WHERE `unseen` = 1 AND `uid` = %d",
+				intval(local_user())
+			);
 	}
 	else {
-		if($update_unseen)
-			$r = q("UPDATE `item` SET `unseen` = 0 $update_unseen");
+		if($update_unseen) {
+
+			$unseen = q("SELECT `id` FROM `item` ".$update_unseen);
+
+			if ($unseen)
+				$r = q("UPDATE `item` SET `unseen` = 0 $update_unseen");
+		}
 	}
 
 	// Set this so that the conversation function can find out contact info for our wall-wall items


### PR DESCRIPTION
We can avoid some write operations when we check if they are really needed. This avoids unnecessary database locking.