### PR TITLE
Bugfix: Only delete spool files that are spool files

### DIFF
--- a/include/spool_post.php
+++ b/include/spool_post.php
@@ -35,7 +35,13 @@ function spool_post_run($argv, $argc) {
 					continue;
 				}
 				$arr = json_decode(file_get_contents($fullfile), true);
+				if (!is_array($arr)) {
+					continue;
+				}
 				$result = item_store($arr);
+				if ($result == 0) {
+					continue;
+				}
 				logger("Spool file ".$file." stored: ".$result, LOGGER_DEBUG);
 				unlink($fullfile);
 			}


### PR DESCRIPTION
See the (german) discussion here: https://philos.fkn-systems.de/display/396637598058a0569d3f588479235112

We mustn't delete files when they aren't spool files.