### PR TITLE
Bugfix for check that the DFRN entry already exists

### DIFF
--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -2411,10 +2411,8 @@ class DFRN
 		);
 
 		// Is there an existing item?
-		if (DBM::is_result($current) && self::isEditedTimestampNewer($current[0], $item)
-			&& (DateTimeFormat::utc($item["edited"]) < $current[0]["edited"])
-		) {
-			logger("Item ".$item["uri"]." already existed.", LOGGER_DEBUG);
+		if (DBM::is_result($current) && !self::isEditedTimestampNewer($current[0], $item)) {
+			logger("Item ".$item["uri"]." already existed in this version.", LOGGER_DEBUG);
 			return;
 		}
 


### PR DESCRIPTION
We constantly imported content although it wasn't newer than the existing one. This is now solved.