### PR TITLE
quattro: fix events_reminder

### DIFF
--- a/view/theme/quattro/templates/events_reminder.tpl
+++ b/view/theme/quattro/templates/events_reminder.tpl
@@ -1,6 +1,7 @@
+
 <link rel='stylesheet' type='text/css' href='{{$baseurl}}/library/fullcalendar/fullcalendar.css' />
-<script language="javascript" type="text/javascript"
-          src="{{$baseurl}}/library/fullcalendar/fullcalendar.min.js"></script>
+<script type="text/javascript" src="{{$baseurl}}/library/moment/moment.min.js"></script>
+<script type="text/javascript" src="{{$baseurl}}/library/fullcalendar/fullcalendar.min.js"></script>
 <script>
 	// start calendar from yesterday
 	var yesterday= new Date()
@@ -12,7 +13,7 @@
 			function(data){
 				$.colorbox({html:data});
 			}
-		);			
+		);
 	}
 	$(document).ready(function() {
 		$('#events-reminder').fullCalendar({
@@ -21,14 +22,10 @@
 			month: yesterday.getMonth(),
 			date: yesterday.getDate(),
 			events: '{{$baseurl}}/events/json/',
-			header: {
-				left: '',
-				center: '',
-				right: ''
-			},			
+			header: false,
 			timeFormat: 'H(:mm)',
 			defaultView: 'basicWeek',
-			height: 50,
+			contentHeight: 50,
 			eventClick: function(calEvent, jsEvent, view) {
 				showEvent(calEvent.id);
 			}


### PR DESCRIPTION
After updating fullcalendar the events reminder didn't work in quattro. This fixes it.

have a look at https://github.com/friendica/friendica/pull/2856#issuecomment-254153709