### PR TITLE
CURLE_OPERATION_TIMEDOUT isn't defined on older PHP versions

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -40,7 +40,7 @@ define ( 'FRIENDICA_PLATFORM',     'Friendica');
 define ( 'FRIENDICA_CODENAME',     'Asparagus');
 define ( 'FRIENDICA_VERSION',      '3.5.2-rc' );
 define ( 'DFRN_PROTOCOL_VERSION',  '2.23'    );
-define ( 'DB_UPDATE_VERSION',      1226      );
+define ( 'DB_UPDATE_VERSION',      1227      );
 
 /**
  * @brief Constant with a HTML line break.
@@ -457,6 +457,13 @@ if (!defined("SIGTERM")) {
 	define("SIGTERM", 15);
 }
 
+/**
+ * Depending on the PHP version this constant does exist - or not.
+ * See here: http://php.net/manual/en/curl.constants.php#117928
+ */
+if (!defined('CURLE_OPERATION_TIMEDOUT')) {
+        define('CURLE_OPERATION_TIMEDOUT', CURLE_OPERATION_TIMEOUTED);
+}
 /**
  *
  * Reverse the effect of magic_quotes_gpc if it is enabled.

--- a/database.sql
+++ b/database.sql
@@ -1,6 +1,6 @@
 -- ------------------------------------------
 -- Friendica 3.5.2-rc (Asparagus)
--- DB_UPDATE_VERSION 1226
+-- DB_UPDATE_VERSION 1227
 -- ------------------------------------------
 
 
@@ -1115,6 +1115,7 @@ CREATE TABLE IF NOT EXISTS `workerqueue` (
 	`pid` int(11) NOT NULL DEFAULT 0,
 	`executed` datetime NOT NULL DEFAULT '0001-01-01 00:00:00',
 	 PRIMARY KEY(`id`),
+	 INDEX `pid` (`pid`),
 	 INDEX `priority_created` (`priority`,`created`)
 ) DEFAULT COLLATE utf8mb4_general_ci;
 

--- a/include/dbstructure.php
+++ b/include/dbstructure.php
@@ -1742,6 +1742,7 @@ function db_definition() {
 					),
 			"indexes" => array(
 					"PRIMARY" => array("id"),
+					"pid" => array("pid"),
 					"priority_created" => array("priority", "created"),
 					)
 			);

--- a/include/poller.php
+++ b/include/poller.php
@@ -545,7 +545,7 @@ function poller_worker_process() {
 	$highest_priority = 0;
 
 	if (poller_passing_slow($highest_priority)) {
-		dba::p('LOCK TABLES `workerqueue` WRITE');
+		dba::e('LOCK TABLES `workerqueue` WRITE');
 
 		// Are there waiting processes with a higher priority than the currently highest?
 		$r = q("SELECT * FROM `workerqueue`
@@ -567,7 +567,7 @@ function poller_worker_process() {
 			return $r;
 		}
 	} else {
-		dba::p('LOCK TABLES `workerqueue` WRITE');
+		dba::e('LOCK TABLES `workerqueue` WRITE');
 	}
 
 	// If there is no result (or we shouldn't pass lower processes) we check without priority limit
@@ -577,7 +577,7 @@ function poller_worker_process() {
 
 	// We only unlock the tables here, when we got no data
 	if (!dbm::is_result($r)) {
-		dba::p('UNLOCK TABLES');
+		dba::e('UNLOCK TABLES');
 	}
 
 	return $r;
@@ -597,7 +597,7 @@ function poller_claim_process($queue) {
 
 	$success = dba::update('workerqueue', array('executed' => datetime_convert(), 'pid' => $mypid),
 			array('id' => $queue["id"], 'pid' => 0));
-	dba::p('UNLOCK TABLES');
+	dba::e('UNLOCK TABLES');
 
 	if (!$success) {
 		logger("Couldn't update queue entry ".$queue["id"]." - skip this execution", LOGGER_DEBUG);

--- a/update.php
+++ b/update.php
@@ -1,6 +1,6 @@
 <?php
 
-define('UPDATE_VERSION' , 1226);
+define('UPDATE_VERSION' , 1227);
 
 /**
  *


### PR DESCRIPTION
See here for an explanation: http://php.net/manual/en/curl.constants.php#117928

This finally fixes this issue: https://helpers.pyxis.uberspace.de/display/ef2be267145921cd1057612000222176

Additionally there is a small additional speed fix for the worker.