### PR TITLE
"no_utf" wasn't in use anymore - it is now removed completely

### DIFF
--- a/doc/Settings.md
+++ b/doc/Settings.md
@@ -152,13 +152,6 @@ Value is in seconds.
 Default is 60 seconds.
 Set to 0 for unlimited (not recommended).
 
-#### UTF-8 Regular Expressions
-
-During registrations, full names are checked using UTF-8 regular expressions.
-This requires PHP to have been compiled with a special setting to allow UTF-8 expressions.
-If you are completely unable to register accounts, set no_utf to true.
-The default is set to false (meaning UTF8 regular expressions are supported and working).
-
 #### Verify SSL Certitificates
 
 By default Friendica allows SSL communication between websites that have "self-signed" SSL certificates.

--- a/include/user.php
+++ b/include/user.php
@@ -97,13 +97,6 @@ function create_user($arr) {
 	if(mb_strlen($username) < 3)
 		$result['message'] .= t('Name too short.') . EOL;
 
-	// I don't really like having this rule, but it cuts down
-	// on the number of auto-registrations by Russian spammers
-
-	//  Using preg_match was completely unreliable, due to mixed UTF-8 regex support
-	//	$no_utf = get_config('system','no_utf');
-	//	$pat = (($no_utf) ? '/^[a-zA-Z]* [a-zA-Z]*$/' : '/^\p{L}* \p{L}*$/u' );
-
 	// So now we are just looking for a space in the full name.
 
 	$loose_reg = get_config('system','no_regfullname');

--- a/mod/admin.php
+++ b/mod/admin.php
@@ -629,7 +629,6 @@ function admin_page_site_post(App $a) {
 	$no_multi_reg		=	((x($_POST,'no_multi_reg'))		? True						: False);
 	$no_openid		=	!((x($_POST,'no_openid'))		? True						: False);
 	$no_regfullname		=	!((x($_POST,'no_regfullname'))		? True						: False);
-	$no_utf			=	!((x($_POST,'no_utf'))			? True						: False);
 	$community_page_style	=	((x($_POST,'community_page_style'))	? intval(trim($_POST['community_page_style']))	: 0);
 	$max_author_posts_community_page	=	((x($_POST,'max_author_posts_community_page'))	? intval(trim($_POST['max_author_posts_community_page']))	: 0);
 
@@ -786,7 +785,6 @@ function admin_page_site_post(App $a) {
 	set_config('system','no_regfullname', $no_regfullname);
 	set_config('system','community_page_style', $community_page_style);
 	set_config('system','max_author_posts_community_page', $max_author_posts_community_page);
-	set_config('system','no_utf', $no_utf);
 	set_config('system','verifyssl', $verifyssl);
 	set_config('system','proxyuser', $proxyuser);
 	set_config('system','proxy', $proxy);
@@ -1008,7 +1006,6 @@ function admin_page_site(App $a) {
 		'$no_multi_reg'		=> array('no_multi_reg', t("Block multiple registrations"),  get_config('system','block_extended_register'), t("Disallow users to register additional accounts for use as pages.")),
 		'$no_openid'		=> array('no_openid', t("OpenID support"), !get_config('system','no_openid'), t("OpenID support for registration and logins.")),
 		'$no_regfullname'	=> array('no_regfullname', t("Fullname check"), !get_config('system','no_regfullname'), t("Force users to register with a space between firstname and lastname in Full name, as an antispam measure")),
-		'$no_utf'		=> array('no_utf', t("UTF-8 Regular expressions"), !get_config('system','no_utf'), t("Use PHP UTF8 regular expressions")),
 		'$community_page_style' => array('community_page_style', t("Community Page Style"), get_config('system','community_page_style'), t("Type of community page to show. 'Global community' shows every public posting from an open distributed network that arrived on this server."), $community_page_style_choices),
 		'$max_author_posts_community_page' => array('max_author_posts_community_page', t("Posts per user on community page"), get_config('system','max_author_posts_community_page'), t("The maximum number of posts per user on the community page. (Not valid for 'Global Community')")),
 		'$ostatus_disabled' 	=> array('ostatus_disabled', t("Enable OStatus support"), !get_config('system','ostatus_disabled'), t("Provide built-in OStatus \x28StatusNet, GNU Social etc.\x29 compatibility. All communications in OStatus are public, so privacy warnings will be occasionally displayed.")),

--- a/view/templates/admin_site.tpl
+++ b/view/templates/admin_site.tpl
@@ -114,7 +114,6 @@
 
 	<h3>{{$advanced}}</h3>
 	{{include file="field_select.tpl" field=$rino}}
-	{{include file="field_checkbox.tpl" field=$no_utf}}
 	{{include file="field_checkbox.tpl" field=$verifyssl}}
 	{{include file="field_input.tpl" field=$proxy}}
 	{{include file="field_input.tpl" field=$proxyuser}}

--- a/view/theme/frost-mobile/templates/admin_site.tpl
+++ b/view/theme/frost-mobile/templates/admin_site.tpl
@@ -52,7 +52,6 @@
 	<div class="submit"><input type="submit" name="page_site" value="{{$submit}}" /></div>
 	
 	<h3>{{$advanced}}</h3>
-	{{include file="field_checkbox.tpl" field=$no_utf}}
 	{{include file="field_checkbox.tpl" field=$verifyssl}}
 	{{include file="field_input.tpl" field=$proxy}}
 	{{include file="field_input.tpl" field=$proxyuser}}

--- a/view/theme/frost/templates/admin_site.tpl
+++ b/view/theme/frost/templates/admin_site.tpl
@@ -52,7 +52,6 @@
 	<div class="submit"><input type="submit" name="page_site" value="{{$submit}}" /></div>
 	
 	<h3>{{$advanced}}</h3>
-	{{include file="field_checkbox.tpl" field=$no_utf}}
 	{{include file="field_checkbox.tpl" field=$verifyssl}}
 	{{include file="field_input.tpl" field=$proxy}}
 	{{include file="field_input.tpl" field=$proxyuser}}


### PR DESCRIPTION
These lines were commented out more than 5 years ago. We really can get rid of this now.