### PR TITLE
Issue 1720: Group filter and new tab don't like each other

### DIFF
--- a/mod/network.php
+++ b/mod/network.php
@@ -47,7 +47,7 @@ function network_init(App $a) {
 			$net_baseurl .= '/' . $sel_groups;
 		}
 
-		if($remember_tab) {
+		if ($remember_tab) {
 			// redirect if current selected tab is '/network' and
 			// last selected tab is _not_ '/network?f=&order=comment'.
 			// and this isn't a date query
@@ -73,20 +73,23 @@ function network_init(App $a) {
 
 			$k = array_search('active', $last_sel_tabs);
 
-			$net_baseurl .= $tab_baseurls[$k];
+			if ($k != 3) {
+				$net_baseurl .= $tab_baseurls[$k];
 
-			// parse out tab queries
-			$dest_qa = array();
-			$dest_qs = $tab_args[$k];
-			parse_str( $dest_qs, $dest_qa);
-			$net_args = array_merge($net_args, $dest_qa);
-		}
-		else if($sel_tabs[4] === 'active') {
+				// parse out tab queries
+				$dest_qa = array();
+				$dest_qs = $tab_args[$k];
+				parse_str($dest_qs, $dest_qa);
+				$net_args = array_merge($net_args, $dest_qa);
+			} else {
+				$remember_tab = false;
+			}
+		} elseif($sel_tabs[4] === 'active') {
 			// The '/new' tab is selected
-			$net_baseurl .= '/new';
+			$remember_group = false;
 		}
 
-		if($remember_net) {
+		if ($remember_net) {
 			$net_args['nets'] = $last_sel_nets;
 		}
 		else if($sel_nets!==false) {
@@ -842,7 +845,7 @@ function network_tabs(App $a) {
 	if(feature_enabled(local_user(),'new_tab')) {
 		$tabs[] = array(
 			'label'	=> t('New'),
-			'url'	=> str_replace('/new', '', $cmd) . ($len_naked_cmd ? '/' : '') . 'new' . ((x($_GET,'cid')) ? '/?f=&cid=' . $_GET['cid'] : ''),
+			'url'	=> 'network/new' . ((x($_GET,'cid')) ? '/?f=&cid=' . $_GET['cid'] : ''),
 			'sel'	=> $new_active,
 			'title'	=> t('Activity Stream - by date'),
 			'id'	=> 'activitiy-by-date-tab',

--- a/mod/network.php
+++ b/mod/network.php
@@ -84,7 +84,7 @@ function network_init(App $a) {
 			} else {
 				$remember_tab = false;
 			}
-		} elseif($sel_tabs[4] === 'active') {
+		} elseif ($sel_tabs[4] === 'active') {
 			// The '/new' tab is selected
 			$remember_group = false;
 		}
@@ -842,7 +842,7 @@ function network_tabs(App $a) {
 		);
 	}
 
-	if(feature_enabled(local_user(),'new_tab')) {
+	if (feature_enabled(local_user(),'new_tab')) {
 		$tabs[] = array(
 			'label'	=> t('New'),
 			'url'	=> 'network/new' . ((x($_GET,'cid')) ? '/?f=&cid=' . $_GET['cid'] : ''),


### PR DESCRIPTION
See issue https://github.com/friendica/friendica/issues/1720

Because of the very complicated query that is needed for the groups, this interferes with the complete different structure of the "new" page. Now they exclude each other. Means: When you have selected "new" and you were previously in a group view, then you automatically leave the group view - and vice versa.

Note to @Hypolite: Yeah, there are "standard problems" in the lines around the changed lines. But if I change these as well, then new "standard problematic lines" will appear around the newly changed lines. When I then change these lines as well then even more problematic lines will appear.

So in the end I had to rework the whole file since this file is really a mess. However we could delegate this task to @Quix0r who seem to like this kind of work. Then you had to accept this pull request in this way.