### PR TITLE
Improve dba::selectFirst calls

### DIFF
--- a/include/api.php
+++ b/include/api.php
@@ -226,7 +226,7 @@ function api_login(App $a)
 		}
 	}
 
-	if (!$record || !count($record)) {
+	if (DBM::is_result($record)) {
 		logger('API_login failure: ' . print_r($_SERVER, true), LOGGER_DEBUG);
 		header('WWW-Authenticate: Basic realm="Friendica"');
 		//header('HTTP/1.0 401 Unauthorized');
@@ -4870,22 +4870,22 @@ function api_friendica_remoteauth()
 
 	// traditional DFRN
 
-	$r = dba::selectFirst('contact', [], ['uid' => api_user(), 'nurl' => $c_url]);
+	$contact = dba::selectFirst('contact', [], ['uid' => api_user(), 'nurl' => $c_url]);
 
-	if (!DBM::is_result($r) || ($r['network'] !== NETWORK_DFRN)) {
+	if (!DBM::is_result($contact) || ($contact['network'] !== NETWORK_DFRN)) {
 		throw new BadRequestException("Unknown contact");
 	}
 
-	$cid = $r['id'];
+	$cid = $contact['id'];
 
-	$dfrn_id = defaults($r, 'issued-id', $r['dfrn-id']);
+	$dfrn_id = defaults($contact, 'issued-id', $contact['dfrn-id']);
 
-	if ($r['duplex'] && $r['issued-id']) {
-		$orig_id = $r['issued-id'];
+	if ($contact['duplex'] && $contact['issued-id']) {
+		$orig_id = $contact['issued-id'];
 		$dfrn_id = '1:' . $orig_id;
 	}
-	if ($r['duplex'] && $r['dfrn-id']) {
-		$orig_id = $r['dfrn-id'];
+	if ($contact['duplex'] && $contact['dfrn-id']) {
+		$orig_id = $contact['dfrn-id'];
 		$dfrn_id = '0:' . $orig_id;
 	}
 
@@ -4901,10 +4901,10 @@ function api_friendica_remoteauth()
 		intval(time() + 45)
 	);
 
-	logger($r['name'] . ' ' . $sec, LOGGER_DEBUG);
+	logger($contact['name'] . ' ' . $sec, LOGGER_DEBUG);
 	$dest = ($url ? '&destination_url=' . $url : '');
 	goaway(
-		$r['poll'] . '?dfrn_id=' . $dfrn_id
+		$contact['poll'] . '?dfrn_id=' . $dfrn_id
 		. '&dfrn_version=' . DFRN_PROTOCOL_VERSION
 		. '&type=profile&sec=' . $sec . $dest . $quiet
 	);

--- a/include/contact_widgets.php
+++ b/include/contact_widgets.php
@@ -224,14 +224,14 @@ function common_friends_visitor_widget($profile_uid)
 
 	if (!$cid) {
 		if (get_my_url()) {
-			$r = dba::selectFirst('contact', ['id'],
+			$contact = dba::selectFirst('contact', ['id'],
 					['nurl' => normalise_link(get_my_url()), 'uid' => $profile_uid]);
-			if (DBM::is_result($r)) {
-				$cid = $r['id'];
+			if (DBM::is_result($contact)) {
+				$cid = $contact['id'];
 			} else {
-				$r = dba::selectFirst('gcontact', ['id'], ['nurl' => normalise_link(get_my_url())]);
-				if (DBM::is_result($r)) {
-					$zcid = $r['id'];
+				$gcontact = dba::selectFirst('gcontact', ['id'], ['nurl' => normalise_link(get_my_url())]);
+				if (DBM::is_result($gcontact)) {
+					$zcid = $gcontact['id'];
 				}
 			}
 		}

--- a/include/conversation.php
+++ b/include/conversation.php
@@ -968,10 +968,15 @@ function best_link_url($item, &$sparkle, $url = '') {
 	$clean_url = normalise_link($item['author-link']);
 
 	if (local_user()) {
-		$r = dba::selectFirst('contact', ['id'],
-			['network' => NETWORK_DFRN, 'uid' => local_user(), 'nurl' => normalise_link($clean_url), 'pending' => false]);
-		if (DBM::is_result($r)) {
-			$best_url = 'redir/' . $r['id'];
+		$condition = [
+			'network' => NETWORK_DFRN,
+			'uid' => local_user(),
+			'nurl' => normalise_link($clean_url),
+			'pending' => false
+		];
+		$contact = dba::selectFirst('contact', ['id'], $condition);
+		if (DBM::is_result($contact)) {
+			$best_url = 'redir/' . $contact['id'];
 			$sparkle = true;
 			if ($url != '') {
 				$hostname = get_app()->get_hostname();
@@ -1019,11 +1024,12 @@ function item_photo_menu($item) {
 	$cid = 0;
 	$network = '';
 	$rel = 0;
-	$r = dba::selectFirst('contact', array('id', 'network', 'rel'), array('uid' => local_user(), 'nurl' => normalise_link($item['author-link'])));
-	if (DBM::is_result($r)) {
-		$cid = $r['id'];
-		$network = $r['network'];
-		$rel = $r['rel'];
+	$condition = ['uid' => local_user(), 'nurl' => normalise_link($item['author-link'])];
+	$contact = dba::selectFirst('contact', ['id', 'network', 'rel'], $condition);
+	if (DBM::is_result($contact)) {
+		$cid = $contact['id'];
+		$network = $contact['network'];
+		$rel = $contact['rel'];
 	}
 
 	if ($sparkle) {

--- a/include/enotify.php
+++ b/include/enotify.php
@@ -106,8 +106,8 @@ function notification($params)
 	}
 
 	if ($params['type'] == NOTIFY_COMMENT) {
-		$p = dba::selectFirst('thread', ['ignored'], ['iid' => $parent_id]);
-		if (DBM::is_result($p) && $p["ignored"]) {
+		$thread = dba::selectFirst('thread', ['ignored'], ['iid' => $parent_id]);
+		if (DBM::is_result($thread) && $thread["ignored"]) {
 			logger("Thread ".$parent_id." will be ignored", LOGGER_DEBUG);
 			return;
 		}
@@ -128,13 +128,13 @@ function notification($params)
 
 		// if it's a post figure out who's post it is.
 
-		$p = null;
+		$item = null;
 
 		if ($params['otype'] === 'item' && $parent_id) {
-			$p = dba::selectFirst('item', [], ['id' => $parent_id]);
+			$item = dba::selectFirst('item', [], ['id' => $parent_id]);
 		}
 
-		$item_post_type = item_post_type($p);
+		$item_post_type = item_post_type($item);
 
 		// "a post"
 		$dest_str = sprintf(t('%1$s commented on [url=%2$s]a %3$s[/url]'),
@@ -143,7 +143,7 @@ function notification($params)
 								$item_post_type);
 
 		// "George Bull's post"
-		if ($p) {
+		if ($item) {
 			$dest_str = sprintf(t('%1$s commented on [url=%2$s]%3$s\'s %4$s[/url]'),
 						'[url='.$params['source_link'].']'.$params['source_name'].'[/url]',
 						$itemlink,
@@ -152,7 +152,7 @@ function notification($params)
 		}
 
 		// "your post"
-		if ($p['owner-name'] == $p['author-name'] && $p['wall']) {
+		if (DBM::is_result($item) && $item['owner-name'] == $item['author-name'] && $item['wall']) {
 			$dest_str = sprintf(t('%1$s commented on [url=%2$s]your %3$s[/url]'),
 								'[url='.$params['source_link'].']'.$params['source_name'].'[/url]',
 								$itemlink,

--- a/include/identity.php
+++ b/include/identity.php
@@ -154,28 +154,27 @@ function profile_load(App $a, $nickname, $profile = 0, $profiledata = array(), $
  *
  * @param string $nickname nick
  * @param int    $uid      uid
- * @param int    $profile  ID of the profile
+ * @param int    $profile_id  ID of the profile
  * @returns array
  */
-function get_profiledata_by_nick($nickname, $uid = 0, $profile = 0)
+function get_profiledata_by_nick($nickname, $uid = 0, $profile_id = 0)
 {
 	if (remote_user() && count($_SESSION['remote'])) {
 		foreach ($_SESSION['remote'] as $visitor) {
 			if ($visitor['uid'] == $uid) {
-				$r = dba::selectFirst('contact', ['profile-id'], ['id' => $visitor['cid']]);
-				if (DBM::is_result($r)) {
-					$profile = $r['profile-id'];
+				$contact = dba::selectFirst('contact', ['profile-id'], ['id' => $visitor['cid']]);
+				if (DBM::is_result($contact)) {
+					$profile_id = $contact['profile-id'];
 				}
 				break;
 			}
 		}
 	}
 
-	$r = null;
+	$profile = null;
 
-	if ($profile) {
-		$profile_int = intval($profile);
-		$r = dba::fetch_first(
+	if ($profile_id) {
+		$profile = dba::fetch_first(
 			"SELECT `contact`.`id` AS `contact_id`, `contact`.`photo` AS `contact_photo`,
 				`contact`.`thumb` AS `contact_thumb`, `contact`.`micro` AS `contact_micro`,
 				`profile`.`uid` AS `profile_uid`, `profile`.*,
@@ -185,11 +184,11 @@ function get_profiledata_by_nick($nickname, $uid = 0, $profile = 0)
 			INNER JOIN `user` ON `profile`.`uid` = `user`.`uid`
 			WHERE `user`.`nickname` = ? AND `profile`.`id` = ? LIMIT 1",
 			$nickname,
-			$profile_int
+			intval($profile_id)
 		);
 	}
-	if (!DBM::is_result($r)) {
-		$r = dba::fetch_first(
+	if (!DBM::is_result($profile)) {
+		$profile = dba::fetch_first(
 			"SELECT `contact`.`id` AS `contact_id`, `contact`.`photo` as `contact_photo`,
 				`contact`.`thumb` AS `contact_thumb`, `contact`.`micro` AS `contact_micro`,
 				`profile`.`uid` AS `profile_uid`, `profile`.*,
@@ -202,7 +201,7 @@ function get_profiledata_by_nick($nickname, $uid = 0, $profile = 0)
 		);
 	}
 
-	return $r;
+	return $profile;
 }
 
 /**
@@ -215,7 +214,7 @@ function get_profiledata_by_nick($nickname, $uid = 0, $profile = 0)
  * @param int $block
  * @param boolean $show_connect Show connect link
  *
- * @return HTML string stuitable for sidebar inclusion
+ * @return HTML string suitable for sidebar inclusion
  *
  * @note Returns empty string if passed $profile is wrong type or not populated
  *

--- a/include/message.php
+++ b/include/message.php
@@ -67,8 +67,9 @@ function send_message($recipient = 0, $body = '', $subject = '', $replyto = '')
 		$fields = array('uid' => local_user(), 'guid' => $conv_guid, 'creator' => $sender_handle,
 			'created' => datetime_convert(), 'updated' => datetime_convert(),
 			'subject' => $subject, 'recips' => $handles);
-		dba::insert('conv', $fields);
-		$convid = dba::lastInsertId();
+		if (dba::insert('conv', $fields)) {
+			$convid = dba::lastInsertId();
+		}
 	}
 
 	if (!$convid) {
@@ -80,7 +81,8 @@ function send_message($recipient = 0, $body = '', $subject = '', $replyto = '')
 		$replyto = $convuri;
 	}
 
-	q("INSERT INTO `mail` ( `uid`, `guid`, `convid`, `from-name`, `from-photo`, `from-url`,
+	$post_id = null;
+	$result = q("INSERT INTO `mail` ( `uid`, `guid`, `convid`, `from-name`, `from-photo`, `from-url`,
 		`contact-id`, `title`, `body`, `seen`, `reply`, `replied`, `uri`, `parent-uri`, `created`)
 		VALUES ( %d, '%s', %d, '%s', '%s', '%s', %d, '%s', '%s', %d, %d, %d, '%s', '%s', '%s' )",
 		intval(local_user()),
@@ -99,7 +101,9 @@ function send_message($recipient = 0, $body = '', $subject = '', $replyto = '')
 		dbesc($replyto),
 		datetime_convert()
 	);
-	$post_id = dba::lastInsertId();
+	if ($result) {
+		$post_id = dba::lastInsertId();
+	}
 
 	/**
 	 *
@@ -171,11 +175,13 @@ function send_wallmessage($recipient = '', $body = '', $subject = '', $replyto =
 
 	$handles = $recip_handle . ';' . $sender_handle;
 
+	$convid = null;
 	$fields = array('uid' => $recipient['uid'], 'guid' => $conv_guid, 'creator' => $sender_handle,
 		'created' => datetime_convert(), 'updated' => datetime_convert(),
 		'subject' => $subject, 'recips' => $handles);
-	dba::insert('conv', $fields);
-	$convid = dba::lastInsertId();
+	if (dba::insert('conv', $fields)) {
+		$convid = dba::lastInsertId();
+	}
 	
 	if (!$convid) {
 		logger('send message: conversation not found.');

--- a/include/message.php
+++ b/include/message.php
@@ -68,11 +68,7 @@ function send_message($recipient = 0, $body = '', $subject = '', $replyto = '')
 			'created' => datetime_convert(), 'updated' => datetime_convert(),
 			'subject' => $subject, 'recips' => $handles);
 		dba::insert('conv', $fields);
-
-		$r = dba::selectFirst('conv', ['id'], ['guid' => $conv_guid, 'uid' => local_user()]);
-		if (DBM::is_result($r)) {
-			$convid = $r['id'];
-		}
+		$convid = dba::lastInsertId();
 	}
 
 	if (!$convid) {
@@ -103,15 +99,7 @@ function send_message($recipient = 0, $body = '', $subject = '', $replyto = '')
 		dbesc($replyto),
 		datetime_convert()
 	);
-
-
-	$r = q("SELECT * FROM `mail` WHERE `uri` = '%s' AND `uid` = %d LIMIT 1",
-		dbesc($uri),
-		intval(local_user())
-	);
-	if (DBM::is_result($r)) {
-		$post_id = $r[0]['id'];
-	}
+	$post_id = dba::lastInsertId();
 
 	/**
 	 *
@@ -187,14 +175,12 @@ function send_wallmessage($recipient = '', $body = '', $subject = '', $replyto =
 		'created' => datetime_convert(), 'updated' => datetime_convert(),
 		'subject' => $subject, 'recips' => $handles);
 	dba::insert('conv', $fields);
-
-	$r = dba::selectFirst('conv', ['id'], ['guid' => $conv_guid, 'uid' => $recipient['uid']]);
-	if (!DBM::is_result($r)) {
+	$convid = dba::lastInsertId();
+	
+	if (!$convid) {
 		logger('send message: conversation not found.');
 		return -4;
 	}
-
-	$convid = $r['id'];
 
 	q("INSERT INTO `mail` ( `uid`, `guid`, `convid`, `from-name`, `from-photo`, `from-url`,
 		`contact-id`, `title`, `body`, `seen`, `reply`, `replied`, `uri`, `parent-uri`, `created`, `unknown`)

--- a/include/nav.php
+++ b/include/nav.php
@@ -94,9 +94,9 @@ function nav_info(App $a)
 		$nav['usermenu'][] = array('notes/', t('Personal notes'), '', t('Your personal notes'));
 
 		// user info
-		$r = dba::selectFirst('contact', ['micro'], ['uid' => $a->user['uid'], 'self' => true]);
+		$contact = dba::selectFirst('contact', ['micro'], ['uid' => $a->user['uid'], 'self' => true]);
 		$userinfo = array(
-			'icon' => (DBM::is_result($r) ? $a->remove_baseurl($r['micro']) : 'images/person-48.jpg'),
+			'icon' => (DBM::is_result($contact) ? $a->remove_baseurl($contact['micro']) : 'images/person-48.jpg'),
 			'name' => $a->user['username'],
 		);
 	} else {

--- a/include/session.php
+++ b/include/session.php
@@ -33,10 +33,10 @@ function ref_session_read($id)
 		return '';
 	}
 
-	$r = dba::selectFirst('session', ['data'], ['sid' => $id]);
-	if (DBM::is_result($r)) {
+	$session = dba::selectFirst('session', ['data'], ['sid' => $id]);
+	if (DBM::is_result($session)) {
 		$session_exists = true;
-		return $r['data'];
+		return $session['data'];
 	} else {
 		logger("no data for session $id", LOGGER_TRACE);
 	}

--- a/index.php
+++ b/index.php
@@ -107,11 +107,11 @@ if (!$a->is_backend()) {
  * We have to do it here because the session was just now opened.
  */
 if (x($_SESSION, 'authenticated') && !x($_SESSION, 'language')) {
-	// we didn't loaded user data yet, but we need user language
-	$r = dba::selectFirst('user', ['language'], ['uid' => $_SESSION['uid']]);
+	// we haven't loaded user data yet, but we need user language
+	$user = dba::selectFirst('user', ['language'], ['uid' => $_SESSION['uid']]);
 	$_SESSION['language'] = $lang;
 	if (DBM::is_result($r)) {
-		$_SESSION['language'] = $r['language'];
+		$_SESSION['language'] = $user['language'];
 	}
 }
 

--- a/mod/contacts.php
+++ b/mod/contacts.php
@@ -30,7 +30,7 @@ function contacts_init(App $a)
 		$a->page['aside'] = '';
 	}
 
-	$contact = [];
+	$contact = null;
 	if ((($a->argc == 2) && intval($a->argv[1])) || (($a->argc == 3) && intval($a->argv[1]) && ($a->argv[2] == "posts"))) {
 		$contact_id = intval($a->argv[1]);
 		$contact = dba::selectFirst('contact', [], ['id' => $contact_id, 'uid' => local_user()]);
@@ -240,7 +240,7 @@ function _contact_update($contact_id)
 
 	$uid = $contact["uid"];
 
-	if ($r[0]["network"] == NETWORK_OSTATUS) {
+	if ($contact["network"] == NETWORK_OSTATUS) {
 		$result = Contact::createFromProbe($uid, $contact["url"], false, $contact["network"]);
 
 		if ($result['success']) {

--- a/mod/hovercard.php
+++ b/mod/hovercard.php
@@ -44,8 +44,8 @@ function hovercard_content()
 	$cid = 0;
 	if (local_user() && strpos($profileurl, 'redir/') === 0) {
 		$cid = intval(substr($profileurl, 6));
-		$r = dba::selectFirst('contact', ['nurl'], ['id' => $cid]);
-		$profileurl = defaults($r, 'nurl', '');
+		$remote_contact = dba::selectFirst('contact', ['nurl'], ['id' => $cid]);
+		$profileurl = defaults($remote_contact, 'nurl', '');
 	}
 
 	$contact = [];

--- a/mod/proxy.php
+++ b/mod/proxy.php
@@ -145,20 +145,19 @@ function proxy_init(App $a) {
 	}
 
 	$valid = true;
-	$r = array();
-
+	$photo = null;
 	if (!$direct_cache && ($cachefile == '')) {
-		$r = dba::selectFirst('photo', ['data', 'desc'], ['resource-id' => $urlhash]);
-		if (DBM::is_result($r)) {
-			$img_str = $r['data'];
-			$mime = $r['desc'];
+		$photo = dba::selectFirst('photo', ['data', 'desc'], ['resource-id' => $urlhash]);
+		if (DBM::is_result($photo)) {
+			$img_str = $photo['data'];
+			$mime = $photo['desc'];
 			if ($mime == '') {
 				$mime = 'image/jpeg';
 			}
 		}
 	}
 
-	if (!DBM::is_result($r)) {
+	if (!DBM::is_result($photo)) {
 		// It shouldn't happen but it does - spaces in URL
 		$_REQUEST['url'] = str_replace(' ', '+', $_REQUEST['url']);
 		$redirects = 0;

--- a/mod/xrd.php
+++ b/mod/xrd.php
@@ -36,24 +36,24 @@ function xrd_init(App $a)
 		$name = substr($local, 0, strpos($local, '@'));
 	}
 
-	$r = dba::selectFirst('user', [], ['nickname' => $name]);
-	if (!DBM::is_result($r)) {
+	$user = dba::selectFirst('user', [], ['nickname' => $name]);
+	if (!DBM::is_result($user)) {
 		killme();
 	}
 
-	$profile_url = System::baseUrl().'/profile/'.$r['nickname'];
+	$profile_url = System::baseUrl().'/profile/'.$user['nickname'];
 
 	$alias = str_replace('/profile/', '/~', $profile_url);
 
-	$addr = 'acct:'.$r['nickname'].'@'.$a->get_hostname();
+	$addr = 'acct:'.$user['nickname'].'@'.$a->get_hostname();
 	if ($a->get_path()) {
 		$addr .= '/'.$a->get_path();
 	}
 
 	if ($mode == 'xml') {
-		xrd_xml($a, $addr, $alias, $profile_url, $r);
+		xrd_xml($a, $addr, $alias, $profile_url, $user);
 	} else {
-		xrd_json($a, $addr, $alias, $profile_url, $r);
+		xrd_json($a, $addr, $alias, $profile_url, $user);
 	}
 }
 

--- a/src/Content/OEmbed.php
+++ b/src/Content/OEmbed.php
@@ -58,9 +58,9 @@ class OEmbed
 		$a = get_app();
 
 		$condition = ['url' => normalise_link($embedurl), 'maxwidth' => $a->videowidth];
-		$r = dba::selectFirst('oembed', ['content'], $condition);
-		if (DBM::is_result($r)) {
-			$txt = $r["content"];
+		$oembed = dba::selectFirst('oembed', ['content'], $condition);
+		if (DBM::is_result($oembed)) {
+			$txt = $oembed["content"];
 		} else {
 			$txt = Cache::get($a->videowidth . $embedurl);
 		}

--- a/src/Core/Cache.php
+++ b/src/Core/Cache.php
@@ -109,10 +109,10 @@ class Cache
 		// Frequently clear cache
 		self::clear();
 
-		$r = dba::selectFirst('cache', ['v'], ['k' => $key]);
+		$cache = dba::selectFirst('cache', ['v'], ['k' => $key]);
 
-		if (DBM::is_result($r)) {
-			$cached = $r['v'];
+		if (DBM::is_result($cache)) {
+			$cached = $cache['v'];
 			$value = @unserialize($cached);
 
 			// Only return a value if the serialized value is valid.

--- a/src/Core/Config.php
+++ b/src/Core/Config.php
@@ -97,10 +97,10 @@ class Config
 			}
 		}
 
-		$ret = dba::selectFirst('config', ['v'], ['cat' => $family, 'k' => $key]);
-		if (DBM::is_result($ret)) {
+		$config = dba::selectFirst('config', ['v'], ['cat' => $family, 'k' => $key]);
+		if (DBM::is_result($config)) {
 			// manage array value
-			$val = (preg_match("|^a:[0-9]+:{.*}$|s", $ret['v']) ? unserialize($ret['v']) : $ret['v']);
+			$val = (preg_match("|^a:[0-9]+:{.*}$|s", $config['v']) ? unserialize($config['v']) : $config['v']);
 
 			// Assign the value from the database to the cache
 			self::$cache[$family][$key] = $val;

--- a/src/Core/NotificationsManager.php
+++ b/src/Core/NotificationsManager.php
@@ -1,11 +1,14 @@
 <?php
+
 /**
  * @file src/Core/NotificationsManager.php
  * @brief Methods for read and write notifications from/to database
  *  or for formatting notifications
  */
+
 namespace Friendica\Core;
 
+use Friendica\BaseObject;
 use Friendica\Core\PConfig;
 use Friendica\Core\System;
 use Friendica\Database\DBM;
@@ -20,18 +23,8 @@ require_once 'include/bbcode.php';
  * @brief Methods for read and write notifications from/to database
  *  or for formatting notifications
  */
-class NotificationsManager
+class NotificationsManager extends BaseObject
 {
-	private $a;
-
-	/**
-	 * Constructor
-	 */
-	public function __construct()
-	{
-		$this->a = get_app();
-	}
-
 	/**
 	 * @brief set some extra note properties
 	 *
@@ -51,14 +44,13 @@ class NotificationsManager
 			$local_time = datetime_convert('UTC', date_default_timezone_get(), $n['date']);
 			$n['timestamp'] = strtotime($local_time);
 			$n['date_rel'] = relative_date($n['date']);
-				$n['msg_html'] = bbcode($n['msg'], false, false, false, false);
-				$n['msg_plain'] = explode("\n", trim(html2plain($n['msg_html'], 0)))[0];
+			$n['msg_html'] = bbcode($n['msg'], false, false, false, false);
+			$n['msg_plain'] = explode("\n", trim(html2plain($n['msg_html'], 0)))[0];
 
 			$rets[] = $n;
 		}
 		return $rets;
 	}
-
 
 	/**
 	 * @brief Get all notifications for local_user()
@@ -77,19 +69,19 @@ class NotificationsManager
 		foreach ($filter as $column => $value) {
 			$filter_str[] = sprintf("`%s` = '%s'", $column, dbesc($value));
 		}
-		if (count($filter_str)>0) {
-			$filter_sql = "AND ".implode(" AND ", $filter_str);
+		if (count($filter_str) > 0) {
+			$filter_sql = "AND " . implode(" AND ", $filter_str);
 		}
 
 		$aOrder = explode(" ", $order);
 		$asOrder = array();
 		foreach ($aOrder as $o) {
 			$dir = "asc";
-			if ($o[0]==="-") {
+			if ($o[0] === "-") {
 				$dir = "desc";
 				$o = substr($o, 1);
 			}
-			if ($o[0]==="+") {
+			if ($o[0] === "+") {
 				$dir = "asc";
 				$o = substr($o, 1);
 			}
@@ -98,12 +90,12 @@ class NotificationsManager
 		$order_sql = implode(", ", $asOrder);
 
 		if ($limit != "") {
-			$limit = " LIMIT ".$limit;
+			$limit = " LIMIT " . $limit;
 		}
-			$r = q(
-				"SELECT * FROM `notify` WHERE `uid` = %d $filter_sql ORDER BY $order_sql $limit",
-				intval(local_user())
-			);
+		$r = q(
+			"SELECT * FROM `notify` WHERE `uid` = %d $filter_sql ORDER BY $order_sql $limit",
+			intval(local_user())
+		);
 
 		if (DBM::is_result($r)) {
 			return $this->_set_extra($r);
@@ -175,37 +167,37 @@ class NotificationsManager
 		$tabs = array(
 			array(
 				'label' => t('System'),
-				'url'=>'notifications/system',
-				'sel'=> (($this->a->argv[1] == 'system') ? 'active' : ''),
-				'id' => 'system-tab',
+				'url'   => 'notifications/system',
+				'sel'   => ((self::getApp()->argv[1] == 'system') ? 'active' : ''),
+				'id'    => 'system-tab',
 				'accesskey' => 'y',
 			),
 			array(
 				'label' => t('Network'),
-				'url'=>'notifications/network',
-				'sel'=> (($this->a->argv[1] == 'network') ? 'active' : ''),
-				'id' => 'network-tab',
+				'url'   => 'notifications/network',
+				'sel'   => ((self::getApp()->argv[1] == 'network') ? 'active' : ''),
+				'id'    => 'network-tab',
 				'accesskey' => 'w',
 			),
 			array(
 				'label' => t('Personal'),
-				'url'=>'notifications/personal',
-				'sel'=> (($this->a->argv[1] == 'personal') ? 'active' : ''),
-				'id' => 'personal-tab',
+				'url'   => 'notifications/personal',
+				'sel'   => ((self::getApp()->argv[1] == 'personal') ? 'active' : ''),
+				'id'    => 'personal-tab',
 				'accesskey' => 'r',
 			),
 			array(
 				'label' => t('Home'),
-				'url' => 'notifications/home',
-				'sel'=> (($this->a->argv[1] == 'home') ? 'active' : ''),
-				'id' => 'home-tab',
+				'url'   => 'notifications/home',
+				'sel'   => ((self::getApp()->argv[1] == 'home') ? 'active' : ''),
+				'id'    => 'home-tab',
 				'accesskey' => 'h',
 			),
 			array(
 				'label' => t('Introductions'),
-				'url' => 'notifications/intros',
-				'sel'=> (($this->a->argv[1] == 'intros') ? 'active' : ''),
-				'id' => 'intro-tab',
+				'url'   => 'notifications/intros',
+				'sel'   => ((self::getApp()->argv[1] == 'intros') ? 'active' : ''),
+				'id'    => 'intro-tab',
 				'accesskey' => 'i',
 			),
 		);
@@ -219,14 +211,14 @@ class NotificationsManager
 	 * @param array  $notifs The array from the db query
 	 * @param string $ident  The notifications identifier (e.g. network)
 	 * @return array
-	 *	string 'label' => The type of the notification
-	 *	string 'link' => URL to the source
-	 *	string 'image' => The avatar image
-	 *	string 'url' => The profile url of the contact
-	 *	string 'text' => The notification text
-	 *	string 'when' => The date of the notification
-	 *	string 'ago' => T relative date of the notification
-	 *	bool 'seen' => Is the notification marked as "seen"
+	 * 	string 'label' => The type of the notification
+	 * 	string 'link' => URL to the source
+	 * 	string 'image' => The avatar image
+	 * 	string 'url' => The profile url of the contact
+	 * 	string 'text' => The notification text
+	 * 	string 'when' => The date of the notification
+	 * 	string 'ago' => T relative date of the notification
+	 * 	bool 'seen' => Is the notification marked as "seen"
 	 */
 	private function formatNotifs($notifs, $ident = "")
 	{
@@ -246,7 +238,7 @@ class NotificationsManager
 				switch ($ident) {
 					case 'system':
 						$default_item_label = 'notify';
-						$default_item_link = System::baseUrl(true).'/notify/view/'. $it['id'];
+						$default_item_link = System::baseUrl(true) . '/notify/view/' . $it['id'];
 						$default_item_image = proxy_url($it['photo'], false, PROXY_SIZE_MICRO);
 						$default_item_url = $it['url'];
 						$default_item_text = strip_tags(bbcode($it['msg']));
@@ -256,7 +248,7 @@ class NotificationsManager
 
 					case 'home':
 						$default_item_label = 'comment';
-						$default_item_link = System::baseUrl(true).'/display/'.$it['pguid'];
+						$default_item_link = System::baseUrl(true) . '/display/' . $it['pguid'];
 						$default_item_image = proxy_url($it['author-avatar'], false, PROXY_SIZE_MICRO);
 						$default_item_url = $it['author-link'];
 						$default_item_text = sprintf(t("%s commented on %s's post"), $it['author-name'], $it['pname']);
@@ -266,7 +258,7 @@ class NotificationsManager
 
 					default:
 						$default_item_label = (($it['id'] == $it['parent']) ? 'post' : 'comment');
-						$default_item_link = System::baseUrl(true).'/display/'.$it['pguid'];
+						$default_item_link = System::baseUrl(true) . '/display/' . $it['pguid'];
 						$default_item_image = proxy_url($it['author-avatar'], false, PROXY_SIZE_MICRO);
 						$default_item_url = $it['author-link'];
 						$default_item_text = (($it['id'] == $it['parent'])
@@ -281,7 +273,7 @@ class NotificationsManager
 					case ACTIVITY_LIKE:
 						$notif = array(
 							'label' => 'like',
-							'link' => System::baseUrl(true).'/display/'.$it['pguid'],
+							'link' => System::baseUrl(true) . '/display/' . $it['pguid'],
 							'image' => proxy_url($it['author-avatar'], false, PROXY_SIZE_MICRO),
 							'url' => $it['author-link'],
 							'text' => sprintf(t("%s liked %s's post"), $it['author-name'], $it['pname']),
@@ -294,7 +286,7 @@ class NotificationsManager
 					case ACTIVITY_DISLIKE:
 						$notif = array(
 							'label' => 'dislike',
-							'link' => System::baseUrl(true).'/display/'.$it['pguid'],
+							'link' => System::baseUrl(true) . '/display/' . $it['pguid'],
 							'image' => proxy_url($it['author-avatar'], false, PROXY_SIZE_MICRO),
 							'url' => $it['author-link'],
 							'text' => sprintf(t("%s disliked %s's post"), $it['author-name'], $it['pname']),
@@ -307,7 +299,7 @@ class NotificationsManager
 					case ACTIVITY_ATTEND:
 						$notif = array(
 							'label' => 'attend',
-							'link' => System::baseUrl(true).'/display/'.$it['pguid'],
+							'link' => System::baseUrl(true) . '/display/' . $it['pguid'],
 							'image' => proxy_url($it['author-avatar'], false, PROXY_SIZE_MICRO),
 							'url' => $it['author-link'],
 							'text' => sprintf(t("%s is attending %s's event"), $it['author-name'], $it['pname']),
@@ -320,7 +312,7 @@ class NotificationsManager
 					case ACTIVITY_ATTENDNO:
 						$notif = array(
 							'label' => 'attendno',
-							'link' => System::baseUrl(true).'/display/'.$it['pguid'],
+							'link' => System::baseUrl(true) . '/display/' . $it['pguid'],
 							'image' => proxy_url($it['author-avatar'], false, PROXY_SIZE_MICRO),
 							'url' => $it['author-link'],
 							'text' => sprintf(t("%s is not attending %s's event"), $it['author-name'], $it['pname']),
@@ -333,7 +325,7 @@ class NotificationsManager
 					case ACTIVITY_ATTENDMAYBE:
 						$notif = array(
 							'label' => 'attendmaybe',
-							'link' => System::baseUrl(true).'/display/'.$it['pguid'],
+							'link' => System::baseUrl(true) . '/display/' . $it['pguid'],
 							'image' => proxy_url($it['author-avatar'], false, PROXY_SIZE_MICRO),
 							'url' => $it['author-link'],
 							'text' => sprintf(t("%s may attend %s's event"), $it['author-name'], $it['pname']),
@@ -344,13 +336,13 @@ class NotificationsManager
 						break;
 
 					case ACTIVITY_FRIEND:
-						$xmlhead="<"."?xml version='1.0' encoding='UTF-8' ?".">";
-						$obj = parse_xml_string($xmlhead.$it['object']);
+						$xmlhead = "<" . "?xml version='1.0' encoding='UTF-8' ?" . ">";
+						$obj = parse_xml_string($xmlhead . $it['object']);
 						$it['fname'] = $obj->title;
 
 						$notif = array(
 							'label' => 'friend',
-							'link' => System::baseUrl(true).'/display/'.$it['pguid'],
+							'link' => System::baseUrl(true) . '/display/' . $it['pguid'],
 							'image' => proxy_url($it['author-avatar'], false, PROXY_SIZE_MICRO),
 							'url' => $it['author-link'],
 							'text' => sprintf(t("%s is now friends with %s"), $it['author-name'], $it['fname']),
@@ -383,7 +375,7 @@ class NotificationsManager
 	/**
 	 * @brief Total number of network notifications
 	 * @param int|string $seen If 0 only include notifications into the query
-	 *	                       which aren't marked as "seen"
+	 * 	                       which aren't marked as "seen"
 	 *
 	 * @return int Number of network notifications
 	 */
@@ -403,7 +395,6 @@ class NotificationsManager
 				$sql_seen",
 			intval(local_user())
 		);
-
 		if (DBM::is_result($r)) {
 			return $r[0]['total'];
 		}
@@ -415,14 +406,14 @@ class NotificationsManager
 	 * @brief Get network notifications
 	 *
 	 * @param int|string $seen  If 0 only include notifications into the query
-	 *	                        which aren't marked as "seen"
+	 * 	                        which aren't marked as "seen"
 	 * @param int        $start Start the query at this point
 	 * @param int        $limit Maximum number of query results
 	 *
 	 * @return array with
-	 *	string 'ident' => Notification identifier
-	 *	int 'total' => Total number of available network notifications
-	 *	array 'notifications' => Network notifications
+	 * 	string 'ident' => Notification identifier
+	 * 	int 'total' => Total number of available network notifications
+	 * 	array 'notifications' => Network notifications
 	 */
 	public function networkNotifs($seen = 0, $start = 0, $limit = 80)
 	{
@@ -434,7 +425,6 @@ class NotificationsManager
 		if ($seen === 0) {
 			$sql_seen = " AND `item`.`unseen` = 1 ";
 		}
-
 
 		$r = q(
 			"SELECT `item`.`id`,`item`.`parent`, `item`.`verb`, `item`.`author-name`, `item`.`unseen`,
@@ -449,16 +439,15 @@ class NotificationsManager
 			intval($start),
 			intval($limit)
 		);
-
 		if (DBM::is_result($r)) {
 			$notifs = $this->formatNotifs($r, $ident);
 		}
 
-		$arr = array (
+		$arr = [
 			'notifications' => $notifs,
 			'ident' => $ident,
 			'total' => $total,
-		);
+		];
 
 		return $arr;
 	}
@@ -466,7 +455,7 @@ class NotificationsManager
 	/**
 	 * @brief Total number of system notifications
 	 * @param int|string $seen If 0 only include notifications into the query
-	 *	                       which aren't marked as "seen"
+	 * 	                       which aren't marked as "seen"
 	 *
 	 * @return int Number of system notifications
 	 */
@@ -482,7 +471,6 @@ class NotificationsManager
 			"SELECT COUNT(*) AS `total` FROM `notify` WHERE `uid` = %d $sql_seen",
 			intval(local_user())
 		);
-
 		if (DBM::is_result($r)) {
 			return $r[0]['total'];
 		}
@@ -494,14 +482,14 @@ class NotificationsManager
 	 * @brief Get system notifications
 	 *
 	 * @param int|string $seen  If 0 only include notifications into the query
-	 *	                        which aren't marked as "seen"
+	 * 	                        which aren't marked as "seen"
 	 * @param int        $start Start the query at this point
 	 * @param int        $limit Maximum number of query results
 	 *
 	 * @return array with
-	 *	string 'ident' => Notification identifier
-	 *	int 'total' => Total number of available system notifications
-	 *	array 'notifications' => System notifications
+	 * 	string 'ident' => Notification identifier
+	 * 	int 'total' => Total number of available system notifications
+	 * 	array 'notifications' => System notifications
 	 */
 	public function systemNotifs($seen = 0, $start = 0, $limit = 80)
 	{
@@ -521,30 +509,29 @@ class NotificationsManager
 			intval($start),
 			intval($limit)
 		);
-
 		if (DBM::is_result($r)) {
 			$notifs = $this->formatNotifs($r, $ident);
 		}
 
-		$arr = array (
+		$arr = [
 			'notifications' => $notifs,
 			'ident' => $ident,
 			'total' => $total,
-		);
+		];
 
 		return $arr;
 	}
 
 	/**
-	 * @brief Addional SQL query string for the personal notifications
+	 * @brief Additional SQL query string for the personal notifications
 	 *
-	 * @return string The additional sql query
+	 * @return string The additional SQL query
 	 */
 	private function personalSqlExtra()
 	{
-		$myurl = System::baseUrl(true) . '/profile/'. $this->a->user['nickname'];
+		$myurl = System::baseUrl(true) . '/profile/' . self::getApp()->user['nickname'];
 		$myurl = substr($myurl, strpos($myurl, '://') + 3);
-		$myurl = str_replace(array('www.','.'), array('','\\.'), $myurl);
+		$myurl = str_replace(array('www.', '.'), array('', '\\.'), $myurl);
 		$diasp_url = str_replace('/profile/', '/u/', $myurl);
 		$sql_extra = sprintf(
 			" AND ( `item`.`author-link` regexp '%s' OR `item`.`tag` regexp '%s' OR `item`.`tag` regexp '%s' ) ",
@@ -559,7 +546,7 @@ class NotificationsManager
 	/**
 	 * @brief Total number of personal notifications
 	 * @param int|string $seen If 0 only include notifications into the query
-	 *	                       which aren't marked as "seen"
+	 * 	                       which aren't marked as "seen"
 	 *
 	 * @return int Number of personal notifications
 	 */
@@ -581,7 +568,6 @@ class NotificationsManager
 				AND `item`.`deleted` = 0 AND `item`.`uid` = %d AND `item`.`wall` = 0 ",
 			intval(local_user())
 		);
-
 		if (DBM::is_result($r)) {
 			return $r[0]['total'];
 		}
@@ -593,14 +579,14 @@ class NotificationsManager
 	 * @brief Get personal notifications
 	 *
 	 * @param int|string $seen  If 0 only include notifications into the query
-	 *	                        which aren't marked as "seen"
+	 * 	                        which aren't marked as "seen"
 	 * @param int        $start Start the query at this point
 	 * @param int        $limit Maximum number of query results
 	 *
 	 * @return array with
-	 *	string 'ident' => Notification identifier
-	 *	int 'total' => Total number of available personal notifications
-	 *	array 'notifications' => Personal notifications
+	 * 	string 'ident' => Notification identifier
+	 * 	int 'total' => Total number of available personal notifications
+	 * 	array 'notifications' => Personal notifications
 	 */
 	public function personalNotifs($seen = 0, $start = 0, $limit = 80)
 	{
@@ -628,12 +614,11 @@ class NotificationsManager
 			intval($start),
 			intval($limit)
 		);
-
 		if (DBM::is_result($r)) {
 			$notifs = $this->formatNotifs($r, $ident);
 		}
 
-		$arr = array (
+		$arr = array(
 			'notifications' => $notifs,
 			'ident' => $ident,
 			'total' => $total,
@@ -645,7 +630,7 @@ class NotificationsManager
 	/**
 	 * @brief Total number of home notifications
 	 * @param int|string $seen If 0 only include notifications into the query
-	 *	                       which aren't marked as "seen"
+	 * 	                       which aren't marked as "seen"
 	 *
 	 * @return int Number of home notifications
 	 */
@@ -664,7 +649,6 @@ class NotificationsManager
 				$sql_seen",
 			intval(local_user())
 		);
-
 		if (DBM::is_result($r)) {
 			return $r[0]['total'];
 		}
@@ -676,14 +660,14 @@ class NotificationsManager
 	 * @brief Get home notifications
 	 *
 	 * @param int|string $seen  If 0 only include notifications into the query
-	 *	                        which aren't marked as "seen"
+	 * 	                        which aren't marked as "seen"
 	 * @param int        $start Start the query at this point
 	 * @param int        $limit Maximum number of query results
 	 *
 	 * @return array with
-	 *	string 'ident' => Notification identifier
-	 *	int 'total' => Total number of available home notifications
-	 *	array 'notifications' => Home notifications
+	 * 	string 'ident' => Notification identifier
+	 * 	int 'total' => Total number of available home notifications
+	 * 	array 'notifications' => Home notifications
 	 */
 	public function homeNotifs($seen = 0, $start = 0, $limit = 80)
 	{
@@ -709,16 +693,15 @@ class NotificationsManager
 			intval($start),
 			intval($limit)
 		);
-
 		if (DBM::is_result($r)) {
 			$notifs = $this->formatNotifs($r, $ident);
 		}
 
-		$arr = array (
+		$arr = [
 			'notifications' => $notifs,
 			'ident' => $ident,
 			'total' => $total,
-		);
+		];
 
 		return $arr;
 	}
@@ -726,7 +709,7 @@ class NotificationsManager
 	/**
 	 * @brief Total number of introductions
 	 * @param bool $all If false only include introductions into the query
-	 *	                which aren't marked as ignored
+	 * 	                which aren't marked as ignored
 	 *
 	 * @return int Number of introductions
 	 */
@@ -755,7 +738,7 @@ class NotificationsManager
 	 * @brief Get introductions
 	 *
 	 * @param bool $all   If false only include introductions into the query
-	 *	                  which aren't marked as ignored
+	 * 	                  which aren't marked as ignored
 	 * @param int  $start Start the query at this point
 	 * @param int  $limit Maximum number of query results
 	 *
@@ -793,16 +776,15 @@ class NotificationsManager
 			intval($start),
 			intval($limit)
 		);
-
 		if (DBM::is_result($r)) {
 			$notifs = $this->formatIntros($r);
 		}
 
-		$arr = array (
+		$arr = [
 			'ident' => $ident,
 			'total' => $total,
 			'notifications' => $notifs,
-		);
+		];
 
 		return $arr;
 	}
@@ -820,10 +802,9 @@ class NotificationsManager
 		foreach ($intros as $it) {
 			// There are two kind of introduction. Contacts suggested by other contacts and normal connection requests.
 			// We have to distinguish between these two because they use different data.
-
 			// Contact suggestions
 			if ($it['fid']) {
-				$return_addr = bin2hex($this->a->user['nickname'] . '@' . $this->a->get_hostname() . (($this->a->path) ? '/' . $this->a->path : ''));
+				$return_addr = bin2hex(self::getApp()->user['nickname'] . '@' . self::getApp()->get_hostname() . ((self::getApp()->path) ? '/' . self::getApp()->path : ''));
 
 				$intro = array(
 					'label' => 'friend_suggestion',
@@ -839,7 +820,6 @@ class NotificationsManager
 					'knowyou' => $knowyou,
 					'note' => $it['note'],
 					'request' => $it['frequest'] . '?addr=' . $return_addr,
-
 				);
 
 				// Normal connection requests

--- a/src/Core/PConfig.php
+++ b/src/Core/PConfig.php
@@ -90,9 +90,9 @@ class PConfig
 			}
 		}
 
-		$ret = dba::selectFirst('pconfig', ['v'], ['uid' => $uid, 'cat' => $family, 'k' => $key]);
-		if (DBM::is_result($ret)) {
-			$val = (preg_match("|^a:[0-9]+:{.*}$|s", $ret['v']) ? unserialize($ret['v']) : $ret['v']);
+		$pconfig = dba::selectFirst('pconfig', ['v'], ['uid' => $uid, 'cat' => $family, 'k' => $key]);
+		if (DBM::is_result($pconfig)) {
+			$val = (preg_match("|^a:[0-9]+:{.*}$|s", $pconfig['v']) ? unserialize($pconfig['v']) : $pconfig['v']);
 			$a->config[$uid][$family][$key] = $val;
 			self::$in_db[$uid][$family][$key] = true;
 

--- a/src/Core/Worker.php
+++ b/src/Core/Worker.php
@@ -165,9 +165,9 @@ class Worker
 	private static function highestPriority()
 	{
 		$condition = array("`executed` <= ? AND NOT `done`", NULL_DATE);
-		$s = dba::selectFirst('workerqueue', ['priority'], $condition, ['order' => ['priority']]);
-		if (DBM::is_result($s)) {
-			return $s["priority"];
+		$workerqueue = dba::selectFirst('workerqueue', ['priority'], $condition, ['order' => ['priority']]);
+		if (DBM::is_result($workerqueue)) {
+			return $workerqueue["priority"];
 		} else {
 			return 0;
 		}

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -89,7 +89,6 @@ class Contact extends BaseObject
 		return $return;
 	}
 
-
 	/**
 	 * Creates the self-contact for the provided user id
 	 *
@@ -432,19 +431,27 @@ class Contact extends BaseObject
 		// Fetch contact data from the contact table for the given user
 		$r = q("SELECT `id`, `id` AS `cid`, 0 AS `gid`, 0 AS `zid`, `uid`, `url`, `nurl`, `alias`, `network`, `name`, `nick`, `addr`, `location`, `about`, `xmpp`,
 			`keywords`, `gender`, `photo`, `thumb`, `micro`, `forum`, `prv`, (`forum` | `prv`) AS `community`, `contact-type`, `bd` AS `birthday`, `self`
-		FROM `contact` WHERE `addr` = '%s' AND `uid` = %d", dbesc($addr), intval($uid));
-
+			FROM `contact` WHERE `addr` = '%s' AND `uid` = %d",
+			dbesc($addr),
+			intval($uid)
+		);
 		// Fetch the data from the contact table with "uid=0" (which is filled automatically)
-		if (!DBM::is_result($r))
+		if (!DBM::is_result($r)) {
 			$r = q("SELECT `id`, 0 AS `cid`, `id` AS `zid`, 0 AS `gid`, `uid`, `url`, `nurl`, `alias`, `network`, `name`, `nick`, `addr`, `location`, `about`, `xmpp`,
-			`keywords`, `gender`, `photo`, `thumb`, `micro`, `forum`, `prv`, (`forum` | `prv`) AS `community`, `contact-type`, `bd` AS `birthday`, 0 AS `self`
-			FROM `contact` WHERE `addr` = '%s' AND `uid` = 0", dbesc($addr));
+				`keywords`, `gender`, `photo`, `thumb`, `micro`, `forum`, `prv`, (`forum` | `prv`) AS `community`, `contact-type`, `bd` AS `birthday`, 0 AS `self`
+				FROM `contact` WHERE `addr` = '%s' AND `uid` = 0",
+				dbesc($addr)
+			);
+		}
 
 		// Fetch the data from the gcontact table
-		if (!DBM::is_result($r))
+		if (!DBM::is_result($r)) {
 			$r = q("SELECT 0 AS `id`, 0 AS `cid`, `id` AS `gid`, 0 AS `zid`, 0 AS `uid`, `url`, `nurl`, `alias`, `network`, `name`, `nick`, `addr`, `location`, `about`, '' AS `xmpp`,
-			`keywords`, `gender`, `photo`, `photo` AS `thumb`, `photo` AS `micro`, `community` AS `forum`, 0 AS `prv`, `community`, `contact-type`, `birthday`, 0 AS `self`
-			FROM `gcontact` WHERE `addr` = '%s'", dbesc($addr));
+				`keywords`, `gender`, `photo`, `photo` AS `thumb`, `photo` AS `micro`, `community` AS `forum`, 0 AS `prv`, `community`, `contact-type`, `birthday`, 0 AS `self`
+				FROM `gcontact` WHERE `addr` = '%s'",
+				dbesc($addr)
+			);
+		}
 
 		if (!DBM::is_result($r)) {
 			$data = Probe::uri($addr);
@@ -540,19 +547,18 @@ class Contact extends BaseObject
 		 * Menu array:
 		 * "name" => [ "Label", "link", (bool)Should the link opened in a new tab? ]
 		 */
-		$menu = array(
-			'status' => array(t("View Status"), $status_link, true),
-			'profile' => array(t("View Profile"), $profile_link, true),
-			'photos' => array(t("View Photos"), $photos_link, true),
-			'network' => array(t("Network Posts"), $posts_link, false),
-			'edit' => array(t("View Contact"), $contact_url, false),
-			'drop' => array(t("Drop Contact"), $contact_drop_link, false),
-			'pm' => array(t("Send PM"), $pm_url, false),
-			'poke' => array(t("Poke"), $poke_link, false),
-		);
+		$menu = [
+			'status'  => [t("View Status")  , $status_link      , true],
+			'profile' => [t("View Profile") , $profile_link     , true],
+			'photos'  => [t("View Photos")  , $photos_link      , true],
+			'network' => [t("Network Posts"), $posts_link       , false],
+			'edit'    => [t("View Contact") , $contact_url      , false],
+			'drop'    => [t("Drop Contact") , $contact_drop_link, false],
+			'pm'      => [t("Send PM")      , $pm_url           , false],
+			'poke'    => [t("Poke")         , $poke_link        , false],
+		];
 
-
-		$args = array('contact' => $contact, 'menu' => &$menu);
+		$args = ['contact' => $contact, 'menu' => &$menu];
 
 		call_hooks('contact_photo_menu', $args);
 
@@ -593,7 +599,9 @@ class Contact extends BaseObject
 					SELECT DISTINCT(`contact-id`)
 					FROM `group_member`
 					WHERE `uid` = %d
-				)", intval($uid), intval($uid)
+				)",
+				intval($uid),
+				intval($uid)
 			);
 
 			return $r;
@@ -612,13 +620,18 @@ class Contact extends BaseObject
 				INNER JOIN `group` ON `group`.`id` = `group_member`.`gid`
 				WHERE `group`.`uid` = %d
 			)
-			LIMIT %d, %d", intval($uid), intval($uid), intval($start), intval($count)
+			LIMIT %d, %d",
+			intval($uid),
+			intval($uid),
+			intval($start),
+			intval($count)
 		);
+		
 		return $r;
 	}
 
 	/**
-	 * @brief Fetch the contact id for a given url and user
+	 * @brief Fetch the contact id for a given URL and user
 	 *
 	 * First lookup in the contact table to find a record matching either `url`, `nurl`,
 	 * `addr` or `alias`.
@@ -627,7 +640,7 @@ class Contact extends BaseObject
 	 * If there's one, we check that it isn't time to update the picture else we
 	 * directly return the found contact id.
 	 *
-	 * Second, we probe the provided $url wether it's http://server.tld/profile or
+	 * Second, we probe the provided $url whether it's http://server.tld/profile or
 	 * nick@server.tld. We quit if we can't get any info back.
 	 *
 	 * Third, we create the contact record if it doesn't exist
@@ -710,19 +723,36 @@ class Contact extends BaseObject
 
 		$url = $data["url"];
 		if (!$contact_id) {
-			dba::insert(
-				'contact', array('uid' => $uid, 'created' => datetime_convert(), 'url' => $data["url"],
-				'nurl' => normalise_link($data["url"]), 'addr' => $data["addr"],
-				'alias' => $data["alias"], 'notify' => $data["notify"], 'poll' => $data["poll"],
-				'name' => $data["name"], 'nick' => $data["nick"], 'photo' => $data["photo"],
-				'keywords' => $data["keywords"], 'location' => $data["location"], 'about' => $data["about"],
-				'network' => $data["network"], 'pubkey' => $data["pubkey"],
-				'rel' => CONTACT_IS_SHARING, 'priority' => $data["priority"],
-				'batch' => $data["batch"], 'request' => $data["request"],
-				'confirm' => $data["confirm"], 'poco' => $data["poco"],
-				'name-date' => datetime_convert(), 'uri-date' => datetime_convert(),
-				'avatar-date' => datetime_convert(), 'writable' => 1, 'blocked' => 0,
-				'readonly' => 0, 'pending' => 0)
+			dba::insert('contact', [
+				'uid'       => $uid,
+				'created'   => datetime_convert(),
+				'url'       => $data["url"],
+				'nurl'      => normalise_link($data["url"]),
+				'addr'      => $data["addr"],
+				'alias'     => $data["alias"],
+				'notify'    => $data["notify"],
+				'poll'      => $data["poll"],
+				'name'      => $data["name"],
+				'nick'      => $data["nick"],
+				'photo'     => $data["photo"],
+				'keywords'  => $data["keywords"],
+				'location'  => $data["location"],
+				'about'     => $data["about"],
+				'network'   => $data["network"],
+				'pubkey'    => $data["pubkey"],
+				'rel'       => CONTACT_IS_SHARING,
+				'priority'  => $data["priority"],
+				'batch'     => $data["batch"],
+				'request'   => $data["request"],
+				'confirm'   => $data["confirm"],
+				'poco'      => $data["poco"],
+				'name-date' => datetime_convert(),
+				'uri-date'  => datetime_convert(),
+				'avatar-date' => datetime_convert(),
+				'writable'  => 1,
+				'blocked'   => 0,
+				'readonly'  => 0,
+				'pending'   => 0]
 			);
 
 			$s = dba::select('contact', ['id'], ['nurl' => normalise_link($data["url"]), 'uid' => $uid], ['order' => ['id'], 'limit' => 2]);
@@ -750,8 +780,8 @@ class Contact extends BaseObject
 			}
 
 			if (count($contacts) > 1 && $uid == 0 && $contact_id != 0 && $data["url"] != "") {
-				dba::delete('contact', array("`nurl` = ? AND `uid` = 0 AND `id` != ? AND NOT `self`",
-					normalise_link($data["url"]), $contact_id));
+				dba::delete('contact', ["`nurl` = ? AND `uid` = 0 AND `id` != ? AND NOT `self`",
+					normalise_link($data["url"]), $contact_id]);
 			}
 		}
 
@@ -859,7 +889,9 @@ class Contact extends BaseObject
 		// There are no posts with "uid = 0" with connector networks
 		// This speeds up the query a lot
 		$r = q("SELECT `network`, `id` AS `author-id`, `contact-type` FROM `contact`
-			WHERE `contact`.`nurl` = '%s' AND `contact`.`uid` = 0", dbesc(normalise_link($contact_url)));
+			WHERE `contact`.`nurl` = '%s' AND `contact`.`uid` = 0",
+			dbesc(normalise_link($contact_url))
+		);
 
 		if (!DBM::is_result($r)) {
 			return '';
@@ -880,7 +912,6 @@ class Contact extends BaseObject
 			intval($author_id), intval(local_user()), dbesc(ACTIVITY_POST),
 			intval($a->pager['start']), intval($a->pager['itemspage'])
 		);
-
 
 		$o = conversation($a, $r, 'contact-posts', false);
 
@@ -918,6 +949,7 @@ class Contact extends BaseObject
 		if (isset($contact["contact-type"])) {
 			$type = $contact["contact-type"];
 		}
+
 		if (isset($contact["account-type"])) {
 			$type = $contact["account-type"];
 		}
@@ -964,10 +996,10 @@ class Contact extends BaseObject
 		$return = dba::update('contact', ['blocked' => false], ['id' => $uid]);
 
 		return $return;
-  }
+	}
 
-  /**
-   * @brief Updates the avatar links in a contact only if needed
+	/**
+	 * @brief Updates the avatar links in a contact only if needed
 	 *
 	 * @param string $avatar Link to avatar picture
 	 * @param int    $uid    User id of contact owner
@@ -1017,9 +1049,9 @@ class Contact extends BaseObject
 	public static function updateFromProbe($id)
 	{
 		/*
-		Warning: Never ever fetch the public key via Probe::uri and write it into the contacts.
-		This will reliably kill your communication with Friendica contacts.
-		*/
+		  Warning: Never ever fetch the public key via Probe::uri and write it into the contacts.
+		  This will reliably kill your communication with Friendica contacts.
+		 */
 
 		$fields = ['url', 'nurl', 'addr', 'alias', 'batch', 'notify', 'poll', 'poco', 'network'];
 		$contact = dba::selectFirst('contact', $fields, ['id' => $id]);
@@ -1052,16 +1084,15 @@ class Contact extends BaseObject
 		}
 
 		dba::update(
-			'contact',
-			[
-				'url' => $ret['url'],
-				'nurl' => normalise_link($ret['url']),
-				'addr' => $ret['addr'],
-				'alias' => $ret['alias'],
-				'batch' => $ret['batch'],
+			'contact', [
+				'url'    => $ret['url'],
+				'nurl'   => normalise_link($ret['url']),
+				'addr'   => $ret['addr'],
+				'alias'  => $ret['alias'],
+				'batch'  => $ret['batch'],
 				'notify' => $ret['notify'],
-				'poll' => $ret['poll'],
-				'poco' => $ret['poco']
+				'poll'   => $ret['poll'],
+				'poco'   => $ret['poco']
 			],
 			['id' => $id]
 		);
@@ -1077,7 +1108,7 @@ class Contact extends BaseObject
 	 * Currently if the contact is DFRN, interactive needs to be true, to redirect to the
 	 * dfrn_request page.
 	 *
-	 * Otherwise this can be used to bulk add statusnet contacts, twitter contacts, etc.
+	 * Otherwise this can be used to bulk add StatusNet contacts, Twitter contacts, etc.
 	 *
 	 * Returns an array
 	 * $return['success'] boolean true if successful
@@ -1204,7 +1235,9 @@ class Contact extends BaseObject
 
 		if (!DBM::is_result($r)) {
 			$r = q("SELECT * FROM `contact` WHERE `uid` = %d AND `nurl` = '%s' AND `network` = '%s' LIMIT 1",
-				intval($uid), dbesc(normalise_link($url)), dbesc($ret['network'])
+				intval($uid),
+				dbesc(normalise_link($url)),
+				dbesc($ret['network'])
 			);
 		}
 
@@ -1218,33 +1251,30 @@ class Contact extends BaseObject
 			$new_relation = ((in_array($ret['network'], array(NETWORK_MAIL))) ? CONTACT_IS_FRIEND : CONTACT_IS_SHARING);
 
 			// create contact record
-			dba::insert(
-				'contact',
-				[
-					'uid' => $uid,
-					'created' => datetime_convert(),
-					'url' => $ret['url'],
-					'nurl' => normalise_link($ret['url']),
-					'addr' => $ret['addr'],
-					'alias' => $ret['alias'],
-					'batch' => $ret['batch'],
-					'notify' => $ret['notify'],
-					'poll' => $ret['poll'],
-					'poco' => $ret['poco'],
-					'name' => $ret['name'],
-					'nick' => $ret['nick'],
-					'network' => $ret['network'],
-					'pubkey' => $ret['pubkey'],
-					'rel' => $new_relation,
-					'priority' => $ret['priority'],
-					'writable' => $writeable,
-					'hidden' => $hidden,
-					'blocked' => 0,
-					'readonly' => 0,
-					'pending' => 0,
-					'subhub' => $subhub
-				]
-			);
+			dba::insert('contact', [
+				'uid'     => $uid,
+				'created' => datetime_convert(),
+				'url'     => $ret['url'],
+				'nurl'    => normalise_link($ret['url']),
+				'addr'    => $ret['addr'],
+				'alias'   => $ret['alias'],
+				'batch'   => $ret['batch'],
+				'notify'  => $ret['notify'],
+				'poll'    => $ret['poll'],
+				'poco'    => $ret['poco'],
+				'name'    => $ret['name'],
+				'nick'    => $ret['nick'],
+				'network' => $ret['network'],
+				'pubkey'  => $ret['pubkey'],
+				'rel'     => $new_relation,
+				'priority'=> $ret['priority'],
+				'writable'=> $writeable,
+				'hidden'  => $hidden,
+				'blocked' => 0,
+				'readonly'=> 0,
+				'pending' => 0,
+				'subhub'  => $subhub
+			]);
 		}
 
 		$contact = dba::selectFirst('contact', [], ['url' => $ret['url'], 'network' => $ret['network'], 'uid' => $uid]);
@@ -1266,8 +1296,8 @@ class Contact extends BaseObject
 		Worker::add(PRIORITY_HIGH, "OnePoll", $contact_id, "force");
 
 		$r = q("SELECT `contact`.*, `user`.* FROM `contact` INNER JOIN `user` ON `contact`.`uid` = `user`.`uid`
-				WHERE `user`.`uid` = %d AND `contact`.`self` LIMIT 1",
-				intval($uid)
+			WHERE `user`.`uid` = %d AND `contact`.`self` LIMIT 1",
+			intval($uid)
 		);
 
 		if (DBM::is_result($r)) {

--- a/src/Network/FKOAuth1.php
+++ b/src/Network/FKOAuth1.php
@@ -63,11 +63,10 @@ class FKOAuth1 extends OAuthServer
 			$a->timezone = $a->user['timezone'];
 		}
 
-		$r = dba::selectFirst('contact', [], ['uid' => $_SESSION['uid'], 'self' => 1]);
-		
-		if (DBM::is_result($r)) {
-			$a->contact = $r;
-			$a->cid = $r['id'];
+		$contact = dba::selectFirst('contact', [], ['uid' => $_SESSION['uid'], 'self' => 1]);
+		if (DBM::is_result($contact)) {
+			$a->contact = $contact;
+			$a->cid = $contact['id'];
 			$_SESSION['cid'] = $a->cid;
 		}
 

--- a/src/Network/FKOAuthDataStore.php
+++ b/src/Network/FKOAuthDataStore.php
@@ -88,10 +88,9 @@ class FKOAuthDataStore extends OAuthDataStore
 	 */
 	public function lookup_nonce($consumer, $token, $nonce, $timestamp)
 	{
-		$r = dba::selectFirst('tokens', ['id', 'secret'], ['client_id' => $consumer->key, 'id' => $nonce, 'expires' => $timestamp]);
-
-		if (DBM::is_result($r)) {
-			return new \OAuthToken($r['id'], $r['secret']);
+		$token = dba::selectFirst('tokens', ['id', 'secret'], ['client_id' => $consumer->key, 'id' => $nonce, 'expires' => $timestamp]);
+		if (DBM::is_result($token)) {
+			return new \OAuthToken($token['id'], $token['secret']);
 		}
 
 		return null;

--- a/src/Object/Post.php
+++ b/src/Object/Post.php
@@ -261,14 +261,14 @@ class Post extends BaseObject
 					'classundo' => $item['starred'] ? "" : "hidden",
 					'starred'   => t('starred'),
 				);
-				$r = dba::selectFirst('thread', ['ignored'], ['uid' => $item['uid'], 'iid' => $item['id']]);
-				if (DBM::is_result($r)) {
+				$thread = dba::selectFirst('thread', ['ignored'], ['uid' => $item['uid'], 'iid' => $item['id']]);
+				if (DBM::is_result($thread)) {
 					$ignore = array(
 						'do'        => t("ignore thread"),
 						'undo'      => t("unignore thread"),
 						'toggle'    => t("toggle ignore status"),
-						'classdo'   => $r['ignored'] ? "hidden" : "",
-						'classundo' => $r['ignored'] ? "" : "hidden",
+						'classdo'   => $thread['ignored'] ? "hidden" : "",
+						'classundo' => $thread['ignored'] ? "" : "hidden",
 						'ignored'   => t('ignored'),
 					);
 				}

--- a/src/Protocol/PortableContact.php
+++ b/src/Protocol/PortableContact.php
@@ -66,10 +66,10 @@ class PortableContact
 
 		if ($cid) {
 			if (!$url || !$uid) {
-				$r = dba::selectFirst('contact', ['poco', 'uid'], ['id' => $cid]);
-				if (DBM::is_result($r)) {
-					$url = $r['poco'];
-					$uid = $r['uid'];
+				$contact = dba::selectFirst('contact', ['poco', 'uid'], ['id' => $cid]);
+				if (DBM::is_result($contact)) {
+					$url = $contact['poco'];
+					$uid = $contact['uid'];
 				}
 			}
 			if (!$uid) {
@@ -813,30 +813,30 @@ class PortableContact
 			return false;
 		}
 
-		$servers = dba::selectFirst('gserver', [], ['nurl' => normalise_link($server_url)]);
-		if (DBM::is_result($servers)) {
-			if ($servers["created"] <= NULL_DATE) {
+		$gserver = dba::selectFirst('gserver', [], ['nurl' => normalise_link($server_url)]);
+		if (DBM::is_result($gserver)) {
+			if ($gserver["created"] <= NULL_DATE) {
 				$fields = ['created' => datetime_convert()];
 				$condition = ['nurl' => normalise_link($server_url)];
 				dba::update('gserver', $fields, $condition);
 			}
-			$poco = $servers["poco"];
-			$noscrape = $servers["noscrape"];
+			$poco = $gserver["poco"];
+			$noscrape = $gserver["noscrape"];
 
 			if ($network == "") {
-				$network = $servers["network"];
+				$network = $gserver["network"];
 			}
 
-			$last_contact = $servers["last_contact"];
-			$last_failure = $servers["last_failure"];
-			$version = $servers["version"];
-			$platform = $servers["platform"];
-			$site_name = $servers["site_name"];
-			$info = $servers["info"];
-			$register_policy = $servers["register_policy"];
-			$registered_users = $servers["registered-users"];
+			$last_contact = $gserver["last_contact"];
+			$last_failure = $gserver["last_failure"];
+			$version = $gserver["version"];
+			$platform = $gserver["platform"];
+			$site_name = $gserver["site_name"];
+			$info = $gserver["info"];
+			$register_policy = $gserver["register_policy"];
+			$registered_users = $gserver["registered-users"];
 
-			if (!$force && !self::updateNeeded($servers["created"], "", $last_failure, $last_contact)) {
+			if (!$force && !self::updateNeeded($gserver["created"], "", $last_failure, $last_contact)) {
 				logger("Use cached data for server ".$server_url, LOGGER_DEBUG);
 				return ($last_contact >= $last_failure);
 			}
@@ -853,7 +853,7 @@ class PortableContact
 			$last_contact = NULL_DATE;
 			$last_failure = NULL_DATE;
 		}
-		logger("Server ".$server_url." is outdated or unknown. Start discovery. Force: ".$force." Created: ".$servers["created"]." Failure: ".$last_failure." Contact: ".$last_contact, LOGGER_DEBUG);
+		logger("Server ".$server_url." is outdated or unknown. Start discovery. Force: ".$force." Created: ".$gserver["created"]." Failure: ".$last_failure." Contact: ".$last_contact, LOGGER_DEBUG);
 
 		$failure = false;
 		$possible_failure = false;
@@ -876,7 +876,7 @@ class PortableContact
 
 		// Quit if there is a timeout.
 		// But we want to make sure to only quit if we are mostly sure that this server url fits.
-		if (DBM::is_result($servers) && ($orig_server_url == $server_url) &&
+		if (DBM::is_result($gserver) && ($orig_server_url == $server_url) &&
 			($serverret['errno'] == CURLE_OPERATION_TIMEDOUT)) {
 			logger("Connection to server ".$server_url." timed out.", LOGGER_DEBUG);
 			dba::update('gserver', array('last_failure' => datetime_convert()), array('nurl' => normalise_link($server_url)));

--- a/src/Worker/OnePoll.php
+++ b/src/Worker/OnePoll.php
@@ -384,16 +384,15 @@ Class OnePoll
 							// Have we seen it before?
 							$fields = ['deleted', 'id'];
 							$condition = ['uid' => $importer_uid, 'uri' => $datarray['uri']];
-							$r = dba::selectFirst('item', $fields, $condition);
-
-							if (DBM::is_result($r)) {
+							$item = dba::selectFirst('item', $fields, $condition);
+							if (DBM::is_result($item)) {
 								logger("Mail: Seen before ".$msg_uid." for ".$mailconf['user']." UID: ".$importer_uid." URI: ".$datarray['uri'],LOGGER_DEBUG);
 
 								// Only delete when mails aren't automatically moved or deleted
 								if (($mailconf['action'] != 1) && ($mailconf['action'] != 3))
-									if ($meta->deleted && ! $r['deleted']) {
+									if ($meta->deleted && ! $item['deleted']) {
 										$fields = array('deleted' => true, 'changed' => datetime_convert());
-										dba::update('item', $fields, array('id' => $r['id']));
+										dba::update('item', $fields, array('id' => $item['id']));
 									}
 
 								switch ($mailconf['action']) {

--- a/src/Worker/Queue.php
+++ b/src/Worker/Queue.php
@@ -68,17 +68,10 @@ class Queue
 
 
 		// delivering
-
-		$r = q(
-			"SELECT * FROM `queue` WHERE `id` = %d LIMIT 1",
-			intval($queue_id)
-		);
-
-		if (!DBM::is_result($r)) {
+		$q_item = dba::selectFirst('queue', [], ['id' => $queue_id]);
+		if (!DBM::is_result($q_item)) {
 			return;
 		}
-
-		$q_item = $r[0];
 
 		$contact = dba::selectFirst('contact', [], ['id' => $q_item['cid']]);
 		if (!DBM::is_result($contact)) {

--- a/util/global_community_silence.php
+++ b/util/global_community_silence.php
@@ -57,8 +57,8 @@ if (in_array($net['network'], array(NETWORK_PHANTOM, NETWORK_MAIL))) {
 	exit(1);
 }
 $nurl = normalise_link($net['url']);
-$r = dba::selectFirst("contact", ["id"], ["nurl" => $nurl, "uid" => 0]);
-if (DBM::is_result($r)) {
+$contact = dba::selectFirst("contact", ["id"], ["nurl" => $nurl, "uid" => 0]);
+if (DBM::is_result($contact)) {
 	dba::update("contact", array("hidden" => true), array("id" => $r["id"]));
 	echo "NOTICE: The account should be silenced from the global community page\r\n";
 } else {


### PR DESCRIPTION
Part of #4176

While doing #4205, I realized that some calls to `dba::selectFirst` weren't cleanly done. I was able to find some remaining references to the previous `$r[0]` record.

I decided to go on a mgical journey, and visit all current `dba::selectFirst()` calls and either improve the legibility by renaming the return variable or fixing an eventual forgotten reference.