### PR TITLE
use thumb avatar size instead of micro size in the contact list

### DIFF
--- a/include/ForumManager.php
+++ b/include/ForumManager.php
@@ -26,6 +26,7 @@ class ForumManager {
 	 *	'name'	=> forum name
 	 *	'id'	=> number of the key from the array
 	 *	'micro' => contact photo in format micro
+	 *	'thumb' => contact photo in format thumb
 	 */
 	public static function get_list($uid, $showhidden = true, $lastitem, $showprivate = false) {
 
@@ -38,7 +39,7 @@ class ForumManager {
 			$select = '(`forum` OR `prv`)';
 		}
 
-		$contacts = q("SELECT `contact`.`id`, `contact`.`url`, `contact`.`name`, `contact`.`micro` FROM `contact`
+		$contacts = q("SELECT `contact`.`id`, `contact`.`url`, `contact`.`name`, `contact`.`micro`, `contact`.`thumb` FROM `contact`
 				WHERE `network`= 'dfrn' AND $select AND `uid` = %d
 				AND NOT `blocked` AND NOT `hidden` AND NOT `pending` AND NOT `archive`
 				AND `success_update` > `failure_update`
@@ -55,6 +56,7 @@ class ForumManager {
 				'name'	=> $contact['name'],
 				'id'	=> $contact['id'],
 				'micro' => $contact['micro'],
+				'thumb' => $contact['thumb'],
 			);
 		}
 		return($forumlist);

--- a/include/text.php
+++ b/include/text.php
@@ -867,7 +867,7 @@ function contact_block() {
 		$micropro = Null;
 
 	} else {
-		$r = q("SELECT `id`, `uid`, `addr`, `url`, `name`, `micro`, `network` FROM `contact`
+		$r = q("SELECT `id`, `uid`, `addr`, `url`, `name`, `thumb`, `network` FROM `contact`
 				WHERE `uid` = %d AND NOT `self` AND NOT `blocked` AND NOT `pending`
 					AND NOT `hidden` AND NOT `archive`
 				AND `network` IN ('%s', '%s', '%s') ORDER BY RAND() LIMIT %d",
@@ -911,7 +911,7 @@ function contact_block() {
  *	string 'url' => The url to the profile page of the contact
  *	string 'addr' => The webbie of the contact (e.g.) username@friendica.com
  *	string 'network' => The network to which the contact belongs to
- *	string 'micro' => The contact picture
+ *	string 'thumb' => The contact picture
  *	string 'click' => js code which is performed when clicking on the contact
  * @param boolean $redirect If true try to use the redir url if it's possible
  * @param string $class CSS class for the 
@@ -950,7 +950,7 @@ function micropro($contact, $redirect = false, $class = '', $textmode = false) {
 		'$click' => (($contact['click']) ? $contact['click'] : ''),
 		'$class' => $class,
 		'$url' => $url,
-		'$photo' => proxy_url($contact['micro'], false, PROXY_SIZE_THUMB),
+		'$photo' => proxy_url($contact['thumb'], false, PROXY_SIZE_THUMB),
 		'$name' => $contact['name'],
 		'title' => $contact['name'] . ' [' . $contact['addr'] . ']',
 		'$parkle' => $sparkle,


### PR DESCRIPTION
The list of contacts used the "micro" avatar size - but frio is using larger images, so now we use the thumb size.