### PR TITLE
 frio: use cached css if no settings (or file) have changed + frio color settings for admins

### DIFF
--- a/view/theme/frio/config.php
+++ b/view/theme/frio/config.php
@@ -1,6 +1,7 @@
 <?php
 
 use Friendica\App;
+use Friendica\Core\Config;
 use Friendica\Core\PConfig;
 use Friendica\Core\System;
 
@@ -24,24 +25,59 @@ function theme_post(App $a) {
 	}
 }
 
+function theme_admin_post(App $a) {
+	if (!local_user()) {
+		return;
+	}
+
+	if (isset($_POST['frio-settings-submit'])) {
+		Config::set('frio', 'schema',           $_POST["frio_schema"]);
+		Config::set('frio', 'nav_bg',           $_POST["frio_nav_bg"]);
+		Config::set('frio', 'nav_icon_color',   $_POST["frio_nav_icon_color"]);
+		Config::set('frio', 'link_color',       $_POST["frio_link_color"]);
+		Config::set('frio', 'background_color', $_POST["frio_background_color"]);
+		Config::set('frio', 'contentbg_transp', $_POST["frio_contentbg_transp"]);
+		Config::set('frio', 'background_image', $_POST["frio_background_image"]);
+		Config::set('frio', 'bg_image_option',  $_POST["frio_bg_image_option"]);
+		Config::set('frio', 'css_modified',     time());
+	}
+}
+
 function theme_content(App $a) {
 	if (!local_user()) {
 		return;
 	}
 	$arr = array();
 
-	$arr["schema"]           = PConfig::get(local_user(),'frio', 'schema');
-	$arr["nav_bg"]           = PConfig::get(local_user(),'frio', 'nav_bg');
-	$arr["nav_icon_color"]   = PConfig::get(local_user(),'frio', 'nav_icon_color');
-	$arr["link_color"]       = PConfig::get(local_user(),'frio', 'link_color');
-	$arr["bgcolor"]          = PConfig::get(local_user(),'frio', 'background_color');
-	$arr["contentbg_transp"] = PConfig::get(local_user(),'frio', 'contentbg_transp');
-	$arr["background_image"] = PConfig::get(local_user(),'frio', 'background_image');
-	$arr["bg_image_option"]  = PConfig::get(local_user(),'frio', 'bg_image_option');
+	$arr["schema"]           = PConfig::get(local_user(), 'frio', 'schema');
+	$arr["nav_bg"]           = PConfig::get(local_user(), 'frio', 'nav_bg');
+	$arr["nav_icon_color"]   = PConfig::get(local_user(), 'frio', 'nav_icon_color');
+	$arr["link_color"]       = PConfig::get(local_user(), 'frio', 'link_color');
+	$arr["bgcolor"]          = PConfig::get(local_user(), 'frio', 'background_color');
+	$arr["contentbg_transp"] = PConfig::get(local_user(), 'frio', 'contentbg_transp');
+	$arr["background_image"] = PConfig::get(local_user(), 'frio', 'background_image');
+	$arr["bg_image_option"]  = PConfig::get(local_user(), 'frio', 'bg_image_option');
 
 	return frio_form($arr);
 }
 
