### PR TITLE
Suppress content from hidden or blocked contacts

### DIFF
--- a/include/conversation.php
+++ b/include/conversation.php
@@ -910,6 +910,7 @@ function community_add_items($parents) {
 	foreach ($parents AS $parent) {
 		$thread_items = dba::p(item_query()." AND `item`.`uid` = ?
 			AND `item`.`parent-uri` = ?
+			AND NOT `author`.`hidden` AND NOT `author`.`blocked`
 			ORDER BY `item`.`commented` DESC LIMIT ".intval($max_comments + 1),
 			local_user(),
 			$parent['uri']

--- a/mod/community.php
+++ b/mod/community.php
@@ -194,7 +194,8 @@ function community_getitems($start, $itemspage, $content)
 	} elseif ($content == 'global') {
 		$r = dba::p("SELECT `uri` FROM `thread`
 				INNER JOIN `item` ON `item`.`id` = `thread`.`iid`
-				WHERE `thread`.`uid` = 0
+		                INNER JOIN `contact` AS `author` ON `author`.`id`=`item`.`author-id`
+				WHERE `thread`.`uid` = 0 AND NOT `author`.`hidden` AND NOT `author`.`blocked`
 				ORDER BY `thread`.`commented` DESC LIMIT " . intval($start) . ", " . intval($itemspage));
 		return dba::inArray($r);
 	}

--- a/mod/network.php
+++ b/mod/network.php
@@ -813,7 +813,9 @@ function networkThreadedView(App $a, $update = 0)
 				(SELECT SUBSTR(`term`, 2) FROM `search` WHERE `uid` = ? AND `term` LIKE '#%') AND `otype` = ? AND `type` = ? AND `uid` = 0) AS `term`
 			ON `item`.`id` = `term`.`oid`
 			INNER JOIN `contact` ON `contact`.`id` = `item`.`contact-id`
-			WHERE `item`.`uid` = 0 AND `item`.$ordering < ? AND `item`.$ordering > ?" . $sql_tag_nets,
+			INNER JOIN `contact` AS `author` ON `author`.`id`=`item`.`author-id`
+			WHERE `item`.`uid` = 0 AND `item`.$ordering < ? AND `item`.$ordering > ?
+				AND NOT `author`.`hidden` AND NOT `author`.`blocked`" . $sql_tag_nets,
 			local_user(), TERM_OBJ_POST, TERM_HASHTAG, $top_limit, $bottom_limit);
 		$data = dba::inArray($items);
 

--- a/mod/search.php
+++ b/mod/search.php
@@ -202,6 +202,7 @@ function search_content(App $a) {
 				STRAIGHT_JOIN `item` ON `item`.`id`=`term`.`oid` %s
 			WHERE %s AND (`term`.`uid` = 0 OR (`term`.`uid` = %d AND NOT `term`.`global`))
 				AND `term`.`otype` = %d AND `term`.`type` = %d AND `term`.`term` = '%s' AND `item`.`verb` = '%s'
+				AND NOT `author`.`blocked` AND NOT `author`.`hidden`
 			ORDER BY term.created DESC LIMIT %d , %d ",
 				item_fieldlists(), item_joins(), item_condition(),
 				intval(local_user()),
@@ -215,6 +216,7 @@ function search_content(App $a) {
 		$r = q("SELECT %s
 			FROM `item` %s
 			WHERE %s AND (`item`.`uid` = 0 OR (`item`.`uid` = %s AND NOT `item`.`global`))
+				AND NOT `author`.`blocked` AND NOT `author`.`hidden`
 				$sql_extra
 			GROUP BY `item`.`uri`, `item`.`id` ORDER BY `item`.`id` DESC LIMIT %d , %d",
 				item_fieldlists(), item_joins(), item_condition(),

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -896,11 +896,6 @@ class Item extends BaseObject
 			return;
 		}
 
-		// Is the public contact configured as hidden?
-		if (Contact::isHidden($item["owner-id"]) || Contact::isHidden($item["author-id"])) {
-			return;
-		}
-
 		// Only do these checks if the post isn't a wall post
 		if (!$item["wall"]) {
 			// Check, if hide-friends is activated - then don't do a shadow entry


### PR DESCRIPTION
Until now we just prevented new content from being displayed when the contact was blocked or hidden. Now we do this immediately.