### PR TITLE
Improve PHP Code Sniffer ruleset

### DIFF
--- a/ruleset.xml
+++ b/ruleset.xml
@@ -1,6 +1,15 @@
 <?xml version="1.0"?>
-<ruleset>
-	<rule ref="PSR2">
-		<exclude name="Generic.WhiteSpace.DisallowTabIndent"/>
-	</rule>
+<ruleset name="Friendica">
+    <description>Friendica Coding Standards: PSR2 with tabs instead of spaces</description>
+    <arg name="tab-width" value="4"/>
+    <rule ref="PSR2">
+        <exclude name="Generic.WhiteSpace.DisallowTabIndent"/>
+    </rule>
+    <rule ref="Generic.WhiteSpace.DisallowSpaceIndent"/>
+    <rule ref="Generic.WhiteSpace.ScopeIndent">
+        <properties>
+            <property name="indent" value="4"/>
+            <property name="tabIndent" value="true"/>
+        </properties>
+    </rule>
 </ruleset>

--- a/vendor/pear/text_languagedetect/phpcs.xml
+++ b/vendor/pear/text_languagedetect/phpcs.xml
@@ -4,23 +4,5 @@
   <!-- we keep the old php4-style variable names for now -->
   <exclude name="PEAR.NamingConventions.ValidFunctionName.PublicUnderscore"/>
   <exclude name="PEAR.NamingConventions.ValidVariableName.PublicUnderscore"/>
-  <exclude name="PEAR.NamingConventions.ValidVariableName.PrivateNoUnderscore"/>
-  <exclude name="PEAR.NamingConventions.ValidFunctionName.PrivateNoUnderscore"/>
-  <exclude name="PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps"/>
-  <exclude name="PEAR.WhiteSpace.ScopeIndent.IncorrectExact"/>
-  <exclude name="PSR1.Methods.CamelCapsMethodName.NotCamelCaps"/>
- </rule>
- <description>PSR2 with tabs instead of spaces.</description>
- <arg name="tab-width" value="4"/>
- <rule ref="PSR2">
-     <exclude name="Generic.WhiteSpace.DisallowTabIndent"/>
-     <exclude name="Generic.Commenting.DocComment.MissingShort"/>
- </rule>
- <rule ref="Generic.WhiteSpace.DisallowSpaceIndent"/>
- <rule ref="Generic.WhiteSpace.ScopeIndent">
-     <properties>
-         <property name="indent" value="4"/>
-         <property name="tabIndent" value="true"/>
-     </properties>
  </rule>
 </ruleset>


### PR DESCRIPTION
Part of #2103
Follow-up to #4123

- Pull Friendica specifics from
vendor/pear/text_languagedetect/phpcs.xml
- Revert changes to vendor/pear/text_languagedetect/phpcs.xml

Thanks @zeroadam for finding out about the correct rules in the first place.