### PR TITLE
frio: disable nav login button on home and login module

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -2134,6 +2134,11 @@ ul.dropdown-menu li:hover {
 .section-title-wrapper {
     overflow: hidden;
 }
+/* Home and Login Page */
+body.mod-home .navbar #nav-login,
+body.mod-login .navbar #nav-login {
+    display: none;
+}
 /* Profile-page */
 #profile-content-standard,
 #profile-content-advanced {

--- a/view/theme/frio/templates/nav.tpl
+++ b/view/theme/frio/templates/nav.tpl
@@ -238,7 +238,6 @@
 		</div>
 		<div class="pull-right">
 			<ul class="nav navbar-nav navbar-right">
-				{{if $nav.register}}<li><a href="register" data-toggle="tooltip" title="{{$nav.register.3}}"><i class="fa fa-street-view fa-fw" aria-hidden="true"></i></a></li>{{/if}}
 				<li>
 					<a href="login?mode=none" id="nav-login"
 						data-toggle="tooltip" title="{{$nav.login.3}}">


### PR DESCRIPTION
This PR does remove the navbar register button because the register link is included in the login form.
It also disables the navbar login button for the home and login module because we already showing the login form.

This addresses https://github.com/friendica/friendica/issues/3671