### PR TITLE
Logging for feeds improved, new "process id" for logging

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -517,6 +517,8 @@ class App {
 	 */
 	public $template_engine_instance = array();
 
+	public $process_id;
+
 	private $ldelim = array(
 		'internal' => '',
 		'smarty3' => '{{'
@@ -576,6 +578,8 @@ class App {
 		$this->pager= array();
 
 		$this->query_string = '';
+
+		$this->process_id = uniqid("log", true);
 
 		startup();
 

--- a/include/bbcode.php
+++ b/include/bbcode.php
@@ -1140,6 +1140,7 @@ function bbcode($Text,$preserve_nl = false, $tryoembed = true, $simplehtml = fal
 		$Text = preg_replace("/\[event\-finish\](.*?)\[\/event\-finish\]/ism",'',$Text);
 		$Text = preg_replace("/\[event\-location\](.*?)\[\/event\-location\]/ism",'',$Text);
 		$Text = preg_replace("/\[event\-adjust\](.*?)\[\/event\-adjust\]/ism",'',$Text);
+		$Text = preg_replace("/\[event\-id\](.*?)\[\/event\-id\]/ism",'',$Text);
 	}
 
 

--- a/include/feed.php
+++ b/include/feed.php
@@ -17,10 +17,15 @@ function feed_import($xml,$importer,&$contact, &$hub, $simulate = false) {
 
 	$a = get_app();
 
-	logger("Import Atom/RSS feed", LOGGER_DEBUG);
+	if (!$simulate)
+		logger("Import Atom/RSS feed '".$contact["name"]."' (Contact ".$contact["id"].") for user ".$importer["uid"], LOGGER_DEBUG);
+	else
+		logger("Test Atom/RSS feed", LOGGER_DEBUG);
 
-	if ($xml == "")
+	if ($xml == "") {
+		logger('XML is empty.', LOGGER_DEBUG);
 		return;
+	}
 
 	$doc = new DOMDocument();
 	@$doc->loadXML($xml);
@@ -150,8 +155,10 @@ function feed_import($xml,$importer,&$contact, &$hub, $simulate = false) {
 		$header["last-child"] = 0;
 	}
 
-	if (!is_object($entries))
+	if (!is_object($entries)) {
+		logger("There are no entries in this feed.", LOGGER_DEBUG);
 		return;
+	}
 
 	$items = array();
 

--- a/include/text.php
+++ b/include/text.php
@@ -717,10 +717,15 @@ function logger($msg,$level = 0) {
 	if((! $debugging) || (! $logfile) || ($level > $loglevel))
 		return;
 
+	$process_id = session_id();
+
+	if ($process_id == "")
+		$process_id = get_app()->process_id;
+
 	$callers = debug_backtrace();
 	$logline =  sprintf("%s@%s\t[%s]:%s:%s:%s\t%s\n",
 				 datetime_convert(),
-				 session_id(),
+				 $process_id,
 				 $LOGGER_LEVELS[$level],
 				 basename($callers[0]['file']),
 				 $callers[0]['line'],


### PR DESCRIPTION
When there is no session id (because it is a background process) we generate a "process id" in the logging to be able to separate the different log entries.

The logging at the feed import is improved as well.