### PR TITLE
The index mustn't be 192 characters long

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -41,7 +41,7 @@ define ( 'FRIENDICA_PLATFORM',     'Friendica');
 define ( 'FRIENDICA_CODENAME',     'Asparagus');
 define ( 'FRIENDICA_VERSION',      '3.5.3-dev' );
 define ( 'DFRN_PROTOCOL_VERSION',  '2.23'    );
-define ( 'DB_UPDATE_VERSION',      1228      );
+define ( 'DB_UPDATE_VERSION',      1229      );
 
 /**
  * @brief Constant with a HTML line break.

--- a/include/dbstructure.php
+++ b/include/dbstructure.php
@@ -1743,7 +1743,7 @@ function db_definition() {
 			"indexes" => array(
 					"PRIMARY" => array("id"),
 					"pid" => array("pid"),
-					"parameter" => array("parameter(192)"),
+					"parameter" => array("parameter(64)"),
 					"priority_created" => array("priority", "created"),
 					)
 			);

--- a/update.php
+++ b/update.php
@@ -1,6 +1,6 @@
 <?php
 
-define('UPDATE_VERSION' , 1228);
+define('UPDATE_VERSION' , 1229);
 
 /**
  *


### PR DESCRIPTION
For technical reasons an index mustn't be 192 characters long. And 64 characters is better because most values are shorter than that