### PR TITLE
Download limit for fetching data via "z_fetch_url"

### DIFF
--- a/doc/htconfig.md
+++ b/doc/htconfig.md
@@ -25,6 +25,7 @@ Example: To set the directory value please add this line to your .htconfig.php:
 * **allowed_link_protocols** (Array) - Allowed protocols in links URLs, add at your own risk. http is always allowed.
 * **birthday_input_format** - Default value is "ymd".
 * **block_local_dir** (Boolean) - Blocks the access to the directory of the local users.
+* **curl_range_bytes** - Maximum number of bytes that should be fetched. Default is 0, which mean "no limit".
 * **dbclean** (Boolean) - Enable the automatic database cleanup process
 * **default_service_class** -
 * **delivery_batch_count** - Number of deliveries per process. Default value is 1. (Disabled when using the worker)

--- a/include/network.php
+++ b/include/network.php
@@ -4,6 +4,9 @@
  * @file include/network.php
  */
 
+use \Friendica\Core\Config;
+use \Friendica\Core\PConfig;
+
 require_once("include/xml.php");
 require_once('include/Probe.php');
 
@@ -93,7 +96,10 @@ function z_fetch_url($url,$binary = false, &$redirects = 0, $opts=array()) {
 	@curl_setopt($ch, CURLOPT_RETURNTRANSFER,true);
 	@curl_setopt($ch, CURLOPT_USERAGENT, $a->get_useragent());
 
-
+	$range = intval(Config::get('system', 'curl_range_bytes', 0));
+	if ($range > 0) {
+		@curl_setopt($ch, CURLOPT_RANGE, '0-'.$range);
+	}
 
 	if(x($opts,'headers')){
 		@curl_setopt($ch, CURLOPT_HTTPHEADER, $opts['headers']);

--- a/mod/oexchange.php
+++ b/mod/oexchange.php
@@ -1,17 +1,14 @@
 <?php
 
-
 function oexchange_init(App &$a) {
 
-	if(($a->argc > 1) && ($a->argv[1] === 'xrd')) {
+	if (($a->argc > 1) && ($a->argv[1] === 'xrd')) {
 		$tpl = get_markup_template('oexchange_xrd.tpl');
 
 		$o = replace_macros($tpl, array('$base' => App::get_baseurl()));
 		echo $o;
 		killme();
 	}
-
-
 }
 
 function oexchange_content(App &$a) {
@@ -26,19 +23,20 @@ function oexchange_content(App &$a) {
 		return;
 	}
 
-	$url = (((x($_REQUEST,'url')) && strlen($_REQUEST['url'])) 
+	$url = (((x($_REQUEST,'url')) && strlen($_REQUEST['url']))
 		? urlencode(notags(trim($_REQUEST['url']))) : '');
-	$title = (((x($_REQUEST,'title')) && strlen($_REQUEST['title'])) 
+	$title = (((x($_REQUEST,'title')) && strlen($_REQUEST['title']))
 		? '&title=' . urlencode(notags(trim($_REQUEST['title']))) : '');
-	$description = (((x($_REQUEST,'description')) && strlen($_REQUEST['description'])) 
+	$description = (((x($_REQUEST,'description')) && strlen($_REQUEST['description']))
 		? '&description=' . urlencode(notags(trim($_REQUEST['description']))) : '');
-	$tags = (((x($_REQUEST,'tags')) && strlen($_REQUEST['tags'])) 
+	$tags = (((x($_REQUEST,'tags')) && strlen($_REQUEST['tags']))
 		? '&tags=' . urlencode(notags(trim($_REQUEST['tags']))) : '');
 
 	$s = fetch_url(App::get_baseurl() . '/parse_url?f=&url=' . $url . $title . $description . $tags);
 
-	if(! strlen($s))
+	if (! strlen($s)) {
 		return;
+	}
 
 	require_once('include/html2bbcode.php');
 
@@ -52,7 +50,4 @@ function oexchange_content(App &$a) {
 	$_REQUEST = $post;
 	require_once('mod/item.php');
 	item_post($a);
-
 }
-
-

--- a/mod/uexport.php
+++ b/mod/uexport.php
@@ -12,113 +12,119 @@ function uexport_init(App &$a){
 /// @TODO Change space -> tab where wanted
 function uexport_content(App &$a){
 
-    if ($a->argc > 1) {
-        header("Content-type: application/json");
-        header('Content-Disposition: attachment; filename="'.$a->user['nickname'].'.'.$a->argv[1].'"');
-        switch($a->argv[1]) {
-            case "backup": uexport_all($a); killme(); break;
-            case "account": uexport_account($a); killme(); break;
-            default:
-                killme();
-        }
-    }
+	if ($a->argc > 1) {
+		header("Content-type: application/json");
+		header('Content-Disposition: attachment; filename="'.$a->user['nickname'].'.'.$a->argv[1].'"');
+		switch($a->argv[1]) {
+			case "backup":
+				uexport_all($a);
+				killme();
+				break;
+			case "account":
+				uexport_account($a);
+				killme();
+				break;
+			default:
+				killme();
+		}
+	}
 
-    /**
-      * options shown on "Export personal data" page
-      * list of array( 'link url', 'link text', 'help text' )
-      */
-    $options = array(
-            array('uexport/account',t('Export account'),t('Export your account info and contacts. Use this to make a backup of your account and/or to move it to another server.')),
-            array('uexport/backup',t('Export all'),t('Export your accout info, contacts and all your items as json. Could be a very big file, and could take a lot of time. Use this to make a full backup of your account (photos are not exported)')),
-    );
-    call_hooks('uexport_options', $options);
+	/**
+	 * options shown on "Export personal data" page
+	 * list of array( 'link url', 'link text', 'help text' )
+	 */
+	$options = array(
+		array('uexport/account',t('Export account'),t('Export your account info and contacts. Use this to make a backup of your account and/or to move it to another server.')),
+		array('uexport/backup',t('Export all'),t('Export your accout info, contacts and all your items as json. Could be a very big file, and could take a lot of time. Use this to make a full backup of your account (photos are not exported)')),
+	);
+	call_hooks('uexport_options', $options);
 
-    $tpl = get_markup_template("uexport.tpl");
-    return replace_macros($tpl, array(
-        '$baseurl' => App::get_baseurl(),
-        '$title' => t('Export personal data'),
-        '$options' => $options
-    ));
-
-
+	$tpl = get_markup_template("uexport.tpl");
+	return replace_macros($tpl, array(
+		'$baseurl' => App::get_baseurl(),
+		'$title' => t('Export personal data'),
+		'$options' => $options
+	));
 }
 
 function _uexport_multirow($query) {
 	$result = array();
 	$r = q($query);
-//	if (dbm::is_result($r)) {
-	if ($r){
+	if (dbm::is_result($r)) {
 		foreach($r as $rr){
-            $p = array();
-			foreach($rr as $k => $v)
+			$p = array();
+			foreach($rr as $k => $v) {
 				$p[$k] = $v;
-            $result[] = $p;
-        }
+			}
+			$result[] = $p;
+		}
 	}
-    return $result;
+	return $result;
 }
 
 function _uexport_row($query) {
 	$result = array();
 	$r = q($query);
-	if ($r) {
-		foreach($r as $rr)
-			foreach($rr as $k => $v)
+	if (dbm::is_result($r)) {
+		foreach($r as $rr) {
+			foreach($rr as $k => $v) {
 				$result[$k] = $v;
-
+			}
+		}
 	}
-    return $result;
+	return $result;
 }
 
 
 function uexport_account($a){
 
 	$user = _uexport_row(
-        sprintf( "SELECT * FROM `user` WHERE `uid` = %d LIMIT 1", intval(local_user()) )
+		sprintf( "SELECT * FROM `user` WHERE `uid` = %d LIMIT 1", intval(local_user()) )
 	);
 
 	$contact = _uexport_multirow(
-        sprintf( "SELECT * FROM `contact` WHERE `uid` = %d ",intval(local_user()) )
+		sprintf( "SELECT * FROM `contact` WHERE `uid` = %d ",intval(local_user()) )
 	);
 
 
 	$profile =_uexport_multirow(
-        sprintf( "SELECT * FROM `profile` WHERE `uid` = %d ", intval(local_user()) )
+		sprintf( "SELECT * FROM `profile` WHERE `uid` = %d ", intval(local_user()) )
 	);
 
-    $photo = _uexport_multirow(
-        sprintf( "SELECT * FROM `photo` WHERE uid = %d AND profile = 1", intval(local_user()) )
-    );
-    foreach ($photo as &$p) $p['data'] = bin2hex($p['data']);
+	$photo = _uexport_multirow(
+		sprintf( "SELECT * FROM `photo` WHERE uid = %d AND profile = 1", intval(local_user()) )
+	);
+	foreach ($photo as &$p) {
+		$p['data'] = bin2hex($p['data']);
+	}
 
-    $pconfig = _uexport_multirow(
-        sprintf( "SELECT * FROM `pconfig` WHERE uid = %d",intval(local_user()) )
-    );
+	$pconfig = _uexport_multirow(
+		sprintf( "SELECT * FROM `pconfig` WHERE uid = %d",intval(local_user()) )
+	);
 
-    $group = _uexport_multirow(
-        sprintf( "SELECT * FROM `group` WHERE uid = %d",intval(local_user()) )
-    );
+	$group = _uexport_multirow(
+		sprintf( "SELECT * FROM `group` WHERE uid = %d",intval(local_user()) )
+	);
 
-    $group_member = _uexport_multirow(
-        sprintf( "SELECT * FROM `group_member` WHERE uid = %d",intval(local_user()) )
-    );
+	$group_member = _uexport_multirow(
+		sprintf( "SELECT * FROM `group_member` WHERE uid = %d",intval(local_user()) )
+	);
 
 	$output = array(
-        'version' => FRIENDICA_VERSION,
-        'schema' => DB_UPDATE_VERSION,
-        'baseurl' => App::get_baseurl(),
-        'user' => $user,
-        'contact' => $contact,
-        'profile' => $profile,
-        'photo' => $photo,
-        'pconfig' => $pconfig,
-        'group' => $group,
-        'group_member' => $group_member,
-    );
+		'version' => FRIENDICA_VERSION,
+		'schema' => DB_UPDATE_VERSION,
+		'baseurl' => App::get_baseurl(),
+		'user' => $user,
+		'contact' => $contact,
+		'profile' => $profile,
+		'photo' => $photo,
+		'pconfig' => $pconfig,
+		'group' => $group,
+		'group_member' => $group_member,
+	);
 
-    //echo "<pre>"; var_dump(json_encode($output)); killme();
+	//echo "<pre>"; var_dump(json_encode($output)); killme();
 	echo json_encode($output);
-
 }
 
 /**
@@ -132,12 +138,12 @@ function uexport_all(App &$a) {
 	$r = q("SELECT count(*) as `total` FROM `item` WHERE `uid` = %d ",
 		intval(local_user())
 	);
-	if (dbm::is_result($r))
+	if (dbm::is_result($r)) {
 		$total = $r[0]['total'];
-
+	}
 	// chunk the output to avoid exhausting memory
 
-	for($x = 0; $x < $total; $x += 500) {
+	for ($x = 0; $x < $total; $x += 500) {
 		$item = array();
 		$r = q("SELECT * FROM `item` WHERE `uid` = %d LIMIT %d, %d",
 			intval(local_user()),
@@ -153,5 +159,4 @@ function uexport_all(App &$a) {
 		$output = array('item' => $r);
 		echo json_encode($output)."\n";
 	}
-
 }

--- a/mod/uimport.php
+++ b/mod/uimport.php
@@ -8,67 +8,68 @@ require_once("include/uimport.php");
 
 function uimport_post(App &$a) {
 	switch($a->config['register_policy']) {
-        case REGISTER_OPEN:
-            $blocked = 0;
-            $verified = 1;
-            break;
+	case REGISTER_OPEN:
+		$blocked = 0;
+		$verified = 1;
+		break;
 
-        case REGISTER_APPROVE:
-            $blocked = 1;
-            $verified = 0;
-            break;
+	case REGISTER_APPROVE:
+		$blocked = 1;
+		$verified = 0;
+		break;
 
-        default:
-        case REGISTER_CLOSED:
-            if((! x($_SESSION,'authenticated') && (! x($_SESSION,'administrator')))) {
-                notice( t('Permission denied.') . EOL );
-                return;
-            }
-            $blocked = 1;
-            $verified = 0;
-            break;
+	default:
+	case REGISTER_CLOSED:
+		if ((! x($_SESSION,'authenticated') && (! x($_SESSION,'administrator')))) {
+			notice( t('Permission denied.') . EOL );
+			return;
+		}
+		$blocked = 1;
+		$verified = 0;
+		break;
 	}
-    
-    if (x($_FILES,'accountfile')){
-        /// @TODO Pass $blocked / $verified, send email to admin on REGISTER_APPROVE
-        import_account($a, $_FILES['accountfile']);
-        return;
-    }
+
+	if (x($_FILES,'accountfile')){
+		/// @TODO Pass $blocked / $verified, send email to admin on REGISTER_APPROVE
+		import_account($a, $_FILES['accountfile']);
+		return;
+	}
 }
 
 function uimport_content(App &$a) {
-	
-	if((! local_user()) && ($a->config['register_policy'] == REGISTER_CLOSED)) {
+
+	if ((! local_user()) && ($a->config['register_policy'] == REGISTER_CLOSED)) {
 		notice("Permission denied." . EOL);
 		return;
 	}
 
 	$max_dailies = intval(get_config('system','max_daily_registrations'));
-	if($max_dailies) {
+	if ($max_dailies) {
 		$r = q("select count(*) as total from user where register_date > UTC_TIMESTAMP - INTERVAL 1 day");
-		if($r && $r[0]['total'] >= $max_dailies) {
+		if ($r && $r[0]['total'] >= $max_dailies) {
 			logger('max daily registrations exceeded.');
 			notice( t('This site has exceeded the number of allowed daily account registrations. Please try again tomorrow.') . EOL);
 			return;
 		}
 	}
-	
-	
-	if(x($_SESSION,'theme'))
+
+
+	if (x($_SESSION,'theme')) {
 		unset($_SESSION['theme']);
-	if(x($_SESSION,'mobile-theme'))
+	}
+	if (x($_SESSION,'mobile-theme')) {
 		unset($_SESSION['mobile-theme']);
+	}
 
-
-    $tpl = get_markup_template("uimport.tpl");
-    return replace_macros($tpl, array(
-        '$regbutt' => t('Import'),
-        '$import' => array(
-            'title' => t("Move account"),
-			'intro' => t("You can import an account from another Friendica server."),
-			'instruct' => t("You need to export your account from the old server and upload it here. We will recreate your old account here with all your contacts. We will try also to inform your friends that you moved here."),
-			'warn' => t("This feature is experimental. We can't import contacts from the OStatus network (GNU Social/Statusnet) or from Diaspora"),
-            'field' => array('accountfile', t('Account file'),'<input id="id_accountfile" name="accountfile" type="file">', t('To export your account, go to "Settings->Export your personal data" and select "Export account"')),
-        ),
-    ));
+	$tpl = get_markup_template("uimport.tpl");
+	return replace_macros($tpl, array(
+		'$regbutt' => t('Import'),
+		'$import' => array(
+		'title' => t("Move account"),
+		'intro' => t("You can import an account from another Friendica server."),
+		'instruct' => t("You need to export your account from the old server and upload it here. We will recreate your old account here with all your contacts. We will try also to inform your friends that you moved here."),
+		'warn' => t("This feature is experimental. We can't import contacts from the OStatus network (GNU Social/Statusnet) or from Diaspora"),
+		'field' => array('accountfile', t('Account file'),'<input id="id_accountfile" name="accountfile" type="file">', t('To export your account, go to "Settings->Export your personal data" and select "Export account"')),
+		),
+	));
 }


### PR DESCRIPTION
Currently we fetch the data via "z_fetch_url" in their whole length. But if we download a too large file the memory will blow up. So we now can define a limit. I haven't added a visible setting since we should play with it a while.

The real code changes are only in "network.php". The other files are only some formatting stuff (where I didn't wanted to do a own pull request for).