### PR TITLE
improve profile page (wall) update for non logged in users and remote users

### DIFF
--- a/index.php
+++ b/index.php
@@ -174,6 +174,10 @@ if (! x($_SESSION,'sysmsg_info')) {
 	$_SESSION['sysmsg_info'] = array();
 }
 
+// Array for informations about last received items
+if (! x($_SESSION,'last_updated')) {
+	$_SESSION['last_updated'] = array();
+}
 /*
  * check_config() is responsible for running update scripts. These automatically
  * update the DB schema whenever we push a new one out. It also checks to see if

--- a/mod/profile.php
+++ b/mod/profile.php
@@ -210,13 +210,15 @@ function profile_content(App $a, $update = 0) {
 
 
 	if ($update) {
+		$last_updated = (x($_SESSION['last_updated'], $last_updated_key) ? $_SESSION['last_updated'][$last_updated_key] : 0);
+
 		// If the page user is the owner of the page we should query for unseen
 		// items. Otherwise use a timestamp of the last succesful update request.
-		if ($is_owner) {
+		if ($is_owner || !$last_updated) {
 			$sql_extra4 = " AND `item`.`unseen`";
 		} else {
-			$last_updated = gmdate("Y-m-d H:i:s", $_SESSION['last_updated'][$last_updated_key]);
-			$sql_extra4 = " AND `item`.`received` > '" . $last_updated . "'";
+			$gmupdate = gmdate("Y-m-d H:i:s", $last_updated);
+			$sql_extra4 = " AND `item`.`received` > '" . $gmupdate . "'";
 		}
 
 		$r = q("SELECT distinct(parent) AS `item_id`, `item`.`network` AS `item_network`, `item`.`created`

--- a/mod/profile.php
+++ b/mod/profile.php
@@ -304,7 +304,7 @@ function profile_content(App $a, $update = 0) {
 	$parents_str = '';
 
 	// Set a time stamp for this page. We will make use of it when we
-	// search fornew items (update routine)
+	// search for new items (update routine)
 	$_SESSION['last_updated'][$last_updated_key] = time();
 
 	if (dbm::is_result($r)) {


### PR DESCRIPTION
The update process for new arrived items didn't work very well on a user profile page if it isn't the users own profile page (e.g. if the user is a remote user or if the user is just a visitor). This is because we did a query in the profile update process for the profile owners unseen items . But If I'm just a visitor this wouldn't make sense.

This PR does set a time stamp when a user does get the items (on page load or on new items). If the user isn't the page owner we now use this time stamp for the query. So visitors and remote users would get the correct new items
