### PR TITLE
Fix OpenID login

### DIFF
--- a/library/openid.php
+++ b/library/openid.php
@@ -375,7 +375,7 @@ class LightOpenID
                                 $server = $server[1];
                                 if (isset($delegate[2])) $this->identity = trim($delegate[2]);
                                 $this->version = 2;
-logger('Server: ' . $server);
+#logger('Server: ' . $server);
                                 $this->server = $server;
                                 return $server;
                             }

--- a/mod/openid.php
+++ b/mod/openid.php
@@ -18,7 +18,8 @@ function openid_content(&$a) {
 
 		if($openid->validate()) {
 
-			$authid = normalise_openid($_REQUEST['openid_identity']);
+			#$authid = normalise_openid($_REQUEST['openid_identity']);
+			$authid = $_REQUEST['openid_identity'];
 
 			if(! strlen($authid)) {
 				logger( t('OpenID protocol error. No ID returned.') . EOL);

--- a/mod/openid.php
+++ b/mod/openid.php
@@ -26,10 +26,15 @@ function openid_content(&$a) {
 				goaway(z_root());
 			}
 
+			// NOTE: we search both for normalised and non-normalised form of $authid
+			//       because the normalization step was removed from setting
+			//       mod/settings.php in 8367cad so it might have left mixed
+			//       records in the user table
+			//
 			$r = q("SELECT `user`.*, `user`.`pubkey` as `upubkey`, `user`.`prvkey` as `uprvkey` 
-				FROM `user` WHERE `openid` = '%s' AND `blocked` = 0 
+				FROM `user` WHERE ( openid = '%s' OR openid = '%s' ) AND blocked = 0
 				AND `account_expired` = 0 AND `account_removed` = 0 AND `verified` = 1 LIMIT 1",
-				dbesc($authid)
+				dbesc($authid), dbesc(normalise_openid($authid))
 			);
 
 			if($r && count($r)) {

--- a/mod/openid.php
+++ b/mod/openid.php
@@ -18,7 +18,6 @@ function openid_content(&$a) {
 
 		if($openid->validate()) {
 
-			#$authid = normalise_openid($_REQUEST['openid_identity']);
 			$authid = $_REQUEST['openid_identity'];
 
 			if(! strlen($authid)) {
@@ -31,9 +30,11 @@ function openid_content(&$a) {
 			//       mod/settings.php in 8367cad so it might have left mixed
 			//       records in the user table
 			//
-			$r = q("SELECT `user`.*, `user`.`pubkey` as `upubkey`, `user`.`prvkey` as `uprvkey` 
-				FROM `user` WHERE ( openid = '%s' OR openid = '%s' ) AND blocked = 0
-				AND `account_expired` = 0 AND `account_removed` = 0 AND `verified` = 1 LIMIT 1",
+			$r = q("SELECT * FROM `user`
+				WHERE ( `openid` = '%s' OR `openid` = '%s' )
+				AND `blocked` = 0 AND `account_expired` = 0
+				AND `account_removed` = 0 AND `verified` = 1
+				LIMIT 1",
 				dbesc($authid), dbesc(normalise_openid($authid))
 			);
 


### PR DESCRIPTION
The problem was that while openid was stored not-normalized in the database,
the checking code was looking for a normalized form instead.

The commit removing normalization step on saving user preferences
was 8367cad, which might have left old users with normalized openid
and new users with non-normalized one.

This commit makes the checking code look for both normalized and not
normalized form, to be backward compatible.

\cc @tobiasd 

NOTE: I also removed a debugging print which was flooding the log (about opendi)