### PR TITLE
Support for comments for the Diaspora relay system

### DIFF
--- a/include/notifier.php
+++ b/include/notifier.php
@@ -549,7 +549,7 @@ function notifier_run(&$argv, &$argc){
 
 	if($public_message) {
 
-		if (!$followup AND $top_level)
+		if (!$followup)
 			$r0 = diaspora::relay_list();
 		else
 			$r0 = array();


### PR DESCRIPTION
The experimental Diaspora relay is now able to relay comments and likes as well.