### PR TITLE
Web app manifest (fixes #3317)

### DIFF
--- a/mod/manifest.php
+++ b/mod/manifest.php
@@ -1,0 +1,26 @@
+<?php
+    use Friendica\Core\Config;
+
+    function manifest_content(App $a) {
+
+		$tpl = get_markup_template('manifest.tpl');
+
+		header('Content-type: application/manifest+json');
+
+		$touch_icon = Config::get('system', 'touch_icon', 'images/friendica-128.png');
+		if ($touch_icon == '') {
+			$touch_icon = 'images/friendica-128.png';
+		}
+
+		$o = replace_macros($tpl, array(
+			'$baseurl' => App::get_baseurl(),
+			'$touch_icon' => $touch_icon,
+			'$title' => Config::get('config', 'sitename', 'Friendica'),
+		));
+
+		echo $o;
+
+		killme();
+
+	}
+?>

--- a/view/templates/head.tpl
+++ b/view/templates/head.tpl
@@ -19,6 +19,7 @@
 <link rel="apple-touch-icon" href="{{$touch_icon}}"/>
 
 <meta name="apple-mobile-web-app-capable" content="yes" />
+<link rel="manifest" href="{{$baseurl}}/manifest" />
 <script>
 // Prevents links to switch to Safari in a home screen app - see https://gist.github.com/irae/1042167
 (function(a,b,c){if(c in b&&b[c]){var d,e=a.location,f=/^(a|html)$/i;a.addEventListener("click",function(a){d=a.target;while(!f.test(d.nodeName))d=d.parentNode;"href"in d&&(chref=d.href).replace(e.href,"").indexOf("#")&&(!/^[a-z\+\.\-]+:/i.test(chref)||chref.indexOf(e.protocol+"//"+e.host)===0)&&(a.preventDefault(),e.href=d.href)},!1)}})(document,window.navigator,"standalone");

--- a/view/templates/manifest.tpl
+++ b/view/templates/manifest.tpl
@@ -1,0 +1,9 @@
+{
+  "name": "{{$title}}",
+  "start_url": "{{$baseurl}}",
+  "display": "standalone",
+  "description": "A Decentralized Social Network",
+  "icons": [{
+    "src": "{{$baseurl}}/{{$touch_icon}}"
+  }]
+}

--- a/view/theme/frio/templates/head.tpl
+++ b/view/theme/frio/templates/head.tpl
@@ -41,6 +41,7 @@
 <link rel="apple-touch-icon" href="{{$touch_icon}}"/>
 
 <meta name="apple-mobile-web-app-capable" content="yes" />
+<link rel="manifest" href="{{$baseurl}}/manifest" />
 <script>
 // Prevents links to switch to Safari in a home screen app - see https://gist.github.com/irae/1042167
 (function(a,b,c){if(c in b&&b[c]){var d,e=a.location,f=/^(a|html)$/i;a.addEventListener("click",function(a){d=a.target;while(!f.test(d.nodeName))d=d.parentNode;"href"in d&&(chref=d.href).replace(e.href,"").indexOf("#")&&(!/^[a-z\+\.\-]+:/i.test(chref)||chref.indexOf(e.protocol+"//"+e.host)===0)&&(a.preventDefault(),e.href=d.href)},!1)}})(document,window.navigator,"standalone");


### PR DESCRIPTION
Implements #3317

This PR adds a web app manifest, which is the new standard way to add a webapp to the Android homescreen.
It brings some improvements over the `apple-mobile-web-app-capable` meta that was used before:
* The app always opens on the homepage (even if the shortcut was added from a different page).
* Every external link is opened in a new browser window.