### PR TITLE
[Hotfix] Add missing require in include/text

### DIFF
--- a/include/text.php
+++ b/include/text.php
@@ -20,6 +20,7 @@ use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Map;
 
 require_once "mod/proxy.php";
+require_once "include/event.php";
 require_once "include/conversation.php";
 
 /**


### PR DESCRIPTION
Fixes a Fatal Error in `/network` when trying to display an event.