### PR TITLE
[Scrutinizer] Fix undeclared variables part 5: src/Protocol/

### DIFF
--- a/src/Protocol/Email.php
+++ b/src/Protocol/Email.php
@@ -617,12 +617,7 @@ class Email
 			$currline = $arrbody[$i];
 
 			while ($previousquote < $quotelevel) {
-				if ($sender != '') {
-					$quote = "[quote title=$sender]";
-					$sender = '';
-				} else
-					$quote = "[quote]";
-
+				$quote = "[quote]";
 				$arrbody[$i] = $quote.$arrbody[$i];
 				$previousquote++;
 			}

--- a/src/Protocol/Feed.php
+++ b/src/Protocol/Feed.php
@@ -68,6 +68,7 @@ class Feed {
 		$xpath->registerNamespace('poco', NAMESPACE_POCO);
 
 		$author = [];
+		$entries = null;
 
 		// Is it RDF?
 		if ($xpath->query('/rdf:RDF/rss:channel')->length > 0) {
@@ -369,9 +370,8 @@ class Feed {
 				$item["title"] = '';
 			}
 
+			$preview = '';
 			if (!empty($contact["fetch_further_information"]) && ($contact["fetch_further_information"] < 3)) {
-				$preview = "";
-
 				// Handle enclosures and treat them as preview picture
 				foreach ($attachments AS $attachment) {
 					if ($attachment["type"] == "image/jpeg") {
@@ -410,6 +410,7 @@ class Feed {
 					if (!empty($tags)) {
 						$item["tag"] = $tags;
 					} else {
+						// @todo $preview is never set in this case, is it intended? - @MrPetovan 2018-02-13
 						$item["tag"] = add_page_keywords($item["plink"], $preview, true, $contact["ffi_keyword_blacklist"]);
 					}
 					$item["body"] .= "\n".$item['tag'];

--- a/src/Protocol/PortableContact.php
+++ b/src/Protocol/PortableContact.php
@@ -317,6 +317,7 @@ class PortableContact
 			$contact['created'] = DateTimeFormat::utcNow();
 		}
 
+		$server_url = '';
 		if ($force) {
 			$server_url = normalise_link(self::detectServer($profile));
 		}


### PR DESCRIPTION
Part of #4176
Follow-up to #4444

- Use dba::selectFirst to remove intermediate variables `$r`
- Remove unused variable `$sender` in Protocol\Email
- Simplify Protocol\OStatus:fetchAuthor cascading queries