### PR TITLE
When RINO is set to a (now) invalid value, we set it to a valid one

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -41,7 +41,7 @@ define('FRIENDICA_PLATFORM',     'Friendica');
 define('FRIENDICA_CODENAME',     'Asparagus');
 define('FRIENDICA_VERSION',      '3.6-dev');
 define('DFRN_PROTOCOL_VERSION',  '2.23');
-define('DB_UPDATE_VERSION',      1244);
+define('DB_UPDATE_VERSION',      1245);
 define('NEW_UPDATE_ROUTINE_VERSION', 1170);
 
 /**

--- a/update.php
+++ b/update.php
@@ -161,3 +161,15 @@ function update_1244() {
 
 	return UPDATE_SUCCESS;
 }
+
+function update_1245() {
+	$rino = Config::get('system', 'rino_encrypt');
+
+	if (!$rino) {
+		return UPDATE_SUCCESS;
+	}
+
+	Config::set('system', 'rino_encrypt', 1);
+
+	return UPDATE_SUCCESS;
+}


### PR DESCRIPTION
This is a fix for the PR which removed RINO2.