### PR TITLE
Frio: Removed github link, changed notification description

### DIFF
--- a/include/nav.php
+++ b/include/nav.php
@@ -170,7 +170,7 @@ function nav_info(&$a) {
 			if(in_array($_SESSION['page_flags'], array(PAGE_NORMAL, PAGE_SOAPBOX, PAGE_FREELOVE))) {
 				$nav['notifications'] = array('notifications',	t('Notifications'), "", t('Notifications'));
 				$nav['notifications']['all']=array('notifications/system', t('See all notifications'), "", "");
-				$nav['notifications']['mark'] = array('', t('Mark all system notifications seen'), '','');
+				$nav['notifications']['mark'] = array('', t('Mark as seen'), '',t('Mark all system notifications seen'));
 			}
 		}
 

--- a/view/templates/nav.tpl
+++ b/view/templates/nav.tpl
@@ -50,7 +50,7 @@
 				<span id="notify-update" class="nav-ajax-left"></span>
 				<ul id="nav-notifications-menu" class="menu-popup">
 					<li id="nav-notifications-see-all"><a href="{{$nav.notifications.all.0}}">{{$nav.notifications.all.1}}</a></li>
-					<li id="nav-notifications-mark-all"><a href="#" onclick="notifyMarkAll(); return false;">{{$nav.notifications.mark.1}}</a></li>
+					<li id="nav-notifications-mark-all"><a href="#" onclick="notifyMarkAll(); return false;">{{$nav.notifications.mark.3}}</a></li>
 					<li class="empty">{{$emptynotifications}}</li>
 				</ul>
 		{{/if}}		

--- a/view/theme/cleanzero/templates/nav.tpl
+++ b/view/theme/cleanzero/templates/nav.tpl
@@ -35,7 +35,7 @@
 				<span id="notify-update" class="nav-ajax-left"></span>
 				<ul id="nav-notifications-menu" class="menu-popup">
 					<li id="nav-notifications-see-all"><a href="{{$nav.notifications.all.0}}">{{$nav.notifications.all.1}}</a></li>
-					<li id="nav-notifications-mark-all"><a href="#" onclick="notifyMarkAll(); return false;">{{$nav.notifications.mark.1}}</a></li>
+					<li id="nav-notifications-mark-all"><a href="#" onclick="notifyMarkAll(); return false;">{{$nav.notifications.mark.3}}</a></li>
 					<li class="empty">{{$emptynotifications}}</li>
 				</ul>
 		{{/if}}	

--- a/view/theme/decaf-mobile/templates/nav.tpl
+++ b/view/theme/decaf-mobile/templates/nav.tpl
@@ -67,7 +67,7 @@
 	{{*<!--<span id="notify-update" class="nav-ajax-left"></span>
 	<ul id="nav-notifications-menu" class="notifications-menu-popup">
 		<li id="nav-notifications-see-all"><a href="{{$nav.notifications.all.0}}">{{$nav.notifications.all.1}}</a></li>
-		<li id="nav-notifications-mark-all"><a href="#" onclick="notifyMarkAll(); return false;">{{$nav.notifications.mark.1}}</a></li>
+		<li id="nav-notifications-mark-all"><a href="#" onclick="notifyMarkAll(); return false;">{{$nav.notifications.mark.3}}</a></li>
 		<li class="empty">{{$emptynotifications}}</li>
 	</ul>-->*}}
 	</div>

--- a/view/theme/diabook/templates/nav.tpl
+++ b/view/theme/diabook/templates/nav.tpl
@@ -48,7 +48,7 @@
 			<span class="icon notify">{{$nav.notifications.1}}</span>
 				<span id="notify-update" class="nav-notify"></span></a>
 				<ul id="nav-notifications-menu" class="menu-popup">
-					<li id="nav-notifications-mark-all"><a href="#" onclick="notifyMarkAll(); return false;">{{$nav.notifications.mark.1}}</a></li>
+					<li id="nav-notifications-mark-all"><a href="#" onclick="notifyMarkAll(); return false;">{{$nav.notifications.mark.3}}</a></li>
 					<li id="nav-notifications-see-all"><a href="{{$nav.notifications.all.0}}">{{$nav.notifications.all.1}}</a></li>
 					<li class="empty">{{$emptynotifications}}</li>
 				</ul>

--- a/view/theme/dispy/templates/nav.tpl
+++ b/view/theme/dispy/templates/nav.tpl
@@ -25,7 +25,7 @@
             rel="#nav-notifications-menu" title="{{$nav.notifications.1}}">{{$nav.notifications.1}}</a></li>
         <ul id="nav-notifications-menu" class="menu-popup">
             <li id="nav-notifications-see-all"><a href="{{$nav.notifications.all.0}}">{{$nav.notifications.all.1}}</a></li>
-            <li id="nav-notifications-mark-all"><a href="#" onclick="notifyMarkAll(); return false;">{{$nav.notifications.mark.1}}</a></li>
+            <li id="nav-notifications-mark-all"><a href="#" onclick="notifyMarkAll(); return false;">{{$nav.notifications.mark.3}}</a></li>
             <li class="empty">{{$emptynotifications}}</li>
         </ul>
     {{/if}}

