### PR TITLE
Commenting to (nearly) every Friendica contact is now possible

### DIFF
--- a/include/conversation.php
+++ b/include/conversation.php
@@ -624,7 +624,7 @@ function conversation(App $a, $items, $mode, $update, $preview = false) {
 				$community_readonly = false;
 				$writable = true;
 			} else {
-				$writable = ($items[0]['uid'] == 0) && in_array($items[0]['network'], array(NETWORK_OSTATUS, NETWORK_DIASPORA));
+				$writable = ($items[0]['uid'] == 0) && in_array($items[0]['network'], array(NETWORK_OSTATUS, NETWORK_DIASPORA, NETWORK_DFRN));
 			}
 		} else {
 			$writable = false;
@@ -929,6 +929,7 @@ function community_add_items($parents) {
 		);
 		$comments = dba::inArray($thread_items);
 
+
 		if (count($comments) == 0) {
 			$thread_items = dba::p(item_query()." AND `item`.`uid` = 0
 				AND `item`.`parent-uri` = ?
@@ -945,7 +946,7 @@ function community_add_items($parents) {
 
 	foreach ($items as $index => $item) {
 		if ($item['uid'] == 0) {
-			$items[$index]['writable'] = in_array($item['network'], [NETWORK_DIASPORA, NETWORK_OSTATUS]);
+			$items[$index]['writable'] = in_array($item['network'], [NETWORK_OSTATUS, NETWORK_DIASPORA, NETWORK_DFRN]);
 		}
 	}
 

--- a/mod/item.php
+++ b/mod/item.php
@@ -209,7 +209,7 @@ function item_post(App $a) {
 	}
 
 	// Allow commenting if it is an answer to a public post
-	$allow_comment = ($profile_uid == 0) && $parent && in_array($parent_item['network'], [NETWORK_OSTATUS, NETWORK_DIASPORA]);
+	$allow_comment = ($profile_uid == 0) && $parent && in_array($parent_item['network'], [NETWORK_OSTATUS, NETWORK_DIASPORA, NETWORK_DFRN]);
 
 	/*
 	 * Now check that it is a page_type of PAGE_BLOG, and that valid personal details

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -3114,7 +3114,15 @@ class Diaspora
 		}
 
 		$logid = random_string(4);
-		$dest_url = (($public_batch) ? $contact["batch"] : $contact["notify"]);
+		$dest_url = ($public_batch ? $contact["batch"] : $contact["notify"]);
+
+		// Fetch the fcontact entry when there is missing data
+		// Will possibly happen when data is transmitted to a DFRN contact
+		if (empty($dest_url) && !empty($contact['addr'])) {
+			$fcontact = self::personByHandle($contact['addr']);
+			$dest_url = ($public_batch ? $fcontact["batch"] : $fcontact["notify"]);
+		}
+
 		if (!$dest_url) {
 			logger("no url for contact: ".$contact["id"]." batch mode =".$public_batch);
 			return 0;

--- a/src/Worker/Delivery.php
+++ b/src/Worker/Delivery.php
@@ -217,9 +217,14 @@ class Delivery {
 		}
 		$deliver_status = 0;
 
+		// Transmit via Diaspora if not possible via Friendica
+		if (($item['uid'] == 0) && ($contact['network'] == NETWORK_DFRN)) {
+			$contact['network'] = NETWORK_DIASPORA;
+		}
+
 		logger("main delivery by delivery: followup=$followup mail=$mail fsuggest=$fsuggest relocate=$relocate - network ".$contact['network']);
 
-		switch($contact['network']) {
+		switch ($contact['network']) {
 
 			case NETWORK_DFRN:
 				logger('notifier: '.$target_item["guid"].' dfrndelivery: '.$contact['name']);


### PR DESCRIPTION
This is part of https://github.com/friendica/friendica/issues/4117 as well.

This is a workaround to enable communication with Friendica users we aren't in contact with. We now are using the Diaspora protocol (only for these users).

It seems to work, but there had been no tests for side effects until now.