### PR TITLE
Use the realpath for the handling with (temporary) paths

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -1399,7 +1399,7 @@ function get_temppath() {
 
 	if (($temppath != "") && App::directory_usable($temppath)) {
 		// We have a temp path and it is usable
-		return $temppath;
+		return realpath($temppath);
 	}
 
 	// We don't have a working preconfigured temp path, so we take the system path.
@@ -1407,6 +1407,9 @@ function get_temppath() {
 
 	// Check if it is usable
 	if (($temppath != "") && App::directory_usable($temppath)) {
+		// Always store the real path, not the path through symlinks
+		$temppath = realpath($temppath);
+
 		// To avoid any interferences with other systems we create our own directory
 		$new_temppath = $temppath . "/" . $a->get_hostname();
 		if (!is_dir($new_temppath)) {
@@ -1495,7 +1498,7 @@ function get_itemcachepath() {
 
 	$itemcache = get_config('system', 'itemcache');
 	if (($itemcache != "") && App::directory_usable($itemcache)) {
-		return $itemcache;
+		return realpath($itemcache);
 	}
 
 	$temppath = get_temppath();

--- a/mod/admin.php
+++ b/mod/admin.php
@@ -973,10 +973,25 @@ function admin_page_site_post(App $a) {
 
 	set_config('system', 'force_ssl', $force_ssl);
 	set_config('system', 'hide_help', $hide_help);
+
+	if ($itemcache != '') {
+		$itemcache = realpath($itemcache);
+	}
+
 	set_config('system', 'itemcache', $itemcache);
 	set_config('system', 'itemcache_duration', $itemcache_duration);
 	set_config('system', 'max_comments', $max_comments);
+
+	if ($temppath != '') {
+		$temppath = realpath($temppath);
+	}
+
 	set_config('system', 'temppath', $temppath);
+
+	if ($basepath != '') {
+		$basepath = realpath($basepath);
+	}
+
 	set_config('system', 'basepath', $basepath);
 	set_config('system', 'proxy_disabled', $proxy_disabled);
 	set_config('system', 'only_tag_search', $only_tag_search);


### PR DESCRIPTION
In the function "clear_cache" we are using "realpath" to avoid problems with relative paths (for example to avoid path manipulations) and to normalize the paths.

This has the downside that when a relative path was entered in the configuration, there was no clearing of cached files at all. This problem was reported by some users.

This now fixes it.