### PR TITLE
Bugfix for badly formatted date time string

### DIFF
--- a/include/dbm.php
+++ b/include/dbm.php
@@ -86,5 +86,16 @@ class dbm {
 	public static function esc_array(&$arr, $add_quotation = false) {
 		array_walk($arr, 'self::esc_array_callback', $add_quotation);
 	}
+
+	/**
+	 * Checks Converts any date string into a SQL compatible date string
+	 *
+	 * @param string $date a date string in any format
+	 * @return string SQL style date string
+	 */
+	public static function date($date) {
+		$timestamp = strtotime($date);
+		return date('Y-m-d H:i:s');
+	}
 }
 ?>

--- a/include/dbm.php
+++ b/include/dbm.php
@@ -95,6 +95,12 @@ class dbm {
 	 */
 	public static function date($date = 'now') {
 		$timestamp = strtotime($date);
+
+		// Don't allow lower date strings as '0001-01-01 00:00:00'
+		if ($timestamp < -62135596800) {
+			$timestamp = -62135596800;
+		}
+
 		return date('Y-m-d H:i:s', $timestamp);
 	}
 }

--- a/include/dbm.php
+++ b/include/dbm.php
@@ -93,9 +93,9 @@ class dbm {
 	 * @param string $date a date string in any format
 	 * @return string SQL style date string
 	 */
-	public static function date($date) {
+	public static function date($date = 'now') {
 		$timestamp = strtotime($date);
-		return date('Y-m-d H:i:s');
+		return date('Y-m-d H:i:s', $timestamp);
 	}
 }
 ?>

--- a/include/dbm.php
+++ b/include/dbm.php
@@ -96,10 +96,17 @@ class dbm {
 	public static function date($date = 'now') {
 		$timestamp = strtotime($date);
 
-		// Don't allow lower date strings as '0001-01-01 00:00:00'
+		// Workaround for 3.5.1
 		if ($timestamp < -62135596800) {
-			$timestamp = -62135596800;
+			return '0000-00-00 00:00:00';
 		}
+
+		// The above will be removed in 3.5.2
+		// The following will then be enabled
+		// Don't allow lower date strings as '0001-01-01 00:00:00'
+		//if ($timestamp < -62135596800) {
+		//	$timestamp = -62135596800;
+		//}
 
 		return date('Y-m-d H:i:s', $timestamp);
 	}

--- a/include/socgraph.php
+++ b/include/socgraph.php
@@ -622,7 +622,7 @@ function poco_last_updated($profile, $force = false) {
 			$last_updated = "0000-00-00 00:00:00";
 
 	q("UPDATE `gcontact` SET `updated` = '%s', `last_contact` = '%s' WHERE `nurl` = '%s'",
-		dbesc($last_updated), dbesc(datetime_convert()), dbesc(normalise_link($profile)));
+		dbesc(dbm::date($last_updated)), dbesc(datetime_convert()), dbesc(normalise_link($profile)));
 
 	if (($gcontacts[0]["generation"] == 0))
 		q("UPDATE `gcontact` SET `generation` = 9 WHERE `nurl` = '%s'",

--- a/include/socgraph.php
+++ b/include/socgraph.php
@@ -622,7 +622,7 @@ function poco_last_updated($profile, $force = false) {
 			$last_updated = "0000-00-00 00:00:00";
 
 	q("UPDATE `gcontact` SET `updated` = '%s', `last_contact` = '%s' WHERE `nurl` = '%s'",
-		dbesc(dbm::date($last_updated)), dbesc(datetime_convert()), dbesc(normalise_link($profile)));
+		dbesc(dbm::date($last_updated)), dbesc(dbm::date()), dbesc(normalise_link($profile)));
 
 	if (($gcontacts[0]["generation"] == 0))
 		q("UPDATE `gcontact` SET `generation` = 9 WHERE `nurl` = '%s'",

--- a/include/socgraph.php
+++ b/include/socgraph.php
@@ -1592,6 +1592,11 @@ function get_gcontact_id($contact) {
  */
 function update_gcontact($contact) {
 
+	// Check for invalid "contact-type" value
+	if (isset($contact['contact-type']) AND (intval($contact['contact-type']) < 0)) {
+		$contact['contact-type'] = 0;
+	}
+
 	/// @todo update contact table as well
 
 	$gcontact_id = get_gcontact_id($contact);


### PR DESCRIPTION
There was one place where we hadn't formatted a date time value according to the SQL standard. To make that easier, I added a new function. By now we are (mis)using "datetime_convert" for that. This is a rather huge function that is oversized for this functionality.