### PR TITLE
Bugfix for "Index column size too large"

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -905,7 +905,7 @@ function login($register = false, $hiddens = false) {
  */
 function killme() {
 	if (!get_app()->is_backend()) {
-		@session_write_close();
+		session_write_close();
 	}
 
 	exit();

--- a/boot.php
+++ b/boot.php
@@ -43,7 +43,7 @@ define ( 'FRIENDICA_PLATFORM',     'Friendica');
 define ( 'FRIENDICA_CODENAME',     'Asparagus');
 define ( 'FRIENDICA_VERSION',      '3.6-dev' );
 define ( 'DFRN_PROTOCOL_VERSION',  '2.23'    );
-define ( 'DB_UPDATE_VERSION',      1234      );
+define ( 'DB_UPDATE_VERSION',      1235      );
 
 /**
  * @brief Constant with a HTML line break.
@@ -905,7 +905,7 @@ function login($register = false, $hiddens = false) {
  */
 function killme() {
 	if (!get_app()->is_backend()) {
-		session_write_close();
+		@session_write_close();
 	}
 
 	exit();

--- a/database.sql
+++ b/database.sql
@@ -1,6 +1,6 @@
 -- ------------------------------------------
 -- Friendica 3.6-dev (Asparagus)
--- DB_UPDATE_VERSION 1234
+-- DB_UPDATE_VERSION 1235
 -- ------------------------------------------
 
 
@@ -184,8 +184,8 @@ CREATE TABLE IF NOT EXISTS `contact` (
 	 INDEX `addr_uid` (`addr`(32),`uid`),
 	 INDEX `nurl_uid` (`nurl`(32),`uid`),
 	 INDEX `nick_uid` (`nick`(32),`uid`),
-	 INDEX `dfrn-id` (`dfrn-id`),
-	 INDEX `issued-id` (`issued-id`)
+	 INDEX `dfrn-id` (`dfrn-id`(64)),
+	 INDEX `issued-id` (`issued-id`(64))
 ) DEFAULT COLLATE utf8mb4_general_ci;
 
 --
@@ -529,11 +529,11 @@ CREATE TABLE IF NOT EXISTS `item` (
 	`rendered-html` mediumtext,
 	`global` tinyint(1) NOT NULL DEFAULT 0,
 	 PRIMARY KEY(`id`),
-	 INDEX `guid` (`guid`),
-	 INDEX `uri` (`uri`),
+	 INDEX `guid` (`guid`(191)),
+	 INDEX `uri` (`uri`(191)),
 	 INDEX `parent` (`parent`),
-	 INDEX `parent-uri` (`parent-uri`),
-	 INDEX `extid` (`extid`),
+	 INDEX `parent-uri` (`parent-uri`(191)),
+	 INDEX `extid` (`extid`(191)),
 	 INDEX `uid_id` (`uid`,`id`),
 	 INDEX `uid_contactid_id` (`uid`,`contact-id`,`id`),
 	 INDEX `uid_created` (`uid`,`created`),
@@ -546,7 +546,7 @@ CREATE TABLE IF NOT EXISTS `item` (
 	 INDEX `authorid_created` (`author-id`,`created`),
 	 INDEX `ownerid` (`owner-id`),
 	 INDEX `uid_uri` (`uid`,`uri`(190)),
-	 INDEX `resource-id` (`resource-id`),
+	 INDEX `resource-id` (`resource-id`(191)),
 	 INDEX `contactid_allowcid_allowpid_denycid_denygid` (`contact-id`,`allow_cid`(10),`allow_gid`(10),`deny_cid`(10),`deny_gid`(10)),
 	 INDEX `uid_type_changed` (`uid`,`type`(190),`changed`),
 	 INDEX `contactid_verb` (`contact-id`,`verb`(190)),
@@ -568,7 +568,7 @@ CREATE TABLE IF NOT EXISTS `item_id` (
 	`service` varchar(255) NOT NULL DEFAULT '',
 	 PRIMARY KEY(`id`),
 	 INDEX `uid` (`uid`),
-	 INDEX `sid` (`sid`),
+	 INDEX `sid` (`sid`(32)),
 	 INDEX `service` (`service`(32)),
 	 INDEX `iid` (`iid`)
 ) DEFAULT COLLATE utf8mb4_general_ci;
@@ -610,7 +610,7 @@ CREATE TABLE IF NOT EXISTS `mail` (
 	 INDEX `convid` (`convid`),
 	 INDEX `uri` (`uri`(64)),
 	 INDEX `parent-uri` (`parent-uri`(64)),
-	 INDEX `contactid` (`contact-id`)
+	 INDEX `contactid` (`contact-id`(32))
 ) DEFAULT COLLATE utf8mb4_general_ci;
 
 --
@@ -961,7 +961,7 @@ CREATE TABLE IF NOT EXISTS `spam` (
 	 INDEX `uid` (`uid`),
 	 INDEX `spam` (`spam`),
 	 INDEX `ham` (`ham`),
-	 INDEX `term` (`term`)
+	 INDEX `term` (`term`(32))
 ) DEFAULT COLLATE utf8mb4_general_ci;
 
 --

--- a/include/dbstructure.php
+++ b/include/dbstructure.php
@@ -130,10 +130,8 @@ function table_structure($table) {
 			}
 
 			$column = $index["Column_name"];
-			// On utf8mb4 a varchar index can only have a length of 191
-			// The "show index" command sometimes returns this value although this value wasn't added manually.
-			// Because we don't want to add this number to every index, we ignore bigger numbers
-			if (($index["Sub_part"] != "") && (($index["Sub_part"] < 191) || ($index["Key_name"] == "PRIMARY"))) {
+
+			if (($index["Sub_part"] != "")) {
 				$column .= "(".$index["Sub_part"].")";
 			}
 
@@ -817,8 +815,8 @@ function db_definition() {
 					"addr_uid" => array("addr(32)", "uid"),
 					"nurl_uid" => array("nurl(32)", "uid"),
 					"nick_uid" => array("nick(32)", "uid"),
-					"dfrn-id" => array("dfrn-id"),
-					"issued-id" => array("issued-id"),
+					"dfrn-id" => array("dfrn-id(64)"),
+					"issued-id" => array("issued-id(64)"),
 					)
 			);
 	$database["conv"] = array(
@@ -1162,11 +1160,11 @@ function db_definition() {
 					),
 			"indexes" => array(
 					"PRIMARY" => array("id"),
-					"guid" => array("guid"),
-					"uri" => array("uri"),
+					"guid" => array("guid(191)"),
+					"uri" => array("uri(191)"),
 					"parent" => array("parent"),
-					"parent-uri" => array("parent-uri"),
-					"extid" => array("extid"),
+					"parent-uri" => array("parent-uri(191)"),
+					"extid" => array("extid(191)"),
 					"uid_id" => array("uid","id"),
 					"uid_contactid_id" => array("uid","contact-id","id"),
 					"uid_created" => array("uid","created"),
@@ -1179,7 +1177,7 @@ function db_definition() {
 					"authorid_created" => array("author-id","created"),
 					"ownerid" => array("owner-id"),
 					"uid_uri" => array("uid", "uri(190)"),
-					"resource-id" => array("resource-id"),
+					"resource-id" => array("resource-id(191)"),
 					"contactid_allowcid_allowpid_denycid_denygid" => array("contact-id","allow_cid(10)","allow_gid(10)","deny_cid(10)","deny_gid(10)"), //
 					"uid_type_changed" => array("uid","type(190)","changed"),
 					"contactid_verb" => array("contact-id","verb(190)"),
@@ -1201,7 +1199,7 @@ function db_definition() {
 			"indexes" => array(
 					"PRIMARY" => array("id"),
 					"uid" => array("uid"),
-					"sid" => array("sid"),
+					"sid" => array("sid(32)"),
 					"service" => array("service(32)"),
 					"iid" => array("iid"),
 					)
@@ -1243,7 +1241,7 @@ function db_definition() {
 					"convid" => array("convid"),
 					"uri" => array("uri(64)"),
 					"parent-uri" => array("parent-uri(64)"),
-					"contactid" => array("contact-id"),
+					"contactid" => array("contact-id(32)"),
 					)
 			);
 	$database["mailacct"] = array(
@@ -1594,7 +1592,7 @@ function db_definition() {
 					"uid" => array("uid"),
 					"spam" => array("spam"),
 					"ham" => array("ham"),
-					"term" => array("term"),
+					"term" => array("term(32)"),
 					)
 			);
 	$database["term"] = array(

--- a/update.php
+++ b/update.php
@@ -1,6 +1,6 @@
 <?php
 
-define('UPDATE_VERSION' , 1234);
+define('UPDATE_VERSION' , 1235);
 
 /**
  *


### PR DESCRIPTION
Installing a new instance of Friendica could fail with the error "Index column size too large. The maximum column size is 767 bytes."

This fixes it.