### PR TITLE
Bugfix: Switch to all networks when posts for a single contact are selected

### DIFF
--- a/mod/network.php
+++ b/mod/network.php
@@ -37,6 +37,8 @@ function network_init(App $a) {
 	$is_a_date_query = false;
 	if (x($_GET, 'cid') && intval($_GET['cid']) != 0) {
 		$cid = $_GET['cid'];
+		$_GET['nets'] = 'all';
+
 	}
 
 	if ($a->argc > 1) {


### PR DESCRIPTION
This avoids a problem when a network is selected and then posts for a single contact and nothing is displayed.