### PR TITLE
Quick fix to PR #2682

### DIFF
--- a/include/api.php
+++ b/include/api.php
@@ -768,6 +768,7 @@
 		}
 
 		$data3 = array($root_element => $data2);
+
 		$ret = xml::from_array($data3, $xml, false, $namespaces);
 		return $ret;
 	}
@@ -2377,9 +2378,9 @@
 		$res = array();
 		$uri = $item['uri']."-l";
 		foreach($activities as $k => $v) {
-			$res[$k] = ( x($v,$uri) ? array_map("api_contactlink_to_array", $v[$uri]) : array() );
+			$res[$k] = (x($v,$uri)?count($v[$uri]):0);
+			#$res[$k] = ( x($v,$uri) ? array_map("api_contactlink_to_array", $v[$uri]) : array() );
 		}
-
 		return $res;
 	}
 

--- a/include/xml.php
+++ b/include/xml.php
@@ -51,8 +51,13 @@ class xml {
 				$element = $xml;
 
 			if (is_integer($key)) {
-				if (isset($element))
-					$element[0] = $value;
+				if (isset($element)) {
+					if (is_scalar($value)) {
+						$element[0] = $value;
+					} else {
+						/// @todo: handle nested array values
+					}
+				}
 				continue;
 			}
 
@@ -145,11 +150,11 @@ class xml {
 	/**
 	 * @brief Convert an XML document to a normalised, case-corrected array
 	 *   used by webfinger
-	 * 
+	 *
 	 * @param object $xml_element The XML document
-	 * @param integer $recursion_depth recursion counter for internal use - default 0 
+	 * @param integer $recursion_depth recursion counter for internal use - default 0
 	 *    internal use, recursion counter
-	 * 
+	 *
 	 * @return array | sring The array from the xml element or the string
 	 */
 	public static function element_to_array($xml_element, &$recursion_depth=0) {
@@ -195,23 +200,23 @@ class xml {
 
 	/**
 	 * @brief Convert the given XML text to an array in the XML structure.
-	 * 
+	 *
 	 * xml::to_array() will convert the given XML text to an array in the XML structure.
 	 * Link: http://www.bin-co.com/php/scripts/xml2array/
 	 * Portions significantly re-written by mike@macgirvin.com for Friendica
 	 * (namespaces, lowercase tags, get_attribute default changed, more...)
-	 * 
+	 *
 	 * Examples: $array =  xml::to_array(file_get_contents('feed.xml'));
 	 *		$array =  xml::to_array(file_get_contents('feed.xml', true, 1, 'attribute'));
-	 * 
+	 *
 	 * @param object $contents The XML text
 	 * @param boolean $namespaces True or false include namespace information
 	 *	in the returned array as array elements.
-	 * @param integer $get_attributes 1 or 0. If this is 1 the function will get the attributes as well as the tag values - 
+	 * @param integer $get_attributes 1 or 0. If this is 1 the function will get the attributes as well as the tag values -
 	 *	this results in a different array structure in the return value.
 	 * @param string $priority Can be 'tag' or 'attribute'. This will change the way the resulting
 	 *	 array sturcture. For 'tag', the tags are given more importance.
-	 * 
+	 *
 	 * @return array The parsed XML in an array form. Use print_r() to see the resulting array structure.
 	 */
 	public static function to_array($contents, $namespaces = true, $get_attributes=1, $priority = 'attribute') {


### PR DESCRIPTION
The issue is caused by automatic array-to-xml transform that don't handle correctly a nested list of array.
This PR add a check in `xml::from_array()` which atm ignore non scalar values in lists, and remove the only know source of list of array in api, which is a friendica-only functionality that no-one is using, so it's safe to remove it until a better solution is found.
