### PR TITLE
Only distribute items to active contacts

### DIFF
--- a/include/notifier.php
+++ b/include/notifier.php
@@ -575,7 +575,7 @@ function notifier_run(&$argv, &$argc){
 			$r0 = array();
 
 		$r1 = q("SELECT DISTINCT(`batch`), `id`, `name`,`network` FROM `contact` WHERE `network` = '%s'
-			AND `uid` = %d AND `rel` != %d group by `batch` ORDER BY rand() ",
+			AND `uid` = %d AND `rel` != %d AND NOT `blocked` AND NOT `pending` AND NOT `archive` GROUP BY `batch` ORDER BY rand()",
 			dbesc(NETWORK_DIASPORA),
 			intval($owner['uid']),
 			intval(CONTACT_IS_SHARING)


### PR DESCRIPTION
This fix avoids the sending of public items to known dead contacts. This is only a partly solution. When a server is gone completely we maybe should mark all contacts of this server as archived.