### PR TITLE
The database structure is now checked ad the admin summary page

### DIFF
--- a/include/dbstructure.php
+++ b/include/dbstructure.php
@@ -8,6 +8,10 @@ require_once("include/text.php");
 
 define('NEW_UPDATE_ROUTINE_VERSION', 1170);
 
+const DB_UPDATE_NOT_CHECKED = 0; // Database check wasn't executed before
+const DB_UPDATE_SUCCESSFUL = 1;  // Database check was successful
+const DB_UPDATE_FAILED = 2;      // Database check failed
+
 /*
  * Converts all tables from MyISAM to InnoDB
  */
@@ -478,6 +482,12 @@ function update_structure($verbose, $action, $tables=null, $definition=null) {
 	if ($action) {
 		Config::set('system', 'maintenance', 0);
 		Config::set('system', 'maintenance_reason', '');
+	}
+
+	if ($errors) {
+		Config::set('system', 'dbupdate', DB_UPDATE_FAILED);
+	} else {
+		Config::set('system', 'dbupdate', DB_UPDATE_SUCCESSFUL);
 	}
 
 	return $errors;

--- a/mod/admin.php
+++ b/mod/admin.php
@@ -545,11 +545,16 @@ function admin_page_summary(App $a) {
 		$showwarning = true;
 		$warningtext[] = sprintf(t('Your DB still runs with MyISAM tables. You should change the engine type to InnoDB. As Friendica will use InnoDB only features in the future, you should change this! See <a href="%s">here</a> for a guide that may be helpful converting the table engines. You may also use the command <tt>php include/dbstructure.php toinnodb</tt> of your Friendica installation for an automatic conversion.<br />'), 'https://dev.mysql.com/doc/refman/5.7/en/converting-tables-to-innodb.html');
 	}
-	// MySQL >= 5.7.4 doesn't support the IGNORE keyword in ALTER TABLE statements
-	if ((version_compare($db->server_info(), '5.7.4') >= 0) AND
-		!(strpos($db->server_info(), 'MariaDB') !== false)) {
-		$warningtext[] = t('You are using a MySQL version which does not support all features that Friendica uses. You should consider switching to MariaDB.');
+
+	if (Config::get('system', 'dbupdate', DB_UPDATE_NOT_CHECKED) == DB_UPDATE_NOT_CHECKED) {
+		require_once("include/dbstructure.php");
+		update_structure(false, true);
 	}
+	if (Config::get('system', 'dbupdate') == DB_UPDATE_FAILED) {
+		$showwarning = true;
+		$warningtext[] = t('The database update failed. Please run "php include/dbstructure.php update" from the command line and have a look at the errors that might appear.');
+	}
+
 	$r = q("SELECT `page-flags`, COUNT(`uid`) AS `count` FROM `user` GROUP BY `page-flags`");
 	$accounts = array(
 		array(t('Normal Account'), 0),


### PR DESCRIPTION
This should help with recognizing failed updates. Additionally the check for newer MySQL versions is removed since we now support them better.