### PR TITLE
Issue 4295: The url detection in BBCode is too greedy 

### DIFF
--- a/include/bbcode.php
+++ b/include/bbcode.php
@@ -971,11 +971,9 @@ function bbcode($Text, $preserve_nl = false, $tryoembed = true, $simplehtml = fa
 	if (!$forplaintext) {
 		// Autolink feature (thanks to http://code.seebz.net/p/autolink-php/)
 		$autolink_regex = "`([^\]\=\"']|^)(https?\://[^\s<]+[^\s<\.\)])`ism";
-		if ($simplehtml != 7) {
-			$Text = preg_replace($autolink_regex, '$1<a href="$2" target="_blank">$2</a>', $Text);
-		} else {
-			$Text = preg_replace($autolink_regex, '$1[url]$2[/url]', $Text);
-
+		$autolink_regex = "/([^\]\='".'"'."]|^)(https?\:\/\/[a-zA-Z0-9\:\/\-\?\&\;\.\=\_\~\#\%\$\!\+\,]+)/ism";
+		$Text = preg_replace($autolink_regex, '$1[url]$2[/url]', $Text);
+		if ($simplehtml == 7) {
 			$Text = preg_replace_callback("/\[url\]([$URLSearchString]*)\[\/url\]/ism", 'bb_style_url', $Text);
 			$Text = preg_replace_callback("/\[url\=([$URLSearchString]*)\]([$URLSearchString]*)\[\/url\]/ism", 'bb_style_url', $Text);
 		}
@@ -1047,7 +1045,7 @@ function bbcode($Text, $preserve_nl = false, $tryoembed = true, $simplehtml = fa
 	$Text = preg_replace($expression, System::baseUrl()."/display/$1", $Text);
 
 	if ($tryoembed) {
-		$Text = preg_replace_callback("/\[url\]([$URLSearchString]*)\[\/url\]/ism", $tryoembed_callback, $Text);
+	//	$Text = preg_replace_callback("/\[url\]([$URLSearchString]*)\[\/url\]/ism", $tryoembed_callback, $Text);
 	}
 
 	$Text = preg_replace("/([#])\[url\=([$URLSearchString]*)\](.*?)\[\/url\]/ism",

--- a/include/bbcode.php
+++ b/include/bbcode.php
@@ -970,7 +970,8 @@ function bbcode($Text, $preserve_nl = false, $tryoembed = true, $simplehtml = fa
 	// if the HTML is used to generate plain text, then don't do this search, but replace all URL of that kind to text
 	if (!$forplaintext) {
 		// Autolink feature (thanks to http://code.seebz.net/p/autolink-php/)
-		$autolink_regex = "`([^\]\=\"']|^)(https?\://[^\s<]+[^\s<\.\)])`ism";
+		// Currently disabled, since the function is too greedy
+		// $autolink_regex = "`([^\]\=\"']|^)(https?\://[^\s<]+[^\s<\.\)])`ism";
 		$autolink_regex = "/([^\]\='".'"'."]|^)(https?\:\/\/[a-zA-Z0-9\:\/\-\?\&\;\.\=\_\~\#\%\$\!\+\,]+)/ism";
 		$Text = preg_replace($autolink_regex, '$1[url]$2[/url]', $Text);
 		if ($simplehtml == 7) {
@@ -1043,10 +1044,6 @@ function bbcode($Text, $preserve_nl = false, $tryoembed = true, $simplehtml = fa
 	// See issue: https://github.com/diaspora/diaspora_federation/issues/75
 	$expression = "=diaspora://.*?/post/([0-9A-Za-z\-_@.:]{15,254}[0-9A-Za-z])=ism";
 	$Text = preg_replace($expression, System::baseUrl()."/display/$1", $Text);
-
-	if ($tryoembed) {
-	//	$Text = preg_replace_callback("/\[url\]([$URLSearchString]*)\[\/url\]/ism", $tryoembed_callback, $Text);
-	}
 
 	$Text = preg_replace("/([#])\[url\=([$URLSearchString]*)\](.*?)\[\/url\]/ism",
 				'$1<a href="$2" class="tag" title="$3">$3</a>', $Text);


### PR DESCRIPTION
See issue https://github.com/friendica/friendica/issues/4295

This is more a quick fix than a final solution. Because of this the old code isn't completely removed.

Additionally we now aren't doing an OEmbed request with ```[url]``` anymore. See issue https://github.com/friendica/friendica/issues/4222