### PR TITLE
New database functions

### DIFF
--- a/include/auth_ejabberd.php
+++ b/include/auth_ejabberd.php
@@ -32,8 +32,6 @@
  *
  */
 
-die();
-
 if (sizeof($_SERVER["argv"]) == 0)
 	die();
 

--- a/include/auth_ejabberd.php
+++ b/include/auth_ejabberd.php
@@ -32,6 +32,8 @@
  *
  */
 
+die();
+
 if (sizeof($_SERVER["argv"]) == 0)
 	die();
 

--- a/include/dba.php
+++ b/include/dba.php
@@ -10,6 +10,7 @@ require_once('include/datetime.php');
  * When logging, all binary info is converted to text and html entities are escaped so that
  * the debugging stream is safe to view within both terminals and web pages.
  *
+ * This class is for the low level database stuff that does driver specific things.
  */
 
 class dba {

--- a/include/dba.php
+++ b/include/dba.php
@@ -522,9 +522,6 @@ class dba {
 					self::$dbo->error = self::$dbo->db->error;
 					self::$dbo->errorno = self::$dbo->db->errno;
 					$retval = false;
-				} elseif (method_exists($stmt, 'get_result')) {
-					// Is mysqlnd installed?
-					$retval = $stmt->get_result();
 				} else {
 					$stmt->store_result();
 					$retval = $stmt;
@@ -657,11 +654,6 @@ class dba {
 			case 'pdo':
 				return $stmt->fetch(PDO::FETCH_ASSOC);
 			case 'mysqli':
-				// When mysqlnd is installed, we can use a shortcut
-				if (method_exists($stmt, 'fetch_array')) {
-					return $stmt->fetch_array(MYSQLI_ASSOC);
-				}
-
 				// This code works, but is slow
 
 				// Bind the result to a result array

--- a/include/dba.php
+++ b/include/dba.php
@@ -15,11 +15,9 @@ require_once('include/datetime.php');
 class dba {
 
 	private $debug = 0;
-	//private $db;
-	public $db;
+	private $db;
 	private $result;
-	//private $driver;
-	public $driver;
+	private $driver;
 	public  $connected = false;
 	public  $error = false;
 	private $_server_info = '';

--- a/include/dba.php
+++ b/include/dba.php
@@ -743,6 +743,8 @@ function dbesc($str) {
 //                   'user', 1);
 function q($sql) {
 	global $db;
+	$args = func_get_args();
+	unset($args[0]);
 
 	if ($db && $db->connected) {
 		$sql = $db->any_value_fallback($sql);

--- a/include/dba.php
+++ b/include/dba.php
@@ -443,8 +443,8 @@ class dba {
 	}
 
 	/**
-	 * @brief Executes a prepared statement
-	 *
+	 * @brief Executes a prepared statement that returns data
+	 * @usage Example: $r = p("SELECT * FROM `item` WHERE `guid` = ?", $guid);
 	 * @param string $sql SQL statement
 	 * @return object statement object
 	 */
@@ -529,6 +529,7 @@ class dba {
 				break;
 			case 'mysql':
 				// For the old "mysql" functions we cannot use prepared statements
+				$offset = 0;
 				foreach ($args AS $param => $value) {
 					if (is_int($args[$param]) OR is_float($args[$param])) {
 						$replace = intval($args[$param]);
@@ -536,10 +537,11 @@ class dba {
 						$replace = "'".dbesc($args[$param])."'";
 					}
 
-					$pos = strpos($sql, '?');
+					$pos = strpos($sql, '?', $offset);
 					if ($pos !== false) {
 						$sql = substr_replace($sql, $replace, $pos, 1);
 					}
+					$offset = $pos + strlen($replace);
 				}
 
 				$retval = mysql_query($sql, self::$dbo->db);
@@ -570,10 +572,10 @@ class dba {
 	}
 
 	/**
-	 * @brief Executes a prepared statement
+	 * @brief Executes a prepared statement like UPDATE or INSERT that doesn't return data
 	 *
 	 * @param string $sql SQL statement
-	 * @return boolean Was the query successfull?
+	 * @return boolean Was the query successfull? False is returned only if an error occurred
 	 */
 	static public function e($sql) {
 		$a = get_app();

--- a/include/dba.php
+++ b/include/dba.php
@@ -135,30 +135,6 @@ class dba {
 	}
 
 	/**
-	 * @brief Returns the number of rows
-	 *
-	 * @return integer
-	 */
-	public function num_rows() {
-		if (!$this->result) {
-			return 0;
-		}
-
-		switch ($this->driver) {
-			case 'pdo':
-				$rows = $this->result->rowCount();
-				break;
-			case 'mysqli':
-				$rows = $this->result->num_rows;
-				break;
-			case 'mysql':
-				$rows = mysql_num_rows($this->result);
-				break;
-		}
-		return $rows;
-	}
-
-	/**
 	 * @brief Analyze a database query and log this if some conditions are met.
 	 *
 	 * @param string $query The database query that will be analyzed
@@ -380,41 +356,6 @@ class dba {
 			logger('dba: ' . printable(print_r($r, true)));
 		}
 		return($r);
-	}
-
-	public function qfetch() {
-		$x = false;
-
-		if ($this->result) {
-			switch ($this->driver) {
-				case 'pdo':
-					$x = $this->result->fetch(PDO::FETCH_ASSOC);
-					break;
-				case 'mysqli':
-					$x = $this->result->fetch_array(MYSQLI_ASSOC);
-					break;
-				case 'mysql':
-					$x = mysql_fetch_array($this->result, MYSQL_ASSOC);
-					break;
-			}
-		}
-		return($x);
-	}
-
-	public function qclose() {
-		if ($this->result) {
-			switch ($this->driver) {
-				case 'pdo':
-					$this->result->closeCursor();
-					break;
-				case 'mysqli':
-					$this->result->free_result();
-					break;
-				case 'mysql':
-					mysql_free_result($this->result);
-					break;
-			}
-		}
 	}
 
 	public function dbg($dbg) {
@@ -691,7 +632,7 @@ class dba {
 	 * @param object Statement object
 	 * @return int Number of rows
 	 */
-	static public function rows($stmt) {
+	static public function num_rows($stmt) {
 		switch (self::$dbo->driver) {
 			case 'pdo':
 				return $stmt->rowCount();

--- a/include/dba.php
+++ b/include/dba.php
@@ -462,8 +462,6 @@ class dba {
 
 		$sql = self::$dbo->any_value_fallback($sql);
 
-		$orig_sql = $sql;
-
 		if (x($a->config,'system') && x($a->config['system'], 'db_callstack')) {
 			$sql = "/*".$a->callstack()." */ ".$sql;
 		}
@@ -676,9 +674,7 @@ class dba {
 
 				call_user_func_array(array($stmt, 'bind_result'), $cols);
 
-				$success = $stmt->fetch();
-
-				if (!$success) {
+				if (!$stmt->fetch()) {
 					return false;
 				}
 

--- a/include/dba.php
+++ b/include/dba.php
@@ -467,6 +467,22 @@ class dba {
 		return $id;
 	}
 
+	function __destruct() {
+		if ($this->db) {
+			switch ($this->driver) {
+				case 'pdo':
+					$this->db = null;
+					break;
+				case 'mysqli':
+					$this->db->close();
+					break;
+				case 'mysql':
+					mysql_close($this->db);
+					break;
+			}
+		}
+	}
+
 	/**
 	 * @brief Replaces ANY_VALUE() function by MIN() function,
 	 *  if the database server does not support ANY_VALUE().
@@ -485,22 +501,6 @@ class dba {
 			$sql = str_ireplace('ANY_VALUE(', 'MIN(', $sql);
 		}
 		return $sql;
-	}
-
-	function __destruct() {
-		if ($this->db) {
-			switch ($this->driver) {
-				case 'pdo':
-					$this->db = null;
-					break;
-				case 'mysqli':
-					$this->db->close();
-					break;
-				case 'mysql':
-					mysql_close($this->db);
-					break;
-			}
-		}
 	}
 
 	/**

--- a/include/dba.php
+++ b/include/dba.php
@@ -635,6 +635,10 @@ class dba {
 	 * @return boolean Was the query successfull?
 	 */
 	static public function e($sql) {
+		$args = func_get_args();
+
+		$stmt = self::p();
+		self::close($stmt);
 	}
 
 	/**
@@ -739,8 +743,6 @@ function dbesc($str) {
 //                   'user', 1);
 function q($sql) {
 	global $db;
-	$args = func_get_args();
-	unset($args[0]);
 
 	if ($db && $db->connected) {
 		$sql = $db->any_value_fallback($sql);

--- a/include/dba.php
+++ b/include/dba.php
@@ -625,7 +625,7 @@ class dba {
 	}
 
 	/**
-	 * @brief Returnr the number of rows of a statement
+	 * @brief Returns the number of rows of a statement
 	 *
 	 * @param object Statement object
 	 * @return int Number of rows

--- a/include/dba.php
+++ b/include/dba.php
@@ -709,6 +709,7 @@ class dba {
 			case 'pdo':
 				return $stmt->closeCursor();
 			case 'mysqli':
+				return $stmt->free_result();
 				return $stmt->close();
 			case 'mysql':
 				return mysql_free_result($stmt);

--- a/include/dba.php
+++ b/include/dba.php
@@ -555,20 +555,20 @@ class dba {
 
 		$a->save_timestamp($stamp1, 'database');
 
-                if (x($a->config,'system') && x($a->config['system'], 'db_log')) {
+		if (x($a->config,'system') && x($a->config['system'], 'db_log')) {
 
 			$stamp2 = microtime(true);
 			$duration = (float)($stamp2 - $stamp1);
 
-                        if (($duration > $a->config["system"]["db_loglimit"])) {
-                                $duration = round($duration, 3);
-                                $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
-                                @file_put_contents($a->config["system"]["db_log"], datetime_convert()."\t".$duration."\t".
-                                                basename($backtrace[1]["file"])."\t".
-                                                $backtrace[1]["line"]."\t".$backtrace[2]["function"]."\t".
-                                                substr($sql, 0, 2000)."\n", FILE_APPEND);
-                        }
-                }
+			if (($duration > $a->config["system"]["db_loglimit"])) {
+				$duration = round($duration, 3);
+				$backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
+				@file_put_contents($a->config["system"]["db_log"], datetime_convert()."\t".$duration."\t".
+						basename($backtrace[1]["file"])."\t".
+						$backtrace[1]["line"]."\t".$backtrace[2]["function"]."\t".
+						substr($sql, 0, 2000)."\n", FILE_APPEND);
+			}
+		}
 		return $retval;
 	}
 

--- a/include/dbclean.php
+++ b/include/dbclean.php
@@ -43,96 +43,103 @@ function remove_orphans($stage = 0) {
 
 	if (($stage == 1) OR ($stage == 0)) {
 		logger("Deleting old global item entries from item table without user copy");
-		if ($db->q("SELECT `id` FROM `item` WHERE `uid` = 0
+		$r = dba::p("SELECT `id` FROM `item` WHERE `uid` = 0
 				AND NOT EXISTS (SELECT `guid` FROM `item` AS `i` WHERE `item`.`guid` = `i`.`guid` AND `i`.`uid` != 0)
-				AND `received` < UTC_TIMESTAMP() - INTERVAL 90 DAY LIMIT ".intval($limit), true)) {
-			$count = $db->num_rows();
+				AND `received` < UTC_TIMESTAMP() - INTERVAL 90 DAY LIMIT ".intval($limit));
+		$count = dba::num_rows($r);
+		if ($count > 0) {
 			logger("found global item orphans: ".$count);
-			while ($orphan = $db->qfetch()) {
+			while ($orphan = dba::fetch($r)) {
 				q("DELETE FROM `item` WHERE `id` = %d", intval($orphan["id"]));
 			}
 		}
-		$db->qclose();
+		dba::close($r);
 		logger("Done deleting old global item entries from item table without user copy");
 	}
 
 	if (($stage == 2) OR ($stage == 0)) {
 		logger("Deleting items without parents");
-		if ($db->q("SELECT `id` FROM `item` WHERE NOT EXISTS (SELECT `id` FROM `item` AS `i` WHERE `item`.`parent` = `i`.`id`) LIMIT ".intval($limit), true)) {
-			$count = $db->num_rows();
+		$r = dba::p("SELECT `id` FROM `item` WHERE NOT EXISTS (SELECT `id` FROM `item` AS `i` WHERE `item`.`parent` = `i`.`id`) LIMIT ".intval($limit));
+		$count = dba::num_rows($r);
+		if ($count > 0) {
 			logger("found item orphans without parents: ".$count);
-			while ($orphan = $db->qfetch()) {
+			while ($orphan = dba::fetch($r)) {
 				q("DELETE FROM `item` WHERE `id` = %d", intval($orphan["id"]));
 			}
 		}
-		$db->qclose();
+		dba::close($r);
 		logger("Done deleting items without parents");
 	}
 
 	if (($stage == 3) OR ($stage == 0)) {
 		logger("Deleting orphaned data from thread table");
-		if ($db->q("SELECT `iid` FROM `thread` WHERE NOT EXISTS (SELECT `id` FROM `item` WHERE `item`.`parent` = `thread`.`iid`) LIMIT ".intval($limit), true)) {
-			$count = $db->num_rows();
+		$r = dba::p("SELECT `iid` FROM `thread` WHERE NOT EXISTS (SELECT `id` FROM `item` WHERE `item`.`parent` = `thread`.`iid`) LIMIT ".intval($limit));
+		$count = dba::num_rows($r);
+		if ($count > 0) {
 			logger("found thread orphans: ".$count);
-			while ($orphan = $db->qfetch()) {
+			while ($orphan = dba::fetch($r)) {
 				q("DELETE FROM `thread` WHERE `iid` = %d", intval($orphan["iid"]));
 			}
 		}
-		$db->qclose();
+		dba::close($r);
 		logger("Done deleting orphaned data from thread table");
 	}
 
 	if (($stage == 4) OR ($stage == 0)) {
 		logger("Deleting orphaned data from notify table");
-		if ($db->q("SELECT `iid` FROM `notify` WHERE NOT EXISTS (SELECT `id` FROM `item` WHERE `item`.`id` = `notify`.`iid`) LIMIT ".intval($limit), true)) {
-			$count = $db->num_rows();
+		$r = dba::p("SELECT `iid` FROM `notify` WHERE NOT EXISTS (SELECT `id` FROM `item` WHERE `item`.`id` = `notify`.`iid`) LIMIT ".intval($limit));
+		$count = dba::num_rows($r);
+		if ($count > 0) {
 			logger("found notify orphans: ".$count);
-			while ($orphan = $db->qfetch()) {
+			while ($orphan = dba::fetch($r)) {
 				q("DELETE FROM `notify` WHERE `iid` = %d", intval($orphan["iid"]));
 			}
 		}
-		$db->qclose();
+		dba::close($r);
 		logger("Done deleting orphaned data from notify table");
 	}
 
 	if (($stage == 5) OR ($stage == 0)) {
 		logger("Deleting orphaned data from notify-threads table");
-		if ($db->q("SELECT `id` FROM `notify-threads` WHERE NOT EXISTS (SELECT `id` FROM `item` WHERE `item`.`parent` = `notify-threads`.`master-parent-item`) LIMIT ".intval($limit), true)) {
-			$count = $db->num_rows();
+		$r = dba::p("SELECT `id` FROM `notify-threads` WHERE NOT EXISTS (SELECT `id` FROM `item` WHERE `item`.`parent` = `notify-threads`.`master-parent-item`) LIMIT ".intval($limit));
+		$count = dba::num_rows($r);
+		if ($count > 0) {
 			logger("found notify-threads orphans: ".$count);
-			while ($orphan = $db->qfetch()) {
+			while ($orphan = dba::fetch($r)) {
 				q("DELETE FROM `notify-threads` WHERE `id` = %d", intval($orphan["id"]));
 			}
 		}
-		$db->qclose();
+		dba::close($r);
 		logger("Done deleting orphaned data from notify-threads table");
 	}
 
 
 	if (($stage == 6) OR ($stage == 0)) {
 		logger("Deleting orphaned data from sign table");
-		if ($db->q("SELECT `iid` FROM `sign` WHERE NOT EXISTS (SELECT `id` FROM `item` WHERE `item`.`id` = `sign`.`iid`) LIMIT ".intval($limit), true)) {
-			$count = $db->num_rows();
+		$r = dba::p("SELECT `iid` FROM `sign` WHERE NOT EXISTS (SELECT `id` FROM `item` WHERE `item`.`id` = `sign`.`iid`) LIMIT ".intval($limit));
+		$count = dba::num_rows($r);
+		if ($count > 0) {
 			logger("found sign orphans: ".$count);
-			while ($orphan = $db->qfetch()) {
+			while ($orphan = dba::fetch($r)) {
 				q("DELETE FROM `sign` WHERE `iid` = %d", intval($orphan["iid"]));
 			}
 		}
-		$db->qclose();
+		dba::close($r);
 		logger("Done deleting orphaned data from sign table");
 	}
 
 
 	if (($stage == 7) OR ($stage == 0)) {
 		logger("Deleting orphaned data from term table");
-		if ($db->q("SELECT `oid` FROM `term` WHERE NOT EXISTS (SELECT `id` FROM `item` WHERE `item`.`id` = `term`.`oid`) LIMIT ".intval($limit), true)) {
-			$count = $db->num_rows();
+		$r = dba::p("SELECT `oid` FROM `term` WHERE NOT EXISTS (SELECT `id` FROM `item` WHERE `item`.`id` = `term`.`oid`) LIMIT ".intval($limit));
+		$count = dba::num_rows($r);
+		if ($count > 0) {
 			logger("found term orphans: ".$count);
-			while ($orphan = $db->qfetch()) {
+			while ($orphan = dba::fetch($r)) {
 				q("DELETE FROM `term` WHERE `oid` = %d", intval($orphan["oid"]));
 			}
 		}
-		$db->qclose();
+		dba::close($r);
 		logger("Done deleting orphaned data from term table");
 	}
 

--- a/include/dbm.php
+++ b/include/dbm.php
@@ -47,6 +47,11 @@ class dbm {
 		if (is_bool($array)) {
 			return $array;
 		}
+
+		if (is_object($array)) {
+			return true;
+		}
+
 		return (is_array($array) && count($array) > 0);
 	}
 

--- a/include/dbm.php
+++ b/include/dbm.php
@@ -2,6 +2,7 @@
 /**
  * @brief This class contain functions for the database management
  *
+ * This class contains functions that doesn't need to know if pdo, mysqli or whatever is used.
  */
 class dbm {
 	/**

--- a/include/tags.php
+++ b/include/tags.php
@@ -111,12 +111,11 @@ function create_tags_from_itemuri($itemuri, $uid) {
 }
 
 function update_items() {
-	global $db;
 
-        $messages = $db->q("SELECT `oid`,`item`.`guid`, `item`.`created`, `item`.`received` FROM `term` INNER JOIN `item` ON `item`.`id`=`term`.`oid` WHERE `term`.`otype` = 1 AND `term`.`guid` = ''", true);
+	$messages = dba::p("SELECT `oid`,`item`.`guid`, `item`.`created`, `item`.`received` FROM `term` INNER JOIN `item` ON `item`.`id`=`term`.`oid` WHERE `term`.`otype` = 1 AND `term`.`guid` = ''");
 
-        logger("fetched messages: ".count($messages));
-        while ($message = $db->qfetch()) {
+	logger("fetched messages: ".dba::num_rows($messages));
+	while ($message = dba::fetch($messages)) {
 
 		if ($message["uid"] == 0) {
 			$global = true;
@@ -135,15 +134,15 @@ function update_items() {
 			intval($global), intval(TERM_OBJ_POST), intval($message["oid"]));
 	}
 
-        $db->qclose();
+	dba::close($messages);
 
-	$messages = $db->q("SELECT `guid` FROM `item` WHERE `uid` = 0", true);
+	$messages = dba::p("SELECT `guid` FROM `item` WHERE `uid` = 0");
 
-	logger("fetched messages: ".count($messages));
-	while ($message = $db->qfetch()) {
+	logger("fetched messages: ".dba::num_rows($messages));
+	while ($message = dba::fetch(messages)) {
 		q("UPDATE `item` SET `global` = 1 WHERE `guid` = '%s'", dbesc($message["guid"]));
 	}
 
-	$db->qclose();
+	dba::close($messages);
 }
 ?>

--- a/include/threads.php
+++ b/include/threads.php
@@ -251,19 +251,17 @@ function delete_thread($itemid, $itemuri = "") {
 }
 
 function update_threads() {
-	global $db;
-
 	logger("update_threads: start");
 
-	$messages = $db->q("SELECT `id` FROM `item` WHERE `id` = `parent`", true);
+	$messages = dba::p("SELECT `id` FROM `item` WHERE `id` = `parent`");
 
-	logger("update_threads: fetched messages: ".count($messages));
+	logger("update_threads: fetched messages: ".dba::num_rows($messages));
 
-	while ($message = $db->qfetch()) {
+	while ($message = dba::fetch($messages)) {
 		add_thread($message["id"]);
 		add_shadow_thread($message["id"]);
 	}
-	$db->qclose();
+	dba::close($messages);
 }
 
 function update_threads_mention() {
@@ -283,18 +281,16 @@ function update_threads_mention() {
 
 
 function update_shadow_copy() {
-	global $db;
-
 	logger("start");
 
-	$messages = $db->q(sprintf("SELECT `iid` FROM `thread` WHERE `uid` != 0 AND `network` IN ('', '%s', '%s', '%s')
-					AND `visible` AND NOT `deleted` AND NOT `moderated` AND NOT `private` ORDER BY `created`",
-				NETWORK_DFRN, NETWORK_DIASPORA, NETWORK_OSTATUS), true);
+	$messages = dba::p("SELECT `iid` FROM `thread` WHERE `uid` != 0 AND `network` IN ('', ?, ?, ?)
+				AND `visible` AND NOT `deleted` AND NOT `moderated` AND NOT `private` ORDER BY `created`",
+				NETWORK_DFRN, NETWORK_DIASPORA, NETWORK_OSTATUS);
 
-	logger("fetched messages: ".count($messages));
-	while ($message = $db->qfetch())
+	logger("fetched messages: ".dba::num_rows($messages));
+	while ($message = dba::fetch($messages))
 		add_shadow_thread($message["iid"]);
 
-	$db->qclose();
+	dba::close($messages);
 }
 ?>


### PR DESCRIPTION
There are now some more database functions that are based upon prepared statements, examples:
```
$r = dba::p("SELECT id, uid FROM `item` WHERE `uid` = ? AND `network` = ? LIMIT 1000", $uid, $network);
while ($row = dba::fetch($r)) {
        print_r($row);
}
dba::close($r);
```
There is no need for functions like ```intval```, ```dbesc``` or ```dbm::is_result``` anymore.

Additionally we don't store the data anymore in a huge array (like ```q``` is doing), which reduces the memory food print.

For simply executing stuff, we are having this function:
```
if (!dba::e(UPDATE `item` SET `body` = ? WHERE `id` = ?, $body, $id)) {
        die('Update failed!');
}
```
The function returns ```true``` or ```false```.

And since we sometimes only have to check for the existence of data, we are now having a special function for that as well:
```
if (!dba::exists("SELECT id, uid FROM `item` WHERE `uid` = ? AND `network` = ? LIMIT 1", $uid, $network)) {
        die('No data found for user.');
}
```

Prepared statements aren't supported by the old ```mysql``` functions, so we emulate it. Problem: On my system I wasn't able to test it - but it looked good.

Another problem: ```mysqli``` is slower than ```pdo``` or the existing functions. I think that we should urge the users to use ```pdo```.