### PR TITLE
We can now unfollow a contact without deleting it

### DIFF
--- a/mod/contacts.php
+++ b/mod/contacts.php
@@ -574,9 +574,15 @@ function contacts_content(App $a) {
 		if ($contact['network'] == NETWORK_DFRN)
 			$profile_select = contact_profile_assign($contact['profile-id'],(($contact['network'] !== NETWORK_DFRN) ? true : false));
 
-		if (in_array($contact['network'], array(NETWORK_DIASPORA, NETWORK_OSTATUS)) &&
-			($contact['rel'] == CONTACT_IS_FOLLOWER))
-			$follow = System::baseUrl(true)."/follow?url=".urlencode($contact["url"]);
+		if (in_array($contact['network'], array(NETWORK_DIASPORA, NETWORK_OSTATUS))) {
+			if ($contact['rel'] == CONTACT_IS_FOLLOWER) {
+				$follow = System::baseUrl(true)."/follow?url=".urlencode($contact["url"]);
+				$follow_text = t("Connect/Follow");
+			} elseif ($contact['rel'] == CONTACT_IS_FRIEND) {
+				$follow = System::baseUrl(true)."/unfollow?url=".urlencode($contact["url"]);
+				$follow_text = t("Disconnect/Unfollow");
+			}
+		}
 
 		// Load contactact related actions like hide, suggest, delete and others
 		$contact_actions = contact_actions($contact);
@@ -613,7 +619,7 @@ function contacts_content(App $a) {
 			'$last_update' => $last_update,
 			'$udnow' => t('Update now'),
 			'$follow' => $follow,
-			'$follow_text' => t("Connect/Follow"),
+			'$follow_text' => $follow_text,
 			'$profile_select' => $profile_select,
 			'$contact_id' => $contact['id'],
 			'$block_text' => (($contact['blocked']) ? t('Unblock') : t('Block') ),

--- a/mod/dfrn_confirm.php
+++ b/mod/dfrn_confirm.php
@@ -352,8 +352,7 @@ function dfrn_confirm_post(App $a, $handsfree = null) {
 				dbesc(NETWORK_DFRN),
 				intval($contact_id)
 			);
-		}
-		else {
+		} else {
 
 			// $network !== NETWORK_DFRN
 
@@ -361,17 +360,15 @@ function dfrn_confirm_post(App $a, $handsfree = null) {
 			$notify = (($contact['notify']) ? $contact['notify'] : '');
 			$poll   = (($contact['poll']) ? $contact['poll'] : '');
 
-			if((! $contact['notify']) || (! $contact['poll'])) {
-				$arr = Probe::lrdd($contact['url']);
-				if(count($arr)) {
-					foreach($arr as $link) {
-						if($link['@attributes']['rel'] === 'salmon')
-							$notify = $link['@attributes']['href'];
-						if($link['@attributes']['rel'] === NAMESPACE_FEED)
-							$poll = $link['@attributes']['href'];
-					}
-				}
+			$arr = Probe::uri($contact['url']);
+			if (empty($contact['notify'])) {
+				$notify = $arr['notify'];
 			}
+			if (empty($contact['poll'])) {
+				$poll = $arr['poll'];
+			}
+
+			$addr = $arr['addr'];
 
 			$new_relation = $contact['rel'];
 			$writable = $contact['writable'];
@@ -394,6 +391,7 @@ function dfrn_confirm_post(App $a, $handsfree = null) {
 
 			$r = q("UPDATE `contact` SET `name-date` = '%s',
 				`uri-date` = '%s',
+				`addr` = '%s',
 				`notify` = '%s',
 				`poll` = '%s',
 				`blocked` = 0,
@@ -406,6 +404,7 @@ function dfrn_confirm_post(App $a, $handsfree = null) {
 			",
 				dbesc(datetime_convert()),
 				dbesc(datetime_convert()),
+				dbesc($addr),
 				dbesc($notify),
 				dbesc($poll),
 				dbesc($network),

--- a/mod/follow.php
+++ b/mod/follow.php
@@ -8,6 +8,47 @@ require_once 'include/follow.php';
 require_once 'include/Contact.php';
 require_once 'include/contact_selectors.php';
 
+function follow_post(App $a) {
+
+	if (! local_user()) {
+		notice( t('Permission denied.') . EOL);
+		goaway($_SESSION['return_url']);
+		// NOTREACHED
+	}
+
+	if ($_REQUEST['cancel']) {
+		goaway($_SESSION['return_url']);
+	}
+
+	$uid = local_user();
+	$url = notags(trim($_REQUEST['url']));
+	$return_url = $_SESSION['return_url'];
+
+	// Makes the connection request for friendica contacts easier
+	// This is just a precaution if maybe this page is called somewhere directly via POST
+	$_SESSION["fastlane"] = $url;
+
+	$result = new_contact($uid,$url,true);
+
+	if ($result['success'] == false) {
+		if ($result['message']) {
+			notice($result['message']);
+		}
+		goaway($return_url);
+	} elseif ($result['cid']) {
+		goaway(System::baseUrl().'/contacts/'.$result['cid']);
+	}
+
+	info( t('Contact added').EOL);
+
+	if (strstr($return_url,'contacts')) {
+		goaway(System::baseUrl().'/contacts/'.$contact_id);
+	}
+
+	goaway($return_url);
+	// NOTREACHED
+}
+
 function follow_content(App $a) {
 
 	if (! local_user()) {
@@ -99,13 +140,6 @@ function follow_content(App $a) {
 		$r[0]["about"] = "";
 	}
 
-	$header = $ret["name"];
-
-	if ($ret["addr"] != "") {
-		$header .= " <".$ret["addr"].">";
-	}
-
-	//$header .= " (".network_to_name($ret['network'], $ret['url']).")";
 	$header = t("Connect/Follow");
 
 	$o  = replace_macros($tpl,array(
@@ -153,45 +187,4 @@ function follow_content(App $a) {
 	}
 
 	return $o;
-}
-
-function follow_post(App $a) {
-
-	if (! local_user()) {
-		notice( t('Permission denied.') . EOL);
-		goaway($_SESSION['return_url']);
-		// NOTREACHED
-	}
-
-	if ($_REQUEST['cancel']) {
-		goaway($_SESSION['return_url']);
-	}
-
-	$uid = local_user();
-	$url = notags(trim($_REQUEST['url']));
-	$return_url = $_SESSION['return_url'];
-
-	// Makes the connection request for friendica contacts easier
-	// This is just a precaution if maybe this page is called somewhere directly via POST
-	$_SESSION["fastlane"] = $url;
-
-	$result = new_contact($uid,$url,true);
-
-	if ($result['success'] == false) {
-		if ($result['message']) {
-			notice($result['message']);
-		}
-		goaway($return_url);
-	} elseif ($result['cid']) {
-		goaway(System::baseUrl().'/contacts/'.$result['cid']);
-	}
-
-	info( t('Contact added').EOL);
-
-	if (strstr($return_url,'contacts')) {
-		goaway(System::baseUrl().'/contacts/'.$contact_id);
-	}
-
-	goaway($return_url);
-	// NOTREACHED
 }

--- a/mod/unfollow.php
+++ b/mod/unfollow.php
@@ -1,0 +1,146 @@
+<?php
+
+use Friendica\App;
+use Friendica\Core\System;
+
+require_once 'include/probe.php';
+require_once 'include/follow.php';
+require_once 'include/Contact.php';
+require_once 'include/contact_selectors.php';
+
+function unfollow_content(App $a) {
+
+	if (! local_user()) {
+		notice(t('Permission denied.') . EOL);
+		goaway($_SESSION['return_url']);
+		// NOTREACHED
+	}
+
+	$uid = local_user();
+	$url = notags(trim($_REQUEST['url']));
+
+	$submit = t('Submit Request');
+
+	$condition = array("`uid` = ? AND `rel` = ? AND (`nurl` = ? OR `alias` = ? OR `alias` = ?) AND `network` != ?",
+			local_user(), CONTACT_IS_FRIEND, normalise_link($url),
+			normalise_link($url), $url, NETWORK_STATUSNET);
+	$contact = dba::select('contact', array('url', 'network', 'addr', 'name'), $condition, array('limit' => 1));
+
+	if (!dbm::is_result($contact)) {
+		notice(t("You aren't a friend of this contact.").EOL);
+		$submit = "";
+		// NOTREACHED
+	}
+
+	if (!in_array($contact['network'], array(NETWORK_DIASPORA, NETWORK_OSTATUS))) {
+		notice(t("Unfollowing is currently not supported by your network.").EOL);
+		$submit = "";
+		// NOTREACHED
+	}
+
+	$request = System::baseUrl()."/unfollow";
+	$tpl = get_markup_template('auto_request.tpl');
+
+	$r = q("SELECT `url` FROM `contact` WHERE `uid` = %d AND `self` LIMIT 1", intval($uid));
+
+	if (!$r) {
+		notice(t('Permission denied.') . EOL);
+		goaway($_SESSION['return_url']);
+		// NOTREACHED
+	}
+
+	$myaddr = $r[0]["url"];
+
+	// Makes the connection request for friendica contacts easier
+	$_SESSION["fastlane"] = $contact["url"];
+
+	$header = $contact["name"];
+
+	if ($contact["addr"] != "") {
+		$header .= " <".$contact["addr"].">";
+	}
+
+	$header = t("Disconnect/Unfollow");
+
+	$o  = replace_macros($tpl,array(
+			'$header' => htmlentities($header),
+			'$desc' => "",
+			'$pls_answer' => "",
+			'$does_know_you' => "",
+			'$add_note' => "",
+			'$page_desc' => "",
+			'$friendica' => "",
+			'$statusnet' => "",
+			'$diaspora' => "",
+			'$diasnote' => "",
+			'$your_address' => t('Your Identity Address:'),
+			'$invite_desc' => "",
+			'$emailnet' => "",
+			'$submit' => $submit,
+			'$cancel' => t('Cancel'),
+			'$nickname' => "",
+			'$name' => $contact["name"],
+			'$url' => $contact["url"],
+			'$zrl' => zrl($contact["url"]),
+			'$url_label' => t("Profile URL"),
+			'$myaddr' => $myaddr,
+			'$request' => $request,
+			'$keywords' => "",
+			'$keywords_label' => ""
+	));
+
+	$a->page['aside'] = "";
+	profile_load($a, "", 0, get_contact_details_by_url($contact["url"]));
+
+	$o .= replace_macros(get_markup_template('section_title.tpl'),
+					array('$title' => t('Status Messages and Posts')
+	));
+
+	// Show last public posts
+	$o .= posts_from_contact_url($a, $contact["url"]);
+
+	return $o;
+}
+
+function unfollow_post(App $a) {
+
+	if (!local_user()) {
+		notice(t('Permission denied.') . EOL);
+		goaway($_SESSION['return_url']);
+		// NOTREACHED
+	}
+
+	if ($_REQUEST['cancel']) {
+		goaway($_SESSION['return_url']);
+	}
+
+	$uid = local_user();
+	$url = notags(trim($_REQUEST['url']));
+	$return_url = $_SESSION['return_url'];
+
+	$condition = array("`uid` = ? AND `rel` = ? AND (`nurl` = ? OR `alias` = ? OR `alias` = ?) AND `network` != ?",
+			$uid, CONTACT_IS_FRIEND, normalise_link($url),
+			normalise_link($url), $url, NETWORK_STATUSNET);
+	$contact = dba::select('contact', array(), $condition, array('limit' => 1));
+
+	if (!dbm::is_result($contact)) {
+		notice(t("Contact wasn't found or can't be unfollowed."));
+	} else {
+		if (in_array($contact['network'], array(NETWORK_OSTATUS))) {
+			$r = q("SELECT `contact`.*, `user`.* FROM `contact` INNER JOIN `user` ON `contact`.`uid` = `user`.`uid`
+				WHERE `user`.`uid` = %d AND `contact`.`self` LIMIT 1",
+				intval($uid)
+			);
+ 			if (dbm::is_result($r)) {
+				$self = ""; // Unused parameter
+				terminate_friendship($r[0], $self, $contact);
+			}
+		}
+		dba::update('contact', array('rel' => CONTACT_IS_FOLLOWER), array('id' => $contact['id']));
+
+		info(t('Contact unfollowed').EOL);
+		goaway(System::baseUrl().'/contacts/'.$contact['id']);
+	}
+	goaway($return_url);
+	// NOTREACHED
+}


### PR DESCRIPTION
Before this PR it was possible to "upgrade" a follower to a friend - but the reverse way wasn't possible.

Only problem: This only works well with Diaspora and OStatus. DFRN needs more attention and possibly some rework to make this possible.