### PR TITLE
best_link_url: don't use redirect for pending contacts

### DIFF
--- a/include/conversation.php
+++ b/include/conversation.php
@@ -887,7 +887,7 @@ function best_link_url($item,&$sparkle,$ssl_state = false) {
 	$clean_url = normalise_link($item['author-link']);
 
 	if (local_user()) {
-		$r = q("SELECT `id` FROM `contact` WHERE `network` = '%s' AND `uid` = %d AND `nurl` = '%s' LIMIT 1",
+		$r = q("SELECT `id` FROM `contact` WHERE `network` = '%s' AND `uid` = %d AND `nurl` = '%s' AND NOT `pending` LIMIT 1",
 			dbesc(NETWORK_DFRN), intval(local_user()), dbesc(normalise_link($clean_url)));
 		if ($r) {
 			$best_url = 'redir/'.$r[0]['id'];


### PR DESCRIPTION
If a connection request isn't accepted (pending contact) we shouldn't try to authenticate at a foreign profile page.

I have some questions:
function auto_redir() doesn't redir when the contact is self or the contact is blocked. Does it make sense to include this conditions also for best_link_url()?
Should this be added also to /mod/redir?

While I'm not sure why we shouldn't redirect (authenticate) to blocked users I don't see the need to redirect if the contact is the local_user (but maybe there are some cases where it would make sense - don't know)