### PR TITLE
API: fix plaintext of reshared attachment

### DIFF
--- a/include/api.php
+++ b/include/api.php
@@ -3184,7 +3184,6 @@
 		$include_entities = strtolower(x($_REQUEST,'include_entities')?$_REQUEST['include_entities']:"false");
 
 		$Text = bb_CleanPictureLinks($Text);
-
 		$URLSearchString = "^\[\]";
 
 		$Text = preg_replace("/([!#@])\[url\=([$URLSearchString]*)\](.*?)\[\/url\]/ism",'$1$3',$Text);
@@ -3222,6 +3221,8 @@
 
 		if (isset($data["url"]))
 			$body .= "\n".$data["url"];
+
+		$body .= $data["after"];
 
 		return $body;
 	}


### PR DESCRIPTION
When replacing `[attachment]` element, text after it wasn't restored.

`[share]` element can contain `[attachment]`, the closing `[/share]` was elided,
then the `[share]` element was shown in plaintext instead of recycle symbol
