### PR TITLE
Frio: Hovercard is now a core function

### DIFF
--- a/mod/hovercard.php
+++ b/mod/hovercard.php
@@ -1,0 +1,126 @@
+<?php
+
+/**
+ * Name: Frio Hovercard
+ * Description: Hovercard addon for the frio theme
+ * Version: 0.1
+ * Author: Rabuzarus <https://github.com/rabuzarus>
+ * License: GNU AFFERO GENERAL PUBLIC LICENSE (Version 3)
+ */
+
+require_once("include/socgraph.php");
+require_once("include/Contact.php");
+
+function hovercard_init(&$a) {
+	// Just for testing purposes
+	$_GET["mode"] = "minimal";
+}
+function hovercard_content() {
+	$profileurl	=	(x($_REQUEST,'profileurl')	? $_REQUEST['profileurl']	: "");
+	$datatype	=	(x($_REQUEST,'datatype')	?$_REQUEST['datatype']		: "json");
+
+	// Get out if the system doesn't have public access allowed
+	if(intval(get_config('system','block_public')))
+		http_status_exit(401);
+
+	// Return the raw content of the template. We use this to make templates usable for js functions.
+	// Look at hovercard.js (function getHoverCardTemplate()).
+	// This part should be moved in it's own module. Maybe we could make more templates accessabel.
+	// (We need to discuss possible security lacks before doing this)
+	if ($datatype == "tpl") {
+		$templatecontent = get_template_content("hovercard.tpl");
+		echo $templatecontent;
+		killme();
+	}
+
+	// If a contact is connected the url is internally changed to "redir/CID". We need the pure url to search for
+	// the contact. So we strip out the contact id from the internal url and look in the contact table for
+	// the real url (nurl)
+	if(local_user() && strpos($profileurl, "redir/") === 0) {
+		$cid = intval(substr($profileurl, 6));
+		$r = q("SELECT `nurl`, `self`  FROM `contact` WHERE `id` = '%d' LIMIT 1", intval($cid));
+		$profileurl = ($r[0]["nurl"] ? $r[0]["nurl"] : "");
+		$self = ($r[0]["self"] ? $r[0]["self"] : "");
+	}
+
+	// if it's the url containing https it should be converted to http
+	$nurl = normalise_link(clean_contact_url($profileurl));
+	if($nurl) {
+		// Search for contact data
+		$contact = get_contact_details_by_url($nurl);
+
+		// Get_contact_details_by_url() doesn't provide the nurl but we
+		// need it for the photo_menu, so we copy it to the contact array
+		if (!isset($contact["nurl"]))
+			$contact["nurl"] = $nurl;
+	}
+
+	if(!is_array($contact))
+		return;
+
+	// Get the photo_menu - the menu if possible contact actions
+	if(local_user())
+		$actions = contact_photo_menu($contact);
+
+
+	// Move the contact data to the profile array so we can deliver it to
+	//
+	$profile = array(
+		'name' => $contact["name"],
+		'nick'	=> $contact["nick"],
+		'addr'	=> (($contact["addr"] != "") ? $contact["addr"] : $contact["url"]),
+		'thumb' => proxy_url($contact["photo"], false, PROXY_SIZE_THUMB),
+		'url' => ($cid ? ("redir/".$cid) : zrl($contact["url"])),
+		'nurl' => $contact["nurl"], // We additionally store the nurl as identifier
+//		'alias' => $contact["alias"],
+		'location' => $contact["location"],
+		'gender' => $contact["gender"],
+		'about' => $contact["about"],
+		'network' => format_network_name($contact["network"], $contact["url"]),
+		'tags' => intval($contact["keywords"]),
+//		'nsfw' => intval($contact["nsfw"]),
+//		'server_url' => $contact["server_url"],
+		'bd' => (($contact["birthday"] == "0000-00-00") ? "" : $contact["birthday"]),
+//		'generation' => $contact["generation"],
+		'account_type' => ($contact['community'] ? t("Forum") : ""),
+		'actions' => $actions,
+	);
+
+	if($datatype == "html") {
+		$t = get_markup_template("hovercard.tpl");
+
+		$o = replace_macros($t, array(
+			'$profile' => $profile,
+		));
+
+		return $o;
+
+	} else {
+		json_return_and_die($profile);
+	}
+}
+
+/**
+ * @brief Get the raw content of a template file
+ * 
+ * @param string $template The name of the template
+ * @param string $root Directory of the template
+ * 
+ * @return string|bool Output the raw content if existent, otherwise false
+ */
+function get_template_content($template, $root = "") {
+
+	// We load the whole template system to get the filename.
+	// Maybe we can do it a little bit smarter if I get time.
+	$t = get_markup_template($template, $root);
+	$filename = $t->filename;
+
+	// Get the content of the template file
+	if(file_exists($filename)) {
+		$content = file_get_contents($filename);
+
+		return $content;
+	}
+
+	return false;
+}

