### PR TITLE
Fix PHP notices

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -1635,14 +1635,11 @@ function argv($x)
 function infinite_scroll_data($module)
 {
 	if (PConfig::get(local_user(), 'system', 'infinite_scroll')
-		&& ($module == "network") && ($_GET["mode"] != "minimal")
+		&& $module == 'network'
+		&& defaults($_GET, 'mode', '') != 'minimal'
 	) {
 		// get the page number
-		if (is_string($_GET["page"])) {
-			$pageno = $_GET["page"];
-		} else {
-			$pageno = 1;
-		}
+		$pageno = defaults($_GET, 'page', 1);
 
 		$reload_uri = "";
 
@@ -1653,7 +1650,8 @@ function infinite_scroll_data($module)
 			}
 		}
 
-		if (($a->page_offset != "") && ! strstr($reload_uri, "&offset=")) {
+		$a = get_app();
+		if ($a->page_offset != "" && !strstr($reload_uri, "&offset=")) {
 			$reload_uri .= "&offset=" . urlencode($a->page_offset);
 		}
 

--- a/boot.php
+++ b/boot.php
@@ -573,6 +573,51 @@ function x($s, $k = null)
 }
 
 /**
+ * Return the provided variable value if it exists and is truthy or the provided
+ * default value instead.
+ *
+ * Works with initialized variables and potentially uninitialized array keys
+ *
+ * Usages:
+ * - defaults($var, $default)
+ * - defaults($array, 'key', $default)
+ *
+ * @brief Returns a defaut value if the provided variable or array key is falsy
+ * @see x()
+ * @return mixed
+ */
+function defaults() {
+	$args = func_get_args();
+
+	if (count($args) < 2) {
+		throw new BadFunctionCallException('defaults() requires at least 2 parameters');
+	}
+	if (count($args) > 3) {
+		throw new BadFunctionCallException('defaults() cannot use more than 3 parameters');
+	}
+	if (count($args) === 3 && !is_array($args[0])) {
+		throw new BadFunctionCallException('defaults($arr, $key, $def) requires an array as first parameter');
+	}
+	if (count($args) === 3 && is_null($args[1])) {
+		throw new BadFunctionCallException('defaults($arr, $key, $def) $key is null');
+	}
+
+	$default = array_pop($args);
+
+	if (call_user_func_array('x', $args)) {
+		if (count($args) === 1) {
+			$return = $args[0];
+		} else {
+			$return = $args[0][$args[1]];
+		}
+	} else {
+		$return = $default;
+	}
+
+	return $return;
+}
+
+/**
  * @brief Returns the baseurl.
  *
  * @see System::baseUrl()

--- a/include/bbcode.php
+++ b/include/bbcode.php
@@ -485,8 +485,6 @@ function bb_ShareAttributes($share, $simplehtml)
 
 	$posted = "";
 
-	$itemcache = get_itemcachepath();
-
 	preg_match("/posted='(.*?)'/ism", $attributes, $matches);
 	if (x($matches, 1)) {
 		$posted = $matches[1];

--- a/include/bbcode.php
+++ b/include/bbcode.php
@@ -435,60 +435,67 @@ function bb_replace_images($body, $images) {
 	return $newbody;
 }
 
-function bb_ShareAttributes($share, $simplehtml) {
+function bb_ShareAttributes($share, $simplehtml)
+{
 	$attributes = $share[2];
 
 	$author = "";
 	preg_match("/author='(.*?)'/ism", $attributes, $matches);
-	if ($matches[1] != "")
-		$author = html_entity_decode($matches[1],ENT_QUOTES,'UTF-8');
+	if (x($matches, 1)) {
+		$author = html_entity_decode($matches[1], ENT_QUOTES, 'UTF-8');
+	}
 
 	preg_match('/author="(.*?)"/ism', $attributes, $matches);
-	if ($matches[1] != "")
+	if (x($matches, 1)) {
 		$author = $matches[1];
+	}
 
 	$profile = "";
 	preg_match("/profile='(.*?)'/ism", $attributes, $matches);
-	if ($matches[1] != "")
+	if (x($matches, 1)) {
 		$profile = $matches[1];
+	}
 
 	preg_match('/profile="(.*?)"/ism', $attributes, $matches);
-	if ($matches[1] != "")
+	if (x($matches, 1)) {
 		$profile = $matches[1];
+	}
 
 	$avatar = "";
 	preg_match("/avatar='(.*?)'/ism", $attributes, $matches);
-	if ($matches[1] != "")
+	if (x($matches, 1)) {
 		$avatar = $matches[1];
+	}
 
 	preg_match('/avatar="(.*?)"/ism', $attributes, $matches);
-	if ($matches[1] != "")
+	if (x($matches, 1)) {
 		$avatar = $matches[1];
+	}
 
 	$link = "";
 	preg_match("/link='(.*?)'/ism", $attributes, $matches);
-	if ($matches[1] != "")
+	if (x($matches, 1)) {
 		$link = $matches[1];
+	}
 
 	preg_match('/link="(.*?)"/ism', $attributes, $matches);
-	if ($matches[1] != "")
+	if (x($matches, 1)) {
 		$link = $matches[1];
+	}
 
 	$posted = "";
 
 	$itemcache = get_itemcachepath();
 
 	preg_match("/posted='(.*?)'/ism", $attributes, $matches);
-	if ($matches[1] != "")
+	if (x($matches, 1)) {
 		$posted = $matches[1];
+	}
 
 	preg_match('/posted="(.*?)"/ism', $attributes, $matches);
-	if ($matches[1] != "")
+	if (x($matches, 1)) {
 		$posted = $matches[1];
-
-	// relative dates only make sense when they aren't cached
-	if ($itemcache == "")
-		$reldate = (($posted) ? " " . relative_date($posted) : '');
+	}
 
 	// We only call this so that a previously unknown contact can be added.
 	// This is important for the function "get_contact_details_by_url".
@@ -497,99 +504,107 @@ function bb_ShareAttributes($share, $simplehtml) {
 
 	$data = Contact::getDetailsByURL($profile);
 
-	if (isset($data["name"]) && ($data["name"] != "") && isset($data["addr"]) && ($data["addr"] != ""))
-	        $userid_compact = $data["name"]." (".$data["addr"].")";
-	else
-		$userid_compact = GetProfileUsername($profile,$author, true);
+	if (x($data, "name") && x($data, "addr")) {
+		$userid_compact = $data["name"] . " (" . $data["addr"] . ")";
+	} else {
+		$userid_compact = GetProfileUsername($profile, $author, true);
+	}
 
-	if (isset($data["addr"]) && ($data["addr"] != ""))
+	if (x($data, "addr")) {
 		$userid = $data["addr"];
-	else
-		$userid = GetProfileUsername($profile,$author, false);
+	} else {
+		$userid = GetProfileUsername($profile, $author, false);
+	}
 
-	if (isset($data["name"]) && ($data["name"] != ""))
+	if (x($data, "name")) {
 		$author = $data["name"];
+	}
 
-	if (isset($data["micro"]) && ($data["micro"] != ""))
+	if (x($data, "micro")) {
 		$avatar = $data["micro"];
+	}
 
 	$preshare = trim($share[1]);
 
-	if ($preshare != "")
+	if ($preshare != "") {
 		$preshare .= "<br /><br />";
+	}
 
 	switch ($simplehtml) {
 		case 1:
-			$text = $preshare.html_entity_decode("&#x2672; ", ENT_QUOTES, 'UTF-8').' <a href="'.$profile.'">'.$userid."</a>: <br />»".$share[3]."«";
+			$text = $preshare . html_entity_decode("&#x2672; ", ENT_QUOTES, 'UTF-8') . ' <a href="' . $profile . '">' . $userid . "</a>: <br />»" . $share[3] . "«";
 			break;
 		case 2:
-			$text = $preshare.html_entity_decode("&#x2672; ", ENT_QUOTES, 'UTF-8').' '.$userid_compact.": <br />".$share[3];
+			$text = $preshare . html_entity_decode("&#x2672; ", ENT_QUOTES, 'UTF-8') . ' ' . $userid_compact . ": <br />" . $share[3];
 			break;
 		case 3: // Diaspora
-			$headline .= '<b>'.html_entity_decode("&#x2672; ", ENT_QUOTES, 'UTF-8').$userid.':</b><br />';
+			$headline .= '<b>' . html_entity_decode("&#x2672; ", ENT_QUOTES, 'UTF-8') . $userid . ':</b><br />';
 
 			$text = trim($share[1]);
 
-			if ($text != "")
+			if ($text != "") {
 				$text .= "<hr />";
+			}
 
 			if (substr(normalise_link($link), 0, 19) != "http://twitter.com/") {
-				$text .= $headline.'<blockquote>'.trim($share[3])."</blockquote><br />";
+				$text .= $headline . '<blockquote>' . trim($share[3]) . "</blockquote><br />";
 
-				if ($link != "")
-					$text .= '<br /><a href="'.$link.'">[l]</a>';
-			} else
-				$text .= '<br /><a href="'.$link.'">'.$link.'</a>';
+				if ($link != "") {
+					$text .= '<br /><a href="' . $link . '">[l]</a>';
+				}
+			} else {
+				$text .= '<br /><a href="' . $link . '">' . $link . '</a>';
+			}
 
 			break;
 		case 4:
-			$headline .= '<br /><b>'.html_entity_decode("&#x2672; ", ENT_QUOTES, 'UTF-8');
-			$headline .= sprintf(t('<a href="%1$s" target="_blank">%2$s</a> %3$s'), $link, $userid, $posted);
+			$headline .= '<br /><b>' . html_entity_decode("&#x2672; ", ENT_QUOTES, 'UTF-8');
+			$headline .= t('<a href="%1$s" target="_blank">%2$s</a> %3$s', $link, $userid, $posted);
 			$headline .= ":</b><br />";
 
 			$text = trim($share[1]);
 
-			if ($text != "")
+			if ($text != "") {
 				$text .= "<hr />";
+			}
 
-			$text .= $headline.'<blockquote class="shared_content">'.trim($share[3])."</blockquote><br />";
+			$text .= $headline . '<blockquote class="shared_content">' . trim($share[3]) . "</blockquote><br />";
 
 			break;
 		case 5:
-			$text = $preshare.html_entity_decode("&#x2672; ", ENT_QUOTES, 'UTF-8').' '.$userid_compact.": <br />".$share[3];
+			$text = $preshare . html_entity_decode("&#x2672; ", ENT_QUOTES, 'UTF-8') . ' ' . $userid_compact . ": <br />" . $share[3];
 			break;
 		case 6: // app.net
-			$text = $preshare."&gt;&gt; @".$userid_compact.": <br />".$share[3];
+			$text = $preshare . "&gt;&gt; @" . $userid_compact . ": <br />" . $share[3];
 			break;
 		case 7: // statusnet/GNU Social
-			$text = $preshare.html_entity_decode("&#x2672; ", ENT_QUOTES, 'UTF-8')." @".$userid_compact.": ".$share[3];
+			$text = $preshare . html_entity_decode("&#x2672; ", ENT_QUOTES, 'UTF-8') . " @" . $userid_compact . ": " . $share[3];
 			break;
 		case 8: // twitter
-			$text = $preshare."RT @".$userid_compact.": ".$share[3];
+			$text = $preshare . "RT @" . $userid_compact . ": " . $share[3];
 			break;
 		case 9: // Google+/Facebook
-			$text = $preshare.html_entity_decode("&#x2672; ", ENT_QUOTES, 'UTF-8').' '.$userid_compact.": <br />".$share[3];
+			$text = $preshare . html_entity_decode("&#x2672; ", ENT_QUOTES, 'UTF-8') . ' ' . $userid_compact . ": <br />" . $share[3];
 
-			if ($link != "")
-				$text .= "<br /><br />".$link;
+			if ($link != "") {
+				$text .= "<br /><br />" . $link;
+			}
 			break;
 		default:
-			$text = trim($share[1])."\n";
+			$text = trim($share[1]) . "\n";
 
 			$avatar = proxy_url($avatar, false, PROXY_SIZE_THUMB);
 
 			$tpl = get_markup_template('shared_content.tpl');
-			$text .= replace_macros($tpl,
-					array(
-						'$profile' => $profile,
-						'$avatar' => $avatar,
-						'$author' => $author,
-						'$link' => $link,
-						'$posted' => $posted,
-						'$reldate' => $reldate,
-						'$content' => trim($share[3])
-					)
-				);
+			$text .= replace_macros($tpl, array(
+					'$profile' => $profile,
+					'$avatar' => $avatar,
+					'$author' => $author,
+					'$link' => $link,
+					'$posted' => $posted,
+					'$content' => trim($share[3])
+				)
+			);
 			break;
 	}
 

--- a/include/conversation.php
+++ b/include/conversation.php
@@ -545,8 +545,10 @@ function conversation(App $a, $items, $mode, $update, $preview = false) {
 		$profile_owner = $a->profile['profile_uid'];
 
 		if (!$update) {
-			$tab = notags(trim($_GET['tab']));
-			$tab = ( $tab ? $tab : 'posts' );
+			$tab = 'posts';
+			if (x($_GET, 'tab')) {
+				$tab = notags(trim($_GET['tab']));
+			}
 			if ($tab === 'posts') {
 				/*
 				 * This is ugly, but we can't pass the profile_uid through the session to the ajax updater,
@@ -647,19 +649,9 @@ function conversation(App $a, $items, $mode, $update, $preview = false) {
 
 				$threadsid++;
 
-				$comment     = '';
 				$owner_url   = '';
 				$owner_name  = '';
 				$sparkle     = '';
-
-				if ($mode === 'search' || $mode === 'community') {
-					if (((activity_match($item['verb'], ACTIVITY_LIKE)) || (activity_match($item['verb'], ACTIVITY_DISLIKE)))
-						&& ($item['id'] != $item['parent']))
-						continue;
-					$nickname = $item['nickname'];
-				} else {
-					$nickname = $a->user['nickname'];
-				}
 
 				// prevent private email from leaking.
 				if ($item['network'] === NETWORK_MAIL && local_user() != $item['uid']) {
@@ -813,7 +805,6 @@ function conversation(App $a, $items, $mode, $update, $preview = false) {
 					'like' => '',
 					'dislike' => '',
 					'comment' => '',
-					//'conv' => (($preview) ? '' : array('href'=> 'display/' . $nickname . '/' . $item['id'], 'title'=> t('View in context'))),
 					'conv' => (($preview) ? '' : array('href'=> 'display/'.$item['guid'], 'title'=> t('View in context'))),
 					'previewing' => $previewing,
 					'wait' => t('Please wait'),
@@ -1197,39 +1188,40 @@ function format_like($cnt, array $arr, $type, $id) {
 	return $o;
 }
 
-function status_editor(App $a, $x, $notes_cid = 0, $popup = false) {
+function status_editor(App $a, $x, $notes_cid = 0, $popup = false)
+{
 	$o = '';
 
-	$geotag = (x($x, 'allow_location') ? replace_macros(get_markup_template('jot_geotag.tpl'), array()) : '');
+	$geotag = x($x, 'allow_location') ? replace_macros(get_markup_template('jot_geotag.tpl'), array()) : '';
 
 	$tpl = get_markup_template('jot-header.tpl');
 	$a->page['htmlhead'] .= replace_macros($tpl, array(
-		'$newpost' => 'true',
-		'$baseurl' => System::baseUrl(true),
-		'$geotag' => $geotag,
-		'$nickname' => $x['nickname'],
-		'$ispublic' => t('Visible to <strong>everybody</strong>'),
-		'$linkurl' => t('Please enter a link URL:'),
-		'$vidurl' => t("Please enter a video link/URL:"),
-		'$audurl' => t("Please enter an audio link/URL:"),
-		'$term' => t('Tag term:'),
-		'$fileas' => t('Save to Folder:'),
+		'$newpost'   => 'true',
+		'$baseurl'   => System::baseUrl(true),
+		'$geotag'    => $geotag,
+		'$nickname'  => $x['nickname'],
+		'$ispublic'  => t('Visible to <strong>everybody</strong>'),
+		'$linkurl'   => t('Please enter a link URL:'),
+		'$vidurl'    => t("Please enter a video link/URL:"),
+		'$audurl'    => t("Please enter an audio link/URL:"),
+		'$term'      => t('Tag term:'),
+		'$fileas'    => t('Save to Folder:'),
 		'$whereareu' => t('Where are you right now?'),
-		'$delitems' => t('Delete item(s)?')
+		'$delitems'  => t('Delete item(s)?')
 	));
 
 	$tpl = get_markup_template('jot-end.tpl');
 	$a->page['end'] .= replace_macros($tpl, array(
-		'$newpost' => 'true',
-		'$baseurl' => System::baseUrl(true),
-		'$geotag' => $geotag,
-		'$nickname' => $x['nickname'],
-		'$ispublic' => t('Visible to <strong>everybody</strong>'),
-		'$linkurl' => t('Please enter a link URL:'),
-		'$vidurl' => t("Please enter a video link/URL:"),
-		'$audurl' => t("Please enter an audio link/URL:"),
-		'$term' => t('Tag term:'),
-		'$fileas' => t('Save to Folder:'),
+		'$newpost'   => 'true',
+		'$baseurl'   => System::baseUrl(true),
+		'$geotag'    => $geotag,
+		'$nickname'  => $x['nickname'],
+		'$ispublic'  => t('Visible to <strong>everybody</strong>'),
+		'$linkurl'   => t('Please enter a link URL:'),
+		'$vidurl'    => t("Please enter a video link/URL:"),
+		'$audurl'    => t("Please enter an audio link/URL:"),
+		'$term'      => t('Tag term:'),
+		'$fileas'    => t('Save to Folder:'),
 		'$whereareu' => t('Where are you right now?')
 	));
 
@@ -1262,57 +1254,56 @@ function status_editor(App $a, $x, $notes_cid = 0, $popup = false) {
 	$tpl = get_markup_template("jot.tpl");
 
 	$o .= replace_macros($tpl,array(
-		'$return_path' => $query_str,
-		'$action' =>  'item',
-		'$share' => (x($x,'button') ? $x['button'] : t('Share')),
-		'$upload' => t('Upload photo'),
-		'$shortupload' => t('upload photo'),
-		'$attach' => t('Attach file'),
-		'$shortattach' => t('attach file'),
-		'$weblink' => t('Insert web link'),
+		'$return_path'  => $query_str,
+		'$action'       => 'item',
+		'$share'        => defaults($x, 'button', t('Share')),
+		'$upload'       => t('Upload photo'),
+		'$shortupload'  => t('upload photo'),
+		'$attach'       => t('Attach file'),
+		'$shortattach'  => t('attach file'),
+		'$weblink'      => t('Insert web link'),
 		'$shortweblink' => t('web link'),
-		'$video' => t('Insert video link'),
-		'$shortvideo' => t('video link'),
-		'$audio' => t('Insert audio link'),
-		'$shortaudio' => t('audio link'),
-		'$setloc' => t('Set your location'),
-		'$shortsetloc' => t('set location'),
-		'$noloc' => t('Clear browser location'),
-		'$shortnoloc' => t('clear location'),
-		'$title' => $x['title'],
+		'$video'        => t('Insert video link'),
+		'$shortvideo'   => t('video link'),
+		'$audio'        => t('Insert audio link'),
+		'$shortaudio'   => t('audio link'),
+		'$setloc'       => t('Set your location'),
+		'$shortsetloc'  => t('set location'),
+		'$noloc'        => t('Clear browser location'),
+		'$shortnoloc'   => t('clear location'),
+		'$title'        => defaults($x, 'title', ''),
 		'$placeholdertitle' => t('Set title'),
-		'$category' => $x['category'],
-		'$placeholdercategory' => (Feature::isEnabled(local_user(), 'categories') ? t('Categories (comma-separated list)') : ''),
-		'$wait' => t('Please wait'),
-		'$permset' => t('Permission settings'),
+		'$category'     => defaults($x, 'category', ''),
+		'$placeholdercategory' => Feature::isEnabled(local_user(), 'categories') ? t('Categories (comma-separated list)') : '',
+		'$wait'         => t('Please wait'),
+		'$permset'      => t('Permission settings'),
 		'$shortpermset' => t('permissions'),
-		'$ptyp' => (($notes_cid) ? 'note' : 'wall'),
-		'$content' => $x['content'],
-		'$post_id' => $x['post_id'],
-		'$baseurl' => System::baseUrl(true),
-		'$defloc' => $x['default_location'],
-		'$visitor' => $x['visitor'],
-		'$pvisit' => (($notes_cid) ? 'none' : $x['visitor']),
-		'$public' => t('Public post'),
-		'$jotnets' => $jotnets,
-		'$lockstate' => $x['lockstate'],
-		'$bang' => $x['bang'],
-		'$profile_uid' => $x['profile_uid'],
-		'$preview' => ((Feature::isEnabled($x['profile_uid'],'preview')) ? t('Preview') : ''),
-		'$jotplugins' => $jotplugins,
-		'$notes_cid' => $notes_cid,
-		'$sourceapp' => t($a->sourcename),
-		'$cancel' => t('Cancel'),
-		'$rand_num' => random_digits(12),
+		'$ptyp'         => $notes_cid ? 'note' : 'wall',
+		'$content'      => defaults($x, 'content', ''),
+		'$post_id'      => defaults($x, 'post_id', ''),
+		'$baseurl'      => System::baseUrl(true),
+		'$defloc'       => $x['default_location'],
+		'$visitor'      => $x['visitor'],
+		'$pvisit'       => $notes_cid ? 'none' : $x['visitor'],
+		'$public'       => t('Public post'),
+		'$lockstate'    => $x['lockstate'],
+		'$bang'         => $x['bang'],
+		'$profile_uid'  => $x['profile_uid'],
+		'$preview'      => Feature::isEnabled($x['profile_uid'], 'preview') ? t('Preview') : '',
+		'$jotplugins'   => $jotplugins,
+		'$notes_cid'    => $notes_cid,
+		'$sourceapp'    => t($a->sourcename),
+		'$cancel'       => t('Cancel'),
+		'$rand_num'     => random_digits(12),
 
 		// ACL permissions box
-		'$acl' => $x['acl'],
-		'$acl_data' => $x['acl_data'],
-		'$group_perms' => t('Post to Groups'),
+		'$acl'           => $x['acl'],
+		'$acl_data'      => $x['acl_data'],
+		'$group_perms'   => t('Post to Groups'),
 		'$contact_perms' => t('Post to Contacts'),
-		'$private' => t('Private post'),
-		'$is_private' => $private_post,
-		'$public_link' => $public_post_link,
+		'$private'       => t('Private post'),
+		'$is_private'    => $private_post,
+		'$public_link'   => $public_post_link,
 
 		//jot nav tab (used in some themes)
 		'$message' => t('Message'),
@@ -1321,7 +1312,7 @@ function status_editor(App $a, $x, $notes_cid = 0, $popup = false) {
 
 
 	if ($popup == true) {
-		$o = '<div id="jot-popup" style="display: none;">'.$o.'</div>';
+		$o = '<div id="jot-popup" style="display: none;">' . $o . '</div>';
 	}
 
 	return $o;
@@ -1577,9 +1568,9 @@ function get_responses($conv_responses, $response_verbs, $ob, $item) {
 	$ret = array();
 	foreach ($response_verbs as $v) {
 		$ret[$v] = array();
-		$ret[$v]['count'] = ((x($conv_responses[$v], $item['uri'])) ? $conv_responses[$v][$item['uri']] : '');
-		$ret[$v]['list']  = ((x($conv_responses[$v], $item['uri'])) ? $conv_responses[$v][$item['uri'] . '-l'] : '');
-		$ret[$v]['self']  = ((x($conv_responses[$v], $item['uri'])) ? $conv_responses[$v][$item['uri'] . '-self'] : '0');
+		$ret[$v]['count'] = defaults($conv_responses[$v], $item['uri'], '');
+		$ret[$v]['list']  = defaults($conv_responses[$v], $item['uri'] . '-l', '');
+		$ret[$v]['self']  = defaults($conv_responses[$v], $item['uri'] . '-self', '0');
 		if (count($ret[$v]['list']) > MAX_LIKERS) {
 			$ret[$v]['list_part'] = array_slice($ret[$v]['list'], 0, MAX_LIKERS);
 			array_push($ret[$v]['list_part'], '<a href="#" data-toggle="modal" data-target="#' . $v . 'Modal-'

--- a/include/event.php
+++ b/include/event.php
@@ -13,7 +13,7 @@ use Friendica\Util\Map;
 
 require_once 'include/bbcode.php';
 require_once 'include/datetime.php';
-require_once "include/conversation.php";
+require_once 'include/conversation.php';
 
 function format_event_html($ev, $simple = false) {
 	if (! ((is_array($ev)) && count($ev))) {
@@ -88,7 +88,7 @@ function format_event_html($ev, $simple = false) {
 
 /**
  * @brief Convert an array with event data to bbcode.
- * 
+ *
  * @param array $ev Array which conains the event data.
  * @return string The event as a bbcode formatted string.
  */
