### PR TITLE
style the photo album page of the vier theme

### DIFF
--- a/view/templates/photo_album.tpl
+++ b/view/templates/photo_album.tpl
@@ -9,9 +9,9 @@
 {{/if}}
 
 {{foreach $photos as $photo}}
-<div class="photo-album-image-wrapper" id="photo-album-image-wrapper-{{$id}}">
-	<a href="{{$photo.link}}" class="photo-album-photo-link" id="photo-album-photo-link-{{$id}}" title="{{$photo.title}}">
-		<img src="{{$photo.src}}" alt="{{if $photo.album.name}}{{$photo.album.name}}{{elseif $photo.desc}}{{$photo.desc}}{{elseif $photo.alt}}{{$photo.alt}}{{else}}{{$photo.unknown}}{{/if}}" title="{{$photo.title}}" class="photo-album-photo lframe resize{{$twist}}" id="photo-album-photo-{{$id}}" />
+<div class="photo-album-image-wrapper" id="photo-album-image-wrapper-{{$photo.id}}">
+	<a href="{{$photo.link}}" class="photo-album-photo-link" id="photo-album-photo-link-{{$photo.id}}" title="{{$photo.title}}">
+		<img src="{{$photo.src}}" alt="{{if $photo.album.name}}{{$photo.album.name}}{{elseif $photo.desc}}{{$photo.desc}}{{elseif $photo.alt}}{{$photo.alt}}{{else}}{{$photo.unknown}}{{/if}}" title="{{$photo.title}}" class="photo-album-photo lframe resize{{$photo.twist}}" id="photo-album-photo-{{$photo.id}}" />
 		<p class='caption'>{{$photo.desc}}</p>		
 	</a>
 </div>

--- a/view/theme/vier/style.css
+++ b/view/theme/vier/style.css
@@ -3024,7 +3024,8 @@ a.btn#contact-edit-actions-button {
 }
 
 /* photo album page */
-.photo-top-image-wrapper {
+.photo-top-image-wrapper,
+.photo-album-image-wrapper {
   position: relative;
   float: left;
   margin-top: 15px;
@@ -3054,10 +3055,32 @@ a.btn#contact-edit-actions-button {
   float: left;
   width: 175px;
 }
-img.photo-top-photo {
+img.photo-top-photo,
+img.photo-album-photo {
   width: 100%;
   height: 100%;
   object-fit: cover;
+}
+.photo-album-photo {
+  float: none;
+}
+.photo-album-image-wrapper .caption {
+  opacity: 0;
+  width: 100%;
+  position: absolute;
+  bottom: 0px;
+  padding: 3px 5px;
+  background-color: rgb(255, 255, 255);
+  margin: 0;
+  overflow: hidden;
+  -webkit-transition: all 0.5s ease-in-out;
+  -moz-transition: all 0.5s ease-in-out;
+  -o-transition: all 0.5s ease-in-out;
+  -ms-transition: all 0.5s ease-in-out;
+  transition: all 0.5s ease-in-out;
+}
+.photo-album-image-wrapper:hover .caption {
+  opacity: 1;
 }
 
 .menu-profile-list{


### PR DESCRIPTION
- vier's photo album page is now similar to 'recent photos' (with square thumbs of the available album photos)
- the description  appears inside the photo thumnail on hover (this fixes https://github.com/friendica/friendica/issues/3130)
- the `photo_album.tpl` was fixed