### PR TITLE
Bugfix: The poller often couldn't store the pid in the workerqueue

### DIFF
--- a/mod/worker.php
+++ b/mod/worker.php
@@ -41,10 +41,14 @@ function worker_init($a){
 		// But since it doesn't destroy anything, we just try to get more execution time in any way.
 		set_time_limit(0);
 
-		poller_execute($r[0]);
+		if (poller_claim_process($r[0])) {
+			poller_execute($r[0]);
+		}
 	}
 
 	call_worker();
+
+	poller_unclaim_process();
 
 	$a->end_process();
 


### PR DESCRIPTION
This avoids this error:

> [DEBUG]:poller.php:604:poller_claim_process	Entry for queue item xxx wasn't stored - skip this execution

This should speed up the poller execution as well.