### PR TITLE
Quickfix: Removed exception since it blocked message delivery

### DIFF
--- a/src/Core/Protocol.php
+++ b/src/Core/Protocol.php
@@ -49,7 +49,7 @@ class Protocol
 		$network = self::matchByProfileUrl($profile_url, $matches);
 
 		if ($network === self::PHANTOM) {
-			throw new Exception('Unknown network for profile URL: ' . $profile_url);
+			return "";
 		}
 
 		$addr = $matches[2] . '@' . $matches[1];


### PR DESCRIPTION
The exception was removed since it blocked the whole worker processing.

Additionally the file was converted to the unix format.