### PR TITLE
during installation inform user that pwd cannot be blank

### DIFF
--- a/mod/install.php
+++ b/mod/install.php
@@ -261,7 +261,7 @@ function install_content(App $a) {
 
 				'$dbhost' => array('dbhost', t('Database Server Name'), $dbhost, '', 'required'),
 				'$dbuser' => array('dbuser', t('Database Login Name'), $dbuser, '', 'required', 'autofocus'),
-				'$dbpass' => array('dbpass', t('Database Login Password'), $dbpass, t("For security reasons thr password must not be empty"), 'required'),
+				'$dbpass' => array('dbpass', t('Database Login Password'), $dbpass, t("For security reasons the password must not be empty"), 'required'),
 				'$dbdata' => array('dbdata', t('Database Name'), $dbdata, '', 'required'),
 				'$adminmail' => array('adminmail', t('Site administrator email address'), $adminmail, t('Your account email address must match this in order to use the web admin panel.'), 'required', 'autofocus', 'email'),
 

--- a/mod/install.php
+++ b/mod/install.php
@@ -261,7 +261,7 @@ function install_content(App $a) {
 
 				'$dbhost' => array('dbhost', t('Database Server Name'), $dbhost, '', 'required'),
 				'$dbuser' => array('dbuser', t('Database Login Name'), $dbuser, '', 'required', 'autofocus'),
-				'$dbpass' => array('dbpass', t('Database Login Password'), $dbpass, t('For security reasons this cannot be empty'), 'required'),
+				'$dbpass' => array('dbpass', t('Database Login Password'), $dbpass, t("For security reasons thr password must not be empty"), 'required'),
 				'$dbdata' => array('dbdata', t('Database Name'), $dbdata, '', 'required'),
 				'$adminmail' => array('adminmail', t('Site administrator email address'), $adminmail, t('Your account email address must match this in order to use the web admin panel.'), 'required', 'autofocus', 'email'),
 

--- a/mod/install.php
+++ b/mod/install.php
@@ -261,7 +261,7 @@ function install_content(App $a) {
 
 				'$dbhost' => array('dbhost', t('Database Server Name'), $dbhost, '', 'required'),
 				'$dbuser' => array('dbuser', t('Database Login Name'), $dbuser, '', 'required', 'autofocus'),
-				'$dbpass' => array('dbpass', t('Database Login Password'), $dbpass, ''),
+				'$dbpass' => array('dbpass', t('Database Login Password'), $dbpass, t('For security reasons this cannot be empty'), 'required'),
 				'$dbdata' => array('dbdata', t('Database Name'), $dbdata, '', 'required'),
 				'$adminmail' => array('adminmail', t('Site administrator email address'), $adminmail, t('Your account email address must match this in order to use the web admin panel.'), 'required', 'autofocus', 'email'),
 

--- a/mod/install.php
+++ b/mod/install.php
@@ -261,7 +261,7 @@ function install_content(App $a) {
 
 				'$dbhost' => array('dbhost', t('Database Server Name'), $dbhost, '', 'required'),
 				'$dbuser' => array('dbuser', t('Database Login Name'), $dbuser, '', 'required', 'autofocus'),
-				'$dbpass' => array('dbpass', t('Database Login Password'), $dbpass, '', 'required'),
+				'$dbpass' => array('dbpass', t('Database Login Password'), $dbpass, ''),
 				'$dbdata' => array('dbdata', t('Database Name'), $dbdata, '', 'required'),
 				'$adminmail' => array('adminmail', t('Site administrator email address'), $adminmail, t('Your account email address must match this in order to use the web admin panel.'), 'required', 'autofocus', 'email'),
 


### PR DESCRIPTION
Inform the users during the installation that the DB passwd cannot be blank, see original discussion on Friendica, relates to #3114 