### PR TITLE
Improvements for the fastlane and forgotten priority

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -2278,7 +2278,7 @@ function current_load() {
 	if (!is_array($load_arr))
 		return false;
 
-	return max($load_arr);
+	return max($load_arr[0], $load_arr[1]);
 }
 
 /**

--- a/include/dfrn.php
+++ b/include/dfrn.php
@@ -1692,7 +1692,7 @@ class dfrn {
 			$changed = true;
 
 			if ($entrytype == DFRN_REPLY_RC)
-				proc_run("php", "include/notifier.php","comment-import", $current["id"]);
+				proc_run(PRIORITY_HIGH, "include/notifier.php","comment-import", $current["id"]);
 		}
 
 		// update last-child if it changes
@@ -2252,7 +2252,7 @@ class dfrn {
 
 				if($posted_id AND $parent AND ($entrytype == DFRN_REPLY_RC)) {
 					logger("Notifying followers about comment ".$posted_id, LOGGER_DEBUG);
-					proc_run("php", "include/notifier.php", "comment-import", $posted_id);
+					proc_run(PRIORITY_HIGH, "include/notifier.php", "comment-import", $posted_id);
 				}
 
 				return true;
@@ -2423,7 +2423,7 @@ class dfrn {
 
 				if($entrytype == DFRN_REPLY_RC) {
 					logger("Notifying followers about deletion of post ".$item["id"], LOGGER_DEBUG);
-					proc_run("php", "include/notifier.php","drop", $item["id"]);
+					proc_run(PRIORITY_HIGH, "include/notifier.php","drop", $item["id"]);
 				}
 			}
 		}

--- a/include/diaspora.php
+++ b/include/diaspora.php
@@ -1184,7 +1184,7 @@ class diaspora {
 			);
 
 			// notify others
-			proc_run("php", "include/notifier.php", "comment-import", $message_id);
+			proc_run(PRIORITY_HIGH, "include/notifier.php", "comment-import", $message_id);
 		}
 
 		return $message_id;
@@ -1519,7 +1519,7 @@ class diaspora {
 			);
 
 			// notify others
-			proc_run("php", "include/notifier.php", "comment-import", $message_id);
+			proc_run(PRIORITY_HIGH, "include/notifier.php", "comment-import", $message_id);
 		}
 
 		return $message_id;
@@ -1799,7 +1799,7 @@ class diaspora {
 
 				$i = item_store($arr);
 				if($i)
-					proc_run("php", "include/notifier.php", "activity", $i);
+					proc_run(PRIORITY_HIGH, "include/notifier.php", "activity", $i);
 			}
 		}
 	}
@@ -2192,7 +2192,7 @@ class diaspora {
 		// Now check if the retraction needs to be relayed by us
 		if($p[0]["origin"]) {
 			// notify others
-			proc_run("php", "include/notifier.php", "drop", $r[0]["id"]);
+			proc_run(PRIORITY_HIGH, "include/notifier.php", "drop", $r[0]["id"]);
 		}
 
 		return true;

--- a/include/items.php
+++ b/include/items.php
@@ -1712,7 +1712,7 @@ function item_expire($uid, $days, $network = "", $force = false) {
 	} else
 		$range = "AND `created` < UTC_TIMESTAMP() - INTERVAL %d DAY ";
 
-	$r = q("SELECT * FROM `item`
+	$r = q("SELECT `file`, `resource-id`, `starred`, `type`, `id` FROM `item`
 		WHERE `uid` = %d $range
 		AND `id` = `parent`
 		$sql_extra

--- a/include/poller.php
+++ b/include/poller.php
@@ -270,24 +270,23 @@ function poller_too_much_workers() {
 		$slope = $maxworkers / pow($maxsysload, $exponent);
 		$queues = ceil($slope * pow(max(0, $maxsysload - $load), $exponent));
 
-		if (Config::get("system", "worker_fastlane", false) AND ($queues > 0) AND ($active >= $queues)) {
-			$s = q("SELECT COUNT(*) AS `total` FROM `workerqueue` WHERE `priority` = %d AND `executed` = '0000-00-00 00:00:00'",
-				intval(PRIORITY_HIGH));
-			$high_waiting = $s[0]["total"];
+		$s = q("SELECT COUNT(*) AS `total` FROM `workerqueue` WHERE `executed` = '0000-00-00 00:00:00'");
+		$entries = $s[0]["total"];
 
-			$s = q("SELECT COUNT(*) AS `total` FROM `workerqueue` WHERE `priority` = %d AND `executed` != '0000-00-00 00:00:00'",
-				intval(PRIORITY_HIGH));
+		if (Config::get("system", "worker_fastlane", false) AND ($queues > 0) AND ($entries > 0) AND ($active >= $queues)) {
+			$s = q("SELECT `priority` FROM `workerqueue` WHERE `executed` = '0000-00-00 00:00:00' ORDER BY `priority` LIMIT 1");
+			$top_priority = $s[0]["priority"];
+
+			$s = q("SELECT COUNT(*) AS `total` FROM `workerqueue` WHERE `priority` <= %d AND `executed` != '0000-00-00 00:00:00'",
+				intval($top_priority));
 			$high_running = $s[0]["total"];
 
 			/// @todo define maximum number of fastlanes
-			if (($high_waiting > 0) AND ($high_running == 0)) {
-				logger("There are ".$high_waiting." high priority jobs waiting but none is executed. Open a fastlane.", LOGGER_DEBUG);
+			if (($high_running == 0) AND ($top_priority >= PRIORITY_HIGH) AND ($top_priority < PRIORITY_LOW)) {
+				logger("There are jobs with priority ".$top_priority." waiting but none is executed. Open a fastlane.", LOGGER_DEBUG);
 				$queues = $active + 1;
 			}
 		}
-
-		$s = q("SELECT COUNT(*) AS `total` FROM `workerqueue` WHERE `executed` = '0000-00-00 00:00:00'");
-		$entries = $s[0]["total"];
 
 		logger("Current load: ".$load." - maximum: ".$maxsysload." - current queues: ".$active."/".$entries." - maximum: ".$queues."/".$maxqueues, LOGGER_DEBUG);
 


### PR DESCRIPTION
The priority for "proc_run" wasn't set for every call for the notifier. This delayed the transmission of relayed comments.

Additionally the fastlane is restructured so that it builds a fastlane whenever a waiting process has a higher priority than the current ones - independently if the waiting process has the "high" or "medium" priority.

Finally the load now only returns the maximum of the first two load values and one query now has a list of fields instead of "*" to save some space.