### PR TITLE
Fix registration

### DIFF
--- a/include/text.php
+++ b/include/text.php
@@ -1068,17 +1068,14 @@ function search($s, $id = 'search-box', $url = 'search', $save = false, $aside =
 }
 
 /**
- * Check if $x is a valid email string
+ * @brief Check for a valid email string
  *
- * @param string $x
+ * @param string $email_address
  * @return boolean
  */
-function valid_email($x){
-
-	/// @TODO Removed because Fabio told me so.
-	//if (Config::get('system','disable_email_validation'))
-	//	return true;
-	return preg_match('/^[_a-zA-Z0-9\-\+]+(\.[_a-zA-Z0-9\-\+]+)*@[a-zA-Z0-9-]+(\.[a-zA-Z0-9-]+)+$/', $x);
+function valid_email($email_address)
+{
+	return preg_match('/^[_a-zA-Z0-9\-\+]+(\.[_a-zA-Z0-9\-\+]+)*@[a-zA-Z0-9-]+(\.[a-zA-Z0-9-]+)+$/', $email_address);
 }
 
 

--- a/mod/admin.php
+++ b/mod/admin.php
@@ -1594,8 +1594,8 @@ function admin_page_users(App $a)
 	/* get pending */
 	$pending = q("SELECT `register`.*, `contact`.`name`, `user`.`email`
 				 FROM `register`
-				 JOIN `contact` ON `register`.`uid` = `contact`.`uid`
-				 JOIN `user` ON `register`.`uid` = `user`.`uid`;");
+				 INNER JOIN `contact` ON `register`.`uid` = `contact`.`uid`
+				 INNER JOIN `user` ON `register`.`uid` = `user`.`uid`;");
 
 
 	/* get users */

--- a/mod/admin.php
+++ b/mod/admin.php
@@ -1587,8 +1587,8 @@ function admin_page_users(App $a)
 	/* get pending */
 	$pending = q("SELECT `register`.*, `contact`.`name`, `user`.`email`
 				 FROM `register`
-				 LEFT JOIN `contact` ON `register`.`uid` = `contact`.`uid`
-				 LEFT JOIN `user` ON `register`.`uid` = `user`.`uid`;");
+				 JOIN `contact` ON `register`.`uid` = `contact`.`uid`
+				 JOIN `user` ON `register`.`uid` = `user`.`uid`;");
 
 
 	/* get users */

--- a/mod/admin.php
+++ b/mod/admin.php
@@ -1466,13 +1466,20 @@ function admin_page_users_post(App $a)
 	check_form_security_token_redirectOnErr('/admin/users', 'admin_users');
 
 	if (!($nu_name === "") && !($nu_email === "") && !($nu_nickname === "")) {
-		$result = User::create(array('username' => $nu_name, 'email' => $nu_email,
-			'nickname' => $nu_nickname, 'verified' => 1, 'language' => $nu_language));
-		if (!$result['success']) {
-			notice($result['message']);
+		try {
+			$result = User::create([
+				'username' => $nu_name,
+				'email' => $nu_email,
+				'nickname' => $nu_nickname,
+				'verified' => 1,
+				'language' => $nu_language
+			]);
+		} catch (Exception $ex) {
+			notice($ex->getMessage());
 			return;
 		}
-		$nu = $result['user'];
+
+		$user = $result['user'];
 		$preamble = deindent(t('
 			Dear %1$s,
 				the administrator of %2$s has set up an account for you.'));
@@ -1502,12 +1509,12 @@ function admin_page_users_post(App $a)
 
 			Thank you and welcome to %4$s.'));
 
-		$preamble = sprintf($preamble, $nu['username'], $a->config['sitename']);
-		$body = sprintf($body, System::baseUrl(), $nu['email'], $result['password'], $a->config['sitename']);
+		$preamble = sprintf($preamble, $user['username'], $a->config['sitename']);
+		$body = sprintf($body, System::baseUrl(), $user['email'], $result['password'], $a->config['sitename']);
 
 		notification(array(
 			'type' => SYSTEM_EMAIL,
-			'to_email' => $nu['email'],
+			'to_email' => $user['email'],
 			'subject' => sprintf(t('Registration details for %s'), $a->config['sitename']),
 			'preamble' => $preamble,
 			'body' => $body));

--- a/mod/register.php
+++ b/mod/register.php
@@ -59,10 +59,10 @@ function register_post(App $a)
 	$arr['verified'] = $verified;
 	$arr['language'] = get_browser_language();
 
-	$result = User::create($arr);
-
-	if (!$result['success']) {
-		notice($result['message']);
+	try {
+		$result = User::create($arr);
+	} catch (Exception $e) {
+		notice($e->getMessage());
 		return;
 	}
 

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -96,11 +96,11 @@ class Contact extends BaseObject
 	public static function createSelfFromUserId($uid)
 	{
 		// Only create the entry if it doesn't exist yet
-		if (dba::exists('contact', ['uid' => intval($uid), 'self'])) {
+		if (dba::exists('contact', ['uid' => $uid, 'self' => true])) {
 			return true;
 		}
 
-		$user = dba::select('user', ['uid', 'username', 'nickname'], ['uid' => intval($uid)], ['limit' => 1]);
+		$user = dba::select('user', ['uid', 'username', 'nickname'], ['uid' => $uid], ['limit' => 1]);
 		if (!DBM::is_result($user)) {
 			return false;
 		}

--- a/src/Model/Group.php
+++ b/src/Model/Group.php
@@ -47,6 +47,9 @@ class Group extends BaseObject
 			}
 
 			$return = dba::insert('group', ['uid' => $uid, 'name' => $name]);
+			if ($return) {
+				$return = dba::lastInsertId();
+			}
 		}
 		return $return;
 	}


### PR DESCRIPTION
Fixes #4041

The problem was a misconception on my part of the condition array in `dba::select()`, I thought I could just mention a field to check its boolean value, but the resulting condition associative array missed a field name key and a field value. Consequently, `Contact::createSelfForUserId()` always returned true when checking for existing rows, even if they haven't been created beforehand.

Since I looked at it so much, I also replaced all the `q()` calls with shiny new `dba` calls in `User::create` and enabled Exceptions for error handling.

PR for addons coming up.