### PR TITLE
cal export && public calendar - fix permissions

### DIFF
--- a/include/event.php
+++ b/include/event.php
@@ -818,13 +818,26 @@ function widget_events() {
 	// of the profile page it should be the personal /events page. So we can use $a->user
 	$user = ($a->data['user']['nickname'] ? $a->data['user']['nickname'] : $a->user['nickname']);
 
-	// a little bit tricky permission testing because we have to respect many cases
-	if(!(local_user()) && !($owner_uid) // not the private events page (we don't get the $owner_uid for /events)
-			|| (intval($owner_uid) && local_user() !== $owner_uid && !(feature_enabled($owner_uid, "export_calendar"))) // cal logged in user (test permission at foreign profile page)
-			|| ( !(local_user()) && !(feature_enabled($owner_uid, "export_calendar"))) // if cal && not logged in && feature is not enabled
-		) {
+
+	// The permission testing is a little bit tricky because we have to respect many cases
+
+	// It's not the private events page (we don't get the $owner_uid for /events)
+	if(! local_user() && ! $owner_uid)
 		return;
-	}
+
+	// Cal logged in user (test permission at foreign profile page)
+	// If the $owner uid is available we know it is part of one of the profile pages (like /cal)
+	// So we have to test if if it's the own profile page of the logged in user 
+	// or a foreign one. For foreign profile pages we need to check if the feature
+	// for exporting the cal is enabled (otherwise the widget would appear for logged in users
+	// on foreigen profile pages even if the widget is disabled)
+	if(intval($owner_uid) && local_user() !== $owner_uid && ! feature_enabled($owner_uid, "export_calendar")) 
+		return;
+
+	// If it's a kind of profile page (intval($owner_uid)) return if the user not logged in and
+	// export feature isn't enabled
+	if(intval($owner_uid) && ! local_user() && ! feature_enabled($owner_uid, "export_calendar"))
+		return;
 
 	return replace_macros(get_markup_template("events_aside.tpl"), array(
 		'$etitle' => t("Export"),

--- a/include/event.php
+++ b/include/event.php
@@ -818,7 +818,7 @@ function widget_events() {
 	// of the profile page it should be the personal /events page. So we can use $a->user
 	$user = ($a->data['user']['nickname'] ? $a->data['user']['nickname'] : $a->user['nickname']);
 
-	if( !(local_user() )&& !(feature_enabled($owner_uid, "export_calendar")) )
+	if( !(local_user()) && !(feature_enabled($owner_uid, "export_calendar")) )
 		return;
 
 	return replace_macros(get_markup_template("events_aside.tpl"), array(

--- a/include/event.php
+++ b/include/event.php
@@ -818,8 +818,13 @@ function widget_events() {
 	// of the profile page it should be the personal /events page. So we can use $a->user
 	$user = ($a->data['user']['nickname'] ? $a->data['user']['nickname'] : $a->user['nickname']);
 
-	if( !(local_user()) && !(feature_enabled($owner_uid, "export_calendar")) )
+	// a little bit tricky permission testing because we have to respect many cases
+	if(!(local_user()) && !($owner_uid) // not the private events page (we don't get the $owner_uid for /events)
+			|| (intval($owner_uid) && local_user() !== $owner_uid && !(feature_enabled($owner_uid, "export_calendar"))) // cal logged in user (test permission at foreign profile page)
+			|| ( !(local_user()) && !(feature_enabled($owner_uid, "export_calendar"))) // if cal && not logged in && feature is not enabled
+		) {
 		return;
+	}
 
 	return replace_macros(get_markup_template("events_aside.tpl"), array(
 		'$etitle' => t("Export"),

--- a/mod/cal.php
+++ b/mod/cal.php
@@ -302,7 +302,8 @@ function cal_content(&$a) {
 			return;
 		}
 
-		if( !(local_user()) && !(feature_enabled($owner_uid, "export_calendar"))) {
+		// Test permissions
+		if( ((local_user() !== $owner_uid)) && !(feature_enabled($owner_uid, "export_calendar"))) {
 			notice( t('Permission denied.') . EOL);
 			return;
 		}

--- a/mod/cal.php
+++ b/mod/cal.php
@@ -303,7 +303,8 @@ function cal_content(&$a) {
 		}
 
 		// Test permissions
-		if( ((local_user() !== $owner_uid)) && !(feature_enabled($owner_uid, "export_calendar"))) {
+		// Respect the export feature setting for all other /cal pages if it's not the own profile
+		if( ((local_user() !== $owner_uid)) && ! feature_enabled($owner_uid, "export_calendar")) {
 			notice( t('Permission denied.') . EOL);
 			return;
 		}

--- a/mod/cal.php
+++ b/mod/cal.php
@@ -156,7 +156,7 @@ function cal_content(&$a) {
 	// get the permissions
 	$sql_perms = item_permissions_sql($owner_uid,$remote_contact,$groups);
 	// we only want to have the events of the profile owner
-	$sql_extra = " AND `event`.`cid` = 0 ";
+	$sql_extra = " AND `event`.`cid` = 0 " . $sql_perms;
 
 	// get the tab navigation bar
 	$tabs .= profile_tabs($a,false, $a->data['user']['nickname']);

--- a/mod/cal.php
+++ b/mod/cal.php
@@ -153,7 +153,10 @@ function cal_content(&$a) {
 		return;
 	}
 
-	$sql_extra = item_permissions_sql($owner_uid,$remote_contact,$groups);
+	// get the permissions
+	$sql_perms = item_permissions_sql($owner_uid,$remote_contact,$groups);
+	// we only want to have the events of the profile owner
+	$sql_extra = " AND `event`.`cid` = 0 ";
 
 	// get the tab navigation bar
 	$tabs .= profile_tabs($a,false, $a->data['user']['nickname']);
@@ -299,7 +302,7 @@ function cal_content(&$a) {
 			return;
 		}
 
-		if(! (feature_enabled($owner_uid, "export_calendar"))) {
+		if( !(local_user()) && !(feature_enabled($owner_uid, "export_calendar"))) {
 			notice( t('Permission denied.') . EOL);
 			return;
 		}


### PR DESCRIPTION
So I hope all permissions are set correct now.

Can anybody have a look at it. It's really hard to hit all the use cases

Additionally /cal does now only present the events of the actual profile (this should be the expected behavior)