### PR TITLE
Always show dislikes - the setting now just hides the button

### DIFF
--- a/src/Core/Item.php
+++ b/src/Core/Item.php
@@ -217,10 +217,7 @@ class Item extends BaseObject
 		}*/
 
 		// process action responses - e.g. like/dislike/attend/agree/whatever
-		$response_verbs = array('like');
-		if (feature_enabled($conv->get_profile_owner(), 'dislike')) {
-			$response_verbs[] = 'dislike';
-		}
+		$response_verbs = array('like', 'dislike');
 
 		if ($item['object-type'] === ACTIVITY_OBJ_EVENT) {
 			$response_verbs[] = 'attendyes';


### PR DESCRIPTION
When the feature "dislike" was disabled, not only the possibility to dislike content was removed, but also it wasn't shown when an item was disliked.

This is a confusing behaviour as can be seen here: https://forum.friendi.ca/display/0b6b25a8105a114951aa3f4476553817

Now the setting only controls whether a user is able to dislike something.