### PR TITLE
Only delete uid=0 entries when cleaning up extra public entries

### DIFF
--- a/include/Contact.php
+++ b/include/Contact.php
@@ -637,7 +637,7 @@ function get_contact($url, $uid = 0, $no_update = false) {
 	}
 
 	if (count($contacts) > 1 && $uid == 0 && $contact_id != 0 && $url != "") {
-		q("DELETE FROM `contact` WHERE `nurl` = '%s' AND `id` != %d AND NOT `self`",
+		q("DELETE FROM `contact` WHERE `nurl` = '%s' AND `uid` = 0 AND `id` != %d AND NOT `self`",
 			dbesc(normalise_link($url)),
 			intval($contact_id));
 	}


### PR DESCRIPTION
This delete can inadvertently remove contacts from normal users under
some conditions.  Since it appears to be intended to only operate on
"public" (uid=0) contacts, this change constrains the delete query to
only uid=0 records.

basic fix for #3571 