### PR TITLE
Bugfix for "Call to undefined function best_link_url()"

### DIFF
--- a/include/event.php
+++ b/include/event.php
@@ -12,6 +12,7 @@ use Friendica\Database\DBM;
 require_once 'include/bbcode.php';
 require_once 'include/map.php';
 require_once 'include/datetime.php';
+require_once "include/conversation.php";
 
 function format_event_html($ev, $simple = false) {
 	if (! ((is_array($ev)) && count($ev))) {

--- a/include/text.php
+++ b/include/text.php
@@ -10,6 +10,7 @@ use Friendica\Database\DBM;
 require_once "include/friendica_smarty.php";
 require_once "include/map.php";
 require_once "mod/proxy.php";
+require_once "include/conversation.php";
 
 /**
  * This is our template processor

--- a/src/Object/Item.php
+++ b/src/Object/Item.php
@@ -13,6 +13,7 @@ use dba;
 
 require_once 'include/text.php';
 require_once 'boot.php';
+require_once "include/conversation.php";
 
 /**
  * An item


### PR DESCRIPTION
The include to "conversation.php" was missing. I can imagine that this possibly was included in one of the moved classes.

I got the following error:
```
PHP Fatal error:  Uncaught Error: Call to undefined function best_link_url() in /var/www/virtual/pirati.ca/htdocs/include/text.php:1301
Stack trace:
#0 /var/www/virtual/pirati.ca/htdocs/include/email.php(278): prepare_body(Array)
#1 /var/www/virtual/pirati.ca/htdocs/src/Worker/Delivery.php(472): email_send('friendica@libre...', 'Re: (no subject...', 'From: Michael V...', Array)
#2 [internal function]: Friendica\Worker\Delivery::execute('comment-new', '18036307', 936)
#3 /var/www/virtual/pirati.ca/htdocs/src/Core/Worker.php(346): call_user_func_array('Friendica\\Worke...', Array)
#4 /var/www/virtual/pirati.ca/htdocs/src/Core/Worker.php(240): Friendica\Core\Worker::execFunction(Array, 'Delivery', Array, true)
#5 /var/www/virtual/pirati.ca/htdocs/src/Core/Worker.php(102): Friendica\Core\Worker::execute(Array)
#6 /var/www/virtual/pirati.ca/htdocs/scripts/worker.php(42): Friendica\Core\Worker::processQueue(false)
#7 {main}
  thrown in /var/www/virtual/pirati.ca/htdocs/include/text.php on line 1301
```