### PR TITLE
Unread notifications are now always on top

### DIFF
--- a/mod/ping.php
+++ b/mod/ping.php
@@ -305,10 +305,6 @@ function ping_init(App $a)
 
 		// sort notifications by $[]['date']
 		$sort_function = function($a, $b) {
-			//if (!$a['seen'] AND $b['seen']) {
-			//	return -1;
-			//}
-
 			$adate = strtotime($a['date']);
 			$bdate = strtotime($b['date']);
 

--- a/mod/ping.php
+++ b/mod/ping.php
@@ -305,8 +305,22 @@ function ping_init(App $a)
 
 		// sort notifications by $[]['date']
 		$sort_function = function($a, $b) {
-			$adate = date($a['date']);
-			$bdate = date($b['date']);
+			//if (!$a['seen'] AND $b['seen']) {
+			//	return -1;
+			//}
+
+			$adate = strtotime($a['date']);
+			$bdate = strtotime($b['date']);
+
+			// Unseen messages are kept at the top
+			// The value 31536000 means one year. This should be enough :-)
+			if (!$a['seen']) {
+				$adate += 31536000;
+			}
+			if (!$b['seen']) {
+				$bdate += 31536000;
+			}
+
 			if ($adate == $bdate) {
 				return 0;
 			}


### PR DESCRIPTION
When a notification was read it now automatically moves behind the last unread notification. 