### PR TITLE
Add support for profile_*_color in API

### DIFF
--- a/include/api.php
+++ b/include/api.php
@@ -782,11 +782,7 @@ function api_get_user(App $a, $contact_id = null)
 
 	// If this is a local user and it uses Frio, we can get its color preferences.
 	if ($ret['self']) {
-		$r = dba::p(
-			"select theme from user where uid = ? limit 1",
-			$ret['uid']
-		);
-		$theme_info = $r->fetch();
+		$theme_info = dba::select('user', ['theme'], ['uid' => $ret['uid']], ['limit' => 1]);
 		if ($theme_info['theme'] === 'frio') {
 			$schema = PConfig::get($ret['uid'], 'frio', 'schema');
 			if (($schema) && ($schema != '---')) {

--- a/include/api.php
+++ b/include/api.php
@@ -785,10 +785,10 @@ function api_get_user(App $a, $contact_id = null)
 		$theme_info = dba::select('user', ['theme'], ['uid' => $ret['uid']], ['limit' => 1]);
 		if ($theme_info['theme'] === 'frio') {
 			$schema = PConfig::get($ret['uid'], 'frio', 'schema');
-			if (($schema) && ($schema != '---')) {
+			if ($schema && ($schema != '---')) {
 				if (file_exists('view/theme/frio/schema/'.$schema.'.php')) {
 					$schemefile = 'view/theme/frio/schema/'.$schema.'.php';
-					require_once($schemefile);
+					require_once $schemefile;
 				}
 			} else {
 				$nav_bg = PConfig::get($ret['uid'], 'frio', 'nav_bg');

--- a/include/api.php
+++ b/include/api.php
@@ -10,6 +10,7 @@ use Friendica\Content\Feature;
 use Friendica\Core\System;
 use Friendica\Core\Config;
 use Friendica\Core\NotificationsManager;
+use Friendica\Core\PConfig;
 use Friendica\Core\Worker;
 use Friendica\Database\DBM;
 use Friendica\Model\Contact;
@@ -778,6 +779,41 @@ function api_get_user(App $a, $contact_id = null)
 		'self' => $uinfo[0]['self'],
 		'network' => $uinfo[0]['network'],
 	);
+
+	// If this is a local user and it uses Frio, we can get its color preferences.
+	if ($ret['self']) {
+		$r = dba::p(
+			"select theme from user where uid = ? limit 1",
+			$ret['uid']
+		);
+		$theme_info = $r->fetch();
+		if ($theme_info['theme'] === 'frio') {
+			$schema = PConfig::get($ret['uid'], 'frio', 'schema');
+			if (($schema) && ($schema != '---')) {
+				if (file_exists('view/theme/frio/schema/'.$schema.'.php')) {
+					$schemefile = 'view/theme/frio/schema/'.$schema.'.php';
+					require_once($schemefile);
+				}
+			} else {
+				$nav_bg = PConfig::get($ret['uid'], 'frio', 'nav_bg');
+				$link_color = PConfig::get($ret['uid'], 'frio', 'link_color');
+				$bgcolor = PConfig::get($ret['uid'], 'frio', 'background_color');
+			}
+			if (!$nav_bg) {
+				$nav_bg = "#708fa0";
+			}
+			if (!$link_color) {
+				$link_color = "#6fdbe8";
+			}
+			if (!$bgcolor) {
+				$bgcolor = "#ededed";
+			}
+
+			$ret['profile_sidebar_fill_color'] = str_replace('#', '', $nav_bg);
+			$ret['profile_link_color'] = str_replace('#', '', $link_color);
+			$ret['profile_background_color'] = str_replace('#', '', $bgcolor);
+		}
+	}
 
 	return $ret;
 }


### PR DESCRIPTION
This patch adds additional values to the user object returned by the API, based on the theme options (if Frio is used).
It is only a subset of the values [from Twitter](https://developer.twitter.com/en/docs/tweets/data-dictionary/overview/user-object) since they don't all apply to Friendica.

(Twidere mainly uses `profile_link_color` to tweak its interface so you can easily distinguish your accounts if you have several accounts in the app.)