### PR TITLE
Avoid SQL errors because of existing entries

### DIFF
--- a/include/oembed.php
+++ b/include/oembed.php
@@ -75,10 +75,13 @@ function oembed_fetch_url($embedurl, $no_rich_type = false){
 		else {	//save in cache
 			$j = json_decode($txt);
 			if ($j->type != "error")
-				q("INSERT INTO `oembed` (`url`, `content`, `created`) VALUES ('%s', '%s', '%s')",
-					dbesc(normalise_link($embedurl)), dbesc($txt), dbesc(datetime_convert()));
+				q("INSERT INTO `oembed` (`url`, `content`, `created`) VALUES ('%s', '%s', '%s')
+					ON DUPLICATE KEY UPDATE `content` = '%s', `created` = '%s'",
+					dbesc(normalise_link($embedurl)),
+					dbesc($txt), dbesc(datetime_convert()),
+					dbesc($txt), dbesc(datetime_convert()));
 
-			Cache::set($a->videowidth . $embedurl,$txt, CACHE_DAY);
+			Cache::set($a->videowidth.$embedurl,$txt, CACHE_DAY);
 		}
 	}
 

--- a/mod/parse_url.php
+++ b/mod/parse_url.php
@@ -72,8 +72,11 @@ function parseurl_getsiteinfo_cached($url, $no_guessing = false, $do_oembed = tr
 
 	$data = parseurl_getsiteinfo($url, $no_guessing, $do_oembed);
 
-	q("INSERT INTO `parsed_url` (`url`, `guessing`, `oembed`, `content`, `created`) VALUES ('%s', %d, %d, '%s', '%s')",
-		dbesc(normalise_link($url)), intval(!$no_guessing), intval($do_oembed), dbesc(serialize($data)), dbesc(datetime_convert()));
+	q("INSERT INTO `parsed_url` (`url`, `guessing`, `oembed`, `content`, `created`) VALUES ('%s', %d, %d, '%s', '%s')
+		 ON DUPLICATE KEY UPDATE `content` = '%s', `created` = '%s'",
+		dbesc(normalise_link($url)), intval(!$no_guessing), intval($do_oembed),
+		dbesc(serialize($data)), dbesc(datetime_convert()),
+		dbesc(serialize($data)), dbesc(datetime_convert()));
 
 	return $data;
 }


### PR DESCRIPTION
There can be timing problems with multiple inserts of the same data. This is solved now by using an extended SQL command.