### PR TITLE
OnePoll: We now force an update check all the time

### DIFF
--- a/src/Worker/OnePoll.php
+++ b/src/Worker/OnePoll.php
@@ -66,7 +66,7 @@ Class OnePoll
 
 		// Diaspora users, archived users and followers are only checked if they still exist.
 		if ($contact['archive'] || ($contact["network"] == NETWORK_DIASPORA) || ($contact["rel"] == CONTACT_IS_FOLLOWER)) {
-			$last_updated = PortableContact::lastUpdated($contact["url"]);
+			$last_updated = PortableContact::lastUpdated($contact["url"], true);
 			$updated = datetime_convert();
 			if ($last_updated) {
 				logger('Contact '.$contact['id'].' had last update on '.$last_updated, LOGGER_DEBUG);


### PR DESCRIPTION
We use "OnePoll" to check if an account is alive. It doesn't make sense to use cached values here.