### PR TITLE
Use get_contact_by_url for unknown contacts in acl_lookup

### DIFF
--- a/include/acl_selectors.php
+++ b/include/acl_selectors.php
@@ -615,7 +615,7 @@ function acl_lookup(App $a, $out_type = 'json') {
 		function _contact_link($i){ return dbesc($i['link']); }
 		$known_contacts = array_map(_contact_link, $contacts);
 		$unknow_contacts=array();
-		$r = q("SELECT `author-avatar`,`author-name`,`author-link`
+		$r = q("SELECT `author-avatar`,`author-name`,`author-link`, `network`
 				FROM `item` WHERE `parent` = %d
 					AND (`author-name` LIKE '%%%s%%' OR `author-link` LIKE '%%%s%%')
 					AND `author-link` NOT IN ('%s')
@@ -640,7 +640,7 @@ function acl_lookup(App $a, $out_type = 'json') {
 					'photo'   => proxy_url($row['author-avatar'], false, PROXY_SIZE_MICRO),
 					'name'    => htmlentities($row['author-name']),
 					'id'      => '',
-					'network' => 'unknown',
+					'network' => $row['network'],
 					'link'    => $row['author-link'],
 					'nick'    => htmlentities($nick),
 					'forum'   => false

--- a/include/acl_selectors.php
+++ b/include/acl_selectors.php
@@ -627,14 +627,14 @@ function acl_lookup(App $a, $out_type = 'json') {
 				dbesc($search),
 				implode("','", $known_contacts)
 		);
-		if (dbm::is_result($r)){
+		if (dbm::is_result($r)) {
 			foreach ($r as $row) {
-				// nickname..
 				$up = parse_url($row['author-link']);
-				$nick = explode("/",$up['path']);
-				$nick = $nick[count($nick)-1];
-				$nick .= "@".$up['host'];
-				// /nickname
+				$nick = explode('/', $up['path']);
+				// Fix for Mastodon URLs with format https://domain.tld/@nick
+				$nick = ltrim($nick[count($nick) - 1], '@');
+				$nick .= '@' . $up['host'];
+
 				$unknow_contacts[] = array(
 					'type'    => 'c',
 					'photo'   => proxy_url($row['author-avatar'], false, PROXY_SIZE_MICRO),

--- a/include/acl_selectors.php
+++ b/include/acl_selectors.php
@@ -639,13 +639,13 @@ function acl_lookup(App $a, $out_type = 'json') {
 
 				if (count($contact) > 0) {
 					$unknown_contacts[] = array(
-						'type'    => 'cu',
+						'type'    => 'c',
 						'photo'   => proxy_url($contact['micro'], false, PROXY_SIZE_MICRO),
 						'name'    => htmlentities($contact['name']),
 						'id'      => intval($contact['cid']),
 						'network' => $contact['network'],
 						'link'    => $contact['url'],
-						'nick'    => $contact['nick'] ? : $contact['addr'],
+						'nick'    => htmlentities($contact['nick'] ? : $contact['addr']),
 						'forum'   => $contact['forum']
 					);
 				}

--- a/include/acl_selectors.php
+++ b/include/acl_selectors.php
@@ -635,18 +635,18 @@ function acl_lookup(App $a, $out_type = 'json') {
 		);
 		if (dbm::is_result($r)) {
 			foreach ($r as $row) {
-				$contact = get_contact_details_by_url($row['author-link'], 0);
+				$contact = get_contact_details_by_url($row['author-link']);
 
 				if (count($contact) > 0) {
 					$unknown_contacts[] = array(
 						'type'    => 'cu',
 						'photo'   => proxy_url($contact['micro'], false, PROXY_SIZE_MICRO),
 						'name'    => htmlentities($contact['name']),
-						'id'      => intval($contact['id']),
+						'id'      => intval($contact['cid']),
 						'network' => $contact['network'],
 						'link'    => $contact['url'],
-						'nick'    => $contact['nick'],
-						'forum'   => false
+						'nick'    => $contact['nick'] ? : $contact['addr'],
+						'forum'   => $contact['forum']
 					);
 				}
 			}

--- a/include/acl_selectors.php
+++ b/include/acl_selectors.php
@@ -637,16 +637,18 @@ function acl_lookup(App $a, $out_type = 'json') {
 			foreach ($r as $row) {
 				$contact = get_contact_details_by_url($row['author-link'], 0);
 
-				$unknown_contacts[] = array(
-					'type'    => 'cu',
-					'photo'   => proxy_url($contact['micro'], false, PROXY_SIZE_MICRO),
-					'name'    => htmlentities($contact['name']),
-					'id'      => intval($contact['id']),
-					'network' => $contact['network'],
-					'link'    => $contact['url'],
-					'nick'    => $contact['nick'],
-					'forum'   => false
-				);
+				if (count($contact) > 0) {
+					$unknown_contacts[] = array(
+						'type'    => 'cu',
+						'photo'   => proxy_url($contact['micro'], false, PROXY_SIZE_MICRO),
+						'name'    => htmlentities($contact['name']),
+						'id'      => intval($contact['id']),
+						'network' => $contact['network'],
+						'link'    => $contact['url'],
+						'nick'    => $contact['nick'],
+						'forum'   => false
+					);
+				}
 			}
 		}
 

--- a/include/acl_selectors.php
+++ b/include/acl_selectors.php
@@ -610,12 +610,18 @@ function acl_lookup(App $a, $out_type = 'json') {
 	$items = array_merge($groups, $contacts);
 
 	if ($conv_id) {
-		/* if $conv_id is set, get unknow contacts in thread */
-		/* but first get know contacts url to filter them out */
-		function _contact_link($i){ return dbesc($i['link']); }
-		$known_contacts = array_map(_contact_link, $contacts);
-		$unknow_contacts=array();
-		$r = q("SELECT `author-avatar`,`author-name`,`author-link`, `network`
+		/*
+		 * if $conv_id is set, get unknown contacts in thread
+		 * but first get known contacts url to filter them out
+		 */
+		$known_contacts = array_map(
+			function ($i) {
+				return dbesc($i['link']);
+			}
+		, $contacts);
+
+		$unknown_contacts = array();
+		$r = q("SELECT `author-link`
 				FROM `item` WHERE `parent` = %d
 					AND (`author-name` LIKE '%%%s%%' OR `author-link` LIKE '%%%s%%')
 					AND `author-link` NOT IN ('%s')
@@ -625,31 +631,27 @@ function acl_lookup(App $a, $out_type = 'json') {
 				intval($conv_id),
 				dbesc($search),
 				dbesc($search),
-				implode("','", $known_contacts)
+				implode("', '", $known_contacts)
 		);
 		if (dbm::is_result($r)) {
 			foreach ($r as $row) {
-				$up = parse_url($row['author-link']);
-				$nick = explode('/', $up['path']);
-				// Fix for Mastodon URLs with format https://domain.tld/@nick
-				$nick = ltrim($nick[count($nick) - 1], '@');
-				$nick .= '@' . $up['host'];
+				$contact = get_contact_details_by_url($row['author-link'], 0);
 
-				$unknow_contacts[] = array(
-					'type'    => 'c',
-					'photo'   => proxy_url($row['author-avatar'], false, PROXY_SIZE_MICRO),
-					'name'    => htmlentities($row['author-name']),
-					'id'      => '',
-					'network' => $row['network'],
-					'link'    => $row['author-link'],
-					'nick'    => htmlentities($nick),
+				$unknown_contacts[] = array(
+					'type'    => 'cu',
+					'photo'   => proxy_url($contact['micro'], false, PROXY_SIZE_MICRO),
+					'name'    => htmlentities($contact['name']),
+					'id'      => intval($contact['id']),
+					'network' => $contact['network'],
+					'link'    => $contact['url'],
+					'nick'    => $contact['nick'],
 					'forum'   => false
 				);
 			}
 		}
 
-		$items = array_merge($items, $unknow_contacts);
-		$tot += count($unknow_contacts);
+		$items = array_merge($items, $unknown_contacts);
+		$tot += count($unknown_contacts);
 	}
 
 	$results = array(

--- a/mod/acl.php
+++ b/mod/acl.php
@@ -1,7 +1,7 @@
 <?php
 /* ACL selector json backend */
 
-require_once("include/acl_selectors.php");
+require_once 'include/acl_selectors.php';
 
 function acl_init(App $a) {
 	acl_lookup($a);


### PR DESCRIPTION
Fixes #3316

However, it also prevents auto-complete for any contact with an `@` in the nick (not the name, though).

A cursory search through my 7000+ contacts didn't show any instance of a nick with a leading `@`, but I can't be sure it's actually a rule through the Fediverse.

I also added the network information because I could.

Test URL: https://friendica.mrpetovan.com/display/735a20299158ec31cd39fea181475070