### PR TITLE
Bugfix DFRN and bookmark detection

### DIFF
--- a/include/bbcode.php
+++ b/include/bbcode.php
@@ -38,6 +38,11 @@ function bb_attachment($Text, $simplehtml = false, $tryoembed = true) {
 	if (!$data)
 		return $Text;
 
+	if (isset($data["title"])) {
+		$data["title"] = strip_tags($data["title"]);
+		$data["title"] = str_replace(array("http://", "https://"), "", $data["title"]);
+	}
+
 	if (((strpos($data["text"], "[img=") !== false) OR (strpos($data["text"], "[img]") !== false)) AND ($data["image"] != "")) {
 		$data["preview"] = $data["image"];
 		$data["image"] = "";

--- a/include/dfrn.php
+++ b/include/dfrn.php
@@ -1988,7 +1988,7 @@ class dfrn {
 
 		$item["extid"] = $xpath->query("dfrn:extid/text()", $entry)->item(0)->nodeValue;
 
-		if ($xpath->query("dfrn:extid/text()", $entry)->item(0)->nodeValue == "true")
+		if ($xpath->query("dfrn:bookmark/text()", $entry)->item(0)->nodeValue == "true")
 			$item["bookmark"] = true;
 
 		$notice_info = $xpath->query("statusnet:notice_info", $entry);

--- a/include/plaintext.php
+++ b/include/plaintext.php
@@ -136,29 +136,25 @@ function get_attachment_data($body) {
 		$data["title"] = $title;
 
 	$image = "";
-	if ($type != "video") {
-		preg_match("/image='(.*?)'/ism", $attributes, $matches);
-		if ($matches[1] != "")
-			$image = $matches[1];
+	preg_match("/image='(.*?)'/ism", $attributes, $matches);
+	if ($matches[1] != "")
+		$image = $matches[1];
 
-		preg_match('/image="(.*?)"/ism', $attributes, $matches);
-		if ($matches[1] != "")
-			$image = $matches[1];
-	}
+	preg_match('/image="(.*?)"/ism', $attributes, $matches);
+	if ($matches[1] != "")
+		$image = $matches[1];
 
 	if ($image != "")
 		$data["image"] = $image;
 
 	$preview = "";
-	if ($type != "video") {
-		preg_match("/preview='(.*?)'/ism", $attributes, $matches);
-		if ($matches[1] != "")
-			$preview = $matches[1];
+	preg_match("/preview='(.*?)'/ism", $attributes, $matches);
+	if ($matches[1] != "")
+		$preview = $matches[1];
 
-		preg_match('/preview="(.*?)"/ism', $attributes, $matches);
-		if ($matches[1] != "")
-			$preview = $matches[1];
-	}
+	preg_match('/preview="(.*?)"/ism', $attributes, $matches);
+	if ($matches[1] != "")
+		$preview = $matches[1];
 
 	if ($preview != "")
 		$data["preview"] = $preview;

--- a/mod/item.php
+++ b/mod/item.php
@@ -505,10 +505,11 @@ function item_post(&$a) {
 		}
 	}
 
-	// embedded bookmark in post? set bookmark flag
+	// embedded bookmark or attachment in post? set bookmark flag
 
 	$bookmark = 0;
-	if(preg_match_all("/\[bookmark\=([^\]]*)\](.*?)\[\/bookmark\]/ism",$body,$match,PREG_SET_ORDER)) {
+	$data = get_attachment_data($body);
+        if (preg_match_all("/\[bookmark\=([^\]]*)\](.*?)\[\/bookmark\]/ism", $body, $match, PREG_SET_ORDER) OR isset($data["type"])) {
 		$objecttype = ACTIVITY_OBJ_BOOKMARK;
 		$bookmark = 1;
 	}


### PR DESCRIPTION
- The bookmark field was transmitted but not read in the DFRN protocol (there was a copy & paste problem)
- The "attachment" field is now detected as "bookmark" during the post creation
- In the attachments there was a problem with http links