### PR TITLE
frio: provide a edit profile button for the advanced profile page

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -835,17 +835,19 @@ nav.navbar a {
     /*border-left: 3px solid #6fdbe8;*/
     border-left: 3px solid $link_color;
     color: #fff!important;
-    background-color: $menu_background_hover_color !important
+    background-color: $menu_background_hover_color !important;
 }
-.nav-pills.preferences .dropdown .dropdown-toggle {
-    color: #bebebe
+.nav-pills.preferences .dropdown .dropdown-toggle,
+.nav-pills.preferences > li > .btn {
+    color: #bebebe;
 }
 .nav-pills.preferences .dropdown.open .dropdown-toggle,
 .nav-pills.preferences .dropdown.open .dropdown-toggle:hover {
-    background-color: $nav_bg
+    background-color: $nav_bg;
 }
 
-.nav-pills.preferences .dropdown .dropdown-toggle {
+.nav-pills.preferences .dropdown .dropdown-toggle,
+.nav-pills.preferences > li > .btn {
     padding: 2px 10px;
 }
 

--- a/view/theme/frio/templates/profile_advanced.tpl
+++ b/view/theme/frio/templates/profile_advanced.tpl
@@ -1,5 +1,5 @@
 
-<script>
+<script language="javascript" type="text/javascript">
 	// the following functions show/hide the specific profile page content 
 	// in dependence of the selected nav
 	function profileStandardActive() {
@@ -21,6 +21,19 @@
 <div id="profile-page" class="generic-page-wrapper">
 	<h3 class="">{{$title}}</h3>
 
+	{{* The link to edit the profile*}}
+	{{if $profile.edit}}
+	<ul class="nav nav-pills preferences">
+		<li class="pull-right">
+			<a class="btn btn-link btn-sm" type="button" id="profile-edit-link" href="{{$profile.edit.0}}" title="{{$profile.edit.3}}">
+				<i class="fa fa-pencil-square-o" aria-hidden="true"></i>&nbsp;{{$profile.edit.1}}
+			</a>
+		</li>
+	</ul>
+	<div class="clear"></div>
+	{{/if}}
+
+	{{* Frio does split the profile information in "standard" and "advanced". This is the tab menu for swithching between this modes *}}
 	<ul id="profile-menu" class="nav nav-tabs" role="menubar" data-tabs="tabs">
 		<li class="active" role="menuitem"><a id="profile-tab-standard-link" onclick="profileStandardActive(); return false;">{{$basic}}</a></li>
 		<li role="menuitem"><a id="profile-tab-advanced-link" onclick="profileAdvancedActive(); return false;">{{$advanced}}</a></li>
@@ -226,4 +239,3 @@
 		{{/if}}
 	</div>
 </div>
-


### PR DESCRIPTION
There was some discussion in the helpers forum because of the visibility of the edit-profile link. This PR adds a button for editing the profile in the upper right corner of the advanced profile page (like in vier) 