### PR TITLE
Diaspora: Better handling for unrelayed comments and likes

### DIFF
--- a/include/diaspora.php
+++ b/include/diaspora.php
@@ -2379,11 +2379,16 @@ class Diaspora {
 			return false;
 		}
 
+		if (!isset($contact["url"])) {
+			$contact["url"] = $person["url"];
+		}
+
 		$r = q("SELECT `id`, `parent`, `parent-uri`, `author-link` FROM `item` WHERE `guid` = '%s' AND `uid` = %d AND NOT `file` LIKE '%%[%%' LIMIT 1",
 			dbesc($target_guid),
 			intval($importer["uid"])
 		);
 		if (!$r) {
+			logger("Target guid ".$target_guid." was not found for user ".$importer["uid"]);
 			return false;
 		}
 
@@ -2429,7 +2434,7 @@ class Diaspora {
 		$target_type = notags(unxmlify($data->target_type));
 
 		$contact = self::contact_by_handle($importer["uid"], $sender);
-		if (!$contact) {
+		if (!$contact AND (in_array($target_type, array("Contact", "Person")))) {
 			logger("cannot find contact for sender: ".$sender." and user ".$importer["uid"]);
 			return false;
 		}
@@ -2442,7 +2447,7 @@ class Diaspora {
 			case "Post": // "Post" will be supported in a future version
 			case "Reshare":
 			case "StatusMessage":
-				return self::item_retraction($importer, $contact, $data);;
+				return self::item_retraction($importer, $contact, $data);
 
 			case "Contact":
 			case "Person":

--- a/include/diaspora.php
+++ b/include/diaspora.php
@@ -380,6 +380,7 @@ class Diaspora {
 	 *
 	 * @param array $importer Array of the importer user
 	 * @param array $msg The post that will be dispatched
+	 * @param object $fields SimpleXML object that contains the message
 	 *
 	 * @return int The message id of the generated message, "true" or "false" if there was an error
 	 */
@@ -457,9 +458,8 @@ class Diaspora {
 	 * It also does the conversion between the old and the new diaspora format.
 	 *
 	 * @param array $msg Array with the XML, the sender handle and the sender signature
-	 * @param object $fields SimpleXML object that contains the posting when it is valid
 	 *
-	 * @return bool Is the posting valid?
+	 * @return bool|array If the posting is valid then an array with an SimpleXML object is returned
 	 */
 	private static function valid_posting($msg) {
 
@@ -556,9 +556,9 @@ class Diaspora {
 			}
 
 		// Only some message types have signatures. So we quit here for the other types.
-		if (!in_array($type, array("comment", "message", "like")))
+		if (!in_array($type, array("comment", "message", "like"))) {
 			return array("fields" => $fields, "relayed" => false);
-
+		}
 		// No author_signature? This is a must, so we quit.
 		if (!isset($author_signature)) {
 			logger("No author signature for type ".$type." - Message: ".$msg["message"], LOGGER_DEBUG);
@@ -583,8 +583,9 @@ class Diaspora {
 		if (!rsa_verify($signed_data, $author_signature, $key, "sha256")) {
 			logger("No valid author signature for author ".$fields->author. " in type ".$type." - signed data: ".$signed_data." - Message: ".$msg["message"]." - Signature ".$author_signature, LOGGER_DEBUG);
 			return false;
-		} else
+		} else {
 			return array("fields" => $fields, "relayed" => $relayed);
+		}
 	}
 
 	/**


### PR DESCRIPTION
This is the next improvement for the Diaspora protocol. We now check more reliable for not relayed comments and likes that have to be send directly to the origin. Additionally retractions for comments and likes (that were meant for Friendica generated threads) will work again.