### PR TITLE
Forum posts with "!" are now created directly as forum post

### DIFF
--- a/include/dfrn.php
+++ b/include/dfrn.php
@@ -1988,81 +1988,6 @@ class dfrn {
 	}
 
 	/**
-	 * @brief Check and possibly rewrite a post if it was a dedicated forum post
-	 *
-	 * @param array $item the new item record
-	 *
-	 * @return boolean Was the post be rewritten?
-	 */
-	private static function rewriteDedicatedForumPost($item) {
-		$fields = array('author-link', 'allow_cid', 'contact-id', 'private', 'wall', 'id', 'parent');
-		$condition = array('uri' => $item['uri'], 'uid' => $item['uid']);
-		$existing = dba::select('item', $fields, $condition, array('limit' => 1));
-		if (!dbm::is_result($existing)) {
-			return false;
-		}
-
-		// Only rewrite if the former post was a private starting post
-		if (!$existing['wall'] || !$existing['private'] || ($existing['id'] != $existing['parent'])) {
-			return false;
-		}
-
-		// Is the post only directed to a single forum?
-		if ($existing['allow_cid'] != '<'.$item['contact-id'].'>') {
-			return false;
-		}
-
-		$fields = array('id');
-		$condition = array('uid' => $item['uid'], 'self' => true);
-		$self = dba::select('contact', $fields, $condition, array('limit' => 1));
-		if (!dbm::is_result($self)) {
-			return false;
-		}
-
-		// is the original item created by the "self" user.
-		if ($self['id'] != $existing['contact-id']) {
-			return false;
-		}
-
-		$fields = array('forum', 'prv');
-		$condition = array('id' => $item['contact-id']);
-		$contact = dba::select('contact', $fields, $condition, array('limit' => 1));
-		if (!dbm::is_result($contact)) {
-			return false;
-		}
-
-		// Is the post from a forum?
-		if (!$contact['forum'] && !$contact['prv']) {
-			return false;
-		}
-
-		/// @todo There is an ugly downside of this whole rewrite process: These items loose the ability to be edited by the user.
-		logger('Item '.$item['uri'].' will be rewritten.', LOGGER_DEBUG);
-
-		$item = store_conversation($item);
-		unset($fields['dsprsig']);
-
-		// Rewrite to a public post if it comes from a public forum
-		if ($contact['forum']) {
-			$item['allow_cid'] = '';
-			$item['allow_gid'] = '';
-			$item['deny_cid'] = '';
-			$item['deny_gid'] = '';
-			$item['private'] = false;
-		}
-
-		$item['wall'] = false;
-
-		$item["owner-id"] = get_contact($item["owner-link"], 0);
-
-		$condition = array('uri' => $item["uri"], 'uid' => $item["uid"]);
-		dba::update('item', $item, $condition);
-
-		add_shadow_thread($existing['id']);
-		return true;
-	}
-
-	/**
 	 * @brief Updates an item
 	 *
 	 * @param array $current the current item record
@@ -2081,14 +2006,12 @@ class dfrn {
 				return false;
 			}
 
-			if (!self::rewriteDedicatedForumPost($item)) {
-				$fields = array('title' => $item["title"], 'body' => $item["body"],
-						'tag' => $item["tag"], 'changed' => datetime_convert(),
-						'edited' => datetime_convert("UTC", "UTC", $item["edited"]));
+			$fields = array('title' => $item["title"], 'body' => $item["body"],
+					'tag' => $item["tag"], 'changed' => datetime_convert(),
+					'edited' => datetime_convert("UTC", "UTC", $item["edited"]));
 
-				$condition = array("`uri` = ? AND `uid` IN (0, ?)", $item["uri"], $importer["importer_uid"]);
-				dba::update('item', $fields, $condition);
-			}
+			$condition = array("`uri` = ? AND `uid` IN (0, ?)", $item["uri"], $importer["importer_uid"]);
+			dba::update('item', $fields, $condition);
 
 			create_tags_from_itemuri($item["uri"], $importer["importer_uid"]);
 			update_thread_uri($item["uri"], $importer["importer_uid"]);

--- a/include/notifier.php
+++ b/include/notifier.php
@@ -215,6 +215,9 @@ function notifier_run(&$argv, &$argc){
 	// Do a PuSH
 	$push_notify = false;
 
+	// Deliver directly to a forum, don't PuSH
+	$direct_forum_delivery = false;
+
 	// fill this in with a single salmon slap if applicable
 	$slap = '';
 
@@ -302,6 +305,7 @@ function notifier_run(&$argv, &$argc){
 			// Is the post from a forum?
 			if ($contact['forum'] || $contact['prv']) {
 				$relay_to_owner = true;
+				$direct_forum_delivery = true;
 			}
 		}
 		if ($relay_to_owner) {
@@ -337,6 +341,11 @@ function notifier_run(&$argv, &$argc){
 					}
 				}
 			}
+
+			if ($direct_forum_delivery) {
+				$push_notify = false;
+			}
+
 			logger("Notify ".$target_item["guid"]." via PuSH: ".($push_notify?"Yes":"No"), LOGGER_DEBUG);
 		} else {
 			$followup = false;


### PR DESCRIPTION
This is a replacement for the last PR. There we rewrote the post when it as mirrored from the forum. Now the post is directly created as forum post. This is much more elegant.