### PR TITLE
with translations now in /view/lang/lng shift the array index along

### DIFF
--- a/include/pgettext.php
+++ b/include/pgettext.php
@@ -179,7 +179,7 @@ function get_avaiable_languages() {
 		asort($langs);
 		foreach($langs as $l) {
 			$t = explode("/",$l);
-			$lang_choices[$t[1]] = $t[1];
+			$lang_choices[$t[2]] = $t[2];
 		}
 	}
 	return $lang_choices;


### PR DESCRIPTION
In #2821 the array index needs to be shifted to 2 as it is now `/view/lang/lng` and not `/view/lng` anymore. Then the selection elements show the list of languages again.