### PR TITLE
In standalone mode, open links to source in a new tab (fixes #3359)

### DIFF
--- a/view/theme/frio/js/theme.js
+++ b/view/theme/frio/js/theme.js
@@ -303,7 +303,7 @@ $(document).ready(function(){
 	// Customize some elements when the app is used in standalone mode on Android
 	if (window.matchMedia('(display-mode: standalone)').matches) {
 		// Open links to source outside of the webview
-		$('.plink').on('click', function (e) {
+		$('body').on('click', '.plink', function (e) {
 			$(e.target).attr('target', '_blank');
 		});
 	}

--- a/view/theme/frio/js/theme.js
+++ b/view/theme/frio/js/theme.js
@@ -300,6 +300,14 @@ $(document).ready(function(){
 		});
 	});
 
+	// Customize some elements when the app is used in standalone mode on Android
+	if (window.matchMedia('(display-mode: standalone)').matches) {
+		// Open links to source outside of the webview
+		$('.plink').on('click', function (e) {
+			$(e.target).attr('target', '_blank');
+		});
+	}
+
 	/*
 	 * This event listeners ensures that the textarea size is updated event if the
 	 * value is changed externally (textcomplete, insertFormatting, fbrowser...)


### PR DESCRIPTION
This PR opens Frio's links to source in a new tab when the app is used in standalone mode (i.e. added to the Android homescreen). This is needed because the standalone mode has no browser UI so the user would be trapped in the external website with no easy way to come back to its Friendica instance.

I used the `click` event so it can work on elements added dynamically by the infinite scrolling.