### PR TITLE
theme-color meta

### DIFF
--- a/view/theme/frio/php/default.php
+++ b/view/theme/frio/php/default.php
@@ -29,21 +29,22 @@
 		}
 	?>
 	<?php
-		require_once("view/theme/frio/php/schema.php");
+		// Add the theme color meta
+		// It makes mobile Chrome UI match Frio's top bar color.
 		$uid = $a->profile_uid;
 		if (is_null($uid)) {
 			$uid = get_theme_uid();
 		}
 		$schema = get_pconfig($uid, 'frio', 'schema');
 		if (($schema) && ($schema != '---')) {
-			if(file_exists('view/theme/frio/schema/'.$schema.'.php')) {
+			if (file_exists('view/theme/frio/schema/'.$schema.'.php')) {
 				$schemefile = 'view/theme/frio/schema/'.$schema.'.php';
 				require_once($schemefile);
 			}
 		} else {
 			$nav_bg = get_pconfig($uid, 'frio', 'nav_bg');
 		}
-		if(!$nav_bg) {
+		if (!$nav_bg) {
 			$nav_bg = "#708fa0";
 		}
 		echo '<meta name="theme-color" content="'.$nav_bg.'" />';

--- a/view/theme/frio/php/default.php
+++ b/view/theme/frio/php/default.php
@@ -28,6 +28,27 @@
 			if(x($page,'htmlhead')) echo $page['htmlhead'];
 		}
 	?>
+	<?php
+		require_once("view/theme/frio/php/schema.php");
+		$uid = $a->profile_uid;
+		if (is_null($uid)) {
+			$uid = get_theme_uid();
+		}
+		$schema = get_pconfig($uid, 'frio', 'schema');
+		if (($schema) && ($schema != '---')) {
+			if(file_exists('view/theme/frio/schema/'.$schema.'.php')) {
+				$schemefile = 'view/theme/frio/schema/'.$schema.'.php';
+				require_once($schemefile);
+			}
+		} else {
+			$nav_bg = get_pconfig($uid, 'frio', 'nav_bg');
+		}
+		if(!$nav_bg) {
+			$nav_bg = "#708fa0";
+		}
+		echo '<meta name="theme-color" content="'.$nav_bg.'" />';
+	?>
+
 </head>
 <?php
 if(($_SERVER['REQUEST_URI'] != "/register") && ($_SERVER['REQUEST_URI'] != "/lostpass") && ($_SERVER['REQUEST_URI'] != "/login"))


### PR DESCRIPTION
This PR adds a `theme-color` meta to frio. This meta makes Chrome UI match Friendica's top bar color.

![screenshot_20170413-025558](https://cloud.githubusercontent.com/assets/840125/24985647/dda0f862-1ff5-11e7-8290-0f6fb6778fe8.png)

The color is also used in Android's app drawer when the web app is in standalone mode (see #3332).