### PR TITLE
Corrected names for counting/ listing account-types in admin panel 

### DIFF
--- a/mod/admin.php
+++ b/mod/admin.php
@@ -558,11 +558,11 @@ function admin_page_summary(App $a) {
 	$r = q("SELECT `page-flags`, COUNT(`uid`) AS `count` FROM `user` GROUP BY `page-flags`");
 	$accounts = array(
 		array(t('Normal Account'), 0),
-		array(t('Soapbox Account'), 0),
-		array(t('Community/Celebrity Account'), 0),
+		array(t('Automatic Follower Account'), 0),
+		array(t('Public Forum Account'), 0),
 		array(t('Automatic Friend Account'), 0),
 		array(t('Blog Account'), 0),
-		array(t('Private Forum'), 0)
+		array(t('Private Forum Account'), 0)
 	);
 
 	$users=0;
@@ -1451,8 +1451,8 @@ function admin_page_users(App $a) {
 	$_setup_users = function ($e) use ($adminlist) {
 		$accounts = array(
 			t('Normal Account'),
-			t('Soapbox Account'),
-			t('Community/Celebrity Account'),
+			t('Automatic Follower Account'),
+			t('Public Forum Account'),
 						t('Automatic Friend Account')
 		);
 		$e['page-flags'] = $accounts[$e['page-flags']];

--- a/util/messages.po
+++ b/util/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-06-09 16:42+0700\n"
+"POT-Creation-Date: 2017-06-19 16:23+0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,122 +18,325 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 
-#: include/contact_selectors.php:32
-msgid "Unknown | Not categorised"
+#: include/ForumManager.php:116 include/nav.php:133 include/text.php:1094
+#: view/theme/vier/theme.php:248
+msgid "Forums"
 msgstr ""
 
-#: include/contact_selectors.php:33
-msgid "Block immediately"
+#: include/ForumManager.php:118 view/theme/vier/theme.php:250
+msgid "External link to forum"
 msgstr ""
 
-#: include/contact_selectors.php:34
-msgid "Shady, spammer, self-marketer"
+#: include/ForumManager.php:121 include/contact_widgets.php:271
+#: include/items.php:2432 mod/content.php:625 object/Item.php:417
+#: src/App.php:507 view/theme/vier/theme.php:253
+msgid "show more"
 msgstr ""
 
-#: include/contact_selectors.php:35
-msgid "Known to me, but no opinion"
+#: include/bb2diaspora.php:233 include/event.php:19 mod/localtime.php:13
+msgid "l F d, Y \\@ g:i A"
 msgstr ""
 
-#: include/contact_selectors.php:36
-msgid "OK, probably harmless"
+#: include/bb2diaspora.php:239 include/event.php:36 include/event.php:56
+#: include/event.php:459
+msgid "Starts:"
 msgstr ""
 
-#: include/contact_selectors.php:37
-msgid "Reputable, has my trust"
+#: include/bb2diaspora.php:247 include/event.php:39 include/event.php:62
+#: include/event.php:460
+msgid "Finishes:"
 msgstr ""
 
-#: include/contact_selectors.php:56 mod/admin.php:986
-msgid "Frequently"
+#: include/bb2diaspora.php:256 include/event.php:43 include/event.php:69
+#: include/event.php:461 include/identity.php:342 mod/directory.php:135
+#: mod/notifications.php:246 mod/contacts.php:639 mod/events.php:496
+msgid "Location:"
 msgstr ""
 
-#: include/contact_selectors.php:57 mod/admin.php:987
-msgid "Hourly"
+#: include/datetime.php:66 include/datetime.php:68 mod/profiles.php:701
+msgid "Miscellaneous"
 msgstr ""
 
-#: include/contact_selectors.php:58 mod/admin.php:988
-msgid "Twice daily"
+#: include/datetime.php:196 include/identity.php:656
+msgid "Birthday:"
 msgstr ""
 
-#: include/contact_selectors.php:59 mod/admin.php:989
-msgid "Daily"
+#: include/datetime.php:198 mod/profiles.php:724
+msgid "Age: "
 msgstr ""
 
-#: include/contact_selectors.php:60
-msgid "Weekly"
+#: include/datetime.php:200
+msgid "YYYY-MM-DD or MM-DD"
 msgstr ""
 
-#: include/contact_selectors.php:61
-msgid "Monthly"
+#: include/datetime.php:370
+msgid "never"
 msgstr ""
 
-#: include/contact_selectors.php:76 mod/dfrn_request.php:886
-msgid "Friendica"
+#: include/datetime.php:376
+msgid "less than a second ago"
 msgstr ""
 
-#: include/contact_selectors.php:77
-msgid "OStatus"
+#: include/datetime.php:379
+msgid "year"
 msgstr ""
 
-#: include/contact_selectors.php:78
-msgid "RSS/Atom"
+#: include/datetime.php:379
+msgid "years"
 msgstr ""
 
-#: include/contact_selectors.php:79 include/contact_selectors.php:86
-#: mod/admin.php:1496 mod/admin.php:1509 mod/admin.php:1522 mod/admin.php:1540
-msgid "Email"
+#: include/datetime.php:380 include/event.php:453 mod/cal.php:281
+#: mod/events.php:387
+msgid "month"
 msgstr ""
 
-#: include/contact_selectors.php:80 mod/dfrn_request.php:888
-#: mod/settings.php:849
-msgid "Diaspora"
+#: include/datetime.php:380
+msgid "months"
 msgstr ""
 
-#: include/contact_selectors.php:81
-msgid "Facebook"
+#: include/datetime.php:381 include/event.php:454 mod/cal.php:282
+#: mod/events.php:388
+msgid "week"
 msgstr ""
 
-#: include/contact_selectors.php:82
-msgid "Zot!"
+#: include/datetime.php:381
+msgid "weeks"
 msgstr ""
 
-#: include/contact_selectors.php:83
-msgid "LinkedIn"
+#: include/datetime.php:382 include/event.php:455 mod/cal.php:283
+#: mod/events.php:389
+msgid "day"
 msgstr ""
 
-#: include/contact_selectors.php:84
-msgid "XMPP/IM"
+#: include/datetime.php:382
+msgid "days"
 msgstr ""
 
-#: include/contact_selectors.php:85
-msgid "MySpace"
+#: include/datetime.php:383
+msgid "hour"
 msgstr ""
 
-#: include/contact_selectors.php:87
-msgid "Google+"
+#: include/datetime.php:383
+msgid "hours"
 msgstr ""
 
-#: include/contact_selectors.php:88
-msgid "pump.io"
+#: include/datetime.php:384
+msgid "minute"
 msgstr ""
 
-#: include/contact_selectors.php:89
-msgid "Twitter"
+#: include/datetime.php:384
+msgid "minutes"
 msgstr ""
 
-#: include/contact_selectors.php:90
-msgid "Diaspora Connector"
+#: include/datetime.php:385
+msgid "second"
 msgstr ""
 
-#: include/contact_selectors.php:91
-msgid "GNU Social Connector"
+#: include/datetime.php:385
+msgid "seconds"
 msgstr ""
 
-#: include/contact_selectors.php:92
-msgid "pnut"
+#: include/datetime.php:394
+#, php-format
+msgid "%1$d %2$s ago"
 msgstr ""
 
-#: include/contact_selectors.php:93
-msgid "App.net"
+#: include/datetime.php:620
+#, php-format
+msgid "%s's birthday"
+msgstr ""
+
+#: include/datetime.php:621 include/dfrn.php:1310
+#, php-format
+msgid "Happy Birthday %s"
+msgstr ""
+
+#: include/event.php:408
+msgid "all-day"
+msgstr ""
+
+#: include/event.php:410
+msgid "Sun"
+msgstr ""
+
+#: include/event.php:411
+msgid "Mon"
+msgstr ""
+
+#: include/event.php:412
+msgid "Tue"
+msgstr ""
+
+#: include/event.php:413
+msgid "Wed"
+msgstr ""
+
+#: include/event.php:414
+msgid "Thu"
+msgstr ""
+
+#: include/event.php:415
+msgid "Fri"
+msgstr ""
+
+#: include/event.php:416
+msgid "Sat"
+msgstr ""
+
+#: include/event.php:418 include/text.php:1199 mod/settings.php:982
+msgid "Sunday"
+msgstr ""
+
+#: include/event.php:419 include/text.php:1199 mod/settings.php:982
+msgid "Monday"
+msgstr ""
+
+#: include/event.php:420 include/text.php:1199
+msgid "Tuesday"
+msgstr ""
+
+#: include/event.php:421 include/text.php:1199
+msgid "Wednesday"
+msgstr ""
+
+#: include/event.php:422 include/text.php:1199
+msgid "Thursday"
+msgstr ""
+
+#: include/event.php:423 include/text.php:1199
+msgid "Friday"
+msgstr ""
+
+#: include/event.php:424 include/text.php:1199
+msgid "Saturday"
+msgstr ""
+
+#: include/event.php:426
+msgid "Jan"
+msgstr ""
+
+#: include/event.php:427
+msgid "Feb"
+msgstr ""
+
+#: include/event.php:428
+msgid "Mar"
+msgstr ""
+
+#: include/event.php:429
+msgid "Apr"
+msgstr ""
+
+#: include/event.php:430 include/event.php:443 include/text.php:1203
+msgid "May"
+msgstr ""
+
+#: include/event.php:431
+msgid "Jun"
+msgstr ""
+
+#: include/event.php:432
+msgid "Jul"
+msgstr ""
+
+#: include/event.php:433
+msgid "Aug"
+msgstr ""
+
+#: include/event.php:434
+msgid "Sept"
+msgstr ""
+
+#: include/event.php:435
+msgid "Oct"
+msgstr ""
+
+#: include/event.php:436
+msgid "Nov"
+msgstr ""
+
+#: include/event.php:437
+msgid "Dec"
+msgstr ""
+
+#: include/event.php:439 include/text.php:1203
+msgid "January"
+msgstr ""
+
+#: include/event.php:440 include/text.php:1203
+msgid "February"
+msgstr ""
+
+#: include/event.php:441 include/text.php:1203
+msgid "March"
+msgstr ""
+
+#: include/event.php:442 include/text.php:1203
+msgid "April"
+msgstr ""
+
+#: include/event.php:444 include/text.php:1203
+msgid "June"
+msgstr ""
+
+#: include/event.php:445 include/text.php:1203
+msgid "July"
+msgstr ""
+
+#: include/event.php:446 include/text.php:1203
+msgid "August"
+msgstr ""
+
+#: include/event.php:447 include/text.php:1203
+msgid "September"
+msgstr ""
+
+#: include/event.php:448 include/text.php:1203
+msgid "October"
+msgstr ""
+
+#: include/event.php:449 include/text.php:1203
+msgid "November"
+msgstr ""
+
+#: include/event.php:450 include/text.php:1203
+msgid "December"
+msgstr ""
+
+#: include/event.php:452 mod/cal.php:280 mod/events.php:386
+msgid "today"
+msgstr ""
+
+#: include/event.php:457
+msgid "No events to display"
+msgstr ""
+
+#: include/event.php:570
+msgid "l, F j"
+msgstr ""
+
+#: include/event.php:592
+msgid "Edit event"
+msgstr ""
+
+#: include/event.php:593
+msgid "Delete event"
+msgstr ""
+
+#: include/event.php:619 include/text.php:1601 include/text.php:1608
+msgid "link to source"
+msgstr ""
+
+#: include/event.php:873
+msgid "Export"
+msgstr ""
+
+#: include/event.php:874
+msgid "Export calendar as ical"
+msgstr ""
+
+#: include/event.php:875
+msgid "Export calendar as csv"
 msgstr ""
 
 #: include/features.php:65
@@ -335,66 +538,626 @@ msgstr ""
 msgid "Show visitors public community forums at the Advanced Profile Page"
 msgstr ""
 
-#: include/group.php:25
+#: include/like.php:30 include/conversation.php:154 include/diaspora.php:1649
+#, php-format
+msgid "%1$s likes %2$s's %3$s"
+msgstr ""
+
+#: include/like.php:34 include/like.php:39 include/conversation.php:157
+#, php-format
+msgid "%1$s doesn't like %2$s's %3$s"
+msgstr ""
+
+#: include/like.php:44
+#, php-format
+msgid "%1$s is attending %2$s's %3$s"
+msgstr ""
+
+#: include/like.php:49
+#, php-format
+msgid "%1$s is not attending %2$s's %3$s"
+msgstr ""
+
+#: include/like.php:54
+#, php-format
+msgid "%1$s may attend %2$s's %3$s"
+msgstr ""
+
+#: include/like.php:181 include/conversation.php:142
+#: include/conversation.php:294 include/text.php:1873 mod/subthread.php:89
+#: mod/tagger.php:63
+msgid "photo"
+msgstr ""
+
+#: include/like.php:181 include/conversation.php:137
+#: include/conversation.php:147 include/conversation.php:289
+#: include/conversation.php:298 include/diaspora.php:1653 mod/subthread.php:89
+#: mod/tagger.php:63
+msgid "status"
+msgstr ""
+
+#: include/like.php:183 include/conversation.php:134
+#: include/conversation.php:286 include/text.php:1871
+msgid "event"
+msgstr ""
+
+#: include/profile_selectors.php:6
+msgid "Male"
+msgstr ""
+
+#: include/profile_selectors.php:6
+msgid "Female"
+msgstr ""
+
+#: include/profile_selectors.php:6
+msgid "Currently Male"
+msgstr ""
+
+#: include/profile_selectors.php:6
+msgid "Currently Female"
+msgstr ""
+
+#: include/profile_selectors.php:6
+msgid "Mostly Male"
+msgstr ""
+
+#: include/profile_selectors.php:6
+msgid "Mostly Female"
+msgstr ""
+
+#: include/profile_selectors.php:6
+msgid "Transgender"
+msgstr ""
+
+#: include/profile_selectors.php:6
+msgid "Intersex"
+msgstr ""
+
+#: include/profile_selectors.php:6
+msgid "Transsexual"
+msgstr ""
+
+#: include/profile_selectors.php:6
+msgid "Hermaphrodite"
+msgstr ""
+
+#: include/profile_selectors.php:6
+msgid "Neuter"
+msgstr ""
+
+#: include/profile_selectors.php:6
+msgid "Non-specific"
+msgstr ""
+
+#: include/profile_selectors.php:6
+msgid "Other"
+msgstr ""
+
+#: include/profile_selectors.php:6 include/conversation.php:1548
+msgid "Undecided"
+msgid_plural "Undecided"
+msgstr[0] ""
+msgstr[1] ""
+
+#: include/profile_selectors.php:23
+msgid "Males"
+msgstr ""
+
+#: include/profile_selectors.php:23
+msgid "Females"
+msgstr ""
+
+#: include/profile_selectors.php:23
+msgid "Gay"
+msgstr ""
+
+#: include/profile_selectors.php:23
+msgid "Lesbian"
+msgstr ""
+
+#: include/profile_selectors.php:23
+msgid "No Preference"
+msgstr ""
+
+#: include/profile_selectors.php:23
+msgid "Bisexual"
+msgstr ""
+
+#: include/profile_selectors.php:23
+msgid "Autosexual"
+msgstr ""
+
+#: include/profile_selectors.php:23
+msgid "Abstinent"
+msgstr ""
+
+#: include/profile_selectors.php:23
+msgid "Virgin"
+msgstr ""
+
+#: include/profile_selectors.php:23
+msgid "Deviant"
+msgstr ""
+
+#: include/profile_selectors.php:23
+msgid "Fetish"
+msgstr ""
+
+#: include/profile_selectors.php:23
+msgid "Oodles"
+msgstr ""
+
+#: include/profile_selectors.php:23
+msgid "Nonsexual"
+msgstr ""
+
+#: include/profile_selectors.php:42
+msgid "Single"
+msgstr ""
+
+#: include/profile_selectors.php:42
+msgid "Lonely"
+msgstr ""
+
+#: include/profile_selectors.php:42
+msgid "Available"
+msgstr ""
+
+#: include/profile_selectors.php:42
+msgid "Unavailable"
+msgstr ""
+
+#: include/profile_selectors.php:42
+msgid "Has crush"
+msgstr ""
+
+#: include/profile_selectors.php:42
+msgid "Infatuated"
+msgstr ""
+
+#: include/profile_selectors.php:42
+msgid "Dating"
+msgstr ""
+
+#: include/profile_selectors.php:42
+msgid "Unfaithful"
+msgstr ""
+
+#: include/profile_selectors.php:42
+msgid "Sex Addict"
+msgstr ""
+
+#: include/profile_selectors.php:42 include/user.php:260 include/user.php:264
+msgid "Friends"
+msgstr ""
+
+#: include/profile_selectors.php:42
+msgid "Friends/Benefits"
+msgstr ""
+
+#: include/profile_selectors.php:42
+msgid "Casual"
+msgstr ""
+
+#: include/profile_selectors.php:42
+msgid "Engaged"
+msgstr ""
+
+#: include/profile_selectors.php:42
+msgid "Married"
+msgstr ""
+
+#: include/profile_selectors.php:42
+msgid "Imaginarily married"
+msgstr ""
+
+#: include/profile_selectors.php:42
+msgid "Partners"
+msgstr ""
+
+#: include/profile_selectors.php:42
+msgid "Cohabiting"
+msgstr ""
+
+#: include/profile_selectors.php:42
+msgid "Common law"
+msgstr ""
+
+#: include/profile_selectors.php:42
+msgid "Happy"
+msgstr ""
+
+#: include/profile_selectors.php:42
+msgid "Not looking"
+msgstr ""
+
+#: include/profile_selectors.php:42
+msgid "Swinger"
+msgstr ""
+
+#: include/profile_selectors.php:42
+msgid "Betrayed"
+msgstr ""
+
+#: include/profile_selectors.php:42
+msgid "Separated"
+msgstr ""
+
+#: include/profile_selectors.php:42
+msgid "Unstable"
+msgstr ""
+
+#: include/profile_selectors.php:42
+msgid "Divorced"
+msgstr ""
+
+#: include/profile_selectors.php:42
+msgid "Imaginarily divorced"
+msgstr ""
+
+#: include/profile_selectors.php:42
+msgid "Widowed"
+msgstr ""
+
+#: include/profile_selectors.php:42
+msgid "Uncertain"
+msgstr ""
+
+#: include/profile_selectors.php:42
+msgid "It's complicated"
+msgstr ""
+
+#: include/profile_selectors.php:42
+msgid "Don't care"
+msgstr ""
+
+#: include/profile_selectors.php:42
+msgid "Ask me"
+msgstr ""
+
+#: include/security.php:63
+msgid "Welcome "
+msgstr ""
+
+#: include/security.php:64
+msgid "Please upload a profile photo."
+msgstr ""
+
+#: include/security.php:67
+msgid "Welcome back "
+msgstr ""
+
+#: include/security.php:431
 msgid ""
-"A deleted group with this name was revived. Existing item permissions "
-"<strong>may</strong> apply to this group and any future members. If this is "
-"not what you intended, please create another group with a different name."
+"The form security token was not correct. This probably happened because the "
+"form has been opened for too long (>3 hours) before submitting it."
 msgstr ""
 
-#: include/group.php:210
-msgid "Default privacy group for new contacts"
+#: include/uimport.php:85
+msgid "Error decoding account file"
 msgstr ""
 
-#: include/group.php:243
-msgid "Everybody"
+#: include/uimport.php:91
+msgid "Error! No version data in file! This is not a Friendica account file?"
 msgstr ""
 
-#: include/group.php:266
-msgid "edit"
+#: include/uimport.php:108 include/uimport.php:119
+msgid "Error! Cannot check nickname"
 msgstr ""
 
-#: include/group.php:287 mod/newmember.php:39
-msgid "Groups"
+#: include/uimport.php:112 include/uimport.php:123
+#, php-format
+msgid "User '%s' already exists on this server!"
 msgstr ""
 
-#: include/group.php:289
-msgid "Edit groups"
+#: include/uimport.php:145
+msgid "User creation error"
 msgstr ""
 
-#: include/group.php:291
-msgid "Edit group"
+#: include/uimport.php:166
+msgid "User profile creation error"
 msgstr ""
 
-#: include/group.php:292
-msgid "Create a new group"
+#: include/uimport.php:215
+#, php-format
+msgid "%d contact not imported"
+msgid_plural "%d contacts not imported"
+msgstr[0] ""
+msgstr[1] ""
+
+#: include/uimport.php:281
+msgid "Done. You can now login with your username and password"
 msgstr ""
 
-#: include/group.php:293 mod/group.php:100 mod/group.php:197
-msgid "Group Name: "
+#: include/user.php:39 mod/settings.php:377
+msgid "Passwords do not match. Password unchanged."
 msgstr ""
 
-#: include/group.php:295
-msgid "Contacts not in any group"
+#: include/user.php:48
+msgid "An invitation is required."
 msgstr ""
 
-#: include/group.php:297 mod/network.php:210
-msgid "add"
+#: include/user.php:53
+msgid "Invitation could not be verified."
 msgstr ""
 
-#: include/ForumManager.php:116 include/text.php:1094 include/nav.php:133
-#: view/theme/vier/theme.php:248
-msgid "Forums"
+#: include/user.php:61
+msgid "Invalid OpenID url"
 msgstr ""
 
-#: include/ForumManager.php:118 view/theme/vier/theme.php:250
-msgid "External link to forum"
+#: include/user.php:75 include/auth.php:139
+msgid ""
+"We encountered a problem while logging in with the OpenID you provided. "
+"Please check the correct spelling of the ID."
 msgstr ""
 
-#: include/ForumManager.php:121 include/contact_widgets.php:271
-#: include/items.php:2432 mod/content.php:625 object/Item.php:417
-#: view/theme/vier/theme.php:253 src/App.php:506
-msgid "show more"
+#: include/user.php:75 include/auth.php:139
+msgid "The error message was:"
+msgstr ""
+
+#: include/user.php:82
+msgid "Please enter the required information."
+msgstr ""
+
+#: include/user.php:96
+msgid "Please use a shorter name."
+msgstr ""
+
+#: include/user.php:98
+msgid "Name too short."
+msgstr ""
+
+#: include/user.php:106
+msgid "That doesn't appear to be your full (First Last) name."
+msgstr ""
+
+#: include/user.php:111
+msgid "Your email domain is not among those allowed on this site."
+msgstr ""
+
+#: include/user.php:114
+msgid "Not a valid email address."
+msgstr ""
+
+#: include/user.php:127
+msgid "Cannot use that email."
+msgstr ""
+
+#: include/user.php:133
+msgid "Your \"nickname\" can only contain \"a-z\", \"0-9\" and \"_\"."
+msgstr ""
+
+#: include/user.php:140 include/user.php:228
+msgid "Nickname is already registered. Please choose another."
+msgstr ""
+
+#: include/user.php:150
+msgid ""
+"Nickname was once registered here and may not be re-used. Please choose "
+"another."
+msgstr ""
+
+#: include/user.php:166
+msgid "SERIOUS ERROR: Generation of security keys failed."
+msgstr ""
+
+#: include/user.php:214
+msgid "An error occurred during registration. Please try again."
+msgstr ""
+
+#: include/user.php:237 view/theme/duepuntozero/config.php:46
+msgid "default"
+msgstr ""
+
+#: include/user.php:247
+msgid "An error occurred creating your default profile. Please try again."
+msgstr ""
+
+#: include/user.php:306 include/user.php:314 include/user.php:322
+#: include/api.php:3702 mod/photos.php:73 mod/photos.php:189 mod/photos.php:776
+#: mod/photos.php:1258 mod/photos.php:1279 mod/photos.php:1865
+#: mod/profile_photo.php:74 mod/profile_photo.php:82 mod/profile_photo.php:90
+#: mod/profile_photo.php:214 mod/profile_photo.php:309
+#: mod/profile_photo.php:319
+msgid "Profile Photos"
+msgstr ""
+
+#: include/user.php:397
+#, php-format
+msgid ""
+"\n"
+"\t\tDear %1$s,\n"
+"\t\t\tThank you for registering at %2$s. Your account is pending for "
+"approval by the administrator.\n"
+"\t"
+msgstr ""
+
+#: include/user.php:407
+#, php-format
+msgid "Registration at %s"
+msgstr ""
+
+#: include/user.php:417
+#, php-format
+msgid ""
+"\n"
+"\t\tDear %1$s,\n"
+"\t\t\tThank you for registering at %2$s. Your account has been created.\n"
+"\t"
+msgstr ""
+
+#: include/user.php:421
+#, php-format
+msgid ""
+"\n"
+"\t\tThe login details are as follows:\n"
+"\t\t\tSite Location:\t%3$s\n"
+"\t\t\tLogin Name:\t%1$s\n"
+"\t\t\tPassword:\t%5$s\n"
+"\n"
+"\t\tYou may change your password from your account \"Settings\" page after "
+"logging\n"
+"\t\tin.\n"
+"\n"
+"\t\tPlease take a few moments to review the other account settings on that "
+"page.\n"
+"\n"
+"\t\tYou may also wish to add some basic information to your default profile\n"
+"\t\t(on the \"Profiles\" page) so that other people can easily find you.\n"
+"\n"
+"\t\tWe recommend setting your full name, adding a profile photo,\n"
+"\t\tadding some profile \"keywords\" (very useful in making new friends) - "
+"and\n"
+"\t\tperhaps what country you live in; if you do not wish to be more "
+"specific\n"
+"\t\tthan that.\n"
+"\n"
+"\t\tWe fully respect your right to privacy, and none of these items are "
+"necessary.\n"
+"\t\tIf you are new and do not know anybody here, they may help\n"
+"\t\tyou to make some new and interesting friends.\n"
+"\n"
+"\n"
+"\t\tThank you and welcome to %2$s."
+msgstr ""
+
+#: include/user.php:453 mod/admin.php:1314
+#, php-format
+msgid "Registration details for %s"
+msgstr ""
+
+#: include/Contact.php:375 include/Contact.php:388 include/Contact.php:433
+#: include/conversation.php:1005 include/conversation.php:1021
+#: mod/allfriends.php:70 mod/directory.php:153 mod/match.php:76
+#: mod/suggest.php:84 mod/dirfind.php:211
+msgid "View Profile"
+msgstr ""
+
+#: include/Contact.php:389 include/contact_widgets.php:34
+#: include/conversation.php:1018 mod/allfriends.php:71 mod/match.php:77
+#: mod/suggest.php:85 mod/contacts.php:613 mod/dirfind.php:212
+#: mod/follow.php:108
+msgid "Connect/Follow"
+msgstr ""
+
+#: include/Contact.php:432 include/conversation.php:1004
+msgid "View Status"
+msgstr ""
+
+#: include/Contact.php:434 include/conversation.php:1006
+msgid "View Photos"
+msgstr ""
+
+#: include/Contact.php:435 include/conversation.php:1007
+msgid "Network Posts"
+msgstr ""
+
+#: include/Contact.php:436 include/conversation.php:1008
+msgid "View Contact"
+msgstr ""
+
+#: include/Contact.php:437
+msgid "Drop Contact"
+msgstr ""
+
+#: include/Contact.php:438 include/conversation.php:1009
+msgid "Send PM"
+msgstr ""
+
+#: include/Contact.php:439 include/conversation.php:1013
+msgid "Poke"
+msgstr ""
+
+#: include/Contact.php:819
+msgid "Organisation"
+msgstr ""
+
+#: include/Contact.php:822
+msgid "News"
+msgstr ""
+
+#: include/Contact.php:825
+msgid "Forum"
+msgstr ""
+
+#: include/NotificationsManager.php:155
+msgid "System"
+msgstr ""
+
+#: include/NotificationsManager.php:162 include/nav.php:160 mod/admin.php:518
+#: view/theme/frio/theme.php:255
+msgid "Network"
+msgstr ""
+
+#: include/NotificationsManager.php:169 mod/profiles.php:699
+#: mod/network.php:835
+msgid "Personal"
+msgstr ""
+
+#: include/NotificationsManager.php:176 include/nav.php:107 include/nav.php:163
+msgid "Home"
+msgstr ""
+
+#: include/NotificationsManager.php:183 include/nav.php:168
+msgid "Introductions"
+msgstr ""
+
+#: include/NotificationsManager.php:241 include/NotificationsManager.php:253
+#, php-format
+msgid "%s commented on %s's post"
+msgstr ""
+
+#: include/NotificationsManager.php:252
+#, php-format
+msgid "%s created a new post"
+msgstr ""
+
+#: include/NotificationsManager.php:267
+#, php-format
+msgid "%s liked %s's post"
+msgstr ""
+
+#: include/NotificationsManager.php:280
+#, php-format
+msgid "%s disliked %s's post"
+msgstr ""
+
+#: include/NotificationsManager.php:293
+#, php-format
+msgid "%s is attending %s's event"
+msgstr ""
+
+#: include/NotificationsManager.php:306
+#, php-format
+msgid "%s is not attending %s's event"
+msgstr ""
+
+#: include/NotificationsManager.php:319
+#, php-format
+msgid "%s may attend %s's event"
+msgstr ""
+
+#: include/NotificationsManager.php:336
+#, php-format
+msgid "%s is now friends with %s"
+msgstr ""
+
+#: include/NotificationsManager.php:774
+msgid "Friend Suggestion"
+msgstr ""
+
+#: include/NotificationsManager.php:803
+msgid "Friend/Connect Request"
+msgstr ""
+
+#: include/NotificationsManager.php:803
+msgid "New Follower"
+msgstr ""
+
+#: include/Photo.php:1075 include/Photo.php:1091 include/Photo.php:1099
+#: include/Photo.php:1124 include/message.php:145 mod/wall_upload.php:249
+#: mod/item.php:468
+msgid "Wall Photos"
 msgstr ""
 
 #: include/acl_selectors.php:355
@@ -430,13 +1193,28 @@ msgstr ""
 msgid "Example: bob@example.com, mary@example.com"
 msgstr ""
 
-#: include/acl_selectors.php:378 mod/events.php:511 mod/photos.php:1198
-#: mod/photos.php:1595
+#: include/acl_selectors.php:378 mod/photos.php:1198 mod/photos.php:1595
+#: mod/events.php:511
 msgid "Permissions"
 msgstr ""
 
 #: include/acl_selectors.php:379
 msgid "Close"
+msgstr ""
+
+#: include/api.php:1102
+#, php-format
+msgid "Daily posting limit of %d posts reached. The post was rejected."
+msgstr ""
+
+#: include/api.php:1123
+#, php-format
+msgid "Weekly posting limit of %d posts reached. The post was rejected."
+msgstr ""
+
+#: include/api.php:1144
+#, php-format
+msgid "Monthly posting limit of %d posts reached. The post was rejected."
 msgstr ""
 
 #: include/auth.php:52
@@ -447,34 +1225,147 @@ msgstr ""
 msgid "Login failed."
 msgstr ""
 
-#: include/auth.php:139 include/user.php:75
-msgid ""
-"We encountered a problem while logging in with the OpenID you provided. "
-"Please check the correct spelling of the ID."
+#: include/bbcode.php:419 include/bbcode.php:1178 include/bbcode.php:1179
+msgid "Image/photo"
 msgstr ""
 
-#: include/auth.php:139 include/user.php:75
-msgid "The error message was:"
+#: include/bbcode.php:536
+#, php-format
+msgid "<a href=\"%1$s\" target=\"_blank\">%2$s</a> %3$s"
 msgstr ""
 
-#: include/bb2diaspora.php:233 include/event.php:19 mod/localtime.php:13
-msgid "l F d, Y \\@ g:i A"
+#: include/bbcode.php:1135 include/bbcode.php:1157
+msgid "$1 wrote:"
 msgstr ""
 
-#: include/bb2diaspora.php:239 include/event.php:36 include/event.php:56
-#: include/event.php:459
-msgid "Starts:"
+#: include/bbcode.php:1187 include/bbcode.php:1188
+msgid "Encrypted content"
 msgstr ""
 
-#: include/bb2diaspora.php:247 include/event.php:39 include/event.php:62
-#: include/event.php:460
-msgid "Finishes:"
+#: include/bbcode.php:1303
+msgid "Invalid source protocol"
 msgstr ""
 
-#: include/bb2diaspora.php:256 include/event.php:43 include/event.php:69
-#: include/event.php:461 include/identity.php:342 mod/directory.php:135
-#: mod/events.php:496 mod/notifications.php:246 mod/contacts.php:639
-msgid "Location:"
+#: include/bbcode.php:1313
+msgid "Invalid link protocol"
+msgstr ""
+
+#: include/contact_selectors.php:32
+msgid "Unknown | Not categorised"
+msgstr ""
+
+#: include/contact_selectors.php:33
+msgid "Block immediately"
+msgstr ""
+
+#: include/contact_selectors.php:34
+msgid "Shady, spammer, self-marketer"
+msgstr ""
+
+#: include/contact_selectors.php:35
+msgid "Known to me, but no opinion"
+msgstr ""
+
+#: include/contact_selectors.php:36
+msgid "OK, probably harmless"
+msgstr ""
+
+#: include/contact_selectors.php:37
+msgid "Reputable, has my trust"
+msgstr ""
+
+#: include/contact_selectors.php:56 mod/admin.php:986
+msgid "Frequently"
+msgstr ""
+
+#: include/contact_selectors.php:57 mod/admin.php:987
+msgid "Hourly"
+msgstr ""
+
+#: include/contact_selectors.php:58 mod/admin.php:988
+msgid "Twice daily"
+msgstr ""
+
+#: include/contact_selectors.php:59 mod/admin.php:989
+msgid "Daily"
+msgstr ""
+
+#: include/contact_selectors.php:60
+msgid "Weekly"
+msgstr ""
+
+#: include/contact_selectors.php:61
+msgid "Monthly"
+msgstr ""
+
+#: include/contact_selectors.php:76 mod/dfrn_request.php:886
+msgid "Friendica"
+msgstr ""
+
+#: include/contact_selectors.php:77
+msgid "OStatus"
+msgstr ""
+
+#: include/contact_selectors.php:78
+msgid "RSS/Atom"
+msgstr ""
+
+#: include/contact_selectors.php:79 include/contact_selectors.php:86
+#: mod/admin.php:1496 mod/admin.php:1509 mod/admin.php:1522 mod/admin.php:1540
+msgid "Email"
+msgstr ""
+
+#: include/contact_selectors.php:80 mod/dfrn_request.php:888
+#: mod/settings.php:849
+msgid "Diaspora"
+msgstr ""
+
+#: include/contact_selectors.php:81
+msgid "Facebook"
+msgstr ""
+
+#: include/contact_selectors.php:82
+msgid "Zot!"
+msgstr ""
+
+#: include/contact_selectors.php:83
+msgid "LinkedIn"
+msgstr ""
+
+#: include/contact_selectors.php:84
+msgid "XMPP/IM"
+msgstr ""
+
+#: include/contact_selectors.php:85
+msgid "MySpace"
+msgstr ""
+
+#: include/contact_selectors.php:87
+msgid "Google+"
+msgstr ""
+
+#: include/contact_selectors.php:88
+msgid "pump.io"
+msgstr ""
+
+#: include/contact_selectors.php:89
+msgid "Twitter"
+msgstr ""
+
+#: include/contact_selectors.php:90
+msgid "Diaspora Connector"
+msgstr ""
+
+#: include/contact_selectors.php:91
+msgid "GNU Social Connector"
+msgstr ""
+
+#: include/contact_selectors.php:92
+msgid "pnut"
+msgstr ""
+
+#: include/contact_selectors.php:93
+msgid "App.net"
 msgstr ""
 
 #: include/contact_widgets.php:8
@@ -490,8 +1381,8 @@ msgid "Example: bob@example.com, http://example.com/barbara"
 msgstr ""
 
 #: include/contact_widgets.php:12 include/identity.php:230
-#: mod/allfriends.php:87 mod/dirfind.php:209 mod/match.php:92
-#: mod/suggest.php:103
+#: mod/allfriends.php:87 mod/match.php:92 mod/suggest.php:103
+#: mod/dirfind.php:209
 msgid "Connect"
 msgstr ""
 
@@ -508,12 +1399,6 @@ msgstr ""
 
 #: include/contact_widgets.php:33
 msgid "Enter name or interest"
-msgstr ""
-
-#: include/contact_widgets.php:34 include/conversation.php:1018
-#: include/Contact.php:389 mod/allfriends.php:71 mod/dirfind.php:212
-#: mod/follow.php:108 mod/match.php:77 mod/suggest.php:85 mod/contacts.php:613
-msgid "Connect/Follow"
 msgstr ""
 
 #: include/contact_widgets.php:35
@@ -563,34 +1448,6 @@ msgid "%d contact in common"
 msgid_plural "%d contacts in common"
 msgstr[0] ""
 msgstr[1] ""
-
-#: include/conversation.php:134 include/conversation.php:286
-#: include/like.php:183 include/text.php:1871
-msgid "event"
-msgstr ""
-
-#: include/conversation.php:137 include/conversation.php:147
-#: include/conversation.php:289 include/conversation.php:298
-#: include/like.php:181 include/diaspora.php:1653 mod/subthread.php:89
-#: mod/tagger.php:63
-msgid "status"
-msgstr ""
-
-#: include/conversation.php:142 include/conversation.php:294
-#: include/like.php:181 include/text.php:1873 mod/subthread.php:89
-#: mod/tagger.php:63
-msgid "photo"
-msgstr ""
-
-#: include/conversation.php:154 include/like.php:30 include/diaspora.php:1649
-#, php-format
-msgid "%1$s likes %2$s's %3$s"
-msgstr ""
-
-#: include/conversation.php:157 include/like.php:34 include/like.php:39
-#, php-format
-msgid "%1$s doesn't like %2$s's %3$s"
-msgstr ""
 
 #: include/conversation.php:160
 #, php-format
@@ -668,7 +1525,7 @@ msgstr ""
 
 #: include/conversation.php:749 mod/content.php:455 mod/content.php:761
 #: mod/photos.php:1731 mod/contacts.php:819 mod/contacts.php:1018
-#: mod/admin.php:1514 mod/settings.php:745 object/Item.php:138
+#: mod/settings.php:745 mod/admin.php:1514 object/Item.php:138
 msgid "Delete"
 msgstr ""
 
@@ -713,37 +1570,6 @@ msgstr ""
 
 #: include/conversation.php:1003
 msgid "Follow Thread"
-msgstr ""
-
-#: include/conversation.php:1004 include/Contact.php:432
-msgid "View Status"
-msgstr ""
-
-#: include/conversation.php:1005 include/conversation.php:1021
-#: include/Contact.php:375 include/Contact.php:388 include/Contact.php:433
-#: mod/allfriends.php:70 mod/directory.php:153 mod/dirfind.php:211
-#: mod/match.php:76 mod/suggest.php:84
-msgid "View Profile"
-msgstr ""
-
-#: include/conversation.php:1006 include/Contact.php:434
-msgid "View Photos"
-msgstr ""
-
-#: include/conversation.php:1007 include/Contact.php:435
-msgid "Network Posts"
-msgstr ""
-
-#: include/conversation.php:1008 include/Contact.php:436
-msgid "View Contact"
-msgstr ""
-
-#: include/conversation.php:1009 include/Contact.php:438
-msgid "Send PM"
-msgstr ""
-
-#: include/conversation.php:1013 include/Contact.php:439
-msgid "Poke"
 msgstr ""
 
 #: include/conversation.php:1140
@@ -947,16 +1773,16 @@ msgid "Public post"
 msgstr ""
 
 #: include/conversation.php:1314 mod/content.php:738 mod/editpost.php:137
-#: mod/events.php:506 mod/photos.php:1649 mod/photos.php:1691
-#: mod/photos.php:1771 object/Item.php:711
+#: mod/photos.php:1649 mod/photos.php:1691 mod/photos.php:1771
+#: mod/events.php:506 object/Item.php:711
 msgid "Preview"
 msgstr ""
 
 #: include/conversation.php:1318 include/items.php:2165 mod/editpost.php:140
-#: mod/fbrowser.php:102 mod/fbrowser.php:137 mod/follow.php:126
-#: mod/message.php:211 mod/photos.php:247 mod/photos.php:339 mod/suggest.php:34
-#: mod/tagrm.php:13 mod/tagrm.php:98 mod/videos.php:134
-#: mod/dfrn_request.php:894 mod/contacts.php:458 mod/settings.php:683
+#: mod/fbrowser.php:102 mod/fbrowser.php:137 mod/message.php:211
+#: mod/photos.php:247 mod/photos.php:339 mod/suggest.php:34 mod/tagrm.php:13
+#: mod/tagrm.php:98 mod/videos.php:134 mod/contacts.php:458
+#: mod/dfrn_request.php:894 mod/follow.php:126 mod/settings.php:683
 #: mod/settings.php:709
 msgid "Cancel"
 msgstr ""
@@ -1003,108 +1829,52 @@ msgid_plural "Not Attending"
 msgstr[0] ""
 msgstr[1] ""
 
-#: include/conversation.php:1548 include/profile_selectors.php:6
-msgid "Undecided"
-msgid_plural "Undecided"
-msgstr[0] ""
-msgstr[1] ""
-
-#: include/datetime.php:66 include/datetime.php:68 mod/profiles.php:701
-msgid "Miscellaneous"
-msgstr ""
-
-#: include/datetime.php:196 include/identity.php:656
-msgid "Birthday:"
-msgstr ""
-
-#: include/datetime.php:198 mod/profiles.php:724
-msgid "Age: "
-msgstr ""
-
-#: include/datetime.php:200
-msgid "YYYY-MM-DD or MM-DD"
-msgstr ""
-
-#: include/datetime.php:370
-msgid "never"
-msgstr ""
-
-#: include/datetime.php:376
-msgid "less than a second ago"
-msgstr ""
-
-#: include/datetime.php:379
-msgid "year"
-msgstr ""
-
-#: include/datetime.php:379
-msgid "years"
-msgstr ""
-
-#: include/datetime.php:380 include/event.php:453 mod/cal.php:281
-#: mod/events.php:387
-msgid "month"
-msgstr ""
-
-#: include/datetime.php:380
-msgid "months"
-msgstr ""
-
-#: include/datetime.php:381 include/event.php:454 mod/cal.php:282
-#: mod/events.php:388
-msgid "week"
-msgstr ""
-
-#: include/datetime.php:381
-msgid "weeks"
-msgstr ""
-
-#: include/datetime.php:382 include/event.php:455 mod/cal.php:283
-#: mod/events.php:389
-msgid "day"
-msgstr ""
-
-#: include/datetime.php:382
-msgid "days"
-msgstr ""
-
-#: include/datetime.php:383
-msgid "hour"
-msgstr ""
-
-#: include/datetime.php:383
-msgid "hours"
-msgstr ""
-
-#: include/datetime.php:384
-msgid "minute"
-msgstr ""
-
-#: include/datetime.php:384
-msgid "minutes"
-msgstr ""
-
-#: include/datetime.php:385
-msgid "second"
-msgstr ""
-
-#: include/datetime.php:385
-msgid "seconds"
-msgstr ""
-
-#: include/datetime.php:394
+#: include/dba.php:59 include/dba_pdo.php:76
 #, php-format
-msgid "%1$d %2$s ago"
+msgid "Cannot locate DNS info for database server '%s'"
 msgstr ""
 
-#: include/datetime.php:620
-#, php-format
-msgid "%s's birthday"
+#: include/dbstructure.php:25
+msgid "There are no tables on MyISAM."
 msgstr ""
 
-#: include/datetime.php:621 include/dfrn.php:1254
+#: include/dbstructure.php:66
 #, php-format
-msgid "Happy Birthday %s"
+msgid ""
+"\n"
+"\t\t\tThe friendica developers released update %s recently,\n"
+"\t\t\tbut when I tried to install it, something went terribly wrong.\n"
+"\t\t\tThis needs to be fixed soon and I can't do it alone. Please contact a\n"
+"\t\t\tfriendica developer if you can not help me on your own. My database "
+"might be invalid."
+msgstr ""
+
+#: include/dbstructure.php:71
+#, php-format
+msgid ""
+"The error message is\n"
+"[pre]%s[/pre]"
+msgstr ""
+
+#: include/dbstructure.php:195
+#, php-format
+msgid ""
+"\n"
+"Error %d occurred during database update:\n"
+"%s\n"
+msgstr ""
+
+#: include/dbstructure.php:198
+msgid "Errors encountered performing database changes: "
+msgstr ""
+
+#: include/dbstructure.php:206
+msgid ": Database update"
+msgstr ""
+
+#: include/dbstructure.php:438
+#, php-format
+msgid "%s: updating %s table."
 msgstr ""
 
 #: include/delivery.php:428
@@ -1115,578 +1885,17 @@ msgstr ""
 msgid "noreply"
 msgstr ""
 
-#: include/dfrn.php:1253
+#: include/dfrn.php:1309
 #, php-format
 msgid "%s\\'s birthday"
 msgstr ""
 
-#: include/event.php:408
-msgid "all-day"
+#: include/diaspora.php:2214
+msgid "Sharing notification from Diaspora network"
 msgstr ""
 
-#: include/event.php:410
-msgid "Sun"
-msgstr ""
-
-#: include/event.php:411
-msgid "Mon"
-msgstr ""
-
-#: include/event.php:412
-msgid "Tue"
-msgstr ""
-
-#: include/event.php:413
-msgid "Wed"
-msgstr ""
-
-#: include/event.php:414
-msgid "Thu"
-msgstr ""
-
-#: include/event.php:415
-msgid "Fri"
-msgstr ""
-
-#: include/event.php:416
-msgid "Sat"
-msgstr ""
-
-#: include/event.php:418 include/text.php:1199 mod/settings.php:982
-msgid "Sunday"
-msgstr ""
-
-#: include/event.php:419 include/text.php:1199 mod/settings.php:982
-msgid "Monday"
-msgstr ""
-
-#: include/event.php:420 include/text.php:1199
-msgid "Tuesday"
-msgstr ""
-
-#: include/event.php:421 include/text.php:1199
-msgid "Wednesday"
-msgstr ""
-
-#: include/event.php:422 include/text.php:1199
-msgid "Thursday"
-msgstr ""
-
-#: include/event.php:423 include/text.php:1199
-msgid "Friday"
-msgstr ""
-
-#: include/event.php:424 include/text.php:1199
-msgid "Saturday"
-msgstr ""
-
-#: include/event.php:426
-msgid "Jan"
-msgstr ""
-
-#: include/event.php:427
-msgid "Feb"
-msgstr ""
-
-#: include/event.php:428
-msgid "Mar"
-msgstr ""
-
-#: include/event.php:429
-msgid "Apr"
-msgstr ""
-
-#: include/event.php:430 include/event.php:443 include/text.php:1203
-msgid "May"
-msgstr ""
-
-#: include/event.php:431
-msgid "Jun"
-msgstr ""
-
-#: include/event.php:432
-msgid "Jul"
-msgstr ""
-
-#: include/event.php:433
-msgid "Aug"
-msgstr ""
-
-#: include/event.php:434
-msgid "Sept"
-msgstr ""
-
-#: include/event.php:435
-msgid "Oct"
-msgstr ""
-
-#: include/event.php:436
-msgid "Nov"
-msgstr ""
-
-#: include/event.php:437
-msgid "Dec"
-msgstr ""
-
-#: include/event.php:439 include/text.php:1203
-msgid "January"
-msgstr ""
-
-#: include/event.php:440 include/text.php:1203
-msgid "February"
-msgstr ""
-
-#: include/event.php:441 include/text.php:1203
-msgid "March"
-msgstr ""
-
-#: include/event.php:442 include/text.php:1203
-msgid "April"
-msgstr ""
-
-#: include/event.php:444 include/text.php:1203
-msgid "June"
-msgstr ""
-
-#: include/event.php:445 include/text.php:1203
-msgid "July"
-msgstr ""
-
-#: include/event.php:446 include/text.php:1203
-msgid "August"
-msgstr ""
-
-#: include/event.php:447 include/text.php:1203
-msgid "September"
-msgstr ""
-
-#: include/event.php:448 include/text.php:1203
-msgid "October"
-msgstr ""
-
-#: include/event.php:449 include/text.php:1203
-msgid "November"
-msgstr ""
-
-#: include/event.php:450 include/text.php:1203
-msgid "December"
-msgstr ""
-
-#: include/event.php:452 mod/cal.php:280 mod/events.php:386
-msgid "today"
-msgstr ""
-
-#: include/event.php:457
-msgid "No events to display"
-msgstr ""
-
-#: include/event.php:570
-msgid "l, F j"
-msgstr ""
-
-#: include/event.php:592
-msgid "Edit event"
-msgstr ""
-
-#: include/event.php:593
-msgid "Delete event"
-msgstr ""
-
-#: include/event.php:619 include/text.php:1601 include/text.php:1608
-msgid "link to source"
-msgstr ""
-
-#: include/event.php:873
-msgid "Export"
-msgstr ""
-
-#: include/event.php:874
-msgid "Export calendar as ical"
-msgstr ""
-
-#: include/event.php:875
-msgid "Export calendar as csv"
-msgstr ""
-
-#: include/follow.php:84 mod/dfrn_request.php:514
-msgid "Disallowed profile URL."
-msgstr ""
-
-#: include/follow.php:89 mod/friendica.php:115 mod/dfrn_request.php:520
-#: mod/admin.php:280 mod/admin.php:298
-msgid "Blocked domain"
-msgstr ""
-
-#: include/follow.php:94
-msgid "Connect URL missing."
-msgstr ""
-
-#: include/follow.php:122
-msgid ""
-"This site is not configured to allow communications with other networks."
-msgstr ""
-
-#: include/follow.php:123 include/follow.php:137
-msgid "No compatible communication protocols or feeds were discovered."
-msgstr ""
-
-#: include/follow.php:135
-msgid "The profile address specified does not provide adequate information."
-msgstr ""
-
-#: include/follow.php:140
-msgid "An author or name was not found."
-msgstr ""
-
-#: include/follow.php:143
-msgid "No browser URL could be matched to this address."
-msgstr ""
-
-#: include/follow.php:146
-msgid ""
-"Unable to match @-style Identity Address with a known protocol or email "
-"contact."
-msgstr ""
-
-#: include/follow.php:147
-msgid "Use mailto: in front of address to force email check."
-msgstr ""
-
-#: include/follow.php:153
-msgid ""
-"The profile address specified belongs to a network which has been disabled "
-"on this site."
-msgstr ""
-
-#: include/follow.php:158
-msgid ""
-"Limited profile. This person will be unable to receive direct/personal "
-"notifications from you."
-msgstr ""
-
-#: include/follow.php:259
-msgid "Unable to retrieve contact information."
-msgstr ""
-
-#: include/like.php:44
-#, php-format
-msgid "%1$s is attending %2$s's %3$s"
-msgstr ""
-
-#: include/like.php:49
-#, php-format
-msgid "%1$s is not attending %2$s's %3$s"
-msgstr ""
-
-#: include/like.php:54
-#, php-format
-msgid "%1$s may attend %2$s's %3$s"
-msgstr ""
-
-#: include/photos.php:57 include/photos.php:66 mod/fbrowser.php:42
-#: mod/fbrowser.php:63 mod/photos.php:189 mod/photos.php:1125
-#: mod/photos.php:1258 mod/photos.php:1279 mod/photos.php:1841
-#: mod/photos.php:1855
-msgid "Contact Photos"
-msgstr ""
-
-#: include/security.php:63
-msgid "Welcome "
-msgstr ""
-
-#: include/security.php:64
-msgid "Please upload a profile photo."
-msgstr ""
-
-#: include/security.php:67
-msgid "Welcome back "
-msgstr ""
-
-#: include/security.php:431
-msgid ""
-"The form security token was not correct. This probably happened because the "
-"form has been opened for too long (>3 hours) before submitting it."
-msgstr ""
-
-#: include/text.php:308
-msgid "newer"
-msgstr ""
-
-#: include/text.php:309
-msgid "older"
-msgstr ""
-
-#: include/text.php:314
-msgid "first"
-msgstr ""
-
-#: include/text.php:315
-msgid "prev"
-msgstr ""
-
-#: include/text.php:349
-msgid "next"
-msgstr ""
-
-#: include/text.php:350
-msgid "last"
-msgstr ""
-
-#: include/text.php:404
-msgid "Loading more entries..."
-msgstr ""
-
-#: include/text.php:405
-msgid "The end"
-msgstr ""
-
-#: include/text.php:956
-msgid "No contacts"
-msgstr ""
-
-#: include/text.php:981
-#, php-format
-msgid "%d Contact"
-msgid_plural "%d Contacts"
-msgstr[0] ""
-msgstr[1] ""
-
-#: include/text.php:994
-msgid "View Contacts"
-msgstr ""
-
-#: include/text.php:1081 include/nav.php:125 mod/search.php:152
-msgid "Search"
-msgstr ""
-
-#: include/text.php:1082 mod/editpost.php:101 mod/filer.php:32 mod/notes.php:64
-msgid "Save"
-msgstr ""
-
-#: include/text.php:1084 include/nav.php:42
-msgid "@name, !forum, #tags, content"
-msgstr ""
-
-#: include/text.php:1089 include/nav.php:128
-msgid "Full Text"
-msgstr ""
-
-#: include/text.php:1090 include/nav.php:129
-msgid "Tags"
-msgstr ""
-
-#: include/text.php:1091 include/nav.php:130 include/nav.php:194
-#: include/identity.php:853 include/identity.php:856 mod/viewcontacts.php:124
-#: mod/contacts.php:803 mod/contacts.php:864 view/theme/frio/theme.php:259
-msgid "Contacts"
-msgstr ""
-
-#: include/text.php:1145
-msgid "poke"
-msgstr ""
-
-#: include/text.php:1145
-msgid "poked"
-msgstr ""
-
-#: include/text.php:1146
-msgid "ping"
-msgstr ""
-
-#: include/text.php:1146
-msgid "pinged"
-msgstr ""
-
-#: include/text.php:1147
-msgid "prod"
-msgstr ""
-
-#: include/text.php:1147
-msgid "prodded"
-msgstr ""
-
-#: include/text.php:1148
-msgid "slap"
-msgstr ""
-
-#: include/text.php:1148
-msgid "slapped"
-msgstr ""
-
-#: include/text.php:1149
-msgid "finger"
-msgstr ""
-
-#: include/text.php:1149
-msgid "fingered"
-msgstr ""
-
-#: include/text.php:1150
-msgid "rebuff"
-msgstr ""
-
-#: include/text.php:1150
-msgid "rebuffed"
-msgstr ""
-
-#: include/text.php:1164
-msgid "happy"
-msgstr ""
-
-#: include/text.php:1165
-msgid "sad"
-msgstr ""
-
-#: include/text.php:1166
-msgid "mellow"
-msgstr ""
-
-#: include/text.php:1167
-msgid "tired"
-msgstr ""
-
-#: include/text.php:1168
-msgid "perky"
-msgstr ""
-
-#: include/text.php:1169
-msgid "angry"
-msgstr ""
-
-#: include/text.php:1170
-msgid "stupified"
-msgstr ""
-
-#: include/text.php:1171
-msgid "puzzled"
-msgstr ""
-
-#: include/text.php:1172
-msgid "interested"
-msgstr ""
-
-#: include/text.php:1173
-msgid "bitter"
-msgstr ""
-
-#: include/text.php:1174
-msgid "cheerful"
-msgstr ""
-
-#: include/text.php:1175
-msgid "alive"
-msgstr ""
-
-#: include/text.php:1176
-msgid "annoyed"
-msgstr ""
-
-#: include/text.php:1177
-msgid "anxious"
-msgstr ""
-
-#: include/text.php:1178
-msgid "cranky"
-msgstr ""
-
-#: include/text.php:1179
-msgid "disturbed"
-msgstr ""
-
-#: include/text.php:1180
-msgid "frustrated"
-msgstr ""
-
-#: include/text.php:1181
-msgid "motivated"
-msgstr ""
-
-#: include/text.php:1182
-msgid "relaxed"
-msgstr ""
-
-#: include/text.php:1183
-msgid "surprised"
-msgstr ""
-
-#: include/text.php:1393 mod/videos.php:388
-msgid "View Video"
-msgstr ""
-
-#: include/text.php:1425
-msgid "bytes"
-msgstr ""
-
-#: include/text.php:1457 include/text.php:1469
-msgid "Click to open/close"
-msgstr ""
-
-#: include/text.php:1595
-msgid "View on separate page"
-msgstr ""
-
-#: include/text.php:1596
-msgid "view on separate page"
-msgstr ""
-
-#: include/text.php:1875
-msgid "activity"
-msgstr ""
-
-#: include/text.php:1877 mod/content.php:624 object/Item.php:416
-#: object/Item.php:428
-msgid "comment"
-msgid_plural "comments"
-msgstr[0] ""
-msgstr[1] ""
-
-#: include/text.php:1878
-msgid "post"
-msgstr ""
-
-#: include/text.php:2046
-msgid "Item filed"
-msgstr ""
-
-#: include/bbcode.php:419 include/bbcode.php:1178 include/bbcode.php:1179
-msgid "Image/photo"
-msgstr ""
-
-#: include/bbcode.php:536
-#, php-format
-msgid "<a href=\"%1$s\" target=\"_blank\">%2$s</a> %3$s"
-msgstr ""
-
-#: include/bbcode.php:1135 include/bbcode.php:1157
-msgid "$1 wrote:"
-msgstr ""
-
-#: include/bbcode.php:1187 include/bbcode.php:1188
-msgid "Encrypted content"
-msgstr ""
-
-#: include/bbcode.php:1303
-msgid "Invalid source protocol"
-msgstr ""
-
-#: include/bbcode.php:1313
-msgid "Invalid link protocol"
-msgstr ""
-
-#: include/Contact.php:437
-msgid "Drop Contact"
-msgstr ""
-
-#: include/Contact.php:819
-msgid "Organisation"
-msgstr ""
-
-#: include/Contact.php:822
-msgid "News"
-msgstr ""
-
-#: include/Contact.php:825
-msgid "Forum"
+#: include/diaspora.php:3234
+msgid "Attachments:"
 msgstr ""
 
 #: include/enotify.php:27
@@ -1981,843 +2190,111 @@ msgstr ""
 msgid "Please visit %s to approve or reject the request."
 msgstr ""
 
-#: include/message.php:14 include/message.php:168
-msgid "[no subject]"
+#: include/follow.php:84 mod/dfrn_request.php:514
+msgid "Disallowed profile URL."
 msgstr ""
 
-#: include/message.php:145 include/Photo.php:1075 include/Photo.php:1091
-#: include/Photo.php:1099 include/Photo.php:1124 mod/wall_upload.php:249
-#: mod/item.php:468
-msgid "Wall Photos"
+#: include/follow.php:89 mod/friendica.php:115 mod/dfrn_request.php:520
+#: mod/admin.php:280 mod/admin.php:298
+msgid "Blocked domain"
 msgstr ""
 
-#: include/nav.php:37 mod/navigation.php:21
-msgid "Nothing new here"
+#: include/follow.php:94
+msgid "Connect URL missing."
 msgstr ""
 
-#: include/nav.php:41 mod/navigation.php:25
-msgid "Clear notifications"
-msgstr ""
-
-#: include/nav.php:80 view/theme/frio/theme.php:245 boot.php:869
-msgid "Logout"
-msgstr ""
-
-#: include/nav.php:80 view/theme/frio/theme.php:245
-msgid "End this session"
-msgstr ""
-
-#: include/nav.php:83 include/identity.php:784 mod/contacts.php:648
-#: mod/contacts.php:844 view/theme/frio/theme.php:248
-msgid "Status"
-msgstr ""
-
-#: include/nav.php:83 include/nav.php:163 view/theme/frio/theme.php:248
-msgid "Your posts and conversations"
-msgstr ""
-
-#: include/nav.php:84 include/identity.php:632 include/identity.php:759
-#: include/identity.php:792 mod/newmember.php:20 mod/profperm.php:107
-#: mod/contacts.php:650 mod/contacts.php:852 view/theme/frio/theme.php:249
-msgid "Profile"
-msgstr ""
-
-#: include/nav.php:84 view/theme/frio/theme.php:249
-msgid "Your profile page"
-msgstr ""
-
-#: include/nav.php:85 include/identity.php:800 mod/fbrowser.php:33
-#: view/theme/frio/theme.php:250
-msgid "Photos"
-msgstr ""
-
-#: include/nav.php:85 view/theme/frio/theme.php:250
-msgid "Your photos"
-msgstr ""
-
-#: include/nav.php:86 include/identity.php:808 include/identity.php:811
-#: view/theme/frio/theme.php:251
-msgid "Videos"
-msgstr ""
-
-#: include/nav.php:86 view/theme/frio/theme.php:251
-msgid "Your videos"
-msgstr ""
-
-#: include/nav.php:87 include/nav.php:151 include/identity.php:820
-#: include/identity.php:831 mod/cal.php:272 mod/events.php:377
-#: view/theme/frio/theme.php:252 view/theme/frio/theme.php:256
-msgid "Events"
-msgstr ""
-
-#: include/nav.php:87 view/theme/frio/theme.php:252
-msgid "Your events"
-msgstr ""
-
-#: include/nav.php:88
-msgid "Personal notes"
-msgstr ""
-
-#: include/nav.php:88
-msgid "Your personal notes"
-msgstr ""
-
-#: include/nav.php:97 mod/bookmarklet.php:14 boot.php:870
-msgid "Login"
-msgstr ""
-
-#: include/nav.php:97
-msgid "Sign in"
-msgstr ""
-
-#: include/nav.php:107 include/nav.php:163 include/NotificationsManager.php:176
-msgid "Home"
-msgstr ""
-
-#: include/nav.php:107
-msgid "Home Page"
-msgstr ""
-
-#: include/nav.php:111 mod/register.php:291 boot.php:846
-msgid "Register"
-msgstr ""
-
-#: include/nav.php:111
-msgid "Create an account"
-msgstr ""
-
-#: include/nav.php:117 mod/help.php:50 view/theme/vier/theme.php:291
-msgid "Help"
-msgstr ""
-
-#: include/nav.php:117
-msgid "Help and documentation"
-msgstr ""
-
-#: include/nav.php:121
-msgid "Apps"
-msgstr ""
-
-#: include/nav.php:121
-msgid "Addon applications, utilities, games"
-msgstr ""
-
-#: include/nav.php:125
-msgid "Search site content"
-msgstr ""
-
-#: include/nav.php:145 include/nav.php:147 mod/community.php:32
-msgid "Community"
-msgstr ""
-
-#: include/nav.php:145
-msgid "Conversations on this site"
-msgstr ""
-
-#: include/nav.php:147
-msgid "Conversations on the network"
-msgstr ""
-
-#: include/nav.php:151 include/identity.php:823 include/identity.php:834
-#: view/theme/frio/theme.php:256
-msgid "Events and Calendar"
-msgstr ""
-
-#: include/nav.php:154
-msgid "Directory"
-msgstr ""
-
-#: include/nav.php:154
-msgid "People directory"
-msgstr ""
-
-#: include/nav.php:156
-msgid "Information"
-msgstr ""
-
-#: include/nav.php:156
-msgid "Information about this friendica instance"
-msgstr ""
-
-#: include/nav.php:160 include/NotificationsManager.php:162 mod/admin.php:518
-#: view/theme/frio/theme.php:255
-msgid "Network"
-msgstr ""
-
-#: include/nav.php:160 view/theme/frio/theme.php:255
-msgid "Conversations from your friends"
-msgstr ""
-
-#: include/nav.php:161
-msgid "Network Reset"
-msgstr ""
-
-#: include/nav.php:161
-msgid "Load Network page with no filters"
-msgstr ""
-
-#: include/nav.php:168 include/NotificationsManager.php:183
-msgid "Introductions"
-msgstr ""
-
-#: include/nav.php:168
-msgid "Friend Requests"
-msgstr ""
-
-#: include/nav.php:171 mod/notifications.php:98
-msgid "Notifications"
-msgstr ""
-
-#: include/nav.php:172
-msgid "See all notifications"
-msgstr ""
-
-#: include/nav.php:173 mod/settings.php:907
-msgid "Mark as seen"
-msgstr ""
-
-#: include/nav.php:173
-msgid "Mark all system notifications seen"
-msgstr ""
-
-#: include/nav.php:177 mod/message.php:181 view/theme/frio/theme.php:257
-msgid "Messages"
-msgstr ""
-
-#: include/nav.php:177 view/theme/frio/theme.php:257
-msgid "Private mail"
-msgstr ""
-
-#: include/nav.php:178
-msgid "Inbox"
-msgstr ""
-
-#: include/nav.php:179
-msgid "Outbox"
-msgstr ""
-
-#: include/nav.php:180 mod/message.php:18
-msgid "New Message"
-msgstr ""
-
-#: include/nav.php:183
-msgid "Manage"
-msgstr ""
-
-#: include/nav.php:183
-msgid "Manage other pages"
-msgstr ""
-
-#: include/nav.php:186 mod/settings.php:83
-msgid "Delegations"
-msgstr ""
-
-#: include/nav.php:186 mod/delegate.php:132
-msgid "Delegate Page Management"
-msgstr ""
-
-#: include/nav.php:188 mod/newmember.php:15 mod/admin.php:1624
-#: mod/admin.php:1900 mod/settings.php:113 view/theme/frio/theme.php:258
-msgid "Settings"
-msgstr ""
-
-#: include/nav.php:188 view/theme/frio/theme.php:258
-msgid "Account settings"
-msgstr ""
-
-#: include/nav.php:191 include/identity.php:296
-msgid "Profiles"
-msgstr ""
-
-#: include/nav.php:191
-msgid "Manage/Edit Profiles"
-msgstr ""
-
-#: include/nav.php:194 view/theme/frio/theme.php:259
-msgid "Manage/edit friends and contacts"
-msgstr ""
-
-#: include/nav.php:199 mod/admin.php:197
-msgid "Admin"
-msgstr ""
-
-#: include/nav.php:199
-msgid "Site setup and configuration"
-msgstr ""
-
-#: include/nav.php:202
-msgid "Navigation"
-msgstr ""
-
-#: include/nav.php:202
-msgid "Site map"
-msgstr ""
-
-#: include/network.php:687
-msgid "view full size"
-msgstr ""
-
-#: include/oembed.php:256
-msgid "Embedded content"
-msgstr ""
-
-#: include/oembed.php:264
-msgid "Embedding disabled"
-msgstr ""
-
-#: include/uimport.php:85
-msgid "Error decoding account file"
-msgstr ""
-
-#: include/uimport.php:91
-msgid "Error! No version data in file! This is not a Friendica account file?"
-msgstr ""
-
-#: include/uimport.php:108 include/uimport.php:119
-msgid "Error! Cannot check nickname"
-msgstr ""
-
-#: include/uimport.php:112 include/uimport.php:123
-#, php-format
-msgid "User '%s' already exists on this server!"
-msgstr ""
-
-#: include/uimport.php:145
-msgid "User creation error"
-msgstr ""
-
-#: include/uimport.php:166
-msgid "User profile creation error"
-msgstr ""
-
-#: include/uimport.php:215
-#, php-format
-msgid "%d contact not imported"
-msgid_plural "%d contacts not imported"
-msgstr[0] ""
-msgstr[1] ""
-
-#: include/uimport.php:281
-msgid "Done. You can now login with your username and password"
-msgstr ""
-
-#: include/user.php:39 mod/settings.php:377
-msgid "Passwords do not match. Password unchanged."
-msgstr ""
-
-#: include/user.php:48
-msgid "An invitation is required."
-msgstr ""
-
-#: include/user.php:53
-msgid "Invitation could not be verified."
-msgstr ""
-
-#: include/user.php:61
-msgid "Invalid OpenID url"
-msgstr ""
-
-#: include/user.php:82
-msgid "Please enter the required information."
-msgstr ""
-
-#: include/user.php:96
-msgid "Please use a shorter name."
-msgstr ""
-
-#: include/user.php:98
-msgid "Name too short."
-msgstr ""
-
-#: include/user.php:106
-msgid "That doesn't appear to be your full (First Last) name."
-msgstr ""
-
-#: include/user.php:111
-msgid "Your email domain is not among those allowed on this site."
-msgstr ""
-
-#: include/user.php:114
-msgid "Not a valid email address."
-msgstr ""
-
-#: include/user.php:127
-msgid "Cannot use that email."
-msgstr ""
-
-#: include/user.php:133
-msgid "Your \"nickname\" can only contain \"a-z\", \"0-9\" and \"_\"."
-msgstr ""
-
-#: include/user.php:140 include/user.php:228
-msgid "Nickname is already registered. Please choose another."
-msgstr ""
-
-#: include/user.php:150
+#: include/follow.php:122
 msgid ""
-"Nickname was once registered here and may not be re-used. Please choose "
-"another."
+"This site is not configured to allow communications with other networks."
 msgstr ""
 
-#: include/user.php:166
-msgid "SERIOUS ERROR: Generation of security keys failed."
+#: include/follow.php:123 include/follow.php:137
+msgid "No compatible communication protocols or feeds were discovered."
 msgstr ""
 
-#: include/user.php:214
-msgid "An error occurred during registration. Please try again."
+#: include/follow.php:135
+msgid "The profile address specified does not provide adequate information."
 msgstr ""
 
-#: include/user.php:237 view/theme/duepuntozero/config.php:46
-msgid "default"
+#: include/follow.php:140
+msgid "An author or name was not found."
 msgstr ""
 
-#: include/user.php:247
-msgid "An error occurred creating your default profile. Please try again."
+#: include/follow.php:143
+msgid "No browser URL could be matched to this address."
 msgstr ""
 
-#: include/user.php:260 include/user.php:264 include/profile_selectors.php:42
-msgid "Friends"
-msgstr ""
-
-#: include/user.php:306 include/user.php:314 include/user.php:322
-#: include/api.php:3702 mod/photos.php:73 mod/photos.php:189 mod/photos.php:776
-#: mod/photos.php:1258 mod/photos.php:1279 mod/photos.php:1865
-#: mod/profile_photo.php:74 mod/profile_photo.php:82 mod/profile_photo.php:90
-#: mod/profile_photo.php:214 mod/profile_photo.php:309
-#: mod/profile_photo.php:319
-msgid "Profile Photos"
-msgstr ""
-
-#: include/user.php:397
-#, php-format
+#: include/follow.php:146
 msgid ""
-"\n"
-"\t\tDear %1$s,\n"
-"\t\t\tThank you for registering at %2$s. Your account is pending for "
-"approval by the administrator.\n"
-"\t"
+"Unable to match @-style Identity Address with a known protocol or email "
+"contact."
 msgstr ""
 
-#: include/user.php:407
-#, php-format
-msgid "Registration at %s"
+#: include/follow.php:147
+msgid "Use mailto: in front of address to force email check."
 msgstr ""
 
-#: include/user.php:417
-#, php-format
+#: include/follow.php:153
 msgid ""
-"\n"
-"\t\tDear %1$s,\n"
-"\t\t\tThank you for registering at %2$s. Your account has been created.\n"
-"\t"
+"The profile address specified belongs to a network which has been disabled "
+"on this site."
 msgstr ""
 
-#: include/user.php:421
-#, php-format
+#: include/follow.php:158
 msgid ""
-"\n"
-"\t\tThe login details are as follows:\n"
-"\t\t\tSite Location:\t%3$s\n"
-"\t\t\tLogin Name:\t%1$s\n"
-"\t\t\tPassword:\t%5$s\n"
-"\n"
-"\t\tYou may change your password from your account \"Settings\" page after "
-"logging\n"
-"\t\tin.\n"
-"\n"
-"\t\tPlease take a few moments to review the other account settings on that "
-"page.\n"
-"\n"
-"\t\tYou may also wish to add some basic information to your default profile\n"
-"\t\t(on the \"Profiles\" page) so that other people can easily find you.\n"
-"\n"
-"\t\tWe recommend setting your full name, adding a profile photo,\n"
-"\t\tadding some profile \"keywords\" (very useful in making new friends) - "
-"and\n"
-"\t\tperhaps what country you live in; if you do not wish to be more "
-"specific\n"
-"\t\tthan that.\n"
-"\n"
-"\t\tWe fully respect your right to privacy, and none of these items are "
-"necessary.\n"
-"\t\tIf you are new and do not know anybody here, they may help\n"
-"\t\tyou to make some new and interesting friends.\n"
-"\n"
-"\n"
-"\t\tThank you and welcome to %2$s."
+"Limited profile. This person will be unable to receive direct/personal "
+"notifications from you."
 msgstr ""
 
-#: include/user.php:453 mod/admin.php:1314
-#, php-format
-msgid "Registration details for %s"
+#: include/follow.php:259
+msgid "Unable to retrieve contact information."
 msgstr ""
 
-#: include/dba_pdo.php:76 include/dba.php:57
-#, php-format
-msgid "Cannot locate DNS info for database server '%s'"
-msgstr ""
-
-#: include/plugin.php:532 include/plugin.php:534
-msgid "Click here to upgrade."
-msgstr ""
-
-#: include/plugin.php:541
-msgid "This action exceeds the limits set by your subscription plan."
-msgstr ""
-
-#: include/plugin.php:546
-msgid "This action is not available under your subscription plan."
-msgstr ""
-
-#: include/profile_selectors.php:6
-msgid "Male"
-msgstr ""
-
-#: include/profile_selectors.php:6
-msgid "Female"
-msgstr ""
-
-#: include/profile_selectors.php:6
-msgid "Currently Male"
-msgstr ""
-
-#: include/profile_selectors.php:6
-msgid "Currently Female"
-msgstr ""
-
-#: include/profile_selectors.php:6
-msgid "Mostly Male"
-msgstr ""
-
-#: include/profile_selectors.php:6
-msgid "Mostly Female"
-msgstr ""
-
-#: include/profile_selectors.php:6
-msgid "Transgender"
-msgstr ""
-
-#: include/profile_selectors.php:6
-msgid "Intersex"
-msgstr ""
-
-#: include/profile_selectors.php:6
-msgid "Transsexual"
-msgstr ""
-
-#: include/profile_selectors.php:6
-msgid "Hermaphrodite"
-msgstr ""
-
-#: include/profile_selectors.php:6
-msgid "Neuter"
-msgstr ""
-
-#: include/profile_selectors.php:6
-msgid "Non-specific"
-msgstr ""
-
-#: include/profile_selectors.php:6
-msgid "Other"
-msgstr ""
-
-#: include/profile_selectors.php:23
-msgid "Males"
-msgstr ""
-
-#: include/profile_selectors.php:23
-msgid "Females"
-msgstr ""
-
-#: include/profile_selectors.php:23
-msgid "Gay"
-msgstr ""
-
-#: include/profile_selectors.php:23
-msgid "Lesbian"
-msgstr ""
-
-#: include/profile_selectors.php:23
-msgid "No Preference"
-msgstr ""
-
-#: include/profile_selectors.php:23
-msgid "Bisexual"
-msgstr ""
-
-#: include/profile_selectors.php:23
-msgid "Autosexual"
-msgstr ""
-
-#: include/profile_selectors.php:23
-msgid "Abstinent"
-msgstr ""
-
-#: include/profile_selectors.php:23
-msgid "Virgin"
-msgstr ""
-
-#: include/profile_selectors.php:23
-msgid "Deviant"
-msgstr ""
-
-#: include/profile_selectors.php:23
-msgid "Fetish"
-msgstr ""
-
-#: include/profile_selectors.php:23
-msgid "Oodles"
-msgstr ""
-
-#: include/profile_selectors.php:23
-msgid "Nonsexual"
-msgstr ""
-
-#: include/profile_selectors.php:42
-msgid "Single"
-msgstr ""
-
-#: include/profile_selectors.php:42
-msgid "Lonely"
-msgstr ""
-
-#: include/profile_selectors.php:42
-msgid "Available"
-msgstr ""
-
-#: include/profile_selectors.php:42
-msgid "Unavailable"
-msgstr ""
-
-#: include/profile_selectors.php:42
-msgid "Has crush"
-msgstr ""
-
-#: include/profile_selectors.php:42
-msgid "Infatuated"
-msgstr ""
-
-#: include/profile_selectors.php:42
-msgid "Dating"
-msgstr ""
-
-#: include/profile_selectors.php:42
-msgid "Unfaithful"
-msgstr ""
-
-#: include/profile_selectors.php:42
-msgid "Sex Addict"
-msgstr ""
-
-#: include/profile_selectors.php:42
-msgid "Friends/Benefits"
-msgstr ""
-
-#: include/profile_selectors.php:42
-msgid "Casual"
-msgstr ""
-
-#: include/profile_selectors.php:42
-msgid "Engaged"
-msgstr ""
-
-#: include/profile_selectors.php:42
-msgid "Married"
-msgstr ""
-
-#: include/profile_selectors.php:42
-msgid "Imaginarily married"
-msgstr ""
-
-#: include/profile_selectors.php:42
-msgid "Partners"
-msgstr ""
-
-#: include/profile_selectors.php:42
-msgid "Cohabiting"
-msgstr ""
-
-#: include/profile_selectors.php:42
-msgid "Common law"
-msgstr ""
-
-#: include/profile_selectors.php:42
-msgid "Happy"
-msgstr ""
-
-#: include/profile_selectors.php:42
-msgid "Not looking"
-msgstr ""
-
-#: include/profile_selectors.php:42
-msgid "Swinger"
-msgstr ""
-
-#: include/profile_selectors.php:42
-msgid "Betrayed"
-msgstr ""
-
-#: include/profile_selectors.php:42
-msgid "Separated"
-msgstr ""
-
-#: include/profile_selectors.php:42
-msgid "Unstable"
-msgstr ""
-
-#: include/profile_selectors.php:42
-msgid "Divorced"
-msgstr ""
-
-#: include/profile_selectors.php:42
-msgid "Imaginarily divorced"
-msgstr ""
-
-#: include/profile_selectors.php:42
-msgid "Widowed"
-msgstr ""
-
-#: include/profile_selectors.php:42
-msgid "Uncertain"
-msgstr ""
-
-#: include/profile_selectors.php:42
-msgid "It's complicated"
-msgstr ""
-
-#: include/profile_selectors.php:42
-msgid "Don't care"
-msgstr ""
-
-#: include/profile_selectors.php:42
-msgid "Ask me"
-msgstr ""
-
-#: include/NotificationsManager.php:155
-msgid "System"
-msgstr ""
-
-#: include/NotificationsManager.php:169 mod/network.php:835
-#: mod/profiles.php:699
-msgid "Personal"
-msgstr ""
-
-#: include/NotificationsManager.php:241 include/NotificationsManager.php:253
-#, php-format
-msgid "%s commented on %s's post"
-msgstr ""
-
-#: include/NotificationsManager.php:252
-#, php-format
-msgid "%s created a new post"
-msgstr ""
-
-#: include/NotificationsManager.php:267
-#, php-format
-msgid "%s liked %s's post"
-msgstr ""
-
-#: include/NotificationsManager.php:280
-#, php-format
-msgid "%s disliked %s's post"
-msgstr ""
-
-#: include/NotificationsManager.php:293
-#, php-format
-msgid "%s is attending %s's event"
-msgstr ""
-
-#: include/NotificationsManager.php:306
-#, php-format
-msgid "%s is not attending %s's event"
-msgstr ""
-
-#: include/NotificationsManager.php:319
-#, php-format
-msgid "%s may attend %s's event"
-msgstr ""
-
-#: include/NotificationsManager.php:336
-#, php-format
-msgid "%s is now friends with %s"
-msgstr ""
-
-#: include/NotificationsManager.php:774
-msgid "Friend Suggestion"
-msgstr ""
-
-#: include/NotificationsManager.php:803
-msgid "Friend/Connect Request"
-msgstr ""
-
-#: include/NotificationsManager.php:803
-msgid "New Follower"
-msgstr ""
-
-#: include/api.php:1102
-#, php-format
-msgid "Daily posting limit of %d posts reached. The post was rejected."
-msgstr ""
-
-#: include/api.php:1123
-#, php-format
-msgid "Weekly posting limit of %d posts reached. The post was rejected."
-msgstr ""
-
-#: include/api.php:1144
-#, php-format
-msgid "Monthly posting limit of %d posts reached. The post was rejected."
-msgstr ""
-
-#: include/dbstructure.php:25
-msgid "There are no tables on MyISAM."
-msgstr ""
-
-#: include/dbstructure.php:66
-#, php-format
+#: include/group.php:25
 msgid ""
-"\n"
-"\t\t\tThe friendica developers released update %s recently,\n"
-"\t\t\tbut when I tried to install it, something went terribly wrong.\n"
-"\t\t\tThis needs to be fixed soon and I can't do it alone. Please contact a\n"
-"\t\t\tfriendica developer if you can not help me on your own. My database "
-"might be invalid."
+"A deleted group with this name was revived. Existing item permissions "
+"<strong>may</strong> apply to this group and any future members. If this is "
+"not what you intended, please create another group with a different name."
 msgstr ""
 
-#: include/dbstructure.php:71
-#, php-format
-msgid ""
-"The error message is\n"
-"[pre]%s[/pre]"
+#: include/group.php:210
+msgid "Default privacy group for new contacts"
 msgstr ""
 
-#: include/dbstructure.php:195
-#, php-format
-msgid ""
-"\n"
-"Error %d occurred during database update:\n"
-"%s\n"
+#: include/group.php:243
+msgid "Everybody"
 msgstr ""
 
-#: include/dbstructure.php:198
-msgid "Errors encountered performing database changes: "
+#: include/group.php:266
+msgid "edit"
 msgstr ""
 
-#: include/dbstructure.php:206
-msgid ": Database update"
+#: include/group.php:287 mod/newmember.php:39
+msgid "Groups"
 msgstr ""
 
-#: include/dbstructure.php:438
-#, php-format
-msgid "%s: updating %s table."
+#: include/group.php:289
+msgid "Edit groups"
 msgstr ""
 
-#: include/diaspora.php:2214
-msgid "Sharing notification from Diaspora network"
+#: include/group.php:291
+msgid "Edit group"
 msgstr ""
 
-#: include/diaspora.php:3234
-msgid "Attachments:"
+#: include/group.php:292
+msgid "Create a new group"
+msgstr ""
+
+#: include/group.php:293 mod/group.php:100 mod/group.php:197
+msgid "Group Name: "
+msgstr ""
+
+#: include/group.php:295
+msgid "Contacts not in any group"
+msgstr ""
+
+#: include/group.php:297 mod/network.php:210
+msgid "add"
 msgstr ""
 
 #: include/identity.php:45
@@ -2834,6 +2311,10 @@ msgstr ""
 
 #: include/identity.php:265
 msgid "Atom feed"
+msgstr ""
+
+#: include/identity.php:296 include/nav.php:191
+msgid "Profiles"
 msgstr ""
 
 #: include/identity.php:296
@@ -2918,6 +2399,12 @@ msgstr ""
 msgid "Events this week:"
 msgstr ""
 
+#: include/identity.php:632 include/identity.php:759 include/identity.php:792
+#: include/nav.php:84 mod/newmember.php:20 mod/profperm.php:107
+#: mod/contacts.php:650 mod/contacts.php:852 view/theme/frio/theme.php:249
+msgid "Profile"
+msgstr ""
+
 #: include/identity.php:641 mod/settings.php:1287
 msgid "Full Name:"
 msgstr ""
@@ -2947,8 +2434,8 @@ msgstr ""
 msgid "Hometown:"
 msgstr ""
 
-#: include/identity.php:690 mod/follow.php:139 mod/notifications.php:250
-#: mod/contacts.php:645
+#: include/identity.php:690 mod/notifications.php:250 mod/contacts.php:645
+#: mod/follow.php:139
 msgid "Tags:"
 msgstr ""
 
@@ -3012,12 +2499,17 @@ msgstr ""
 msgid "Basic"
 msgstr ""
 
-#: include/identity.php:761 mod/events.php:510 mod/contacts.php:881
+#: include/identity.php:761 mod/contacts.php:881 mod/events.php:510
 #: mod/admin.php:1065
 msgid "Advanced"
 msgstr ""
 
-#: include/identity.php:787 mod/follow.php:147 mod/contacts.php:847
+#: include/identity.php:784 include/nav.php:83 mod/contacts.php:648
+#: mod/contacts.php:844 view/theme/frio/theme.php:248
+msgid "Status"
+msgstr ""
+
+#: include/identity.php:787 mod/contacts.php:847 mod/follow.php:147
 msgid "Status Messages and Posts"
 msgstr ""
 
@@ -3025,8 +2517,29 @@ msgstr ""
 msgid "Profile Details"
 msgstr ""
 
+#: include/identity.php:800 include/nav.php:85 mod/fbrowser.php:33
+#: view/theme/frio/theme.php:250
+msgid "Photos"
+msgstr ""
+
 #: include/identity.php:803 mod/photos.php:95
 msgid "Photo Albums"
+msgstr ""
+
+#: include/identity.php:808 include/identity.php:811 include/nav.php:86
+#: view/theme/frio/theme.php:251
+msgid "Videos"
+msgstr ""
+
+#: include/identity.php:820 include/identity.php:831 include/nav.php:87
+#: include/nav.php:151 mod/cal.php:272 mod/events.php:377
+#: view/theme/frio/theme.php:252 view/theme/frio/theme.php:256
+msgid "Events"
+msgstr ""
+
+#: include/identity.php:823 include/identity.php:834 include/nav.php:151
+#: view/theme/frio/theme.php:256
+msgid "Events and Calendar"
 msgstr ""
 
 #: include/identity.php:842 mod/notes.php:49
@@ -3037,13 +2550,19 @@ msgstr ""
 msgid "Only You Can See This"
 msgstr ""
 
+#: include/identity.php:853 include/identity.php:856 include/nav.php:130
+#: include/nav.php:194 include/text.php:1091 mod/viewcontacts.php:124
+#: mod/contacts.php:803 mod/contacts.php:864 view/theme/frio/theme.php:259
+msgid "Contacts"
+msgstr ""
+
 #: include/items.php:1736 mod/dfrn_confirm.php:738 mod/dfrn_request.php:759
 msgid "[Name Withheld]"
 msgstr ""
 
-#: include/items.php:2121 mod/display.php:105 mod/display.php:280
-#: mod/display.php:485 mod/notice.php:17 mod/viewsrc.php:16 mod/admin.php:248
-#: mod/admin.php:1571 mod/admin.php:1822
+#: include/items.php:2121 mod/notice.php:17 mod/viewsrc.php:16
+#: mod/display.php:117 mod/display.php:289 mod/display.php:504
+#: mod/admin.php:248 mod/admin.php:1571 mod/admin.php:1822
 msgid "Item not found."
 msgstr ""
 
@@ -3051,10 +2570,10 @@ msgstr ""
 msgid "Do you really want to delete this item?"
 msgstr ""
 
-#: include/items.php:2162 mod/api.php:107 mod/follow.php:115
-#: mod/message.php:208 mod/register.php:247 mod/suggest.php:31
-#: mod/dfrn_request.php:880 mod/contacts.php:455 mod/profiles.php:643
-#: mod/profiles.php:646 mod/profiles.php:673 mod/settings.php:1172
+#: include/items.php:2162 mod/api.php:107 mod/message.php:208
+#: mod/profiles.php:643 mod/profiles.php:646 mod/profiles.php:673
+#: mod/suggest.php:31 mod/contacts.php:455 mod/dfrn_request.php:880
+#: mod/follow.php:115 mod/register.php:247 mod/settings.php:1172
 #: mod/settings.php:1178 mod/settings.php:1185 mod/settings.php:1189
 #: mod/settings.php:1194 mod/settings.php:1199 mod/settings.php:1204
 #: mod/settings.php:1209 mod/settings.php:1235 mod/settings.php:1236
@@ -3064,26 +2583,272 @@ msgstr ""
 
 #: include/items.php:2309 mod/allfriends.php:14 mod/api.php:28 mod/api.php:33
 #: mod/attach.php:35 mod/cal.php:301 mod/common.php:20 mod/crepair.php:105
-#: mod/delegate.php:14 mod/dfrn_confirm.php:63 mod/dirfind.php:15
-#: mod/display.php:482 mod/editpost.php:12 mod/events.php:188 mod/follow.php:13
-#: mod/follow.php:76 mod/follow.php:160 mod/fsuggest.php:80 mod/group.php:20
-#: mod/invite.php:17 mod/invite.php:105 mod/manage.php:103 mod/message.php:48
-#: mod/message.php:173 mod/mood.php:116 mod/network.php:7 mod/nogroup.php:29
-#: mod/notes.php:25 mod/notifications.php:73 mod/ostatus_subscribe.php:11
-#: mod/photos.php:168 mod/photos.php:1111 mod/poke.php:155 mod/register.php:44
-#: mod/repair_ostatus.php:11 mod/suggest.php:60 mod/viewcontacts.php:49
+#: mod/delegate.php:14 mod/dfrn_confirm.php:63 mod/editpost.php:12
+#: mod/fsuggest.php:80 mod/group.php:20 mod/invite.php:17 mod/invite.php:105
+#: mod/manage.php:103 mod/message.php:48 mod/message.php:173 mod/mood.php:116
+#: mod/nogroup.php:29 mod/notes.php:25 mod/notifications.php:73
+#: mod/ostatus_subscribe.php:11 mod/photos.php:168 mod/photos.php:1111
+#: mod/poke.php:155 mod/profile_photo.php:19 mod/profile_photo.php:179
+#: mod/profile_photo.php:190 mod/profile_photo.php:203 mod/profiles.php:172
+#: mod/profiles.php:610 mod/regmod.php:106 mod/repair_ostatus.php:11
+#: mod/suggest.php:60 mod/uimport.php:26 mod/viewcontacts.php:49
 #: mod/wall_attach.php:69 mod/wall_attach.php:72 mod/wall_upload.php:101
 #: mod/wall_upload.php:104 mod/wallmessage.php:11 mod/wallmessage.php:35
-#: mod/wallmessage.php:75 mod/wallmessage.php:99 mod/item.php:197
-#: mod/item.php:209 mod/regmod.php:106 mod/uimport.php:26 mod/contacts.php:363
-#: mod/profile_photo.php:19 mod/profile_photo.php:179 mod/profile_photo.php:190
-#: mod/profile_photo.php:203 mod/profiles.php:172 mod/profiles.php:610
-#: mod/settings.php:24 mod/settings.php:132 mod/settings.php:669 index.php:410
+#: mod/wallmessage.php:75 mod/wallmessage.php:99 mod/contacts.php:363
+#: mod/dirfind.php:15 mod/display.php:501 mod/events.php:188 mod/follow.php:13
+#: mod/follow.php:76 mod/follow.php:160 mod/item.php:197 mod/item.php:209
+#: mod/network.php:7 mod/register.php:44 mod/settings.php:24
+#: mod/settings.php:132 mod/settings.php:669 index.php:410
 msgid "Permission denied."
 msgstr ""
 
 #: include/items.php:2426
 msgid "Archives"
+msgstr ""
+
+#: include/message.php:14 include/message.php:168
+msgid "[no subject]"
+msgstr ""
+
+#: include/nav.php:37 mod/navigation.php:21
+msgid "Nothing new here"
+msgstr ""
+
+#: include/nav.php:41 mod/navigation.php:25
+msgid "Clear notifications"
+msgstr ""
+
+#: include/nav.php:42 include/text.php:1084
+msgid "@name, !forum, #tags, content"
+msgstr ""
+
+#: include/nav.php:80 view/theme/frio/theme.php:245 boot.php:871
+msgid "Logout"
+msgstr ""
+
+#: include/nav.php:80 view/theme/frio/theme.php:245
+msgid "End this session"
+msgstr ""
+
+#: include/nav.php:83 include/nav.php:163 view/theme/frio/theme.php:248
+msgid "Your posts and conversations"
+msgstr ""
+
+#: include/nav.php:84 view/theme/frio/theme.php:249
+msgid "Your profile page"
+msgstr ""
+
+#: include/nav.php:85 view/theme/frio/theme.php:250
+msgid "Your photos"
+msgstr ""
+
+#: include/nav.php:86 view/theme/frio/theme.php:251
+msgid "Your videos"
+msgstr ""
+
+#: include/nav.php:87 view/theme/frio/theme.php:252
+msgid "Your events"
+msgstr ""
+
+#: include/nav.php:88
+msgid "Personal notes"
+msgstr ""
+
+#: include/nav.php:88
+msgid "Your personal notes"
+msgstr ""
+
+#: include/nav.php:97 mod/bookmarklet.php:14 boot.php:872
+msgid "Login"
+msgstr ""
+
+#: include/nav.php:97
+msgid "Sign in"
+msgstr ""
+
+#: include/nav.php:107
+msgid "Home Page"
+msgstr ""
+
+#: include/nav.php:111 mod/register.php:291 boot.php:848
+msgid "Register"
+msgstr ""
+
+#: include/nav.php:111
+msgid "Create an account"
+msgstr ""
+
+#: include/nav.php:117 mod/help.php:50 view/theme/vier/theme.php:291
+msgid "Help"
+msgstr ""
+
+#: include/nav.php:117
+msgid "Help and documentation"
+msgstr ""
+
+#: include/nav.php:121
+msgid "Apps"
+msgstr ""
+
+#: include/nav.php:121
+msgid "Addon applications, utilities, games"
+msgstr ""
+
+#: include/nav.php:125 include/text.php:1081 mod/search.php:152
+msgid "Search"
+msgstr ""
+
+#: include/nav.php:125
+msgid "Search site content"
+msgstr ""
+
+#: include/nav.php:128 include/text.php:1089
+msgid "Full Text"
+msgstr ""
+
+#: include/nav.php:129 include/text.php:1090
+msgid "Tags"
+msgstr ""
+
+#: include/nav.php:145 include/nav.php:147 mod/community.php:32
+msgid "Community"
+msgstr ""
+
+#: include/nav.php:145
+msgid "Conversations on this site"
+msgstr ""
+
+#: include/nav.php:147
+msgid "Conversations on the network"
+msgstr ""
+
+#: include/nav.php:154
+msgid "Directory"
+msgstr ""
+
+#: include/nav.php:154
+msgid "People directory"
+msgstr ""
+
+#: include/nav.php:156
+msgid "Information"
+msgstr ""
+
+#: include/nav.php:156
+msgid "Information about this friendica instance"
+msgstr ""
+
+#: include/nav.php:160 view/theme/frio/theme.php:255
+msgid "Conversations from your friends"
+msgstr ""
+
+#: include/nav.php:161
+msgid "Network Reset"
+msgstr ""
+
+#: include/nav.php:161
+msgid "Load Network page with no filters"
+msgstr ""
+
+#: include/nav.php:168
+msgid "Friend Requests"
+msgstr ""
+
+#: include/nav.php:171 mod/notifications.php:98
+msgid "Notifications"
+msgstr ""
+
+#: include/nav.php:172
+msgid "See all notifications"
+msgstr ""
+
+#: include/nav.php:173 mod/settings.php:907
+msgid "Mark as seen"
+msgstr ""
+
+#: include/nav.php:173
+msgid "Mark all system notifications seen"
+msgstr ""
+
+#: include/nav.php:177 mod/message.php:181 view/theme/frio/theme.php:257
+msgid "Messages"
+msgstr ""
+
+#: include/nav.php:177 view/theme/frio/theme.php:257
+msgid "Private mail"
+msgstr ""
+
+#: include/nav.php:178
+msgid "Inbox"
+msgstr ""
+
+#: include/nav.php:179
+msgid "Outbox"
+msgstr ""
+
+#: include/nav.php:180 mod/message.php:18
+msgid "New Message"
+msgstr ""
+
+#: include/nav.php:183
+msgid "Manage"
+msgstr ""
+
+#: include/nav.php:183
+msgid "Manage other pages"
+msgstr ""
+
+#: include/nav.php:186 mod/settings.php:83
+msgid "Delegations"
+msgstr ""
+
+#: include/nav.php:186 mod/delegate.php:132
+msgid "Delegate Page Management"
+msgstr ""
+
+#: include/nav.php:188 mod/newmember.php:15 mod/settings.php:113
+#: mod/admin.php:1624 mod/admin.php:1900 view/theme/frio/theme.php:258
+msgid "Settings"
+msgstr ""
+
+#: include/nav.php:188 view/theme/frio/theme.php:258
+msgid "Account settings"
+msgstr ""
+
+#: include/nav.php:191
+msgid "Manage/Edit Profiles"
+msgstr ""
+
+#: include/nav.php:194 view/theme/frio/theme.php:259
+msgid "Manage/edit friends and contacts"
+msgstr ""
+
+#: include/nav.php:199 mod/admin.php:197
+msgid "Admin"
+msgstr ""
+
+#: include/nav.php:199
+msgid "Site setup and configuration"
+msgstr ""
+
+#: include/nav.php:202
+msgid "Navigation"
+msgstr ""
+
+#: include/nav.php:202
+msgid "Site map"
+msgstr ""
+
+#: include/network.php:687
+msgid "view full size"
+msgstr ""
+
+#: include/oembed.php:256
+msgid "Embedded content"
+msgstr ""
+
+#: include/oembed.php:264
+msgid "Embedding disabled"
 msgstr ""
 
 #: include/ostatus.php:1962
@@ -3102,6 +2867,243 @@ msgstr ""
 
 #: include/ostatus.php:1967
 msgid "stopped following"
+msgstr ""
+
+#: include/photos.php:57 include/photos.php:66 mod/fbrowser.php:42
+#: mod/fbrowser.php:63 mod/photos.php:189 mod/photos.php:1125
+#: mod/photos.php:1258 mod/photos.php:1279 mod/photos.php:1841
+#: mod/photos.php:1855
+msgid "Contact Photos"
+msgstr ""
+
+#: include/plugin.php:532 include/plugin.php:534
+msgid "Click here to upgrade."
+msgstr ""
+
+#: include/plugin.php:541
+msgid "This action exceeds the limits set by your subscription plan."
+msgstr ""
+
+#: include/plugin.php:546
+msgid "This action is not available under your subscription plan."
+msgstr ""
+
+#: include/text.php:308
+msgid "newer"
+msgstr ""
+
+#: include/text.php:309
+msgid "older"
+msgstr ""
+
+#: include/text.php:314
+msgid "first"
+msgstr ""
+
+#: include/text.php:315
+msgid "prev"
+msgstr ""
+
+#: include/text.php:349
+msgid "next"
+msgstr ""
+
+#: include/text.php:350
+msgid "last"
+msgstr ""
+
+#: include/text.php:404
+msgid "Loading more entries..."
+msgstr ""
+
+#: include/text.php:405
+msgid "The end"
+msgstr ""
+
+#: include/text.php:956
+msgid "No contacts"
+msgstr ""
+
+#: include/text.php:981
+#, php-format
+msgid "%d Contact"
+msgid_plural "%d Contacts"
+msgstr[0] ""
+msgstr[1] ""
+
+#: include/text.php:994
+msgid "View Contacts"
+msgstr ""
+
+#: include/text.php:1082 mod/editpost.php:101 mod/filer.php:32 mod/notes.php:64
+msgid "Save"
+msgstr ""
+
+#: include/text.php:1145
+msgid "poke"
+msgstr ""
+
+#: include/text.php:1145
+msgid "poked"
+msgstr ""
+
+#: include/text.php:1146
+msgid "ping"
+msgstr ""
+
+#: include/text.php:1146
+msgid "pinged"
+msgstr ""
+
+#: include/text.php:1147
+msgid "prod"
+msgstr ""
+
+#: include/text.php:1147
+msgid "prodded"
+msgstr ""
+
+#: include/text.php:1148
+msgid "slap"
+msgstr ""
+
+#: include/text.php:1148
+msgid "slapped"
+msgstr ""
+
+#: include/text.php:1149
+msgid "finger"
+msgstr ""
+
+#: include/text.php:1149
+msgid "fingered"
+msgstr ""
+
+#: include/text.php:1150
+msgid "rebuff"
+msgstr ""
+
+#: include/text.php:1150
+msgid "rebuffed"
+msgstr ""
+
+#: include/text.php:1164
+msgid "happy"
+msgstr ""
+
+#: include/text.php:1165
+msgid "sad"
+msgstr ""
+
+#: include/text.php:1166
+msgid "mellow"
+msgstr ""
+
+#: include/text.php:1167
+msgid "tired"
+msgstr ""
+
+#: include/text.php:1168
+msgid "perky"
+msgstr ""
+
+#: include/text.php:1169
+msgid "angry"
+msgstr ""
+
+#: include/text.php:1170
+msgid "stupified"
+msgstr ""
+
+#: include/text.php:1171
+msgid "puzzled"
+msgstr ""
+
+#: include/text.php:1172
+msgid "interested"
+msgstr ""
+
+#: include/text.php:1173
+msgid "bitter"
+msgstr ""
+
+#: include/text.php:1174
+msgid "cheerful"
+msgstr ""
+
+#: include/text.php:1175
+msgid "alive"
+msgstr ""
+
+#: include/text.php:1176
+msgid "annoyed"
+msgstr ""
+
+#: include/text.php:1177
+msgid "anxious"
+msgstr ""
+
+#: include/text.php:1178
+msgid "cranky"
+msgstr ""
+
+#: include/text.php:1179
+msgid "disturbed"
+msgstr ""
+
+#: include/text.php:1180
+msgid "frustrated"
+msgstr ""
+
+#: include/text.php:1181
+msgid "motivated"
+msgstr ""
+
+#: include/text.php:1182
+msgid "relaxed"
+msgstr ""
+
+#: include/text.php:1183
+msgid "surprised"
+msgstr ""
+
+#: include/text.php:1393 mod/videos.php:388
+msgid "View Video"
+msgstr ""
+
+#: include/text.php:1425
+msgid "bytes"
+msgstr ""
+
+#: include/text.php:1457 include/text.php:1469
+msgid "Click to open/close"
+msgstr ""
+
+#: include/text.php:1595
+msgid "View on separate page"
+msgstr ""
+
+#: include/text.php:1596
+msgid "view on separate page"
+msgstr ""
+
+#: include/text.php:1875
+msgid "activity"
+msgstr ""
+
+#: include/text.php:1877 mod/content.php:624 object/Item.php:416
+#: object/Item.php:428
+msgid "comment"
+msgid_plural "comments"
+msgstr[0] ""
+msgstr[1] ""
+
+#: include/text.php:1878
+msgid "post"
+msgstr ""
+
+#: include/text.php:2046
+msgid "Item filed"
 msgstr ""
 
 #: mod/allfriends.php:48
@@ -3126,9 +3128,9 @@ msgid ""
 "and/or create new posts for you?"
 msgstr ""
 
-#: mod/api.php:108 mod/follow.php:115 mod/register.php:248
-#: mod/dfrn_request.php:880 mod/profiles.php:643 mod/profiles.php:647
-#: mod/profiles.php:673 mod/settings.php:1172 mod/settings.php:1178
+#: mod/api.php:108 mod/profiles.php:643 mod/profiles.php:647
+#: mod/profiles.php:673 mod/dfrn_request.php:880 mod/follow.php:115
+#: mod/register.php:248 mod/settings.php:1172 mod/settings.php:1178
 #: mod/settings.php:1185 mod/settings.php:1189 mod/settings.php:1194
 #: mod/settings.php:1199 mod/settings.php:1204 mod/settings.php:1209
 #: mod/settings.php:1235 mod/settings.php:1236 mod/settings.php:1237
@@ -3208,7 +3210,7 @@ msgstr ""
 msgid "The post was created"
 msgstr ""
 
-#: mod/cal.php:145 mod/display.php:329 mod/profile.php:156
+#: mod/cal.php:145 mod/profile.php:156 mod/display.php:348
 msgid "Access to this profile has been restricted."
 msgstr ""
 
@@ -3220,7 +3222,7 @@ msgstr ""
 msgid "Previous"
 msgstr ""
 
-#: mod/cal.php:275 mod/events.php:381 mod/install.php:203
+#: mod/cal.php:275 mod/install.php:203 mod/events.php:381
 msgid "Next"
 msgstr ""
 
@@ -3250,21 +3252,6 @@ msgstr ""
 
 #: mod/common.php:143 mod/contacts.php:874
 msgid "Common Friends"
-msgstr ""
-
-#: mod/community.php:18 mod/directory.php:33 mod/display.php:201
-#: mod/photos.php:981 mod/search.php:96 mod/search.php:102 mod/videos.php:200
-#: mod/viewcontacts.php:39 mod/webfinger.php:10 mod/dfrn_request.php:804
-#: mod/probe.php:9
-msgid "Public access denied."
-msgstr ""
-
-#: mod/community.php:23
-msgid "Not available."
-msgstr ""
-
-#: mod/community.php:50 mod/search.php:222
-msgid "No results."
 msgstr ""
 
 #: mod/content.php:120 mod/network.php:478
@@ -3330,13 +3317,13 @@ msgstr ""
 msgid "Comment"
 msgstr ""
 
-#: mod/content.php:729 mod/crepair.php:159 mod/events.php:508
-#: mod/fsuggest.php:109 mod/install.php:244 mod/install.php:284
-#: mod/invite.php:144 mod/localtime.php:46 mod/manage.php:156
-#: mod/message.php:340 mod/message.php:523 mod/mood.php:139 mod/photos.php:1143
-#: mod/photos.php:1273 mod/photos.php:1599 mod/photos.php:1648
-#: mod/photos.php:1690 mod/photos.php:1770 mod/poke.php:204
-#: mod/contacts.php:588 mod/profiles.php:684 object/Item.php:702
+#: mod/content.php:729 mod/crepair.php:159 mod/fsuggest.php:109
+#: mod/install.php:244 mod/install.php:284 mod/invite.php:144
+#: mod/localtime.php:46 mod/manage.php:156 mod/message.php:340
+#: mod/message.php:523 mod/mood.php:139 mod/photos.php:1143 mod/photos.php:1273
+#: mod/photos.php:1599 mod/photos.php:1648 mod/photos.php:1690
+#: mod/photos.php:1770 mod/poke.php:204 mod/profiles.php:684
+#: mod/contacts.php:588 mod/events.php:508 object/Item.php:702
 #: view/theme/duepuntozero/config.php:64 view/theme/frio/config.php:67
 #: view/theme/quattro/config.php:70 view/theme/vier/config.php:113
 msgid "Submit"
@@ -3513,8 +3500,8 @@ msgid ""
 "entries from this contact."
 msgstr ""
 
-#: mod/crepair.php:170 mod/admin.php:1496 mod/admin.php:1509 mod/admin.php:1522
-#: mod/admin.php:1538 mod/settings.php:684 mod/settings.php:710
+#: mod/crepair.php:170 mod/settings.php:684 mod/settings.php:710
+#: mod/admin.php:1496 mod/admin.php:1509 mod/admin.php:1522 mod/admin.php:1538
 msgid "Name"
 msgstr ""
 
@@ -3670,6 +3657,13 @@ msgstr ""
 msgid "%1$s welcomes %2$s"
 msgstr ""
 
+#: mod/directory.php:33 mod/photos.php:981 mod/probe.php:9 mod/videos.php:200
+#: mod/viewcontacts.php:39 mod/webfinger.php:10 mod/community.php:18
+#: mod/dfrn_request.php:804 mod/display.php:213 mod/search.php:96
+#: mod/search.php:102
+msgid "Public access denied."
+msgstr ""
+
 #: mod/directory.php:195 view/theme/vier/theme.php:193
 msgid "Global Directory"
 msgstr ""
@@ -3690,24 +3684,6 @@ msgstr ""
 msgid "No entries (some entries may be hidden)."
 msgstr ""
 
-#: mod/dirfind.php:39
-#, php-format
-msgid "People Search - %s"
-msgstr ""
-
-#: mod/dirfind.php:50
-#, php-format
-msgid "Forum Search - %s"
-msgstr ""
-
-#: mod/dirfind.php:247 mod/match.php:112
-msgid "No matches"
-msgstr ""
-
-#: mod/display.php:480
-msgid "Item has been removed."
-msgstr ""
-
 #: mod/editpost.php:19 mod/editpost.php:29
 msgid "Item not found"
 msgstr ""
@@ -3716,122 +3692,12 @@ msgstr ""
 msgid "Edit post"
 msgstr ""
 
-#: mod/events.php:96 mod/events.php:98
-msgid "Event can not end before it has started."
-msgstr ""
-
-#: mod/events.php:105 mod/events.php:107
-msgid "Event title and start time are required."
-msgstr ""
-
-#: mod/events.php:379
-msgid "Create New Event"
-msgstr ""
-
-#: mod/events.php:484
-msgid "Event details"
-msgstr ""
-
-#: mod/events.php:485
-msgid "Starting date and Title are required."
-msgstr ""
-
-#: mod/events.php:486 mod/events.php:487
-msgid "Event Starts:"
-msgstr ""
-
-#: mod/events.php:486 mod/events.php:498 mod/profiles.php:712
-msgid "Required"
-msgstr ""
-
-#: mod/events.php:488 mod/events.php:504
-msgid "Finish date/time is not known or not relevant"
-msgstr ""
-
-#: mod/events.php:490 mod/events.php:491
-msgid "Event Finishes:"
-msgstr ""
-
-#: mod/events.php:492 mod/events.php:505
-msgid "Adjust for viewer timezone"
-msgstr ""
-
-#: mod/events.php:494
-msgid "Description:"
-msgstr ""
-
-#: mod/events.php:498 mod/events.php:500
-msgid "Title:"
-msgstr ""
-
-#: mod/events.php:501 mod/events.php:502
-msgid "Share this event"
-msgstr ""
-
-#: mod/events.php:531
-msgid "Failed to remove event"
-msgstr ""
-
-#: mod/events.php:533
-msgid "Event removed"
-msgstr ""
-
 #: mod/fbrowser.php:134
 msgid "Files"
 msgstr ""
 
-#: mod/fetch.php:15 mod/fetch.php:42 mod/fetch.php:51 mod/help.php:56
-#: mod/p.php:19 mod/p.php:46 mod/p.php:55 index.php:301
-msgid "Not Found"
-msgstr ""
-
 #: mod/filer.php:31
 msgid "- select -"
-msgstr ""
-
-#: mod/follow.php:21 mod/dfrn_request.php:893
-msgid "Submit Request"
-msgstr ""
-
-#: mod/follow.php:32
-msgid "You already added this contact."
-msgstr ""
-
-#: mod/follow.php:41
-msgid "Diaspora support isn't enabled. Contact can't be added."
-msgstr ""
-
-#: mod/follow.php:48
-msgid "OStatus support is disabled. Contact can't be added."
-msgstr ""
-
-#: mod/follow.php:55
-msgid "The network type couldn't be detected. Contact can't be added."
-msgstr ""
-
-#: mod/follow.php:114 mod/dfrn_request.php:879
-msgid "Please answer the following:"
-msgstr ""
-
-#: mod/follow.php:115 mod/dfrn_request.php:880
-#, php-format
-msgid "Does %s know you?"
-msgstr ""
-
-#: mod/follow.php:116 mod/dfrn_request.php:884
-msgid "Add a personal note:"
-msgstr ""
-
-#: mod/follow.php:122 mod/dfrn_request.php:890
-msgid "Your Identity Address:"
-msgstr ""
-
-#: mod/follow.php:131 mod/notifications.php:257 mod/contacts.php:635
-msgid "Profile URL"
-msgstr ""
-
-#: mod/follow.php:188
-msgid "Contact added"
 msgstr ""
 
 #: mod/friendica.php:69
@@ -3965,6 +3831,11 @@ msgstr ""
 
 #: mod/help.php:44
 msgid "Help:"
+msgstr ""
+
+#: mod/help.php:56 mod/p.php:19 mod/p.php:46 mod/p.php:55 mod/fetch.php:15
+#: mod/fetch.php:42 mod/fetch.php:51 index.php:301
+msgid "Not Found"
 msgstr ""
 
 #: mod/help.php:59 index.php:304
@@ -4504,7 +4375,7 @@ msgid ""
 "Password reset failed."
 msgstr ""
 
-#: mod/lostpass.php:112 boot.php:884
+#: mod/lostpass.php:112 boot.php:886
 msgid "Password Reset"
 msgstr ""
 
@@ -4572,7 +4443,7 @@ msgid ""
 "your email for further instructions."
 msgstr ""
 
-#: mod/lostpass.php:163 boot.php:872
+#: mod/lostpass.php:163 boot.php:874
 msgid "Nickname or Email: "
 msgstr ""
 
@@ -4608,6 +4479,10 @@ msgstr ""
 
 #: mod/match.php:105
 msgid "Profile Match"
+msgstr ""
+
+#: mod/match.php:112 mod/dirfind.php:247
+msgid "No matches"
 msgstr ""
 
 #: mod/message.php:62 mod/wallmessage.php:52
@@ -4712,82 +4587,6 @@ msgstr ""
 
 #: mod/mood.php:136
 msgid "Set your current mood and tell your friends"
-msgstr ""
-
-#: mod/network.php:154 mod/search.php:230 mod/contacts.php:808
-#, php-format
-msgid "Results for: %s"
-msgstr ""
-
-#: mod/network.php:200 mod/search.php:28
-msgid "Remove term"
-msgstr ""
-
-#: mod/network.php:407
-#, php-format
-msgid ""
-"Warning: This group contains %s member from a network that doesn't allow non "
-"public messages."
-msgid_plural ""
-"Warning: This group contains %s members from a network that doesn't allow "
-"non public messages."
-msgstr[0] ""
-msgstr[1] ""
-
-#: mod/network.php:410
-msgid "Messages in this group won't be send to these receivers."
-msgstr ""
-
-#: mod/network.php:538
-msgid "Private messages to this person are at risk of public disclosure."
-msgstr ""
-
-#: mod/network.php:543
-msgid "Invalid contact."
-msgstr ""
-
-#: mod/network.php:816
-msgid "Commented Order"
-msgstr ""
-
-#: mod/network.php:819
-msgid "Sort by Comment Date"
-msgstr ""
-
-#: mod/network.php:824
-msgid "Posted Order"
-msgstr ""
-
-#: mod/network.php:827
-msgid "Sort by Post Date"
-msgstr ""
-
-#: mod/network.php:838
-msgid "Posts that mention or involve you"
-msgstr ""
-
-#: mod/network.php:846
-msgid "New"
-msgstr ""
-
-#: mod/network.php:849
-msgid "Activity Stream - by date"
-msgstr ""
-
-#: mod/network.php:857
-msgid "Shared Links"
-msgstr ""
-
-#: mod/network.php:860
-msgid "Interesting Links"
-msgstr ""
-
-#: mod/network.php:868
-msgid "Starred"
-msgstr ""
-
-#: mod/network.php:871
-msgid "Favourite Posts"
 msgstr ""
 
 #: mod/newmember.php:7
@@ -5084,6 +4883,10 @@ msgstr ""
 msgid "Subscriber"
 msgstr ""
 
+#: mod/notifications.php:257 mod/contacts.php:635 mod/follow.php:131
+msgid "Profile URL"
+msgstr ""
+
 #: mod/notifications.php:274
 msgid "No introductions."
 msgstr ""
@@ -5199,7 +5002,7 @@ msgstr ""
 msgid "a photo"
 msgstr ""
 
-#: mod/photos.php:815 mod/wall_upload.php:181 mod/profile_photo.php:155
+#: mod/photos.php:815 mod/profile_photo.php:155 mod/wall_upload.php:181
 #, php-format
 msgid "Image exceeds size limit of %s"
 msgstr ""
@@ -5208,11 +5011,11 @@ msgstr ""
 msgid "Image file is empty."
 msgstr ""
 
-#: mod/photos.php:856 mod/wall_upload.php:218 mod/profile_photo.php:164
+#: mod/photos.php:856 mod/profile_photo.php:164 mod/wall_upload.php:218
 msgid "Unable to process image."
 msgstr ""
 
-#: mod/photos.php:885 mod/wall_upload.php:257 mod/profile_photo.php:314
+#: mod/photos.php:885 mod/profile_photo.php:314 mod/wall_upload.php:257
 msgid "Image upload failed."
 msgstr ""
 
@@ -5373,8 +5176,376 @@ msgstr ""
 msgid "Make this post private"
 msgstr ""
 
+#: mod/probe.php:10 mod/webfinger.php:11
+msgid "Only logged in users are permitted to perform a probing."
+msgstr ""
+
 #: mod/profile.php:176
 msgid "Tips for New Members"
+msgstr ""
+
+#: mod/profile_photo.php:44
+msgid "Image uploaded but image cropping failed."
+msgstr ""
+
+#: mod/profile_photo.php:77 mod/profile_photo.php:85 mod/profile_photo.php:93
+#: mod/profile_photo.php:322
+#, php-format
+msgid "Image size reduction [%s] failed."
+msgstr ""
+
+#: mod/profile_photo.php:127
+msgid ""
+"Shift-reload the page or clear browser cache if the new photo does not "
+"display immediately."
+msgstr ""
+
+#: mod/profile_photo.php:136
+msgid "Unable to process image"
+msgstr ""
+
+#: mod/profile_photo.php:253
+msgid "Upload File:"
+msgstr ""
+
+#: mod/profile_photo.php:254
+msgid "Select a profile:"
+msgstr ""
+
+#: mod/profile_photo.php:256
+#: view/smarty3/compiled/04b5adc938a37b0a51a14fb26634819e90d47ba4.file.filebrowser.tpl.php:119
+msgid "Upload"
+msgstr ""
+
+#: mod/profile_photo.php:259
+msgid "or"
+msgstr ""
+
+#: mod/profile_photo.php:259
+msgid "skip this step"
+msgstr ""
+
+#: mod/profile_photo.php:259
+msgid "select a photo from your photo albums"
+msgstr ""
+
+#: mod/profile_photo.php:273
+msgid "Crop Image"
+msgstr ""
+
+#: mod/profile_photo.php:274
+msgid "Please adjust the image cropping for optimum viewing."
+msgstr ""
+
+#: mod/profile_photo.php:276
+msgid "Done Editing"
+msgstr ""
+
+#: mod/profile_photo.php:312
+msgid "Image uploaded successfully."
+msgstr ""
+
+#: mod/profiles.php:42
+msgid "Profile deleted."
+msgstr ""
+
+#: mod/profiles.php:58 mod/profiles.php:94
+msgid "Profile-"
+msgstr ""
+
+#: mod/profiles.php:77 mod/profiles.php:122
+msgid "New profile created."
+msgstr ""
+
+#: mod/profiles.php:100
+msgid "Profile unavailable to clone."
+msgstr ""
+
+#: mod/profiles.php:196
+msgid "Profile Name is required."
+msgstr ""
+
+#: mod/profiles.php:336
+msgid "Marital Status"
+msgstr ""
+
+#: mod/profiles.php:340
+msgid "Romantic Partner"
+msgstr ""
+
+#: mod/profiles.php:352
+msgid "Work/Employment"
+msgstr ""
+
+#: mod/profiles.php:355
+msgid "Religion"
+msgstr ""
+
+#: mod/profiles.php:359
+msgid "Political Views"
+msgstr ""
+
+#: mod/profiles.php:363
+msgid "Gender"
+msgstr ""
+
+#: mod/profiles.php:367
+msgid "Sexual Preference"
+msgstr ""
+
+#: mod/profiles.php:371
+msgid "XMPP"
+msgstr ""
+
+#: mod/profiles.php:375
+msgid "Homepage"
+msgstr ""
+
+#: mod/profiles.php:379 mod/profiles.php:698
+msgid "Interests"
+msgstr ""
+
+#: mod/profiles.php:383
+msgid "Address"
+msgstr ""
+
+#: mod/profiles.php:390 mod/profiles.php:694
+msgid "Location"
+msgstr ""
+
+#: mod/profiles.php:475
+msgid "Profile updated."
+msgstr ""
+
+#: mod/profiles.php:567
+msgid " and "
+msgstr ""
+
+#: mod/profiles.php:576
+msgid "public profile"
+msgstr ""
+
+#: mod/profiles.php:579
+#, php-format
+msgid "%1$s changed %2$s to &ldquo;%3$s&rdquo;"
+msgstr ""
+
+#: mod/profiles.php:580
+#, php-format
+msgid " - Visit %1$s's %2$s"
+msgstr ""
+
+#: mod/profiles.php:582
+#, php-format
+msgid "%1$s has an updated %2$s, changing %3$s."
+msgstr ""
+
+#: mod/profiles.php:640
+msgid "Hide contacts and friends:"
+msgstr ""
+
+#: mod/profiles.php:645
+msgid "Hide your contact/friend list from viewers of this profile?"
+msgstr ""
+
+#: mod/profiles.php:670
+msgid "Show more profile fields:"
+msgstr ""
+
+#: mod/profiles.php:682
+msgid "Profile Actions"
+msgstr ""
+
+#: mod/profiles.php:683
+msgid "Edit Profile Details"
+msgstr ""
+
+#: mod/profiles.php:685
+msgid "Change Profile Photo"
+msgstr ""
+
+#: mod/profiles.php:686
+msgid "View this profile"
+msgstr ""
+
+#: mod/profiles.php:688
+msgid "Create a new profile using these settings"
+msgstr ""
+
+#: mod/profiles.php:689
+msgid "Clone this profile"
+msgstr ""
+
+#: mod/profiles.php:690
+msgid "Delete this profile"
+msgstr ""
+
+#: mod/profiles.php:692
+msgid "Basic information"
+msgstr ""
+
+#: mod/profiles.php:693
+msgid "Profile picture"
+msgstr ""
+
+#: mod/profiles.php:695
+msgid "Preferences"
+msgstr ""
+
+#: mod/profiles.php:696
+msgid "Status information"
+msgstr ""
+
+#: mod/profiles.php:697
+msgid "Additional information"
+msgstr ""
+
+#: mod/profiles.php:700
+msgid "Relation"
+msgstr ""
+
+#: mod/profiles.php:704
+msgid "Your Gender:"
+msgstr ""
+
+#: mod/profiles.php:705
+msgid "<span class=\"heart\">&hearts;</span> Marital Status:"
+msgstr ""
+
+#: mod/profiles.php:707
+msgid "Example: fishing photography software"
+msgstr ""
+
+#: mod/profiles.php:712
+msgid "Profile Name:"
+msgstr ""
+
+#: mod/profiles.php:712 mod/events.php:486 mod/events.php:498
+msgid "Required"
+msgstr ""
+
+#: mod/profiles.php:714
+msgid ""
+"This is your <strong>public</strong> profile.<br />It <strong>may</strong> "
+"be visible to anybody using the internet."
+msgstr ""
+
+#: mod/profiles.php:715
+msgid "Your Full Name:"
+msgstr ""
+
+#: mod/profiles.php:716
+msgid "Title/Description:"
+msgstr ""
+
+#: mod/profiles.php:719
+msgid "Street Address:"
+msgstr ""
+
+#: mod/profiles.php:720
+msgid "Locality/City:"
+msgstr ""
+
+#: mod/profiles.php:721
+msgid "Region/State:"
+msgstr ""
+
+#: mod/profiles.php:722
+msgid "Postal/Zip Code:"
+msgstr ""
+
+#: mod/profiles.php:723
+msgid "Country:"
+msgstr ""
+
+#: mod/profiles.php:727
+msgid "Who: (if applicable)"
+msgstr ""
+
+#: mod/profiles.php:727
+msgid "Examples: cathy123, Cathy Williams, cathy@example.com"
+msgstr ""
+
+#: mod/profiles.php:728
+msgid "Since [date]:"
+msgstr ""
+
+#: mod/profiles.php:730
+msgid "Tell us about yourself..."
+msgstr ""
+
+#: mod/profiles.php:731
+msgid "XMPP (Jabber) address:"
+msgstr ""
+
+#: mod/profiles.php:731
+msgid ""
+"The XMPP address will be propagated to your contacts so that they can follow "
+"you."
+msgstr ""
+
+#: mod/profiles.php:732
+msgid "Homepage URL:"
+msgstr ""
+
+#: mod/profiles.php:735
+msgid "Religious Views:"
+msgstr ""
+
+#: mod/profiles.php:736
+msgid "Public Keywords:"
+msgstr ""
+
+#: mod/profiles.php:736
+msgid "(Used for suggesting potential friends, can be seen by others)"
+msgstr ""
+
+#: mod/profiles.php:737
+msgid "Private Keywords:"
+msgstr ""
+
+#: mod/profiles.php:737
+msgid "(Used for searching profiles, never shown to others)"
+msgstr ""
+
+#: mod/profiles.php:740
+msgid "Musical interests"
+msgstr ""
+
+#: mod/profiles.php:741
+msgid "Books, literature"
+msgstr ""
+
+#: mod/profiles.php:742
+msgid "Television"
+msgstr ""
+
+#: mod/profiles.php:743
+msgid "Film/dance/culture/entertainment"
+msgstr ""
+
+#: mod/profiles.php:744
+msgid "Hobbies/Interests"
+msgstr ""
+
+#: mod/profiles.php:745
+msgid "Love/romance"
+msgstr ""
+
+#: mod/profiles.php:746
+msgid "Work/employment"
+msgstr ""
+
+#: mod/profiles.php:747
+msgid "School/education"
+msgstr ""
+
+#: mod/profiles.php:748
+msgid "Contact information and Social Networks"
+msgstr ""
+
+#: mod/profiles.php:789
+msgid "Edit/Manage Profiles"
 msgstr ""
 
 #: mod/profperm.php:28 mod/profperm.php:59
@@ -5393,113 +5564,17 @@ msgstr ""
 msgid "All Contacts (with secure profile access)"
 msgstr ""
 
-#: mod/register.php:95
-msgid ""
-"Registration successful. Please check your email for further instructions."
+#: mod/regmod.php:60
+msgid "Account approved."
 msgstr ""
 
-#: mod/register.php:100
+#: mod/regmod.php:88
 #, php-format
-msgid ""
-"Failed to send email message. Here your accout details:<br> login: %s<br> "
-"password: %s<br><br>You can change your password after login."
+msgid "Registration revoked for %s"
 msgstr ""
 
-#: mod/register.php:107
-msgid "Registration successful."
-msgstr ""
-
-#: mod/register.php:113
-msgid "Your registration can not be processed."
-msgstr ""
-
-#: mod/register.php:162
-msgid "Your registration is pending approval by the site owner."
-msgstr ""
-
-#: mod/register.php:200 mod/uimport.php:53
-msgid ""
-"This site has exceeded the number of allowed daily account registrations. "
-"Please try again tomorrow."
-msgstr ""
-
-#: mod/register.php:228
-msgid ""
-"You may (optionally) fill in this form via OpenID by supplying your OpenID "
-"and clicking 'Register'."
-msgstr ""
-
-#: mod/register.php:229
-msgid ""
-"If you are not familiar with OpenID, please leave that field blank and fill "
-"in the rest of the items."
-msgstr ""
-
-#: mod/register.php:230
-msgid "Your OpenID (optional): "
-msgstr ""
-
-#: mod/register.php:244
-msgid "Include your profile in member directory?"
-msgstr ""
-
-#: mod/register.php:269
-msgid "Note for the admin"
-msgstr ""
-
-#: mod/register.php:269
-msgid "Leave a message for the admin, why you want to join this node"
-msgstr ""
-
-#: mod/register.php:270
-msgid "Membership on this site is by invitation only."
-msgstr ""
-
-#: mod/register.php:271
-msgid "Your invitation ID: "
-msgstr ""
-
-#: mod/register.php:274 mod/admin.php:1062
-msgid "Registration"
-msgstr ""
-
-#: mod/register.php:282
-msgid "Your Full Name (e.g. Joe Smith, real or real-looking): "
-msgstr ""
-
-#: mod/register.php:283
-msgid "Your Email Address: "
-msgstr ""
-
-#: mod/register.php:285 mod/settings.php:1279
-msgid "New Password:"
-msgstr ""
-
-#: mod/register.php:285
-msgid "Leave empty for an auto generated password."
-msgstr ""
-
-#: mod/register.php:286 mod/settings.php:1280
-msgid "Confirm:"
-msgstr ""
-
-#: mod/register.php:287
-msgid ""
-"Choose a profile nickname. This must begin with a text character. Your "
-"profile address on this site will then be '<strong>nickname@$sitename</"
-"strong>'."
-msgstr ""
-
-#: mod/register.php:288
-msgid "Choose a nickname: "
-msgstr ""
-
-#: mod/register.php:297 mod/uimport.php:68
-msgid "Import"
-msgstr ""
-
-#: mod/register.php:298
-msgid "Import your profile to this friendica instance"
+#: mod/regmod.php:100
+msgid "Please login."
 msgstr ""
 
 #: mod/removeme.php:54 mod/removeme.php:57
@@ -5522,23 +5597,6 @@ msgstr ""
 
 #: mod/repair_ostatus.php:32
 msgid "Error"
-msgstr ""
-
-#: mod/search.php:103
-msgid "Only logged in users are permitted to perform a search."
-msgstr ""
-
-#: mod/search.php:127
-msgid "Too Many Requests"
-msgstr ""
-
-#: mod/search.php:128
-msgid "Only one search per minute is permitted for not logged in users."
-msgstr ""
-
-#: mod/search.php:228
-#, php-format
-msgid "Items tagged with: %s"
 msgstr ""
 
 #: mod/subthread.php:105
@@ -5597,8 +5655,49 @@ msgstr ""
 msgid "Export personal data"
 msgstr ""
 
+#: mod/uimport.php:53 mod/register.php:200
+msgid ""
+"This site has exceeded the number of allowed daily account registrations. "
+"Please try again tomorrow."
+msgstr ""
+
+#: mod/uimport.php:68 mod/register.php:297
+msgid "Import"
+msgstr ""
+
+#: mod/uimport.php:70
+msgid "Move account"
+msgstr ""
+
+#: mod/uimport.php:71
+msgid "You can import an account from another Friendica server."
+msgstr ""
+
+#: mod/uimport.php:72
+msgid ""
+"You need to export your account from the old server and upload it here. We "
+"will recreate your old account here with all your contacts. We will try also "
+"to inform your friends that you moved here."
+msgstr ""
+
+#: mod/uimport.php:73
+msgid ""
+"This feature is experimental. We can't import contacts from the OStatus "
+"network (GNU Social/Statusnet) or from Diaspora"
+msgstr ""
+
+#: mod/uimport.php:74
+msgid "Account file"
+msgstr ""
+
+#: mod/uimport.php:74
+msgid ""
+"To export your account, go to \"Settings->Export your personal data\" and "
+"select \"Export account\""
+msgstr ""
+
 #: mod/update_community.php:21 mod/update_display.php:25
-#: mod/update_network.php:29 mod/update_notes.php:38 mod/update_profile.php:37
+#: mod/update_notes.php:38 mod/update_profile.php:37 mod/update_network.php:29
 msgid "[Embedded content - reload page to view]"
 msgstr ""
 
@@ -5673,235 +5772,12 @@ msgid ""
 "your site allow private mail from unknown senders."
 msgstr ""
 
-#: mod/webfinger.php:11 mod/probe.php:10
-msgid "Only logged in users are permitted to perform a probing."
+#: mod/community.php:23
+msgid "Not available."
 msgstr ""
 
-#: mod/dfrn_request.php:103
-msgid "This introduction has already been accepted."
-msgstr ""
-
-#: mod/dfrn_request.php:126 mod/dfrn_request.php:528
-msgid "Profile location is not valid or does not contain profile information."
-msgstr ""
-
-#: mod/dfrn_request.php:131 mod/dfrn_request.php:533
-msgid "Warning: profile location has no identifiable owner name."
-msgstr ""
-
-#: mod/dfrn_request.php:134 mod/dfrn_request.php:536
-msgid "Warning: profile location has no profile photo."
-msgstr ""
-
-#: mod/dfrn_request.php:138 mod/dfrn_request.php:540
-#, php-format
-msgid "%d required parameter was not found at the given location"
-msgid_plural "%d required parameters were not found at the given location"
-msgstr[0] ""
-msgstr[1] ""
-
-#: mod/dfrn_request.php:182
-msgid "Introduction complete."
-msgstr ""
-
-#: mod/dfrn_request.php:227
-msgid "Unrecoverable protocol error."
-msgstr ""
-
-#: mod/dfrn_request.php:255
-msgid "Profile unavailable."
-msgstr ""
-
-#: mod/dfrn_request.php:282
-#, php-format
-msgid "%s has received too many connection requests today."
-msgstr ""
-
-#: mod/dfrn_request.php:283
-msgid "Spam protection measures have been invoked."
-msgstr ""
-
-#: mod/dfrn_request.php:284
-msgid "Friends are advised to please try again in 24 hours."
-msgstr ""
-
-#: mod/dfrn_request.php:346
-msgid "Invalid locator"
-msgstr ""
-
-#: mod/dfrn_request.php:355
-msgid "Invalid email address."
-msgstr ""
-
-#: mod/dfrn_request.php:380
-msgid "This account has not been configured for email. Request failed."
-msgstr ""
-
-#: mod/dfrn_request.php:483
-msgid "You have already introduced yourself here."
-msgstr ""
-
-#: mod/dfrn_request.php:487
-#, php-format
-msgid "Apparently you are already friends with %s."
-msgstr ""
-
-#: mod/dfrn_request.php:508
-msgid "Invalid profile URL."
-msgstr ""
-
-#: mod/dfrn_request.php:593 mod/contacts.php:221
-msgid "Failed to update contact record."
-msgstr ""
-
-#: mod/dfrn_request.php:614
-msgid "Your introduction has been sent."
-msgstr ""
-
-#: mod/dfrn_request.php:656
-msgid ""
-"Remote subscription can't be done for your network. Please subscribe "
-"directly on your system."
-msgstr ""
-
-#: mod/dfrn_request.php:677
-msgid "Please login to confirm introduction."
-msgstr ""
-
-#: mod/dfrn_request.php:687
-msgid ""
-"Incorrect identity currently logged in. Please login to <strong>this</"
-"strong> profile."
-msgstr ""
-
-#: mod/dfrn_request.php:701 mod/dfrn_request.php:718
-msgid "Confirm"
-msgstr ""
-
-#: mod/dfrn_request.php:713
-msgid "Hide this contact"
-msgstr ""
-
-#: mod/dfrn_request.php:716
-#, php-format
-msgid "Welcome home %s."
-msgstr ""
-
-#: mod/dfrn_request.php:717
-#, php-format
-msgid "Please confirm your introduction/connection request to %s."
-msgstr ""
-
-#: mod/dfrn_request.php:848
-msgid ""
-"Please enter your 'Identity Address' from one of the following supported "
-"communications networks:"
-msgstr ""
-
-#: mod/dfrn_request.php:872
-#, php-format
-msgid ""
-"If you are not yet a member of the free social web, <a href=\"%s/siteinfo"
-"\">follow this link to find a public Friendica site and join us today</a>."
-msgstr ""
-
-#: mod/dfrn_request.php:877
-msgid "Friend/Connection Request"
-msgstr ""
-
-#: mod/dfrn_request.php:878
-msgid ""
-"Examples: jojo@demo.friendica.com, http://demo.friendica.com/profile/jojo, "
-"testuser@identi.ca"
-msgstr ""
-
-#: mod/dfrn_request.php:887
-msgid "StatusNet/Federated Social Web"
-msgstr ""
-
-#: mod/dfrn_request.php:889
-#, php-format
-msgid ""
-" - please do not use this form.  Instead, enter %s into your Diaspora search "
-"bar."
-msgstr ""
-
-#: mod/item.php:118
-msgid "Unable to locate original post."
-msgstr ""
-
-#: mod/item.php:345
-msgid "Empty post discarded."
-msgstr ""
-
-#: mod/item.php:904
-msgid "System error. Post not saved."
-msgstr ""
-
-#: mod/item.php:995
-#, php-format
-msgid ""
-"This message was sent to you by %s, a member of the Friendica social network."
-msgstr ""
-
-#: mod/item.php:997
-#, php-format
-msgid "You may visit them online at %s"
-msgstr ""
-
-#: mod/item.php:998
-msgid ""
-"Please contact the sender by replying to this post if you do not wish to "
-"receive these messages."
-msgstr ""
-
-#: mod/item.php:1002
-#, php-format
-msgid "%s posted an update."
-msgstr ""
-
-#: mod/regmod.php:60
-msgid "Account approved."
-msgstr ""
-
-#: mod/regmod.php:88
-#, php-format
-msgid "Registration revoked for %s"
-msgstr ""
-
-#: mod/regmod.php:100
-msgid "Please login."
-msgstr ""
-
-#: mod/uimport.php:70
-msgid "Move account"
-msgstr ""
-
-#: mod/uimport.php:71
-msgid "You can import an account from another Friendica server."
-msgstr ""
-
-#: mod/uimport.php:72
-msgid ""
-"You need to export your account from the old server and upload it here. We "
-"will recreate your old account here with all your contacts. We will try also "
-"to inform your friends that you moved here."
-msgstr ""
-
-#: mod/uimport.php:73
-msgid ""
-"This feature is experimental. We can't import contacts from the OStatus "
-"network (GNU Social/Statusnet) or from Diaspora"
-msgstr ""
-
-#: mod/uimport.php:74
-msgid "Account file"
-msgstr ""
-
-#: mod/uimport.php:74
-msgid ""
-"To export your account, go to \"Settings->Export your personal data\" and "
-"select \"Export account\""
+#: mod/community.php:50 mod/search.php:222
+msgid "No results."
 msgstr ""
 
 #: mod/contacts.php:137
@@ -5921,6 +5797,10 @@ msgstr ""
 
 #: mod/contacts.php:219
 msgid "Contact updated."
+msgstr ""
+
+#: mod/contacts.php:221 mod/dfrn_request.php:593
+msgid "Failed to update contact record."
 msgstr ""
 
 #: mod/contacts.php:402
@@ -6183,6 +6063,11 @@ msgstr ""
 msgid "Search your contacts"
 msgstr ""
 
+#: mod/contacts.php:808 mod/network.php:154 mod/search.php:230
+#, php-format
+msgid "Results for: %s"
+msgstr ""
+
 #: mod/contacts.php:815 mod/settings.php:162 mod/settings.php:708
 msgid "Update"
 msgstr ""
@@ -6239,6 +6124,367 @@ msgstr ""
 msgid "Delete contact"
 msgstr ""
 
+#: mod/dfrn_request.php:103
+msgid "This introduction has already been accepted."
+msgstr ""
+
+#: mod/dfrn_request.php:126 mod/dfrn_request.php:528
+msgid "Profile location is not valid or does not contain profile information."
+msgstr ""
+
+#: mod/dfrn_request.php:131 mod/dfrn_request.php:533
+msgid "Warning: profile location has no identifiable owner name."
+msgstr ""
+
+#: mod/dfrn_request.php:134 mod/dfrn_request.php:536
+msgid "Warning: profile location has no profile photo."
+msgstr ""
+
+#: mod/dfrn_request.php:138 mod/dfrn_request.php:540
+#, php-format
+msgid "%d required parameter was not found at the given location"
+msgid_plural "%d required parameters were not found at the given location"
+msgstr[0] ""
+msgstr[1] ""
+
+#: mod/dfrn_request.php:182
+msgid "Introduction complete."
+msgstr ""
+
+#: mod/dfrn_request.php:227
+msgid "Unrecoverable protocol error."
+msgstr ""
+
+#: mod/dfrn_request.php:255
+msgid "Profile unavailable."
+msgstr ""
+
+#: mod/dfrn_request.php:282
+#, php-format
+msgid "%s has received too many connection requests today."
+msgstr ""
+
+#: mod/dfrn_request.php:283
+msgid "Spam protection measures have been invoked."
+msgstr ""
+
+#: mod/dfrn_request.php:284
+msgid "Friends are advised to please try again in 24 hours."
+msgstr ""
+
+#: mod/dfrn_request.php:346
+msgid "Invalid locator"
+msgstr ""
+
+#: mod/dfrn_request.php:355
+msgid "Invalid email address."
+msgstr ""
+
+#: mod/dfrn_request.php:380
+msgid "This account has not been configured for email. Request failed."
+msgstr ""
+
+#: mod/dfrn_request.php:483
+msgid "You have already introduced yourself here."
+msgstr ""
+
+#: mod/dfrn_request.php:487
+#, php-format
+msgid "Apparently you are already friends with %s."
+msgstr ""
+
+#: mod/dfrn_request.php:508
+msgid "Invalid profile URL."
+msgstr ""
+
+#: mod/dfrn_request.php:614
+msgid "Your introduction has been sent."
+msgstr ""
+
+#: mod/dfrn_request.php:656
+msgid ""
+"Remote subscription can't be done for your network. Please subscribe "
+"directly on your system."
+msgstr ""
+
+#: mod/dfrn_request.php:677
+msgid "Please login to confirm introduction."
+msgstr ""
+
+#: mod/dfrn_request.php:687
+msgid ""
+"Incorrect identity currently logged in. Please login to <strong>this</"
+"strong> profile."
+msgstr ""
+
+#: mod/dfrn_request.php:701 mod/dfrn_request.php:718
+msgid "Confirm"
+msgstr ""
+
+#: mod/dfrn_request.php:713
+msgid "Hide this contact"
+msgstr ""
+
+#: mod/dfrn_request.php:716
+#, php-format
+msgid "Welcome home %s."
+msgstr ""
+
+#: mod/dfrn_request.php:717
+#, php-format
+msgid "Please confirm your introduction/connection request to %s."
+msgstr ""
+
+#: mod/dfrn_request.php:848
+msgid ""
+"Please enter your 'Identity Address' from one of the following supported "
+"communications networks:"
+msgstr ""
+
+#: mod/dfrn_request.php:872
+#, php-format
+msgid ""
+"If you are not yet a member of the free social web, <a href=\"%s/siteinfo"
+"\">follow this link to find a public Friendica site and join us today</a>."
+msgstr ""
+
+#: mod/dfrn_request.php:877
+msgid "Friend/Connection Request"
+msgstr ""
+
+#: mod/dfrn_request.php:878
+msgid ""
+"Examples: jojo@demo.friendica.com, http://demo.friendica.com/profile/jojo, "
+"testuser@identi.ca"
+msgstr ""
+
+#: mod/dfrn_request.php:879 mod/follow.php:114
+msgid "Please answer the following:"
+msgstr ""
+
+#: mod/dfrn_request.php:880 mod/follow.php:115
+#, php-format
+msgid "Does %s know you?"
+msgstr ""
+
+#: mod/dfrn_request.php:884 mod/follow.php:116
+msgid "Add a personal note:"
+msgstr ""
+
+#: mod/dfrn_request.php:887
+msgid "StatusNet/Federated Social Web"
+msgstr ""
+
+#: mod/dfrn_request.php:889
+#, php-format
+msgid ""
+" - please do not use this form.  Instead, enter %s into your Diaspora search "
+"bar."
+msgstr ""
+
+#: mod/dfrn_request.php:890 mod/follow.php:122
+msgid "Your Identity Address:"
+msgstr ""
+
+#: mod/dfrn_request.php:893 mod/follow.php:21
+msgid "Submit Request"
+msgstr ""
+
+#: mod/dirfind.php:39
+#, php-format
+msgid "People Search - %s"
+msgstr ""
+
+#: mod/dirfind.php:50
+#, php-format
+msgid "Forum Search - %s"
+msgstr ""
+
+#: mod/display.php:499
+msgid "Item has been removed."
+msgstr ""
+
+#: mod/events.php:96 mod/events.php:98
+msgid "Event can not end before it has started."
+msgstr ""
+
+#: mod/events.php:105 mod/events.php:107
+msgid "Event title and start time are required."
+msgstr ""
+
+#: mod/events.php:379
+msgid "Create New Event"
+msgstr ""
+
+#: mod/events.php:484
+msgid "Event details"
+msgstr ""
+
+#: mod/events.php:485
+msgid "Starting date and Title are required."
+msgstr ""
+
+#: mod/events.php:486 mod/events.php:487
+msgid "Event Starts:"
+msgstr ""
+
+#: mod/events.php:488 mod/events.php:504
+msgid "Finish date/time is not known or not relevant"
+msgstr ""
+
+#: mod/events.php:490 mod/events.php:491
+msgid "Event Finishes:"
+msgstr ""
+
+#: mod/events.php:492 mod/events.php:505
+msgid "Adjust for viewer timezone"
+msgstr ""
+
+#: mod/events.php:494
+msgid "Description:"
+msgstr ""
+
+#: mod/events.php:498 mod/events.php:500
+msgid "Title:"
+msgstr ""
+
+#: mod/events.php:501 mod/events.php:502
+msgid "Share this event"
+msgstr ""
+
+#: mod/events.php:531
+msgid "Failed to remove event"
+msgstr ""
+
+#: mod/events.php:533
+msgid "Event removed"
+msgstr ""
+
+#: mod/follow.php:32
+msgid "You already added this contact."
+msgstr ""
+
+#: mod/follow.php:41
+msgid "Diaspora support isn't enabled. Contact can't be added."
+msgstr ""
+
+#: mod/follow.php:48
+msgid "OStatus support is disabled. Contact can't be added."
+msgstr ""
+
+#: mod/follow.php:55
+msgid "The network type couldn't be detected. Contact can't be added."
+msgstr ""
+
+#: mod/follow.php:188
+msgid "Contact added"
+msgstr ""
+
+#: mod/item.php:118
+msgid "Unable to locate original post."
+msgstr ""
+
+#: mod/item.php:345
+msgid "Empty post discarded."
+msgstr ""
+
+#: mod/item.php:904
+msgid "System error. Post not saved."
+msgstr ""
+
+#: mod/item.php:995
+#, php-format
+msgid ""
+"This message was sent to you by %s, a member of the Friendica social network."
+msgstr ""
+
+#: mod/item.php:997
+#, php-format
+msgid "You may visit them online at %s"
+msgstr ""
+
+#: mod/item.php:998
+msgid ""
+"Please contact the sender by replying to this post if you do not wish to "
+"receive these messages."
+msgstr ""
+
+#: mod/item.php:1002
+#, php-format
+msgid "%s posted an update."
+msgstr ""
+
+#: mod/network.php:200 mod/search.php:28
+msgid "Remove term"
+msgstr ""
+
+#: mod/network.php:407
+#, php-format
+msgid ""
+"Warning: This group contains %s member from a network that doesn't allow non "
+"public messages."
+msgid_plural ""
+"Warning: This group contains %s members from a network that doesn't allow "
+"non public messages."
+msgstr[0] ""
+msgstr[1] ""
+
+#: mod/network.php:410
+msgid "Messages in this group won't be send to these receivers."
+msgstr ""
+
+#: mod/network.php:538
+msgid "Private messages to this person are at risk of public disclosure."
+msgstr ""
+
+#: mod/network.php:543
+msgid "Invalid contact."
+msgstr ""
+
+#: mod/network.php:816
+msgid "Commented Order"
+msgstr ""
+
+#: mod/network.php:819
+msgid "Sort by Comment Date"
+msgstr ""
+
+#: mod/network.php:824
+msgid "Posted Order"
+msgstr ""
+
+#: mod/network.php:827
+msgid "Sort by Post Date"
+msgstr ""
+
+#: mod/network.php:838
+msgid "Posts that mention or involve you"
+msgstr ""
+
+#: mod/network.php:846
+msgid "New"
+msgstr ""
+
+#: mod/network.php:849
+msgid "Activity Stream - by date"
+msgstr ""
+
+#: mod/network.php:857
+msgid "Shared Links"
+msgstr ""
+
+#: mod/network.php:860
+msgid "Interesting Links"
+msgstr ""
+
+#: mod/network.php:868
+msgid "Starred"
+msgstr ""
+
+#: mod/network.php:871
+msgid "Favourite Posts"
+msgstr ""
+
 #: mod/ping.php:274
 msgid "{0} wants to be your friend"
 msgstr ""
@@ -6251,363 +6497,874 @@ msgstr ""
 msgid "{0} requested registration"
 msgstr ""
 
-#: mod/profile_photo.php:44
-msgid "Image uploaded but image cropping failed."
-msgstr ""
-
-#: mod/profile_photo.php:77 mod/profile_photo.php:85 mod/profile_photo.php:93
-#: mod/profile_photo.php:322
-#, php-format
-msgid "Image size reduction [%s] failed."
-msgstr ""
-
-#: mod/profile_photo.php:127
+#: mod/register.php:95
 msgid ""
-"Shift-reload the page or clear browser cache if the new photo does not "
-"display immediately."
+"Registration successful. Please check your email for further instructions."
 msgstr ""
 
-#: mod/profile_photo.php:136
-msgid "Unable to process image"
-msgstr ""
-
-#: mod/profile_photo.php:253
-msgid "Upload File:"
-msgstr ""
-
-#: mod/profile_photo.php:254
-msgid "Select a profile:"
-msgstr ""
-
-#: mod/profile_photo.php:256
-msgid "Upload"
-msgstr ""
-
-#: mod/profile_photo.php:259
-msgid "or"
-msgstr ""
-
-#: mod/profile_photo.php:259
-msgid "skip this step"
-msgstr ""
-
-#: mod/profile_photo.php:259
-msgid "select a photo from your photo albums"
-msgstr ""
-
-#: mod/profile_photo.php:273
-msgid "Crop Image"
-msgstr ""
-
-#: mod/profile_photo.php:274
-msgid "Please adjust the image cropping for optimum viewing."
-msgstr ""
-
-#: mod/profile_photo.php:276
-msgid "Done Editing"
-msgstr ""
-
-#: mod/profile_photo.php:312
-msgid "Image uploaded successfully."
-msgstr ""
-
-#: mod/profiles.php:42
-msgid "Profile deleted."
-msgstr ""
-
-#: mod/profiles.php:58 mod/profiles.php:94
-msgid "Profile-"
-msgstr ""
-
-#: mod/profiles.php:77 mod/profiles.php:122
-msgid "New profile created."
-msgstr ""
-
-#: mod/profiles.php:100
-msgid "Profile unavailable to clone."
-msgstr ""
-
-#: mod/profiles.php:196
-msgid "Profile Name is required."
-msgstr ""
-
-#: mod/profiles.php:336
-msgid "Marital Status"
-msgstr ""
-
-#: mod/profiles.php:340
-msgid "Romantic Partner"
-msgstr ""
-
-#: mod/profiles.php:352
-msgid "Work/Employment"
-msgstr ""
-
-#: mod/profiles.php:355
-msgid "Religion"
-msgstr ""
-
-#: mod/profiles.php:359
-msgid "Political Views"
-msgstr ""
-
-#: mod/profiles.php:363
-msgid "Gender"
-msgstr ""
-
-#: mod/profiles.php:367
-msgid "Sexual Preference"
-msgstr ""
-
-#: mod/profiles.php:371
-msgid "XMPP"
-msgstr ""
-
-#: mod/profiles.php:375
-msgid "Homepage"
-msgstr ""
-
-#: mod/profiles.php:379 mod/profiles.php:698
-msgid "Interests"
-msgstr ""
-
-#: mod/profiles.php:383
-msgid "Address"
-msgstr ""
-
-#: mod/profiles.php:390 mod/profiles.php:694
-msgid "Location"
-msgstr ""
-
-#: mod/profiles.php:475
-msgid "Profile updated."
-msgstr ""
-
-#: mod/profiles.php:567
-msgid " and "
-msgstr ""
-
-#: mod/profiles.php:576
-msgid "public profile"
-msgstr ""
-
-#: mod/profiles.php:579
+#: mod/register.php:100
 #, php-format
-msgid "%1$s changed %2$s to &ldquo;%3$s&rdquo;"
-msgstr ""
-
-#: mod/profiles.php:580
-#, php-format
-msgid " - Visit %1$s's %2$s"
-msgstr ""
-
-#: mod/profiles.php:582
-#, php-format
-msgid "%1$s has an updated %2$s, changing %3$s."
-msgstr ""
-
-#: mod/profiles.php:640
-msgid "Hide contacts and friends:"
-msgstr ""
-
-#: mod/profiles.php:645
-msgid "Hide your contact/friend list from viewers of this profile?"
-msgstr ""
-
-#: mod/profiles.php:670
-msgid "Show more profile fields:"
-msgstr ""
-
-#: mod/profiles.php:682
-msgid "Profile Actions"
-msgstr ""
-
-#: mod/profiles.php:683
-msgid "Edit Profile Details"
-msgstr ""
-
-#: mod/profiles.php:685
-msgid "Change Profile Photo"
-msgstr ""
-
-#: mod/profiles.php:686
-msgid "View this profile"
-msgstr ""
-
-#: mod/profiles.php:688
-msgid "Create a new profile using these settings"
-msgstr ""
-
-#: mod/profiles.php:689
-msgid "Clone this profile"
-msgstr ""
-
-#: mod/profiles.php:690
-msgid "Delete this profile"
-msgstr ""
-
-#: mod/profiles.php:692
-msgid "Basic information"
-msgstr ""
-
-#: mod/profiles.php:693
-msgid "Profile picture"
-msgstr ""
-
-#: mod/profiles.php:695
-msgid "Preferences"
-msgstr ""
-
-#: mod/profiles.php:696
-msgid "Status information"
-msgstr ""
-
-#: mod/profiles.php:697
-msgid "Additional information"
-msgstr ""
-
-#: mod/profiles.php:700
-msgid "Relation"
-msgstr ""
-
-#: mod/profiles.php:704
-msgid "Your Gender:"
-msgstr ""
-
-#: mod/profiles.php:705
-msgid "<span class=\"heart\">&hearts;</span> Marital Status:"
-msgstr ""
-
-#: mod/profiles.php:707
-msgid "Example: fishing photography software"
-msgstr ""
-
-#: mod/profiles.php:712
-msgid "Profile Name:"
-msgstr ""
-
-#: mod/profiles.php:714
 msgid ""
-"This is your <strong>public</strong> profile.<br />It <strong>may</strong> "
-"be visible to anybody using the internet."
+"Failed to send email message. Here your accout details:<br> login: %s<br> "
+"password: %s<br><br>You can change your password after login."
 msgstr ""
 
-#: mod/profiles.php:715
-msgid "Your Full Name:"
+#: mod/register.php:107
+msgid "Registration successful."
 msgstr ""
 
-#: mod/profiles.php:716
-msgid "Title/Description:"
+#: mod/register.php:113
+msgid "Your registration can not be processed."
 msgstr ""
 
-#: mod/profiles.php:719
-msgid "Street Address:"
+#: mod/register.php:162
+msgid "Your registration is pending approval by the site owner."
 msgstr ""
 
-#: mod/profiles.php:720
-msgid "Locality/City:"
-msgstr ""
-
-#: mod/profiles.php:721
-msgid "Region/State:"
-msgstr ""
-
-#: mod/profiles.php:722
-msgid "Postal/Zip Code:"
-msgstr ""
-
-#: mod/profiles.php:723
-msgid "Country:"
-msgstr ""
-
-#: mod/profiles.php:727
-msgid "Who: (if applicable)"
-msgstr ""
-
-#: mod/profiles.php:727
-msgid "Examples: cathy123, Cathy Williams, cathy@example.com"
-msgstr ""
-
-#: mod/profiles.php:728
-msgid "Since [date]:"
-msgstr ""
-
-#: mod/profiles.php:730
-msgid "Tell us about yourself..."
-msgstr ""
-
-#: mod/profiles.php:731
-msgid "XMPP (Jabber) address:"
-msgstr ""
-
-#: mod/profiles.php:731
+#: mod/register.php:228
 msgid ""
-"The XMPP address will be propagated to your contacts so that they can follow "
-"you."
+"You may (optionally) fill in this form via OpenID by supplying your OpenID "
+"and clicking 'Register'."
 msgstr ""
 
-#: mod/profiles.php:732
-msgid "Homepage URL:"
+#: mod/register.php:229
+msgid ""
+"If you are not familiar with OpenID, please leave that field blank and fill "
+"in the rest of the items."
 msgstr ""
 
-#: mod/profiles.php:735
-msgid "Religious Views:"
+#: mod/register.php:230
+msgid "Your OpenID (optional): "
 msgstr ""
 
-#: mod/profiles.php:736
-msgid "Public Keywords:"
+#: mod/register.php:244
+msgid "Include your profile in member directory?"
 msgstr ""
 
-#: mod/profiles.php:736
-msgid "(Used for suggesting potential friends, can be seen by others)"
+#: mod/register.php:269
+msgid "Note for the admin"
 msgstr ""
 
-#: mod/profiles.php:737
-msgid "Private Keywords:"
+#: mod/register.php:269
+msgid "Leave a message for the admin, why you want to join this node"
 msgstr ""
 
-#: mod/profiles.php:737
-msgid "(Used for searching profiles, never shown to others)"
+#: mod/register.php:270
+msgid "Membership on this site is by invitation only."
 msgstr ""
 
-#: mod/profiles.php:740
-msgid "Musical interests"
+#: mod/register.php:271
+msgid "Your invitation ID: "
 msgstr ""
 
-#: mod/profiles.php:741
-msgid "Books, literature"
+#: mod/register.php:274 mod/admin.php:1062
+msgid "Registration"
 msgstr ""
 
-#: mod/profiles.php:742
-msgid "Television"
+#: mod/register.php:282
+msgid "Your Full Name (e.g. Joe Smith, real or real-looking): "
 msgstr ""
 
-#: mod/profiles.php:743
-msgid "Film/dance/culture/entertainment"
+#: mod/register.php:283
+msgid "Your Email Address: "
 msgstr ""
 
-#: mod/profiles.php:744
-msgid "Hobbies/Interests"
+#: mod/register.php:285 mod/settings.php:1279
+msgid "New Password:"
 msgstr ""
 
-#: mod/profiles.php:745
-msgid "Love/romance"
+#: mod/register.php:285
+msgid "Leave empty for an auto generated password."
 msgstr ""
 
-#: mod/profiles.php:746
-msgid "Work/employment"
+#: mod/register.php:286 mod/settings.php:1280
+msgid "Confirm:"
 msgstr ""
 
-#: mod/profiles.php:747
-msgid "School/education"
+#: mod/register.php:287
+msgid ""
+"Choose a profile nickname. This must begin with a text character. Your "
+"profile address on this site will then be '<strong>nickname@$sitename</"
+"strong>'."
 msgstr ""
 
-#: mod/profiles.php:748
-msgid "Contact information and Social Networks"
+#: mod/register.php:288
+msgid "Choose a nickname: "
 msgstr ""
 
-#: mod/profiles.php:789
-msgid "Edit/Manage Profiles"
+#: mod/register.php:298
+msgid "Import your profile to this friendica instance"
+msgstr ""
+
+#: mod/search.php:103
+msgid "Only logged in users are permitted to perform a search."
+msgstr ""
+
+#: mod/search.php:127
+msgid "Too Many Requests"
+msgstr ""
+
+#: mod/search.php:128
+msgid "Only one search per minute is permitted for not logged in users."
+msgstr ""
+
+#: mod/search.php:228
+#, php-format
+msgid "Items tagged with: %s"
+msgstr ""
+
+#: mod/settings.php:45 mod/admin.php:1496
+msgid "Account"
+msgstr ""
+
+#: mod/settings.php:54 mod/admin.php:170
+msgid "Additional features"
+msgstr ""
+
+#: mod/settings.php:62
+msgid "Display"
+msgstr ""
+
+#: mod/settings.php:69 mod/settings.php:891
+msgid "Social Networks"
+msgstr ""
+
+#: mod/settings.php:76 mod/admin.php:168 mod/admin.php:1622 mod/admin.php:1685
+msgid "Plugins"
+msgstr ""
+
+#: mod/settings.php:90
+msgid "Connected apps"
+msgstr ""
+
+#: mod/settings.php:104
+msgid "Remove account"
+msgstr ""
+
+#: mod/settings.php:159
+msgid "Missing some important data!"
+msgstr ""
+
+#: mod/settings.php:273
+msgid "Failed to connect with email account using the settings provided."
+msgstr ""
+
+#: mod/settings.php:278
+msgid "Email settings updated."
+msgstr ""
+
+#: mod/settings.php:293
+msgid "Features updated"
+msgstr ""
+
+#: mod/settings.php:363
+msgid "Relocate message has been send to your contacts"
+msgstr ""
+
+#: mod/settings.php:382
+msgid "Empty passwords are not allowed. Password unchanged."
+msgstr ""
+
+#: mod/settings.php:390
+msgid "Wrong password."
+msgstr ""
+
+#: mod/settings.php:401
+msgid "Password changed."
+msgstr ""
+
+#: mod/settings.php:403
+msgid "Password update failed. Please try again."
+msgstr ""
+
+#: mod/settings.php:483
+msgid " Please use a shorter name."
+msgstr ""
+
+#: mod/settings.php:485
+msgid " Name too short."
+msgstr ""
+
+#: mod/settings.php:494
+msgid "Wrong Password"
+msgstr ""
+
+#: mod/settings.php:499
+msgid " Not valid email."
+msgstr ""
+
+#: mod/settings.php:505
+msgid " Cannot change to that email."
+msgstr ""
+
+#: mod/settings.php:561
+msgid "Private forum has no privacy permissions. Using default privacy group."
+msgstr ""
+
+#: mod/settings.php:565
+msgid "Private forum has no privacy permissions and no default privacy group."
+msgstr ""
+
+#: mod/settings.php:605
+msgid "Settings updated."
+msgstr ""
+
+#: mod/settings.php:681 mod/settings.php:707 mod/settings.php:743
+msgid "Add application"
+msgstr ""
+
+#: mod/settings.php:682 mod/settings.php:793 mod/settings.php:842
+#: mod/settings.php:909 mod/settings.php:1006 mod/settings.php:1272
+#: mod/admin.php:1061 mod/admin.php:1686 mod/admin.php:1949 mod/admin.php:2023
+#: mod/admin.php:2176
+msgid "Save Settings"
+msgstr ""
+
+#: mod/settings.php:685 mod/settings.php:711
+msgid "Consumer Key"
+msgstr ""
+
+#: mod/settings.php:686 mod/settings.php:712
+msgid "Consumer Secret"
+msgstr ""
+
+#: mod/settings.php:687 mod/settings.php:713
+msgid "Redirect"
+msgstr ""
+
+#: mod/settings.php:688 mod/settings.php:714
+msgid "Icon url"
+msgstr ""
+
+#: mod/settings.php:699
+msgid "You can't edit this application."
+msgstr ""
+
+#: mod/settings.php:742
+msgid "Connected Apps"
+msgstr ""
+
+#: mod/settings.php:746
+msgid "Client key starts with"
+msgstr ""
+
+#: mod/settings.php:747
+msgid "No name"
+msgstr ""
+
+#: mod/settings.php:748
+msgid "Remove authorization"
+msgstr ""
+
+#: mod/settings.php:760
+msgid "No Plugin settings configured"
+msgstr ""
+
+#: mod/settings.php:769
+msgid "Plugin Settings"
+msgstr ""
+
+#: mod/settings.php:783 mod/admin.php:2165 mod/admin.php:2166
+msgid "Off"
+msgstr ""
+
+#: mod/settings.php:783 mod/admin.php:2165 mod/admin.php:2166
+msgid "On"
+msgstr ""
+
+#: mod/settings.php:791
+msgid "Additional Features"
+msgstr ""
+
+#: mod/settings.php:801 mod/settings.php:805
+msgid "General Social Media Settings"
+msgstr ""
+
+#: mod/settings.php:811
+msgid "Disable intelligent shortening"
+msgstr ""
+
+#: mod/settings.php:813
+msgid ""
+"Normally the system tries to find the best link to add to shortened posts. "
+"If this option is enabled then every shortened post will always point to the "
+"original friendica post."
+msgstr ""
+
+#: mod/settings.php:819
+msgid "Automatically follow any GNU Social (OStatus) followers/mentioners"
+msgstr ""
+
+#: mod/settings.php:821
+msgid ""
+"If you receive a message from an unknown OStatus user, this option decides "
+"what to do. If it is checked, a new contact will be created for every "
+"unknown user."
+msgstr ""
+
+#: mod/settings.php:827
+msgid "Default group for OStatus contacts"
+msgstr ""
+
+#: mod/settings.php:835
+msgid "Your legacy GNU Social account"
+msgstr ""
+
+#: mod/settings.php:837
+msgid ""
+"If you enter your old GNU Social/Statusnet account name here (in the format "
+"user@domain.tld), your contacts will be added automatically. The field will "
+"be emptied when done."
+msgstr ""
+
+#: mod/settings.php:840
+msgid "Repair OStatus subscriptions"
+msgstr ""
+
+#: mod/settings.php:849 mod/settings.php:850
+#, php-format
+msgid "Built-in support for %s connectivity is %s"
+msgstr ""
+
+#: mod/settings.php:849 mod/settings.php:850
+msgid "enabled"
+msgstr ""
+
+#: mod/settings.php:849 mod/settings.php:850
+msgid "disabled"
+msgstr ""
+
+#: mod/settings.php:850
+msgid "GNU Social (OStatus)"
+msgstr ""
+
+#: mod/settings.php:884
+msgid "Email access is disabled on this site."
+msgstr ""
+
+#: mod/settings.php:896
+msgid "Email/Mailbox Setup"
+msgstr ""
+
+#: mod/settings.php:897
+msgid ""
+"If you wish to communicate with email contacts using this service "
+"(optional), please specify how to connect to your mailbox."
+msgstr ""
+
+#: mod/settings.php:898
+msgid "Last successful email check:"
+msgstr ""
+
+#: mod/settings.php:900
+msgid "IMAP server name:"
+msgstr ""
+
+#: mod/settings.php:901
+msgid "IMAP port:"
+msgstr ""
+
+#: mod/settings.php:902
+msgid "Security:"
+msgstr ""
+
+#: mod/settings.php:902 mod/settings.php:907
+msgid "None"
+msgstr ""
+
+#: mod/settings.php:903
+msgid "Email login name:"
+msgstr ""
+
+#: mod/settings.php:904
+msgid "Email password:"
+msgstr ""
+
+#: mod/settings.php:905
+msgid "Reply-to address:"
+msgstr ""
+
+#: mod/settings.php:906
+msgid "Send public posts to all email contacts:"
+msgstr ""
+
+#: mod/settings.php:907
+msgid "Action after import:"
+msgstr ""
+
+#: mod/settings.php:907
+msgid "Move to folder"
+msgstr ""
+
+#: mod/settings.php:908
+msgid "Move to folder:"
+msgstr ""
+
+#: mod/settings.php:944 mod/admin.php:948
+msgid "No special theme for mobile devices"
+msgstr ""
+
+#: mod/settings.php:1004
+msgid "Display Settings"
+msgstr ""
+
+#: mod/settings.php:1010 mod/settings.php:1033
+msgid "Display Theme:"
+msgstr ""
+
+#: mod/settings.php:1011
+msgid "Mobile Theme:"
+msgstr ""
+
+#: mod/settings.php:1012
+msgid "Suppress warning of insecure networks"
+msgstr ""
+
+#: mod/settings.php:1012
+msgid ""
+"Should the system suppress the warning that the current group contains "
+"members of networks that can't receive non public postings."
+msgstr ""
+
+#: mod/settings.php:1013
+msgid "Update browser every xx seconds"
+msgstr ""
+
+#: mod/settings.php:1013
+msgid "Minimum of 10 seconds. Enter -1 to disable it."
+msgstr ""
+
+#: mod/settings.php:1014
+msgid "Number of items to display per page:"
+msgstr ""
+
+#: mod/settings.php:1014 mod/settings.php:1015
+msgid "Maximum of 100 items"
+msgstr ""
+
+#: mod/settings.php:1015
+msgid "Number of items to display per page when viewed from mobile device:"
+msgstr ""
+
+#: mod/settings.php:1016
+msgid "Don't show emoticons"
+msgstr ""
+
+#: mod/settings.php:1017
+msgid "Calendar"
+msgstr ""
+
+#: mod/settings.php:1018
+msgid "Beginning of week:"
+msgstr ""
+
+#: mod/settings.php:1019
+msgid "Don't show notices"
+msgstr ""
+
+#: mod/settings.php:1020
+msgid "Infinite scroll"
+msgstr ""
+
+#: mod/settings.php:1021
+msgid "Automatic updates only at the top of the network page"
+msgstr ""
+
+#: mod/settings.php:1022
+msgid "Bandwith Saver Mode"
+msgstr ""
+
+#: mod/settings.php:1022
+msgid ""
+"When enabled, embedded content is not displayed on automatic updates, they "
+"only show on page reload."
+msgstr ""
+
+#: mod/settings.php:1024
+msgid "General Theme Settings"
+msgstr ""
+
+#: mod/settings.php:1025
+msgid "Custom Theme Settings"
+msgstr ""
+
+#: mod/settings.php:1026
+msgid "Content Settings"
+msgstr ""
+
+#: mod/settings.php:1027 view/theme/duepuntozero/config.php:66
+#: view/theme/frio/config.php:69 view/theme/quattro/config.php:72
+#: view/theme/vier/config.php:115
+msgid "Theme settings"
+msgstr ""
+
+#: mod/settings.php:1111
+msgid "Account Types"
+msgstr ""
+
+#: mod/settings.php:1112
+msgid "Personal Page Subtypes"
+msgstr ""
+
+#: mod/settings.php:1113
+msgid "Community Forum Subtypes"
+msgstr ""
+
+#: mod/settings.php:1120
+msgid "Personal Page"
+msgstr ""
+
+#: mod/settings.php:1121
+msgid "Account for a personal profile."
+msgstr ""
+
+#: mod/settings.php:1124
+msgid "Organisation Page"
+msgstr ""
+
+#: mod/settings.php:1125
+msgid ""
+"Account for an organisation that automatically approves contact requests as "
+"\"Followers\"."
+msgstr ""
+
+#: mod/settings.php:1128
+msgid "News Page"
+msgstr ""
+
+#: mod/settings.php:1129
+msgid ""
+"Account for a news reflector that automatically approves contact requests as "
+"\"Followers\"."
+msgstr ""
+
+#: mod/settings.php:1132
+msgid "Community Forum"
+msgstr ""
+
+#: mod/settings.php:1133
+msgid "Account for community discussions."
+msgstr ""
+
+#: mod/settings.php:1136
+msgid "Normal Account Page"
+msgstr ""
+
+#: mod/settings.php:1137
+msgid ""
+"Account for a regular personal profile that requires manual approval of "
+"\"Friends\" and \"Followers\"."
+msgstr ""
+
+#: mod/settings.php:1140
+msgid "Soapbox Page"
+msgstr ""
+
+#: mod/settings.php:1141
+msgid ""
+"Account for a public profile that automatically approves contact requests as "
+"\"Followers\"."
+msgstr ""
+
+#: mod/settings.php:1144
+msgid "Public Forum"
+msgstr ""
+
+#: mod/settings.php:1145
+msgid "Automatically approves all contact requests."
+msgstr ""
+
+#: mod/settings.php:1148
+msgid "Automatic Friend Page"
+msgstr ""
+
+#: mod/settings.php:1149
+msgid ""
+"Account for a popular profile that automatically approves contact requests "
+"as \"Friends\"."
+msgstr ""
+
+#: mod/settings.php:1152
+msgid "Private Forum [Experimental]"
+msgstr ""
+
+#: mod/settings.php:1153
+msgid "Requires manual approval of contact requests."
+msgstr ""
+
+#: mod/settings.php:1164
+msgid "OpenID:"
+msgstr ""
+
+#: mod/settings.php:1164
+msgid "(Optional) Allow this OpenID to login to this account."
+msgstr ""
+
+#: mod/settings.php:1172
+msgid "Publish your default profile in your local site directory?"
+msgstr ""
+
+#: mod/settings.php:1172
+msgid "Your profile may be visible in public."
+msgstr ""
+
+#: mod/settings.php:1178
+msgid "Publish your default profile in the global social directory?"
+msgstr ""
+
+#: mod/settings.php:1185
+msgid "Hide your contact/friend list from viewers of your default profile?"
+msgstr ""
+
+#: mod/settings.php:1189
+msgid ""
+"If enabled, posting public messages to Diaspora and other networks isn't "
+"possible."
+msgstr ""
+
+#: mod/settings.php:1194
+msgid "Allow friends to post to your profile page?"
+msgstr ""
+
+#: mod/settings.php:1199
+msgid "Allow friends to tag your posts?"
+msgstr ""
+
+#: mod/settings.php:1204
+msgid "Allow us to suggest you as a potential friend to new members?"
+msgstr ""
+
+#: mod/settings.php:1209
+msgid "Permit unknown people to send you private mail?"
+msgstr ""
+
+#: mod/settings.php:1217
+msgid "Profile is <strong>not published</strong>."
+msgstr ""
+
+#: mod/settings.php:1225
+#, php-format
+msgid "Your Identity Address is <strong>'%s'</strong> or '%s'."
+msgstr ""
+
+#: mod/settings.php:1232
+msgid "Automatically expire posts after this many days:"
+msgstr ""
+
+#: mod/settings.php:1232
+msgid "If empty, posts will not expire. Expired posts will be deleted"
+msgstr ""
+
+#: mod/settings.php:1233
+msgid "Advanced expiration settings"
+msgstr ""
+
+#: mod/settings.php:1234
+msgid "Advanced Expiration"
+msgstr ""
+
+#: mod/settings.php:1235
+msgid "Expire posts:"
+msgstr ""
+
+#: mod/settings.php:1236
+msgid "Expire personal notes:"
+msgstr ""
+
+#: mod/settings.php:1237
+msgid "Expire starred posts:"
+msgstr ""
+
+#: mod/settings.php:1238
+msgid "Expire photos:"
+msgstr ""
+
+#: mod/settings.php:1239
+msgid "Only expire posts by others:"
+msgstr ""
+
+#: mod/settings.php:1270
+msgid "Account Settings"
+msgstr ""
+
+#: mod/settings.php:1278
+msgid "Password Settings"
+msgstr ""
+
+#: mod/settings.php:1280
+msgid "Leave password fields blank unless changing"
+msgstr ""
+
+#: mod/settings.php:1281
+msgid "Current Password:"
+msgstr ""
+
+#: mod/settings.php:1281 mod/settings.php:1282
+msgid "Your current password to confirm the changes"
+msgstr ""
+
+#: mod/settings.php:1282
+msgid "Password:"
+msgstr ""
+
+#: mod/settings.php:1286
+msgid "Basic Settings"
+msgstr ""
+
+#: mod/settings.php:1288
+msgid "Email Address:"
+msgstr ""
+
+#: mod/settings.php:1289
+msgid "Your Timezone:"
+msgstr ""
+
+#: mod/settings.php:1290
+msgid "Your Language:"
+msgstr ""
+
+#: mod/settings.php:1290
+msgid ""
+"Set the language we use to show you friendica interface and to send you "
+"emails"
+msgstr ""
+
+#: mod/settings.php:1291
+msgid "Default Post Location:"
+msgstr ""
+
+#: mod/settings.php:1292
+msgid "Use Browser Location:"
+msgstr ""
+
+#: mod/settings.php:1295
+msgid "Security and Privacy Settings"
+msgstr ""
+
+#: mod/settings.php:1297
+msgid "Maximum Friend Requests/Day:"
+msgstr ""
+
+#: mod/settings.php:1297 mod/settings.php:1327
+msgid "(to prevent spam abuse)"
+msgstr ""
+
+#: mod/settings.php:1298
+msgid "Default Post Permissions"
+msgstr ""
+
+#: mod/settings.php:1299
+msgid "(click to open/close)"
+msgstr ""
+
+#: mod/settings.php:1310
+msgid "Default Private Post"
+msgstr ""
+
+#: mod/settings.php:1311
+msgid "Default Public Post"
+msgstr ""
+
+#: mod/settings.php:1315
+msgid "Default Permissions for New Posts"
+msgstr ""
+
+#: mod/settings.php:1327
+msgid "Maximum private messages per day from unknown people:"
+msgstr ""
+
+#: mod/settings.php:1330
+msgid "Notification Settings"
+msgstr ""
+
+#: mod/settings.php:1331
+msgid "By default post a status message when:"
+msgstr ""
+
+#: mod/settings.php:1332
+msgid "accepting a friend request"
+msgstr ""
+
+#: mod/settings.php:1333
+msgid "joining a forum/community"
+msgstr ""
+
+#: mod/settings.php:1334
+msgid "making an <em>interesting</em> profile change"
+msgstr ""
+
+#: mod/settings.php:1335
+msgid "Send a notification email when:"
+msgstr ""
+
+#: mod/settings.php:1336
+msgid "You receive an introduction"
+msgstr ""
+
+#: mod/settings.php:1337
+msgid "Your introductions are confirmed"
+msgstr ""
+
+#: mod/settings.php:1338
+msgid "Someone writes on your profile wall"
+msgstr ""
+
+#: mod/settings.php:1339
+msgid "Someone writes a followup comment"
+msgstr ""
+
+#: mod/settings.php:1340
+msgid "You receive a private message"
+msgstr ""
+
+#: mod/settings.php:1341
+msgid "You receive a friend suggestion"
+msgstr ""
+
+#: mod/settings.php:1342
+msgid "You are tagged in a post"
+msgstr ""
+
+#: mod/settings.php:1343
+msgid "You are poked/prodded/etc. in a post"
+msgstr ""
+
+#: mod/settings.php:1345
+msgid "Activate desktop notifications"
+msgstr ""
+
+#: mod/settings.php:1345
+msgid "Show desktop popup on new notifications"
+msgstr ""
+
+#: mod/settings.php:1347
+msgid "Text-only notification emails"
+msgstr ""
+
+#: mod/settings.php:1349
+msgid "Send text only notification emails, without the html part"
+msgstr ""
+
+#: mod/settings.php:1351
+msgid "Advanced Account/Page Type Settings"
+msgstr ""
+
+#: mod/settings.php:1352
+msgid "Change the behaviour of this account for special situations"
+msgstr ""
+
+#: mod/settings.php:1355
+msgid "Relocate"
+msgstr ""
+
+#: mod/settings.php:1356
+msgid ""
+"If you have moved this profile from another server, and some of your "
+"contacts don't receive your updates, try pushing this button."
+msgstr ""
+
+#: mod/settings.php:1357
+msgid "Resend relocate message to contacts"
 msgstr ""
 
 #: mod/admin.php:97
@@ -6622,16 +7379,8 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: mod/admin.php:168 mod/admin.php:1622 mod/admin.php:1685 mod/settings.php:76
-msgid "Plugins"
-msgstr ""
-
 #: mod/admin.php:169 mod/admin.php:1898 mod/admin.php:1948
 msgid "Themes"
-msgstr ""
-
-#: mod/admin.php:170 mod/settings.php:54
-msgid "Additional features"
 msgstr ""
 
 #: mod/admin.php:171
@@ -6831,11 +7580,11 @@ msgid "Normal Account"
 msgstr ""
 
 #: mod/admin.php:561 mod/admin.php:1454
-msgid "Soapbox Account"
+msgid "Automatic Follower Account"
 msgstr ""
 
 #: mod/admin.php:562 mod/admin.php:1455
-msgid "Community/Celebrity Account"
+msgid "Public Forum Account"
 msgstr ""
 
 #: mod/admin.php:563 mod/admin.php:1456
@@ -6847,7 +7596,7 @@ msgid "Blog Account"
 msgstr ""
 
 #: mod/admin.php:565
-msgid "Private Forum"
+msgid "Private Forum Account"
 msgstr ""
 
 #: mod/admin.php:587
@@ -6880,10 +7629,6 @@ msgstr ""
 
 #: mod/admin.php:920
 msgid "Site settings updated."
-msgstr ""
-
-#: mod/admin.php:948 mod/settings.php:944
-msgid "No special theme for mobile devices"
 msgstr ""
 
 #: mod/admin.php:977
@@ -6952,13 +7697,6 @@ msgstr ""
 
 #: mod/admin.php:1039
 msgid "Self-signed certificate, use SSL for local links only (discouraged)"
-msgstr ""
-
-#: mod/admin.php:1061 mod/admin.php:1686 mod/admin.php:1949 mod/admin.php:2023
-#: mod/admin.php:2176 mod/settings.php:682 mod/settings.php:793
-#: mod/settings.php:842 mod/settings.php:909 mod/settings.php:1006
-#: mod/settings.php:1272
-msgid "Save Settings"
 msgstr ""
 
 #: mod/admin.php:1063
@@ -7789,10 +8527,6 @@ msgstr ""
 msgid "Last item"
 msgstr ""
 
-#: mod/admin.php:1496 mod/settings.php:45
-msgid "Account"
-msgstr ""
-
 #: mod/admin.php:1505
 msgid "Add User"
 msgstr ""
@@ -7983,14 +8717,6 @@ msgid ""
 "'display_errors' is to enable these options, set to '0' to disable them."
 msgstr ""
 
-#: mod/admin.php:2165 mod/admin.php:2166 mod/settings.php:783
-msgid "Off"
-msgstr ""
-
-#: mod/admin.php:2165 mod/admin.php:2166 mod/settings.php:783
-msgid "On"
-msgstr ""
-
 #: mod/admin.php:2166
 #, php-format
 msgid "Lock feature %s"
@@ -8000,731 +8726,16 @@ msgstr ""
 msgid "Manage Additional Features"
 msgstr ""
 
-#: mod/settings.php:62
-msgid "Display"
-msgstr ""
-
-#: mod/settings.php:69 mod/settings.php:891
-msgid "Social Networks"
-msgstr ""
-
-#: mod/settings.php:90
-msgid "Connected apps"
-msgstr ""
-
-#: mod/settings.php:104
-msgid "Remove account"
-msgstr ""
-
-#: mod/settings.php:159
-msgid "Missing some important data!"
-msgstr ""
-
-#: mod/settings.php:273
-msgid "Failed to connect with email account using the settings provided."
-msgstr ""
-
-#: mod/settings.php:278
-msgid "Email settings updated."
-msgstr ""
-
-#: mod/settings.php:293
-msgid "Features updated"
-msgstr ""
-
-#: mod/settings.php:363
-msgid "Relocate message has been send to your contacts"
-msgstr ""
-
-#: mod/settings.php:382
-msgid "Empty passwords are not allowed. Password unchanged."
-msgstr ""
-
-#: mod/settings.php:390
-msgid "Wrong password."
-msgstr ""
-
-#: mod/settings.php:401
-msgid "Password changed."
-msgstr ""
-
-#: mod/settings.php:403
-msgid "Password update failed. Please try again."
-msgstr ""
-
-#: mod/settings.php:483
-msgid " Please use a shorter name."
-msgstr ""
-
-#: mod/settings.php:485
-msgid " Name too short."
-msgstr ""
-
-#: mod/settings.php:494
-msgid "Wrong Password"
-msgstr ""
-
-#: mod/settings.php:499
-msgid " Not valid email."
-msgstr ""
-
-#: mod/settings.php:505
-msgid " Cannot change to that email."
-msgstr ""
-
-#: mod/settings.php:561
-msgid "Private forum has no privacy permissions. Using default privacy group."
-msgstr ""
-
-#: mod/settings.php:565
-msgid "Private forum has no privacy permissions and no default privacy group."
-msgstr ""
-
-#: mod/settings.php:605
-msgid "Settings updated."
-msgstr ""
-
-#: mod/settings.php:681 mod/settings.php:707 mod/settings.php:743
-msgid "Add application"
-msgstr ""
-
-#: mod/settings.php:685 mod/settings.php:711
-msgid "Consumer Key"
-msgstr ""
-
-#: mod/settings.php:686 mod/settings.php:712
-msgid "Consumer Secret"
-msgstr ""
-
-#: mod/settings.php:687 mod/settings.php:713
-msgid "Redirect"
-msgstr ""
-
-#: mod/settings.php:688 mod/settings.php:714
-msgid "Icon url"
-msgstr ""
-
-#: mod/settings.php:699
-msgid "You can't edit this application."
-msgstr ""
-
-#: mod/settings.php:742
-msgid "Connected Apps"
-msgstr ""
-
-#: mod/settings.php:746
-msgid "Client key starts with"
-msgstr ""
-
-#: mod/settings.php:747
-msgid "No name"
-msgstr ""
-
-#: mod/settings.php:748
-msgid "Remove authorization"
-msgstr ""
-
-#: mod/settings.php:760
-msgid "No Plugin settings configured"
-msgstr ""
-
-#: mod/settings.php:769
-msgid "Plugin Settings"
-msgstr ""
-
-#: mod/settings.php:791
-msgid "Additional Features"
-msgstr ""
-
-#: mod/settings.php:801 mod/settings.php:805
-msgid "General Social Media Settings"
-msgstr ""
-
-#: mod/settings.php:811
-msgid "Disable intelligent shortening"
-msgstr ""
-
-#: mod/settings.php:813
-msgid ""
-"Normally the system tries to find the best link to add to shortened posts. "
-"If this option is enabled then every shortened post will always point to the "
-"original friendica post."
-msgstr ""
-
-#: mod/settings.php:819
-msgid "Automatically follow any GNU Social (OStatus) followers/mentioners"
-msgstr ""
-
-#: mod/settings.php:821
-msgid ""
-"If you receive a message from an unknown OStatus user, this option decides "
-"what to do. If it is checked, a new contact will be created for every "
-"unknown user."
-msgstr ""
-
-#: mod/settings.php:827
-msgid "Default group for OStatus contacts"
-msgstr ""
-
-#: mod/settings.php:835
-msgid "Your legacy GNU Social account"
-msgstr ""
-
-#: mod/settings.php:837
-msgid ""
-"If you enter your old GNU Social/Statusnet account name here (in the format "
-"user@domain.tld), your contacts will be added automatically. The field will "
-"be emptied when done."
-msgstr ""
-
-#: mod/settings.php:840
-msgid "Repair OStatus subscriptions"
-msgstr ""
-
-#: mod/settings.php:849 mod/settings.php:850
-#, php-format
-msgid "Built-in support for %s connectivity is %s"
-msgstr ""
-
-#: mod/settings.php:849 mod/settings.php:850
-msgid "enabled"
-msgstr ""
-
-#: mod/settings.php:849 mod/settings.php:850
-msgid "disabled"
-msgstr ""
-
-#: mod/settings.php:850
-msgid "GNU Social (OStatus)"
-msgstr ""
-
-#: mod/settings.php:884
-msgid "Email access is disabled on this site."
-msgstr ""
-
-#: mod/settings.php:896
-msgid "Email/Mailbox Setup"
-msgstr ""
-
-#: mod/settings.php:897
-msgid ""
-"If you wish to communicate with email contacts using this service "
-"(optional), please specify how to connect to your mailbox."
-msgstr ""
-
-#: mod/settings.php:898
-msgid "Last successful email check:"
-msgstr ""
-
-#: mod/settings.php:900
-msgid "IMAP server name:"
-msgstr ""
-
-#: mod/settings.php:901
-msgid "IMAP port:"
-msgstr ""
-
-#: mod/settings.php:902
-msgid "Security:"
-msgstr ""
-
-#: mod/settings.php:902 mod/settings.php:907
-msgid "None"
-msgstr ""
-
-#: mod/settings.php:903
-msgid "Email login name:"
-msgstr ""
-
-#: mod/settings.php:904
-msgid "Email password:"
-msgstr ""
-
-#: mod/settings.php:905
-msgid "Reply-to address:"
-msgstr ""
-
-#: mod/settings.php:906
-msgid "Send public posts to all email contacts:"
-msgstr ""
-
-#: mod/settings.php:907
-msgid "Action after import:"
-msgstr ""
-
-#: mod/settings.php:907
-msgid "Move to folder"
-msgstr ""
-
-#: mod/settings.php:908
-msgid "Move to folder:"
-msgstr ""
-
-#: mod/settings.php:1004
-msgid "Display Settings"
-msgstr ""
-
-#: mod/settings.php:1010 mod/settings.php:1033
-msgid "Display Theme:"
-msgstr ""
-
-#: mod/settings.php:1011
-msgid "Mobile Theme:"
-msgstr ""
-
-#: mod/settings.php:1012
-msgid "Suppress warning of insecure networks"
-msgstr ""
-
-#: mod/settings.php:1012
-msgid ""
-"Should the system suppress the warning that the current group contains "
-"members of networks that can't receive non public postings."
-msgstr ""
-
-#: mod/settings.php:1013
-msgid "Update browser every xx seconds"
-msgstr ""
-
-#: mod/settings.php:1013
-msgid "Minimum of 10 seconds. Enter -1 to disable it."
-msgstr ""
-
-#: mod/settings.php:1014
-msgid "Number of items to display per page:"
-msgstr ""
-
-#: mod/settings.php:1014 mod/settings.php:1015
-msgid "Maximum of 100 items"
-msgstr ""
-
-#: mod/settings.php:1015
-msgid "Number of items to display per page when viewed from mobile device:"
-msgstr ""
-
-#: mod/settings.php:1016
-msgid "Don't show emoticons"
-msgstr ""
-
-#: mod/settings.php:1017
-msgid "Calendar"
-msgstr ""
-
-#: mod/settings.php:1018
-msgid "Beginning of week:"
-msgstr ""
-
-#: mod/settings.php:1019
-msgid "Don't show notices"
-msgstr ""
-
-#: mod/settings.php:1020
-msgid "Infinite scroll"
-msgstr ""
-
-#: mod/settings.php:1021
-msgid "Automatic updates only at the top of the network page"
-msgstr ""
-
-#: mod/settings.php:1022
-msgid "Bandwith Saver Mode"
-msgstr ""
-
-#: mod/settings.php:1022
-msgid ""
-"When enabled, embedded content is not displayed on automatic updates, they "
-"only show on page reload."
-msgstr ""
-
-#: mod/settings.php:1024
-msgid "General Theme Settings"
-msgstr ""
-
-#: mod/settings.php:1025
-msgid "Custom Theme Settings"
-msgstr ""
-
-#: mod/settings.php:1026
-msgid "Content Settings"
-msgstr ""
-
-#: mod/settings.php:1027 view/theme/duepuntozero/config.php:66
-#: view/theme/frio/config.php:69 view/theme/quattro/config.php:72
-#: view/theme/vier/config.php:115
-msgid "Theme settings"
-msgstr ""
-
-#: mod/settings.php:1111
-msgid "Account Types"
-msgstr ""
-
-#: mod/settings.php:1112
-msgid "Personal Page Subtypes"
-msgstr ""
-
-#: mod/settings.php:1113
-msgid "Community Forum Subtypes"
-msgstr ""
-
-#: mod/settings.php:1120
-msgid "Personal Page"
-msgstr ""
-
-#: mod/settings.php:1121
-msgid "Account for a personal profile."
-msgstr ""
-
-#: mod/settings.php:1124
-msgid "Organisation Page"
-msgstr ""
-
-#: mod/settings.php:1125
-msgid ""
-"Account for an organisation that automatically approves contact requests as "
-"\"Followers\"."
-msgstr ""
-
-#: mod/settings.php:1128
-msgid "News Page"
-msgstr ""
-
-#: mod/settings.php:1129
-msgid ""
-"Account for a news reflector that automatically approves contact requests as "
-"\"Followers\"."
-msgstr ""
-
-#: mod/settings.php:1132
-msgid "Community Forum"
-msgstr ""
-
-#: mod/settings.php:1133
-msgid "Account for community discussions."
-msgstr ""
-
-#: mod/settings.php:1136
-msgid "Normal Account Page"
-msgstr ""
-
-#: mod/settings.php:1137
-msgid ""
-"Account for a regular personal profile that requires manual approval of "
-"\"Friends\" and \"Followers\"."
-msgstr ""
-
-#: mod/settings.php:1140
-msgid "Soapbox Page"
-msgstr ""
-
-#: mod/settings.php:1141
-msgid ""
-"Account for a public profile that automatically approves contact requests as "
-"\"Followers\"."
-msgstr ""
-
-#: mod/settings.php:1144
-msgid "Public Forum"
-msgstr ""
-
-#: mod/settings.php:1145
-msgid "Automatically approves all contact requests."
-msgstr ""
-
-#: mod/settings.php:1148
-msgid "Automatic Friend Page"
-msgstr ""
-
-#: mod/settings.php:1149
-msgid ""
-"Account for a popular profile that automatically approves contact requests "
-"as \"Friends\"."
-msgstr ""
-
-#: mod/settings.php:1152
-msgid "Private Forum [Experimental]"
-msgstr ""
-
-#: mod/settings.php:1153
-msgid "Requires manual approval of contact requests."
-msgstr ""
-
-#: mod/settings.php:1164
-msgid "OpenID:"
-msgstr ""
-
-#: mod/settings.php:1164
-msgid "(Optional) Allow this OpenID to login to this account."
-msgstr ""
-
-#: mod/settings.php:1172
-msgid "Publish your default profile in your local site directory?"
-msgstr ""
-
-#: mod/settings.php:1172
-msgid "Your profile may be visible in public."
-msgstr ""
-
-#: mod/settings.php:1178
-msgid "Publish your default profile in the global social directory?"
-msgstr ""
-
-#: mod/settings.php:1185
-msgid "Hide your contact/friend list from viewers of your default profile?"
-msgstr ""
-
-#: mod/settings.php:1189
-msgid ""
-"If enabled, posting public messages to Diaspora and other networks isn't "
-"possible."
-msgstr ""
-
-#: mod/settings.php:1194
-msgid "Allow friends to post to your profile page?"
-msgstr ""
-
-#: mod/settings.php:1199
-msgid "Allow friends to tag your posts?"
-msgstr ""
-
-#: mod/settings.php:1204
-msgid "Allow us to suggest you as a potential friend to new members?"
-msgstr ""
-
-#: mod/settings.php:1209
-msgid "Permit unknown people to send you private mail?"
-msgstr ""
-
-#: mod/settings.php:1217
-msgid "Profile is <strong>not published</strong>."
-msgstr ""
-
-#: mod/settings.php:1225
-#, php-format
-msgid "Your Identity Address is <strong>'%s'</strong> or '%s'."
-msgstr ""
-
-#: mod/settings.php:1232
-msgid "Automatically expire posts after this many days:"
-msgstr ""
-
-#: mod/settings.php:1232
-msgid "If empty, posts will not expire. Expired posts will be deleted"
-msgstr ""
-
-#: mod/settings.php:1233
-msgid "Advanced expiration settings"
-msgstr ""
-
-#: mod/settings.php:1234
-msgid "Advanced Expiration"
-msgstr ""
-
-#: mod/settings.php:1235
-msgid "Expire posts:"
-msgstr ""
-
-#: mod/settings.php:1236
-msgid "Expire personal notes:"
-msgstr ""
-
-#: mod/settings.php:1237
-msgid "Expire starred posts:"
-msgstr ""
-
-#: mod/settings.php:1238
-msgid "Expire photos:"
-msgstr ""
-
-#: mod/settings.php:1239
-msgid "Only expire posts by others:"
-msgstr ""
-
-#: mod/settings.php:1270
-msgid "Account Settings"
-msgstr ""
-
-#: mod/settings.php:1278
-msgid "Password Settings"
-msgstr ""
-
-#: mod/settings.php:1280
-msgid "Leave password fields blank unless changing"
-msgstr ""
-
-#: mod/settings.php:1281
-msgid "Current Password:"
-msgstr ""
-
-#: mod/settings.php:1281 mod/settings.php:1282
-msgid "Your current password to confirm the changes"
-msgstr ""
-
-#: mod/settings.php:1282
-msgid "Password:"
-msgstr ""
-
-#: mod/settings.php:1286
-msgid "Basic Settings"
-msgstr ""
-
-#: mod/settings.php:1288
-msgid "Email Address:"
-msgstr ""
-
-#: mod/settings.php:1289
-msgid "Your Timezone:"
-msgstr ""
-
-#: mod/settings.php:1290
-msgid "Your Language:"
-msgstr ""
-
-#: mod/settings.php:1290
-msgid ""
-"Set the language we use to show you friendica interface and to send you "
-"emails"
-msgstr ""
-
-#: mod/settings.php:1291
-msgid "Default Post Location:"
-msgstr ""
-
-#: mod/settings.php:1292
-msgid "Use Browser Location:"
-msgstr ""
-
-#: mod/settings.php:1295
-msgid "Security and Privacy Settings"
-msgstr ""
-
-#: mod/settings.php:1297
-msgid "Maximum Friend Requests/Day:"
-msgstr ""
-
-#: mod/settings.php:1297 mod/settings.php:1327
-msgid "(to prevent spam abuse)"
-msgstr ""
-
-#: mod/settings.php:1298
-msgid "Default Post Permissions"
-msgstr ""
-
-#: mod/settings.php:1299
-msgid "(click to open/close)"
-msgstr ""
-
-#: mod/settings.php:1310
-msgid "Default Private Post"
-msgstr ""
-
-#: mod/settings.php:1311
-msgid "Default Public Post"
-msgstr ""
-
-#: mod/settings.php:1315
-msgid "Default Permissions for New Posts"
-msgstr ""
-
-#: mod/settings.php:1327
-msgid "Maximum private messages per day from unknown people:"
-msgstr ""
-
-#: mod/settings.php:1330
-msgid "Notification Settings"
-msgstr ""
-
-#: mod/settings.php:1331
-msgid "By default post a status message when:"
-msgstr ""
-
-#: mod/settings.php:1332
-msgid "accepting a friend request"
-msgstr ""
-
-#: mod/settings.php:1333
-msgid "joining a forum/community"
-msgstr ""
-
-#: mod/settings.php:1334
-msgid "making an <em>interesting</em> profile change"
-msgstr ""
-
-#: mod/settings.php:1335
-msgid "Send a notification email when:"
-msgstr ""
-
-#: mod/settings.php:1336
-msgid "You receive an introduction"
-msgstr ""
-
-#: mod/settings.php:1337
-msgid "Your introductions are confirmed"
-msgstr ""
-
-#: mod/settings.php:1338
-msgid "Someone writes on your profile wall"
-msgstr ""
-
-#: mod/settings.php:1339
-msgid "Someone writes a followup comment"
-msgstr ""
-
-#: mod/settings.php:1340
-msgid "You receive a private message"
-msgstr ""
-
-#: mod/settings.php:1341
-msgid "You receive a friend suggestion"
-msgstr ""
-
-#: mod/settings.php:1342
-msgid "You are tagged in a post"
-msgstr ""
-
-#: mod/settings.php:1343
-msgid "You are poked/prodded/etc. in a post"
-msgstr ""
-
-#: mod/settings.php:1345
-msgid "Activate desktop notifications"
-msgstr ""
-
-#: mod/settings.php:1345
-msgid "Show desktop popup on new notifications"
-msgstr ""
-
-#: mod/settings.php:1347
-msgid "Text-only notification emails"
-msgstr ""
-
-#: mod/settings.php:1349
-msgid "Send text only notification emails, without the html part"
-msgstr ""
-
-#: mod/settings.php:1351
-msgid "Advanced Account/Page Type Settings"
-msgstr ""
-
-#: mod/settings.php:1352
-msgid "Change the behaviour of this account for special situations"
-msgstr ""
-
-#: mod/settings.php:1355
-msgid "Relocate"
-msgstr ""
-
-#: mod/settings.php:1356
-msgid ""
-"If you have moved this profile from another server, and some of your "
-"contacts don't receive your updates, try pushing this button."
-msgstr ""
-
-#: mod/settings.php:1357
-msgid "Resend relocate message to contacts"
-msgstr ""
-
 #: object/Item.php:356
 msgid "via"
+msgstr ""
+
+#: src/App.php:506
+msgid "Delete this item?"
+msgstr ""
+
+#: src/App.php:508
+msgid "show fewer"
 msgstr ""
 
 #: view/theme/duepuntozero/config.php:47
@@ -8753,38 +8764,6 @@ msgstr ""
 
 #: view/theme/duepuntozero/config.php:67
 msgid "Variations"
-msgstr ""
-
-#: view/theme/frio/php/Image.php:23
-msgid "Repeat the image"
-msgstr ""
-
-#: view/theme/frio/php/Image.php:23
-msgid "Will repeat your image to fill the background."
-msgstr ""
-
-#: view/theme/frio/php/Image.php:25
-msgid "Stretch"
-msgstr ""
-
-#: view/theme/frio/php/Image.php:25
-msgid "Will stretch to width/height of the image."
-msgstr ""
-
-#: view/theme/frio/php/Image.php:27
-msgid "Resize fill and-clip"
-msgstr ""
-
-#: view/theme/frio/php/Image.php:27
-msgid "Resize to fill and retain aspect ratio."
-msgstr ""
-
-#: view/theme/frio/php/Image.php:29
-msgid "Resize best fit"
-msgstr ""
-
-#: view/theme/frio/php/Image.php:29
-msgid "Resize to best fit and retain aspect ratio."
 msgstr ""
 
 #: view/theme/frio/config.php:50
@@ -8825,6 +8804,38 @@ msgstr ""
 
 #: view/theme/frio/config.php:76
 msgid "Set the background image"
+msgstr ""
+
+#: view/theme/frio/php/Image.php:23
+msgid "Repeat the image"
+msgstr ""
+
+#: view/theme/frio/php/Image.php:23
+msgid "Will repeat your image to fill the background."
+msgstr ""
+
+#: view/theme/frio/php/Image.php:25
+msgid "Stretch"
+msgstr ""
+
+#: view/theme/frio/php/Image.php:25
+msgid "Will stretch to width/height of the image."
+msgstr ""
+
+#: view/theme/frio/php/Image.php:27
+msgid "Resize fill and-clip"
+msgstr ""
+
+#: view/theme/frio/php/Image.php:27
+msgid "Resize to fill and retain aspect ratio."
+msgstr ""
+
+#: view/theme/frio/php/Image.php:29
+msgid "Resize best fit"
+msgstr ""
+
+#: view/theme/frio/php/Image.php:29
+msgid "Resize to best fit and retain aspect ratio."
 msgstr ""
 
 #: view/theme/frio/theme.php:228
@@ -8899,55 +8910,47 @@ msgstr ""
 msgid "Quick Start"
 msgstr ""
 
-#: src/App.php:505
-msgid "Delete this item?"
-msgstr ""
-
-#: src/App.php:507
-msgid "show fewer"
-msgstr ""
-
-#: index.php:436
-msgid "toggle mobile"
-msgstr ""
-
-#: boot.php:733
+#: boot.php:735
 #, php-format
 msgid "Update %s failed. See error logs."
 msgstr ""
 
-#: boot.php:845
+#: boot.php:847
 msgid "Create a New Account"
 msgstr ""
 
-#: boot.php:873
+#: boot.php:875
 msgid "Password: "
 msgstr ""
 
-#: boot.php:874
+#: boot.php:876
 msgid "Remember me"
 msgstr ""
 
-#: boot.php:877
+#: boot.php:879
 msgid "Or login using OpenID: "
 msgstr ""
 
-#: boot.php:883
+#: boot.php:885
 msgid "Forgot your password?"
 msgstr ""
 
-#: boot.php:886
+#: boot.php:888
 msgid "Website Terms of Service"
 msgstr ""
 
-#: boot.php:887
+#: boot.php:889
 msgid "terms of service"
 msgstr ""
 
-#: boot.php:889
+#: boot.php:891
 msgid "Website Privacy Policy"
 msgstr ""
 
-#: boot.php:890
+#: boot.php:892
 msgid "privacy policy"
+msgstr ""
+
+#: index.php:436
+msgid "toggle mobile"
 msgstr ""


### PR DESCRIPTION
This patch tries to address the current inconsistency how different account types are _counted_ in the admin panel.

It replaces the specific type called "Soapbox" with a generic catch-all wording called "Automatic Follower". This is done because under the heading "Soapbox" other auto-follower accounts such as "News Page" in addition to 'Soapbox-proper' are also counted. 

The "Community/Celebrity Account" is renamed to the "Public Community Forum" as I believe that this merely counts such public forums as celebrity accounts current don't exist.
