### PR TITLE
Don't post an item if it belongs to a picture upload without an post

### DIFF
--- a/src/Protocol/OStatus.php
+++ b/src/Protocol/OStatus.php
@@ -2128,6 +2128,7 @@ class OStatus
 				AND `item`.`created` > '%s'
 				AND NOT `item`.`deleted`
 				AND NOT `item`.`private`
+				AND `item`.`visible`
 				AND `thread`.`network` IN ('%s', '%s')
 				$sql_extra
 				ORDER BY `item`.`created` DESC LIMIT %d",


### PR DESCRIPTION
See issue https://github.com/friendica/friendica/issues/4228

This was hard to find. A picture upload "without a post" creates a hidden item. The push functionality hadn't checked if the item was hidden.