### PR TITLE
add a comment as explanation for #3737

### DIFF
--- a/object/Item.php
+++ b/object/Item.php
@@ -96,6 +96,11 @@ class Item extends BaseObject {
 
 		$item = $this->get_data();
 		$edited = false;
+		// If the time between "created" and "editet" differes we add 
+		// a notices that the post was editet.
+		// Note: In some networks reshared items seem to have (sometimes) a difference
+		// between creation time and edit time of a second. Thats why we add the notice
+		// only if the difference is more than 1 second.
 		if (abs(strtotime($item['created']) - strtotime($item['edited'])) > 1) {
 			$edited = array(
 				'label'    => t('This entry was edited'),


### PR DESCRIPTION
I think https://github.com/friendica/friendica/pull/3737 does need an explaining comment. Otherwise in one or two years no one would remember why we have chosen 1 second as period of time. 