### PR TITLE
limit pagination page buttons to  max 10

### DIFF
--- a/include/text.php
+++ b/include/text.php
@@ -291,8 +291,8 @@ function paginate_data(App $a, $count = null) {
 	}
 
 	$url = $stripped;
-
 	$data = array();
+
 	function _l(&$d, $name, $url, $text, $class = '') {
 		if (strpos($url, '?') === false && ($pos = strpos($url, '&')) !== false) {
 			$url = substr($url, 0, $pos) . '?' . substr($url, $pos + 1);
@@ -318,9 +318,10 @@ function paginate_data(App $a, $count = null) {
 			$numstart = 1;
 			$numstop = $numpages;
 
-			if ($numpages > 14) {
-				$numstart = (($pagenum > 7) ? ($pagenum - 7) : 1);
-				$numstop = (($pagenum > ($numpages - 7)) ? $numpages : ($numstart + 14));
+			// Limit the number of displayed page number buttons.
+			if ($numpages > 8) {
+				$numstart = (($pagenum > 4) ? ($pagenum - 4) : 1);
+				$numstop = (($pagenum > ($numpages - 7)) ? $numpages : ($numstart + 8));
 			}
 
 			$pages = array();

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -2509,21 +2509,53 @@ body .tread-wrapper .hovercard:hover .hover-card-content a {
 }
 
 /* Pagination improvements */
+.pagination {
+    text-align: center;
+    display: block;
+}
 .pagination > li > a,
 .pagination > li > span {
-	color: $link_color;
+    color: $link_color;
+    float: none;
 }
-.pagination>.active>a,
-.pagination>.active>a:focus,
-.pagination>.active>a:hover,
-.pagination>.active>span,
-.pagination>.active>span:focus,
-.pagination>.active>span:hover {
-	background-color: $link_color;
+.pagination>li>a:hover,
+.pagination>li>span:hover {
+    color: $link_hover_color;
+}
+.pagination > .active > a,
+.pagination > .active > a:focus,
+.pagination > .active > a:hover,
+.pagination > .active > span,
+.pagination > .active > span:focus,
+.pagination > .active > span:hover {
+    background-color: $link_color;
     border-color: $link_color;
+    border-radius: 3px;
 }
-.disabled > a {
-	pointer-events: none;
+.pagination li.pager_n a {
+    margin-left: 3px;
+    border-radius: 3px;
+}
+.pagination .pager_prev a {
+    margin-left: -5px;
+    margin-right: 4px;
+    border-top-right-radius: 3px;
+    border-bottom-right-radius: 3px;
+}
+.pagination .pager_next a {
+    margin-left: 4px;
+    margin-right: -5px;
+    border-top-left-radius: 3px;
+    border-bottom-left-radius: 3px;
+}
+.pager .next > a,
+.pager .previous > a {
+    float: none;
+    border-radius: 3px;
+}
+.pagination .disabled > a,
+.pager .disabled > a {
+    display: none;
 }
 
 /*

--- a/view/theme/frio/templates/paginate.tpl
+++ b/view/theme/frio/templates/paginate.tpl
@@ -1,14 +1,16 @@
+
 {{* Pager template, uses output of paginate_data() in include/text.php *}}
+
 {{if $pager}}
-<div class="{{$pager.class}}">
-	{{if $pager.first}}<li class="pager_first {{$pager.first.class}}"><a href="{{$pager.first.url}}">{{$pager.first.text}}</a></li>{{/if}}
+<ul class="{{$pager.class}} pagination-sm">
+	{{if $pager.first}}<li class="pager_first {{$pager.first.class}}"><a href="{{$pager.first.url}}" title="{{$pager.first.text}}">&#8739;&lt;</a></li>{{/if}}
 
-	{{if $pager.prev}}<li class="pager_prev {{$pager.prev.class}}"><a href="{{$pager.prev.url}}">{{$pager.prev.text}}</a></li>{{/if}}
+	{{if $pager.prev}}<li class="pager_prev {{$pager.prev.class}}"><a href="{{$pager.prev.url}}" title="{{$pager.prev.text}}">&lt;</a></li>{{/if}}
 
-	{{foreach $pager.pages as $p}}<li class="pager_{{$p.class}}"><a href="{{$p.url}}">{{$p.text}}</a></li>{{/foreach}}
+	{{foreach $pager.pages as $p}}<li class="pager_{{$p.class}} hidden-xs hidden-sm"><a href="{{$p.url}}">{{$p.text}}</a></li>{{/foreach}}
 
-	{{if $pager.next}}<li class="pager_next {{$pager.next.class}}"><a href="{{$pager.next.url}}">{{$pager.next.text}}</a></li>{{/if}}
+	{{if $pager.next}}<li class="pager_next {{$pager.next.class}}"><a href="{{$pager.next.url}}" title="{{$pager.next.text}}">&gt;</a></li>{{/if}}
 
-	{{if $pager.last}}&nbsp;<li class="pager_last {{$pager.last.class}}"><a href="{{$pager.last.url}}">{{$pager.last.text}}</a></li>{{/if}}
-</div>
+	{{if $pager.last}}<li class="pager_last {{$pager.last.class}}"><a href="{{$pager.last.url}}" title="{{$pager.last.text}}">&gt;&#8739;</a></li>{{/if}}
+</ul>
 {{/if}}


### PR DESCRIPTION
this is a PR to polish https://github.com/friendica/friendica/pull/3200
Now the pagination does show only 10 pages in its list (formerly 16) to save some space.

Frio does now use symbols (instead of text) for the `first`, `last`, `previous` and `next` page. Im not totally satisfied with the used chars. If anyone knows better chars or good icons please improve the situation