### PR TITLE
help text for settings should be translateable

### DIFF
--- a/mod/settings.php
+++ b/mod/settings.php
@@ -1004,7 +1004,7 @@ function settings_content(&$a) {
 			'$noinfo'	=> array('noinfo', t("Don't show notices"), $noinfo, ''),
 			'$infinite_scroll'	=> array('infinite_scroll', t("Infinite scroll"), $infinite_scroll, ''),
 			'$no_auto_update'	=> array('no_auto_update', t("Automatic updates only at the top of the network page"), $no_auto_update, 'When disabled, the network page is updated all the time, which could be confusing while reading.'),
-			'$bandwidth_saver' => array('bandwidth_saver', t('Bandwith Saver Mode'), $bandwidth_saver, 'When enabled, embedded content is not displayed on automatic updates, they only show on page reload.'),
+			'$bandwidth_saver' => array('bandwidth_saver', t('Bandwith Saver Mode'), $bandwidth_saver, t('When enabled, embedded content is not displayed on automatic updates, they only show on page reload.')),
 
 			'$d_tset' => t('General Theme Settings'),
 			'$d_ctset' => t('Custom Theme Settings'),


### PR DESCRIPTION
The settings for the bandwidth saver mode have a halp text, which sould be translate able.