### PR TITLE
 Fix OEmbed iframe

### DIFF
--- a/include/bbcode.php
+++ b/include/bbcode.php
@@ -586,8 +586,8 @@ function bb_ShareAttributes($share, $simplehtml)
 			}
 			break;
 		default:
-			// Transforms quoted tweets in rich attachments to avoid nested tweetsx
-			if (stripos(normalise_link($link), 'http://twitter.com/') === 0) {
+			// Transforms quoted tweets in rich attachments to avoid nested tweets
+			if (stripos(normalise_link($link), 'http://twitter.com/') === 0 && OEmbed::isAllowedURL($link)) {
 				$bookmark = array(sprintf('[bookmark=%s]%s[/bookmark]', $link, $preshare), $link, $preshare);
 				$text = $preshare . tryoembed($bookmark);
 			} else {

--- a/include/bbcode.php
+++ b/include/bbcode.php
@@ -76,7 +76,7 @@ function bb_attachment($Text, $simplehtml = false, $tryoembed = true) {
 			$oembed = $bookmark[0];
 		}
 
-		if (strstr(strtolower($oembed), "<iframe ")) {
+		if (stripos($oembed, "<iframe ") !== false) {
 			$text = $oembed;
 		} else {
 			if (($data["image"] != "") && !strstr(strtolower($oembed), "<img ")) {
@@ -541,7 +541,7 @@ function bb_ShareAttributes($share, $simplehtml)
 				$text .= "<hr />";
 			}
 
-			if (substr(normalise_link($link), 0, 19) != "http://twitter.com/") {
+			if (stripos(normalise_link($link), 'http://twitter.com/') === 0) {
 				$text .= $headline . '<blockquote>' . trim($share[3]) . "</blockquote><br />";
 
 				if ($link != "") {
@@ -586,20 +586,26 @@ function bb_ShareAttributes($share, $simplehtml)
 			}
 			break;
 		default:
-			$text = trim($share[1]) . "\n";
+			// Transforms quoted tweets in rich attachments to avoid nested tweetsx
+			if (stripos(normalise_link($link), 'http://twitter.com/') === 0) {
+				$bookmark = array(sprintf('[bookmark=%s]%s[/bookmark]', $link, $preshare), $link, $preshare);
+				$text = $preshare . tryoembed($bookmark);
+			} else {
+				$text = trim($share[1]) . "\n";
 
-			$avatar = proxy_url($avatar, false, PROXY_SIZE_THUMB);
+				$avatar = proxy_url($avatar, false, PROXY_SIZE_THUMB);
 
-			$tpl = get_markup_template('shared_content.tpl');
-			$text .= replace_macros($tpl, array(
-					'$profile' => $profile,
-					'$avatar' => $avatar,
-					'$author' => $author,
-					'$link' => $link,
-					'$posted' => $posted,
-					'$content' => trim($share[3])
-				)
-			);
+				$tpl = get_markup_template('shared_content.tpl');
+				$text .= replace_macros($tpl, array(
+						'$profile' => $profile,
+						'$avatar' => $avatar,
+						'$author' => $author,
+						'$link' => $link,
+						'$posted' => $posted,
+						'$content' => trim($share[3])
+					)
+				);
+			}
 			break;
 	}
 

--- a/include/bbcode.php
+++ b/include/bbcode.php
@@ -40,8 +40,19 @@ function bb_map_location($match) {
 	return str_replace($match[0], '<div class="map"  >' . Map::byLocation($match[1]) . '</div>', $match[0]);
 }
 
-function bb_attachment($Text, $simplehtml = false, $tryoembed = true) {
-
+/**
+ * Processes [attachment] tags
+ *
+ * Note: Can produce a [bookmark] tag in the returned string
+ *
+ * @brief Processes [attachment] tags
+ * @param string $Text
+ * @param bool|int $simplehtml
+ * @param bool $tryoembed
+ * @return string
+ */
+function bb_attachment($Text, $simplehtml = false, $tryoembed = true)
+{
 	$data = get_attachment_data($Text);
 	if (!$data) {
 		return $Text;
@@ -52,10 +63,7 @@ function bb_attachment($Text, $simplehtml = false, $tryoembed = true) {
 		$data["title"] = str_replace(array("http://", "https://"), "", $data["title"]);
 	}
 
-	if (((strpos($data["text"], "[img=") !== false)
-		|| (strpos($data["text"], "[img]") !== false)
-		|| Config::get('system', 'always_show_preview'))
-		&& ($data["image"] != "")) {
+	if (((strpos($data["text"], "[img=") !== false) || (strpos($data["text"], "[img]") !== false) || Config::get('system', 'always_show_preview')) && ($data["image"] != "")) {
 		$data["preview"] = $data["image"];
 		$data["image"] = "";
 	}
@@ -69,11 +77,13 @@ function bb_attachment($Text, $simplehtml = false, $tryoembed = true) {
 			$text = sprintf('<span class="type-%s">', $data["type"]);
 		}
 
-		$bookmark = array(sprintf('[bookmark=%s]%s[/bookmark]', $data["url"], $data["title"]), $data["url"], $data["title"]);
+		$oembed = sprintf('[bookmark=%s]%s[/bookmark]', $data['url'], $data['title']);
 		if ($tryoembed) {
-			$oembed = tryoembed($bookmark);
-		} else {
-			$oembed = $bookmark[0];
+			try {
+				$oembed = OEmbed::getHTML($data['url'], $data['title']);
+			} catch (Exception $e) {
+				// $oembed isn't modified
+			}
 		}
 
 		if (stripos($oembed, "<iframe ") !== false) {
@@ -100,7 +110,7 @@ function bb_attachment($Text, $simplehtml = false, $tryoembed = true) {
 			$text .= '</span>';
 		}
 	}
-	return trim($data["text"].' '.$text.' '.$data["after"]);
+	return trim($data["text"] . ' ' . $text . ' ' . $data["after"]);
 }
 
 function bb_remove_share_information($Text, $plaintext = false, $nolink = false) {
@@ -221,32 +231,6 @@ function style_url_for_mastodon($url) {
 
 function stripcode_br_cb($s) {
 	return '[code]' . str_replace('<br />', '', $s[1]) . '[/code]';
-}
-
-function tryoembed($match) {
-	$url = $match[1];
-
-	// Always embed the SSL version
-	$url = str_replace(array("http://www.youtube.com/", "http://player.vimeo.com/"),
-				array("https://www.youtube.com/", "https://player.vimeo.com/"), $url);
-
-	$o = OEmbed::fetchURL($url);
-
-	if (!is_object($o)) {
-		return $match[0];
-	}
-
-	if (isset($match[2])) {
-		$o->title = $match[2];
-	}
-
-	if ($o->type == "error") {
-		return $match[0];
-	}
-
-	$html = OEmbed::formatObject($o);
-
-	return $html;
 }
 
 /*
@@ -432,6 +416,16 @@ function bb_replace_images($body, $images) {
 	return $newbody;
 }
 
+/**
+ * Processes [share] tags
+ *
+ * Note: Can produce a [bookmark] tag in the output
+ *
+ * @brief Processes [share] tags
+ * @param array    $share      preg_match_callback result array
+ * @param bool|int $simplehtml
+ * @return string
+ */
 function bb_ShareAttributes($share, $simplehtml)
 {
 	$attributes = $share[2];
@@ -520,7 +514,6 @@ function bb_ShareAttributes($share, $simplehtml)
 	}
 
 	$preshare = trim($share[1]);
-
 	if ($preshare != "") {
 		$preshare .= "<br /><br />";
 	}
@@ -588,8 +581,13 @@ function bb_ShareAttributes($share, $simplehtml)
 		default:
 			// Transforms quoted tweets in rich attachments to avoid nested tweets
 			if (stripos(normalise_link($link), 'http://twitter.com/') === 0 && OEmbed::isAllowedURL($link)) {
-				$bookmark = array(sprintf('[bookmark=%s]%s[/bookmark]', $link, $preshare), $link, $preshare);
-				$text = $preshare . tryoembed($bookmark);
+				try {
+					$oembed = OEmbed::getHTML($link, $preshare);
+				} catch (Exception $e) {
+					$oembed = sprintf('[bookmark=%s]%s[/bookmark]', $link, $preshare);
+				}
+
+				$text = $preshare . $oembed;
 			} else {
 				$text = trim($share[1]) . "\n";
 
@@ -597,14 +595,13 @@ function bb_ShareAttributes($share, $simplehtml)
 
 				$tpl = get_markup_template('shared_content.tpl');
 				$text .= replace_macros($tpl, array(
-						'$profile' => $profile,
-						'$avatar' => $avatar,
-						'$author' => $author,
-						'$link' => $link,
-						'$posted' => $posted,
-						'$content' => trim($share[3])
-					)
-				);
+					'$profile' => $profile,
+					'$avatar' => $avatar,
+					'$author' => $author,
+					'$link' => $link,
+					'$posted' => $posted,
+					'$content' => trim($share[3])
+				));
 			}
 			break;
 	}

--- a/src/Content/OEmbed.php
+++ b/src/Content/OEmbed.php
@@ -15,6 +15,7 @@ use dba;
 use DOMDocument;
 use DOMXPath;
 use DOMNode;
+use Exception;
 
 require_once 'include/dba.php';
 require_once 'mod/proxy.php';
@@ -303,6 +304,27 @@ class OEmbed
 		$allowed = explode(',', $str_allowed);
 
 		return allowed_domain($domain, $allowed, true);
+	}
+
+	public static function getHTML($url, $title = null)
+	{
+		// Always embed the SSL version
+		$url = str_replace(array("http://www.youtube.com/", "http://player.vimeo.com/"),
+					array("https://www.youtube.com/", "https://player.vimeo.com/"), $url);
+
+		$o = OEmbed::fetchURL($url);
+
+		if (!is_object($o) || $o->type == 'error') {
+			throw new Exception('OEmbed failed for URL: ' . $url);
+		}
+
+		if (x($title)) {
+			$o->title = $title;
+		}
+
+		$html = OEmbed::formatObject($o);
+
+		return $html;
 	}
 
 	/**

--- a/src/Content/OEmbed.php
+++ b/src/Content/OEmbed.php
@@ -285,6 +285,27 @@ class OEmbed
 	}
 
 	/**
+	 * Determines if rich content OEmbed is allowed for the provided URL
+	 *
+	 * @brief Determines if rich content OEmbed is allowed for the provided URL
+	 * @param string $url
+	 * @return boolean
+	 */
+	public static function isAllowedURL($url)
+	{
+		if (!Config::get('system', 'no_oembed_rich_content')) {
+			return true;
+		}
+
+		$domain = parse_url($url, PHP_URL_HOST);
+
+		$str_allowed = Config::get('system', 'allowed_oembed', '');
+		$allowed = explode(',', $str_allowed);
+
+		return allowed_domain($domain, $allowed, true);
+	}
+
+	/**
 	 * @brief Generates the iframe HTML for an oembed attachment.
 	 *
 	 * Width and height are given by the remote, and are regularly too small for
@@ -352,24 +373,4 @@ class OEmbed
 		return $innerHTML;
 	}
 
-	/**
-	 * Determines if rich content OEmbed is allowed for the provided URL
-	 *
-	 * @brief Determines if rich content OEmbed is allowed for the provided URL
-	 * @param string $url
-	 * @return boolean
-	 */
-	private static function isAllowedURL($url)
-	{
-		if (!Config::get('system', 'no_oembed_rich_content')) {
-			return true;
-		}
-
-		$domain = parse_url($url, PHP_URL_HOST);
-
-		$str_allowed = Config::get('system', 'allowed_oembed', '');
-		$allowed = explode(',', $str_allowed);
-
-		return allowed_domain($domain, $allowed, true);
-	}
 }


### PR DESCRIPTION
Fixes #4173

I finally got a chance to really dive deep into OEmbed, and I gotta say it's pretty cool as it allows to add HTML to display rich third-party content embeds.

Of course, this means that bad actors can add harmful scripts to their OEmbed snippets and harvest data on our local website. So far, we relied on a same domain iframe to mitigate the issue which would actually do very little while adding complexity.

Now we have a domain whitelist to allow specific domains to embed their HTML in Friendica posts (#4167) and we don't use the same domain iframe anymore. I left the function in the code in case someone wants to implement a different OEmbed domain settings.

I also tackled an issue that was bugging me for a while. We receive quote tweets from Twitter as shares, and if the quoted tweet mentions another tweet, it is treated as a link attachment and the display is mangled.

Instead, the quoted tweet is now treated as a rich attachment for display purposes and we let Twitter decide to display mentioned links (or not).

Caveat: Let's Encrypt for Apache2 on Debian Stretch sets X-Frame-Options=SAMEORIGIN for all requests, which effectively kills most iframe-based embeds, including WordPress. Unless people comment out the `Header always set X-Frame-Options SAMEORIGIN` line in their Let's Encrypt configuration file (`/etc/letsencrypt/options-ssl-apache.conf` on Debian), there's nothing to do to fix those embeds.
  