### PR TITLE
Make log-in cookie expiration time configurable

### DIFF
--- a/doc/htconfig.md
+++ b/doc/htconfig.md
@@ -25,7 +25,7 @@ Example: To set the directory value please add this line to your .htconfig.php:
 * **allowed_link_protocols** (Array) - Allowed protocols in links URLs, add at your own risk. http is always allowed.
 * **birthday_input_format** - Default value is "ymd".
 * **block_local_dir** (Boolean) - Blocks the access to the directory of the local users.
-* **auth_cookie_lifetime** (Integer) - Number of days that should pass without any activity from a before before the users who choosed "Remember me" when logging in from that browser is considered logged out.
+* **auth_cookie_lifetime** (Integer) - Number of days that should pass without any activity from a before before the users who choosed "Remember me" when logging in from that browser is considered logged out. Defaults to 7.
 * **curl_range_bytes** - Maximum number of bytes that should be fetched. Default is 0, which mean "no limit".
 * **db_log** - Name of a logfile to log slow database queries
 * **db_loglimit** - If a database call lasts longer than this value it is logged

--- a/doc/htconfig.md
+++ b/doc/htconfig.md
@@ -25,6 +25,7 @@ Example: To set the directory value please add this line to your .htconfig.php:
 * **allowed_link_protocols** (Array) - Allowed protocols in links URLs, add at your own risk. http is always allowed.
 * **birthday_input_format** - Default value is "ymd".
 * **block_local_dir** (Boolean) - Blocks the access to the directory of the local users.
+* **auth_cookie_lifetime** (Integer) - Number of days that should pass without any activity from a before before the users who choosed "Remember me" when logging in from that browser is considered logged out.
 * **curl_range_bytes** - Maximum number of bytes that should be fetched. Default is 0, which mean "no limit".
 * **db_log** - Name of a logfile to log slow database queries
 * **db_loglimit** - If a database call lasts longer than this value it is logged

--- a/htconfig.php
+++ b/htconfig.php
@@ -93,4 +93,4 @@ $a->config['system']['directory'] = 'https://dir.friendica.social';
 $a->config['system']['allowed_link_protocols'] = array('ftp', 'ftps', 'mailto', 'cid', 'gopher');
 
 // Authentication cookie lifetime, in days
-$a->config['system']['auth_cookie_lifetime'] = 7
+$a->config['system']['auth_cookie_lifetime'] = 7;

--- a/htconfig.php
+++ b/htconfig.php
@@ -91,3 +91,6 @@ $a->config['system']['directory'] = 'https://dir.friendica.social';
 
 // Allowed protocols in link URLs; HTTP protocols always are accepted
 $a->config['system']['allowed_link_protocols'] = array('ftp', 'ftps', 'mailto', 'cid', 'gopher');
+
+// Authentication cookie lifetime, in days
+$a->config['system']['auth_cookie_lifetime'] = 7

--- a/include/auth.php
+++ b/include/auth.php
@@ -1,4 +1,7 @@
 <?php
+
+use \Friendica\Core\Config;
+
 require_once('include/security.php');
 require_once('include/datetime.php');
 
@@ -21,7 +24,7 @@ if (isset($_COOKIE["Friendica"])) {
 			// Renew the cookie
 			// Expires after 7 days by default,
 			// can be set via system.auth_cookie_lifetime
-			$authcookiedays = get_config('system','auth_cookie_lifetime') || 7;
+			$authcookiedays = Config::get('system', 'auth_cookie_lifetime') || 7;
 			new_cookie($authcookiedays*24*60*60, $r[0]);
 
 			// Do the authentification if not done by now

--- a/include/auth.php
+++ b/include/auth.php
@@ -24,7 +24,7 @@ if (isset($_COOKIE["Friendica"])) {
 			// Renew the cookie
 			// Expires after 7 days by default,
 			// can be set via system.auth_cookie_lifetime
-			$authcookiedays = Config::get('system', 'auth_cookie_lifetime') || 7;
+			$authcookiedays = Config::get('system', 'auth_cookie_lifetime', 7);
 			new_cookie($authcookiedays*24*60*60, $r[0]);
 
 			// Do the authentification if not done by now

--- a/include/auth.php
+++ b/include/auth.php
@@ -19,8 +19,10 @@ if (isset($_COOKIE["Friendica"])) {
 			}
 
 			// Renew the cookie
-			// Expires after 90 days - TODO: use a configuration variable
-			new_cookie(90*24*60*60, $r[0]);
+			// Expires after 7 days by default,
+			// can be set via system.auth_cookie_lifetime
+			$authcookiedays = get_config('system','auth_cookie_lifetime') || 7;
+			new_cookie($authcookiedays*24*60*60, $r[0]);
 
 			// Do the authentification if not done by now
 			if (!isset($_SESSION) OR !isset($_SESSION['authenticated'])) {

--- a/include/auth.php
+++ b/include/auth.php
@@ -19,7 +19,8 @@ if (isset($_COOKIE["Friendica"])) {
 			}
 
 			// Renew the cookie
-			new_cookie(604800, $r[0]);
+			// Expires after 90 days - TODO: use a configuration variable
+			new_cookie(90*24*60*60, $r[0]);
 
 			// Do the authentification if not done by now
 			if (!isset($_SESSION) OR !isset($_SESSION['authenticated'])) {

--- a/view/templates/htconfig.tpl
+++ b/view/templates/htconfig.tpl
@@ -99,3 +99,6 @@ $a->config['system']['no_regfullname'] = true;
 
 // Location of the global directory
 $a->config['system']['directory'] = 'http://dir.friendi.ca';
+
+// Authentication cookie lifetime, in days
+$a->config['system']['auth_cookie_lifetime'] = 7;


### PR DESCRIPTION
It happens to me to not connect in 7 days... (90 days is the cookie
lifetime I saw used by facebook)