### PR TITLE
Replace dba::select(limit => 1) by dba::selectFirst()

### DIFF
--- a/include/api.php
+++ b/include/api.php
@@ -222,7 +222,7 @@ function api_login(App $a)
 	} else {
 		$user_id = User::authenticate(trim($user), trim($password));
 		if ($user_id) {
-			$record = dba::select('user', [], ['uid' => $user_id], ['limit' => 1]);
+			$record = dba::selectOne('user', [], ['uid' => $user_id]);
 		}
 	}
 
@@ -473,7 +473,7 @@ function api_rss_extra(App $a, $arr, $user_info)
  */
 function api_unique_id_to_nurl($id)
 {
-	$r = dba::select('contact', array('nurl'), array('uid' => 0, 'id' => $id), array('limit' => 1));
+	$r = dba::selectOne('contact', array('nurl'), array('uid' => 0, 'id' => $id));
 
 	if (DBM::is_result($r)) {
 		return $r["nurl"];
@@ -792,7 +792,7 @@ function api_get_user(App $a, $contact_id = null)
 
 	// If this is a local user and it uses Frio, we can get its color preferences.
 	if ($ret['self']) {
-		$theme_info = dba::select('user', ['theme'], ['uid' => $ret['uid']], ['limit' => 1]);
+		$theme_info = dba::selectOne('user', ['theme'], ['uid' => $ret['uid']]);
 		if ($theme_info['theme'] === 'frio') {
 			$schema = PConfig::get($ret['uid'], 'frio', 'schema');
 			if ($schema && ($schema != '---')) {
@@ -4870,7 +4870,7 @@ function api_friendica_remoteauth()
 
 	// traditional DFRN
 
-	$r = dba::select('contact', [], ['uid' => api_user(), 'nurl' => $c_url], ['limit' => 1]);
+	$r = dba::selectOne('contact', [], ['uid' => api_user(), 'nurl' => $c_url]);
 
 	if (!DBM::is_result($r) || ($r['network'] !== NETWORK_DFRN)) {
 		throw new BadRequestException("Unknown contact");

--- a/include/api.php
+++ b/include/api.php
@@ -222,7 +222,7 @@ function api_login(App $a)
 	} else {
 		$user_id = User::authenticate(trim($user), trim($password));
 		if ($user_id) {
-			$record = dba::selectOne('user', [], ['uid' => $user_id]);
+			$record = dba::selectFirst('user', [], ['uid' => $user_id]);
 		}
 	}
 
@@ -473,7 +473,7 @@ function api_rss_extra(App $a, $arr, $user_info)
  */
 function api_unique_id_to_nurl($id)
 {
-	$r = dba::selectOne('contact', array('nurl'), array('uid' => 0, 'id' => $id));
+	$r = dba::selectFirst('contact', array('nurl'), array('uid' => 0, 'id' => $id));
 
 	if (DBM::is_result($r)) {
 		return $r["nurl"];
@@ -792,7 +792,7 @@ function api_get_user(App $a, $contact_id = null)
 
 	// If this is a local user and it uses Frio, we can get its color preferences.
 	if ($ret['self']) {
-		$theme_info = dba::selectOne('user', ['theme'], ['uid' => $ret['uid']]);
+		$theme_info = dba::selectFirst('user', ['theme'], ['uid' => $ret['uid']]);
 		if ($theme_info['theme'] === 'frio') {
 			$schema = PConfig::get($ret['uid'], 'frio', 'schema');
 			if ($schema && ($schema != '---')) {
@@ -4870,7 +4870,7 @@ function api_friendica_remoteauth()
 
 	// traditional DFRN
 
-	$r = dba::selectOne('contact', [], ['uid' => api_user(), 'nurl' => $c_url]);
+	$r = dba::selectFirst('contact', [], ['uid' => api_user(), 'nurl' => $c_url]);
 
 	if (!DBM::is_result($r) || ($r['network'] !== NETWORK_DFRN)) {
 		throw new BadRequestException("Unknown contact");

--- a/include/contact_widgets.php
+++ b/include/contact_widgets.php
@@ -224,12 +224,12 @@ function common_friends_visitor_widget($profile_uid)
 
 	if (!$cid) {
 		if (get_my_url()) {
-			$r = dba::select('contact', array('id'),
-					array('nurl' => normalise_link(get_my_url()), 'uid' => $profile_uid), array('limit' => 1));
+			$r = dba::selectOne('contact', ['id'],
+					['nurl' => normalise_link(get_my_url()), 'uid' => $profile_uid]);
 			if (DBM::is_result($r)) {
 				$cid = $r['id'];
 			} else {
-				$r = dba::select('gcontact', array('id'), array('nurl' => normalise_link(get_my_url())), array('limit' => 1));
+				$r = dba::selectOne('gcontact', ['id'], ['nurl' => normalise_link(get_my_url())]);
 				if (DBM::is_result($r)) {
 					$zcid = $r['id'];
 				}

--- a/include/contact_widgets.php
+++ b/include/contact_widgets.php
@@ -224,12 +224,12 @@ function common_friends_visitor_widget($profile_uid)
 
 	if (!$cid) {
 		if (get_my_url()) {
-			$r = dba::selectOne('contact', ['id'],
+			$r = dba::selectFirst('contact', ['id'],
 					['nurl' => normalise_link(get_my_url()), 'uid' => $profile_uid]);
 			if (DBM::is_result($r)) {
 				$cid = $r['id'];
 			} else {
-				$r = dba::selectOne('gcontact', ['id'], ['nurl' => normalise_link(get_my_url())]);
+				$r = dba::selectFirst('gcontact', ['id'], ['nurl' => normalise_link(get_my_url())]);
 				if (DBM::is_result($r)) {
 					$zcid = $r['id'];
 				}

--- a/include/conversation.php
+++ b/include/conversation.php
@@ -968,9 +968,8 @@ function best_link_url($item, &$sparkle, $url = '') {
 	$clean_url = normalise_link($item['author-link']);
 
 	if (local_user()) {
-		$r = dba::select('contact', array('id'),
-			array('network' => NETWORK_DFRN, 'uid' => local_user(), 'nurl' => normalise_link($clean_url), 'pending' => false),
-			array('limit' => 1));
+		$r = dba::selectOne('contact', ['id'],
+			['network' => NETWORK_DFRN, 'uid' => local_user(), 'nurl' => normalise_link($clean_url), 'pending' => false]);
 		if (DBM::is_result($r)) {
 			$best_url = 'redir/' . $r['id'];
 			$sparkle = true;
@@ -1020,7 +1019,7 @@ function item_photo_menu($item) {
 	$cid = 0;
 	$network = '';
 	$rel = 0;
-	$r = dba::select('contact', array('id', 'network', 'rel'), array('uid' => local_user(), 'nurl' => normalise_link($item['author-link'])), array('limit' => 1));
+	$r = dba::selectOne('contact', array('id', 'network', 'rel'), array('uid' => local_user(), 'nurl' => normalise_link($item['author-link'])));
 	if (DBM::is_result($r)) {
 		$cid = $r['id'];
 		$network = $r['network'];

--- a/include/conversation.php
+++ b/include/conversation.php
@@ -968,7 +968,7 @@ function best_link_url($item, &$sparkle, $url = '') {
 	$clean_url = normalise_link($item['author-link']);
 
 	if (local_user()) {
-		$r = dba::selectOne('contact', ['id'],
+		$r = dba::selectFirst('contact', ['id'],
 			['network' => NETWORK_DFRN, 'uid' => local_user(), 'nurl' => normalise_link($clean_url), 'pending' => false]);
 		if (DBM::is_result($r)) {
 			$best_url = 'redir/' . $r['id'];
@@ -1019,7 +1019,7 @@ function item_photo_menu($item) {
 	$cid = 0;
 	$network = '';
 	$rel = 0;
-	$r = dba::selectOne('contact', array('id', 'network', 'rel'), array('uid' => local_user(), 'nurl' => normalise_link($item['author-link'])));
+	$r = dba::selectFirst('contact', array('id', 'network', 'rel'), array('uid' => local_user(), 'nurl' => normalise_link($item['author-link'])));
 	if (DBM::is_result($r)) {
 		$cid = $r['id'];
 		$network = $r['network'];

--- a/include/dba.php
+++ b/include/dba.php
@@ -313,7 +313,7 @@ class dba {
 	 * For all regular queries please use dba::select or dba::exists
 	 *
 	 * @param string $sql SQL statement
-	 * @return object statement object
+	 * @return bool|object statement object
 	 */
 	public static function p($sql) {
 		$a = get_app();
@@ -586,10 +586,11 @@ class dba {
 	}
 
 	/**
+	 * Fetches the first row
+	 * 
+	 * Please use dba::selectOne or dba::exists whenever this is possible.
+	 *
 	 * @brief Fetches the first row
-	 *
-	 * Please use dba::select or dba::exists whenever this is possible.
-	 *
 	 * @param string $sql SQL statement
 	 * @return array first row of query
 	 */
@@ -639,7 +640,7 @@ class dba {
 	/**
 	 * @brief Returns the number of rows of a statement
 	 *
-	 * @param object Statement object
+	 * @param PDOStatement|mysqli_result|mysqli_stmt Statement object
 	 * @return int Number of rows
 	 */
 	public static function num_rows($stmt) {
@@ -658,7 +659,7 @@ class dba {
 	/**
 	 * @brief Fetch a single row
 	 *
-	 * @param object $stmt statement object
+	 * @param PDOStatement|mysqli_result|mysqli_stmt $stmt statement object
 	 * @return array current row
 	 */
 	public static function fetch($stmt) {
@@ -1111,12 +1112,12 @@ class dba {
 	/**
 	 * @brief Select rows from a table
 	 *
-	 * @param string $table Table name
-	 * @param array $fields array of selected fields
-	 * @param array $condition array of fields for condition
-	 * @param array $params array of several parameters
+	 * @param string $table     Table name
+	 * @param array  $fields    Array of selected fields, empty for all
+	 * @param array  $condition Array of fields for condition
+	 * @param array  $params    Array of several parameters
 	 *
-	 * @return boolean|object If "limit" is equal "1" only a single row is returned, else a query object is returned
+	 * @return boolean|object
 	 *
 	 * Example:
 	 * $table = "item";
@@ -1126,7 +1127,7 @@ class dba {
 	 * or:
 	 * $condition = array("`uid` = ? AND `network` IN (?, ?)", 1, 'dfrn', 'dspr');
 	 *
-	 * $params = array("order" => array("id", "received" => true), "limit" => 1);
+	 * $params = array("order" => array("id", "received" => true), "limit" => 10);
 	 *
 	 * $data = dba::select($table, $fields, $condition, $params);
 	 */
@@ -1280,7 +1281,7 @@ class dba {
 	 * @brief Closes the current statement
 	 *
 	 * @param object $stmt statement object
-	 * @return boolean was the close successfull?
+	 * @return boolean was the close successful?
 	 */
 	public static function close($stmt) {
 		if (!is_object($stmt)) {

--- a/include/dba.php
+++ b/include/dba.php
@@ -1047,7 +1047,7 @@ class dba {
 		if (is_bool($old_fields)) {
 			$do_insert = $old_fields;
 
-			$old_fields = self::selectOne($table, [], $condition);
+			$old_fields = self::selectFirst($table, [], $condition);
 
 			if (is_bool($old_fields)) {
 				if ($do_insert) {
@@ -1095,7 +1095,7 @@ class dba {
 	 * @return bool|array
 	 * @see dba::select
 	 */
-	public static function selectOne($table, array $fields = [], array $condition = [], $params = [])
+	public static function selectFirst($table, array $fields = [], array $condition = [], $params = [])
 	{
 		$params['limit'] = 1;
 		$result = self::select($table, $fields, $condition, $params);

--- a/include/dba.php
+++ b/include/dba.php
@@ -587,8 +587,8 @@ class dba {
 
 	/**
 	 * Fetches the first row
-	 * 
-	 * Please use dba::selectOne or dba::exists whenever this is possible.
+	 *
+	 * Please use dba::selectFirst or dba::exists whenever this is possible.
 	 *
 	 * @brief Fetches the first row
 	 * @param string $sql SQL statement
@@ -1086,7 +1086,7 @@ class dba {
 
 	/**
 	 * Retrieve a single record from a table and returns it in an associative array
-	 * 
+	 *
 	 * @brief Retrieve a single record from a table
 	 * @param string $table
 	 * @param array  $fields

--- a/include/enotify.php
+++ b/include/enotify.php
@@ -106,7 +106,7 @@ function notification($params)
 	}
 
 	if ($params['type'] == NOTIFY_COMMENT) {
-		$p = dba::selectOne('thread', ['ignored'], ['iid' => $parent_id]);
+		$p = dba::selectFirst('thread', ['ignored'], ['iid' => $parent_id]);
 		if (DBM::is_result($p) && $p["ignored"]) {
 			logger("Thread ".$parent_id." will be ignored", LOGGER_DEBUG);
 			return;
@@ -131,7 +131,7 @@ function notification($params)
 		$p = null;
 
 		if ($params['otype'] === 'item' && $parent_id) {
-			$p = dba::selectOne('item', [], ['id' => $parent_id]);
+			$p = dba::selectFirst('item', [], ['id' => $parent_id]);
 		}
 
 		$item_post_type = item_post_type($p);
@@ -672,12 +672,12 @@ function check_item_notification($itemid, $uid, $defaulttype = "") {
 	$profiles = $notification_data["profiles"];
 
 	$fields = ['notify-flags', 'language', 'username', 'email', 'nickname'];
-	$user = dba::selectOne('user', $fields, ['uid' => $uid]);
+	$user = dba::selectFirst('user', $fields, ['uid' => $uid]);
 	if (!DBM::is_result($user)) {
 		return false;
 	}
 
-	$owner = dba::selectOne('contact', ['url'], ['self' => true, 'uid' => $uid]);
+	$owner = dba::selectFirst('contact', ['url'], ['self' => true, 'uid' => $uid]);
 	if (!DBM::is_result($owner)) {
 		return false;
 	}

--- a/include/enotify.php
+++ b/include/enotify.php
@@ -106,7 +106,7 @@ function notification($params)
 	}
 
 	if ($params['type'] == NOTIFY_COMMENT) {
-		$p = dba::select('thread', ['ignored'], ['iid' => $parent_id], ['limit' => 1]);
+		$p = dba::selectOne('thread', ['ignored'], ['iid' => $parent_id]);
 		if (DBM::is_result($p) && $p["ignored"]) {
 			logger("Thread ".$parent_id." will be ignored", LOGGER_DEBUG);
 			return;
@@ -131,7 +131,7 @@ function notification($params)
 		$p = null;
 
 		if ($params['otype'] === 'item' && $parent_id) {
-			$p = dba::select('item', [], ['id' => $parent_id], ['limit' => 1]);
+			$p = dba::selectOne('item', [], ['id' => $parent_id]);
 		}
 
 		$item_post_type = item_post_type($p);
@@ -672,12 +672,12 @@ function check_item_notification($itemid, $uid, $defaulttype = "") {
 	$profiles = $notification_data["profiles"];
 
 	$fields = ['notify-flags', 'language', 'username', 'email', 'nickname'];
-	$user = dba::select('user', $fields, ['uid' => $uid], ['limit' => 1]);
+	$user = dba::selectOne('user', $fields, ['uid' => $uid]);
 	if (!DBM::is_result($user)) {
 		return false;
 	}
 
-	$owner = dba::select('contact', ['url'], ['self' => true, 'uid' => $uid], ['limit' => 1]);
+	$owner = dba::selectOne('contact', ['url'], ['self' => true, 'uid' => $uid]);
 	if (!DBM::is_result($owner)) {
 		return false;
 	}

--- a/include/enotify.php
+++ b/include/enotify.php
@@ -50,8 +50,8 @@ function notification($params)
 	}
 
 	if ($params['type'] != SYSTEM_EMAIL) {
-		$user = dba::select('user', array('nickname', 'page-flags'),
-			array('uid' => $params['uid']), array('limit' => 1));
+		$user = dba::selectFirst('user', ['nickname', 'page-flags'],
+			['uid' => $params['uid']]);
 
 		// There is no need to create notifications for forum accounts
 		if (!DBM::is_result($user) || in_array($user["page-flags"], array(PAGE_COMMUNITY, PAGE_PRVGROUP))) {

--- a/include/identity.php
+++ b/include/identity.php
@@ -162,7 +162,7 @@ function get_profiledata_by_nick($nickname, $uid = 0, $profile = 0)
 	if (remote_user() && count($_SESSION['remote'])) {
 		foreach ($_SESSION['remote'] as $visitor) {
 			if ($visitor['uid'] == $uid) {
-				$r = dba::select('contact', array('profile-id'), array('id' => $visitor['cid']), array('limit' => 1));
+				$r = dba::selectOne('contact', ['profile-id'], ['id' => $visitor['cid']]);
 				if (DBM::is_result($r)) {
 					$profile = $r['profile-id'];
 				}

--- a/include/identity.php
+++ b/include/identity.php
@@ -162,7 +162,7 @@ function get_profiledata_by_nick($nickname, $uid = 0, $profile = 0)
 	if (remote_user() && count($_SESSION['remote'])) {
 		foreach ($_SESSION['remote'] as $visitor) {
 			if ($visitor['uid'] == $uid) {
-				$r = dba::selectOne('contact', ['profile-id'], ['id' => $visitor['cid']]);
+				$r = dba::selectFirst('contact', ['profile-id'], ['id' => $visitor['cid']]);
 				if (DBM::is_result($r)) {
 					$profile = $r['profile-id'];
 				}

--- a/include/items.php
+++ b/include/items.php
@@ -562,7 +562,7 @@ function item_store($arr, $force_parent = false, $notify = false, $dontcache = f
 	// check for create date and expire time
 	$expire_interval = Config::get('system', 'dbclean-expire-days', 0);
 
-	$user = dba::selectOne('user', ['expire'], ['uid' => $uid]);
+	$user = dba::selectFirst('user', ['expire'], ['uid' => $uid]);
 	if (DBM::is_result($user) && ($user['expire'] > 0) && (($user['expire'] < $expire_interval) || ($expire_interval == 0))) {
 		$expire_interval = $user['expire'];
 	}
@@ -1149,14 +1149,14 @@ function item_store($arr, $force_parent = false, $notify = false, $dontcache = f
  */
 function item_set_last_item($arr) {
 	// Unarchive the author
-	$contact = dba::selectOne('contact', [], ['id' => $arr["author-link"]]);
+	$contact = dba::selectFirst('contact', [], ['id' => $arr["author-link"]]);
 	if ($contact['term-date'] > NULL_DATE) {
 		 Contact::unmarkForArchival($contact);
 	}
 
 	// Unarchive the contact if it is a toplevel posting
 	if ($arr["parent-uri"] === $arr["uri"]) {
-		$contact = dba::selectOne('contact', [], ['id' => $arr["contact-id"]]);
+		$contact = dba::selectFirst('contact', [], ['id' => $arr["contact-id"]]);
 		if ($contact['term-date'] > NULL_DATE) {
 			 Contact::unmarkForArchival($contact);
 		}

--- a/include/items.php
+++ b/include/items.php
@@ -562,9 +562,9 @@ function item_store($arr, $force_parent = false, $notify = false, $dontcache = f
 	// check for create date and expire time
 	$expire_interval = Config::get('system', 'dbclean-expire-days', 0);
 
-	$r = dba::select('user', array('expire'), array('uid' => $uid), array("limit" => 1));
-	if (DBM::is_result($r) && ($r['expire'] > 0) && (($r['expire'] < $expire_interval) || ($expire_interval == 0))) {
-		$expire_interval = $r['expire'];
+	$user = dba::selectOne('user', ['expire'], ['uid' => $uid]);
+	if (DBM::is_result($user) && ($user['expire'] > 0) && (($user['expire'] < $expire_interval) || ($expire_interval == 0))) {
+		$expire_interval = $user['expire'];
 	}
 
 	if (($expire_interval > 0) && !empty($arr['created'])) {
@@ -1149,14 +1149,14 @@ function item_store($arr, $force_parent = false, $notify = false, $dontcache = f
  */
 function item_set_last_item($arr) {
 	// Unarchive the author
-	$contact = dba::select('contact', [], ['id' => $arr["author-link"]], ['limit' => 1]);
+	$contact = dba::selectOne('contact', [], ['id' => $arr["author-link"]]);
 	if ($contact['term-date'] > NULL_DATE) {
 		 Contact::unmarkForArchival($contact);
 	}
 
 	// Unarchive the contact if it is a toplevel posting
 	if ($arr["parent-uri"] === $arr["uri"]) {
-		$contact = dba::select('contact', [], ['id' => $arr["contact-id"]], ['limit' => 1]);
+		$contact = dba::selectOne('contact', [], ['id' => $arr["contact-id"]]);
 		if ($contact['term-date'] > NULL_DATE) {
 			 Contact::unmarkForArchival($contact);
 		}

--- a/include/message.php
+++ b/include/message.php
@@ -69,7 +69,7 @@ function send_message($recipient = 0, $body = '', $subject = '', $replyto = '')
 			'subject' => $subject, 'recips' => $handles);
 		dba::insert('conv', $fields);
 
-		$r = dba::select('conv', array('id'), array('guid' => $conv_guid, 'uid' => local_user()), array('limit' => 1));
+		$r = dba::selectOne('conv', ['id'], ['guid' => $conv_guid, 'uid' => local_user()]);
 		if (DBM::is_result($r)) {
 			$convid = $r['id'];
 		}
@@ -188,7 +188,7 @@ function send_wallmessage($recipient = '', $body = '', $subject = '', $replyto =
 		'subject' => $subject, 'recips' => $handles);
 	dba::insert('conv', $fields);
 
-	$r = dba::select('conv', array('id'), array('guid' => $conv_guid, 'uid' => $recipient['uid']), array('limit' => 1));
+	$r = dba::selectOne('conv', ['id'], ['guid' => $conv_guid, 'uid' => $recipient['uid']]);
 	if (!DBM::is_result($r)) {
 		logger('send message: conversation not found.');
 		return -4;

--- a/include/message.php
+++ b/include/message.php
@@ -69,7 +69,7 @@ function send_message($recipient = 0, $body = '', $subject = '', $replyto = '')
 			'subject' => $subject, 'recips' => $handles);
 		dba::insert('conv', $fields);
 
-		$r = dba::selectOne('conv', ['id'], ['guid' => $conv_guid, 'uid' => local_user()]);
+		$r = dba::selectFirst('conv', ['id'], ['guid' => $conv_guid, 'uid' => local_user()]);
 		if (DBM::is_result($r)) {
 			$convid = $r['id'];
 		}
@@ -188,7 +188,7 @@ function send_wallmessage($recipient = '', $body = '', $subject = '', $replyto =
 		'subject' => $subject, 'recips' => $handles);
 	dba::insert('conv', $fields);
 
-	$r = dba::selectOne('conv', ['id'], ['guid' => $conv_guid, 'uid' => $recipient['uid']]);
+	$r = dba::selectFirst('conv', ['id'], ['guid' => $conv_guid, 'uid' => $recipient['uid']]);
 	if (!DBM::is_result($r)) {
 		logger('send message: conversation not found.');
 		return -4;

--- a/include/nav.php
+++ b/include/nav.php
@@ -94,7 +94,7 @@ function nav_info(App $a)
 		$nav['usermenu'][] = array('notes/', t('Personal notes'), '', t('Your personal notes'));
 
 		// user info
-		$r = dba::selectOne('contact', ['micro'], ['uid' => $a->user['uid'], 'self' => true]);
+		$r = dba::selectFirst('contact', ['micro'], ['uid' => $a->user['uid'], 'self' => true]);
 		$userinfo = array(
 			'icon' => (DBM::is_result($r) ? $a->remove_baseurl($r['micro']) : 'images/person-48.jpg'),
 			'name' => $a->user['username'],

--- a/include/nav.php
+++ b/include/nav.php
@@ -94,7 +94,7 @@ function nav_info(App $a)
 		$nav['usermenu'][] = array('notes/', t('Personal notes'), '', t('Your personal notes'));
 
 		// user info
-		$r = dba::select('contact', array('micro'), array('uid' => $a->user['uid'], 'self' => true), array('limit' => 1));
+		$r = dba::selectOne('contact', ['micro'], ['uid' => $a->user['uid'], 'self' => true]);
 		$userinfo = array(
 			'icon' => (DBM::is_result($r) ? $a->remove_baseurl($r['micro']) : 'images/person-48.jpg'),
 			'name' => $a->user['username'],

--- a/include/session.php
+++ b/include/session.php
@@ -33,7 +33,7 @@ function ref_session_read($id)
 		return '';
 	}
 
-	$r = dba::select('session', array('data'), array('sid' => $id), array('limit' => 1));
+	$r = dba::selectOne('session', ['data'], ['sid' => $id]);
 	if (DBM::is_result($r)) {
 		$session_exists = true;
 		return $r['data'];

--- a/include/session.php
+++ b/include/session.php
@@ -33,7 +33,7 @@ function ref_session_read($id)
 		return '';
 	}
 
-	$r = dba::selectOne('session', ['data'], ['sid' => $id]);
+	$r = dba::selectFirst('session', ['data'], ['sid' => $id]);
 	if (DBM::is_result($r)) {
 		$session_exists = true;
 		return $r['data'];

--- a/include/tags.php
+++ b/include/tags.php
@@ -226,7 +226,7 @@ function wtagblock($uid, $count = 0, $owner_id = 0, $flags = '', $type = TERM_HA
 	$o = '';
 	$r = tagadelic($uid, $count, $owner_id, $flags, $type);
 	if (count($r)) {
-		$contact = dba::selectOne('contact', ['url'], ['id' => $uid]);
+		$contact = dba::selectFirst('contact', ['url'], ['id' => $uid]);
 		$url = System::removedBaseUrl($contact['url']);
 
 		foreach ($r as $rr) {

--- a/include/tags.php
+++ b/include/tags.php
@@ -226,12 +226,7 @@ function wtagblock($uid, $count = 0, $owner_id = 0, $flags = '', $type = TERM_HA
 	$o = '';
 	$r = tagadelic($uid, $count, $owner_id, $flags, $type);
 	if (count($r)) {
-		$contact = dba::select(
-			'contact',
-			array('url'),
-			array('id' => $uid),
-			array('limit' => 1)
-		);
+		$contact = dba::selectOne('contact', ['url'], ['id' => $uid]);
 		$url = System::removedBaseUrl($contact['url']);
 
 		foreach ($r as $rr) {

--- a/index.php
+++ b/index.php
@@ -108,7 +108,7 @@ if (!$a->is_backend()) {
  */
 if (x($_SESSION, 'authenticated') && !x($_SESSION, 'language')) {
 	// we didn't loaded user data yet, but we need user language
-	$r = dba::select('user', array('language'), array('uid' => $_SESSION['uid']), array('limit' => 1));
+	$r = dba::selectOne('user', ['language'], ['uid' => $_SESSION['uid']]);
 	$_SESSION['language'] = $lang;
 	if (DBM::is_result($r)) {
 		$_SESSION['language'] = $r['language'];

--- a/index.php
+++ b/index.php
@@ -108,7 +108,7 @@ if (!$a->is_backend()) {
  */
 if (x($_SESSION, 'authenticated') && !x($_SESSION, 'language')) {
 	// we didn't loaded user data yet, but we need user language
-	$r = dba::selectOne('user', ['language'], ['uid' => $_SESSION['uid']]);
+	$r = dba::selectFirst('user', ['language'], ['uid' => $_SESSION['uid']]);
 	$_SESSION['language'] = $lang;
 	if (DBM::is_result($r)) {
 		$_SESSION['language'] = $r['language'];

--- a/mod/admin.php
+++ b/mod/admin.php
@@ -1551,7 +1551,7 @@ function admin_page_users(App $a)
 {
 	if ($a->argc > 2) {
 		$uid = $a->argv[3];
-		$user = dba::selectOne('user', ['username', 'blocked'], ['uid' => $uid]);
+		$user = dba::selectFirst('user', ['username', 'blocked'], ['uid' => $uid]);
 		if (DBM::is_result($user)) {
 			notice('User not found' . EOL);
 			goaway('admin/users');

--- a/mod/admin.php
+++ b/mod/admin.php
@@ -1551,8 +1551,8 @@ function admin_page_users(App $a)
 {
 	if ($a->argc > 2) {
 		$uid = $a->argv[3];
-		$user = q("SELECT `username`, `blocked` FROM `user` WHERE `uid` = %d", intval($uid));
-		if (count($user) == 0) {
+		$user = dba::selectOne('user', ['username', 'blocked'], ['uid' => $uid]);
+		if (DBM::is_result($user)) {
 			notice('User not found' . EOL);
 			goaway('admin/users');
 			return ''; // NOTREACHED
@@ -1563,15 +1563,15 @@ function admin_page_users(App $a)
 				// delete user
 				User::remove($uid);
 
-				notice(t("User '%s' deleted", $user[0]['username']) . EOL);
+				notice(t("User '%s' deleted", $user['username']) . EOL);
 				break;
 			case "block":
 				check_form_security_token_redirectOnErr('/admin/users', 'admin_users', 't');
 				q("UPDATE `user` SET `blocked` = %d WHERE `uid` = %s",
-					intval(1 - $user[0]['blocked']),
+					intval(1 - $user['blocked']),
 					intval($uid)
 				);
-				notice(sprintf(($user[0]['blocked'] ? t("User '%s' unblocked") : t("User '%s' blocked")), $user[0]['username']) . EOL);
+				notice(sprintf(($user['blocked'] ? t("User '%s' unblocked") : t("User '%s' blocked")), $user['username']) . EOL);
 				break;
 		}
 		goaway('admin/users');

--- a/mod/admin.php
+++ b/mod/admin.php
@@ -1625,8 +1625,6 @@ function admin_page_users(App $a)
 				ORDER BY $sql_order $sql_order_direction LIMIT %d, %d", intval($a->pager['start']), intval($a->pager['itemspage'])
 	);
 
-	//echo "<pre>$users"; killme();
-
 	$adminlist = explode(",", str_replace(" ", "", $a->config['admin_email']));
 	$_setup_users = function ($e) use ($adminlist) {
 		$accounts = array(

--- a/mod/cal.php
+++ b/mod/cal.php
@@ -32,7 +32,7 @@ function cal_init(App $a)
 
 	if ($a->argc > 1) {
 		$nick = $a->argv[1];
-		$user = dba::selectOne('user', [], ['nickname' => $nick, 'blocked' => false]);
+		$user = dba::selectFirst('user', [], ['nickname' => $nick, 'blocked' => false]);
 		if (!DBM::is_result($user)) {
 			return;
 		}

--- a/mod/cal.php
+++ b/mod/cal.php
@@ -6,10 +6,10 @@
  * 	This calendar is for profile visitors and contains only the events
  * 	of the profile owner
  */
+
 use Friendica\App;
 use Friendica\Content\Feature;
 use Friendica\Core\Config;
-use Friendica\Core\PConfig;
 use Friendica\Core\System;
 use Friendica\Database\DBM;
 use Friendica\Model\Contact;

--- a/mod/cal.php
+++ b/mod/cal.php
@@ -32,16 +32,13 @@ function cal_init(App $a)
 
 	if ($a->argc > 1) {
 		$nick = $a->argv[1];
-		$user = q("SELECT * FROM `user` WHERE `nickname` = '%s' AND `blocked` = 0 LIMIT 1",
-			dbesc($nick)
-		);
-
-		if (!count($user)) {
+		$user = dba::selectOne('user', [], ['nickname' => $nick, 'blocked' => false]);
+		if (!DBM::is_result($user)) {
 			return;
 		}
 
-		$a->data['user'] = $user[0];
-		$a->profile_uid = $user[0]['uid'];
+		$a->data['user'] = $user;
+		$a->profile_uid = $user['uid'];
 
 		// if it's a json request abort here becaus we don't
 		// need the widget data

--- a/mod/common.php
+++ b/mod/common.php
@@ -63,11 +63,11 @@ function common_content(App $a)
 	}
 
 	if (!$cid && get_my_url()) {
-		$contact = dba::selectOne('contact', ['id'], ['nurl' => normalise_link(get_my_url()), 'uid' => $uid]);
+		$contact = dba::selectFirst('contact', ['id'], ['nurl' => normalise_link(get_my_url()), 'uid' => $uid]);
 		if (DBM::is_result($contact)) {
 			$cid = $contact['id'];
 		} else {
-			$gcontact = dba::selectOne('gcontact', ['id'], ['nurl' => normalise_link(get_my_url())]);
+			$gcontact = dba::selectFirst('gcontact', ['id'], ['nurl' => normalise_link(get_my_url())]);
 			if (DBM::is_result($gcontact)) {
 				$zcid = $gcontact['id'];
 			}

--- a/mod/common.php
+++ b/mod/common.php
@@ -63,19 +63,13 @@ function common_content(App $a)
 	}
 
 	if (!$cid && get_my_url()) {
-		/// @todo : Initialize $profile_uid
-		$r = q("SELECT `id` FROM `contact` WHERE `nurl` = '%s' AND `uid` = %d LIMIT 1",
-			dbesc(normalise_link(get_my_url())),
-			intval($profile_uid)
-		);
-		if (DBM::is_result($r)) {
-			$cid = $r[0]['id'];
+		$contact = dba::selectOne('contact', ['id'], ['nurl' => normalise_link(get_my_url()), 'uid' => $uid]);
+		if (DBM::is_result($contact)) {
+			$cid = $contact['id'];
 		} else {
-			$r = q("SELECT `id` FROM `gcontact` WHERE `nurl` = '%s' LIMIT 1",
-				dbesc(normalise_link(get_my_url()))
-			);
-			if (DBM::is_result($r)) {
-				$zcid = $r[0]['id'];
+			$gcontact = dba::selectOne('gcontact', ['id'], ['nurl' => normalise_link(get_my_url())]);
+			if (DBM::is_result($gcontact)) {
+				$zcid = $gcontact['id'];
 			}
 		}
 	}

--- a/mod/contacts.php
+++ b/mod/contacts.php
@@ -33,7 +33,7 @@ function contacts_init(App $a)
 	$contact = [];
 	if ((($a->argc == 2) && intval($a->argv[1])) || (($a->argc == 3) && intval($a->argv[1]) && ($a->argv[2] == "posts"))) {
 		$contact_id = intval($a->argv[1]);
-		$contact = dba::select('contact', [], ['id' => $contact_id, 'uid' => local_user()], ['limit' => 1]);
+		$contact = dba::selectOne('contact', [], ['id' => $contact_id, 'uid' => local_user()]);
 	}
 
 	if (DBM::is_result($contact)) {
@@ -222,7 +222,7 @@ function contacts_post(App $a)
 		notice(t('Failed to update contact record.') . EOL);
 	}
 
-	$contact = dba::select('contact', [], ['id' => $contact_id, 'uid' => local_user()], ['limit' => 1]);
+	$contact = dba::selectOne('contact', [], ['id' => $contact_id, 'uid' => local_user()]);
 	if (DBM::is_result($contact)) {
 		$a->data['contact'] = $contact;
 	}
@@ -233,7 +233,7 @@ function contacts_post(App $a)
 
 function _contact_update($contact_id)
 {
-	$contact = dba::select('contact', ['uid', 'url', 'network'], ['id' => $contact_id, 'uid' => local_user()], ['limit' => 1]);
+	$contact = dba::selectOne('contact', ['uid', 'url', 'network'], ['id' => $contact_id, 'uid' => local_user()]);
 	if (!DBM::is_result($contact)) {
 		return;
 	}
@@ -254,7 +254,7 @@ function _contact_update($contact_id)
 
 function _contact_update_profile($contact_id)
 {
-	$contact = dba::select('contact', ['uid', 'url', 'network'], ['id' => $contact_id, 'uid' => local_user()], ['limit' => 1]);
+	$contact = dba::selectOne('contact', ['uid', 'url', 'network'], ['id' => $contact_id, 'uid' => local_user()]);
 	if (!DBM::is_result($contact)) {
 		return;
 	}
@@ -389,7 +389,7 @@ function contacts_content(App $a)
 
 		$cmd = $a->argv[2];
 
-		$orig_record = dba::select('contact', [], ['id' => $contact_id, 'uid' => local_user(), 'self' => false], ['limit' => 1]);
+		$orig_record = dba::selectOne('contact', [], ['id' => $contact_id, 'uid' => local_user(), 'self' => false]);
 		if (!DBM::is_result($orig_record)) {
 			notice(t('Could not access contact record.') . EOL);
 			goaway('contacts');
@@ -904,7 +904,7 @@ function contact_posts($a, $contact_id)
 {
 	$o = contacts_tab($a, $contact_id, 1);
 
-	$contact = dba::select('contact', ['url'], ['id' => $contact_id], ['limit' => 1]);
+	$contact = dba::selectOne('contact', ['url'], ['id' => $contact_id]);
 	if (DBM::is_result($contact)) {
 		$a->page['aside'] = "";
 		profile_load($a, "", 0, Contact::getDetailsByURL($contact["url"]));

--- a/mod/contacts.php
+++ b/mod/contacts.php
@@ -33,7 +33,7 @@ function contacts_init(App $a)
 	$contact = [];
 	if ((($a->argc == 2) && intval($a->argv[1])) || (($a->argc == 3) && intval($a->argv[1]) && ($a->argv[2] == "posts"))) {
 		$contact_id = intval($a->argv[1]);
-		$contact = dba::selectOne('contact', [], ['id' => $contact_id, 'uid' => local_user()]);
+		$contact = dba::selectFirst('contact', [], ['id' => $contact_id, 'uid' => local_user()]);
 	}
 
 	if (DBM::is_result($contact)) {
@@ -222,7 +222,7 @@ function contacts_post(App $a)
 		notice(t('Failed to update contact record.') . EOL);
 	}
 
-	$contact = dba::selectOne('contact', [], ['id' => $contact_id, 'uid' => local_user()]);
+	$contact = dba::selectFirst('contact', [], ['id' => $contact_id, 'uid' => local_user()]);
 	if (DBM::is_result($contact)) {
 		$a->data['contact'] = $contact;
 	}
@@ -233,7 +233,7 @@ function contacts_post(App $a)
 
 function _contact_update($contact_id)
 {
-	$contact = dba::selectOne('contact', ['uid', 'url', 'network'], ['id' => $contact_id, 'uid' => local_user()]);
+	$contact = dba::selectFirst('contact', ['uid', 'url', 'network'], ['id' => $contact_id, 'uid' => local_user()]);
 	if (!DBM::is_result($contact)) {
 		return;
 	}
@@ -254,7 +254,7 @@ function _contact_update($contact_id)
 
 function _contact_update_profile($contact_id)
 {
-	$contact = dba::selectOne('contact', ['uid', 'url', 'network'], ['id' => $contact_id, 'uid' => local_user()]);
+	$contact = dba::selectFirst('contact', ['uid', 'url', 'network'], ['id' => $contact_id, 'uid' => local_user()]);
 	if (!DBM::is_result($contact)) {
 		return;
 	}
@@ -389,7 +389,7 @@ function contacts_content(App $a)
 
 		$cmd = $a->argv[2];
 
-		$orig_record = dba::selectOne('contact', [], ['id' => $contact_id, 'uid' => local_user(), 'self' => false]);
+		$orig_record = dba::selectFirst('contact', [], ['id' => $contact_id, 'uid' => local_user(), 'self' => false]);
 		if (!DBM::is_result($orig_record)) {
 			notice(t('Could not access contact record.') . EOL);
 			goaway('contacts');
@@ -904,7 +904,7 @@ function contact_posts($a, $contact_id)
 {
 	$o = contacts_tab($a, $contact_id, 1);
 
-	$contact = dba::selectOne('contact', ['url'], ['id' => $contact_id]);
+	$contact = dba::selectFirst('contact', ['url'], ['id' => $contact_id]);
 	if (DBM::is_result($contact)) {
 		$a->page['aside'] = "";
 		profile_load($a, "", 0, Contact::getDetailsByURL($contact["url"]));

--- a/mod/display.php
+++ b/mod/display.php
@@ -202,7 +202,7 @@ function display_content(App $a, $update = false, $update_uid = 0) {
 
 	if ($update) {
 		$item_id = $_REQUEST['item_id'];
-		$item = dba::select('item', ['uid', 'parent'], ['id' => $item_id], ['limit' => 1]);
+		$item = dba::selectOne('item', ['uid', 'parent'], ['id' => $item_id]);
 		$a->profile = array('uid' => intval($item['uid']), 'profile_uid' => intval($item['uid']));
 		$item_parent = $item['parent'];
 	} else {
@@ -345,7 +345,7 @@ function display_content(App $a, $update = false, $update_uid = 0) {
 	$s = dba::inArray($r);
 
 	if (local_user() && (local_user() == $a->profile['uid'])) {
-		$unseen = dba::select('item', array('id'), array('parent' => $s[0]['parent'], 'unseen' => true), array('limit' => 1));
+		$unseen = dba::selectOne('item', ['id'], ['parent' => $s[0]['parent'], 'unseen' => true]);
 		if (DBM::is_result($unseen)) {
 			dba::update('item', array('unseen' => false), array('parent' => $s[0]['parent'], 'unseen' => true));
 		}

--- a/mod/display.php
+++ b/mod/display.php
@@ -202,7 +202,7 @@ function display_content(App $a, $update = false, $update_uid = 0) {
 
 	if ($update) {
 		$item_id = $_REQUEST['item_id'];
-		$item = dba::selectOne('item', ['uid', 'parent'], ['id' => $item_id]);
+		$item = dba::selectFirst('item', ['uid', 'parent'], ['id' => $item_id]);
 		$a->profile = array('uid' => intval($item['uid']), 'profile_uid' => intval($item['uid']));
 		$item_parent = $item['parent'];
 	} else {
@@ -345,7 +345,7 @@ function display_content(App $a, $update = false, $update_uid = 0) {
 	$s = dba::inArray($r);
 
 	if (local_user() && (local_user() == $a->profile['uid'])) {
-		$unseen = dba::selectOne('item', ['id'], ['parent' => $s[0]['parent'], 'unseen' => true]);
+		$unseen = dba::selectFirst('item', ['id'], ['parent' => $s[0]['parent'], 'unseen' => true]);
 		if (DBM::is_result($unseen)) {
 			dba::update('item', array('unseen' => false), array('parent' => $s[0]['parent'], 'unseen' => true));
 		}

--- a/mod/hovercard.php
+++ b/mod/hovercard.php
@@ -44,7 +44,7 @@ function hovercard_content()
 	$cid = 0;
 	if (local_user() && strpos($profileurl, 'redir/') === 0) {
 		$cid = intval(substr($profileurl, 6));
-		$r = dba::selectOne('contact', ['nurl'], ['id' => $cid]);
+		$r = dba::selectFirst('contact', ['nurl'], ['id' => $cid]);
 		$profileurl = defaults($r, 'nurl', '');
 	}
 

--- a/mod/hovercard.php
+++ b/mod/hovercard.php
@@ -44,7 +44,7 @@ function hovercard_content()
 	$cid = 0;
 	if (local_user() && strpos($profileurl, 'redir/') === 0) {
 		$cid = intval(substr($profileurl, 6));
-		$r = dba::select('contact', array('nurl'), array('id' => $cid), array('limit' => 1));
+		$r = dba::selectOne('contact', ['nurl'], ['id' => $cid]);
 		$profileurl = defaults($r, 'nurl', '');
 	}
 

--- a/mod/network.php
+++ b/mod/network.php
@@ -581,7 +581,7 @@ function networkThreadedView(App $a, $update = 0) {
 		if ($cid) {
 			// If $cid belongs to a communitity forum or a privat goup,.add a mention to the status editor
 			$condition = ["`id` = ? AND (`forum` OR `prv`)", $cid];
-			$contact = dba::selectOne('contact', ['addr', 'nick'], $condition);
+			$contact = dba::selectFirst('contact', ['addr', 'nick'], $condition);
 			if (DBM::is_result($contact)) {
 				if ($contact["addr"] != '') {
 					$content = "!".$contact["addr"];
@@ -632,7 +632,7 @@ function networkThreadedView(App $a, $update = 0) {
 	$sql_nets = (($nets) ? sprintf(" and $sql_table.`network` = '%s' ", dbesc($nets)) : '');
 
 	if ($group) {
-		$r = dba::selectOne('group', ['name'], ['id' => $group, 'uid' => $_SESSION['uid']]);
+		$r = dba::selectFirst('group', ['name'], ['id' => $group, 'uid' => $_SESSION['uid']]);
 		if (!DBM::is_result($r)) {
 			if ($update)
 				killme();
@@ -647,7 +647,7 @@ function networkThreadedView(App $a, $update = 0) {
 			$contact_str_self = "";
 
 			$contact_str = implode(',',$contacts);
-			$self = dba::selectOne('contact', ['id'], ['uid' => $_SESSION['uid'], 'self' => true]);
+			$self = dba::selectFirst('contact', ['id'], ['uid' => $_SESSION['uid'], 'self' => true]);
 			if (DBM::is_result($self)) {
 				$contact_str_self = $self["id"];
 			}
@@ -668,7 +668,7 @@ function networkThreadedView(App $a, $update = 0) {
 		$fields = ['id', 'name', 'network', 'writable', 'nurl',
 				'forum', 'prv', 'contact-type', 'addr', 'thumb', 'location'];
 		$condition = ["`id` = ? AND (NOT `blocked` OR `pending`)", $cid];
-		$r = dba::selectOne('contact', $fields, $condition);
+		$r = dba::selectFirst('contact', $fields, $condition);
 		if (DBM::is_result($r)) {
 			$sql_extra = " AND ".$sql_table.".`contact-id` = ".intval($cid);
 

--- a/mod/network.php
+++ b/mod/network.php
@@ -580,8 +580,8 @@ function networkThreadedView(App $a, $update = 0) {
 
 		if ($cid) {
 			// If $cid belongs to a communitity forum or a privat goup,.add a mention to the status editor
-			$condition = array("`id` = ? AND (`forum` OR `prv`)", $cid);
-			$contact = dba::select('contact', array('addr', 'nick'), $condition, array('limit' => 1));
+			$condition = ["`id` = ? AND (`forum` OR `prv`)", $cid];
+			$contact = dba::selectOne('contact', ['addr', 'nick'], $condition);
 			if (DBM::is_result($contact)) {
 				if ($contact["addr"] != '') {
 					$content = "!".$contact["addr"];
@@ -632,7 +632,7 @@ function networkThreadedView(App $a, $update = 0) {
 	$sql_nets = (($nets) ? sprintf(" and $sql_table.`network` = '%s' ", dbesc($nets)) : '');
 
 	if ($group) {
-		$r = dba::select('group', array('name'), array('id' => $group, 'uid' => $_SESSION['uid']), array('limit' => 1));
+		$r = dba::selectOne('group', ['name'], ['id' => $group, 'uid' => $_SESSION['uid']]);
 		if (!DBM::is_result($r)) {
 			if ($update)
 				killme();
@@ -647,7 +647,7 @@ function networkThreadedView(App $a, $update = 0) {
 			$contact_str_self = "";
 
 			$contact_str = implode(',',$contacts);
-			$self = dba::select('contact', array('id'), array('uid' => $_SESSION['uid'], 'self' => true), array('limit' => 1));
+			$self = dba::selectOne('contact', ['id'], ['uid' => $_SESSION['uid'], 'self' => true]);
 			if (DBM::is_result($self)) {
 				$contact_str_self = $self["id"];
 			}
@@ -665,10 +665,10 @@ function networkThreadedView(App $a, $update = 0) {
 		)) . $o;
 
 	} elseif ($cid) {
-		$fields = array('id', 'name', 'network', 'writable', 'nurl',
-				'forum', 'prv', 'contact-type', 'addr', 'thumb', 'location');
-		$condition = array("`id` = ? AND (NOT `blocked` OR `pending`)", $cid);
-		$r = dba::select('contact', $fields, $condition, array('limit' => 1));
+		$fields = ['id', 'name', 'network', 'writable', 'nurl',
+				'forum', 'prv', 'contact-type', 'addr', 'thumb', 'location'];
+		$condition = ["`id` = ? AND (NOT `blocked` OR `pending`)", $cid];
+		$r = dba::selectOne('contact', $fields, $condition);
 		if (DBM::is_result($r)) {
 			$sql_extra = " AND ".$sql_table.".`contact-id` = ".intval($cid);
 

--- a/mod/noscrape.php
+++ b/mod/noscrape.php
@@ -67,14 +67,14 @@ function noscrape_init(App $a) {
 
 	// We display the last activity (post or login), reduced to year and week number
 	$last_active = 0;
-	$condition = array('uid' => $a->profile['uid'], 'self' => true);
-	$contact = dba::select('contact', array('last-item'), $condition, array('limit' => 1));
+	$condition = ['uid' => $a->profile['uid'], 'self' => true];
+	$contact = dba::selectOne('contact', ['last-item'], $condition);
 	if (DBM::is_result($contact)) {
 		$last_active = strtotime($contact['last-item']);
 	}
 
-	$condition = array('uid' => $a->profile['uid']);
-	$user = dba::select('user', array('login_date'), $condition, array('limit' => 1));
+	$condition = ['uid' => $a->profile['uid']];
+	$user = dba::selectOne('user', ['login_date'], $condition);
 	if (DBM::is_result($user)) {
 		if ($last_active < strtotime($user['login_date'])) {
 			$last_active = strtotime($user['login_date']);

--- a/mod/noscrape.php
+++ b/mod/noscrape.php
@@ -68,13 +68,13 @@ function noscrape_init(App $a) {
 	// We display the last activity (post or login), reduced to year and week number
 	$last_active = 0;
 	$condition = ['uid' => $a->profile['uid'], 'self' => true];
-	$contact = dba::selectOne('contact', ['last-item'], $condition);
+	$contact = dba::selectFirst('contact', ['last-item'], $condition);
 	if (DBM::is_result($contact)) {
 		$last_active = strtotime($contact['last-item']);
 	}
 
 	$condition = ['uid' => $a->profile['uid']];
-	$user = dba::selectOne('user', ['login_date'], $condition);
+	$user = dba::selectFirst('user', ['login_date'], $condition);
 	if (DBM::is_result($user)) {
 		if ($last_active < strtotime($user['login_date'])) {
 			$last_active = strtotime($user['login_date']);

--- a/mod/proxy.php
+++ b/mod/proxy.php
@@ -148,7 +148,7 @@ function proxy_init(App $a) {
 	$r = array();
 
 	if (!$direct_cache && ($cachefile == '')) {
-		$r = dba::selectOne('photo', ['data', 'desc'], ['resource-id' => $urlhash]);
+		$r = dba::selectFirst('photo', ['data', 'desc'], ['resource-id' => $urlhash]);
 		if (DBM::is_result($r)) {
 			$img_str = $r['data'];
 			$mime = $r['desc'];

--- a/mod/proxy.php
+++ b/mod/proxy.php
@@ -148,7 +148,7 @@ function proxy_init(App $a) {
 	$r = array();
 
 	if (!$direct_cache && ($cachefile == '')) {
-		$r = dba::select('photo', array('data', 'desc'), array('resource-id' => $urlhash), array('limit' => 1));
+		$r = dba::selectOne('photo', ['data', 'desc'], ['resource-id' => $urlhash]);
 		if (DBM::is_result($r)) {
 			$img_str = $r['data'];
 			$mime = $r['desc'];

--- a/mod/receive.php
+++ b/mod/receive.php
@@ -32,7 +32,7 @@ function receive_post(App $a)
 		}
 		$guid = $a->argv[2];
 
-		$importer = dba::selectOne('user', [], ['guid' => $guid, 'account_expired' => false, 'account_removed' => false]);
+		$importer = dba::selectFirst('user', [], ['guid' => $guid, 'account_expired' => false, 'account_removed' => false]);
 		if (!DBM::is_result($importer)) {
 			http_status_exit(500);
 		}

--- a/mod/receive.php
+++ b/mod/receive.php
@@ -32,7 +32,7 @@ function receive_post(App $a)
 		}
 		$guid = $a->argv[2];
 
-		$importer = dba::select('user', array(), array('guid' => $guid, 'account_expired' => false, 'account_removed' => false), array('limit' => 1));
+		$importer = dba::selectOne('user', [], ['guid' => $guid, 'account_expired' => false, 'account_removed' => false]);
 		if (!DBM::is_result($importer)) {
 			http_status_exit(500);
 		}

--- a/mod/settings.php
+++ b/mod/settings.php
@@ -997,7 +997,7 @@ function settings_content(App $a)
 
 	require_once('include/acl_selectors.php');
 
-	$profile = dba::select('profile', [], ['is-default' => true, 'uid' => local_user()], ['limit' => 1]);
+	$profile = dba::selectOne('profile', [], ['is-default' => true, 'uid' => local_user()]);
 	if (!DBM::is_result($profile)) {
 		notice(t('Unable to find your profile. Please contact your admin.') . EOL);
 		return;

--- a/mod/settings.php
+++ b/mod/settings.php
@@ -997,7 +997,7 @@ function settings_content(App $a)
 
 	require_once('include/acl_selectors.php');
 
-	$profile = dba::selectOne('profile', [], ['is-default' => true, 'uid' => local_user()]);
+	$profile = dba::selectFirst('profile', [], ['is-default' => true, 'uid' => local_user()]);
 	if (!DBM::is_result($profile)) {
 		notice(t('Unable to find your profile. Please contact your admin.') . EOL);
 		return;

--- a/mod/unfollow.php
+++ b/mod/unfollow.php
@@ -26,7 +26,7 @@ function unfollow_post(App $a) {
 	$condition = ["`uid` = ? AND `rel` = ? AND (`nurl` = ? OR `alias` = ? OR `alias` = ?) AND `network` != ?",
 			$uid, CONTACT_IS_FRIEND, normalise_link($url),
 			normalise_link($url), $url, NETWORK_STATUSNET];
-	$contact = dba::selectOne('contact', [], $condition);
+	$contact = dba::selectFirst('contact', [], $condition);
 
 	if (!DBM::is_result($contact)) {
 		notice(t("Contact wasn't found or can't be unfollowed."));
@@ -65,7 +65,7 @@ function unfollow_content(App $a) {
 	$condition = ["`uid` = ? AND `rel` = ? AND (`nurl` = ? OR `alias` = ? OR `alias` = ?) AND `network` != ?",
 			local_user(), CONTACT_IS_FRIEND, normalise_link($url),
 			normalise_link($url), $url, NETWORK_STATUSNET];
-	$contact = dba::selectOne('contact', ['url', 'network', 'addr', 'name'], $condition);
+	$contact = dba::selectFirst('contact', ['url', 'network', 'addr', 'name'], $condition);
 
 	if (!DBM::is_result($contact)) {
 		notice(t("You aren't a friend of this contact.").EOL);

--- a/mod/unfollow.php
+++ b/mod/unfollow.php
@@ -23,10 +23,10 @@ function unfollow_post(App $a) {
 	$url = notags(trim($_REQUEST['url']));
 	$return_url = $_SESSION['return_url'];
 
-	$condition = array("`uid` = ? AND `rel` = ? AND (`nurl` = ? OR `alias` = ? OR `alias` = ?) AND `network` != ?",
+	$condition = ["`uid` = ? AND `rel` = ? AND (`nurl` = ? OR `alias` = ? OR `alias` = ?) AND `network` != ?",
 			$uid, CONTACT_IS_FRIEND, normalise_link($url),
-			normalise_link($url), $url, NETWORK_STATUSNET);
-	$contact = dba::select('contact', array(), $condition, array('limit' => 1));
+			normalise_link($url), $url, NETWORK_STATUSNET];
+	$contact = dba::selectOne('contact', [], $condition);
 
 	if (!DBM::is_result($contact)) {
 		notice(t("Contact wasn't found or can't be unfollowed."));
@@ -62,10 +62,10 @@ function unfollow_content(App $a) {
 
 	$submit = t('Submit Request');
 
-	$condition = array("`uid` = ? AND `rel` = ? AND (`nurl` = ? OR `alias` = ? OR `alias` = ?) AND `network` != ?",
+	$condition = ["`uid` = ? AND `rel` = ? AND (`nurl` = ? OR `alias` = ? OR `alias` = ?) AND `network` != ?",
 			local_user(), CONTACT_IS_FRIEND, normalise_link($url),
-			normalise_link($url), $url, NETWORK_STATUSNET);
-	$contact = dba::select('contact', array('url', 'network', 'addr', 'name'), $condition, array('limit' => 1));
+			normalise_link($url), $url, NETWORK_STATUSNET];
+	$contact = dba::selectOne('contact', ['url', 'network', 'addr', 'name'], $condition);
 
 	if (!DBM::is_result($contact)) {
 		notice(t("You aren't a friend of this contact.").EOL);

--- a/mod/xrd.php
+++ b/mod/xrd.php
@@ -35,7 +35,7 @@ function xrd_init(App $a)
 		$name = substr($local, 0, strpos($local, '@'));
 	}
 
-	$r = dba::select('user', array(), array('nickname' => $name), array('limit' => 1));
+	$r = dba::selectOne('user', [], ['nickname' => $name]);
 	if (!DBM::is_result($r)) {
 		killme();
 	}

--- a/mod/xrd.php
+++ b/mod/xrd.php
@@ -29,8 +29,9 @@ function xrd_init(App $a)
 		$name = ltrim(basename($uri), '~');
 	} else {
 		$local = str_replace('acct:', '', $uri);
-		if (substr($local, 0, 2) == '//')
+		if (substr($local, 0, 2) == '//') {
 			$local = substr($local, 2);
+		}
 
 		$name = substr($local, 0, strpos($local, '@'));
 	}

--- a/mod/xrd.php
+++ b/mod/xrd.php
@@ -36,7 +36,7 @@ function xrd_init(App $a)
 		$name = substr($local, 0, strpos($local, '@'));
 	}
 
-	$r = dba::selectOne('user', [], ['nickname' => $name]);
+	$r = dba::selectFirst('user', [], ['nickname' => $name]);
 	if (!DBM::is_result($r)) {
 		killme();
 	}

--- a/src/Content/OEmbed.php
+++ b/src/Content/OEmbed.php
@@ -57,9 +57,8 @@ class OEmbed
 
 		$a = get_app();
 
-		$condition = array('url' => normalise_link($embedurl));
-		$r = dba::select('oembed', array('content'), $condition, array('limit' => 1));
-
+		$condition = ['url' => normalise_link($embedurl)];
+		$r = dba::selectOne('oembed', ['content'], $condition);
 		if (DBM::is_result($r)) {
 			$txt = $r["content"];
 		} else {

--- a/src/Content/OEmbed.php
+++ b/src/Content/OEmbed.php
@@ -58,7 +58,7 @@ class OEmbed
 		$a = get_app();
 
 		$condition = ['url' => normalise_link($embedurl)];
-		$r = dba::selectOne('oembed', ['content'], $condition);
+		$r = dba::selectFirst('oembed', ['content'], $condition);
 		if (DBM::is_result($r)) {
 			$txt = $r["content"];
 		} else {

--- a/src/Core/Cache.php
+++ b/src/Core/Cache.php
@@ -109,7 +109,7 @@ class Cache
 		// Frequently clear cache
 		self::clear();
 
-		$r = dba::select('cache', array('v'), array('k' => $key), array('limit' => 1));
+		$r = dba::selectOne('cache', ['v'], ['k' => $key]);
 
 		if (DBM::is_result($r)) {
 			$cached = $r['v'];

--- a/src/Core/Cache.php
+++ b/src/Core/Cache.php
@@ -109,7 +109,7 @@ class Cache
 		// Frequently clear cache
 		self::clear();
 
-		$r = dba::selectOne('cache', ['v'], ['k' => $key]);
+		$r = dba::selectFirst('cache', ['v'], ['k' => $key]);
 
 		if (DBM::is_result($r)) {
 			$cached = $r['v'];

--- a/src/Core/Config.php
+++ b/src/Core/Config.php
@@ -97,7 +97,7 @@ class Config
 			}
 		}
 
-		$ret = dba::select('config', array('v'), array('cat' => $family, 'k' => $key), array('limit' => 1));
+		$ret = dba::selectOne('config', ['v'], ['cat' => $family, 'k' => $key]);
 		if (DBM::is_result($ret)) {
 			// manage array value
 			$val = (preg_match("|^a:[0-9]+:{.*}$|s", $ret['v']) ? unserialize($ret['v']) : $ret['v']);

--- a/src/Core/Config.php
+++ b/src/Core/Config.php
@@ -97,7 +97,7 @@ class Config
 			}
 		}
 
-		$ret = dba::selectOne('config', ['v'], ['cat' => $family, 'k' => $key]);
+		$ret = dba::selectFirst('config', ['v'], ['cat' => $family, 'k' => $key]);
 		if (DBM::is_result($ret)) {
 			// manage array value
 			$val = (preg_match("|^a:[0-9]+:{.*}$|s", $ret['v']) ? unserialize($ret['v']) : $ret['v']);

--- a/src/Core/PConfig.php
+++ b/src/Core/PConfig.php
@@ -90,7 +90,7 @@ class PConfig
 			}
 		}
 
-		$ret = dba::select('pconfig', array('v'), array('uid' => $uid, 'cat' => $family, 'k' => $key), array('limit' => 1));
+		$ret = dba::selectOne('pconfig', ['v'], ['uid' => $uid, 'cat' => $family, 'k' => $key]);
 		if (DBM::is_result($ret)) {
 			$val = (preg_match("|^a:[0-9]+:{.*}$|s", $ret['v']) ? unserialize($ret['v']) : $ret['v']);
 			$a->config[$uid][$family][$key] = $val;

--- a/src/Core/PConfig.php
+++ b/src/Core/PConfig.php
@@ -90,7 +90,7 @@ class PConfig
 			}
 		}
 
-		$ret = dba::selectOne('pconfig', ['v'], ['uid' => $uid, 'cat' => $family, 'k' => $key]);
+		$ret = dba::selectFirst('pconfig', ['v'], ['uid' => $uid, 'cat' => $family, 'k' => $key]);
 		if (DBM::is_result($ret)) {
 			$val = (preg_match("|^a:[0-9]+:{.*}$|s", $ret['v']) ? unserialize($ret['v']) : $ret['v']);
 			$a->config[$uid][$family][$key] = $val;

--- a/src/Core/Worker.php
+++ b/src/Core/Worker.php
@@ -165,7 +165,7 @@ class Worker
 	private static function highestPriority()
 	{
 		$condition = array("`executed` <= ? AND NOT `done`", NULL_DATE);
-		$s = dba::select('workerqueue', array('priority'), $condition, array('limit' => 1, 'order' => array('priority')));
+		$s = dba::selectOne('workerqueue', ['priority'], $condition, ['order' => ['priority']]);
 		if (DBM::is_result($s)) {
 			return $s["priority"];
 		} else {
@@ -772,9 +772,9 @@ class Worker
 			// Are there waiting processes with a higher priority than the currently highest?
 			$result = dba::select(
 				'workerqueue',
-				array('id'),
-				array("`executed` <= ? AND `priority` < ? AND NOT `done`", NULL_DATE, $highest_priority),
-				array('limit' => $limit, 'order' => array('priority', 'created'), 'only_query' => true)
+				['id'],
+				["`executed` <= ? AND `priority` < ? AND NOT `done`", NULL_DATE, $highest_priority],
+				['limit' => $limit, 'order' => ['priority', 'created']]
 			);
 
 			while ($id = dba::fetch($result)) {
@@ -788,9 +788,9 @@ class Worker
 				// Give slower processes some processing time
 				$result = dba::select(
 					'workerqueue',
-					array('id'),
-					array("`executed` <= ? AND `priority` > ? AND NOT `done`", NULL_DATE, $highest_priority),
-					array('limit' => $limit, 'order' => array('priority', 'created'), 'only_query' => true)
+					['id'],
+					["`executed` <= ? AND `priority` > ? AND NOT `done`", NULL_DATE, $highest_priority],
+					['limit' => $limit, 'order' => ['priority', 'created']]
 				);
 
 				while ($id = dba::fetch($result)) {
@@ -807,9 +807,9 @@ class Worker
 		if (!$found) {
 			$result = dba::select(
 				'workerqueue',
-				array('id'),
-				array("`executed` <= ? AND NOT `done`", NULL_DATE),
-				array('limit' => $limit, 'order' => array('priority', 'created'), 'only_query' => true)
+				['id'],
+				["`executed` <= ? AND NOT `done`", NULL_DATE],
+				['limit' => $limit, 'order' => ['priority', 'created']]
 			);
 
 			while ($id = dba::fetch($result)) {

--- a/src/Core/Worker.php
+++ b/src/Core/Worker.php
@@ -165,7 +165,7 @@ class Worker
 	private static function highestPriority()
 	{
 		$condition = array("`executed` <= ? AND NOT `done`", NULL_DATE);
-		$s = dba::selectOne('workerqueue', ['priority'], $condition, ['order' => ['priority']]);
+		$s = dba::selectFirst('workerqueue', ['priority'], $condition, ['order' => ['priority']]);
 		if (DBM::is_result($s)) {
 			return $s["priority"];
 		} else {

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -103,7 +103,7 @@ class Contact extends BaseObject
 			return true;
 		}
 
-		$user = dba::selectOne('user', ['uid', 'username', 'nickname'], ['uid' => $uid]);
+		$user = dba::selectFirst('user', ['uid', 'username', 'nickname'], ['uid' => $uid]);
 		if (!DBM::is_result($user)) {
 			return false;
 		}
@@ -145,7 +145,7 @@ class Contact extends BaseObject
 	public static function remove($id)
 	{
 		// We want just to make sure that we don't delete our "self" contact
-		$r = dba::selectOne('contact', ['uid'], ['id' => $id, 'self' => false]);
+		$r = dba::selectFirst('contact', ['uid'], ['id' => $id, 'self' => false]);
 
 		if (!DBM::is_result($r) || !intval($r['uid'])) {
 			return;
@@ -490,7 +490,7 @@ class Contact extends BaseObject
 				return $menu;
 			}
 
-			$r = dba::selectOne('contact', [], ['nurl' => $contact['nurl'], 'network' => $contact['network'], 'uid' => $uid]);
+			$r = dba::selectFirst('contact', [], ['nurl' => $contact['nurl'], 'network' => $contact['network'], 'uid' => $uid]);
 			if ($r) {
 				return self::photoMenu($r, $uid);
 			} else {
@@ -653,18 +653,18 @@ class Contact extends BaseObject
 
 		/// @todo Verify if we can't use Contact::getDetailsByUrl instead of the following
 		// We first try the nurl (http://server.tld/nick), most common case
-		$contact = dba::selectOne('contact', ['id', 'avatar-date'], ['nurl' => normalise_link($url), 'uid' => $uid]);
+		$contact = dba::selectFirst('contact', ['id', 'avatar-date'], ['nurl' => normalise_link($url), 'uid' => $uid]);
 
 		// Then the addr (nick@server.tld)
 		if (!DBM::is_result($contact)) {
-			$contact = dba::selectOne('contact', ['id', 'avatar-date'], ['addr' => $url, 'uid' => $uid]);
+			$contact = dba::selectFirst('contact', ['id', 'avatar-date'], ['addr' => $url, 'uid' => $uid]);
 		}
 
 		// Then the alias (which could be anything)
 		if (!DBM::is_result($contact)) {
 			// The link could be provided as http although we stored it as https
 			$ssl_url = str_replace('http://', 'https://', $url);
-			$r = dba::selectOne('contact', ['id', 'avatar', 'avatar-date'], ['`alias` IN (?, ?, ?) AND `uid` = ?', $url, normalise_link($url), $ssl_url, $uid]);
+			$r = dba::selectFirst('contact', ['id', 'avatar', 'avatar-date'], ['`alias` IN (?, ?, ?) AND `uid` = ?', $url, normalise_link($url), $ssl_url, $uid]);
 			$contact = dba::fetch($r);
 			dba::close($r);
 		}
@@ -697,7 +697,7 @@ class Contact extends BaseObject
 			}
 
 			// Get data from the gcontact table
-			$gcontacts = dba::selectOne('gcontact', ['name', 'nick', 'url', 'photo', 'addr', 'alias', 'network'], ['nurl' => normalise_link($url)]);
+			$gcontacts = dba::selectFirst('gcontact', ['name', 'nick', 'url', 'photo', 'addr', 'alias', 'network'], ['nurl' => normalise_link($url)]);
 			if (!DBM::is_result($gcontacts)) {
 				return 0;
 			}
@@ -735,7 +735,7 @@ class Contact extends BaseObject
 			$contact_id = $contacts[0]["id"];
 
 			// Update the newly created contact from data in the gcontact table
-			$gcontact = dba::selectOne('gcontact', ['location', 'about', 'keywords', 'gender'], ['nurl' => normalise_link($data["url"])]);
+			$gcontact = dba::selectFirst('gcontact', ['location', 'about', 'keywords', 'gender'], ['nurl' => normalise_link($data["url"])]);
 			if (DBM::is_result($gcontact)) {
 				// Only use the information when the probing hadn't fetched these values
 				if ($data['keywords'] != '') {
@@ -759,7 +759,7 @@ class Contact extends BaseObject
 		self::updateAvatar($data["photo"], $uid, $contact_id);
 
 		$fields = ['url', 'nurl', 'addr', 'alias', 'name', 'nick', 'keywords', 'location', 'about', 'avatar-date', 'pubkey'];
-		$contact = dba::selectOne('contact', $fields, ['id' => $contact_id]);
+		$contact = dba::selectFirst('contact', $fields, ['id' => $contact_id]);
 
 		// This condition should always be true
 		if (!DBM::is_result($contact)) {
@@ -817,7 +817,7 @@ class Contact extends BaseObject
 			return false;
 		}
 
-		$blocked = dba::selectOne('contact', ['blocked'], ['id' => $cid]);
+		$blocked = dba::selectFirst('contact', ['blocked'], ['id' => $cid]);
 		if (!DBM::is_result($blocked)) {
 			return false;
 		}
@@ -837,7 +837,7 @@ class Contact extends BaseObject
 			return false;
 		}
 
-		$hidden = dba::selectOne('contact', ['hidden'], ['id' => $cid]);
+		$hidden = dba::selectFirst('contact', ['hidden'], ['id' => $cid]);
 		if (!DBM::is_result($hidden)) {
 			return false;
 		}
@@ -980,7 +980,7 @@ class Contact extends BaseObject
 	public static function updateAvatar($avatar, $uid, $cid, $force = false)
 	{
 		// Limit = 1 returns the row so no need for dba:inArray()
-		$r = dba::selectOne('contact', ['avatar', 'photo', 'thumb', 'micro', 'nurl'], ['id' => $cid]);
+		$r = dba::selectFirst('contact', ['avatar', 'photo', 'thumb', 'micro', 'nurl'], ['id' => $cid]);
 		if (!DBM::is_result($r)) {
 			return false;
 		} else {
@@ -999,7 +999,7 @@ class Contact extends BaseObject
 
 				// Update the public contact (contact id = 0)
 				if ($uid != 0) {
-					$pcontact = dba::selectOne('contact', ['id'], ['nurl' => $r[0]['nurl']]);
+					$pcontact = dba::selectFirst('contact', ['id'], ['nurl' => $r[0]['nurl']]);
 					if (DBM::is_result($pcontact)) {
 						self::updateAvatar($avatar, 0, $pcontact['id'], $force);
 					}
@@ -1023,7 +1023,7 @@ class Contact extends BaseObject
 		This will reliably kill your communication with Friendica contacts.
 		*/
 
-		$r = dba::selectOne('contact', ['url', 'nurl', 'addr', 'alias', 'batch', 'notify', 'poll', 'poco', 'network'], ['id' => $id]);
+		$r = dba::selectFirst('contact', ['url', 'nurl', 'addr', 'alias', 'batch', 'notify', 'poll', 'poco', 'network'], ['id' => $id]);
 		if (!DBM::is_result($r)) {
 			return false;
 		}
@@ -1246,7 +1246,7 @@ class Contact extends BaseObject
 			);
 		}
 
-		$r = dba::selectOne('contact', ['url' => $ret['url'], 'network' => $ret['network'], 'uid' => $uid]);
+		$r = dba::selectFirst('contact', ['url' => $ret['url'], 'network' => $ret['network'], 'uid' => $uid]);
 
 		if (!DBM::is_result($r)) {
 			$result['message'] .= t('Unable to retrieve contact information.') . EOL;

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -103,7 +103,7 @@ class Contact extends BaseObject
 			return true;
 		}
 
-		$user = dba::select('user', ['uid', 'username', 'nickname'], ['uid' => $uid], ['limit' => 1]);
+		$user = dba::selectOne('user', ['uid', 'username', 'nickname'], ['uid' => $uid]);
 		if (!DBM::is_result($user)) {
 			return false;
 		}
@@ -145,7 +145,7 @@ class Contact extends BaseObject
 	public static function remove($id)
 	{
 		// We want just to make sure that we don't delete our "self" contact
-		$r = dba::select('contact', array('uid'), array('id' => $id, 'self' => false), array('limit' => 1));
+		$r = dba::selectOne('contact', ['uid'], ['id' => $id, 'self' => false]);
 
 		if (!DBM::is_result($r) || !intval($r['uid'])) {
 			return;
@@ -490,7 +490,7 @@ class Contact extends BaseObject
 				return $menu;
 			}
 
-			$r = dba::select('contact', array(), array('nurl' => $contact['nurl'], 'network' => $contact['network'], 'uid' => $uid), array('limit' => 1));
+			$r = dba::selectOne('contact', [], ['nurl' => $contact['nurl'], 'network' => $contact['network'], 'uid' => $uid]);
 			if ($r) {
 				return self::photoMenu($r, $uid);
 			} else {
@@ -653,18 +653,18 @@ class Contact extends BaseObject
 
 		/// @todo Verify if we can't use Contact::getDetailsByUrl instead of the following
 		// We first try the nurl (http://server.tld/nick), most common case
-		$contact = dba::select('contact', array('id', 'avatar-date'), array('nurl' => normalise_link($url), 'uid' => $uid), array('limit' => 1));
+		$contact = dba::selectOne('contact', ['id', 'avatar-date'], ['nurl' => normalise_link($url), 'uid' => $uid]);
 
 		// Then the addr (nick@server.tld)
 		if (!DBM::is_result($contact)) {
-			$contact = dba::select('contact', array('id', 'avatar-date'), array('addr' => $url, 'uid' => $uid), array('limit' => 1));
+			$contact = dba::selectOne('contact', ['id', 'avatar-date'], ['addr' => $url, 'uid' => $uid]);
 		}
 
 		// Then the alias (which could be anything)
 		if (!DBM::is_result($contact)) {
 			// The link could be provided as http although we stored it as https
 			$ssl_url = str_replace('http://', 'https://', $url);
-			$r = dba::select('contact', array('id', 'avatar', 'avatar-date'), array('`alias` IN (?, ?, ?) AND `uid` = ?', $url, normalise_link($url), $ssl_url, $uid), array('limit' => 1));
+			$r = dba::selectOne('contact', ['id', 'avatar', 'avatar-date'], ['`alias` IN (?, ?, ?) AND `uid` = ?', $url, normalise_link($url), $ssl_url, $uid]);
 			$contact = dba::fetch($r);
 			dba::close($r);
 		}
@@ -697,7 +697,7 @@ class Contact extends BaseObject
 			}
 
 			// Get data from the gcontact table
-			$gcontacts = dba::select('gcontact', array('name', 'nick', 'url', 'photo', 'addr', 'alias', 'network'), array('nurl' => normalise_link($url)), array('limit' => 1));
+			$gcontacts = dba::selectOne('gcontact', ['name', 'nick', 'url', 'photo', 'addr', 'alias', 'network'], ['nurl' => normalise_link($url)]);
 			if (!DBM::is_result($gcontacts)) {
 				return 0;
 			}
@@ -735,7 +735,7 @@ class Contact extends BaseObject
 			$contact_id = $contacts[0]["id"];
 
 			// Update the newly created contact from data in the gcontact table
-			$gcontact = dba::select('gcontact', array('location', 'about', 'keywords', 'gender'), array('nurl' => normalise_link($data["url"])), array('limit' => 1));
+			$gcontact = dba::selectOne('gcontact', ['location', 'about', 'keywords', 'gender'], ['nurl' => normalise_link($data["url"])]);
 			if (DBM::is_result($gcontact)) {
 				// Only use the information when the probing hadn't fetched these values
 				if ($data['keywords'] != '') {
@@ -758,8 +758,8 @@ class Contact extends BaseObject
 
 		self::updateAvatar($data["photo"], $uid, $contact_id);
 
-		$fields = array('url', 'nurl', 'addr', 'alias', 'name', 'nick', 'keywords', 'location', 'about', 'avatar-date', 'pubkey');
-		$contact = dba::select('contact', $fields, array('id' => $contact_id), array('limit' => 1));
+		$fields = ['url', 'nurl', 'addr', 'alias', 'name', 'nick', 'keywords', 'location', 'about', 'avatar-date', 'pubkey'];
+		$contact = dba::selectOne('contact', $fields, ['id' => $contact_id]);
 
 		// This condition should always be true
 		if (!DBM::is_result($contact)) {
@@ -817,7 +817,7 @@ class Contact extends BaseObject
 			return false;
 		}
 
-		$blocked = dba::select('contact', array('blocked'), array('id' => $cid), array('limit' => 1));
+		$blocked = dba::selectOne('contact', ['blocked'], ['id' => $cid]);
 		if (!DBM::is_result($blocked)) {
 			return false;
 		}
@@ -837,7 +837,7 @@ class Contact extends BaseObject
 			return false;
 		}
 
-		$hidden = dba::select('contact', array('hidden'), array('id' => $cid), array('limit' => 1));
+		$hidden = dba::selectOne('contact', ['hidden'], ['id' => $cid]);
 		if (!DBM::is_result($hidden)) {
 			return false;
 		}
@@ -980,7 +980,7 @@ class Contact extends BaseObject
 	public static function updateAvatar($avatar, $uid, $cid, $force = false)
 	{
 		// Limit = 1 returns the row so no need for dba:inArray()
-		$r = dba::select('contact', array('avatar', 'photo', 'thumb', 'micro', 'nurl'), array('id' => $cid), array('limit' => 1));
+		$r = dba::selectOne('contact', ['avatar', 'photo', 'thumb', 'micro', 'nurl'], ['id' => $cid]);
 		if (!DBM::is_result($r)) {
 			return false;
 		} else {
@@ -999,7 +999,7 @@ class Contact extends BaseObject
 
 				// Update the public contact (contact id = 0)
 				if ($uid != 0) {
-					$pcontact = dba::select('contact', array('id'), array('nurl' => $r[0]['nurl']), array('limit' => 1));
+					$pcontact = dba::selectOne('contact', ['id'], ['nurl' => $r[0]['nurl']]);
 					if (DBM::is_result($pcontact)) {
 						self::updateAvatar($avatar, 0, $pcontact['id'], $force);
 					}
@@ -1023,7 +1023,7 @@ class Contact extends BaseObject
 		This will reliably kill your communication with Friendica contacts.
 		*/
 
-		$r = dba::select('contact', ['url', 'nurl', 'addr', 'alias', 'batch', 'notify', 'poll', 'poco', 'network'], ['id' => $id], ['limit' => 1]);
+		$r = dba::selectOne('contact', ['url', 'nurl', 'addr', 'alias', 'batch', 'notify', 'poll', 'poco', 'network'], ['id' => $id]);
 		if (!DBM::is_result($r)) {
 			return false;
 		}
@@ -1246,7 +1246,7 @@ class Contact extends BaseObject
 			);
 		}
 
-		$r = dba::select('contact', ['url' => $ret['url'], 'network' => $ret['network'], 'uid' => $uid], ['limit' => 1]);
+		$r = dba::selectOne('contact', ['url' => $ret['url'], 'network' => $ret['network'], 'uid' => $uid]);
 
 		if (!DBM::is_result($r)) {
 			$result['message'] .= t('Unable to retrieve contact information.') . EOL;

--- a/src/Model/GContact.php
+++ b/src/Model/GContact.php
@@ -888,7 +888,7 @@ class GContact
 						'network', 'bd', 'gender',
 						'keywords', 'alias', 'contact-type',
 						'url', 'location', 'about');
-				$old_contact = dba::select('contact', $fields, array('id' => $r[0]["id"]), array('limit' => 1));
+				$old_contact = dba::selectOne('contact', $fields, ['id' => $r[0]["id"]]);
 
 				// Update it with the current values
 				$fields = array('name' => $contact['name'], 'nick' => $contact['nick'],

--- a/src/Model/GContact.php
+++ b/src/Model/GContact.php
@@ -888,7 +888,7 @@ class GContact
 						'network', 'bd', 'gender',
 						'keywords', 'alias', 'contact-type',
 						'url', 'location', 'about');
-				$old_contact = dba::selectOne('contact', $fields, ['id' => $r[0]["id"]]);
+				$old_contact = dba::selectFirst('contact', $fields, ['id' => $r[0]["id"]]);
 
 				// Update it with the current values
 				$fields = array('name' => $contact['name'], 'nick' => $contact['nick'],

--- a/src/Model/Group.php
+++ b/src/Model/Group.php
@@ -39,7 +39,7 @@ class Group extends BaseObject
 				// all the old members are gone, but the group remains so we don't break any security
 				// access lists. What we're doing here is reviving the dead group, but old content which
 				// was restricted to this group may now be seen by the new group members.
-				$group = dba::select('group', ['deleted'], ['id' => $gid], ['limit' => 1]);
+				$group = dba::selectOne('group', ['deleted'], ['id' => $gid]);
 				if (DBM::is_result($group) && $group['deleted']) {
 					dba::update('group', ['deleted' => 0], ['gid' => $gid]);
 					notice(t('A deleted group with this name was revived. Existing item permissions <strong>may</strong> apply to this group and any future members. If this is not what you intended, please create another group with a different name.') . EOL);
@@ -120,7 +120,7 @@ class Group extends BaseObject
 			return false;
 		}
 
-		$group = dba::select('group', ['id'], ['uid' => $uid, 'name' => $name], ['limit' => 1]);
+		$group = dba::selectOne('group', ['id'], ['uid' => $uid, 'name' => $name]);
 		if (DBM::is_result($group)) {
 			return $group['id'];
 		}
@@ -139,13 +139,13 @@ class Group extends BaseObject
 			return false;
 		}
 
-		$group = dba::select('group', ['uid'], ['gid' => $gid], ['limit' => 1]);
+		$group = dba::selectOne('group', ['uid'], ['gid' => $gid]);
 		if (!DBM::is_result($group)) {
 			return false;
 		}
 
 		// remove group from default posting lists
-		$user = dba::select('user', ['def_gid', 'allow_gid', 'deny_gid'], ['uid' => $group['uid']], ['limit' => 1]);
+		$user = dba::selectOne('user', ['def_gid', 'allow_gid', 'deny_gid'], ['uid' => $group['uid']]);
 		if (DBM::is_result($user)) {
 			$change = false;
 

--- a/src/Model/Group.php
+++ b/src/Model/Group.php
@@ -39,7 +39,7 @@ class Group extends BaseObject
 				// all the old members are gone, but the group remains so we don't break any security
 				// access lists. What we're doing here is reviving the dead group, but old content which
 				// was restricted to this group may now be seen by the new group members.
-				$group = dba::selectOne('group', ['deleted'], ['id' => $gid]);
+				$group = dba::selectFirst('group', ['deleted'], ['id' => $gid]);
 				if (DBM::is_result($group) && $group['deleted']) {
 					dba::update('group', ['deleted' => 0], ['gid' => $gid]);
 					notice(t('A deleted group with this name was revived. Existing item permissions <strong>may</strong> apply to this group and any future members. If this is not what you intended, please create another group with a different name.') . EOL);
@@ -120,7 +120,7 @@ class Group extends BaseObject
 			return false;
 		}
 
-		$group = dba::selectOne('group', ['id'], ['uid' => $uid, 'name' => $name]);
+		$group = dba::selectFirst('group', ['id'], ['uid' => $uid, 'name' => $name]);
 		if (DBM::is_result($group)) {
 			return $group['id'];
 		}
@@ -139,13 +139,13 @@ class Group extends BaseObject
 			return false;
 		}
 
-		$group = dba::selectOne('group', ['uid'], ['gid' => $gid]);
+		$group = dba::selectFirst('group', ['uid'], ['gid' => $gid]);
 		if (!DBM::is_result($group)) {
 			return false;
 		}
 
 		// remove group from default posting lists
-		$user = dba::selectOne('user', ['def_gid', 'allow_gid', 'deny_gid'], ['uid' => $group['uid']]);
+		$user = dba::selectFirst('user', ['def_gid', 'allow_gid', 'deny_gid'], ['uid' => $group['uid']]);
 		if (DBM::is_result($user)) {
 			$change = false;
 

--- a/src/Model/Photo.php
+++ b/src/Model/Photo.php
@@ -38,14 +38,14 @@ class Photo
 	 */
 	public static function store(Image $Image, $uid, $cid, $rid, $filename, $album, $scale, $profile = 0, $allow_cid = '', $allow_gid = '', $deny_cid = '', $deny_gid = '', $desc = '')
 	{
-		$r = dba::selectOne('photo', ['guid'], ["`resource-id` = ? AND `guid` != ?", $rid, '']);
+		$r = dba::selectFirst('photo', ['guid'], ["`resource-id` = ? AND `guid` != ?", $rid, '']);
 		if (DBM::is_result($r)) {
 			$guid = $r['guid'];
 		} else {
 			$guid = get_guid();
 		}
 
-		$x = dba::selectOne('photo', ['id'], ['resource-id' => $rid, 'uid' => $uid, 'contact-id' => $cid, 'scale' => $scale]);
+		$x = dba::selectFirst('photo', ['id'], ['resource-id' => $rid, 'uid' => $uid, 'contact-id' => $cid, 'scale' => $scale]);
 
 		$fields = array(
 			'uid' => $uid,
@@ -88,7 +88,7 @@ class Photo
 	 */
 	public static function importProfilePhoto($photo, $uid, $cid, $quit_on_error = false)
 	{
-		$r = dba::selectOne(
+		$r = dba::selectFirst(
 			'photo', ['resource-id'], ['uid' => $uid, 'contact-id' => $cid, 'scale' => 4, 'album' => 'Contact Photos']
 		);
 

--- a/src/Model/Photo.php
+++ b/src/Model/Photo.php
@@ -38,14 +38,14 @@ class Photo
 	 */
 	public static function store(Image $Image, $uid, $cid, $rid, $filename, $album, $scale, $profile = 0, $allow_cid = '', $allow_gid = '', $deny_cid = '', $deny_gid = '', $desc = '')
 	{
-		$r = dba::select('photo', array('guid'), array("`resource-id` = ? AND `guid` != ?", $rid, ''), array('limit' => 1));
+		$r = dba::selectOne('photo', ['guid'], ["`resource-id` = ? AND `guid` != ?", $rid, '']);
 		if (DBM::is_result($r)) {
 			$guid = $r['guid'];
 		} else {
 			$guid = get_guid();
 		}
 
-		$x = dba::select('photo', array('id'), array('resource-id' => $rid, 'uid' => $uid, 'contact-id' => $cid, 'scale' => $scale), array('limit' => 1));
+		$x = dba::selectOne('photo', ['id'], ['resource-id' => $rid, 'uid' => $uid, 'contact-id' => $cid, 'scale' => $scale]);
 
 		$fields = array(
 			'uid' => $uid,
@@ -88,8 +88,8 @@ class Photo
 	 */
 	public static function importProfilePhoto($photo, $uid, $cid, $quit_on_error = false)
 	{
-		$r = dba::select(
-			'photo', array('resource-id'), array('uid' => $uid, 'contact-id' => $cid, 'scale' => 4, 'album' => 'Contact Photos'), array('limit' => 1)
+		$r = dba::selectOne(
+			'photo', ['resource-id'], ['uid' => $uid, 'contact-id' => $cid, 'scale' => 4, 'album' => 'Contact Photos']
 		);
 
 		if (DBM::is_result($r) && strlen($r['resource-id'])) {

--- a/src/Model/Term.php
+++ b/src/Model/Term.php
@@ -16,12 +16,10 @@ class Term
 	 */
 	public static function createFromItem($itemid)
 	{
-		$messages = dba::select('item', ['uid', 'deleted', 'file'], ['id' => $itemid], ['limit' => 1]);
-		if (!$messages) {
+		$message = dba::selectFirst('item', ['uid', 'deleted', 'file'], ['id' => $itemid]);
+		if (!\Friendica\Database\DBM::is_result($message)) {
 			return;
 		}
-
-		$message = $messages[0];
 
 		// Clean up all tags
 		q("DELETE FROM `term` WHERE `otype` = %d AND `oid` = %d AND `type` IN (%d, %d)",
@@ -30,18 +28,31 @@ class Term
 			intval(TERM_FILE),
 			intval(TERM_CATEGORY));
 
-		if ($message["deleted"])
+		if ($message["deleted"]) {
 			return;
+		}
 
 		if (preg_match_all("/\[(.*?)\]/ism", $message["file"], $files)) {
 			foreach ($files[1] as $file) {
-				dba::insert('term', ['uid' => $message["uid"], 'oid' => $itemid, 'otype' => TERM_OBJ_POST, 'type' => TERM_FILE, 'term' => $file]);
+				dba::insert('term', [
+					'uid' => $message["uid"],
+					'oid' => $itemid,
+					'otype' => TERM_OBJ_POST,
+					'type' => TERM_FILE,
+					'term' => $file
+				]);
 			}
 		}
 
 		if (preg_match_all("/\<(.*?)\>/ism", $message["file"], $files)) {
 			foreach ($files[1] as $file) {
-				dba::insert('term', ['uid' => $message["uid"], 'oid' => $itemid, 'otype' => TERM_OBJ_POST, 'type' => TERM_CATEGORY, 'term' => $file]);
+				dba::insert('term', [
+					'uid' => $message["uid"],
+					'oid' => $itemid,
+					'otype' => TERM_OBJ_POST,
+					'type' => TERM_CATEGORY,
+					'term' => $file
+				]);
 			}
 		}
 	}

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -84,7 +84,7 @@ class User
 			return $default_group;
 		}
 
-		$user = dba::select('user', ['def_gid'], ['uid' => $uid], ['limit' => 1]);
+		$user = dba::selectOne('user', ['def_gid'], ['uid' => $uid]);
 
 		if (DBM::is_result($user)) {
 			$default_group = $user["def_gid"];
@@ -112,16 +112,14 @@ class User
 		if (is_object($user_info)) {
 			$user = (array) $user_info;
 		} elseif (is_int($user_info)) {
-			$user = dba::select('user',
-				['uid', 'password'],
+			$user = dba::selectOne('user', ['uid', 'password'],
 				[
 					'uid' => $user_info,
 					'blocked' => 0,
 					'account_expired' => 0,
 					'account_removed' => 0,
 					'verified' => 1
-				],
-				['limit' => 1]
+				]
 			);
 		} elseif (is_string($user_info)) {
 			$user = dba::fetch_first('SELECT `uid`, `password`
@@ -330,7 +328,7 @@ class User
 
 		if ($insert_result) {
 			$uid = dba::lastInsertId();
-			$user = dba::select('user', [], ['uid' => $uid], ['limit' => 1]);
+			$user = dba::selectOne('user', [], ['uid' => $uid]);
 		} else {
 			throw new Exception(t('An error occurred during registration. Please try again.'));
 		}
@@ -532,7 +530,7 @@ class User
 
 		logger('Removing user: ' . $uid);
 
-		$user = dba::select('user', [], ['uid' => $uid], ['limit' => 1]);
+		$user = dba::selectOne('user', [], ['uid' => $uid]);
 
 		call_hooks('remove_user', $user);
 

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -84,7 +84,7 @@ class User
 			return $default_group;
 		}
 
-		$user = dba::selectOne('user', ['def_gid'], ['uid' => $uid]);
+		$user = dba::selectFirst('user', ['def_gid'], ['uid' => $uid]);
 
 		if (DBM::is_result($user)) {
 			$default_group = $user["def_gid"];
@@ -112,7 +112,7 @@ class User
 		if (is_object($user_info)) {
 			$user = (array) $user_info;
 		} elseif (is_int($user_info)) {
-			$user = dba::selectOne('user', ['uid', 'password'],
+			$user = dba::selectFirst('user', ['uid', 'password'],
 				[
 					'uid' => $user_info,
 					'blocked' => 0,
@@ -328,7 +328,7 @@ class User
 
 		if ($insert_result) {
 			$uid = dba::lastInsertId();
-			$user = dba::selectOne('user', [], ['uid' => $uid]);
+			$user = dba::selectFirst('user', [], ['uid' => $uid]);
 		} else {
 			throw new Exception(t('An error occurred during registration. Please try again.'));
 		}
@@ -530,7 +530,7 @@ class User
 
 		logger('Removing user: ' . $uid);
 
-		$user = dba::selectOne('user', [], ['uid' => $uid]);
+		$user = dba::selectFirst('user', [], ['uid' => $uid]);
 
 		call_hooks('remove_user', $user);
 

--- a/src/Module/Login.php
+++ b/src/Module/Login.php
@@ -99,7 +99,7 @@ class Login extends BaseModule
 			} else {
 				$user_id = User::authenticate(trim($_POST['username']), trim($_POST['password']));
 				if ($user_id) {
-					$record = dba::selectOne('user', [], ['uid' => $user_id]);
+					$record = dba::selectFirst('user', [], ['uid' => $user_id]);
 				}
 			}
 
@@ -141,7 +141,7 @@ class Login extends BaseModule
 			$data = json_decode($_COOKIE["Friendica"]);
 			if (isset($data->uid)) {
 
-				$user = dba::selectOne('user', [],
+				$user = dba::selectFirst('user', [],
 					[
 						'uid'             => $data->uid,
 						'blocked'         => false,
@@ -196,7 +196,7 @@ class Login extends BaseModule
 					goaway(self::getApp()->get_baseurl());
 				}
 
-				$user = dba::selectOne('user', [],
+				$user = dba::selectFirst('user', [],
 					[
 						'uid'             => $_SESSION['uid'],
 						'blocked'         => false,

--- a/src/Module/Login.php
+++ b/src/Module/Login.php
@@ -99,7 +99,7 @@ class Login extends BaseModule
 			} else {
 				$user_id = User::authenticate(trim($_POST['username']), trim($_POST['password']));
 				if ($user_id) {
-					$record = dba::select('user', [], ['uid' => $user_id], ['limit' => 1]);
+					$record = dba::selectOne('user', [], ['uid' => $user_id]);
 				}
 			}
 
@@ -141,18 +141,15 @@ class Login extends BaseModule
 			$data = json_decode($_COOKIE["Friendica"]);
 			if (isset($data->uid)) {
 
-				$user = dba::select('user',
-					[],
+				$user = dba::selectOne('user', [],
 					[
 						'uid'             => $data->uid,
 						'blocked'         => false,
 						'account_expired' => false,
 						'account_removed' => false,
 						'verified'        => true,
-					],
-					['limit' => 1]
+					]
 				);
-
 				if (DBM::is_result($user)) {
 					if ($data->hash != cookie_hash($user)) {
 						logger("Hash for user " . $data->uid . " doesn't fit.");
@@ -199,16 +196,14 @@ class Login extends BaseModule
 					goaway(self::getApp()->get_baseurl());
 				}
 
-				$user = dba::select('user',
-					[],
+				$user = dba::selectOne('user', [],
 					[
 						'uid'             => $_SESSION['uid'],
 						'blocked'         => false,
 						'account_expired' => false,
 						'account_removed' => false,
 						'verified'        => true,
-					],
-					['limit' => 1]
+					]
 				);
 				if (!DBM::is_result($user)) {
 					nuke_session();

--- a/src/Network/FKOAuth1.php
+++ b/src/Network/FKOAuth1.php
@@ -40,7 +40,7 @@ class FKOAuth1 extends OAuthServer
 	{
 		logger("FKOAuth1::loginUser $uid");
 		$a = get_app();
-		$record = dba::select('user', array(), array('uid' => $uid, 'blocked' => 0, 'account_expired' => 0, 'account_removed' => 0, 'verified' => 1), array('limit' => 1));
+		$record = dba::selectOne('user', [], ['uid' => $uid, 'blocked' => 0, 'account_expired' => 0, 'account_removed' => 0, 'verified' => 1]);
 
 		if (!DBM::is_result($record)) {
 			logger('FKOAuth1::loginUser failure: ' . print_r($_SERVER, true), LOGGER_DEBUG);
@@ -63,7 +63,7 @@ class FKOAuth1 extends OAuthServer
 			$a->timezone = $a->user['timezone'];
 		}
 
-		$r = dba::select('contact', array(), array('uid' => $_SESSION['uid'], 'self' => 1), array('limit' => 1));
+		$r = dba::selectOne('contact', [], ['uid' => $_SESSION['uid'], 'self' => 1]);
 		
 		if (DBM::is_result($r)) {
 			$a->contact = $r;

--- a/src/Network/FKOAuth1.php
+++ b/src/Network/FKOAuth1.php
@@ -40,7 +40,7 @@ class FKOAuth1 extends OAuthServer
 	{
 		logger("FKOAuth1::loginUser $uid");
 		$a = get_app();
-		$record = dba::selectOne('user', [], ['uid' => $uid, 'blocked' => 0, 'account_expired' => 0, 'account_removed' => 0, 'verified' => 1]);
+		$record = dba::selectFirst('user', [], ['uid' => $uid, 'blocked' => 0, 'account_expired' => 0, 'account_removed' => 0, 'verified' => 1]);
 
 		if (!DBM::is_result($record)) {
 			logger('FKOAuth1::loginUser failure: ' . print_r($_SERVER, true), LOGGER_DEBUG);
@@ -63,7 +63,7 @@ class FKOAuth1 extends OAuthServer
 			$a->timezone = $a->user['timezone'];
 		}
 
-		$r = dba::selectOne('contact', [], ['uid' => $_SESSION['uid'], 'self' => 1]);
+		$r = dba::selectFirst('contact', [], ['uid' => $_SESSION['uid'], 'self' => 1]);
 		
 		if (DBM::is_result($r)) {
 			$a->contact = $r;

--- a/src/Network/FKOAuthDataStore.php
+++ b/src/Network/FKOAuthDataStore.php
@@ -88,7 +88,7 @@ class FKOAuthDataStore extends OAuthDataStore
 	 */
 	public function lookup_nonce($consumer, $token, $nonce, $timestamp)
 	{
-		$r = dba::select('tokens', ['id', 'secret'], ['client_id' => $consumer->key, 'id' => $nonce, 'expires' => $timestamp], ['limit' => 1]);
+		$r = dba::selectOne('tokens', ['id', 'secret'], ['client_id' => $consumer->key, 'id' => $nonce, 'expires' => $timestamp]);
 
 		if (DBM::is_result($r)) {
 			return new \OAuthToken($r['id'], $r['secret']);

--- a/src/Network/FKOAuthDataStore.php
+++ b/src/Network/FKOAuthDataStore.php
@@ -88,7 +88,7 @@ class FKOAuthDataStore extends OAuthDataStore
 	 */
 	public function lookup_nonce($consumer, $token, $nonce, $timestamp)
 	{
-		$r = dba::selectOne('tokens', ['id', 'secret'], ['client_id' => $consumer->key, 'id' => $nonce, 'expires' => $timestamp]);
+		$r = dba::selectFirst('tokens', ['id', 'secret'], ['client_id' => $consumer->key, 'id' => $nonce, 'expires' => $timestamp]);
 
 		if (DBM::is_result($r)) {
 			return new \OAuthToken($r['id'], $r['secret']);

--- a/src/Network/Probe.php
+++ b/src/Network/Probe.php
@@ -406,7 +406,7 @@ class Probe
 
 				$condition = array('nurl' => normalise_link($data["url"]));
 
-				$old_fields = dba::select('gcontact', $fieldnames, $condition, array('limit' => 1));
+				$old_fields = dba::selectOne('gcontact', $fieldnames, $condition);
 
 				dba::update('gcontact', $fields, $condition, $old_fields);
 
@@ -439,7 +439,7 @@ class Probe
 
 				$condition = array('nurl' => normalise_link($data["url"]), 'self' => false, 'uid' => 0);
 
-				$old_fields = dba::select('contact', $fieldnames, $condition, array('limit' => 1));
+				$old_fields = dba::selectOne('contact', $fieldnames, $condition);
 
 				dba::update('contact', $fields, $condition, $old_fields);
 			}

--- a/src/Network/Probe.php
+++ b/src/Network/Probe.php
@@ -406,7 +406,7 @@ class Probe
 
 				$condition = array('nurl' => normalise_link($data["url"]));
 
-				$old_fields = dba::selectOne('gcontact', $fieldnames, $condition);
+				$old_fields = dba::selectFirst('gcontact', $fieldnames, $condition);
 
 				dba::update('gcontact', $fields, $condition, $old_fields);
 
@@ -439,7 +439,7 @@ class Probe
 
 				$condition = array('nurl' => normalise_link($data["url"]), 'self' => false, 'uid' => 0);
 
-				$old_fields = dba::selectOne('contact', $fieldnames, $condition);
+				$old_fields = dba::selectFirst('contact', $fieldnames, $condition);
 
 				dba::update('contact', $fields, $condition, $old_fields);
 			}

--- a/src/Object/Post.php
+++ b/src/Object/Post.php
@@ -261,7 +261,7 @@ class Post extends BaseObject
 					'classundo' => $item['starred'] ? "" : "hidden",
 					'starred'   => t('starred'),
 				);
-				$r = dba::select('thread', array('ignored'), array('uid' => $item['uid'], 'iid' => $item['id']), array('limit' => 1));
+				$r = dba::selectOne('thread', ['ignored'], ['uid' => $item['uid'], 'iid' => $item['id']]);
 				if (DBM::is_result($r)) {
 					$ignore = array(
 						'do'        => t("ignore thread"),

--- a/src/Object/Post.php
+++ b/src/Object/Post.php
@@ -261,7 +261,7 @@ class Post extends BaseObject
 					'classundo' => $item['starred'] ? "" : "hidden",
 					'starred'   => t('starred'),
 				);
-				$r = dba::selectOne('thread', ['ignored'], ['uid' => $item['uid'], 'iid' => $item['id']]);
+				$r = dba::selectFirst('thread', ['ignored'], ['uid' => $item['uid'], 'iid' => $item['id']]);
 				if (DBM::is_result($r)) {
 					$ignore = array(
 						'do'        => t("ignore thread"),

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -2015,7 +2015,7 @@ class Diaspora
 
 		// like on comments have the comment as parent. So we need to fetch the toplevel parent
 		if ($parent_item["id"] != $parent_item["parent"]) {
-			$toplevel = dba::select('item', array('origin'), array('id' => $parent_item["parent"]), array('limit' => 1));
+			$toplevel = dba::selectOne('item', ['origin'], ['id' => $parent_item["parent"]]);
 			$origin = $toplevel["origin"];
 		} else {
 			$origin = $parent_item["origin"];
@@ -2317,7 +2317,7 @@ class Diaspora
 
 				$arr["last-child"] = 1;
 
-				$user = dba::select('user', ['allow_cid', 'allow_gid', 'deny_cid', 'deny_gid'], ['uid' => $importer["uid"]], ['limit' => 1]);
+				$user = dba::selectOne('user', ['allow_cid', 'allow_gid', 'deny_cid', 'deny_gid'], ['uid' => $importer["uid"]]);
 
 				$arr["allow_cid"] = $user["allow_cid"];
 				$arr["allow_gid"] = $user["allow_gid"];
@@ -2741,7 +2741,7 @@ class Diaspora
 
 		while ($item = dba::fetch($r)) {
 			// Fetch the parent item
-			$parent = dba::select('item', array('author-link', 'origin'), array('id' => $item["parent"]), array('limit' => 1));
+			$parent = dba::selectOne('item', ['author-link', 'origin'], ['id' => $item["parent"]]);
 
 			// Only delete it if the parent author really fits
 			if (!link_compare($parent["author-link"], $contact["url"]) && !link_compare($item["author-link"], $contact["url"])) {
@@ -3255,7 +3255,7 @@ class Diaspora
 		// If the item belongs to a user, we take this user id.
 		if ($item['uid'] == 0) {
 			$condition = ['verified' => true, 'blocked' => false, 'account_removed' => false, 'account_expired' => false];
-			$first_user = dba::select('user', ['uid'], $condition, ['limit' => 1]);
+			$first_user = dba::selectOne('user', ['uid'], $condition);
 			$owner = User::getOwnerDataById($first_user['uid']);
 		} else {
 			$owner = User::getOwnerDataById($item['uid']);

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -2015,7 +2015,7 @@ class Diaspora
 
 		// like on comments have the comment as parent. So we need to fetch the toplevel parent
 		if ($parent_item["id"] != $parent_item["parent"]) {
-			$toplevel = dba::selectOne('item', ['origin'], ['id' => $parent_item["parent"]]);
+			$toplevel = dba::selectFirst('item', ['origin'], ['id' => $parent_item["parent"]]);
 			$origin = $toplevel["origin"];
 		} else {
 			$origin = $parent_item["origin"];
@@ -2317,7 +2317,7 @@ class Diaspora
 
 				$arr["last-child"] = 1;
 
-				$user = dba::selectOne('user', ['allow_cid', 'allow_gid', 'deny_cid', 'deny_gid'], ['uid' => $importer["uid"]]);
+				$user = dba::selectFirst('user', ['allow_cid', 'allow_gid', 'deny_cid', 'deny_gid'], ['uid' => $importer["uid"]]);
 
 				$arr["allow_cid"] = $user["allow_cid"];
 				$arr["allow_gid"] = $user["allow_gid"];
@@ -2741,7 +2741,7 @@ class Diaspora
 
 		while ($item = dba::fetch($r)) {
 			// Fetch the parent item
-			$parent = dba::selectOne('item', ['author-link', 'origin'], ['id' => $item["parent"]]);
+			$parent = dba::selectFirst('item', ['author-link', 'origin'], ['id' => $item["parent"]]);
 
 			// Only delete it if the parent author really fits
 			if (!link_compare($parent["author-link"], $contact["url"]) && !link_compare($item["author-link"], $contact["url"])) {
@@ -3255,7 +3255,7 @@ class Diaspora
 		// If the item belongs to a user, we take this user id.
 		if ($item['uid'] == 0) {
 			$condition = ['verified' => true, 'blocked' => false, 'account_removed' => false, 'account_expired' => false];
-			$first_user = dba::selectOne('user', ['uid'], $condition);
+			$first_user = dba::selectFirst('user', ['uid'], $condition);
 			$owner = User::getOwnerDataById($first_user['uid']);
 		} else {
 			$owner = User::getOwnerDataById($item['uid']);

--- a/src/Protocol/Feed.php
+++ b/src/Protocol/Feed.php
@@ -254,7 +254,7 @@ class Feed {
 			if (!$simulate) {
 				$condition = ["`uid` = ? AND `uri` = ? AND `network` IN (?, ?)",
 					$importer["uid"], $item["uri"], NETWORK_FEED, NETWORK_DFRN];
-				$previous = dba::selectOne('item', ['id'], $condition);
+				$previous = dba::selectFirst('item', ['id'], $condition);
 				if (DBM::is_result($previous)) {
 					logger("Item with uri ".$item["uri"]." for user ".$importer["uid"]." already existed under id ".$previous["id"], LOGGER_DEBUG);
 					continue;

--- a/src/Protocol/Feed.php
+++ b/src/Protocol/Feed.php
@@ -254,7 +254,7 @@ class Feed {
 			if (!$simulate) {
 				$condition = ["`uid` = ? AND `uri` = ? AND `network` IN (?, ?)",
 					$importer["uid"], $item["uri"], NETWORK_FEED, NETWORK_DFRN];
-				$previous = dba::select('item', ['id'], $condition, ['limit' => 1]);
+				$previous = dba::selectOne('item', ['id'], $condition);
 				if (DBM::is_result($previous)) {
 					logger("Item with uri ".$item["uri"]." for user ".$importer["uid"]." already existed under id ".$previous["id"], LOGGER_DEBUG);
 					continue;

--- a/src/Protocol/OStatus.php
+++ b/src/Protocol/OStatus.php
@@ -70,9 +70,9 @@ class OStatus
 		$found = false;
 
 		if ($aliaslink != '') {
-			$condition = array("`uid` = ? AND `alias` = ? AND `network` != ?",
-					$importer["uid"], $aliaslink, NETWORK_STATUSNET);
-			$r = dba::select('contact', array(), $condition, array('limit' => 1));
+			$condition = ["`uid` = ? AND `alias` = ? AND `network` != ?",
+					$importer["uid"], $aliaslink, NETWORK_STATUSNET];
+			$r = dba::selectOne('contact', [], $condition);
 
 			if (DBM::is_result($r)) {
 				$found = true;
@@ -89,9 +89,9 @@ class OStatus
 				$aliaslink = $author["author-link"];
 			}
 
-			$condition = array("`uid` = ? AND `nurl` IN (?, ?) AND `network` != ?", $importer["uid"],
-					normalise_link($author["author-link"]), normalise_link($aliaslink), NETWORK_STATUSNET);
-			$r = dba::select('contact', array(), $condition, array('limit' => 1));
+			$condition = ["`uid` = ? AND `nurl` IN (?, ?) AND `network` != ?", $importer["uid"],
+					normalise_link($author["author-link"]), normalise_link($aliaslink), NETWORK_STATUSNET];
+			$r = dba::selectOne('contact', [], $condition);
 
 			if (DBM::is_result($r)) {
 				$found = true;
@@ -104,9 +104,9 @@ class OStatus
 		}
 
 		if (!$found && ($addr != "")) {
-			$condition = array("`uid` = ? AND `addr` = ? AND `network` != ?",
-					$importer["uid"], $addr, NETWORK_STATUSNET);
-			$r = dba::select('contact', array(), $condition, array('limit' => 1));
+			$condition = ["`uid` = ? AND `addr` = ? AND `network` != ?",
+					$importer["uid"], $addr, NETWORK_STATUSNET];
+			$r = dba::selectOne('contact', [], $condition);
 
 			if (DBM::is_result($r)) {
 				$found = true;
@@ -207,8 +207,8 @@ class OStatus
 			$cid = Contact::getIdForURL($aliaslink, 0);
 
 			if ($cid) {
-				$fields = array('url', 'nurl', 'name', 'nick', 'alias', 'about', 'location');
-				$old_contact = dba::select('contact', $fields, array('id' => $cid), array('limit' => 1));
+				$fields = ['url', 'nurl', 'name', 'nick', 'alias', 'about', 'location'];
+				$old_contact = dba::selectOne('contact', $fields, ['id' => $cid]);
 
 				// Update it with the current values
 				$fields = array('url' => $author["author-link"], 'name' => $contact["name"],
@@ -541,8 +541,8 @@ class OStatus
 	 */
 	private static function deleteNotice($item)
 	{
-		$condition = array('uid' => $item['uid'], 'author-link' => $item['author-link'], 'uri' => $item['uri']);
-		$deleted = dba::select('item', array('id', 'parent-uri'), $condition, array('limit' => 1));
+		$condition = ['uid' => $item['uid'], 'author-link' => $item['author-link'], 'uri' => $item['uri']];
+		$deleted = dba::selectOne('item', ['id', 'parent-uri'], $condition);
 		if (!DBM::is_result($deleted)) {
 			logger('Item from '.$item['author-link'].' with uri '.$item['uri'].' for user '.$item['uid']." wasn't found. We don't delete it. ");
 			return;
@@ -895,8 +895,8 @@ class OStatus
 	 */
 	private static function fetchRelated($related, $related_uri, $importer)
 	{
-		$condition = array('`item-uri` = ? AND `protocol` IN (?, ?)', $related_uri, PROTOCOL_DFRN, PROTOCOL_OSTATUS_SALMON);
-		$conversation = dba::select('conversation', array('source', 'protocol'), $condition,  array('limit' => 1));
+		$condition = ['`item-uri` = ? AND `protocol` IN (?, ?)', $related_uri, PROTOCOL_DFRN, PROTOCOL_OSTATUS_SALMON];
+		$conversation = dba::selectOne('conversation', ['source', 'protocol'], $condition);
 		if (DBM::is_result($conversation)) {
 			$stored = true;
 			$xml = $conversation['source'];
@@ -975,8 +975,8 @@ class OStatus
 
 		// Finally we take the data that we fetched from "ostatus:conversation"
 		if ($xml == '') {
-			$condition = array('item-uri' => $related_uri, 'protocol' => PROTOCOL_SPLITTED_CONV);
-			$conversation = dba::select('conversation', array('source'), $condition,  array('limit' => 1));
+			$condition = ['item-uri' => $related_uri, 'protocol' => PROTOCOL_SPLITTED_CONV];
+			$conversation = dba::selectOne('conversation', ['source'], $condition);
 			if (DBM::is_result($conversation)) {
 				$stored = true;
 				logger('Got cached XML from conversation for URI '.$related_uri, LOGGER_DEBUG);

--- a/src/Protocol/OStatus.php
+++ b/src/Protocol/OStatus.php
@@ -72,7 +72,7 @@ class OStatus
 		if ($aliaslink != '') {
 			$condition = ["`uid` = ? AND `alias` = ? AND `network` != ?",
 					$importer["uid"], $aliaslink, NETWORK_STATUSNET];
-			$r = dba::selectOne('contact', [], $condition);
+			$r = dba::selectFirst('contact', [], $condition);
 
 			if (DBM::is_result($r)) {
 				$found = true;
@@ -91,7 +91,7 @@ class OStatus
 
 			$condition = ["`uid` = ? AND `nurl` IN (?, ?) AND `network` != ?", $importer["uid"],
 					normalise_link($author["author-link"]), normalise_link($aliaslink), NETWORK_STATUSNET];
-			$r = dba::selectOne('contact', [], $condition);
+			$r = dba::selectFirst('contact', [], $condition);
 
 			if (DBM::is_result($r)) {
 				$found = true;
@@ -106,7 +106,7 @@ class OStatus
 		if (!$found && ($addr != "")) {
 			$condition = ["`uid` = ? AND `addr` = ? AND `network` != ?",
 					$importer["uid"], $addr, NETWORK_STATUSNET];
-			$r = dba::selectOne('contact', [], $condition);
+			$r = dba::selectFirst('contact', [], $condition);
 
 			if (DBM::is_result($r)) {
 				$found = true;
@@ -208,7 +208,7 @@ class OStatus
 
 			if ($cid) {
 				$fields = ['url', 'nurl', 'name', 'nick', 'alias', 'about', 'location'];
-				$old_contact = dba::selectOne('contact', $fields, ['id' => $cid]);
+				$old_contact = dba::selectFirst('contact', $fields, ['id' => $cid]);
 
 				// Update it with the current values
 				$fields = array('url' => $author["author-link"], 'name' => $contact["name"],
@@ -542,7 +542,7 @@ class OStatus
 	private static function deleteNotice($item)
 	{
 		$condition = ['uid' => $item['uid'], 'author-link' => $item['author-link'], 'uri' => $item['uri']];
-		$deleted = dba::selectOne('item', ['id', 'parent-uri'], $condition);
+		$deleted = dba::selectFirst('item', ['id', 'parent-uri'], $condition);
 		if (!DBM::is_result($deleted)) {
 			logger('Item from '.$item['author-link'].' with uri '.$item['uri'].' for user '.$item['uid']." wasn't found. We don't delete it. ");
 			return;
@@ -896,7 +896,7 @@ class OStatus
 	private static function fetchRelated($related, $related_uri, $importer)
 	{
 		$condition = ['`item-uri` = ? AND `protocol` IN (?, ?)', $related_uri, PROTOCOL_DFRN, PROTOCOL_OSTATUS_SALMON];
-		$conversation = dba::selectOne('conversation', ['source', 'protocol'], $condition);
+		$conversation = dba::selectFirst('conversation', ['source', 'protocol'], $condition);
 		if (DBM::is_result($conversation)) {
 			$stored = true;
 			$xml = $conversation['source'];
@@ -976,7 +976,7 @@ class OStatus
 		// Finally we take the data that we fetched from "ostatus:conversation"
 		if ($xml == '') {
 			$condition = ['item-uri' => $related_uri, 'protocol' => PROTOCOL_SPLITTED_CONV];
-			$conversation = dba::selectOne('conversation', ['source'], $condition);
+			$conversation = dba::selectFirst('conversation', ['source'], $condition);
 			if (DBM::is_result($conversation)) {
 				$stored = true;
 				logger('Got cached XML from conversation for URI '.$related_uri, LOGGER_DEBUG);

--- a/src/Protocol/PortableContact.php
+++ b/src/Protocol/PortableContact.php
@@ -66,7 +66,7 @@ class PortableContact
 
 		if ($cid) {
 			if (!$url || !$uid) {
-				$r = dba::select('contact', ['poco', 'uid'], ['id' => $cid], ['limit' => 1]);
+				$r = dba::selectOne('contact', ['poco', 'uid'], ['id' => $cid]);
 				if (DBM::is_result($r)) {
 					$url = $r['poco'];
 					$uid = $r['uid'];
@@ -813,7 +813,7 @@ class PortableContact
 			return false;
 		}
 
-		$servers = dba::select('gserver', [], ['nurl' => normalise_link($server_url)], ['limit' => 1]);
+		$servers = dba::selectOne('gserver', [], ['nurl' => normalise_link($server_url)]);
 		if (DBM::is_result($servers)) {
 			if ($servers["created"] <= NULL_DATE) {
 				$fields = ['created' => datetime_convert()];

--- a/src/Protocol/PortableContact.php
+++ b/src/Protocol/PortableContact.php
@@ -66,7 +66,7 @@ class PortableContact
 
 		if ($cid) {
 			if (!$url || !$uid) {
-				$r = dba::selectOne('contact', ['poco', 'uid'], ['id' => $cid]);
+				$r = dba::selectFirst('contact', ['poco', 'uid'], ['id' => $cid]);
 				if (DBM::is_result($r)) {
 					$url = $r['poco'];
 					$uid = $r['uid'];
@@ -813,7 +813,7 @@ class PortableContact
 			return false;
 		}
 
-		$servers = dba::selectOne('gserver', [], ['nurl' => normalise_link($server_url)]);
+		$servers = dba::selectFirst('gserver', [], ['nurl' => normalise_link($server_url)]);
 		if (DBM::is_result($servers)) {
 			if ($servers["created"] <= NULL_DATE) {
 				$fields = ['created' => datetime_convert()];

--- a/src/Util/ExAuth.php
+++ b/src/Util/ExAuth.php
@@ -226,7 +226,7 @@ class ExAuth
 		if ($a->get_hostname() == $aCommand[2]) {
 			$this->writeLog(LOG_INFO, 'internal auth for ' . $sUser . '@' . $aCommand[2]);
 
-			$aUser = dba::select('user', ['uid', 'password'], ['nickname' => $sUser], ['limit' => 1]);
+			$aUser = dba::selectOne('user', ['uid', 'password'], ['nickname' => $sUser]);
 			if (DBM::is_result($aUser)) {
 				$uid = $aUser['uid'];
 				$success = User::authenticate($aUser, $aCommand[3]);

--- a/src/Util/ExAuth.php
+++ b/src/Util/ExAuth.php
@@ -226,7 +226,7 @@ class ExAuth
 		if ($a->get_hostname() == $aCommand[2]) {
 			$this->writeLog(LOG_INFO, 'internal auth for ' . $sUser . '@' . $aCommand[2]);
 
-			$aUser = dba::selectOne('user', ['uid', 'password'], ['nickname' => $sUser]);
+			$aUser = dba::selectFirst('user', ['uid', 'password'], ['nickname' => $sUser]);
 			if (DBM::is_result($aUser)) {
 				$uid = $aUser['uid'];
 				$success = User::authenticate($aUser, $aCommand[3]);

--- a/src/Util/Lock.php
+++ b/src/Util/Lock.php
@@ -126,7 +126,7 @@ class Lock
 
 		do {
 			dba::lock('locks');
-			$lock = dba::selectOne('locks', ['locked', 'pid'], ['name' => $fn_name]);
+			$lock = dba::selectFirst('locks', ['locked', 'pid'], ['name' => $fn_name]);
 
 			if (DBM::is_result($lock)) {
 				if ($lock['locked']) {

--- a/src/Util/Lock.php
+++ b/src/Util/Lock.php
@@ -126,7 +126,7 @@ class Lock
 
 		do {
 			dba::lock('locks');
-			$lock = dba::select('locks', array('locked', 'pid'), array('name' => $fn_name), array('limit' => 1));
+			$lock = dba::selectOne('locks', ['locked', 'pid'], ['name' => $fn_name]);
 
 			if (DBM::is_result($lock)) {
 				if ($lock['locked']) {

--- a/src/Worker/Expire.php
+++ b/src/Worker/Expire.php
@@ -39,7 +39,7 @@ class Expire {
 			}
 			return;
 		} elseif (intval($param) > 0) {
-			$user = dba::selectOne('user', ['uid', 'username', 'expire'], ['uid' => $param]);
+			$user = dba::selectFirst('user', ['uid', 'username', 'expire'], ['uid' => $param]);
 			if (DBM::is_result($user)) {
 				logger('Expire items for user '.$user['uid'].' ('.$user['username'].') - interval: '.$user['expire'], LOGGER_DEBUG);
 				item_expire($user['uid'], $user['expire']);

--- a/src/Worker/Expire.php
+++ b/src/Worker/Expire.php
@@ -39,7 +39,7 @@ class Expire {
 			}
 			return;
 		} elseif (intval($param) > 0) {
-			$user = dba::select('user', array('uid', 'username', 'expire'), array('uid' => $param), array('limit' => 1));
+			$user = dba::selectOne('user', ['uid', 'username', 'expire'], ['uid' => $param]);
 			if (DBM::is_result($user)) {
 				logger('Expire items for user '.$user['uid'].' ('.$user['username'].') - interval: '.$user['expire'], LOGGER_DEBUG);
 				item_expire($user['uid'], $user['expire']);

--- a/src/Worker/Notifier.php
+++ b/src/Worker/Notifier.php
@@ -267,7 +267,7 @@ class Notifier {
 
 				$fields = ['forum', 'prv'];
 				$condition = ['id' => $target_item['contact-id']];
-				$contact = dba::selectOne('contact', $fields, $condition);
+				$contact = dba::selectFirst('contact', $fields, $condition);
 				if (!DBM::is_result($contact)) {
 					// Should never happen
 					return false;

--- a/src/Worker/Notifier.php
+++ b/src/Worker/Notifier.php
@@ -265,9 +265,9 @@ class Notifier {
 				($owner['id'] != $target_item['contact-id']) &&
 				($target_item['uri'] === $target_item['parent-uri'])) {
 
-				$fields = array('forum', 'prv');
-				$condition = array('id' => $target_item['contact-id']);
-				$contact = dba::select('contact', $fields, $condition, array('limit' => 1));
+				$fields = ['forum', 'prv'];
+				$condition = ['id' => $target_item['contact-id']];
+				$contact = dba::selectOne('contact', $fields, $condition);
 				if (!DBM::is_result($contact)) {
 					// Should never happen
 					return false;

--- a/src/Worker/OnePoll.php
+++ b/src/Worker/OnePoll.php
@@ -42,7 +42,7 @@ Class OnePoll
 
 		$d = datetime_convert();
 
-		$contact = dba::select('contact', [], ['id' => $contact_id], ['limit' => 1]);
+		$contact = dba::selectOne('contact', [], ['id' => $contact_id]);
 		if (!DBM::is_result($contact)) {
 			logger('Contact not found or cannot be used.');
 			return;
@@ -339,14 +339,14 @@ Class OnePoll
 			logger("Mail: Enabled", LOGGER_DEBUG);
 
 			$mbox = null;
-			$x = dba::select('user', array('prvkey'), array('uid' => $importer_uid), array('limit' => 1));
+			$user = dba::selectOne('user', ['prvkey'], ['uid' => $importer_uid]);
 
-			$condition = array("`server` != '' AND `uid` = ?", $importer_uid);
-			$mailconf = dba::select('mailacct', array(), $condition, array('limit' => 1));
-			if (DBM::is_result($x) && DBM::is_result($mailconf)) {
+			$condition = ["`server` != '' AND `uid` = ?", $importer_uid];
+			$mailconf = dba::selectOne('mailacct', [], $condition);
+			if (DBM::is_result($user) && DBM::is_result($mailconf)) {
 				$mailbox = Email::constructMailboxName($mailconf);
 				$password = '';
-				openssl_private_decrypt(hex2bin($mailconf['pass']), $password, $x['prvkey']);
+				openssl_private_decrypt(hex2bin($mailconf['pass']), $password, $user['prvkey']);
 				$mbox = Email::connect($mailbox, $mailconf['user'], $password);
 				unset($password);
 				logger("Mail: Connect to " . $mailconf['user']);
@@ -382,9 +382,9 @@ Class OnePoll
 							$datarray['uri'] = Email::msgid2iri(trim($meta->message_id, '<>'));
 
 							// Have we seen it before?
-							$fields = array('deleted', 'id');
-							$condition = array('uid' => $importer_uid, 'uri' => $datarray['uri']);
-							$r = dba::select('item', $fields, $condition, array('limit' => 1));
+							$fields = ['deleted', 'id'];
+							$condition = ['uid' => $importer_uid, 'uri' => $datarray['uri']];
+							$r = dba::selectOne('item', $fields, $condition);
 
 							if (DBM::is_result($r)) {
 								logger("Mail: Seen before ".$msg_uid." for ".$mailconf['user']." UID: ".$importer_uid." URI: ".$datarray['uri'],LOGGER_DEBUG);

--- a/src/Worker/OnePoll.php
+++ b/src/Worker/OnePoll.php
@@ -42,7 +42,7 @@ Class OnePoll
 
 		$d = datetime_convert();
 
-		$contact = dba::selectOne('contact', [], ['id' => $contact_id]);
+		$contact = dba::selectFirst('contact', [], ['id' => $contact_id]);
 		if (!DBM::is_result($contact)) {
 			logger('Contact not found or cannot be used.');
 			return;
@@ -339,10 +339,10 @@ Class OnePoll
 			logger("Mail: Enabled", LOGGER_DEBUG);
 
 			$mbox = null;
-			$user = dba::selectOne('user', ['prvkey'], ['uid' => $importer_uid]);
+			$user = dba::selectFirst('user', ['prvkey'], ['uid' => $importer_uid]);
 
 			$condition = ["`server` != '' AND `uid` = ?", $importer_uid];
-			$mailconf = dba::selectOne('mailacct', [], $condition);
+			$mailconf = dba::selectFirst('mailacct', [], $condition);
 			if (DBM::is_result($user) && DBM::is_result($mailconf)) {
 				$mailbox = Email::constructMailboxName($mailconf);
 				$password = '';
@@ -384,7 +384,7 @@ Class OnePoll
 							// Have we seen it before?
 							$fields = ['deleted', 'id'];
 							$condition = ['uid' => $importer_uid, 'uri' => $datarray['uri']];
-							$r = dba::selectOne('item', $fields, $condition);
+							$r = dba::selectFirst('item', $fields, $condition);
 
 							if (DBM::is_result($r)) {
 								logger("Mail: Seen before ".$msg_uid." for ".$mailconf['user']." UID: ".$importer_uid." URI: ".$datarray['uri'],LOGGER_DEBUG);

--- a/src/Worker/Queue.php
+++ b/src/Worker/Queue.php
@@ -80,7 +80,7 @@ class Queue
 
 		$q_item = $r[0];
 
-		$contact = dba::select('contact', [], ['id' => $q_item['cid']], ['limit' => 1]);
+		$contact = dba::selectOne('contact', [], ['id' => $q_item['cid']]);
 		if (!DBM::is_result($contact)) {
 			remove_queue_item($q_item['id']);
 			return;
@@ -113,7 +113,7 @@ class Queue
 			}
 		}
 
-		$user = dba::select('user', [], ['uid' => $contact['uid']], ['limit' => 1]);
+		$user = dba::selectOne('user', [], ['uid' => $contact['uid']]);
 		if (!DBM::is_result($user)) {
 			remove_queue_item($q_item['id']);
 			return;

--- a/src/Worker/Queue.php
+++ b/src/Worker/Queue.php
@@ -80,7 +80,7 @@ class Queue
 
 		$q_item = $r[0];
 
-		$contact = dba::selectOne('contact', [], ['id' => $q_item['cid']]);
+		$contact = dba::selectFirst('contact', [], ['id' => $q_item['cid']]);
 		if (!DBM::is_result($contact)) {
 			remove_queue_item($q_item['id']);
 			return;
@@ -113,7 +113,7 @@ class Queue
 			}
 		}
 
-		$user = dba::selectOne('user', [], ['uid' => $contact['uid']]);
+		$user = dba::selectFirst('user', [], ['uid' => $contact['uid']]);
 		if (!DBM::is_result($user)) {
 			remove_queue_item($q_item['id']);
 			return;

--- a/util/global_community_silence.php
+++ b/util/global_community_silence.php
@@ -57,7 +57,7 @@ if (in_array($net['network'], array(NETWORK_PHANTOM, NETWORK_MAIL))) {
 	exit(1);
 }
 $nurl = normalise_link($net['url']);
-$r = dba::select("contact", array("id"), array("nurl" => $nurl, "uid" => 0), array("limit" => 1));
+$r = dba::selectOne("contact", ["id"], ["nurl" => $nurl, "uid" => 0]);
 if (DBM::is_result($r)) {
 	dba::update("contact", array("hidden" => true), array("id" => $r["id"]));
 	echo "NOTICE: The account should be silenced from the global community page\r\n";

--- a/util/global_community_silence.php
+++ b/util/global_community_silence.php
@@ -57,7 +57,7 @@ if (in_array($net['network'], array(NETWORK_PHANTOM, NETWORK_MAIL))) {
 	exit(1);
 }
 $nurl = normalise_link($net['url']);
-$r = dba::selectOne("contact", ["id"], ["nurl" => $nurl, "uid" => 0]);
+$r = dba::selectFirst("contact", ["id"], ["nurl" => $nurl, "uid" => 0]);
 if (DBM::is_result($r)) {
 	dba::update("contact", array("hidden" => true), array("id" => $r["id"]));
 	echo "NOTICE: The account should be silenced from the global community page\r\n";


### PR DESCRIPTION
Part of #4176

This PR separates the two different modes of `dba::select()` about the `limit => 1` parameter.

This saves characters on one-liner, makes return type of `dba::select` less vague and generally removes code cruft, whether it is in calls or even in the method definition in `include/dba.php`.
  