### PR TITLE
Probing sometimes failed / problems with some web servers

### DIFF
--- a/include/network.php
+++ b/include/network.php
@@ -107,6 +107,11 @@ function z_fetch_url($url, $binary = false, &$redirects = 0, $opts = array()) {
 		@curl_setopt($ch, CURLOPT_RANGE, '0-' . $range);
 	}
 
+	// Without this setting it seems as if some webservers send compressed content
+	// This seems to confuse curl so that it shows this uncompressed.
+	/// @todo  We could possibly set this value to "gzip" or something similar
+	curl_setopt($ch, CURLOPT_ENCODING, '');
+
 	if (x($opts, 'headers')) {
 		@curl_setopt($ch, CURLOPT_HTTPHEADER, $opts['headers']);
 	}

--- a/src/Network/Probe.php
+++ b/src/Network/Probe.php
@@ -104,13 +104,10 @@ class Probe {
 		logger("Probing for ".$host, LOGGER_DEBUG);
 
 		$ret = z_fetch_url($ssl_url, false, $redirects, array('timeout' => $xrd_timeout, 'accept_content' => 'application/xrd+xml'));
-		if (($ret['errno'] == CURLE_OPERATION_TIMEDOUT) && !self::ownHost($ssl_url)) {
-			logger("Probing timeout for ".$ssl_url, LOGGER_DEBUG);
-			return false;
+		if ($ret['success']) {
+			$xml = $ret['body'];
+			$xrd = parse_xml_string($xml, false);
 		}
-		$xml = $ret['body'];
-
-		$xrd = parse_xml_string($xml, false);
 
 		if (!is_object($xrd)) {
 			$ret = z_fetch_url($url, false, $redirects, array('timeout' => $xrd_timeout, 'accept_content' => 'application/xrd+xml'));


### PR DESCRIPTION
Sometimes probing the SSL port can create a timeout - although the unsafe port works. This is now solved. Additionally there had been some problems with web servers sending compressed content.