### PR TITLE
Bugfix: Sometimes the self contact seems to destroy itself

### DIFF
--- a/include/Contact.php
+++ b/include/Contact.php
@@ -64,12 +64,12 @@ function contact_remove($id) {
 	$r = q("SELECT `uid` FROM `contact` WHERE `id` = %d AND NOT `self` LIMIT 1",
 		intval($id)
 	);
-	if((! dbm::is_result($r)) || (! intval($r[0]['uid']))) {
+	if (!dbm::is_result($r) || !intval($r[0]['uid'])) {
 		return;
 	}
 
 	$archive = get_pconfig($r[0]['uid'], 'system','archive_removed_contacts');
-	if($archive) {
+	if ($archive) {
 		q("update contact set `archive` = 1, `network` = 'none', `writable` = 0 where id = %d",
 			intval($id)
 		);

--- a/include/Contact.php
+++ b/include/Contact.php
@@ -60,11 +60,13 @@ function user_remove($uid) {
 
 function contact_remove($id) {
 
-	$r = q("select uid from contact where id = %d limit 1",
+	// We want just to make sure that we don't delete our "self" contact
+	$r = q("SELECT `uid` FROM `contact` WHERE `id` = %d AND NOT `self` LIMIT 1",
 		intval($id)
 	);
-	if((! dbm::is_result($r)) || (! intval($r[0]['uid'])))
+	if((! dbm::is_result($r)) || (! intval($r[0]['uid']))) {
 		return;
+	}
 
 	$archive = get_pconfig($r[0]['uid'], 'system','archive_removed_contacts');
 	if($archive) {
@@ -571,7 +573,7 @@ function get_contact($url, $uid = 0, $no_update = false) {
 	}
 
 	if ((count($contact) > 1) AND ($uid == 0) AND ($contactid != 0) AND ($url != ""))
-		q("DELETE FROM `contact` WHERE `nurl` = '%s' AND `id` != %d",
+		q("DELETE FROM `contact` WHERE `nurl` = '%s' AND `id` != %d AND NOT `self`",
 			dbesc(normalise_link($url)),
 			intval($contactid));
 

--- a/mod/dfrn_request.php
+++ b/mod/dfrn_request.php
@@ -301,7 +301,7 @@ function dfrn_request_post(App $a) {
 		if (dbm::is_result($r)) {
 			foreach ($r as $rr) {
 				if(! $rr['rel']) {
-					q("DELETE FROM `contact` WHERE `id` = %d",
+					q("DELETE FROM `contact` WHERE `id` = %d AND NOT `self`",
 						intval($rr['cid'])
 					);
 				}
@@ -326,7 +326,7 @@ function dfrn_request_post(App $a) {
 		if (dbm::is_result($r)) {
 			foreach ($r as $rr) {
 				if(! $rr['rel']) {
-					q("DELETE FROM `contact` WHERE `id` = %d",
+					q("DELETE FROM `contact` WHERE `id` = %d AND NOT `self`",
 						intval($rr['cid'])
 					);
 				}


### PR DESCRIPTION
There is a reporting from a user that his "self" contact was deleted after the update to 3.5.0. I'm not totally sure how this can happen - but it did multiple times on his setup. Hopefully this prevents further contacts to be deleted.