### PR TITLE
Rewrites/coding convention

### DIFF
--- a/include/dfrn.php
+++ b/include/dfrn.php
@@ -637,18 +637,24 @@ class dfrn {
 			$entry = $doc->createElement($element);
 
 			$r = parse_xml_string($activity, false);
-			if(!$r)
+			if (!$r) {
 				return false;
-			if($r->type)
+			}
+			if ($r->type) {
 				xml::add_element($doc, $entry, "activity:object-type", $r->type);
-			if($r->id)
+			}
+			if ($r->id) {
 				xml::add_element($doc, $entry, "id", $r->id);
-			if($r->title)
+			}
+			if ($r->title) {
 				xml::add_element($doc, $entry, "title", $r->title);
-			if($r->link) {
-				if(substr($r->link,0,1) == '<') {
-					if(strstr($r->link,'&') && (! strstr($r->link,'&amp;')))
+			}
+
+			if ($r->link) {
+				if (substr($r->link,0,1) == '<') {
+					if (strstr($r->link,'&') && (! strstr($r->link,'&amp;'))) {
 						$r->link = str_replace('&','&amp;', $r->link);
+					}
 
 					$r->link = preg_replace('/\<link(.*?)\"\>/','<link$1"/>',$r->link);
 
@@ -657,8 +663,9 @@ class dfrn {
 					if (is_object($data)) {
 						foreach ($data->link AS $link) {
 							$attributes = array();
-							foreach ($link->attributes() AS $parameter => $value)
+							foreach ($link->attributes() AS $parameter => $value) {
 								$attributes[$parameter] = $value;
+							}
 							xml::add_element($doc, $entry, "link", "", $attributes);
 						}
 					}
@@ -667,8 +674,9 @@ class dfrn {
 					xml::add_element($doc, $entry, "link", "", $attributes);
 				}
 			}
-			if($r->content)
+			if ($r->content) {
 				xml::add_element($doc, $entry, "content", bbcode($r->content), array("type" => "html"));
+			}
 
 			return $entry;
 		}
@@ -687,20 +695,22 @@ class dfrn {
 	 */
 	private function get_attachment($doc, $root, $item) {
 		$arr = explode('[/attach],',$item['attach']);
-		if(count($arr)) {
-			foreach($arr as $r) {
+		if (count($arr)) {
+			foreach ($arr as $r) {
 				$matches = false;
 				$cnt = preg_match('|\[attach\]href=\"(.*?)\" length=\"(.*?)\" type=\"(.*?)\" title=\"(.*?)\"|',$r,$matches);
-				if($cnt) {
+				if ($cnt) {
 					$attributes = array("rel" => "enclosure",
 							"href" => $matches[1],
 							"type" => $matches[3]);
 
-					if(intval($matches[2]))
+					if (intval($matches[2])) {
 						$attributes["length"] = intval($matches[2]);
+					}
 
-					if(trim($matches[4]) != "")
+					if (trim($matches[4]) != "") {
 						$attributes["title"] = trim($matches[4]);
+					}
 
 					xml::add_element($doc, $root, "link", "", $attributes);
 				}
@@ -724,20 +734,22 @@ class dfrn {
 
 		$mentioned = array();
 
-		if(!$item['parent'])
+		if (!$item['parent']) {
 			return;
+		}
 
-		if($item['deleted']) {
+		if ($item['deleted']) {
 			$attributes = array("ref" => $item['uri'], "when" => datetime_convert('UTC','UTC',$item['edited'] . '+00:00',ATOM_TIME));
 			return xml::create_element($doc, "at:deleted-entry", "", $attributes);
 		}
 
 		$entry = $doc->createElement("entry");
 
-		if($item['allow_cid'] || $item['allow_gid'] || $item['deny_cid'] || $item['deny_gid'])
+		if ($item['allow_cid'] || $item['allow_gid'] || $item['deny_cid'] || $item['deny_gid']) {
 			$body = fix_private_photos($item['body'],$owner['uid'],$item,$cid);
-		else
+		} else {
 			$body = $item['body'];
+		}
 
 		// Remove the abstract element. It is only locally important.
 		$body = remove_abstract($body);
@@ -745,8 +757,9 @@ class dfrn {
 		if ($type == 'html') {
 			$htmlbody = $body;
 
-			if ($item['title'] != "")
+			if ($item['title'] != "") {
 				$htmlbody = "[b]".$item['title']."[/b]\n\n".$htmlbody;
+			}
 
 			$htmlbody = bbcode($htmlbody, false, false, 7);
 		}
@@ -757,7 +770,7 @@ class dfrn {
 		$dfrnowner = self::add_entry_author($doc, "dfrn:owner", $item["owner-link"], $item);
 		$entry->appendChild($dfrnowner);
 
-		if(($item['parent'] != $item['id']) || ($item['parent-uri'] !== $item['uri']) || (($item['thr-parent'] !== '') && ($item['thr-parent'] !== $item['uri']))) {
+		if (($item['parent'] != $item['id']) || ($item['parent-uri'] !== $item['uri']) || (($item['thr-parent'] !== '') && ($item['thr-parent'] !== $item['uri']))) {
 			$parent = q("SELECT `guid` FROM `item` WHERE `id` = %d", intval($item["parent"]));
 			$parent_item = (($item['thr-parent']) ? $item['thr-parent'] : $item['parent-uri']);
 			$attributes = array("ref" => $parent_item, "type" => "text/html",
@@ -785,26 +798,33 @@ class dfrn {
 
 		// "comment-allow" is some old fashioned stuff for old Friendica versions.
 		// It is included in the rewritten code for completeness
-		if ($comment)
+		if ($comment) {
 			xml::add_element($doc, $entry, "dfrn:comment-allow", intval($item['last-child']));
+		}
 
-		if($item['location'])
+		if ($item['location']) {
 			xml::add_element($doc, $entry, "dfrn:location", $item['location']);
+		}
 
-		if($item['coord'])
+		if ($item['coord']) {
 			xml::add_element($doc, $entry, "georss:point", $item['coord']);
+		}
 
-		if(($item['private']) || strlen($item['allow_cid']) || strlen($item['allow_gid']) || strlen($item['deny_cid']) || strlen($item['deny_gid']))
+		if (($item['private']) || strlen($item['allow_cid']) || strlen($item['allow_gid']) || strlen($item['deny_cid']) || strlen($item['deny_gid'])) {
 			xml::add_element($doc, $entry, "dfrn:private", (($item['private']) ? $item['private'] : 1));
+		}
 
-		if($item['extid'])
+		if ($item['extid']) {
 			xml::add_element($doc, $entry, "dfrn:extid", $item['extid']);
+		}
 
-		if($item['bookmark'])
+		if ($item['bookmark']) {
 			xml::add_element($doc, $entry, "dfrn:bookmark", "true");
+		}
 
-		if($item['app'])
+		if ($item['app']) {
 			xml::add_element($doc, $entry, "statusnet:notice_info", "", array("local_id" => $item['id'], "source" => $item['app']));
+		}
 
 		xml::add_element($doc, $entry, "dfrn:diaspora_guid", $item["guid"]);
 
@@ -817,46 +837,56 @@ class dfrn {
 
 		xml::add_element($doc, $entry, "activity:verb", construct_verb($item));
 
-		if ($item['object-type'] != "")
+		if ($item['object-type'] != "") {
 			xml::add_element($doc, $entry, "activity:object-type", $item['object-type']);
-		elseif ($item['id'] == $item['parent'])
+		} elseif ($item['id'] == $item['parent']) {
 			xml::add_element($doc, $entry, "activity:object-type", ACTIVITY_OBJ_NOTE);
-		else
+		} else {
 			xml::add_element($doc, $entry, "activity:object-type", ACTIVITY_OBJ_COMMENT);
+		}
 
 		$actobj = self::create_activity($doc, "activity:object", $item['object']);
-		if ($actobj)
+		if ($actobj) {
 			$entry->appendChild($actobj);
+		}
 
 		$actarg = self::create_activity($doc, "activity:target", $item['target']);
-		if ($actarg)
+		if ($actarg) {
 			$entry->appendChild($actarg);
+		}
 
 		$tags = item_getfeedtags($item);
 
-		if(count($tags)) {
-			foreach($tags as $t)
-				if (($type != 'html') OR ($t[0] != "@"))
+		if( count($tags)) {
+			foreach ($tags as $t) {
+				if (($type != 'html') OR ($t[0] != "@")) {
 					xml::add_element($doc, $entry, "category", "", array("scheme" => "X-DFRN:".$t[0].":".$t[1], "term" => $t[2]));
+				}
+			}
 		}
 
-		if(count($tags))
-			foreach($tags as $t)
-				if ($t[0] == "@")
+		if (count($tags)) {
+			foreach($tags as $t) {
+				if ($t[0] == "@") {
 					$mentioned[$t[1]] = $t[1];
+				}
+			}
+		}
 
 		foreach ($mentioned AS $mention) {
 			$r = q("SELECT `forum`, `prv` FROM `contact` WHERE `uid` = %d AND `nurl` = '%s'",
 				intval($owner["uid"]),
 				dbesc(normalise_link($mention)));
-			if ($r[0]["forum"] OR $r[0]["prv"])
+
+			if ($r[0]["forum"] OR $r[0]["prv"]) {
 				xml::add_element($doc, $entry, "link", "", array("rel" => "mentioned",
 											"ostatus:object-type" => ACTIVITY_OBJ_GROUP,
 											"href" => $mention));
-			else
+			} else {
 				xml::add_element($doc, $entry, "link", "", array("rel" => "mentioned",
 											"ostatus:object-type" => ACTIVITY_OBJ_PERSON,
 											"href" => $mention));
+			}
 		}
 
 		self::get_attachment($doc, $entry, $item);
@@ -880,16 +910,20 @@ class dfrn {
 
 		$idtosend = $orig_id = (($contact['dfrn-id']) ? $contact['dfrn-id'] : $contact['issued-id']);
 
-		if($contact['duplex'] && $contact['dfrn-id'])
+		if ($contact['duplex'] && $contact['dfrn-id']) {
 			$idtosend = '0:' . $orig_id;
-		if($contact['duplex'] && $contact['issued-id'])
+		}
+		if ($contact['duplex'] && $contact['issued-id']) {
 			$idtosend = '1:' . $orig_id;
-
+		}
 
 		$rino = get_config('system','rino_encrypt');
 		$rino = intval($rino);
+
 		// use RINO1 if mcrypt isn't installed and RINO2 was selected
-		if ($rino==2 and !function_exists('mcrypt_create_iv')) $rino=1;
+		if ($rino==2 and !function_exists('mcrypt_create_iv')) {
+			$rino=1;
+		}
 
 		logger("Local rino version: ". $rino, LOGGER_DEBUG);
 
@@ -916,15 +950,17 @@ class dfrn {
 		$xml = fetch_url($url);
 
 		$curl_stat = $a->get_curl_code();
-		if(! $curl_stat)
+		if (! $curl_stat) {
 			return(-1); // timed out
+		}
 
 		logger('dfrn_deliver: ' . $xml, LOGGER_DATA);
 
-		if(! $xml)
+		if (! $xml) {
 			return 3;
+		}
 
-		if(strpos($xml,'<?xml') === false) {
+		if (strpos($xml,'<?xml') === false) {
 			logger('dfrn_deliver: no valid XML returned');
 			logger('dfrn_deliver: returned XML: ' . $xml, LOGGER_DATA);
 			return 3;
@@ -932,8 +968,9 @@ class dfrn {
 
 		$res = parse_xml_string($xml);
 
-		if((intval($res->status) != 0) || (! strlen($res->challenge)) || (! strlen($res->dfrn_id)))
+		if ((intval($res->status) != 0) || (! strlen($res->challenge)) || (! strlen($res->dfrn_id))) {
 			return (($res->status) ? $res->status : 3);
+		}
 
 		$postvars     = array();
 		$sent_dfrn_id = hex2bin((string) $res->dfrn_id);
@@ -945,13 +982,14 @@ class dfrn {
 
 		logger("Remote rino version: ".$rino_remote_version." for ".$contact["url"], LOGGER_DEBUG);
 
-		if($owner['page-flags'] == PAGE_PRVGROUP)
+		if ($owner['page-flags'] == PAGE_PRVGROUP) {
 			$page = 2;
+		}
 
 		$final_dfrn_id = '';
 
-		if($perm) {
-			if((($perm == 'rw') && (! intval($contact['writable'])))
+		if ($perm) {
+			if ((($perm == 'rw') && (! intval($contact['writable'])))
 				|| (($perm == 'r') && (intval($contact['writable'])))) {
 				q("update contact set writable = %d where id = %d",
 					intval(($perm == 'rw') ? 1 : 0),
@@ -961,7 +999,7 @@ class dfrn {
 			}
 		}
 
-		if(($contact['duplex'] && strlen($contact['pubkey']))
+		if (($contact['duplex'] && strlen($contact['pubkey']))
 			|| ($owner['page-flags'] == PAGE_COMMUNITY && strlen($contact['pubkey']))
 			|| ($contact['rel'] == CONTACT_IS_SHARING && strlen($contact['pubkey']))) {
 			openssl_public_decrypt($sent_dfrn_id,$final_dfrn_id,$contact['pubkey']);
@@ -973,10 +1011,11 @@ class dfrn {
 
 		$final_dfrn_id = substr($final_dfrn_id, 0, strpos($final_dfrn_id, '.'));
 
-		if(strpos($final_dfrn_id,':') == 1)
+		if (strpos($final_dfrn_id,':') == 1) {
 			$final_dfrn_id = substr($final_dfrn_id,2);
+		}
 
-		if($final_dfrn_id != $orig_id) {
+		if ($final_dfrn_id != $orig_id) {
 			logger('dfrn_deliver: wrong dfrn_id.');
 			// did not decode properly - cannot trust this site
 			return 3;
@@ -984,11 +1023,12 @@ class dfrn {
 
 		$postvars['dfrn_id']      = $idtosend;
 		$postvars['dfrn_version'] = DFRN_PROTOCOL_VERSION;
-		if($dissolve)
+		if ($dissolve) {
 			$postvars['dissolve'] = '1';
+		}
 
 
-		if((($contact['rel']) && ($contact['rel'] != CONTACT_IS_SHARING) && (! $contact['blocked'])) || ($owner['page-flags'] == PAGE_COMMUNITY)) {
+		if ((($contact['rel']) && ($contact['rel'] != CONTACT_IS_SHARING) && (! $contact['blocked'])) || ($owner['page-flags'] == PAGE_COMMUNITY)) {
 			$postvars['data'] = $atom;
 			$postvars['perm'] = 'rw';
 		} else {
@@ -998,11 +1038,12 @@ class dfrn {
 
 		$postvars['ssl_policy'] = $ssl_policy;
 
-		if($page)
+		if ($page) {
 			$postvars['page'] = $page;
+		}
 
 
-		if($rino>0 && $rino_remote_version>0 && (! $dissolve)) {
+		if ($rino>0 && $rino_remote_version>0 && (! $dissolve)) {
 			logger('rino version: '. $rino_remote_version);
 
 			switch($rino_remote_version) {
@@ -1040,23 +1081,25 @@ class dfrn {
 			$postvars['rino'] = $rino_remote_version;
 			$postvars['data'] = bin2hex($data);
 
-			#logger('rino: sent key = ' . $key, LOGGER_DEBUG);
+			//logger('rino: sent key = ' . $key, LOGGER_DEBUG);
 
 
-			if($dfrn_version >= 2.1) {
-				if(($contact['duplex'] && strlen($contact['pubkey']))
+			if ($dfrn_version >= 2.1) {
+				if (($contact['duplex'] && strlen($contact['pubkey'])) {
 					|| ($owner['page-flags'] == PAGE_COMMUNITY && strlen($contact['pubkey']))
 					|| ($contact['rel'] == CONTACT_IS_SHARING && strlen($contact['pubkey'])))
 
 					openssl_public_encrypt($key,$postvars['key'],$contact['pubkey']);
-				else
+				} else {
 					openssl_private_encrypt($key,$postvars['key'],$contact['prvkey']);
+				}
 
 			} else {
-				if(($contact['duplex'] && strlen($contact['prvkey'])) || ($owner['page-flags'] == PAGE_COMMUNITY))
+				if (($contact['duplex'] && strlen($contact['prvkey'])) || ($owner['page-flags'] == PAGE_COMMUNITY)) {
 					openssl_private_encrypt($key,$postvars['key'],$contact['prvkey']);
-				else
+				} else {
 					openssl_public_encrypt($key,$postvars['key'],$contact['pubkey']);
+				}
 
 			}
 
@@ -1073,19 +1116,21 @@ class dfrn {
 		logger('dfrn_deliver: ' . "RECEIVED: " . $xml, LOGGER_DATA);
 
 		$curl_stat = $a->get_curl_code();
-		if((! $curl_stat) || (! strlen($xml)))
+		if ((! $curl_stat) || (! strlen($xml))) {
 			return(-1); // timed out
+		}
 
-		if(($curl_stat == 503) && (stristr($a->get_curl_headers(),'retry-after')))
+		if (($curl_stat == 503) && (stristr($a->get_curl_headers(),'retry-after'))) {
 			return(-1);
+		}
 
-		if(strpos($xml,'<?xml') === false) {
+		if (strpos($xml,'<?xml') === false) {
 			logger('dfrn_deliver: phase 2: no valid XML returned');
 			logger('dfrn_deliver: phase 2: returned XML: ' . $xml, LOGGER_DATA);
 			return 3;
 		}
 
-		if($contact['term-date'] != '0000-00-00 00:00:00') {
+		if ($contact['term-date'] != '0000-00-00 00:00:00') {
 			logger("dfrn_deliver: $url back from the dead - removing mark for death");
 			require_once('include/Contact.php');
 			unmark_for_death($contact);
@@ -1146,7 +1191,8 @@ class dfrn {
 				`name`, `nick`, `about`, `location`, `keywords`, `xmpp`, `bdyear`, `bd`, `hidden`, `contact-type`
 				FROM `contact` WHERE `uid` = %d AND `nurl` = '%s' AND `network` != '%s'",
 			intval($importer["uid"]), dbesc(normalise_link($author["link"])), dbesc(NETWORK_STATUSNET));
-		if ($r) {
+
+		if (dbm::is_result($r)) {
 			$contact = $r[0];
 			$author["contact-id"] = $r[0]["id"];
 			$author["network"] = $r[0]["network"];
@@ -1167,15 +1213,19 @@ class dfrn {
 			$href = "";
 			$width = 0;
 			foreach($avatar->attributes AS $attributes) {
-				if ($attributes->name == "href")
+				if ($attributes->name == "href") {
 					$href = $attributes->textContent;
-				if ($attributes->name == "width")
+				}
+				if ($attributes->name == "width") {
 					$width = $attributes->textContent;
-				if ($attributes->name == "updated")
+				}
+				if ($attributes->name == "updated") {
 					$contact["avatar-date"] = $attributes->textContent;
+				}
 			}
-			if (($width > 0) AND ($href != ""))
+			if (($width > 0) AND ($href != "")) {
 				$avatarlist[$width] = $href;
+			}
 		}
 		if (count($avatarlist) > 0) {
 			krsort($avatarlist);
@@ -1189,40 +1239,50 @@ class dfrn {
 
 			// When was the last change to name or uri?
 			$name_element = $xpath->query($element."/atom:name", $context)->item(0);
-			foreach($name_element->attributes AS $attributes)
-				if ($attributes->name == "updated")
+			foreach ($name_element->attributes AS $attributes) {
+				if ($attributes->name == "updated") {
 					$poco["name-date"] = $attributes->textContent;
+				}
+			}
 
 			$link_element = $xpath->query($element."/atom:link", $context)->item(0);
-			foreach($link_element->attributes AS $attributes)
-				if ($attributes->name == "updated")
+			foreach ($link_element->attributes AS $attributes) {
+				if ($attributes->name == "updated") {
 					$poco["uri-date"] = $attributes->textContent;
+				}
+			}
 
 			// Update contact data
 			$value = $xpath->evaluate($element."/dfrn:handle/text()", $context)->item(0)->nodeValue;
-			if ($value != "")
+			if ($value != "") {
 				$poco["addr"] = $value;
+			}
 
 			$value = $xpath->evaluate($element."/poco:displayName/text()", $context)->item(0)->nodeValue;
-			if ($value != "")
+			if ($value != "") {
 				$poco["name"] = $value;
+			}
 
 			$value = $xpath->evaluate($element."/poco:preferredUsername/text()", $context)->item(0)->nodeValue;
-			if ($value != "")
+			if ($value != "") {
 				$poco["nick"] = $value;
+			}
 
 			$value = $xpath->evaluate($element."/poco:note/text()", $context)->item(0)->nodeValue;
-			if ($value != "")
+			if ($value != "") {
 				$poco["about"] = $value;
+			}
 
 			$value = $xpath->evaluate($element."/poco:address/poco:formatted/text()", $context)->item(0)->nodeValue;
-			if ($value != "")
+			if ($value != "") {
 				$poco["location"] = $value;
+			}
 
 			/// @todo Only search for elements with "poco:type" = "xmpp"
 			$value = $xpath->evaluate($element."/poco:ims/poco:value/text()", $context)->item(0)->nodeValue;
-			if ($value != "")
+			if ($value != "") {
 				$poco["xmpp"] = $value;
+			}
 
 			/// @todo Add support for the following fields that we don't support by now in the contact table:
 			/// - poco:utcOffset
@@ -1238,17 +1298,20 @@ class dfrn {
 
 			// If the contact isn't searchable then set the contact to "hidden".
 			// Problem: This can be manually overridden by the user.
-			if ($hide)
+			if ($hide) {
 				$contact["hidden"] = true;
+			}
 
 			// Save the keywords into the contact table
 			$tags = array();
 			$tagelements = $xpath->evaluate($element."/poco:tags/text()", $context);
-			foreach($tagelements AS $tag)
+			foreach ($tagelements AS $tag) {
 				$tags[$tag->nodeValue] = $tag->nodeValue;
+			}
 
-			if (count($tags))
+			if (count($tags)) {
 				$poco["keywords"] = implode(", ", $tags);
+			}
 
 			// "dfrn:birthday" contains the birthday converted to UTC
 			$old_bdyear = $contact["bdyear"];
@@ -1278,13 +1341,15 @@ class dfrn {
 
 			$contact = array_merge($contact, $poco);
 
-			if ($old_bdyear != $contact["bdyear"])
+			if ($old_bdyear != $contact["bdyear"]) {
 				self::birthday_event($contact, $birthday);
+			}
 
 			// Get all field names
 			$fields = array();
-			foreach ($r[0] AS $field => $data)
+			foreach ($r[0] AS $field => $data) {
 				$fields[$field] = $data;
+			}
 
 			unset($fields["id"]);
 			unset($fields["uid"]);
@@ -1349,8 +1414,9 @@ class dfrn {
 	 * @return string XML string
 	 */
 	private function transform_activity($xpath, $activity, $element) {
-		if (!is_object($activity))
+		if (!is_object($activity)) {
 			return "";
+		}
 
 		$obj_doc = new DOMDocument("1.0", "utf-8");
 		$obj_doc->formatOutput = true;

--- a/include/dfrn.php
+++ b/include/dfrn.php
@@ -41,6 +41,7 @@ class dfrn {
 	 * @param array $owner Owner record
 	 *
 	 * @return string DFRN entries
+	 * @todo Add type-hints
 	 */
 	public static function entries($items,$owner) {
 
@@ -49,10 +50,11 @@ class dfrn {
 
 		$root = self::add_header($doc, $owner, "dfrn:owner", "", false);
 
-		if(! count($items))
+		if (! count($items)) {
 			return trim($doc->saveXML());
+		}
 
-		foreach($items as $item) {
+		foreach ($items as $item) {
 			$entry = self::entry($doc, "text", $item, $owner, $item["entry:comment-allow"], $item["entry:cid"]);
 			$root->appendChild($entry);
 		}
@@ -82,14 +84,17 @@ class dfrn {
 		$starred     = false;   // not yet implemented, possible security issues
 		$converse    = false;
 
-		if($public_feed && $a->argc > 2) {
-			for($x = 2; $x < $a->argc; $x++) {
-				if($a->argv[$x] == 'converse')
+		if ($public_feed && $a->argc > 2) {
+			for ($x = 2; $x < $a->argc; $x++) {
+				if ($a->argv[$x] == 'converse') {
 					$converse = true;
-				if($a->argv[$x] == 'starred')
+				}
+				if ($a->argv[$x] == 'starred') {
 					$starred = true;
-				if($a->argv[$x] == 'category' && $a->argc > ($x + 1) && strlen($a->argv[$x+1]))
+				}
+				if ($a->argv[$x] == 'category' && $a->argc > ($x + 1) && strlen($a->argv[$x+1])) {
 					$category = $a->argv[$x+1];
+				}
 			}
 		}
 
@@ -115,7 +120,7 @@ class dfrn {
 
 		$sql_post_table = "";
 
-		if(! $public_feed) {
+		if (! $public_feed) {
 
 			$sql_extra = '';
 			switch($direction) {
@@ -148,12 +153,13 @@ class dfrn {
 			require_once('include/security.php');
 			$groups = init_groups_visitor($contact['id']);
 
-			if(count($groups)) {
-				for($x = 0; $x < count($groups); $x ++)
+			if (count($groups)) {
+				for ($x = 0; $x < count($groups); $x ++)
 					$groups[$x] = '<' . intval($groups[$x]) . '>' ;
 				$gs = implode('|', $groups);
-			} else
+			} else {
 				$gs = '<<>>' ; // Impossible to match
+			}
 
 			$sql_extra = sprintf("
 				AND ( `allow_cid` = '' OR     `allow_cid` REGEXP '<%d>' )
@@ -168,23 +174,26 @@ class dfrn {
 			);
 		}
 
-		if($public_feed)
+		if ($public_feed) {
 			$sort = 'DESC';
-		else
+		} else {
 			$sort = 'ASC';
+		}
 
-		if(! strlen($last_update))
+		if (! strlen($last_update)) {
 			$last_update = 'now -30 days';
+		}
 
-		if(isset($category)) {
+		if (isset($category)) {
 			$sql_post_table = sprintf("INNER JOIN (SELECT `oid` FROM `term` WHERE `term` = '%s' AND `otype` = %d AND `type` = %d AND `uid` = %d ORDER BY `tid` DESC) AS `term` ON `item`.`id` = `term`.`oid` ",
 					dbesc(protect_sprintf($category)), intval(TERM_OBJ_POST), intval(TERM_CATEGORY), intval($owner_id));
 			//$sql_extra .= file_tag_file_query('item',$category,'category');
 		}
 
-		if($public_feed) {
-			if(! $converse)
+		if ($public_feed) {
+			if (! $converse) {
 				$sql_extra .= " AND `contact`.`self` = 1 ";
+			}
 		}
 
 		$check_date = datetime_convert('UTC','UTC',$last_update,'Y-m-d H:i:s');
@@ -207,6 +216,11 @@ class dfrn {
 			dbesc($sort)
 		);
 
+		if (!dbm::is_result($r)) {
+			/// @TODO Some logging?
+			killme();
+		}
+
 		// Will check further below if this actually returned results.
 		// We will provide an empty feed if that is the case.
 
@@ -217,13 +231,15 @@ class dfrn {
 
 		$alternatelink = $owner['url'];
 
-		if(isset($category))
+		if (isset($category)) {
 			$alternatelink .= "/category/".$category;
+		}
 
-		if ($public_feed)
+		if ($public_feed) {
 			$author = "dfrn:owner";
-		else
+		} else {
 			$author = "author";
+		}
 
 		$root = self::add_header($doc, $owner, $author, $alternatelink, true);
 
@@ -238,21 +254,24 @@ class dfrn {
 			return $atom;
 		}
 
-		foreach($items as $item) {
+		foreach ($items as $item) {
 
 			// prevent private email from leaking.
-			if($item['network'] == NETWORK_MAIL)
+			if ($item['network'] == NETWORK_MAIL) {
 				continue;
+			}
 
 			// public feeds get html, our own nodes use bbcode
 
-			if($public_feed) {
+			if ($public_feed) {
 				$type = 'html';
 				// catch any email that's in a public conversation and make sure it doesn't leak
-				if($item['private'])
+				if ($item['private']) {
 					continue;
-			} else
+				}
+			} else {
 				$type = 'text';
+			}
 
 			$entry = self::entry($doc, $type, $item, $owner, true);
 			$root->appendChild($entry);
@@ -273,6 +292,7 @@ class dfrn {
 	 * @param array $owner Owner record
 	 *
 	 * @return string DFRN mail
+	 * @todo Add type-hints
 	 */
 	public static function mail($item, $owner) {
 		$doc = new DOMDocument('1.0', 'utf-8');
@@ -307,6 +327,7 @@ class dfrn {
 	 * @param array $owner Owner record
 	 *
 	 * @return string DFRN suggestions
+	 * @todo Add type-hints
 	 */
 	public static function fsuggest($item, $owner) {
 		$doc = new DOMDocument('1.0', 'utf-8');
@@ -334,12 +355,13 @@ class dfrn {
 	 * @param int $uid User ID
 	 *
 	 * @return string DFRN relocations
+	 * @todo Add type-hints
 	 */
 	public static function relocate($owner, $uid) {
 
 		/* get site pubkey. this could be a new installation with no site keys*/
 		$pubkey = get_config('system','site_pubkey');
-		if(! $pubkey) {
+		if (! $pubkey) {
 			$res = new_keypair(1024);
 			set_config('system','site_prvkey', $res['prvkey']);
 			set_config('system','site_pubkey', $res['pubkey']);
@@ -350,8 +372,9 @@ class dfrn {
 		$photos = array();
 		$ext = Photo::supportedTypes();
 
-		foreach($rp as $p)
+		foreach ($rp as $p) {
 			$photos[$p['scale']] = app::get_baseurl().'/photo/'.$p['resource-id'].'-'.$p['scale'].'.'.$ext[$p['type']];
+		}
 
 		unset($rp, $ext);
 
@@ -390,11 +413,13 @@ class dfrn {
 	 * @param bool $public Is it a header for public posts?
 	 *
 	 * @return object XML root object
+	 * @todo Add type-hints
 	 */
 	private function add_header($doc, $owner, $authorelement, $alternatelink = "", $public = false) {
 
-		if ($alternatelink == "")
+		if ($alternatelink == "") {
 			$alternatelink = $owner['url'];
+		}
 
 		$root = $doc->createElementNS(NAMESPACE_ATOM1, 'feed');
 		$doc->appendChild($root);
@@ -437,8 +462,9 @@ class dfrn {
 		}
 
 		// For backward compatibility we keep this element
-		if ($owner['page-flags'] == PAGE_COMMUNITY)
+		if ($owner['page-flags'] == PAGE_COMMUNITY) {
 			xml::add_element($doc, $root, "dfrn:community", 1);
+		}
 
 		// The former element is replaced by this one
 		xml::add_element($doc, $root, "dfrn:account_type", $owner["account-type"]);
@@ -461,6 +487,7 @@ class dfrn {
 	 * @param string $authorelement Element name for the author
 	 *
 	 * @return object XML author object
+	 * @todo Add type-hints
 	 */
 	private function add_author($doc, $owner, $authorelement, $public) {
 
@@ -468,10 +495,11 @@ class dfrn {
 		$r = q("SELECT `id` FROM `profile` INNER JOIN `user` ON `user`.`uid` = `profile`.`uid`
 				WHERE (`hidewall` OR NOT `net-publish`) AND `user`.`uid` = %d",
 			intval($owner['uid']));
-		if ($r)
+		if (dbm::is_result($r)) {
 			$hidewall = true;
-		else
+		} else {
 			$hidewall = false;
+		}
 
 		$author = $doc->createElement($authorelement);
 
@@ -479,10 +507,11 @@ class dfrn {
 		$uridate = datetime_convert('UTC', 'UTC', $owner['uri-date'].'+00:00', ATOM_TIME);
 		$picdate = datetime_convert('UTC', 'UTC', $owner['avatar-date'].'+00:00', ATOM_TIME);
 
-		if (!$public OR !$hidewall)
+		$attributes = array();
+
+		if (!$public OR !$hidewall) {
 			$attributes = array("dfrn:updated" => $namdate);
-		else
-			$attributes = array();
+		}
 
 		xml::add_element($doc, $author, "name", $owner["name"], $attributes);
 		xml::add_element($doc, $author, "uri", app::get_baseurl().'/profile/'.$owner["nickname"], $attributes);
@@ -491,20 +520,23 @@ class dfrn {
 		$attributes = array("rel" => "photo", "type" => "image/jpeg",
 					"media:width" => 175, "media:height" => 175, "href" => $owner['photo']);
 
-		if (!$public OR !$hidewall)
+		if (!$public OR !$hidewall) {
 			$attributes["dfrn:updated"] = $picdate;
+		}
 
 		xml::add_element($doc, $author, "link", "", $attributes);
 
 		$attributes["rel"] = "avatar";
 		xml::add_element($doc, $author, "link", "", $attributes);
 
-		if ($hidewall)
+		if ($hidewall) {
 			xml::add_element($doc, $author, "dfrn:hide", "true");
+		}
 
 		// The following fields will only be generated if the data isn't meant for a public feed
-		if ($public)
+		if ($public) {
 			return $author;
+		}
 
 		$birthday = feed_birthday($owner['uid'], $owner['timezone']);
 
@@ -519,7 +551,7 @@ class dfrn {
 				INNER JOIN `user` ON `user`.`uid` = `profile`.`uid`
 				WHERE `profile`.`is-default` AND NOT `user`.`hidewall` AND `user`.`uid` = %d",
 			intval($owner['uid']));
-		if ($r) {
+		if (dbm::is_result($r)) {
 			$profile = $r[0];
 
 			xml::add_element($doc, $author, "poco:displayName", $profile["name"]);
@@ -547,8 +579,9 @@ class dfrn {
 			if (trim($profile["pub_keywords"]) != "") {
 				$keywords = explode(",", $profile["pub_keywords"]);
 
-				foreach ($keywords AS $keyword)
+				foreach ($keywords AS $keyword) {
 					xml::add_element($doc, $author, "poco:tags", trim($keyword));
+				}
 
 			}
 
@@ -565,14 +598,17 @@ class dfrn {
 
 				xml::add_element($doc, $element, "poco:formatted", formatted_location($profile));
 
-				if (trim($profile["locality"]) != "")
+				if (trim($profile["locality"]) != "") {
 					xml::add_element($doc, $element, "poco:locality", $profile["locality"]);
+				}
 
-				if (trim($profile["region"]) != "")
+				if (trim($profile["region"]) != "") {
 					xml::add_element($doc, $element, "poco:region", $profile["region"]);
+				}
 
-				if (trim($profile["country-name"]) != "")
+				if (trim($profile["country-name"]) != "") {
 					xml::add_element($doc, $element, "poco:country", $profile["country-name"]);
+				}
 
 				$author->appendChild($element);
 			}
@@ -590,6 +626,7 @@ class dfrn {
 	 * @param array $items Item elements
 	 *
 	 * @return object XML author object
+	 * @todo Add type-hints
 	 */
 	private function add_entry_author($doc, $element, $contact_url, $item) {
 
@@ -630,10 +667,11 @@ class dfrn {
 	 * @param string $activity activity value
 	 *
 	 * @return object XML activity object
+	 * @todo Add type-hints
 	 */
 	private function create_activity($doc, $element, $activity) {
 
-		if($activity) {
+		if ($activity) {
 			$entry = $doc->createElement($element);
 
 			$r = parse_xml_string($activity, false);
@@ -692,6 +730,7 @@ class dfrn {
 	 * @param array $item Item element
 	 *
 	 * @return object XML attachment object
+	 * @todo Add type-hints
 	 */
 	private function get_attachment($doc, $root, $item) {
 		$arr = explode('[/attach],',$item['attach']);
@@ -729,6 +768,7 @@ class dfrn {
 	 * @param int $cid Contact ID of the recipient
 	 *
 	 * @return object XML entry object
+	 * @todo Add type-hints
 	 */
 	private function entry($doc, $type, $item, $owner, $comment = false, $cid = 0) {
 
@@ -857,7 +897,7 @@ class dfrn {
 
 		$tags = item_getfeedtags($item);
 
-		if( count($tags)) {
+		if (count($tags)) {
 			foreach ($tags as $t) {
 				if (($type != 'html') OR ($t[0] != "@")) {
 					xml::add_element($doc, $entry, "category", "", array("scheme" => "X-DFRN:".$t[0].":".$t[1], "term" => $t[2]));
@@ -866,7 +906,7 @@ class dfrn {
 		}
 
 		if (count($tags)) {
-			foreach($tags as $t) {
+			foreach ($tags as $t) {
 				if ($t[0] == "@") {
 					$mentioned[$t[1]] = $t[1];
 				}
@@ -877,6 +917,11 @@ class dfrn {
 			$r = q("SELECT `forum`, `prv` FROM `contact` WHERE `uid` = %d AND `nurl` = '%s'",
 				intval($owner["uid"]),
 				dbesc(normalise_link($mention)));
+
+			if (!dbm::is_result($r)) {
+				/// @TODO Maybe some logging?
+				killme();
+			}
 
 			if ($r[0]["forum"] OR $r[0]["prv"]) {
 				xml::add_element($doc, $entry, "link", "", array("rel" => "mentioned",
@@ -903,6 +948,7 @@ class dfrn {
 	 * @param bool $dissolve (to be documented)
 	 *
 	 * @return int Deliver status. -1 means an error.
+	 * @todo Add array type-hint for $owner, $contact
 	 */
 	public static function deliver($owner,$contact,$atom, $dissolve = false) {
 
@@ -1146,7 +1192,7 @@ class dfrn {
 	 *
 	 * @param array $contact Contact record
 	 * @param string $birthday Birthday of the contact
-	 *
+	 * @todo Add array type-hint for $contact
 	 */
 	private function birthday_event($contact, $birthday) {
 
@@ -1180,6 +1226,7 @@ class dfrn {
 	 * @param bool $onlyfetch Should the data only be fetched or should it update the contact record as well
 	 *
 	 * @return Returns an array with relevant data of the author
+	 * @todo Find good type-hints for all parameter
 	 */
 	private function fetchauthor($xpath, $context, $importer, $element, $onlyfetch, $xml = "") {
 
@@ -1197,8 +1244,9 @@ class dfrn {
 			$author["contact-id"] = $r[0]["id"];
 			$author["network"] = $r[0]["network"];
 		} else {
-			if (!$onlyfetch)
+			if (!$onlyfetch) {
 				logger("Contact ".$author["link"]." wasn't found for user ".$importer["uid"]." XML: ".$xml, LOGGER_DEBUG);
+			}
 
 			$author["contact-id"] = $importer["id"];
 			$author["network"] = $importer["network"];
@@ -1209,10 +1257,11 @@ class dfrn {
 		$avatarlist = array();
 		/// @todo check if "avatar" or "photo" would be the best field in the specification
 		$avatars = $xpath->query($element."/atom:link[@rel='avatar']", $context);
-		foreach($avatars AS $avatar) {
+		foreach ($avatars AS $avatar) {
 			$href = "";
 			$width = 0;
-			foreach($avatar->attributes AS $attributes) {
+			foreach ($avatar->attributes AS $attributes) {
+				/// @TODO Rewrite these similar if() to one switch
 				if ($attributes->name == "href") {
 					$href = $attributes->textContent;
 				}
@@ -1232,7 +1281,7 @@ class dfrn {
 			$author["avatar"] = current($avatarlist);
 		}
 
-		if ($r AND !$onlyfetch) {
+		if (dbm::is_result($r) AND !$onlyfetch) {
 			logger("Check if contact details for contact ".$r[0]["id"]." (".$r[0]["nick"].") have to be updated.", LOGGER_DEBUG);
 
 			$poco = array("url" => $contact["url"]);
@@ -1360,17 +1409,19 @@ class dfrn {
 
 			// Update check for this field has to be done differently
 			$datefields = array("name-date", "uri-date");
-			foreach ($datefields AS $field)
+			foreach ($datefields AS $field) {
 				if (strtotime($contact[$field]) > strtotime($r[0][$field])) {
 					logger("Difference for contact ".$contact["id"]." in field '".$field."'. New value: '".$contact[$field]."', old value '".$r[0][$field]."'", LOGGER_DEBUG);
 					$update = true;
 				}
+			}
 
-			foreach ($fields AS $field => $data)
+			foreach ($fields AS $field => $data) {
 				if ($contact[$field] != $r[0][$field]) {
 					logger("Difference for contact ".$contact["id"]." in field '".$field."'. New value: '".$contact[$field]."', old value '".$r[0][$field]."'", LOGGER_DEBUG);
 					$update = true;
 				}
+			}
 
 			if ($update) {
 				logger("Update contact data for contact ".$contact["id"]." (".$contact["nick"].")", LOGGER_DEBUG);
@@ -1412,6 +1463,7 @@ class dfrn {
 	 * @param text $element element name
 	 *
 	 * @return string XML string
+	 * @todo Find good type-hints for all parameter
 	 */
 	private function transform_activity($xpath, $activity, $element) {
 		if (!is_object($activity)) {
@@ -1427,21 +1479,26 @@ class dfrn {
 		xml::add_element($obj_doc, $obj_element, "type", $activity_type);
 
 		$id = $xpath->query("atom:id", $activity)->item(0);
-		if (is_object($id))
+		if (is_object($id)) {
 			$obj_element->appendChild($obj_doc->importNode($id, true));
+		}
 
 		$title = $xpath->query("atom:title", $activity)->item(0);
-		if (is_object($title))
+		if (is_object($title)) {
 			$obj_element->appendChild($obj_doc->importNode($title, true));
+		}
 
 		$links = $xpath->query("atom:link", $activity);
-		if (is_object($links))
-			foreach ($links AS $link)
+		if (is_object($links)) {
+			foreach ($links AS $link) {
 				$obj_element->appendChild($obj_doc->importNode($link, true));
+			}
+		}
 
 		$content = $xpath->query("atom:content", $activity)->item(0);
-		if (is_object($content))
+		if (is_object($content)) {
 			$obj_element->appendChild($obj_doc->importNode($content, true));
+		}
 
 		$obj_doc->appendChild($obj_element);
 
@@ -1458,11 +1515,13 @@ class dfrn {
 	 * @param object $xpath XPath object
 	 * @param object $mail mail elements
 	 * @param array $importer Record of the importer user mixed with contact of the content
+	 * @todo Find good type-hints for all parameter
 	 */
 	private function process_mail($xpath, $mail, $importer) {
 
 		logger("Processing mails");
 
+		/// @TODO Rewrite this to one statement
 		$msg = array();
 		$msg["uid"] = $importer["importer_uid"];
 		$msg["from-name"] = $xpath->query("dfrn:sender/dfrn:name/text()", $mail)->item(0)->nodeValue;
@@ -1482,7 +1541,7 @@ class dfrn {
 		$r = dbq("INSERT INTO `mail` (`".implode("`, `", array_keys($msg))."`) VALUES ('".implode("', '", array_values($msg))."')");
 
 		// send notifications.
-
+		/// @TODO Arange this mess
 		$notif_params = array(
 			"type" => NOTIFY_MAIL,
 			"notify_flags" => $importer["notify-flags"],
@@ -1509,12 +1568,14 @@ class dfrn {
 	 * @param object $xpath XPath object
 	 * @param object $suggestion suggestion elements
 	 * @param array $importer Record of the importer user mixed with contact of the content
+	 * @todo Find good type-hints for all parameter
 	 */
 	private function process_suggestion($xpath, $suggestion, $importer) {
 		$a = get_app();
 
 		logger("Processing suggestions");
 
+		/// @TODO Rewrite this to one statement
 		$suggest = array();
 		$suggest["uid"] = $importer["importer_uid"];
 		$suggest["cid"] = $importer["id"];
@@ -1531,8 +1592,10 @@ class dfrn {
 			dbesc(normalise_link($suggest["url"])),
 			intval($suggest["uid"])
 		);
-		if (dbm::is_result($r))
+		/// @TODO Really abort on valid result??? Maybe missed ! here?
+		if (dbm::is_result($r)) {
 			return false;
+		}
 
 		// Do we already have an fcontact record for this person?
 
@@ -1550,10 +1613,12 @@ class dfrn {
 				intval($suggest["uid"]),
 				intval($fid)
 			);
-			if (dbm::is_result($r))
+			/// @TODO Really abort on valid result??? Maybe missed ! here?
+			if (dbm::is_result($r)) {
 				return false;
+			}
 		}
-		if(!$fid)
+		if (!$fid)
 			$r = q("INSERT INTO `fcontact` (`name`,`url`,`photo`,`request`) VALUES ('%s', '%s', '%s', '%s')",
 			dbesc($suggest["name"]),
 			dbesc($suggest["url"]),
@@ -1565,11 +1630,12 @@ class dfrn {
 			dbesc($suggest["name"]),
 			dbesc($suggest["request"])
 		);
-		if (dbm::is_result($r))
+		if (dbm::is_result($r)) {
 			$fid = $r[0]["id"];
-		else
+		} else {
 			// database record did not get created. Quietly give up.
-			return false;
+			killme();
+		}
 
 
 		$hash = random_string();
@@ -1611,11 +1677,13 @@ class dfrn {
 	 * @param object $xpath XPath object
 	 * @param object $relocation relocation elements
 	 * @param array $importer Record of the importer user mixed with contact of the content
+	 * @todo Find good type-hints for all parameter
 	 */
 	private function process_relocation($xpath, $relocation, $importer) {
 
 		logger("Processing relocations");
 
+		/// @TODO Rewrite this to one statement
 		$relocate = array();
 		$relocate["uid"] = $importer["importer_uid"];
 		$relocate["cid"] = $importer["id"];
@@ -1632,18 +1700,22 @@ class dfrn {
 		$relocate["poll"] = $xpath->query("dfrn:poll/text()", $relocation)->item(0)->nodeValue;
 		$relocate["sitepubkey"] = $xpath->query("dfrn:sitepubkey/text()", $relocation)->item(0)->nodeValue;
 
-		if (($relocate["avatar"] == "") AND ($relocate["photo"] != ""))
+		if (($relocate["avatar"] == "") AND ($relocate["photo"] != "")) {
 			$relocate["avatar"] = $relocate["photo"];
+		}
 
-		if ($relocate["addr"] == "")
+		if ($relocate["addr"] == "") {
 			$relocate["addr"] = preg_replace("=(https?://)(.*)/profile/(.*)=ism", "$3@$2", $relocate["url"]);
+		}
 
 		// update contact
 		$r = q("SELECT `photo`, `url` FROM `contact` WHERE `id` = %d AND `uid` = %d;",
 			intval($importer["id"]),
 			intval($importer["importer_uid"]));
-		if (!$r)
-			return false;
+
+		if (!dbm::is_result($r)) {
+			killme();
+		}
 
 		$old = $r[0];
 
@@ -1699,8 +1771,9 @@ class dfrn {
 
 		update_contact_avatar($relocate["avatar"], $importer["importer_uid"], $importer["id"], true);
 
-		if ($x === false)
+		if ($x === false) {
 			return false;
+		}
 
 		// update items
 		/// @todo This is an extreme performance killer
@@ -1715,7 +1788,7 @@ class dfrn {
 					$n, dbesc($f[0]),
 					intval($importer["importer_uid"]));
 
-			if ($r) {
+			if (dbm::is_result($r)) {
 				$x = q("UPDATE `item` SET `%s` = '%s' WHERE `%s` = '%s' AND `uid` = %d",
 						$n, dbesc($f[1]),
 						$n, dbesc($f[0]),
@@ -1764,12 +1837,13 @@ class dfrn {
 
 			$changed = true;
 
-			if ($entrytype == DFRN_REPLY_RC)
+			if ($entrytype == DFRN_REPLY_RC) {
 				proc_run(PRIORITY_HIGH, "include/notifier.php","comment-import", $current["id"]);
+			}
 		}
 
 		// update last-child if it changes
-		if($item["last-child"] AND ($item["last-child"] != $current["last-child"])) {
+		if ($item["last-child"] AND ($item["last-child"] != $current["last-child"])) {
 			$r = q("UPDATE `item` SET `last-child` = 0, `changed` = '%s' WHERE `parent-uri` = '%s' AND `uid` = %d",
 				dbesc(datetime_convert()),
 				dbesc($item["parent-uri"]),
@@ -1801,8 +1875,9 @@ class dfrn {
 				$sql_extra = "";
 				$community = true;
 				logger("possible community action");
-			} else
+			} else {
 				$sql_extra = " AND `contact`.`self` AND `item`.`wall` ";
+			}
 
 			// was the top-level post for this action written by somebody on this site?
 			// Specifically, the recipient?
@@ -1826,8 +1901,9 @@ class dfrn {
 					dbesc($r[0]["parent-uri"]),
 					intval($importer["importer_uid"])
 				);
-				if (dbm::is_result($r))
+				if (dbm::is_result($r)) {
 					$is_a_remote_action = true;
+				}
 			}
 
 			// Does this have the characteristics of a community or private group action?
@@ -1835,20 +1911,22 @@ class dfrn {
 			// valid community action. Also forum_mode makes it valid for sure.
 			// If neither, it's not.
 
-			if($is_a_remote_action && $community) {
-				if((!$r[0]["forum_mode"]) && (!$r[0]["wall"])) {
+			if ($is_a_remote_action && $community) {
+				if ((!$r[0]["forum_mode"]) && (!$r[0]["wall"])) {
 					$is_a_remote_action = false;
 					logger("not a community action");
 				}
 			}
 
-			if ($is_a_remote_action)
+			if ($is_a_remote_action) {
 				return DFRN_REPLY_RC;
-			else
+			} else {
 				return DFRN_REPLY;
+			}
 
-		} else
+		} else {
 			return DFRN_TOP_LEVEL;
+		}
 
 	}
 
@@ -1861,14 +1939,15 @@ class dfrn {
 	 */
 	private function do_poke($item, $importer, $posted_id) {
 		$verb = urldecode(substr($item["verb"],strpos($item["verb"], "#")+1));
-		if(!$verb)
+		if (!$verb) {
 			return;
+		}
 		$xo = parse_xml_string($item["object"],false);
 
-		if(($xo->type == ACTIVITY_OBJ_PERSON) && ($xo->id)) {
+		if (($xo->type == ACTIVITY_OBJ_PERSON) && ($xo->id)) {
 
 			// somebody was poked/prodded. Was it me?
-			foreach($xo->link as $l) {
+			foreach ($xo->link as $l) {
 				$atts = $l->attributes();
 				switch($atts["rel"]) {
 					case "alternate":
@@ -1927,22 +2006,22 @@ class dfrn {
 
 			// Big question: Do we need these functions? They were part of the "consume_feed" function.
 			// This function once was responsible for DFRN and OStatus.
-			if(activity_match($item["verb"],ACTIVITY_FOLLOW)) {
+			if (activity_match($item["verb"],ACTIVITY_FOLLOW)) {
 				logger("New follower");
 				new_follower($importer, $contact, $item, $nickname);
 				return false;
 			}
-			if(activity_match($item["verb"],ACTIVITY_UNFOLLOW))  {
+			if (activity_match($item["verb"],ACTIVITY_UNFOLLOW))  {
 				logger("Lost follower");
 				lose_follower($importer, $contact, $item);
 				return false;
 			}
-			if(activity_match($item["verb"],ACTIVITY_REQ_FRIEND)) {
+			if (activity_match($item["verb"],ACTIVITY_REQ_FRIEND)) {
 				logger("New friend request");
 				new_follower($importer, $contact, $item, $nickname, true);
 				return false;
 			}
-			if(activity_match($item["verb"],ACTIVITY_UNFRIEND))  {
+			if (activity_match($item["verb"],ACTIVITY_UNFRIEND))  {
 				logger("Lost sharer");
 				lose_sharer($importer, $contact, $item);
 				return false;
@@ -1964,8 +2043,9 @@ class dfrn {
 					dbesc($item["verb"]),
 					dbesc($item["parent-uri"])
 				);
-				if (dbm::is_result($r))
+				if (dbm::is_result($r)) {
 					return false;
+				}
 
 				$r = q("SELECT `id` FROM `item` WHERE `uid` = %d AND `author-link` = '%s' AND `verb` = '%s' AND `thr-parent` = '%s' AND NOT `deleted` LIMIT 1",
 					intval($item["uid"]),
@@ -1973,28 +2053,31 @@ class dfrn {
 					dbesc($item["verb"]),
 					dbesc($item["parent-uri"])
 				);
-				if (dbm::is_result($r))
+				if (dbm::is_result($r)) {
 					return false;
-			} else
+				}
+			} else {
 				$is_like = false;
+			}
 
-			if(($item["verb"] == ACTIVITY_TAG) && ($item["object-type"] == ACTIVITY_OBJ_TAGTERM)) {
+			if (($item["verb"] == ACTIVITY_TAG) && ($item["object-type"] == ACTIVITY_OBJ_TAGTERM)) {
 
 				$xo = parse_xml_string($item["object"],false);
 				$xt = parse_xml_string($item["target"],false);
 
-				if($xt->type == ACTIVITY_OBJ_NOTE) {
+				if ($xt->type == ACTIVITY_OBJ_NOTE) {
 					$r = q("SELECT `id`, `tag` FROM `item` WHERE `uri` = '%s' AND `uid` = %d LIMIT 1",
 						dbesc($xt->id),
 						intval($importer["importer_uid"])
 					);
 
-					if (!dbm::is_result($r))
-						return false;
+					if (!dbm::is_result($r)) {
+						killme();
+					}
 
 					// extract tag, if not duplicate, add to parent item
-					if($xo->content) {
-						if(!(stristr($r[0]["tag"],trim($xo->content)))) {
+					if ($xo->content) {
+						if (!(stristr($r[0]["tag"],trim($xo->content)))) {
 							q("UPDATE `item` SET `tag` = '%s' WHERE `id` = %d",
 								dbesc($r[0]["tag"] . (strlen($r[0]["tag"]) ? ',' : '') . '#[url=' . $xo->id . ']'. $xo->content . '[/url]'),
 								intval($r[0]["id"])
@@ -2013,6 +2096,7 @@ class dfrn {
 	 *
 	 * @param object $links link elements
 	 * @param array $item the item record
+	 * @todo Add type-hints
 	 */
 	private function parse_links($links, &$item) {
 		$rel = "";
@@ -2021,17 +2105,23 @@ class dfrn {
 		$length = "0";
 		$title = "";
 		foreach ($links AS $link) {
-			foreach($link->attributes AS $attributes) {
-				if ($attributes->name == "href")
+			foreach ($link->attributes AS $attributes) {
+				/// @TODO Rewrite these repeated (same) if() statements to a switch()
+				if ($attributes->name == "href") {
 					$href = $attributes->textContent;
-				if ($attributes->name == "rel")
+				}
+				if ($attributes->name == "rel") {
 					$rel = $attributes->textContent;
-				if ($attributes->name == "type")
+				}
+				if ($attributes->name == "type") {
 					$type = $attributes->textContent;
-				if ($attributes->name == "length")
+				}
+				if ($attributes->name == "length") {
 					$length = $attributes->textContent;
-				if ($attributes->name == "title")
+				}
+				if ($attributes->name == "title") {
 					$title = $attributes->textContent;
+				}
 			}
 			if (($rel != "") AND ($href != ""))
 				switch($rel) {
@@ -2040,8 +2130,9 @@ class dfrn {
 						break;
 					case "enclosure":
 						$enclosure = $href;
-						if(strlen($item["attach"]))
+						if (strlen($item["attach"])) {
 							$item["attach"] .= ",";
+						}
 
 						$item["attach"] .= '[attach]href="'.$href.'" length="'.$length.'" type="'.$type.'" title="'.$title.'"[/attach]';
 						break;
@@ -2056,6 +2147,7 @@ class dfrn {
 	 * @param object $xpath XPath object
 	 * @param object $entry entry elements
 	 * @param array $importer Record of the importer user mixed with contact of the content
+	 * @todo Add type-hints
 	 */
 	private function process_entry($header, $xpath, $entry, $importer) {
 
@@ -2093,7 +2185,7 @@ class dfrn {
 		$item["body"] = limit_body_size($item["body"]);
 
 		/// @todo Do we really need this check for HTML elements? (It was copied from the old function)
-		if((strpos($item['body'],'<') !== false) && (strpos($item['body'],'>') !== false)) {
+		if ((strpos($item['body'],'<') !== false) && (strpos($item['body'],'>') !== false)) {
 
 			$item['body'] = reltoabs($item['body'],$base_url);
 
@@ -2122,21 +2214,24 @@ class dfrn {
 		$item["location"] = $xpath->query("dfrn:location/text()", $entry)->item(0)->nodeValue;
 
 		$georsspoint = $xpath->query("georss:point", $entry);
-		if ($georsspoint)
+		if ($georsspoint) {
 			$item["coord"] = $georsspoint->item(0)->nodeValue;
+		}
 
 		$item["private"] = $xpath->query("dfrn:private/text()", $entry)->item(0)->nodeValue;
 
 		$item["extid"] = $xpath->query("dfrn:extid/text()", $entry)->item(0)->nodeValue;
 
-		if ($xpath->query("dfrn:bookmark/text()", $entry)->item(0)->nodeValue == "true")
+		if ($xpath->query("dfrn:bookmark/text()", $entry)->item(0)->nodeValue == "true") {
 			$item["bookmark"] = true;
+		}
 
 		$notice_info = $xpath->query("statusnet:notice_info", $entry);
 		if ($notice_info AND ($notice_info->length > 0)) {
-			foreach($notice_info->item(0)->attributes AS $attributes) {
-				if ($attributes->name == "source")
+			foreach ($notice_info->item(0)->attributes AS $attributes) {
+				if ($attributes->name == "source") {
 					$item["app"] = strip_tags($attributes->textContent);
+				}
 			}
 		}
 
@@ -2144,21 +2239,24 @@ class dfrn {
 
 		// We store the data from "dfrn:diaspora_signature" in a different table, this is done in "item_store"
 		$dsprsig = unxmlify($xpath->query("dfrn:diaspora_signature/text()", $entry)->item(0)->nodeValue);
-		if ($dsprsig != "")
+		if ($dsprsig != "") {
 			$item["dsprsig"] = $dsprsig;
+		}
 
 		$item["verb"] = $xpath->query("activity:verb/text()", $entry)->item(0)->nodeValue;
 
-		if ($xpath->query("activity:object-type/text()", $entry)->item(0)->nodeValue != "")
+		if ($xpath->query("activity:object-type/text()", $entry)->item(0)->nodeValue != "") {
 			$item["object-type"] = $xpath->query("activity:object-type/text()", $entry)->item(0)->nodeValue;
+		}
 
 		$object = $xpath->query("activity:object", $entry)->item(0);
 		$item["object"] = self::transform_activity($xpath, $object, "object");
 
 		if (trim($item["object"]) != "") {
 			$r = parse_xml_string($item["object"], false);
-			if (isset($r->type))
+			if (isset($r->type)) {
 				$item["object-type"] = $r->type;
+			}
 		}
 
 		$target = $xpath->query("activity:target", $entry)->item(0);
@@ -2169,12 +2267,14 @@ class dfrn {
 			foreach ($categories AS $category) {
 				$term = "";
 				$scheme = "";
-				foreach($category->attributes AS $attributes) {
-					if ($attributes->name == "term")
+				foreach ($category->attributes AS $attributes) {
+					if ($attributes->name == "term") {
 						$term = $attributes->textContent;
+					}
 
-					if ($attributes->name == "scheme")
+					if ($attributes->name == "scheme") {
 						$scheme = $attributes->textContent;
+					}
 				}
 
 				if (($term != "") AND ($scheme != "")) {
@@ -2183,8 +2283,9 @@ class dfrn {
 						$termhash = array_shift($parts);
 						$termurl = implode(":", $parts);
 
-						if(strlen($item["tag"]))
+						if (strlen($item["tag"])) {
 							$item["tag"] .= ",";
+						}
 
 						$item["tag"] .= $termhash."[url=".$termurl."]".$term."[/url]";
 					}
@@ -2195,37 +2296,46 @@ class dfrn {
 		$enclosure = "";
 
 		$links = $xpath->query("atom:link", $entry);
-		if ($links)
+		if ($links) {
 			self::parse_links($links, $item);
+		}
 
 		// Is it a reply or a top level posting?
 		$item["parent-uri"] = $item["uri"];
 
 		$inreplyto = $xpath->query("thr:in-reply-to", $entry);
-		if (is_object($inreplyto->item(0)))
-			foreach($inreplyto->item(0)->attributes AS $attributes)
-				if ($attributes->name == "ref")
+		if (is_object($inreplyto->item(0))) {
+			foreach ($inreplyto->item(0)->attributes AS $attributes) {
+				if ($attributes->name == "ref") {
 					$item["parent-uri"] = $attributes->textContent;
+				}
+			}
+		}
 
 		// Get the type of the item (Top level post, reply or remote reply)
 		$entrytype = self::get_entry_type($importer, $item);
 
 		// Now assign the rest of the values that depend on the type of the message
 		if (in_array($entrytype, array(DFRN_REPLY, DFRN_REPLY_RC))) {
-			if (!isset($item["object-type"]))
+			if (!isset($item["object-type"])) {
 				$item["object-type"] = ACTIVITY_OBJ_COMMENT;
+			}
 
-			if ($item["contact-id"] != $owner["contact-id"])
+			if ($item["contact-id"] != $owner["contact-id"]) {
 				$item["contact-id"] = $owner["contact-id"];
+			}
 
-			if (($item["network"] != $owner["network"]) AND ($owner["network"] != ""))
+			if (($item["network"] != $owner["network"]) AND ($owner["network"] != "")) {
 				$item["network"] = $owner["network"];
+			}
 
-			if ($item["contact-id"] != $author["contact-id"])
+			if ($item["contact-id"] != $author["contact-id"]) {
 				$item["contact-id"] = $author["contact-id"];
+			}
 
-			if (($item["network"] != $author["network"]) AND ($author["network"] != ""))
+			if (($item["network"] != $author["network"]) AND ($author["network"] != "")) {
 				$item["network"] = $author["network"];
+			}
 
 			// This code was taken from the old DFRN code
 			// When activated, forums don't work.
@@ -2241,14 +2351,15 @@ class dfrn {
 			$item["type"] = "remote-comment";
 			$item["wall"] = 1;
 		} elseif ($entrytype == DFRN_TOP_LEVEL) {
-			if (!isset($item["object-type"]))
+			if (!isset($item["object-type"])) {
 				$item["object-type"] = ACTIVITY_OBJ_NOTE;
+			}
 
 			// Is it an event?
 			if ($item["object-type"] == ACTIVITY_OBJ_EVENT) {
 				logger("Item ".$item["uri"]." seems to contain an event.", LOGGER_DEBUG);
 				$ev = bbtoevent($item["body"]);
-				if((x($ev, "desc") || x($ev, "summary")) && x($ev, "start")) {
+				if ((x($ev, "desc") || x($ev, "summary")) && x($ev, "start")) {
 					logger("Event in item ".$item["uri"]." was found.", LOGGER_DEBUG);
 					$ev["cid"] = $importer["id"];
 					$ev["uid"] = $importer["uid"];
@@ -2261,8 +2372,9 @@ class dfrn {
 						dbesc($item["uri"]),
 						intval($importer["uid"])
 					);
-					if (dbm::is_result($r))
+					if (dbm::is_result($r)) {
 						$ev["id"] = $r[0]["id"];
+					}
 
 					$event_id = event_store($ev);
 					logger("Event ".$event_id." was stored", LOGGER_DEBUG);
@@ -2283,10 +2395,11 @@ class dfrn {
 
 		// Update content if 'updated' changes
 		if (dbm::is_result($r)) {
-			if (self::update_content($r[0], $item, $importer, $entrytype))
+			if (self::update_content($r[0], $item, $importer, $entrytype)) {
 				logger("Item ".$item["uri"]." was updated.", LOGGER_DEBUG);
-			else
+			} else {
 				logger("Item ".$item["uri"]." already existed.", LOGGER_DEBUG);
+			}
 			return;
 		}
 
@@ -2294,7 +2407,7 @@ class dfrn {
 			$posted_id = item_store($item);
 			$parent = 0;
 
-			if($posted_id) {
+			if ($posted_id) {
 
 				logger("Reply from contact ".$item["contact-id"]." was stored with id ".$posted_id, LOGGER_DEBUG);
 
@@ -2309,7 +2422,7 @@ class dfrn {
 					$parent_uri = $r[0]["parent-uri"];
 				}
 
-				if(!$is_like) {
+				if (!$is_like) {
 					$r1 = q("UPDATE `item` SET `last-child` = 0, `changed` = '%s' WHERE `uid` = %d AND `parent` = %d",
 						dbesc(datetime_convert()),
 						intval($importer["importer_uid"]),
@@ -2323,7 +2436,7 @@ class dfrn {
 					);
 				}
 
-				if($posted_id AND $parent AND ($entrytype == DFRN_REPLY_RC)) {
+				if ($posted_id AND $parent AND ($entrytype == DFRN_REPLY_RC)) {
 					logger("Notifying followers about comment ".$posted_id, LOGGER_DEBUG);
 					proc_run(PRIORITY_HIGH, "include/notifier.php", "comment-import", $posted_id);
 				}
@@ -2331,7 +2444,7 @@ class dfrn {
 				return true;
 			}
 		} else { // $entrytype == DFRN_TOP_LEVEL
-			if(!link_compare($item["owner-link"],$importer["url"])) {
+			if (!link_compare($item["owner-link"],$importer["url"])) {
 				// The item owner info is not our contact. It's OK and is to be expected if this is a tgroup delivery,
 				// but otherwise there's a possible data mixup on the sender's system.
 				// the tgroup delivery code called from item_store will correct it if it's a forum,
@@ -2342,7 +2455,7 @@ class dfrn {
 				$item["owner-avatar"] = $importer["thumb"];
 			}
 
-			if(($importer["rel"] == CONTACT_IS_FOLLOWER) && (!tgroup_check($importer["importer_uid"], $item))) {
+			if (($importer["rel"] == CONTACT_IS_FOLLOWER) && (!tgroup_check($importer["importer_uid"], $item))) {
 				logger("Contact ".$importer["id"]." is only follower and tgroup check was negative.", LOGGER_DEBUG);
 				return;
 			}
@@ -2371,19 +2484,23 @@ class dfrn {
 
 		logger("Processing deletions");
 
-		foreach($deletion->attributes AS $attributes) {
-			if ($attributes->name == "ref")
+		foreach ($deletion->attributes AS $attributes) {
+			if ($attributes->name == "ref") {
 				$uri = $attributes->textContent;
-			if ($attributes->name == "when")
+			}
+			if ($attributes->name == "when") {
 				$when = $attributes->textContent;
+			}
 		}
-		if ($when)
+		if ($when) {
 			$when = datetime_convert("UTC", "UTC", $when, "Y-m-d H:i:s");
-		else
+		} else {
 			$when = datetime_convert("UTC", "UTC", "now", "Y-m-d H:i:s");
+		}
 
-		if (!$uri OR !$importer["id"])
+		if (!$uri OR !$importer["id"]) {
 			return false;
+		}
 
 		/// @todo Only select the used fields
 		$r = q("SELECT `item`.*, `contact`.`self` FROM `item` INNER JOIN `contact` on `item`.`contact-id` = `contact`.`id`
@@ -2401,22 +2518,23 @@ class dfrn {
 
 			$entrytype = self::get_entry_type($importer, $item);
 
-			if(!$item["deleted"])
+			if (!$item["deleted"]) {
 				logger('deleting item '.$item["id"].' uri='.$uri, LOGGER_DEBUG);
-			else
+			} else {
 				return;
+			}
 
-			if($item["object-type"] == ACTIVITY_OBJ_EVENT) {
+			if ($item["object-type"] == ACTIVITY_OBJ_EVENT) {
 				logger("Deleting event ".$item["event-id"], LOGGER_DEBUG);
 				event_delete($item["event-id"]);
 			}
 
-			if(($item["verb"] == ACTIVITY_TAG) && ($item["object-type"] == ACTIVITY_OBJ_TAGTERM)) {
+			if (($item["verb"] == ACTIVITY_TAG) && ($item["object-type"] == ACTIVITY_OBJ_TAGTERM)) {
 
 				$xo = parse_xml_string($item["object"],false);
 				$xt = parse_xml_string($item["target"],false);
 
-				if($xt->type == ACTIVITY_OBJ_NOTE) {
+				if ($xt->type == ACTIVITY_OBJ_NOTE) {
 					$i = q("SELECT `id`, `contact-id`, `tag` FROM `item` WHERE `uri` = '%s' AND `uid` = %d LIMIT 1",
 						dbesc($xt->id),
 						intval($importer["importer_uid"])
@@ -2429,15 +2547,18 @@ class dfrn {
 						$author_remove = (($item["origin"] && $item["self"]) ? true : false);
 						$author_copy = (($item["origin"]) ? true : false);
 
-						if($owner_remove && $author_copy)
+						if ($owner_remove && $author_copy) {
 							return;
-						if($author_remove || $owner_remove) {
+						}
+						if ($author_remove || $owner_remove) {
 							$tags = explode(',',$i[0]["tag"]);
 							$newtags = array();
-							if(count($tags)) {
-								foreach($tags as $tag)
-									if(trim($tag) !== trim($xo->body))
+							if (count($tags)) {
+								foreach ($tags as $tag) {
+									if (trim($tag) !== trim($xo->body)) {
 										$newtags[] = trim($tag);
+									}
+								}
 							}
 							q("UPDATE `item` SET `tag` = '%s' WHERE `id` = %d",
 								dbesc(implode(',',$newtags)),
@@ -2578,25 +2699,30 @@ class dfrn {
 			);
 
 		$mails = $xpath->query("/atom:feed/dfrn:mail");
-		foreach ($mails AS $mail)
+		foreach ($mails AS $mail) {
 			self::process_mail($xpath, $mail, $importer);
+		}
 
 		$suggestions = $xpath->query("/atom:feed/dfrn:suggest");
-		foreach ($suggestions AS $suggestion)
+		foreach ($suggestions AS $suggestion) {
 			self::process_suggestion($xpath, $suggestion, $importer);
+		}
 
 		$relocations = $xpath->query("/atom:feed/dfrn:relocate");
-		foreach ($relocations AS $relocation)
+		foreach ($relocations AS $relocation) {
 			self::process_relocation($xpath, $relocation, $importer);
+		}
 
 		$deletions = $xpath->query("/atom:feed/at:deleted-entry");
-		foreach ($deletions AS $deletion)
+		foreach ($deletions AS $deletion) {
 			self::process_deletion($xpath, $deletion, $importer);
+		}
 
 		if (!$sort_by_date) {
 			$entries = $xpath->query("/atom:feed/atom:entry");
-			foreach ($entries AS $entry)
+			foreach ($entries AS $entry) {
 				self::process_entry($header, $xpath, $entry, $importer);
+			}
 		} else {
 			$newentries = array();
 			$entries = $xpath->query("/atom:feed/atom:entry");
@@ -2608,8 +2734,9 @@ class dfrn {
 			// Now sort after the publishing date
 			ksort($newentries);
 
-			foreach ($newentries AS $entry)
+			foreach ($newentries AS $entry) {
 				self::process_entry($header, $xpath, $entry, $importer);
+			}
 		}
 		logger("Import done for user ".$importer["uid"]." from contact ".$importer["id"], LOGGER_DEBUG);
 	}

--- a/include/dfrn.php
+++ b/include/dfrn.php
@@ -1085,9 +1085,9 @@ class dfrn {
 
 
 			if ($dfrn_version >= 2.1) {
-				if (($contact['duplex'] && strlen($contact['pubkey'])) {
+				if (($contact['duplex'] && strlen($contact['pubkey']))
 					|| ($owner['page-flags'] == PAGE_COMMUNITY && strlen($contact['pubkey']))
-					|| ($contact['rel'] == CONTACT_IS_SHARING && strlen($contact['pubkey'])))
+					|| ($contact['rel'] == CONTACT_IS_SHARING && strlen($contact['pubkey']))) {
 
 					openssl_public_encrypt($key,$postvars['key'],$contact['pubkey']);
 				} else {

--- a/include/ostatus.php
+++ b/include/ostatus.php
@@ -1245,7 +1245,7 @@ class ostatus {
 							"title", "attach", "app", "type", "location", "contact-id", "uri");
 				foreach ($copy_fields AS $field) {
 					if (isset($item[$field])) {
-						$arr[$field] = $item[$field]; {
+						$arr[$field] = $item[$field];
 					}
 				}
 

--- a/include/ostatus.php
+++ b/include/ostatus.php
@@ -104,24 +104,29 @@ class ostatus {
 			//	$contact["poll"] = $value;
 
 			$value = $xpath->evaluate('atom:author/atom:uri/text()', $context)->item(0)->nodeValue;
-			if ($value != "")
+			if ($value != "") {
 				$contact["alias"] = $value;
+			}
 
 			$value = $xpath->evaluate('atom:author/poco:displayName/text()', $context)->item(0)->nodeValue;
-			if ($value != "")
+			if ($value != "") {
 				$contact["name"] = $value;
+			}
 
 			$value = $xpath->evaluate('atom:author/poco:preferredUsername/text()', $context)->item(0)->nodeValue;
-			if ($value != "")
+			if ($value != "") {
 				$contact["nick"] = $value;
+			}
 
 			$value = $xpath->evaluate('atom:author/poco:note/text()', $context)->item(0)->nodeValue;
-			if ($value != "")
+			if ($value != "") {
 				$contact["about"] = html2bbcode($value);
+			}
 
 			$value = $xpath->evaluate('atom:author/poco:address/poco:formatted/text()', $context)->item(0)->nodeValue;
-			if ($value != "")
+			if ($value != "") {
 				$contact["location"] = $value;
+			}
 
 			if (($contact["name"] != $r[0]["name"]) OR ($contact["nick"] != $r[0]["nick"]) OR ($contact["about"] != $r[0]["about"]) OR
 				($contact["alias"] != $r[0]["alias"]) OR ($contact["location"] != $r[0]["location"])) {
@@ -179,8 +184,9 @@ class ostatus {
 	 */
 	public static function salmon_author($xml, $importer) {
 
-		if ($xml == "")
+		if ($xml == "") {
 			return;
+		}
 
 		$doc = new DOMDocument();
 		@$doc->loadXML($xml);
@@ -217,8 +223,9 @@ class ostatus {
 
 		logger("Import OStatus message", LOGGER_DEBUG);
 
-		if ($xml == "")
+		if ($xml == "") {
 			return;
+		}
 
 		//$tempfile = tempnam(get_temppath(), "import");
 		//file_put_contents($tempfile, $xml);
@@ -238,12 +245,14 @@ class ostatus {
 
 		$gub = "";
 		$hub_attributes = $xpath->query("/atom:feed/atom:link[@rel='hub']")->item(0)->attributes;
-		if (is_object($hub_attributes))
-			foreach($hub_attributes AS $hub_attribute)
+		if (is_object($hub_attributes)) {
+			foreach($hub_attributes AS $hub_attribute) {
 				if ($hub_attribute->name == "href") {
 					$hub = $hub_attribute->textContent;
 					logger("Found hub ".$hub, LOGGER_DEBUG);
 				}
+			}
+		}
 
 		$header = array();
 		$header["uid"] = $importer["uid"];
@@ -257,10 +266,11 @@ class ostatus {
 		// depending on that, the first node is different
 		$first_child = $doc->firstChild->tagName;
 
-		if ($first_child == "feed")
+		if ($first_child == "feed") {
 			$entries = $xpath->query('/atom:feed/atom:entry');
-		else
+		} else {
 			$entries = $xpath->query('/atom:entry');
+		}
 
 		$conversation = "";
 		$conversationlist = array();
@@ -277,16 +287,18 @@ class ostatus {
 			$mention = false;
 
 			// fetch the author
-			if ($first_child == "feed")
+			if ($first_child == "feed") {
 				$author = self::fetchauthor($xpath, $doc->firstChild, $importer, $contact, false);
-			else
+			} else {
 				$author = self::fetchauthor($xpath, $entry, $importer, $contact, false);
+			}
 
 			$value = $xpath->evaluate('atom:author/poco:preferredUsername/text()', $context)->item(0)->nodeValue;
-			if ($value != "")
+			if ($value != "") {
 				$nickname = $value;
-			else
+			} else {
 				$nickname = $author["author-name"];
+			}
 
 			$item = array_merge($header, $author);
 
@@ -295,7 +307,7 @@ class ostatus {
 
 			$r = q("SELECT `id` FROM `item` WHERE `uid` = %d AND `uri` = '%s'",
 				intval($importer["uid"]), dbesc($item["uri"]));
-			if ($r) {
+			if (dbm::is_result($r)) {
 				logger("Item with uri ".$item["uri"]." for user ".$importer["uid"]." already existed under id ".$r[0]["id"], LOGGER_DEBUG);
 				continue;
 			}
@@ -306,8 +318,9 @@ class ostatus {
 			if (($item["object-type"] == ACTIVITY_OBJ_BOOKMARK) OR ($item["object-type"] == ACTIVITY_OBJ_EVENT)) {
 				$item["title"] = $xpath->query('atom:title/text()', $entry)->item(0)->nodeValue;
 				$item["body"] = $xpath->query('atom:summary/text()', $entry)->item(0)->nodeValue;
-			} elseif ($item["object-type"] == ACTIVITY_OBJ_QUESTION)
+			} elseif ($item["object-type"] == ACTIVITY_OBJ_QUESTION) {
 				$item["title"] = $xpath->query('atom:title/text()', $entry)->item(0)->nodeValue;
+			}
 
 			$item["object"] = $xml;
 			$item["verb"] = $xpath->query('activity:verb/text()', $entry)->item(0)->nodeValue;
@@ -352,8 +365,9 @@ class ostatus {
 			}
 
 			// http://activitystrea.ms/schema/1.0/rsvp-yes
-			if (!in_array($item["verb"], array(ACTIVITY_POST, ACTIVITY_LIKE, ACTIVITY_SHARE)))
+			if (!in_array($item["verb"], array(ACTIVITY_POST, ACTIVITY_LIKE, ACTIVITY_SHARE))) {
 				logger("Unhandled verb ".$item["verb"]." ".print_r($item, true));
+			}
 
 			$item["created"] = $xpath->query('atom:published/text()', $entry)->item(0)->nodeValue;
 			$item["edited"] = $xpath->query('atom:updated/text()', $entry)->item(0)->nodeValue;
@@ -364,10 +378,12 @@ class ostatus {
 			$inreplyto = $xpath->query('thr:in-reply-to', $entry);
 			if (is_object($inreplyto->item(0))) {
 				foreach($inreplyto->item(0)->attributes AS $attributes) {
-					if ($attributes->name == "ref")
+					if ($attributes->name == "ref") {
 						$item["parent-uri"] = $attributes->textContent;
-					if ($attributes->name == "href")
+					}
+					if ($attributes->name == "href") {
 						$related = $attributes->textContent;
+					}
 				}
 			}
 
@@ -411,7 +427,7 @@ class ostatus {
 						if ($attributes->name == "title")
 							$title = $attributes->textContent;
 					}
-					if (($rel != "") AND ($href != ""))
+					if (($rel != "") AND ($href != "")) {
 						switch($rel) {
 							case "alternate":
 								$item["plink"] = $href;
@@ -448,6 +464,7 @@ class ostatus {
 									$mention = true;
 								break;
 						}
+					}
 				}
 			}
 
@@ -457,12 +474,15 @@ class ostatus {
 			$notice_info = $xpath->query('statusnet:notice_info', $entry);
 			if ($notice_info AND ($notice_info->length > 0)) {
 				foreach($notice_info->item(0)->attributes AS $attributes) {
-					if ($attributes->name == "source")
+					if ($attributes->name == "source") {
 						$item["app"] = strip_tags($attributes->textContent);
-					if ($attributes->name == "local_id")
+					}
+					if ($attributes->name == "local_id") {
 						$local_id = $attributes->textContent;
-					if ($attributes->name == "repeat_of")
+					}
+					if ($attributes->name == "repeat_of") {
 						$repeat_of = $attributes->textContent;
+					}
 				}
 			}
 
@@ -473,24 +493,32 @@ class ostatus {
 				if (is_object($activityobjects)) {
 
 					$orig_uri = $xpath->query("activity:object/atom:id", $activityobjects)->item(0)->nodeValue;
-					if (!isset($orig_uri))
+					if (!isset($orig_uri)) {
 						$orig_uri = $xpath->query('atom:id/text()', $activityobjects)->item(0)->nodeValue;
+					}
 
 					$orig_links = $xpath->query("activity:object/atom:link[@rel='alternate']", $activityobjects);
-					if ($orig_links AND ($orig_links->length > 0))
-						foreach($orig_links->item(0)->attributes AS $attributes)
-							if ($attributes->name == "href")
+					if ($orig_links AND ($orig_links->length > 0)) {
+						foreach ($orig_links->item(0)->attributes AS $attributes) {
+							if ($attributes->name == "href") {
 								$orig_link = $attributes->textContent;
+							}
+						}
+					}
 
-					if (!isset($orig_link))
+					if (!isset($orig_link)) {
 						$orig_link = $xpath->query("atom:link[@rel='alternate']", $activityobjects)->item(0)->nodeValue;
+					}
 
-					if (!isset($orig_link))
+					if (!isset($orig_link)) {
 						$orig_link =  self::convert_href($orig_uri);
+					}
 
 					$orig_body = $xpath->query('activity:object/atom:content/text()', $activityobjects)->item(0)->nodeValue;
-					if (!isset($orig_body))
+
+					if (!isset($orig_body)) {
 						$orig_body = $xpath->query('atom:content/text()', $activityobjects)->item(0)->nodeValue;
+					}
 
 					$orig_created = $xpath->query('atom:published/text()', $activityobjects)->item(0)->nodeValue;
 					$orig_edited = $xpath->query('atom:updated/text()', $activityobjects)->item(0)->nodeValue;
@@ -511,8 +539,10 @@ class ostatus {
 					$item["verb"] = $xpath->query('activity:verb/text()', $activityobjects)->item(0)->nodeValue;
 
 					$item["object-type"] = $xpath->query('activity:object/activity:object-type/text()', $activityobjects)->item(0)->nodeValue;
-					if (!isset($item["object-type"]))
+
+					if (!isset($item["object-type"])) {
 						$item["object-type"] = $xpath->query('activity:object-type/text()', $activityobjects)->item(0)->nodeValue;
+					}
 				}
 			}
 
@@ -540,12 +570,14 @@ class ostatus {
 							intval($importer["uid"]), dbesc($item["parent-uri"]));
 					}
 				}
-				if ($r) {
+
+				if (dbm::is_result($r)) {
 					$item["type"] = 'remote-comment';
 					$item["gravity"] = GRAVITY_COMMENT;
 				}
-			} else
+			} else {
 				$item["parent-uri"] = $item["uri"];
+			}
 
 			$item_id = self::completion($conversation, $importer["uid"], $item, $self);
 

--- a/mod/contacts.php
+++ b/mod/contacts.php
@@ -136,8 +136,7 @@ function contacts_batch_actions(App $a) {
 
 	if (x($_SESSION,'return_url')) {
 		goaway('' . $_SESSION['return_url']);
-	}
-	else {
+	} else {
 		goaway('contacts');
 	}
 
@@ -194,8 +193,10 @@ function contacts_post(App $a) {
 	$ffi_keyword_blacklist = fix_mce_lf(escape_tags(trim($_POST['ffi_keyword_blacklist'])));
 
 	$priority = intval($_POST['poll']);
-	if($priority > 5 || $priority < 0)
+
+	if ($priority > 5 || $priority < 0) {
 		$priority = 0;
+	}
 
 	$info = fix_mce_lf(escape_tags(trim($_POST['info'])));
 
@@ -212,17 +213,20 @@ function contacts_post(App $a) {
 		intval($contact_id),
 		intval(local_user())
 	);
-	if($r)
+	if ($r) {
 		info( t('Contact updated.') . EOL);
-	else
+	} else {
 		notice( t('Failed to update contact record.') . EOL);
+	}
 
-	$r = q("select * from contact where id = %d and uid = %d limit 1",
+	$r = q("SELECT * FROM `contact` WHERE `id` = %d AND `uid` = %d LIMIT 1",
 		intval($contact_id),
 		intval(local_user())
 	);
-	if($r && dbm::is_result($r))
+
+	if (dbm::is_result($r)) {
 		$a->data['contact'] = $r[0];
+	}
 
 	return;
 

--- a/mod/crepair.php
+++ b/mod/crepair.php
@@ -20,10 +20,11 @@ function crepair_init(App $a) {
 		}
 	}
 
-	if(! x($a->page,'aside'))
+	if (! x($a->page,'aside')) {
 		$a->page['aside'] = '';
+	}
 
-	if($contact_id) {
+	if ($contact_id) {
 		$a->data['contact'] = $r[0];
 		$contact = $r[0];
 		profile_load($a, "", 0, get_contact_details_by_url($contact["url"]));
@@ -35,9 +36,12 @@ function crepair_post(App $a) {
 		return;
 	}
 
+	// Init $r here if $cid is not set
+	$r = false;
+
 	$cid = (($a->argc > 1) ? intval($a->argv[1]) : 0);
 
-	if($cid) {
+	if ($cid) {
 		$r = q("SELECT * FROM `contact` WHERE `id` = %d AND `uid` = %d LIMIT 1",
 			intval($cid),
 			intval(local_user())
@@ -78,18 +82,18 @@ function crepair_post(App $a) {
 		local_user()
 	);
 
-	if($photo) {
+	if ($photo) {
 		logger('mod-crepair: updating photo from ' . $photo);
 		require_once("include/Photo.php");
 
 		update_contact_avatar($photo,local_user(),$contact['id']);
 	}
 
-	if($r)
+	if ($r) {
 		info( t('Contact settings applied.') . EOL);
-	else
+	} else {
 		notice( t('Contact update failed.') . EOL);
-
+	}
 
 	return;
 }

--- a/mod/dfrn_confirm.php
+++ b/mod/dfrn_confirm.php
@@ -588,17 +588,18 @@ function dfrn_confirm_post(App $a, $handsfree = null) {
 			dbesc($decrypted_source_url),
 			intval($local_uid)
 		);
-		if(! count($ret)) {
-			if(strstr($decrypted_source_url,'http:'))
+		if (!dbm::is_result($ret)) {
+			if (strstr($decrypted_source_url,'http:')) {
 				$newurl = str_replace('http:','https:',$decrypted_source_url);
-			else
+			} else {
 				$newurl = str_replace('https:','http:',$decrypted_source_url);
+			}
 
 			$ret = q("SELECT * FROM `contact` WHERE `url` = '%s' AND `uid` = %d LIMIT 1",
 				dbesc($newurl),
 				intval($local_uid)
 			);
-			if(! count($ret)) {
+			if (!dbm::is_result($ret)) {
 				// this is either a bogus confirmation (?) or we deleted the original introduction.
 				$message = t('Contact record was not found for you on our site.');
 				xml_status(3,$message);
@@ -613,7 +614,7 @@ function dfrn_confirm_post(App $a, $handsfree = null) {
 		$foreign_pubkey = $ret[0]['site-pubkey'];
 		$dfrn_record    = $ret[0]['id'];
 
-		if(! $foreign_pubkey) {
+		if (! $foreign_pubkey) {
 			$message = sprintf( t('Site public key not available in contact record for URL %s.'), $newurl);
 			xml_status(3,$message);
 		}
@@ -621,7 +622,7 @@ function dfrn_confirm_post(App $a, $handsfree = null) {
 		$decrypted_dfrn_id = "";
 		openssl_public_decrypt($dfrn_id,$decrypted_dfrn_id,$foreign_pubkey);
 
-		if(strlen($aes_key)) {
+		if (strlen($aes_key)) {
 			$decrypted_aes_key = "";
 			openssl_private_decrypt($aes_key,$decrypted_aes_key,$my_prvkey);
 			$dfrn_pubkey = openssl_decrypt($public_key,'AES-256-CBC',$decrypted_aes_key);

--- a/mod/message.php
+++ b/mod/message.php
@@ -262,8 +262,9 @@ function message_content(App $a) {
 				//	);
 				//}
 
-				if($r)
+				if ($r) {
 					info( t('Conversation removed.') . EOL );
+				}
 			}
 			//goaway(App::get_baseurl(true) . '/message' );
 			goaway($_SESSION['return_url']);

--- a/mod/profiles.php
+++ b/mod/profiles.php
@@ -34,8 +34,9 @@ function profiles_init(App $a) {
 			intval($a->argv[2]),
 			intval(local_user())
 		);
-		if($r)
+		if ($r) {
 			info(t('Profile deleted.').EOL);
+		}
 
 		goaway('profiles');
 		return; // NOTREACHED
@@ -473,11 +474,12 @@ function profiles_post(App $a) {
 			intval(local_user())
 		);
 
-		if($r)
+		if ($r) {
 			info( t('Profile updated.') . EOL);
+		}
 
 
-		if($namechanged && $is_default) {
+		if ($namechanged && $is_default) {
 			$r = q("UPDATE `contact` SET `name` = '%s', `name-date` = '%s' WHERE `self` = 1 AND `uid` = %d",
 				dbesc($name),
 				dbesc(datetime_convert()),
@@ -489,7 +491,7 @@ function profiles_post(App $a) {
 			);
 		}
 
-		if($is_default) {
+		if ($is_default) {
 			$location = formatted_location(array("locality" => $locality, "region" => $region, "country-name" => $country_name));
 
 			q("UPDATE `contact` SET `about` = '%s', `location` = '%s', `keywords` = '%s', `gender` = '%s' WHERE `self` AND `uid` = %d",

--- a/mod/profiles.php
+++ b/mod/profiles.php
@@ -264,13 +264,12 @@ function profiles_post(App $a) {
 				}
 				else {
 					$newname = $lookup;
-/*					if(strstr($lookup,' ')) {
+/*					if (strstr($lookup,' ')) {
 						$r = q("SELECT * FROM `contact` WHERE `name` = '%s' AND `uid` = %d LIMIT 1",
 							dbesc($newname),
 							intval(local_user())
 						);
-					}
-					else {
+					} else {
 						$r = q("SELECT * FROM `contact` WHERE `nick` = '%s' AND `uid` = %d LIMIT 1",
 							dbesc($lookup),
 							intval(local_user())

--- a/mod/settings.php
+++ b/mod/settings.php
@@ -364,22 +364,22 @@ function settings_post(App $a) {
 
 	call_hooks('settings_post', $_POST);
 
-	if((x($_POST,'password')) || (x($_POST,'confirm'))) {
+	if ((x($_POST,'password')) || (x($_POST,'confirm'))) {
 
 		$newpass = $_POST['password'];
 		$confirm = $_POST['confirm'];
 		$oldpass = hash('whirlpool', $_POST['opassword']);
 
 		$err = false;
-		if($newpass != $confirm ) {
+		if ($newpass != $confirm ) {
 			notice( t('Passwords do not match. Password unchanged.') . EOL);
 			$err = true;
 		}
 
-		if((! x($newpass)) || (! x($confirm))) {
+		if ((! x($newpass)) || (! x($confirm))) {
 			notice( t('Empty passwords are not allowed. Password unchanged.') . EOL);
 			$err = true;
-        }
+		}
 
 		//  check if the old password was supplied correctly before
 		//  changing it to the new value

--- a/mod/settings.php
+++ b/mod/settings.php
@@ -381,13 +381,15 @@ function settings_post(App $a) {
 			$err = true;
         }
 
-        //  check if the old password was supplied correctly before
-        //  changing it to the new value
-        $r = q("SELECT `password` FROM `user`WHERE `uid` = %d LIMIT 1", intval(local_user()));
-        if( $oldpass != $r[0]['password'] ) {
-            notice( t('Wrong password.') . EOL);
-            $err = true;
-        }
+		//  check if the old password was supplied correctly before
+		//  changing it to the new value
+		$r = q("SELECT `password` FROM `user`WHERE `uid` = %d LIMIT 1", intval(local_user()));
+		if (!dbm::is_result($r)) {
+			killme();
+		} elseif ( $oldpass != $r[0]['password'] ) {
+			notice( t('Wrong password.') . EOL);
+			$err = true;
+		}
 
 		if(! $err) {
 			$password = hash('whirlpool',$newpass);
@@ -395,10 +397,11 @@ function settings_post(App $a) {
 				dbesc($password),
 				intval(local_user())
 			);
-			if($r)
+			if($r) {
 				info( t('Password changed.') . EOL);
-			else
+			} else {
 				notice( t('Password update failed. Please try again.') . EOL);
+			}
 		}
 	}
 

--- a/mod/settings.php
+++ b/mod/settings.php
@@ -397,7 +397,7 @@ function settings_post(App $a) {
 				dbesc($password),
 				intval(local_user())
 			);
-			if($r) {
+			if ($r) {
 				info( t('Password changed.') . EOL);
 			} else {
 				notice( t('Password update failed. Please try again.') . EOL);
@@ -602,8 +602,9 @@ function settings_post(App $a) {
 			dbesc($language),
 			intval(local_user())
 	);
-	if($r)
+	if ($r) {
 		info( t('Settings updated.') . EOL);
+	}
 
 	// clear session language
 	unset($_SESSION['language']);
@@ -622,7 +623,7 @@ function settings_post(App $a) {
 	);
 
 
-	if($name_change) {
+	if ($name_change) {
 		q("UPDATE `contact` SET `name` = '%s', `name-date` = '%s' WHERE `uid` = %d AND `self`",
 			dbesc($username),
 			dbesc(datetime_convert()),

--- a/mod/settings.php
+++ b/mod/settings.php
@@ -391,7 +391,7 @@ function settings_post(App $a) {
 			$err = true;
 		}
 
-		if(! $err) {
+		if (! $err) {
 			$password = hash('whirlpool',$newpass);
 			$r = q("UPDATE `user` SET `password` = '%s' WHERE `uid` = %d",
 				dbesc($password),
@@ -445,32 +445,41 @@ function settings_post(App $a) {
 
 	$notify = 0;
 
-	if(x($_POST,'notify1'))
+	if (x($_POST,'notify1')) {
 		$notify += intval($_POST['notify1']);
-	if(x($_POST,'notify2'))
+	}
+	if (x($_POST,'notify2')) {
 		$notify += intval($_POST['notify2']);
-	if(x($_POST,'notify3'))
+	}
+	if (x($_POST,'notify3')) {
 		$notify += intval($_POST['notify3']);
-	if(x($_POST,'notify4'))
+	}
+	if (x($_POST,'notify4')) {
 		$notify += intval($_POST['notify4']);
-	if(x($_POST,'notify5'))
+	}
+	if (x($_POST,'notify5')) {
 		$notify += intval($_POST['notify5']);
-	if(x($_POST,'notify6'))
+	}
+	if (x($_POST,'notify6')) {
 		$notify += intval($_POST['notify6']);
-	if(x($_POST,'notify7'))
+	}
+	if (x($_POST,'notify7')) {
 		$notify += intval($_POST['notify7']);
-	if(x($_POST,'notify8'))
+	}
+	if (x($_POST,'notify8')) {
 		$notify += intval($_POST['notify8']);
+	}
 
 	// Adjust the page flag if the account type doesn't fit to the page flag.
-	if (($account_type == ACCOUNT_TYPE_PERSON) AND !in_array($page_flags, array(PAGE_NORMAL, PAGE_SOAPBOX, PAGE_FREELOVE)))
+	if (($account_type == ACCOUNT_TYPE_PERSON) AND !in_array($page_flags, array(PAGE_NORMAL, PAGE_SOAPBOX, PAGE_FREELOVE))) {
 		$page_flags = PAGE_NORMAL;
-	elseif (($account_type == ACCOUNT_TYPE_ORGANISATION) AND !in_array($page_flags, array(PAGE_SOAPBOX)))
+	} elseif (($account_type == ACCOUNT_TYPE_ORGANISATION) AND !in_array($page_flags, array(PAGE_SOAPBOX))) {
 		$page_flags = PAGE_SOAPBOX;
-	elseif (($account_type == ACCOUNT_TYPE_NEWS) AND !in_array($page_flags, array(PAGE_SOAPBOX)))
+	} elseif (($account_type == ACCOUNT_TYPE_NEWS) AND !in_array($page_flags, array(PAGE_SOAPBOX))) {
 		$page_flags = PAGE_SOAPBOX;
-	elseif (($account_type == ACCOUNT_TYPE_COMMUNITY) AND !in_array($page_flags, array(PAGE_COMMUNITY, PAGE_PRVGROUP)))
+	} elseif (($account_type == ACCOUNT_TYPE_COMMUNITY) AND !in_array($page_flags, array(PAGE_COMMUNITY, PAGE_PRVGROUP))) {
 		$page_flags = PAGE_COMMUNITY;
+	}
 
 	$email_changed = false;
 
@@ -480,13 +489,15 @@ function settings_post(App $a) {
 
 	if($username != $a->user['username']) {
 		$name_change = true;
-		if(strlen($username) > 40)
+		if (strlen($username) > 40) {
 			$err .= t(' Please use a shorter name.');
-		if(strlen($username) < 3)
+		}
+		if (strlen($username) < 3) {
 			$err .= t(' Name too short.');
+		}
 	}
 
-	if($email != $a->user['email']) {
+	if ($email != $a->user['email']) {
 		$email_changed = true;
 		//  check for the correct password
 		$r = q("SELECT `password` FROM `user`WHERE `uid` = %d LIMIT 1", intval(local_user()));
@@ -496,11 +507,12 @@ function settings_post(App $a) {
 			$email = $a->user['email'];
 		}
 		//  check the email is valid
-		if(! valid_email($email))
+		if (! valid_email($email)) {
 			$err .= t(' Not valid email.');
+		}
 		//  ensure new email is not the admin mail
 		//if((x($a->config,'admin_email')) && (strcasecmp($email,$a->config['admin_email']) == 0)) {
-		if(x($a->config,'admin_email')) {
+		if (x($a->config,'admin_email')) {
 			$adminlist = explode(",", str_replace(" ", "", strtolower($a->config['admin_email'])));
 			if (in_array(strtolower($email), $adminlist)) {
 				$err .= t(' Cannot change to that email.');
@@ -509,14 +521,13 @@ function settings_post(App $a) {
 		}
 	}
 
-	if(strlen($err)) {
+	if (strlen($err)) {
 		notice($err . EOL);
 		return;
 	}
 
-	if($timezone != $a->user['timezone']) {
-		if(strlen($timezone))
-			date_default_timezone_set($timezone);
+	if ($timezone != $a->user['timezone'] && strlen($timezone)) {
+		date_default_timezone_set($timezone);
 	}
 
 	$str_group_allow   = perms2str($_POST['group_allow']);
@@ -529,17 +540,17 @@ function settings_post(App $a) {
 
 	// If openid has changed or if there's an openid but no openidserver, try and discover it.
 
-	if($openid != $a->user['openid'] || (strlen($openid) && (! strlen($openidserver)))) {
+	if ($openid != $a->user['openid'] || (strlen($openid) && (! strlen($openidserver)))) {
 		$tmp_str = $openid;
-		if(strlen($tmp_str) && validate_url($tmp_str)) {
+		if (strlen($tmp_str) && validate_url($tmp_str)) {
 			logger('updating openidserver');
 			require_once('library/openid.php');
 			$open_id_obj = new LightOpenID;
 			$open_id_obj->identity = $openid;
 			$openidserver = $open_id_obj->discover($open_id_obj->identity);
-		}
-		else
+		} else {
 			$openidserver = '';
+		}
 	}
 
 	set_pconfig(local_user(),'expire','items', $expire_items);
@@ -555,14 +566,13 @@ function settings_post(App $a) {
 
 	set_pconfig(local_user(),'system','email_textonly', $email_textonly);
 
-	if($page_flags == PAGE_PRVGROUP) {
+	if ($page_flags == PAGE_PRVGROUP) {
 		$hidewall = 1;
-		if((! $str_contact_allow) && (! $str_group_allow) && (! $str_contact_deny) && (! $str_group_deny)) {
-			if($def_gid) {
+		if ((! $str_contact_allow) && (! $str_group_allow) && (! $str_contact_deny) && (! $str_group_deny)) {
+			if ($def_gid) {
 				info( t('Private forum has no privacy permissions. Using default privacy group.'). EOL);
 				$str_group_allow = '<' . $def_gid . '>';
-			}
-			else {
+			} else {
 				notice( t('Private forum has no privacy permissions and no default privacy group.') . EOL);
 			}
 		}
@@ -672,8 +682,6 @@ function settings_content(App $a) {
 		notice( t('Permission denied.') . EOL );
 		return;
 	}
-
-
 
 	if (($a->argc > 1) && ($a->argv[1] === 'oauth')) {
 

--- a/mod/wall_upload.php
+++ b/mod/wall_upload.php
@@ -215,7 +215,7 @@ function wall_upload_post(App $a, $desktopmode = true) {
 
 	$r = $ph->store($page_owner_uid, $visitor, $hash, $filename, t('Wall Photos'), 0, 0, $defperm);
 
-	if(! $r) {
+	if (! $r) {
 		$msg = t('Image upload failed.');
 		if ($r_json) {
 			echo json_encode(array('error'=>$msg));
@@ -225,18 +225,20 @@ function wall_upload_post(App $a, $desktopmode = true) {
 		killme();
 	}
 
-	if($width > 640 || $height > 640) {
+	if ($width > 640 || $height > 640) {
 		$ph->scaleImage(640);
 		$r = $ph->store($page_owner_uid, $visitor, $hash, $filename, t('Wall Photos'), 1, 0, $defperm);
-		if ($r)
+		if ($r) {
 			$smallest = 1;
+		}
 	}
 
 	if ($width > 320 || $height > 320) {
 		$ph->scaleImage(320);
 		$r = $ph->store($page_owner_uid, $visitor, $hash, $filename, t('Wall Photos'), 2, 0, $defperm);
-		if ($r AND ($smallest == 0))
+		if ($r AND ($smallest == 0)) {
 			$smallest = 2;
+		}
 	}
 
 	$basename = basename($filename);

--- a/mod/wall_upload.php
+++ b/mod/wall_upload.php
@@ -228,14 +228,14 @@ function wall_upload_post(App $a, $desktopmode = true) {
 	if($width > 640 || $height > 640) {
 		$ph->scaleImage(640);
 		$r = $ph->store($page_owner_uid, $visitor, $hash, $filename, t('Wall Photos'), 1, 0, $defperm);
-		if($r)
+		if ($r)
 			$smallest = 1;
 	}
 
-	if($width > 320 || $height > 320) {
+	if ($width > 320 || $height > 320) {
 		$ph->scaleImage(320);
 		$r = $ph->store($page_owner_uid, $visitor, $hash, $filename, t('Wall Photos'), 2, 0, $defperm);
-		if($r AND ($smallest == 0))
+		if ($r AND ($smallest == 0))
 			$smallest = 2;
 	}
 
@@ -244,7 +244,7 @@ function wall_upload_post(App $a, $desktopmode = true) {
 	if (!$desktopmode) {
 
 		$r = q("SELECT `id`, `datasize`, `width`, `height`, `type` FROM `photo` WHERE `resource-id` = '%s' ORDER BY `width` DESC LIMIT 1", $hash);
-		if (!$r){
+		if (!dbm::is_result($r)) {
 			if ($r_json) {
 				echo json_encode(array('error'=>''));
 				killme();

--- a/update.php
+++ b/update.php
@@ -311,7 +311,7 @@ function update_1031() {
 	$r = q("SELECT `id`, `object` FROM `item` WHERE `object` != '' ");
 	if (dbm::is_result($r)) {
 		foreach ($r as $rr) {
-			if(strstr($rr['object'],'type=&quot;http')) {
+			if (strstr($rr['object'],'type=&quot;http')) {
 				q("UPDATE `item` SET `object` = '%s' WHERE `id` = %d",
 					dbesc(str_replace('type=&quot;http','href=&quot;http',$rr['object'])),
 					intval($rr['id'])

--- a/update.php
+++ b/update.php
@@ -157,14 +157,15 @@ function update_1014() {
 	$r = q("SELECT * FROM `contact` WHERE 1");
 	if (dbm::is_result($r)) {
 		foreach ($r as $rr) {
-			if(stristr($rr['thumb'],'avatar'))
+			if (stristr($rr['thumb'],'avatar')) {
 				q("UPDATE `contact` SET `micro` = '%s' WHERE `id` = %d",
 					dbesc(str_replace('avatar','micro',$rr['thumb'])),
 					intval($rr['id']));
-			else
+			} else {
 				q("UPDATE `contact` SET `micro` = '%s' WHERE `id` = %d",
 					dbesc(str_replace('5.jpg','6.jpg',$rr['thumb'])),
 					intval($rr['id']));
+			}
 		}
 	}
 }
@@ -595,10 +596,11 @@ function update_1074() {
 	q("ALTER TABLE `user` ADD `hidewall` TINYINT( 1) NOT NULL DEFAULT '0' AFTER `blockwall` ");
 	$r = q("SELECT `uid` FROM `profile` WHERE `is-default` = 1 AND `hidewall` = 1");
 	if (dbm::is_result($r)) {
-		foreach ($r as $rr)
+		foreach ($r as $rr) {
 			q("UPDATE `user` SET `hidewall` = 1 WHERE `uid` = %d",
 				intval($rr['uid'])
 			);
+		}
 	}
 	q("ALTER TABLE `profile` DROP `hidewall`");
 }
@@ -1782,19 +1784,22 @@ function update_1190() {
 			$key = $rr['k'];
 			$value = $rr['v'];
 
-			if ($key === 'randomise')
+			if ($key === 'randomise') {
 				del_pconfig($uid,$family,$key);
+			}
 
 			if ($key === 'show_on_profile') {
-				if ($value)
+				if ($value) {
 					set_pconfig($uid,feature,forumlist_profile,$value);
+				}
 
 				del_pconfig($uid,$family,$key);
 			}
 
 			if ($key === 'show_on_network') {
-				if ($value)
+				if ($value) {
 					set_pconfig($uid,feature,forumlist_widget,$value);
+				}
 
 				del_pconfig($uid,$family,$key);
 			}

--- a/update.php
+++ b/update.php
@@ -1302,7 +1302,7 @@ function update_1145() {
 }
 
 function update_1146() {
-	$r = q("ALTER TABLE profile add hometown char(255) not null after `country-name`, add index ( `hometown` ) ");
+	$r = q("ALTER TABLE `profile` ADD `hometown` CHAR(255) NOT NULL AFTER `country-name`, ADD INDEX ( `hometown` ) ");
 
 	if ($r) {
 		return UPDATE_SUCCESS ;
@@ -1324,7 +1324,7 @@ function update_1147() {
 }
 
 function update_1148() {
-	$r = q("ALTER TABLE photo ADD type CHAR(128) NOT NULL DEFAULT 'image/jpeg' AFTER filename");
+	$r = q("ALTER TABLE `photo` ADD `type` CHAR(128) NOT NULL DEFAULT 'image/jpeg' AFTER `filename`");
 
 	if ($r) {
 		return UPDATE_SUCCESS ;
@@ -1335,8 +1335,8 @@ function update_1148() {
 
 
 function update_1149() {
-	$r1 = q("ALTER TABLE profile ADD likes text NOT NULL after prv_keywords");
-	$r2 = q("ALTER TABLE profile ADD dislikes text NOT NULL after likes");
+	$r1 = q("ALTER TABLE `profile` ADD `likes` TEXT NOT NULL AFTER `prv_keywords`");
+	$r2 = q("ALTER TABLE `profile` ADD `dislikes` TEXT NOT NULL AFTER `likes`");
 
 	if ($r1 && $r2) {
 		return UPDATE_SUCCESS;
@@ -1347,7 +1347,7 @@ function update_1149() {
 
 
 function update_1150() {
-	$r = q("ALTER TABLE event ADD summary text NOT NULL after finish, add index ( uid ), add index ( cid ), add index ( uri ), add index ( `start` ), add index ( finish ), add index ( `type` ), add index ( adjust ) ");
+	$r = q("ALTER TABLE `event` ADD `summary` TEXT NOT NULL AFTER `finish`, ADD INDEX ( `uid` ), ADD INDEX ( `cid` ), ADD INDEX ( `uri` ), ADD INDEX ( `start` ), ADD INDEX ( `finish` ), ADD INDEX ( `type` ), ADD INDEX ( `adjust` ) ");
 
 	if ($r) {
 		return UPDATE_SUCCESS ;
@@ -1358,10 +1358,10 @@ function update_1150() {
 
 
 function update_1151() {
-	$r = q("CREATE TABLE IF NOT EXISTS locks (
-			id INT NOT NULL AUTO_INCREMENT PRIMARY KEY ,
-			name CHAR( 128 ) NOT NULL ,
-			locked TINYINT( 1 ) NOT NULL DEFAULT '0'
+	$r = q("CREATE TABLE IF NOT EXISTS `locks` (
+			`id` INT NOT NULL AUTO_INCREMENT PRIMARY KEY ,
+			`name` CHAR( 128 ) NOT NULL ,
+			`locked` TINYINT( 1 ) NOT NULL DEFAULT '0'
 		  ) ENGINE = MYISAM DEFAULT CHARSET=utf8 ");
 
 	if ($r) {

--- a/update.php
+++ b/update.php
@@ -567,7 +567,6 @@ function update_1069() {
 	q("ALTER TABLE `fcontact` ADD `request` CHAR( 255 ) NOT NULL AFTER `photo` ");
 }
 
-/// @TODO Still meeded?
 // mail body needs to accomodate private photos
 
 function update_1070() {
@@ -596,7 +595,7 @@ function update_1074() {
 	q("ALTER TABLE `user` ADD `hidewall` TINYINT( 1) NOT NULL DEFAULT '0' AFTER `blockwall` ");
 	$r = q("SELECT `uid` FROM `profile` WHERE `is-default` = 1 AND `hidewall` = 1");
 	if (dbm::is_result($r)) {
-		foreach($r as $rr)
+		foreach ($r as $rr)
 			q("UPDATE `user` SET `hidewall` = 1 WHERE `uid` = %d",
 				intval($rr['uid'])
 			);
@@ -895,7 +894,7 @@ function update_1102() {
 
 
 function update_1103() {
-/// @TODO Comented out:
+/// @TODO Commented out:
 //	q("ALTER TABLE `item` ADD INDEX ( `wall` ) ");
 	q("ALTER TABLE `item` ADD FULLTEXT ( `tag` ) ");
 	q("ALTER TABLE `contact` ADD INDEX ( `pending` ) ");
@@ -1041,7 +1040,7 @@ function update_1120() {
 
 	$r = q("describe item");
 	if (dbm::is_result($r)) {
-		foreach($r as $rr) {
+		foreach ($r as $rr) {
 			if ($rr['Field'] == 'spam') {
 				return;
 			}

--- a/update.php
+++ b/update.php
@@ -37,7 +37,7 @@ define('UPDATE_VERSION' , 1212);
  */
 
 
-
+/// @TODO These old updates need to have UPDATE_SUCCESS returned on success?
 function update_1000() {
 
 	q("ALTER TABLE `item` DROP `like`, DROP `dislike` ");
@@ -308,7 +308,7 @@ function update_1030() {
 function update_1031() {
 	// Repair any bad links that slipped into the item table
 	$r = q("SELECT `id`, `object` FROM `item` WHERE `object` != '' ");
-	if($r && dbm::is_result($r)) {
+	if (dbm::is_result($r)) {
 		foreach ($r as $rr) {
 			if(strstr($rr['object'],'type=&quot;http')) {
 				q("UPDATE `item` SET `object` = '%s' WHERE `id` = %d",
@@ -368,13 +368,11 @@ function update_1036() {
 }
 
 function update_1037() {
-
 	q("ALTER TABLE `contact` CHANGE `lrdd` `alias` CHAR( 255 ) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL ");
-
 }
 
 function update_1038() {
- q("ALTER TABLE `item` ADD `plink` CHAR( 255 ) NOT NULL AFTER `target` ");
+	q("ALTER TABLE `item` ADD `plink` CHAR( 255 ) NOT NULL AFTER `target` ");
 }
 
 function update_1039() {
@@ -532,8 +530,10 @@ function update_1065() {
 
 function update_1066() {
 	$r = q("ALTER TABLE `item` ADD `received` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00' AFTER `edited` ");
-	if($r)
+
+	if ($r) {
 		q("ALTER TABLE `item` ADD INDEX ( `received` ) ");
+	}
 
 	$r = q("UPDATE `item` SET `received` = `edited` WHERE 1");
 }
@@ -567,6 +567,7 @@ function update_1069() {
 	q("ALTER TABLE `fcontact` ADD `request` CHAR( 255 ) NOT NULL AFTER `photo` ");
 }
 
+/// @TODO Still meeded?
 // mail body needs to accomodate private photos
 
 function update_1070() {
@@ -614,8 +615,9 @@ function update_1075() {
 				$x = q("SELECT `uid` FROM `user` WHERE `guid` = '%s' LIMIT 1",
 					dbesc($guid)
 				);
-				if(! count($x))
+				if (!dbm::is_result($x)) {
 					$found = false;
+				}
 			} while ($found == true );
 
 			q("UPDATE `user` SET `guid` = '%s' WHERE `uid` = %d",
@@ -684,14 +686,19 @@ function update_1082() {
 	q("ALTER TABLE `photo` ADD `guid` CHAR( 64 ) NOT NULL AFTER `contact-id`,
 		ADD INDEX ( `guid` )  ");
 	// make certain the following code is only executed once
-	$r = q("select `id` from `photo` where `guid` != '' limit 1");
-	if (dbm::is_result($r))
+
+	$r = q("SELECT `id` FROM `photo` WHERE `guid` != '' LIMIT 1");
+
+	if (dbm::is_result($r)) {
 		return;
+	}
+
 	$r = q("SELECT distinct(`resource-id`) FROM `photo` WHERE 1 group by `id`");
+
 	if (dbm::is_result($r)) {
 		foreach ($r as $rr) {
 			$guid = get_guid();
-			q("update `photo` set `guid` = '%s' where `resource-id` = '%s'",
+			q("UPDATE `photo` SET `guid` = '%s' WHERE `resource-id` = '%s'",
 				dbesc($guid),
 				dbesc($rr['resource-id'])
 			);
@@ -736,11 +743,13 @@ function update_1087() {
 			$x = q("SELECT max(`created`) AS `cdate` FROM `item` WHERE `parent` = %d LIMIT 1",
 				intval($rr['id'])
 			);
-			if(count($x))
+
+			if (dbm::is_result($x)) {
 				q("UPDATE `item` SET `commented` = '%s' WHERE `id` = %d",
 					dbesc($x[0]['cdate']),
 					intval($rr['id'])
 				);
+			}
 		}
 	}
 }
@@ -849,14 +858,14 @@ function update_1099() {
 
 function update_1100() {
 	q("ALTER TABLE `contact` ADD `nurl` CHAR( 255 ) NOT NULL AFTER `url` ");
-	q("alter table contact add index (`nurl`) ");
+	q("ALTER TABLE `contact` ADD INDEX (`nurl`) ");
 
 	require_once('include/text.php');
 
-	$r = q("select id, url from contact where url != '' and nurl = '' ");
+	$r = q("SELECT `id`, `url` FROM `contact` WHERE `url` != '' AND `nurl` = '' ");
 	if (dbm::is_result($r)) {
 		foreach ($r as $rr) {
-			q("update contact set nurl = '%s' where id = %d",
+			q("UPDATE `contact` SET `nurl` = '%s' WHERE `id` = %d",
 				dbesc(normalise_link($rr['url'])),
 				intval($rr['id'])
 			);
@@ -886,6 +895,7 @@ function update_1102() {
 
 
 function update_1103() {
+/// @TODO Comented out:
 //	q("ALTER TABLE `item` ADD INDEX ( `wall` ) ");
 	q("ALTER TABLE `item` ADD FULLTEXT ( `tag` ) ");
 	q("ALTER TABLE `contact` ADD INDEX ( `pending` ) ");
@@ -1031,9 +1041,11 @@ function update_1120() {
 
 	$r = q("describe item");
 	if (dbm::is_result($r)) {
-		foreach($r as $rr)
-			if($rr['Field'] == 'spam')
+		foreach($r as $rr) {
+			if ($rr['Field'] == 'spam') {
 				return;
+			}
+		}
 	}
 	q("ALTER TABLE `item` ADD `spam` TINYINT( 1 ) NOT NULL DEFAULT '0' AFTER `visible` , ADD INDEX (`spam`) ");
 
@@ -1067,16 +1079,16 @@ function update_1121() {
 }
 
 function update_1122() {
-q("ALTER TABLE `notify` ADD `hash` CHAR( 64 ) NOT NULL AFTER `id` ,
+	q("ALTER TABLE `notify` ADD `hash` CHAR( 64 ) NOT NULL AFTER `id` ,
 ADD INDEX ( `hash` ) ");
 }
 
 function update_1123() {
-set_config('system','allowed_themes','dispy,quattro,testbubble,vier,darkbubble,darkzero,duepuntozero,greenzero,purplezero,quattro-green,slackr');
+	set_config('system','allowed_themes','dispy,quattro,testbubble,vier,darkbubble,darkzero,duepuntozero,greenzero,purplezero,quattro-green,slackr');
 }
 
 function update_1124() {
-q("alter table item add index (`author-name`) ");
+	q("ALTER TABLE `item` ADD INDEX (`author-name`) ");
 }
 
 function update_1125() {
@@ -1112,7 +1124,7 @@ function update_1127() {
 
 
 function update_1128() {
-	q("alter table spam add `date` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00' AFTER `term` ");
+	q("ALTER TABLE `spam` ADD `date` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00' AFTER `term` ");
 }
 
 function update_1129() {
@@ -1138,9 +1150,9 @@ INDEX ( `username` )
 }
 
 function update_1133() {
-q("ALTER TABLE `user` ADD `unkmail` TINYINT( 1 ) NOT NULL DEFAULT '0' AFTER `blocktags` , ADD INDEX ( `unkmail` ) ");
-q("ALTER TABLE `user` ADD `cntunkmail` INT NOT NULL DEFAULT '10' AFTER `unkmail` , ADD INDEX ( `cntunkmail` ) ");
-q("ALTER TABLE `mail` ADD `unknown` TINYINT( 1 ) NOT NULL DEFAULT '0' AFTER `replied` , ADD INDEX ( `unknown` ) ");
+	q("ALTER TABLE `user` ADD `unkmail` TINYINT( 1 ) NOT NULL DEFAULT '0' AFTER `blocktags` , ADD INDEX ( `unkmail` ) ");
+	q("ALTER TABLE `user` ADD `cntunkmail` INT NOT NULL DEFAULT '10' AFTER `unkmail` , ADD INDEX ( `cntunkmail` ) ");
+	q("ALTER TABLE `mail` ADD `unknown` TINYINT( 1 ) NOT NULL DEFAULT '0' AFTER `replied` , ADD INDEX ( `unknown` ) ");
 }
 
 function update_1134() {
@@ -1167,38 +1179,38 @@ function update_1136() {
 
 	// order in reverse so that we save the newest entry
 
-	$r = q("select * from config where 1 order by id desc");
+	$r = q("SELECT * FROM `config` WHERE 1 ORDER BY `id` DESC");
 	if (dbm::is_result($r)) {
 		foreach ($r as $rr) {
 			$found = false;
-			foreach($arr as $x) {
-				if($x['cat'] == $rr['cat'] && $x['k'] == $rr['k']) {
+			foreach ($arr as $x) {
+				if ($x['cat'] == $rr['cat'] && $x['k'] == $rr['k']) {
 					$found = true;
-					q("delete from config where id = %d",
+					q("DELETE FROM `config` WHERE `id` = %d",
 						intval($rr['id'])
 					);
 				}
 			}
-			if(! $found) {
+			if (! $found) {
 				$arr[] = $rr;
 			}
 		}
 	}
 
 	$arr = array();
-	$r = q("select * from pconfig where 1 order by id desc");
+	$r = q("SELECT * FROM `pconfig` WHERE 1 ORDER BY `id` DESC");
 	if (dbm::is_result($r)) {
 		foreach ($r as $rr) {
 			$found = false;
-			foreach($arr as $x) {
-				if($x['uid'] == $rr['uid'] && $x['cat'] == $rr['cat'] && $x['k'] == $rr['k']) {
+			foreach ($arr as $x) {
+				if ($x['uid'] == $rr['uid'] && $x['cat'] == $rr['cat'] && $x['k'] == $rr['k']) {
 					$found = true;
-					q("delete from pconfig where id = %d",
+					q("DELETE FROM `pconfig` WHERE `id` = %d",
 						intval($rr['id'])
 					);
 				}
 			}
-			if(! $found) {
+			if (! $found) {
 				$arr[] = $rr;
 			}
 		}
@@ -1210,102 +1222,138 @@ function update_1136() {
 
 
 function update_1137() {
-	q("alter table item_id DROP `face` , DROP `dspr` , DROP `twit` , DROP `stat` ");
-	q("ALTER TABLE `item_id` ADD `sid` CHAR( 255 ) NOT NULL AFTER `uid` , ADD `service` CHAR( 255 ) NOT NULL AFTER `sid` , add index (`sid`), add index ( `service`) ");
+	q("ALTER TABLE `item_id` DROP `face` , DROP `dspr` , DROP `twit` , DROP `stat` ");
+	q("ALTER TABLE `item_id` ADD `sid` CHAR( 255 ) NOT NULL AFTER `uid` , ADD `service` CHAR( 255 ) NOT NULL AFTER `sid` , ADD INDEX (`sid`), ADD INDEX ( `service`) ");
 }
 
 function update_1138() {
-	q("alter table contact add archive tinyint(1) not null default '0' after hidden, add index (archive)");
+	q("ALTER TABLE `contact` ADD `archive` TINYINT(1) NOT NULL DEFAULT '0' AFTER `hidden`, ADD INDEX (`archive`)");
 }
 
 function update_1139() {
-	$r = q("alter table user add account_removed tinyint(1) not null default '0' after expire, add index(account_removed) ");
-	if(! $r)
-		return UPDATE_FAILED ;
-	return UPDATE_SUCCESS ;
+	$r = q("ALTER TABLE `user` ADD `account_removed` TINYINT(1) NOT NULL DEFAULT '0' AFTER `expire`, ADD INDEX(`account_removed`)");
+
+	if ($r) {
+		return UPDATE_SUCCESS ;
+	}
+
+	return UPDATE_FAILED ;
 }
 
 function update_1140() {
-	$r = q("alter table addon add hidden tinyint(1) not null default '0' after installed, add index(hidden) ");
-	if(! $r)
-		return UPDATE_FAILED ;
-	return UPDATE_SUCCESS ;
+	$r = q("ALTER TABLE `addon` ADD `hidden` TINYINT(1) NOT NULL DEFAULT '0' AFTER `installed`, ADD INDEX(`hidden`) ");
+
+	if ($r) {
+		return UPDATE_SUCCESS ;
+	}
+
+	return UPDATE_FAILED ;
 }
 
 function update_1141() {
-	$r = q("alter table glink add zcid int(11) not null after gcid, add index(zcid) ");
-	if(! $r)
-		return UPDATE_FAILED ;
-	return UPDATE_SUCCESS ;
+	$r = q("ALTER TABLE `glink` ADD `zcid` INT(11) NOT NULL AFTER `gcid`, ADD INDEX(`zcid`) ");
+
+	if ($r) {
+		return UPDATE_SUCCESS ;
+	}
+
+	return UPDATE_FAILED ;
 }
 
 
 function update_1142() {
-	$r = q("alter table user add service_class char(32) not null after expire_notification_sent, add index(service_class) ");
-	if(! $r)
-		return UPDATE_FAILED ;
-	return UPDATE_SUCCESS ;
+	$r = q("ALTER TABLE `user` ADD `service_class` CHAR(32) NOT NULL AFTER `expire_notification_sent`, ADD INDEX(`service_class`) ");
+
+	if ($r) {
+		return UPDATE_SUCCESS ;
+	}
+
+	return UPDATE_FAILED ;
 }
 
 function update_1143() {
-	$r = q("alter table user add def_gid int(11) not null default '0' after service_class");
-	if(! $r)
-		return UPDATE_FAILED ;
-	return UPDATE_SUCCESS ;
+	$r = q("ALTER TABLE `user` ADD `def_gid` INT(11) NOT NULL DEFAULT '0' AFTER `service_class`");
+
+	if ($r) {
+		return UPDATE_SUCCESS ;
+	}
+
+	return UPDATE_FAILED ;
 }
 
 function update_1144() {
-	$r = q("alter table contact add prv tinyint(1) not null default '0' after forum");
-	if(! $r)
-		return UPDATE_FAILED ;
-	return UPDATE_SUCCESS ;
+	$r = q("ALTER TABLE `contact` ADD `prv` TINYINT(1) NOT NULL DEFAULT '0' AFTER `forum`");
+
+	if ($r) {
+		return UPDATE_SUCCESS ;
+	}
+
+	return UPDATE_FAILED ;
 }
 
 function update_1145() {
-	$r = q("alter table profile add howlong datetime not null default '0000-00-00 00:00:00' after `with`");
-	if(! $r)
-		return UPDATE_FAILED ;
-	return UPDATE_SUCCESS ;
+	$r = q("ALTER TABLE `profile` ADD `howlong` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00' AFTER `with`");
+
+	if ($r) {
+		return UPDATE_SUCCESS ;
+	}
+
+	return UPDATE_FAILED ;
 }
 
 function update_1146() {
-	$r = q("alter table profile add hometown char(255) not null after `country-name`, add index ( `hometown` ) ");
-	if(! $r)
-		return UPDATE_FAILED ;
-	return UPDATE_SUCCESS ;
+	$r = q("ALTER TABLE profile add hometown char(255) not null after `country-name`, add index ( `hometown` ) ");
+
+	if ($r) {
+		return UPDATE_SUCCESS ;
+	}
+
+	return UPDATE_FAILED ;
 }
 
 function update_1147() {
 	$r1 = q("ALTER TABLE `sign` ALTER `iid` SET DEFAULT '0'");
 	$r2 = q("ALTER TABLE `sign` ADD `retract_iid` INT(10) UNSIGNED NOT NULL DEFAULT '0' AFTER `iid`");
 	$r3 = q("ALTER TABLE `sign` ADD INDEX ( `retract_iid` )");
-	if((! $r1) || (! $r2) || (! $r3))
-		return UPDATE_FAILED ;
-	return UPDATE_SUCCESS ;
+
+	if ($r1 && $r2 && $r3) {
+		return UPDATE_SUCCESS ;
+	}
+
+	return UPDATE_FAILED ;
 }
 
 function update_1148() {
 	$r = q("ALTER TABLE photo ADD type CHAR(128) NOT NULL DEFAULT 'image/jpeg' AFTER filename");
-	if (!$r)
-		return UPDATE_FAILED;
-	return UPDATE_SUCCESS;
+
+	if ($r) {
+		return UPDATE_SUCCESS ;
+	}
+
+	return UPDATE_FAILED ;
 }
 
 
 function update_1149() {
 	$r1 = q("ALTER TABLE profile ADD likes text NOT NULL after prv_keywords");
 	$r2 = q("ALTER TABLE profile ADD dislikes text NOT NULL after likes");
-	if (! ($r1 && $r2))
-		return UPDATE_FAILED;
-	return UPDATE_SUCCESS;
+
+	if ($r1 && $r2) {
+		return UPDATE_SUCCESS;
+	}
+
+	return UPDATE_FAILED;
 }
 
 
 function update_1150() {
 	$r = q("ALTER TABLE event ADD summary text NOT NULL after finish, add index ( uid ), add index ( cid ), add index ( uri ), add index ( `start` ), add index ( finish ), add index ( `type` ), add index ( adjust ) ");
-	if(! $r)
-		return UPDATE_FAILED;
-	return UPDATE_SUCCESS;
+
+	if ($r) {
+		return UPDATE_SUCCESS ;
+	}
+
+	return UPDATE_FAILED ;
 }
 
 
@@ -1315,9 +1363,12 @@ function update_1151() {
 			name CHAR( 128 ) NOT NULL ,
 			locked TINYINT( 1 ) NOT NULL DEFAULT '0'
 		  ) ENGINE = MYISAM DEFAULT CHARSET=utf8 ");
-	if (!$r)
-		return UPDATE_FAILED;
-	return UPDATE_SUCCESS;
+
+	if ($r) {
+		return UPDATE_SUCCESS ;
+	}
+
+	return UPDATE_FAILED ;
 }
 
 function update_1152() {
@@ -1333,23 +1384,32 @@ function update_1152() {
 		KEY `type`  ( `type` ),
 		KEY `term`  ( `term` )
 		) ENGINE = MYISAM DEFAULT CHARSET=utf8 ");
-	if (!$r)
-		return UPDATE_FAILED;
-	return UPDATE_SUCCESS;
+
+	if ($r) {
+		return UPDATE_SUCCESS;
+	}
+
+	return UPDATE_FAILED;
 }
 
 function update_1153() {
 	$r = q("ALTER TABLE `hook` ADD `priority` INT(11) UNSIGNED NOT NULL DEFAULT '0'");
 
-	if(!$r) return UPDATE_FAILED;
-	return UPDATE_SUCCESS;
+	if ($r) {
+		return UPDATE_SUCCESS;
+	}
+
+	return UPDATE_FAILED;
 }
 
 function update_1154() {
 	$r = q("ALTER TABLE `event` ADD `ignore` TINYINT( 1 ) UNSIGNED NOT NULL DEFAULT '0' AFTER `adjust` , ADD INDEX ( `ignore` )");
 
-	if(!$r) return UPDATE_FAILED;
-	return UPDATE_SUCCESS;
+	if ($r) {
+		return UPDATE_SUCCESS;
+	}
+
+	return UPDATE_FAILED;
 }
 
 function update_1155() {
@@ -1357,8 +1417,9 @@ function update_1155() {
 	$r2 = q("ALTER TABLE `item_id` ADD `id` INT NOT NULL AUTO_INCREMENT PRIMARY KEY FIRST");
 	$r3 = q("ALTER TABLE `item_id` ADD INDEX ( `iid` ) ");
 
-	if($r1 && $r2 && $r3)
+	if ($r1 && $r2 && $r3) {
 		return UPDATE_SUCCESS;
+	}
 
 	return UPDATE_FAILED;
 }
@@ -1367,12 +1428,15 @@ function update_1156() {
 	$r = q("ALTER TABLE `photo` ADD `datasize` INT UNSIGNED NOT NULL DEFAULT '0' AFTER `width` ,
 ADD INDEX ( `datasize` ) ");
 
-	if(!$r) return UPDATE_FAILED;
-	return UPDATE_SUCCESS;
+	if ($r) {
+		return UPDATE_SUCCESS;
+	}
+
+	return UPDATE_FAILED;
 }
 
 function update_1157() {
-	$r = q("CREATE TABLE  IF NOT EXISTS `dsprphotoq` (
+	$r = q("CREATE TABLE IF NOT EXISTS `dsprphotoq` (
 	  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
 	  `uid` int(11) NOT NULL,
 	  `msg` mediumtext NOT NULL,
@@ -1381,8 +1445,11 @@ function update_1157() {
 	  ) ENGINE=MyISAM DEFAULT CHARSET=utf8"
 	);
 
-	if($r)
+	if ($r) {
 		return UPDATE_SUCCESS;
+	}
+
+	return UPDATE_FAILED;
 }
 
 function update_1158() {
@@ -1395,8 +1462,9 @@ function update_1158() {
 	$r = q("CREATE INDEX event_id ON item(`event-id`)");
 	set_config('system', 'maintenance', 0);
 
-	if($r)
+	if ($r) {
 		return UPDATE_SUCCESS;
+	}
 
 	return UPDATE_FAILED;
 }
@@ -1407,10 +1475,11 @@ function update_1159() {
 		ADD INDEX (`uid`),
 		ADD INDEX (`aid`)");
 
-	if(!$r)
-		return UPDATE_FAILED;
+	if ($r) {
+		return UPDATE_SUCCESS;
+	}
 
-	return UPDATE_SUCCESS;
+	return UPDATE_FAILED;
 }
 
 function update_1160() {
@@ -1423,19 +1492,21 @@ function update_1160() {
 	$r = q("ALTER TABLE `item` ADD `mention` TINYINT(1) NOT NULL DEFAULT '0', ADD INDEX (`mention`)");
 	set_config('system', 'maintenance', 0);
 
-	if(!$r)
-		return UPDATE_FAILED;
+	if ($r) {
+		return UPDATE_SUCCESS;
+	}
 
-	return UPDATE_SUCCESS;
+	return UPDATE_FAILED;
 }
 
 function update_1161() {
 	$r = q("ALTER TABLE `pconfig` ADD INDEX (`cat`)");
 
-	if(!$r)
-		return UPDATE_FAILED;
+	if ($r) {
+		return UPDATE_SUCCESS;
+	}
 
-	return UPDATE_SUCCESS;
+	return UPDATE_FAILED;
 }
 
 function update_1162() {
@@ -1451,14 +1522,17 @@ function update_1163() {
 	$r = q("ALTER TABLE `item` ADD `network` char(32) NOT NULL");
 
 	set_config('system', 'maintenance', 0);
-	if(!$r)
-		return UPDATE_FAILED;
 
-	return UPDATE_SUCCESS;
+	if ($r) {
+		return UPDATE_SUCCESS;
+	}
+
+	return UPDATE_FAILED;
 }
 function update_1164() {
 	set_config('system', 'maintenance', 1);
 
+	/// @TODO If one update fails, should it continue?
 	$r = q("UPDATE `item` SET `network`='%s' WHERE `contact-id` IN (SELECT `id` FROM`contact` WHERE `network` = '' AND `contact`.`uid` = `item`.`uid`)",
 		NETWORK_DFRN);
 
@@ -1511,19 +1585,21 @@ function update_1164() {
 
 function update_1165() {
 	$r = q("CREATE TABLE IF NOT EXISTS `push_subscriber` (
-			`id` INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
-		    `uid` INT NOT NULL,
-	        `callback_url` CHAR( 255 ) NOT NULL,
-            `topic` CHAR( 255 ) NOT NULL,
-            `nickname` CHAR( 255 ) NOT NULL,
-            `push` INT NOT NULL,
-            `last_update` DATETIME NOT NULL,
-            `secret` CHAR( 255 ) NOT NULL
-		  ) ENGINE = MYISAM DEFAULT CHARSET=utf8 ");
-	if (!$r)
-		return UPDATE_FAILED;
+	`id` INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+	`uid` INT NOT NULL,
+	`callback_url` CHAR( 255 ) NOT NULL,
+	`topic` CHAR( 255 ) NOT NULL,
+	`nickname` CHAR( 255 ) NOT NULL,
+	`push` INT NOT NULL,
+	`last_update` DATETIME NOT NULL,
+	`secret` CHAR( 255 ) NOT NULL
+	) ENGINE = MYISAM DEFAULT CHARSET=utf8 ");
 
-	return UPDATE_SUCCESS;
+	if ($r) {
+		return UPDATE_SUCCESS;
+	}
+
+	return UPDATE_FAILED;
 }
 
 function update_1166() {
@@ -1535,26 +1611,32 @@ function update_1166() {
 			`avatar` CHAR(255) NOT NULL,
 			INDEX (`url`)
 		  ) ENGINE = MYISAM DEFAULT CHARSET=utf8 ");
-	if (!$r)
-		return UPDATE_FAILED;
 
-	return UPDATE_SUCCESS;
+	if ($r) {
+		return UPDATE_SUCCESS;
+	}
+
+	return UPDATE_FAILED;
 }
 
 function update_1167() {
 	$r = q("ALTER TABLE `contact` ADD `notify_new_posts` TINYINT(1) NOT NULL DEFAULT '0'");
-	if (!$r)
-		return UPDATE_FAILED;
 
-	return UPDATE_SUCCESS;
+	if ($r) {
+		return UPDATE_SUCCESS;
+	}
+
+	return UPDATE_FAILED;
 }
 
 function update_1168() {
 	$r = q("ALTER TABLE `contact` ADD `fetch_further_information` TINYINT(1) NOT NULL DEFAULT '0'");
-	if (!$r)
-		return UPDATE_FAILED;
 
-	return UPDATE_SUCCESS;
+	if ($r) {
+		return UPDATE_SUCCESS ;
+	}
+
+	return UPDATE_FAILED ;
 }
 
 function update_1169() {
@@ -1592,8 +1674,10 @@ function update_1169() {
 		  KEY `uid_created` (`uid`,`created`),
 		  KEY `uid_commented` (`uid`,`commented`)
 		) ENGINE=MyISAM  DEFAULT CHARSET=utf8;");
-	if (!$r)
+
+	if (!$r) {
 		return UPDATE_FAILED;
+	}
 
 	proc_run(PRIORITY_LOW, "include/threadupdate.php");
 

--- a/util/po2php.php
+++ b/util/po2php.php
@@ -12,7 +12,7 @@ function po2php_run(&$argv, &$argc) {
 	$pofile = $argv[1];
 	$outfile = dirname($pofile)."/strings.php";
 
-	if(strstr($outfile,'util'))
+	if (strstr($outfile,'util'))
 		$lang = 'en';
 	else
 		$lang = str_replace('-','_',basename(dirname($pofile)));

--- a/util/po2php.php
+++ b/util/po2php.php
@@ -12,10 +12,11 @@ function po2php_run(&$argv, &$argc) {
 	$pofile = $argv[1];
 	$outfile = dirname($pofile)."/strings.php";
 
-	if (strstr($outfile,'util'))
+	if (strstr($outfile,'util')) {
 		$lang = 'en';
-	else
+	} else {
 		$lang = str_replace('-','_',basename(dirname($pofile)));
+	}
 
 
 


### PR DESCRIPTION
I have again applied more coding convention stuff, e.g. added missing curly braces, spaces and usage of `dbm::is_result()`. Also I have unified most db upgrades to a more common way:

````
function update_xxxx() {
    $r = q("ALTER TABLE `foo` DO SOMETHING");

    if ($r) {
        return UPDATE_SUCCESS;
    }
    return UPDATE_FAILED;
}
````
There are a few exceptions, plus a lot older updates that needs being fixed/considered.