### PR TITLE
Bugfix: frio - fix text of input elements disappears behind the button

### DIFF
--- a/view/theme/frio/js/theme.js
+++ b/view/theme/frio/js/theme.js
@@ -256,40 +256,30 @@ $(document).ready(function(){
 		input.val(val);
 	});
 
+	// Set the padding for input elements with inline buttons
+	//
+	// In Frio we use some input elemnts where the submit button is visually
+	// inside the the input field (through css). We need to set a padding-right
+	// to the input field where the padding value would be at least the width
+	// of the button. Otherwise long user input would be invisible because it is
+	// behind the button.
+	$("body").on('click', '.form-group-search > input', function() {
+		// Get the width of the button (if the button isn't available
+		// buttonWidth will be null
+		var buttonWidth = $(this).next('.form-button-search').outerWidth();
+
+		if (buttonWidth) {
+			// Take the width of the button and ad 5px
+			var newWidth = buttonWidth + 5;
+			// Set the padding of the input element according
+			// to the width of the button
+			$(this).css('padding-right', newWidth);
+		}
+
+	});
+
+
 });
-//function commentOpenUI(obj, id) {
-//	$(document).unbind( "click.commentOpen", handler );
-//
-//	var handler = function() {
-//		if(obj.value == '{{$comment}}') {
-//			obj.value = '';
-//			$("#comment-edit-text-" + id).addClass("comment-edit-text-full").removeClass("comment-edit-text-empty");
-//			// Choose an arbitrary tab index that's greater than what we're using in jot (3 of them)
-//			// The submit button gets tabindex + 1
-//			$("#comment-edit-text-" + id).attr('tabindex','9');
-//			$("#comment-edit-submit-" + id).attr('tabindex','10');
-//			$("#comment-edit-submit-wrapper-" + id).show();
-//		}
-//	};
-//
-//	$(document).bind( "click.commentOpen", handler );
-//}
-//
-//function commentCloseUI(obj, id) {
-//	$(document).unbind( "click.commentClose", handler );
-//
-//	var handler = function() {
-//		if(obj.value === '') {
-//		obj.value = '{{$comment}}';
-//			$("#comment-edit-text-" + id).removeClass("comment-edit-text-full").addClass("comment-edit-text-empty");
-//			$("#comment-edit-text-" + id).removeAttr('tabindex');
-//			$("#comment-edit-submit-" + id).removeAttr('tabindex');
-//			$("#comment-edit-submit-wrapper-" + id).hide();
-//		}
-//	};
-//
-//	$(document).bind( "click.commentClose", handler );
-//}
 
 function openClose(theID) {
 	var elem = document.getElementById(theID);

--- a/view/theme/frio/js/theme.js
+++ b/view/theme/frio/js/theme.js
@@ -258,9 +258,9 @@ $(document).ready(function(){
 
 	// Set the padding for input elements with inline buttons
 	//
-	// In Frio we use some input elemnts where the submit button is visually
+	// In Frio we use some input elements where the submit button is visually
 	// inside the the input field (through css). We need to set a padding-right
-	// to the input field where the padding value would be at least the width
+	// to the input element where the padding value would be at least the width
 	// of the button. Otherwise long user input would be invisible because it is
 	// behind the button.
 	$("body").on('click', '.form-group-search > input', function() {


### PR DESCRIPTION
In Frio we use some input elemnts where the submit button is visually inside the the input field (through css). We need to set a padding-right to the input field where the padding value would be at least the width
of the button. Otherwise long user input would be invisible because it is behind the button.