### PR TITLE
add frontend worker to the admin panel and regen master messages.po file

### DIFF
--- a/doc/htconfig.md
+++ b/doc/htconfig.md
@@ -29,7 +29,6 @@ Example: To set the directory value please add this line to your .htconfig.php:
 * disable_email_validation (Boolean) - Disables the check if a mail address is in a valid format and can be resolved via DNS.
 * disable_url_validation (Boolean) - Disables the DNS lookup of an URL.
 * event_input_format - Default value is "ymd".
-* frontend_worker (Boolean) - Activates the frontend worker which acts as a replacement for running the poller via the command line.
 * frontend_worker_timeout - Value in minutes after we think that a frontend task was killed by the webserver. Default value is 10.
 * ignore_cache (Boolean) - For development only. Disables the item cache.
 * like_no_comment (Boolean) - Don't update the "commented" value of an item when it is liked.

--- a/mod/admin.php
+++ b/mod/admin.php
@@ -669,6 +669,7 @@ function admin_page_site_post(&$a) {
 	$worker_queues		=	((x($_POST,'worker_queues'))		? intval($_POST['worker_queues'])		: 4);
 	$worker_dont_fork	=	((x($_POST,'worker_dont_fork'))		? True						: False);
 	$worker_fastlane	=	((x($_POST,'worker_fastlane'))		? True						: False);
+	$worker_frontend	=	((x($_POST,'worker_frontend'))		? True						: False);
 
 	if($a->get_path() != "")
 		$diaspora_enabled = false;
@@ -819,6 +820,7 @@ function admin_page_site_post(&$a) {
 	set_config('system','worker_queues', $worker_queues);
 	set_config('system','worker_dont_fork', $worker_dont_fork);
 	set_config('system','worker_fastlane', $worker_fastlane);
+	set_config('system','frontend_worker', $worker_frontend);
 
 	if($rino==2 and !function_exists('mcrypt_create_iv')) {
 		notice(t("RINO2 needs mcrypt php extension to work."));
@@ -1050,6 +1052,7 @@ function admin_page_site(&$a) {
 		'$worker_queues' 	=> array('worker_queues', t("Maximum number of parallel workers"), get_config('system','worker_queues'), t("On shared hosters set this to 2. On larger systems, values of 10 are great. Default value is 4.")),
 		'$worker_dont_fork'	=> array('worker_dont_fork', t("Don't use 'proc_open' with the worker"), get_config('system','worker_dont_fork'), t("Enable this if your system doesn't allow the use of 'proc_open'. This can happen on shared hosters. If this is enabled you should increase the frequency of poller calls in your crontab.")),
 		'$worker_fastlane'	=> array('worker_fastlane', t("Enable fastlane"), get_config('system','worker_fastlane'), t("When enabed, the fastlane mechanism starts an additional worker if processes with higher priority are blocked by processes of lower priority.")),
+		'$worker_frontend'	=> array('worker_frontend', t('Enable frontend worker'), get_config('system','frontend_worker'), t('When enabled the Worker process is triggered when backend access is performed (e.g. messages being delivered). On smaller sites you might want to call yourdomain.tld/worker on a regular basis via an external cron job. You should only enable this option if you cannot utilize cron/scheduled jobs on your server. The worker background process needs to be activated for this.')),
 
 		'$form_security_token'	=> get_form_security_token("admin_site")
 

--- a/util/messages.po
+++ b/util/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-11-20 21:45+0100\n"
+"POT-Creation-Date: 2016-12-06 08:42+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,916 +18,85 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 
-#: include/contact_widgets.php:6
-msgid "Add New Contact"
+#: boot.php:970
+msgid "Delete this item?"
 msgstr ""
 
-#: include/contact_widgets.php:7
-msgid "Enter address or web location"
+#: boot.php:971 mod/content.php:727 mod/content.php:945 mod/photos.php:1589
+#: mod/photos.php:1637 mod/photos.php:1723 object/Item.php:403
+#: object/Item.php:719
+msgid "Comment"
 msgstr ""
 
-#: include/contact_widgets.php:8
-msgid "Example: bob@example.com, http://example.com/barbara"
-msgstr ""
-
-#: include/contact_widgets.php:10 include/identity.php:218
-#: mod/allfriends.php:82 mod/dirfind.php:201 mod/match.php:87
-#: mod/suggest.php:101
-msgid "Connect"
-msgstr ""
-
-#: include/contact_widgets.php:24
-#, php-format
-msgid "%d invitation available"
-msgid_plural "%d invitations available"
-msgstr[0] ""
-msgstr[1] ""
-
-#: include/contact_widgets.php:30
-msgid "Find People"
-msgstr ""
-
-#: include/contact_widgets.php:31
-msgid "Enter name or interest"
-msgstr ""
-
-#: include/contact_widgets.php:32 include/Contact.php:375
-#: include/conversation.php:981 mod/follow.php:103 mod/allfriends.php:66
-#: mod/contacts.php:602 mod/dirfind.php:204 mod/match.php:72
-#: mod/suggest.php:83
-msgid "Connect/Follow"
-msgstr ""
-
-#: include/contact_widgets.php:33
-msgid "Examples: Robert Morgenstein, Fishing"
-msgstr ""
-
-#: include/contact_widgets.php:34 mod/contacts.php:798 mod/directory.php:204
-msgid "Find"
-msgstr ""
-
-#: include/contact_widgets.php:35 mod/suggest.php:114
-#: view/theme/vier/theme.php:203
-msgid "Friend Suggestions"
-msgstr ""
-
-#: include/contact_widgets.php:36 view/theme/vier/theme.php:202
-msgid "Similar Interests"
-msgstr ""
-
-#: include/contact_widgets.php:37
-msgid "Random Profile"
-msgstr ""
-
-#: include/contact_widgets.php:38 view/theme/vier/theme.php:204
-msgid "Invite Friends"
-msgstr ""
-
-#: include/contact_widgets.php:108
-msgid "Networks"
-msgstr ""
-
-#: include/contact_widgets.php:111
-msgid "All Networks"
-msgstr ""
-
-#: include/contact_widgets.php:141 include/features.php:103
-msgid "Saved Folders"
-msgstr ""
-
-#: include/contact_widgets.php:144 include/contact_widgets.php:176
-msgid "Everything"
-msgstr ""
-
-#: include/contact_widgets.php:173
-msgid "Categories"
-msgstr ""
-
-#: include/contact_widgets.php:237
-#, php-format
-msgid "%d contact in common"
-msgid_plural "%d contacts in common"
-msgstr[0] ""
-msgstr[1] ""
-
-#: include/contact_widgets.php:242 include/ForumManager.php:119
-#: include/items.php:2223 mod/content.php:624 object/Item.php:432
-#: view/theme/vier/theme.php:260 boot.php:971
+#: boot.php:972 include/contact_widgets.php:242 include/ForumManager.php:119
+#: include/items.php:2241 mod/content.php:624 object/Item.php:432
+#: view/theme/vier/theme.php:260
 msgid "show more"
 msgstr ""
 
-#: include/ForumManager.php:114 include/nav.php:131 include/text.php:1025
-#: view/theme/vier/theme.php:255
-msgid "Forums"
+#: boot.php:973
+msgid "show fewer"
 msgstr ""
 
-#: include/ForumManager.php:116 view/theme/vier/theme.php:257
-msgid "External link to forum"
-msgstr ""
-
-#: include/profile_selectors.php:6
-msgid "Male"
-msgstr ""
-
-#: include/profile_selectors.php:6
-msgid "Female"
-msgstr ""
-
-#: include/profile_selectors.php:6
-msgid "Currently Male"
-msgstr ""
-
-#: include/profile_selectors.php:6
-msgid "Currently Female"
-msgstr ""
-
-#: include/profile_selectors.php:6
-msgid "Mostly Male"
-msgstr ""
-
-#: include/profile_selectors.php:6
-msgid "Mostly Female"
-msgstr ""
-
-#: include/profile_selectors.php:6
-msgid "Transgender"
-msgstr ""
-
-#: include/profile_selectors.php:6
-msgid "Intersex"
-msgstr ""
-
-#: include/profile_selectors.php:6
-msgid "Transsexual"
-msgstr ""
-
-#: include/profile_selectors.php:6
-msgid "Hermaphrodite"
-msgstr ""
-
-#: include/profile_selectors.php:6
-msgid "Neuter"
-msgstr ""
-
-#: include/profile_selectors.php:6
-msgid "Non-specific"
-msgstr ""
-
-#: include/profile_selectors.php:6
-msgid "Other"
-msgstr ""
-
-#: include/profile_selectors.php:6 include/conversation.php:1483
-msgid "Undecided"
-msgid_plural "Undecided"
-msgstr[0] ""
-msgstr[1] ""
-
-#: include/profile_selectors.php:23
-msgid "Males"
-msgstr ""
-
-#: include/profile_selectors.php:23
-msgid "Females"
-msgstr ""
-
-#: include/profile_selectors.php:23
-msgid "Gay"
-msgstr ""
-
-#: include/profile_selectors.php:23
-msgid "Lesbian"
-msgstr ""
-
-#: include/profile_selectors.php:23
-msgid "No Preference"
-msgstr ""
-
-#: include/profile_selectors.php:23
-msgid "Bisexual"
-msgstr ""
-
-#: include/profile_selectors.php:23
-msgid "Autosexual"
-msgstr ""
-
-#: include/profile_selectors.php:23
-msgid "Abstinent"
-msgstr ""
-
-#: include/profile_selectors.php:23
-msgid "Virgin"
-msgstr ""
-
-#: include/profile_selectors.php:23
-msgid "Deviant"
-msgstr ""
-
-#: include/profile_selectors.php:23
-msgid "Fetish"
-msgstr ""
-
-#: include/profile_selectors.php:23
-msgid "Oodles"
-msgstr ""
-
-#: include/profile_selectors.php:23
-msgid "Nonsexual"
-msgstr ""
-
-#: include/profile_selectors.php:42
-msgid "Single"
-msgstr ""
-
-#: include/profile_selectors.php:42
-msgid "Lonely"
-msgstr ""
-
-#: include/profile_selectors.php:42
-msgid "Available"
-msgstr ""
-
-#: include/profile_selectors.php:42
-msgid "Unavailable"
-msgstr ""
-
-#: include/profile_selectors.php:42
-msgid "Has crush"
-msgstr ""
-
-#: include/profile_selectors.php:42
-msgid "Infatuated"
-msgstr ""
-
-#: include/profile_selectors.php:42
-msgid "Dating"
-msgstr ""
-
-#: include/profile_selectors.php:42
-msgid "Unfaithful"
-msgstr ""
-
-#: include/profile_selectors.php:42
-msgid "Sex Addict"
-msgstr ""
-
-#: include/profile_selectors.php:42 include/user.php:299 include/user.php:303
-msgid "Friends"
-msgstr ""
-
-#: include/profile_selectors.php:42
-msgid "Friends/Benefits"
-msgstr ""
-
-#: include/profile_selectors.php:42
-msgid "Casual"
-msgstr ""
-
-#: include/profile_selectors.php:42
-msgid "Engaged"
-msgstr ""
-
-#: include/profile_selectors.php:42
-msgid "Married"
-msgstr ""
-
-#: include/profile_selectors.php:42
-msgid "Imaginarily married"
-msgstr ""
-
-#: include/profile_selectors.php:42
-msgid "Partners"
-msgstr ""
-
-#: include/profile_selectors.php:42
-msgid "Cohabiting"
-msgstr ""
-
-#: include/profile_selectors.php:42
-msgid "Common law"
-msgstr ""
-
-#: include/profile_selectors.php:42
-msgid "Happy"
-msgstr ""
-
-#: include/profile_selectors.php:42
-msgid "Not looking"
-msgstr ""
-
-#: include/profile_selectors.php:42
-msgid "Swinger"
-msgstr ""
-
-#: include/profile_selectors.php:42
-msgid "Betrayed"
-msgstr ""
-
-#: include/profile_selectors.php:42
-msgid "Separated"
-msgstr ""
-
-#: include/profile_selectors.php:42
-msgid "Unstable"
-msgstr ""
-
-#: include/profile_selectors.php:42
-msgid "Divorced"
-msgstr ""
-
-#: include/profile_selectors.php:42
-msgid "Imaginarily divorced"
-msgstr ""
-
-#: include/profile_selectors.php:42
-msgid "Widowed"
-msgstr ""
-
-#: include/profile_selectors.php:42
-msgid "Uncertain"
-msgstr ""
-
-#: include/profile_selectors.php:42
-msgid "It's complicated"
-msgstr ""
-
-#: include/profile_selectors.php:42
-msgid "Don't care"
-msgstr ""
-
-#: include/profile_selectors.php:42
-msgid "Ask me"
-msgstr ""
-
-#: include/bb2diaspora.php:148 include/event.php:16 mod/localtime.php:12
-msgid "l F d, Y \\@ g:i A"
-msgstr ""
-
-#: include/bb2diaspora.php:154 include/event.php:33 include/event.php:51
-#: include/event.php:487
-msgid "Starts:"
-msgstr ""
-
-#: include/bb2diaspora.php:162 include/event.php:36 include/event.php:57
-#: include/event.php:488
-msgid "Finishes:"
-msgstr ""
-
-#: include/bb2diaspora.php:170 include/event.php:39 include/event.php:63
-#: include/event.php:489 include/identity.php:328 mod/notifications.php:232
-#: mod/contacts.php:628 mod/directory.php:137 mod/events.php:494
-msgid "Location:"
-msgstr ""
-
-#: include/dba_pdo.php:72 include/dba.php:56
+#: boot.php:1655
 #, php-format
-msgid "Cannot locate DNS info for database server '%s'"
+msgid "Update %s failed. See error logs."
 msgstr ""
 
-#: include/auth.php:45
-msgid "Logged out."
+#: boot.php:1767
+msgid "Create a New Account"
 msgstr ""
 
-#: include/auth.php:116 include/auth.php:178 mod/openid.php:100
-msgid "Login failed."
+#: boot.php:1768 include/nav.php:109 mod/register.php:289
+msgid "Register"
 msgstr ""
 
-#: include/auth.php:132 include/user.php:75
-msgid ""
-"We encountered a problem while logging in with the OpenID you provided. "
-"Please check the correct spelling of the ID."
+#: boot.php:1792 include/nav.php:78 view/theme/frio/theme.php:246
+msgid "Logout"
 msgstr ""
 
-#: include/auth.php:132 include/user.php:75
-msgid "The error message was:"
+#: boot.php:1793 include/nav.php:95 mod/bookmarklet.php:12
+msgid "Login"
 msgstr ""
 
-#: include/group.php:25
-msgid ""
-"A deleted group with this name was revived. Existing item permissions "
-"<strong>may</strong> apply to this group and any future members. If this is "
-"not what you intended, please create another group with a different name."
+#: boot.php:1795 mod/lostpass.php:161
+msgid "Nickname or Email: "
 msgstr ""
 
-#: include/group.php:209
-msgid "Default privacy group for new contacts"
+#: boot.php:1796
+msgid "Password: "
 msgstr ""
 
-#: include/group.php:242
-msgid "Everybody"
+#: boot.php:1797
+msgid "Remember me"
 msgstr ""
 
-#: include/group.php:265
-msgid "edit"
+#: boot.php:1800
+msgid "Or login using OpenID: "
 msgstr ""
 
-#: include/group.php:286 mod/newmember.php:61
-msgid "Groups"
+#: boot.php:1806
+msgid "Forgot your password?"
 msgstr ""
 
-#: include/group.php:288
-msgid "Edit groups"
+#: boot.php:1807 mod/lostpass.php:109
+msgid "Password Reset"
 msgstr ""
 
-#: include/group.php:290
-msgid "Edit group"
+#: boot.php:1809
+msgid "Website Terms of Service"
 msgstr ""
 
-#: include/group.php:291
-msgid "Create a new group"
+#: boot.php:1810
+msgid "terms of service"
 msgstr ""
 
-#: include/group.php:292 mod/group.php:94 mod/group.php:178
-msgid "Group Name: "
+#: boot.php:1812
+msgid "Website Privacy Policy"
 msgstr ""
 
-#: include/group.php:294
-msgid "Contacts not in any group"
-msgstr ""
-
-#: include/group.php:296 mod/network.php:201
-msgid "add"
-msgstr ""
-
-#: include/contact_selectors.php:32
-msgid "Unknown | Not categorised"
-msgstr ""
-
-#: include/contact_selectors.php:33
-msgid "Block immediately"
-msgstr ""
-
-#: include/contact_selectors.php:34
-msgid "Shady, spammer, self-marketer"
-msgstr ""
-
-#: include/contact_selectors.php:35
-msgid "Known to me, but no opinion"
-msgstr ""
-
-#: include/contact_selectors.php:36
-msgid "OK, probably harmless"
-msgstr ""
-
-#: include/contact_selectors.php:37
-msgid "Reputable, has my trust"
-msgstr ""
-
-#: include/contact_selectors.php:56 mod/admin.php:887
-msgid "Frequently"
-msgstr ""
-
-#: include/contact_selectors.php:57 mod/admin.php:888
-msgid "Hourly"
-msgstr ""
-
-#: include/contact_selectors.php:58 mod/admin.php:889
-msgid "Twice daily"
-msgstr ""
-
-#: include/contact_selectors.php:59 mod/admin.php:890
-msgid "Daily"
-msgstr ""
-
-#: include/contact_selectors.php:60
-msgid "Weekly"
-msgstr ""
-
-#: include/contact_selectors.php:61
-msgid "Monthly"
-msgstr ""
-
-#: include/contact_selectors.php:76 mod/dfrn_request.php:867
-msgid "Friendica"
-msgstr ""
-
-#: include/contact_selectors.php:77
-msgid "OStatus"
-msgstr ""
-
-#: include/contact_selectors.php:78
-msgid "RSS/Atom"
-msgstr ""
-
-#: include/contact_selectors.php:79 include/contact_selectors.php:86
-#: mod/admin.php:1392 mod/admin.php:1405 mod/admin.php:1418 mod/admin.php:1436
-msgid "Email"
-msgstr ""
-
-#: include/contact_selectors.php:80 mod/dfrn_request.php:869
-#: mod/settings.php:842
-msgid "Diaspora"
-msgstr ""
-
-#: include/contact_selectors.php:81
-msgid "Facebook"
-msgstr ""
-
-#: include/contact_selectors.php:82
-msgid "Zot!"
-msgstr ""
-
-#: include/contact_selectors.php:83
-msgid "LinkedIn"
-msgstr ""
-
-#: include/contact_selectors.php:84
-msgid "XMPP/IM"
-msgstr ""
-
-#: include/contact_selectors.php:85
-msgid "MySpace"
-msgstr ""
-
-#: include/contact_selectors.php:87
-msgid "Google+"
-msgstr ""
-
-#: include/contact_selectors.php:88
-msgid "pump.io"
-msgstr ""
-
-#: include/contact_selectors.php:89
-msgid "Twitter"
-msgstr ""
-
-#: include/contact_selectors.php:90
-msgid "Diaspora Connector"
-msgstr ""
-
-#: include/contact_selectors.php:91
-msgid "GNU Social"
-msgstr ""
-
-#: include/contact_selectors.php:92
-msgid "App.net"
-msgstr ""
-
-#: include/contact_selectors.php:103
-msgid "Hubzilla/Redmatrix"
-msgstr ""
-
-#: include/acl_selectors.php:327
-msgid "Post to Email"
-msgstr ""
-
-#: include/acl_selectors.php:332
-#, php-format
-msgid "Connectors disabled, since \"%s\" is enabled."
-msgstr ""
-
-#: include/acl_selectors.php:333 mod/settings.php:1181
-msgid "Hide your profile details from unknown viewers?"
-msgstr ""
-
-#: include/acl_selectors.php:338
-msgid "Visible to everybody"
-msgstr ""
-
-#: include/acl_selectors.php:339 view/theme/vier/config.php:103
-msgid "show"
-msgstr ""
-
-#: include/acl_selectors.php:340 view/theme/vier/config.php:103
-msgid "don't show"
-msgstr ""
-
-#: include/acl_selectors.php:346 mod/editpost.php:133
-msgid "CC: email addresses"
-msgstr ""
-
-#: include/acl_selectors.php:347 mod/editpost.php:140
-msgid "Example: bob@example.com, mary@example.com"
-msgstr ""
-
-#: include/acl_selectors.php:349 mod/events.php:509 mod/photos.php:1156
-#: mod/photos.php:1535
-msgid "Permissions"
-msgstr ""
-
-#: include/acl_selectors.php:350
-msgid "Close"
-msgstr ""
-
-#: include/like.php:163 include/conversation.php:130
-#: include/conversation.php:266 include/text.php:1808 mod/subthread.php:87
-#: mod/tagger.php:62
-msgid "photo"
-msgstr ""
-
-#: include/like.php:163 include/conversation.php:125
-#: include/conversation.php:134 include/conversation.php:261
-#: include/conversation.php:270 include/diaspora.php:1406 mod/subthread.php:87
-#: mod/tagger.php:62
-msgid "status"
-msgstr ""
-
-#: include/like.php:165 include/conversation.php:122
-#: include/conversation.php:258 include/text.php:1806
-msgid "event"
-msgstr ""
-
-#: include/like.php:182 include/conversation.php:141 include/diaspora.php:1402
-#, php-format
-msgid "%1$s likes %2$s's %3$s"
-msgstr ""
-
-#: include/like.php:184 include/conversation.php:144
-#, php-format
-msgid "%1$s doesn't like %2$s's %3$s"
-msgstr ""
-
-#: include/like.php:186
-#, php-format
-msgid "%1$s is attending %2$s's %3$s"
-msgstr ""
-
-#: include/like.php:188
-#, php-format
-msgid "%1$s is not attending %2$s's %3$s"
-msgstr ""
-
-#: include/like.php:190
-#, php-format
-msgid "%1$s may attend %2$s's %3$s"
-msgstr ""
-
-#: include/message.php:15 include/message.php:173
-msgid "[no subject]"
-msgstr ""
-
-#: include/message.php:145 include/Photo.php:1040 include/Photo.php:1056
-#: include/Photo.php:1064 include/Photo.php:1089 mod/item.php:477
-#: mod/wall_upload.php:218 mod/wall_upload.php:232 mod/wall_upload.php:239
-msgid "Wall Photos"
-msgstr ""
-
-#: include/plugin.php:526 include/plugin.php:528
-msgid "Click here to upgrade."
-msgstr ""
-
-#: include/plugin.php:534
-msgid "This action exceeds the limits set by your subscription plan."
-msgstr ""
-
-#: include/plugin.php:539
-msgid "This action is not available under your subscription plan."
-msgstr ""
-
-#: include/uimport.php:94
-msgid "Error decoding account file"
-msgstr ""
-
-#: include/uimport.php:100
-msgid "Error! No version data in file! This is not a Friendica account file?"
-msgstr ""
-
-#: include/uimport.php:116 include/uimport.php:127
-msgid "Error! Cannot check nickname"
-msgstr ""
-
-#: include/uimport.php:120 include/uimport.php:131
-#, php-format
-msgid "User '%s' already exists on this server!"
-msgstr ""
-
-#: include/uimport.php:153
-msgid "User creation error"
-msgstr ""
-
-#: include/uimport.php:173
-msgid "User profile creation error"
-msgstr ""
-
-#: include/uimport.php:222
-#, php-format
-msgid "%d contact not imported"
-msgid_plural "%d contacts not imported"
-msgstr[0] ""
-msgstr[1] ""
-
-#: include/uimport.php:292
-msgid "Done. You can now login with your username and password"
-msgstr ""
-
-#: include/features.php:63
-msgid "General Features"
-msgstr ""
-
-#: include/features.php:65
-msgid "Multiple Profiles"
-msgstr ""
-
-#: include/features.php:65
-msgid "Ability to create multiple profiles"
-msgstr ""
-
-#: include/features.php:66
-msgid "Photo Location"
-msgstr ""
-
-#: include/features.php:66
-msgid ""
-"Photo metadata is normally stripped. This extracts the location (if present) "
-"prior to stripping metadata and links it to a map."
-msgstr ""
-
-#: include/features.php:67
-msgid "Export Public Calendar"
-msgstr ""
-
-#: include/features.php:67
-msgid "Ability for visitors to download the public calendar"
-msgstr ""
-
-#: include/features.php:72
-msgid "Post Composition Features"
-msgstr ""
-
-#: include/features.php:73
-msgid "Richtext Editor"
-msgstr ""
-
-#: include/features.php:73
-msgid "Enable richtext editor"
-msgstr ""
-
-#: include/features.php:74
-msgid "Post Preview"
-msgstr ""
-
-#: include/features.php:74
-msgid "Allow previewing posts and comments before publishing them"
-msgstr ""
-
-#: include/features.php:75
-msgid "Auto-mention Forums"
-msgstr ""
-
-#: include/features.php:75
-msgid ""
-"Add/remove mention when a forum page is selected/deselected in ACL window."
-msgstr ""
-
-#: include/features.php:80
-msgid "Network Sidebar Widgets"
-msgstr ""
-
-#: include/features.php:81
-msgid "Search by Date"
-msgstr ""
-
-#: include/features.php:81
-msgid "Ability to select posts by date ranges"
-msgstr ""
-
-#: include/features.php:82 include/features.php:112
-msgid "List Forums"
-msgstr ""
-
-#: include/features.php:82
-msgid "Enable widget to display the forums your are connected with"
-msgstr ""
-
-#: include/features.php:83
-msgid "Group Filter"
-msgstr ""
-
-#: include/features.php:83
-msgid "Enable widget to display Network posts only from selected group"
-msgstr ""
-
-#: include/features.php:84
-msgid "Network Filter"
-msgstr ""
-
-#: include/features.php:84
-msgid "Enable widget to display Network posts only from selected network"
-msgstr ""
-
-#: include/features.php:85 mod/search.php:34 mod/network.php:200
-msgid "Saved Searches"
-msgstr ""
-
-#: include/features.php:85
-msgid "Save search terms for re-use"
-msgstr ""
-
-#: include/features.php:90
-msgid "Network Tabs"
-msgstr ""
-
-#: include/features.php:91
-msgid "Network Personal Tab"
-msgstr ""
-
-#: include/features.php:91
-msgid "Enable tab to display only Network posts that you've interacted on"
-msgstr ""
-
-#: include/features.php:92
-msgid "Network New Tab"
-msgstr ""
-
-#: include/features.php:92
-msgid "Enable tab to display only new Network posts (from the last 12 hours)"
-msgstr ""
-
-#: include/features.php:93
-msgid "Network Shared Links Tab"
-msgstr ""
-
-#: include/features.php:93
-msgid "Enable tab to display only Network posts with links in them"
-msgstr ""
-
-#: include/features.php:98
-msgid "Post/Comment Tools"
-msgstr ""
-
-#: include/features.php:99
-msgid "Multiple Deletion"
-msgstr ""
-
-#: include/features.php:99
-msgid "Select and delete multiple posts/comments at once"
-msgstr ""
-
-#: include/features.php:100
-msgid "Edit Sent Posts"
-msgstr ""
-
-#: include/features.php:100
-msgid "Edit and correct posts and comments after sending"
-msgstr ""
-
-#: include/features.php:101
-msgid "Tagging"
-msgstr ""
-
-#: include/features.php:101
-msgid "Ability to tag existing posts"
-msgstr ""
-
-#: include/features.php:102
-msgid "Post Categories"
-msgstr ""
-
-#: include/features.php:102
-msgid "Add categories to your posts"
-msgstr ""
-
-#: include/features.php:103
-msgid "Ability to file posts under folders"
-msgstr ""
-
-#: include/features.php:104
-msgid "Dislike Posts"
-msgstr ""
-
-#: include/features.php:104
-msgid "Ability to dislike posts/comments"
-msgstr ""
-
-#: include/features.php:105
-msgid "Star Posts"
-msgstr ""
-
-#: include/features.php:105
-msgid "Ability to mark special posts with a star indicator"
-msgstr ""
-
-#: include/features.php:106
-msgid "Mute Post Notifications"
-msgstr ""
-
-#: include/features.php:106
-msgid "Ability to mute notifications for a thread"
-msgstr ""
-
-#: include/features.php:111
-msgid "Advanced Profile Settings"
-msgstr ""
-
-#: include/features.php:112
-msgid "Show visitors public community forums at the Advanced Profile Page"
-msgstr ""
-
-#: include/bbcode.php:348 include/bbcode.php:1055 include/bbcode.php:1056
-msgid "Image/photo"
-msgstr ""
-
-#: include/bbcode.php:465
-#, php-format
-msgid "<a href=\"%1$s\" target=\"_blank\">%2$s</a> %3$s"
-msgstr ""
-
-#: include/bbcode.php:1015 include/bbcode.php:1035
-msgid "$1 wrote:"
-msgstr ""
-
-#: include/bbcode.php:1064 include/bbcode.php:1065
-msgid "Encrypted content"
+#: boot.php:1813
+msgid "privacy policy"
 msgstr ""
 
 #: include/datetime.php:57 include/datetime.php:59 mod/profiles.php:705
@@ -962,8 +131,8 @@ msgstr ""
 msgid "years"
 msgstr ""
 
-#: include/datetime.php:351 include/event.php:480 mod/cal.php:284
-#: mod/events.php:389
+#: include/datetime.php:351 include/event.php:480 mod/events.php:389
+#: mod/cal.php:284
 msgid "month"
 msgstr ""
 
@@ -971,8 +140,8 @@ msgstr ""
 msgid "months"
 msgstr ""
 
-#: include/datetime.php:352 include/event.php:481 mod/cal.php:285
-#: mod/events.php:390
+#: include/datetime.php:352 include/event.php:481 mod/events.php:390
+#: mod/cal.php:285
 msgid "week"
 msgstr ""
 
@@ -980,8 +149,8 @@ msgstr ""
 msgid "weeks"
 msgstr ""
 
-#: include/datetime.php:353 include/event.php:482 mod/cal.php:286
-#: mod/events.php:391
+#: include/datetime.php:353 include/event.php:482 mod/events.php:391
+#: mod/cal.php:286
 msgid "day"
 msgstr ""
 
@@ -1023,9 +192,175 @@ msgstr ""
 msgid "%s's birthday"
 msgstr ""
 
-#: include/datetime.php:573 include/dfrn.php:1108
+#: include/datetime.php:573 include/dfrn.php:1109
 #, php-format
 msgid "Happy Birthday %s"
+msgstr ""
+
+#: include/contact_widgets.php:6
+msgid "Add New Contact"
+msgstr ""
+
+#: include/contact_widgets.php:7
+msgid "Enter address or web location"
+msgstr ""
+
+#: include/contact_widgets.php:8
+msgid "Example: bob@example.com, http://example.com/barbara"
+msgstr ""
+
+#: include/contact_widgets.php:10 include/identity.php:218 mod/dirfind.php:201
+#: mod/match.php:87 mod/allfriends.php:82 mod/suggest.php:101
+msgid "Connect"
+msgstr ""
+
+#: include/contact_widgets.php:24
+#, php-format
+msgid "%d invitation available"
+msgid_plural "%d invitations available"
+msgstr[0] ""
+msgstr[1] ""
+
+#: include/contact_widgets.php:30
+msgid "Find People"
+msgstr ""
+
+#: include/contact_widgets.php:31
+msgid "Enter name or interest"
+msgstr ""
+
+#: include/contact_widgets.php:32 include/conversation.php:981
+#: include/Contact.php:361 mod/dirfind.php:204 mod/match.php:72
+#: mod/allfriends.php:66 mod/contacts.php:602 mod/follow.php:103
+#: mod/suggest.php:83
+msgid "Connect/Follow"
+msgstr ""
+
+#: include/contact_widgets.php:33
+msgid "Examples: Robert Morgenstein, Fishing"
+msgstr ""
+
+#: include/contact_widgets.php:34 mod/directory.php:204 mod/contacts.php:798
+msgid "Find"
+msgstr ""
+
+#: include/contact_widgets.php:35 mod/suggest.php:114
+#: view/theme/vier/theme.php:203
+msgid "Friend Suggestions"
+msgstr ""
+
+#: include/contact_widgets.php:36 view/theme/vier/theme.php:202
+msgid "Similar Interests"
+msgstr ""
+
+#: include/contact_widgets.php:37
+msgid "Random Profile"
+msgstr ""
+
+#: include/contact_widgets.php:38 view/theme/vier/theme.php:204
+msgid "Invite Friends"
+msgstr ""
+
+#: include/contact_widgets.php:108
+msgid "Networks"
+msgstr ""
+
+#: include/contact_widgets.php:111
+msgid "All Networks"
+msgstr ""
+
+#: include/contact_widgets.php:141 include/features.php:110
+msgid "Saved Folders"
+msgstr ""
+
+#: include/contact_widgets.php:144 include/contact_widgets.php:176
+msgid "Everything"
+msgstr ""
+
+#: include/contact_widgets.php:173
+msgid "Categories"
+msgstr ""
+
+#: include/contact_widgets.php:237
+#, php-format
+msgid "%d contact in common"
+msgid_plural "%d contacts in common"
+msgstr[0] ""
+msgstr[1] ""
+
+#: include/NotificationsManager.php:153
+msgid "System"
+msgstr ""
+
+#: include/NotificationsManager.php:160 include/nav.php:158 mod/admin.php:411
+#: view/theme/frio/theme.php:256
+msgid "Network"
+msgstr ""
+
+#: include/NotificationsManager.php:167 mod/profiles.php:703
+#: mod/network.php:846
+msgid "Personal"
+msgstr ""
+
+#: include/NotificationsManager.php:174 include/nav.php:105
+#: include/nav.php:161
+msgid "Home"
+msgstr ""
+
+#: include/NotificationsManager.php:181 include/nav.php:166
+msgid "Introductions"
+msgstr ""
+
+#: include/NotificationsManager.php:234 include/NotificationsManager.php:244
+#, php-format
+msgid "%s commented on %s's post"
+msgstr ""
+
+#: include/NotificationsManager.php:243
+#, php-format
+msgid "%s created a new post"
+msgstr ""
+
+#: include/NotificationsManager.php:256
+#, php-format
+msgid "%s liked %s's post"
+msgstr ""
+
+#: include/NotificationsManager.php:267
+#, php-format
+msgid "%s disliked %s's post"
+msgstr ""
+
+#: include/NotificationsManager.php:278
+#, php-format
+msgid "%s is attending %s's event"
+msgstr ""
+
+#: include/NotificationsManager.php:289
+#, php-format
+msgid "%s is not attending %s's event"
+msgstr ""
+
+#: include/NotificationsManager.php:300
+#, php-format
+msgid "%s may attend %s's event"
+msgstr ""
+
+#: include/NotificationsManager.php:315
+#, php-format
+msgid "%s is now friends with %s"
+msgstr ""
+
+#: include/NotificationsManager.php:748
+msgid "Friend Suggestion"
+msgstr ""
+
+#: include/NotificationsManager.php:781
+msgid "Friend/Connect Request"
+msgstr ""
+
+#: include/NotificationsManager.php:781
+msgid "New Follower"
 msgstr ""
 
 #: include/enotify.php:24
@@ -1324,6 +659,114 @@ msgstr ""
 msgid "Please visit %s to approve or reject the request."
 msgstr ""
 
+#: include/plugin.php:526 include/plugin.php:528
+msgid "Click here to upgrade."
+msgstr ""
+
+#: include/plugin.php:534
+msgid "This action exceeds the limits set by your subscription plan."
+msgstr ""
+
+#: include/plugin.php:539
+msgid "This action is not available under your subscription plan."
+msgstr ""
+
+#: include/ForumManager.php:114 include/text.php:1025 include/nav.php:131
+#: view/theme/vier/theme.php:255
+msgid "Forums"
+msgstr ""
+
+#: include/ForumManager.php:116 view/theme/vier/theme.php:257
+msgid "External link to forum"
+msgstr ""
+
+#: include/diaspora.php:1402 include/conversation.php:141 include/like.php:182
+#, php-format
+msgid "%1$s likes %2$s's %3$s"
+msgstr ""
+
+#: include/diaspora.php:1406 include/conversation.php:125
+#: include/conversation.php:134 include/conversation.php:261
+#: include/conversation.php:270 include/like.php:163 mod/tagger.php:62
+#: mod/subthread.php:87
+msgid "status"
+msgstr ""
+
+#: include/diaspora.php:1958
+msgid "Sharing notification from Diaspora network"
+msgstr ""
+
+#: include/diaspora.php:2864
+msgid "Attachments:"
+msgstr ""
+
+#: include/dfrn.php:1108
+#, php-format
+msgid "%s\\'s birthday"
+msgstr ""
+
+#: include/uimport.php:94
+msgid "Error decoding account file"
+msgstr ""
+
+#: include/uimport.php:100
+msgid "Error! No version data in file! This is not a Friendica account file?"
+msgstr ""
+
+#: include/uimport.php:116 include/uimport.php:127
+msgid "Error! Cannot check nickname"
+msgstr ""
+
+#: include/uimport.php:120 include/uimport.php:131
+#, php-format
+msgid "User '%s' already exists on this server!"
+msgstr ""
+
+#: include/uimport.php:153
+msgid "User creation error"
+msgstr ""
+
+#: include/uimport.php:173
+msgid "User profile creation error"
+msgstr ""
+
+#: include/uimport.php:222
+#, php-format
+msgid "%d contact not imported"
+msgid_plural "%d contacts not imported"
+msgstr[0] ""
+msgstr[1] ""
+
+#: include/uimport.php:292
+msgid "Done. You can now login with your username and password"
+msgstr ""
+
+#: include/dba.php:56 include/dba_pdo.php:72
+#, php-format
+msgid "Cannot locate DNS info for database server '%s'"
+msgstr ""
+
+#: include/event.php:16 include/bb2diaspora.php:148 mod/localtime.php:12
+msgid "l F d, Y \\@ g:i A"
+msgstr ""
+
+#: include/event.php:33 include/event.php:51 include/event.php:487
+#: include/bb2diaspora.php:154
+msgid "Starts:"
+msgstr ""
+
+#: include/event.php:36 include/event.php:57 include/event.php:488
+#: include/bb2diaspora.php:162
+msgid "Finishes:"
+msgstr ""
+
+#: include/event.php:39 include/event.php:63 include/event.php:489
+#: include/identity.php:328 include/bb2diaspora.php:170
+#: mod/notifications.php:232 mod/events.php:494 mod/directory.php:137
+#: mod/contacts.php:628
+msgid "Location:"
+msgstr ""
+
 #: include/event.php:441
 msgid "Sun"
 msgstr ""
@@ -1472,7 +915,7 @@ msgstr ""
 msgid "December"
 msgstr ""
 
-#: include/event.php:479 mod/cal.php:283 mod/events.php:388
+#: include/event.php:479 mod/events.php:388 mod/cal.php:283
 msgid "today"
 msgstr ""
 
@@ -1508,364 +951,6 @@ msgstr ""
 msgid "Export calendar as csv"
 msgstr ""
 
-#: include/follow.php:77 mod/dfrn_request.php:507
-msgid "Disallowed profile URL."
-msgstr ""
-
-#: include/follow.php:82
-msgid "Connect URL missing."
-msgstr ""
-
-#: include/follow.php:109
-msgid ""
-"This site is not configured to allow communications with other networks."
-msgstr ""
-
-#: include/follow.php:110 include/follow.php:130
-msgid "No compatible communication protocols or feeds were discovered."
-msgstr ""
-
-#: include/follow.php:128
-msgid "The profile address specified does not provide adequate information."
-msgstr ""
-
-#: include/follow.php:132
-msgid "An author or name was not found."
-msgstr ""
-
-#: include/follow.php:134
-msgid "No browser URL could be matched to this address."
-msgstr ""
-
-#: include/follow.php:136
-msgid ""
-"Unable to match @-style Identity Address with a known protocol or email "
-"contact."
-msgstr ""
-
-#: include/follow.php:137
-msgid "Use mailto: in front of address to force email check."
-msgstr ""
-
-#: include/follow.php:143
-msgid ""
-"The profile address specified belongs to a network which has been disabled "
-"on this site."
-msgstr ""
-
-#: include/follow.php:153
-msgid ""
-"Limited profile. This person will be unable to receive direct/personal "
-"notifications from you."
-msgstr ""
-
-#: include/follow.php:254
-msgid "Unable to retrieve contact information."
-msgstr ""
-
-#: include/follow.php:287
-msgid "following"
-msgstr ""
-
-#: include/nav.php:35 mod/navigation.php:19
-msgid "Nothing new here"
-msgstr ""
-
-#: include/nav.php:39 mod/navigation.php:23
-msgid "Clear notifications"
-msgstr ""
-
-#: include/nav.php:40 include/text.php:1015
-msgid "@name, !forum, #tags, content"
-msgstr ""
-
-#: include/nav.php:78 view/theme/frio/theme.php:243 boot.php:1787
-msgid "Logout"
-msgstr ""
-
-#: include/nav.php:78 view/theme/frio/theme.php:243
-msgid "End this session"
-msgstr ""
-
-#: include/nav.php:81 include/identity.php:714 mod/contacts.php:637
-#: mod/contacts.php:833 view/theme/frio/theme.php:246
-msgid "Status"
-msgstr ""
-
-#: include/nav.php:81 include/nav.php:161 view/theme/frio/theme.php:246
-msgid "Your posts and conversations"
-msgstr ""
-
-#: include/nav.php:82 include/identity.php:605 include/identity.php:691
-#: include/identity.php:722 mod/profperm.php:104 mod/newmember.php:32
-#: mod/contacts.php:639 mod/contacts.php:841 view/theme/frio/theme.php:247
-msgid "Profile"
-msgstr ""
-
-#: include/nav.php:82 view/theme/frio/theme.php:247
-msgid "Your profile page"
-msgstr ""
-
-#: include/nav.php:83 include/identity.php:730 mod/fbrowser.php:32
-#: view/theme/frio/theme.php:248
-msgid "Photos"
-msgstr ""
-
-#: include/nav.php:83 view/theme/frio/theme.php:248
-msgid "Your photos"
-msgstr ""
-
-#: include/nav.php:84 include/identity.php:738 include/identity.php:741
-#: view/theme/frio/theme.php:249
-msgid "Videos"
-msgstr ""
-
-#: include/nav.php:84 view/theme/frio/theme.php:249
-msgid "Your videos"
-msgstr ""
-
-#: include/nav.php:85 include/nav.php:149 include/identity.php:750
-#: include/identity.php:761 mod/cal.php:275 mod/events.php:379
-#: view/theme/frio/theme.php:250 view/theme/frio/theme.php:254
-msgid "Events"
-msgstr ""
-
-#: include/nav.php:85 view/theme/frio/theme.php:250
-msgid "Your events"
-msgstr ""
-
-#: include/nav.php:86
-msgid "Personal notes"
-msgstr ""
-
-#: include/nav.php:86
-msgid "Your personal notes"
-msgstr ""
-
-#: include/nav.php:95 mod/bookmarklet.php:12 boot.php:1788
-msgid "Login"
-msgstr ""
-
-#: include/nav.php:95
-msgid "Sign in"
-msgstr ""
-
-#: include/nav.php:105 include/nav.php:161
-#: include/NotificationsManager.php:174
-msgid "Home"
-msgstr ""
-
-#: include/nav.php:105
-msgid "Home Page"
-msgstr ""
-
-#: include/nav.php:109 mod/register.php:289 boot.php:1763
-msgid "Register"
-msgstr ""
-
-#: include/nav.php:109
-msgid "Create an account"
-msgstr ""
-
-#: include/nav.php:115 mod/help.php:47 view/theme/vier/theme.php:298
-msgid "Help"
-msgstr ""
-
-#: include/nav.php:115
-msgid "Help and documentation"
-msgstr ""
-
-#: include/nav.php:119
-msgid "Apps"
-msgstr ""
-
-#: include/nav.php:119
-msgid "Addon applications, utilities, games"
-msgstr ""
-
-#: include/nav.php:123 include/text.php:1012 mod/search.php:149
-msgid "Search"
-msgstr ""
-
-#: include/nav.php:123
-msgid "Search site content"
-msgstr ""
-
-#: include/nav.php:126 include/text.php:1020
-msgid "Full Text"
-msgstr ""
-
-#: include/nav.php:127 include/text.php:1021
-msgid "Tags"
-msgstr ""
-
-#: include/nav.php:128 include/nav.php:192 include/identity.php:783
-#: include/identity.php:786 include/text.php:1022 mod/contacts.php:792
-#: mod/contacts.php:853 mod/viewcontacts.php:116 view/theme/frio/theme.php:257
-msgid "Contacts"
-msgstr ""
-
-#: include/nav.php:143 include/nav.php:145 mod/community.php:36
-msgid "Community"
-msgstr ""
-
-#: include/nav.php:143
-msgid "Conversations on this site"
-msgstr ""
-
-#: include/nav.php:145
-msgid "Conversations on the network"
-msgstr ""
-
-#: include/nav.php:149 include/identity.php:753 include/identity.php:764
-#: view/theme/frio/theme.php:254
-msgid "Events and Calendar"
-msgstr ""
-
-#: include/nav.php:152
-msgid "Directory"
-msgstr ""
-
-#: include/nav.php:152
-msgid "People directory"
-msgstr ""
-
-#: include/nav.php:154
-msgid "Information"
-msgstr ""
-
-#: include/nav.php:154
-msgid "Information about this friendica instance"
-msgstr ""
-
-#: include/nav.php:158 include/NotificationsManager.php:160 mod/admin.php:411
-#: view/theme/frio/theme.php:253
-msgid "Network"
-msgstr ""
-
-#: include/nav.php:158 view/theme/frio/theme.php:253
-msgid "Conversations from your friends"
-msgstr ""
-
-#: include/nav.php:159
-msgid "Network Reset"
-msgstr ""
-
-#: include/nav.php:159
-msgid "Load Network page with no filters"
-msgstr ""
-
-#: include/nav.php:166 include/NotificationsManager.php:181
-msgid "Introductions"
-msgstr ""
-
-#: include/nav.php:166
-msgid "Friend Requests"
-msgstr ""
-
-#: include/nav.php:169 mod/notifications.php:96
-msgid "Notifications"
-msgstr ""
-
-#: include/nav.php:170
-msgid "See all notifications"
-msgstr ""
-
-#: include/nav.php:171 mod/settings.php:902
-msgid "Mark as seen"
-msgstr ""
-
-#: include/nav.php:171
-msgid "Mark all system notifications seen"
-msgstr ""
-
-#: include/nav.php:175 mod/message.php:190 view/theme/frio/theme.php:255
-msgid "Messages"
-msgstr ""
-
-#: include/nav.php:175 view/theme/frio/theme.php:255
-msgid "Private mail"
-msgstr ""
-
-#: include/nav.php:176
-msgid "Inbox"
-msgstr ""
-
-#: include/nav.php:177
-msgid "Outbox"
-msgstr ""
-
-#: include/nav.php:178 mod/message.php:16
-msgid "New Message"
-msgstr ""
-
-#: include/nav.php:181
-msgid "Manage"
-msgstr ""
-
-#: include/nav.php:181
-msgid "Manage other pages"
-msgstr ""
-
-#: include/nav.php:184 mod/settings.php:81
-msgid "Delegations"
-msgstr ""
-
-#: include/nav.php:184 mod/delegate.php:130
-msgid "Delegate Page Management"
-msgstr ""
-
-#: include/nav.php:186 mod/newmember.php:22 mod/admin.php:1520
-#: mod/admin.php:1778 mod/settings.php:111 view/theme/frio/theme.php:256
-msgid "Settings"
-msgstr ""
-
-#: include/nav.php:186 view/theme/frio/theme.php:256
-msgid "Account settings"
-msgstr ""
-
-#: include/nav.php:189 include/identity.php:282
-msgid "Profiles"
-msgstr ""
-
-#: include/nav.php:189
-msgid "Manage/Edit Profiles"
-msgstr ""
-
-#: include/nav.php:192 view/theme/frio/theme.php:257
-msgid "Manage/edit friends and contacts"
-msgstr ""
-
-#: include/nav.php:197 mod/admin.php:186
-msgid "Admin"
-msgstr ""
-
-#: include/nav.php:197
-msgid "Site setup and configuration"
-msgstr ""
-
-#: include/nav.php:200
-msgid "Navigation"
-msgstr ""
-
-#: include/nav.php:200
-msgid "Site map"
-msgstr ""
-
-#: include/oembed.php:252
-msgid "Embedded content"
-msgstr ""
-
-#: include/oembed.php:260
-msgid "Embedding disabled"
-msgstr ""
-
-#: include/photos.php:53 mod/fbrowser.php:41 mod/fbrowser.php:62
-#: mod/photos.php:180 mod/photos.php:1086 mod/photos.php:1211
-#: mod/photos.php:1232 mod/photos.php:1795 mod/photos.php:1807
-msgid "Contact Photos"
-msgstr ""
-
 #: include/security.php:22
 msgid "Welcome "
 msgstr ""
@@ -1884,829 +969,298 @@ msgid ""
 "form has been opened for too long (>3 hours) before submitting it."
 msgstr ""
 
-#: include/Contact.php:119
-msgid "stopped following"
+#: include/profile_selectors.php:6
+msgid "Male"
 msgstr ""
 
-#: include/Contact.php:361 include/Contact.php:374 include/Contact.php:419
-#: include/conversation.php:968 include/conversation.php:984
-#: mod/allfriends.php:65 mod/directory.php:155 mod/dirfind.php:203
-#: mod/match.php:71 mod/suggest.php:82
-msgid "View Profile"
+#: include/profile_selectors.php:6
+msgid "Female"
 msgstr ""
 
-#: include/Contact.php:418 include/conversation.php:967
-msgid "View Status"
+#: include/profile_selectors.php:6
+msgid "Currently Male"
 msgstr ""
 
-#: include/Contact.php:420 include/conversation.php:969
-msgid "View Photos"
+#: include/profile_selectors.php:6
+msgid "Currently Female"
 msgstr ""
 
-#: include/Contact.php:421 include/conversation.php:970
-msgid "Network Posts"
+#: include/profile_selectors.php:6
+msgid "Mostly Male"
 msgstr ""
 
-#: include/Contact.php:422 include/conversation.php:971
-msgid "View Contact"
+#: include/profile_selectors.php:6
+msgid "Mostly Female"
 msgstr ""
 
-#: include/Contact.php:423
-msgid "Drop Contact"
+#: include/profile_selectors.php:6
+msgid "Transgender"
 msgstr ""
 
-#: include/Contact.php:424 include/conversation.php:972
-msgid "Send PM"
+#: include/profile_selectors.php:6
+msgid "Intersex"
 msgstr ""
 
-#: include/Contact.php:425 include/conversation.php:976
-msgid "Poke"
+#: include/profile_selectors.php:6
+msgid "Transsexual"
 msgstr ""
 
-#: include/Contact.php:798
-msgid "Organisation"
+#: include/profile_selectors.php:6
+msgid "Hermaphrodite"
 msgstr ""
 
-#: include/Contact.php:801
-msgid "News"
+#: include/profile_selectors.php:6
+msgid "Neuter"
 msgstr ""
 
-#: include/Contact.php:804
-msgid "Forum"
+#: include/profile_selectors.php:6
+msgid "Non-specific"
 msgstr ""
 
-#: include/NotificationsManager.php:153
-msgid "System"
+#: include/profile_selectors.php:6
+msgid "Other"
 msgstr ""
 
-#: include/NotificationsManager.php:167 mod/profiles.php:703
-#: mod/network.php:846
-msgid "Personal"
-msgstr ""
-
-#: include/NotificationsManager.php:234 include/NotificationsManager.php:244
-#, php-format
-msgid "%s commented on %s's post"
-msgstr ""
-
-#: include/NotificationsManager.php:243
-#, php-format
-msgid "%s created a new post"
-msgstr ""
-
-#: include/NotificationsManager.php:256
-#, php-format
-msgid "%s liked %s's post"
-msgstr ""
-
-#: include/NotificationsManager.php:267
-#, php-format
-msgid "%s disliked %s's post"
-msgstr ""
-
-#: include/NotificationsManager.php:278
-#, php-format
-msgid "%s is attending %s's event"
-msgstr ""
-
-#: include/NotificationsManager.php:289
-#, php-format
-msgid "%s is not attending %s's event"
-msgstr ""
-
-#: include/NotificationsManager.php:300
-#, php-format
-msgid "%s may attend %s's event"
-msgstr ""
-
-#: include/NotificationsManager.php:315
-#, php-format
-msgid "%s is now friends with %s"
-msgstr ""
-
-#: include/NotificationsManager.php:748
-msgid "Friend Suggestion"
-msgstr ""
-
-#: include/NotificationsManager.php:781
-msgid "Friend/Connect Request"
-msgstr ""
-
-#: include/NotificationsManager.php:781
-msgid "New Follower"
-msgstr ""
-
-#: include/api.php:1018
-#, php-format
-msgid "Daily posting limit of %d posts reached. The post was rejected."
-msgstr ""
-
-#: include/api.php:1038
-#, php-format
-msgid "Weekly posting limit of %d posts reached. The post was rejected."
-msgstr ""
-
-#: include/api.php:1059
-#, php-format
-msgid "Monthly posting limit of %d posts reached. The post was rejected."
-msgstr ""
-
-#: include/conversation.php:147
-#, php-format
-msgid "%1$s attends %2$s's %3$s"
-msgstr ""
-
-#: include/conversation.php:150
-#, php-format
-msgid "%1$s doesn't attend %2$s's %3$s"
-msgstr ""
-
-#: include/conversation.php:153
-#, php-format
-msgid "%1$s attends maybe %2$s's %3$s"
-msgstr ""
-
-#: include/conversation.php:185 mod/dfrn_confirm.php:473
-#, php-format
-msgid "%1$s is now friends with %2$s"
-msgstr ""
-
-#: include/conversation.php:219
-#, php-format
-msgid "%1$s poked %2$s"
-msgstr ""
-
-#: include/conversation.php:239 mod/mood.php:62
-#, php-format
-msgid "%1$s is currently %2$s"
-msgstr ""
-
-#: include/conversation.php:278 mod/tagger.php:95
-#, php-format
-msgid "%1$s tagged %2$s's %3$s with %4$s"
-msgstr ""
-
-#: include/conversation.php:303
-msgid "post/item"
-msgstr ""
-
-#: include/conversation.php:304
-#, php-format
-msgid "%1$s marked %2$s's %3$s as favorite"
-msgstr ""
-
-#: include/conversation.php:585 mod/content.php:372 mod/profiles.php:346
-#: mod/photos.php:1607
-msgid "Likes"
-msgstr ""
-
-#: include/conversation.php:585 mod/content.php:372 mod/profiles.php:350
-#: mod/photos.php:1607
-msgid "Dislikes"
-msgstr ""
-
-#: include/conversation.php:586 include/conversation.php:1477
-#: mod/content.php:373 mod/photos.php:1608
-msgid "Attending"
-msgid_plural "Attending"
+#: include/profile_selectors.php:6 include/conversation.php:1487
+msgid "Undecided"
+msgid_plural "Undecided"
 msgstr[0] ""
 msgstr[1] ""
 
-#: include/conversation.php:586 mod/content.php:373 mod/photos.php:1608
-msgid "Not attending"
+#: include/profile_selectors.php:23
+msgid "Males"
 msgstr ""
 
-#: include/conversation.php:586 mod/content.php:373 mod/photos.php:1608
-msgid "Might attend"
+#: include/profile_selectors.php:23
+msgid "Females"
 msgstr ""
 
-#: include/conversation.php:708 mod/content.php:453 mod/content.php:758
-#: mod/photos.php:1681 object/Item.php:133
-msgid "Select"
+#: include/profile_selectors.php:23
+msgid "Gay"
 msgstr ""
 
-#: include/conversation.php:709 mod/group.php:171 mod/content.php:454
-#: mod/content.php:759 mod/contacts.php:808 mod/contacts.php:1016
-#: mod/admin.php:1410 mod/photos.php:1682 mod/settings.php:741
-#: object/Item.php:134
-msgid "Delete"
+#: include/profile_selectors.php:23
+msgid "Lesbian"
 msgstr ""
 
-#: include/conversation.php:753 mod/content.php:487 mod/content.php:910
-#: mod/content.php:911 object/Item.php:367 object/Item.php:368
-#, php-format
-msgid "View %s's profile @ %s"
+#: include/profile_selectors.php:23
+msgid "No Preference"
 msgstr ""
 
-#: include/conversation.php:765 object/Item.php:355
-msgid "Categories:"
+#: include/profile_selectors.php:23
+msgid "Bisexual"
 msgstr ""
 
-#: include/conversation.php:766 object/Item.php:356
-msgid "Filed under:"
+#: include/profile_selectors.php:23
+msgid "Autosexual"
 msgstr ""
 
-#: include/conversation.php:773 mod/content.php:497 mod/content.php:923
-#: object/Item.php:381
-#, php-format
-msgid "%s from %s"
+#: include/profile_selectors.php:23
+msgid "Abstinent"
 msgstr ""
 
-#: include/conversation.php:789 mod/content.php:513
-msgid "View in context"
+#: include/profile_selectors.php:23
+msgid "Virgin"
 msgstr ""
 
-#: include/conversation.php:791 include/conversation.php:1261
-#: mod/editpost.php:124 mod/wallmessage.php:156 mod/message.php:356
-#: mod/message.php:548 mod/content.php:515 mod/content.php:948
-#: mod/photos.php:1570 object/Item.php:406
-msgid "Please wait"
+#: include/profile_selectors.php:23
+msgid "Deviant"
 msgstr ""
 
-#: include/conversation.php:870
-msgid "remove"
+#: include/profile_selectors.php:23
+msgid "Fetish"
 msgstr ""
 
-#: include/conversation.php:874
-msgid "Delete Selected Items"
+#: include/profile_selectors.php:23
+msgid "Oodles"
 msgstr ""
 
-#: include/conversation.php:966
-msgid "Follow Thread"
+#: include/profile_selectors.php:23
+msgid "Nonsexual"
 msgstr ""
 
-#: include/conversation.php:1094
-#, php-format
-msgid "%s likes this."
+#: include/profile_selectors.php:42
+msgid "Single"
 msgstr ""
 
-#: include/conversation.php:1097
-#, php-format
-msgid "%s doesn't like this."
+#: include/profile_selectors.php:42
+msgid "Lonely"
 msgstr ""
 
-#: include/conversation.php:1100
-#, php-format
-msgid "%s attends."
+#: include/profile_selectors.php:42
+msgid "Available"
 msgstr ""
 
-#: include/conversation.php:1103
-#, php-format
-msgid "%s doesn't attend."
+#: include/profile_selectors.php:42
+msgid "Unavailable"
 msgstr ""
 
-#: include/conversation.php:1106
-#, php-format
-msgid "%s attends maybe."
+#: include/profile_selectors.php:42
+msgid "Has crush"
 msgstr ""
 
-#: include/conversation.php:1116
-msgid "and"
+#: include/profile_selectors.php:42
+msgid "Infatuated"
 msgstr ""
 
-#: include/conversation.php:1122
-#, php-format
-msgid ", and %d other people"
+#: include/profile_selectors.php:42
+msgid "Dating"
 msgstr ""
 
-#: include/conversation.php:1131
-#, php-format
-msgid "<span  %1$s>%2$d people</span> like this"
+#: include/profile_selectors.php:42
+msgid "Unfaithful"
 msgstr ""
 
-#: include/conversation.php:1132
-#, php-format
-msgid "%s like this."
+#: include/profile_selectors.php:42
+msgid "Sex Addict"
 msgstr ""
 
-#: include/conversation.php:1135
-#, php-format
-msgid "<span  %1$s>%2$d people</span> don't like this"
+#: include/profile_selectors.php:42 include/user.php:299 include/user.php:303
+msgid "Friends"
 msgstr ""
 
-#: include/conversation.php:1136
-#, php-format
-msgid "%s don't like this."
+#: include/profile_selectors.php:42
+msgid "Friends/Benefits"
 msgstr ""
 
-#: include/conversation.php:1139
-#, php-format
-msgid "<span  %1$s>%2$d people</span> attend"
+#: include/profile_selectors.php:42
+msgid "Casual"
 msgstr ""
 
-#: include/conversation.php:1140
-#, php-format
-msgid "%s attend."
+#: include/profile_selectors.php:42
+msgid "Engaged"
 msgstr ""
 
-#: include/conversation.php:1143
-#, php-format
-msgid "<span  %1$s>%2$d people</span> don't attend"
+#: include/profile_selectors.php:42
+msgid "Married"
 msgstr ""
 
-#: include/conversation.php:1144
-#, php-format
-msgid "%s don't attend."
+#: include/profile_selectors.php:42
+msgid "Imaginarily married"
 msgstr ""
 
-#: include/conversation.php:1147
-#, php-format
-msgid "<span  %1$s>%2$d people</span> attend maybe"
+#: include/profile_selectors.php:42
+msgid "Partners"
 msgstr ""
 
-#: include/conversation.php:1148
-#, php-format
-msgid "%s anttend maybe."
+#: include/profile_selectors.php:42
+msgid "Cohabiting"
 msgstr ""
 
-#: include/conversation.php:1187 include/conversation.php:1205
-msgid "Visible to <strong>everybody</strong>"
+#: include/profile_selectors.php:42
+msgid "Common law"
 msgstr ""
 
-#: include/conversation.php:1188 include/conversation.php:1206
-#: mod/wallmessage.php:127 mod/wallmessage.php:135 mod/message.php:291
-#: mod/message.php:299 mod/message.php:442 mod/message.php:450
-msgid "Please enter a link URL:"
+#: include/profile_selectors.php:42
+msgid "Happy"
 msgstr ""
 
-#: include/conversation.php:1189 include/conversation.php:1207
-msgid "Please enter a video link/URL:"
+#: include/profile_selectors.php:42
+msgid "Not looking"
 msgstr ""
 
-#: include/conversation.php:1190 include/conversation.php:1208
-msgid "Please enter an audio link/URL:"
+#: include/profile_selectors.php:42
+msgid "Swinger"
 msgstr ""
 
-#: include/conversation.php:1191 include/conversation.php:1209
-msgid "Tag term:"
+#: include/profile_selectors.php:42
+msgid "Betrayed"
 msgstr ""
 
-#: include/conversation.php:1192 include/conversation.php:1210
-#: mod/filer.php:30
-msgid "Save to Folder:"
+#: include/profile_selectors.php:42
+msgid "Separated"
 msgstr ""
 
-#: include/conversation.php:1193 include/conversation.php:1211
-msgid "Where are you right now?"
+#: include/profile_selectors.php:42
+msgid "Unstable"
 msgstr ""
 
-#: include/conversation.php:1194
-msgid "Delete item(s)?"
+#: include/profile_selectors.php:42
+msgid "Divorced"
 msgstr ""
 
-#: include/conversation.php:1242 mod/photos.php:1569
-msgid "Share"
+#: include/profile_selectors.php:42
+msgid "Imaginarily divorced"
 msgstr ""
 
-#: include/conversation.php:1243 mod/editpost.php:110 mod/wallmessage.php:154
-#: mod/message.php:354 mod/message.php:545
-msgid "Upload photo"
+#: include/profile_selectors.php:42
+msgid "Widowed"
 msgstr ""
 
-#: include/conversation.php:1244 mod/editpost.php:111
-msgid "upload photo"
+#: include/profile_selectors.php:42
+msgid "Uncertain"
 msgstr ""
 
-#: include/conversation.php:1245 mod/editpost.php:112
-msgid "Attach file"
+#: include/profile_selectors.php:42
+msgid "It's complicated"
 msgstr ""
 
-#: include/conversation.php:1246 mod/editpost.php:113
-msgid "attach file"
+#: include/profile_selectors.php:42
+msgid "Don't care"
 msgstr ""
 
-#: include/conversation.php:1247 mod/editpost.php:114 mod/wallmessage.php:155
-#: mod/message.php:355 mod/message.php:546
-msgid "Insert web link"
+#: include/profile_selectors.php:42
+msgid "Ask me"
 msgstr ""
 
-#: include/conversation.php:1248 mod/editpost.php:115
-msgid "web link"
-msgstr ""
-
-#: include/conversation.php:1249 mod/editpost.php:116
-msgid "Insert video link"
-msgstr ""
-
-#: include/conversation.php:1250 mod/editpost.php:117
-msgid "video link"
-msgstr ""
-
-#: include/conversation.php:1251 mod/editpost.php:118
-msgid "Insert audio link"
-msgstr ""
-
-#: include/conversation.php:1252 mod/editpost.php:119
-msgid "audio link"
-msgstr ""
-
-#: include/conversation.php:1253 mod/editpost.php:120
-msgid "Set your location"
-msgstr ""
-
-#: include/conversation.php:1254 mod/editpost.php:121
-msgid "set location"
-msgstr ""
-
-#: include/conversation.php:1255 mod/editpost.php:122
-msgid "Clear browser location"
-msgstr ""
-
-#: include/conversation.php:1256 mod/editpost.php:123
-msgid "clear location"
-msgstr ""
-
-#: include/conversation.php:1258 mod/editpost.php:137
-msgid "Set title"
-msgstr ""
-
-#: include/conversation.php:1260 mod/editpost.php:139
-msgid "Categories (comma-separated list)"
-msgstr ""
-
-#: include/conversation.php:1262 mod/editpost.php:125
-msgid "Permission settings"
-msgstr ""
-
-#: include/conversation.php:1263 mod/editpost.php:154
-msgid "permissions"
-msgstr ""
-
-#: include/conversation.php:1271 mod/editpost.php:134
-msgid "Public post"
-msgstr ""
-
-#: include/conversation.php:1276 mod/editpost.php:145 mod/content.php:737
-#: mod/events.php:504 mod/photos.php:1591 mod/photos.php:1639
-#: mod/photos.php:1725 object/Item.php:729
-msgid "Preview"
-msgstr ""
-
-#: include/conversation.php:1280 include/items.php:1952 mod/fbrowser.php:101
-#: mod/fbrowser.php:136 mod/tagrm.php:11 mod/tagrm.php:94 mod/follow.php:121
-#: mod/editpost.php:148 mod/message.php:220 mod/dfrn_request.php:875
-#: mod/contacts.php:445 mod/suggest.php:32 mod/photos.php:235
-#: mod/photos.php:322 mod/settings.php:679 mod/settings.php:705
-#: mod/videos.php:128
-msgid "Cancel"
-msgstr ""
-
-#: include/conversation.php:1286
-msgid "Post to Groups"
-msgstr ""
-
-#: include/conversation.php:1287
-msgid "Post to Contacts"
-msgstr ""
-
-#: include/conversation.php:1288
-msgid "Private post"
-msgstr ""
-
-#: include/conversation.php:1293 include/identity.php:256 mod/editpost.php:152
-msgid "Message"
-msgstr ""
-
-#: include/conversation.php:1294 mod/editpost.php:153
-msgid "Browser"
-msgstr ""
-
-#: include/conversation.php:1449
-msgid "View all"
-msgstr ""
-
-#: include/conversation.php:1471
-msgid "Like"
-msgid_plural "Likes"
-msgstr[0] ""
-msgstr[1] ""
-
-#: include/conversation.php:1474
-msgid "Dislike"
-msgid_plural "Dislikes"
-msgstr[0] ""
-msgstr[1] ""
-
-#: include/conversation.php:1480
-msgid "Not Attending"
-msgid_plural "Not Attending"
-msgstr[0] ""
-msgstr[1] ""
-
-#: include/dbstructure.php:26
-#, php-format
-msgid ""
-"\n"
-"\t\t\tThe friendica developers released update %s recently,\n"
-"\t\t\tbut when I tried to install it, something went terribly wrong.\n"
-"\t\t\tThis needs to be fixed soon and I can't do it alone. Please contact a\n"
-"\t\t\tfriendica developer if you can not help me on your own. My database "
-"might be invalid."
-msgstr ""
-
-#: include/dbstructure.php:31
-#, php-format
-msgid ""
-"The error message is\n"
-"[pre]%s[/pre]"
-msgstr ""
-
-#: include/dbstructure.php:183
-msgid "Errors encountered creating database tables."
-msgstr ""
-
-#: include/dbstructure.php:260
-msgid "Errors encountered performing database changes."
-msgstr ""
-
-#: include/delivery.php:446
-msgid "(no subject)"
-msgstr ""
-
-#: include/dfrn.php:1107
-#, php-format
-msgid "%s\\'s birthday"
-msgstr ""
-
-#: include/diaspora.php:1958
-msgid "Sharing notification from Diaspora network"
-msgstr ""
-
-#: include/diaspora.php:2864
-msgid "Attachments:"
-msgstr ""
-
-#: include/identity.php:42
-msgid "Requested account is not available."
-msgstr ""
-
-#: include/identity.php:51 mod/profile.php:21
-msgid "Requested profile is not available."
-msgstr ""
-
-#: include/identity.php:95 include/identity.php:311 include/identity.php:688
-msgid "Edit profile"
-msgstr ""
-
-#: include/identity.php:251
-msgid "Atom feed"
-msgstr ""
-
-#: include/identity.php:282
-msgid "Manage/edit profiles"
-msgstr ""
-
-#: include/identity.php:287 include/identity.php:313 mod/profiles.php:795
-msgid "Change profile photo"
-msgstr ""
-
-#: include/identity.php:288 mod/profiles.php:796
-msgid "Create New Profile"
-msgstr ""
-
-#: include/identity.php:298 mod/profiles.php:785
-msgid "Profile Image"
-msgstr ""
-
-#: include/identity.php:301 mod/profiles.php:787
-msgid "visible to everybody"
-msgstr ""
-
-#: include/identity.php:302 mod/profiles.php:691 mod/profiles.php:788
-msgid "Edit visibility"
-msgstr ""
-
-#: include/identity.php:330 include/identity.php:616 mod/notifications.php:238
-#: mod/directory.php:139
-msgid "Gender:"
-msgstr ""
-
-#: include/identity.php:333 include/identity.php:636 mod/directory.php:141
-msgid "Status:"
-msgstr ""
-
-#: include/identity.php:335 include/identity.php:647 mod/directory.php:143
-msgid "Homepage:"
-msgstr ""
-
-#: include/identity.php:337 include/identity.php:657 mod/notifications.php:234
-#: mod/contacts.php:632 mod/directory.php:145
-msgid "About:"
-msgstr ""
-
-#: include/identity.php:339 mod/contacts.php:630
-msgid "XMPP:"
-msgstr ""
-
-#: include/identity.php:422 mod/notifications.php:246 mod/contacts.php:50
-msgid "Network:"
-msgstr ""
-
-#: include/identity.php:451 include/identity.php:535
-msgid "g A l F d"
-msgstr ""
-
-#: include/identity.php:452 include/identity.php:536
-msgid "F d"
-msgstr ""
-
-#: include/identity.php:497 include/identity.php:582
-msgid "[today]"
-msgstr ""
-
-#: include/identity.php:509
-msgid "Birthday Reminders"
-msgstr ""
-
-#: include/identity.php:510
-msgid "Birthdays this week:"
-msgstr ""
-
-#: include/identity.php:569
-msgid "[No description]"
-msgstr ""
-
-#: include/identity.php:593
-msgid "Event Reminders"
-msgstr ""
-
-#: include/identity.php:594
-msgid "Events this week:"
-msgstr ""
-
-#: include/identity.php:614 mod/settings.php:1279
-msgid "Full Name:"
-msgstr ""
-
-#: include/identity.php:621
-msgid "j F, Y"
-msgstr ""
-
-#: include/identity.php:622
-msgid "j F"
-msgstr ""
-
-#: include/identity.php:633
-msgid "Age:"
-msgstr ""
-
-#: include/identity.php:642
-#, php-format
-msgid "for %1$d %2$s"
-msgstr ""
-
-#: include/identity.php:645 mod/profiles.php:710
-msgid "Sexual Preference:"
-msgstr ""
-
-#: include/identity.php:649 mod/profiles.php:737
-msgid "Hometown:"
-msgstr ""
-
-#: include/identity.php:651 mod/follow.php:134 mod/notifications.php:236
-#: mod/contacts.php:634
-msgid "Tags:"
-msgstr ""
-
-#: include/identity.php:653 mod/profiles.php:738
-msgid "Political Views:"
-msgstr ""
-
-#: include/identity.php:655
-msgid "Religion:"
-msgstr ""
-
-#: include/identity.php:659
-msgid "Hobbies/Interests:"
-msgstr ""
-
-#: include/identity.php:661 mod/profiles.php:742
-msgid "Likes:"
-msgstr ""
-
-#: include/identity.php:663 mod/profiles.php:743
-msgid "Dislikes:"
-msgstr ""
-
-#: include/identity.php:666
-msgid "Contact information and Social Networks:"
-msgstr ""
-
-#: include/identity.php:668
-msgid "Musical interests:"
-msgstr ""
-
-#: include/identity.php:670
-msgid "Books, literature:"
-msgstr ""
-
-#: include/identity.php:672
-msgid "Television:"
-msgstr ""
-
-#: include/identity.php:674
-msgid "Film/dance/culture/entertainment:"
-msgstr ""
-
-#: include/identity.php:676
-msgid "Love/Romance:"
-msgstr ""
-
-#: include/identity.php:678
-msgid "Work/employment:"
-msgstr ""
-
-#: include/identity.php:680
-msgid "School/education:"
-msgstr ""
-
-#: include/identity.php:684
-msgid "Forums:"
-msgstr ""
-
-#: include/identity.php:692 mod/events.php:507
-msgid "Basic"
-msgstr ""
-
-#: include/identity.php:693 mod/contacts.php:870 mod/events.php:508
-#: mod/admin.php:956
-msgid "Advanced"
-msgstr ""
-
-#: include/identity.php:717 mod/follow.php:143 mod/contacts.php:836
-msgid "Status Messages and Posts"
-msgstr ""
-
-#: include/identity.php:725 mod/contacts.php:844
-msgid "Profile Details"
-msgstr ""
-
-#: include/identity.php:733 mod/photos.php:87
-msgid "Photo Albums"
-msgstr ""
-
-#: include/identity.php:772 mod/notes.php:46
-msgid "Personal Notes"
-msgstr ""
-
-#: include/identity.php:775
-msgid "Only You Can See This"
-msgstr ""
-
-#: include/items.php:1553 mod/dfrn_request.php:745 mod/dfrn_confirm.php:726
+#: include/items.php:1571 mod/dfrn_confirm.php:730 mod/dfrn_request.php:746
 msgid "[Name Withheld]"
 msgstr ""
 
-#: include/items.php:1908 mod/viewsrc.php:15 mod/notice.php:15
-#: mod/display.php:103 mod/display.php:279 mod/display.php:478
-#: mod/admin.php:234 mod/admin.php:1467 mod/admin.php:1701
+#: include/items.php:1926 mod/viewsrc.php:15 mod/admin.php:234
+#: mod/admin.php:1471 mod/admin.php:1705 mod/display.php:103
+#: mod/display.php:279 mod/display.php:478 mod/notice.php:15
 msgid "Item not found."
 msgstr ""
 
-#: include/items.php:1947
+#: include/items.php:1965
 msgid "Do you really want to delete this item?"
 msgstr ""
 
-#: include/items.php:1949 mod/follow.php:110 mod/api.php:105
-#: mod/message.php:217 mod/dfrn_request.php:861 mod/profiles.php:648
-#: mod/profiles.php:651 mod/profiles.php:677 mod/contacts.php:442
-#: mod/suggest.php:29 mod/register.php:245 mod/settings.php:1163
-#: mod/settings.php:1169 mod/settings.php:1177 mod/settings.php:1181
-#: mod/settings.php:1186 mod/settings.php:1192 mod/settings.php:1198
-#: mod/settings.php:1204 mod/settings.php:1230 mod/settings.php:1231
-#: mod/settings.php:1232 mod/settings.php:1233 mod/settings.php:1234
+#: include/items.php:1967 mod/profiles.php:648 mod/profiles.php:651
+#: mod/profiles.php:677 mod/contacts.php:442 mod/follow.php:110
+#: mod/suggest.php:29 mod/dfrn_request.php:862 mod/register.php:245
+#: mod/settings.php:1163 mod/settings.php:1169 mod/settings.php:1177
+#: mod/settings.php:1181 mod/settings.php:1186 mod/settings.php:1192
+#: mod/settings.php:1198 mod/settings.php:1204 mod/settings.php:1230
+#: mod/settings.php:1231 mod/settings.php:1232 mod/settings.php:1233
+#: mod/settings.php:1234 mod/api.php:105 mod/message.php:217
 msgid "Yes"
 msgstr ""
 
-#: include/items.php:2112 mod/notes.php:22 mod/uimport.php:23
-#: mod/nogroup.php:25 mod/invite.php:15 mod/invite.php:101
-#: mod/repair_ostatus.php:9 mod/delegate.php:12 mod/attach.php:33
-#: mod/follow.php:11 mod/follow.php:73 mod/follow.php:155 mod/editpost.php:10
-#: mod/group.php:19 mod/wallmessage.php:9 mod/wallmessage.php:33
-#: mod/wallmessage.php:79 mod/wallmessage.php:103 mod/api.php:26
-#: mod/api.php:31 mod/ostatus_subscribe.php:9 mod/message.php:46
-#: mod/message.php:182 mod/manage.php:96 mod/crepair.php:100
-#: mod/dfrn_confirm.php:57 mod/fsuggest.php:78 mod/mood.php:114
-#: mod/poke.php:150 mod/profile_photo.php:19 mod/profile_photo.php:175
-#: mod/profile_photo.php:186 mod/profile_photo.php:199 mod/regmod.php:110
-#: mod/notifications.php:71 mod/profiles.php:166 mod/profiles.php:605
-#: mod/allfriends.php:12 mod/cal.php:304 mod/common.php:18
-#: mod/contacts.php:350 mod/dirfind.php:11 mod/display.php:475
-#: mod/events.php:190 mod/suggest.php:58 mod/item.php:198 mod/item.php:210
-#: mod/network.php:4 mod/photos.php:159 mod/photos.php:1072
-#: mod/register.php:42 mod/settings.php:22 mod/settings.php:128
-#: mod/settings.php:665 mod/viewcontacts.php:45 mod/wall_attach.php:67
-#: mod/wall_attach.php:70 mod/wall_upload.php:77 mod/wall_upload.php:80
-#: index.php:397
+#: include/items.php:1970 include/conversation.php:1283 mod/fbrowser.php:101
+#: mod/fbrowser.php:136 mod/tagrm.php:11 mod/tagrm.php:94 mod/videos.php:128
+#: mod/photos.php:235 mod/photos.php:322 mod/contacts.php:445
+#: mod/follow.php:121 mod/suggest.php:32 mod/editpost.php:148
+#: mod/dfrn_request.php:876 mod/settings.php:679 mod/settings.php:705
+#: mod/message.php:220
+msgid "Cancel"
+msgstr ""
+
+#: include/items.php:2130 index.php:401 mod/regmod.php:110 mod/dirfind.php:11
+#: mod/notifications.php:71 mod/dfrn_confirm.php:61 mod/wall_upload.php:77
+#: mod/wall_upload.php:80 mod/fsuggest.php:78 mod/notes.php:22
+#: mod/events.php:190 mod/uimport.php:23 mod/nogroup.php:25 mod/invite.php:15
+#: mod/invite.php:101 mod/viewcontacts.php:45 mod/crepair.php:100
+#: mod/wall_attach.php:67 mod/wall_attach.php:70 mod/allfriends.php:12
+#: mod/cal.php:304 mod/repair_ostatus.php:9 mod/delegate.php:12
+#: mod/profiles.php:166 mod/profiles.php:605 mod/poke.php:150
+#: mod/photos.php:159 mod/photos.php:1072 mod/attach.php:33
+#: mod/contacts.php:350 mod/follow.php:11 mod/follow.php:73 mod/follow.php:155
+#: mod/suggest.php:58 mod/display.php:475 mod/common.php:18 mod/mood.php:114
+#: mod/editpost.php:10 mod/network.php:4 mod/group.php:19
+#: mod/profile_photo.php:19 mod/profile_photo.php:175
+#: mod/profile_photo.php:186 mod/profile_photo.php:199 mod/register.php:42
+#: mod/settings.php:22 mod/settings.php:128 mod/settings.php:665
+#: mod/wallmessage.php:9 mod/wallmessage.php:33 mod/wallmessage.php:79
+#: mod/wallmessage.php:103 mod/api.php:26 mod/api.php:31 mod/item.php:198
+#: mod/item.php:210 mod/ostatus_subscribe.php:9 mod/message.php:46
+#: mod/message.php:182 mod/manage.php:96
 msgid "Permission denied."
 msgstr ""
 
-#: include/items.php:2217
+#: include/items.php:2235
 msgid "Archives"
-msgstr ""
-
-#: include/network.php:595
-msgid "view full size"
 msgstr ""
 
 #: include/text.php:304
@@ -2756,9 +1310,31 @@ msgstr[1] ""
 msgid "View Contacts"
 msgstr ""
 
+#: include/text.php:1012 include/nav.php:123 mod/search.php:149
+msgid "Search"
+msgstr ""
+
 #: include/text.php:1013 mod/notes.php:61 mod/filer.php:31
 #: mod/editpost.php:109
 msgid "Save"
+msgstr ""
+
+#: include/text.php:1015 include/nav.php:40
+msgid "@name, !forum, #tags, content"
+msgstr ""
+
+#: include/text.php:1020 include/nav.php:126
+msgid "Full Text"
+msgstr ""
+
+#: include/text.php:1021 include/nav.php:127
+msgid "Tags"
+msgstr ""
+
+#: include/text.php:1022 include/identity.php:783 include/identity.php:786
+#: include/nav.php:128 include/nav.php:192 mod/viewcontacts.php:116
+#: mod/contacts.php:792 mod/contacts.php:853 view/theme/frio/theme.php:260
+msgid "Contacts"
 msgstr ""
 
 #: include/text.php:1076
@@ -2909,6 +1485,17 @@ msgstr ""
 msgid "view on separate page"
 msgstr ""
 
+#: include/text.php:1806 include/conversation.php:122
+#: include/conversation.php:258 include/like.php:165
+msgid "event"
+msgstr ""
+
+#: include/text.php:1808 include/conversation.php:130
+#: include/conversation.php:266 include/like.php:163 mod/tagger.php:62
+#: mod/subthread.php:87
+msgid "photo"
+msgstr ""
+
 #: include/text.php:1810
 msgid "activity"
 msgstr ""
@@ -2926,6 +1513,1001 @@ msgstr ""
 
 #: include/text.php:1981
 msgid "Item filed"
+msgstr ""
+
+#: include/conversation.php:144 include/like.php:184
+#, php-format
+msgid "%1$s doesn't like %2$s's %3$s"
+msgstr ""
+
+#: include/conversation.php:147
+#, php-format
+msgid "%1$s attends %2$s's %3$s"
+msgstr ""
+
+#: include/conversation.php:150
+#, php-format
+msgid "%1$s doesn't attend %2$s's %3$s"
+msgstr ""
+
+#: include/conversation.php:153
+#, php-format
+msgid "%1$s attends maybe %2$s's %3$s"
+msgstr ""
+
+#: include/conversation.php:185 mod/dfrn_confirm.php:477
+#, php-format
+msgid "%1$s is now friends with %2$s"
+msgstr ""
+
+#: include/conversation.php:219
+#, php-format
+msgid "%1$s poked %2$s"
+msgstr ""
+
+#: include/conversation.php:239 mod/mood.php:62
+#, php-format
+msgid "%1$s is currently %2$s"
+msgstr ""
+
+#: include/conversation.php:278 mod/tagger.php:95
+#, php-format
+msgid "%1$s tagged %2$s's %3$s with %4$s"
+msgstr ""
+
+#: include/conversation.php:303
+msgid "post/item"
+msgstr ""
+
+#: include/conversation.php:304
+#, php-format
+msgid "%1$s marked %2$s's %3$s as favorite"
+msgstr ""
+
+#: include/conversation.php:585 mod/content.php:372 mod/profiles.php:346
+#: mod/photos.php:1607
+msgid "Likes"
+msgstr ""
+
+#: include/conversation.php:585 mod/content.php:372 mod/profiles.php:350
+#: mod/photos.php:1607
+msgid "Dislikes"
+msgstr ""
+
+#: include/conversation.php:586 include/conversation.php:1481
+#: mod/content.php:373 mod/photos.php:1608
+msgid "Attending"
+msgid_plural "Attending"
+msgstr[0] ""
+msgstr[1] ""
+
+#: include/conversation.php:586 mod/content.php:373 mod/photos.php:1608
+msgid "Not attending"
+msgstr ""
+
+#: include/conversation.php:586 mod/content.php:373 mod/photos.php:1608
+msgid "Might attend"
+msgstr ""
+
+#: include/conversation.php:708 mod/content.php:453 mod/content.php:758
+#: mod/photos.php:1681 object/Item.php:133
+msgid "Select"
+msgstr ""
+
+#: include/conversation.php:709 mod/admin.php:1414 mod/content.php:454
+#: mod/content.php:759 mod/photos.php:1682 mod/contacts.php:808
+#: mod/contacts.php:1016 mod/group.php:171 mod/settings.php:741
+#: object/Item.php:134
+msgid "Delete"
+msgstr ""
+
+#: include/conversation.php:753 mod/content.php:487 mod/content.php:910
+#: mod/content.php:911 object/Item.php:367 object/Item.php:368
+#, php-format
+msgid "View %s's profile @ %s"
+msgstr ""
+
+#: include/conversation.php:765 object/Item.php:355
+msgid "Categories:"
+msgstr ""
+
+#: include/conversation.php:766 object/Item.php:356
+msgid "Filed under:"
+msgstr ""
+
+#: include/conversation.php:773 mod/content.php:497 mod/content.php:923
+#: object/Item.php:381
+#, php-format
+msgid "%s from %s"
+msgstr ""
+
+#: include/conversation.php:789 mod/content.php:513
+msgid "View in context"
+msgstr ""
+
+#: include/conversation.php:791 include/conversation.php:1264
+#: mod/content.php:515 mod/content.php:948 mod/photos.php:1570
+#: mod/editpost.php:124 mod/wallmessage.php:156 mod/message.php:356
+#: mod/message.php:548 object/Item.php:406
+msgid "Please wait"
+msgstr ""
+
+#: include/conversation.php:870
+msgid "remove"
+msgstr ""
+
+#: include/conversation.php:874
+msgid "Delete Selected Items"
+msgstr ""
+
+#: include/conversation.php:966
+msgid "Follow Thread"
+msgstr ""
+
+#: include/conversation.php:967 include/Contact.php:404
+msgid "View Status"
+msgstr ""
+
+#: include/conversation.php:968 include/conversation.php:984
+#: include/Contact.php:347 include/Contact.php:360 include/Contact.php:405
+#: mod/dirfind.php:203 mod/directory.php:155 mod/match.php:71
+#: mod/allfriends.php:65 mod/suggest.php:82
+msgid "View Profile"
+msgstr ""
+
+#: include/conversation.php:969 include/Contact.php:406
+msgid "View Photos"
+msgstr ""
+
+#: include/conversation.php:970 include/Contact.php:407
+msgid "Network Posts"
+msgstr ""
+
+#: include/conversation.php:971 include/Contact.php:408
+msgid "View Contact"
+msgstr ""
+
+#: include/conversation.php:972 include/Contact.php:410
+msgid "Send PM"
+msgstr ""
+
+#: include/conversation.php:976 include/Contact.php:411
+msgid "Poke"
+msgstr ""
+
+#: include/conversation.php:1097
+#, php-format
+msgid "%s likes this."
+msgstr ""
+
+#: include/conversation.php:1100
+#, php-format
+msgid "%s doesn't like this."
+msgstr ""
+
+#: include/conversation.php:1103
+#, php-format
+msgid "%s attends."
+msgstr ""
+
+#: include/conversation.php:1106
+#, php-format
+msgid "%s doesn't attend."
+msgstr ""
+
+#: include/conversation.php:1109
+#, php-format
+msgid "%s attends maybe."
+msgstr ""
+
+#: include/conversation.php:1119
+msgid "and"
+msgstr ""
+
+#: include/conversation.php:1125
+#, php-format
+msgid ", and %d other people"
+msgstr ""
+
+#: include/conversation.php:1134
+#, php-format
+msgid "<span  %1$s>%2$d people</span> like this"
+msgstr ""
+
+#: include/conversation.php:1135
+#, php-format
+msgid "%s like this."
+msgstr ""
+
+#: include/conversation.php:1138
+#, php-format
+msgid "<span  %1$s>%2$d people</span> don't like this"
+msgstr ""
+
+#: include/conversation.php:1139
+#, php-format
+msgid "%s don't like this."
+msgstr ""
+
+#: include/conversation.php:1142
+#, php-format
+msgid "<span  %1$s>%2$d people</span> attend"
+msgstr ""
+
+#: include/conversation.php:1143
+#, php-format
+msgid "%s attend."
+msgstr ""
+
+#: include/conversation.php:1146
+#, php-format
+msgid "<span  %1$s>%2$d people</span> don't attend"
+msgstr ""
+
+#: include/conversation.php:1147
+#, php-format
+msgid "%s don't attend."
+msgstr ""
+
+#: include/conversation.php:1150
+#, php-format
+msgid "<span  %1$s>%2$d people</span> attend maybe"
+msgstr ""
+
+#: include/conversation.php:1151
+#, php-format
+msgid "%s anttend maybe."
+msgstr ""
+
+#: include/conversation.php:1190 include/conversation.php:1208
+msgid "Visible to <strong>everybody</strong>"
+msgstr ""
+
+#: include/conversation.php:1191 include/conversation.php:1209
+#: mod/wallmessage.php:127 mod/wallmessage.php:135 mod/message.php:291
+#: mod/message.php:299 mod/message.php:442 mod/message.php:450
+msgid "Please enter a link URL:"
+msgstr ""
+
+#: include/conversation.php:1192 include/conversation.php:1210
+msgid "Please enter a video link/URL:"
+msgstr ""
+
+#: include/conversation.php:1193 include/conversation.php:1211
+msgid "Please enter an audio link/URL:"
+msgstr ""
+
+#: include/conversation.php:1194 include/conversation.php:1212
+msgid "Tag term:"
+msgstr ""
+
+#: include/conversation.php:1195 include/conversation.php:1213
+#: mod/filer.php:30
+msgid "Save to Folder:"
+msgstr ""
+
+#: include/conversation.php:1196 include/conversation.php:1214
+msgid "Where are you right now?"
+msgstr ""
+
+#: include/conversation.php:1197
+msgid "Delete item(s)?"
+msgstr ""
+
+#: include/conversation.php:1245 mod/photos.php:1569
+msgid "Share"
+msgstr ""
+
+#: include/conversation.php:1246 mod/editpost.php:110 mod/wallmessage.php:154
+#: mod/message.php:354 mod/message.php:545
+msgid "Upload photo"
+msgstr ""
+
+#: include/conversation.php:1247 mod/editpost.php:111
+msgid "upload photo"
+msgstr ""
+
+#: include/conversation.php:1248 mod/editpost.php:112
+msgid "Attach file"
+msgstr ""
+
+#: include/conversation.php:1249 mod/editpost.php:113
+msgid "attach file"
+msgstr ""
+
+#: include/conversation.php:1250 mod/editpost.php:114 mod/wallmessage.php:155
+#: mod/message.php:355 mod/message.php:546
+msgid "Insert web link"
+msgstr ""
+
+#: include/conversation.php:1251 mod/editpost.php:115
+msgid "web link"
+msgstr ""
+
+#: include/conversation.php:1252 mod/editpost.php:116
+msgid "Insert video link"
+msgstr ""
+
+#: include/conversation.php:1253 mod/editpost.php:117
+msgid "video link"
+msgstr ""
+
+#: include/conversation.php:1254 mod/editpost.php:118
+msgid "Insert audio link"
+msgstr ""
+
+#: include/conversation.php:1255 mod/editpost.php:119
+msgid "audio link"
+msgstr ""
+
+#: include/conversation.php:1256 mod/editpost.php:120
+msgid "Set your location"
+msgstr ""
+
+#: include/conversation.php:1257 mod/editpost.php:121
+msgid "set location"
+msgstr ""
+
+#: include/conversation.php:1258 mod/editpost.php:122
+msgid "Clear browser location"
+msgstr ""
+
+#: include/conversation.php:1259 mod/editpost.php:123
+msgid "clear location"
+msgstr ""
+
+#: include/conversation.php:1261 mod/editpost.php:137
+msgid "Set title"
+msgstr ""
+
+#: include/conversation.php:1263 mod/editpost.php:139
+msgid "Categories (comma-separated list)"
+msgstr ""
+
+#: include/conversation.php:1265 mod/editpost.php:125
+msgid "Permission settings"
+msgstr ""
+
+#: include/conversation.php:1266 mod/editpost.php:154
+msgid "permissions"
+msgstr ""
+
+#: include/conversation.php:1274 mod/editpost.php:134
+msgid "Public post"
+msgstr ""
+
+#: include/conversation.php:1279 mod/events.php:504 mod/content.php:737
+#: mod/photos.php:1591 mod/photos.php:1639 mod/photos.php:1725
+#: mod/editpost.php:145 object/Item.php:729
+msgid "Preview"
+msgstr ""
+
+#: include/conversation.php:1289
+msgid "Post to Groups"
+msgstr ""
+
+#: include/conversation.php:1290
+msgid "Post to Contacts"
+msgstr ""
+
+#: include/conversation.php:1291
+msgid "Private post"
+msgstr ""
+
+#: include/conversation.php:1296 include/identity.php:256 mod/editpost.php:152
+msgid "Message"
+msgstr ""
+
+#: include/conversation.php:1297 mod/editpost.php:153
+msgid "Browser"
+msgstr ""
+
+#: include/conversation.php:1453
+msgid "View all"
+msgstr ""
+
+#: include/conversation.php:1475
+msgid "Like"
+msgid_plural "Likes"
+msgstr[0] ""
+msgstr[1] ""
+
+#: include/conversation.php:1478
+msgid "Dislike"
+msgid_plural "Dislikes"
+msgstr[0] ""
+msgstr[1] ""
+
+#: include/conversation.php:1484
+msgid "Not Attending"
+msgid_plural "Not Attending"
+msgstr[0] ""
+msgstr[1] ""
+
+#: include/photos.php:53 mod/fbrowser.php:41 mod/fbrowser.php:62
+#: mod/photos.php:180 mod/photos.php:1086 mod/photos.php:1211
+#: mod/photos.php:1232 mod/photos.php:1795 mod/photos.php:1807
+msgid "Contact Photos"
+msgstr ""
+
+#: include/identity.php:42
+msgid "Requested account is not available."
+msgstr ""
+
+#: include/identity.php:51 mod/profile.php:21
+msgid "Requested profile is not available."
+msgstr ""
+
+#: include/identity.php:95 include/identity.php:311 include/identity.php:688
+msgid "Edit profile"
+msgstr ""
+
+#: include/identity.php:251
+msgid "Atom feed"
+msgstr ""
+
+#: include/identity.php:282 include/nav.php:189
+msgid "Profiles"
+msgstr ""
+
+#: include/identity.php:282
+msgid "Manage/edit profiles"
+msgstr ""
+
+#: include/identity.php:287 include/identity.php:313 mod/profiles.php:795
+msgid "Change profile photo"
+msgstr ""
+
+#: include/identity.php:288 mod/profiles.php:796
+msgid "Create New Profile"
+msgstr ""
+
+#: include/identity.php:298 mod/profiles.php:785
+msgid "Profile Image"
+msgstr ""
+
+#: include/identity.php:301 mod/profiles.php:787
+msgid "visible to everybody"
+msgstr ""
+
+#: include/identity.php:302 mod/profiles.php:691 mod/profiles.php:788
+msgid "Edit visibility"
+msgstr ""
+
+#: include/identity.php:330 include/identity.php:616 mod/notifications.php:238
+#: mod/directory.php:139
+msgid "Gender:"
+msgstr ""
+
+#: include/identity.php:333 include/identity.php:636 mod/directory.php:141
+msgid "Status:"
+msgstr ""
+
+#: include/identity.php:335 include/identity.php:647 mod/directory.php:143
+msgid "Homepage:"
+msgstr ""
+
+#: include/identity.php:337 include/identity.php:657 mod/notifications.php:234
+#: mod/directory.php:145 mod/contacts.php:632
+msgid "About:"
+msgstr ""
+
+#: include/identity.php:339 mod/contacts.php:630
+msgid "XMPP:"
+msgstr ""
+
+#: include/identity.php:422 mod/notifications.php:246 mod/contacts.php:50
+msgid "Network:"
+msgstr ""
+
+#: include/identity.php:451 include/identity.php:535
+msgid "g A l F d"
+msgstr ""
+
+#: include/identity.php:452 include/identity.php:536
+msgid "F d"
+msgstr ""
+
+#: include/identity.php:497 include/identity.php:582
+msgid "[today]"
+msgstr ""
+
+#: include/identity.php:509
+msgid "Birthday Reminders"
+msgstr ""
+
+#: include/identity.php:510
+msgid "Birthdays this week:"
+msgstr ""
+
+#: include/identity.php:569
+msgid "[No description]"
+msgstr ""
+
+#: include/identity.php:593
+msgid "Event Reminders"
+msgstr ""
+
+#: include/identity.php:594
+msgid "Events this week:"
+msgstr ""
+
+#: include/identity.php:605 include/identity.php:691 include/identity.php:722
+#: include/nav.php:82 mod/profperm.php:104 mod/contacts.php:639
+#: mod/contacts.php:841 mod/newmember.php:32 view/theme/frio/theme.php:250
+msgid "Profile"
+msgstr ""
+
+#: include/identity.php:614 mod/settings.php:1279
+msgid "Full Name:"
+msgstr ""
+
+#: include/identity.php:621
+msgid "j F, Y"
+msgstr ""
+
+#: include/identity.php:622
+msgid "j F"
+msgstr ""
+
+#: include/identity.php:633
+msgid "Age:"
+msgstr ""
+
+#: include/identity.php:642
+#, php-format
+msgid "for %1$d %2$s"
+msgstr ""
+
+#: include/identity.php:645 mod/profiles.php:710
+msgid "Sexual Preference:"
+msgstr ""
+
+#: include/identity.php:649 mod/profiles.php:737
+msgid "Hometown:"
+msgstr ""
+
+#: include/identity.php:651 mod/notifications.php:236 mod/contacts.php:634
+#: mod/follow.php:134
+msgid "Tags:"
+msgstr ""
+
+#: include/identity.php:653 mod/profiles.php:738
+msgid "Political Views:"
+msgstr ""
+
+#: include/identity.php:655
+msgid "Religion:"
+msgstr ""
+
+#: include/identity.php:659
+msgid "Hobbies/Interests:"
+msgstr ""
+
+#: include/identity.php:661 mod/profiles.php:742
+msgid "Likes:"
+msgstr ""
+
+#: include/identity.php:663 mod/profiles.php:743
+msgid "Dislikes:"
+msgstr ""
+
+#: include/identity.php:666
+msgid "Contact information and Social Networks:"
+msgstr ""
+
+#: include/identity.php:668
+msgid "Musical interests:"
+msgstr ""
+
+#: include/identity.php:670
+msgid "Books, literature:"
+msgstr ""
+
+#: include/identity.php:672
+msgid "Television:"
+msgstr ""
+
+#: include/identity.php:674
+msgid "Film/dance/culture/entertainment:"
+msgstr ""
+
+#: include/identity.php:676
+msgid "Love/Romance:"
+msgstr ""
+
+#: include/identity.php:678
+msgid "Work/employment:"
+msgstr ""
+
+#: include/identity.php:680
+msgid "School/education:"
+msgstr ""
+
+#: include/identity.php:684
+msgid "Forums:"
+msgstr ""
+
+#: include/identity.php:692 mod/events.php:507
+msgid "Basic"
+msgstr ""
+
+#: include/identity.php:693 mod/events.php:508 mod/admin.php:959
+#: mod/contacts.php:870
+msgid "Advanced"
+msgstr ""
+
+#: include/identity.php:714 include/nav.php:81 mod/contacts.php:637
+#: mod/contacts.php:833 view/theme/frio/theme.php:249
+msgid "Status"
+msgstr ""
+
+#: include/identity.php:717 mod/contacts.php:836 mod/follow.php:143
+msgid "Status Messages and Posts"
+msgstr ""
+
+#: include/identity.php:725 mod/contacts.php:844
+msgid "Profile Details"
+msgstr ""
+
+#: include/identity.php:730 include/nav.php:83 mod/fbrowser.php:32
+#: view/theme/frio/theme.php:251
+msgid "Photos"
+msgstr ""
+
+#: include/identity.php:733 mod/photos.php:87
+msgid "Photo Albums"
+msgstr ""
+
+#: include/identity.php:738 include/identity.php:741 include/nav.php:84
+#: view/theme/frio/theme.php:252
+msgid "Videos"
+msgstr ""
+
+#: include/identity.php:750 include/identity.php:761 include/nav.php:85
+#: include/nav.php:149 mod/events.php:379 mod/cal.php:275
+#: view/theme/frio/theme.php:253 view/theme/frio/theme.php:257
+msgid "Events"
+msgstr ""
+
+#: include/identity.php:753 include/identity.php:764 include/nav.php:149
+#: view/theme/frio/theme.php:257
+msgid "Events and Calendar"
+msgstr ""
+
+#: include/identity.php:772 mod/notes.php:46
+msgid "Personal Notes"
+msgstr ""
+
+#: include/identity.php:775
+msgid "Only You Can See This"
+msgstr ""
+
+#: include/follow.php:77 mod/dfrn_request.php:509
+msgid "Disallowed profile URL."
+msgstr ""
+
+#: include/follow.php:82
+msgid "Connect URL missing."
+msgstr ""
+
+#: include/follow.php:109
+msgid ""
+"This site is not configured to allow communications with other networks."
+msgstr ""
+
+#: include/follow.php:110 include/follow.php:130
+msgid "No compatible communication protocols or feeds were discovered."
+msgstr ""
+
+#: include/follow.php:128
+msgid "The profile address specified does not provide adequate information."
+msgstr ""
+
+#: include/follow.php:132
+msgid "An author or name was not found."
+msgstr ""
+
+#: include/follow.php:134
+msgid "No browser URL could be matched to this address."
+msgstr ""
+
+#: include/follow.php:136
+msgid ""
+"Unable to match @-style Identity Address with a known protocol or email "
+"contact."
+msgstr ""
+
+#: include/follow.php:137
+msgid "Use mailto: in front of address to force email check."
+msgstr ""
+
+#: include/follow.php:143
+msgid ""
+"The profile address specified belongs to a network which has been disabled "
+"on this site."
+msgstr ""
+
+#: include/follow.php:153
+msgid ""
+"Limited profile. This person will be unable to receive direct/personal "
+"notifications from you."
+msgstr ""
+
+#: include/follow.php:254
+msgid "Unable to retrieve contact information."
+msgstr ""
+
+#: include/follow.php:287
+msgid "following"
+msgstr ""
+
+#: include/Contact.php:105
+msgid "stopped following"
+msgstr ""
+
+#: include/Contact.php:409
+msgid "Drop Contact"
+msgstr ""
+
+#: include/Contact.php:784
+msgid "Organisation"
+msgstr ""
+
+#: include/Contact.php:787
+msgid "News"
+msgstr ""
+
+#: include/Contact.php:790
+msgid "Forum"
+msgstr ""
+
+#: include/oembed.php:264
+msgid "Embedded content"
+msgstr ""
+
+#: include/oembed.php:272
+msgid "Embedding disabled"
+msgstr ""
+
+#: include/bbcode.php:348 include/bbcode.php:1055 include/bbcode.php:1056
+msgid "Image/photo"
+msgstr ""
+
+#: include/bbcode.php:465
+#, php-format
+msgid "<a href=\"%1$s\" target=\"_blank\">%2$s</a> %3$s"
+msgstr ""
+
+#: include/bbcode.php:1015 include/bbcode.php:1035
+msgid "$1 wrote:"
+msgstr ""
+
+#: include/bbcode.php:1064 include/bbcode.php:1065
+msgid "Encrypted content"
+msgstr ""
+
+#: include/contact_selectors.php:32
+msgid "Unknown | Not categorised"
+msgstr ""
+
+#: include/contact_selectors.php:33
+msgid "Block immediately"
+msgstr ""
+
+#: include/contact_selectors.php:34
+msgid "Shady, spammer, self-marketer"
+msgstr ""
+
+#: include/contact_selectors.php:35
+msgid "Known to me, but no opinion"
+msgstr ""
+
+#: include/contact_selectors.php:36
+msgid "OK, probably harmless"
+msgstr ""
+
+#: include/contact_selectors.php:37
+msgid "Reputable, has my trust"
+msgstr ""
+
+#: include/contact_selectors.php:56 mod/admin.php:890
+msgid "Frequently"
+msgstr ""
+
+#: include/contact_selectors.php:57 mod/admin.php:891
+msgid "Hourly"
+msgstr ""
+
+#: include/contact_selectors.php:58 mod/admin.php:892
+msgid "Twice daily"
+msgstr ""
+
+#: include/contact_selectors.php:59 mod/admin.php:893
+msgid "Daily"
+msgstr ""
+
+#: include/contact_selectors.php:60
+msgid "Weekly"
+msgstr ""
+
+#: include/contact_selectors.php:61
+msgid "Monthly"
+msgstr ""
+
+#: include/contact_selectors.php:76 mod/dfrn_request.php:868
+msgid "Friendica"
+msgstr ""
+
+#: include/contact_selectors.php:77
+msgid "OStatus"
+msgstr ""
+
+#: include/contact_selectors.php:78
+msgid "RSS/Atom"
+msgstr ""
+
+#: include/contact_selectors.php:79 include/contact_selectors.php:86
+#: mod/admin.php:1396 mod/admin.php:1409 mod/admin.php:1422 mod/admin.php:1440
+msgid "Email"
+msgstr ""
+
+#: include/contact_selectors.php:80 mod/dfrn_request.php:870
+#: mod/settings.php:842
+msgid "Diaspora"
+msgstr ""
+
+#: include/contact_selectors.php:81
+msgid "Facebook"
+msgstr ""
+
+#: include/contact_selectors.php:82
+msgid "Zot!"
+msgstr ""
+
+#: include/contact_selectors.php:83
+msgid "LinkedIn"
+msgstr ""
+
+#: include/contact_selectors.php:84
+msgid "XMPP/IM"
+msgstr ""
+
+#: include/contact_selectors.php:85
+msgid "MySpace"
+msgstr ""
+
+#: include/contact_selectors.php:87
+msgid "Google+"
+msgstr ""
+
+#: include/contact_selectors.php:88
+msgid "pump.io"
+msgstr ""
+
+#: include/contact_selectors.php:89
+msgid "Twitter"
+msgstr ""
+
+#: include/contact_selectors.php:90
+msgid "Diaspora Connector"
+msgstr ""
+
+#: include/contact_selectors.php:91
+msgid "GNU Social"
+msgstr ""
+
+#: include/contact_selectors.php:92
+msgid "App.net"
+msgstr ""
+
+#: include/contact_selectors.php:103
+msgid "Hubzilla/Redmatrix"
+msgstr ""
+
+#: include/dbstructure.php:26
+#, php-format
+msgid ""
+"\n"
+"\t\t\tThe friendica developers released update %s recently,\n"
+"\t\t\tbut when I tried to install it, something went terribly wrong.\n"
+"\t\t\tThis needs to be fixed soon and I can't do it alone. Please contact a\n"
+"\t\t\tfriendica developer if you can not help me on your own. My database "
+"might be invalid."
+msgstr ""
+
+#: include/dbstructure.php:31
+#, php-format
+msgid ""
+"The error message is\n"
+"[pre]%s[/pre]"
+msgstr ""
+
+#: include/dbstructure.php:183
+msgid "Errors encountered creating database tables."
+msgstr ""
+
+#: include/dbstructure.php:260
+msgid "Errors encountered performing database changes."
+msgstr ""
+
+#: include/auth.php:45
+msgid "Logged out."
+msgstr ""
+
+#: include/auth.php:116 include/auth.php:178 mod/openid.php:100
+msgid "Login failed."
+msgstr ""
+
+#: include/auth.php:132 include/user.php:75
+msgid ""
+"We encountered a problem while logging in with the OpenID you provided. "
+"Please check the correct spelling of the ID."
+msgstr ""
+
+#: include/auth.php:132 include/user.php:75
+msgid "The error message was:"
+msgstr ""
+
+#: include/network.php:595
+msgid "view full size"
+msgstr ""
+
+#: include/group.php:25
+msgid ""
+"A deleted group with this name was revived. Existing item permissions "
+"<strong>may</strong> apply to this group and any future members. If this is "
+"not what you intended, please create another group with a different name."
+msgstr ""
+
+#: include/group.php:209
+msgid "Default privacy group for new contacts"
+msgstr ""
+
+#: include/group.php:242
+msgid "Everybody"
+msgstr ""
+
+#: include/group.php:265
+msgid "edit"
+msgstr ""
+
+#: include/group.php:286 mod/newmember.php:61
+msgid "Groups"
+msgstr ""
+
+#: include/group.php:288
+msgid "Edit groups"
+msgstr ""
+
+#: include/group.php:290
+msgid "Edit group"
+msgstr ""
+
+#: include/group.php:291
+msgid "Create a new group"
+msgstr ""
+
+#: include/group.php:292 mod/group.php:94 mod/group.php:178
+msgid "Group Name: "
+msgstr ""
+
+#: include/group.php:294
+msgid "Contacts not in any group"
+msgstr ""
+
+#: include/group.php:296 mod/network.php:201
+msgid "add"
+msgstr ""
+
+#: include/Photo.php:1040 include/Photo.php:1056 include/Photo.php:1064
+#: include/Photo.php:1089 include/message.php:145 mod/wall_upload.php:218
+#: mod/wall_upload.php:232 mod/wall_upload.php:239 mod/item.php:477
+msgid "Wall Photos"
+msgstr ""
+
+#: include/delivery.php:446
+msgid "(no subject)"
 msgstr ""
 
 #: include/user.php:39 mod/settings.php:373
@@ -3003,11 +2585,10 @@ msgid "An error occurred creating your default profile. Please try again."
 msgstr ""
 
 #: include/user.php:345 include/user.php:352 include/user.php:359
-#: mod/profile_photo.php:74 mod/profile_photo.php:81 mod/profile_photo.php:88
-#: mod/profile_photo.php:210 mod/profile_photo.php:302
-#: mod/profile_photo.php:311 mod/photos.php:66 mod/photos.php:180
-#: mod/photos.php:751 mod/photos.php:1211 mod/photos.php:1232
-#: mod/photos.php:1819
+#: mod/photos.php:66 mod/photos.php:180 mod/photos.php:751 mod/photos.php:1211
+#: mod/photos.php:1232 mod/photos.php:1819 mod/profile_photo.php:74
+#: mod/profile_photo.php:81 mod/profile_photo.php:88 mod/profile_photo.php:210
+#: mod/profile_photo.php:302 mod/profile_photo.php:311
 msgid "Profile Photos"
 msgstr ""
 
@@ -3070,13 +2651,547 @@ msgid ""
 "\t\tThank you and welcome to %2$s."
 msgstr ""
 
-#: include/user.php:446 mod/admin.php:1209
+#: include/user.php:446 mod/admin.php:1213
 #, php-format
 msgid "Registration details for %s"
 msgstr ""
 
+#: include/api.php:1018
+#, php-format
+msgid "Daily posting limit of %d posts reached. The post was rejected."
+msgstr ""
+
+#: include/api.php:1038
+#, php-format
+msgid "Weekly posting limit of %d posts reached. The post was rejected."
+msgstr ""
+
+#: include/api.php:1059
+#, php-format
+msgid "Monthly posting limit of %d posts reached. The post was rejected."
+msgstr ""
+
+#: include/features.php:70
+msgid "General Features"
+msgstr ""
+
+#: include/features.php:72
+msgid "Multiple Profiles"
+msgstr ""
+
+#: include/features.php:72
+msgid "Ability to create multiple profiles"
+msgstr ""
+
+#: include/features.php:73
+msgid "Photo Location"
+msgstr ""
+
+#: include/features.php:73
+msgid ""
+"Photo metadata is normally stripped. This extracts the location (if present) "
+"prior to stripping metadata and links it to a map."
+msgstr ""
+
+#: include/features.php:74
+msgid "Export Public Calendar"
+msgstr ""
+
+#: include/features.php:74
+msgid "Ability for visitors to download the public calendar"
+msgstr ""
+
+#: include/features.php:79
+msgid "Post Composition Features"
+msgstr ""
+
+#: include/features.php:80
+msgid "Richtext Editor"
+msgstr ""
+
+#: include/features.php:80
+msgid "Enable richtext editor"
+msgstr ""
+
+#: include/features.php:81
+msgid "Post Preview"
+msgstr ""
+
+#: include/features.php:81
+msgid "Allow previewing posts and comments before publishing them"
+msgstr ""
+
+#: include/features.php:82
+msgid "Auto-mention Forums"
+msgstr ""
+
+#: include/features.php:82
+msgid ""
+"Add/remove mention when a forum page is selected/deselected in ACL window."
+msgstr ""
+
+#: include/features.php:87
+msgid "Network Sidebar Widgets"
+msgstr ""
+
+#: include/features.php:88
+msgid "Search by Date"
+msgstr ""
+
+#: include/features.php:88
+msgid "Ability to select posts by date ranges"
+msgstr ""
+
+#: include/features.php:89 include/features.php:119
+msgid "List Forums"
+msgstr ""
+
+#: include/features.php:89
+msgid "Enable widget to display the forums your are connected with"
+msgstr ""
+
+#: include/features.php:90
+msgid "Group Filter"
+msgstr ""
+
+#: include/features.php:90
+msgid "Enable widget to display Network posts only from selected group"
+msgstr ""
+
+#: include/features.php:91
+msgid "Network Filter"
+msgstr ""
+
+#: include/features.php:91
+msgid "Enable widget to display Network posts only from selected network"
+msgstr ""
+
+#: include/features.php:92 mod/search.php:34 mod/network.php:200
+msgid "Saved Searches"
+msgstr ""
+
+#: include/features.php:92
+msgid "Save search terms for re-use"
+msgstr ""
+
+#: include/features.php:97
+msgid "Network Tabs"
+msgstr ""
+
+#: include/features.php:98
+msgid "Network Personal Tab"
+msgstr ""
+
+#: include/features.php:98
+msgid "Enable tab to display only Network posts that you've interacted on"
+msgstr ""
+
+#: include/features.php:99
+msgid "Network New Tab"
+msgstr ""
+
+#: include/features.php:99
+msgid "Enable tab to display only new Network posts (from the last 12 hours)"
+msgstr ""
+
+#: include/features.php:100
+msgid "Network Shared Links Tab"
+msgstr ""
+
+#: include/features.php:100
+msgid "Enable tab to display only Network posts with links in them"
+msgstr ""
+
+#: include/features.php:105
+msgid "Post/Comment Tools"
+msgstr ""
+
+#: include/features.php:106
+msgid "Multiple Deletion"
+msgstr ""
+
+#: include/features.php:106
+msgid "Select and delete multiple posts/comments at once"
+msgstr ""
+
+#: include/features.php:107
+msgid "Edit Sent Posts"
+msgstr ""
+
+#: include/features.php:107
+msgid "Edit and correct posts and comments after sending"
+msgstr ""
+
+#: include/features.php:108
+msgid "Tagging"
+msgstr ""
+
+#: include/features.php:108
+msgid "Ability to tag existing posts"
+msgstr ""
+
+#: include/features.php:109
+msgid "Post Categories"
+msgstr ""
+
+#: include/features.php:109
+msgid "Add categories to your posts"
+msgstr ""
+
+#: include/features.php:110
+msgid "Ability to file posts under folders"
+msgstr ""
+
+#: include/features.php:111
+msgid "Dislike Posts"
+msgstr ""
+
+#: include/features.php:111
+msgid "Ability to dislike posts/comments"
+msgstr ""
+
+#: include/features.php:112
+msgid "Star Posts"
+msgstr ""
+
+#: include/features.php:112
+msgid "Ability to mark special posts with a star indicator"
+msgstr ""
+
+#: include/features.php:113
+msgid "Mute Post Notifications"
+msgstr ""
+
+#: include/features.php:113
+msgid "Ability to mute notifications for a thread"
+msgstr ""
+
+#: include/features.php:118
+msgid "Advanced Profile Settings"
+msgstr ""
+
+#: include/features.php:119
+msgid "Show visitors public community forums at the Advanced Profile Page"
+msgstr ""
+
+#: include/nav.php:35 mod/navigation.php:19
+msgid "Nothing new here"
+msgstr ""
+
+#: include/nav.php:39 mod/navigation.php:23
+msgid "Clear notifications"
+msgstr ""
+
+#: include/nav.php:78 view/theme/frio/theme.php:246
+msgid "End this session"
+msgstr ""
+
+#: include/nav.php:81 include/nav.php:161 view/theme/frio/theme.php:249
+msgid "Your posts and conversations"
+msgstr ""
+
+#: include/nav.php:82 view/theme/frio/theme.php:250
+msgid "Your profile page"
+msgstr ""
+
+#: include/nav.php:83 view/theme/frio/theme.php:251
+msgid "Your photos"
+msgstr ""
+
+#: include/nav.php:84 view/theme/frio/theme.php:252
+msgid "Your videos"
+msgstr ""
+
+#: include/nav.php:85 view/theme/frio/theme.php:253
+msgid "Your events"
+msgstr ""
+
+#: include/nav.php:86
+msgid "Personal notes"
+msgstr ""
+
+#: include/nav.php:86
+msgid "Your personal notes"
+msgstr ""
+
+#: include/nav.php:95
+msgid "Sign in"
+msgstr ""
+
+#: include/nav.php:105
+msgid "Home Page"
+msgstr ""
+
+#: include/nav.php:109
+msgid "Create an account"
+msgstr ""
+
+#: include/nav.php:115 mod/help.php:47 view/theme/vier/theme.php:298
+msgid "Help"
+msgstr ""
+
+#: include/nav.php:115
+msgid "Help and documentation"
+msgstr ""
+
+#: include/nav.php:119
+msgid "Apps"
+msgstr ""
+
+#: include/nav.php:119
+msgid "Addon applications, utilities, games"
+msgstr ""
+
+#: include/nav.php:123
+msgid "Search site content"
+msgstr ""
+
+#: include/nav.php:143 include/nav.php:145 mod/community.php:36
+msgid "Community"
+msgstr ""
+
+#: include/nav.php:143
+msgid "Conversations on this site"
+msgstr ""
+
+#: include/nav.php:145
+msgid "Conversations on the network"
+msgstr ""
+
+#: include/nav.php:152
+msgid "Directory"
+msgstr ""
+
+#: include/nav.php:152
+msgid "People directory"
+msgstr ""
+
+#: include/nav.php:154
+msgid "Information"
+msgstr ""
+
+#: include/nav.php:154
+msgid "Information about this friendica instance"
+msgstr ""
+
+#: include/nav.php:158 view/theme/frio/theme.php:256
+msgid "Conversations from your friends"
+msgstr ""
+
+#: include/nav.php:159
+msgid "Network Reset"
+msgstr ""
+
+#: include/nav.php:159
+msgid "Load Network page with no filters"
+msgstr ""
+
+#: include/nav.php:166
+msgid "Friend Requests"
+msgstr ""
+
+#: include/nav.php:169 mod/notifications.php:96
+msgid "Notifications"
+msgstr ""
+
+#: include/nav.php:170
+msgid "See all notifications"
+msgstr ""
+
+#: include/nav.php:171 mod/settings.php:902
+msgid "Mark as seen"
+msgstr ""
+
+#: include/nav.php:171
+msgid "Mark all system notifications seen"
+msgstr ""
+
+#: include/nav.php:175 mod/message.php:190 view/theme/frio/theme.php:258
+msgid "Messages"
+msgstr ""
+
+#: include/nav.php:175 view/theme/frio/theme.php:258
+msgid "Private mail"
+msgstr ""
+
+#: include/nav.php:176
+msgid "Inbox"
+msgstr ""
+
+#: include/nav.php:177
+msgid "Outbox"
+msgstr ""
+
+#: include/nav.php:178 mod/message.php:16
+msgid "New Message"
+msgstr ""
+
+#: include/nav.php:181
+msgid "Manage"
+msgstr ""
+
+#: include/nav.php:181
+msgid "Manage other pages"
+msgstr ""
+
+#: include/nav.php:184 mod/settings.php:81
+msgid "Delegations"
+msgstr ""
+
+#: include/nav.php:184 mod/delegate.php:130
+msgid "Delegate Page Management"
+msgstr ""
+
+#: include/nav.php:186 mod/admin.php:1524 mod/admin.php:1782
+#: mod/newmember.php:22 mod/settings.php:111 view/theme/frio/theme.php:259
+msgid "Settings"
+msgstr ""
+
+#: include/nav.php:186 view/theme/frio/theme.php:259
+msgid "Account settings"
+msgstr ""
+
+#: include/nav.php:189
+msgid "Manage/Edit Profiles"
+msgstr ""
+
+#: include/nav.php:192 view/theme/frio/theme.php:260
+msgid "Manage/edit friends and contacts"
+msgstr ""
+
+#: include/nav.php:197 mod/admin.php:186
+msgid "Admin"
+msgstr ""
+
+#: include/nav.php:197
+msgid "Site setup and configuration"
+msgstr ""
+
+#: include/nav.php:200
+msgid "Navigation"
+msgstr ""
+
+#: include/nav.php:200
+msgid "Site map"
+msgstr ""
+
+#: include/like.php:186
+#, php-format
+msgid "%1$s is attending %2$s's %3$s"
+msgstr ""
+
+#: include/like.php:188
+#, php-format
+msgid "%1$s is not attending %2$s's %3$s"
+msgstr ""
+
+#: include/like.php:190
+#, php-format
+msgid "%1$s may attend %2$s's %3$s"
+msgstr ""
+
+#: include/acl_selectors.php:327
+msgid "Post to Email"
+msgstr ""
+
+#: include/acl_selectors.php:332
+#, php-format
+msgid "Connectors disabled, since \"%s\" is enabled."
+msgstr ""
+
+#: include/acl_selectors.php:333 mod/settings.php:1181
+msgid "Hide your profile details from unknown viewers?"
+msgstr ""
+
+#: include/acl_selectors.php:338
+msgid "Visible to everybody"
+msgstr ""
+
+#: include/acl_selectors.php:339 view/theme/vier/config.php:103
+msgid "show"
+msgstr ""
+
+#: include/acl_selectors.php:340 view/theme/vier/config.php:103
+msgid "don't show"
+msgstr ""
+
+#: include/acl_selectors.php:346 mod/editpost.php:133
+msgid "CC: email addresses"
+msgstr ""
+
+#: include/acl_selectors.php:347 mod/editpost.php:140
+msgid "Example: bob@example.com, mary@example.com"
+msgstr ""
+
+#: include/acl_selectors.php:349 mod/events.php:509 mod/photos.php:1156
+#: mod/photos.php:1535
+msgid "Permissions"
+msgstr ""
+
+#: include/acl_selectors.php:350
+msgid "Close"
+msgstr ""
+
+#: include/message.php:15 include/message.php:173
+msgid "[no subject]"
+msgstr ""
+
+#: index.php:244 mod/apps.php:7
+msgid "You must be logged in to use addons. "
+msgstr ""
+
+#: index.php:288 mod/help.php:53 mod/p.php:16 mod/p.php:43 mod/p.php:52
+#: mod/fetch.php:12 mod/fetch.php:39 mod/fetch.php:48
+msgid "Not Found"
+msgstr ""
+
+#: index.php:291 mod/help.php:56
+msgid "Page not found."
+msgstr ""
+
+#: index.php:400 mod/profperm.php:19 mod/group.php:72
+msgid "Permission denied"
+msgstr ""
+
+#: index.php:451
+msgid "toggle mobile"
+msgstr ""
+
+#: mod/regmod.php:55
+msgid "Account approved."
+msgstr ""
+
+#: mod/regmod.php:92
+#, php-format
+msgid "Registration revoked for %s"
+msgstr ""
+
+#: mod/regmod.php:104
+msgid "Please login."
+msgstr ""
+
 #: mod/oexchange.php:25
 msgid "Post successful."
+msgstr ""
+
+#: mod/update_community.php:19 mod/update_notes.php:36
+#: mod/update_display.php:23 mod/update_profile.php:35
+#: mod/update_network.php:27
+msgid "[Embedded content - reload page to view]"
+msgstr ""
+
+#: mod/dirfind.php:36
+#, php-format
+msgid "People Search - %s"
+msgstr ""
+
+#: mod/dirfind.php:47
+#, php-format
+msgid "Forum Search - %s"
+msgstr ""
+
+#: mod/dirfind.php:240 mod/match.php:107
+msgid "No matches"
 msgstr ""
 
 #: mod/viewsrc.php:7
@@ -3100,9 +3215,9 @@ msgstr ""
 msgid "Remove term"
 msgstr ""
 
-#: mod/search.php:93 mod/search.php:99 mod/dfrn_request.php:790
-#: mod/community.php:22 mod/directory.php:37 mod/display.php:200
-#: mod/photos.php:944 mod/videos.php:194 mod/viewcontacts.php:35
+#: mod/search.php:93 mod/search.php:99 mod/directory.php:37
+#: mod/viewcontacts.php:35 mod/videos.php:194 mod/photos.php:944
+#: mod/display.php:200 mod/community.php:22 mod/dfrn_request.php:791
 msgid "Public access denied."
 msgstr ""
 
@@ -3130,6 +3245,210 @@ msgstr ""
 #: mod/search.php:232 mod/contacts.php:797 mod/network.php:146
 #, php-format
 msgid "Results for: %s"
+msgstr ""
+
+#: mod/notifications.php:35
+msgid "Invalid request identifier."
+msgstr ""
+
+#: mod/notifications.php:44 mod/notifications.php:180
+#: mod/notifications.php:252
+msgid "Discard"
+msgstr ""
+
+#: mod/notifications.php:60 mod/notifications.php:179
+#: mod/notifications.php:251 mod/contacts.php:606 mod/contacts.php:806
+#: mod/contacts.php:1000
+msgid "Ignore"
+msgstr ""
+
+#: mod/notifications.php:105
+msgid "Network Notifications"
+msgstr ""
+
+#: mod/notifications.php:117
+msgid "Personal Notifications"
+msgstr ""
+
+#: mod/notifications.php:123
+msgid "Home Notifications"
+msgstr ""
+
+#: mod/notifications.php:152
+msgid "Show Ignored Requests"
+msgstr ""
+
+#: mod/notifications.php:152
+msgid "Hide Ignored Requests"
+msgstr ""
+
+#: mod/notifications.php:164 mod/notifications.php:222
+msgid "Notification type: "
+msgstr ""
+
+#: mod/notifications.php:167
+#, php-format
+msgid "suggested by %s"
+msgstr ""
+
+#: mod/notifications.php:172 mod/notifications.php:239 mod/contacts.php:613
+msgid "Hide this contact from others"
+msgstr ""
+
+#: mod/notifications.php:173 mod/notifications.php:240
+msgid "Post a new friend activity"
+msgstr ""
+
+#: mod/notifications.php:173 mod/notifications.php:240
+msgid "if applicable"
+msgstr ""
+
+#: mod/notifications.php:176 mod/notifications.php:249 mod/admin.php:1412
+msgid "Approve"
+msgstr ""
+
+#: mod/notifications.php:195
+msgid "Claims to be known to you: "
+msgstr ""
+
+#: mod/notifications.php:196
+msgid "yes"
+msgstr ""
+
+#: mod/notifications.php:196
+msgid "no"
+msgstr ""
+
+#: mod/notifications.php:197
+msgid ""
+"Shall your connection be bidirectional or not? \"Friend\" implies that you "
+"allow to read and you subscribe to their posts. \"Fan/Admirer\" means that "
+"you allow to read but you do not want to read theirs. Approve as: "
+msgstr ""
+
+#: mod/notifications.php:200
+msgid ""
+"Shall your connection be bidirectional or not? \"Friend\" implies that you "
+"allow to read and you subscribe to their posts. \"Sharer\" means that you "
+"allow to read but you do not want to read theirs. Approve as: "
+msgstr ""
+
+#: mod/notifications.php:209
+msgid "Friend"
+msgstr ""
+
+#: mod/notifications.php:210
+msgid "Sharer"
+msgstr ""
+
+#: mod/notifications.php:210
+msgid "Fan/Admirer"
+msgstr ""
+
+#: mod/notifications.php:243 mod/contacts.php:624 mod/follow.php:126
+msgid "Profile URL"
+msgstr ""
+
+#: mod/notifications.php:260
+msgid "No introductions."
+msgstr ""
+
+#: mod/notifications.php:299
+msgid "Show unread"
+msgstr ""
+
+#: mod/notifications.php:299
+msgid "Show all"
+msgstr ""
+
+#: mod/notifications.php:305
+#, php-format
+msgid "No more %s notifications."
+msgstr ""
+
+#: mod/dfrn_confirm.php:70 mod/profiles.php:19 mod/profiles.php:134
+#: mod/profiles.php:180 mod/profiles.php:617
+msgid "Profile not found."
+msgstr ""
+
+#: mod/dfrn_confirm.php:126 mod/fsuggest.php:20 mod/fsuggest.php:92
+#: mod/crepair.php:114
+msgid "Contact not found."
+msgstr ""
+
+#: mod/dfrn_confirm.php:127
+msgid ""
+"This may occasionally happen if contact was requested by both persons and it "
+"has already been approved."
+msgstr ""
+
+#: mod/dfrn_confirm.php:246
+msgid "Response from remote site was not understood."
+msgstr ""
+
+#: mod/dfrn_confirm.php:255 mod/dfrn_confirm.php:260
+msgid "Unexpected response from remote site: "
+msgstr ""
+
+#: mod/dfrn_confirm.php:269
+msgid "Confirmation completed successfully."
+msgstr ""
+
+#: mod/dfrn_confirm.php:271 mod/dfrn_confirm.php:285 mod/dfrn_confirm.php:292
+msgid "Remote site reported: "
+msgstr ""
+
+#: mod/dfrn_confirm.php:283
+msgid "Temporary failure. Please wait and try again."
+msgstr ""
+
+#: mod/dfrn_confirm.php:290
+msgid "Introduction failed or was revoked."
+msgstr ""
+
+#: mod/dfrn_confirm.php:419
+msgid "Unable to set contact photo."
+msgstr ""
+
+#: mod/dfrn_confirm.php:557
+#, php-format
+msgid "No user record found for '%s' "
+msgstr ""
+
+#: mod/dfrn_confirm.php:567
+msgid "Our site encryption key is apparently messed up."
+msgstr ""
+
+#: mod/dfrn_confirm.php:578
+msgid "Empty site URL was provided or URL could not be decrypted by us."
+msgstr ""
+
+#: mod/dfrn_confirm.php:599
+msgid "Contact record was not found for you on our site."
+msgstr ""
+
+#: mod/dfrn_confirm.php:613
+#, php-format
+msgid "Site public key not available in contact record for URL %s."
+msgstr ""
+
+#: mod/dfrn_confirm.php:633
+msgid ""
+"The ID provided by your system is a duplicate on our system. It should work "
+"if you try again."
+msgstr ""
+
+#: mod/dfrn_confirm.php:644
+msgid "Unable to set your contact credentials on our system."
+msgstr ""
+
+#: mod/dfrn_confirm.php:703
+msgid "Unable to update your contact profile details on our system"
+msgstr ""
+
+#: mod/dfrn_confirm.php:775
+#, php-format
+msgid "%1$s has joined %2$s"
 msgstr ""
 
 #: mod/friendica.php:70
@@ -3222,10 +3541,6 @@ msgid ""
 "Password reset failed."
 msgstr ""
 
-#: mod/lostpass.php:109 boot.php:1802
-msgid "Password Reset"
-msgstr ""
-
 #: mod/lostpass.php:110
 msgid "Your password has been reset as requested."
 msgstr ""
@@ -3290,10 +3605,6 @@ msgid ""
 "your email for further instructions."
 msgstr ""
 
-#: mod/lostpass.php:161 boot.php:1790
-msgid "Nickname or Email: "
-msgstr ""
-
 #: mod/lostpass.php:162
 msgid "Reset"
 msgstr ""
@@ -3306,13 +3617,49 @@ msgstr ""
 msgid "Help:"
 msgstr ""
 
-#: mod/help.php:53 mod/p.php:16 mod/p.php:43 mod/p.php:52 mod/fetch.php:12
-#: mod/fetch.php:39 mod/fetch.php:48 index.php:284
-msgid "Not Found"
+#: mod/wall_upload.php:20 mod/wall_upload.php:33 mod/wall_upload.php:86
+#: mod/wall_upload.php:122 mod/wall_upload.php:125 mod/wall_attach.php:17
+#: mod/wall_attach.php:25 mod/wall_attach.php:76
+msgid "Invalid request."
 msgstr ""
 
-#: mod/help.php:56 index.php:287
-msgid "Page not found."
+#: mod/wall_upload.php:151 mod/photos.php:786 mod/profile_photo.php:150
+#, php-format
+msgid "Image exceeds size limit of %s"
+msgstr ""
+
+#: mod/wall_upload.php:188 mod/photos.php:826 mod/profile_photo.php:159
+msgid "Unable to process image."
+msgstr ""
+
+#: mod/wall_upload.php:221 mod/photos.php:853 mod/profile_photo.php:307
+msgid "Image upload failed."
+msgstr ""
+
+#: mod/fsuggest.php:63
+msgid "Friend suggestion sent."
+msgstr ""
+
+#: mod/fsuggest.php:97
+msgid "Suggest Friends"
+msgstr ""
+
+#: mod/fsuggest.php:99
+#, php-format
+msgid "Suggest a friend for %s"
+msgstr ""
+
+#: mod/fsuggest.php:107 mod/events.php:506 mod/invite.php:140
+#: mod/crepair.php:154 mod/content.php:728 mod/profiles.php:688
+#: mod/poke.php:199 mod/photos.php:1104 mod/photos.php:1226
+#: mod/photos.php:1539 mod/photos.php:1590 mod/photos.php:1638
+#: mod/photos.php:1724 mod/install.php:272 mod/install.php:312
+#: mod/contacts.php:577 mod/mood.php:137 mod/localtime.php:45
+#: mod/message.php:357 mod/message.php:547 mod/manage.php:143
+#: object/Item.php:720 view/theme/frio/config.php:59
+#: view/theme/quattro/config.php:64 view/theme/vier/config.php:107
+#: view/theme/duepuntozero/config.php:59
+msgid "Submit"
 msgstr ""
 
 #: mod/lockview.php:31 mod/lockview.php:39
@@ -3321,6 +3668,94 @@ msgstr ""
 
 #: mod/lockview.php:48
 msgid "Visible to:"
+msgstr ""
+
+#: mod/events.php:95 mod/events.php:97
+msgid "Event can not end before it has started."
+msgstr ""
+
+#: mod/events.php:104 mod/events.php:106
+msgid "Event title and start time are required."
+msgstr ""
+
+#: mod/events.php:380 mod/cal.php:276
+msgid "View"
+msgstr ""
+
+#: mod/events.php:381
+msgid "Create New Event"
+msgstr ""
+
+#: mod/events.php:382 mod/cal.php:277
+msgid "Previous"
+msgstr ""
+
+#: mod/events.php:383 mod/cal.php:278 mod/install.php:231
+msgid "Next"
+msgstr ""
+
+#: mod/events.php:392 mod/cal.php:287
+msgid "list"
+msgstr ""
+
+#: mod/events.php:482
+msgid "Event details"
+msgstr ""
+
+#: mod/events.php:483
+msgid "Starting date and Title are required."
+msgstr ""
+
+#: mod/events.php:484 mod/events.php:485
+msgid "Event Starts:"
+msgstr ""
+
+#: mod/events.php:484 mod/events.php:496 mod/profiles.php:716
+msgid "Required"
+msgstr ""
+
+#: mod/events.php:486 mod/events.php:502
+msgid "Finish date/time is not known or not relevant"
+msgstr ""
+
+#: mod/events.php:488 mod/events.php:489
+msgid "Event Finishes:"
+msgstr ""
+
+#: mod/events.php:490 mod/events.php:503
+msgid "Adjust for viewer timezone"
+msgstr ""
+
+#: mod/events.php:492
+msgid "Description:"
+msgstr ""
+
+#: mod/events.php:496 mod/events.php:498
+msgid "Title:"
+msgstr ""
+
+#: mod/events.php:499 mod/events.php:500
+msgid "Share this event"
+msgstr ""
+
+#: mod/directory.php:197 view/theme/vier/theme.php:201
+msgid "Global Directory"
+msgstr ""
+
+#: mod/directory.php:199
+msgid "Find on this site"
+msgstr ""
+
+#: mod/directory.php:201
+msgid "Results for:"
+msgstr ""
+
+#: mod/directory.php:203
+msgid "Site Directory"
+msgstr ""
+
+#: mod/directory.php:210
+msgid "No entries (some entries may be hidden)."
 msgstr ""
 
 #: mod/openid.php:24
@@ -3373,8 +3808,8 @@ msgid ""
 "select \"Export account\""
 msgstr ""
 
-#: mod/nogroup.php:41 mod/contacts.php:586 mod/contacts.php:939
-#: mod/viewcontacts.php:97
+#: mod/nogroup.php:41 mod/viewcontacts.php:97 mod/contacts.php:586
+#: mod/contacts.php:939
 #, php-format
 msgid "Visit %s's profile [%s]"
 msgstr ""
@@ -3385,6 +3820,18 @@ msgstr ""
 
 #: mod/nogroup.php:63
 msgid "Contacts who are not members of a group"
+msgstr ""
+
+#: mod/match.php:33
+msgid "No keywords to match. Please add keywords to your default profile."
+msgstr ""
+
+#: mod/match.php:86
+msgid "is interested in:"
+msgstr ""
+
+#: mod/match.php:100
+msgid "Profile Match"
 msgstr ""
 
 #: mod/uexport.php:29
@@ -3509,24 +3956,12 @@ msgid ""
 "important, please visit http://friendica.com"
 msgstr ""
 
-#: mod/invite.php:140 mod/localtime.php:45 mod/message.php:357
-#: mod/message.php:547 mod/manage.php:143 mod/crepair.php:154
-#: mod/content.php:728 mod/fsuggest.php:107 mod/mood.php:137 mod/poke.php:199
-#: mod/profiles.php:688 mod/contacts.php:577 mod/events.php:506
-#: mod/install.php:272 mod/install.php:312 mod/photos.php:1104
-#: mod/photos.php:1226 mod/photos.php:1539 mod/photos.php:1590
-#: mod/photos.php:1638 mod/photos.php:1724 object/Item.php:720
-#: view/theme/frio/config.php:59 view/theme/quattro/config.php:64
-#: view/theme/vier/config.php:107 view/theme/duepuntozero/config.php:59
-msgid "Submit"
-msgstr ""
-
 #: mod/fbrowser.php:133
 msgid "Files"
 msgstr ""
 
-#: mod/profperm.php:19 mod/group.php:72 index.php:396
-msgid "Permission denied"
+#: mod/maintenance.php:9
+msgid "System down for maintenance"
 msgstr ""
 
 #: mod/profperm.php:25 mod/profperm.php:56
@@ -3549,671 +3984,8 @@ msgstr ""
 msgid "All Contacts (with secure profile access)"
 msgstr ""
 
-#: mod/tagrm.php:41
-msgid "Tag removed"
-msgstr ""
-
-#: mod/tagrm.php:79
-msgid "Remove Item Tag"
-msgstr ""
-
-#: mod/tagrm.php:81
-msgid "Select a tag to remove: "
-msgstr ""
-
-#: mod/tagrm.php:93 mod/delegate.php:139
-msgid "Remove"
-msgstr ""
-
-#: mod/repair_ostatus.php:14
-msgid "Resubscribing to OStatus contacts"
-msgstr ""
-
-#: mod/repair_ostatus.php:30
-msgid "Error"
-msgstr ""
-
-#: mod/repair_ostatus.php:44 mod/ostatus_subscribe.php:51
-msgid "Done"
-msgstr ""
-
-#: mod/repair_ostatus.php:50 mod/ostatus_subscribe.php:73
-msgid "Keep this window open until done."
-msgstr ""
-
-#: mod/delegate.php:101
-msgid "No potential page delegates located."
-msgstr ""
-
-#: mod/delegate.php:132
-msgid ""
-"Delegates are able to manage all aspects of this account/page except for "
-"basic account settings. Please do not delegate your personal account to "
-"anybody that you do not trust completely."
-msgstr ""
-
-#: mod/delegate.php:133
-msgid "Existing Page Managers"
-msgstr ""
-
-#: mod/delegate.php:135
-msgid "Existing Page Delegates"
-msgstr ""
-
-#: mod/delegate.php:137
-msgid "Potential Delegates"
-msgstr ""
-
-#: mod/delegate.php:140
-msgid "Add"
-msgstr ""
-
-#: mod/delegate.php:141
-msgid "No entries."
-msgstr ""
-
-#: mod/credits.php:16
-msgid "Credits"
-msgstr ""
-
-#: mod/credits.php:17
-msgid ""
-"Friendica is a community project, that would not be possible without the "
-"help of many people. Here is a list of those who have contributed to the "
-"code or the translation of Friendica. Thank you all!"
-msgstr ""
-
-#: mod/filer.php:30
-msgid "- select -"
-msgstr ""
-
-#: mod/subthread.php:103
-#, php-format
-msgid "%1$s is following %2$s's %3$s"
-msgstr ""
-
-#: mod/attach.php:8
-msgid "Item not available."
-msgstr ""
-
-#: mod/attach.php:20
-msgid "Item was not found."
-msgstr ""
-
-#: mod/follow.php:19 mod/dfrn_request.php:874
-msgid "Submit Request"
-msgstr ""
-
-#: mod/follow.php:30
-msgid "You already added this contact."
-msgstr ""
-
-#: mod/follow.php:39
-msgid "Diaspora support isn't enabled. Contact can't be added."
-msgstr ""
-
-#: mod/follow.php:46
-msgid "OStatus support is disabled. Contact can't be added."
-msgstr ""
-
-#: mod/follow.php:53
-msgid "The network type couldn't be detected. Contact can't be added."
-msgstr ""
-
-#: mod/follow.php:109 mod/dfrn_request.php:860
-msgid "Please answer the following:"
-msgstr ""
-
-#: mod/follow.php:110 mod/dfrn_request.php:861
-#, php-format
-msgid "Does %s know you?"
-msgstr ""
-
-#: mod/follow.php:110 mod/api.php:106 mod/dfrn_request.php:861
-#: mod/profiles.php:648 mod/profiles.php:652 mod/profiles.php:677
-#: mod/register.php:246 mod/settings.php:1163 mod/settings.php:1169
-#: mod/settings.php:1177 mod/settings.php:1181 mod/settings.php:1186
-#: mod/settings.php:1192 mod/settings.php:1198 mod/settings.php:1204
-#: mod/settings.php:1230 mod/settings.php:1231 mod/settings.php:1232
-#: mod/settings.php:1233 mod/settings.php:1234
-msgid "No"
-msgstr ""
-
-#: mod/follow.php:111 mod/dfrn_request.php:865
-msgid "Add a personal note:"
-msgstr ""
-
-#: mod/follow.php:117 mod/dfrn_request.php:871
-msgid "Your Identity Address:"
-msgstr ""
-
-#: mod/follow.php:126 mod/notifications.php:243 mod/contacts.php:624
-msgid "Profile URL"
-msgstr ""
-
-#: mod/follow.php:180
-msgid "Contact added"
-msgstr ""
-
-#: mod/apps.php:7 index.php:240
-msgid "You must be logged in to use addons. "
-msgstr ""
-
-#: mod/apps.php:11
-msgid "Applications"
-msgstr ""
-
-#: mod/apps.php:14
-msgid "No installed applications."
-msgstr ""
-
-#: mod/p.php:9
-msgid "Not Extended"
-msgstr ""
-
-#: mod/newmember.php:6
-msgid "Welcome to Friendica"
-msgstr ""
-
-#: mod/newmember.php:8
-msgid "New Member Checklist"
-msgstr ""
-
-#: mod/newmember.php:12
-msgid ""
-"We would like to offer some tips and links to help make your experience "
-"enjoyable. Click any item to visit the relevant page. A link to this page "
-"will be visible from your home page for two weeks after your initial "
-"registration and then will quietly disappear."
-msgstr ""
-
-#: mod/newmember.php:14
-msgid "Getting Started"
-msgstr ""
-
-#: mod/newmember.php:18
-msgid "Friendica Walk-Through"
-msgstr ""
-
-#: mod/newmember.php:18
-msgid ""
-"On your <em>Quick Start</em> page - find a brief introduction to your "
-"profile and network tabs, make some new connections, and find some groups to "
-"join."
-msgstr ""
-
-#: mod/newmember.php:26
-msgid "Go to Your Settings"
-msgstr ""
-
-#: mod/newmember.php:26
-msgid ""
-"On your <em>Settings</em> page -  change your initial password. Also make a "
-"note of your Identity Address. This looks just like an email address - and "
-"will be useful in making friends on the free social web."
-msgstr ""
-
-#: mod/newmember.php:28
-msgid ""
-"Review the other settings, particularly the privacy settings. An unpublished "
-"directory listing is like having an unlisted phone number. In general, you "
-"should probably publish your listing - unless all of your friends and "
-"potential friends know exactly how to find you."
-msgstr ""
-
-#: mod/newmember.php:36 mod/profile_photo.php:250 mod/profiles.php:707
-msgid "Upload Profile Photo"
-msgstr ""
-
-#: mod/newmember.php:36
-msgid ""
-"Upload a profile photo if you have not done so already. Studies have shown "
-"that people with real photos of themselves are ten times more likely to make "
-"friends than people who do not."
-msgstr ""
-
-#: mod/newmember.php:38
-msgid "Edit Your Profile"
-msgstr ""
-
-#: mod/newmember.php:38
-msgid ""
-"Edit your <strong>default</strong> profile to your liking. Review the "
-"settings for hiding your list of friends and hiding the profile from unknown "
-"visitors."
-msgstr ""
-
-#: mod/newmember.php:40
-msgid "Profile Keywords"
-msgstr ""
-
-#: mod/newmember.php:40
-msgid ""
-"Set some public keywords for your default profile which describe your "
-"interests. We may be able to find other people with similar interests and "
-"suggest friendships."
-msgstr ""
-
-#: mod/newmember.php:44
-msgid "Connecting"
-msgstr ""
-
-#: mod/newmember.php:51
-msgid "Importing Emails"
-msgstr ""
-
-#: mod/newmember.php:51
-msgid ""
-"Enter your email access information on your Connector Settings page if you "
-"wish to import and interact with friends or mailing lists from your email "
-"INBOX"
-msgstr ""
-
-#: mod/newmember.php:53
-msgid "Go to Your Contacts Page"
-msgstr ""
-
-#: mod/newmember.php:53
-msgid ""
-"Your Contacts page is your gateway to managing friendships and connecting "
-"with friends on other networks. Typically you enter their address or site "
-"URL in the <em>Add New Contact</em> dialog."
-msgstr ""
-
-#: mod/newmember.php:55
-msgid "Go to Your Site's Directory"
-msgstr ""
-
-#: mod/newmember.php:55
-msgid ""
-"The Directory page lets you find other people in this network or other "
-"federated sites. Look for a <em>Connect</em> or <em>Follow</em> link on "
-"their profile page. Provide your own Identity Address if requested."
-msgstr ""
-
-#: mod/newmember.php:57
-msgid "Finding New People"
-msgstr ""
-
-#: mod/newmember.php:57
-msgid ""
-"On the side panel of the Contacts page are several tools to find new "
-"friends. We can match people by interest, look up people by name or "
-"interest, and provide suggestions based on network relationships. On a brand "
-"new site, friend suggestions will usually begin to be populated within 24 "
-"hours."
-msgstr ""
-
-#: mod/newmember.php:65
-msgid "Group Your Contacts"
-msgstr ""
-
-#: mod/newmember.php:65
-msgid ""
-"Once you have made some friends, organize them into private conversation "
-"groups from the sidebar of your Contacts page and then you can interact with "
-"each group privately on your Network page."
-msgstr ""
-
-#: mod/newmember.php:68
-msgid "Why Aren't My Posts Public?"
-msgstr ""
-
-#: mod/newmember.php:68
-msgid ""
-"Friendica respects your privacy. By default, your posts will only show up to "
-"people you've added as friends. For more information, see the help section "
-"from the link above."
-msgstr ""
-
-#: mod/newmember.php:73
-msgid "Getting Help"
-msgstr ""
-
-#: mod/newmember.php:77
-msgid "Go to the Help Section"
-msgstr ""
-
-#: mod/newmember.php:77
-msgid ""
-"Our <strong>help</strong> pages may be consulted for detail on other program "
-"features and resources."
-msgstr ""
-
-#: mod/removeme.php:46 mod/removeme.php:49
-msgid "Remove My Account"
-msgstr ""
-
-#: mod/removeme.php:47
-msgid ""
-"This will completely remove your account. Once this has been done it is not "
-"recoverable."
-msgstr ""
-
-#: mod/removeme.php:48
-msgid "Please enter your password for verification:"
-msgstr ""
-
-#: mod/editpost.php:17 mod/editpost.php:27
-msgid "Item not found"
-msgstr ""
-
-#: mod/editpost.php:40
-msgid "Edit post"
-msgstr ""
-
-#: mod/localtime.php:24
-msgid "Time Conversion"
-msgstr ""
-
-#: mod/localtime.php:26
-msgid ""
-"Friendica provides this service for sharing events with other networks and "
-"friends in unknown timezones."
-msgstr ""
-
-#: mod/localtime.php:30
-#, php-format
-msgid "UTC time: %s"
-msgstr ""
-
-#: mod/localtime.php:33
-#, php-format
-msgid "Current timezone: %s"
-msgstr ""
-
-#: mod/localtime.php:36
-#, php-format
-msgid "Converted localtime: %s"
-msgstr ""
-
-#: mod/localtime.php:41
-msgid "Please select your timezone:"
-msgstr ""
-
-#: mod/bookmarklet.php:41
-msgid "The post was created"
-msgstr ""
-
-#: mod/group.php:29
-msgid "Group created."
-msgstr ""
-
-#: mod/group.php:35
-msgid "Could not create group."
-msgstr ""
-
-#: mod/group.php:47 mod/group.php:140
-msgid "Group not found."
-msgstr ""
-
-#: mod/group.php:60
-msgid "Group name changed."
-msgstr ""
-
-#: mod/group.php:87
-msgid "Save Group"
-msgstr ""
-
-#: mod/group.php:93
-msgid "Create a group of contacts/friends."
-msgstr ""
-
-#: mod/group.php:113
-msgid "Group removed."
-msgstr ""
-
-#: mod/group.php:115
-msgid "Unable to remove group."
-msgstr ""
-
-#: mod/group.php:177
-msgid "Group Editor"
-msgstr ""
-
-#: mod/group.php:190
-msgid "Members"
-msgstr ""
-
-#: mod/group.php:192 mod/contacts.php:692
-msgid "All Contacts"
-msgstr ""
-
-#: mod/group.php:193 mod/content.php:130 mod/network.php:496
-msgid "Group is empty"
-msgstr ""
-
-#: mod/wallmessage.php:42 mod/wallmessage.php:112
-#, php-format
-msgid "Number of daily wall messages for %s exceeded. Message failed."
-msgstr ""
-
-#: mod/wallmessage.php:56 mod/message.php:71
-msgid "No recipient selected."
-msgstr ""
-
-#: mod/wallmessage.php:59
-msgid "Unable to check your home location."
-msgstr ""
-
-#: mod/wallmessage.php:62 mod/message.php:78
-msgid "Message could not be sent."
-msgstr ""
-
-#: mod/wallmessage.php:65 mod/message.php:81
-msgid "Message collection failure."
-msgstr ""
-
-#: mod/wallmessage.php:68 mod/message.php:84
-msgid "Message sent."
-msgstr ""
-
-#: mod/wallmessage.php:86 mod/wallmessage.php:95
-msgid "No recipient."
-msgstr ""
-
-#: mod/wallmessage.php:142 mod/message.php:341
-msgid "Send Private Message"
-msgstr ""
-
-#: mod/wallmessage.php:143
-#, php-format
-msgid ""
-"If you wish for %s to respond, please check that the privacy settings on "
-"your site allow private mail from unknown senders."
-msgstr ""
-
-#: mod/wallmessage.php:144 mod/message.php:342 mod/message.php:536
-msgid "To:"
-msgstr ""
-
-#: mod/wallmessage.php:145 mod/message.php:347 mod/message.php:538
-msgid "Subject:"
-msgstr ""
-
-#: mod/share.php:38
-msgid "link"
-msgstr ""
-
-#: mod/api.php:76 mod/api.php:102
-msgid "Authorize application connection"
-msgstr ""
-
-#: mod/api.php:77
-msgid "Return to your app and insert this Securty Code:"
-msgstr ""
-
-#: mod/api.php:89
-msgid "Please login to continue."
-msgstr ""
-
-#: mod/api.php:104
-msgid ""
-"Do you want to authorize this application to access your posts and contacts, "
-"and/or create new posts for you?"
-msgstr ""
-
-#: mod/babel.php:17
-msgid "Source (bbcode) text:"
-msgstr ""
-
-#: mod/babel.php:23
-msgid "Source (Diaspora) text to convert to BBcode:"
-msgstr ""
-
-#: mod/babel.php:31
-msgid "Source input: "
-msgstr ""
-
-#: mod/babel.php:35
-msgid "bb2html (raw HTML): "
-msgstr ""
-
-#: mod/babel.php:39
-msgid "bb2html: "
-msgstr ""
-
-#: mod/babel.php:43
-msgid "bb2html2bb: "
-msgstr ""
-
-#: mod/babel.php:47
-msgid "bb2md: "
-msgstr ""
-
-#: mod/babel.php:51
-msgid "bb2md2html: "
-msgstr ""
-
-#: mod/babel.php:55
-msgid "bb2dia2bb: "
-msgstr ""
-
-#: mod/babel.php:59
-msgid "bb2md2html2bb: "
-msgstr ""
-
-#: mod/babel.php:69
-msgid "Source input (Diaspora format): "
-msgstr ""
-
-#: mod/babel.php:74
-msgid "diaspora2bb: "
-msgstr ""
-
-#: mod/ostatus_subscribe.php:14
-msgid "Subscribing to OStatus contacts"
-msgstr ""
-
-#: mod/ostatus_subscribe.php:25
-msgid "No contact provided."
-msgstr ""
-
-#: mod/ostatus_subscribe.php:30
-msgid "Couldn't fetch information for contact."
-msgstr ""
-
-#: mod/ostatus_subscribe.php:38
-msgid "Couldn't fetch friends for contact."
-msgstr ""
-
-#: mod/ostatus_subscribe.php:65
-msgid "success"
-msgstr ""
-
-#: mod/ostatus_subscribe.php:67
-msgid "failed"
-msgstr ""
-
-#: mod/ostatus_subscribe.php:69 mod/content.php:792 object/Item.php:245
-msgid "ignored"
-msgstr ""
-
-#: mod/dfrn_poll.php:104 mod/dfrn_poll.php:537
-#, php-format
-msgid "%1$s welcomes %2$s"
-msgstr ""
-
-#: mod/message.php:75
-msgid "Unable to locate contact information."
-msgstr ""
-
-#: mod/message.php:215
-msgid "Do you really want to delete this message?"
-msgstr ""
-
-#: mod/message.php:235
-msgid "Message deleted."
-msgstr ""
-
-#: mod/message.php:266
-msgid "Conversation removed."
-msgstr ""
-
-#: mod/message.php:383
-msgid "No messages."
-msgstr ""
-
-#: mod/message.php:426
-msgid "Message not available."
-msgstr ""
-
-#: mod/message.php:503
-msgid "Delete message"
-msgstr ""
-
-#: mod/message.php:529 mod/message.php:609
-msgid "Delete conversation"
-msgstr ""
-
-#: mod/message.php:531
-msgid ""
-"No secure communications available. You <strong>may</strong> be able to "
-"respond from the sender's profile page."
-msgstr ""
-
-#: mod/message.php:535
-msgid "Send Reply"
-msgstr ""
-
-#: mod/message.php:579
-#, php-format
-msgid "Unknown sender - %s"
-msgstr ""
-
-#: mod/message.php:581
-#, php-format
-msgid "You and %s"
-msgstr ""
-
-#: mod/message.php:583
-#, php-format
-msgid "%s and You"
-msgstr ""
-
-#: mod/message.php:612
-msgid "D, d M Y - g:i A"
-msgstr ""
-
-#: mod/message.php:615
-#, php-format
-msgid "%d message"
-msgid_plural "%d messages"
-msgstr[0] ""
-msgstr[1] ""
-
-#: mod/manage.php:139
-msgid "Manage Identities and/or Pages"
-msgstr ""
-
-#: mod/manage.php:140
-msgid ""
-"Toggle between different identities or community/group pages which share "
-"your account details or which you have been granted \"manage\" permissions"
-msgstr ""
-
-#: mod/manage.php:141
-msgid "Select an identity to manage: "
+#: mod/viewcontacts.php:72
+msgid "No contacts."
 msgstr ""
 
 #: mod/crepair.php:87
@@ -4222,11 +3994,6 @@ msgstr ""
 
 #: mod/crepair.php:89
 msgid "Contact update failed."
-msgstr ""
-
-#: mod/crepair.php:114 mod/dfrn_confirm.php:122 mod/fsuggest.php:20
-#: mod/fsuggest.php:92
-msgid "Contact not found."
 msgstr ""
 
 #: mod/crepair.php:120
@@ -4275,8 +4042,8 @@ msgid ""
 "entries from this contact."
 msgstr ""
 
-#: mod/crepair.php:165 mod/admin.php:1392 mod/admin.php:1405
-#: mod/admin.php:1418 mod/admin.php:1434 mod/settings.php:680
+#: mod/crepair.php:165 mod/admin.php:1396 mod/admin.php:1409
+#: mod/admin.php:1422 mod/admin.php:1438 mod/settings.php:680
 #: mod/settings.php:706
 msgid "Name"
 msgstr ""
@@ -4313,157 +4080,1500 @@ msgstr ""
 msgid "New photo from this URL"
 msgstr ""
 
-#: mod/dfrn_request.php:100
-msgid "This introduction has already been accepted."
+#: mod/tagrm.php:41
+msgid "Tag removed"
 msgstr ""
 
-#: mod/dfrn_request.php:123 mod/dfrn_request.php:518
-msgid "Profile location is not valid or does not contain profile information."
+#: mod/tagrm.php:79
+msgid "Remove Item Tag"
 msgstr ""
 
-#: mod/dfrn_request.php:128 mod/dfrn_request.php:523
-msgid "Warning: profile location has no identifiable owner name."
+#: mod/tagrm.php:81
+msgid "Select a tag to remove: "
 msgstr ""
 
-#: mod/dfrn_request.php:130 mod/dfrn_request.php:525
-msgid "Warning: profile location has no profile photo."
+#: mod/tagrm.php:93 mod/delegate.php:139
+msgid "Remove"
 msgstr ""
 
-#: mod/dfrn_request.php:133 mod/dfrn_request.php:528
+#: mod/ping.php:261
+msgid "{0} wants to be your friend"
+msgstr ""
+
+#: mod/ping.php:276
+msgid "{0} sent you a message"
+msgstr ""
+
+#: mod/ping.php:291
+msgid "{0} requested registration"
+msgstr ""
+
+#: mod/admin.php:92
+msgid "Theme settings updated."
+msgstr ""
+
+#: mod/admin.php:156 mod/admin.php:954
+msgid "Site"
+msgstr ""
+
+#: mod/admin.php:157 mod/admin.php:898 mod/admin.php:1404 mod/admin.php:1420
+msgid "Users"
+msgstr ""
+
+#: mod/admin.php:158 mod/admin.php:1522 mod/admin.php:1582 mod/settings.php:74
+msgid "Plugins"
+msgstr ""
+
+#: mod/admin.php:159 mod/admin.php:1780 mod/admin.php:1830
+msgid "Themes"
+msgstr ""
+
+#: mod/admin.php:160 mod/settings.php:52
+msgid "Additional features"
+msgstr ""
+
+#: mod/admin.php:161
+msgid "DB updates"
+msgstr ""
+
+#: mod/admin.php:162 mod/admin.php:406
+msgid "Inspect Queue"
+msgstr ""
+
+#: mod/admin.php:163 mod/admin.php:372
+msgid "Federation Statistics"
+msgstr ""
+
+#: mod/admin.php:177 mod/admin.php:188 mod/admin.php:1904
+msgid "Logs"
+msgstr ""
+
+#: mod/admin.php:178 mod/admin.php:1972
+msgid "View Logs"
+msgstr ""
+
+#: mod/admin.php:179
+msgid "probe address"
+msgstr ""
+
+#: mod/admin.php:180
+msgid "check webfinger"
+msgstr ""
+
+#: mod/admin.php:187
+msgid "Plugin Features"
+msgstr ""
+
+#: mod/admin.php:189
+msgid "diagnostics"
+msgstr ""
+
+#: mod/admin.php:190
+msgid "User registrations waiting for confirmation"
+msgstr ""
+
+#: mod/admin.php:306
+msgid "unknown"
+msgstr ""
+
+#: mod/admin.php:365
+msgid ""
+"This page offers you some numbers to the known part of the federated social "
+"network your Friendica node is part of. These numbers are not complete but "
+"only reflect the part of the network your node is aware of."
+msgstr ""
+
+#: mod/admin.php:366
+msgid ""
+"The <em>Auto Discovered Contact Directory</em> feature is not enabled, it "
+"will improve the data displayed here."
+msgstr ""
+
+#: mod/admin.php:371 mod/admin.php:405 mod/admin.php:484 mod/admin.php:953
+#: mod/admin.php:1403 mod/admin.php:1521 mod/admin.php:1581 mod/admin.php:1779
+#: mod/admin.php:1829 mod/admin.php:1903 mod/admin.php:1971
+msgid "Administration"
+msgstr ""
+
+#: mod/admin.php:378
 #, php-format
-msgid "%d required parameter was not found at the given location"
-msgid_plural "%d required parameters were not found at the given location"
+msgid "Currently this node is aware of %d nodes from the following platforms:"
+msgstr ""
+
+#: mod/admin.php:408
+msgid "ID"
+msgstr ""
+
+#: mod/admin.php:409
+msgid "Recipient Name"
+msgstr ""
+
+#: mod/admin.php:410
+msgid "Recipient Profile"
+msgstr ""
+
+#: mod/admin.php:412
+msgid "Created"
+msgstr ""
+
+#: mod/admin.php:413
+msgid "Last Tried"
+msgstr ""
+
+#: mod/admin.php:414
+msgid ""
+"This page lists the content of the queue for outgoing postings. These are "
+"postings the initial delivery failed for. They will be resend later and "
+"eventually deleted if the delivery fails permanently."
+msgstr ""
+
+#: mod/admin.php:439
+#, php-format
+msgid ""
+"Your DB still runs with MyISAM tables. You should change the engine type to "
+"InnoDB. As Friendica will use InnoDB only features in the future, you should "
+"change this! See <a href=\"%s\">here</a> for a guide that may be helpful "
+"converting the table engines. You may also use the <tt>convert_innodb.sql</"
+"tt> in the <tt>/util</tt> directory of your Friendica installation.<br />"
+msgstr ""
+
+#: mod/admin.php:444
+msgid ""
+"You are using a MySQL version which does not support all features that "
+"Friendica uses. You should consider switching to MariaDB."
+msgstr ""
+
+#: mod/admin.php:448 mod/admin.php:1352
+msgid "Normal Account"
+msgstr ""
+
+#: mod/admin.php:449 mod/admin.php:1353
+msgid "Soapbox Account"
+msgstr ""
+
+#: mod/admin.php:450 mod/admin.php:1354
+msgid "Community/Celebrity Account"
+msgstr ""
+
+#: mod/admin.php:451 mod/admin.php:1355
+msgid "Automatic Friend Account"
+msgstr ""
+
+#: mod/admin.php:452
+msgid "Blog Account"
+msgstr ""
+
+#: mod/admin.php:453
+msgid "Private Forum"
+msgstr ""
+
+#: mod/admin.php:479
+msgid "Message queues"
+msgstr ""
+
+#: mod/admin.php:485
+msgid "Summary"
+msgstr ""
+
+#: mod/admin.php:488
+msgid "Registered users"
+msgstr ""
+
+#: mod/admin.php:490
+msgid "Pending registrations"
+msgstr ""
+
+#: mod/admin.php:491
+msgid "Version"
+msgstr ""
+
+#: mod/admin.php:496
+msgid "Active plugins"
+msgstr ""
+
+#: mod/admin.php:521
+msgid "Can not parse base url. Must have at least <scheme>://<domain>"
+msgstr ""
+
+#: mod/admin.php:826
+msgid "RINO2 needs mcrypt php extension to work."
+msgstr ""
+
+#: mod/admin.php:834
+msgid "Site settings updated."
+msgstr ""
+
+#: mod/admin.php:862 mod/settings.php:934
+msgid "No special theme for mobile devices"
+msgstr ""
+
+#: mod/admin.php:881
+msgid "No community page"
+msgstr ""
+
+#: mod/admin.php:882
+msgid "Public postings from users of this site"
+msgstr ""
+
+#: mod/admin.php:883
+msgid "Global community page"
+msgstr ""
+
+#: mod/admin.php:888 mod/contacts.php:530
+msgid "Never"
+msgstr ""
+
+#: mod/admin.php:889
+msgid "At post arrival"
+msgstr ""
+
+#: mod/admin.php:897 mod/contacts.php:557
+msgid "Disabled"
+msgstr ""
+
+#: mod/admin.php:899
+msgid "Users, Global Contacts"
+msgstr ""
+
+#: mod/admin.php:900
+msgid "Users, Global Contacts/fallback"
+msgstr ""
+
+#: mod/admin.php:904
+msgid "One month"
+msgstr ""
+
+#: mod/admin.php:905
+msgid "Three months"
+msgstr ""
+
+#: mod/admin.php:906
+msgid "Half a year"
+msgstr ""
+
+#: mod/admin.php:907
+msgid "One year"
+msgstr ""
+
+#: mod/admin.php:912
+msgid "Multi user instance"
+msgstr ""
+
+#: mod/admin.php:935
+msgid "Closed"
+msgstr ""
+
+#: mod/admin.php:936
+msgid "Requires approval"
+msgstr ""
+
+#: mod/admin.php:937
+msgid "Open"
+msgstr ""
+
+#: mod/admin.php:941
+msgid "No SSL policy, links will track page SSL state"
+msgstr ""
+
+#: mod/admin.php:942
+msgid "Force all links to use SSL"
+msgstr ""
+
+#: mod/admin.php:943
+msgid "Self-signed certificate, use SSL for local links only (discouraged)"
+msgstr ""
+
+#: mod/admin.php:955 mod/admin.php:1583 mod/admin.php:1831 mod/admin.php:1905
+#: mod/admin.php:2055 mod/settings.php:678 mod/settings.php:788
+#: mod/settings.php:835 mod/settings.php:904 mod/settings.php:996
+#: mod/settings.php:1264
+msgid "Save Settings"
+msgstr ""
+
+#: mod/admin.php:956 mod/register.php:272
+msgid "Registration"
+msgstr ""
+
+#: mod/admin.php:957
+msgid "File upload"
+msgstr ""
+
+#: mod/admin.php:958
+msgid "Policies"
+msgstr ""
+
+#: mod/admin.php:960
+msgid "Auto Discovered Contact Directory"
+msgstr ""
+
+#: mod/admin.php:961
+msgid "Performance"
+msgstr ""
+
+#: mod/admin.php:962
+msgid "Worker"
+msgstr ""
+
+#: mod/admin.php:963
+msgid ""
+"Relocate - WARNING: advanced function. Could make this server unreachable."
+msgstr ""
+
+#: mod/admin.php:966
+msgid "Site name"
+msgstr ""
+
+#: mod/admin.php:967
+msgid "Host name"
+msgstr ""
+
+#: mod/admin.php:968
+msgid "Sender Email"
+msgstr ""
+
+#: mod/admin.php:968
+msgid ""
+"The email address your server shall use to send notification emails from."
+msgstr ""
+
+#: mod/admin.php:969
+msgid "Banner/Logo"
+msgstr ""
+
+#: mod/admin.php:970
+msgid "Shortcut icon"
+msgstr ""
+
+#: mod/admin.php:970
+msgid "Link to an icon that will be used for browsers."
+msgstr ""
+
+#: mod/admin.php:971
+msgid "Touch icon"
+msgstr ""
+
+#: mod/admin.php:971
+msgid "Link to an icon that will be used for tablets and mobiles."
+msgstr ""
+
+#: mod/admin.php:972
+msgid "Additional Info"
+msgstr ""
+
+#: mod/admin.php:972
+#, php-format
+msgid ""
+"For public servers: you can add additional information here that will be "
+"listed at %s/siteinfo."
+msgstr ""
+
+#: mod/admin.php:973
+msgid "System language"
+msgstr ""
+
+#: mod/admin.php:974
+msgid "System theme"
+msgstr ""
+
+#: mod/admin.php:974
+msgid ""
+"Default system theme - may be over-ridden by user profiles - <a href='#' "
+"id='cnftheme'>change theme settings</a>"
+msgstr ""
+
+#: mod/admin.php:975
+msgid "Mobile system theme"
+msgstr ""
+
+#: mod/admin.php:975
+msgid "Theme for mobile devices"
+msgstr ""
+
+#: mod/admin.php:976
+msgid "SSL link policy"
+msgstr ""
+
+#: mod/admin.php:976
+msgid "Determines whether generated links should be forced to use SSL"
+msgstr ""
+
+#: mod/admin.php:977
+msgid "Force SSL"
+msgstr ""
+
+#: mod/admin.php:977
+msgid ""
+"Force all Non-SSL requests to SSL - Attention: on some systems it could lead "
+"to endless loops."
+msgstr ""
+
+#: mod/admin.php:978
+msgid "Old style 'Share'"
+msgstr ""
+
+#: mod/admin.php:978
+msgid "Deactivates the bbcode element 'share' for repeating items."
+msgstr ""
+
+#: mod/admin.php:979
+msgid "Hide help entry from navigation menu"
+msgstr ""
+
+#: mod/admin.php:979
+msgid ""
+"Hides the menu entry for the Help pages from the navigation menu. You can "
+"still access it calling /help directly."
+msgstr ""
+
+#: mod/admin.php:980
+msgid "Single user instance"
+msgstr ""
+
+#: mod/admin.php:980
+msgid "Make this instance multi-user or single-user for the named user"
+msgstr ""
+
+#: mod/admin.php:981
+msgid "Maximum image size"
+msgstr ""
+
+#: mod/admin.php:981
+msgid ""
+"Maximum size in bytes of uploaded images. Default is 0, which means no "
+"limits."
+msgstr ""
+
+#: mod/admin.php:982
+msgid "Maximum image length"
+msgstr ""
+
+#: mod/admin.php:982
+msgid ""
+"Maximum length in pixels of the longest side of uploaded images. Default is "
+"-1, which means no limits."
+msgstr ""
+
+#: mod/admin.php:983
+msgid "JPEG image quality"
+msgstr ""
+
+#: mod/admin.php:983
+msgid ""
+"Uploaded JPEGS will be saved at this quality setting [0-100]. Default is "
+"100, which is full quality."
+msgstr ""
+
+#: mod/admin.php:985
+msgid "Register policy"
+msgstr ""
+
+#: mod/admin.php:986
+msgid "Maximum Daily Registrations"
+msgstr ""
+
+#: mod/admin.php:986
+msgid ""
+"If registration is permitted above, this sets the maximum number of new user "
+"registrations to accept per day.  If register is set to closed, this setting "
+"has no effect."
+msgstr ""
+
+#: mod/admin.php:987
+msgid "Register text"
+msgstr ""
+
+#: mod/admin.php:987
+msgid "Will be displayed prominently on the registration page."
+msgstr ""
+
+#: mod/admin.php:988
+msgid "Accounts abandoned after x days"
+msgstr ""
+
+#: mod/admin.php:988
+msgid ""
+"Will not waste system resources polling external sites for abandonded "
+"accounts. Enter 0 for no time limit."
+msgstr ""
+
+#: mod/admin.php:989
+msgid "Allowed friend domains"
+msgstr ""
+
+#: mod/admin.php:989
+msgid ""
+"Comma separated list of domains which are allowed to establish friendships "
+"with this site. Wildcards are accepted. Empty to allow any domains"
+msgstr ""
+
+#: mod/admin.php:990
+msgid "Allowed email domains"
+msgstr ""
+
+#: mod/admin.php:990
+msgid ""
+"Comma separated list of domains which are allowed in email addresses for "
+"registrations to this site. Wildcards are accepted. Empty to allow any "
+"domains"
+msgstr ""
+
+#: mod/admin.php:991
+msgid "Block public"
+msgstr ""
+
+#: mod/admin.php:991
+msgid ""
+"Check to block public access to all otherwise public personal pages on this "
+"site unless you are currently logged in."
+msgstr ""
+
+#: mod/admin.php:992
+msgid "Force publish"
+msgstr ""
+
+#: mod/admin.php:992
+msgid ""
+"Check to force all profiles on this site to be listed in the site directory."
+msgstr ""
+
+#: mod/admin.php:993
+msgid "Global directory URL"
+msgstr ""
+
+#: mod/admin.php:993
+msgid ""
+"URL to the global directory. If this is not set, the global directory is "
+"completely unavailable to the application."
+msgstr ""
+
+#: mod/admin.php:994
+msgid "Allow threaded items"
+msgstr ""
+
+#: mod/admin.php:994
+msgid "Allow infinite level threading for items on this site."
+msgstr ""
+
+#: mod/admin.php:995
+msgid "Private posts by default for new users"
+msgstr ""
+
+#: mod/admin.php:995
+msgid ""
+"Set default post permissions for all new members to the default privacy "
+"group rather than public."
+msgstr ""
+
+#: mod/admin.php:996
+msgid "Don't include post content in email notifications"
+msgstr ""
+
+#: mod/admin.php:996
+msgid ""
+"Don't include the content of a post/comment/private message/etc. in the "
+"email notifications that are sent out from this site, as a privacy measure."
+msgstr ""
+
+#: mod/admin.php:997
+msgid "Disallow public access to addons listed in the apps menu."
+msgstr ""
+
+#: mod/admin.php:997
+msgid ""
+"Checking this box will restrict addons listed in the apps menu to members "
+"only."
+msgstr ""
+
+#: mod/admin.php:998
+msgid "Don't embed private images in posts"
+msgstr ""
+
+#: mod/admin.php:998
+msgid ""
+"Don't replace locally-hosted private photos in posts with an embedded copy "
+"of the image. This means that contacts who receive posts containing private "
+"photos will have to authenticate and load each image, which may take a while."
+msgstr ""
+
+#: mod/admin.php:999
+msgid "Allow Users to set remote_self"
+msgstr ""
+
+#: mod/admin.php:999
+msgid ""
+"With checking this, every user is allowed to mark every contact as a "
+"remote_self in the repair contact dialog. Setting this flag on a contact "
+"causes mirroring every posting of that contact in the users stream."
+msgstr ""
+
+#: mod/admin.php:1000
+msgid "Block multiple registrations"
+msgstr ""
+
+#: mod/admin.php:1000
+msgid "Disallow users to register additional accounts for use as pages."
+msgstr ""
+
+#: mod/admin.php:1001
+msgid "OpenID support"
+msgstr ""
+
+#: mod/admin.php:1001
+msgid "OpenID support for registration and logins."
+msgstr ""
+
+#: mod/admin.php:1002
+msgid "Fullname check"
+msgstr ""
+
+#: mod/admin.php:1002
+msgid ""
+"Force users to register with a space between firstname and lastname in Full "
+"name, as an antispam measure"
+msgstr ""
+
+#: mod/admin.php:1003
+msgid "UTF-8 Regular expressions"
+msgstr ""
+
+#: mod/admin.php:1003
+msgid "Use PHP UTF8 regular expressions"
+msgstr ""
+
+#: mod/admin.php:1004
+msgid "Community Page Style"
+msgstr ""
+
+#: mod/admin.php:1004
+msgid ""
+"Type of community page to show. 'Global community' shows every public "
+"posting from an open distributed network that arrived on this server."
+msgstr ""
+
+#: mod/admin.php:1005
+msgid "Posts per user on community page"
+msgstr ""
+
+#: mod/admin.php:1005
+msgid ""
+"The maximum number of posts per user on the community page. (Not valid for "
+"'Global Community')"
+msgstr ""
+
+#: mod/admin.php:1006
+msgid "Enable OStatus support"
+msgstr ""
+
+#: mod/admin.php:1006
+msgid ""
+"Provide built-in OStatus (StatusNet, GNU Social etc.) compatibility. All "
+"communications in OStatus are public, so privacy warnings will be "
+"occasionally displayed."
+msgstr ""
+
+#: mod/admin.php:1007
+msgid "OStatus conversation completion interval"
+msgstr ""
+
+#: mod/admin.php:1007
+msgid ""
+"How often shall the poller check for new entries in OStatus conversations? "
+"This can be a very ressource task."
+msgstr ""
+
+#: mod/admin.php:1008
+msgid "Only import OStatus threads from our contacts"
+msgstr ""
+
+#: mod/admin.php:1008
+msgid ""
+"Normally we import every content from our OStatus contacts. With this option "
+"we only store threads that are started by a contact that is known on our "
+"system."
+msgstr ""
+
+#: mod/admin.php:1009
+msgid "OStatus support can only be enabled if threading is enabled."
+msgstr ""
+
+#: mod/admin.php:1011
+msgid ""
+"Diaspora support can't be enabled because Friendica was installed into a sub "
+"directory."
+msgstr ""
+
+#: mod/admin.php:1012
+msgid "Enable Diaspora support"
+msgstr ""
+
+#: mod/admin.php:1012
+msgid "Provide built-in Diaspora network compatibility."
+msgstr ""
+
+#: mod/admin.php:1013
+msgid "Only allow Friendica contacts"
+msgstr ""
+
+#: mod/admin.php:1013
+msgid ""
+"All contacts must use Friendica protocols. All other built-in communication "
+"protocols disabled."
+msgstr ""
+
+#: mod/admin.php:1014
+msgid "Verify SSL"
+msgstr ""
+
+#: mod/admin.php:1014
+msgid ""
+"If you wish, you can turn on strict certificate checking. This will mean you "
+"cannot connect (at all) to self-signed SSL sites."
+msgstr ""
+
+#: mod/admin.php:1015
+msgid "Proxy user"
+msgstr ""
+
+#: mod/admin.php:1016
+msgid "Proxy URL"
+msgstr ""
+
+#: mod/admin.php:1017
+msgid "Network timeout"
+msgstr ""
+
+#: mod/admin.php:1017
+msgid "Value is in seconds. Set to 0 for unlimited (not recommended)."
+msgstr ""
+
+#: mod/admin.php:1018
+msgid "Delivery interval"
+msgstr ""
+
+#: mod/admin.php:1018
+msgid ""
+"Delay background delivery processes by this many seconds to reduce system "
+"load. Recommend: 4-5 for shared hosts, 2-3 for virtual private servers. 0-1 "
+"for large dedicated servers."
+msgstr ""
+
+#: mod/admin.php:1019
+msgid "Poll interval"
+msgstr ""
+
+#: mod/admin.php:1019
+msgid ""
+"Delay background polling processes by this many seconds to reduce system "
+"load. If 0, use delivery interval."
+msgstr ""
+
+#: mod/admin.php:1020
+msgid "Maximum Load Average"
+msgstr ""
+
+#: mod/admin.php:1020
+msgid ""
+"Maximum system load before delivery and poll processes are deferred - "
+"default 50."
+msgstr ""
+
+#: mod/admin.php:1021
+msgid "Maximum Load Average (Frontend)"
+msgstr ""
+
+#: mod/admin.php:1021
+msgid "Maximum system load before the frontend quits service - default 50."
+msgstr ""
+
+#: mod/admin.php:1022
+msgid "Maximum table size for optimization"
+msgstr ""
+
+#: mod/admin.php:1022
+msgid ""
+"Maximum table size (in MB) for the automatic optimization - default 100 MB. "
+"Enter -1 to disable it."
+msgstr ""
+
+#: mod/admin.php:1023
+msgid "Minimum level of fragmentation"
+msgstr ""
+
+#: mod/admin.php:1023
+msgid ""
+"Minimum fragmenation level to start the automatic optimization - default "
+"value is 30%."
+msgstr ""
+
+#: mod/admin.php:1025
+msgid "Periodical check of global contacts"
+msgstr ""
+
+#: mod/admin.php:1025
+msgid ""
+"If enabled, the global contacts are checked periodically for missing or "
+"outdated data and the vitality of the contacts and servers."
+msgstr ""
+
+#: mod/admin.php:1026
+msgid "Days between requery"
+msgstr ""
+
+#: mod/admin.php:1026
+msgid "Number of days after which a server is requeried for his contacts."
+msgstr ""
+
+#: mod/admin.php:1027
+msgid "Discover contacts from other servers"
+msgstr ""
+
+#: mod/admin.php:1027
+msgid ""
+"Periodically query other servers for contacts. You can choose between "
+"'users': the users on the remote system, 'Global Contacts': active contacts "
+"that are known on the system. The fallback is meant for Redmatrix servers "
+"and older friendica servers, where global contacts weren't available. The "
+"fallback increases the server load, so the recommened setting is 'Users, "
+"Global Contacts'."
+msgstr ""
+
+#: mod/admin.php:1028
+msgid "Timeframe for fetching global contacts"
+msgstr ""
+
+#: mod/admin.php:1028
+msgid ""
+"When the discovery is activated, this value defines the timeframe for the "
+"activity of the global contacts that are fetched from other servers."
+msgstr ""
+
+#: mod/admin.php:1029
+msgid "Search the local directory"
+msgstr ""
+
+#: mod/admin.php:1029
+msgid ""
+"Search the local directory instead of the global directory. When searching "
+"locally, every search will be executed on the global directory in the "
+"background. This improves the search results when the search is repeated."
+msgstr ""
+
+#: mod/admin.php:1031
+msgid "Publish server information"
+msgstr ""
+
+#: mod/admin.php:1031
+msgid ""
+"If enabled, general server and usage data will be published. The data "
+"contains the name and version of the server, number of users with public "
+"profiles, number of posts and the activated protocols and connectors. See <a "
+"href='http://the-federation.info/'>the-federation.info</a> for details."
+msgstr ""
+
+#: mod/admin.php:1033
+msgid "Use MySQL full text engine"
+msgstr ""
+
+#: mod/admin.php:1033
+msgid ""
+"Activates the full text engine. Speeds up search - but can only search for "
+"four and more characters."
+msgstr ""
+
+#: mod/admin.php:1034
+msgid "Suppress Language"
+msgstr ""
+
+#: mod/admin.php:1034
+msgid "Suppress language information in meta information about a posting."
+msgstr ""
+
+#: mod/admin.php:1035
+msgid "Suppress Tags"
+msgstr ""
+
+#: mod/admin.php:1035
+msgid "Suppress showing a list of hashtags at the end of the posting."
+msgstr ""
+
+#: mod/admin.php:1036
+msgid "Path to item cache"
+msgstr ""
+
+#: mod/admin.php:1036
+msgid "The item caches buffers generated bbcode and external images."
+msgstr ""
+
+#: mod/admin.php:1037
+msgid "Cache duration in seconds"
+msgstr ""
+
+#: mod/admin.php:1037
+msgid ""
+"How long should the cache files be hold? Default value is 86400 seconds (One "
+"day). To disable the item cache, set the value to -1."
+msgstr ""
+
+#: mod/admin.php:1038
+msgid "Maximum numbers of comments per post"
+msgstr ""
+
+#: mod/admin.php:1038
+msgid "How much comments should be shown for each post? Default value is 100."
+msgstr ""
+
+#: mod/admin.php:1039
+msgid "Path for lock file"
+msgstr ""
+
+#: mod/admin.php:1039
+msgid ""
+"The lock file is used to avoid multiple pollers at one time. Only define a "
+"folder here."
+msgstr ""
+
+#: mod/admin.php:1040
+msgid "Temp path"
+msgstr ""
+
+#: mod/admin.php:1040
+msgid ""
+"If you have a restricted system where the webserver can't access the system "
+"temp path, enter another path here."
+msgstr ""
+
+#: mod/admin.php:1041
+msgid "Base path to installation"
+msgstr ""
+
+#: mod/admin.php:1041
+msgid ""
+"If the system cannot detect the correct path to your installation, enter the "
+"correct path here. This setting should only be set if you are using a "
+"restricted system and symbolic links to your webroot."
+msgstr ""
+
+#: mod/admin.php:1042
+msgid "Disable picture proxy"
+msgstr ""
+
+#: mod/admin.php:1042
+msgid ""
+"The picture proxy increases performance and privacy. It shouldn't be used on "
+"systems with very low bandwith."
+msgstr ""
+
+#: mod/admin.php:1043
+msgid "Enable old style pager"
+msgstr ""
+
+#: mod/admin.php:1043
+msgid ""
+"The old style pager has page numbers but slows down massively the page speed."
+msgstr ""
+
+#: mod/admin.php:1044
+msgid "Only search in tags"
+msgstr ""
+
+#: mod/admin.php:1044
+msgid "On large systems the text search can slow down the system extremely."
+msgstr ""
+
+#: mod/admin.php:1046
+msgid "New base url"
+msgstr ""
+
+#: mod/admin.php:1046
+msgid ""
+"Change base url for this server. Sends relocate message to all DFRN contacts "
+"of all users."
+msgstr ""
+
+#: mod/admin.php:1048
+msgid "RINO Encryption"
+msgstr ""
+
+#: mod/admin.php:1048
+msgid "Encryption layer between nodes."
+msgstr ""
+
+#: mod/admin.php:1049
+msgid "Embedly API key"
+msgstr ""
+
+#: mod/admin.php:1049
+msgid ""
+"<a href='http://embed.ly'>Embedly</a> is used to fetch additional data for "
+"web pages. This is an optional parameter."
+msgstr ""
+
+#: mod/admin.php:1051
+msgid "Enable 'worker' background processing"
+msgstr ""
+
+#: mod/admin.php:1051
+msgid ""
+"The worker background processing limits the number of parallel background "
+"jobs to a maximum number and respects the system load."
+msgstr ""
+
+#: mod/admin.php:1052
+msgid "Maximum number of parallel workers"
+msgstr ""
+
+#: mod/admin.php:1052
+msgid ""
+"On shared hosters set this to 2. On larger systems, values of 10 are great. "
+"Default value is 4."
+msgstr ""
+
+#: mod/admin.php:1053
+msgid "Don't use 'proc_open' with the worker"
+msgstr ""
+
+#: mod/admin.php:1053
+msgid ""
+"Enable this if your system doesn't allow the use of 'proc_open'. This can "
+"happen on shared hosters. If this is enabled you should increase the "
+"frequency of poller calls in your crontab."
+msgstr ""
+
+#: mod/admin.php:1054
+msgid "Enable fastlane"
+msgstr ""
+
+#: mod/admin.php:1054
+msgid ""
+"When enabed, the fastlane mechanism starts an additional worker if processes "
+"with higher priority are blocked by processes of lower priority."
+msgstr ""
+
+#: mod/admin.php:1055
+msgid "Enable frontend worker"
+msgstr ""
+
+#: mod/admin.php:1055
+msgid ""
+"When enabled the Worker process is triggered when backend access is "
+"performed (e.g. messages being delivered). On smaller sites you might want "
+"to call yourdomain.tld/worker on a regular basis via an external cron job. "
+"You should only enable this option if you cannot utilize cron/scheduled jobs "
+"on your server. The worker background process needs to be activated for this."
+msgstr ""
+
+#: mod/admin.php:1084
+msgid "Update has been marked successful"
+msgstr ""
+
+#: mod/admin.php:1092
+#, php-format
+msgid "Database structure update %s was successfully applied."
+msgstr ""
+
+#: mod/admin.php:1095
+#, php-format
+msgid "Executing of database structure update %s failed with error: %s"
+msgstr ""
+
+#: mod/admin.php:1107
+#, php-format
+msgid "Executing %s failed with error: %s"
+msgstr ""
+
+#: mod/admin.php:1110
+#, php-format
+msgid "Update %s was successfully applied."
+msgstr ""
+
+#: mod/admin.php:1114
+#, php-format
+msgid "Update %s did not return a status. Unknown if it succeeded."
+msgstr ""
+
+#: mod/admin.php:1116
+#, php-format
+msgid "There was no additional update function %s that needed to be called."
+msgstr ""
+
+#: mod/admin.php:1135
+msgid "No failed updates."
+msgstr ""
+
+#: mod/admin.php:1136
+msgid "Check database structure"
+msgstr ""
+
+#: mod/admin.php:1141
+msgid "Failed Updates"
+msgstr ""
+
+#: mod/admin.php:1142
+msgid ""
+"This does not include updates prior to 1139, which did not return a status."
+msgstr ""
+
+#: mod/admin.php:1143
+msgid "Mark success (if update was manually applied)"
+msgstr ""
+
+#: mod/admin.php:1144
+msgid "Attempt to execute this update step automatically"
+msgstr ""
+
+#: mod/admin.php:1178
+#, php-format
+msgid ""
+"\n"
+"\t\t\tDear %1$s,\n"
+"\t\t\t\tthe administrator of %2$s has set up an account for you."
+msgstr ""
+
+#: mod/admin.php:1181
+#, php-format
+msgid ""
+"\n"
+"\t\t\tThe login details are as follows:\n"
+"\n"
+"\t\t\tSite Location:\t%1$s\n"
+"\t\t\tLogin Name:\t\t%2$s\n"
+"\t\t\tPassword:\t\t%3$s\n"
+"\n"
+"\t\t\tYou may change your password from your account \"Settings\" page after "
+"logging\n"
+"\t\t\tin.\n"
+"\n"
+"\t\t\tPlease take a few moments to review the other account settings on that "
+"page.\n"
+"\n"
+"\t\t\tYou may also wish to add some basic information to your default "
+"profile\n"
+"\t\t\t(on the \"Profiles\" page) so that other people can easily find you.\n"
+"\n"
+"\t\t\tWe recommend setting your full name, adding a profile photo,\n"
+"\t\t\tadding some profile \"keywords\" (very useful in making new friends) - "
+"and\n"
+"\t\t\tperhaps what country you live in; if you do not wish to be more "
+"specific\n"
+"\t\t\tthan that.\n"
+"\n"
+"\t\t\tWe fully respect your right to privacy, and none of these items are "
+"necessary.\n"
+"\t\t\tIf you are new and do not know anybody here, they may help\n"
+"\t\t\tyou to make some new and interesting friends.\n"
+"\n"
+"\t\t\tThank you and welcome to %4$s."
+msgstr ""
+
+#: mod/admin.php:1225
+#, php-format
+msgid "%s user blocked/unblocked"
+msgid_plural "%s users blocked/unblocked"
 msgstr[0] ""
 msgstr[1] ""
 
-#: mod/dfrn_request.php:178
-msgid "Introduction complete."
-msgstr ""
-
-#: mod/dfrn_request.php:220
-msgid "Unrecoverable protocol error."
-msgstr ""
-
-#: mod/dfrn_request.php:248
-msgid "Profile unavailable."
-msgstr ""
-
-#: mod/dfrn_request.php:273
+#: mod/admin.php:1232
 #, php-format
-msgid "%s has received too many connection requests today."
-msgstr ""
+msgid "%s user deleted"
+msgid_plural "%s users deleted"
+msgstr[0] ""
+msgstr[1] ""
 
-#: mod/dfrn_request.php:274
-msgid "Spam protection measures have been invoked."
-msgstr ""
-
-#: mod/dfrn_request.php:275
-msgid "Friends are advised to please try again in 24 hours."
-msgstr ""
-
-#: mod/dfrn_request.php:337
-msgid "Invalid locator"
-msgstr ""
-
-#: mod/dfrn_request.php:346
-msgid "Invalid email address."
-msgstr ""
-
-#: mod/dfrn_request.php:373
-msgid "This account has not been configured for email. Request failed."
-msgstr ""
-
-#: mod/dfrn_request.php:476
-msgid "You have already introduced yourself here."
-msgstr ""
-
-#: mod/dfrn_request.php:480
+#: mod/admin.php:1279
 #, php-format
-msgid "Apparently you are already friends with %s."
+msgid "User '%s' deleted"
 msgstr ""
 
-#: mod/dfrn_request.php:501
-msgid "Invalid profile URL."
-msgstr ""
-
-#: mod/dfrn_request.php:579 mod/contacts.php:208
-msgid "Failed to update contact record."
-msgstr ""
-
-#: mod/dfrn_request.php:600
-msgid "Your introduction has been sent."
-msgstr ""
-
-#: mod/dfrn_request.php:640
-msgid ""
-"Remote subscription can't be done for your network. Please subscribe "
-"directly on your system."
-msgstr ""
-
-#: mod/dfrn_request.php:663
-msgid "Please login to confirm introduction."
-msgstr ""
-
-#: mod/dfrn_request.php:673
-msgid ""
-"Incorrect identity currently logged in. Please login to <strong>this</"
-"strong> profile."
-msgstr ""
-
-#: mod/dfrn_request.php:687 mod/dfrn_request.php:704
-msgid "Confirm"
-msgstr ""
-
-#: mod/dfrn_request.php:699
-msgid "Hide this contact"
-msgstr ""
-
-#: mod/dfrn_request.php:702
+#: mod/admin.php:1287
 #, php-format
-msgid "Welcome home %s."
+msgid "User '%s' unblocked"
 msgstr ""
 
-#: mod/dfrn_request.php:703
+#: mod/admin.php:1287
 #, php-format
-msgid "Please confirm your introduction/connection request to %s."
+msgid "User '%s' blocked"
 msgstr ""
 
-#: mod/dfrn_request.php:832
+#: mod/admin.php:1396 mod/admin.php:1422
+msgid "Register date"
+msgstr ""
+
+#: mod/admin.php:1396 mod/admin.php:1422
+msgid "Last login"
+msgstr ""
+
+#: mod/admin.php:1396 mod/admin.php:1422
+msgid "Last item"
+msgstr ""
+
+#: mod/admin.php:1396 mod/settings.php:43
+msgid "Account"
+msgstr ""
+
+#: mod/admin.php:1405
+msgid "Add User"
+msgstr ""
+
+#: mod/admin.php:1406
+msgid "select all"
+msgstr ""
+
+#: mod/admin.php:1407
+msgid "User registrations waiting for confirm"
+msgstr ""
+
+#: mod/admin.php:1408
+msgid "User waiting for permanent deletion"
+msgstr ""
+
+#: mod/admin.php:1409
+msgid "Request date"
+msgstr ""
+
+#: mod/admin.php:1410
+msgid "No registrations."
+msgstr ""
+
+#: mod/admin.php:1411
+msgid "Note from the user"
+msgstr ""
+
+#: mod/admin.php:1413
+msgid "Deny"
+msgstr ""
+
+#: mod/admin.php:1415 mod/contacts.php:605 mod/contacts.php:805
+#: mod/contacts.php:992
+msgid "Block"
+msgstr ""
+
+#: mod/admin.php:1416 mod/contacts.php:605 mod/contacts.php:805
+#: mod/contacts.php:992
+msgid "Unblock"
+msgstr ""
+
+#: mod/admin.php:1417
+msgid "Site admin"
+msgstr ""
+
+#: mod/admin.php:1418
+msgid "Account expired"
+msgstr ""
+
+#: mod/admin.php:1421
+msgid "New User"
+msgstr ""
+
+#: mod/admin.php:1422
+msgid "Deleted since"
+msgstr ""
+
+#: mod/admin.php:1427
 msgid ""
-"Please enter your 'Identity Address' from one of the following supported "
-"communications networks:"
+"Selected users will be deleted!\\n\\nEverything these users had posted on "
+"this site will be permanently deleted!\\n\\nAre you sure?"
 msgstr ""
 
-#: mod/dfrn_request.php:853
+#: mod/admin.php:1428
+msgid ""
+"The user {0} will be deleted!\\n\\nEverything this user has posted on this "
+"site will be permanently deleted!\\n\\nAre you sure?"
+msgstr ""
+
+#: mod/admin.php:1438
+msgid "Name of the new user."
+msgstr ""
+
+#: mod/admin.php:1439
+msgid "Nickname"
+msgstr ""
+
+#: mod/admin.php:1439
+msgid "Nickname of the new user."
+msgstr ""
+
+#: mod/admin.php:1440
+msgid "Email address of the new user."
+msgstr ""
+
+#: mod/admin.php:1483
+#, php-format
+msgid "Plugin %s disabled."
+msgstr ""
+
+#: mod/admin.php:1487
+#, php-format
+msgid "Plugin %s enabled."
+msgstr ""
+
+#: mod/admin.php:1498 mod/admin.php:1734
+msgid "Disable"
+msgstr ""
+
+#: mod/admin.php:1500 mod/admin.php:1736
+msgid "Enable"
+msgstr ""
+
+#: mod/admin.php:1523 mod/admin.php:1781
+msgid "Toggle"
+msgstr ""
+
+#: mod/admin.php:1531 mod/admin.php:1790
+msgid "Author: "
+msgstr ""
+
+#: mod/admin.php:1532 mod/admin.php:1791
+msgid "Maintainer: "
+msgstr ""
+
+#: mod/admin.php:1584
+msgid "Reload active plugins"
+msgstr ""
+
+#: mod/admin.php:1589
 #, php-format
 msgid ""
-"If you are not yet a member of the free social web, <a href=\"%s/siteinfo"
-"\">follow this link to find a public Friendica site and join us today</a>."
+"There are currently no plugins available on your node. You can find the "
+"official plugin repository at %1$s and might find other interesting plugins "
+"in the open plugin registry at %2$s"
 msgstr ""
 
-#: mod/dfrn_request.php:858
-msgid "Friend/Connection Request"
+#: mod/admin.php:1694
+msgid "No themes found."
 msgstr ""
 
-#: mod/dfrn_request.php:859
-msgid ""
-"Examples: jojo@demo.friendica.com, http://demo.friendica.com/profile/jojo, "
-"testuser@identi.ca"
+#: mod/admin.php:1772
+msgid "Screenshot"
 msgstr ""
 
-#: mod/dfrn_request.php:868
-msgid "StatusNet/Federated Social Web"
+#: mod/admin.php:1832
+msgid "Reload active themes"
 msgstr ""
 
-#: mod/dfrn_request.php:870
+#: mod/admin.php:1837
 #, php-format
+msgid "No themes found on the system. They should be paced in %1$s"
+msgstr ""
+
+#: mod/admin.php:1838
+msgid "[Experimental]"
+msgstr ""
+
+#: mod/admin.php:1839
+msgid "[Unsupported]"
+msgstr ""
+
+#: mod/admin.php:1863
+msgid "Log settings updated."
+msgstr ""
+
+#: mod/admin.php:1895
+msgid "PHP log currently enabled."
+msgstr ""
+
+#: mod/admin.php:1897
+msgid "PHP log currently disabled."
+msgstr ""
+
+#: mod/admin.php:1906
+msgid "Clear"
+msgstr ""
+
+#: mod/admin.php:1911
+msgid "Enable Debugging"
+msgstr ""
+
+#: mod/admin.php:1912
+msgid "Log file"
+msgstr ""
+
+#: mod/admin.php:1912
 msgid ""
-" - please do not use this form.  Instead, enter %s into your Diaspora search "
-"bar."
+"Must be writable by web server. Relative to your Friendica top-level "
+"directory."
+msgstr ""
+
+#: mod/admin.php:1913
+msgid "Log level"
+msgstr ""
+
+#: mod/admin.php:1916
+msgid "PHP logging"
+msgstr ""
+
+#: mod/admin.php:1917
+msgid ""
+"To enable logging of PHP errors and warnings you can add the following to "
+"the .htconfig.php file of your installation. The filename set in the "
+"'error_log' line is relative to the friendica top-level directory and must "
+"be writeable by the web server. The option '1' for 'log_errors' and "
+"'display_errors' is to enable these options, set to '0' to disable them."
+msgstr ""
+
+#: mod/admin.php:2044 mod/admin.php:2045 mod/settings.php:778
+msgid "Off"
+msgstr ""
+
+#: mod/admin.php:2044 mod/admin.php:2045 mod/settings.php:778
+msgid "On"
+msgstr ""
+
+#: mod/admin.php:2045
+#, php-format
+msgid "Lock feature %s"
+msgstr ""
+
+#: mod/admin.php:2053
+msgid "Manage Additional Features"
+msgstr ""
+
+#: mod/wall_attach.php:94
+msgid "Sorry, maybe your upload is bigger than the PHP configuration allows"
+msgstr ""
+
+#: mod/wall_attach.php:94
+msgid "Or - did you try to upload an empty file?"
+msgstr ""
+
+#: mod/wall_attach.php:105
+#, php-format
+msgid "File exceeds size limit of %s"
+msgstr ""
+
+#: mod/wall_attach.php:156 mod/wall_attach.php:172
+msgid "File upload failed."
+msgstr ""
+
+#: mod/allfriends.php:43
+msgid "No friends to display."
+msgstr ""
+
+#: mod/cal.php:149 mod/display.php:328 mod/profile.php:155
+msgid "Access to this profile has been restricted."
+msgstr ""
+
+#: mod/cal.php:297
+msgid "User not found"
+msgstr ""
+
+#: mod/cal.php:313
+msgid "This calendar format is not supported"
+msgstr ""
+
+#: mod/cal.php:315
+msgid "No exportable data found"
+msgstr ""
+
+#: mod/cal.php:330
+msgid "calendar"
 msgstr ""
 
 #: mod/content.php:119 mod/network.php:469
 msgid "No such group"
+msgstr ""
+
+#: mod/content.php:130 mod/network.php:496 mod/group.php:193
+msgid "Group is empty"
 msgstr ""
 
 #: mod/content.php:135 mod/network.php:500
@@ -4513,12 +5623,6 @@ msgstr ""
 #: mod/content.php:725 mod/photos.php:1587 mod/photos.php:1635
 #: mod/photos.php:1721 object/Item.php:717
 msgid "This is you"
-msgstr ""
-
-#: mod/content.php:727 mod/content.php:945 mod/photos.php:1589
-#: mod/photos.php:1637 mod/photos.php:1723 object/Item.php:403
-#: object/Item.php:719 boot.php:970
-msgid "Comment"
 msgstr ""
 
 #: mod/content.php:729 object/Item.php:721
@@ -4590,6 +5694,10 @@ msgstr ""
 msgid "toggle ignore status"
 msgstr ""
 
+#: mod/content.php:792 mod/ostatus_subscribe.php:69 object/Item.php:245
+msgid "ignored"
+msgstr ""
+
 #: mod/content.php:803 object/Item.php:137
 msgid "save to folder"
 msgstr ""
@@ -4618,326 +5726,79 @@ msgstr ""
 msgid "via Wall-To-Wall:"
 msgstr ""
 
-#: mod/dfrn_confirm.php:66 mod/profiles.php:19 mod/profiles.php:134
-#: mod/profiles.php:180 mod/profiles.php:617
-msgid "Profile not found."
+#: mod/repair_ostatus.php:14
+msgid "Resubscribing to OStatus contacts"
 msgstr ""
 
-#: mod/dfrn_confirm.php:123
+#: mod/repair_ostatus.php:30
+msgid "Error"
+msgstr ""
+
+#: mod/repair_ostatus.php:44 mod/ostatus_subscribe.php:51
+msgid "Done"
+msgstr ""
+
+#: mod/repair_ostatus.php:50 mod/ostatus_subscribe.php:73
+msgid "Keep this window open until done."
+msgstr ""
+
+#: mod/delegate.php:101
+msgid "No potential page delegates located."
+msgstr ""
+
+#: mod/delegate.php:132
 msgid ""
-"This may occasionally happen if contact was requested by both persons and it "
-"has already been approved."
+"Delegates are able to manage all aspects of this account/page except for "
+"basic account settings. Please do not delegate your personal account to "
+"anybody that you do not trust completely."
 msgstr ""
 
-#: mod/dfrn_confirm.php:242
-msgid "Response from remote site was not understood."
+#: mod/delegate.php:133
+msgid "Existing Page Managers"
 msgstr ""
 
-#: mod/dfrn_confirm.php:251 mod/dfrn_confirm.php:256
-msgid "Unexpected response from remote site: "
+#: mod/delegate.php:135
+msgid "Existing Page Delegates"
 msgstr ""
 
-#: mod/dfrn_confirm.php:265
-msgid "Confirmation completed successfully."
+#: mod/delegate.php:137
+msgid "Potential Delegates"
 msgstr ""
 
-#: mod/dfrn_confirm.php:267 mod/dfrn_confirm.php:281 mod/dfrn_confirm.php:288
-msgid "Remote site reported: "
+#: mod/delegate.php:140
+msgid "Add"
 msgstr ""
 
-#: mod/dfrn_confirm.php:279
-msgid "Temporary failure. Please wait and try again."
+#: mod/delegate.php:141
+msgid "No entries."
 msgstr ""
 
-#: mod/dfrn_confirm.php:286
-msgid "Introduction failed or was revoked."
+#: mod/videos.php:120
+msgid "Do you really want to delete this video?"
 msgstr ""
 
-#: mod/dfrn_confirm.php:415
-msgid "Unable to set contact photo."
+#: mod/videos.php:125
+msgid "Delete Video"
 msgstr ""
 
-#: mod/dfrn_confirm.php:553
-#, php-format
-msgid "No user record found for '%s' "
+#: mod/videos.php:204
+msgid "No videos selected"
 msgstr ""
 
-#: mod/dfrn_confirm.php:563
-msgid "Our site encryption key is apparently messed up."
+#: mod/videos.php:305 mod/photos.php:1054
+msgid "Access to this item is restricted."
 msgstr ""
 
-#: mod/dfrn_confirm.php:574
-msgid "Empty site URL was provided or URL could not be decrypted by us."
+#: mod/videos.php:387 mod/photos.php:1847
+msgid "View Album"
 msgstr ""
 
-#: mod/dfrn_confirm.php:595
-msgid "Contact record was not found for you on our site."
+#: mod/videos.php:396
+msgid "Recent Videos"
 msgstr ""
 
-#: mod/dfrn_confirm.php:609
-#, php-format
-msgid "Site public key not available in contact record for URL %s."
-msgstr ""
-
-#: mod/dfrn_confirm.php:629
-msgid ""
-"The ID provided by your system is a duplicate on our system. It should work "
-"if you try again."
-msgstr ""
-
-#: mod/dfrn_confirm.php:640
-msgid "Unable to set your contact credentials on our system."
-msgstr ""
-
-#: mod/dfrn_confirm.php:699
-msgid "Unable to update your contact profile details on our system"
-msgstr ""
-
-#: mod/dfrn_confirm.php:771
-#, php-format
-msgid "%1$s has joined %2$s"
-msgstr ""
-
-#: mod/fsuggest.php:63
-msgid "Friend suggestion sent."
-msgstr ""
-
-#: mod/fsuggest.php:97
-msgid "Suggest Friends"
-msgstr ""
-
-#: mod/fsuggest.php:99
-#, php-format
-msgid "Suggest a friend for %s"
-msgstr ""
-
-#: mod/mood.php:133
-msgid "Mood"
-msgstr ""
-
-#: mod/mood.php:134
-msgid "Set your current mood and tell your friends"
-msgstr ""
-
-#: mod/poke.php:192
-msgid "Poke/Prod"
-msgstr ""
-
-#: mod/poke.php:193
-msgid "poke, prod or do other things to somebody"
-msgstr ""
-
-#: mod/poke.php:194
-msgid "Recipient"
-msgstr ""
-
-#: mod/poke.php:195
-msgid "Choose what you wish to do to recipient"
-msgstr ""
-
-#: mod/poke.php:198
-msgid "Make this post private"
-msgstr ""
-
-#: mod/profile_photo.php:44
-msgid "Image uploaded but image cropping failed."
-msgstr ""
-
-#: mod/profile_photo.php:77 mod/profile_photo.php:84 mod/profile_photo.php:91
-#: mod/profile_photo.php:314
-#, php-format
-msgid "Image size reduction [%s] failed."
-msgstr ""
-
-#: mod/profile_photo.php:124
-msgid ""
-"Shift-reload the page or clear browser cache if the new photo does not "
-"display immediately."
-msgstr ""
-
-#: mod/profile_photo.php:134
-msgid "Unable to process image"
-msgstr ""
-
-#: mod/profile_photo.php:150 mod/photos.php:786 mod/wall_upload.php:151
-#, php-format
-msgid "Image exceeds size limit of %s"
-msgstr ""
-
-#: mod/profile_photo.php:159 mod/photos.php:826 mod/wall_upload.php:188
-msgid "Unable to process image."
-msgstr ""
-
-#: mod/profile_photo.php:248
-msgid "Upload File:"
-msgstr ""
-
-#: mod/profile_photo.php:249
-msgid "Select a profile:"
-msgstr ""
-
-#: mod/profile_photo.php:251
-msgid "Upload"
-msgstr ""
-
-#: mod/profile_photo.php:254
-msgid "or"
-msgstr ""
-
-#: mod/profile_photo.php:254
-msgid "skip this step"
-msgstr ""
-
-#: mod/profile_photo.php:254
-msgid "select a photo from your photo albums"
-msgstr ""
-
-#: mod/profile_photo.php:268
-msgid "Crop Image"
-msgstr ""
-
-#: mod/profile_photo.php:269
-msgid "Please adjust the image cropping for optimum viewing."
-msgstr ""
-
-#: mod/profile_photo.php:271
-msgid "Done Editing"
-msgstr ""
-
-#: mod/profile_photo.php:305
-msgid "Image uploaded successfully."
-msgstr ""
-
-#: mod/profile_photo.php:307 mod/photos.php:853 mod/wall_upload.php:221
-msgid "Image upload failed."
-msgstr ""
-
-#: mod/regmod.php:55
-msgid "Account approved."
-msgstr ""
-
-#: mod/regmod.php:92
-#, php-format
-msgid "Registration revoked for %s"
-msgstr ""
-
-#: mod/regmod.php:104
-msgid "Please login."
-msgstr ""
-
-#: mod/notifications.php:35
-msgid "Invalid request identifier."
-msgstr ""
-
-#: mod/notifications.php:44 mod/notifications.php:180
-#: mod/notifications.php:252
-msgid "Discard"
-msgstr ""
-
-#: mod/notifications.php:60 mod/notifications.php:179
-#: mod/notifications.php:251 mod/contacts.php:606 mod/contacts.php:806
-#: mod/contacts.php:1000
-msgid "Ignore"
-msgstr ""
-
-#: mod/notifications.php:105
-msgid "Network Notifications"
-msgstr ""
-
-#: mod/notifications.php:117
-msgid "Personal Notifications"
-msgstr ""
-
-#: mod/notifications.php:123
-msgid "Home Notifications"
-msgstr ""
-
-#: mod/notifications.php:152
-msgid "Show Ignored Requests"
-msgstr ""
-
-#: mod/notifications.php:152
-msgid "Hide Ignored Requests"
-msgstr ""
-
-#: mod/notifications.php:164 mod/notifications.php:222
-msgid "Notification type: "
-msgstr ""
-
-#: mod/notifications.php:167
-#, php-format
-msgid "suggested by %s"
-msgstr ""
-
-#: mod/notifications.php:172 mod/notifications.php:239 mod/contacts.php:613
-msgid "Hide this contact from others"
-msgstr ""
-
-#: mod/notifications.php:173 mod/notifications.php:240
-msgid "Post a new friend activity"
-msgstr ""
-
-#: mod/notifications.php:173 mod/notifications.php:240
-msgid "if applicable"
-msgstr ""
-
-#: mod/notifications.php:176 mod/notifications.php:249 mod/admin.php:1408
-msgid "Approve"
-msgstr ""
-
-#: mod/notifications.php:195
-msgid "Claims to be known to you: "
-msgstr ""
-
-#: mod/notifications.php:196
-msgid "yes"
-msgstr ""
-
-#: mod/notifications.php:196
-msgid "no"
-msgstr ""
-
-#: mod/notifications.php:197
-msgid ""
-"Shall your connection be bidirectional or not? \"Friend\" implies that you "
-"allow to read and you subscribe to their posts. \"Fan/Admirer\" means that "
-"you allow to read but you do not want to read theirs. Approve as: "
-msgstr ""
-
-#: mod/notifications.php:200
-msgid ""
-"Shall your connection be bidirectional or not? \"Friend\" implies that you "
-"allow to read and you subscribe to their posts. \"Sharer\" means that you "
-"allow to read but you do not want to read theirs. Approve as: "
-msgstr ""
-
-#: mod/notifications.php:209
-msgid "Friend"
-msgstr ""
-
-#: mod/notifications.php:210
-msgid "Sharer"
-msgstr ""
-
-#: mod/notifications.php:210
-msgid "Fan/Admirer"
-msgstr ""
-
-#: mod/notifications.php:260
-msgid "No introductions."
-msgstr ""
-
-#: mod/notifications.php:299
-msgid "Show unread"
-msgstr ""
-
-#: mod/notifications.php:299
-msgid "Show all"
-msgstr ""
-
-#: mod/notifications.php:305
-#, php-format
-msgid "No more %s notifications."
+#: mod/videos.php:398
+msgid "Upload New Videos"
 msgstr ""
 
 #: mod/profiles.php:38
@@ -5039,6 +5900,16 @@ msgstr ""
 msgid "Hide contacts and friends:"
 msgstr ""
 
+#: mod/profiles.php:648 mod/profiles.php:652 mod/profiles.php:677
+#: mod/follow.php:110 mod/dfrn_request.php:862 mod/register.php:246
+#: mod/settings.php:1163 mod/settings.php:1169 mod/settings.php:1177
+#: mod/settings.php:1181 mod/settings.php:1186 mod/settings.php:1192
+#: mod/settings.php:1198 mod/settings.php:1204 mod/settings.php:1230
+#: mod/settings.php:1231 mod/settings.php:1232 mod/settings.php:1233
+#: mod/settings.php:1234 mod/api.php:106
+msgid "No"
+msgstr ""
+
 #: mod/profiles.php:650
 msgid "Hide your contact/friend list from viewers of this profile?"
 msgstr ""
@@ -5099,6 +5970,10 @@ msgstr ""
 msgid "Relation"
 msgstr ""
 
+#: mod/profiles.php:707 mod/newmember.php:36 mod/profile_photo.php:250
+msgid "Upload Profile Photo"
+msgstr ""
+
 #: mod/profiles.php:708
 msgid "Your Gender:"
 msgstr ""
@@ -5113,10 +5988,6 @@ msgstr ""
 
 #: mod/profiles.php:716
 msgid "Profile Name:"
-msgstr ""
-
-#: mod/profiles.php:716 mod/events.php:484 mod/events.php:496
-msgid "Required"
 msgstr ""
 
 #: mod/profiles.php:718
@@ -5243,477 +6114,217 @@ msgstr ""
 msgid "Edit/Manage Profiles"
 msgstr ""
 
-#: mod/allfriends.php:43
-msgid "No friends to display."
+#: mod/credits.php:16
+msgid "Credits"
 msgstr ""
 
-#: mod/cal.php:149 mod/display.php:328 mod/profile.php:155
-msgid "Access to this profile has been restricted."
-msgstr ""
-
-#: mod/cal.php:276 mod/events.php:380
-msgid "View"
-msgstr ""
-
-#: mod/cal.php:277 mod/events.php:382
-msgid "Previous"
-msgstr ""
-
-#: mod/cal.php:278 mod/events.php:383 mod/install.php:231
-msgid "Next"
-msgstr ""
-
-#: mod/cal.php:287 mod/events.php:392
-msgid "list"
-msgstr ""
-
-#: mod/cal.php:297
-msgid "User not found"
-msgstr ""
-
-#: mod/cal.php:313
-msgid "This calendar format is not supported"
-msgstr ""
-
-#: mod/cal.php:315
-msgid "No exportable data found"
-msgstr ""
-
-#: mod/cal.php:330
-msgid "calendar"
-msgstr ""
-
-#: mod/common.php:86
-msgid "No contacts in common."
-msgstr ""
-
-#: mod/common.php:134 mod/contacts.php:863
-msgid "Common Friends"
-msgstr ""
-
-#: mod/community.php:27
-msgid "Not available."
-msgstr ""
-
-#: mod/contacts.php:128
-#, php-format
-msgid "%d contact edited."
-msgid_plural "%d contacts edited."
-msgstr[0] ""
-msgstr[1] ""
-
-#: mod/contacts.php:159 mod/contacts.php:368
-msgid "Could not access contact record."
-msgstr ""
-
-#: mod/contacts.php:173
-msgid "Could not locate selected profile."
-msgstr ""
-
-#: mod/contacts.php:206
-msgid "Contact updated."
-msgstr ""
-
-#: mod/contacts.php:389
-msgid "Contact has been blocked"
-msgstr ""
-
-#: mod/contacts.php:389
-msgid "Contact has been unblocked"
-msgstr ""
-
-#: mod/contacts.php:400
-msgid "Contact has been ignored"
-msgstr ""
-
-#: mod/contacts.php:400
-msgid "Contact has been unignored"
-msgstr ""
-
-#: mod/contacts.php:412
-msgid "Contact has been archived"
-msgstr ""
-
-#: mod/contacts.php:412
-msgid "Contact has been unarchived"
-msgstr ""
-
-#: mod/contacts.php:437
-msgid "Drop contact"
-msgstr ""
-
-#: mod/contacts.php:440 mod/contacts.php:801
-msgid "Do you really want to delete this contact?"
-msgstr ""
-
-#: mod/contacts.php:457
-msgid "Contact has been removed."
-msgstr ""
-
-#: mod/contacts.php:498
-#, php-format
-msgid "You are mutual friends with %s"
-msgstr ""
-
-#: mod/contacts.php:502
-#, php-format
-msgid "You are sharing with %s"
-msgstr ""
-
-#: mod/contacts.php:507
-#, php-format
-msgid "%s is sharing with you"
-msgstr ""
-
-#: mod/contacts.php:527
-msgid "Private communications are not available for this contact."
-msgstr ""
-
-#: mod/contacts.php:530 mod/admin.php:885
-msgid "Never"
-msgstr ""
-
-#: mod/contacts.php:534
-msgid "(Update was successful)"
-msgstr ""
-
-#: mod/contacts.php:534
-msgid "(Update was not successful)"
-msgstr ""
-
-#: mod/contacts.php:536 mod/contacts.php:973
-msgid "Suggest friends"
-msgstr ""
-
-#: mod/contacts.php:540
-#, php-format
-msgid "Network type: %s"
-msgstr ""
-
-#: mod/contacts.php:553
-msgid "Communications lost with this contact!"
-msgstr ""
-
-#: mod/contacts.php:556
-msgid "Fetch further information for feeds"
-msgstr ""
-
-#: mod/contacts.php:557 mod/admin.php:894
-msgid "Disabled"
-msgstr ""
-
-#: mod/contacts.php:557
-msgid "Fetch information"
-msgstr ""
-
-#: mod/contacts.php:557
-msgid "Fetch information and keywords"
-msgstr ""
-
-#: mod/contacts.php:575
-msgid "Contact"
-msgstr ""
-
-#: mod/contacts.php:578
-msgid "Profile Visibility"
-msgstr ""
-
-#: mod/contacts.php:579
-#, php-format
+#: mod/credits.php:17
 msgid ""
-"Please choose the profile you would like to display to %s when viewing your "
-"profile securely."
+"Friendica is a community project, that would not be possible without the "
+"help of many people. Here is a list of those who have contributed to the "
+"code or the translation of Friendica. Thank you all!"
 msgstr ""
 
-#: mod/contacts.php:580
-msgid "Contact Information / Notes"
+#: mod/filer.php:30
+msgid "- select -"
 msgstr ""
 
-#: mod/contacts.php:581
-msgid "Edit contact notes"
+#: mod/poke.php:192
+msgid "Poke/Prod"
 msgstr ""
 
-#: mod/contacts.php:587
-msgid "Block/Unblock contact"
+#: mod/poke.php:193
+msgid "poke, prod or do other things to somebody"
 msgstr ""
 
-#: mod/contacts.php:588
-msgid "Ignore contact"
+#: mod/poke.php:194
+msgid "Recipient"
 msgstr ""
 
-#: mod/contacts.php:589
-msgid "Repair URL settings"
+#: mod/poke.php:195
+msgid "Choose what you wish to do to recipient"
 msgstr ""
 
-#: mod/contacts.php:590
-msgid "View conversations"
+#: mod/poke.php:198
+msgid "Make this post private"
 msgstr ""
 
-#: mod/contacts.php:596
-msgid "Last update:"
+#: mod/photos.php:88 mod/photos.php:1856
+msgid "Recent Photos"
 msgstr ""
 
-#: mod/contacts.php:598
-msgid "Update public posts"
+#: mod/photos.php:91 mod/photos.php:1283 mod/photos.php:1858
+msgid "Upload New Photos"
 msgstr ""
 
-#: mod/contacts.php:600 mod/contacts.php:983
-msgid "Update now"
+#: mod/photos.php:105 mod/settings.php:36
+msgid "everybody"
 msgstr ""
 
-#: mod/contacts.php:605 mod/contacts.php:805 mod/contacts.php:992
-#: mod/admin.php:1412
-msgid "Unblock"
+#: mod/photos.php:169
+msgid "Contact information unavailable"
 msgstr ""
 
-#: mod/contacts.php:605 mod/contacts.php:805 mod/contacts.php:992
-#: mod/admin.php:1411
-msgid "Block"
+#: mod/photos.php:190
+msgid "Album not found."
 msgstr ""
 
-#: mod/contacts.php:606 mod/contacts.php:806 mod/contacts.php:1000
-msgid "Unignore"
+#: mod/photos.php:220 mod/photos.php:232 mod/photos.php:1227
+msgid "Delete Album"
 msgstr ""
 
-#: mod/contacts.php:610
-msgid "Currently blocked"
+#: mod/photos.php:230
+msgid "Do you really want to delete this photo album and all its photos?"
 msgstr ""
 
-#: mod/contacts.php:611
-msgid "Currently ignored"
+#: mod/photos.php:308 mod/photos.php:319 mod/photos.php:1540
+msgid "Delete Photo"
 msgstr ""
 
-#: mod/contacts.php:612
-msgid "Currently archived"
+#: mod/photos.php:317
+msgid "Do you really want to delete this photo?"
 msgstr ""
 
-#: mod/contacts.php:613
-msgid ""
-"Replies/likes to your public posts <strong>may</strong> still be visible"
-msgstr ""
-
-#: mod/contacts.php:614
-msgid "Notification for new posts"
-msgstr ""
-
-#: mod/contacts.php:614
-msgid "Send a notification of every new post of this contact"
-msgstr ""
-
-#: mod/contacts.php:617
-msgid "Blacklisted keywords"
-msgstr ""
-
-#: mod/contacts.php:617
-msgid ""
-"Comma separated list of keywords that should not be converted to hashtags, "
-"when \"Fetch information and keywords\" is selected"
-msgstr ""
-
-#: mod/contacts.php:635
-msgid "Actions"
-msgstr ""
-
-#: mod/contacts.php:638
-msgid "Contact Settings"
-msgstr ""
-
-#: mod/contacts.php:684
-msgid "Suggestions"
-msgstr ""
-
-#: mod/contacts.php:687
-msgid "Suggest potential friends"
-msgstr ""
-
-#: mod/contacts.php:695
-msgid "Show all contacts"
-msgstr ""
-
-#: mod/contacts.php:700
-msgid "Unblocked"
-msgstr ""
-
-#: mod/contacts.php:703
-msgid "Only show unblocked contacts"
-msgstr ""
-
-#: mod/contacts.php:709
-msgid "Blocked"
-msgstr ""
-
-#: mod/contacts.php:712
-msgid "Only show blocked contacts"
-msgstr ""
-
-#: mod/contacts.php:718
-msgid "Ignored"
-msgstr ""
-
-#: mod/contacts.php:721
-msgid "Only show ignored contacts"
-msgstr ""
-
-#: mod/contacts.php:727
-msgid "Archived"
-msgstr ""
-
-#: mod/contacts.php:730
-msgid "Only show archived contacts"
-msgstr ""
-
-#: mod/contacts.php:736
-msgid "Hidden"
-msgstr ""
-
-#: mod/contacts.php:739
-msgid "Only show hidden contacts"
-msgstr ""
-
-#: mod/contacts.php:796
-msgid "Search your contacts"
-msgstr ""
-
-#: mod/contacts.php:804 mod/settings.php:158 mod/settings.php:704
-msgid "Update"
-msgstr ""
-
-#: mod/contacts.php:807 mod/contacts.php:1008
-msgid "Archive"
-msgstr ""
-
-#: mod/contacts.php:807 mod/contacts.php:1008
-msgid "Unarchive"
-msgstr ""
-
-#: mod/contacts.php:810
-msgid "Batch Actions"
-msgstr ""
-
-#: mod/contacts.php:856
-msgid "View all contacts"
-msgstr ""
-
-#: mod/contacts.php:866
-msgid "View all common friends"
-msgstr ""
-
-#: mod/contacts.php:873
-msgid "Advanced Contact Settings"
-msgstr ""
-
-#: mod/contacts.php:916
-msgid "Mutual Friendship"
-msgstr ""
-
-#: mod/contacts.php:920
-msgid "is a fan of yours"
-msgstr ""
-
-#: mod/contacts.php:924
-msgid "you are a fan of"
-msgstr ""
-
-#: mod/contacts.php:994
-msgid "Toggle Blocked status"
-msgstr ""
-
-#: mod/contacts.php:1002
-msgid "Toggle Ignored status"
-msgstr ""
-
-#: mod/contacts.php:1010
-msgid "Toggle Archive status"
-msgstr ""
-
-#: mod/contacts.php:1018
-msgid "Delete contact"
-msgstr ""
-
-#: mod/directory.php:197 view/theme/vier/theme.php:201
-msgid "Global Directory"
-msgstr ""
-
-#: mod/directory.php:199
-msgid "Find on this site"
-msgstr ""
-
-#: mod/directory.php:201
-msgid "Results for:"
-msgstr ""
-
-#: mod/directory.php:203
-msgid "Site Directory"
-msgstr ""
-
-#: mod/directory.php:210
-msgid "No entries (some entries may be hidden)."
-msgstr ""
-
-#: mod/dirfind.php:36
+#: mod/photos.php:688
 #, php-format
-msgid "People Search - %s"
+msgid "%1$s was tagged in %2$s by %3$s"
 msgstr ""
 
-#: mod/dirfind.php:47
+#: mod/photos.php:688
+msgid "a photo"
+msgstr ""
+
+#: mod/photos.php:794
+msgid "Image file is empty."
+msgstr ""
+
+#: mod/photos.php:954
+msgid "No photos selected"
+msgstr ""
+
+#: mod/photos.php:1114
 #, php-format
-msgid "Forum Search - %s"
+msgid "You have used %1$.2f Mbytes of %2$.2f Mbytes photo storage."
 msgstr ""
 
-#: mod/dirfind.php:240 mod/match.php:107
-msgid "No matches"
+#: mod/photos.php:1148
+msgid "Upload Photos"
 msgstr ""
 
-#: mod/display.php:473
-msgid "Item has been removed."
+#: mod/photos.php:1152 mod/photos.php:1222
+msgid "New album name: "
 msgstr ""
 
-#: mod/events.php:95 mod/events.php:97
-msgid "Event can not end before it has started."
+#: mod/photos.php:1153
+msgid "or existing album name: "
 msgstr ""
 
-#: mod/events.php:104 mod/events.php:106
-msgid "Event title and start time are required."
+#: mod/photos.php:1154
+msgid "Do not show a status post for this upload"
 msgstr ""
 
-#: mod/events.php:381
-msgid "Create New Event"
+#: mod/photos.php:1165 mod/photos.php:1544 mod/settings.php:1300
+msgid "Show to Groups"
 msgstr ""
 
-#: mod/events.php:482
-msgid "Event details"
+#: mod/photos.php:1166 mod/photos.php:1545 mod/settings.php:1301
+msgid "Show to Contacts"
 msgstr ""
 
-#: mod/events.php:483
-msgid "Starting date and Title are required."
+#: mod/photos.php:1167
+msgid "Private Photo"
 msgstr ""
 
-#: mod/events.php:484 mod/events.php:485
-msgid "Event Starts:"
+#: mod/photos.php:1168
+msgid "Public Photo"
 msgstr ""
 
-#: mod/events.php:486 mod/events.php:502
-msgid "Finish date/time is not known or not relevant"
+#: mod/photos.php:1234
+msgid "Edit Album"
 msgstr ""
 
-#: mod/events.php:488 mod/events.php:489
-msgid "Event Finishes:"
+#: mod/photos.php:1240
+msgid "Show Newest First"
 msgstr ""
 
-#: mod/events.php:490 mod/events.php:503
-msgid "Adjust for viewer timezone"
+#: mod/photos.php:1242
+msgid "Show Oldest First"
 msgstr ""
 
-#: mod/events.php:492
-msgid "Description:"
+#: mod/photos.php:1269 mod/photos.php:1841
+msgid "View Photo"
 msgstr ""
 
-#: mod/events.php:496 mod/events.php:498
-msgid "Title:"
+#: mod/photos.php:1315
+msgid "Permission denied. Access to this item may be restricted."
 msgstr ""
 
-#: mod/events.php:499 mod/events.php:500
-msgid "Share this event"
+#: mod/photos.php:1317
+msgid "Photo not available"
+msgstr ""
+
+#: mod/photos.php:1372
+msgid "View photo"
+msgstr ""
+
+#: mod/photos.php:1372
+msgid "Edit photo"
+msgstr ""
+
+#: mod/photos.php:1373
+msgid "Use as profile photo"
+msgstr ""
+
+#: mod/photos.php:1398
+msgid "View Full Size"
+msgstr ""
+
+#: mod/photos.php:1484
+msgid "Tags: "
+msgstr ""
+
+#: mod/photos.php:1487
+msgid "[Remove any tag]"
+msgstr ""
+
+#: mod/photos.php:1526
+msgid "New album name"
+msgstr ""
+
+#: mod/photos.php:1527
+msgid "Caption"
+msgstr ""
+
+#: mod/photos.php:1528
+msgid "Add a Tag"
+msgstr ""
+
+#: mod/photos.php:1528
+msgid "Example: @bob, @Barbara_Jensen, @jim@example.com, #California, #camping"
+msgstr ""
+
+#: mod/photos.php:1529
+msgid "Do not rotate"
+msgstr ""
+
+#: mod/photos.php:1530
+msgid "Rotate CW (right)"
+msgstr ""
+
+#: mod/photos.php:1531
+msgid "Rotate CCW (left)"
+msgstr ""
+
+#: mod/photos.php:1546
+msgid "Private photo"
+msgstr ""
+
+#: mod/photos.php:1547
+msgid "Public photo"
+msgstr ""
+
+#: mod/photos.php:1770
+msgid "Map"
 msgstr ""
 
 #: mod/install.php:139
@@ -6068,24 +6679,395 @@ msgid ""
 "IMPORTANT: You will need to [manually] setup a scheduled task for the poller."
 msgstr ""
 
-#: mod/maintenance.php:9
-msgid "System down for maintenance"
+#: mod/subthread.php:103
+#, php-format
+msgid "%1$s is following %2$s's %3$s"
 msgstr ""
 
-#: mod/match.php:33
-msgid "No keywords to match. Please add keywords to your default profile."
+#: mod/attach.php:8
+msgid "Item not available."
 msgstr ""
 
-#: mod/match.php:86
-msgid "is interested in:"
+#: mod/attach.php:20
+msgid "Item was not found."
 msgstr ""
 
-#: mod/match.php:100
-msgid "Profile Match"
+#: mod/contacts.php:128
+#, php-format
+msgid "%d contact edited."
+msgid_plural "%d contacts edited."
+msgstr[0] ""
+msgstr[1] ""
+
+#: mod/contacts.php:159 mod/contacts.php:368
+msgid "Could not access contact record."
 msgstr ""
 
-#: mod/profile.php:179
-msgid "Tips for New Members"
+#: mod/contacts.php:173
+msgid "Could not locate selected profile."
+msgstr ""
+
+#: mod/contacts.php:206
+msgid "Contact updated."
+msgstr ""
+
+#: mod/contacts.php:208 mod/dfrn_request.php:583
+msgid "Failed to update contact record."
+msgstr ""
+
+#: mod/contacts.php:389
+msgid "Contact has been blocked"
+msgstr ""
+
+#: mod/contacts.php:389
+msgid "Contact has been unblocked"
+msgstr ""
+
+#: mod/contacts.php:400
+msgid "Contact has been ignored"
+msgstr ""
+
+#: mod/contacts.php:400
+msgid "Contact has been unignored"
+msgstr ""
+
+#: mod/contacts.php:412
+msgid "Contact has been archived"
+msgstr ""
+
+#: mod/contacts.php:412
+msgid "Contact has been unarchived"
+msgstr ""
+
+#: mod/contacts.php:437
+msgid "Drop contact"
+msgstr ""
+
+#: mod/contacts.php:440 mod/contacts.php:801
+msgid "Do you really want to delete this contact?"
+msgstr ""
+
+#: mod/contacts.php:457
+msgid "Contact has been removed."
+msgstr ""
+
+#: mod/contacts.php:498
+#, php-format
+msgid "You are mutual friends with %s"
+msgstr ""
+
+#: mod/contacts.php:502
+#, php-format
+msgid "You are sharing with %s"
+msgstr ""
+
+#: mod/contacts.php:507
+#, php-format
+msgid "%s is sharing with you"
+msgstr ""
+
+#: mod/contacts.php:527
+msgid "Private communications are not available for this contact."
+msgstr ""
+
+#: mod/contacts.php:534
+msgid "(Update was successful)"
+msgstr ""
+
+#: mod/contacts.php:534
+msgid "(Update was not successful)"
+msgstr ""
+
+#: mod/contacts.php:536 mod/contacts.php:973
+msgid "Suggest friends"
+msgstr ""
+
+#: mod/contacts.php:540
+#, php-format
+msgid "Network type: %s"
+msgstr ""
+
+#: mod/contacts.php:553
+msgid "Communications lost with this contact!"
+msgstr ""
+
+#: mod/contacts.php:556
+msgid "Fetch further information for feeds"
+msgstr ""
+
+#: mod/contacts.php:557
+msgid "Fetch information"
+msgstr ""
+
+#: mod/contacts.php:557
+msgid "Fetch information and keywords"
+msgstr ""
+
+#: mod/contacts.php:575
+msgid "Contact"
+msgstr ""
+
+#: mod/contacts.php:578
+msgid "Profile Visibility"
+msgstr ""
+
+#: mod/contacts.php:579
+#, php-format
+msgid ""
+"Please choose the profile you would like to display to %s when viewing your "
+"profile securely."
+msgstr ""
+
+#: mod/contacts.php:580
+msgid "Contact Information / Notes"
+msgstr ""
+
+#: mod/contacts.php:581
+msgid "Edit contact notes"
+msgstr ""
+
+#: mod/contacts.php:587
+msgid "Block/Unblock contact"
+msgstr ""
+
+#: mod/contacts.php:588
+msgid "Ignore contact"
+msgstr ""
+
+#: mod/contacts.php:589
+msgid "Repair URL settings"
+msgstr ""
+
+#: mod/contacts.php:590
+msgid "View conversations"
+msgstr ""
+
+#: mod/contacts.php:596
+msgid "Last update:"
+msgstr ""
+
+#: mod/contacts.php:598
+msgid "Update public posts"
+msgstr ""
+
+#: mod/contacts.php:600 mod/contacts.php:983
+msgid "Update now"
+msgstr ""
+
+#: mod/contacts.php:606 mod/contacts.php:806 mod/contacts.php:1000
+msgid "Unignore"
+msgstr ""
+
+#: mod/contacts.php:610
+msgid "Currently blocked"
+msgstr ""
+
+#: mod/contacts.php:611
+msgid "Currently ignored"
+msgstr ""
+
+#: mod/contacts.php:612
+msgid "Currently archived"
+msgstr ""
+
+#: mod/contacts.php:613
+msgid ""
+"Replies/likes to your public posts <strong>may</strong> still be visible"
+msgstr ""
+
+#: mod/contacts.php:614
+msgid "Notification for new posts"
+msgstr ""
+
+#: mod/contacts.php:614
+msgid "Send a notification of every new post of this contact"
+msgstr ""
+
+#: mod/contacts.php:617
+msgid "Blacklisted keywords"
+msgstr ""
+
+#: mod/contacts.php:617
+msgid ""
+"Comma separated list of keywords that should not be converted to hashtags, "
+"when \"Fetch information and keywords\" is selected"
+msgstr ""
+
+#: mod/contacts.php:635
+msgid "Actions"
+msgstr ""
+
+#: mod/contacts.php:638
+msgid "Contact Settings"
+msgstr ""
+
+#: mod/contacts.php:684
+msgid "Suggestions"
+msgstr ""
+
+#: mod/contacts.php:687
+msgid "Suggest potential friends"
+msgstr ""
+
+#: mod/contacts.php:692 mod/group.php:192
+msgid "All Contacts"
+msgstr ""
+
+#: mod/contacts.php:695
+msgid "Show all contacts"
+msgstr ""
+
+#: mod/contacts.php:700
+msgid "Unblocked"
+msgstr ""
+
+#: mod/contacts.php:703
+msgid "Only show unblocked contacts"
+msgstr ""
+
+#: mod/contacts.php:709
+msgid "Blocked"
+msgstr ""
+
+#: mod/contacts.php:712
+msgid "Only show blocked contacts"
+msgstr ""
+
+#: mod/contacts.php:718
+msgid "Ignored"
+msgstr ""
+
+#: mod/contacts.php:721
+msgid "Only show ignored contacts"
+msgstr ""
+
+#: mod/contacts.php:727
+msgid "Archived"
+msgstr ""
+
+#: mod/contacts.php:730
+msgid "Only show archived contacts"
+msgstr ""
+
+#: mod/contacts.php:736
+msgid "Hidden"
+msgstr ""
+
+#: mod/contacts.php:739
+msgid "Only show hidden contacts"
+msgstr ""
+
+#: mod/contacts.php:796
+msgid "Search your contacts"
+msgstr ""
+
+#: mod/contacts.php:804 mod/settings.php:158 mod/settings.php:704
+msgid "Update"
+msgstr ""
+
+#: mod/contacts.php:807 mod/contacts.php:1008
+msgid "Archive"
+msgstr ""
+
+#: mod/contacts.php:807 mod/contacts.php:1008
+msgid "Unarchive"
+msgstr ""
+
+#: mod/contacts.php:810
+msgid "Batch Actions"
+msgstr ""
+
+#: mod/contacts.php:856
+msgid "View all contacts"
+msgstr ""
+
+#: mod/contacts.php:863 mod/common.php:134
+msgid "Common Friends"
+msgstr ""
+
+#: mod/contacts.php:866
+msgid "View all common friends"
+msgstr ""
+
+#: mod/contacts.php:873
+msgid "Advanced Contact Settings"
+msgstr ""
+
+#: mod/contacts.php:916
+msgid "Mutual Friendship"
+msgstr ""
+
+#: mod/contacts.php:920
+msgid "is a fan of yours"
+msgstr ""
+
+#: mod/contacts.php:924
+msgid "you are a fan of"
+msgstr ""
+
+#: mod/contacts.php:994
+msgid "Toggle Blocked status"
+msgstr ""
+
+#: mod/contacts.php:1002
+msgid "Toggle Ignored status"
+msgstr ""
+
+#: mod/contacts.php:1010
+msgid "Toggle Archive status"
+msgstr ""
+
+#: mod/contacts.php:1018
+msgid "Delete contact"
+msgstr ""
+
+#: mod/follow.php:19 mod/dfrn_request.php:875
+msgid "Submit Request"
+msgstr ""
+
+#: mod/follow.php:30
+msgid "You already added this contact."
+msgstr ""
+
+#: mod/follow.php:39
+msgid "Diaspora support isn't enabled. Contact can't be added."
+msgstr ""
+
+#: mod/follow.php:46
+msgid "OStatus support is disabled. Contact can't be added."
+msgstr ""
+
+#: mod/follow.php:53
+msgid "The network type couldn't be detected. Contact can't be added."
+msgstr ""
+
+#: mod/follow.php:109 mod/dfrn_request.php:861
+msgid "Please answer the following:"
+msgstr ""
+
+#: mod/follow.php:110 mod/dfrn_request.php:862
+#, php-format
+msgid "Does %s know you?"
+msgstr ""
+
+#: mod/follow.php:111 mod/dfrn_request.php:866
+msgid "Add a personal note:"
+msgstr ""
+
+#: mod/follow.php:117 mod/dfrn_request.php:872
+msgid "Your Identity Address:"
+msgstr ""
+
+#: mod/follow.php:180
+msgid "Contact added"
+msgstr ""
+
+#: mod/apps.php:11
+msgid "Applications"
+msgstr ""
+
+#: mod/apps.php:14
+msgid "No installed applications."
 msgstr ""
 
 #: mod/suggest.php:27
@@ -6102,1431 +7084,211 @@ msgstr ""
 msgid "Ignore/Hide"
 msgstr ""
 
-#: mod/update_community.php:19 mod/update_display.php:23
-#: mod/update_network.php:27 mod/update_notes.php:36 mod/update_profile.php:35
-msgid "[Embedded content - reload page to view]"
+#: mod/p.php:9
+msgid "Not Extended"
 msgstr ""
 
-#: mod/admin.php:92
-msgid "Theme settings updated."
+#: mod/display.php:473
+msgid "Item has been removed."
 msgstr ""
 
-#: mod/admin.php:156 mod/admin.php:951
-msgid "Site"
+#: mod/common.php:86
+msgid "No contacts in common."
 msgstr ""
 
-#: mod/admin.php:157 mod/admin.php:895 mod/admin.php:1400 mod/admin.php:1416
-msgid "Users"
+#: mod/newmember.php:6
+msgid "Welcome to Friendica"
 msgstr ""
 
-#: mod/admin.php:158 mod/admin.php:1518 mod/admin.php:1578 mod/settings.php:74
-msgid "Plugins"
+#: mod/newmember.php:8
+msgid "New Member Checklist"
 msgstr ""
 
-#: mod/admin.php:159 mod/admin.php:1776 mod/admin.php:1826
-msgid "Themes"
-msgstr ""
-
-#: mod/admin.php:160 mod/settings.php:52
-msgid "Additional features"
-msgstr ""
-
-#: mod/admin.php:161
-msgid "DB updates"
-msgstr ""
-
-#: mod/admin.php:162 mod/admin.php:406
-msgid "Inspect Queue"
-msgstr ""
-
-#: mod/admin.php:163 mod/admin.php:372
-msgid "Federation Statistics"
-msgstr ""
-
-#: mod/admin.php:177 mod/admin.php:188 mod/admin.php:1900
-msgid "Logs"
-msgstr ""
-
-#: mod/admin.php:178 mod/admin.php:1968
-msgid "View Logs"
-msgstr ""
-
-#: mod/admin.php:179
-msgid "probe address"
-msgstr ""
-
-#: mod/admin.php:180
-msgid "check webfinger"
-msgstr ""
-
-#: mod/admin.php:187
-msgid "Plugin Features"
-msgstr ""
-
-#: mod/admin.php:189
-msgid "diagnostics"
-msgstr ""
-
-#: mod/admin.php:190
-msgid "User registrations waiting for confirmation"
-msgstr ""
-
-#: mod/admin.php:306
-msgid "unknown"
-msgstr ""
-
-#: mod/admin.php:365
-msgid ""
-"This page offers you some numbers to the known part of the federated social "
-"network your Friendica node is part of. These numbers are not complete but "
-"only reflect the part of the network your node is aware of."
-msgstr ""
-
-#: mod/admin.php:366
-msgid ""
-"The <em>Auto Discovered Contact Directory</em> feature is not enabled, it "
-"will improve the data displayed here."
-msgstr ""
-
-#: mod/admin.php:371 mod/admin.php:405 mod/admin.php:483 mod/admin.php:950
-#: mod/admin.php:1399 mod/admin.php:1517 mod/admin.php:1577 mod/admin.php:1775
-#: mod/admin.php:1825 mod/admin.php:1899 mod/admin.php:1967
-msgid "Administration"
-msgstr ""
-
-#: mod/admin.php:378
-#, php-format
-msgid "Currently this node is aware of %d nodes from the following platforms:"
-msgstr ""
-
-#: mod/admin.php:408
-msgid "ID"
-msgstr ""
-
-#: mod/admin.php:409
-msgid "Recipient Name"
-msgstr ""
-
-#: mod/admin.php:410
-msgid "Recipient Profile"
-msgstr ""
-
-#: mod/admin.php:412
-msgid "Created"
-msgstr ""
-
-#: mod/admin.php:413
-msgid "Last Tried"
-msgstr ""
-
-#: mod/admin.php:414
-msgid ""
-"This page lists the content of the queue for outgoing postings. These are "
-"postings the initial delivery failed for. They will be resend later and "
-"eventually deleted if the delivery fails permanently."
-msgstr ""
-
-#: mod/admin.php:438
-#, php-format
-msgid ""
-"Your DB still runs with MyISAM tables. You should change the engine type to "
-"InnoDB. As Friendica will use InnoDB only features in the future, you should "
-"change this! See <a href=\"%s\">here</a> for a guide that may be helpful "
-"converting the table engines. You may also use the <tt>convert_innodb.sql</"
-"tt> in the <tt>/util</tt> directory of your Friendica installation.<br />"
-msgstr ""
-
-#: mod/admin.php:443
-msgid ""
-"You are using a MySQL version which does not support all features that "
-"Friendica uses. You should consider switching to MariaDB."
-msgstr ""
-
-#: mod/admin.php:447 mod/admin.php:1348
-msgid "Normal Account"
-msgstr ""
-
-#: mod/admin.php:448 mod/admin.php:1349
-msgid "Soapbox Account"
-msgstr ""
-
-#: mod/admin.php:449 mod/admin.php:1350
-msgid "Community/Celebrity Account"
-msgstr ""
-
-#: mod/admin.php:450 mod/admin.php:1351
-msgid "Automatic Friend Account"
-msgstr ""
-
-#: mod/admin.php:451
-msgid "Blog Account"
-msgstr ""
-
-#: mod/admin.php:452
-msgid "Private Forum"
-msgstr ""
-
-#: mod/admin.php:478
-msgid "Message queues"
-msgstr ""
-
-#: mod/admin.php:484
-msgid "Summary"
-msgstr ""
-
-#: mod/admin.php:487
-msgid "Registered users"
-msgstr ""
-
-#: mod/admin.php:489
-msgid "Pending registrations"
-msgstr ""
-
-#: mod/admin.php:490
-msgid "Version"
-msgstr ""
-
-#: mod/admin.php:495
-msgid "Active plugins"
-msgstr ""
-
-#: mod/admin.php:520
-msgid "Can not parse base url. Must have at least <scheme>://<domain>"
-msgstr ""
-
-#: mod/admin.php:823
-msgid "RINO2 needs mcrypt php extension to work."
-msgstr ""
-
-#: mod/admin.php:831
-msgid "Site settings updated."
-msgstr ""
-
-#: mod/admin.php:859 mod/settings.php:934
-msgid "No special theme for mobile devices"
-msgstr ""
-
-#: mod/admin.php:878
-msgid "No community page"
-msgstr ""
-
-#: mod/admin.php:879
-msgid "Public postings from users of this site"
-msgstr ""
-
-#: mod/admin.php:880
-msgid "Global community page"
-msgstr ""
-
-#: mod/admin.php:886
-msgid "At post arrival"
-msgstr ""
-
-#: mod/admin.php:896
-msgid "Users, Global Contacts"
-msgstr ""
-
-#: mod/admin.php:897
-msgid "Users, Global Contacts/fallback"
-msgstr ""
-
-#: mod/admin.php:901
-msgid "One month"
-msgstr ""
-
-#: mod/admin.php:902
-msgid "Three months"
-msgstr ""
-
-#: mod/admin.php:903
-msgid "Half a year"
-msgstr ""
-
-#: mod/admin.php:904
-msgid "One year"
-msgstr ""
-
-#: mod/admin.php:909
-msgid "Multi user instance"
-msgstr ""
-
-#: mod/admin.php:932
-msgid "Closed"
-msgstr ""
-
-#: mod/admin.php:933
-msgid "Requires approval"
-msgstr ""
-
-#: mod/admin.php:934
-msgid "Open"
-msgstr ""
-
-#: mod/admin.php:938
-msgid "No SSL policy, links will track page SSL state"
-msgstr ""
-
-#: mod/admin.php:939
-msgid "Force all links to use SSL"
-msgstr ""
-
-#: mod/admin.php:940
-msgid "Self-signed certificate, use SSL for local links only (discouraged)"
-msgstr ""
-
-#: mod/admin.php:952 mod/admin.php:1579 mod/admin.php:1827 mod/admin.php:1901
-#: mod/admin.php:2051 mod/settings.php:678 mod/settings.php:788
-#: mod/settings.php:835 mod/settings.php:904 mod/settings.php:996
-#: mod/settings.php:1264
-msgid "Save Settings"
-msgstr ""
-
-#: mod/admin.php:953 mod/register.php:272
-msgid "Registration"
-msgstr ""
-
-#: mod/admin.php:954
-msgid "File upload"
-msgstr ""
-
-#: mod/admin.php:955
-msgid "Policies"
-msgstr ""
-
-#: mod/admin.php:957
-msgid "Auto Discovered Contact Directory"
-msgstr ""
-
-#: mod/admin.php:958
-msgid "Performance"
-msgstr ""
-
-#: mod/admin.php:959
-msgid "Worker"
-msgstr ""
-
-#: mod/admin.php:960
-msgid ""
-"Relocate - WARNING: advanced function. Could make this server unreachable."
-msgstr ""
-
-#: mod/admin.php:963
-msgid "Site name"
-msgstr ""
-
-#: mod/admin.php:964
-msgid "Host name"
-msgstr ""
-
-#: mod/admin.php:965
-msgid "Sender Email"
-msgstr ""
-
-#: mod/admin.php:965
-msgid ""
-"The email address your server shall use to send notification emails from."
-msgstr ""
-
-#: mod/admin.php:966
-msgid "Banner/Logo"
-msgstr ""
-
-#: mod/admin.php:967
-msgid "Shortcut icon"
-msgstr ""
-
-#: mod/admin.php:967
-msgid "Link to an icon that will be used for browsers."
-msgstr ""
-
-#: mod/admin.php:968
-msgid "Touch icon"
-msgstr ""
-
-#: mod/admin.php:968
-msgid "Link to an icon that will be used for tablets and mobiles."
-msgstr ""
-
-#: mod/admin.php:969
-msgid "Additional Info"
-msgstr ""
-
-#: mod/admin.php:969
-#, php-format
-msgid ""
-"For public servers: you can add additional information here that will be "
-"listed at %s/siteinfo."
-msgstr ""
-
-#: mod/admin.php:970
-msgid "System language"
-msgstr ""
-
-#: mod/admin.php:971
-msgid "System theme"
-msgstr ""
-
-#: mod/admin.php:971
-msgid ""
-"Default system theme - may be over-ridden by user profiles - <a href='#' "
-"id='cnftheme'>change theme settings</a>"
-msgstr ""
-
-#: mod/admin.php:972
-msgid "Mobile system theme"
-msgstr ""
-
-#: mod/admin.php:972
-msgid "Theme for mobile devices"
-msgstr ""
-
-#: mod/admin.php:973
-msgid "SSL link policy"
-msgstr ""
-
-#: mod/admin.php:973
-msgid "Determines whether generated links should be forced to use SSL"
-msgstr ""
-
-#: mod/admin.php:974
-msgid "Force SSL"
-msgstr ""
-
-#: mod/admin.php:974
-msgid ""
-"Force all Non-SSL requests to SSL - Attention: on some systems it could lead "
-"to endless loops."
-msgstr ""
-
-#: mod/admin.php:975
-msgid "Old style 'Share'"
-msgstr ""
-
-#: mod/admin.php:975
-msgid "Deactivates the bbcode element 'share' for repeating items."
-msgstr ""
-
-#: mod/admin.php:976
-msgid "Hide help entry from navigation menu"
-msgstr ""
-
-#: mod/admin.php:976
-msgid ""
-"Hides the menu entry for the Help pages from the navigation menu. You can "
-"still access it calling /help directly."
-msgstr ""
-
-#: mod/admin.php:977
-msgid "Single user instance"
-msgstr ""
-
-#: mod/admin.php:977
-msgid "Make this instance multi-user or single-user for the named user"
-msgstr ""
-
-#: mod/admin.php:978
-msgid "Maximum image size"
-msgstr ""
-
-#: mod/admin.php:978
-msgid ""
-"Maximum size in bytes of uploaded images. Default is 0, which means no "
-"limits."
-msgstr ""
-
-#: mod/admin.php:979
-msgid "Maximum image length"
-msgstr ""
-
-#: mod/admin.php:979
-msgid ""
-"Maximum length in pixels of the longest side of uploaded images. Default is "
-"-1, which means no limits."
-msgstr ""
-
-#: mod/admin.php:980
-msgid "JPEG image quality"
-msgstr ""
-
-#: mod/admin.php:980
-msgid ""
-"Uploaded JPEGS will be saved at this quality setting [0-100]. Default is "
-"100, which is full quality."
-msgstr ""
-
-#: mod/admin.php:982
-msgid "Register policy"
-msgstr ""
-
-#: mod/admin.php:983
-msgid "Maximum Daily Registrations"
-msgstr ""
-
-#: mod/admin.php:983
-msgid ""
-"If registration is permitted above, this sets the maximum number of new user "
-"registrations to accept per day.  If register is set to closed, this setting "
-"has no effect."
-msgstr ""
-
-#: mod/admin.php:984
-msgid "Register text"
-msgstr ""
-
-#: mod/admin.php:984
-msgid "Will be displayed prominently on the registration page."
-msgstr ""
-
-#: mod/admin.php:985
-msgid "Accounts abandoned after x days"
-msgstr ""
-
-#: mod/admin.php:985
-msgid ""
-"Will not waste system resources polling external sites for abandonded "
-"accounts. Enter 0 for no time limit."
-msgstr ""
-
-#: mod/admin.php:986
-msgid "Allowed friend domains"
-msgstr ""
-
-#: mod/admin.php:986
-msgid ""
-"Comma separated list of domains which are allowed to establish friendships "
-"with this site. Wildcards are accepted. Empty to allow any domains"
-msgstr ""
-
-#: mod/admin.php:987
-msgid "Allowed email domains"
-msgstr ""
-
-#: mod/admin.php:987
-msgid ""
-"Comma separated list of domains which are allowed in email addresses for "
-"registrations to this site. Wildcards are accepted. Empty to allow any "
-"domains"
-msgstr ""
-
-#: mod/admin.php:988
-msgid "Block public"
-msgstr ""
-
-#: mod/admin.php:988
-msgid ""
-"Check to block public access to all otherwise public personal pages on this "
-"site unless you are currently logged in."
-msgstr ""
-
-#: mod/admin.php:989
-msgid "Force publish"
-msgstr ""
-
-#: mod/admin.php:989
-msgid ""
-"Check to force all profiles on this site to be listed in the site directory."
-msgstr ""
-
-#: mod/admin.php:990
-msgid "Global directory URL"
-msgstr ""
-
-#: mod/admin.php:990
-msgid ""
-"URL to the global directory. If this is not set, the global directory is "
-"completely unavailable to the application."
-msgstr ""
-
-#: mod/admin.php:991
-msgid "Allow threaded items"
-msgstr ""
-
-#: mod/admin.php:991
-msgid "Allow infinite level threading for items on this site."
-msgstr ""
-
-#: mod/admin.php:992
-msgid "Private posts by default for new users"
-msgstr ""
-
-#: mod/admin.php:992
-msgid ""
-"Set default post permissions for all new members to the default privacy "
-"group rather than public."
-msgstr ""
-
-#: mod/admin.php:993
-msgid "Don't include post content in email notifications"
-msgstr ""
-
-#: mod/admin.php:993
-msgid ""
-"Don't include the content of a post/comment/private message/etc. in the "
-"email notifications that are sent out from this site, as a privacy measure."
-msgstr ""
-
-#: mod/admin.php:994
-msgid "Disallow public access to addons listed in the apps menu."
-msgstr ""
-
-#: mod/admin.php:994
-msgid ""
-"Checking this box will restrict addons listed in the apps menu to members "
-"only."
-msgstr ""
-
-#: mod/admin.php:995
-msgid "Don't embed private images in posts"
-msgstr ""
-
-#: mod/admin.php:995
-msgid ""
-"Don't replace locally-hosted private photos in posts with an embedded copy "
-"of the image. This means that contacts who receive posts containing private "
-"photos will have to authenticate and load each image, which may take a while."
-msgstr ""
-
-#: mod/admin.php:996
-msgid "Allow Users to set remote_self"
-msgstr ""
-
-#: mod/admin.php:996
-msgid ""
-"With checking this, every user is allowed to mark every contact as a "
-"remote_self in the repair contact dialog. Setting this flag on a contact "
-"causes mirroring every posting of that contact in the users stream."
-msgstr ""
-
-#: mod/admin.php:997
-msgid "Block multiple registrations"
-msgstr ""
-
-#: mod/admin.php:997
-msgid "Disallow users to register additional accounts for use as pages."
-msgstr ""
-
-#: mod/admin.php:998
-msgid "OpenID support"
-msgstr ""
-
-#: mod/admin.php:998
-msgid "OpenID support for registration and logins."
-msgstr ""
-
-#: mod/admin.php:999
-msgid "Fullname check"
-msgstr ""
-
-#: mod/admin.php:999
-msgid ""
-"Force users to register with a space between firstname and lastname in Full "
-"name, as an antispam measure"
-msgstr ""
-
-#: mod/admin.php:1000
-msgid "UTF-8 Regular expressions"
-msgstr ""
-
-#: mod/admin.php:1000
-msgid "Use PHP UTF8 regular expressions"
-msgstr ""
-
-#: mod/admin.php:1001
-msgid "Community Page Style"
-msgstr ""
-
-#: mod/admin.php:1001
-msgid ""
-"Type of community page to show. 'Global community' shows every public "
-"posting from an open distributed network that arrived on this server."
-msgstr ""
-
-#: mod/admin.php:1002
-msgid "Posts per user on community page"
-msgstr ""
-
-#: mod/admin.php:1002
-msgid ""
-"The maximum number of posts per user on the community page. (Not valid for "
-"'Global Community')"
-msgstr ""
-
-#: mod/admin.php:1003
-msgid "Enable OStatus support"
-msgstr ""
-
-#: mod/admin.php:1003
-msgid ""
-"Provide built-in OStatus (StatusNet, GNU Social etc.) compatibility. All "
-"communications in OStatus are public, so privacy warnings will be "
-"occasionally displayed."
-msgstr ""
-
-#: mod/admin.php:1004
-msgid "OStatus conversation completion interval"
-msgstr ""
-
-#: mod/admin.php:1004
-msgid ""
-"How often shall the poller check for new entries in OStatus conversations? "
-"This can be a very ressource task."
-msgstr ""
-
-#: mod/admin.php:1005
-msgid "Only import OStatus threads from our contacts"
-msgstr ""
-
-#: mod/admin.php:1005
-msgid ""
-"Normally we import every content from our OStatus contacts. With this option "
-"we only store threads that are started by a contact that is known on our "
-"system."
-msgstr ""
-
-#: mod/admin.php:1006
-msgid "OStatus support can only be enabled if threading is enabled."
-msgstr ""
-
-#: mod/admin.php:1008
-msgid ""
-"Diaspora support can't be enabled because Friendica was installed into a sub "
-"directory."
-msgstr ""
-
-#: mod/admin.php:1009
-msgid "Enable Diaspora support"
-msgstr ""
-
-#: mod/admin.php:1009
-msgid "Provide built-in Diaspora network compatibility."
-msgstr ""
-
-#: mod/admin.php:1010
-msgid "Only allow Friendica contacts"
-msgstr ""
-
-#: mod/admin.php:1010
-msgid ""
-"All contacts must use Friendica protocols. All other built-in communication "
-"protocols disabled."
-msgstr ""
-
-#: mod/admin.php:1011
-msgid "Verify SSL"
-msgstr ""
-
-#: mod/admin.php:1011
-msgid ""
-"If you wish, you can turn on strict certificate checking. This will mean you "
-"cannot connect (at all) to self-signed SSL sites."
-msgstr ""
-
-#: mod/admin.php:1012
-msgid "Proxy user"
-msgstr ""
-
-#: mod/admin.php:1013
-msgid "Proxy URL"
-msgstr ""
-
-#: mod/admin.php:1014
-msgid "Network timeout"
-msgstr ""
-
-#: mod/admin.php:1014
-msgid "Value is in seconds. Set to 0 for unlimited (not recommended)."
-msgstr ""
-
-#: mod/admin.php:1015
-msgid "Delivery interval"
-msgstr ""
-
-#: mod/admin.php:1015
-msgid ""
-"Delay background delivery processes by this many seconds to reduce system "
-"load. Recommend: 4-5 for shared hosts, 2-3 for virtual private servers. 0-1 "
-"for large dedicated servers."
-msgstr ""
-
-#: mod/admin.php:1016
-msgid "Poll interval"
-msgstr ""
-
-#: mod/admin.php:1016
-msgid ""
-"Delay background polling processes by this many seconds to reduce system "
-"load. If 0, use delivery interval."
-msgstr ""
-
-#: mod/admin.php:1017
-msgid "Maximum Load Average"
-msgstr ""
-
-#: mod/admin.php:1017
-msgid ""
-"Maximum system load before delivery and poll processes are deferred - "
-"default 50."
-msgstr ""
-
-#: mod/admin.php:1018
-msgid "Maximum Load Average (Frontend)"
-msgstr ""
-
-#: mod/admin.php:1018
-msgid "Maximum system load before the frontend quits service - default 50."
-msgstr ""
-
-#: mod/admin.php:1019
-msgid "Maximum table size for optimization"
-msgstr ""
-
-#: mod/admin.php:1019
-msgid ""
-"Maximum table size (in MB) for the automatic optimization - default 100 MB. "
-"Enter -1 to disable it."
-msgstr ""
-
-#: mod/admin.php:1020
-msgid "Minimum level of fragmentation"
-msgstr ""
-
-#: mod/admin.php:1020
-msgid ""
-"Minimum fragmenation level to start the automatic optimization - default "
-"value is 30%."
-msgstr ""
-
-#: mod/admin.php:1022
-msgid "Periodical check of global contacts"
-msgstr ""
-
-#: mod/admin.php:1022
-msgid ""
-"If enabled, the global contacts are checked periodically for missing or "
-"outdated data and the vitality of the contacts and servers."
-msgstr ""
-
-#: mod/admin.php:1023
-msgid "Days between requery"
-msgstr ""
-
-#: mod/admin.php:1023
-msgid "Number of days after which a server is requeried for his contacts."
-msgstr ""
-
-#: mod/admin.php:1024
-msgid "Discover contacts from other servers"
-msgstr ""
-
-#: mod/admin.php:1024
-msgid ""
-"Periodically query other servers for contacts. You can choose between "
-"'users': the users on the remote system, 'Global Contacts': active contacts "
-"that are known on the system. The fallback is meant for Redmatrix servers "
-"and older friendica servers, where global contacts weren't available. The "
-"fallback increases the server load, so the recommened setting is 'Users, "
-"Global Contacts'."
-msgstr ""
-
-#: mod/admin.php:1025
-msgid "Timeframe for fetching global contacts"
-msgstr ""
-
-#: mod/admin.php:1025
-msgid ""
-"When the discovery is activated, this value defines the timeframe for the "
-"activity of the global contacts that are fetched from other servers."
-msgstr ""
-
-#: mod/admin.php:1026
-msgid "Search the local directory"
-msgstr ""
-
-#: mod/admin.php:1026
-msgid ""
-"Search the local directory instead of the global directory. When searching "
-"locally, every search will be executed on the global directory in the "
-"background. This improves the search results when the search is repeated."
-msgstr ""
-
-#: mod/admin.php:1028
-msgid "Publish server information"
-msgstr ""
-
-#: mod/admin.php:1028
-msgid ""
-"If enabled, general server and usage data will be published. The data "
-"contains the name and version of the server, number of users with public "
-"profiles, number of posts and the activated protocols and connectors. See <a "
-"href='http://the-federation.info/'>the-federation.info</a> for details."
-msgstr ""
-
-#: mod/admin.php:1030
-msgid "Use MySQL full text engine"
-msgstr ""
-
-#: mod/admin.php:1030
-msgid ""
-"Activates the full text engine. Speeds up search - but can only search for "
-"four and more characters."
-msgstr ""
-
-#: mod/admin.php:1031
-msgid "Suppress Language"
-msgstr ""
-
-#: mod/admin.php:1031
-msgid "Suppress language information in meta information about a posting."
-msgstr ""
-
-#: mod/admin.php:1032
-msgid "Suppress Tags"
-msgstr ""
-
-#: mod/admin.php:1032
-msgid "Suppress showing a list of hashtags at the end of the posting."
-msgstr ""
-
-#: mod/admin.php:1033
-msgid "Path to item cache"
-msgstr ""
-
-#: mod/admin.php:1033
-msgid "The item caches buffers generated bbcode and external images."
-msgstr ""
-
-#: mod/admin.php:1034
-msgid "Cache duration in seconds"
-msgstr ""
-
-#: mod/admin.php:1034
-msgid ""
-"How long should the cache files be hold? Default value is 86400 seconds (One "
-"day). To disable the item cache, set the value to -1."
-msgstr ""
-
-#: mod/admin.php:1035
-msgid "Maximum numbers of comments per post"
-msgstr ""
-
-#: mod/admin.php:1035
-msgid "How much comments should be shown for each post? Default value is 100."
-msgstr ""
-
-#: mod/admin.php:1036
-msgid "Path for lock file"
-msgstr ""
-
-#: mod/admin.php:1036
+#: mod/newmember.php:12
 msgid ""
-"The lock file is used to avoid multiple pollers at one time. Only define a "
-"folder here."
-msgstr ""
-
-#: mod/admin.php:1037
-msgid "Temp path"
+"We would like to offer some tips and links to help make your experience "
+"enjoyable. Click any item to visit the relevant page. A link to this page "
+"will be visible from your home page for two weeks after your initial "
+"registration and then will quietly disappear."
 msgstr ""
 
-#: mod/admin.php:1037
-msgid ""
-"If you have a restricted system where the webserver can't access the system "
-"temp path, enter another path here."
+#: mod/newmember.php:14
+msgid "Getting Started"
 msgstr ""
 
-#: mod/admin.php:1038
-msgid "Base path to installation"
+#: mod/newmember.php:18
+msgid "Friendica Walk-Through"
 msgstr ""
 
-#: mod/admin.php:1038
+#: mod/newmember.php:18
 msgid ""
-"If the system cannot detect the correct path to your installation, enter the "
-"correct path here. This setting should only be set if you are using a "
-"restricted system and symbolic links to your webroot."
+"On your <em>Quick Start</em> page - find a brief introduction to your "
+"profile and network tabs, make some new connections, and find some groups to "
+"join."
 msgstr ""
 
-#: mod/admin.php:1039
-msgid "Disable picture proxy"
+#: mod/newmember.php:26
+msgid "Go to Your Settings"
 msgstr ""
 
-#: mod/admin.php:1039
+#: mod/newmember.php:26
 msgid ""
-"The picture proxy increases performance and privacy. It shouldn't be used on "
-"systems with very low bandwith."
+"On your <em>Settings</em> page -  change your initial password. Also make a "
+"note of your Identity Address. This looks just like an email address - and "
+"will be useful in making friends on the free social web."
 msgstr ""
 
-#: mod/admin.php:1040
-msgid "Enable old style pager"
-msgstr ""
-
-#: mod/admin.php:1040
+#: mod/newmember.php:28
 msgid ""
-"The old style pager has page numbers but slows down massively the page speed."
-msgstr ""
-
-#: mod/admin.php:1041
-msgid "Only search in tags"
-msgstr ""
-
-#: mod/admin.php:1041
-msgid "On large systems the text search can slow down the system extremely."
-msgstr ""
-
-#: mod/admin.php:1043
-msgid "New base url"
+"Review the other settings, particularly the privacy settings. An unpublished "
+"directory listing is like having an unlisted phone number. In general, you "
+"should probably publish your listing - unless all of your friends and "
+"potential friends know exactly how to find you."
 msgstr ""
 
-#: mod/admin.php:1043
+#: mod/newmember.php:36
 msgid ""
-"Change base url for this server. Sends relocate message to all DFRN contacts "
-"of all users."
+"Upload a profile photo if you have not done so already. Studies have shown "
+"that people with real photos of themselves are ten times more likely to make "
+"friends than people who do not."
 msgstr ""
 
-#: mod/admin.php:1045
-msgid "RINO Encryption"
+#: mod/newmember.php:38
+msgid "Edit Your Profile"
 msgstr ""
 
-#: mod/admin.php:1045
-msgid "Encryption layer between nodes."
-msgstr ""
-
-#: mod/admin.php:1046
-msgid "Embedly API key"
-msgstr ""
-
-#: mod/admin.php:1046
+#: mod/newmember.php:38
 msgid ""
-"<a href='http://embed.ly'>Embedly</a> is used to fetch additional data for "
-"web pages. This is an optional parameter."
+"Edit your <strong>default</strong> profile to your liking. Review the "
+"settings for hiding your list of friends and hiding the profile from unknown "
+"visitors."
 msgstr ""
 
-#: mod/admin.php:1048
-msgid "Enable 'worker' background processing"
+#: mod/newmember.php:40
+msgid "Profile Keywords"
 msgstr ""
 
-#: mod/admin.php:1048
+#: mod/newmember.php:40
 msgid ""
-"The worker background processing limits the number of parallel background "
-"jobs to a maximum number and respects the system load."
+"Set some public keywords for your default profile which describe your "
+"interests. We may be able to find other people with similar interests and "
+"suggest friendships."
 msgstr ""
 
-#: mod/admin.php:1049
-msgid "Maximum number of parallel workers"
+#: mod/newmember.php:44
+msgid "Connecting"
 msgstr ""
 
-#: mod/admin.php:1049
-msgid ""
-"On shared hosters set this to 2. On larger systems, values of 10 are great. "
-"Default value is 4."
-msgstr ""
-
-#: mod/admin.php:1050
-msgid "Don't use 'proc_open' with the worker"
+#: mod/newmember.php:51
+msgid "Importing Emails"
 msgstr ""
 
-#: mod/admin.php:1050
+#: mod/newmember.php:51
 msgid ""
-"Enable this if your system doesn't allow the use of 'proc_open'. This can "
-"happen on shared hosters. If this is enabled you should increase the "
-"frequency of poller calls in your crontab."
+"Enter your email access information on your Connector Settings page if you "
+"wish to import and interact with friends or mailing lists from your email "
+"INBOX"
 msgstr ""
 
-#: mod/admin.php:1051
-msgid "Enable fastlane"
+#: mod/newmember.php:53
+msgid "Go to Your Contacts Page"
 msgstr ""
 
-#: mod/admin.php:1051
+#: mod/newmember.php:53
 msgid ""
-"When enabed, the fastlane mechanism starts an additional worker if processes "
-"with higher priority are blocked by processes of lower priority."
-msgstr ""
-
-#: mod/admin.php:1080
-msgid "Update has been marked successful"
-msgstr ""
-
-#: mod/admin.php:1088
-#, php-format
-msgid "Database structure update %s was successfully applied."
-msgstr ""
-
-#: mod/admin.php:1091
-#, php-format
-msgid "Executing of database structure update %s failed with error: %s"
-msgstr ""
-
-#: mod/admin.php:1103
-#, php-format
-msgid "Executing %s failed with error: %s"
-msgstr ""
-
-#: mod/admin.php:1106
-#, php-format
-msgid "Update %s was successfully applied."
-msgstr ""
-
-#: mod/admin.php:1110
-#, php-format
-msgid "Update %s did not return a status. Unknown if it succeeded."
-msgstr ""
-
-#: mod/admin.php:1112
-#, php-format
-msgid "There was no additional update function %s that needed to be called."
-msgstr ""
-
-#: mod/admin.php:1131
-msgid "No failed updates."
-msgstr ""
-
-#: mod/admin.php:1132
-msgid "Check database structure"
+"Your Contacts page is your gateway to managing friendships and connecting "
+"with friends on other networks. Typically you enter their address or site "
+"URL in the <em>Add New Contact</em> dialog."
 msgstr ""
 
-#: mod/admin.php:1137
-msgid "Failed Updates"
+#: mod/newmember.php:55
+msgid "Go to Your Site's Directory"
 msgstr ""
 
-#: mod/admin.php:1138
+#: mod/newmember.php:55
 msgid ""
-"This does not include updates prior to 1139, which did not return a status."
-msgstr ""
-
-#: mod/admin.php:1139
-msgid "Mark success (if update was manually applied)"
-msgstr ""
-
-#: mod/admin.php:1140
-msgid "Attempt to execute this update step automatically"
+"The Directory page lets you find other people in this network or other "
+"federated sites. Look for a <em>Connect</em> or <em>Follow</em> link on "
+"their profile page. Provide your own Identity Address if requested."
 msgstr ""
 
-#: mod/admin.php:1174
-#, php-format
-msgid ""
-"\n"
-"\t\t\tDear %1$s,\n"
-"\t\t\t\tthe administrator of %2$s has set up an account for you."
+#: mod/newmember.php:57
+msgid "Finding New People"
 msgstr ""
 
-#: mod/admin.php:1177
-#, php-format
+#: mod/newmember.php:57
 msgid ""
-"\n"
-"\t\t\tThe login details are as follows:\n"
-"\n"
-"\t\t\tSite Location:\t%1$s\n"
-"\t\t\tLogin Name:\t\t%2$s\n"
-"\t\t\tPassword:\t\t%3$s\n"
-"\n"
-"\t\t\tYou may change your password from your account \"Settings\" page after "
-"logging\n"
-"\t\t\tin.\n"
-"\n"
-"\t\t\tPlease take a few moments to review the other account settings on that "
-"page.\n"
-"\n"
-"\t\t\tYou may also wish to add some basic information to your default "
-"profile\n"
-"\t\t\t(on the \"Profiles\" page) so that other people can easily find you.\n"
-"\n"
-"\t\t\tWe recommend setting your full name, adding a profile photo,\n"
-"\t\t\tadding some profile \"keywords\" (very useful in making new friends) - "
-"and\n"
-"\t\t\tperhaps what country you live in; if you do not wish to be more "
-"specific\n"
-"\t\t\tthan that.\n"
-"\n"
-"\t\t\tWe fully respect your right to privacy, and none of these items are "
-"necessary.\n"
-"\t\t\tIf you are new and do not know anybody here, they may help\n"
-"\t\t\tyou to make some new and interesting friends.\n"
-"\n"
-"\t\t\tThank you and welcome to %4$s."
-msgstr ""
-
-#: mod/admin.php:1221
-#, php-format
-msgid "%s user blocked/unblocked"
-msgid_plural "%s users blocked/unblocked"
-msgstr[0] ""
-msgstr[1] ""
-
-#: mod/admin.php:1228
-#, php-format
-msgid "%s user deleted"
-msgid_plural "%s users deleted"
-msgstr[0] ""
-msgstr[1] ""
-
-#: mod/admin.php:1275
-#, php-format
-msgid "User '%s' deleted"
-msgstr ""
-
-#: mod/admin.php:1283
-#, php-format
-msgid "User '%s' unblocked"
-msgstr ""
-
-#: mod/admin.php:1283
-#, php-format
-msgid "User '%s' blocked"
-msgstr ""
-
-#: mod/admin.php:1392 mod/admin.php:1418
-msgid "Register date"
-msgstr ""
-
-#: mod/admin.php:1392 mod/admin.php:1418
-msgid "Last login"
-msgstr ""
-
-#: mod/admin.php:1392 mod/admin.php:1418
-msgid "Last item"
-msgstr ""
-
-#: mod/admin.php:1392 mod/settings.php:43
-msgid "Account"
-msgstr ""
-
-#: mod/admin.php:1401
-msgid "Add User"
-msgstr ""
-
-#: mod/admin.php:1402
-msgid "select all"
-msgstr ""
-
-#: mod/admin.php:1403
-msgid "User registrations waiting for confirm"
-msgstr ""
-
-#: mod/admin.php:1404
-msgid "User waiting for permanent deletion"
-msgstr ""
-
-#: mod/admin.php:1405
-msgid "Request date"
-msgstr ""
-
-#: mod/admin.php:1406
-msgid "No registrations."
-msgstr ""
-
-#: mod/admin.php:1407
-msgid "Note from the user"
-msgstr ""
-
-#: mod/admin.php:1409
-msgid "Deny"
-msgstr ""
-
-#: mod/admin.php:1413
-msgid "Site admin"
+"On the side panel of the Contacts page are several tools to find new "
+"friends. We can match people by interest, look up people by name or "
+"interest, and provide suggestions based on network relationships. On a brand "
+"new site, friend suggestions will usually begin to be populated within 24 "
+"hours."
 msgstr ""
 
-#: mod/admin.php:1414
-msgid "Account expired"
+#: mod/newmember.php:65
+msgid "Group Your Contacts"
 msgstr ""
 
-#: mod/admin.php:1417
-msgid "New User"
-msgstr ""
-
-#: mod/admin.php:1418
-msgid "Deleted since"
-msgstr ""
-
-#: mod/admin.php:1423
+#: mod/newmember.php:65
 msgid ""
-"Selected users will be deleted!\\n\\nEverything these users had posted on "
-"this site will be permanently deleted!\\n\\nAre you sure?"
-msgstr ""
-
-#: mod/admin.php:1424
-msgid ""
-"The user {0} will be deleted!\\n\\nEverything this user has posted on this "
-"site will be permanently deleted!\\n\\nAre you sure?"
-msgstr ""
-
-#: mod/admin.php:1434
-msgid "Name of the new user."
-msgstr ""
-
-#: mod/admin.php:1435
-msgid "Nickname"
-msgstr ""
-
-#: mod/admin.php:1435
-msgid "Nickname of the new user."
-msgstr ""
-
-#: mod/admin.php:1436
-msgid "Email address of the new user."
-msgstr ""
-
-#: mod/admin.php:1479
-#, php-format
-msgid "Plugin %s disabled."
-msgstr ""
-
-#: mod/admin.php:1483
-#, php-format
-msgid "Plugin %s enabled."
-msgstr ""
-
-#: mod/admin.php:1494 mod/admin.php:1730
-msgid "Disable"
-msgstr ""
-
-#: mod/admin.php:1496 mod/admin.php:1732
-msgid "Enable"
-msgstr ""
-
-#: mod/admin.php:1519 mod/admin.php:1777
-msgid "Toggle"
-msgstr ""
-
-#: mod/admin.php:1527 mod/admin.php:1786
-msgid "Author: "
-msgstr ""
-
-#: mod/admin.php:1528 mod/admin.php:1787
-msgid "Maintainer: "
+"Once you have made some friends, organize them into private conversation "
+"groups from the sidebar of your Contacts page and then you can interact with "
+"each group privately on your Network page."
 msgstr ""
 
-#: mod/admin.php:1580
-msgid "Reload active plugins"
+#: mod/newmember.php:68
+msgid "Why Aren't My Posts Public?"
 msgstr ""
 
-#: mod/admin.php:1585
-#, php-format
+#: mod/newmember.php:68
 msgid ""
-"There are currently no plugins available on your node. You can find the "
-"official plugin repository at %1$s and might find other interesting plugins "
-"in the open plugin registry at %2$s"
-msgstr ""
-
-#: mod/admin.php:1690
-msgid "No themes found."
-msgstr ""
-
-#: mod/admin.php:1768
-msgid "Screenshot"
-msgstr ""
-
-#: mod/admin.php:1828
-msgid "Reload active themes"
-msgstr ""
-
-#: mod/admin.php:1833
-#, php-format
-msgid "No themes found on the system. They should be paced in %1$s"
-msgstr ""
-
-#: mod/admin.php:1834
-msgid "[Experimental]"
-msgstr ""
-
-#: mod/admin.php:1835
-msgid "[Unsupported]"
-msgstr ""
-
-#: mod/admin.php:1859
-msgid "Log settings updated."
-msgstr ""
-
-#: mod/admin.php:1891
-msgid "PHP log currently enabled."
-msgstr ""
-
-#: mod/admin.php:1893
-msgid "PHP log currently disabled."
-msgstr ""
-
-#: mod/admin.php:1902
-msgid "Clear"
+"Friendica respects your privacy. By default, your posts will only show up to "
+"people you've added as friends. For more information, see the help section "
+"from the link above."
 msgstr ""
 
-#: mod/admin.php:1907
-msgid "Enable Debugging"
+#: mod/newmember.php:73
+msgid "Getting Help"
 msgstr ""
 
-#: mod/admin.php:1908
-msgid "Log file"
+#: mod/newmember.php:77
+msgid "Go to the Help Section"
 msgstr ""
 
-#: mod/admin.php:1908
+#: mod/newmember.php:77
 msgid ""
-"Must be writable by web server. Relative to your Friendica top-level "
-"directory."
-msgstr ""
-
-#: mod/admin.php:1909
-msgid "Log level"
+"Our <strong>help</strong> pages may be consulted for detail on other program "
+"features and resources."
 msgstr ""
 
-#: mod/admin.php:1912
-msgid "PHP logging"
+#: mod/removeme.php:46 mod/removeme.php:49
+msgid "Remove My Account"
 msgstr ""
 
-#: mod/admin.php:1913
+#: mod/removeme.php:47
 msgid ""
-"To enable logging of PHP errors and warnings you can add the following to "
-"the .htconfig.php file of your installation. The filename set in the "
-"'error_log' line is relative to the friendica top-level directory and must "
-"be writeable by the web server. The option '1' for 'log_errors' and "
-"'display_errors' is to enable these options, set to '0' to disable them."
-msgstr ""
-
-#: mod/admin.php:2040 mod/admin.php:2041 mod/settings.php:778
-msgid "Off"
-msgstr ""
-
-#: mod/admin.php:2040 mod/admin.php:2041 mod/settings.php:778
-msgid "On"
-msgstr ""
-
-#: mod/admin.php:2041
-#, php-format
-msgid "Lock feature %s"
-msgstr ""
-
-#: mod/admin.php:2049
-msgid "Manage Additional Features"
-msgstr ""
-
-#: mod/item.php:116
-msgid "Unable to locate original post."
-msgstr ""
-
-#: mod/item.php:340
-msgid "Empty post discarded."
+"This will completely remove your account. Once this has been done it is not "
+"recoverable."
 msgstr ""
 
-#: mod/item.php:898
-msgid "System error. Post not saved."
+#: mod/removeme.php:48
+msgid "Please enter your password for verification:"
 msgstr ""
 
-#: mod/item.php:988
-#, php-format
-msgid ""
-"This message was sent to you by %s, a member of the Friendica social network."
+#: mod/mood.php:133
+msgid "Mood"
 msgstr ""
 
-#: mod/item.php:990
-#, php-format
-msgid "You may visit them online at %s"
+#: mod/mood.php:134
+msgid "Set your current mood and tell your friends"
 msgstr ""
 
-#: mod/item.php:991
-msgid ""
-"Please contact the sender by replying to this post if you do not wish to "
-"receive these messages."
+#: mod/editpost.php:17 mod/editpost.php:27
+msgid "Item not found"
 msgstr ""
 
-#: mod/item.php:995
-#, php-format
-msgid "%s posted an update."
+#: mod/editpost.php:40
+msgid "Edit post"
 msgstr ""
 
 #: mod/network.php:398
@@ -7596,202 +7358,286 @@ msgstr ""
 msgid "Favourite Posts"
 msgstr ""
 
-#: mod/photos.php:88 mod/photos.php:1856
-msgid "Recent Photos"
+#: mod/community.php:27
+msgid "Not available."
 msgstr ""
 
-#: mod/photos.php:91 mod/photos.php:1283 mod/photos.php:1858
-msgid "Upload New Photos"
+#: mod/localtime.php:24
+msgid "Time Conversion"
 msgstr ""
 
-#: mod/photos.php:105 mod/settings.php:36
-msgid "everybody"
+#: mod/localtime.php:26
+msgid ""
+"Friendica provides this service for sharing events with other networks and "
+"friends in unknown timezones."
 msgstr ""
 
-#: mod/photos.php:169
-msgid "Contact information unavailable"
-msgstr ""
-
-#: mod/photos.php:190
-msgid "Album not found."
-msgstr ""
-
-#: mod/photos.php:220 mod/photos.php:232 mod/photos.php:1227
-msgid "Delete Album"
-msgstr ""
-
-#: mod/photos.php:230
-msgid "Do you really want to delete this photo album and all its photos?"
-msgstr ""
-
-#: mod/photos.php:308 mod/photos.php:319 mod/photos.php:1540
-msgid "Delete Photo"
-msgstr ""
-
-#: mod/photos.php:317
-msgid "Do you really want to delete this photo?"
-msgstr ""
-
-#: mod/photos.php:688
+#: mod/localtime.php:30
 #, php-format
-msgid "%1$s was tagged in %2$s by %3$s"
+msgid "UTC time: %s"
 msgstr ""
 
-#: mod/photos.php:688
-msgid "a photo"
-msgstr ""
-
-#: mod/photos.php:794
-msgid "Image file is empty."
-msgstr ""
-
-#: mod/photos.php:954
-msgid "No photos selected"
-msgstr ""
-
-#: mod/photos.php:1054 mod/videos.php:305
-msgid "Access to this item is restricted."
-msgstr ""
-
-#: mod/photos.php:1114
+#: mod/localtime.php:33
 #, php-format
-msgid "You have used %1$.2f Mbytes of %2$.2f Mbytes photo storage."
+msgid "Current timezone: %s"
 msgstr ""
 
-#: mod/photos.php:1148
-msgid "Upload Photos"
+#: mod/localtime.php:36
+#, php-format
+msgid "Converted localtime: %s"
 msgstr ""
 
-#: mod/photos.php:1152 mod/photos.php:1222
-msgid "New album name: "
+#: mod/localtime.php:41
+msgid "Please select your timezone:"
 msgstr ""
 
-#: mod/photos.php:1153
-msgid "or existing album name: "
+#: mod/bookmarklet.php:41
+msgid "The post was created"
 msgstr ""
 
-#: mod/photos.php:1154
-msgid "Do not show a status post for this upload"
+#: mod/group.php:29
+msgid "Group created."
 msgstr ""
 
-#: mod/photos.php:1165 mod/photos.php:1544 mod/settings.php:1300
-msgid "Show to Groups"
+#: mod/group.php:35
+msgid "Could not create group."
 msgstr ""
 
-#: mod/photos.php:1166 mod/photos.php:1545 mod/settings.php:1301
-msgid "Show to Contacts"
+#: mod/group.php:47 mod/group.php:140
+msgid "Group not found."
 msgstr ""
 
-#: mod/photos.php:1167
-msgid "Private Photo"
+#: mod/group.php:60
+msgid "Group name changed."
 msgstr ""
 
-#: mod/photos.php:1168
-msgid "Public Photo"
+#: mod/group.php:87
+msgid "Save Group"
 msgstr ""
 
-#: mod/photos.php:1234
-msgid "Edit Album"
+#: mod/group.php:93
+msgid "Create a group of contacts/friends."
 msgstr ""
 
-#: mod/photos.php:1240
-msgid "Show Newest First"
+#: mod/group.php:113
+msgid "Group removed."
 msgstr ""
 
-#: mod/photos.php:1242
-msgid "Show Oldest First"
+#: mod/group.php:115
+msgid "Unable to remove group."
 msgstr ""
 
-#: mod/photos.php:1269 mod/photos.php:1841
-msgid "View Photo"
+#: mod/group.php:177
+msgid "Group Editor"
 msgstr ""
 
-#: mod/photos.php:1315
-msgid "Permission denied. Access to this item may be restricted."
+#: mod/group.php:190
+msgid "Members"
 msgstr ""
 
-#: mod/photos.php:1317
-msgid "Photo not available"
+#: mod/dfrn_request.php:101
+msgid "This introduction has already been accepted."
 msgstr ""
 
-#: mod/photos.php:1372
-msgid "View photo"
+#: mod/dfrn_request.php:124 mod/dfrn_request.php:520
+msgid "Profile location is not valid or does not contain profile information."
 msgstr ""
 
-#: mod/photos.php:1372
-msgid "Edit photo"
+#: mod/dfrn_request.php:129 mod/dfrn_request.php:525
+msgid "Warning: profile location has no identifiable owner name."
 msgstr ""
 
-#: mod/photos.php:1373
-msgid "Use as profile photo"
+#: mod/dfrn_request.php:131 mod/dfrn_request.php:527
+msgid "Warning: profile location has no profile photo."
 msgstr ""
 
-#: mod/photos.php:1398
-msgid "View Full Size"
+#: mod/dfrn_request.php:134 mod/dfrn_request.php:530
+#, php-format
+msgid "%d required parameter was not found at the given location"
+msgid_plural "%d required parameters were not found at the given location"
+msgstr[0] ""
+msgstr[1] ""
+
+#: mod/dfrn_request.php:180
+msgid "Introduction complete."
 msgstr ""
 
-#: mod/photos.php:1484
-msgid "Tags: "
+#: mod/dfrn_request.php:222
+msgid "Unrecoverable protocol error."
 msgstr ""
 
-#: mod/photos.php:1487
-msgid "[Remove any tag]"
+#: mod/dfrn_request.php:250
+msgid "Profile unavailable."
 msgstr ""
 
-#: mod/photos.php:1526
-msgid "New album name"
+#: mod/dfrn_request.php:277
+#, php-format
+msgid "%s has received too many connection requests today."
 msgstr ""
 
-#: mod/photos.php:1527
-msgid "Caption"
+#: mod/dfrn_request.php:278
+msgid "Spam protection measures have been invoked."
 msgstr ""
 
-#: mod/photos.php:1528
-msgid "Add a Tag"
+#: mod/dfrn_request.php:279
+msgid "Friends are advised to please try again in 24 hours."
 msgstr ""
 
-#: mod/photos.php:1528
-msgid "Example: @bob, @Barbara_Jensen, @jim@example.com, #California, #camping"
+#: mod/dfrn_request.php:341
+msgid "Invalid locator"
 msgstr ""
 
-#: mod/photos.php:1529
-msgid "Do not rotate"
+#: mod/dfrn_request.php:350
+msgid "Invalid email address."
 msgstr ""
 
-#: mod/photos.php:1530
-msgid "Rotate CW (right)"
+#: mod/dfrn_request.php:375
+msgid "This account has not been configured for email. Request failed."
 msgstr ""
 
-#: mod/photos.php:1531
-msgid "Rotate CCW (left)"
+#: mod/dfrn_request.php:478
+msgid "You have already introduced yourself here."
 msgstr ""
 
-#: mod/photos.php:1546
-msgid "Private photo"
+#: mod/dfrn_request.php:482
+#, php-format
+msgid "Apparently you are already friends with %s."
 msgstr ""
 
-#: mod/photos.php:1547
-msgid "Public photo"
+#: mod/dfrn_request.php:503
+msgid "Invalid profile URL."
 msgstr ""
 
-#: mod/photos.php:1770
-msgid "Map"
+#: mod/dfrn_request.php:604
+msgid "Your introduction has been sent."
 msgstr ""
 
-#: mod/photos.php:1847 mod/videos.php:387
-msgid "View Album"
+#: mod/dfrn_request.php:644
+msgid ""
+"Remote subscription can't be done for your network. Please subscribe "
+"directly on your system."
 msgstr ""
 
-#: mod/ping.php:211
-msgid "{0} wants to be your friend"
+#: mod/dfrn_request.php:664
+msgid "Please login to confirm introduction."
 msgstr ""
 
-#: mod/ping.php:226
-msgid "{0} sent you a message"
+#: mod/dfrn_request.php:674
+msgid ""
+"Incorrect identity currently logged in. Please login to <strong>this</"
+"strong> profile."
 msgstr ""
 
-#: mod/ping.php:241
-msgid "{0} requested registration"
+#: mod/dfrn_request.php:688 mod/dfrn_request.php:705
+msgid "Confirm"
+msgstr ""
+
+#: mod/dfrn_request.php:700
+msgid "Hide this contact"
+msgstr ""
+
+#: mod/dfrn_request.php:703
+#, php-format
+msgid "Welcome home %s."
+msgstr ""
+
+#: mod/dfrn_request.php:704
+#, php-format
+msgid "Please confirm your introduction/connection request to %s."
+msgstr ""
+
+#: mod/dfrn_request.php:833
+msgid ""
+"Please enter your 'Identity Address' from one of the following supported "
+"communications networks:"
+msgstr ""
+
+#: mod/dfrn_request.php:854
+#, php-format
+msgid ""
+"If you are not yet a member of the free social web, <a href=\"%s/siteinfo"
+"\">follow this link to find a public Friendica site and join us today</a>."
+msgstr ""
+
+#: mod/dfrn_request.php:859
+msgid "Friend/Connection Request"
+msgstr ""
+
+#: mod/dfrn_request.php:860
+msgid ""
+"Examples: jojo@demo.friendica.com, http://demo.friendica.com/profile/jojo, "
+"testuser@identi.ca"
+msgstr ""
+
+#: mod/dfrn_request.php:869
+msgid "StatusNet/Federated Social Web"
+msgstr ""
+
+#: mod/dfrn_request.php:871
+#, php-format
+msgid ""
+" - please do not use this form.  Instead, enter %s into your Diaspora search "
+"bar."
+msgstr ""
+
+#: mod/profile_photo.php:44
+msgid "Image uploaded but image cropping failed."
+msgstr ""
+
+#: mod/profile_photo.php:77 mod/profile_photo.php:84 mod/profile_photo.php:91
+#: mod/profile_photo.php:314
+#, php-format
+msgid "Image size reduction [%s] failed."
+msgstr ""
+
+#: mod/profile_photo.php:124
+msgid ""
+"Shift-reload the page or clear browser cache if the new photo does not "
+"display immediately."
+msgstr ""
+
+#: mod/profile_photo.php:134
+msgid "Unable to process image"
+msgstr ""
+
+#: mod/profile_photo.php:248
+msgid "Upload File:"
+msgstr ""
+
+#: mod/profile_photo.php:249
+msgid "Select a profile:"
+msgstr ""
+
+#: mod/profile_photo.php:251
+msgid "Upload"
+msgstr ""
+
+#: mod/profile_photo.php:254
+msgid "or"
+msgstr ""
+
+#: mod/profile_photo.php:254
+msgid "skip this step"
+msgstr ""
+
+#: mod/profile_photo.php:254
+msgid "select a photo from your photo albums"
+msgstr ""
+
+#: mod/profile_photo.php:268
+msgid "Crop Image"
+msgstr ""
+
+#: mod/profile_photo.php:269
+msgid "Please adjust the image cropping for optimum viewing."
+msgstr ""
+
+#: mod/profile_photo.php:271
+msgid "Done Editing"
+msgstr ""
+
+#: mod/profile_photo.php:305
+msgid "Image uploaded successfully."
 msgstr ""
 
 #: mod/register.php:93
@@ -8599,51 +8445,271 @@ msgstr ""
 msgid "Resend relocate message to contacts"
 msgstr ""
 
-#: mod/videos.php:120
-msgid "Do you really want to delete this video?"
-msgstr ""
-
-#: mod/videos.php:125
-msgid "Delete Video"
-msgstr ""
-
-#: mod/videos.php:204
-msgid "No videos selected"
-msgstr ""
-
-#: mod/videos.php:396
-msgid "Recent Videos"
-msgstr ""
-
-#: mod/videos.php:398
-msgid "Upload New Videos"
-msgstr ""
-
-#: mod/viewcontacts.php:72
-msgid "No contacts."
-msgstr ""
-
-#: mod/wall_attach.php:17 mod/wall_attach.php:25 mod/wall_attach.php:76
-#: mod/wall_upload.php:20 mod/wall_upload.php:33 mod/wall_upload.php:86
-#: mod/wall_upload.php:122 mod/wall_upload.php:125
-msgid "Invalid request."
-msgstr ""
-
-#: mod/wall_attach.php:94
-msgid "Sorry, maybe your upload is bigger than the PHP configuration allows"
-msgstr ""
-
-#: mod/wall_attach.php:94
-msgid "Or - did you try to upload an empty file?"
-msgstr ""
-
-#: mod/wall_attach.php:105
+#: mod/wallmessage.php:42 mod/wallmessage.php:112
 #, php-format
-msgid "File exceeds size limit of %s"
+msgid "Number of daily wall messages for %s exceeded. Message failed."
 msgstr ""
 
-#: mod/wall_attach.php:156 mod/wall_attach.php:172
-msgid "File upload failed."
+#: mod/wallmessage.php:56 mod/message.php:71
+msgid "No recipient selected."
+msgstr ""
+
+#: mod/wallmessage.php:59
+msgid "Unable to check your home location."
+msgstr ""
+
+#: mod/wallmessage.php:62 mod/message.php:78
+msgid "Message could not be sent."
+msgstr ""
+
+#: mod/wallmessage.php:65 mod/message.php:81
+msgid "Message collection failure."
+msgstr ""
+
+#: mod/wallmessage.php:68 mod/message.php:84
+msgid "Message sent."
+msgstr ""
+
+#: mod/wallmessage.php:86 mod/wallmessage.php:95
+msgid "No recipient."
+msgstr ""
+
+#: mod/wallmessage.php:142 mod/message.php:341
+msgid "Send Private Message"
+msgstr ""
+
+#: mod/wallmessage.php:143
+#, php-format
+msgid ""
+"If you wish for %s to respond, please check that the privacy settings on "
+"your site allow private mail from unknown senders."
+msgstr ""
+
+#: mod/wallmessage.php:144 mod/message.php:342 mod/message.php:536
+msgid "To:"
+msgstr ""
+
+#: mod/wallmessage.php:145 mod/message.php:347 mod/message.php:538
+msgid "Subject:"
+msgstr ""
+
+#: mod/share.php:38
+msgid "link"
+msgstr ""
+
+#: mod/api.php:76 mod/api.php:102
+msgid "Authorize application connection"
+msgstr ""
+
+#: mod/api.php:77
+msgid "Return to your app and insert this Securty Code:"
+msgstr ""
+
+#: mod/api.php:89
+msgid "Please login to continue."
+msgstr ""
+
+#: mod/api.php:104
+msgid ""
+"Do you want to authorize this application to access your posts and contacts, "
+"and/or create new posts for you?"
+msgstr ""
+
+#: mod/babel.php:17
+msgid "Source (bbcode) text:"
+msgstr ""
+
+#: mod/babel.php:23
+msgid "Source (Diaspora) text to convert to BBcode:"
+msgstr ""
+
+#: mod/babel.php:31
+msgid "Source input: "
+msgstr ""
+
+#: mod/babel.php:35
+msgid "bb2html (raw HTML): "
+msgstr ""
+
+#: mod/babel.php:39
+msgid "bb2html: "
+msgstr ""
+
+#: mod/babel.php:43
+msgid "bb2html2bb: "
+msgstr ""
+
+#: mod/babel.php:47
+msgid "bb2md: "
+msgstr ""
+
+#: mod/babel.php:51
+msgid "bb2md2html: "
+msgstr ""
+
+#: mod/babel.php:55
+msgid "bb2dia2bb: "
+msgstr ""
+
+#: mod/babel.php:59
+msgid "bb2md2html2bb: "
+msgstr ""
+
+#: mod/babel.php:69
+msgid "Source input (Diaspora format): "
+msgstr ""
+
+#: mod/babel.php:74
+msgid "diaspora2bb: "
+msgstr ""
+
+#: mod/item.php:116
+msgid "Unable to locate original post."
+msgstr ""
+
+#: mod/item.php:340
+msgid "Empty post discarded."
+msgstr ""
+
+#: mod/item.php:898
+msgid "System error. Post not saved."
+msgstr ""
+
+#: mod/item.php:988
+#, php-format
+msgid ""
+"This message was sent to you by %s, a member of the Friendica social network."
+msgstr ""
+
+#: mod/item.php:990
+#, php-format
+msgid "You may visit them online at %s"
+msgstr ""
+
+#: mod/item.php:991
+msgid ""
+"Please contact the sender by replying to this post if you do not wish to "
+"receive these messages."
+msgstr ""
+
+#: mod/item.php:995
+#, php-format
+msgid "%s posted an update."
+msgstr ""
+
+#: mod/ostatus_subscribe.php:14
+msgid "Subscribing to OStatus contacts"
+msgstr ""
+
+#: mod/ostatus_subscribe.php:25
+msgid "No contact provided."
+msgstr ""
+
+#: mod/ostatus_subscribe.php:30
+msgid "Couldn't fetch information for contact."
+msgstr ""
+
+#: mod/ostatus_subscribe.php:38
+msgid "Couldn't fetch friends for contact."
+msgstr ""
+
+#: mod/ostatus_subscribe.php:65
+msgid "success"
+msgstr ""
+
+#: mod/ostatus_subscribe.php:67
+msgid "failed"
+msgstr ""
+
+#: mod/dfrn_poll.php:104 mod/dfrn_poll.php:537
+#, php-format
+msgid "%1$s welcomes %2$s"
+msgstr ""
+
+#: mod/profile.php:179
+msgid "Tips for New Members"
+msgstr ""
+
+#: mod/message.php:75
+msgid "Unable to locate contact information."
+msgstr ""
+
+#: mod/message.php:215
+msgid "Do you really want to delete this message?"
+msgstr ""
+
+#: mod/message.php:235
+msgid "Message deleted."
+msgstr ""
+
+#: mod/message.php:266
+msgid "Conversation removed."
+msgstr ""
+
+#: mod/message.php:383
+msgid "No messages."
+msgstr ""
+
+#: mod/message.php:426
+msgid "Message not available."
+msgstr ""
+
+#: mod/message.php:503
+msgid "Delete message"
+msgstr ""
+
+#: mod/message.php:529 mod/message.php:609
+msgid "Delete conversation"
+msgstr ""
+
+#: mod/message.php:531
+msgid ""
+"No secure communications available. You <strong>may</strong> be able to "
+"respond from the sender's profile page."
+msgstr ""
+
+#: mod/message.php:535
+msgid "Send Reply"
+msgstr ""
+
+#: mod/message.php:579
+#, php-format
+msgid "Unknown sender - %s"
+msgstr ""
+
+#: mod/message.php:581
+#, php-format
+msgid "You and %s"
+msgstr ""
+
+#: mod/message.php:583
+#, php-format
+msgid "%s and You"
+msgstr ""
+
+#: mod/message.php:612
+msgid "D, d M Y - g:i A"
+msgstr ""
+
+#: mod/message.php:615
+#, php-format
+msgid "%d message"
+msgid_plural "%d messages"
+msgstr[0] ""
+msgstr[1] ""
+
+#: mod/manage.php:139
+msgid "Manage Identities and/or Pages"
+msgstr ""
+
+#: mod/manage.php:140
+msgid ""
+"Toggle between different identities or community/group pages which share "
+"your account details or which you have been granted \"manage\" permissions"
+msgstr ""
+
+#: mod/manage.php:141
+msgid "Select an identity to manage: "
 msgstr ""
 
 #: object/Item.php:370
@@ -8680,6 +8746,14 @@ msgstr ""
 
 #: view/theme/frio/php/Image.php:29
 msgid "Resize to best fit and retain aspect ratio."
+msgstr ""
+
+#: view/theme/frio/theme.php:229
+msgid "Guest"
+msgstr ""
+
+#: view/theme/frio/theme.php:235
+msgid "Visitor"
 msgstr ""
 
 #: view/theme/frio/config.php:42
@@ -8720,14 +8794,6 @@ msgstr ""
 
 #: view/theme/frio/config.php:68
 msgid "Set the background image"
-msgstr ""
-
-#: view/theme/frio/theme.php:226
-msgid "Guest"
-msgstr ""
-
-#: view/theme/frio/theme.php:232
-msgid "Visitor"
 msgstr ""
 
 #: view/theme/quattro/config.php:67
@@ -8820,57 +8886,4 @@ msgstr ""
 
 #: view/theme/duepuntozero/config.php:62
 msgid "Variations"
-msgstr ""
-
-#: index.php:447
-msgid "toggle mobile"
-msgstr ""
-
-#: boot.php:969
-msgid "Delete this item?"
-msgstr ""
-
-#: boot.php:972
-msgid "show fewer"
-msgstr ""
-
-#: boot.php:1650
-#, php-format
-msgid "Update %s failed. See error logs."
-msgstr ""
-
-#: boot.php:1762
-msgid "Create a New Account"
-msgstr ""
-
-#: boot.php:1791
-msgid "Password: "
-msgstr ""
-
-#: boot.php:1792
-msgid "Remember me"
-msgstr ""
-
-#: boot.php:1795
-msgid "Or login using OpenID: "
-msgstr ""
-
-#: boot.php:1801
-msgid "Forgot your password?"
-msgstr ""
-
-#: boot.php:1804
-msgid "Website Terms of Service"
-msgstr ""
-
-#: boot.php:1805
-msgid "terms of service"
-msgstr ""
-
-#: boot.php:1807
-msgid "Website Privacy Policy"
-msgstr ""
-
-#: boot.php:1808
-msgid "privacy policy"
 msgstr ""

--- a/view/templates/admin_site.tpl
+++ b/view/templates/admin_site.tpl
@@ -161,6 +161,7 @@
 	{{include file="field_input.tpl" field=$worker_queues}}
 	{{include file="field_checkbox.tpl" field=$worker_dont_fork}}
 	{{include file="field_checkbox.tpl" field=$worker_fastlane}}
+	{{include file="field_checkbox.tpl" field=$worker_frontend}}
 	<div class="submit"><input type="submit" name="page_site" value="{{$submit|escape:'html'}}" /></div>
 
 	</form>

--- a/view/templates/admin_site.tpl
+++ b/view/templates/admin_site.tpl
@@ -158,10 +158,12 @@
 
 	<h3>{{$worker_title}}</h3>
 	{{include file="field_checkbox.tpl" field=$worker}}
-	{{include file="field_input.tpl" field=$worker_queues}}
-	{{include file="field_checkbox.tpl" field=$worker_dont_fork}}
-	{{include file="field_checkbox.tpl" field=$worker_fastlane}}
-	{{include file="field_checkbox.tpl" field=$worker_frontend}}
+	{{if $worker.2}}
+		{{include file="field_input.tpl" field=$worker_queues}}
+		{{include file="field_checkbox.tpl" field=$worker_dont_fork}}
+		{{include file="field_checkbox.tpl" field=$worker_fastlane}}
+		{{include file="field_checkbox.tpl" field=$worker_frontend}}
+	{{/if}}
 	<div class="submit"><input type="submit" name="page_site" value="{{$submit|escape:'html'}}" /></div>
 
 	</form>


### PR DESCRIPTION
The setting to activate the "frontend worker" can now be done in the admin panel, hence the option was removed from the docs. Also the master messages.po file was updated so the newly added strings can be picked up by the translation process.

As the "frontend worker" makes addons like the extcron one obsolete, I feed it's activation should be as easy as to activate an addon in the admin panel. 