### PR TITLE
Fix Friendica private image URL replacing

### DIFF
--- a/include/text.php
+++ b/include/text.php
@@ -771,7 +771,7 @@ function activity_match($haystack,$needle) {
 
 /**
  * @brief Pull out all #hashtags and @person tags from $string.
- * 
+ *
  * We also get @person@domain.com - which would make
  * the regex quite complicated as tags can also
  * end a sentence. So we'll run through our results
@@ -1170,33 +1170,29 @@ function link_compare($a,$b) {
 	return false;
 }}
 
-
-if(! function_exists('redir_private_images')) {
 /**
- * Find any non-embedded images in private items and add redir links to them
+ * @brief Find any non-embedded images in private items and add redir links to them
  *
  * @param App $a
- * @param array $item
+ * @param array &$item The field array of an item row
  */
-function redir_private_images($a, &$item) {
-
+function redir_private_images($a, &$item)
+{
 	$matches = false;
 	$cnt = preg_match_all('|\[img\](http[^\[]*?/photo/[a-fA-F0-9]+?(-[0-9]\.[\w]+?)?)\[\/img\]|', $item['body'], $matches, PREG_SET_ORDER);
-	if($cnt) {
-		//logger("redir_private_images: matches = " . print_r($matches, true));
-		foreach($matches as $mtch) {
-			if(strpos($mtch[1], '/redir') !== false)
+	if ($cnt) {
+		foreach ($matches as $mtch) {
+			if(strpos($mtch[1], '/redir') !== false) {
 				continue;
+			}
 
-			if((local_user() == $item['uid']) && ($item['private'] != 0) && ($item['contact-id'] != $a->contact['id']) && ($item['network'] == NETWORK_DFRN)) {
-				//logger("redir_private_images: redir");
-				$img_url = 'redir?f=1&quiet=1&url=' . $mtch[1] . '&conurl=' . $item['author-link'];
-				$item['body'] = str_replace($mtch[0], "[img]".$img_url."[/img]", $item['body']);
+			if ((local_user() == $item['uid']) && ($item['private'] != 0) && ($item['contact-id'] != $a->contact['id']) && ($item['network'] == NETWORK_DFRN)) {
+				$img_url = $a->get_baseurl() . '/redir?f=1&quiet=1&url=' . urlencode($mtch[1]) . '&conurl=' . urlencode($item['author-link']);
+				$item['body'] = str_replace($mtch[0], '[img]' . $img_url . '[/img]', $item['body']);
 			}
 		}
 	}
-
-}}
+}
 
 function put_item_in_cache(&$item, $update = false) {
 


### PR DESCRIPTION
Fixes an issue where private photo URLs would end up being stripped from the resulting HTML.

- Add baseurl to redir_private_images to prevent empty src attribute in
generated HTML
- URL encode the URL parameter url and conurl
- Formatting
- Documentation