### PR TITLE
events with no finish should not export it to ical

### DIFF
--- a/include/event.php
+++ b/include/event.php
@@ -673,7 +673,7 @@ function event_format_export ($events, $format = 'ical', $timezone) {
 					$dtformat = "%Y%m%dT%H%M%S".$UTC;
 					$o .= 'DTSTART:'.strftime($dtformat, $tmp).PHP_EOL;
 				}
-				if ($event['finish']) {
+				if (!$event['nofinish']) {
 					$tmp = strtotime($event['finish']);
 					$dtformat = "%Y%m%dT%H%M%S".$UTC;
 					$o .= 'DTEND:'.strftime($dtformat, $tmp).PHP_EOL;
@@ -732,13 +732,13 @@ function events_by_uid($uid = 0, $sql_extra = '') {
 	//  requested? then show all of your events, otherwise only those that 
 	//  don't have limitations set in allow_cid and allow_gid
 	if (local_user() == $uid) {
-		$r = q("SELECT `start`, `finish`, `adjust`, `summary`, `desc`, `location`
+		$r = q("SELECT `start`, `finish`, `adjust`, `summary`, `desc`, `location`, `nofinish`
 			FROM `event` WHERE `uid`= %d AND `cid` = 0 ",
 			intval($uid)
 		);
 	} else {
-		$r = q("SELECT `start`, `finish`, `adjust`, `summary`, `desc`, `location`FROM `event`
-			WHERE  `uid` = %d AND `cid` = 0 $sql_extra ",
+		$r = q("SELECT `start`, `finish`, `adjust`, `summary`, `desc`, `location`, `nofinish`
+			FROM `event` WHERE `uid`= %d AND `cid` = 0 $sql_extra ",
 			intval($uid)
 		);
 	}


### PR DESCRIPTION
This is a fix for a parsing problem a [user](http://friendica.xyz/display/adf174d51557b6df3f236f9100655419) reported. When an event has no finish date, the DTEND field in ical should not be populated for this event.