### PR TITLE
Disable editing of public items / Reshare of community items

### DIFF
--- a/mod/community.php
+++ b/mod/community.php
@@ -81,6 +81,22 @@ function community_content(App $a, $update = 0) {
 		$o .= replace_macros($tab_tpl, array('$tabs' => $tabs));
 
 		nav_set_selected('community');
+
+		// We need the editor here to be able to reshare an item.
+		if (local_user()) {
+			$x = array(
+				'is_owner' => true,
+				'allow_location' => $a->user['allow_location'],
+				'default_location' => $a->user['default-location'],
+				'nickname' => $a->user['nickname'],
+				'lockstate' => (is_array($a->user) && (strlen($a->user['allow_cid']) || strlen($a->user['allow_gid']) || strlen($a->user['deny_cid']) || strlen($a->user['deny_gid'])) ? 'lock' : 'unlock'),
+				'acl' => populate_acl($a->user, true),
+				'bang' => '',
+				'visitor' => 'block',
+				'profile_uid' => local_user(),
+			);
+			$o .= status_editor($a, $x, 0, true);
+		}
 	}
 
 	if (Config::get('system', 'comment_public')) {

--- a/src/Object/Post.php
+++ b/src/Object/Post.php
@@ -155,6 +155,13 @@ class Post extends BaseObject
 			$edpost = false;
 		}
 
+		// Editing on items of not subscribed users isn't currently possible
+		// There are some issues on editing that prevent this.
+		// But also it is an issue of the supported protocols that doesn't allow editing at all.
+		if ($item['uid'] == 0) {
+			$edpost = false;
+		}
+
 		if (($this->getDataValue('uid') == local_user()) || $this->isVisiting()) {
 			$dropping = true;
 		}


### PR DESCRIPTION
Part of https://github.com/friendica/friendica/issues/4117

Editing of these items is currently disabled. This has two reasons:

1. It needs some work
2. It would only work for DFRN - which we currently can't use for this

Additionally now the "reshare" button does work on the community page.