### PR TITLE
Improved priorities and some more dbclean queries

### DIFF
--- a/include/cron.php
+++ b/include/cron.php
@@ -131,6 +131,9 @@ function cron_run(&$argv, &$argc){
 			proc_run(PRIORITY_LOW, 'include/dbclean.php', 2);
 			proc_run(PRIORITY_LOW, 'include/dbclean.php', 3);
 			proc_run(PRIORITY_LOW, 'include/dbclean.php', 4);
+			proc_run(PRIORITY_LOW, 'include/dbclean.php', 5);
+			proc_run(PRIORITY_LOW, 'include/dbclean.php', 6);
+			proc_run(PRIORITY_LOW, 'include/dbclean.php', 7);
 		} else {
 			proc_run(PRIORITY_LOW, 'include/dbclean.php');
 		}
@@ -330,7 +333,11 @@ function cron_poll_contacts($argc, $argv) {
 
 			logger("Polling ".$contact["network"]." ".$contact["id"]." ".$contact["nick"]." ".$contact["name"]);
 
-			proc_run(PRIORITY_MEDIUM, 'include/onepoll.php', $contact['id']);
+			if ($contact["remote_self"]) {
+				proc_run(PRIORITY_MEDIUM, 'include/onepoll.php', $contact['id']);
+			} else {
+				proc_run(PRIORITY_LOW, 'include/onepoll.php', $contact['id']);
+			}
 
 			if($interval)
 				@time_sleep_until(microtime(true) + (float) $interval);

--- a/include/cron.php
+++ b/include/cron.php
@@ -126,17 +126,7 @@ function cron_run(&$argv, &$argc){
 
 		proc_run(PRIORITY_LOW, 'include/expire.php');
 
-		if (get_config("system", "worker")) {
-			proc_run(PRIORITY_LOW, 'include/dbclean.php', 1);
-			proc_run(PRIORITY_LOW, 'include/dbclean.php', 2);
-			proc_run(PRIORITY_LOW, 'include/dbclean.php', 3);
-			proc_run(PRIORITY_LOW, 'include/dbclean.php', 4);
-			proc_run(PRIORITY_LOW, 'include/dbclean.php', 5);
-			proc_run(PRIORITY_LOW, 'include/dbclean.php', 6);
-			proc_run(PRIORITY_LOW, 'include/dbclean.php', 7);
-		} else {
-			proc_run(PRIORITY_LOW, 'include/dbclean.php');
-		}
+		proc_run(PRIORITY_LOW, 'include/dbclean.php');
 
 		cron_update_photo_albums();
 	}

--- a/include/follow.php
+++ b/include/follow.php
@@ -270,7 +270,7 @@ function new_contact($uid,$url,$interactive = false) {
 
 	// pull feed and consume it, which should subscribe to the hub.
 
-	proc_run(PRIORITY_MEDIUM, "include/onepoll.php", $contact_id, "force");
+	proc_run(PRIORITY_HIGH, "include/onepoll.php", $contact_id, "force");
 
 	// create a follow slap
 

--- a/mod/contacts.php
+++ b/mod/contacts.php
@@ -237,7 +237,7 @@ function _contact_update($contact_id) {
 				intval($contact_id));
 	} else
 		// pull feed and consume it, which should subscribe to the hub.
-		proc_run(PRIORITY_MEDIUM, "include/onepoll.php", $contact_id, "force");
+		proc_run(PRIORITY_HIGH, "include/onepoll.php", $contact_id, "force");
 }
 
 function _contact_update_profile($contact_id) {


### PR DESCRIPTION
The "onepoll" priority for "remote-self" contacts is now higher than for regular contacts. This means that they will be pulled more often.

dbclean now remove more data and on systems with activated worker the system will work more often.