### PR TITLE
viewcontacts - fix: tabmenu was not returned

### DIFF
--- a/mod/viewcontacts.php
+++ b/mod/viewcontacts.php
@@ -43,7 +43,7 @@ function viewcontacts_content(&$a) {
 
 	if(((! count($a->profile)) || ($a->profile['hide-friends']))) {
 		notice( t('Permission denied.') . EOL);
-		return;
+		return $o;
 	}
 
 	$r = q("SELECT COUNT(*) AS `total` FROM `contact`


### PR DESCRIPTION
In the last PR for viewcontacts I forgot to return the tab menu. This fixes this issue