### PR TITLE
Bugfix: Timeout problems when saving profile settings

### DIFF
--- a/include/api.php
+++ b/include/api.php
@@ -3744,8 +3744,7 @@ $called_api = null;
 			proc_run(PRIORITY_LOW, "include/directory.php", $url);
 		}
 
-		require_once 'include/profile_update.php';
-		profile_change();
+		proc_run(PRIORITY_LOW, 'include/profile_update.php', api_user());
 
 		// output for client
 		if ($data) {

--- a/include/profile_update.php
+++ b/include/profile_update.php
@@ -1,6 +1,12 @@
 <?php
 require_once('include/diaspora.php');
 
-function profile_change() {
-	Diaspora::send_profile(local_user());
+function profile_update_run(&$argv, &$argc) {
+	if ($argc != 2) {
+		return;
+	}
+
+	$uid = intval($argv[1]);
+
+	Diaspora::send_profile($uid);
 }

--- a/mod/profile_photo.php
+++ b/mod/profile_photo.php
@@ -131,8 +131,7 @@ function profile_photo_post(App $a) {
 					proc_run(PRIORITY_LOW, "include/directory.php", $url);
 				}
 
-				require_once('include/profile_update.php');
-				profile_change();
+				proc_run(PRIORITY_LOW, 'include/profile_update.php', local_user());
 			} else {
 				notice( t('Unable to process image') . EOL);
 			}

--- a/mod/profiles.php
+++ b/mod/profiles.php
@@ -504,8 +504,7 @@ function profiles_post(App $a) {
 				proc_run(PRIORITY_LOW, "include/directory.php", $url);
 			}
 
-			require_once 'include/profile_update.php';
-			profile_change();
+			proc_run(PRIORITY_LOW, 'include/profile_update.php', local_user());
 
 			// Update the global contact for the user
 			update_gcontact_for_user(local_user());

--- a/mod/settings.php
+++ b/mod/settings.php
@@ -637,8 +637,7 @@ function settings_post(App $a) {
 		}
 	}
 
-	require_once('include/profile_update.php');
-	profile_change();
+	proc_run(PRIORITY_LOW, 'include/profile_update.php', local_user());
 
 	// Update the global contact for the user
 	update_gcontact_for_user(local_user());


### PR DESCRIPTION
The updated profile is send to Diaspora followers when they are changed. When a user has got many followers this lasted several seconds which could lead to a time out on the front end.

The profile update message is now sent from the back end.