### PR TITLE
Remove @ signs in Twitter posts

### DIFF
--- a/include/bbcode.php
+++ b/include/bbcode.php
@@ -485,7 +485,7 @@ function bb_ShareAttributes($share, $simplehtml) {
 			$text = $preshare.html_entity_decode("&#x2672; ", ENT_QUOTES, 'UTF-8')." @".$userid_compact.": ".$share[3];
 			break;
 		case 8: // twitter
-			$text = $preshare."RT @".$userid_compact.": ".$share[3];
+			$text = $preshare."RT ".$author.": ".$share[3];
 			break;
 		case 9: // Google+/Facebook
 			$text = $preshare.html_entity_decode("&#x2672; ", ENT_QUOTES, 'UTF-8').' '.$userid_compact.": <br />".$share[3];

--- a/include/plaintext.php
+++ b/include/plaintext.php
@@ -301,7 +301,12 @@ function plaintext(App $a, $b, $limit = 0, $includedlinks = false, $htmlmode = 2
 
 	// Remove the hash tags
 	$URLSearchString = "^\[\]";
-	$body = preg_replace("/([#@])\[url\=([$URLSearchString]*)\](.*?)\[\/url\]/ism", '$1$3', $b["body"]);
+	if ($htmlmode == 8) {
+		// Twitter: Remove @ signs, keep names and hashtags
+		$body = preg_replace("/((#)|(@))\[url\=([$URLSearchString]*)\](.*?)\[\/url\]/ism", '$2$5', $b["body"]);
+	} else {
+		$body = preg_replace("/([#@])\[url\=([$URLSearchString]*)\](.*?)\[\/url\]/ism", '$1$3', $b["body"]);
+	}
 
 	// Add an URL element if the text contains a raw link
 	$body = preg_replace("/([^\]\='".'"'."]|^)(https?\:\/\/[a-zA-Z0-9\:\/\-\?\&\;\.\=\_\~\#\%\$\!\+\,]+)/ism", '$1[url]$2[/url]', $body);


### PR DESCRIPTION
Fix #3215

Additionally, RTs now use a shorter version of the account display name. It used to be "Full name (nick@server.tld)", I stripped the address part that doesn't mean much on Twitter.