### PR TITLE
fix undeclared variables or wrong variable names (/mod) part 2

### DIFF
--- a/mod/dfrn_request.php
+++ b/mod/dfrn_request.php
@@ -168,7 +168,7 @@ function dfrn_request_post(App $a)
 					$parms['key'] // this was already escaped
 				);
 				if (DBM::is_result($r)) {
-					Group::addMember(User::getDefaultGroup($uid, $r[0]["network"]), $r[0]['id']);
+					Group::addMember(User::getDefaultGroup(local_user(), $r[0]["network"]), $r[0]['id']);
 
 					if (isset($photo)) {
 						Contact::updateAvatar($photo, local_user(), $r[0]["id"], true);

--- a/mod/editpost.php
+++ b/mod/editpost.php
@@ -63,10 +63,11 @@ function editpost_content(App $a) {
 
 	$tpl = get_markup_template("jot.tpl");
 
-	if(($group) || (is_array($a->user) && ((strlen($a->user['allow_cid'])) || (strlen($a->user['allow_gid'])) || (strlen($a->user['deny_cid'])) || (strlen($a->user['deny_gid'])))))
+	if (strlen($itm['allow_cid']) || strlen($itm['allow_gid']) || strlen($itm['deny_cid']) || strlen($itm['deny_gid'])) {
 		$lockstate = 'lock';
-	else
+	} else {
 		$lockstate = 'unlock';
+	}
 
 	$jotplugins = '';
 	$jotnets = '';

--- a/mod/editpost.php
+++ b/mod/editpost.php
@@ -143,7 +143,7 @@ function editpost_content(App $a) {
 		'$emtitle' => L10n::t('Example: bob@example.com, mary@example.com'),
 		'$lockstate' => $lockstate,
 		'$acl' => '', // populate_acl((($group) ? $group_acl : $a->user)),
-		'$bang' => (($group) ? '!' : ''),
+		'$bang' => ($lockstate === 'lock' ? '!' : ''),
 		'$profile_uid' => $_SESSION['uid'],
 		'$preview' => L10n::t('Preview'),
 		'$jotplugins' => $jotplugins,

--- a/mod/editpost.php
+++ b/mod/editpost.php
@@ -38,6 +38,8 @@ function editpost_content(App $a) {
 		return;
 	}
 
+	$geotag = '';
+
 	$o .= replace_macros(get_markup_template("section_title.tpl"),[
 		'$title' => L10n::t('Edit post')
 	]);

--- a/mod/follow.php
+++ b/mod/follow.php
@@ -41,11 +41,7 @@ function follow_post(App $a) {
 		goaway(System::baseUrl().'/contacts/'.$result['cid']);
 	}
 
-	info(L10n::t('Contact added').EOL);
-
-	if (strstr($return_url, 'contacts')) {
-		goaway(System::baseUrl().'/contacts/'.$contact_id);
-	}
+	info(L10n::t('The contact could not be added.').EOL);
 
 	goaway($return_url);
 	// NOTREACHED

--- a/mod/install.php
+++ b/mod/install.php
@@ -222,6 +222,7 @@ function install_content(App $a) {
 			$dbdata = notags(trim($_POST['dbdata']));
 			$phpath = notags(trim($_POST['phpath']));
 
+			$adminmail = notags(trim($_POST['adminmail']));
 
 			$tpl = get_markup_template('install_db.tpl');
 			$o .= replace_macros($tpl, [

--- a/mod/localtime.php
+++ b/mod/localtime.php
@@ -30,7 +30,7 @@ function localtime_content(App $a)
 		$t = 'now';
 	}
 
-	$o .= '<h3>' . L10n::t('Time Conversion') . '</h3>';
+	$o  = '<h3>' . L10n::t('Time Conversion') . '</h3>';
 
 	$o .= '<p>' . L10n::t('Friendica provides this service for sharing events with other networks and friends in unknown timezones.') . '</p>';
 

--- a/mod/lostpass.php
+++ b/mod/lostpass.php
@@ -125,6 +125,7 @@ function lostpass_form()
 function lostpass_generate_password($user)
 {
 	$o = '';
+	$a = get_app();
 
 	$new_password = User::generateNewPassword();
 	$result = User::updatePassword($user['uid'], $new_password);

--- a/mod/message.php
+++ b/mod/message.php
@@ -250,7 +250,6 @@ function message_content(App $a)
 			'$to' => L10n::t('To:'),
 			'$showinputs' => 'true',
 			'$prefill' => $prefill,
-			'$autocomp' => $autocomp,
 			'$preid' => $preid,
 			'$subject' => L10n::t('Subject:'),
 			'$subjtxt' => x($_REQUEST, 'subject') ? strip_tags($_REQUEST['subject']) : '',

--- a/mod/network.php
+++ b/mod/network.php
@@ -444,7 +444,7 @@ function networkFlatView(App $a, $update = 0)
 	}
 
 	if (strlen($file)) {
-		$sql_post_table .= sprintf("INNER JOIN (SELECT `oid` FROM `term` WHERE `term` = '%s' AND `otype` = %d AND `type` = %d AND `uid` = %d ORDER BY `tid` DESC) AS `term` ON `item`.`id` = `term`.`oid` ",
+		$sql_post_table = sprintf("INNER JOIN (SELECT `oid` FROM `term` WHERE `term` = '%s' AND `otype` = %d AND `type` = %d AND `uid` = %d ORDER BY `tid` DESC) AS `term` ON `item`.`id` = `term`.`oid` ",
 			dbesc(protect_sprintf($file)), intval(TERM_OBJ_POST), intval(TERM_FILE), intval(local_user()));
 	} else {
 		$sql_post_table = " INNER JOIN `thread` ON `thread`.`iid` = `item`.`parent`";

--- a/mod/notify.php
+++ b/mod/notify.php
@@ -77,7 +77,7 @@ function notify_content(App $a)
 		$notif_content .= L10n::t('No more system notifications.');
 	}
 
-	$o .= replace_macros($notif_tpl, [
+	$o = replace_macros($notif_tpl, [
 		'$notif_header' => L10n::t('System Notifications'),
 		'$tabs' => false, // $tabs,
 		'$notif_content' => $notif_content,

--- a/mod/photos.php
+++ b/mod/photos.php
@@ -865,7 +865,7 @@ function photos_post(App $a)
 
 	// Create item container
 	$lat = $lon = null;
-	if ($exif && $exif['GPS'] && Feature::isEnabled($channel_id, 'photo_location')) {
+	if ($exif && $exif['GPS'] && Feature::isEnabled($page_owner_uid, 'photo_location')) {
 		$lat = Photo::getGps($exif['GPS']['GPSLatitude'], $exif['GPS']['GPSLatitudeRef']);
 		$lon = Photo::getGps($exif['GPS']['GPSLongitude'], $exif['GPS']['GPSLongitudeRef']);
 	}

--- a/mod/ping.php
+++ b/mod/ping.php
@@ -571,8 +571,8 @@ function ping_format_xml_data($data, $sysnotify, $notifs, $sysmsgs, $sysmsgs_inf
 	$forums = [];
 	if (count($forums_unseen)) {
 		foreach ($forums_unseen as $key => $item) {
-			$forums[$count . ':forum'] = $item['count'];
-			$forums[$count . ':@attributes'] = ['id' => $item['id']];
+			$forums[$key . ':forum'] = $item['count'];
+			$forums[$key . ':@attributes'] = ['id' => $item['id']];
 		}
 		$data['forums'] = $forums;
 	}

--- a/mod/poke.php
+++ b/mod/poke.php
@@ -138,10 +138,7 @@ function poke_init(App $a) {
 		Worker::add(PRIORITY_HIGH, "Notifier", "tag", $item_id);
 	}
 
-
 	Addon::callHooks('post_local_end', $arr);
-
-	Worker::add(PRIORITY_HIGH, "Notifier", "like", $post_id);
 
 	return;
 }

--- a/mod/probe.php
+++ b/mod/probe.php
@@ -15,7 +15,7 @@ function probe_content(App $a)
 		killme();
 	}
 
-	$o .= '<h3>Probe Diagnostic</h3>';
+	$o  = '<h3>Probe Diagnostic</h3>';
 
 	$o .= '<form action="probe" method="get">';
 	$o .= 'Lookup address: <input type="text" style="width: 250px;" name="addr" value="' . $_GET['addr'] . '" />';

--- a/mod/profile_photo.php
+++ b/mod/profile_photo.php
@@ -257,7 +257,7 @@ function profile_photo_content(App $a) {
 
 		$tpl = get_markup_template('profile_photo.tpl');
 
-		$o .= replace_macros($tpl,[
+		$o = replace_macros($tpl,[
 			'$user' => $a->user['nickname'],
 			'$lbl_upfile' => L10n::t('Upload File:'),
 			'$lbl_profiles' => L10n::t('Select a profile:'),
@@ -272,9 +272,8 @@ function profile_photo_content(App $a) {
 	}
 	else {
 		$filename = $a->config['imagecrop'] . '-' . $a->config['imagecrop_resolution'] . '.'.$a->config['imagecrop_ext'];
-		$resolution = $a->config['imagecrop_resolution'];
 		$tpl = get_markup_template("cropbody.tpl");
-		$o .= replace_macros($tpl,[
+		$o = replace_macros($tpl,[
 			'$filename' => $filename,
 			'$profile' => intval($_REQUEST['profile']),
 			'$resource' => $a->config['imagecrop'] . '-' . $a->config['imagecrop_resolution'],
@@ -313,6 +312,7 @@ function profile_photo_crop_ui_head(App $a, Image $Image) {
 
 
 	$smallest = 0;
+	$filename = '';
 
 	$r = Photo::store($Image, local_user(), 0, $hash, $filename, L10n::t('Profile Photos'), 0);
 

--- a/mod/profperm.php
+++ b/mod/profperm.php
@@ -35,6 +35,8 @@ function profperm_content(App $a) {
 		return;
 	}
 
+	$o = '';
+
 	// Switch to text mod interface if we have more than 'n' contacts or group members
 
 	$switchtotext = PConfig::get(local_user(),'system','groupedit_image_limit');
@@ -165,4 +167,3 @@ function profperm_content(App $a) {
 	return $o;
 
 }
-

--- a/mod/register.php
+++ b/mod/register.php
@@ -58,7 +58,7 @@ function register_post(App $a)
 			break;
 	}
 
-	$netpublish = (((x($_POST, 'profile_publish_reg')) &intval($_POST['profile_publish_reg']) = 1) ? 1 : 0);
+	$netpublish = !empty($_POST['profile_publish_reg']);
 
 	$arr = $_POST;
 

--- a/mod/register.php
+++ b/mod/register.php
@@ -58,6 +58,7 @@ function register_post(App $a)
 			break;
 	}
 
+	$netpublish = (((x($_POST, 'profile_publish_reg')) &intval($_POST['profile_publish_reg']) = 1) ? 1 : 0);
 
 	$arr = $_POST;
 

--- a/mod/regmod.php
+++ b/mod/regmod.php
@@ -55,7 +55,7 @@ function user_allow($hash)
 
 	L10n::pushLang($register[0]['language']);
 
-	User::sendRegisterOpenEmail(
+	$res = User::sendRegisterOpenEmail(
 		$user[0]['email'],
 		$a->config['sitename'],
 		System::baseUrl(),
@@ -100,7 +100,7 @@ function regmod_content(App $a)
 
 	if (!local_user()) {
 		info(L10n::t('Please login.') . EOL);
-		$o .= '<br /><br />' . Login::form($a->query_string, $a->config['register_policy'] == REGISTER_CLOSED ? 0 : 1);
+		$o = '<br /><br />' . Login::form($a->query_string, $a->config['register_policy'] == REGISTER_CLOSED ? 0 : 1);
 		return $o;
 	}
 

--- a/mod/removeme.php
+++ b/mod/removeme.php
@@ -49,7 +49,7 @@ function removeme_content(App $a)
 	$_SESSION['remove_account_verify'] = $hash;
 
 	$tpl = get_markup_template('removeme.tpl');
-	$o .= replace_macros($tpl, [
+	$o = replace_macros($tpl, [
 		'$basedir' => System::baseUrl(),
 		'$hash' => $hash,
 		'$title' => L10n::t('Remove My Account'),

--- a/mod/search.php
+++ b/mod/search.php
@@ -19,6 +19,7 @@ require_once 'mod/dirfind.php';
 function search_saved_searches() {
 
 	$o = '';
+	$search = ((x($_GET,'search')) ? notags(trim(rawurldecode($_GET['search']))) : '');
 
 	if (! Feature::isEnabled(local_user(),'savedsearch'))
 		return $o;
@@ -150,7 +151,7 @@ function search_content(App $a) {
 	}
 
 	// contruct a wrapper for the search header
-	$o .= replace_macros(get_markup_template("content_wrapper.tpl"),[
+	$o = replace_macros(get_markup_template("content_wrapper.tpl"),[
 		'name' => "search-header",
 		'$title' => L10n::t("Search"),
 		'$title_size' => 3,

--- a/mod/tagger.php
+++ b/mod/tagger.php
@@ -72,7 +72,7 @@ function tagger_content(App $a) {
 	$targettype = (($item['resource-id']) ? ACTIVITY_OBJ_IMAGE : ACTIVITY_OBJ_NOTE );
 
 	$link = xmlify('<link rel="alternate" type="text/html" href="'
-		. System::baseUrl() . '/display/' . $owner['nickname'] . '/' . $item['id'] . '" />' . "\n") ;
+		. System::baseUrl() . '/display/' . $r['nickname'] . '/' . $item['id'] . '" />' . "\n") ;
 
 	$body = xmlify($item['body']);
 

--- a/mod/tagger.php
+++ b/mod/tagger.php
@@ -44,6 +44,8 @@ function tagger_content(App $a) {
 	$item = $r[0];
 
 	$owner_uid = $item['uid'];
+	$owner_nick = '';
+	$blocktags = 0;
 
 	$r = q("select `nickname`,`blocktags` from user where uid = %d limit 1",
 		intval($owner_uid)
@@ -71,8 +73,13 @@ function tagger_content(App $a) {
 	$post_type = (($item['resource-id']) ? L10n::t('photo') : L10n::t('status'));
 	$targettype = (($item['resource-id']) ? ACTIVITY_OBJ_IMAGE : ACTIVITY_OBJ_NOTE );
 
-	$link = xmlify('<link rel="alternate" type="text/html" href="'
-		. System::baseUrl() . '/display/' . $owner_nick . '/' . $item['id'] . '" />' . "\n") ;
+	if ($owner_nick) {
+		$href = System::baseUrl() . '/display/' . $owner_nick . '/' . $item['id'];
+	} else {
+		$href = System::baseUrl() . '/display/' . $item['guid'];
+	}
+
+	$link = xmlify('<link rel="alternate" type="text/html" href="'. $href . '" />' . "\n") ;
 
 	$body = xmlify($item['body']);
 

--- a/mod/tagger.php
+++ b/mod/tagger.php
@@ -72,7 +72,7 @@ function tagger_content(App $a) {
 	$targettype = (($item['resource-id']) ? ACTIVITY_OBJ_IMAGE : ACTIVITY_OBJ_NOTE );
 
 	$link = xmlify('<link rel="alternate" type="text/html" href="'
-		. System::baseUrl() . '/display/' . $r['nickname'] . '/' . $item['id'] . '" />' . "\n") ;
+		. System::baseUrl() . '/display/' . $owner_nick . '/' . $item['id'] . '" />' . "\n") ;
 
 	$body = xmlify($item['body']);
 

--- a/mod/viewcontacts.php
+++ b/mod/viewcontacts.php
@@ -46,6 +46,8 @@ function viewcontacts_content(App $a)
 		return;
 	}
 
+	$is_owner = ((local_user() && ($a->profile['profile_uid'] == local_user())) ? true : false);
+
 	$o = "";
 
 	// tabs
@@ -97,9 +99,6 @@ function viewcontacts_content(App $a)
 		$url = $rr['url'];
 
 		// route DFRN profiles through the redirect
-
-		$is_owner = ((local_user() && ($a->profile['profile_uid'] == local_user())) ? true : false);
-
 		if ($is_owner && ($rr['network'] === NETWORK_DFRN) && ($rr['rel'])) {
 			$url = 'redir/' . $rr['id'];
 		} else {

--- a/mod/viewcontacts.php
+++ b/mod/viewcontacts.php
@@ -46,7 +46,7 @@ function viewcontacts_content(App $a)
 		return;
 	}
 
-	$is_owner = ((local_user() && ($a->profile['profile_uid'] == local_user())) ? true : false);
+	$is_owner = $a->profile['profile_uid'] == local_user();
 
 	$o = "";
 

--- a/mod/viewsrc.php
+++ b/mod/viewsrc.php
@@ -13,6 +13,7 @@ function viewsrc_content(App $a) {
 		return;
 	}
 
+	$o = ''; 
 	$item_id = (($a->argc > 1) ? intval($a->argv[1]) : 0);
 
 	if(! $item_id) {

--- a/mod/wallmessage.php
+++ b/mod/wallmessage.php
@@ -128,7 +128,7 @@ function wallmessage_content(App $a) {
 	]);
 
 	$tpl = get_markup_template('wallmessage.tpl');
-	$o .= replace_macros($tpl, [
+	$o = replace_macros($tpl, [
 		'$header' => L10n::t('Send Private Message'),
 		'$subheader' => L10n::t('If you wish for %s to respond, please check that the privacy settings on your site allow private mail from unknown senders.', $user['username']),
 		'$to' => L10n::t('To:'),
@@ -139,7 +139,6 @@ function wallmessage_content(App $a) {
 		'$text' => ((x($_REQUEST, 'body')) ? escape_tags(htmlspecialchars($_REQUEST['body'])) : ''),
 		'$readonly' => '',
 		'$yourmessage' => L10n::t('Your message:'),
-		'$select' => $select,
 		'$parent' => '',
 		'$upload' => L10n::t('Upload photo'),
 		'$insert' => L10n::t('Insert web link'),

--- a/mod/webfinger.php
+++ b/mod/webfinger.php
@@ -20,7 +20,7 @@ function webfinger_content(App $a)
 		killme();
 	}
 
-	$o .= '<h3>Webfinger Diagnostic</h3>';
+	$o  = '<h3>Webfinger Diagnostic</h3>';
 
 	$o .= '<form action="webfinger" method="get">';
 	$o .= 'Lookup address: <input type="text" style="width: 250px;" name="addr" value="' . $_GET['addr'] .'" />';


### PR DESCRIPTION
Some variables were not declared. Some variables were not available. And some variables were did have a typo.
This PR fixes this issue for the files in the /mod directory.

I couldn't solve following "undeclared variable" issues in /mod:
1.) /mod/editpost.php
L66 - https://github.com/friendica/friendica/blob/develop/mod/editpost.php#L64
How do we get the `$group` variable? (does also affect L143)

2.) /mod/follow.php
L47 - https://github.com/friendica/friendica/blob/develop/mod/follow.php#L47
`$contact_id` isn't declared. But I don't know the intended beavior so I couldn't fix it.

3.) /mod/poke.php.
L144 - https://github.com/friendica/friendica/blob/develop/mod/poke.php#L144
We have `$item_id` but what is `$post_id` and from where should we get it?

Note:
By adding missing variables the code should be fixed but it could have an impact on how the code will work. Keep this in mind when reviewing the PR.