### PR TITLE
Basic support for account/update_profile API (fixes #4094)

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -692,6 +692,23 @@ On error:
 
 ---
 
+### account/update_profile (POST; AUTH)
+
+#### Parameters
+
+* name (optional): full name of the user
+* description (optional): a description of the user
+
+#### Unsupported parameters
+
+* url
+* location
+* profile_link_color
+* include_entities
+* skip_status
+
+---
+
 ### friendships/incoming (*; AUTH)
 
 #### Unsupported parameters
@@ -1205,7 +1222,6 @@ The following API calls from the Twitter API are not implemented in either Frien
 * friendships/lookup
 * account/settings
 * account/update_delivery_device
-* account/update_profile
 * blocks/ids
 * users/show
 * users/search

--- a/include/api.php
+++ b/include/api.php
@@ -4481,17 +4481,17 @@ api_register_func('api/account/update_profile_image', 'api_account_update_profil
  */
 function api_account_update_profile($type)
 {
-	$local_user = local_user();
+	$local_user = api_user();
 	$api_user = api_get_user(get_app());
 
-	if (x($_POST['name'])) {
+	if (!empty($_POST['name'])) {
 		dba::update('profile', ['name' => $_POST['name']], ['uid' => $local_user]);
 		dba::update('user', ['username' => $_POST['name']], ['uid' => $local_user]);
 		dba::update('contact', ['name' => $_POST['name']], ['uid' => $local_user, 'self' => 1]);
 		dba::update('contact', ['name' => $_POST['name']], ['id' => $api_user['id']]);
 	}
 
-	if (x($_POST['description'])) {
+	if (isset($_POST['description'])) {
 		dba::update('profile', ['about' => $_POST['description']], ['uid' => $local_user]);
 		dba::update('contact', ['about' => $_POST['description']], ['uid' => $local_user, 'self' => 1]);
 		dba::update('contact', ['about' => $_POST['description']], ['id' => $api_user['id']]);

--- a/include/api.php
+++ b/include/api.php
@@ -4498,6 +4498,11 @@ function api_account_update_profile($type)
 	}
 
 	Worker::add(PRIORITY_LOW, 'ProfileUpdate', api_user());
+	// Update global directory in background
+	$url = $_SESSION['my_url'];
+	if ($url && strlen(Config::get('system', 'directory'))) {
+		Worker::add(PRIORITY_LOW, "Directory", $url);
+	}
 
 	return api_account_verify_credentials($type);
 }

--- a/include/api.php
+++ b/include/api.php
@@ -4473,6 +4473,39 @@ api_register_func('api/friendica/photo', 'api_fr_photo_detail', true);
 api_register_func('api/account/update_profile_image', 'api_account_update_profile_image', true, API_METHOD_POST);
 
 /**
+ * Update user profile
+ *
+ * @param string $type Known types are 'atom', 'rss', 'xml' and 'json'
+ *
+ * @return array|string
+ */
+function api_account_update_profile($type)
+{
+	$local_user = local_user();
+	$api_user = api_get_user(get_app());
+
+	if (x($_POST['name'])) {
+		dba::update('profile', ['name' => $_POST['name']], ['uid' => $local_user]);
+		dba::update('user', ['username' => $_POST['name']], ['uid' => $local_user]);
+		dba::update('contact', ['name' => $_POST['name']], ['uid' => $local_user, 'self' => 1]);
+		dba::update('contact', ['name' => $_POST['name']], ['id' => $api_user['id']]);
+	}
+
+	if (x($_POST['description'])) {
+		dba::update('profile', ['about' => $_POST['description']], ['uid' => $local_user]);
+		dba::update('contact', ['about' => $_POST['description']], ['uid' => $local_user, 'self' => 1]);
+		dba::update('contact', ['about' => $_POST['description']], ['id' => $api_user['id']]);
+	}
+
+	Worker::add(PRIORITY_LOW, 'ProfileUpdate', api_user());
+
+	return api_account_verify_credentials($type);
+}
+
+/// @TODO move to top of file or somewhere better
+api_register_func('api/account/update_profile', 'api_account_update_profile', true, API_METHOD_POST);
+
+/**
  *
  * @param string $acl_string
  */


### PR DESCRIPTION
Only the `name` and `description` parameters are implemented.

I got a bit confused because this stuff is duplicated in different places in the database so please tell me if I missed anything.