### PR TITLE
frio notifications templates + local date & profile link for the notifications page

### DIFF
--- a/include/NotificationsManager.php
+++ b/include/NotificationsManager.php
@@ -198,9 +198,10 @@ class NotificationsManager {
 	 *	string 'label' => The type of the notification
 	 *	string 'link' => URL to the source
 	 *	string 'image' => The avatar image
-	 * *	string 'url' => The profile url of the contact
+	 *	string 'url' => The profile url of the contact
 	 *	string 'text' => The notification text
-	 *	string 'when' => Relative date of the notification
+	 *	string 'when' => The date of the notification
+	 *	string 'ago' => T relative date of the notification
 	 *	bool 'seen' => Is the notification marked as "seen"
 	 */
 	private function formatNotifs($notifs, $ident = "") {
@@ -226,7 +227,8 @@ class NotificationsManager {
 						$default_item_image = proxy_url($it['photo'], false, PROXY_SIZE_MICRO);
 						$default_item_url = $it['url'];
 						$default_item_text = strip_tags(bbcode($it['msg']));
-						$default_item_when = relative_date($it['date']);
+						$default_item_when = datetime_convert('UTC', date_default_timezone_get(), $it['date'], 'r');
+						$default_item_ago = relative_date($it['date']);
 						break;
 
 					case 'home':
@@ -235,7 +237,8 @@ class NotificationsManager {
 						$default_item_image = proxy_url($it['author-avatar'], false, PROXY_SIZE_MICRO);
 						$default_item_url = $it['author-link'];
 						$default_item_text = sprintf(t("%s commented on %s's post"), $it['author-name'], $it['pname']);
-						$default_item_when = relative_date($it['created']);
+						$default_item_when = datetime_convert('UTC', date_default_timezone_get(), $it['created'], 'r');
+						$default_item_ago = relative_date($it['created']);
 						break;
 
 					default:
@@ -246,7 +249,8 @@ class NotificationsManager {
 						$default_item_text = (($it['id'] == $it['parent'])
 									? sprintf(t("%s created a new post"), $it['author-name'])
 									: sprintf(t("%s commented on %s's post"), $it['author-name'], $it['pname']));
-						$default_item_when = relative_date($it['created']);
+						$default_item_when = datetime_convert('UTC', date_default_timezone_get(), $it['created'], 'r');
+						$default_item_ago = relative_date($it['created']);
 
 				}
 
@@ -259,7 +263,8 @@ class NotificationsManager {
 							'image' => proxy_url($it['author-avatar'], false, PROXY_SIZE_MICRO),
 							'url' => $it['author-link'],
 							'text' => sprintf(t("%s liked %s's post"), $it['author-name'], $it['pname']),
-							'when' => relative_date($it['created']),
+							'when' => $default_item_when,
+							'ago' => $default_item_ago,
 							'seen' => $it['seen']
 						);
 						break;
@@ -271,7 +276,8 @@ class NotificationsManager {
 							'image' => proxy_url($it['author-avatar'], false, PROXY_SIZE_MICRO),
 							'url' => $it['author-link'],
 							'text' => sprintf(t("%s disliked %s's post"), $it['author-name'], $it['pname']),
-							'when' => relative_date($it['created']),
+							'when' => $default_item_when,
+							'ago' => $default_item_ago,
 							'seen' => $it['seen']
 						);
 						break;
@@ -283,7 +289,8 @@ class NotificationsManager {
 							'image' => proxy_url($it['author-avatar'], false, PROXY_SIZE_MICRO),
 							'url' => $it['author-link'],
 							'text' => sprintf(t("%s is attending %s's event"), $it['author-name'], $it['pname']),
-							'when' => relative_date($it['created']),
+							'when' => $default_item_when,
+							'ago' => $default_item_ago,
 							'seen' => $it['seen']
 						);
 						break;
@@ -295,7 +302,8 @@ class NotificationsManager {
 							'image' => proxy_url($it['author-avatar'], false, PROXY_SIZE_MICRO),
 							'url' => $it['author-link'],
 							'text' => sprintf( t("%s is not attending %s's event"), $it['author-name'], $it['pname']),
-							'when' => relative_date($it['created']),
+							'when' => $default_item_when,
+							'ago' => $default_item_ago,
 							'seen' => $it['seen']
 						);
 						break;
@@ -307,7 +315,8 @@ class NotificationsManager {
 							'image' => proxy_url($it['author-avatar'], false, PROXY_SIZE_MICRO),
 							'url' => $it['author-link'],
 							'text' => sprintf(t("%s may attend %s's event"), $it['author-name'], $it['pname']),
-							'when' => relative_date($it['created']),
+							'when' => $default_item_when,
+							'ago' => $default_item_ago,
 							'seen' => $it['seen']
 						);
 						break;
@@ -323,7 +332,8 @@ class NotificationsManager {
 							'image' => proxy_url($it['author-avatar'], false, PROXY_SIZE_MICRO),
 							'url' => $it['author-link'],
 							'text' => sprintf(t("%s is now friends with %s"), $it['author-name'], $it['fname']),
-							'when' => relative_date($it['created']),
+							'when' => $default_item_when,
+							'ago' => $default_item_ago,
 							'seen' => $it['seen']
 						);
 						break;
@@ -336,6 +346,7 @@ class NotificationsManager {
 							'url' => $default_item_url,
 							'text' => $default_item_text,
 							'when' => $default_item_when,
+							'ago' => $default_item_ago,
 							'seen' => $it['seen']
 						);
 				}

--- a/mod/notifications.php
+++ b/mod/notifications.php
@@ -285,6 +285,7 @@ function notifications_content(&$a) {
 				'$item_label' => $it['label'],
 				'$item_link' => $it['link'],
 				'$item_image' => $it['image'],
+				'$item_url' => $it['url'],
 				'$item_text' => htmlentities($it['text']),
 				'$item_when' => $it['when'],
 				'$item_seen' => $it['seen'],

--- a/mod/notifications.php
+++ b/mod/notifications.php
@@ -288,6 +288,7 @@ function notifications_content(&$a) {
 				'$item_url' => $it['url'],
 				'$item_text' => htmlentities($it['text']),
 				'$item_when' => $it['when'],
+				'$item_ago' => $it['ago'],
 				'$item_seen' => $it['seen'],
 			));
 		}

--- a/view/templates/notifications_attend_item.tpl
+++ b/view/templates/notifications_attend_item.tpl
@@ -1,4 +1,4 @@
 
 <div class="notif-item {{if !$item_seen}}unseen{{/if}}">
-	<a href="{{$item_link}}" target="friendica-notification"><img src="{{$item_image}}" class="notif-image">{{$item_text}} <span class="notif-when">{{$item_when}}</span></a>
+	<a href="{{$item_link}}" target="friendica-notification"><img src="{{$item_image}}" class="notif-image">{{$item_text}} <span class="notif-when">{{$item_ago}}</span></a>
 </div>

--- a/view/templates/notifications_comments_item.tpl
+++ b/view/templates/notifications_comments_item.tpl
@@ -1,4 +1,4 @@
 
 <div class="notif-item {{if !$item_seen}}unseen{{/if}}">
-	<a href="{{$item_link}}" target="friendica-notifications"><img src="{{$item_image}}" class="notif-image">{{$item_text}} <span class="notif-when">{{$item_when}}</span></a>
+	<a href="{{$item_link}}" target="friendica-notifications"><img src="{{$item_image}}" class="notif-image">{{$item_text}} <span class="notif-when">{{$item_ago}}</span></a>
 </div>

--- a/view/templates/notifications_dislikes_item.tpl
+++ b/view/templates/notifications_dislikes_item.tpl
@@ -1,4 +1,4 @@
 
 <div class="notif-item {{if !$item_seen}}unseen{{/if}}">
-	<a href="{{$item_link}}" target="friendica-notifications"><img src="{{$item_image}}" class="notif-image">{{$item_text}} <span class="notif-when">{{$item_when}}</span></a>
+	<a href="{{$item_link}}" target="friendica-notifications"><img src="{{$item_image}}" class="notif-image">{{$item_text}} <span class="notif-when">{{$item_ago}}</span></a>
 </div>

--- a/view/templates/notifications_friends_item.tpl
+++ b/view/templates/notifications_friends_item.tpl
@@ -1,4 +1,4 @@
 
 <div class="notif-item {{if !$item_seen}}unseen{{/if}}">
-	<a href="{{$item_link}}" target="friendica-notifications"><img src="{{$item_image}}" class="notif-image">{{$item_text}} <span class="notif-when">{{$item_when}}</span></a>
+	<a href="{{$item_link}}" target="friendica-notifications"><img src="{{$item_image}}" class="notif-image">{{$item_text}} <span class="notif-when">{{$item_ago}}</span></a>
 </div>

--- a/view/templates/notifications_likes_item.tpl
+++ b/view/templates/notifications_likes_item.tpl
@@ -1,4 +1,4 @@
 
 <div class="notif-item {{if !$item_seen}}unseen{{/if}}">
-	<a href="{{$item_link}}" target="friendica-notification"><img src="{{$item_image}}" class="notif-image">{{$item_text}} <span class="notif-when">{{$item_when}}</span></a>
+	<a href="{{$item_link}}" target="friendica-notification"><img src="{{$item_image}}" class="notif-image">{{$item_text}} <span class="notif-when">{{$item_ago}}</span></a>
 </div>

--- a/view/templates/notifications_network_item.tpl
+++ b/view/templates/notifications_network_item.tpl
@@ -1,4 +1,4 @@
 
 <div class="notif-item {{if !$item_seen}}unseen{{/if}}">
-	<a href="{{$item_link}}" target="friendica-notifications"><img src="{{$item_image}}" class="notif-image">{{$item_text}} <span class="notif-when">{{$item_when}}</span></a>
+	<a href="{{$item_link}}" target="friendica-notifications"><img src="{{$item_image}}" class="notif-image">{{$item_text}} <span class="notif-when">{{$item_ago}}</span></a>
 </div>

--- a/view/templates/notifications_posts_item.tpl
+++ b/view/templates/notifications_posts_item.tpl
@@ -1,4 +1,4 @@
 
 <div class="notif-item {{if !$item_seen}}unseen{{/if}}">
-	<a href="{{$item_link}}" target="friendica-notifications"><img src="{{$item_image}}" class="notif-image">{{$item_text}} <span class="notif-when">{{$item_when}}</span></a>
+	<a href="{{$item_link}}" target="friendica-notifications"><img src="{{$item_image}}" class="notif-image">{{$item_text}} <span class="notif-when">{{$item_ago}}</span></a>
 </div>

--- a/view/templates/notify.tpl
+++ b/view/templates/notify.tpl
@@ -1,4 +1,4 @@
 
 <div class="notif-item {{if !$item_seen}}unseen{{/if}}">
-	<a href="{{$item_link}}" target="friendica-notifications"><img src="{{$item_image}}" class="notif-image">{{$item_text}} <span class="notif-when">{{$item_when}}</span></a>
+	<a href="{{$item_link}}" target="friendica-notifications"><img src="{{$item_image}}" class="notif-image">{{$item_text}} <span class="notif-when">{{$item_ago}}</span></a>
 </div>

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -2220,10 +2220,6 @@ ul.notif-network-list > li {
     padding-left: 15px;
     padding-right: 15px;
 }
-ul.notif-network-list li.unseen {
-    border-left: 3px solid #f3fcfd;
-    background-color: #f3fcfd;
-}
 .intro-wrapper.media {
     overflow: visible;
     word-wrap: break-word;
@@ -2283,6 +2279,9 @@ ul.notif-network-list > li:hover .intro-action-buttons {
 }
 
 /* Notifications Page */
+ul.notif-network-list li.unseen {
+    background-color: #f3fcfd;
+}
 .notif-item img.notif-image {
     height: 48px;
     width: 48px;

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -1882,6 +1882,9 @@ ul.dropdown-menu li:hover {
     -moz-box-shadow: 0 0 3px #dadada;
 }
 
+.section-title-wrapper {
+    overflow: hidden;
+}
 /* Profile-page */
 #profile-content-standard,
 #profile-content-advanced {
@@ -2208,7 +2211,7 @@ ul li:hover .contact-wrapper a.contact-action-link:hover {
     margin-left: 20px;
 }
 
-/* Notifications */
+/* Intro Notifications */
 ul.notif-network-list {
     margin-left: -15px;
     margin-right: -15px;
@@ -2226,10 +2229,9 @@ ul.notif-network-list li.unseen {
     word-wrap: break-word;
     margin-top: 0;
 }
-.intro-photo-wrapper img.intro-photo,
-.notif-item img.notif-image {
-    height:80px;
-    width: 80px;
+.intro-photo-wrapper img.intro-photo {
+    height:48px;
+    width: 48px;
     border-radius: 4px;
 }
 .intro-actions {
@@ -2278,6 +2280,23 @@ ul.notif-network-list > li:hover .intro-action-buttons {
 .intro-contact-info.xs .intro-knowyou-label {
     display: block;
     margin-top: 5px
+}
+
+/* Notifications Page */
+.notif-item img.notif-image {
+    height: 48px;
+    width: 48px;
+    border-radius: 4px;
+}
+.notif-item .notif-desc-wrapper {
+    height: 48px;
+}
+.notif-item .notif-desc-wrapper a {
+    height: 100%;
+    display: block;
+    color: #555;
+    font-size: 13px;
+    font-weight: 600;
 }
 
 /* Search Page */

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -2226,8 +2226,8 @@ ul.notif-network-list > li {
     margin-top: 0;
 }
 .intro-photo-wrapper img.intro-photo {
-    height:48px;
-    width: 48px;
+    height:80px;
+    width: 80px;
     border-radius: 4px;
 }
 .intro-actions {

--- a/view/theme/frio/templates/notifications_attend_item.tpl
+++ b/view/theme/frio/templates/notifications_attend_item.tpl
@@ -1,0 +1,2 @@
+
+{{include file="notify.tpl"}}

--- a/view/theme/frio/templates/notifications_comments_item.tpl
+++ b/view/theme/frio/templates/notifications_comments_item.tpl
@@ -1,0 +1,2 @@
+
+{{include file="notify.tpl"}}

--- a/view/theme/frio/templates/notifications_dislikes_item.tpl
+++ b/view/theme/frio/templates/notifications_dislikes_item.tpl
@@ -1,0 +1,2 @@
+
+{{include file="notify.tpl"}}

--- a/view/theme/frio/templates/notifications_friends_item.tpl
+++ b/view/theme/frio/templates/notifications_friends_item.tpl
@@ -1,0 +1,2 @@
+
+{{include file="notify.tpl"}}

--- a/view/theme/frio/templates/notifications_likes_item.tpl
+++ b/view/theme/frio/templates/notifications_likes_item.tpl
@@ -1,0 +1,2 @@
+
+{{include file="notify.tpl"}}

--- a/view/theme/frio/templates/notifications_network_item.tpl
+++ b/view/theme/frio/templates/notifications_network_item.tpl
@@ -1,0 +1,2 @@
+
+{{include file="notify.tpl"}}

--- a/view/theme/frio/templates/notifications_posts_item.tpl
+++ b/view/theme/frio/templates/notifications_posts_item.tpl
@@ -1,0 +1,2 @@
+
+{{include file="notify.tpl"}}

--- a/view/theme/frio/templates/notify.tpl
+++ b/view/theme/frio/templates/notify.tpl
@@ -6,7 +6,7 @@
 	<div class="notif-desc-wrapper media-body">
 		<a href="{{$item_link}}">
 			{{$item_text}}
-			<div><time class="notif-when time" data-toggle="tooltip">{{$item_when}}</time></div>
+			<div><time class="notif-when time" data-toggle="tooltip" title="{{$item_when}}">{{$item_ago}}</time></div>
 		</a>
 	</div>
 </div>

--- a/view/theme/frio/templates/notify.tpl
+++ b/view/theme/frio/templates/notify.tpl
@@ -1,7 +1,7 @@
 
 <div class="notif-item {{if !$item_seen}}unseen{{/if}} {{$item_label}} media">
 	<div class="notif-photo-wrapper media-object pull-left">
-		<img src="{{$item_image}}" class="notif-image">
+		<a class="userinfo" href="{{$item_url}}"><img src="{{$item_image}}" class="notif-image"></a>
 	</div>
 	<div class="notif-desc-wrapper media-body">
 		<a href="{{$item_link}}">

--- a/view/theme/frio/templates/notify.tpl
+++ b/view/theme/frio/templates/notify.tpl
@@ -1,0 +1,12 @@
+
+<div class="notif-item {{if !$item_seen}}unseen{{/if}} {{$item_label}} media">
+	<div class="notif-photo-wrapper media-object pull-left">
+		<img src="{{$item_image}}" class="notif-image">
+	</div>
+	<div class="notif-desc-wrapper media-body">
+		<a href="{{$item_link}}">
+			{{$item_text}}
+			<div><time class="notif-when time" data-toggle="tooltip">{{$item_when}}</time></div>
+		</a>
+	</div>
+</div>


### PR DESCRIPTION
Frio does now have own templates for the notifications pages.

In addition the notifications pages does provide a profile link (used in frio to link the avatar picture to the profile url and to provide hovercards) and the local date is presented in a tooltip