### PR TITLE
Endless scroll now avoids showing the same items

### DIFF
--- a/include/conversation.php
+++ b/include/conversation.php
@@ -424,7 +424,6 @@ function item_fieldlists() {
 These Fields are not added below (yet). They are here to for bug search.
 `item`.`type`,
 `item`.`extid`,
-`item`.`received`,
 `item`.`changed`,
 `item`.`moderated`,
 `item`.`target-type`,
@@ -451,7 +450,7 @@ These Fields are not added below (yet). They are here to for bug search.
 		`item`.`owner-id`, `item`.`owner-link`, `item`.`owner-name`, `item`.`owner-avatar`,
 		`item`.`contact-id`, `item`.`uid`, `item`.`id`, `item`.`parent`,
 		`item`.`uri`, `item`.`thr-parent`, `item`.`parent-uri`,
-		`item`.`commented`, `item`.`created`, `item`.`edited`,
+		`item`.`commented`, `item`.`created`, `item`.`edited`, `item`.`received`,
 		`item`.`verb`, `item`.`object-type`, `item`.`postopts`, `item`.`plink`,
 		`item`.`guid`, `item`.`wall`, `item`.`private`, `item`.`starred`,
 		`item`.`title`,	`item`.`body`, `item`.`file`, `item`.`event-id`,

--- a/js/main.js
+++ b/js/main.js
@@ -720,11 +720,41 @@
 		// page number
 		infinite_scroll.pageno+=1;
 
+		match = $("span.received").last();
+		if (match.length > 0) {
+			received = match[0].innerHTML;
+		} else {
+			received = "0000-00-00 00:00:00";
+		}
+
+		match = $("span.created").last();
+		if (match.length > 0) {
+			created = match[0].innerHTML;
+		} else {
+			created = "0000-00-00 00:00:00";
+		}
+
+		match = $("span.commented").last();
+		if (match.length > 0) {
+			commented = match[0].innerHTML;
+		} else {
+			commented = "0000-00-00 00:00:00";
+		}
+
+		match = $("span.id").last();
+		if (match.length > 0) {
+			id = match[0].innerHTML;
+		} else {
+			id = "0";
+		}
+		// console.log("Received: " + received + " - Commented: " + commented+ " - Created: " + created + " - ID: " + id);
+
 		// get the raw content from the next page and insert this content
 		// right before "#conversation-end"
-		$.get('network?mode=raw' + infinite_scroll.reload_uri + '&page=' + infinite_scroll.pageno, function(data) {
+		$.get('network?mode=raw' + infinite_scroll.reload_uri + '&last_received=' + received + '&last_commented=' + commented + '&last_created=' + created + '&last_id=' + id + '&page=' + infinite_scroll.pageno, function(data) {
 			$("#scroll-loader").hide();
 			if ($(data).length > 0) {
+
 				$(data).insertBefore('#conversation-end');
 				lockLoadContent = false;
 			} else {

--- a/object/Item.php
+++ b/object/Item.php
@@ -394,6 +394,9 @@ class Item extends BaseObject {
 			'edited'          => $edited,
 			'network'         => $item["item_network"],
 			'network_name'    => network_to_name($item['item_network'], $profile_link),
+			'received'        => $item['received'],
+			'commented'       => $item['commented'],
+			'created_date'    => $item['created'],
 		);
 
 		$arr = array('item' => $item, 'output' => $tmp_item);

--- a/view/templates/wall_thread.tpl
+++ b/view/templates/wall_thread.tpl
@@ -5,6 +5,12 @@
 	</div>
 	<div id="collapsed-comments-{{$item.id}}" class="collapsed-comments" style="display: none;">
 {{/if}}
+{{if $item.thread_level==1}}
+<span class="commented" style="display: none;">{{$item.commented}}</span>
+<span class="received" style="display: none;">{{$item.received}}</span>
+<span class="created" style="display: none;">{{$item.created_date}}</span>
+<span class="id" style="display: none;">{{$item.id}}</span>
+{{/if}}
 <div id="tread-wrapper-{{$item.id}}" class="tread-wrapper {{$item.toplevel}} {{if $item.toplevel}} h-entry {{else}} u-comment h-cite {{/if}}">
 <a name="{{$item.id}}" ></a>
 <div class="wall-item-outside-wrapper {{$item.indent}}{{$item.previewing}}{{if $item.owner_url}} wallwall{{/if}}" id="wall-item-outside-wrapper-{{$item.id}}" >

--- a/view/theme/frio/templates/wall_thread.tpl
+++ b/view/theme/frio/templates/wall_thread.tpl
@@ -71,7 +71,13 @@ as the value of $top_child_total (this is done at the end of this file)
 <div class="item-{{$item.id}} wall-item-container {{$item.indent}} {{$item.shiny}} {{$item.network}} thread_level_{{$item.thread_level}} {{if $item.thread_level==1}}panel-body h-entry{{else}}u-comment h-cite{{/if}}" id="item-{{$item.guid}}"><!-- wall-item-container -->
 {{else}}
 <div class="item-{{$item.id}} wall-item-container {{$item.indent}} {{$item.shiny}} {{$item.network}} thread_level_7 u-comment h-cite" id="item-{{$item.guid}}">
- {{/if}}
+{{/if}}
+{{if $item.thread_level==1}}
+<span class="commented" style="display: none;">{{$item.commented}}</span>
+<span class="received" style="display: none;">{{$item.received}}</span>
+<span class="created" style="display: none;">{{$item.created_date}}</span>
+<span class="id" style="display: none;">{{$item.id}}</span>
+{{/if}}
 	<div class="media">
 		{{* Put addional actions in a top-right dropdown menu *}}
 

--- a/view/theme/quattro/templates/wall_thread.tpl
+++ b/view/theme/quattro/templates/wall_thread.tpl
@@ -19,7 +19,14 @@
 {{/if}}
 {{/if}}
 
-{{if $item.thread_level!=1}}<div class="children u-comment h-cite">{{/if}}
+{{if $item.thread_level!=1}}
+<div class="children u-comment h-cite">
+{{else}}
+<span class="commented" style="display: none;">{{$item.commented}}</span>
+<span class="received" style="display: none;">{{$item.received}}</span>
+<span class="created" style="display: none;">{{$item.created_date}}</span>
+<span class="id" style="display: none;">{{$item.id}}</span>
+{{/if}}
 
 <div class="wall-item-decor">
 	{{if $item.star}}<span class="icon s22 star {{$item.isstarred}}" id="starred-{{$item.id}}" title="{{$item.star.starred}}">{{$item.star.starred}}</span>{{/if}}

--- a/view/theme/vier/templates/wall_thread.tpl
+++ b/view/theme/vier/templates/wall_thread.tpl
@@ -28,6 +28,12 @@
 {{else}}
 	<div class="wall-item-container {{$item.indent}} {{$item.shiny}} {{$item.network}} thread_level_7" id="item-{{$item.guid}}">
 {{/if}}
+{{if $item.thread_level==1}}
+<span class="commented" style="display: none;">{{$item.commented}}</span>
+<span class="received" style="display: none;">{{$item.received}}</span>
+<span class="created" style="display: none;">{{$item.created_date}}</span>
+<span class="id" style="display: none;">{{$item.id}}</span>
+{{/if}}
 	<div class="wall-item-item">
 		<div class="wall-item-info">
 			<div class="contact-photo-wrapper mframe{{if $item.owner_url}} wwfrom{{/if}} p-author h-card">


### PR DESCRIPTION
Formerly there had been the problem that the endless scroll worked with a simple paging. This lead to a problem when in the meantime new items arrived at the top. Then some items duplicated mysteriously during fetching the next page.

This behavior is now changed.

**Important:**
The developers have to add these lines to their own version of "wall_thread.tpl":
```
{{if $item.thread_level==1}}
<span class="commented" style="display: none;">{{$item.commented}}</span>
<span class="received" style="display: none;">{{$item.received}}</span>
<span class="created" style="display: none;">{{$item.created_date}}</span>
<span class="id" style="display: none;">{{$item.id}}</span>
{{/if}}
```
(It is done for the standard template, frio, vier and quattro)