+function theme_admin(App $a) {
+	if (!local_user()) {
+		return;
+	}
+	$arr = array();
+
+	$arr["schema"]           = Config::get('frio', 'schema');
+	$arr["nav_bg"]           = Config::get('frio', 'nav_bg');
+	$arr["nav_icon_color"]   = Config::get('frio', 'nav_icon_color');
+	$arr["link_color"]       = Config::get('frio', 'link_color');
+	$arr["bgcolor"]          = Config::get('frio', 'background_color');
+	$arr["contentbg_transp"] = Config::get('frio', 'contentbg_transp');
+	$arr["background_image"] = Config::get('frio', 'background_image');
+	$arr["bg_image_option"]  = Config::get('frio', 'bg_image_option');
+
+	return frio_form($arr);
+}
 
 function frio_form($arr) {
 	require_once("view/theme/frio/php/schema.php");

--- a/view/theme/frio/config.php
+++ b/view/theme/frio/config.php
@@ -1,27 +1,10 @@
 <?php
 
 use Friendica\App;
+use Friendica\Core\PConfig;
 use Friendica\Core\System;
 
 require_once('view/theme/frio/php/Image.php');
-
-function theme_content(App $a) {
-	if (!local_user()) {
-		return;
-	}
-	$arr = array();
-
-	$arr["schema"]		= get_pconfig(local_user(),'frio', 'schema');
-	$arr["nav_bg"]		= get_pconfig(local_user(),'frio', 'nav_bg' );
-	$arr["nav_icon_color"]	= get_pconfig(local_user(),'frio', 'nav_icon_color' );
-	$arr["link_color"]	= get_pconfig(local_user(),'frio', 'link_color' );
-	$arr["bgcolor"]		= get_pconfig(local_user(),'frio', 'background_color' );
-	$arr["contentbg_transp"] = get_pconfig(local_user(),'frio', 'contentbg_transp' );
-	$arr["background_image"] = get_pconfig(local_user(),'frio', 'background_image' );
-	$arr["bg_image_option"] = get_pconfig(local_user(),'frio', 'bg_image_option' );
-
-	return frio_form($arr);
-}
 
 function theme_post(App $a) {
 	if (!local_user()) {
@@ -29,53 +12,74 @@ function theme_post(App $a) {
 	}
 
 	if (isset($_POST['frio-settings-submit'])) {
-		set_pconfig(local_user(), 'frio', 'schema',		$_POST["frio_schema"]);
-		set_pconfig(local_user(), 'frio', 'nav_bg',		$_POST["frio_nav_bg"]);
-		set_pconfig(local_user(), 'frio', 'nav_icon_color',	$_POST["frio_nav_icon_color"]);
-		set_pconfig(local_user(), 'frio', 'link_color',		$_POST["frio_link_color"]);
-		set_pconfig(local_user(), 'frio', 'background_color',	$_POST["frio_background_color"]);
-		set_pconfig(local_user(), 'frio', 'contentbg_transp',	$_POST["frio_contentbg_transp"]);
-		set_pconfig(local_user(), 'frio', 'background_image',	$_POST["frio_background_image"]);
-		set_pconfig(local_user(), 'frio', 'bg_image_option',	$_POST["frio_bg_image_option"]);
+		PConfig::set(local_user(), 'frio', 'schema',           $_POST["frio_schema"]);
+		PConfig::set(local_user(), 'frio', 'nav_bg',           $_POST["frio_nav_bg"]);
+		PConfig::set(local_user(), 'frio', 'nav_icon_color',   $_POST["frio_nav_icon_color"]);
+		PConfig::set(local_user(), 'frio', 'link_color',       $_POST["frio_link_color"]);
+		PConfig::set(local_user(), 'frio', 'background_color', $_POST["frio_background_color"]);
+		PConfig::set(local_user(), 'frio', 'contentbg_transp', $_POST["frio_contentbg_transp"]);
+		PConfig::set(local_user(), 'frio', 'background_image', $_POST["frio_background_image"]);
+		PConfig::set(local_user(), 'frio', 'bg_image_option',  $_POST["frio_bg_image_option"]);
+		PConfig::set(local_user(), 'frio', 'css_modified',     time());
 	}
 }
+
+function theme_content(App $a) {
+	if (!local_user()) {
+		return;
+	}
+	$arr = array();
+
+	$arr["schema"]           = PConfig::get(local_user(),'frio', 'schema');
+	$arr["nav_bg"]           = PConfig::get(local_user(),'frio', 'nav_bg');
+	$arr["nav_icon_color"]   = PConfig::get(local_user(),'frio', 'nav_icon_color');
+	$arr["link_color"]       = PConfig::get(local_user(),'frio', 'link_color');
+	$arr["bgcolor"]          = PConfig::get(local_user(),'frio', 'background_color');
+	$arr["contentbg_transp"] = PConfig::get(local_user(),'frio', 'contentbg_transp');
+	$arr["background_image"] = PConfig::get(local_user(),'frio', 'background_image');
+	$arr["bg_image_option"]  = PConfig::get(local_user(),'frio', 'bg_image_option');
+
+	return frio_form($arr);
+}
+
 
 function frio_form($arr) {
 	require_once("view/theme/frio/php/schema.php");
 
 	$scheme_info = get_schema_info($arr["schema"]);
 	$disable = $scheme_info["overwrites"];
-	if (!is_array($disable)) $disable = array();
+	if (!is_array($disable)) {
+		$disable = array();
+	}
 
 	$scheme_choices = array();
 	$scheme_choices["---"] = t("Default");
 	$files = glob('view/theme/frio/schema/*.php');
-	if($files) {
-		foreach($files as $file) {
+	if ($files) {
+		foreach ($files as $file) {
 			$f = basename($file, ".php");
-			if($f != 'default') {
+			if ($f != 'default') {
 				$scheme_name = $f;
 				$scheme_choices[$f] = $scheme_name;
 			}
 		}
 	}
 
-	$background_image_help = "<strong>" . t("Note: "). "</strong>".t("Check image permissions if all users are allowed to visit the image");
-
+	$background_image_help = "<strong>" . t("Note"). ": </strong>".t("Check image permissions if all users are allowed to visit the image");
 
 	$t = get_markup_template('theme_settings.tpl');
 	$o .= replace_macros($t, array(
-		'$submit'		=> t('Submit'),
-		'$baseurl'		=> System::baseUrl(),
-		'$title'		=> t("Theme settings"),
-		'$schema'		=> array('frio_schema',		t("Select scheme"),			$arr["schema"], '', $scheme_choices),
-		'$nav_bg'		=> array_key_exists("nav_bg", $disable) ? "" : array('frio_nav_bg',		t('Navigation bar background color'),	$arr['nav_bg']),
-		'$nav_icon_color'	=> array_key_exists("nav_icon_color", $disable) ? "" : array('frio_nav_icon_color', t('Navigation bar icon color '),	$arr['nav_icon_color']),
-		'$link_color'		=> array_key_exists("link_color", $disable) ? "" : array('frio_link_color',	t('Link color'),			$arr['link_color'],		'', $link_colors),
-		'$bgcolor'		=> array_key_exists("bgcolor", $disable) ? "" : array('frio_background_color', t('Set the background color'),	$arr['bgcolor']),
-		'$contentbg_transp'	=> array_key_exists("contentbg_transp", $disable) ? "" : array('frio_contentbg_transp', t("Content background transparency"), ($arr["contentbg_transp"] ? $arr["contentbg_transp"] : 0 )),
-		'$background_image'	=> array_key_exists("background_image", $disable ) ? "" : array('frio_background_image', t('Set the background image'),	$arr['background_image'], $background_image_help),
-		'$bg_image_options'	=> Image::get_options($arr),
+		'$submit'           => t('Submit'),
+		'$baseurl'          => System::baseUrl(),
+		'$title'            => t("Theme settings"),
+		'$schema'           => array('frio_schema', t("Select scheme"), $arr["schema"], '', $scheme_choices),
+		'$nav_bg'           => array_key_exists("nav_bg", $disable) ? "" : array('frio_nav_bg', t('Navigation bar background color'), $arr['nav_bg']),
+		'$nav_icon_color'   => array_key_exists("nav_icon_color", $disable) ? "" : array('frio_nav_icon_color', t('Navigation bar icon color '), $arr['nav_icon_color']),
+		'$link_color'       => array_key_exists("link_color", $disable) ? "" : array('frio_link_color', t('Link color'), $arr['link_color'], '', $link_colors),
+		'$bgcolor'          => array_key_exists("bgcolor", $disable) ? "" : array('frio_background_color', t('Set the background color'), $arr['bgcolor']),
+		'$contentbg_transp' => array_key_exists("contentbg_transp", $disable) ? "" : array('frio_contentbg_transp', t("Content background transparency"), ((isset($arr["contentbg_transp"]) && $arr["contentbg_transp"] != "") ? $arr["contentbg_transp"] : 100)),
+		'$background_image' => array_key_exists("background_image", $disable ) ? "" : array('frio_background_image', t('Set the background image'), $arr['background_image'], $background_image_help),
+		'$bg_image_options' => Image::get_options($arr),
 	));
 
 	return $o;

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -2817,6 +2817,14 @@ section.help-content-wrapper li {
     font-size: 0.96em;
 }
 
+/*Admin Page*/
+#adminpage #frio_background_image .image-select {
+    display: none;
+}
+#adminpage #frio_background_image.input-group {
+    display: block;
+}
+
 /* Register Page*/
 #register-openid-wrapper, #register-name-wrapper, #register-invite-wrapper, #profile-publish-wrapper {
     margin-top: 20px;

--- a/view/theme/frio/style.php
+++ b/view/theme/frio/style.php
@@ -1,6 +1,7 @@
 <?php
 require_once 'view/theme/frio/php/PHPColors/Color.php';
 
+use Friendica\Core\Config;
 use Friendica\Core\PConfig;
 
 $schemecss = "";
@@ -28,6 +29,25 @@ if (! $a->install) {
 		// In this case we store the present time.
 		if (empty($modified)) {
 			PConfig::set($uid, 'frio', 'css_modified', time());
+		}
+	} else {
+		Config::load('frio');
+
+		// Load frios system config.
+		$schema           = Config::get("frio", "schema");
+		$nav_bg           = Config::get("frio", "nav_bg");
+		$nav_icon_color   = Config::get("frio", "nav_icon_color");
+		$link_color       = Config::get("frio", "link_color");
+		$bgcolor          = Config::get("frio", "background_color");
+		$contentbg_transp = Config::get("frio", "contentbg_transp");
+		$background_image = Config::get("frio", "background_image");
+		$bg_image_option  = Config::get("frio", "bg_image_option");
+		$modified         = Config::get("frio", "css_modified");
+
+		// There is maybe the case that the user did never modify the theme settings.
+		// In this case we store the present time.
+		if (empty($modified)) {
+			Config::set('frio', 'css_modified', time());
 		}
 	}
 }

--- a/view/theme/frio/style.php
+++ b/view/theme/frio/style.php
@@ -65,12 +65,13 @@ if (! $schema) {
 
 //Set some defaults - we have to do this after pulling owner settings, and we have to check for each setting
 //individually.  If we don't, we'll have problems if a user has set one, but not all options.
-$nav_bg           = (empty($nav_bg)           ? "#708fa0" :      $nav_bg);
-$nav_icon_color   = (empty($nav_icon_color)   ? "#fff"    :      $nav_icon_color);
-$link_color       = (empty($link_color)       ? "#6fdbe8" :      $link_color);
-$bgcolor          = (empty($bgcolor)          ? "#ededed" :      $bgcolor);
-$background_image = (empty($background_image) ? ''        :      $background_image);
-$modified         = (empty($modified)         ? time()    :      $modified);
+$nav_bg           = (empty($nav_bg)           ? "#708fa0"      : $nav_bg);
+$nav_icon_color   = (empty($nav_icon_color)   ? "#fff"         : $nav_icon_color);
+$link_color       = (empty($link_color)       ? "#6fdbe8"      : $link_color);
+$bgcolor          = (empty($bgcolor)          ? "#ededed"      : $bgcolor);
+// The background image can not be empty. So we use a dummy jpg if no image was set.
+$background_image = (empty($background_image) ? 'img/none.jpg' : $background_image);
+$modified         = (empty($modified)         ? time()         :$modified);
 
 $contentbg_transp = ((isset($contentbg_transp) && $contentbg_transp != "") ?  $contentbg_transp : 100);
 

--- a/view/theme/frio/style.php
+++ b/view/theme/frio/style.php
@@ -1,40 +1,52 @@
 <?php
-require_once('view/theme/frio/php/PHPColors/Color.php');
+require_once 'view/theme/frio/php/PHPColors/Color.php';
 
+use Friendica\Core\PConfig;
 
-if(! $a->install) {
-	// Get the UID of the channel owner
+$schemecss = "";
+$schemecssfile = false;
+$scheme_modified = 0;
+
+if (! $a->install) {
+	// Get the UID of the profile owner.
 	$uid = get_theme_uid();
-	if($uid) {
-		load_pconfig($uid,'frio');
+	if ($uid) {
+		PConfig::load($uid, 'frio');
+
+		// Load the profile owners pconfig.
+		$schema           = PConfig::get($uid, "frio", "schema");
+		$nav_bg           = PConfig::get($uid, "frio", "nav_bg");
+		$nav_icon_color   = PConfig::get($uid, "frio", "nav_icon_color");
+		$link_color       = PConfig::get($uid, "frio", "link_color");
+		$bgcolor          = PConfig::get($uid, "frio", "background_color");
+		$contentbg_transp = PConfig::get($uid, "frio", "contentbg_transp");
+		$background_image = PConfig::get($uid, "frio", "background_image");
+		$bg_image_option  = PConfig::get($uid, "frio", "bg_image_option");
+		$modified         = PConfig::get($uid, "frio", "css_modified");
+
+		// There is maybe the case that the user did never modify the theme settings.
+		// In this case we store the present time.
+		if (empty($modified)) {
+			PConfig::set($uid, 'frio', 'css_modified', time());
+		}
 	}
-	// Load the owners pconfig
-	$schema		= get_pconfig($uid, "frio", "schema");
-	$nav_bg		= get_pconfig($uid, "frio", "nav_bg");
-	$nav_icon_color = get_pconfig($uid, "frio", "nav_icon_color");
-	$link_color	= get_pconfig($uid, "frio", "link_color");
-	$bgcolor	= get_pconfig($uid, "frio", "background_color");
-	$contentbg_transp = get_pconfig($uid, "frio", "contentbg_transp");
-	$background_image = get_pconfig($uid, "frio", "background_image");
-	$bg_image_option = get_pconfig($uid, "frio", "bg_image_option");
 }
 
 // Now load the scheme.  If a value is changed above, we'll keep the settings
 // If not, we'll keep those defined by the schema
 // Setting $schema to '' wasn't working for some reason, so we'll check it's
 // not --- like the mobile theme does instead.
-// Allow layouts to over-ride the schema
-if($_REQUEST['schema']) {
+// Allow layouts to over-ride the schema.
+if ($_REQUEST['schema']) {
 	$schema = $_REQUEST['schema'];
 }
 if (($schema) && ($schema != '---')) {
-	// Check it exists, because this setting gets distributed to clones
-	if(file_exists('view/theme/frio/schema/' . $schema . '.php')) {
+	if (file_exists('view/theme/frio/schema/' . $schema . '.php')) {
 		$schemefile = 'view/theme/frio/schema/' . $schema . '.php';
-		require_once ($schemefile);
+		require_once $schemefile;
 	}
-	if(file_exists('view/theme/frio/schema/' . $schema . '.css')) {
-		$schemecss = file_get_contents('view/theme/frio/schema/' . $schema . '.css');
+	if (file_exists('view/theme/frio/schema/' . $schema . '.css')) {
+		$schemecssfile = 'view/theme/frio/schema/' . $schema . '.css';
 	}
 }
 
@@ -44,57 +56,53 @@ if (($schema) && ($schema != '---')) {
 if (! $schema) {
 	if(file_exists('view/theme/frio/schema/default.php')) {
 		$schemefile = 'view/theme/frio/schema/default.php';
-		require_once ($schemefile);
+		require_once $schemefile;
 	}
 	if(file_exists('view/theme/frio/schema/default.css')) {
-		$schemecss = file_get_contents('view/theme/frio/schema/default.css');
+		$schemecssfile = 'view/theme/frio/schema/default.css';
 	}
 }
 
 //Set some defaults - we have to do this after pulling owner settings, and we have to check for each setting
 //individually.  If we don't, we'll have problems if a user has set one, but not all options.
-if(! $nav_bg)
-	$nav_bg = "#708fa0";
-if(! $nav_icon_color)
-	$nav_icon_color = "#fff";
-if(! $link_color)
-	$link_color = "#6fdbe8";
-if(! $bgcolor)
-	$bgcolor = "#ededed";
-if(! $contentbg_transp)
-	$contentbg_transp = 100;
-if(! $background_image)
-	$background_image ='';
+$nav_bg           = (empty($nav_bg)           ? "#708fa0" :      $nav_bg);
+$nav_icon_color   = (empty($nav_icon_color)   ? "#fff"    :      $nav_icon_color);
+$link_color       = (empty($link_color)       ? "#6fdbe8" :      $link_color);
+$bgcolor          = (empty($bgcolor)          ? "#ededed" :      $bgcolor);
+$background_image = (empty($background_image) ? ''        :      $background_image);
+$modified         = (empty($modified)         ? time()    :      $modified);
 
-// Calculate some colors in dependance of existing colors
+$contentbg_transp = ((isset($contentbg_transp) && $contentbg_transp != "") ?  $contentbg_transp : 100);
+
+// Calculate some colors in dependance of existing colors.
 // Some colors are calculated to don't have too many selection
-// fields in the theme settings
-if(! $menu_background_hover_color) {
+// fields in the theme settings.
+if (! $menu_background_hover_color) {
 	$mbhc = new Color($nav_bg);
 	$mcolor = $mbhc->getHex();
 
-	if($mbhc->isLight($mcolor, 75)) {
+	if ($mbhc->isLight($mcolor, 75)) {
 		$menu_is = 'light';
 		$menu_background_hover_color = '#' . $mbhc->darken(5);
 	} else {
 		$menu_is = 'dark';
 		$menu_background_hover_color = '#' . $mbhc->lighten(5);
-	//$menu_background_hover_color = "#628394";
 	}
 }
-if(! $nav_icon_hover_color) {
+if (! $nav_icon_hover_color) {
 	$nihc = new Color($nav_bg);
 
-	if($nihc->isLight())
+	if ($nihc->isLight()) {
 		$nav_icon_hover_color = '#' . $nihc->darken(10);
-	else
+	} else {
 		$nav_icon_hover_color = '#' . $nihc->lighten(10);
+	}
 }
-if(! $link_hover_color) {
+if (! $link_hover_color) {
 	$lhc = new Color($link_color);
 	$lcolor = $lhc->getHex();
 
-	if($lhc->isLight($lcolor, 75)) {
+	if ($lhc->isLight($lcolor, 75)) {
 		$link_hover_color = '#' . $lhc->darken(5);
 	} else {
 		$link_hover_color = '#' . $lhc->lighten(5);
@@ -102,7 +110,7 @@ if(! $link_hover_color) {
 
 }
 
-// Convert $bg_image_options into css
+// Convert $bg_image_options into css.
 switch ($bg_image_option) {
 	case "stretch":
 		$background_size_img = "100%";
@@ -122,32 +130,59 @@ switch ($bg_image_option) {
 		break;
 }
 
-// Convert transparency level from percentage to opacity value
+// Convert transparency level from percentage to opacity value.
 $contentbg_transp = $contentbg_transp / 100;
 
+$options = array (
+	'$nav_bg'                      => $nav_bg,
+	'$nav_icon_color'              => $nav_icon_color,
+	'$nav_icon_hover_color'        => $nav_icon_hover_color,
+	'$link_color'                  => $link_color,
+	'$link_hover_color'            => $link_hover_color,
+	'$menu_background_hover_color' => $menu_background_hover_color,
+	'$btn_primary_color'           => $nav_icon_color,
+	'$btn_primary_hover_color'     => $menu_background_hover_color,
+	'$bgcolor'                     => $bgcolor,
+	'$contentbg_transp'            => $contentbg_transp,
+	'$background_image'            => $background_image,
+	'$background_size_img'         => $background_size_img,
+);
 
-// Apply the settings
-if(file_exists('view/theme/frio/css/style.css')) {
-	$x = file_get_contents('view/theme/frio/css/style.css');
+$css_tpl = file_get_contents('view/theme/frio/css/style.css');
 
-	$options = array (
-		'$nav_bg'			=> $nav_bg,
-		'$nav_icon_color'		=> $nav_icon_color,
-		'$nav_icon_hover_color'		=> $nav_icon_hover_color,
-		'$link_color'			=> $link_color,
-		'$link_hover_color'		=> $link_hover_color,
-		'$menu_background_hover_color'	=> $menu_background_hover_color,
-		'$btn_primary_color'		=> $nav_icon_color,
-		'$btn_primary_hover_color'	=> $menu_background_hover_color,
-		'$bgcolor'			=> $bgcolor,
-		'$contentbg_transp'		=> $contentbg_transp,
-		'$background_image'		=> $background_image,
-		'$background_size_img'		=> $background_size_img,
-	);
-
-	echo str_replace(array_keys($options), array_values($options), $x);
+// Get the content of the scheme css file and the time of the last file change.
+if ($schemecssfile) {
+	$css_tpl .= file_get_contents($schemecssfile);
+	$scheme_modified = filemtime($schemecssfile);
 }
 
-if($schemecss) {
-	echo $schemecss;
+// We need to check which is the most recent css data.
+// We will use this time later to decide if we load the cached or fresh css data.
+if ($scheme_modified > $modified) {
+	$modified = $scheme_modified;
 }
+// Apply the settings to the css template.
+$css = str_replace(array_keys($options), array_values($options), $css_tpl);
+
+$modified = gmdate('r', $modified);
+
+$etag = md5($css);
+
+// Set a header for caching.
+header('Cache-Control: public');
+header('ETag: "'.$etag.'"');
+header('Last-Modified: '.$modified);
+
+// Only send the CSS file if it was changed.
+if (isset($_SERVER['HTTP_IF_MODIFIED_SINCE']) || isset($_SERVER['HTTP_IF_NONE_MATCH'])) {
+	$cached_modified = gmdate('r', strtotime($_SERVER['HTTP_IF_MODIFIED_SINCE']));
+	$cached_etag = str_replace(array('"', "-gzip"), array('', ''),
+				stripslashes($_SERVER['HTTP_IF_NONE_MATCH']));
+
+	if (($cached_modified == $modified) && ($cached_etag == $etag)) {
+		header('HTTP/1.1 304 Not Modified');
+		exit();
+	}
+}
+
+echo $css;

--- a/view/theme/frio/style.php
+++ b/view/theme/frio/style.php
@@ -61,7 +61,9 @@ if ($_REQUEST['schema']) {
 	$schema = $_REQUEST['schema'];
 }
 
-$schema = basename($schema);
+// Sanitize the data.
+$schema = !empty($schema) ? basename($schema) : "";
+
 
 if (($schema) && ($schema != '---')) {
 	if (file_exists('view/theme/frio/schema/' . $schema . '.php')) {
@@ -96,7 +98,7 @@ $bgcolor          = (empty($bgcolor)          ? "#ededed"      : $bgcolor);
 $background_image = (empty($background_image) ? 'img/none.jpg' : $background_image);
 $modified         = (empty($modified)         ? time()         :$modified);
 
-$contentbg_transp = ((isset($contentbg_transp) && $contentbg_transp != "") ?  $contentbg_transp : 100);
+$contentbg_transp = ((isset($contentbg_transp) && $contentbg_transp != "") ? $contentbg_transp : 100);
 
 // Calculate some colors in dependance of existing colors.
 // Some colors are calculated to don't have too many selection

--- a/view/theme/frio/style.php
+++ b/view/theme/frio/style.php
@@ -60,6 +60,9 @@ if (! $a->install) {
 if ($_REQUEST['schema']) {
 	$schema = $_REQUEST['schema'];
 }
+
+$schema = basename($schema);
+
 if (($schema) && ($schema != '---')) {
 	if (file_exists('view/theme/frio/schema/' . $schema . '.php')) {
 		$schemefile = 'view/theme/frio/schema/' . $schema . '.php';

--- a/view/theme/frio/templates/theme_settings.tpl
+++ b/view/theme/frio/templates/theme_settings.tpl
@@ -31,7 +31,7 @@
 </div>
 
 <script type="text/javascript">
-	$(function(){
+	$(document).ready(function() {
 		$("#frio_nav_bg, #frio_nav_icon_color, #frio_background_color, #frio_link_color").colorpicker({format: 'hex', align: 'left'});
 
 		// show image options when user user starts to type the address of the image

--- a/view/theme/frio/templates/theme_settings.tpl
+++ b/view/theme/frio/templates/theme_settings.tpl
@@ -60,6 +60,13 @@
 			theme: 'theme-frio',
 		});
 
+		// The position of the slider is wrong calculated on hidden elements.
+		// So set an event listener toggle and update the jRange value.
+		$(document).on('click', '#custom-settings-title a', function() {
+			var bgTransp = $('#frio_contentbg_transp').val();
+			$('.slider-input').jRange('setValue', bgTransp);
+		});
+
 	});
 </script>
 

--- a/view/theme/frio/theme.php
+++ b/view/theme/frio/theme.php
@@ -37,7 +37,7 @@ function frio_init(App $a) {
 				var is_mobile = 1;
 			</script>
 EOT;
-			}
+}
 
 	if ($style == "")
 		$style = get_config('frio', 'style');


### PR DESCRIPTION
If no color settings were changed and if no css file was changed, we use the cached css now.
In addition, the the admin can now change the color of the pages that do not belong to a user profile.
Furthermore two bugs were fixed. The wrong calculation of the jRange slider (because the div was hidden) and a bug in css which resulted in a second http request.