### PR TITLE
add allowed protocols during installation

### DIFF
--- a/htconfig.php
+++ b/htconfig.php
@@ -66,7 +66,7 @@ $a->config['system']['allowed_themes'] = 'quattro,vier,duepuntozero';
 
 // default system theme
 
-$a->config['system']['theme'] = 'duepuntozero';
+$a->config['system']['theme'] = 'vier';
 
 
 // By default allow pseudonyms

--- a/view/templates/htconfig.tpl
+++ b/view/templates/htconfig.tpl
@@ -95,3 +95,6 @@ $a->config['system']['no_regfullname'] = true;
 
 // Location of the global directory
 $a->config['system']['directory'] = 'http://dir.friendi.ca';
+
+// Allowed protocols in link URLs; HTTP protocols always are accepted
+$a->config['system']['allowed_link_protocols'] = array('ftp', 'ftps', 'mailto', 'cid', 'gopher');

--- a/view/templates/htconfig.tpl
+++ b/view/templates/htconfig.tpl
@@ -35,6 +35,9 @@ $a->config['php_path'] = '{{$phpath}}';
 
 $a->path = '{{$urlpath}}';
 
+// Allowed protocols in link URLs; HTTP protocols always are accepted
+$a->config['system']['allowed_link_protocols'] = array('ftp', 'ftps', 'mailto', 'cid', 'gopher');
+
 /* *********************************************************************
  *  The configuration below will be overruled by the admin panel.
  *  Changes made below will only have an effect if the database does
@@ -95,6 +98,3 @@ $a->config['system']['no_regfullname'] = true;
 
 // Location of the global directory
 $a->config['system']['directory'] = 'http://dir.friendi.ca';
-
-// Allowed protocols in link URLs; HTTP protocols always are accepted
-$a->config['system']['allowed_link_protocols'] = array('ftp', 'ftps', 'mailto', 'cid', 'gopher');


### PR DESCRIPTION
follow-up for #2932  adding the new config variable also to the template used during installation.

Also in the `htconfig.php` example file, `vier` was not used as default theme.