### PR TITLE
New function to recursively delete data

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -38,7 +38,7 @@ define ( 'FRIENDICA_PLATFORM',     'Friendica');
 define ( 'FRIENDICA_CODENAME',     'Asparagus');
 define ( 'FRIENDICA_VERSION',      '3.5.2-dev' );
 define ( 'DFRN_PROTOCOL_VERSION',  '2.23'    );
-define ( 'DB_UPDATE_VERSION',      1221      );
+define ( 'DB_UPDATE_VERSION',      1222      );
 
 /**
  * @brief Constant with a HTML line break.

--- a/include/dba.php
+++ b/include/dba.php
@@ -520,7 +520,7 @@ class dba {
 				}
 
 				if (!$stmt->execute()) {
-					$errorInfo = self::$dbo->db->errorInfo();
+					$errorInfo = $stmt->errorInfo();
 					self::$dbo->error = $errorInfo[2];
 					self::$dbo->errorno = $errorInfo[1];
 					$retval = false;
@@ -532,8 +532,8 @@ class dba {
 				$stmt = self::$dbo->db->stmt_init();
 
 				if (!$stmt->prepare($sql)) {
-					self::$dbo->error = self::$dbo->db->error;
-					self::$dbo->errorno = self::$dbo->db->errno;
+					self::$dbo->error = $stmt->error;
+					self::$dbo->errorno = $stmt->errno;
 					$retval = false;
 					break;
 				}

--- a/include/dba.php
+++ b/include/dba.php
@@ -812,20 +812,14 @@ class dba {
 		// Is there a relation entry for the table?
 		if (isset(self::$relation[$table])) {
 			foreach (self::$relation[$table] AS $field => $rel_def) {
-				// Currently we only support relations with a single variable
-				if (count($rel_def) > 1) {
-					return false;
-				}
-
-				$rel_field = array_values($rel_def)[0];
-				$rel_table = array_keys($rel_def)[0];
-
 				// When the search field is the relation field, we don't need to fetch the rows
 				// This is useful when the leading record is already deleted in the frontend but the rest is done in the backend
 				if ((count($param) == 1) AND ($field == array_keys($param)[0])) {
-					$retval = self::delete($rel_table, array($rel_field => array_values($param)[0]), true, $callstack);
-					if (!$retval) {
-						return false;
+					foreach ($rel_def AS $rel_table => $rel_field) {
+						$retval = self::delete($rel_table, array($rel_field => array_values($param)[0]), true, $callstack);
+						if (!$retval) {
+							return false;
+						}
 					}
 				} else {
 					// Fetch all rows that are to be deleted
@@ -834,10 +828,12 @@ class dba {
 					$retval = false;
 					$data = self::p($sql, $param);
 					while ($row = self::fetch($data)) {
-						// We have to do a separate delete process per row
-						$retval = self::delete($rel_table, array($rel_field => $row[$field]), true, $callstack);
-						if (!$retval) {
-							return false;
+						foreach ($rel_def AS $rel_table => $rel_field) {
+							// We have to do a separate delete process per row
+							$retval = self::delete($rel_table, array($rel_field => $row[$field]), true, $callstack);
+							if (!$retval) {
+								return false;
+							}
 						}
 					}
 					if (!$retval) {

--- a/include/dbstructure.php
+++ b/include/dbstructure.php
@@ -1069,7 +1069,7 @@ function db_definition() {
 			);
 	$database["item"] = array(
 			"fields" => array(
-					"id" => array("type" => "int(10) unsigned", "not null" => "1", "extra" => "auto_increment", "primary" => "1"),
+					"id" => array("type" => "int(10) unsigned", "not null" => "1", "extra" => "auto_increment", "primary" => "1", "relation" => array("thread" => "iid")),
 					"guid" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
 					"uri" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
 					"uid" => array("type" => "int(10) unsigned", "not null" => "1", "default" => "0", "relation" => array("user" => "uid")),

--- a/include/dbstructure.php
+++ b/include/dbstructure.php
@@ -300,6 +300,9 @@ function update_structure($verbose, $action, $tables=null, $definition=null) {
 					// Compare the field definition
 					$field_definition = $database[$name]["fields"][$fieldname];
 
+					// Remove the relation data that is used for the referential integrity
+					unset($parameters['relation']);
+
 					// We change the collation after the indexes had been changed.
 					// This is done to avoid index length problems.
 					// So here we always ensure that there is no need to change it.
@@ -627,7 +630,7 @@ function db_definition() {
 	$database["attach"] = array(
 			"fields" => array(
 					"id" => array("type" => "int(11)", "not null" => "1", "extra" => "auto_increment", "primary" => "1"),
-					"uid" => array("type" => "int(11)", "not null" => "1", "default" => "0"),
+					"uid" => array("type" => "int(11)", "not null" => "1", "default" => "0", "relation" => array("user" => "uid")),
 					"hash" => array("type" => "varchar(64)", "not null" => "1", "default" => ""),
 					"filename" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
 					"filetype" => array("type" => "varchar(64)", "not null" => "1", "default" => ""),
@@ -647,7 +650,7 @@ function db_definition() {
 	$database["auth_codes"] = array(
 			"fields" => array(
 					"id" => array("type" => "varchar(40)", "not null" => "1", "primary" => "1"),
-					"client_id" => array("type" => "varchar(20)", "not null" => "1", "default" => ""),
+					"client_id" => array("type" => "varchar(20)", "not null" => "1", "default" => "", "relation" => array("clients" => "client_id")),
 					"redirect_uri" => array("type" => "varchar(200)", "not null" => "1", "default" => ""),
 					"expires" => array("type" => "int(11)", "not null" => "1", "default" => "0"),
 					"scope" => array("type" => "varchar(250)", "not null" => "1", "default" => ""),
@@ -688,7 +691,7 @@ function db_definition() {
 					"redirect_uri" => array("type" => "varchar(200)", "not null" => "1", "default" => ""),
 					"name" => array("type" => "text"),
 					"icon" => array("type" => "text"),
-					"uid" => array("type" => "int(11)", "not null" => "1", "default" => "0"),
+					"uid" => array("type" => "int(11)", "not null" => "1", "default" => "0", "relation" => array("user" => "uid")),
 					),
 			"indexes" => array(
 					"PRIMARY" => array("client_id"),
@@ -709,7 +712,7 @@ function db_definition() {
 	$database["contact"] = array(
 			"fields" => array(
 					"id" => array("type" => "int(11)", "not null" => "1", "extra" => "auto_increment", "primary" => "1"),
-					"uid" => array("type" => "int(11)", "not null" => "1", "default" => "0"),
+					"uid" => array("type" => "int(11)", "not null" => "1", "default" => "0", "relation" => array("user" => "uid")),
 					"created" => array("type" => "datetime", "not null" => "1", "default" => NULL_DATE),
 					"self" => array("type" => "tinyint(1)", "not null" => "1", "default" => "0"),
 					"remote_self" => array("type" => "tinyint(1)", "not null" => "1", "default" => "0"),
@@ -798,7 +801,7 @@ function db_definition() {
 					"id" => array("type" => "int(10) unsigned", "not null" => "1", "extra" => "auto_increment", "primary" => "1"),
 					"guid" => array("type" => "varchar(64)", "not null" => "1", "default" => ""),
 					"recips" => array("type" => "text"),
-					"uid" => array("type" => "int(11)", "not null" => "1", "default" => "0"),
+					"uid" => array("type" => "int(11)", "not null" => "1", "default" => "0", "relation" => array("user" => "uid")),
 					"creator" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
 					"created" => array("type" => "datetime", "not null" => "1", "default" => NULL_DATE),
 					"updated" => array("type" => "datetime", "not null" => "1", "default" => NULL_DATE),
@@ -828,8 +831,8 @@ function db_definition() {
 			"fields" => array(
 					"id" => array("type" => "int(11)", "not null" => "1", "extra" => "auto_increment", "primary" => "1"),
 					"guid" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
-					"uid" => array("type" => "int(11)", "not null" => "1", "default" => "0"),
-					"cid" => array("type" => "int(11)", "not null" => "1", "default" => "0"),
+					"uid" => array("type" => "int(11)", "not null" => "1", "default" => "0", "relation" => array("user" => "uid")),
+					"cid" => array("type" => "int(11)", "not null" => "1", "default" => "0", "relation" => array("contact" => "id")),
 					"uri" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
 					"created" => array("type" => "datetime", "not null" => "1", "default" => NULL_DATE),
 					"edited" => array("type" => "datetime", "not null" => "1", "default" => NULL_DATE),
@@ -881,9 +884,9 @@ function db_definition() {
 	$database["ffinder"] = array(
 			"fields" => array(
 					"id" => array("type" => "int(10) unsigned", "not null" => "1", "extra" => "auto_increment", "primary" => "1"),
-					"uid" => array("type" => "int(10) unsigned", "not null" => "1", "default" => "0"),
-					"cid" => array("type" => "int(10) unsigned", "not null" => "1", "default" => "0"),
-					"fid" => array("type" => "int(10) unsigned", "not null" => "1", "default" => "0"),
+					"uid" => array("type" => "int(10) unsigned", "not null" => "1", "default" => "0", "relation" => array("user" => "uid")),
+					"cid" => array("type" => "int(10) unsigned", "not null" => "1", "default" => "0", "relation" => array("contact" => "id")),
+					"fid" => array("type" => "int(10) unsigned", "not null" => "1", "default" => "0", "relation" => array("fcontact" => "id")),
 					),
 			"indexes" => array(
 					"PRIMARY" => array("id"),
@@ -904,8 +907,8 @@ function db_definition() {
 	$database["fsuggest"] = array(
 			"fields" => array(
 					"id" => array("type" => "int(11)", "not null" => "1", "extra" => "auto_increment", "primary" => "1"),
-					"uid" => array("type" => "int(11)", "not null" => "1", "default" => "0"),
-					"cid" => array("type" => "int(11)", "not null" => "1", "default" => "0"),
+					"uid" => array("type" => "int(11)", "not null" => "1", "default" => "0", "relation" => array("user" => "uid")),
+					"cid" => array("type" => "int(11)", "not null" => "1", "default" => "0", "relation" => array("contact" => "id")),
 					"name" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
 					"url" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
 					"request" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
@@ -920,8 +923,8 @@ function db_definition() {
 	$database["gcign"] = array(
 			"fields" => array(
 					"id" => array("type" => "int(11)", "not null" => "1", "extra" => "auto_increment", "primary" => "1"),
-					"uid" => array("type" => "int(11)", "not null" => "1", "default" => "0"),
-					"gcid" => array("type" => "int(11)", "not null" => "1", "default" => "0"),
+					"uid" => array("type" => "int(11)", "not null" => "1", "default" => "0", "relation" => array("user" => "uid")),
+					"gcid" => array("type" => "int(11)", "not null" => "1", "default" => "0", "relation" => array("gcontact" => "id")),
 					),
 			"indexes" => array(
 					"PRIMARY" => array("id"),
@@ -971,10 +974,10 @@ function db_definition() {
 	$database["glink"] = array(
 			"fields" => array(
 					"id" => array("type" => "int(10) unsigned", "not null" => "1", "extra" => "auto_increment", "primary" => "1"),
-					"cid" => array("type" => "int(11)", "not null" => "1", "default" => "0"),
-					"uid" => array("type" => "int(11)", "not null" => "1", "default" => "0"),
-					"gcid" => array("type" => "int(11)", "not null" => "1", "default" => "0"),
-					"zcid" => array("type" => "int(11)", "not null" => "1", "default" => "0"),
+					"cid" => array("type" => "int(11)", "not null" => "1", "default" => "0", "relation" => array("contact" => "id")),
+					"uid" => array("type" => "int(11)", "not null" => "1", "default" => "0", "relation" => array("user" => "uid")),
+					"gcid" => array("type" => "int(11)", "not null" => "1", "default" => "0", "relation" => array("gcontact" => "id")),
+					"zcid" => array("type" => "int(11)", "not null" => "1", "default" => "0", "relation" => array("gcontact" => "id")),
 					"updated" => array("type" => "datetime", "not null" => "1", "default" => NULL_DATE),
 					),
 			"indexes" => array(
@@ -986,7 +989,7 @@ function db_definition() {
 	$database["group"] = array(
 			"fields" => array(
 					"id" => array("type" => "int(10) unsigned", "not null" => "1", "extra" => "auto_increment", "primary" => "1"),
-					"uid" => array("type" => "int(10) unsigned", "not null" => "1", "default" => "0"),
+					"uid" => array("type" => "int(10) unsigned", "not null" => "1", "default" => "0", "relation" => array("user" => "uid")),
 					"visible" => array("type" => "tinyint(1)", "not null" => "1", "default" => "0"),
 					"deleted" => array("type" => "tinyint(1)", "not null" => "1", "default" => "0"),
 					"name" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
@@ -999,9 +1002,9 @@ function db_definition() {
 	$database["group_member"] = array(
 			"fields" => array(
 					"id" => array("type" => "int(10) unsigned", "not null" => "1", "extra" => "auto_increment", "primary" => "1"),
-					"uid" => array("type" => "int(10) unsigned", "not null" => "1", "default" => "0"),
-					"gid" => array("type" => "int(10) unsigned", "not null" => "1", "default" => "0"),
-					"contact-id" => array("type" => "int(10) unsigned", "not null" => "1", "default" => "0"),
+					"uid" => array("type" => "int(10) unsigned", "not null" => "1", "default" => "0", "relation" => array("user" => "uid")),
+					"gid" => array("type" => "int(10) unsigned", "not null" => "1", "default" => "0", "relation" => array("group" => "id")),
+					"contact-id" => array("type" => "int(10) unsigned", "not null" => "1", "default" => "0", "relation" => array("contact" => "id")),
 					),
 			"indexes" => array(
 					"PRIMARY" => array("id"),
@@ -1049,9 +1052,9 @@ function db_definition() {
 	$database["intro"] = array(
 			"fields" => array(
 					"id" => array("type" => "int(10) unsigned", "not null" => "1", "extra" => "auto_increment", "primary" => "1"),
-					"uid" => array("type" => "int(10) unsigned", "not null" => "1", "default" => "0"),
-					"fid" => array("type" => "int(11)", "not null" => "1", "default" => "0"),
-					"contact-id" => array("type" => "int(11)", "not null" => "1", "default" => "0"),
+					"uid" => array("type" => "int(10) unsigned", "not null" => "1", "default" => "0", "relation" => array("user" => "uid")),
+					"fid" => array("type" => "int(11)", "not null" => "1", "default" => "0", "relation" => array("fcontact" => "id")),
+					"contact-id" => array("type" => "int(11)", "not null" => "1", "default" => "0", "relation" => array("contact" => "id")),
 					"knowyou" => array("type" => "tinyint(1)", "not null" => "1", "default" => "0"),
 					"duplex" => array("type" => "tinyint(1)", "not null" => "1", "default" => "0"),
 					"note" => array("type" => "text"),
@@ -1069,9 +1072,9 @@ function db_definition() {
 					"id" => array("type" => "int(10) unsigned", "not null" => "1", "extra" => "auto_increment", "primary" => "1"),
 					"guid" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
 					"uri" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
-					"uid" => array("type" => "int(10) unsigned", "not null" => "1", "default" => "0"),
-					"contact-id" => array("type" => "int(11)", "not null" => "1", "default" => "0"),
-					"gcontact-id" => array("type" => "int(11) unsigned", "not null" => "1", "default" => "0"),
+					"uid" => array("type" => "int(10) unsigned", "not null" => "1", "default" => "0", "relation" => array("user" => "uid")),
+					"contact-id" => array("type" => "int(11)", "not null" => "1", "default" => "0", "relation" => array("contact" => "id")),
+					"gcontact-id" => array("type" => "int(11) unsigned", "not null" => "1", "default" => "0", "relation" => array("gcontact" => "id")),
 					"type" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
 					"wall" => array("type" => "tinyint(1)", "not null" => "1", "default" => "0"),
 					"gravity" => array("type" => "tinyint(1)", "not null" => "1", "default" => "0"),
@@ -1084,11 +1087,11 @@ function db_definition() {
 					"commented" => array("type" => "datetime", "not null" => "1", "default" => NULL_DATE),
 					"received" => array("type" => "datetime", "not null" => "1", "default" => NULL_DATE),
 					"changed" => array("type" => "datetime", "not null" => "1", "default" => NULL_DATE),
-					"owner-id" => array("type" => "int(11)", "not null" => "1", "default" => "0"),
+					"owner-id" => array("type" => "int(11)", "not null" => "1", "default" => "0", "relation" => array("contact" => "id")),
 					"owner-name" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
 					"owner-link" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
 					"owner-avatar" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
-					"author-id" => array("type" => "int(11)", "not null" => "1", "default" => "0"),
+					"author-id" => array("type" => "int(11)", "not null" => "1", "default" => "0", "relation" => array("contact" => "id")),
 					"author-name" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
 					"author-link" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
 					"author-avatar" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
@@ -1103,7 +1106,7 @@ function db_definition() {
 					"postopts" => array("type" => "text"),
 					"plink" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
 					"resource-id" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
-					"event-id" => array("type" => "int(11)", "not null" => "1", "default" => "0"),
+					"event-id" => array("type" => "int(11)", "not null" => "1", "default" => "0", "relation" => array("event" => "id")),
 					"tag" => array("type" => "mediumtext"),
 					"attach" => array("type" => "mediumtext"),
 					"inform" => array("type" => "mediumtext"),
@@ -1164,8 +1167,8 @@ function db_definition() {
 	$database["item_id"] = array(
 			"fields" => array(
 					"id" => array("type" => "int(11)", "not null" => "1", "extra" => "auto_increment", "primary" => "1"),
-					"iid" => array("type" => "int(11)", "not null" => "1", "default" => "0"),
-					"uid" => array("type" => "int(11)", "not null" => "1", "default" => "0"),
+					"iid" => array("type" => "int(11)", "not null" => "1", "default" => "0", "relation" => array("item" => "id")),
+					"uid" => array("type" => "int(11)", "not null" => "1", "default" => "0", "relation" => array("user" => "uid")),
 					"sid" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
 					"service" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
 					),
@@ -1191,13 +1194,13 @@ function db_definition() {
 	$database["mail"] = array(
 			"fields" => array(
 					"id" => array("type" => "int(10) unsigned", "not null" => "1", "extra" => "auto_increment", "primary" => "1"),
-					"uid" => array("type" => "int(10) unsigned", "not null" => "1", "default" => "0"),
+					"uid" => array("type" => "int(10) unsigned", "not null" => "1", "default" => "0", "relation" => array("user" => "uid")),
 					"guid" => array("type" => "varchar(64)", "not null" => "1", "default" => ""),
 					"from-name" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
 					"from-photo" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
 					"from-url" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
-					"contact-id" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
-					"convid" => array("type" => "int(11) unsigned", "not null" => "1", "default" => "0"),
+					"contact-id" => array("type" => "varchar(255)", "not null" => "1", "default" => "", "relation" => array("contact" => "id")),
+					"convid" => array("type" => "int(11) unsigned", "not null" => "1", "default" => "0", "relation" => array("conv" => "id")),
 					"title" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
 					"body" => array("type" => "mediumtext"),
 					"seen" => array("type" => "tinyint(1)", "not null" => "1", "default" => "0"),
@@ -1219,7 +1222,7 @@ function db_definition() {
 	$database["mailacct"] = array(
 			"fields" => array(
 					"id" => array("type" => "int(11)", "not null" => "1", "extra" => "auto_increment", "primary" => "1"),
-					"uid" => array("type" => "int(11)", "not null" => "1", "default" => "0"),
+					"uid" => array("type" => "int(11)", "not null" => "1", "default" => "0", "relation" => array("user" => "uid")),
 					"server" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
 					"port" => array("type" => "int(11)", "not null" => "1", "default" => "0"),
 					"ssltype" => array("type" => "varchar(16)", "not null" => "1", "default" => ""),
@@ -1239,8 +1242,8 @@ function db_definition() {
 	$database["manage"] = array(
 			"fields" => array(
 					"id" => array("type" => "int(11)", "not null" => "1", "extra" => "auto_increment", "primary" => "1"),
-					"uid" => array("type" => "int(11)", "not null" => "1", "default" => "0"),
-					"mid" => array("type" => "int(11)", "not null" => "1", "default" => "0"),
+					"uid" => array("type" => "int(11)", "not null" => "1", "default" => "0", "relation" => array("user" => "uid")),
+					"mid" => array("type" => "int(11)", "not null" => "1", "default" => "0", "relation" => array("user" => "uid")),
 					),
 			"indexes" => array(
 					"PRIMARY" => array("id"),
@@ -1257,10 +1260,10 @@ function db_definition() {
 					"photo" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
 					"date" => array("type" => "datetime", "not null" => "1", "default" => NULL_DATE),
 					"msg" => array("type" => "mediumtext"),
-					"uid" => array("type" => "int(11)", "not null" => "1", "default" => "0"),
+					"uid" => array("type" => "int(11)", "not null" => "1", "default" => "0", "relation" => array("user" => "uid")),
 					"link" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
-					"iid" => array("type" => "int(11)", "not null" => "1", "default" => "0"),
-					"parent" => array("type" => "int(11)", "not null" => "1", "default" => "0"),
+					"iid" => array("type" => "int(11)", "not null" => "1", "default" => "0", "relation" => array("item" => "id")),
+					"parent" => array("type" => "int(11)", "not null" => "1", "default" => "0", "relation" => array("item" => "id")),
 					"seen" => array("type" => "tinyint(1)", "not null" => "1", "default" => "0"),
 					"verb" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
 					"otype" => array("type" => "varchar(16)", "not null" => "1", "default" => ""),
@@ -1278,10 +1281,10 @@ function db_definition() {
 	$database["notify-threads"] = array(
 			"fields" => array(
 					"id" => array("type" => "int(11)", "not null" => "1", "extra" => "auto_increment", "primary" => "1"),
-					"notify-id" => array("type" => "int(11)", "not null" => "1", "default" => "0"),
-					"master-parent-item" => array("type" => "int(10) unsigned", "not null" => "1", "default" => "0"),
+					"notify-id" => array("type" => "int(11)", "not null" => "1", "default" => "0", "relation" => array("notify" => "id")),
+					"master-parent-item" => array("type" => "int(10) unsigned", "not null" => "1", "default" => "0", "relation" => array("item" => "id")),
 					"parent-item" => array("type" => "int(10) unsigned", "not null" => "1", "default" => "0"),
-					"receiver-uid" => array("type" => "int(11)", "not null" => "1", "default" => "0"),
+					"receiver-uid" => array("type" => "int(11)", "not null" => "1", "default" => "0", "relation" => array("user" => "id")),
 					),
 			"indexes" => array(
 					"PRIMARY" => array("id"),
@@ -1314,7 +1317,7 @@ function db_definition() {
 	$database["pconfig"] = array(
 			"fields" => array(
 					"id" => array("type" => "int(11)", "not null" => "1", "extra" => "auto_increment", "primary" => "1"),
-					"uid" => array("type" => "int(11)", "not null" => "1", "default" => "0"),
+					"uid" => array("type" => "int(11)", "not null" => "1", "default" => "0", "relation" => array("user" => "uid")),
 					"cat" => array("type" => "varbinary(255)", "not null" => "1", "default" => ""),
 					"k" => array("type" => "varbinary(255)", "not null" => "1", "default" => ""),
 					"v" => array("type" => "mediumtext"),
@@ -1327,8 +1330,8 @@ function db_definition() {
 	$database["photo"] = array(
 			"fields" => array(
 					"id" => array("type" => "int(10) unsigned", "not null" => "1", "extra" => "auto_increment", "primary" => "1"),
-					"uid" => array("type" => "int(10) unsigned", "not null" => "1", "default" => "0"),
-					"contact-id" => array("type" => "int(10) unsigned", "not null" => "1", "default" => "0"),
+					"uid" => array("type" => "int(10) unsigned", "not null" => "1", "default" => "0", "relation" => array("user" => "uid")),
+					"contact-id" => array("type" => "int(10) unsigned", "not null" => "1", "default" => "0", "relation" => array("contact" => "id")),
 					"guid" => array("type" => "varchar(64)", "not null" => "1", "default" => ""),
 					"resource-id" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
 					"created" => array("type" => "datetime", "not null" => "1", "default" => NULL_DATE),
@@ -1361,7 +1364,7 @@ function db_definition() {
 	$database["poll"] = array(
 			"fields" => array(
 					"id" => array("type" => "int(11)", "not null" => "1", "extra" => "auto_increment", "primary" => "1"),
-					"uid" => array("type" => "int(11)", "not null" => "1", "default" => "0"),
+					"uid" => array("type" => "int(11)", "not null" => "1", "default" => "0", "relation" => array("user" => "uid")),
 					"q0" => array("type" => "text"),
 					"q1" => array("type" => "text"),
 					"q2" => array("type" => "text"),
@@ -1381,7 +1384,7 @@ function db_definition() {
 	$database["poll_result"] = array(
 			"fields" => array(
 					"id" => array("type" => "int(11)", "not null" => "1", "extra" => "auto_increment", "primary" => "1"),
-					"poll_id" => array("type" => "int(11)", "not null" => "1", "default" => "0"),
+					"poll_id" => array("type" => "int(11)", "not null" => "1", "default" => "0", "relation" => array("poll" => "id")),
 					"choice" => array("type" => "int(11)", "not null" => "1", "default" => "0"),
 					),
 			"indexes" => array(
@@ -1404,7 +1407,7 @@ function db_definition() {
 	$database["profile"] = array(
 			"fields" => array(
 					"id" => array("type" => "int(11)", "not null" => "1", "extra" => "auto_increment", "primary" => "1"),
-					"uid" => array("type" => "int(11)", "not null" => "1", "default" => "0"),
+					"uid" => array("type" => "int(11)", "not null" => "1", "default" => "0", "relation" => array("user" => "uid")),
 					"profile-name" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
 					"is-default" => array("type" => "tinyint(1)", "not null" => "1", "default" => "0"),
 					"hide-friends" => array("type" => "tinyint(1)", "not null" => "1", "default" => "0"),
@@ -1454,8 +1457,8 @@ function db_definition() {
 	$database["profile_check"] = array(
 			"fields" => array(
 					"id" => array("type" => "int(10) unsigned", "not null" => "1", "extra" => "auto_increment", "primary" => "1"),
-					"uid" => array("type" => "int(10) unsigned", "not null" => "1", "default" => "0"),
-					"cid" => array("type" => "int(10) unsigned", "not null" => "1", "default" => "0"),
+					"uid" => array("type" => "int(10) unsigned", "not null" => "1", "default" => "0", "relation" => array("user" => "uid")),
+					"cid" => array("type" => "int(10) unsigned", "not null" => "1", "default" => "0", "relation" => array("contact" => "id")),
 					"dfrn_id" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
 					"sec" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
 					"expire" => array("type" => "int(11)", "not null" => "1", "default" => "0"),
@@ -1467,7 +1470,7 @@ function db_definition() {
 	$database["push_subscriber"] = array(
 			"fields" => array(
 					"id" => array("type" => "int(11)", "not null" => "1", "extra" => "auto_increment", "primary" => "1"),
-					"uid" => array("type" => "int(11)", "not null" => "1", "default" => "0"),
+					"uid" => array("type" => "int(11)", "not null" => "1", "default" => "0", "relation" => array("user" => "uid")),
 					"callback_url" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
 					"topic" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
 					"nickname" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
@@ -1482,7 +1485,7 @@ function db_definition() {
 	$database["queue"] = array(
 			"fields" => array(
 					"id" => array("type" => "int(11)", "not null" => "1", "extra" => "auto_increment", "primary" => "1"),
-					"cid" => array("type" => "int(11)", "not null" => "1", "default" => "0"),
+					"cid" => array("type" => "int(11)", "not null" => "1", "default" => "0", "relation" => array("contact" => "id")),
 					"network" => array("type" => "varchar(32)", "not null" => "1", "default" => ""),
 					"created" => array("type" => "datetime", "not null" => "1", "default" => NULL_DATE),
 					"last" => array("type" => "datetime", "not null" => "1", "default" => NULL_DATE),
@@ -1503,7 +1506,7 @@ function db_definition() {
 					"id" => array("type" => "int(11) unsigned", "not null" => "1", "extra" => "auto_increment", "primary" => "1"),
 					"hash" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
 					"created" => array("type" => "datetime", "not null" => "1", "default" => NULL_DATE),
-					"uid" => array("type" => "int(11) unsigned", "not null" => "1", "default" => "0"),
+					"uid" => array("type" => "int(11) unsigned", "not null" => "1", "default" => "0", "relation" => array("user" => "uid")),
 					"password" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
 					"language" => array("type" => "varchar(16)", "not null" => "1", "default" => ""),
 					"note" => array("type" => "text"),
@@ -1515,7 +1518,7 @@ function db_definition() {
 	$database["search"] = array(
 			"fields" => array(
 					"id" => array("type" => "int(11)", "not null" => "1", "extra" => "auto_increment", "primary" => "1"),
-					"uid" => array("type" => "int(11)", "not null" => "1", "default" => "0"),
+					"uid" => array("type" => "int(11)", "not null" => "1", "default" => "0", "relation" => array("user" => "uid")),
 					"term" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
 					),
 			"indexes" => array(
@@ -1539,7 +1542,7 @@ function db_definition() {
 	$database["sign"] = array(
 			"fields" => array(
 					"id" => array("type" => "int(10) unsigned", "not null" => "1", "extra" => "auto_increment", "primary" => "1"),
-					"iid" => array("type" => "int(10) unsigned", "not null" => "1", "default" => "0"),
+					"iid" => array("type" => "int(10) unsigned", "not null" => "1", "default" => "0", "relation" => array("item" => "id")),
 					"signed_text" => array("type" => "mediumtext"),
 					"signature" => array("type" => "text"),
 					"signer" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
@@ -1552,7 +1555,7 @@ function db_definition() {
 	$database["spam"] = array(
 			"fields" => array(
 					"id" => array("type" => "int(11)", "not null" => "1", "extra" => "auto_increment", "primary" => "1"),
-					"uid" => array("type" => "int(11)", "not null" => "1", "default" => "0"),
+					"uid" => array("type" => "int(11)", "not null" => "1", "default" => "0", "relation" => array("user" => "uid")),
 					"spam" => array("type" => "int(11)", "not null" => "1", "default" => "0"),
 					"ham" => array("type" => "int(11)", "not null" => "1", "default" => "0"),
 					"term" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
@@ -1569,7 +1572,7 @@ function db_definition() {
 	$database["term"] = array(
 			"fields" => array(
 					"tid" => array("type" => "int(10) unsigned", "not null" => "1", "extra" => "auto_increment", "primary" => "1"),
-					"oid" => array("type" => "int(10) unsigned", "not null" => "1", "default" => "0"),
+					"oid" => array("type" => "int(10) unsigned", "not null" => "1", "default" => "0", "relation" => array("item" => "id")),
 					"otype" => array("type" => "tinyint(3) unsigned", "not null" => "1", "default" => "0"),
 					"type" => array("type" => "tinyint(3) unsigned", "not null" => "1", "default" => "0"),
 					"term" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
@@ -1579,7 +1582,7 @@ function db_definition() {
 					"received" => array("type" => "datetime", "not null" => "1", "default" => NULL_DATE),
 					"global" => array("type" => "tinyint(1)", "not null" => "1", "default" => "0"),
 					"aid" => array("type" => "int(10) unsigned", "not null" => "1", "default" => "0"),
-					"uid" => array("type" => "int(10) unsigned", "not null" => "1", "default" => "0"),
+					"uid" => array("type" => "int(10) unsigned", "not null" => "1", "default" => "0", "relation" => array("user" => "uid")),
 					),
 			"indexes" => array(
 					"PRIMARY" => array("tid"),
@@ -1591,12 +1594,12 @@ function db_definition() {
 			);
 	$database["thread"] = array(
 			"fields" => array(
-					"iid" => array("type" => "int(10) unsigned", "not null" => "1", "default" => "0", "primary" => "1"),
-					"uid" => array("type" => "int(10) unsigned", "not null" => "1", "default" => "0"),
-					"contact-id" => array("type" => "int(11) unsigned", "not null" => "1", "default" => "0"),
-					"gcontact-id" => array("type" => "int(11) unsigned", "not null" => "1", "default" => "0"),
-					"owner-id" => array("type" => "int(11) unsigned", "not null" => "1", "default" => "0"),
-					"author-id" => array("type" => "int(11) unsigned", "not null" => "1", "default" => "0"),
+					"iid" => array("type" => "int(10) unsigned", "not null" => "1", "default" => "0", "primary" => "1", "relation" => array("item" => "id")),
+					"uid" => array("type" => "int(10) unsigned", "not null" => "1", "default" => "0", "relation" => array("user" => "uid")),
+					"contact-id" => array("type" => "int(11) unsigned", "not null" => "1", "default" => "0", "relation" => array("contact" => "id")),
+					"gcontact-id" => array("type" => "int(11) unsigned", "not null" => "1", "default" => "0", "relation" => array("gcontact" => "id")),
+					"owner-id" => array("type" => "int(11) unsigned", "not null" => "1", "default" => "0", "relation" => array("contact" => "id")),
+					"author-id" => array("type" => "int(11) unsigned", "not null" => "1", "default" => "0", "relation" => array("contact" => "id")),
 					"created" => array("type" => "datetime", "not null" => "1", "default" => NULL_DATE),
 					"edited" => array("type" => "datetime", "not null" => "1", "default" => NULL_DATE),
 					"commented" => array("type" => "datetime", "not null" => "1", "default" => NULL_DATE),
@@ -1633,10 +1636,10 @@ function db_definition() {
 			"fields" => array(
 					"id" => array("type" => "varchar(40)", "not null" => "1", "primary" => "1"),
 					"secret" => array("type" => "text"),
-					"client_id" => array("type" => "varchar(20)", "not null" => "1", "default" => ""),
+					"client_id" => array("type" => "varchar(20)", "not null" => "1", "default" => "", "relation" => array("clients" => "client_id")),
 					"expires" => array("type" => "int(11)", "not null" => "1", "default" => "0"),
 					"scope" => array("type" => "varchar(200)", "not null" => "1", "default" => ""),
-					"uid" => array("type" => "int(11)", "not null" => "1", "default" => "0"),
+					"uid" => array("type" => "int(11)", "not null" => "1", "default" => "0", "relation" => array("user" => "uid")),
 					),
 			"indexes" => array(
 					"PRIMARY" => array("id"),
@@ -1780,7 +1783,7 @@ function dbstructure_run(&$argv, &$argc) {
 	echo "dryrun		show database update schema queries without running them\n";
 	echo "update		update database schema\n";
 	echo "dumpsql		dump database schema\n";
-	echo "toinnodb		convert all tables from MyISAM to InnoDB\n";
+	echo "toinnodb	convert all tables from MyISAM to InnoDB\n";
 	return;
 
 }

--- a/include/dbstructure.php
+++ b/include/dbstructure.php
@@ -1152,6 +1152,7 @@ function db_definition() {
 					"uid_parenturi" => array("uid","parent-uri(190)"),
 					"uid_contactid_created" => array("uid","contact-id","created"),
 					"authorid_created" => array("author-id","created"),
+					"ownerid" => array("owner-id"),
 					"uid_uri" => array("uid", "uri(190)"),
 					"resource-id" => array("resource-id"),
 					"contactid_allowcid_allowpid_denycid_denygid" => array("contact-id","allow_cid(10)","allow_gid(10)","deny_cid(10)","deny_gid(10)"), //
@@ -1627,6 +1628,9 @@ function db_definition() {
 					"uid_network_created" => array("uid","network","created"),
 					"uid_contactid_commented" => array("uid","contact-id","commented"),
 					"uid_contactid_created" => array("uid","contact-id","created"),
+					"contactid" => array("contact-id"),
+					"ownerid" => array("owner-id"),
+					"authorid" => array("author-id"),
 					"uid_created" => array("uid","created"),
 					"uid_commented" => array("uid","commented"),
 					"uid_wall_created" => array("uid","wall","created"),

--- a/include/dbstructure.php
+++ b/include/dbstructure.php
@@ -1078,7 +1078,7 @@ function db_definition() {
 					"type" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
 					"wall" => array("type" => "tinyint(1)", "not null" => "1", "default" => "0"),
 					"gravity" => array("type" => "tinyint(1)", "not null" => "1", "default" => "0"),
-					"parent" => array("type" => "int(10) unsigned", "not null" => "1", "default" => "0"),
+					"parent" => array("type" => "int(10) unsigned", "not null" => "1", "default" => "0", "relation" => array("item" => "id")),
 					"parent-uri" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
 					"extid" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
 					"thr-parent" => array("type" => "varchar(255)", "not null" => "1", "default" => ""),
@@ -1284,7 +1284,7 @@ function db_definition() {
 					"notify-id" => array("type" => "int(11)", "not null" => "1", "default" => "0", "relation" => array("notify" => "id")),
 					"master-parent-item" => array("type" => "int(10) unsigned", "not null" => "1", "default" => "0", "relation" => array("item" => "id")),
 					"parent-item" => array("type" => "int(10) unsigned", "not null" => "1", "default" => "0"),
-					"receiver-uid" => array("type" => "int(11)", "not null" => "1", "default" => "0", "relation" => array("user" => "id")),
+					"receiver-uid" => array("type" => "int(11)", "not null" => "1", "default" => "0", "relation" => array("user" => "uid")),
 					),
 			"indexes" => array(
 					"PRIMARY" => array("id"),

--- a/include/remove_contact.php
+++ b/include/remove_contact.php
@@ -19,14 +19,7 @@ function remove_contact_run($argv, $argc) {
 		return;
 	}
 
-	q("DELETE FROM `item` WHERE `contact-id` = %d", intval($id));
-
-	q("DELETE FROM `photo` WHERE `contact-id` = %d", intval($id));
-
-	q("DELETE FROM `mail` WHERE `contact-id` = %d", intval($id));
-
-	q("DELETE FROM `event` WHERE `cid` = %d", intval($id));
-
-	q("DELETE FROM `queue` WHERE `cid` = %d", intval($id));
+	// Now we delete all the depending table entries
+	dba::delete('contact', array('id' => $id));
 }
 ?>

--- a/update.php
+++ b/update.php
@@ -1,6 +1,6 @@
 <?php
 
-define('UPDATE_VERSION' , 1221);
+define('UPDATE_VERSION' , 1222);
 
 /**
  *


### PR DESCRIPTION
There is a new function to safely delete data including all dependencies.

Example:
```

$table = "item";
$condition = array("id" => 4711);
dba::delete($table, $condition);
```
This will not only delete this item entry but also depending entries in other tables. If this item entry is a thread starter then the whole thread is deleted.

This is a function that will help here: https://github.com/friendica/friendica/issues/3409