### PR TITLE
Bugfix: Probe - get the contact address from xrd 'subject' key

### DIFF
--- a/src/Network/Probe.php
+++ b/src/Network/Probe.php
@@ -962,6 +962,10 @@ class Probe
 			}
 		}
 
+		if (substr($webfinger["subject"], 0, 5) == "acct:") {
+			$data["addr"] = substr($webfinger["subject"], 5);
+		}
+
 		if (!isset($data["network"]) || ($hcard_url == "")) {
 			return false;
 		}


### PR DESCRIPTION
If noscrape is disabled Friendica didn't get the the contacts `addr` while probing.

As far as I can see the uri can be found in the `subject` key of the json xrd output (https://github.com/friendica/friendica/blob/develop/mod/xrd.php#L68).
