### PR TITLE
Admin menu reorganisation

### DIFF
--- a/mod/admin.php
+++ b/mod/admin.php
@@ -171,17 +171,30 @@ function admin_content(App $a)
 	// array(url, name, extra css classes)
 	// not part of $aside to make the template more adjustable
 	$aside_sub = [
-		'site'         => ["admin/site/"        , L10n::t("Site")                 , "site"],
-		'users'        => ["admin/users/"       , L10n::t("Users")                , "users"],
-		'addons'       => ["admin/addons/"      , L10n::t("Addons")               , "addons"],
-		'themes'       => ["admin/themes/"      , L10n::t("Themes")               , "themes"],
-		'features'     => ["admin/features/"    , L10n::t("Additional features")  , "features"],
-		'dbsync'       => ["admin/dbsync/"      , L10n::t('DB updates')           , "dbsync"],
-		'queue'        => ["admin/queue/"       , L10n::t('Inspect Queue')        , "queue"],
-		'contactblock' => ["admin/contactblock/", L10n::t('Contact Blocklist')    , "contactblock"],
-		'blocklist'    => ["admin/blocklist/"   , L10n::t('Server Blocklist')     , "blocklist"],
-		'federation'   => ["admin/federation/"  , L10n::t('Federation Statistics'), "federation"],
-		'deleteitem'   => ["admin/deleteitem/"  , L10n::t('Delete Item')          , 'deleteitem'],
+		'information' => [ L10n::t('Information'), [
+			"overview" => ["admin/", L10n::t("Overview"), "overview" ],
+			'federation'   => ["admin/federation/"  , L10n::t('Federation Statistics'), "federation"] ]],
+		'configuration' => [ L10n::t('Configuration'), [
+			'site'         => ["admin/site/"        , L10n::t("Site")                 , "site"],
+			'users'        => ["admin/users/"       , L10n::t("Users")                , "users"],
+			'addons'       => ["admin/addons/"      , L10n::t("Addons")               , "addons"],
+			'themes'       => ["admin/themes/"      , L10n::t("Themes")               , "themes"],
+			'features'     => ["admin/features/"    , L10n::t("Additional features")  , "features"] ]],
+		'database' => [ L10n::t('Database'), [ 
+			'dbsync'       => ["admin/dbsync/"      , L10n::t('DB updates')           , "dbsync"],
+			'queue'        => ["admin/queue/"       , L10n::t('Inspect Queue')        , "queue"], ]],
+		'tools' => [ L10n::t('Tools'), [ 
+			'contactblock' => ["admin/contactblock/", L10n::t('Contact Blocklist')    , "contactblock"],
+			'blocklist'    => ["admin/blocklist/"   , L10n::t('Server Blocklist')     , "blocklist"],
+			'deleteitem'   => ["admin/deleteitem/"  , L10n::t('Delete Item')          , 'deleteitem'], ]],
+		"logs" => [ L10n::t("Logs"), [
+			"logsconfig" => ["admin/logs/", L10n::t("Logs"), "logs"],
+			"logsview" => ["admin/viewlogs/", L10n::t("View Logs"), 'viewlogs']
+		]],
+		"diagnostics" => [ L10n::t("Diagnostics"), [
+			"probe" => ['probe/', L10n::t('probe address'), 'probe'],
+			"webfinger" =>['webfinger/', L10n::t('check webfinger'), 'webfinger']
+		]]
 	];
 
 	/* get addons admin page */
@@ -195,19 +208,12 @@ function admin_content(App $a)
 		$a->addons_admin[] = $addon;
 	}
 
-	$aside_tools['logs'] = ["admin/logs/", L10n::t("Logs"), "logs"];
-	$aside_tools['viewlogs'] = ["admin/viewlogs/", L10n::t("View Logs"), 'viewlogs'];
-	$aside_tools['diagnostics_probe'] = ['probe/', L10n::t('probe address'), 'probe'];
-	$aside_tools['diagnostics_webfinger'] = ['webfinger/', L10n::t('check webfinger'), 'webfinger'];
-
 	$t = get_markup_template('admin/aside.tpl');
 	$a->page['aside'] .= replace_macros($t, [
 		'$admin' => $aside_tools,
 		'$subpages' => $aside_sub,
 		'$admtxt' => L10n::t('Admin'),
 		'$plugadmtxt' => L10n::t('Addon Features'),
-		'$logtxt' => L10n::t('Logs'),
-		'$diagnosticstxt' => L10n::t('diagnostics'),
 		'$h_pending' => L10n::t('User registrations waiting for confirmation'),
 		'$admurl' => "admin/"
 	]);

--- a/view/templates/admin/aside.tpl
+++ b/view/templates/admin/aside.tpl
@@ -11,17 +11,20 @@
 	});
 </script>
 
-<h4><a href="{{$admurl}}">{{$admtxt}}</a></h4>
-<ul class='admin linklist'>
 {{foreach $subpages as $page}}