--- a/view/theme/duepuntozero/templates/nav.tpl
+++ b/view/theme/duepuntozero/templates/nav.tpl
@@ -49,7 +49,7 @@
 				<span id="notify-update" class="nav-ajax-left"></span>
 				<ul id="nav-notifications-menu" class="menu-popup">
 					<li id="nav-notifications-see-all"><a href="{{$nav.notifications.all.0}}">{{$nav.notifications.all.1}}</a></li>
-					<li id="nav-notifications-mark-all"><a href="#" onclick="notifyMarkAll(); return false;">{{$nav.notifications.mark.1}}</a></li>
+					<li id="nav-notifications-mark-all"><a href="#" onclick="notifyMarkAll(); return false;">{{$nav.notifications.mark.3}}</a></li>
 					<li class="empty">{{$emptynotifications}}</li>
 				</ul>
 		{{/if}}		

--- a/view/theme/facepark/templates/nav.tpl
+++ b/view/theme/facepark/templates/nav.tpl
@@ -50,7 +50,7 @@
 				<span id="notify-update" class="nav-ajax-left"></span>
 				<ul id="nav-notifications-menu" class="menu-popup">
 					<li id="nav-notifications-see-all"><a href="{{$nav.notifications.all.0}}">{{$nav.notifications.all.1}}</a></li>
-					<li id="nav-notifications-mark-all"><a href="#" onclick="notifyMarkAll(); return false;">{{$nav.notifications.mark.1}}</a></li>
+					<li id="nav-notifications-mark-all"><a href="#" onclick="notifyMarkAll(); return false;">{{$nav.notifications.mark.3}}</a></li>
 					<li class="empty">{{$emptynotifications}}</li>
 				</ul>
 		{{/if}}		

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -527,7 +527,8 @@ nav.navbar a {
 }
 /* The Top Nav Bar user menu */
 #topbar-first .account .user-title {
-    text-align: right
+    text-align: right;
+    margin-top: 7px;
 }
 #topbar-first .account .user-title span {
     color: $nav_icon_color;

--- a/view/theme/frio/templates/nav.tpl
+++ b/view/theme/frio/templates/nav.tpl
@@ -84,7 +84,7 @@
 									<div class="arrow"></div>
 									{{$nav.notifications.1}}
 									<div class="dropdown-header-link">
-										<a href="#" onclick="notifyMarkAll(); return false;" data-toggle="tooltip" title="{{$nav.notifications.mark.1}}" class="">{{$clear_notifs}}{{*** @todo Translation ***}}</a>
+										<a href="#" onclick="notifyMarkAll(); return false;" data-toggle="tooltip" title="{{$nav.notifications.mark.1}}" class="">{{$clear_notifs}}</a>
 									</div>
 
 								</li>

--- a/view/theme/frio/templates/nav.tpl
+++ b/view/theme/frio/templates/nav.tpl
@@ -84,7 +84,7 @@
 									<div class="arrow"></div>
 									{{$nav.notifications.1}}
 									<div class="dropdown-header-link">
-										<a href="#" onclick="notifyMarkAll(); return false;" data-toggle="tooltip" title="{{$nav.notifications.mark.1}}" class="">{{$clear_notifs}}</a>
+										<a href="#" onclick="notifyMarkAll(); return false;" data-toggle="tooltip" title="{{$nav.notifications.mark.3}}" class="">{{$nav.notifications.mark.1}}</a>
 									</div>
 
 								</li>

--- a/view/theme/frio/templates/nav.tpl
+++ b/view/theme/frio/templates/nav.tpl
@@ -84,7 +84,7 @@
 									<div class="arrow"></div>
 									{{$nav.notifications.1}}
 									<div class="dropdown-header-link">
-										<a href="#" onclick="notifyMarkAll(); return false;" data-toggle="tooltip" title="{{$nav.notifications.mark.1}}" class="">Mark as read{{*** @todo Translation ***}}</a>
+										<a href="#" onclick="notifyMarkAll(); return false;" data-toggle="tooltip" title="{{$nav.notifications.mark.1}}" class="">{{$clear_notifs}}{{*** @todo Translation ***}}</a>
 									</div>
 
 								</li>
@@ -139,8 +139,6 @@
 							{{foreach $nav.usermenu as $usermenu}}
 							<li role="menuitem"><a class="{{$usermenu.2}}" href="{{$usermenu.0}}" title="{{$usermenu.3}}">{{$usermenu.1}}</a></li>
 							{{/foreach}}
-							<li role="separator" class="divider"></li>
-							<li role="menuitem"><a href="https://github.com/rabuzarus/frio" target="new" title="frio on GitHub"><i class="fa fa-github"></i> frio on GitHub</a></li>
 							<li role="separator" class="divider"></li>
 							{{if $nav.notifications}}
 							<li role="menuitem"><a href="{{$nav.notifications.0}}" title="{{$nav.notifications.1}}"><i class="fa fa-exclamation-circle fa-fw"></i> {{$nav.notifications.1}}</a></li>

