### PR TITLE
New binary data fields to avoid index length problems

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -38,7 +38,7 @@ define ( 'FRIENDICA_PLATFORM',     'Friendica');
 define ( 'FRIENDICA_CODENAME',     'Asparagus');
 define ( 'FRIENDICA_VERSION',      '3.5.1-dev' );
 define ( 'DFRN_PROTOCOL_VERSION',  '2.23'    );
-define ( 'DB_UPDATE_VERSION',      1209      );
+define ( 'DB_UPDATE_VERSION',      1210      );
 
 /**
  * @brief Constant with a HTML line break.

--- a/database.sql
+++ b/database.sql
@@ -1,6 +1,6 @@
 -- ------------------------------------------
 -- Friendica 3.5.1-dev (Asparagus)
--- DB_UPDATE_VERSION 1208
+-- DB_UPDATE_VERSION 1210
 -- ------------------------------------------
 
 
@@ -54,11 +54,11 @@ CREATE TABLE IF NOT EXISTS `auth_codes` (
 -- TABLE cache
 --
 CREATE TABLE IF NOT EXISTS `cache` (
-	`k` varchar(255) NOT NULL,
+	`k` varbinary(255) NOT NULL,
 	`v` text,
 	`expire_mode` int(11) NOT NULL DEFAULT 0,
 	`updated` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
-	 PRIMARY KEY(`k`(191)),
+	 PRIMARY KEY(`k`),
 	 INDEX `updated` (`updated`),
 	 INDEX `expire_mode_updated` (`expire_mode`,`updated`)
 ) DEFAULT CHARSET=utf8mb4;
@@ -94,11 +94,11 @@ CREATE TABLE IF NOT EXISTS `clients` (
 --
 CREATE TABLE IF NOT EXISTS `config` (
 	`id` int(10) unsigned NOT NULL auto_increment,
-	`cat` varchar(255) NOT NULL DEFAULT '',
-	`k` varchar(255) NOT NULL DEFAULT '',
+	`cat` varbinary(255) NOT NULL DEFAULT '',
+	`k` varbinary(255) NOT NULL DEFAULT '',
 	`v` text,
 	 PRIMARY KEY(`id`),
-	 UNIQUE INDEX `cat_k` (`cat`(30),`k`(30))
+	 UNIQUE INDEX `cat_k` (`cat`,`k`)
 ) DEFAULT CHARSET=utf8mb4;
 
 --
@@ -200,7 +200,7 @@ CREATE TABLE IF NOT EXISTS `conv` (
 --
 CREATE TABLE IF NOT EXISTS `deliverq` (
 	`id` int(10) unsigned NOT NULL auto_increment,
-	`cmd` varchar(32) NOT NULL DEFAULT '',
+	`cmd` varbinary(32) NOT NULL DEFAULT '',
 	`item` int(11) NOT NULL DEFAULT 0,
 	`contact` int(11) NOT NULL DEFAULT 0,
 	 PRIMARY KEY(`id`),
@@ -682,10 +682,10 @@ CREATE TABLE IF NOT EXISTS `notify-threads` (
 -- TABLE oembed
 --
 CREATE TABLE IF NOT EXISTS `oembed` (
-	`url` varchar(255) NOT NULL,
+	`url` varbinary(255) NOT NULL,
 	`content` text,
 	`created` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
-	 PRIMARY KEY(`url`(191)),
+	 PRIMARY KEY(`url`),
 	 INDEX `created` (`created`)
 ) DEFAULT CHARSET=utf8mb4;
 
@@ -693,12 +693,12 @@ CREATE TABLE IF NOT EXISTS `oembed` (
 -- TABLE parsed_url
 --
 CREATE TABLE IF NOT EXISTS `parsed_url` (
-	`url` varchar(255) NOT NULL,
+	`url` varbinary(255) NOT NULL,
 	`guessing` tinyint(1) NOT NULL DEFAULT 0,
 	`oembed` tinyint(1) NOT NULL DEFAULT 0,
 	`content` text,
 	`created` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
-	 PRIMARY KEY(`url`(191),`guessing`,`oembed`),
+	 PRIMARY KEY(`url`,`guessing`,`oembed`),
 	 INDEX `created` (`created`)
 ) DEFAULT CHARSET=utf8mb4;
 
@@ -708,11 +708,11 @@ CREATE TABLE IF NOT EXISTS `parsed_url` (
 CREATE TABLE IF NOT EXISTS `pconfig` (
 	`id` int(11) NOT NULL auto_increment,
 	`uid` int(11) NOT NULL DEFAULT 0,
-	`cat` varchar(255) NOT NULL DEFAULT '',
-	`k` varchar(255) NOT NULL DEFAULT '',
+	`cat` varbinary(255) NOT NULL DEFAULT '',
+	`k` varbinary(255) NOT NULL DEFAULT '',
 	`v` mediumtext,
 	 PRIMARY KEY(`id`),
-	 UNIQUE INDEX `uid_cat_k` (`uid`,`cat`(30),`k`(30))
+	 UNIQUE INDEX `uid_cat_k` (`uid`,`cat`,`k`)
 ) DEFAULT CHARSET=utf8mb4;
 
 --
@@ -786,7 +786,7 @@ CREATE TABLE IF NOT EXISTS `poll_result` (
 --
 CREATE TABLE IF NOT EXISTS `process` (
 	`pid` int(10) unsigned NOT NULL,
-	`command` varchar(32) NOT NULL DEFAULT '',
+	`command` varbinary(32) NOT NULL DEFAULT '',
 	`created` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
 	 PRIMARY KEY(`pid`),
 	 INDEX `command` (`command`)
@@ -920,7 +920,7 @@ CREATE TABLE IF NOT EXISTS `search` (
 --
 CREATE TABLE IF NOT EXISTS `session` (
 	`id` bigint(20) unsigned NOT NULL auto_increment,
-	`sid` varchar(255) NOT NULL DEFAULT '',
+	`sid` varbinary(255) NOT NULL DEFAULT '',
 	`data` text,
 	`expire` int(10) unsigned NOT NULL DEFAULT 0,
 	 PRIMARY KEY(`id`),

--- a/include/dbstructure.php
+++ b/include/dbstructure.php
@@ -464,13 +464,13 @@ function db_definition($charset) {
 			);
 	$database["cache"] = array(
 			"fields" => array(
-					"k" => array("type" => "varchar(255)", "not null" => "1", "primary" => "1"),
+					"k" => array("type" => "varbinary(255)", "not null" => "1", "primary" => "1"),
 					"v" => array("type" => "text"),
 					"expire_mode" => array("type" => "int(11)", "not null" => "1", "default" => "0"),
 					"updated" => array("type" => "datetime", "not null" => "1", "default" => "0000-00-00 00:00:00"),
 					),
 			"indexes" => array(
-					"PRIMARY" => array("k".db_index_suffix($charset)),
+					"PRIMARY" => array("k"),
 					"updated" => array("updated"),
 					"expire_mode_updated" => array("expire_mode", "updated"),
 					)
@@ -504,13 +504,13 @@ function db_definition($charset) {
 	$database["config"] = array(
 			"fields" => array(
 					"id" => array("type" => "int(10) unsigned", "not null" => "1", "extra" => "auto_increment", "primary" => "1"),
-					"cat" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
-					"k" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
+					"cat" => array("type" => "varbinary(255)", "not null" => "1", "default" => ""),
+					"k" => array("type" => "varbinary(255)", "not null" => "1", "default" => ""),
 					"v" => array("type" => "text"),
 					),
 			"indexes" => array(
 					"PRIMARY" => array("id"),
-					"cat_k" => array("UNIQUE", "cat(30)","k(30)"),
+					"cat_k" => array("UNIQUE", "cat", "k"),
 					)
 			);
 	$database["contact"] = array(
@@ -610,7 +610,7 @@ function db_definition($charset) {
 	$database["deliverq"] = array(
 			"fields" => array(
 					"id" => array("type" => "int(10) unsigned", "not null" => "1", "extra" => "auto_increment", "primary" => "1"),
-					"cmd" => array("type" => "varchar(32)", "not null" => "1", "default" => ""),
+					"cmd" => array("type" => "varbinary(32)", "not null" => "1", "default" => ""),
 					"item" => array("type" => "int(11)", "not null" => "1", "default" => "0"),
 					"contact" => array("type" => "int(11)", "not null" => "1", "default" => "0"),
 					),
@@ -1092,25 +1092,25 @@ function db_definition($charset) {
 			);
 	$database["oembed"] = array(
 			"fields" => array(
-					"url" => array("type" => "varchar(255)", "not null" => "1", "primary" => "1"),
+					"url" => array("type" => "varbinary(255)", "not null" => "1", "primary" => "1"),
 					"content" => array("type" => "text"),
 					"created" => array("type" => "datetime", "not null" => "1", "default" => "0000-00-00 00:00:00"),
 					),
 			"indexes" => array(
-					"PRIMARY" => array("url".db_index_suffix($charset)),
+					"PRIMARY" => array("url"),
 					"created" => array("created"),
 					)
 			);
 	$database["parsed_url"] = array(
 			"fields" => array(
-					"url" => array("type" => "varchar(255)", "not null" => "1", "primary" => "1"),
+					"url" => array("type" => "varbinary(255)", "not null" => "1", "primary" => "1"),
 					"guessing" => array("type" => "tinyint(1)", "not null" => "1", "default" => "0", "primary" => "1"),
 					"oembed" => array("type" => "tinyint(1)", "not null" => "1", "default" => "0", "primary" => "1"),
 					"content" => array("type" => "text"),
 					"created" => array("type" => "datetime", "not null" => "1", "default" => "0000-00-00 00:00:00"),
 					),
 			"indexes" => array(
-					"PRIMARY" => array("url".db_index_suffix($charset), "guessing", "oembed"),
+					"PRIMARY" => array("url", "guessing", "oembed"),
 					"created" => array("created"),
 					)
 			);
@@ -1118,13 +1118,13 @@ function db_definition($charset) {
 			"fields" => array(
 					"id" => array("type" => "int(11)", "not null" => "1", "extra" => "auto_increment", "primary" => "1"),
 					"uid" => array("type" => "int(11)", "not null" => "1", "default" => "0"),
-					"cat" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
-					"k" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
+					"cat" => array("type" => "varbinary(255)", "not null" => "1", "default" => ""),
+					"k" => array("type" => "varbinary(255)", "not null" => "1", "default" => ""),
 					"v" => array("type" => "mediumtext"),
 					),
 			"indexes" => array(
 					"PRIMARY" => array("id"),
-					"uid_cat_k" => array("UNIQUE", "uid","cat(30)","k(30)"),
+					"uid_cat_k" => array("UNIQUE", "uid", "cat", "k"),
 					)
 			);
 	$database["photo"] = array(
@@ -1196,7 +1196,7 @@ function db_definition($charset) {
 	$database["process"] = array(
 			"fields" => array(
 					"pid" => array("type" => "int(10) unsigned", "not null" => "1", "primary" => "1"),
-					"command" => array("type" => "varchar(32)", "not null" => "1", "default" => ""),
+					"command" => array("type" => "varbinary(32)", "not null" => "1", "default" => ""),
 					"created" => array("type" => "datetime", "not null" => "1", "default" => "0000-00-00 00:00:00"),
 					),
 			"indexes" => array(
@@ -1330,7 +1330,7 @@ function db_definition($charset) {
 	$database["session"] = array(
 			"fields" => array(
 					"id" => array("type" => "bigint(20) unsigned", "not null" => "1", "extra" => "auto_increment", "primary" => "1"),
-					"sid" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
+					"sid" => array("type" => "varbinary(255)", "not null" => "1", "default" => ""),
 					"data" => array("type" => "text"),
 					"expire" => array("type" => "int(10) unsigned", "not null" => "1", "default" => "0"),
 					),

--- a/update.php
+++ b/update.php
@@ -1,6 +1,6 @@
 <?php
 
-define('UPDATE_VERSION' , 1209);
+define('UPDATE_VERSION' , 1210);
 
 /**
  *


### PR DESCRIPTION
MySQL only supports a index key length of 1000 bytes. When using utf8mb4 the maximum length is reduced by factor 4 (so the maximum length is shorter than 200 characters). This can be avoided by using "varbinary" instead of "varchar".

We should only use "varbinary" at places where we are sure that only 1 byte characters are used.