### PR TITLE
Items aren't edited when it happens within a second

### DIFF
--- a/object/Item.php
+++ b/object/Item.php
@@ -96,7 +96,7 @@ class Item extends BaseObject {
 
 		$item = $this->get_data();
 		$edited = false;
-		if (strcmp($item['created'], $item['edited'])<>0) {
+		if (abs(strtotime($item['created']) - strtotime($item['edited'])) > 1) {
 			$edited = array(
 				'label'    => t('This entry was edited'),
 				'date'     => datetime_convert('UTC', date_default_timezone_get(), $item['edited'], 'r'),


### PR DESCRIPTION
Reshared items from Mastodon seem to (sometimes) have a difference between creation time and edit time of a second. This is nothing that we should declare as "entry was edited".