-	<li class='admin link button {{$page.2}}'><a href='{{$page.0}}'>{{$page.1}}</a></li>
+<h4>{{$page.0}}</h4>
+<ul class="admin linklist" role="menu">
+{{foreach $page.1 as $item}}
+	<li class='admin link button {{$item.2}}' role="menuitem"><a href='{{$item.0}}'>{{$item.1}}</a></li>
 {{/foreach}}
 </ul>
+{{/foreach}}
+
+
 
 {{if $admin.update}}
 <ul class='admin linklist'>
 	<li class='admin link button {{$admin.update.2}}'><a href='{{$admin.update.0}}'>{{$admin.update.1}}</a></li>
-	<li class='admin link button {{$admin.update.2}}'><a href='https://kakste.com/profile/inthegit'>Important Changes</a></li>
 </ul>
 {{/if}}
 
@@ -34,14 +37,3 @@
 </ul>
 	
 	
-<h4>{{$logtxt}}</h4>
-<ul class='admin linklist'>
-	<li class='admin link button {{$admin.logs.2}}'><a href='{{$admin.logs.0}}'>{{$admin.logs.1}}</a></li>
-	<li class='admin link button {{$admin.viewlogs.2}}'><a href='{{$admin.viewlogs.0}}'>{{$admin.viewlogs.1}}</a></li>
-</ul>
-
-<h4>{{$diagnosticstxt}}</h4>
-<ul class='admin linklist'>
-	<li class='admin link {{$admin.diagnostics_probe.2}}'><a href="{{$admin.diagnostics_probe.0}}">{{$admin.diagnostics_probe.1}}</a></li>
-	<li class='admin link {{$admin.diagnostics_webfinger.2}}'><a href="{{$admin.diagnostics_webfinger.0}}">{{$admin.diagnostics_webfinger.1}}</a></li>
-</ul>

--- a/view/theme/frio/templates/admin/aside.tpl
+++ b/view/theme/frio/templates/admin/aside.tpl
@@ -10,11 +10,11 @@
 	});
 </script>
 
+{{foreach $subpages as $page}}
 <div class="widget">
-	<h3><a href="{{$admurl}}">{{$admtxt}}</a></h3>
-
+	<h3>{{$page.0}}</h3>
 	<ul role="menu">
-		{{foreach $subpages as $name => $item}}
+		{{foreach $page.1 as $item}}
 		<li role="menuitem" class="{{$item.2}}">
 			<a href="{{$item.0}}" {{if $item.accesskey}}accesskey="{{$item.accesskey}}"{{/if}}>
 				{{$item.1}}
@@ -36,6 +36,7 @@
 	</ul>
 	{{/if}}
 </div>
+{{/foreach}}
 
 {{if $admin.addons_admin}}
 <div class="widget">
@@ -52,34 +53,3 @@
 </div>
 {{/if}}
 
-<div class="widget">
-	<h3>{{$logtxt}}</h3>
-	<ul role="menu">
-		<li role="menuitem" class="{{$admin.logs.2}}">
-			<a href="{{$admin.logs.0}}" {{if $admin.logs.accesskey}}accesskey="{{$admin.logs.accesskey}}"{{/if}}>
-				{{$admin.logs.1}}
-			</a>
-		</li>
-		<li role="menuitem" class="{{$admin.viewlogs.2}}">
-			<a href="{{$admin.viewlogs.0}}" {{if $admin.viewlogs.accesskey}}accesskey="{{$admin.viewlogs.accesskey}}"{{/if}}>
-				{{$admin.viewlogs.1}}
-			</a>
-		</li>
-	</ul>
-</div>
-
-<div class="widget">
-	<h3>{{$diagnosticstxt}}</h3>
-	<ul role="menu">
-		<li role="menuitem" class="{{$admin.diagnostics_probe.2}}">
-			<a href="{{$admin.diagnostics_probe.0}}" {{if $admin.diagnostics_probe.accesskey}}accesskey="{{$admin.diagnostics_probe.accesskey}}"{{/if}}>
-				{{$admin.diagnostics_probe.1}}
-			</a>
-		</li>
-		<li role="menuitem" class="{{$admin.diagnostics_webfinger.2}}">
-			<a href="{{$admin.diagnostics_webfinger.0}}" {{if $admin.viewlogs.accesskey}}accesskey="{{$admin.diagnostics_webfinger.accesskey}}"{{/if}}>
-				{{$admin.diagnostics_webfinger.1}}
-			</a>
-		</li>
-	</ul>
-</div>


### PR DESCRIPTION
The aside menu in the admin panel is now handled in one array, which also holds the submenu items. Also the sections of the menu are now a bit more structured and separated from each other.

Similar to what is shown in [this thread](https://forum.friendi.ca/display/f3ad7b1c735a2e494ee5791238530785).


