### PR TITLE
Add the feed link to the body when not present in the feed

### DIFF
--- a/src/Protocol/Feed.php
+++ b/src/Protocol/Feed.php
@@ -417,7 +417,8 @@ class Feed {
 					}
 					$item["body"] .= "\n".$item['tag'];
 				}
-				if (!strstr($item["body"], '[url') && ($item['plink'] != '')) {
+x				// Add the link to the original feed entry if not present in feed
+				if (!strstr($item["body"], $item['plink']) && ($item['plink'] != '')) {
 					$item["body"] .= "[hr][url]".$item['plink']."[/url]";
 				}
 			}


### PR DESCRIPTION
When using "remote self" it is appropriate to set a link to the original item. Sometimes it is in the content, sometimes not. If not, we now add it at the bottom. It fixes an issue with the account https://libranet.de/profile/ncnews