### PR TITLE
Increase the page load speed with Frio

### DIFF
--- a/include/acl_selectors.php
+++ b/include/acl_selectors.php
@@ -388,13 +388,9 @@ function populate_acl($user = null, $show_jotnets = false) {
 }
 
 function construct_acl_data(App $a, $user) {
-
-	$arr = array('user' => $user);
-	call_hooks('construct_acl_data', $arr);
-
-	if (isset($arr['cancel'])) {
-		return;
-	}
+	// This function is now deactivated. It seems as if the generated data isn't used anywhere.
+	// We will remove the function completely before the release of 3.5.3 when there won't be any issues.
+	return;
 
 	// Get group and contact information for html ACL selector
 	$acl_data = acl_lookup($a, 'html');

--- a/include/acl_selectors.php
+++ b/include/acl_selectors.php
@@ -389,6 +389,13 @@ function populate_acl($user = null, $show_jotnets = false) {
 
 function construct_acl_data(App $a, $user) {
 
+	$arr = array('user' => $user);
+	call_hooks('construct_acl_data', $arr);
+
+	if (isset($arr['cancel'])) {
+		return;
+	}
+
 	// Get group and contact information for html ACL selector
 	$acl_data = acl_lookup($a, 'html');
 

--- a/include/acl_selectors.php
+++ b/include/acl_selectors.php
@@ -389,7 +389,7 @@ function populate_acl($user = null, $show_jotnets = false) {
 
 function construct_acl_data(App $a, $user) {
 	// This function is now deactivated. It seems as if the generated data isn't used anywhere.
-	// We will remove the function completely before the release of 3.5.3 when there won't be any issues.
+	/// @todo Remove this function and all function calls before releasing Friendica 3.5.3
 	return;
 
 	// Get group and contact information for html ACL selector

--- a/view/theme/frio/theme.php
+++ b/view/theme/frio/theme.php
@@ -48,7 +48,6 @@ function frio_install() {
 	register_hook('contact_photo_menu', 'view/theme/frio/theme.php', 'frio_contact_photo_menu');
 	register_hook('nav_info', 'view/theme/frio/theme.php', 'frio_remote_nav');
 	register_hook('acl_lookup_end', 'view/theme/frio/theme.php', 'frio_acl_lookup');
-	register_hook('construct_acl_data', 'view/theme/frio/theme.php', 'frio_construct_acl_data');
 
 	logger("installed theme frio");
 }
@@ -59,7 +58,6 @@ function frio_uninstall() {
 	unregister_hook('contact_photo_menu', 'view/theme/frio/theme.php', 'frio_contact_photo_menu');
 	unregister_hook('nav_info', 'view/theme/frio/theme.php', 'frio_remote_nav');
 	unregister_hook('acl_lookup_end', 'view/theme/frio/theme.php', 'frio_acl_lookup');
-	unregister_hook('construct_acl_data', 'view/theme/frio/theme.php', 'frio_construct_acl_data');
 
 	logger("uninstalled theme frio");
 }
@@ -322,16 +320,4 @@ function frio_acl_lookup(App $a, &$results) {
 		$results["items"] = $contacts;
 		$results["tot"] = $total;
 	}
-}
-
-/**
- * @brief: Deactivate the old style acl selector
- *
- * We don't need the old one for Frio. Deactivating makes page loading much faster
- *
- * @param App $a The app data @TODO Unused
- * @param array $arr We use this array to stop processing. See construct_acl_data in include/acl_selectors.php
- */
-function frio_construct_acl_data(App $a, &$arr) {
-	$arr['cancel'] = true;
 }

--- a/view/theme/frio/theme.php
+++ b/view/theme/frio/theme.php
@@ -48,6 +48,7 @@ function frio_install() {
 	register_hook('contact_photo_menu', 'view/theme/frio/theme.php', 'frio_contact_photo_menu');
 	register_hook('nav_info', 'view/theme/frio/theme.php', 'frio_remote_nav');
 	register_hook('acl_lookup_end', 'view/theme/frio/theme.php', 'frio_acl_lookup');
+	register_hook('construct_acl_data', 'view/theme/frio/theme.php', 'frio_construct_acl_data');
 
 	logger("installed theme frio");
 }
@@ -58,6 +59,7 @@ function frio_uninstall() {
 	unregister_hook('contact_photo_menu', 'view/theme/frio/theme.php', 'frio_contact_photo_menu');
 	unregister_hook('nav_info', 'view/theme/frio/theme.php', 'frio_remote_nav');
 	unregister_hook('acl_lookup_end', 'view/theme/frio/theme.php', 'frio_acl_lookup');
+	unregister_hook('construct_acl_data', 'view/theme/frio/theme.php', 'frio_construct_acl_data');
 
 	logger("uninstalled theme frio");
 }
@@ -320,4 +322,16 @@ function frio_acl_lookup(App $a, &$results) {
 		$results["items"] = $contacts;
 		$results["tot"] = $total;
 	}
+}
+
+/**
+ * @brief: Deactivate the old style acl selector
+ *
+ * We don't need the old one for Frio. Deactivating makes page loading much faster
+ *
+ * @param App $a The app data @TODO Unused
+ * @param array $arr We use this array to stop processing. See construct_acl_data in include/acl_selectors.php
+ */
+function frio_construct_acl_data(App $a, &$arr) {
+	$arr['cancel'] = true;
 }


### PR DESCRIPTION
Frio doesn't use the value that is generated by ```construct_acl_data```. The generation of this data can be slow (on my machine sometimes a second). We deactivate it now for Frio.