### PR TITLE
Possibly Issue 3611: Better feed handling when there is no body

### DIFF
--- a/include/feed.php
+++ b/include/feed.php
@@ -338,12 +338,24 @@ function feed_import($xml,$importer,&$contact, &$hub, $simulate = false) {
 			if ($body == "") {
 				$body = trim($xpath->evaluate('atom:summary/text()', $entry)->item(0)->nodeValue);
 			}
+
 			// remove the content of the title if it is identically to the body
 			// This helps with auto generated titles e.g. from tumblr
 			if (title_is_body($item["title"], $body)) {
 				$item["title"] = "";
 			}
 			$item["body"] = html2bbcode($body);
+
+			if ($item["body"] == "") {
+				if ($item["title"] != '') {
+					$item["body"] = $item["title"];
+					$item["title"] = '';
+				}
+			}
+
+			if (!strstr($item["body"], '[url') && ($item['plink'] != '')) {
+				$item["body"] .= "\n[hr]\n[url]".$item['plink']."[/url]";
+			}
 		}
 
 		if (!$simulate) {

--- a/include/feed.php
+++ b/include/feed.php
@@ -346,11 +346,9 @@ function feed_import($xml,$importer,&$contact, &$hub, $simulate = false) {
 			}
 			$item["body"] = html2bbcode($body);
 
-			if ($item["body"] == "") {
-				if ($item["title"] != '') {
-					$item["body"] = $item["title"];
-					$item["title"] = '';
-				}
+			if (($item["body"] == '') && ($item["title"] != '')) {
+				$item["body"] = $item["title"];
+				$item["title"] = '';
 			}
 
 			if (!strstr($item["body"], '[url') && ($item['plink'] != '')) {

--- a/include/feed.php
+++ b/include/feed.php
@@ -352,7 +352,7 @@ function feed_import($xml,$importer,&$contact, &$hub, $simulate = false) {
 			}
 
 			if (!strstr($item["body"], '[url') && ($item['plink'] != '')) {
-				$item["body"] .= "\n[hr]\n[url]".$item['plink']."[/url]";
+				$item["body"] .= "[hr][url]".$item['plink']."[/url]";
 			}
 		}
 


### PR DESCRIPTION
This possibly fixes issue https://github.com/friendica/friendica/issues/3611

When a feed didn't contain a message but only a title then we now use the title as body. And when there is no link to the original content in the feed text then we add it.

It is important to do this in the body since the information in the "plink" is lost when it is a "remote self" post.