### PR TITLE
Small fixes to Frio theme

### DIFF
--- a/view/theme/frio/config.php
+++ b/view/theme/frio/config.php
@@ -36,6 +36,7 @@ function frio_form(&$a, $arr) {
 	
 	$scheme_info = get_schema_info($arr["schema"]);
 	$disable = $scheme_info["overwrites"];
+	if (!is_array($disable)) $disable = array();
 
 	$scheme_choices = array();
 	$scheme_choices["---"] = t("Default");

--- a/view/theme/frio/php/modes/default.php
+++ b/view/theme/frio/php/modes/default.php
@@ -44,7 +44,6 @@ else
 	echo"<body id=\"top\">";
 }
 ?>
-<?php if($_SERVER['REQUEST_URI'] == "/"){header('Location: /login');} ?>
 <a href="#content" class="sr-only sr-only-focusable">Skip to main content</a>
 <?php
 	if(x($page,'nav') && (!$minimal)){


### PR DESCRIPTION
two small fixes:

- initialize `$disable` array in `config.php`. Fix warnings when default schema is selected.
- remove the call to `header()` in `default.php`. Fix another error message, because output was already sent to the browser when header was called. 