### PR TITLE
add a hook call to acl_lookup()

### DIFF
--- a/doc/Plugins.md
+++ b/doc/Plugins.md
@@ -281,6 +281,11 @@ $b is an array with:
     'template' => filename of template
     'vars' => array of vars passed to template
 
+### ''acl_lookup_end'
+is called after the other queries have passed.
+The registered function can add, change or remove the acl_lookup() variables.
+
+    'results' => array of the acl_lookup() vars 
 
 
 Complete list of hook callbacks
@@ -337,6 +342,8 @@ include/acl_selectors.php:	call_hooks($a->module . '_post_' . $selname, $o);
 include/acl_selectors.php:	call_hooks($a->module . '_pre_' . $selname, $arr);
 
 include/acl_selectors.php:	call_hooks($a->module . '_post_' . $selname, $o);
+
+include/acl_selectors.php	call_hooks('acl_lookup_end', $results);
 
 include/notifier.php:		call_hooks('notifier_normal',$target_item);
 

--- a/include/acl_selectors.php
+++ b/include/acl_selectors.php
@@ -637,22 +637,35 @@ function acl_lookup(&$a, $out_type = 'json') {
 		$tot += count($unknow_contacts);
 	}
 
+	$results = array(
+		"tot"	=> $tot,
+		"start" => $start,
+		"count" => $count,
+		"groups" => $groups,
+		"contacts" => $contacts,
+		"items"	=> $items,
+		"type"	=> $type,
+		"search" => $search,
+	);
+
+	call_hooks('acl_lookup_end', $results);
+
 	if($out_type === 'html') {
 		$o = array(
-			'tot'		=> $tot,
-			'start'	=> $start,
-			'count'	=> $count,
-			'groups'	=> $groups,
-			'contacts'	=> $contacts,
+			'tot'		=> $results["tot"],
+			'start'		=> $results["start"],
+			'count'		=> $results["count"],
+			'groups'	=> $results["groups"],
+			'contacts'	=> $results["contacts"],
 		);
 		return $o;
 	}
 
 	$o = array(
-		'tot'	=> $tot,
-		'start' => $start,
-		'count'	=> $count,
-		'items'	=> $items,
+		'tot'	=> $results["tot"],
+		'start' => $results["start"],
+		'count'	=> $results["count"],
+		'items'	=> $results["items"],
 	);
 
 	echo json_encode($o);


### PR DESCRIPTION
adds a hook to make acl_lookup() extendable.

For my own needs I only need $items, $type and $search but I added the other variables too for other people.