### PR TITLE
Normalize App parameter declaration (view folder)

### DIFF
--- a/view/theme/duepuntozero/config.php
+++ b/view/theme/duepuntozero/config.php
@@ -3,7 +3,7 @@
  * Theme settings
  */
 
-function theme_content(App &$a){
+function theme_content(App $a) {
 	if (!local_user()) {
 		return;
 	}
@@ -14,7 +14,7 @@ function theme_content(App &$a){
 	return clean_form($a, $colorset, $user);
 }
 
-function theme_post(App &$a){
+function theme_post(App $a) {
 	if (! local_user()) {
 		return;
 	}
@@ -24,23 +24,23 @@ function theme_post(App &$a){
 	}
 }
 
-function theme_admin(App &$a){
+function theme_admin(App $a) {
 	$colorset = get_config( 'duepuntozero', 'colorset');
 	$user = false;
 
 	return clean_form($a, $colorset, $user);
 }
 
-function theme_admin_post(App &$a){
+function theme_admin_post(App $a) {
 	if (isset($_POST['duepuntozero-settings-submit'])){
 		set_config('duepuntozero', 'colorset', $_POST['duepuntozero_colorset']);
 	}
 }
 
 /// @TODO $a is no longer used
-function clean_form(&$a, &$colorset, $user){
+function clean_form(App $a, &$colorset, $user) {
 	$colorset = array(
-		'default'     =>t('default'), 
+		'default'     =>t('default'),
 		'greenzero'   =>t('greenzero'),
 		'purplezero'  =>t('purplezero'),
 		'easterbunny' =>t('easterbunny'),

--- a/view/theme/duepuntozero/theme.php
+++ b/view/theme/duepuntozero/theme.php
@@ -1,6 +1,6 @@
 <?php
 
-function duepuntozero_init(App &$a) {
+function duepuntozero_init(App $a) {
 
 set_template_engine($a, 'smarty3');
 
@@ -24,7 +24,7 @@ set_template_engine($a, 'smarty3');
 $a->page['htmlhead'] .= <<< EOT
 <script>
 function insertFormatting(comment,BBcode,id) {
-	
+
 		var tmpStr = $("#comment-edit-text-" + id).val();
 		if(tmpStr == comment) {
 			tmpStr = "";
@@ -40,7 +40,7 @@ function insertFormatting(comment,BBcode,id) {
 		selected = document.selection.createRange();
 		if (BBcode == "url"){
 			selected.text = "["+BBcode+"]" + "http://" +  selected.text + "[/"+BBcode+"]";
-			} else			
+			} else
 		selected.text = "["+BBcode+"]" + selected.text + "[/"+BBcode+"]";
 	} else if (textarea.selectionStart || textarea.selectionStart == "0") {
 		var start = textarea.selectionStart;

--- a/view/theme/frio/config.php
+++ b/view/theme/frio/config.php
@@ -1,7 +1,7 @@
 <?php
 require_once('view/theme/frio/php/Image.php');
 
-function theme_content(App &$a) {
+function theme_content(App $a) {
 	if (!local_user()) {
 		return;
 	}
@@ -16,10 +16,10 @@ function theme_content(App &$a) {
 	$arr["background_image"] = get_pconfig(local_user(),'frio', 'background_image' );
 	$arr["bg_image_option"] = get_pconfig(local_user(),'frio', 'bg_image_option' );
 
-	return frio_form($a, $arr);
+	return frio_form($arr);
 }
 
-function theme_post(App &$a) {
+function theme_post(App $a) {
 	if (!local_user()) {
 		return;
 	}
@@ -36,9 +36,9 @@ function theme_post(App &$a) {
 	}
 }
 
-function frio_form(&$a, $arr) {
+function frio_form($arr) {
 	require_once("view/theme/frio/php/schema.php");
-	
+
 	$scheme_info = get_schema_info($arr["schema"]);
 	$disable = $scheme_info["overwrites"];
 	if (!is_array($disable)) $disable = array();

--- a/view/theme/frio/php/frio_boot.php
+++ b/view/theme/frio/php/frio_boot.php
@@ -2,18 +2,18 @@
 
 /**
  * @file view/theme/frio/php/frio_boot.php
- * 
+ *
  * @brief This file contains functions for page contstruction
- * 
+ *
  */
 
 
 /**
  * @brief Load page template in dependence of the template mode
- * 
+ *
  * @todo Check if this is really needed.
  */
-function load_page(App &$a) {
+function load_page(App $a) {
 	if(isset($_GET["mode"]) AND ($_GET["mode"] == "minimal")) {
 		require "view/theme/frio/minimal.php";
 	} elseif((isset($_GET["mode"]) AND ($_GET["mode"] == "none"))) {
@@ -27,16 +27,16 @@ function load_page(App &$a) {
 			require_once(str_replace('theme/' . current_theme() . '/', '', $template));
 	}
 
-	
+
 }
 
 
 /**
  * @brief Check if page is a modal page
- * 
+ *
  * This function checks if $_REQUEST['pagename'] is
  * a defined in a $modalpages
- * 
+ *
  * @return bool
  */
 function is_modal() {
@@ -48,16 +48,16 @@ function is_modal() {
 			$is_modal = true;
 		}
 	}
-	
+
 	return $is_modal;
 }
 
 /**
  * @brief Array with modalpages
- * 
+ *
  * The array contains the page names of the pages
  * which should displayed as modals
- * 
+ *
  * @return array Pagenames as path
  */
 function get_modalpage_list() {
@@ -74,10 +74,10 @@ function get_modalpage_list() {
 
 /**
  * @brief Array with standard pages
- * 
+ *
  * The array contains the page names of the pages
  * which should displayed as standard-page
- * 
+ *
  * @return array Pagenames as path
  */
 function get_standard_page_list() {
@@ -91,10 +91,10 @@ function get_standard_page_list() {
 
 /**
  * @brief Check if page is standard page
- * 
+ *
  * This function checks if $_REQUEST['pagename'] is
  * a defined $standardpages
- * 
+ *
  * @param string $pagetitle Title of the actual page
  * @return bool
  */
@@ -107,12 +107,12 @@ function is_standard_page($pagetitle) {
 			$is_standard_page = true;
 		}
 	}
-	
+
 	return $is_standard_page;
 }
 /**
  * @brief Get the typ of the page
- * 
+ *
  * @param type $pagetitle
  * @return string
  */

--- a/view/theme/frio/theme.php
+++ b/view/theme/frio/theme.php
@@ -4,14 +4,14 @@
  * Description: Bootstrap V3 theme. The theme is currently under construction, so it is far from finished. For further information have a look at the <a href="https://github.com/friendica/friendica/tree/develop/view/theme/frio/README.md">ReadMe</a>.
  * Version: V.0.7
  * Author: Rabuzarus <https://friendica.kommune4.de/profile/rabuzarus>
- * 
+ *
  */
 
 $frio = "view/theme/frio";
 
 global $frio;
 
-function frio_init(App &$a) {
+function frio_init(App $a) {
 
 	// disable the events module link in the profile tab
 	$a->theme_events_in_profile = false;
@@ -63,18 +63,18 @@ function frio_uninstall() {
 	logger("uninstalled theme frio");
 }
 /**
- * @brief Replace friendica photo links
- * 
+ * @brief Replace friendica photo links hook
+ *
  *  This function does replace the links to photos
  *  of other friendica users. Original the photos are
  *  linked to the photo page. Now they will linked directly
  *  to the photo file. This function is nessesary to use colorbox
  *  in the network stream
- * 
- * @param App $a
+ *
+ * @param App $a Unused but required by hook definition
  * @param array $body_info The item and its html output
  */
-function frio_item_photo_links(&$a, &$body_info) {
+function frio_item_photo_links(App $a, &$body_info) {
 	require_once('include/Photo.php');
 
 	$phototypes = Photo::supportedTypes();
@@ -104,16 +104,16 @@ function frio_item_photo_links(&$a, &$body_info) {
 }
 
 /**
- * @brief Replace links of the item_photo_menu
- * 
+ * @brief Replace links of the item_photo_menu hook
+ *
  *  This function replaces the original poke and the message links
  *  to call the addToModal javascript function so this pages can
  *  be loaded in a bootstrap modal
- * 
- * @param app $a The app data
+ *
+ * @param App $a Unused but required by the hook definition
  * @param array $arr Contains item data and the original photo_menu
  */
-function frio_item_photo_menu($a, &$arr){
+function frio_item_photo_menu(App $a, &$arr) {
 
 	foreach($arr["menu"] as $k =>$v) {
 		if(strpos($v,'poke/?f=&c=') === 0 || strpos($v,'message/new/') === 0) {
@@ -126,17 +126,17 @@ function frio_item_photo_menu($a, &$arr){
 
 /**
  * @brief Replace links of the contact_photo_menu
- * 
+ *
  *  This function replaces the original poke and the message links
  *  to call the addToModal javascript function so this pages can
  *  be loaded in a bootstrap modal
  *  Additionally the profile, status and photo page links  will be changed
  *  to don't open in a new tab if the contact is a friendica contact.
- * 
+ *
  * @param app $a The app data
  * @param array $args Contains contact data and the original photo_menu
  */
-function frio_contact_photo_menu($a, &$args){
+function frio_contact_photo_menu(App $a, &$args){
 
 	$pokelink = "";
 	$pmlink = "";
@@ -152,7 +152,7 @@ function frio_contact_photo_menu($a, &$args){
 	// friendicas "magic-link" which indicates a friendica user on froreign
 	// friendica servers as remote user or visitor
 	//
-	// The value for opening in a new tab is e.g. when 
+	// The value for opening in a new tab is e.g. when
 	// $args["menu"]["status"][2] is true. If the value of the [2] key is true
 	// and if it's a friendica contact we set it to false
 	foreach($args["menu"] as $k =>$v) {
@@ -176,15 +176,15 @@ function frio_contact_photo_menu($a, &$args){
 
 /**
  * @brief Construct remote nav menu
- * 
+ *
  *  It creates a remote baseurl form $_SESSION for remote users and friendica
- *  visitors. This url will be added to some of the nav links. With this behaviour 
+ *  visitors. This url will be added to some of the nav links. With this behaviour
  *  the user will come back to her/his own pages on his/her friendica server.
  *  Not all possible links are available (notifications, administrator, manage,
  *  notes aren't available because we have no way the check remote permissions)..
  *  Some links will point to the local pages because the user would expect
  *  local page (these pages are: search, community, help, apps, directory).
- * 
+ *
  * @param app $a The App class
  * @param array $nav The original nav menu
  */
@@ -196,11 +196,11 @@ function frio_remote_nav($a,&$nav) {
 
 	// split up the url in it's parts (protocol,domain/directory, /profile/, nickname
 	// I'm not familiar with regex, so someone might find a better solutionen
-	// 
+	//
 	// E.g $homelink = 'https://friendica.domain.com/profile/mickey' should result in an array
 	// with 0 => 'https://friendica.domain.com/profile/mickey' 1 => 'https://',
 	// 2 => 'friendica.domain.com' 3 => '/profile/' 4 => 'mickey'
-	// 
+	//
 	//$server_url = preg_match('/^(https?:\/\/.*?)\/profile\//2', $homelink);
 	preg_match('/^(https?:\/\/)?(.*?)(\/profile\/)(.*)/', $homelink, $url_parts);
 
@@ -220,7 +220,7 @@ function frio_remote_nav($a,&$nav) {
 		$server_url = '';
 		// user info
 		$r = q("SELECT `micro` FROM `contact` WHERE `uid` = %d AND `self` = 1", intval($a->user['uid']));
-		
+
 		$r[0]['photo'] = (dbm::is_result($r) ? $a->remove_baseurl($r[0]['micro']) : "images/person-48.jpg");
 		$r[0]['name'] = $a->user['username'];
 
@@ -263,14 +263,14 @@ function frio_remote_nav($a,&$nav) {
 }
 /**
  * @brief: Search for contacts
- * 
+ *
  * This function search for a users contacts. The code is copied from contact search
  * in /mod/contacts.php. With this function the contacts will permitted to acl_lookup()
- * and can grabbed as json. For this we use the type="r". This is usful to to let js 
+ * and can grabbed as json. For this we use the type="r". This is usful to to let js
  * grab the contact data.
  * We use this to give the data to textcomplete and have a filter function at the
  * contact page.
- * 
+ *
  * @param App $a The app data @TODO Unused
  * @param array $results The array with the originals from acl_lookup()
  */

--- a/view/theme/frost-mobile/theme.php
+++ b/view/theme/frost-mobile/theme.php
@@ -9,7 +9,7 @@
  * Maintainer: Zach P <techcity@f.shmuz.in>
  */
 
-function frost_mobile_init(App &$a) {
+function frost_mobile_init(App $a) {
 	$a->sourcename = 'Friendica mobile web';
 	$a->videowidth = 250;
 	$a->videoheight = 200;
@@ -18,7 +18,7 @@ function frost_mobile_init(App &$a) {
 	set_template_engine($a, 'smarty3');
 }
 
-function frost_mobile_content_loaded(App &$a) {
+function frost_mobile_content_loaded(App $a) {
 
 	// I could do this in style.php, but by having the CSS in a file the browser will cache it,
 	// making pages load faster

--- a/view/theme/frost/theme.php
+++ b/view/theme/frost/theme.php
@@ -9,14 +9,14 @@
  * Maintainer: Zach P <techcity@f.shmuz.in>
  */
 
-function frost_init(App &$a) {
+function frost_init(App $a) {
 	$a->videowidth = 400;
 	$a->videoheight = 330;
 	$a->theme_thread_allow = false;
 	set_template_engine($a, 'smarty3');
 }
 
-function frost_content_loaded(App &$a) {
+function frost_content_loaded(App $a) {
 
 	// I could do this in style.php, but by having the CSS in a file the browser will cache it,
 	// making pages load faster
@@ -43,7 +43,7 @@ function frost_uninstall() {
 	logger("uninstalled theme frost");
 }
 
-function frost_item_photo_links(&$a, &$body_info) {
+function frost_item_photo_links(App $a, &$body_info) {
 	require_once('include/Photo.php');
 	$phototypes = Photo::supportedTypes();
 
@@ -68,7 +68,7 @@ function frost_item_photo_links(&$a, &$body_info) {
 			$body_info['html'] = str_replace($link, $newlink, $body_info['html']);
 
 		}
-		
+
 		$p = bb_find_open_close($body_info['html'], "<a", ">", $occurence);
 	}
 }

--- a/view/theme/quattro/config.php
+++ b/view/theme/quattro/config.php
@@ -3,7 +3,7 @@
  * Theme settings
  */
 
-function theme_content(App &$a){
+function theme_content(App $a) {
 	if (!local_user()) {
 		return;
 	}
@@ -16,7 +16,7 @@ function theme_content(App &$a){
 	return quattro_form($a,$align, $color, $tfs, $pfs);
 }
 
-function theme_post(App &$a){
+function theme_post(App $a) {
 	if (! local_user()) {
 		return;
 	}
@@ -29,7 +29,7 @@ function theme_post(App &$a){
 	}
 }
 
-function theme_admin(App &$a){
+function theme_admin(App $a) {
 	$align = get_config('quattro', 'align' );
 	$color = get_config('quattro', 'color' );
 	$tfs = get_config("quattro","tfs");
@@ -38,7 +38,7 @@ function theme_admin(App &$a){
 	return quattro_form($a,$align, $color, $tfs, $pfs);
 }
 
-function theme_admin_post(App &$a){
+function theme_admin_post(App $a) {
 	if (isset($_POST['quattro-settings-submit'])){
 		set_config('quattro', 'align', $_POST['quattro_align']);
 		set_config('quattro', 'color', $_POST['quattro_color']);
@@ -48,7 +48,7 @@ function theme_admin_post(App &$a){
 }
 
 /// @TODO $a is no longer used here
-function quattro_form(App &$a, $align, $color, $tfs, $pfs){
+function quattro_form(App $a, $align, $color, $tfs, $pfs) {
 	$colors = array(
 		"dark"  => "Quattro",
 		"lilac" => "Lilac",

--- a/view/theme/quattro/theme.php
+++ b/view/theme/quattro/theme.php
@@ -7,7 +7,7 @@
  * Maintainer: Tobias <https://diekershoff.homeunix.net/friendica/profile/tobias>
  */
 
-function quattro_init(App &$a) {
+function quattro_init(App $a) {
 	$a->page['htmlhead'] .= '<script src="'.App::get_baseurl().'/view/theme/quattro/tinycon.min.js"></script>';
 	$a->page['htmlhead'] .= '<script src="'.App::get_baseurl().'/view/theme/quattro/js/quattro.js"></script>';;
 }

--- a/view/theme/smoothly/theme.php
+++ b/view/theme/smoothly/theme.php
@@ -10,7 +10,7 @@
  * Screenshot: <a href="screenshot.png">Screenshot</a>
  */
 
-function smoothly_init(App &$a) {
+function smoothly_init(App $a) {
 	set_template_engine($a, 'smarty3');
 
 	$cssFile = null;
@@ -20,7 +20,7 @@ $a->page['htmlhead'] .= <<< EOT
 
 <script>
 function insertFormatting(comment,BBcode,id) {
-	
+
 		var tmpStr = $("#comment-edit-text-" + id).val();
 		if(tmpStr == comment) {
 			tmpStr = "";
@@ -36,7 +36,7 @@ function insertFormatting(comment,BBcode,id) {
 		selected = document.selection.createRange();
 		if (BBcode == "url"){
 			selected.text = "["+BBcode+"]" + "http://" +  selected.text + "[/"+BBcode+"]";
-			} else			
+			} else
 		selected.text = "["+BBcode+"]" + selected.text + "[/"+BBcode+"]";
 	} else if (textarea.selectionStart || textarea.selectionStart == "0") {
 		var start = textarea.selectionStart;

--- a/view/theme/vier/config.php
+++ b/view/theme/vier/config.php
@@ -5,7 +5,7 @@
 
 
 
-function theme_content(App &$a){
+function theme_content(App $a) {
 	if (!local_user()) {
 		return;
 	}
@@ -35,7 +35,7 @@ function theme_content(App &$a){
 			$show_services, $show_friends, $show_lastusers);
 }
 
-function theme_post(App &$a){
+function theme_post(App $a) {
 	if (! local_user()) {
 		return;
 	}
@@ -52,7 +52,7 @@ function theme_post(App &$a){
 }
 
 
-function theme_admin(App &$a){
+function theme_admin(App $a) {
 
 	if (!function_exists('get_vier_config'))
 		return;
@@ -81,7 +81,7 @@ function theme_admin(App &$a){
 	return $o;
 }
 
-function theme_admin_post(App &$a){
+function theme_admin_post(App $a) {
 	if (isset($_POST['vier-settings-submit'])){
 		set_config('vier', 'style', $_POST['vier_style']);
 		set_config('vier', 'show_pages', $_POST['vier_show_pages']);
@@ -95,7 +95,7 @@ function theme_admin_post(App &$a){
 }
 
 /// @TODO $a is no longer used
-function vier_form(&$a, $style, $show_pages, $show_profiles, $show_helpers, $show_services, $show_friends, $show_lastusers){
+function vier_form(App $a, $style, $show_pages, $show_profiles, $show_helpers, $show_services, $show_friends, $show_lastusers) {
 	$styles = array(
 		"plus"=>"Plus",
 		"breathe"=>"Breathe",

--- a/view/theme/vier/theme.php
+++ b/view/theme/vier/theme.php
@@ -13,7 +13,7 @@ require_once("include/plugin.php");
 require_once("include/socgraph.php");
 require_once("mod/proxy.php");
 
-function vier_init(App &$a) {
+function vier_init(App $a) {
 
 	$a->theme_events_in_profile = false;
 


### PR DESCRIPTION
Fixes #3039

This is a simple cosmetics change, removing redundant `&` operators, adding `App` type hints, a few spaces in function declaration lines, but nothing more.

I won’t accept any change suggestions (like standards or docs) not directly related with the relevant function declaration lines. The diff was so big that I had to split the changes between 4 other PRs:
- #3076 (doc-include folders, boot)
- #3077 (mod folder, 1 out of 3)
- #3078 (mod folder, 2 out of 3)
- #3079 (mod folder, 3 out of 3)