### PR TITLE
Bugfix: On "photos" the session management has to work

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -1133,7 +1133,6 @@ class App {
 		$backend[] = "noscrape";
 		$backend[] = "p";
 		$backend[] = "photo";
-		$backend[] = "photos";
 		$backend[] = "poco";
 		$backend[] = "post";
 		$backend[] = "proxy";


### PR DESCRIPTION
The frontend/backend detection thought that /photos was a backend thing. It isn't.