### PR TITLE
Bugfix: You cannot be local and remote at the same time

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -947,6 +947,10 @@ function public_contact() {
  * @return int|bool visitor_id or false
  */
 function remote_user() {
+	// You cannot be both local and remote
+	if (local_user()) {
+		return false;
+	}
 	if ((x($_SESSION, 'authenticated')) && (x($_SESSION, 'visitor_id'))) {
 		return intval($_SESSION['visitor_id']);
 	}


### PR DESCRIPTION
It can happen that you are both a remote and a local user. I guess this happens with magic links where you are authenticated at the same time.

This just creates confusion, so from now on you can only be a local or a remote user - but not both.