### PR TITLE
Bugfix: the curl option CURLOPT_SSL_VERIFYHOST is problematic

### DIFF
--- a/include/ParseUrl.php
+++ b/include/ParseUrl.php
@@ -146,7 +146,9 @@ class ParseUrl {
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 		curl_setopt($ch, CURLOPT_USERAGENT, $a->get_useragent());
 		curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, (($check_cert) ? true : false));
-		curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, (($check_cert) ? 2 : false));
+		if ($check_cert) {
+			@curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
+		}
 
 		$header = curl_exec($ch);
 		$curl_info = @curl_getinfo($ch);

--- a/include/network.php
+++ b/include/network.php
@@ -118,7 +118,9 @@ function z_fetch_url($url,$binary = false, &$redirects = 0, $opts=array()) {
 
 	$check_cert = get_config('system','verifyssl');
 	@curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, (($check_cert) ? true : false));
-	@curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, (($check_cert) ? 2 : false));
+	if ($check_cert) {
+		@curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
+	}
 
 	$prx = get_config('system','proxy');
 	if(strlen($prx)) {
@@ -265,7 +267,9 @@ function post_url($url,$params, $headers = null, &$redirects = 0, $timeout = 0) 
 
 	$check_cert = get_config('system','verifyssl');
 	curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, (($check_cert) ? true : false));
-	curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, (($check_cert) ? 2 : false));
+	if ($check_cert) {
+		@curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
+	}
 	$prx = get_config('system','proxy');
 	if(strlen($prx)) {
 		curl_setopt($ch, CURLOPT_HTTPPROXYTUNNEL, 1);

--- a/include/poller.php
+++ b/include/poller.php
@@ -11,7 +11,6 @@ if (!file_exists("boot.php") AND (sizeof($_SERVER["argv"]) != 0)) {
 }
 
 use \Friendica\Core\Config;
-use \Friendica\Core\PConfig;
 
 require_once("boot.php");
 
@@ -28,6 +27,8 @@ function poller_run($argv, $argc){
 		$db = new dba($db_host, $db_user, $db_pass, $db_data);
 		unset($db_host, $db_user, $db_pass, $db_data);
 	};
+
+	Config::load();
 
 	// Quit when in maintenance
 	if (Config::get('system', 'maintenance', true)) {


### PR DESCRIPTION
See the discussion here: https://core.trac.wordpress.org/ticket/34794

The value "false" for the curl option CURLOPT_SSL_VERIFYHOST is not defined and makes problems.

On my server setting this option to "false" resulted in returning false content when the server wasn't reachable.

The other line is only some precaution. I'm having the problem that sometimes the config values aren't loaded. Hopefully this solves it.