### PR TITLE
Postpone contact update in Contact::getIdForURL

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -925,10 +925,10 @@ function public_contact()
 	if (!$public_contact_id && x($_SESSION, 'authenticated')) {
 		if (x($_SESSION, 'my_address')) {
 			// Local user
-			$public_contact_id = intval(Contact::getIdForURL($_SESSION['my_address'], 0));
+			$public_contact_id = intval(Contact::getIdForURL($_SESSION['my_address'], 0, true));
 		} elseif (x($_SESSION, 'visitor_home')) {
 			// Remote user
-			$public_contact_id = intval(Contact::getIdForURL($_SESSION['visitor_home'], 0));
+			$public_contact_id = intval(Contact::getIdForURL($_SESSION['visitor_home'], 0, true));
 		}
 	} elseif (!x($_SESSION, 'authenticated')) {
 		$public_contact_id = false;

--- a/mod/admin.php
+++ b/mod/admin.php
@@ -384,7 +384,7 @@ function admin_page_contactblock_post(App $a)
 	check_form_security_token_redirectOnErr('/admin/contactblock', 'admin_contactblock');
 
 	if (x($_POST, 'page_contactblock_block')) {
-		$contact_id = Contact::getIdForURL($contact_url, 0);
+		$contact_id = Contact::getIdForURL($contact_url);
 		if ($contact_id) {
 			Contact::block($contact_id);
 			notice(L10n::t('The contact has been blocked from the node'));

--- a/mod/item.php
+++ b/mod/item.php
@@ -593,11 +593,11 @@ function item_post(App $a) {
 	$datarray['owner-name']    = $contact_record['name'];
 	$datarray['owner-link']    = $contact_record['url'];
 	$datarray['owner-avatar']  = $contact_record['thumb'];
-	$datarray['owner-id']      = Contact::getIdForURL($datarray['owner-link'], 0);
+	$datarray['owner-id']      = Contact::getIdForURL($datarray['owner-link']);
 	$datarray['author-name']   = $author['name'];
 	$datarray['author-link']   = $author['url'];
 	$datarray['author-avatar'] = $author['thumb'];
-	$datarray['author-id']     = Contact::getIdForURL($datarray['author-link'], 0);
+	$datarray['author-id']     = Contact::getIdForURL($datarray['author-link']);
 	$datarray['created']       = DateTimeFormat::utcNow();
 	$datarray['edited']        = DateTimeFormat::utcNow();
 	$datarray['commented']     = DateTimeFormat::utcNow();

--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -1077,7 +1077,7 @@ class BBCode
 		// We only call this so that a previously unknown contact can be added.
 		// This is important for the function "Model\Contact::getDetailsByURL()".
 		// This function then can fetch an entry from the contact table.
-		Contact::getIdForURL($profile, 0);
+		Contact::getIdForURL($profile, 0, true);
 
 		$data = Contact::getDetailsByURL($profile);
 

--- a/src/Content/Widget.php
+++ b/src/Content/Widget.php
@@ -330,7 +330,7 @@ class Widget
 		}
 
 		if (Feature::isEnabled($a->profile['profile_uid'], 'tagadelic')) {
-			$owner_id = Contact::getIdForURL($a->profile['url']);
+			$owner_id = Contact::getIdForURL($a->profile['url'], 0, true);
 
 			if (!$owner_id) {
 				return '';

--- a/src/Database/PostUpdate.php
+++ b/src/Database/PostUpdate.php
@@ -162,8 +162,8 @@ class PostUpdate
 
         // Set the "author-id" and "owner-id" in the item table and add a new public contact entry if needed
         foreach ($item_arr as $item) {
-            $author_id = Contact::getIdForURL($item["author-link"], 0);
-            $owner_id = Contact::getIdForURL($item["owner-link"], 0);
+            $author_id = Contact::getIdForURL($item["author-link"]);
+            $owner_id = Contact::getIdForURL($item["owner-link"]);
 
             if ($author_id == 0)
                 $author_id = -1;

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -1723,7 +1723,7 @@ class Item extends BaseObject
 			$item_contact_id = $owner_self_contact['id'];
 			$item_contact = $owner_self_contact;
 		} else {
-			$item_contact_id = Contact::getIdForURL($author_contact['url'], $uid);
+			$item_contact_id = Contact::getIdForURL($author_contact['url'], $uid, true);
 			$item_contact = dba::selectFirst('contact', [], ['id' => $item_contact_id]);
 			if (!DBM::is_result($item_contact)) {
 				logger('like: unknown item contact ' . $item_contact_id);

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -474,14 +474,14 @@ class Item extends BaseObject
 		// The contact-id should be set before "self::insert" was called - but there seems to be issues sometimes
 		$item["contact-id"] = self::contactId($item);
 
-		$item['author-id'] = defaults($item, 'author-id', Contact::getIdForURL($item["author-link"], 0));
+		$item['author-id'] = defaults($item, 'author-id', Contact::getIdForURL($item["author-link"]));
 
 		if (Contact::isBlocked($item["author-id"])) {
 			logger('Contact '.$item["author-id"].' is blocked, item '.$item["uri"].' will not be stored');
 			return 0;
 		}
 
-		$item['owner-id'] = defaults($item, 'owner-id', Contact::getIdForURL($item["owner-link"], 0));
+		$item['owner-id'] = defaults($item, 'owner-id', Contact::getIdForURL($item["owner-link"]));
 
 		if (Contact::isBlocked($item["owner-id"])) {
 			logger('Contact '.$item["owner-id"].' is blocked, item '.$item["uri"].' will not be stored');
@@ -897,7 +897,7 @@ class Item extends BaseObject
 				$item['uid'] = 0;
 				$item['origin'] = 0;
 				$item['wall'] = 0;
-				$item['contact-id'] = Contact::getIdForURL($item['author-link'], 0);
+				$item['contact-id'] = Contact::getIdForURL($item['author-link']);
 
 				if (in_array($item['type'], ["net-comment", "wall-comment"])) {
 					$item['type'] = 'remote-comment';
@@ -951,7 +951,7 @@ class Item extends BaseObject
 		$item['uid'] = 0;
 		$item['origin'] = 0;
 		$item['wall'] = 0;
-		$item['contact-id'] = Contact::getIdForURL($item['author-link'], 0);
+		$item['contact-id'] = Contact::getIdForURL($item['author-link']);
 
 		if (in_array($item['type'], ["net-comment", "wall-comment"])) {
 			$item['type'] = 'remote-comment';

--- a/src/Protocol/OStatus.php
+++ b/src/Protocol/OStatus.php
@@ -186,7 +186,7 @@ class OStatus
 			}
 
 			// Ensure that we are having this contact (with uid=0)
-			$cid = Contact::getIdForURL($aliaslink, 0);
+			$cid = Contact::getIdForURL($aliaslink, 0, true);
 
 			if ($cid) {
 				$fields = ['url', 'nurl', 'name', 'nick', 'alias', 'about', 'location'];
@@ -2108,7 +2108,7 @@ class OStatus
 		}
 
 		$check_date = DateTimeFormat::utc($last_update);
-		$authorid = Contact::getIdForURL($owner["url"], 0);
+		$authorid = Contact::getIdForURL($owner["url"], 0, true);
 
 		$sql_extra = '';
 		if ($filter === 'posts') {

--- a/util/global_community_block.php
+++ b/util/global_community_block.php
@@ -43,7 +43,7 @@ require_once '.htconfig.php';
 dba::connect($db_host, $db_user, $db_pass, $db_data);
 unset($db_host, $db_user, $db_pass, $db_data);
 
-$contact_id = Contact::getIdForURL($argv[1], 0);
+$contact_id = Contact::getIdForURL($argv[1]);
 if (!$contact_id) {
 	echo L10n::t('Could not find any contact entry for this URL (%s)', $nurl);
 	echo "\r\n";


### PR DESCRIPTION
Closes #4522

This was an easy performance fix. `Contact::getIdForURL` is trying to do too many things at the same time by default.

Just adding the `$no_update` restores some sanity to this function by sticking to its core goal, ensuring we have a contact Id for a given address.

In the process we reap a visible performance increase in all the network/display pages.