### PR TITLE
add a switch to the Markdown parser for using hard line wraps

### DIFF
--- a/library/markdown.php
+++ b/library/markdown.php
@@ -1,14 +1,39 @@
 <?php
+
+/**
+ * @file library/markdown.php
+ *
+ * @brief Parser for Markdown files
+ */
+
 require_once "library/php-markdown/Michelf/MarkdownExtra.inc.php";
 use \Michelf\MarkdownExtra;
 
-function Markdown($text) {
+/**
+ * @brief This function parses a text using php-markdown library to render Markdown syntax to HTML
+ *
+ * This function is using the php-markdown library by Michel Fortin to parse a 
+ * string ($text).It returns the rendered HTML code from that text. The optional 
+ * $hardbreak parameter is used to switch between inserting hard breaks after
+ * every linefeed, which is required for Diaspora compatibility, or not. The
+ * later is used for parsing documentation and README.md files.
+ *
+ * @param string $text
+ * @param boolean $hardbreak
+ * @returns string
+ */
+
+function Markdown($text, $hardbreak=true) {
 	$a = get_app();
 
 	$stamp1 = microtime(true);
 
 	$MarkdownParser = new MarkdownExtra();
-	$MarkdownParser->hard_wrap = true;
+	if ($hardbreak) {
+		$MarkdownParser->hard_wrap = true;
+	} else {
+		$MarkdownParser->hard_wrap = false;
+	}
 	$html = $MarkdownParser->transform($text);
 
 	$a->save_timestamp($stamp1, "parser");

--- a/library/markdown.php
+++ b/library/markdown.php
@@ -23,7 +23,7 @@ use \Michelf\MarkdownExtra;
  * @return string
  */
 
-function Markdown($text, $hardwrap=true) {
+function Markdown($text, $hardwrap = true) {
 	$a = get_app();
 
 	$stamp1 = microtime(true);

--- a/library/markdown.php
+++ b/library/markdown.php
@@ -14,22 +14,22 @@ use \Michelf\MarkdownExtra;
  *
  * This function is using the php-markdown library by Michel Fortin to parse a 
  * string ($text).It returns the rendered HTML code from that text. The optional 
- * $hardbreak parameter is used to switch between inserting hard breaks after
+ * $hardwrap parameter is used to switch between inserting hard breaks after
  * every linefeed, which is required for Diaspora compatibility, or not. The
  * later is used for parsing documentation and README.md files.
  *
  * @param string $text
- * @param boolean $hardbreak
- * @returns string
+ * @param boolean $hardwrap
+ * @return string
  */
 
-function Markdown($text, $hardbreak=true) {
+function Markdown($text, $hardwrap=true) {
 	$a = get_app();
 
 	$stamp1 = microtime(true);
 
 	$MarkdownParser = new MarkdownExtra();
-	if ($hardbreak) {
+	if ($hardwrap) {
 		$MarkdownParser->hard_wrap = true;
 	} else {
 		$MarkdownParser->hard_wrap = false;

--- a/library/markdown.php
+++ b/library/markdown.php
@@ -29,11 +29,7 @@ function Markdown($text, $hardwrap = true) {
 	$stamp1 = microtime(true);
 
 	$MarkdownParser = new MarkdownExtra();
-	if ($hardwrap) {
-		$MarkdownParser->hard_wrap = true;
-	} else {
-		$MarkdownParser->hard_wrap = false;
-	}
+	$MarkdownParser->hard_wrap = $hardwrap;
 	$html = $MarkdownParser->transform($text);
 
 	$a->save_timestamp($stamp1, "parser");

--- a/mod/admin.php
+++ b/mod/admin.php
@@ -1687,7 +1687,7 @@ function admin_page_plugins(App $a) {
 		$readme=Null;
 		if (is_file("addon/$plugin/README.md")) {
 			$readme = file_get_contents("addon/$plugin/README.md");
-			$readme = Markdown($readme);
+			$readme = Markdown($readme, false);
 		} elseif (is_file("addon/$plugin/README")) {
 			$readme = "<pre>". file_get_contents("addon/$plugin/README") ."</pre>";
 		}
@@ -1939,7 +1939,7 @@ function admin_page_themes(App $a) {
 		$readme = Null;
 		if (is_file("view/theme/$theme/README.md")) {
 			$readme = file_get_contents("view/theme/$theme/README.md");
-			$readme = Markdown($readme);
+			$readme = Markdown($readme, false);
 		} elseif (is_file("view/theme/$theme/README")) {
 			$readme = "<pre>". file_get_contents("view/theme/$theme/README") ."</pre>";
 		}

--- a/mod/help.php
+++ b/mod/help.php
@@ -49,7 +49,7 @@ function help_content(App $a) {
 		$filename = "Home";
 		$a->page['title'] = t('Help');
 	} else {
-		$a->page['aside'] = Markdown($home);
+		$a->page['aside'] = Markdown($home, false);
 	}
 
 	if (!strlen($text)) {
@@ -60,7 +60,7 @@ function help_content(App $a) {
 				));
 	}
 
-	$html = Markdown($text);
+	$html = Markdown($text, false);
 
 	if ($filename !== "Home") {
 		// create TOC but not for home


### PR DESCRIPTION
This fixes the problem of parsing our documentation and some README.md files of addons that use the rule of *one sentence per line*. (issue #3592)

The default behaviour is to use the hard wrap mode as this is the current default and apparently needed for Diaspora compatibility. For parsing doc/*.md and README.md files this mode is turned off.