### PR TITLE
Normalize App parameter declaration (mod folder, 3 out of 3)

### DIFF
--- a/mod/profiles.php
+++ b/mod/profiles.php
@@ -2,7 +2,7 @@
 require_once("include/Contact.php");
 require_once('include/Probe.php');
 
-function profiles_init(App &$a) {
+function profiles_init(App $a) {
 
 	nav_set_selected('profiles');
 
@@ -160,7 +160,7 @@ function profile_clean_keywords($keywords) {
 	return $keywords;
 }
 
-function profiles_post(App &$a) {
+function profiles_post(App $a) {
 
 	if (! local_user()) {
 		notice( t('Permission denied.') . EOL);
@@ -601,7 +601,7 @@ function profile_activity($changed, $value) {
 }
 
 
-function profiles_content(App &$a) {
+function profiles_content(App $a) {
 
 	if (! local_user()) {
 		notice( t('Permission denied.') . EOL);

--- a/mod/profperm.php
+++ b/mod/profperm.php
@@ -1,6 +1,6 @@
 <?php
 
-function profperm_init(App &$a) {
+function profperm_init(App $a) {
 
 	if (! local_user()) {
 		return;
@@ -14,7 +14,7 @@ function profperm_init(App &$a) {
 }
 
 
-function profperm_content(App &$a) {
+function profperm_content(App $a) {
 
 	if (! local_user()) {
 		notice( t('Permission denied') . EOL);
@@ -109,9 +109,9 @@ function profperm_content(App &$a) {
 	}
 
 	$o .= '<div id="prof-update-wrapper">';
-	if($change) 
+	if($change)
 		$o = '';
-	
+
 	$o .= '<div id="prof-members-title">';
 	$o .= '<h3>' . t('Visible To') . '</h3>';
 	$o .= '</div>';

--- a/mod/pubsub.php
+++ b/mod/pubsub.php
@@ -26,7 +26,7 @@ function hub_post_return() {
 
 
 
-function pubsub_init(App &$a) {
+function pubsub_init(App $a) {
 
 	$nick       = (($a->argc > 1) ? notags(trim($a->argv[1])) : '');
 	$contact_id = (($a->argc > 2) ? intval($a->argv[2])       : 0 );
@@ -57,7 +57,7 @@ function pubsub_init(App &$a) {
 
 		$sql_extra = ((strlen($hub_verify)) ? sprintf(" AND `hub-verify` = '%s' ", dbesc($hub_verify)) : '');
 
-		$r = q("SELECT * FROM `contact` WHERE `id` = %d AND `uid` = %d 
+		$r = q("SELECT * FROM `contact` WHERE `id` = %d AND `uid` = %d
 			AND `blocked` = 0 AND `pending` = 0 $sql_extra LIMIT 1",
 			intval($contact_id),
 			intval($owner['uid'])
@@ -75,7 +75,7 @@ function pubsub_init(App &$a) {
 
 		$contact = $r[0];
 
-		// We must initiate an unsubscribe request with a verify_token. 
+		// We must initiate an unsubscribe request with a verify_token.
 		// Don't allow outsiders to unsubscribe us.
 
 		if($hub_mode === 'unsubscribe') {
@@ -98,7 +98,7 @@ function pubsub_init(App &$a) {
 
 require_once('include/security.php');
 
-function pubsub_post(App &$a) {
+function pubsub_post(App $a) {
 
 	$xml = file_get_contents('php://input');
 

--- a/mod/pubsubhubbub.php
+++ b/mod/pubsubhubbub.php
@@ -4,7 +4,7 @@ function post_var($name) {
 	return (x($_POST, $name)) ? notags(trim($_POST[$name])) : '';
 }
 
-function pubsubhubbub_init(App &$a) {
+function pubsubhubbub_init(App $a) {
 	// PuSH subscription must be considered "public" so just block it
 	// if public access isn't enabled.
 	if (get_config('system', 'block_public')) {

--- a/mod/qsearch.php
+++ b/mod/qsearch.php
@@ -1,6 +1,6 @@
 <?php
 
-function qsearch_init(App &$a) {
+function qsearch_init(App $a) {
 
 	if (! local_user()) {
 		killme();

--- a/mod/randprof.php
+++ b/mod/randprof.php
@@ -1,7 +1,7 @@
 <?php
 
 
-function randprof_init(App &$a) {
+function randprof_init(App $a) {
 	require_once('include/Contact.php');
 
 	$x = random_profile();

--- a/mod/receive.php
+++ b/mod/receive.php
@@ -10,7 +10,7 @@ require_once('include/crypto.php');
 require_once('include/diaspora.php');
 
 
-function receive_post(App &$a) {
+function receive_post(App $a) {
 
 
 	$enabled = intval(get_config('system','diaspora_enabled'));

--- a/mod/redir.php
+++ b/mod/redir.php
@@ -1,6 +1,6 @@
 <?php
 
-function redir_init(App &$a) {
+function redir_init(App $a) {
 
 	$url = ((x($_GET,'url')) ? $_GET['url'] : '');
 	$quiet = ((x($_GET,'quiet')) ? '&quiet=1' : '');
@@ -57,9 +57,9 @@ function redir_init(App &$a) {
 			intval(time() + 45)
 		);
 
-		logger('mod_redir: ' . $r[0]['name'] . ' ' . $sec, LOGGER_DEBUG); 
+		logger('mod_redir: ' . $r[0]['name'] . ' ' . $sec, LOGGER_DEBUG);
 		$dest = (($url) ? '&destination_url=' . $url : '');
-		goaway ($r[0]['poll'] . '?dfrn_id=' . $dfrn_id 
+		goaway ($r[0]['poll'] . '?dfrn_id=' . $dfrn_id
 			. '&dfrn_version=' . DFRN_PROTOCOL_VERSION . '&type=profile&sec=' . $sec . $dest . $quiet );
 	}
 

--- a/mod/register.php
+++ b/mod/register.php
@@ -5,7 +5,7 @@ require_once('include/bbcode.php');
 require_once('include/user.php');
 
 if(! function_exists('register_post')) {
-function register_post(App &$a) {
+function register_post(App $a) {
 
 	global $lang;
 
@@ -172,7 +172,7 @@ function register_post(App &$a) {
 
 
 if(! function_exists('register_content')) {
-function register_content(App &$a) {
+function register_content(App $a) {
 
 	// logged in users can register others (people/pages/groups)
 	// even with closed registrations, unless specifically prohibited by site policy.

--- a/mod/regmod.php
+++ b/mod/regmod.php
@@ -97,7 +97,7 @@ function user_deny($hash) {
 
 }
 
-function regmod_content(App &$a) {
+function regmod_content(App $a) {
 
 	global $lang;
 

--- a/mod/removeme.php
+++ b/mod/removeme.php
@@ -1,6 +1,6 @@
 <?php
 
-function removeme_post(App &$a) {
+function removeme_post(App $a) {
 
 	if (! local_user()) {
 		return;
@@ -32,7 +32,7 @@ function removeme_post(App &$a) {
 
 }
 
-function removeme_content(App &$a) {
+function removeme_content(App $a) {
 
 	if (! local_user()) {
 		goaway(z_root());

--- a/mod/repair_ostatus.php
+++ b/mod/repair_ostatus.php
@@ -3,7 +3,7 @@
 require_once('include/Scrape.php');
 require_once('include/follow.php');
 
-function repair_ostatus_content(App &$a) {
+function repair_ostatus_content(App $a) {
 
 	if (! local_user()) {
 		notice( t('Permission denied.') . EOL);

--- a/mod/rsd_xml.php
+++ b/mod/rsd_xml.php
@@ -2,7 +2,7 @@
 
 
 
-function rsd_xml_content(App &$a) {
+function rsd_xml_content(App $a) {
 	header ("Content-Type: text/xml");
 	echo '<?xml version="1.0" encoding="UTF-8"?>
  <rsd version="1.0" xmlns="http://archipelago.phrasewise.com/rsd">

--- a/mod/salmon.php
+++ b/mod/salmon.php
@@ -19,7 +19,7 @@ function salmon_return($val) {
 
 }
 
-function salmon_post(App &$a) {
+function salmon_post(App $a) {
 
 	$xml = file_get_contents('php://input');
 
@@ -156,7 +156,7 @@ function salmon_post(App &$a) {
 		if(get_pconfig($importer['uid'],'system','ostatus_autofriend')) {
 			$result = new_contact($importer['uid'],$author_link);
 			if($result['success']) {
-				$r = q("SELECT * FROM `contact` WHERE `network` = '%s' AND ( `url` = '%s' OR `alias` = '%s') 
+				$r = q("SELECT * FROM `contact` WHERE `network` = '%s' AND ( `url` = '%s' OR `alias` = '%s')
 					AND `uid` = %d LIMIT 1",
 					dbesc(NETWORK_OSTATUS),
 					dbesc($author_link),

--- a/mod/search.php
+++ b/mod/search.php
@@ -43,7 +43,7 @@ function search_saved_searches() {
 }
 
 
-function search_init(App &$a) {
+function search_init(App $a) {
 
 	$search = ((x($_GET,'search')) ? notags(trim(rawurldecode($_GET['search']))) : '');
 
@@ -81,13 +81,13 @@ function search_init(App &$a) {
 
 
 
-function search_post(App &$a) {
+function search_post(App $a) {
 	if(x($_POST,'search'))
 		$a->data['search'] = $_POST['search'];
 }
 
 
-function search_content(App &$a) {
+function search_content(App $a) {
 
 	if((get_config('system','block_public')) && (! local_user()) && (! remote_user())) {
 		notice( t('Public access denied.') . EOL);

--- a/mod/session.php
+++ b/mod/session.php
@@ -1,5 +1,5 @@
 <?php
 
-function session_content(&$a) {
+function session_content(App $a) {
 
 }

--- a/mod/settings.php
+++ b/mod/settings.php
@@ -16,7 +16,7 @@ function get_theme_config_file($theme){
 	return null;
 }
 
-function settings_init(App &$a) {
+function settings_init(App $a) {
 
 	if (! local_user()) {
 		notice( t('Permission denied.') . EOL );
@@ -116,7 +116,7 @@ function settings_init(App &$a) {
 }
 
 
-function settings_post(App &$a) {
+function settings_post(App $a) {
 
 	if (! local_user()) {
 		return;
@@ -654,7 +654,7 @@ function settings_post(App &$a) {
 }
 
 
-function settings_content(App &$a) {
+function settings_content(App $a) {
 
 	$o = '';
 	nav_set_selected('settings');

--- a/mod/share.php
+++ b/mod/share.php
@@ -1,12 +1,12 @@
 <?php
-function share_init(App &$a) {
+function share_init(App $a) {
 
 	$post_id = (($a->argc > 1) ? intval($a->argv[1]) : 0);
 	if((! $post_id) || (! local_user()))
 		killme();
 
-	$r = q("SELECT item.*, contact.network FROM `item` 
-		inner join contact on `item`.`contact-id` = `contact`.`id` 
+	$r = q("SELECT item.*, contact.network FROM `item`
+		inner join contact on `item`.`contact-id` = `contact`.`id`
 		WHERE `item`.`id` = %d AND `item`.`uid` = %d LIMIT 1",
 
 		intval($post_id),

--- a/mod/smilies.php
+++ b/mod/smilies.php
@@ -6,7 +6,7 @@
 
 require_once("include/Smilies.php");
 
-function smilies_content(App &$a) {
+function smilies_content(App $a) {
 	if ($a->argv[1]==="json"){
 		$tmp = Smilies::get_list();
 		$results = array();

--- a/mod/starred.php
+++ b/mod/starred.php
@@ -1,7 +1,7 @@
 <?php
 
 
-function starred_init(App &$a) {
+function starred_init(App $a) {
 
 	require_once("include/threads.php");
 

--- a/mod/statistics_json.php
+++ b/mod/statistics_json.php
@@ -5,7 +5,7 @@
 
 require_once("include/plugin.php");
 
-function statistics_json_init(App &$a) {
+function statistics_json_init(App $a) {
 
         if (!get_config("system", "nodeinfo")) {
                 http_status_exit(404);

--- a/mod/subthread.php
+++ b/mod/subthread.php
@@ -5,7 +5,7 @@ require_once('include/bbcode.php');
 require_once('include/items.php');
 
 
-function subthread_content(App &$a) {
+function subthread_content(App $a) {
 
 	if(! local_user() && ! remote_user()) {
 		return;
@@ -49,7 +49,7 @@ function subthread_content(App &$a) {
 		}
 	}
 
-	// this represents the post owner on this system. 
+	// this represents the post owner on this system.
 
 	$r = q("SELECT `contact`.*, `user`.`nickname` FROM `contact` LEFT JOIN `user` ON `contact`.`uid` = `user`.`uid`
 		WHERE `contact`.`self` = 1 AND `contact`.`uid` = %d LIMIT 1",

--- a/mod/suggest.php
+++ b/mod/suggest.php
@@ -3,7 +3,7 @@
 require_once('include/socgraph.php');
 require_once('include/contact_widgets.php');
 
-function suggest_init(App &$a) {
+function suggest_init(App $a) {
 	if (! local_user()) {
 		return;
 	}
@@ -49,7 +49,7 @@ function suggest_init(App &$a) {
 
 
 
-function suggest_content(App &$a) {
+function suggest_content(App $a) {
 
 	require_once("mod/proxy.php");
 

--- a/mod/tagger.php
+++ b/mod/tagger.php
@@ -5,7 +5,7 @@ require_once('include/bbcode.php');
 require_once('include/items.php');
 
 
-function tagger_content(App &$a) {
+function tagger_content(App $a) {
 
 	if(! local_user() && ! remote_user()) {
 		return;

--- a/mod/tagrm.php
+++ b/mod/tagrm.php
@@ -2,7 +2,7 @@
 
 require_once('include/bbcode.php');
 
-function tagrm_post(App &$a) {
+function tagrm_post(App $a) {
 
 	if (! local_user()) {
 		goaway(App::get_baseurl() . '/' . $_SESSION['photo_return']);
@@ -42,14 +42,14 @@ function tagrm_post(App &$a) {
 
 	info( t('Tag removed') . EOL );
 	goaway(App::get_baseurl() . '/' . $_SESSION['photo_return']);
-	
+
 	// NOTREACHED
 
 }
 
 
 
-function tagrm_content(App &$a) {
+function tagrm_content(App $a) {
 
 	$o = '';
 

--- a/mod/toggle_mobile.php
+++ b/mod/toggle_mobile.php
@@ -1,6 +1,6 @@
 <?php
 
-function toggle_mobile_init(App &$a) {
+function toggle_mobile_init(App $a) {
 
 	if (isset($_GET['off'])) {
 		$_SESSION['show-mobile'] = false;

--- a/mod/uexport.php
+++ b/mod/uexport.php
@@ -1,6 +1,6 @@
 <?php
 
-function uexport_init(App &$a){
+function uexport_init(App $a) {
 	if (! local_user()) {
 		killme();
 	}
@@ -10,7 +10,7 @@ function uexport_init(App &$a){
 }
 
 /// @TODO Change space -> tab where wanted
-function uexport_content(App &$a){
+function uexport_content(App $a) {
 
     if ($a->argc > 1) {
         header("Content-type: application/json");
@@ -124,7 +124,7 @@ function uexport_account($a){
 /**
  * echoes account data and items as separated json, one per line
  */
-function uexport_all(App &$a) {
+function uexport_all(App $a) {
 
 	uexport_account($a);
 	echo "\n";

--- a/mod/uimport.php
+++ b/mod/uimport.php
@@ -6,7 +6,7 @@
 
 require_once("include/uimport.php");
 
-function uimport_post(App &$a) {
+function uimport_post(App $a) {
 	switch($a->config['register_policy']) {
         case REGISTER_OPEN:
             $blocked = 0;
@@ -28,7 +28,7 @@ function uimport_post(App &$a) {
             $verified = 0;
             break;
 	}
-    
+
     if (x($_FILES,'accountfile')){
         /// @TODO Pass $blocked / $verified, send email to admin on REGISTER_APPROVE
         import_account($a, $_FILES['accountfile']);
@@ -36,8 +36,8 @@ function uimport_post(App &$a) {
     }
 }
 
-function uimport_content(App &$a) {
-	
+function uimport_content(App $a) {
+
 	if((! local_user()) && ($a->config['register_policy'] == REGISTER_CLOSED)) {
 		notice("Permission denied." . EOL);
 		return;
@@ -52,8 +52,8 @@ function uimport_content(App &$a) {
 			return;
 		}
 	}
-	
-	
+
+
 	if(x($_SESSION,'theme'))
 		unset($_SESSION['theme']);
 	if(x($_SESSION,'mobile-theme'))

--- a/mod/update_community.php
+++ b/mod/update_community.php
@@ -4,7 +4,7 @@
 
 require_once("mod/community.php");
 
-function update_community_content(App &$a) {
+function update_community_content(App $a) {
 
 	header("Content-type: text/html");
 	echo "<!DOCTYPE html><html><body>\r\n";

--- a/mod/update_display.php
+++ b/mod/update_display.php
@@ -5,7 +5,7 @@
 require_once("mod/display.php");
 require_once("include/group.php");
 
-function update_display_content(App &$a) {
+function update_display_content(App $a) {
 
 	$profile_uid = intval($_GET["p"]);
 

--- a/mod/update_network.php
+++ b/mod/update_network.php
@@ -5,7 +5,7 @@
 require_once("mod/network.php");
 require_once("include/group.php");
 
-function update_network_content(App &$a) {
+function update_network_content(App $a) {
 
 	$profile_uid = intval($_GET["p"]);
 

--- a/mod/update_notes.php
+++ b/mod/update_notes.php
@@ -7,7 +7,7 @@
 
 require_once("mod/notes.php");
 
-function update_notes_content(App &$a) {
+function update_notes_content(App $a) {
 
 	$profile_uid = intval($_GET["p"]);
 

--- a/mod/update_profile.php
+++ b/mod/update_profile.php
@@ -7,7 +7,7 @@
 
 require_once("mod/profile.php");
 
-function update_profile_content(App &$a) {
+function update_profile_content(App $a) {
 
 	$profile_uid = intval($_GET["p"]);
 

--- a/mod/videos.php
+++ b/mod/videos.php
@@ -6,7 +6,7 @@ require_once('include/security.php');
 require_once('include/redir.php');
 
 
-function videos_init(App &$a) {
+function videos_init(App $a) {
 
 	if($a->argc > 1)
 		auto_redir($a, $a->argv[1]);
@@ -102,7 +102,7 @@ function videos_init(App &$a) {
 
 
 
-function videos_post(App &$a) {
+function videos_post(App $a) {
 
 	$owner_uid = $a->data['user']['uid'];
 
@@ -182,7 +182,7 @@ function videos_post(App &$a) {
 
 
 
-function videos_content(App &$a) {
+function videos_content(App $a) {
 
 	// URLs (most aren't currently implemented):
 	// videos/name

--- a/mod/viewcontacts.php
+++ b/mod/viewcontacts.php
@@ -2,7 +2,7 @@
 require_once('include/Contact.php');
 require_once('include/contact_selectors.php');
 
-function viewcontacts_init(App &$a) {
+function viewcontacts_init(App $a) {
 
 	if((get_config('system','block_public')) && (! local_user()) && (! remote_user())) {
 		return;
@@ -29,7 +29,7 @@ function viewcontacts_init(App &$a) {
 }
 
 
-function viewcontacts_content(App &$a) {
+function viewcontacts_content(App $a) {
 	require_once("mod/proxy.php");
 
 	if((get_config('system','block_public')) && (! local_user()) && (! remote_user())) {

--- a/mod/viewsrc.php
+++ b/mod/viewsrc.php
@@ -1,7 +1,7 @@
 <?php
 
 
-function viewsrc_content(App &$a) {
+function viewsrc_content(App $a) {
 
 	if (! local_user()) {
 		notice( t('Access denied.') . EOL);
@@ -16,7 +16,7 @@ function viewsrc_content(App &$a) {
 		return;
 	}
 
-	$r = q("SELECT `item`.`body` FROM `item` 
+	$r = q("SELECT `item`.`body` FROM `item`
 		WHERE `item`.`uid` = %d AND `item`.`visible` = 1 AND `item`.`deleted` = 0
 		and `item`.`moderated` = 0
 		AND `item`.`id` = '%s' LIMIT 1",

--- a/mod/wall_attach.php
+++ b/mod/wall_attach.php
@@ -3,7 +3,7 @@
 require_once('include/attach.php');
 require_once('include/datetime.php');
 
-function wall_attach_post(App &$a) {
+function wall_attach_post(App $a) {
 
 	$r_json = (x($_GET,'response') && $_GET['response']=='json');
 

--- a/mod/wall_upload.php
+++ b/mod/wall_upload.php
@@ -2,7 +2,7 @@
 
 require_once('include/Photo.php');
 
-function wall_upload_post(&$a, $desktopmode = true) {
+function wall_upload_post(App $a, $desktopmode = true) {
 
 	logger("wall upload: starting new upload", LOGGER_DEBUG);
 

--- a/mod/wallmessage.php
+++ b/mod/wallmessage.php
@@ -2,7 +2,7 @@
 
 require_once('include/message.php');
 
-function wallmessage_post(App &$a) {
+function wallmessage_post(App $a) {
 
 	$replyto = get_my_url();
 	if(! $replyto) {
@@ -73,7 +73,7 @@ function wallmessage_post(App &$a) {
 }
 
 
-function wallmessage_content(App &$a) {
+function wallmessage_content(App $a) {
 
 	if(! get_my_url()) {
 		notice( t('Permission denied.') . EOL);
@@ -134,9 +134,9 @@ function wallmessage_content(App &$a) {
 		'$nickname' => $user['nickname'],
 		'$linkurl' => t('Please enter a link URL:')
 	));
-	
 
-	
+
+
 	$tpl = get_markup_template('wallmessage.tpl');
 	$o .= replace_macros($tpl,array(
 		'$header' => t('Send Private Message'),

--- a/mod/webfinger.php
+++ b/mod/webfinger.php
@@ -1,7 +1,7 @@
 <?php
 require_once("include/Probe.php");
 
-function webfinger_content(App &$a) {
+function webfinger_content(App $a) {
 
 	$o .= '<h3>Webfinger Diagnostic</h3>';
 

--- a/mod/xrd.php
+++ b/mod/xrd.php
@@ -2,7 +2,7 @@
 
 require_once('include/crypto.php');
 
-function xrd_init(App &$a) {
+function xrd_init(App $a) {
 
 	$uri = urldecode(notags(trim($_GET['uri'])));
 


### PR DESCRIPTION
Fixes #3039

This is a simple cosmetics change, removing redundant `&` operators, adding `App` type hints, a few spaces in function declaration lines, but nothing more.

I won’t accept any change suggestions (like standards or docs) not directly related with the relevant function declaration lines. The diff was so big that I had to split the changes between 4 other PRs:
- #3075 (view folder)
- #3076 (doc-include folders, boot)
- #3077 (mod folder, 1 out of 3)
- #3078 (mod folder, 2 out of 3)