### PR TITLE
added editorconfig config file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# editorconfig tool configuration
+# see http://editorconfig.org for docs
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+trim_trailing_whitespaces = true
+indent_style = tab


### PR DESCRIPTION
To assist coding style compliance there exists an addon for many common editors called [editorconfig](http://editorconfig.org/) this PR adds a config file for said addon. It follows the conclusions from #2841.