### PR TITLE
Polling feeds is now done with a higher priority.

### DIFF
--- a/include/cron.php
+++ b/include/cron.php
@@ -325,7 +325,7 @@ function cron_poll_contacts($argc, $argv) {
 
 			logger("Polling ".$contact["network"]." ".$contact["id"]." ".$contact["nick"]." ".$contact["name"]);
 
-			if ($contact["remote_self"]) {
+			if (($contact['network'] == NETWORK_FEED) AND ($contact['priority'] <= 3)) {
 				proc_run(PRIORITY_MEDIUM, 'include/onepoll.php', $contact['id']);
 			} else {
 				proc_run(PRIORITY_LOW, 'include/onepoll.php', $contact['id']);


### PR DESCRIPTION
The old programming prioritized the "remote self" contacts. But in fact we have to do it on every feed that is polled in in a faster interval. Otherwise regular feeds are delayed to long.