### PR TITLE
dfrn_request: include the graphic of the connection process into the doxygen header

### DIFF
--- a/mod/dfrn_request.php
+++ b/mod/dfrn_request.php
@@ -8,6 +8,8 @@
  * friend requests.
  *
  * @see PDF with dfrn specs: https://github.com/friendica/friendica/blob/master/spec/dfrn2.pdf
+ *    You also find a graphic which describes the confirmation process at
+ *    https://github.com/friendica/friendica/blob/master/spec/dfrn2_contact_request.png
  */
 
 require_once('include/enotify.php');


### PR DESCRIPTION
This is a PR in relation to https://github.com/friendica/friendica/pull/2977

I haven't done it unil now to prevent merge conflicts