### PR TITLE
Bugfix: cached data doesn't need to get unserialized anymore

### DIFF
--- a/include/identity.php
+++ b/include/identity.php
@@ -813,7 +813,6 @@ function zrl_init(&$a) {
 
 		$result = Cache::get("gprobe:".$urlparts["host"]);
 		if (!is_null($result)) {
-			$result = unserialize($result);
 			if (in_array($result["network"], array(NETWORK_FEED, NETWORK_PHANTOM))) {
 				logger("DDoS attempt detected for ".$urlparts["host"]." by ".$_SERVER["REMOTE_ADDR"].". server data: ".print_r($_SERVER, true), LOGGER_DEBUG);
 				return;


### PR DESCRIPTION
unserializing cache data isn't needed anymore because it is done in the cache class since https://github.com/friendica/friendica/pull/2896