### PR TITLE
Skip lang file search if lang=en

### DIFF
--- a/include/pgettext.php
+++ b/include/pgettext.php
@@ -44,7 +44,7 @@ function get_browser_language() {
 	// check if we have translations for the preferred languages and pick the 1st that has
 	for ($i=0; $i<count($lang_list); $i++) {
 		$lang = $lang_list[$i];
-		if(file_exists("view/lang/$lang") && is_dir("view/lang/$lang")) {
+		if($lang === 'en' || file_exists("view/lang/$lang") && is_dir("view/lang/$lang")) {
 			$preferred = $lang;
 			break;
 		}

--- a/include/pgettext.php
+++ b/include/pgettext.php
@@ -44,7 +44,7 @@ function get_browser_language() {
 	// check if we have translations for the preferred languages and pick the 1st that has
 	for ($i=0; $i<count($lang_list); $i++) {
 		$lang = $lang_list[$i];
-		if($lang === 'en' || (file_exists("view/lang/$lang") && is_dir("view/lang/$lang"))) {
+		if ($lang === 'en' || (file_exists("view/lang/$lang") && is_dir("view/lang/$lang"))) {
 			$preferred = $lang;
 			break;
 		}

--- a/include/pgettext.php
+++ b/include/pgettext.php
@@ -44,7 +44,7 @@ function get_browser_language() {
 	// check if we have translations for the preferred languages and pick the 1st that has
 	for ($i=0; $i<count($lang_list); $i++) {
 		$lang = $lang_list[$i];
-		if($lang === 'en' || file_exists("view/lang/$lang") && is_dir("view/lang/$lang")) {
+		if($lang === 'en' || (file_exists("view/lang/$lang") && is_dir("view/lang/$lang"))) {
 			$preferred = $lang;
 			break;
 		}


### PR DESCRIPTION
Finally fixes #2752.

We were skipping `en` language code from `Accept-Language` header because there's no `view/lang/en` folder since translation strings are english by default.

Now the english language will be accurately be recognized.