### PR TITLE
Migrate password hashing Part 3: Switch to password hash

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -41,7 +41,7 @@ define('FRIENDICA_PLATFORM',     'Friendica');
 define('FRIENDICA_CODENAME',     'Asparagus');
 define('FRIENDICA_VERSION',      '3.6-dev');
 define('DFRN_PROTOCOL_VERSION',  '2.23');
-define('DB_UPDATE_VERSION',      1243);
+define('DB_UPDATE_VERSION',      1244);
 define('NEW_UPDATE_ROUTINE_VERSION', 1170);
 
 /**

--- a/database.sql
+++ b/database.sql
@@ -1006,7 +1006,7 @@ CREATE TABLE IF NOT EXISTS `user` (
 	`guid` varchar(64) NOT NULL DEFAULT '' COMMENT '',
 	`username` varchar(255) NOT NULL DEFAULT '' COMMENT '',
 	`password` varchar(255) NOT NULL DEFAULT '' COMMENT '',
-	`legacy_password` tinyint NOT NULL DEFAULT 0 COMMENT 'Is the password hash double-hashed?',
+	`legacy_password` boolean NOT NULL DEFAULT 0 COMMENT 'Is the password hash double-hashed?',
 	`nickname` varchar(255) NOT NULL DEFAULT '' COMMENT '',
 	`email` varchar(255) NOT NULL DEFAULT '' COMMENT '',
 	`openid` varchar(255) NOT NULL DEFAULT '' COMMENT '',

--- a/database.sql
+++ b/database.sql
@@ -1,6 +1,6 @@
 -- ------------------------------------------
 -- Friendica 3.6-dev (Asparagus)
--- DB_UPDATE_VERSION 1243
+-- DB_UPDATE_VERSION 1244
 -- ------------------------------------------
 
 
@@ -1006,6 +1006,7 @@ CREATE TABLE IF NOT EXISTS `user` (
 	`guid` varchar(64) NOT NULL DEFAULT '' COMMENT '',
 	`username` varchar(255) NOT NULL DEFAULT '' COMMENT '',
 	`password` varchar(255) NOT NULL DEFAULT '' COMMENT '',
+	`legacy_password` tinyint NOT NULL DEFAULT 0 COMMENT 'Is the password hash double-hashed?',
 	`nickname` varchar(255) NOT NULL DEFAULT '' COMMENT '',
 	`email` varchar(255) NOT NULL DEFAULT '' COMMENT '',
 	`openid` varchar(255) NOT NULL DEFAULT '' COMMENT '',

--- a/src/Database/DBStructure.php
+++ b/src/Database/DBStructure.php
@@ -1708,6 +1708,7 @@ class DBStructure {
 						"guid" => ["type" => "varchar(64)", "not null" => "1", "default" => "", "comment" => ""],
 						"username" => ["type" => "varchar(255)", "not null" => "1", "default" => "", "comment" => ""],
 						"password" => ["type" => "varchar(255)", "not null" => "1", "default" => "", "comment" => ""],
+						"legacy_password" => ["type" => "tinyint", "not null" => "1", "default" => "0", "comment" => "Is the password hash double-hashed?"],
 						"nickname" => ["type" => "varchar(255)", "not null" => "1", "default" => "", "comment" => ""],
 						"email" => ["type" => "varchar(255)", "not null" => "1", "default" => "", "comment" => ""],
 						"openid" => ["type" => "varchar(255)", "not null" => "1", "default" => "", "comment" => ""],

--- a/src/Database/DBStructure.php
+++ b/src/Database/DBStructure.php
@@ -1708,7 +1708,7 @@ class DBStructure {
 						"guid" => ["type" => "varchar(64)", "not null" => "1", "default" => "", "comment" => ""],
 						"username" => ["type" => "varchar(255)", "not null" => "1", "default" => "", "comment" => ""],
 						"password" => ["type" => "varchar(255)", "not null" => "1", "default" => "", "comment" => ""],
-						"legacy_password" => ["type" => "tinyint", "not null" => "1", "default" => "0", "comment" => "Is the password hash double-hashed?"],
+						"legacy_password" => ["type" => "boolean", "not null" => "1", "default" => "0", "comment" => "Is the password hash double-hashed?"],
 						"nickname" => ["type" => "varchar(255)", "not null" => "1", "default" => "", "comment" => ""],
 						"email" => ["type" => "varchar(255)", "not null" => "1", "default" => "", "comment" => ""],
 						"openid" => ["type" => "varchar(255)", "not null" => "1", "default" => "", "comment" => ""],

--- a/src/Util/ExAuth.php
+++ b/src/Util/ExAuth.php
@@ -226,7 +226,7 @@ class ExAuth
 		if ($a->get_hostname() == $aCommand[2]) {
 			$this->writeLog(LOG_INFO, 'internal auth for ' . $sUser . '@' . $aCommand[2]);
 
-			$aUser = dba::selectFirst('user', ['uid', 'password'], ['nickname' => $sUser]);
+			$aUser = dba::selectFirst('user', ['uid', 'password', 'legacy_password'], ['nickname' => $sUser]);
 			if (DBM::is_result($aUser)) {
 				$uid = $aUser['uid'];
 				$success = User::authenticate($aUser, $aCommand[3]);


### PR DESCRIPTION
Closes #3942

This is it, folks, the final step to make Friendica marginally more secure!

We are now using the newfangled `password_hash()` introduced in PHP *cough* 5.5.

This function is meant to evolve in time as new hashing algorithms get added to the pool and the default changes. As such, our code re-hashes obsolete cleartext password anytime the user provides it, whether at login or during password change.

Shout out to @paragonie-scott for his long-lasting commitment to make PHP software more secure that got me into improving security for Friendica. However, even his iron will would have been for nothing if he didn't provide crucial help through [his blog post at Paragon Initiative Enterprise](https://paragonie.com/blog/2016/02/how-safely-store-password-in-2016#legacy-hashes).