### PR TITLE
Improving ping.php performance

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -787,27 +787,29 @@ class App {
 		if (!is_object($this))
 			return(self::$a->get_baseurl($ssl));
 
-		$scheme = $this->scheme;
+		if (!$this->baseurl) {
+			$scheme = $this->scheme;
 
-		if((x($this->config,'system')) && (x($this->config['system'],'ssl_policy'))) {
-			if(intval($this->config['system']['ssl_policy']) === intval(SSL_POLICY_FULL))
-				$scheme = 'https';
-
-			//	Basically, we have $ssl = true on any links which can only be seen by a logged in user
-			//	(and also the login link). Anything seen by an outsider will have it turned off.
-
-			if($this->config['system']['ssl_policy'] == SSL_POLICY_SELFSIGN) {
-				if($ssl)
+			if((x($this->config,'system')) && (x($this->config['system'],'ssl_policy'))) {
+				if(intval($this->config['system']['ssl_policy']) === intval(SSL_POLICY_FULL))
 					$scheme = 'https';
-				else
-					$scheme = 'http';
+
+				//	Basically, we have $ssl = true on any links which can only be seen by a logged in user
+				//	(and also the login link). Anything seen by an outsider will have it turned off.
+
+				if($this->config['system']['ssl_policy'] == SSL_POLICY_SELFSIGN) {
+					if($ssl)
+						$scheme = 'https';
+					else
+						$scheme = 'http';
+				}
 			}
+
+			if (get_config('config','hostname') != "")
+				$this->hostname = get_config('config','hostname');
+
+			$this->baseurl = $scheme . "://" . $this->hostname . ((isset($this->path) && strlen($this->path)) ? '/' . $this->path : '' );
 		}
-
-		if (get_config('config','hostname') != "")
-			$this->hostname = get_config('config','hostname');
-
-		$this->baseurl = $scheme . "://" . $this->hostname . ((isset($this->path) && strlen($this->path)) ? '/' . $this->path : '' );
 		return $this->baseurl;
 	}
 

--- a/boot.php
+++ b/boot.php
@@ -793,21 +793,22 @@ class App {
 
 		// Is the function called statically?
 		if (!is_object($this)) {
-			return(self::$a->get_baseurl($ssl));
+			return self::$a->get_baseurl($ssl);
 		}
 
 		if (!isset($this->baseurl[$ssl ? 'https' : 'http'])) {
 			$scheme = $this->scheme;
 
-			if((x($this->config, 'system')) && (x($this->config['system'], 'ssl_policy'))) {
-				if(intval($this->config['system']['ssl_policy']) === intval(SSL_POLICY_FULL))
+			if ((x($this->config, 'system')) && (x($this->config['system'], 'ssl_policy'))) {
+				if (intval($this->config['system']['ssl_policy']) === SSL_POLICY_FULL) {
 					$scheme = 'https';
+				}
 
 				//	Basically, we have $ssl = true on any links which can only be seen by a logged in user
 				//	(and also the login link). Anything seen by an outsider will have it turned off.
 
-				if($this->config['system']['ssl_policy'] == SSL_POLICY_SELFSIGN) {
-					if($ssl) {
+				if ($this->config['system']['ssl_policy'] == SSL_POLICY_SELFSIGN) {
+					if ($ssl) {
 						$scheme = 'https';
 					} else {
 						$scheme = 'http';
@@ -815,7 +816,7 @@ class App {
 				}
 			}
 
-			if (get_config('config','hostname') != '') {
+			if (get_config('config', 'hostname') != '') {
 				$this->hostname = get_config('config', 'hostname');
 			}
 

--- a/boot.php
+++ b/boot.php
@@ -38,7 +38,7 @@ define ( 'FRIENDICA_PLATFORM',     'Friendica');
 define ( 'FRIENDICA_CODENAME',     'Asparagus');
 define ( 'FRIENDICA_VERSION',      '3.5.1-dev' );
 define ( 'DFRN_PROTOCOL_VERSION',  '2.23'    );
-define ( 'DB_UPDATE_VERSION',      1206      );
+define ( 'DB_UPDATE_VERSION',      1207      );
 
 /**
  * @brief Constant with a HTML line break.

--- a/boot.php
+++ b/boot.php
@@ -800,7 +800,9 @@ class App {
 			return self::$a->get_baseurl($ssl);
 		}
 
-		if (!isset($this->baseurl[$ssl ? 'https' : 'http'])) {
+		$cache_index = $ssl ? 'https' : 'http';
+
+		if (!isset($this->baseurl[$cache_index])) {
 			$scheme = $this->scheme;
 
 			if ((x($this->config, 'system')) && (x($this->config['system'], 'ssl_policy'))) {
@@ -824,9 +826,9 @@ class App {
 				$this->hostname = get_config('config', 'hostname');
 			}
 
-			$this->baseurl[$ssl ? 'https' : 'http'] = $scheme . "://" . $this->hostname . ((isset($this->path) && strlen($this->path)) ? '/' . $this->path : '' );
+			$this->baseurl[$cache_index] = $scheme . "://" . $this->hostname . ((isset($this->path) && strlen($this->path)) ? '/' . $this->path : '' );
 		}
-		return $this->baseurl[$ssl ? 'https' : 'http'];
+		return $this->baseurl[$cache_index];
 	}
 
 	/**

--- a/boot.php
+++ b/boot.php
@@ -38,7 +38,7 @@ define ( 'FRIENDICA_PLATFORM',     'Friendica');
 define ( 'FRIENDICA_CODENAME',     'Asparagus');
 define ( 'FRIENDICA_VERSION',      '3.5.1-dev' );
 define ( 'DFRN_PROTOCOL_VERSION',  '2.23'    );
-define ( 'DB_UPDATE_VERSION',      1207      );
+define ( 'DB_UPDATE_VERSION',      1208      );
 
 /**
  * @brief Constant with a HTML line break.

--- a/database.sql
+++ b/database.sql
@@ -655,6 +655,8 @@ CREATE TABLE IF NOT EXISTS `notify` (
 	`seen` tinyint(1) NOT NULL DEFAULT 0,
 	`verb` varchar(255) NOT NULL DEFAULT '',
 	`otype` varchar(16) NOT NULL DEFAULT '',
+	`name_cache` tinytext,
+	`msg_name` mediumtext,
 	 PRIMARY KEY(`id`),
 	 INDEX `uid` (`uid`)
 ) DEFAULT CHARSET=utf8mb4;

--- a/doc/database/db_notify.md
+++ b/doc/database/db_notify.md
@@ -1,22 +1,24 @@
 Table notify
 ============
 
-| Field  | Description                       | Type         | Null | Key | Default             | Extra           |
-| ------ | --------------------------------- | ------------ | ---- | --- | ------------------- | --------------- |
-| id     | sequential ID                     | int(11)      | NO   | PRI | NULL                | auto_increment  |
-| hash   |                                   | varchar(64)  | NO   |     |                     |                 |
-| type   |                                   | int(11)      | NO   |     | 0                   |                 |
-| name   |                                   | varchar(255) | NO   |     |                     |                 |
-| url    |                                   | varchar(255) | NO   |     |                     |                 |
-| photo  |                                   | varchar(255) | NO   |     |                     |                 |
-| date   |                                   | datetime     | NO   |     | 0000-00-00 00:00:00 |                 |
-| msg    |                                   | mediumtext   | NO   |     | NULL                |                 |
-| uid    | user.id of the owner of this data | int(11)      | NO   | MUL | 0                   |                 |
-| link   |                                   | varchar(255) | NO   |     |                     |                 |
-| parent |                                   | int(11)      | NO   |     | 0                   |                 |
-| seen   |                                   | tinyint(1)   | NO   |     | 0                   |                 |
-| verb   |                                   | varchar(255) | NO   |     |                     |                 |
-| otype  |                                   | varchar(16)  | NO   |     |                     |                 |
-| iid    | item.id                           | int(11)      | NO   |     | 0                   |                 |
+| Field      | Description                       | Type         | Null | Key | Default             | Extra           |
+| ---------- | --------------------------------- | ------------ | ---- | --- | ------------------- | --------------- |
+| id         | sequential ID                     | int(11)      | NO   | PRI | NULL                | auto_increment  |
+| hash       |                                   | varchar(64)  | NO   |     |                     |                 |
+| type       |                                   | int(11)      | NO   |     | 0                   |                 |
+| name       |                                   | varchar(255) | NO   |     |                     |                 |
+| url        |                                   | varchar(255) | NO   |     |                     |                 |
+| photo      |                                   | varchar(255) | NO   |     |                     |                 |
+| date       |                                   | datetime     | NO   |     | 0000-00-00 00:00:00 |                 |
+| msg        |                                   | mediumtext   | YES  |     | NULL                |                 |
+| uid        | user.id of the owner of this data | int(11)      | NO   | MUL | 0                   |                 |
+| link       |                                   | varchar(255) | NO   |     |                     |                 |
+| iid        | item.id                           | int(11)      | NO   |     | 0                   |                 |
+| parent     |                                   | int(11)      | NO   |     | 0                   |                 |
+| seen       |                                   | tinyint(1)   | NO   |     | 0                   |                 |
+| verb       |                                   | varchar(255) | NO   |     |                     |                 |
+| otype      |                                   | varchar(16)  | NO   |     |                     |                 |
+| name_cache | Cached bbcode parsing of name     | tinytext     | YES  |     | NULL                |                 |
+| msg_cache  | Cached bbcode parsing of msg      | mediumtext   | YES  |     | NULL                |                 |
 
 Return to [database documentation](help/database)

--- a/include/datetime.php
+++ b/include/datetime.php
@@ -328,12 +328,12 @@ function datetimesel($format, $min, $max, $default, $label, $id = 'datetimepicke
  * @param string $posted_date
  * @param string $format (optional) Parsed with sprintf()
  *    <tt>%1$d %2$s ago</tt>, e.g. 22 hours ago, 1 minute ago
- * 
+ *
  * @return string with relative date
  */
-function relative_date($posted_date,$format = null) {
+function relative_date($posted_date, $format = null) {
 
-	$localtime = datetime_convert('UTC',date_default_timezone_get(),$posted_date);
+	$localtime = $posted_date . ' UTC';
 
 	$abs = strtotime($localtime);
 
@@ -346,13 +346,6 @@ function relative_date($posted_date,$format = null) {
 	if ($etime < 1) {
 		return t('less than a second ago');
 	}
-
-	/*
-	$time_append = '';
-	if ($etime >= 86400) {
-		$time_append = ' ('.$localtime.')';
-	}
-	*/
 
 	$a = array( 12 * 30 * 24 * 60 * 60  =>  array( t('year'),   t('years')),
 				30 * 24 * 60 * 60       =>  array( t('month'),  t('months')),
@@ -368,8 +361,9 @@ function relative_date($posted_date,$format = null) {
 		if ($d >= 1) {
 			$r = round($d);
 			// translators - e.g. 22 hours ago, 1 minute ago
-			if(! $format)
+			if(! $format) {
 				$format = t('%1$d %2$s ago');
+			}
 
 			return sprintf( $format,$r, (($r == 1) ? $str[0] : $str[1]));
 		}

--- a/include/datetime.php
+++ b/include/datetime.php
@@ -325,7 +325,7 @@ function datetimesel($format, $min, $max, $default, $label, $id = 'datetimepicke
  * Results relative to current timezone.
  * Limited to range of timestamps.
  *
- * @param string $posted_date
+ * @param string $posted_date MySQL-formatted date string (YYYY-MM-DD HH:MM:SS)
  * @param string $format (optional) Parsed with sprintf()
  *    <tt>%1$d %2$s ago</tt>, e.g. 22 hours ago, 1 minute ago
  *
@@ -361,11 +361,11 @@ function relative_date($posted_date, $format = null) {
 		if ($d >= 1) {
 			$r = round($d);
 			// translators - e.g. 22 hours ago, 1 minute ago
-			if(! $format) {
+			if (!$format) {
 				$format = t('%1$d %2$s ago');
 			}
 
-			return sprintf( $format,$r, (($r == 1) ? $str[0] : $str[1]));
+			return sprintf($format, $r, (($r == 1) ? $str[0] : $str[1]));
 		}
 	}
 }

--- a/include/dbstructure.php
+++ b/include/dbstructure.php
@@ -1036,6 +1036,8 @@ function db_definition($charset) {
 					"seen" => array("type" => "tinyint(1)", "not null" => "1", "default" => "0"),
 					"verb" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
 					"otype" => array("type" => "varchar(16)", "not null" => "1", "default" => ""),
+					"name_cache" => array("type" => "tinytext"),
+					"msg_cache" => array("type" => "mediumtext")
 					),
 			"indexes" => array(
 					"PRIMARY" => array("id"),

--- a/include/enotify.php
+++ b/include/enotify.php
@@ -418,6 +418,7 @@ function notification($params) {
 		$datarray = array();
 		$datarray['hash']  = $hash;
 		$datarray['name']  = $params['source_name'];
+		$datarray['name_cache'] = strip_tags(bbcode($params['source_name']));
 		$datarray['url']   = $params['source_link'];
 		$datarray['photo'] = $params['source_photo'];
 		$datarray['date']  = datetime_convert();
@@ -439,7 +440,7 @@ function notification($params) {
 
 		// create notification entry in DB
 
-		$r = q("INSERT INTO `notify` (`hash`, `name`, `url`, `photo`, `date`, `uid`, `link`, `iid`, `parent`, `type`, `verb`, `otype`)
+		$r = q("INSERT INTO `notify` (`hash`, `name`, `url`, `photo`, `date`, `uid`, `link`, `iid`, `parent`, `type`, `verb`, `otype`, `name_cache`)
 			values('%s', '%s', '%s', '%s', '%s', %d, '%s', %d, %d, %d, '%s', '%s')",
 			dbesc($datarray['hash']),
 			dbesc($datarray['name']),
@@ -452,7 +453,8 @@ function notification($params) {
 			intval($datarray['parent']),
 			intval($datarray['type']),
 			dbesc($datarray['verb']),
-			dbesc($datarray['otype'])
+			dbesc($datarray['otype']),
+			dbesc($datarray["name_cache"])
 		);
 
 		$r = q("SELECT `id` FROM `notify` WHERE `hash` = '%s' AND `uid` = %d LIMIT 1",
@@ -494,8 +496,10 @@ function notification($params) {
 
 		$itemlink = $a->get_baseurl().'/notify/view/'.$notify_id;
 		$msg = replace_macros($epreamble, array('$itemlink' => $itemlink));
-		$r = q("UPDATE `notify` SET `msg` = '%s' WHERE `id` = %d AND `uid` = %d",
+		$msg_cache = format_notification_message($datarray['name_cache'], strip_tags(bbcode($msg)));
+		$r = q("UPDATE `notify` SET `msg` = '%s', `msg_cache` = '%s' WHERE `id` = %d AND `uid` = %d",
 			dbesc($msg),
+			dbesc($msg_cache),
 			intval($notify_id),
 			intval($params['uid'])
 		);
@@ -778,4 +782,27 @@ function check_item_notification($itemid, $uid, $defaulttype = "") {
 	if (isset($params["type"]))
 		notification($params);
 }
-?>
+
+/**
+ * @brief Formats a notification message with the notification author
+ *
+ * Replace the name with {0} but ensure to make that only once. The {0} is used
+ * later and prints the name in bold.
+ *
+ * @param string $name
+ * @param string $message
+ * @return string Formatted message
+ */
+function format_notification_message($name, $message) {
+	if ($name != '') {
+		$pos = strpos($message, $name);
+	} else {
+		$pos = false;
+	}
+
+	if ($pos !== false) {
+		$message = substr_replace($message, '{0}', $pos, strlen($name));
+	}
+
+	return $message;
+}

--- a/include/session.php
+++ b/include/session.php
@@ -26,18 +26,30 @@ function ref_session_read ($id) {
 	return '';
 }}
 
-if(! function_exists('ref_session_write')) {
-function ref_session_write ($id,$data) {
+/**
+ * @brief Standard PHP session write callback
+ *
+ * This callback updates the DB-stored session data and/or the expiration depending
+ * on the case. Uses the $session_expire global for existing session, 5 minutes
+ * for newly created session.
+ *
+ * @global bool $session_exists Whether a session with the given id already exists
+ * @global int $session_expire Session expiration delay in seconds
+ * @param string $id Session ID with format: [a-z0-9]{26}
+ * @param string $data Serialized session data
+ * @return boolean Returns false if parameters are missing, true otherwise
+ */
+function ref_session_write($id, $data) {
 	global $session_exists, $session_expire;
 
-	if(! $id || ! $data) {
+	if (!$id || !$data) {
 		return false;
 	}
 
 	$expire = time() + $session_expire;
 	$default_expire = time() + 300;
 
-	if($session_exists) {
+	if ($session_exists) {
 		$r = q("UPDATE `session`
 				SET `data` = '%s'
 				WHERE `sid` = '%s' AND `data` != '%s'",
@@ -47,13 +59,14 @@ function ref_session_write ($id,$data) {
 				SET `expire` = '%s'
 				WHERE `sid` = '%s' AND `expire` != '%s'",
 				dbesc($expire), dbesc($expire), dbesc($id));
-	} else
+	} else {
 		$r = q("INSERT INTO `session`
 				SET `sid` = '%s', `expire` = '%s', `data` = '%s'",
 				dbesc($id), dbesc($default_expire), dbesc($data));
+	}
 
 	return true;
-}}
+}
 
 if(! function_exists('ref_session_close')) {
 function ref_session_close() {

--- a/include/session.php
+++ b/include/session.php
@@ -52,12 +52,12 @@ function ref_session_write($id, $data) {
 	if ($session_exists) {
 		$r = q("UPDATE `session`
 				SET `data` = '%s'
-				WHERE `sid` = '%s' AND `data` != '%s'",
+				WHERE `data` != '%s' AND `sid` = '%s'",
 				dbesc($data), dbesc($data), dbesc($id));
 
 		$r = q("UPDATE `session`
 				SET `expire` = '%s'
-				WHERE `sid` = '%s' AND `expire` != '%s'",
+				WHERE `expire` != '%s' AND `sid` = '%s'",
 				dbesc($expire), dbesc($expire), dbesc($id));
 	} else {
 		$r = q("INSERT INTO `session`

--- a/include/session.php
+++ b/include/session.php
@@ -40,12 +40,12 @@ function ref_session_write ($id,$data) {
 	if($session_exists) {
 		$r = q("UPDATE `session`
 				SET `data` = '%s'
-				WHERE `data` != '%s' AND `sid` = '%s'",
+				WHERE `sid` = '%s' AND `data` != '%s'",
 				dbesc($data), dbesc($data), dbesc($id));
 
 		$r = q("UPDATE `session`
 				SET `expire` = '%s'
-				WHERE `expire` != '%s' AND `sid` = '%s'",
+				WHERE `sid` = '%s' AND `expire` != '%s'",
 				dbesc($expire), dbesc($expire), dbesc($id));
 	} else
 		$r = q("INSERT INTO `session`

--- a/mod/ping.php
+++ b/mod/ping.php
@@ -347,8 +347,8 @@ function ping_init(&$a) {
 /**
  * @brief Retrieves the notifications array for the given user ID
  *
- * @param int $uid
- * @return array
+ * @param int $uid User id
+ * @return array Associative array of notifications
  */
 function ping_get_notifications($uid) {
 

--- a/update.php
+++ b/update.php
@@ -1,6 +1,6 @@
 <?php
 
-define('UPDATE_VERSION' , 1206);
+define('UPDATE_VERSION' , 1207);
 
 /**
  *

--- a/update.php
+++ b/update.php
@@ -1,6 +1,6 @@
 <?php
 
-define('UPDATE_VERSION' , 1207);
+define('UPDATE_VERSION' , 1208);
 
 /**
  *


### PR DESCRIPTION
`ping.php` is called very frequently, and upon its performance depend many display refresh delays. The following improvements reduce `ping.php` execution time by 50%-60%, from ~950ms to ~350-450ms.

Details:
- Caching baseurl: `get_baseurl()` is called very frequently throughout Friendica, but its value was computed each time. Caching it saves ~50ms
- Removing `datetime_convert()` in `relative_time()`: Converting a date from a timezone to another is expensive, and in the case of `relative_time()`, not needed by tricking `strtotime()` to accept the input as UTC. Saves ~50ms.
- ~~Optimizing `ref_session_write()` update queries: by reversing the order of the conditions in those two queries, we leverage lazy evaluation to save about 40ms each script call.~~ False positive
- Caching notification bbcode: BBCode replacement is expensive and should only be ran once for each string. While this was in place for items, it wasn't for notifications. `ping.php` was replacing BBCodes in the two fields of 200 notifications each time it was called. Adding bbcode caching database fields saves ~300-400ms.

While the latter improvement is specific to `ping.php`, the others aren't, which means that all Friendica calls will be slightly faster. For most calls it won't be noticeable but this is non-negligible nevertheless.
