### PR TITLE
Preparation for the possibility to globally block contacts

### DIFF
--- a/include/Contact.php
+++ b/include/Contact.php
@@ -696,6 +696,44 @@ function get_contact($url, $uid = 0, $no_update = false) {
 }
 
 /**
+ * @brief Checks if the contact is blocked
+ *
+ * @param int $cid contact id
+ *
+ * @return boolean Is the contact blocked?
+ */
+function blockedContact($cid) {
+	if ($cid == 0) {
+		return false;
+	}
+
+	$blocked = dba::select('contact', array('blocked'), array('id' => $cid), array('limit' => 1));
+	if (!dbm::is_result($blocked)) {
+		return false;
+	}
+	return (bool)$blocked['blocked'];
+}
+
+/**
+ * @brief Checks if the contact is hidden
+ *
+ * @param int $cid contact id
+ *
+ * @return boolean Is the contact hidden?
+ */
+function hiddenContact($cid) {
+	if ($cid == 0) {
+		return false;
+	}
+
+	$hidden = dba::select('contact', array('hidden'), array('id' => $cid), array('limit' => 1));
+	if (!dbm::is_result($hidden)) {
+		return false;
+	}
+	return (bool)$hidden['hidden'];
+}
+
+/**
  * @brief Returns posts from a given gcontact
  *
  * @param App $a argv application class

--- a/include/items.php
+++ b/include/items.php
@@ -761,8 +761,18 @@ function item_store($arr, $force_parent = false, $notify = false, $dontcache = f
 		$arr["author-id"] = get_contact($arr["author-link"], 0);
 	}
 
+	if (blockedContact($arr["author-id"])) {
+		logger('Contact '.$arr["author-id"].' is blocked, item '.$arr["uri"].' will not be stored');
+		return 0;
+	}
+
 	if ($arr["owner-id"] == 0) {
 		$arr["owner-id"] = get_contact($arr["owner-link"], 0);
+	}
+
+	if (blockedContact($arr["owner-id"])) {
+		logger('Contact '.$arr["owner-id"].' is blocked, item '.$arr["uri"].' will not be stored');
+		return 0;
 	}
 
 	if ($arr['guid'] != "") {

--- a/include/threads.php
+++ b/include/threads.php
@@ -32,7 +32,7 @@ function add_thread($itemid, $onlyshadow = false) {
  * @param integer $itemid Item ID that should be added
  */
 function add_shadow_thread($itemid) {
-	$items = q("SELECT `uid`, `wall`, `private`, `moderated`, `visible`, `contact-id`, `deleted`, `network`
+	$items = q("SELECT `uid`, `wall`, `private`, `moderated`, `visible`, `contact-id`, `deleted`, `network`, `author-id`, `owner-id`
 		FROM `item` WHERE `id` = %d AND (`parent` = %d OR `parent` = 0) LIMIT 1", intval($itemid), intval($itemid));
 
 	if (!dbm::is_result($items)) {
@@ -55,6 +55,11 @@ function add_shadow_thread($itemid) {
 	if (!in_array($item["network"], array(NETWORK_DFRN, NETWORK_DIASPORA, NETWORK_OSTATUS, ""))) {
 		return;
 	}
+
+	// Is the public contact configured as hidden?
+        if (hiddenContact($item["owner-id"]) || hiddenContact($item["author-id"])) {
+                return;
+        }
 
 	// Only do these checks if the post isn't a wall post
 	if (!$item["wall"]) {


### PR DESCRIPTION
With this PR we are now having a possibility to centrally block contacts. If set, items from these public contacts won't be stored on the server. Additionally we can define if posts from a contact are suppressed from the community page and in searches.

Currently we don't have a frontend for that. Changes had to be done via the MySQL console.