### PR TITLE
Check the global contacts every 90 days/Better handling in item creation

### DIFF
--- a/include/feed.php
+++ b/include/feed.php
@@ -47,7 +47,7 @@ function feed_import($xml,$importer,&$contact, &$hub, $simulate = false) {
 	}
 
 	// Is it Atom?
-	if ($xpath->query('/atom:feed/atom:entry')->length > 0) {
+	if ($xpath->query('/atom:feed')->length > 0) {
 		$alternate = $xpath->query("atom:link[@rel='alternate']")->item(0)->attributes;
 		if (is_object($alternate))
 			foreach($alternate AS $attributes)

--- a/include/gprobe.php
+++ b/include/gprobe.php
@@ -39,7 +39,7 @@ function gprobe_run(&$argv, &$argc){
 
 	logger("gprobe start for ".normalise_link($url), LOGGER_DEBUG);
 
-	if(! count($r)) {
+	if (!count($r)) {
 
 		// Is it a DDoS attempt?
 		$urlparts = parse_url($url);
@@ -65,9 +65,11 @@ function gprobe_run(&$argv, &$argc){
 			dbesc(normalise_link($url))
 		);
 	}
-	if(count($r))
-		if ($r[0]["network"] == NETWORK_DFRN)
+	if(count($r)) {
+		// Check for accessibility and do a poco discovery
+		if (poco_last_updated($r[0]['url'], true) AND ($r[0]["network"] == NETWORK_DFRN))
 			poco_load(0,0,$r[0]['id'], str_replace('/profile/','/poco/',$r[0]['url']));
+	}
 
 	logger("gprobe end for ".normalise_link($url), LOGGER_DEBUG);
 	return;

--- a/mod/item.php
+++ b/mod/item.php
@@ -1121,29 +1121,43 @@ function handle_tag($a, &$body, &$inform, &$str_tags, $profile_uid, $tag, $netwo
 			// Is it in format @user@domain.tld or @http://domain.tld/...?
 
 			// First check the contact table for the address
-			$r = q("SELECT `id`, `url`, `nick`, `name`, `alias`, `network`, `notify` FROM `contact` WHERE `addr` = '%s' AND `uid` = %d LIMIT 1",
+			$r = q("SELECT `id`, `url`, `nick`, `name`, `alias`, `network`, `notify` FROM `contact`
+				WHERE `addr` = '%s' AND `uid` = %d AND
+					(`network` != '%s' OR (`notify` != '' AND `alias` != ''))
+				LIMIT 1",
 					dbesc($name),
-					intval($profile_uid)
+					intval($profile_uid),
+					dbesc(NETWORK_OSTATUS)
 			);
 
 			// Then check in the contact table for the url
 			if (!$r)
-				$r = q("SELECT `id`, `url`, `nick`, `name`, `alias`, `notify`, `network` FROM `contact` WHERE `nurl` = '%s' AND `uid` = %d LIMIT 1",
+				$r = q("SELECT `id`, `url`, `nick`, `name`, `alias`, `network`, `notify` FROM `contact`
+					WHERE `nurl` = '%s' AND `uid` = %d AND
+						(`network` != '%s' OR (`notify` != '' AND `alias` != ''))
+					LIMIT 1",
 						dbesc(normalise_link($name)),
-						intval($profile_uid)
+						intval($profile_uid),
+						dbesc(NETWORK_OSTATUS)
 				);
 
 			// Then check in the global contacts for the address
 			if (!$r)
-				$r = q("SELECT `url`, `name`, `nick`, `network`, `alias`, `notify` FROM `gcontact` WHERE `addr` = '%s' LIMIT 1", dbesc($name));
+				$r = q("SELECT `url`, `nick`, `name`, `alias`, `network`, `notify` FROM `gcontact`
+					WHERE `addr` = '%s' AND (`network` != '%s' OR (`notify` != '' AND `alias` != ''))
+					LIMIT 1",
+						dbesc($name),
+						dbesc(NETWORK_OSTATUS)
+				);
 
 			// Then check in the global contacts for the url
 			if (!$r)
-				$r = q("SELECT `url`, `name`, `nick`, `network`, `alias`, `notify` FROM `gcontact` WHERE `nurl` = '%s' LIMIT 1", dbesc(normalise_link($name)));
-
-			// If the data isn't complete then refetch the data
-			if ($r AND ($r[0]["network"] == NETWORK_OSTATUS) AND (($r[0]["notify"] == "") OR ($r[0]["alias"] == "")))
-				$r = false;
+				$r = q("SELECT `url`, `nick`, `name`, `alias`, `network`, `notify` FROM `gcontact`
+					WHERE `nurl` = '%s' AND (`network` != '%s' OR (`notify` != '' AND `alias` != ''))
+					LIMIT 1",
+						dbesc(normalise_link($name)),
+						dbesc(NETWORK_OSTATUS)
+				);
 
 			if (!$r) {
 				$probed = probe_url($name);


### PR DESCRIPTION
This pull request should reduce the need of probing contact urls when writing comments. Now the probing is done when the global contact is added. Additionally the system checks every 90 days if the contact is still reachable.