### PR TITLE
Diaspora: Normalize line endings instead of adding <br> before Markdown()

### DIFF
--- a/include/bb2diaspora.php
+++ b/include/bb2diaspora.php
@@ -39,9 +39,9 @@ function diaspora2bb($s) {
 	$s = html_entity_decode($s, ENT_COMPAT, 'UTF-8');
 
 	// Handles single newlines
-	$s = str_replace("\r", '<br>', $s);
-
+	$s = str_replace("\r\n", "\n", $s);
 	$s = str_replace("\n", " \n", $s);
+	$s = str_replace("\r", " \n", $s);
 
 	// Replace lonely stars in lines not starting with it with literal stars
 	$s = preg_replace('/^([^\*]+)\*([^\*]*)$/im', '$1\*$2', $s);


### PR DESCRIPTION
Fixes #3220 and #3217.

For some reason, we were adding `<br>` tags just before the `Markdown()` treatment, which fooled it into thinking quotes should run the full text instead of stopping at the nearest double-newline.

Normalizing line endings should fix this behavior while retaining the `\r` trimming that probably was performed for a reason, although it still is unclear to me why since the output seemed to be correct without the offending line.