### PR TITLE
Bugfix: float for remote-friends-in-common wrapper

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -2404,3 +2404,11 @@ body .tread-wrapper .hovercard a:hover {
 body .tread-wrapper .hovercard:hover .hover-card-content a {
     color: $link_color !important;
 }
+
+/*
+ * some temporary workarounds until this will solved
+ * elsewhere (e.g. new templates)
+ */
+section .profile-match-wrapper {
+    float: left;
+}


### PR DESCRIPTION
now the common friends above the stream are floated left