### PR TITLE
Cleaner way to get user URL in api_account_update_profile

### DIFF
--- a/include/api.php
+++ b/include/api.php
@@ -4497,11 +4497,10 @@ function api_account_update_profile($type)
 		dba::update('contact', ['about' => $_POST['description']], ['id' => $api_user['id']]);
 	}
 
-	Worker::add(PRIORITY_LOW, 'ProfileUpdate', api_user());
+	Worker::add(PRIORITY_LOW, 'ProfileUpdate', $local_user);
 	// Update global directory in background
-	$url = $_SESSION['my_url'];
-	if ($url && strlen(Config::get('system', 'directory'))) {
-		Worker::add(PRIORITY_LOW, "Directory", $url);
+	if ($api_user['url'] && strlen(Config::get('system', 'directory'))) {
+		Worker::add(PRIORITY_LOW, "Directory", $api_user['url']);
 	}
 
 	return api_account_verify_credentials($type);


### PR DESCRIPTION
Here are some changes to #4130 suggested by @annando.