### PR TITLE
Implement search API (fixes #929)

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -450,6 +450,24 @@ It shows all direct answers (excluding the original post) to a given id.
 Friendica doesn't allow showing followers of other users.
 
 ---
+### search (*; AUTH)
+#### Parameters
+* q: search query
+* page: the page number (starting at 1) to return
+* rpp: the number of statuses to return per page
+* count: alias for the rpp parameter
+* since_id: returns statuses with ids greater than the given id
+* max_id: returns statuses with ids lower or equal to the given id
+
+#### Unsupported parameters
+* geocode
+* lang
+* locale
+* result_type
+* until
+* include_entities
+
+---
 ### users/search (*)
 #### Parameters
 * q: name of the user

--- a/include/api.php
+++ b/include/api.php
@@ -1526,7 +1526,7 @@ function api_search($type)
 		"SELECT ".item_fieldlists()."
 		FROM `item` ".item_joins()."
 		WHERE ".item_condition()." AND (`item`.`uid` = 0 OR (`item`.`uid` = ? AND NOT `item`.`global`))
-		AND `item`.`body` REGEXP ?
+		AND `item`.`body` LIKE CONCAT('%',?,'%')
 		$sql_extra
 		AND `item`.`id`>?
 		ORDER BY `item`.`id` DESC LIMIT ".intval($start)." ,".intval($count)." ",

--- a/include/api.php
+++ b/include/api.php
@@ -1530,9 +1530,9 @@ function api_search($type)
 		$sql_extra
 		AND `item`.`id`>?
 		ORDER BY `item`.`id` DESC LIMIT ".intval($start)." ,".intval($count)." ",
-		intval(api_user()),
+		api_user(),
 		$_REQUEST['q'],
-		intval($since_id)
+		$since_id
 	);
 
 	$data['status'] = api_format_items(dba::inArray($r), api_get_user(get_app()));

--- a/include/api.php
+++ b/include/api.php
@@ -1535,12 +1535,7 @@ function api_search($type)
 		intval($since_id)
 	);
 
-	$statuses = array();
-	while ($row = dba::fetch($r)) {
-		$statuses[] = $row;
-	}
-
-	$data['status'] = api_format_items($statuses, api_get_user(get_app()));
+	$data['status'] = api_format_items(dba::inArray($r), api_get_user(get_app()));
 
 	return api_format_data("statuses", $type, $data);
 }


### PR DESCRIPTION
This PR adds two API endpoints:
* `search` (from the [GNU Social API](https://gnusocial.net/doc/twitterapi))
* `search/tweets` (from the [Twitter API](https://developer.twitter.com/en/docs/tweets/search/api-reference/get-search-tweets))
As the parameters are very similar, they both use the same function.
All the GNU Social parameters are implemented but several Twitter parameters are missing.

I'm not very familiar with the Friendica database and most of the SQL code is borrowed from other functions so please tell me if I missed something.