### PR TITLE
Update vier with new global support forum

### DIFF
--- a/view/theme/vier/config.php
+++ b/view/theme/vier/config.php
@@ -64,7 +64,7 @@ function theme_admin(App $a) {
 	$helperlist = get_config('vier', 'helperlist');
 
 	if ($helperlist == "")
-		$helperlist = "https://helpers.pyxis.uberspace.de/profile/helpers";
+		$helperlist = "https://forum.friendi.ca/profile/helpers";
 
 	$t = get_markup_template("theme_admin_settings.tpl");
 	$o .= replace_macros($t, array(


### PR DESCRIPTION
vier has a hardcoded path to the helpers forum as well.
I've changed the path of the global support forum to https://forum.friendi.ca/profile/helpers.