### PR TITLE
Misc performance improvement

### DIFF
--- a/include/session.php
+++ b/include/session.php
@@ -71,14 +71,9 @@ function ref_session_write($id, $data) {
 
 	if ($session_exists) {
 		$r = q("UPDATE `session`
-				SET `data` = '%s'
-				WHERE `data` != '%s' AND `sid` = '%s'",
-				dbesc($data), dbesc($data), dbesc($id));
-
-		$r = q("UPDATE `session`
-				SET `expire` = '%s'
-				WHERE `expire` != '%s' AND `sid` = '%s'",
-				dbesc($expire), dbesc($expire), dbesc($id));
+				SET `data` = '%s', `expire` = '%s'
+				WHERE `sid` = '%s'",
+				dbesc($data), dbesc($expire), dbesc($id));
 	} else {
 		$r = q("INSERT INTO `session`
 				SET `sid` = '%s', `expire` = '%s', `data` = '%s'",

--- a/include/session.php
+++ b/include/session.php
@@ -72,8 +72,9 @@ function ref_session_write($id, $data) {
 	if ($session_exists) {
 		$r = q("UPDATE `session`
 				SET `data` = '%s', `expire` = '%s'
-				WHERE `sid` = '%s'",
-				dbesc($data), dbesc($expire), dbesc($id));
+				WHERE `sid` = '%s'
+				AND (`data` != '%s' OR `expire` != '%s'",
+				dbesc($data), dbesc($expire), dbesc($id), dbesc($data), dbesc($expire));
 	} else {
 		$r = q("INSERT INTO `session`
 				SET `sid` = '%s', `expire` = '%s', `data` = '%s'",


### PR DESCRIPTION
I found a few performance improvements while working on the JSON version of ping.php.

- Cache contact detail by url during script: this one is simple: if we already retrieved the contact details for a given url/uid couple in the same script, then we don't do it again. Particularly useful in ping.php where each notification tries to perform a `get_contact_details_by_url()`.
- Remove extraneous session write DB query: the conditional DB queries seemed like a good idea, but in the end the expire query was run each time because the expire is updated lines before, and the session data query could run or not. Result is 1-2 DB update. I cut that to a flat 1 DB update by merging both queries. Updating the session data isn't as expensive as having a second query.