### PR TITLE
frio: fix dropItem() didn't work for hubzila posts

### DIFF
--- a/view/theme/frio/js/textedit.js
+++ b/view/theme/frio/js/textedit.js
@@ -181,11 +181,19 @@ function confirmDelete() { return confirm(aStr.delitem); }
 
 function dropItem(url, object) {
 	var confirm = confirmDelete();
+
+	//if the first character of the object is #, remove it because
+	// we use getElementById which don't need the #
+	// getElementByID selects elements even if there are special characters
+	// in the ID (like %) which won't work with jQuery
+	/// @todo ceck if we can solve this in the template
+	object = object.indexOf('#') == 0 ? object.substring(1) : object;
+
 	if(confirm) {
 		$('body').css('cursor', 'wait');
-		$(object).fadeTo('fast', 0.33, function () {
+		$(document.getElementById(object)).fadeTo('fast', 0.33, function () {
 			$.get(url).done(function() {
-				$(object).remove();
+				$(document.getElementById(object)).remove();
 				$('body').css('cursor', 'auto');
 			});
 		});


### PR DESCRIPTION
In frio the js function dropItem() does use the ID for optical remove. The ID is the guid of the item. For hubzilla posts this is e.g. something like `#item-c1253c48996b1d4375716a3810c6cc38272249cd3c6d4642490e0226c2cfe512%40blablanet.com`. Because of `%` is a special character it can't be used with jQuery. With this fix the `#` gets removed and `getElementById()` is used to select the element.

Note:
Maybe we can remove the `#` directly in the template but I need to check if there would be any side effects. At the moment I don't have the time to do this. So I  defer this until later.