### PR TITLE
Normalize App parameter declaration (doc-include folders, boot)

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -1540,7 +1540,7 @@ function check_db() {
  * Sets the base url for use in cmdline programs which don't have
  * $_SERVER variables
  */
-function check_url(App &$a) {
+function check_url(App $a) {
 
 	$url = get_config('system','url');
 
@@ -1562,7 +1562,7 @@ function check_url(App &$a) {
 /**
  * @brief Automatic database updates
  */
-function update_db(App &$a) {
+function update_db(App $a) {
 	$build = get_config('system','build');
 	if(! x($build))
 		$build = set_config('system','build',DB_UPDATE_VERSION);
@@ -1678,7 +1678,7 @@ function run_update_function($x) {
  * @param App $a
  *
 	 */
-function check_plugins(App &$a) {
+function check_plugins(App $a) {
 
 	$r = q("SELECT * FROM `addon` WHERE `installed` = 1");
 	if (dbm::is_result($r))
@@ -2414,7 +2414,7 @@ function get_temppath() {
 }
 
 /// @deprecated
-function set_template_engine(App &$a, $engine = 'internal') {
+function set_template_engine(App $a, $engine = 'internal') {
 /// @note This function is no longer necessary, but keep it as a wrapper to the class method
 /// to avoid breaking themes again unnecessarily
 

--- a/doc/Plugins.md
+++ b/doc/Plugins.md
@@ -40,7 +40,7 @@ Arguments
 ---
 Your hook callback functions will be called with at least one and possibly two arguments
 
-    function myhook_function(&$a, &$b) {
+    function myhook_function(App $a, &$b) {
 
     }
 
@@ -77,9 +77,9 @@ This will include:
     $a->argc = 3
     $a->argv = array(0 => 'plugin', 1 => 'arg1', 2 => 'arg2');
 
-Your module functions will often contain the function plugin_name_content(App &$a), which defines and returns the page body content.
-They may also contain plugin_name_post(App &$a) which is called before the _content function and typically handles the results of POST forms.
-You may also have plugin_name_init(App &$a) which is called very early on and often does module initialisation.
+Your module functions will often contain the function plugin_name_content(App $a), which defines and returns the page body content.
+They may also contain plugin_name_post(App $a) which is called before the _content function and typically handles the results of POST forms.
+You may also have plugin_name_init(App $a) which is called very early on and often does module initialisation.
 
 Templates
 ---
@@ -285,7 +285,7 @@ $b is an array with:
 is called after the other queries have passed.
 The registered function can add, change or remove the acl_lookup() variables.
 
-    'results' => array of the acl_lookup() vars 
+    'results' => array of the acl_lookup() vars
 
 
 Complete list of hook callbacks

--- a/doc/autoloader.md
+++ b/doc/autoloader.md
@@ -32,7 +32,7 @@ Let's say you have a php file in "include/" that define a very useful class:
     file: include/ItemsManager.php
     <?php
     namespace \Friendica;
-    
+
     class ItemsManager {
        public function getAll() { ... }
        public function getByID($id) { ... }
@@ -67,11 +67,11 @@ The code will be something like:
 ```
     file: mod/network.php
     <?php
-    
-    function network_content(App &$a) {
+
+    function network_content(App $a) {
        $itemsmanager = new \Friendica\ItemsManager();
        $items = $itemsmanager->getAll();
-    
+
        // pass $items to template
        // return result
     }
@@ -86,7 +86,7 @@ Going further: now we have a bunch of "*Manager" classes that cause some code du
     file: include/BaseManager.php
     <?php
     namespace \Friendica;
-    
+
     class BaseManager {
       public function thatFunctionEveryManagerUses() { ... }
     }
@@ -98,7 +98,7 @@ and then let's change the ItemsManager class to use this code
     file: include/ItemsManager.php
     <?php
     namespace \Friendica;
-    
+
     class ItemsManager extends BaseManager {
        public function getAll() { ... }
        public function getByID($id) { ... }
@@ -110,9 +110,9 @@ It works with the "BaseManager" example here, it works when we need to call stat
 
 ```
     file: include/dfrn.php
-    <?php    
+    <?php
     namespace \Friendica;
-    
+
     class dfrn {
       public static function  mail($item, $owner) { ... }
     }
@@ -121,7 +121,7 @@ It works with the "BaseManager" example here, it works when we need to call stat
 ```
     file: mod/mail.php
     <?php
-    
+
     mail_post($a){
      ...
      \Friendica\dfrn::mail($item, $owner);
@@ -134,15 +134,15 @@ If your code is in same namespace as the class you need, you don't need to prepe
 ```
     file: include/delivery.php
     <?php
-    
+
     namespace \Friendica;
-    
-    // this is the same content of current include/delivery.php, 
+
+    // this is the same content of current include/delivery.php,
     // but has been declared to be in "Friendica" namespace
-    
+
     [...]
     switch($contact['network']) {
-    
+
         case NETWORK_DFRN:
             if ($mail) {
                 $item['body'] = ...
@@ -161,10 +161,10 @@ But if you want to use classes from another library, you need to use the full na
 ```
     <?php
     namespace \Frienidca;
-    
+
     class Diaspora {
       public function md2bbcode() {
-        $html = \Michelf\MarkdownExtra::defaultTransform($text); 
+        $html = \Michelf\MarkdownExtra::defaultTransform($text);
       }
     }
 ```
@@ -174,12 +174,12 @@ if you use that class in many places of the code and you don't want to write the
 ```
     <?php
     namespace \Frienidca;
-    
+
     use \Michelf\MarkdownExtra;
-    
+
     class Diaspora {
       public function md2bbcode() {
-        $html = MarkdownExtra::defaultTransform($text); 
+        $html = MarkdownExtra::defaultTransform($text);
       }
     }
 ```
@@ -190,7 +190,7 @@ You can go more deep if you want to, like:
 ```
     <?php
     namespace \Friendica\Network;
-    
+
     class DFRN {
     }
 ```
@@ -200,7 +200,7 @@ or
 ```
     <?php
     namespace \Friendica\DBA;
-    
+
     class MySQL {
     }
 ```

--- a/doc/autoloader.md
+++ b/doc/autoloader.md
@@ -160,7 +160,7 @@ But if you want to use classes from another library, you need to use the full na
 
 ```
     <?php
-    namespace \Frienidca;
+    namespace \Friendica;
 
     class Diaspora {
       public function md2bbcode() {
@@ -173,7 +173,7 @@ if you use that class in many places of the code and you don't want to write the
 
 ```
     <?php
-    namespace \Frienidca;
+    namespace \Friendica;
 
     use \Michelf\MarkdownExtra;
 

--- a/doc/de/Plugins.md
+++ b/doc/de/Plugins.md
@@ -40,7 +40,7 @@ Argumente
 
 Deine Hook-Callback-Funktion wird mit mindestens einem und bis zu zwei Argumenten aufgerufen
 
-    function myhook_function(&$a, &$b) {
+    function myhook_function(App $a, &$b) {
 
     }
 
@@ -67,9 +67,9 @@ So würde http://example.com/plugin/arg1/arg2 nach einem Modul "plugin" suchen u
     $a->argc = 3
     $a->argv = array(0 => 'plugin', 1 => 'arg1', 2 => 'arg2');
 
-Deine Modulfunktionen umfassen oft die Funktion plugin_name_content(App &$a), welche den Seiteninhalt definiert und zurückgibt.
-Sie können auch plugin_name_post(App &$a) umfassen, welches vor der content-Funktion aufgerufen wird und normalerweise die Resultate der POST-Formulare handhabt.
-Du kannst ebenso plugin_name_init(App &$a) nutzen, was oft frühzeitig aufgerufen wird und das Modul initialisert.
+Deine Modulfunktionen umfassen oft die Funktion plugin_name_content(App $a), welche den Seiteninhalt definiert und zurückgibt.
+Sie können auch plugin_name_post(App $a) umfassen, welches vor der content-Funktion aufgerufen wird und normalerweise die Resultate der POST-Formulare handhabt.
+Du kannst ebenso plugin_name_init(App $a) nutzen, was oft frühzeitig aufgerufen wird und das Modul initialisert.
 
 
 Derzeitige Hooks
@@ -311,7 +311,7 @@ mod/photos.php:			call_hooks('photo_post_end',intval($item_id));
 
 mod/photos.php:			call_hooks('photo_upload_form',$ret);
 
-mod/friendica.php:		call_hooks('about_hook', $o); 	
+mod/friendica.php:		call_hooks('about_hook', $o);
 
 mod/editpost.php:		call_hooks('jot_tool', $jotplugins);
 

--- a/doc/themes.md
+++ b/doc/themes.md
@@ -122,7 +122,7 @@ the 1st part of the line is the name of the CSS file (without the .css) the 2nd 
 Calling the t() function with the common name makes the string translateable.
 The selected 1st part will be saved in the database by the theme_post function.
 
-    function theme_post(App &$a){
+    function theme_post(App $a){
         // non local users shall not pass
         if (! local_user()) {
             return;
@@ -168,7 +168,7 @@ The content of this file should be something like
 
     <?php
     /* meta informations for the theme, see below */
-    function duepuntozero_lr_init(App &$a) {
+    function duepuntozero_lr_init(App $a) {
         $a-> theme_info = array(
             'extends' => 'duepuntozero'.
         );
@@ -251,7 +251,7 @@ Next crucial part of the theme.php file is a definition of an init function.
 The name of the function is <theme-name>_init.
 So in the case of quattro it is
 
-    function quattro_init(App &$a) {
+    function quattro_init(App $a) {
       $a->theme_info = array();
       set_template_engine($a, 'smarty3');
     }

--- a/include/Contact.php
+++ b/include/Contact.php
@@ -612,7 +612,7 @@ function get_contact($url, $uid = 0, $no_update = false) {
  *
  * @return string posts in HTML
  */
-function posts_from_gcontact($a, $gcontact_id) {
+function posts_from_gcontact(App $a, $gcontact_id) {
 
 	require_once('include/conversation.php');
 
@@ -664,7 +664,7 @@ function posts_from_gcontact($a, $gcontact_id) {
  *
  * @return string posts in HTML
  */
-function posts_from_contact_url($a, $contact_url) {
+function posts_from_contact_url(App $a, $contact_url) {
 
 	require_once('include/conversation.php');
 

--- a/include/Photo.php
+++ b/include/Photo.php
@@ -283,7 +283,7 @@ class Photo {
 			do {
 
 				// FIXME - implement horizantal bias for scaling as in followin GD functions
-				// to allow very tall images to be constrained only horizontally. 
+				// to allow very tall images to be constrained only horizontally.
 
 				$this->image->scaleImage($dest_width, $dest_height);
 			} while ($this->image->nextImage());
@@ -943,7 +943,7 @@ function scale_image($width, $height, $max) {
 	return array("width" => $dest_width, "height" => $dest_height);
 }
 
-function store_photo($a, $uid, $imagedata = "", $url = "") {
+function store_photo(App $a, $uid, $imagedata = "", $url = "") {
 	$r = q("SELECT `user`.`nickname`, `user`.`page-flags`, `contact`.`id` FROM `user` INNER JOIN `contact` on `user`.`uid` = `contact`.`uid`
 		WHERE `user`.`uid` = %d AND `user`.`blocked` = 0 AND `contact`.`self` = 1 LIMIT 1",
 		intval($uid));

--- a/include/acl_selectors.php
+++ b/include/acl_selectors.php
@@ -372,7 +372,7 @@ function populate_acl($user = null, $show_jotnets = false) {
 
 }
 
-function construct_acl_data(&$a, $user) {
+function construct_acl_data(App $a, $user) {
 
 	// Get group and contact information for html ACL selector
 	$acl_data = acl_lookup($a, 'html');
@@ -404,7 +404,7 @@ function construct_acl_data(&$a, $user) {
 
 }
 
-function acl_lookup(&$a, $out_type = 'json') {
+function acl_lookup(App $a, $out_type = 'json') {
 
 	if (!local_user()) {
 		return '';
@@ -687,11 +687,11 @@ function acl_lookup(&$a, $out_type = 'json') {
 }
 /**
  * @brief Searching for global contacts for autocompletion
- * 
+ *
  * @param App $a
  * @return array with the search results
  */
-function navbar_complete(App &$a) {
+function navbar_complete(App $a) {
 
 //	logger('navbar_complete');
 

--- a/include/api.php
+++ b/include/api.php
@@ -133,7 +133,7 @@
 	 * @hook 'logged_in'
 	 * 		array $user	logged user record
 	 */
-	function api_login(App &$a){
+	function api_login(App $a){
 		// login with oauth
 		try{
 			$oauth = new FKOAuth1();
@@ -251,7 +251,7 @@
 	 * @param App $a
 	 * @return string API call result
 	 */
-	function api_call(App &$a){
+	function api_call(App $a){
 		global $API, $called_api;
 
 		$type="json";
@@ -404,7 +404,7 @@
 	 * @param array $user_info
 	 * @return array
 	 */
-	function api_rss_extra(&$a, $arr, $user_info){
+	function api_rss_extra(App $a, $arr, $user_info){
 		if (is_null($user_info)) $user_info = api_get_user($a);
 		$arr['$user'] = $user_info;
 		$arr['$rss'] = array(
@@ -444,7 +444,7 @@
 	 * @param int|string $contact_id Contact ID or URL
 	 * @param string $type Return type (for errors)
 	 */
-	function api_get_user(&$a, $contact_id = Null, $type = "json"){
+	function api_get_user(App $a, $contact_id = Null, $type = "json"){
 		global $called_api;
 		$user = null;
 		$extra_query = "";
@@ -712,7 +712,7 @@
 	 * @param array $item : item from db
 	 * @return array(array:author, array:owner)
 	 */
-	function api_item_get_user(&$a, $item) {
+	function api_item_get_user(App $a, $item) {
 
 		$status_user = api_get_user($a, $item["author-link"]);
 
@@ -2451,7 +2451,7 @@
 							'homepage' => $profile['homepage'],
 							'users' => null);
 			return $profile;
-		} 
+		}
 	}
 
 	/**
@@ -2874,14 +2874,14 @@
 		// BadRequestException if no id specified (for clients using Twitter API)
 		if ($id == 0) throw new BadRequestException('Message id not specified');
 
-		// add parent-uri to sql command if specified by calling app		
+		// add parent-uri to sql command if specified by calling app
 		$sql_extra = ($parenturi != "" ? " AND `parent-uri` = '" . dbesc($parenturi) . "'" : "");
 
 		// get data of the specified message id
 		$r = q("SELECT `id` FROM `mail` WHERE `uid` = %d AND `id` = %d" . $sql_extra,
-			intval($uid), 
+			intval($uid),
 			intval($id));
-	
+
 		// error message if specified id is not in database
 		if (!dbm::is_result($r)) {
 			if ($verbose == "true") {
@@ -2893,8 +2893,8 @@
 		}
 
 		// delete message
-		$result = q("DELETE FROM `mail` WHERE `uid` = %d AND `id` = %d" . $sql_extra, 
-			intval($uid), 
+		$result = q("DELETE FROM `mail` WHERE `uid` = %d AND `id` = %d" . $sql_extra,
+			intval($uid),
 			intval($id));
 
 		if ($verbose == "true") {
@@ -3860,7 +3860,7 @@
 
 		// get data of the specified message id
 		$r = q("SELECT `id` FROM `mail` WHERE `id` = %d AND `uid` = %d",
-			intval($id), 
+			intval($id),
 			intval($uid));
 		// error message if specified id is not in database
 		if (!dbm::is_result($r)) {
@@ -3869,8 +3869,8 @@
 		}
 
 		// update seen indicator
-		$result = q("UPDATE `mail` SET `seen` = 1 WHERE `id` = %d AND `uid` = %d", 
-			intval($id), 
+		$result = q("UPDATE `mail` SET `seen` = 1 WHERE `id` = %d AND `uid` = %d",
+			intval($id),
 			intval($uid));
 
 		if ($result) {
@@ -3921,7 +3921,7 @@
 		// message if nothing was found
 		if (!dbm::is_result($r))
 			$success = array('success' => false, 'search_results' => 'problem with query');
-		else if (count($r) == 0) 
+		else if (count($r) == 0)
 			$success = array('success' => false, 'search_results' => 'nothing found');
 		else {
 			$ret = Array();

--- a/include/conversation.php
+++ b/include/conversation.php
@@ -466,7 +466,7 @@ function item_condition() {
  */
 
 if(!function_exists('conversation')) {
-function conversation(&$a, $items, $mode, $update, $preview = false) {
+function conversation(App $a, $items, $mode, $update, $preview = false) {
 
 	require_once('include/bbcode.php');
 	require_once('include/Contact.php');

--- a/include/cron.php
+++ b/include/cron.php
@@ -343,7 +343,7 @@ function cron_poll_contacts($argc, $argv) {
  *
  * @param App $a
  */
-function cron_clear_cache(App &$a) {
+function cron_clear_cache(App $a) {
 
 	$last = get_config('system','cache_last_cleared');
 
@@ -430,7 +430,7 @@ function cron_clear_cache(App &$a) {
  *
  * @param App $a
  */
-function cron_repair_diaspora(App &$a) {
+function cron_repair_diaspora(App $a) {
 	$r = q("SELECT `id`, `url` FROM `contact`
 		WHERE `network` = '%s' AND (`batch` = '' OR `notify` = '' OR `poll` = '' OR pubkey = '')
 			ORDER BY RAND() LIMIT 50", dbesc(NETWORK_DIASPORA));

--- a/include/event.php
+++ b/include/event.php
@@ -206,7 +206,7 @@ function bbtoevent($s) {
 }
 
 
-function sort_by_date(App &$a) {
+function sort_by_date(App $a) {
 
 	usort($a,'ev_compare');
 	return $a;
@@ -495,7 +495,7 @@ function get_event_strings() {
 
 /**
  * @brief Get an event by its event ID
- * 
+ *
  * @param type $owner_uid The User ID of the owner of the event
  * @param type $event_params An assoziative array with
  *	int 'event_id' => The ID of the event in the event table
@@ -523,15 +523,15 @@ function event_by_id($owner_uid = 0, $event_params, $sql_extra = '') {
 
 /**
  * @brief Get all events in a specific timeframe
- * 
+ *
  * @param int $owner_uid The User ID of the owner of the events
  * @param array $event_params An assoziative array with
- *	int 'ignored' => 
+ *	int 'ignored' =>
  *	string 'start' => Start time of the timeframe
  *	string 'finish' => Finish time of the timeframe
- *	string 'adjust_start' => 
  *	string 'adjust_start' =>
- *	
+ *	string 'adjust_start' =>
+ *
  * @param string $sql_extra Additional sql conditions (e.g. permission request)
  * @return array Query results
  */
@@ -564,7 +564,7 @@ function events_by_date($owner_uid = 0, $event_params, $sql_extra = '') {
 
 /**
  * @brief Convert an array query results in an arry which could be used by the events template
- * 
+ *
  * @param array $arr Event query array
  * @return array Event array for the template
  */
@@ -623,11 +623,11 @@ function process_events ($arr) {
 
 /**
  * @brief Format event to export format (ical/csv)
- * 
+ *
  * @param array $events Query result for events
  * @param string $format The output format (ical/csv)
  * @param string $timezone The timezone of the user (not implemented yet)
- * 
+ *
  * @return string Content according to selected export format
  */
 function event_format_export ($events, $format = 'ical', $timezone) {
@@ -641,7 +641,7 @@ function event_format_export ($events, $format = 'ical', $timezone) {
 			$o = '"Subject", "Start Date", "Start Time", "Description", "End Date", "End Time", "Location"' . PHP_EOL;
 
 			foreach ($events as $event) {
-			/// @todo the time / date entries don't include any information about the 
+			/// @todo the time / date entries don't include any information about the
 			// timezone the event is scheduled in :-/
 				$tmp1 = strtotime($event['start']);
 				$tmp2 = strtotime($event['finish']);
@@ -650,7 +650,7 @@ function event_format_export ($events, $format = 'ical', $timezone) {
 				$o .= '"'.$event['summary'].'", "'.strftime($date_format, $tmp1) .
 					'", "'.strftime($time_format, $tmp1).'", "'.$event['desc'] .
 					'", "'.strftime($date_format, $tmp2) .
-					'", "'.strftime($time_format, $tmp2) . 
+					'", "'.strftime($time_format, $tmp2) .
 					'", "'.$event['location'].'"' . PHP_EOL;
 			}
 			break;
@@ -672,7 +672,7 @@ function event_format_export ($events, $format = 'ical', $timezone) {
 			foreach ($events as $event) {
 				if ($event['adjust'] == 1) {
 					$UTC = 'Z';
-				} else { 
+				} else {
 					$UTC = '';
 				}
 				$o .= 'BEGIN:VEVENT' . PHP_EOL;
@@ -716,16 +716,16 @@ function event_format_export ($events, $format = 'ical', $timezone) {
 
 /**
  * @brief Get all events for a user ID
- * 
+ *
  *    The query for events is done permission sensitive
  *    If the user is the owner of the calendar he/she
  *    will get all of his/her available events.
  *    If the user is only a visitor only the public events will
  *    be available
- * 
+ *
  * @param int $uid The user ID
  * @param int $sql_extra Additional sql conditions for permission
- * 
+ *
  * @return array Query results
  */
 function events_by_uid($uid = 0, $sql_extra = '') {
@@ -736,8 +736,8 @@ function events_by_uid($uid = 0, $sql_extra = '') {
 	if($sql_extra == '')
 		$sql_extra = " AND `allow_cid` = '' AND `allow_gid` = '' ";
 
-	//  does the user who requests happen to be the owner of the events 
-	//  requested? then show all of your events, otherwise only those that 
+	//  does the user who requests happen to be the owner of the events
+	//  requested? then show all of your events, otherwise only those that
 	//  don't have limitations set in allow_cid and allow_gid
 	if (local_user() == $uid) {
 		$r = q("SELECT `start`, `finish`, `adjust`, `summary`, `desc`, `location`, `nofinish`
@@ -756,7 +756,7 @@ function events_by_uid($uid = 0, $sql_extra = '') {
 }
 
 /**
- * 
+ *
  * @param int $uid The user ID
  * @param string $format Output format (ical/csv)
  * @return array With the results
@@ -764,7 +764,7 @@ function events_by_uid($uid = 0, $sql_extra = '') {
  *	string 'format' => The output format
  *	string 'extension' => The file extension of the output format
  *	string 'content' => The formatted output content
- * 
+ *
  * @todo Respect authenticated users with events_by_uid()
  */
 function event_export($uid, $format = 'ical') {
@@ -815,7 +815,7 @@ function event_export($uid, $format = 'ical') {
 
 /**
  * @brief Get the events widget
- * 
+ *
  * @return string Formated html of the evens widget
  */
 function widget_events() {
@@ -835,11 +835,11 @@ function widget_events() {
 
 	// Cal logged in user (test permission at foreign profile page)
 	// If the $owner uid is available we know it is part of one of the profile pages (like /cal)
-	// So we have to test if if it's the own profile page of the logged in user 
+	// So we have to test if if it's the own profile page of the logged in user
 	// or a foreign one. For foreign profile pages we need to check if the feature
 	// for exporting the cal is enabled (otherwise the widget would appear for logged in users
 	// on foreigen profile pages even if the widget is disabled)
-	if(intval($owner_uid) && local_user() !== $owner_uid && ! feature_enabled($owner_uid, "export_calendar")) 
+	if(intval($owner_uid) && local_user() !== $owner_uid && ! feature_enabled($owner_uid, "export_calendar"))
 		return;
 
 	// If it's a kind of profile page (intval($owner_uid)) return if the user not logged in and

--- a/include/identity.php
+++ b/include/identity.php
@@ -31,7 +31,7 @@ require_once("mod/proxy.php");
  * @param int $profile
  * @param array $profiledata
  */
-function profile_load(&$a, $nickname, $profile = 0, $profiledata = array()) {
+function profile_load(App $a, $nickname, $profile = 0, $profiledata = array()) {
 
 	$user = q("SELECT `uid` FROM `user` WHERE `nickname` = '%s' LIMIT 1",
 		dbesc($nickname)
@@ -118,12 +118,12 @@ function profile_load(&$a, $nickname, $profile = 0, $profiledata = array()) {
 
 /**
  * @brief Get all profil data of a local user
- * 
+ *
  * If the viewer is an authenticated remote viewer, the profile displayed is the
  * one that has been configured for his/her viewing in the Contact manager.
  * Passing a non-zero profile ID can also allow a preview of a selected profile
  * by the owner
- * 
+ *
  * @param string $nickname
  * @param int $uid
  * @param int $profile
@@ -177,17 +177,17 @@ function get_profiledata_by_nick($nickname, $uid = 0, $profile = 0) {
 
 /**
  * @brief Formats a profile for display in the sidebar.
- * 
+ *
  * It is very difficult to templatise the HTML completely
  * because of all the conditional logic.
- * 
+ *
  * @param array $profile
  * @param int $block
- * 
+ *
  * @return HTML string stuitable for sidebar inclusion
- * 
+ *
  * @note Returns empty string if passed $profile is wrong type or not populated
- * 
+ *
  * @hooks 'profile_sidebar_enter'
  *      array $profile - profile data
  * @hooks 'profile_sidebar'
@@ -598,7 +598,7 @@ function get_events() {
 	));
 }
 
-function advanced_profile(App &$a) {
+function advanced_profile(App $a) {
 
 	$o = '';
 	$uid = $a->profile['uid'];
@@ -755,7 +755,7 @@ function profile_tabs($a, $is_owner=False, $nickname=Null){
 		array(
 			'label'=>t('Status'),
 			'url' => $url,
-			'sel' => ((!isset($tab)&&$a->argv[0]=='profile')?'active':''),
+			'sel' => ((!isset($tab) && $a->argv[0]=='profile')?'active':''),
 			'title' => t('Status Messages and Posts'),
 			'id' => 'status-tab',
 			'accesskey' => 'm',
@@ -771,7 +771,7 @@ function profile_tabs($a, $is_owner=False, $nickname=Null){
 		array(
 			'label' => t('Photos'),
 			'url'	=> App::get_baseurl() . '/photos/' . $nickname,
-			'sel'	=> ((!isset($tab)&&$a->argv[0]=='photos')?'active':''),
+			'sel'	=> ((!isset($tab) && $a->argv[0]=='photos')?'active':''),
 			'title' => t('Photo Albums'),
 			'id' => 'photo-tab',
 			'accesskey' => 'h',
@@ -779,7 +779,7 @@ function profile_tabs($a, $is_owner=False, $nickname=Null){
 		array(
 			'label' => t('Videos'),
 			'url'	=> App::get_baseurl() . '/videos/' . $nickname,
-			'sel'	=> ((!isset($tab)&&$a->argv[0]=='videos')?'active':''),
+			'sel'	=> ((!isset($tab) && $a->argv[0]=='videos')?'active':''),
 			'title' => t('Videos'),
 			'id' => 'video-tab',
 			'accesskey' => 'v',
@@ -791,7 +791,7 @@ function profile_tabs($a, $is_owner=False, $nickname=Null){
 			$tabs[] = array(
 				'label' => t('Events'),
 				'url'	=> App::get_baseurl() . '/events',
-				'sel' 	=>((!isset($tab)&&$a->argv[0]=='events')?'active':''),
+				'sel' 	=>((!isset($tab) && $a->argv[0]=='events')?'active':''),
 				'title' => t('Events and Calendar'),
 				'id' => 'events-tab',
 				'accesskey' => 'e',
@@ -802,7 +802,7 @@ function profile_tabs($a, $is_owner=False, $nickname=Null){
 		$tabs[] = array(
 				'label' => t('Events'),
 				'url'	=> App::get_baseurl() . '/cal/' . $nickname,
-				'sel' 	=>((!isset($tab)&&$a->argv[0]=='cal')?'active':''),
+				'sel' 	=>((!isset($tab) && $a->argv[0]=='cal')?'active':''),
 				'title' => t('Events and Calendar'),
 				'id' => 'events-tab',
 				'accesskey' => 'e',
@@ -813,7 +813,7 @@ function profile_tabs($a, $is_owner=False, $nickname=Null){
 		$tabs[] = array(
 			'label' => t('Personal Notes'),
 			'url'	=> App::get_baseurl() . '/notes',
-			'sel' 	=>((!isset($tab)&&$a->argv[0]=='notes')?'active':''),
+			'sel' 	=>((!isset($tab) && $a->argv[0]=='notes')?'active':''),
 			'title' => t('Only You Can See This'),
 			'id' => 'notes-tab',
 			'accesskey' => 't',
@@ -824,7 +824,7 @@ function profile_tabs($a, $is_owner=False, $nickname=Null){
 		$tabs[] = array(
 			'label' => t('Contacts'),
 			'url'	=> App::get_baseurl() . '/viewcontacts/' . $nickname,
-			'sel'	=> ((!isset($tab)&&$a->argv[0]=='viewcontacts')?'active':''),
+			'sel'	=> ((!isset($tab) && $a->argv[0]=='viewcontacts')?'active':''),
 			'title' => t('Contacts'),
 			'id' => 'viewcontacts-tab',
 			'accesskey' => 'k',
@@ -845,7 +845,7 @@ function get_my_url() {
 	return false;
 }
 
-function zrl_init(App &$a) {
+function zrl_init(App $a) {
 	$tmp_str = get_my_url();
 	if(validate_url($tmp_str)) {
 
@@ -891,7 +891,7 @@ function zrl($s,$force = false) {
  * settings except their own while on this site.
  *
  * @return int user ID
- * 
+ *
  * @note Returns local_user instead of user ID if "always_my_theme"
  *      is set to true
  */

--- a/include/nav.php
+++ b/include/nav.php
@@ -1,6 +1,6 @@
 <?php
 
-function nav(App &$a) {
+function nav(App $a) {
 
 	/*
 	 *

--- a/include/ostatus.php
+++ b/include/ostatus.php
@@ -2072,7 +2072,7 @@ class ostatus {
 	 *
 	 * @return string XML feed
 	 */
-	public static function feed(&$a, $owner_nick, $last_update) {
+	public static function feed(App $a, $owner_nick, $last_update) {
 
 		$r = q("SELECT `contact`.*, `user`.`nickname`, `user`.`timezone`, `user`.`page-flags`
 				FROM `contact` INNER JOIN `user` ON `user`.`uid` = `contact`.`uid`

--- a/include/plaintext.php
+++ b/include/plaintext.php
@@ -296,7 +296,7 @@ function shortenmsg($msg, $limit, $twitter = false) {
  *
  * @return string The converted message
  */
-function plaintext($a, $b, $limit = 0, $includedlinks = false, $htmlmode = 2, $target_network = "") {
+function plaintext(App $a, $b, $limit = 0, $includedlinks = false, $htmlmode = 2, $target_network = "") {
 
 	// Remove the hash tags
 	$URLSearchString = "^\[\]";

--- a/include/redir.php
+++ b/include/redir.php
@@ -1,6 +1,6 @@
 <?php
 
-function auto_redir(&$a, $contact_nick) {
+function auto_redir(App $a, $contact_nick) {
 
 	// prevent looping
 
@@ -70,7 +70,7 @@ function auto_redir(&$a, $contact_nick) {
 
 		if(strlen($dfrn_id) < 3)
 			return;
-			
+
 		$sec = random_string();
 
 		q("INSERT INTO `profile_check` ( `uid`, `cid`, `dfrn_id`, `sec`, `expire`)
@@ -84,9 +84,9 @@ function auto_redir(&$a, $contact_nick) {
 
 		$url = curPageURL();
 
-		logger('auto_redir: ' . $r[0]['name'] . ' ' . $sec, LOGGER_DEBUG); 
+		logger('auto_redir: ' . $r[0]['name'] . ' ' . $sec, LOGGER_DEBUG);
 		$dest = (($url) ? '&destination_url=' . $url : '');
-		goaway ($r[0]['poll'] . '?dfrn_id=' . $dfrn_id 
+		goaway ($r[0]['poll'] . '?dfrn_id=' . $dfrn_id
 			. '&dfrn_version=' . DFRN_PROTOCOL_VERSION . '&type=profile&sec=' . $sec . $dest );
 	}
 

--- a/include/security.php
+++ b/include/security.php
@@ -106,7 +106,7 @@ function authenticate_success($user_record, $login_initial = false, $interactive
 
 
 
-function can_write_wall(&$a,$owner) {
+function can_write_wall(App $a, $owner) {
 
 	static $verified = 0;
 
@@ -148,8 +148,8 @@ function can_write_wall(&$a,$owner) {
 				return false;
 			}
 
-			$r = q("SELECT `contact`.*, `user`.`page-flags` FROM `contact` INNER JOIN `user` on `user`.`uid` = `contact`.`uid` 
-				WHERE `contact`.`uid` = %d AND `contact`.`id` = %d AND `contact`.`blocked` = 0 AND `contact`.`pending` = 0 
+			$r = q("SELECT `contact`.*, `user`.`page-flags` FROM `contact` INNER JOIN `user` on `user`.`uid` = `contact`.`uid`
+				WHERE `contact`.`uid` = %d AND `contact`.`id` = %d AND `contact`.`blocked` = 0 AND `contact`.`pending` = 0
 				AND `user`.`blockwall` = 0 AND `readonly` = 0  AND ( `contact`.`rel` IN ( %d , %d ) OR `user`.`page-flags` = %d ) LIMIT 1",
 				intval($owner),
 				intval($cid),
@@ -183,10 +183,10 @@ function permissions_sql($owner_id,$remote_verified = false,$groups = null) {
 	 * default permissions - anonymous user
 	 */
 
-	$sql = " AND allow_cid = '' 
-			 AND allow_gid = '' 
-			 AND deny_cid  = '' 
-			 AND deny_gid  = '' 
+	$sql = " AND allow_cid = ''
+			 AND allow_gid = ''
+			 AND deny_cid  = ''
+			 AND deny_gid  = ''
 	";
 
 	/**
@@ -194,11 +194,11 @@ function permissions_sql($owner_id,$remote_verified = false,$groups = null) {
 	 */
 
 	if(($local_user) && ($local_user == $owner_id)) {
-		$sql = ''; 
+		$sql = '';
 	}
 
 	/**
-	 * Authenticated visitor. Unless pre-verified, 
+	 * Authenticated visitor. Unless pre-verified,
 	 * check that the contact belongs to this $owner_id
 	 * and load the groups the visitor belongs to.
 	 * If pre-verified, the caller is expected to have already
@@ -224,11 +224,11 @@ function permissions_sql($owner_id,$remote_verified = false,$groups = null) {
 			if(is_array($groups) && count($groups)) {
 				foreach($groups as $g)
 					$gs .= '|<' . intval($g) . '>';
-			} 
+			}
 
 			/*$sql = sprintf(
-				" AND ( allow_cid = '' OR allow_cid REGEXP '<%d>' ) 
-				  AND ( deny_cid  = '' OR  NOT deny_cid REGEXP '<%d>' ) 
+				" AND ( allow_cid = '' OR allow_cid REGEXP '<%d>' )
+				  AND ( deny_cid  = '' OR  NOT deny_cid REGEXP '<%d>' )
 				  AND ( allow_gid = '' OR allow_gid REGEXP '%s' )
 				  AND ( deny_gid  = '' OR NOT deny_gid REGEXP '%s')
 				",
@@ -280,7 +280,7 @@ function item_permissions_sql($owner_id,$remote_verified = false,$groups = null)
 	}
 
 	/**
-	 * Authenticated visitor. Unless pre-verified, 
+	 * Authenticated visitor. Unless pre-verified,
 	 * check that the contact belongs to this $owner_id
 	 * and load the groups the visitor belongs to.
 	 * If pre-verified, the caller is expected to have already
@@ -306,13 +306,13 @@ function item_permissions_sql($owner_id,$remote_verified = false,$groups = null)
 			if(is_array($groups) && count($groups)) {
 				foreach($groups as $g)
 					$gs .= '|<' . intval($g) . '>';
-			} 
+			}
 
 			$sql = sprintf(
-				/*" AND ( private = 0 OR ( private in (1,2) AND wall = 1 AND ( allow_cid = '' OR allow_cid REGEXP '<%d>' ) 
-				  AND ( deny_cid  = '' OR  NOT deny_cid REGEXP '<%d>' ) 
+				/*" AND ( private = 0 OR ( private in (1,2) AND wall = 1 AND ( allow_cid = '' OR allow_cid REGEXP '<%d>' )
+				  AND ( deny_cid  = '' OR  NOT deny_cid REGEXP '<%d>' )
 				  AND ( allow_gid = '' OR allow_gid REGEXP '%s' )
-				  AND ( deny_gid  = '' OR NOT deny_gid REGEXP '%s'))) 
+				  AND ( deny_gid  = '' OR NOT deny_gid REGEXP '%s')))
 				",
 				intval($remote_user),
 				intval($remote_user),
@@ -345,29 +345,29 @@ function item_permissions_sql($owner_id,$remote_verified = false,$groups = null)
  *    If the new page contains by any chance external elements, then the used security token is exposed by the referrer.
  *    Actually, important actions should not be triggered by Links / GET-Requests at all, but somethimes they still are,
  *    so this mechanism brings in some damage control (the attacker would be able to forge a request to a form of this type, but not to forms of other types).
- */ 
+ */
 function get_form_security_token($typename = '') {
 	$a = get_app();
-	
+
 	$timestamp = time();
 	$sec_hash = hash('whirlpool', $a->user['guid'] . $a->user['prvkey'] . session_id() . $timestamp . $typename);
-	
+
 	return $timestamp . '.' . $sec_hash;
 }
 
 function check_form_security_token($typename = '', $formname = 'form_security_token') {
 	if (!x($_REQUEST, $formname)) return false;
 	$hash = $_REQUEST[$formname];
-	
+
 	$max_livetime = 10800; // 3 hours
-	
+
 	$a = get_app();
-	
+
 	$x = explode('.', $hash);
 	if (time() > (IntVal($x[0]) + $max_livetime)) return false;
-	
+
 	$sec_hash = hash('whirlpool', $a->user['guid'] . $a->user['prvkey'] . session_id() . $x[0] . $typename);
-	
+
 	return ($sec_hash == $x[1]);
 }
 
@@ -395,13 +395,13 @@ function check_form_security_token_ForbiddenOnErr($typename = '', $formname = 'f
 
 // Returns an array of group id's this contact is a member of.
 // This array will only contain group id's related to the uid of this
-// DFRN contact. They are *not* neccessarily unique across the entire site. 
+// DFRN contact. They are *not* neccessarily unique across the entire site.
 
 
 if(! function_exists('init_groups_visitor')) {
 function init_groups_visitor($contact_id) {
 	$groups = array();
-	$r = q("SELECT `gid` FROM `group_member` 
+	$r = q("SELECT `gid` FROM `group_member`
 		WHERE `contact-id` = %d ",
 		intval($contact_id)
 	);

--- a/include/text.php
+++ b/include/text.php
@@ -276,7 +276,7 @@ if(! function_exists('paginate_data')) {
  * @param int $count [optional] item count (used with alt pager)
  * @return Array data for pagination template
  */
-function paginate_data(&$a, $count=null) {
+function paginate_data(App $a, $count=null) {
 	$stripped = preg_replace('/([&?]page=[0-9]*)/','',$a->query_string);
 
 	$stripped = str_replace('q=','',$stripped);
@@ -369,7 +369,7 @@ if(! function_exists('paginate')) {
  * @param App $a App instance
  * @return string html for pagination #FIXME remove html
  */
-function paginate(App &$a) {
+function paginate(App $a) {
 
 	$data = paginate_data($a);
 	$tpl = get_markup_template("paginate.tpl");
@@ -384,7 +384,7 @@ if(! function_exists('alt_pager')) {
  * @param int $i
  * @return string html for pagination #FIXME remove html
  */
-function alt_pager(&$a, $i) {
+function alt_pager(App $a, $i) {
 
 	$data = paginate_data($a, $i);
 	$tpl = get_markup_template("paginate.tpl");

--- a/include/uimport.php
+++ b/include/uimport.php
@@ -78,7 +78,7 @@ function import_cleanup($newuid) {
 	q("DELETE FROM `pconfig` WHERE uid = %d", $newuid);
 }
 
-function import_account(&$a, $file) {
+function import_account(App $a, $file) {
 	logger("Start user import from " . $file['tmp_name']);
 	/*
 	  STEPS


### PR DESCRIPTION
Fixes #3039

This is a simple cosmetics change, removing redundant `&` operators, adding `App` type hints, a few spaces in function declaration lines, but nothing more.

I won’t accept any change suggestions (like standards or docs) not directly related with the relevant function declaration lines. The diff was so big that I had to split the changes between 4 other PRs:
- #3075 (view folder)
- #3077 (mod folder, 1 out of 3)
- #3078 (mod folder, 2 out of 3)
- #3079 (mod folder, 3 out of 3)