### PR TITLE
Reformatted get_contact()

### DIFF
--- a/include/Contact.php
+++ b/include/Contact.php
@@ -577,11 +577,6 @@ function get_contact($url, $uid = 0, $no_update = false) {
 
 	require_once('include/Probe.php');
 	$data = Probe::uri($url);
-	if (!$data['url']) {
-		return 0;
-	}
-
-	$url = $data["url"];
 
 	// Does this address belongs to a valid network?
 	if (!in_array($data["network"], array(NETWORK_DFRN, NETWORK_OSTATUS, NETWORK_DIASPORA))) {
@@ -599,6 +594,12 @@ function get_contact($url, $uid = 0, $no_update = false) {
 		$data = $gcontacts[0];
 	}
 
+	// Unable to convert nick@server.tld into http://server.tld/nick
+	if (!$data['url'] && (!strstr($url, "http") OR strstr($url, "@"))) {
+		return 0;
+	}
+
+	$url = $data["url"];
 
 	if (!$contact_id) {
 		q("INSERT INTO `contact` (`uid`, `created`, `url`, `nurl`, `addr`, `alias`, `notify`, `poll`,

--- a/include/Contact.php
+++ b/include/Contact.php
@@ -508,72 +508,81 @@ function contacts_not_grouped($uid,$start = 0,$count = 0) {
 /**
  * @brief Fetch the contact id for a given url and user
  *
+ * First lookup in the contact table to find a record matching either `url`, `nurl`,
+ * `addr` or `alias`.
+ *
+ * If there's no record and we aren't looking for a public contact, we quit.
+ * If there's one, we check that it isn't time to update the picture else we
+ * directly return the found contact id.
+ *
+ * Second, we probe the provided $url wether it's http://server.tld/profile or
+ * nick@server.tld. We quit if we can't get any info back.
+ *
+ * Third, we create the contact record if it doesn't exist
+ *
+ * Fourth, we update the existing record with the new data (avatar, alias, nick)
+ * if there's any updates
+ *
  * @param string $url Contact URL
- * @param integer $uid The user id for the contact
+ * @param integer $uid The user id for the contact (0 = public contact)
  * @param boolean $no_update Don't update the contact
  *
  * @return integer Contact ID
  */
 function get_contact($url, $uid = 0, $no_update = false) {
-	require_once("include/Scrape.php");
+	require_once "include/Scrape.php";
 
 	logger("Get contact data for url ".$url." and user ".$uid." - ".App::callstack(), LOGGER_DEBUG);;
 
 	$data = array();
-	$contactid = 0;
+	$contact_id = 0;
 
-	// is it an address in the format user@server.tld?
-	/// @todo use gcontact and/or the addr field for a lookup
-	if (!strstr($url, "http") OR strstr($url, "@")) {
-		$data = probe_url($url);
-		$url = $data["url"];
-		if ($url == "")
-			return 0;
-	}
+	// Catch-all query, may return multiple rows
+	$contacts = q("SELECT `id`, `avatar-date` FROM `contact`
+				WHERE ('%s' IN (`url`, `addr`, `alias`) OR '%s' IN (`nurl`, `alias`))
+				AND `uid` = %d",
+		dbesc($url),
+		dbesc(normalise_link($url)),
+		intval($uid));
 
-	$contact = q("SELECT `id`, `avatar-date` FROM `contact` WHERE `nurl` = '%s' AND `uid` = %d ORDER BY `id` LIMIT 2",
-			dbesc(normalise_link($url)),
-			intval($uid));
-
-	if (!$contact)
-		$contact = q("SELECT `id`, `avatar-date` FROM `contact` WHERE `alias` IN ('%s', '%s') AND `uid` = %d ORDER BY `id` LIMIT 1",
-				dbesc($url),
-				dbesc(normalise_link($url)),
-				intval($uid));
-
-	if ($contact) {
-		$contactid = $contact[0]["id"];
+	if (dbm::is_result($contacts)) {
+		$contact_id = $contacts[0]["id"];
 
 		// Update the contact every 7 days
-		$update_photo = ($contact[0]['avatar-date'] < datetime_convert('','','now -7 days'));
-		//$update_photo = ($contact[0]['avatar-date'] < datetime_convert('','','now -12 hours'));
+		$update_photo = ($contacts[0]['avatar-date'] < datetime_convert('','','now -7 days'));
 
 		if (!$update_photo OR $no_update) {
-			return($contactid);
+			return $contact_id;
 		}
-	} elseif ($uid != 0)
+	} elseif ($uid != 0) {
 		return 0;
+	}
 
-	if (!count($data))
-		$data = probe_url($url);
-
-	// Does this address belongs to a valid network?
-	if (!in_array($data["network"], array(NETWORK_DFRN, NETWORK_OSTATUS, NETWORK_DIASPORA))) {
-		if ($uid != 0)
-			return 0;
-
-		// Get data from the gcontact table
-		$r = q("SELECT `name`, `nick`, `url`, `photo`, `addr`, `alias`, `network` FROM `gcontact` WHERE `nurl` = '%s'",
-			 dbesc(normalise_link($url)));
-		if (!$r)
-			return 0;
-
-		$data = $r[0];
+	$data = probe_url($url);
+	if (!$data['url']) {
+		return 0;
 	}
 
 	$url = $data["url"];
 
-	if ($contactid == 0) {
+	// Does this address belongs to a valid network?
+	if (!in_array($data["network"], array(NETWORK_DFRN, NETWORK_OSTATUS, NETWORK_DIASPORA))) {
+		if ($uid != 0) {
+			return 0;
+		}
+
+		// Get data from the gcontact table
+		$gcontacts = q("SELECT `name`, `nick`, `url`, `photo`, `addr`, `alias`, `network` FROM `gcontact` WHERE `nurl` = '%s'",
+			 dbesc(normalise_link($url)));
+		if (!$gcontacts) {
+			return 0;
+		}
+
+		$data = $gcontacts[0];
+	}
+
+
+	if (!$contact_id) {
 		q("INSERT INTO `contact` (`uid`, `created`, `url`, `nurl`, `addr`, `alias`, `notify`, `poll`,
 					`name`, `nick`, `photo`, `network`, `pubkey`, `rel`, `priority`,
 					`batch`, `request`, `confirm`, `poco`, `name-date`, `uri-date`,
@@ -602,45 +611,48 @@ function get_contact($url, $uid = 0, $no_update = false) {
 			dbesc(datetime_convert())
 		);
 
-		$contact = q("SELECT `id` FROM `contact` WHERE `nurl` = '%s' AND `uid` = %d ORDER BY `id` LIMIT 2",
+		$contacts = q("SELECT `id` FROM `contact` WHERE `nurl` = '%s' AND `uid` = %d ORDER BY `id` LIMIT 2",
 				dbesc(normalise_link($data["url"])),
 				intval($uid));
-		if (!$contact)
+		if (!dbm::is_result($contacts)) {
 			return 0;
+		}
 
-		$contactid = $contact[0]["id"];
+		$contact_id = $contacts[0]["id"];
 
 		// Update the newly created contact from data in the gcontact table
-		$r = q("SELECT `location`, `about`, `keywords`, `gender` FROM `gcontact` WHERE `nurl` = '%s'",
+		$gcontacts = q("SELECT `location`, `about`, `keywords`, `gender` FROM `gcontact` WHERE `nurl` = '%s'",
 			 dbesc(normalise_link($data["url"])));
-		if ($r) {
-			logger("Update contact ".$data["url"]);
+		if (dbm::is_result($gcontacts)) {
+			logger("Update contact " . $data["url"] . ' from gcontact');
 			q("UPDATE `contact` SET `location` = '%s', `about` = '%s', `keywords` = '%s', `gender` = '%s' WHERE `id` = %d",
-				dbesc($r["location"]), dbesc($r["about"]), dbesc($r["keywords"]),
-				dbesc($r["gender"]), intval($contactid));
+				dbesc($gcontacts[0]["location"]), dbesc($gcontacts[0]["about"]), dbesc($gcontacts[0]["keywords"]),
+				dbesc($gcontacts[0]["gender"]), intval($contact_id));
 		}
 	}
 
-	if ((count($contact) > 1) AND ($uid == 0) AND ($contactid != 0) AND ($url != ""))
+	if (count($contacts) > 1 AND $uid == 0 AND $contact_id != 0 AND $url != "") {
 		q("DELETE FROM `contact` WHERE `nurl` = '%s' AND `id` != %d AND NOT `self`",
 			dbesc(normalise_link($url)),
-			intval($contactid));
+			intval($contact_id));
+	}
 
-	require_once("Photo.php");
+	require_once "Photo.php";
 
-	update_contact_avatar($data["photo"],$uid,$contactid);
+	update_contact_avatar($data["photo"], $uid, $contact_id);
 
-	$r = q("SELECT `addr`, `alias`, `name`, `nick` FROM `contact`  WHERE `id` = %d", intval($contactid));
+	$contacts = q("SELECT `addr`, `alias`, `name`, `nick` FROM `contact` WHERE `id` = %d", intval($contact_id));
 
 	// This condition should always be true
-	if (!dbm::is_result($r))
-		return $contactid;
+	if (!dbm::is_result($contacts)) {
+		return $contact_id;
+	}
 
 	// Only update if there had something been changed
-	if (($data["addr"] != $r[0]["addr"]) OR
-		($data["alias"] != $r[0]["alias"]) OR
-		($data["name"] != $r[0]["name"]) OR
-		($data["nick"] != $r[0]["nick"]))
+	if ($data["addr"] != $contacts[0]["addr"] OR
+		$data["alias"] != $contacts[0]["alias"] OR
+		$data["name"] != $contacts[0]["name"] OR
+		$data["nick"] != $contacts[0]["nick"]) {
 		q("UPDATE `contact` SET `addr` = '%s', `alias` = '%s', `name` = '%s', `nick` = '%s',
 			`name-date` = '%s', `uri-date` = '%s' WHERE `id` = %d",
 			dbesc($data["addr"]),
@@ -649,10 +661,11 @@ function get_contact($url, $uid = 0, $no_update = false) {
 			dbesc($data["nick"]),
 			dbesc(datetime_convert()),
 			dbesc(datetime_convert()),
-			intval($contactid)
+			intval($contact_id)
 		);
+	}
 
-	return $contactid;
+	return $contact_id;
 }
 
 /**

--- a/include/Contact.php
+++ b/include/Contact.php
@@ -578,8 +578,8 @@ function get_contact($url, $uid = 0, $no_update = false) {
 	require_once('include/Probe.php');
 	$data = Probe::uri($url);
 
-	// Does this address belongs to a valid network?
-	if (!in_array($data["network"], array(NETWORK_DFRN, NETWORK_OSTATUS, NETWORK_DIASPORA))) {
+	// Last try in gcontact for unsupported networks
+	if (!in_array($data["network"], array(NETWORK_DFRN, NETWORK_OSTATUS, NETWORK_DIASPORA, NETWORK_PUMPIO))) {
 		if ($uid != 0) {
 			return 0;
 		}
@@ -592,11 +592,6 @@ function get_contact($url, $uid = 0, $no_update = false) {
 		}
 
 		$data = $gcontacts[0];
-	}
-
-	// Unable to convert nick@server.tld into http://server.tld/nick
-	if (!$data['url'] && (!strstr($url, "http") OR strstr($url, "@"))) {
-		return 0;
 	}
 
 	$url = $data["url"];

--- a/include/Contact.php
+++ b/include/Contact.php
@@ -534,19 +534,20 @@ function get_contact($url, $uid = 0, $no_update = false) {
 	$data = array();
 	$contact_id = 0;
 
-	// We first try the addr (nick@server.tld)
+	// We first try the nurl (http://server.tld/nick), most common case
 	$contacts = q("SELECT `id`, `avatar-date` FROM `contact`
-				WHERE `addr` = '%s'
-				AND `uid` = %d",
-		dbesc($url),
-		intval($uid));
-
-	// Then the nurl (http://server.tld/nick)
-	if (! dbm::is_result($contacts)) {
-		$contacts = q("SELECT `id`, `avatar-date` FROM `contact`
 					WHERE `nurl` = '%s'
 					AND `uid` = %d",
 			dbesc(normalise_link($url)),
+			intval($uid));
+
+
+	// Then the addr (nick@server.tld)
+	if (! dbm::is_result($contacts)) {
+		$contacts = q("SELECT `id`, `avatar-date` FROM `contact`
+					WHERE `addr` = '%s'
+					AND `uid` = %d",
+			dbesc($url),
 			intval($uid));
 	}
 

--- a/include/Contact.php
+++ b/include/Contact.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once('include/Probe.php');
-
 // Included here for completeness, but this is a very dangerous operation.
 // It is the caller's responsibility to confirm the requestor's intent and
 // authorisation to do this.
@@ -355,6 +353,7 @@ function get_contact_details_by_addr($addr, $uid = -1) {
 				dbesc($addr));
 
 	if (!dbm::is_result($r)) {
+		require_once('include/Probe.php');
 		$data = Probe::uri($addr);
 
 		$profile = get_contact_details_by_url($data['url'], $uid);
@@ -530,8 +529,6 @@ function contacts_not_grouped($uid,$start = 0,$count = 0) {
  * @return integer Contact ID
  */
 function get_contact($url, $uid = 0, $no_update = false) {
-	require_once "include/Scrape.php";
-
 	logger("Get contact data for url ".$url." and user ".$uid." - ".App::callstack(), LOGGER_DEBUG);;
 
 	$data = array();
@@ -558,7 +555,8 @@ function get_contact($url, $uid = 0, $no_update = false) {
 		return 0;
 	}
 
-	$data = probe_url($url);
+	require_once('include/Probe.php');
+	$data = Probe::uri($url);
 	if (!$data['url']) {
 		return 0;
 	}


### PR DESCRIPTION
This is a free-floating PR related to #3213 without any behavior change.

It's an improvement of `get_contact()` that solves a `@todo` and reformat the function for readability and code standards compliance.