### PR TITLE
fix undeclared variables or wrong variable names (/include) - part 1

### DIFF
--- a/include/acl_selectors.php
+++ b/include/acl_selectors.php
@@ -716,7 +716,7 @@ function navbar_complete(App $a) {
 	// check if searching in the local global contact table is enabled
 	$localsearch = Config::get('system','poco_local_search');
 
-	$search = $prefix.notags(trim($_REQUEST['search']));
+	$search = notags(trim($_REQUEST['search']));
 	$mode = $_REQUEST['smode'];
 
 	// don't search if search term has less than 2 characters

--- a/include/items.php
+++ b/include/items.php
@@ -24,7 +24,7 @@ require_once 'include/text.php';
 require_once 'mod/share.php';
 require_once 'include/enotify.php';
 
-function add_page_info_data($data) {
+function add_page_info_data($data, $no_photos = false) {
 	Addon::callHooks('page_info_data', $data);
 
 	// It maybe is a rich content, but if it does have everything that a link has,
@@ -92,7 +92,7 @@ function add_page_info_data($data) {
 	return "\n".$text.$hashtags;
 }
 
-function query_page_info($url, $no_photos = false, $photo = "", $keywords = false, $keyword_blacklist = "") {
+function query_page_info($url, $photo = "", $keywords = false, $keyword_blacklist = "") {
 
 	$data = ParseUrl::getSiteinfoCached($url, true);
 
@@ -120,8 +120,8 @@ function query_page_info($url, $no_photos = false, $photo = "", $keywords = fals
 	return $data;
 }
 
-function add_page_keywords($url, $no_photos = false, $photo = "", $keywords = false, $keyword_blacklist = "") {
-	$data = query_page_info($url, $no_photos, $photo, $keywords, $keyword_blacklist);
+function add_page_keywords($url, $photo = "", $keywords = false, $keyword_blacklist = "") {
+	$data = query_page_info($url, $photo, $keywords, $keyword_blacklist);
 
 	$tags = "";
 	if (isset($data["keywords"]) && count($data["keywords"])) {
@@ -141,9 +141,9 @@ function add_page_keywords($url, $no_photos = false, $photo = "", $keywords = fa
 }
 
 function add_page_info($url, $no_photos = false, $photo = "", $keywords = false, $keyword_blacklist = "") {
-	$data = query_page_info($url, $no_photos, $photo, $keywords, $keyword_blacklist);
+	$data = query_page_info($url, $photo, $keywords, $keyword_blacklist);
 
-	$text = add_page_info_data($data);
+	$text = add_page_info_data($data, $no_photos);
 
 	return $text;
 }

--- a/src/Protocol/Feed.php
+++ b/src/Protocol/Feed.php
@@ -402,7 +402,7 @@ class Feed {
 				// We always strip the title since it will be added in the page information
 				$item["title"] = "";
 				$item["body"] = $item["body"].add_page_info($item["plink"], false, $preview, ($contact["fetch_further_information"] == 2), $contact["ffi_keyword_blacklist"]);
-				$item["tag"] = add_page_keywords($item["plink"], false, $preview, ($contact["fetch_further_information"] == 2), $contact["ffi_keyword_blacklist"]);
+				$item["tag"] = add_page_keywords($item["plink"], $preview, ($contact["fetch_further_information"] == 2), $contact["ffi_keyword_blacklist"]);
 				$item["object-type"] = ACTIVITY_OBJ_BOOKMARK;
 				unset($item["attach"]);
 			} else {
@@ -410,7 +410,7 @@ class Feed {
 					if (!empty($tags)) {
 						$item["tag"] = $tags;
 					} else {
-						$item["tag"] = add_page_keywords($item["plink"], false, $preview, true, $contact["ffi_keyword_blacklist"]);
+						$item["tag"] = add_page_keywords($item["plink"], $preview, true, $contact["ffi_keyword_blacklist"]);
 					}
 					$item["body"] .= "\n".$item['tag'];
 				}


### PR DESCRIPTION
Some variables were not declared. Some variables were not available. And some variables were did have a typo.
This PR fixes this issue for the files in the `/include` directory.

There is one variable where I was unsure how to deal with it. Have a look at `/include/items.php` and the `$no_photos` parameter. The only impact of this variable would be in `function add_page_info_data()` where it would abort the processing. But `function add_page_info_data()` don't get `$no_photos` as a parameter.
The question is: Should `$no_photos` be added as a parameter or should we solve this in another function?

Note:
By adding missing variables the code should be fixed but it could have an impact on how the code will work. Keep this in mind when reviewing the PR.