### PR TITLE
Avoid a warning with activated rendertime

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -609,6 +609,7 @@ class App {
 		$this->performance["markstart"] = microtime(true);
 
 		$this->callstack["database"] = array();
+		$this->callstack["database_write"] = array();
 		$this->callstack["network"] = array();
 		$this->callstack["file"] = array();
 		$this->callstack["rendering"] = array();


### PR DESCRIPTION
We are using this array key - but haven't initialised it.