--- a/view/templates/hovercard.tpl
+++ b/view/templates/hovercard.tpl
@@ -1,0 +1,39 @@
+<div class="basic-content" >
+	<div class="hover-card-details">
+		<div class="hover-card-header left-align">
+			<div class="hover-card-pic left-align">
+				<span class="image-wrapper medium">
+					<a href="{{$profile.url}}" title="{{$profile.name}}"><img href="" class="left-align thumbnail" src="{{$profile.thumb}}"></a>
+				</span>
+			</div>
+			<div class="hover-card-content">
+				<div class="profile-entry-name">
+					<h4 class="left-align1"><a href="{{$profile.url}}">{{$profile.name}}</a></h4>{{if $profile.account_type}}<span>{{$profile.account_type}}</span>{{/if}}
+				</div>
+				<div class="profile-details">
+					<span class="profile-addr">{{$profile.addr}}</span>
+					{{if $profile.network}}<span class="profile-network"> ({{$profile.network}})</span>{{/if}}
+				</div>
+				{{*{{if $profile.about}}<div class="profile-details profile-about">{{$profile.about}}</div>{{/if}}*}}
+	
+			</div>
+			<div class="hover-card-actions  right-aligned">
+				{{* here are the differnt actions like privat message, poke, delete and so on *}}
+				{{* @todo we have two different photo menus one for contacts and one for items at the network stream. We currently use the contact photo menu, so the items options are missing We need to move them *}}
+				<div class="hover-card-actions-social">
+					{{if $profile.actions.pm}}<a class="btn btn-labeled btn-primary btn-sm" onclick="addToModal('{{$profile.actions.pm.1}}')" title="{{$profile.actions.pm.0}}"><i class="fa fa-envelope" aria-hidden="true"></i></a>{{/if}}
+					{{if $profile.actions.poke}}<a class="btn btn-labeled btn-primary btn-sm" onclick="addToModal('{{$profile.actions.poke.1}}')" title="{{$profile.actions.poke.0}}"><i class="fa fa-heartbeat" aria-hidden="true"></i></a>{{/if}}
+				</div>
+				<div class="hover-card-actions-connection">
+					{{if $profile.actions.network}}<a class="btn btn-labeled btn-primary btn-sm" href="{{$profile.actions.network.1}}" title="{{$profile.actions.network.0}}"><i class="fa fa-cloud" aria-hidden="true"></i></a>{{/if}}
+					{{if $profile.actions.edit}}<a class="btn btn-labeled btn-primary btn-sm" href="{{$profile.actions.edit.1}}" title="{{$profile.actions.edit.0}}"><i class="fa fa-pencil" aria-hidden="true"></i></a>{{/if}}
+					{{if $profile.actions.follow}}<a class="btn btn-labeled btn-primary btn-sm" href="{{$profile.actions.follow.1}}" title="{{$profile.actions.follow.0}}"><i class="fa fa-user-plus" aria-hidden="true"></i></a>{{/if}}
+				</div>
+			</div>
+		</div>
+
+		<div class="clearfix"></div>
+
+	</div>
+</div>
+{{if $profile.tags}}<div class="hover-card-footer">{{$profile.tags}}</div>{{/if}}

--- a/view/theme/frio/css/hovercard.css
+++ b/view/theme/frio/css/hovercard.css
@@ -286,7 +286,7 @@
   display: flex;
 }
 .hover-card-actions-connection {
-  margin-left: 30px;
+  margin-left: 10px;
 }
 .hovercard .hovercard-content .hover-card-actions a.btn {
   display: inline-block;

--- a/view/theme/frio/js/hovercard.js
+++ b/view/theme/frio/js/hovercard.js
@@ -40,7 +40,7 @@ $(document).ready(function(){
 			// Take link href attribute as link to the profile
 			var profileurl = hrefAttr;
 			// the url to get the contact and template data
-			var url = baseurl + "/frio_hovercard";
+			var url = baseurl + "/hovercard";
 
 			// store the title in an other data attribute beause bootstrap
 			// popover destroys the title.attribute. We can restore it later


### PR DESCRIPTION
Like discussed here: https://github.com/friendica/friendica/issues/2537

Additionally it is changed so that it now contains these actions:
![bildschirmfoto 2016-05-29 um 16 01 26](https://cloud.githubusercontent.com/assets/844208/15633827/cc88d00c-25b6-11e6-9d04-b4c4db4b815f.png)

The space between the actions is reduced. And instead of deleting there is now an option for the posts.

For testing purposes the page mode for html is set to "minimal".