### PR TITLE
SQL fix fbrowser

### DIFF
--- a/mod/fbrowser.php
+++ b/mod/fbrowser.php
@@ -56,7 +56,8 @@ function fbrowser_content(App $a) {
 				$path[]=array($a->argv[2], $album);
 			}
 
-			$r = q("SELECT `resource-id`, `id`, `filename`, type, min(`scale`) AS `hiq`,max(`scale`) AS `loq`, `desc`
+			$r = q("SELECT `resource-id`, ANY_VALUE(`id`) AS `id`, ANY_VALUE(`filename`) AS `filename`, ANY_VALUE(`type`) AS `type`,
+					min(`scale`) AS `hiq`, max(`scale`) AS `loq`, ANY_VALUE(`desc`) AS `desc`, ANY_VALUE(`created`) AS `created`
 					FROM `photo` WHERE `uid` = %d $sql_extra AND `album` != '%s' AND `album` != '%s'
 					GROUP BY `resource-id` $sql_extra2",
 				intval(local_user()),

--- a/mods/sample-nginx.config
+++ b/mods/sample-nginx.config
@@ -129,9 +129,8 @@ server {
     # With php5-fpm:
     fastcgi_pass unix:/var/run/php5-fpm.sock;
 
-    include fastcgi_params;
+    include fastcgi.conf;
     fastcgi_index index.php;
-    fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
   }
 
   # deny access to all dot files


### PR DESCRIPTION
Fixing non-standard GROUP BY, and non-standard ORDER BY.

```
DB Error 1055: Expression #2 of SELECT list is not in GROUP BY clause
and contains nonaggregated column 'friendica.photo.id' which is not
functionally dependent on columns in GROUP BY clause; this is
incompatible with sql_mode=only_full_group_by
q, fbrowser_content
SELECT `resource-id`, `id`, `filename`, type, min(`scale`) AS
`hiq`,max(`scale`) AS `loq`, `desc` FROM `photo` WHERE `uid` = 1 AND
`album` != 'Contact Photos' AND `album` != 'Contact Photos' GROUP BY
`resource-id` ORDER BY created DESC LIMIT 0, 10
2017-09-27T17:16:35Z@tmkfko6titb71nug3i4vr1mnb1 [NORMAL]:dba.php:553:p
DB Error 1055: Expression #2 of SELECT list is not in GROUP BY clause
and contains nonaggregated column 'friendica.photo.id' which is not
functionally dependent on columns in GROUP BY clause; this is
incompatible with sql_mode=only_full_group_by
q, fbrowser_content
```

```
ERROR 1055 (42000): Expression #1 of ORDER BY clause is not in GROUP BY clause and contains nonaggregated column 'friendica.photo.created' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by
```