### PR TITLE
frio: bind short-info scrollspy on class fn (insteadof p-addr)

### DIFF
--- a/view/theme/frio/js/theme.js
+++ b/view/theme/frio/js/theme.js
@@ -155,10 +155,10 @@ $(document).ready(function(){
 	$(".search-content-wrapper #search-save-form ").appendTo("#topbar-second > .container > #navbar-button");
 
 	// append the vcard-short-info to the second nav after passing the element
-	// with .p-addr (vcard). Use scrollspy to get the scroll position.
+	// with .fn (vcard username). Use scrollspy to get the scroll position.
 	if( $("aside .vcard .fn").length) {
 		$(".vcard .fn").scrollspy({
-			min: $(".vcard .p-addr").position().top - 70,
+			min: $(".vcard .fn").position().top - 50,
 			onLeaveTop: function onLeave(element) {
 				$("#vcard-short-info").fadeOut(500, function () {
 					$("#vcard-short-info").appendTo("#vcard-short-info-wrapper");

--- a/view/theme/frio/js/theme.js
+++ b/view/theme/frio/js/theme.js
@@ -156,9 +156,9 @@ $(document).ready(function(){
 
 	// append the vcard-short-info to the second nav after passing the element
 	// with .p-addr (vcard). Use scrollspy to get the scroll position.
-	if( $("aside .vcard .p-addr").length) {
-		$(".vcard .p-addr").scrollspy({
-			min: $(".vcard .p-addr").position().top - 50,
+	if( $("aside .vcard .fn").length) {
+		$(".vcard .fn").scrollspy({
+			min: $(".vcard .p-addr").position().top - 70,
 			onLeaveTop: function onLeave(element) {
 				$("#vcard-short-info").fadeOut(500, function () {
 					$("#vcard-short-info").appendTo("#vcard-short-info-wrapper");


### PR DESCRIPTION
the class p-addr wasn't a good choice because it seems that not all users does have an addr in db. So the scrollspy for the short-info listens now to the fn class (the vcard user name)