--- a/view/theme/frost-mobile/templates/nav.tpl
+++ b/view/theme/frost-mobile/templates/nav.tpl
@@ -63,7 +63,7 @@
 	<span id="notify-update" class="nav-ajax-left"></span>
 	<ul id="nav-notifications-menu" class="notifications-menu-popup">
 		<li id="nav-notifications-see-all"><a href="{{$nav.notifications.all.0}}">{{$nav.notifications.all.1}}</a></li>
-		<li id="nav-notifications-mark-all"><a href="#" onclick="notifyMarkAll(); return false;">{{$nav.notifications.mark.1}}</a></li>
+		<li id="nav-notifications-mark-all"><a href="#" onclick="notifyMarkAll(); return false;">{{$nav.notifications.mark.3}}</a></li>
 		<li class="empty">{{$emptynotifications}}</li>
 	</ul>
 	</div>

--- a/view/theme/frost/templates/nav.tpl
+++ b/view/theme/frost/templates/nav.tpl
@@ -63,7 +63,7 @@
 	<span id="notify-update" class="nav-ajax-left" rel="#nav-network-notifications-popup"></span>
 	<ul id="nav-notifications-menu" class="notifications-menu-popup">
 		<li id="nav-notifications-see-all"><a href="{{$nav.notifications.all.0}}">{{$nav.notifications.all.1}}</a></li>
-		<li id="nav-notifications-mark-all"><a href="#" onclick="notifyMarkAll(); return false;">{{$nav.notifications.mark.1}}</a></li>
+		<li id="nav-notifications-mark-all"><a href="#" onclick="notifyMarkAll(); return false;">{{$nav.notifications.mark.3}}</a></li>
 		<li class="empty">{{$emptynotifications}}</li>
 	</ul>
 	</div>

--- a/view/theme/quattro/templates/nav.tpl
+++ b/view/theme/quattro/templates/nav.tpl
@@ -64,7 +64,7 @@
 				<span id="notify-update" class="nav-notify"></span>
 				<ul id="nav-notifications-menu" class="menu-popup">
 					<!-- TODO: better icons! -->
-					<li id="nav-notifications-mark-all" class="toolbar"><a href="#" onclick="notifyMarkAll(); return false;" title="{{$nav.notifications.mark.1}}"><span class="icon s10 edit"></span></a></a><a href="{{$nav.notifications.all.0}}" title="{{$nav.notifications.all.1}}"><span class="icon s10 plugin"></span></a></li>
+					<li id="nav-notifications-mark-all" class="toolbar"><a href="#" onclick="notifyMarkAll(); return false;" title="{{$nav.notifications.mark.3}}"><span class="icon s10 edit"></span></a></a><a href="{{$nav.notifications.all.0}}" title="{{$nav.notifications.all.1}}"><span class="icon s10 plugin"></span></a></li>
 					<li class="empty">{{$emptynotifications}}</li>
 				</ul>
 			</li>		

--- a/view/theme/smoothly/templates/nav.tpl
+++ b/view/theme/smoothly/templates/nav.tpl
@@ -11,7 +11,7 @@
 		{{if $nav.notifications}}<a rel="#nav-notifications-menu" id="notify-update" class="nav-ajax-update" href="{{$nav.notifications.0}}"  title="{{$nav.notifications.1}}"></a>{{/if}}
 
 		<ul id="nav-notifications-menu" class="menu-popup">
-			<li id="nav-notifications-mark-all"><a href="#" onclick="notifyMarkAll(); return false;">{{$nav.notifications.mark.1}}</a></li>
+			<li id="nav-notifications-mark-all"><a href="#" onclick="notifyMarkAll(); return false;">{{$nav.notifications.mark.3}}</a></li>
 			<li id="nav-notifications-see-all"><a href="{{$nav.notifications.all.0}}">{{$nav.notifications.all.1}}</a></li>
 			<li class="empty">{{$emptynotifications}}</li>
 		</ul>

--- a/view/theme/testbubble/templates/nav.tpl
+++ b/view/theme/testbubble/templates/nav.tpl
@@ -13,7 +13,7 @@
 		{{if $nav.notifications}}<a rel="#nav-notifications-menu" id="notify-update" class="nav-ajax-update" href="{{$nav.notifications.0}}"  title="{{$nav.notifications.1}}"></a>{{/if}}
 
 		<ul id="nav-notifications-menu" class="menu-popup">
-			<li id="nav-notifications-mark-all"><a href="#" onclick="notifyMarkAll(); return false;">{{$nav.notifications.mark.1}}</a></li>
+			<li id="nav-notifications-mark-all"><a href="#" onclick="notifyMarkAll(); return false;">{{$nav.notifications.mark.3}}</a></li>
 			<li id="nav-notifications-see-all"><a href="{{$nav.notifications.all.0}}">{{$nav.notifications.all.1}}</a></li>
 			<li class="empty">{{$emptynotifications}}</li>
 		</ul>


### PR DESCRIPTION
Since Frio is now in the core we don't need the github link anymore. Additionally the text "mark as read" is replaced with a fitting text that is already translated.