### PR TITLE
Bugfix: Always comment on the correct entry

### DIFF
--- a/mod/network.php
+++ b/mod/network.php
@@ -815,7 +815,7 @@ function networkThreadedView(App $a, $update = 0)
 
 		if (count($data) > 0) {
 			logger('Tagged items: ' . count($data) . ' - ' . $bottom_limit . ' - ' . $top_limit . ' - ' . local_user()); //$last_date);
-			$r = array_merge($r, $data);
+			$r = array_merge($data, $r);
 		}
 	}
 


### PR DESCRIPTION
When we follow tags and one of our contacts was writing something that contained one of that tags, our comments went to the wrong item entry.