### PR TITLE
Enhance feed information for "fetch further information"

### DIFF
--- a/include/feed.php
+++ b/include/feed.php
@@ -353,6 +353,10 @@ function feed_import($xml,$importer,&$contact, &$hub, $simulate = false) {
 				}
 			}
 
+			// Remove a possible link to the item itself
+			$item["body"] = str_replace($item["plink"], '', $item["body"]);
+			$item["body"] = preg_replace('/\[url\=\](\w+.*?)\[\/url\]/i', '', $item["body"]);
+
 			// Replace the content when the title is longer than the body
 			$replace = (strlen($item["title"]) > strlen($item["body"]));
 
@@ -368,8 +372,9 @@ function feed_import($xml,$importer,&$contact, &$hub, $simulate = false) {
 
 			if ($replace) {
 				$item["body"] = $item["title"];
-				$item["title"] = "";
 			}
+			// We always strip the title since it will be added in the page information
+			$item["title"] = "";
 			$item["body"] = $item["body"].add_page_info($item["plink"], false, $preview, ($contact["fetch_further_information"] == 2), $contact["ffi_keyword_blacklist"]);
 			$item["tag"] = add_page_keywords($item["plink"], false, $preview, ($contact["fetch_further_information"] == 2), $contact["ffi_keyword_blacklist"]);
 			$item["object-type"] = ACTIVITY_OBJ_BOOKMARK;

--- a/include/feed.php
+++ b/include/feed.php
@@ -353,7 +353,20 @@ function feed_import($xml,$importer,&$contact, &$hub, $simulate = false) {
 				}
 			}
 
-			if (strlen($item["title"]) > strlen($item["body"])) {
+			// Replace the content when the title is longer than the body
+			$replace = (strlen($item["title"]) > strlen($item["body"]));
+
+			// Replace it, when there is an image in the body
+			if (strstr($item["body"], '[/img]')) {
+				$replace = true;
+			}
+
+			// Replace it, when there is a link in the body
+			if (strstr($item["body"], '[/url]')) {
+				$replace = true;
+			}
+
+			if ($replace) {
 				$item["body"] = $item["title"];
 				$item["title"] = "";
 			}

--- a/include/feed.php
+++ b/include/feed.php
@@ -354,7 +354,6 @@ function feed_import($xml,$importer,&$contact, &$hub, $simulate = false) {
 			}
 
 			if (strlen($item["title"]) > strlen($item["body"])) {
-//echo "*".strlen($item["title"]).">".strlen($item["body"])."\n";
 				$item["body"] = $item["title"];
 				$item["title"] = "";
 			}


### PR DESCRIPTION
Until now we simply used the feed entry title as body text, when "fetch further information" was activated. Now we use a more detailed rule that (hopefully) fetches the best available information.