### PR TITLE
frio: fix bulk deletion doesn't appear if post item was inserted by js

### DIFF
--- a/view/theme/frio/js/theme.js
+++ b/view/theme/frio/js/theme.js
@@ -69,7 +69,7 @@ $(document).ready(function(){
 	}
 
 	// show bulk deletion button at network page if checkbox is checked
-	$('input.item-select').change(function(){
+	$("body").change("input.item-select", function(){
 		var checked = false;
 
 		// We need to get all checked items, so it would close the delete button


### PR DESCRIPTION
there was an issue that the bulk deletion button didn't appear if a post was inserted through update or auto page load. Hope this fixes the issue 