### PR TITLE
webfinger_dfrn now work as expected

### DIFF
--- a/include/Probe.php
+++ b/include/Probe.php
@@ -118,18 +118,16 @@ class Probe {
 	 */
 
 	public static function webfinger_dfrn($webbie, &$hcard) {
-		if (!strstr($webbie, '@'))
-			return $webbie;
 
 		$profile_link = '';
 
-		$links = self::webfinger($webbie);
+		$links = self::lrdd($webbie);
 		logger('webfinger_dfrn: '.$webbie.':'.print_r($links,true), LOGGER_DATA);
 		if (count($links)) {
 			foreach ($links as $link) {
 				if ($link['@attributes']['rel'] === NAMESPACE_DFRN)
 					$profile_link = $link['@attributes']['href'];
-				if ($link['@attributes']['rel'] === NAMESPACE_OSTATUSSUB)
+				if (($link['@attributes']['rel'] === NAMESPACE_OSTATUSSUB) AND ($profile_link == ""))
 					$profile_link = 'stat:'.$link['@attributes']['template'];
 				if ($link['@attributes']['rel'] === 'http://microformats.org/profile/hcard')
 					$hcard = $link['@attributes']['href'];


### PR DESCRIPTION
See issue https://github.com/friendica/friendica/issues/2850. The function "webfinger_dfrn" was expected to return the profile link and the hcard link for a given address in the format "user@domain.tld" - but that never worked.