### PR TITLE
Bugfix: Revive dead contacts

### DIFF
--- a/include/Contact.php
+++ b/include/Contact.php
@@ -155,7 +155,7 @@ function mark_for_death($contact) {
 
 function unmark_for_death($contact) {
 
-	$r = q("SELECT `term-date` FROM `contact` WHERE `id` = %d AND `term-date` > '%s'",
+	$r = q("SELECT `term-date` FROM `contact` WHERE `id` = %d AND (`term-date` > '%s' OR `archive`)",
 		intval($contact['id']),
 		dbesc('1000-00-00 00:00:00')
 	);
@@ -166,16 +166,11 @@ function unmark_for_death($contact) {
 	}
 
 	// It's a miracle. Our dead contact has inexplicably come back to life.
-	q("UPDATE `contact` SET `term-date` = '%s' WHERE `id` = %d",
-		dbesc(NULL_DATE),
-		intval($contact['id'])
-	);
+	$fields = array('term-date' => NULL_DATE, 'archive' => false);
+	dba::update('contact', $fields, array('id' => $contact['id']));
 
 	if ($contact['url'] != '') {
-		q("UPDATE `contact` SET `term-date` = '%s' WHERE `nurl` = '%s'",
-			dbesc(NULL_DATE),
-			dbesc(normalise_link($contact['url']))
-		);
+		dba::update('contact', $fields, array('nurl' => normalise_link($contact['url'])));
 	}
 }
 

--- a/include/follow.php
+++ b/include/follow.php
@@ -2,6 +2,7 @@
 
 use Friendica\App;
 use Friendica\Core\System;
+use Friendica\Network\Probe;
 
 require_once 'include/probe.php';
 require_once 'include/socgraph.php';
@@ -71,7 +72,7 @@ function update_contact($id) {
 
 
 
-function new_contact($uid,$url,$interactive = false) {
+function new_contact($uid, $url, $interactive = false, $network = '') {
 
 	$result = array('cid' => -1, 'success' => false,'message' => '');
 
@@ -102,9 +103,13 @@ function new_contact($uid,$url,$interactive = false) {
 
 	if (x($arr['contact'],'name')) {
 		$ret = $arr['contact'];
+	} else {
+		$ret = Probe::uri($url, $network, $uid, false);
 	}
-	else {
-		$ret = probe_url($url);
+
+	if (($network != '') && ($ret['network'] != $network)) {
+		logger('Expected network '.$network.' does not match actual network '.$ret['network']);
+		return result;
 	}
 
 	if ($ret['network'] === NETWORK_DFRN) {

--- a/include/ostatus.php
+++ b/include/ostatus.php
@@ -149,6 +149,9 @@ class ostatus {
 		// Only update the contacts if it is an OStatus contact
 		if ($r && ($r['id'] > 0) && !$onlyfetch && ($contact["network"] == NETWORK_OSTATUS)) {
 
+			// This contact is vital, so we awake it from the dead
+			unmark_for_death($contact);
+
 			// Update contact data
 
 			$current = $contact;

--- a/mod/contacts.php
+++ b/mod/contacts.php
@@ -244,7 +244,7 @@ function _contact_update($contact_id) {
 		return;
 
 	if ($r[0]["network"] == NETWORK_OSTATUS) {
-		$result = new_contact($uid, $r[0]["url"], false);
+		$result = new_contact($uid, $r[0]["url"], false, $r[0]["network"]);
 
 		if ($result['success'])
 			$r = q("UPDATE `contact` SET `subhub` = 1 WHERE `id` = %d",

--- a/mod/ostatus_subscribe.php
+++ b/mod/ostatus_subscribe.php
@@ -66,7 +66,7 @@ function ostatus_subscribe_content(App $a) {
 
 	$data = probe_url($url);
 	if ($data["network"] == NETWORK_OSTATUS) {
-		$result = new_contact($uid,$url,true);
+		$result = new_contact($uid, $url, true, NETWORK_OSTATUS);
 		if ($result["success"]) {
 			$o .= " - ".t("success");
 		} else {


### PR DESCRIPTION
We now unmark dead contacts in OStatus when we receive content from them.

Additionally there are bugs where OStatus contacts are detected as feeds. We can now workaround this.