### PR TITLE
frio: Wallmessage - distinguish between own and foreign host

### DIFF
--- a/view/theme/frio/js/modal.js
+++ b/view/theme/frio/js/modal.js
@@ -293,3 +293,19 @@ function toggleJotNav (elm) {
 	$(elm).parent("li").addClass("active");
 }
 
+// Wall Message needs a special handling because in some cases
+// it redirects you to your own server. In such cases we can't
+// load it into a modal
+function openWallMessage(url) {
+	// split the the url in its parts
+	var parts = parseUrl(url);
+
+	// If the host isn't the same we can't load it in a modal.
+	// So we will go to to the url directly
+	if( ("host" in parts) && (parts.host !== window.location.host)) {
+		window.location.href = url;
+	} else {
+		// otherwise load the wall message into a modal
+		addToModal(url);
+	}
+}

--- a/view/theme/frio/templates/profile_vcard.tpl
+++ b/view/theme/frio/templates/profile_vcard.tpl
@@ -61,7 +61,7 @@
 				{{/if}}
 				{{if $wallmessage}}
 				<div id="wallmessage-link-botton">
-					<a id="wallmessage-link" class="btn btn-labeled btn-primary btn-sm" onclick="addToModal('{{$wallmessage_link}}')">
+					<a id="wallmessage-link" class="btn btn-labeled btn-primary btn-sm" onclick="openWallMessage('{{$wallmessage_link}}')">
 						<span class=""><i class="fa fa-envelope"></i></span>
 						<span class="">{{$wallmessage}}</span>
 					</a>


### PR DESCRIPTION
Foreign urls can't be loaded into a modal. If this should be the case for a wallmessage link do a redirect to the foreign url