### PR TITLE
Better implementation of "hidewall" with feeds

### DIFF
--- a/include/dfrn.php
+++ b/include/dfrn.php
@@ -68,6 +68,7 @@ class dfrn {
 	 * @param string $owner_nick Owner nick name
 	 * @param string $last_update Date of the last update
 	 * @param int $direction Can be -1, 0 or 1.
+	 * @param boolean $onlyheader Output only the header without content? (Default is "no")
 	 *
 	 * @return string DFRN feed entries
 	 */

--- a/include/dfrn.php
+++ b/include/dfrn.php
@@ -71,7 +71,7 @@ class dfrn {
 	 *
 	 * @return string DFRN feed entries
 	 */
-	public static function feed($dfrn_id, $owner_nick, $last_update, $direction = 0) {
+	public static function feed($dfrn_id, $owner_nick, $last_update, $direction = 0, $onlyheader = false) {
 
 		$a = get_app();
 
@@ -234,7 +234,7 @@ class dfrn {
 		// This hook can't work anymore
 		//	call_hooks('atom_feed', $atom);
 
-		if(! count($items)) {
+		if (!count($items) OR $onlyheader) {
 			$atom = trim($doc->saveXML());
 
 			call_hooks('atom_feed_end', $atom);

--- a/include/dfrn.php
+++ b/include/dfrn.php
@@ -462,44 +462,52 @@ class dfrn {
 	 */
 	private function add_author($doc, $owner, $authorelement, $public) {
 
-		$author = $doc->createElement($authorelement);
-
-		$namdate = datetime_convert('UTC', 'UTC', $owner['name-date'].'+00:00' , ATOM_TIME);
-		$uridate = datetime_convert('UTC', 'UTC', $owner['uri-date'].'+00:00', ATOM_TIME);
-		$picdate = datetime_convert('UTC', 'UTC', $owner['avatar-date'].'+00:00', ATOM_TIME);
-
-		$attributes = array("dfrn:updated" => $namdate);
-		xml::add_element($doc, $author, "name", $owner["name"], $attributes);
-
-		$attributes = array("dfrn:updated" => $namdate);
-		xml::add_element($doc, $author, "uri", app::get_baseurl().'/profile/'.$owner["nickname"], $attributes);
-
-		$attributes = array("dfrn:updated" => $namdate);
-		xml::add_element($doc, $author, "dfrn:handle", $owner["addr"], $attributes);
-
-		$attributes = array("rel" => "photo", "type" => "image/jpeg", "dfrn:updated" => $picdate,
-					"media:width" => 175, "media:height" => 175, "href" => $owner['photo']);
-		xml::add_element($doc, $author, "link", "", $attributes);
-
-		$attributes = array("rel" => "avatar", "type" => "image/jpeg", "dfrn:updated" => $picdate,
-					"media:width" => 175, "media:height" => 175, "href" => $owner['photo']);
-		xml::add_element($doc, $author, "link", "", $attributes);
-
-		$birthday = feed_birthday($owner['uid'], $owner['timezone']);
-
-		if ($birthday)
-			xml::add_element($doc, $author, "dfrn:birthday", $birthday);
-
 		// Is the profile hidden or shouldn't be published in the net? Then add the "hide" element
 		$r = q("SELECT `id` FROM `profile` INNER JOIN `user` ON `user`.`uid` = `profile`.`uid`
 				WHERE (`hidewall` OR NOT `net-publish`) AND `user`.`uid` = %d",
 			intval($owner['uid']));
 		if ($r)
+			$hidewall = true;
+		else
+			$hidewall = false;
+
+		$author = $doc->createElement($authorelement);
+
+		$namdate = datetime_convert('UTC', 'UTC', $owner['name-date'].'+00:00', ATOM_TIME);
+		$uridate = datetime_convert('UTC', 'UTC', $owner['uri-date'].'+00:00', ATOM_TIME);
+		$picdate = datetime_convert('UTC', 'UTC', $owner['avatar-date'].'+00:00', ATOM_TIME);
+
+		if (!$public OR !$hidewall)
+			$attributes = array("dfrn:updated" => $namdate);
+		else
+			$attributes = array();
+
+		xml::add_element($doc, $author, "name", $owner["name"], $attributes);
+		xml::add_element($doc, $author, "uri", app::get_baseurl().'/profile/'.$owner["nickname"], $attributes);
+		xml::add_element($doc, $author, "dfrn:handle", $owner["addr"], $attributes);
+
+		$attributes = array("rel" => "photo", "type" => "image/jpeg",
+					"media:width" => 175, "media:height" => 175, "href" => $owner['photo']);
+
+		if (!$public OR !$hidewall)
+			$attributes["dfrn:updated"] = $picdate;
+
+		xml::add_element($doc, $author, "link", "", $attributes);
+
+		$attributes["rel"] = "avatar";
+		xml::add_element($doc, $author, "link", "", $attributes);
+
+		if ($hidewall)
 			xml::add_element($doc, $author, "dfrn:hide", "true");
 
 		// The following fields will only be generated if the data isn't meant for a public feed
 		if ($public)
 			return $author;
+
+		$birthday = feed_birthday($owner['uid'], $owner['timezone']);
+
+		if ($birthday)
+			xml::add_element($doc, $author, "dfrn:birthday", $birthday);
 
 		// Only show contact details when we are allowed to
 		$r = q("SELECT `profile`.`about`, `profile`.`name`, `profile`.`homepage`, `user`.`nickname`, `user`.`timezone`,

--- a/mod/dfrn_poll.php
+++ b/mod/dfrn_poll.php
@@ -25,6 +25,8 @@ function dfrn_poll_init(&$a) {
 		$dfrn_id   = substr($dfrn_id,2);
 	}
 
+	$hidewall = false;
+
 	if(($dfrn_id === '') && (! x($_POST,'dfrn_id'))) {
 		if((get_config('system','block_public')) && (! local_user()) && (! remote_user())) {
 			http_status_exit(403);
@@ -35,16 +37,17 @@ function dfrn_poll_init(&$a) {
 			$r = q("SELECT `hidewall`,`nickname` FROM `user` WHERE `user`.`nickname` = '%s' LIMIT 1",
 				dbesc($a->argv[1])
 			);
-			if(! $r)
+			if (!$r)
 				http_status_exit(404);
-			if(($r[0]['hidewall']) && (! local_user()))
-				http_status_exit(403);
+
+			$hidewall = ($r[0]['hidewall'] && !local_user());
+
 			$user = $r[0]['nickname'];
 		}
 
 		logger('dfrn_poll: public feed request from ' . $_SERVER['REMOTE_ADDR'] . ' for ' . $user);
 		header("Content-type: application/atom+xml");
-		echo dfrn::feed('', $user,$last_update);
+		echo dfrn::feed('', $user,$last_update, 0, $hidewall);
 		killme();
 	}
 


### PR DESCRIPTION
When "hidewall" is activated it prevents visitors from seeing posts of a profile - but not the profile itself. This can be seen.

The feed under "dfrn_poll" now behaves the same. It don't returns an error 403 anymore, but a (purified) feed header without a post.

This is done so that vitality checks for profiles can be done reliable. (This is done by visiting the feed)

The data under "dfrn_poll" does not contain more data than the data that can be taken from the profile page so this is not a problem.