### PR TITLE
Normalize App parameter declaration (mod folder, 2 out of 3)

### DIFF
--- a/mod/hovercard.php
+++ b/mod/hovercard.php
@@ -11,7 +11,7 @@
 require_once("include/socgraph.php");
 require_once("include/Contact.php");
 
-function hovercard_init(App &$a) {
+function hovercard_init(App $a) {
 	// Just for testing purposes
 	$_GET["mode"] = "minimal";
 }
@@ -96,10 +96,10 @@ function hovercard_content() {
 
 /**
  * @brief Get the raw content of a template file
- * 
+ *
  * @param string $template The name of the template
  * @param string $root Directory of the template
- * 
+ *
  * @return string|bool Output the raw content if existent, otherwise false
  */
 function get_template_content($template, $root = "") {

--- a/mod/ignored.php
+++ b/mod/ignored.php
@@ -1,7 +1,7 @@
 <?php
 
 
-function ignored_init(App &$a) {
+function ignored_init(App $a) {
 
 	$ignored = 0;
 

--- a/mod/install.php
+++ b/mod/install.php
@@ -4,7 +4,7 @@ require_once "include/Photo.php";
 $install_wizard_pass=1;
 
 
-function install_init(App &$a){
+function install_init(App $a) {
 
 	// $baseurl/install/testrwrite to test if rewite in .htaccess is working
 	if ($a->argc==2 && $a->argv[1]=="testrewrite") {
@@ -24,7 +24,7 @@ function install_init(App &$a){
 
 }
 
-function install_post(App &$a) {
+function install_post(App $a) {
 	global $install_wizard_pass, $db;
 
 	switch($install_wizard_pass) {
@@ -132,7 +132,7 @@ function get_db_errno() {
 	}
 }
 
-function install_content(App &$a) {
+function install_content(App $a) {
 
 	global $install_wizard_pass, $db;
 	$o = '';
@@ -565,7 +565,7 @@ function check_imagik(&$checks) {
 	}
 }
 
-function manual_config(App &$a) {
+function manual_config(App $a) {
 	$data = htmlentities($a->data['txt'],ENT_COMPAT,'UTF-8');
 	$o = t('The database configuration file ".htconfig.php" could not be written. Please use the enclosed text to create a configuration file in your web server root.');
 	$o .= "<textarea rows=\"24\" cols=\"80\" >$data</textarea>";

--- a/mod/invite.php
+++ b/mod/invite.php
@@ -9,7 +9,7 @@
 
 require_once('include/email.php');
 
-function invite_post(App &$a) {
+function invite_post(App $a) {
 
 	if (! local_user()) {
 		notice( t('Permission denied.') . EOL);
@@ -73,8 +73,8 @@ function invite_post(App &$a) {
 			$nmessage = $message;
 		}
 
-		$res = mail($recip, email_header_encode( t('Please join us on Friendica'),'UTF-8'), 
-			$nmessage, 
+		$res = mail($recip, email_header_encode( t('Please join us on Friendica'),'UTF-8'),
+			$nmessage,
 			"From: " . $a->user['email'] . "\n"
 			. 'Content-type: text/plain; charset=UTF-8' . "\n"
 			. 'Content-transfer-encoding: 8bit' );
@@ -97,7 +97,7 @@ function invite_post(App &$a) {
 }
 
 
-function invite_content(App &$a) {
+function invite_content(App $a) {
 
 	if (! local_user()) {
 		notice( t('Permission denied.') . EOL);
@@ -136,7 +136,7 @@ function invite_content(App &$a) {
 		'$msg_text'            => t('Your message:'),
 		'$default_message'     => t('You are cordially invited to join me and other close friends on Friendica - and help us to create a better social web.') . "\r\n" . "\r\n"
 			. $linktxt
-			. "\r\n" . "\r\n" . (($invonly) ? t('You will need to supply this invitation code: $invite_code') . "\r\n" . "\r\n" : '') .t('Once you have registered, please connect with me via my profile page at:') 
+			. "\r\n" . "\r\n" . (($invonly) ? t('You will need to supply this invitation code: $invite_code') . "\r\n" . "\r\n" : '') .t('Once you have registered, please connect with me via my profile page at:')
 			. "\r\n" . "\r\n" . App::get_baseurl() . '/profile/' . $a->user['nickname']
 			. "\r\n" . "\r\n" . t('For more information about the Friendica project and why we feel it is important, please visit http://friendica.com') . "\r\n" . "\r\n"  ,
 		'$submit'              => t('Submit')

--- a/mod/item.php
+++ b/mod/item.php
@@ -27,7 +27,7 @@ require_once('include/Scrape.php');
 require_once('include/diaspora.php');
 require_once('include/Contact.php');
 
-function item_post(App &$a) {
+function item_post(App $a) {
 
 	if((! local_user()) && (! remote_user()) && (! x($_REQUEST,'commenter')))
 		return;
@@ -1066,7 +1066,7 @@ function item_post_return($baseurl, $api_source, $return_path) {
 
 
 
-function item_content(App &$a) {
+function item_content(App $a) {
 
 	if ((! local_user()) && (! remote_user())) {
 		return;

--- a/mod/like.php
+++ b/mod/like.php
@@ -5,7 +5,7 @@ require_once('include/bbcode.php');
 require_once('include/items.php');
 require_once('include/like.php');
 
-function like_content(App &$a) {
+function like_content(App $a) {
 	if(! local_user() && ! remote_user()) {
 		return false;
 	}

--- a/mod/localtime.php
+++ b/mod/localtime.php
@@ -3,7 +3,7 @@
 require_once('include/datetime.php');
 
 
-function localtime_post(App &$a) {
+function localtime_post(App $a) {
 
 	$t = $_REQUEST['time'];
 	if(! $t)
@@ -16,7 +16,7 @@ function localtime_post(App &$a) {
 
 }
 
-function localtime_content(App &$a) {
+function localtime_content(App $a) {
 	$t = $_REQUEST['time'];
 	if(! $t)
 		$t = 'now';
@@ -38,7 +38,7 @@ function localtime_content(App &$a) {
 
 	$o .= '<form action ="' . App::get_baseurl() . '/localtime?f=&time=' . $t . '" method="post" >';
 
-	$o .= '<p>' . t('Please select your timezone:') . '</p>'; 
+	$o .= '<p>' . t('Please select your timezone:') . '</p>';
 
 	$o .= select_timezone(($_REQUEST['timezone']) ? $_REQUEST['timezone'] : 'America/Los_Angeles');
 

--- a/mod/lockview.php
+++ b/mod/lockview.php
@@ -1,8 +1,8 @@
 <?php
 
 
-function lockview_content(App &$a) {
-  
+function lockview_content(App $a) {
+
 	$type = (($a->argc > 1) ? $a->argv[1] : 0);
 	if (is_numeric($type)) {
 		$item_id = intval($type);
@@ -10,13 +10,13 @@ function lockview_content(App &$a) {
 	} else {
 		$item_id = (($a->argc > 2) ? intval($a->argv[2]) : 0);
 	}
-  
+
 	if(! $item_id)
 		killme();
 
 	if (!in_array($type, array('item','photo','event')))
 		killme();
-     
+
 	$r = q("SELECT * FROM `%s` WHERE `id` = %d LIMIT 1",
 		dbesc($type),
 		intval($item_id)
@@ -34,7 +34,7 @@ function lockview_content(App &$a) {
 	}
 
 
-	if(($item['private'] == 1) && (! strlen($item['allow_cid'])) && (! strlen($item['allow_gid'])) 
+	if(($item['private'] == 1) && (! strlen($item['allow_cid'])) && (! strlen($item['allow_gid']))
 		&& (! strlen($item['deny_cid'])) && (! strlen($item['deny_gid']))) {
 
 		echo t('Remote privacy information not available.') . '<br />';
@@ -54,7 +54,7 @@ function lockview_content(App &$a) {
 			dbesc(implode(', ', $allowed_groups))
 		);
 		if (dbm::is_result($r))
-			foreach($r as $rr) 
+			foreach($r as $rr)
 				$l[] = '<b>' . $rr['name'] . '</b>';
 	}
 	if(count($allowed_users)) {
@@ -62,7 +62,7 @@ function lockview_content(App &$a) {
 			dbesc(implode(', ',$allowed_users))
 		);
 		if (dbm::is_result($r))
-			foreach($r as $rr) 
+			foreach($r as $rr)
 				$l[] = $rr['name'];
 
 	}
@@ -72,7 +72,7 @@ function lockview_content(App &$a) {
 			dbesc(implode(', ', $deny_groups))
 		);
 		if (dbm::is_result($r))
-			foreach($r as $rr) 
+			foreach($r as $rr)
 				$l[] = '<b><strike>' . $rr['name'] . '</strike></b>';
 	}
 	if(count($deny_users)) {
@@ -80,7 +80,7 @@ function lockview_content(App &$a) {
 			dbesc(implode(', ',$deny_users))
 		);
 		if (dbm::is_result($r))
-			foreach($r as $rr) 
+			foreach($r as $rr)
 				$l[] = '<strike>' . $rr['name'] . '</strike>';
 
 	}

--- a/mod/login.php
+++ b/mod/login.php
@@ -1,6 +1,6 @@
 <?php
 
-function login_content(App &$a) {
+function login_content(App $a) {
 	if(x($_SESSION,'theme'))
 		unset($_SESSION['theme']);
 	if(x($_SESSION,'mobile-theme'))

--- a/mod/lostpass.php
+++ b/mod/lostpass.php
@@ -4,7 +4,7 @@ require_once('include/email.php');
 require_once('include/enotify.php');
 require_once('include/text.php');
 
-function lostpass_post(App &$a) {
+function lostpass_post(App $a) {
 
 	$loginame = notags(trim($_POST['login-name']));
 	if(! $loginame)
@@ -77,7 +77,7 @@ function lostpass_post(App &$a) {
 }
 
 
-function lostpass_content(App &$a) {
+function lostpass_content(App $a) {
 
 
 	if(x($_GET,'verify')) {

--- a/mod/maintenance.php
+++ b/mod/maintenance.php
@@ -1,6 +1,6 @@
 <?php
 
-function maintenance_content(App &$a) {
+function maintenance_content(App $a) {
 	header('HTTP/1.1 503 Service Temporarily Unavailable');
 	header('Status: 503 Service Temporarily Unavailable');
 	header('Retry-After: 600');

--- a/mod/manage.php
+++ b/mod/manage.php
@@ -3,7 +3,7 @@
 require_once("include/text.php");
 
 
-function manage_post(App &$a) {
+function manage_post(App $a) {
 
 	if (! local_user()) {
 		return;
@@ -92,7 +92,7 @@ function manage_post(App &$a) {
 
 
 
-function manage_content(App &$a) {
+function manage_content(App $a) {
 
 	if (! local_user()) {
 		notice( t('Permission denied.') . EOL);

--- a/mod/match.php
+++ b/mod/match.php
@@ -10,10 +10,10 @@ require_once('mod/proxy.php');
  * It takes keywords from your profile and queries the directory server for
  * matching keywords from other profiles.
  *
- * @param App &$a
+ * @param App $a
  * @return void|string
  */
-function match_content(App &$a) {
+function match_content(App $a) {
 
 	$o = '';
 	if (! local_user()) {

--- a/mod/message.php
+++ b/mod/message.php
@@ -4,7 +4,7 @@ require_once('include/acl_selectors.php');
 require_once('include/message.php');
 require_once('include/Smilies.php');
 
-function message_init(App &$a) {
+function message_init(App $a) {
 
 	$tabs = '';
 
@@ -40,7 +40,7 @@ function message_init(App &$a) {
 
 }
 
-function message_post(App &$a) {
+function message_post(App $a) {
 
 	if (! local_user()) {
 		notice( t('Permission denied.') . EOL);
@@ -173,7 +173,7 @@ function item_redir_and_replace_images($body, $images, $cid) {
 
 
 
-function message_content(App &$a) {
+function message_content(App $a) {
 
 	$o = '';
 	nav_set_selected('messages');

--- a/mod/modexp.php
+++ b/mod/modexp.php
@@ -2,7 +2,7 @@
 
 require_once('library/asn1.php');
 
-function modexp_init(App &$a) {
+function modexp_init(App $a) {
 
 	if($a->argc != 2)
 		killme();

--- a/mod/mood.php
+++ b/mod/mood.php
@@ -5,7 +5,7 @@ require_once('include/bbcode.php');
 require_once('include/items.php');
 
 
-function mood_init(App &$a) {
+function mood_init(App $a) {
 
 	if (! local_user()) {
 		return;
@@ -60,7 +60,7 @@ function mood_init(App &$a) {
 
 	$uri = item_new_uri($a->get_hostname(),$uid);
 
-	$action = sprintf( t('%1$s is currently %2$s'), '[url=' . $poster['url'] . ']' . $poster['name'] . '[/url]' , $verbs[$verb]); 
+	$action = sprintf( t('%1$s is currently %2$s'), '[url=' . $poster['url'] . ']' . $poster['name'] . '[/url]' , $verbs[$verb]);
 
 	$arr = array();
 	$arr['guid']          = get_guid(32);
@@ -109,7 +109,7 @@ function mood_init(App &$a) {
 
 
 
-function mood_content(App &$a) {
+function mood_content(App $a) {
 
 	if (! local_user()) {
 		notice( t('Permission denied.') . EOL);

--- a/mod/msearch.php
+++ b/mod/msearch.php
@@ -1,6 +1,6 @@
 <?php
 
-function msearch_post(App &$a) {
+function msearch_post(App $a) {
 
 	$perpage = (($_POST['n']) ? $_POST['n'] : 80);
 	$page = (($_POST['p']) ? intval($_POST['p'] - 1) : 0);
@@ -28,8 +28,8 @@ function msearch_post(App &$a) {
 	if (dbm::is_result($r)) {
 		foreach($r as $rr)
 			$results[] = array(
-				'name' => $rr['name'], 
-				'url' => App::get_baseurl() . '/profile/' . $rr['nickname'], 
+				'name' => $rr['name'],
+				'url' => App::get_baseurl() . '/profile/' . $rr['nickname'],
 				'photo' => App::get_baseurl() . '/photo/avatar/' . $rr['uid'] . '.jpg',
 				'tags' => str_replace(array(',','  '),array(' ',' '),$rr['pub_keywords'])
 			);

--- a/mod/navigation.php
+++ b/mod/navigation.php
@@ -2,7 +2,7 @@
 
 require_once("include/nav.php");
 
-function navigation_content(App &$a) {
+function navigation_content(App $a) {
 
 	$nav_info = nav_info($a);
 

--- a/mod/network.php
+++ b/mod/network.php
@@ -1,5 +1,5 @@
 <?php
-function network_init(App &$a) {
+function network_init(App $a) {
 	if (! local_user()) {
 		notice( t('Permission denied.') . EOL);
 		return;
@@ -221,7 +221,7 @@ function saved_searches($search) {
  *
  * @return Array ( $no_active, $comment_active, $postord_active, $conv_active, $new_active, $starred_active, $bookmarked_active, $spam_active );
  */
-function network_query_get_sel_tab(App &$a) {
+function network_query_get_sel_tab(App $a) {
 	$no_active='';
 	$starred_active = '';
 	$new_active = '';
@@ -292,7 +292,7 @@ function network_query_get_sel_net() {
 	return $network;
 }
 
-function network_query_get_sel_group(App &$a) {
+function network_query_get_sel_group(App $a) {
 	$group = false;
 
 	if($a->argc >= 2 && is_numeric($a->argv[1])) {
@@ -303,7 +303,7 @@ function network_query_get_sel_group(App &$a) {
 }
 
 
-function network_content(&$a, $update = 0) {
+function network_content(App $a, $update = 0) {
 
 	require_once('include/conversation.php');
 
@@ -728,7 +728,7 @@ function network_content(&$a, $update = 0) {
 					intval($parents),
 					intval($max_comments + 1)
 				);
-	
+
 				if (dbm::is_result($thread_items))
 					$items = array_merge($items, $thread_items);
 			}
@@ -805,11 +805,11 @@ function network_content(&$a, $update = 0) {
 
 /**
  * @brief Get the network tabs menu
- * 
+ *
  * @param app $a The global App
  * @return string Html of the networktab
  */
-function network_tabs(App &$a) {
+function network_tabs(App $a) {
 	// item filter tabs
 	/// @TODO fix this logic, reduce duplication
 	/// $a->page['content'] .= '<div class="tabs-wrapper">';
@@ -892,7 +892,7 @@ function network_tabs(App &$a) {
 
 	$arr = array('tabs' => $tabs);
 	call_hooks('network_tabs', $arr);
-	
+
 	$tpl = get_markup_template('common_tabs.tpl');
 
 	return replace_macros($tpl, array('$tabs' => $arr['tabs']));

--- a/mod/newmember.php
+++ b/mod/newmember.php
@@ -1,6 +1,6 @@
 <?php
 
-function newmember_content(App &$a) {
+function newmember_content(App $a) {
 
 
 	$o = '<h1>' . t('Welcome to Friendica') . '</h1>';
@@ -15,7 +15,7 @@ function newmember_content(App &$a) {
 
 	$o .= '<ul>';
 
-	$o .= '<li> ' . '<a target="newmember" href="help/guide">' . t('Friendica Walk-Through') . '</a><br />' . t('On your <em>Quick Start</em> page - find a brief introduction to your profile and network tabs, make some new connections, and find some groups to join.') . '</li>' . EOL; 
+	$o .= '<li> ' . '<a target="newmember" href="help/guide">' . t('Friendica Walk-Through') . '</a><br />' . t('On your <em>Quick Start</em> page - find a brief introduction to your profile and network tabs, make some new connections, and find some groups to join.') . '</li>' . EOL;
 
 	$o .= '</ul>';
 
@@ -23,7 +23,7 @@ function newmember_content(App &$a) {
 
 	$o .= '<ul>';
 
-	$o .= '<li>' . '<a target="newmember" href="settings">' . t('Go to Your Settings') . '</a><br />' . t('On your <em>Settings</em> page -  change your initial password. Also make a note of your Identity Address. This looks just like an email address - and will be useful in making friends on the free social web.') . '</li>' . EOL; 
+	$o .= '<li>' . '<a target="newmember" href="settings">' . t('Go to Your Settings') . '</a><br />' . t('On your <em>Settings</em> page -  change your initial password. Also make a note of your Identity Address. This looks just like an email address - and will be useful in making friends on the free social web.') . '</li>' . EOL;
 
 	$o .= '<li>' . t('Review the other settings, particularly the privacy settings. An unpublished directory listing is like having an unlisted phone number. In general, you should probably publish your listing - unless all of your friends and potential friends know exactly how to find you.') . '</li>' . EOL;
 
@@ -33,7 +33,7 @@ function newmember_content(App &$a) {
 
 	$o .= '<ul>';
 
-	$o .= '<li>' . '<a target="newmember" href="profile_photo">' . t('Upload Profile Photo') . '</a><br />' . t('Upload a profile photo if you have not done so already. Studies have shown that people with real photos of themselves are ten times more likely to make friends than people who do not.') . '</li>' . EOL;  
+	$o .= '<li>' . '<a target="newmember" href="profile_photo">' . t('Upload Profile Photo') . '</a><br />' . t('Upload a profile photo if you have not done so already. Studies have shown that people with real photos of themselves are ten times more likely to make friends than people who do not.') . '</li>' . EOL;
 
 	$o .= '<li>' . '<a target="newmember" href="profiles">' . t('Edit Your Profile') . '</a><br />' . t('Edit your <strong>default</strong> profile to your liking. Review the settings for hiding your list of friends and hiding the profile from unknown visitors.') . '</li>' . EOL;
 
@@ -46,7 +46,7 @@ function newmember_content(App &$a) {
 	$o .= '<ul>';
 
     $mail_disabled = ((function_exists('imap_open') && (! get_config('system','imap_disabled'))) ? 0 : 1);
-	
+
 	if(! $mail_disabled)
 		$o .= '<li>' . '<a target="newmember" href="settings/connectors">' . t('Importing Emails') . '</a><br />' . t('Enter your email access information on your Connector Settings page if you wish to import and interact with friends or mailing lists from your email INBOX') . '</li>' . EOL;
 

--- a/mod/nodeinfo.php
+++ b/mod/nodeinfo.php
@@ -1,13 +1,13 @@
 <?php
 /**
  * @file mod/nodeinfo.php
- * 
+ *
  * Documentation: http://nodeinfo.diaspora.software/schema.html
 */
 
 require_once("include/plugin.php");
 
-function nodeinfo_wellknown(App &$a) {
+function nodeinfo_wellknown(App $a) {
 	if (!get_config("system", "nodeinfo")) {
 		http_status_exit(404);
 		killme();
@@ -20,7 +20,7 @@ function nodeinfo_wellknown(App &$a) {
 	exit;
 }
 
-function nodeinfo_init(App &$a){
+function nodeinfo_init(App $a) {
 	if (!get_config("system", "nodeinfo")) {
 		http_status_exit(404);
 		killme();

--- a/mod/nogroup.php
+++ b/mod/nogroup.php
@@ -4,7 +4,7 @@ require_once('include/Contact.php');
 require_once('include/socgraph.php');
 require_once('include/contact_selectors.php');
 
-function nogroup_init(App &$a) {
+function nogroup_init(App $a) {
 
 	if (! local_user()) {
 		return;
@@ -21,7 +21,7 @@ function nogroup_init(App &$a) {
 }
 
 
-function nogroup_content(App &$a) {
+function nogroup_content(App $a) {
 
 	if (! local_user()) {
 		notice( t('Permission denied.') . EOL);

--- a/mod/noscrape.php
+++ b/mod/noscrape.php
@@ -1,6 +1,6 @@
 <?php
 
-function noscrape_init(App &$a) {
+function noscrape_init(App $a) {
 
 	if($a->argc > 1)
 		$which = $a->argv[1];

--- a/mod/notes.php
+++ b/mod/notes.php
@@ -1,6 +1,6 @@
 <?php
 
-function notes_init(App &$a) {
+function notes_init(App $a) {
 
 	if (! local_user()) {
 		return;
@@ -17,7 +17,7 @@ function notes_init(App &$a) {
 }
 
 
-function notes_content(&$a,$update = false) {
+function notes_content(App $a, $update = false) {
 
 	if (! local_user()) {
 		notice( t('Permission denied.') . EOL);

--- a/mod/notice.php
+++ b/mod/notice.php
@@ -1,7 +1,7 @@
 <?php
 	/* identi.ca -> friendica items permanent-url compatibility */
-	
-	function notice_init(App &$a){
+
+	function notice_init(App $a) {
 		$id = $a->argv[1];
 		$r = q("SELECT user.nickname FROM user LEFT JOIN item ON item.uid=user.uid WHERE item.id=%d",
 				intval($id)

--- a/mod/notifications.php
+++ b/mod/notifications.php
@@ -9,7 +9,7 @@ require_once("include/NotificationsManager.php");
 require_once("include/contact_selectors.php");
 require_once("include/network.php");
 
-function notifications_post(App &$a) {
+function notifications_post(App $a) {
 
 	if (! local_user()) {
 		goaway(z_root());
@@ -65,7 +65,7 @@ function notifications_post(App &$a) {
 	}
 }
 
-function notifications_content(App &$a) {
+function notifications_content(App $a) {
 
 	if (! local_user()) {
 		notice( t('Permission denied.') . EOL);

--- a/mod/notify.php
+++ b/mod/notify.php
@@ -1,7 +1,7 @@
 <?php
 require_once('include/NotificationsManager.php');
 
-function notify_init(App &$a) {
+function notify_init(App $a) {
 	if (! local_user()) {
 		return;
 	}
@@ -12,7 +12,7 @@ function notify_init(App &$a) {
 		$note = $nm->getByID($a->argv[2]);
 		if ($note) {
 			$nm->setSeen($note);
-		
+
 			// The friendica client has problems with the GUID. this is some workaround
 			if ($a->is_friendica_app()) {
 				require_once("include/items.php");
@@ -39,13 +39,13 @@ function notify_init(App &$a) {
 
 }
 
-function notify_content(App &$a) {
+function notify_content(App $a) {
 	if (! local_user()) {
 		return login();
 	}
 
 	$nm = new NotificationsManager();
-	
+
 	$notif_tpl = get_markup_template('notifications.tpl');
 
 	$not_tpl = get_markup_template('notify.tpl');

--- a/mod/oembed.php
+++ b/mod/oembed.php
@@ -1,7 +1,7 @@
 <?php
 require_once("include/oembed.php");
 
-function oembed_content(App &$a){
+function oembed_content(App $a) {
 	// logger('mod_oembed ' . $a->query_string, LOGGER_ALL);
 
 	if ($a->argv[1]=='b2h'){

--- a/mod/oexchange.php
+++ b/mod/oexchange.php
@@ -1,7 +1,7 @@
 <?php
 
 
-function oexchange_init(App &$a) {
+function oexchange_init(App $a) {
 
 	if(($a->argc > 1) && ($a->argv[1] === 'xrd')) {
 		$tpl = get_markup_template('oexchange_xrd.tpl');
@@ -14,7 +14,7 @@ function oexchange_init(App &$a) {
 
 }
 
-function oexchange_content(App &$a) {
+function oexchange_content(App $a) {
 
 	if (! local_user()) {
 		$o = login(false);
@@ -26,13 +26,13 @@ function oexchange_content(App &$a) {
 		return;
 	}
 
-	$url = (((x($_REQUEST,'url')) && strlen($_REQUEST['url'])) 
+	$url = (((x($_REQUEST,'url')) && strlen($_REQUEST['url']))
 		? urlencode(notags(trim($_REQUEST['url']))) : '');
-	$title = (((x($_REQUEST,'title')) && strlen($_REQUEST['title'])) 
+	$title = (((x($_REQUEST,'title')) && strlen($_REQUEST['title']))
 		? '&title=' . urlencode(notags(trim($_REQUEST['title']))) : '');
-	$description = (((x($_REQUEST,'description')) && strlen($_REQUEST['description'])) 
+	$description = (((x($_REQUEST,'description')) && strlen($_REQUEST['description']))
 		? '&description=' . urlencode(notags(trim($_REQUEST['description']))) : '');
-	$tags = (((x($_REQUEST,'tags')) && strlen($_REQUEST['tags'])) 
+	$tags = (((x($_REQUEST,'tags')) && strlen($_REQUEST['tags']))
 		? '&tags=' . urlencode(notags(trim($_REQUEST['tags']))) : '');
 
 	$s = fetch_url(App::get_baseurl() . '/parse_url?f=&url=' . $url . $title . $description . $tags);

--- a/mod/openid.php
+++ b/mod/openid.php
@@ -4,7 +4,7 @@
 require_once('library/openid.php');
 
 
-function openid_content(App &$a) {
+function openid_content(App $a) {
 
 	$noid = get_config('system','no_openid');
 	if($noid)
@@ -47,7 +47,7 @@ function openid_content(App &$a) {
 				require_once('include/security.php');
 				authenticate_success($r[0],true,true);
 
-				// just in case there was no return url set 
+				// just in case there was no return url set
 				// and we fell through
 
 				goaway(z_root());

--- a/mod/opensearch.php
+++ b/mod/opensearch.php
@@ -1,18 +1,18 @@
 <?php
-    function opensearch_content(App &$a) {
-    	
+    function opensearch_content(App $a) {
+
 		$tpl = get_markup_template('opensearch.tpl');
-	
+
 		header("Content-type: application/opensearchdescription+xml");
-	
+
 		$o = replace_macros($tpl, array(
 			'$baseurl' => App::get_baseurl(),
 			'$nodename' => $a->get_hostname(),
 		));
-		
+
 		echo $o;
-		
+
 		killme();
-		
+
 	}
 ?>

--- a/mod/ostatus_subscribe.php
+++ b/mod/ostatus_subscribe.php
@@ -3,7 +3,7 @@
 require_once('include/Scrape.php');
 require_once('include/follow.php');
 
-function ostatus_subscribe_content(App &$a) {
+function ostatus_subscribe_content(App $a) {
 
 	if (! local_user()) {
 		notice( t('Permission denied.') . EOL);

--- a/mod/parse_url.php
+++ b/mod/parse_url.php
@@ -1,9 +1,9 @@
 <?php
 
-/** 
+/**
  * @file mod/parse_url.php
  * @brief The parse_url module
- * 
+ *
  * This module does parse an url for embedable content (audio, video, image files or link)
  * information and does format this information to BBCode or html (this depends
  * on the user settings - default is BBCode output).
@@ -11,15 +11,15 @@
  * (Note: This is not always possible and in some case not useful because
  * the richtext editor doesn't support all kind of html).
  * Otherwise the output will be constructed BBCode.
- * 
- * @see ParseUrl::getSiteinfo() for more information about scraping embeddable content 
+ *
+ * @see ParseUrl::getSiteinfo() for more information about scraping embeddable content
 */
 
 use \Friendica\ParseUrl;
 
 require_once("include/items.php");
 
-function parse_url_content(App &$a) {
+function parse_url_content(App $a) {
 
 	$text = null;
 	$str_tags = "";
@@ -153,20 +153,20 @@ function parse_url_content(App &$a) {
 
 /**
  * @brief Legacy function to call ParseUrl::getSiteinfoCached
- * 
+ *
  * Note: We have moved the function to ParseUrl.php. This function is only for
  * legacy support and will be remove in the future
- * 
+ *
  * @param type $url The url of the page which should be scraped
  * @param type $no_guessing If true the parse doens't search for
  *    preview pictures
  * @param type $do_oembed The false option is used by the function fetch_oembed()
  *    to avoid endless loops
- * 
+ *
  * @return array which contains needed data for embedding
- * 
+ *
  * @see ParseUrl::getSiteinfoCached()
- * 
+ *
  * @todo Remove this function after all Addons has been changed to use
  *    ParseUrl::getSiteinfoCached
  */

--- a/mod/photo.php
+++ b/mod/photo.php
@@ -3,7 +3,7 @@
 require_once('include/security.php');
 require_once('include/Photo.php');
 
-function photo_init(App &$a) {
+function photo_init(App $a) {
 	global $_SERVER;
 
 	$prvcachecontrol = false;

--- a/mod/photos.php
+++ b/mod/photos.php
@@ -10,7 +10,7 @@ require_once('include/tags.php');
 require_once('include/threads.php');
 require_once('include/Probe.php');
 
-function photos_init(App &$a) {
+function photos_init(App $a) {
 
 	if ($a->argc > 1)
 		auto_redir($a, $a->argv[1]);
@@ -112,7 +112,7 @@ function photos_init(App &$a) {
 
 
 
-function photos_post(App &$a) {
+function photos_post(App $a) {
 
 	logger('mod-photos: photos_post: begin' , LOGGER_DEBUG);
 
@@ -945,7 +945,7 @@ function photos_post(App &$a) {
 
 
 
-function photos_content(App &$a) {
+function photos_content(App $a) {
 
 	// URLs:
 	// photos/name
@@ -1307,7 +1307,7 @@ function photos_content(App &$a) {
 
 	}
 
-	/** 
+	/**
 	 * Display one photo
 	 */
 

--- a/mod/poco.php
+++ b/mod/poco.php
@@ -2,7 +2,7 @@
 // See here for a documentation for portable contacts:
 // https://web.archive.org/web/20160405005550/http://portablecontacts.net/draft-spec.html
 
-function poco_init(App &$a) {
+function poco_init(App $a) {
 	require_once("include/bbcode.php");
 
 	$system_mode = false;

--- a/mod/poke.php
+++ b/mod/poke.php
@@ -4,11 +4,11 @@
  *
  * Poke, prod, finger, or otherwise do unspeakable things to somebody - who must be a connection in your address book
  * This function can be invoked with the required arguments (verb and cid and private and possibly parent) silently via ajax or
- * other web request. You must be logged in and connected to a profile. 
+ * other web request. You must be logged in and connected to a profile.
  * If the required arguments aren't present, we'll display a simple form to choose a recipient and a verb.
  * parent is a special argument which let's you attach this activity as a comment to an existing conversation, which
  * may have started with somebody else poking (etc.) somebody, but this isn't necessary. This can be used in the more pokes
- * plugin version to have entire conversations where Alice poked Bob, Bob fingered Alice, Alice hugged Bob, etc.  
+ * plugin version to have entire conversations where Alice poked Bob, Bob fingered Alice, Alice hugged Bob, etc.
  *
  * private creates a private conversation with the recipient. Otherwise your profile's default post privacy is used.
  *
@@ -19,7 +19,7 @@ require_once('include/bbcode.php');
 require_once('include/items.php');
 
 
-function poke_init(App &$a) {
+function poke_init(App $a) {
 
 	if (! local_user()) {
 		return;
@@ -148,7 +148,7 @@ function poke_init(App &$a) {
 
 
 
-function poke_content(App &$a) {
+function poke_content(App $a) {
 
 	if (! local_user()) {
 		notice( t('Permission denied.') . EOL);

--- a/mod/post.php
+++ b/mod/post.php
@@ -9,8 +9,8 @@ require_once('include/salmon.php');
 require_once('include/crypto.php');
 // not yet ready for prime time
 //require_once('include/zot.php');
-	
-function post_post(App &$a) {
+
+function post_post(App $a) {
 
 	$bulk_delivery = false;
 
@@ -19,7 +19,7 @@ function post_post(App &$a) {
 	}
 	else {
 		$nickname = $a->argv[2];
-		$r = q("SELECT * FROM `user` WHERE `nickname` = '%s' 
+		$r = q("SELECT * FROM `user` WHERE `nickname` = '%s'
 				AND `account_expired` = 0 AND `account_removed` = 0 LIMIT 1",
 			dbesc($nickname)
 		);

--- a/mod/pretheme.php
+++ b/mod/pretheme.php
@@ -1,7 +1,7 @@
 <?php
 
-function pretheme_init(App &$a) {
-	
+function pretheme_init(App $a) {
+
 	if($_REQUEST['theme']) {
 		$theme = $_REQUEST['theme'];
 		$info = get_theme_info($theme);

--- a/mod/probe.php
+++ b/mod/probe.php
@@ -2,13 +2,13 @@
 
 require_once('include/Scrape.php');
 
-function probe_content(App &$a) {
+function probe_content(App $a) {
 
 	$o .= '<h3>Probe Diagnostic</h3>';
 
 	$o .= '<form action="probe" method="get">';
 	$o .= 'Lookup address: <input type="text" style="width: 250px;" name="addr" value="' . $_GET['addr'] .'" />';
-	$o .= '<input type="submit" name="submit" value="Submit" /></form>'; 
+	$o .= '<input type="submit" name="submit" value="Submit" /></form>';
 
 	$o .= '<br /><br />';
 

--- a/mod/profile.php
+++ b/mod/profile.php
@@ -4,7 +4,7 @@ require_once('include/contact_widgets.php');
 require_once('include/redir.php');
 
 
-function profile_init(App &$a) {
+function profile_init(App $a) {
 
 	if(! x($a->page,'aside'))
 		$a->page['aside'] = '';
@@ -71,7 +71,7 @@ function profile_init(App &$a) {
 }
 
 
-function profile_content(&$a, $update = 0) {
+function profile_content(App $a, $update = 0) {
 
 	$category = $datequery = $datequery2 = '';
 

--- a/mod/profile_photo.php
+++ b/mod/profile_photo.php
@@ -2,7 +2,7 @@
 
 require_once("include/Photo.php");
 
-function profile_photo_init(App &$a) {
+function profile_photo_init(App $a) {
 
 	if (! local_user()) {
 		return;
@@ -13,7 +13,7 @@ function profile_photo_init(App &$a) {
 }
 
 
-function profile_photo_post(App &$a) {
+function profile_photo_post(App $a) {
 
 	if (! local_user()) {
 		notice ( t('Permission denied.') . EOL );
@@ -174,13 +174,13 @@ function profile_photo_post(App &$a) {
 
 
 if(! function_exists('profile_photo_content')) {
-function profile_photo_content(App &$a) {
+function profile_photo_content(App $a) {
 
 	if (! local_user()) {
 		notice( t('Permission denied.') . EOL );
 		return;
 	}
-	
+
 	$newuser = false;
 
 	if($a->argc == 2 && $a->argv[1] === 'new')
@@ -191,9 +191,9 @@ function profile_photo_content(App &$a) {
 			notice( t('Permission denied.') . EOL );
 			return;
 		};
-		
+
 //		check_form_security_token_redirectOnErr('/profile_photo', 'profile_photo');
-        
+
 		$resource_id = $a->argv[2];
 		//die(":".local_user());
 		$r=q("SELECT * FROM `photo` WHERE `uid` = %d AND `resource-id` = '%s' ORDER BY `scale` ASC",
@@ -246,7 +246,7 @@ function profile_photo_content(App &$a) {
 
 
 	if(! x($a->config,'imagecrop')) {
-	
+
 		$tpl = get_markup_template('profile_photo.tpl');
 
 		$o .= replace_macros($tpl,array(
@@ -284,7 +284,7 @@ function profile_photo_content(App &$a) {
 
 
 if(! function_exists('profile_photo_crop_ui_head')) {
-function profile_photo_crop_ui_head(&$a, $ph){
+function profile_photo_crop_ui_head(App $a, $ph) {
 	$max_length = get_config('system','max_image_length');
 	if (! $max_length) {
 		$max_length = MAX_IMAGE_LENGTH;
@@ -303,11 +303,11 @@ function profile_photo_crop_ui_head(&$a, $ph){
 	}
 
 	$hash = photo_new_resource();
-	
+
 
 	$smallest = 0;
 
-	$r = $ph->store(local_user(), 0 , $hash, $filename, t('Profile Photos'), 0 );	
+	$r = $ph->store(local_user(), 0 , $hash, $filename, t('Profile Photos'), 0 );
 
 	if ($r) {
 		info( t('Image uploaded successfully.') . EOL );
@@ -317,7 +317,7 @@ function profile_photo_crop_ui_head(&$a, $ph){
 
 	if ($width > 640 || $height > 640) {
 		$ph->scaleImage(640);
-		$r = $ph->store(local_user(), 0 , $hash, $filename, t('Profile Photos'), 1 );	
+		$r = $ph->store(local_user(), 0 , $hash, $filename, t('Profile Photos'), 1 );
 
 		if ($r === false) {
 			notice( sprintf(t('Image size reduction [%s] failed.'),"640") . EOL );


### PR DESCRIPTION
Fixes #3039

This is a simple cosmetics change, removing redundant `&` operators, adding `App` type hints, a few spaces in function declaration lines, but nothing more.

I won’t accept any change suggestions (like standards or docs) not directly related with the relevant function declaration lines. The diff was so big that I had to split the changes between 4 other PRs:
- #3075 (view folder)
- #3076 (doc-include folders, boot)
- #3077 (mod folder, 1 out of 3)
- #3079 (mod folder, 3 out of 3)