### PR TITLE
Normalize App parameter declaration (mod folder, 1 out of 3)

### DIFF
--- a/mod/_well_known.php
+++ b/mod/_well_known.php
@@ -3,7 +3,7 @@
 require_once("mod/hostxrd.php");
 require_once("mod/nodeinfo.php");
 
-function _well_known_init(App &$a){
+function _well_known_init(App $a) {
 	if ($a->argc > 1) {
 		switch($a->argv[1]) {
 			case "host-meta":
@@ -21,7 +21,7 @@ function _well_known_init(App &$a){
 	killme();
 }
 
-function wk_social_relay(App &$a) {
+function wk_social_relay(App $a) {
 
 	define('SR_SCOPE_ALL', 'all');
 	define('SR_SCOPE_TAGS', 'tags');

--- a/mod/acctlink.php
+++ b/mod/acctlink.php
@@ -2,7 +2,7 @@
 
 require_once('include/Scrape.php');
 
-function acctlink_init(App &$a) {
+function acctlink_init(App $a) {
 
 	if(x($_GET,'addr')) {
 		$addr = trim($_GET['addr']);

--- a/mod/acl.php
+++ b/mod/acl.php
@@ -3,7 +3,7 @@
 
 require_once("include/acl_selectors.php");
 
-function acl_init(App &$a){
+function acl_init(App $a) {
 	acl_lookup($a);
 }
 

--- a/mod/admin.php
+++ b/mod/admin.php
@@ -2,7 +2,7 @@
 
  /**
  * @file mod/admin.php
- * 
+ *
  * @brief Friendica admin
  */
 
@@ -23,7 +23,7 @@ require_once("include/text.php");
  * @param App $a
  *
  */
-function admin_post(App &$a){
+function admin_post(App $a) {
 
 
 	if(!is_site_admin()) {
@@ -66,7 +66,7 @@ function admin_post(App &$a){
 
 				$theme = $a->argv[2];
 				if(is_file("view/theme/$theme/config.php")){
-					function __call_theme_admin_post(&$a, $theme) {
+					function __call_theme_admin_post(App $a, $theme) {
 						$orig_theme = $a->theme;
 						$orig_page = $a->page;
 						$orig_session_theme = $_SESSION['theme'];
@@ -127,7 +127,7 @@ function admin_post(App &$a){
  * @param App $a
  * @return string
  */
-function admin_content(App &$a) {
+function admin_content(App $a) {
 
 	if(!is_site_admin()) {
 		return login(false);
@@ -260,7 +260,7 @@ function admin_content(App &$a) {
  * @param App $a
  * @return string
  */
-function admin_page_federation(App &$a) {
+function admin_page_federation(App $a) {
 	// get counts on active friendica, diaspora, redmatrix, hubzilla, gnu
 	// social and statusnet nodes this node is knowing
 	//
@@ -316,12 +316,12 @@ function admin_page_federation(App &$a) {
 				$newVC = $vv['total'];
 				$newVV = $vv['version'];
 				$posDash = strpos($newVV, '-');
-				if($posDash) 
+				if($posDash)
 					$newVV = substr($newVV, 0, $posDash);
 				if(isset($newV[$newVV]))
-					$newV[$newVV] += $newVC; 
+					$newV[$newVV] += $newVC;
 				else
-					$newV[$newVV] = $newVC; 
+					$newV[$newVV] = $newVC;
 			}
 			foreach ($newV as $key => $value) {
 				array_push($newVv, array('total'=>$value, 'version'=>$key));
@@ -393,7 +393,7 @@ function admin_page_federation(App &$a) {
  * @param App $a
  * @return string
  */
-function admin_page_queue(App &$a) {
+function admin_page_queue(App $a) {
 	// get content from the queue table
 	$r = q("SELECT `c`.`name`, `c`.`nurl`, `q`.`id`, `q`.`network`, `q`.`created`, `q`.`last`
 			FROM `queue` AS `q`, `contact` AS `c`
@@ -427,7 +427,7 @@ function admin_page_queue(App &$a) {
  * @param App $a
  * @return string
  */
-function admin_page_summary(App &$a) {
+function admin_page_summary(App $a) {
 	global $db;
 	// are there MyISAM tables in the DB? If so, trigger a warning message
 	$r = q("SELECT `engine` FROM `information_schema`.`tables` WHERE `engine` = 'myisam' AND `table_schema` = '%s' LIMIT 1",
@@ -501,10 +501,10 @@ function admin_page_summary(App &$a) {
 
 /**
  * @brief Process send data from Admin Site Page
- * 
+ *
  * @param App $a
  */
-function admin_page_site_post(App &$a) {
+function admin_page_site_post(App $a) {
 	if(!x($_POST,"page_site")) {
 		return;
 	}
@@ -845,7 +845,7 @@ function admin_page_site_post(App &$a) {
  * @param  App $a
  * @return string
  */
-function admin_page_site(App &$a) {
+function admin_page_site(App $a) {
 
 	/* Installed langs */
 	$lang_choices = get_available_languages();
@@ -1072,7 +1072,7 @@ function admin_page_site(App &$a) {
  * @param App $a
  * @return string
  **/
-function admin_page_dbsync(App &$a) {
+function admin_page_dbsync(App $a) {
 
 	$o = '';
 
@@ -1152,10 +1152,10 @@ function admin_page_dbsync(App &$a) {
 
 /**
  * @brief Process data send by Users admin page
- * 
+ *
  * @param App $a
  */
-function admin_page_users_post(App &$a){
+function admin_page_users_post(App $a) {
 	$pending     = (x($_POST, 'pending')           ? $_POST['pending']           : array());
 	$users       = (x($_POST, 'user')              ? $_POST['user']		      : array());
 	$nu_name     = (x($_POST, 'new_user_name')     ? $_POST['new_user_name']     : '');
@@ -1168,7 +1168,7 @@ function admin_page_users_post(App &$a){
 	if (!($nu_name==="") && !($nu_email==="") && !($nu_nickname==="")) {
 		require_once('include/user.php');
 
-		$result = create_user(array('username'=>$nu_name, 'email'=>$nu_email, 
+		$result = create_user(array('username'=>$nu_name, 'email'=>$nu_email,
 			'nickname'=>$nu_nickname, 'verified'=>1, 'language'=>$nu_language));
 		if (! $result['success']) {
 			notice($result['message']);
@@ -1260,7 +1260,7 @@ function admin_page_users_post(App &$a){
  * @param App $a
  * @return string
  */
-function admin_page_users(App &$a){
+function admin_page_users(App $a) {
 	if($a->argc>2) {
 		$uid = $a->argv[3];
 		$user = q("SELECT `username`, `blocked` FROM `user` WHERE `uid` = %d", intval($uid));
@@ -1396,7 +1396,7 @@ function admin_page_users(App &$a){
 		array(t('Name'), t('Email'), t('Register date'), t('Last login'), t('Last item'),  t('Account')),
 		$valid_orders
 	);
-	
+
 	$t = get_markup_template("admin_users.tpl");
 	$o = replace_macros($t, array(
 		// strings //
@@ -1460,7 +1460,7 @@ function admin_page_users(App &$a){
  * @param App $a
  * @return string
  */
-function admin_page_plugins(App &$a){
+function admin_page_plugins(App $a) {
 
 	/*
 	 * Single plugin
@@ -1588,7 +1588,7 @@ function admin_page_plugins(App &$a){
 		'$baseurl' => App::get_baseurl(true),
 		'$function' => 'plugins',
 		'$plugins' => $plugins,
-		'$pcount' => count($plugins), 
+		'$pcount' => count($plugins),
 		'$noplugshint' => sprintf(t('There are currently no plugins available on your node. You can find the official plugin repository at %1$s and might find other interesting plugins in the open plugin registry at %2$s'), 'https://github.com/friendica/friendica-addons', 'http://addons.friendi.ca'),
 		'$form_security_token' => get_form_security_token("admin_themes"),
 	));
@@ -1669,7 +1669,7 @@ function rebuild_theme_table($themes) {
  * @param App $a
  * @return string
  */
-function admin_page_themes(App &$a){
+function admin_page_themes(App $a) {
 
 	$allowed_themes_str = get_config('system','allowed_themes');
 	$allowed_themes_raw = explode(',',$allowed_themes_str);
@@ -1749,7 +1749,7 @@ function admin_page_themes(App &$a){
 
 		$admin_form="";
 		if(is_file("view/theme/$theme/config.php")) {
-			function __get_theme_admin_form(&$a, $theme) {
+			function __get_theme_admin_form(App $a, $theme) {
 				$orig_theme = $a->theme;
 				$orig_page = $a->page;
 				$orig_session_theme = $_SESSION['theme'];
@@ -1847,10 +1847,10 @@ function admin_page_themes(App &$a){
 
 /**
  * @brief Prosesses data send by Logs admin page
- * 
+ *
  * @param App $a
  */
-function admin_page_logs_post(App &$a) {
+function admin_page_logs_post(App $a) {
 	if (x($_POST,"page_logs")) {
 		check_form_security_token_redirectOnErr('/admin/logs', 'admin_logs');
 
@@ -1884,7 +1884,7 @@ function admin_page_logs_post(App &$a) {
  * @param App $a
  * @return string
  */
-function admin_page_logs(App &$a){
+function admin_page_logs(App $a) {
 
 	$log_choices = array(
 		LOGGER_NORMAL	=> 'Normal',
@@ -1893,7 +1893,7 @@ function admin_page_logs(App &$a){
 		LOGGER_DATA	=> 'Data',
 		LOGGER_ALL	=> 'All'
 	);
-	
+
 	if (ini_get('log_errors')) {
 		$phplogenabled = t('PHP log currently enabled.');
 	} else {
@@ -1941,7 +1941,7 @@ function admin_page_logs(App &$a){
  * @param App $a
  * @return string
  */
-function admin_page_viewlogs(App &$a){
+function admin_page_viewlogs(App $a) {
 	$t = get_markup_template("admin_viewlogs.tpl");
 	$f = get_config('system','logfile');
 	$data = '';
@@ -1980,10 +1980,10 @@ function admin_page_viewlogs(App &$a){
 
 /**
  * @brief Prosesses data send by the features admin page
- * 
+ *
  * @param App $a
  */
-function admin_page_features_post(App &$a) {
+function admin_page_features_post(App $a) {
 
 	check_form_security_token_redirectOnErr('/admin/features', 'admin_manage_features');
 
@@ -2017,20 +2017,20 @@ function admin_page_features_post(App &$a) {
 
 /**
  * @brief Subpage for global additional feature management
- * 
+ *
  * This functin generates the subpage 'Manage Additional Features'
  * for the admin panel. At this page the admin can set preferences
- * for the user settings of the 'additional features'. If needed this 
+ * for the user settings of the 'additional features'. If needed this
  * preferences can be locked through the admin.
- * 
+ *
  * The returned string contains the HTML code of the subpage 'Manage
  * Additional Features'
- * 
+ *
  * @param App $a
  * @return string
  */
-function admin_page_features(App &$a) {
-	
+function admin_page_features(App $a) {
+
 	if((argc() > 1) && (argv(1) === 'features')) {
 		$arr = array();
 		$features = get_features(false);
@@ -2049,7 +2049,7 @@ function admin_page_features(App &$a) {
 				);
 			}
 		}
-		
+
 		$tpl = get_markup_template("admin_settings_features.tpl");
 		$o .= replace_macros($tpl, array(
 			'$form_security_token' => get_form_security_token("admin_manage_features"),

--- a/mod/allfriends.php
+++ b/mod/allfriends.php
@@ -5,7 +5,7 @@ require_once('include/Contact.php');
 require_once('include/contact_selectors.php');
 require_once('mod/contacts.php');
 
-function allfriends_content(App &$a) {
+function allfriends_content(App $a) {
 
 	$o = '';
 	if (! local_user()) {

--- a/mod/amcd.php
+++ b/mod/amcd.php
@@ -1,6 +1,6 @@
 <?php
 
-function amcd_content(App &$a) {
+function amcd_content(App $a) {
 //header("Content-type: text/json");
 echo <<< EOT
 {

--- a/mod/api.php
+++ b/mod/api.php
@@ -20,7 +20,7 @@ function oauth_get_client($request){
 	return $r[0];
 }
 
-function api_post(App &$a) {
+function api_post(App $a) {
 
 	if (! local_user()) {
 		notice( t('Permission denied.') . EOL);
@@ -34,7 +34,7 @@ function api_post(App &$a) {
 
 }
 
-function api_content(App &$a) {
+function api_content(App $a) {
 	if ($a->cmd=='api/oauth/authorize'){
 		/*
 		 * api/oauth/authorize interact with the user. return a standard page

--- a/mod/apps.php
+++ b/mod/apps.php
@@ -1,6 +1,6 @@
 <?php
 
-function apps_content(App &$a) {
+function apps_content(App $a) {
     $privateaddons = get_config('config','private_addons');
       if ($privateaddons === "1") {
 	if((! (local_user())))  {
@@ -20,6 +20,6 @@ function apps_content(App &$a) {
 		'$apps' => $a->apps,
 	));
 
-	
+
 
 }

--- a/mod/attach.php
+++ b/mod/attach.php
@@ -2,7 +2,7 @@
 
 require_once('include/security.php');
 
-function attach_init(App &$a) {
+function attach_init(App $a) {
 
 	if($a->argc != 2) {
 		notice( t('Item not available.') . EOL);

--- a/mod/babel.php
+++ b/mod/babel.php
@@ -9,55 +9,55 @@ function visible_lf($s) {
 	return str_replace("\n",'<br />', $s);
 }
 
-function babel_content(App &$a) {
+function babel_content(App $a) {
 
 	$o .= '<h1>Babel Diagnostic</h1>';
 
 	$o .= '<form action="babel" method="post">';
 	$o .= t('Source (bbcode) text:') . EOL . '<textarea name="text" >' . htmlspecialchars($_REQUEST['text']) .'</textarea>' . EOL;
-	$o .= '<input type="submit" name="submit" value="Submit" /></form>'; 
+	$o .= '<input type="submit" name="submit" value="Submit" /></form>';
 
 	$o .= '<br /><br />';
 
 	$o .= '<form action="babel" method="post">';
 	$o .= t('Source (Diaspora) text to convert to BBcode:') . EOL . '<textarea name="d2bbtext" >' . htmlspecialchars($_REQUEST['d2bbtext']) .'</textarea>' . EOL;
-	$o .= '<input type="submit" name="submit" value="Submit" /></form>'; 
+	$o .= '<input type="submit" name="submit" value="Submit" /></form>';
 
 	$o .= '<br /><br />';
 
 	if(x($_REQUEST,'text')) {
 
 		$text = trim($_REQUEST['text']);
-		$o .= "<h2>" . t("Source input: ") . "</h2>" . EOL. EOL; 
-		$o .= visible_lf($text) . EOL. EOL; 
+		$o .= "<h2>" . t("Source input: ") . "</h2>" . EOL. EOL;
+		$o .= visible_lf($text) . EOL. EOL;
 
 		$html = bbcode($text);
-		$o .= "<h2>" . t("bb2html (raw HTML): ") . "</h2>" . EOL. EOL; 
-		$o .= htmlspecialchars($html). EOL. EOL; 
+		$o .= "<h2>" . t("bb2html (raw HTML): ") . "</h2>" . EOL. EOL;
+		$o .= htmlspecialchars($html). EOL. EOL;
 
 		//$html = bbcode($text);
-		$o .= "<h2>" . t("bb2html: ") . "</h2>" . EOL. EOL; 
-		$o .= $html. EOL. EOL; 
+		$o .= "<h2>" . t("bb2html: ") . "</h2>" . EOL. EOL;
+		$o .= $html. EOL. EOL;
 
 		$bbcode = html2bbcode($html);
-		$o .= "<h2>" . t("bb2html2bb: ") . "</h2>" . EOL. EOL; 
-		$o .= visible_lf($bbcode) . EOL. EOL; 
+		$o .= "<h2>" . t("bb2html2bb: ") . "</h2>" . EOL. EOL;
+		$o .= visible_lf($bbcode) . EOL. EOL;
 
 		$diaspora = bb2diaspora($text);
-		$o .= "<h2>" . t("bb2md: ") . "</h2>" . EOL. EOL; 
-		$o .= visible_lf($diaspora) . EOL. EOL; 
+		$o .= "<h2>" . t("bb2md: ") . "</h2>" . EOL. EOL;
+		$o .= visible_lf($diaspora) . EOL. EOL;
 
 		$html = Markdown($diaspora);
-		$o .= "<h2>" . t("bb2md2html: ") . "</h2>" . EOL. EOL; 
-		$o .= $html. EOL. EOL; 
+		$o .= "<h2>" . t("bb2md2html: ") . "</h2>" . EOL. EOL;
+		$o .= $html. EOL. EOL;
 
 		$bbcode = diaspora2bb($diaspora);
-		$o .= "<h2>" . t("bb2dia2bb: ") . "</h2>" . EOL. EOL; 
-		$o .= visible_lf($bbcode) . EOL. EOL; 
+		$o .= "<h2>" . t("bb2dia2bb: ") . "</h2>" . EOL. EOL;
+		$o .= visible_lf($bbcode) . EOL. EOL;
 
 		$bbcode = html2bbcode($html);
-		$o .= "<h2>" . t("bb2md2html2bb: ") . "</h2>" . EOL. EOL; 
-		$o .= visible_lf($bbcode) . EOL. EOL; 
+		$o .= "<h2>" . t("bb2md2html2bb: ") . "</h2>" . EOL. EOL;
+		$o .= visible_lf($bbcode) . EOL. EOL;
 
 
 
@@ -66,13 +66,13 @@ function babel_content(App &$a) {
 	if(x($_REQUEST,'d2bbtext')) {
 
 		$d2bbtext = trim($_REQUEST['d2bbtext']);
-		$o .= "<h2>" . t("Source input (Diaspora format): ") . "</h2>" . EOL. EOL; 
-		$o .= visible_lf($d2bbtext) . EOL. EOL; 
+		$o .= "<h2>" . t("Source input (Diaspora format): ") . "</h2>" . EOL. EOL;
+		$o .= visible_lf($d2bbtext) . EOL. EOL;
 
 
 		$bb = diaspora2bb($d2bbtext);
-		$o .= "<h2>" . t("diaspora2bb: ") . "</h2>" . EOL. EOL; 
-		$o .= visible_lf($bb) . EOL. EOL; 
+		$o .= "<h2>" . t("diaspora2bb: ") . "</h2>" . EOL. EOL;
+		$o .= visible_lf($bb) . EOL. EOL;
 	}
 
 	return $o;

--- a/mod/bookmarklet.php
+++ b/mod/bookmarklet.php
@@ -3,11 +3,11 @@
 require_once('include/conversation.php');
 require_once('include/items.php');
 
-function bookmarklet_init(App &$a) {
+function bookmarklet_init(App $a) {
 	$_GET["mode"] = "minimal";
 }
 
-function bookmarklet_content(App &$a) {
+function bookmarklet_content(App $a) {
 	if (!local_user()) {
 		$o = '<h2>'.t('Login').'</h2>';
 		$o .= login(($a->config['register_policy'] == REGISTER_CLOSED) ? false : true);

--- a/mod/cal.php
+++ b/mod/cal.php
@@ -9,7 +9,7 @@
 require_once('include/event.php');
 require_once('include/redir.php');
 
-function cal_init(App &$a) {
+function cal_init(App $a) {
 	if($a->argc > 1)
 		auto_redir($a, $a->argv[1]);
 
@@ -64,7 +64,7 @@ function cal_init(App &$a) {
 	return;
 }
 
-function cal_content(App &$a) {
+function cal_content(App $a) {
 	nav_set_selected('events');
 
 	$editselect = 'none';

--- a/mod/cb.php
+++ b/mod/cb.php
@@ -5,19 +5,19 @@
  */
 
 
-function cb_init(App &$a) {
+function cb_init(App $a) {
 	call_hooks('cb_init');
 }
 
-function cb_post(App &$a) {
+function cb_post(App $a) {
 	call_hooks('cb_post', $_POST);
 }
 
-function cb_afterpost(App &$a) {
+function cb_afterpost(App $a) {
 	call_hooks('cb_afterpost');
 }
 
-function cb_content(App &$a) {
+function cb_content(App $a) {
 	$o = '';
 	call_hooks('cb_content', $o);
 	return $o;

--- a/mod/common.php
+++ b/mod/common.php
@@ -5,7 +5,7 @@ require_once('include/Contact.php');
 require_once('include/contact_selectors.php');
 require_once('mod/contacts.php');
 
-function common_content(App &$a) {
+function common_content(App $a) {
 
 	$o = '';
 

--- a/mod/community.php
+++ b/mod/community.php
@@ -1,6 +1,6 @@
 <?php
 
-function community_init(App &$a) {
+function community_init(App $a) {
 	if (! local_user()) {
 		unset($_SESSION['theme']);
 		unset($_SESSION['mobile-theme']);
@@ -10,7 +10,7 @@ function community_init(App &$a) {
 }
 
 
-function community_content(&$a, $update = 0) {
+function community_content(App $a, $update = 0) {
 
 	$o = '';
 

--- a/mod/contactgroup.php
+++ b/mod/contactgroup.php
@@ -2,7 +2,7 @@
 
 require_once('include/group.php');
 
-function contactgroup_content(App &$a) {
+function contactgroup_content(App $a) {
 
 
 	if (! local_user()) {

--- a/mod/contacts.php
+++ b/mod/contacts.php
@@ -7,7 +7,7 @@ require_once('include/Scrape.php');
 require_once('mod/proxy.php');
 require_once('include/Photo.php');
 
-function contacts_init(App &$a) {
+function contacts_init(App $a) {
 	if (! local_user()) {
 		return;
 	}
@@ -97,7 +97,7 @@ function contacts_init(App &$a) {
 
 }
 
-function contacts_batch_actions(App &$a){
+function contacts_batch_actions(App $a) {
 	$contacts_id = $_POST['contact_batch'];
 	if (!is_array($contacts_id)) return;
 
@@ -144,7 +144,7 @@ function contacts_batch_actions(App &$a){
 }
 
 
-function contacts_post(App &$a) {
+function contacts_post(App $a) {
 
 	if (! local_user()) {
 		return;
@@ -349,7 +349,7 @@ function _contact_drop($contact_id, $orig_record) {
 }
 
 
-function contacts_content(App &$a) {
+function contacts_content(App $a) {
 
 	$sort_type = 0;
 	$o = '';
@@ -831,13 +831,13 @@ function contacts_content(App &$a) {
 
 /**
  * @brief List of pages for the Contact TabBar
- * 
+ *
  * Available Pages are 'Status', 'Profile', 'Contacts' and 'Common Friends'
- * 
+ *
  * @param app $a
  * @param int $contact_id The ID of the contact
  * @param int $active_tab 1 if tab should be marked as active
- * 
+ *
  * @return array with with contact TabBar data
  */
 function contacts_tab($a, $contact_id, $active_tab) {
@@ -961,9 +961,9 @@ function _contact_detail_for_template($rr){
 
 /**
  * @brief Gives a array with actions which can performed to a given contact
- * 
+ *
  * This includes actions like e.g. 'block', 'hide', 'archive', 'delete' and others
- * 
+ *
  * @param array $contact Data about the Contact
  * @return array with contact related actions
  */
@@ -1019,7 +1019,7 @@ function contact_actions($contact) {
 
 	$contact_actions['delete'] = array(
 						'label'	=> t('Delete'),
-						'url'	=> 'contacts/' . $contact['id'] . '/drop', 
+						'url'	=> 'contacts/' . $contact['id'] . '/drop',
 						'title'	=> t('Delete contact'),
 						'sel'	=> '',
 						'id'	=> 'delete',

--- a/mod/content.php
+++ b/mod/content.php
@@ -16,7 +16,7 @@
 // and 10-20 milliseconds to fetch all the child items.
 
 
-function content_content(&$a, $update = 0) {
+function content_content(App $a, $update = 0) {
 
 	require_once('include/conversation.php');
 
@@ -61,7 +61,7 @@ function content_content(&$a, $update = 0) {
 
 	$o = '';
 
-	
+
 
 	$contact_id = $a->cid;
 
@@ -100,7 +100,7 @@ function content_content(&$a, $update = 0) {
 			$def_acl = array('allow_cid' => $str);
 	}
 
-	
+
 	$sql_options  = (($star) ? " and starred = 1 " : '');
 	$sql_options .= (($bmark) ? " and bookmark = 1 " : '');
 
@@ -137,7 +137,7 @@ function content_content(&$a, $update = 0) {
 	}
 	elseif($cid) {
 
-		$r = q("SELECT `id`,`name`,`network`,`writable`,`nurl` FROM `contact` WHERE `id` = %d 
+		$r = q("SELECT `id`,`name`,`network`,`writable`,`nurl` FROM `contact` WHERE `id` = %d
 				AND `blocked` = 0 AND `pending` = 0 LIMIT 1",
 			intval($cid)
 		);
@@ -307,7 +307,7 @@ function content_content(&$a, $update = 0) {
 
 
 
-function render_content(&$a, $items, $mode, $update, $preview = false) {
+function render_content(App $a, $items, $mode, $update, $preview = false) {
 
 	require_once('include/bbcode.php');
 	require_once('mod/proxy.php');
@@ -382,7 +382,7 @@ function render_content(&$a, $items, $mode, $update, $preview = false) {
 
 		if($mode === 'network-new' || $mode === 'search' || $mode === 'community') {
 
-			// "New Item View" on network page or search page results 
+			// "New Item View" on network page or search page results
 			// - just loop through the items and format them minimally for display
 
 			//$tpl = get_markup_template('search_item.tpl');
@@ -402,7 +402,7 @@ function render_content(&$a, $items, $mode, $update, $preview = false) {
 						|| (activity_match($item['verb'],ACTIVITY_DISLIKE))
 						|| activity_match($item['verb'],ACTIVITY_ATTEND)
 						|| activity_match($item['verb'],ACTIVITY_ATTENDNO)
-						|| activity_match($item['verb'],ACTIVITY_ATTENDMAYBE)) 
+						|| activity_match($item['verb'],ACTIVITY_ATTENDMAYBE))
 						&& ($item['id'] != $item['parent']))
 						continue;
 					$nickname = $item['nickname'];
@@ -450,7 +450,7 @@ function render_content(&$a, $items, $mode, $update, $preview = false) {
 
 				$drop = array(
 					'dropping' => $dropping,
-					'select' => t('Select'), 
+					'select' => t('Select'),
 					'delete' => t('Delete'),
 				);
 
@@ -540,11 +540,11 @@ function render_content(&$a, $items, $mode, $update, $preview = false) {
 						$comments[$item['parent']] = 1;
 					else
 						$comments[$item['parent']] += 1;
-				} elseif(! x($comments,$item['parent'])) 
+				} elseif(! x($comments,$item['parent']))
 					$comments[$item['parent']] = 0; // avoid notices later on
 			}
 
-			// map all the like/dislike/attendance activities for each parent item 
+			// map all the like/dislike/attendance activities for each parent item
 			// Store these in the $alike and $dlike arrays
 
 			foreach($items as $item) {
@@ -633,14 +633,14 @@ function render_content(&$a, $items, $mode, $update, $preview = false) {
 
 				$redirect_url = 'redir/' . $item['cid'] ;
 
-				$lock = ((($item['private'] == 1) || (($item['uid'] == local_user()) && (strlen($item['allow_cid']) || strlen($item['allow_gid']) 
+				$lock = ((($item['private'] == 1) || (($item['uid'] == local_user()) && (strlen($item['allow_cid']) || strlen($item['allow_gid'])
 					|| strlen($item['deny_cid']) || strlen($item['deny_gid']))))
 					? t('Private Message')
 					: false);
 
 
 				// Top-level wall post not written by the wall owner (wall-to-wall)
-				// First figure out who owns it. 
+				// First figure out who owns it.
 
 				$osparkle = '';
 
@@ -667,13 +667,13 @@ function render_content(&$a, $items, $mode, $update, $preview = false) {
 						if((! $owner_linkmatch) && (! $alias_linkmatch) && (! $owner_namematch)) {
 
 							// The author url doesn't match the owner (typically the contact)
-							// and also doesn't match the contact alias. 
-							// The name match is a hack to catch several weird cases where URLs are 
+							// and also doesn't match the contact alias.
+							// The name match is a hack to catch several weird cases where URLs are
 							// all over the park. It can be tricked, but this prevents you from
 							// seeing "Bob Smith to Bob Smith via Wall-to-wall" and you know darn
-							// well that it's the same Bob Smith. 
+							// well that it's the same Bob Smith.
 
-							// But it could be somebody else with the same name. It just isn't highly likely. 
+							// But it could be somebody else with the same name. It just isn't highly likely.
 
 
 							$owner_url = $item['owner-link'];
@@ -682,7 +682,7 @@ function render_content(&$a, $items, $mode, $update, $preview = false) {
 							$template = $wallwall;
 							$commentww = 'ww';
 							// If it is our contact, use a friendly redirect link
-							if((link_compare($item['owner-link'],$item['url'])) 
+							if((link_compare($item['owner-link'],$item['url']))
 								&& ($item['network'] === NETWORK_DFRN)) {
 								$owner_url = $redirect_url;
 								$osparkle = ' sparkle';
@@ -694,7 +694,7 @@ function render_content(&$a, $items, $mode, $update, $preview = false) {
 				}
 
 				$likebuttons = '';
-				$shareable = ((($profile_owner == local_user()) && ($item['private'] != 1)) ? true : false); 
+				$shareable = ((($profile_owner == local_user()) && ($item['private'] != 1)) ? true : false);
 
 				if($page_writeable) {
 /*					if($toplevelpost) {  */
@@ -714,7 +714,7 @@ function render_content(&$a, $items, $mode, $update, $preview = false) {
 
 					if(($show_comment_box) || (($show_comment_box == false) && ($override_comment_box == false) && ($item['last-child']))) {
 						$comment = replace_macros($cmnt_tpl,array(
-							'$return_path' => '', 
+							'$return_path' => '',
 							'$jsreload' => (($mode === 'display') ? $_SESSION['return_url'] : ''),
 							'$type' => (($mode === 'profile') ? 'wall-comment' : 'net-comment'),
 							'$id' => $item['item_id'],
@@ -756,7 +756,7 @@ function render_content(&$a, $items, $mode, $update, $preview = false) {
 
 				$drop = array(
 					'dropping' => $dropping,
-					'select' => t('Select'), 
+					'select' => t('Select'),
 					'delete' => t('Delete'),
 				);
 

--- a/mod/credits.php
+++ b/mod/credits.php
@@ -5,7 +5,7 @@
  * addons repository will be listed though ATM)
  */
 
-function credits_content (App &$a) {
+function credits_content (App $a) {
     /* fill the page with credits */
     $f = fopen('util/credits.txt','r');
     $names = fread($f, filesize('util/credits.txt'));

--- a/mod/crepair.php
+++ b/mod/crepair.php
@@ -2,7 +2,7 @@
 require_once("include/contact_selectors.php");
 require_once("mod/contacts.php");
 
-function crepair_init(App &$a) {
+function crepair_init(App $a) {
 	if (! local_user()) {
 		return;
 	}
@@ -30,7 +30,7 @@ function crepair_init(App &$a) {
 	}
 }
 
-function crepair_post(App &$a) {
+function crepair_post(App $a) {
 	if (! local_user()) {
 		return;
 	}
@@ -96,7 +96,7 @@ function crepair_post(App &$a) {
 
 
 
-function crepair_content(App &$a) {
+function crepair_content(App $a) {
 
 	if (! local_user()) {
 		notice( t('Permission denied.') . EOL);

--- a/mod/delegate.php
+++ b/mod/delegate.php
@@ -1,12 +1,12 @@
 <?php
 require_once('mod/settings.php');
 
-function delegate_init(App &$a) {
+function delegate_init(App $a) {
 	return settings_init($a);
 }
 
 
-function delegate_content(App &$a) {
+function delegate_content(App $a) {
 
 	if (! local_user()) {
 		notice( t('Permission denied.') . EOL);
@@ -90,12 +90,12 @@ function delegate_content(App &$a) {
 
 	// find every contact who might be a candidate for delegation
 
-	$r = q("select nurl from contact where substring_index(contact.nurl,'/',3) = '%s' 
+	$r = q("select nurl from contact where substring_index(contact.nurl,'/',3) = '%s'
 		and contact.uid = %d and contact.self = 0 and network = '%s' ",
 		dbesc(normalise_link(App::get_baseurl())),
 		intval(local_user()),
 		dbesc(NETWORK_DFRN)
-	); 
+	);
 
 	if (! dbm::is_result($r)) {
 		notice( t('No potential page delegates located.') . EOL);

--- a/mod/dfrn_confirm.php
+++ b/mod/dfrn_confirm.php
@@ -22,7 +22,7 @@ require_once('include/enotify.php');
 require_once('include/group.php');
 require_once('include/Probe.php');
 
-function dfrn_confirm_post(&$a,$handsfree = null) {
+function dfrn_confirm_post(App $a, $handsfree = null) {
 
 	if(is_array($handsfree)) {
 

--- a/mod/dfrn_notify.php
+++ b/mod/dfrn_notify.php
@@ -11,7 +11,7 @@ require_once('include/event.php');
 
 require_once('library/defuse/php-encryption-1.2.1/Crypto.php');
 
-function dfrn_notify_post(App &$a) {
+function dfrn_notify_post(App $a) {
 	logger(__function__, LOGGER_TRACE);
 	$dfrn_id      = ((x($_POST,'dfrn_id'))      ? notags(trim($_POST['dfrn_id']))   : '');
 	$dfrn_version = ((x($_POST,'dfrn_version')) ? (float) $_POST['dfrn_version']    : 2.0);
@@ -221,7 +221,7 @@ function dfrn_notify_post(App &$a) {
 }
 
 
-function dfrn_notify_content(App &$a) {
+function dfrn_notify_content(App $a) {
 
 	if(x($_GET,'dfrn_id')) {
 

--- a/mod/dfrn_poll.php
+++ b/mod/dfrn_poll.php
@@ -4,7 +4,7 @@ require_once('include/auth.php');
 require_once('include/dfrn.php');
 
 
-function dfrn_poll_init(App &$a) {
+function dfrn_poll_init(App $a) {
 
 
 	$dfrn_id         = ((x($_GET,'dfrn_id'))         ? $_GET['dfrn_id']              : '');
@@ -163,7 +163,7 @@ function dfrn_poll_init(App &$a) {
 
 			if($final_dfrn_id != $orig_id) {
 				logger('profile_check: ' . $final_dfrn_id . ' != ' . $orig_id, LOGGER_DEBUG);
-				// did not decode properly - cannot trust this site 
+				// did not decode properly - cannot trust this site
 				xml_status(3, 'Bad decryption');
 			}
 
@@ -203,7 +203,7 @@ function dfrn_poll_init(App &$a) {
 
 
 
-function dfrn_poll_post(App &$a) {
+function dfrn_poll_post(App $a) {
 
 	$dfrn_id      = ((x($_POST,'dfrn_id'))      ? $_POST['dfrn_id']              : '');
 	$challenge    = ((x($_POST,'challenge'))    ? $_POST['challenge']            : '');
@@ -260,7 +260,7 @@ function dfrn_poll_post(App &$a) {
 
 			if($final_dfrn_id != $orig_id) {
 				logger('profile_check: ' . $final_dfrn_id . ' != ' . $orig_id, LOGGER_DEBUG);
-				// did not decode properly - cannot trust this site 
+				// did not decode properly - cannot trust this site
 				xml_status(3, 'Bad decryption');
 			}
 
@@ -383,7 +383,7 @@ function dfrn_poll_post(App &$a) {
 	}
 }
 
-function dfrn_poll_content(App &$a) {
+function dfrn_poll_content(App $a) {
 
 	$dfrn_id         = ((x($_GET,'dfrn_id'))         ? $_GET['dfrn_id']              : '');
 	$type            = ((x($_GET,'type'))            ? $_GET['type']                 : 'data');

--- a/mod/dfrn_request.php
+++ b/mod/dfrn_request.php
@@ -17,7 +17,7 @@ require_once('include/Scrape.php');
 require_once('include/Probe.php');
 require_once('include/group.php');
 
-function dfrn_request_init(App &$a) {
+function dfrn_request_init(App $a) {
 
 	if($a->argc > 1)
 		$which = $a->argv[1];
@@ -42,7 +42,7 @@ function dfrn_request_init(App &$a) {
  * After logging in, we click 'submit' to approve the linkage.
  *
  */
-function dfrn_request_post(App &$a) {
+function dfrn_request_post(App $a) {
 
 	if(($a->argc != 2) || (! count($a->profile))) {
 		logger('Wrong count of argc or profiles: argc=' . $a->argc . ',profile()=' . count($a->profile));
@@ -658,7 +658,7 @@ function dfrn_request_post(App &$a) {
 }
 
 
-function dfrn_request_content(App &$a) {
+function dfrn_request_content(App $a) {
 
 	if (($a->argc != 2) || (! count($a->profile))) {
 		return "";

--- a/mod/directory.php
+++ b/mod/directory.php
@@ -1,6 +1,6 @@
 <?php
 
-function directory_init(App &$a) {
+function directory_init(App $a) {
 	$a->set_pager_itemspage(60);
 
 	if(local_user()) {
@@ -20,19 +20,19 @@ function directory_init(App &$a) {
 }
 
 
-function directory_post(App &$a) {
+function directory_post(App $a) {
 	if(x($_POST,'search'))
 		$a->data['search'] = $_POST['search'];
 }
 
 
 
-function directory_content(App &$a) {
+function directory_content(App $a) {
 	global $db;
 
 	require_once("mod/proxy.php");
 
-	if((get_config('system','block_public')) && (! local_user()) && (! remote_user()) || 
+	if((get_config('system','block_public')) && (! local_user()) && (! remote_user()) ||
 		(get_config('system','block_local_dir')) && (! local_user()) && (! remote_user())) {
 		notice( t('Public access denied.') . EOL);
 		return;
@@ -124,7 +124,7 @@ function directory_content(App &$a) {
 			}
 //			if(strlen($rr['dob'])) {
 //				if(($years = age($rr['dob'],$rr['timezone'],'')) != 0)
-//					$details .= '<br />' . t('Age: ') . $years ; 
+//					$details .= '<br />' . t('Age: ') . $years ;
 //			}
 //			if(strlen($rr['gender']))
 //				$details .= '<br />' . t('Gender: ') . $rr['gender'];

--- a/mod/dirfind.php
+++ b/mod/dirfind.php
@@ -5,7 +5,7 @@ require_once('include/Contact.php');
 require_once('include/contact_selectors.php');
 require_once('mod/contacts.php');
 
-function dirfind_init(App &$a) {
+function dirfind_init(App $a) {
 
 	if (! local_user()) {
 		notice( t('Permission denied.') . EOL );
@@ -23,7 +23,7 @@ function dirfind_init(App &$a) {
 
 
 
-function dirfind_content(&$a, $prefix = "") {
+function dirfind_content(App $a, $prefix = "") {
 
 	$community = false;
 	$discover_user = false;

--- a/mod/display.php
+++ b/mod/display.php
@@ -1,6 +1,6 @@
 <?php
 
-function display_init(App &$a) {
+function display_init(App $a) {
 
 	if ((get_config('system','block_public')) && (! local_user()) && (! remote_user())) {
 		return;
@@ -194,7 +194,7 @@ function display_fetchauthor($a, $item) {
 	return($profiledata);
 }
 
-function display_content(&$a, $update = 0) {
+function display_content(App $a, $update = 0) {
 
 	if ((get_config('system','block_public')) && (! local_user()) && (! remote_user())) {
 		notice(t('Public access denied.') . EOL);

--- a/mod/editpost.php
+++ b/mod/editpost.php
@@ -2,7 +2,7 @@
 
 require_once('include/acl_selectors.php');
 
-function editpost_content(App &$a) {
+function editpost_content(App $a) {
 
 	$o = '';
 

--- a/mod/events.php
+++ b/mod/events.php
@@ -8,7 +8,7 @@ require_once('include/datetime.php');
 require_once('include/event.php');
 require_once('include/items.php');
 
-function events_init(App &$a) {
+function events_init(App $a) {
 	if (! local_user()) {
 		return;
 	}
@@ -31,7 +31,7 @@ function events_init(App &$a) {
 	return;
 }
 
-function events_post(App &$a) {
+function events_post(App $a) {
 
 	logger('post: ' . print_r($_REQUEST,true));
 
@@ -189,7 +189,7 @@ function events_post(App &$a) {
 
 
 
-function events_content(App &$a) {
+function events_content(App $a) {
 
 	if (! local_user()) {
 		notice( t('Permission denied.') . EOL);

--- a/mod/fbrowser.php
+++ b/mod/fbrowser.php
@@ -10,7 +10,7 @@ require_once('include/Photo.php');
 /**
  * @param App $a
  */
-function fbrowser_content(App &$a){
+function fbrowser_content(App $a) {
 
 	if (!local_user())
 		killme();

--- a/mod/fetch.php
+++ b/mod/fetch.php
@@ -6,9 +6,7 @@ require_once("include/crypto.php");
 require_once("include/diaspora.php");
 require_once("include/xml.php");
 
-/// @TODO You always make it like this: function foo(&$a)
-/// @TODO This means that the value of $a can be changed in anything, remove & and use App as type-hint
-function fetch_init(App &$a){
+function fetch_init(App $a) {
 
 	if (($a->argc != 3) OR (!in_array($a->argv[1], array("post", "status_message", "reshare")))) {
 		header($_SERVER["SERVER_PROTOCOL"].' 404 '.t('Not Found'));

--- a/mod/filer.php
+++ b/mod/filer.php
@@ -5,7 +5,7 @@ require_once('include/bbcode.php');
 require_once('include/items.php');
 
 
-function filer_content(App &$a) {
+function filer_content(App $a) {
 
 	if (! local_user()) {
 		killme();
@@ -30,7 +30,7 @@ function filer_content(App &$a) {
 			'$field' => array('term', t("Save to Folder:"), '', '', $filetags, t('- select -')),
 			'$submit' => t('Save'),
 		));
-		
+
 		echo $o;
 	}
 	killme();

--- a/mod/filerm.php
+++ b/mod/filerm.php
@@ -1,6 +1,6 @@
 <?php
 
-function filerm_content(App &$a) {
+function filerm_content(App $a) {
 
 	if (! local_user()) {
 		killme();

--- a/mod/follow.php
+++ b/mod/follow.php
@@ -5,7 +5,7 @@ require_once('include/follow.php');
 require_once('include/Contact.php');
 require_once('include/contact_selectors.php');
 
-function follow_content(App &$a) {
+function follow_content(App $a) {
 
 	if (! local_user()) {
 		notice( t('Permission denied.') . EOL);
@@ -152,7 +152,7 @@ function follow_content(App &$a) {
 	return $o;
 }
 
-function follow_post(App &$a) {
+function follow_post(App $a) {
 
 	if (! local_user()) {
 		notice( t('Permission denied.') . EOL);

--- a/mod/friendica.php
+++ b/mod/friendica.php
@@ -1,6 +1,6 @@
 <?php
 
-function friendica_init(App &$a) {
+function friendica_init(App $a) {
 	if ($a->argv[1]=="json"){
 		$register_policy = Array('REGISTER_CLOSED', 'REGISTER_APPROVE', 'REGISTER_OPEN');
 
@@ -59,7 +59,7 @@ function friendica_init(App &$a) {
 
 
 
-function friendica_content(App &$a) {
+function friendica_content(App $a) {
 
 	$o = '';
 	$o .= '<h3>Friendica</h3>';
@@ -70,7 +70,7 @@ function friendica_content(App &$a) {
 	$o .= t('This is Friendica, version') . ' ' . FRIENDICA_VERSION . ' ';
 	$o .= t('running at web location') . ' ' . z_root() . '</p><p>';
 
-	$o .= t('Please visit <a href="http://friendica.com">Friendica.com</a> to learn more about the Friendica project.') . '</p><p>';	
+	$o .= t('Please visit <a href="http://friendica.com">Friendica.com</a> to learn more about the Friendica project.') . '</p><p>';
 
 	$o .= t('Bug reports and issues: please visit') . ' ' . '<a href="https://github.com/friendica/friendica/issues?state=open">'.t('the bugtracker at github').'</a></p><p>';
 	$o .= t('Suggestions, praise, donations, etc. - please email "Info" at Friendica - dot com') . '</p>';
@@ -102,7 +102,7 @@ function friendica_content(App &$a) {
 	else
 		$o .= '<p>' . t('No installed plugins/addons/apps') . '</p>';
 
-	call_hooks('about_hook', $o); 	
+	call_hooks('about_hook', $o);
 
 	return $o;
 

--- a/mod/fsuggest.php
+++ b/mod/fsuggest.php
@@ -1,7 +1,7 @@
 <?php
 
 
-function fsuggest_post(App &$a) {
+function fsuggest_post(App $a) {
 
 	if (! local_user()) {
 		return;
@@ -40,11 +40,11 @@ function fsuggest_post(App &$a) {
 				VALUES ( %d, %d, '%s','%s','%s','%s','%s','%s')",
 				intval(local_user()),
 				intval($contact_id),
-				dbesc($r[0]['name']), 
-				dbesc($r[0]['url']), 
-				dbesc($r[0]['request']), 
-				dbesc($r[0]['photo']), 
-				dbesc($hash), 
+				dbesc($r[0]['name']),
+				dbesc($r[0]['url']),
+				dbesc($r[0]['request']),
+				dbesc($r[0]['photo']),
+				dbesc($hash),
 				dbesc(datetime_convert())
 			);
 			$r = q("SELECT `id` FROM `fsuggest` WHERE `note` = '%s' AND `uid` = %d LIMIT 1",
@@ -71,7 +71,7 @@ function fsuggest_post(App &$a) {
 
 
 
-function fsuggest_content(App &$a) {
+function fsuggest_content(App $a) {
 
 	require_once('include/acl_selectors.php');
 
@@ -101,7 +101,7 @@ function fsuggest_content(App &$a) {
 
 	$o .= '<form id="fsuggest-form" action="fsuggest/' . $contact_id . '" method="post" >';
 
-	$o .= contact_selector('suggest','suggest-select', false, 
+	$o .= contact_selector('suggest','suggest-select', false,
 		array('size' => 4, 'exclude' => $contact_id, 'networks' => 'DFRN_ONLY', 'single' => true));
 
 

--- a/mod/group.php
+++ b/mod/group.php
@@ -4,7 +4,7 @@ function validate_members(&$item) {
 	$item = intval($item);
 }
 
-function group_init(App &$a) {
+function group_init(App $a) {
 	if(local_user()) {
 		require_once('include/group.php');
 		$a->page['aside'] = group_side('contacts','group','extended',(($a->argc > 1) ? intval($a->argv[1]) : 0));
@@ -13,7 +13,7 @@ function group_init(App &$a) {
 
 
 
-function group_post(App &$a) {
+function group_post(App $a) {
 
 	if (! local_user()) {
 		notice( t('Permission denied.') . EOL);
@@ -69,7 +69,7 @@ function group_post(App &$a) {
 	return;
 }
 
-function group_content(App &$a) {
+function group_content(App $a) {
 	$change = false;
 
 	if (! local_user()) {

--- a/mod/hcard.php
+++ b/mod/hcard.php
@@ -1,6 +1,6 @@
 <?php
 
-function hcard_init(App &$a) {
+function hcard_init(App $a) {
 
 	$blocked = (((get_config('system','block_public')) && (! local_user()) && (! remote_user())) ? true : false);
 

--- a/mod/help.php
+++ b/mod/help.php
@@ -18,7 +18,7 @@ if (!function_exists('load_doc_file')) {
 
 }
 
-function help_content(App &$a) {
+function help_content(App $a) {
 
 	nav_set_selected('help');
 

--- a/mod/home.php
+++ b/mod/home.php
@@ -1,7 +1,7 @@
 <?php
 
 if(! function_exists('home_init')) {
-function home_init(App &$a) {
+function home_init(App $a) {
 
 	$ret = array();
 	call_hooks('home_init',$ret);
@@ -17,7 +17,7 @@ function home_init(App &$a) {
 }}
 
 if(! function_exists('home_content')) {
-function home_content(App &$a) {
+function home_content(App $a) {
 
 	$o = '';
 

--- a/mod/hostxrd.php
+++ b/mod/hostxrd.php
@@ -2,7 +2,7 @@
 
 require_once('include/crypto.php');
 
-function hostxrd_init(App &$a) {
+function hostxrd_init(App $a) {
 	header('Access-Control-Allow-Origin: *');
 	header("Content-type: text/xml");
 	$pubkey = get_config('system','site_pubkey');


### PR DESCRIPTION
Fixes #3039

This is a simple cosmetics change, removing redundant `&` operators, adding `App` type hints, a few spaces in function declaration lines, but nothing more.

I won’t accept any change suggestions (like standards or docs) not directly related with the relevant function declaration lines. The diff was so big that I had to split the changes between 4 other PRs:
- #3075 (view folder)
- #3076 (doc-include folders, boot)
- #3078 (mod folder, 2 out of 3)
- #3079 (mod folder, 3 out of 3)