### PR TITLE
Bugfix: not complete a url with parameter or fragment

### DIFF
--- a/include/html2bbcode.php
+++ b/include/html2bbcode.php
@@ -340,6 +340,8 @@ function html2bbcode($message, $basepath = '')
  */
 function addHostnameSub($matches, $basepath) {
 	$base = parse_url($basepath);
+	unset($base['query']);
+	unset($base['fragment']);
 
 	$link = $matches[0];
 	$url = $matches[1];


### PR DESCRIPTION
This is important for completing URL on feeds.

See here for a completion that went wrong: https://libranet.de/display/0b6b25a8a0bf3c5834387eff24ba447bdee38d25

The query parameter in the links belong to the feed URL.