### PR TITLE
The creation of unique keys failed for MariaDB

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -38,7 +38,7 @@ define ( 'FRIENDICA_PLATFORM',     'Friendica');
 define ( 'FRIENDICA_CODENAME',     'Asparagus');
 define ( 'FRIENDICA_VERSION',      '3.5.1-dev' );
 define ( 'DFRN_PROTOCOL_VERSION',  '2.23'    );
-define ( 'DB_UPDATE_VERSION',      1205      );
+define ( 'DB_UPDATE_VERSION',      1206      );
 
 /**
  * @brief Constant with a HTML line break.

--- a/include/Core/Config.php
+++ b/include/Core/Config.php
@@ -32,7 +32,7 @@ class Config {
 	public static function load($family) {
 		global $a;
 
-		$r = q("SELECT `v`, `k` FROM `config` WHERE `cat` = '%s'", dbesc($family));
+		$r = q("SELECT `v`, `k` FROM `config` WHERE `cat` = '%s' ORDER BY `cat`, `k`, `id`", dbesc($family));
 		if(count($r)) {
 			foreach($r as $rr) {
 				$k = $rr['k'];
@@ -90,7 +90,7 @@ class Config {
 			}
 		}
 
-		$ret = q("SELECT `v` FROM `config` WHERE `cat` = '%s' AND `k` = '%s' LIMIT 1",
+		$ret = q("SELECT `v` FROM `config` WHERE `cat` = '%s' AND `k` = '%s' ORDER BY `id` DESC LIMIT 1",
 			dbesc($family),
 			dbesc($key)
 		);

--- a/include/Core/PConfig.php
+++ b/include/Core/PConfig.php
@@ -29,7 +29,7 @@ class PConfig {
 	 */
 	public static function load($uid,$family) {
 		global $a;
-		$r = q("SELECT `v`,`k` FROM `pconfig` WHERE `cat` = '%s' AND `uid` = %d",
+		$r = q("SELECT `v`,`k` FROM `pconfig` WHERE `cat` = '%s' AND `uid` = %d ORDER BY `cat`, `k`, `id`",
 			dbesc($family),
 			intval($uid)
 		);
@@ -83,7 +83,7 @@ class PConfig {
 			}
 		}
 
-		$ret = q("SELECT `v` FROM `pconfig` WHERE `uid` = %d AND `cat` = '%s' AND `k` = '%s' LIMIT 1",
+		$ret = q("SELECT `v` FROM `pconfig` WHERE `uid` = %d AND `cat` = '%s' AND `k` = '%s' ORDER BY `id` DESC LIMIT 1",
 			intval($uid),
 			dbesc($family),
 			dbesc($key)

--- a/include/dbstructure.php
+++ b/include/dbstructure.php
@@ -166,7 +166,8 @@ function update_structure($verbose, $action, $tables=null, $definition=null) {
 		@$db->q($sql_config);
 
 	// MySQL >= 5.7.4 doesn't support the IGNORE keyword in ALTER TABLE statements
-	if (version_compare($db->server_info(), '5.7.4') >= 0) {
+	if ((version_compare($db->server_info(), '5.7.4') >= 0) AND
+		!(strpos($db->server_info(), 'MariaDB') !== false)) {
 		$ignore = '';
 	}else {
 		$ignore = ' IGNORE';
@@ -196,7 +197,7 @@ function update_structure($verbose, $action, $tables=null, $definition=null) {
 				if ($current_index_definition != $new_index_definition && substr($indexname, 0, 6) != 'local_') {
 					$sql2=db_drop_index($indexname);
 					if ($sql3 == "")
-						$sql3 = "ALTER TABLE `".$name."` ".$sql2;
+						$sql3 = "ALTER".$ignore." TABLE `".$name."` ".$sql2;
 					else
 						$sql3 .= ", ".$sql2;
 				}

--- a/update.php
+++ b/update.php
@@ -1,6 +1,6 @@
 <?php
 
-define('UPDATE_VERSION' , 1205);
+define('UPDATE_VERSION' , 1206);
 
 /**
  *


### PR DESCRIPTION
In conjunction with the new code in the config class this lead to the bad situation where config values were stored multiple times.

This is some quickfix. We should check in the future how to do the version check more reliantly.

Additionally there is some check that always the newest config entry will be taken. This is to make sure that things work fine even when the index wasn't applied correctly.