### PR TITLE
Site settings: some settings are disabled when the worker is active

### DIFF
--- a/view/templates/admin_site.tpl
+++ b/view/templates/admin_site.tpl
@@ -120,8 +120,10 @@
 	{{include file="field_input.tpl" field=$proxy}}
 	{{include file="field_input.tpl" field=$proxyuser}}
 	{{include file="field_input.tpl" field=$timeout}}
-	{{include file="field_input.tpl" field=$delivery_interval}}
-	{{include file="field_input.tpl" field=$poll_interval}}
+	{{if NOT $worker.2}}
+		{{include file="field_input.tpl" field=$delivery_interval}}
+		{{include file="field_input.tpl" field=$poll_interval}}
+	{{/if}}
 	{{include file="field_input.tpl" field=$maxloadavg}}
 	{{include file="field_input.tpl" field=$maxloadavg_frontend}}
 	{{include file="field_input.tpl" field=$optimize_max_tablesize}}


### PR DESCRIPTION
The delivery interval and the poll interval isn't used when the worker is active.