### PR TITLE
Allow cid URLs for images

### DIFF
--- a/include/bbcode.php
+++ b/include/bbcode.php
@@ -1164,7 +1164,7 @@ function bbcode($Text,$preserve_nl = false, $tryoembed = true, $simplehtml = fal
 	$Text = preg_replace('/\<([^>]*?)(src|href)=(.*?)\&amp\;(.*?)\>/ism', '<$1$2=$3&$4>', $Text);
 
 	// sanitizes src attributes (http and redir URLs for displaying in a web page, cid used for inline images in emails)
-	$allowed_src_protocols = array('http', 'redir', 'cid');
+	static $allowed_src_protocols = array('http', 'redir', 'cid');
 	$Text = preg_replace('#<([^>]*?)(src)="(?!' . implode('|', $allowed_src_protocols) . ')(.*?)"(.*?)>#ism',
 			     '<$1$2=""$4 class="invalid-src" title="' . t('Invalid source protocol') . '">', $Text);
 

--- a/include/bbcode.php
+++ b/include/bbcode.php
@@ -1164,7 +1164,7 @@ function bbcode($Text,$preserve_nl = false, $tryoembed = true, $simplehtml = fal
 	$Text = preg_replace('/\<([^>]*?)(src|href)=(.*?)\&amp\;(.*?)\>/ism', '<$1$2=$3&$4>', $Text);
 
 	// sanitizes src attributes (only relative redir URIs or http URLs)
-	$Text = preg_replace('#<([^>]*?)(src)="(?!http|redir)(.*?)"(.*?)>#ism', '<$1$2=""$4 class="invalid-src" title="' . t('Invalid source protocol') . '">', $Text);
+	$Text = preg_replace('#<([^>]*?)(src)="(?!http|redir|cid)(.*?)"(.*?)>#ism', '<$1$2=""$4 class="invalid-src" title="' . t('Invalid source protocol') . '">', $Text);
 
 	// sanitize href attributes (only whitelisted protocols URLs)
 	// default value for backward compatibility

--- a/include/bbcode.php
+++ b/include/bbcode.php
@@ -1163,8 +1163,10 @@ function bbcode($Text,$preserve_nl = false, $tryoembed = true, $simplehtml = fal
 	// fix any escaped ampersands that may have been converted into links
 	$Text = preg_replace('/\<([^>]*?)(src|href)=(.*?)\&amp\;(.*?)\>/ism', '<$1$2=$3&$4>', $Text);
 
-	// sanitizes src attributes (only relative redir URIs or http URLs)
-	$Text = preg_replace('#<([^>]*?)(src)="(?!http|redir|cid)(.*?)"(.*?)>#ism', '<$1$2=""$4 class="invalid-src" title="' . t('Invalid source protocol') . '">', $Text);
+	// sanitizes src attributes (http and redir URLs for displaying in a web page, cid used for inline images in emails)
+	$allowed_src_protocols = array('http', 'redir', 'cid');
+	$Text = preg_replace('#<([^>]*?)(src)="(?!' . implode('|', $allowed_src_protocols) . ')(.*?)"(.*?)>#ism',
+			     '<$1$2=""$4 class="invalid-src" title="' . t('Invalid source protocol') . '">', $Text);
 
 	// sanitize href attributes (only whitelisted protocols URLs)
 	// default value for backward compatibility


### PR DESCRIPTION
These are used by mailstream for displaying inline attachments.