### PR TITLE
send email confirming pending registration #2916

### DIFF
--- a/include/user.php
+++ b/include/user.php
@@ -384,6 +384,7 @@ function create_user($arr) {
  * @param string $email
  * @param string $sitename
  * @param string $username
+ * @return NULL|boolean
  */
 function send_register_pending_eml($email, $sitename, $username) {
 	$body = deindent(t('

--- a/include/user.php
+++ b/include/user.php
@@ -378,6 +378,28 @@ function create_user($arr) {
 }
 
 
+/**
+ * @brief send registration confiŕmation with the intormation that reg is pending
+ *
+ * @param string $email
+ * @param string $sitename
+ * @param string $username
+ */
+function send_register_pending_eml($email, $sitename, $username) {
+	$body = deindent(t('
+		Dear %1$s,
+			Thank you for registering at %2$s. Your account is pending for approval by the administrator.
+	'));
+
+	$body = sprintf($body, $username, $sitename);
+
+	return notification(array(
+		'type' => "SYSTEM_EMAIL",
+		'to_email' => $email,
+		'subject'=> sprintf( t('Registration at %s'), $sitename),
+		'body' => $body));
+}
+
 /*
  * send registration confirmation.
  * It's here as a function because the mail is sent

--- a/include/user.php
+++ b/include/user.php
@@ -384,7 +384,7 @@ function create_user($arr) {
  * @param string $email
  * @param string $sitename
  * @param string $username
- * @return NULL|boolean
+ * @return NULL|boolean from notification() and email() inherited 
  */
 function send_register_pending_eml($email, $sitename, $username) {
 	$body = deindent(t('

--- a/mod/register.php
+++ b/mod/register.php
@@ -133,6 +133,7 @@ function register_post(&$a) {
 			$admin_mail_list
 		);
 
+		// send notification to admins
 		foreach ($adminlist as $admin) {
 			notification(array(
 				'type' => NOTIFY_SYSTEM,
@@ -149,6 +150,11 @@ function register_post(&$a) {
 				'show_in_notification_page' => false
 			));
 		}
+		// send notification to the user, that the registration is pending
+		send_register_pending_eml(
+				$user['email'],
+				$a->config['sitename'],
+				$user['username']);
 
 		info( t('Your registration is pending approval by the site owner.') . EOL ) ;
 		goaway(z_root());


### PR DESCRIPTION
When the registration is set to "requires approval" send an email to the user registering a new account telling that the account is pending approval by the administrator. #2926 