### PR TITLE
Fix crash with expiration, false logger constant, no empty postings

### DIFF
--- a/include/dbstructure.php
+++ b/include/dbstructure.php
@@ -52,7 +52,7 @@ function update_fail($update_id, $error_message) {
 
 	// No valid result?
 	if (!dbm::is_result($adminlist)) {
-		logger(sprintf('Cannot notify administrators about update_id=%d, error_message=%s', $update_id, $error_message), LOGGER_WARNING);
+		logger(sprintf('Cannot notify administrators about update_id=%d, error_message=%s', $update_id, $error_message), LOGGER_NORMAL);
 
 		// Don't continue
 		return;

--- a/include/items.php
+++ b/include/items.php
@@ -569,9 +569,9 @@ function item_store($arr, $force_parent = false, $notify = false, $dontcache = f
 	$r = q("SELECT expire FROM user WHERE uid = %d", intval($uid));
 	if (dbm::is_result($r)) {
 		$expire_interval = $r[0]['expire'];
-		if ($expire_interval>0) {
-			$expire_date =  new DateTime( '- '.$expire_interval.' days', new DateTimeZone('UTC'));
-			$created_date = new DateTime($arr['created'], new DateTimeZone('UTC'));
+		if ($expire_interval > 0) {
+			$expire_date = datetime_convert('UTC', 'UTC', '- '.$expire_interval.' days');
+			$created_date = datetime_convert('UTC', 'UTC', $arr['created']);
 			if ($created_date < $expire_date) {
 				logger('item-store: item created ('.$arr['created'].') before expiration time ('.$expire_date->format(DateTime::W3C).'). ignored. ' . print_r($arr,true), LOGGER_DEBUG);
 				return 0;
@@ -653,6 +653,11 @@ function item_store($arr, $force_parent = false, $notify = false, $dontcache = f
 	$arr['event-id']      = ((x($arr, 'event-id'))      ? intval($arr['event-id'])            : 0 );
 	$arr['inform']        = ((x($arr, 'inform'))        ? trim($arr['inform'])                : '');
 	$arr['file']          = ((x($arr, 'file'))          ? trim($arr['file'])                  : '');
+
+	// When there is no content then we don't post it
+	if ($arr['body'].$arr['title'] == '') {
+		return 0;
+	}
 
 	// Items cannot be stored before they happen ...
 	if ($arr['created'] > datetime_convert()) {


### PR DESCRIPTION
This is a "3 in 1" pull request ;-)

It combines three different issues:

1. Fix for a wrong logger constant in dbstructure.pjp
2. Avoid storing posts without any content
3. There was a situation when storing an item simply crashed on one of my servers. This has to do something with invalid date time values.