### PR TITLE
Support for hashtags with "#" inside the link (mastodon style?)

### DIFF
--- a/include/bbcode.php
+++ b/include/bbcode.php
@@ -1051,6 +1051,9 @@ function bbcode($Text, $preserve_nl = false, $tryoembed = true, $simplehtml = fa
 	$Text = preg_replace("/([#])\[url\=([$URLSearchString]*)\](.*?)\[\/url\]/ism",
 				'$1<a href="' . System::baseUrl() . '/search?tag=$3" class="tag" title="$3">$3</a>', $Text);
 
+	$Text = preg_replace("/\[url\=([$URLSearchString]*)\]#(.*?)\[\/url\]/ism",
+				'#<a href="' . System::baseUrl() . '/search?tag=$2" class="tag" title="$2">$2</a>', $Text);
+
 	$Text = preg_replace("/\[url\]([$URLSearchString]*)\[\/url\]/ism", '<a href="$1" target="_blank">$1</a>', $Text);
 	$Text = preg_replace("/\[url\=([$URLSearchString]*)\](.*?)\[\/url\]/ism", '<a href="$1" target="_blank">$2</a>', $Text);
 	//$Text = preg_replace("/\[url\=([$URLSearchString]*)\]([$URLSearchString]*)\[\/url\]/ism", '<a href="$1" target="_blank">$2</a>', $Text);


### PR DESCRIPTION
Normally the ```#``` is outside the link - there seem to be some posts from mastodon where the ```#``` is inside the link.

We now support this as well.