### PR TITLE
fix undeclared variables or wrong variable names (/src) part 3

### DIFF
--- a/doc/Addons.md
+++ b/doc/Addons.md
@@ -471,3 +471,5 @@ mod/cb.php:	Addon::callHooks('cb_afterpost');
 mod/cb.php:	Addon::callHooks('cb_content', $o);
 
 mod/directory.php:			Addon::callHooks('directory_item', $arr);
+
+src/Model/Item.php Addon::callHooks('tagged', $arr);

--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -1115,7 +1115,7 @@ class BBCode
 				$text = $preshare . html_entity_decode("&#x2672; ", ENT_QUOTES, 'UTF-8') . ' ' . $userid_compact . ": <br />" . $share[3];
 				break;
 			case 3: // Diaspora
-				$headline .= '<b>' . html_entity_decode("&#x2672; ", ENT_QUOTES, 'UTF-8') . $userid . ':</b><br />';
+				$headline = '<b>' . html_entity_decode("&#x2672; ", ENT_QUOTES, 'UTF-8') . $userid . ':</b><br />';
 
 				$text = trim($share[1]);
 

--- a/src/Content/Widget.php
+++ b/src/Content/Widget.php
@@ -51,7 +51,7 @@ class Widget
 			if ($x || is_site_admin()) {
 				$a->page['aside'] .= '<div class="side-link" id="side-invite-remain">'
 					. L10n::tt('%d invitation available', '%d invitations available', $x)
-					. '</div>' . $inv;
+					. '</div>';
 			}
 		}
 

--- a/src/Model/Conversation.php
+++ b/src/Model/Conversation.php
@@ -66,7 +66,7 @@ class Conversation
 					unset($conversation['source']);
 				}
 				if (!dba::update('conversation', $conversation, ['item-uri' => $conversation['item-uri']], $old_conv)) {
-					logger('Conversation: update for '.$conversation['item-uri'].' from '.$conv['protocol'].' to '.$conversation['protocol'].' failed', LOGGER_DEBUG);
+					logger('Conversation: update for '.$conversation['item-uri'].' from '.$old_conv['protocol'].' to '.$conversation['protocol'].' failed', LOGGER_DEBUG);
 				}
 			} else {
 				if (!dba::insert('conversation', $conversation, true)) {

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -263,8 +263,7 @@ class Item extends BaseObject
 		}
 
 		$arr['guid'] = notags(trim(defaults($arr, 'guid', get_guid(32, $guid_prefix))));
-		/// @todo Declare $uid variable - Rabuzarus - 2018-02-12.
-		$arr['uri'] = notags(trim(defaults($arr, 'uri', item_new_uri($a->get_hostname(), $uid, $arr['guid']))));
+		$arr['uri'] = notags(trim(defaults($arr, 'uri', item_new_uri($a->get_hostname(), $arr['uid'], $arr['guid']))));
 
 		// Store conversation data
 		$arr = Conversation::insert($arr);

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -1294,8 +1294,7 @@ class Item extends BaseObject
 			return;
 		}
 
-		/// @todo Declare $r or lets remove it - Rabuzarus - 2018-02-12.
-		$arr = ['item' => $item, 'user' => $u[0], 'contact' => $r[0]];
+		$arr = ['item' => $item, 'user' => $u[0]];
 
 		Addon::callHooks('tagged', $arr);
 

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -263,6 +263,7 @@ class Item extends BaseObject
 		}
 
 		$arr['guid'] = notags(trim(defaults($arr, 'guid', get_guid(32, $guid_prefix))));
+		/// @todo Declare $uid variable - Rabuzarus - 2018-02-12.
 		$arr['uri'] = notags(trim(defaults($arr, 'uri', item_new_uri($a->get_hostname(), $uid, $arr['guid']))));
 
 		// Store conversation data
@@ -1294,6 +1295,7 @@ class Item extends BaseObject
 			return;
 		}
 
+		/// @todo Declare $r or lets remove it - Rabuzarus - 2018-02-12.
 		$arr = ['item' => $item, 'user' => $u[0], 'contact' => $r[0]];
 
 		Addon::callHooks('tagged', $arr);

--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -625,6 +625,7 @@ class Profile
 		require_once 'include/bbcode.php';
 
 		$a = get_app();
+		$o = '';
 
 		if (!local_user() || $a->is_mobile || $a->is_tablet) {
 			return $o;

--- a/src/Util/DateTimeFormat.php
+++ b/src/Util/DateTimeFormat.php
@@ -90,12 +90,12 @@ class DateTimeFormat
 	{
 		// Defaults to UTC if nothing is set, but throws an exception if set to empty string.
 		// Provide some sane defaults regardless.
-		if ($from === '') {
-			$from = 'UTC';
+		if ($tz_from === '') {
+			$tz_from = 'UTC';
 		}
 
-		if ($to === '') {
-			$to = 'UTC';
+		if ($tz_to === '') {
+			$tz_to = 'UTC';
 		}
 
 		if (($s === '') || (!is_string($s))) {

--- a/src/Util/Network.php
+++ b/src/Util/Network.php
@@ -370,6 +370,9 @@ class Network
 
 		if ($http_code == 301 || $http_code == 302 || $http_code == 303 || $http_code == 307) {
 			$matches = [];
+			$new_location_info = @parse_url($curl_info['redirect_url']);
+			$old_location_info = @parse_url($curl_info['url']);
+	
 			preg_match('/(Location:|URI:)(.*?)\n/', $header, $matches);
 			$newurl = trim(array_pop($matches));
 

--- a/src/Util/Temporal.php
+++ b/src/Util/Temporal.php
@@ -127,6 +127,8 @@ class Temporal
 	 */
 	public static function getDateofBirthField($dob)
 	{
+		$a = get_app();
+
 		list($year, $month, $day) = sscanf($dob, '%4d-%2d-%2d');
 
 		if ($dob < '0000-01-01') {


### PR DESCRIPTION
Some variables were not declared. Some variables were not available. And some variables were did have a typo.
This PR fixes this issue for the files in the /src directory.

There are two issues left in /src/Model/Item.php (see `@todo`):
Can we move the declaration of `$uid` (L305) up?

Note:
By adding missing variables the code should be fixed but it could have an impact on how the code will work. Keep this in mind when reviewing the PR.