### PR TITLE
fix theme loading

### DIFF
--- a/include/identity.php
+++ b/include/identity.php
@@ -71,8 +71,8 @@ function profile_load(&$a, $nickname, $profile = 0, $profiledata = array()) {
 
 	$a->page['title'] = $a->profile['name'] . " @ " . $a->config['sitename'];
 
-//		if (!$profiledata)
-//			$_SESSION['theme'] = $a->profile['theme'];
+		if (!$profiledata  && !get_pconfig(local_user(),'system','always_my_theme'))
+			$_SESSION['theme'] = $a->profile['theme'];
 
 	$_SESSION['mobile-theme'] = $a->profile['mobile-theme'];
 


### PR DESCRIPTION
If someone comments directly at someones profile page the correct profile theme won't work in some cases.

A year ago I commented `$_SESSION['theme'] = $a->profile['theme'];` out to make the user setting 'always_my_theme' work.

It seems that this change introduced the bug.
The bug doesn't seem to appear when the user is logged in (local_user). So this PR should fix the regression. I hope this doesn't introduce some other side effects.