### PR TITLE
We have to delete spool files after posting in any case

### DIFF
--- a/include/spool_post.php
+++ b/include/spool_post.php
@@ -35,13 +35,19 @@ function spool_post_run($argv, $argc) {
 					continue;
 				}
 				$arr = json_decode(file_get_contents($fullfile), true);
+
+				// If it isn't an array then it is no spool file
 				if (!is_array($arr)) {
 					continue;
 				}
-				$result = item_store($arr);
-				if ($result == 0) {
+
+				// Skip if it doesn't seem to be an item array
+				if (!isset($arr['uid']) AND !isset($arr['uri']) AND !isset($arr['network'])) {
 					continue;
 				}
+
+				$result = item_store($arr);
+
 				logger("Spool file ".$file." stored: ".$result, LOGGER_DEBUG);
 				unlink($fullfile);
 			}


### PR DESCRIPTION
We must not delete files that aren't item arrays. But we mustn't keep files that couldn't be posted since this probably multiplies the amount of spool files.