### PR TITLE
Fix frio calendar strings

### DIFF
--- a/view/templates/event_head.tpl
+++ b/view/templates/event_head.tpl
@@ -11,7 +11,7 @@
 			function(data){
 				$.colorbox({html:data});
 			}
-		);			
+		);
 	}
 
 	function doEventPreview() {
@@ -33,25 +33,67 @@
 
 	$(document).ready(function() {
 		$('#events-calendar').fullCalendar({
-			firstDay: {{$i18n.firstDay}},
-			monthNames: ['{{$i18n.January}}','{{$i18n.February}}','{{$i18n.March}}','{{$i18n.April}}','{{$i18n.May}}','{{$i18n.June}}','{{$i18n.July}}','{{$i18n.August}}','{{$i18n.September}}','{{$i18n.October}}','{{$i18n.November}}','{{$i18n.December}}'],
-			monthNamesShort: ['{{$i18n.Jan}}','{{$i18n.Feb}}','{{$i18n.Mar}}','{{$i18n.Apr}}','{{$i18n.May}}','{{$i18n.Jun}}','{{$i18n.Jul}}','{{$i18n.Aug}}','{{$i18n.Sep}}','{{$i18n.Oct}}','{{$i18n.Nov}}','{{$i18n.Dec}}'],
-			dayNames: ['{{$i18n.Sunday}}','{{$i18n.Monday}}','{{$i18n.Tuesday}}','{{$i18n.Wednesday}}','{{$i18n.Thursday}}','{{$i18n.Friday}}','{{$i18n.Saturday}}'],
-			dayNamesShort: ['{{$i18n.Sun}}','{{$i18n.Mon}}','{{$i18n.Tue}}','{{$i18n.Wed}}','{{$i18n.Thu}}','{{$i18n.Fri}}','{{$i18n.Sat}}'],
-			allDayText: '{{$i18n.allday}}',
-			noEventsMessage: '{{$i18n.noevent}}',
+			firstDay: '{{$i18n.firstDay|escape:'quotes'}}',
+			monthNames: [
+				'{{$i18n.January|escape:'quotes'}}',
+				'{{$i18n.February|escape:'quotes'}}',
+				'{{$i18n.March|escape:'quotes'}}',
+				'{{$i18n.April|escape:'quotes'}}',
+				'{{$i18n.May|escape:'quotes'}}',
+				'{{$i18n.June|escape:'quotes'}}',
+				'{{$i18n.July|escape:'quotes'}}',
+				'{{$i18n.August|escape:'quotes'}}',
+				'{{$i18n.September|escape:'quotes'}}',
+				'{{$i18n.October|escape:'quotes'}}',
+				'{{$i18n.November|escape:'quotes'}}',
+				'{{$i18n.December|escape:'quotes'}}'
+			],
+			monthNamesShort: [
+				'{{$i18n.Jan|escape:'quotes'}}',
+				'{{$i18n.Feb|escape:'quotes'}}',
+				'{{$i18n.Mar|escape:'quotes'}}',
+				'{{$i18n.Apr|escape:'quotes'}}',
+				'{{$i18n.May|escape:'quotes'}}',
+				'{{$i18n.Jun|escape:'quotes'}}',
+				'{{$i18n.Jul|escape:'quotes'}}',
+				'{{$i18n.Aug|escape:'quotes'}}',
+				'{{$i18n.Sep|escape:'quotes'}}',
+				'{{$i18n.Oct|escape:'quotes'}}',
+				'{{$i18n.Nov|escape:'quotes'}}',
+				'{{$i18n.Dec|escape:'quotes'}}'
+			],
+			dayNames: [
+				'{{$i18n.Sunday|escape:'quotes'}}',
+				'{{$i18n.Monday|escape:'quotes'}}',
+				'{{$i18n.Tuesday|escape:'quotes'}}',
+				'{{$i18n.Wednesday|escape:'quotes'}}',
+				'{{$i18n.Thursday|escape:'quotes'}}',
+				'{{$i18n.Friday|escape:'quotes'}}',
+				'{{$i18n.Saturday|escape:'quotes'}}'
+			],
+			dayNamesShort: [
+				'{{$i18n.Sun|escape:'quotes'}}',
+				'{{$i18n.Mon|escape:'quotes'}}',
+				'{{$i18n.Tue|escape:'quotes'}}',
+				'{{$i18n.Wed|escape:'quotes'}}',
+				'{{$i18n.Thu|escape:'quotes'}}',
+				'{{$i18n.Fri|escape:'quotes'}}',
+				'{{$i18n.Sat|escape:'quotes'}}'
+			],
+			allDayText: '{{$i18n.allday|escape:'quotes'}}',
+			noEventsMessage: '{{$i18n.noevent|escape:'quotes'}}',
 			buttonText: {
-				today: '{{$i18n.today}}',
-				month: '{{$i18n.month}}',
-				week: '{{$i18n.week}}',
-				day: '{{$i18n.day}}'
+				today: '{{$i18n.today|escape:'quotes'}}',
+				month: '{{$i18n.month|escape:'quotes'}}',
+				week: '{{$i18n.week|escape:'quotes'}}',
+				day: '{{$i18n.day|escape:'quotes'}}'
 			},
 			events: '{{$baseurl}}{{$module_url}}/json/',
 			header: {
 				left: 'prev,next today',
 				center: 'title',
 				right: 'month,agendaWeek,agendaDay'
-			},			
+			},
 			timeFormat: 'H(:mm)',
 			eventClick: function(calEvent, jsEvent, view) {
 				showEvent(calEvent.id);
@@ -61,7 +103,7 @@
 					$('td.fc-day').dblclick(function() { window.location.href='/events/new?start='+$(this).data('date'); });
 				}
 			},
-			
+
 			eventRender: function(event, element, view) {
 				//console.log(view.name);
 				if (event.item['author-name']==null) return;
@@ -94,9 +136,9 @@
 					break;
 				}
 			}
-			
+
 		})
