### PR TITLE
Avoid possible problems with numeric nicknames and GNU Social

### DIFF
--- a/include/Probe.php
+++ b/include/Probe.php
@@ -364,9 +364,9 @@ class Probe {
 				return self::mail($uri, $uid);
 			}
 
-			if ($network == NETWORK_MAIL)
+			if ($network == NETWORK_MAIL) {
 				return self::mail($uri, $uid);
-
+			}
 			// Remove "acct:" from the URI
 			$uri = str_replace('acct:', '', $uri);
 
@@ -391,37 +391,37 @@ class Probe {
 		/// @todo Do we need the prefix "acct:" or "acct://"?
 
 		foreach ($lrdd AS $key => $link) {
-			if ($webfinger)
+			if ($webfinger) {
 				continue;
+			}
+			if (!in_array($key, array("lrdd", "lrdd-xml", "lrdd-json"))) {
+				continue;
+			}
+			// At first try it with the given uri
+			$path = str_replace('{uri}', urlencode($uri), $link);
+			$webfinger = self::webfinger($path);
 
-			if (!in_array($key, array("lrdd", "lrdd-xml", "lrdd-json")))
-				continue;
+			// We cannot be sure that the detected address was correct, so we don't use the values
+			if ($webfinger AND ($uri != $addr)) {
+				$nick = "";
+				$addr = "";
+			}
 
 			// Try webfinger with the address (user@domain.tld)
-			$path = str_replace('{uri}', urlencode($addr), $link);
-			$webfinger = self::webfinger($path);
+			if (!$webfinger) {
+				$path = str_replace('{uri}', urlencode($addr), $link);
+				$webfinger = self::webfinger($path);
+			}
 
 			// Mastodon needs to have it with "acct:"
 			if (!$webfinger) {
 				$path = str_replace('{uri}', urlencode("acct:".$addr), $link);
 				$webfinger = self::webfinger($path);
 			}
-
-			// If webfinger wasn't successful then try it with the URL - possibly in the format https://...
-			if (!$webfinger AND ($uri != $addr)) {
-				$path = str_replace('{uri}', urlencode($uri), $link);
-				$webfinger = self::webfinger($path);
-
-				// Since the detection with the address wasn't successful, we delete it.
-				if ($webfinger) {
-					$nick = "";
-					$addr = "";
-				}
-			}
-
 		}
-		if (!$webfinger)
+		if (!$webfinger) {
 			return self::feed($uri);
+		}
 
 		$result = false;
 

--- a/mod/probe.php
+++ b/mod/probe.php
@@ -4,6 +4,13 @@ require_once('include/Scrape.php');
 
 function probe_content(App $a) {
 
+	if (!local_user()) {
+		http_status_exit(403,
+				array("title" => t("Public access denied."),
+					"description" => t("Only logged in users are permitted to perform a probing.")));
+		killme();
+	}
+
 	$o .= '<h3>Probe Diagnostic</h3>';
 
 	$o .= '<form action="probe" method="get">';

--- a/mod/webfinger.php
+++ b/mod/webfinger.php
@@ -3,6 +3,13 @@ require_once("include/Probe.php");
 
 function webfinger_content(App $a) {
 
+	if (!local_user()) {
+		http_status_exit(403,
+				array("title" => t("Public access denied."),
+					"description" => t("Only logged in users are permitted to perform a probing.")));
+		killme();
+	}
+
 	$o .= '<h3>Webfinger Diagnostic</h3>';
 
 	$o .= '<form action="webfinger" method="get">';


### PR DESCRIPTION
On GNU Social a user has different url formats. One of this is http://domain.tld/users/id (with "id" being a numeric value).

Our detection assumed that the last part of an url is always a nickname. When probing the format like described above it tried with the numeric id as nickname - which mostly will fail, but not always. When it failed then everything was okay, we just proceeded with the detection process. But when it hadn't failed, we will have detected a wrong account.

This fixes it.

Additionally this PR blocks the access to the "probe" and "webfinger" web interface for not logged in users. I have a better feeling when we don't allow anyone to do a network intense thing on our system.