### PR TITLE
Bugfix: search in local directory didn't work

### DIFF
--- a/mod/directory.php
+++ b/mod/directory.php
@@ -12,12 +12,12 @@ use Friendica\Database\DBM;
 use Friendica\Model\Contact;
 use Friendica\Model\Profile;
 
-function directory_init(App $a) {
+function directory_init(App $a)
+{
 	$a->set_pager_itemspage(60);
 
-	if(local_user()) {
+	if (local_user()) {
 		$a->page['aside'] .= Widget::findPeople();
-
 		$a->page['aside'] .= Widget::follow();
 	} else {
 		unset($_SESSION['theme']);
@@ -25,16 +25,20 @@ function directory_init(App $a) {
 	}
 }
 
-function directory_post(App $a) {
-	if(x($_POST,'search'))
+function directory_post(App $a)
+{
+	if (x($_POST, 'search')) {
 		$a->data['search'] = $_POST['search'];
+	}
 }
 
-function directory_content(App $a) {
+function directory_content(App $a)
+{
 	require_once("mod/proxy.php");
 
-	if((Config::get('system','block_public')) && (! local_user()) && (! remote_user()) ||
-		(Config::get('system','block_local_dir')) && (! local_user()) && (! remote_user())) {
+	if ((Config::get('system', 'block_public') && !local_user() && !remote_user())
+		|| (Config::get('system', 'block_local_dir') && !local_user() && !remote_user())
+	) {
 		notice(L10n::t('Public access denied.') . EOL);
 		return;
 	}
@@ -42,18 +46,19 @@ function directory_content(App $a) {
 	$o = '';
 	Nav::setSelected('directory');
 
-	if(x($a->data,'search'))
+	if (x($a->data, 'search')) {
 		$search = notags(trim($a->data['search']));
-	else
-		$search = ((x($_GET,'search')) ? notags(trim(rawurldecode($_GET['search']))) : '');
-
-	$gdirpath = '';
-	$dirurl = Config::get('system','directory');
-	if(strlen($dirurl)) {
-		$gdirpath = Profile::zrl($dirurl,true);
+	} else {
+		$search = ((x($_GET, 'search')) ? notags(trim(rawurldecode($_GET['search']))) : '');
 	}
 
-	if($search) {
+	$gdirpath = '';
+	$dirurl = Config::get('system', 'directory');
+	if (strlen($dirurl)) {
+		$gdirpath = Profile::zrl($dirurl, true);
+	}
+
+	if ($search) {
 		$search = dbesc($search);
 
 		$sql_extra = " AND ((`profile`.`name` LIKE '%$search%') OR
@@ -73,35 +78,35 @@ function directory_content(App $a) {
 				(`profile`.`prv_keywords` LIKE '%$search%'))";
 	}
 
-	$publish = ((Config::get('system','publish_all')) ? '' : " AND `publish` = 1 " );
+	$publish = ((Config::get('system', 'publish_all')) ? '' : " AND `publish` = 1 " );
 
 
-	$r = q("SELECT COUNT(*) AS `total` FROM `profile`
+	$total = q("SELECT COUNT(*) AS `total` FROM `profile`
 			LEFT JOIN `user` ON `user`.`uid` = `profile`.`uid`
-			WHERE `is-default` = 1 $publish AND `user`.`blocked` = 0 $sql_extra ");
-	if (DBM::is_result($r))
-		$a->set_pager_total($r[0]['total']);
+			WHERE `is-default` = 1 $publish AND `user`.`blocked` = 0 $sql_extra "
+	);
+	if (DBM::is_result($total)) {
+		$a->set_pager_total($total[0]['total']);
+	}
 
 	$order = " ORDER BY `name` ASC ";
 
-	$limit = intval($a->pager['start']).",".intval($a->pager['itemspage']);
+	$limit = intval($a->pager['start'])."," . intval($a->pager['itemspage']);
 
 	$r = dba::p("SELECT `profile`.*, `profile`.`uid` AS `profile_uid`, `user`.`nickname`, `user`.`timezone` , `user`.`page-flags`,
 			`contact`.`addr`, `contact`.`url` AS profile_url FROM `profile`
 			LEFT JOIN `user` ON `user`.`uid` = `profile`.`uid`
 			LEFT JOIN `contact` ON `contact`.`uid` = `user`.`uid`
-			WHERE `is-default` $publish AND `user`.`blocked` = 0 AND `contact`.`self` $sql_extra $order LIMIT ".$limit);
+			WHERE `is-default` $publish AND `user`.`blocked` = 0 AND `contact`.`self` $sql_extra $order LIMIT ".$limit
+	);
 	if (DBM::is_result($r)) {
-
 		if (in_array('small', $a->argv)) {
 			$photo = 'thumb';
-		}
-		else {
+		} else {
 			$photo = 'photo';
 		}
 
 		while ($rr = dba::fetch($r)) {
-
 			$itemurl= '';
 
 			$itemurl = (($rr['addr'] != "") ? $rr['addr'] : $rr['profile_url']);
@@ -111,16 +116,19 @@ function directory_content(App $a) {
 			$pdesc = (($rr['pdesc']) ? $rr['pdesc'] . '<br />' : '');
 
 			$details = '';
-			if(strlen($rr['locality']))
+			if (strlen($rr['locality'])) {
 				$details .= $rr['locality'];
-			if(strlen($rr['region'])) {
-				if(strlen($rr['locality']))
+			}
+			if (strlen($rr['region'])) {
+				if (strlen($rr['locality'])) {
 					$details .= ', ';
+				}
 				$details .= $rr['region'];
 			}
-			if(strlen($rr['country-name'])) {
-				if(strlen($details))
+			if (strlen($rr['country-name'])) {
+				if (strlen($details)) {
 					$details .= ', ';
+				}
 				$details .= $rr['country-name'];
 			}
 //			if(strlen($rr['dob'])) {
@@ -132,20 +140,19 @@ function directory_content(App $a) {
 
 			$profile = $rr;
 
-			if((x($profile,'address') == 1)
-				|| (x($profile,'locality') == 1)
-				|| (x($profile,'region') == 1)
-				|| (x($profile,'postal-code') == 1)
-				|| (x($profile,'country-name') == 1))
-			$location = L10n::t('Location:');
+			if ((x($profile, 'address')             == 1)
+				|| (x($profile, 'locality')     == 1)
+				|| (x($profile, 'region')       == 1)
+				|| (x($profile, 'postal-code')  == 1)
+				|| (x($profile, 'country-name') == 1)
+			) {
+				$location = L10n::t('Location:');
+			}
 
-			$gender = ((x($profile,'gender') == 1) ? L10n::t('Gender:') : False);
-
-			$marital = ((x($profile,'marital') == 1) ?  L10n::t('Status:') : False);
-
-			$homepage = ((x($profile,'homepage') == 1) ?  L10n::t('Homepage:') : False);
-
-			$about = ((x($profile,'about') == 1) ?  L10n::t('About:') : False);
+			$gender   = ((x($profile, 'gender')   == 1) ? L10n::t('Gender:')   : false);
+			$marital  = ((x($profile, 'marital')  == 1) ? L10n::t('Status:')   : false);
+			$homepage = ((x($profile, 'homepage') == 1) ? L10n::t('Homepage:') : false);
+			$about    = ((x($profile, 'about')    == 1) ? L10n::t('About:')    : false);
 
 			$location_e = $location;
 
@@ -154,23 +161,23 @@ function directory_content(App $a) {
 			];
 
 			$entry = [
-				'id' => $rr['id'],
-				'url' => $profile_link,
-				'itemurl' => $itemurl,
-				'thumb' => proxy_url($rr[$photo], false, PROXY_SIZE_THUMB),
-				'img_hover' => $rr['name'],
-				'name' => $rr['name'],
-				'details' => $details,
+				'id'           => $rr['id'],
+				'url'          => $profile_link,
+				'itemurl'      => $itemurl,
+				'thumb'        => proxy_url($rr[$photo], false, PROXY_SIZE_THUMB),
+				'img_hover'    => $rr['name'],
+				'name'         => $rr['name'],
+				'details'      => $details,
 				'account_type' => Contact::getAccountType($rr),
-				'profile' => $profile,
-				'location' => $location_e,
-				'tags' => $rr['pub_keywords'],
-				'gender'   => $gender,
-				'pdesc'	=> $pdesc,
-				'marital'  => $marital,
-				'homepage' => $homepage,
-				'about' => $about,
-				'photo_menu' => $photo_menu,
+				'profile'      => $profile,
+				'location'     => $location_e,
+				'tags'         => $rr['pub_keywords'],
+				'gender'       => $gender,
+				'pdesc'        => $pdesc,
+				'marital'      => $marital,
+				'homepage'     => $homepage,
+				'about'        => $about,
+				'photo_menu'   => $photo_menu,
 
 			];
 
@@ -192,16 +199,16 @@ function directory_content(App $a) {
 		$tpl = get_markup_template('directory_header.tpl');
 
 		$o .= replace_macros($tpl, [
-			'$search' => $search,
+			'$search'    => $search,
 			'$globaldir' => L10n::t('Global Directory'),
-			'$gdirpath' => $gdirpath,
-			'$desc' => L10n::t('Find on this site'),
-			'$contacts' => $entries,
-			'$finding' => L10n::t('Results for:'),
-			'$findterm' => (strlen($search) ? $search : ""),
-			'$title' => L10n::t('Site Directory'),
-			'$submit' => L10n::t('Find'),
-			'$paginate' => paginate($a),
+			'$gdirpath'  => $gdirpath,
+			'$desc'      => L10n::t('Find on this site'),
+			'$contacts'  => $entries,
+			'$finding'   => L10n::t('Results for:'),
+			'$findterm'  => (strlen($search) ? $search : ""),
+			'$title'     => L10n::t('Site Directory'),
+			'$submit'    => L10n::t('Find'),
+			'$paginate'  => paginate($a),
 		]);
 	} else {
 		info(L10n::t("No entries \x28some entries may be hidden\x29.") . EOL);

--- a/mod/directory.php
+++ b/mod/directory.php
@@ -86,7 +86,7 @@ function directory_content(App $a) {
 
 	$limit = intval($a->pager['start']).",".intval($a->pager['itemspage']);
 
-	$r = q("SELECT `profile`.*, `profile`.`uid` AS `profile_uid`, `user`.`nickname`, `user`.`timezone` , `user`.`page-flags`,
+	$r = dba::p("SELECT `profile`.*, `profile`.`uid` AS `profile_uid`, `user`.`nickname`, `user`.`timezone` , `user`.`page-flags`,
 			`contact`.`addr`, `contact`.`url` AS profile_url FROM `profile`
 			LEFT JOIN `user` ON `user`.`uid` = `profile`.`uid`
 			LEFT JOIN `contact` ON `contact`.`uid` = `user`.`uid`
@@ -100,7 +100,7 @@ function directory_content(App $a) {
 			$photo = 'photo';
 		}
 
-		foreach ($r as $rr) {
+		while ($rr = dba::fetch($r)) {
 
 			$itemurl= '';
 
@@ -187,6 +187,7 @@ function directory_content(App $a) {
 
 			$entries[] = $arr['entry'];
 		}
+		dba::close($r);
 
 		$tpl = get_markup_template('directory_header.tpl');
 


### PR DESCRIPTION
The local search in the directory module didn't work. This should fix it
There is another issue with the query for `$total` (https://github.com/friendica/friendica/compare/3.6-rc...rabuzarus:20180303_-_fix_directory_search?expand=1#diff-a0b2702db8d766b6bb2b7e0fa318c78aR84).
Searching for a contact in the local directory gives `dba.php:479:p  DB Error 1065: Query was empty` 