### PR TITLE
Resubmit all profiles on directory change

### DIFF
--- a/include/directory.php
+++ b/include/directory.php
@@ -2,13 +2,14 @@
 use \Friendica\Core\Config;
 
 function directory_run(&$argv, &$argc){
-	if ($argc != 2) {
-		return;
-	}
-
 	$dir = get_config('system', 'directory');
 
 	if (!strlen($dir)) {
+		return;
+	}
+
+	if ($argc < 2) {
+		directory_update_all();
 		return;
 	}
 
@@ -23,4 +24,18 @@ function directory_run(&$argv, &$argc){
 		fetch_url($dir . '?url=' . bin2hex($arr['url']));
 	}
 	return;
+}
+
+function directory_update_all() {
+	$r = q("SELECT `url` FROM `contact`
+		INNER JOIN `profile` ON `profile`.`uid` = `contact`.`uid`
+		INNER JOIN `user` ON `user`.`uid` = `contact`.`uid`
+			WHERE `contact`.`self` AND `profile`.`net-publish` AND `profile`.`is-default` AND
+				NOT `user`.`account_expired` AND `user`.`verified`");
+
+	if (dbm::is_result($r)) {
+		foreach ($r AS $user) {
+			proc_run(PRIORITY_LOW, 'include/directory.php', $user['url']);
+		}
+	}
 }

--- a/mod/admin.php
+++ b/mod/admin.php
@@ -668,6 +668,12 @@ function admin_page_site_post(App $a) {
 	$worker_fastlane	=	((x($_POST,'worker_fastlane'))		? True						: False);
 	$worker_frontend	=	((x($_POST,'worker_frontend'))		? True						: False);
 
+	// Has the directory url changed? If yes, then resubmit the existing profiles there
+	if ($global_directory != Config::get('system', 'directory') AND ($global_directory != '')) {
+		Config::set('system', 'directory', $global_directory);
+		proc_run(PRIORITY_LOW, 'include/directory.php');
+	}
+
 	if ($a->get_path() != "") {
 		$diaspora_enabled = false;
 	}
@@ -771,7 +777,6 @@ function admin_page_site_post(App $a) {
 	set_config('system', 'allowed_email', $allowed_email);
 	set_config('system', 'block_public', $block_public);
 	set_config('system', 'publish_all', $force_publish);
-	set_config('system', 'directory', $global_directory);
 	set_config('system', 'thread_allow', $thread_allow);
 	set_config('system', 'newuser_private', $newuser_private);
 	set_config('system', 'enotify_no_content', $enotify_no_content);


### PR DESCRIPTION
dir.friendi.ca and dir.friendica.com aren't available at the moment. So when people change the directory to dir.friendica.social then all to be published profiles will be submitted to that directory again.