### PR TITLE
Issue 3135: dbupdate is started again and again

### DIFF
--- a/include/dbupdate.php
+++ b/include/dbupdate.php
@@ -20,6 +20,10 @@ function dbupdate_run(&$argv, &$argc) {
 
 	Config::load();
 
+	// We are deleting the latest dbupdate entry.
+	// This is done to avoid endless loops because the update was interupted.
+	Config::delete('database','dbupdate_'.DB_UPDATE_VERSION);
+
 	update_db($a);
 }
 


### PR DESCRIPTION
See issue https://github.com/friendica/friendica/issues/3135

Under certain circumstances it can happen that the update isn't finished. Then it would never be executed again automatically. When using the worker, this problem is now fixed.