### PR TITLE
frio: show attachment icons in posts

### DIFF
--- a/view/theme/frio/css/font-awesome.custom.css
+++ b/view/theme/frio/css/font-awesome.custom.css
@@ -1,0 +1,21 @@
+/*
+@fiel view/theme/frio/css/font-awesome.custom.css
+@brief This file applies Font Awesome icons to some friendica standard classes
+*/
+
+.icon:before {
+    font-family: FontAwesome;
+    font-weight: normal;
+    font-style: normal;
+    display: inline-block;
+    text-decoration: inherit;
+    vertical-align: top;
+    font-size: 1.4em;
+}
+/* media icons */
+.icon.type-image:before           { content: "\f1c5"; }
+.icon.type-video:before           { content: "\f1c8"; }
+.icon.type-audio:before           { content: "\f1c7"; }
+.icon.type-text:before            { content: "\f0f6"; }
+.icon.type-application:before     { content: "\f016"; }
+.icon.type-unkn:before            { content: "\f016"; }

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -1404,6 +1404,15 @@ section #jotOpen {
 .wall-item-body > a > img {
     border-radius: 3px;
 }
+.wall-item-body .body-attach > a {
+    color: #555;
+    display: inline-block;
+}
+.wall-item-body .body-attach > a div {
+    color: #555;
+    width: 20px;
+}
+
 .shared-wrapper,
 .vevent {
     margin-left: 50px;
@@ -1486,7 +1495,8 @@ blockquote.shared_content {
 
 /* wall item hover effects */
 .wall-item-container .wall-item-links,
-.wall-item-container .wall-item-actions {
+.wall-item-container .wall-item-actions,
+.wall-item-container .body-attach > a {
     opacity: 0.3;
     -webkit-transition: all 0.25s ease-in-out;
     -moz-transition: all 0.25s ease-in-out;
@@ -1495,13 +1505,17 @@ blockquote.shared_content {
     transition: all 0.25s ease-in-out;
 }
 .wall-item-container:hover .wall-item-links,
-.wall-item-container:hover .wall-item-actions {
+.wall-item-container:hover .wall-item-actions,
+.wall-item-container:hover .body-attach > a {
     opacity: 0.6;
     -webkit-transition: all 0.25s ease-in-out;
     -moz-transition: all 0.25s ease-in-out;
     -o-transition: all 0.25s ease-in-out;
     -ms-transition: all 0.25s ease-in-out;
     transition: all 0.25s ease-in-out;
+}
+.wall-item-container .wall-item-body .body-attach > a:hover {
+    opacity: 1;
 }
 
 /*

--- a/view/theme/frio/templates/head.tpl
+++ b/view/theme/frio/templates/head.tpl
@@ -30,6 +30,7 @@
 
 {{* own css files *}}
 <link rel="stylesheet" href="view/theme/frio/css/hovercard.css" type="text/css" media="screen"/>
+<link rel="stylesheet" href="view/theme/frio/css/font-awesome.custom.css" type="text/css" media="screen"/>
 
 <!--
 <link rel="shortcut icon" href="images/friendica-32.png" />


### PR DESCRIPTION
Frio didn't display the attachments of a post. This should fix it.

Feature Wish:
The way how attachments are presented shouldn't be hardcoded. Instead the theme should decide how it will be displayed