### PR TITLE
Conversation data is stored for own posts as well/improved function dba:update

### DIFF
--- a/doc/database.md
+++ b/doc/database.md
@@ -14,6 +14,7 @@ Database Tables
 | [config](help/database/db_config)                    | main configuration storage                       |
 | [contact](help/database/db_contact)                  | contact table                                    |
 | [conv](help/database/db_conv)                        | private messages                                 |
+| [conversation](help/database/db_conversation)        | Raw data and structure information for messages  |
 | [event](help/database/db_event)                      | Events                                           |
 | [fcontact](help/database/db_fcontact)                | friend suggestion stuff                          |
 | [ffinder](help/database/db_ffinder)                  | friend suggestion stuff                          |

--- a/doc/database/db_conversation.md
+++ b/doc/database/db_conversation.md
@@ -1,14 +1,14 @@
 Table conversation
 ==================
 
-| Field             | Description   | Type                | Null | Key | Default             | Extra          |
-|-------------------| ------------- |---------------------|------|-----|---------------------|----------------|
-| item-uri          |               | varbinary(255)      | NO   | PRI | NULL                |                |
-| reply-to-uri      |               | varbinary(255)      | NO   |     |                     |                |
-| conversation-uri  |               | varbinary(255)      | NO   |     |                     |                |
-| conversation-href |               | varbinary(255)      | NO   |     |                     |                |
-| protocol          |               | tinyint(1) unsigned | NO   |     | 0                   |                |
-| source            |               | mediumtext          | NO   |     |                     |                |
-| received          |               | datetime            | NO   |     | 0001-01-01          |                |
+| Field             | Description                        | Type                | Null | Key | Default             | Extra          |
+|-------------------| ---------------------------------- |---------------------|------|-----|---------------------|----------------|
+| item-uri          | URI of the item                    | varbinary(255)      | NO   | PRI | NULL                |                |
+| reply-to-uri      | URI to which this item is a reply  | varbinary(255)      | NO   |     |                     |                |
+| conversation-uri  | GNU Social conversation URI        | varbinary(255)      | NO   |     |                     |                |
+| conversation-href | GNU Social conversation link       | varbinary(255)      | NO   |     |                     |                |
+| protocol          | The protocol of the item           | tinyint(1) unsigned | NO   |     | 0                   |                |
+| source            | Original source                    | mediumtext          | NO   |     |                     |                |
+| received          | Receiving date                     | datetime            | NO   |     | 0001-01-01          |                |
 
 Return to [database documentation](help/database)

--- a/doc/database/db_conversation.md
+++ b/doc/database/db_conversation.md
@@ -1,0 +1,14 @@
+Table conversation
+==================
+
+| Field             | Description   | Type                | Null | Key | Default             | Extra          |
+|-------------------| ------------- |---------------------|------|-----|---------------------|----------------|
+| item-uri          |               | varbinary(255)      | NO   | PRI | NULL                |                |
+| reply-to-uri      |               | varbinary(255)      | NO   |     |                     |                |
+| conversation-uri  |               | varbinary(255)      | NO   |     |                     |                |
+| conversation-href |               | varbinary(255)      | NO   |     |                     |                |
+| protocol          |               | tinyint(1) unsigned | NO   |     | 0                   |                |
+| source            |               | mediumtext          | NO   |     |                     |                |
+| received          |               | datetime            | NO   |     | 0001-01-01          |                |
+
+Return to [database documentation](help/database)

