### PR TITLE
Fix license info in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
 		"ostatus",
 		"diaspora"
 	],
-	"licence": "GNU-Affero",
+	"license": "AGPL-3.0+",
 	"support": {
 		"issues": "https://github.com/friendica/friendica/issues"
 	},


### PR DESCRIPTION
This PR fixes a typo in the `license` key and uses the correct SPDX code for the AGPL license.