### PR TITLE
Hide the discard option from Diaspora contact requests

### DIFF
--- a/view/templates/intros.tpl
+++ b/view/templates/intros.tpl
@@ -14,7 +14,9 @@
 <div class="intro-wrapper-end" id="intro-wrapper-end-{{$contact_id}}"></div>
 <form class="intro-form" action="notifications/{{$intro_id}}" method="post">
 <input class="intro-submit-ignore" type="submit" name="submit" value="{{$ignore|escape:'html'}}" />
-<input class="intro-submit-discard" type="submit" name="submit" value="{{$discard|escape:'html'}}" />
+{{if $network != diaspora}}
+	<input class="intro-submit-discard" type="submit" name="submit" value="{{$discard|escape:'html'}}" />
+{{/if}}
 </form>
 <div class="intro-form-end"></div>
 


### PR DESCRIPTION
When one discards a contact request the request is repeated automatically, the only cause it to ignore the request. So for requests from Diaspora the "Discard" button is not shown with this PR.