### PR TITLE
[Scrutinizer] Fix undeclared variables part 7: mod/ and view/

### DIFF
--- a/mod/salmon.php
+++ b/mod/salmon.php
@@ -13,19 +13,6 @@ use Friendica\Util\Crypto;
 
 require_once 'include/items.php';
 
-function salmon_return($val) {
-
-	if($val >= 400)
-		$err = 'Error';
-	if($val >= 200 && $val < 300)
-		$err = 'OK';
-
-	logger('mod-salmon returns ' . $val);
-	header($_SERVER["SERVER_PROTOCOL"] . ' ' . $val . ' ' . $err);
-	killme();
-
-}
-
 function salmon_post(App $a) {
 
 	$xml = file_get_contents('php://input');
@@ -48,8 +35,9 @@ function salmon_post(App $a) {
 
 	$dom = simplexml_load_string($xml,'SimpleXMLElement',0,NAMESPACE_SALMON_ME);
 
-	// figure out where in the DOM tree our data is hiding
+	$base = null;
 
+	// figure out where in the DOM tree our data is hiding
 	if($dom->provenance->data)
 		$base = $dom->provenance;
 	elseif($dom->env->data)

--- a/mod/starred.php
+++ b/mod/starred.php
@@ -9,6 +9,7 @@ use Friendica\Model\Item;
 
 function starred_init(App $a) {
 	$starred = 0;
+	$message_id = null;
 
 	if (! local_user()) {
 		killme();

--- a/mod/subthread.php
+++ b/mod/subthread.php
@@ -57,6 +57,7 @@ function subthread_content(App $a) {
 		}
 	}
 
+	$owner = null;
 	// this represents the post owner on this system.
 
 	$r = q("SELECT `contact`.*, `user`.`nickname` FROM `contact` LEFT JOIN `user` ON `contact`.`uid` = `user`.`uid`
@@ -75,6 +76,7 @@ function subthread_content(App $a) {
 		$remote_owner = $owner;
 
 
+	$contact = null;
 	// This represents the person posting
 
 	if ((local_user()) && (local_user() == $owner_uid)) {

--- a/mod/uexport.php
+++ b/mod/uexport.php
@@ -141,6 +141,7 @@ function uexport_all(App $a) {
 	uexport_account($a);
 	echo "\n";
 
+	$total = 0;
 	$r = q("SELECT count(*) as `total` FROM `item` WHERE `uid` = %d ",
 		intval(local_user())
 	);

--- a/mod/wall_upload.php
+++ b/mod/wall_upload.php
@@ -114,7 +114,10 @@ function wall_upload_post(App $a, $desktopmode = true) {
 		killme();
 	}
 
-	$src = "";
+	$src = '';
+	$filename = '';
+	$filesize = 0;
+	$filetype = '';
 	if (x($_FILES, 'userfile')) {
 		$src      = $_FILES['userfile']['tmp_name'];
 		$filename = basename($_FILES['userfile']['name']);

--- a/view/theme/frio/theme.php
+++ b/view/theme/frio/theme.php
@@ -217,6 +217,7 @@ function frio_remote_nav($a, &$nav)
 	// And construct a webbie (e.g. mickey@friendica.domain.com for the search in gcontact
 	// We use the webbie for search in gcontact because we don't know if gcontact table stores
 	// the right value if its http or https protocol
+	$webbie = '';
 	if (count($url_parts)) {
 		$server_url = $url_parts[1] . $url_parts[2];
 		$webbie = $url_parts[4] . '@' . $url_parts[2];
@@ -296,14 +297,9 @@ function frio_acl_lookup(App $a, &$results)
 		return;
 	}
 
-	$searching = false;
+	$sql_extra = '';
 	if ($results["search"]) {
 		$search_txt = dbesc(protect_sprintf(preg_quote($results["search"])));
-		$searching = true;
-	}
-
-	$sql_extra = '';
-	if ($searching) {
 		$sql_extra .= " AND (`attag` LIKE '%%" . dbesc($search_txt) . "%%' OR `name` LIKE '%%" . dbesc($search_txt) . "%%' OR `nick` LIKE '%%" . dbesc($search_txt) . "%%') ";
 	}
 
@@ -311,6 +307,7 @@ function frio_acl_lookup(App $a, &$results)
 		$sql_extra .= sprintf(" AND network = '%s' ", dbesc($nets));
 	}
 
+	$total = 0;
 	$r = q("SELECT COUNT(*) AS `total` FROM `contact`
 		WHERE `uid` = %d AND NOT `self` AND NOT `pending` $sql_extra ", intval($_SESSION['uid']));
 	if (DBM::is_result($r)) {

--- a/view/theme/vier/theme.php
+++ b/view/theme/vier/theme.php
@@ -215,6 +215,7 @@ function vier_community_info()
 
 	//Community_Pages at right_aside
 	if ($show_pages && local_user()) {
+		$cid = null;
 		if (x($_GET, 'cid') && intval($_GET['cid']) != 0) {
 			$cid = $_GET['cid'];
 		}


### PR DESCRIPTION
Part of #4176
Follow-up to #4455

- Remove unused function `salmon_return()`