### PR TITLE
Update config classes

### DIFF
--- a/include/Core/Config.php
+++ b/include/Core/Config.php
@@ -64,11 +64,13 @@ class Config {
 	 *  The category of the configuration value
 	 * @param string $key
 	 *  The configuration key to query
-	 * @param boolean $refresh
-	 *  If true the config is loaded from the db and not from the cache
+	 * @param mixed $default_value optional
+	 *  The value to return if key is not set (default: null)
+	 * @param boolean $refresh optional
+	 *  If true the config is loaded from the db and not from the cache (default: false)
 	 * @return mixed Stored value or null if it does not exist
 	 */
-	public static function get($family, $key, $refresh = false) {
+	public static function get($family, $key, $default_value=null, $refresh = false) {
 
 		global $a;
 
@@ -76,13 +78,13 @@ class Config {
 			// Looking if the whole family isn't set
 			if(isset($a->config[$family])) {
 				if($a->config[$family] === '!<unset>!') {
-					return null;
+					return $default_value;
 				}
 			}
 
 			if(isset($a->config[$family][$key])) {
 				if($a->config[$family][$key] === '!<unset>!') {
-					return null;
+					return $default_value;
 				}
 				return $a->config[$family][$key];
 			}
@@ -137,7 +139,7 @@ class Config {
 			elseif (function_exists("xcache_set"))
 				xcache_set($family."|".$key, '!<unset>!', 600);*/
 		}
-		return null;
+		return $default_value;
 	}
 
 	/**

--- a/include/Core/Config.php
+++ b/include/Core/Config.php
@@ -1,7 +1,7 @@
 <?php
-
+namespace Friendica\Core;
 /**
- * @file include/Config.php
+ * @file include/Core/Config.php
  * 
  *  @brief Contains the class with methods for system configuration
  */

--- a/include/Core/PConfig.php
+++ b/include/Core/PConfig.php
@@ -1,7 +1,7 @@
 <?php
-
+namespace Friendica\Core;
 /**
- * @file include/PConfig.php
+ * @file include/Core/PConfig.php
  * @brief contains the class with methods for the management
  * of the user configuration
  */

--- a/include/Core/PConfig.php
+++ b/include/Core/PConfig.php
@@ -57,11 +57,13 @@ class PConfig {
 	 *  The category of the configuration value
 	 * @param string $key
 	 *  The configuration key to query
-	 * @param boolean $refresh
-	 *  If true the config is loaded from the db and not from the cache
+	 * @param mixed $default_value optional
+	 *  The value to return if key is not set (default: null)
+	 * @param boolean $refresh optional
+	 *  If true the config is loaded from the db and not from the cache (default: false)
 	 * @return mixed Stored value or null if it does not exist
 	 */
-	public static function get($uid, $family, $key, $refresh = false) {
+	public static function get($uid, $family, $key, $default_value = null, $refresh = false) {
 
 		global $a;
 
@@ -69,13 +71,13 @@ class PConfig {
 			// Looking if the whole family isn't set
 			if(isset($a->config[$uid][$family])) {
 				if($a->config[$uid][$family] === '!<unset>!') {
-					return null;
+					return $default_value;
 				}
 			}
 
 			if(isset($a->config[$uid][$family][$key])) {
 				if($a->config[$uid][$family][$key] === '!<unset>!') {
-					return null;
+					return $default_value;
 				}
 				return $a->config[$uid][$family][$key];
 			}
@@ -131,7 +133,7 @@ class PConfig {
 			elseif (function_exists("xcache_set"))
 				xcache_set($uid."|".$family."|".$key, '!<unset>!', 600);*/
 		}
-		return null;
+		return $default_value;
 	}
 
 	/**

--- a/include/autoloader/autoload_psr4.php
+++ b/include/autoloader/autoload_psr4.php
@@ -6,4 +6,5 @@ $vendorDir = dirname(dirname(dirname(__FILE__)))."/library";
 $baseDir = dirname($vendorDir);
 
 return array(
+	'Friendica\\' => array($baseDir . '/include'),
 );

--- a/include/config.php
+++ b/include/config.php
@@ -43,10 +43,7 @@ function load_config($family) {
  * @return mixed Stored value or false if it does not exist
  */
 function get_config($family, $key, $refresh = false) {
-	$v = Config::get($family, $key, $refresh);
-	if(is_null($v))
-		$v = false;
-
+	$v = Config::get($family, $key, false, $refresh);
 	return $v;
 }
 
@@ -114,10 +111,7 @@ function load_pconfig($uid,$family) {
  * @return mixed Stored value or false if it does not exist
  */
 function get_pconfig($uid, $family, $key, $refresh = false) {
-	$v = PConfig::get($uid, $family, $key, $refresh);
-	if(is_null($v))
-		$v = false;
-
+	$v = PConfig::get($uid, $family, $key, false, $refresh);
 	return $v;
 }
 

--- a/include/config.php
+++ b/include/config.php
@@ -1,8 +1,4 @@
 <?php
-
-require_once("include/PConfig.php");
-require_once("include/Config.php");
-
 /**
  * @file include/config.php
  * 
@@ -15,6 +11,9 @@ require_once("include/Config.php");
  * There are a few places in the code (such as the admin panel) where boolean
  * configurations need to be fixed as of 10/08/2011.
  */
+
+use \Friendica\Core\Config;
+use \Friendica\Core\PConfig;
 
 /**
  * @brief (Deprecated) Loads all configuration values of family into a cached storage.


### PR DESCRIPTION
This is a follow up to pr #2576 

- Add `\Friendica` namespace pointing to `include/`
- move `Config `and `PConfig `classes under `\Friendica\Core\` namespace
- add `$default_value` parameter to `Config::get()` and `PConfig::get()`
- update legacy `include\config.php` to reflect the changes

see `include\config.php` on how to use config classes in code
