### PR TITLE
[frio] Fix wall_thread.tpl error with unstareable items

### DIFF
--- a/view/theme/frio/templates/wall_thread.tpl
+++ b/view/theme/frio/templates/wall_thread.tpl
@@ -3,7 +3,7 @@
 It would be better if it would be done in friendica core but since core lacks this functionality
 it is done in the theme
 
-In short: the piece of code counts the total number of children of the toplevelpost 
+In short: the piece of code counts the total number of children of the toplevelpost
 - this are usaly all posts with thread_level = 2 - and stores it in variable $top_children_total.
 The first time a children which hits thread_level = 2 and $top_child = 1 opens the div.
 
@@ -41,9 +41,9 @@ as the value of $top_child_total (this is done at the end of this file)
 	{{if $item.thread_level<3}}
 		<div class="hide-comments-outer-wrapper">
 			<div class="hide-comments-outer btn-link" onclick="showHideComments({{$item.id}});">
-				<span id="hide-comments-total-{{$item.id}}" 
+				<span id="hide-comments-total-{{$item.id}}"
 					class="hide-comments-total">{{$item.num_comments}}</span>
-				<span id="hide-comments-{{$item.id}}" 
+				<span id="hide-comments-{{$item.id}}"
 					class="hide-comments fakelink">{{$item.hide_text}}</span>
 			</div>
 			<hr />
@@ -57,7 +57,9 @@ as the value of $top_child_total (this is done at the end of this file)
 
 <!-- TODO => Unknow block -->
 <div class="wall-item-decor" style="display:none;">
+	{{if $item.star}}
 	<span class="icon s22 star {{$item.isstarred}}" id="starred-{{$item.id}}" title="{{$item.star.starred}}">{{$item.star.starred}}</span>
+	{{/if}}
 	{{if $item.lock}}<span class="navicon lock fakelink" onclick="lockview(event,{{$item.id}});" title="{{$item.lock}}"></span><span class="fa fa-lock"></span>{{/if}}
 	<img id="like-rotator-{{$item.id}}" class="like-rotator" src="images/rotator.gif" alt="{{$item.wait}}" title="{{$item.wait}}" style="display: none;" />
 </div>
@@ -73,7 +75,7 @@ as the value of $top_child_total (this is done at the end of this file)
  {{/if}}
 	<div class="media">
 		{{* Put addional actions in a top-right dropdown menu *}}
-		
+
 		<ul class="nav nav-pills preferences">
 			<li><span class="wall-item-network" title="{{$item.app}}">{{$item.network_name}}</span></li>
 


### PR DESCRIPTION
Looking at my logs, I got a bunch of 

`PHP Warning:  Illegal string offset 'starred' in /view/smarty3/compiled/dac307b3f5c8b36b554e0605d3d19458841b9b62.file.wall_thread.tpl.php on line 86`

It turns out that for items that can't be starred like comments, we were still trying to get their star status.

A simple condition will suppress the warning forever.

Paging @rabuzarus