### PR TITLE
Bugfix: Commenting on public posts was not possible anymore

### DIFF
--- a/mod/item.php
+++ b/mod/item.php
@@ -174,7 +174,7 @@ function item_post(App $a) {
 	}
 
 	$user = dba::selectFirst('user', [], ['uid' => $profile_uid]);
-	if (!DBM::is_result($user) && !$orig_post) {
+	if (!DBM::is_result($user) && !$parent) {
 		return;
 	}
 


### PR DESCRIPTION
One of the last changes to mod/item.php introduced this bug that prevented us from commenting on public posts from users we don't follow.