### PR TITLE
dbstructure now switches in the maintenance mode when updating

### DIFF
--- a/include/dbstructure.php
+++ b/include/dbstructure.php
@@ -126,6 +126,9 @@ function print_structure($database, $charset) {
 function update_structure($verbose, $action, $tables=null, $definition=null) {
 	global $a, $db;
 
+	if ($action)
+		set_config('system', 'maintenance', 1);
+
 	if (isset($a->config["system"]["db_charset"]))
 		$charset = $a->config["system"]["db_charset"];
 	else
@@ -240,6 +243,9 @@ function update_structure($verbose, $action, $tables=null, $definition=null) {
 			}
 		}
 	}
+
+	if ($action)
+		set_config('system', 'maintenance', 0);
 
 	return $errors;
 }

--- a/include/poller.php
+++ b/include/poller.php
@@ -29,6 +29,10 @@ function poller_run(&$argv, &$argc){
 		unset($db_host, $db_user, $db_pass, $db_data);
 	};
 
+	// Quit when in maintenance
+	if (get_config('system', 'maintenance', true))
+		return;
+
 	$a->start_process();
 
 	$mypid = getmypid();
@@ -70,6 +74,10 @@ function poller_run(&$argv, &$argc){
 	$starttime = time();
 
 	while ($r = q("SELECT * FROM `workerqueue` WHERE `executed` = '0000-00-00 00:00:00' ORDER BY `priority`, `created` LIMIT 1")) {
+
+		// Quit when in maintenance
+		if (get_config('system', 'maintenance', true))
+			return;
 
 		// Constantly check the number of parallel database processes
 		if ($a->max_processes_reached())

--- a/mod/maintenance.php
+++ b/mod/maintenance.php
@@ -1,6 +1,10 @@
 <?php
 
 function maintenance_content(&$a) {
+	header('HTTP/1.1 503 Service Temporarily Unavailable');
+	header('Status: 503 Service Temporarily Unavailable');
+	header('Retry-After: 600');
+
 	return replace_macros(get_markup_template('maintenance.tpl'), array(
 		'$sysdown' => t('System down for maintenance')
 	));


### PR DESCRIPTION
Additionally the poller stops in maintenance mode and we send the correct header type for the maintenance mode.