### PR TITLE
Add posts only feed

### DIFF
--- a/mod/dfrn_poll.php
+++ b/mod/dfrn_poll.php
@@ -29,7 +29,7 @@ function dfrn_poll_init(App $a)
 	if (($a->argc > 1) && ($dfrn_id == '') && !strstr($_SERVER["HTTP_USER_AGENT"], 'Friendica')) {
 		$nickname = $a->argv[1];
 		header("Content-type: application/atom+xml");
-		echo OStatus::feed($a, $nickname, $last_update, 10);
+		echo OStatus::feed($nickname, $last_update, 10);
 		killme();
 	}
 

--- a/mod/dfrn_poll.php
+++ b/mod/dfrn_poll.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file mod/dfrn_poll.php
  */
@@ -12,16 +13,17 @@ use Friendica\Protocol\OStatus;
 require_once 'include/items.php';
 require_once 'include/auth.php';
 
-function dfrn_poll_init(App $a) {
-	$dfrn_id         = ((x($_GET,'dfrn_id'))         ? $_GET['dfrn_id']              : '');
-	$type            = ((x($_GET,'type'))            ? $_GET['type']                 : 'data');
-	$last_update     = ((x($_GET,'last_update'))     ? $_GET['last_update']          : '');
-	$destination_url = ((x($_GET,'destination_url')) ? $_GET['destination_url']      : '');
-	$challenge       = ((x($_GET,'challenge'))       ? $_GET['challenge']            : '');
-	$sec             = ((x($_GET,'sec'))             ? $_GET['sec']                  : '');
-	$dfrn_version    = ((x($_GET,'dfrn_version'))    ? (float) $_GET['dfrn_version'] : 2.0);
-	$perm            = ((x($_GET,'perm'))            ? $_GET['perm']                 : 'r');
-	$quiet			 = ((x($_GET,'quiet'))			 ? true							 : false);
+function dfrn_poll_init(App $a)
+{
+	$dfrn_id         = x($_GET,'dfrn_id')         ? $_GET['dfrn_id']              : '';
+	$type            = x($_GET,'type')            ? $_GET['type']                 : 'data';
+	$last_update     = x($_GET,'last_update')     ? $_GET['last_update']          : '';
+	$destination_url = x($_GET,'destination_url') ? $_GET['destination_url']      : '';
+	$challenge       = x($_GET,'challenge')       ? $_GET['challenge']            : '';
+	$sec             = x($_GET,'sec')             ? $_GET['sec']                  : '';
+	$dfrn_version    = x($_GET,'dfrn_version')    ? (float) $_GET['dfrn_version'] : 2.0;
+	$perm            = x($_GET,'perm')            ? $_GET['perm']                 : 'r';
+	$quiet           = x($_GET,'quiet')           ? true                          : false;
 
 	// Possibly it is an OStatus compatible server that requests a user feed
 	if (($a->argc > 1) && ($dfrn_id == '') && !strstr($_SERVER["HTTP_USER_AGENT"], 'Friendica')) {
@@ -31,28 +33,28 @@ function dfrn_poll_init(App $a) {
 		killme();
 	}
 
-	$direction = (-1);
+	$direction = -1;
 
-
-	if(strpos($dfrn_id,':') == 1) {
-		$direction = intval(substr($dfrn_id,0,1));
-		$dfrn_id   = substr($dfrn_id,2);
+	if (strpos($dfrn_id, ':') == 1) {
+		$direction = intval(substr($dfrn_id, 0, 1));
+		$dfrn_id = substr($dfrn_id, 2);
 	}
 
 	$hidewall = false;
 
-	if(($dfrn_id === '') && (! x($_POST,'dfrn_id'))) {
-		if((Config::get('system','block_public')) && (! local_user()) && (! remote_user())) {
+	if (($dfrn_id === '') && (!x($_POST, 'dfrn_id'))) {
+		if (Config::get('system', 'block_public') && !local_user() && !remote_user()) {
 			http_status_exit(403);
 		}
 
 		$user = '';
-		if($a->argc > 1) {
+		if ($a->argc > 1) {
 			$r = q("SELECT `hidewall`,`nickname` FROM `user` WHERE `user`.`nickname` = '%s' LIMIT 1",
 				dbesc($a->argv[1])
 			);
-			if (!$r)
+			if (!$r) {
 				http_status_exit(404);
+			}
 
 			$hidewall = ($r[0]['hidewall'] && !local_user());
 
@@ -61,16 +63,15 @@ function dfrn_poll_init(App $a) {
 
 		logger('dfrn_poll: public feed request from ' . $_SERVER['REMOTE_ADDR'] . ' for ' . $user);
 		header("Content-type: application/atom+xml");
-		echo DFRN::feed('', $user,$last_update, 0, $hidewall);
+		echo DFRN::feed('', $user, $last_update, 0, $hidewall);
 		killme();
 	}
 
-	if(($type === 'profile') && (! strlen($sec))) {
-
+	if (($type === 'profile') && (!strlen($sec))) {
 		$sql_extra = '';
-		switch($direction) {
-			case (-1):
-				$sql_extra = sprintf(" AND ( `dfrn-id` = '%s' OR `issued-id` = '%s' ) ", dbesc($dfrn_id),dbesc($dfrn_id));
+		switch ($direction) {
+			case -1:
+				$sql_extra = sprintf(" AND ( `dfrn-id` = '%s' OR `issued-id` = '%s' ) ", dbesc($dfrn_id), dbesc($dfrn_id));
 				$my_id = $dfrn_id;
 				break;
 			case 0:
@@ -94,28 +95,29 @@ function dfrn_poll_init(App $a) {
 		);
 
 		if (DBM::is_result($r)) {
-
 			$s = fetch_url($r[0]['poll'] . '?dfrn_id=' . $my_id . '&type=profile-check');
 
 			logger("dfrn_poll: old profile returns " . $s, LOGGER_DATA);
 
-			if(strlen($s)) {
-
+			if (strlen($s)) {
 				$xml = parse_xml_string($s);
 
-				if((int) $xml->status == 1) {
+				if ((int) $xml->status === 1) {
 					$_SESSION['authenticated'] = 1;
-					if(! x($_SESSION,'remote'))
+					if (!x($_SESSION, 'remote')) {
 						$_SESSION['remote'] = array();
+					}
 
-					$_SESSION['remote'][] = array('cid' => $r[0]['id'],'uid' => $r[0]['uid'],'url' => $r[0]['url']);
+					$_SESSION['remote'][] = array('cid' => $r[0]['id'], 'uid' => $r[0]['uid'], 'url' => $r[0]['url']);
 
 					$_SESSION['visitor_id'] = $r[0]['id'];
 					$_SESSION['visitor_home'] = $r[0]['url'];
 					$_SESSION['visitor_handle'] = $r[0]['addr'];
 					$_SESSION['visitor_visiting'] = $r[0]['uid'];
-					if(!$quiet)
-						info( sprintf(t('%1$s welcomes %2$s'), $r[0]['username'] , $r[0]['name']) . EOL);
+					if (!$quiet) {
+						info(sprintf(t('%1$s welcomes %2$s'), $r[0]['username'], $r[0]['name']) . EOL);
+					}
+
 					// Visitors get 1 day session.
 					$session_id = session_id();
 					$expire = time() + 86400;
@@ -129,53 +131,53 @@ function dfrn_poll_init(App $a) {
 			goaway((strlen($destination_url)) ? $destination_url : System::baseUrl() . '/profile/' . $profile);
 		}
 		goaway(System::baseUrl());
-
 	}
 
-	if($type === 'profile-check' && $dfrn_version < 2.2 ) {
-
-		if((strlen($challenge)) && (strlen($sec))) {
-
+	if ($type === 'profile-check' && $dfrn_version < 2.2) {
+		if ((strlen($challenge)) && (strlen($sec))) {
 			q("DELETE FROM `profile_check` WHERE `expire` < " . intval(time()));
 			$r = q("SELECT * FROM `profile_check` WHERE `sec` = '%s' ORDER BY `expire` DESC LIMIT 1",
 				dbesc($sec)
 			);
-			if (! DBM::is_result($r)) {
+			if (!DBM::is_result($r)) {
 				xml_status(3, 'No ticket');
 				// NOTREACHED
 			}
+
 			$orig_id = $r[0]['dfrn_id'];
-			if(strpos($orig_id, ':'))
-				$orig_id = substr($orig_id,2);
+			if (strpos($orig_id, ':')) {
+				$orig_id = substr($orig_id, 2);
+			}
 
 			$c = q("SELECT * FROM `contact` WHERE `id` = %d LIMIT 1",
 				intval($r[0]['cid'])
 			);
-			if (! DBM::is_result($c)) {
+			if (!DBM::is_result($c)) {
 				xml_status(3, 'No profile');
 			}
+
 			$contact = $c[0];
 
 			$sent_dfrn_id = hex2bin($dfrn_id);
-			$challenge    = hex2bin($challenge);
+			$challenge = hex2bin($challenge);
 
 			$final_dfrn_id = '';
 
-			if(($contact['duplex']) && strlen($contact['prvkey'])) {
-				openssl_private_decrypt($sent_dfrn_id,$final_dfrn_id,$contact['prvkey']);
-				openssl_private_decrypt($challenge,$decoded_challenge,$contact['prvkey']);
-			}
-			else {
-				openssl_public_decrypt($sent_dfrn_id,$final_dfrn_id,$contact['pubkey']);
-				openssl_public_decrypt($challenge,$decoded_challenge,$contact['pubkey']);
+			if (($contact['duplex']) && strlen($contact['prvkey'])) {
+				openssl_private_decrypt($sent_dfrn_id, $final_dfrn_id, $contact['prvkey']);
+				openssl_private_decrypt($challenge, $decoded_challenge, $contact['prvkey']);
+			} else {
+				openssl_public_decrypt($sent_dfrn_id, $final_dfrn_id, $contact['pubkey']);
+				openssl_public_decrypt($challenge, $decoded_challenge, $contact['pubkey']);
 			}
 
 			$final_dfrn_id = substr($final_dfrn_id, 0, strpos($final_dfrn_id, '.'));
 
-			if(strpos($final_dfrn_id,':') == 1)
-				$final_dfrn_id = substr($final_dfrn_id,2);
+			if (strpos($final_dfrn_id, ':') == 1) {
+				$final_dfrn_id = substr($final_dfrn_id, 2);
+			}
 
-			if($final_dfrn_id != $orig_id) {
+			if ($final_dfrn_id != $orig_id) {
 				logger('profile_check: ' . $final_dfrn_id . ' != ' . $orig_id, LOGGER_DEBUG);
 				// did not decode properly - cannot trust this site
 				xml_status(3, 'Bad decryption');
@@ -185,11 +187,9 @@ function dfrn_poll_init(App $a) {
 			echo "<?xml version=\"1.0\" encoding=\"UTF-8\"?><dfrn_poll><status>0</status><challenge>$decoded_challenge</challenge><sec>$sec</sec></dfrn_poll>";
 			killme();
 			// NOTREACHED
-		}
-		else {
-				// old protocol
-
-			switch($direction) {
+		} else {
+			// old protocol
+			switch ($direction) {
 				case 1:
 					$dfrn_id = '0:' . $dfrn_id;
 					break;
@@ -199,7 +199,6 @@ function dfrn_poll_init(App $a) {
 				default:
 					break;
 			}
-
 
 			q("DELETE FROM `profile_check` WHERE `expire` < " . intval(time()));
 			$r = q("SELECT * FROM `profile_check` WHERE `dfrn_id` = '%s' ORDER BY `expire` DESC",
@@ -212,67 +211,65 @@ function dfrn_poll_init(App $a) {
 			return; // NOTREACHED
 		}
 	}
-
 }
 
+function dfrn_poll_post(App $a)
+{
+	$dfrn_id      = x($_POST,'dfrn_id')      ? $_POST['dfrn_id']              : '';
+	$challenge    = x($_POST,'challenge')    ? $_POST['challenge']            : '';
+	$url          = x($_POST,'url')          ? $_POST['url']                  : '';
+	$sec          = x($_POST,'sec')          ? $_POST['sec']                  : '';
+	$ptype        = x($_POST,'type')         ? $_POST['type']                 : '';
+	$dfrn_version = x($_POST,'dfrn_version') ? (float) $_POST['dfrn_version'] : 2.0;
+	$perm         = x($_POST,'perm')         ? $_POST['perm']                 : 'r';
 
-
-function dfrn_poll_post(App $a) {
-
-	$dfrn_id      = ((x($_POST,'dfrn_id'))      ? $_POST['dfrn_id']              : '');
-	$challenge    = ((x($_POST,'challenge'))    ? $_POST['challenge']            : '');
-	$url          = ((x($_POST,'url'))          ? $_POST['url']                  : '');
-	$sec          = ((x($_POST,'sec'))          ? $_POST['sec']                  : '');
-	$ptype        = ((x($_POST,'type'))         ? $_POST['type']                 : '');
-	$dfrn_version = ((x($_POST,'dfrn_version')) ? (float) $_POST['dfrn_version'] : 2.0);
-	$perm         = ((x($_POST,'perm'))         ? $_POST['perm']                 : 'r');
-
-	if($ptype === 'profile-check') {
-
-		if((strlen($challenge)) && (strlen($sec))) {
-
+	if ($ptype === 'profile-check') {
+		if (strlen($challenge) && strlen($sec)) {
 			logger('dfrn_poll: POST: profile-check');
 
 			q("DELETE FROM `profile_check` WHERE `expire` < " . intval(time()));
 			$r = q("SELECT * FROM `profile_check` WHERE `sec` = '%s' ORDER BY `expire` DESC LIMIT 1",
 				dbesc($sec)
 			);
-			if (! DBM::is_result($r)) {
+			if (!DBM::is_result($r)) {
 				xml_status(3, 'No ticket');
 				// NOTREACHED
 			}
+
 			$orig_id = $r[0]['dfrn_id'];
-			if(strpos($orig_id, ':'))
-				$orig_id = substr($orig_id,2);
+			if (strpos($orig_id, ':')) {
+				$orig_id = substr($orig_id, 2);
+			}
 
 			$c = q("SELECT * FROM `contact` WHERE `id` = %d LIMIT 1",
 				intval($r[0]['cid'])
 			);
-			if (! DBM::is_result($c)) {
+			if (!DBM::is_result($c)) {
 				xml_status(3, 'No profile');
 			}
+
 			$contact = $c[0];
 
 			$sent_dfrn_id = hex2bin($dfrn_id);
-			$challenge    = hex2bin($challenge);
+			$challenge = hex2bin($challenge);
 
 			$final_dfrn_id = '';
 
-			if(($contact['duplex']) && strlen($contact['prvkey'])) {
-				openssl_private_decrypt($sent_dfrn_id,$final_dfrn_id,$contact['prvkey']);
-				openssl_private_decrypt($challenge,$decoded_challenge,$contact['prvkey']);
-			}
-			else {
-				openssl_public_decrypt($sent_dfrn_id,$final_dfrn_id,$contact['pubkey']);
-				openssl_public_decrypt($challenge,$decoded_challenge,$contact['pubkey']);
+			if ($contact['duplex'] && strlen($contact['prvkey'])) {
+				openssl_private_decrypt($sent_dfrn_id, $final_dfrn_id, $contact['prvkey']);
+				openssl_private_decrypt($challenge, $decoded_challenge, $contact['prvkey']);
+			} else {
+				openssl_public_decrypt($sent_dfrn_id, $final_dfrn_id, $contact['pubkey']);
+				openssl_public_decrypt($challenge, $decoded_challenge, $contact['pubkey']);
 			}
 
 			$final_dfrn_id = substr($final_dfrn_id, 0, strpos($final_dfrn_id, '.'));
 
-			if(strpos($final_dfrn_id,':') == 1)
-				$final_dfrn_id = substr($final_dfrn_id,2);
+			if (strpos($final_dfrn_id, ':') == 1) {
+				$final_dfrn_id = substr($final_dfrn_id, 2);
+			}
 
-			if($final_dfrn_id != $orig_id) {
+			if ($final_dfrn_id != $orig_id) {
 				logger('profile_check: ' . $final_dfrn_id . ' != ' . $orig_id, LOGGER_DEBUG);
 				// did not decode properly - cannot trust this site
 				xml_status(3, 'Bad decryption');
@@ -283,22 +280,20 @@ function dfrn_poll_post(App $a) {
 			killme();
 			// NOTREACHED
 		}
-
 	}
 
-	$direction    = (-1);
-	if(strpos($dfrn_id,':') == 1) {
-		$direction = intval(substr($dfrn_id,0,1));
-		$dfrn_id   = substr($dfrn_id,2);
+	$direction = -1;
+	if (strpos($dfrn_id, ':') == 1) {
+		$direction = intval(substr($dfrn_id, 0, 1));
+		$dfrn_id = substr($dfrn_id, 2);
 	}
-
 
 	$r = q("SELECT * FROM `challenge` WHERE `dfrn-id` = '%s' AND `challenge` = '%s' LIMIT 1",
 		dbesc($dfrn_id),
 		dbesc($challenge)
 	);
 
-	if (! DBM::is_result($r)) {
+	if (!DBM::is_result($r)) {
 		killme();
 	}
 
@@ -312,8 +307,8 @@ function dfrn_poll_post(App $a) {
 
 
 	$sql_extra = '';
-	switch($direction) {
-		case (-1):
+	switch ($direction) {
+		case -1:
 			$sql_extra = sprintf(" AND `issued-id` = '%s' ", dbesc($dfrn_id));
 			$my_id = $dfrn_id;
 			break;
@@ -330,11 +325,8 @@ function dfrn_poll_post(App $a) {
 			break; // NOTREACHED
 	}
 
-
 	$r = q("SELECT * FROM `contact` WHERE `blocked` = 0 AND `pending` = 0 $sql_extra LIMIT 1");
-
-
-	if (! DBM::is_result($r)) {
+	if (!DBM::is_result($r)) {
 		killme();
 	}
 
@@ -342,8 +334,7 @@ function dfrn_poll_post(App $a) {
 	$owner_uid = $r[0]['uid'];
 	$contact_id = $r[0]['id'];
 
-
-	if($type === 'reputation' && strlen($url)) {
+	if ($type === 'reputation' && strlen($url)) {
 		$r = q("SELECT * FROM `contact` WHERE `url` = '%s' AND `uid` = %d LIMIT 1",
 			dbesc($url),
 			intval($owner_uid)
@@ -355,7 +346,7 @@ function dfrn_poll_post(App $a) {
 			$reputation = $r[0]['rating'];
 			$text = $r[0]['reason'];
 
-			if($r[0]['id'] == $contact_id) {	// inquiring about own reputation not allowed
+			if ($r[0]['id'] == $contact_id) { // inquiring about own reputation not allowed
 				$reputation = 0;
 				$text = '';
 			}
@@ -370,18 +361,17 @@ function dfrn_poll_post(App $a) {
 		";
 		killme();
 		// NOTREACHED
-	}
-	else {
-
+	} else {
 		// Update the writable flag if it changed
-		logger('dfrn_poll: post request feed: ' . print_r($_POST,true),LOGGER_DATA);
-		if($dfrn_version >= 2.21) {
-			if($perm === 'rw')
+		logger('dfrn_poll: post request feed: ' . print_r($_POST, true), LOGGER_DATA);
+		if ($dfrn_version >= 2.21) {
+			if ($perm === 'rw') {
 				$writable = 1;
-			else
+			} else {
 				$writable = 0;
+			}
 
-			if($writable !=  $contact['writable']) {
+			if ($writable != $contact['writable']) {
 				q("UPDATE `contact` SET `writable` = %d WHERE `id` = %d",
 					intval($writable),
 					intval($contact_id)
@@ -393,29 +383,27 @@ function dfrn_poll_post(App $a) {
 		$o = DFRN::feed($dfrn_id, $a->argv[1], $last_update, $direction);
 		echo $o;
 		killme();
-
 	}
 }
 
-function dfrn_poll_content(App $a) {
+function dfrn_poll_content(App $a)
+{
+	$dfrn_id         = x($_GET,'dfrn_id')         ? $_GET['dfrn_id']              : '';
+	$type            = x($_GET,'type')            ? $_GET['type']                 : 'data';
+	$last_update     = x($_GET,'last_update')     ? $_GET['last_update']          : '';
+	$destination_url = x($_GET,'destination_url') ? $_GET['destination_url']      : '';
+	$sec             = x($_GET,'sec')             ? $_GET['sec']                  : '';
+	$dfrn_version    = x($_GET,'dfrn_version')    ? (float) $_GET['dfrn_version'] : 2.0;
+	$perm            = x($_GET,'perm')            ? $_GET['perm']                 : 'r';
+	$quiet           = x($_GET,'quiet')           ? true                          : false;
 
-	$dfrn_id         = ((x($_GET,'dfrn_id'))         ? $_GET['dfrn_id']              : '');
-	$type            = ((x($_GET,'type'))            ? $_GET['type']                 : 'data');
-	$last_update     = ((x($_GET,'last_update'))     ? $_GET['last_update']          : '');
-	$destination_url = ((x($_GET,'destination_url')) ? $_GET['destination_url']      : '');
-	$sec             = ((x($_GET,'sec'))             ? $_GET['sec']                  : '');
-	$dfrn_version    = ((x($_GET,'dfrn_version'))    ? (float) $_GET['dfrn_version'] : 2.0);
-	$perm            = ((x($_GET,'perm'))            ? $_GET['perm']                 : 'r');
-	$quiet		 = ((x($_GET,'quiet'))           ? true	                         : false);
-
-	$direction = (-1);
-	if(strpos($dfrn_id,':') == 1) {
-		$direction = intval(substr($dfrn_id,0,1));
-		$dfrn_id = substr($dfrn_id,2);
+	$direction = -1;
+	if (strpos($dfrn_id, ':') == 1) {
+		$direction = intval(substr($dfrn_id, 0, 1));
+		$dfrn_id = substr($dfrn_id, 2);
 	}
 
-
-	if($dfrn_id != '') {
+	if ($dfrn_id != '') {
 		// initial communication from external contact
 		$hash = random_string();
 
@@ -423,7 +411,7 @@ function dfrn_poll_content(App $a) {
 
 		$r = q("DELETE FROM `challenge` WHERE `expire` < " . intval(time()));
 
-		if($type !== 'profile') {
+		if ($type !== 'profile') {
 			$r = q("INSERT INTO `challenge` ( `challenge`, `dfrn-id`, `expire` , `type`, `last_update` )
 				VALUES( '%s', '%s', '%s', '%s', '%s' ) ",
 				dbesc($hash),
@@ -433,13 +421,16 @@ function dfrn_poll_content(App $a) {
 				dbesc($last_update)
 			);
 		}
+
 		$sql_extra = '';
-		switch($direction) {
-			case (-1):
-				if($type === 'profile')
-					$sql_extra = sprintf(" AND ( `dfrn-id` = '%s' OR `issued-id` = '%s' ) ", dbesc($dfrn_id),dbesc($dfrn_id));
-				else
+		switch ($direction) {
+			case -1:
+				if ($type === 'profile') {
+					$sql_extra = sprintf(" AND ( `dfrn-id` = '%s' OR `issued-id` = '%s' ) ", dbesc($dfrn_id), dbesc($dfrn_id));
+				} else {
 					$sql_extra = sprintf(" AND `issued-id` = '%s' ", dbesc($dfrn_id));
+				}
+
 				$my_id = $dfrn_id;
 				break;
 			case 0:
@@ -463,36 +454,30 @@ function dfrn_poll_content(App $a) {
 			AND `user`.`nickname` = '%s' $sql_extra LIMIT 1",
 			dbesc($nickname)
 		);
-
 		if (DBM::is_result($r)) {
-
 			$challenge = '';
 			$encrypted_id = '';
-			$id_str = $my_id . '.' . mt_rand(1000,9999);
+			$id_str = $my_id . '.' . mt_rand(1000, 9999);
 
-			if(($r[0]['duplex'] && strlen($r[0]['pubkey'])) || (! strlen($r[0]['prvkey']))) {
-				openssl_public_encrypt($hash,$challenge,$r[0]['pubkey']);
-				openssl_public_encrypt($id_str,$encrypted_id,$r[0]['pubkey']);
-			}
-			else {
-				openssl_private_encrypt($hash,$challenge,$r[0]['prvkey']);
-				openssl_private_encrypt($id_str,$encrypted_id,$r[0]['prvkey']);
+			if (($r[0]['duplex'] && strlen($r[0]['pubkey'])) || !strlen($r[0]['prvkey'])) {
+				openssl_public_encrypt($hash, $challenge, $r[0]['pubkey']);
+				openssl_public_encrypt($id_str, $encrypted_id, $r[0]['pubkey']);
+			} else {
+				openssl_private_encrypt($hash, $challenge, $r[0]['prvkey']);
+				openssl_private_encrypt($id_str, $encrypted_id, $r[0]['prvkey']);
 			}
 
 			$challenge = bin2hex($challenge);
 			$encrypted_id = bin2hex($encrypted_id);
-		}
-		else {
+		} else {
 			$status = 1;
 			$challenge = '';
 			$encrypted_id = '';
 		}
 
-		if(($type === 'profile') && (strlen($sec))) {
-
+		if (($type === 'profile') && (strlen($sec))) {
 			// URL reply
-
-			if($dfrn_version < 2.2) {
+			if ($dfrn_version < 2.2) {
 				$s = fetch_url($r[0]['poll']
 					. '?dfrn_id=' . $encrypted_id
 					. '&type=profile-check'
@@ -500,8 +485,7 @@ function dfrn_poll_content(App $a) {
 					. '&challenge=' . $challenge
 					. '&sec=' . $sec
 				);
-			}
-			else {
+			} else {
 				$s = post_url($r[0]['poll'], array(
 					'dfrn_id' => $encrypted_id,
 					'type' => 'profile-check',
@@ -513,7 +497,7 @@ function dfrn_poll_content(App $a) {
 
 			$profile = ((DBM::is_result($r) && $r[0]['nickname']) ? $r[0]['nickname'] : $nickname);
 
-			switch($destination_url) {
+			switch ($destination_url) {
 				case 'profile':
 					$dest = System::baseUrl() . '/profile/' . $profile . '?f=&tab=profile';
 					break;
@@ -532,26 +516,28 @@ function dfrn_poll_content(App $a) {
 
 			logger("dfrn_poll: sec profile: " . $s, LOGGER_DATA);
 
-			if(strlen($s) && strstr($s,'<?xml')) {
-
+			if (strlen($s) && strstr($s, '<?xml')) {
 				$xml = parse_xml_string($s);
 
-				logger('dfrn_poll: profile: parsed xml: ' . print_r($xml,true), LOGGER_DATA);
+				logger('dfrn_poll: profile: parsed xml: ' . print_r($xml, true), LOGGER_DATA);
 
 				logger('dfrn_poll: secure profile: challenge: ' . $xml->challenge . ' expecting ' . $hash);
 				logger('dfrn_poll: secure profile: sec: ' . $xml->sec . ' expecting ' . $sec);
 
-
-				if(((int) $xml->status == 0) && ($xml->challenge == $hash)  && ($xml->sec == $sec)) {
+				if (((int) $xml->status == 0) && ($xml->challenge == $hash) && ($xml->sec == $sec)) {
 					$_SESSION['authenticated'] = 1;
-					if(! x($_SESSION,'remote'))
+					if (!x($_SESSION, 'remote')) {
 						$_SESSION['remote'] = array();
-					$_SESSION['remote'][] = array('cid' => $r[0]['id'],'uid' => $r[0]['uid'],'url' => $r[0]['url']);
+					}
+
+					$_SESSION['remote'][] = array('cid' => $r[0]['id'], 'uid' => $r[0]['uid'], 'url' => $r[0]['url']);
 					$_SESSION['visitor_id'] = $r[0]['id'];
 					$_SESSION['visitor_home'] = $r[0]['url'];
 					$_SESSION['visitor_visiting'] = $r[0]['uid'];
-					if(!$quiet)
-						info( sprintf(t('%1$s welcomes %2$s'), $r[0]['username'] , $r[0]['name']) . EOL);
+					if (!$quiet) {
+						info(sprintf(t('%1$s welcomes %2$s'), $r[0]['username'], $r[0]['name']) . EOL);
+					}
+
 					// Visitors get 1 day session.
 					$session_id = session_id();
 					$expire = time() + 86400;
@@ -565,9 +551,7 @@ function dfrn_poll_content(App $a) {
 			}
 			goaway($dest);
 			// NOTREACHED
-
-		}
-		else {
+		} else {
 			// XML reply
 			header("Content-type: text/xml");
 			echo '<?xml version="1.0" encoding="UTF-8"?>' . "\r\n"
@@ -576,7 +560,7 @@ function dfrn_poll_content(App $a) {
 				. "\t" . '<dfrn_version>' . DFRN_PROTOCOL_VERSION . '</dfrn_version>' . "\r\n"
 				. "\t" . '<dfrn_id>' . $encrypted_id . '</dfrn_id>' . "\r\n"
 				. "\t" . '<challenge>' . $challenge . '</challenge>' . "\r\n"
-				. '</dfrn_poll>' . "\r\n" ;
+				. '</dfrn_poll>' . "\r\n";
 			killme();
 			// NOTREACHED
 		}

--- a/mod/hcard.php
+++ b/mod/hcard.php
@@ -45,9 +45,7 @@ function hcard_init(App $a) {
 	}
 
 	$a->page['htmlhead'] .= '<meta name="dfrn-global-visibility" content="' . (($a->profile['net-publish']) ? 'true' : 'false') . '" />' . "\r\n" ;
-	$a->page['htmlhead'] .= '<link rel="alternate" type="application/atom+xml" href="' . System::baseUrl() . '/feed/' . $which . '/" title="' . t('%s\'s posts', $a->profile['username']) . '"/>' . "\r\n";
-	$a->page['htmlhead'] .= '<link rel="alternate" type="application/atom+xml" href="' . System::baseUrl() . '/feed/' . $which . '/comments" title="' . t('%s\'s comments', $a->profile['username']) . '"/>' . "\r\n";
-	$a->page['htmlhead'] .= '<link rel="alternate" type="application/atom+xml" href="' . System::baseUrl() . '/feed/' . $which . '/activity" title="' . t('%s\'s timeline', $a->profile['username']) . '"/>' . "\r\n";
+	$a->page['htmlhead'] .= '<link rel="alternate" type="application/atom+xml" href="' . System::baseUrl() . '/dfrn_poll/' . $which .'" />' . "\r\n" ;
 	$uri = urlencode('acct:' . $a->profile['nickname'] . '@' . $a->get_hostname() . (($a->path) ? '/' . $a->path : ''));
 	$a->page['htmlhead'] .= '<link rel="lrdd" type="application/xrd+xml" href="' . System::baseUrl() . '/xrd/?uri=' . $uri . '" />' . "\r\n";
 	header('Link: <' . System::baseUrl() . '/xrd/?uri=' . $uri . '>; rel="lrdd"; type="application/xrd+xml"', false);

--- a/mod/hcard.php
+++ b/mod/hcard.php
@@ -45,7 +45,9 @@ function hcard_init(App $a) {
 	}
 
 	$a->page['htmlhead'] .= '<meta name="dfrn-global-visibility" content="' . (($a->profile['net-publish']) ? 'true' : 'false') . '" />' . "\r\n" ;
-	$a->page['htmlhead'] .= '<link rel="alternate" type="application/atom+xml" href="' . System::baseUrl() . '/dfrn_poll/' . $which .'" />' . "\r\n" ;
+	$a->page['htmlhead'] .= '<link rel="alternate" type="application/atom+xml" href="' . System::baseUrl() . '/feed/' . $which . '/" title="' . t('%s\'s posts', $a->profile['username']) . '"/>' . "\r\n";
+	$a->page['htmlhead'] .= '<link rel="alternate" type="application/atom+xml" href="' . System::baseUrl() . '/feed/' . $which . '/comments" title="' . t('%s\'s comments', $a->profile['username']) . '"/>' . "\r\n";
+	$a->page['htmlhead'] .= '<link rel="alternate" type="application/atom+xml" href="' . System::baseUrl() . '/feed/' . $which . '/activity" title="' . t('%s\'s timeline', $a->profile['username']) . '"/>' . "\r\n";
 	$uri = urlencode('acct:' . $a->profile['nickname'] . '@' . $a->get_hostname() . (($a->path) ? '/' . $a->path : ''));
 	$a->page['htmlhead'] .= '<link rel="lrdd" type="application/xrd+xml" href="' . System::baseUrl() . '/xrd/?uri=' . $uri . '" />' . "\r\n";
 	header('Link: <' . System::baseUrl() . '/xrd/?uri=' . $uri . '>; rel="lrdd"; type="application/xrd+xml"', false);

--- a/mod/profile.php
+++ b/mod/profile.php
@@ -64,7 +64,9 @@ function profile_init(App $a)
 	}
 
 	$a->page['htmlhead'] .= '<meta name="dfrn-global-visibility" content="' . ($a->profile['net-publish'] ? 'true' : 'false') . '" />' . "\r\n";
-	$a->page['htmlhead'] .= '<link rel="alternate" type="application/atom+xml" href="' . System::baseUrl() . '/dfrn_poll/' . $which . '" />' . "\r\n";
+	$a->page['htmlhead'] .= '<link rel="alternate" type="application/atom+xml" href="' . System::baseUrl() . '/feed/' . $which . '/" title="' . t('%s\'s posts', $a->profile['username']) . '"/>' . "\r\n";
+	$a->page['htmlhead'] .= '<link rel="alternate" type="application/atom+xml" href="' . System::baseUrl() . '/feed/' . $which . '/comments" title="' . t('%s\'s comments', $a->profile['username']) . '"/>' . "\r\n";
+	$a->page['htmlhead'] .= '<link rel="alternate" type="application/atom+xml" href="' . System::baseUrl() . '/feed/' . $which . '/activity" title="' . t('%s\'s timeline', $a->profile['username']) . '"/>' . "\r\n";
 	$uri = urlencode('acct:' . $a->profile['nickname'] . '@' . $a->get_hostname() . ($a->path ? '/' . $a->path : ''));
 	$a->page['htmlhead'] .= '<link rel="lrdd" type="application/xrd+xml" href="' . System::baseUrl() . '/xrd/?uri=' . $uri . '" />' . "\r\n";
 	header('Link: <' . System::baseUrl() . '/xrd/?uri=' . $uri . '>; rel="lrdd"; type="application/xrd+xml"', false);

--- a/mod/profile.php
+++ b/mod/profile.php
@@ -6,78 +6,79 @@ use Friendica\Core\PConfig;
 use Friendica\Core\System;
 use Friendica\Database\DBM;
 
-require_once('include/contact_widgets.php');
-require_once('include/redir.php');
+require_once 'include/contact_widgets.php';
+require_once 'include/redir.php';
 
-function profile_init(App $a) {
-
-	if(! x($a->page,'aside'))
+function profile_init(App $a)
+{
+	if (!x($a->page, 'aside')) {
 		$a->page['aside'] = '';
+	}
 
-	if($a->argc > 1)
+	if ($a->argc > 1) {
 		$which = htmlspecialchars($a->argv[1]);
-	else {
-		$r = q("select nickname from user where blocked = 0 and account_expired = 0 and account_removed = 0 and verified = 1 order by rand() limit 1");
+	} else {
+		$r = q("SELECT `nickname` FROM `user` WHERE `blocked` = 0 AND `account_expired` = 0 AND `account_removed` = 0 AND `verified` = 1 ORDER BY RAND() LIMIT 1");
 		if (DBM::is_result($r)) {
 			goaway(System::baseUrl() . '/profile/' . $r[0]['nickname']);
-		}
-		else {
+		} else {
 			logger('profile error: mod_profile ' . $a->query_string, LOGGER_DEBUG);
-			notice( t('Requested profile is not available.') . EOL );
+			notice(t('Requested profile is not available.') . EOL);
 			$a->error = 404;
 			return;
 		}
 	}
 
 	$profile = 0;
-	if((local_user()) && ($a->argc > 2) && ($a->argv[2] === 'view')) {
+	if (local_user() && $a->argc > 2 && $a->argv[2] === 'view') {
 		$which = $a->user['nickname'];
 		$profile = htmlspecialchars($a->argv[1]);
-	}
-	else {
+	} else {
 		auto_redir($a, $which);
 	}
 
-	profile_load($a,$which,$profile);
+	profile_load($a, $which, $profile);
 
-	$blocked = (((Config::get('system','block_public')) && (! local_user()) && (! remote_user())) ? true : false);
-	$userblock = (($a->profile['hidewall'] && (! local_user()) && (! remote_user())) ? true : false);
+	$blocked = Config::get('system', 'block_public') && !local_user() && !remote_user();
+	$userblock = $a->profile['hidewall'] && !local_user() && !remote_user();
 
-	if((x($a->profile,'page-flags')) && ($a->profile['page-flags'] == PAGE_COMMUNITY)) {
+	if (x($a->profile, 'page-flags') && $a->profile['page-flags'] == PAGE_COMMUNITY) {
 		$a->page['htmlhead'] .= '<meta name="friendica.community" content="true" />';
 	}
-	if (x($a->profile,'openidserver')) {
+
+	if (x($a->profile, 'openidserver')) {
 		$a->page['htmlhead'] .= '<link rel="openid.server" href="' . $a->profile['openidserver'] . '" />' . "\r\n";
 	}
-	if (x($a->profile,'openid')) {
-		$delegate = ((strstr($a->profile['openid'],'://')) ? $a->profile['openid'] : 'https://' . $a->profile['openid']);
+
+	if (x($a->profile, 'openid')) {
+		$delegate = ((strstr($a->profile['openid'], '://')) ? $a->profile['openid'] : 'https://' . $a->profile['openid']);
 		$a->page['htmlhead'] .= '<link rel="openid.delegate" href="' . $delegate . '" />' . "\r\n";
 	}
 	// site block
-	if ((! $blocked) && (! $userblock)) {
-		$keywords = ((x($a->profile,'pub_keywords')) ? $a->profile['pub_keywords'] : '');
-		$keywords = str_replace(array('#',',',' ',',,'),array('',' ',',',','),$keywords);
-		if(strlen($keywords))
-			$a->page['htmlhead'] .= '<meta name="keywords" content="' . $keywords . '" />' . "\r\n" ;
+	if (!$blocked && !$userblock) {
+		$keywords = x($a->profile, 'pub_keywords') ? $a->profile['pub_keywords'] : '';
+		$keywords = str_replace(array('#', ',', ' ', ',,'), array('', ' ', ',', ','), $keywords);
+		if (strlen($keywords)) {
+			$a->page['htmlhead'] .= '<meta name="keywords" content="' . $keywords . '" />' . "\r\n";
+		}
 	}
 
-	$a->page['htmlhead'] .= '<meta name="dfrn-global-visibility" content="' . (($a->profile['net-publish']) ? 'true' : 'false') . '" />' . "\r\n" ;
-	$a->page['htmlhead'] .= '<link rel="alternate" type="application/atom+xml" href="' . System::baseUrl() . '/dfrn_poll/' . $which .'" />' . "\r\n" ;
-	$uri = urlencode('acct:' . $a->profile['nickname'] . '@' . $a->get_hostname() . (($a->path) ? '/' . $a->path : ''));
+	$a->page['htmlhead'] .= '<meta name="dfrn-global-visibility" content="' . ($a->profile['net-publish'] ? 'true' : 'false') . '" />' . "\r\n";
+	$a->page['htmlhead'] .= '<link rel="alternate" type="application/atom+xml" href="' . System::baseUrl() . '/dfrn_poll/' . $which . '" />' . "\r\n";
+	$uri = urlencode('acct:' . $a->profile['nickname'] . '@' . $a->get_hostname() . ($a->path ? '/' . $a->path : ''));
 	$a->page['htmlhead'] .= '<link rel="lrdd" type="application/xrd+xml" href="' . System::baseUrl() . '/xrd/?uri=' . $uri . '" />' . "\r\n";
 	header('Link: <' . System::baseUrl() . '/xrd/?uri=' . $uri . '>; rel="lrdd"; type="application/xrd+xml"', false);
 
 	$dfrn_pages = array('request', 'confirm', 'notify', 'poll');
 	foreach ($dfrn_pages as $dfrn) {
-		$a->page['htmlhead'] .= "<link rel=\"dfrn-{$dfrn}\" href=\"".System::baseUrl()."/dfrn_{$dfrn}/{$which}\" />\r\n";
+		$a->page['htmlhead'] .= "<link rel=\"dfrn-{$dfrn}\" href=\"" . System::baseUrl() . "/dfrn_{$dfrn}/{$which}\" />\r\n";
 	}
-	$a->page['htmlhead'] .= "<link rel=\"dfrn-poco\" href=\"".System::baseUrl()."/poco/{$which}\" />\r\n";
 
+	$a->page['htmlhead'] .= "<link rel=\"dfrn-poco\" href=\"" . System::baseUrl() . "/poco/{$which}\" />\r\n";
 }
 
-
-function profile_content(App $a, $update = 0) {
-
+function profile_content(App $a, $update = 0)
+{
 	$category = $datequery = $datequery2 = '';
 
 	if ($a->argc > 2) {
@@ -94,21 +95,21 @@ function profile_content(App $a, $update = 0) {
 		}
 	}
 
-	if (! x($category)) {
-		$category = ((x($_GET,'category')) ? $_GET['category'] : '');
+	if (!x($category)) {
+		$category = x($_GET, 'category') ? $_GET['category'] : '';
 	}
 
-	$hashtags = (x($_GET, 'tag') ? $_GET['tag'] : '');
+	$hashtags = x($_GET, 'tag') ? $_GET['tag'] : '';
 
-	if (Config::get('system','block_public') && (! local_user()) && (! remote_user())) {
+	if (Config::get('system', 'block_public') && (!local_user()) && (!remote_user())) {
 		return login();
 	}
 
-	require_once("include/bbcode.php");
-	require_once('include/security.php');
-	require_once('include/conversation.php');
-	require_once('include/acl_selectors.php');
-	require_once('include/items.php');
+	require_once 'include/bbcode.php';
+	require_once 'include/security.php';
+	require_once 'include/conversation.php';
+	require_once 'include/acl_selectors.php';
+	require_once 'include/items.php';
 
 	$groups = array();
 
@@ -148,74 +149,72 @@ function profile_content(App $a, $update = 0) {
 		}
 	}
 
-	if (! $remote_contact) {
+	if (!$remote_contact) {
 		if (local_user()) {
 			$contact_id = $_SESSION['cid'];
 			$contact = $a->contact;
 		}
 	}
 
-	$is_owner = ((local_user()) && (local_user() == $a->profile['profile_uid']) ? true : false);
+	$is_owner = local_user() && local_user() == $a->profile['profile_uid'];
 	$last_updated_key = "profile:" . $a->profile['profile_uid'] . ":" . local_user() . ":" . remote_user();
 
-	if ($a->profile['hidewall'] && (! $is_owner) && (! $remote_contact)) {
-		notice( t('Access to this profile has been restricted.') . EOL);
+	if ($a->profile['hidewall'] && !$is_owner && !$remote_contact) {
+		notice(t('Access to this profile has been restricted.') . EOL);
 		return;
 	}
 
-	if (! $update) {
-		if (x($_GET,'tab')) {
+	if (!$update) {
+		if (x($_GET, 'tab')) {
 			$tab = notags(trim($_GET['tab']));
 		}
 
-		$o.=profile_tabs($a, $is_owner, $a->profile['nickname']);
+		$o .= profile_tabs($a, $is_owner, $a->profile['nickname']);
 
 		if ($tab === 'profile') {
 			$o .= advanced_profile($a);
-			call_hooks('profile_advanced',$o);
+			call_hooks('profile_advanced', $o);
 			return $o;
 		}
 
 		$o .= common_friends_visitor_widget($a->profile['profile_uid']);
 
-		if (x($_SESSION,'new_member') && $_SESSION['new_member'] && $is_owner) {
+		if (x($_SESSION, 'new_member') && $_SESSION['new_member'] && $is_owner) {
 			$o .= '<a href="newmember" id="newmember-tips" style="font-size: 1.2em;"><b>' . t('Tips for New Members') . '</b></a>' . EOL;
 		}
 
 		$commpage = (($a->profile['page-flags'] == PAGE_COMMUNITY) ? true : false);
 		$commvisitor = (($commpage && $remote_contact == true) ? true : false);
 
-		$a->page['aside'] .= posted_date_widget(System::baseUrl(true) . '/profile/' . $a->profile['nickname'],$a->profile['profile_uid'],true);
-		$a->page['aside'] .= categories_widget(System::baseUrl(true) . '/profile/' . $a->profile['nickname'],(x($category) ? xmlify($category) : ''));
+		$a->page['aside'] .= posted_date_widget(System::baseUrl(true) . '/profile/' . $a->profile['nickname'], $a->profile['profile_uid'], true);
+		$a->page['aside'] .= categories_widget(System::baseUrl(true) . '/profile/' . $a->profile['nickname'], (x($category) ? xmlify($category) : ''));
 		$a->page['aside'] .= tagcloud_wall_widget();
 
-		if (can_write_wall($a,$a->profile['profile_uid'])) {
-
+		if (can_write_wall($a, $a->profile['profile_uid'])) {
 			$x = array(
 				'is_owner' => $is_owner,
 				'allow_location' => ((($is_owner || $commvisitor) && $a->profile['allow_location']) ? true : false),
 				'default_location' => (($is_owner) ? $a->user['default-location'] : ''),
 				'nickname' => $a->profile['nickname'],
-				'lockstate' => (((is_array($a->user) && ((strlen($a->user['allow_cid'])) ||
-						(strlen($a->user['allow_gid'])) || (strlen($a->user['deny_cid'])) ||
-						(strlen($a->user['deny_gid']))))) ? 'lock' : 'unlock'),
-				'acl' => (($is_owner) ? populate_acl($a->user, true) : ''),
+				'lockstate' => is_array($a->user)
+					&& (strlen($a->user['allow_cid'])
+						|| strlen($a->user['allow_gid'])
+						|| strlen($a->user['deny_cid'])
+						|| strlen($a->user['deny_gid'])
+					) ? 'lock' : 'unlock',
+				'acl' => $is_owner ? populate_acl($a->user, true) : '',
 				'bang' => '',
-				'visitor' => (($is_owner || $commvisitor) ? 'block' : 'none'),
+				'visitor' => $is_owner || $commvisitor ? 'block' : 'none',
 				'profile_uid' => $a->profile['profile_uid'],
-				'acl_data' => ( $is_owner ? construct_acl_data($a, $a->user) : '' ), // For non-Javascript ACL selector
+				'acl_data' => $is_owner ? construct_acl_data($a, $a->user) : '', // For non-Javascript ACL selector
 			);
 
-			$o .= status_editor($a,$x);
+			$o .= status_editor($a, $x);
 		}
 	}
 
-
-	/**
-	 * Get permissions SQL - if $remote_contact is true, our remote user has been pre-verified and we already have fetched his/her groups
-	 */
-	$sql_extra = item_permissions_sql($a->profile['profile_uid'],$remote_contact,$groups);
-
+	// Get permissions SQL - if $remote_contact is true, our remote user has been pre-verified and we already have fetched his/her groups
+	$sql_extra = item_permissions_sql($a->profile['profile_uid'], $remote_contact, $groups);
 
 	if ($update) {
 		$last_updated = (x($_SESSION['last_updated'], $last_updated_key) ? $_SESSION['last_updated'][$last_updated_key] : 0);
@@ -233,7 +232,7 @@ function profile_content(App $a, $update = 0) {
 			FROM `item` INNER JOIN `contact` ON `contact`.`id` = `item`.`contact-id`
 			AND `contact`.`blocked` = 0 AND `contact`.`pending` = 0
 			WHERE `item`.`uid` = %d AND `item`.`visible` = 1 AND
-			(`item`.`deleted` = 0 OR item.verb = '" . ACTIVITY_LIKE ."'
+			(`item`.`deleted` = 0 OR item.verb = '" . ACTIVITY_LIKE . "'
 			OR item.verb = '" . ACTIVITY_DISLIKE . "' OR item.verb = '" . ACTIVITY_ATTEND . "'
 			OR item.verb = '" . ACTIVITY_ATTENDNO . "' OR item.verb = '" . ACTIVITY_ATTENDMAYBE . "')
 			AND `item`.`moderated` = 0
@@ -247,7 +246,6 @@ function profile_content(App $a, $update = 0) {
 		if (!DBM::is_result($r)) {
 			return '';
 		}
-
 	} else {
 		$sql_post_table = "";
 
@@ -263,10 +261,10 @@ function profile_content(App $a, $update = 0) {
 		}
 
 		if ($datequery) {
-			$sql_extra2 .= protect_sprintf(sprintf(" AND `thread`.`created` <= '%s' ", dbesc(datetime_convert(date_default_timezone_get(),'',$datequery))));
+			$sql_extra2 .= protect_sprintf(sprintf(" AND `thread`.`created` <= '%s' ", dbesc(datetime_convert(date_default_timezone_get(), '', $datequery))));
 		}
 		if ($datequery2) {
-			$sql_extra2 .= protect_sprintf(sprintf(" AND `thread`.`created` >= '%s' ", dbesc(datetime_convert(date_default_timezone_get(),'',$datequery2))));
+			$sql_extra2 .= protect_sprintf(sprintf(" AND `thread`.`created` >= '%s' ", dbesc(datetime_convert(date_default_timezone_get(), '', $datequery2))));
 		}
 
 		// Belongs the profile page to a forum?
@@ -283,20 +281,22 @@ function profile_content(App $a, $update = 0) {
 		//  check if we serve a mobile device and get the user settings
 		//  accordingly
 		if ($a->is_mobile) {
-			$itemspage_network = PConfig::get(local_user(),'system','itemspage_mobile_network');
+			$itemspage_network = PConfig::get(local_user(), 'system', 'itemspage_mobile_network');
 			$itemspage_network = ((intval($itemspage_network)) ? $itemspage_network : 10);
 		} else {
-			$itemspage_network = PConfig::get(local_user(),'system','itemspage_network');
+			$itemspage_network = PConfig::get(local_user(), 'system', 'itemspage_network');
 			$itemspage_network = ((intval($itemspage_network)) ? $itemspage_network : 20);
 		}
+
 		//  now that we have the user settings, see if the theme forces
 		//  a maximum item number which is lower then the user choice
-		if(($a->force_max_items > 0) && ($a->force_max_items < $itemspage_network))
+		if (($a->force_max_items > 0) && ($a->force_max_items < $itemspage_network)) {
 			$itemspage_network = $a->force_max_items;
+		}
 
 		$a->set_pager_itemspage($itemspage_network);
 
-		$pager_sql = sprintf(" LIMIT %d, %d ",intval($a->pager['start']), intval($a->pager['itemspage']));
+		$pager_sql = sprintf(" LIMIT %d, %d ", intval($a->pager['start']), intval($a->pager['itemspage']));
 
 		$r = q("SELECT `thread`.`iid` AS `item_id`, `thread`.`network` AS `item_network`
 			FROM `thread`
@@ -312,7 +312,6 @@ function profile_content(App $a, $update = 0) {
 			ORDER BY `thread`.`created` DESC $pager_sql",
 			intval($a->profile['profile_uid'])
 		);
-
 	}
 
 	$parents_arr = array();
@@ -323,23 +322,25 @@ function profile_content(App $a, $update = 0) {
 	$_SESSION['last_updated'][$last_updated_key] = time();
 
 	if (DBM::is_result($r)) {
-		foreach($r as $rr)
+		foreach ($r as $rr) {
 			$parents_arr[] = $rr['item_id'];
+		}
+
 		$parents_str = implode(', ', $parents_arr);
 
-		$items = q(item_query()." AND `item`.`uid` = %d
+		$items = q(item_query() . " AND `item`.`uid` = %d
 			AND `item`.`parent` IN (%s)
 			$sql_extra ",
 			intval($a->profile['profile_uid']),
 			dbesc($parents_str)
 		);
 
-		$items = conv_sort($items,'created');
+		$items = conv_sort($items, 'created');
 	} else {
 		$items = array();
 	}
 
-	if($is_owner && (! $update) && (! Config::get('theme','hide_eventlist'))) {
+	if ($is_owner && !$update && !Config::get('theme', 'hide_eventlist')) {
 		$o .= get_birthdays();
 		$o .= get_events();
 	}

--- a/src/Module/Feed.php
+++ b/src/Module/Feed.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Friendica\Module;
+
+use Friendica\BaseModule;
+use Friendica\Protocol\OStatus;
+
+/**
+ * Provides public Atom feeds
+ *
+ * Currently supported:
+ * - /feed/[nickname]/ => posts
+ * - /feed/[nickname]/posts => posts
+ * - /feed/[nickname]/comments => comments
+ * - /feed/[nickname]/replies => comments
+ * - /feed/[nickname]/activity => activity
+ *
+ * The nocache GET parameter is provided mainly for debug purposes, requires auth
+ *
+ * @brief Provides public Atom feeds
+ *
+ * @author Hypolite Petovan <mrpetovan@gmail.com>
+ */
+class Feed extends BaseModule
+{
+	public static function content()
+	{
+		$a = self::getApp();
+
+		$last_update = x($_GET, 'last_update') ? $_GET['last_update'] : '';
+		$nocache     = x($_GET, 'nocache') && local_user();
+
+		if ($a->argc < 2) {
+			http_status_exit(400);
+		}
+
+		$type = null;
+		if ($a->argc > 2) {
+			$type = $a->argv[2];
+		}
+
+		switch ($type) {
+			case 'posts':
+			case 'comments':
+			case 'activity':
+				break;
+			case 'replies':
+				$type = 'comments';
+				break;
+			default:
+				$type = 'posts';
+		}
+
+		$nickname = $a->argv[1];
+		header("Content-type: application/atom+xml");
+		echo OStatus::feed($nickname, $last_update, 10, $type, $nocache);
+		killme();
+	}
+}

--- a/src/Protocol/OStatus.php
+++ b/src/Protocol/OStatus.php
@@ -1240,7 +1240,7 @@ class OStatus
 	 *
 	 * @return object header root element
 	 */
-	private static function addHeader($doc, $owner)
+	private static function addHeader($doc, $owner, $type)
 	{
 		$a = get_app();
 
@@ -1256,10 +1256,16 @@ class OStatus
 		$root->setAttribute("xmlns:statusnet", NAMESPACE_STATUSNET);
 		$root->setAttribute("xmlns:mastodon", NAMESPACE_MASTODON);
 
-		$attributes = array("uri" => "https://friendi.ca", "version" => FRIENDICA_VERSION."-".DB_UPDATE_VERSION);
+		switch ($type) {
+			case 'activity': $title = t('%s\'s timeline', $owner['name']); break;
+			case 'posts'   : $title = t('%s\'s posts'   , $owner['name']); break;
+			case 'comments': $title = t('%s\'s comments', $owner['name']); break;
+		}
+
+		$attributes = array("uri" => "https://friendi.ca", "version" => FRIENDICA_VERSION . "-" . DB_UPDATE_VERSION);
 		XML::addElement($doc, $root, "generator", FRIENDICA_PLATFORM, $attributes);
-		XML::addElement($doc, $root, "id", System::baseUrl()."/profile/".$owner["nick"]);
-		XML::addElement($doc, $root, "title", sprintf("%s timeline", $owner["name"]));
+		XML::addElement($doc, $root, "id", System::baseUrl() . "/profile/" . $owner["nick"]);
+		XML::addElement($doc, $root, "title", $title);
 		XML::addElement($doc, $root, "subtitle", sprintf("Updates from %s on %s", $owner["name"], $a->config["sitename"]));
 		XML::addElement($doc, $root, "logo", $owner["photo"]);
 		XML::addElement($doc, $root, "updated", datetime_convert("UTC", "UTC", "now", ATOM_TIME));
@@ -1278,17 +1284,17 @@ class OStatus
 
 		self::hublinks($doc, $root, $owner["nick"]);
 
-		$attributes = array("href" => System::baseUrl()."/salmon/".$owner["nick"], "rel" => "salmon");
+		$attributes = array("href" => System::baseUrl() . "/salmon/" . $owner["nick"], "rel" => "salmon");
 		XML::addElement($doc, $root, "link", "", $attributes);
 
-		$attributes = array("href" => System::baseUrl()."/salmon/".$owner["nick"], "rel" => "http://salmon-protocol.org/ns/salmon-replies");
+		$attributes = array("href" => System::baseUrl() . "/salmon/" . $owner["nick"], "rel" => "http://salmon-protocol.org/ns/salmon-replies");
 		XML::addElement($doc, $root, "link", "", $attributes);
 
-		$attributes = array("href" => System::baseUrl()."/salmon/".$owner["nick"], "rel" => "http://salmon-protocol.org/ns/salmon-mention");
+		$attributes = array("href" => System::baseUrl() . "/salmon/" . $owner["nick"], "rel" => "http://salmon-protocol.org/ns/salmon-mention");
 		XML::addElement($doc, $root, "link", "", $attributes);
 
-		$attributes = array("href" => System::baseUrl()."/api/statuses/user_timeline/".$owner["nick"].".atom",
-				"rel" => "self", "type" => "application/atom+xml");
+		$attributes = array("href" => System::baseUrl() . "/api/statuses/user_timeline/" . $owner["nick"] . ".atom",
+			"rel" => "self", "type" => "application/atom+xml");
 		XML::addElement($doc, $root, "link", "", $attributes);
 
 		return $root;
@@ -2067,41 +2073,50 @@ class OStatus
 	}
 
 	/**
+	 * Creates the XML feed for a given nickname
+	 *
+	 * Supported filters:
+	 * - activity (default): all the public posts
+	 * - posts: all the public top-level posts
+	 * - comments: all the public replies
+	 *
+	 * Updates the provided last_update parameter if the result comes from the
+	 * cache or it is empty
+	 *
 	 * @brief Creates the XML feed for a given nickname
 	 *
-	 * @param object  $a           The application class
 	 * @param string  $owner_nick  Nickname of the feed owner
 	 * @param string  $last_update Date of the last update
 	 * @param integer $max_items   Number of maximum items to fetch
+	 * @param string  $type        Type of feed (posts, comments or activity)
+	 * @param boolean $nocache     Wether to bypass the cache
 	 *
 	 * @return string XML feed
 	 */
-	public static function feed(App $a, $owner_nick, &$last_update, $max_items = 300)
+	public static function feed($owner_nick, &$last_update, $max_items = 300, $type = 'activity', $nocache = false)
 	{
 		$stamp = microtime(true);
 
-		$cachekey = "ostatus:feed:".$owner_nick.":".$last_update;
+		$cachekey = "ostatus:feed:" . $owner_nick . ":" . $type . ":" . $last_update;
 
 		$previous_created = $last_update;
 
 		$result = Cache::get($cachekey);
-		if (!is_null($result)) {
-			logger('Feed duration: '.number_format(microtime(true) - $stamp, 3).' - '.$owner_nick.' - '.$previous_created.' (cached)', LOGGER_DEBUG);
+		if (!$nocache && !is_null($result)) {
+			logger('Feed duration: ' . number_format(microtime(true) - $stamp, 3) . ' - ' . $owner_nick . ' - ' . $type . ' - ' . $previous_created . ' (cached)', LOGGER_DEBUG);
 			$last_update = $result['last_update'];
 			return $result['feed'];
 		}
 
-		$r = q(
+		$owner = dba::fetch_first(
 			"SELECT `contact`.*, `user`.`nickname`, `user`.`timezone`, `user`.`page-flags`
 				FROM `contact` INNER JOIN `user` ON `user`.`uid` = `contact`.`uid`
-				WHERE `contact`.`self` AND `user`.`nickname` = '%s' LIMIT 1",
-			dbesc($owner_nick)
+				WHERE `contact`.`self` AND `user`.`nickname` = ? LIMIT 1",
+			$owner_nick
 		);
-		if (!DBM::is_result($r)) {
+		if (!DBM::is_result($owner)) {
 			return;
 		}
-
-		$owner = $r[0];
 
 		if (!strlen($last_update)) {
 			$last_update = 'now -30 days';
@@ -2110,23 +2125,40 @@ class OStatus
 		$check_date = datetime_convert('UTC', 'UTC', $last_update, 'Y-m-d H:i:s');
 		$authorid = Contact::getIdForURL($owner["url"], 0);
 
+		$sql_extra = '';
+		if ($type === 'posts') {
+			$sql_extra .= ' AND `item`.`id` = `item`.`parent` ';
+		}
+
+		if ($type === 'comments') {
+			$sql_extra .= sprintf(" AND `item`.`object-type` = '%s' ", dbesc(ACTIVITY_OBJ_COMMENT));
+		}
+
 		$items = q(
 			"SELECT `item`.*, `item`.`id` AS `item_id` FROM `item` USE INDEX (`uid_contactid_created`)
 				STRAIGHT_JOIN `thread` ON `thread`.`iid` = `item`.`parent`
-				WHERE `item`.`uid` = %d AND `item`.`contact-id` = %d AND
-					`item`.`author-id` = %d AND `item`.`created` > '%s' AND
-					NOT `item`.`deleted` AND NOT `item`.`private` AND
-					`thread`.`network` IN ('%s', '%s')
+				WHERE `item`.`uid` = %d
+				AND `item`.`contact-id` = %d
+				AND `item`.`author-id` = %d
+				AND `item`.`created` > '%s'
+				AND NOT `item`.`deleted`
+				AND NOT `item`.`private`
+				AND `thread`.`network` IN ('%s', '%s')
+				$sql_extra
 				ORDER BY `item`.`created` DESC LIMIT %d",
-			intval($owner["uid"]), intval($owner["id"]),
-			intval($authorid), dbesc($check_date),
-			dbesc(NETWORK_OSTATUS), dbesc(NETWORK_DFRN), intval($max_items)
+			intval($owner["uid"]),
+			intval($owner["id"]),
+			intval($authorid),
+			dbesc($check_date),
+			dbesc(NETWORK_OSTATUS),
+			dbesc(NETWORK_DFRN),
+			intval($max_items)
 		);
 
 		$doc = new DOMDocument('1.0', 'utf-8');
 		$doc->formatOutput = true;
 
-		$root = self::addHeader($doc, $owner);
+		$root = self::addHeader($doc, $owner, $type);
 
 		foreach ($items as $item) {
 			if (Config::get('system', 'ostatus_debug')) {
@@ -2145,7 +2177,7 @@ class OStatus
 		$msg = array('feed' => $feeddata, 'last_update' => $last_update);
 		Cache::set($cachekey, $msg, CACHE_QUARTER_HOUR);
 
-		logger('Feed duration: '.number_format(microtime(true) - $stamp, 3).' - '.$owner_nick.' - '.$previous_created, LOGGER_DEBUG);
+		logger('Feed duration: ' . number_format(microtime(true) - $stamp, 3) . ' - ' . $owner_nick . ' - ' . $type . ' - ' . $previous_created, LOGGER_DEBUG);
 
 		return $feeddata;
 	}

--- a/src/Worker/PubSubPublish.php
+++ b/src/Worker/PubSubPublish.php
@@ -52,7 +52,7 @@ class PubSubPublish {
 		logger("Generate feed of user ".$rr['nickname']." to ".$rr['callback_url']." - last updated ".$rr['last_update'], LOGGER_DEBUG);
 
 		$last_update = $rr['last_update'];
-		$params = OStatus::feed($a, $rr['nickname'], $last_update);
+		$params = OStatus::feed($rr['nickname'], $last_update);
 
 		if (!$params) {
 			return;


### PR DESCRIPTION
Resolves #4137

Basically, I just took the program path of the existing feed we provide through the profile page and added a couple of conditions on a new filter parameter.

Public feeds now have their own module instead of piggy-backing off `dfrn_poll`. I left the original logic in the `dfrn_poll` because it's used in [multiple other locations](https://github.com/friendica/friendica/search?q=dfrn_poll&type=Code&utf8=✓) but I'd rather we use the new module for simple OStatus feeds.

Please advise which instances of `dfrn_poll` I should convert to the new module, as far as I'm concerned I'm satisfied with the current state of this PR.