### PR TITLE
Remove group_member.uid

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -43,7 +43,7 @@ define('FRIENDICA_PLATFORM',     'Friendica');
 define('FRIENDICA_CODENAME',     'Asparagus');
 define('FRIENDICA_VERSION',      '3.6-dev');
 define('DFRN_PROTOCOL_VERSION',  '2.23');
-define('DB_UPDATE_VERSION',      1236);
+define('DB_UPDATE_VERSION',      1237);
 define('NEW_UPDATE_ROUTINE_VERSION', 1170);
 
 /**

--- a/include/acl_selectors.php
+++ b/include/acl_selectors.php
@@ -529,7 +529,7 @@ function acl_lookup(App $a, $out_type = 'json') {
 		// This can be done when we can delete cache entries via wildcard
 		$r = q("SELECT `group`.`id`, `group`.`name`, GROUP_CONCAT(DISTINCT `group_member`.`contact-id` SEPARATOR ',') AS uids
 				FROM `group`
-				INNER JOIN `group_member` ON `group_member`.`gid`=`group`.`id` AND `group_member`.`uid` = `group`.`uid`
+				INNER JOIN `group_member` ON `group_member`.`gid`=`group`.`id`
 				WHERE NOT `group`.`deleted` AND `group`.`uid` = %d
 					$sql_extra
 				GROUP BY `group`.`name`, `group`.`id`

--- a/include/uimport.php
+++ b/include/uimport.php
@@ -232,8 +232,6 @@ function import_account(App $a, $file) {
 	}
 
 	foreach ($account['group_member'] as &$group_member) {
-		$group_member['uid'] = $newuid;
-
 		$import = 0;
 		foreach ($account['group'] as $group) {
 			if ($group['id'] == $group_member['gid'] && isset($group['newid'])) {

--- a/mod/uexport.php
+++ b/mod/uexport.php
@@ -109,7 +109,7 @@ function uexport_account($a) {
 	);
 
 	$group_member = _uexport_multirow(
-		sprintf("SELECT * FROM `group_member` WHERE uid = %d", intval(local_user()))
+		sprintf("SELECT `group_member`.`gid`, `group_member`.`contact-id` FROM `group_member` INNER JOIN `group` ON `group`.`id` = `group_member`.`gid` WHERE `group`.`uid` = %d", intval(local_user()))
 	);
 
 	$output = array(

--- a/src/Database/DBStructure.php
+++ b/src/Database/DBStructure.php
@@ -996,7 +996,6 @@ class DBStructure {
 				"indexes" => array(
 						"PRIMARY" => array("id"),
 						"contactid" => array("contact-id"),
-						"gid" => array("gid"),
 						"gid_contactid" => array("UNIQUE", "gid", "contact-id"),
 						)
 				);

--- a/src/Database/DBStructure.php
+++ b/src/Database/DBStructure.php
@@ -996,7 +996,8 @@ class DBStructure {
 				"indexes" => array(
 						"PRIMARY" => array("id"),
 						"contactid" => array("contact-id"),
-						"gid_contactid" => array("gid", "contact-id"),
+						"gid" => array("gid"),
+						"gid_contactid" => array("UNIQUE", "gid", "contact-id"),
 						)
 				);
 		$database["gserver"] = array(

--- a/src/Database/DBStructure.php
+++ b/src/Database/DBStructure.php
@@ -990,7 +990,6 @@ class DBStructure {
 		$database["group_member"] = array(
 				"fields" => array(
 						"id" => array("type" => "int(10) unsigned", "not null" => "1", "extra" => "auto_increment", "primary" => "1"),
-						"uid" => array("type" => "int(10) unsigned", "not null" => "1", "default" => "0", "relation" => array("user" => "uid")),
 						"gid" => array("type" => "int(10) unsigned", "not null" => "1", "default" => "0", "relation" => array("group" => "id")),
 						"contact-id" => array("type" => "int(10) unsigned", "not null" => "1", "default" => "0", "relation" => array("contact" => "id")),
 						),
@@ -998,7 +997,6 @@ class DBStructure {
 						"PRIMARY" => array("id"),
 						"contactid" => array("contact-id"),
 						"gid_contactid" => array("gid", "contact-id"),
-						"uid_gid_contactid" => array("UNIQUE", "uid", "gid", "contact-id"),
 						)
 				);
 		$database["gserver"] = array(

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -42,7 +42,7 @@ class Contact extends BaseObject
 				INNER JOIN `group_member`
 					ON `contact`.`id` = `group_member`.`contact-id`
 				WHERE `gid` = ?
-				AND `group_member`.`uid` = ?
+				AND `contact`.`uid` = ?
 				AND NOT `contact`.`self`
 				AND NOT `contact`.`blocked`
 				AND NOT `contact`.`pending`
@@ -73,7 +73,7 @@ class Contact extends BaseObject
 				INNER JOIN `group_member`
 					ON `contact`.`id` = `group_member`.`contact-id`
 				WHERE `gid` = ?
-				AND `group_member`.`uid` = ?
+				AND `contact`.`uid` = ?
 				AND `contact`.`network` = ?
 				AND `contact`.`notify` != ""',
 				$gid,
@@ -605,7 +605,9 @@ class Contact extends BaseObject
 			AND NOT `pending`
 			AND `id` NOT IN (
 				SELECT DISTINCT(`contact-id`)
-				FROM `group_member` WHERE `uid` = %d
+				FROM `group_member`
+				JOIN `group` ON `group`.`id` = `group_member`.`gid`
+				WHERE `group`.`uid` = %d
 			)
 			LIMIT %d, %d", intval($uid), intval($uid), intval($start), intval($count)
 		);

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -606,7 +606,7 @@ class Contact extends BaseObject
 			AND `id` NOT IN (
 				SELECT DISTINCT(`contact-id`)
 				FROM `group_member`
-				JOIN `group` ON `group`.`id` = `group_member`.`gid`
+				INNER JOIN `group` ON `group`.`id` = `group_member`.`gid`
 				WHERE `group`.`uid` = %d
 			)
 			LIMIT %d, %d", intval($uid), intval($uid), intval($start), intval($count)

--- a/src/Model/Group.php
+++ b/src/Model/Group.php
@@ -96,8 +96,7 @@ class Group extends BaseObject
 					AND `contact-id` IN
 						(SELECT `contact-id`
 						FROM `group_member`
-						WHERE `group_member`.`gid` = `group`.`id`
-						AND `group_member`.`uid` = ?)
+						WHERE `group_member`.`gid` = `group`.`id`)
 					) AS `count`
 				FROM `group`
 				WHERE `group`.`uid` = ?;",

--- a/update.php
+++ b/update.php
@@ -1,6 +1,6 @@
 <?php
 
-define('UPDATE_VERSION' , 1236);
+define('UPDATE_VERSION' , 1237);
 
 use Friendica\Core\Config;
 use Friendica\Core\PConfig;


### PR DESCRIPTION
Follow-up to #4046 and #4064

This PR gets rid of group_member.uid, a doubly redundant field present both in the group and the contact table which are foreign keys of group_member.

Queries using it have been modified accordingly.