### PR TITLE
including the print css file hides control buttons in calendar overview

### DIFF
--- a/view/templates/event_head.tpl
+++ b/view/templates/event_head.tpl
@@ -1,6 +1,5 @@
 
 <link rel="stylesheet" type="text/css" href="{{$baseurl}}/vendor/asset/fullcalendar/dist/fullcalendar.min.css" />
-<link rel="stylesheet" type="text/css" href="{{$baseurl}}/vendor/asset/fullcalendar/dist/fullcalendar.print.min.css" />
 <script type="text/javascript" src="{{$baseurl}}/vendor/asset/moment/min/moment-with-locales.min.js"></script>
 <script type="text/javascript" src="{{$baseurl}}/vendor/asset/fullcalendar/dist/fullcalendar.min.js"></script>
 

--- a/view/theme/frio/templates/event_head.tpl
+++ b/view/theme/frio/templates/event_head.tpl
@@ -1,6 +1,5 @@
 
 <link rel="stylesheet" type="text/css" href="{{$baseurl}}/vendor/asset/fullcalendar/dist/fullcalendar.min.css" />
-<link rel="stylesheet" type="text/css" href="{{$baseurl}}/vendor/asset/fullcalendar/dist/fullcalendar.print.min.css" />
 <link rel="stylesheet" type="text/css" href="view/theme/frio/css/mod_events.css" />
 <script type="text/javascript" src="{{$baseurl}}/vendor/asset/moment/min/moment-with-locales.min.js"></script>
 <script type="text/javascript" src="{{$baseurl}}/vendor/asset/fullcalendar/dist/fullcalendar.min.js"></script>

--- a/view/theme/frost-mobile/templates/event_head.tpl
+++ b/view/theme/frost-mobile/templates/event_head.tpl
@@ -1,6 +1,5 @@
 
 <link rel="stylesheet" type="text/css" href="{{$baseurl}}/vendor/asset/fullcalendar/dist/fullcalendar.min.css" />
-<link rel="stylesheet" type="text/css" href="{{$baseurl}}/vendor/asset/fullcalendar/dist/fullcalendar.print.min.css" />
 
 <script language="javascript" type="text/javascript">
 window.aclType = 'event_head';

--- a/view/theme/frost/templates/event_head.tpl
+++ b/view/theme/frost/templates/event_head.tpl
@@ -1,6 +1,5 @@
 
 <link rel="stylesheet" type="text/css" href="{{$baseurl}}/vendor/asset/fullcalendar/dist/fullcalendar.min.css" />
-<link rel="stylesheet" type="text/css" href="{{$baseurl}}/vendor/asset/fullcalendar/dist/fullcalendar.print.min.css" />
 
 <script language="javascript" type="text/javascript">
 window.aclType = 'event_head';

--- a/view/theme/vier/templates/event_head.tpl
+++ b/view/theme/vier/templates/event_head.tpl
@@ -1,6 +1,5 @@
 
 <link rel="stylesheet" type="text/css" href="{{$baseurl}}/vendor/asset/fullcalendar/dist/fullcalendar.min.css" />
-<link rel="stylesheet" type="text/css" href="{{$baseurl}}/vendor/asset/fullcalendar/dist/fullcalendar.print.min.css" />
 <script type="text/javascript" src="{{$baseurl}}/vendor/asset/moment/min/moment-with-locales.min.js"></script>
 <script type="text/javascript" src="{{$baseurl}}/vendor/asset/fullcalendar/dist/fullcalendar.min.js"></script>
 


### PR DESCRIPTION
except in frio as there the control styling is changed again after
including the css file.

Follow up to #4338