### PR TITLE
Bugfix: for "embedded videos are cut off" #2987

### DIFF
--- a/view/global.css
+++ b/view/global.css
@@ -117,6 +117,10 @@ span.connector {
   position: relative;
 }
 
+.embed_video.active {
+  float: none;
+}
+
 .embed_rich {
   display: block;
   transition: height .75s;

--- a/view/templates/oembed_video.tpl
+++ b/view/templates/oembed_video.tpl
@@ -1,4 +1,4 @@
-<a class="embed_video" href='{{$embedurl}}' onclick='this.innerHTML=Base64.decode("{{$escapedhtml}}"); return false;'>
+<a class="embed_video" href='{{$embedurl}}' onclick='this.innerHTML=Base64.decode("{{$escapedhtml}}"); this.classList.add("active"); return false;'>
 	<img width='{{$tw}}' height='{{$th}}' src='{{$turl}}' >
 	<div style='width: {{$tw}}px; height: {{$th}}px;'></div>
 </a>


### PR DESCRIPTION
Bam Bam Bam. Finally :-)
This fixes https://github.com/friendica/friendica/issues/2987

The PR adds a little piece js to the oembed_video.tpl. If the oembed link is clicked it will add the class "active" to the clicked link element.

The css part does delete the float

This fix will only apply to new post since the old posts are cached with the old code