### PR TITLE
We can now delegate again like before

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -39,7 +39,7 @@ define('FRIENDICA_PLATFORM',     'Friendica');
 define('FRIENDICA_CODENAME',     'Asparagus');
 define('FRIENDICA_VERSION',      '3.6-dev');
 define('DFRN_PROTOCOL_VERSION',  '2.23');
-define('DB_UPDATE_VERSION',      1251);
+define('DB_UPDATE_VERSION',      1252);
 define('NEW_UPDATE_ROUTINE_VERSION', 1170);
 
 /**

--- a/src/Database/DBStructure.php
+++ b/src/Database/DBStructure.php
@@ -1707,6 +1707,7 @@ class DBStructure
 				"comment" => "The local users",
 				"fields" => [
 						"uid" => ["type" => "mediumint", "not null" => "1", "extra" => "auto_increment", "primary" => "1", "comment" => ""],
+						"parent-uid" => ["type" => "mediumint", "not null" => "1", "default" => "0", "relation" => ["user" => "uid"], "comment" => "The parent user that has full control about this user"],
 						"guid" => ["type" => "varchar(64)", "not null" => "1", "default" => "", "comment" => ""],
 						"username" => ["type" => "varchar(255)", "not null" => "1", "default" => "", "comment" => ""],
 						"password" => ["type" => "varchar(255)", "not null" => "1", "default" => "", "comment" => ""],


### PR DESCRIPTION
There is now a possibility to do the delegation like it was done before. When a user record has got a ```parent-uid``` that isn't equal zero, then that parent user can completely manage that user account.

Currently a web frontend for this setting is missing. Hopefully someone does this in a nice way. :-)