### PR TITLE
Avoid empty needle warning

### DIFF
--- a/src/Protocol/Feed.php
+++ b/src/Protocol/Feed.php
@@ -415,7 +415,7 @@ class Feed {
 					$item["body"] .= "\n".$item['tag'];
 				}
 				// Add the link to the original feed entry if not present in feed
-				if (!strstr($item["body"], $item['plink']) && ($item['plink'] != '')) {
+				if (($item['plink'] != '') && !strstr($item["body"], $item['plink'])) {
 					$item["body"] .= "[hr][url]".$item['plink']."[/url]";
 				}
 			}


### PR DESCRIPTION
This avoids the warning ```PHP Warning:  strstr(): Empty needle in /.../src/Protocol/Feed.php on line 418```
