### PR TITLE
Mark contacts as dead or undead while transmitting and receiving messages

### DIFF
--- a/include/delivery.php
+++ b/include/delivery.php
@@ -381,7 +381,14 @@ function delivery_run(&$argv, &$argc){
 				if ($deliver_status == (-1)) {
 					logger('notifier: delivery failed: queuing message');
 					add_to_queue($contact['id'],NETWORK_DFRN,$atom);
+
+					// The message could not be delivered. We mark the contact as "dead"
+					mark_for_death($contact);
+				} else {
+					// We successfully delivered a message, the contact is alive
+					unmark_for_death($contact);
 				}
+
 				break;
 
 			case NETWORK_OSTATUS:

--- a/include/diaspora.php
+++ b/include/diaspora.php
@@ -999,17 +999,21 @@ class diaspora {
 	 */
 	private function author_contact_by_url($contact, $person, $uid) {
 
-		$r = q("SELECT `id`, `network` FROM `contact` WHERE `nurl` = '%s' AND `uid` = %d LIMIT 1",
+		$r = q("SELECT `id`, `network`, `url` FROM `contact` WHERE `nurl` = '%s' AND `uid` = %d LIMIT 1",
 			dbesc(normalise_link($person["url"])), intval($uid));
 		if ($r) {
 			$cid = $r[0]["id"];
 			$network = $r[0]["network"];
+
+			// We are receiving content from a user that is about to be terminated
+			// This means the user is vital, so we remove a possible termination date.
+			unmark_for_death($contact);
 		} else {
 			$cid = $contact["id"];
 			$network = NETWORK_DIASPORA;
 		}
 
-		return (array("cid" => $cid, "network" => $network));
+		return array("cid" => $cid, "network" => $network);
 	}
 
 	/**
@@ -2633,7 +2637,13 @@ class diaspora {
 			} else {
 				// queue message for redelivery
 				add_to_queue($contact["id"], NETWORK_DIASPORA, $slap, $public_batch);
+
+				// The message could not be delivered. We mark the contact as "dead"
+				mark_for_death($contact);
 			}
+		} elseif (($return_code >= 200) AND ($return_code <= 299)) {
+			// We successfully delivered a message, the contact is alive
+			unmark_for_death($contact);
 		}
 
 		return(($return_code) ? $return_code : (-1));


### PR DESCRIPTION
We extend the already existing functionality of marking contacts as dead or living at several other places. This hopefully reduces the items in the queues that can't be delivered.