### PR TITLE
Prevent the running of multiple xmpp auth daemons at a time

### DIFF
--- a/doc/htconfig.md
+++ b/doc/htconfig.md
@@ -19,6 +19,7 @@ Example: To set the directory value please add this line to your .htconfig.php:
 
 ## jabber ##
 * **debug** (Boolean) - Enable debug level for the jabber account synchronisation.
+* **lockpath** - Must be writable by the ejabberd process. if set then it will prevent the running of multiple processes.
 
 ## system ##
 

--- a/src/Util/ExAuth.php
+++ b/src/Util/ExAuth.php
@@ -270,7 +270,9 @@ class ExAuth
 	 */
 	private function checkCredentials($host, $user, $password, $ssl)
 	{
-		$url = ($ssl ? 'https' : 'http') . '://' . $host . '/api/account/verify_credentials.json';
+		$this->writeLog(LOG_INFO, 'external credential check for ' . $user . '@' . $host);
+
+		$url = ($ssl ? 'https' : 'http') . '://' . $host . '/api/account/verify_credentials.json?skip_status=true';
 
 		$ch = curl_init();
 		curl_setopt($ch, CURLOPT_URL, $url);


### PR DESCRIPTION
For unknown reasons it happens that the auth daemon for ejabberd is sometimes started multiple times. This results that one of these processes is using 100% cpu time.

We now check for the existence of another process and kill the old one.

This is done at the first auth call since only then we will know the hostname that will be used for the pid file. Since you can use the auth daemon for a multi host scenario, this is the only way.

Additionally the file src/Util/ExAuth.php was converted from the dos format to the unix format and the pidfile class was made workable.