### PR TITLE
Frio: Added a link to the thread on the same server

### DIFF
--- a/view/theme/frio/templates/wall_thread.tpl
+++ b/view/theme/frio/templates/wall_thread.tpl
@@ -190,7 +190,7 @@ as the value of $top_child_total (this is done at the end of this file)
 
 			<div class="additional-info text-muted">
 				<div id="wall-item-ago-{{$item.id}}" class="wall-item-ago">
-					<small><span class="time" title="{{$item.localtime}}" data-toggle="tooltip">{{$item.ago}}</span></small>
+					<small><a href="{{$item.plink.orig}}"><span class="time" title="{{$item.localtime}}" data-toggle="tooltip">{{$item.ago}}</span></a></small>
 				</div>
 
 				{{if $item.location}}
@@ -207,7 +207,7 @@ as the value of $top_child_total (this is done at the end of this file)
 			<h5 class="media-heading">
 				<a href="{{$item.profile_url}}" title="{{$item.linktitle}}" class="wall-item-name-link userinfo"><span>{{$item.name}}</span></a>
 				<p class="text-muted">
-					<small><span class="wall-item-ago">{{$item.ago}}</span> {{if $item.location}}&nbsp;&mdash;&nbsp;({{$item.location}}){{/if}}</small>
+					<small><a class="time" href="{{$item.plink.orig}}"><span class="wall-item-ago">{{$item.ago}}</span></a> {{if $item.location}}&nbsp;&mdash;&nbsp;({{$item.location}}){{/if}}</small>
 				</p>
 			</h5>
 		</div>


### PR DESCRIPTION
When you now click on the date field of a post, this will direct you to the single thread view of that post on the same server. This behaviour is found on many other networks as well (like Diaspora, GNU Social, pump.io, Twitter or Google+)