### PR TITLE
limit the description of the meta tag to 160 characters in /mod/display

### DIFF
--- a/mod/display.php
+++ b/mod/display.php
@@ -425,6 +425,12 @@ function display_content(App $a, $update = 0) {
 		if ($title == "") {
 			$title = $author_name;
 		}
+
+		// Limit the description to 160 characters
+		if (strlen($description) > 160) {
+			$description = substr($description, 0, 157) . '...';
+		}
+
 		$description = htmlspecialchars($description, ENT_COMPAT, 'UTF-8', true); // allow double encoding here
 		$title = htmlspecialchars($title, ENT_COMPAT, 'UTF-8', true); // allow double encoding here
 		$author_name = htmlspecialchars($author_name, ENT_COMPAT, 'UTF-8', true); // allow double encoding here


### PR DESCRIPTION
I read at several places that the description of the the social media tags should be maximal 160 characters