### PR TITLE
Ignore Activity Streams `delete` messages from Mastodon

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -382,6 +382,7 @@ define ( 'ACTIVITY_UPDATE',      NAMESPACE_ACTIVITY_SCHEMA . 'update' );
 define ( 'ACTIVITY_TAG',         NAMESPACE_ACTIVITY_SCHEMA . 'tag' );
 define ( 'ACTIVITY_FAVORITE',    NAMESPACE_ACTIVITY_SCHEMA . 'favorite' );
 define ( 'ACTIVITY_SHARE',       NAMESPACE_ACTIVITY_SCHEMA . 'share' );
+define ( 'ACTIVITY_DELETE',      NAMESPACE_ACTIVITY_SCHEMA . 'delete' );
 
 define ( 'ACTIVITY_POKE',        NAMESPACE_ZOT . '/activity/poke' );
 define ( 'ACTIVITY_MOOD',        NAMESPACE_ZOT . '/activity/mood' );

--- a/include/ostatus.php
+++ b/include/ostatus.php
@@ -367,7 +367,7 @@ class ostatus {
 
 			/// @TODO
 			/// Delete a message
-			if ($item["verb"] == "qvitter-delete-notice") {
+			if ($item["verb"] == "qvitter-delete-notice" || $item["verb"] == ACTIVITY_DELETE) {
 				// ignore "Delete" messages (by now)
 				logger("Ignore delete message ".print_r($item, true));
 				continue;


### PR DESCRIPTION
Fixes #3292.

I wasn't sure if I should dabble into removing OStatus messages, therefore I went the easiest route to prevent blank items.

In particular, I've not been able to find the original message those delete commands referenced, so it looks like we can safely ignore them.

Please correct me if I'm wrong.