### PR TITLE
Semaphore based locking and hopefully the fix for the workerqueue

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -42,7 +42,7 @@ define ( 'FRIENDICA_PLATFORM',     'Friendica');
 define ( 'FRIENDICA_CODENAME',     'Asparagus');
 define ( 'FRIENDICA_VERSION',      '3.5.3-dev' );
 define ( 'DFRN_PROTOCOL_VERSION',  '2.23'    );
-define ( 'DB_UPDATE_VERSION',      1230      );
+define ( 'DB_UPDATE_VERSION',      1231      );
 
 /**
  * @brief Constant with a HTML line break.

--- a/database.sql
+++ b/database.sql
@@ -1,6 +1,6 @@
 -- ------------------------------------------
--- Friendica 3.5.3dev (Asparagus)
--- DB_UPDATE_VERSION 1228
+-- Friendica 3.5.3-dev (Asparagus)
+-- DB_UPDATE_VERSION 1231
 -- ------------------------------------------
 
 
@@ -1114,9 +1114,11 @@ CREATE TABLE IF NOT EXISTS `workerqueue` (
 	`created` datetime NOT NULL DEFAULT '0001-01-01 00:00:00',
 	`pid` int(11) NOT NULL DEFAULT 0,
 	`executed` datetime NOT NULL DEFAULT '0001-01-01 00:00:00',
+	`done` tinyint(1) NOT NULL DEFAULT 0,
 	 PRIMARY KEY(`id`),
 	 INDEX `pid` (`pid`),
-	 INDEX `parameter` (`parameter`(192)),
-	 INDEX `priority_created` (`priority`,`created`)
+	 INDEX `parameter` (`parameter`(64)),
+	 INDEX `priority_created` (`priority`,`created`),
+	 INDEX `executed` (`executed`)
 ) DEFAULT COLLATE utf8mb4_general_ci;
 

--- a/include/cron.php
+++ b/include/cron.php
@@ -84,7 +84,7 @@ function cron_run(&$argv, &$argc){
 		proc_run(PRIORITY_LOW, "include/cronjobs.php", "update_photo_albums");
 
 		// Delete all done workerqueue entries
-		dba::delete('workerqueue', array('done' => true));
+		dba::e('DELETE FROM `workerqueue` WHERE `done` AND `executed` < UTC_TIMESTAMP() - INTERVAL 12 HOUR');
 	}
 
 	// Poll contacts

--- a/include/dbstructure.php
+++ b/include/dbstructure.php
@@ -1747,6 +1747,7 @@ function db_definition() {
 					"pid" => array("pid"),
 					"parameter" => array("parameter(64)"),
 					"priority_created" => array("priority", "created"),
+					"executed" => array("executed"),
 					)
 			);
 

--- a/src/Util/Lock.php
+++ b/src/Util/Lock.php
@@ -17,6 +17,8 @@ use dbm;
  * @brief This class contain Functions for preventing parallel execution of functions
  */
 class Lock {
+	private static $semaphore = array();
+
        /**
 	 * @brief Check for memcache and open a connection if configured
 	 *
@@ -44,6 +46,25 @@ class Lock {
 	}
 
 	/**
+	 * @brief Creates a semaphore key
+	 *
+	 * @param string $fn_name Name of the lock
+	 *
+	 * @return ressource the semaphore key
+	 */
+	private static function semaphore_key($fn_name) {
+		$temp = get_temppath();
+
+		$file = $temp.'/'.$fn_name.'.sem';
+
+		if (!file_exists($file)) {
+			file_put_contents($file, $function);
+		}
+
+		return ftok($file, 'f');
+	}
+
+	/**
 	 * @brief Sets a lock for a given name
 	 *
 	 * @param string $fn_name Name of the lock
@@ -54,6 +75,13 @@ class Lock {
 	public static function set($fn_name, $timeout = 120) {
 		$got_lock = false;
 		$start = time();
+
+		if (function_exists('sem_get')) {
+			self::$semaphore[$fn_name] = sem_get(self::semaphore_key($fn_name));
+			if (self::$semaphore[$fn_name]) {
+				return sem_acquire(self::$semaphore[$fn_name], ($timeout == 0));
+			}
+		}
 
 		$memcache = self::connectMemcache();
 		if (is_object($memcache)) {
@@ -128,6 +156,11 @@ class Lock {
 	 * @param string $fn_name Name of the lock
 	 */
 	public static function remove($fn_name) {
+		if (function_exists('sem_get') && self::$semaphore[$fn_name]) {
+			sem_release(self::$semaphore[$fn_name]);
+			return;
+		}
+
 		$memcache = self::connectMemcache();
 		if (is_object($memcache)) {
 			$cachekey = get_app()->get_hostname().";lock:".$fn_name;

--- a/update.php
+++ b/update.php
@@ -1,6 +1,6 @@
 <?php
 
-define('UPDATE_VERSION' , 1230);
+define('UPDATE_VERSION' , 1231);
 
 /**
  *
@@ -1728,4 +1728,9 @@ function update_1190() {
 function update_1202() {
 	$r = q("UPDATE `user` SET `account-type` = %d WHERE `page-flags` IN (%d, %d)",
 		dbesc(ACCOUNT_TYPE_COMMUNITY), dbesc(PAGE_COMMUNITY), dbesc(PAGE_PRVGROUP));
+}
+
+function update_1230() {
+	// For this special case we have to use the old update routine
+	$r = q("ALTER TABLE `workerqueue` ADD `done2` tinyint(1) NOT NULL DEFAULT 0");
 }


### PR DESCRIPTION
This PR should hopefully handle the case that we had a new field in the table structure of the "workerqueue" table but the update routine for this couldn't be started since we already relied on this new field before it was created.

Additionally the process locking now uses semaphores if available. This should be better than everything we had done before.