### PR TITLE
frio: line-break for event-owner names in event modals

### DIFF
--- a/view/theme/frio/templates/event.tpl
+++ b/view/theme/frio/templates/event.tpl
@@ -5,7 +5,7 @@
 	<div class="event-wrapper">
 		<div class="event">
 			<div class="media">
-				<div class="event-owner pull-left">
+				<div class="event-owner media-left">
 					{{if $event.item.author_name}}
 					<a href="{{$event.item.author_link}}" ><img src="{{$event.item.author_avatar}}" /></a>
 					<a href="{{$event.item.author_link}}" >{{$event.item.author_name}}</a>


### PR DESCRIPTION
Long event-owner names have been taken to much space in the event modals. Now a line break will appear if they contain a space character