### PR TITLE
Show contacts personal message in local profile

### DIFF
--- a/mod/contacts.php
+++ b/mod/contacts.php
@@ -589,6 +589,8 @@ function contacts_content(App $a) {
 			'$lbl_vis1' => t('Profile Visibility'),
 			'$lbl_vis2' => sprintf( t('Please choose the profile you would like to display to %s when viewing your profile securely.'), $contact['name']),
 			'$lbl_info1' => t('Contact Information / Notes'),
+			'$lbl_info2' => t('Their personal note'),
+			'$reason' => trim(notags($contact['reason'])),
 			'$infedit' => t('Edit contact notes'),
 			'$common_text' => $common_text,
 			'$common_link' => 'common/loc/' . local_user() . '/' . $contact['id'],

--- a/view/templates/contact_edit.tpl
+++ b/view/templates/contact_edit.tpl
@@ -81,6 +81,14 @@
 				</div>
 				<div id="contact-edit-info-end"></div>
 
+				{{if $reason}}
+				<div id="contact-info-wrapper">
+					<h4>{{$lbl_info2}}</h4>
+					<p>{{$reason}}</p>
+				</div>
+				<div id="contact-info-end"></div>
+				{{/if}}
+
 				{{if $profile_select}}
 					<div id="contact-edit-profile-select-text">
 					<h4>{{$lbl_vis1}}</h4>


### PR DESCRIPTION
If a *personal note* was given during contact requesting, display that reason in the local profile view just beneath the personal notes made about that contact.

solves #2998 