### PR TITLE
Split expire.php in several processes / small worker changes

### DIFF
--- a/include/cron.php
+++ b/include/cron.php
@@ -253,7 +253,7 @@ function cron_poll_contacts($argc, $argv) {
 			} else {
 				$priority = PRIORITY_LOW;
 			}
-			proc_run(array('priority' => $priority, 'dont_fork' => true), 'include/onepoll.php', intval($contact['id']));
+			proc_run(array('priority' => $priority, 'dont_fork' => true), 'include/onepoll.php', (int)$contact['id']);
 		}
 	}
 }

--- a/include/discover_poco.php
+++ b/include/discover_poco.php
@@ -47,13 +47,12 @@ function discover_poco_run(&$argv, &$argc) {
 	logger('start '.$search);
 
 	if ($mode == 8) {
-		$profile_url = base64_decode($argv[2]);
-		if ($profile_url != "") {
-			poco_last_updated($profile_url, true);
+		if ($argv[2] != "") {
+			poco_last_updated($argv[2], true);
 		}
 	} elseif ($mode == 7) {
 		if ($argc == 6) {
-			$url = base64_decode($argv[5]);
+			$url = $argv[5];
 		} else {
 			$url = '';
 		}
@@ -63,7 +62,7 @@ function discover_poco_run(&$argv, &$argc) {
 	} elseif ($mode == 5) {
 		update_server();
 	} elseif ($mode == 4) {
-		$server_url = base64_decode($argv[2]);
+		$server_url = $argv[2];
 		if ($server_url == "") {
 			return;
 		}
@@ -119,7 +118,7 @@ function update_server() {
 		}
 		logger('Update server status for server '.$server["url"], LOGGER_DEBUG);
 
-		proc_run(PRIORITY_LOW, "include/discover_poco.php", "server", base64_encode($server["url"]));
+		proc_run(PRIORITY_LOW, "include/discover_poco.php", "server", $server["url"]);
 
 		if (++$updated > 250) {
 			return;
@@ -178,7 +177,7 @@ function discover_users() {
 
 		if ((($server_url == "") && ($user["network"] == NETWORK_FEED)) || $force_update || poco_check_server($server_url, $user["network"])) {
 			logger('Check profile '.$user["url"]);
-			proc_run(PRIORITY_LOW, "include/discover_poco.php", "check_profile", base64_encode($user["url"]));
+			proc_run(PRIORITY_LOW, "include/discover_poco.php", "check_profile", $user["url"]);
 
 			if (++$checked > 100) {
 				return;

--- a/include/expire.php
+++ b/include/expire.php
@@ -9,14 +9,32 @@ function expire_run(&$argv, &$argc){
 	require_once('include/items.php');
 	require_once('include/Contact.php');
 
+	load_hooks();
+
+	if (($argc == 2) && (intval($argv[1]) > 0)) {
+		$user = dba::select('user', array('uid', 'username', 'expire'), array('uid' => $argv[1]), array('limit' => 1));
+		if (dbm::is_result($user)) {
+			logger('Expire items for user '.$user['uid'].' ('.$user['username'].') - interval: '.$user['expire'], LOGGER_DEBUG);
+			item_expire($user['uid'], $user['expire']);
+			logger('Expire items for user '.$user['uid'].' ('.$user['username'].') - done ', LOGGER_DEBUG);
+		}
+		return;
+	} elseif (($argc == 3) && ($argv[1] == 'hook') && is_array($a->hooks) && array_key_exists("expire", $a->hooks)) {
+		foreach ($a->hooks["expire"] as $hook) {
+			if ($hook[1] == $argv[2]) {
+				logger("Calling expire hook '" . $hook[1] . "'", LOGGER_DEBUG);
+				call_single_hook($a, $name, $hook, $data);
+			}
+		}
+		return;
+	}
+
 	// physically remove anything that has been deleted for more than two months
 	$r = dba::p("SELECT `id` FROM `item` WHERE `deleted` AND `changed` < UTC_TIMESTAMP() - INTERVAL 60 DAY");
-	if (dbm::is_result($r)) {
-		while ($row = dba::fetch($r)) {
-			dba::delete('item', array('id' => $row['id']));
-		}
-		dba::close($r);
+	while ($row = dba::fetch($r)) {
+		dba::delete('item', array('id' => $row['id']));
 	}
+	dba::close($r);
 
 	// make this optional as it could have a performance impact on large sites
 	if (intval(get_config('system', 'optimize_items'))) {
@@ -25,17 +43,25 @@ function expire_run(&$argv, &$argc){
 
 	logger('expire: start');
 
-	$r = q("SELECT `uid`, `username`, `expire` FROM `user` WHERE `expire` != 0");
-	if (dbm::is_result($r)) {
-		foreach ($r as $rr) {
-			logger('Expire: ' . $rr['username'] . ' interval: ' . $rr['expire'], LOGGER_DEBUG);
-			item_expire($rr['uid'], $rr['expire']);
+	$r = dba::p("SELECT `uid`, `username` FROM `user` WHERE `expire` != 0");
+	while ($row = dba::fetch($r)) {
+		logger('Calling expiry for user '.$row['uid'].' ('.$row['username'].')', LOGGER_DEBUG);
+		proc_run(array('priority' => $a->queue['priority'], 'created' => $a->queue['created'], 'dont_fork' => true),
+				'include/expire.php', (int)$row['uid']);
+	}
+	dba::close($r);
+
+	logger('expire: calling hooks');
+
+	if (is_array($a->hooks) && array_key_exists('expire', $a->hooks)) {
+		foreach ($a->hooks['expire'] as $hook) {
+			logger("Calling expire hook for '" . $hook[1] . "'", LOGGER_DEBUG);
+			proc_run(array('priority' => $a->queue['priority'], 'created' => $a->queue['created'], 'dont_fork' => true),
+					'include/expire.php', 'hook', $hook[1]);
 		}
 	}
 
-	load_hooks();
-
-	call_hooks('expire');
+	logger('expire: end');
 
 	return;
 }

--- a/include/gprobe.php
+++ b/include/gprobe.php
@@ -10,7 +10,7 @@ function gprobe_run(&$argv, &$argc){
 	if ($argc != 2) {
 		return;
 	}
-	$url = hex2bin($argv[1]);
+	$url = $argv[1];
 
 	$r = q("SELECT `id`, `url`, `network` FROM `gcontact` WHERE `nurl` = '%s' ORDER BY `id` LIMIT 1",
 		dbesc(normalise_link($url))

--- a/include/identity.php
+++ b/include/identity.php
@@ -888,7 +888,7 @@ function zrl_init(App $a) {
 			return;
 		}
 
-		proc_run(PRIORITY_LOW, 'include/gprobe.php', bin2hex($tmp_str));
+		proc_run(PRIORITY_LOW, 'include/gprobe.php', $tmp_str);
 		$arr = array('zrl' => $tmp_str, 'url' => $a->cmd);
 		call_hooks('zrl_init', $arr);
 	}

--- a/include/queue.php
+++ b/include/queue.php
@@ -52,7 +52,7 @@ function queue_run(&$argv, &$argc) {
 		if (dbm::is_result($r)) {
 			foreach ($r as $q_item) {
 				logger('Call queue for id '.$q_item['id']);
-				proc_run(array('priority' => PRIORITY_LOW, 'dont_fork' => true), "include/queue.php", $q_item['id']);
+				proc_run(array('priority' => PRIORITY_LOW, 'dont_fork' => true), "include/queue.php", (int)$q_item['id']);
 			}
 		}
 		return;

--- a/include/socgraph.php
+++ b/include/socgraph.php
@@ -38,7 +38,7 @@ require_once 'include/Photo.php';
  */
 function poco_load($cid, $uid = 0, $zcid = 0, $url = null) {
 	// Call the function "poco_load_worker" via the worker
-	proc_run(PRIORITY_LOW, "include/discover_poco.php", "poco_load", intval($cid), intval($uid), intval($zcid), base64_encode($url));
+	proc_run(PRIORITY_LOW, "include/discover_poco.php", "poco_load", (int)$cid, (int)$uid, (int)$zcid, $url);
 }
 
 /**
@@ -1668,7 +1668,7 @@ function poco_fetch_serverlist($poco) {
 		$r = q("SELECT `nurl` FROM `gserver` WHERE `nurl` = '%s'", dbesc(normalise_link($server_url)));
 		if (!dbm::is_result($r)) {
 			logger("Call server check for server ".$server_url, LOGGER_DEBUG);
-			proc_run(PRIORITY_LOW, "include/discover_poco.php", "server", base64_encode($server_url));
+			proc_run(PRIORITY_LOW, "include/discover_poco.php", "server", $server_url);
 		}
 	}
 }
@@ -1690,7 +1690,7 @@ function poco_discover_federation() {
 		$servers = json_decode($serverdata);
 
 		foreach ($servers->pods as $server) {
-			proc_run(PRIORITY_LOW, "include/discover_poco.php", "server", base64_encode("https://".$server->host));
+			proc_run(PRIORITY_LOW, "include/discover_poco.php", "server", "https://".$server->host);
 		}
 	}
 
@@ -1703,7 +1703,7 @@ function poco_discover_federation() {
 
 			foreach ($servers as $server) {
 				$url = (is_null($server->https_score) ? 'http' : 'https').'://'.$server->name;
-				proc_run(PRIORITY_LOW, "include/discover_poco.php", "server", base64_encode($url));
+				proc_run(PRIORITY_LOW, "include/discover_poco.php", "server", $url);
 			}
 		}
 	}
@@ -1813,7 +1813,7 @@ function poco_discover($complete = false) {
 			}
 
 			logger('Update directory from server '.$server['url'].' with ID '.$server['id'], LOGGER_DEBUG);
-			proc_run(PRIORITY_LOW, "include/discover_poco.php", "update_server_directory", intval($server['id']));
+			proc_run(PRIORITY_LOW, "include/discover_poco.php", "update_server_directory", (int)$server['id']);
 
 			if (!$complete && (--$no_of_queries == 0)) {
 				break;
@@ -2091,7 +2091,7 @@ function get_gcontact_id($contact) {
 
 	if ($doprobing) {
 		logger("Last Contact: ". $last_contact_str." - Last Failure: ".$last_failure_str." - Checking: ".$contact["url"], LOGGER_DEBUG);
-		proc_run(PRIORITY_LOW, 'include/gprobe.php', bin2hex($contact["url"]));
+		proc_run(PRIORITY_LOW, 'include/gprobe.php', $contact["url"]);
 	}
 
 	return $gcontact_id;


### PR DESCRIPTION
The expire process can take some time. So it is better to split it into several sub processes.

Additionally parameters for worker calls aren't encoded anymore. In the past this had been done to avoid problems with special characters that could have made problems when the scripts were called from the command line.

Finally there are some small adjustments to the poller.php. With the last changes it could happen that fast processes were put on a worker that was busy with slow processes. And the amount of processes per worker is now dynamically defined.