### PR TITLE
Some changes to the Vagrant configuration

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,7 +17,7 @@ Vagrant.configure(2) do |config|
   # Create a hostname, don't forget to put it to the `hosts` file
   # This will point to the server's default virtual host
   # TO DO: Make this work with virtualhost along-side xip.io URL
-  config.vm.hostname = "friendica-xenial.dev"
+  config.vm.hostname = "friendica.dev"
 
   # Create a static IP
   config.vm.network :private_network, ip: server_ip

--- a/util/vagrant_provision.sh
+++ b/util/vagrant_provision.sh
@@ -92,5 +92,6 @@ echo "*/10 * * * * cd /vagrant; /usr/bin/php scripts/worker.php" >> friendicacro
 sudo crontab friendicacron
 sudo rm friendicacron
 
-#Optional: checkout addon repositroy
-#sudo git clone https://github.com/friendica/friendica-addons.git /vagrant/addon
+# friendica needs write access to /tmp
+sudo chmod 777 /tmp
+


### PR DESCRIPTION
The domain name is outdated, from when we tried to integrate trusty and xenial in the configuration. And the `tmp` writability is just to clean an annoyance in the logs.