### PR TITLE
added missing constant

### DIFF
--- a/src/Render/FriendicaSmartyEngine.php
+++ b/src/Render/FriendicaSmartyEngine.php
@@ -6,6 +6,8 @@ namespace Friendica\Render;
 
 use Friendica\Core\Addon;
 
+define('SMARTY3_TEMPLATE_FOLDER', 'templates');
+
 class FriendicaSmartyEngine implements ITemplateEngine
 {
 	static $name = "smarty3";


### PR DESCRIPTION
This fixes the WSoD due the missing template path for the SMARTY templates
after #4375. But as now the constant is defined twice it feels wrong and 
most likely could be done better.