### PR TITLE
displays the correct profile for contacts that have set the default profile

### DIFF
--- a/include/contact_selectors.php
+++ b/include/contact_selectors.php
@@ -9,12 +9,12 @@ function contact_profile_assign($current,$foreign_net) {
 
 	$o .= "<select id=\"contact-profile-selector\" class=\"form-control\" $disabled name=\"profile-assign\" />\r\n";
 
-	$r = q("SELECT `id`, `profile-name` FROM `profile` WHERE `uid` = %d",
+	$r = q("SELECT `id`, `profile-name`, `is-default` FROM `profile` WHERE `uid` = %d",
 			intval($_SESSION['uid']));
 
 	if (dbm::is_result($r)) {
 		foreach ($r as $rr) {
-			$selected = (($rr['id'] == $current) ? " selected=\"selected\" " : "");
+			$selected = (($rr['id'] == $current || ($current == 0 && $rr['is-default'] == 1)) ? " selected=\"selected\" " : "");
 			$o .= "<option value=\"{$rr['id']}\" $selected >{$rr['profile-name']}</option>\r\n";
 		}
 	}


### PR DESCRIPTION
This commit selects the default profile in contacts display if no profile for a contact is set. https://friends.tausys.de/display/1b7273f81758f66b11e4315349665630