### PR TITLE
Load whole config in cache on boot

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -722,8 +722,6 @@ function update_db()
 		$stored = intval($build);
 		$current = intval(DB_UPDATE_VERSION);
 		if ($stored < $current) {
-			Config::load('database');
-
 			// Compare the current structure with the defined structure
 			$t = Config::get('database', 'dbupdate_' . DB_UPDATE_VERSION);
 			if (!is_null($t)) {

--- a/mod/friendica.php
+++ b/mod/friendica.php
@@ -40,7 +40,6 @@ function friendica_init(App $a)
 			}
 		}
 
-		Config::load('feature_lock');
 		$locked_features = [];
 		if (is_array($a->config['feature_lock']) && count($a->config['feature_lock'])) {
 			foreach ($a->config['feature_lock'] as $k => $v) {

--- a/view/theme/frio/style.php
+++ b/view/theme/frio/style.php
@@ -35,8 +35,6 @@ if ($a->module !== 'install') {
 			PConfig::set($uid, 'frio', 'css_modified', time());
 		}
 	} else {
-		Config::load('frio');
-
 		// Load frios system config.
 		$schema           = Config::get("frio", "schema");
 		$nav_bg           = Config::get("frio", "nav_bg");


### PR DESCRIPTION
Part of #4520

I know I'm pulling @annando's leg right now, but I believe it's for a good cause.

Loading the whole config on a warm system takes 0.001s + 0.003s whereas each individual Config::get takes 0.001s.

When there are at least 4 Config::get calls for existing config values, we are saving time.

The last bottleneck is for non-existant config values, but since we are loading the whole config in cache on boot we can assume there aren't in DB either.

Will our intrepid hero manage to config @annando? You'll know in the next PR!