### PR TITLE
Avoid UTF8 warning in mod/proxy.php

### DIFF
--- a/mod/proxy.php
+++ b/mod/proxy.php
@@ -264,7 +264,7 @@ function proxy_url($url, $writemode = false, $size = '') {
 	}
 
 	// Image URL may have encoded ampersands for display which aren't desirable for proxy
-	$url = html_entity_decode($url, ENT_NOQUOTES, 'UTF8');
+	$url = html_entity_decode($url, ENT_NOQUOTES, 'utf-8');
 
 	// Creating a sub directory to reduce the amount of files in the cache directory
 	$basepath = $a->get_basepath() . '/proxy';


### PR DESCRIPTION
This avoids the warning ````PHP Warning:  html_entity_decode(): charset `UTF8' not supported, assuming utf-8 in /path/to/friendica/mod/proxy.php on line 267````