### PR TITLE
viewcontacts - make the tabbar available even if hide-friends is active

### DIFF
--- a/mod/viewcontacts.php
+++ b/mod/viewcontacts.php
@@ -36,15 +36,15 @@ function viewcontacts_content(&$a) {
 		return;
 	}
 
-	if(((! count($a->profile)) || ($a->profile['hide-friends']))) {
-		notice( t('Permission denied.') . EOL);
-		return;
-	}
-
 	$o = "";
 
 	// tabs
 	$o .= profile_tabs($a,$is_owner, $a->data['user']['nickname']);
+
+	if(((! count($a->profile)) || ($a->profile['hide-friends']))) {
+		notice( t('Permission denied.') . EOL);
+		return;
+	}
 
 	$r = q("SELECT COUNT(*) AS `total` FROM `contact`
 		WHERE `uid` = %d AND `blocked` = 0 AND `pending` = 0 AND `hidden` = 0 AND `archive` = 0

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -1770,7 +1770,7 @@ ul.dropdown-menu li:hover {
 .allfriends-content-wrapper, .match-content-wrapper, .dirfind-content-wrapper,
 .directory-content-wrapper, .manage-content-wrapper, .notes-content-wrapper,
 .message-content-wrapper, .apps-content-wrapper, .notifications-content-wrapper,
-.admin-content-wrapper, .group-content-wrapper {
+.admin-content-wrapper, .group-content-wrapper, .viewcontacts-content-wrapper {
     min-height: calc(100vh - 150px);
     padding: 15px;
     padding-bottom: 20px;


### PR DESCRIPTION
Since the tab bar is important for navigation (moving to to other profile pages) it should be displayed even if the hide-friends option is active