### PR TITLE
Implement friendships/incoming and users/lookup APIs

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -504,6 +504,15 @@ Friendica doesn't allow showing followers of other users.
 
 Friendica doesn't allow showing friends of other users.
 
+---
+### users/lookup (*; AUTH)
+
+#### Parameters
+* user_id: list of ids to lookup
+
+#### Unsupported parameters
+* screen_name
+* include_entities
 
 ---
 ### account/update_profile_image (POST; AUTH)
@@ -939,6 +948,12 @@ General description of profile data in API returns:
 * description ... homepage: different data fields from 'profile' table in database
 * users: array with the users allowed to view this profile (empty if is_default=true)
 
+---
+### friendships/incoming (*; AUTH)
+
+#### Unsupported parameters
+* cursor
+* stringify_ids
 
 ---
 ## Not Implemented API calls
@@ -963,7 +978,6 @@ The following API calls from the Twitter API are not implemented in either Frien
 * direct_messages/show
 * search/tweets
 * friendships/no_retweets/ids
-* friendships/incoming
 * friendships/outgoing
 * friendships/update
 * friends/list
@@ -973,7 +987,6 @@ The following API calls from the Twitter API are not implemented in either Frien
 * account/update_profile
 * account/update_profile_background_image
 * blocks/ids
-* users/lookup
 * users/show
 * users/search
 * account/remove_profile_banner

--- a/include/api.php
+++ b/include/api.php
@@ -1494,14 +1494,22 @@ api_register_func('api/users/search', 'api_users_search');
  *
  * @return array|string
  * @throws UnauthorizedException
+ * @throws NotFoundException
  */
 function api_users_lookup($type)
 {
 	$users = array();
-	foreach (explode(',', $_REQUEST['user_id']) as $id) {
-		if (!empty($id)) {
-			$users[] = api_get_user(get_app(), $id);
+
+	if (x($_REQUEST['user_id'])) {
+		foreach (explode(',', $_REQUEST['user_id']) as $id) {
+			if (!empty($id)) {
+				$users[] = api_get_user(get_app(), $id);
+			}
 		}
+	}
+
+	if (empty($users)) {
+		throw new NotFoundException;
 	}
 
 	return api_format_data("users", $type, array('users' => $users));

--- a/include/api.php
+++ b/include/api.php
@@ -1486,6 +1486,31 @@ function api_users_search($type)
 api_register_func('api/users/search', 'api_users_search');
 
 /**
+ * Return user objects
+ *
+ * @see https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-users-lookup
+ *
+ * @param string $type Return format: json or xml
+ *
+ * @return array|string
+ * @throws UnauthorizedException
+ */
+function api_users_lookup($type)
+{
+	$users = array();
+	foreach (explode(',', $_REQUEST['user_id']) as $id) {
+		if (!empty($id)) {
+			$users[] = api_get_user(get_app(), $id);
+		}
+	}
+
+	return api_format_data("users", $type, array('users' => $users));
+}
+
+/// @TODO move to top of file or somewhere better
+api_register_func('api/users/lookup', 'api_users_lookup', true);
+
+/**
  * Returns statuses that match a specified query.
  *
  * @see https://developer.twitter.com/en/docs/tweets/search/api-reference/get-search-tweets
@@ -3115,9 +3140,11 @@ function api_statuses_f($qtype)
 	}
 
 	if ($qtype == 'blocks') {
-		$sql_blocked = 'AND `blocked`';
+		$sql_filter = 'AND `blocked` AND NOT `pending`';
+	} elseif ($qtype == 'incoming') {
+		$sql_filter = 'AND `pending`';
 	} else {
-		$sql_blocked = 'AND NOT `blocked`';
+		$sql_filter = 'AND (NOT `blocked` OR `pending`)';
 	}
 
 	$r = q(
@@ -3125,8 +3152,7 @@ function api_statuses_f($qtype)
 		FROM `contact`
 		WHERE `uid` = %d
 		AND NOT `self`
-		$sql_blocked
-		AND NOT `pending`
+		$sql_filter
 		$sql_extra
 		ORDER BY `nick`
 		LIMIT %d, %d",
@@ -3210,6 +3236,34 @@ function api_blocks_list($type)
 
 /// @TODO move to top of file or somewhere better
 api_register_func('api/blocks/list', 'api_blocks_list', true);
+
+/**
+ * Returns the list of pending users IDs
+ *
+ * @see https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-friendships-incoming
+ *
+ * @param string $type Either "json" or "xml"
+ *
+ * @return boolean|string|array
+ * @throws UnauthorizedException
+ */
+function api_friendships_incoming($type)
+{
+	$data =  api_statuses_f('incoming');
+	if ($data === false) {
+		return false;
+	}
+
+	$ids = array();
+	foreach ($data['user'] as $user) {
+		$ids[] = $user['id'];
+	}
+
+	return api_format_data("ids", $type, array('id' => $ids));
+}
+
+/// @TODO move to top of file or somewhere better
+api_register_func('api/friendships/incoming', 'api_friendships_incoming', true);
 
 function api_statusnet_config($type)
 {


### PR DESCRIPTION
This patch implements the `friendships/incoming` API. Since it only returns user IDs, I also had to implement `users/lookup` in order to get full user objects from the IDs.