### PR TITLE
We now incrementally calculate the queue delivery time

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -39,7 +39,7 @@ define('FRIENDICA_PLATFORM',     'Friendica');
 define('FRIENDICA_CODENAME',     'Asparagus');
 define('FRIENDICA_VERSION',      '3.6-dev');
 define('DFRN_PROTOCOL_VERSION',  '2.23');
-define('DB_UPDATE_VERSION',      1250);
+define('DB_UPDATE_VERSION',      1251);
 define('NEW_UPDATE_ROUTINE_VERSION', 1170);
 
 /**

--- a/database.sql
+++ b/database.sql
@@ -853,19 +853,18 @@ CREATE TABLE IF NOT EXISTS `push_subscriber` (
 --
 CREATE TABLE IF NOT EXISTS `queue` (
 	`id` int NOT NULL auto_increment COMMENT '',
-	`cid` int NOT NULL DEFAULT 0 COMMENT '',
-	`network` varchar(32) NOT NULL DEFAULT '' COMMENT '',
-	`guid` varchar(255) NOT NULL DEFAULT '' COMMENT '',
-	`created` datetime NOT NULL DEFAULT '0001-01-01 00:00:00' COMMENT '',
-	`last` datetime NOT NULL DEFAULT '0001-01-01 00:00:00' COMMENT '',
+	`cid` int NOT NULL DEFAULT 0 COMMENT 'Message receiver',
+	`network` varchar(32) NOT NULL DEFAULT '' COMMENT 'Receiver\'s network',
+	`guid` varchar(255) NOT NULL DEFAULT '' COMMENT 'Unique GUID of the message',
+	`created` datetime NOT NULL DEFAULT '0001-01-01 00:00:00' COMMENT 'Date, when the message was created',
+	`last` datetime NOT NULL DEFAULT '0001-01-01 00:00:00' COMMENT 'Date of last trial',
+	`next` datetime NOT NULL DEFAULT '0001-01-01 00:00:00' COMMENT 'Next retrial date',
+	`retrial` tinyint NOT NULL DEFAULT 0 COMMENT 'Retrial counter',
 	`content` mediumtext COMMENT '',
 	`batch` boolean NOT NULL DEFAULT '0' COMMENT '',
 	 PRIMARY KEY(`id`),
-	 INDEX `cid` (`cid`),
-	 INDEX `created` (`created`),
 	 INDEX `last` (`last`),
-	 INDEX `network` (`network`),
-	 INDEX `batch` (`batch`)
+	 INDEX `next` (`next`)
 ) DEFAULT COLLATE utf8mb4_general_ci;
 
 --

--- a/src/Database/DBStructure.php
+++ b/src/Database/DBStructure.php
@@ -1553,17 +1553,16 @@ class DBStructure
 						"network" => ["type" => "varchar(32)", "not null" => "1", "default" => "", "comment" => "Receiver's network"],
 						"guid" => ["type" => "varchar(255)", "not null" => "1", "default" => "", "comment" => "Unique GUID of the message"],
 						"created" => ["type" => "datetime", "not null" => "1", "default" => NULL_DATE, "comment" => "Date, when the message was created"],
-						"last" => ["type" => "datetime", "not null" => "1", "default" => NULL_DATE, "comment" => ""],
+						"last" => ["type" => "datetime", "not null" => "1", "default" => NULL_DATE, "comment" => "Date of last trial"],
+						"next" => ["type" => "datetime", "not null" => "1", "default" => NULL_DATE, "comment" => "Next retrial date"],
+						"retrial" => ["type" => "tinyint", "not null" => "1", "default" => "0", "comment" => "Retrial counter"],
 						"content" => ["type" => "mediumtext", "comment" => ""],
 						"batch" => ["type" => "boolean", "not null" => "1", "default" => "0", "comment" => ""],
 						],
 				"indexes" => [
 						"PRIMARY" => ["id"],
-						"cid" => ["cid"],
-						"created" => ["created"],
 						"last" => ["last"],
-						"network" => ["network"],
-						"batch" => ["batch"],
+						"next" => ["next"],
 						]
 				];
 		$database["register"] = [

--- a/src/Model/Queue.php
+++ b/src/Model/Queue.php
@@ -32,7 +32,7 @@ class Queue
 
 		// Calculate the delay until the next trial
 		$delay = (($retrial + 3) ** 4) + (rand(1, 30) * ($retrial + 1));
-		$next = DateTimeFormat::utc('now ' . $delay . ' seconds');
+		$next = DateTimeFormat::utc('now + ' . $delay . ' seconds');
 
 		dba::update('queue', ['last' => DateTimeFormat::utcNow(), 'retrial' => $retrial + 1, 'next' => $next], ['id' => $id]);
 	}

--- a/src/Model/Queue.php
+++ b/src/Model/Queue.php
@@ -32,7 +32,7 @@ class Queue
 
 		// Calculate the delay until the next trial
 		$delay = (($retrial + 3) ** 4) + (rand(1, 30) * ($retrial + 1));
-		$next = DateTimeFormat::utc(date('c', time() + $delay));
+		$next = DateTimeFormat::utc('now ' . $delay . ' seconds');
 
 		dba::update('queue', ['last' => DateTimeFormat::utcNow(), 'retrial' => $retrial + 1, 'next' => $next], ['id' => $id]);
 	}


### PR DESCRIPTION
Currently we really penetrated other systems with the redelivering of messages (every 15 minutes for 12 hours, then for two days every hour). This was bad for the performance of the delivering system, but could also had been bad for the receiver if it had got load problems.

We are now using the mechanism that Diaspora is using as well. We try 14 times with an increasing time between each trial. 