@@ -126,7 +126,7 @@ function format_event_bbcode($ev) {
 /**
  * @brief Extract bbcode formatted event data from a string
  *     and convert it to html.
- * 
+ *
  * @params: string $s The string which should be parsed for event data.
  * @return string The html output.
  */
@@ -143,7 +143,7 @@ function bbtovcal($s) {
 
 /**
  * @brief Extract bbcode formatted event data from a string.
- * 
+ *
  * @params: string $s The string which should be parsed for event data.
  * @return array The array with the event information.
  */
@@ -206,10 +206,10 @@ function ev_compare($a,$b) {
 
 /**
  * @brief Delete an event from the event table.
- * 
+ *
  * Note: This function does only delete the event from the event table not its
  * related entry in the item table.
- * 
+ *
  * @param int $event_id Event ID.
  * @return void
  */
@@ -224,9 +224,9 @@ function event_delete($event_id) {
 
 /**
  * @brief Store the event.
- * 
+ *
  * Store the event in the event table and create an event item in the item table.
- * 
+ *
  * @param array $arr Array with event data.
  * @return int The event id.
  */
@@ -433,7 +433,7 @@ function event_store($arr) {
 
 /**
  * @brief Create an array with translation strings used for events.
- * 
+ *
  * @return array Array with translations strings.
  */
 function get_event_strings() {
@@ -564,7 +564,7 @@ function event_by_id($owner_uid = 0, $event_params, $sql_extra = '') {
  *	string 'adjust_start' =>
  *
  * @param string $sql_extra Additional sql conditions (e.g. permission request).
- * 
+ *
  * @return array Query results.
  */
 function events_by_date($owner_uid = 0, $event_params, $sql_extra = '') {
@@ -626,6 +626,9 @@ function process_events($arr) {
 
 			// Show edit and drop actions only if the user is the owner of the event and the event
 			// is a real event (no bithdays).
+			$edit = null;
+			$copy = null;
+			$drop = null;
 			if (local_user() && local_user() == $rr['uid'] && $rr['type'] == 'event') {
 				$edit = ((! $rr['cid']) ? array(System::baseUrl() . '/events/event/' . $rr['id'], t('Edit event'), '', '') : null);
 				$copy = ((! $rr['cid']) ? array(System::baseUrl() . '/events/copy/' . $rr['id'], t('Duplicate event'), '', '') : null);
@@ -768,7 +771,7 @@ function event_format_export ($events, $format = 'ical', $timezone) {
 
 /**
  * @brief Get all events for a user ID.
- * 
+ *
  *    The query for events is done permission sensitive.
  *    If the user is the owner of the calendar he/she
  *    will get all of his/her available events.
@@ -922,7 +925,7 @@ function widget_events() {
 
 /**
  * @brief Format an item array with event data to HTML.
- * 
+ *
  * @param arr $item Array with item and event data.
  * @return string HTML output.
  */
@@ -1013,12 +1016,12 @@ function format_event_item($item) {
 
 /**
  * @brief Format a string with map bbcode to an array with location data.
- * 
+ *
  * Note: The string must only contain location data. A string with no bbcode will be
  * handled as location name.
- * 
+ *
  * @param string $s The string with the bbcode formatted location data.
- * 
+ *
  * @return array The array with the location data.
  *  'name' => The name of the location,<br>
  * 'address' => The address of the location,<br>

--- a/include/identity.php
+++ b/include/identity.php
@@ -1,8 +1,8 @@
 <?php
+
 /**
  * @file include/identity.php
  */
-
 use Friendica\App;
 use Friendica\Content\Feature;
 use Friendica\Content\ForumManager;
@@ -50,11 +50,23 @@ function profile_load(App $a, $nickname, $profile = 0, $profiledata = array(), $
 		dbesc($nickname)
 	);
 
-	if (!$user && count($user) && !count($profiledata)) {
+	if (!$user && !count($user) && !count($profiledata)) {
 		logger('profile error: ' . $a->query_string, LOGGER_DEBUG);
 		notice(t('Requested account is not available.') . EOL);
 		$a->error = 404;
 		return;
+	}
+
+	if (!x($a->page, 'aside')) {
+		$a->page['aside'] = '';
+	}
+
+	if ($profiledata) {
+		$a->page['aside'] .= profile_sidebar($profiledata, true, $show_connect);
+
+		if (!DBM::is_result($user)) {
+			return;
+		}
 	}
 
 	$pdata = get_profiledata_by_nick($nickname, $user[0]['uid'], $profile);
@@ -73,8 +85,9 @@ function profile_load(App $a, $nickname, $profile = 0, $profiledata = array(), $
 			"SELECT `pub_keywords` FROM `profile` WHERE `uid` = %d AND `is-default` = 1 LIMIT 1",
 			intval($pdata['profile_uid'])
 		);
-		if ($x && count($x))
+		if ($x && count($x)) {
 			$pdata['pub_keywords'] = $x[0]['pub_keywords'];
+		}
 	}
 
 	$a->profile = $pdata;
@@ -83,9 +96,9 @@ function profile_load(App $a, $nickname, $profile = 0, $profiledata = array(), $
 	$a->profile['mobile-theme'] = PConfig::get($a->profile['profile_uid'], 'system', 'mobile_theme');
 	$a->profile['network'] = NETWORK_DFRN;
 
-	$a->page['title'] = $a->profile['name'] . " @ " . $a->config['sitename'];
+	$a->page['title'] = $a->profile['name'] . ' @ ' . $a->config['sitename'];
 
-	if (!$profiledata  && !PConfig::get(local_user(), 'system', 'always_my_theme')) {
+	if (!$profiledata && !PConfig::get(local_user(), 'system', 'always_my_theme')) {
 		$_SESSION['theme'] = $a->profile['theme'];
 	}
 
@@ -97,19 +110,18 @@ function profile_load(App $a, $nickname, $profile = 0, $profiledata = array(), $
 
 	$a->set_template_engine(); // reset the template engine to the default in case the user's theme doesn't specify one
 
-	$theme_info_file = "view/theme/" . current_theme() . "/theme.php";
+	$theme_info_file = 'view/theme/' . current_theme() . '/theme.php';
 	if (file_exists($theme_info_file)) {
 		require_once $theme_info_file;
 	}
 
-	if (! (x($a->page, 'aside'))) {
+	if (!x($a->page, 'aside')) {
 		$a->page['aside'] = '';
 	}
 
 	if (local_user() && local_user() == $a->profile['uid'] && $profiledata) {
 		$a->page['aside'] .= replace_macros(
-			get_markup_template('profile_edlink.tpl'),
-			array(
+			get_markup_template('profile_edlink.tpl'), array(
 				'$editprofile' => t('Edit profile'),
 				'$profid' => $a->profile['id']
 			)
@@ -123,18 +135,12 @@ function profile_load(App $a, $nickname, $profile = 0, $profiledata = array(), $
 	 * By now, the contact block isn't shown, when a different profile is given
 	 * But: When this profile was on the same server, then we could display the contacts
 	 */
-	if ($profiledata) {
-		$a->page['aside'] .= profile_sidebar($profiledata, true, $show_connect);
-	} else {
+	if (!$profiledata) {
 		$a->page['aside'] .= profile_sidebar($a->profile, $block, $show_connect);
 	}
 
-	/*if (! $block)
-	 $a->page['aside'] .= contact_block();*/
-
 	return;
 }
-
 
 /**
  * @brief Get all profil data of a local user
@@ -144,11 +150,12 @@ function profile_load(App $a, $nickname, $profile = 0, $profiledata = array(), $
  * Passing a non-zero profile ID can also allow a preview of a selected profile
  * by the owner
  *
+ * Includes all available profile data
+ *
  * @param string $nickname nick
  * @param int    $uid      uid
  * @param int    $profile  ID of the profile
  * @returns array
- *	Includes all available profile data
  */
 function get_profiledata_by_nick($nickname, $uid = 0, $profile = 0)
 {
@@ -198,7 +205,6 @@ function get_profiledata_by_nick($nickname, $uid = 0, $profile = 0)
 	return $r;
 }
 
-
 /**
  * @brief Formats a profile for display in the sidebar.
  *
@@ -225,28 +231,27 @@ function profile_sidebar($profile, $block = 0, $show_connect = true)
 	$o = '';
 	$location = false;
 	$address = false;
-	// $pdesc = true;
 
 	// This function can also use contact information in $profile
 	$is_contact = x($profile, 'cid');
 
-	if ((! is_array($profile)) && (! count($profile))) {
+	if (!is_array($profile) && !count($profile)) {
 		return $o;
 	}
 
-	$profile['picdate'] = urlencode($profile['picdate']);
+	$profile['picdate'] = urlencode(defaults($profile, 'picdate', ''));
 
-	if (($profile['network'] != "") && ($profile['network'] != NETWORK_DFRN)) {
+	if (($profile['network'] != '') && ($profile['network'] != NETWORK_DFRN)) {
 		$profile['network_name'] = format_network_name($profile['network'], $profile['url']);
 	} else {
-		$profile['network_name'] = "";
+		$profile['network_name'] = '';
 	}
 
 	call_hooks('profile_sidebar_enter', $profile);
 
 
 	// don't show connect link to yourself
-	$connect = (($profile['uid'] != local_user()) ? t('Connect')  : false);
+	$connect = $profile['uid'] != local_user() ? t('Connect') : false;
 
 	// don't show connect link to authenticated visitors either
 	if (remote_user() && count($_SESSION['remote'])) {
@@ -264,10 +269,10 @@ function profile_sidebar($profile, $block = 0, $show_connect = true)
 
 	// Is the local user already connected to that user?
 	if ($connect && local_user()) {
-		if (isset($profile["url"])) {
-			$profile_url = normalise_link($profile["url"]);
+		if (isset($profile['url'])) {
+			$profile_url = normalise_link($profile['url']);
 		} else {
-			$profile_url = normalise_link(System::baseUrl()."/profile/".$profile["nickname"]);
+			$profile_url = normalise_link(System::baseUrl() . '/profile/' . $profile['nickname']);
 		}
 
 		if (dba::exists('contact', array('pending' => false, 'uid' => local_user(), 'nurl' => $profile_url))) {
@@ -275,21 +280,24 @@ function profile_sidebar($profile, $block = 0, $show_connect = true)
 		}
 	}
 
-	if ($connect && ($profile['network'] != NETWORK_DFRN) && !isset($profile['remoteconnect']))
+	if ($connect && ($profile['network'] != NETWORK_DFRN) && !isset($profile['remoteconnect'])) {
 		$connect = false;
+	}
 
 	$remoteconnect = null;
-	if (isset($profile['remoteconnect']))
+	if (isset($profile['remoteconnect'])) {
 		$remoteconnect = $profile['remoteconnect'];
+	}
 
-	if ($connect && ($profile['network'] == NETWORK_DFRN) && !isset($remoteconnect))
-		$subscribe_feed = t("Atom feed");
-	else
+	if ($connect && ($profile['network'] == NETWORK_DFRN) && !isset($remoteconnect)) {
+		$subscribe_feed = t('Atom feed');
+	} else {
 		$subscribe_feed = false;
+	}
 
-	if (remote_user() || (get_my_url() && $profile['unkmail'] && ($profile['uid'] != local_user()))) {
+	if (remote_user() || (get_my_url() && x($profile, 'unkmail') && ($profile['uid'] != local_user()))) {
 		$wallmessage = t('Message');
-		$wallmessage_link = "wallmessage/".$profile["nickname"];
+		$wallmessage_link = 'wallmessage/' . $profile['nickname'];
 
 		if (remote_user()) {
 			$r = q(
@@ -307,9 +315,9 @@ function profile_sidebar($profile, $block = 0, $show_connect = true)
 			);
 		}
 		if ($r) {
-			$remote_url = $r[0]["url"];
-			$message_path = preg_replace("=(.*)/profile/(.*)=ism", "$1/message/new/", $remote_url);
-			$wallmessage_link = $message_path.base64_encode($profile["addr"]);
+			$remote_url = $r[0]['url'];
+			$message_path = preg_replace('=(.*)/profile/(.*)=ism', '$1/message/new/', $remote_url);
+			$wallmessage_link = $message_path . base64_encode($profile['addr']);
 		}
 	} else {
 		$wallmessage = false;
@@ -318,7 +326,7 @@ function profile_sidebar($profile, $block = 0, $show_connect = true)
 
 	// show edit profile to yourself
 	if (!$is_contact && $profile['uid'] == local_user() && Feature::isEnabled(local_user(), 'multi_profiles')) {
-		$profile['edit'] = array(System::baseUrl(). '/profiles', t('Profiles'),"", t('Manage/edit profiles'));
+		$profile['edit'] = array(System::baseUrl() . '/profiles', t('Profiles'), '', t('Manage/edit profiles'));
 		$r = q(
 			"SELECT * FROM `profile` WHERE `uid` = %d",
 			local_user()
@@ -338,14 +346,14 @@ function profile_sidebar($profile, $block = 0, $show_connect = true)
 					'alt' => t('Profile Image'),
 					'profile_name' => $rr['profile-name'],
 					'isdefault' => $rr['is-default'],
-					'visibile_to_everybody' =>  t('visible to everybody'),
+					'visibile_to_everybody' => t('visible to everybody'),
 					'edit_visibility' => t('Edit visibility'),
 				);
 			}
 		}
 	}
 	if (!$is_contact && $profile['uid'] == local_user() && !Feature::isEnabled(local_user(), 'multi_profiles')) {
-		$profile['edit'] = array(System::baseUrl(). '/profiles/'.$profile['id'], t('Edit profile'),"", t('Edit profile'));
+		$profile['edit'] = array(System::baseUrl() . '/profiles/' . $profile['id'], t('Edit profile'), '', t('Edit profile'));
 		$profile['menu'] = array(
 			'chg_photo' => t('Change profile photo'),
 			'cr_new' => null,
@@ -356,28 +364,23 @@ function profile_sidebar($profile, $block = 0, $show_connect = true)
 	// Fetch the account type
 	$account_type = Contact::getAccountType($profile);
 
-	if ((x($profile, 'address') == 1)
-		|| (x($profile, 'location') == 1)
-		|| (x($profile, 'locality') == 1)
-		|| (x($profile, 'region') == 1)
-		|| (x($profile, 'postal-code') == 1)
-		|| (x($profile, 'country-name') == 1)
+	if (x($profile, 'address')
+		|| x($profile, 'location')
+		|| x($profile, 'locality')
+		|| x($profile, 'region')
+		|| x($profile, 'postal-code')
+		|| x($profile, 'country-name')
 	) {
 		$location = t('Location:');
 	}
 
-	$gender = ((x($profile, 'gender') == 1) ? t('Gender:') : false);
+	$gender   = x($profile, 'gender')   ? t('Gender:')   : false;
+	$marital  = x($profile, 'marital')  ? t('Status:')   : false;
+	$homepage = x($profile, 'homepage') ? t('Homepage:') : false;
+	$about    = x($profile, 'about')    ? t('About:')    : false;
+	$xmpp     = x($profile, 'xmpp')     ? t('XMPP:')     : false;
 
-
-	$marital = ((x($profile, 'marital') == 1) ?  t('Status:') : false);
-
-	$homepage = ((x($profile, 'homepage') == 1) ?  t('Homepage:') : false);
-
-	$about = ((x($profile, 'about') == 1) ?  t('About:') : false);
-
-	$xmpp = ((x($profile, 'xmpp') == 1) ?  t('XMPP:') : false);
-
-	if (($profile['hidewall'] || $block) && (! local_user()) && (! remote_user())) {
+	if ((x($profile, 'hidewall') || $block) && !local_user() && !remote_user()) {
 		$location = $pdesc = $gender = $marital = $homepage = $about = false;
 	}
 
@@ -385,7 +388,7 @@ function profile_sidebar($profile, $block = 0, $show_connect = true)
 	$firstname = $split_name['first'];
 	$lastname = $split_name['last'];
 
-	if ($profile['guid'] != "") {
+	if (x($profile, 'guid')) {
 		$diaspora = array(
 			'guid' => $profile['guid'],
 			'podloc' => System::baseUrl(),
@@ -402,6 +405,9 @@ function profile_sidebar($profile, $block = 0, $show_connect = true)
 		$diaspora = false;
 	}
 
+	$contact_block = '';
+	$updated = '';
+	$contacts = 0;
 	if (!$block) {
 		$contact_block = contact_block();
 
@@ -411,7 +417,7 @@ function profile_sidebar($profile, $block = 0, $show_connect = true)
 				intval($a->profile['uid'])
 			);
 			if (DBM::is_result($r)) {
-				$updated =  date("c", strtotime($r[0]['updated']));
+				$updated = date('c', strtotime($r[0]['updated']));
 			}
 
 			$r = q(
@@ -437,45 +443,41 @@ function profile_sidebar($profile, $block = 0, $show_connect = true)
 		$p[$k] = $v;
 	}
 
-	if (isset($p["about"])) {
-		$p["about"] = bbcode($p["about"]);
+	if (isset($p['about'])) {
+		$p['about'] = bbcode($p['about']);
 	}
 
-	if (isset($p["address"])) {
-		$p["address"] = bbcode($p["address"]);
+	if (isset($p['address'])) {
+		$p['address'] = bbcode($p['address']);
 	} else {
-		$p["address"] = bbcode($p["location"]);
+		$p['address'] = bbcode($p['location']);
 	}
 
-	if (isset($p["photo"])) {
-		$p["photo"] = proxy_url($p["photo"], false, PROXY_SIZE_SMALL);
+	if (isset($p['photo'])) {
+		$p['photo'] = proxy_url($p['photo'], false, PROXY_SIZE_SMALL);
 	}
 
 	$tpl = get_markup_template('profile_vcard.tpl');
-	$o .= replace_macros(
-		$tpl,
-		array(
+	$o .= replace_macros($tpl, array(
 		'$profile' => $p,
 		'$xmpp' => $xmpp,
-		'$connect'  => $connect,
-		'$remoteconnect'  => $remoteconnect,
+		'$connect' => $connect,
+		'$remoteconnect' => $remoteconnect,
 		'$subscribe_feed' => $subscribe_feed,
 		'$wallmessage' => $wallmessage,
 		'$wallmessage_link' => $wallmessage_link,
 		'$account_type' => $account_type,
 		'$location' => $location,
-		'$gender'   => $gender,
-		// '$pdesc'	=> $pdesc,
-		'$marital'  => $marital,
+		'$gender' => $gender,
+		'$marital' => $marital,
 		'$homepage' => $homepage,
 		'$about' => $about,
-		'$network' =>  t('Network:'),
+		'$network' => t('Network:'),
 		'$contacts' => $contacts,
 		'$updated' => $updated,
 		'$diaspora' => $diaspora,
 		'$contact_block' => $contact_block,
-		)
-	);
+	));
 
 	$arr = array('profile' => &$profile, 'entry' => &$o);
 
@@ -484,27 +486,26 @@ function profile_sidebar($profile, $block = 0, $show_connect = true)
 	return $o;
 }
 
-
 function get_birthdays()
 {
 	$a = get_app();
 	$o = '';
 
-	if (! local_user() || $a->is_mobile || $a->is_tablet) {
+	if (!local_user() || $a->is_mobile || $a->is_tablet) {
 		return $o;
 	}
 
 	/*
 	 * $mobile_detect = new Mobile_Detect();
 	 * $is_mobile = $mobile_detect->isMobile() || $mobile_detect->isTablet();
-	 *		if ($is_mobile)
-	 *			return $o;
+	 * 		if ($is_mobile)
+	 * 			return $o;
 	 */
 
 	$bd_format = t('g A l F d'); // 8 AM Friday January 18
 	$bd_short = t('F d');
 
-	$cachekey = "get_birthdays:".local_user();
+	$cachekey = 'get_birthdays:' . local_user();
 	$r = Cache::get($cachekey);
 	if (is_null($r)) {
 		$s = dba::p(
@@ -538,7 +539,7 @@ function get_birthdays()
 		$classtoday = $istoday ? ' birthday-today ' : '';
 		if ($total) {
 			foreach ($r as &$rr) {
-				if (! strlen($rr['name'])) {
+				if (!strlen($rr['name'])) {
 					continue;
 				}
 
@@ -553,34 +554,30 @@ function get_birthdays()
 				$sparkle = '';
 				$url = $rr['url'];
 				if ($rr['network'] === NETWORK_DFRN) {
-					$sparkle = " sparkle";
-					$url = System::baseUrl() . '/redir/'  . $rr['cid'];
+					$sparkle = ' sparkle';
+					$url = System::baseUrl() . '/redir/' . $rr['cid'];
 				}
 
 				$rr['link'] = $url;
 				$rr['title'] = $rr['name'];
-				$rr['date'] = day_translate(datetime_convert('UTC', $a->timezone, $rr['start'], $rr['adjust'] ? $bd_format : $bd_short)) . (($today) ?  ' ' . t('[today]') : '');
+				$rr['date'] = day_translate(datetime_convert('UTC', $a->timezone, $rr['start'], $rr['adjust'] ? $bd_format : $bd_short)) . (($today) ? ' ' . t('[today]') : '');
 				$rr['startime'] = null;
 				$rr['today'] = $today;
 			}
 		}
 	}
-	$tpl = get_markup_template("birthdays_reminder.tpl");
-	return replace_macros(
-		$tpl,
-		array(
+	$tpl = get_markup_template('birthdays_reminder.tpl');
+	return replace_macros($tpl, array(
 		'$baseurl' => System::baseUrl(),
 		'$classtoday' => $classtoday,
 		'$count' => $total,
 		'$event_reminders' => t('Birthday Reminders'),
 		'$event_title' => t('Birthdays this week:'),
 		'$events' => $r,
-		'$lbr' => '{',  // raw brackets mess up if/endif macro processing
+		'$lbr' => '{', // raw brackets mess up if/endif macro processing
 		'$rbr' => '}'
-		)
-	);
+	));
 }
-
 
 function get_events()
 {
@@ -588,19 +585,19 @@ function get_events()
 
 	$a = get_app();
 
-	if (! local_user() || $a->is_mobile || $a->is_tablet) {
+	if (!local_user() || $a->is_mobile || $a->is_tablet) {
 		return $o;
 	}
 
 	/*
-	 *	$mobile_detect = new Mobile_Detect();
-	 *		$is_mobile = $mobile_detect->isMobile() || $mobile_detect->isTablet();
-	 *		if ($is_mobile)
-	 *			return $o;
+	 * 	$mobile_detect = new Mobile_Detect();
+	 * 		$is_mobile = $mobile_detect->isMobile() || $mobile_detect->isTablet();
+	 * 		if ($is_mobile)
+	 * 			return $o;
 	 */
 
 	$bd_format = t('g A l F d'); // 8 AM Friday January 18
-	$bd_short = t('F d');
+	$classtoday = '';
 
 	$s = dba::p(
 		"SELECT `event`.* FROM `event`
@@ -614,7 +611,6 @@ function get_events()
 	$r = array();
 
 	if (DBM::is_result($s)) {
-		$now = strtotime('now');
 		$istoday = false;
 
 		while ($rr = dba::fetch($s)) {
@@ -634,7 +630,7 @@ function get_events()
 			}
 
 			$description = substr(strip_tags(bbcode($rr['desc'])), 0, 32) . '... ';
-			if (! $description) {
+			if (!$description) {
 				$description = t('[No description]');
 			}
 
@@ -647,8 +643,8 @@ function get_events()
 			$today = ((substr($strt, 0, 10) === datetime_convert('UTC', $a->timezone, 'now', 'Y-m-d')) ? true : false);
 
 			$rr['title'] = $title;
-			$rr['description'] = $desciption;
-			$rr['date'] = day_translate(datetime_convert('UTC', $rr['adjust'] ? $a->timezone : 'UTC', $rr['start'], $bd_format)) . (($today) ?  ' ' . t('[today]') : '');
+			$rr['description'] = $description;
+			$rr['date'] = day_translate(datetime_convert('UTC', $rr['adjust'] ? $a->timezone : 'UTC', $rr['start'], $bd_format)) . (($today) ? ' ' . t('[today]') : '');
 			$rr['startime'] = $strt;
 			$rr['today'] = $today;
 
@@ -657,18 +653,15 @@ function get_events()
 		dba::close($s);
 		$classtoday = (($istoday) ? 'event-today' : '');
 	}
-	$tpl = get_markup_template("events_reminder.tpl");
-	return replace_macros(
-		$tpl,
-		array(
+	$tpl = get_markup_template('events_reminder.tpl');
+	return replace_macros($tpl, array(
 		'$baseurl' => System::baseUrl(),
 		'$classtoday' => $classtoday,
 		'$count' => count($r),
 		'$event_reminders' => t('Event Reminders'),
 		'$event_title' => t('Events this week:'),
 		'$events' => $r,
-		)
-	);
+	));
 }
 
 function advanced_profile(App $a)
@@ -677,9 +670,8 @@ function advanced_profile(App $a)
 	$uid = $a->profile['uid'];
 
 	$o .= replace_macros(
-		get_markup_template('section_title.tpl'),
-		array(
-		'$title' => t('Profile')
+		get_markup_template('section_title.tpl'), array(
+			'$title' => t('Profile')
 		)
 	);
 
@@ -688,32 +680,32 @@ function advanced_profile(App $a)
 
 		$profile = array();
 
-		$profile['fullname'] = array( t('Full Name:'), $a->profile['name'] ) ;
+		$profile['fullname'] = array(t('Full Name:'), $a->profile['name']);
 
 		if ($a->profile['gender']) {
-			$profile['gender'] = array( t('Gender:'),  $a->profile['gender'] );
+			$profile['gender'] = array(t('Gender:'), $a->profile['gender']);
 		}
 
 		if (($a->profile['dob']) && ($a->profile['dob'] > '0001-01-01')) {
 			$year_bd_format = t('j F, Y');
 			$short_bd_format = t('j F');
 
+			$val = intval($a->profile['dob']) ?
+				day_translate(datetime_convert('UTC', 'UTC', $a->profile['dob'] . ' 00:00 +00:00', $year_bd_format))
+				: day_translate(datetime_convert('UTC', 'UTC', '2001-' . substr($a->profile['dob'], 5) . ' 00:00 +00:00', $short_bd_format));
 
-			$val = ((intval($a->profile['dob']))
-				? day_translate(datetime_convert('UTC', 'UTC', $a->profile['dob'] . ' 00:00 +00:00', $year_bd_format))
-				: day_translate(datetime_convert('UTC', 'UTC', '2001-' . substr($a->profile['dob'], 5) . ' 00:00 +00:00', $short_bd_format)));
-
-			$profile['birthday'] = array( t('Birthday:'), $val);
+			$profile['birthday'] = array(t('Birthday:'), $val);
 		}
+
 		if (!empty($a->profile['dob'])
 			&& $a->profile['dob'] > '0001-01-01'
 			&& $age = age($a->profile['dob'], $a->profile['timezone'], '')
 		) {
-			$profile['age'] = array( t('Age:'), $age );
+			$profile['age'] = array(t('Age:'), $age);
 		}
 
 		if ($a->profile['marital']) {
-			$profile['marital'] = array( t('Status:'), $a->profile['marital']);
+			$profile['marital'] = array(t('Status:'), $a->profile['marital']);
 		}
 
 		/// @TODO Maybe use x() here, plus below?
@@ -726,95 +718,92 @@ function advanced_profile(App $a)
 		}
 
 		if ($a->profile['sexual']) {
-			$profile['sexual'] = array( t('Sexual Preference:'), $a->profile['sexual'] );
+			$profile['sexual'] = array(t('Sexual Preference:'), $a->profile['sexual']);
 		}
 
 		if ($a->profile['homepage']) {
-			$profile['homepage'] = array( t('Homepage:'), linkify($a->profile['homepage']) );
+			$profile['homepage'] = array(t('Homepage:'), linkify($a->profile['homepage']));
 		}
 
 		if ($a->profile['hometown']) {
-			$profile['hometown'] = array( t('Hometown:'), linkify($a->profile['hometown']) );
+			$profile['hometown'] = array(t('Hometown:'), linkify($a->profile['hometown']));
 		}
 
 		if ($a->profile['pub_keywords']) {
-			$profile['pub_keywords'] = array( t('Tags:'), $a->profile['pub_keywords']);
+			$profile['pub_keywords'] = array(t('Tags:'), $a->profile['pub_keywords']);
 		}
 
 		if ($a->profile['politic']) {
-			$profile['politic'] = array( t('Political Views:'), $a->profile['politic']);
+			$profile['politic'] = array(t('Political Views:'), $a->profile['politic']);
 		}
 
 		if ($a->profile['religion']) {
-			$profile['religion'] = array( t('Religion:'), $a->profile['religion']);
+			$profile['religion'] = array(t('Religion:'), $a->profile['religion']);
 		}
 
 		if ($txt = prepare_text($a->profile['about'])) {
-			$profile['about'] = array( t('About:'), $txt );
+			$profile['about'] = array(t('About:'), $txt);
 		}
 
 		if ($txt = prepare_text($a->profile['interest'])) {
-			$profile['interest'] = array( t('Hobbies/Interests:'), $txt);
+			$profile['interest'] = array(t('Hobbies/Interests:'), $txt);
 		}
 
 		if ($txt = prepare_text($a->profile['likes'])) {
-			$profile['likes'] = array( t('Likes:'), $txt);
+			$profile['likes'] = array(t('Likes:'), $txt);
 		}
 
 		if ($txt = prepare_text($a->profile['dislikes'])) {
-			$profile['dislikes'] = array( t('Dislikes:'), $txt);
+			$profile['dislikes'] = array(t('Dislikes:'), $txt);
 		}
 
 		if ($txt = prepare_text($a->profile['contact'])) {
-			$profile['contact'] = array( t('Contact information and Social Networks:'), $txt);
+			$profile['contact'] = array(t('Contact information and Social Networks:'), $txt);
 		}
 
 		if ($txt = prepare_text($a->profile['music'])) {
-			$profile['music'] = array( t('Musical interests:'), $txt);
+			$profile['music'] = array(t('Musical interests:'), $txt);
 		}
 
 		if ($txt = prepare_text($a->profile['book'])) {
-			$profile['book'] = array( t('Books, literature:'), $txt);
+			$profile['book'] = array(t('Books, literature:'), $txt);
 		}
 
 		if ($txt = prepare_text($a->profile['tv'])) {
-			$profile['tv'] = array( t('Television:'), $txt);
+			$profile['tv'] = array(t('Television:'), $txt);
 		}
 
 		if ($txt = prepare_text($a->profile['film'])) {
-			$profile['film'] = array( t('Film/dance/culture/entertainment:'), $txt);
+			$profile['film'] = array(t('Film/dance/culture/entertainment:'), $txt);
 		}
 
 		if ($txt = prepare_text($a->profile['romance'])) {
-			$profile['romance'] = array( t('Love/Romance:'), $txt);
+			$profile['romance'] = array(t('Love/Romance:'), $txt);
 		}
 
 		if ($txt = prepare_text($a->profile['work'])) {
-			$profile['work'] = array( t('Work/employment:'), $txt);
+			$profile['work'] = array(t('Work/employment:'), $txt);
 		}
 
 		if ($txt = prepare_text($a->profile['education'])) {
-			$profile['education'] = array( t('School/education:'), $txt );
+			$profile['education'] = array(t('School/education:'), $txt);
 		}
 
 		//show subcribed forum if it is enabled in the usersettings
 		if (Feature::isEnabled($uid, 'forumlist_profile')) {
-			$profile['forumlist'] = array( t('Forums:'), ForumManager::profileAdvanced($uid));
+			$profile['forumlist'] = array(t('Forums:'), ForumManager::profileAdvanced($uid));
 		}
 
 		if ($a->profile['uid'] == local_user()) {
-			$profile['edit'] = array(System::baseUrl(). '/profiles/'.$a->profile['id'], t('Edit profile'),"", t('Edit profile'));
+			$profile['edit'] = array(System::baseUrl() . '/profiles/' . $a->profile['id'], t('Edit profile'), '', t('Edit profile'));
 		}
 
-		return replace_macros(
-			$tpl,
-			array(
+		return replace_macros($tpl, array(
 			'$title' => t('Profile'),
 			'$basic' => t('Basic'),
 			'$advanced' => t('Advanced'),
 			'$profile' => $profile
-			)
-		);
+		));
 	}
 
 	return '';
@@ -822,12 +811,11 @@ function advanced_profile(App $a)
 
 function profile_tabs($a, $is_owner = false, $nickname = null)
 {
-	//echo "<pre>"; var_dump($a->user); killme();
-
 	if (is_null($nickname)) {
-		$nickname  = $a->user['nickname'];
+		$nickname = $a->user['nickname'];
 	}
 
+	$tab = false;
 	if (x($_GET, 'tab')) {
 		$tab = notags(trim($_GET['tab']));
 	}
@@ -836,85 +824,85 @@ function profile_tabs($a, $is_owner = false, $nickname = null)
 
 	$tabs = array(
 		array(
-			'label'=>t('Status'),
-			'url' => $url,
-			'sel' => ((!isset($tab) && $a->argv[0]=='profile') ? 'active' : ''),
+			'label' => t('Status'),
+			'url'   => $url,
+			'sel'   => !$tab && $a->argv[0] == 'profile' ? 'active' : '',
 			'title' => t('Status Messages and Posts'),
-			'id' => 'status-tab',
+			'id'    => 'status-tab',
 			'accesskey' => 'm',
 		),
 		array(
 			'label' => t('Profile'),
-			'url' 	=> $url.'/?tab=profile',
-			'sel'	=> ((isset($tab) && $tab=='profile') ? 'active' : ''),
+			'url'   => $url . '/?tab=profile',
+			'sel'   => $tab == 'profile' ? 'active' : '',
 			'title' => t('Profile Details'),
-			'id' => 'profile-tab',
+			'id'    => 'profile-tab',
 			'accesskey' => 'r',
 		),
 		array(
 			'label' => t('Photos'),
-			'url'	=> System::baseUrl() . '/photos/' . $nickname,
-			'sel'	=> ((!isset($tab) && $a->argv[0]=='photos') ? 'active' : ''),
+			'url'   => System::baseUrl() . '/photos/' . $nickname,
+			'sel'   => !$tab && $a->argv[0] == 'photos' ? 'active' : '',
 			'title' => t('Photo Albums'),
-			'id' => 'photo-tab',
+			'id'    => 'photo-tab',
 			'accesskey' => 'h',
 		),
 		array(
 			'label' => t('Videos'),
-			'url'	=> System::baseUrl() . '/videos/' . $nickname,
-			'sel'	=> ((!isset($tab) && $a->argv[0]=='videos') ? 'active' : ''),
+			'url'   => System::baseUrl() . '/videos/' . $nickname,
+			'sel'   => !$tab && $a->argv[0] == 'videos' ? 'active' : '',
 			'title' => t('Videos'),
-			'id' => 'video-tab',
+			'id'    => 'video-tab',
 			'accesskey' => 'v',
 		),
 	);
 
 	// the calendar link for the full featured events calendar
 	if ($is_owner && $a->theme_events_in_profile) {
-			$tabs[] = array(
-				'label' => t('Events'),
-				'url'	=> System::baseUrl() . '/events',
-				'sel' 	=>((!isset($tab) && $a->argv[0]=='events') ? 'active' : ''),
-				'title' => t('Events and Calendar'),
-				'id' => 'events-tab',
-				'accesskey' => 'e',
-			);
+		$tabs[] = array(
+			'label' => t('Events'),
+			'url'   => System::baseUrl() . '/events',
+			'sel'   => !$tab && $a->argv[0] == 'events' ? 'active' : '',
+			'title' => t('Events and Calendar'),
+			'id'    => 'events-tab',
+			'accesskey' => 'e',
+		);
 		// if the user is not the owner of the calendar we only show a calendar
 		// with the public events of the calendar owner
-	} elseif (! $is_owner) {
+	} elseif (!$is_owner) {
 		$tabs[] = array(
-				'label' => t('Events'),
-				'url'	=> System::baseUrl() . '/cal/' . $nickname,
-				'sel' 	=>((!isset($tab) && $a->argv[0]=='cal') ? 'active' : ''),
-				'title' => t('Events and Calendar'),
-				'id' => 'events-tab',
-				'accesskey' => 'e',
-			);
+			'label' => t('Events'),
+			'url'   => System::baseUrl() . '/cal/' . $nickname,
+			'sel'   => !$tab && $a->argv[0] == 'cal' ? 'active' : '',
+			'title' => t('Events and Calendar'),
+			'id'    => 'events-tab',
+			'accesskey' => 'e',
+		);
 	}
 
 	if ($is_owner) {
 		$tabs[] = array(
 			'label' => t('Personal Notes'),
-			'url'	=> System::baseUrl() . '/notes',
-			'sel' 	=>((!isset($tab) && $a->argv[0]=='notes') ? 'active' : ''),
+			'url'   => System::baseUrl() . '/notes',
+			'sel'   => !$tab && $a->argv[0] == 'notes' ? 'active' : '',
 			'title' => t('Only You Can See This'),
-			'id' => 'notes-tab',
+			'id'    => 'notes-tab',
 			'accesskey' => 't',
 		);
 	}
 
-	if ((! $is_owner) && ((count($a->profile)) || (! $a->profile['hide-friends']))) {
+	if ((!$is_owner) && ((count($a->profile)) || (!$a->profile['hide-friends']))) {
 		$tabs[] = array(
 			'label' => t('Contacts'),
-			'url'	=> System::baseUrl() . '/viewcontacts/' . $nickname,
-			'sel'	=> ((!isset($tab) && $a->argv[0]=='viewcontacts') ? 'active' : ''),
+			'url'   => System::baseUrl() . '/viewcontacts/' . $nickname,
+			'sel'   => !$tab && $a->argv[0] == 'viewcontacts' ? 'active' : '',
 			'title' => t('Contacts'),
-			'id' => 'viewcontacts-tab',
+			'id'    => 'viewcontacts-tab',
 			'accesskey' => 'k',
 		);
 	}
 
-	$arr = array('is_owner' => $is_owner, 'nickname' => $nickname, 'tab' => (($tab) ? $tab : false), 'tabs' => $tabs);
+	$arr = array('is_owner' => $is_owner, 'nickname' => $nickname, 'tab' => $tab, 'tabs' => $tabs);
 	call_hooks('profile_tabs', $arr);
 
 	$tpl = get_markup_template('common_tabs.tpl');
@@ -938,9 +926,9 @@ function zrl_init(App $a)
 		// The check fetches the cached value from gprobe to reduce the load for this system
 		$urlparts = parse_url($tmp_str);
 
-		$result = Cache::get("gprobe:" . $urlparts["host"]);
-		if ((!is_null($result)) && (in_array($result["network"], array(NETWORK_FEED, NETWORK_PHANTOM)))) {
-			logger("DDoS attempt detected for " . $urlparts["host"] . " by " . $_SERVER["REMOTE_ADDR"] . ". server data: " . print_r($_SERVER, true), LOGGER_DEBUG);
+		$result = Cache::get('gprobe:' . $urlparts['host']);
+		if ((!is_null($result)) && (in_array($result['network'], array(NETWORK_FEED, NETWORK_PHANTOM)))) {
+			logger('DDoS attempt detected for ' . $urlparts['host'] . ' by ' . $_SERVER['REMOTE_ADDR'] . '. server data: ' . print_r($_SERVER, true), LOGGER_DEBUG);
 			return;
 		}
 
@@ -952,10 +940,10 @@ function zrl_init(App $a)
 
 function zrl($s, $force = false)
 {
-	if (! strlen($s)) {
+	if (!strlen($s)) {
 		return $s;
 	}
-	if ((! strpos($s, '/profile/')) && (! $force)) {
+	if ((!strpos($s, '/profile/')) && (!$force)) {
 		return $s;
 	}
 	if ($force && substr($s, -1, 1) !== '/') {
@@ -963,7 +951,7 @@ function zrl($s, $force = false)
 	}
 	$achar = strpos($s, '?') ? '&' : '?';
 	$mine = get_my_url();
-	if ($mine && ! link_compare($mine, $s)) {
+	if ($mine && !link_compare($mine, $s)) {
 		return $s . $achar . 'zrl=' . urlencode($mine);
 	}
 	return $s;
@@ -986,7 +974,7 @@ function zrl($s, $force = false)
 function get_theme_uid()
 {
 	$uid = ((!empty($_REQUEST['puid'])) ? intval($_REQUEST['puid']) : 0);
-	if ((local_user()) && ((PConfig::get(local_user(), 'system', 'always_my_theme')) || (! $uid))) {
+	if ((local_user()) && ((PConfig::get(local_user(), 'system', 'always_my_theme')) || (!$uid))) {
 		return local_user();
 	}
 

--- a/include/items.php
+++ b/include/items.php
@@ -421,7 +421,7 @@ function uri_to_guid($uri, $host = "") {
  * @return array Item array with removed conversation data
  */
 function store_conversation($arr) {
-	if (in_array($arr['network'], array(NETWORK_DFRN, NETWORK_DIASPORA, NETWORK_OSTATUS)) && !empty($arr['uri'])) {
+	if (in_array(defaults($arr, 'network', NETWORK_PHANTOM), array(NETWORK_DFRN, NETWORK_DIASPORA, NETWORK_OSTATUS)) && !empty($arr['uri'])) {
 		$conversation = array('item-uri' => $arr['uri'], 'received' => DBM::date());
 
 		if (isset($arr['parent-uri']) && ($arr['parent-uri'] != $arr['uri'])) {
@@ -535,7 +535,7 @@ function item_store($arr, $force_parent = false, $notify = false, $dontcache = f
 
 	// Converting the plink
 	/// @todo Check if this is really still needed
-	if ($arr['network'] == NETWORK_OSTATUS) {
+	if (defaults($arr, 'network', NETWORK_PHANTOM) == NETWORK_OSTATUS) {
 		if (isset($arr['plink'])) {
 			$arr['plink'] = OStatus::convertHref($arr['plink']);
 		} elseif (isset($arr['uri'])) {
@@ -581,7 +581,7 @@ function item_store($arr, $force_parent = false, $notify = false, $dontcache = f
 	 * We have to check several networks since Friendica posts could be repeated
 	 * via OStatus (maybe Diasporsa as well)
 	 */
-	if (in_array(trim($arr['network']), array(NETWORK_DIASPORA, NETWORK_DFRN, NETWORK_OSTATUS, ""))) {
+	if (in_array(trim(defaults($arr, 'network', NETWORK_PHANTOM)), array(NETWORK_DIASPORA, NETWORK_DFRN, NETWORK_OSTATUS, ""))) {
 		$r = q("SELECT `id`, `network` FROM `item` WHERE `uri` = '%s' AND `uid` = %d AND `network` IN ('%s', '%s', '%s')  LIMIT 1",
 				dbesc(trim($arr['uri'])),
 				intval($uid),

--- a/include/items.php
+++ b/include/items.php
@@ -733,7 +733,7 @@ function item_store($arr, $force_parent = false, $notify = false, $dontcache = f
 		logger("Contact-id was missing for post ".$arr["guid"]." from user id ".$uid." - now set to ".$arr["contact-id"], LOGGER_DEBUG);
 	}
 
-	if ($arr["gcontact-id"] == 0) {
+	if (defaults($arr, "gcontact-id", 0) === 0) {
 		/*
 		 * The gcontact should mostly behave like the contact. But is is supposed to be global for the system.
 		 * This means that wall posts, repeated posts, etc. should have the gcontact id of the owner.

--- a/include/text.php
+++ b/include/text.php
@@ -994,7 +994,7 @@ function contact_block() {
 function micropro($contact, $redirect = false, $class = '', $textmode = false) {
 
 	// Use the contact URL if no address is available
-	if ($contact["addr"] == "") {
+	if (!x($contact, "addr")) {
 		$contact["addr"] = $contact["url"];
 	}
 
@@ -1020,7 +1020,7 @@ function micropro($contact, $redirect = false, $class = '', $textmode = false) {
 	}
 
 	return replace_macros(get_markup_template(($textmode)?'micropro_txt.tpl':'micropro_img.tpl'),array(
-		'$click' => (($contact['click']) ? $contact['click'] : ''),
+		'$click' => defaults($contact, 'click', ''),
 		'$class' => $class,
 		'$url' => $url,
 		'$photo' => proxy_url($contact['thumb'], false, PROXY_SIZE_THUMB),
@@ -1202,11 +1202,15 @@ function redir_private_images($a, &$item)
 	}
 }
 
-function put_item_in_cache(&$item, $update = false) {
+function put_item_in_cache(&$item, $update = false)
+{
+	$rendered_hash = defaults($item, 'rendered-hash', '');
 
-	if (($item["rendered-hash"] != hash("md5", $item["body"])) || ($item["rendered-hash"] == "") ||
-		($item["rendered-html"] == "") || Config::get("system", "ignore_cache")) {
-
+	if ($rendered_hash == ''
+		|| $item["rendered-html"] == ""
+		|| $rendered_hash != hash("md5", $item["body"])
+		|| Config::get("system", "ignore_cache")
+	) {
 		// The function "redir_private_images" changes the body.
 		// I'm not sure if we should store it permanently, so we save the old value.
 		$body = $item["body"];
@@ -2026,7 +2030,7 @@ function deindent($text, $chr = "[\t ]", $count = NULL) {
 }
 
 function formatBytes($bytes, $precision = 2) {
-	 $units = array('B', 'KB', 'MB', 'GB', 'TB');
+	$units = array('B', 'KB', 'MB', 'GB', 'TB');
 
 	$bytes = max($bytes, 0);
 	$pow = floor(($bytes ? log($bytes) : 0) / log(1024));

--- a/index.php
+++ b/index.php
@@ -97,6 +97,7 @@ if (!$a->is_backend()) {
 	session_start();
 	$a->save_timestamp($stamp1, "parser");
 } else {
+	$_SESSION = [];
 	Worker::executeIfIdle();
 }
 
@@ -148,7 +149,7 @@ if ((x($_GET, 'zrl')) && (!$install && !$maintenance)) {
 
 // header('Link: <' . System::baseUrl() . '/amcd>; rel="acct-mgmt";');
 
-if (x($_COOKIE["Friendica"]) || (x($_SESSION, 'authenticated')) || (x($_POST, 'auth-params')) || ($a->module === 'login')) {
+if (x($_COOKIE, "Friendica") || (x($_SESSION, 'authenticated')) || (x($_POST, 'auth-params')) || ($a->module === 'login')) {
 	require "include/auth.php";
 }
 

--- a/mod/display.php
+++ b/mod/display.php
@@ -201,8 +201,9 @@ function display_content(App $a, $update = false, $update_uid = 0) {
 
 	if ($update) {
 		$item_id = $_REQUEST['item_id'];
-		$item = dba::select('item', ['uid'], ['id' => $item_id], ['limit' => 1]);
+		$item = dba::select('item', ['uid', 'parent'], ['id' => $item_id], ['limit' => 1]);
 		$a->profile = array('uid' => intval($item['uid']), 'profile_uid' => intval($item['uid']));
+		$item_parent = $item['parent'];
 	} else {
 		$item_id = (($a->argc > 2) ? $a->argv[2] : 0);
 
@@ -260,7 +261,7 @@ function display_content(App $a, $update = false, $update_uid = 0) {
 
 	$contact_id = 0;
 
-	if (is_array($_SESSION['remote'])) {
+	if (x($_SESSION, 'remote') && is_array($_SESSION['remote'])) {
 		foreach ($_SESSION['remote'] as $v) {
 			if ($v['uid'] == $a->profile['uid']) {
 				$contact_id = $v['cid'];
@@ -294,7 +295,7 @@ function display_content(App $a, $update = false, $update_uid = 0) {
 	}
 	$is_owner = (local_user() && (in_array($a->profile['profile_uid'], [local_user(), 0])) ? true : false);
 
-	if ($a->profile['hidewall'] && !$is_owner && !$remote_contact) {
+	if (x($a->profile, 'hidewall') && !$is_owner && !$remote_contact) {
 		notice(t('Access to this profile has been restricted.') . EOL);
 		return;
 	}

--- a/mod/events.php
+++ b/mod/events.php
@@ -20,7 +20,7 @@ function events_init(App $a) {
 		return;
 	}
 
-	if ($a->argc == 1) {
+	if ($a->argc > 1) {
 		// If it's a json request abort here because we don't
 		// need the widget data
 		if ($a->argv[1] === 'json') {
@@ -234,6 +234,7 @@ function events_content(App $a) {
 	));
 
 	$o = '';
+	$tabs = '';
 	// tabs
 	if ($a->theme_events_in_profile) {
 		$tabs = profile_tabs($a, true);
@@ -309,10 +310,13 @@ function events_content(App $a) {
 		$start  = sprintf('%d-%d-%d %d:%d:%d', $y, $m, 1, 0, 0, 0);
 		$finish = sprintf('%d-%d-%d %d:%d:%d', $y, $m, $dim, 23, 59, 59);
 
-
-		if ($a->argv[1] === 'json') {
-			if (x($_GET, 'start')) {$start  = $_GET['start'];}
-			if (x($_GET, 'end'))   {$finish = $_GET['end'];}
+		if ($a->argc > 1 && $a->argv[1] === 'json') {
+			if (x($_GET, 'start')) {
+				$start  = $_GET['start'];
+			}
+			if (x($_GET, 'end'))   {
+				$finish = $_GET['end'];
+			}
 		}
 
 		$start  = datetime_convert('UTC', 'UTC', $start);
@@ -358,7 +362,7 @@ function events_content(App $a) {
 			$events = process_events($r);
 		}
 
-		if ($a->argv[1] === 'json'){
+		if ($a->argc > 1 && $a->argv[1] === 'json'){
 			echo json_encode($events);
 			killme();
 		}

--- a/mod/hovercard.php
+++ b/mod/hovercard.php
@@ -7,90 +7,87 @@
  * Author: Rabuzarus <https://github.com/rabuzarus>
  * License: GNU AFFERO GENERAL PUBLIC LICENSE (Version 3)
  */
-
 use Friendica\App;
 use Friendica\Core\Config;
 use Friendica\Model\Contact;
 use Friendica\Model\GContact;
 
-function hovercard_init(App $a) {
+function hovercard_init(App $a)
+{
 	// Just for testing purposes
-	$_GET["mode"] = "minimal";
+	$_GET['mode'] = 'minimal';
 }
 
-function hovercard_content() {
-	$profileurl	=	(x($_REQUEST,'profileurl')	? $_REQUEST['profileurl']	: "");
-	$datatype	=	(x($_REQUEST,'datatype')	?$_REQUEST['datatype']		: "json");
+function hovercard_content()
+{
+	$profileurl = defaults($_REQUEST, 'profileurl', '');
+	$datatype   = defaults($_REQUEST, 'datatype'  , 'json');
 
 	// Get out if the system doesn't have public access allowed
-	if(intval(Config::get('system','block_public')))
+	if (intval(Config::get('system', 'block_public'))) {
 		http_status_exit(401);
+	}
 
 	// Return the raw content of the template. We use this to make templates usable for js functions.
 	// Look at hovercard.js (function getHoverCardTemplate()).
-	// This part should be moved in it's own module. Maybe we could make more templates accessabel.
-	// (We need to discuss possible security lacks before doing this)
-	if ($datatype == "tpl") {
-		$templatecontent = get_template_content("hovercard.tpl");
+	// This part should be moved in its own module. Maybe we could make more templates accessible.
+	// (We need to discuss possible security leaks before doing this)
+	if ($datatype == 'tpl') {
+		$templatecontent = get_template_content('hovercard.tpl');
 		echo $templatecontent;
 		killme();
 	}
 
-	// If a contact is connected the url is internally changed to "redir/CID". We need the pure url to search for
+	// If a contact is connected the url is internally changed to 'redir/CID'. We need the pure url to search for
 	// the contact. So we strip out the contact id from the internal url and look in the contact table for
 	// the real url (nurl)
-	if (local_user() && strpos($profileurl, "redir/") === 0) {
+	$cid = 0;
+	if (local_user() && strpos($profileurl, 'redir/') === 0) {
 		$cid = intval(substr($profileurl, 6));
-		$r = dba::select('contact', array('nurl', 'self'), array('id' => $cid), array('limit' => 1));
-		$profileurl = ($r["nurl"] ? $r["nurl"] : "");
-		$self = ($r["self"] ? $r["self"] : "");
+		$r = dba::select('contact', array('nurl'), array('id' => $cid), array('limit' => 1));
+		$profileurl = defaults($r, 'nurl', '');
 	}
 
+	$contact = [];
 	// if it's the url containing https it should be converted to http
 	$nurl = normalise_link(GContact::cleanContactUrl($profileurl));
-	if($nurl) {
+	if ($nurl) {
 		// Search for contact data
 		$contact = Contact::getDetailsByURL($nurl);
 	}
-	if(!is_array($contact))
+	if (!count($contact)) {
 		return;
+	}
 
 	// Get the photo_menu - the menu if possible contact actions
-	if(local_user())
+	if (local_user()) {
 		$actions = Contact::photoMenu($contact);
-
+	}
 
 	// Move the contact data to the profile array so we can deliver it to
-	//
 	$profile = array(
-		'name' => $contact["name"],
-		'nick'	=> $contact["nick"],
-		'addr'	=> (($contact["addr"] != "") ? $contact["addr"] : $contact["url"]),
-		'thumb' => proxy_url($contact["thumb"], false, PROXY_SIZE_THUMB),
-		'url' => ($cid ? ("redir/".$cid) : zrl($contact["url"])),
-		'nurl' => $contact["nurl"], // We additionally store the nurl as identifier
-//		'alias' => $contact["alias"],
-		'location' => $contact["location"],
-		'gender' => $contact["gender"],
-		'about' => $contact["about"],
-		'network' => format_network_name($contact["network"], $contact["url"]),
-		'tags' => $contact["keywords"],
-//		'nsfw' => intval($contact["nsfw"]),
-//		'server_url' => $contact["server_url"],
-		'bd' => (($contact["birthday"] <= '0001-01-01') ? "" : $contact["birthday"]),
-//		'generation' => $contact["generation"],
+		'name'     => $contact['name'],
+		'nick'     => $contact['nick'],
+		'addr'     => defaults($contact, 'addr', $contact['url']),
+		'thumb'    => proxy_url($contact['thumb'], false, PROXY_SIZE_THUMB),
+		'url'      => $cid ? ('redir/' . $cid) : zrl($contact['url']),
+		'nurl'     => $contact['nurl'], // We additionally store the nurl as identifier
+		'location' => $contact['location'],
+		'gender'   => $contact['gender'],
+		'about'    => $contact['about'],
+		'network'  => format_network_name($contact['network'], $contact['url']),
+		'tags'     => $contact['keywords'],
+		'bd'       => $contact['birthday'] <= '0001-01-01' ? '' : $contact['birthday'],
 		'account_type' => Contact::getAccountType($contact),
-		'actions' => $actions,
+		'actions'  => $actions,
 	);
-	if($datatype == "html") {
-		$t = get_markup_template("hovercard.tpl");
-
-		$o = replace_macros($t, array(
+	if ($datatype == 'html') {
+		$tpl = get_markup_template('hovercard.tpl');
+		$o = replace_macros($tpl, array(
 			'$profile' => $profile,
 		));
 
 		return $o;
-
 	} else {
 		json_return_and_die($profile);
 	}
@@ -104,15 +101,15 @@ function hovercard_content() {
  *
  * @return string|bool Output the raw content if existent, otherwise false
  */
-function get_template_content($template, $root = "") {
-
+function get_template_content($template, $root = '')
+{
 	// We load the whole template system to get the filename.
 	// Maybe we can do it a little bit smarter if I get time.
 	$t = get_markup_template($template, $root);
 	$filename = $t->filename;
 
 	// Get the content of the template file
-	if(file_exists($filename)) {
+	if (file_exists($filename)) {
 		$content = file_get_contents($filename);
 
 		return $content;

--- a/mod/message.php
+++ b/mod/message.php
@@ -10,107 +10,104 @@ require_once 'include/acl_selectors.php';
 require_once 'include/message.php';
 require_once 'include/conversation.php';
 
-function message_init(App $a) {
-
+function message_init(App $a)
+{
 	$tabs = '';
 
-	if ($a->argc >1 && is_numeric($a->argv[1])) {
-		$tabs = render_messages(get_messages(local_user(),0,5), 'mail_list.tpl');
+	if ($a->argc > 1 && is_numeric($a->argv[1])) {
+		$tabs = render_messages(get_messages(local_user(), 0, 5), 'mail_list.tpl');
 	}
 
 	$new = array(
 		'label' => t('New Message'),
 		'url' => 'message/new',
-		'sel'=> ($a->argv[1] == 'new'),
+		'sel' => $a->argc > 1 && $a->argv[1] == 'new',
 		'accesskey' => 'm',
 	);
 
 	$tpl = get_markup_template('message_side.tpl');
 	$a->page['aside'] = replace_macros($tpl, array(
-		'$tabs'=>$tabs,
-		'$new'=>$new,
+		'$tabs' => $tabs,
+		'$new' => $new,
 	));
 	$base = System::baseUrl();
 
 	$head_tpl = get_markup_template('message-head.tpl');
-	$a->page['htmlhead'] .= replace_macros($head_tpl,array(
+	$a->page['htmlhead'] .= replace_macros($head_tpl, array(
 		'$baseurl' => System::baseUrl(true),
 		'$base' => $base
 	));
 
 	$end_tpl = get_markup_template('message-end.tpl');
-	$a->page['end'] .= replace_macros($end_tpl,array(
+	$a->page['end'] .= replace_macros($end_tpl, array(
 		'$baseurl' => System::baseUrl(true),
 		'$base' => $base
 	));
-
 }
 
-function message_post(App $a) {
-
-	if (! local_user()) {
-		notice( t('Permission denied.') . EOL);
+function message_post(App $a)
+{
+	if (!local_user()) {
+		notice(t('Permission denied.') . EOL);
 		return;
 	}
 
-	$replyto   = ((x($_REQUEST,'replyto'))   ? notags(trim($_REQUEST['replyto']))   : '');
-	$subject   = ((x($_REQUEST,'subject'))   ? notags(trim($_REQUEST['subject']))   : '');
-	$body      = ((x($_REQUEST,'body'))      ? escape_tags(trim($_REQUEST['body'])) : '');
-	$recipient = ((x($_REQUEST,'messageto')) ? intval($_REQUEST['messageto'])       : 0 );
+	$replyto   = x($_REQUEST, 'replyto')   ? notags(trim($_REQUEST['replyto']))   : '';
+	$subject   = x($_REQUEST, 'subject')   ? notags(trim($_REQUEST['subject']))   : '';
+	$body      = x($_REQUEST, 'body')      ? escape_tags(trim($_REQUEST['body'])) : '';
+	$recipient = x($_REQUEST, 'messageto') ? intval($_REQUEST['messageto'])       : 0;
 
 	$ret = send_message($recipient, $body, $subject, $replyto);
 	$norecip = false;
 
-	switch($ret){
+	switch ($ret) {
 		case -1:
-			notice( t('No recipient selected.') . EOL );
+			notice(t('No recipient selected.') . EOL);
 			$norecip = true;
 			break;
 		case -2:
-			notice( t('Unable to locate contact information.') . EOL );
+			notice(t('Unable to locate contact information.') . EOL);
 			break;
 		case -3:
-			notice( t('Message could not be sent.') . EOL );
+			notice(t('Message could not be sent.') . EOL);
 			break;
 		case -4:
-			notice( t('Message collection failure.') . EOL );
+			notice(t('Message collection failure.') . EOL);
 			break;
 		default:
-			info( t('Message sent.') . EOL );
+			info(t('Message sent.') . EOL);
 	}
 
 	// fake it to go back to the input form if no recipient listed
-
 	if ($norecip) {
 		$a->argc = 2;
 		$a->argv[1] = 'new';
-	} else
+	} else {
 		goaway($_SESSION['return_url']);
-
+	}
 }
 
-function message_content(App $a) {
-
+function message_content(App $a)
+{
 	$o = '';
 	nav_set_selected('messages');
 
-	if (! local_user()) {
-		notice( t('Permission denied.') . EOL);
+	if (!local_user()) {
+		notice(t('Permission denied.') . EOL);
 		return;
 	}
 
-	$myprofile = System::baseUrl().'/profile/' . $a->user['nickname'];
+	$myprofile = System::baseUrl() . '/profile/' . $a->user['nickname'];
 
 	$tpl = get_markup_template('mail_head.tpl');
 	$header = replace_macros($tpl, array(
 		'$messages' => t('Messages'),
-		'$tab_content' => $tab_content
 	));
 
-
 	if (($a->argc == 3) && ($a->argv[1] === 'drop' || $a->argv[1] === 'dropconv')) {
-		if (! intval($a->argv[2]))
+		if (!intval($a->argv[2])) {
 			return;
+		}
 
 		// Check if we should do HTML-based delete confirmation
 		if ($_REQUEST['confirm']) {
@@ -118,7 +115,7 @@ function message_content(App $a) {
 			// so add any arguments as hidden inputs
 			$query = explode_querystring($a->query_string);
 			$inputs = array();
-			foreach($query['args'] as $arg) {
+			foreach ($query['args'] as $arg) {
 				if (strpos($arg, 'confirm=') === false) {
 					$arg_parts = explode('=', $arg);
 					$inputs[] = array('name' => $arg_parts[0], 'value' => $arg_parts[1]);
@@ -148,7 +145,7 @@ function message_content(App $a) {
 				intval(local_user())
 			);
 			if ($r) {
-				info( t('Message deleted.') . EOL );
+				info(t('Message deleted.') . EOL);
 			}
 			//goaway(System::baseUrl(true) . '/message' );
 			goaway($_SESSION['return_url']);
@@ -170,24 +167,22 @@ function message_content(App $a) {
 				// Actually if we do this, we can never receive another reply to that conversation,
 				// as we will never again have the info we need to re-create it.
 				// We'll just have to orphan it.
-
 				//if ($convid) {
 				//	q("delete from conv where id = %d limit 1",
 				//		intval($convid)
 				//	);
 				//}
 
-				if ($r)
-					info( t('Conversation removed.') . EOL );
+				if ($r) {
+					info(t('Conversation removed.') . EOL);
+				}
 			}
 			//goaway(System::baseUrl(true) . '/message' );
 			goaway($_SESSION['return_url']);
 		}
-
 	}
 
 	if (($a->argc > 1) && ($a->argv[1] === 'new')) {
-
 		$o .= $header;
 
 		$tpl = get_markup_template('msg-header.tpl');
@@ -204,8 +199,7 @@ function message_content(App $a) {
 			'$linkurl' => t('Please enter a link URL:')
 		));
 
-		$preselect = (isset($a->argv[2])?array($a->argv[2]):false);
-
+		$preselect = isset($a->argv[2]) ? array($a->argv[2]) : false;
 
 		$prename = $preurl = $preid = '';
 
@@ -233,18 +227,18 @@ function message_content(App $a) {
 				$preurl = $r[0]['url'];
 				$preid = $r[0]['id'];
 				$preselect = array($preid);
-			} else
+			} else {
 				$preselect = false;
+			}
 		}
 
-		$prefill = (($preselect) ? $prename  : '');
+		$prefill = $preselect ? $prename : '';
 
 		// the ugly select box
-
-		$select = contact_select('messageto','message-to-select', $preselect, 4, true, false, false, 10);
+		$select = contact_select('messageto', 'message-to-select', $preselect, 4, true, false, false, 10);
 
 		$tpl = get_markup_template('prv_message.tpl');
-		$o .= replace_macros($tpl,array(
+		$o .= replace_macros($tpl, array(
 			'$header' => t('Send Private Message'),
 			'$to' => t('To:'),
 			'$showinputs' => 'true',
@@ -252,8 +246,8 @@ function message_content(App $a) {
 			'$autocomp' => $autocomp,
 			'$preid' => $preid,
 			'$subject' => t('Subject:'),
-			'$subjtxt' => ((x($_REQUEST,'subject')) ? strip_tags($_REQUEST['subject']) : ''),
-			'$text' => ((x($_REQUEST,'body')) ? escape_tags(htmlspecialchars($_REQUEST['body'])) : ''),
+			'$subjtxt' => x($_REQUEST, 'subject') ? strip_tags($_REQUEST['subject']) : '',
+			'$text' => x($_REQUEST, 'body') ? escape_tags(htmlspecialchars($_REQUEST['body'])) : '',
 			'$readonly' => '',
 			'$yourmessage' => t('Your message:'),
 			'$select' => $select,
@@ -286,8 +280,8 @@ function message_content(App $a) {
 
 		$r = get_messages(local_user(), $a->pager['start'], $a->pager['itemspage']);
 
-		if (! DBM::is_result($r)) {
-			info( t('No messages.') . EOL);
+		if (!DBM::is_result($r)) {
+			info(t('No messages.') . EOL);
 			return $o;
 		}
 
@@ -325,8 +319,8 @@ function message_content(App $a) {
 				intval(local_user())
 			);
 		}
-		if (! count($messages)) {
-			notice( t('Message not available.') . EOL );
+		if (!count($messages)) {
+			notice(t('Message not available.') . EOL);
 			return $o;
 		}
 
@@ -355,24 +349,24 @@ function message_content(App $a) {
 		$seen = 0;
 		$unknown = false;
 
-		foreach($messages as $message) {
+		foreach ($messages as $message) {
 			if ($message['unknown'])
 				$unknown = true;
 			if ($message['from-url'] == $myprofile) {
 				$from_url = $myprofile;
 				$sparkle = '';
 			} elseif ($message['contact-id'] != 0) {
-				$from_url = 'redir/'.$message['contact-id'];
+				$from_url = 'redir/' . $message['contact-id'];
 				$sparkle = ' sparkle';
 			} else {
-				$from_url = $message['from-url']."?zrl=".urlencode($myprofile);
+				$from_url = $message['from-url'] . "?zrl=" . urlencode($myprofile);
 				$sparkle = ' sparkle';
 			}
 
-
 			$extracted = item_extract_images($message['body']);
-			if ($extracted['images'])
+			if ($extracted['images']) {
 				$message['body'] = item_redir_and_replace_images($extracted['body'], $extracted['images'], $message['contact-id']);
+			}
 
 			$from_name_e = $message['from-name'];
 			$subject_e = $message['title'];
@@ -380,10 +374,11 @@ function message_content(App $a) {
 			$to_name_e = $message['name'];
 
 			$contact = Contact::getDetailsByURL($message['from-url']);
-			if (isset($contact["thumb"]))
+			if (isset($contact["thumb"])) {
 				$from_photo = $contact["thumb"];
-			else
+			} else {
 				$from_photo = $message['from-photo'];
+			}
 
 			$mails[] = array(
 				'id' => $message['id'],
@@ -396,26 +391,22 @@ function message_content(App $a) {
 				'body' => $body_e,
 				'delete' => t('Delete message'),
 				'to_name' => $to_name_e,
-				'date' => datetime_convert('UTC',date_default_timezone_get(),$message['created'],'D, d M Y - g:i A'),
-                                'ago' => relative_date($message['created']),
+				'date' => datetime_convert('UTC', date_default_timezone_get(), $message['created'], 'D, d M Y - g:i A'),
+				'ago' => relative_date($message['created']),
 			);
 
 			$seen = $message['seen'];
 		}
 
-
 		$select = $message['name'] . '<input type="hidden" name="messageto" value="' . $contact_id . '" />';
 		$parent = '<input type="hidden" name="replyto" value="' . $message['parent-uri'] . '" />';
 
 		$tpl = get_markup_template('mail_display.tpl');
-
-		$subjtxt_e = $message['title'];
-
 		$o = replace_macros($tpl, array(
 			'$thread_id' => $a->argv[1],
 			'$thread_subject' => $message['title'],
 			'$thread_seen' => $seen,
-			'$delete' =>  t('Delete conversation'),
+			'$delete' => t('Delete conversation'),
 			'$canreply' => (($unknown) ? false : '1'),
 			'$unknown_text' => t("No secure communications available. You <strong>may</strong> be able to respond from the sender's profile page."),
 			'$mails' => $mails,
@@ -425,7 +416,7 @@ function message_content(App $a) {
 			'$to' => t('To:'),
 			'$showinputs' => '',
 			'$subject' => t('Subject:'),
-			'$subjtxt' => $subjtxt_e,
+			'$subjtxt' => $message['title'],
 			'$readonly' => ' readonly="readonly" style="background: #BBBBBB;" ',
 			'$yourmessage' => t('Your message:'),
 			'$text' => '',
@@ -435,14 +426,14 @@ function message_content(App $a) {
 			'$insert' => t('Insert web link'),
 			'$submit' => t('Submit'),
 			'$wait' => t('Please wait')
-
 		));
 
 		return $o;
 	}
 }
 
-function get_messages($user, $lstart, $lend) {
+function get_messages($user, $lstart, $lend)
+{
 	//TODO: rewritte with a sub-query to get the first message of each private thread with certainty
 	return q("SELECT max(`mail`.`created`) AS `mailcreated`, min(`mail`.`seen`) AS `mailseen`,
 		ANY_VALUE(`mail`.`id`) AS `id`, ANY_VALUE(`mail`.`uid`) AS `uid`, ANY_VALUE(`mail`.`guid`) AS `guid`,
@@ -461,33 +452,34 @@ function get_messages($user, $lstart, $lend) {
 	);
 }
 
-function render_messages(array $msg, $t) {
-
+function render_messages(array $msg, $t)
+{
 	$a = get_app();
 
 	$tpl = get_markup_template($t);
 	$rslt = '';
 
-	$myprofile = System::baseUrl().'/profile/' . $a->user['nickname'];
+	$myprofile = System::baseUrl() . '/profile/' . $a->user['nickname'];
 
-	foreach($msg as $rr) {
-
-		if ($rr['unknown'])
-			$participants = sprintf( t("Unknown sender - %s"),$rr['from-name']);
-		elseif (link_compare($rr['from-url'], $myprofile))
-			$participants = sprintf( t("You and %s"), $rr['name']);
-		else
-			$participants = sprintf(t("%s and You"), $rr['from-name']);
+	foreach ($msg as $rr) {
+		if ($rr['unknown']) {
+			$participants = t("Unknown sender - %s", $rr['from-name']);
+		} elseif (link_compare($rr['from-url'], $myprofile)) {
+			$participants = t("You and %s", $rr['name']);
+		} else {
+			$participants = t("%s and You", $rr['from-name']);
+		}
 
 		$subject_e = (($rr['mailseen']) ? $rr['title'] : '<strong>' . $rr['title'] . '</strong>');
 		$body_e = $rr['body'];
 		$to_name_e = $rr['name'];
 
 		$contact = Contact::getDetailsByURL($rr['url']);
-		if (isset($contact["thumb"]))
+		if (isset($contact["thumb"])) {
 			$from_photo = $contact["thumb"];
-		else
+		} else {
 			$from_photo = (($rr['thumb']) ? $rr['thumb'] : $rr['from-photo']);
+		}
 
 		$rslt .= replace_macros($tpl, array(
 			'$id' => $rr['id'],
@@ -500,10 +492,10 @@ function render_messages(array $msg, $t) {
 			'$delete' => t('Delete conversation'),
 			'$body' => $body_e,
 			'$to_name' => $to_name_e,
-			'$date' => datetime_convert('UTC',date_default_timezone_get(),$rr['mailcreated'], t('D, d M Y - g:i A')),
-															'$ago' => relative_date($rr['mailcreated']),
+			'$date' => datetime_convert('UTC', date_default_timezone_get(), $rr['mailcreated'], t('D, d M Y - g:i A')),
+			'$ago' => relative_date($rr['mailcreated']),
 			'$seen' => $rr['mailseen'],
-			'$count' => sprintf( tt('%d message', '%d messages', $rr['count']), $rr['count']),
+			'$count' => tt('%d message', '%d messages', $rr['count']),
 		));
 	}
 

--- a/mod/nogroup.php
+++ b/mod/nogroup.php
@@ -41,28 +41,25 @@ function nogroup_content(App $a)
 			$contact_details = Contact::getDetailsByURL($rr['url'], local_user(), $rr);
 
 			$contacts[] = array(
-				'img_hover' => sprintf(t('Visit %s\'s profile [%s]'), $contact_details['name'], $rr['url']),
+				'img_hover' => t('Visit %s\'s profile [%s]', $contact_details['name'], $rr['url']),
 				'edit_hover' => t('Edit contact'),
 				'photo_menu' => Contact::photoMenu($rr),
 				'id' => $rr['id'],
-				'alt_text' => $alt_text,
-				'dir_icon' => $dir_icon,
 				'thumb' => proxy_url($contact_details['thumb'], false, PROXY_SIZE_THUMB),
 				'name' => $contact_details['name'],
 				'username' => $contact_details['name'],
 				'details'       => $contact_details['location'],
 				'tags'          => $contact_details['keywords'],
 				'about'         => $contact_details['about'],
-				'sparkle' => $sparkle,
 				'itemurl' => (($contact_details['addr'] != "") ? $contact_details['addr'] : $rr['url']),
 				'url' => $rr['url'],
-				'network' => network_to_name($rr['network'], $url),
+				'network' => network_to_name($rr['network'], $rr['url']),
 			);
 		}
 	}
 
 	$tpl = get_markup_template("nogroup-template.tpl");
-	$o .= replace_macros(
+	$o = replace_macros(
 		$tpl,
 		array(
 		'$header' => t('Contacts who are not members of a group'),

--- a/mod/ping.php
+++ b/mod/ping.php
@@ -164,8 +164,8 @@ function ping_init(App $a)
 
 			if (intval(Feature::isEnabled(local_user(), 'forumlist_widget'))) {
 				$forum_counts = ForumManager::countUnseenItems();
-				if (DBM::is_result($forums_counts)) {
-					foreach ($forums_counts as $forum_count) {
+				if (DBM::is_result($forum_counts)) {
+					foreach ($forum_counts as $forum_count) {
 						if ($forum_count['count'] > 0) {
 							$forums_unseen[] = $forum_count;
 						}
@@ -490,8 +490,10 @@ function ping_get_notifications($uid)
 
 			$notification["href"] = System::baseUrl() . "/notify/view/" . $notification["id"];
 
-			if ($notification["visible"] && !$notification["spam"]
-				&& !$notification["deleted"] && !is_array($result[$notification["parent"]])
+			if ($notification["visible"]
+				&& !$notification["spam"]
+				&& !$notification["deleted"]
+				&& !(x($result, $notification["parent"]) && is_array($result[$notification["parent"]]))
 			) {
 				// Should we condense the notifications or show them all?
 				if (PConfig::get(local_user(), 'system', 'detailed_notif')) {

--- a/mod/videos.php
+++ b/mod/videos.php
@@ -7,11 +7,11 @@ use Friendica\Core\Worker;
 use Friendica\Database\DBM;
 use Friendica\Model\Contact;
 
-require_once('include/items.php');
-require_once('include/acl_selectors.php');
-require_once('include/bbcode.php');
-require_once('include/security.php');
-require_once('include/redir.php');
+require_once 'include/items.php';
+require_once 'include/acl_selectors.php';
+require_once 'include/bbcode.php';
+require_once 'include/security.php';
+require_once 'include/redir.php';
 
 function videos_init(App $a) {
 
@@ -44,12 +44,12 @@ function videos_init(App $a) {
 
 		$tpl = get_markup_template("vcard-widget.tpl");
 
-		$vcard_widget .= replace_macros($tpl, array(
+		$vcard_widget = replace_macros($tpl, array(
 			'$name' => $profile['name'],
 			'$photo' => $profile['photo'],
-			'$addr' => (($profile['addr'] != "") ? $profile['addr'] : ""),
+			'$addr' => defaults($profile, 'addr', ''),
 			'$account_type' => $account_type,
-			'$pdesc' => (($profile['pdesc'] != "") ? $profile['pdesc'] : ""),
+			'$pdesc' => defaults($profile, 'pdesc', ''),
 		));
 
 
@@ -280,8 +280,9 @@ function videos_content(App $a) {
 		}
 	}
 
-	// perhaps they're visiting - but not a community page, so they wouldn't have write access
+	$groups = [];
 
+	// perhaps they're visiting - but not a community page, so they wouldn't have write access
 	if(remote_user() && (! $visitor)) {
 		$contact_id = 0;
 		if(is_array($_SESSION['remote'])) {
@@ -317,7 +318,7 @@ function videos_content(App $a) {
 		return;
 	}
 
-	$sql_extra = permissions_sql($owner_uid,$remote_contact,$groups);
+	$sql_extra = permissions_sql($owner_uid, $remote_contact, $groups);
 
 	$o = "";
 

--- a/src/App.php
+++ b/src/App.php
@@ -37,6 +37,7 @@ class App {
 	public $query_string;
 	public $config;
 	public $page;
+	public $page_offset;
 	public $profile;
 	public $profile_uid;
 	public $user;

--- a/src/Content/OEmbed.php
+++ b/src/Content/OEmbed.php
@@ -100,7 +100,7 @@ class OEmbed
 
 			$txt = trim($txt);
 
-			if ($txt[0] != "{") {
+			if (!$txt || $txt[0] != "{") {
 				$txt = '{"type":"error"}';
 			} else { //save in cache
 				$j = json_decode($txt);

--- a/src/Core/Worker.php
+++ b/src/Core/Worker.php
@@ -606,6 +606,7 @@ class Worker
 			$exponent = 3;
 			$slope = $maxworkers / pow($maxsysload, $exponent);
 			$queues = ceil($slope * pow(max(0, $maxsysload - $load), $exponent));
+			$processlist = '';
 
 			if (Config::get('system', 'worker_debug')) {
 				// Create a list of queue entries grouped by their priority

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -662,7 +662,7 @@ class Contact extends BaseObject
 		if (!DBM::is_result($contact)) {
 			// The link could be provided as http although we stored it as https
 			$ssl_url = str_replace('http://', 'https://', $url);
-			$r = dba::select('contact', array('id', 'avatar-date'), array('`alias` IN (?, ?, ?) AND `uid` = ?', $url, normalise_link($url), $ssl_url, $uid), array('limit' => 1));
+			$r = dba::select('contact', array('id', 'avatar', 'avatar-date'), array('`alias` IN (?, ?, ?) AND `uid` = ?', $url, normalise_link($url), $ssl_url, $uid), array('limit' => 1));
 			$contact = dba::fetch($r);
 			dba::close($r);
 		}
@@ -674,7 +674,7 @@ class Contact extends BaseObject
 			$update_contact = ($contact['avatar-date'] < datetime_convert('', '', 'now -7 days'));
 
 			// We force the update if the avatar is empty
-			if ($contact['avatar'] == '') {
+			if (!x($contact, 'avatar')) {
 				$update_contact = true;
 			}
 

--- a/src/Network/Probe.php
+++ b/src/Network/Probe.php
@@ -330,7 +330,7 @@ class Probe
 			$data["url"] = $uri;
 		}
 
-		if ($data["photo"] != "") {
+		if (x($data, "photo")) {
 			$data["baseurl"] = matching_url(normalise_link($data["baseurl"]), normalise_link($data["photo"]));
 		} else {
 			$data["photo"] = System::baseUrl().'/images/person-175.jpg';
@@ -341,7 +341,7 @@ class Probe
 				$data["name"] = $data["nick"];
 			}
 
-			if ($data["name"] == "") {
+			if (!x($data, "name")) {
 				$data["name"] = $data["url"];
 			}
 		}

--- a/src/Object/Post.php
+++ b/src/Object/Post.php
@@ -168,7 +168,7 @@ class Post extends BaseObject
 
 		$filer = (($conv->getProfileOwner() == local_user()) ? t("save to folder") : false);
 
-		$diff_author = ((link_compare($item['url'], $item['author-link'])) ? false : true);
+		$diff_author = !link_compare($item['url'], $item['author-link']);
 		$profile_name = htmlentities(((strlen($item['author-name'])) && $diff_author) ? $item['author-name'] : $item['name']);
 		if ($item['author-link'] && (!$item['author-name'])) {
 			$profile_name = $item['author-link'];

--- a/src/Object/Post.php
+++ b/src/Object/Post.php
@@ -1,7 +1,9 @@
 <?php
+
 /**
  * @file src/Object/Post.php
  */
+
 namespace Friendica\Object;
 
 use Friendica\BaseObject;
@@ -52,9 +54,9 @@ class Post extends BaseObject
 
 		$this->data = $data;
 		$this->setTemplate('wall');
-		$this->toplevel = ($this->getId() == $this->getDataValue('parent'));
+		$this->toplevel = $this->getId() == $this->getDataValue('parent');
 
-		if (is_array($_SESSION['remote'])) {
+		if (x($_SESSION, 'remote') && is_array($_SESSION['remote'])) {
 			foreach ($_SESSION['remote'] as $visitor) {
 				if ($visitor['cid'] == $this->getDataValue('contact-id')) {
 					$this->visiting = true;
@@ -63,9 +65,7 @@ class Post extends BaseObject
 			}
 		}
 
-		$this->writable = ($this->getDataValue('writable') || $this->getDataValue('self'));
-
-		$ssl_state = ((local_user()) ? true : false);
+		$this->writable = $this->getDataValue('writable') || $this->getDataValue('self');
 		$this->redirect_url = 'redir/' . $this->getDataValue('cid');
 
 		if (!$this->isToplevel()) {
@@ -75,12 +75,10 @@ class Post extends BaseObject
 		// Prepare the children
 		if (count($data['children'])) {
 			foreach ($data['children'] as $item) {
-				/*
-				 * Only add will be displayed
-				 */
+				// Only add will be displayed
 				if ($item['network'] === NETWORK_MAIL && local_user() != $item['uid']) {
 					continue;
-				} elseif (! visible_activity($item)) {
+				} elseif (!visible_activity($item)) {
 					continue;
 				}
 
@@ -145,13 +143,13 @@ class Post extends BaseObject
 			|| strlen($item['deny_cid']) || strlen($item['deny_gid']))))
 			? t('Private Message')
 			: false);
-		$shareable = ((in_array($conv->getProfileOwner(), [0, local_user()]) && ($item['private'] != 1)) ? true : false);
+		$shareable = in_array($conv->getProfileOwner(), [0, local_user()]) && $item['private'] != 1;
 
 		if (local_user() && link_compare($a->contact['url'], $item['author-link'])) {
 			if ($item["event-id"] != 0) {
-				$edpost = array("events/event/".$item['event-id'], t("Edit"));
+				$edpost = array("events/event/" . $item['event-id'], t("Edit"));
 			} else {
-				$edpost = array("editpost/".$item['id'], t("Edit"));
+				$edpost = array("editpost/" . $item['id'], t("Edit"));
 			}
 		} else {
 			$edpost = false;
@@ -170,9 +168,9 @@ class Post extends BaseObject
 
 		$filer = (($conv->getProfileOwner() == local_user()) ? t("save to folder") : false);
 
-		$diff_author    = ((link_compare($item['url'], $item['author-link'])) ? false : true);
-		$profile_name   = htmlentities(((strlen($item['author-name'])) && $diff_author) ? $item['author-name'] : $item['name']);
-		if ($item['author-link'] && (! $item['author-name'])) {
+		$diff_author = ((link_compare($item['url'], $item['author-link'])) ? false : true);
+		$profile_name = htmlentities(((strlen($item['author-name'])) && $diff_author) ? $item['author-name'] : $item['name']);
+		if ($item['author-link'] && (!$item['author-name'])) {
 			$profile_name = $item['author-link'];
 		}
 
@@ -210,39 +208,25 @@ class Post extends BaseObject
 		call_hooks('render_location', $locate);
 		$location = ((strlen($locate['html'])) ? $locate['html'] : render_location_dummy($locate));
 
-		$tags=array();
-		$hashtags = array();
-		$mentions = array();
-
-		/*foreach(explode(',',$item['tag']) as $tag){
-			$tag = trim($tag);
-			if ($tag!="") {
-				$t = bbcode($tag);
-				$tags[] = $t;
-				if($t[0] == '#')
-					$hashtags[] = $t;
-				elseif($t[0] == '@')
-					$mentions[] = $t;
-			}
-		}*/
-
 		// process action responses - e.g. like/dislike/attend/agree/whatever
 		$response_verbs = array('like', 'dislike');
 
+		$isevent = false;
+		$attend = [];
 		if ($item['object-type'] === ACTIVITY_OBJ_EVENT) {
 			$response_verbs[] = 'attendyes';
 			$response_verbs[] = 'attendno';
 			$response_verbs[] = 'attendmaybe';
 			if ($conv->isWritable()) {
 				$isevent = true;
-				$attend = array( t('I will attend'), t('I will not attend'), t('I might attend'));
+				$attend = array(t('I will attend'), t('I will not attend'), t('I might attend'));
 			}
 		}
 
 		$responses = get_responses($conv_responses, $response_verbs, $this, $item);
 
 		foreach ($response_verbs as $value => $verbs) {
-			$responses[$verbs]['output']  = ((x($conv_responses[$verbs], $item['uri'])) ? format_like($conv_responses[$verbs][$item['uri']], $conv_responses[$verbs][$item['uri'] . '-l'], $verbs, $item['uri']) : '');
+			$responses[$verbs]['output'] = x($conv_responses[$verbs], $item['uri']) ? format_like($conv_responses[$verbs][$item['uri']], $conv_responses[$verbs][$item['uri'] . '-l'], $verbs, $item['uri']) : '';
 		}
 
 		/*
@@ -256,6 +240,8 @@ class Post extends BaseObject
 			$osparkle = ' sparkle';
 		}
 
+		$tagger = '';
+
 		if ($this->isToplevel()) {
 			if ($conv->getProfileOwner() == local_user()) {
 				$isstarred = (($item['starred']) ? "starred" : "unstarred");
@@ -264,9 +250,9 @@ class Post extends BaseObject
 					'do'        => t("add star"),
 					'undo'      => t("remove star"),
 					'toggle'    => t("toggle star status"),
-					'classdo'   => (($item['starred']) ? "hidden" : ""),
-					'classundo' => (($item['starred']) ? "" : "hidden"),
-					'starred'   =>  t('starred'),
+					'classdo'   => $item['starred'] ? "hidden" : "",
+					'classundo' => $item['starred'] ? "" : "hidden",
+					'starred'   => t('starred'),
 				);
 				$r = dba::select('thread', array('ignored'), array('uid' => $item['uid'], 'iid' => $item['id']), array('limit' => 1));
 				if (DBM::is_result($r)) {
@@ -274,13 +260,12 @@ class Post extends BaseObject
 						'do'        => t("ignore thread"),
 						'undo'      => t("unignore thread"),
 						'toggle'    => t("toggle ignore status"),
-						'classdo'   => (($r['ignored']) ? "hidden" : ""),
-						'classundo' => (($r['ignored']) ? "" : "hidden"),
-						'ignored'   =>  t('ignored'),
+						'classdo'   => $r['ignored'] ? "hidden" : "",
+						'classundo' => $r['ignored'] ? "" : "hidden",
+						'ignored'   => t('ignored'),
 					);
 				}
 
-				$tagger = '';
 				if (Feature::isEnabled($conv->getProfileOwner(), 'commtag')) {
 					$tagger = array(
 						'add'   => t("add tag"),
@@ -294,11 +279,11 @@ class Post extends BaseObject
 
 		if ($conv->isWritable()) {
 			$buttons = array(
-				'like' => array( t("I like this \x28toggle\x29"), t("like")),
-				'dislike' => ((Feature::isEnabled($conv->getProfileOwner(), 'dislike')) ? array( t("I don't like this \x28toggle\x29"), t("dislike")) : ''),
+				'like'    => array(t("I like this \x28toggle\x29"), t("like")),
+				'dislike' => Feature::isEnabled($conv->getProfileOwner(), 'dislike') ? array(t("I don't like this \x28toggle\x29"), t("dislike")) : '',
 			);
 			if ($shareable) {
-				$buttons['share'] = array( t('Share this'), t('share'));
+				$buttons['share'] = array(t('Share this'), t('share'));
 			}
 		}
 
@@ -322,10 +307,10 @@ class Post extends BaseObject
 		$owner_name_e = $this->getOwnerName();
 
 		// Disable features that aren't available in several networks
-
 		/// @todo Add NETWORK_DIASPORA when it will pass this information
 		if (!in_array($item["item_network"], array(NETWORK_DFRN)) && isset($buttons["dislike"])) {
-			unset($buttons["dislike"], $isevent);
+			unset($buttons["dislike"]);
+			$isevent = false;
 			$tagger = '';
 		}
 
@@ -355,8 +340,8 @@ class Post extends BaseObject
 			'guid'            => urlencode($item['guid']),
 			'isevent'         => $isevent,
 			'attend'          => $attend,
-			'linktitle'       => sprintf(t('View %s\'s profile @ %s'), $profile_name, ((strlen($item['author-link'])) ? $item['author-link'] : $item['url'])),
-			'olinktitle'      => sprintf(t('View %s\'s profile @ %s'), htmlentities($this->getOwnerName()), ((strlen($item['owner-link'])) ? $item['owner-link'] : $item['url'])),
+			'linktitle'       => t('View %s\'s profile @ %s', $profile_name, defaults($item, 'author-link', $item['url'])),
+			'olinktitle'      => t('View %s\'s profile @ %s', htmlentities($this->getOwnerName()), defaults($item, 'owner-link', $item['url'])),
 			'to'              => t('to'),
 			'via'             => t('via'),
 			'wall'            => t('Wall-to-Wall'),
@@ -369,7 +354,7 @@ class Post extends BaseObject
 			'sparkle'         => $sparkle,
 			'title'           => $title_e,
 			'localtime'       => datetime_convert('UTC', date_default_timezone_get(), $item['created'], 'r'),
-			'ago'             => (($item['app']) ? sprintf(t('%s from %s'), relative_date($item['created']), $item['app']) : relative_date($item['created'])),
+			'ago'             => $item['app'] ? t('%s from %s', relative_date($item['created']), $item['app']) : relative_date($item['created']),
 			'app'             => $item['app'],
 			'created'         => relative_date($item['created']),
 			'lock'            => $lock,
@@ -380,12 +365,12 @@ class Post extends BaseObject
 			'owner_photo'     => $a->remove_baseurl(proxy_url($item['owner-thumb'], false, PROXY_SIZE_THUMB)),
 			'owner_name'      => htmlentities($owner_name_e),
 			'plink'           => get_plink($item),
-			'edpost'          => ((Feature::isEnabled($conv->getProfileOwner(), 'edit_posts')) ? $edpost : ''),
+			'edpost'          => Feature::isEnabled($conv->getProfileOwner(), 'edit_posts') ? $edpost : '',
 			'isstarred'       => $isstarred,
-			'star'            => ((Feature::isEnabled($conv->getProfileOwner(), 'star_posts')) ? $star : ''),
-			'ignore'          => ((Feature::isEnabled($conv->getProfileOwner(), 'ignore_posts')) ? $ignore : ''),
+			'star'            => Feature::isEnabled($conv->getProfileOwner(), 'star_posts') ? $star : '',
+			'ignore'          => Feature::isEnabled($conv->getProfileOwner(), 'ignore_posts') ? $ignore : '',
 			'tagger'          => $tagger,
-			'filer'           => ((Feature::isEnabled($conv->getProfileOwner(), 'filing')) ? $filer : ''),
+			'filer'           => Feature::isEnabled($conv->getProfileOwner(), 'filing') ? $filer : '',
 			'drop'            => $drop,
 			'vote'            => $buttons,
 			'like'            => $responses['like']['output'],
@@ -393,7 +378,7 @@ class Post extends BaseObject
 			'responses'       => $responses,
 			'switchcomment'   => t('Comment'),
 			'comment'         => $comment,
-			'previewing'      => ($conv->isPreview() ? ' preview ' : ''),
+			'previewing'      => $conv->isPreview() ? ' preview ' : '',
 			'wait'            => t('Please wait'),
 			'thread_level'    => $thread_level,
 			'edited'          => $edited,
@@ -419,7 +404,7 @@ class Post extends BaseObject
 			// Collapse
 			if (($nb_children > 2) || ($thread_level > 1)) {
 				$result['children'][0]['comment_firstcollapsed'] = true;
-				$result['children'][0]['num_comments'] = sprintf(tt('%d comment', '%d comments', $total_children), $total_children);
+				$result['children'][0]['num_comments'] = tt('%d comment', '%d comments', $total_children);
 				$result['children'][0]['hidden_comments_num'] = $total_children;
 				$result['children'][0]['hidden_comments_text'] = tt('comment', 'comments', $total_children);
 				$result['children'][0]['hide_text'] = t('show more');
@@ -480,7 +465,7 @@ class Post extends BaseObject
 			logger('[ERROR] Post::addChild : Item has no ID!!', LOGGER_DEBUG);
 			return false;
 		} elseif ($this->getChild($item->getId())) {
-			logger('[WARN] Post::addChild : Item already exists ('. $item->getId() .').', LOGGER_DEBUG);
+			logger('[WARN] Post::addChild : Item already exists (' . $item->getId() . ').', LOGGER_DEBUG);
 			return false;
 		}
 		/*
@@ -574,7 +559,7 @@ class Post extends BaseObject
 				return true;
 			}
 		}
-		logger('[WARN] Item::removeChild : Item is not a child ('. $id .').', LOGGER_DEBUG);
+		logger('[WARN] Item::removeChild : Item is not a child (' . $id . ').', LOGGER_DEBUG);
 		return false;
 	}
 
@@ -657,7 +642,7 @@ class Post extends BaseObject
 	private function setTemplate($name)
 	{
 		if (!x($this->available_templates, $name)) {
-			logger('[ERROR] Item::setTemplate : Template not available ("'. $name .'").', LOGGER_DEBUG);
+			logger('[ERROR] Item::setTemplate : Template not available ("' . $name . '").', LOGGER_DEBUG);
 			return false;
 		}
 
@@ -696,7 +681,6 @@ class Post extends BaseObject
 		if ($conv) {
 			// This will allow us to comment on wall-to-wall items owned by our friends
 			// and community forums even if somebody else wrote the post.
-
 			// bug #517 - this fixes for conversation owner
 			if ($conv->getMode() == 'profile' && $conv->getProfileOwner() == local_user()) {
 				return true;
@@ -750,14 +734,13 @@ class Post extends BaseObject
 
 		$comment_box = '';
 		$conv = $this->getThread();
-		$template = get_markup_template($this->getCommentBoxTemplate());
 		$ww = '';
 		if (($conv->getMode() === 'network') && $this->isWallToWall()) {
 			$ww = 'ww';
 		}
 
 		if ($conv->isWritable() && $this->isWritable()) {
-			$qc = $qcomment =  null;
+			$qc = $qcomment = null;
 
 			/*
 			 * Hmmm, code depending on the presence of a particular plugin?
@@ -768,18 +751,16 @@ class Post extends BaseObject
 				$qcomment = (($qc) ? explode("\n", $qc) : null);
 			}
 
-			$comment_box = replace_macros(
-				$template,
-				array(
+			$template = get_markup_template($this->getCommentBoxTemplate());
+			$comment_box = replace_macros($template, array(
 				'$return_path' => $a->query_string,
 				'$threaded'    => $this->isThreaded(),
-				// '$jsreload'    => (($conv->getMode() === 'display') ? $_SESSION['return_url'] : ''),
 				'$jsreload'    => '',
-				'$type'        => (($conv->getMode() === 'profile') ? 'wall-comment' : 'net-comment'),
+				'$type'        => $conv->getMode() === 'profile' ? 'wall-comment' : 'net-comment',
 				'$id'          => $this->getId(),
 				'$parent'      => $this->getId(),
 				'$qcomment'    => $qcomment,
-				'$profile_uid' =>  $conv->getProfileOwner(),
+				'$profile_uid' => $conv->getProfileOwner(),
 				'$mylink'      => $a->remove_baseurl($a->contact['url']),
 				'$mytitle'     => t('This is you'),
 				'$myphoto'     => $a->remove_baseurl($a->contact['thumb']),
@@ -796,9 +777,9 @@ class Post extends BaseObject
 				'$preview'     => ((Feature::isEnabled($conv->getProfileOwner(), 'preview')) ? t('Preview') : ''),
 				'$indent'      => $indent,
 				'$sourceapp'   => t($a->sourcename),
-				'$ww'          => (($conv->getMode() === 'network') ? $ww : ''),
-				'$rand_num'    => random_digits(12))
-			);
+				'$ww'          => $conv->getMode() === 'network' ? $ww : '',
+				'$rand_num'    => random_digits(12)
+			));
 		}
 
 		return $comment_box;
@@ -839,14 +820,13 @@ class Post extends BaseObject
 					$alias_linkmatch = (($this->getDataValue('alias')) && link_compare($this->getDataValue('alias'), $this->getDataValue('author-link')));
 					$owner_namematch = (($this->getDataValue('owner-name')) && $this->getDataValue('owner-name') == $this->getDataValue('author-name'));
 
-					if ((! $owner_linkmatch) && (! $alias_linkmatch) && (! $owner_namematch)) {
+					if ((!$owner_linkmatch) && (!$alias_linkmatch) && (!$owner_namematch)) {
 						// The author url doesn't match the owner (typically the contact)
 						// and also doesn't match the contact alias.
 						// The name match is a hack to catch several weird cases where URLs are
 						// all over the park. It can be tricked, but this prevents you from
 						// seeing "Bob Smith to Bob Smith via Wall-to-wall" and you know darn
 						// well that it's the same Bob Smith.
-
 						// But it could be somebody else with the same name. It just isn't highly likely.
 
 
@@ -854,8 +834,8 @@ class Post extends BaseObject
 						$this->owner_name = $this->getDataValue('owner-name');
 						$this->wall_to_wall = true;
 						// If it is our contact, use a friendly redirect link
-						if ((link_compare($this->getDataValue('owner-link'), $this->getDataValue('url')))
-							&& ($this->getDataValue('network') === NETWORK_DFRN)
+						if ($this->getDataValue('network') === NETWORK_DFRN
+							&& link_compare($this->getDataValue('owner-link'), $this->getDataValue('url'))
 						) {
 							$this->owner_url = $this->getRedirectUrl();
 						} else {

--- a/view/templates/shared_content.tpl
+++ b/view/templates/shared_content.tpl
@@ -5,7 +5,6 @@
 			<img src="{{$avatar}}" height="32" width="32">
 			</a>
 		{{/if}}
-		{{*<span><a href="{{$profile}}" target="_blank" class="shared-wall-item-name">{{$author}}</a> wrote the following <a href="{{$link}}" target="_blank">post</a>{{$reldate}}:</span>*}}
 		<div><a href="{{$profile}}" target="_blank" class="shared-wall-item-name"><span class="shared-author">{{$author}}</span></a></div>
 		<div class="shared-wall-item-ago"><small><a href="{{$link}}" target="_blank"><span class="shared-time">{{$posted}}</a></a></small></div>
 	</div>

--- a/view/theme/frio/style.php
+++ b/view/theme/frio/style.php
@@ -8,7 +8,7 @@ $schemecss = "";
 $schemecssfile = false;
 $scheme_modified = 0;
 
-if (! $a->install) {
+if ($a->module !== 'install') {
 	// Get the UID of the profile owner.
 	$uid = get_theme_uid();
 	if ($uid) {
@@ -57,7 +57,7 @@ if (! $a->install) {
 // Setting $schema to '' wasn't working for some reason, so we'll check it's
 // not --- like the mobile theme does instead.
 // Allow layouts to over-ride the schema.
-if ($_REQUEST['schema']) {
+if (x($_REQUEST, 'schema')) {
 	$schema = $_REQUEST['schema'];
 }
 
@@ -103,7 +103,7 @@ $contentbg_transp = ((isset($contentbg_transp) && $contentbg_transp != "") ? $co
 // Calculate some colors in dependance of existing colors.
 // Some colors are calculated to don't have too many selection
 // fields in the theme settings.
-if (! $menu_background_hover_color) {
+if (!isset($menu_background_hover_color)) {
 	$mbhc = new Color($nav_bg);
 	$mcolor = $mbhc->getHex();
 
@@ -115,7 +115,7 @@ if (! $menu_background_hover_color) {
 		$menu_background_hover_color = '#' . $mbhc->lighten(5);
 	}
 }
-if (! $nav_icon_hover_color) {
+if (!isset($nav_icon_hover_color)) {
 	$nihc = new Color($nav_bg);
 
 	if ($nihc->isLight()) {
@@ -124,7 +124,7 @@ if (! $nav_icon_hover_color) {
 		$nav_icon_hover_color = '#' . $nihc->lighten(10);
 	}
 }
-if (! $link_hover_color) {
+if (!isset($link_hover_color)) {
 	$lhc = new Color($link_color);
 	$lcolor = $lhc->getHex();
 
@@ -137,6 +137,9 @@ if (! $link_hover_color) {
 }
 
 // Convert $bg_image_options into css.
+if (!isset($bg_image_option)) {
+	$bg_image_option = null;
+}
 switch ($bg_image_option) {
 	case "stretch":
 		$background_size_img = "100%";

--- a/view/theme/frio/theme.php
+++ b/view/theme/frio/theme.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Name: frio
  * Description: Bootstrap V3 theme. The theme is currently under construction, so it is far from finished. For further information have a look at the <a href="https://github.com/friendica/friendica/tree/develop/view/theme/frio/README.md">ReadMe</a>.
@@ -18,8 +19,8 @@ $frio = "view/theme/frio";
 
 global $frio;
 
-function frio_init(App $a) {
-
+function frio_init(App $a)
+{
 	// disable the events module link in the profile tab
 	$a->theme_events_in_profile = false;
 
@@ -35,19 +36,21 @@ function frio_init(App $a) {
 
 	// if the device is a mobile device set js is_mobile
 	// variable so the js scripts can use this information
-	if($a->is_mobile || $a->is_tablet) {
+	if ($a->is_mobile || $a->is_tablet) {
 		$a->page["htmlhead"] .= <<< EOT
 			<script type="text/javascript">
 				var is_mobile = 1;
 			</script>
 EOT;
-}
+	}
 
-	if ($style == "")
+	if ($style == "") {
 		$style = Config::get('frio', 'style');
+	}
 }
 
-function frio_install() {
+function frio_install()
+{
 	register_hook('prepare_body_final', 'view/theme/frio/theme.php', 'frio_item_photo_links');
 	register_hook('item_photo_menu', 'view/theme/frio/theme.php', 'frio_item_photo_menu');
 	register_hook('contact_photo_menu', 'view/theme/frio/theme.php', 'frio_contact_photo_menu');
@@ -58,7 +61,8 @@ function frio_install() {
 	logger("installed theme frio");
 }
 
-function frio_uninstall() {
+function frio_uninstall()
+{
 	unregister_hook('prepare_body_final', 'view/theme/frio/theme.php', 'frio_item_photo_links');
 	unregister_hook('item_photo_menu', 'view/theme/frio/theme.php', 'frio_item_photo_menu');
 	unregister_hook('contact_photo_menu', 'view/theme/frio/theme.php', 'frio_contact_photo_menu');
@@ -68,6 +72,7 @@ function frio_uninstall() {
 
 	logger("uninstalled theme frio");
 }
+
 /**
  * @brief Replace friendica photo links hook
  *
@@ -86,19 +91,19 @@ function frio_item_photo_links(App $a, &$body_info)
 	$occurence = 1;
 	$p = bb_find_open_close($body_info['html'], "<a", ">");
 
-	while($p !== false && ($occurence++ < 500)) {
+	while ($p !== false && ($occurence++ < 500)) {
 		$link = substr($body_info['html'], $p['start'], $p['end'] - $p['start']);
 		$matches = array();
 
 		preg_match("/\/photos\/[\w]+\/image\/([\w]+)/", $link, $matches);
-		if($matches) {
+		if ($matches) {
 			// Replace the link for the photo's page with a direct link to the photo itself
 			$newlink = str_replace($matches[0], "/photo/{$matches[1]}", $link);
 
 			// Add a "quiet" parameter to any redir links to prevent the "XX welcomes YY" info boxes
 			$newlink = preg_replace("/href=\"([^\"]+)\/redir\/([^\"]+)&url=([^\"]+)\"/", 'href="$1/redir/$2&quiet=1&url=$3"', $newlink);
 
-			 // Having any arguments to the link for Colorbox causes it to fetch base64 code instead of the image
+			// Having any arguments to the link for Colorbox causes it to fetch base64 code instead of the image
 			$newlink = preg_replace("/\/[?&]zrl=([^&\"]+)/", '', $newlink);
 
 			$body_info['html'] = str_replace($link, $newlink, $body_info['html']);
@@ -118,15 +123,14 @@ function frio_item_photo_links(App $a, &$body_info)
  * @param App $a Unused but required by the hook definition
  * @param array $arr Contains item data and the original photo_menu
  */
-function frio_item_photo_menu(App $a, &$arr) {
-
-	foreach($arr["menu"] as $k =>$v) {
-		if(strpos($v,'poke/?f=&c=') === 0 || strpos($v,'message/new/') === 0) {
+function frio_item_photo_menu(App $a, &$arr)
+{
+	foreach ($arr["menu"] as $k => $v) {
+		if (strpos($v, 'poke/?f=&c=') === 0 || strpos($v, 'message/new/') === 0) {
 			$v = "javascript:addToModal('" . $v . "'); return false;";
 			$arr["menu"][$k] = $v;
 		}
 	}
-	$args = array('item' => $item, 'menu' => $menu);
 }
 
 /**
@@ -141,12 +145,8 @@ function frio_item_photo_menu(App $a, &$arr) {
  * @param App $a The app data
  * @param array $args Contains contact data and the original photo_menu
  */
-function frio_contact_photo_menu(App $a, &$args){
-
-	$pokelink = "";
-	$pmlink = "";
-	$cid = "";
-
+function frio_contact_photo_menu(App $a, &$args)
+{
 	$cid = $args["contact"]["id"];
 	$pokelink = $args["menu"]["poke"][1];
 	$pmlink = $args["menu"]["pm"][1];
@@ -160,8 +160,8 @@ function frio_contact_photo_menu(App $a, &$args){
 	// The value for opening in a new tab is e.g. when
 	// $args["menu"]["status"][2] is true. If the value of the [2] key is true
 	// and if it's a friendica contact we set it to false
-	foreach($args["menu"] as $k =>$v) {
-		if($k === "status" || $k === "profile" || $k === "photos") {
+	foreach ($args["menu"] as $k => $v) {
+		if ($k === "status" || $k === "profile" || $k === "photos") {
 			$v[2] = (($args["contact"]["network"] === "dfrn") ? false : true);
 			$args["menu"][$k][2] = $v[2];
 		}
@@ -170,13 +170,13 @@ function frio_contact_photo_menu(App $a, &$args){
 	// Add to pm and poke links a new key with the value 'modal'.
 	// Later we can make conditions in the corresponing templates (e.g.
 	// contact_template.tpl)
-	if(strpos($pokelink,'poke/?f=&c='. $cid) !== false)
+	if (strpos($pokelink, 'poke/?f=&c=' . $cid) !== false) {
 		$args["menu"]["poke"][3] = "modal";
+	}
 
-	if(strpos($pmlink,'message/new/' . $cid) !== false)
+	if (strpos($pmlink, 'message/new/' . $cid) !== false) {
 		$args["menu"]["pm"][3] = "modal";
-
-	$args = array('contact' => $contact, 'menu' => &$menu);
+	}
 }
 
 /**
@@ -193,11 +193,13 @@ function frio_contact_photo_menu(App $a, &$args){
  * @param App $a The App class
  * @param array $nav The original nav menu
  */
-function frio_remote_nav($a,&$nav) {
+function frio_remote_nav($a, &$nav)
+{
 	// get the homelink from $_XSESSION
 	$homelink = get_my_url();
-	if(! $homelink)
-		$homelink = ((x($_SESSION,'visitor_home')) ? $_SESSION['visitor_home'] : '');
+	if (!$homelink) {
+		$homelink = defaults($_SESSION, 'visitor_home', '');
+	}
 
 	// split up the url in it's parts (protocol,domain/directory, /profile/, nickname
 	// I'm not familiar with regex, so someone might find a better solutionen
@@ -213,7 +215,7 @@ function frio_remote_nav($a,&$nav) {
 	// And construct a webbie (e.g. mickey@friendica.domain.com for the search in gcontact
 	// We use the webbie for search in gcontact because we don't know if gcontact table stores
 	// the right value if its http or https protocol
-	if(count($url_parts)) {
+	if (count($url_parts)) {
 		$server_url = $url_parts[1] . $url_parts[2];
 		$webbie = $url_parts[4] . '@' . $url_parts[2];
 	}
@@ -228,11 +230,9 @@ function frio_remote_nav($a,&$nav) {
 
 		$r[0]['photo'] = (DBM::is_result($r) ? $a->remove_baseurl($r[0]['micro']) : "images/person-48.jpg");
 		$r[0]['name'] = $a->user['username'];
-
 	} elseif (!local_user() && remote_user()) {
 		$r = q("SELECT `name`, `nick`, `micro` AS `photo` FROM `contact` WHERE `id` = %d", intval(remote_user()));
 		$nav['remote'] = t("Guest");
-
 	} elseif (get_my_url()) {
 		$r = q("SELECT `name`, `nick`, `photo` FROM `gcontact`
 				WHERE `addr` = '%s' AND `network` = 'dfrn'",
@@ -243,18 +243,18 @@ function frio_remote_nav($a,&$nav) {
 	}
 
 	if (DBM::is_result($r)) {
-			$nav['userinfo'] = array(
-				'icon' => (DBM::is_result($r) ? $r[0]['photo'] : "images/person-48.jpg"),
-				'name' => $r[0]['name'],
-			);
-		}
+		$nav['userinfo'] = array(
+			'icon' => (DBM::is_result($r) ? $r[0]['photo'] : "images/person-48.jpg"),
+			'name' => $r[0]['name'],
+		);
+	}
 
 	if (!local_user() && !empty($server_url)) {
 		$nav['logout'] = Array($server_url . '/logout', t('Logout'), "", t('End this session'));
 
 		// user menu
 		$nav['usermenu'][] = Array($server_url . '/profile/' . $a->user['nickname'], t('Status'), "", t('Your posts and conversations'));
-		$nav['usermenu'][] = Array($server_url . '/profile/' . $a->user['nickname']. '?tab=profile', t('Profile'), "", t('Your profile page'));
+		$nav['usermenu'][] = Array($server_url . '/profile/' . $a->user['nickname'] . '?tab=profile', t('Profile'), "", t('Your profile page'));
 		$nav['usermenu'][] = Array($server_url . '/photos/' . $a->user['nickname'], t('Photos'), "", t('Your photos'));
 		$nav['usermenu'][] = Array($server_url . '/videos/' . $a->user['nickname'], t('Videos'), "", t('Your videos'));
 		$nav['usermenu'][] = Array($server_url . '/events/', t('Events'), "", t('Your events'));
@@ -263,11 +263,12 @@ function frio_remote_nav($a,&$nav) {
 		$nav['network'] = array($server_url . '/network', t('Network'), "", t('Conversations from your friends'));
 		$nav['events'] = Array($server_url . '/events', t('Events'), "", t('Events and Calendar'));
 		$nav['messages'] = array($server_url . '/message', t('Messages'), "", t('Private mail'));
-		$nav['settings'] = array($server_url . '/settings', t('Settings'),"", t('Account settings'));
-		$nav['contacts'] = array($server_url . '/contacts', t('Contacts'),"", t('Manage/edit friends and contacts'));
+		$nav['settings'] = array($server_url . '/settings', t('Settings'), "", t('Account settings'));
+		$nav['contacts'] = array($server_url . '/contacts', t('Contacts'), "", t('Manage/edit friends and contacts'));
 		$nav['sitename'] = $a->config['sitename'];
 	}
 }
+
 /**
  * @brief: Search for contacts
  *
@@ -281,10 +282,11 @@ function frio_remote_nav($a,&$nav) {
  * @param App $a The app data @TODO Unused
  * @param array $results The array with the originals from acl_lookup()
  */
-function frio_acl_lookup(App $a, &$results) {
-	require_once("mod/contacts.php");
+function frio_acl_lookup(App $a, &$results)
+{
+	require_once 'mod/contacts.php';
 
-	$nets = ((x($_GET,"nets")) ? notags(trim($_GET["nets"])) : "");
+	$nets = x($_GET, "nets") ? notags(trim($_GET["nets"])) : "";
 
 	// we introduce a new search type, r should do the same query like it's
 	// done in /mod/contacts for connections
@@ -295,17 +297,17 @@ function frio_acl_lookup(App $a, &$results) {
 			$search_txt = dbesc(protect_sprintf(preg_quote($search)));
 			$searching = true;
 		}
-		$sql_extra .= (($searching) ? " AND (`attag` LIKE '%%".dbesc($search_txt)."%%' OR `name` LIKE '%%".dbesc($search_txt)."%%' OR `nick` LIKE '%%".dbesc($search_txt)."%%') " : "");
+		$sql_extra = '';
+		if ($searching) {
+			$sql_extra .= " AND (`attag` LIKE '%%" . dbesc($search_txt) . "%%' OR `name` LIKE '%%" . dbesc($search_txt) . "%%' OR `nick` LIKE '%%" . dbesc($search_txt) . "%%') ";
+		}
 
 		if ($nets) {
 			$sql_extra .= sprintf(" AND network = '%s' ", dbesc($nets));
 		}
 
-		$sql_extra2 = ((($sort_type > 0) && ($sort_type <= CONTACT_IS_FRIEND)) ? sprintf(" AND `rel` = %d ",intval($sort_type)) : '');
-
-
 		$r = q("SELECT COUNT(*) AS `total` FROM `contact`
-			WHERE `uid` = %d AND NOT `self` AND NOT `pending` $sql_extra $sql_extra2 ",
+			WHERE `uid` = %d AND NOT `self` AND NOT `pending` $sql_extra ",
 			intval($_SESSION['uid']));
 		if (DBM::is_result($r)) {
 			$total = $r[0]["total"];
@@ -313,7 +315,7 @@ function frio_acl_lookup(App $a, &$results) {
 
 		$sql_extra3 = unavailable_networks();
 
-		$r = q("SELECT * FROM `contact` WHERE `uid` = %d AND NOT `self` AND NOT `pending` $sql_extra $sql_extra2 $sql_extra3 ORDER BY `name` ASC LIMIT 100 ",
+		$r = q("SELECT * FROM `contact` WHERE `uid` = %d AND NOT `self` AND NOT `pending` $sql_extra $sql_extra3 ORDER BY `name` ASC LIMIT 100 ",
 			intval($_SESSION['uid'])
 		);
 
@@ -332,19 +334,19 @@ function frio_acl_lookup(App $a, &$results) {
 
 /**
  * @brief Manipulate the data of the item
- * 
+ *
  * At the moment we use this function to add some own stuff to the item menu
- * 
+ *
  * @param App $a App $a The app data
  * @param array $arr Array with the item and the item actions<br>
  *     'item' => Array with item data<br>
  *     'output' => Array with item actions<br>
  */
-function frio_display_item(App $a,&$arr) {
-
+function frio_display_item(App $a, &$arr)
+{
 	// Add subthread to the item menu
 	$subthread = array();
-	if ((local_user()) && local_user() == $arr['item']['uid'] && $arr['item']['parent'] == $arr['item']['id'] && (! $arr['item']['self'])) {
+	if (local_user() == $arr['item']['uid'] && $arr['item']['parent'] == $arr['item']['id'] && !$arr['item']['self']) {
 		$subthread = array(
 			'menu'   => 'follow_thread',
 			'title'  => t('Follow Thread'),


### PR DESCRIPTION
I made a terrible mistake.

While I was working on my other PRs, I set the error_reporting level to E_ALL, which instantly filled my Apache error log with tens of PHP notices each time I was loading any page on Friendica.

Once I was done with #4152 and #4156, while I was waiting for @annando to review them, I started fixing the notices, one by one. At first it was pretty innocent, but it rapidly became a drug, and I added formatting fixes on top of it because I couldn't stand missing condition braces or uneven spacing.

It became quickly evident that I wasn't waiting for @annando anymore and that I was caught in the tidying up process too deep.

What saved me? I didn't add error_reporting to the worker scripts, Lord knows that I would still be at it right now.

The result? This monstrosity, better enjoyed at small doses, a commit after the other, like an epic fantasy saga. Sorry in advance for anyone trying to review it, and thanks.

Sometimes I wonder how Friendica can even work with all those silly code mistakes that the PHP engines has to compensate for.