### PR TITLE
frio: open hovercard on click if device is a mobile device

### DIFF
--- a/view/theme/frio/js/hovercard.js
+++ b/view/theme/frio/js/hovercard.js
@@ -47,6 +47,14 @@ $(document).ready(function(){
 			var title = targetElement.attr("title");
 			targetElement.attr({"data-orig-title": title, title: ""});
 
+			// if the device is a mobile open the hover card by click and not by hover
+			if(typeof is_mobile != "undefined") {
+					targetElement[0].removeAttribute("href");
+					var hctrigger = 'click';
+				} else {
+					var hctrigger = 'manual';
+			};
+
 			// Timeoute until the hover-card does appear
 			setTimeout(function(){
 				if(targetElement.is(":hover") && parseInt(targetElement.attr('data-awaiting-hover-card'),10) == timeNow) {
@@ -69,7 +77,7 @@ $(document).ready(function(){
 										}
 										return "top";
 									},
-									trigger: 'manual',
+									trigger: hctrigger,
 									template: '<div class="popover hovercard" data-card-created="' + timeNow + '"><div class="arrow"></div><div class="popover-content hovercard-content"></div></div>',
 									content: data
 								}).popover('show');
@@ -90,8 +98,12 @@ $(document).ready(function(){
 
 	// hover cards should be removed very easily, e.g. when any of these events happen
 	$('body').on("mouseleave touchstart scroll click dblclick mousedown mouseup submit keydown keypress keyup", function(e){
-		var timeNow = new Date().getTime();
-		removeAllhoverCards(e,timeNow);
+		// remove hover card only for desktiop user, since on mobile we openen the hovercards
+		// by click event insteadof hover
+		if(typeof is_mobile == "undefined") {
+			var timeNow = new Date().getTime();
+			removeAllhoverCards(e,timeNow);
+		};
 	});
 
 	// if we're hovering a hover card, give it a class, so we don't remove it

--- a/view/theme/frio/theme.php
+++ b/view/theme/frio/theme.php
@@ -21,9 +21,16 @@ function frio_init(&$a) {
 	$frio = "view/theme/frio";
 
 	global $frio;
-	
-	
 
+	// if the device is a mobile device set js is_mobile
+	// variable so the js scripts can use this information
+	if($a->is_mobile || $a->is_tablet) {
+		$a->page["htmlhead"] .= <<< EOT
+			<script>
+				var is_mobile = 1;
+			</script>
+EOT;
+			}
 
 	if ($style == "")
 		$style = get_config('frio', 'style');


### PR DESCRIPTION
heading describes it :-)

Since on touch devices no hovering is possible the hover card opens on click event instead on hovering.

On links which directs to the profile page the href attribute will be deleted. I see no problem with this since the profile link will be available through the hover card. But this would mean that frio_hovercard is getting more and more a requirement to have the full friendica/frio experience 