### PR TITLE
If a post is dedicated to a single forum then it will be rewritten

### DIFF
--- a/mod/item.php
+++ b/mod/item.php
@@ -575,6 +575,7 @@ function item_post(App $a) {
 	$tagged = array();
 
 	$private_forum = false;
+	$only_to_forum = false;
 
 	if (count($tags)) {
 		foreach ($tags as $tag) {
@@ -608,12 +609,13 @@ function item_post(App $a) {
 			// When the forum is private or the forum is addressed with a "!" make the post private
 			if (is_array($success['contact']) && ($success['contact']['prv'] || ($tag_type == '!'))) {
 				$private_forum = true;
+				$only_to_forum = ($tag_type == '!');
 				$private_id = $success['contact']['id'];
 			}
 		}
 	}
 
-	if ($private_forum && !$parent && !$private) {
+	if ($private_forum && !$parent && (!$private || $only_to_forum)) {
 		// we tagged a private forum in a top level post and the message was public.
 		// Restrict it.
 		$private = 1;

--- a/object/Item.php
+++ b/object/Item.php
@@ -127,7 +127,9 @@ class Item extends BaseObject {
 			? t('Private Message')
 			: false);
 		$shareable = ((($conv->get_profile_owner() == local_user()) && ($item['private'] != 1)) ? true : false);
-		if (local_user() && link_compare($a->contact['url'],$item['author-link'])) {
+
+		/// @todo The check for the contact-id is here to block editing of rewritten forum posts - see function dfrn::rewriteDedicatedForumPost
+		if (local_user() && link_compare($a->contact['url'],$item['author-link']) && ($a->contact['id'] == $item['contact-id'])) {
 			if ($item["event-id"] != 0) {
 				$edpost = array("events/event/".$item['event-id'], t("Edit"));
 			} else {


### PR DESCRIPTION
These post will then become posts that had been generated by the forum. And if the forum was public then the post becomes public as well.

This is meant so that these posts will appear under the sidebar link for forum posts.

Downside: The post looses the ability to be edited or deleted by the original author.