### PR TITLE
Bugfix: proc_run hadn't worked anymore due to the priority changes

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -571,6 +571,7 @@ class App {
 
 		$this->performance["start"] = microtime(true);
 		$this->performance["database"] = 0;
+		$this->performance["database_write"] = 0;
 		$this->performance["network"] = 0;
 		$this->performance["file"] = 0;
 		$this->performance["rendering"] = 0;
@@ -1263,7 +1264,7 @@ class App {
 	function proc_run($args) {
 
 		// Add the php path if it is a php call
-		if (count($args) && $args[0] === 'php')
+		if (count($args) && ($args[0] === 'php' OR is_int($args[0])))
 			$args[0] = ((x($this->config,'php_path')) && (strlen($this->config['php_path'])) ? $this->config['php_path'] : 'php');
 
 		// add baseurl to args. cli scripts can't construct it

--- a/include/dba.php
+++ b/include/dba.php
@@ -107,6 +107,9 @@ class dba {
 
 		$a->save_timestamp($stamp1, "database");
 
+		if (strtolower(substr($sql, 0, 6)) != "select")
+			$a->save_timestamp($stamp1, "database_write");
+
 		if(x($a->config,'system') && x($a->config['system'],'db_log')) {
 			if (($duration > $a->config["system"]["db_loglimit"])) {
 				$duration = round($duration, 3);


### PR DESCRIPTION
Recent changes to "proc_run" caused it to stop working when the worker wasn't active.

The other changes in this pull request are part of an upcoming pull request to "rendertime". The database requests are now split between read and write operations.