### PR TITLE
Remove vcard Edit link pointing to profiles for contacts

### DIFF
--- a/include/identity.php
+++ b/include/identity.php
@@ -283,8 +283,6 @@ function profile_sidebar($profile, $block = 0) {
 		$wallmessage_link = false;
 	}
 
-	var_dump($profile);
-
 	// show edit profile to yourself
 	if (!$is_contact && $profile['uid'] == local_user() && feature_enabled(local_user(),'multi_profiles')) {
 		$profile['edit'] = array(App::get_baseurl(). '/profiles', t('Profiles'),"", t('Manage/edit profiles'));

--- a/include/identity.php
+++ b/include/identity.php
@@ -202,6 +202,9 @@ function profile_sidebar($profile, $block = 0) {
 	$address = false;
 //		$pdesc = true;
 
+	// This function can also use contact information in $profile
+	$is_contact = x($profile, 'cid');
+
 	if((! is_array($profile)) && (! count($profile)))
 		return $o;
 
@@ -280,8 +283,10 @@ function profile_sidebar($profile, $block = 0) {
 		$wallmessage_link = false;
 	}
 
+	var_dump($profile);
+
 	// show edit profile to yourself
-	if ($profile['uid'] == local_user() && feature_enabled(local_user(),'multi_profiles')) {
+	if (!$is_contact && $profile['uid'] == local_user() && feature_enabled(local_user(),'multi_profiles')) {
 		$profile['edit'] = array(App::get_baseurl(). '/profiles', t('Profiles'),"", t('Manage/edit profiles'));
 		$r = q("SELECT * FROM `profile` WHERE `uid` = %d",
 				local_user());
@@ -310,7 +315,7 @@ function profile_sidebar($profile, $block = 0) {
 
 		}
 	}
-	if ($profile['uid'] == local_user() && !feature_enabled(local_user(),'multi_profiles')) {
+	if (!$is_contact && $profile['uid'] == local_user() && !feature_enabled(local_user(),'multi_profiles')) {
 		$profile['edit'] = array(App::get_baseurl(). '/profiles/'.$profile['id'], t('Edit profile'),"", t('Edit profile'));
 		$profile['menu'] = array(
 			'chg_photo' => t('Change profile photo'),


### PR DESCRIPTION
When visiting a contact page, an edit link would show on the avatar pointing to a non-existing `/profiles/xxxx` URL.

This came from the fact that we use either contact or profile info in the vcard aside.

There may be other places to use the new flag, however this is the only glaring issue I've encountered.