### PR TITLE
frio: some hover-card css fixes

### DIFF
--- a/view/theme/frio/css/hovercard.css
+++ b/view/theme/frio/css/hovercard.css
@@ -282,6 +282,9 @@
   display: block;
   text-overflow: ellipsis;
 }
+.hovercard-content .hover-card-details .hover-card-content   .profile-details > .profile-network a {
+    color: #777;
+}
 .hover-card-actions {
   display: flex;
 }

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -109,7 +109,7 @@ a#item-delete-selected {
 * Overwriting and Extend Bootstrap
 */
 .label, .label a {
-    color: #fff !important;
+    color: #fff;
 }
 
 /* Buttons */
@@ -1301,6 +1301,10 @@ blockquote.shared_content {
 .wall-item-tags a:hover {
     text-decoration: none;
 }
+.wall-item-bottom .label,
+.wall-item-bottom .label a {
+    color: #fff;
+}
 
 /* item social action buttons */
 .wall-item-actions, .wall-item-actions a {
@@ -1924,3 +1928,11 @@ There are for some reasons empty <a> tags. I don't know why */
     padding: 0;
 }
 
+/* hovercard fix */
+body .tread-wrapper .hovercard a,
+body .tread-wrapper .hovercard a:hover {
+    color: $link_color;
+}
+body .tread-wrapper .hovercard:hover .hover-card-content a {
+    color: $link_color !important;
+}

--- a/view/theme/frio/js/hovercard.js
+++ b/view/theme/frio/js/hovercard.js
@@ -112,7 +112,7 @@ $(document).ready(function(){
 	});
 	$('body').on('mouseleave','.hovercard', function(e) {
 		$(this).removeClass('dont-remove-card');
-		$(this).popover("hide");
+		//$(this).popover("hide");
 	});
 
 }); // End of $(document).ready
@@ -128,7 +128,7 @@ function removeAllhoverCards(event,priorTo) {
 				// don't remove it if we're hovering it right now!
 				if(!$(this).hasClass('dont-remove-card')) {
 					$('[data-hover-card-active="' + $(this).data('card-created') + '"]').removeAttr('data-hover-card-active');
-					$(this).popover("hide");
+					//(this).popover("hide");
 				}
 			}
 		});

--- a/view/theme/frio/js/hovercard.js
+++ b/view/theme/frio/js/hovercard.js
@@ -112,7 +112,7 @@ $(document).ready(function(){
 	});
 	$('body').on('mouseleave','.hovercard', function(e) {
 		$(this).removeClass('dont-remove-card');
-		//$(this).popover("hide");
+		$(this).popover("hide");
 	});
 
 }); // End of $(document).ready
@@ -128,7 +128,7 @@ function removeAllhoverCards(event,priorTo) {
 				// don't remove it if we're hovering it right now!
 				if(!$(this).hasClass('dont-remove-card')) {
 					$('[data-hover-card-active="' + $(this).data('card-created') + '"]').removeAttr('data-hover-card-active');
-					//(this).popover("hide");
+					$(this).popover("hide");
 				}
 			}
 		});


### PR DESCRIPTION
The color handling of hover-card links wasn't unique.

This should fix this. It's a little bit hacky. I had to insert some hover-card overwriting in the style.css (but it should go into hovercard.css). But since personal color variables are only available for style.css I didn't found any other solution.

If anyone finds a better solution he/she is very welcome to change this.