### PR TITLE
dfrn_request: added $blocked and $pending as variable to make code mo…

### DIFF
--- a/mod/dfrn_request.php
+++ b/mod/dfrn_request.php
@@ -75,6 +75,8 @@ function dfrn_request_post(&$a) {
 			$confirm_key = ((x($_POST,'confirm_key')) ? $_POST['confirm_key'] : "");
 			$hidden = ((x($_POST,'hidden-contact')) ? intval($_POST['hidden-contact']) : 0);
 			$contact_record = null;
+			$blocked = 1;
+			$pending = 1;
 
 			if(x($dfrn_url)) {
 
@@ -148,7 +150,7 @@ function dfrn_request_post(&$a) {
 					 */
 
 					$r = q("INSERT INTO `contact` ( `uid`, `created`,`url`, `nurl`, `addr`, `name`, `nick`, `photo`, `site-pubkey`,
-						`request`, `confirm`, `notify`, `poll`, `poco`, `network`, `aes_allow`, `hidden`)
+						`request`, `confirm`, `notify`, `poll`, `poco`, `network`, `aes_allow`, `hidden`, `blocked`, `pending`)
 						VALUES ( %d, '%s', '%s', '%s', '%s', '%s' , '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', %d, %d)",
 						intval(local_user()),
 						datetime_convert(),
@@ -166,7 +168,9 @@ function dfrn_request_post(&$a) {
 						$parms['dfrn-poco'],
 						dbesc(NETWORK_DFRN),
 						intval($aes_allow),
-						intval($hidden)
+						intval($hidden),
+						intval($blocked),
+						intval($pending)
 					);
 				}
 


### PR DESCRIPTION
…re understandable

$blocked and $pending does now have the value 1 and will be stored during the connection process in the contact table.
This isn't really needed because the columns `blocked` and `pending` does have a default value of `1` but to have these variables in the code does make the code/process more understandable