### PR TITLE
Fix/workaround weird load order issue.

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -1392,6 +1392,43 @@ function get_server() {
 	return($server);
 }
 
+function get_temppath() {
+	$a = get_app();
+
+	$temppath = get_config("system", "temppath");
+
+	if (($temppath != "") && App::directory_usable($temppath)) {
+		// We have a temp path and it is usable
+		return $temppath;
+	}
+
+	// We don't have a working preconfigured temp path, so we take the system path.
+	$temppath = sys_get_temp_dir();
+
+	// Check if it is usable
+	if (($temppath != "") && App::directory_usable($temppath)) {
+		// To avoid any interferences with other systems we create our own directory
+		$new_temppath = $temppath . "/" . $a->get_hostname();
+		if (!is_dir($new_temppath)) {
+			/// @TODO There is a mkdir()+chmod() upwards, maybe generalize this (+ configurable) into a function/method?
+			mkdir($new_temppath);
+		}
+
+		if (App::directory_usable($new_temppath)) {
+			// The new path is usable, we are happy
+			set_config("system", "temppath", $new_temppath);
+			return $new_temppath;
+		} else {
+			// We can't create a subdirectory, strange.
+			// But the directory seems to work, so we use it but don't store it.
+			return $temppath;
+		}
+	}
+
+	// Reaching this point means that the operating system is configured badly.
+	return '';
+}
+
 function get_cachefile($file, $writemode = true) {
 	$cache = get_itemcachepath();
 
@@ -1512,43 +1549,6 @@ function get_spoolpath() {
 
 	// Reaching this point means that the operating system is configured badly.
 	return "";
-}
-
-function get_temppath() {
-	$a = get_app();
-
-	$temppath = get_config("system", "temppath");
-
-	if (($temppath != "") && App::directory_usable($temppath)) {
-		// We have a temp path and it is usable
-		return $temppath;
-	}
-
-	// We don't have a working preconfigured temp path, so we take the system path.
-	$temppath = sys_get_temp_dir();
-
-	// Check if it is usable
-	if (($temppath != "") && App::directory_usable($temppath)) {
-		// To avoid any interferences with other systems we create our own directory
-		$new_temppath = $temppath . "/" . $a->get_hostname();
-		if (!is_dir($new_temppath)) {
-			/// @TODO There is a mkdir()+chmod() upwards, maybe generalize this (+ configurable) into a function/method?
-			mkdir($new_temppath);
-		}
-
-		if (App::directory_usable($new_temppath)) {
-			// The new path is usable, we are happy
-			set_config("system", "temppath", $new_temppath);
-			return $new_temppath;
-		} else {
-			// We can't create a subdirectory, strange.
-			// But the directory seems to work, so we use it but don't store it.
-			return $temppath;
-		}
-	}
-
-	// Reaching this point means that the operating system is configured badly.
-	return '';
 }
 
 /// @deprecated


### PR DESCRIPTION
When I create a new item, I get redirected to /item. The item is created, and federated, but the item module gives me a 500 error.

PHP Fatal error:  Call to undefined function Friendica\Util\get_temppath() in /var/www/soc.beardyunixer.com/src/Util/Lock.php on line 56

Additionally, mod/proxy.php also throws up Call to undefined function get_temppath() in /var/www/soc.beardyunixer.com/mod/proxy.php on line 160

There is some discussion at https://helpers.pyxis.uberspace.de/display/0c5b5b9020595ed81f4c1b6459772483

Simply moving get_temppath() to earlier in boot.php fixes both issues.  I'm suspicious of this commit, so it's probably wise to try to remember it happened...but it does work, and it doesn't break anything else.