### PR TITLE
frio: show tooltip only on hover (and not on focus)

### DIFF
--- a/view/theme/frio/js/theme.js
+++ b/view/theme/frio/js/theme.js
@@ -123,6 +123,7 @@ $(document).ready(function(){
 		animation: true,
 		html: true,
 		placement: 'auto',
+		trigger: 'hover',
 		delay: {
 			show: 500,
 			hide: 100


### PR DESCRIPTION
There was a issue that if you are open the notification the tooltip was hiding a part of the notification popup. Now the tooltip is only shown on hover event and not anymore on focus event.