### PR TITLE
 Improved resource id creation

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -854,11 +854,13 @@ function check_addons(App $a)
 	return;
 }
 
-function get_guid($size = 16, $prefix = "")
+function get_guid($size = 16, $prefix = '')
 {
-	if ($prefix == "") {
+	if (is_bool($prefix)) {
+		$prefix = '';
+	} elseif ($prefix == '') {
 		$a = get_app();
-		$prefix = hash("crc32", $a->get_hostname());
+		$prefix = hash('crc32', $a->get_hostname());
 	}
 
 	while (strlen($prefix) < ($size - 13)) {
@@ -867,10 +869,10 @@ function get_guid($size = 16, $prefix = "")
 
 	if ($size >= 24) {
 		$prefix = substr($prefix, 0, $size - 22);
-		return(str_replace(".", "", uniqid($prefix, true)));
+		return str_replace('.', '', uniqid($prefix, true));
 	} else {
 		$prefix = substr($prefix, 0, max($size - 13, 0));
-		return(uniqid($prefix));
+		return uniqid($prefix);
 	}
 }
 

--- a/boot.php
+++ b/boot.php
@@ -856,7 +856,7 @@ function check_addons(App $a)
 
 function get_guid($size = 16, $prefix = '')
 {
-	if (is_bool($prefix)) {
+	if (is_bool($prefix) && !$prefix) {
 		$prefix = '';
 	} elseif ($prefix == '') {
 		$a = get_app();

--- a/include/api.php
+++ b/include/api.php
@@ -4614,7 +4614,7 @@ function save_media_to_database($mediatype, $media, $type, $album, $allow_cid, $
 	$height = $Image->getHeight();
 
 	// create a new resource-id if not already provided
-	$hash = ($photo_id == null) ? photo_new_resource() : $photo_id;
+	$hash = ($photo_id == null) ? Photo::newResource() : $photo_id;
 
 	if ($mediatype == "photo") {
 		// upload normal image (scales 0, 1, 2)

--- a/include/text.php
+++ b/include/text.php
@@ -489,31 +489,6 @@ function item_new_uri($hostname, $uid, $guid = "") {
 	return $uri;
 }
 
-
-/**
- * Generate a guaranteed unique photo ID.
- * safe from birthday paradox
- *
- * @return string
- */
-function photo_new_resource() {
-
-	do {
-		$found = false;
-		$resource = hash('md5',uniqid(mt_rand(),true));
-		$r = q("SELECT `id` FROM `photo` WHERE `resource-id` = '%s' LIMIT 1",
-			dbesc($resource)
-		);
-
-		if (DBM::is_result($r)) {
-			$found = true;
-		}
-	} while ($found == true);
-
-	return $resource;
-}
-
-
 /**
  * @deprecated
  * wrapper to load a view template, checking for alternate

--- a/mod/photos.php
+++ b/mod/photos.php
@@ -838,7 +838,7 @@ function photos_post(App $a)
 
 	$smallest = 0;
 
-	$photo_hash = photo_new_resource();
+	$photo_hash = Photo::newResource();
 
 	$r = Photo::store($Image, $page_owner_uid, $visitor, $photo_hash, $filename, $album, 0 , 0, $str_contact_allow, $str_group_allow, $str_contact_deny, $str_group_deny);
 

--- a/mod/profile_photo.php
+++ b/mod/profile_photo.php
@@ -308,7 +308,7 @@ function profile_photo_crop_ui_head(App $a, Image $Image) {
 		$height = $Image->getHeight();
 	}
 
-	$hash = photo_new_resource();
+	$hash = Photo::newResource();
 
 
 	$smallest = 0;

--- a/mod/wall_upload.php
+++ b/mod/wall_upload.php
@@ -222,7 +222,7 @@ function wall_upload_post(App $a, $desktopmode = true) {
 	$width = $Image->getWidth();
 	$height = $Image->getHeight();
 
-	$hash = photo_new_resource();
+	$hash = Photo::newResource();
 
 	$smallest = 0;
 

--- a/src/Model/Photo.php
+++ b/src/Model/Photo.php
@@ -273,7 +273,8 @@ class Photo
 	 *
 	 * @return string
 	 */
-	public static function newResource() {
+	public static function newResource()
+	{
 		return get_guid(32, false);
 	}
 }

--- a/src/Model/Photo.php
+++ b/src/Model/Photo.php
@@ -100,7 +100,7 @@ class Photo
 		if (x($photo['resource-id'])) {
 			$hash = $photo['resource-id'];
 		} else {
-			$hash = photo_new_resource();
+			$hash = self::newResource();
 		}
 
 		$photo_failure = false;
@@ -266,5 +266,14 @@ class Photo
 	{
 		$key = "photo_albums:".$uid.":".local_user().":".remote_user();
 		Cache::set($key, null, CACHE_DAY);
+	}
+
+	/**
+	 * Generate a unique photo ID.
+	 *
+	 * @return string
+	 */
+	public static function newResource() {
+		return get_guid(32, false);
 	}
 }

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -521,7 +521,7 @@ class User
 			if ($Image->isValid()) {
 				$Image->scaleToSquare(175);
 
-				$hash = photo_new_resource();
+				$hash = Photo::newResource();
 
 				$r = Photo::store($Image, $uid, 0, $hash, $filename, L10n::t('Profile Photos'), 4);
 

--- a/src/Object/Image.php
+++ b/src/Object/Image.php
@@ -937,7 +937,7 @@ class Image
 		$width = $Image->getWidth();
 		$height = $Image->getHeight();
 
-		$hash = photo_new_resource();
+		$hash = Photo::newResource();
 
 		$smallest = 0;
 


### PR DESCRIPTION
During the work at PR https://github.com/friendica/friendica/pull/4479 i realized that the resource id creation for photos wasn't optimal. Using a hash of an unique id isn't a very good idea.

The old function is now replaced with a new one that used the standard PHP function for unique ids. The function had been altered to support even more entropy in the same string length, so we don't need a check if that id had been used before.

Attention: This PR can only be merged, **after** PR https://github.com/friendica/friendica/pull/4479 had been merged.