### PR TITLE
Strip @hubzilla.server part from guid for autoscrolling purpuses

### DIFF
--- a/view/theme/frio/js/mod_display.js
+++ b/view/theme/frio/js/mod_display.js
@@ -4,8 +4,9 @@
 
 // Catch the GUID from the URL
 var itemGuid = window.location.pathname.split("/").pop();
+var itemGuidSafe = itemGuid.replace(/%.*/, '');
 
 $(window).load(function(){
 	// Scroll to the Item by its GUID
-	scrollToItem('item-'+itemGuid);
+	scrollToItem('item-' + itemGuidSafe);
 });

--- a/view/theme/frio/templates/wall_thread.tpl
+++ b/view/theme/frio/templates/wall_thread.tpl
@@ -68,9 +68,9 @@ as the value of $top_child_total (this is done at the end of this file)
 
 {{* Use a different div container in dependence max thread-level = 7 *}}
 {{if $item.thread_level<7}}
-<div class="wall-item-container {{$item.indent}} {{$item.shiny}} {{$item.network}} thread_level_{{$item.thread_level}} {{if $item.thread_level==1}}panel-body h-entry{{else}}u-comment h-cite{{/if}}" id="item-{{$item.guid}}"><!-- wall-item-container -->
+<div class="wall-item-container {{$item.indent}} {{$item.shiny}} {{$item.network}} thread_level_{{$item.thread_level}} {{if $item.thread_level==1}}panel-body h-entry{{else}}u-comment h-cite{{/if}}" id="item-{{$item.guid|regex_replace:'/%.*/':''}}"><!-- wall-item-container -->
 {{else}}
-<div class="wall-item-container {{$item.indent}} {{$item.shiny}} {{$item.network}} thread_level_7 u-comment h-cite" id="item-{{$item.guid}}">
+<div class="wall-item-container {{$item.indent}} {{$item.shiny}} {{$item.network}} thread_level_7 u-comment h-cite" id="item-{{$item.guid|regex_replace:'/%.*/':''}}">
  {{/if}}
 	<div class="media">
 		{{* Put addional actions in a top-right dropdown menu *}}


### PR DESCRIPTION
Fixes #3194.

Anchor names apparently have banned characters, including % which was present in the urlencoded form of Hubzilla item guids

Example:
`27cadfdb95469a21fbcc242d7c503a3ad80587b9ef1110d6643a043d8d7c4dfa%40ethical.qc.to`

The solution to make the auto-scroll work again was to ignore the '@hubzilla.server' part when setting up the anchor and when looking for it.