### PR TITLE
Diaspora: XML parsing is more tolerant now

### DIFF
--- a/include/diaspora.php
+++ b/include/diaspora.php
@@ -118,7 +118,7 @@ class Diaspora {
 	 */
 	private static function verify_magic_envelope($envelope) {
 
-		$basedom = parse_xml_string($envelope, false);
+		$basedom = parse_xml_string($envelope);
 
 		if (!is_object($basedom)) {
 			logger("Envelope is no XML file");
@@ -309,7 +309,7 @@ class Diaspora {
 			$decrypted = self::aes_decrypt($outer_key, $outer_iv, $ciphertext);
 
 			logger('decrypted: '.$decrypted, LOGGER_DEBUG);
-			$idom = parse_xml_string($decrypted,false);
+			$idom = parse_xml_string($decrypted);
 
 			$inner_iv = base64_decode($idom->iv);
 			$inner_aes_key = base64_decode($idom->aes_key);
@@ -556,7 +556,7 @@ class Diaspora {
 	 */
 	private static function valid_posting($msg) {
 
-		$data = parse_xml_string($msg["message"], false);
+		$data = parse_xml_string($msg["message"]);
 
 		if (!is_object($data)) {
 			logger("No valid XML ".$msg["message"], LOGGER_DEBUG);
@@ -1153,7 +1153,7 @@ class Diaspora {
 				return false;
 		}
 
-		$source_xml = parse_xml_string($x, false);
+		$source_xml = parse_xml_string($x);
 
 		if (!is_object($source_xml))
 			return false;

--- a/include/network.php
+++ b/include/network.php
@@ -620,20 +620,15 @@ function avatar_img($email) {
 }
 
 
-function parse_xml_string($s,$strict = true) {
+function parse_xml_string($s, $strict = true) {
+	// the "strict" parameter is deactivated
+
 	/// @todo Move this function to the xml class
-	if ($strict) {
-		if (! strstr($s,'<?xml'))
-			return false;
-		$s2 = substr($s,strpos($s,'<?xml'));
-	}
-	else
-		$s2 = $s;
 	libxml_use_internal_errors(true);
 
-	$x = @simplexml_load_string($s2);
-	if (! $x) {
-		logger('libxml: parse: error: ' . $s2, LOGGER_DATA);
+	$x = @simplexml_load_string($s);
+	if (!$x) {
+		logger('libxml: parse: error: ' . $s, LOGGER_DATA);
 		foreach (libxml_get_errors() as $err) {
 			logger('libxml: parse: ' . $err->code." at ".$err->line.":".$err->column." : ".$err->message, LOGGER_DATA);
 		}


### PR DESCRIPTION
Posts from "socialhome" weren't always parsed. Source was an XML that was parseable but hadn't contained a ```<?xml ...``` line.

The strictness check is removed since it really doesn't make any sense.