### PR TITLE
Bugfix for shares in the plaintext function

### DIFF
--- a/include/plaintext.php
+++ b/include/plaintext.php
@@ -343,7 +343,7 @@ function plaintext($a, $b, $limit = 0, $includedlinks = false, $htmlmode = 2, $t
 		}
 	}
 
-	$html = bbcode($post["text"], false, false, $htmlmode);
+	$html = bbcode($post["text"].$post["after"], false, false, $htmlmode);
 	$msg = html2plain($html, 0, true);
 	$msg = trim(html_entity_decode($msg,ENT_QUOTES,'UTF-8'));
 

--- a/include/plaintext.php
+++ b/include/plaintext.php
@@ -128,10 +128,9 @@ function get_attachment_data($body) {
 	if ($matches[1] != "")
 		$title = $matches[1];
 
-	//$title = htmlentities($title, ENT_QUOTES, 'UTF-8', false);
 	$title = bbcode(html_entity_decode($title, ENT_QUOTES, 'UTF-8'), false, false, true);
+	$title = html_entity_decode($title, ENT_QUOTES, 'UTF-8');
 	$title = str_replace(array("[", "]"), array("&#91;", "&#93;"), $title);
-
 	if ($title != "")
 		$data["title"] = $title;
 


### PR DESCRIPTION
Shared posts to third party networks had some optical failure since the changes in the share functionality. This is fixed now.