### PR TITLE
Workaround for not createable spool path 

### DIFF
--- a/include/items.php
+++ b/include/items.php
@@ -857,7 +857,9 @@ function item_store($arr,$force_parent = false, $notify = false, $dontcache = fa
 		}
 
 		// Now we store the data in the spool directory
-		$file = 'item-'.round(microtime(true) * 10000).".msg";
+		// We use "microtime" to keep the arrival order and "mt_rand" to avoid duplicates
+		$file = 'item-'.round(microtime(true) * 10000).'-'.mt_rand().'.msg';
+
 		$spool = get_spoolpath().'/'.$file;
 		file_put_contents($spool, json_encode($arr));
 		logger("Item wasn't stored - Item was spooled into file ".$file, LOGGER_DEBUG);

--- a/include/items.php
+++ b/include/items.php
@@ -860,9 +860,12 @@ function item_store($arr,$force_parent = false, $notify = false, $dontcache = fa
 		// We use "microtime" to keep the arrival order and "mt_rand" to avoid duplicates
 		$file = 'item-'.round(microtime(true) * 10000).'-'.mt_rand().'.msg';
 
-		$spool = get_spoolpath().'/'.$file;
-		file_put_contents($spool, json_encode($arr));
-		logger("Item wasn't stored - Item was spooled into file ".$file, LOGGER_DEBUG);
+		$spoolpath = get_spoolpath();
+		if ($spoolpath != "") {
+			$spool = $spoolpath.'/'.$file;
+			file_put_contents($spool, json_encode($arr));
+			logger("Item wasn't stored - Item was spooled into file ".$file, LOGGER_DEBUG);
+		}
 		return 0;
 	}
 

--- a/include/spool_post.php
+++ b/include/spool_post.php
@@ -27,7 +27,7 @@ function spool_post_run($argv, $argc) {
 
 	$path = get_spoolpath();
 
-	if (is_writable($path)){
+	if (($path != '') AND is_writable($path)){
 		if ($dh = opendir($path)) {
 			while (($file = readdir($dh)) !== false) {
 

--- a/include/spool_post.php
+++ b/include/spool_post.php
@@ -30,10 +30,24 @@ function spool_post_run($argv, $argc) {
 	if (is_writable($path)){
 		if ($dh = opendir($path)) {
 			while (($file = readdir($dh)) !== false) {
+
+				// It is not named like a spool file, so we don't care.
+				if (substr($file, 0, 5) != "item-") {
+					continue;
+				}
+
 				$fullfile = $path."/".$file;
+
+				// We don't care about directories either
 				if (filetype($fullfile) != "file") {
 					continue;
 				}
+
+				// We can't read or write the file? So we don't care about it.
+				if (!is_writable($fullfile) OR !is_readable($fullfile)) {
+					continue;
+				}
+
 				$arr = json_decode(file_get_contents($fullfile), true);
 
 				// If it isn't an array then it is no spool file


### PR DESCRIPTION
Systemd is doing its very own thing with temp paths which causes some problems: http://stackoverflow.com/questions/30444914/php-has-its-own-tmp-in-tmp-systemd-private-nabcde-tmp-when-accessed-through-ng

This behaviour simply is a mess when working with Friendica. In the future we should find a way to detect this during the installation. Then we can urge the administrator to deactivate it or to define a different temp path for friendica.

In the meantime this pull request will fix the most annoying side effects.