### PR TITLE
QuickFix Issue #2850 - Users with non XHTML themes can't use their account@friendica.instance to connect

### DIFF
--- a/mod/dfrn_request.php
+++ b/mod/dfrn_request.php
@@ -446,9 +446,12 @@ function dfrn_request_post(&$a) {
 			// Detect the network
 			$data = probe_url($url);
 			$network = $data["network"];
+			$url = $data["url"];
 
-			// Canonicalise email-style profile locator
-			$url = Probe::webfinger_dfrn($url,$hcard);
+			if (!$url) {
+				// Canonicalise email-style profile locator
+				$url = Probe::webfinger_dfrn($url,$hcard);
+			}
 
 			if (substr($url,0,5) === 'stat:') {
 


### PR DESCRIPTION
Here's what I found: Before `Probe::webfinger_dfrn()` is executed to retrieve the profile URL from a profile email-style address and fails for non-XML compliant themes, `probe_url()`  is performed. This call is successful for non-XML compliant themes and correctly retrieves the profile URL from an email-style profile address.

The fix then was simple: if the `probe_url()` calls yields the profile URL, then we don't have to execute `Probe::webfinger_dfrn()` and it doesn't have to fail.

Now, this is a quick fix because the call will still fail for non-XML compliant themes if the `probe_url()` fails as well.

Quick fixes #2850 

Successfully tested with a Friendica profile address and a Hubzilla profile address. Testing with a Diaspora profile address redirected me to the page where it says that we Disapora doesn't support remote friending.