### PR TITLE
Basic forum support for Diaspora

### DIFF
--- a/include/bbcode.php
+++ b/include/bbcode.php
@@ -997,8 +997,9 @@ function bbcode($Text, $preserve_nl = false, $tryoembed = true, $simplehtml = fa
 	if ((!$tryoembed || $simplehtml) && !in_array($simplehtml, [3, 7])) {
 		$Text = preg_replace("/([#@!])\[url\=([$URLSearchString]*)\](.*?)\[\/url\]/ism", '$1$3', $Text);
 	} elseif ($simplehtml == 3) {
+		// The ! is converted to @ since Diaspora only understands the @
 		$Text = preg_replace("/([@!])\[url\=([$URLSearchString]*)\](.*?)\[\/url\]/ism",
-			'$1<a href="$2">$3</a>',
+			'@<a href="$2">$3</a>',
 			$Text);
 	} elseif ($simplehtml == 7) {
 		$Text = preg_replace("/([@!])\[url\=([$URLSearchString]*)\](.*?)\[\/url\]/ism",

--- a/src/Worker/Delivery.php
+++ b/src/Worker/Delivery.php
@@ -133,7 +133,8 @@ class Delivery {
 			return;
 		}
 
-		$walltowall = (($top_level && ($owner['id'] != $items[0]['contact-id'])) ? true : false);
+		// We don't treat Forum posts as "wall-to-wall" to be able to post them via Diaspora
+		$walltowall = $top_level && ($owner['id'] != $items[0]['contact-id']) & ($owner['account-type'] != ACCOUNT_TYPE_COMMUNITY);
 
 		$public_message = true;
 


### PR DESCRIPTION
There is now a basic support of forums for Diaspora. It has got two downsides:

1. Diaspora users can't start forum posts
2. Diaspora users can't see the original name of the poster. The starting post always appears as if it was sent from the forum

The forum post has to be sent via the ```!``` to ensure the correct distribution.