### PR TITLE
Support of utf8mb4

### DIFF
--- a/include/dbstructure.php
+++ b/include/dbstructure.php
@@ -336,7 +336,6 @@ function db_create_index($indexname, $fieldnames, $method="ADD") {
 	}
 
 	if ($indexname == "PRIMARY") {
-		//return sprintf("%s PRIMARY KEY(`%s`)", $method, implode("`,`", $fieldnames));
 		return sprintf("%s PRIMARY KEY(%s)", $method, $names);
 	}
 


### PR DESCRIPTION
utf8mb4 on mysql has different limits than utf8. Indexes on mysql have the limit of 1000 characters. With utf8 (which can contain 3 byte unicode characters) this means a limit of 255 characters, with utf8mb4 (and 4 byte unicode characters) the limit shrinks to 191.

This is now respected.