### PR TITLE
Performance improvements when storing items (via API)

### DIFF
--- a/include/Photo.php
+++ b/include/Photo.php
@@ -707,11 +707,6 @@ class Photo {
 			);
 		}
 
-		// Update the cached values
-		if ($album != 'Contact Photos') {
-			photo_albums($uid, true);
-		}
-
 		return $r;
 	}
 }
@@ -872,7 +867,7 @@ function get_photo_info($url) {
 
 	$data = Cache::get($url);
 
-	if (is_null($data) OR !$data) {
+	if (is_null($data) OR !$data OR !is_array($data)) {
 		$img_str = fetch_url($url, true, $redirects, 4);
 		$filesize = strlen($img_str);
 

--- a/include/api.php
+++ b/include/api.php
@@ -281,16 +281,15 @@
 					logger("API call duration: ".round($duration, 2)."\t".$a->query_string, LOGGER_DEBUG);
 
 					if (get_config("system", "profiler")) {
-						logger(sprintf("Database: %s/%s, Network: %s, Rendering: %s, Session: %s, I/O: %s, Other: %s, Total: %s",
+						$duration = microtime(true)-$a->performance["start"];
+
+						logger(parse_url($a->query_string, PHP_URL_PATH).": ".sprintf("Database: %s/%s, Network: %s, I/O: %s, Other: %s, Total: %s",
 							round($a->performance["database"] - $a->performance["database_write"], 3),
 							round($a->performance["database_write"], 3),
 							round($a->performance["network"], 2),
-							round($a->performance["rendering"], 2),
-							round($a->performance["parser"], 2),
 							round($a->performance["file"], 2),
-							round($duration - $a->performance["database"]
-								 - $a->performance["network"] - $a->performance["rendering"]
-								 - $a->performance["parser"] - $a->performance["file"], 2),
+							round($duration - ($a->performance["database"] + $a->performance["network"]
+								+ $a->performance["file"]), 2),
 							round($duration, 2)),
 							LOGGER_DEBUG);
 

--- a/include/create_shadowentry.php
+++ b/include/create_shadowentry.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * @file include/create_shadowentry.php
+ * @brief This script creates posts with UID = 0 for a given public post.
+ *
+ * This script is started from mod/item.php to save some time when doing a post.
+ */
+require_once("boot.php");
+require_once("include/threads.php");
+
+function create_shadowentry_run(&$argv, &$argc) {
+	global $a, $db;
+
+	if (is_null($a))
+		$a = new App;
+
+	if (is_null($db)) {
+		@include(".htconfig.php");
+		require_once("include/dba.php");
+		$db = new dba($db_host, $db_user, $db_pass, $db_data);
+		unset($db_host, $db_user, $db_pass, $db_data);
+	}
+
+	load_config('config');
+	load_config('system');
+
+	if ($argc != 2) {
+		return;
+	}
+
+	$message_id = intval($argv[1]);
+
+	add_shadow_entry($message_id);
+}
+
+if (array_search(__file__,get_included_files())===0){
+  create_shadowentry_run($_SERVER["argv"],$_SERVER["argc"]);
+  killme();
+}
+?>

--- a/include/create_shadowentry.php
+++ b/include/create_shadowentry.php
@@ -8,7 +8,7 @@
 require_once("boot.php");
 require_once("include/threads.php");
 
-function create_shadowentry_run(&$argv, &$argc) {
+function create_shadowentry_run($argv, $argc) {
 	global $a, $db;
 
 	if (is_null($a))

--- a/include/threads.php
+++ b/include/threads.php
@@ -123,7 +123,18 @@ function add_shadow_thread($itemid) {
 function add_shadow_entry($itemid) {
 
 	$items = q("SELECT * FROM `item` WHERE `id` = %d", intval($itemid));
+
+	if (!dbm::is_result($items)) {
+		return;
+	}
+
 	$item = $items[0];
+
+	// Is it a toplevel post?
+	if ($item['id'] == $item['parent']) {
+		add_shadow_thread($itemid);
+		return;
+	}
 
 	// Is this a shadow entry?
 	if ($item['uid'] == 0)


### PR DESCRIPTION
When posting via the API we don't have much time for a call or we get a timeout error. This especially happens when pictures are posted.

To speed up the item creation we now don't update the cached album values anymore when creating a picture. Additionally we store the items with the UID = 0 in the background. And (when using the poller) we just add the command to the worker queue without executing it. 