### PR TITLE
Reworked and unified database structure, added comments

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -43,7 +43,7 @@ define('FRIENDICA_PLATFORM',     'Friendica');
 define('FRIENDICA_CODENAME',     'Asparagus');
 define('FRIENDICA_VERSION',      '3.6-dev');
 define('DFRN_PROTOCOL_VERSION',  '2.23');
-define('DB_UPDATE_VERSION',      1241);
+define('DB_UPDATE_VERSION',      1242);
 define('NEW_UPDATE_ROUTINE_VERSION', 1170);
 
 /**

--- a/src/Database/DBStructure.php
+++ b/src/Database/DBStructure.php
@@ -323,7 +323,6 @@ class DBStructure {
 						$current_field_definition = implode(",", $field_definition);
 						$new_field_definition = implode(",", $parameters);
 						if ($current_field_definition != $new_field_definition) {
-						echo $current_field_definition ."\t". $new_field_definition ."\n";
 							$sql2 = self::modifyTableField($fieldname, $parameters);
 							if ($sql3 == "") {
 								$sql3 = "ALTER" . $ignore . " TABLE `".$temp_name."` ".$sql2;
@@ -1645,7 +1644,7 @@ class DBStructure {
 						)
 				);
 		$database["thread"] = array(
-				"comment" => "Thread related data)",
+				"comment" => "Thread related data",
 				"fields" => array(
 						"iid" => array("type" => "int", "not null" => "1", "default" => "0", "primary" => "1", "relation" => array("item" => "id"), "comment" => ""),
 						"uid" => array("type" => "mediumint", "not null" => "1", "default" => "0", "relation" => array("user" => "uid"), "comment" => "User id"),


### PR DESCRIPTION
The database structure consisted of a mixture of different integer types with different lengths, ...

This is now unified. We now only separate between the basic types. The length value doesn't matter since it is only used for display purposes.

Additionally the possibility was added to write comments for tables and fields. This will enable us to create the table documentation under /doc/database/ automatically.