### PR TITLE
We should only use utf8mb4 for dumpsql and new installations

### DIFF
--- a/include/dbstructure.php
+++ b/include/dbstructure.php
@@ -262,7 +262,7 @@ function db_create_table($name, $fields, $verbose, $action, $indexes=null) {
 
 	if (isset($a->config["system"]["db_charset"]))
 		$charset = $a->config["system"]["db_charset"];
-	elseif ($verbose)
+	elseif (!$action) // Used for dumpsql
 		$charset = "utf8mb4";
 	else
 		$charset = "utf8";


### PR DESCRIPTION
We changed the charset for new installations to utfmb4. On old installations the charset has to stay at utf8. There was a bug in the routine that switched between this.