### PR TITLE
Fix: Multiple accounts per mail address are allowed

### DIFF
--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -382,7 +382,7 @@ class User
 			throw new Exception(L10n::t('Not a valid email address.'));
 		}
 
-		if (dba::exists('user', ['email' => $email])) {
+		if (Config::get('system', 'block_extended_register', false) && dba::exists('user', ['email' => $email])) {
 			throw new Exception(L10n::t('Cannot use that email.'));
 		}
 


### PR DESCRIPTION
They are only forbidden when it's configured. (But Default is "allow")