### PR TITLE
Add type="text" attribute for openid input field

### DIFF
--- a/view/templates/field_openid.tpl
+++ b/view/templates/field_openid.tpl
@@ -1,6 +1,6 @@
 	
 	<div class='field input openid' id='wrapper_{{$field.0}}'>
 		<label for='id_{{$field.0}}'>{{$field.1}}</label>
-		<input name='{{$field.0}}' id='id_{{$field.0}}' value="{{$field.2|escape:'html'}}" aria-describedby='{{$field.0}}_tip'>
+		<input name='{{$field.0}}' id='id_{{$field.0}}' type="text" value="{{$field.2|escape:'html'}}" aria-describedby='{{$field.0}}_tip'>
 		<span class='field_help' role='tooltip' id='{{$field.0}}_tip'>{{$field.3}}</span>
 	</div>

--- a/view/theme/frost-mobile/templates/field_openid.tpl
+++ b/view/theme/frost-mobile/templates/field_openid.tpl
@@ -1,6 +1,6 @@
 	
 	<div class='field input openid' id='wrapper_{{$field.0}}'>
 		<label for='id_{{$field.0}}'>{{$field.1}}</label><br />
-		<input name='{{$field.0}}' id='id_{{$field.0}}' value="{{$field.2}}">
+		<input name='{{$field.0}}' id='id_{{$field.0}}' type="text" value="{{$field.2}}">
 		<span class='field_help'>{{$field.3}}</span>
 	</div>


### PR DESCRIPTION
The type attribute was present in another theme, and in other input fields