### PR TITLE
Avoid empty user export when there are UTF8 problems

### DIFF
--- a/mod/uexport.php
+++ b/mod/uexport.php
@@ -126,7 +126,7 @@ function uexport_account($a) {
 	);
 
 	//echo "<pre>"; var_dump(json_encode($output)); killme();
-	echo json_encode($output);
+	echo json_encode($output, JSON_PARTIAL_OUTPUT_ON_ERROR);
 }
 
 /**
@@ -154,6 +154,6 @@ function uexport_all(App $a) {
 		);
 
 		$output = array('item' => $r);
-		echo json_encode($output) . "\n";
+		echo json_encode($output, JSON_PARTIAL_OUTPUT_ON_ERROR). "\n";
 	}
 }


### PR DESCRIPTION
With this option only some fields are empty but not the whole file.