### PR TITLE
Bugfix: Don't cache when looking for maintenance mode

### DIFF
--- a/scripts/worker.php
+++ b/scripts/worker.php
@@ -37,7 +37,7 @@ Config::load();
 check_db(true);
 
 // Quit when in maintenance
-if (Config::get('system', 'maintenance', true)) {
+if (Config::get('system', 'maintenance', false, true)) {
 	return;
 }
 

--- a/src/Core/Worker.php
+++ b/src/Core/Worker.php
@@ -201,7 +201,7 @@ class Worker
 		$mypid = getmypid();
 
 		// Quit when in maintenance
-		if (Config::get('system', 'maintenance', true)) {
+		if (Config::get('system', 'maintenance', false, true)) {
 			logger("Maintenance mode - quit process ".$mypid, LOGGER_DEBUG);
 			return false;
 		}


### PR DESCRIPTION
The worker mustn't rely on cached config data when checking for the maintenance mode.