### PR TITLE
Bugfix: don't probe for introduction if it is not necessary

### DIFF
--- a/include/NotificationsManager.php
+++ b/include/NotificationsManager.php
@@ -850,13 +850,13 @@ class NotificationsManager {
 		// get the missing data data from other sources
 		if ($arr['gnetwork'] == "" || $arr['gaddr'] == "") {
 			$ret = get_contact_details_by_url($arr['url']);
-		}
 
-		if ($arr['gnetwork'] == "") {
-			$arr['gnetwork'] = $ret['network'];
-		}
-		if ($arr['gaddr'] == "") {
-			$arr['gaddr'] = $ret['addr'];
+			if ($arr['gnetwork'] == "" && $ret['network'] != "") {
+				$arr['gnetwork'] = $ret['network'];
+			}
+			if ($arr['gaddr'] == "" && $ret['addr'] != "") {
+				$arr['gaddr'] = $ret['addr'];
+			}
 		}
 
 		return $arr;

--- a/include/NotificationsManager.php
+++ b/include/NotificationsManager.php
@@ -5,12 +5,11 @@
  *  or for formatting notifications
  */
 
-use Friendica\Network\Probe;
-
 require_once 'include/html2plain.php';
 require_once 'include/probe.php';
 require_once 'include/datetime.php';
 require_once 'include/bbcode.php';
+require_once 'include/Contact.php';
 
 /**
  * @brief Methods for read and write notifications from/to database
@@ -847,10 +846,10 @@ class NotificationsManager {
 			$arr['gaddr'] = $arr['addr'];
 		}
 
-		// If the network and addr is still not available try to probe
-		// the contact url to fetch the missing data
+		// If the network and addr is still not available
+		// get the missing data data from other sources
 		if ($arr['gnetwork'] == "" || $arr['gaddr'] == "") {
-			$ret = Probe::uri($arr["url"]);
+			$ret = get_contact_details_by_url($arr['url']);
 		}
 
 		if ($arr['gnetwork'] == "") {

--- a/include/NotificationsManager.php
+++ b/include/NotificationsManager.php
@@ -4,6 +4,9 @@
  * @brief Methods for read and write notifications from/to database
  *  or for formatting notifications
  */
+
+use Friendica\Network\Probe;
+
 require_once 'include/html2plain.php';
 require_once 'include/probe.php';
 require_once 'include/datetime.php';
@@ -847,7 +850,7 @@ class NotificationsManager {
 		// If the network and addr is still not available try to probe
 		// the contact url to fetch the missing data
 		if ($arr['gnetwork'] == "" || $arr['gaddr'] == "") {
-			$ret = probe_url($arr["url"]);
+			$ret = Probe::uri($arr["url"]);
 		}
 
 		if ($arr['gnetwork'] == "") {


### PR DESCRIPTION
when visiting the `notifications/intros` a `probe_url()` was done for every intro contact.
This PR changes the behavior a little bit to the following.
- If data is missing in the `gcontact` table entry, add additional data from the `contact` table entry
- If data is still missing do a `probe_url()` to fetch the missing data