### PR TITLE
[frio] Changes to shared post display (width, base font size)

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -1415,8 +1415,6 @@ section #jotOpen {
 
 .shared-wrapper,
 .vevent {
-    margin-left: 50px;
-    margin-right: 50px;
     padding: 10px;
     box-shadow: 0 0 0 1.5px rgba(0, 0, 0, .1) inset, 0 1px 1px rgba(0, 0, 0, .05);
 }

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -60,6 +60,9 @@ section hr {
 iframe, img {
     max-width: 100%;
 }
+blockquote {
+    font-size: inherit;
+}
 .clear {
     clear: both;
 }
@@ -1441,7 +1444,6 @@ blockquote.shared_content {
     padding: 0px;
     margin-left: 0px;
     color: inherit;
-    font-size: inherit;
 }
 .wall-item-tags,
 .itemedited {

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -1431,13 +1431,15 @@ section #jotOpen {
 }
 .shared_header {
     margin-left: 0px;
-        margin-top: 0px;
+    margin-top: 0px;
     padding-top: 0px;
+    margin-bottom: 10px;
     border-top: none;
     color: inherit;
 }
 blockquote.shared_content {
-    margin-left: 20px;
+    padding: 0px;
+    margin-left: 0px;
     color: inherit;
 }
 .wall-item-tags,

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -1441,6 +1441,7 @@ blockquote.shared_content {
     padding: 0px;
     margin-left: 0px;
     color: inherit;
+    font-size: inherit;
 }
 .wall-item-tags,
 .itemedited {

--- a/view/theme/frio/php/default.php
+++ b/view/theme/frio/php/default.php
@@ -73,7 +73,7 @@ else
 						"; if(x($page,'right_aside')) echo $page['right_aside']; echo"
 					</aside>
 
-					<div class=\"col-lg-9 col-md-9 col-sm-12 col-xs-12\" id=\"content\">
+					<div class=\"col-lg-7 col-md-7 col-sm-12 col-xs-12\" id=\"content\">
 						<section class=\"sectiontop "; echo $a->argv[0]; echo "-content-wrapper\">";
 								if(x($page,'content')) echo $page['content']; echo"
 								<div id=\"pause\"></div> <!-- The pause/resume Ajax indicator -->

--- a/view/theme/frio/php/default.php
+++ b/view/theme/frio/php/default.php
@@ -73,7 +73,7 @@ else
 						"; if(x($page,'right_aside')) echo $page['right_aside']; echo"
 					</aside>
 
-					<div class=\"col-lg-7 col-md-7 col-sm-12 col-xs-12\" id=\"content\">
+					<div class=\"col-lg-9 col-md-9 col-sm-12 col-xs-12\" id=\"content\">
 						<section class=\"sectiontop "; echo $a->argv[0]; echo "-content-wrapper\">";
 								if(x($page,'content')) echo $page['content']; echo"
 								<div id=\"pause\"></div> <!-- The pause/resume Ajax indicator -->


### PR DESCRIPTION
Lately, I've been frustrated with a couple of width-related points on the frio theme:
- There is a large blank space on the right of the screen
- Shared items have large left and right margins which compresses the shared content

This PR aims at solving both those issues. The changes aren't groundbreaking, but they saves a few scrolls when going through the stream.

Before:
![screen shot 2016-09-28 at 11 17 48 am](https://cloud.githubusercontent.com/assets/925415/18920010/1f70482e-856e-11e6-8fc4-e964317a7b9c.png)

After:
![screen shot 2016-09-28 at 11 18 56 am](https://cloud.githubusercontent.com/assets/925415/18920020/2653c27e-856e-11e6-81e2-c5505fbdcb58.png)

A couple of notes regarding the increased width of the center column:
- The bootstrap grid has 12 divisions, however so far on desktop frio only used 10 of them (3 left + 10 center), and the right space wasn't preserved for the right aside, which is displayed on the left column under the left aside. I just reclaimed the missing 2 divisions.
- Even when resizing the browser to extreme width, the content doesn't become unreadable with the change because the parent container has a fixed width.