### PR TITLE
Bugfix: pubsubpublish has always to be called with high priority

### DIFF
--- a/include/notifier.php
+++ b/include/notifier.php
@@ -603,7 +603,7 @@ function notifier_run(&$argv, &$argc){
 		}
 
 		// Handling the pubsubhubbub requests
-		proc_run($priority, 'include/pubsubpublish.php');
+		proc_run(PRIORITY_HIGH, 'include/pubsubpublish.php');
 	}
 
 	logger('notifier: calling hooks', LOGGER_DEBUG);


### PR DESCRIPTION
"pubsubpublish" isn't called for a specific item or action. This means that we mustn't call it with different priorities.