### PR TITLE
Fix Issue #2813 - Double notification + wrong message for requested registrations

### DIFF
--- a/include/enotify.php
+++ b/include/enotify.php
@@ -49,7 +49,7 @@ function notification($params) {
 	// with $params['show_in_notification_page'] == false, the notification isn't inserted into
 	// the database, and an email is sent if applicable.
 	// default, if not specified: true
-	$show_in_notification_page = ((x($params, 'show_in_notification_page'))	? $params['show_in_notification_page']:True);
+	$show_in_notification_page = ((x($params, 'show_in_notification_page'))	? $params['show_in_notification_page']:true);
 
 	$additional_mail_header = "";
 	$additional_mail_header .= "Precedence: list\n";

--- a/js/main.js
+++ b/js/main.js
@@ -264,13 +264,13 @@
 					var html = notifications_tpl.format(
 						e.attr('href'),                     // {0}  // link to the source
 						e.attr('photo'),                    // {1}  // photo of the contact
-						text,                               // {2}  // preformatet text (autor + text)
+						text,                               // {2}  // preformatted text (autor + text)
 						e.attr('date'),                     // {3}  // date of notification (time ago)
-						seenclass,                          // {4}  // vistiting status of the notification
-						new Date(e.attr('timestamp')*1000), // {5}  //date of notification
+						seenclass,                          // {4}  // visited status of the notification
+						new Date(e.attr('timestamp')*1000), // {5}  // date of notification
 						e.attr('url'),                      // {6}  // profile url of the contact
-						e.text().format(""),                // {7}  // clean status text
-						contact                             // {8}  //preformatat author (name + profile url)
+						e.text().format(contact),           // {7}  // preformatted html (text including author profile url)
+						''                                  // {8}  // Deprecated
 					);
 					nnm.append(html);
 				});

--- a/mod/register.php
+++ b/mod/register.php
@@ -132,24 +132,6 @@ function register_post(&$a) {
 			$admin_mail_list
 		);
 
-
-		foreach ($adminlist as $admin) {
-			notification(array(
-				'type' => NOTIFY_SYSTEM,
-				'event' => 'SYSTEM_REGISTER_REQUEST',
-				'source_name' => $user['username'],
-				'source_mail' => $user['email'],
-				'source_nick' => $user['nickname'],
-				'source_link' => $a->get_baseurl()."/admin/users/",
-				'link' => $a->get_baseurl()."/admin/users/",
-				'source_photo' => $a->get_baseurl() . "/photo/avatar/".$user['uid'].".jpg",
-				'to_email' => $admin['email'],
-				'uid' => $admin['uid'],
-				'language' => ($admin['language']?$admin['language']:'en'))
-			);
-		}
-
-
 		info( t('Your registration is pending approval by the site owner.') . EOL ) ;
 		goaway(z_root());
 

--- a/mod/register.php
+++ b/mod/register.php
@@ -132,6 +132,23 @@ function register_post(&$a) {
 			$admin_mail_list
 		);
 
+		foreach ($adminlist as $admin) {
+			notification(array(
+				'type' => NOTIFY_SYSTEM,
+				'event' => 'SYSTEM_REGISTER_REQUEST',
+				'source_name' => $user['username'],
+				'source_mail' => $user['email'],
+				'source_nick' => $user['nickname'],
+				'source_link' => $a->get_baseurl()."/admin/users/",
+				'link' => $a->get_baseurl()."/admin/users/",
+				'source_photo' => $a->get_baseurl() . "/photo/avatar/".$user['uid'].".jpg",
+				'to_email' => $admin['email'],
+				'uid' => $admin['uid'],
+				'language' => ($admin['language']?$admin['language']:'en'),
+				'show_in_notification_page' => false
+			));
+		}
+
 		info( t('Your registration is pending approval by the site owner.') . EOL ) ;
 		goaway(z_root());
 


### PR DESCRIPTION
- Remove adding a notification for each admin on register approval
request (as per @rabuzarus's suggestion on #2813)
- Fix wrong display of the above notification that is removed anyway
- Fix comments