### PR TITLE
Fix oembed iframe url for Facebook attachments

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -43,7 +43,7 @@ define('FRIENDICA_PLATFORM',     'Friendica');
 define('FRIENDICA_CODENAME',     'Asparagus');
 define('FRIENDICA_VERSION',      '3.6-dev');
 define('DFRN_PROTOCOL_VERSION',  '2.23');
-define('DB_UPDATE_VERSION',      1239);
+define('DB_UPDATE_VERSION',      1240);
 define('NEW_UPDATE_ROUTINE_VERSION', 1170);
 
 /**

--- a/doc/database/db_oembed.md
+++ b/doc/database/db_oembed.md
@@ -4,6 +4,7 @@ Table oembed
 | Field        | Description                        | Type         | Null | Key | Default             | Extra |
 | ------------ | ---------------------------------- | ------------ | ---- | --- | ------------------- | ----- |
 | url          | page url                           | varchar(255) | NO   | PRI | NULL                |       |
+| maxwidth     | Maximum width passed to Oembed     | int(11)      | NO   | PRI | 0                   |       |
 | content      | OEmbed data of the page            | text         | NO   |     | NULL                |       |
 | created      | datetime of creation               | datetime     | NO   | MUL | 0001-01-01 00:00:00 |       |
 

--- a/src/Content/OEmbed.php
+++ b/src/Content/OEmbed.php
@@ -47,8 +47,8 @@ class OEmbed
 	 * @param string $embedurl The URL from which the data should be fetched.
 	 * @param bool $no_rich_type If set to true rich type content won't be fetched.
 	 *
-	 * @return bool|object Returns object with embed content or false if no embedable
-	 * 	 content exists
+	 * @return bool|object Returns object with embed content or false if no embeddable
+	 * 	                   content exists
 	 */
 	public static function fetchURL($embedurl, $no_rich_type = false)
 	{
@@ -57,7 +57,7 @@ class OEmbed
 
 		$a = get_app();
 
-		$condition = ['url' => normalise_link($embedurl)];
+		$condition = ['url' => normalise_link($embedurl), 'maxwidth' => $a->videowidth];
 		$r = dba::selectFirst('oembed', ['content'], $condition);
 		if (DBM::is_result($r)) {
 			$txt = $r["content"];
@@ -105,8 +105,12 @@ class OEmbed
 			} else { //save in cache
 				$j = json_decode($txt);
 				if ($j->type != "error") {
-					dba::insert('oembed', array('url' => normalise_link($embedurl),
-						'content' => $txt, 'created' => datetime_convert()), true);
+					dba::insert('oembed', [
+						'url' => normalise_link($embedurl),
+						'maxwidth' => $a->videowidth,
+						'content' => $txt,
+						'created' => datetime_convert()
+					], true);
 				}
 
 				Cache::set($a->videowidth . $embedurl, $txt, CACHE_DAY);
@@ -306,7 +310,7 @@ class OEmbed
 		if (!x($str_allowed)) {
 			return false;
 		}
-		
+
 		$allowed = explode(',', $str_allowed);
 
 		return allowed_domain($domain, $allowed);

--- a/src/Database/DBStructure.php
+++ b/src/Database/DBStructure.php
@@ -1277,11 +1277,12 @@ class DBStructure {
 		$database["oembed"] = array(
 				"fields" => array(
 						"url" => array("type" => "varbinary(255)", "not null" => "1", "primary" => "1"),
+						"maxwidth" => array("type" => "int(11)", "not null" => "1", "primary" => "1"),
 						"content" => array("type" => "mediumtext"),
 						"created" => array("type" => "datetime", "not null" => "1", "default" => NULL_DATE),
 						),
 				"indexes" => array(
-						"PRIMARY" => array("url"),
+						"PRIMARY" => array("url", "maxwidth"),
 						"created" => array("created"),
 						)
 				);

--- a/view/theme/frio/theme.php
+++ b/view/theme/frio/theme.php
@@ -23,6 +23,7 @@ function frio_init(App $a)
 {
 	// disable the events module link in the profile tab
 	$a->theme_events_in_profile = false;
+	$a->videowidth = 622;
 
 	$a->set_template_engine('smarty3');
 


### PR DESCRIPTION
Part of #4173
Follow-up to #4179 and #4183

If the OEmbed HTML code didn't feature an iframe tag, we were rewriting the whole attachment from scratch.

Since we now provide with a OEmbed whitelist, we don't need to be as guarded with OEmbed snippets.

This PR also sets the videowidth to 622px for frio theme, which allows embedded content to take the maximum space that the frio theme allows.