### PR TITLE
fix photos page permissions

### DIFF
--- a/include/items.php
+++ b/include/items.php
@@ -1896,21 +1896,21 @@ function drop_item($id,$interactive = true) {
 
 	$owner = $item['uid'];
 
-	$cid = 0;
+	$contact_id = 0;
 
 	// check if logged in user is either the author or owner of this item
 
 	if (is_array($_SESSION['remote'])) {
 		foreach($_SESSION['remote'] as $visitor) {
 			if ($visitor['uid'] == $item['uid'] && $visitor['cid'] == $item['contact-id']) {
-				$cid = $visitor['cid'];
+				$contact_id = $visitor['cid'];
 				break;
 			}
 		}
 	}
 
 
-	if ((local_user() == $item['uid']) || ($cid) || (! $interactive)) {
+	if ((local_user() == $item['uid']) || ($contact_id) || (! $interactive)) {
 
 		// Check if we should do HTML-based delete confirmation
 		if ($_REQUEST['confirm']) {

--- a/mod/photos.php
+++ b/mod/photos.php
@@ -132,24 +132,24 @@ function photos_post(&$a) {
 		$can_post = true;
 	else {
 		if ($community_page && remote_user()) {
-			$cid = 0;
+			$contact_id = 0;
 			if (is_array($_SESSION['remote'])) {
 				foreach ($_SESSION['remote'] as $v) {
 					if ($v['uid'] == $page_owner_uid) {
-						$cid = $v['cid'];
+						$contact_id = $v['cid'];
 						break;
 					}
 				}
 			}
-			if ($cid) {
+			if ($contact_id) {
 
 				$r = qu("SELECT `uid` FROM `contact` WHERE `blocked` = 0 AND `pending` = 0 AND `id` = %d AND `uid` = %d LIMIT 1",
-					intval($cid),
+					intval($contact_id),
 					intval($page_owner_uid)
 				);
 				if (dbm::is_result($r)) {
 					$can_post = true;
-					$visitor = $cid;
+					$visitor = $contact_id;
 				}
 			}
 		}
@@ -1012,7 +1012,7 @@ function photos_content(&$a) {
 					$can_post = true;
 					$contact = $r[0];
 					$remote_contact = true;
-					$visitor = $cid;
+					$visitor = $contact_id;
 				}
 			}
 		}

--- a/mod/videos.php
+++ b/mod/videos.php
@@ -263,7 +263,7 @@ function videos_content(&$a) {
 					$can_post = true;
 					$contact = $r[0];
 					$remote_contact = true;
-					$visitor = $cid;
+					$visitor = $contact_id;
 				}
 			}
 		}

--- a/mod/wall_attach.php
+++ b/mod/wall_attach.php
@@ -14,19 +14,19 @@ function wall_attach_post(&$a) {
 		);
 		if(! count($r)){
 			if ($r_json) {
-                            echo json_encode(array('error'=>t('Invalid request.')));
-                            killme();
-                        }
+				echo json_encode(array('error'=>t('Invalid request.')));
+				killme();
+			}
 			return;
-        }
+	}
 
 	} else {
 		if ($r_json) {
-                    echo json_encode(array('error'=>t('Invalid request.')));
-                    killme();
-                }
+			echo json_encode(array('error'=>t('Invalid request.')));
+			killme();
+		}
 		return;
-    }
+	}
 
 	$can_post  = false;
 	$visitor   = 0;
@@ -40,41 +40,41 @@ function wall_attach_post(&$a) {
 		$can_post = true;
 	else {
 		if($community_page && remote_user()) {
-			$cid = 0;
+			$contact_id = 0;
 			if(is_array($_SESSION['remote'])) {
 				foreach($_SESSION['remote'] as $v) {
 					if($v['uid'] == $page_owner_uid) {
-						$cid = $v['cid'];
+						$contact_id = $v['cid'];
 						break;
 					}
 				}
 			}
-			if($cid) {
+			if($contact_id) {
 
 				$r = q("SELECT `uid` FROM `contact` WHERE `blocked` = 0 AND `pending` = 0 AND `id` = %d AND `uid` = %d LIMIT 1",
-					intval($cid),
+					intval($contact_id),
 					intval($page_owner_uid)
 				);
 				if(count($r)) {
 					$can_post = true;
-					$visitor = $cid;
+					$visitor = $contact_id;
 				}
 			}
 		}
 	}
 	if(! $can_post) {
 		if ($r_json) {
-                    echo json_encode(array('error'=>t('Permission denied.')));
-                    killme();
-                }
+			echo json_encode(array('error'=>t('Permission denied.')));
+			killme();
+		}
 		notice( t('Permission denied.') . EOL );
 		killme();
 	}
 
 	if(! x($_FILES,'userfile')) {
 		if ($r_json) {
-                    echo json_encode(array('error'=>t('Invalid request.')));
-                }
+			echo json_encode(array('error'=>t('Invalid request.')));
+		}
 		killme();
 	}
 
