### PR TITLE
Fix Issue #2800 - Prevent internal link from switching to Safari in standalone mode

### DIFF
--- a/view/templates/head.tpl
+++ b/view/templates/head.tpl
@@ -20,10 +20,9 @@
 
 <meta name="apple-mobile-web-app-capable" content="yes" />
 <script>
-// Prevents links to switch to Safari in a home screen app
+// Prevents links to switch to Safari in a home screen app - see https://gist.github.com/irae/1042167
 (function(a,b,c){if(c in b&&b[c]){var d,e=a.location,f=/^(a|html)$/i;a.addEventListener("click",function(a){d=a.target;while(!f.test(d.nodeName))d=d.parentNode;"href"in d&&(chref=d.href).replace(e.href,"").indexOf("#")&&(!/^[a-z\+\.\-]+:/i.test(chref)||chref.indexOf(e.protocol+"//"+e.host)===0)&&(a.preventDefault(),e.href=d.href)},!1)}})(document,window.navigator,"standalone");
 </script>
-
 
 <link rel="search"
          href="{{$baseurl}}/opensearch"

--- a/view/templates/head.tpl
+++ b/view/templates/head.tpl
@@ -18,12 +18,16 @@
 <link rel="shortcut icon" href="{{$shortcut_icon}}" />
 <link rel="apple-touch-icon" href="{{$touch_icon}}"/>
 
-<meta name="apple-mobile-web-app-capable" content="yes" /> 
+<meta name="apple-mobile-web-app-capable" content="yes" />
+<script>
+// Prevents links to switch to Safari in a home screen app
+(function(a,b,c){if(c in b&&b[c]){var d,e=a.location,f=/^(a|html)$/i;a.addEventListener("click",function(a){d=a.target;while(!f.test(d.nodeName))d=d.parentNode;"href"in d&&(chref=d.href).replace(e.href,"").indexOf("#")&&(!/^[a-z\+\.\-]+:/i.test(chref)||chref.indexOf(e.protocol+"//"+e.host)===0)&&(a.preventDefault(),e.href=d.href)},!1)}})(document,window.navigator,"standalone");
+</script>
 
 
 <link rel="search"
-         href="{{$baseurl}}/opensearch" 
-         type="application/opensearchdescription+xml" 
+         href="{{$baseurl}}/opensearch"
+         type="application/opensearchdescription+xml"
          title="Search in Friendica" />
 
 <!--[if IE]>

--- a/view/theme/frio/templates/head.tpl
+++ b/view/theme/frio/templates/head.tpl
@@ -39,11 +39,15 @@
 <link rel="shortcut icon" href="{{$shortcut_icon}}" />
 <link rel="apple-touch-icon" href="{{$touch_icon}}"/>
 
-<meta name="apple-mobile-web-app-capable" content="yes" /> 
+<meta name="apple-mobile-web-app-capable" content="yes" />
+<script>
+// Prevents links to switch to Safari in a home screen app - see https://gist.github.com/irae/1042167
+(function(a,b,c){if(c in b&&b[c]){var d,e=a.location,f=/^(a|html)$/i;a.addEventListener("click",function(a){d=a.target;while(!f.test(d.nodeName))d=d.parentNode;"href"in d&&(chref=d.href).replace(e.href,"").indexOf("#")&&(!/^[a-z\+\.\-]+:/i.test(chref)||chref.indexOf(e.protocol+"//"+e.host)===0)&&(a.preventDefault(),e.href=d.href)},!1)}})(document,window.navigator,"standalone");
+</script>
 
 <link rel="search"
-         href="{{$baseurl}}/opensearch" 
-         type="application/opensearchdescription+xml" 
+         href="{{$baseurl}}/opensearch"
+         type="application/opensearchdescription+xml"
          title="Search in Friendica" />
 
 

--- a/view/theme/frio/templates/nav.tpl
+++ b/view/theme/frio/templates/nav.tpl
@@ -275,7 +275,7 @@
 
 {{*The second part of the notifications dropdown menu. It handles the notifications *}}
 {{if $nav.notifications}}
-<ul id="nav-notifications-template" class="media-list" style="display:none;" rel="template"> <!-- needs further investigation. I thought the notifications have their own templates -->
+<ul id="nav-notifications-template" class="media-list" style="display:none;" rel="template">
 	<li class="{4} notif-entry">
 		<div class="notif-entry-wrapper media">
 			<div class="notif-photo-wrapper media-object pull-left"><a href="{6}"><img data-src="{1}"></a></div>


### PR DESCRIPTION
This little script delegate an event listener that matches internal links to prevent them to switch to the Safari application when Friendica is in standalone mode (added to Home Screen on an Apple device).

There's one limitation though: the notification links redirect to the actual item URL, which triggers the app switching anyway.

Fixes 1. of #2800 