### PR TITLE
Spool items that weren't stored before

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -2365,20 +2365,27 @@ function get_lockpath() {
 	return "";
 }
 
+/**
+ * @brief Returns the path where spool files are stored
+ *
+ * @return string Spool path
+ */
 function get_spoolpath() {
 	$spoolpath = get_config('system','spoolpath');
-	if (($spoolpath != "") AND is_dir($spoolpath) AND is_writable($spoolpath))
+	if (($spoolpath != "") AND is_dir($spoolpath) AND is_writable($spoolpath)) {
 		return($spoolpath);
+	}
 
 	$temppath = get_temppath();
 
 	if ($temppath != "") {
 		$spoolpath = $temppath."/spool";
 
-		if (!is_dir($spoolpath))
+		if (!is_dir($spoolpath)) {
 			mkdir($spoolpath);
-		elseif (!is_writable($spoolpath))
+		} elseif (!is_writable($spoolpath)) {
 			$spoolpath = $temppath;
+		}
 
 		if (is_dir($spoolpath) AND is_writable($spoolpath)) {
 			set_config("system", "spoolpath", $spoolpath);

--- a/include/items.php
+++ b/include/items.php
@@ -851,8 +851,9 @@ function item_store($arr,$force_parent = false, $notify = false, $dontcache = fa
 		// Store the data into a spool file so that we can try again later.
 
 		// At first we restore the Diaspora signature that we removed above.
-		if (isset($encoded_signature))
+		if (isset($encoded_signature)) {
 			$arr['dsprsig'] = $encoded_signature;
+		}
 
 		// Now we store the data in the spool directory
 		$file = 'item-'.round(microtime(true) * 10000).".msg";

--- a/include/items.php
+++ b/include/items.php
@@ -846,7 +846,6 @@ function item_store($arr,$force_parent = false, $notify = false, $dontcache = fa
 		}
 	} else {
 		// This can happen - for example - if there are locking timeouts.
-		logger("Item wasn't stored - we quit here.");
 		q("ROLLBACK");
 
 		// Store the data into a spool file so that we can try again later.
@@ -856,8 +855,10 @@ function item_store($arr,$force_parent = false, $notify = false, $dontcache = fa
 			$arr['dsprsig'] = $encoded_signature;
 
 		// Now we store the data in the spool directory
-		$spool = get_spoolpath().'/'.round(microtime(true) * 10000).".msg";
+		$file = 'item-'.round(microtime(true) * 10000).".msg";
+		$spool = get_spoolpath().'/'.$file;
 		file_put_contents($spool, json_encode($arr));
+		logger("Item wasn't stored - Item was spooled into file ".$file, LOGGER_DEBUG);
 		return 0;
 	}
 

--- a/include/poller.php
+++ b/include/poller.php
@@ -556,6 +556,9 @@ function clear_worker_processes() {
 function poller_run_cron() {
 	logger('Add cron entries', LOGGER_DEBUG);
 
+	// Check for spooled items
+	proc_run(PRIORITY_HIGH, "include/spool_post.php");
+
 	// Run the cron job that calls all other jobs
 	proc_run(PRIORITY_MEDIUM, "include/cron.php");
 

--- a/include/spool_post.php
+++ b/include/spool_post.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * @file include/spool_post.php
+ * @brief Posts items that wer spooled because they couldn't be posted.
+ */
+require_once("boot.php");
+require_once("include/items.php");
+
+function spool_post_run($argv, $argc) {
+	global $a, $db;
+
+	if (is_null($a)) {
+		$a = new App;
+	}
+
+	if (is_null($db)) {
+		@include(".htconfig.php");
+		require_once("include/dba.php");
+		$db = new dba($db_host, $db_user, $db_pass, $db_data);
+		unset($db_host, $db_user, $db_pass, $db_data);
+	}
+
+	load_config('config');
+	load_config('system');
+
+	$path = get_spoolpath();
+
+	if (is_writable($path)){
+		if ($dh = opendir($path)) {
+			while (($file = readdir($dh)) !== false) {
+				$fullfile = $path."/".$file;
+				if (filetype($fullfile) != "file") {
+					continue;
+				}
+				$arr = json_decode(file_get_contents($fullfile), true);
+				$result = item_store($arr);
+				logger("Spool file ".$file." stored: ".$result, LOGGER_DEBUG);
+				unlink($fullfile);
+			}
+			closedir($dh);
+		}
+	}
+}
+
+if (array_search(__file__, get_included_files()) === 0) {
+	spool_post_run($_SERVER["argv"], $_SERVER["argc"]);
+	killme();
+}
+?>

--- a/mod/worker.php
+++ b/mod/worker.php
@@ -14,8 +14,10 @@ function worker_init($a){
 		return;
 	}
 
-	// We don't need the following lines if we can execute background jobs
+	// We don't need the following lines if we can execute background jobs.
+	// So we just wake up the worker if it sleeps.
 	if (function_exists("proc_open")) {
+		call_worker_if_idle();
 		return;
 	}
 


### PR DESCRIPTION
Some times a day I see entries in my log file that an item couldn't be stored due to a deadlock. The new coding now stores these items into a spool directory. The files in that directory will then be posted some time later.