@@ -179,9 +179,9 @@ function wall_attach_post(&$a) {
 	}
 
 	if ($r_json) {
-            echo json_encode(array('ok'=>true));
-            killme();
-        }
+		echo json_encode(array('ok'=>true));
+		killme();
+	}
 
 	$lf = "\n";
 

--- a/mod/wall_upload.php
+++ b/mod/wall_upload.php
@@ -17,8 +17,8 @@ function wall_upload_post(&$a, $desktopmode = true) {
 
 			if(! count($r)){
 				if ($r_json) {
-				    echo json_encode(array('error'=>t('Invalid request.')));
-				    killme();
+					echo json_encode(array('error'=>t('Invalid request.')));
+					killme();
 				}
 				return;
 			}
@@ -30,8 +30,8 @@ function wall_upload_post(&$a, $desktopmode = true) {
 		}
 	} else {
 		if ($r_json) {
-		    echo json_encode(array('error'=>t('Invalid request.')));
-		    killme();
+			echo json_encode(array('error'=>t('Invalid request.')));
+			killme();
 		}
 		return;
 	}
@@ -48,24 +48,24 @@ function wall_upload_post(&$a, $desktopmode = true) {
 		$can_post = true;
 	else {
 		if($community_page && remote_user()) {
-			$cid = 0;
+			$contact_id = 0;
 			if(is_array($_SESSION['remote'])) {
 				foreach($_SESSION['remote'] as $v) {
 					if($v['uid'] == $page_owner_uid) {
-						$cid = $v['cid'];
+						$contact_id = $v['cid'];
 						break;
 					}
 				}
 			}
-			if($cid) {
+			if($contact_id) {
 
 				$r = q("SELECT `uid` FROM `contact` WHERE `blocked` = 0 AND `pending` = 0 AND `id` = %d AND `uid` = %d LIMIT 1",
-					intval($cid),
+					intval($contact_id),
 					intval($page_owner_uid)
 				);
 				if(count($r)) {
 					$can_post = true;
-					$visitor = $cid;
+					$visitor = $contact_id;
 				}
 			}
 		}
@@ -74,8 +74,8 @@ function wall_upload_post(&$a, $desktopmode = true) {
 
 	if(! $can_post) {
 		if ($r_json) {
-		    echo json_encode(array('error'=>t('Permission denied.')));
-		    killme();
+			echo json_encode(array('error'=>t('Permission denied.')));
+			killme();
 		}
 		notice( t('Permission denied.') . EOL );
 		killme();
@@ -83,7 +83,7 @@ function wall_upload_post(&$a, $desktopmode = true) {
 
 	if(! x($_FILES,'userfile') && ! x($_FILES,'media')){
 		if ($r_json) {
-		    echo json_encode(array('error'=>t('Invalid request.')));
+			echo json_encode(array('error'=>t('Invalid request.')));
 		}
 		killme();
 	}
@@ -119,8 +119,8 @@ function wall_upload_post(&$a, $desktopmode = true) {
 
 	if ($src=="") {
 		if ($r_json) {
-		    echo json_encode(array('error'=>t('Invalid request.')));
-		    killme();
+			echo json_encode(array('error'=>t('Invalid request.')));
+			killme();
 		}
 		notice(t('Invalid request.').EOL);
 		killme();
@@ -248,8 +248,8 @@ function wall_upload_post(&$a, $desktopmode = true) {
 		$r = q("SELECT `id`, `datasize`, `width`, `height`, `type` FROM `photo` WHERE `resource-id` = '%s' ORDER BY `width` DESC LIMIT 1", $hash);
 		if (!$r){
 			if ($r_json) {
-			    echo json_encode(array('error'=>''));
-			    killme();
+				echo json_encode(array('error'=>''));
+				killme();
 			}
 			return false;
 		}
@@ -265,16 +265,16 @@ function wall_upload_post(&$a, $desktopmode = true) {
 		$picture["preview"] = $a->get_baseurl()."/photo/{$hash}-{$smallest}.".$ph->getExt();
 
 		if ($r_json) {
-		    echo json_encode(array('picture'=>$picture));
-		    killme();
+			echo json_encode(array('picture'=>$picture));
+			killme();
 		}
 		return $picture;
 	}
 
 
 	if ($r_json) {
-	    echo json_encode(array('ok'=>true));
-	    killme();
+		echo json_encode(array('ok'=>true));
+		killme();
 	}
 
 /* mod Waitman Gobble NO WARRANTY */


### PR DESCRIPTION
In `function photos_content()` `$visitor = $cid;` was wrong because `$cid` didn't exist. It was changed to `$visitor = $contact_id;`

In addition I changed the naming of `$cid` to `$contact_id` in similar code blocks to unify the variable name (`$contact_id` is also used in `cal.php`, `profile.php`, `item.php` and `display.php`) 