### PR TITLE
only convert tables in friendica DB

### DIFF
--- a/util/convert_innodb.sql
+++ b/util/convert_innodb.sql
@@ -1,4 +1,4 @@
 
 SELECT CONCAT('ALTER TABLE ',table_schema,'.',table_name,' engine=InnoDB;') 
 FROM information_schema.tables 
-WHERE engine = 'MyISAM';
+WHERE engine = 'MyISAM' AND  `table_schema` = 'friendica';

--- a/util/convert_innodb.sql
+++ b/util/convert_innodb.sql
@@ -1,4 +1,6 @@
-
+#  script to convert tables from MyISAM to InnoDB
+#  change the %PLACEHOLDER% to ythe actual name of your Friendica DB
+ 
 SELECT CONCAT('ALTER TABLE ',table_schema,'.',table_name,' engine=InnoDB;') 
 FROM information_schema.tables 
-WHERE engine = 'MyISAM' AND  `table_schema` = 'friendica';
+WHERE engine = 'MyISAM' AND  `table_schema` = '%PLACEHOLDER%';

--- a/util/convert_innodb.sql
+++ b/util/convert_innodb.sql
@@ -1,5 +1,5 @@
 #  script to convert tables from MyISAM to InnoDB
-#  change the %PLACEHOLDER% to ythe actual name of your Friendica DB
+#  change the %PLACEHOLDER% to the actual name of your Friendica DB
  
 SELECT CONCAT('ALTER TABLE ',table_schema,'.',table_name,' engine=InnoDB;') 
 FROM information_schema.tables 


### PR DESCRIPTION
if the DB is not called `friendica` MySQL should throw an error and the user should remember the different DB name.