### PR TITLE
Performance improvements for the poller

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -1266,8 +1266,20 @@ class App {
 	function proc_run($args) {
 
 		// Add the php path if it is a php call
-		if (count($args) && ($args[0] === 'php' OR is_int($args[0])))
+		if (count($args) && ($args[0] === 'php' OR is_int($args[0]))) {
+
+			// If the last worker fork was less than 10 seconds before then don't fork another one.
+			// This should prevent the forking of masses of workers.
+			if (get_config("system", "worker")) {
+				if ((time() - get_config("system", "proc_run_started")) < 10)
+					return;
+
+				// Set the timestamp of the last proc_run
+				set_config("system", "proc_run_started", time());
+			}
+
 			$args[0] = ((x($this->config,'php_path')) && (strlen($this->config['php_path'])) ? $this->config['php_path'] : 'php');
+		}
 
 		// add baseurl to args. cli scripts can't construct it
 		$args[] = $this->get_baseurl();

--- a/include/poller.php
+++ b/include/poller.php
@@ -239,10 +239,13 @@ function poller_kill_stale_workers() {
 			$max_duration_defaults = array(PRIORITY_SYSTEM => 360, PRIORITY_HIGH => 10, PRIORITY_MEDIUM => 60, PRIORITY_LOW => 180);
 			$max_duration = $max_duration_defaults[$pid["priority"]];
 
+			$argv = json_decode($pid["parameter"]);
+			$argv[0] = basename($argv[0]);
+
 			// How long is the process already running?
 			$duration = (time() - strtotime($pid["executed"])) / 60;
 			if ($duration > $max_duration) {
-				logger("Worker process ".$pid["pid"]." (".$pid["parameter"].") took more than ".$max_duration." minutes. It will be killed now.");
+				logger("Worker process ".$pid["pid"]." (".implode(" ", $argv).") took more than ".$max_duration." minutes. It will be killed now.");
 				posix_kill($pid["pid"], SIGTERM);
 
 				// We killed the stale process.
@@ -254,7 +257,7 @@ function poller_kill_stale_workers() {
 					intval(PRIORITY_LOW),
 					intval($pid["pid"]));
 			} else
-				logger("Worker process ".$pid["pid"]." now runs for ".round($duration)." of ".$max_duration." allowed minutes. That's okay.", LOGGER_DEBUG);
+				logger("Worker process ".$pid["pid"]." (".implode(" ", $argv).") now runs for ".round($duration)." of ".$max_duration." allowed minutes. That's okay.", LOGGER_DEBUG);
 		}
 }
 

--- a/include/post_update.php
+++ b/include/post_update.php
@@ -159,7 +159,7 @@ function post_update_1198() {
 	logger("Start", LOGGER_DEBUG);
 
 	// Check if the first step is done (Setting "author-id" and "owner-id" in the item table)
-	$r = q("SELECT `author-link`, `owner-link`, `uid` FROM `item` WHERE `author-id` = 0 AND `owner-id` = 0 LIMIT 1000");
+	$r = q("SELECT `author-link`, `owner-link`, `uid` FROM `item` WHERE `author-id` = 0 AND `owner-id` = 0 LIMIT 100");
 	if (!$r) {
 		// Are there unfinished entries in the thread table?
 		$r = q("SELECT COUNT(*) AS `total` FROM `thread`


### PR DESCRIPTION
Three things to improve the poller:

1. Only spawn a new poller if the last spawn is longer than 10 seconds away. This prevents multiple useless pollers from being spawned. Useless because some (many?) will quit after being forked because too many pollers were forked. 
2. The single queue run is now split in multiple queue calls. On slow systems the queue run can last longer than the maximum time. If it is split into several calls the queue is processed more reliable.
3. The post update call now only calls the first 100 rows instead of 1000 rows. This should be better on slower systems.