### PR TITLE
Replace explicit php logical operators

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -993,7 +993,7 @@ function notice($s) {
 function info($s) {
 	$a = get_app();
 
-	if (local_user() AND get_pconfig(local_user(), 'system', 'ignore_info')) {
+	if (local_user() && get_pconfig(local_user(), 'system', 'ignore_info')) {
 		return;
 	}
 
@@ -1063,7 +1063,7 @@ function proc_run($cmd) {
 	$arr = array('args' => $args, 'run_cmd' => true);
 
 	call_hooks("proc_run", $arr);
-	if (!$arr['run_cmd'] OR ! count($args)) {
+	if (!$arr['run_cmd'] || ! count($args)) {
 		return;
 	}
 
@@ -1407,7 +1407,7 @@ function clear_cache($basepath = "", $path = "") {
 		$path = $basepath;
 	}
 
-	if (($path == "") OR (!is_dir($path))) {
+	if (($path == "") || (!is_dir($path))) {
 		return;
 	}
 
@@ -1444,7 +1444,7 @@ function get_itemcachepath() {
 	}
 
 	$itemcache = get_config('system', 'itemcache');
-	if (($itemcache != "") AND App::directory_usable($itemcache)) {
+	if (($itemcache != "") && App::directory_usable($itemcache)) {
 		return $itemcache;
 	}
 
@@ -1471,7 +1471,7 @@ function get_itemcachepath() {
  */
 function get_spoolpath() {
 	$spoolpath = get_config('system', 'spoolpath');
-	if (($spoolpath != "") AND App::directory_usable($spoolpath)) {
+	if (($spoolpath != "") && App::directory_usable($spoolpath)) {
 		// We have a spool path and it is usable
 		return $spoolpath;
 	}
@@ -1506,7 +1506,7 @@ function get_temppath() {
 
 	$temppath = get_config("system", "temppath");
 
-	if (($temppath != "") AND App::directory_usable($temppath)) {
+	if (($temppath != "") && App::directory_usable($temppath)) {
 		// We have a temp path and it is usable
 		return $temppath;
 	}
@@ -1515,7 +1515,7 @@ function get_temppath() {
 	$temppath = sys_get_temp_dir();
 
 	// Check if it is usable
-	if (($temppath != "") AND App::directory_usable($temppath)) {
+	if (($temppath != "") && App::directory_usable($temppath)) {
 		// To avoid any interferences with other systems we create our own directory
 		$new_temppath = $temppath . "/" . $a->get_hostname();
 		if (!is_dir($new_temppath)) {
@@ -1638,7 +1638,7 @@ function argv($x) {
 function infinite_scroll_data($module) {
 
 	if (get_pconfig(local_user(), 'system', 'infinite_scroll')
-		AND ($module == "network") AND ($_GET["mode"] != "minimal")) {
+		&& ($module == "network") && ($_GET["mode"] != "minimal")) {
 
 		// get the page number
 		if (is_string($_GET["page"])) {
@@ -1651,12 +1651,12 @@ function infinite_scroll_data($module) {
 
 		// try to get the uri from which we load the content
 		foreach ($_GET AS $param => $value) {
-			if (($param != "page") AND ($param != "q")) {
+			if (($param != "page") && ($param != "q")) {
 				$reload_uri .= "&" . $param . "=" . urlencode($value);
 			}
 		}
 
-		if (($a->page_offset != "") AND ! strstr($reload_uri, "&offset=")) {
+		if (($a->page_offset != "") && ! strstr($reload_uri, "&offset=")) {
 			$reload_uri .= "&offset=" . urlencode($a->page_offset);
 		}
 

--- a/boot.php
+++ b/boot.php
@@ -1424,10 +1424,10 @@ function clear_cache($basepath = "", $path = "") {
 		if ($dh = opendir($path)) {
 			while (($file = readdir($dh)) !== false) {
 				$fullpath = $path . "/" . $file;
-				if ((filetype($fullpath) == "dir") and ($file != ".") and ($file != "..")) {
+				if ((filetype($fullpath) == "dir") && ($file != ".") && ($file != "..")) {
 					clear_cache($basepath, $fullpath);
 				}
-				if ((filetype($fullpath) == "file") and (filectime($fullpath) < (time() - $cachetime))) {
+				if ((filetype($fullpath) == "file") && (filectime($fullpath) < (time() - $cachetime))) {
 					unlink($fullpath);
 				}
 			}

--- a/doc/Developers-Intro.md
+++ b/doc/Developers-Intro.md
@@ -64,6 +64,7 @@ Here's a few primers if you are new to Friendica or to the PSR-2 coding standard
  * By default, strings are enclosed in single quotes, but feel free to use double quotes if it makes more sense (SQL queries, adding tabs and line feeds).
  * Operators are wrapped by spaces, e.g. `$var === true`, `$var = 1 + 2` and `'string' . $concat . 'enation'`
  * Braces are mandatory in conditions
+ * Boolean operators are `&&` and `||` for PHP conditions, `AND` and `OR` for SQL queries
  * No closing PHP tag
  * No trailing spaces
 

--- a/include/Contact.php
+++ b/include/Contact.php
@@ -262,33 +262,33 @@ function get_contact_details_by_url($url, $uid = -1, $default = array()) {
 		$profile = $default;
 	}
 
-	if (($profile["photo"] == "") AND isset($default["photo"])) {
+	if (($profile["photo"] == "") && isset($default["photo"])) {
 		$profile["photo"] = $default["photo"];
 	}
 
-	if (($profile["name"] == "") AND isset($default["name"])) {
+	if (($profile["name"] == "") && isset($default["name"])) {
 		$profile["name"] = $default["name"];
 	}
 
-	if (($profile["network"] == "") AND isset($default["network"])) {
+	if (($profile["network"] == "") && isset($default["network"])) {
 		$profile["network"] = $default["network"];
 	}
 
-	if (($profile["thumb"] == "") AND isset($profile["photo"])) {
+	if (($profile["thumb"] == "") && isset($profile["photo"])) {
 		$profile["thumb"] = $profile["photo"];
 	}
 
-	if (($profile["micro"] == "") AND isset($profile["thumb"])) {
+	if (($profile["micro"] == "") && isset($profile["thumb"])) {
 		$profile["micro"] = $profile["thumb"];
 	}
 
-	if ((($profile["addr"] == "") OR ($profile["name"] == "")) AND ($profile["gid"] != 0) AND
+	if ((($profile["addr"] == "") || ($profile["name"] == "")) && ($profile["gid"] != 0) &&
 		in_array($profile["network"], array(NETWORK_DFRN, NETWORK_DIASPORA, NETWORK_OSTATUS))) {
 		proc_run(PRIORITY_LOW, "include/update_gcontact.php", $profile["gid"]);
 	}
 
 	// Show contact details of Diaspora contacts only if connected
-	if (($profile["cid"] == 0) AND ($profile["network"] == NETWORK_DIASPORA)) {
+	if (($profile["cid"] == 0) && ($profile["network"] == NETWORK_DIASPORA)) {
 		$profile["location"] = "";
 		$profile["about"] = "";
 		$profile["gender"] = "";
@@ -559,7 +559,7 @@ function get_contact($url, $uid = 0, $no_update = false) {
 		// Update the contact every 7 days
 		$update_photo = ($contacts[0]['avatar-date'] < datetime_convert('','','now -7 days'));
 
-		if (!$update_photo OR $no_update) {
+		if (!$update_photo || $no_update) {
 			return $contact_id;
 		}
 	} elseif ($uid != 0) {
@@ -636,7 +636,7 @@ function get_contact($url, $uid = 0, $no_update = false) {
 		}
 	}
 
-	if (count($contacts) > 1 AND $uid == 0 AND $contact_id != 0 AND $url != "") {
+	if (count($contacts) > 1 && $uid == 0 && $contact_id != 0 && $url != "") {
 		q("DELETE FROM `contact` WHERE `nurl` = '%s' AND `id` != %d AND NOT `self`",
 			dbesc(normalise_link($url)),
 			intval($contact_id));
@@ -654,9 +654,9 @@ function get_contact($url, $uid = 0, $no_update = false) {
 	}
 
 	// Only update if there had something been changed
-	if ($data["addr"] != $contacts[0]["addr"] OR
-		$data["alias"] != $contacts[0]["alias"] OR
-		$data["name"] != $contacts[0]["name"] OR
+	if ($data["addr"] != $contacts[0]["addr"] ||
+		$data["alias"] != $contacts[0]["alias"] ||
+		$data["name"] != $contacts[0]["name"] ||
 		$data["nick"] != $contacts[0]["nick"]) {
 		q("UPDATE `contact` SET `addr` = '%s', `alias` = '%s', `name` = '%s', `nick` = '%s',
 			`name-date` = '%s', `uri-date` = '%s' WHERE `id` = %d",
@@ -769,7 +769,7 @@ function formatted_location($profile) {
 	if($profile['locality'])
 		$location .= $profile['locality'];
 
-	if($profile['region'] AND ($profile['locality'] != $profile['region'])) {
+	if($profile['region'] && ($profile['locality'] != $profile['region'])) {
 		if($location)
 			$location .= ', ';
 

--- a/include/NotificationsManager.php
+++ b/include/NotificationsManager.php
@@ -512,7 +512,7 @@ class NotificationsManager {
 		$myurl = substr($myurl,strpos($myurl,'://')+3);
 		$myurl = str_replace(array('www.','.'),array('','\\.'),$myurl);
 		$diasp_url = str_replace('/profile/','/u/',$myurl);
-		$sql_extra = sprintf(" AND ( `item`.`author-link` regexp '%s' or `item`.`tag` regexp '%s' or `item`.`tag` regexp '%s' ) ",
+		$sql_extra = sprintf(" AND ( `item`.`author-link` regexp '%s' OR `item`.`tag` regexp '%s' OR `item`.`tag` regexp '%s' ) ",
 			dbesc($myurl . '$'),
 			dbesc($myurl . '\\]'),
 			dbesc($diasp_url . '\\]')
@@ -829,11 +829,11 @@ class NotificationsManager {
 	}
 
 	/**
-	 * @brief Check for missing contact data and try to fetch the data from 
+	 * @brief Check for missing contact data and try to fetch the data from
 	 *     from other sources
-	 * 
+	 *
 	 * @param array $arr The input array with the intro data
-	 * 
+	 *
 	 * @return array The array with the intro data
 	 */
 	private function getMissingIntroData($arr) {

--- a/include/Photo.php
+++ b/include/Photo.php
@@ -785,7 +785,7 @@ function update_contact_avatar($avatar, $uid, $cid, $force = false) {
 		$data = array($r[0]["photo"], $r[0]["thumb"], $r[0]["micro"]);
 	}
 
-	if (($r[0]["avatar"] != $avatar) OR $force) {
+	if (($r[0]["avatar"] != $avatar) || $force) {
 		$photos = import_profile_photo($avatar, $uid, $cid, true);
 
 		if ($photos) {
@@ -825,7 +825,7 @@ function import_profile_photo($photo, $uid, $cid, $quit_on_error = false) {
 	$filename = basename($photo);
 	$img_str = fetch_url($photo, true);
 
-	if ($quit_on_error AND ($img_str == "")) {
+	if ($quit_on_error && ($img_str == "")) {
 		return false;
 	}
 
@@ -883,7 +883,7 @@ function import_profile_photo($photo, $uid, $cid, $quit_on_error = false) {
 		$photo_failure = true;
 	}
 
-	if ($photo_failure AND $quit_on_error) {
+	if ($photo_failure && $quit_on_error) {
 		return false;
 	}
 
@@ -902,7 +902,7 @@ function get_photo_info($url) {
 
 	$data = Cache::get($url);
 
-	if (is_null($data) OR !$data OR !is_array($data)) {
+	if (is_null($data) || !$data || !is_array($data)) {
 		$img_str = fetch_url($url, true, $redirects, 4);
 		$filesize = strlen($img_str);
 
@@ -996,7 +996,7 @@ function store_photo(App $a, $uid, $imagedata = "", $url = "") {
 	/// $default_cid      = $r[0]['id'];
 	/// $community_page   = (($r[0]['page-flags'] == PAGE_COMMUNITY) ? true : false);
 
-	if ((strlen($imagedata) == 0) AND ($url == "")) {
+	if ((strlen($imagedata) == 0) && ($url == "")) {
 		logger("No image data and no url provided", LOGGER_DEBUG);
 		return(array());
 	} elseif (strlen($imagedata) == 0) {
@@ -1102,7 +1102,7 @@ function store_photo(App $a, $uid, $imagedata = "", $url = "") {
 		}
 	}
 
-	if ($width > 160 AND $height > 160) {
+	if ($width > 160 && $height > 160) {
 		$x = 0;
 		$y = 0;
 

--- a/include/acl_selectors.php
+++ b/include/acl_selectors.php
@@ -209,7 +209,7 @@ function contact_select($selname, $selclass, $preselected = false, $size = 4, $p
 
 	$tabindex = ($tabindex > 0 ? "tabindex=\"$tabindex\"" : "");
 
-	if ($privmail AND $preselected) {
+	if ($privmail && $preselected) {
 		$sql_extra .= " AND `id` IN (".implode(",", $preselected).")";
 		$hidepreselected = ' style="display: none;"';
 	} else {
@@ -261,7 +261,7 @@ function contact_select($selname, $selclass, $preselected = false, $size = 4, $p
 
 	$o .= "</select>\r\n";
 
-	if ($privmail AND $preselected) {
+	if ($privmail && $preselected) {
 		$o .= implode(", ", $receiverlist);
 	}
 

--- a/include/api.php
+++ b/include/api.php
@@ -483,7 +483,7 @@ $called_api = null;
 		logger("api_get_user: Fetching user data for user ".$contact_id, LOGGER_DEBUG);
 
 		// Searching for contact URL
-		if (!is_null($contact_id) AND (intval($contact_id) == 0)) {
+		if (!is_null($contact_id) && (intval($contact_id) == 0)) {
 			$user = dbesc(normalise_link($contact_id));
 			$url = $user;
 			$extra_query = "AND `contact`.`nurl` = '%s' ";
@@ -493,7 +493,7 @@ $called_api = null;
 		}
 
 		// Searching for contact id with uid = 0
-		if (!is_null($contact_id) AND (intval($contact_id) != 0)) {
+		if (!is_null($contact_id) && (intval($contact_id) != 0)) {
 			$user = dbesc(api_unique_id_to_url($contact_id));
 
 			if ($user == "") {
@@ -538,7 +538,7 @@ $called_api = null;
 			}
 		}
 
-		if (is_null($user) AND ($a->argc > (count($called_api) - 1)) AND (count($called_api) > 0)) {
+		if (is_null($user) && ($a->argc > (count($called_api) - 1)) && (count($called_api) > 0)) {
 			$argid = count($called_api);
 			list($user, $null) = explode(".", $a->argv[$argid]);
 			if (is_numeric($user)) {
@@ -600,7 +600,7 @@ $called_api = null;
 				$network_name = network_to_name($r[0]['network'], $r[0]['url']);
 
 				// If no nick where given, extract it from the address
-				if (($r[0]['nick'] == "") OR ($r[0]['name'] == $r[0]['nick'])) {
+				if (($r[0]['nick'] == "") || ($r[0]['name'] == $r[0]['nick'])) {
 					$r[0]['nick'] = api_get_nick($r[0]["url"]);
 				}
 
@@ -716,7 +716,7 @@ $called_api = null;
 		$starred = 0;
 
 		// Add a nick if it isn't present there
-		if (($uinfo[0]['nick'] == "") OR ($uinfo[0]['name'] == $uinfo[0]['nick'])) {
+		if (($uinfo[0]['nick'] == "") || ($uinfo[0]['name'] == $uinfo[0]['nick'])) {
 			$uinfo[0]['nick'] = api_get_nick($uinfo[0]["url"]);
 		}
 
@@ -749,7 +749,7 @@ $called_api = null;
 			'contributors_enabled' => false,
 			'is_translator' => false,
 			'is_translation_enabled' => false,
-			'following' => (($uinfo[0]['rel'] == CONTACT_IS_FOLLOWER) OR ($uinfo[0]['rel'] == CONTACT_IS_FRIEND)),
+			'following' => (($uinfo[0]['rel'] == CONTACT_IS_FOLLOWER) || ($uinfo[0]['rel'] == CONTACT_IS_FRIEND)),
 			'follow_request_sent' => false,
 			'statusnet_blocking' => false,
 			'notifications' => false,
@@ -777,10 +777,10 @@ $called_api = null;
 
 		$status_user = api_get_user($a, $item["author-link"]);
 
-		$status_user["protected"] = (($item["allow_cid"] != "") OR
-						($item["allow_gid"] != "") OR
-						($item["deny_cid"] != "") OR
-						($item["deny_gid"] != "") OR
+		$status_user["protected"] = (($item["allow_cid"] != "") ||
+						($item["allow_gid"] != "") ||
+						($item["deny_cid"] != "") ||
+						($item["deny_gid"] != "") ||
 						$item["private"]);
 
 		if ($item['thr-parent'] == $item['uri']) {
@@ -1305,9 +1305,9 @@ $called_api = null;
 				$status_info["entities"] = $converted["entities"];
 			}
 
-			if (($lastwall['item_network'] != "") AND ($status["source"] == 'web')) {
+			if (($lastwall['item_network'] != "") && ($status["source"] == 'web')) {
 				$status_info["source"] = network_to_name($lastwall['item_network'], $user_info['url']);
-			} elseif (($lastwall['item_network'] != "") AND (network_to_name($lastwall['item_network'], $user_info['url']) != $status_info["source"])) {
+			} elseif (($lastwall['item_network'] != "") && (network_to_name($lastwall['item_network'], $user_info['url']) != $status_info["source"])) {
 				$status_info["source"] = trim($status_info["source"].' ('.network_to_name($lastwall['item_network'], $user_info['url']).')');
 			}
 
@@ -1393,11 +1393,11 @@ $called_api = null;
 				$user_info["status"]["entities"] = $converted["entities"];
 			}
 
-			if (($lastwall['item_network'] != "") AND ($user_info["status"]["source"] == 'web')) {
+			if (($lastwall['item_network'] != "") && ($user_info["status"]["source"] == 'web')) {
 				$user_info["status"]["source"] = network_to_name($lastwall['item_network'], $user_info['url']);
 			}
 
-			if (($lastwall['item_network'] != "") AND (network_to_name($lastwall['item_network'], $user_info['url']) != $user_info["status"]["source"])) {
+			if (($lastwall['item_network'] != "") && (network_to_name($lastwall['item_network'], $user_info['url']) != $user_info["status"]["source"])) {
 				$user_info["status"]["source"] = trim($user_info["status"]["source"] . ' (' . network_to_name($lastwall['item_network'], $user_info['url']) . ')');
 			}
 
@@ -2289,11 +2289,11 @@ $called_api = null;
 			$statushtml = "<h4>" . bbcode($item['title']) . "</h4>\n" . $statushtml;
 		}
 
-		// feeds without body should contain the link 
-		if (($item['network'] == NETWORK_FEED) && (strlen($item['body']) == 0)) { 
-			$statushtml .= bbcode($item['plink']); 
-		} 
-		
+		// feeds without body should contain the link
+		if (($item['network'] == NETWORK_FEED) && (strlen($item['body']) == 0)) {
+			$statushtml .= bbcode($item['plink']);
+		}
+
 		$entities = api_get_entitities($statustext, $body);
 
 		return array(
@@ -2402,8 +2402,8 @@ $called_api = null;
 		$offset = 0;
 		//foreach ($urls[1] AS $id=>$url) {
 		foreach ($ordered_urls AS $url) {
-			if ((substr($url["title"], 0, 7) != "http://") AND (substr($url["title"], 0, 8) != "https://") AND
-				!strpos($url["title"], "http://") AND !strpos($url["title"], "https://"))
+			if ((substr($url["title"], 0, 7) != "http://") && (substr($url["title"], 0, 8) != "https://") &&
+				!strpos($url["title"], "http://") && !strpos($url["title"], "https://"))
 				$display_url = $url["title"];
 			else {
 				$display_url = str_replace(array("http://www.", "https://www."), array("", ""), $url["url"]);
@@ -2455,7 +2455,7 @@ $called_api = null;
 						$scale = scale_image($image[0], $image[1], 150);
 						$sizes["thumb"] = array("w" => $scale["width"], "h" => $scale["height"], "resize" => "fit");
 
-						if (($image[0] > 150) OR ($image[1] > 150)) {
+						if (($image[0] > 150) || ($image[1] > 150)) {
 							$scale = scale_image($image[0], $image[1], 340);
 							$sizes["small"] = array("w" => $scale["width"], "h" => $scale["height"], "resize" => "fit");
 						}
@@ -2463,7 +2463,7 @@ $called_api = null;
 						$scale = scale_image($image[0], $image[1], 600);
 						$sizes["medium"] = array("w" => $scale["width"], "h" => $scale["height"], "resize" => "fit");
 
-						if (($image[0] > 600) OR ($image[1] > 600)) {
+						if (($image[0] > 600) || ($image[1] > 600)) {
 							$scale = scale_image($image[0], $image[1], 1024);
 							$sizes["large"] = array("w" => $scale["width"], "h" => $scale["height"], "resize" => "fit");
 						}
@@ -2668,7 +2668,7 @@ $called_api = null;
 			list($status_user, $owner_user) = api_item_get_user($a, $item);
 
 			// Look if the posts are matching if they should be filtered by user id
-			if ($filter_user AND ($status_user["id"] != $user_info["id"])) {
+			if ($filter_user && ($status_user["id"] != $user_info["id"])) {
 				continue;
 			}
 
@@ -2712,9 +2712,9 @@ $called_api = null;
 				$status["entities"] = $converted["entities"];
 			}
 
-			if (($item['item_network'] != "") AND ($status["source"] == 'web')) {
+			if (($item['item_network'] != "") && ($status["source"] == 'web')) {
 				$status["source"] = network_to_name($item['item_network'], $user_info['url']);
-			} elseif (($item['item_network'] != "") AND (network_to_name($item['item_network'], $user_info['url']) != $status["source"])) {
+			} elseif (($item['item_network'] != "") && (network_to_name($item['item_network'], $user_info['url']) != $status["source"])) {
 				$status["source"] = trim($status["source"].' ('.network_to_name($item['item_network'], $user_info['url']).')');
 			}
 
@@ -2723,7 +2723,7 @@ $called_api = null;
 			// It doesn't work reliable with the link if its a feed
 			//$IsRetweet = ($item['owner-link'] != $item['author-link']);
 			//if ($IsRetweet)
-			//	$IsRetweet = (($item['owner-name'] != $item['author-name']) OR ($item['owner-avatar'] != $item['author-avatar']));
+			//	$IsRetweet = (($item['owner-name'] != $item['author-name']) || ($item['owner-avatar'] != $item['author-avatar']));
 
 
 			if ($item["id"] == $item["parent"]) {
@@ -3022,7 +3022,7 @@ $called_api = null;
 
 		if (api_user() === false) throw new ForbiddenException();
 
-		if (!x($_POST, "text") OR (!x($_POST,"screen_name") AND !x($_POST,"user_id"))) return;
+		if (!x($_POST, "text") || (!x($_POST,"screen_name") && !x($_POST,"user_id"))) return;
 
 		$sender = api_get_user($a);
 
@@ -4334,7 +4334,7 @@ $called_api = null;
 		$in_reply_to['user_id_str'] = NULL;
 		$in_reply_to['screen_name'] = NULL;
 
-		if (($item['thr-parent'] != $item['uri']) AND (intval($item['parent']) != intval($item['id']))) {
+		if (($item['thr-parent'] != $item['uri']) && (intval($item['parent']) != intval($item['id']))) {
 			$r = q("SELECT `id` FROM `item` WHERE `uid` = %d AND `uri` = '%s' LIMIT 1",
 				intval($item['uid']),
 				dbesc($item['thr-parent']));
@@ -4415,7 +4415,7 @@ $called_api = null;
 		if (isset($data["text"]))
 			$body = $data["text"];
 
-		if (($body == "") AND (isset($data["title"])))
+		if (($body == "") && (isset($data["title"])))
 			$body = $data["title"];
 
 		if (isset($data["url"]))

--- a/include/api.php
+++ b/include/api.php
@@ -2178,7 +2178,7 @@ $called_api = null;
 				`contact`.`id` AS `cid`
 				FROM `item`, `contact`
 				WHERE `item`.`uid` = %d
-				AND `item`.`visible` = 1 and `item`.`moderated` = 0 AND `item`.`deleted` = 0
+				AND `item`.`visible` = 1 AND `item`.`moderated` = 0 AND `item`.`deleted` = 0
 				AND `item`.`starred` = 1
 				AND `contact`.`id` = `item`.`contact-id`
 				AND (NOT `contact`.`blocked` OR `contact`.`pending`)
@@ -2263,13 +2263,13 @@ $called_api = null;
 
 		$statustitle = trim($item['title']);
 
-		if (($statustitle != '') and (strpos($statusbody, $statustitle) !== false)) {
+		if (($statustitle != '') && (strpos($statusbody, $statustitle) !== false)) {
 			$statustext = trim($statusbody);
 		} else {
 			$statustext = trim($statustitle."\n\n".$statusbody);
 		}
 
-		if (($item["network"] == NETWORK_FEED) and (strlen($statustext)> 1000)) {
+		if (($item["network"] == NETWORK_FEED) && (strlen($statustext)> 1000)) {
 			$statustext = substr($statustext, 0, 1000)."... \n".$item["plink"];
 		}
 
@@ -3982,7 +3982,7 @@ $called_api = null;
 	}
 
 	function prepare_photo_data($type, $scale, $photo_id) {
-		$scale_sql = ($scale === false ? "" : sprintf("and scale=%d", intval($scale)));
+		$scale_sql = ($scale === false ? "" : sprintf("AND scale=%d", intval($scale)));
 		$data_sql = ($scale === false ? "" : "data, ");
 
 		// added allow_cid, allow_gid, deny_cid, deny_gid to output as string like stored in database

--- a/include/auth.php
+++ b/include/auth.php
@@ -29,7 +29,7 @@ if (isset($_COOKIE["Friendica"])) {
 			new_cookie($authcookiedays*24*60*60, $r[0]);
 
 			// Do the authentification if not done by now
-			if (!isset($_SESSION) OR !isset($_SESSION['authenticated'])) {
+			if (!isset($_SESSION) || !isset($_SESSION['authenticated'])) {
 				authenticate_success($r[0]);
 
 				if (get_config('system','paranoia'))

--- a/include/auth_ejabberd.php
+++ b/include/auth_ejabberd.php
@@ -89,7 +89,7 @@ class exAuth {
 
 		// Open the logfile if the logfile name is defined
 		if ($this->sLogFile != '')
-			$this->rLogFile = fopen($this->sLogFile, "a") or die("Error opening log file: ". $this->sLogFile);
+			$this->rLogFile = fopen($this->sLogFile, "a") || die("Error opening log file: ". $this->sLogFile);
 
 		$this->writeLog("[exAuth] start");
 

--- a/include/bbcode.php
+++ b/include/bbcode.php
@@ -49,14 +49,14 @@ function bb_attachment($Text, $simplehtml = false, $tryoembed = true) {
 		$data["title"] = str_replace(array("http://", "https://"), "", $data["title"]);
 	}
 
-	if (((strpos($data["text"], "[img=") !== false) OR (strpos($data["text"], "[img]") !== false)) AND ($data["image"] != "")) {
+	if (((strpos($data["text"], "[img=") !== false) || (strpos($data["text"], "[img]") !== false)) && ($data["image"] != "")) {
 		$data["preview"] = $data["image"];
 		$data["image"] = "";
 	}
 
 	if ($simplehtml == 7) {
 		$text = style_url_for_mastodon($data["url"]);
-	} elseif (($simplehtml != 4) AND ($simplehtml != 0)) {
+	} elseif (($simplehtml != 4) && ($simplehtml != 0)) {
 		$text = sprintf('<a href="%s" target="_blank">%s</a><br>', $data["url"], $data["title"]);
 	} else {
 		$text = sprintf('<span class="type-%s">', $data["type"]);
@@ -71,13 +71,13 @@ function bb_attachment($Text, $simplehtml = false, $tryoembed = true) {
 		if (strstr(strtolower($oembed), "<iframe ")) {
 			$text = $oembed;
 		} else {
-			if (($data["image"] != "") AND !strstr(strtolower($oembed), "<img ")) {
+			if (($data["image"] != "") && !strstr(strtolower($oembed), "<img ")) {
 				$text .= sprintf('<a href="%s" target="_blank"><img src="%s" alt="" title="%s" class="attachment-image" /></a><br />', $data["url"], proxy_url($data["image"]), $data["title"]);
-			} elseif (($data["preview"] != "") AND !strstr(strtolower($oembed), "<img ")) {
+			} elseif (($data["preview"] != "") && !strstr(strtolower($oembed), "<img ")) {
 				$text .= sprintf('<a href="%s" target="_blank"><img src="%s" alt="" title="%s" class="attachment-preview" /></a><br />', $data["url"], proxy_url($data["preview"]), $data["title"]);
 			}
 
-			if (($data["type"] == "photo") AND ($data["url"] != "") AND ($data["image"] != "")) {
+			if (($data["type"] == "photo") && ($data["url"] != "") && ($data["image"] != "")) {
 				$text .= sprintf('<a href="%s" target="_blank"><img src="%s" alt="" title="%s" class="attachment-image" /></a>', $data["url"], proxy_url($data["image"]), $data["title"]);
 			} else {
 				$text .= $oembed;
@@ -103,25 +103,25 @@ function bb_remove_share_information($Text, $plaintext = false, $nolink = false)
 
 	$title = htmlentities($data["title"], ENT_QUOTES, 'UTF-8', false);
 	$text = htmlentities($data["text"], ENT_QUOTES, 'UTF-8', false);
-	if ($plaintext OR (($title != "") AND strstr($text, $title))) {
+	if ($plaintext || (($title != "") && strstr($text, $title))) {
 		$data["title"] = $data["url"];
-	} elseif (($text != "") AND strstr($title, $text)) {
+	} elseif (($text != "") && strstr($title, $text)) {
 		$data["text"] = $data["title"];
 		$data["title"] = $data["url"];
 	}
 
-	if (($data["text"] == "") AND ($data["title"] != "") AND ($data["url"] == "")) {
+	if (($data["text"] == "") && ($data["title"] != "") && ($data["url"] == "")) {
 		return $data["title"] . $data["after"];
 	}
 
 	// If the link already is included in the post, don't add it again
-	if (($data["url"] != "") AND strpos($data["text"], $data["url"])) {
+	if (($data["url"] != "") && strpos($data["text"], $data["url"])) {
 		return $data["text"] . $data["after"];
 	}
 
 	$text = $data["text"];
 
-	if (($data["url"] != "") AND ($data["title"] != "")) {
+	if (($data["url"] != "") && ($data["title"] != "")) {
 		$text .= "\n[url=" . $data["url"] . "]" . $data["title"] . "[/url]";
 	} elseif (($data["url"] != "")) {
 		$text .= "\n" . $data["url"];
@@ -167,7 +167,7 @@ function cleancss($input) {
 function bb_style_url($match) {
         $url = $match[1];
 
-	if (isset($match[2]) AND ($match[1] != $match[2])) {
+	if (isset($match[2]) && ($match[1] != $match[2])) {
 		return $match[0];
 	}
 
@@ -485,20 +485,20 @@ function bb_ShareAttributes($share, $simplehtml) {
 
 	$data = get_contact_details_by_url($profile);
 
-	if (isset($data["name"]) AND ($data["name"] != "") AND isset($data["addr"]) AND ($data["addr"] != ""))
+	if (isset($data["name"]) && ($data["name"] != "") && isset($data["addr"]) && ($data["addr"] != ""))
 	        $userid_compact = $data["name"]." (".$data["addr"].")";
 	else
 		$userid_compact = GetProfileUsername($profile,$author, true);
 
-	if (isset($data["addr"]) AND ($data["addr"] != ""))
+	if (isset($data["addr"]) && ($data["addr"] != ""))
 		$userid = $data["addr"];
 	else
 		$userid = GetProfileUsername($profile,$author, false);
 
-	if (isset($data["name"]) AND ($data["name"] != ""))
+	if (isset($data["name"]) && ($data["name"] != ""))
 		$author = $data["name"];
 
-	if (isset($data["micro"]) AND ($data["micro"] != ""))
+	if (isset($data["micro"]) && ($data["micro"] != ""))
 		$avatar = $data["micro"];
 
 	$preshare = trim($share[1]);
@@ -744,7 +744,7 @@ function bb_RemovePictureLinks($match) {
 }
 
 function bb_expand_links($match) {
-	if (($match[3] == "") OR ($match[2] == $match[3]) OR stristr($match[2], $match[3])) {
+	if (($match[3] == "") || ($match[2] == $match[3]) || stristr($match[2], $match[3])) {
 		return ($match[1] . "[url]" . $match[2] . "[/url]");
 	} else {
 		return ($match[1] . $match[3] . " [url]" . $match[2] . "[/url]");
@@ -930,7 +930,7 @@ function bbcode($Text, $preserve_nl = false, $tryoembed = true, $simplehtml = fa
 	$MAILSearchString = $URLSearchString;
 
 	// Remove all hashtag addresses
-	if ((!$tryoembed OR $simplehtml) AND !in_array($simplehtml, array(3, 7))) {
+	if ((!$tryoembed || $simplehtml) && !in_array($simplehtml, array(3, 7))) {
 		$Text = preg_replace("/([#@])\[url\=([$URLSearchString]*)\](.*?)\[\/url\]/ism", '$1$3', $Text);
 	} elseif ($simplehtml == 3) {
 		$Text = preg_replace("/([@])\[url\=([$URLSearchString]*)\](.*?)\[\/url\]/ism",
@@ -1319,7 +1319,7 @@ function bbcode($Text, $preserve_nl = false, $tryoembed = true, $simplehtml = fa
 	// Clean up the HTML by loading and saving the HTML with the DOM.
 	// Bad structured html can break a whole page.
 	// For performance reasons do it only with ativated item cache or at export.
-	if (!$tryoembed OR (get_itemcachepath() != "")) {
+	if (!$tryoembed || (get_itemcachepath() != "")) {
 		$doc = new DOMDocument();
 		$doc->preserveWhiteSpace = false;
 

--- a/include/bbcode.php
+++ b/include/bbcode.php
@@ -147,7 +147,7 @@ function cleancss($input) {
 	for ($i = 0; $i < strlen($input); $i++) {
 		$char = substr($input, $i, 1);
 
-		if (($char >= "a") and ($char <= "z")) {
+		if (($char >= "a") && ($char <= "z")) {
 			$cleaned .= $char;
 		}
 
@@ -1126,7 +1126,7 @@ function bbcode($Text, $preserve_nl = false, $tryoembed = true, $simplehtml = fa
 	// Check for [spoiler] text
 	// handle nested quotes
 	$endlessloop = 0;
-	while ((strpos($Text, "[/spoiler]") !== false) and (strpos($Text, "[spoiler]") !== false) and (++$endlessloop < 20)) {
+	while ((strpos($Text, "[/spoiler]") !== false) && (strpos($Text, "[spoiler]") !== false) && (++$endlessloop < 20)) {
 		$Text = preg_replace("/\[spoiler\](.*?)\[\/spoiler\]/ism", "$SpoilerLayout", $Text);
 	}
 
@@ -1136,7 +1136,7 @@ function bbcode($Text, $preserve_nl = false, $tryoembed = true, $simplehtml = fa
 
 	// handle nested quotes
 	$endlessloop = 0;
-	while ((strpos($Text, "[/spoiler]")!== false)  and (strpos($Text, "[spoiler=") !== false) and (++$endlessloop < 20)) {
+	while ((strpos($Text, "[/spoiler]")!== false)  && (strpos($Text, "[spoiler=") !== false) && (++$endlessloop < 20)) {
 		$Text = preg_replace("/\[spoiler=[\"\']*(.*?)[\"\']*\](.*?)\[\/spoiler\]/ism",
 				     "<br /><strong class=".'"spoiler"'.">" . $t_wrote . "</strong><blockquote class=".'"spoiler"'.">$2</blockquote>",
 				     $Text);
@@ -1148,7 +1148,7 @@ function bbcode($Text, $preserve_nl = false, $tryoembed = true, $simplehtml = fa
 	// Check for [quote] text
 	// handle nested quotes
 	$endlessloop = 0;
-	while ((strpos($Text, "[/quote]") !== false) and (strpos($Text, "[quote]") !== false) and (++$endlessloop < 20)) {
+	while ((strpos($Text, "[/quote]") !== false) && (strpos($Text, "[quote]") !== false) && (++$endlessloop < 20)) {
 		$Text = preg_replace("/\[quote\](.*?)\[\/quote\]/ism", "$QuoteLayout", $Text);
 	}
 
@@ -1158,7 +1158,7 @@ function bbcode($Text, $preserve_nl = false, $tryoembed = true, $simplehtml = fa
 
 	// handle nested quotes
 	$endlessloop = 0;
-	while ((strpos($Text, "[/quote]")!== false)  and (strpos($Text, "[quote=") !== false) and (++$endlessloop < 20)) {
+	while ((strpos($Text, "[/quote]")!== false)  && (strpos($Text, "[quote=") !== false) && (++$endlessloop < 20)) {
 		$Text = preg_replace("/\[quote=[\"\']*(.*?)[\"\']*\](.*?)\[\/quote\]/ism",
 				     "<br /><strong class=".'"author"'.">" . $t_wrote . "</strong><blockquote>$2</blockquote>",
 				     $Text);

--- a/include/cache.php
+++ b/include/cache.php
@@ -172,35 +172,35 @@ class Cache {
 			set_config("system", "cache_cleared_day", time());
 		}
 
-		if (($max_level <= CACHE_HOUR) AND (get_config("system", "cache_cleared_hour")) < time() - self::duration(CACHE_HOUR)) {
+		if (($max_level <= CACHE_HOUR) && (get_config("system", "cache_cleared_hour")) < time() - self::duration(CACHE_HOUR)) {
 			q("DELETE FROM `cache` WHERE `updated` < '%s' AND `expire_mode` = %d",
 				dbesc(datetime_convert('UTC','UTC',"now - 1 hours")), intval(CACHE_HOUR));
 
 			set_config("system", "cache_cleared_hour", time());
 		}
 
-		if (($max_level <= CACHE_HALF_HOUR) AND (get_config("system", "cache_cleared_half_hour")) < time() - self::duration(CACHE_HALF_HOUR)) {
+		if (($max_level <= CACHE_HALF_HOUR) && (get_config("system", "cache_cleared_half_hour")) < time() - self::duration(CACHE_HALF_HOUR)) {
 			q("DELETE FROM `cache` WHERE `updated` < '%s' AND `expire_mode` = %d",
 				dbesc(datetime_convert('UTC','UTC',"now - 30 minutes")), intval(CACHE_HALF_HOUR));
 
 			set_config("system", "cache_cleared_half_hour", time());
 		}
 
-		if (($max_level <= CACHE_QUARTER_HOUR) AND (get_config("system", "cache_cleared_quarter_hour")) < time() - self::duration(CACHE_QUARTER_HOUR)) {
+		if (($max_level <= CACHE_QUARTER_HOUR) && (get_config("system", "cache_cleared_quarter_hour")) < time() - self::duration(CACHE_QUARTER_HOUR)) {
 			q("DELETE FROM `cache` WHERE `updated` < '%s' AND `expire_mode` = %d",
 				dbesc(datetime_convert('UTC','UTC',"now - 15 minutes")), intval(CACHE_QUARTER_HOUR));
 
 			set_config("system", "cache_cleared_quarter_hour", time());
 		}
 
-		if (($max_level <= CACHE_FIVE_MINUTES) AND (get_config("system", "cache_cleared_five_minute")) < time() - self::duration(CACHE_FIVE_MINUTES)) {
+		if (($max_level <= CACHE_FIVE_MINUTES) && (get_config("system", "cache_cleared_five_minute")) < time() - self::duration(CACHE_FIVE_MINUTES)) {
 			q("DELETE FROM `cache` WHERE `updated` < '%s' AND `expire_mode` = %d",
 				dbesc(datetime_convert('UTC','UTC',"now - 5 minutes")), intval(CACHE_FIVE_MINUTES));
 
 			set_config("system", "cache_cleared_five_minute", time());
 		}
 
-		if (($max_level <= CACHE_MINUTE) AND (get_config("system", "cache_cleared_minute")) < time() - self::duration(CACHE_MINUTE)) {
+		if (($max_level <= CACHE_MINUTE) && (get_config("system", "cache_cleared_minute")) < time() - self::duration(CACHE_MINUTE)) {
 			q("DELETE FROM `cache` WHERE `updated` < '%s' AND `expire_mode` = %d",
 				dbesc(datetime_convert('UTC','UTC',"now - 1 minutes")), intval(CACHE_MINUTE));
 

--- a/include/contact_selectors.php
+++ b/include/contact_selectors.php
@@ -100,7 +100,7 @@ function network_to_name($s, $profile = "") {
 
 	$networkname = str_replace($search, $replace, $s);
 
-	if ((in_array($s, array(NETWORK_DFRN, NETWORK_DIASPORA, NETWORK_OSTATUS))) AND ($profile != "")) {
+	if ((in_array($s, array(NETWORK_DFRN, NETWORK_DIASPORA, NETWORK_OSTATUS))) && ($profile != "")) {
 		$r = q("SELECT `gserver`.`platform` FROM `gcontact`
 				INNER JOIN `gserver` ON `gserver`.`nurl` = `gcontact`.`server_url`
 				WHERE `gcontact`.`nurl` = '%s' AND `platform` != ''",

--- a/include/contact_widgets.php
+++ b/include/contact_widgets.php
@@ -51,7 +51,7 @@ function unavailable_networks() {
 		$networks[] = NETWORK_APPNET;
 	}
 
-	if (!plugin_enabled("fbpost") AND !plugin_enabled("facebook")) {
+	if (!plugin_enabled("fbpost") && !plugin_enabled("facebook")) {
 		$networks[] = NETWORK_FACEBOOK;
 	}
 

--- a/include/conversation.php
+++ b/include/conversation.php
@@ -712,7 +712,7 @@ function conversation(App $a, $items, $mode, $update, $preview = false) {
 					$profile_link = zrl($profile_link);
 				}
 
-				if (!x($item, 'author-thumb') OR ($item['author-thumb'] == "")) {
+				if (!x($item, 'author-thumb') || ($item['author-thumb'] == "")) {
 					$author_contact = get_contact_details_by_url($item['author-link'], $profile_owner);
 					if ($author_contact["thumb"]) {
 						$item['author-thumb'] = $author_contact["thumb"];
@@ -721,7 +721,7 @@ function conversation(App $a, $items, $mode, $update, $preview = false) {
 					}
 				}
 
-				if (!isset($item['owner-thumb']) OR ($item['owner-thumb'] == "")) {
+				if (!isset($item['owner-thumb']) || ($item['owner-thumb'] == "")) {
 					$owner_contact = get_contact_details_by_url($item['owner-link'], $profile_owner);
 					if ($owner_contact["thumb"]) {
 						$item['owner-thumb'] = $owner_contact["thumb"];
@@ -1013,7 +1013,7 @@ function item_photo_menu($item) {
 			$menu[t("Poke")] = $poke_link;
 		}
 
-		if ((($cid == 0) OR ($rel == CONTACT_IS_FOLLOWER)) AND
+		if ((($cid == 0) || ($rel == CONTACT_IS_FOLLOWER)) &&
 			in_array($item['network'], array(NETWORK_DFRN, NETWORK_OSTATUS, NETWORK_DIASPORA))) {
 			$menu[t('Connect/Follow')] = 'follow?url=' . urlencode($item['author-link']);
 		}

--- a/include/cron.php
+++ b/include/cron.php
@@ -186,7 +186,7 @@ function cron_poll_contacts($argc, $argv) {
 				$contact['priority'] = 2;
 			}
 
-			if ($contact['subhub'] AND in_array($contact['network'], array(NETWORK_DFRN, NETWORK_ZOT, NETWORK_OSTATUS))) {
+			if ($contact['subhub'] && in_array($contact['network'], array(NETWORK_DFRN, NETWORK_ZOT, NETWORK_OSTATUS))) {
 				/*
 				 * We should be getting everything via a hub. But just to be sure, let's check once a day.
 				 * (You can make this more or less frequent if desired by setting 'pushpoll_frequency' appropriately)
@@ -197,7 +197,7 @@ function cron_poll_contacts($argc, $argv) {
 				$contact['priority'] = (($poll_interval !== false) ? intval($poll_interval) : 3);
 			}
 
-			if (($contact['priority'] >= 0) AND !$force) {
+			if (($contact['priority'] >= 0) && !$force) {
 				$update = false;
 
 				$t = $contact['last-update'];
@@ -245,7 +245,7 @@ function cron_poll_contacts($argc, $argv) {
 
 			logger("Polling " . $contact["network"] . " " . $contact["id"] . " " . $contact["nick"] . " " . $contact["name"]);
 
-			if (($contact['network'] == NETWORK_FEED) AND ($contact['priority'] <= 3)) {
+			if (($contact['network'] == NETWORK_FEED) && ($contact['priority'] <= 3)) {
 				$priority = PRIORITY_MEDIUM;
 			} else {
 				$priority = PRIORITY_LOW;

--- a/include/cronhooks.php
+++ b/include/cronhooks.php
@@ -7,7 +7,7 @@ function cronhooks_run(&$argv, &$argc) {
 
 	require_once 'include/datetime.php';
 
-	if (($argc == 2) AND is_array($a->hooks) AND array_key_exists("cron", $a->hooks)) {
+	if (($argc == 2) && is_array($a->hooks) && array_key_exists("cron", $a->hooks)) {
 		foreach ($a->hooks["cron"] as $hook) {
 			if ($hook[1] == $argv[1]) {
 				logger("Calling cron hook '" . $hook[1] . "'", LOGGER_DEBUG);
@@ -38,7 +38,7 @@ function cronhooks_run(&$argv, &$argc) {
 
 	$d = datetime_convert();
 
-	if (is_array($a->hooks) AND array_key_exists("cron", $a->hooks)) {
+	if (is_array($a->hooks) && array_key_exists("cron", $a->hooks)) {
 		foreach ($a->hooks["cron"] as $hook) {
 			logger("Calling cronhooks for '" . $hook[1] . "'", LOGGER_DEBUG);
 			proc_run(PRIORITY_MEDIUM, "include/cronhooks.php", $hook[1]);

--- a/include/dba.php
+++ b/include/dba.php
@@ -117,7 +117,7 @@ class dba {
 
 	/**
 	 * @brief Returns the MySQL server version string
-	 * 
+	 *
 	 * This function discriminate between the deprecated mysql API and the current
 	 * object-oriented mysqli API. Example of returned string: 5.5.46-0+deb8u1
 	 *
@@ -183,17 +183,17 @@ class dba {
 
 		foreach ($r AS $row) {
 			if ((intval($a->config["system"]["db_loglimit_index"]) > 0)) {
-				$log = (in_array($row['key'], $watchlist) AND
+				$log = (in_array($row['key'], $watchlist) &&
 					($row['rows'] >= intval($a->config["system"]["db_loglimit_index"])));
 			} else {
 				$log = false;
 			}
 
-			if ((intval($a->config["system"]["db_loglimit_index_high"]) > 0) AND ($row['rows'] >= intval($a->config["system"]["db_loglimit_index_high"]))) {
+			if ((intval($a->config["system"]["db_loglimit_index_high"]) > 0) && ($row['rows'] >= intval($a->config["system"]["db_loglimit_index_high"]))) {
 				$log = true;
 			}
 
-			if (in_array($row['key'], $blacklist) OR ($row['key'] == "")) {
+			if (in_array($row['key'], $blacklist) || ($row['key'] == "")) {
 				$log = false;
 			}
 
@@ -363,7 +363,7 @@ class dba {
 		// PDO doesn't return "true" on successful operations - like mysqli does
 		// Emulate this behaviour by checking if the query returned data and had columns
 		// This should be reliable enough
-		if (($this->driver == 'pdo') AND (count($r) == 0) AND ($columns == 0)) {
+		if (($this->driver == 'pdo') && (count($r) == 0) && ($columns == 0)) {
 			return true;
 		}
 
@@ -490,7 +490,7 @@ class dba {
 	static private function replace_parameters($sql, $args) {
 		$offset = 0;
 		foreach ($args AS $param => $value) {
-			if (is_int($args[$param]) OR is_float($args[$param])) {
+			if (is_int($args[$param]) || is_float($args[$param])) {
 				$replace = intval($args[$param]);
 			} else {
 				$replace = "'".self::$dbo->escape($args[$param])."'";
@@ -520,7 +520,7 @@ class dba {
 		unset($args[0]);
 
 		// When the second function parameter is an array then use this as the parameter array
-		if ((count($args) > 0) AND (is_array($args[1]))) {
+		if ((count($args) > 0) && (is_array($args[1]))) {
 			$params = $args[1];
 		} else {
 			$params = $args;
@@ -533,7 +533,7 @@ class dba {
 			$args[++$i] = $param;
 		}
 
-		if (!self::$dbo OR !self::$dbo->connected) {
+		if (!self::$dbo || !self::$dbo->connected) {
 			return false;
 		}
 
@@ -948,7 +948,7 @@ class dba {
 
 			// When the search field is the relation field, we don't need to fetch the rows
 			// This is useful when the leading record is already deleted in the frontend but the rest is done in the backend
-			if ((count($param) == 1) AND ($field == array_keys($param)[0])) {
+			if ((count($param) == 1) && ($field == array_keys($param)[0])) {
 				foreach ($rel_def AS $rel_table => $rel_fields) {
 					foreach ($rel_fields AS $rel_field) {
 						$retval = self::delete($rel_table, array($rel_field => array_values($param)[0]), true, $callstack);
@@ -1110,7 +1110,7 @@ class dba {
 			}
 		}
 
-		if (!$do_update OR (count($fields) == 0)) {
+		if (!$do_update || (count($fields) == 0)) {
 			return true;
 		}
 
@@ -1190,7 +1190,7 @@ class dba {
 
 		$result = self::p($sql, $condition);
 
-		if (is_bool($result) OR !$single_row) {
+		if (is_bool($result) || !$single_row) {
 			return $result;
 		} else {
 			$row = self::fetch($result);

--- a/include/dba_pdo.php
+++ b/include/dba_pdo.php
@@ -190,14 +190,14 @@ class dba {
 		 * regardless of any logging that may or may nor be in effect.
 		 * These usually indicate SQL syntax errors that need to be resolved.
 		 */
-		if (isset($result) AND ($result === false)) {
+		if (isset($result) && ($result === false)) {
 			logger('dba: ' . printable($sql) . ' returned false.' . "\n" . $this->error);
 			if (file_exists('dbfail.out')) {
 				file_put_contents('dbfail.out', datetime_convert() . "\n" . printable($sql) . ' returned false' . "\n" . $this->error . "\n", FILE_APPEND);
 			}
 		}
 
-		if (isset($result) AND (($result === true) || ($result === false))) {
+		if (isset($result) && (($result === true) || ($result === false))) {
 			return $result;
 		}
 

--- a/include/dbclean.php
+++ b/include/dbclean.php
@@ -24,7 +24,7 @@ function dbclean_run(&$argv, &$argc) {
 		for ($i = 1; $i <= 9; $i++) {
 			// Execute the background script for a step when it isn't finished.
 			// Execute step 8 and 9 only when $days is defined.
-			if (!Config::get('system', 'finished-dbclean-'.$i, false) AND (($i < 8) OR ($days > 0))) {
+			if (!Config::get('system', 'finished-dbclean-'.$i, false) && (($i < 8) || ($days > 0))) {
 				proc_run(PRIORITY_LOW, 'include/dbclean.php', $i);
 			}
 		}
@@ -296,7 +296,7 @@ function remove_orphans($stage = 0) {
 	}
 
 	// Call it again if not all entries were purged
-	if (($stage != 0) AND ($count > 0)) {
+	if (($stage != 0) && ($count > 0)) {
 		proc_run(PRIORITY_MEDIUM, 'include/dbclean.php');
 	}
 }

--- a/include/dbm.php
+++ b/include/dbm.php
@@ -76,7 +76,7 @@ class dbm {
 
 		if (is_bool($value)) {
 			$value = ($value ? 'true' : 'false');
-		} elseif (is_float($value) OR is_integer($value)) {
+		} elseif (is_float($value) || is_integer($value)) {
 			$value = (string)$value;
 		} else {
 			 $value = "'".dbesc($value)."'";

--- a/include/dbstructure.php
+++ b/include/dbstructure.php
@@ -530,7 +530,7 @@ function db_create_table($name, $fields, $verbose, $action, $indexes=null) {
 	$primary_keys = array();
 	foreach ($fields AS $fieldname => $field) {
 		$sql_rows[] = "`".dbesc($fieldname)."` ".db_field_command($field);
-		if (x($field,'primary') and $field['primary']!='') {
+		if (x($field,'primary') && $field['primary']!='') {
 			$primary_keys[] = $fieldname;
 		}
 	}

--- a/include/dbstructure.php
+++ b/include/dbstructure.php
@@ -133,7 +133,7 @@ function table_structure($table) {
 			// On utf8mb4 a varchar index can only have a length of 191
 			// The "show index" command sometimes returns this value although this value wasn't added manually.
 			// Because we don't want to add this number to every index, we ignore bigger numbers
-			if (($index["Sub_part"] != "") AND (($index["Sub_part"] < 191) OR ($index["Key_name"] == "PRIMARY"))) {
+			if (($index["Sub_part"] != "") && (($index["Sub_part"] < 191) || ($index["Key_name"] == "PRIMARY"))) {
 				$column .= "(".$index["Sub_part"].")";
 			}
 
@@ -232,7 +232,7 @@ function update_structure($verbose, $action, $tables=null, $definition=null) {
 	}
 
 	// MySQL >= 5.7.4 doesn't support the IGNORE keyword in ALTER TABLE statements
-	if ((version_compare($db->server_info(), '5.7.4') >= 0) AND
+	if ((version_compare($db->server_info(), '5.7.4') >= 0) &&
 		!(strpos($db->server_info(), 'MariaDB') !== false)) {
 		$ignore = '';
 	} else {
@@ -381,7 +381,7 @@ function update_structure($verbose, $action, $tables=null, $definition=null) {
 				$field_definition = $database[$name]["fields"][$fieldname];
 
 				// Define the default collation if not given
-				if (!isset($parameters['Collation']) AND !is_null($field_definition['Collation'])) {
+				if (!isset($parameters['Collation']) && !is_null($field_definition['Collation'])) {
 					$parameters['Collation'] = 'utf8mb4_general_ci';
 				} else {
 					$parameters['Collation'] = null;
@@ -389,7 +389,7 @@ function update_structure($verbose, $action, $tables=null, $definition=null) {
 
 				if ($field_definition['Collation'] != $parameters['Collation']) {
 					$sql2 = db_modify_table_field($fieldname, $parameters);
-					if (($sql3 == "") OR (substr($sql3, -2, 2) == "; ")) {
+					if (($sql3 == "") || (substr($sql3, -2, 2) == "; ")) {
 						$sql3 .= "ALTER" . $ignore . " TABLE `".$temp_name."` ".$sql2;
 					} else {
 						$sql3 .= ", ".$sql2;
@@ -513,7 +513,7 @@ function db_field_command($parameters, $create = true) {
 	if ($parameters["extra"] != "")
 		$fieldstruct .= " ".$parameters["extra"];
 
-	/*if (($parameters["primary"] != "") AND $create)
+	/*if (($parameters["primary"] != "") && $create)
 		$fieldstruct .= " PRIMARY KEY";*/
 
 	return($fieldstruct);

--- a/include/delivery.php
+++ b/include/delivery.php
@@ -339,7 +339,7 @@ function delivery_run(&$argv, &$argc){
 
 						// If we are setup as a soapbox we aren't accepting top level posts from this person
 
-						if (($x[0]['page-flags'] == PAGE_SOAPBOX) AND $top_level) {
+						if (($x[0]['page-flags'] == PAGE_SOAPBOX) && $top_level) {
 							break;
 						}
 						logger('mod-delivery: local delivery');
@@ -462,14 +462,14 @@ function delivery_run(&$argv, &$argc){
 								dbesc($it['parent-uri']),
 								intval($uid));
 
-							if (dbm::is_result($r) AND ($r[0]['title'] != '')) {
+							if (dbm::is_result($r) && ($r[0]['title'] != '')) {
 								$subject = $r[0]['title'];
 							} else {
 								$r = q("SELECT `title` FROM `item` WHERE `parent-uri` = '%s' AND `uid` = %d LIMIT 1",
 									dbesc($it['parent-uri']),
 									intval($uid));
 
-								if (dbm::is_result($r) AND ($r[0]['title'] != ''))
+								if (dbm::is_result($r) && ($r[0]['title'] != ''))
 									$subject = $r[0]['title'];
 							}
 						}

--- a/include/delivery.php
+++ b/include/delivery.php
@@ -91,7 +91,7 @@ function delivery_run(&$argv, &$argc){
 			$uid = $item_id;
 		} else {
 			// find ancestors
-			$r = q("SELECT * FROM `item` WHERE `id` = %d and visible = 1 and moderated = 0 LIMIT 1",
+			$r = q("SELECT * FROM `item` WHERE `id` = %d AND visible = 1 AND moderated = 0 LIMIT 1",
 				intval($item_id)
 			);
 
@@ -105,7 +105,7 @@ function delivery_run(&$argv, &$argc){
 			$updated = $r[0]['edited'];
 
 			$items = q("SELECT `item`.*, `sign`.`signed_text`,`sign`.`signature`,`sign`.`signer`
-				FROM `item` LEFT JOIN `sign` ON `sign`.`iid` = `item`.`id` WHERE `parent` = %d and visible = 1 and moderated = 0 ORDER BY `id` ASC",
+				FROM `item` LEFT JOIN `sign` ON `sign`.`iid` = `item`.`id` WHERE `parent` = %d AND visible = 1 AND moderated = 0 ORDER BY `id` ASC",
 				intval($parent_id)
 			);
 
@@ -453,7 +453,7 @@ function delivery_run(&$argv, &$argc){
 						$headers .= "References: <".iri2msgid($it["parent-uri"]).">";
 
 						// If Threading is enabled, write down the correct parent
-						if (($it["thr-parent"] != "") and ($it["thr-parent"] != $it["parent-uri"]))
+						if (($it["thr-parent"] != "") && ($it["thr-parent"] != $it["parent-uri"]))
 							$headers .= " <".iri2msgid($it["thr-parent"]).">";
 						$headers .= "\n";
 

--- a/include/dfrn.php
+++ b/include/dfrn.php
@@ -245,7 +245,7 @@ class dfrn {
 		/// @TODO This hook can't work anymore
 		//	call_hooks('atom_feed', $atom);
 
-		if (!dbm::is_result($items) OR $onlyheader) {
+		if (!dbm::is_result($items) || $onlyheader) {
 			$atom = trim($doc->saveXML());
 
 			call_hooks('atom_feed_end', $atom);
@@ -508,7 +508,7 @@ class dfrn {
 
 		$attributes = array();
 
-		if (!$public OR !$hidewall) {
+		if (!$public || !$hidewall) {
 			$attributes = array("dfrn:updated" => $namdate);
 		}
 
@@ -519,7 +519,7 @@ class dfrn {
 		$attributes = array("rel" => "photo", "type" => "image/jpeg",
 					"media:width" => 175, "media:height" => 175, "href" => $owner['photo']);
 
-		if (!$public OR !$hidewall) {
+		if (!$public || !$hidewall) {
 			$attributes["dfrn:updated"] = $picdate;
 		}
 
@@ -921,7 +921,7 @@ class dfrn {
 
 		if (count($tags)) {
 			foreach ($tags as $t) {
-				if (($type != 'html') OR ($t[0] != "@")) {
+				if (($type != 'html') || ($t[0] != "@")) {
 					xml::add_element($doc, $entry, "category", "", array("scheme" => "X-DFRN:".$t[0].":".$t[1], "term" => $t[2]));
 				}
 			}
@@ -940,7 +940,7 @@ class dfrn {
 				intval($owner["uid"]),
 				dbesc(normalise_link($mention)));
 
-			if (dbm::is_result($r) AND ($r[0]["forum"] OR $r[0]["prv"])) {
+			if (dbm::is_result($r) && ($r[0]["forum"] || $r[0]["prv"])) {
 				xml::add_element($doc, $entry, "link", "", array("rel" => "mentioned",
 											"ostatus:object-type" => ACTIVITY_OBJ_GROUP,
 											"href" => $mention));
@@ -1323,7 +1323,7 @@ class dfrn {
 					$contact["avatar-date"] = $attributes->textContent;
 				}
 			}
-			if (($width > 0) AND ($href != "")) {
+			if (($width > 0) && ($href != "")) {
 				$avatarlist[$width] = $href;
 			}
 		}
@@ -1332,7 +1332,7 @@ class dfrn {
 			$author["avatar"] = current($avatarlist);
 		}
 
-		if (dbm::is_result($r) AND !$onlyfetch) {
+		if (dbm::is_result($r) && !$onlyfetch) {
 			logger("Check if contact details for contact " . $r[0]["id"] . " (" . $r[0]["nick"] . ") have to be updated.", LOGGER_DEBUG);
 
 			$poco = array("url" => $contact["url"]);
@@ -1774,7 +1774,7 @@ class dfrn {
 		$relocate["poll"] = $xpath->query("dfrn:poll/text()", $relocation)->item(0)->nodeValue;
 		$relocate["sitepubkey"] = $xpath->query("dfrn:sitepubkey/text()", $relocation)->item(0)->nodeValue;
 
-		if (($relocate["avatar"] == "") AND ($relocate["photo"] != "")) {
+		if (($relocate["avatar"] == "") && ($relocate["photo"] != "")) {
 			$relocate["avatar"] = $relocate["photo"];
 		}
 
@@ -1922,7 +1922,7 @@ class dfrn {
 		}
 
 		// update last-child if it changes
-		if ($item["last-child"] AND ($item["last-child"] != $current["last-child"])) {
+		if ($item["last-child"] && ($item["last-child"] != $current["last-child"])) {
 			$r = q("UPDATE `item` SET `last-child` = 0, `changed` = '%s' WHERE `parent-uri` = '%s' AND `uid` = %d",
 				dbesc(datetime_convert()),
 				dbesc($item["parent-uri"]),
@@ -2206,7 +2206,7 @@ class dfrn {
 					$title = $attributes->textContent;
 				}
 			}
-			if (($rel != "") AND ($href != "")) {
+			if (($rel != "") && ($href != "")) {
 				switch ($rel) {
 					case "alternate":
 						$item["plink"] = $href;
@@ -2254,7 +2254,7 @@ class dfrn {
 		);
 
 		// Is there an existing item?
-		if (dbm::is_result($current) AND edited_timestamp_is_newer($current[0], $item) AND
+		if (dbm::is_result($current) && edited_timestamp_is_newer($current[0], $item) &&
 			(datetime_convert("UTC","UTC",$item["edited"]) < $current[0]["edited"])) {
 			logger("Item ".$item["uri"]." already existed.", LOGGER_DEBUG);
 			return;
@@ -2328,7 +2328,7 @@ class dfrn {
 		}
 
 		$notice_info = $xpath->query("statusnet:notice_info", $entry);
-		if ($notice_info AND ($notice_info->length > 0)) {
+		if ($notice_info && ($notice_info->length > 0)) {
 			foreach ($notice_info->item(0)->attributes AS $attributes) {
 				if ($attributes->name == "source") {
 					$item["app"] = strip_tags($attributes->textContent);
@@ -2378,9 +2378,9 @@ class dfrn {
 					}
 				}
 
-				if (($term != "") AND ($scheme != "")) {
+				if (($term != "") && ($scheme != "")) {
 					$parts = explode(":", $scheme);
-					if ((count($parts) >= 4) AND (array_shift($parts) == "X-DFRN")) {
+					if ((count($parts) >= 4) && (array_shift($parts) == "X-DFRN")) {
 						$termhash = array_shift($parts);
 						$termurl = implode(":", $parts);
 
@@ -2440,7 +2440,7 @@ class dfrn {
 				$item["contact-id"] = $owner["contact-id"];
 			}
 
-			if (($item["network"] != $owner["network"]) AND ($owner["network"] != "")) {
+			if (($item["network"] != $owner["network"]) && ($owner["network"] != "")) {
 				$item["network"] = $owner["network"];
 			}
 
@@ -2448,7 +2448,7 @@ class dfrn {
 				$item["contact-id"] = $author["contact-id"];
 			}
 
-			if (($item["network"] != $author["network"]) AND ($author["network"] != "")) {
+			if (($item["network"] != $author["network"]) && ($author["network"] != "")) {
 				$item["network"] = $author["network"];
 			}
 
@@ -2548,7 +2548,7 @@ class dfrn {
 					);
 				}
 
-				if ($posted_id AND $parent AND ($entrytype == DFRN_REPLY_RC)) {
+				if ($posted_id && $parent && ($entrytype == DFRN_REPLY_RC)) {
 					logger("Notifying followers about comment ".$posted_id, LOGGER_DEBUG);
 					proc_run(PRIORITY_HIGH, "include/notifier.php", "comment-import", $posted_id);
 				}
@@ -2613,7 +2613,7 @@ class dfrn {
 			$when = datetime_convert("UTC", "UTC", "now", "Y-m-d H:i:s");
 		}
 
-		if (!$uri OR !$importer["id"]) {
+		if (!$uri || !$importer["id"]) {
 			return false;
 		}
 

--- a/include/diaspora.php
+++ b/include/diaspora.php
@@ -416,7 +416,7 @@ class Diaspora {
 		$fields = $postdata['fields'];
 
 		// Is it a an action (comment, like, ...) for our own post?
-		if (isset($fields->parent_guid) AND !$postdata["relayed"]) {
+		if (isset($fields->parent_guid) && !$postdata["relayed"]) {
 			$guid = notags(unxmlify($fields->parent_guid));
 			$importer = self::importer_for_guid($guid);
 			if (is_array($importer)) {
@@ -612,9 +612,9 @@ class Diaspora {
 				}
 			}
 
-			if (($fieldname == "author_signature") AND ($entry != ""))
+			if (($fieldname == "author_signature") && ($entry != ""))
 				$author_signature = base64_decode($entry);
-			elseif (($fieldname == "parent_author_signature") AND ($entry != ""))
+			elseif (($fieldname == "parent_author_signature") && ($entry != ""))
 				$parent_author_signature = base64_decode($entry);
 			elseif (!in_array($fieldname, array("author_signature", "parent_author_signature", "target_author_signature"))) {
 				if ($signed_data != "") {
@@ -624,7 +624,7 @@ class Diaspora {
 
 				$signed_data .= $entry;
 			}
-			if (!in_array($fieldname, array("parent_author_signature", "target_author_signature")) OR
+			if (!in_array($fieldname, array("parent_author_signature", "target_author_signature")) ||
 				($orig_type == "relayable_retraction"))
 				xml::copy($entry, $fields, $fieldname);
 		}
@@ -714,13 +714,13 @@ class Diaspora {
 				$update = true;
 		}
 
-		if (!$person OR $update) {
+		if (!$person || $update) {
 			logger("create or refresh", LOGGER_DEBUG);
 			$r = probe_url($handle, PROBE_DIASPORA);
 
 			// Note that Friendica contacts will return a "Diaspora person"
 			// if Diaspora connectivity is enabled on their server
-			if ($r AND ($r["network"] === NETWORK_DIASPORA)) {
+			if ($r && ($r["network"] === NETWORK_DIASPORA)) {
 				self::add_fcontact($r, $update);
 				$person = $r;
 			}
@@ -1143,7 +1143,7 @@ class Diaspora {
 		// Fetch the author - for the old and the new Diaspora version
 		if ($source_xml->post->status_message->diaspora_handle)
 			$author = (string)$source_xml->post->status_message->diaspora_handle;
-		elseif ($source_xml->author AND ($source_xml->getName() == "status_message"))
+		elseif ($source_xml->author && ($source_xml->getName() == "status_message"))
 			$author = (string)$source_xml->author;
 
 		// If this isn't a "status_message" then quit
@@ -1463,7 +1463,7 @@ class Diaspora {
 		}
 
 		// If we are the origin of the parent we store the original data and notify our followers
-		if ($message_id AND $parent_item["origin"]) {
+		if ($message_id && $parent_item["origin"]) {
 
 			// Formerly we stored the signed text, the signature and the author in different fields.
 			// We now store the raw data so that we are more flexible.
@@ -1767,7 +1767,7 @@ class Diaspora {
 		}
 
 		// If we are the origin of the parent we store the original data and notify our followers
-		if ($message_id AND $parent_item["origin"]) {
+		if ($message_id && $parent_item["origin"]) {
 
 			// Formerly we stored the signed text, the signature and the author in different fields.
 			// We now store the raw data so that we are more flexible.
@@ -2116,7 +2116,7 @@ class Diaspora {
 		// perhaps we were already sharing with this person. Now they're sharing with us.
 		// That makes us friends.
 		if ($contact) {
-			if ($following AND $sharing) {
+			if ($following && $sharing) {
 				logger("Author ".$author." (Contact ".$contact["id"].") wants to have a bidirectional conection.", LOGGER_DEBUG);
 				self::receive_request_make_friend($importer, $contact);
 
@@ -2139,17 +2139,17 @@ class Diaspora {
 			}
 		}
 
-		if (!$following AND $sharing AND in_array($importer["page-flags"], array(PAGE_SOAPBOX, PAGE_NORMAL))) {
+		if (!$following && $sharing && in_array($importer["page-flags"], array(PAGE_SOAPBOX, PAGE_NORMAL))) {
 			logger("Author ".$author." wants to share with us - but doesn't want to listen. Request is ignored.", LOGGER_DEBUG);
 			return false;
-		} elseif (!$following AND !$sharing) {
+		} elseif (!$following && !$sharing) {
 			logger("Author ".$author." doesn't want anything - and we don't know the author. Request is ignored.", LOGGER_DEBUG);
 			return false;
-		} elseif (!$following AND $sharing) {
+		} elseif (!$following && $sharing) {
 			logger("Author ".$author." wants to share with us.", LOGGER_DEBUG);
-		} elseif ($following AND $sharing) {
+		} elseif ($following && $sharing) {
 			logger("Author ".$author." wants to have a bidirectional conection.", LOGGER_DEBUG);
-		} elseif ($following AND !$sharing) {
+		} elseif ($following && !$sharing) {
 			logger("Author ".$author." wants to listen to us.", LOGGER_DEBUG);
 		}
 
@@ -2227,9 +2227,9 @@ class Diaspora {
 			// but if our page-type is PAGE_COMMUNITY or PAGE_SOAPBOX
 			// we are going to change the relationship and make them a follower.
 
-			if (($importer["page-flags"] == PAGE_FREELOVE) AND $sharing AND $following)
+			if (($importer["page-flags"] == PAGE_FREELOVE) && $sharing && $following)
 				$new_relation = CONTACT_IS_FRIEND;
-			elseif (($importer["page-flags"] == PAGE_FREELOVE) AND $sharing)
+			elseif (($importer["page-flags"] == PAGE_FREELOVE) && $sharing)
 				$new_relation = CONTACT_IS_SHARING;
 			else
 				$new_relation = CONTACT_IS_FOLLOWER;
@@ -2452,7 +2452,7 @@ class Diaspora {
 			intval($r[0]["parent"]));
 
 		// Only delete it if the parent author really fits
-		if (!link_compare($p[0]["author-link"], $contact["url"]) AND !link_compare($r[0]["author-link"], $contact["url"])) {
+		if (!link_compare($p[0]["author-link"], $contact["url"]) && !link_compare($r[0]["author-link"], $contact["url"])) {
 			logger("Thread author ".$p[0]["author-link"]." and item author ".$r[0]["author-link"]." don't fit to expected contact ".$contact["url"], LOGGER_DEBUG);
 			return false;
 		}
@@ -2489,7 +2489,7 @@ class Diaspora {
 		$target_type = notags(unxmlify($data->target_type));
 
 		$contact = self::contact_by_handle($importer["uid"], $sender);
-		if (!$contact AND (in_array($target_type, array("Contact", "Person")))) {
+		if (!$contact && (in_array($target_type, array("Contact", "Person")))) {
 			logger("cannot find contact for sender: ".$sender." and user ".$importer["uid"]);
 			return false;
 		}
@@ -2617,7 +2617,7 @@ class Diaspora {
 			$datarray["location"] = $address["address"];
 		}
 
-		if (isset($address["lat"]) AND isset($address["lng"])) {
+		if (isset($address["lat"]) && isset($address["lng"])) {
 			$datarray["coord"] = $address["lat"]." ".$address["lng"];
 		}
 
@@ -2930,7 +2930,7 @@ class Diaspora {
 				// The message could not be delivered. We mark the contact as "dead"
 				mark_for_death($contact);
 			}
-		} elseif (($return_code >= 200) AND ($return_code <= 299)) {
+		} elseif (($return_code >= 200) && ($return_code <= 299)) {
 			// We successfully delivered a message, the contact is alive
 			unmark_for_death($contact);
 		}
@@ -3040,7 +3040,7 @@ class Diaspora {
 
 		// Skip if it isn't a pure repeated messages
 		// Does it start with a share?
-		if ((strpos($body, "[share") > 0) AND $complete)
+		if ((strpos($body, "[share") > 0) && $complete)
 			return(false);
 
 		// Does it end with a share?
@@ -3088,7 +3088,7 @@ class Diaspora {
 		$ret= array();
 
 		$ret["root_handle"] = preg_replace("=https?://(.*)/u/(.*)=ism", "$2@$1", $profile);
-		if (($ret["root_handle"] == $profile) OR ($ret["root_handle"] == ""))
+		if (($ret["root_handle"] == $profile) || ($ret["root_handle"] == ""))
 			return(false);
 
 		$link = "";
@@ -3101,7 +3101,7 @@ class Diaspora {
 			$link = $matches[1];
 
 		$ret["root_guid"] = preg_replace("=https?://(.*)/posts/(.*)=ism", "$2", $link);
-		if (($ret["root_guid"] == $link) OR (trim($ret["root_guid"]) == ""))
+		if (($ret["root_guid"] == $link) || (trim($ret["root_guid"]) == ""))
 			return(false);
 
 		return($ret);
@@ -3161,7 +3161,7 @@ class Diaspora {
 		if ($event['start']) {
 			$eventdata['start'] = datetime_convert($eventdata['timezone'], "UTC", $event['start'], $mask);
 		}
-		if ($event['finish'] AND !$event['nofinish']) {
+		if ($event['finish'] && !$event['nofinish']) {
 			$eventdata['end'] = datetime_convert($eventdata['timezone'], "UTC", $event['finish'], $mask);
 		}
 		if ($event['summary']) {
@@ -3207,7 +3207,7 @@ class Diaspora {
 		$created = datetime_convert("UTC", "UTC", $item["created"], 'Y-m-d\TH:i:s\Z');
 
 		// Detect a share element and do a reshare
-		if (!$item['private'] AND ($ret = self::is_reshare($item["body"]))) {
+		if (!$item['private'] && ($ret = self::is_reshare($item["body"]))) {
 			$message = array("root_diaspora_id" => $ret["root_handle"],
 					"root_guid" => $ret["root_guid"],
 					"guid" => $item["guid"],
@@ -3257,7 +3257,7 @@ class Diaspora {
 					"provider_display_name" => $item["app"]);
 
 			// Diaspora rejects messages when they contain a location without "lat" or "lng"
-			if (!isset($location["lat"]) OR !isset($location["lng"])) {
+			if (!isset($location["lat"]) || !isset($location["lng"])) {
 				unset($message["location"]);
 			}
 
@@ -3532,7 +3532,7 @@ class Diaspora {
 
 		// Old way - is used by the internal Friendica functions
 		/// @todo Change all signatur storing functions to the new format
-		if ($signature['signed_text'] AND $signature['signature'] AND $signature['signer'])
+		if ($signature['signed_text'] && $signature['signature'] && $signature['signer'])
 			$message = self::message_from_signature($item, $signature);
 		else {// New way
 			$msg = json_decode($signature['signed_text'], true);
@@ -3584,7 +3584,7 @@ class Diaspora {
 			$target_type = "StatusMessage";
 		}
 
-		if ($relay AND ($item["uri"] !== $item["parent-uri"]))
+		if ($relay && ($item["uri"] !== $item["parent-uri"]))
 			$signature = "parent_author_signature";
 		else
 			$signature = "target_author_signature";
@@ -3764,7 +3764,7 @@ class Diaspora {
 	public static function store_like_signature($contact, $post_id) {
 
 		// Is the contact the owner? Then fetch the private key
-		if (!$contact['self'] OR ($contact['uid'] == 0)) {
+		if (!$contact['self'] || ($contact['uid'] == 0)) {
 			logger("No owner post, so not storing signature", LOGGER_DEBUG);
 			return false;
 		}

--- a/include/discover_poco.php
+++ b/include/discover_poco.php
@@ -81,12 +81,12 @@ function discover_poco_run(&$argv, &$argc) {
 		logger($result, LOGGER_DEBUG);
 	} elseif ($mode == 3) {
 		update_suggestions();
-	} elseif (($mode == 2) AND get_config('system','poco_completion')) {
+	} elseif (($mode == 2) && get_config('system','poco_completion')) {
 		discover_users();
-	} elseif (($mode == 1) AND ($search != "") and get_config('system','poco_local_search')) {
+	} elseif (($mode == 1) && ($search != "") and get_config('system','poco_local_search')) {
 		discover_directory($search);
 		gs_search_user($search);
-	} elseif (($mode == 0) AND ($search == "") and (get_config('system','poco_discovery') > 0)) {
+	} elseif (($mode == 0) && ($search == "") and (get_config('system','poco_discovery') > 0)) {
 		// Query Friendica and Hubzilla servers for their users
 		poco_discover();
 
@@ -176,7 +176,7 @@ function discover_users() {
 			$server_url = $user["server_url"];
 		}
 
-		if ((($server_url == "") AND ($user["network"] == NETWORK_FEED)) OR $force_update OR poco_check_server($server_url, $user["network"])) {
+		if ((($server_url == "") && ($user["network"] == NETWORK_FEED)) || $force_update || poco_check_server($server_url, $user["network"])) {
 			logger('Check profile '.$user["url"]);
 			proc_run(PRIORITY_LOW, "include/discover_poco.php", "check_profile", base64_encode($user["url"]));
 
@@ -216,7 +216,7 @@ function discover_directory($search) {
 			if (dbm::is_result($exists)) {
 				logger("Profile ".$jj->url." already exists (".$search.")", LOGGER_DEBUG);
 
-				if (($exists[0]["last_contact"] < $exists[0]["last_failure"]) AND
+				if (($exists[0]["last_contact"] < $exists[0]["last_failure"]) &&
 					($exists[0]["updated"] < $exists[0]["last_failure"])) {
 					continue;
 				}

--- a/include/discover_poco.php
+++ b/include/discover_poco.php
@@ -83,10 +83,10 @@ function discover_poco_run(&$argv, &$argc) {
 		update_suggestions();
 	} elseif (($mode == 2) && get_config('system','poco_completion')) {
 		discover_users();
-	} elseif (($mode == 1) && ($search != "") and get_config('system','poco_local_search')) {
+	} elseif (($mode == 1) && ($search != "") && get_config('system','poco_local_search')) {
 		discover_directory($search);
 		gs_search_user($search);
-	} elseif (($mode == 0) && ($search == "") and (get_config('system','poco_discovery') > 0)) {
+	} elseif (($mode == 0) && ($search == "") && (get_config('system','poco_discovery') > 0)) {
 		// Query Friendica and Hubzilla servers for their users
 		poco_discover();
 

--- a/include/email.php
+++ b/include/email.php
@@ -152,7 +152,7 @@ function email_get_part($mbox,$uid,$p,$partno, $subtype) {
 	if ($p->parameters)
 		foreach ($p->parameters as $x)
 			$params[strtolower($x->attribute)] = $x->value;
-	if (isset($p->dparameters) and $p->dparameters)
+	if (isset($p->dparameters) && $p->dparameters)
 		foreach ($p->dparameters as $x)
 			$params[strtolower($x->attribute)] = $x->value;
 
@@ -160,7 +160,7 @@ function email_get_part($mbox,$uid,$p,$partno, $subtype) {
 	// Any part with a filename is an attachment,
 	// so an attached text file (type 0) is not mistaken as the message.
 
-	if ((isset($params['filename']) and $params['filename']) || (isset($params['name']) and $params['name'])) {
+	if ((isset($params['filename']) && $params['filename']) || (isset($params['name']) && $params['name'])) {
 		// filename may be given as 'Filename' or 'Name' or both
 		$filename = ($params['filename'])? $params['filename'] : $params['name'];
 		// filename may be encoded, so see imap_mime_header_decode()
@@ -191,7 +191,7 @@ function email_get_part($mbox,$uid,$p,$partno, $subtype) {
 //	}
 
 	// SUBPART RECURSION
-	if (isset($p->parts) and $p->parts) {
+	if (isset($p->parts) && $p->parts) {
 		$x = "";
 		foreach ($p->parts as $partno0=>$p2) {
 			$x .=  email_get_part($mbox,$uid,$p2,$partno . '.' . ($partno0+1), $subtype);  // 1.2, 1.2.1, etc.

--- a/include/enotify.php
+++ b/include/enotify.php
@@ -99,7 +99,7 @@ function notification($params) {
 			intval($parent_id),
 			intval($params['uid'])
 		);
-		if ($p AND count($p) AND ($p[0]["ignored"])) {
+		if ($p && count($p) && ($p[0]["ignored"])) {
 			logger("Thread ".$parent_id." will be ignored", LOGGER_DEBUG);
 			return;
 		}
@@ -515,7 +515,7 @@ function notification($params) {
 
 		logger('sending notification email');
 
-		if (isset($params['parent']) AND (intval($params['parent']) != 0)) {
+		if (isset($params['parent']) && (intval($params['parent']) != 0)) {
 			$id_for_parent = $params['parent']."@".$hostname;
 
 			// Is this the first email notification for this parent item and user?
@@ -676,7 +676,7 @@ function check_item_notification($itemid, $uid, $defaulttype = "") {
 		// Check for invalid profile urls. 13 should be the shortest possible profile length:
 		// http://a.bc/d
 		// Additionally check for invalid urls that would return the normalised value "http:"
-		if ((strlen($profile) >= 13) AND (normalise_link($profile) != "http:")) {
+		if ((strlen($profile) >= 13) && (normalise_link($profile) != "http:")) {
 			if (!in_array($profile, $profiles2))
 				$profiles2[] = $profile;
 
@@ -760,11 +760,11 @@ function check_item_notification($itemid, $uid, $defaulttype = "") {
 	$tagged = false;
 
 	foreach ($profiles AS $profile) {
-		if (strpos($item[0]["tag"], "=".$profile."]") OR strpos($item[0]["body"], "=".$profile."]"))
+		if (strpos($item[0]["tag"], "=".$profile."]") || strpos($item[0]["body"], "=".$profile."]"))
 			$tagged = true;
 	}
 
-	if ($item[0]["mention"] OR $tagged OR ($defaulttype == NOTIFY_TAGSELF)) {
+	if ($item[0]["mention"] || $tagged || ($defaulttype == NOTIFY_TAGSELF)) {
 		$params["type"] = NOTIFY_TAGSELF;
 		$params["verb"] = ACTIVITY_TAG;
 	}
@@ -776,7 +776,7 @@ function check_item_notification($itemid, $uid, $defaulttype = "") {
 			LIMIT 1",
 			intval($item[0]["parent"]), intval($uid));
 
-	if ($parent AND !isset($params["type"])) {
+	if ($parent && !isset($params["type"])) {
 		$params["type"] = NOTIFY_COMMENT;
 		$params["verb"] = ACTIVITY_POST;
 	}

--- a/include/enotify.php
+++ b/include/enotify.php
@@ -115,7 +115,7 @@ function notification($params) {
 			dbesc($params['link']),
 			intval($params['uid'])
 		);
-		if ($p and count($p)) {
+		if ($p && count($p)) {
 			pop_lang();
 			return;
 		}

--- a/include/follow.php
+++ b/include/follow.php
@@ -30,10 +30,10 @@ function update_contact($id) {
 
 	// make sure to not overwrite existing values with blank entries
 	foreach ($ret AS $key => $val) {
-		if (isset($r[0][$key]) AND ($r[0][$key] != "") AND ($val == ""))
+		if (isset($r[0][$key]) && ($r[0][$key] != "") && ($val == ""))
 			$ret[$key] = $r[0][$key];
 
-		if (isset($r[0][$key]) AND ($ret[$key] != $r[0][$key]))
+		if (isset($r[0][$key]) && ($ret[$key] != $r[0][$key]))
 			$update = true;
 	}
 

--- a/include/gprobe.php
+++ b/include/gprobe.php
@@ -47,7 +47,7 @@ function gprobe_run(&$argv, &$argc){
 	}
 	if (dbm::is_result($r)) {
 		// Check for accessibility and do a poco discovery
-		if (poco_last_updated($r[0]['url'], true) AND ($r[0]["network"] == NETWORK_DFRN))
+		if (poco_last_updated($r[0]['url'], true) && ($r[0]["network"] == NETWORK_DFRN))
 			poco_load(0,0,$r[0]['id'], str_replace('/profile/','/poco/',$r[0]['url']));
 	}
 

--- a/include/group.php
+++ b/include/group.php
@@ -22,7 +22,7 @@ function group_add($uid,$name) {
 					intval($uid),
 					dbesc($name)
 				);
-				notice( t('A deleted group with this name was revived. Existing item permissions <strong>may</strong> apply to this group and any future members. If this is not what you intended, please create another group with a different name.') . EOL); 
+				notice( t('A deleted group with this name was revived. Existing item permissions <strong>may</strong> apply to this group and any future members. If this is not what you intended, please create another group with a different name.') . EOL);
 			}
 			return true;
 		}
@@ -320,7 +320,7 @@ function expand_groups($a,$check_dead = false, $use_gcontact = false) {
 	if (dbm::is_result($r))
 		foreach ($r as $rr)
 			$ret[] = $rr['contact-id'];
-	if ($check_dead AND !$use_gcontact) {
+	if ($check_dead && !$use_gcontact) {
 		require_once('include/acl_selectors.php');
 		$ret = prune_deadguys($ret);
 	}

--- a/include/html2bbcode.php
+++ b/include/html2bbcode.php
@@ -44,7 +44,7 @@ function node2bbcodesub(&$doc, $oldnode, $attributes, $startbb, $endbb)
 
 			if (strpos('*'.$startbb, '$1') > 0) {
 
-				if ($replace and (@$attr[$attribute] != '')) {
+				if ($replace && (@$attr[$attribute] != '')) {
 
 					$startbb = preg_replace($value, $startbb, $attr[$attribute], -1, $count);
 

--- a/include/html2plain.php
+++ b/include/html2plain.php
@@ -212,7 +212,7 @@ function html2plain($html, $wraplength = 75, $compact = false)
 
 	$message = html_entity_decode($message, ENT_QUOTES, 'UTF-8');
 
-	if (!$compact AND ($message != "")) {
+	if (!$compact && ($message != "")) {
 		$counter = 1;
 		foreach ($urls as $id=>$url)
 			if ($url != "")

--- a/include/html2plain.php
+++ b/include/html2plain.php
@@ -23,7 +23,7 @@ function breaklines($line, $level, $wraplength = 75)
 		if ($pos == 0)
 			$pos = strpos($line, ' ');
 
-		if (($pos > 0) and strlen($line) > $wraplen) {
+		if (($pos > 0) && strlen($line) > $wraplen) {
 			$newline = trim(substr($line, 0, $pos));
 			if ($level > 0)
                 		$newline = str_repeat(">", $level).' '.$newline;
@@ -32,7 +32,7 @@ function breaklines($line, $level, $wraplength = 75)
 			$line = substr($line, $pos+1);
 		}
 
-	} while ((strlen($line) > $wraplen) and !($oldline == $line));
+	} while ((strlen($line) > $wraplen) && !($oldline == $line));
 
 	if ($level > 0)
 		$line = str_repeat(">", $level).' '.$line;
@@ -70,7 +70,7 @@ function quotelevel($message, $wraplength = 75)
 			$line = substr($line, 0, $pos).substr($line, $pos+8);
 		}
 
-		if (!$startquote or ($line != ''))
+		if (!$startquote || ($line != ''))
 			$newlines[] = breaklines($line, $currlevel, $wraplength);
 	}
 	return(implode($newlines, "\n"));
@@ -92,13 +92,13 @@ function collecturls($message) {
 			if (strpos($treffer[1], $listitem) !== false)
 				$ignore = true;
 
-		if ((strpos($treffer[1], "//twitter.com/") !== false) and (strpos($treffer[1], "/status/") !== false))
+		if ((strpos($treffer[1], "//twitter.com/") !== false) && (strpos($treffer[1], "/status/") !== false))
 				$ignore = false;
 
-		if ((strpos($treffer[1], "//plus.google.com/") !== false) and (strpos($treffer[1], "/posts") !== false))
+		if ((strpos($treffer[1], "//plus.google.com/") !== false) && (strpos($treffer[1], "/posts") !== false))
 				$ignore = false;
 
-		if ((strpos($treffer[1], "//plus.google.com/") !== false) and (strpos($treffer[1], "/photos") !== false))
+		if ((strpos($treffer[1], "//plus.google.com/") !== false) && (strpos($treffer[1], "/photos") !== false))
 				$ignore = false;
 
 		if (!$ignore)

--- a/include/identity.php
+++ b/include/identity.php
@@ -217,7 +217,7 @@ function profile_sidebar($profile, $block = 0) {
 
 	$profile['picdate'] = urlencode($profile['picdate']);
 
-	if (($profile['network'] != "") AND ($profile['network'] != NETWORK_DFRN)) {
+	if (($profile['network'] != "") && ($profile['network'] != NETWORK_DFRN)) {
 		$profile['network_name'] = format_network_name($profile['network'], $profile['url']);
 	} else {
 		$profile['network_name'] = "";
@@ -240,7 +240,7 @@ function profile_sidebar($profile, $block = 0) {
 	}
 
 	// Is the local user already connected to that user?
-	if ($connect AND local_user()) {
+	if ($connect && local_user()) {
 		if (isset($profile["url"])) {
 			$profile_url = normalise_link($profile["url"]);
 		} else {
@@ -254,19 +254,19 @@ function profile_sidebar($profile, $block = 0) {
 			$connect = false;
 	}
 
-	if ($connect AND ($profile['network'] != NETWORK_DFRN) AND !isset($profile['remoteconnect']))
+	if ($connect && ($profile['network'] != NETWORK_DFRN) && !isset($profile['remoteconnect']))
 		$connect = false;
 
 	$remoteconnect = NULL;
 	if (isset($profile['remoteconnect']))
 		$remoteconnect = $profile['remoteconnect'];
 
-	if ($connect AND ($profile['network'] == NETWORK_DFRN) AND !isset($remoteconnect))
+	if ($connect && ($profile['network'] == NETWORK_DFRN) && !isset($remoteconnect))
 		$subscribe_feed = t("Atom feed");
 	else
 		$subscribe_feed = false;
 
-	if (remote_user() OR (get_my_url() && $profile['unkmail'] && ($profile['uid'] != local_user()))) {
+	if (remote_user() || (get_my_url() && $profile['unkmail'] && ($profile['uid'] != local_user()))) {
 		$wallmessage = t('Message');
 		$wallmessage_link = "wallmessage/".$profile["nickname"];
 
@@ -379,7 +379,7 @@ function profile_sidebar($profile, $block = 0) {
 	if (!$block) {
 		$contact_block = contact_block();
 
-		if (is_array($a->profile) AND !$a->profile['hide-friends']) {
+		if (is_array($a->profile) && !$a->profile['hide-friends']) {
 			$r = q("SELECT `gcontact`.`updated` FROM `contact` INNER JOIN `gcontact` WHERE `gcontact`.`nurl` = `contact`.`nurl` AND `self` AND `uid` = %d LIMIT 1",
 				intval($a->profile['uid']));
 			if (dbm::is_result($r))

--- a/include/items.php
+++ b/include/items.php
@@ -159,16 +159,16 @@ function add_page_info_data($data) {
 
 	// It maybe is a rich content, but if it does have everything that a link has,
 	// then treat it that way
-	if (($data["type"] == "rich") AND is_string($data["title"]) AND
-		is_string($data["text"]) AND (sizeof($data["images"]) > 0)) {
+	if (($data["type"] == "rich") && is_string($data["title"]) &&
+		is_string($data["text"]) && (sizeof($data["images"]) > 0)) {
 		$data["type"] = "link";
 	}
 
-	if ((($data["type"] != "link") AND ($data["type"] != "video") AND ($data["type"] != "photo")) OR ($data["title"] == $data["url"])) {
+	if ((($data["type"] != "link") && ($data["type"] != "video") && ($data["type"] != "photo")) || ($data["title"] == $data["url"])) {
 		return "";
 	}
 
-	if ($no_photos AND ($data["type"] == "photo")) {
+	if ($no_photos && ($data["type"] == "photo")) {
 		return "";
 	}
 
@@ -204,7 +204,7 @@ function add_page_info_data($data) {
 		$preview = str_replace(array("[", "]"), array("&#91;", "&#93;"), htmlentities($data["images"][0]["src"], ENT_QUOTES, 'UTF-8', false));
 		// if the preview picture is larger than 500 pixels then show it in a larger mode
 		// But only, if the picture isn't higher than large (To prevent huge posts)
-		if (($data["images"][0]["width"] >= 500) AND ($data["images"][0]["width"] >= $data["images"][0]["height"])) {
+		if (($data["images"][0]["width"] >= 500) && ($data["images"][0]["width"] >= $data["images"][0]["height"])) {
 			$text .= " image='".$preview."'";
 		} else {
 			$text .= " preview='".$preview."'";
@@ -214,7 +214,7 @@ function add_page_info_data($data) {
 	$text .= "]".$data["text"]."[/attachment]";
 
 	$hashtags = "";
-	if (isset($data["keywords"]) AND count($data["keywords"])) {
+	if (isset($data["keywords"]) && count($data["keywords"])) {
 		$hashtags = "\n";
 		foreach ($data["keywords"] AS $keyword) {
 			/// @todo make a positive list of allowed characters
@@ -237,11 +237,11 @@ function query_page_info($url, $no_photos = false, $photo = "", $keywords = fals
 
 	logger('fetch page info for ' . $url . ' ' . print_r($data, true), LOGGER_DEBUG);
 
-	if (!$keywords AND isset($data["keywords"])) {
+	if (!$keywords && isset($data["keywords"])) {
 		unset($data["keywords"]);
 	}
 
-	if (($keyword_blacklist != "") AND isset($data["keywords"])) {
+	if (($keyword_blacklist != "") && isset($data["keywords"])) {
 		$list = explode(", ", $keyword_blacklist);
 		foreach ($list AS $keyword) {
 			$keyword = trim($keyword);
@@ -259,7 +259,7 @@ function add_page_keywords($url, $no_photos = false, $photo = "", $keywords = fa
 	$data = query_page_info($url, $no_photos, $photo, $keywords, $keyword_blacklist);
 
 	$tags = "";
-	if (isset($data["keywords"]) AND count($data["keywords"])) {
+	if (isset($data["keywords"]) && count($data["keywords"])) {
 		foreach ($data["keywords"] AS $keyword) {
 			$hashtag = str_replace(array(" ", "+", "/", ".", "#", "'"),
 				array("", "", "", "", "", ""), $keyword);
@@ -301,7 +301,7 @@ function add_page_info_to_body($body, $texturl = false, $no_photos = false) {
 	}
 
 	// Convert urls without bbcode elements
-	if (!$matches AND $texturl) {
+	if (!$matches && $texturl) {
 		preg_match("/([^\]\='".'"'."]|^)(https?\:\/\/[a-zA-Z0-9\:\/\-\?\&\;\.\=\_\~\#\%\$\!\+\,]+)/ism", " ".$body, $matches);
 
 		// Yeah, a hack. I really hate regular expressions :)
@@ -315,21 +315,21 @@ function add_page_info_to_body($body, $texturl = false, $no_photos = false) {
 	}
 
 	// Remove the link from the body if the link is attached at the end of the post
-	if (isset($footer) AND (trim($footer) != "") AND (strpos($footer, $matches[1]))) {
+	if (isset($footer) && (trim($footer) != "") && (strpos($footer, $matches[1]))) {
 		$removedlink = trim(str_replace($matches[1], "", $body));
-		if (($removedlink == "") OR strstr($body, $removedlink)) {
+		if (($removedlink == "") || strstr($body, $removedlink)) {
 			$body = $removedlink;
 		}
 
 		$url = str_replace(array('/', '.'), array('\/', '\.'), $matches[1]);
 		$removedlink = preg_replace("/\[url\=" . $url . "\](.*?)\[\/url\]/ism", '', $body);
-		if (($removedlink == "") OR strstr($body, $removedlink)) {
+		if (($removedlink == "") || strstr($body, $removedlink)) {
 			$body = $removedlink;
 		}
 	}
 
 	// Add the page information to the bottom
-	if (isset($footer) AND (trim($footer) != "")) {
+	if (isset($footer) && (trim($footer) != "")) {
 		$body .= $footer;
 	}
 
@@ -421,10 +421,10 @@ function store_conversation($arr) {
 	if (in_array($arr['network'], array(NETWORK_DFRN, NETWORK_DIASPORA, NETWORK_OSTATUS))) {
 		$conversation = array('item-uri' => $arr['uri'], 'received' => dbm::date());
 
-		if (isset($arr['parent-uri']) AND ($arr['parent-uri'] != $arr['uri'])) {
+		if (isset($arr['parent-uri']) && ($arr['parent-uri'] != $arr['uri'])) {
 			$conversation['reply-to-uri'] = $arr['parent-uri'];
 		}
-		if (isset($arr['thr-parent']) AND ($arr['thr-parent'] != $arr['uri'])) {
+		if (isset($arr['thr-parent']) && ($arr['thr-parent'] != $arr['uri'])) {
 			$conversation['reply-to-uri'] = $arr['thr-parent'];
 		}
 
@@ -453,7 +453,7 @@ function store_conversation($arr) {
 				unset($old_conv['source']);
 			}
 			// Update structure data all the time but the source only when its from a better protocol.
-			if (($old_conv['protocol'] < $conversation['protocol']) AND ($old_conv['protocol'] != 0)) {
+			if (($old_conv['protocol'] < $conversation['protocol']) && ($old_conv['protocol'] != 0)) {
 				unset($conversation['protocol']);
 				unset($conversation['source']);
 			}
@@ -503,9 +503,9 @@ function item_store($arr, $force_parent = false, $notify = false, $dontcache = f
 
 	if ($notify) {
 		$guid_prefix = "";
-	} elseif ((trim($arr['guid']) == "") AND (trim($arr['plink']) != "")) {
+	} elseif ((trim($arr['guid']) == "") && (trim($arr['plink']) != "")) {
 		$arr['guid'] = uri_to_guid($arr['plink']);
-	} elseif ((trim($arr['guid']) == "") AND (trim($arr['uri']) != "")) {
+	} elseif ((trim($arr['guid']) == "") && (trim($arr['uri']) != "")) {
 		$arr['guid'] = uri_to_guid($arr['uri']);
 	} else {
 		$parsed = parse_url($arr["author-link"]);
@@ -653,7 +653,7 @@ function item_store($arr, $force_parent = false, $notify = false, $dontcache = f
 		$arr['edited'] = datetime_convert();
 	}
 
-	if (($arr['author-link'] == "") AND ($arr['owner-link'] == "")) {
+	if (($arr['author-link'] == "") && ($arr['owner-link'] == "")) {
 		logger("Both author-link and owner-link are empty. Called by: " . App::callstack(), LOGGER_DEBUG);
 	}
 
@@ -832,7 +832,7 @@ function item_store($arr, $force_parent = false, $notify = false, $dontcache = f
 				$a = get_app();
 				$self = normalise_link(App::get_baseurl() . '/profile/' . $u[0]['nickname']);
 				logger("item_store: 'myself' is ".$self." for parent ".$parent_id." checking against ".$arr['author-link']." and ".$arr['owner-link'], LOGGER_DEBUG);
-				if ((normalise_link($arr['author-link']) == $self) OR (normalise_link($arr['owner-link']) == $self)) {
+				if ((normalise_link($arr['author-link']) == $self) || (normalise_link($arr['owner-link']) == $self)) {
 					q("UPDATE `thread` SET `mention` = 1 WHERE `iid` = %d", intval($parent_id));
 					logger("item_store: tagged thread ".$parent_id." as mention for user ".$self, LOGGER_DEBUG);
 				}
@@ -1051,7 +1051,7 @@ function item_store($arr, $force_parent = false, $notify = false, $dontcache = f
 
 	// update the commented timestamp on the parent
 	// Only update "commented" if it is really a comment
-	if (($arr['verb'] == ACTIVITY_POST) OR !get_config("system", "like_no_comment")) {
+	if (($arr['verb'] == ACTIVITY_POST) || !get_config("system", "like_no_comment")) {
 		q("UPDATE `item` SET `commented` = '%s', `changed` = '%s' WHERE `id` = %d",
 			dbesc(datetime_convert()),
 			dbesc(datetime_convert()),
@@ -1089,7 +1089,7 @@ function item_store($arr, $force_parent = false, $notify = false, $dontcache = f
 	 * current post can be deleted if is for a community page and no mention are
 	 * in it.
 	 */
-	if (!$deleted AND !$dontcache) {
+	if (!$deleted && !$dontcache) {
 
 		$r = q('SELECT * FROM `item` WHERE `id` = %d', intval($current_post));
 		if ((dbm::is_result($r)) && (count($r) == 1)) {
@@ -1156,10 +1156,10 @@ function item_store($arr, $force_parent = false, $notify = false, $dontcache = f
  */
 function item_set_last_item($arr) {
 
-	$update = (!$arr['private'] AND (($arr["author-link"] === $arr["owner-link"]) OR ($arr["parent-uri"] === $arr["uri"])));
+	$update = (!$arr['private'] && (($arr["author-link"] === $arr["owner-link"]) || ($arr["parent-uri"] === $arr["uri"])));
 
 	// Is it a forum? Then we don't care about the rules from above
-	if (!$update AND ($arr["network"] == NETWORK_DFRN) AND ($arr["parent-uri"] === $arr["uri"])) {
+	if (!$update && ($arr["network"] == NETWORK_DFRN) && ($arr["parent-uri"] === $arr["uri"])) {
 		$isforum = q("SELECT `forum` FROM `contact` WHERE `id` = %d AND `forum`",
 				intval($arr['contact-id']));
 		if (dbm::is_result($isforum)) {
@@ -1600,7 +1600,7 @@ function item_is_remote_self($contact, &$datarray) {
 		return false;
 	}
 
-	if (($contact['network'] != NETWORK_FEED) AND $datarray['private']) {
+	if (($contact['network'] != NETWORK_FEED) && $datarray['private']) {
 		return false;
 	}
 
@@ -1701,7 +1701,7 @@ function new_follower($importer, $contact, $datarray, $item, $sharing = false) {
 			intval($importer['uid'])
 		);
 
-		if (dbm::is_result($r) AND !in_array($r[0]['page-flags'], array(PAGE_SOAPBOX, PAGE_FREELOVE))) {
+		if (dbm::is_result($r) && !in_array($r[0]['page-flags'], array(PAGE_SOAPBOX, PAGE_FREELOVE))) {
 
 			// create notification
 			$hash = random_string();
@@ -1741,7 +1741,7 @@ function new_follower($importer, $contact, $datarray, $item, $sharing = false) {
 				));
 
 			}
-		} elseif (dbm::is_result($r) AND in_array($r[0]['page-flags'], array(PAGE_SOAPBOX, PAGE_FREELOVE))) {
+		} elseif (dbm::is_result($r) && in_array($r[0]['page-flags'], array(PAGE_SOAPBOX, PAGE_FREELOVE))) {
 			$r = q("UPDATE `contact` SET `pending` = 0 WHERE `uid` = %d AND `url` = '%s' AND `pending` LIMIT 1",
 					intval($importer['uid']),
 					dbesc($url)
@@ -1803,7 +1803,7 @@ function subscribe_to_hub($url, $importer, $contact, $hubmode = 'subscribe') {
 
 	logger('subscribe_to_hub: ' . $hubmode . ' ' . $contact['name'] . ' to hub ' . $url . ' endpoint: '  . $push_url . ' with verifier ' . $verify_token);
 
-	if (!strlen($contact['hub-verify']) OR ($contact['hub-verify'] != $verify_token)) {
+	if (!strlen($contact['hub-verify']) || ($contact['hub-verify'] != $verify_token)) {
 		$r = q("UPDATE `contact` SET `hub-verify` = '%s' WHERE `id` = %d",
 			dbesc($verify_token),
 			intval($contact['id'])

--- a/include/items.php
+++ b/include/items.php
@@ -143,7 +143,7 @@ function title_is_body($title, $body) {
 		$body = substr($body, 0, strlen($title));
 	}
 
-	if (($title != $body) and (substr($title, -3) == "...")) {
+	if (($title != $body) && (substr($title, -3) == "...")) {
 		$pos = strrpos($title, "...");
 		if ($pos > 0) {
 			$title = substr($title, 0, $pos);
@@ -1282,7 +1282,7 @@ function get_item_id($guid, $uid = 0) {
 	// Does the given user have this item?
 	if ($uid) {
 		$r = q("SELECT `item`.`id`, `user`.`nickname` FROM `item` INNER JOIN `user` ON `user`.`uid` = `item`.`uid`
-			WHERE `item`.`visible` = 1 AND `item`.`deleted` = 0 and `item`.`moderated` = 0
+			WHERE `item`.`visible` = 1 AND `item`.`deleted` = 0 AND `item`.`moderated` = 0
 				AND `item`.`guid` = '%s' AND `item`.`uid` = %d", dbesc($guid), intval($uid));
 		if (dbm::is_result($r)) {
 			$id = $r[0]["id"];
@@ -1293,7 +1293,7 @@ function get_item_id($guid, $uid = 0) {
 	// Or is it anywhere on the server?
 	if ($nick == "") {
 		$r = q("SELECT `item`.`id`, `user`.`nickname` FROM `item` INNER JOIN `user` ON `user`.`uid` = `item`.`uid`
-			WHERE `item`.`visible` = 1 AND `item`.`deleted` = 0 and `item`.`moderated` = 0
+			WHERE `item`.`visible` = 1 AND `item`.`deleted` = 0 AND `item`.`moderated` = 0
 				AND `item`.`allow_cid` = ''  AND `item`.`allow_gid` = ''
 				AND `item`.`deny_cid`  = '' AND `item`.`deny_gid`  = ''
 				AND `item`.`private` = 0 AND `item`.`wall` = 1

--- a/include/message.php
+++ b/include/message.php
@@ -108,7 +108,7 @@ function send_message($recipient=0, $body='', $subject='', $replyto=''){
 	);
 
 
-	$r = q("SELECT * FROM `mail` WHERE `uri` = '%s' and `uid` = %d LIMIT 1",
+	$r = q("SELECT * FROM `mail` WHERE `uri` = '%s' AND `uid` = %d LIMIT 1",
 		dbesc($uri),
 		intval(local_user())
 	);

--- a/include/msgclean.php
+++ b/include/msgclean.php
@@ -124,7 +124,7 @@ function removesig($message)
 
 	// Sollte sich der Signaturtrenner innerhalb eines Quotes befinden
 	// wird keine Signaturtrennung ausgefuehrt
-	if (($sigpos < $quotepos) and ($sigpos != 0))
+	if (($sigpos < $quotepos) && ($sigpos != 0))
 		return(array('body' => $message, 'sig' => ''));
 
 	/// @TODO Regexp umstellen, so dass auf 1 oder kein Leerzeichen
@@ -135,7 +135,7 @@ function removesig($message)
 
 	preg_match($pattern, $message, $result);
 
-	if (($result[1] != '') and ($result[2] != '')) {
+	if (($result[1] != '') && ($result[2] != '')) {
 		$cleaned = trim($result[1])."\n";
 		$sig = trim($result[2]);
 		//	'[hr][size=x-small][color=darkblue]'.trim($result[2]).'[/color][/size]';
@@ -157,8 +157,8 @@ function removelinebreak($message)
 	foreach ($arrbody as $i => $line) {
 		$currquotelevel = 0;
 		$currline = $line;
-		while ((strlen($currline)>0) and ((substr($currline, 0, 1) == '>')
- 			or (substr($currline, 0, 1) == ' '))) {
+		while ((strlen($currline)>0) && ((substr($currline, 0, 1) == '>')
+ 			|| (substr($currline, 0, 1) == ' '))) {
 			if (substr($currline, 0, 1) == '>')
 				$currquotelevel++;
 
@@ -167,8 +167,8 @@ function removelinebreak($message)
 
 		$quotelevel = 0;
 		$nextline = trim($arrbody[$i+1]);
-		while ((strlen($nextline)>0) and ((substr($nextline, 0, 1) == '>')
- 			or (substr($nextline, 0, 1) == ' '))) {
+		while ((strlen($nextline)>0) && ((substr($nextline, 0, 1) == '>')
+ 			|| (substr($nextline, 0, 1) == ' '))) {
 			if (substr($nextline, 0, 1) == '>')
 				$quotelevel++;
 
@@ -178,21 +178,21 @@ function removelinebreak($message)
 		$len = strlen($line);
 		$firstword = strpos($nextline.' ', ' ');
 
-		$specialchars = ((substr(trim($nextline), 0, 1) == '-') or
-				(substr(trim($nextline), 0, 1) == '=') or
-				(substr(trim($nextline), 0, 1) == '*') or
-				(substr(trim($nextline), 0, 1) == '·') or
-				(substr(trim($nextline), 0, 4) == '[url') or
-				(substr(trim($nextline), 0, 5) == '[size') or
-				(substr(trim($nextline), 0, 7) == 'http://') or
+		$specialchars = ((substr(trim($nextline), 0, 1) == '-') ||
+				(substr(trim($nextline), 0, 1) == '=') ||
+				(substr(trim($nextline), 0, 1) == '*') ||
+				(substr(trim($nextline), 0, 1) == '·') ||
+				(substr(trim($nextline), 0, 4) == '[url') ||
+				(substr(trim($nextline), 0, 5) == '[size') ||
+				(substr(trim($nextline), 0, 7) == 'http://') ||
 				(substr(trim($nextline), 0, 8) == 'https://'));
 
 		if (!$specialchars)
-			$specialchars = ((substr(rtrim($line), -1) == '-') or
-					(substr(rtrim($line), -1) == '=') or
-					(substr(rtrim($line), -1) == '*') or
-					(substr(rtrim($line), -1) == '·') or
-					(substr(rtrim($line), -6) == '[/url]') or
+			$specialchars = ((substr(rtrim($line), -1) == '-') ||
+					(substr(rtrim($line), -1) == '=') ||
+					(substr(rtrim($line), -1) == '*') ||
+					(substr(rtrim($line), -1) == '·') ||
+					(substr(rtrim($line), -6) == '[/url]') ||
 					(substr(rtrim($line), -7) == '[/size]'));
 
 		//if ($specialchars)
@@ -202,8 +202,8 @@ function removelinebreak($message)
 			if (substr($lines[$lineno], -1) != ' ')
 			$lines[$lineno] .= ' ';
 
-			while ((strlen($line)>0) and ((substr($line, 0, 1) == '>')
- 			or (substr($line, 0, 1) == ' '))) {
+			while ((strlen($line)>0) && ((substr($line, 0, 1) == '>')
+ 			|| (substr($line, 0, 1) == ' '))) {
 
 				$line = ltrim(substr($line, 1));
 			}
@@ -213,10 +213,10 @@ function removelinebreak($message)
 		//	$lines[$lineno] = $quotelevel.'-'.$len.'-'.$firstword.'-';
 
 		$lines[$lineno] .= $line;
-		//if ((($len + $firstword < 68) and (substr($line, -1, 1) != ' '))
-		//	or ($quotelevel != $currquotelevel) or $specialchars)
+		//if ((($len + $firstword < 68) && (substr($line, -1, 1) != ' '))
+		//	|| ($quotelevel != $currquotelevel) || $specialchars)
 		if (((substr($line, -1, 1) != ' '))
-			or ($quotelevel != $currquotelevel))
+			|| ($quotelevel != $currquotelevel))
 			$lineno++;
 	}
 	return(implode("\n", $lines));

--- a/include/nav.php
+++ b/include/nav.php
@@ -121,7 +121,7 @@ function nav_info(App $a)
 		$nav['apps'] = array('apps', t('Apps'), '', t('Addon applications, utilities, games'));
 	}
 
-	if (local_user() OR !get_config('system', 'local_search')) {
+	if (local_user() || !get_config('system', 'local_search')) {
 		$nav['search'] = array('search', t('Search'), '', t('Search site content'));
 
 		$nav['searchoption'] = array(

--- a/include/network.php
+++ b/include/network.php
@@ -187,7 +187,7 @@ function z_fetch_url($url, $binary = false, &$redirects = 0, $opts = array()) {
 
 		$newurl = $curl_info['redirect_url'];
 
-		if (($new_location_info['path'] == '') AND ( $new_location_info['host'] != '')) {
+		if (($new_location_info['path'] == '') && ( $new_location_info['host'] != '')) {
 			$newurl = $new_location_info['scheme'] . '://' . $new_location_info['host'] . $old_location_info['path'];
 		}
 
@@ -818,8 +818,8 @@ function original_url($url, $depth = 1, $fetchbody = false) {
 	if ($http_code == 0)
 		return($url);
 
-	if ((($curl_info['http_code'] == "301") OR ($curl_info['http_code'] == "302"))
-		AND (($curl_info['redirect_url'] != "") OR ($curl_info['location'] != ""))) {
+	if ((($curl_info['http_code'] == "301") || ($curl_info['http_code'] == "302"))
+		&& (($curl_info['redirect_url'] != "") || ($curl_info['location'] != ""))) {
 		if ($curl_info['redirect_url'] != "")
 			return(original_url($curl_info['redirect_url'], ++$depth, $fetchbody));
 		else
@@ -835,7 +835,7 @@ function original_url($url, $depth = 1, $fetchbody = false) {
 		return($url);
 
 	// if it isn't a HTML file then exit
-	if (($curl_info["content_type"] != "") AND !strstr(strtolower($curl_info["content_type"]),"html"))
+	if (($curl_info["content_type"] != "") && !strstr(strtolower($curl_info["content_type"]),"html"))
 		return($url);
 
 	$stamp1 = microtime(true);
@@ -929,7 +929,7 @@ function json_return_and_die($x) {
  */
 function matching_url($url1, $url2) {
 
-	if (($url1 == "") OR ($url2 == ""))
+	if (($url1 == "") || ($url2 == ""))
 		return "";
 
 	$url1 = normalise_link($url1);
@@ -938,7 +938,7 @@ function matching_url($url1, $url2) {
 	$parts1 = parse_url($url1);
 	$parts2 = parse_url($url2);
 
-	if (!isset($parts1["host"]) OR !isset($parts2["host"]))
+	if (!isset($parts1["host"]) || !isset($parts2["host"]))
 		return "";
 
 	if ($parts1["scheme"] != $parts2["scheme"])
@@ -967,7 +967,7 @@ function matching_url($url1, $url2) {
 		if ($path1 == $path2)
 			$path .= $path1."/";
 
-	} while (($path1 == $path2) AND ($i++ <= count($pathparts1)));
+	} while (($path1 == $path2) && ($i++ <= count($pathparts1)));
 
 	$match .= $path;
 

--- a/include/notifier.php
+++ b/include/notifier.php
@@ -163,7 +163,7 @@ function notifier_run(&$argv, &$argc){
 		$recipients_relocate = q("SELECT * FROM contact WHERE uid = %d  AND self = 0 AND network = '%s'" , intval($uid), NETWORK_DFRN);
 	} else {
 		// find ancestors
-		$r = q("SELECT * FROM `item` WHERE `id` = %d and visible = 1 and moderated = 0 LIMIT 1",
+		$r = q("SELECT * FROM `item` WHERE `id` = %d AND visible = 1 AND moderated = 0 LIMIT 1",
 			intval($item_id)
 		);
 
@@ -177,7 +177,7 @@ function notifier_run(&$argv, &$argc){
 		$updated = $r[0]['edited'];
 
 		$items = q("SELECT `item`.*, `sign`.`signed_text`,`sign`.`signature`,`sign`.`signer`
-			FROM `item` LEFT JOIN `sign` ON `sign`.`iid` = `item`.`id` WHERE `parent` = %d and visible = 1 and moderated = 0 ORDER BY `id` ASC",
+			FROM `item` LEFT JOIN `sign` ON `sign`.`iid` = `item`.`id` WHERE `parent` = %d AND visible = 1 AND moderated = 0 ORDER BY `id` ASC",
 			intval($parent_id)
 		);
 

--- a/include/notifier.php
+++ b/include/notifier.php
@@ -306,13 +306,13 @@ function notifier_run(&$argv, &$argc){
 			$recipients = array($parent['contact-id']);
 			$recipients_followup  = array($parent['contact-id']);
 
-			//if (!$target_item['private'] AND $target_item['wall'] AND
-			if (!$target_item['private'] AND
+			//if (!$target_item['private'] && $target_item['wall'] &&
+			if (!$target_item['private'] &&
 				(strlen($target_item['allow_cid'].$target_item['allow_gid'].
 					$target_item['deny_cid'].$target_item['deny_gid']) == 0))
 				$push_notify = true;
 
-			if (($thr_parent AND ($thr_parent[0]['network'] == NETWORK_OSTATUS)) OR ($parent['network'] == NETWORK_OSTATUS)) {
+			if (($thr_parent && ($thr_parent[0]['network'] == NETWORK_OSTATUS)) || ($parent['network'] == NETWORK_OSTATUS)) {
 
 				$push_notify = true;
 
@@ -396,7 +396,7 @@ function notifier_run(&$argv, &$argc){
 
 		// If the thread parent is OStatus then do some magic to distribute the messages.
 		// We have not only to look at the parent, since it could be a Friendica thread.
-		if (($thr_parent AND ($thr_parent[0]['network'] == NETWORK_OSTATUS)) OR ($parent['network'] == NETWORK_OSTATUS)) {
+		if (($thr_parent && ($thr_parent[0]['network'] == NETWORK_OSTATUS)) || ($parent['network'] == NETWORK_OSTATUS)) {
 
 			$diaspora_delivery = false;
 
@@ -573,7 +573,7 @@ function notifier_run(&$argv, &$argc){
 	}
 
 	// Notify PuSH subscribers (Used for OStatus distribution of regular posts)
-	if ($push_notify AND strlen($hub)) {
+	if ($push_notify && strlen($hub)) {
 		$hubs = explode(',', $hub);
 		if (count($hubs)) {
 			foreach ($hubs as $h) {

--- a/include/oembed.php
+++ b/include/oembed.php
@@ -108,7 +108,7 @@ function oembed_fetch_url($embedurl, $no_rich_type = false){
 	$j->embedurl = $embedurl;
 
 	// If fetching information doesn't work, then improve via internal functions
-	if (($j->type == "error") OR ($no_rich_type AND ($j->type == "rich"))) {
+	if (($j->type == "error") || ($no_rich_type && ($j->type == "rich"))) {
 		$data = ParseUrl::getSiteinfoCached($embedurl, true, false);
 		$j->type = $data["type"];
 
@@ -194,7 +194,7 @@ function oembed_format_object($j){
 			if (isset($j->author_name)) {
 				$ret.=" (".$j->author_name.")";
 			}
-		} elseif (isset($j->provider_name) OR isset($j->author_name)) {
+		} elseif (isset($j->provider_name) || isset($j->author_name)) {
 			$embedlink = "";
 			if (isset($j->provider_name)) {
 				$embedlink .= $j->provider_name;

--- a/include/onepoll.php
+++ b/include/onepoll.php
@@ -69,8 +69,8 @@ function onepoll_run(&$argv, &$argc){
 
 	// load current friends if possible.
 	if (($contact['poco'] != "") && ($contact['success_update'] > $contact['failure_update'])) {
-		$r = q("SELECT count(*) as total from glink
-			where `cid` = %d and updated > UTC_TIMESTAMP() - INTERVAL 1 DAY",
+		$r = q("SELECT count(*) AS total FROM glink
+			WHERE `cid` = %d AND updated > UTC_TIMESTAMP() - INTERVAL 1 DAY",
 			intval($contact['id'])
 		);
 		if (dbm::is_result($r)) {
@@ -467,15 +467,15 @@ function onepoll_run(&$argv, &$argc){
 						$datarray['created'] = datetime_convert('UTC','UTC',$meta->date);
 
 						// Is it a reply?
-						$reply = ((substr(strtolower($datarray['title']), 0, 3) == "re:") or
-							(substr(strtolower($datarray['title']), 0, 3) == "re-") or
+						$reply = ((substr(strtolower($datarray['title']), 0, 3) == "re:") ||
+							(substr(strtolower($datarray['title']), 0, 3) == "re-") ||
 							($raw_refs != ""));
 
 						// Remove Reply-signs in the subject
 						$datarray['title'] = RemoveReply($datarray['title']);
 
 						// If it seems to be a reply but a header couldn't be found take the last message with matching subject
-						if (!x($datarray,'parent-uri') and $reply) {
+						if (!x($datarray,'parent-uri') && $reply) {
 							$r = q("SELECT `uri` , `parent-uri` FROM `item` WHERE `title` = \"%s\" AND `uid` = %d AND `network` = '%s' ORDER BY `created` DESC LIMIT 1",
 								dbesc(protect_sprintf($datarray['title'])),
 								intval($importer_uid),

--- a/include/onepoll.php
+++ b/include/onepoll.php
@@ -68,7 +68,7 @@ function onepoll_run(&$argv, &$argc){
 	$contact = $contacts[0];
 
 	// load current friends if possible.
-	if (($contact['poco'] != "") AND ($contact['success_update'] > $contact['failure_update'])) {
+	if (($contact['poco'] != "") && ($contact['success_update'] > $contact['failure_update'])) {
 		$r = q("SELECT count(*) as total from glink
 			where `cid` = %d and updated > UTC_TIMESTAMP() - INTERVAL 1 DAY",
 			intval($contact['id'])
@@ -395,7 +395,7 @@ function onepoll_run(&$argv, &$argc){
 							logger("Mail: Seen before ".$msg_uid." for ".$mailconf[0]['user']." UID: ".$importer_uid." URI: ".$datarray['uri'],LOGGER_DEBUG);
 
 							// Only delete when mails aren't automatically moved or deleted
-							if (($mailconf[0]['action'] != 1) AND ($mailconf[0]['action'] != 3))
+							if (($mailconf[0]['action'] != 1) && ($mailconf[0]['action'] != 3))
 								if ($meta->deleted && ! $r[0]['deleted']) {
 									q("UPDATE `item` SET `deleted` = 1, `changed` = '%s' WHERE `id` = %d",
 										dbesc(datetime_convert()),

--- a/include/ostatus.php
+++ b/include/ostatus.php
@@ -54,7 +54,7 @@ class ostatus {
 		$alternate = $xpath->query("atom:author/atom:link[@rel='alternate']", $context)->item(0)->attributes;
 		if (is_object($alternate)) {
 			foreach ($alternate AS $attributes) {
-				if (($attributes->name == "href") AND ($attributes->textContent != "")) {
+				if (($attributes->name == "href") && ($attributes->textContent != "")) {
 					$author["author-link"] = $attributes->textContent;
 				}
 			}
@@ -100,7 +100,7 @@ class ostatus {
 					$width = $attributes->textContent;
 				}
 			}
-			if (($width > 0) AND ($href != "")) {
+			if (($width > 0) && ($href != "")) {
 				$avatarlist[$width] = $href;
 			}
 		}
@@ -119,7 +119,7 @@ class ostatus {
 		$author["owner-avatar"] = $author["author-avatar"];
 
 		// Only update the contacts if it is an OStatus contact
-		if ($r AND !$onlyfetch AND ($contact["network"] == NETWORK_OSTATUS)) {
+		if ($r && !$onlyfetch && ($contact["network"] == NETWORK_OSTATUS)) {
 
 			// Update contact data
 
@@ -153,8 +153,8 @@ class ostatus {
 			if ($value != "")
 				$contact["location"] = $value;
 
-			if (($contact["name"] != $r[0]["name"]) OR ($contact["nick"] != $r[0]["nick"]) OR ($contact["about"] != $r[0]["about"]) OR
-				($contact["alias"] != $r[0]["alias"]) OR ($contact["location"] != $r[0]["location"])) {
+			if (($contact["name"] != $r[0]["name"]) || ($contact["nick"] != $r[0]["nick"]) || ($contact["about"] != $r[0]["about"]) ||
+				($contact["alias"] != $r[0]["alias"]) || ($contact["location"] != $r[0]["location"])) {
 
 				logger("Update contact data for contact ".$contact["id"], LOGGER_DEBUG);
 
@@ -164,7 +164,7 @@ class ostatus {
 					dbesc(datetime_convert()), intval($contact["id"]));
 			}
 
-			if (isset($author["author-avatar"]) AND ($author["author-avatar"] != $r[0]['avatar'])) {
+			if (isset($author["author-avatar"]) && ($author["author-avatar"] != $r[0]['avatar'])) {
 				logger("Update profile picture for contact ".$contact["id"], LOGGER_DEBUG);
 
 				update_contact_avatar($author["author-avatar"], $importer["uid"], $contact["id"]);
@@ -354,13 +354,13 @@ class ostatus {
 			$item["verb"] = $xpath->query('activity:verb/text()', $entry)->item(0)->nodeValue;
 
 			// Mastodon Content Warning
-			if (($item["verb"] == ACTIVITY_POST) AND $xpath->evaluate('boolean(atom:summary)', $entry)) {
+			if (($item["verb"] == ACTIVITY_POST) && $xpath->evaluate('boolean(atom:summary)', $entry)) {
 				$clear_text = $xpath->query('atom:summary/text()', $entry)->item(0)->nodeValue;
 
 				$item["body"] = html2bbcode($clear_text) . '[spoiler]' . $item["body"] . '[/spoiler]';
 			}
 
-			if (($item["object-type"] == ACTIVITY_OBJ_BOOKMARK) OR ($item["object-type"] == ACTIVITY_OBJ_EVENT)) {
+			if (($item["object-type"] == ACTIVITY_OBJ_BOOKMARK) || ($item["object-type"] == ACTIVITY_OBJ_EVENT)) {
 				$item["title"] = $xpath->query('atom:title/text()', $entry)->item(0)->nodeValue;
 				$item["body"] = $xpath->query('atom:summary/text()', $entry)->item(0)->nodeValue;
 			} elseif ($item["object-type"] == ACTIVITY_OBJ_QUESTION) {
@@ -469,11 +469,11 @@ class ostatus {
 				foreach ($links AS $link) {
 					$attribute = self::read_attributes($link);
 
-					if (($attribute['rel'] != "") AND ($attribute['href'] != "")) {
+					if (($attribute['rel'] != "") && ($attribute['href'] != "")) {
 						switch ($attribute['rel']) {
 							case "alternate":
 								$item["plink"] = $attribute['href'];
-								if (($item["object-type"] == ACTIVITY_OBJ_QUESTION) OR
+								if (($item["object-type"] == ACTIVITY_OBJ_QUESTION) ||
 									($item["object-type"] == ACTIVITY_OBJ_EVENT)) {
 									$item["body"] .= add_page_info($attribute['href']);
 								}
@@ -525,7 +525,7 @@ class ostatus {
 			$repeat_of = "";
 
 			$notice_info = $xpath->query('statusnet:notice_info', $entry);
-			if ($notice_info AND ($notice_info->length > 0)) {
+			if ($notice_info && ($notice_info->length > 0)) {
 				foreach ($notice_info->item(0)->attributes AS $attributes) {
 					if ($attributes->name == "source") {
 						$item["app"] = strip_tags($attributes->textContent);
@@ -540,7 +540,7 @@ class ostatus {
 			}
 
 			// Is it a repeated post?
-			if (($repeat_of != "") OR ($item["verb"] == ACTIVITY_SHARE)) {
+			if (($repeat_of != "") || ($item["verb"] == ACTIVITY_SHARE)) {
 				$activityobjects = $xpath->query('activity:object', $entry)->item(0);
 
 				if (is_object($activityobjects)) {
@@ -550,7 +550,7 @@ class ostatus {
 						$orig_uri = $xpath->query('atom:id/text()', $activityobjects)->item(0)->nodeValue;
 					}
 					$orig_links = $xpath->query("activity:object/atom:link[@rel='alternate']", $activityobjects);
-					if ($orig_links AND ($orig_links->length > 0)) {
+					if ($orig_links && ($orig_links->length > 0)) {
 						foreach ($orig_links->item(0)->attributes AS $attributes) {
 							if ($attributes->name == "href") {
 								$orig_link = $attributes->textContent;
@@ -621,8 +621,8 @@ class ostatus {
 					intval($importer["uid"]), dbesc($item["parent-uri"]));
 
 				// Only fetch missing stuff if it is a comment or reshare.
-				if (in_array($item["verb"], array(ACTIVITY_POST, ACTIVITY_SHARE)) AND
-					!dbm::is_result($r) AND ($related != "")) {
+				if (in_array($item["verb"], array(ACTIVITY_POST, ACTIVITY_SHARE)) &&
+					!dbm::is_result($r) && ($related != "")) {
 					$reply_path = str_replace("/notice/", "/api/statuses/show/", $related).".atom";
 
 					if ($reply_path != $related) {
@@ -668,16 +668,16 @@ class ostatus {
 	public static function convert_href($href) {
 		$elements = explode(":",$href);
 
-		if ((count($elements) <= 2) OR ($elements[0] != "tag"))
+		if ((count($elements) <= 2) || ($elements[0] != "tag"))
 			return $href;
 
 		$server = explode(",", $elements[1]);
 		$conversation = explode("=", $elements[2]);
 
-		if ((count($elements) == 4) AND ($elements[2] == "post"))
+		if ((count($elements) == 4) && ($elements[2] == "post"))
 			return "http://".$server[0]."/notice/".$elements[3];
 
-		if ((count($conversation) != 2) OR ($conversation[1] ==""))
+		if ((count($conversation) != 2) || ($conversation[1] ==""))
 			return $href;
 
 		if ($elements[3] == "objectType=thread")
@@ -703,7 +703,7 @@ class ostatus {
 		}
 
 		// Don't poll if the interval is set negative
-		if (($poll_interval < 0) AND !$override) {
+		if (($poll_interval < 0) && !$override) {
 			return;
 		}
 
@@ -720,7 +720,7 @@ class ostatus {
 		}
 
 
-		if ($last AND !$override) {
+		if ($last && !$override) {
 			$next = $last + ($poll_interval * 60);
 			if ($next > time()) {
 				logger('poll interval not reached');
@@ -818,7 +818,7 @@ class ostatus {
 		if ($conversation_id != "") {
 			$elements = explode(":", $conversation_id);
 
-			if ((count($elements) <= 2) OR ($elements[0] != "tag"))
+			if ((count($elements) <= 2) || ($elements[0] != "tag"))
 				return $conversation_id;
 		}
 
@@ -933,8 +933,8 @@ class ostatus {
 
 		// If the thread shouldn't be completed then store the item and go away
 		// Don't do a completion on liked content
-		if (((intval(get_config('system','ostatus_poll_interval')) == -2) AND (count($item) > 0)) OR
-			($item["verb"] == ACTIVITY_LIKE) OR ($conversation_url == "")) {
+		if (((intval(get_config('system','ostatus_poll_interval')) == -2) && (count($item) > 0)) ||
+			($item["verb"] == ACTIVITY_LIKE) || ($conversation_url == "")) {
 			$item_stored = item_store($item, $all_threads);
 			return $item_stored;
 		}
@@ -979,10 +979,10 @@ class ostatus {
 			$conv_arr = z_fetch_url($conv."?page=".$pageno);
 
 			// If it is a non-ssl site and there is an error, then try ssl or vice versa
-			if (!$conv_arr["success"] AND (substr($conv, 0, 7) == "http://")) {
+			if (!$conv_arr["success"] && (substr($conv, 0, 7) == "http://")) {
 				$conv = str_replace("http://", "https://", $conv);
 				$conv_as = fetch_url($conv."?page=".$pageno);
-			} elseif (!$conv_arr["success"] AND (substr($conv, 0, 8) == "https://")) {
+			} elseif (!$conv_arr["success"] && (substr($conv, 0, 8) == "https://")) {
 				$conv = str_replace("https://", "http://", $conv);
 				$conv_as = fetch_url($conv."?page=".$pageno);
 			} else
@@ -1057,7 +1057,7 @@ class ostatus {
 				// 1. Our conversation hasn't the "real" thread starter
 				// 2. This first post is a post inside our thread
 				// 3. This first post is a post inside another thread
-				if (($first_id != $parent["uri"]) AND ($parent["uri"] != "")) {
+				if (($first_id != $parent["uri"]) && ($parent["uri"] != "")) {
 
 					$new_parent = true;
 
@@ -1144,7 +1144,7 @@ class ostatus {
 				}
 
 				// The item we are having on the system is the one that we wanted to store via the item array
-				if (isset($item["uri"]) AND ($item["uri"] == $existing_message["uri"])) {
+				if (isset($item["uri"]) && ($item["uri"] == $existing_message["uri"])) {
 					$item = array();
 					$item_stored = 0;
 				}
@@ -1164,7 +1164,7 @@ class ostatus {
 			$details = self::get_actor_details($actor, $uid, $parent["contact-id"]);
 
 			// Do we only want to import threads that were started by our contacts?
-			if ($details["not_following"] AND $new_parent AND get_config('system','ostatus_full_threads')) {
+			if ($details["not_following"] && $new_parent && get_config('system','ostatus_full_threads')) {
 				logger("Don't import uri ".$first_id." because user ".$uid." doesn't follow the person ".$actor, LOGGER_DEBUG);
 				continue;
 			}
@@ -1218,7 +1218,7 @@ class ostatus {
 			$arr["coord"] = trim($single_conv->location->lat." ".$single_conv->location->lon);
 
 			// Is it a reshared item?
-			if (isset($single_conv->verb) AND ($single_conv->verb == "share") AND isset($single_conv->object)) {
+			if (isset($single_conv->verb) && ($single_conv->verb == "share") && isset($single_conv->object)) {
 				if (is_array($single_conv->object))
 					$single_conv->object = $single_conv->object[0];
 
@@ -1277,7 +1277,7 @@ class ostatus {
 				unset($arr["coord"]);
 
 			// Copy fields from given item array
-			if (isset($item["uri"]) AND (($item["uri"] == $arr["uri"]) OR ($item["uri"] ==  $single_conv->id))) {
+			if (isset($item["uri"]) && (($item["uri"] == $arr["uri"]) || ($item["uri"] ==  $single_conv->id))) {
 				logger('Use stored item array for item with URI '.$item["uri"], LOGGER_DEBUG);
 				$newitem = item_store($item);
 				$item = array();
@@ -1307,7 +1307,7 @@ class ostatus {
 			}
 		}
 
-		if (($item_stored < 0) AND (count($item) > 0)) {
+		if (($item_stored < 0) && (count($item) > 0)) {
 
 			if (get_config('system','ostatus_full_threads')) {
 				$details = self::get_actor_details($item["owner-link"], $uid, $item["contact-id"]);
@@ -1543,7 +1543,7 @@ class ostatus {
 				break;
 		}
 
-		if (($siteinfo["type"] != "photo") AND isset($siteinfo["image"])) {
+		if (($siteinfo["type"] != "photo") && isset($siteinfo["image"])) {
 			$imgdata = get_photo_info($siteinfo["image"]);
 			$attributes = array("rel" => "enclosure",
 					"href" => $siteinfo["image"],
@@ -1788,7 +1788,7 @@ class ostatus {
 	 */
 	private function reshare_entry($doc, $item, $owner, $repeated_guid, $toplevel) {
 
-		if (($item["id"] != $item["parent"]) AND (normalise_link($item["author-link"]) != normalise_link($owner["url"]))) {
+		if (($item["id"] != $item["parent"]) && (normalise_link($item["author-link"]) != normalise_link($owner["url"]))) {
 			logger("OStatus entry is from author ".$owner["url"]." - not from ".$item["author-link"].". Quitting.", LOGGER_DEBUG);
 		}
 
@@ -1854,7 +1854,7 @@ class ostatus {
 	 */
 	private function like_entry($doc, $item, $owner, $toplevel) {
 
-		if (($item["id"] != $item["parent"]) AND (normalise_link($item["author-link"]) != normalise_link($owner["url"]))) {
+		if (($item["id"] != $item["parent"]) && (normalise_link($item["author-link"]) != normalise_link($owner["url"]))) {
 			logger("OStatus entry is from author ".$owner["url"]." - not from ".$item["author-link"].". Quitting.", LOGGER_DEBUG);
 		}
 
@@ -1999,7 +1999,7 @@ class ostatus {
 	 */
 	private function note_entry($doc, $item, $owner, $toplevel) {
 
-		if (($item["id"] != $item["parent"]) AND (normalise_link($item["author-link"]) != normalise_link($owner["url"]))) {
+		if (($item["id"] != $item["parent"]) && (normalise_link($item["author-link"]) != normalise_link($owner["url"]))) {
 			logger("OStatus entry is from author ".$owner["url"]." - not from ".$item["author-link"].". Quitting.", LOGGER_DEBUG);
 		}
 
@@ -2080,7 +2080,7 @@ class ostatus {
 		xml::add_element($doc, $entry, "link", "", array("rel" => "alternate", "type" => "text/html",
 								"href" => App::get_baseurl()."/display/".$item["guid"]));
 
-		if ($complete AND ($item["id"] > 0))
+		if ($complete && ($item["id"] > 0))
 			xml::add_element($doc, $entry, "status_net", "", array("notice_id" => $item["id"]));
 
 		xml::add_element($doc, $entry, "activity:verb", $verb);
@@ -2102,7 +2102,7 @@ class ostatus {
 
 		$mentioned = array();
 
-		if (($item['parent'] != $item['id']) OR ($item['parent-uri'] !== $item['uri']) OR (($item['thr-parent'] !== '') AND ($item['thr-parent'] !== $item['uri']))) {
+		if (($item['parent'] != $item['id']) || ($item['parent-uri'] !== $item['uri']) || (($item['thr-parent'] !== '') && ($item['thr-parent'] !== $item['uri']))) {
 			$parent = q("SELECT `guid`, `author-link`, `owner-link` FROM `item` WHERE `id` = %d", intval($item["parent"]));
 			$parent_item = (($item['thr-parent']) ? $item['thr-parent'] : $item['parent-uri']);
 
@@ -2175,7 +2175,7 @@ class ostatus {
 			$r = q("SELECT `forum`, `prv` FROM `contact` WHERE `uid` = %d AND `nurl` = '%s'",
 				intval($owner["uid"]),
 				dbesc(normalise_link($mention)));
-			if ($r[0]["forum"] OR $r[0]["prv"])
+			if ($r[0]["forum"] || $r[0]["prv"])
 				xml::add_element($doc, $entry, "link", "", array("rel" => "mentioned",
 											"ostatus:object-type" => ACTIVITY_OBJ_GROUP,
 											"href" => $mention));
@@ -2201,7 +2201,7 @@ class ostatus {
 
 		self::get_attachment($doc, $entry, $item);
 
-		if ($complete AND ($item["id"] > 0)) {
+		if ($complete && ($item["id"] > 0)) {
 			$app = $item["app"];
 			if ($app == "")
 				$app = "web";

--- a/include/photos.php
+++ b/include/photos.php
@@ -12,7 +12,7 @@ function getGps($exifCoord, $hemi) {
 	$minutes = count($exifCoord) > 1 ? gps2Num($exifCoord[1]) : 0;
 	$seconds = count($exifCoord) > 2 ? gps2Num($exifCoord[2]) : 0;
 
-	$flip = ($hemi == 'W' or $hemi == 'S') ? -1 : 1;
+	$flip = ($hemi == 'W' || $hemi == 'S') ? -1 : 1;
 
 	return floatval($flip * ($degrees + ($minutes / 60) + ($seconds / 3600)));
 }

--- a/include/photos.php
+++ b/include/photos.php
@@ -44,7 +44,7 @@ function photo_albums($uid, $update = false) {
 
 	$key = "photo_albums:".$uid.":".local_user().":".remote_user();
 	$albums = Cache::get($key);
-	if (is_null($albums) OR $update) {
+	if (is_null($albums) || $update) {
 		if (!Config::get('system', 'no_count', false)) {
 			/// @todo This query needs to be renewed. It is really slow
 			// At this time we just store the data in the cache

--- a/include/pidfile.php
+++ b/include/pidfile.php
@@ -8,7 +8,7 @@ class pidfile {
 
 		if (file_exists($this->_file)) {
 			$pid = trim(@file_get_contents($this->_file));
-			if (($pid != "") AND posix_kill($pid, 0)) {
+			if (($pid != "") && posix_kill($pid, 0)) {
 				$this->_running = true;
 			}
 		}

--- a/include/plaintext.php
+++ b/include/plaintext.php
@@ -54,7 +54,7 @@ function get_old_attachment_data($body) {
 
 				$picturedata = get_photo_info($matches[1]);
 
-				if (($picturedata[0] >= 500) AND ($picturedata[0] >= $picturedata[1]))
+				if (($picturedata[0] >= 500) && ($picturedata[0] >= $picturedata[1]))
 					$post["image"] = $matches[1];
 				else
 					$post["preview"] = $matches[1];
@@ -64,8 +64,8 @@ function get_old_attachment_data($body) {
 				$post["url"] = $matches[1];
 				$post["title"] = $matches[2];
 			}
-			if (($post["url"] == "") AND (in_array($post["type"], array("link", "video")))
-				AND preg_match("/\[url\=([$URLSearchString]*)\](.*?)\[\/url\]/ism", $attacheddata, $matches)) {
+			if (($post["url"] == "") && (in_array($post["type"], array("link", "video")))
+				&& preg_match("/\[url\=([$URLSearchString]*)\](.*?)\[\/url\]/ism", $attacheddata, $matches)) {
 				$post["url"] = $matches[1];
 			}
 
@@ -204,7 +204,7 @@ function get_attached_data($body) {
 				// Workaround:
 				// Sometimes photo posts to the own album are not detected at the start.
 				// So we seem to cannot use the cache for these cases. That's strange.
-				if (($data["type"] != "photo") AND strstr($pictures[0][1], "/photos/"))
+				if (($data["type"] != "photo") && strstr($pictures[0][1], "/photos/"))
 					$data = ParseUrl::getSiteinfo($pictures[0][1], true);
 
 				if ($data["type"] == "photo") {
@@ -256,7 +256,7 @@ function get_attached_data($body) {
 			$post["type"] = "text";
 			$post["text"] = trim($body);
 		}
-	} elseif (isset($post["url"]) AND ($post["type"] == "video")) {
+	} elseif (isset($post["url"]) && ($post["type"] == "video")) {
 		$data = ParseUrl::getSiteinfoCached($post["url"], true);
 
 		if (isset($data["images"][0]))
@@ -278,7 +278,7 @@ function shortenmsg($msg, $limit, $twitter = false) {
 		if (iconv_strlen(trim($msg."\n".$line), "UTF-8") <= $limit)
 			$msg = trim($msg."\n".$line);
 		// Is the new message empty by now or is it a reshared message?
-		elseif (($msg == "") OR (($row == 1) AND (substr($msg, 0, 4) == $recycle)))
+		elseif (($msg == "") || (($row == 1) && (substr($msg, 0, 4) == $recycle)))
 			$msg = iconv_substr(iconv_substr(trim($msg."\n".$line), 0, $limit, "UTF-8"), 0, -3, "UTF-8").$ellipsis;
 		else
 			break;
@@ -315,7 +315,7 @@ function plaintext(App $a, $b, $limit = 0, $includedlinks = false, $htmlmode = 2
 	//$post = get_attached_data($b["body"]);
 	$post = get_attached_data($body);
 
-	if (($b["title"] != "") AND ($post["text"] != ""))
+	if (($b["title"] != "") && ($post["text"] != ""))
 		$post["text"] = trim($b["title"]."\n\n".$post["text"]);
 	elseif ($b["title"] != "")
 		$post["text"] = trim($b["title"]);
@@ -329,7 +329,7 @@ function plaintext(App $a, $b, $limit = 0, $includedlinks = false, $htmlmode = 2
 
 		// If we post to a network with no limit we only fetch
 		// an abstract exactly for this network
-		if (($limit == 0) AND ($abstract == $default_abstract))
+		if (($limit == 0) && ($abstract == $default_abstract))
 			$abstract = "";
 
 	} else // Try to guess the correct target network
@@ -373,25 +373,25 @@ function plaintext(App $a, $b, $limit = 0, $includedlinks = false, $htmlmode = 2
 		elseif ($post["type"] == "photo")
 			$link = $post["image"];
 
-		if (($msg == "") AND isset($post["title"]))
+		if (($msg == "") && isset($post["title"]))
 			$msg = trim($post["title"]);
 
-		if (($msg == "") AND isset($post["description"]))
+		if (($msg == "") && isset($post["description"]))
 			$msg = trim($post["description"]);
 
 		// If the link is already contained in the post, then it neeedn't to be added again
 		// But: if the link is beyond the limit, then it has to be added.
-		if (($link != "") AND strstr($msg, $link)) {
+		if (($link != "") && strstr($msg, $link)) {
 			$pos = strpos($msg, $link);
 
 			// Will the text be shortened in the link?
 			// Or is the link the last item in the post?
-			if (($limit > 0) AND ($pos < $limit) AND (($pos + 23 > $limit) OR ($pos + strlen($link) == strlen($msg))))
+			if (($limit > 0) && ($pos < $limit) && (($pos + 23 > $limit) || ($pos + strlen($link) == strlen($msg))))
 				$msg = trim(str_replace($link, "", $msg));
-			elseif (($limit == 0) OR ($pos < $limit)) {
+			elseif (($limit == 0) || ($pos < $limit)) {
 				// The limit has to be increased since it will be shortened - but not now
 				// Only do it with Twitter (htmlmode = 8)
-				if (($limit > 0) AND (strlen($link) > 23) AND ($htmlmode == 8))
+				if (($limit > 0) && (strlen($link) > 23) && ($htmlmode == 8))
 					$limit = $limit - 23 + strlen($link);
 
 				$link = "";
@@ -414,7 +414,7 @@ function plaintext(App $a, $b, $limit = 0, $includedlinks = false, $htmlmode = 2
 
 		if (iconv_strlen($msg, "UTF-8") > $limit) {
 
-			if (($post["type"] == "text") AND isset($post["url"]))
+			if (($post["type"] == "text") && isset($post["url"]))
 				$post["url"] = $b["plink"];
 			elseif (!isset($post["url"])) {
 				$limit = $limit - 23;

--- a/include/plugin.php
+++ b/include/plugin.php
@@ -563,7 +563,7 @@ function theme_include($file, $root = '') {
 		$root = $root . '/';
 	}
 	$theme_info = $a->theme_info;
-	if (is_array($theme_info) AND array_key_exists('extends',$theme_info)) {
+	if (is_array($theme_info) && array_key_exists('extends',$theme_info)) {
 		$parent = $theme_info['extends'];
 	} else {
 		$parent = 'NOPATH';

--- a/include/poller.php
+++ b/include/poller.php
@@ -4,7 +4,7 @@ use Friendica\App;
 use Friendica\Core\Config;
 use Friendica\Util\Lock;
 
-if (!file_exists("boot.php") AND (sizeof($_SERVER["argv"]) != 0)) {
+if (!file_exists("boot.php") && (sizeof($_SERVER["argv"]) != 0)) {
 	$directory = dirname($_SERVER["argv"][0]);
 
 	if (substr($directory, 0, 1) != "/") {
@@ -75,7 +75,7 @@ function poller_run($argv, $argc){
 	}
 
 	// Now we start additional cron processes if we should do so
-	if (($argc <= 1) OR ($argv[1] != "no_cron")) {
+	if (($argc <= 1) || ($argv[1] != "no_cron")) {
 		poller_run_cron();
 	}
 
@@ -467,7 +467,7 @@ function poller_too_much_workers() {
 		$s = q("SELECT COUNT(*) AS `total` FROM `workerqueue` WHERE `executed` <= '%s'", dbesc(NULL_DATE));
 		$entries = $s[0]["total"];
 
-		if (Config::get("system", "worker_fastlane", false) AND ($queues > 0) AND ($entries > 0) AND ($active >= $queues)) {
+		if (Config::get("system", "worker_fastlane", false) && ($queues > 0) && ($entries > 0) && ($active >= $queues)) {
 			$s = q("SELECT `priority` FROM `workerqueue` WHERE `executed` <= '%s' ORDER BY `priority` LIMIT 1", dbesc(NULL_DATE));
 			$top_priority = $s[0]["priority"];
 
@@ -475,7 +475,7 @@ function poller_too_much_workers() {
 				intval($top_priority), dbesc(NULL_DATE));
 			$high_running = dbm::is_result($s);
 
-			if (!$high_running AND ($top_priority > PRIORITY_UNDEFINED) AND ($top_priority < PRIORITY_NEGLIGIBLE)) {
+			if (!$high_running && ($top_priority > PRIORITY_UNDEFINED) && ($top_priority < PRIORITY_NEGLIGIBLE)) {
 				logger("There are jobs with priority ".$top_priority." waiting but none is executed. Open a fastlane.", LOGGER_DEBUG);
 				$queues = $active + 1;
 			}
@@ -484,7 +484,7 @@ function poller_too_much_workers() {
 		logger("Load: ".$load."/".$maxsysload." - processes: ".$active."/".$entries.$processlist." - maximum: ".$queues."/".$maxqueues, LOGGER_DEBUG);
 
 		// Are there fewer workers running as possible? Then fork a new one.
-		if (!Config::get("system", "worker_dont_fork") AND ($queues > ($active + 1)) AND ($entries > 1)) {
+		if (!Config::get("system", "worker_dont_fork") && ($queues > ($active + 1)) && ($entries > 1)) {
 			logger("Active workers: ".$active."/".$queues." Fork a new worker.", LOGGER_DEBUG);
 			$args = array("include/poller.php", "no_cron");
 			$a = get_app();
@@ -632,7 +632,7 @@ function poller_claim_process($queue) {
 	if (!$id) {
 		logger("Queue item ".$queue["id"]." vanished - skip this execution", LOGGER_DEBUG);
 		return false;
-	} elseif ((strtotime($id[0]["executed"]) <= 0) OR ($id[0]["pid"] == 0)) {
+	} elseif ((strtotime($id[0]["executed"]) <= 0) || ($id[0]["pid"] == 0)) {
 		logger("Entry for queue item ".$queue["id"]." wasn't stored - skip this execution", LOGGER_DEBUG);
 		return false;
 	} elseif ($id[0]["pid"] != $mypid) {

--- a/include/post_update.php
+++ b/include/post_update.php
@@ -45,7 +45,7 @@ function post_update_1192() {
 			WHERE `thread`.`gcontact-id` = 0 AND
 				(`thread`.`uid` IN (SELECT `uid` from `user`) OR `thread`.`uid` = 0)");
 
-		if ($r AND ($r[0]["total"] == 0)) {
+		if ($r && ($r[0]["total"] == 0)) {
 			set_config("system", "post_update_version", 1192);
 			return true;
 		}
@@ -171,7 +171,7 @@ function post_update_1198() {
 			WHERE `thread`.`author-id` = 0 AND `thread`.`owner-id` = 0 AND
 				(`thread`.`uid` IN (SELECT `uid` from `user`) OR `thread`.`uid` = 0)");
 
-		if ($r AND ($r[0]["total"] == 0)) {
+		if ($r && ($r[0]["total"] == 0)) {
 			set_config("system", "post_update_version", 1198);
 			logger("Done", LOGGER_DEBUG);
 			return true;
@@ -247,7 +247,7 @@ function post_update_1206() {
 		return false;
 	}
 	foreach ($r AS $user) {
-		if (!empty($user["lastitem_date"]) AND ($user["lastitem_date"] > $user["last-item"])) {
+		if (!empty($user["lastitem_date"]) && ($user["lastitem_date"] > $user["last-item"])) {
 			q("UPDATE `contact` SET `last-item` = '%s' WHERE `id` = %d",
 				dbesc($user["lastitem_date"]),
 				intval($user["id"]));

--- a/include/queue.php
+++ b/include/queue.php
@@ -44,7 +44,7 @@ function queue_run(&$argv, &$argc){
 		// For the first 12 hours we'll try to deliver every 15 minutes
 		// After that, we'll only attempt delivery once per hour.
 
-		$r = q("SELECT `id` FROM `queue` WHERE ((`created` > UTC_TIMESTAMP() - INTERVAL 12 HOUR && `last` < UTC_TIMESTAMP() - INTERVAL 15 MINUTE) OR (`last` < UTC_TIMESTAMP() - INTERVAL 1 HOUR)) ORDER BY `cid`, `created`");
+		$r = q("SELECT `id` FROM `queue` WHERE ((`created` > UTC_TIMESTAMP() - INTERVAL 12 HOUR AND `last` < UTC_TIMESTAMP() - INTERVAL 15 MINUTE) OR (`last` < UTC_TIMESTAMP() - INTERVAL 1 HOUR)) ORDER BY `cid`, `created`");
 
 		call_hooks('queue_predeliver', $a, $r);
 

--- a/include/queue.php
+++ b/include/queue.php
@@ -83,7 +83,7 @@ function queue_run(&$argv, &$argc){
 
 	$dead = Cache::get($cachekey_deadguy.$c[0]['notify']);
 
-	if (!is_null($dead) AND $dead) {
+	if (!is_null($dead) && $dead) {
 		logger('queue: skipping known dead url: '.$c[0]['notify']);
 		update_queue_time($q_item['id']);
 		return;
@@ -101,7 +101,7 @@ function queue_run(&$argv, &$argc){
 			Cache::set($cachekey_server.$server, $vital, CACHE_QUARTER_HOUR);
 		}
 
-		if (!is_null($vital) AND !$vital) {
+		if (!is_null($vital) && !$vital) {
 			logger('queue: skipping dead server: '.$server);
 			update_queue_time($q_item['id']);
 			return;

--- a/include/quoteconvert.php
+++ b/include/quoteconvert.php
@@ -10,7 +10,7 @@ function convertquote($body, $reply)
 		$quoteline = $arrbody[$i];
 
 		while ((strlen($quoteline)>0) and ((substr($quoteline, 0, 1) == '>')
-			or (substr($quoteline, 0, 1) == ' '))) {
+			|| (substr($quoteline, 0, 1) == ' '))) {
 			if (substr($quoteline, 0, 1) == '>')
 				$quotelevel++;
 

--- a/include/session.php
+++ b/include/session.php
@@ -65,7 +65,7 @@ function ref_session_write($id, $data) {
 
 	$memcache = cache::memcache();
 	$a = get_app();
-	if (is_object($memcache) AND is_object($a)) {
+	if (is_object($memcache) && is_object($a)) {
 		$memcache->set($a->get_hostname().":session:".$id, $data, MEMCACHE_COMPRESSED, $expire);
 		return true;
 	}

--- a/include/socgraph.php
+++ b/include/socgraph.php
@@ -150,7 +150,7 @@ function poco_load_worker($cid, $uid, $zcid, $url) {
 			$gender = $entry->gender;
 		}
 
-		if (isset($entry->generation) AND ($entry->generation > 0)) {
+		if (isset($entry->generation) && ($entry->generation > 0)) {
 			$generation = ++$entry->generation;
 		}
 
@@ -160,7 +160,7 @@ function poco_load_worker($cid, $uid, $zcid, $url) {
 			}
 		}
 
-		if (isset($entry->contactType) AND ($entry->contactType >= 0))
+		if (isset($entry->contactType) && ($entry->contactType >= 0))
 			$contact_type = $entry->contactType;
 
 		$gcontact = array("url" => $profile_url,
@@ -238,7 +238,7 @@ function sanitize_gcontact($gcontact) {
 	$alternate = poco_alternate_ostatus_url($gcontact['url']);
 
 	// The global contacts should contain the original picture, not the cached one
-	if (($gcontact['generation'] != 1) AND stristr(normalise_link($gcontact['photo']), normalise_link(App::get_baseurl()."/photo/"))) {
+	if (($gcontact['generation'] != 1) && stristr(normalise_link($gcontact['photo']), normalise_link(App::get_baseurl()."/photo/"))) {
 		$gcontact['photo'] = "";
 	}
 
@@ -250,7 +250,7 @@ function sanitize_gcontact($gcontact) {
 			$gcontact['network'] = $r[0]["network"];
 		}
 
-		if (($gcontact['network'] == "") OR ($gcontact['network'] == NETWORK_OSTATUS)) {
+		if (($gcontact['network'] == "") || ($gcontact['network'] == NETWORK_OSTATUS)) {
 			$r = q("SELECT `network`, `url` FROM `contact` WHERE `uid` = 0 AND `alias` IN ('%s', '%s') AND `network` != '' AND `network` != '%s' LIMIT 1",
 				dbesc($gcontact['url']), dbesc(normalise_link($gcontact['url'])), dbesc(NETWORK_STATUSNET)
 			);
@@ -268,13 +268,13 @@ function sanitize_gcontact($gcontact) {
 	);
 
 	if (count($x)) {
-		if (!isset($gcontact['network']) AND ($x[0]["network"] != NETWORK_STATUSNET)) {
+		if (!isset($gcontact['network']) && ($x[0]["network"] != NETWORK_STATUSNET)) {
 			$gcontact['network'] = $x[0]["network"];
 		}
 		if ($gcontact['updated'] <= NULL_DATE) {
 			$gcontact['updated'] = $x[0]["updated"];
 		}
-		if (!isset($gcontact['server_url']) AND (normalise_link($x[0]["server_url"]) != normalise_link($x[0]["url"]))) {
+		if (!isset($gcontact['server_url']) && (normalise_link($x[0]["server_url"]) != normalise_link($x[0]["url"]))) {
 			$gcontact['server_url'] = $x[0]["server_url"];
 		}
 		if (!isset($gcontact['addr'])) {
@@ -282,8 +282,8 @@ function sanitize_gcontact($gcontact) {
 		}
 	}
 
-	if ((!isset($gcontact['network']) OR !isset($gcontact['name']) OR !isset($gcontact['addr']) OR !isset($gcontact['photo']) OR !isset($gcontact['server_url']) OR $alternate)
-		AND poco_reachable($gcontact['url'], $gcontact['server_url'], $gcontact['network'], false)) {
+	if ((!isset($gcontact['network']) || !isset($gcontact['name']) || !isset($gcontact['addr']) || !isset($gcontact['photo']) || !isset($gcontact['server_url']) || $alternate)
+		&& poco_reachable($gcontact['url'], $gcontact['server_url'], $gcontact['network'], false)) {
 		$data = Probe::uri($gcontact['url']);
 
 		if ($data["network"] == NETWORK_PHANTOM) {
@@ -296,7 +296,7 @@ function sanitize_gcontact($gcontact) {
 
 		$gcontact = array_merge($gcontact, $data);
 
-		if ($alternate AND ($gcontact['network'] == NETWORK_OSTATUS)) {
+		if ($alternate && ($gcontact['network'] == NETWORK_OSTATUS)) {
 			// Delete the old entry - if it exists
 			$r = q("SELECT `id` FROM `gcontact` WHERE `nurl` = '%s'", dbesc(normalise_link($orig_profile)));
 			if ($r) {
@@ -306,7 +306,7 @@ function sanitize_gcontact($gcontact) {
 		}
 	}
 
-	if (!isset($gcontact['name']) OR !isset($gcontact['photo'])) {
+	if (!isset($gcontact['name']) || !isset($gcontact['photo'])) {
 		throw new Exception('No name and photo for URL '.$gcontact['url']);
 	}
 
@@ -481,11 +481,11 @@ function poco_last_updated($profile, $force = false) {
 		$server_url = normalise_link(poco_detect_server($profile));
 	}
 
-	if (($server_url == '') AND ($gcontacts[0]["server_url"] != "")) {
+	if (($server_url == '') && ($gcontacts[0]["server_url"] != "")) {
 		$server_url = $gcontacts[0]["server_url"];
 	}
 
-	if (!$force AND (($server_url == '') OR ($gcontacts[0]["server_url"] == $gcontacts[0]["nurl"]))) {
+	if (!$force && (($server_url == '') || ($gcontacts[0]["server_url"] == $gcontacts[0]["nurl"]))) {
 		$server_url = normalise_link(poco_detect_server($profile));
 	}
 
@@ -519,7 +519,7 @@ function poco_last_updated($profile, $force = false) {
 	}
 
 	// noscrape is really fast so we don't cache the call.
-	if (($server_url != "") AND ($gcontacts[0]["nick"] != "")) {
+	if (($server_url != "") && ($gcontacts[0]["nick"] != "")) {
 
 		//  Use noscrape if possible
 		$server = q("SELECT `noscrape`, `network` FROM `gserver` WHERE `nurl` = '%s' AND `noscrape` != ''", dbesc(normalise_link($server_url)));
@@ -527,7 +527,7 @@ function poco_last_updated($profile, $force = false) {
 		if ($server) {
 			$noscraperet = z_fetch_url($server[0]["noscrape"]."/".$gcontacts[0]["nick"]);
 
-			if ($noscraperet["success"] AND ($noscraperet["body"] != "")) {
+			if ($noscraperet["success"] && ($noscraperet["body"] != "")) {
 
 				$noscrape = json_decode($noscraperet["body"], true);
 
@@ -591,7 +591,7 @@ function poco_last_updated($profile, $force = false) {
 	}
 
 	// If we only can poll the feed, then we only do this once a while
-	if (!$force AND !poco_do_update($gcontacts[0]["created"], $gcontacts[0]["updated"], $gcontacts[0]["last_failure"], $gcontacts[0]["last_contact"])) {
+	if (!$force && !poco_do_update($gcontacts[0]["created"], $gcontacts[0]["updated"], $gcontacts[0]["last_failure"], $gcontacts[0]["last_contact"])) {
 		logger("Profile ".$profile." was last updated at ".$gcontacts[0]["updated"]." (cached)", LOGGER_DEBUG);
 
 		update_gcontact($contact);
@@ -602,8 +602,8 @@ function poco_last_updated($profile, $force = false) {
 
 	// Is the profile link the alternate OStatus link notation? (http://domain.tld/user/4711)
 	// Then check the other link and delete this one
-	if (($data["network"] == NETWORK_OSTATUS) AND poco_alternate_ostatus_url($profile) AND
-		(normalise_link($profile) == normalise_link($data["alias"])) AND
+	if (($data["network"] == NETWORK_OSTATUS) && poco_alternate_ostatus_url($profile) &&
+		(normalise_link($profile) == normalise_link($data["alias"])) &&
 		(normalise_link($profile) != normalise_link($data["url"]))) {
 
 		// Delete the old entry
@@ -627,7 +627,7 @@ function poco_last_updated($profile, $force = false) {
 		return false;
 	}
 
-	if (($data["poll"] == "") OR (in_array($data["network"], array(NETWORK_FEED, NETWORK_PHANTOM)))) {
+	if (($data["poll"] == "") || (in_array($data["network"], array(NETWORK_FEED, NETWORK_PHANTOM)))) {
 		q("UPDATE `gcontact` SET `last_failure` = '%s' WHERE `nurl` = '%s'",
 			dbesc(datetime_convert()), dbesc(normalise_link($profile)));
 
@@ -715,24 +715,24 @@ function poco_do_update($created, $updated, $last_failure,  $last_contact) {
 		return false;
 
 	// If the last contact was less than a week ago and the last failure is older than a week then don't update
-	//if ((($now - $contact_time) < (60 * 60 * 24 * 7)) AND ($contact_time > $failure_time))
+	//if ((($now - $contact_time) < (60 * 60 * 24 * 7)) && ($contact_time > $failure_time))
 	//	return false;
 
 	// If the last contact time was more than a week ago and the contact was created more than a week ago, then only try once a week
-	if ((($now - $contact_time) > (60 * 60 * 24 * 7)) AND (($now - $created_time) > (60 * 60 * 24 * 7)) AND (($now - $failure_time) < (60 * 60 * 24 * 7)))
+	if ((($now - $contact_time) > (60 * 60 * 24 * 7)) && (($now - $created_time) > (60 * 60 * 24 * 7)) && (($now - $failure_time) < (60 * 60 * 24 * 7)))
 		return false;
 
 	// If the last contact time was more than a month ago and the contact was created more than a month ago, then only try once a month
-	if ((($now - $contact_time) > (60 * 60 * 24 * 30)) AND (($now - $created_time) > (60 * 60 * 24 * 30)) AND (($now - $failure_time) < (60 * 60 * 24 * 30)))
+	if ((($now - $contact_time) > (60 * 60 * 24 * 30)) && (($now - $created_time) > (60 * 60 * 24 * 30)) && (($now - $failure_time) < (60 * 60 * 24 * 30)))
 		return false;
 
 	return true;
 }
 
 function poco_to_boolean($val) {
-	if (($val == "true") OR ($val == 1))
+	if (($val == "true") || ($val == 1))
 		return(true);
-	if (($val == "false") OR ($val == 0))
+	if (($val == "false") || ($val == 0))
 		return(false);
 
 	return ($val);
@@ -823,7 +823,7 @@ function poco_fetch_nodeinfo($server_url) {
 
 	$server['register_policy'] = REGISTER_CLOSED;
 
-	if (is_bool($nodeinfo->openRegistrations) AND $nodeinfo->openRegistrations) {
+	if (is_bool($nodeinfo->openRegistrations) && $nodeinfo->openRegistrations) {
 		$server['register_policy'] = REGISTER_OPEN;
 	}
 
@@ -975,7 +975,7 @@ function poco_check_server($server_url, $network = "", $force = false) {
 		$info = $servers[0]["info"];
 		$register_policy = $servers[0]["register_policy"];
 
-		if (!$force AND !poco_do_update($servers[0]["created"], "", $last_failure, $last_contact)) {
+		if (!$force && !poco_do_update($servers[0]["created"], "", $last_failure, $last_contact)) {
 			logger("Use cached data for server ".$server_url, LOGGER_DEBUG);
 			return ($last_contact >= $last_failure);
 		}
@@ -1007,7 +1007,7 @@ function poco_check_server($server_url, $network = "", $force = false) {
 
 	// Quit if there is a timeout.
 	// But we want to make sure to only quit if we are mostly sure that this server url fits.
-	if (dbm::is_result($servers) AND ($orig_server_url == $server_url) AND
+	if (dbm::is_result($servers) && ($orig_server_url == $server_url) &&
 		($serverret['errno'] == CURLE_OPERATION_TIMEDOUT)) {
 		logger("Connection to server ".$server_url." timed out.", LOGGER_DEBUG);
 		dba::p("UPDATE `gserver` SET `last_failure` = ? WHERE `nurl` = ?", datetime_convert(), normalise_link($server_url));
@@ -1016,7 +1016,7 @@ function poco_check_server($server_url, $network = "", $force = false) {
 
 	// Maybe the page is unencrypted only?
 	$xmlobj = @simplexml_load_string($serverret["body"],'SimpleXMLElement',0, "http://docs.oasis-open.org/ns/xri/xrd-1.0");
-	if (!$serverret["success"] OR ($serverret["body"] == "") OR (@sizeof($xmlobj) == 0) OR !is_object($xmlobj)) {
+	if (!$serverret["success"] || ($serverret["body"] == "") || (@sizeof($xmlobj) == 0) || !is_object($xmlobj)) {
 		$server_url = str_replace("https://", "http://", $server_url);
 
 		// We set the timeout to 20 seconds since this operation should be done in no time if the server was vital
@@ -1032,7 +1032,7 @@ function poco_check_server($server_url, $network = "", $force = false) {
 		$xmlobj = @simplexml_load_string($serverret["body"],'SimpleXMLElement',0, "http://docs.oasis-open.org/ns/xri/xrd-1.0");
 	}
 
-	if (!$serverret["success"] OR ($serverret["body"] == "") OR (sizeof($xmlobj) == 0) OR !is_object($xmlobj)) {
+	if (!$serverret["success"] || ($serverret["body"] == "") || (sizeof($xmlobj) == 0) || !is_object($xmlobj)) {
 		// Workaround for bad configured servers (known nginx problem)
 		if (!in_array($serverret["debug"]["http_code"], array("403", "404"))) {
 			$failure = true;
@@ -1071,7 +1071,7 @@ function poco_check_server($server_url, $network = "", $force = false) {
 		// Test for Diaspora, Hubzilla, Mastodon or older Friendica servers
 		$serverret = z_fetch_url($server_url);
 
-		if (!$serverret["success"] OR ($serverret["body"] == "")) {
+		if (!$serverret["success"] || ($serverret["body"] == "")) {
 			$failure = true;
 		} else {
 			$server = poco_detect_server_type($serverret["body"]);
@@ -1104,13 +1104,13 @@ function poco_check_server($server_url, $network = "", $force = false) {
 		}
 	}
 
-	if (!$failure AND ($poco == "")) {
+	if (!$failure && ($poco == "")) {
 		// Test for Statusnet
 		// Will also return data for Friendica and GNU Social - but it will be overwritten later
 		// The "not implemented" is a special treatment for really, really old Friendica versions
 		$serverret = z_fetch_url($server_url."/api/statusnet/version.json");
-		if ($serverret["success"] AND ($serverret["body"] != '{"error":"not implemented"}') AND
-			($serverret["body"] != '') AND (strlen($serverret["body"]) < 30)) {
+		if ($serverret["success"] && ($serverret["body"] != '{"error":"not implemented"}') &&
+			($serverret["body"] != '') && (strlen($serverret["body"]) < 30)) {
 			$platform = "StatusNet";
 			// Remove junk that some GNU Social servers return
 			$version = str_replace(chr(239).chr(187).chr(191), "", $serverret["body"]);
@@ -1120,8 +1120,8 @@ function poco_check_server($server_url, $network = "", $force = false) {
 
 		// Test for GNU Social
 		$serverret = z_fetch_url($server_url."/api/gnusocial/version.json");
-		if ($serverret["success"] AND ($serverret["body"] != '{"error":"not implemented"}') AND
-			($serverret["body"] != '') AND (strlen($serverret["body"]) < 30)) {
+		if ($serverret["success"] && ($serverret["body"] != '{"error":"not implemented"}') &&
+			($serverret["body"] != '') && (strlen($serverret["body"]) < 30)) {
 			$platform = "GNU Social";
 			// Remove junk that some GNU Social servers return
 			$version = str_replace(chr(239).chr(187).chr(191), "", $serverret["body"]);
@@ -1131,7 +1131,7 @@ function poco_check_server($server_url, $network = "", $force = false) {
 
 		// Test for Mastodon
 		$serverret = z_fetch_url($server_url."/api/v1/instance");
-		if ($serverret["success"] AND ($serverret["body"] != '')) {
+		if ($serverret["success"] && ($serverret["body"] != '')) {
 			$data = json_decode($serverret["body"]);
 			if (isset($data->version)) {
 				$platform = "Mastodon";
@@ -1185,9 +1185,9 @@ function poco_check_server($server_url, $network = "", $force = false) {
 				$data->site->private = poco_to_boolean($data->site->private);
 				$data->site->inviteonly = poco_to_boolean($data->site->inviteonly);
 
-				if (!$data->site->closed AND !$data->site->private and $data->site->inviteonly)
+				if (!$data->site->closed && !$data->site->private and $data->site->inviteonly)
 					$register_policy = REGISTER_APPROVE;
-				elseif (!$data->site->closed AND !$data->site->private)
+				elseif (!$data->site->closed && !$data->site->private)
 					$register_policy = REGISTER_OPEN;
 				else
 					$register_policy = REGISTER_CLOSED;
@@ -1251,7 +1251,7 @@ function poco_check_server($server_url, $network = "", $force = false) {
 
 	// Check for noscrape
 	// Friendica servers could be detected as OStatus servers
-	if (!$failure AND in_array($network, array(NETWORK_DFRN, NETWORK_OSTATUS))) {
+	if (!$failure && in_array($network, array(NETWORK_DFRN, NETWORK_OSTATUS))) {
 		$serverret = z_fetch_url($server_url."/friendica/json");
 
 		if (!$serverret["success"])
@@ -1285,7 +1285,7 @@ function poco_check_server($server_url, $network = "", $force = false) {
 		}
 	}
 
-	if ($possible_failure AND !$failure) {
+	if ($possible_failure && !$failure) {
 		$failure = true;
 	}
 
@@ -1297,9 +1297,9 @@ function poco_check_server($server_url, $network = "", $force = false) {
 		$last_failure = $orig_last_failure;
 	}
 
-	if (($last_contact <= $last_failure) AND !$failure) {
+	if (($last_contact <= $last_failure) && !$failure) {
 		logger("Server ".$server_url." seems to be alive, but last contact wasn't set - could be a bug", LOGGER_DEBUG);
-	} else if (($last_contact >= $last_failure) AND $failure) {
+	} else if (($last_contact >= $last_failure) && $failure) {
 		logger("Server ".$server_url." seems to be dead, but last failure wasn't set - could be a bug", LOGGER_DEBUG);
 	}
 
@@ -1729,7 +1729,7 @@ function poco_discover_single_server($id) {
 				$success = poco_discover_server(json_decode($retdata["body"]));
 			}
 
-			if (!$success AND (get_config('system','poco_discovery') > 2)) {
+			if (!$success && (get_config('system','poco_discovery') > 2)) {
 				logger("Fetch contacts from users of the server ".$server["nurl"], LOGGER_DEBUG);
 				poco_discover_server_users($data, $server);
 			}
@@ -1776,7 +1776,7 @@ function poco_discover($complete = false) {
 			logger('Update directory from server '.$server['url'].' with ID '.$server['id'], LOGGER_DEBUG);
 			proc_run(PRIORITY_LOW, "include/discover_poco.php", "update_server_directory", intval($server['id']));
 
-			if (!$complete AND (--$no_of_queries == 0)) {
+			if (!$complete && (--$no_of_queries == 0)) {
 				break;
 			}
 		}
@@ -1813,7 +1813,7 @@ function poco_discover_server_users($data, $server) {
 
 function poco_discover_server($data, $default_generation = 0) {
 
-	if (!isset($data->entry) OR !count($data->entry))
+	if (!isset($data->entry) || !count($data->entry))
 		return false;
 
 	$success = false;
@@ -1876,11 +1876,11 @@ function poco_discover_server($data, $default_generation = 0) {
 			$gender = $entry->gender;
 		}
 
-		if(isset($entry->generation) AND ($entry->generation > 0)) {
+		if(isset($entry->generation) && ($entry->generation > 0)) {
 			$generation = ++$entry->generation;
 		}
 
-		if(isset($entry->contactType) AND ($entry->contactType >= 0)) {
+		if(isset($entry->contactType) && ($entry->contactType >= 0)) {
 			$contact_type = $entry->contactType;
 		}
 
@@ -1930,7 +1930,7 @@ function poco_discover_server($data, $default_generation = 0) {
 function clean_contact_url($url) {
 	$parts = parse_url($url);
 
-	if (!isset($parts["scheme"]) OR !isset($parts["host"]))
+	if (!isset($parts["scheme"]) || !isset($parts["host"]))
 		return $url;
 
 	$new_url = $parts["scheme"]."://".$parts["host"];
@@ -1953,7 +1953,7 @@ function clean_contact_url($url) {
  * @param arr $contact contact array (called by reference)
  */
 function fix_alternate_contact_address(&$contact) {
-	if (($contact["network"] == NETWORK_OSTATUS) AND poco_alternate_ostatus_url($contact["url"])) {
+	if (($contact["network"] == NETWORK_OSTATUS) && poco_alternate_ostatus_url($contact["url"])) {
 		$data = probe_url($contact["url"]);
 		if ($contact["network"] == NETWORK_OSTATUS) {
 			logger("Fix primary url from ".$contact["url"]." to ".$data["url"]." - Called by: ".App::callstack(), LOGGER_DEBUG);
@@ -2008,7 +2008,7 @@ function get_gcontact_id($contact) {
 			$last_failure = strtotime($r[0]["last_failure"]);
 			$last_contact_str = $r[0]["last_contact"];
 			$last_contact = strtotime($r[0]["last_contact"]);
-			$doprobing = (((time() - $last_contact) > (90 * 86400)) AND ((time() - $last_failure) > (90 * 86400)));
+			$doprobing = (((time() - $last_contact) > (90 * 86400)) && ((time() - $last_failure) > (90 * 86400)));
 		}
 	} else {
 		q("INSERT INTO `gcontact` (`name`, `nick`, `addr` , `network`, `url`, `nurl`, `photo`, `created`, `updated`, `location`, `about`, `hide`, `generation`)
@@ -2056,7 +2056,7 @@ function get_gcontact_id($contact) {
 function update_gcontact($contact) {
 
 	// Check for invalid "contact-type" value
-	if (isset($contact['contact-type']) AND (intval($contact['contact-type']) < 0)) {
+	if (isset($contact['contact-type']) && (intval($contact['contact-type']) < 0)) {
 		$contact['contact-type'] = 0;
 	}
 
@@ -2091,7 +2091,7 @@ function update_gcontact($contact) {
 
 	// assign all unassigned fields from the database entry
 	foreach ($fields AS $field => $data)
-		if (!isset($contact[$field]) OR ($contact[$field] == ""))
+		if (!isset($contact[$field]) || ($contact[$field] == ""))
 			$contact[$field] = $r[0][$field];
 
 	if (!isset($contact["hide"]))
@@ -2125,7 +2125,7 @@ function update_gcontact($contact) {
 	} else
 		$contact["server_url"] = normalise_link($contact["server_url"]);
 
-	if (($contact["addr"] == "") AND ($contact["server_url"] != "") AND ($contact["nick"] != "")) {
+	if (($contact["addr"] == "") && ($contact["server_url"] != "") && ($contact["nick"] != "")) {
 		$hostname = str_replace("http://", "", $contact["server_url"]);
 		$contact["addr"] = $contact["nick"]."@".$hostname;
 	}
@@ -2134,7 +2134,7 @@ function update_gcontact($contact) {
 	$update = false;
 	unset($fields["generation"]);
 
-	if ((($contact["generation"] > 0) AND ($contact["generation"] <= $r[0]["generation"])) OR ($r[0]["generation"] == 0)) {
+	if ((($contact["generation"] > 0) && ($contact["generation"] <= $r[0]["generation"])) || ($r[0]["generation"] == 0)) {
 		foreach ($fields AS $field => $data)
 			if ($contact[$field] != $r[0][$field]) {
 				logger("Difference for contact ".$contact["url"]." in field '".$field."'. New value: '".$contact[$field]."', old value '".$r[0][$field]."'", LOGGER_DEBUG);
@@ -2240,7 +2240,7 @@ function update_gcontact_for_user($uid) {
 			"gender" => $r[0]["gender"], "keywords" => $r[0]["pub_keywords"],
 			"birthday" => $r[0]["dob"], "photo" => $r[0]["photo"],
 			"notify" => $r[0]["notify"], "url" => $r[0]["url"],
-			"hide" => ($r[0]["hidewall"] OR !$r[0]["net-publish"]),
+			"hide" => ($r[0]["hidewall"] || !$r[0]["net-publish"]),
 			"nick" => $r[0]["nickname"], "addr" => $addr,
 			"connect" => $addr, "server_url" => App::get_baseurl(),
 			"generation" => 1, "network" => NETWORK_DFRN);

--- a/include/spool_post.php
+++ b/include/spool_post.php
@@ -13,7 +13,7 @@ function spool_post_run($argv, $argc) {
 
 	$path = get_spoolpath();
 
-	if (($path != '') AND is_writable($path)){
+	if (($path != '') && is_writable($path)){
 		if ($dh = opendir($path)) {
 			while (($file = readdir($dh)) !== false) {
 
@@ -30,7 +30,7 @@ function spool_post_run($argv, $argc) {
 				}
 
 				// We can't read or write the file? So we don't care about it.
-				if (!is_writable($fullfile) OR !is_readable($fullfile)) {
+				if (!is_writable($fullfile) || !is_readable($fullfile)) {
 					continue;
 				}
 
@@ -42,7 +42,7 @@ function spool_post_run($argv, $argc) {
 				}
 
 				// Skip if it doesn't seem to be an item array
-				if (!isset($arr['uid']) AND !isset($arr['uri']) AND !isset($arr['network'])) {
+				if (!isset($arr['uid']) && !isset($arr['uri']) && !isset($arr['network'])) {
 					continue;
 				}
 

--- a/include/tags.php
+++ b/include/tags.php
@@ -31,7 +31,7 @@ function create_tags_from_item($itemid) {
 
 	$tags = "";
 	foreach ($taglist as $tag)
-		if ((substr(trim($tag), 0, 1) == "#") OR (substr(trim($tag), 0, 1) == "@"))
+		if ((substr(trim($tag), 0, 1) == "#") || (substr(trim($tag), 0, 1) == "@"))
 			$tags .= " ".trim($tag);
 		else
 			$tags .= " #".trim($tag);
@@ -91,7 +91,7 @@ function create_tags_from_item($itemid) {
 			dbesc($link), dbesc($message["guid"]), dbesc($message["created"]), dbesc($message["received"]), intval($global));
 
 		// Search for mentions
-		if ((substr($tag, 0, 1) == '@') AND (strpos($link, $profile_base_friendica) OR strpos($link, $profile_base_diaspora))) {
+		if ((substr($tag, 0, 1) == '@') && (strpos($link, $profile_base_friendica) || strpos($link, $profile_base_diaspora))) {
 			$users = q("SELECT `uid` FROM `contact` WHERE self AND (`url` = '%s' OR `nurl` = '%s')", $link, $link);
 			foreach ($users AS $user) {
 				if ($user["uid"] == $message["uid"]) {

--- a/include/text.php
+++ b/include/text.php
@@ -287,7 +287,7 @@ function paginate_data(App $a, $count = null) {
 	$stripped = trim($stripped, '/');
 	$pagenum = $a->pager['page'];
 
-	if (($a->page_offset != '') AND !preg_match('/[?&].offset=/', $stripped)) {
+	if (($a->page_offset != '') && !preg_match('/[?&].offset=/', $stripped)) {
 		$stripped .= '&offset=' . urlencode($a->page_offset);
 	}
 
@@ -1265,8 +1265,8 @@ function redir_private_images($a, &$item)
 
 function put_item_in_cache(&$item, $update = false) {
 
-	if (($item["rendered-hash"] != hash("md5", $item["body"])) OR ($item["rendered-hash"] == "") OR
-		($item["rendered-html"] == "") OR get_config("system", "ignore_cache")) {
+	if (($item["rendered-hash"] != hash("md5", $item["body"])) || ($item["rendered-hash"] == "") ||
+		($item["rendered-html"] == "") || get_config("system", "ignore_cache")) {
 
 		// The function "redir_private_images" changes the body.
 		// I'm not sure if we should store it permanently, so we save the old value.
@@ -1279,7 +1279,7 @@ function put_item_in_cache(&$item, $update = false) {
 		$item["rendered-hash"] = hash("md5", $item["body"]);
 		$item["body"] = $body;
 
-		if ($update AND ($item["id"] != 0)) {
+		if ($update && ($item["id"] != 0)) {
 			q("UPDATE `item` SET `rendered-html` = '%s', `rendered-hash` = '%s' WHERE `id` = %d",
 				dbesc($item["rendered-html"]), dbesc($item["rendered-hash"]), intval($item["id"]));
 		}
@@ -1340,7 +1340,7 @@ function prepare_body(&$item,$attach = false, $preview = false) {
 	$update = (!local_user() and !remote_user() and ($item["uid"] == 0));
 
 	// Or update it if the current viewer is the intented viewer
-	if (($item["uid"] == local_user()) AND ($item["uid"] != 0))
+	if (($item["uid"] == local_user()) && ($item["uid"] != 0))
 		$update = true;
 
 	put_item_in_cache($item, $update);

--- a/include/threads.php
+++ b/include/threads.php
@@ -45,12 +45,12 @@ function add_shadow_thread($itemid) {
 	$item = $items[0];
 
 	// is it already a copy?
-	if (($itemid == 0) OR ($item['uid'] == 0)) {
+	if (($itemid == 0) || ($item['uid'] == 0)) {
 		return;
 	}
 
 	// Is it a visible public post?
-	if (!$item["visible"] OR $item["deleted"] OR $item["moderated"] OR $item["private"]) {
+	if (!$item["visible"] || $item["deleted"] || $item["moderated"] || $item["private"]) {
 		return;
 	}
 
@@ -86,8 +86,8 @@ function add_shadow_thread($itemid) {
 
 	$item = q("SELECT * FROM `item` WHERE `id` = %d", intval($itemid));
 
-	if (count($item) AND ($item[0]["allow_cid"] == '')  AND ($item[0]["allow_gid"] == '') AND
-		($item[0]["deny_cid"] == '') AND ($item[0]["deny_gid"] == '')) {
+	if (count($item) && ($item[0]["allow_cid"] == '')  && ($item[0]["allow_gid"] == '') &&
+		($item[0]["deny_cid"] == '') && ($item[0]["deny_gid"] == '')) {
 
 		$r = q("SELECT `id` FROM `item` WHERE `uri` = '%s' AND `uid` = 0 LIMIT 1",
 			dbesc($item['uri']));

--- a/include/update_gcontact.php
+++ b/include/update_gcontact.php
@@ -40,16 +40,16 @@ function update_gcontact_run(&$argv, &$argc) {
 		return;
 	}
 
-	if (($data["name"] == "") AND ($r[0]['name'] != ""))
+	if (($data["name"] == "") && ($r[0]['name'] != ""))
 		$data["name"] = $r[0]['name'];
 
-	if (($data["nick"] == "") AND ($r[0]['nick'] != ""))
+	if (($data["nick"] == "") && ($r[0]['nick'] != ""))
 		$data["nick"] = $r[0]['nick'];
 
-	if (($data["addr"] == "") AND ($r[0]['addr'] != ""))
+	if (($data["addr"] == "") && ($r[0]['addr'] != ""))
 		$data["addr"] = $r[0]['addr'];
 
-	if (($data["photo"] == "") AND ($r[0]['photo'] != ""))
+	if (($data["photo"] == "") && ($r[0]['photo'] != ""))
 		$data["photo"] = $r[0]['photo'];
 
 

--- a/include/xml.php
+++ b/include/xml.php
@@ -323,7 +323,7 @@ class xml {
 
 			if ($type == "open") {   // The starting of the tag '<tag>'
 				$parent[$level-1] = &$current;
-				if (!is_array($current) or (!in_array($tag, array_keys($current)))) { // Insert New tag
+				if (!is_array($current) || (!in_array($tag, array_keys($current)))) { // Insert New tag
 					$current[$tag] = $result;
 					if ($attributes_data) {
 						$current[$tag. '_attr'] = $attributes_data;

--- a/include/xml.php
+++ b/include/xml.php
@@ -51,7 +51,7 @@ class xml {
 		}
 
 		foreach($array as $key => $value) {
-			if (!isset($element) AND isset($xml)) {
+			if (!isset($element) && isset($xml)) {
 				$element = $xml;
 			}
 
@@ -67,7 +67,7 @@ class xml {
 			}
 
 			$element_parts = explode(":", $key);
-			if ((count($element_parts) > 1) AND isset($namespaces[$element_parts[0]])) {
+			if ((count($element_parts) > 1) && isset($namespaces[$element_parts[0]])) {
 				$namespace = $namespaces[$element_parts[0]];
 			} elseif (isset($namespaces[""])) {
 				$namespace = $namespaces[""];
@@ -76,18 +76,18 @@ class xml {
 			}
 
 			// Remove undefined namespaces from the key
-			if ((count($element_parts) > 1) AND is_null($namespace)) {
+			if ((count($element_parts) > 1) && is_null($namespace)) {
 				$key = $element_parts[1];
 			}
 
 			if (substr($key, 0, 11) == "@attributes") {
-				if (!isset($element) OR !is_array($value)) {
+				if (!isset($element) || !is_array($value)) {
 					continue;
 				}
 
 				foreach ($value as $attr_key => $attr_value) {
 					$element_parts = explode(":", $attr_key);
-					if ((count($element_parts) > 1) AND isset($namespaces[$element_parts[0]])) {
+					if ((count($element_parts) > 1) && isset($namespaces[$element_parts[0]])) {
 						$namespace = $namespaces[$element_parts[0]];
 					} else {
 						$namespace = NULL;
@@ -399,7 +399,7 @@ class xml {
 
 	/**
 	 * @brief Delete a node in a XML object
-	 * 
+	 *
 	 * @param object $doc XML document
 	 * @param string $node Node name
 	 */

--- a/index.php
+++ b/index.php
@@ -59,15 +59,15 @@ if (!$install) {
 
 	Config::load();
 
-	if ($a->max_processes_reached() OR $a->maxload_reached()) {
+	if ($a->max_processes_reached() || $a->maxload_reached()) {
 		header($_SERVER["SERVER_PROTOCOL"] . ' 503 Service Temporarily Unavailable');
 		header('Retry-After: 120');
 		header('Refresh: 120; url=' . App::get_baseurl() . "/" . $a->query_string);
 		die("System is currently unavailable. Please try again later");
 	}
 
-	if (get_config('system', 'force_ssl') AND ($a->get_scheme() == "http") AND
-		(intval(get_config('system', 'ssl_policy')) == SSL_POLICY_FULL) AND
+	if (get_config('system', 'force_ssl') && ($a->get_scheme() == "http") &&
+		(intval(get_config('system', 'ssl_policy')) == SSL_POLICY_FULL) &&
 		(substr(App::get_baseurl(), 0, 8) == "https://")) {
 		header("HTTP/1.1 302 Moved Temporarily");
 		header("Location: " . App::get_baseurl() . "/" . $a->query_string);
@@ -128,7 +128,7 @@ if ((x($_SESSION,'language')) && ($_SESSION['language'] !== $lang)) {
 if ((x($_GET,'zrl')) && (!$install && !$maintenance)) {
 	// Only continue when the given profile link seems valid
 	// Valid profile links contain a path with "/profile/" and no query parameters
-	if ((parse_url($_GET['zrl'], PHP_URL_QUERY) == "") AND
+	if ((parse_url($_GET['zrl'], PHP_URL_QUERY) == "") &&
 		strstr(parse_url($_GET['zrl'], PHP_URL_PATH), "/profile/")) {
 		$_SESSION['my_url'] = $_GET['zrl'];
 		$a->query_string = preg_replace('/[\?&]zrl=(.*?)([\?&]|$)/is','',$a->query_string);
@@ -245,7 +245,7 @@ if (strlen($a->module)) {
 	}
 
 	// Compatibility with the Firefox App
-	if (($a->module == "users") AND ($a->cmd == "users/sign_in")) {
+	if (($a->module == "users") && ($a->cmd == "users/sign_in")) {
 		$a->module = "login";
 	}
 
@@ -450,7 +450,7 @@ if (!$a->theme['stylesheet']) {
 $a->page['htmlhead'] = str_replace('{{$stylesheet}}',$stylesheet,$a->page['htmlhead']);
 //$a->page['htmlhead'] = replace_macros($a->page['htmlhead'], array('$stylesheet' => $stylesheet));
 
-if (isset($_GET["mode"]) AND (($_GET["mode"] == "raw") OR ($_GET["mode"] == "minimal"))) {
+if (isset($_GET["mode"]) && (($_GET["mode"] == "raw") || ($_GET["mode"] == "minimal"))) {
 	$doc = new DOMDocument();
 
 	$target = new DOMDocument();
@@ -473,7 +473,7 @@ if (isset($_GET["mode"]) AND (($_GET["mode"] == "raw") OR ($_GET["mode"] == "min
 	}
 }
 
-if (isset($_GET["mode"]) AND ($_GET["mode"] == "raw")) {
+if (isset($_GET["mode"]) && ($_GET["mode"] == "raw")) {
 
 	header("Content-type: text/html; charset=utf-8");
 

--- a/mod/admin.php
+++ b/mod/admin.php
@@ -770,7 +770,7 @@ function admin_page_site_post(App $a) {
 	$worker_frontend	=	((x($_POST,'worker_frontend'))		? True						: False);
 
 	// Has the directory url changed? If yes, then resubmit the existing profiles there
-	if ($global_directory != Config::get('system', 'directory') AND ($global_directory != '')) {
+	if ($global_directory != Config::get('system', 'directory') && ($global_directory != '')) {
 		Config::set('system', 'directory', $global_directory);
 		proc_run(PRIORITY_LOW, 'include/directory.php');
 	}
@@ -936,7 +936,7 @@ function admin_page_site(App $a) {
 	/* Installed langs */
 	$lang_choices = get_available_languages();
 
-	if (strlen(get_config('system','directory_submit_url')) AND
+	if (strlen(get_config('system','directory_submit_url')) &&
 		!strlen(get_config('system','directory'))) {
 			set_config('system','directory', dirname(get_config('system','directory_submit_url')));
 			del_config('system','directory_submit_url');
@@ -958,7 +958,7 @@ function admin_page_site(App $a) {
 			$f = basename($file);
 
 			// Only show allowed themes here
-			if (($allowed_theme_list != '') AND !strstr($allowed_theme_list, $f)) {
+			if (($allowed_theme_list != '') && !strstr($allowed_theme_list, $f)) {
 				continue;
 			}
 
@@ -1183,7 +1183,7 @@ function admin_page_dbsync(App $a) {
 		goaway('admin/dbsync');
 	}
 
-	if (($a->argc > 2) AND (intval($a->argv[2]) OR ($a->argv[2] === 'check'))) {
+	if (($a->argc > 2) && (intval($a->argv[2]) || ($a->argv[2] === 'check'))) {
 		require_once("include/dbstructure.php");
 		$retval = update_structure(false, true);
 		if (!$retval) {
@@ -1663,7 +1663,7 @@ function admin_page_plugins(App $a) {
 				$show_plugin = true;
 
 				// If the addon is unsupported, then only show it, when it is enabled
-				if ((strtolower($info["status"]) == "unsupported") AND !in_array($id,  $a->plugins)) {
+				if ((strtolower($info["status"]) == "unsupported") && !in_array($id,  $a->plugins)) {
 					$show_plugin = false;
 				}
 
@@ -1801,7 +1801,7 @@ function admin_page_themes(App $a) {
 			$is_supported = 1-(intval(file_exists($file.'/unsupported')));
 			$is_allowed = intval(in_array($f,$allowed_themes));
 
-			if ($is_allowed OR $is_supported OR get_config("system", "show_unsupported_themes")) {
+			if ($is_allowed || $is_supported || get_config("system", "show_unsupported_themes")) {
 				$themes[] = array('name' => $f, 'experimental' => $is_experimental, 'supported' => $is_supported, 'allowed' => $is_allowed);
 			}
 		}

--- a/mod/community.php
+++ b/mod/community.php
@@ -68,14 +68,14 @@ function community_content(App $a, $update = 0) {
 				}
 				$previousauthor = $item["author-link"];
 
-				if (($numposts < $maxpostperauthor) AND (sizeof($s) < $a->pager['itemspage'])) {
+				if (($numposts < $maxpostperauthor) && (sizeof($s) < $a->pager['itemspage'])) {
 					$s[] = $item;
 				}
 			}
 			if ((sizeof($s) < $a->pager['itemspage'])) {
 				$r = community_getitems($a->pager['start'] + ($count * $a->pager['itemspage']), $a->pager['itemspage']);
 			}
-		} while ((sizeof($s) < $a->pager['itemspage']) AND (++$count < 50) AND (sizeof($r) > 0));
+		} while ((sizeof($s) < $a->pager['itemspage']) && (++$count < 50) && (sizeof($r) > 0));
 	} else {
 		$s = $r;
 	}

--- a/mod/contacts.php
+++ b/mod/contacts.php
@@ -17,7 +17,7 @@ function contacts_init(App $a) {
 
 	$contact_id = 0;
 
-	if((($a->argc == 2) && intval($a->argv[1])) OR (($a->argc == 3) && intval($a->argv[1]) && ($a->argv[2] == "posts"))) {
+	if((($a->argc == 2) && intval($a->argv[1])) || (($a->argc == 3) && intval($a->argv[1]) && ($a->argv[2] == "posts"))) {
 		$contact_id = intval($a->argv[1]);
 		$r = q("SELECT * FROM `contact` WHERE `uid` = %d and `id` = %d LIMIT 1",
 			intval(local_user()),
@@ -42,7 +42,7 @@ function contacts_init(App $a) {
 	if ($contact_id) {
 		$a->data['contact'] = $r[0];
 
-		if (($a->data['contact']['network'] != "") AND ($a->data['contact']['network'] != NETWORK_DFRN)) {
+		if (($a->data['contact']['network'] != "") && ($a->data['contact']['network'] != NETWORK_DFRN)) {
 			$networkname = format_network_name($a->data['contact']['network'],$a->data['contact']['url']);
 		} else {
 			$networkname = '';
@@ -266,7 +266,7 @@ function _contact_update_profile($contact_id) {
 	$data = Probe::uri($r[0]["url"], "", 0, false);
 
 	// "Feed" or "Unknown" is mostly a sign of communication problems
-	if ((in_array($data["network"], array(NETWORK_FEED, NETWORK_PHANTOM))) AND ($data["network"] != $r[0]["network"]))
+	if ((in_array($data["network"], array(NETWORK_FEED, NETWORK_PHANTOM))) && ($data["network"] != $r[0]["network"]))
 		return;
 
 	$updatefields = array("name", "nick", "url", "addr", "batch", "notify", "poll", "request", "confirm",
@@ -281,14 +281,14 @@ function _contact_update_profile($contact_id) {
 	}
 
 	foreach($updatefields AS $field)
-		if (isset($data[$field]) AND ($data[$field] != ""))
+		if (isset($data[$field]) && ($data[$field] != ""))
 			$update[$field] = $data[$field];
 
 	$update["nurl"] = normalise_link($data["url"]);
 
 	$query = "";
 
-	if (isset($data["priority"]) AND ($data["priority"] != 0))
+	if (isset($data["priority"]) && ($data["priority"] != 0))
 		$query = "`priority` = ".intval($data["priority"]);
 
 	foreach($update AS $key => $value) {
@@ -573,7 +573,7 @@ function contacts_content(App $a) {
 		if ($contact['network'] == NETWORK_DFRN)
 			$profile_select = contact_profile_assign($contact['profile-id'],(($contact['network'] !== NETWORK_DFRN) ? true : false));
 
-		if (in_array($contact['network'], array(NETWORK_DIASPORA, NETWORK_OSTATUS)) AND
+		if (in_array($contact['network'], array(NETWORK_DIASPORA, NETWORK_OSTATUS)) &&
 			($contact['rel'] == CONTACT_IS_FOLLOWER))
 			$follow = App::get_baseurl(true)."/follow?url=".urlencode($contact["url"]);
 

--- a/mod/dfrn_request.php
+++ b/mod/dfrn_request.php
@@ -626,7 +626,7 @@ function dfrn_request_post(App $a) {
 			);
 			// NOTREACHED
 			// END $network === NETWORK_DFRN
-		} elseif (($network != NETWORK_PHANTOM) AND ($url != "")) {
+		} elseif (($network != NETWORK_PHANTOM) && ($url != "")) {
 
 			/*
 			 *
@@ -693,7 +693,7 @@ function dfrn_request_content(App $a) {
 		$confirm_key = (x($_GET,'confirm_key') ? $_GET['confirm_key'] : "");
 
 		// Checking fastlane for validity
-		if (x($_SESSION, "fastlane") AND (normalise_link($_SESSION["fastlane"]) == normalise_link($dfrn_url))) {
+		if (x($_SESSION, "fastlane") && (normalise_link($_SESSION["fastlane"]) == normalise_link($dfrn_url))) {
 			$_POST["dfrn_url"] = $dfrn_url;
 			$_POST["confirm_key"] = $confirm_key;
 			$_POST["localconfirm"] = 1;
@@ -813,9 +813,9 @@ function dfrn_request_content(App $a) {
 
 		// At first look if an address was provided
 		// Otherwise take the local address
-		if (x($_GET,'addr') AND ($_GET['addr'] != "")) {
+		if (x($_GET,'addr') && ($_GET['addr'] != "")) {
 			$myaddr = hex2bin($_GET['addr']);
-		} elseif (x($_GET,'address') AND ($_GET['address'] != "")) {
+		} elseif (x($_GET,'address') && ($_GET['address'] != "")) {
 			$myaddr = $_GET['address'];
 		} elseif (local_user()) {
 			if (strlen($a->path)) {

--- a/mod/dirfind.php
+++ b/mod/dirfind.php
@@ -37,7 +37,7 @@ function dirfind_content(App $a, $prefix = "") {
 	if (strpos($search,'@') === 0) {
 		$search = substr($search,1);
 		$header = sprintf( t('People Search - %s'), $search);
-		if ((valid_email($search) AND validate_email($search)) OR
+		if ((valid_email($search) && validate_email($search)) ||
 			(substr(normalise_link($search), 0, 7) == "http://")) {
 			$user_data = probe_url($search);
 			$discover_user = (in_array($user_data["network"], array(NETWORK_DFRN, NETWORK_OSTATUS, NETWORK_DIASPORA)));
@@ -75,7 +75,7 @@ function dirfind_content(App $a, $prefix = "") {
 			$j->results[] = $objresult;
 
 			// Add the contact to the global contacts if it isn't already in our system
-			if (($contact["cid"] == 0) AND ($contact["zid"] == 0) AND ($contact["gid"] == 0)) {
+			if (($contact["cid"] == 0) && ($contact["zid"] == 0) && ($contact["gid"] == 0)) {
 				update_gcontact($user_data);
 			}
 		} elseif ($local) {

--- a/mod/display.php
+++ b/mod/display.php
@@ -59,7 +59,7 @@ function display_init(App $a) {
 					WHERE `item`.`visible` AND NOT `item`.`deleted` AND NOT `item`.`moderated`
 						AND `id` = %d", $r[0]["parent"]);
 			}
-			if (($itemuid != local_user()) AND local_user()) {
+			if (($itemuid != local_user()) && local_user()) {
 				// Do we know this contact but we haven't got this item?
 				// Copy the wohle thread to our local storage so that we can interact.
 				// We really should change this need for the future since it scales very bad.
@@ -129,11 +129,11 @@ function display_fetchauthor($a, $item) {
 
 	// Skip if it isn't a pure repeated messages
 	// Does it start with a share?
-	if (!$skip AND strpos($body, "[share") > 0) {
+	if (!$skip && strpos($body, "[share") > 0) {
 		$skip = true;
 	}
 	// Does it end with a share?
-	if (!$skip AND (strlen($body) > (strrpos($body, "[/share]") + 8))) {
+	if (!$skip && (strlen($body) > (strrpos($body, "[/share]") + 8))) {
 		$skip = true;
 	}
 	if (!$skip) {
@@ -265,7 +265,7 @@ function display_content(App $a, $update = 0) {
 		}
 	}
 
-	if ($item_id AND !is_numeric($item_id)) {
+	if ($item_id && !is_numeric($item_id)) {
 		$r = qu("SELECT `id` FROM `item` WHERE `uri` = '%s' AND `uid` = %d LIMIT 1",
 			dbesc($item_id), intval($a->profile['uid']));
 		if (dbm::is_result($r)) {

--- a/mod/events.php
+++ b/mod/events.php
@@ -436,7 +436,7 @@ function events_content(App $a) {
 			$sh_checked = (($orig_event['allow_cid'] === '<' . local_user() . '>' && (! $orig_event['allow_gid']) && (! $orig_event['deny_cid']) && (! $orig_event['deny_gid'])) ? '' : ' checked="checked" ');
 		}
 
-		if ($cid OR ($mode !== 'new')) {
+		if ($cid || ($mode !== 'new')) {
 			$sh_checked .= ' disabled="disabled" ';
 		}
 

--- a/mod/fetch.php
+++ b/mod/fetch.php
@@ -11,7 +11,7 @@ require_once("include/xml.php");
 
 function fetch_init(App $a) {
 
-	if (($a->argc != 3) OR (!in_array($a->argv[1], array("post", "status_message", "reshare")))) {
+	if (($a->argc != 3) || (!in_array($a->argv[1], array("post", "status_message", "reshare")))) {
 		header($_SERVER["SERVER_PROTOCOL"].' 404 '.t('Not Found'));
 		killme();
 	}

--- a/mod/follow.php
+++ b/mod/follow.php
@@ -37,14 +37,14 @@ function follow_content(App $a) {
 
 	$ret = probe_url($url);
 
-	if (($ret["network"] == NETWORK_DIASPORA) AND !get_config('system','diaspora_enabled')) {
+	if (($ret["network"] == NETWORK_DIASPORA) && !get_config('system','diaspora_enabled')) {
 		notice( t("Diaspora support isn't enabled. Contact can't be added.") . EOL);
 		$submit = "";
 		//goaway($_SESSION['return_url']);
 		// NOTREACHED
 	}
 
-	if (($ret["network"] == NETWORK_OSTATUS) AND get_config('system','ostatus_disabled')) {
+	if (($ret["network"] == NETWORK_OSTATUS) && get_config('system','ostatus_disabled')) {
 		notice( t("OStatus support is disabled. Contact can't be added.") . EOL);
 		$submit = "";
 		//goaway($_SESSION['return_url']);

--- a/mod/item.php
+++ b/mod/item.php
@@ -139,8 +139,8 @@ function item_post(App $a) {
 
 			// If the contact id doesn't fit with the contact, then set the contact to null
 			$thrparent = q("SELECT `author-link`, `network` FROM `item` WHERE `uri` = '%s' LIMIT 1", dbesc($thr_parent));
-			if (dbm::is_result($thrparent) AND ($thrparent[0]["network"] === NETWORK_OSTATUS)
-				AND (normalise_link($parent_contact["url"]) != normalise_link($thrparent[0]["author-link"]))) {
+			if (dbm::is_result($thrparent) && ($thrparent[0]["network"] === NETWORK_OSTATUS)
+				&& (normalise_link($parent_contact["url"]) != normalise_link($thrparent[0]["author-link"]))) {
 				$parent_contact = get_contact_details_by_url($thrparent[0]["author-link"]);
 
 				if (!isset($parent_contact["nick"])) {
@@ -175,7 +175,7 @@ function item_post(App $a) {
 	$object      = ((x($_REQUEST, 'object'))      ? $_REQUEST['object']              : '');
 
 	// Check for multiple posts with the same message id (when the post was created via API)
-	if (($message_id != '') AND ($profile_uid != 0)) {
+	if (($message_id != '') && ($profile_uid != 0)) {
 		$r = q("SELECT * FROM `item` WHERE `uri` = '%s' AND `uid` = %d LIMIT 1",
 			dbesc($message_id),
 			intval($profile_uid)
@@ -309,8 +309,8 @@ function item_post(App $a) {
 
 			// for non native networks use the network of the original post as network of the item
 			if (($parent_item['network'] != NETWORK_DIASPORA)
-				AND ($parent_item['network'] != NETWORK_OSTATUS)
-				AND ($network == "")) {
+				&& ($parent_item['network'] != NETWORK_OSTATUS)
+				&& ($network == "")) {
 				$network = $parent_item['network'];
 			}
 
@@ -504,7 +504,7 @@ function item_post(App $a) {
 
 	$bookmark = 0;
 	$data = get_attachment_data($body);
-	if (preg_match_all("/\[bookmark\=([^\]]*)\](.*?)\[\/bookmark\]/ism", $body, $match, PREG_SET_ORDER) OR isset($data["type"])) {
+	if (preg_match_all("/\[bookmark\=([^\]]*)\](.*?)\[\/bookmark\]/ism", $body, $match, PREG_SET_ORDER) || isset($data["type"])) {
 		$objecttype = ACTIVITY_OBJ_BOOKMARK;
 		$bookmark = 1;
 	}
@@ -543,7 +543,7 @@ function item_post(App $a) {
 	 * add a statusnet style reply tag if the original post was from there
 	 * and we are replying, and there isn't one already
 	 */
-	if ($parent AND ($parent_contact['network'] == NETWORK_OSTATUS)) {
+	if ($parent && ($parent_contact['network'] == NETWORK_OSTATUS)) {
 		$contact = '@[url=' . $parent_contact['url'] . ']' . $parent_contact['nick'] . '[/url]';
 
 		if (!in_array($contact, $tags)) {
@@ -1226,7 +1226,7 @@ function handle_tag(App $a, &$body, &$inform, &$str_tags, $profile_uid, $tag, $n
 			}
 
 			// select someone by attag or nick and the name passed in the current network
-			if(!dbm::is_result($r) AND ($network != ""))
+			if(!dbm::is_result($r) && ($network != ""))
 				$r = q("SELECT `id`, `url`, `nick`, `name`, `alias`, `network` FROM `contact` WHERE `attag` = '%s' OR `nick` = '%s' AND `network` = '%s' AND `uid` = %d ORDER BY `attag` DESC LIMIT 1",
 						dbesc($name),
 						dbesc($name),
@@ -1235,7 +1235,7 @@ function handle_tag(App $a, &$body, &$inform, &$str_tags, $profile_uid, $tag, $n
 				);
 
 			//select someone from this user's contacts by name in the current network
-			if (!dbm::is_result($r) AND ($network != "")) {
+			if (!dbm::is_result($r) && ($network != "")) {
 				$r = q("SELECT `id`, `url`, `nick`, `name`, `alias`, `network` FROM `contact` WHERE `name` = '%s' AND `network` = '%s' AND `uid` = %d LIMIT 1",
 						dbesc($name),
 						dbesc($network),
@@ -1262,7 +1262,7 @@ function handle_tag(App $a, &$body, &$inform, &$str_tags, $profile_uid, $tag, $n
 		}
 
 		if (dbm::is_result($r)) {
-			if (strlen($inform) AND (isset($r[0]["notify"]) OR isset($r[0]["id"]))) {
+			if (strlen($inform) && (isset($r[0]["notify"]) || isset($r[0]["id"]))) {
 				$inform .= ',';
 			}
 
@@ -1275,14 +1275,14 @@ function handle_tag(App $a, &$body, &$inform, &$str_tags, $profile_uid, $tag, $n
 			$profile = $r[0]["url"];
 			$alias   = $r[0]["alias"];
 			$newname = $r[0]["nick"];
-			if (($newname == "") OR (($r[0]["network"] != NETWORK_OSTATUS) AND ($r[0]["network"] != NETWORK_TWITTER)
-				AND ($r[0]["network"] != NETWORK_STATUSNET) AND ($r[0]["network"] != NETWORK_APPNET))) {
+			if (($newname == "") || (($r[0]["network"] != NETWORK_OSTATUS) && ($r[0]["network"] != NETWORK_TWITTER)
+				&& ($r[0]["network"] != NETWORK_STATUSNET) && ($r[0]["network"] != NETWORK_APPNET))) {
 				$newname = $r[0]["name"];
 			}
 		}
 
 		//if there is an url for this persons profile
-		if (isset($profile) AND ($newname != "")) {
+		if (isset($profile) && ($newname != "")) {
 
 			$replaced = true;
 			// create profile link

--- a/mod/network.php
+++ b/mod/network.php
@@ -398,7 +398,7 @@ function network_content(App $a, $update = 0) {
 	}
 	set_pconfig(local_user(), 'network.view', 'net.selected', ($nets ? $nets : 'all'));
 
-	if(!$update AND !$rawmode) {
+	if(!$update && !$rawmode) {
 		$tabs = network_tabs($a);
 		$o .= $tabs;
 
@@ -459,7 +459,7 @@ function network_content(App $a, $update = 0) {
 	$sql_table = "`thread`";
 	$sql_parent = "`iid`";
 
-	if ($nouveau OR strlen($file) OR $update) {
+	if ($nouveau || strlen($file) || $update) {
 		$sql_table = "`item`";
 		$sql_parent = "`parent`";
 		$sql_post_table = " INNER JOIN `thread` ON `thread`.`iid` = `item`.`parent`";

--- a/mod/nodeinfo.php
+++ b/mod/nodeinfo.php
@@ -25,12 +25,12 @@ function nodeinfo_init(App $a) {
 		killme();
 	}
 
-	if (($a->argc != 2) OR ($a->argv[1] != '1.0')) {
+	if (($a->argc != 2) || ($a->argv[1] != '1.0')) {
 		http_status_exit(404);
 		killme();
 	}
 
-	$smtp = (function_exists('imap_open') AND !Config::get('system', 'imap_disabled') AND !Config::get('system', 'dfrn_only'));
+	$smtp = (function_exists('imap_open') && !Config::get('system', 'imap_disabled') && !Config::get('system', 'dfrn_only'));
 
 	$nodeinfo = array();
 	$nodeinfo['version'] = '1.0';
@@ -74,7 +74,7 @@ function nodeinfo_init(App $a) {
 		if (plugin_enabled('appnet')) {
 			$nodeinfo['services']['inbound'][] = 'appnet';
 		}
-		if (plugin_enabled('appnet') OR plugin_enabled('buffer')) {
+		if (plugin_enabled('appnet') || plugin_enabled('buffer')) {
 			$nodeinfo['services']['outbound'][] = 'appnet';
 		}
 		if (plugin_enabled('blogger')) {
@@ -83,7 +83,7 @@ function nodeinfo_init(App $a) {
 		if (plugin_enabled('dwpost')) {
 			$nodeinfo['services']['outbound'][] = 'dreamwidth';
 		}
-		if (plugin_enabled('fbpost') OR plugin_enabled('buffer')) {
+		if (plugin_enabled('fbpost') || plugin_enabled('buffer')) {
 			$nodeinfo['services']['outbound'][] = 'facebook';
 		}
 		if (plugin_enabled('statusnet')) {
@@ -91,7 +91,7 @@ function nodeinfo_init(App $a) {
 			$nodeinfo['services']['outbound'][] = 'gnusocial';
 		}
 
-		if (plugin_enabled('gpluspost') OR plugin_enabled('buffer')) {
+		if (plugin_enabled('gpluspost') || plugin_enabled('buffer')) {
 			$nodeinfo['services']['outbound'][] = 'google';
 		}
 		if (plugin_enabled('ijpost')) {
@@ -123,7 +123,7 @@ function nodeinfo_init(App $a) {
 		if (plugin_enabled('tumblr')) {
 			$nodeinfo['services']['outbound'][] = 'tumblr';
 		}
-		if (plugin_enabled('twitter') OR plugin_enabled('buffer')) {
+		if (plugin_enabled('twitter') || plugin_enabled('buffer')) {
 			$nodeinfo['services']['outbound'][] = 'twitter';
 		}
 		if (plugin_enabled('wppost')) {
@@ -203,11 +203,11 @@ function nodeinfo_cron() {
 			$month = time() - (30 * 24 * 60 * 60);
 
 			foreach ($users AS $user) {
-				if ((strtotime($user['login_date']) > $halfyear) OR
+				if ((strtotime($user['login_date']) > $halfyear) ||
 					(strtotime($user['last-item']) > $halfyear)) {
 					++$active_users_halfyear;
 				}
-				if ((strtotime($user['login_date']) > $month) OR
+				if ((strtotime($user['login_date']) > $month) ||
 					(strtotime($user['last-item']) > $month)) {
 					++$active_users_monthly;
 				}

--- a/mod/noscrape.php
+++ b/mod/noscrape.php
@@ -17,7 +17,7 @@ function noscrape_init(App $a) {
 
 	profile_load($a,$which,$profile);
 
-	if (!$a->profile['net-publish'] OR $a->profile['hidewall']) {
+	if (!$a->profile['net-publish'] || $a->profile['hidewall']) {
 		header('Content-type: application/json; charset=utf-8');
 		$json_info = array("hide" => true);
 		echo json_encode($json_info);
@@ -42,7 +42,7 @@ function noscrape_init(App $a) {
 		'tags'     => $keywords
 	);
 
-	if (is_array($a->profile) AND !$a->profile['hide-friends']) {
+	if (is_array($a->profile) && !$a->profile['hide-friends']) {
 		$r = q("SELECT `gcontact`.`updated` FROM `contact` INNER JOIN `gcontact` WHERE `gcontact`.`nurl` = `contact`.`nurl` AND `self` AND `uid` = %d LIMIT 1",
 			intval($a->profile['uid']));
 		if (dbm::is_result($r)) {

--- a/mod/photo.php
+++ b/mod/photo.php
@@ -119,7 +119,7 @@ function photo_init(App $a) {
 				intval($resolution)
 			);
 
-			$public = (dbm::is_result($r)) AND ($r[0]['allow_cid'] == '') AND ($r[0]['allow_gid'] == '') AND ($r[0]['deny_cid']  == '') AND ($r[0]['deny_gid']  == '');
+			$public = (dbm::is_result($r)) && ($r[0]['allow_cid'] == '') && ($r[0]['allow_gid'] == '') && ($r[0]['deny_cid']  == '') && ($r[0]['deny_gid']  == '');
 
 			if (dbm::is_result($r)) {
 				$resolution = $r[0]['scale'];

--- a/mod/ping.php
+++ b/mod/ping.php
@@ -330,10 +330,10 @@ function ping_init(App $a)
 
 		if (dbm::is_result($notifs)) {
 			// Are the nofications called from the regular process or via the friendica app?
-			$regularnotifications = (intval($_GET['uid']) AND intval($_GET['_']));
+			$regularnotifications = (intval($_GET['uid']) && intval($_GET['_']));
 
 			foreach ($notifs as $notif) {
-				if ($a->is_friendica_app() OR !$regularnotifications) {
+				if ($a->is_friendica_app() || !$regularnotifications) {
 					$notif['message'] = str_replace("{0}", $notif['name'], $notif['message']);
 				}
 
@@ -434,7 +434,7 @@ function ping_get_notifications($uid)
 			intval($offset)
 		);
 
-		if (!$r AND !$seen) {
+		if (!$r && !$seen) {
 			$seen = true;
 			$seensql = "";
 			$order = "DESC";
@@ -474,12 +474,12 @@ function ping_get_notifications($uid)
 
 			$notification["href"] = App::get_baseurl() . "/notify/view/" . $notification["id"];
 
-			if ($notification["visible"] AND !$notification["spam"] AND
-				!$notification["deleted"] AND !is_array($result[$notification["parent"]])) {
+			if ($notification["visible"] && !$notification["spam"] &&
+				!$notification["deleted"] && !is_array($result[$notification["parent"]])) {
 				$result[$notification["parent"]] = $notification;
 			}
 		}
-	} while ((count($result) < 50) AND !$quit);
+	} while ((count($result) < 50) && !$quit);
 
 	return($result);
 }

--- a/mod/poco.php
+++ b/mod/poco.php
@@ -55,7 +55,7 @@ function poco_init(App $a) {
 		$cid = intval($a->argv[4]);
 	}
 
-	if (! $system_mode AND ! $global) {
+	if (! $system_mode && ! $global) {
 		$users = q("SELECT `user`.*,`profile`.`hide-friends` from user left join profile on `user`.`uid` = `profile`.`uid`
 			where `user`.`nickname` = '%s' and `profile`.`is-default` = 1 limit 1",
 			dbesc($user)
@@ -157,7 +157,7 @@ function poco_init(App $a) {
 	if (x($_GET, 'filtered')) {
 		$ret['filtered'] = false;
 	}
-	if (x($_GET, 'updatedSince') AND ! $global) {
+	if (x($_GET, 'updatedSince') && ! $global) {
 		$ret['updatedSince'] = false;
 	}
 	$ret['startIndex']   = (int) $startIndex;
@@ -207,21 +207,21 @@ function poco_init(App $a) {
 					}
 				}
 
-				if (($contact['about'] == "") AND isset($contact['pabout'])) {
+				if (($contact['about'] == "") && isset($contact['pabout'])) {
 					$contact['about'] = $contact['pabout'];
 				}
 				if ($contact['location'] == "") {
 					if (isset($contact['plocation'])) {
 						$contact['location'] = $contact['plocation'];
 					}
-					if (isset($contact['pregion']) AND ( $contact['pregion'] != "")) {
+					if (isset($contact['pregion']) && ( $contact['pregion'] != "")) {
 						if ($contact['location'] != "") {
 							$contact['location'] .= ", ";
 						}
 						$contact['location'] .= $contact['pregion'];
 					}
 
-					if (isset($contact['pcountry']) AND ( $contact['pcountry'] != "")) {
+					if (isset($contact['pcountry']) && ( $contact['pcountry'] != "")) {
 						if ($contact['location'] != "") {
 							$contact['location'] .= ", ";
 						}
@@ -229,10 +229,10 @@ function poco_init(App $a) {
 					}
 				}
 
-				if (($contact['gender'] == "") AND isset($contact['pgender'])) {
+				if (($contact['gender'] == "") && isset($contact['pgender'])) {
 					$contact['gender'] = $contact['pgender'];
 				}
-				if (($contact['keywords'] == "") AND isset($contact['pub_keywords'])) {
+				if (($contact['keywords'] == "") && isset($contact['pub_keywords'])) {
 					$contact['keywords'] = $contact['pub_keywords'];
 				}
 				if (isset($contact['account-type'])) {
@@ -306,7 +306,7 @@ function poco_init(App $a) {
 					if ($entry['network'] == NETWORK_STATUSNET) {
 						$entry['network'] = NETWORK_OSTATUS;
 					}
-					if (($entry['network'] == "") AND ($contact['self'])) {
+					if (($entry['network'] == "") && ($contact['self'])) {
 						$entry['network'] = NETWORK_DFRN;
 					}
 				}

--- a/mod/proxy.php
+++ b/mod/proxy.php
@@ -48,15 +48,15 @@ function proxy_init(App $a) {
 	$basepath = $a->get_basepath();
 
 	// If the cache path isn't there, try to create it
-	if (!is_dir($basepath . '/proxy') AND is_writable($basepath)) {
+	if (!is_dir($basepath . '/proxy') && is_writable($basepath)) {
 		mkdir($basepath . '/proxy');
 	}
 
 	// Checking if caching into a folder in the webroot is activated and working
-	$direct_cache = (is_dir($basepath . '/proxy') AND is_writable($basepath . '/proxy'));
+	$direct_cache = (is_dir($basepath . '/proxy') && is_writable($basepath . '/proxy'));
 
 	// Look for filename in the arguments
-	if ((isset($a->argv[1]) OR isset($a->argv[2]) OR isset($a->argv[3])) AND !isset($_REQUEST['url'])) {
+	if ((isset($a->argv[1]) || isset($a->argv[2]) || isset($a->argv[3])) && !isset($_REQUEST['url'])) {
 		if (isset($a->argv[3])) {
 			$url = $a->argv[3];
 		} elseif (isset($a->argv[2])) {
@@ -65,7 +65,7 @@ function proxy_init(App $a) {
 			$url = $a->argv[1];
 		}
 
-		if (isset($a->argv[3]) AND ($a->argv[3] == 'thumb')) {
+		if (isset($a->argv[3]) && ($a->argv[3] == 'thumb')) {
 			$size = 200;
 		}
 
@@ -112,7 +112,7 @@ function proxy_init(App $a) {
 		$urlhash = 'pic:' . sha1($_REQUEST['url']);
 
 		$cachefile = get_cachefile(hash('md5', $_REQUEST['url']));
-		if ($cachefile != '' AND file_exists($cachefile)) {
+		if ($cachefile != '' && file_exists($cachefile)) {
 			$img_str = file_get_contents($cachefile);
 			$mime = image_type_to_mime_type(exif_imagetype($cachefile));
 
@@ -140,7 +140,7 @@ function proxy_init(App $a) {
 	$valid = true;
 	$r = array();
 
-	if (!$direct_cache AND ($cachefile == '')) {
+	if (!$direct_cache && ($cachefile == '')) {
 		$r = qu("SELECT * FROM `photo` WHERE `resource-id` = '%s' LIMIT 1", $urlhash);
 		if (dbm::is_result($r)) {
 			$img_str = $r[0]['data'];
@@ -163,7 +163,7 @@ function proxy_init(App $a) {
 		unlink($tempfile);
 
 		// If there is an error then return a blank image
-		if ((substr($a->get_curl_code(), 0, 1) == '4') OR (!$img_str)) {
+		if ((substr($a->get_curl_code(), 0, 1) == '4') || (!$img_str)) {
 			$img_str = file_get_contents('images/blank.png');
 			$mime = 'image/png';
 			$cachefile = ''; // Clear the cachefile so that the dummy isn't stored
@@ -173,7 +173,7 @@ function proxy_init(App $a) {
 				$img->scaleImage(10);
 				$img_str = $img->imageString();
 			}
-		} elseif ($mime != 'image/jpeg' AND !$direct_cache AND $cachefile == '') {
+		} elseif ($mime != 'image/jpeg' && !$direct_cache && $cachefile == '') {
 			$image = @imagecreatefromstring($img_str);
 
 			if ($image === FALSE) {
@@ -199,7 +199,7 @@ function proxy_init(App $a) {
 
 		} else {
 			$img = new Photo($img_str, $mime);
-			if ($img->is_valid() AND !$direct_cache AND ($cachefile == '')) {
+			if ($img->is_valid() && !$direct_cache && ($cachefile == '')) {
 				$img->store(0, 0, $urlhash, $_REQUEST['url'], '', 100);
 			}
 		}
@@ -219,7 +219,7 @@ function proxy_init(App $a) {
 	// If there is a real existing directory then put the cache file there
 	// advantage: real file access is really fast
 	// Otherwise write in cachefile
-	if ($valid AND $direct_cache) {
+	if ($valid && $direct_cache) {
 		file_put_contents($basepath . '/proxy/' . proxy_url($_REQUEST['url'], true), $img_str_orig);
 		if ($sizetype != '') {
 			file_put_contents($basepath . '/proxy/' . proxy_url($_REQUEST['url'], true) . $sizetype, $img_str);
@@ -282,7 +282,7 @@ function proxy_url($url, $writemode = false, $size = '') {
 	$shortpath = hash('md5', $url);
 	$longpath = substr($shortpath, 0, 2);
 
-	if (is_dir($basepath) AND $writemode AND !is_dir($basepath . '/' . $longpath)) {
+	if (is_dir($basepath) && $writemode && !is_dir($basepath . '/' . $longpath)) {
 		mkdir($basepath . '/' . $longpath);
 		chmod($basepath . '/' . $longpath, 0777);
 	}
@@ -306,7 +306,7 @@ function proxy_url($url, $writemode = false, $size = '') {
 
 	// Too long files aren't supported by Apache
 	// Writemode in combination with long files shouldn't be possible
-	if ((strlen($proxypath) > 250) AND $writemode) {
+	if ((strlen($proxypath) > 250) && $writemode) {
 		return $shortpath;
 	} elseif (strlen($proxypath) > 250) {
 		return App::get_baseurl() . '/proxy/' . $shortpath . '?url=' . urlencode($url);
@@ -360,7 +360,7 @@ function proxy_parse_query($url) {
 function proxy_img_cb($matches) {
 	// if the picture seems to be from another picture cache then take the original source
 	$queryvar = proxy_parse_query($matches[2]);
-	if (($queryvar['url'] != '') AND (substr($queryvar['url'], 0, 4) == 'http')) {
+	if (($queryvar['url'] != '') && (substr($queryvar['url'], 0, 4) == 'http')) {
 		$matches[2] = urldecode($queryvar['url']);
 	}
 

--- a/mod/register.php
+++ b/mod/register.php
@@ -83,7 +83,7 @@ function register_post(App $a) {
 		}
 
 		// Only send a password mail when the password wasn't manually provided
-		if (!x($_POST,'password1') OR !x($_POST,'confirm')) {
+		if (!x($_POST,'password1') || !x($_POST,'confirm')) {
 			$res = send_register_open_eml(
 				$user['email'],
 				$a->config['sitename'],

--- a/mod/search.php
+++ b/mod/search.php
@@ -97,7 +97,7 @@ function search_content(App $a) {
 		return;
 	}
 
-	if(get_config('system','local_search') AND !local_user()) {
+	if(get_config('system','local_search') && !local_user()) {
 		http_status_exit(403,
 				array("title" => t("Public access denied."),
 					"description" => t("Only logged in users are permitted to perform a search.")));
@@ -106,7 +106,7 @@ function search_content(App $a) {
 		//return;
 	}
 
-	if (get_config('system','permit_crawling') AND !local_user()) {
+	if (get_config('system','permit_crawling') && !local_user()) {
 		// Default values:
 		// 10 requests are "free", after the 11th only a call per minute is allowed
 
@@ -122,7 +122,7 @@ function search_content(App $a) {
 		$result = Cache::get("remote_search:".$remote);
 		if (!is_null($result)) {
 			$resultdata = json_decode($result);
-			if (($resultdata->time > (time() - $crawl_permit_period)) AND ($resultdata->accesses > $free_crawls)) {
+			if (($resultdata->time > (time() - $crawl_permit_period)) && ($resultdata->accesses > $free_crawls)) {
 				http_status_exit(429,
 						array("title" => t("Too Many Requests"),
 							"description" => t("Only one search per minute is permitted for not logged in users.")));

--- a/mod/settings.php
+++ b/mod/settings.php
@@ -949,7 +949,7 @@ function settings_content(App $a) {
 				$is_experimental = file_exists('view/theme/' . $th . '/experimental');
 				$unsupported = file_exists('view/theme/' . $th . '/unsupported');
 				$is_mobile = file_exists('view/theme/' . $th . '/mobile');
-				if (!$is_experimental or ($is_experimental && (get_config('experimentals','exp_themes')==1 or get_config('experimentals','exp_themes')===false))){
+				if (!$is_experimental || ($is_experimental && (get_config('experimentals','exp_themes')==1 || get_config('experimentals','exp_themes')===false))){
 					$theme_name = (($is_experimental) ?  sprintf("%s - \x28Experimental\x29", $f) : $f);
 					if ($is_mobile) {
 						$mobile_themes[$f]=$theme_name;

--- a/mod/settings.php
+++ b/mod/settings.php
@@ -462,13 +462,13 @@ function settings_post(App $a) {
 		$notify += intval($_POST['notify8']);
 
 	// Adjust the page flag if the account type doesn't fit to the page flag.
-	if (($account_type == ACCOUNT_TYPE_PERSON) AND !in_array($page_flags, array(PAGE_NORMAL, PAGE_SOAPBOX, PAGE_FREELOVE)))
+	if (($account_type == ACCOUNT_TYPE_PERSON) && !in_array($page_flags, array(PAGE_NORMAL, PAGE_SOAPBOX, PAGE_FREELOVE)))
 		$page_flags = PAGE_NORMAL;
-	elseif (($account_type == ACCOUNT_TYPE_ORGANISATION) AND !in_array($page_flags, array(PAGE_SOAPBOX)))
+	elseif (($account_type == ACCOUNT_TYPE_ORGANISATION) && !in_array($page_flags, array(PAGE_SOAPBOX)))
 		$page_flags = PAGE_SOAPBOX;
-	elseif (($account_type == ACCOUNT_TYPE_NEWS) AND !in_array($page_flags, array(PAGE_SOAPBOX)))
+	elseif (($account_type == ACCOUNT_TYPE_NEWS) && !in_array($page_flags, array(PAGE_SOAPBOX)))
 		$page_flags = PAGE_SOAPBOX;
-	elseif (($account_type == ACCOUNT_TYPE_COMMUNITY) AND !in_array($page_flags, array(PAGE_COMMUNITY, PAGE_PRVGROUP)))
+	elseif (($account_type == ACCOUNT_TYPE_COMMUNITY) && !in_array($page_flags, array(PAGE_COMMUNITY, PAGE_PRVGROUP)))
 		$page_flags = PAGE_COMMUNITY;
 
 	$email_changed = false;
@@ -1101,7 +1101,7 @@ function settings_content(App $a) {
 
 	// Set the account type to "Community" when the page is a community page but the account type doesn't fit
 	// This is only happening on the first visit after the update
-	if (in_array($a->user['page-flags'], array(PAGE_COMMUNITY, PAGE_PRVGROUP)) AND
+	if (in_array($a->user['page-flags'], array(PAGE_COMMUNITY, PAGE_PRVGROUP)) &&
 		($a->user['account-type'] != ACCOUNT_TYPE_COMMUNITY))
 		$a->user['account-type'] = ACCOUNT_TYPE_COMMUNITY;
 

--- a/mod/update_network.php
+++ b/mod/update_network.php
@@ -15,7 +15,7 @@ function update_network_content(App $a) {
 	echo "<!DOCTYPE html><html><body>\r\n";
 	echo "<section>";
 
-	if (!get_pconfig($profile_uid, "system", "no_auto_update") OR ($_GET["force"] == 1)) {
+	if (!get_pconfig($profile_uid, "system", "no_auto_update") || ($_GET["force"] == 1)) {
 		$text = network_content($a, $profile_uid);
 	} else {
 		$text = "";

--- a/object/Item.php
+++ b/object/Item.php
@@ -158,7 +158,7 @@ class Item extends BaseObject {
 			$profile_link = zrl($profile_link);
 		}
 
-		if (!isset($item['author-thumb']) OR ($item['author-thumb'] == "")) {
+		if (!isset($item['author-thumb']) || ($item['author-thumb'] == "")) {
 			$author_contact = get_contact_details_by_url($item['author-link'], $conv->get_profile_owner());
 			if ($author_contact["thumb"]) {
 				$item['author-thumb'] = $author_contact["thumb"];
@@ -167,7 +167,7 @@ class Item extends BaseObject {
 			}
 		}
 
-		if (!isset($item['owner-thumb']) OR ($item['owner-thumb'] == "")) {
+		if (!isset($item['owner-thumb']) || ($item['owner-thumb'] == "")) {
 			$owner_contact = get_contact_details_by_url($item['owner-link'], $conv->get_profile_owner());
 			if ($owner_contact["thumb"]) {
 				$item['owner-thumb'] = $owner_contact["thumb"];
@@ -307,28 +307,28 @@ class Item extends BaseObject {
 		// Disable features that aren't available in several networks
 
 		/// @todo Add NETWORK_DIASPORA when it will pass this information
-		if (!in_array($item["item_network"], array(NETWORK_DFRN)) AND isset($buttons["dislike"])) {
+		if (!in_array($item["item_network"], array(NETWORK_DFRN)) && isset($buttons["dislike"])) {
 			unset($buttons["dislike"],$isevent);
 			$tagger = '';
 		}
 
-		if (($item["item_network"] == NETWORK_FEED) AND isset($buttons["like"])) {
+		if (($item["item_network"] == NETWORK_FEED) && isset($buttons["like"])) {
 			unset($buttons["like"]);
 		}
 
-		if (($item["item_network"] == NETWORK_MAIL) AND isset($buttons["like"])) {
+		if (($item["item_network"] == NETWORK_MAIL) && isset($buttons["like"])) {
 			unset($buttons["like"]);
 		}
 
  		// Diaspora isn't able to do likes on comments - but Hubzilla does
 		/// @todo When Diaspora will pass this information we will remove these lines
-		if (($item["item_network"] == NETWORK_DIASPORA) AND ($indent == 'comment') AND
-			!Diaspora::is_redmatrix($item["owner-link"]) AND isset($buttons["like"])) {
+		if (($item["item_network"] == NETWORK_DIASPORA) && ($indent == 'comment') &&
+			!Diaspora::is_redmatrix($item["owner-link"]) && isset($buttons["like"])) {
 			unset($buttons["like"]);
 		}
 
 		// Facebook can like comments - but it isn't programmed in the connector yet.
-		if (($item["item_network"] == NETWORK_FACEBOOK) AND ($indent == 'comment') AND isset($buttons["like"])) {
+		if (($item["item_network"] == NETWORK_FACEBOOK) && ($indent == 'comment') && isset($buttons["like"])) {
 			unset($buttons["like"]);
 		}
 
@@ -733,7 +733,7 @@ class Item extends BaseObject {
 
 		if($this->is_toplevel()) {
 			if($conv->get_mode() !== 'profile') {
-				if($this->get_data_value('wall') AND !$this->get_data_value('self')) {
+				if($this->get_data_value('wall') && !$this->get_data_value('self')) {
 					// On the network page, I am the owner. On the display page it will be the profile owner.
 					// This will have been stored in $a->page_contact by our calling page.
 					// Put this person as the wall owner of the wall-to-wall notice.

--- a/src/App.php
+++ b/src/App.php
@@ -406,7 +406,7 @@ class App {
 				$this->hostname = Config::get('config', 'hostname');
 			}
 
-			if (!isset($this->hostname) OR ( $this->hostname == '')) {
+			if (!isset($this->hostname) || ( $this->hostname == '')) {
 				$this->hostname = $hostname;
 			}
 		}
@@ -850,7 +850,7 @@ class App {
 			$meminfo[$key] = (int) ($meminfo[$key] / 1024);
 		}
 
-		if (!isset($meminfo['MemAvailable']) OR ! isset($meminfo['MemFree'])) {
+		if (!isset($meminfo['MemAvailable']) || ! isset($meminfo['MemFree'])) {
 			return false;
 		}
 
@@ -907,7 +907,7 @@ class App {
 		$cachekey = 'app:proc_run:started';
 		$result = Cache::get($cachekey);
 
-		if (!is_null($result) AND ( time() - $result) < 2) {
+		if (!is_null($result) && ( time() - $result) < 2) {
 			return;
 		}
 
@@ -949,7 +949,7 @@ class App {
 	 * @return string system username
 	 */
 	static function systemuser() {
-		if (!function_exists('posix_getpwuid') OR ! function_exists('posix_geteuid')) {
+		if (!function_exists('posix_getpwuid') || ! function_exists('posix_geteuid')) {
 			return '';
 		}
 
@@ -980,7 +980,7 @@ class App {
 			logger('Path "' . $directory . '" is not a directory for user ' . self::systemuser(), LOGGER_DEBUG);
 			return false;
 		}
-		if ($check_writable AND !is_writable($directory)) {
+		if ($check_writable && !is_writable($directory)) {
 			logger('Path "' . $directory . '" is not writable for user ' . self::systemuser(), LOGGER_DEBUG);
 			return false;
 		}

--- a/src/Core/Config.php
+++ b/src/Core/Config.php
@@ -151,7 +151,7 @@ class Config {
 
 		$stored = self::get($family, $key, null, true);
 
-		if (($stored === $dbvalue) AND self::$in_db[$family][$key]) {
+		if (($stored === $dbvalue) && self::$in_db[$family][$key]) {
 			return true;
 		}
 
@@ -167,7 +167,7 @@ class Config {
 		// manage array value
 		$dbvalue = (is_array($value) ? serialize($value) : $dbvalue);
 
-		if (is_null($stored) OR !self::$in_db[$family][$key]) {
+		if (is_null($stored) || !self::$in_db[$family][$key]) {
 			$ret = q("INSERT INTO `config` (`cat`, `k`, `v`) VALUES ('%s', '%s', '%s') ON DUPLICATE KEY UPDATE `v` = '%s'",
 				dbesc($family),
 				dbesc($key),

--- a/src/Core/PConfig.php
+++ b/src/Core/PConfig.php
@@ -138,7 +138,7 @@ class PConfig {
 
 		$stored = self::get($uid, $family, $key, null, true);
 
-		if (($stored === $dbvalue) AND self::$in_db[$uid][$family][$key]) {
+		if (($stored === $dbvalue) && self::$in_db[$uid][$family][$key]) {
 			return true;
 		}
 
@@ -147,7 +147,7 @@ class PConfig {
 		// manage array value
 		$dbvalue = (is_array($value) ? serialize($value) : $dbvalue);
 
-		if (is_null($stored) OR !self::$in_db[$uid][$family][$key]) {
+		if (is_null($stored) || !self::$in_db[$uid][$family][$key]) {
 			$ret = q("INSERT INTO `pconfig` (`uid`, `cat`, `k`, `v`) VALUES (%d, '%s', '%s', '%s') ON DUPLICATE KEY UPDATE `v` = '%s'",
 				intval($uid),
 				dbesc($family),

--- a/src/Network/Probe.php
+++ b/src/Network/Probe.php
@@ -104,7 +104,7 @@ class Probe {
 		logger("Probing for ".$host, LOGGER_DEBUG);
 
 		$ret = z_fetch_url($ssl_url, false, $redirects, array('timeout' => $xrd_timeout, 'accept_content' => 'application/xrd+xml'));
-		if (($ret['errno'] == CURLE_OPERATION_TIMEDOUT) AND !self::ownHost($ssl_url)) {
+		if (($ret['errno'] == CURLE_OPERATION_TIMEDOUT) && !self::ownHost($ssl_url)) {
 			logger("Probing timeout for ".$ssl_url, LOGGER_DEBUG);
 			return false;
 		}
@@ -144,11 +144,11 @@ class Probe {
 			}
 
 			if (($attributes["rel"] == "lrdd")
-				AND ($attributes["type"] == "application/xrd+xml")
+				&& ($attributes["type"] == "application/xrd+xml")
 			) {
 				$xrd_data["lrdd-xml"] = $attributes["template"];
 			} elseif (($attributes["rel"] == "lrdd")
-				AND ($attributes["type"] == "application/json")
+				&& ($attributes["type"] == "application/json")
 			) {
 				$xrd_data["lrdd-json"] = $attributes["template"];
 			} elseif ($attributes["rel"] == "lrdd") {
@@ -195,7 +195,7 @@ class Probe {
 				if ($link['@attributes']['rel'] === NAMESPACE_DFRN) {
 					$profile_link = $link['@attributes']['href'];
 				}
-				if (($link['@attributes']['rel'] === NAMESPACE_OSTATUSSUB) AND ($profile_link == "")) {
+				if (($link['@attributes']['rel'] === NAMESPACE_OSTATUSSUB) && ($profile_link == "")) {
 					$profile_link = 'stat:'.$link['@attributes']['template'];
 				}
 				if ($link['@attributes']['rel'] === 'http://microformats.org/profile/hcard') {
@@ -244,7 +244,7 @@ class Probe {
 			do {
 				$lrdd = self::xrd($host);
 				$host .= "/".array_shift($path_parts);
-			} while (!$lrdd AND (sizeof($path_parts) > 0));
+			} while (!$lrdd && (sizeof($path_parts) > 0));
 		}
 
 		if (!$lrdd) {
@@ -264,7 +264,7 @@ class Probe {
 			$path = str_replace('{uri}', urlencode($uri), $link);
 			$webfinger = self::webfinger($path);
 
-			if (!$webfinger AND (strstr($uri, "@"))) {
+			if (!$webfinger && (strstr($uri, "@"))) {
 				$path = str_replace('{uri}', urlencode("acct:".$uri), $link);
 				$webfinger = self::webfinger($path);
 			}
@@ -272,7 +272,7 @@ class Probe {
 			// Special treatment for Mastodon
 			// Problem is that Mastodon uses an URL format like http://domain.tld/@nick
 			// But the webfinger for this format fails.
-			if (!$webfinger AND isset($nick)) {
+			if (!$webfinger && isset($nick)) {
 				// Mastodon uses a "@" as prefix for usernames in their url format
 				$nick = ltrim($nick, '@');
 
@@ -340,7 +340,7 @@ class Probe {
 			$data["photo"] = App::get_baseurl().'/images/person-175.jpg';
 		}
 
-		if (!isset($data["name"]) OR ($data["name"] == "")) {
+		if (!isset($data["name"]) || ($data["name"] == "")) {
 			if (isset($data["nick"])) {
 				$data["name"] = $data["nick"];
 			}
@@ -350,7 +350,7 @@ class Probe {
 			}
 		}
 
-		if (!isset($data["nick"]) OR ($data["nick"] == "")) {
+		if (!isset($data["nick"]) || ($data["nick"] == "")) {
 			$data["nick"] = strtolower($data["name"]);
 
 			if (strpos($data['nick'], ' ')) {
@@ -377,12 +377,12 @@ class Probe {
 			/// It should only be updated if the existing picture isn't existing anymore.
 			/// We only update the contact when it is no probing for a specific network.
 			if (($data['network'] != NETWORK_FEED)
-				AND ($network == "")
-				AND $data["name"]
-				AND $data["nick"]
-				AND $data["url"]
-				AND $data["addr"]
-				AND $data["poll"]
+				&& ($network == "")
+				&& $data["name"]
+				&& $data["nick"]
+				&& $data["url"]
+				&& $data["addr"]
+				&& $data["poll"]
 			) {
 				q("UPDATE `contact` SET `name` = '%s', `nick` = '%s', `url` = '%s', `addr` = '%s',
 						`notify` = '%s', `poll` = '%s', `alias` = '%s', `success_update` = '%s'
@@ -417,7 +417,7 @@ class Probe {
 	private function detect($uri, $network, $uid) {
 		$parts = parse_url($uri);
 
-		if (isset($parts["scheme"]) AND isset($parts["host"]) AND isset($parts["path"])) {
+		if (isset($parts["scheme"]) && isset($parts["host"]) && isset($parts["path"])) {
 			$host = $parts["host"];
 			if (isset($parts["port"])) {
 				$host .= ':'.$parts["port"];
@@ -434,7 +434,7 @@ class Probe {
 
 			$path_parts = explode("/", trim($parts["path"], "/"));
 
-			while (!$lrdd AND (sizeof($path_parts) > 1)) {
+			while (!$lrdd && (sizeof($path_parts) > 1)) {
 				$host .= "/".array_shift($path_parts);
 				$lrdd = self::xrd($host);
 			}
@@ -501,7 +501,7 @@ class Probe {
 			$webfinger = self::webfinger($path);
 
 			// We cannot be sure that the detected address was correct, so we don't use the values
-			if ($webfinger AND ($uri != $addr)) {
+			if ($webfinger && ($uri != $addr)) {
 				$nick = "";
 				$addr = "";
 			}
@@ -529,32 +529,32 @@ class Probe {
 		if (in_array($network, array("", NETWORK_DFRN))) {
 			$result = self::dfrn($webfinger);
 		}
-		if ((!$result AND ($network == "")) OR ($network == NETWORK_DIASPORA)) {
+		if ((!$result && ($network == "")) || ($network == NETWORK_DIASPORA)) {
 			$result = self::diaspora($webfinger);
 		}
-		if ((!$result AND ($network == "")) OR ($network == NETWORK_OSTATUS)) {
+		if ((!$result && ($network == "")) || ($network == NETWORK_OSTATUS)) {
 			$result = self::ostatus($webfinger);
 		}
-		if ((!$result AND ($network == "")) OR ($network == NETWORK_PUMPIO)) {
+		if ((!$result && ($network == "")) || ($network == NETWORK_PUMPIO)) {
 			$result = self::pumpio($webfinger);
 		}
-		if ((!$result AND ($network == "")) OR ($network == NETWORK_FEED)) {
+		if ((!$result && ($network == "")) || ($network == NETWORK_FEED)) {
 			$result = self::feed($uri);
 		} else {
 			// We overwrite the detected nick with our try if the previois routines hadn't detected it.
 			// Additionally it is overwritten when the nickname doesn't make sense (contains spaces).
-			if ((!isset($result["nick"]) OR ($result["nick"] == "") OR (strstr($result["nick"], " "))) AND ($nick != "")) {
+			if ((!isset($result["nick"]) || ($result["nick"] == "") || (strstr($result["nick"], " "))) && ($nick != "")) {
 				$result["nick"] = $nick;
 			}
 
-			if ((!isset($result["addr"]) OR ($result["addr"] == "")) AND ($addr != "")) {
+			if ((!isset($result["addr"]) || ($result["addr"] == "")) && ($addr != "")) {
 				$result["addr"] = $addr;
 			}
 		}
 
 		logger($uri." is ".$result["network"], LOGGER_DEBUG);
 
-		if (!isset($result["baseurl"]) OR ($result["baseurl"] == "")) {
+		if (!isset($result["baseurl"]) || ($result["baseurl"] == "")) {
 			$pos = strpos($result["url"], $host);
 			if ($pos) {
 				$result["baseurl"] = substr($result["url"], 0, $pos).$host;
@@ -762,12 +762,12 @@ class Probe {
 		$data = self::pollNoscrape($noscrape_url, $data);
 
 		if (!isset($data["notify"])
-			OR !isset($data["confirm"])
-			OR !isset($data["request"])
-			OR !isset($data["poll"])
-			OR !isset($data["poco"])
-			OR !isset($data["name"])
-			OR !isset($data["photo"])
+			|| !isset($data["confirm"])
+			|| !isset($data["request"])
+			|| !isset($data["poll"])
+			|| !isset($data["poco"])
+			|| !isset($data["name"])
+			|| !isset($data["photo"])
 		) {
 			$data = self::pollHcard($profile_link, $data, true);
 		}
@@ -801,33 +801,33 @@ class Probe {
 		$hcard_url = "";
 		$data = array();
 		foreach ($webfinger["links"] as $link) {
-			if (($link["rel"] == NAMESPACE_DFRN) AND ($link["href"] != "")) {
+			if (($link["rel"] == NAMESPACE_DFRN) && ($link["href"] != "")) {
 				$data["network"] = NETWORK_DFRN;
-			} elseif (($link["rel"] == NAMESPACE_FEED) AND ($link["href"] != "")) {
+			} elseif (($link["rel"] == NAMESPACE_FEED) && ($link["href"] != "")) {
 				$data["poll"] = $link["href"];
-			} elseif (($link["rel"] == "http://webfinger.net/rel/profile-page") AND ($link["type"] == "text/html") AND ($link["href"] != "")) {
+			} elseif (($link["rel"] == "http://webfinger.net/rel/profile-page") && ($link["type"] == "text/html") && ($link["href"] != "")) {
 				$data["url"] = $link["href"];
-			} elseif (($link["rel"] == "http://microformats.org/profile/hcard") AND ($link["href"] != "")) {
+			} elseif (($link["rel"] == "http://microformats.org/profile/hcard") && ($link["href"] != "")) {
 				$hcard_url = $link["href"];
-			} elseif (($link["rel"] == NAMESPACE_POCO) AND ($link["href"] != "")) {
+			} elseif (($link["rel"] == NAMESPACE_POCO) && ($link["href"] != "")) {
 				$data["poco"] = $link["href"];
-			} elseif (($link["rel"] == "http://webfinger.net/rel/avatar") AND ($link["href"] != "")) {
+			} elseif (($link["rel"] == "http://webfinger.net/rel/avatar") && ($link["href"] != "")) {
 				$data["photo"] = $link["href"];
-			} elseif (($link["rel"] == "http://joindiaspora.com/seed_location") AND ($link["href"] != "")) {
+			} elseif (($link["rel"] == "http://joindiaspora.com/seed_location") && ($link["href"] != "")) {
 				$data["baseurl"] = trim($link["href"], '/');
-			} elseif (($link["rel"] == "http://joindiaspora.com/guid") AND ($link["href"] != "")) {
+			} elseif (($link["rel"] == "http://joindiaspora.com/guid") && ($link["href"] != "")) {
 				$data["guid"] = $link["href"];
-			} elseif (($link["rel"] == "diaspora-public-key") AND ($link["href"] != "")) {
+			} elseif (($link["rel"] == "diaspora-public-key") && ($link["href"] != "")) {
 				$data["pubkey"] = base64_decode($link["href"]);
 
-				//if (strstr($data["pubkey"], 'RSA ') OR ($link["type"] == "RSA"))
+				//if (strstr($data["pubkey"], 'RSA ') || ($link["type"] == "RSA"))
 				if (strstr($data["pubkey"], 'RSA ')) {
 					$data["pubkey"] = rsatopem($data["pubkey"]);
 				}
 			}
 		}
 
-		if (!isset($data["network"]) OR ($hcard_url == "")) {
+		if (!isset($data["network"]) || ($hcard_url == "")) {
 			return false;
 		}
 
@@ -836,11 +836,11 @@ class Probe {
 		$data = self::pollNoscrape($noscrape_url, $data);
 
 		if (isset($data["notify"])
-			AND isset($data["confirm"])
-			AND isset($data["request"])
-			AND isset($data["poll"])
-			AND isset($data["name"])
-			AND isset($data["photo"])
+			&& isset($data["confirm"])
+			&& isset($data["request"])
+			&& isset($data["poll"])
+			&& isset($data["name"])
+			&& isset($data["photo"])
 		) {
 			return $data;
 		}
@@ -887,7 +887,7 @@ class Probe {
 			// We have to discard the guid from the hcard in favour of the guid from lrdd
 			// Reason: Hubzilla doesn't use the value "uid" in the hcard like Diaspora does.
 			$search = $xpath->query("//*[contains(concat(' ', @class, ' '), ' uid ')]", $vcard); // */
-			if (($search->length > 0) AND ($data["guid"] == "")) {
+			if (($search->length > 0) && ($data["guid"] == "")) {
 				$data["guid"] = $search->item(0)->nodeValue;
 			}
 
@@ -928,13 +928,13 @@ class Probe {
 				$attr[$attribute->name] = trim($attribute->value);
 			}
 
-			if (isset($attr["src"]) AND isset($attr["width"])) {
+			if (isset($attr["src"]) && isset($attr["width"])) {
 				$avatar[$attr["width"]] = $attr["src"];
 			}
 
 			// We don't have a width. So we just take everything that we got.
 			// This is a Hubzilla workaround which doesn't send a width.
-			if ((sizeof($avatar) == 0) AND isset($attr["src"])) {
+			if ((sizeof($avatar) == 0) && isset($attr["src"])) {
 				$avatar[] = $attr["src"];
 			}
 		}
@@ -981,37 +981,37 @@ class Probe {
 		$hcard_url = "";
 		$data = array();
 		foreach ($webfinger["links"] as $link) {
-			if (($link["rel"] == "http://microformats.org/profile/hcard") AND ($link["href"] != "")) {
+			if (($link["rel"] == "http://microformats.org/profile/hcard") && ($link["href"] != "")) {
 				$hcard_url = $link["href"];
-			} elseif (($link["rel"] == "http://joindiaspora.com/seed_location") AND ($link["href"] != "")) {
+			} elseif (($link["rel"] == "http://joindiaspora.com/seed_location") && ($link["href"] != "")) {
 				$data["baseurl"] = trim($link["href"], '/');
-			} elseif (($link["rel"] == "http://joindiaspora.com/guid") AND ($link["href"] != "")) {
+			} elseif (($link["rel"] == "http://joindiaspora.com/guid") && ($link["href"] != "")) {
 				$data["guid"] = $link["href"];
-			} elseif (($link["rel"] == "http://webfinger.net/rel/profile-page") AND ($link["type"] == "text/html") AND ($link["href"] != "")) {
+			} elseif (($link["rel"] == "http://webfinger.net/rel/profile-page") && ($link["type"] == "text/html") && ($link["href"] != "")) {
 				$data["url"] = $link["href"];
-			} elseif (($link["rel"] == NAMESPACE_FEED) AND ($link["href"] != "")) {
+			} elseif (($link["rel"] == NAMESPACE_FEED) && ($link["href"] != "")) {
 				$data["poll"] = $link["href"];
-			} elseif (($link["rel"] == NAMESPACE_POCO) AND ($link["href"] != "")) {
+			} elseif (($link["rel"] == NAMESPACE_POCO) && ($link["href"] != "")) {
 				$data["poco"] = $link["href"];
-			} elseif (($link["rel"] == "salmon") AND ($link["href"] != "")) {
+			} elseif (($link["rel"] == "salmon") && ($link["href"] != "")) {
 				$data["notify"] = $link["href"];
-			} elseif (($link["rel"] == "diaspora-public-key") AND ($link["href"] != "")) {
+			} elseif (($link["rel"] == "diaspora-public-key") && ($link["href"] != "")) {
 				$data["pubkey"] = base64_decode($link["href"]);
 
-				//if (strstr($data["pubkey"], 'RSA ') OR ($link["type"] == "RSA"))
+				//if (strstr($data["pubkey"], 'RSA ') || ($link["type"] == "RSA"))
 				if (strstr($data["pubkey"], 'RSA ')) {
 					$data["pubkey"] = rsatopem($data["pubkey"]);
 				}
 			}
 		}
 
-		if (!isset($data["url"]) OR ($hcard_url == "")) {
+		if (!isset($data["url"]) || ($hcard_url == "")) {
 			return false;
 		}
 
 		if (is_array($webfinger["aliases"])) {
 			foreach ($webfinger["aliases"] as $alias) {
-				if (normalise_link($alias) != normalise_link($data["url"]) AND ! strstr($alias, "@")) {
+				if (normalise_link($alias) != normalise_link($data["url"]) && ! strstr($alias, "@")) {
 					$data["alias"] = $alias;
 				}
 			}
@@ -1025,10 +1025,10 @@ class Probe {
 		}
 
 		if (isset($data["url"])
-			AND isset($data["guid"])
-			AND isset($data["baseurl"])
-			AND isset($data["pubkey"])
-			AND ($hcard_url != "")
+			&& isset($data["guid"])
+			&& isset($data["baseurl"])
+			&& isset($data["pubkey"])
+			&& ($hcard_url != "")
 		) {
 			$data["network"] = NETWORK_DIASPORA;
 
@@ -1062,21 +1062,21 @@ class Probe {
 			}
 		}
 
-		if (is_string($webfinger["subject"]) AND strstr($webfinger["subject"], "@")) {
+		if (is_string($webfinger["subject"]) && strstr($webfinger["subject"], "@")) {
 			$data["addr"] = str_replace('acct:', '', $webfinger["subject"]);
 		}
 		$pubkey = "";
 		foreach ($webfinger["links"] as $link) {
 			if (($link["rel"] == "http://webfinger.net/rel/profile-page")
-				AND ($link["type"] == "text/html")
-				AND ($link["href"] != "")
+				&& ($link["type"] == "text/html")
+				&& ($link["href"] != "")
 			) {
 				$data["url"] = $link["href"];
-			} elseif (($link["rel"] == "salmon") AND ($link["href"] != "")) {
+			} elseif (($link["rel"] == "salmon") && ($link["href"] != "")) {
 				$data["notify"] = $link["href"];
-			} elseif (($link["rel"] == NAMESPACE_FEED) AND ($link["href"] != "")) {
+			} elseif (($link["rel"] == NAMESPACE_FEED) && ($link["href"] != "")) {
 				$data["poll"] = $link["href"];
-			} elseif (($link["rel"] == "magic-public-key") AND ($link["href"] != "")) {
+			} elseif (($link["rel"] == "magic-public-key") && ($link["href"] != "")) {
 				$pubkey = $link["href"];
 
 				if (substr($pubkey, 0, 5) === 'data:') {
@@ -1103,9 +1103,9 @@ class Probe {
 			}
 		}
 
-		if (isset($data["notify"]) AND isset($data["pubkey"])
-			AND isset($data["poll"])
-			AND isset($data["url"])
+		if (isset($data["notify"]) && isset($data["pubkey"])
+			&& isset($data["poll"])
+			&& isset($data["url"])
 		) {
 			$data["network"] = NETWORK_OSTATUS;
 		} else {
@@ -1200,21 +1200,21 @@ class Probe {
 		$data = array();
 		foreach ($webfinger["links"] as $link) {
 			if (($link["rel"] == "http://webfinger.net/rel/profile-page")
-				AND ($link["type"] == "text/html")
-				AND ($link["href"] != "")
+				&& ($link["type"] == "text/html")
+				&& ($link["href"] != "")
 			) {
 				$data["url"] = $link["href"];
-			} elseif (($link["rel"] == "activity-inbox") AND ($link["href"] != "")) {
+			} elseif (($link["rel"] == "activity-inbox") && ($link["href"] != "")) {
 				$data["notify"] = $link["href"];
-			} elseif (($link["rel"] == "activity-outbox") AND ($link["href"] != "")) {
+			} elseif (($link["rel"] == "activity-outbox") && ($link["href"] != "")) {
 				$data["poll"] = $link["href"];
-			} elseif (($link["rel"] == "dialback") AND ($link["href"] != "")) {
+			} elseif (($link["rel"] == "dialback") && ($link["href"] != "")) {
 				$data["dialback"] = $link["href"];
 			}
 		}
-		if (isset($data["poll"]) AND isset($data["notify"])
-			AND isset($data["dialback"])
-			AND isset($data["url"])
+		if (isset($data["poll"]) && isset($data["notify"])
+			&& isset($data["dialback"])
+			&& isset($data["url"])
 		) {
 			// by now we use these fields only for the network type detection
 			// So we unset all data that isn't used at the moment

--- a/src/Util/Lock.php
+++ b/src/Util/Lock.php
@@ -68,7 +68,7 @@ class Lock {
 
 					// When the process id isn't used anymore, we can safely claim the lock for us.
 					// Or we do want to lock something that was already locked by us.
-					if (!posix_kill($pid, 0) OR ($pid == getmypid())) {
+					if (!posix_kill($pid, 0) || ($pid == getmypid())) {
 						$lock = false;
 					}
 				}
@@ -76,10 +76,10 @@ class Lock {
 					$memcache->set($cachekey, getmypid(), MEMCACHE_COMPRESSED, 300);
 					$got_lock = true;
 				}
-				if (!$got_lock AND ($timeout > 0)) {
+				if (!$got_lock && ($timeout > 0)) {
 					usleep($wait_sec * 1000000);
 				}
-			} while (!$got_lock AND ((time() - $start) < $timeout));
+			} while (!$got_lock && ((time() - $start) < $timeout));
 
 			return $got_lock;
 		}
@@ -112,10 +112,10 @@ class Lock {
 
 			dba::unlock();
 
-			if (!$got_lock AND ($timeout > 0)) {
+			if (!$got_lock && ($timeout > 0)) {
 				sleep($wait_sec);
 			}
-		} while (!$got_lock AND ((time() - $start) < $timeout));
+		} while (!$got_lock && ((time() - $start) < $timeout));
 
 		return $got_lock;
 	}

--- a/update.php
+++ b/update.php
@@ -356,7 +356,7 @@ function update_1035() {
 
 function update_1036() {
 
-	$r = dbq("SELECT * FROM `contact` WHERE `network` = 'dfrn' && `photo` LIKE '%include/photo%' ");
+	$r = dbq("SELECT * FROM `contact` WHERE `network` = 'dfrn' AND `photo` LIKE '%include/photo%' ");
 	if (dbm::is_result($r)) {
 		foreach ($r as $rr) {
 			q("UPDATE `contact` SET `photo` = '%s', `thumb` = '%s', `micro` = '%s' WHERE `id` = %d",

--- a/update.php
+++ b/update.php
@@ -1652,7 +1652,7 @@ function update_1180() {
 
 function update_1188() {
 
-	if (strlen(get_config('system','directory_submit_url')) AND
+	if (strlen(get_config('system','directory_submit_url')) &&
 		!strlen(get_config('system','directory'))) {
 		set_config('system','directory', dirname(get_config('system','directory_submit_url')));
 		del_config('system','directory_submit_url');

--- a/util/maintenance.php
+++ b/util/maintenance.php
@@ -24,7 +24,7 @@ if ($argc > 1) {
 
 Config::set('system', 'maintenance', $maint_mode);
 
-if ($maint_mode AND ($argc > 2)) {
+if ($maint_mode && ($argc > 2)) {
 	$reason_arr = $argv;
 	array_shift($reason_arr);
 	array_shift($reason_arr);

--- a/util/php2po.php
+++ b/util/php2po.php
@@ -93,7 +93,7 @@ print "\nLoading base message.po...";
 // load base messages.po and extract msgids
 $base_msgids = array();
 $norm_base_msgids = array();
-$base_f = file("util/messages.po") or die("No base messages.po\n");
+$base_f = file("util/messages.po") || die("No base messages.po\n");
 $_f = 0; $_mid = ""; $_mids = array();
 foreach( $base_f as $l) {
 	$l = trim($l);

--- a/util/typo.php
+++ b/util/typo.php
@@ -27,7 +27,7 @@ $Iterator = new RecursiveDirectoryIterator('src');
 foreach (new RecursiveIteratorIterator($Iterator) as $file) {
 	if (substr($file, -4) === '.php') {
 		passthru("$phpath -l $file", $ret);
-		$ret === 0 or die();
+		$ret === 0 || die();
 	}
 }
 
@@ -35,21 +35,21 @@ echo "Directory: mod\n";
 $files = glob('mod/*.php');
 foreach ($files as $file) {
 	passthru("$phpath -l $file", $ret);
-	$ret === 0 or die();
+	$ret === 0 || die();
 }
 
 echo "Directory: include\n";
 $files = glob('include/*.php');
 foreach ($files as $file) {
 	passthru("$phpath -l $file", $ret);
-	$ret === 0 or die();
+	$ret === 0 || die();
 }
 
 echo "Directory: object\n";
 $files = glob('object/*.php');
 foreach ($files as $file) {
 	passthru("$phpath -l $file", $ret);
-	$ret === 0 or die();
+	$ret === 0 || die();
 }
 
 echo "Directory: addon\n";
@@ -60,7 +60,7 @@ foreach ($dirs as $dir) {
 	$files = glob($dir . '/' . $addon . '.php');
 	foreach ($files as $file) {
 		passthru("$phpath -l $file", $ret);
-		$ret === 0 or die();
+		$ret === 0 || die();
 	}
 }
 
@@ -68,10 +68,10 @@ echo "String files\n";
 
 echo 'util/strings.php' . "\n";
 passthru("$phpath -l util/strings.php", $ret);
-$ret === 0 or die();
+$ret === 0 || die();
 
 $files = glob('view/lang/*/strings.php');
 foreach ($files as $file) {
 	passthru("$phpath -l $file", $ret);
-	$ret === 0 or die();
+	$ret === 0 || die();
 }

--- a/view/theme/frio/php/frio_boot.php
+++ b/view/theme/frio/php/frio_boot.php
@@ -15,9 +15,9 @@ use Friendica\App;
  * @todo Check if this is really needed.
  */
 function load_page(App $a) {
-	if(isset($_GET["mode"]) AND ($_GET["mode"] == "minimal")) {
+	if(isset($_GET["mode"]) && ($_GET["mode"] == "minimal")) {
 		require "view/theme/frio/minimal.php";
-	} elseif((isset($_GET["mode"]) AND ($_GET["mode"] == "none"))) {
+	} elseif((isset($_GET["mode"]) && ($_GET["mode"] == "none"))) {
 		require "view/theme/frio/none.php";
 	} else {
 		$template = 'view/theme/' . current_theme() . '/'

--- a/view/theme/vier/style.php
+++ b/view/theme/vier/style.php
@@ -46,7 +46,7 @@ if (isset($_SERVER['HTTP_IF_MODIFIED_SINCE']) || isset($_SERVER['HTTP_IF_NONE_MA
 	$cached_etag = str_replace(array('"', "-gzip"), array('', ''),
 				stripslashes($_SERVER['HTTP_IF_NONE_MATCH']));
 
-	if (($cached_modified == $modified) AND ($cached_etag == $etag)) {
+	if (($cached_modified == $modified) && ($cached_etag == $etag)) {
 		header('HTTP/1.1 304 Not Modified');
 		exit();
 	}

--- a/view/theme/vier/theme.php
+++ b/view/theme/vier/theme.php
@@ -96,14 +96,14 @@ EOT;
 
 	// Hide the left menu bar
 	/// @TODO maybe move this static array out where it should belong?
-	if (($a->page['aside'] == "") AND in_array($a->argv[0], array("community", "events", "help", "manage", "notifications",
+	if (($a->page['aside'] == "") && in_array($a->argv[0], array("community", "events", "help", "manage", "notifications",
 			"probe", "webfinger", "login", "invite", "credits"))) {
 		$a->page['htmlhead'] .= "<link rel='stylesheet' href='view/theme/vier/hide.css' />";
 	}
 }
 
 function get_vier_config($key, $default = false, $admin = false) {
-	if (local_user() AND !$admin) {
+	if (local_user() && !$admin) {
 		$result = get_pconfig(local_user(), "vier", $key);
 		if ($result !== false) {
 			return $result;
@@ -186,7 +186,7 @@ function vier_community_info() {
 	}
 
 	//right_aside FIND FRIENDS
-	if ($show_friends AND local_user()) {
+	if ($show_friends && local_user()) {
 		$nv = array();
 		$nv['title'] = array("", t('Find Friends'), "", "");
 		$nv['directory'] = array('directory', t('Local Directory'), "", "");
@@ -206,7 +206,7 @@ function vier_community_info() {
 	}
 
 	//Community_Pages at right_aside
-	if ($show_pages AND local_user()) {
+	if ($show_pages && local_user()) {
 
 		require_once 'include/ForumManager.php';
 
@@ -372,7 +372,7 @@ function vier_community_info() {
 			$r[] = array("photo" => "images/wordpress.png", "name" => "Wordpress");
 		}
 
-		if (function_exists("imap_open") AND !get_config("system","imap_disabled") AND !get_config("system","dfrn_only")) {
+		if (function_exists("imap_open") && !get_config("system","imap_disabled") && !get_config("system","dfrn_only")) {
 			$r[] = array("photo" => "images/mail.png", "name" => "E-Mail");
 		}
 

--- a/view/theme/vier/theme.php
+++ b/view/theme/vier/theme.php
@@ -21,7 +21,7 @@ function vier_init(App $a) {
 
 	set_template_engine($a, 'smarty3');
 
-	if ($a->argv[0].$a->argv[1] === "profile".$a->user['nickname'] or $a->argv[0] === "network" && local_user()) {
+	if ($a->argv[0].$a->argv[1] === "profile".$a->user['nickname'] || $a->argv[0] === "network" && local_user()) {
 		vier_community_info();
 
 		$a->page['htmlhead'] .= "<link rel='stylesheet' type='text/css' href='view/theme/vier/wide.css' media='screen and (min-width: 1300px)'/>\n";


### PR DESCRIPTION
This PR replaces all `AND` and `OR` in PHP conditions by `&&` and `||`. See [this post](https://friendica.mrpetovan.com/display/735a2029455936b97c677a0809576252) for an explanation.

There was 3 cases where there could have been an ambiguity between both logical operators styles, but they already were correctly protected by parentheses.

This means that this PR introduces absolutely no functional change, it only allows developers not to add extra parenthesis in boolean variable assignments in the future. It doesn't change anything for `if` conditions.

Additionally, it corrects two SQL queries using the `&&` operators (which is exactly equivalent to `AND` in SQL) 