### PR TITLE
Semaphore lock deactivated for PHP lower 5.6.1

### DIFF
--- a/include/network.php
+++ b/include/network.php
@@ -150,6 +150,10 @@ function z_fetch_url($url, $binary = false, &$redirects = 0, $opts = array()) {
 		}
 	}
 
+	if (Config::get('system', 'ipv4_resolve', false)) {
+		curl_setopt($ch, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
+	}
+
 	if ($binary) {
 		@curl_setopt($ch, CURLOPT_BINARYTRANSFER, 1);
 	}
@@ -277,6 +281,10 @@ function post_url($url, $params, $headers = null, &$redirects = 0, $timeout = 0)
 	curl_setopt($ch, CURLOPT_POST, 1);
 	curl_setopt($ch, CURLOPT_POSTFIELDS, $params);
 	curl_setopt($ch, CURLOPT_USERAGENT, $a->get_useragent());
+
+	if (Config::get('system', 'ipv4_resolve', false)) {
+		curl_setopt($ch, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
+	}
 
 	if (intval($timeout)) {
 		curl_setopt($ch, CURLOPT_TIMEOUT, $timeout);

--- a/src/Util/Lock.php
+++ b/src/Util/Lock.php
@@ -76,7 +76,8 @@ class Lock {
 		$got_lock = false;
 		$start = time();
 
-		if (function_exists('sem_get')) {
+		// The second parameter for "sem_acquire" doesn't exist before 5.6.1
+		if (function_exists('sem_get') && version_compare(PHP_VERSION, '5.6.1', '>=')) {
 			self::$semaphore[$fn_name] = sem_get(self::semaphoreKey($fn_name));
 			if (self::$semaphore[$fn_name]) {
 				return sem_acquire(self::$semaphore[$fn_name], ($timeout == 0));
@@ -156,7 +157,7 @@ class Lock {
 	 * @param string $fn_name Name of the lock
 	 */
 	public static function remove($fn_name) {
-		if (function_exists('sem_get')) {
+		if (function_exists('sem_get') && version_compare(PHP_VERSION, '5.6.1', '>=')) {
 			if (empty(self::$semaphore[$fn_name])) {
 				return false;
 			} else {


### PR DESCRIPTION
PHP before 5.6.1 didn't knew the second parameter for "sem_acquire". So we don't do semaphore based locks prior to this version.