### PR TITLE
Use "sup" instead of "h5" for the link to the website

### DIFF
--- a/include/bbcode.php
+++ b/include/bbcode.php
@@ -106,7 +106,7 @@ function bb_attachment($return, $simplehtml = false, $tryoembed = true)
 			}
 
 			if ($data["type"] == "link") {
-				$return .= sprintf('<h5><a href="%s">%s</a></h5>', $data['url'], parse_url($data['url'], PHP_URL_HOST));
+				$return .= sprintf('<sup><a href="%s">%s</a></sup>', $data['url'], parse_url($data['url'], PHP_URL_HOST));
 			}
 
 			if ($simplehtml != 4) {

--- a/mod/contacts.php
+++ b/mod/contacts.php
@@ -552,7 +552,7 @@ function contacts_content(App $a)
 		// tabs
 		$tab_str = contacts_tab($a, $contact_id, 2);
 
-		$lost_contact = (($contact['archive'] && $contact['term-date'] > NULL_DATE && $contact['term-date'] < datetime_converL10n::t('', '', 'now')) ? L10n::t('Communications lost with this contact!') : '');
+		$lost_contact = (($contact['archive'] && $contact['term-date'] > NULL_DATE && $contact['term-date'] < datetime_convert('', '', 'now')) ? L10n::t('Communications lost with this contact!') : '');
 
 		$fetch_further_information = null;
 		if ($contact['network'] == NETWORK_FEED) {


### PR DESCRIPTION
Attached links contain a link to the website at the bottom. It had been ```<h5>``` before. But technically this is no header, since there is no following content. We now use the ```<sup>``` element, since it is more some kind of footnote.

Accidentally this PR also contains a bugfix that is part of PR https://github.com/friendica/friendica/pull/4327 (I forgot to exclude this file from the commit).