### PR TITLE
The account type is now read and displayed

### DIFF
--- a/include/Contact.php
+++ b/include/Contact.php
@@ -687,12 +687,13 @@ function formatted_location($profile) {
 /**
  * @brief Returns the account type name
  *
- * The function be called with either the profile or the contct array
+ * The function can be called with either the user or the contact array
  *
- * @param array $contact contact or profile array
+ * @param array $contact contact or user array
  */
 function account_type($contact) {
 
+	// There are several fields that indicate that the contact or user is a forum
 	if((isset($contact['page-flags']) && (intval($contact['page-flags']) == PAGE_COMMUNITY))
 		|| (isset($contact['page-flags']) && (intval($contact['page-flags']) == PAGE_PRVGROUP))
 		|| (isset($contact['forum']) && intval($contact['forum']))
@@ -702,23 +703,26 @@ function account_type($contact) {
 	else
 		$type = ACCOUNT_TYPE_PERSON;
 
+	// The field is named differently in the user and the contact record
 	if (isset($contact["contact-type"]))
 		$type = $contact["contact-type"];
 	if (isset($contact["account-type"]))
 		$type = $contact["account-type"];
 
-	if ($type != 0)
-		switch($type) {
-			case ACCOUNT_TYPE_ORGANISATION:
-				$account_type = t("Organisation");
-				 break;
-			case ACCOUNT_TYPE_NEWS:
-				$account_type = t('News');
-				break;
-			case ACCOUNT_TYPE_COMMUNITY:
-				$account_type = t("Forum");
-				break;
-		}
+	switch($type) {
+		case ACCOUNT_TYPE_ORGANISATION:
+			$account_type = t("Organisation");
+			break;
+		case ACCOUNT_TYPE_NEWS:
+			$account_type = t('News');
+			break;
+		case ACCOUNT_TYPE_COMMUNITY:
+			$account_type = t("Forum");
+			break;
+		default:
+			$account_type = "";
+			break;
+	}
 
 	return $account_type;
 }

--- a/include/Contact.php
+++ b/include/Contact.php
@@ -694,6 +694,9 @@ function formatted_location($profile) {
 function account_type($contact) {
 
 	// There are several fields that indicate that the contact or user is a forum
+	// "page-flags" is a field in the user table,
+	// "forum" and "prv" are used in the contact table. They stand for PAGE_COMMUNITY and PAGE_PRVGROUP.
+	// "community" is used in the gcontact table and is true if the contact is PAGE_COMMUNITY or PAGE_PRVGROUP.
 	if((isset($contact['page-flags']) && (intval($contact['page-flags']) == PAGE_COMMUNITY))
 		|| (isset($contact['page-flags']) && (intval($contact['page-flags']) == PAGE_PRVGROUP))
 		|| (isset($contact['forum']) && intval($contact['forum']))
@@ -703,7 +706,7 @@ function account_type($contact) {
 	else
 		$type = ACCOUNT_TYPE_PERSON;
 
-	// The field is named differently in the user and the contact record
+	// The "contact-type" (contact table) and "account-type" (user table) are more general then the chaos from above.
 	if (isset($contact["contact-type"]))
 		$type = $contact["contact-type"];
 	if (isset($contact["account-type"]))

--- a/include/Contact.php
+++ b/include/Contact.php
@@ -208,22 +208,22 @@ function get_contact_details_by_url($url, $uid = -1, $default = array()) {
 		$uid = local_user();
 
 	// Fetch contact data from the contact table for the given user
-	$r = q("SELECT `id`, `id` AS `cid`, 0 AS `gid`, 0 AS `zid`, `uid`, `url`, `nurl`, `alias`, `network`, `name`, `nick`, `addr`, `location`, `about`,
-			`xmpp`, `keywords`, `gender`, `photo`, `thumb`, `micro`, `forum`, `prv`, (`forum` | `prv`) AS `community`, `bd` AS `birthday`, `self`
+	$r = q("SELECT `id`, `id` AS `cid`, 0 AS `gid`, 0 AS `zid`, `uid`, `url`, `nurl`, `alias`, `network`, `name`, `nick`, `addr`, `location`, `about`, `xmpp`,
+			`keywords`, `gender`, `photo`, `thumb`, `micro`, `forum`, `prv`, (`forum` | `prv`) AS `community`, `contact-type`, `bd` AS `birthday`, `self`
 		FROM `contact` WHERE `nurl` = '%s' AND `uid` = %d",
 			dbesc(normalise_link($url)), intval($uid));
 
 	// Fetch the data from the contact table with "uid=0" (which is filled automatically)
 	if (!$r)
-		$r = q("SELECT `id`, 0 AS `cid`, `id` AS `zid`, 0 AS `gid`, `uid`, `url`, `nurl`, `alias`, `network`, `name`, `nick`, `addr`, `location`, `about`,
-				`xmpp`, `keywords`, `gender`, `photo`, `thumb`, `micro`, `forum`, `prv`, (`forum` | `prv`) AS `community`, `bd` AS `birthday`, 0 AS `self`
+		$r = q("SELECT `id`, 0 AS `cid`, `id` AS `zid`, 0 AS `gid`, `uid`, `url`, `nurl`, `alias`, `network`, `name`, `nick`, `addr`, `location`, `about`, `xmpp`,
+			`keywords`, `gender`, `photo`, `thumb`, `micro`, `forum`, `prv`, (`forum` | `prv`) AS `community`, `contact-type`, `bd` AS `birthday`, 0 AS `self`
 			FROM `contact` WHERE `nurl` = '%s' AND `uid` = 0",
 				dbesc(normalise_link($url)));
 
 	// Fetch the data from the gcontact table
 	if (!$r)
-		$r = q("SELECT 0 AS `id`, 0 AS `cid`, `id` AS `gid`, 0 AS `zid`, 0 AS `uid`, `url`, `nurl`, `alias`, `network`, `name`, `nick`, `addr`, `location`, `about`,
-				'' AS `xmpp`, `keywords`, `gender`, `photo`, `photo` AS `thumb`, `photo` AS `micro`, `community` AS `forum`, 0 AS `prv`, `community`, `birthday`, 0 AS `self`
+		$r = q("SELECT 0 AS `id`, 0 AS `cid`, `id` AS `gid`, 0 AS `zid`, 0 AS `uid`, `url`, `nurl`, `alias`, `network`, `name`, `nick`, `addr`, `location`, `about`, '' AS `xmpp`,
+			`keywords`, `gender`, `photo`, `photo` AS `thumb`, `photo` AS `micro`, `community` AS `forum`, 0 AS `prv`, `community`, 0 AS `contact-type`, `birthday`, 0 AS `self`
 			FROM `gcontact` WHERE `nurl` = '%s'",
 				dbesc(normalise_link($url)));
 
@@ -682,5 +682,44 @@ function formatted_location($profile) {
 	}
 
 	return $location;
+}
+
+/**
+ * @brief Returns the account type name
+ *
+ * The function be called with either the profile or the contct array
+ *
+ * @param array $contact contact or profile array
+ */
+function account_type($contact) {
+
+	if((isset($contact['page-flags']) && (intval($contact['page-flags']) == PAGE_COMMUNITY))
+		|| (isset($contact['page-flags']) && (intval($contact['page-flags']) == PAGE_PRVGROUP))
+		|| (isset($contact['forum']) && intval($contact['forum']))
+		|| (isset($contact['prv']) && intval($contact['prv']))
+		|| (isset($contact['community']) && intval($contact['community'])))
+		$type = ACCOUNT_TYPE_COMMUNITY;
+	else
+		$type = ACCOUNT_TYPE_PERSON;
+
+	if (isset($contact["contact-type"]))
+		$type = $contact["contact-type"];
+	if (isset($contact["account-type"]))
+		$type = $contact["account-type"];
+
+	if ($type != 0)
+		switch($type) {
+			case ACCOUNT_TYPE_ORGANISATION:
+				$account_type = t("Organisation");
+				 break;
+			case ACCOUNT_TYPE_NEWS:
+				$account_type = t('News');
+				break;
+			case ACCOUNT_TYPE_COMMUNITY:
+				$account_type = t("Forum");
+				break;
+		}
+
+	return $account_type;
 }
 ?>

--- a/include/dfrn.php
+++ b/include/dfrn.php
@@ -2492,7 +2492,19 @@ class dfrn {
 
 		logger("Import DFRN message for user ".$importer["uid"]." from contact ".$importer["id"], LOGGER_DEBUG);
 
-		// is it a public forum? Private forums aren't supported by now with this method
+		// The account type is new since 3.5.1
+		if ($xpath->query("/atom:feed/dfrn:account_type")->length > 0) {
+			$accounttype = intval($xpath->evaluate("/atom:feed/dfrn:account_type/text()", $context)->item(0)->nodeValue);
+
+			if ($accounttype != $importer["contact-type"])
+				q("UPDATE `contact` SET `contact-type` = %d WHERE `id` = %d",
+					intval($accounttype),
+					intval($importer["id"])
+				);
+		}
+
+		// is it a public forum? Private forums aren't supported with this method
+		// This is deprecated since 3.5.1
 		$forum = intval($xpath->evaluate("/atom:feed/dfrn:community/text()", $context)->item(0)->nodeValue);
 
 		if ($forum != $importer["forum"])

--- a/include/identity.php
+++ b/include/identity.php
@@ -310,15 +310,8 @@ function profile_sidebar($profile, $block = 0) {
 		);
 	}
 
-	// check if profile is a forum
-	if((intval($profile['page-flags']) == PAGE_COMMUNITY)
-			|| (intval($profile['page-flags']) == PAGE_PRVGROUP)
-			|| (isset($profile['forum']) && intval($profile['forum']))
-			|| (isset($profile['prv']) && intval($profile['prv']))
-			|| (isset($profile['community']) && intval($profile['community'])))
-		$account_type = t('Forum');
-	else
-		$account_type = "";
+	// Fetch the account type
+	$account_type = account_type($profile);
 
 	if((x($profile,'address') == 1)
 			|| (x($profile,'location') == 1)

--- a/mod/allfriends.php
+++ b/mod/allfriends.php
@@ -76,7 +76,7 @@ function allfriends_content(&$a) {
 			'details'	=> $contact_details['location'],
 			'tags'		=> $contact_details['keywords'],
 			'about'		=> $contact_details['about'],
-			'account_type'	=> (($contact_details['community']) ? t('Forum') : ''),
+			'account_type'	=> account_type($contact_details),
 			'network'	=> network_to_name($contact_details['network'], $contact_details['url']),
 			'photo_menu'	=> $photo_menu,
 			'conntxt'	=> t('Connect'),

--- a/mod/cal.php
+++ b/mod/cal.php
@@ -40,10 +40,7 @@ function cal_init(&$a) {
 
 		$profile = get_profiledata_by_nick($nick, $a->profile_uid);
 
-		if((intval($profile['page-flags']) == PAGE_COMMUNITY) || (intval($profile['page-flags']) == PAGE_PRVGROUP))
-			$account_type = t('Forum');
-		else
-			$account_type = "";
+		$account_type = account_type($profile);
 
 		$tpl = get_markup_template("vcard-widget.tpl");
 

--- a/mod/common.php
+++ b/mod/common.php
@@ -120,7 +120,7 @@ function common_content(&$a) {
 			'details'	=> $contact_details['location'],
 			'tags'		=> $contact_details['keywords'],
 			'about'		=> $contact_details['about'],
-			'account_type'	=> (($contact_details['community']) ? t('Forum') : ''),
+			'account_type'	=> account_type($contact_details),
 			'network'	=> network_to_name($contact_details['network'], $contact_details['url']),
 			'photo_menu'	=> $photo_menu,
 			'id'		=> ++$id,

--- a/mod/contacts.php
+++ b/mod/contacts.php
@@ -38,7 +38,7 @@ function contacts_init(&$a) {
 
 			if (($a->data['contact']['network'] != "") AND ($a->data['contact']['network'] != NETWORK_DFRN)) {
 				$networkname = format_network_name($a->data['contact']['network'],$a->data['contact']['url']);
-			} else 
+			} else
 				$networkname = '';
 
 			$vcard_widget = replace_macros(get_markup_template("vcard-widget.tpl"),array(
@@ -48,7 +48,7 @@ function contacts_init(&$a) {
 				'$addr' => (($a->data['contact']['addr'] != "") ? ($a->data['contact']['addr']) : ""),
 				'$network_name' => $networkname,
 				'$network' => t('Network:'),
-				'account_type' => (($a->data['contact']['forum'] || $a->data['contact']['prv']) ? t('Forum') : '')
+				'$account_type' => account_type($a->data['contact'])
 			));
 			$finpeople_widget = '';
 			$follow_widget = '';
@@ -623,7 +623,7 @@ function contacts_content(&$a) {
 			'$url' => $url,
 			'$profileurllabel' => t('Profile URL'),
 			'$profileurl' => $contact['url'],
-			'account_type' => (($contact['forum'] || $contact['prv']) ? t('Forum') : ''),
+			'$account_type' => account_type($contact),
 			'$location' => bbcode($contact["location"]),
 			'$location_label' => t("Location:"),
 			'$xmpp' => bbcode($contact["xmpp"]),
@@ -910,8 +910,6 @@ function contact_posts($a, $contact_id) {
 
 function _contact_detail_for_template($rr){
 
-	$community = '';
-
 	switch($rr['rel']) {
 		case CONTACT_IS_FRIEND:
 			$dir_icon = 'images/lrarrow.gif';
@@ -937,11 +935,6 @@ function _contact_detail_for_template($rr){
 		$sparkle = '';
 	}
 
-	//test if contact is a forum page
-	if (isset($rr['forum']) OR isset($rr['prv']))
-				$community = ($rr['forum'] OR $rr['prv']);
-
-
 	return array(
 		'img_hover' => sprintf( t('Visit %s\'s profile [%s]'),$rr['name'],$rr['url']),
 		'edit_hover' => t('Edit contact'),
@@ -952,7 +945,7 @@ function _contact_detail_for_template($rr){
 		'thumb' => proxy_url($rr['thumb'], false, PROXY_SIZE_THUMB),
 		'name' => htmlentities($rr['name']),
 		'username' => htmlentities($rr['name']),
-		'account_type' => ($community ? t('Forum') : ''),
+		'account_type' => account_type($rr),
 		'sparkle' => $sparkle,
 		'itemurl' => (($rr['addr'] != "") ? $rr['addr'] : $rr['url']),
 		'url' => $url,

--- a/mod/directory.php
+++ b/mod/directory.php
@@ -99,7 +99,6 @@ function directory_content(&$a) {
 
 		foreach($r as $rr) {
 
-			$community = '';
 			$itemurl= '';
 
 			$itemurl = (($rr['addr'] != "") ? $rr['addr'] : $rr['profile_url']);
@@ -127,13 +126,6 @@ function directory_content(&$a) {
 //			}
 //			if(strlen($rr['gender']))
 //				$details .= '<br />' . t('Gender: ') . $rr['gender'];
-
-
-			// show if account is a community account
-			/// @TODO The other page types should be also respected, but first we need a good 
-			/// translatiion and systemwide consistency for displaying the page type
-			if((intval($rr['page-flags']) == PAGE_COMMUNITY) OR (intval($rr['page-flags']) == PAGE_PRVGROUP))
-				$community = true;
 
 			$profile = $rr;
 
@@ -171,7 +163,7 @@ function directory_content(&$a) {
 				'img_hover' => $rr['name'],
 				'name' => $rr['name'],
 				'details' => $details,
-				'account_type' => ($community ? t('Forum') : ''),
+				'account_type' => account_type($rr),
 				'profile' => $profile,
 				'location' => $location_e,
 				'tags' => $rr['pub_keywords'],

--- a/mod/dirfind.php
+++ b/mod/dirfind.php
@@ -220,7 +220,7 @@ function dirfind_content(&$a, $prefix = "") {
 					'details'       => $contact_details['location'],
 					'tags'          => $contact_details['keywords'],
 					'about'         => $contact_details['about'],
-					'account_type'  => (($contact_details['community']) ? t('Forum') : ''),
+					'account_type'  => account_type($contact_details),
 					'network' => network_to_name($jj->network, $jj->url),
 					'id' => ++$id,
 				);

--- a/mod/hovercard.php
+++ b/mod/hovercard.php
@@ -77,10 +77,9 @@ function hovercard_content() {
 //		'server_url' => $contact["server_url"],
 		'bd' => (($contact["birthday"] == "0000-00-00") ? "" : $contact["birthday"]),
 //		'generation' => $contact["generation"],
-		'account_type' => ($contact['community'] ? t("Forum") : ""),
+		'account_type' => account_type($contact),
 		'actions' => $actions,
 	);
-
 	if($datatype == "html") {
 		$t = get_markup_template("hovercard.tpl");
 

--- a/mod/match.php
+++ b/mod/match.php
@@ -81,7 +81,7 @@ function match_content(&$a) {
 						'details'       => $contact_details['location'],
 						'tags'          => $contact_details['keywords'],
 						'about'         => $contact_details['about'],
-						'account_type'  => (($contact_details['community']) ? t('Forum') : ''),
+						'account_type'  => account_type($contact_details),
 						'thumb' => proxy_url($jj->photo, false, PROXY_SIZE_THUMB),
 						'inttxt' => ' ' . t('is interested in:'),
 						'conntxt' => t('Connect'),

--- a/mod/network.php
+++ b/mod/network.php
@@ -502,7 +502,7 @@ function network_content(&$a, $update = 0) {
 	}
 	elseif($cid) {
 
-		$r = q("SELECT `id`,`name`,`network`,`writable`,`nurl`, `forum`, `prv`, `addr`, `thumb`, `location` FROM `contact` WHERE `id` = %d
+		$r = q("SELECT `id`,`name`,`network`,`writable`,`nurl`, `forum`, `prv`, `contact-type`, `addr`, `thumb`, `location` FROM `contact` WHERE `id` = %d
 				AND `blocked` = 0 AND `pending` = 0 LIMIT 1",
 			intval($cid)
 		);
@@ -514,9 +514,10 @@ function network_content(&$a, $update = 0) {
 				'name' => htmlentities($r[0]['name']),
 				'itemurl' => (($r[0]['addr']) ? ($r[0]['addr']) : ($r[0]['nurl'])),
 				'thumb' => proxy_url($r[0]['thumb'], false, PROXY_SIZE_THUMB),
-				'account_type' => (($r[0]['forum']) || ($r[0]['prv']) ? t('Forum') : ''),
 				'details' => $r[0]['location'],
 			);
+
+			$entries[0]["account_type"] = account_type($r[0]);
 
 			$o = replace_macros(get_markup_template("viewcontact_template.tpl"),array(
 				'contacts' => $entries,

--- a/mod/photos.php
+++ b/mod/photos.php
@@ -38,10 +38,7 @@ function photos_init(&$a) {
 
 		$profile = get_profiledata_by_nick($nick, $a->profile_uid);
 
-		if((intval($profile['page-flags']) == PAGE_COMMUNITY) || (intval($profile['page-flags']) == PAGE_PRVGROUP))
-			$account_type = t('Forum');
-		else
-			$account_type = "";
+		$account_type = account_type($profile);
 
 		$tpl = get_markup_template("vcard-widget.tpl");
 

--- a/mod/suggest.php
+++ b/mod/suggest.php
@@ -95,7 +95,7 @@ function suggest_content(&$a) {
 			'details'       => $contact_details['location'],
 			'tags'          => $contact_details['keywords'],
 			'about'         => $contact_details['about'],
-			'account_type'  => (($contact_details['community']) ? t('Forum') : ''),
+			'account_type'  => account_type($contact_details),
 			'ignlnk' => $ignlnk,
 			'ignid' => $rr['id'],
 			'conntxt' => t('Connect'),
@@ -113,7 +113,6 @@ function suggest_content(&$a) {
 	$o .= replace_macros($tpl,array(
 		'$title' => t('Friend Suggestions'),
 		'$contacts' => $entries,
-		
 	));
 
 	return $o;

--- a/mod/videos.php
+++ b/mod/videos.php
@@ -33,10 +33,7 @@ function videos_init(&$a) {
 
 		$profile = get_profiledata_by_nick($nick, $a->profile_uid);
 
-		if((intval($profile['page-flags']) == PAGE_COMMUNITY) || (intval($profile['page-flags']) == PAGE_PRVGROUP))
-			$account_type = t('Forum');
-		else
-			$account_type = "";
+		$account_type = account_type($profile);
 
 		$tpl = get_markup_template("vcard-widget.tpl");
 

--- a/mod/viewcontacts.php
+++ b/mod/viewcontacts.php
@@ -102,7 +102,7 @@ function viewcontacts_content(&$a) {
 			'details'       => $contact_details['location'],
 			'tags'          => $contact_details['keywords'],
 			'about'         => $contact_details['about'],
-			'account_type'  => (($contact_details['community']) ? t('Forum') : ''),
+			'account_type'  => account_type($contact_details),
 			'url' => $url,
 			'sparkle' => '',
 			'itemurl' => (($contact_details['addr'] != "") ? $contact_details['addr'] : $rr['url']),


### PR DESCRIPTION
In one of the last pull requests we started to transmit the account type. Now we are reading it. Additionally there is now a centralized function that displays the account type. It replaces the code on multiple places with a single function.