### PR TITLE
Scroll to next/previous thread when pressing j/k (fixes #3327)

### DIFF
--- a/doc/KeyboardShortcuts.md
+++ b/doc/KeyboardShortcuts.md
@@ -1,0 +1,10 @@
+Keyboard shortcuts in Friendica
+=======================
+
+* [Home](help)
+
+General
+-------
+
+* j: Scroll to next thread
+* k: Scroll to previous thread

--- a/js/main.js
+++ b/js/main.js
@@ -322,6 +322,29 @@
 			}
 		});
 
+		$(document).keydown(function (event) {
+			var threads = $('.thread_level_1');
+			if ((event.keyCode === 74 || event.keyCode === 75) && !$(event.target).is('textarea, input')) {
+				var scrollTop = $(window).scrollTop();
+				if (event.keyCode === 75) {
+					threads = $(threads.get().reverse());
+				}
+				threads.each(function(key, item) {
+					var comparison;
+					var top = $(item).offset().top - 100;
+					if (event.keyCode === 74) {
+						comparison = top > scrollTop + 1;
+					} else if (event.keyCode === 75) {
+						comparison = top < scrollTop - 1;
+					}
+					if (comparison) {
+						$('html, body').animate({ scrollTop: top }, 200);
+						return false;
+					}
+				});
+			}
+		});
+
 		// Set an event listener for infinite scroll
 		if(typeof infinite_scroll !== 'undefined') {
 			$(window).scroll(function(e){

--- a/js/main.js
+++ b/js/main.js
@@ -322,6 +322,7 @@
 			}
 		});
 
+		// Scroll to the next/previous thread when pressing J and K
 		$(document).keydown(function (event) {
 			var threads = $('.thread_level_1');
 			if ((event.keyCode === 74 || event.keyCode === 75) && !$(event.target).is('textarea, input')) {


### PR DESCRIPTION
This patch adds keyboard events on the `j` and `k` keys that scroll to the next/previous thread.
I have successfully tested it with the vier and frio themes.