### PR TITLE
silence accounts from global community page

### DIFF
--- a/util/global_community_silence.php
+++ b/util/global_community_silence.php
@@ -28,12 +28,14 @@ if ($argc!=2 || $argv[1]=="-h" || $argv[1]=="--help" || $argv[1]=="-?") {
 	echo "    profile_url ...... The URL of the profile you want to silence\r\n";
 	echo "\r\n";
 	echo "Example: Silence bob@example.com\r\n";
-	echo "$> ".$argv[0]." https://exaple.com/profiles/bob\r\n";
+	echo "$> ".$argv[0]." https://example.com/profiles/bob\r\n";
 	echo "\r\n";
 	exit(0);
 }
 
 use Friendica\Database\DBM;
+use Friendica\Network\Probe;
+
 require_once("boot.php");
 require_once('include/dba.php');
 require_once("include/text.php");
@@ -48,11 +50,16 @@ unset($db_host, $db_user, $db_pass, $db_data);
  * 2. check DB (contact) if there is a contact with uid=0 and that nurl, get the ID
  * 3. set the flag hidden=1 for the contact entry with the found ID
  **/
-
-$nurl = normalise_link($argv[1]);
-$r = dba::select("contact", array("id"), array("nurl" => $nurl, "uid" => 0), array("limit"=> 1));
+$net = Probe::uri($argv[1]);
+if (in_array($net['network'], array(NETWORK_PHANTOM, NETWORK_MAIL))) {
+	echo "This account seems not to exist.";
+	echo "\r\n";
+	exit(1);
+}
+$nurl = normalise_link($net['url']);
+$r = dba::select("contact", array("id"), array("nurl" => $nurl, "uid" => 0), array("limit" => 1));
 if (DBM::is_result($r)) {
-	dba::update("contact", array("hidden"=>1), array("id"=>$r["id"]));
+	dba::update("contact", array("hidden" => true), array("id" => $r["id"]));
 	echo "NOTICE: The account should be silenced from the global community page\r\n";
 } else {
 	echo "NOTICE: Could not find any entry for this URL (".$nurl.")\r\n";

--- a/util/global_community_silence.php
+++ b/util/global_community_silence.php
@@ -1,0 +1,61 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * @brief tool to silence accounts on the global community page
+ *
+ * With this tool, you can silence an account on the global community page.
+ * Postings from silenced accounts will not be displayes on the community
+ * page. This silencing does only affect the display on the community page,
+ * accounts following the silenced accounts will still get their postings.
+ *
+ * Usage: pass the URL of the to be silenced account as only parameter
+ *        at the command line when running this tool. E.g.
+ *
+ *        $> util/global_community_silence.php http://example.com/profile/bob
+ *
+ *        will silence bob@example.com so that his postings wont appear at
+ *        the global community page.
+ *
+ * Author: Tobias Diekershoff
+ *
+ * License: AGPLv3 or later, same as Friendica
+ **/
+
+if ($argc!=2 || $argv[1]=="-h" || $argv[1]=="--help" || $argv[1]=="-?") {
+	echo "Usage: ".$argv[0]." [-h|profile_url]\r\n";
+	echo "    -h, -?, --help ... show this help\r\n";
+	echo "    profile_url ...... The URL of the profile you want to silence\r\n";
+	echo "\r\n";
+	echo "Example: Silence bob@example.com\r\n";
+	echo "$> ".$argv[0]." https://exaple.com/profiles/bob\r\n";
+	echo "\r\n";
+	exit(0);
+}
+
+use Friendica\Database\DBM;
+require_once("boot.php");
+require_once('include/dba.php');
+require_once("include/text.php");
+$a = get_app();
+require_once ".htconfig.php";
+
+dba::connect($db_host, $db_user, $db_pass, $db_data);
+unset($db_host, $db_user, $db_pass, $db_data);
+
+/**
+ * 1. make nurl from last parameter
+ * 2. check DB (contact) if there is a contact with uid=0 and that nurl, get the ID
+ * 3. set the flag hidden=1 for the contact entry with the found ID
+ **/
+
+$nurl = normalise_link($argv[1]);
+$r = dba::select("contact", array("id"), array("nurl" => $nurl, "uid" => 0), array("limit"=> 1));
+if (DBM::is_result($r)) {
+	dba::update("contact", array("hidden"=>1), array("id"=>$r["id"]));
+	echo "NOTICE: The account should be silenced from the global community page\r\n";
+} else {
+	echo "NOTICE: Could not find any entry for this URL (".$nurl.")\r\n";
+}
+
+?>


### PR DESCRIPTION
The community page can show all public postings arriving on a node. Some users might follow someone who posts content one does not want to see on the community page of the node. This script acts as a CLI interface to silence accounts from the global community page of the node.

Currently this has to be done directly at the database.