### PR TITLE
Support for the new Diaspora mention format

### DIFF
--- a/include/Contact.php
+++ b/include/Contact.php
@@ -1,5 +1,6 @@
 <?php
 
+require_once('include/Probe.php');
 
 // Included here for completeness, but this is a very dangerous operation.
 // It is the caller's responsibility to confirm the requestor's intent and

--- a/include/Contact.php
+++ b/include/Contact.php
@@ -316,6 +316,54 @@ function get_contact_details_by_url($url, $uid = -1, $default = array()) {
 	return $profile;
 }
 
+/**
+ * @brief Get contact data for a given address
+ *
+ * The function looks at several places (contact table and gcontact table) for the contact
+ *
+ * @param string $addr The profile link
+ * @param int $uid User id
+ *
+ * @return array Contact data
+ */
+function get_contact_details_by_addr($addr, $uid = -1) {
+	static $cache = array();
+
+	if ($uid == -1) {
+		$uid = local_user();
+	}
+
+	// Fetch contact data from the contact table for the given user
+	$r = q("SELECT `id`, `id` AS `cid`, 0 AS `gid`, 0 AS `zid`, `uid`, `url`, `nurl`, `alias`, `network`, `name`, `nick`, `addr`, `location`, `about`, `xmpp`,
+			`keywords`, `gender`, `photo`, `thumb`, `micro`, `forum`, `prv`, (`forum` | `prv`) AS `community`, `contact-type`, `bd` AS `birthday`, `self`
+		FROM `contact` WHERE `addr` = '%s' AND `uid` = %d",
+			dbesc($addr), intval($uid));
+
+	// Fetch the data from the contact table with "uid=0" (which is filled automatically)
+	if (!dbm::is_result($r))
+		$r = q("SELECT `id`, 0 AS `cid`, `id` AS `zid`, 0 AS `gid`, `uid`, `url`, `nurl`, `alias`, `network`, `name`, `nick`, `addr`, `location`, `about`, `xmpp`,
+			`keywords`, `gender`, `photo`, `thumb`, `micro`, `forum`, `prv`, (`forum` | `prv`) AS `community`, `contact-type`, `bd` AS `birthday`, 0 AS `self`
+			FROM `contact` WHERE `addr` = '%s' AND `uid` = 0",
+				dbesc($addr));
+
+	// Fetch the data from the gcontact table
+	if (!dbm::is_result($r))
+		$r = q("SELECT 0 AS `id`, 0 AS `cid`, `id` AS `gid`, 0 AS `zid`, 0 AS `uid`, `url`, `nurl`, `alias`, `network`, `name`, `nick`, `addr`, `location`, `about`, '' AS `xmpp`,
+			`keywords`, `gender`, `photo`, `photo` AS `thumb`, `photo` AS `micro`, `community` AS `forum`, 0 AS `prv`, `community`, `contact-type`, `birthday`, 0 AS `self`
+			FROM `gcontact` WHERE `addr` = '%s'",
+				dbesc($addr));
+
+	if (!dbm::is_result($r)) {
+		$data = Probe::uri($addr);
+
+		$profile = get_contact_details_by_url($data['url'], $uid);
+	} else {
+		$profile = $r[0];
+	}
+
+	return $profile;
+}
+
 if (! function_exists('contact_photo_menu')) {
 function contact_photo_menu($contact, $uid = 0)
 {

--- a/include/bb2diaspora.php
+++ b/include/bb2diaspora.php
@@ -11,15 +11,13 @@ require_once("library/html-to-markdown/HTML_To_Markdown.php");
  * @brief Callback function to replace a Diaspora style mention in a mention for Friendica
  *
  * @param array $match Matching values for the callback
- * @return text Replaced mention
+ * @return string Replaced mention
  */
 function diaspora_mention2bb($match) {
 	if ($match[2] == '') {
 		return;
 	}
 
-	/// @todo Don't use probe
-	//$data = Probe::uri($match[2]);
 	$data = get_contact_details_by_addr($match[2]);
 
 	$name = $match[1];
@@ -97,7 +95,7 @@ function diaspora2bb($s) {
  * @brief Callback function to replace a Friendica style mention in a mention for Diaspora
  *
  * @param array $match Matching values for the callback
- * @return text Replaced mention
+ * @return string Replaced mention
  */
 function diaspora_mentions($match) {
 

--- a/include/bb2diaspora.php
+++ b/include/bb2diaspora.php
@@ -7,6 +7,29 @@ require_once("include/html2bbcode.php");
 require_once("include/bbcode.php");
 require_once("library/html-to-markdown/HTML_To_Markdown.php");
 
+/**
+ * @brief Callback function to replace a Diaspora style mention in a mention for Friendica
+ *
+ * @param array $match Matching values for the callback
+ * @return text Replaced mention
+ */
+function diaspora_mention2bb($match) {
+	if ($match[2] == '') {
+		return;
+	}
+
+	/// @todo Don't use probe
+	//$data = Probe::uri($match[2]);
+	$data = get_contact_details_by_addr($match[2]);
+
+	$name = $match[1];
+
+	if ($name == '') {
+		$name = $data['name'];
+	}
+
+	return '@[url='.$data['url'].']'.$name.'[/url]';
+}
 
 // we don't want to support a bbcode specific markdown interpreter
 // and the markdown library we have is pretty good, but provides HTML output.
@@ -33,7 +56,8 @@ function diaspora2bb($s) {
 
 	$s = Markdown($s);
 
-	$s = preg_replace('/\@\{(.+?)\; (.+?)\@(.+?)\}/', '@[url=https://$3/u/$2]$1[/url]', $s);
+	$regexp = "/@\{(?:([^\}]+?); )?([^\} ]+)\}/";
+	$s = preg_replace_callback($regexp, 'diaspora_mention2bb', $s);
 
 	$s = str_replace('&#35;', '#', $s);
 


### PR DESCRIPTION
Eventually Diaspora will change to a new format in their mentions. By now it is ````@{FirstName LastName; user@pod.tld}```` - it will be changed to ````@{user@pod.tld}````.

Question is if it is a bugfix or a new feature :-)