### PR TITLE
Improved priorities for handling the item expiration

### DIFF
--- a/doc/htconfig.md
+++ b/doc/htconfig.md
@@ -54,6 +54,7 @@ Example: To set the directory value please add this line to your .htconfig.php:
 * **max_batch_queue** - Default value is 1000.
 * **max_processes_backend** - Maximum number of concurrent database processes for background tasks. Default value is 5.
 * **max_processes_frontend** - Maximum number of concurrent database processes for foreground tasks. Default value is 20.
+* **min_poll_interval** - minimal distance in minutes between two polls for a contact. Default is 1. Reasonable values are between 1 and 59.
 * **memcache** (Boolean) - Use memcache. To use memcache the PECL extension "memcache" has to be installed and activated.
 * **memcache_host** - Hostname of the memcache daemon. Default is '127.0.0.1'.
 * **memcache_port** - Portnumber of the memcache daemon. Default is 11211.

--- a/include/cron.php
+++ b/include/cron.php
@@ -195,7 +195,7 @@ function cron_poll_contacts($argc, $argv) {
 				$contact['priority'] = (($poll_interval !== false) ? intval($poll_interval) : 3);
 			}
 
-			if ($contact['priority'] AND !$force) {
+			if (($contact['priority'] >= 0) AND !$force) {
 				$update = false;
 
 				$t = $contact['last-update'];
@@ -225,8 +225,13 @@ function cron_poll_contacts($argc, $argv) {
 						}
 						break;
 					case 1:
-					default:
 						if (datetime_convert('UTC', 'UTC', 'now') > datetime_convert('UTC', 'UTC', $t . " + 1 hour")) {
+							$update = true;
+						}
+						break;
+					case 0:
+					default:
+						if (datetime_convert('UTC', 'UTC', 'now') > datetime_convert('UTC', 'UTC', $t . " + 15 minute")) {
 							$update = true;
 						}
 						break;

--- a/include/cron.php
+++ b/include/cron.php
@@ -122,6 +122,8 @@ function cron_poll_contacts($argc, $argv) {
 		$force     = true;
 	}
 
+	$min_poll_interval = Config::get('system', 'min_poll_interval', 1);
+
 	$sql_extra = (($manual_id) ? " AND `id` = $manual_id " : "");
 
 	reload_plugins();
@@ -231,7 +233,7 @@ function cron_poll_contacts($argc, $argv) {
 						break;
 					case 0:
 					default:
-						if (datetime_convert('UTC', 'UTC', 'now') > datetime_convert('UTC', 'UTC', $t . " + 15 minute")) {
+						if (datetime_convert('UTC', 'UTC', 'now') > datetime_convert('UTC', 'UTC', $t . " + ".$min_poll_interval." minute")) {
 							$update = true;
 						}
 						break;

--- a/include/items.php
+++ b/include/items.php
@@ -2076,7 +2076,7 @@ function item_expire($uid, $days, $network = "", $force = false) {
 		drop_item($item['id'], false);
 	}
 
-	proc_run(PRIORITY_HIGH, "include/notifier.php", "expire", $uid);
+	proc_run(PRIORITY_LOW, "include/notifier.php", "expire", $uid);
 
 }
 
@@ -2099,7 +2099,7 @@ function drop_items($items) {
 	// multiple threads may have been deleted, send an expire notification
 
 	if ($uid) {
-		proc_run(PRIORITY_HIGH, "include/notifier.php", "expire", $uid);
+		proc_run(PRIORITY_LOW, "include/notifier.php", "expire", $uid);
 	}
 }
 
@@ -2290,11 +2290,15 @@ function drop_item($id, $interactive = true) {
 			}
 		}
 
-		$drop_id = intval($item['id']);
+		// send the notification upstream/downstream when it is one of our posts
+		// We don't have to do this for foreign posts
+		/// @todo Check if we still can delete foreign comments on our own post
+		if ($item['wall'] OR $item['origin']) {
+			$drop_id = intval($item['id']);
+			$priority = ($interactive ? PRIORITY_HIGH : PRIORITY_LOW);
 
-		// send the notification upstream/downstream as the case may be
-
-		proc_run(PRIORITY_HIGH, "include/notifier.php", "drop", $drop_id);
+			proc_run($priority, "include/notifier.php", "drop", $drop_id);
+		}
 
 		if (! $interactive) {
 			return $owner;

--- a/include/items.php
+++ b/include/items.php
@@ -2290,15 +2290,12 @@ function drop_item($id, $interactive = true) {
 			}
 		}
 
-		// send the notification upstream/downstream when it is one of our posts
-		// We don't have to do this for foreign posts
-		/// @todo Check if we still can delete foreign comments on our own post
-		if ($item['wall'] OR $item['origin']) {
-			$drop_id = intval($item['id']);
-			$priority = ($interactive ? PRIORITY_HIGH : PRIORITY_LOW);
+		// send the notification upstream/downstream
+		// The priority depends on how the deletion is done.
+		$drop_id = intval($item['id']);
+		$priority = ($interactive ? PRIORITY_HIGH : PRIORITY_LOW);
 
-			proc_run($priority, "include/notifier.php", "drop", $drop_id);
-		}
+		proc_run($priority, "include/notifier.php", "drop", $drop_id);
 
 		if (! $interactive) {
 			return $owner;

--- a/include/notifier.php
+++ b/include/notifier.php
@@ -58,7 +58,7 @@ function notifier_run(&$argv, &$argc){
 	// Inherit the priority
 	$queue = dba::select('workerqueue', array('priority'), array('pid' => getmypid()), array('limit' => 1));
 	if (dbm::is_result($queue)) {
-		$priority = $queue['priority'];
+		$priority = (int)$queue['priority'];
 		logger('inherited priority: '.$priority);
 	} else {
 		// Normally this shouldn't happen.


### PR DESCRIPTION
On squeet.me I activated the expiration of items on many of my bot accounts. This created a problem with the queue handling. Currently my system has more than 300k entries in the workerqueue table. This created the problem that no messages were sent out - until the 300k entries had been handled, which will last several days.

The priority handling is now improved so that automated deletions are done with low priority. Additionally one can configure am minimal poll interval so that especially on servers with many bots the amount of new entries in the workerqueue will be reduced.

I consider this is an issue for the RC.