### PR TITLE
Use `use` instead of `\`

### DIFF
--- a/include/dba_pdo.php
+++ b/include/dba_pdo.php
@@ -1,12 +1,11 @@
 <?php
 
-use DDDBL;
-
-use Exception;
+use DDDBL\DataObjectPool;
+use DDDBL\Queue;
 
 require_once('include/datetime.php');
 
-$objDDDBLResultHandler = new DDDBL\DataObjectPool('Result-Handler');
+$objDDDBLResultHandler = new DataObjectPool('Result-Handler');
 
 /**
   * create handler, which returns just the PDOStatement object
@@ -14,7 +13,7 @@ $objDDDBLResultHandler = new DDDBL\DataObjectPool('Result-Handler');
   * big result-sets
   *
   **/
-$cloPDOStatementResultHandler = function(DDDBL\Queue $objQueue) {
+$cloPDOStatementResultHandler = function(Queue $objQueue) {
 
   $objPDO = $objQueue->getState()->get('PDOStatement');
   $objQueue->getState()->update(array('result' => $objPDO));
@@ -51,7 +50,7 @@ class dba {
 		$a = get_app();
 
     # work around, to store the database - configuration in DDDBL
-    $objDataObjectPool = new DDDBL\DataObjectPool('Database-Definition');
+    $objDataObjectPool = new DataObjectPool('Database-Definition');
     $objDataObjectPool->add('DEFAULT', array('CONNECTION' => "mysql:host=$server;dbname=$db",
                                              'USER'       => $user,
                                              'PASS'       => $pass,
@@ -110,7 +109,7 @@ class dba {
     $strQueryAlias = md5($sql);
     $strSQLType    = strtoupper(strstr($sql, ' ', true));
 
-    $objPreparedQueryPool = new DDDBL\DataObjectPool('Query-Definition');
+    $objPreparedQueryPool = new DataObjectPool('Query-Definition');
 
     # check if query do not exists till now, if so create its definition
     if (!$objPreparedQueryPool->exists($strQueryAlias))

--- a/include/socgraph.php
+++ b/include/socgraph.php
@@ -11,9 +11,6 @@ use Friendica\App;
 use Friendica\Core\Config;
 use Friendica\Network\Probe;
 
-use DomXPath;
-use DOMDocument;
-
 require_once 'include/datetime.php';
 require_once 'include/probe.php';
 require_once 'include/network.php';

--- a/include/socgraph.php
+++ b/include/socgraph.php
@@ -11,6 +11,9 @@ use Friendica\App;
 use Friendica\Core\Config;
 use Friendica\Network\Probe;
 
+use DomXPath;
+use DOMDocument;
+
 require_once 'include/datetime.php';
 require_once 'include/probe.php';
 require_once 'include/network.php';
@@ -890,9 +893,9 @@ function poco_fetch_nodeinfo($server_url) {
 function poco_detect_server_type($body) {
 	$server = false;
 
-	$doc = new \DOMDocument();
+	$doc = new DOMDocument();
 	@$doc->loadHTML($body);
-	$xpath = new \DomXPath($doc);
+	$xpath = new DomXPath($doc);
 
 	$list = $xpath->query("//meta[@name]");
 

--- a/src/Network/Probe.php
+++ b/src/Network/Probe.php
@@ -11,6 +11,13 @@ namespace Friendica\Network;
 use Friendica\App;
 use Friendica\Core\Config;
 
+use dbm;
+use Cache;
+use xml;
+
+use DomXPath;
+use DOMDocument;
+
 require_once 'include/feed.php';
 require_once 'include/email.php';
 require_once 'include/network.php';
@@ -92,7 +99,7 @@ class Probe {
 			return false;
 		}
 
-		$links = \xml::element_to_array($xrd);
+		$links = xml::element_to_array($xrd);
 		if (!isset($links["xrd"]["link"])) {
 			return false;
 		}
@@ -275,7 +282,7 @@ class Probe {
 	public static function uri($uri, $network = "", $uid = 0, $cache = true) {
 
 		if ($cache) {
-			$result = \Cache::get("probe_url:".$network.":".$uri);
+			$result = Cache::get("probe_url:".$network.":".$uri);
 			if (!is_null($result)) {
 				return $result;
 			}
@@ -327,7 +334,7 @@ class Probe {
 
 		// Only store into the cache if the value seems to be valid
 		if (!in_array($data['network'], array(NETWORK_PHANTOM, NETWORK_MAIL))) {
-			\Cache::set("probe_url:".$network.":".$uri, $data, CACHE_DAY);
+			Cache::set("probe_url:".$network.":".$uri, $data, CACHE_DAY);
 
 			/// @todo temporary fix - we need a real contact update function that updates only changing fields
 			/// The biggest problem is the avatar picture that could have a reduced image size.
@@ -543,7 +550,7 @@ class Probe {
 			return $webfinger;
 		}
 
-		$xrd_arr = \xml::element_to_array($xrd);
+		$xrd_arr = xml::element_to_array($xrd);
 		if (!isset($xrd_arr["xrd"]["link"])) {
 			return false;
 		}
@@ -811,12 +818,12 @@ class Probe {
 			return false;
 		}
 
-		$doc = new \DOMDocument();
+		$doc = new DOMDocument();
 		if (!@$doc->loadHTML($content)) {
 			return false;
 		}
 
-		$xpath = new \DomXPath($doc);
+		$xpath = new DomXPath($doc);
 
 		$vcards = $xpath->query("//div[contains(concat(' ', @class, ' '), ' vcard ')]");
 		if (!is_object($vcards)) {
@@ -1099,12 +1106,12 @@ class Probe {
 	 */
 	private function pumpioProfileData($profile_link) {
 
-		$doc = new \DOMDocument();
+		$doc = new DOMDocument();
 		if (!@$doc->loadHTMLFile($profile_link)) {
 			return false;
 		}
 
-		$xpath = new \DomXPath($doc);
+		$xpath = new DomXPath($doc);
 
 		$data = array();
 
@@ -1186,13 +1193,13 @@ class Probe {
 	 * @return string feed link
 	 */
 	private function getFeedLink($url) {
-		$doc = new \DOMDocument();
+		$doc = new DOMDocument();
 
 		if (!@$doc->loadHTMLFile($url)) {
 			return false;
 		}
 
-		$xpath = new \DomXPath($doc);
+		$xpath = new DomXPath($doc);
 
 		//$feeds = $xpath->query("/html/head/link[@type='application/rss+xml']");
 		$feeds = $xpath->query("/html/head/link[@type='application/rss+xml' and @rel='alternate']");
@@ -1298,7 +1305,7 @@ class Probe {
 
 		$r = q("SELECT * FROM `mailacct` WHERE `uid` = %d AND `server` != '' LIMIT 1", intval($uid));
 
-		if (\dbm::is_result($x) && \dbm::is_result($r)) {
+		if (dbm::is_result($x) && dbm::is_result($r)) {
 			$mailbox = construct_mailbox_name($r[0]);
 			$password = '';
 			openssl_private_decrypt(hex2bin($r[0]['pass']), $password, $x[0]['prvkey']);

--- a/src/ParseUrl.php
+++ b/src/ParseUrl.php
@@ -9,6 +9,11 @@ namespace Friendica;
 
 use Friendica\Core\Config;
 
+use xml;
+
+use DomXPath;
+use DOMDocument;
+
 require_once("include/network.php");
 require_once("include/Photo.php");
 require_once("include/oembed.php");
@@ -223,22 +228,22 @@ class ParseUrl {
 
 		$body = mb_convert_encoding($body, 'HTML-ENTITIES', "UTF-8");
 
-		$doc = new \DOMDocument();
+		$doc = new DOMDocument();
 		@$doc->loadHTML($body);
 
-		\xml::deleteNode($doc, "style");
-		\xml::deleteNode($doc, "script");
-		\xml::deleteNode($doc, "option");
-		\xml::deleteNode($doc, "h1");
-		\xml::deleteNode($doc, "h2");
-		\xml::deleteNode($doc, "h3");
-		\xml::deleteNode($doc, "h4");
-		\xml::deleteNode($doc, "h5");
-		\xml::deleteNode($doc, "h6");
-		\xml::deleteNode($doc, "ol");
-		\xml::deleteNode($doc, "ul");
+		xml::deleteNode($doc, "style");
+		xml::deleteNode($doc, "script");
+		xml::deleteNode($doc, "option");
+		xml::deleteNode($doc, "h1");
+		xml::deleteNode($doc, "h2");
+		xml::deleteNode($doc, "h3");
+		xml::deleteNode($doc, "h4");
+		xml::deleteNode($doc, "h5");
+		xml::deleteNode($doc, "h6");
+		xml::deleteNode($doc, "ol");
+		xml::deleteNode($doc, "ul");
 
-		$xpath = new \DomXPath($doc);
+		$xpath = new DomXPath($doc);
 
 		$list = $xpath->query("//meta[@content]");
 		foreach ($list as $node) {


### PR DESCRIPTION
Follow-up for #3446, #3449 and #3450

Basically, we avoid using the global indicator `\` when referencing classes, instead we declare them in a use statement.

The use statement grouping is as follow:
- First the Friendica namespaced classes
- Then the soon-to-be Friendica namespaces classes (custom Friendica classes)
- Then the vendor-supplied classes
- Then PHP built-in classes (like Exception, DOMDocument, etc…)