### PR TITLE
Bugfix issue 3187

### DIFF
--- a/mod/notifications.php
+++ b/mod/notifications.php
@@ -194,10 +194,12 @@ function notifications_content(App $a) {
 						if($it['network'] === NETWORK_DFRN) {
 							$lbl_knowyou = t('Claims to be known to you: ');
 							$knowyou = (($it['knowyou']) ? t('yes') : t('no'));
-							$helptext = t('Shall your connection be bidirectional or not? "Friend" implies that you allow to read and you subscribe to their posts. "Fan/Admirer" means that you allow to read but you do not want to read theirs. Approve as: ');
+							$helptext = t('Shall your connection be bidirectional or not?');
+							$helptext2 = t('"Friend" implies that you allow to read and you subscribe to their posts. "Subscriber" means that you allow to read but you do not want to read theirs. Approve as: ');
 						} else {
 							$knowyou = '';
-							$helptext = t('Shall your connection be bidirectional or not? "Friend" implies that you allow to read and you subscribe to their posts. "Sharer" means that you allow to read but you do not want to read theirs. Approve as: ');
+							$helptext = t('Shall your connection be bidirectional or not?');
+							$helptext2 = t('"Friend" implies that you allow to read and you subscribe to their posts. "Sharer" means that you allow to read but you do not want to read theirs. Approve as: ');
 						}
 					}
 
@@ -205,9 +207,10 @@ function notifications_content(App $a) {
 						'$intro_id' => $it['intro_id'],
 						'$friend_selected' => $friend_selected,
 						'$fan_selected' => $fan_selected,
-						'$approve_as' => $helptext,
+						'$approve_as1' => $helptext,
+						'$approve_as2' => $helptext2,
 						'$as_friend' => t('Friend'),
-						'$as_fan' => (($it['network'] == NETWORK_DIASPORA) ? t('Sharer') : t('Fan/Admirer'))
+						'$as_fan' => (($it['network'] == NETWORK_DIASPORA) ? t('Sharer') : t('Subscriber'))
 					));
 
 					$header = $it["name"];

--- a/mod/notifications.php
+++ b/mod/notifications.php
@@ -195,11 +195,13 @@ function notifications_content(App $a) {
 							$lbl_knowyou = t('Claims to be known to you: ');
 							$knowyou = (($it['knowyou']) ? t('yes') : t('no'));
 							$helptext = t('Shall your connection be bidirectional or not?');
-							$helptext2 = t('"Friend" implies that you allow to read and you subscribe to their posts. "Subscriber" means that you allow to read but you do not want to read theirs. Approve as: ');
+							$helptext2 = sprintf(t('Accepting %s as a friend allows %s to subscribe to your posts, and you will also receive updates from them in your news feed.'), $it['name'], $it['name']);
+							$helptext3 = sprintf(t('Accepting %s as a subscriber allows them to subscribe to your posts, but you will not receive updates from them in your news feed.'), $it['name']);
 						} else {
 							$knowyou = '';
 							$helptext = t('Shall your connection be bidirectional or not?');
-							$helptext2 = t('"Friend" implies that you allow to read and you subscribe to their posts. "Sharer" means that you allow to read but you do not want to read theirs. Approve as: ');
+							$helptext2 = sprintf(t('Accepting %s as a friend allows %s to subscribe to your posts, and you will also receive updates from them in your news feed.'), $it['name'], $it['name']);
+							$helptext3 = sprintf(t('Accepting %s as a sharer allows them to subscribe to your posts, but you will not receive updates from them in your news feed.'), $it['name']);
 						}
 					}
 
@@ -209,6 +211,7 @@ function notifications_content(App $a) {
 						'$fan_selected' => $fan_selected,
 						'$approve_as1' => $helptext,
 						'$approve_as2' => $helptext2,
+						'$approve_as3' => $helptext3,
 						'$as_friend' => t('Friend'),
 						'$as_fan' => (($it['network'] == NETWORK_DIASPORA) ? t('Sharer') : t('Subscriber'))
 					));

--- a/util/messages.po
+++ b/util/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-12-19 07:46+0100\n"
+"POT-Creation-Date: 2017-03-03 10:29+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,112 +17,6 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-
-#: include/contact_widgets.php:6
-msgid "Add New Contact"
-msgstr ""
-
-#: include/contact_widgets.php:7
-msgid "Enter address or web location"
-msgstr ""
-
-#: include/contact_widgets.php:8
-msgid "Example: bob@example.com, http://example.com/barbara"
-msgstr ""
-
-#: include/contact_widgets.php:10 include/identity.php:218
-#: mod/allfriends.php:82 mod/dirfind.php:201 mod/match.php:87
-#: mod/suggest.php:101
-msgid "Connect"
-msgstr ""
-
-#: include/contact_widgets.php:24
-#, php-format
-msgid "%d invitation available"
-msgid_plural "%d invitations available"
-msgstr[0] ""
-msgstr[1] ""
-
-#: include/contact_widgets.php:30
-msgid "Find People"
-msgstr ""
-
-#: include/contact_widgets.php:31
-msgid "Enter name or interest"
-msgstr ""
-
-#: include/contact_widgets.php:32 include/Contact.php:354
-#: include/conversation.php:981 mod/allfriends.php:66 mod/dirfind.php:204
-#: mod/match.php:72 mod/suggest.php:83 mod/contacts.php:602 mod/follow.php:103
-msgid "Connect/Follow"
-msgstr ""
-
-#: include/contact_widgets.php:33
-msgid "Examples: Robert Morgenstein, Fishing"
-msgstr ""
-
-#: include/contact_widgets.php:34 mod/directory.php:204 mod/contacts.php:798
-msgid "Find"
-msgstr ""
-
-#: include/contact_widgets.php:35 mod/suggest.php:114
-#: view/theme/vier/theme.php:203
-msgid "Friend Suggestions"
-msgstr ""
-
-#: include/contact_widgets.php:36 view/theme/vier/theme.php:202
-msgid "Similar Interests"
-msgstr ""
-
-#: include/contact_widgets.php:37
-msgid "Random Profile"
-msgstr ""
-
-#: include/contact_widgets.php:38 view/theme/vier/theme.php:204
-msgid "Invite Friends"
-msgstr ""
-
-#: include/contact_widgets.php:108
-msgid "Networks"
-msgstr ""
-
-#: include/contact_widgets.php:111
-msgid "All Networks"
-msgstr ""
-
-#: include/contact_widgets.php:141 include/features.php:110
-msgid "Saved Folders"
-msgstr ""
-
-#: include/contact_widgets.php:144 include/contact_widgets.php:176
-msgid "Everything"
-msgstr ""
-
-#: include/contact_widgets.php:173
-msgid "Categories"
-msgstr ""
-
-#: include/contact_widgets.php:237
-#, php-format
-msgid "%d contact in common"
-msgid_plural "%d contacts in common"
-msgstr[0] ""
-msgstr[1] ""
-
-#: include/contact_widgets.php:242 include/ForumManager.php:119
-#: include/items.php:2245 mod/content.php:624 object/Item.php:432
-#: view/theme/vier/theme.php:260 boot.php:972
-msgid "show more"
-msgstr ""
-
-#: include/ForumManager.php:114 include/nav.php:131 include/text.php:1025
-#: view/theme/vier/theme.php:255
-msgid "Forums"
-msgstr ""
-
-#: include/ForumManager.php:116 view/theme/vier/theme.php:257
-msgid "External link to forum"
-msgstr ""
 
 #: include/profile_selectors.php:6
 msgid "Male"
@@ -176,7 +70,7 @@ msgstr ""
 msgid "Other"
 msgstr ""
 
-#: include/profile_selectors.php:6 include/conversation.php:1487
+#: include/profile_selectors.php:6 include/conversation.php:1478
 msgid "Undecided"
 msgid_plural "Undecided"
 msgstr[0] ""
@@ -358,432 +252,148 @@ msgstr ""
 msgid "Ask me"
 msgstr ""
 
-#: include/dba_pdo.php:72 include/dba.php:56
+#: include/ForumManager.php:114 include/nav.php:131 include/text.php:1027
+#: view/theme/vier/theme.php:250
+msgid "Forums"
+msgstr ""
+
+#: include/ForumManager.php:116 view/theme/vier/theme.php:252
+msgid "External link to forum"
+msgstr ""
+
+#: include/ForumManager.php:119 include/contact_widgets.php:253
+#: include/items.php:2254 mod/content.php:624 object/Item.php:447
+#: view/theme/vier/theme.php:255 boot.php:971
+msgid "show more"
+msgstr ""
+
+#: include/NotificationsManager.php:153
+msgid "System"
+msgstr ""
+
+#: include/NotificationsManager.php:160 include/nav.php:158 mod/admin.php:412
+#: view/theme/frio/theme.php:253
+msgid "Network"
+msgstr ""
+
+#: include/NotificationsManager.php:167 mod/profiles.php:695
+#: mod/network.php:846
+msgid "Personal"
+msgstr ""
+
+#: include/NotificationsManager.php:174 include/nav.php:105
+#: include/nav.php:161
+msgid "Home"
+msgstr ""
+
+#: include/NotificationsManager.php:181 include/nav.php:166
+msgid "Introductions"
+msgstr ""
+
+#: include/NotificationsManager.php:239 include/NotificationsManager.php:251
 #, php-format
-msgid "Cannot locate DNS info for database server '%s'"
+msgid "%s commented on %s's post"
+msgstr ""
+
+#: include/NotificationsManager.php:250
+#, php-format
+msgid "%s created a new post"
+msgstr ""
+
+#: include/NotificationsManager.php:265
+#, php-format
+msgid "%s liked %s's post"
+msgstr ""
+
+#: include/NotificationsManager.php:278
+#, php-format
+msgid "%s disliked %s's post"
+msgstr ""
+
+#: include/NotificationsManager.php:291
+#, php-format
+msgid "%s is attending %s's event"
+msgstr ""
+
+#: include/NotificationsManager.php:304
+#, php-format
+msgid "%s is not attending %s's event"
+msgstr ""
+
+#: include/NotificationsManager.php:317
+#, php-format
+msgid "%s may attend %s's event"
+msgstr ""
+
+#: include/NotificationsManager.php:334
+#, php-format
+msgid "%s is now friends with %s"
+msgstr ""
+
+#: include/NotificationsManager.php:770
+msgid "Friend Suggestion"
+msgstr ""
+
+#: include/NotificationsManager.php:803
+msgid "Friend/Connect Request"
+msgstr ""
+
+#: include/NotificationsManager.php:803
+msgid "New Follower"
+msgstr ""
+
+#: include/Photo.php:1038 include/Photo.php:1054 include/Photo.php:1062
+#: include/Photo.php:1087 include/message.php:146 mod/item.php:462
+#: mod/wall_upload.php:216 mod/wall_upload.php:230 mod/wall_upload.php:237
+msgid "Wall Photos"
 msgstr ""
 
 #: include/auth.php:45
 msgid "Logged out."
 msgstr ""
 
-#: include/auth.php:116 include/auth.php:178 mod/openid.php:100
+#: include/auth.php:116 include/auth.php:177 mod/openid.php:110
 msgid "Login failed."
 msgstr ""
 
-#: include/auth.php:132 include/user.php:75
+#: include/auth.php:131 include/user.php:75
 msgid ""
 "We encountered a problem while logging in with the OpenID you provided. "
 "Please check the correct spelling of the ID."
 msgstr ""
 
-#: include/auth.php:132 include/user.php:75
+#: include/auth.php:131 include/user.php:75
 msgid "The error message was:"
 msgstr ""
 
-#: include/group.php:25
-msgid ""
-"A deleted group with this name was revived. Existing item permissions "
-"<strong>may</strong> apply to this group and any future members. If this is "
-"not what you intended, please create another group with a different name."
+#: include/bbcode.php:350 include/bbcode.php:1055 include/bbcode.php:1056
+msgid "Image/photo"
 msgstr ""
 
-#: include/group.php:209
-msgid "Default privacy group for new contacts"
-msgstr ""
-
-#: include/group.php:242
-msgid "Everybody"
-msgstr ""
-
-#: include/group.php:265
-msgid "edit"
-msgstr ""
-
-#: include/group.php:286 mod/newmember.php:61
-msgid "Groups"
-msgstr ""
-
-#: include/group.php:288
-msgid "Edit groups"
-msgstr ""
-
-#: include/group.php:290
-msgid "Edit group"
-msgstr ""
-
-#: include/group.php:291
-msgid "Create a new group"
-msgstr ""
-
-#: include/group.php:292 mod/group.php:94 mod/group.php:178
-msgid "Group Name: "
-msgstr ""
-
-#: include/group.php:294
-msgid "Contacts not in any group"
-msgstr ""
-
-#: include/group.php:296 mod/network.php:201
-msgid "add"
-msgstr ""
-
-#: include/contact_selectors.php:32
-msgid "Unknown | Not categorised"
-msgstr ""
-
-#: include/contact_selectors.php:33
-msgid "Block immediately"
-msgstr ""
-
-#: include/contact_selectors.php:34
-msgid "Shady, spammer, self-marketer"
-msgstr ""
-
-#: include/contact_selectors.php:35
-msgid "Known to me, but no opinion"
-msgstr ""
-
-#: include/contact_selectors.php:36
-msgid "OK, probably harmless"
-msgstr ""
-
-#: include/contact_selectors.php:37
-msgid "Reputable, has my trust"
-msgstr ""
-
-#: include/contact_selectors.php:56 mod/admin.php:890
-msgid "Frequently"
-msgstr ""
-
-#: include/contact_selectors.php:57 mod/admin.php:891
-msgid "Hourly"
-msgstr ""
-
-#: include/contact_selectors.php:58 mod/admin.php:892
-msgid "Twice daily"
-msgstr ""
-
-#: include/contact_selectors.php:59 mod/admin.php:893
-msgid "Daily"
-msgstr ""
-
-#: include/contact_selectors.php:60
-msgid "Weekly"
-msgstr ""
-
-#: include/contact_selectors.php:61
-msgid "Monthly"
-msgstr ""
-
-#: include/contact_selectors.php:76 mod/dfrn_request.php:868
-msgid "Friendica"
-msgstr ""
-
-#: include/contact_selectors.php:77
-msgid "OStatus"
-msgstr ""
-
-#: include/contact_selectors.php:78
-msgid "RSS/Atom"
-msgstr ""
-
-#: include/contact_selectors.php:79 include/contact_selectors.php:86
-#: mod/admin.php:1396 mod/admin.php:1409 mod/admin.php:1422 mod/admin.php:1440
-msgid "Email"
-msgstr ""
-
-#: include/contact_selectors.php:80 mod/settings.php:842
-#: mod/dfrn_request.php:870
-msgid "Diaspora"
-msgstr ""
-
-#: include/contact_selectors.php:81
-msgid "Facebook"
-msgstr ""
-
-#: include/contact_selectors.php:82
-msgid "Zot!"
-msgstr ""
-
-#: include/contact_selectors.php:83
-msgid "LinkedIn"
-msgstr ""
-
-#: include/contact_selectors.php:84
-msgid "XMPP/IM"
-msgstr ""
-
-#: include/contact_selectors.php:85
-msgid "MySpace"
-msgstr ""
-
-#: include/contact_selectors.php:87
-msgid "Google+"
-msgstr ""
-
-#: include/contact_selectors.php:88
-msgid "pump.io"
-msgstr ""
-
-#: include/contact_selectors.php:89
-msgid "Twitter"
-msgstr ""
-
-#: include/contact_selectors.php:90
-msgid "Diaspora Connector"
-msgstr ""
-
-#: include/contact_selectors.php:91
-msgid "GNU Social"
-msgstr ""
-
-#: include/contact_selectors.php:92
-msgid "App.net"
-msgstr ""
-
-#: include/contact_selectors.php:103
-msgid "Hubzilla/Redmatrix"
-msgstr ""
-
-#: include/acl_selectors.php:327
-msgid "Post to Email"
-msgstr ""
-
-#: include/acl_selectors.php:332
+#: include/bbcode.php:467
 #, php-format
-msgid "Connectors disabled, since \"%s\" is enabled."
+msgid "<a href=\"%1$s\" target=\"_blank\">%2$s</a> %3$s"
 msgstr ""
 
-#: include/acl_selectors.php:333 mod/settings.php:1181
-msgid "Hide your profile details from unknown viewers?"
+#: include/bbcode.php:1015 include/bbcode.php:1035
+msgid "$1 wrote:"
 msgstr ""
 
-#: include/acl_selectors.php:338
-msgid "Visible to everybody"
+#: include/bbcode.php:1064 include/bbcode.php:1065
+msgid "Encrypted content"
 msgstr ""
 
-#: include/acl_selectors.php:339 view/theme/vier/config.php:103
-msgid "show"
+#: include/bbcode.php:1167
+msgid "Invalid source protocol"
 msgstr ""
 
-#: include/acl_selectors.php:340 view/theme/vier/config.php:103
-msgid "don't show"
+#: include/bbcode.php:1177
+msgid "Invalid link protocol"
 msgstr ""
 
-#: include/acl_selectors.php:346 mod/editpost.php:133
-msgid "CC: email addresses"
-msgstr ""
-
-#: include/acl_selectors.php:347 mod/editpost.php:140
-msgid "Example: bob@example.com, mary@example.com"
-msgstr ""
-
-#: include/acl_selectors.php:349 mod/events.php:509 mod/photos.php:1156
-#: mod/photos.php:1535
-msgid "Permissions"
-msgstr ""
-
-#: include/acl_selectors.php:350
-msgid "Close"
-msgstr ""
-
-#: include/like.php:163 include/conversation.php:130
-#: include/conversation.php:266 include/text.php:1804 mod/subthread.php:87
-#: mod/tagger.php:62
-msgid "photo"
-msgstr ""
-
-#: include/like.php:163 include/diaspora.php:1406 include/conversation.php:125
-#: include/conversation.php:134 include/conversation.php:261
-#: include/conversation.php:270 mod/subthread.php:87 mod/tagger.php:62
-msgid "status"
-msgstr ""
-
-#: include/like.php:165 include/conversation.php:122
-#: include/conversation.php:258 include/text.php:1802
-msgid "event"
-msgstr ""
-
-#: include/like.php:182 include/diaspora.php:1402 include/conversation.php:141
+#: include/dba_pdo.php:72 include/dba.php:56
 #, php-format
-msgid "%1$s likes %2$s's %3$s"
-msgstr ""
-
-#: include/like.php:184 include/conversation.php:144
-#, php-format
-msgid "%1$s doesn't like %2$s's %3$s"
-msgstr ""
-
-#: include/like.php:186
-#, php-format
-msgid "%1$s is attending %2$s's %3$s"
-msgstr ""
-
-#: include/like.php:188
-#, php-format
-msgid "%1$s is not attending %2$s's %3$s"
-msgstr ""
-
-#: include/like.php:190
-#, php-format
-msgid "%1$s may attend %2$s's %3$s"
-msgstr ""
-
-#: include/message.php:15 include/message.php:173
-msgid "[no subject]"
-msgstr ""
-
-#: include/message.php:145 include/Photo.php:1040 include/Photo.php:1056
-#: include/Photo.php:1064 include/Photo.php:1089 mod/wall_upload.php:218
-#: mod/wall_upload.php:232 mod/wall_upload.php:239 mod/item.php:478
-msgid "Wall Photos"
-msgstr ""
-
-#: include/plugin.php:526 include/plugin.php:528
-msgid "Click here to upgrade."
-msgstr ""
-
-#: include/plugin.php:534
-msgid "This action exceeds the limits set by your subscription plan."
-msgstr ""
-
-#: include/plugin.php:539
-msgid "This action is not available under your subscription plan."
-msgstr ""
-
-#: include/uimport.php:94
-msgid "Error decoding account file"
-msgstr ""
-
-#: include/uimport.php:100
-msgid "Error! No version data in file! This is not a Friendica account file?"
-msgstr ""
-
-#: include/uimport.php:116 include/uimport.php:127
-msgid "Error! Cannot check nickname"
-msgstr ""
-
-#: include/uimport.php:120 include/uimport.php:131
-#, php-format
-msgid "User '%s' already exists on this server!"
-msgstr ""
-
-#: include/uimport.php:153
-msgid "User creation error"
-msgstr ""
-
-#: include/uimport.php:173
-msgid "User profile creation error"
-msgstr ""
-
-#: include/uimport.php:222
-#, php-format
-msgid "%d contact not imported"
-msgid_plural "%d contacts not imported"
-msgstr[0] ""
-msgstr[1] ""
-
-#: include/uimport.php:292
-msgid "Done. You can now login with your username and password"
-msgstr ""
-
-#: include/datetime.php:57 include/datetime.php:59 mod/profiles.php:705
-msgid "Miscellaneous"
-msgstr ""
-
-#: include/datetime.php:183 include/identity.php:629
-msgid "Birthday:"
-msgstr ""
-
-#: include/datetime.php:185 mod/profiles.php:728
-msgid "Age: "
-msgstr ""
-
-#: include/datetime.php:187
-msgid "YYYY-MM-DD or MM-DD"
-msgstr ""
-
-#: include/datetime.php:341
-msgid "never"
-msgstr ""
-
-#: include/datetime.php:347
-msgid "less than a second ago"
-msgstr ""
-
-#: include/datetime.php:350
-msgid "year"
-msgstr ""
-
-#: include/datetime.php:350
-msgid "years"
-msgstr ""
-
-#: include/datetime.php:351 include/event.php:480 mod/cal.php:284
-#: mod/events.php:389
-msgid "month"
-msgstr ""
-
-#: include/datetime.php:351
-msgid "months"
-msgstr ""
-
-#: include/datetime.php:352 include/event.php:481 mod/cal.php:285
-#: mod/events.php:390
-msgid "week"
-msgstr ""
-
-#: include/datetime.php:352
-msgid "weeks"
-msgstr ""
-
-#: include/datetime.php:353 include/event.php:482 mod/cal.php:286
-#: mod/events.php:391
-msgid "day"
-msgstr ""
-
-#: include/datetime.php:353
-msgid "days"
-msgstr ""
-
-#: include/datetime.php:354
-msgid "hour"
-msgstr ""
-
-#: include/datetime.php:354
-msgid "hours"
-msgstr ""
-
-#: include/datetime.php:355
-msgid "minute"
-msgstr ""
-
-#: include/datetime.php:355
-msgid "minutes"
-msgstr ""
-
-#: include/datetime.php:356
-msgid "second"
-msgstr ""
-
-#: include/datetime.php:356
-msgid "seconds"
-msgstr ""
-
-#: include/datetime.php:365
-#, php-format
-msgid "%1$d %2$s ago"
-msgstr ""
-
-#: include/datetime.php:572
-#, php-format
-msgid "%s's birthday"
-msgstr ""
-
-#: include/datetime.php:573 include/dfrn.php:1109
-#, php-format
-msgid "Happy Birthday %s"
+msgid "Cannot locate DNS info for database server '%s'"
 msgstr ""
 
 #: include/enotify.php:24
@@ -804,7 +414,7 @@ msgstr ""
 msgid "%1$s, %2$s Administrator"
 msgstr ""
 
-#: include/enotify.php:43 include/delivery.php:457
+#: include/enotify.php:43 include/delivery.php:482
 msgid "noreply"
 msgstr ""
 
@@ -1082,209 +692,153 @@ msgstr ""
 msgid "Please visit %s to approve or reject the request."
 msgstr ""
 
-#: include/event.php:16 include/bb2diaspora.php:152 mod/localtime.php:12
-msgid "l F d, Y \\@ g:i A"
+#: include/follow.php:81 mod/dfrn_request.php:512
+msgid "Disallowed profile URL."
 msgstr ""
 
-#: include/event.php:33 include/event.php:51 include/event.php:487
-#: include/bb2diaspora.php:158
-msgid "Starts:"
+#: include/follow.php:86
+msgid "Connect URL missing."
 msgstr ""
 
-#: include/event.php:36 include/event.php:57 include/event.php:488
-#: include/bb2diaspora.php:166
-msgid "Finishes:"
+#: include/follow.php:114
+msgid ""
+"This site is not configured to allow communications with other networks."
 msgstr ""
 
-#: include/event.php:39 include/event.php:63 include/event.php:489
-#: include/bb2diaspora.php:174 include/identity.php:328
-#: mod/notifications.php:232 mod/directory.php:137 mod/events.php:494
-#: mod/contacts.php:628
-msgid "Location:"
+#: include/follow.php:115 include/follow.php:129
+msgid "No compatible communication protocols or feeds were discovered."
 msgstr ""
 
-#: include/event.php:441
-msgid "Sun"
+#: include/follow.php:127
+msgid "The profile address specified does not provide adequate information."
 msgstr ""
 
-#: include/event.php:442
-msgid "Mon"
+#: include/follow.php:132
+msgid "An author or name was not found."
 msgstr ""
 
-#: include/event.php:443
-msgid "Tue"
+#: include/follow.php:135
+msgid "No browser URL could be matched to this address."
 msgstr ""
 
-#: include/event.php:444
-msgid "Wed"
+#: include/follow.php:138
+msgid ""
+"Unable to match @-style Identity Address with a known protocol or email "
+"contact."
 msgstr ""
 
-#: include/event.php:445
-msgid "Thu"
+#: include/follow.php:139
+msgid "Use mailto: in front of address to force email check."
 msgstr ""
 
-#: include/event.php:446
-msgid "Fri"
+#: include/follow.php:145
+msgid ""
+"The profile address specified belongs to a network which has been disabled "
+"on this site."
 msgstr ""
 
-#: include/event.php:447
-msgid "Sat"
+#: include/follow.php:150
+msgid ""
+"Limited profile. This person will be unable to receive direct/personal "
+"notifications from you."
 msgstr ""
 
-#: include/event.php:448 include/text.php:1130 mod/settings.php:972
-msgid "Sunday"
+#: include/follow.php:251
+msgid "Unable to retrieve contact information."
 msgstr ""
 
-#: include/event.php:449 include/text.php:1130 mod/settings.php:972
-msgid "Monday"
+#: include/group.php:25
+msgid ""
+"A deleted group with this name was revived. Existing item permissions "
+"<strong>may</strong> apply to this group and any future members. If this is "
+"not what you intended, please create another group with a different name."
 msgstr ""
 
-#: include/event.php:450 include/text.php:1130
-msgid "Tuesday"
+#: include/group.php:210
+msgid "Default privacy group for new contacts"
 msgstr ""
 
-#: include/event.php:451 include/text.php:1130
-msgid "Wednesday"
+#: include/group.php:243
+msgid "Everybody"
 msgstr ""
 
-#: include/event.php:452 include/text.php:1130
-msgid "Thursday"
+#: include/group.php:266
+msgid "edit"
 msgstr ""
 
-#: include/event.php:453 include/text.php:1130
-msgid "Friday"
+#: include/group.php:287 mod/newmember.php:61
+msgid "Groups"
 msgstr ""
 
-#: include/event.php:454 include/text.php:1130
-msgid "Saturday"
+#: include/group.php:289
+msgid "Edit groups"
 msgstr ""
 
-#: include/event.php:455
-msgid "Jan"
+#: include/group.php:291
+msgid "Edit group"
 msgstr ""
 
-#: include/event.php:456
-msgid "Feb"
+#: include/group.php:292
+msgid "Create a new group"
 msgstr ""
 
-#: include/event.php:457
-msgid "Mar"
+#: include/group.php:293 mod/group.php:98 mod/group.php:188
+msgid "Group Name: "
 msgstr ""
 
-#: include/event.php:458
-msgid "Apr"
+#: include/group.php:295
+msgid "Contacts not in any group"
 msgstr ""
 
-#: include/event.php:459 include/event.php:471 include/text.php:1134
-msgid "May"
+#: include/group.php:297 mod/network.php:200
+msgid "add"
 msgstr ""
 
-#: include/event.php:460
-msgid "Jun"
+#: include/like.php:164 include/conversation.php:130
+#: include/conversation.php:266 include/text.php:1806 mod/subthread.php:88
+#: mod/tagger.php:62
+msgid "photo"
 msgstr ""
 
-#: include/event.php:461
-msgid "Jul"
+#: include/like.php:164 include/conversation.php:125
+#: include/conversation.php:134 include/conversation.php:261
+#: include/conversation.php:270 include/diaspora.php:1530 mod/subthread.php:88
+#: mod/tagger.php:62
+msgid "status"
 msgstr ""
 
-#: include/event.php:462
-msgid "Aug"
+#: include/like.php:166 include/conversation.php:122
+#: include/conversation.php:258 include/text.php:1804
+msgid "event"
 msgstr ""
 
-#: include/event.php:463
-msgid "Sept"
+#: include/like.php:184 include/conversation.php:141 include/diaspora.php:1526
+#, php-format
+msgid "%1$s likes %2$s's %3$s"
 msgstr ""
 
-#: include/event.php:464
-msgid "Oct"
+#: include/like.php:187 include/conversation.php:144
+#, php-format
+msgid "%1$s doesn't like %2$s's %3$s"
 msgstr ""
 
-#: include/event.php:465
-msgid "Nov"
+#: include/like.php:190
+#, php-format
+msgid "%1$s is attending %2$s's %3$s"
 msgstr ""
 
-#: include/event.php:466
-msgid "Dec"
+#: include/like.php:193
+#, php-format
+msgid "%1$s is not attending %2$s's %3$s"
 msgstr ""
 
-#: include/event.php:467 include/text.php:1134
-msgid "January"
+#: include/like.php:196
+#, php-format
+msgid "%1$s may attend %2$s's %3$s"
 msgstr ""
 
-#: include/event.php:468 include/text.php:1134
-msgid "February"
-msgstr ""
-
-#: include/event.php:469 include/text.php:1134
-msgid "March"
-msgstr ""
-
-#: include/event.php:470 include/text.php:1134
-msgid "April"
-msgstr ""
-
-#: include/event.php:472 include/text.php:1134
-msgid "June"
-msgstr ""
-
-#: include/event.php:473 include/text.php:1134
-msgid "July"
-msgstr ""
-
-#: include/event.php:474 include/text.php:1134
-msgid "August"
-msgstr ""
-
-#: include/event.php:475 include/text.php:1134
-msgid "September"
-msgstr ""
-
-#: include/event.php:476 include/text.php:1134
-msgid "October"
-msgstr ""
-
-#: include/event.php:477 include/text.php:1134
-msgid "November"
-msgstr ""
-
-#: include/event.php:478 include/text.php:1134
-msgid "December"
-msgstr ""
-
-#: include/event.php:479 mod/cal.php:283 mod/events.php:388
-msgid "today"
-msgstr ""
-
-#: include/event.php:483
-msgid "all-day"
-msgstr ""
-
-#: include/event.php:485
-msgid "No events to display"
-msgstr ""
-
-#: include/event.php:574
-msgid "l, F j"
-msgstr ""
-
-#: include/event.php:593
-msgid "Edit event"
-msgstr ""
-
-#: include/event.php:615 include/text.php:1532 include/text.php:1539
-msgid "link to source"
-msgstr ""
-
-#: include/event.php:850
-msgid "Export"
-msgstr ""
-
-#: include/event.php:851
-msgid "Export calendar as ical"
-msgstr ""
-
-#: include/event.php:852
-msgid "Export calendar as csv"
+#: include/message.php:15 include/message.php:169
+msgid "[no subject]"
 msgstr ""
 
 #: include/nav.php:35 mod/navigation.php:19
@@ -1295,62 +849,62 @@ msgstr ""
 msgid "Clear notifications"
 msgstr ""
 
-#: include/nav.php:40 include/text.php:1015
+#: include/nav.php:40 include/text.php:1017
 msgid "@name, !forum, #tags, content"
 msgstr ""
 
-#: include/nav.php:78 view/theme/frio/theme.php:246 boot.php:1792
+#: include/nav.php:78 view/theme/frio/theme.php:243 boot.php:1833
 msgid "Logout"
 msgstr ""
 
-#: include/nav.php:78 view/theme/frio/theme.php:246
+#: include/nav.php:78 view/theme/frio/theme.php:243
 msgid "End this session"
 msgstr ""
 
-#: include/nav.php:81 include/identity.php:714 mod/contacts.php:637
-#: mod/contacts.php:833 view/theme/frio/theme.php:249
+#: include/nav.php:81 include/identity.php:766 mod/contacts.php:645
+#: mod/contacts.php:841 view/theme/frio/theme.php:246
 msgid "Status"
 msgstr ""
 
-#: include/nav.php:81 include/nav.php:161 view/theme/frio/theme.php:249
+#: include/nav.php:81 include/nav.php:161 view/theme/frio/theme.php:246
 msgid "Your posts and conversations"
 msgstr ""
 
-#: include/nav.php:82 include/identity.php:605 include/identity.php:691
-#: include/identity.php:722 mod/profperm.php:104 mod/newmember.php:32
-#: mod/contacts.php:639 mod/contacts.php:841 view/theme/frio/theme.php:250
+#: include/nav.php:82 include/identity.php:617 include/identity.php:741
+#: include/identity.php:774 mod/newmember.php:32 mod/profperm.php:105
+#: mod/contacts.php:647 mod/contacts.php:849 view/theme/frio/theme.php:247
 msgid "Profile"
 msgstr ""
 
-#: include/nav.php:82 view/theme/frio/theme.php:250
+#: include/nav.php:82 view/theme/frio/theme.php:247
 msgid "Your profile page"
 msgstr ""
 
-#: include/nav.php:83 include/identity.php:730 mod/fbrowser.php:32
-#: view/theme/frio/theme.php:251
+#: include/nav.php:83 include/identity.php:782 mod/fbrowser.php:31
+#: view/theme/frio/theme.php:248
 msgid "Photos"
 msgstr ""
 
-#: include/nav.php:83 view/theme/frio/theme.php:251
+#: include/nav.php:83 view/theme/frio/theme.php:248
 msgid "Your photos"
 msgstr ""
 
-#: include/nav.php:84 include/identity.php:738 include/identity.php:741
-#: view/theme/frio/theme.php:252
+#: include/nav.php:84 include/identity.php:790 include/identity.php:793
+#: view/theme/frio/theme.php:249
 msgid "Videos"
 msgstr ""
 
-#: include/nav.php:84 view/theme/frio/theme.php:252
+#: include/nav.php:84 view/theme/frio/theme.php:249
 msgid "Your videos"
 msgstr ""
 
-#: include/nav.php:85 include/nav.php:149 include/identity.php:750
-#: include/identity.php:761 mod/cal.php:275 mod/events.php:379
-#: view/theme/frio/theme.php:253 view/theme/frio/theme.php:257
+#: include/nav.php:85 include/nav.php:149 include/identity.php:802
+#: include/identity.php:813 mod/cal.php:270 mod/events.php:386
+#: view/theme/frio/theme.php:250 view/theme/frio/theme.php:254
 msgid "Events"
 msgstr ""
 
-#: include/nav.php:85 view/theme/frio/theme.php:253
+#: include/nav.php:85 view/theme/frio/theme.php:250
 msgid "Your events"
 msgstr ""
 
@@ -1362,7 +916,7 @@ msgstr ""
 msgid "Your personal notes"
 msgstr ""
 
-#: include/nav.php:95 mod/bookmarklet.php:12 boot.php:1793
+#: include/nav.php:95 mod/bookmarklet.php:12 boot.php:1834
 msgid "Login"
 msgstr ""
 
@@ -1370,16 +924,11 @@ msgstr ""
 msgid "Sign in"
 msgstr ""
 
-#: include/nav.php:105 include/nav.php:161
-#: include/NotificationsManager.php:174
-msgid "Home"
-msgstr ""
-
 #: include/nav.php:105
 msgid "Home Page"
 msgstr ""
 
-#: include/nav.php:109 mod/register.php:289 boot.php:1768
+#: include/nav.php:109 mod/register.php:289 boot.php:1809
 msgid "Register"
 msgstr ""
 
@@ -1387,7 +936,7 @@ msgstr ""
 msgid "Create an account"
 msgstr ""
 
-#: include/nav.php:115 mod/help.php:47 view/theme/vier/theme.php:298
+#: include/nav.php:115 mod/help.php:47 view/theme/vier/theme.php:293
 msgid "Help"
 msgstr ""
 
@@ -1403,7 +952,7 @@ msgstr ""
 msgid "Addon applications, utilities, games"
 msgstr ""
 
-#: include/nav.php:123 include/text.php:1012 mod/search.php:149
+#: include/nav.php:123 include/text.php:1014 mod/search.php:149
 msgid "Search"
 msgstr ""
 
@@ -1411,17 +960,17 @@ msgstr ""
 msgid "Search site content"
 msgstr ""
 
-#: include/nav.php:126 include/text.php:1020
+#: include/nav.php:126 include/text.php:1022
 msgid "Full Text"
 msgstr ""
 
-#: include/nav.php:127 include/text.php:1021
+#: include/nav.php:127 include/text.php:1023
 msgid "Tags"
 msgstr ""
 
-#: include/nav.php:128 include/nav.php:192 include/identity.php:783
-#: include/identity.php:786 include/text.php:1022 mod/contacts.php:792
-#: mod/contacts.php:853 mod/viewcontacts.php:116 view/theme/frio/theme.php:260
+#: include/nav.php:128 include/nav.php:192 include/identity.php:835
+#: include/identity.php:838 include/text.php:1024 mod/contacts.php:800
+#: mod/contacts.php:861 mod/viewcontacts.php:121 view/theme/frio/theme.php:257
 msgid "Contacts"
 msgstr ""
 
@@ -1437,8 +986,8 @@ msgstr ""
 msgid "Conversations on the network"
 msgstr ""
 
-#: include/nav.php:149 include/identity.php:753 include/identity.php:764
-#: view/theme/frio/theme.php:257
+#: include/nav.php:149 include/identity.php:805 include/identity.php:816
+#: view/theme/frio/theme.php:254
 msgid "Events and Calendar"
 msgstr ""
 
@@ -1458,12 +1007,7 @@ msgstr ""
 msgid "Information about this friendica instance"
 msgstr ""
 
-#: include/nav.php:158 include/NotificationsManager.php:160 mod/admin.php:411
-#: view/theme/frio/theme.php:256
-msgid "Network"
-msgstr ""
-
-#: include/nav.php:158 view/theme/frio/theme.php:256
+#: include/nav.php:158 view/theme/frio/theme.php:253
 msgid "Conversations from your friends"
 msgstr ""
 
@@ -1473,10 +1017,6 @@ msgstr ""
 
 #: include/nav.php:159
 msgid "Load Network page with no filters"
-msgstr ""
-
-#: include/nav.php:166 include/NotificationsManager.php:181
-msgid "Introductions"
 msgstr ""
 
 #: include/nav.php:166
@@ -1491,7 +1031,7 @@ msgstr ""
 msgid "See all notifications"
 msgstr ""
 
-#: include/nav.php:171 mod/settings.php:902
+#: include/nav.php:171 mod/settings.php:906
 msgid "Mark as seen"
 msgstr ""
 
@@ -1499,11 +1039,11 @@ msgstr ""
 msgid "Mark all system notifications seen"
 msgstr ""
 
-#: include/nav.php:175 mod/message.php:190 view/theme/frio/theme.php:258
+#: include/nav.php:175 mod/message.php:179 view/theme/frio/theme.php:255
 msgid "Messages"
 msgstr ""
 
-#: include/nav.php:175 view/theme/frio/theme.php:258
+#: include/nav.php:175 view/theme/frio/theme.php:255
 msgid "Private mail"
 msgstr ""
 
@@ -1536,15 +1076,15 @@ msgid "Delegate Page Management"
 msgstr ""
 
 #: include/nav.php:186 mod/newmember.php:22 mod/settings.php:111
-#: mod/admin.php:1524 mod/admin.php:1782 view/theme/frio/theme.php:259
+#: mod/admin.php:1545 mod/admin.php:1815 view/theme/frio/theme.php:256
 msgid "Settings"
 msgstr ""
 
-#: include/nav.php:186 view/theme/frio/theme.php:259
+#: include/nav.php:186 view/theme/frio/theme.php:256
 msgid "Account settings"
 msgstr ""
 
-#: include/nav.php:189 include/identity.php:282
+#: include/nav.php:189 include/identity.php:285
 msgid "Profiles"
 msgstr ""
 
@@ -1552,11 +1092,11 @@ msgstr ""
 msgid "Manage/Edit Profiles"
 msgstr ""
 
-#: include/nav.php:192 view/theme/frio/theme.php:260
+#: include/nav.php:192 view/theme/frio/theme.php:257
 msgid "Manage/edit friends and contacts"
 msgstr ""
 
-#: include/nav.php:197 mod/admin.php:186
+#: include/nav.php:197 mod/admin.php:187
 msgid "Admin"
 msgstr ""
 
@@ -1572,10 +1112,42 @@ msgstr ""
 msgid "Site map"
 msgstr ""
 
-#: include/photos.php:53 mod/fbrowser.php:41 mod/fbrowser.php:62
-#: mod/photos.php:180 mod/photos.php:1086 mod/photos.php:1211
-#: mod/photos.php:1232 mod/photos.php:1795 mod/photos.php:1807
-msgid "Contact Photos"
+#: include/oembed.php:266
+msgid "Embedded content"
+msgstr ""
+
+#: include/oembed.php:274
+msgid "Embedding disabled"
+msgstr ""
+
+#: include/ostatus.php:1832
+#, php-format
+msgid "%s is now following %s."
+msgstr ""
+
+#: include/ostatus.php:1833
+msgid "following"
+msgstr ""
+
+#: include/ostatus.php:1836
+#, php-format
+msgid "%s stopped following %s."
+msgstr ""
+
+#: include/ostatus.php:1837
+msgid "stopped following"
+msgstr ""
+
+#: include/plugin.php:530 include/plugin.php:532
+msgid "Click here to upgrade."
+msgstr ""
+
+#: include/plugin.php:538
+msgid "This action exceeds the limits set by your subscription plan."
+msgstr ""
+
+#: include/plugin.php:543
+msgid "This action is not available under your subscription plan."
 msgstr ""
 
 #: include/security.php:22
@@ -1590,1361 +1162,49 @@ msgstr ""
 msgid "Welcome back "
 msgstr ""
 
-#: include/security.php:373
+#: include/security.php:375
 msgid ""
 "The form security token was not correct. This probably happened because the "
 "form has been opened for too long (>3 hours) before submitting it."
 msgstr ""
 
-#: include/NotificationsManager.php:153
-msgid "System"
+#: include/uimport.php:94
+msgid "Error decoding account file"
 msgstr ""
 
-#: include/NotificationsManager.php:167 mod/profiles.php:703
-#: mod/network.php:845
-msgid "Personal"
+#: include/uimport.php:100
+msgid "Error! No version data in file! This is not a Friendica account file?"
 msgstr ""
 
-#: include/NotificationsManager.php:234 include/NotificationsManager.php:244
+#: include/uimport.php:116 include/uimport.php:127
+msgid "Error! Cannot check nickname"
+msgstr ""
+
+#: include/uimport.php:120 include/uimport.php:131
 #, php-format
-msgid "%s commented on %s's post"
+msgid "User '%s' already exists on this server!"
 msgstr ""
 
-#: include/NotificationsManager.php:243
+#: include/uimport.php:153
+msgid "User creation error"
+msgstr ""
+
+#: include/uimport.php:173
+msgid "User profile creation error"
+msgstr ""
+
+#: include/uimport.php:222
 #, php-format
-msgid "%s created a new post"
-msgstr ""
-
-#: include/NotificationsManager.php:256
-#, php-format
-msgid "%s liked %s's post"
-msgstr ""
-
-#: include/NotificationsManager.php:267
-#, php-format
-msgid "%s disliked %s's post"
-msgstr ""
-
-#: include/NotificationsManager.php:278
-#, php-format
-msgid "%s is attending %s's event"
-msgstr ""
-
-#: include/NotificationsManager.php:289
-#, php-format
-msgid "%s is not attending %s's event"
-msgstr ""
-
-#: include/NotificationsManager.php:300
-#, php-format
-msgid "%s may attend %s's event"
-msgstr ""
-
-#: include/NotificationsManager.php:315
-#, php-format
-msgid "%s is now friends with %s"
-msgstr ""
-
-#: include/NotificationsManager.php:748
-msgid "Friend Suggestion"
-msgstr ""
-
-#: include/NotificationsManager.php:781
-msgid "Friend/Connect Request"
-msgstr ""
-
-#: include/NotificationsManager.php:781
-msgid "New Follower"
-msgstr ""
-
-#: include/dbstructure.php:26
-#, php-format
-msgid ""
-"\n"
-"\t\t\tThe friendica developers released update %s recently,\n"
-"\t\t\tbut when I tried to install it, something went terribly wrong.\n"
-"\t\t\tThis needs to be fixed soon and I can't do it alone. Please contact a\n"
-"\t\t\tfriendica developer if you can not help me on your own. My database "
-"might be invalid."
-msgstr ""
-
-#: include/dbstructure.php:31
-#, php-format
-msgid ""
-"The error message is\n"
-"[pre]%s[/pre]"
-msgstr ""
-
-#: include/dbstructure.php:183
-msgid "Errors encountered creating database tables."
-msgstr ""
-
-#: include/dbstructure.php:260
-msgid "Errors encountered performing database changes."
-msgstr ""
-
-#: include/delivery.php:446
-msgid "(no subject)"
-msgstr ""
-
-#: include/diaspora.php:1958
-msgid "Sharing notification from Diaspora network"
-msgstr ""
-
-#: include/diaspora.php:2864
-msgid "Attachments:"
-msgstr ""
-
-#: include/network.php:595
-msgid "view full size"
-msgstr ""
-
-#: include/Contact.php:340 include/Contact.php:353 include/Contact.php:398
-#: include/conversation.php:968 include/conversation.php:984
-#: mod/allfriends.php:65 mod/directory.php:155 mod/dirfind.php:203
-#: mod/match.php:71 mod/suggest.php:82
-msgid "View Profile"
-msgstr ""
-
-#: include/Contact.php:397 include/conversation.php:967
-msgid "View Status"
-msgstr ""
-
-#: include/Contact.php:399 include/conversation.php:969
-msgid "View Photos"
-msgstr ""
-
-#: include/Contact.php:400 include/conversation.php:970
-msgid "Network Posts"
-msgstr ""
-
-#: include/Contact.php:401 include/conversation.php:971
-msgid "View Contact"
-msgstr ""
-
-#: include/Contact.php:402
-msgid "Drop Contact"
-msgstr ""
-
-#: include/Contact.php:403 include/conversation.php:972
-msgid "Send PM"
-msgstr ""
-
-#: include/Contact.php:404 include/conversation.php:976
-msgid "Poke"
-msgstr ""
-
-#: include/Contact.php:775
-msgid "Organisation"
-msgstr ""
-
-#: include/Contact.php:778
-msgid "News"
-msgstr ""
-
-#: include/Contact.php:781
-msgid "Forum"
-msgstr ""
-
-#: include/api.php:1018
-#, php-format
-msgid "Daily posting limit of %d posts reached. The post was rejected."
-msgstr ""
-
-#: include/api.php:1038
-#, php-format
-msgid "Weekly posting limit of %d posts reached. The post was rejected."
-msgstr ""
-
-#: include/api.php:1059
-#, php-format
-msgid "Monthly posting limit of %d posts reached. The post was rejected."
-msgstr ""
-
-#: include/bbcode.php:350 include/bbcode.php:1057 include/bbcode.php:1058
-msgid "Image/photo"
-msgstr ""
-
-#: include/bbcode.php:467
-#, php-format
-msgid "<a href=\"%1$s\" target=\"_blank\">%2$s</a> %3$s"
-msgstr ""
-
-#: include/bbcode.php:1017 include/bbcode.php:1037
-msgid "$1 wrote:"
-msgstr ""
-
-#: include/bbcode.php:1066 include/bbcode.php:1067
-msgid "Encrypted content"
-msgstr ""
-
-#: include/bbcode.php:1169
-msgid "Invalid source protocol"
-msgstr ""
-
-#: include/bbcode.php:1179
-msgid "Invalid link protocol"
-msgstr ""
-
-#: include/conversation.php:147
-#, php-format
-msgid "%1$s attends %2$s's %3$s"
-msgstr ""
-
-#: include/conversation.php:150
-#, php-format
-msgid "%1$s doesn't attend %2$s's %3$s"
-msgstr ""
-
-#: include/conversation.php:153
-#, php-format
-msgid "%1$s attends maybe %2$s's %3$s"
-msgstr ""
-
-#: include/conversation.php:185 mod/dfrn_confirm.php:477
-#, php-format
-msgid "%1$s is now friends with %2$s"
-msgstr ""
-
-#: include/conversation.php:219
-#, php-format
-msgid "%1$s poked %2$s"
-msgstr ""
-
-#: include/conversation.php:239 mod/mood.php:62
-#, php-format
-msgid "%1$s is currently %2$s"
-msgstr ""
-
-#: include/conversation.php:278 mod/tagger.php:95
-#, php-format
-msgid "%1$s tagged %2$s's %3$s with %4$s"
-msgstr ""
-
-#: include/conversation.php:303
-msgid "post/item"
-msgstr ""
-
-#: include/conversation.php:304
-#, php-format
-msgid "%1$s marked %2$s's %3$s as favorite"
-msgstr ""
-
-#: include/conversation.php:585 mod/content.php:372 mod/profiles.php:346
-#: mod/photos.php:1607
-msgid "Likes"
-msgstr ""
-
-#: include/conversation.php:585 mod/content.php:372 mod/profiles.php:350
-#: mod/photos.php:1607
-msgid "Dislikes"
-msgstr ""
-
-#: include/conversation.php:586 include/conversation.php:1481
-#: mod/content.php:373 mod/photos.php:1608
-msgid "Attending"
-msgid_plural "Attending"
+msgid "%d contact not imported"
+msgid_plural "%d contacts not imported"
 msgstr[0] ""
 msgstr[1] ""
 
-#: include/conversation.php:586 mod/content.php:373 mod/photos.php:1608
-msgid "Not attending"
+#: include/uimport.php:292
+msgid "Done. You can now login with your username and password"
 msgstr ""
 
-#: include/conversation.php:586 mod/content.php:373 mod/photos.php:1608
-msgid "Might attend"
-msgstr ""
-
-#: include/conversation.php:708 mod/content.php:453 mod/content.php:758
-#: mod/photos.php:1681 object/Item.php:133
-msgid "Select"
-msgstr ""
-
-#: include/conversation.php:709 mod/group.php:171 mod/content.php:454
-#: mod/content.php:759 mod/photos.php:1682 mod/settings.php:741
-#: mod/admin.php:1414 mod/contacts.php:808 mod/contacts.php:1007
-#: object/Item.php:134
-msgid "Delete"
-msgstr ""
-
-#: include/conversation.php:753 mod/content.php:487 mod/content.php:910
-#: mod/content.php:911 object/Item.php:367 object/Item.php:368
-#, php-format
-msgid "View %s's profile @ %s"
-msgstr ""
-
-#: include/conversation.php:765 object/Item.php:355
-msgid "Categories:"
-msgstr ""
-
-#: include/conversation.php:766 object/Item.php:356
-msgid "Filed under:"
-msgstr ""
-
-#: include/conversation.php:773 mod/content.php:497 mod/content.php:923
-#: object/Item.php:381
-#, php-format
-msgid "%s from %s"
-msgstr ""
-
-#: include/conversation.php:789 mod/content.php:513
-msgid "View in context"
-msgstr ""
-
-#: include/conversation.php:791 include/conversation.php:1264
-#: mod/editpost.php:124 mod/wallmessage.php:156 mod/message.php:356
-#: mod/message.php:548 mod/content.php:515 mod/content.php:948
-#: mod/photos.php:1570 object/Item.php:406
-msgid "Please wait"
-msgstr ""
-
-#: include/conversation.php:870
-msgid "remove"
-msgstr ""
-
-#: include/conversation.php:874
-msgid "Delete Selected Items"
-msgstr ""
-
-#: include/conversation.php:966
-msgid "Follow Thread"
-msgstr ""
-
-#: include/conversation.php:1097
-#, php-format
-msgid "%s likes this."
-msgstr ""
-
-#: include/conversation.php:1100
-#, php-format
-msgid "%s doesn't like this."
-msgstr ""
-
-#: include/conversation.php:1103
-#, php-format
-msgid "%s attends."
-msgstr ""
-
-#: include/conversation.php:1106
-#, php-format
-msgid "%s doesn't attend."
-msgstr ""
-
-#: include/conversation.php:1109
-#, php-format
-msgid "%s attends maybe."
-msgstr ""
-
-#: include/conversation.php:1119
-msgid "and"
-msgstr ""
-
-#: include/conversation.php:1125
-#, php-format
-msgid ", and %d other people"
-msgstr ""
-
-#: include/conversation.php:1134
-#, php-format
-msgid "<span  %1$s>%2$d people</span> like this"
-msgstr ""
-
-#: include/conversation.php:1135
-#, php-format
-msgid "%s like this."
-msgstr ""
-
-#: include/conversation.php:1138
-#, php-format
-msgid "<span  %1$s>%2$d people</span> don't like this"
-msgstr ""
-
-#: include/conversation.php:1139
-#, php-format
-msgid "%s don't like this."
-msgstr ""
-
-#: include/conversation.php:1142
-#, php-format
-msgid "<span  %1$s>%2$d people</span> attend"
-msgstr ""
-
-#: include/conversation.php:1143
-#, php-format
-msgid "%s attend."
-msgstr ""
-
-#: include/conversation.php:1146
-#, php-format
-msgid "<span  %1$s>%2$d people</span> don't attend"
-msgstr ""
-
-#: include/conversation.php:1147
-#, php-format
-msgid "%s don't attend."
-msgstr ""
-
-#: include/conversation.php:1150
-#, php-format
-msgid "<span  %1$s>%2$d people</span> attend maybe"
-msgstr ""
-
-#: include/conversation.php:1151
-#, php-format
-msgid "%s anttend maybe."
-msgstr ""
-
-#: include/conversation.php:1190 include/conversation.php:1208
-msgid "Visible to <strong>everybody</strong>"
-msgstr ""
-
-#: include/conversation.php:1191 include/conversation.php:1209
-#: mod/wallmessage.php:127 mod/wallmessage.php:135 mod/message.php:291
-#: mod/message.php:299 mod/message.php:442 mod/message.php:450
-msgid "Please enter a link URL:"
-msgstr ""
-
-#: include/conversation.php:1192 include/conversation.php:1210
-msgid "Please enter a video link/URL:"
-msgstr ""
-
-#: include/conversation.php:1193 include/conversation.php:1211
-msgid "Please enter an audio link/URL:"
-msgstr ""
-
-#: include/conversation.php:1194 include/conversation.php:1212
-msgid "Tag term:"
-msgstr ""
-
-#: include/conversation.php:1195 include/conversation.php:1213
-#: mod/filer.php:30
-msgid "Save to Folder:"
-msgstr ""
-
-#: include/conversation.php:1196 include/conversation.php:1214
-msgid "Where are you right now?"
-msgstr ""
-
-#: include/conversation.php:1197
-msgid "Delete item(s)?"
-msgstr ""
-
-#: include/conversation.php:1245 mod/photos.php:1569
-msgid "Share"
-msgstr ""
-
-#: include/conversation.php:1246 mod/editpost.php:110 mod/wallmessage.php:154
-#: mod/message.php:354 mod/message.php:545
-msgid "Upload photo"
-msgstr ""
-
-#: include/conversation.php:1247 mod/editpost.php:111
-msgid "upload photo"
-msgstr ""
-
-#: include/conversation.php:1248 mod/editpost.php:112
-msgid "Attach file"
-msgstr ""
-
-#: include/conversation.php:1249 mod/editpost.php:113
-msgid "attach file"
-msgstr ""
-
-#: include/conversation.php:1250 mod/editpost.php:114 mod/wallmessage.php:155
-#: mod/message.php:355 mod/message.php:546
-msgid "Insert web link"
-msgstr ""
-
-#: include/conversation.php:1251 mod/editpost.php:115
-msgid "web link"
-msgstr ""
-
-#: include/conversation.php:1252 mod/editpost.php:116
-msgid "Insert video link"
-msgstr ""
-
-#: include/conversation.php:1253 mod/editpost.php:117
-msgid "video link"
-msgstr ""
-
-#: include/conversation.php:1254 mod/editpost.php:118
-msgid "Insert audio link"
-msgstr ""
-
-#: include/conversation.php:1255 mod/editpost.php:119
-msgid "audio link"
-msgstr ""
-
-#: include/conversation.php:1256 mod/editpost.php:120
-msgid "Set your location"
-msgstr ""
-
-#: include/conversation.php:1257 mod/editpost.php:121
-msgid "set location"
-msgstr ""
-
-#: include/conversation.php:1258 mod/editpost.php:122
-msgid "Clear browser location"
-msgstr ""
-
-#: include/conversation.php:1259 mod/editpost.php:123
-msgid "clear location"
-msgstr ""
-
-#: include/conversation.php:1261 mod/editpost.php:137
-msgid "Set title"
-msgstr ""
-
-#: include/conversation.php:1263 mod/editpost.php:139
-msgid "Categories (comma-separated list)"
-msgstr ""
-
-#: include/conversation.php:1265 mod/editpost.php:125
-msgid "Permission settings"
-msgstr ""
-
-#: include/conversation.php:1266 mod/editpost.php:154
-msgid "permissions"
-msgstr ""
-
-#: include/conversation.php:1274 mod/editpost.php:134
-msgid "Public post"
-msgstr ""
-
-#: include/conversation.php:1279 mod/editpost.php:145 mod/content.php:737
-#: mod/events.php:504 mod/photos.php:1591 mod/photos.php:1639
-#: mod/photos.php:1725 object/Item.php:729
-msgid "Preview"
-msgstr ""
-
-#: include/conversation.php:1283 include/items.php:1974 mod/fbrowser.php:101
-#: mod/fbrowser.php:136 mod/tagrm.php:11 mod/tagrm.php:94 mod/editpost.php:148
-#: mod/message.php:220 mod/suggest.php:32 mod/photos.php:235
-#: mod/photos.php:322 mod/settings.php:679 mod/settings.php:705
-#: mod/videos.php:128 mod/contacts.php:445 mod/dfrn_request.php:876
-#: mod/follow.php:121
-msgid "Cancel"
-msgstr ""
-
-#: include/conversation.php:1289
-msgid "Post to Groups"
-msgstr ""
-
-#: include/conversation.php:1290
-msgid "Post to Contacts"
-msgstr ""
-
-#: include/conversation.php:1291
-msgid "Private post"
-msgstr ""
-
-#: include/conversation.php:1296 include/identity.php:256 mod/editpost.php:152
-msgid "Message"
-msgstr ""
-
-#: include/conversation.php:1297 mod/editpost.php:153
-msgid "Browser"
-msgstr ""
-
-#: include/conversation.php:1453
-msgid "View all"
-msgstr ""
-
-#: include/conversation.php:1475
-msgid "Like"
-msgid_plural "Likes"
-msgstr[0] ""
-msgstr[1] ""
-
-#: include/conversation.php:1478
-msgid "Dislike"
-msgid_plural "Dislikes"
-msgstr[0] ""
-msgstr[1] ""
-
-#: include/conversation.php:1484
-msgid "Not Attending"
-msgid_plural "Not Attending"
-msgstr[0] ""
-msgstr[1] ""
-
-#: include/dfrn.php:1108
-#, php-format
-msgid "%s\\'s birthday"
-msgstr ""
-
-#: include/features.php:70
-msgid "General Features"
-msgstr ""
-
-#: include/features.php:72
-msgid "Multiple Profiles"
-msgstr ""
-
-#: include/features.php:72
-msgid "Ability to create multiple profiles"
-msgstr ""
-
-#: include/features.php:73
-msgid "Photo Location"
-msgstr ""
-
-#: include/features.php:73
-msgid ""
-"Photo metadata is normally stripped. This extracts the location (if present) "
-"prior to stripping metadata and links it to a map."
-msgstr ""
-
-#: include/features.php:74
-msgid "Export Public Calendar"
-msgstr ""
-
-#: include/features.php:74
-msgid "Ability for visitors to download the public calendar"
-msgstr ""
-
-#: include/features.php:79
-msgid "Post Composition Features"
-msgstr ""
-
-#: include/features.php:80
-msgid "Richtext Editor"
-msgstr ""
-
-#: include/features.php:80
-msgid "Enable richtext editor"
-msgstr ""
-
-#: include/features.php:81
-msgid "Post Preview"
-msgstr ""
-
-#: include/features.php:81
-msgid "Allow previewing posts and comments before publishing them"
-msgstr ""
-
-#: include/features.php:82
-msgid "Auto-mention Forums"
-msgstr ""
-
-#: include/features.php:82
-msgid ""
-"Add/remove mention when a forum page is selected/deselected in ACL window."
-msgstr ""
-
-#: include/features.php:87
-msgid "Network Sidebar Widgets"
-msgstr ""
-
-#: include/features.php:88
-msgid "Search by Date"
-msgstr ""
-
-#: include/features.php:88
-msgid "Ability to select posts by date ranges"
-msgstr ""
-
-#: include/features.php:89 include/features.php:119
-msgid "List Forums"
-msgstr ""
-
-#: include/features.php:89
-msgid "Enable widget to display the forums your are connected with"
-msgstr ""
-
-#: include/features.php:90
-msgid "Group Filter"
-msgstr ""
-
-#: include/features.php:90
-msgid "Enable widget to display Network posts only from selected group"
-msgstr ""
-
-#: include/features.php:91
-msgid "Network Filter"
-msgstr ""
-
-#: include/features.php:91
-msgid "Enable widget to display Network posts only from selected network"
-msgstr ""
-
-#: include/features.php:92 mod/search.php:34 mod/network.php:200
-msgid "Saved Searches"
-msgstr ""
-
-#: include/features.php:92
-msgid "Save search terms for re-use"
-msgstr ""
-
-#: include/features.php:97
-msgid "Network Tabs"
-msgstr ""
-
-#: include/features.php:98
-msgid "Network Personal Tab"
-msgstr ""
-
-#: include/features.php:98
-msgid "Enable tab to display only Network posts that you've interacted on"
-msgstr ""
-
-#: include/features.php:99
-msgid "Network New Tab"
-msgstr ""
-
-#: include/features.php:99
-msgid "Enable tab to display only new Network posts (from the last 12 hours)"
-msgstr ""
-
-#: include/features.php:100
-msgid "Network Shared Links Tab"
-msgstr ""
-
-#: include/features.php:100
-msgid "Enable tab to display only Network posts with links in them"
-msgstr ""
-
-#: include/features.php:105
-msgid "Post/Comment Tools"
-msgstr ""
-
-#: include/features.php:106
-msgid "Multiple Deletion"
-msgstr ""
-
-#: include/features.php:106
-msgid "Select and delete multiple posts/comments at once"
-msgstr ""
-
-#: include/features.php:107
-msgid "Edit Sent Posts"
-msgstr ""
-
-#: include/features.php:107
-msgid "Edit and correct posts and comments after sending"
-msgstr ""
-
-#: include/features.php:108
-msgid "Tagging"
-msgstr ""
-
-#: include/features.php:108
-msgid "Ability to tag existing posts"
-msgstr ""
-
-#: include/features.php:109
-msgid "Post Categories"
-msgstr ""
-
-#: include/features.php:109
-msgid "Add categories to your posts"
-msgstr ""
-
-#: include/features.php:110
-msgid "Ability to file posts under folders"
-msgstr ""
-
-#: include/features.php:111
-msgid "Dislike Posts"
-msgstr ""
-
-#: include/features.php:111
-msgid "Ability to dislike posts/comments"
-msgstr ""
-
-#: include/features.php:112
-msgid "Star Posts"
-msgstr ""
-
-#: include/features.php:112
-msgid "Ability to mark special posts with a star indicator"
-msgstr ""
-
-#: include/features.php:113
-msgid "Mute Post Notifications"
-msgstr ""
-
-#: include/features.php:113
-msgid "Ability to mute notifications for a thread"
-msgstr ""
-
-#: include/features.php:118
-msgid "Advanced Profile Settings"
-msgstr ""
-
-#: include/features.php:119
-msgid "Show visitors public community forums at the Advanced Profile Page"
-msgstr ""
-
-#: include/follow.php:81 mod/dfrn_request.php:509
-msgid "Disallowed profile URL."
-msgstr ""
-
-#: include/follow.php:86
-msgid "Connect URL missing."
-msgstr ""
-
-#: include/follow.php:113
-msgid ""
-"This site is not configured to allow communications with other networks."
-msgstr ""
-
-#: include/follow.php:114 include/follow.php:134
-msgid "No compatible communication protocols or feeds were discovered."
-msgstr ""
-
-#: include/follow.php:132
-msgid "The profile address specified does not provide adequate information."
-msgstr ""
-
-#: include/follow.php:136
-msgid "An author or name was not found."
-msgstr ""
-
-#: include/follow.php:138
-msgid "No browser URL could be matched to this address."
-msgstr ""
-
-#: include/follow.php:140
-msgid ""
-"Unable to match @-style Identity Address with a known protocol or email "
-"contact."
-msgstr ""
-
-#: include/follow.php:141
-msgid "Use mailto: in front of address to force email check."
-msgstr ""
-
-#: include/follow.php:147
-msgid ""
-"The profile address specified belongs to a network which has been disabled "
-"on this site."
-msgstr ""
-
-#: include/follow.php:157
-msgid ""
-"Limited profile. This person will be unable to receive direct/personal "
-"notifications from you."
-msgstr ""
-
-#: include/follow.php:258
-msgid "Unable to retrieve contact information."
-msgstr ""
-
-#: include/identity.php:42
-msgid "Requested account is not available."
-msgstr ""
-
-#: include/identity.php:51 mod/profile.php:21
-msgid "Requested profile is not available."
-msgstr ""
-
-#: include/identity.php:95 include/identity.php:311 include/identity.php:688
-msgid "Edit profile"
-msgstr ""
-
-#: include/identity.php:251
-msgid "Atom feed"
-msgstr ""
-
-#: include/identity.php:282
-msgid "Manage/edit profiles"
-msgstr ""
-
-#: include/identity.php:287 include/identity.php:313 mod/profiles.php:795
-msgid "Change profile photo"
-msgstr ""
-
-#: include/identity.php:288 mod/profiles.php:796
-msgid "Create New Profile"
-msgstr ""
-
-#: include/identity.php:298 mod/profiles.php:785
-msgid "Profile Image"
-msgstr ""
-
-#: include/identity.php:301 mod/profiles.php:787
-msgid "visible to everybody"
-msgstr ""
-
-#: include/identity.php:302 mod/profiles.php:691 mod/profiles.php:788
-msgid "Edit visibility"
-msgstr ""
-
-#: include/identity.php:330 include/identity.php:616 mod/notifications.php:238
-#: mod/directory.php:139
-msgid "Gender:"
-msgstr ""
-
-#: include/identity.php:333 include/identity.php:636 mod/directory.php:141
-msgid "Status:"
-msgstr ""
-
-#: include/identity.php:335 include/identity.php:647 mod/directory.php:143
-msgid "Homepage:"
-msgstr ""
-
-#: include/identity.php:337 include/identity.php:657 mod/notifications.php:234
-#: mod/directory.php:145 mod/contacts.php:632
-msgid "About:"
-msgstr ""
-
-#: include/identity.php:339 mod/contacts.php:630
-msgid "XMPP:"
-msgstr ""
-
-#: include/identity.php:422 mod/notifications.php:246 mod/contacts.php:50
-msgid "Network:"
-msgstr ""
-
-#: include/identity.php:451 include/identity.php:535
-msgid "g A l F d"
-msgstr ""
-
-#: include/identity.php:452 include/identity.php:536
-msgid "F d"
-msgstr ""
-
-#: include/identity.php:497 include/identity.php:582
-msgid "[today]"
-msgstr ""
-
-#: include/identity.php:509
-msgid "Birthday Reminders"
-msgstr ""
-
-#: include/identity.php:510
-msgid "Birthdays this week:"
-msgstr ""
-
-#: include/identity.php:569
-msgid "[No description]"
-msgstr ""
-
-#: include/identity.php:593
-msgid "Event Reminders"
-msgstr ""
-
-#: include/identity.php:594
-msgid "Events this week:"
-msgstr ""
-
-#: include/identity.php:614 mod/settings.php:1279
-msgid "Full Name:"
-msgstr ""
-
-#: include/identity.php:621
-msgid "j F, Y"
-msgstr ""
-
-#: include/identity.php:622
-msgid "j F"
-msgstr ""
-
-#: include/identity.php:633
-msgid "Age:"
-msgstr ""
-
-#: include/identity.php:642
-#, php-format
-msgid "for %1$d %2$s"
-msgstr ""
-
-#: include/identity.php:645 mod/profiles.php:710
-msgid "Sexual Preference:"
-msgstr ""
-
-#: include/identity.php:649 mod/profiles.php:737
-msgid "Hometown:"
-msgstr ""
-
-#: include/identity.php:651 mod/notifications.php:236 mod/contacts.php:634
-#: mod/follow.php:134
-msgid "Tags:"
-msgstr ""
-
-#: include/identity.php:653 mod/profiles.php:738
-msgid "Political Views:"
-msgstr ""
-
-#: include/identity.php:655
-msgid "Religion:"
-msgstr ""
-
-#: include/identity.php:659
-msgid "Hobbies/Interests:"
-msgstr ""
-
-#: include/identity.php:661 mod/profiles.php:742
-msgid "Likes:"
-msgstr ""
-
-#: include/identity.php:663 mod/profiles.php:743
-msgid "Dislikes:"
-msgstr ""
-
-#: include/identity.php:666
-msgid "Contact information and Social Networks:"
-msgstr ""
-
-#: include/identity.php:668
-msgid "Musical interests:"
-msgstr ""
-
-#: include/identity.php:670
-msgid "Books, literature:"
-msgstr ""
-
-#: include/identity.php:672
-msgid "Television:"
-msgstr ""
-
-#: include/identity.php:674
-msgid "Film/dance/culture/entertainment:"
-msgstr ""
-
-#: include/identity.php:676
-msgid "Love/Romance:"
-msgstr ""
-
-#: include/identity.php:678
-msgid "Work/employment:"
-msgstr ""
-
-#: include/identity.php:680
-msgid "School/education:"
-msgstr ""
-
-#: include/identity.php:684
-msgid "Forums:"
-msgstr ""
-
-#: include/identity.php:692 mod/events.php:507
-msgid "Basic"
-msgstr ""
-
-#: include/identity.php:693 mod/events.php:508 mod/admin.php:959
-#: mod/contacts.php:870
-msgid "Advanced"
-msgstr ""
-
-#: include/identity.php:717 mod/contacts.php:836 mod/follow.php:142
-msgid "Status Messages and Posts"
-msgstr ""
-
-#: include/identity.php:725 mod/contacts.php:844
-msgid "Profile Details"
-msgstr ""
-
-#: include/identity.php:733 mod/photos.php:87
-msgid "Photo Albums"
-msgstr ""
-
-#: include/identity.php:772 mod/notes.php:46
-msgid "Personal Notes"
-msgstr ""
-
-#: include/identity.php:775
-msgid "Only You Can See This"
-msgstr ""
-
-#: include/items.php:1575 mod/dfrn_confirm.php:730 mod/dfrn_request.php:746
-msgid "[Name Withheld]"
-msgstr ""
-
-#: include/items.php:1930 mod/viewsrc.php:15 mod/notice.php:15
-#: mod/display.php:103 mod/display.php:279 mod/display.php:478
-#: mod/admin.php:234 mod/admin.php:1471 mod/admin.php:1705
-msgid "Item not found."
-msgstr ""
-
-#: include/items.php:1969
-msgid "Do you really want to delete this item?"
-msgstr ""
-
-#: include/items.php:1971 mod/api.php:105 mod/message.php:217
-#: mod/profiles.php:648 mod/profiles.php:651 mod/profiles.php:677
-#: mod/suggest.php:29 mod/register.php:245 mod/settings.php:1163
-#: mod/settings.php:1169 mod/settings.php:1177 mod/settings.php:1181
-#: mod/settings.php:1186 mod/settings.php:1192 mod/settings.php:1198
-#: mod/settings.php:1204 mod/settings.php:1230 mod/settings.php:1231
-#: mod/settings.php:1232 mod/settings.php:1233 mod/settings.php:1234
-#: mod/contacts.php:442 mod/dfrn_request.php:862 mod/follow.php:110
-msgid "Yes"
-msgstr ""
-
-#: include/items.php:2134 mod/notes.php:22 mod/uimport.php:23
-#: mod/nogroup.php:25 mod/invite.php:15 mod/invite.php:101
-#: mod/repair_ostatus.php:9 mod/delegate.php:12 mod/attach.php:33
-#: mod/editpost.php:10 mod/group.php:19 mod/wallmessage.php:9
-#: mod/wallmessage.php:33 mod/wallmessage.php:79 mod/wallmessage.php:103
-#: mod/api.php:26 mod/api.php:31 mod/ostatus_subscribe.php:9
-#: mod/message.php:46 mod/message.php:182 mod/manage.php:96
-#: mod/crepair.php:100 mod/fsuggest.php:78 mod/mood.php:114 mod/poke.php:150
-#: mod/profile_photo.php:19 mod/profile_photo.php:175
-#: mod/profile_photo.php:186 mod/profile_photo.php:199 mod/regmod.php:110
-#: mod/notifications.php:71 mod/profiles.php:166 mod/profiles.php:605
-#: mod/allfriends.php:12 mod/cal.php:304 mod/common.php:18 mod/dirfind.php:11
-#: mod/display.php:475 mod/events.php:190 mod/suggest.php:58
-#: mod/photos.php:159 mod/photos.php:1072 mod/register.php:42
-#: mod/settings.php:22 mod/settings.php:128 mod/settings.php:665
-#: mod/wall_attach.php:67 mod/wall_attach.php:70 mod/wall_upload.php:77
-#: mod/wall_upload.php:80 mod/contacts.php:350 mod/dfrn_confirm.php:61
-#: mod/follow.php:11 mod/follow.php:73 mod/follow.php:155 mod/item.php:199
-#: mod/item.php:211 mod/network.php:4 mod/viewcontacts.php:45 index.php:401
-msgid "Permission denied."
-msgstr ""
-
-#: include/items.php:2239
-msgid "Archives"
-msgstr ""
-
-#: include/oembed.php:264
-msgid "Embedded content"
-msgstr ""
-
-#: include/oembed.php:272
-msgid "Embedding disabled"
-msgstr ""
-
-#: include/ostatus.php:1825
-#, php-format
-msgid "%s is now following %s."
-msgstr ""
-
-#: include/ostatus.php:1826
-msgid "following"
-msgstr ""
-
-#: include/ostatus.php:1829
-#, php-format
-msgid "%s stopped following %s."
-msgstr ""
-
-#: include/ostatus.php:1830
-msgid "stopped following"
-msgstr ""
-
-#: include/text.php:304
-msgid "newer"
-msgstr ""
-
-#: include/text.php:306
-msgid "older"
-msgstr ""
-
-#: include/text.php:311
-msgid "prev"
-msgstr ""
-
-#: include/text.php:313
-msgid "first"
-msgstr ""
-
-#: include/text.php:345
-msgid "last"
-msgstr ""
-
-#: include/text.php:348
-msgid "next"
-msgstr ""
-
-#: include/text.php:403
-msgid "Loading more entries..."
-msgstr ""
-
-#: include/text.php:404
-msgid "The end"
-msgstr ""
-
-#: include/text.php:889
-msgid "No contacts"
-msgstr ""
-
-#: include/text.php:912
-#, php-format
-msgid "%d Contact"
-msgid_plural "%d Contacts"
-msgstr[0] ""
-msgstr[1] ""
-
-#: include/text.php:925
-msgid "View Contacts"
-msgstr ""
-
-#: include/text.php:1013 mod/notes.php:61 mod/filer.php:31
-#: mod/editpost.php:109
-msgid "Save"
-msgstr ""
-
-#: include/text.php:1076
-msgid "poke"
-msgstr ""
-
-#: include/text.php:1076
-msgid "poked"
-msgstr ""
-
-#: include/text.php:1077
-msgid "ping"
-msgstr ""
-
-#: include/text.php:1077
-msgid "pinged"
-msgstr ""
-
-#: include/text.php:1078
-msgid "prod"
-msgstr ""
-
-#: include/text.php:1078
-msgid "prodded"
-msgstr ""
-
-#: include/text.php:1079
-msgid "slap"
-msgstr ""
-
-#: include/text.php:1079
-msgid "slapped"
-msgstr ""
-
-#: include/text.php:1080
-msgid "finger"
-msgstr ""
-
-#: include/text.php:1080
-msgid "fingered"
-msgstr ""
-
-#: include/text.php:1081
-msgid "rebuff"
-msgstr ""
-
-#: include/text.php:1081
-msgid "rebuffed"
-msgstr ""
-
-#: include/text.php:1095
-msgid "happy"
-msgstr ""
-
-#: include/text.php:1096
-msgid "sad"
-msgstr ""
-
-#: include/text.php:1097
-msgid "mellow"
-msgstr ""
-
-#: include/text.php:1098
-msgid "tired"
-msgstr ""
-
-#: include/text.php:1099
-msgid "perky"
-msgstr ""
-
-#: include/text.php:1100
-msgid "angry"
-msgstr ""
-
-#: include/text.php:1101
-msgid "stupified"
-msgstr ""
-
-#: include/text.php:1102
-msgid "puzzled"
-msgstr ""
-
-#: include/text.php:1103
-msgid "interested"
-msgstr ""
-
-#: include/text.php:1104
-msgid "bitter"
-msgstr ""
-
-#: include/text.php:1105
-msgid "cheerful"
-msgstr ""
-
-#: include/text.php:1106
-msgid "alive"
-msgstr ""
-
-#: include/text.php:1107
-msgid "annoyed"
-msgstr ""
-
-#: include/text.php:1108
-msgid "anxious"
-msgstr ""
-
-#: include/text.php:1109
-msgid "cranky"
-msgstr ""
-
-#: include/text.php:1110
-msgid "disturbed"
-msgstr ""
-
-#: include/text.php:1111
-msgid "frustrated"
-msgstr ""
-
-#: include/text.php:1112
-msgid "motivated"
-msgstr ""
-
-#: include/text.php:1113
-msgid "relaxed"
-msgstr ""
-
-#: include/text.php:1114
-msgid "surprised"
-msgstr ""
-
-#: include/text.php:1324 mod/videos.php:380
-msgid "View Video"
-msgstr ""
-
-#: include/text.php:1356
-msgid "bytes"
-msgstr ""
-
-#: include/text.php:1388 include/text.php:1400
-msgid "Click to open/close"
-msgstr ""
-
-#: include/text.php:1526
-msgid "View on separate page"
-msgstr ""
-
-#: include/text.php:1527
-msgid "view on separate page"
-msgstr ""
-
-#: include/text.php:1806
-msgid "activity"
-msgstr ""
-
-#: include/text.php:1808 mod/content.php:623 object/Item.php:431
-#: object/Item.php:444
-msgid "comment"
-msgid_plural "comments"
-msgstr[0] ""
-msgstr[1] ""
-
-#: include/text.php:1809
-msgid "post"
-msgstr ""
-
-#: include/text.php:1977
-msgid "Item filed"
-msgstr ""
-
-#: include/user.php:39 mod/settings.php:373
+#: include/user.php:39 mod/settings.php:375
 msgid "Passwords do not match. Password unchanged."
 msgstr ""
 
@@ -3010,7 +1270,8 @@ msgstr ""
 msgid "An error occurred during registration. Please try again."
 msgstr ""
 
-#: include/user.php:256 view/theme/duepuntozero/config.php:44
+#: include/user.php:256 view/theme/duepuntozero/config.php:43
+#: view/theme/clean/config.php:60
 msgid "default"
 msgstr ""
 
@@ -3018,16 +1279,16 @@ msgstr ""
 msgid "An error occurred creating your default profile. Please try again."
 msgstr ""
 
-#: include/user.php:326 include/user.php:333 include/user.php:340
-#: mod/profile_photo.php:74 mod/profile_photo.php:81 mod/profile_photo.php:88
-#: mod/profile_photo.php:210 mod/profile_photo.php:302
-#: mod/profile_photo.php:311 mod/photos.php:66 mod/photos.php:180
-#: mod/photos.php:751 mod/photos.php:1211 mod/photos.php:1232
-#: mod/photos.php:1819
+#: include/user.php:326 include/user.php:334 include/user.php:342
+#: mod/profile_photo.php:74 mod/profile_photo.php:82 mod/profile_photo.php:90
+#: mod/profile_photo.php:215 mod/profile_photo.php:310
+#: mod/profile_photo.php:320 mod/photos.php:68 mod/photos.php:182
+#: mod/photos.php:768 mod/photos.php:1231 mod/photos.php:1252
+#: mod/photos.php:1839
 msgid "Profile Photos"
 msgstr ""
 
-#: include/user.php:414
+#: include/user.php:417
 #, php-format
 msgid ""
 "\n"
@@ -3037,12 +1298,12 @@ msgid ""
 "\t"
 msgstr ""
 
-#: include/user.php:424
+#: include/user.php:427
 #, php-format
 msgid "Registration at %s"
 msgstr ""
 
-#: include/user.php:434
+#: include/user.php:437
 #, php-format
 msgid ""
 "\n"
@@ -3051,7 +1312,7 @@ msgid ""
 "\t"
 msgstr ""
 
-#: include/user.php:438
+#: include/user.php:441
 #, php-format
 msgid ""
 "\n"
@@ -3086,102 +1347,2501 @@ msgid ""
 "\t\tThank you and welcome to %2$s."
 msgstr ""
 
-#: include/user.php:470 mod/admin.php:1213
+#: include/user.php:473 mod/admin.php:1234
 #, php-format
 msgid "Registration details for %s"
 msgstr ""
 
-#: mod/oexchange.php:25
-msgid "Post successful."
+#: include/acl_selectors.php:341
+msgid "Post to Email"
 msgstr ""
 
-#: mod/viewsrc.php:7
-msgid "Access denied."
+#: include/acl_selectors.php:346
+#, php-format
+msgid "Connectors disabled, since \"%s\" is enabled."
 msgstr ""
 
-#: mod/home.php:35
+#: include/acl_selectors.php:347 mod/settings.php:1188
+msgid "Hide your profile details from unknown viewers?"
+msgstr ""
+
+#: include/acl_selectors.php:352
+msgid "Visible to everybody"
+msgstr ""
+
+#: include/acl_selectors.php:353 view/theme/vier/config.php:108
+msgid "show"
+msgstr ""
+
+#: include/acl_selectors.php:354 view/theme/vier/config.php:108
+msgid "don't show"
+msgstr ""
+
+#: include/acl_selectors.php:360 mod/editpost.php:123
+msgid "CC: email addresses"
+msgstr ""
+
+#: include/acl_selectors.php:361 mod/editpost.php:130
+msgid "Example: bob@example.com, mary@example.com"
+msgstr ""
+
+#: include/acl_selectors.php:363 mod/events.php:516 mod/photos.php:1176
+#: mod/photos.php:1558
+msgid "Permissions"
+msgstr ""
+
+#: include/acl_selectors.php:364
+msgid "Close"
+msgstr ""
+
+#: include/conversation.php:147
+#, php-format
+msgid "%1$s attends %2$s's %3$s"
+msgstr ""
+
+#: include/conversation.php:150
+#, php-format
+msgid "%1$s doesn't attend %2$s's %3$s"
+msgstr ""
+
+#: include/conversation.php:153
+#, php-format
+msgid "%1$s attends maybe %2$s's %3$s"
+msgstr ""
+
+#: include/conversation.php:185 mod/dfrn_confirm.php:478
+#, php-format
+msgid "%1$s is now friends with %2$s"
+msgstr ""
+
+#: include/conversation.php:219
+#, php-format
+msgid "%1$s poked %2$s"
+msgstr ""
+
+#: include/conversation.php:239 mod/mood.php:63
+#, php-format
+msgid "%1$s is currently %2$s"
+msgstr ""
+
+#: include/conversation.php:278 mod/tagger.php:95
+#, php-format
+msgid "%1$s tagged %2$s's %3$s with %4$s"
+msgstr ""
+
+#: include/conversation.php:303
+msgid "post/item"
+msgstr ""
+
+#: include/conversation.php:304
+#, php-format
+msgid "%1$s marked %2$s's %3$s as favorite"
+msgstr ""
+
+#: include/conversation.php:587 mod/content.php:372 mod/photos.php:1629
+#: mod/profiles.php:346
+msgid "Likes"
+msgstr ""
+
+#: include/conversation.php:587 mod/content.php:372 mod/photos.php:1629
+#: mod/profiles.php:350
+msgid "Dislikes"
+msgstr ""
+
+#: include/conversation.php:588 include/conversation.php:1472
+#: mod/content.php:373 mod/photos.php:1630
+msgid "Attending"
+msgid_plural "Attending"
+msgstr[0] ""
+msgstr[1] ""
+
+#: include/conversation.php:588 mod/content.php:373 mod/photos.php:1630
+msgid "Not attending"
+msgstr ""
+
+#: include/conversation.php:588 mod/content.php:373 mod/photos.php:1630
+msgid "Might attend"
+msgstr ""
+
+#: include/conversation.php:710 mod/content.php:453 mod/content.php:759
+#: mod/photos.php:1703 object/Item.php:137
+msgid "Select"
+msgstr ""
+
+#: include/conversation.php:711 mod/content.php:454 mod/content.php:760
+#: mod/group.php:181 mod/settings.php:744 mod/contacts.php:816
+#: mod/contacts.php:1015 mod/photos.php:1704 mod/admin.php:1435
+#: object/Item.php:138
+msgid "Delete"
+msgstr ""
+
+#: include/conversation.php:755 mod/content.php:487 mod/content.php:915
+#: mod/content.php:916 object/Item.php:382 object/Item.php:383
+#, php-format
+msgid "View %s's profile @ %s"
+msgstr ""
+
+#: include/conversation.php:767 object/Item.php:370
+msgid "Categories:"
+msgstr ""
+
+#: include/conversation.php:768 object/Item.php:371
+msgid "Filed under:"
+msgstr ""
+
+#: include/conversation.php:775 mod/content.php:497 mod/content.php:928
+#: object/Item.php:396
+#, php-format
+msgid "%s from %s"
+msgstr ""
+
+#: include/conversation.php:791 mod/content.php:513
+msgid "View in context"
+msgstr ""
+
+#: include/conversation.php:793 include/conversation.php:1255
+#: mod/content.php:515 mod/content.php:953 mod/editpost.php:114
+#: mod/message.php:337 mod/message.php:522 mod/wallmessage.php:140
+#: mod/photos.php:1592 object/Item.php:421
+msgid "Please wait"
+msgstr ""
+
+#: include/conversation.php:872
+msgid "remove"
+msgstr ""
+
+#: include/conversation.php:876
+msgid "Delete Selected Items"
+msgstr ""
+
+#: include/conversation.php:968
+msgid "Follow Thread"
+msgstr ""
+
+#: include/conversation.php:969 include/Contact.php:445
+msgid "View Status"
+msgstr ""
+
+#: include/conversation.php:970 include/conversation.php:986
+#: include/Contact.php:388 include/Contact.php:401 include/Contact.php:446
+#: mod/allfriends.php:68 mod/directory.php:157 mod/dirfind.php:209
+#: mod/match.php:73 mod/suggest.php:82
+msgid "View Profile"
+msgstr ""
+
+#: include/conversation.php:971 include/Contact.php:447
+msgid "View Photos"
+msgstr ""
+
+#: include/conversation.php:972 include/Contact.php:448
+msgid "Network Posts"
+msgstr ""
+
+#: include/conversation.php:973 include/Contact.php:449
+msgid "View Contact"
+msgstr ""
+
+#: include/conversation.php:974 include/Contact.php:451
+msgid "Send PM"
+msgstr ""
+
+#: include/conversation.php:978 include/Contact.php:452
+msgid "Poke"
+msgstr ""
+
+#: include/conversation.php:983 include/contact_widgets.php:32
+#: include/Contact.php:402 mod/allfriends.php:69 mod/dirfind.php:210
+#: mod/follow.php:106 mod/match.php:74 mod/suggest.php:83 mod/contacts.php:610
+msgid "Connect/Follow"
+msgstr ""
+
+#: include/conversation.php:1099
+#, php-format
+msgid "%s likes this."
+msgstr ""
+
+#: include/conversation.php:1102
+#, php-format
+msgid "%s doesn't like this."
+msgstr ""
+
+#: include/conversation.php:1105
+#, php-format
+msgid "%s attends."
+msgstr ""
+
+#: include/conversation.php:1108
+#, php-format
+msgid "%s doesn't attend."
+msgstr ""
+
+#: include/conversation.php:1111
+#, php-format
+msgid "%s attends maybe."
+msgstr ""
+
+#: include/conversation.php:1121
+msgid "and"
+msgstr ""
+
+#: include/conversation.php:1127
+#, php-format
+msgid ", and %d other people"
+msgstr ""
+
+#: include/conversation.php:1136
+#, php-format
+msgid "<span  %1$s>%2$d people</span> like this"
+msgstr ""
+
+#: include/conversation.php:1137
+#, php-format
+msgid "%s like this."
+msgstr ""
+
+#: include/conversation.php:1140
+#, php-format
+msgid "<span  %1$s>%2$d people</span> don't like this"
+msgstr ""
+
+#: include/conversation.php:1141
+#, php-format
+msgid "%s don't like this."
+msgstr ""
+
+#: include/conversation.php:1144
+#, php-format
+msgid "<span  %1$s>%2$d people</span> attend"
+msgstr ""
+
+#: include/conversation.php:1145
+#, php-format
+msgid "%s attend."
+msgstr ""
+
+#: include/conversation.php:1148
+#, php-format
+msgid "<span  %1$s>%2$d people</span> don't attend"
+msgstr ""
+
+#: include/conversation.php:1149
+#, php-format
+msgid "%s don't attend."
+msgstr ""
+
+#: include/conversation.php:1152
+#, php-format
+msgid "<span  %1$s>%2$d people</span> attend maybe"
+msgstr ""
+
+#: include/conversation.php:1153
+#, php-format
+msgid "%s anttend maybe."
+msgstr ""
+
+#: include/conversation.php:1183 include/conversation.php:1199
+msgid "Visible to <strong>everybody</strong>"
+msgstr ""
+
+#: include/conversation.php:1184 include/conversation.php:1200
+#: mod/message.php:271 mod/message.php:278 mod/message.php:418
+#: mod/message.php:425 mod/wallmessage.php:114 mod/wallmessage.php:121
+msgid "Please enter a link URL:"
+msgstr ""
+
+#: include/conversation.php:1185 include/conversation.php:1201
+msgid "Please enter a video link/URL:"
+msgstr ""
+
+#: include/conversation.php:1186 include/conversation.php:1202
+msgid "Please enter an audio link/URL:"
+msgstr ""
+
+#: include/conversation.php:1187 include/conversation.php:1203
+msgid "Tag term:"
+msgstr ""
+
+#: include/conversation.php:1188 include/conversation.php:1204
+#: mod/filer.php:30
+msgid "Save to Folder:"
+msgstr ""
+
+#: include/conversation.php:1189 include/conversation.php:1205
+msgid "Where are you right now?"
+msgstr ""
+
+#: include/conversation.php:1190
+msgid "Delete item(s)?"
+msgstr ""
+
+#: include/conversation.php:1236
+msgid "Share"
+msgstr ""
+
+#: include/conversation.php:1237 mod/editpost.php:100 mod/message.php:335
+#: mod/message.php:519 mod/wallmessage.php:138
+msgid "Upload photo"
+msgstr ""
+
+#: include/conversation.php:1238 mod/editpost.php:101
+msgid "upload photo"
+msgstr ""
+
+#: include/conversation.php:1239 mod/editpost.php:102
+msgid "Attach file"
+msgstr ""
+
+#: include/conversation.php:1240 mod/editpost.php:103
+msgid "attach file"
+msgstr ""
+
+#: include/conversation.php:1241 mod/editpost.php:104 mod/message.php:336
+#: mod/message.php:520 mod/wallmessage.php:139
+msgid "Insert web link"
+msgstr ""
+
+#: include/conversation.php:1242 mod/editpost.php:105
+msgid "web link"
+msgstr ""
+
+#: include/conversation.php:1243 mod/editpost.php:106
+msgid "Insert video link"
+msgstr ""
+
+#: include/conversation.php:1244 mod/editpost.php:107
+msgid "video link"
+msgstr ""
+
+#: include/conversation.php:1245 mod/editpost.php:108
+msgid "Insert audio link"
+msgstr ""
+
+#: include/conversation.php:1246 mod/editpost.php:109
+msgid "audio link"
+msgstr ""
+
+#: include/conversation.php:1247 mod/editpost.php:110
+msgid "Set your location"
+msgstr ""
+
+#: include/conversation.php:1248 mod/editpost.php:111
+msgid "set location"
+msgstr ""
+
+#: include/conversation.php:1249 mod/editpost.php:112
+msgid "Clear browser location"
+msgstr ""
+
+#: include/conversation.php:1250 mod/editpost.php:113
+msgid "clear location"
+msgstr ""
+
+#: include/conversation.php:1252 mod/editpost.php:127
+msgid "Set title"
+msgstr ""
+
+#: include/conversation.php:1254 mod/editpost.php:129
+msgid "Categories (comma-separated list)"
+msgstr ""
+
+#: include/conversation.php:1256 mod/editpost.php:115
+msgid "Permission settings"
+msgstr ""
+
+#: include/conversation.php:1257 mod/editpost.php:144
+msgid "permissions"
+msgstr ""
+
+#: include/conversation.php:1265 mod/editpost.php:124
+msgid "Public post"
+msgstr ""
+
+#: include/conversation.php:1270 mod/content.php:737 mod/editpost.php:135
+#: mod/events.php:511 mod/photos.php:1613 mod/photos.php:1661
+#: mod/photos.php:1747 object/Item.php:741
+msgid "Preview"
+msgstr ""
+
+#: include/conversation.php:1274 include/items.php:1983 mod/follow.php:124
+#: mod/settings.php:682 mod/settings.php:708 mod/suggest.php:32
+#: mod/tagrm.php:11 mod/tagrm.php:96 mod/videos.php:132 mod/contacts.php:455
+#: mod/editpost.php:138 mod/fbrowser.php:100 mod/fbrowser.php:135
+#: mod/message.php:209 mod/photos.php:240 mod/photos.php:331
+#: mod/dfrn_request.php:889
+msgid "Cancel"
+msgstr ""
+
+#: include/conversation.php:1280
+msgid "Post to Groups"
+msgstr ""
+
+#: include/conversation.php:1281
+msgid "Post to Contacts"
+msgstr ""
+
+#: include/conversation.php:1282
+msgid "Private post"
+msgstr ""
+
+#: include/conversation.php:1287 include/identity.php:259 mod/editpost.php:142
+msgid "Message"
+msgstr ""
+
+#: include/conversation.php:1288 mod/editpost.php:143
+msgid "Browser"
+msgstr ""
+
+#: include/conversation.php:1444
+msgid "View all"
+msgstr ""
+
+#: include/conversation.php:1466
+msgid "Like"
+msgid_plural "Likes"
+msgstr[0] ""
+msgstr[1] ""
+
+#: include/conversation.php:1469
+msgid "Dislike"
+msgid_plural "Dislikes"
+msgstr[0] ""
+msgstr[1] ""
+
+#: include/conversation.php:1475
+msgid "Not Attending"
+msgid_plural "Not Attending"
+msgstr[0] ""
+msgstr[1] ""
+
+#: include/delivery.php:470
+msgid "(no subject)"
+msgstr ""
+
+#: include/features.php:65
+msgid "General Features"
+msgstr ""
+
+#: include/features.php:67
+msgid "Multiple Profiles"
+msgstr ""
+
+#: include/features.php:67
+msgid "Ability to create multiple profiles"
+msgstr ""
+
+#: include/features.php:68
+msgid "Photo Location"
+msgstr ""
+
+#: include/features.php:68
+msgid ""
+"Photo metadata is normally stripped. This extracts the location (if present) "
+"prior to stripping metadata and links it to a map."
+msgstr ""
+
+#: include/features.php:69
+msgid "Export Public Calendar"
+msgstr ""
+
+#: include/features.php:69
+msgid "Ability for visitors to download the public calendar"
+msgstr ""
+
+#: include/features.php:74
+msgid "Post Composition Features"
+msgstr ""
+
+#: include/features.php:75
+msgid "Post Preview"
+msgstr ""
+
+#: include/features.php:75
+msgid "Allow previewing posts and comments before publishing them"
+msgstr ""
+
+#: include/features.php:76
+msgid "Auto-mention Forums"
+msgstr ""
+
+#: include/features.php:76
+msgid ""
+"Add/remove mention when a forum page is selected/deselected in ACL window."
+msgstr ""
+
+#: include/features.php:81
+msgid "Network Sidebar Widgets"
+msgstr ""
+
+#: include/features.php:82
+msgid "Search by Date"
+msgstr ""
+
+#: include/features.php:82
+msgid "Ability to select posts by date ranges"
+msgstr ""
+
+#: include/features.php:83 include/features.php:113
+msgid "List Forums"
+msgstr ""
+
+#: include/features.php:83
+msgid "Enable widget to display the forums your are connected with"
+msgstr ""
+
+#: include/features.php:84
+msgid "Group Filter"
+msgstr ""
+
+#: include/features.php:84
+msgid "Enable widget to display Network posts only from selected group"
+msgstr ""
+
+#: include/features.php:85
+msgid "Network Filter"
+msgstr ""
+
+#: include/features.php:85
+msgid "Enable widget to display Network posts only from selected network"
+msgstr ""
+
+#: include/features.php:86 mod/network.php:199 mod/search.php:34
+msgid "Saved Searches"
+msgstr ""
+
+#: include/features.php:86
+msgid "Save search terms for re-use"
+msgstr ""
+
+#: include/features.php:91
+msgid "Network Tabs"
+msgstr ""
+
+#: include/features.php:92
+msgid "Network Personal Tab"
+msgstr ""
+
+#: include/features.php:92
+msgid "Enable tab to display only Network posts that you've interacted on"
+msgstr ""
+
+#: include/features.php:93
+msgid "Network New Tab"
+msgstr ""
+
+#: include/features.php:93
+msgid "Enable tab to display only new Network posts (from the last 12 hours)"
+msgstr ""
+
+#: include/features.php:94
+msgid "Network Shared Links Tab"
+msgstr ""
+
+#: include/features.php:94
+msgid "Enable tab to display only Network posts with links in them"
+msgstr ""
+
+#: include/features.php:99
+msgid "Post/Comment Tools"
+msgstr ""
+
+#: include/features.php:100
+msgid "Multiple Deletion"
+msgstr ""
+
+#: include/features.php:100
+msgid "Select and delete multiple posts/comments at once"
+msgstr ""
+
+#: include/features.php:101
+msgid "Edit Sent Posts"
+msgstr ""
+
+#: include/features.php:101
+msgid "Edit and correct posts and comments after sending"
+msgstr ""
+
+#: include/features.php:102
+msgid "Tagging"
+msgstr ""
+
+#: include/features.php:102
+msgid "Ability to tag existing posts"
+msgstr ""
+
+#: include/features.php:103
+msgid "Post Categories"
+msgstr ""
+
+#: include/features.php:103
+msgid "Add categories to your posts"
+msgstr ""
+
+#: include/features.php:104 include/contact_widgets.php:150
+msgid "Saved Folders"
+msgstr ""
+
+#: include/features.php:104
+msgid "Ability to file posts under folders"
+msgstr ""
+
+#: include/features.php:105
+msgid "Dislike Posts"
+msgstr ""
+
+#: include/features.php:105
+msgid "Ability to dislike posts/comments"
+msgstr ""
+
+#: include/features.php:106
+msgid "Star Posts"
+msgstr ""
+
+#: include/features.php:106
+msgid "Ability to mark special posts with a star indicator"
+msgstr ""
+
+#: include/features.php:107
+msgid "Mute Post Notifications"
+msgstr ""
+
+#: include/features.php:107
+msgid "Ability to mute notifications for a thread"
+msgstr ""
+
+#: include/features.php:112
+msgid "Advanced Profile Settings"
+msgstr ""
+
+#: include/features.php:113
+msgid "Show visitors public community forums at the Advanced Profile Page"
+msgstr ""
+
+#: include/photos.php:57 include/photos.php:67 mod/fbrowser.php:40
+#: mod/fbrowser.php:61 mod/photos.php:182 mod/photos.php:1106
+#: mod/photos.php:1231 mod/photos.php:1252 mod/photos.php:1817
+#: mod/photos.php:1829
+msgid "Contact Photos"
+msgstr ""
+
+#: include/datetime.php:58 include/datetime.php:60 mod/profiles.php:697
+msgid "Miscellaneous"
+msgstr ""
+
+#: include/datetime.php:184 include/identity.php:641
+msgid "Birthday:"
+msgstr ""
+
+#: include/datetime.php:186 mod/profiles.php:720
+msgid "Age: "
+msgstr ""
+
+#: include/datetime.php:188
+msgid "YYYY-MM-DD or MM-DD"
+msgstr ""
+
+#: include/datetime.php:343
+msgid "never"
+msgstr ""
+
+#: include/datetime.php:349
+msgid "less than a second ago"
+msgstr ""
+
+#: include/datetime.php:352
+msgid "year"
+msgstr ""
+
+#: include/datetime.php:352
+msgid "years"
+msgstr ""
+
+#: include/datetime.php:353 include/event.php:481 mod/cal.php:279
+#: mod/events.php:396
+msgid "month"
+msgstr ""
+
+#: include/datetime.php:353
+msgid "months"
+msgstr ""
+
+#: include/datetime.php:354 include/event.php:482 mod/cal.php:280
+#: mod/events.php:397
+msgid "week"
+msgstr ""
+
+#: include/datetime.php:354
+msgid "weeks"
+msgstr ""
+
+#: include/datetime.php:355 include/event.php:483 mod/cal.php:281
+#: mod/events.php:398
+msgid "day"
+msgstr ""
+
+#: include/datetime.php:355
+msgid "days"
+msgstr ""
+
+#: include/datetime.php:356
+msgid "hour"
+msgstr ""
+
+#: include/datetime.php:356
+msgid "hours"
+msgstr ""
+
+#: include/datetime.php:357
+msgid "minute"
+msgstr ""
+
+#: include/datetime.php:357
+msgid "minutes"
+msgstr ""
+
+#: include/datetime.php:358
+msgid "second"
+msgstr ""
+
+#: include/datetime.php:358
+msgid "seconds"
+msgstr ""
+
+#: include/datetime.php:367
+#, php-format
+msgid "%1$d %2$s ago"
+msgstr ""
+
+#: include/datetime.php:585
+#, php-format
+msgid "%s's birthday"
+msgstr ""
+
+#: include/datetime.php:586 include/dfrn.php:1122
+#, php-format
+msgid "Happy Birthday %s"
+msgstr ""
+
+#: include/event.php:16 include/bb2diaspora.php:199 mod/localtime.php:12
+msgid "l F d, Y \\@ g:i A"
+msgstr ""
+
+#: include/event.php:33 include/event.php:51 include/event.php:488
+#: include/bb2diaspora.php:205
+msgid "Starts:"
+msgstr ""
+
+#: include/event.php:36 include/event.php:57 include/event.php:489
+#: include/bb2diaspora.php:213
+msgid "Finishes:"
+msgstr ""
+
+#: include/event.php:39 include/event.php:63 include/event.php:490
+#: include/bb2diaspora.php:221 include/identity.php:331 mod/directory.php:139
+#: mod/contacts.php:636 mod/events.php:501 mod/notifications.php:238
+msgid "Location:"
+msgstr ""
+
+#: include/event.php:442
+msgid "Sun"
+msgstr ""
+
+#: include/event.php:443
+msgid "Mon"
+msgstr ""
+
+#: include/event.php:444
+msgid "Tue"
+msgstr ""
+
+#: include/event.php:445
+msgid "Wed"
+msgstr ""
+
+#: include/event.php:446
+msgid "Thu"
+msgstr ""
+
+#: include/event.php:447
+msgid "Fri"
+msgstr ""
+
+#: include/event.php:448
+msgid "Sat"
+msgstr ""
+
+#: include/event.php:449 include/text.php:1132 mod/settings.php:981
+msgid "Sunday"
+msgstr ""
+
+#: include/event.php:450 include/text.php:1132 mod/settings.php:981
+msgid "Monday"
+msgstr ""
+
+#: include/event.php:451 include/text.php:1132
+msgid "Tuesday"
+msgstr ""
+
+#: include/event.php:452 include/text.php:1132
+msgid "Wednesday"
+msgstr ""
+
+#: include/event.php:453 include/text.php:1132
+msgid "Thursday"
+msgstr ""
+
+#: include/event.php:454 include/text.php:1132
+msgid "Friday"
+msgstr ""
+
+#: include/event.php:455 include/text.php:1132
+msgid "Saturday"
+msgstr ""
+
+#: include/event.php:456
+msgid "Jan"
+msgstr ""
+
+#: include/event.php:457
+msgid "Feb"
+msgstr ""
+
+#: include/event.php:458
+msgid "Mar"
+msgstr ""
+
+#: include/event.php:459
+msgid "Apr"
+msgstr ""
+
+#: include/event.php:460 include/event.php:472 include/text.php:1136
+msgid "May"
+msgstr ""
+
+#: include/event.php:461
+msgid "Jun"
+msgstr ""
+
+#: include/event.php:462
+msgid "Jul"
+msgstr ""
+
+#: include/event.php:463
+msgid "Aug"
+msgstr ""
+
+#: include/event.php:464
+msgid "Sept"
+msgstr ""
+
+#: include/event.php:465
+msgid "Oct"
+msgstr ""
+
+#: include/event.php:466
+msgid "Nov"
+msgstr ""
+
+#: include/event.php:467
+msgid "Dec"
+msgstr ""
+
+#: include/event.php:468 include/text.php:1136
+msgid "January"
+msgstr ""
+
+#: include/event.php:469 include/text.php:1136
+msgid "February"
+msgstr ""
+
+#: include/event.php:470 include/text.php:1136
+msgid "March"
+msgstr ""
+
+#: include/event.php:471 include/text.php:1136
+msgid "April"
+msgstr ""
+
+#: include/event.php:473 include/text.php:1136
+msgid "June"
+msgstr ""
+
+#: include/event.php:474 include/text.php:1136
+msgid "July"
+msgstr ""
+
+#: include/event.php:475 include/text.php:1136
+msgid "August"
+msgstr ""
+
+#: include/event.php:476 include/text.php:1136
+msgid "September"
+msgstr ""
+
+#: include/event.php:477 include/text.php:1136
+msgid "October"
+msgstr ""
+
+#: include/event.php:478 include/text.php:1136
+msgid "November"
+msgstr ""
+
+#: include/event.php:479 include/text.php:1136
+msgid "December"
+msgstr ""
+
+#: include/event.php:480 mod/cal.php:278 mod/events.php:395
+msgid "today"
+msgstr ""
+
+#: include/event.php:484
+msgid "all-day"
+msgstr ""
+
+#: include/event.php:486
+msgid "No events to display"
+msgstr ""
+
+#: include/event.php:596
+msgid "l, F j"
+msgstr ""
+
+#: include/event.php:615
+msgid "Edit event"
+msgstr ""
+
+#: include/event.php:637 include/text.php:1534 include/text.php:1541
+msgid "link to source"
+msgstr ""
+
+#: include/event.php:872
+msgid "Export"
+msgstr ""
+
+#: include/event.php:873
+msgid "Export calendar as ical"
+msgstr ""
+
+#: include/event.php:874
+msgid "Export calendar as csv"
+msgstr ""
+
+#: include/dfrn.php:1121
+#, php-format
+msgid "%s\\'s birthday"
+msgstr ""
+
+#: include/contact_selectors.php:32
+msgid "Unknown | Not categorised"
+msgstr ""
+
+#: include/contact_selectors.php:33
+msgid "Block immediately"
+msgstr ""
+
+#: include/contact_selectors.php:34
+msgid "Shady, spammer, self-marketer"
+msgstr ""
+
+#: include/contact_selectors.php:35
+msgid "Known to me, but no opinion"
+msgstr ""
+
+#: include/contact_selectors.php:36
+msgid "OK, probably harmless"
+msgstr ""
+
+#: include/contact_selectors.php:37
+msgid "Reputable, has my trust"
+msgstr ""
+
+#: include/contact_selectors.php:56 mod/admin.php:901
+msgid "Frequently"
+msgstr ""
+
+#: include/contact_selectors.php:57 mod/admin.php:902
+msgid "Hourly"
+msgstr ""
+
+#: include/contact_selectors.php:58 mod/admin.php:903
+msgid "Twice daily"
+msgstr ""
+
+#: include/contact_selectors.php:59 mod/admin.php:904
+msgid "Daily"
+msgstr ""
+
+#: include/contact_selectors.php:60
+msgid "Weekly"
+msgstr ""
+
+#: include/contact_selectors.php:61
+msgid "Monthly"
+msgstr ""
+
+#: include/contact_selectors.php:76 mod/dfrn_request.php:881
+msgid "Friendica"
+msgstr ""
+
+#: include/contact_selectors.php:77
+msgid "OStatus"
+msgstr ""
+
+#: include/contact_selectors.php:78
+msgid "RSS/Atom"
+msgstr ""
+
+#: include/contact_selectors.php:79 include/contact_selectors.php:86
+#: mod/admin.php:1417 mod/admin.php:1430 mod/admin.php:1443 mod/admin.php:1461
+msgid "Email"
+msgstr ""
+
+#: include/contact_selectors.php:80 mod/settings.php:848
+#: mod/dfrn_request.php:883
+msgid "Diaspora"
+msgstr ""
+
+#: include/contact_selectors.php:81
+msgid "Facebook"
+msgstr ""
+
+#: include/contact_selectors.php:82
+msgid "Zot!"
+msgstr ""
+
+#: include/contact_selectors.php:83
+msgid "LinkedIn"
+msgstr ""
+
+#: include/contact_selectors.php:84
+msgid "XMPP/IM"
+msgstr ""
+
+#: include/contact_selectors.php:85
+msgid "MySpace"
+msgstr ""
+
+#: include/contact_selectors.php:87
+msgid "Google+"
+msgstr ""
+
+#: include/contact_selectors.php:88
+msgid "pump.io"
+msgstr ""
+
+#: include/contact_selectors.php:89
+msgid "Twitter"
+msgstr ""
+
+#: include/contact_selectors.php:90
+msgid "Diaspora Connector"
+msgstr ""
+
+#: include/contact_selectors.php:91
+msgid "GNU Social"
+msgstr ""
+
+#: include/contact_selectors.php:92
+msgid "pnut"
+msgstr ""
+
+#: include/contact_selectors.php:93
+msgid "App.net"
+msgstr ""
+
+#: include/contact_selectors.php:104
+msgid "Hubzilla/Redmatrix"
+msgstr ""
+
+#: include/contact_widgets.php:6
+msgid "Add New Contact"
+msgstr ""
+
+#: include/contact_widgets.php:7
+msgid "Enter address or web location"
+msgstr ""
+
+#: include/contact_widgets.php:8
+msgid "Example: bob@example.com, http://example.com/barbara"
+msgstr ""
+
+#: include/contact_widgets.php:10 include/identity.php:219
+#: mod/allfriends.php:85 mod/dirfind.php:207 mod/match.php:89
+#: mod/suggest.php:101
+msgid "Connect"
+msgstr ""
+
+#: include/contact_widgets.php:24
+#, php-format
+msgid "%d invitation available"
+msgid_plural "%d invitations available"
+msgstr[0] ""
+msgstr[1] ""
+
+#: include/contact_widgets.php:30
+msgid "Find People"
+msgstr ""
+
+#: include/contact_widgets.php:31
+msgid "Enter name or interest"
+msgstr ""
+
+#: include/contact_widgets.php:33
+msgid "Examples: Robert Morgenstein, Fishing"
+msgstr ""
+
+#: include/contact_widgets.php:34 mod/directory.php:206 mod/contacts.php:806
+msgid "Find"
+msgstr ""
+
+#: include/contact_widgets.php:35 mod/suggest.php:114
+#: view/theme/vier/theme.php:198
+msgid "Friend Suggestions"
+msgstr ""
+
+#: include/contact_widgets.php:36 view/theme/vier/theme.php:197
+msgid "Similar Interests"
+msgstr ""
+
+#: include/contact_widgets.php:37
+msgid "Random Profile"
+msgstr ""
+
+#: include/contact_widgets.php:38 view/theme/vier/theme.php:199
+msgid "Invite Friends"
+msgstr ""
+
+#: include/contact_widgets.php:115
+msgid "Networks"
+msgstr ""
+
+#: include/contact_widgets.php:118
+msgid "All Networks"
+msgstr ""
+
+#: include/contact_widgets.php:153 include/contact_widgets.php:187
+msgid "Everything"
+msgstr ""
+
+#: include/contact_widgets.php:184
+msgid "Categories"
+msgstr ""
+
+#: include/contact_widgets.php:248
+#, php-format
+msgid "%d contact in common"
+msgid_plural "%d contacts in common"
+msgstr[0] ""
+msgstr[1] ""
+
+#: include/api.php:1021
+#, php-format
+msgid "Daily posting limit of %d posts reached. The post was rejected."
+msgstr ""
+
+#: include/api.php:1041
+#, php-format
+msgid "Weekly posting limit of %d posts reached. The post was rejected."
+msgstr ""
+
+#: include/api.php:1062
+#, php-format
+msgid "Monthly posting limit of %d posts reached. The post was rejected."
+msgstr ""
+
+#: include/diaspora.php:2087
+msgid "Sharing notification from Diaspora network"
+msgstr ""
+
+#: include/diaspora.php:3096
+msgid "Attachments:"
+msgstr ""
+
+#: include/identity.php:43
+msgid "Requested account is not available."
+msgstr ""
+
+#: include/identity.php:52 mod/profile.php:21
+msgid "Requested profile is not available."
+msgstr ""
+
+#: include/identity.php:96 include/identity.php:314 include/identity.php:737
+msgid "Edit profile"
+msgstr ""
+
+#: include/identity.php:254
+msgid "Atom feed"
+msgstr ""
+
+#: include/identity.php:285
+msgid "Manage/edit profiles"
+msgstr ""
+
+#: include/identity.php:290 include/identity.php:316 mod/profiles.php:789
+msgid "Change profile photo"
+msgstr ""
+
+#: include/identity.php:291 mod/profiles.php:790
+msgid "Create New Profile"
+msgstr ""
+
+#: include/identity.php:301 mod/profiles.php:779
+msgid "Profile Image"
+msgstr ""
+
+#: include/identity.php:304 mod/profiles.php:781
+msgid "visible to everybody"
+msgstr ""
+
+#: include/identity.php:305 mod/profiles.php:683 mod/profiles.php:782
+msgid "Edit visibility"
+msgstr ""
+
+#: include/identity.php:333 include/identity.php:628 mod/directory.php:141
+#: mod/notifications.php:244
+msgid "Gender:"
+msgstr ""
+
+#: include/identity.php:336 include/identity.php:648 mod/directory.php:143
+msgid "Status:"
+msgstr ""
+
+#: include/identity.php:338 include/identity.php:664 mod/directory.php:145
+msgid "Homepage:"
+msgstr ""
+
+#: include/identity.php:340 include/identity.php:684 mod/directory.php:147
+#: mod/contacts.php:640 mod/notifications.php:240
+msgid "About:"
+msgstr ""
+
+#: include/identity.php:342 mod/contacts.php:638
+msgid "XMPP:"
+msgstr ""
+
+#: include/identity.php:428 mod/contacts.php:55 mod/notifications.php:252
+msgid "Network:"
+msgstr ""
+
+#: include/identity.php:457 include/identity.php:547
+msgid "g A l F d"
+msgstr ""
+
+#: include/identity.php:458 include/identity.php:548
+msgid "F d"
+msgstr ""
+
+#: include/identity.php:509 include/identity.php:594
+msgid "[today]"
+msgstr ""
+
+#: include/identity.php:521
+msgid "Birthday Reminders"
+msgstr ""
+
+#: include/identity.php:522
+msgid "Birthdays this week:"
+msgstr ""
+
+#: include/identity.php:581
+msgid "[No description]"
+msgstr ""
+
+#: include/identity.php:605
+msgid "Event Reminders"
+msgstr ""
+
+#: include/identity.php:606
+msgid "Events this week:"
+msgstr ""
+
+#: include/identity.php:626 mod/settings.php:1286
+msgid "Full Name:"
+msgstr ""
+
+#: include/identity.php:633
+msgid "j F, Y"
+msgstr ""
+
+#: include/identity.php:634
+msgid "j F"
+msgstr ""
+
+#: include/identity.php:645
+msgid "Age:"
+msgstr ""
+
+#: include/identity.php:656
+#, php-format
+msgid "for %1$d %2$s"
+msgstr ""
+
+#: include/identity.php:660 mod/profiles.php:702
+msgid "Sexual Preference:"
+msgstr ""
+
+#: include/identity.php:668 mod/profiles.php:729
+msgid "Hometown:"
+msgstr ""
+
+#: include/identity.php:672 mod/follow.php:137 mod/contacts.php:642
+#: mod/notifications.php:242
+msgid "Tags:"
+msgstr ""
+
+#: include/identity.php:676 mod/profiles.php:730
+msgid "Political Views:"
+msgstr ""
+
+#: include/identity.php:680
+msgid "Religion:"
+msgstr ""
+
+#: include/identity.php:688
+msgid "Hobbies/Interests:"
+msgstr ""
+
+#: include/identity.php:692 mod/profiles.php:734
+msgid "Likes:"
+msgstr ""
+
+#: include/identity.php:696 mod/profiles.php:735
+msgid "Dislikes:"
+msgstr ""
+
+#: include/identity.php:700
+msgid "Contact information and Social Networks:"
+msgstr ""
+
+#: include/identity.php:704
+msgid "Musical interests:"
+msgstr ""
+
+#: include/identity.php:708
+msgid "Books, literature:"
+msgstr ""
+
+#: include/identity.php:712
+msgid "Television:"
+msgstr ""
+
+#: include/identity.php:716
+msgid "Film/dance/culture/entertainment:"
+msgstr ""
+
+#: include/identity.php:720
+msgid "Love/Romance:"
+msgstr ""
+
+#: include/identity.php:724
+msgid "Work/employment:"
+msgstr ""
+
+#: include/identity.php:728
+msgid "School/education:"
+msgstr ""
+
+#: include/identity.php:733
+msgid "Forums:"
+msgstr ""
+
+#: include/identity.php:742 mod/events.php:514
+msgid "Basic"
+msgstr ""
+
+#: include/identity.php:743 mod/contacts.php:878 mod/events.php:515
+#: mod/admin.php:980
+msgid "Advanced"
+msgstr ""
+
+#: include/identity.php:769 mod/follow.php:145 mod/contacts.php:844
+msgid "Status Messages and Posts"
+msgstr ""
+
+#: include/identity.php:777 mod/contacts.php:852
+msgid "Profile Details"
+msgstr ""
+
+#: include/identity.php:785 mod/photos.php:89
+msgid "Photo Albums"
+msgstr ""
+
+#: include/identity.php:824 mod/notes.php:47
+msgid "Personal Notes"
+msgstr ""
+
+#: include/identity.php:827
+msgid "Only You Can See This"
+msgstr ""
+
+#: include/text.php:304
+msgid "newer"
+msgstr ""
+
+#: include/text.php:306
+msgid "older"
+msgstr ""
+
+#: include/text.php:311
+msgid "prev"
+msgstr ""
+
+#: include/text.php:313
+msgid "first"
+msgstr ""
+
+#: include/text.php:345
+msgid "last"
+msgstr ""
+
+#: include/text.php:348
+msgid "next"
+msgstr ""
+
+#: include/text.php:403
+msgid "Loading more entries..."
+msgstr ""
+
+#: include/text.php:404
+msgid "The end"
+msgstr ""
+
+#: include/text.php:889
+msgid "No contacts"
+msgstr ""
+
+#: include/text.php:914
+#, php-format
+msgid "%d Contact"
+msgid_plural "%d Contacts"
+msgstr[0] ""
+msgstr[1] ""
+
+#: include/text.php:927
+msgid "View Contacts"
+msgstr ""
+
+#: include/text.php:1015 mod/filer.php:31 mod/notes.php:62 mod/editpost.php:99
+msgid "Save"
+msgstr ""
+
+#: include/text.php:1078
+msgid "poke"
+msgstr ""
+
+#: include/text.php:1078
+msgid "poked"
+msgstr ""
+
+#: include/text.php:1079
+msgid "ping"
+msgstr ""
+
+#: include/text.php:1079
+msgid "pinged"
+msgstr ""
+
+#: include/text.php:1080
+msgid "prod"
+msgstr ""
+
+#: include/text.php:1080
+msgid "prodded"
+msgstr ""
+
+#: include/text.php:1081
+msgid "slap"
+msgstr ""
+
+#: include/text.php:1081
+msgid "slapped"
+msgstr ""
+
+#: include/text.php:1082
+msgid "finger"
+msgstr ""
+
+#: include/text.php:1082
+msgid "fingered"
+msgstr ""
+
+#: include/text.php:1083
+msgid "rebuff"
+msgstr ""
+
+#: include/text.php:1083
+msgid "rebuffed"
+msgstr ""
+
+#: include/text.php:1097
+msgid "happy"
+msgstr ""
+
+#: include/text.php:1098
+msgid "sad"
+msgstr ""
+
+#: include/text.php:1099
+msgid "mellow"
+msgstr ""
+
+#: include/text.php:1100
+msgid "tired"
+msgstr ""
+
+#: include/text.php:1101
+msgid "perky"
+msgstr ""
+
+#: include/text.php:1102
+msgid "angry"
+msgstr ""
+
+#: include/text.php:1103
+msgid "stupified"
+msgstr ""
+
+#: include/text.php:1104
+msgid "puzzled"
+msgstr ""
+
+#: include/text.php:1105
+msgid "interested"
+msgstr ""
+
+#: include/text.php:1106
+msgid "bitter"
+msgstr ""
+
+#: include/text.php:1107
+msgid "cheerful"
+msgstr ""
+
+#: include/text.php:1108
+msgid "alive"
+msgstr ""
+
+#: include/text.php:1109
+msgid "annoyed"
+msgstr ""
+
+#: include/text.php:1110
+msgid "anxious"
+msgstr ""
+
+#: include/text.php:1111
+msgid "cranky"
+msgstr ""
+
+#: include/text.php:1112
+msgid "disturbed"
+msgstr ""
+
+#: include/text.php:1113
+msgid "frustrated"
+msgstr ""
+
+#: include/text.php:1114
+msgid "motivated"
+msgstr ""
+
+#: include/text.php:1115
+msgid "relaxed"
+msgstr ""
+
+#: include/text.php:1116
+msgid "surprised"
+msgstr ""
+
+#: include/text.php:1326 mod/videos.php:384
+msgid "View Video"
+msgstr ""
+
+#: include/text.php:1358
+msgid "bytes"
+msgstr ""
+
+#: include/text.php:1390 include/text.php:1402
+msgid "Click to open/close"
+msgstr ""
+
+#: include/text.php:1528
+msgid "View on separate page"
+msgstr ""
+
+#: include/text.php:1529
+msgid "view on separate page"
+msgstr ""
+
+#: include/text.php:1808
+msgid "activity"
+msgstr ""
+
+#: include/text.php:1810 mod/content.php:623 object/Item.php:446
+#: object/Item.php:458
+msgid "comment"
+msgid_plural "comments"
+msgstr[0] ""
+msgstr[1] ""
+
+#: include/text.php:1811
+msgid "post"
+msgstr ""
+
+#: include/text.php:1979
+msgid "Item filed"
+msgstr ""
+
+#: include/Contact.php:450
+msgid "Drop Contact"
+msgstr ""
+
+#: include/Contact.php:827
+msgid "Organisation"
+msgstr ""
+
+#: include/Contact.php:830
+msgid "News"
+msgstr ""
+
+#: include/Contact.php:833
+msgid "Forum"
+msgstr ""
+
+#: include/items.php:1584 mod/dfrn_confirm.php:735 mod/dfrn_request.php:754
+msgid "[Name Withheld]"
+msgstr ""
+
+#: include/items.php:1939 mod/notice.php:15 mod/viewsrc.php:15
+#: mod/display.php:103 mod/display.php:279 mod/display.php:484
+#: mod/admin.php:235 mod/admin.php:1492 mod/admin.php:1738
+msgid "Item not found."
+msgstr ""
+
+#: include/items.php:1978
+msgid "Do you really want to delete this item?"
+msgstr ""
+
+#: include/items.php:1980 mod/api.php:105 mod/follow.php:113
+#: mod/register.php:245 mod/settings.php:1171 mod/settings.php:1177
+#: mod/settings.php:1184 mod/settings.php:1188 mod/settings.php:1193
+#: mod/settings.php:1198 mod/settings.php:1203 mod/settings.php:1208
+#: mod/settings.php:1234 mod/settings.php:1235 mod/settings.php:1236
+#: mod/settings.php:1237 mod/settings.php:1238 mod/suggest.php:29
+#: mod/contacts.php:452 mod/message.php:206 mod/dfrn_request.php:875
+#: mod/profiles.php:640 mod/profiles.php:643 mod/profiles.php:669
+msgid "Yes"
+msgstr ""
+
+#: include/items.php:2143 mod/allfriends.php:12 mod/api.php:26 mod/api.php:31
+#: mod/attach.php:33 mod/common.php:18 mod/crepair.php:102 mod/delegate.php:12
+#: mod/dirfind.php:11 mod/follow.php:11 mod/follow.php:74 mod/follow.php:158
+#: mod/fsuggest.php:79 mod/group.php:19 mod/invite.php:15 mod/invite.php:103
+#: mod/manage.php:98 mod/mood.php:115 mod/nogroup.php:27 mod/notes.php:23
+#: mod/ostatus_subscribe.php:9 mod/poke.php:154 mod/profile_photo.php:19
+#: mod/profile_photo.php:180 mod/profile_photo.php:191
+#: mod/profile_photo.php:204 mod/register.php:42 mod/regmod.php:113
+#: mod/repair_ostatus.php:9 mod/settings.php:22 mod/settings.php:130
+#: mod/settings.php:668 mod/suggest.php:58 mod/uimport.php:24
+#: mod/wall_attach.php:67 mod/wall_attach.php:70 mod/cal.php:299
+#: mod/contacts.php:360 mod/dfrn_confirm.php:61 mod/editpost.php:10
+#: mod/events.php:195 mod/item.php:193 mod/item.php:205 mod/message.php:46
+#: mod/message.php:171 mod/wall_upload.php:77 mod/wall_upload.php:80
+#: mod/wallmessage.php:9 mod/wallmessage.php:33 mod/wallmessage.php:73
+#: mod/wallmessage.php:97 mod/photos.php:161 mod/photos.php:1092
+#: mod/profiles.php:166 mod/profiles.php:607 mod/display.php:481
+#: mod/viewcontacts.php:46 mod/network.php:4 mod/notifications.php:71
+#: index.php:407
+msgid "Permission denied."
+msgstr ""
+
+#: include/items.php:2248
+msgid "Archives"
+msgstr ""
+
+#: include/dbstructure.php:33
+#, php-format
+msgid ""
+"\n"
+"\t\t\tThe friendica developers released update %s recently,\n"
+"\t\t\tbut when I tried to install it, something went terribly wrong.\n"
+"\t\t\tThis needs to be fixed soon and I can't do it alone. Please contact a\n"
+"\t\t\tfriendica developer if you can not help me on your own. My database "
+"might be invalid."
+msgstr ""
+
+#: include/dbstructure.php:38
+#, php-format
+msgid ""
+"The error message is\n"
+"[pre]%s[/pre]"
+msgstr ""
+
+#: include/dbstructure.php:195
+msgid "Errors encountered creating database tables."
+msgstr ""
+
+#: include/dbstructure.php:329 include/dbstructure.php:337
+#: include/dbstructure.php:345 include/dbstructure.php:350
+#: include/dbstructure.php:355
+msgid "Errors encountered performing database changes."
+msgstr ""
+
+#: include/network.php:619
+msgid "view full size"
+msgstr ""
+
+#: mod/allfriends.php:46
+msgid "No friends to display."
+msgstr ""
+
+#: mod/api.php:76 mod/api.php:102
+msgid "Authorize application connection"
+msgstr ""
+
+#: mod/api.php:77
+msgid "Return to your app and insert this Securty Code:"
+msgstr ""
+
+#: mod/api.php:89
+msgid "Please login to continue."
+msgstr ""
+
+#: mod/api.php:104
+msgid ""
+"Do you want to authorize this application to access your posts and contacts, "
+"and/or create new posts for you?"
+msgstr ""
+
+#: mod/api.php:106 mod/follow.php:113 mod/register.php:246
+#: mod/settings.php:1171 mod/settings.php:1177 mod/settings.php:1184
+#: mod/settings.php:1188 mod/settings.php:1193 mod/settings.php:1198
+#: mod/settings.php:1203 mod/settings.php:1208 mod/settings.php:1234
+#: mod/settings.php:1235 mod/settings.php:1236 mod/settings.php:1237
+#: mod/settings.php:1238 mod/dfrn_request.php:875 mod/profiles.php:640
+#: mod/profiles.php:644 mod/profiles.php:669
+msgid "No"
+msgstr ""
+
+#: mod/apps.php:7 index.php:248
+msgid "You must be logged in to use addons. "
+msgstr ""
+
+#: mod/apps.php:11
+msgid "Applications"
+msgstr ""
+
+#: mod/apps.php:14
+msgid "No installed applications."
+msgstr ""
+
+#: mod/attach.php:8
+msgid "Item not available."
+msgstr ""
+
+#: mod/attach.php:20
+msgid "Item was not found."
+msgstr ""
+
+#: mod/babel.php:17
+msgid "Source (bbcode) text:"
+msgstr ""
+
+#: mod/babel.php:23
+msgid "Source (Diaspora) text to convert to BBcode:"
+msgstr ""
+
+#: mod/babel.php:31
+msgid "Source input: "
+msgstr ""
+
+#: mod/babel.php:35
+msgid "bb2html (raw HTML): "
+msgstr ""
+
+#: mod/babel.php:39
+msgid "bb2html: "
+msgstr ""
+
+#: mod/babel.php:43
+msgid "bb2html2bb: "
+msgstr ""
+
+#: mod/babel.php:47
+msgid "bb2md: "
+msgstr ""
+
+#: mod/babel.php:51
+msgid "bb2md2html: "
+msgstr ""
+
+#: mod/babel.php:55
+msgid "bb2dia2bb: "
+msgstr ""
+
+#: mod/babel.php:59
+msgid "bb2md2html2bb: "
+msgstr ""
+
+#: mod/babel.php:69
+msgid "Source input (Diaspora format): "
+msgstr ""
+
+#: mod/babel.php:74
+msgid "diaspora2bb: "
+msgstr ""
+
+#: mod/bookmarklet.php:41
+msgid "The post was created"
+msgstr ""
+
+#: mod/common.php:91
+msgid "No contacts in common."
+msgstr ""
+
+#: mod/common.php:141 mod/contacts.php:871
+msgid "Common Friends"
+msgstr ""
+
+#: mod/community.php:22 mod/directory.php:37 mod/videos.php:198
+#: mod/photos.php:964 mod/dfrn_request.php:799 mod/display.php:200
+#: mod/viewcontacts.php:36 mod/search.php:93 mod/search.php:99
+msgid "Public access denied."
+msgstr ""
+
+#: mod/community.php:27
+msgid "Not available."
+msgstr ""
+
+#: mod/community.php:66 mod/community.php:75 mod/search.php:224
+msgid "No results."
+msgstr ""
+
+#: mod/content.php:119 mod/network.php:468
+msgid "No such group"
+msgstr ""
+
+#: mod/content.php:130 mod/group.php:203 mod/network.php:495
+msgid "Group is empty"
+msgstr ""
+
+#: mod/content.php:135 mod/network.php:499
+#, php-format
+msgid "Group: %s"
+msgstr ""
+
+#: mod/content.php:325 object/Item.php:96
+msgid "This entry was edited"
+msgstr ""
+
+#: mod/content.php:621 object/Item.php:444
+#, php-format
+msgid "%d comment"
+msgid_plural "%d comments"
+msgstr[0] ""
+msgstr[1] ""
+
+#: mod/content.php:638 mod/photos.php:1402 object/Item.php:117
+msgid "Private Message"
+msgstr ""
+
+#: mod/content.php:702 mod/photos.php:1590 object/Item.php:274
+msgid "I like this (toggle)"
+msgstr ""
+
+#: mod/content.php:702 object/Item.php:274
+msgid "like"
+msgstr ""
+
+#: mod/content.php:703 mod/photos.php:1591 object/Item.php:275
+msgid "I don't like this (toggle)"
+msgstr ""
+
+#: mod/content.php:703 object/Item.php:275
+msgid "dislike"
+msgstr ""
+
+#: mod/content.php:705 object/Item.php:278
+msgid "Share this"
+msgstr ""
+
+#: mod/content.php:705 object/Item.php:278
+msgid "share"
+msgstr ""
+
+#: mod/content.php:725 mod/photos.php:1609 mod/photos.php:1657
+#: mod/photos.php:1743 object/Item.php:729
+msgid "This is you"
+msgstr ""
+
+#: mod/content.php:727 mod/content.php:950 mod/photos.php:1611
+#: mod/photos.php:1659 mod/photos.php:1745 object/Item.php:418
+#: object/Item.php:731
+msgid "Comment"
+msgstr ""
+
+#: mod/content.php:728 mod/crepair.php:156 mod/fsuggest.php:108
+#: mod/invite.php:142 mod/localtime.php:45 mod/manage.php:145 mod/mood.php:138
+#: mod/poke.php:203 mod/contacts.php:585 mod/events.php:513
+#: mod/message.php:338 mod/message.php:521 mod/photos.php:1124
+#: mod/photos.php:1246 mod/photos.php:1562 mod/photos.php:1612
+#: mod/photos.php:1660 mod/photos.php:1746 mod/install.php:276
+#: mod/install.php:316 mod/profiles.php:680 object/Item.php:732
+#: view/theme/quattro/config.php:67 view/theme/vier/config.php:112
+#: view/theme/duepuntozero/config.php:61 view/theme/clean/config.php:87
+#: view/theme/frio/config.php:64
+msgid "Submit"
+msgstr ""
+
+#: mod/content.php:729 object/Item.php:733
+msgid "Bold"
+msgstr ""
+
+#: mod/content.php:730 object/Item.php:734
+msgid "Italic"
+msgstr ""
+
+#: mod/content.php:731 object/Item.php:735
+msgid "Underline"
+msgstr ""
+
+#: mod/content.php:732 object/Item.php:736
+msgid "Quote"
+msgstr ""
+
+#: mod/content.php:733 object/Item.php:737
+msgid "Code"
+msgstr ""
+
+#: mod/content.php:734 object/Item.php:738
+msgid "Image"
+msgstr ""
+
+#: mod/content.php:735 object/Item.php:739
+msgid "Link"
+msgstr ""
+
+#: mod/content.php:736 object/Item.php:740
+msgid "Video"
+msgstr ""
+
+#: mod/content.php:746 mod/settings.php:743 object/Item.php:122
+#: object/Item.php:124
+msgid "Edit"
+msgstr ""
+
+#: mod/content.php:772 object/Item.php:238
+msgid "add star"
+msgstr ""
+
+#: mod/content.php:773 object/Item.php:239
+msgid "remove star"
+msgstr ""
+
+#: mod/content.php:774 object/Item.php:240
+msgid "toggle star status"
+msgstr ""
+
+#: mod/content.php:777 object/Item.php:243
+msgid "starred"
+msgstr ""
+
+#: mod/content.php:778 mod/content.php:800 object/Item.php:263
+msgid "add tag"
+msgstr ""
+
+#: mod/content.php:789 object/Item.php:251
+msgid "ignore thread"
+msgstr ""
+
+#: mod/content.php:790 object/Item.php:252
+msgid "unignore thread"
+msgstr ""
+
+#: mod/content.php:791 object/Item.php:253
+msgid "toggle ignore status"
+msgstr ""
+
+#: mod/content.php:794 mod/ostatus_subscribe.php:73 object/Item.php:256
+msgid "ignored"
+msgstr ""
+
+#: mod/content.php:805 object/Item.php:141
+msgid "save to folder"
+msgstr ""
+
+#: mod/content.php:853 object/Item.php:212
+msgid "I will attend"
+msgstr ""
+
+#: mod/content.php:853 object/Item.php:212
+msgid "I will not attend"
+msgstr ""
+
+#: mod/content.php:853 object/Item.php:212
+msgid "I might attend"
+msgstr ""
+
+#: mod/content.php:917 object/Item.php:384
+msgid "to"
+msgstr ""
+
+#: mod/content.php:918 object/Item.php:386
+msgid "Wall-to-Wall"
+msgstr ""
+
+#: mod/content.php:919 object/Item.php:387
+msgid "via Wall-To-Wall:"
+msgstr ""
+
+#: mod/credits.php:16
+msgid "Credits"
+msgstr ""
+
+#: mod/credits.php:17
+msgid ""
+"Friendica is a community project, that would not be possible without the "
+"help of many people. Here is a list of those who have contributed to the "
+"code or the translation of Friendica. Thank you all!"
+msgstr ""
+
+#: mod/crepair.php:89
+msgid "Contact settings applied."
+msgstr ""
+
+#: mod/crepair.php:91
+msgid "Contact update failed."
+msgstr ""
+
+#: mod/crepair.php:116 mod/fsuggest.php:21 mod/fsuggest.php:93
+#: mod/dfrn_confirm.php:126
+msgid "Contact not found."
+msgstr ""
+
+#: mod/crepair.php:122
+msgid ""
+"<strong>WARNING: This is highly advanced</strong> and if you enter incorrect "
+"information your communications with this contact may stop working."
+msgstr ""
+
+#: mod/crepair.php:123
+msgid ""
+"Please use your browser 'Back' button <strong>now</strong> if you are "
+"uncertain what to do on this page."
+msgstr ""
+
+#: mod/crepair.php:136 mod/crepair.php:138
+msgid "No mirroring"
+msgstr ""
+
+#: mod/crepair.php:136
+msgid "Mirror as forwarded posting"
+msgstr ""
+
+#: mod/crepair.php:136 mod/crepair.php:138
+msgid "Mirror as my own posting"
+msgstr ""
+
+#: mod/crepair.php:152
+msgid "Return to contact editor"
+msgstr ""
+
+#: mod/crepair.php:154
+msgid "Refetch contact data"
+msgstr ""
+
+#: mod/crepair.php:158
+msgid "Remote Self"
+msgstr ""
+
+#: mod/crepair.php:161
+msgid "Mirror postings from this contact"
+msgstr ""
+
+#: mod/crepair.php:163
+msgid ""
+"Mark this contact as remote_self, this will cause friendica to repost new "
+"entries from this contact."
+msgstr ""
+
+#: mod/crepair.php:167 mod/settings.php:683 mod/settings.php:709
+#: mod/admin.php:1417 mod/admin.php:1430 mod/admin.php:1443 mod/admin.php:1459
+msgid "Name"
+msgstr ""
+
+#: mod/crepair.php:168
+msgid "Account Nickname"
+msgstr ""
+
+#: mod/crepair.php:169
+msgid "@Tagname - overrides Name/Nickname"
+msgstr ""
+
+#: mod/crepair.php:170
+msgid "Account URL"
+msgstr ""
+
+#: mod/crepair.php:171
+msgid "Friend Request URL"
+msgstr ""
+
+#: mod/crepair.php:172
+msgid "Friend Confirm URL"
+msgstr ""
+
+#: mod/crepair.php:173
+msgid "Notification Endpoint URL"
+msgstr ""
+
+#: mod/crepair.php:174
+msgid "Poll/Feed URL"
+msgstr ""
+
+#: mod/crepair.php:175
+msgid "New photo from this URL"
+msgstr ""
+
+#: mod/delegate.php:101
+msgid "No potential page delegates located."
+msgstr ""
+
+#: mod/delegate.php:132
+msgid ""
+"Delegates are able to manage all aspects of this account/page except for "
+"basic account settings. Please do not delegate your personal account to "
+"anybody that you do not trust completely."
+msgstr ""
+
+#: mod/delegate.php:133
+msgid "Existing Page Managers"
+msgstr ""
+
+#: mod/delegate.php:135
+msgid "Existing Page Delegates"
+msgstr ""
+
+#: mod/delegate.php:137
+msgid "Potential Delegates"
+msgstr ""
+
+#: mod/delegate.php:139 mod/tagrm.php:95
+msgid "Remove"
+msgstr ""
+
+#: mod/delegate.php:140
+msgid "Add"
+msgstr ""
+
+#: mod/delegate.php:141
+msgid "No entries."
+msgstr ""
+
+#: mod/dfrn_poll.php:104 mod/dfrn_poll.php:539
+#, php-format
+msgid "%1$s welcomes %2$s"
+msgstr ""
+
+#: mod/directory.php:199 view/theme/vier/theme.php:196
+msgid "Global Directory"
+msgstr ""
+
+#: mod/directory.php:201
+msgid "Find on this site"
+msgstr ""
+
+#: mod/directory.php:203
+msgid "Results for:"
+msgstr ""
+
+#: mod/directory.php:205
+msgid "Site Directory"
+msgstr ""
+
+#: mod/directory.php:212
+msgid "No entries (some entries may be hidden)."
+msgstr ""
+
+#: mod/dirfind.php:37
+#, php-format
+msgid "People Search - %s"
+msgstr ""
+
+#: mod/dirfind.php:48
+#, php-format
+msgid "Forum Search - %s"
+msgstr ""
+
+#: mod/dirfind.php:245 mod/match.php:109
+msgid "No matches"
+msgstr ""
+
+#: mod/filer.php:30
+msgid "- select -"
+msgstr ""
+
+#: mod/follow.php:19 mod/dfrn_request.php:888
+msgid "Submit Request"
+msgstr ""
+
+#: mod/follow.php:30
+msgid "You already added this contact."
+msgstr ""
+
+#: mod/follow.php:39
+msgid "Diaspora support isn't enabled. Contact can't be added."
+msgstr ""
+
+#: mod/follow.php:46
+msgid "OStatus support is disabled. Contact can't be added."
+msgstr ""
+
+#: mod/follow.php:53
+msgid "The network type couldn't be detected. Contact can't be added."
+msgstr ""
+
+#: mod/follow.php:112 mod/dfrn_request.php:874
+msgid "Please answer the following:"
+msgstr ""
+
+#: mod/follow.php:113 mod/dfrn_request.php:875
+#, php-format
+msgid "Does %s know you?"
+msgstr ""
+
+#: mod/follow.php:114 mod/dfrn_request.php:879
+msgid "Add a personal note:"
+msgstr ""
+
+#: mod/follow.php:120 mod/dfrn_request.php:885
+msgid "Your Identity Address:"
+msgstr ""
+
+#: mod/follow.php:129 mod/contacts.php:632 mod/notifications.php:249
+msgid "Profile URL"
+msgstr ""
+
+#: mod/follow.php:186
+msgid "Contact added"
+msgstr ""
+
+#: mod/fsuggest.php:64
+msgid "Friend suggestion sent."
+msgstr ""
+
+#: mod/fsuggest.php:98
+msgid "Suggest Friends"
+msgstr ""
+
+#: mod/fsuggest.php:100
+#, php-format
+msgid "Suggest a friend for %s"
+msgstr ""
+
+#: mod/group.php:29
+msgid "Group created."
+msgstr ""
+
+#: mod/group.php:35
+msgid "Could not create group."
+msgstr ""
+
+#: mod/group.php:49 mod/group.php:150
+msgid "Group not found."
+msgstr ""
+
+#: mod/group.php:63
+msgid "Group name changed."
+msgstr ""
+
+#: mod/group.php:76 mod/profperm.php:20 index.php:406
+msgid "Permission denied"
+msgstr ""
+
+#: mod/group.php:91
+msgid "Save Group"
+msgstr ""
+
+#: mod/group.php:97
+msgid "Create a group of contacts/friends."
+msgstr ""
+
+#: mod/group.php:122
+msgid "Group removed."
+msgstr ""
+
+#: mod/group.php:124
+msgid "Unable to remove group."
+msgstr ""
+
+#: mod/group.php:187
+msgid "Group Editor"
+msgstr ""
+
+#: mod/group.php:200
+msgid "Members"
+msgstr ""
+
+#: mod/group.php:202 mod/contacts.php:700
+msgid "All Contacts"
+msgstr ""
+
+#: mod/group.php:233 mod/profperm.php:107
+msgid "Click on a contact to add or remove."
+msgstr ""
+
+#: mod/hcard.php:11
+msgid "No profile"
+msgstr ""
+
+#: mod/help.php:41
+msgid "Help:"
+msgstr ""
+
+#: mod/help.php:53 mod/fetch.php:12 mod/fetch.php:39 mod/fetch.php:48
+#: mod/p.php:16 mod/p.php:43 mod/p.php:52 index.php:292
+msgid "Not Found"
+msgstr ""
+
+#: mod/help.php:56 index.php:295
+msgid "Page not found."
+msgstr ""
+
+#: mod/home.php:39
 #, php-format
 msgid "Welcome to %s"
 msgstr ""
 
-#: mod/notify.php:60
-msgid "No more system notifications."
+#: mod/invite.php:28
+msgid "Total invitation limit exceeded."
 msgstr ""
 
-#: mod/notify.php:64 mod/notifications.php:111
-msgid "System Notifications"
-msgstr ""
-
-#: mod/search.php:25 mod/network.php:191
-msgid "Remove term"
-msgstr ""
-
-#: mod/search.php:93 mod/search.php:99 mod/community.php:22
-#: mod/directory.php:37 mod/display.php:200 mod/photos.php:944
-#: mod/videos.php:194 mod/dfrn_request.php:791 mod/viewcontacts.php:35
-msgid "Public access denied."
-msgstr ""
-
-#: mod/search.php:100
-msgid "Only logged in users are permitted to perform a search."
-msgstr ""
-
-#: mod/search.php:124
-msgid "Too Many Requests"
-msgstr ""
-
-#: mod/search.php:125
-msgid "Only one search per minute is permitted for not logged in users."
-msgstr ""
-
-#: mod/search.php:224 mod/community.php:66 mod/community.php:75
-msgid "No results."
-msgstr ""
-
-#: mod/search.php:230
+#: mod/invite.php:51
 #, php-format
-msgid "Items tagged with: %s"
+msgid "%s : Not a valid email address."
 msgstr ""
 
-#: mod/search.php:232 mod/contacts.php:797 mod/network.php:146
+#: mod/invite.php:76
+msgid "Please join us on Friendica"
+msgstr ""
+
+#: mod/invite.php:87
+msgid "Invitation limit exceeded. Please contact your site administrator."
+msgstr ""
+
+#: mod/invite.php:91
 #, php-format
-msgid "Results for: %s"
+msgid "%s : Message delivery failed."
 msgstr ""
 
-#: mod/friendica.php:70
-msgid "This is Friendica, version"
+#: mod/invite.php:95
+#, php-format
+msgid "%d message sent."
+msgid_plural "%d messages sent."
+msgstr[0] ""
+msgstr[1] ""
+
+#: mod/invite.php:114
+msgid "You have no more invitations available"
 msgstr ""
 
-#: mod/friendica.php:71
-msgid "running at web location"
-msgstr ""
-
-#: mod/friendica.php:73
+#: mod/invite.php:122
+#, php-format
 msgid ""
-"Please visit <a href=\"http://friendica.com\">Friendica.com</a> to learn "
-"more about the Friendica project."
+"Visit %s for a list of public sites that you can join. Friendica members on "
+"other sites can all connect with each other, as well as with members of many "
+"other social networks."
 msgstr ""
 
-#: mod/friendica.php:75
-msgid "Bug reports and issues: please visit"
-msgstr ""
-
-#: mod/friendica.php:75
-msgid "the bugtracker at github"
-msgstr ""
-
-#: mod/friendica.php:76
+#: mod/invite.php:124
+#, php-format
 msgid ""
-"Suggestions, praise, donations, etc. - please email \"Info\" at Friendica - "
-"dot com"
+"To accept this invitation, please visit and register at %s or any other "
+"public Friendica website."
 msgstr ""
 
-#: mod/friendica.php:90
-msgid "Installed plugins/addons/apps:"
+#: mod/invite.php:125
+#, php-format
+msgid ""
+"Friendica sites all inter-connect to create a huge privacy-enhanced social "
+"web that is owned and controlled by its members. They can also connect with "
+"many traditional social networks. See %s for a list of alternate Friendica "
+"sites you can join."
 msgstr ""
 
-#: mod/friendica.php:103
-msgid "No installed plugins/addons/apps"
+#: mod/invite.php:128
+msgid ""
+"Our apologies. This system is not currently configured to connect with other "
+"public sites or invite members."
+msgstr ""
+
+#: mod/invite.php:134
+msgid "Send invitations"
+msgstr ""
+
+#: mod/invite.php:135
+msgid "Enter email addresses, one per line:"
+msgstr ""
+
+#: mod/invite.php:136 mod/message.php:332 mod/message.php:515
+#: mod/wallmessage.php:135
+msgid "Your message:"
+msgstr ""
+
+#: mod/invite.php:137
+msgid ""
+"You are cordially invited to join me and other close friends on Friendica - "
+"and help us to create a better social web."
+msgstr ""
+
+#: mod/invite.php:139
+msgid "You will need to supply this invitation code: $invite_code"
+msgstr ""
+
+#: mod/invite.php:139
+msgid ""
+"Once you have registered, please connect with me via my profile page at:"
+msgstr ""
+
+#: mod/invite.php:141
+msgid ""
+"For more information about the Friendica project and why we feel it is "
+"important, please visit http://friendica.com"
+msgstr ""
+
+#: mod/localtime.php:24
+msgid "Time Conversion"
+msgstr ""
+
+#: mod/localtime.php:26
+msgid ""
+"Friendica provides this service for sharing events with other networks and "
+"friends in unknown timezones."
+msgstr ""
+
+#: mod/localtime.php:30
+#, php-format
+msgid "UTC time: %s"
+msgstr ""
+
+#: mod/localtime.php:33
+#, php-format
+msgid "Current timezone: %s"
+msgstr ""
+
+#: mod/localtime.php:36
+#, php-format
+msgid "Converted localtime: %s"
+msgstr ""
+
+#: mod/localtime.php:41
+msgid "Please select your timezone:"
+msgstr ""
+
+#: mod/lockview.php:32 mod/lockview.php:40
+msgid "Remote privacy information not available."
+msgstr ""
+
+#: mod/lockview.php:49
+msgid "Visible to:"
 msgstr ""
 
 #: mod/lostpass.php:19
@@ -3192,7 +3852,7 @@ msgstr ""
 msgid "Password reset request issued. Check your email."
 msgstr ""
 
-#: mod/lostpass.php:42
+#: mod/lostpass.php:41
 #, php-format
 msgid ""
 "\n"
@@ -3209,7 +3869,7 @@ msgid ""
 "\t\tissued this request."
 msgstr ""
 
-#: mod/lostpass.php:53
+#: mod/lostpass.php:52
 #, php-format
 msgid ""
 "\n"
@@ -3227,38 +3887,38 @@ msgid ""
 "\t\tLogin Name:\t%3$s"
 msgstr ""
 
-#: mod/lostpass.php:72
+#: mod/lostpass.php:71
 #, php-format
 msgid "Password reset requested at %s"
 msgstr ""
 
-#: mod/lostpass.php:92
+#: mod/lostpass.php:91
 msgid ""
 "Request could not be verified. (You may have previously submitted it.) "
 "Password reset failed."
 msgstr ""
 
-#: mod/lostpass.php:109 boot.php:1807
+#: mod/lostpass.php:110 boot.php:1848
 msgid "Password Reset"
 msgstr ""
 
-#: mod/lostpass.php:110
+#: mod/lostpass.php:111
 msgid "Your password has been reset as requested."
 msgstr ""
 
-#: mod/lostpass.php:111
+#: mod/lostpass.php:112
 msgid "Your new password is"
 msgstr ""
 
-#: mod/lostpass.php:112
+#: mod/lostpass.php:113
 msgid "Save or copy your new password - and then"
 msgstr ""
 
-#: mod/lostpass.php:113
+#: mod/lostpass.php:114
 msgid "click here to login"
 msgstr ""
 
-#: mod/lostpass.php:114
+#: mod/lostpass.php:115
 msgid ""
 "Your password may be changed from the <em>Settings</em> page after "
 "successful login."
@@ -3306,7 +3966,7 @@ msgid ""
 "your email for further instructions."
 msgstr ""
 
-#: mod/lostpass.php:161 boot.php:1795
+#: mod/lostpass.php:161 boot.php:1836
 msgid "Nickname or Email: "
 msgstr ""
 
@@ -3314,362 +3974,42 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
-#: mod/hcard.php:10
-msgid "No profile"
+#: mod/maintenance.php:9
+msgid "System down for maintenance"
 msgstr ""
 
-#: mod/help.php:41
-msgid "Help:"
+#: mod/manage.php:141
+msgid "Manage Identities and/or Pages"
 msgstr ""
 
-#: mod/help.php:53 mod/p.php:16 mod/p.php:43 mod/p.php:52 mod/fetch.php:12
-#: mod/fetch.php:39 mod/fetch.php:48 index.php:288
-msgid "Not Found"
-msgstr ""
-
-#: mod/help.php:56 index.php:291
-msgid "Page not found."
-msgstr ""
-
-#: mod/lockview.php:31 mod/lockview.php:39
-msgid "Remote privacy information not available."
-msgstr ""
-
-#: mod/lockview.php:48
-msgid "Visible to:"
-msgstr ""
-
-#: mod/openid.php:24
-msgid "OpenID protocol error. No ID returned."
-msgstr ""
-
-#: mod/openid.php:60
+#: mod/manage.php:142
 msgid ""
-"Account not found and OpenID registration is not permitted on this site."
+"Toggle between different identities or community/group pages which share "
+"your account details or which you have been granted \"manage\" permissions"
 msgstr ""
 
-#: mod/uimport.php:50 mod/register.php:198
-msgid ""
-"This site has exceeded the number of allowed daily account registrations. "
-"Please try again tomorrow."
+#: mod/manage.php:143
+msgid "Select an identity to manage: "
 msgstr ""
 
-#: mod/uimport.php:64 mod/register.php:295
-msgid "Import"
+#: mod/match.php:35
+msgid "No keywords to match. Please add keywords to your default profile."
 msgstr ""
 
-#: mod/uimport.php:66
-msgid "Move account"
+#: mod/match.php:88
+msgid "is interested in:"
 msgstr ""
 
-#: mod/uimport.php:67
-msgid "You can import an account from another Friendica server."
+#: mod/match.php:102
+msgid "Profile Match"
 msgstr ""
 
-#: mod/uimport.php:68
-msgid ""
-"You need to export your account from the old server and upload it here. We "
-"will recreate your old account here with all your contacts. We will try also "
-"to inform your friends that you moved here."
+#: mod/mood.php:134
+msgid "Mood"
 msgstr ""
 
-#: mod/uimport.php:69
-msgid ""
-"This feature is experimental. We can't import contacts from the OStatus "
-"network (GNU Social/Statusnet) or from Diaspora"
-msgstr ""
-
-#: mod/uimport.php:70
-msgid "Account file"
-msgstr ""
-
-#: mod/uimport.php:70
-msgid ""
-"To export your account, go to \"Settings->Export your personal data\" and "
-"select \"Export account\""
-msgstr ""
-
-#: mod/nogroup.php:41 mod/contacts.php:586 mod/contacts.php:930
-#: mod/viewcontacts.php:97
-#, php-format
-msgid "Visit %s's profile [%s]"
-msgstr ""
-
-#: mod/nogroup.php:42 mod/contacts.php:931
-msgid "Edit contact"
-msgstr ""
-
-#: mod/nogroup.php:63
-msgid "Contacts who are not members of a group"
-msgstr ""
-
-#: mod/uexport.php:29
-msgid "Export account"
-msgstr ""
-
-#: mod/uexport.php:29
-msgid ""
-"Export your account info and contacts. Use this to make a backup of your "
-"account and/or to move it to another server."
-msgstr ""
-
-#: mod/uexport.php:30
-msgid "Export all"
-msgstr ""
-
-#: mod/uexport.php:30
-msgid ""
-"Export your accout info, contacts and all your items as json. Could be a "
-"very big file, and could take a lot of time. Use this to make a full backup "
-"of your account (photos are not exported)"
-msgstr ""
-
-#: mod/uexport.php:37 mod/settings.php:95
-msgid "Export personal data"
-msgstr ""
-
-#: mod/invite.php:27
-msgid "Total invitation limit exceeded."
-msgstr ""
-
-#: mod/invite.php:49
-#, php-format
-msgid "%s : Not a valid email address."
-msgstr ""
-
-#: mod/invite.php:73
-msgid "Please join us on Friendica"
-msgstr ""
-
-#: mod/invite.php:84
-msgid "Invitation limit exceeded. Please contact your site administrator."
-msgstr ""
-
-#: mod/invite.php:89
-#, php-format
-msgid "%s : Message delivery failed."
-msgstr ""
-
-#: mod/invite.php:93
-#, php-format
-msgid "%d message sent."
-msgid_plural "%d messages sent."
-msgstr[0] ""
-msgstr[1] ""
-
-#: mod/invite.php:112
-msgid "You have no more invitations available"
-msgstr ""
-
-#: mod/invite.php:120
-#, php-format
-msgid ""
-"Visit %s for a list of public sites that you can join. Friendica members on "
-"other sites can all connect with each other, as well as with members of many "
-"other social networks."
-msgstr ""
-
-#: mod/invite.php:122
-#, php-format
-msgid ""
-"To accept this invitation, please visit and register at %s or any other "
-"public Friendica website."
-msgstr ""
-
-#: mod/invite.php:123
-#, php-format
-msgid ""
-"Friendica sites all inter-connect to create a huge privacy-enhanced social "
-"web that is owned and controlled by its members. They can also connect with "
-"many traditional social networks. See %s for a list of alternate Friendica "
-"sites you can join."
-msgstr ""
-
-#: mod/invite.php:126
-msgid ""
-"Our apologies. This system is not currently configured to connect with other "
-"public sites or invite members."
-msgstr ""
-
-#: mod/invite.php:132
-msgid "Send invitations"
-msgstr ""
-
-#: mod/invite.php:133
-msgid "Enter email addresses, one per line:"
-msgstr ""
-
-#: mod/invite.php:134 mod/wallmessage.php:151 mod/message.php:351
-#: mod/message.php:541
-msgid "Your message:"
-msgstr ""
-
-#: mod/invite.php:135
-msgid ""
-"You are cordially invited to join me and other close friends on Friendica - "
-"and help us to create a better social web."
-msgstr ""
-
-#: mod/invite.php:137
-msgid "You will need to supply this invitation code: $invite_code"
-msgstr ""
-
-#: mod/invite.php:137
-msgid ""
-"Once you have registered, please connect with me via my profile page at:"
-msgstr ""
-
-#: mod/invite.php:139
-msgid ""
-"For more information about the Friendica project and why we feel it is "
-"important, please visit http://friendica.com"
-msgstr ""
-
-#: mod/invite.php:140 mod/localtime.php:45 mod/message.php:357
-#: mod/message.php:547 mod/manage.php:143 mod/crepair.php:154
-#: mod/content.php:728 mod/fsuggest.php:107 mod/mood.php:137 mod/poke.php:199
-#: mod/profiles.php:688 mod/events.php:506 mod/photos.php:1104
-#: mod/photos.php:1226 mod/photos.php:1539 mod/photos.php:1590
-#: mod/photos.php:1638 mod/photos.php:1724 mod/contacts.php:577
-#: mod/install.php:272 mod/install.php:312 object/Item.php:720
-#: view/theme/frio/config.php:59 view/theme/quattro/config.php:64
-#: view/theme/vier/config.php:107 view/theme/duepuntozero/config.php:59
-msgid "Submit"
-msgstr ""
-
-#: mod/fbrowser.php:133
-msgid "Files"
-msgstr ""
-
-#: mod/profperm.php:19 mod/group.php:72 index.php:400
-msgid "Permission denied"
-msgstr ""
-
-#: mod/profperm.php:25 mod/profperm.php:56
-msgid "Invalid profile identifier."
-msgstr ""
-
-#: mod/profperm.php:102
-msgid "Profile Visibility Editor"
-msgstr ""
-
-#: mod/profperm.php:106 mod/group.php:223
-msgid "Click on a contact to add or remove."
-msgstr ""
-
-#: mod/profperm.php:115
-msgid "Visible To"
-msgstr ""
-
-#: mod/profperm.php:131
-msgid "All Contacts (with secure profile access)"
-msgstr ""
-
-#: mod/tagrm.php:41
-msgid "Tag removed"
-msgstr ""
-
-#: mod/tagrm.php:79
-msgid "Remove Item Tag"
-msgstr ""
-
-#: mod/tagrm.php:81
-msgid "Select a tag to remove: "
-msgstr ""
-
-#: mod/tagrm.php:93 mod/delegate.php:139
-msgid "Remove"
-msgstr ""
-
-#: mod/repair_ostatus.php:14
-msgid "Resubscribing to OStatus contacts"
-msgstr ""
-
-#: mod/repair_ostatus.php:30
-msgid "Error"
-msgstr ""
-
-#: mod/repair_ostatus.php:44 mod/ostatus_subscribe.php:51
-msgid "Done"
-msgstr ""
-
-#: mod/repair_ostatus.php:50 mod/ostatus_subscribe.php:73
-msgid "Keep this window open until done."
-msgstr ""
-
-#: mod/delegate.php:101
-msgid "No potential page delegates located."
-msgstr ""
-
-#: mod/delegate.php:132
-msgid ""
-"Delegates are able to manage all aspects of this account/page except for "
-"basic account settings. Please do not delegate your personal account to "
-"anybody that you do not trust completely."
-msgstr ""
-
-#: mod/delegate.php:133
-msgid "Existing Page Managers"
-msgstr ""
-
-#: mod/delegate.php:135
-msgid "Existing Page Delegates"
-msgstr ""
-
-#: mod/delegate.php:137
-msgid "Potential Delegates"
-msgstr ""
-
-#: mod/delegate.php:140
-msgid "Add"
-msgstr ""
-
-#: mod/delegate.php:141
-msgid "No entries."
-msgstr ""
-
-#: mod/credits.php:16
-msgid "Credits"
-msgstr ""
-
-#: mod/credits.php:17
-msgid ""
-"Friendica is a community project, that would not be possible without the "
-"help of many people. Here is a list of those who have contributed to the "
-"code or the translation of Friendica. Thank you all!"
-msgstr ""
-
-#: mod/filer.php:30
-msgid "- select -"
-msgstr ""
-
-#: mod/subthread.php:103
-#, php-format
-msgid "%1$s is following %2$s's %3$s"
-msgstr ""
-
-#: mod/attach.php:8
-msgid "Item not available."
-msgstr ""
-
-#: mod/attach.php:20
-msgid "Item was not found."
-msgstr ""
-
-#: mod/apps.php:7 index.php:244
-msgid "You must be logged in to use addons. "
-msgstr ""
-
-#: mod/apps.php:11
-msgid "Applications"
-msgstr ""
-
-#: mod/apps.php:14
-msgid "No installed applications."
-msgstr ""
-
-#: mod/p.php:9
-msgid "Not Extended"
+#: mod/mood.php:135
+msgid "Set your current mood and tell your friends"
 msgstr ""
 
 #: mod/newmember.php:6
@@ -3722,7 +4062,7 @@ msgid ""
 "potential friends know exactly how to find you."
 msgstr ""
 
-#: mod/newmember.php:36 mod/profile_photo.php:250 mod/profiles.php:707
+#: mod/newmember.php:36 mod/profile_photo.php:256 mod/profiles.php:699
 msgid "Upload Profile Photo"
 msgstr ""
 
@@ -3841,235 +4181,39 @@ msgid ""
 "features and resources."
 msgstr ""
 
-#: mod/removeme.php:46 mod/removeme.php:49
-msgid "Remove My Account"
+#: mod/nogroup.php:43 mod/contacts.php:594 mod/contacts.php:938
+#: mod/viewcontacts.php:102
+#, php-format
+msgid "Visit %s's profile [%s]"
 msgstr ""
 
-#: mod/removeme.php:47
+#: mod/nogroup.php:44 mod/contacts.php:939
+msgid "Edit contact"
+msgstr ""
+
+#: mod/nogroup.php:65
+msgid "Contacts who are not members of a group"
+msgstr ""
+
+#: mod/notify.php:65
+msgid "No more system notifications."
+msgstr ""
+
+#: mod/notify.php:69 mod/notifications.php:111
+msgid "System Notifications"
+msgstr ""
+
+#: mod/oexchange.php:21
+msgid "Post successful."
+msgstr ""
+
+#: mod/openid.php:24
+msgid "OpenID protocol error. No ID returned."
+msgstr ""
+
+#: mod/openid.php:60
 msgid ""
-"This will completely remove your account. Once this has been done it is not "
-"recoverable."
-msgstr ""
-
-#: mod/removeme.php:48
-msgid "Please enter your password for verification:"
-msgstr ""
-
-#: mod/editpost.php:17 mod/editpost.php:27
-msgid "Item not found"
-msgstr ""
-
-#: mod/editpost.php:40
-msgid "Edit post"
-msgstr ""
-
-#: mod/localtime.php:24
-msgid "Time Conversion"
-msgstr ""
-
-#: mod/localtime.php:26
-msgid ""
-"Friendica provides this service for sharing events with other networks and "
-"friends in unknown timezones."
-msgstr ""
-
-#: mod/localtime.php:30
-#, php-format
-msgid "UTC time: %s"
-msgstr ""
-
-#: mod/localtime.php:33
-#, php-format
-msgid "Current timezone: %s"
-msgstr ""
-
-#: mod/localtime.php:36
-#, php-format
-msgid "Converted localtime: %s"
-msgstr ""
-
-#: mod/localtime.php:41
-msgid "Please select your timezone:"
-msgstr ""
-
-#: mod/bookmarklet.php:41
-msgid "The post was created"
-msgstr ""
-
-#: mod/group.php:29
-msgid "Group created."
-msgstr ""
-
-#: mod/group.php:35
-msgid "Could not create group."
-msgstr ""
-
-#: mod/group.php:47 mod/group.php:140
-msgid "Group not found."
-msgstr ""
-
-#: mod/group.php:60
-msgid "Group name changed."
-msgstr ""
-
-#: mod/group.php:87
-msgid "Save Group"
-msgstr ""
-
-#: mod/group.php:93
-msgid "Create a group of contacts/friends."
-msgstr ""
-
-#: mod/group.php:113
-msgid "Group removed."
-msgstr ""
-
-#: mod/group.php:115
-msgid "Unable to remove group."
-msgstr ""
-
-#: mod/group.php:177
-msgid "Group Editor"
-msgstr ""
-
-#: mod/group.php:190
-msgid "Members"
-msgstr ""
-
-#: mod/group.php:192 mod/contacts.php:692
-msgid "All Contacts"
-msgstr ""
-
-#: mod/group.php:193 mod/content.php:130 mod/network.php:496
-msgid "Group is empty"
-msgstr ""
-
-#: mod/wallmessage.php:42 mod/wallmessage.php:112
-#, php-format
-msgid "Number of daily wall messages for %s exceeded. Message failed."
-msgstr ""
-
-#: mod/wallmessage.php:56 mod/message.php:71
-msgid "No recipient selected."
-msgstr ""
-
-#: mod/wallmessage.php:59
-msgid "Unable to check your home location."
-msgstr ""
-
-#: mod/wallmessage.php:62 mod/message.php:78
-msgid "Message could not be sent."
-msgstr ""
-
-#: mod/wallmessage.php:65 mod/message.php:81
-msgid "Message collection failure."
-msgstr ""
-
-#: mod/wallmessage.php:68 mod/message.php:84
-msgid "Message sent."
-msgstr ""
-
-#: mod/wallmessage.php:86 mod/wallmessage.php:95
-msgid "No recipient."
-msgstr ""
-
-#: mod/wallmessage.php:142 mod/message.php:341
-msgid "Send Private Message"
-msgstr ""
-
-#: mod/wallmessage.php:143
-#, php-format
-msgid ""
-"If you wish for %s to respond, please check that the privacy settings on "
-"your site allow private mail from unknown senders."
-msgstr ""
-
-#: mod/wallmessage.php:144 mod/message.php:342 mod/message.php:536
-msgid "To:"
-msgstr ""
-
-#: mod/wallmessage.php:145 mod/message.php:347 mod/message.php:538
-msgid "Subject:"
-msgstr ""
-
-#: mod/share.php:38
-msgid "link"
-msgstr ""
-
-#: mod/api.php:76 mod/api.php:102
-msgid "Authorize application connection"
-msgstr ""
-
-#: mod/api.php:77
-msgid "Return to your app and insert this Securty Code:"
-msgstr ""
-
-#: mod/api.php:89
-msgid "Please login to continue."
-msgstr ""
-
-#: mod/api.php:104
-msgid ""
-"Do you want to authorize this application to access your posts and contacts, "
-"and/or create new posts for you?"
-msgstr ""
-
-#: mod/api.php:106 mod/profiles.php:648 mod/profiles.php:652
-#: mod/profiles.php:677 mod/register.php:246 mod/settings.php:1163
-#: mod/settings.php:1169 mod/settings.php:1177 mod/settings.php:1181
-#: mod/settings.php:1186 mod/settings.php:1192 mod/settings.php:1198
-#: mod/settings.php:1204 mod/settings.php:1230 mod/settings.php:1231
-#: mod/settings.php:1232 mod/settings.php:1233 mod/settings.php:1234
-#: mod/dfrn_request.php:862 mod/follow.php:110
-msgid "No"
-msgstr ""
-
-#: mod/babel.php:17
-msgid "Source (bbcode) text:"
-msgstr ""
-
-#: mod/babel.php:23
-msgid "Source (Diaspora) text to convert to BBcode:"
-msgstr ""
-
-#: mod/babel.php:31
-msgid "Source input: "
-msgstr ""
-
-#: mod/babel.php:35
-msgid "bb2html (raw HTML): "
-msgstr ""
-
-#: mod/babel.php:39
-msgid "bb2html: "
-msgstr ""
-
-#: mod/babel.php:43
-msgid "bb2html2bb: "
-msgstr ""
-
-#: mod/babel.php:47
-msgid "bb2md: "
-msgstr ""
-
-#: mod/babel.php:51
-msgid "bb2md2html: "
-msgstr ""
-
-#: mod/babel.php:55
-msgid "bb2dia2bb: "
-msgstr ""
-
-#: mod/babel.php:59
-msgid "bb2md2html2bb: "
-msgstr ""
-
-#: mod/babel.php:69
-msgid "Source input (Diaspora format): "
-msgstr ""
-
-#: mod/babel.php:74
-msgid "diaspora2bb: "
+"Account not found and OpenID registration is not permitted on this site."
 msgstr ""
 
 #: mod/ostatus_subscribe.php:14
@@ -4080,614 +4224,2596 @@ msgstr ""
 msgid "No contact provided."
 msgstr ""
 
-#: mod/ostatus_subscribe.php:30
+#: mod/ostatus_subscribe.php:31
 msgid "Couldn't fetch information for contact."
 msgstr ""
 
-#: mod/ostatus_subscribe.php:38
+#: mod/ostatus_subscribe.php:40
 msgid "Couldn't fetch friends for contact."
 msgstr ""
 
-#: mod/ostatus_subscribe.php:65
+#: mod/ostatus_subscribe.php:54 mod/repair_ostatus.php:44
+msgid "Done"
+msgstr ""
+
+#: mod/ostatus_subscribe.php:68
 msgid "success"
 msgstr ""
 
-#: mod/ostatus_subscribe.php:67
+#: mod/ostatus_subscribe.php:70
 msgid "failed"
 msgstr ""
 
-#: mod/ostatus_subscribe.php:69 mod/content.php:792 object/Item.php:245
-msgid "ignored"
+#: mod/ostatus_subscribe.php:78 mod/repair_ostatus.php:50
+msgid "Keep this window open until done."
 msgstr ""
 
-#: mod/dfrn_poll.php:104 mod/dfrn_poll.php:537
-#, php-format
-msgid "%1$s welcomes %2$s"
-msgstr ""
-
-#: mod/message.php:75
-msgid "Unable to locate contact information."
-msgstr ""
-
-#: mod/message.php:215
-msgid "Do you really want to delete this message?"
-msgstr ""
-
-#: mod/message.php:235
-msgid "Message deleted."
-msgstr ""
-
-#: mod/message.php:266
-msgid "Conversation removed."
-msgstr ""
-
-#: mod/message.php:383
-msgid "No messages."
-msgstr ""
-
-#: mod/message.php:426
-msgid "Message not available."
-msgstr ""
-
-#: mod/message.php:503
-msgid "Delete message"
-msgstr ""
-
-#: mod/message.php:529 mod/message.php:609
-msgid "Delete conversation"
-msgstr ""
-
-#: mod/message.php:531
-msgid ""
-"No secure communications available. You <strong>may</strong> be able to "
-"respond from the sender's profile page."
-msgstr ""
-
-#: mod/message.php:535
-msgid "Send Reply"
-msgstr ""
-
-#: mod/message.php:579
-#, php-format
-msgid "Unknown sender - %s"
-msgstr ""
-
-#: mod/message.php:581
-#, php-format
-msgid "You and %s"
-msgstr ""
-
-#: mod/message.php:583
-#, php-format
-msgid "%s and You"
-msgstr ""
-
-#: mod/message.php:612
-msgid "D, d M Y - g:i A"
-msgstr ""
-
-#: mod/message.php:615
-#, php-format
-msgid "%d message"
-msgid_plural "%d messages"
-msgstr[0] ""
-msgstr[1] ""
-
-#: mod/manage.php:139
-msgid "Manage Identities and/or Pages"
-msgstr ""
-
-#: mod/manage.php:140
-msgid ""
-"Toggle between different identities or community/group pages which share "
-"your account details or which you have been granted \"manage\" permissions"
-msgstr ""
-
-#: mod/manage.php:141
-msgid "Select an identity to manage: "
-msgstr ""
-
-#: mod/crepair.php:87
-msgid "Contact settings applied."
-msgstr ""
-
-#: mod/crepair.php:89
-msgid "Contact update failed."
-msgstr ""
-
-#: mod/crepair.php:114 mod/fsuggest.php:20 mod/fsuggest.php:92
-#: mod/dfrn_confirm.php:126
-msgid "Contact not found."
-msgstr ""
-
-#: mod/crepair.php:120
-msgid ""
-"<strong>WARNING: This is highly advanced</strong> and if you enter incorrect "
-"information your communications with this contact may stop working."
-msgstr ""
-
-#: mod/crepair.php:121
-msgid ""
-"Please use your browser 'Back' button <strong>now</strong> if you are "
-"uncertain what to do on this page."
-msgstr ""
-
-#: mod/crepair.php:134 mod/crepair.php:136
-msgid "No mirroring"
-msgstr ""
-
-#: mod/crepair.php:134
-msgid "Mirror as forwarded posting"
-msgstr ""
-
-#: mod/crepair.php:134 mod/crepair.php:136
-msgid "Mirror as my own posting"
-msgstr ""
-
-#: mod/crepair.php:150
-msgid "Return to contact editor"
-msgstr ""
-
-#: mod/crepair.php:152
-msgid "Refetch contact data"
-msgstr ""
-
-#: mod/crepair.php:156
-msgid "Remote Self"
-msgstr ""
-
-#: mod/crepair.php:159
-msgid "Mirror postings from this contact"
-msgstr ""
-
-#: mod/crepair.php:161
-msgid ""
-"Mark this contact as remote_self, this will cause friendica to repost new "
-"entries from this contact."
-msgstr ""
-
-#: mod/crepair.php:165 mod/settings.php:680 mod/settings.php:706
-#: mod/admin.php:1396 mod/admin.php:1409 mod/admin.php:1422 mod/admin.php:1438
-msgid "Name"
-msgstr ""
-
-#: mod/crepair.php:166
-msgid "Account Nickname"
-msgstr ""
-
-#: mod/crepair.php:167
-msgid "@Tagname - overrides Name/Nickname"
-msgstr ""
-
-#: mod/crepair.php:168
-msgid "Account URL"
-msgstr ""
-
-#: mod/crepair.php:169
-msgid "Friend Request URL"
-msgstr ""
-
-#: mod/crepair.php:170
-msgid "Friend Confirm URL"
-msgstr ""
-
-#: mod/crepair.php:171
-msgid "Notification Endpoint URL"
-msgstr ""
-
-#: mod/crepair.php:172
-msgid "Poll/Feed URL"
-msgstr ""
-
-#: mod/crepair.php:173
-msgid "New photo from this URL"
-msgstr ""
-
-#: mod/content.php:119 mod/network.php:469
-msgid "No such group"
-msgstr ""
-
-#: mod/content.php:135 mod/network.php:500
-#, php-format
-msgid "Group: %s"
-msgstr ""
-
-#: mod/content.php:325 object/Item.php:95
-msgid "This entry was edited"
-msgstr ""
-
-#: mod/content.php:621 object/Item.php:429
-#, php-format
-msgid "%d comment"
-msgid_plural "%d comments"
-msgstr[0] ""
-msgstr[1] ""
-
-#: mod/content.php:638 mod/photos.php:1379 object/Item.php:117
-msgid "Private Message"
-msgstr ""
-
-#: mod/content.php:702 mod/photos.php:1567 object/Item.php:263
-msgid "I like this (toggle)"
-msgstr ""
-
-#: mod/content.php:702 object/Item.php:263
-msgid "like"
-msgstr ""
-
-#: mod/content.php:703 mod/photos.php:1568 object/Item.php:264
-msgid "I don't like this (toggle)"
-msgstr ""
-
-#: mod/content.php:703 object/Item.php:264
-msgid "dislike"
-msgstr ""
-
-#: mod/content.php:705 object/Item.php:266
-msgid "Share this"
-msgstr ""
-
-#: mod/content.php:705 object/Item.php:266
-msgid "share"
-msgstr ""
-
-#: mod/content.php:725 mod/photos.php:1587 mod/photos.php:1635
-#: mod/photos.php:1721 object/Item.php:717
-msgid "This is you"
-msgstr ""
-
-#: mod/content.php:727 mod/content.php:945 mod/photos.php:1589
-#: mod/photos.php:1637 mod/photos.php:1723 object/Item.php:403
-#: object/Item.php:719 boot.php:971
-msgid "Comment"
-msgstr ""
-
-#: mod/content.php:729 object/Item.php:721
-msgid "Bold"
-msgstr ""
-
-#: mod/content.php:730 object/Item.php:722
-msgid "Italic"
-msgstr ""
-
-#: mod/content.php:731 object/Item.php:723
-msgid "Underline"
-msgstr ""
-
-#: mod/content.php:732 object/Item.php:724
-msgid "Quote"
-msgstr ""
-
-#: mod/content.php:733 object/Item.php:725
-msgid "Code"
-msgstr ""
-
-#: mod/content.php:734 object/Item.php:726
-msgid "Image"
-msgstr ""
-
-#: mod/content.php:735 object/Item.php:727
-msgid "Link"
-msgstr ""
-
-#: mod/content.php:736 object/Item.php:728
-msgid "Video"
-msgstr ""
-
-#: mod/content.php:746 mod/settings.php:740 object/Item.php:122
-#: object/Item.php:124
-msgid "Edit"
-msgstr ""
-
-#: mod/content.php:771 object/Item.php:227
-msgid "add star"
-msgstr ""
-
-#: mod/content.php:772 object/Item.php:228
-msgid "remove star"
-msgstr ""
-
-#: mod/content.php:773 object/Item.php:229
-msgid "toggle star status"
-msgstr ""
-
-#: mod/content.php:776 object/Item.php:232
-msgid "starred"
-msgstr ""
-
-#: mod/content.php:777 mod/content.php:798 object/Item.php:252
-msgid "add tag"
-msgstr ""
-
-#: mod/content.php:787 object/Item.php:240
-msgid "ignore thread"
-msgstr ""
-
-#: mod/content.php:788 object/Item.php:241
-msgid "unignore thread"
-msgstr ""
-
-#: mod/content.php:789 object/Item.php:242
-msgid "toggle ignore status"
-msgstr ""
-
-#: mod/content.php:803 object/Item.php:137
-msgid "save to folder"
-msgstr ""
-
-#: mod/content.php:848 object/Item.php:201
-msgid "I will attend"
-msgstr ""
-
-#: mod/content.php:848 object/Item.php:201
-msgid "I will not attend"
-msgstr ""
-
-#: mod/content.php:848 object/Item.php:201
-msgid "I might attend"
-msgstr ""
-
-#: mod/content.php:912 object/Item.php:369
-msgid "to"
-msgstr ""
-
-#: mod/content.php:913 object/Item.php:371
-msgid "Wall-to-Wall"
-msgstr ""
-
-#: mod/content.php:914 object/Item.php:372
-msgid "via Wall-To-Wall:"
-msgstr ""
-
-#: mod/fsuggest.php:63
-msgid "Friend suggestion sent."
-msgstr ""
-
-#: mod/fsuggest.php:97
-msgid "Suggest Friends"
-msgstr ""
-
-#: mod/fsuggest.php:99
-#, php-format
-msgid "Suggest a friend for %s"
-msgstr ""
-
-#: mod/mood.php:133
-msgid "Mood"
-msgstr ""
-
-#: mod/mood.php:134
-msgid "Set your current mood and tell your friends"
-msgstr ""
-
-#: mod/poke.php:192
+#: mod/poke.php:196
 msgid "Poke/Prod"
 msgstr ""
 
-#: mod/poke.php:193
+#: mod/poke.php:197
 msgid "poke, prod or do other things to somebody"
 msgstr ""
 
-#: mod/poke.php:194
+#: mod/poke.php:198
 msgid "Recipient"
 msgstr ""
 
-#: mod/poke.php:195
+#: mod/poke.php:199
 msgid "Choose what you wish to do to recipient"
 msgstr ""
 
-#: mod/poke.php:198
+#: mod/poke.php:202
 msgid "Make this post private"
+msgstr ""
+
+#: mod/profile.php:154 mod/cal.php:143 mod/display.php:328
+msgid "Access to this profile has been restricted."
+msgstr ""
+
+#: mod/profile.php:174
+msgid "Tips for New Members"
 msgstr ""
 
 #: mod/profile_photo.php:44
 msgid "Image uploaded but image cropping failed."
 msgstr ""
 
-#: mod/profile_photo.php:77 mod/profile_photo.php:84 mod/profile_photo.php:91
-#: mod/profile_photo.php:314
+#: mod/profile_photo.php:77 mod/profile_photo.php:85 mod/profile_photo.php:93
+#: mod/profile_photo.php:323
 #, php-format
 msgid "Image size reduction [%s] failed."
 msgstr ""
 
-#: mod/profile_photo.php:124
+#: mod/profile_photo.php:127
 msgid ""
 "Shift-reload the page or clear browser cache if the new photo does not "
 "display immediately."
 msgstr ""
 
-#: mod/profile_photo.php:134
+#: mod/profile_photo.php:137
 msgid "Unable to process image"
 msgstr ""
 
-#: mod/profile_photo.php:150 mod/photos.php:786 mod/wall_upload.php:151
+#: mod/profile_photo.php:156 mod/wall_upload.php:151 mod/photos.php:803
 #, php-format
 msgid "Image exceeds size limit of %s"
 msgstr ""
 
-#: mod/profile_photo.php:159 mod/photos.php:826 mod/wall_upload.php:188
+#: mod/profile_photo.php:165 mod/wall_upload.php:186 mod/photos.php:844
 msgid "Unable to process image."
 msgstr ""
 
-#: mod/profile_photo.php:248
+#: mod/profile_photo.php:254
 msgid "Upload File:"
 msgstr ""
 
-#: mod/profile_photo.php:249
+#: mod/profile_photo.php:255
 msgid "Select a profile:"
 msgstr ""
 
-#: mod/profile_photo.php:251
+#: mod/profile_photo.php:257
 msgid "Upload"
 msgstr ""
 
-#: mod/profile_photo.php:254
+#: mod/profile_photo.php:260
 msgid "or"
 msgstr ""
 
-#: mod/profile_photo.php:254
+#: mod/profile_photo.php:260
 msgid "skip this step"
 msgstr ""
 
-#: mod/profile_photo.php:254
+#: mod/profile_photo.php:260
 msgid "select a photo from your photo albums"
 msgstr ""
 
-#: mod/profile_photo.php:268
+#: mod/profile_photo.php:274
 msgid "Crop Image"
 msgstr ""
 
-#: mod/profile_photo.php:269
+#: mod/profile_photo.php:275
 msgid "Please adjust the image cropping for optimum viewing."
 msgstr ""
 
-#: mod/profile_photo.php:271
+#: mod/profile_photo.php:277
 msgid "Done Editing"
 msgstr ""
 
-#: mod/profile_photo.php:305
+#: mod/profile_photo.php:313
 msgid "Image uploaded successfully."
 msgstr ""
 
-#: mod/profile_photo.php:307 mod/photos.php:853 mod/wall_upload.php:221
+#: mod/profile_photo.php:315 mod/wall_upload.php:219 mod/photos.php:871
 msgid "Image upload failed."
 msgstr ""
 
-#: mod/regmod.php:55
+#: mod/profperm.php:26 mod/profperm.php:57
+msgid "Invalid profile identifier."
+msgstr ""
+
+#: mod/profperm.php:103
+msgid "Profile Visibility Editor"
+msgstr ""
+
+#: mod/profperm.php:116
+msgid "Visible To"
+msgstr ""
+
+#: mod/profperm.php:132
+msgid "All Contacts (with secure profile access)"
+msgstr ""
+
+#: mod/register.php:93
+msgid ""
+"Registration successful. Please check your email for further instructions."
+msgstr ""
+
+#: mod/register.php:98
+#, php-format
+msgid ""
+"Failed to send email message. Here your accout details:<br> login: %s<br> "
+"password: %s<br><br>You can change your password after login."
+msgstr ""
+
+#: mod/register.php:105
+msgid "Registration successful."
+msgstr ""
+
+#: mod/register.php:111
+msgid "Your registration can not be processed."
+msgstr ""
+
+#: mod/register.php:160
+msgid "Your registration is pending approval by the site owner."
+msgstr ""
+
+#: mod/register.php:198 mod/uimport.php:51
+msgid ""
+"This site has exceeded the number of allowed daily account registrations. "
+"Please try again tomorrow."
+msgstr ""
+
+#: mod/register.php:226
+msgid ""
+"You may (optionally) fill in this form via OpenID by supplying your OpenID "
+"and clicking 'Register'."
+msgstr ""
+
+#: mod/register.php:227
+msgid ""
+"If you are not familiar with OpenID, please leave that field blank and fill "
+"in the rest of the items."
+msgstr ""
+
+#: mod/register.php:228
+msgid "Your OpenID (optional): "
+msgstr ""
+
+#: mod/register.php:242
+msgid "Include your profile in member directory?"
+msgstr ""
+
+#: mod/register.php:267
+msgid "Note for the admin"
+msgstr ""
+
+#: mod/register.php:267
+msgid "Leave a message for the admin, why you want to join this node"
+msgstr ""
+
+#: mod/register.php:268
+msgid "Membership on this site is by invitation only."
+msgstr ""
+
+#: mod/register.php:269
+msgid "Your invitation ID: "
+msgstr ""
+
+#: mod/register.php:272 mod/admin.php:977
+msgid "Registration"
+msgstr ""
+
+#: mod/register.php:280
+msgid "Your Full Name (e.g. Joe Smith, real or real-looking): "
+msgstr ""
+
+#: mod/register.php:281
+msgid "Your Email Address: "
+msgstr ""
+
+#: mod/register.php:283 mod/settings.php:1278
+msgid "New Password:"
+msgstr ""
+
+#: mod/register.php:283
+msgid "Leave empty for an auto generated password."
+msgstr ""
+
+#: mod/register.php:284 mod/settings.php:1279
+msgid "Confirm:"
+msgstr ""
+
+#: mod/register.php:285
+msgid ""
+"Choose a profile nickname. This must begin with a text character. Your "
+"profile address on this site will then be '<strong>nickname@$sitename</"
+"strong>'."
+msgstr ""
+
+#: mod/register.php:286
+msgid "Choose a nickname: "
+msgstr ""
+
+#: mod/register.php:295 mod/uimport.php:66
+msgid "Import"
+msgstr ""
+
+#: mod/register.php:296
+msgid "Import your profile to this friendica instance"
+msgstr ""
+
+#: mod/regmod.php:58
 msgid "Account approved."
 msgstr ""
 
-#: mod/regmod.php:92
+#: mod/regmod.php:95
 #, php-format
 msgid "Registration revoked for %s"
 msgstr ""
 
-#: mod/regmod.php:104
+#: mod/regmod.php:107
 msgid "Please login."
 msgstr ""
 
-#: mod/notifications.php:35
-msgid "Invalid request identifier."
+#: mod/removeme.php:52 mod/removeme.php:55
+msgid "Remove My Account"
 msgstr ""
 
-#: mod/notifications.php:44 mod/notifications.php:180
-#: mod/notifications.php:252
-msgid "Discard"
+#: mod/removeme.php:53
+msgid ""
+"This will completely remove your account. Once this has been done it is not "
+"recoverable."
 msgstr ""
 
+#: mod/removeme.php:54
+msgid "Please enter your password for verification:"
+msgstr ""
+
+#: mod/repair_ostatus.php:14
+msgid "Resubscribing to OStatus contacts"
+msgstr ""
+
+#: mod/repair_ostatus.php:30
+msgid "Error"
+msgstr ""
+
+#: mod/settings.php:36 mod/photos.php:107
+msgid "everybody"
+msgstr ""
+
+#: mod/settings.php:43 mod/admin.php:1417
+msgid "Account"
+msgstr ""
+
+#: mod/settings.php:52 mod/admin.php:161
+msgid "Additional features"
+msgstr ""
+
+#: mod/settings.php:60
+msgid "Display"
+msgstr ""
+
+#: mod/settings.php:67 mod/settings.php:890
+msgid "Social Networks"
+msgstr ""
+
+#: mod/settings.php:74 mod/admin.php:159 mod/admin.php:1543 mod/admin.php:1606
+msgid "Plugins"
+msgstr ""
+
+#: mod/settings.php:88
+msgid "Connected apps"
+msgstr ""
+
+#: mod/settings.php:95 mod/uexport.php:45
+msgid "Export personal data"
+msgstr ""
+
+#: mod/settings.php:102
+msgid "Remove account"
+msgstr ""
+
+#: mod/settings.php:157
+msgid "Missing some important data!"
+msgstr ""
+
+#: mod/settings.php:160 mod/settings.php:707 mod/contacts.php:812
+msgid "Update"
+msgstr ""
+
+#: mod/settings.php:271
+msgid "Failed to connect with email account using the settings provided."
+msgstr ""
+
+#: mod/settings.php:276
+msgid "Email settings updated."
+msgstr ""
+
+#: mod/settings.php:291
+msgid "Features updated"
+msgstr ""
+
+#: mod/settings.php:361
+msgid "Relocate message has been send to your contacts"
+msgstr ""
+
+#: mod/settings.php:380
+msgid "Empty passwords are not allowed. Password unchanged."
+msgstr ""
+
+#: mod/settings.php:388
+msgid "Wrong password."
+msgstr ""
+
+#: mod/settings.php:399
+msgid "Password changed."
+msgstr ""
+
+#: mod/settings.php:401
+msgid "Password update failed. Please try again."
+msgstr ""
+
+#: mod/settings.php:481
+msgid " Please use a shorter name."
+msgstr ""
+
+#: mod/settings.php:483
+msgid " Name too short."
+msgstr ""
+
+#: mod/settings.php:492
+msgid "Wrong Password"
+msgstr ""
+
+#: mod/settings.php:497
+msgid " Not valid email."
+msgstr ""
+
+#: mod/settings.php:503
+msgid " Cannot change to that email."
+msgstr ""
+
+#: mod/settings.php:559
+msgid "Private forum has no privacy permissions. Using default privacy group."
+msgstr ""
+
+#: mod/settings.php:563
+msgid "Private forum has no privacy permissions and no default privacy group."
+msgstr ""
+
+#: mod/settings.php:603
+msgid "Settings updated."
+msgstr ""
+
+#: mod/settings.php:680 mod/settings.php:706 mod/settings.php:742
+msgid "Add application"
+msgstr ""
+
+#: mod/settings.php:681 mod/settings.php:792 mod/settings.php:841
+#: mod/settings.php:908 mod/settings.php:1005 mod/settings.php:1271
+#: mod/admin.php:976 mod/admin.php:1607 mod/admin.php:1864 mod/admin.php:1938
+#: mod/admin.php:2088
+msgid "Save Settings"
+msgstr ""
+
+#: mod/settings.php:684 mod/settings.php:710
+msgid "Consumer Key"
+msgstr ""
+
+#: mod/settings.php:685 mod/settings.php:711
+msgid "Consumer Secret"
+msgstr ""
+
+#: mod/settings.php:686 mod/settings.php:712
+msgid "Redirect"
+msgstr ""
+
+#: mod/settings.php:687 mod/settings.php:713
+msgid "Icon url"
+msgstr ""
+
+#: mod/settings.php:698
+msgid "You can't edit this application."
+msgstr ""
+
+#: mod/settings.php:741
+msgid "Connected Apps"
+msgstr ""
+
+#: mod/settings.php:745
+msgid "Client key starts with"
+msgstr ""
+
+#: mod/settings.php:746
+msgid "No name"
+msgstr ""
+
+#: mod/settings.php:747
+msgid "Remove authorization"
+msgstr ""
+
+#: mod/settings.php:759
+msgid "No Plugin settings configured"
+msgstr ""
+
+#: mod/settings.php:768
+msgid "Plugin Settings"
+msgstr ""
+
+#: mod/settings.php:782 mod/admin.php:2077 mod/admin.php:2078
+msgid "Off"
+msgstr ""
+
+#: mod/settings.php:782 mod/admin.php:2077 mod/admin.php:2078
+msgid "On"
+msgstr ""
+
+#: mod/settings.php:790
+msgid "Additional Features"
+msgstr ""
+
+#: mod/settings.php:800 mod/settings.php:804
+msgid "General Social Media Settings"
+msgstr ""
+
+#: mod/settings.php:810
+msgid "Disable intelligent shortening"
+msgstr ""
+
+#: mod/settings.php:812
+msgid ""
+"Normally the system tries to find the best link to add to shortened posts. "
+"If this option is enabled then every shortened post will always point to the "
+"original friendica post."
+msgstr ""
+
+#: mod/settings.php:818
+msgid "Automatically follow any GNU Social (OStatus) followers/mentioners"
+msgstr ""
+
+#: mod/settings.php:820
+msgid ""
+"If you receive a message from an unknown OStatus user, this option decides "
+"what to do. If it is checked, a new contact will be created for every "
+"unknown user."
+msgstr ""
+
+#: mod/settings.php:826
+msgid "Default group for OStatus contacts"
+msgstr ""
+
+#: mod/settings.php:834
+msgid "Your legacy GNU Social account"
+msgstr ""
+
+#: mod/settings.php:836
+msgid ""
+"If you enter your old GNU Social/Statusnet account name here (in the format "
+"user@domain.tld), your contacts will be added automatically. The field will "
+"be emptied when done."
+msgstr ""
+
+#: mod/settings.php:839
+msgid "Repair OStatus subscriptions"
+msgstr ""
+
+#: mod/settings.php:848 mod/settings.php:849
+#, php-format
+msgid "Built-in support for %s connectivity is %s"
+msgstr ""
+
+#: mod/settings.php:848 mod/settings.php:849
+msgid "enabled"
+msgstr ""
+
+#: mod/settings.php:848 mod/settings.php:849
+msgid "disabled"
+msgstr ""
+
+#: mod/settings.php:849
+msgid "GNU Social (OStatus)"
+msgstr ""
+
+#: mod/settings.php:883
+msgid "Email access is disabled on this site."
+msgstr ""
+
+#: mod/settings.php:895
+msgid "Email/Mailbox Setup"
+msgstr ""
+
+#: mod/settings.php:896
+msgid ""
+"If you wish to communicate with email contacts using this service "
+"(optional), please specify how to connect to your mailbox."
+msgstr ""
+
+#: mod/settings.php:897
+msgid "Last successful email check:"
+msgstr ""
+
+#: mod/settings.php:899
+msgid "IMAP server name:"
+msgstr ""
+
+#: mod/settings.php:900
+msgid "IMAP port:"
+msgstr ""
+
+#: mod/settings.php:901
+msgid "Security:"
+msgstr ""
+
+#: mod/settings.php:901 mod/settings.php:906
+msgid "None"
+msgstr ""
+
+#: mod/settings.php:902
+msgid "Email login name:"
+msgstr ""
+
+#: mod/settings.php:903
+msgid "Email password:"
+msgstr ""
+
+#: mod/settings.php:904
+msgid "Reply-to address:"
+msgstr ""
+
+#: mod/settings.php:905
+msgid "Send public posts to all email contacts:"
+msgstr ""
+
+#: mod/settings.php:906
+msgid "Action after import:"
+msgstr ""
+
+#: mod/settings.php:906
+msgid "Move to folder"
+msgstr ""
+
+#: mod/settings.php:907
+msgid "Move to folder:"
+msgstr ""
+
+#: mod/settings.php:943 mod/admin.php:863
+msgid "No special theme for mobile devices"
+msgstr ""
+
+#: mod/settings.php:1003
+msgid "Display Settings"
+msgstr ""
+
+#: mod/settings.php:1009 mod/settings.php:1032
+msgid "Display Theme:"
+msgstr ""
+
+#: mod/settings.php:1010
+msgid "Mobile Theme:"
+msgstr ""
+
+#: mod/settings.php:1011
+msgid "Suppress warning of insecure networks"
+msgstr ""
+
+#: mod/settings.php:1011
+msgid ""
+"Should the system suppress the warning that the current group contains "
+"members of networks that can't receive non public postings."
+msgstr ""
+
+#: mod/settings.php:1012
+msgid "Update browser every xx seconds"
+msgstr ""
+
+#: mod/settings.php:1012
+msgid "Minimum of 10 seconds. Enter -1 to disable it."
+msgstr ""
+
+#: mod/settings.php:1013
+msgid "Number of items to display per page:"
+msgstr ""
+
+#: mod/settings.php:1013 mod/settings.php:1014
+msgid "Maximum of 100 items"
+msgstr ""
+
+#: mod/settings.php:1014
+msgid "Number of items to display per page when viewed from mobile device:"
+msgstr ""
+
+#: mod/settings.php:1015
+msgid "Don't show emoticons"
+msgstr ""
+
+#: mod/settings.php:1016
+msgid "Calendar"
+msgstr ""
+
+#: mod/settings.php:1017
+msgid "Beginning of week:"
+msgstr ""
+
+#: mod/settings.php:1018
+msgid "Don't show notices"
+msgstr ""
+
+#: mod/settings.php:1019
+msgid "Infinite scroll"
+msgstr ""
+
+#: mod/settings.php:1020
+msgid "Automatic updates only at the top of the network page"
+msgstr ""
+
+#: mod/settings.php:1021
+msgid "Bandwith Saver Mode"
+msgstr ""
+
+#: mod/settings.php:1021
+msgid ""
+"When enabled, embedded content is not displayed on automatic updates, they "
+"only show on page reload."
+msgstr ""
+
+#: mod/settings.php:1023
+msgid "General Theme Settings"
+msgstr ""
+
+#: mod/settings.php:1024
+msgid "Custom Theme Settings"
+msgstr ""
+
+#: mod/settings.php:1025
+msgid "Content Settings"
+msgstr ""
+
+#: mod/settings.php:1026 view/theme/quattro/config.php:69
+#: view/theme/vier/config.php:114 view/theme/duepuntozero/config.php:63
+#: view/theme/clean/config.php:89 view/theme/frio/config.php:66
+msgid "Theme settings"
+msgstr ""
+
+#: mod/settings.php:1110
+msgid "Account Types"
+msgstr ""
+
+#: mod/settings.php:1111
+msgid "Personal Page Subtypes"
+msgstr ""
+
+#: mod/settings.php:1112
+msgid "Community Forum Subtypes"
+msgstr ""
+
+#: mod/settings.php:1119
+msgid "Personal Page"
+msgstr ""
+
+#: mod/settings.php:1120
+msgid "This account is a regular personal profile"
+msgstr ""
+
+#: mod/settings.php:1123
+msgid "Organisation Page"
+msgstr ""
+
+#: mod/settings.php:1124
+msgid "This account is a profile for an organisation"
+msgstr ""
+
+#: mod/settings.php:1127
+msgid "News Page"
+msgstr ""
+
+#: mod/settings.php:1128
+msgid "This account is a news account/reflector"
+msgstr ""
+
+#: mod/settings.php:1131
+msgid "Community Forum"
+msgstr ""
+
+#: mod/settings.php:1132
+msgid ""
+"This account is a community forum where people can discuss with each other"
+msgstr ""
+
+#: mod/settings.php:1135
+msgid "Normal Account Page"
+msgstr ""
+
+#: mod/settings.php:1136
+msgid "This account is a normal personal profile"
+msgstr ""
+
+#: mod/settings.php:1139
+msgid "Soapbox Page"
+msgstr ""
+
+#: mod/settings.php:1140
+msgid "Automatically approve all connection/friend requests as read-only fans"
+msgstr ""
+
+#: mod/settings.php:1143
+msgid "Public Forum"
+msgstr ""
+
+#: mod/settings.php:1144
+msgid "Automatically approve all contact requests"
+msgstr ""
+
+#: mod/settings.php:1147
+msgid "Automatic Friend Page"
+msgstr ""
+
+#: mod/settings.php:1148
+msgid "Automatically approve all connection/friend requests as friends"
+msgstr ""
+
+#: mod/settings.php:1151
+msgid "Private Forum [Experimental]"
+msgstr ""
+
+#: mod/settings.php:1152
+msgid "Private forum - approved members only"
+msgstr ""
+
+#: mod/settings.php:1163
+msgid "OpenID:"
+msgstr ""
+
+#: mod/settings.php:1163
+msgid "(Optional) Allow this OpenID to login to this account."
+msgstr ""
+
+#: mod/settings.php:1171
+msgid "Publish your default profile in your local site directory?"
+msgstr ""
+
+#: mod/settings.php:1177
+msgid "Publish your default profile in the global social directory?"
+msgstr ""
+
+#: mod/settings.php:1184
+msgid "Hide your contact/friend list from viewers of your default profile?"
+msgstr ""
+
+#: mod/settings.php:1188
+msgid ""
+"If enabled, posting public messages to Diaspora and other networks isn't "
+"possible."
+msgstr ""
+
+#: mod/settings.php:1193
+msgid "Allow friends to post to your profile page?"
+msgstr ""
+
+#: mod/settings.php:1198
+msgid "Allow friends to tag your posts?"
+msgstr ""
+
+#: mod/settings.php:1203
+msgid "Allow us to suggest you as a potential friend to new members?"
+msgstr ""
+
+#: mod/settings.php:1208
+msgid "Permit unknown people to send you private mail?"
+msgstr ""
+
+#: mod/settings.php:1216
+msgid "Profile is <strong>not published</strong>."
+msgstr ""
+
+#: mod/settings.php:1224
+#, php-format
+msgid "Your Identity Address is <strong>'%s'</strong> or '%s'."
+msgstr ""
+
+#: mod/settings.php:1231
+msgid "Automatically expire posts after this many days:"
+msgstr ""
+
+#: mod/settings.php:1231
+msgid "If empty, posts will not expire. Expired posts will be deleted"
+msgstr ""
+
+#: mod/settings.php:1232
+msgid "Advanced expiration settings"
+msgstr ""
+
+#: mod/settings.php:1233
+msgid "Advanced Expiration"
+msgstr ""
+
+#: mod/settings.php:1234
+msgid "Expire posts:"
+msgstr ""
+
+#: mod/settings.php:1235
+msgid "Expire personal notes:"
+msgstr ""
+
+#: mod/settings.php:1236
+msgid "Expire starred posts:"
+msgstr ""
+
+#: mod/settings.php:1237
+msgid "Expire photos:"
+msgstr ""
+
+#: mod/settings.php:1238
+msgid "Only expire posts by others:"
+msgstr ""
+
+#: mod/settings.php:1269
+msgid "Account Settings"
+msgstr ""
+
+#: mod/settings.php:1277
+msgid "Password Settings"
+msgstr ""
+
+#: mod/settings.php:1279
+msgid "Leave password fields blank unless changing"
+msgstr ""
+
+#: mod/settings.php:1280
+msgid "Current Password:"
+msgstr ""
+
+#: mod/settings.php:1280 mod/settings.php:1281
+msgid "Your current password to confirm the changes"
+msgstr ""
+
+#: mod/settings.php:1281
+msgid "Password:"
+msgstr ""
+
+#: mod/settings.php:1285
+msgid "Basic Settings"
+msgstr ""
+
+#: mod/settings.php:1287
+msgid "Email Address:"
+msgstr ""
+
+#: mod/settings.php:1288
+msgid "Your Timezone:"
+msgstr ""
+
+#: mod/settings.php:1289
+msgid "Your Language:"
+msgstr ""
+
+#: mod/settings.php:1289
+msgid ""
+"Set the language we use to show you friendica interface and to send you "
+"emails"
+msgstr ""
+
+#: mod/settings.php:1290
+msgid "Default Post Location:"
+msgstr ""
+
+#: mod/settings.php:1291
+msgid "Use Browser Location:"
+msgstr ""
+
+#: mod/settings.php:1294
+msgid "Security and Privacy Settings"
+msgstr ""
+
+#: mod/settings.php:1296
+msgid "Maximum Friend Requests/Day:"
+msgstr ""
+
+#: mod/settings.php:1296 mod/settings.php:1326
+msgid "(to prevent spam abuse)"
+msgstr ""
+
+#: mod/settings.php:1297
+msgid "Default Post Permissions"
+msgstr ""
+
+#: mod/settings.php:1298
+msgid "(click to open/close)"
+msgstr ""
+
+#: mod/settings.php:1307 mod/photos.php:1185 mod/photos.php:1567
+msgid "Show to Groups"
+msgstr ""
+
+#: mod/settings.php:1308 mod/photos.php:1186 mod/photos.php:1568
+msgid "Show to Contacts"
+msgstr ""
+
+#: mod/settings.php:1309
+msgid "Default Private Post"
+msgstr ""
+
+#: mod/settings.php:1310
+msgid "Default Public Post"
+msgstr ""
+
+#: mod/settings.php:1314
+msgid "Default Permissions for New Posts"
+msgstr ""
+
+#: mod/settings.php:1326
+msgid "Maximum private messages per day from unknown people:"
+msgstr ""
+
+#: mod/settings.php:1329
+msgid "Notification Settings"
+msgstr ""
+
+#: mod/settings.php:1330
+msgid "By default post a status message when:"
+msgstr ""
+
+#: mod/settings.php:1331
+msgid "accepting a friend request"
+msgstr ""
+
+#: mod/settings.php:1332
+msgid "joining a forum/community"
+msgstr ""
+
+#: mod/settings.php:1333
+msgid "making an <em>interesting</em> profile change"
+msgstr ""
+
+#: mod/settings.php:1334
+msgid "Send a notification email when:"
+msgstr ""
+
+#: mod/settings.php:1335
+msgid "You receive an introduction"
+msgstr ""
+
+#: mod/settings.php:1336
+msgid "Your introductions are confirmed"
+msgstr ""
+
+#: mod/settings.php:1337
+msgid "Someone writes on your profile wall"
+msgstr ""
+
+#: mod/settings.php:1338
+msgid "Someone writes a followup comment"
+msgstr ""
+
+#: mod/settings.php:1339
+msgid "You receive a private message"
+msgstr ""
+
+#: mod/settings.php:1340
+msgid "You receive a friend suggestion"
+msgstr ""
+
+#: mod/settings.php:1341
+msgid "You are tagged in a post"
+msgstr ""
+
+#: mod/settings.php:1342
+msgid "You are poked/prodded/etc. in a post"
+msgstr ""
+
+#: mod/settings.php:1344
+msgid "Activate desktop notifications"
+msgstr ""
+
+#: mod/settings.php:1344
+msgid "Show desktop popup on new notifications"
+msgstr ""
+
+#: mod/settings.php:1346
+msgid "Text-only notification emails"
+msgstr ""
+
+#: mod/settings.php:1348
+msgid "Send text only notification emails, without the html part"
+msgstr ""
+
+#: mod/settings.php:1350
+msgid "Advanced Account/Page Type Settings"
+msgstr ""
+
+#: mod/settings.php:1351
+msgid "Change the behaviour of this account for special situations"
+msgstr ""
+
+#: mod/settings.php:1354
+msgid "Relocate"
+msgstr ""
+
+#: mod/settings.php:1355
+msgid ""
+"If you have moved this profile from another server, and some of your "
+"contacts don't receive your updates, try pushing this button."
+msgstr ""
+
+#: mod/settings.php:1356
+msgid "Resend relocate message to contacts"
+msgstr ""
+
+#: mod/share.php:38
+msgid "link"
+msgstr ""
+
+#: mod/subthread.php:104
+#, php-format
+msgid "%1$s is following %2$s's %3$s"
+msgstr ""
+
+#: mod/suggest.php:27
+msgid "Do you really want to delete this suggestion?"
+msgstr ""
+
+#: mod/suggest.php:71
+msgid ""
+"No suggestions available. If this is a new site, please try again in 24 "
+"hours."
+msgstr ""
+
+#: mod/suggest.php:84 mod/suggest.php:104
+msgid "Ignore/Hide"
+msgstr ""
+
+#: mod/tagrm.php:43
+msgid "Tag removed"
+msgstr ""
+
+#: mod/tagrm.php:82
+msgid "Remove Item Tag"
+msgstr ""
+
+#: mod/tagrm.php:84
+msgid "Select a tag to remove: "
+msgstr ""
+
+#: mod/uexport.php:37
+msgid "Export account"
+msgstr ""
+
+#: mod/uexport.php:37
+msgid ""
+"Export your account info and contacts. Use this to make a backup of your "
+"account and/or to move it to another server."
+msgstr ""
+
+#: mod/uexport.php:38
+msgid "Export all"
+msgstr ""
+
+#: mod/uexport.php:38
+msgid ""
+"Export your accout info, contacts and all your items as json. Could be a "
+"very big file, and could take a lot of time. Use this to make a full backup "
+"of your account (photos are not exported)"
+msgstr ""
+
+#: mod/uimport.php:68
+msgid "Move account"
+msgstr ""
+
+#: mod/uimport.php:69
+msgid "You can import an account from another Friendica server."
+msgstr ""
+
+#: mod/uimport.php:70
+msgid ""
+"You need to export your account from the old server and upload it here. We "
+"will recreate your old account here with all your contacts. We will try also "
+"to inform your friends that you moved here."
+msgstr ""
+
+#: mod/uimport.php:71
+msgid ""
+"This feature is experimental. We can't import contacts from the OStatus "
+"network (GNU Social/Statusnet) or from Diaspora"
+msgstr ""
+
+#: mod/uimport.php:72
+msgid "Account file"
+msgstr ""
+
+#: mod/uimport.php:72
+msgid ""
+"To export your account, go to \"Settings->Export your personal data\" and "
+"select \"Export account\""
+msgstr ""
+
+#: mod/update_community.php:19 mod/update_display.php:23
+#: mod/update_network.php:27 mod/update_notes.php:36 mod/update_profile.php:35
+msgid "[Embedded content - reload page to view]"
+msgstr ""
+
+#: mod/videos.php:124
+msgid "Do you really want to delete this video?"
+msgstr ""
+
+#: mod/videos.php:129
+msgid "Delete Video"
+msgstr ""
+
+#: mod/videos.php:208
+msgid "No videos selected"
+msgstr ""
+
+#: mod/videos.php:309 mod/photos.php:1074
+msgid "Access to this item is restricted."
+msgstr ""
+
+#: mod/videos.php:391 mod/photos.php:1867
+msgid "View Album"
+msgstr ""
+
+#: mod/videos.php:400
+msgid "Recent Videos"
+msgstr ""
+
+#: mod/videos.php:402
+msgid "Upload New Videos"
+msgstr ""
+
+#: mod/viewsrc.php:7
+msgid "Access denied."
+msgstr ""
+
+#: mod/wall_attach.php:17 mod/wall_attach.php:25 mod/wall_attach.php:76
+#: mod/wall_upload.php:20 mod/wall_upload.php:33 mod/wall_upload.php:86
+#: mod/wall_upload.php:122 mod/wall_upload.php:125
+msgid "Invalid request."
+msgstr ""
+
+#: mod/wall_attach.php:94
+msgid "Sorry, maybe your upload is bigger than the PHP configuration allows"
+msgstr ""
+
+#: mod/wall_attach.php:94
+msgid "Or - did you try to upload an empty file?"
+msgstr ""
+
+#: mod/wall_attach.php:105
+#, php-format
+msgid "File exceeds size limit of %s"
+msgstr ""
+
+#: mod/wall_attach.php:158 mod/wall_attach.php:174
+msgid "File upload failed."
+msgstr ""
+
+#: mod/cal.php:271 mod/events.php:387
+msgid "View"
+msgstr ""
+
+#: mod/cal.php:272 mod/events.php:389
+msgid "Previous"
+msgstr ""
+
+#: mod/cal.php:273 mod/events.php:390 mod/install.php:235
+msgid "Next"
+msgstr ""
+
+#: mod/cal.php:282 mod/events.php:399
+msgid "list"
+msgstr ""
+
+#: mod/cal.php:292
+msgid "User not found"
+msgstr ""
+
+#: mod/cal.php:308
+msgid "This calendar format is not supported"
+msgstr ""
+
+#: mod/cal.php:310
+msgid "No exportable data found"
+msgstr ""
+
+#: mod/cal.php:325
+msgid "calendar"
+msgstr ""
+
+#: mod/contacts.php:134
+#, php-format
+msgid "%d contact edited."
+msgid_plural "%d contacts edited."
+msgstr[0] ""
+msgstr[1] ""
+
+#: mod/contacts.php:169 mod/contacts.php:378
+msgid "Could not access contact record."
+msgstr ""
+
+#: mod/contacts.php:183
+msgid "Could not locate selected profile."
+msgstr ""
+
+#: mod/contacts.php:216
+msgid "Contact updated."
+msgstr ""
+
+#: mod/contacts.php:218 mod/dfrn_request.php:588
+msgid "Failed to update contact record."
+msgstr ""
+
+#: mod/contacts.php:399
+msgid "Contact has been blocked"
+msgstr ""
+
+#: mod/contacts.php:399
+msgid "Contact has been unblocked"
+msgstr ""
+
+#: mod/contacts.php:410
+msgid "Contact has been ignored"
+msgstr ""
+
+#: mod/contacts.php:410
+msgid "Contact has been unignored"
+msgstr ""
+
+#: mod/contacts.php:422
+msgid "Contact has been archived"
+msgstr ""
+
+#: mod/contacts.php:422
+msgid "Contact has been unarchived"
+msgstr ""
+
+#: mod/contacts.php:447
+msgid "Drop contact"
+msgstr ""
+
+#: mod/contacts.php:450 mod/contacts.php:809
+msgid "Do you really want to delete this contact?"
+msgstr ""
+
+#: mod/contacts.php:469
+msgid "Contact has been removed."
+msgstr ""
+
+#: mod/contacts.php:506
+#, php-format
+msgid "You are mutual friends with %s"
+msgstr ""
+
+#: mod/contacts.php:510
+#, php-format
+msgid "You are sharing with %s"
+msgstr ""
+
+#: mod/contacts.php:515
+#, php-format
+msgid "%s is sharing with you"
+msgstr ""
+
+#: mod/contacts.php:535
+msgid "Private communications are not available for this contact."
+msgstr ""
+
+#: mod/contacts.php:538 mod/admin.php:899
+msgid "Never"
+msgstr ""
+
+#: mod/contacts.php:542
+msgid "(Update was successful)"
+msgstr ""
+
+#: mod/contacts.php:542
+msgid "(Update was not successful)"
+msgstr ""
+
+#: mod/contacts.php:544 mod/contacts.php:972
+msgid "Suggest friends"
+msgstr ""
+
+#: mod/contacts.php:548
+#, php-format
+msgid "Network type: %s"
+msgstr ""
+
+#: mod/contacts.php:561
+msgid "Communications lost with this contact!"
+msgstr ""
+
+#: mod/contacts.php:564
+msgid "Fetch further information for feeds"
+msgstr ""
+
+#: mod/contacts.php:565 mod/admin.php:908
+msgid "Disabled"
+msgstr ""
+
+#: mod/contacts.php:565
+msgid "Fetch information"
+msgstr ""
+
+#: mod/contacts.php:565
+msgid "Fetch information and keywords"
+msgstr ""
+
+#: mod/contacts.php:583
+msgid "Contact"
+msgstr ""
+
+#: mod/contacts.php:586
+msgid "Profile Visibility"
+msgstr ""
+
+#: mod/contacts.php:587
+#, php-format
+msgid ""
+"Please choose the profile you would like to display to %s when viewing your "
+"profile securely."
+msgstr ""
+
+#: mod/contacts.php:588
+msgid "Contact Information / Notes"
+msgstr ""
+
+#: mod/contacts.php:589
+msgid "Edit contact notes"
+msgstr ""
+
+#: mod/contacts.php:595
+msgid "Block/Unblock contact"
+msgstr ""
+
+#: mod/contacts.php:596
+msgid "Ignore contact"
+msgstr ""
+
+#: mod/contacts.php:597
+msgid "Repair URL settings"
+msgstr ""
+
+#: mod/contacts.php:598
+msgid "View conversations"
+msgstr ""
+
+#: mod/contacts.php:604
+msgid "Last update:"
+msgstr ""
+
+#: mod/contacts.php:606
+msgid "Update public posts"
+msgstr ""
+
+#: mod/contacts.php:608 mod/contacts.php:982
+msgid "Update now"
+msgstr ""
+
+#: mod/contacts.php:613 mod/contacts.php:813 mod/contacts.php:991
+#: mod/admin.php:1437
+msgid "Unblock"
+msgstr ""
+
+#: mod/contacts.php:613 mod/contacts.php:813 mod/contacts.php:991
+#: mod/admin.php:1436
+msgid "Block"
+msgstr ""
+
+#: mod/contacts.php:614 mod/contacts.php:814 mod/contacts.php:999
+msgid "Unignore"
+msgstr ""
+
+#: mod/contacts.php:614 mod/contacts.php:814 mod/contacts.php:999
 #: mod/notifications.php:60 mod/notifications.php:179
-#: mod/notifications.php:251 mod/contacts.php:606 mod/contacts.php:806
-#: mod/contacts.php:991
+#: mod/notifications.php:257
 msgid "Ignore"
 msgstr ""
 
-#: mod/notifications.php:105
-msgid "Network Notifications"
+#: mod/contacts.php:618
+msgid "Currently blocked"
 msgstr ""
 
-#: mod/notifications.php:117
-msgid "Personal Notifications"
+#: mod/contacts.php:619
+msgid "Currently ignored"
 msgstr ""
 
-#: mod/notifications.php:123
-msgid "Home Notifications"
+#: mod/contacts.php:620
+msgid "Currently archived"
 msgstr ""
 
-#: mod/notifications.php:152
-msgid "Show Ignored Requests"
-msgstr ""
-
-#: mod/notifications.php:152
-msgid "Hide Ignored Requests"
-msgstr ""
-
-#: mod/notifications.php:164 mod/notifications.php:222
-msgid "Notification type: "
-msgstr ""
-
-#: mod/notifications.php:167
-#, php-format
-msgid "suggested by %s"
-msgstr ""
-
-#: mod/notifications.php:172 mod/notifications.php:239 mod/contacts.php:613
+#: mod/contacts.php:621 mod/notifications.php:172 mod/notifications.php:245
 msgid "Hide this contact from others"
 msgstr ""
 
-#: mod/notifications.php:173 mod/notifications.php:240
-msgid "Post a new friend activity"
-msgstr ""
-
-#: mod/notifications.php:173 mod/notifications.php:240
-msgid "if applicable"
-msgstr ""
-
-#: mod/notifications.php:176 mod/notifications.php:249 mod/admin.php:1412
-msgid "Approve"
-msgstr ""
-
-#: mod/notifications.php:195
-msgid "Claims to be known to you: "
-msgstr ""
-
-#: mod/notifications.php:196
-msgid "yes"
-msgstr ""
-
-#: mod/notifications.php:196
-msgid "no"
-msgstr ""
-
-#: mod/notifications.php:197
+#: mod/contacts.php:621
 msgid ""
-"Shall your connection be bidirectional or not? \"Friend\" implies that you "
-"allow to read and you subscribe to their posts. \"Fan/Admirer\" means that "
-"you allow to read but you do not want to read theirs. Approve as: "
+"Replies/likes to your public posts <strong>may</strong> still be visible"
 msgstr ""
 
-#: mod/notifications.php:200
+#: mod/contacts.php:622
+msgid "Notification for new posts"
+msgstr ""
+
+#: mod/contacts.php:622
+msgid "Send a notification of every new post of this contact"
+msgstr ""
+
+#: mod/contacts.php:625
+msgid "Blacklisted keywords"
+msgstr ""
+
+#: mod/contacts.php:625
 msgid ""
-"Shall your connection be bidirectional or not? \"Friend\" implies that you "
-"allow to read and you subscribe to their posts. \"Sharer\" means that you "
-"allow to read but you do not want to read theirs. Approve as: "
+"Comma separated list of keywords that should not be converted to hashtags, "
+"when \"Fetch information and keywords\" is selected"
 msgstr ""
 
-#: mod/notifications.php:209
-msgid "Friend"
+#: mod/contacts.php:643
+msgid "Actions"
 msgstr ""
 
-#: mod/notifications.php:210
-msgid "Sharer"
+#: mod/contacts.php:646
+msgid "Contact Settings"
 msgstr ""
 
-#: mod/notifications.php:210
-msgid "Fan/Admirer"
+#: mod/contacts.php:692
+msgid "Suggestions"
 msgstr ""
 
-#: mod/notifications.php:243 mod/contacts.php:624 mod/follow.php:126
-msgid "Profile URL"
+#: mod/contacts.php:695
+msgid "Suggest potential friends"
 msgstr ""
 
-#: mod/notifications.php:260
-msgid "No introductions."
+#: mod/contacts.php:703
+msgid "Show all contacts"
 msgstr ""
 
-#: mod/notifications.php:299
-msgid "Show unread"
+#: mod/contacts.php:708
+msgid "Unblocked"
 msgstr ""
 
-#: mod/notifications.php:299
-msgid "Show all"
+#: mod/contacts.php:711
+msgid "Only show unblocked contacts"
 msgstr ""
 
-#: mod/notifications.php:305
+#: mod/contacts.php:717
+msgid "Blocked"
+msgstr ""
+
+#: mod/contacts.php:720
+msgid "Only show blocked contacts"
+msgstr ""
+
+#: mod/contacts.php:726
+msgid "Ignored"
+msgstr ""
+
+#: mod/contacts.php:729
+msgid "Only show ignored contacts"
+msgstr ""
+
+#: mod/contacts.php:735
+msgid "Archived"
+msgstr ""
+
+#: mod/contacts.php:738
+msgid "Only show archived contacts"
+msgstr ""
+
+#: mod/contacts.php:744
+msgid "Hidden"
+msgstr ""
+
+#: mod/contacts.php:747
+msgid "Only show hidden contacts"
+msgstr ""
+
+#: mod/contacts.php:804
+msgid "Search your contacts"
+msgstr ""
+
+#: mod/contacts.php:805 mod/network.php:145 mod/search.php:232
 #, php-format
-msgid "No more %s notifications."
+msgid "Results for: %s"
 msgstr ""
 
-#: mod/profiles.php:19 mod/profiles.php:134 mod/profiles.php:180
-#: mod/profiles.php:617 mod/dfrn_confirm.php:70
+#: mod/contacts.php:815 mod/contacts.php:1007
+msgid "Archive"
+msgstr ""
+
+#: mod/contacts.php:815 mod/contacts.php:1007
+msgid "Unarchive"
+msgstr ""
+
+#: mod/contacts.php:818
+msgid "Batch Actions"
+msgstr ""
+
+#: mod/contacts.php:864
+msgid "View all contacts"
+msgstr ""
+
+#: mod/contacts.php:874
+msgid "View all common friends"
+msgstr ""
+
+#: mod/contacts.php:881
+msgid "Advanced Contact Settings"
+msgstr ""
+
+#: mod/contacts.php:915
+msgid "Mutual Friendship"
+msgstr ""
+
+#: mod/contacts.php:919
+msgid "is a fan of yours"
+msgstr ""
+
+#: mod/contacts.php:923
+msgid "you are a fan of"
+msgstr ""
+
+#: mod/contacts.php:993
+msgid "Toggle Blocked status"
+msgstr ""
+
+#: mod/contacts.php:1001
+msgid "Toggle Ignored status"
+msgstr ""
+
+#: mod/contacts.php:1009
+msgid "Toggle Archive status"
+msgstr ""
+
+#: mod/contacts.php:1017
+msgid "Delete contact"
+msgstr ""
+
+#: mod/dfrn_confirm.php:70 mod/profiles.php:19 mod/profiles.php:134
+#: mod/profiles.php:180 mod/profiles.php:619
 msgid "Profile not found."
+msgstr ""
+
+#: mod/dfrn_confirm.php:127
+msgid ""
+"This may occasionally happen if contact was requested by both persons and it "
+"has already been approved."
+msgstr ""
+
+#: mod/dfrn_confirm.php:244
+msgid "Response from remote site was not understood."
+msgstr ""
+
+#: mod/dfrn_confirm.php:253 mod/dfrn_confirm.php:258
+msgid "Unexpected response from remote site: "
+msgstr ""
+
+#: mod/dfrn_confirm.php:267
+msgid "Confirmation completed successfully."
+msgstr ""
+
+#: mod/dfrn_confirm.php:269 mod/dfrn_confirm.php:283 mod/dfrn_confirm.php:290
+msgid "Remote site reported: "
+msgstr ""
+
+#: mod/dfrn_confirm.php:281
+msgid "Temporary failure. Please wait and try again."
+msgstr ""
+
+#: mod/dfrn_confirm.php:288
+msgid "Introduction failed or was revoked."
+msgstr ""
+
+#: mod/dfrn_confirm.php:418
+msgid "Unable to set contact photo."
+msgstr ""
+
+#: mod/dfrn_confirm.php:559
+#, php-format
+msgid "No user record found for '%s' "
+msgstr ""
+
+#: mod/dfrn_confirm.php:569
+msgid "Our site encryption key is apparently messed up."
+msgstr ""
+
+#: mod/dfrn_confirm.php:580
+msgid "Empty site URL was provided or URL could not be decrypted by us."
+msgstr ""
+
+#: mod/dfrn_confirm.php:601
+msgid "Contact record was not found for you on our site."
+msgstr ""
+
+#: mod/dfrn_confirm.php:615
+#, php-format
+msgid "Site public key not available in contact record for URL %s."
+msgstr ""
+
+#: mod/dfrn_confirm.php:635
+msgid ""
+"The ID provided by your system is a duplicate on our system. It should work "
+"if you try again."
+msgstr ""
+
+#: mod/dfrn_confirm.php:646
+msgid "Unable to set your contact credentials on our system."
+msgstr ""
+
+#: mod/dfrn_confirm.php:708
+msgid "Unable to update your contact profile details on our system"
+msgstr ""
+
+#: mod/dfrn_confirm.php:780
+#, php-format
+msgid "%1$s has joined %2$s"
+msgstr ""
+
+#: mod/editpost.php:17 mod/editpost.php:27
+msgid "Item not found"
+msgstr ""
+
+#: mod/editpost.php:32
+msgid "Edit post"
+msgstr ""
+
+#: mod/events.php:100 mod/events.php:102
+msgid "Event can not end before it has started."
+msgstr ""
+
+#: mod/events.php:109 mod/events.php:111
+msgid "Event title and start time are required."
+msgstr ""
+
+#: mod/events.php:388
+msgid "Create New Event"
+msgstr ""
+
+#: mod/events.php:489
+msgid "Event details"
+msgstr ""
+
+#: mod/events.php:490
+msgid "Starting date and Title are required."
+msgstr ""
+
+#: mod/events.php:491 mod/events.php:492
+msgid "Event Starts:"
+msgstr ""
+
+#: mod/events.php:491 mod/events.php:503 mod/profiles.php:708
+msgid "Required"
+msgstr ""
+
+#: mod/events.php:493 mod/events.php:509
+msgid "Finish date/time is not known or not relevant"
+msgstr ""
+
+#: mod/events.php:495 mod/events.php:496
+msgid "Event Finishes:"
+msgstr ""
+
+#: mod/events.php:497 mod/events.php:510
+msgid "Adjust for viewer timezone"
+msgstr ""
+
+#: mod/events.php:499
+msgid "Description:"
+msgstr ""
+
+#: mod/events.php:503 mod/events.php:505
+msgid "Title:"
+msgstr ""
+
+#: mod/events.php:506 mod/events.php:507
+msgid "Share this event"
+msgstr ""
+
+#: mod/fbrowser.php:132
+msgid "Files"
+msgstr ""
+
+#: mod/friendica.php:72
+msgid "This is Friendica, version"
+msgstr ""
+
+#: mod/friendica.php:73
+msgid "running at web location"
+msgstr ""
+
+#: mod/friendica.php:75
+msgid ""
+"Please visit <a href=\"http://friendica.com\">Friendica.com</a> to learn "
+"more about the Friendica project."
+msgstr ""
+
+#: mod/friendica.php:77
+msgid "Bug reports and issues: please visit"
+msgstr ""
+
+#: mod/friendica.php:77
+msgid "the bugtracker at github"
+msgstr ""
+
+#: mod/friendica.php:78
+msgid ""
+"Suggestions, praise, donations, etc. - please email \"Info\" at Friendica - "
+"dot com"
+msgstr ""
+
+#: mod/friendica.php:92
+msgid "Installed plugins/addons/apps:"
+msgstr ""
+
+#: mod/friendica.php:105
+msgid "No installed plugins/addons/apps"
+msgstr ""
+
+#: mod/item.php:118
+msgid "Unable to locate original post."
+msgstr ""
+
+#: mod/item.php:336
+msgid "Empty post discarded."
+msgstr ""
+
+#: mod/item.php:889
+msgid "System error. Post not saved."
+msgstr ""
+
+#: mod/item.php:979
+#, php-format
+msgid ""
+"This message was sent to you by %s, a member of the Friendica social network."
+msgstr ""
+
+#: mod/item.php:981
+#, php-format
+msgid "You may visit them online at %s"
+msgstr ""
+
+#: mod/item.php:982
+msgid ""
+"Please contact the sender by replying to this post if you do not wish to "
+"receive these messages."
+msgstr ""
+
+#: mod/item.php:986
+#, php-format
+msgid "%s posted an update."
+msgstr ""
+
+#: mod/message.php:60 mod/wallmessage.php:50
+msgid "No recipient selected."
+msgstr ""
+
+#: mod/message.php:64
+msgid "Unable to locate contact information."
+msgstr ""
+
+#: mod/message.php:67 mod/wallmessage.php:56
+msgid "Message could not be sent."
+msgstr ""
+
+#: mod/message.php:70 mod/wallmessage.php:59
+msgid "Message collection failure."
+msgstr ""
+
+#: mod/message.php:73 mod/wallmessage.php:62
+msgid "Message sent."
+msgstr ""
+
+#: mod/message.php:204
+msgid "Do you really want to delete this message?"
+msgstr ""
+
+#: mod/message.php:224
+msgid "Message deleted."
+msgstr ""
+
+#: mod/message.php:255
+msgid "Conversation removed."
+msgstr ""
+
+#: mod/message.php:322 mod/wallmessage.php:126
+msgid "Send Private Message"
+msgstr ""
+
+#: mod/message.php:323 mod/message.php:510 mod/wallmessage.php:128
+msgid "To:"
+msgstr ""
+
+#: mod/message.php:328 mod/message.php:512 mod/wallmessage.php:129
+msgid "Subject:"
+msgstr ""
+
+#: mod/message.php:364
+msgid "No messages."
+msgstr ""
+
+#: mod/message.php:403
+msgid "Message not available."
+msgstr ""
+
+#: mod/message.php:477
+msgid "Delete message"
+msgstr ""
+
+#: mod/message.php:503 mod/message.php:583
+msgid "Delete conversation"
+msgstr ""
+
+#: mod/message.php:505
+msgid ""
+"No secure communications available. You <strong>may</strong> be able to "
+"respond from the sender's profile page."
+msgstr ""
+
+#: mod/message.php:509
+msgid "Send Reply"
+msgstr ""
+
+#: mod/message.php:553
+#, php-format
+msgid "Unknown sender - %s"
+msgstr ""
+
+#: mod/message.php:555
+#, php-format
+msgid "You and %s"
+msgstr ""
+
+#: mod/message.php:557
+#, php-format
+msgid "%s and You"
+msgstr ""
+
+#: mod/message.php:586
+msgid "D, d M Y - g:i A"
+msgstr ""
+
+#: mod/message.php:589
+#, php-format
+msgid "%d message"
+msgid_plural "%d messages"
+msgstr[0] ""
+msgstr[1] ""
+
+#: mod/p.php:9
+msgid "Not Extended"
+msgstr ""
+
+#: mod/ping.php:270
+msgid "{0} wants to be your friend"
+msgstr ""
+
+#: mod/ping.php:285
+msgid "{0} sent you a message"
+msgstr ""
+
+#: mod/ping.php:300
+msgid "{0} requested registration"
+msgstr ""
+
+#: mod/wallmessage.php:42 mod/wallmessage.php:106
+#, php-format
+msgid "Number of daily wall messages for %s exceeded. Message failed."
+msgstr ""
+
+#: mod/wallmessage.php:53
+msgid "Unable to check your home location."
+msgstr ""
+
+#: mod/wallmessage.php:80 mod/wallmessage.php:89
+msgid "No recipient."
+msgstr ""
+
+#: mod/wallmessage.php:127
+#, php-format
+msgid ""
+"If you wish for %s to respond, please check that the privacy settings on "
+"your site allow private mail from unknown senders."
+msgstr ""
+
+#: mod/photos.php:90 mod/photos.php:1876
+msgid "Recent Photos"
+msgstr ""
+
+#: mod/photos.php:93 mod/photos.php:1303 mod/photos.php:1878
+msgid "Upload New Photos"
+msgstr ""
+
+#: mod/photos.php:171
+msgid "Contact information unavailable"
+msgstr ""
+
+#: mod/photos.php:192
+msgid "Album not found."
+msgstr ""
+
+#: mod/photos.php:225 mod/photos.php:237 mod/photos.php:1247
+msgid "Delete Album"
+msgstr ""
+
+#: mod/photos.php:235
+msgid "Do you really want to delete this photo album and all its photos?"
+msgstr ""
+
+#: mod/photos.php:317 mod/photos.php:328 mod/photos.php:1563
+msgid "Delete Photo"
+msgstr ""
+
+#: mod/photos.php:326
+msgid "Do you really want to delete this photo?"
+msgstr ""
+
+#: mod/photos.php:705
+#, php-format
+msgid "%1$s was tagged in %2$s by %3$s"
+msgstr ""
+
+#: mod/photos.php:705
+msgid "a photo"
+msgstr ""
+
+#: mod/photos.php:811
+msgid "Image file is empty."
+msgstr ""
+
+#: mod/photos.php:974
+msgid "No photos selected"
+msgstr ""
+
+#: mod/photos.php:1134
+#, php-format
+msgid "You have used %1$.2f Mbytes of %2$.2f Mbytes photo storage."
+msgstr ""
+
+#: mod/photos.php:1168
+msgid "Upload Photos"
+msgstr ""
+
+#: mod/photos.php:1172 mod/photos.php:1242
+msgid "New album name: "
+msgstr ""
+
+#: mod/photos.php:1173
+msgid "or existing album name: "
+msgstr ""
+
+#: mod/photos.php:1174
+msgid "Do not show a status post for this upload"
+msgstr ""
+
+#: mod/photos.php:1187
+msgid "Private Photo"
+msgstr ""
+
+#: mod/photos.php:1188
+msgid "Public Photo"
+msgstr ""
+
+#: mod/photos.php:1254
+msgid "Edit Album"
+msgstr ""
+
+#: mod/photos.php:1260
+msgid "Show Newest First"
+msgstr ""
+
+#: mod/photos.php:1262
+msgid "Show Oldest First"
+msgstr ""
+
+#: mod/photos.php:1289 mod/photos.php:1861
+msgid "View Photo"
+msgstr ""
+
+#: mod/photos.php:1335
+msgid "Permission denied. Access to this item may be restricted."
+msgstr ""
+
+#: mod/photos.php:1337
+msgid "Photo not available"
+msgstr ""
+
+#: mod/photos.php:1395
+msgid "View photo"
+msgstr ""
+
+#: mod/photos.php:1395
+msgid "Edit photo"
+msgstr ""
+
+#: mod/photos.php:1396
+msgid "Use as profile photo"
+msgstr ""
+
+#: mod/photos.php:1421
+msgid "View Full Size"
+msgstr ""
+
+#: mod/photos.php:1507
+msgid "Tags: "
+msgstr ""
+
+#: mod/photos.php:1510
+msgid "[Remove any tag]"
+msgstr ""
+
+#: mod/photos.php:1549
+msgid "New album name"
+msgstr ""
+
+#: mod/photos.php:1550
+msgid "Caption"
+msgstr ""
+
+#: mod/photos.php:1551
+msgid "Add a Tag"
+msgstr ""
+
+#: mod/photos.php:1551
+msgid "Example: @bob, @Barbara_Jensen, @jim@example.com, #California, #camping"
+msgstr ""
+
+#: mod/photos.php:1552
+msgid "Do not rotate"
+msgstr ""
+
+#: mod/photos.php:1553
+msgid "Rotate CW (right)"
+msgstr ""
+
+#: mod/photos.php:1554
+msgid "Rotate CCW (left)"
+msgstr ""
+
+#: mod/photos.php:1569
+msgid "Private photo"
+msgstr ""
+
+#: mod/photos.php:1570
+msgid "Public photo"
+msgstr ""
+
+#: mod/photos.php:1792
+msgid "Map"
+msgstr ""
+
+#: mod/dfrn_request.php:101
+msgid "This introduction has already been accepted."
+msgstr ""
+
+#: mod/dfrn_request.php:124 mod/dfrn_request.php:523
+msgid "Profile location is not valid or does not contain profile information."
+msgstr ""
+
+#: mod/dfrn_request.php:129 mod/dfrn_request.php:528
+msgid "Warning: profile location has no identifiable owner name."
+msgstr ""
+
+#: mod/dfrn_request.php:132 mod/dfrn_request.php:531
+msgid "Warning: profile location has no profile photo."
+msgstr ""
+
+#: mod/dfrn_request.php:136 mod/dfrn_request.php:535
+#, php-format
+msgid "%d required parameter was not found at the given location"
+msgid_plural "%d required parameters were not found at the given location"
+msgstr[0] ""
+msgstr[1] ""
+
+#: mod/dfrn_request.php:180
+msgid "Introduction complete."
+msgstr ""
+
+#: mod/dfrn_request.php:225
+msgid "Unrecoverable protocol error."
+msgstr ""
+
+#: mod/dfrn_request.php:253
+msgid "Profile unavailable."
+msgstr ""
+
+#: mod/dfrn_request.php:280
+#, php-format
+msgid "%s has received too many connection requests today."
+msgstr ""
+
+#: mod/dfrn_request.php:281
+msgid "Spam protection measures have been invoked."
+msgstr ""
+
+#: mod/dfrn_request.php:282
+msgid "Friends are advised to please try again in 24 hours."
+msgstr ""
+
+#: mod/dfrn_request.php:344
+msgid "Invalid locator"
+msgstr ""
+
+#: mod/dfrn_request.php:353
+msgid "Invalid email address."
+msgstr ""
+
+#: mod/dfrn_request.php:378
+msgid "This account has not been configured for email. Request failed."
+msgstr ""
+
+#: mod/dfrn_request.php:481
+msgid "You have already introduced yourself here."
+msgstr ""
+
+#: mod/dfrn_request.php:485
+#, php-format
+msgid "Apparently you are already friends with %s."
+msgstr ""
+
+#: mod/dfrn_request.php:506
+msgid "Invalid profile URL."
+msgstr ""
+
+#: mod/dfrn_request.php:609
+msgid "Your introduction has been sent."
+msgstr ""
+
+#: mod/dfrn_request.php:651
+msgid ""
+"Remote subscription can't be done for your network. Please subscribe "
+"directly on your system."
+msgstr ""
+
+#: mod/dfrn_request.php:672
+msgid "Please login to confirm introduction."
+msgstr ""
+
+#: mod/dfrn_request.php:682
+msgid ""
+"Incorrect identity currently logged in. Please login to <strong>this</"
+"strong> profile."
+msgstr ""
+
+#: mod/dfrn_request.php:696 mod/dfrn_request.php:713
+msgid "Confirm"
+msgstr ""
+
+#: mod/dfrn_request.php:708
+msgid "Hide this contact"
+msgstr ""
+
+#: mod/dfrn_request.php:711
+#, php-format
+msgid "Welcome home %s."
+msgstr ""
+
+#: mod/dfrn_request.php:712
+#, php-format
+msgid "Please confirm your introduction/connection request to %s."
+msgstr ""
+
+#: mod/dfrn_request.php:843
+msgid ""
+"Please enter your 'Identity Address' from one of the following supported "
+"communications networks:"
+msgstr ""
+
+#: mod/dfrn_request.php:867
+#, php-format
+msgid ""
+"If you are not yet a member of the free social web, <a href=\"%s/siteinfo"
+"\">follow this link to find a public Friendica site and join us today</a>."
+msgstr ""
+
+#: mod/dfrn_request.php:872
+msgid "Friend/Connection Request"
+msgstr ""
+
+#: mod/dfrn_request.php:873
+msgid ""
+"Examples: jojo@demo.friendica.com, http://demo.friendica.com/profile/jojo, "
+"testuser@identi.ca"
+msgstr ""
+
+#: mod/dfrn_request.php:882
+msgid "StatusNet/Federated Social Web"
+msgstr ""
+
+#: mod/dfrn_request.php:884
+#, php-format
+msgid ""
+" - please do not use this form.  Instead, enter %s into your Diaspora search "
+"bar."
+msgstr ""
+
+#: mod/install.php:140
+msgid "Friendica Communications Server - Setup"
+msgstr ""
+
+#: mod/install.php:146
+msgid "Could not connect to database."
+msgstr ""
+
+#: mod/install.php:150
+msgid "Could not create table."
+msgstr ""
+
+#: mod/install.php:156
+msgid "Your Friendica site database has been installed."
+msgstr ""
+
+#: mod/install.php:161
+msgid ""
+"You may need to import the file \"database.sql\" manually using phpmyadmin "
+"or mysql."
+msgstr ""
+
+#: mod/install.php:162 mod/install.php:234 mod/install.php:609
+msgid "Please see the file \"INSTALL.txt\"."
+msgstr ""
+
+#: mod/install.php:174
+msgid "Database already in use."
+msgstr ""
+
+#: mod/install.php:231
+msgid "System check"
+msgstr ""
+
+#: mod/install.php:236
+msgid "Check again"
+msgstr ""
+
+#: mod/install.php:255
+msgid "Database connection"
+msgstr ""
+
+#: mod/install.php:256
+msgid ""
+"In order to install Friendica we need to know how to connect to your "
+"database."
+msgstr ""
+
+#: mod/install.php:257
+msgid ""
+"Please contact your hosting provider or site administrator if you have "
+"questions about these settings."
+msgstr ""
+
+#: mod/install.php:258
+msgid ""
+"The database you specify below should already exist. If it does not, please "
+"create it before continuing."
+msgstr ""
+
+#: mod/install.php:262
+msgid "Database Server Name"
+msgstr ""
+
+#: mod/install.php:263
+msgid "Database Login Name"
+msgstr ""
+
+#: mod/install.php:264
+msgid "Database Login Password"
+msgstr ""
+
+#: mod/install.php:264
+msgid "For security reasons the password must not be empty"
+msgstr ""
+
+#: mod/install.php:265
+msgid "Database Name"
+msgstr ""
+
+#: mod/install.php:266 mod/install.php:307
+msgid "Site administrator email address"
+msgstr ""
+
+#: mod/install.php:266 mod/install.php:307
+msgid ""
+"Your account email address must match this in order to use the web admin "
+"panel."
+msgstr ""
+
+#: mod/install.php:270 mod/install.php:310
+msgid "Please select a default timezone for your website"
+msgstr ""
+
+#: mod/install.php:297
+msgid "Site settings"
+msgstr ""
+
+#: mod/install.php:311
+msgid "System Language:"
+msgstr ""
+
+#: mod/install.php:311
+msgid ""
+"Set the default language for your Friendica installation interface and to "
+"send emails."
+msgstr ""
+
+#: mod/install.php:351
+msgid "Could not find a command line version of PHP in the web server PATH."
+msgstr ""
+
+#: mod/install.php:352
+msgid ""
+"If you don't have a command line version of PHP installed on server, you "
+"will not be able to run background polling via cron. See <a href='https://"
+"github.com/friendica/friendica/blob/master/doc/Install.md#set-up-the-"
+"poller'>'Setup the poller'</a>"
+msgstr ""
+
+#: mod/install.php:356
+msgid "PHP executable path"
+msgstr ""
+
+#: mod/install.php:356
+msgid ""
+"Enter full path to php executable. You can leave this blank to continue the "
+"installation."
+msgstr ""
+
+#: mod/install.php:361
+msgid "Command line PHP"
+msgstr ""
+
+#: mod/install.php:370
+msgid "PHP executable is not the php cli binary (could be cgi-fgci version)"
+msgstr ""
+
+#: mod/install.php:371
+msgid "Found PHP version: "
+msgstr ""
+
+#: mod/install.php:373
+msgid "PHP cli binary"
+msgstr ""
+
+#: mod/install.php:384
+msgid ""
+"The command line version of PHP on your system does not have "
+"\"register_argc_argv\" enabled."
+msgstr ""
+
+#: mod/install.php:385
+msgid "This is required for message delivery to work."
+msgstr ""
+
+#: mod/install.php:387
+msgid "PHP register_argc_argv"
+msgstr ""
+
+#: mod/install.php:410
+msgid ""
+"Error: the \"openssl_pkey_new\" function on this system is not able to "
+"generate encryption keys"
+msgstr ""
+
+#: mod/install.php:411
+msgid ""
+"If running under Windows, please see \"http://www.php.net/manual/en/openssl."
+"installation.php\"."
+msgstr ""
+
+#: mod/install.php:413
+msgid "Generate encryption keys"
+msgstr ""
+
+#: mod/install.php:420
+msgid "libCurl PHP module"
+msgstr ""
+
+#: mod/install.php:421
+msgid "GD graphics PHP module"
+msgstr ""
+
+#: mod/install.php:422
+msgid "OpenSSL PHP module"
+msgstr ""
+
+#: mod/install.php:423
+msgid "mysqli PHP module"
+msgstr ""
+
+#: mod/install.php:424
+msgid "mb_string PHP module"
+msgstr ""
+
+#: mod/install.php:425
+msgid "mcrypt PHP module"
+msgstr ""
+
+#: mod/install.php:426
+msgid "XML PHP module"
+msgstr ""
+
+#: mod/install.php:427
+msgid "iconv module"
+msgstr ""
+
+#: mod/install.php:431 mod/install.php:433
+msgid "Apache mod_rewrite module"
+msgstr ""
+
+#: mod/install.php:431
+msgid ""
+"Error: Apache webserver mod-rewrite module is required but not installed."
+msgstr ""
+
+#: mod/install.php:439
+msgid "Error: libCURL PHP module required but not installed."
+msgstr ""
+
+#: mod/install.php:443
+msgid ""
+"Error: GD graphics PHP module with JPEG support required but not installed."
+msgstr ""
+
+#: mod/install.php:447
+msgid "Error: openssl PHP module required but not installed."
+msgstr ""
+
+#: mod/install.php:451
+msgid "Error: mysqli PHP module required but not installed."
+msgstr ""
+
+#: mod/install.php:455
+msgid "Error: mb_string PHP module required but not installed."
+msgstr ""
+
+#: mod/install.php:459
+msgid "Error: mcrypt PHP module required but not installed."
+msgstr ""
+
+#: mod/install.php:463
+msgid "Error: iconv PHP module required but not installed."
+msgstr ""
+
+#: mod/install.php:472
+msgid ""
+"If you are using php_cli, please make sure that mcrypt module is enabled in "
+"its config file"
+msgstr ""
+
+#: mod/install.php:475
+msgid ""
+"Function mcrypt_create_iv() is not defined. This is needed to enable RINO2 "
+"encryption layer."
+msgstr ""
+
+#: mod/install.php:477
+msgid "mcrypt_create_iv() function"
+msgstr ""
+
+#: mod/install.php:485
+msgid "Error, XML PHP module required but not installed."
+msgstr ""
+
+#: mod/install.php:500
+msgid ""
+"The web installer needs to be able to create a file called \".htconfig.php\" "
+"in the top folder of your web server and it is unable to do so."
+msgstr ""
+
+#: mod/install.php:501
+msgid ""
+"This is most often a permission setting, as the web server may not be able "
+"to write files in your folder - even if you can."
+msgstr ""
+
+#: mod/install.php:502
+msgid ""
+"At the end of this procedure, we will give you a text to save in a file "
+"named .htconfig.php in your Friendica top folder."
+msgstr ""
+
+#: mod/install.php:503
+msgid ""
+"You can alternatively skip this procedure and perform a manual installation. "
+"Please see the file \"INSTALL.txt\" for instructions."
+msgstr ""
+
+#: mod/install.php:506
+msgid ".htconfig.php is writable"
+msgstr ""
+
+#: mod/install.php:516
+msgid ""
+"Friendica uses the Smarty3 template engine to render its web views. Smarty3 "
+"compiles templates to PHP to speed up rendering."
+msgstr ""
+
+#: mod/install.php:517
+msgid ""
+"In order to store these compiled templates, the web server needs to have "
+"write access to the directory view/smarty3/ under the Friendica top level "
+"folder."
+msgstr ""
+
+#: mod/install.php:518
+msgid ""
+"Please ensure that the user that your web server runs as (e.g. www-data) has "
+"write access to this folder."
+msgstr ""
+
+#: mod/install.php:519
+msgid ""
+"Note: as a security measure, you should give the web server write access to "
+"view/smarty3/ only--not the template files (.tpl) that it contains."
+msgstr ""
+
+#: mod/install.php:522
+msgid "view/smarty3 is writable"
+msgstr ""
+
+#: mod/install.php:538
+msgid ""
+"Url rewrite in .htaccess is not working. Check your server configuration."
+msgstr ""
+
+#: mod/install.php:540
+msgid "Url rewrite is working"
+msgstr ""
+
+#: mod/install.php:559
+msgid "ImageMagick PHP extension is not installed"
+msgstr ""
+
+#: mod/install.php:561
+msgid "ImageMagick PHP extension is installed"
+msgstr ""
+
+#: mod/install.php:563
+msgid "ImageMagick supports GIF"
+msgstr ""
+
+#: mod/install.php:570
+msgid ""
+"The database configuration file \".htconfig.php\" could not be written. "
+"Please use the enclosed text to create a configuration file in your web "
+"server root."
+msgstr ""
+
+#: mod/install.php:607
+msgid "<h1>What next</h1>"
+msgstr ""
+
+#: mod/install.php:608
+msgid ""
+"IMPORTANT: You will need to [manually] setup a scheduled task for the poller."
 msgstr ""
 
 #: mod/profiles.php:38
@@ -4746,7 +6872,7 @@ msgstr ""
 msgid "Homepage"
 msgstr ""
 
-#: mod/profiles.php:381 mod/profiles.php:702
+#: mod/profiles.php:381 mod/profiles.php:694
 msgid "Interests"
 msgstr ""
 
@@ -4754,7 +6880,7 @@ msgstr ""
 msgid "Address"
 msgstr ""
 
-#: mod/profiles.php:392 mod/profiles.php:698
+#: mod/profiles.php:392 mod/profiles.php:690
 msgid "Location"
 msgstr ""
 
@@ -4762,1599 +6888,349 @@ msgstr ""
 msgid "Profile updated."
 msgstr ""
 
-#: mod/profiles.php:564
+#: mod/profiles.php:565
 msgid " and "
 msgstr ""
 
-#: mod/profiles.php:572
+#: mod/profiles.php:573
 msgid "public profile"
-msgstr ""
-
-#: mod/profiles.php:575
-#, php-format
-msgid "%1$s changed %2$s to &ldquo;%3$s&rdquo;"
 msgstr ""
 
 #: mod/profiles.php:576
 #, php-format
+msgid "%1$s changed %2$s to &ldquo;%3$s&rdquo;"
+msgstr ""
+
+#: mod/profiles.php:577
+#, php-format
 msgid " - Visit %1$s's %2$s"
 msgstr ""
 
-#: mod/profiles.php:579
+#: mod/profiles.php:580
 #, php-format
 msgid "%1$s has an updated %2$s, changing %3$s."
 msgstr ""
 
-#: mod/profiles.php:645
+#: mod/profiles.php:637
 msgid "Hide contacts and friends:"
 msgstr ""
 
-#: mod/profiles.php:650
+#: mod/profiles.php:642
 msgid "Hide your contact/friend list from viewers of this profile?"
 msgstr ""
 
-#: mod/profiles.php:674
+#: mod/profiles.php:666
 msgid "Show more profile fields:"
 msgstr ""
 
-#: mod/profiles.php:686
+#: mod/profiles.php:678
 msgid "Profile Actions"
 msgstr ""
 
-#: mod/profiles.php:687
+#: mod/profiles.php:679
 msgid "Edit Profile Details"
 msgstr ""
 
-#: mod/profiles.php:689
+#: mod/profiles.php:681
 msgid "Change Profile Photo"
 msgstr ""
 
-#: mod/profiles.php:690
+#: mod/profiles.php:682
 msgid "View this profile"
 msgstr ""
 
-#: mod/profiles.php:692
+#: mod/profiles.php:684
 msgid "Create a new profile using these settings"
 msgstr ""
 
-#: mod/profiles.php:693
+#: mod/profiles.php:685
 msgid "Clone this profile"
 msgstr ""
 
-#: mod/profiles.php:694
+#: mod/profiles.php:686
 msgid "Delete this profile"
 msgstr ""
 
-#: mod/profiles.php:696
+#: mod/profiles.php:688
 msgid "Basic information"
 msgstr ""
 
-#: mod/profiles.php:697
+#: mod/profiles.php:689
 msgid "Profile picture"
 msgstr ""
 
-#: mod/profiles.php:699
+#: mod/profiles.php:691
 msgid "Preferences"
 msgstr ""
 
-#: mod/profiles.php:700
+#: mod/profiles.php:692
 msgid "Status information"
 msgstr ""
 
-#: mod/profiles.php:701
+#: mod/profiles.php:693
 msgid "Additional information"
 msgstr ""
 
-#: mod/profiles.php:704
+#: mod/profiles.php:696
 msgid "Relation"
 msgstr ""
 
-#: mod/profiles.php:708
+#: mod/profiles.php:700
 msgid "Your Gender:"
 msgstr ""
 
-#: mod/profiles.php:709
+#: mod/profiles.php:701
 msgid "<span class=\"heart\">&hearts;</span> Marital Status:"
 msgstr ""
 
-#: mod/profiles.php:711
+#: mod/profiles.php:703
 msgid "Example: fishing photography software"
 msgstr ""
 
-#: mod/profiles.php:716
+#: mod/profiles.php:708
 msgid "Profile Name:"
 msgstr ""
 
-#: mod/profiles.php:716 mod/events.php:484 mod/events.php:496
-msgid "Required"
-msgstr ""
-
-#: mod/profiles.php:718
+#: mod/profiles.php:710
 msgid ""
 "This is your <strong>public</strong> profile.<br />It <strong>may</strong> "
 "be visible to anybody using the internet."
 msgstr ""
 
-#: mod/profiles.php:719
+#: mod/profiles.php:711
 msgid "Your Full Name:"
 msgstr ""
 
-#: mod/profiles.php:720
+#: mod/profiles.php:712
 msgid "Title/Description:"
 msgstr ""
 
-#: mod/profiles.php:723
+#: mod/profiles.php:715
 msgid "Street Address:"
 msgstr ""
 
-#: mod/profiles.php:724
+#: mod/profiles.php:716
 msgid "Locality/City:"
 msgstr ""
 
-#: mod/profiles.php:725
+#: mod/profiles.php:717
 msgid "Region/State:"
 msgstr ""
 
-#: mod/profiles.php:726
+#: mod/profiles.php:718
 msgid "Postal/Zip Code:"
 msgstr ""
 
-#: mod/profiles.php:727
+#: mod/profiles.php:719
 msgid "Country:"
 msgstr ""
 
-#: mod/profiles.php:731
+#: mod/profiles.php:723
 msgid "Who: (if applicable)"
 msgstr ""
 
-#: mod/profiles.php:731
+#: mod/profiles.php:723
 msgid "Examples: cathy123, Cathy Williams, cathy@example.com"
 msgstr ""
 
-#: mod/profiles.php:732
+#: mod/profiles.php:724
 msgid "Since [date]:"
 msgstr ""
 
-#: mod/profiles.php:734
+#: mod/profiles.php:726
 msgid "Tell us about yourself..."
 msgstr ""
 
-#: mod/profiles.php:735
+#: mod/profiles.php:727
 msgid "XMPP (Jabber) address:"
 msgstr ""
 
-#: mod/profiles.php:735
+#: mod/profiles.php:727
 msgid ""
 "The XMPP address will be propagated to your contacts so that they can follow "
 "you."
 msgstr ""
 
-#: mod/profiles.php:736
+#: mod/profiles.php:728
 msgid "Homepage URL:"
 msgstr ""
 
-#: mod/profiles.php:739
+#: mod/profiles.php:731
 msgid "Religious Views:"
 msgstr ""
 
-#: mod/profiles.php:740
+#: mod/profiles.php:732
 msgid "Public Keywords:"
 msgstr ""
 
-#: mod/profiles.php:740
+#: mod/profiles.php:732
 msgid "(Used for suggesting potential friends, can be seen by others)"
 msgstr ""
 
-#: mod/profiles.php:741
+#: mod/profiles.php:733
 msgid "Private Keywords:"
 msgstr ""
 
-#: mod/profiles.php:741
+#: mod/profiles.php:733
 msgid "(Used for searching profiles, never shown to others)"
 msgstr ""
 
-#: mod/profiles.php:744
+#: mod/profiles.php:736
 msgid "Musical interests"
 msgstr ""
 
-#: mod/profiles.php:745
+#: mod/profiles.php:737
 msgid "Books, literature"
 msgstr ""
 
-#: mod/profiles.php:746
+#: mod/profiles.php:738
 msgid "Television"
 msgstr ""
 
-#: mod/profiles.php:747
+#: mod/profiles.php:739
 msgid "Film/dance/culture/entertainment"
 msgstr ""
 
-#: mod/profiles.php:748
+#: mod/profiles.php:740
 msgid "Hobbies/Interests"
 msgstr ""
 
-#: mod/profiles.php:749
+#: mod/profiles.php:741
 msgid "Love/romance"
 msgstr ""
 
-#: mod/profiles.php:750
+#: mod/profiles.php:742
 msgid "Work/employment"
 msgstr ""
 
-#: mod/profiles.php:751
+#: mod/profiles.php:743
 msgid "School/education"
 msgstr ""
 
-#: mod/profiles.php:752
+#: mod/profiles.php:744
 msgid "Contact information and Social Networks"
 msgstr ""
 
-#: mod/profiles.php:794
+#: mod/profiles.php:788
 msgid "Edit/Manage Profiles"
 msgstr ""
 
-#: mod/allfriends.php:43
-msgid "No friends to display."
-msgstr ""
-
-#: mod/cal.php:149 mod/display.php:328 mod/profile.php:155
-msgid "Access to this profile has been restricted."
-msgstr ""
-
-#: mod/cal.php:276 mod/events.php:380
-msgid "View"
-msgstr ""
-
-#: mod/cal.php:277 mod/events.php:382
-msgid "Previous"
-msgstr ""
-
-#: mod/cal.php:278 mod/events.php:383 mod/install.php:231
-msgid "Next"
-msgstr ""
-
-#: mod/cal.php:287 mod/events.php:392
-msgid "list"
-msgstr ""
-
-#: mod/cal.php:297
-msgid "User not found"
-msgstr ""
-
-#: mod/cal.php:313
-msgid "This calendar format is not supported"
-msgstr ""
-
-#: mod/cal.php:315
-msgid "No exportable data found"
-msgstr ""
-
-#: mod/cal.php:330
-msgid "calendar"
-msgstr ""
-
-#: mod/common.php:86
-msgid "No contacts in common."
-msgstr ""
-
-#: mod/common.php:134 mod/contacts.php:863
-msgid "Common Friends"
-msgstr ""
-
-#: mod/community.php:27
-msgid "Not available."
-msgstr ""
-
-#: mod/directory.php:197 view/theme/vier/theme.php:201
-msgid "Global Directory"
-msgstr ""
-
-#: mod/directory.php:199
-msgid "Find on this site"
-msgstr ""
-
-#: mod/directory.php:201
-msgid "Results for:"
-msgstr ""
-
-#: mod/directory.php:203
-msgid "Site Directory"
-msgstr ""
-
-#: mod/directory.php:210
-msgid "No entries (some entries may be hidden)."
-msgstr ""
-
-#: mod/dirfind.php:36
-#, php-format
-msgid "People Search - %s"
-msgstr ""
-
-#: mod/dirfind.php:47
-#, php-format
-msgid "Forum Search - %s"
-msgstr ""
-
-#: mod/dirfind.php:240 mod/match.php:107
-msgid "No matches"
-msgstr ""
-
-#: mod/display.php:473
+#: mod/display.php:479
 msgid "Item has been removed."
-msgstr ""
-
-#: mod/events.php:95 mod/events.php:97
-msgid "Event can not end before it has started."
-msgstr ""
-
-#: mod/events.php:104 mod/events.php:106
-msgid "Event title and start time are required."
-msgstr ""
-
-#: mod/events.php:381
-msgid "Create New Event"
-msgstr ""
-
-#: mod/events.php:482
-msgid "Event details"
-msgstr ""
-
-#: mod/events.php:483
-msgid "Starting date and Title are required."
-msgstr ""
-
-#: mod/events.php:484 mod/events.php:485
-msgid "Event Starts:"
-msgstr ""
-
-#: mod/events.php:486 mod/events.php:502
-msgid "Finish date/time is not known or not relevant"
-msgstr ""
-
-#: mod/events.php:488 mod/events.php:489
-msgid "Event Finishes:"
-msgstr ""
-
-#: mod/events.php:490 mod/events.php:503
-msgid "Adjust for viewer timezone"
-msgstr ""
-
-#: mod/events.php:492
-msgid "Description:"
-msgstr ""
-
-#: mod/events.php:496 mod/events.php:498
-msgid "Title:"
-msgstr ""
-
-#: mod/events.php:499 mod/events.php:500
-msgid "Share this event"
-msgstr ""
-
-#: mod/maintenance.php:9
-msgid "System down for maintenance"
-msgstr ""
-
-#: mod/match.php:33
-msgid "No keywords to match. Please add keywords to your default profile."
-msgstr ""
-
-#: mod/match.php:86
-msgid "is interested in:"
-msgstr ""
-
-#: mod/match.php:100
-msgid "Profile Match"
-msgstr ""
-
-#: mod/profile.php:179
-msgid "Tips for New Members"
-msgstr ""
-
-#: mod/suggest.php:27
-msgid "Do you really want to delete this suggestion?"
-msgstr ""
-
-#: mod/suggest.php:71
-msgid ""
-"No suggestions available. If this is a new site, please try again in 24 "
-"hours."
-msgstr ""
-
-#: mod/suggest.php:84 mod/suggest.php:104
-msgid "Ignore/Hide"
-msgstr ""
-
-#: mod/update_community.php:19 mod/update_display.php:23
-#: mod/update_network.php:27 mod/update_notes.php:36 mod/update_profile.php:35
-msgid "[Embedded content - reload page to view]"
-msgstr ""
-
-#: mod/photos.php:88 mod/photos.php:1856
-msgid "Recent Photos"
-msgstr ""
-
-#: mod/photos.php:91 mod/photos.php:1283 mod/photos.php:1858
-msgid "Upload New Photos"
-msgstr ""
-
-#: mod/photos.php:105 mod/settings.php:36
-msgid "everybody"
-msgstr ""
-
-#: mod/photos.php:169
-msgid "Contact information unavailable"
-msgstr ""
-
-#: mod/photos.php:190
-msgid "Album not found."
-msgstr ""
-
-#: mod/photos.php:220 mod/photos.php:232 mod/photos.php:1227
-msgid "Delete Album"
-msgstr ""
-
-#: mod/photos.php:230
-msgid "Do you really want to delete this photo album and all its photos?"
-msgstr ""
-
-#: mod/photos.php:308 mod/photos.php:319 mod/photos.php:1540
-msgid "Delete Photo"
-msgstr ""
-
-#: mod/photos.php:317
-msgid "Do you really want to delete this photo?"
-msgstr ""
-
-#: mod/photos.php:688
-#, php-format
-msgid "%1$s was tagged in %2$s by %3$s"
-msgstr ""
-
-#: mod/photos.php:688
-msgid "a photo"
-msgstr ""
-
-#: mod/photos.php:794
-msgid "Image file is empty."
-msgstr ""
-
-#: mod/photos.php:954
-msgid "No photos selected"
-msgstr ""
-
-#: mod/photos.php:1054 mod/videos.php:305
-msgid "Access to this item is restricted."
-msgstr ""
-
-#: mod/photos.php:1114
-#, php-format
-msgid "You have used %1$.2f Mbytes of %2$.2f Mbytes photo storage."
-msgstr ""
-
-#: mod/photos.php:1148
-msgid "Upload Photos"
-msgstr ""
-
-#: mod/photos.php:1152 mod/photos.php:1222
-msgid "New album name: "
-msgstr ""
-
-#: mod/photos.php:1153
-msgid "or existing album name: "
-msgstr ""
-
-#: mod/photos.php:1154
-msgid "Do not show a status post for this upload"
-msgstr ""
-
-#: mod/photos.php:1165 mod/photos.php:1544 mod/settings.php:1300
-msgid "Show to Groups"
-msgstr ""
-
-#: mod/photos.php:1166 mod/photos.php:1545 mod/settings.php:1301
-msgid "Show to Contacts"
-msgstr ""
-
-#: mod/photos.php:1167
-msgid "Private Photo"
-msgstr ""
-
-#: mod/photos.php:1168
-msgid "Public Photo"
-msgstr ""
-
-#: mod/photos.php:1234
-msgid "Edit Album"
-msgstr ""
-
-#: mod/photos.php:1240
-msgid "Show Newest First"
-msgstr ""
-
-#: mod/photos.php:1242
-msgid "Show Oldest First"
-msgstr ""
-
-#: mod/photos.php:1269 mod/photos.php:1841
-msgid "View Photo"
-msgstr ""
-
-#: mod/photos.php:1315
-msgid "Permission denied. Access to this item may be restricted."
-msgstr ""
-
-#: mod/photos.php:1317
-msgid "Photo not available"
-msgstr ""
-
-#: mod/photos.php:1372
-msgid "View photo"
-msgstr ""
-
-#: mod/photos.php:1372
-msgid "Edit photo"
-msgstr ""
-
-#: mod/photos.php:1373
-msgid "Use as profile photo"
-msgstr ""
-
-#: mod/photos.php:1398
-msgid "View Full Size"
-msgstr ""
-
-#: mod/photos.php:1484
-msgid "Tags: "
-msgstr ""
-
-#: mod/photos.php:1487
-msgid "[Remove any tag]"
-msgstr ""
-
-#: mod/photos.php:1526
-msgid "New album name"
-msgstr ""
-
-#: mod/photos.php:1527
-msgid "Caption"
-msgstr ""
-
-#: mod/photos.php:1528
-msgid "Add a Tag"
-msgstr ""
-
-#: mod/photos.php:1528
-msgid "Example: @bob, @Barbara_Jensen, @jim@example.com, #California, #camping"
-msgstr ""
-
-#: mod/photos.php:1529
-msgid "Do not rotate"
-msgstr ""
-
-#: mod/photos.php:1530
-msgid "Rotate CW (right)"
-msgstr ""
-
-#: mod/photos.php:1531
-msgid "Rotate CCW (left)"
-msgstr ""
-
-#: mod/photos.php:1546
-msgid "Private photo"
-msgstr ""
-
-#: mod/photos.php:1547
-msgid "Public photo"
-msgstr ""
-
-#: mod/photos.php:1770
-msgid "Map"
-msgstr ""
-
-#: mod/photos.php:1847 mod/videos.php:387
-msgid "View Album"
-msgstr ""
-
-#: mod/register.php:93
-msgid ""
-"Registration successful. Please check your email for further instructions."
-msgstr ""
-
-#: mod/register.php:98
-#, php-format
-msgid ""
-"Failed to send email message. Here your accout details:<br> login: %s<br> "
-"password: %s<br><br>You can change your password after login."
-msgstr ""
-
-#: mod/register.php:105
-msgid "Registration successful."
-msgstr ""
-
-#: mod/register.php:111
-msgid "Your registration can not be processed."
-msgstr ""
-
-#: mod/register.php:160
-msgid "Your registration is pending approval by the site owner."
-msgstr ""
-
-#: mod/register.php:226
-msgid ""
-"You may (optionally) fill in this form via OpenID by supplying your OpenID "
-"and clicking 'Register'."
-msgstr ""
-
-#: mod/register.php:227
-msgid ""
-"If you are not familiar with OpenID, please leave that field blank and fill "
-"in the rest of the items."
-msgstr ""
-
-#: mod/register.php:228
-msgid "Your OpenID (optional): "
-msgstr ""
-
-#: mod/register.php:242
-msgid "Include your profile in member directory?"
-msgstr ""
-
-#: mod/register.php:267
-msgid "Note for the admin"
-msgstr ""
-
-#: mod/register.php:267
-msgid "Leave a message for the admin, why you want to join this node"
-msgstr ""
-
-#: mod/register.php:268
-msgid "Membership on this site is by invitation only."
-msgstr ""
-
-#: mod/register.php:269
-msgid "Your invitation ID: "
-msgstr ""
-
-#: mod/register.php:272 mod/admin.php:956
-msgid "Registration"
-msgstr ""
-
-#: mod/register.php:280
-msgid "Your Full Name (e.g. Joe Smith, real or real-looking): "
-msgstr ""
-
-#: mod/register.php:281
-msgid "Your Email Address: "
-msgstr ""
-
-#: mod/register.php:283 mod/settings.php:1271
-msgid "New Password:"
-msgstr ""
-
-#: mod/register.php:283
-msgid "Leave empty for an auto generated password."
-msgstr ""
-
-#: mod/register.php:284 mod/settings.php:1272
-msgid "Confirm:"
-msgstr ""
-
-#: mod/register.php:285
-msgid ""
-"Choose a profile nickname. This must begin with a text character. Your "
-"profile address on this site will then be '<strong>nickname@$sitename</"
-"strong>'."
-msgstr ""
-
-#: mod/register.php:286
-msgid "Choose a nickname: "
-msgstr ""
-
-#: mod/register.php:296
-msgid "Import your profile to this friendica instance"
-msgstr ""
-
-#: mod/settings.php:43 mod/admin.php:1396
-msgid "Account"
-msgstr ""
-
-#: mod/settings.php:52 mod/admin.php:160
-msgid "Additional features"
-msgstr ""
-
-#: mod/settings.php:60
-msgid "Display"
-msgstr ""
-
-#: mod/settings.php:67 mod/settings.php:886
-msgid "Social Networks"
-msgstr ""
-
-#: mod/settings.php:74 mod/admin.php:158 mod/admin.php:1522 mod/admin.php:1582
-msgid "Plugins"
-msgstr ""
-
-#: mod/settings.php:88
-msgid "Connected apps"
-msgstr ""
-
-#: mod/settings.php:102
-msgid "Remove account"
-msgstr ""
-
-#: mod/settings.php:155
-msgid "Missing some important data!"
-msgstr ""
-
-#: mod/settings.php:158 mod/settings.php:704 mod/contacts.php:804
-msgid "Update"
-msgstr ""
-
-#: mod/settings.php:269
-msgid "Failed to connect with email account using the settings provided."
-msgstr ""
-
-#: mod/settings.php:274
-msgid "Email settings updated."
-msgstr ""
-
-#: mod/settings.php:289
-msgid "Features updated"
-msgstr ""
-
-#: mod/settings.php:359
-msgid "Relocate message has been send to your contacts"
-msgstr ""
-
-#: mod/settings.php:378
-msgid "Empty passwords are not allowed. Password unchanged."
-msgstr ""
-
-#: mod/settings.php:386
-msgid "Wrong password."
-msgstr ""
-
-#: mod/settings.php:397
-msgid "Password changed."
-msgstr ""
-
-#: mod/settings.php:399
-msgid "Password update failed. Please try again."
-msgstr ""
-
-#: mod/settings.php:479
-msgid " Please use a shorter name."
-msgstr ""
-
-#: mod/settings.php:481
-msgid " Name too short."
-msgstr ""
-
-#: mod/settings.php:490
-msgid "Wrong Password"
-msgstr ""
-
-#: mod/settings.php:495
-msgid " Not valid email."
-msgstr ""
-
-#: mod/settings.php:501
-msgid " Cannot change to that email."
-msgstr ""
-
-#: mod/settings.php:557
-msgid "Private forum has no privacy permissions. Using default privacy group."
-msgstr ""
-
-#: mod/settings.php:561
-msgid "Private forum has no privacy permissions and no default privacy group."
-msgstr ""
-
-#: mod/settings.php:601
-msgid "Settings updated."
-msgstr ""
-
-#: mod/settings.php:677 mod/settings.php:703 mod/settings.php:739
-msgid "Add application"
-msgstr ""
-
-#: mod/settings.php:678 mod/settings.php:788 mod/settings.php:835
-#: mod/settings.php:904 mod/settings.php:996 mod/settings.php:1264
-#: mod/admin.php:955 mod/admin.php:1583 mod/admin.php:1831 mod/admin.php:1905
-#: mod/admin.php:2055
-msgid "Save Settings"
-msgstr ""
-
-#: mod/settings.php:681 mod/settings.php:707
-msgid "Consumer Key"
-msgstr ""
-
-#: mod/settings.php:682 mod/settings.php:708
-msgid "Consumer Secret"
-msgstr ""
-
-#: mod/settings.php:683 mod/settings.php:709
-msgid "Redirect"
-msgstr ""
-
-#: mod/settings.php:684 mod/settings.php:710
-msgid "Icon url"
-msgstr ""
-
-#: mod/settings.php:695
-msgid "You can't edit this application."
-msgstr ""
-
-#: mod/settings.php:738
-msgid "Connected Apps"
-msgstr ""
-
-#: mod/settings.php:742
-msgid "Client key starts with"
-msgstr ""
-
-#: mod/settings.php:743
-msgid "No name"
-msgstr ""
-
-#: mod/settings.php:744
-msgid "Remove authorization"
-msgstr ""
-
-#: mod/settings.php:756
-msgid "No Plugin settings configured"
-msgstr ""
-
-#: mod/settings.php:764
-msgid "Plugin Settings"
-msgstr ""
-
-#: mod/settings.php:778 mod/admin.php:2044 mod/admin.php:2045
-msgid "Off"
-msgstr ""
-
-#: mod/settings.php:778 mod/admin.php:2044 mod/admin.php:2045
-msgid "On"
-msgstr ""
-
-#: mod/settings.php:786
-msgid "Additional Features"
-msgstr ""
-
-#: mod/settings.php:796 mod/settings.php:800
-msgid "General Social Media Settings"
-msgstr ""
-
-#: mod/settings.php:806
-msgid "Disable intelligent shortening"
-msgstr ""
-
-#: mod/settings.php:808
-msgid ""
-"Normally the system tries to find the best link to add to shortened posts. "
-"If this option is enabled then every shortened post will always point to the "
-"original friendica post."
-msgstr ""
-
-#: mod/settings.php:814
-msgid "Automatically follow any GNU Social (OStatus) followers/mentioners"
-msgstr ""
-
-#: mod/settings.php:816
-msgid ""
-"If you receive a message from an unknown OStatus user, this option decides "
-"what to do. If it is checked, a new contact will be created for every "
-"unknown user."
-msgstr ""
-
-#: mod/settings.php:822
-msgid "Default group for OStatus contacts"
-msgstr ""
-
-#: mod/settings.php:828
-msgid "Your legacy GNU Social account"
-msgstr ""
-
-#: mod/settings.php:830
-msgid ""
-"If you enter your old GNU Social/Statusnet account name here (in the format "
-"user@domain.tld), your contacts will be added automatically. The field will "
-"be emptied when done."
-msgstr ""
-
-#: mod/settings.php:833
-msgid "Repair OStatus subscriptions"
-msgstr ""
-
-#: mod/settings.php:842 mod/settings.php:843
-#, php-format
-msgid "Built-in support for %s connectivity is %s"
-msgstr ""
-
-#: mod/settings.php:842 mod/settings.php:843
-msgid "enabled"
-msgstr ""
-
-#: mod/settings.php:842 mod/settings.php:843
-msgid "disabled"
-msgstr ""
-
-#: mod/settings.php:843
-msgid "GNU Social (OStatus)"
-msgstr ""
-
-#: mod/settings.php:879
-msgid "Email access is disabled on this site."
-msgstr ""
-
-#: mod/settings.php:891
-msgid "Email/Mailbox Setup"
-msgstr ""
-
-#: mod/settings.php:892
-msgid ""
-"If you wish to communicate with email contacts using this service "
-"(optional), please specify how to connect to your mailbox."
-msgstr ""
-
-#: mod/settings.php:893
-msgid "Last successful email check:"
-msgstr ""
-
-#: mod/settings.php:895
-msgid "IMAP server name:"
-msgstr ""
-
-#: mod/settings.php:896
-msgid "IMAP port:"
-msgstr ""
-
-#: mod/settings.php:897
-msgid "Security:"
-msgstr ""
-
-#: mod/settings.php:897 mod/settings.php:902
-msgid "None"
-msgstr ""
-
-#: mod/settings.php:898
-msgid "Email login name:"
-msgstr ""
-
-#: mod/settings.php:899
-msgid "Email password:"
-msgstr ""
-
-#: mod/settings.php:900
-msgid "Reply-to address:"
-msgstr ""
-
-#: mod/settings.php:901
-msgid "Send public posts to all email contacts:"
-msgstr ""
-
-#: mod/settings.php:902
-msgid "Action after import:"
-msgstr ""
-
-#: mod/settings.php:902
-msgid "Move to folder"
-msgstr ""
-
-#: mod/settings.php:903
-msgid "Move to folder:"
-msgstr ""
-
-#: mod/settings.php:934 mod/admin.php:862
-msgid "No special theme for mobile devices"
-msgstr ""
-
-#: mod/settings.php:994
-msgid "Display Settings"
-msgstr ""
-
-#: mod/settings.php:1000 mod/settings.php:1023
-msgid "Display Theme:"
-msgstr ""
-
-#: mod/settings.php:1001
-msgid "Mobile Theme:"
-msgstr ""
-
-#: mod/settings.php:1002
-msgid "Suppress warning of insecure networks"
-msgstr ""
-
-#: mod/settings.php:1002
-msgid ""
-"Should the system suppress the warning that the current group contains "
-"members of networks that can't receive non public postings."
-msgstr ""
-
-#: mod/settings.php:1003
-msgid "Update browser every xx seconds"
-msgstr ""
-
-#: mod/settings.php:1003
-msgid "Minimum of 10 seconds. Enter -1 to disable it."
-msgstr ""
-
-#: mod/settings.php:1004
-msgid "Number of items to display per page:"
-msgstr ""
-
-#: mod/settings.php:1004 mod/settings.php:1005
-msgid "Maximum of 100 items"
-msgstr ""
-
-#: mod/settings.php:1005
-msgid "Number of items to display per page when viewed from mobile device:"
-msgstr ""
-
-#: mod/settings.php:1006
-msgid "Don't show emoticons"
-msgstr ""
-
-#: mod/settings.php:1007
-msgid "Calendar"
-msgstr ""
-
-#: mod/settings.php:1008
-msgid "Beginning of week:"
-msgstr ""
-
-#: mod/settings.php:1009
-msgid "Don't show notices"
-msgstr ""
-
-#: mod/settings.php:1010
-msgid "Infinite scroll"
-msgstr ""
-
-#: mod/settings.php:1011
-msgid "Automatic updates only at the top of the network page"
-msgstr ""
-
-#: mod/settings.php:1012
-msgid "Bandwith Saver Mode"
-msgstr ""
-
-#: mod/settings.php:1012
-msgid ""
-"When enabled, embedded content is not displayed on automatic updates, they "
-"only show on page reload."
-msgstr ""
-
-#: mod/settings.php:1014
-msgid "General Theme Settings"
-msgstr ""
-
-#: mod/settings.php:1015
-msgid "Custom Theme Settings"
-msgstr ""
-
-#: mod/settings.php:1016
-msgid "Content Settings"
-msgstr ""
-
-#: mod/settings.php:1017 view/theme/frio/config.php:61
-#: view/theme/quattro/config.php:66 view/theme/vier/config.php:109
-#: view/theme/duepuntozero/config.php:61
-msgid "Theme settings"
-msgstr ""
-
-#: mod/settings.php:1099
-msgid "Account Types"
-msgstr ""
-
-#: mod/settings.php:1100
-msgid "Personal Page Subtypes"
-msgstr ""
-
-#: mod/settings.php:1101
-msgid "Community Forum Subtypes"
-msgstr ""
-
-#: mod/settings.php:1108
-msgid "Personal Page"
-msgstr ""
-
-#: mod/settings.php:1109
-msgid "This account is a regular personal profile"
-msgstr ""
-
-#: mod/settings.php:1112
-msgid "Organisation Page"
-msgstr ""
-
-#: mod/settings.php:1113
-msgid "This account is a profile for an organisation"
-msgstr ""
-
-#: mod/settings.php:1116
-msgid "News Page"
-msgstr ""
-
-#: mod/settings.php:1117
-msgid "This account is a news account/reflector"
-msgstr ""
-
-#: mod/settings.php:1120
-msgid "Community Forum"
-msgstr ""
-
-#: mod/settings.php:1121
-msgid ""
-"This account is a community forum where people can discuss with each other"
-msgstr ""
-
-#: mod/settings.php:1124
-msgid "Normal Account Page"
-msgstr ""
-
-#: mod/settings.php:1125
-msgid "This account is a normal personal profile"
-msgstr ""
-
-#: mod/settings.php:1128
-msgid "Soapbox Page"
-msgstr ""
-
-#: mod/settings.php:1129
-msgid "Automatically approve all connection/friend requests as read-only fans"
-msgstr ""
-
-#: mod/settings.php:1132
-msgid "Public Forum"
-msgstr ""
-
-#: mod/settings.php:1133
-msgid "Automatically approve all contact requests"
-msgstr ""
-
-#: mod/settings.php:1136
-msgid "Automatic Friend Page"
-msgstr ""
-
-#: mod/settings.php:1137
-msgid "Automatically approve all connection/friend requests as friends"
-msgstr ""
-
-#: mod/settings.php:1140
-msgid "Private Forum [Experimental]"
-msgstr ""
-
-#: mod/settings.php:1141
-msgid "Private forum - approved members only"
-msgstr ""
-
-#: mod/settings.php:1153
-msgid "OpenID:"
-msgstr ""
-
-#: mod/settings.php:1153
-msgid "(Optional) Allow this OpenID to login to this account."
-msgstr ""
-
-#: mod/settings.php:1163
-msgid "Publish your default profile in your local site directory?"
-msgstr ""
-
-#: mod/settings.php:1169
-msgid "Publish your default profile in the global social directory?"
-msgstr ""
-
-#: mod/settings.php:1177
-msgid "Hide your contact/friend list from viewers of your default profile?"
-msgstr ""
-
-#: mod/settings.php:1181
-msgid ""
-"If enabled, posting public messages to Diaspora and other networks isn't "
-"possible."
-msgstr ""
-
-#: mod/settings.php:1186
-msgid "Allow friends to post to your profile page?"
-msgstr ""
-
-#: mod/settings.php:1192
-msgid "Allow friends to tag your posts?"
-msgstr ""
-
-#: mod/settings.php:1198
-msgid "Allow us to suggest you as a potential friend to new members?"
-msgstr ""
-
-#: mod/settings.php:1204
-msgid "Permit unknown people to send you private mail?"
-msgstr ""
-
-#: mod/settings.php:1212
-msgid "Profile is <strong>not published</strong>."
-msgstr ""
-
-#: mod/settings.php:1220
-#, php-format
-msgid "Your Identity Address is <strong>'%s'</strong> or '%s'."
-msgstr ""
-
-#: mod/settings.php:1227
-msgid "Automatically expire posts after this many days:"
-msgstr ""
-
-#: mod/settings.php:1227
-msgid "If empty, posts will not expire. Expired posts will be deleted"
-msgstr ""
-
-#: mod/settings.php:1228
-msgid "Advanced expiration settings"
-msgstr ""
-
-#: mod/settings.php:1229
-msgid "Advanced Expiration"
-msgstr ""
-
-#: mod/settings.php:1230
-msgid "Expire posts:"
-msgstr ""
-
-#: mod/settings.php:1231
-msgid "Expire personal notes:"
-msgstr ""
-
-#: mod/settings.php:1232
-msgid "Expire starred posts:"
-msgstr ""
-
-#: mod/settings.php:1233
-msgid "Expire photos:"
-msgstr ""
-
-#: mod/settings.php:1234
-msgid "Only expire posts by others:"
-msgstr ""
-
-#: mod/settings.php:1262
-msgid "Account Settings"
-msgstr ""
-
-#: mod/settings.php:1270
-msgid "Password Settings"
-msgstr ""
-
-#: mod/settings.php:1272
-msgid "Leave password fields blank unless changing"
-msgstr ""
-
-#: mod/settings.php:1273
-msgid "Current Password:"
-msgstr ""
-
-#: mod/settings.php:1273 mod/settings.php:1274
-msgid "Your current password to confirm the changes"
-msgstr ""
-
-#: mod/settings.php:1274
-msgid "Password:"
-msgstr ""
-
-#: mod/settings.php:1278
-msgid "Basic Settings"
-msgstr ""
-
-#: mod/settings.php:1280
-msgid "Email Address:"
-msgstr ""
-
-#: mod/settings.php:1281
-msgid "Your Timezone:"
-msgstr ""
-
-#: mod/settings.php:1282
-msgid "Your Language:"
-msgstr ""
-
-#: mod/settings.php:1282
-msgid ""
-"Set the language we use to show you friendica interface and to send you "
-"emails"
-msgstr ""
-
-#: mod/settings.php:1283
-msgid "Default Post Location:"
-msgstr ""
-
-#: mod/settings.php:1284
-msgid "Use Browser Location:"
-msgstr ""
-
-#: mod/settings.php:1287
-msgid "Security and Privacy Settings"
-msgstr ""
-
-#: mod/settings.php:1289
-msgid "Maximum Friend Requests/Day:"
-msgstr ""
-
-#: mod/settings.php:1289 mod/settings.php:1319
-msgid "(to prevent spam abuse)"
-msgstr ""
-
-#: mod/settings.php:1290
-msgid "Default Post Permissions"
-msgstr ""
-
-#: mod/settings.php:1291
-msgid "(click to open/close)"
-msgstr ""
-
-#: mod/settings.php:1302
-msgid "Default Private Post"
-msgstr ""
-
-#: mod/settings.php:1303
-msgid "Default Public Post"
-msgstr ""
-
-#: mod/settings.php:1307
-msgid "Default Permissions for New Posts"
-msgstr ""
-
-#: mod/settings.php:1319
-msgid "Maximum private messages per day from unknown people:"
-msgstr ""
-
-#: mod/settings.php:1322
-msgid "Notification Settings"
-msgstr ""
-
-#: mod/settings.php:1323
-msgid "By default post a status message when:"
-msgstr ""
-
-#: mod/settings.php:1324
-msgid "accepting a friend request"
-msgstr ""
-
-#: mod/settings.php:1325
-msgid "joining a forum/community"
-msgstr ""
-
-#: mod/settings.php:1326
-msgid "making an <em>interesting</em> profile change"
-msgstr ""
-
-#: mod/settings.php:1327
-msgid "Send a notification email when:"
-msgstr ""
-
-#: mod/settings.php:1328
-msgid "You receive an introduction"
-msgstr ""
-
-#: mod/settings.php:1329
-msgid "Your introductions are confirmed"
-msgstr ""
-
-#: mod/settings.php:1330
-msgid "Someone writes on your profile wall"
-msgstr ""
-
-#: mod/settings.php:1331
-msgid "Someone writes a followup comment"
-msgstr ""
-
-#: mod/settings.php:1332
-msgid "You receive a private message"
-msgstr ""
-
-#: mod/settings.php:1333
-msgid "You receive a friend suggestion"
-msgstr ""
-
-#: mod/settings.php:1334
-msgid "You are tagged in a post"
-msgstr ""
-
-#: mod/settings.php:1335
-msgid "You are poked/prodded/etc. in a post"
-msgstr ""
-
-#: mod/settings.php:1337
-msgid "Activate desktop notifications"
-msgstr ""
-
-#: mod/settings.php:1337
-msgid "Show desktop popup on new notifications"
-msgstr ""
-
-#: mod/settings.php:1339
-msgid "Text-only notification emails"
-msgstr ""
-
-#: mod/settings.php:1341
-msgid "Send text only notification emails, without the html part"
-msgstr ""
-
-#: mod/settings.php:1343
-msgid "Advanced Account/Page Type Settings"
-msgstr ""
-
-#: mod/settings.php:1344
-msgid "Change the behaviour of this account for special situations"
-msgstr ""
-
-#: mod/settings.php:1347
-msgid "Relocate"
-msgstr ""
-
-#: mod/settings.php:1348
-msgid ""
-"If you have moved this profile from another server, and some of your "
-"contacts don't receive your updates, try pushing this button."
-msgstr ""
-
-#: mod/settings.php:1349
-msgid "Resend relocate message to contacts"
-msgstr ""
-
-#: mod/videos.php:120
-msgid "Do you really want to delete this video?"
-msgstr ""
-
-#: mod/videos.php:125
-msgid "Delete Video"
-msgstr ""
-
-#: mod/videos.php:204
-msgid "No videos selected"
-msgstr ""
-
-#: mod/videos.php:396
-msgid "Recent Videos"
-msgstr ""
-
-#: mod/videos.php:398
-msgid "Upload New Videos"
-msgstr ""
-
-#: mod/wall_attach.php:17 mod/wall_attach.php:25 mod/wall_attach.php:76
-#: mod/wall_upload.php:20 mod/wall_upload.php:33 mod/wall_upload.php:86
-#: mod/wall_upload.php:122 mod/wall_upload.php:125
-msgid "Invalid request."
-msgstr ""
-
-#: mod/wall_attach.php:94
-msgid "Sorry, maybe your upload is bigger than the PHP configuration allows"
-msgstr ""
-
-#: mod/wall_attach.php:94
-msgid "Or - did you try to upload an empty file?"
-msgstr ""
-
-#: mod/wall_attach.php:105
-#, php-format
-msgid "File exceeds size limit of %s"
-msgstr ""
-
-#: mod/wall_attach.php:156 mod/wall_attach.php:172
-msgid "File upload failed."
 msgstr ""
 
 #: mod/admin.php:92
 msgid "Theme settings updated."
 msgstr ""
 
-#: mod/admin.php:156 mod/admin.php:954
+#: mod/admin.php:157 mod/admin.php:975
 msgid "Site"
 msgstr ""
 
-#: mod/admin.php:157 mod/admin.php:898 mod/admin.php:1404 mod/admin.php:1420
+#: mod/admin.php:158 mod/admin.php:909 mod/admin.php:1425 mod/admin.php:1441
 msgid "Users"
 msgstr ""
 
-#: mod/admin.php:159 mod/admin.php:1780 mod/admin.php:1830
+#: mod/admin.php:160 mod/admin.php:1813 mod/admin.php:1863
 msgid "Themes"
 msgstr ""
 
-#: mod/admin.php:161
+#: mod/admin.php:162
 msgid "DB updates"
 msgstr ""
 
-#: mod/admin.php:162 mod/admin.php:406
+#: mod/admin.php:163 mod/admin.php:407
 msgid "Inspect Queue"
 msgstr ""
 
-#: mod/admin.php:163 mod/admin.php:372
+#: mod/admin.php:164 mod/admin.php:373
 msgid "Federation Statistics"
 msgstr ""
 
-#: mod/admin.php:177 mod/admin.php:188 mod/admin.php:1904
+#: mod/admin.php:178 mod/admin.php:189 mod/admin.php:1937
 msgid "Logs"
 msgstr ""
 
-#: mod/admin.php:178 mod/admin.php:1972
+#: mod/admin.php:179 mod/admin.php:2005
 msgid "View Logs"
 msgstr ""
 
-#: mod/admin.php:179
+#: mod/admin.php:180
 msgid "probe address"
 msgstr ""
 
-#: mod/admin.php:180
+#: mod/admin.php:181
 msgid "check webfinger"
 msgstr ""
 
-#: mod/admin.php:187
+#: mod/admin.php:188
 msgid "Plugin Features"
 msgstr ""
 
-#: mod/admin.php:189
+#: mod/admin.php:190
 msgid "diagnostics"
 msgstr ""
 
-#: mod/admin.php:190
+#: mod/admin.php:191
 msgid "User registrations waiting for confirmation"
 msgstr ""
 
-#: mod/admin.php:306
+#: mod/admin.php:307
 msgid "unknown"
 msgstr ""
 
-#: mod/admin.php:365
+#: mod/admin.php:366
 msgid ""
 "This page offers you some numbers to the known part of the federated social "
 "network your Friendica node is part of. These numbers are not complete but "
 "only reflect the part of the network your node is aware of."
 msgstr ""
 
-#: mod/admin.php:366
+#: mod/admin.php:367
 msgid ""
 "The <em>Auto Discovered Contact Directory</em> feature is not enabled, it "
 "will improve the data displayed here."
 msgstr ""
 
-#: mod/admin.php:371 mod/admin.php:405 mod/admin.php:484 mod/admin.php:953
-#: mod/admin.php:1403 mod/admin.php:1521 mod/admin.php:1581 mod/admin.php:1779
-#: mod/admin.php:1829 mod/admin.php:1903 mod/admin.php:1971
+#: mod/admin.php:372 mod/admin.php:406 mod/admin.php:485 mod/admin.php:974
+#: mod/admin.php:1424 mod/admin.php:1542 mod/admin.php:1605 mod/admin.php:1812
+#: mod/admin.php:1862 mod/admin.php:1936 mod/admin.php:2004
 msgid "Administration"
 msgstr ""
 
-#: mod/admin.php:378
+#: mod/admin.php:379
 #, php-format
 msgid "Currently this node is aware of %d nodes from the following platforms:"
 msgstr ""
 
-#: mod/admin.php:408
+#: mod/admin.php:409
 msgid "ID"
 msgstr ""
 
-#: mod/admin.php:409
+#: mod/admin.php:410
 msgid "Recipient Name"
 msgstr ""
 
-#: mod/admin.php:410
+#: mod/admin.php:411
 msgid "Recipient Profile"
 msgstr ""
 
-#: mod/admin.php:412
+#: mod/admin.php:413
 msgid "Created"
 msgstr ""
 
-#: mod/admin.php:413
+#: mod/admin.php:414
 msgid "Last Tried"
 msgstr ""
 
-#: mod/admin.php:414
+#: mod/admin.php:415
 msgid ""
 "This page lists the content of the queue for outgoing postings. These are "
 "postings the initial delivery failed for. They will be resend later and "
 "eventually deleted if the delivery fails permanently."
 msgstr ""
 
-#: mod/admin.php:439
+#: mod/admin.php:440
 #, php-format
 msgid ""
 "Your DB still runs with MyISAM tables. You should change the engine type to "
@@ -6364,682 +7240,674 @@ msgid ""
 "tt> in the <tt>/util</tt> directory of your Friendica installation.<br />"
 msgstr ""
 
-#: mod/admin.php:444
+#: mod/admin.php:445
 msgid ""
 "You are using a MySQL version which does not support all features that "
 "Friendica uses. You should consider switching to MariaDB."
 msgstr ""
 
-#: mod/admin.php:448 mod/admin.php:1352
+#: mod/admin.php:449 mod/admin.php:1373
 msgid "Normal Account"
 msgstr ""
 
-#: mod/admin.php:449 mod/admin.php:1353
+#: mod/admin.php:450 mod/admin.php:1374
 msgid "Soapbox Account"
 msgstr ""
 
-#: mod/admin.php:450 mod/admin.php:1354
+#: mod/admin.php:451 mod/admin.php:1375
 msgid "Community/Celebrity Account"
 msgstr ""
 
-#: mod/admin.php:451 mod/admin.php:1355
+#: mod/admin.php:452 mod/admin.php:1376
 msgid "Automatic Friend Account"
 msgstr ""
 
-#: mod/admin.php:452
+#: mod/admin.php:453
 msgid "Blog Account"
 msgstr ""
 
-#: mod/admin.php:453
+#: mod/admin.php:454
 msgid "Private Forum"
 msgstr ""
 
-#: mod/admin.php:479
+#: mod/admin.php:480
 msgid "Message queues"
 msgstr ""
 
-#: mod/admin.php:485
+#: mod/admin.php:486
 msgid "Summary"
 msgstr ""
 
-#: mod/admin.php:488
+#: mod/admin.php:489
 msgid "Registered users"
 msgstr ""
 
-#: mod/admin.php:490
+#: mod/admin.php:491
 msgid "Pending registrations"
 msgstr ""
 
-#: mod/admin.php:491
+#: mod/admin.php:492
 msgid "Version"
 msgstr ""
 
-#: mod/admin.php:496
+#: mod/admin.php:497
 msgid "Active plugins"
 msgstr ""
 
-#: mod/admin.php:521
+#: mod/admin.php:522
 msgid "Can not parse base url. Must have at least <scheme>://<domain>"
 msgstr ""
 
-#: mod/admin.php:826
+#: mod/admin.php:827
 msgid "RINO2 needs mcrypt php extension to work."
 msgstr ""
 
-#: mod/admin.php:834
+#: mod/admin.php:835
 msgid "Site settings updated."
 msgstr ""
 
-#: mod/admin.php:881
+#: mod/admin.php:892
 msgid "No community page"
 msgstr ""
 
-#: mod/admin.php:882
+#: mod/admin.php:893
 msgid "Public postings from users of this site"
 msgstr ""
 
-#: mod/admin.php:883
+#: mod/admin.php:894
 msgid "Global community page"
 msgstr ""
 
-#: mod/admin.php:888 mod/contacts.php:530
-msgid "Never"
-msgstr ""
-
-#: mod/admin.php:889
+#: mod/admin.php:900
 msgid "At post arrival"
 msgstr ""
 
-#: mod/admin.php:897 mod/contacts.php:557
-msgid "Disabled"
-msgstr ""
-
-#: mod/admin.php:899
+#: mod/admin.php:910
 msgid "Users, Global Contacts"
 msgstr ""
 
-#: mod/admin.php:900
+#: mod/admin.php:911
 msgid "Users, Global Contacts/fallback"
 msgstr ""
 
-#: mod/admin.php:904
+#: mod/admin.php:915
 msgid "One month"
 msgstr ""
 
-#: mod/admin.php:905
+#: mod/admin.php:916
 msgid "Three months"
 msgstr ""
 
-#: mod/admin.php:906
+#: mod/admin.php:917
 msgid "Half a year"
 msgstr ""
 
-#: mod/admin.php:907
+#: mod/admin.php:918
 msgid "One year"
 msgstr ""
 
-#: mod/admin.php:912
+#: mod/admin.php:923
 msgid "Multi user instance"
 msgstr ""
 
-#: mod/admin.php:935
+#: mod/admin.php:946
 msgid "Closed"
 msgstr ""
 
-#: mod/admin.php:936
+#: mod/admin.php:947
 msgid "Requires approval"
 msgstr ""
 
-#: mod/admin.php:937
+#: mod/admin.php:948
 msgid "Open"
 msgstr ""
 
-#: mod/admin.php:941
+#: mod/admin.php:952
 msgid "No SSL policy, links will track page SSL state"
 msgstr ""
 
-#: mod/admin.php:942
+#: mod/admin.php:953
 msgid "Force all links to use SSL"
 msgstr ""
 
-#: mod/admin.php:943
+#: mod/admin.php:954
 msgid "Self-signed certificate, use SSL for local links only (discouraged)"
 msgstr ""
 
-#: mod/admin.php:957
+#: mod/admin.php:978
 msgid "File upload"
 msgstr ""
 
-#: mod/admin.php:958
+#: mod/admin.php:979
 msgid "Policies"
 msgstr ""
 
-#: mod/admin.php:960
+#: mod/admin.php:981
 msgid "Auto Discovered Contact Directory"
 msgstr ""
 
-#: mod/admin.php:961
+#: mod/admin.php:982
 msgid "Performance"
 msgstr ""
 
-#: mod/admin.php:962
+#: mod/admin.php:983
 msgid "Worker"
 msgstr ""
 
-#: mod/admin.php:963
+#: mod/admin.php:984
 msgid ""
 "Relocate - WARNING: advanced function. Could make this server unreachable."
 msgstr ""
 
-#: mod/admin.php:966
+#: mod/admin.php:987
 msgid "Site name"
 msgstr ""
 
-#: mod/admin.php:967
+#: mod/admin.php:988
 msgid "Host name"
 msgstr ""
 
-#: mod/admin.php:968
+#: mod/admin.php:989
 msgid "Sender Email"
 msgstr ""
 
-#: mod/admin.php:968
+#: mod/admin.php:989
 msgid ""
 "The email address your server shall use to send notification emails from."
 msgstr ""
 
-#: mod/admin.php:969
+#: mod/admin.php:990
 msgid "Banner/Logo"
 msgstr ""
 
-#: mod/admin.php:970
+#: mod/admin.php:991
 msgid "Shortcut icon"
 msgstr ""
 
-#: mod/admin.php:970
+#: mod/admin.php:991
 msgid "Link to an icon that will be used for browsers."
 msgstr ""
 
-#: mod/admin.php:971
+#: mod/admin.php:992
 msgid "Touch icon"
 msgstr ""
 
-#: mod/admin.php:971
+#: mod/admin.php:992
 msgid "Link to an icon that will be used for tablets and mobiles."
 msgstr ""
 
-#: mod/admin.php:972
+#: mod/admin.php:993
 msgid "Additional Info"
 msgstr ""
 
-#: mod/admin.php:972
+#: mod/admin.php:993
 #, php-format
 msgid ""
 "For public servers: you can add additional information here that will be "
 "listed at %s/siteinfo."
 msgstr ""
 
-#: mod/admin.php:973
+#: mod/admin.php:994
 msgid "System language"
 msgstr ""
 
-#: mod/admin.php:974
+#: mod/admin.php:995
 msgid "System theme"
 msgstr ""
 
-#: mod/admin.php:974
+#: mod/admin.php:995
 msgid ""
 "Default system theme - may be over-ridden by user profiles - <a href='#' "
 "id='cnftheme'>change theme settings</a>"
 msgstr ""
 
-#: mod/admin.php:975
+#: mod/admin.php:996
 msgid "Mobile system theme"
 msgstr ""
 
-#: mod/admin.php:975
+#: mod/admin.php:996
 msgid "Theme for mobile devices"
 msgstr ""
 
-#: mod/admin.php:976
+#: mod/admin.php:997
 msgid "SSL link policy"
 msgstr ""
 
-#: mod/admin.php:976
+#: mod/admin.php:997
 msgid "Determines whether generated links should be forced to use SSL"
 msgstr ""
 
-#: mod/admin.php:977
+#: mod/admin.php:998
 msgid "Force SSL"
 msgstr ""
 
-#: mod/admin.php:977
+#: mod/admin.php:998
 msgid ""
 "Force all Non-SSL requests to SSL - Attention: on some systems it could lead "
 "to endless loops."
 msgstr ""
 
-#: mod/admin.php:978
+#: mod/admin.php:999
 msgid "Old style 'Share'"
 msgstr ""
 
-#: mod/admin.php:978
+#: mod/admin.php:999
 msgid "Deactivates the bbcode element 'share' for repeating items."
 msgstr ""
 
-#: mod/admin.php:979
+#: mod/admin.php:1000
 msgid "Hide help entry from navigation menu"
 msgstr ""
 
-#: mod/admin.php:979
+#: mod/admin.php:1000
 msgid ""
 "Hides the menu entry for the Help pages from the navigation menu. You can "
 "still access it calling /help directly."
 msgstr ""
 
-#: mod/admin.php:980
+#: mod/admin.php:1001
 msgid "Single user instance"
 msgstr ""
 
-#: mod/admin.php:980
+#: mod/admin.php:1001
 msgid "Make this instance multi-user or single-user for the named user"
 msgstr ""
 
-#: mod/admin.php:981
+#: mod/admin.php:1002
 msgid "Maximum image size"
 msgstr ""
 
-#: mod/admin.php:981
+#: mod/admin.php:1002
 msgid ""
 "Maximum size in bytes of uploaded images. Default is 0, which means no "
 "limits."
 msgstr ""
 
-#: mod/admin.php:982
+#: mod/admin.php:1003
 msgid "Maximum image length"
 msgstr ""
 
-#: mod/admin.php:982
+#: mod/admin.php:1003
 msgid ""
 "Maximum length in pixels of the longest side of uploaded images. Default is "
 "-1, which means no limits."
 msgstr ""
 
-#: mod/admin.php:983
+#: mod/admin.php:1004
 msgid "JPEG image quality"
 msgstr ""
 
-#: mod/admin.php:983
+#: mod/admin.php:1004
 msgid ""
 "Uploaded JPEGS will be saved at this quality setting [0-100]. Default is "
 "100, which is full quality."
 msgstr ""
 
-#: mod/admin.php:985
+#: mod/admin.php:1006
 msgid "Register policy"
 msgstr ""
 
-#: mod/admin.php:986
+#: mod/admin.php:1007
 msgid "Maximum Daily Registrations"
 msgstr ""
 
-#: mod/admin.php:986
+#: mod/admin.php:1007
 msgid ""
 "If registration is permitted above, this sets the maximum number of new user "
 "registrations to accept per day.  If register is set to closed, this setting "
 "has no effect."
 msgstr ""
 
-#: mod/admin.php:987
+#: mod/admin.php:1008
 msgid "Register text"
 msgstr ""
 
-#: mod/admin.php:987
+#: mod/admin.php:1008
 msgid "Will be displayed prominently on the registration page."
 msgstr ""
 
-#: mod/admin.php:988
+#: mod/admin.php:1009
 msgid "Accounts abandoned after x days"
 msgstr ""
 
-#: mod/admin.php:988
+#: mod/admin.php:1009
 msgid ""
 "Will not waste system resources polling external sites for abandonded "
 "accounts. Enter 0 for no time limit."
 msgstr ""
 
-#: mod/admin.php:989
+#: mod/admin.php:1010
 msgid "Allowed friend domains"
 msgstr ""
 
-#: mod/admin.php:989
+#: mod/admin.php:1010
 msgid ""
 "Comma separated list of domains which are allowed to establish friendships "
 "with this site. Wildcards are accepted. Empty to allow any domains"
 msgstr ""
 
-#: mod/admin.php:990
+#: mod/admin.php:1011
 msgid "Allowed email domains"
 msgstr ""
 
-#: mod/admin.php:990
+#: mod/admin.php:1011
 msgid ""
 "Comma separated list of domains which are allowed in email addresses for "
 "registrations to this site. Wildcards are accepted. Empty to allow any "
 "domains"
 msgstr ""
 
-#: mod/admin.php:991
+#: mod/admin.php:1012
 msgid "Block public"
 msgstr ""
 
-#: mod/admin.php:991
+#: mod/admin.php:1012
 msgid ""
 "Check to block public access to all otherwise public personal pages on this "
 "site unless you are currently logged in."
 msgstr ""
 
-#: mod/admin.php:992
+#: mod/admin.php:1013
 msgid "Force publish"
 msgstr ""
 
-#: mod/admin.php:992
+#: mod/admin.php:1013
 msgid ""
 "Check to force all profiles on this site to be listed in the site directory."
 msgstr ""
 
-#: mod/admin.php:993
+#: mod/admin.php:1014
 msgid "Global directory URL"
 msgstr ""
 
-#: mod/admin.php:993
+#: mod/admin.php:1014
 msgid ""
 "URL to the global directory. If this is not set, the global directory is "
 "completely unavailable to the application."
 msgstr ""
 
-#: mod/admin.php:994
+#: mod/admin.php:1015
 msgid "Allow threaded items"
 msgstr ""
 
-#: mod/admin.php:994
+#: mod/admin.php:1015
 msgid "Allow infinite level threading for items on this site."
 msgstr ""
 
-#: mod/admin.php:995
+#: mod/admin.php:1016
 msgid "Private posts by default for new users"
 msgstr ""
 
-#: mod/admin.php:995
+#: mod/admin.php:1016
 msgid ""
 "Set default post permissions for all new members to the default privacy "
 "group rather than public."
 msgstr ""
 
-#: mod/admin.php:996
+#: mod/admin.php:1017
 msgid "Don't include post content in email notifications"
 msgstr ""
 
-#: mod/admin.php:996
+#: mod/admin.php:1017
 msgid ""
 "Don't include the content of a post/comment/private message/etc. in the "
 "email notifications that are sent out from this site, as a privacy measure."
 msgstr ""
 
-#: mod/admin.php:997
+#: mod/admin.php:1018
 msgid "Disallow public access to addons listed in the apps menu."
 msgstr ""
 
-#: mod/admin.php:997
+#: mod/admin.php:1018
 msgid ""
 "Checking this box will restrict addons listed in the apps menu to members "
 "only."
 msgstr ""
 
-#: mod/admin.php:998
+#: mod/admin.php:1019
 msgid "Don't embed private images in posts"
 msgstr ""
 
-#: mod/admin.php:998
+#: mod/admin.php:1019
 msgid ""
 "Don't replace locally-hosted private photos in posts with an embedded copy "
 "of the image. This means that contacts who receive posts containing private "
 "photos will have to authenticate and load each image, which may take a while."
 msgstr ""
 
-#: mod/admin.php:999
+#: mod/admin.php:1020
 msgid "Allow Users to set remote_self"
 msgstr ""
 
-#: mod/admin.php:999
+#: mod/admin.php:1020
 msgid ""
 "With checking this, every user is allowed to mark every contact as a "
 "remote_self in the repair contact dialog. Setting this flag on a contact "
 "causes mirroring every posting of that contact in the users stream."
 msgstr ""
 
-#: mod/admin.php:1000
+#: mod/admin.php:1021
 msgid "Block multiple registrations"
 msgstr ""
 
-#: mod/admin.php:1000
+#: mod/admin.php:1021
 msgid "Disallow users to register additional accounts for use as pages."
 msgstr ""
 
-#: mod/admin.php:1001
+#: mod/admin.php:1022
 msgid "OpenID support"
 msgstr ""
 
-#: mod/admin.php:1001
+#: mod/admin.php:1022
 msgid "OpenID support for registration and logins."
 msgstr ""
 
-#: mod/admin.php:1002
+#: mod/admin.php:1023
 msgid "Fullname check"
 msgstr ""
 
-#: mod/admin.php:1002
+#: mod/admin.php:1023
 msgid ""
 "Force users to register with a space between firstname and lastname in Full "
 "name, as an antispam measure"
 msgstr ""
 
-#: mod/admin.php:1003
+#: mod/admin.php:1024
 msgid "UTF-8 Regular expressions"
 msgstr ""
 
-#: mod/admin.php:1003
+#: mod/admin.php:1024
 msgid "Use PHP UTF8 regular expressions"
 msgstr ""
 
-#: mod/admin.php:1004
+#: mod/admin.php:1025
 msgid "Community Page Style"
 msgstr ""
 
-#: mod/admin.php:1004
+#: mod/admin.php:1025
 msgid ""
 "Type of community page to show. 'Global community' shows every public "
 "posting from an open distributed network that arrived on this server."
 msgstr ""
 
-#: mod/admin.php:1005
+#: mod/admin.php:1026
 msgid "Posts per user on community page"
 msgstr ""
 
-#: mod/admin.php:1005
+#: mod/admin.php:1026
 msgid ""
 "The maximum number of posts per user on the community page. (Not valid for "
 "'Global Community')"
 msgstr ""
 
-#: mod/admin.php:1006
+#: mod/admin.php:1027
 msgid "Enable OStatus support"
 msgstr ""
 
-#: mod/admin.php:1006
+#: mod/admin.php:1027
 msgid ""
 "Provide built-in OStatus (StatusNet, GNU Social etc.) compatibility. All "
 "communications in OStatus are public, so privacy warnings will be "
 "occasionally displayed."
 msgstr ""
 
-#: mod/admin.php:1007
+#: mod/admin.php:1028
 msgid "OStatus conversation completion interval"
 msgstr ""
 
-#: mod/admin.php:1007
+#: mod/admin.php:1028
 msgid ""
 "How often shall the poller check for new entries in OStatus conversations? "
 "This can be a very ressource task."
 msgstr ""
 
-#: mod/admin.php:1008
+#: mod/admin.php:1029
 msgid "Only import OStatus threads from our contacts"
 msgstr ""
 
-#: mod/admin.php:1008
+#: mod/admin.php:1029
 msgid ""
 "Normally we import every content from our OStatus contacts. With this option "
 "we only store threads that are started by a contact that is known on our "
 "system."
 msgstr ""
 
-#: mod/admin.php:1009
+#: mod/admin.php:1030
 msgid "OStatus support can only be enabled if threading is enabled."
 msgstr ""
 
-#: mod/admin.php:1011
+#: mod/admin.php:1032
 msgid ""
 "Diaspora support can't be enabled because Friendica was installed into a sub "
 "directory."
 msgstr ""
 
-#: mod/admin.php:1012
+#: mod/admin.php:1033
 msgid "Enable Diaspora support"
 msgstr ""
 
-#: mod/admin.php:1012
+#: mod/admin.php:1033
 msgid "Provide built-in Diaspora network compatibility."
 msgstr ""
 
-#: mod/admin.php:1013
+#: mod/admin.php:1034
 msgid "Only allow Friendica contacts"
 msgstr ""
 
-#: mod/admin.php:1013
+#: mod/admin.php:1034
 msgid ""
 "All contacts must use Friendica protocols. All other built-in communication "
 "protocols disabled."
 msgstr ""
 
-#: mod/admin.php:1014
+#: mod/admin.php:1035
 msgid "Verify SSL"
 msgstr ""
 
-#: mod/admin.php:1014
+#: mod/admin.php:1035
 msgid ""
 "If you wish, you can turn on strict certificate checking. This will mean you "
 "cannot connect (at all) to self-signed SSL sites."
 msgstr ""
 
-#: mod/admin.php:1015
+#: mod/admin.php:1036
 msgid "Proxy user"
 msgstr ""
 
-#: mod/admin.php:1016
+#: mod/admin.php:1037
 msgid "Proxy URL"
 msgstr ""
 
-#: mod/admin.php:1017
+#: mod/admin.php:1038
 msgid "Network timeout"
 msgstr ""
 
-#: mod/admin.php:1017
+#: mod/admin.php:1038
 msgid "Value is in seconds. Set to 0 for unlimited (not recommended)."
 msgstr ""
 
-#: mod/admin.php:1018
+#: mod/admin.php:1039
 msgid "Delivery interval"
 msgstr ""
 
-#: mod/admin.php:1018
+#: mod/admin.php:1039
 msgid ""
 "Delay background delivery processes by this many seconds to reduce system "
 "load. Recommend: 4-5 for shared hosts, 2-3 for virtual private servers. 0-1 "
 "for large dedicated servers."
 msgstr ""
 
-#: mod/admin.php:1019
+#: mod/admin.php:1040
 msgid "Poll interval"
 msgstr ""
 
-#: mod/admin.php:1019
+#: mod/admin.php:1040
 msgid ""
 "Delay background polling processes by this many seconds to reduce system "
 "load. If 0, use delivery interval."
 msgstr ""
 
-#: mod/admin.php:1020
+#: mod/admin.php:1041
 msgid "Maximum Load Average"
 msgstr ""
 
-#: mod/admin.php:1020
+#: mod/admin.php:1041
 msgid ""
 "Maximum system load before delivery and poll processes are deferred - "
 "default 50."
 msgstr ""
 
-#: mod/admin.php:1021
+#: mod/admin.php:1042
 msgid "Maximum Load Average (Frontend)"
 msgstr ""
 
-#: mod/admin.php:1021
+#: mod/admin.php:1042
 msgid "Maximum system load before the frontend quits service - default 50."
 msgstr ""
 
-#: mod/admin.php:1022
+#: mod/admin.php:1043
 msgid "Maximum table size for optimization"
 msgstr ""
 
-#: mod/admin.php:1022
+#: mod/admin.php:1043
 msgid ""
 "Maximum table size (in MB) for the automatic optimization - default 100 MB. "
 "Enter -1 to disable it."
 msgstr ""
 
-#: mod/admin.php:1023
+#: mod/admin.php:1044
 msgid "Minimum level of fragmentation"
 msgstr ""
 
-#: mod/admin.php:1023
+#: mod/admin.php:1044
 msgid ""
 "Minimum fragmenation level to start the automatic optimization - default "
 "value is 30%."
 msgstr ""
 
-#: mod/admin.php:1025
+#: mod/admin.php:1046
 msgid "Periodical check of global contacts"
 msgstr ""
 
-#: mod/admin.php:1025
+#: mod/admin.php:1046
 msgid ""
 "If enabled, the global contacts are checked periodically for missing or "
 "outdated data and the vitality of the contacts and servers."
 msgstr ""
 
-#: mod/admin.php:1026
+#: mod/admin.php:1047
 msgid "Days between requery"
 msgstr ""
 
-#: mod/admin.php:1026
+#: mod/admin.php:1047
 msgid "Number of days after which a server is requeried for his contacts."
 msgstr ""
 
-#: mod/admin.php:1027
+#: mod/admin.php:1048
 msgid "Discover contacts from other servers"
 msgstr ""
 
-#: mod/admin.php:1027
+#: mod/admin.php:1048
 msgid ""
 "Periodically query other servers for contacts. You can choose between "
 "'users': the users on the remote system, 'Global Contacts': active contacts "
@@ -7049,32 +7917,32 @@ msgid ""
 "Global Contacts'."
 msgstr ""
 
-#: mod/admin.php:1028
+#: mod/admin.php:1049
 msgid "Timeframe for fetching global contacts"
 msgstr ""
 
-#: mod/admin.php:1028
+#: mod/admin.php:1049
 msgid ""
 "When the discovery is activated, this value defines the timeframe for the "
 "activity of the global contacts that are fetched from other servers."
 msgstr ""
 
-#: mod/admin.php:1029
+#: mod/admin.php:1050
 msgid "Search the local directory"
 msgstr ""
 
-#: mod/admin.php:1029
+#: mod/admin.php:1050
 msgid ""
 "Search the local directory instead of the global directory. When searching "
 "locally, every search will be executed on the global directory in the "
 "background. This improves the search results when the search is repeated."
 msgstr ""
 
-#: mod/admin.php:1031
+#: mod/admin.php:1052
 msgid "Publish server information"
 msgstr ""
 
-#: mod/admin.php:1031
+#: mod/admin.php:1052
 msgid ""
 "If enabled, general server and usage data will be published. The data "
 "contains the name and version of the server, number of users with public "
@@ -7082,190 +7950,190 @@ msgid ""
 "href='http://the-federation.info/'>the-federation.info</a> for details."
 msgstr ""
 
-#: mod/admin.php:1033
+#: mod/admin.php:1054
 msgid "Use MySQL full text engine"
 msgstr ""
 
-#: mod/admin.php:1033
+#: mod/admin.php:1054
 msgid ""
 "Activates the full text engine. Speeds up search - but can only search for "
 "four and more characters."
 msgstr ""
 
-#: mod/admin.php:1034
+#: mod/admin.php:1055
 msgid "Suppress Language"
 msgstr ""
 
-#: mod/admin.php:1034
+#: mod/admin.php:1055
 msgid "Suppress language information in meta information about a posting."
 msgstr ""
 
-#: mod/admin.php:1035
+#: mod/admin.php:1056
 msgid "Suppress Tags"
 msgstr ""
 
-#: mod/admin.php:1035
+#: mod/admin.php:1056
 msgid "Suppress showing a list of hashtags at the end of the posting."
 msgstr ""
 
-#: mod/admin.php:1036
+#: mod/admin.php:1057
 msgid "Path to item cache"
 msgstr ""
 
-#: mod/admin.php:1036
+#: mod/admin.php:1057
 msgid "The item caches buffers generated bbcode and external images."
 msgstr ""
 
-#: mod/admin.php:1037
+#: mod/admin.php:1058
 msgid "Cache duration in seconds"
 msgstr ""
 
-#: mod/admin.php:1037
+#: mod/admin.php:1058
 msgid ""
 "How long should the cache files be hold? Default value is 86400 seconds (One "
 "day). To disable the item cache, set the value to -1."
 msgstr ""
 
-#: mod/admin.php:1038
+#: mod/admin.php:1059
 msgid "Maximum numbers of comments per post"
 msgstr ""
 
-#: mod/admin.php:1038
+#: mod/admin.php:1059
 msgid "How much comments should be shown for each post? Default value is 100."
 msgstr ""
 
-#: mod/admin.php:1039
+#: mod/admin.php:1060
 msgid "Path for lock file"
 msgstr ""
 
-#: mod/admin.php:1039
+#: mod/admin.php:1060
 msgid ""
 "The lock file is used to avoid multiple pollers at one time. Only define a "
 "folder here."
 msgstr ""
 
-#: mod/admin.php:1040
+#: mod/admin.php:1061
 msgid "Temp path"
 msgstr ""
 
-#: mod/admin.php:1040
+#: mod/admin.php:1061
 msgid ""
 "If you have a restricted system where the webserver can't access the system "
 "temp path, enter another path here."
 msgstr ""
 
-#: mod/admin.php:1041
+#: mod/admin.php:1062
 msgid "Base path to installation"
 msgstr ""
 
-#: mod/admin.php:1041
+#: mod/admin.php:1062
 msgid ""
 "If the system cannot detect the correct path to your installation, enter the "
 "correct path here. This setting should only be set if you are using a "
 "restricted system and symbolic links to your webroot."
 msgstr ""
 
-#: mod/admin.php:1042
+#: mod/admin.php:1063
 msgid "Disable picture proxy"
 msgstr ""
 
-#: mod/admin.php:1042
+#: mod/admin.php:1063
 msgid ""
 "The picture proxy increases performance and privacy. It shouldn't be used on "
 "systems with very low bandwith."
 msgstr ""
 
-#: mod/admin.php:1043
+#: mod/admin.php:1064
 msgid "Enable old style pager"
 msgstr ""
 
-#: mod/admin.php:1043
+#: mod/admin.php:1064
 msgid ""
 "The old style pager has page numbers but slows down massively the page speed."
 msgstr ""
 
-#: mod/admin.php:1044
+#: mod/admin.php:1065
 msgid "Only search in tags"
 msgstr ""
 
-#: mod/admin.php:1044
+#: mod/admin.php:1065
 msgid "On large systems the text search can slow down the system extremely."
 msgstr ""
 
-#: mod/admin.php:1046
+#: mod/admin.php:1067
 msgid "New base url"
 msgstr ""
 
-#: mod/admin.php:1046
+#: mod/admin.php:1067
 msgid ""
 "Change base url for this server. Sends relocate message to all DFRN contacts "
 "of all users."
 msgstr ""
 
-#: mod/admin.php:1048
+#: mod/admin.php:1069
 msgid "RINO Encryption"
 msgstr ""
 
-#: mod/admin.php:1048
+#: mod/admin.php:1069
 msgid "Encryption layer between nodes."
 msgstr ""
 
-#: mod/admin.php:1049
+#: mod/admin.php:1070
 msgid "Embedly API key"
 msgstr ""
 
-#: mod/admin.php:1049
+#: mod/admin.php:1070
 msgid ""
 "<a href='http://embed.ly'>Embedly</a> is used to fetch additional data for "
 "web pages. This is an optional parameter."
 msgstr ""
 
-#: mod/admin.php:1051
+#: mod/admin.php:1072
 msgid "Enable 'worker' background processing"
 msgstr ""
 
-#: mod/admin.php:1051
+#: mod/admin.php:1072
 msgid ""
 "The worker background processing limits the number of parallel background "
 "jobs to a maximum number and respects the system load."
 msgstr ""
 
-#: mod/admin.php:1052
+#: mod/admin.php:1073
 msgid "Maximum number of parallel workers"
 msgstr ""
 
-#: mod/admin.php:1052
+#: mod/admin.php:1073
 msgid ""
 "On shared hosters set this to 2. On larger systems, values of 10 are great. "
 "Default value is 4."
 msgstr ""
 
-#: mod/admin.php:1053
+#: mod/admin.php:1074
 msgid "Don't use 'proc_open' with the worker"
 msgstr ""
 
-#: mod/admin.php:1053
+#: mod/admin.php:1074
 msgid ""
 "Enable this if your system doesn't allow the use of 'proc_open'. This can "
 "happen on shared hosters. If this is enabled you should increase the "
 "frequency of poller calls in your crontab."
 msgstr ""
 
-#: mod/admin.php:1054
+#: mod/admin.php:1075
 msgid "Enable fastlane"
 msgstr ""
 
-#: mod/admin.php:1054
+#: mod/admin.php:1075
 msgid ""
 "When enabed, the fastlane mechanism starts an additional worker if processes "
 "with higher priority are blocked by processes of lower priority."
 msgstr ""
 
-#: mod/admin.php:1055
+#: mod/admin.php:1076
 msgid "Enable frontend worker"
 msgstr ""
 
-#: mod/admin.php:1055
+#: mod/admin.php:1076
 msgid ""
 "When enabled the Worker process is triggered when backend access is "
 "performed (e.g. messages being delivered). On smaller sites you might want "
@@ -7274,66 +8142,66 @@ msgid ""
 "on your server. The worker background process needs to be activated for this."
 msgstr ""
 
-#: mod/admin.php:1084
+#: mod/admin.php:1105
 msgid "Update has been marked successful"
 msgstr ""
 
-#: mod/admin.php:1092
+#: mod/admin.php:1113
 #, php-format
 msgid "Database structure update %s was successfully applied."
 msgstr ""
 
-#: mod/admin.php:1095
+#: mod/admin.php:1116
 #, php-format
 msgid "Executing of database structure update %s failed with error: %s"
 msgstr ""
 
-#: mod/admin.php:1107
+#: mod/admin.php:1128
 #, php-format
 msgid "Executing %s failed with error: %s"
 msgstr ""
 
-#: mod/admin.php:1110
+#: mod/admin.php:1131
 #, php-format
 msgid "Update %s was successfully applied."
 msgstr ""
 
-#: mod/admin.php:1114
+#: mod/admin.php:1135
 #, php-format
 msgid "Update %s did not return a status. Unknown if it succeeded."
 msgstr ""
 
-#: mod/admin.php:1116
+#: mod/admin.php:1137
 #, php-format
 msgid "There was no additional update function %s that needed to be called."
 msgstr ""
 
-#: mod/admin.php:1135
+#: mod/admin.php:1156
 msgid "No failed updates."
 msgstr ""
 
-#: mod/admin.php:1136
+#: mod/admin.php:1157
 msgid "Check database structure"
 msgstr ""
 
-#: mod/admin.php:1141
+#: mod/admin.php:1162
 msgid "Failed Updates"
 msgstr ""
 
-#: mod/admin.php:1142
+#: mod/admin.php:1163
 msgid ""
 "This does not include updates prior to 1139, which did not return a status."
 msgstr ""
 
-#: mod/admin.php:1143
+#: mod/admin.php:1164
 msgid "Mark success (if update was manually applied)"
 msgstr ""
 
-#: mod/admin.php:1144
+#: mod/admin.php:1165
 msgid "Attempt to execute this update step automatically"
 msgstr ""
 
-#: mod/admin.php:1178
+#: mod/admin.php:1199
 #, php-format
 msgid ""
 "\n"
@@ -7341,7 +8209,7 @@ msgid ""
 "\t\t\t\tthe administrator of %2$s has set up an account for you."
 msgstr ""
 
-#: mod/admin.php:1181
+#: mod/admin.php:1202
 #, php-format
 msgid ""
 "\n"
@@ -7377,168 +8245,162 @@ msgid ""
 "\t\t\tThank you and welcome to %4$s."
 msgstr ""
 
-#: mod/admin.php:1225
+#: mod/admin.php:1246
 #, php-format
 msgid "%s user blocked/unblocked"
 msgid_plural "%s users blocked/unblocked"
 msgstr[0] ""
 msgstr[1] ""
 
-#: mod/admin.php:1232
+#: mod/admin.php:1253
 #, php-format
 msgid "%s user deleted"
 msgid_plural "%s users deleted"
 msgstr[0] ""
 msgstr[1] ""
 
-#: mod/admin.php:1279
+#: mod/admin.php:1300
 #, php-format
 msgid "User '%s' deleted"
 msgstr ""
 
-#: mod/admin.php:1287
+#: mod/admin.php:1308
 #, php-format
 msgid "User '%s' unblocked"
 msgstr ""
 
-#: mod/admin.php:1287
+#: mod/admin.php:1308
 #, php-format
 msgid "User '%s' blocked"
 msgstr ""
 
-#: mod/admin.php:1396 mod/admin.php:1422
+#: mod/admin.php:1417 mod/admin.php:1443
 msgid "Register date"
 msgstr ""
 
-#: mod/admin.php:1396 mod/admin.php:1422
+#: mod/admin.php:1417 mod/admin.php:1443
 msgid "Last login"
 msgstr ""
 
-#: mod/admin.php:1396 mod/admin.php:1422
+#: mod/admin.php:1417 mod/admin.php:1443
 msgid "Last item"
 msgstr ""
 
-#: mod/admin.php:1405
+#: mod/admin.php:1426
 msgid "Add User"
 msgstr ""
 
-#: mod/admin.php:1406
+#: mod/admin.php:1427
 msgid "select all"
 msgstr ""
 
-#: mod/admin.php:1407
+#: mod/admin.php:1428
 msgid "User registrations waiting for confirm"
 msgstr ""
 
-#: mod/admin.php:1408
+#: mod/admin.php:1429
 msgid "User waiting for permanent deletion"
 msgstr ""
 
-#: mod/admin.php:1409
+#: mod/admin.php:1430
 msgid "Request date"
 msgstr ""
 
-#: mod/admin.php:1410
+#: mod/admin.php:1431
 msgid "No registrations."
 msgstr ""
 
-#: mod/admin.php:1411
+#: mod/admin.php:1432
 msgid "Note from the user"
 msgstr ""
 
-#: mod/admin.php:1413
+#: mod/admin.php:1433 mod/notifications.php:176 mod/notifications.php:255
+msgid "Approve"
+msgstr ""
+
+#: mod/admin.php:1434
 msgid "Deny"
 msgstr ""
 
-#: mod/admin.php:1415 mod/contacts.php:605 mod/contacts.php:805
-#: mod/contacts.php:983
-msgid "Block"
-msgstr ""
-
-#: mod/admin.php:1416 mod/contacts.php:605 mod/contacts.php:805
-#: mod/contacts.php:983
-msgid "Unblock"
-msgstr ""
-
-#: mod/admin.php:1417
+#: mod/admin.php:1438
 msgid "Site admin"
 msgstr ""
 
-#: mod/admin.php:1418
+#: mod/admin.php:1439
 msgid "Account expired"
 msgstr ""
 
-#: mod/admin.php:1421
+#: mod/admin.php:1442
 msgid "New User"
 msgstr ""
 
-#: mod/admin.php:1422
+#: mod/admin.php:1443
 msgid "Deleted since"
 msgstr ""
 
-#: mod/admin.php:1427
+#: mod/admin.php:1448
 msgid ""
 "Selected users will be deleted!\\n\\nEverything these users had posted on "
 "this site will be permanently deleted!\\n\\nAre you sure?"
 msgstr ""
 
-#: mod/admin.php:1428
+#: mod/admin.php:1449
 msgid ""
 "The user {0} will be deleted!\\n\\nEverything this user has posted on this "
 "site will be permanently deleted!\\n\\nAre you sure?"
 msgstr ""
 
-#: mod/admin.php:1438
+#: mod/admin.php:1459
 msgid "Name of the new user."
 msgstr ""
 
-#: mod/admin.php:1439
+#: mod/admin.php:1460
 msgid "Nickname"
 msgstr ""
 
-#: mod/admin.php:1439
+#: mod/admin.php:1460
 msgid "Nickname of the new user."
 msgstr ""
 
-#: mod/admin.php:1440
+#: mod/admin.php:1461
 msgid "Email address of the new user."
 msgstr ""
 
-#: mod/admin.php:1483
+#: mod/admin.php:1504
 #, php-format
 msgid "Plugin %s disabled."
 msgstr ""
 
-#: mod/admin.php:1487
+#: mod/admin.php:1508
 #, php-format
 msgid "Plugin %s enabled."
 msgstr ""
 
-#: mod/admin.php:1498 mod/admin.php:1734
+#: mod/admin.php:1519 mod/admin.php:1767
 msgid "Disable"
 msgstr ""
 
-#: mod/admin.php:1500 mod/admin.php:1736
+#: mod/admin.php:1521 mod/admin.php:1769
 msgid "Enable"
 msgstr ""
 
-#: mod/admin.php:1523 mod/admin.php:1781
+#: mod/admin.php:1544 mod/admin.php:1814
 msgid "Toggle"
 msgstr ""
 
-#: mod/admin.php:1531 mod/admin.php:1790
+#: mod/admin.php:1552 mod/admin.php:1823
 msgid "Author: "
 msgstr ""
 
-#: mod/admin.php:1532 mod/admin.php:1791
+#: mod/admin.php:1553 mod/admin.php:1824
 msgid "Maintainer: "
 msgstr ""
 
-#: mod/admin.php:1584
+#: mod/admin.php:1608
 msgid "Reload active plugins"
 msgstr ""
 
-#: mod/admin.php:1589
+#: mod/admin.php:1613
 #, php-format
 msgid ""
 "There are currently no plugins available on your node. You can find the "
@@ -7546,70 +8408,70 @@ msgid ""
 "in the open plugin registry at %2$s"
 msgstr ""
 
-#: mod/admin.php:1694
+#: mod/admin.php:1727
 msgid "No themes found."
 msgstr ""
 
-#: mod/admin.php:1772
+#: mod/admin.php:1805
 msgid "Screenshot"
 msgstr ""
 
-#: mod/admin.php:1832
+#: mod/admin.php:1865
 msgid "Reload active themes"
 msgstr ""
 
-#: mod/admin.php:1837
+#: mod/admin.php:1870
 #, php-format
 msgid "No themes found on the system. They should be paced in %1$s"
 msgstr ""
 
-#: mod/admin.php:1838
+#: mod/admin.php:1871
 msgid "[Experimental]"
 msgstr ""
 
-#: mod/admin.php:1839
+#: mod/admin.php:1872
 msgid "[Unsupported]"
 msgstr ""
 
-#: mod/admin.php:1863
+#: mod/admin.php:1896
 msgid "Log settings updated."
 msgstr ""
 
-#: mod/admin.php:1895
+#: mod/admin.php:1928
 msgid "PHP log currently enabled."
 msgstr ""
 
-#: mod/admin.php:1897
+#: mod/admin.php:1930
 msgid "PHP log currently disabled."
 msgstr ""
 
-#: mod/admin.php:1906
+#: mod/admin.php:1939
 msgid "Clear"
 msgstr ""
 
-#: mod/admin.php:1911
+#: mod/admin.php:1944
 msgid "Enable Debugging"
 msgstr ""
 
-#: mod/admin.php:1912
+#: mod/admin.php:1945
 msgid "Log file"
 msgstr ""
 
-#: mod/admin.php:1912
+#: mod/admin.php:1945
 msgid ""
 "Must be writable by web server. Relative to your Friendica top-level "
 "directory."
 msgstr ""
 
-#: mod/admin.php:1913
+#: mod/admin.php:1946
 msgid "Log level"
 msgstr ""
 
-#: mod/admin.php:1916
+#: mod/admin.php:1949
 msgid "PHP logging"
 msgstr ""
 
-#: mod/admin.php:1917
+#: mod/admin.php:1950
 msgid ""
 "To enable logging of PHP errors and warnings you can add the following to "
 "the .htconfig.php file of your installation. The filename set in the "
@@ -7618,984 +8480,24 @@ msgid ""
 "'display_errors' is to enable these options, set to '0' to disable them."
 msgstr ""
 
-#: mod/admin.php:2045
+#: mod/admin.php:2078
 #, php-format
 msgid "Lock feature %s"
 msgstr ""
 
-#: mod/admin.php:2053
+#: mod/admin.php:2086
 msgid "Manage Additional Features"
 msgstr ""
 
-#: mod/contacts.php:128
-#, php-format
-msgid "%d contact edited."
-msgid_plural "%d contacts edited."
-msgstr[0] ""
-msgstr[1] ""
-
-#: mod/contacts.php:159 mod/contacts.php:368
-msgid "Could not access contact record."
-msgstr ""
-
-#: mod/contacts.php:173
-msgid "Could not locate selected profile."
-msgstr ""
-
-#: mod/contacts.php:206
-msgid "Contact updated."
-msgstr ""
-
-#: mod/contacts.php:208 mod/dfrn_request.php:583
-msgid "Failed to update contact record."
-msgstr ""
-
-#: mod/contacts.php:389
-msgid "Contact has been blocked"
-msgstr ""
-
-#: mod/contacts.php:389
-msgid "Contact has been unblocked"
-msgstr ""
-
-#: mod/contacts.php:400
-msgid "Contact has been ignored"
-msgstr ""
-
-#: mod/contacts.php:400
-msgid "Contact has been unignored"
-msgstr ""
-
-#: mod/contacts.php:412
-msgid "Contact has been archived"
-msgstr ""
-
-#: mod/contacts.php:412
-msgid "Contact has been unarchived"
-msgstr ""
-
-#: mod/contacts.php:437
-msgid "Drop contact"
-msgstr ""
-
-#: mod/contacts.php:440 mod/contacts.php:801
-msgid "Do you really want to delete this contact?"
-msgstr ""
-
-#: mod/contacts.php:457
-msgid "Contact has been removed."
-msgstr ""
-
-#: mod/contacts.php:498
-#, php-format
-msgid "You are mutual friends with %s"
-msgstr ""
-
-#: mod/contacts.php:502
-#, php-format
-msgid "You are sharing with %s"
-msgstr ""
-
-#: mod/contacts.php:507
-#, php-format
-msgid "%s is sharing with you"
-msgstr ""
-
-#: mod/contacts.php:527
-msgid "Private communications are not available for this contact."
-msgstr ""
-
-#: mod/contacts.php:534
-msgid "(Update was successful)"
-msgstr ""
-
-#: mod/contacts.php:534
-msgid "(Update was not successful)"
-msgstr ""
-
-#: mod/contacts.php:536 mod/contacts.php:964
-msgid "Suggest friends"
-msgstr ""
-
-#: mod/contacts.php:540
-#, php-format
-msgid "Network type: %s"
-msgstr ""
-
-#: mod/contacts.php:553
-msgid "Communications lost with this contact!"
-msgstr ""
-
-#: mod/contacts.php:556
-msgid "Fetch further information for feeds"
-msgstr ""
-
-#: mod/contacts.php:557
-msgid "Fetch information"
-msgstr ""
-
-#: mod/contacts.php:557
-msgid "Fetch information and keywords"
-msgstr ""
-
-#: mod/contacts.php:575
-msgid "Contact"
-msgstr ""
-
-#: mod/contacts.php:578
-msgid "Profile Visibility"
-msgstr ""
-
-#: mod/contacts.php:579
-#, php-format
-msgid ""
-"Please choose the profile you would like to display to %s when viewing your "
-"profile securely."
-msgstr ""
-
-#: mod/contacts.php:580
-msgid "Contact Information / Notes"
-msgstr ""
-
-#: mod/contacts.php:581
-msgid "Edit contact notes"
-msgstr ""
-
-#: mod/contacts.php:587
-msgid "Block/Unblock contact"
-msgstr ""
-
-#: mod/contacts.php:588
-msgid "Ignore contact"
-msgstr ""
-
-#: mod/contacts.php:589
-msgid "Repair URL settings"
-msgstr ""
-
-#: mod/contacts.php:590
-msgid "View conversations"
-msgstr ""
-
-#: mod/contacts.php:596
-msgid "Last update:"
-msgstr ""
-
-#: mod/contacts.php:598
-msgid "Update public posts"
-msgstr ""
-
-#: mod/contacts.php:600 mod/contacts.php:974
-msgid "Update now"
-msgstr ""
-
-#: mod/contacts.php:606 mod/contacts.php:806 mod/contacts.php:991
-msgid "Unignore"
-msgstr ""
-
-#: mod/contacts.php:610
-msgid "Currently blocked"
-msgstr ""
-
-#: mod/contacts.php:611
-msgid "Currently ignored"
-msgstr ""
-
-#: mod/contacts.php:612
-msgid "Currently archived"
-msgstr ""
-
-#: mod/contacts.php:613
-msgid ""
-"Replies/likes to your public posts <strong>may</strong> still be visible"
-msgstr ""
-
-#: mod/contacts.php:614
-msgid "Notification for new posts"
-msgstr ""
-
-#: mod/contacts.php:614
-msgid "Send a notification of every new post of this contact"
-msgstr ""
-
-#: mod/contacts.php:617
-msgid "Blacklisted keywords"
-msgstr ""
-
-#: mod/contacts.php:617
-msgid ""
-"Comma separated list of keywords that should not be converted to hashtags, "
-"when \"Fetch information and keywords\" is selected"
-msgstr ""
-
-#: mod/contacts.php:635
-msgid "Actions"
-msgstr ""
-
-#: mod/contacts.php:638
-msgid "Contact Settings"
-msgstr ""
-
-#: mod/contacts.php:684
-msgid "Suggestions"
-msgstr ""
-
-#: mod/contacts.php:687
-msgid "Suggest potential friends"
-msgstr ""
-
-#: mod/contacts.php:695
-msgid "Show all contacts"
-msgstr ""
-
-#: mod/contacts.php:700
-msgid "Unblocked"
-msgstr ""
-
-#: mod/contacts.php:703
-msgid "Only show unblocked contacts"
-msgstr ""
-
-#: mod/contacts.php:709
-msgid "Blocked"
-msgstr ""
-
-#: mod/contacts.php:712
-msgid "Only show blocked contacts"
-msgstr ""
-
-#: mod/contacts.php:718
-msgid "Ignored"
-msgstr ""
-
-#: mod/contacts.php:721
-msgid "Only show ignored contacts"
-msgstr ""
-
-#: mod/contacts.php:727
-msgid "Archived"
-msgstr ""
-
-#: mod/contacts.php:730
-msgid "Only show archived contacts"
-msgstr ""
-
-#: mod/contacts.php:736
-msgid "Hidden"
-msgstr ""
-
-#: mod/contacts.php:739
-msgid "Only show hidden contacts"
-msgstr ""
-
-#: mod/contacts.php:796
-msgid "Search your contacts"
-msgstr ""
-
-#: mod/contacts.php:807 mod/contacts.php:999
-msgid "Archive"
-msgstr ""
-
-#: mod/contacts.php:807 mod/contacts.php:999
-msgid "Unarchive"
-msgstr ""
-
-#: mod/contacts.php:810
-msgid "Batch Actions"
-msgstr ""
-
-#: mod/contacts.php:856
-msgid "View all contacts"
-msgstr ""
-
-#: mod/contacts.php:866
-msgid "View all common friends"
-msgstr ""
-
-#: mod/contacts.php:873
-msgid "Advanced Contact Settings"
-msgstr ""
-
-#: mod/contacts.php:907
-msgid "Mutual Friendship"
-msgstr ""
-
-#: mod/contacts.php:911
-msgid "is a fan of yours"
-msgstr ""
-
-#: mod/contacts.php:915
-msgid "you are a fan of"
-msgstr ""
-
-#: mod/contacts.php:985
-msgid "Toggle Blocked status"
-msgstr ""
-
-#: mod/contacts.php:993
-msgid "Toggle Ignored status"
-msgstr ""
-
-#: mod/contacts.php:1001
-msgid "Toggle Archive status"
-msgstr ""
-
-#: mod/contacts.php:1009
-msgid "Delete contact"
-msgstr ""
-
-#: mod/dfrn_confirm.php:127
-msgid ""
-"This may occasionally happen if contact was requested by both persons and it "
-"has already been approved."
-msgstr ""
-
-#: mod/dfrn_confirm.php:246
-msgid "Response from remote site was not understood."
-msgstr ""
-
-#: mod/dfrn_confirm.php:255 mod/dfrn_confirm.php:260
-msgid "Unexpected response from remote site: "
-msgstr ""
-
-#: mod/dfrn_confirm.php:269
-msgid "Confirmation completed successfully."
-msgstr ""
-
-#: mod/dfrn_confirm.php:271 mod/dfrn_confirm.php:285 mod/dfrn_confirm.php:292
-msgid "Remote site reported: "
-msgstr ""
-
-#: mod/dfrn_confirm.php:283
-msgid "Temporary failure. Please wait and try again."
-msgstr ""
-
-#: mod/dfrn_confirm.php:290
-msgid "Introduction failed or was revoked."
-msgstr ""
-
-#: mod/dfrn_confirm.php:419
-msgid "Unable to set contact photo."
-msgstr ""
-
-#: mod/dfrn_confirm.php:557
-#, php-format
-msgid "No user record found for '%s' "
-msgstr ""
-
-#: mod/dfrn_confirm.php:567
-msgid "Our site encryption key is apparently messed up."
-msgstr ""
-
-#: mod/dfrn_confirm.php:578
-msgid "Empty site URL was provided or URL could not be decrypted by us."
-msgstr ""
-
-#: mod/dfrn_confirm.php:599
-msgid "Contact record was not found for you on our site."
-msgstr ""
-
-#: mod/dfrn_confirm.php:613
-#, php-format
-msgid "Site public key not available in contact record for URL %s."
-msgstr ""
-
-#: mod/dfrn_confirm.php:633
-msgid ""
-"The ID provided by your system is a duplicate on our system. It should work "
-"if you try again."
-msgstr ""
-
-#: mod/dfrn_confirm.php:644
-msgid "Unable to set your contact credentials on our system."
-msgstr ""
-
-#: mod/dfrn_confirm.php:703
-msgid "Unable to update your contact profile details on our system"
-msgstr ""
-
-#: mod/dfrn_confirm.php:775
-#, php-format
-msgid "%1$s has joined %2$s"
-msgstr ""
-
-#: mod/dfrn_request.php:101
-msgid "This introduction has already been accepted."
-msgstr ""
-
-#: mod/dfrn_request.php:124 mod/dfrn_request.php:520
-msgid "Profile location is not valid or does not contain profile information."
-msgstr ""
-
-#: mod/dfrn_request.php:129 mod/dfrn_request.php:525
-msgid "Warning: profile location has no identifiable owner name."
-msgstr ""
-
-#: mod/dfrn_request.php:131 mod/dfrn_request.php:527
-msgid "Warning: profile location has no profile photo."
-msgstr ""
-
-#: mod/dfrn_request.php:134 mod/dfrn_request.php:530
-#, php-format
-msgid "%d required parameter was not found at the given location"
-msgid_plural "%d required parameters were not found at the given location"
-msgstr[0] ""
-msgstr[1] ""
-
-#: mod/dfrn_request.php:180
-msgid "Introduction complete."
-msgstr ""
-
-#: mod/dfrn_request.php:222
-msgid "Unrecoverable protocol error."
-msgstr ""
-
-#: mod/dfrn_request.php:250
-msgid "Profile unavailable."
-msgstr ""
-
-#: mod/dfrn_request.php:277
-#, php-format
-msgid "%s has received too many connection requests today."
-msgstr ""
-
-#: mod/dfrn_request.php:278
-msgid "Spam protection measures have been invoked."
-msgstr ""
-
-#: mod/dfrn_request.php:279
-msgid "Friends are advised to please try again in 24 hours."
-msgstr ""
-
-#: mod/dfrn_request.php:341
-msgid "Invalid locator"
-msgstr ""
-
-#: mod/dfrn_request.php:350
-msgid "Invalid email address."
-msgstr ""
-
-#: mod/dfrn_request.php:375
-msgid "This account has not been configured for email. Request failed."
-msgstr ""
-
-#: mod/dfrn_request.php:478
-msgid "You have already introduced yourself here."
-msgstr ""
-
-#: mod/dfrn_request.php:482
-#, php-format
-msgid "Apparently you are already friends with %s."
-msgstr ""
-
-#: mod/dfrn_request.php:503
-msgid "Invalid profile URL."
-msgstr ""
-
-#: mod/dfrn_request.php:604
-msgid "Your introduction has been sent."
-msgstr ""
-
-#: mod/dfrn_request.php:644
-msgid ""
-"Remote subscription can't be done for your network. Please subscribe "
-"directly on your system."
-msgstr ""
-
-#: mod/dfrn_request.php:664
-msgid "Please login to confirm introduction."
-msgstr ""
-
-#: mod/dfrn_request.php:674
-msgid ""
-"Incorrect identity currently logged in. Please login to <strong>this</"
-"strong> profile."
-msgstr ""
-
-#: mod/dfrn_request.php:688 mod/dfrn_request.php:705
-msgid "Confirm"
-msgstr ""
-
-#: mod/dfrn_request.php:700
-msgid "Hide this contact"
-msgstr ""
-
-#: mod/dfrn_request.php:703
-#, php-format
-msgid "Welcome home %s."
-msgstr ""
-
-#: mod/dfrn_request.php:704
-#, php-format
-msgid "Please confirm your introduction/connection request to %s."
-msgstr ""
-
-#: mod/dfrn_request.php:833
-msgid ""
-"Please enter your 'Identity Address' from one of the following supported "
-"communications networks:"
-msgstr ""
-
-#: mod/dfrn_request.php:854
-#, php-format
-msgid ""
-"If you are not yet a member of the free social web, <a href=\"%s/siteinfo"
-"\">follow this link to find a public Friendica site and join us today</a>."
-msgstr ""
-
-#: mod/dfrn_request.php:859
-msgid "Friend/Connection Request"
-msgstr ""
-
-#: mod/dfrn_request.php:860
-msgid ""
-"Examples: jojo@demo.friendica.com, http://demo.friendica.com/profile/jojo, "
-"testuser@identi.ca"
-msgstr ""
-
-#: mod/dfrn_request.php:861 mod/follow.php:109
-msgid "Please answer the following:"
-msgstr ""
-
-#: mod/dfrn_request.php:862 mod/follow.php:110
-#, php-format
-msgid "Does %s know you?"
-msgstr ""
-
-#: mod/dfrn_request.php:866 mod/follow.php:111
-msgid "Add a personal note:"
-msgstr ""
-
-#: mod/dfrn_request.php:869
-msgid "StatusNet/Federated Social Web"
-msgstr ""
-
-#: mod/dfrn_request.php:871
-#, php-format
-msgid ""
-" - please do not use this form.  Instead, enter %s into your Diaspora search "
-"bar."
-msgstr ""
-
-#: mod/dfrn_request.php:872 mod/follow.php:117
-msgid "Your Identity Address:"
-msgstr ""
-
-#: mod/dfrn_request.php:875 mod/follow.php:19
-msgid "Submit Request"
-msgstr ""
-
-#: mod/follow.php:30
-msgid "You already added this contact."
-msgstr ""
-
-#: mod/follow.php:39
-msgid "Diaspora support isn't enabled. Contact can't be added."
-msgstr ""
-
-#: mod/follow.php:46
-msgid "OStatus support is disabled. Contact can't be added."
-msgstr ""
-
-#: mod/follow.php:53
-msgid "The network type couldn't be detected. Contact can't be added."
-msgstr ""
-
-#: mod/follow.php:180
-msgid "Contact added"
-msgstr ""
-
-#: mod/install.php:139
-msgid "Friendica Communications Server - Setup"
-msgstr ""
-
-#: mod/install.php:145
-msgid "Could not connect to database."
-msgstr ""
-
-#: mod/install.php:149
-msgid "Could not create table."
-msgstr ""
-
-#: mod/install.php:155
-msgid "Your Friendica site database has been installed."
-msgstr ""
-
-#: mod/install.php:160
-msgid ""
-"You may need to import the file \"database.sql\" manually using phpmyadmin "
-"or mysql."
-msgstr ""
-
-#: mod/install.php:161 mod/install.php:230 mod/install.php:607
-msgid "Please see the file \"INSTALL.txt\"."
-msgstr ""
-
-#: mod/install.php:173
-msgid "Database already in use."
-msgstr ""
-
-#: mod/install.php:227
-msgid "System check"
-msgstr ""
-
-#: mod/install.php:232
-msgid "Check again"
-msgstr ""
-
-#: mod/install.php:251
-msgid "Database connection"
-msgstr ""
-
-#: mod/install.php:252
-msgid ""
-"In order to install Friendica we need to know how to connect to your "
-"database."
-msgstr ""
-
-#: mod/install.php:253
-msgid ""
-"Please contact your hosting provider or site administrator if you have "
-"questions about these settings."
-msgstr ""
-
-#: mod/install.php:254
-msgid ""
-"The database you specify below should already exist. If it does not, please "
-"create it before continuing."
-msgstr ""
-
-#: mod/install.php:258
-msgid "Database Server Name"
-msgstr ""
-
-#: mod/install.php:259
-msgid "Database Login Name"
-msgstr ""
-
-#: mod/install.php:260
-msgid "Database Login Password"
-msgstr ""
-
-#: mod/install.php:261
-msgid "Database Name"
-msgstr ""
-
-#: mod/install.php:262 mod/install.php:303
-msgid "Site administrator email address"
-msgstr ""
-
-#: mod/install.php:262 mod/install.php:303
-msgid ""
-"Your account email address must match this in order to use the web admin "
-"panel."
-msgstr ""
-
-#: mod/install.php:266 mod/install.php:306
-msgid "Please select a default timezone for your website"
-msgstr ""
-
-#: mod/install.php:293
-msgid "Site settings"
-msgstr ""
-
-#: mod/install.php:307
-msgid "System Language:"
-msgstr ""
-
-#: mod/install.php:307
-msgid ""
-"Set the default language for your Friendica installation interface and to "
-"send emails."
-msgstr ""
-
-#: mod/install.php:347
-msgid "Could not find a command line version of PHP in the web server PATH."
-msgstr ""
-
-#: mod/install.php:348
-msgid ""
-"If you don't have a command line version of PHP installed on server, you "
-"will not be able to run background polling via cron. See <a href='https://"
-"github.com/friendica/friendica/blob/master/doc/Install.md#set-up-the-"
-"poller'>'Setup the poller'</a>"
-msgstr ""
-
-#: mod/install.php:352
-msgid "PHP executable path"
-msgstr ""
-
-#: mod/install.php:352
-msgid ""
-"Enter full path to php executable. You can leave this blank to continue the "
-"installation."
-msgstr ""
-
-#: mod/install.php:357
-msgid "Command line PHP"
-msgstr ""
-
-#: mod/install.php:366
-msgid "PHP executable is not the php cli binary (could be cgi-fgci version)"
-msgstr ""
-
-#: mod/install.php:367
-msgid "Found PHP version: "
-msgstr ""
-
-#: mod/install.php:369
-msgid "PHP cli binary"
-msgstr ""
-
-#: mod/install.php:380
-msgid ""
-"The command line version of PHP on your system does not have "
-"\"register_argc_argv\" enabled."
-msgstr ""
-
-#: mod/install.php:381
-msgid "This is required for message delivery to work."
-msgstr ""
-
-#: mod/install.php:383
-msgid "PHP register_argc_argv"
-msgstr ""
-
-#: mod/install.php:404
-msgid ""
-"Error: the \"openssl_pkey_new\" function on this system is not able to "
-"generate encryption keys"
-msgstr ""
-
-#: mod/install.php:405
-msgid ""
-"If running under Windows, please see \"http://www.php.net/manual/en/openssl."
-"installation.php\"."
-msgstr ""
-
-#: mod/install.php:407
-msgid "Generate encryption keys"
-msgstr ""
-
-#: mod/install.php:414
-msgid "libCurl PHP module"
-msgstr ""
-
-#: mod/install.php:415
-msgid "GD graphics PHP module"
-msgstr ""
-
-#: mod/install.php:416
-msgid "OpenSSL PHP module"
-msgstr ""
-
-#: mod/install.php:417
-msgid "mysqli PHP module"
-msgstr ""
-
-#: mod/install.php:418
-msgid "mb_string PHP module"
-msgstr ""
-
-#: mod/install.php:419
-msgid "mcrypt PHP module"
-msgstr ""
-
-#: mod/install.php:420
-msgid "XML PHP module"
-msgstr ""
-
-#: mod/install.php:421
-msgid "iconv module"
-msgstr ""
-
-#: mod/install.php:425 mod/install.php:427
-msgid "Apache mod_rewrite module"
-msgstr ""
-
-#: mod/install.php:425
-msgid ""
-"Error: Apache webserver mod-rewrite module is required but not installed."
-msgstr ""
-
-#: mod/install.php:433
-msgid "Error: libCURL PHP module required but not installed."
-msgstr ""
-
-#: mod/install.php:437
-msgid ""
-"Error: GD graphics PHP module with JPEG support required but not installed."
-msgstr ""
-
-#: mod/install.php:441
-msgid "Error: openssl PHP module required but not installed."
-msgstr ""
-
-#: mod/install.php:445
-msgid "Error: mysqli PHP module required but not installed."
-msgstr ""
-
-#: mod/install.php:449
-msgid "Error: mb_string PHP module required but not installed."
-msgstr ""
-
-#: mod/install.php:453
-msgid "Error: mcrypt PHP module required but not installed."
-msgstr ""
-
-#: mod/install.php:457
-msgid "Error: iconv PHP module required but not installed."
-msgstr ""
-
-#: mod/install.php:466
-msgid ""
-"If you are using php_cli, please make sure that mcrypt module is enabled in "
-"its config file"
-msgstr ""
-
-#: mod/install.php:469
-msgid ""
-"Function mcrypt_create_iv() is not defined. This is needed to enable RINO2 "
-"encryption layer."
-msgstr ""
-
-#: mod/install.php:471
-msgid "mcrypt_create_iv() function"
-msgstr ""
-
-#: mod/install.php:479
-msgid "Error, XML PHP module required but not installed."
-msgstr ""
-
-#: mod/install.php:494
-msgid ""
-"The web installer needs to be able to create a file called \".htconfig.php\" "
-"in the top folder of your web server and it is unable to do so."
-msgstr ""
-
-#: mod/install.php:495
-msgid ""
-"This is most often a permission setting, as the web server may not be able "
-"to write files in your folder - even if you can."
-msgstr ""
-
-#: mod/install.php:496
-msgid ""
-"At the end of this procedure, we will give you a text to save in a file "
-"named .htconfig.php in your Friendica top folder."
-msgstr ""
-
-#: mod/install.php:497
-msgid ""
-"You can alternatively skip this procedure and perform a manual installation. "
-"Please see the file \"INSTALL.txt\" for instructions."
-msgstr ""
-
-#: mod/install.php:500
-msgid ".htconfig.php is writable"
-msgstr ""
-
-#: mod/install.php:510
-msgid ""
-"Friendica uses the Smarty3 template engine to render its web views. Smarty3 "
-"compiles templates to PHP to speed up rendering."
-msgstr ""
-
-#: mod/install.php:511
-msgid ""
-"In order to store these compiled templates, the web server needs to have "
-"write access to the directory view/smarty3/ under the Friendica top level "
-"folder."
-msgstr ""
-
-#: mod/install.php:512
-msgid ""
-"Please ensure that the user that your web server runs as (e.g. www-data) has "
-"write access to this folder."
-msgstr ""
-
-#: mod/install.php:513
-msgid ""
-"Note: as a security measure, you should give the web server write access to "
-"view/smarty3/ only--not the template files (.tpl) that it contains."
-msgstr ""
-
-#: mod/install.php:516
-msgid "view/smarty3 is writable"
-msgstr ""
-
-#: mod/install.php:532
-msgid ""
-"Url rewrite in .htaccess is not working. Check your server configuration."
-msgstr ""
-
-#: mod/install.php:534
-msgid "Url rewrite is working"
-msgstr ""
-
-#: mod/install.php:552
-msgid "ImageMagick PHP extension is not installed"
-msgstr ""
-
-#: mod/install.php:555
-msgid "ImageMagick PHP extension is installed"
-msgstr ""
-
-#: mod/install.php:557
-msgid "ImageMagick supports GIF"
-msgstr ""
-
-#: mod/install.php:566
-msgid ""
-"The database configuration file \".htconfig.php\" could not be written. "
-"Please use the enclosed text to create a configuration file in your web "
-"server root."
-msgstr ""
-
-#: mod/install.php:605
-msgid "<h1>What next</h1>"
-msgstr ""
-
-#: mod/install.php:606
-msgid ""
-"IMPORTANT: You will need to [manually] setup a scheduled task for the poller."
-msgstr ""
-
-#: mod/item.php:116
-msgid "Unable to locate original post."
-msgstr ""
-
-#: mod/item.php:341
-msgid "Empty post discarded."
-msgstr ""
-
-#: mod/item.php:902
-msgid "System error. Post not saved."
-msgstr ""
-
-#: mod/item.php:992
-#, php-format
-msgid ""
-"This message was sent to you by %s, a member of the Friendica social network."
-msgstr ""
-
-#: mod/item.php:994
-#, php-format
-msgid "You may visit them online at %s"
-msgstr ""
-
-#: mod/item.php:995
-msgid ""
-"Please contact the sender by replying to this post if you do not wish to "
-"receive these messages."
+#: mod/viewcontacts.php:75
+msgid "No contacts."
 msgstr ""
 
-#: mod/item.php:999
-#, php-format
-msgid "%s posted an update."
+#: mod/network.php:190 mod/search.php:25
+msgid "Remove term"
 msgstr ""
 
-#: mod/network.php:398
+#: mod/network.php:397
 #, php-format
 msgid ""
 "Warning: This group contains %s member from a network that doesn't allow non "
@@ -8606,80 +8508,344 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: mod/network.php:401
+#: mod/network.php:400
 msgid "Messages in this group won't be send to these receivers."
 msgstr ""
 
-#: mod/network.php:529
+#: mod/network.php:528
 msgid "Private messages to this person are at risk of public disclosure."
 msgstr ""
 
-#: mod/network.php:534
+#: mod/network.php:533
 msgid "Invalid contact."
 msgstr ""
 
-#: mod/network.php:826
+#: mod/network.php:827
 msgid "Commented Order"
 msgstr ""
 
-#: mod/network.php:829
+#: mod/network.php:830
 msgid "Sort by Comment Date"
 msgstr ""
 
-#: mod/network.php:834
+#: mod/network.php:835
 msgid "Posted Order"
 msgstr ""
 
-#: mod/network.php:837
+#: mod/network.php:838
 msgid "Sort by Post Date"
 msgstr ""
 
-#: mod/network.php:848
+#: mod/network.php:849
 msgid "Posts that mention or involve you"
 msgstr ""
 
-#: mod/network.php:856
+#: mod/network.php:857
 msgid "New"
 msgstr ""
 
-#: mod/network.php:859
+#: mod/network.php:860
 msgid "Activity Stream - by date"
 msgstr ""
 
-#: mod/network.php:867
+#: mod/network.php:868
 msgid "Shared Links"
 msgstr ""
 
-#: mod/network.php:870
+#: mod/network.php:871
 msgid "Interesting Links"
 msgstr ""
 
-#: mod/network.php:878
+#: mod/network.php:879
 msgid "Starred"
 msgstr ""
 
-#: mod/network.php:881
+#: mod/network.php:882
 msgid "Favourite Posts"
 msgstr ""
 
-#: mod/ping.php:261
-msgid "{0} wants to be your friend"
+#: mod/search.php:100
+msgid "Only logged in users are permitted to perform a search."
 msgstr ""
 
-#: mod/ping.php:276
-msgid "{0} sent you a message"
+#: mod/search.php:124
+msgid "Too Many Requests"
 msgstr ""
 
-#: mod/ping.php:291
-msgid "{0} requested registration"
+#: mod/search.php:125
+msgid "Only one search per minute is permitted for not logged in users."
 msgstr ""
 
-#: mod/viewcontacts.php:72
-msgid "No contacts."
+#: mod/search.php:230
+#, php-format
+msgid "Items tagged with: %s"
 msgstr ""
 
-#: object/Item.php:370
+#: mod/notifications.php:35
+msgid "Invalid request identifier."
+msgstr ""
+
+#: mod/notifications.php:44 mod/notifications.php:180
+#: mod/notifications.php:258
+msgid "Discard"
+msgstr ""
+
+#: mod/notifications.php:105
+msgid "Network Notifications"
+msgstr ""
+
+#: mod/notifications.php:117
+msgid "Personal Notifications"
+msgstr ""
+
+#: mod/notifications.php:123
+msgid "Home Notifications"
+msgstr ""
+
+#: mod/notifications.php:152
+msgid "Show Ignored Requests"
+msgstr ""
+
+#: mod/notifications.php:152
+msgid "Hide Ignored Requests"
+msgstr ""
+
+#: mod/notifications.php:164 mod/notifications.php:228
+msgid "Notification type: "
+msgstr ""
+
+#: mod/notifications.php:167
+#, php-format
+msgid "suggested by %s"
+msgstr ""
+
+#: mod/notifications.php:173 mod/notifications.php:246
+msgid "Post a new friend activity"
+msgstr ""
+
+#: mod/notifications.php:173 mod/notifications.php:246
+msgid "if applicable"
+msgstr ""
+
+#: mod/notifications.php:195
+msgid "Claims to be known to you: "
+msgstr ""
+
+#: mod/notifications.php:196
+msgid "yes"
+msgstr ""
+
+#: mod/notifications.php:196
+msgid "no"
+msgstr ""
+
+#: mod/notifications.php:197 mod/notifications.php:202
+msgid "Shall your connection be bidirectional or not?"
+msgstr ""
+
+#: mod/notifications.php:198 mod/notifications.php:203
+#, php-format
+msgid ""
+"Accepting %s as a friend allows %s to subscribe to your posts, and you will "
+"also receive updates from them in your news feed."
+msgstr ""
+
+#: mod/notifications.php:199
+#, php-format
+msgid ""
+"Accepting %s as a subscriber allows them to subscribe to your posts, but you "
+"will not receive updates from them in your news feed."
+msgstr ""
+
+#: mod/notifications.php:204
+#, php-format
+msgid ""
+"Accepting %s as a sharer allows them to subscribe to your posts, but you "
+"will not receive updates from them in your news feed."
+msgstr ""
+
+#: mod/notifications.php:215
+msgid "Friend"
+msgstr ""
+
+#: mod/notifications.php:216
+msgid "Sharer"
+msgstr ""
+
+#: mod/notifications.php:216
+msgid "Subscriber"
+msgstr ""
+
+#: mod/notifications.php:266
+msgid "No introductions."
+msgstr ""
+
+#: mod/notifications.php:307
+msgid "Show unread"
+msgstr ""
+
+#: mod/notifications.php:307
+msgid "Show all"
+msgstr ""
+
+#: mod/notifications.php:313
+#, php-format
+msgid "No more %s notifications."
+msgstr ""
+
+#: object/Item.php:385
 msgid "via"
+msgstr ""
+
+#: view/theme/quattro/config.php:70
+msgid "Alignment"
+msgstr ""
+
+#: view/theme/quattro/config.php:70
+msgid "Left"
+msgstr ""
+
+#: view/theme/quattro/config.php:70
+msgid "Center"
+msgstr ""
+
+#: view/theme/quattro/config.php:71 view/theme/clean/config.php:108
+msgid "Color scheme"
+msgstr ""
+
+#: view/theme/quattro/config.php:72
+msgid "Posts font size"
+msgstr ""
+
+#: view/theme/quattro/config.php:73
+msgid "Textareas font size"
+msgstr ""
+
+#: view/theme/vier/config.php:69
+msgid "Comma separated list of helper forums"
+msgstr ""
+
+#: view/theme/vier/config.php:115
+msgid "Set style"
+msgstr ""
+
+#: view/theme/vier/config.php:116
+msgid "Community Pages"
+msgstr ""
+
+#: view/theme/vier/config.php:117 view/theme/vier/theme.php:146
+msgid "Community Profiles"
+msgstr ""
+
+#: view/theme/vier/config.php:118
+msgid "Help or @NewHere ?"
+msgstr ""
+
+#: view/theme/vier/config.php:119 view/theme/vier/theme.php:385
+msgid "Connect Services"
+msgstr ""
+
+#: view/theme/vier/config.php:120 view/theme/vier/theme.php:194
+msgid "Find Friends"
+msgstr ""
+
+#: view/theme/vier/config.php:121 view/theme/vier/theme.php:176
+msgid "Last users"
+msgstr ""
+
+#: view/theme/vier/theme.php:195
+msgid "Local Directory"
+msgstr ""
+
+#: view/theme/vier/theme.php:286
+msgid "Quick Start"
+msgstr ""
+
+#: view/theme/duepuntozero/config.php:44
+msgid "greenzero"
+msgstr ""
+
+#: view/theme/duepuntozero/config.php:45
+msgid "purplezero"
+msgstr ""
+
+#: view/theme/duepuntozero/config.php:46
+msgid "easterbunny"
+msgstr ""
+
+#: view/theme/duepuntozero/config.php:47
+msgid "darkzero"
+msgstr ""
+
+#: view/theme/duepuntozero/config.php:48
+msgid "comix"
+msgstr ""
+
+#: view/theme/duepuntozero/config.php:49
+msgid "slackr"
+msgstr ""
+
+#: view/theme/duepuntozero/config.php:64
+msgid "Variations"
+msgstr ""
+
+#: view/theme/clean/config.php:61
+msgid "Midnight"
+msgstr ""
+
+#: view/theme/clean/config.php:62
+msgid "Zenburn"
+msgstr ""
+
+#: view/theme/clean/config.php:63
+msgid "Bootstrap"
+msgstr ""
+
+#: view/theme/clean/config.php:64
+msgid "Shades of Pink"
+msgstr ""
+
+#: view/theme/clean/config.php:65
+msgid "Lime and Orange"
+msgstr ""
+
+#: view/theme/clean/config.php:66
+msgid "GeoCities Retro"
+msgstr ""
+
+#: view/theme/clean/config.php:92
+msgid "Background Image"
+msgstr ""
+
+#: view/theme/clean/config.php:94
+msgid ""
+"The URL to a picture (e.g. from your photo album) that should be used as "
+"background image."
+msgstr ""
+
+#: view/theme/clean/config.php:99
+msgid "Background Color"
+msgstr ""
+
+#: view/theme/clean/config.php:101
+msgid "HEX value for the background color. Don't include the #"
+msgstr ""
+
+#: view/theme/clean/config.php:115
+msgid "font size"
+msgstr ""
+
+#: view/theme/clean/config.php:117
+msgid "base font size for your interface"
+msgstr ""
+
+#: view/theme/clean/config.php:122
+msgid "Display Accesskeys"
+msgstr ""
+
+#: view/theme/clean/config.php:124
+msgid ""
+"Diaplay the access keys assigned to some menu element in the web interface."
 msgstr ""
 
 #: view/theme/frio/php/Image.php:23
@@ -8714,195 +8880,103 @@ msgstr ""
 msgid "Resize to best fit and retain aspect ratio."
 msgstr ""
 
-#: view/theme/frio/config.php:42
+#: view/theme/frio/config.php:47
 msgid "Default"
 msgstr ""
 
-#: view/theme/frio/config.php:54
+#: view/theme/frio/config.php:59
 msgid "Note: "
 msgstr ""
 
-#: view/theme/frio/config.php:54
+#: view/theme/frio/config.php:59
 msgid "Check image permissions if all users are allowed to visit the image"
 msgstr ""
 
-#: view/theme/frio/config.php:62
+#: view/theme/frio/config.php:67
 msgid "Select scheme"
 msgstr ""
 
-#: view/theme/frio/config.php:63
+#: view/theme/frio/config.php:68
 msgid "Navigation bar background color"
 msgstr ""
 
-#: view/theme/frio/config.php:64
+#: view/theme/frio/config.php:69
 msgid "Navigation bar icon color "
 msgstr ""
 
-#: view/theme/frio/config.php:65
+#: view/theme/frio/config.php:70
 msgid "Link color"
 msgstr ""
 
-#: view/theme/frio/config.php:66
+#: view/theme/frio/config.php:71
 msgid "Set the background color"
 msgstr ""
 
-#: view/theme/frio/config.php:67
+#: view/theme/frio/config.php:72
 msgid "Content background transparency"
 msgstr ""
 
-#: view/theme/frio/config.php:68
+#: view/theme/frio/config.php:73
 msgid "Set the background image"
 msgstr ""
 
-#: view/theme/frio/theme.php:229
+#: view/theme/frio/theme.php:226
 msgid "Guest"
 msgstr ""
 
-#: view/theme/frio/theme.php:235
+#: view/theme/frio/theme.php:232
 msgid "Visitor"
 msgstr ""
 
-#: view/theme/quattro/config.php:67
-msgid "Alignment"
-msgstr ""
-
-#: view/theme/quattro/config.php:67
-msgid "Left"
-msgstr ""
-
-#: view/theme/quattro/config.php:67
-msgid "Center"
-msgstr ""
-
-#: view/theme/quattro/config.php:68
-msgid "Color scheme"
-msgstr ""
-
-#: view/theme/quattro/config.php:69
-msgid "Posts font size"
-msgstr ""
-
-#: view/theme/quattro/config.php:70
-msgid "Textareas font size"
-msgstr ""
-
-#: view/theme/vier/theme.php:152 view/theme/vier/config.php:112
-msgid "Community Profiles"
-msgstr ""
-
-#: view/theme/vier/theme.php:181 view/theme/vier/config.php:116
-msgid "Last users"
-msgstr ""
-
-#: view/theme/vier/theme.php:199 view/theme/vier/config.php:115
-msgid "Find Friends"
-msgstr ""
-
-#: view/theme/vier/theme.php:200
-msgid "Local Directory"
-msgstr ""
-
-#: view/theme/vier/theme.php:291
-msgid "Quick Start"
-msgstr ""
-
-#: view/theme/vier/theme.php:373 view/theme/vier/config.php:114
-msgid "Connect Services"
-msgstr ""
-
-#: view/theme/vier/config.php:64
-msgid "Comma separated list of helper forums"
-msgstr ""
-
-#: view/theme/vier/config.php:110
-msgid "Set style"
-msgstr ""
-
-#: view/theme/vier/config.php:111
-msgid "Community Pages"
-msgstr ""
-
-#: view/theme/vier/config.php:113
-msgid "Help or @NewHere ?"
-msgstr ""
-
-#: view/theme/duepuntozero/config.php:45
-msgid "greenzero"
-msgstr ""
-
-#: view/theme/duepuntozero/config.php:46
-msgid "purplezero"
-msgstr ""
-
-#: view/theme/duepuntozero/config.php:47
-msgid "easterbunny"
-msgstr ""
-
-#: view/theme/duepuntozero/config.php:48
-msgid "darkzero"
-msgstr ""
-
-#: view/theme/duepuntozero/config.php:49
-msgid "comix"
-msgstr ""
-
-#: view/theme/duepuntozero/config.php:50
-msgid "slackr"
-msgstr ""
-
-#: view/theme/duepuntozero/config.php:62
-msgid "Variations"
+#: index.php:457
+msgid "toggle mobile"
 msgstr ""
 
 #: boot.php:970
 msgid "Delete this item?"
 msgstr ""
 
-#: boot.php:973
+#: boot.php:972
 msgid "show fewer"
 msgstr ""
 
-#: boot.php:1655
+#: boot.php:1696
 #, php-format
 msgid "Update %s failed. See error logs."
 msgstr ""
 
-#: boot.php:1767
+#: boot.php:1808
 msgid "Create a New Account"
 msgstr ""
 
-#: boot.php:1796
+#: boot.php:1837
 msgid "Password: "
 msgstr ""
 
-#: boot.php:1797
+#: boot.php:1838
 msgid "Remember me"
 msgstr ""
 
-#: boot.php:1800
+#: boot.php:1841
 msgid "Or login using OpenID: "
 msgstr ""
 
-#: boot.php:1806
+#: boot.php:1847
 msgid "Forgot your password?"
 msgstr ""
 
-#: boot.php:1809
+#: boot.php:1850
 msgid "Website Terms of Service"
 msgstr ""
 
-#: boot.php:1810
+#: boot.php:1851
 msgid "terms of service"
 msgstr ""
 
-#: boot.php:1812
+#: boot.php:1853
 msgid "Website Privacy Policy"
 msgstr ""
 
-#: boot.php:1813
+#: boot.php:1854
 msgid "privacy policy"
-msgstr ""
-
-#: index.php:451
-msgid "toggle mobile"
 msgstr ""

--- a/view/templates/netfriend.tpl
+++ b/view/templates/netfriend.tpl
@@ -1,5 +1,5 @@
 
-<div class="intro-approve-as-friend-desc">{{$approve_as1}}<br /><br />{{$approve_as2}}</div>
+<div class="intro-approve-as-friend-desc">{{$approve_as1}}<br /><br />{{$approve_as2}}<br /><br />{{$approve_as3}}</div>
 
 <div class="intro-approve-as-friend-wrapper">
 	<label class="intro-approve-as-friend-label" for="intro-approve-as-friend-{{$intro_id}}">{{$as_friend}}</label>

--- a/view/templates/netfriend.tpl
+++ b/view/templates/netfriend.tpl
@@ -1,5 +1,5 @@
 
-<div class="intro-approve-as-friend-desc">{{$approve_as}}</div>
+<div class="intro-approve-as-friend-desc">{{$approve_as1}}<br /><br />{{$approve_as2}}</div>
 
 <div class="intro-approve-as-friend-wrapper">
 	<label class="intro-approve-as-friend-label" for="intro-approve-as-friend-{{$intro_id}}">{{$as_friend}}</label>

--- a/view/templates/netfriend.tpl
+++ b/view/templates/netfriend.tpl
@@ -1,5 +1,9 @@
 
-<div class="intro-approve-as-friend-desc">{{$approve_as1}}<br /><br />{{$approve_as2}}<br /><br />{{$approve_as3}}</div>
+<div class="intro-approve-as-friend-desc">
+  <p>{{$approve_as1}}</p>
+  <p>{{$approve_as2}}</p>
+  <p>{{$approve_as3}}</p>
+</div>
 
 <div class="intro-approve-as-friend-wrapper">
 	<label class="intro-approve-as-friend-label" for="intro-approve-as-friend-{{$intro_id}}">{{$as_friend}}</label>


### PR DESCRIPTION
The new contact confirmation dialog had a wording problem (see #3187). With this bugfix the dialog should be more clear and user friendly.

The PR also includes a regenerated `util/messages.po` file so the translation pipe can pick up the changes.

See the discussion [here](https://helpers.pyxis.uberspace.de/display/ec054ce71258b1624cb2779814782315).