### PR TITLE
Preparation to add the social network "pnut"

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -245,6 +245,7 @@ define ( 'NETWORK_STATUSNET',        'stac');    // Statusnet connector
 define ( 'NETWORK_APPNET',           'apdn');    // app.net
 define ( 'NETWORK_NEWS',             'nntp');    // Network News Transfer Protocol
 define ( 'NETWORK_ICALENDAR',        'ical');    // iCalendar
+define ( 'NETWORK_PNUT',             'pnut');    // pnut.io
 define ( 'NETWORK_PHANTOM',          'unkn');    // Place holder
 /** @}*/
 
@@ -274,6 +275,7 @@ $netgroup_ids = array(
 	NETWORK_APPNET    => (-17),
 	NETWORK_NEWS      => (-18),
 	NETWORK_ICALENDAR => (-19),
+	NETWORK_PNUT      => (-20),
 
 	NETWORK_PHANTOM  => (-127),
 );

--- a/include/contact_selectors.php
+++ b/include/contact_selectors.php
@@ -89,6 +89,7 @@ function network_to_name($s, $profile = "") {
 		NETWORK_TWITTER  => t('Twitter'),
 		NETWORK_DIASPORA2 => t('Diaspora Connector'),
 		NETWORK_STATUSNET => t('GNU Social'),
+		NETWORK_PNUT      => t('pnut'),
 		NETWORK_APPNET => t('App.net')
 	);
 

--- a/include/contact_widgets.php
+++ b/include/contact_widgets.php
@@ -66,6 +66,9 @@ function unavailable_networks() {
 	if (!get_config("system","diaspora_enabled"))
 		$networks[] = NETWORK_DIASPORA;
 
+	if (!plugin_enabled("pnut"))
+		$networks[] = NETWORK_PNUT;
+
 	if (!sizeof($networks))
 		return "";
 


### PR DESCRIPTION
This is a preparation for the issue https://github.com/friendica/friendica/issues/3145

The probability is high that we eventually will support pnut as a social network via a connector. Since addons doesn't fall under our release cycles, it would be great to accept this pull request for the upcoming version - although there is a feature freeze.

One could call this a preparation for preventing a future bug that will occur when someone would like to use the "pnut" addon on the 3.5.1 - so this is some kind of bugfix :-)