### PR TITLE
Bugfix: frio - the tabbar should be hidden if it is a dirict child of the section element

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -1719,6 +1719,12 @@ img.acpopup-img {
 
 }
 /* Menubar Tabs */
+section > ul.tabbar {
+/* The tabbar shouldn't' be visibile inside
+the section element. Only after we have
+moved it to the nav through js */
+    display: none !important;
+}
 #tabmenu,
 .tabbar,
 .tabbar > li {

--- a/view/theme/frio/js/theme.js
+++ b/view/theme/frio/js/theme.js
@@ -40,9 +40,7 @@ $(document).ready(function(){
 	$(".field.select > select, .field.custom > select").addClass("form-control");
 
 	// move the tabbar to the second nav bar
-	if( $("ul.tabbar").length ) {
-		$("ul.tabbar").appendTo("#topbar-second > .container > #tabmenu");
-	}
+	$("section ul.tabbar").first().appendTo("#topbar-second > .container > #tabmenu");
 
 	// add mask css url to the logo-img container
 	//

--- a/view/theme/frio/templates/contacts-template.tpl
+++ b/view/theme/frio/templates/contacts-template.tpl
@@ -1,7 +1,7 @@
 
-<div id="contacts" class="generic-page-wrapper">
+{{$tabs}}
 
-	{{$tabs}}
+<div id="contacts" class="generic-page-wrapper">
 
 	{{* The page heading with it's contacts counter *}}
 	<h2 class="heading">{{$header}} {{if $total}} ({{$total}}) {{/if}}</h2>


### PR DESCRIPTION
There was a small visual glitch in frio on pages which use the `common_tabs.tpl`. After the page was loaded it is visible for a very short time before the js part did append it to frios second navbar.

This commit do hide tabbars which are in the `section element`.

At to moment this is OK because we only use the tabbar for the profile, contact and network pages. But there are maybe unofficial plugins which does use more than one tabbar. One example is @fabrixxm git plugin for frio. They should use another template with another class (or ID). At the moment this isn't a problem because the js part should append both to frios second navbar. But because there isn't enough space in the second navbar I guess I will change this behavior in another PR so that only the first `tabbar` element of as direct child of the `section` element will be moved to the second nav

Instead of writing an own template for additional tabbars the plugin developer could put the tabbar which shouldn't be hidden in an own container (e.g. a "page-wrapper" - so the tabbar wouldn't be a direct child of section anymore) 