### PR TITLE
show the workerqueue in the admin panel summary

### DIFF
--- a/doc/Settings.md
+++ b/doc/Settings.md
@@ -9,6 +9,8 @@ This number should decrease quickly.
 The second is the messages which could for various reasons not being delivered.
 They will be resend later.
 You can have a quick glance into that second queus in the "Inspect Queue" section of the admin panel.
+If you have activated the background workers, there might be a third number representing the count of jobs queued for the workers.
+
 Then you get an overview of the accounts on your node, which can be moderated in the "Users" section of the panel.
 As well as an overview of the currently active addons
 The list is linked, so you can have quick access to the plugin settings.

--- a/doc/de/Settings.md
+++ b/doc/de/Settings.md
@@ -9,6 +9,9 @@ Diese Zahl sollte sich relativ schnell sinken.
 Die zweite Zahl gibt die Anzahl von Nachrichten an, die nicht zugestellt werden konnten.
 Die Zustellung wird zu einem späteren Zeitpunkt noch einmal versucht.
 Unter dem Punkt "Warteschlange Inspizieren" kannst du einen schnellen Blick auf die zweite Warteschlange werfen.
+Solltest du für die Hintergrundprozesse die Worker aktiviert haben, könntest du eine dritte Zahl angezeigt bekommen.
+Diese repräsentiert die Anzahl der Aufgaben, die die Worker noch vor sich haben.
+
 Des weiteren findest du eine Übersicht über die Accounts auf dem Friendica Knoten, die unter dem Punkt "Nutzer" moderiert werden können.
 Sowie eine Liste der derzeit aktivierten Addons.
 Diese Liste ist verlinkt, so dass du schnellen Zugriff auf die Informationsseiten der einzelnen Addons hast.

--- a/mod/admin.php
+++ b/mod/admin.php
@@ -440,9 +440,16 @@ function admin_page_summary(&$a) {
 	$r = q("select count(*) as total from queue where 1");
 	$queue = (($r) ? $r[0]['total'] : 0);
 
+    if (get_config('system','worker')) {
+        $r = q("select count(*) as total from workerqueue where 1");
+        $workerqueue = (($r) ? $r[0]['total'] : 0);
+    } else {
+        $workerqueue = 0;
+    }
+
 	// We can do better, but this is a quick queue status
 
-	$queues = array('label' => t('Message queues'), 'deliverq' => $deliverq, 'queue' => $queue);
+	$queues = array('label' => t('Message queues'), 'deliverq' => $deliverq, 'queue' => $queue, 'workerq' => $workerqueue);
 
 
 	$t = get_markup_template("admin_summary.tpl");

--- a/view/templates/admin_summary.tpl
+++ b/view/templates/admin_summary.tpl
@@ -4,7 +4,7 @@
 
 	<dl>
 		<dt>{{$queues.label}}</dt>
-		<dd>{{$queues.deliverq}} - <a href="{{$baseurl}}/admin/queue">{{$queues.queue}}</a></dd>
+		<dd>{{$queues.deliverq}} - <a href="{{$baseurl}}/admin/queue">{{$queues.queue}}</a>{{if $queues.workerq}} - {{$queues.workerq}}{{/if}}</dd>
 	</dl>
 	<dl>
 		<dt>{{$pending.0}}</dt>


### PR DESCRIPTION
with this PR a 3rd number is added to the lines of queues in the admin panel summary for the jobs the workers still have to fulfill. The number will only be shown, if the number of jobs is greater then zero. So the workers can rest undisturbed should they have completed all the work.

Also expanded the docs for information about this 3rd number.