### PR TITLE
Vier: No visible login border/no search and events without login

### DIFF
--- a/include/nav.php
+++ b/include/nav.php
@@ -118,15 +118,17 @@ function nav_info(&$a) {
 	if(count($a->apps)>0)
 		$nav['apps'] = array('apps', t('Apps'), "", t('Addon applications, utilities, games'));
 
-	$nav['search'] = array('search', t('Search'), "", t('Search site content'));
+	if (local_user()) {
+		$nav['search'] = array('search', t('Search'), "", t('Search site content'));
 
-	$nav['searchoption'] = array(
-					t("Full Text"),
-					t("Tags"),
-					t("Contacts"));
+		$nav['searchoption'] = array(
+						t("Full Text"),
+						t("Tags"),
+						t("Contacts"));
 
-	if (get_config('system','poco_local_search'))
-		$nav['searchoption'][] = t("Forums");
+		if (get_config('system','poco_local_search'))
+			$nav['searchoption'][] = t("Forums");
+	}
 
 	$gdirpath = 'directory';
 
@@ -140,7 +142,8 @@ function nav_info(&$a) {
 	elseif(get_config('system','community_page_style') == CP_GLOBAL_COMMUNITY)
 		$nav['community'] = array('community', t('Community'), "", t('Conversations on the network'));
 
-	$nav['events'] = Array('events', t('Events'), "", t('Events and Calendar'));
+	if(local_user())
+		$nav['events'] = Array('events', t('Events'), "", t('Events and Calendar'));
 
 	$nav['directory'] = array($gdirpath, t('Directory'), "", t('People directory'));
 

--- a/include/nav.php
+++ b/include/nav.php
@@ -118,7 +118,7 @@ function nav_info(&$a) {
 	if(count($a->apps)>0)
 		$nav['apps'] = array('apps', t('Apps'), "", t('Addon applications, utilities, games'));
 
-	if (local_user()) {
+	if (local_user() OR !get_config('system','local_search')) {
 		$nav['search'] = array('search', t('Search'), "", t('Search site content'));
 
 		$nav['searchoption'] = array(

--- a/view/theme/vier/style.css
+++ b/view/theme/vier/style.css
@@ -2378,6 +2378,11 @@ ul.tabs li .active, span.pager_current a {
 aside form {
   overflow-x: hidden;
 }
+aside form fieldset {
+  margin: 0px;
+  padding: 0px;
+  border: 0px none;
+}
 aside form .field label {
   float: left;
   width: 170px;


### PR DESCRIPTION
The login form at the side menu now doesn't have a visible border anymore so that it visually fits again.

Additionally the search and the events link in the top navbar is only shown when logged in.