### PR TITLE
Several more replaced database calls

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -42,7 +42,7 @@ define ( 'FRIENDICA_PLATFORM',     'Friendica');
 define ( 'FRIENDICA_CODENAME',     'Asparagus');
 define ( 'FRIENDICA_VERSION',      '3.5.3-dev' );
 define ( 'DFRN_PROTOCOL_VERSION',  '2.23'    );
-define ( 'DB_UPDATE_VERSION',      1233      );
+define ( 'DB_UPDATE_VERSION',      1234      );
 
 /**
  * @brief Constant with a HTML line break.

--- a/boot.php
+++ b/boot.php
@@ -1090,9 +1090,9 @@ function proc_run($cmd) {
 	array_shift($argv);
 
 	$parameters = json_encode($argv);
-	$found = dba::select('workerqueue', array('id'), array('parameter' => $parameters, 'done' => false), array('limit' => 1));
+	$found = dba::exists('workerqueue', array('parameter' => $parameters, 'done' => false));
 
-	if (!dbm::is_result($found)) {
+	if (!$found) {
 		dba::insert('workerqueue', array('parameter' => $parameters, 'created' => $created, 'priority' => $priority));
 	}
 

--- a/database.sql
+++ b/database.sql
@@ -1,6 +1,6 @@
 -- ------------------------------------------
 -- Friendica 3.5.3-dev (Asparagus)
--- DB_UPDATE_VERSION 1233
+-- DB_UPDATE_VERSION 1234
 -- ------------------------------------------
 
 
@@ -1027,7 +1027,8 @@ CREATE TABLE IF NOT EXISTS `thread` (
 	 INDEX `authorid` (`author-id`),
 	 INDEX `uid_created` (`uid`,`created`),
 	 INDEX `uid_commented` (`uid`,`commented`),
-	 INDEX `uid_wall_created` (`uid`,`wall`,`created`)
+	 INDEX `uid_wall_created` (`uid`,`wall`,`created`),
+	 INDEX `private_wall_received` (`private`,`wall`,`received`)
 ) DEFAULT COLLATE utf8mb4_general_ci;
 
 --

--- a/include/Contact.php
+++ b/include/Contact.php
@@ -206,26 +206,27 @@ function get_contact_details_by_url($url, $uid = -1, $default = array()) {
 	}
 
 	// Fetch contact data from the contact table for the given user
-	$r = q("SELECT `id`, `id` AS `cid`, 0 AS `gid`, 0 AS `zid`, `uid`, `url`, `nurl`, `alias`, `network`, `name`, `nick`, `addr`, `location`, `about`, `xmpp`,
+	$s = dba::p("SELECT `id`, `id` AS `cid`, 0 AS `gid`, 0 AS `zid`, `uid`, `url`, `nurl`, `alias`, `network`, `name`, `nick`, `addr`, `location`, `about`, `xmpp`,
 			`keywords`, `gender`, `photo`, `thumb`, `micro`, `forum`, `prv`, (`forum` | `prv`) AS `community`, `contact-type`, `bd` AS `birthday`, `self`
-		FROM `contact` WHERE `nurl` = '%s' AND `uid` = %d",
-			dbesc(normalise_link($url)), intval($uid));
+		FROM `contact` WHERE `nurl` = ? AND `uid` = ?",
+			normalise_link($url), $uid);
 
 	// Fetch the data from the contact table with "uid=0" (which is filled automatically)
-	if (!dbm::is_result($r))
-		$r = q("SELECT `id`, 0 AS `cid`, `id` AS `zid`, 0 AS `gid`, `uid`, `url`, `nurl`, `alias`, `network`, `name`, `nick`, `addr`, `location`, `about`, `xmpp`,
+	if (!dbm::is_result($s))
+		$s = dba::p("SELECT `id`, 0 AS `cid`, `id` AS `zid`, 0 AS `gid`, `uid`, `url`, `nurl`, `alias`, `network`, `name`, `nick`, `addr`, `location`, `about`, `xmpp`,
 			`keywords`, `gender`, `photo`, `thumb`, `micro`, `forum`, `prv`, (`forum` | `prv`) AS `community`, `contact-type`, `bd` AS `birthday`, 0 AS `self`
-			FROM `contact` WHERE `nurl` = '%s' AND `uid` = 0",
-				dbesc(normalise_link($url)));
+			FROM `contact` WHERE `nurl` = ? AND `uid` = 0",
+				normalise_link($url));
 
 	// Fetch the data from the gcontact table
-	if (!dbm::is_result($r))
-		$r = q("SELECT 0 AS `id`, 0 AS `cid`, `id` AS `gid`, 0 AS `zid`, 0 AS `uid`, `url`, `nurl`, `alias`, `network`, `name`, `nick`, `addr`, `location`, `about`, '' AS `xmpp`,
+	if (!dbm::is_result($s))
+		$s = dba::p("SELECT 0 AS `id`, 0 AS `cid`, `id` AS `gid`, 0 AS `zid`, 0 AS `uid`, `url`, `nurl`, `alias`, `network`, `name`, `nick`, `addr`, `location`, `about`, '' AS `xmpp`,
 			`keywords`, `gender`, `photo`, `photo` AS `thumb`, `photo` AS `micro`, `community` AS `forum`, 0 AS `prv`, `community`, `contact-type`, `birthday`, 0 AS `self`
-			FROM `gcontact` WHERE `nurl` = '%s'",
-				dbesc(normalise_link($url)));
+			FROM `gcontact` WHERE `nurl` = ?",
+				normalise_link($url));
 
-	if (dbm::is_result($r)) {
+	if (dbm::is_result($s)) {
+		$r = dba::inArray($s);
 		// If there is more than one entry we filter out the connector networks
 		if (count($r) > 1) {
 			foreach ($r AS $id => $result) {

--- a/include/Contact.php
+++ b/include/Contact.php
@@ -56,7 +56,7 @@ function contact_remove($id) {
 		return;
 	}
 
-	q("DELETE FROM `contact` WHERE `id` = %d", intval($id));
+	dba::delete('contact', array('id' => $id));
 
 	// Delete the rest in the background
 	proc_run(PRIORITY_LOW, 'include/remove_contact.php', $id);
@@ -617,8 +617,8 @@ function get_contact($url, $uid = 0, $no_update = false) {
 		}
 
 		if (count($contacts) > 1 && $uid == 0 && $contact_id != 0 && $data["url"] != "") {
-			dba::e("DELETE FROM `contact` WHERE `nurl` = ? AND `uid` = 0 AND `id` != ? AND NOT `self`",
-				normalise_link($data["url"]), $contact_id);
+			dba::delete('contact', array("`nurl` = ? AND `uid` = 0 AND `id` != ? AND NOT `self`",
+				normalise_link($data["url"]), $contact_id));
 		}
 	}
 

--- a/include/ForumManager.php
+++ b/include/ForumManager.php
@@ -41,18 +41,18 @@ class ForumManager {
 			$select = '(`forum` OR `prv`)';
 		}
 
-		$contacts = q("SELECT `contact`.`id`, `contact`.`url`, `contact`.`name`, `contact`.`micro`, `contact`.`thumb` FROM `contact`
-				WHERE `network`= 'dfrn' AND $select AND `uid` = %d
+		$contacts = dba::p("SELECT `contact`.`id`, `contact`.`url`, `contact`.`name`, `contact`.`micro`, `contact`.`thumb` FROM `contact`
+				WHERE `network`= 'dfrn' AND $select AND `uid` = ?
 				AND NOT `blocked` AND NOT `hidden` AND NOT `pending` AND NOT `archive`
 				AND `success_update` > `failure_update`
 				$order ",
-				intval($uid)
+				$uid
 		);
 
 		if (!$contacts)
 			return($forumlist);
 
-		foreach($contacts as $contact) {
+		while ($contact = dba::fetch($contacts)) {
 			$forumlist[] = array(
 				'url'	=> $contact['url'],
 				'name'	=> $contact['name'],
@@ -61,6 +61,8 @@ class ForumManager {
 				'thumb' => $contact['thumb'],
 			);
 		}
+		dba::close($contacts);
+
 		return($forumlist);
 	}
 

--- a/include/conversation.php
+++ b/include/conversation.php
@@ -680,8 +680,9 @@ function conversation(App $a, $items, $mode, $update, $preview = false) {
 				$hashtags = array();
 				$mentions = array();
 
-				$taglist = dba::p("SELECT `type`, `term`, `url` FROM `term` WHERE `otype` = ? AND `oid` = ? AND `type` IN (?, ?) ORDER BY `tid`",
-						intval(TERM_OBJ_POST), intval($item['id']), intval(TERM_HASHTAG), intval(TERM_MENTION));
+				$taglist = dba::select('term', array('type', 'term', 'url'),
+							array("`otype` = ? AND `oid` = ? AND `type` IN (?, ?)", TERM_OBJ_POST, $item['id'], TERM_HASHTAG, TERM_MENTION),
+							array('order' => array('tid')));
 
 				while ($tag = dba::fetch($taglist)) {
 					if ($tag["url"] == "") {

--- a/include/conversation.php
+++ b/include/conversation.php
@@ -680,11 +680,10 @@ function conversation(App $a, $items, $mode, $update, $preview = false) {
 				$hashtags = array();
 				$mentions = array();
 
-				$taglist = q("SELECT `type`, `term`, `url` FROM `term` WHERE `otype` = %d AND `oid` = %d AND `type` IN (%d, %d) ORDER BY `tid`",
+				$taglist = dba::p("SELECT `type`, `term`, `url` FROM `term` WHERE `otype` = ? AND `oid` = ? AND `type` IN (?, ?) ORDER BY `tid`",
 						intval(TERM_OBJ_POST), intval($item['id']), intval(TERM_HASHTAG), intval(TERM_MENTION));
 
-				foreach ($taglist as $tag) {
-
+				while ($tag = dba::fetch($taglist)) {
 					if ($tag["url"] == "") {
 						$tag["url"] = $searchpath . strtolower($tag["term"]);
 					}
@@ -698,6 +697,7 @@ function conversation(App $a, $items, $mode, $update, $preview = false) {
 					}
 					$tags[] = $prefix."<a href=\"" . $tag["url"] . "\" target=\"_blank\">" . $tag["term"] . "</a>";
 				}
+				dba::close($taglist);
 
 				$sp = false;
 				$profile_link = best_link_url($item,$sp);

--- a/include/cron.php
+++ b/include/cron.php
@@ -84,7 +84,7 @@ function cron_run(&$argv, &$argc){
 		proc_run(PRIORITY_LOW, "include/cronjobs.php", "update_photo_albums");
 
 		// Delete all done workerqueue entries
-		dba::e('DELETE FROM `workerqueue` WHERE `done` AND `executed` < UTC_TIMESTAMP() - INTERVAL 12 HOUR');
+		dba::delete('workerqueue', array('`done` AND `executed` < UTC_TIMESTAMP() - INTERVAL 12 HOUR'));
 	}
 
 	// Poll contacts

--- a/include/dba.php
+++ b/include/dba.php
@@ -1290,6 +1290,24 @@ class dba {
 		}
 	}
 
+
+	/**
+	 * @brief Fills an array with data from a query
+	 *
+	 * @param object $stmt statement object
+	 * @return array Data array
+	 */
+	static public function inArray($stmt, $do_close = true) {
+		$data = array();
+		while ($row = self::fetch($stmt)) {
+			$data[] = $row;
+		}
+		if ($do_close) {
+			self::close($stmt);
+		}
+		return $data;
+	}
+
 	/**
 	 * @brief Closes the current statement
 	 *

--- a/include/dba.php
+++ b/include/dba.php
@@ -1167,7 +1167,7 @@ class dba {
 
 		return $commands;
 	}
-// $param
+
 	/**
 	 * @brief Updates rows
 	 *

--- a/include/dba.php
+++ b/include/dba.php
@@ -767,13 +767,19 @@ class dba {
 	/**
 	 * @brief Check if data exists
 	 *
-	 * @param string $sql SQL statement
-	 * @return boolean Are there rows for that query?
+	 * @param string $table Table name
+	 * @param array $condition array of fields for condition
+	 *
+	 * @return boolean Are there rows for that condition?
 	 */
