### PR TITLE
Diaspora: Posts from Diaspora relais are transmitted the old way

### DIFF
--- a/include/Smilies.php
+++ b/include/Smilies.php
@@ -3,6 +3,9 @@
 /**
  * @file include/Smilies.php
  * @brief This file contains the Smilies class which contains functions to handle smiles
+ *
+ * @todo Use the shortcodes from here:
+ * https://github.com/iamcal/emoji-data/blob/master/emoji_pretty.json?raw=true
  */
 
 use Friendica\App;

--- a/include/diaspora.php
+++ b/include/diaspora.php
@@ -227,7 +227,7 @@ class Diaspora {
 		$basedom = parse_xml_string($xml);
 
 		if (!is_object($basedom)) {
-			logger('Received data does not seem to be an XML. Discarding.');
+			logger('Received data does not seem to be an XML. Discarding. '.$xml);
 			http_status_exit(400);
 		}
 

--- a/include/diaspora.php
+++ b/include/diaspora.php
@@ -287,6 +287,11 @@ class Diaspora {
 			$public = true;
 			$author_link = str_replace('acct:','',$children->header->author_id);
 		} else {
+			// This happens with posts from a relais
+			if (!$importer) {
+				logger("This is no private post in the old format", LOGGER_DEBUG);
+				return false;
+			}
 
 			$encrypted_header = json_decode(base64_decode($children->encrypted_header));
 

--- a/mod/receive.php
+++ b/mod/receive.php
@@ -17,11 +17,11 @@ function receive_post(App $a) {
 		http_status_exit(500);
 	}
 
-	$public = false;
-
 	if (($a->argc == 2) && ($a->argv[1] === 'public')) {
 		$public = true;
+		$importer = false;
 	} else {
+		$public = false;
 
 		if ($a->argc != 3 || $a->argv[1] !== 'users') {
 			http_status_exit(500);
@@ -49,8 +49,13 @@ function receive_post(App $a) {
 		logger('mod-diaspora: message is in the new format', LOGGER_DEBUG);
 		$msg = Diaspora::decode_raw($importer, $postdata);
 	} else {
-		logger('mod-diaspora: message is in the old format', LOGGER_DEBUG);
+		logger('mod-diaspora: decode message in the old format', LOGGER_DEBUG);
 		$msg = Diaspora::decode($importer, $xml);
+
+		if ($public && !$msg) {
+			logger('mod-diaspora: decode message in the new format', LOGGER_DEBUG);
+			$msg = Diaspora::decode_raw($importer, $xml);
+		}
 	}
 
 	logger('mod-diaspora: decoded', LOGGER_DEBUG);


### PR DESCRIPTION
Messages from Diaspora relais are transmitted in the old transport format - but possibly in the new message format.