### PR TITLE
missing L10n::t for date string formatting

### DIFF
--- a/mod/message.php
+++ b/mod/message.php
@@ -396,7 +396,7 @@ function message_content(App $a)
 				'body' => $body_e,
 				'delete' => L10n::t('Delete message'),
 				'to_name' => $to_name_e,
-				'date' => DateTimeFormat::local($message['created'], 'D, d M Y - g:i A'),
+				'date' => DateTimeFormat::local($message['created'], L10n::t('D, d M Y - g:i A')),
 				'ago' => Temporal::getRelativeDate($message['created']),
 			];
 


### PR DESCRIPTION
Additionally to the missing call there is a problem with translation of the date strings as PHP generates them in English, following the format string. Maybe an additional parameter for Util/DateTimeFormat::local, by default false but if true to make a string replace for the names of weekdays and month in the returned string?