### PR TITLE
posts_from_contact_url: Handle the case when a contact is unknown.

### DIFF
--- a/include/Contact.php
+++ b/include/Contact.php
@@ -730,6 +730,10 @@ function posts_from_contact_url(App $a, $contact_url) {
 		$sql = "`item`.`uid` = %d";
 	}
 
+	if (!dbm::is_result($r)) {
+		return '';
+	}
+
 	$author_id = intval($r[0]["author-id"]);
 
 	if (get_config('system', 'old_pager')) {


### PR DESCRIPTION
The function "posts_from_contact_url" had problems when it was called with a contact url that doesn't fit to any known contact.