### PR TITLE
Move Nginx reverse proxy sample from INSTALL to separate file

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -154,18 +154,6 @@ Friendica also supports a number on non-standard headers in common use.
     X-Forwarded-Ssl: on
 
 It is however preferable to use the standard approach if configuring a new server.
-In Nginx, this can be done as follows (assuming Friendica runs on port 8080).
-
-    location / {
-            if ( $scheme != https ) {		# Force Redirect to HTTPS
-                    return 302 https://$host$uri;
-            }
-            proxy_pass http://localhost:8080;
-            proxy_redirect off;
-            proxy_set_header Host $host;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header Forwarded "for=$proxy_add_x_forwarded_for; proto=$scheme";
-    }
 
 #####################################################################
 

--- a/mods/sample-nginx-reverse-proxy.config
+++ b/mods/sample-nginx-reverse-proxy.config
@@ -1,0 +1,30 @@
+#
+# Example of NGINX as reverse-proxy terminating an HTTPS connection.
+#
+# This is not a complete NGINX config.
+#
+# Please refer to NGINX docs
+#
+
+...
+
+server {
+
+	...
+
+	# assuming Friendica runs on port 8080
+	location / {
+		if ( $scheme != https ) {
+			# Force Redirect to HTTPS
+			return 302 https://$host$uri;
+		}
+		proxy_pass http://localhost:8080;
+		proxy_redirect off;
+		proxy_set_header Host $host;
+		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+		proxy_set_header Forwarded "for=$proxy_add_x_forwarded_for; proto=$scheme";
+	}
+
+	...
+
+}


### PR DESCRIPTION
This is a follow-up of #2353 

Note that:
- I'm not using nginx
- I don't know nginix config syntax
- I can't test the example
- I simply moved the nginx-related code from INSTALL.txt to a separate file