-	static public function exists($sql) {
-		$params = self::getParam(func_get_args());
+	static public function exists($table, $condition) {
+		if (empty($table)) {
+			return false;
+		}
 
-		$stmt = self::p($sql, $params);
+		$fields = array_keys($condition);
+
+		$stmt = self::select($table, array($fields[0]), $condition, array('limit' => 1, 'only_query' => true));
 
 		if (is_bool($stmt)) {
 			$retval = $stmt;
@@ -1270,11 +1276,13 @@ class dba {
 			$param_string = substr($param_string, 0, -2);
 		}
 
-		if (isset($params['limit'])) {
-			if (is_int($params['limit'])) {
-				$param_string .= " LIMIT ".$params['limit'];
-				$single_row =($params['limit'] == 1);
-			}
+		if (isset($params['limit']) && is_int($params['limit'])) {
+			$param_string .= " LIMIT ".$params['limit'];
+			$single_row = ($params['limit'] == 1);
+		}
+
+		if (isset($params['only_query']) && $params['only_query']) {
+			$single_row = !$params['only_query'];
 		}
 
 		$sql = "SELECT ".$select_fields." FROM `".$table."`".$condition_string.$param_string;

--- a/include/dbstructure.php
+++ b/include/dbstructure.php
@@ -1656,6 +1656,7 @@ function db_definition() {
 					"uid_created" => array("uid","created"),
 					"uid_commented" => array("uid","commented"),
 					"uid_wall_created" => array("uid","wall","created"),
+					"private_wall_received" => array("private","wall","received"),
 					)
 			);
 	$database["tokens"] = array(

--- a/include/identity.php
+++ b/include/identity.php
@@ -245,9 +245,8 @@ function profile_sidebar($profile, $block = 0) {
 			$profile_url = normalise_link(App::get_baseurl()."/profile/".$profile["nickname"]);
 		}
 
-		$r = q("SELECT * FROM `contact` WHERE NOT `pending` AND `uid` = %d AND `nurl` = '%s'",
-			local_user(), $profile_url);
-
+		$r = dba::select('contact', array('id'),
+			array('pending' => false, 'uid' => local_user(), 'nurl' => $profile_url), array('limit' => 1));
 		if (dbm::is_result($r))
 			$connect = false;
 	}

--- a/include/identity.php
+++ b/include/identity.php
@@ -245,10 +245,7 @@ function profile_sidebar($profile, $block = 0) {
 			$profile_url = normalise_link(App::get_baseurl()."/profile/".$profile["nickname"]);
 		}
 
-		$r = dba::select('contact', array('id'),
-			array('pending' => false, 'uid' => local_user(), 'nurl' => $profile_url), array('limit' => 1));
-		if (dbm::is_result($r))
-			$connect = false;
+		$connect = !dba::exists('contact', array('pending' => false, 'uid' => local_user(), 'nurl' => $profile_url));
 	}
 
 	if ($connect && ($profile['network'] != NETWORK_DFRN) && !isset($profile['remoteconnect']))

--- a/include/items.php
+++ b/include/items.php
@@ -963,13 +963,7 @@ function item_store($arr, $force_parent = false, $notify = false, $dontcache = f
 
 	// When the item was successfully stored we fetch the ID of the item.
 	if (dbm::is_result($r)) {
-		$r = q("SELECT LAST_INSERT_ID() AS `item-id`");
-		if (dbm::is_result($r)) {
-			$current_post = $r[0]['item-id'];
-		} else {
-			// This shouldn't happen
-			$current_post = 0;
-		}
+		$current_post = dba::lastInsertId();
 	} else {
 		// This can happen - for example - if there are locking timeouts.
 		dba::rollback();

--- a/include/network.php
+++ b/include/network.php
@@ -220,8 +220,8 @@ function z_fetch_url($url, $binary = false, &$redirects = 0, $opts = array()) {
 	if (!$ret['success']) {
 		$ret['error'] = curl_error($ch);
 		$ret['debug'] = $curl_info;
-		logger('z_fetch_url: error: ' . $url . ': ' . $ret['error'], LOGGER_DEBUG);
-		logger('z_fetch_url: debug: ' . print_r($curl_info, true), LOGGER_DATA);
+		logger('z_fetch_url: error: '.$url.': '.$ret['return_code'].' - '.$ret['error'], LOGGER_DEBUG);
+		logger('z_fetch_url: debug: '.print_r($curl_info, true), LOGGER_DATA);
 	}
 
 	$ret['body'] = substr($s, strlen($header));

--- a/include/plugin.php
+++ b/include/plugin.php
@@ -121,7 +121,7 @@ function reload_plugins() {
  * @return boolean
  */
 function plugin_enabled($plugin) {
-	$r = q("SELECT * FROM `addon` WHERE `installed` = 1 AND `name` = '%s'", $plugin);
+	$r = dba::select('addon', array('id'), array('installed' => true, 'name' => $plugin), array('limit' => 1));
 	return ((dbm::is_result($r)) && (count($r) > 0));
 }
 

--- a/include/plugin.php
+++ b/include/plugin.php
@@ -544,6 +544,8 @@ function upgrade_bool_message($bbcode = false) {
  * @return string Path to the file or empty string if the file isn't found
  */
 function theme_include($file, $root = '') {
+	$file = basename($file);
+
 	// Make sure $root ends with a slash / if it's not blank
 	if ($root !== '' && $root[strlen($root)-1] !== '/') {
 		$root = $root . '/';

--- a/include/plugin.php
+++ b/include/plugin.php
@@ -121,8 +121,7 @@ function reload_plugins() {
  * @return boolean
  */
 function plugin_enabled($plugin) {
-	$r = dba::select('addon', array('id'), array('installed' => true, 'name' => $plugin), array('limit' => 1));
-	return ((dbm::is_result($r)) && (count($r) > 0));
+	return dba::exists('addon', array('installed' => true, 'name' => $plugin));
 }
 
 

--- a/include/remove_contact.php
+++ b/include/remove_contact.php
@@ -14,8 +14,8 @@ function remove_contact_run($argv, $argc) {
 	$id = intval($argv[1]);
 
 	// Only delete if the contact doesn't exist (anymore)
-	$r = dba::select('contact', array('id'), array('id' => $id), array('limit' => 1));
-	if (dbm::is_result($r)) {
+	$r = dba::exists('contact', array('id' => $id));
+	if ($r) {
 		return;
 	}
 

--- a/include/socgraph.php
+++ b/include/socgraph.php
@@ -1025,7 +1025,7 @@ function poco_check_server($server_url, $network = "", $force = false) {
 	if (dbm::is_result($servers) && ($orig_server_url == $server_url) &&
 		($serverret['errno'] == CURLE_OPERATION_TIMEDOUT)) {
 		logger("Connection to server ".$server_url." timed out.", LOGGER_DEBUG);
-		dba::p("UPDATE `gserver` SET `last_failure` = ? WHERE `nurl` = ?", datetime_convert(), normalise_link($server_url));
+		dba::update('gserver', array('last_failure' => datetime_convert()), array('nurl' => normalise_link($server_url)));
 		return false;
 	}
 
@@ -1040,7 +1040,7 @@ function poco_check_server($server_url, $network = "", $force = false) {
 		// Quit if there is a timeout
 		if ($serverret['errno'] == CURLE_OPERATION_TIMEDOUT) {
 			logger("Connection to server ".$server_url." timed out.", LOGGER_DEBUG);
-			dba::p("UPDATE `gserver` SET `last_failure` = ? WHERE `nurl` = ?", datetime_convert(), normalise_link($server_url));
+			dba::update('gserver', array('last_failure' => datetime_convert()), array('nurl' => normalise_link($server_url)));
 			return false;
 		}
 

--- a/include/text.php
+++ b/include/text.php
@@ -1289,7 +1289,7 @@ function put_item_in_cache(&$item, $update = false) {
 		$item["rendered-hash"] = hash("md5", $item["body"]);
 		$item["body"] = $body;
 
-		if ($update && ($item["id"] != 0)) {
+		if ($update && ($item["id"] > 0)) {
 			dba::update('item', array('rendered-html' => $item["rendered-html"], 'rendered-hash' => $item["rendered-hash"]),
 					array('id' => $item["id"]), false);
 		}

--- a/include/text.php
+++ b/include/text.php
@@ -1290,8 +1290,8 @@ function put_item_in_cache(&$item, $update = false) {
 		$item["body"] = $body;
 
 		if ($update && ($item["id"] != 0)) {
-			q("UPDATE `item` SET `rendered-html` = '%s', `rendered-hash` = '%s' WHERE `id` = %d",
-				dbesc($item["rendered-html"]), dbesc($item["rendered-hash"]), intval($item["id"]));
+			dba::update('item', array('rendered-html' => $item["rendered-html"], 'rendered-hash' => $item["rendered-hash"]),
+					array('id' => $item["id"]), false);
 		}
 	}
 }

--- a/include/text.php
+++ b/include/text.php
@@ -499,8 +499,7 @@ function item_new_uri($hostname, $uid, $guid = "") {
 
 		$uri = "urn:X-dfrn:" . $hostname . ':' . $uid . ':' . $hash;
 
-		$r = q("SELECT `id` FROM `item` WHERE `uri` = '%s' LIMIT 1",
-			dbesc($uri));
+		$r = dba::select('item', array('id'), array('uri' => $uri), array('limit' => 1));
 		if (dbm::is_result($r)) {
 			$dups = true;
 		}
@@ -1324,11 +1323,10 @@ function prepare_body(&$item, $attach = false, $preview = false) {
 	$mentions = array();
 
 	if (!get_config('system','suppress_tags')) {
-		$taglist = q("SELECT `type`, `term`, `url` FROM `term` WHERE `otype` = %d AND `oid` = %d AND `type` IN (%d, %d) ORDER BY `tid`",
+		$taglist = dba::p("SELECT `type`, `term`, `url` FROM `term` WHERE `otype` = ? AND `oid` = ? AND `type` IN (?, ?) ORDER BY `tid`",
 				intval(TERM_OBJ_POST), intval($item['id']), intval(TERM_HASHTAG), intval(TERM_MENTION));
 
-		foreach ($taglist as $tag) {
-
+		while ($tag = dba::fetch($taglist)) {
 			if ($tag["url"] == "") {
 				$tag["url"] = $searchpath.strtolower($tag["term"]);
 			}
@@ -1342,6 +1340,7 @@ function prepare_body(&$item, $attach = false, $preview = false) {
 			}
 			$tags[] = $prefix."<a href=\"".$tag["url"]."\" target=\"_blank\">".$tag["term"]."</a>";
 		}
+		dba::close($taglist);
 	}
 
 	$item['tags'] = $tags;
@@ -1665,7 +1664,7 @@ function generate_user_guid() {
 		if (! dbm::is_result($x)) {
 			$found = false;
 		}
-	} while ($found == true );
+	} while ($found == true);
 
 	return $guid;
 }

--- a/include/text.php
+++ b/include/text.php
@@ -488,8 +488,6 @@ if (! function_exists('item_new_uri')) {
 function item_new_uri($hostname, $uid, $guid = "") {
 
 	do {
-		$dups = false;
-
 		if ($guid == "") {
 			$hash = get_guid(32);
 		} else {
@@ -499,10 +497,7 @@ function item_new_uri($hostname, $uid, $guid = "") {
 
 		$uri = "urn:X-dfrn:" . $hostname . ':' . $uid . ':' . $hash;
 
-		$r = dba::select('item', array('id'), array('uri' => $uri), array('limit' => 1));
-		if (dbm::is_result($r)) {
-			$dups = true;
-		}
+		$dups = dba::exists('item', array('uri' => $uri));
 	} while ($dups == true);
 
 	return $uri;

--- a/include/threads.php
+++ b/include/threads.php
@@ -262,7 +262,7 @@ function delete_thread($itemid, $itemuri = "") {
 function update_threads() {
 	logger("update_threads: start");
 
-	$messages = dba::p("SELECT `id` FROM `item` WHERE `id` = `parent`");
+	$messages = dba::select('item', array('id'), array("`id` = `parent`"));
 
 	logger("update_threads: fetched messages: ".dba::num_rows($messages));
 
@@ -292,9 +292,9 @@ function update_threads_mention() {
 function update_shadow_copy() {
 	logger("start");
 
-	$messages = dba::p("SELECT `iid` FROM `thread` WHERE `uid` != 0 AND `network` IN ('', ?, ?, ?)
-				AND `visible` AND NOT `deleted` AND NOT `moderated` AND NOT `private` ORDER BY `created`",
-				NETWORK_DFRN, NETWORK_DIASPORA, NETWORK_OSTATUS);
+	$condition = "`uid` != 0 AND `network` IN ('', ?, ?, ?) AND `visible` AND NOT `deleted` AND NOT `moderated` AND NOT `private`";
+	$messages = dba::select('thread', array('iid'), array($condition, NETWORK_DFRN, NETWORK_DIASPORA, NETWORK_OSTATUS),
+				array('order' => 'created'));
 
 	logger("fetched messages: ".dba::num_rows($messages));
 	while ($message = dba::fetch($messages))

--- a/include/uimport.php
+++ b/include/uimport.php
@@ -6,13 +6,11 @@ require_once("include/Photo.php");
 define("IMPORT_DEBUG", False);
 
 function last_insert_id() {
-	global $db;
-
 	if (IMPORT_DEBUG) {
 		return 1;
 	}
 
-	return $db->insert_id();
+	return dba::lastInsertId();
 }
 
 function last_error() {

--- a/index.php
+++ b/index.php
@@ -498,7 +498,7 @@ if (isset($_GET["mode"])) {
 }
 
 // If there is no page template use the default page template
-if (!$template) {
+if (empty($template)) {
 	$template = theme_include("default.php");
 }
 

--- a/mod/community.php
+++ b/mod/community.php
@@ -11,7 +11,6 @@ function community_init(App $a) {
 }
 
 function community_content(App $a, $update = 0) {
-
 	$o = '';
 
 	if ((Config::get('system','block_public')) && (! local_user()) && (! remote_user())) {
@@ -92,34 +91,27 @@ function community_getitems($start, $itemspage) {
 	if (Config::get('system','community_page_style') == CP_GLOBAL_COMMUNITY) {
 		return(community_getpublicitems($start, $itemspage));
 	}
-	$r = qu("SELECT %s
-		FROM `thread`
+	$r = dba::p("SELECT ".item_fieldlists()." FROM `thread`
 		INNER JOIN `user` ON `user`.`uid` = `thread`.`uid` AND NOT `user`.`hidewall`
 		INNER JOIN `item` ON `item`.`id` = `thread`.`iid`
 		AND `item`.`allow_cid` = ''  AND `item`.`allow_gid` = ''
-		AND `item`.`deny_cid`  = '' AND `item`.`deny_gid`  = ''
-		%s AND `contact`.`self`
+		AND `item`.`deny_cid`  = '' AND `item`.`deny_gid`  = ''".
+		item_joins()." AND `contact`.`self`
 		WHERE `thread`.`visible` AND NOT `thread`.`deleted` AND NOT `thread`.`moderated`
 		AND NOT `thread`.`private` AND `thread`.`wall`
-		ORDER BY `thread`.`received` DESC LIMIT %d, %d",
-		item_fieldlists(), item_joins(),
-		intval($start), intval($itemspage)
+		ORDER BY `thread`.`received` DESC LIMIT ".intval($start).", ".intval($itemspage)
 	);
 
-	return($r);
-
+	return dba::inArray($r);
 }
 
 function community_getpublicitems($start, $itemspage) {
-
-	$r = qu("SELECT %s
-		FROM `thread`
-		INNER JOIN `item` ON `item`.`id` = `thread`.`iid` %s
-		WHERE `thread`.`uid` = 0 AND `verb` = '%s'
-		ORDER BY `thread`.`created` DESC LIMIT %d, %d",
-		item_fieldlists(), item_joins(),
-		dbesc(ACTIVITY_POST), intval($start), intval($itemspage)
+	$r = dba::p("SELECT ".item_fieldlists()." FROM `thread`
+		INNER JOIN `item` ON `item`.`id` = `thread`.`iid` ".item_joins().
+		"WHERE `thread`.`uid` = 0 AND `verb` = ?
+		ORDER BY `thread`.`created` DESC LIMIT ".intval($start).", ".intval($itemspage),
+		ACTIVITY_POST
 	);
 
-	return($r);
+	return dba::inArray($r);
 }

--- a/mod/display.php
+++ b/mod/display.php
@@ -72,7 +72,7 @@ function display_init(App $a) {
 			if ($r["id"] != $r["parent"]) {
 				$r = dba::fetch_first("SELECT `id`, `author-name`, `author-link`, `author-avatar`, `network`, `body`, `uid`, `owner-link` FROM `item`
 					WHERE `item`.`visible` AND NOT `item`.`deleted` AND NOT `item`.`moderated`
-						AND `id` = %d", $r["parent"]);
+						AND `id` = ?", $r["parent"]);
 			}
 			if (($itemuid != local_user()) && local_user()) {
 				// Do we know this contact but we haven't got this item?

--- a/mod/display.php
+++ b/mod/display.php
@@ -80,7 +80,7 @@ function display_init(App $a) {
 				// We really should change this need for the future since it scales very bad.
 				$contactid = get_contact($r['owner-link'], local_user());
 				if ($contactid) {
-					$items = dba::p("SELECT * FROM `item` WHERE `parent` = ? ORDER BY `id`", $r["id"]);
+					$items = dba::select('item', array(), array('parent' => $r["id"]), array('order' => array('id')));
 					while ($item = dba::fetch($items)) {
 						$itemcontactid = get_contact($item['owner-link'], local_user());
 						if (!$itemcontactid) {

--- a/mod/display.php
+++ b/mod/display.php
@@ -81,7 +81,7 @@ function display_init(App $a) {
 				$contactid = get_contact($r['owner-link'], local_user());
 				if ($contactid) {
 					$items = dba::p("SELECT * FROM `item` WHERE `parent` = ? ORDER BY `id`", $r["id"]);
-					while ($item = self::fetch($items)) {
+					while ($item = dba::fetch($items)) {
 						$itemcontactid = get_contact($item['owner-link'], local_user());
 						if (!$itemcontactid) {
 							$itemcontactid = $contactid;

--- a/mod/display.php
+++ b/mod/display.php
@@ -292,8 +292,8 @@ function display_content(App $a, $update = 0) {
 	}
 
 	// We are displaying an "alternate" link if that post was public. See issue 2864
-	$items = dba::select('item', array('id'), array('id' => $item_id, 'private' => false, 'wall' => true));
-	if (dbm::is_result($items)) {
+	$is_public = dba::exists('item', array('id' => $item_id, 'private' => false, 'wall' => true));
+	if ($is_public) {
 		$alternate = App::get_baseurl().'/display/'.$nick.'/'.$item_id.'.atom';
 	} else {
 		$alternate = '';
@@ -369,14 +369,14 @@ function display_content(App $a, $update = 0) {
 	$sql_extra = item_permissions_sql($a->profile['uid'],$remote_contact,$groups);
 
 	if ($update) {
-		$r = dba::exists("SELECT `id` FROM `item` WHERE `item`.`uid` = ?
+		$r = dba::p("SELECT `id` FROM `item` WHERE `item`.`uid` = ?
 			AND `item`.`parent` = (SELECT `parent` FROM `item` WHERE `id` = ?)
 			$sql_extra AND `unseen`",
 			$a->profile['uid'],
 			$item_id
 		);
 
-		if (!$r) {
+		if (dba::num_rows($r) == 0) {
 			return '';
 		}
 	}

--- a/mod/item.php
+++ b/mod/item.php
@@ -887,12 +887,7 @@ function item_post(App $a) {
 	);
 
 	if (dbm::is_result($r)) {
-		$r = q("SELECT LAST_INSERT_ID() AS `item-id`");
-		if (dbm::is_result($r)) {
-			$post_id = $r[0]['item-id'];
-		} else {
-			$post_id = 0;
-		}
+		$post_id = dba::lastInsertId();
 	} else {
 		logger('mod_item: unable to create post.');
 		$post_id = 0;

--- a/mod/network.php
+++ b/mod/network.php
@@ -793,9 +793,9 @@ function network_content(App $a, $update = 0) {
 
 
 	if (!$group && !$cid && !$star) {
-		$unseen = dba::select('item', array('id'), array('unseen' => true, 'uid' => local_user()), array('limit' => 1));
+		$unseen = dba::exists('item', array('unseen' => true, 'uid' => local_user()));
 
-		if (dbm::is_result($unseen)) {
+		if ($unseen) {
 			$r = dba::update('item', array('unseen' => false), array('uid' => local_user(), 'unseen' => true));
 		}
 	} elseif ($update_unseen) {

--- a/mod/profile.php
+++ b/mod/profile.php
@@ -333,11 +333,13 @@ function profile_content(App $a, $update = 0) {
 	}
 
 
-	if($is_owner) {
-		$r = q("UPDATE `item` SET `unseen` = 0
-			WHERE `wall` = 1 AND `unseen` = 1 AND `uid` = %d",
-			intval(local_user())
-		);
+	if ($is_owner) {
+		$unseen = dba::select('item', array('id'), array('wall' => true, 'unseen' => true, 'uid' => local_user()),
+			array('limit' => 1));
+		if (dbm::is_result($unseen)) {
+			$r = dba::update('item', array('unseen' => false),
+					array('wall' => true, 'unseen' => true, 'uid' => local_user()));
+		}
 	}
 
 	$o .= conversation($a, $items, 'profile', $update);

--- a/mod/profile.php
+++ b/mod/profile.php
@@ -334,9 +334,8 @@ function profile_content(App $a, $update = 0) {
 
 
 	if ($is_owner) {
-		$unseen = dba::select('item', array('id'), array('wall' => true, 'unseen' => true, 'uid' => local_user()),
-			array('limit' => 1));
-		if (dbm::is_result($unseen)) {
+		$unseen = dba::exists('item', array('wall' => true, 'unseen' => true, 'uid' => local_user()));
+		if ($unseen) {
 			$r = dba::update('item', array('unseen' => false),
 					array('wall' => true, 'unseen' => true, 'uid' => local_user()));
 		}

--- a/src/App.php
+++ b/src/App.php
@@ -760,7 +760,11 @@ class App {
 
 		$callstack = array();
 		foreach ($trace AS $func) {
-			$callstack[] = $func['function'];
+			if (!empty($func['class'])) {
+				$callstack[] = $func['class'].'::'.$func['function'];
+			} else {
+				$callstack[] = $func['function'];
+			}
 		}
 
 		return implode(', ', $callstack);

--- a/update.php
+++ b/update.php
@@ -1,6 +1,6 @@
 <?php
 
-define('UPDATE_VERSION' , 1233);
+define('UPDATE_VERSION' , 1234);
 
 /**
  *


### PR DESCRIPTION
Many old database calls are replaced by their new representatives. Additionally the new calls now accept complex conditions as well. From now on we should be able to execute (nearly) every modification call (delete, update, insert) and most other calls (except "select" calls with table relations, count, distinct, ...) via the more abstract functions.

@tobiasd If you tell me a nice place for that, I will document the usage of the new commands.

@tobiasd @rabuzarus @fabrixxm @Hypolite When checking pull requests we now should enforce the new commands. No new calls of the old function "q" should be accepted, I think.