### PR TITLE
Additional info in registration request

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -38,7 +38,7 @@ define ( 'FRIENDICA_PLATFORM',     'Friendica');
 define ( 'FRIENDICA_CODENAME',     'Asparagus');
 define ( 'FRIENDICA_VERSION',      '3.5.1-dev' );
 define ( 'DFRN_PROTOCOL_VERSION',  '2.23'    );
-define ( 'DB_UPDATE_VERSION',      1208      );
+define ( 'DB_UPDATE_VERSION',      1209      );
 
 /**
  * @brief Constant with a HTML line break.

--- a/database.sql
+++ b/database.sql
@@ -1,6 +1,6 @@
 -- ------------------------------------------
 -- Friendica 3.5.1-dev (Asparagus)
--- DB_UPDATE_VERSION 1205
+-- DB_UPDATE_VERSION 1208
 -- ------------------------------------------
 
 
@@ -59,7 +59,8 @@ CREATE TABLE IF NOT EXISTS `cache` (
 	`expire_mode` int(11) NOT NULL DEFAULT 0,
 	`updated` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
 	 PRIMARY KEY(`k`(191)),
-	 INDEX `updated` (`updated`)
+	 INDEX `updated` (`updated`),
+	 INDEX `expire_mode_updated` (`expire_mode`,`updated`)
 ) DEFAULT CHARSET=utf8mb4;
 
 --
@@ -174,6 +175,7 @@ CREATE TABLE IF NOT EXISTS `contact` (
 	`ffi_keyword_blacklist` mediumtext,
 	 PRIMARY KEY(`id`),
 	 INDEX `uid` (`uid`),
+	 INDEX `addr_uid` (`addr`,`uid`),
 	 INDEX `nurl` (`nurl`)
 ) DEFAULT CHARSET=utf8mb4;
 
@@ -201,7 +203,8 @@ CREATE TABLE IF NOT EXISTS `deliverq` (
 	`cmd` varchar(32) NOT NULL DEFAULT '',
 	`item` int(11) NOT NULL DEFAULT 0,
 	`contact` int(11) NOT NULL DEFAULT 0,
-	 PRIMARY KEY(`id`)
+	 PRIMARY KEY(`id`),
+	 UNIQUE INDEX `cmd_item_contact` (`cmd`,`item`,`contact`)
 ) DEFAULT CHARSET=utf8mb4;
 
 --
@@ -656,7 +659,7 @@ CREATE TABLE IF NOT EXISTS `notify` (
 	`verb` varchar(255) NOT NULL DEFAULT '',
 	`otype` varchar(16) NOT NULL DEFAULT '',
 	`name_cache` tinytext,
-	`msg_name` mediumtext,
+	`msg_cache` mediumtext,
 	 PRIMARY KEY(`id`),
 	 INDEX `uid` (`uid`)
 ) DEFAULT CHARSET=utf8mb4;
@@ -739,7 +742,9 @@ CREATE TABLE IF NOT EXISTS `photo` (
 	`deny_cid` mediumtext,
 	`deny_gid` mediumtext,
 	 PRIMARY KEY(`id`),
-	 INDEX `uid` (`uid`),
+	 INDEX `uid_contactid` (`uid`,`contact-id`),
+	 INDEX `uid_profile` (`uid`,`profile`),
+	 INDEX `uid_album_created` (`uid`,`album`,`created`),
 	 INDEX `resource-id` (`resource-id`),
 	 INDEX `guid` (`guid`)
 ) DEFAULT CHARSET=utf8mb4;
@@ -894,6 +899,7 @@ CREATE TABLE IF NOT EXISTS `register` (
 	`uid` int(11) unsigned NOT NULL DEFAULT 0,
 	`password` varchar(255) NOT NULL DEFAULT '',
 	`language` varchar(16) NOT NULL DEFAULT '',
+	`note` text,
 	 PRIMARY KEY(`id`)
 ) DEFAULT CHARSET=utf8mb4;
 
@@ -974,6 +980,7 @@ CREATE TABLE IF NOT EXISTS `term` (
 	 INDEX `type_term` (`type`,`term`),
 	 INDEX `uid_otype_type_term_global_created` (`uid`,`otype`,`type`,`term`,`global`,`created`),
 	 INDEX `otype_type_term_tid` (`otype`,`type`,`term`,`tid`),
+	 INDEX `uid_otype_type_url` (`uid`,`otype`,`type`,`url`),
 	 INDEX `guid` (`guid`)
 ) DEFAULT CHARSET=utf8mb4;
 

--- a/include/dbstructure.php
+++ b/include/dbstructure.php
@@ -1280,6 +1280,7 @@ function db_definition($charset) {
 					"uid" => array("type" => "int(11) unsigned", "not null" => "1", "default" => "0"),
 					"password" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
 					"language" => array("type" => "varchar(16)", "not null" => "1", "default" => ""),
+					"note" => array("type" => "text"),
 					),
 			"indexes" => array(
 					"PRIMARY" => array("id"),

--- a/mod/admin.php
+++ b/mod/admin.php
@@ -1388,6 +1388,7 @@ function admin_page_users(&$a){
 		'$h_deleted' => t('User waiting for permanent deletion'),
 		'$th_pending' => array(t('Request date'), t('Name'), t('Email')),
 		'$no_pending' =>  t('No registrations.'),
+		'$pendingnotetext' => t('Note from the user'),
 		'$approve' => t('Approve'),
 		'$deny' => t('Deny'),
 		'$delete' => t('Delete'),

--- a/mod/register.php
+++ b/mod/register.php
@@ -113,12 +113,13 @@ function register_post(&$a) {
 		}
 
 		$hash = random_string();
-		$r = q("INSERT INTO `register` ( `hash`, `created`, `uid`, `password`, `language` ) VALUES ( '%s', '%s', %d, '%s', '%s' ) ",
+		$r = q("INSERT INTO `register` ( `hash`, `created`, `uid`, `password`, `language`, `note` ) VALUES ( '%s', '%s', %d, '%s', '%s', '%s' ) ",
 			dbesc($hash),
 			dbesc(datetime_convert()),
 			intval($user['uid']),
 			dbesc($result['password']),
-			dbesc($lang)
+			dbesc($lang),
+			dbesc($_POST['permonlybox'])
 		);
 
 		// invite system
@@ -262,6 +263,8 @@ function register_content(&$a) {
 	$o = replace_macros($o, array(
 		'$oidhtml' => $oidhtml,
 		'$invitations' => get_config('system','invitation_only'),
+		'$permonly' => $a->config['register_policy'] == REGISTER_APPROVE,
+		'$permonlybox' => array('permonlybox', t('Note for the admin'), '', t('Leave a message for the admin, why you want to join this node')),
 		'$invite_desc' => t('Membership on this site is by invitation only.'),
 		'$invite_label' => t('Your invitation ID: '),
 		'$invite_id' => $invite_id,

--- a/update.php
+++ b/update.php
@@ -1,6 +1,6 @@
 <?php
 
-define('UPDATE_VERSION' , 1208);
+define('UPDATE_VERSION' , 1209);
 
 /**
  *

--- a/view/global.css
+++ b/view/global.css
@@ -464,3 +464,12 @@ td.federation-data {
 #settings-form .pageflags {
     margin: 0 0 20px 30px;
 }
+
+/* admin pending user notes */
+td.pendingnote {
+	padding-left: 20px;
+	padding-right: 20px;
+}
+td.pendingnote > p > span {
+	font-weight: bold;
+}

--- a/view/templates/admin_users.tpl
+++ b/view/templates/admin_users.tpl
@@ -39,6 +39,9 @@
 						<a href="{{$baseurl}}/regmod/deny/{{$u.hash}}" title='{{$deny}}'><span class='icon dislike'></span></a>
 					</td>
 				</tr>
+				<tr>
+					<td class="pendingnote"><p><span>{{$pendingnotetext}}:</span> {{$u.note}}</p></td>
+				</tr>
 			{{/foreach}}
 				</tbody>
 			</table>

--- a/view/templates/register.tpl
+++ b/view/templates/register.tpl
@@ -57,6 +57,10 @@
 	</div>
 	<div id="register-nickname-end" ></div>
 
+{{if $permonly}}
+    {{include file="field_textarea.tpl" field=$permonlybox}}
+{{/if}}
+
 	{{$publish}}
 
 	<div id="register-submit-wrapper">


### PR DESCRIPTION
When register policy is set to `require_approval` a new field is added to the registration form with which the user can add a note to the admin why joining this node. This info is then displayed in the admin panel.

#844 