### PR TITLE
Commenting on postings from tags on the network page does work now

### DIFF
--- a/src/Object/Post.php
+++ b/src/Object/Post.php
@@ -769,7 +769,7 @@ class Post extends BaseObject
 			$uid = $conv->getProfileOwner();
 			$parent_uid = $this->getDataValue('uid');
 
-			if (!empty($parent_uid) && empty($uid) && ($uid != $parent_uid)) {
+			if (!is_null($parent_uid) && ($uid != $parent_uid)) {
 				$uid = $parent_uid;
 			}
 


### PR DESCRIPTION
We have to get the user id from the parent entry. The previous coding worked from the community page - but not the network page.