### PR TITLE
Bugfix: Locations without coordinates aren't good for Diaspora

### DIFF
--- a/include/diaspora.php
+++ b/include/diaspora.php
@@ -2876,8 +2876,9 @@ class diaspora {
 					"created_at" => $created,
 					"provider_display_name" => $item["app"]);
 
-			if (count($location) == 0)
+			if (!isset($location["lat"]) OR !isset($location["lng"])) {
 				unset($message["location"]);
+			}
 
 			$type = "status_message";
 		}

--- a/include/diaspora.php
+++ b/include/diaspora.php
@@ -2876,6 +2876,7 @@ class diaspora {
 					"created_at" => $created,
 					"provider_display_name" => $item["app"]);
 
+			// Diaspora rejects messages when they contain a location without "lat" or "lng"
 			if (!isset($location["lat"]) OR !isset($location["lng"])) {
 				unset($message["location"]);
 			}


### PR DESCRIPTION
Diaspora doesn't accept messages when they contain a location but no coordinates.