### PR TITLE
Show the worker queue count if the workers are active

### DIFF
--- a/doc/Settings.md
+++ b/doc/Settings.md
@@ -9,7 +9,8 @@ This number should decrease quickly.
 The second is the messages which could for various reasons not being delivered.
 They will be resend later.
 You can have a quick glance into that second queus in the "Inspect Queue" section of the admin panel.
-If you have activated the background workers, there might be a third number representing the count of jobs queued for the workers.
+If you have activated the background workers, there is a third number representing the count of jobs queued for the workers.
+These worker tasks are prioritised and are done accordingly.
 
 Then you get an overview of the accounts on your node, which can be moderated in the "Users" section of the panel.
 As well as an overview of the currently active addons

--- a/doc/de/Settings.md
+++ b/doc/de/Settings.md
@@ -9,8 +9,9 @@ Diese Zahl sollte sich relativ schnell sinken.
 Die zweite Zahl gibt die Anzahl von Nachrichten an, die nicht zugestellt werden konnten.
 Die Zustellung wird zu einem späteren Zeitpunkt noch einmal versucht.
 Unter dem Punkt "Warteschlange Inspizieren" kannst du einen schnellen Blick auf die zweite Warteschlange werfen.
-Solltest du für die Hintergrundprozesse die Worker aktiviert haben, könntest du eine dritte Zahl angezeigt bekommen.
+Solltest du für die Hintergrundprozesse die Worker aktiviert haben, wird eine dritte Zahl angezeigt.
 Diese repräsentiert die Anzahl der Aufgaben, die die Worker noch vor sich haben.
+Die Aufgaben der Worker sind priorisiert und werden anhand dieser Prioritäten abgearbeitet.
 
 Des weiteren findest du eine Übersicht über die Accounts auf dem Friendica Knoten, die unter dem Punkt "Nutzer" moderiert werden können.
 Sowie eine Liste der derzeit aktivierten Addons.

--- a/mod/admin.php
+++ b/mod/admin.php
@@ -460,6 +460,7 @@ function admin_page_summary(&$a) {
 		'$title' => t('Administration'),
 		'$page' => t('Summary'),
 		'$queues' => $queues,
+		'$workeractive' => get_config('system','worker'),
 		'$users' => array(t('Registered users'), $users),
 		'$accounts' => $accounts,
 		'$pending' => array(t('Pending registrations'), $pending),

--- a/view/templates/admin_summary.tpl
+++ b/view/templates/admin_summary.tpl
@@ -4,7 +4,7 @@
 
 	<dl>
 		<dt>{{$queues.label}}</dt>
-		<dd>{{$queues.deliverq}} - <a href="{{$baseurl}}/admin/queue">{{$queues.queue}}</a>{{if $queues.workerq}} - {{$queues.workerq}}{{/if}}</dd>
+		<dd>{{$queues.deliverq}} - <a href="{{$baseurl}}/admin/queue">{{$queues.queue}}</a>{{if $workeractive}} - {{$queues.workerq}}{{/if}}</dd>
 	</dl>
 	<dl>
 		<dt>{{$pending.0}}</dt>


### PR DESCRIPTION
Currently the worker queue count is shown, if it is not zero.

With this PR it is shown if the workers are active. Also the documentation was updated accordingly.