### PR TITLE
DB Structure call is now executed directly when it cannot be called via proc_run

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -591,7 +591,7 @@ function is_ajax() {
 	return (!empty($_SERVER['HTTP_X_REQUESTED_WITH']) && strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) == 'xmlhttprequest');
 }
 
-function check_db() {
+function check_db($via_worker) {
 
 	$build = get_config('system', 'build');
 	if (!x($build)) {
@@ -600,7 +600,7 @@ function check_db() {
 	}
 	if ($build != DB_UPDATE_VERSION) {
 		// When we cannot execute the database update via the worker, we will do it directly
-		if (!proc_run(PRIORITY_CRITICAL, 'include/dbupdate.php')) {
+		if (!proc_run(PRIORITY_CRITICAL, 'include/dbupdate.php') && $via_worker) {
 			update_db(get_app());
 		}
 	}

--- a/boot.php
+++ b/boot.php
@@ -591,6 +591,11 @@ function is_ajax() {
 	return (!empty($_SERVER['HTTP_X_REQUESTED_WITH']) && strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) == 'xmlhttprequest');
 }
 
+/**
+ * @brief Function to check if request was an AJAX (xmlhttprequest) request.
+ *
+ * @param $via_worker boolean Is the check run via the poller?
+ */
 function check_db($via_worker) {
 
 	$build = get_config('system', 'build');

--- a/boot.php
+++ b/boot.php
@@ -599,7 +599,10 @@ function check_db() {
 		$build = DB_UPDATE_VERSION;
 	}
 	if ($build != DB_UPDATE_VERSION) {
-		proc_run(PRIORITY_CRITICAL, 'include/dbupdate.php');
+		// When we cannot execute the database update via the worker, we will do it directly
+		if (!proc_run(PRIORITY_CRITICAL, 'include/dbupdate.php')) {
+			update_db(get_app());
+		}
 	}
 }
 
@@ -1024,6 +1027,8 @@ function get_max_import_size() {
  *
  * @hooks 'proc_run'
  * 	array $arr
+ *
+ * @return boolean "false" if proc_run couldn't be executed
  */
 function proc_run($cmd) {
 
@@ -1033,7 +1038,7 @@ function proc_run($cmd) {
 
 	$args = array();
 	if (!count($proc_args)) {
-		return;
+		return false;
 	}
 
 	// Preserve the first parameter
@@ -1059,7 +1064,7 @@ function proc_run($cmd) {
 
 	call_hooks("proc_run", $arr);
 	if (!$arr['run_cmd'] || ! count($args)) {
-		return;
+		return true;
 	}
 
 	$priority = PRIORITY_MEDIUM;
@@ -1088,7 +1093,7 @@ function proc_run($cmd) {
 
 	// Quit if there was a database error - a precaution for the update process to 3.5.3
 	if (dba::errorNo() != 0) {
-		return;
+		return false;
 	}
 
 	if (!$found) {
@@ -1097,12 +1102,12 @@ function proc_run($cmd) {
 
 	// Should we quit and wait for the poller to be called as a cronjob?
 	if ($dont_fork) {
-		return;
+		return true;
 	}
 
 	// If there is a lock then we don't have to check for too much worker
 	if (!Lock::set('poller_worker', 0)) {
-		return;
+		return true;
 	}
 
 	// If there are already enough workers running, don't fork another one
@@ -1110,13 +1115,15 @@ function proc_run($cmd) {
 	Lock::remove('poller_worker');
 
 	if ($quit) {
-		return;
+		return true;
 	}
 
 	// Now call the poller to execute the jobs that we just added to the queue
 	$args = array("include/poller.php", "no_cron");
 
 	$a->proc_run($args);
+
+	return true;
 }
 
 function current_theme() {

--- a/include/poller.php
+++ b/include/poller.php
@@ -32,6 +32,9 @@ function poller_run($argv, $argc){
 
 	Config::load();
 
+	// Check the database structure and possibly fixes it
+	check_db(true);
+
 	// Quit when in maintenance
 	if (Config::get('system', 'maintenance', true)) {
 		return;
@@ -890,9 +893,6 @@ function poller_run_cron() {
 }
 
 if (array_search(__file__,get_included_files())===0) {
-	// Check the database structure and possibly fixes it
-	check_db(true);
-
 	poller_run($_SERVER["argv"],$_SERVER["argc"]);
 
 	poller_unclaim_process();

--- a/include/poller.php
+++ b/include/poller.php
@@ -889,7 +889,10 @@ function poller_run_cron() {
 	poller_kill_stale_workers();
 }
 
-if (array_search(__file__,get_included_files())===0){
+if (array_search(__file__,get_included_files())===0) {
+	// Check the database structure and possibly fixes it
+	check_db(true);
+
 	poller_run($_SERVER["argv"],$_SERVER["argc"]);
 
 	poller_unclaim_process();

--- a/index.php
+++ b/index.php
@@ -196,7 +196,7 @@ if ($install && $a->module!="view") {
 	$a->module = 'maintenance';
 } else {
 	check_url($a);
-	check_db();
+	check_db(false);
 	check_plugins($a);
 }
 

--- a/update.php
+++ b/update.php
@@ -1729,8 +1729,3 @@ function update_1202() {
 	$r = q("UPDATE `user` SET `account-type` = %d WHERE `page-flags` IN (%d, %d)",
 		dbesc(ACCOUNT_TYPE_COMMUNITY), dbesc(PAGE_COMMUNITY), dbesc(PAGE_PRVGROUP));
 }
-
-function update_1231() {
-	// For this special case we have to use the old update routine
-	$r = q("ALTER TABLE `workerqueue` ADD `done` tinyint(1) NOT NULL DEFAULT 0");
-}

--- a/util/db_update.php
+++ b/util/db_update.php
@@ -29,7 +29,6 @@ echo "New DB VERSION: " . DB_UPDATE_VERSION . "\n";
 
 if ($build != DB_UPDATE_VERSION) {
 	echo "Updating database...";
-	check_db($a);
+	update_db($a);
 	echo "Done\n";
 }
-


### PR DESCRIPTION
This is a workaround for the case when the worker can't be executed because it needs a database update - but for the database update the worker needs to be executed.

To avoid timeout problems when called via frontend, the update is only called directly when called via poller.php