### PR TITLE
Fix test for static calls with PHP 7

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -809,7 +809,7 @@ class App {
 	function get_baseurl($ssl = false) {
 
 		// Is the function called statically?
-		if (!is_object($this)) {
+		if (!(isset($this) && get_class($this) == __CLASS__)) {
 			return self::$a->get_baseurl($ssl);
 		}
 
@@ -1053,7 +1053,7 @@ class App {
 	function remove_baseurl($orig_url){
 
 		// Is the function called statically?
-		if (!is_object($this)) {
+		if (!(isset($this) && get_class($this) == __CLASS__)) {
 			return(self::$a->remove_baseurl($orig_url));
 		}
 


### PR DESCRIPTION
`is_object($this)` throws `PHP Fatal error:  Uncaught Error: Using $this when not in object context in /var/www/...` with PHP 7.1.

This is working fine for me. Since (in my opinion) this is a bug, I will also open a pull request against master.