### PR TITLE
Use a more simple HTML for API output

### DIFF
--- a/include/api.php
+++ b/include/api.php
@@ -2647,7 +2647,7 @@ function api_convert_item($item)
 		$statustext = substr($statustext, 0, 1000)."... \n".$item["plink"];
 	}
 
-	$statushtml = trim(bbcode($body, false, false));
+	$statushtml = bbcode(api_clean_attachments($body), false, false);
 
 	// Workaround for clients with limited HTML parser functionality
 	$search = ["<br>", "<blockquote>", "</blockquote>",

--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -2412,7 +2412,7 @@ class DFRN
 
 		// Is there an existing item?
 		if (DBM::is_result($current) && !self::isEditedTimestampNewer($current[0], $item)) {
-			logger("Item ".$item["uri"]." already existed in this version.", LOGGER_DEBUG);
+			logger("Item ".$item["uri"]." (".$item['edited'].") already existed.", LOGGER_DEBUG);
 			return;
 		}
 


### PR DESCRIPTION
Current mobile clients do fail while trying to display complicated HTML. So we now simplify it.