-		
+
 		// center on date
 		var args=location.href.replace(baseurl,"").split("/");
 		{{if $modparams == 2}}
@@ -107,12 +149,12 @@
 		if (args.length>=4) {
 			$("#events-calendar").fullCalendar('gotoDate',args[2] , args[3]-1);
 		}
-		{{/if}} 
-		
+		{{/if}}
+
 		// show event popup
 		var hash = location.hash.split("-")
 		if (hash.length==2 && hash[0]=="#link") showEvent(hash[1]);
-		
+
 	});
 </script>
 
@@ -152,7 +194,7 @@
 
 	});
 
-	$(document).ready(function() { 
+	$(document).ready(function() {
 		$('.comment-edit-bb').hide();
 	});
 	{{else}}
@@ -160,14 +202,14 @@
 	{{/if}}
 
 
-	$(document).ready(function() { 
+	$(document).ready(function() {
 		{{if $editselect = 'none'}}
 		$("#comment-edit-text-desc").bbco_autocomplete('bbcode');
 		{{/if}}
 
 		$('#id_share').change(function() {
 
-			if ($('#id_share').is(':checked')) { 
+			if ($('#id_share').is(':checked')) {
 				$('#acl-wrapper').show();
 			}
 			else {

--- a/view/templates/event_head.tpl
+++ b/view/templates/event_head.tpl
@@ -30,7 +30,6 @@
 			$('#id_finish_text').prop("disabled", false);
 	}
 
-
 	$(document).ready(function() {
 		$('#events-calendar').fullCalendar({
 			firstDay: '{{$i18n.firstDay|escape:'quotes'}}',
@@ -105,7 +104,6 @@
 			},
 
 			eventRender: function(event, element, view) {
-				//console.log(view.name);
 				if (event.item['author-name']==null) return;
 				switch(view.name){
 					case "month":
@@ -141,15 +139,15 @@
 
 		// center on date
 		var args=location.href.replace(baseurl,"").split("/");
-		{{if $modparams == 2}}
+{{if $modparams == 2}}
 		if (args.length>=5) {
 			$("#events-calendar").fullCalendar('gotoDate',args[3] , args[4]-1);
 		}
-		{{else}}
+{{else}}
 		if (args.length>=4) {
 			$("#events-calendar").fullCalendar('gotoDate',args[2] , args[3]-1);
 		}
-		{{/if}}
+{{/if}}
 
 		// show event popup
 		var hash = location.hash.split("-")
@@ -158,12 +156,10 @@
 	});
 </script>
 
-
 {{if $editselect != 'none'}}
 <script language="javascript" type="text/javascript"
 	  src="{{$baseurl}}/library/tinymce/jscripts/tiny_mce/tiny_mce_src.js"></script>
 <script language="javascript" type="text/javascript">
-
 
 	tinyMCE.init({
 		theme : "advanced",
@@ -181,8 +177,6 @@
 		entity_encoding : "raw",
 		add_unload_trigger : false,
 		remove_linebreaks : false,
-		//force_p_newlines : false,
-		//force_br_newlines : true,
 		forced_root_block : 'div',
 		content_css: "{{$baseurl}}/view/custom_tinymce.css",
 		theme_advanced_path : false,
@@ -197,15 +191,14 @@
 	$(document).ready(function() {
 		$('.comment-edit-bb').hide();
 	});
-	{{else}}
+{{else}}
 	<script language="javascript" type="text/javascript">
-	{{/if}}
-
+{{/if}}
 
 	$(document).ready(function() {
-		{{if $editselect = 'none'}}
+{{if $editselect = 'none'}}
 		$("#comment-edit-text-desc").bbco_autocomplete('bbcode');
-		{{/if}}
+{{/if}}
 
 		$('#id_share').change(function() {
 
@@ -216,7 +209,6 @@
 				$('#acl-wrapper').hide();
 			}
 		}).trigger('change');
-
 
 		$('#contact_allow, #contact_deny, #group_allow, #group_deny').change(function() {
 			var selstr;

--- a/view/theme/frio/templates/event_head.tpl
+++ b/view/theme/frio/templates/event_head.tpl
@@ -6,7 +6,6 @@
 <script type="text/javascript" src="{{$baseurl}}/library/fullcalendar/fullcalendar.min.js"></script>
 <script type="text/javascript" src="view/theme/frio/js/mod_events.js"></script>
 
-
 <script language="javascript" type="text/javascript">
 	// pass php translation strings to js variables/arrays so we can make use of it in js files
 	aStr.monthNames = [
@@ -79,7 +78,6 @@
 	  src="{{$baseurl}}/library/tinymce/jscripts/tiny_mce/tiny_mce_src.js"></script>
 <script language="javascript" type="text/javascript">
 
-
 	tinyMCE.init({
 		theme : "advanced",
 		mode : "textareas",
@@ -96,8 +94,6 @@
 		entity_encoding : "raw",
 		add_unload_trigger : false,
 		remove_linebreaks : false,
-		//force_p_newlines : false,
-		//force_br_newlines : true,
 		forced_root_block : 'div',
 		content_css: "{{$baseurl}}/view/custom_tinymce.css",
 		theme_advanced_path : false,
@@ -112,15 +108,14 @@
 	$(document).ready(function() {
 		$('.comment-edit-bb').hide();
 	});
-	{{else}}
+{{else}}
 	<script language="javascript" type="text/javascript">
-	{{/if}}
-
+{{/if}}
 
 	$(document).ready(function() {
-		{{if $editselect = 'none'}}
+{{if $editselect = 'none'}}
 		$("#comment-edit-text-desc").bbco_autocomplete('bbcode');
-		{{/if}}
+{{/if}}
 
 	});
 

--- a/view/theme/frio/templates/event_head.tpl
+++ b/view/theme/frio/templates/event_head.tpl
@@ -9,11 +9,52 @@
 
 <script language="javascript" type="text/javascript">
 	// pass php translation strings to js variables/arrays so we can make use of it in js files
-	aStr.monthNames = ['{{$i18n.January}}','{{$i18n.February}}','{{$i18n.March}}','{{$i18n.April}}','{{$i18n.May}}','{{$i18n.June}}','{{$i18n.July}}','{{$i18n.August}}','{{$i18n.September}}','{{$i18n.October}}','{{$i18n.November}}','{{$i18n.December}}'];
-	aStr.monthNamesShort = ['{{$i18n.Jan}}','{{$i18n.Feb}}','{{$i18n.Mar}}','{{$i18n.Apr}}','{{$i18n.May}}','{{$i18n.Jun}}','{{$i18n.Jul}}','{{$i18n.Aug}}','{{$i18n.Sep}}','{{$i18n.Oct}}','{{$i18n.Nov}}','{{$i18n.Dec}}'];
-	aStr.monthNamesShort = ['{{$i18n.Jan}}','{{$i18n.Feb}}','{{$i18n.Mar}}','{{$i18n.Apr}}','{{$i18n.May}}','{{$i18n.Jun}}','{{$i18n.Jul}}','{{$i18n.Aug}}','{{$i18n.Sep}}','{{$i18n.Oct}}','{{$i18n.Nov}}','{{$i18n.Dec}}'];
-	aStr.dayNames = ['{{$i18n.Sunday}}','{{$i18n.Monday}}','{{$i18n.Tuesday}}','{{$i18n.Wednesday}}','{{$i18n.Thursday}}','{{$i18n.Friday}}','{{$i18n.Saturday}}'];
-	aStr.dayNamesShort = ['{{$i18n.Sun}}','{{$i18n.Mon}}','{{$i18n.Tue}}','{{$i18n.Wed}}','{{$i18n.Thu}}','{{$i18n.Fri}}','{{$i18n.Sat}}'];
+	aStr.monthNames = [
+		'{{$i18n.January|escape:'quotes'}}',
+		'{{$i18n.February|escape:'quotes'}}',
+		'{{$i18n.March|escape:'quotes'}}',
+		'{{$i18n.April|escape:'quotes'}}',
+		'{{$i18n.May|escape:'quotes'}}',
+		'{{$i18n.June|escape:'quotes'}}',
+		'{{$i18n.July|escape:'quotes'}}',
+		'{{$i18n.August|escape:'quotes'}}',
+		'{{$i18n.September|escape:'quotes'}}',
+		'{{$i18n.October|escape:'quotes'}}',
+		'{{$i18n.November|escape:'quotes'}}',
+		'{{$i18n.December|escape:'quotes'}}'
+	];
+	aStr.monthNamesShort = [
+		'{{$i18n.Jan|escape:'quotes'}}',
+		'{{$i18n.Feb|escape:'quotes'}}',
+		'{{$i18n.Mar|escape:'quotes'}}',
+		'{{$i18n.Apr|escape:'quotes'}}',
+		'{{$i18n.May|escape:'quotes'}}',
+		'{{$i18n.Jun|escape:'quotes'}}',
+		'{{$i18n.Jul|escape:'quotes'}}',
+		'{{$i18n.Aug|escape:'quotes'}}',
+		'{{$i18n.Sep|escape:'quotes'}}',
+		'{{$i18n.Oct|escape:'quotes'}}',
+		'{{$i18n.Nov|escape:'quotes'}}',
+		'{{$i18n.Dec|escape:'quotes'}}'
+	];
+	aStr.dayNames = [
+		'{{$i18n.Sunday|escape:'quotes'}}',
+		'{{$i18n.Monday|escape:'quotes'}}',
+		'{{$i18n.Tuesday|escape:'quotes'}}',
+		'{{$i18n.Wednesday|escape:'quotes'}}',
+		'{{$i18n.Thursday|escape:'quotes'}}',
+		'{{$i18n.Friday|escape:'quotes'}}',
+		'{{$i18n.Saturday|escape:'quotes'}}'
+	];
+	aStr.dayNamesShort = [
+		'{{$i18n.Sun|escape:'quotes'}}',
+		'{{$i18n.Mon|escape:'quotes'}}',
+		'{{$i18n.Tue|escape:'quotes'}}',
+		'{{$i18n.Wed|escape:'quotes'}}',
+		'{{$i18n.Thu|escape:'quotes'}}',
+		'{{$i18n.Fri|escape:'quotes'}}',
+		'{{$i18n.Sat|escape:'quotes'}}'
+	];
 
 	aStr.firstDay = '{{$i18n.firstDay|escape:'quotes'}}';
 	aStr.today = '{{$i18n.today|escape:'quotes'}}';

--- a/view/theme/frio/templates/event_head.tpl
+++ b/view/theme/frio/templates/event_head.tpl
@@ -15,18 +15,18 @@
 	aStr.dayNames = ['{{$i18n.Sunday}}','{{$i18n.Monday}}','{{$i18n.Tuesday}}','{{$i18n.Wednesday}}','{{$i18n.Thursday}}','{{$i18n.Friday}}','{{$i18n.Saturday}}'];
 	aStr.dayNamesShort = ['{{$i18n.Sun}}','{{$i18n.Mon}}','{{$i18n.Tue}}','{{$i18n.Wed}}','{{$i18n.Thu}}','{{$i18n.Fri}}','{{$i18n.Sat}}'];
 
-	aStr.firstDay = '{{$i18n.firstDay}}';
-	aStr.today = '{{$i18n.today}}';
-	aStr.month = '{{$i18n.month}}';
-	aStr.week = '{{$i18n.week}}';
-	aStr.day = '{{$i18n.day}}';
+	aStr.firstDay = '{{$i18n.firstDay|escape:'quotes'}}';
+	aStr.today = '{{$i18n.today|escape:'quotes'}}';
+	aStr.month = '{{$i18n.month|escape:'quotes'}}';
+	aStr.week = '{{$i18n.week|escape:'quotes'}}';
+	aStr.day = '{{$i18n.day|escape:'quotes'}}';
 
-	aStr.allday = '{{$i18n.allday}}';
-	aStr.noevent = '{{$i18n.noevent}}';
+	aStr.allday = '{{$i18n.allday|escape:'quotes'}}';
+	aStr.noevent = '{{$i18n.noevent|escape:'quotes'}}';
 
-	aStr.dtstartLabel = '{{$i18n.dtstart_label}}';
-	aStr.dtendLabel = '{{$i18n.dtend_label}}';
-	aStr.locationLabel = '{{$i18n.location_label}}';
+	aStr.dtstartLabel = '{{$i18n.dtstart_label|escape:'quotes'}}';
+	aStr.dtendLabel = '{{$i18n.dtend_label|escape:'quotes'}}';
+	aStr.locationLabel = '{{$i18n.location_label|escape:'quotes'}}';
 
 	var moduleUrl = '{{$module_url}}';
 	var modparams = {{$modparams}}
@@ -68,7 +68,7 @@
 
 	});
 
-	$(document).ready(function() { 
+	$(document).ready(function() {
 		$('.comment-edit-bb').hide();
 	});
 	{{else}}
@@ -76,7 +76,7 @@
 	{{/if}}
 
 
-	$(document).ready(function() { 
+	$(document).ready(function() {
 		{{if $editselect = 'none'}}
 		$("#comment-edit-text-desc").bbco_autocomplete('bbcode');
 		{{/if}}


### PR DESCRIPTION
In French, “today” is “aujourd’hui”, which breaks the current calendar
Javascript strings quoted declaration.

This PR adds quote escaping to the i18n strings.