--- a/include/items.php
+++ b/include/items.php
@@ -446,6 +446,12 @@ function store_conversation($arr) {
 		$old_conv = dba::fetch_first("SELECT `item-uri`, `reply-to-uri`, `conversation-uri`, `conversation-href`, `protocol`, `source`
 				FROM `conversation` WHERE `item-uri` = ?", $conversation['item-uri']);
 		if (dbm::is_result($old_conv)) {
+			// Don't update when only the source has changed.
+			// Only do this when there had been no source before.
+			if ($old_conv['source'] != '') {
+				unset($old_conv['source']);
+			}
+			// Update structure data all the time but the source only when its from a better protocol.
 			if (($old_conv['protocol'] < $conversation['protocol']) AND ($old_conv['protocol'] != 0)) {
 				unset($conversation['protocol']);
 				unset($conversation['source']);

--- a/include/items.php
+++ b/include/items.php
@@ -443,18 +443,16 @@ function store_conversation($arr) {
 			$conversation['source'] = $arr['source'];
 		}
 
-		$conv = dba::fetch_first("SELECT `protocol` FROM `conversation` WHERE `item-uri` = ?", $conversation['item-uri']);
-		if (dbm::is_result($conv)) {
-			if (($conv['protocol'] < $conversation['protocol']) AND ($conv['protocol'] != 0)) {
+		$old_conv = dba::fetch_first("SELECT `item-uri`, `reply-to-uri`, `conversation-uri`, `conversation-href`, `protocol`, `source`
+				FROM `conversation` WHERE `item-uri` = ?", $conversation['item-uri']);
+		if (dbm::is_result($old_conv)) {
+			if (($old_conv['protocol'] < $conversation['protocol']) AND ($old_conv['protocol'] != 0)) {
 				unset($conversation['protocol']);
 				unset($conversation['source']);
 			}
-			// Replace the conversation entry when the new one is better
-			//if ((($conv['protocol'] == 0) OR ($conv['protocol'] >= $conversation['protocol'])) AND ($conversation['protocol'] > 0)) {
-				if (!dba::update('conversation', $conversation, array('item-uri' => $conversation['item-uri']))) {
-					logger('Conversation: update for '.$conversation['item-uri'].' from '.$conv['protocol'].' to '.$conversation['protocol'].' failed', LOGGER_DEBUG);
-				}
-			//}
+			if (!dba::update('conversation', $conversation, array('item-uri' => $conversation['item-uri']), $old_conv)) {
+				logger('Conversation: update for '.$conversation['item-uri'].' from '.$conv['protocol'].' to '.$conversation['protocol'].' failed', LOGGER_DEBUG);
+			}
 		} else {
 			if (!dba::insert('conversation', $conversation)) {
 				logger('Conversation: insert for '.$conversation['item-uri'].' (protocol '.$conversation['protocol'].') failed', LOGGER_DEBUG);

--- a/include/items.php
+++ b/include/items.php
@@ -410,6 +410,12 @@ function uri_to_guid($uri, $host = "") {
 	return $guid_prefix.$host_hash;
 }
 
+/**
+ * @brief Store the conversation data
+ *
+ * @param array $arr Item array with conversation data
+ * @return array Item array with removed conversation data
+ */
 function store_conversation($arr) {
 	if (in_array($arr['network'], array(NETWORK_DFRN, NETWORK_DIASPORA, NETWORK_OSTATUS))) {
 		$conversation = array('item-uri' => $arr['uri'], 'received' => dbm::date());
@@ -476,6 +482,7 @@ function item_store($arr, $force_parent = false, $notify = false, $dontcache = f
 		$arr['origin'] = 1;
 		$arr['last-child'] = 1;
 		$arr['network'] = NETWORK_DFRN;
+		$arr['protocol'] = PROTOCOL_DFRN;
 
 		// We have to avoid duplicates. So we create the GUID in form of a hash of the plink or uri.
 		// In difference to the call to "uri_to_guid" several lines below we add the hash of our own host.

--- a/include/ostatus.php
+++ b/include/ostatus.php
@@ -916,6 +916,8 @@ class ostatus {
 			($item["verb"] == ACTIVITY_LIKE) OR ($conversation_url == "")) {
 			$item_stored = item_store($item, $all_threads);
 			return $item_stored;
+		} elseif (count($item) > 0) {
+			$item = store_conversation($item);
 		}
 
 		// Get the parent

--- a/mod/item.php
+++ b/mod/item.php
@@ -723,6 +723,18 @@ function item_post(App $a) {
 	$datarray['last-child'] = 1;
 	$datarray['visible'] = 1;
 
+	$datarray['protocol'] = PROTOCOL_DFRN;
+
+	$r = dba::fetch_first("SELECT `conversation-uri`, `conversation-href` FROM `conversation` WHERE `item-uri` = ?", $datarray['parent-uri']);
+	if (dbm::is_result($r)) {
+		if ($r['conversation-uri'] != '') {
+			$datarray['conversation-uri'] = $r['conversation-uri'];
+		}
+		if ($r['conversation-href'] != '') {
+			$datarray['conversation-href'] = $r['conversation-href'];
+		}
+	}
+
 	if ($orig_post) {
 		$datarray['edit'] = true;
 	}
@@ -761,6 +773,8 @@ function item_post(App $a) {
 
 	// Fill the cache field
 	put_item_in_cache($datarray);
+
+	$datarray = store_conversation($datarray);
 
 	if ($orig_post) {
 		$r = q("UPDATE `item` SET `title` = '%s', `body` = '%s', `tag` = '%s', `attach` = '%s', `file` = '%s', `rendered-html` = '%s', `rendered-hash` = '%s', `edited` = '%s', `changed` = '%s' WHERE `id` = %d AND `uid` = %d",


### PR DESCRIPTION
The functionality to store conversations has now moved into a separate function. This function is now called at several places.

Additionally the function dba::update had been changed so that it only updates the changed fields. The function can now do this check on its own. This is one more step towards more abstract database functions.