### PR TITLE
Wrong parameter for delete command

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -38,7 +38,7 @@ define ( 'FRIENDICA_PLATFORM',     'Friendica');
 define ( 'FRIENDICA_CODENAME',     'Asparagus');
 define ( 'FRIENDICA_VERSION',      '3.5.2-dev' );
 define ( 'DFRN_PROTOCOL_VERSION',  '2.23'    );
-define ( 'DB_UPDATE_VERSION',      1223      );
+define ( 'DB_UPDATE_VERSION',      1224      );
 
 /**
  * @brief Constant with a HTML line break.

--- a/include/dba.php
+++ b/include/dba.php
@@ -914,7 +914,7 @@ class dba {
 
 						logger(dba::replace_parameters($sql, $field_values), LOGGER_DATA);
 
-						if (!self::e($sql, $param)) {
+						if (!self::e($sql, $field_values)) {
 							self::p("ROLLBACK");
 							return false;
 						}

--- a/include/dba.php
+++ b/include/dba.php
@@ -886,7 +886,7 @@ class dba {
 
 					logger(dba::replace_parameters($sql, $command['param']), LOGGER_DATA);
 
-					if (!self::e($sql, $param)) {
+					if (!self::e($sql, $command['param'])) {
 						self::p("ROLLBACK");
 						return false;
 					}

--- a/include/dbstructure.php
+++ b/include/dbstructure.php
@@ -1218,6 +1218,7 @@ function db_definition() {
 					"convid" => array("convid"),
 					"uri" => array("uri(64)"),
 					"parent-uri" => array("parent-uri(64)"),
+					"contactid" => array("contact-id"),
 					)
 			);
 	$database["mailacct"] = array(
@@ -1355,6 +1356,7 @@ function db_definition() {
 					),
 			"indexes" => array(
 					"PRIMARY" => array("id"),
+					"contactid" => array("contact-id"),
 					"uid_contactid" => array("uid", "contact-id"),
 					"uid_profile" => array("uid", "profile"),
 					"uid_album_scale_created" => array("uid", "album(32)", "scale", "created"),

--- a/update.php
+++ b/update.php
@@ -1,6 +1,6 @@
 <?php
 
-define('UPDATE_VERSION' , 1223);
+define('UPDATE_VERSION' , 1224);
 
 /**
  *


### PR DESCRIPTION
The function "dba::delete" had used the wrong parameters for the query execution. Additionally two new indexes were created that improves speed when deleting contacts.