### PR TITLE
Prevent a memory Access Violation when the database isn't connected

### DIFF
--- a/include/text.php
+++ b/include/text.php
@@ -707,9 +707,6 @@ function logger($msg, $level = 0) {
 	if (
 		$a->module == 'install'
 		|| ! ($db && $db->connected)
-		|| ! $debugging
-		|| ! $logfile
-		|| $level > $loglevel
 	) {
 		return;
 	}
@@ -717,6 +714,14 @@ function logger($msg, $level = 0) {
 	$debugging = get_config('system','debugging');
 	$logfile   = get_config('system','logfile');
 	$loglevel = intval(get_config('system','loglevel'));
+
+	if (
+		! $debugging
+		|| ! $logfile
+		|| $level > $loglevel
+	) {
+		return;
+	}
 
 	if (count($LOGGER_LEVELS) == 0) {
 		foreach (get_defined_constants() as $k => $v) {

--- a/include/text.php
+++ b/include/text.php
@@ -703,10 +703,6 @@ function logger($msg, $level = 0) {
 	global $db;
 	global $LOGGER_LEVELS;
 
-	$debugging = get_config('system','debugging');
-	$logfile   = get_config('system','logfile');
-	$loglevel = intval(get_config('system','loglevel'));
-
 	// turn off logger in install mode
 	if (
 		$a->module == 'install'
@@ -717,6 +713,10 @@ function logger($msg, $level = 0) {
 	) {
 		return;
 	}
+
+	$debugging = get_config('system','debugging');
+	$logfile   = get_config('system','logfile');
+	$loglevel = intval(get_config('system','loglevel'));
 
 	if (count($LOGGER_LEVELS) == 0) {
 		foreach (get_defined_constants() as $k => $v) {


### PR DESCRIPTION
There was some endless loop:

When a database query is done the system checks if the database is connected. When the database isn't connected the system wants to log it. But when the logger is called, the function "get_config" is called which is doing a database query - And then the story begins again.