### PR TITLE
We now use the new Diaspora protocol for sending

### DIFF
--- a/include/diaspora.php
+++ b/include/diaspora.php
@@ -3001,9 +3001,15 @@ class Diaspora {
 	 *
 	 * @return int The result of the transmission
 	 */
-	public static function send_share($owner,$contact) {
+	public static function send_share($owner, $contact) {
 
 		/// @todo support the different possible combinations of "following" and "sharing"
+/*
+				if (in_array($contact["rel"], array(CONTACT_IS_FRIEND, CONTACT_IS_FOLLOWER))) {
+				$new_relation = CONTACT_IS_FRIEND;
+				$new_relation = CONTACT_IS_SHARING;
+				$new_relation = CONTACT_IS_FOLLOWER;
+*/
 		$message = array("author" => self::my_handle($owner),
 				"recipient" => $contact["addr"],
 				"following" => "true",
@@ -3022,15 +3028,16 @@ class Diaspora {
 	 *
 	 * @return int The result of the transmission
 	 */
-	public static function send_unshare($owner,$contact) {
+	public static function send_unshare($owner, $contact) {
 
 		$message = array("author" => self::my_handle($owner),
-				"target_guid" => $owner["guid"],
-				"target_type" => "Person");
+				"recipient" => $contact["addr"],
+				"following" => "false",
+				"sharing" => "false");
 
 		logger("Send unshare ".print_r($message, true), LOGGER_DEBUG);
 
-		return self::build_and_transmit($owner, $contact, "retraction", $message);
+		return self::build_and_transmit($owner, $contact, "contact", $message);
 	}
 
 	/**

--- a/include/diaspora.php
+++ b/include/diaspora.php
@@ -2502,7 +2502,6 @@ class Diaspora {
 			case "Comment":
 			case "Like":
 			case "Post":
-				return self::item_retraction($importer, $contact, $data);
 			case "Reshare":
 			case "StatusMessage":
 				return self::item_retraction($importer, $contact, $data);
@@ -3645,18 +3644,12 @@ class Diaspora {
 		$body = bb2diaspora($item["body"]);
 		$created = datetime_convert("UTC", "UTC", $item["created"], 'Y-m-d\TH:i:s\Z');
 
-		$signed_text = $item["guid"].";".$cnv["guid"].";".$body.";".$created.";".$myaddr.";".$cnv['guid'];
-		$sig = base64_encode(rsa_sign($signed_text, $owner["uprvkey"], "sha256"));
-
 		$msg = array(
 			"author" => $myaddr,
 			"guid" => $item["guid"],
 			"conversation_guid" => $cnv["guid"],
 			"text" => $body,
 			"created_at" => $created,
-			//"parent_guid" => $cnv["guid"],
-			//"parent_author_signature" => $sig,
-			//"author_signature" => $sig,
 		);
 
 		if ($item["reply"]) {

--- a/include/diaspora.php
+++ b/include/diaspora.php
@@ -4,8 +4,8 @@
  * @brief The implementation of the diaspora protocol
  *
  * The new protocol is described here: http://diaspora.github.io/diaspora_federation/index.html
- * Currently this implementation here interprets the old and the new protocol and sends the old one.
- * This will change in the future.
+ * This implementation here interprets the old and the new protocol and sends the new one.
+ * In the future we will remove most stuff from "valid_posting" and interpret only the new protocol.
  */
 
 use Friendica\App;
@@ -2883,7 +2883,7 @@ class Diaspora {
 		$new = Config::get('system', 'new_diaspora', null, true);
 
 		if ($new) {
-			if ($public) {
+			if (!$public) {
 				$msg = Diaspora::encode_private_data($msg, $user, $contact, $prvkey, $pubkey);
 			}
 


### PR DESCRIPTION
Since months, Diaspora is preparing a huge protocol change. This was done in several steps. The first step was to accept both the new and the old format while sending the old format. The second step is now to send the new format while the old and new format is accepted. The third step will be that only the new format is accepted.

We are now at the second step and some days faster than Diaspora :-) Their develop version will be releases in some days as well.

With this change we will stay compatible with all recent versions of Diaspora, but communication with old Diaspora versions and with Hubzilla will now fail. 