### PR TITLE
API: The "friendica-owner" has only to be different from the user on starting posts

### DIFF
--- a/include/api.php
+++ b/include/api.php
@@ -726,7 +726,11 @@ use \Friendica\Core\Config;
 						($item["deny_gid"] != "") OR
 						$item["private"]);
 
-		$owner_user = api_get_user($a, $item["owner-link"]);
+		if ($item['thr-parent'] == $item['uri']) {
+			$owner_user = api_get_user($a, $item["owner-link"]);
+		} else {
+			$owner_user = $status_user;
+		}
 
 		return (array($status_user, $owner_user));
 	}


### PR DESCRIPTION
The API returns the fields "user" and "friendica_owner". The "user" is the author. These two fields are important for forum posts, but not for comments.