### PR TITLE
Removed directory setting from htconfig.md and changed the example

### DIFF
--- a/doc/htconfig.md
+++ b/doc/htconfig.md
@@ -13,9 +13,9 @@ Or it is for testing purposes only.
 Especially don't do that with undocumented values.
 
 The header of the section describes the category, the value is the parameter.
-Example: To set the directory value please add this line to your .htconfig.php:
+Example: To set the automatic database cleanup process add this line to your .htconfig.php:
 
-    $a->config['system']['directory'] = 'http://dir.friendica.social';
+    $a->config['system']['dbclean'] = true;
 
 ## jabber ##
 * **debug** (Boolean) - Enable debug level for the jabber account synchronisation.
@@ -38,7 +38,6 @@ Example: To set the directory value please add this line to your .htconfig.php:
 * **dbclean** (Boolean) - Enable the automatic database cleanup process
 * **dbclean-expire-days** (Integer) - Days after which remote items will be deleted. Own items, and marked or filed items are kept.
 * **diaspora_test** (Boolean) - For development only. Disables the message transfer.
-* **directory** - The path to global directory. If not set then "http://dir.friendica.social" is used.
 * **disable_email_validation** (Boolean) - Disables the check if a mail address is in a valid format and can be resolved via DNS.
 * **disable_url_validation** (Boolean) - Disables the DNS lookup of an URL.
 * **dlogfile - location of the developer log file


### PR DESCRIPTION
Found out, that the setting for the used directory server can now be done via the admin panel, so I removed it from the documentation file 'htconfig.md' and changed the example in the description.