### PR TITLE
[frio] Fix code block display

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -75,6 +75,9 @@ blockquote {
 .hidden {
     display: none !important;
 }
+code {
+	white-space: pre;
+}
 
 /*
 * standard page elements


### PR DESCRIPTION
From @fabrixxm, a much-needed fix for code blocks on the frio theme bungling the white space display.