### PR TITLE
Prevent lowest priority calls from never being called

### DIFF
--- a/include/cron.php
+++ b/include/cron.php
@@ -70,7 +70,7 @@ function cron_run(&$argv, &$argc){
 
 	// run queue delivery process in the background
 
-	proc_run(PRIORITY_LOW,"include/queue.php");
+	proc_run(PRIORITY_NEGLIGIBLE,"include/queue.php");
 
 	// run the process to discover global contacts in the background
 


### PR DESCRIPTION
The call for the queue creates other entries with the same priority (low). But since these calls can take a very long time, this could prevent calls of the lowest priority from being called. So if the creation of the queue entries now also has the lowest priority, these calls will eventually be called.