### PR TITLE
Reliably show posts from contact

### DIFF
--- a/include/Contact.php
+++ b/include/Contact.php
@@ -576,6 +576,11 @@ function get_contact($url, $uid = 0, $no_update = false) {
 		// Update the contact every 7 days
 		$update_contact = ($contact['avatar-date'] < datetime_convert('','','now -7 days'));
 
+		// We force the update if the avatar is empty
+		if ($contact['avatar'] == '') {
+			$update_contact = true;
+		}
+
 		if (!$update_contact || $no_update) {
 			return $contact_id;
 		}
@@ -747,7 +752,7 @@ function posts_from_contact_url(App $a, $contact_url) {
 		WHERE `contact`.`nurl` = '%s' AND `contact`.`uid` = 0",
 		dbesc(normalise_link($contact_url)));
 	if (in_array($r[0]["network"], array(NETWORK_DFRN, NETWORK_DIASPORA, NETWORK_OSTATUS, ""))) {
-		$sql = "(`item`.`uid` = 0 OR (`item`.`uid` = %d AND `item`.`private`))";
+		$sql = "(`item`.`uid` = 0 OR (`item`.`uid` = %d AND NOT `item`.`global`))";
 	} else {
 		$sql = "`item`.`uid` = %d";
 	}

--- a/include/Smilies.php
+++ b/include/Smilies.php
@@ -6,6 +6,11 @@
  *
  * @todo Use the shortcodes from here:
  * https://github.com/iamcal/emoji-data/blob/master/emoji_pretty.json?raw=true
+ * https://raw.githubusercontent.com/emojione/emojione/master/extras/alpha-codes/eac.json?raw=true
+ * https://github.com/johannhof/emoji-helper/blob/master/data/emoji.json?raw=true
+ *
+ * Have also a look here:
+ * https://www.webpagefx.com/tools/emoji-cheat-sheet/
  */
 
 use Friendica\App;

--- a/object/Item.php
+++ b/object/Item.php
@@ -96,12 +96,12 @@ class Item extends BaseObject {
 
 		$item = $this->get_data();
 		$edited = false;
-		// If the time between "created" and "editet" differes we add 
-		// a notices that the post was editet.
+		// If the time between "created" and "edited" differs we add
+		// a notice that the post was edited.
 		// Note: In some networks reshared items seem to have (sometimes) a difference
 		// between creation time and edit time of a second. Thats why we add the notice
 		// only if the difference is more than 1 second.
-		if (abs(strtotime($item['created']) - strtotime($item['edited'])) > 1) {
+		if (strtotime($item['edited']) - strtotime($item['created']) > 1) {
 			$edited = array(
 				'label'    => t('This entry was edited'),
 				'date'     => datetime_convert('UTC', date_default_timezone_get(), $item['edited'], 'r'),


### PR DESCRIPTION
Not every non private post is available with "uid=0". The "global" value is more reliable.

Additionally there are some small other fixes included.