### PR TITLE
frio: fix - jot default was not removed in every case while inserting…

### DIFF
--- a/view/theme/frio/js/textedit.js
+++ b/view/theme/frio/js/textedit.js
@@ -191,5 +191,3 @@ function dropItem(url, object) {
 		});
 	}
 }
-
-	

--- a/view/theme/frio/templates/jot-header.tpl
+++ b/view/theme/frio/templates/jot-header.tpl
@@ -143,10 +143,14 @@ function enableOnUser(){
 	$(document).ready(function() {
 
 		/* enable tinymce on focus and click */
-		$("#profile-jot-text").focus(enableOnUser);
-		$("#profile-jot-text").click(enableOnUser);
+		//$("#profile-jot-text").focus(enableOnUser);
+		//$("#profile-jot-text").click(enableOnUser);
 
-
+		// When clicking on a forum in acl we should remove the profile jot textarea
+		// default value before inserting the forum mention
+		$("body").on('click', '#jot-modal .acl-list-item.forum', function(){
+			jotTextOpenUI(document.getElementById("profile-jot-text"));
+		});
 
 
 		/* show images / file browser window
@@ -376,8 +380,14 @@ function enableOnUser(){
 
 	function addeditortext(data) {
 		if(plaintext == 'none') {
+			// get the textfield
+			var textfield = document.getElementById("profile-jot-text");
+			// check if the textfield does have the default-value
+			jotTextOpenUI(textfield);
+			// save already existent content
 			var currentText = $("#profile-jot-text").val();
-			$("#profile-jot-text").val(currentText + data);
+			//insert the data as new value
+			textfield.value = currentText + data;
 		}
 		else
 			tinyMCE.execCommand('mceInsertRawHTML',false,data);
@@ -425,6 +435,7 @@ function enableOnUser(){
 
 		$(function() {Dialog.showJot();});
 	}
+
 
 </script>
 


### PR DESCRIPTION
… content

In some cases where content was inserted automatically in to the jot text field (e.g. links, mentions) the default value (`share`) was not removed. This shoud fix this in most cases

This addresses https://github.com/friendica/friendica/issues/2552