### PR TITLE
Only import new OStatus posts if they are from our followers

### DIFF
--- a/include/ostatus.php
+++ b/include/ostatus.php
@@ -811,7 +811,7 @@ class ostatus {
 		if (((intval(get_config('system','ostatus_poll_interval')) == -2) AND (count($item) > 0)) OR
 			($item["verb"] == ACTIVITY_LIKE) OR ($conversation_url == "")) {
 			$item_stored = item_store($item, $all_threads);
-			return($item_stored);
+			return $item_stored;
 		}
 
 		// Get the parent

--- a/include/ostatus.php
+++ b/include/ostatus.php
@@ -799,6 +799,9 @@ class ostatus {
 
 		/// @todo This function is totally ugly and has to be rewritten totally
 
+		// Import all threads or only threads that were started by our followers?
+		$all_threads = !get_config('system','ostatus_full_threads');
+
 		$item_stored = -1;
 
 		$conversation_url = self::fetch_conversation($self, $conversation_url);
@@ -807,7 +810,7 @@ class ostatus {
 		// Don't do a completion on liked content
 		if (((intval(get_config('system','ostatus_poll_interval')) == -2) AND (count($item) > 0)) OR
 			($item["verb"] == ACTIVITY_LIKE) OR ($conversation_url == "")) {
-			$item_stored = item_store($item, true);
+			$item_stored = item_store($item, $all_threads);
 			return($item_stored);
 		}
 
@@ -888,7 +891,7 @@ class ostatus {
 
 		if (!sizeof($items)) {
 			if (count($item) > 0) {
-				$item_stored = item_store($item, true);
+				$item_stored = item_store($item, $all_threads);
 
 				if ($item_stored) {
 					logger("Conversation ".$conversation_url." couldn't be fetched. Item uri ".$item["uri"]." stored: ".$item_stored, LOGGER_DEBUG);
@@ -1186,7 +1189,7 @@ class ostatus {
 				}
 			}
 
-			$item_stored = item_store($item, true);
+			$item_stored = item_store($item, $all_threads);
 			if ($item_stored) {
 				logger("Uri ".$item["uri"]." wasn't found in conversation ".$conversation_url, LOGGER_DEBUG);
 				self::store_conversation($item_stored, $conversation_url);


### PR DESCRIPTION
This covers the issues https://github.com/friendica/friendica/issues/2364 and https://github.com/friendica/friendica/issues/2961 which both covering the same issue: When people chose to only import starting posts from their OStatus followers, then they don't want to see them answering to posts that they don't have on their system.

To make this work, the option "Only import OStatus threads from our contacts" has to be enabled.