### PR TITLE
Quit if follow fails because of not configured addon

### DIFF
--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -1151,6 +1151,11 @@ class Contact extends BaseObject
 
 		Addon::callHooks('follow', $arr);
 
+		if (empty($arr)) {
+			$result['message'] = L10n::t('Contact cannot be added.');
+			return $result;
+		}
+
 		if (x($arr['contact'], 'name')) {
 			$ret = $arr['contact'];
 		} else {

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -1152,7 +1152,7 @@ class Contact extends BaseObject
 		Addon::callHooks('follow', $arr);
 
 		if (empty($arr)) {
-			$result['message'] = L10n::t('Contact cannot be added.');
+			$result['message'] = L10n::t('The contact could not be added. It is possible you are attempting to add a contact that requires an Addon that is not enabled on this system.');
 			return $result;
 		}
 

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -1152,7 +1152,7 @@ class Contact extends BaseObject
 		Addon::callHooks('follow', $arr);
 
 		if (empty($arr)) {
-			$result['message'] = L10n::t('The contact could not be added. It is possible you are attempting to add a contact that requires an Addon that is not configured on this system.');
+			$result['message'] = L10n::t('The contact could not be added. Please check the relevant network credentials in your Settings -> Social Networks page.');
 			return $result;
 		}
 

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -1152,7 +1152,7 @@ class Contact extends BaseObject
 		Addon::callHooks('follow', $arr);
 
 		if (empty($arr)) {
-			$result['message'] = L10n::t('The contact could not be added. It is possible you are attempting to add a contact that requires an Addon that is not enabled on this system.');
+			$result['message'] = L10n::t('The contact could not be added. It is possible you are attempting to add a contact that requires an Addon that is not configured on this system.');
 			return $result;
 		}
 


### PR DESCRIPTION
When an addon fails we now quit the following.