### PR TITLE
[develop] Hotfix: Fix wrong session expire set for custom duration

### DIFF
--- a/src/Core/Cache.php
+++ b/src/Core/Cache.php
@@ -12,14 +12,14 @@ use Friendica\Core\Config;
  */
 class Cache extends \Friendica\BaseObject
 {
-	const MONTH        = 0;
-	const WEEK         = 1;
-	const DAY          = 2;
-	const HOUR         = 3;
-	const HALF_HOUR    = 4;
-	const QUARTER_HOUR = 5;
-	const FIVE_MINUTES = 6;
-	const MINUTE       = 7;
+	const MONTH        = 2592000;
+	const WEEK         = 604800;
+	const DAY          = 86400;
+	const HOUR         = 3600;
+	const HALF_HOUR    = 1800;
+	const QUARTER_HOUR = 900;
+	const FIVE_MINUTES = 300;
+	const MINUTE       = 60;
 
 	/**
 	 * @var Cache\ICacheDriver
@@ -43,45 +43,6 @@ class Cache extends \Friendica\BaseObject
 			default:
 				self::$driver = new Cache\DatabaseCacheDriver();
 		}
-	}
-
-	/**
-	 * @brief Return the duration for a given cache level
-	 *
-	 * @param integer $level Cache level
-	 *
-	 * @return integer The cache duration in seconds
-	 */
-	public static function duration($level)
-	{
-		switch ($level) {
-			case self::MONTH:
-				$seconds = 2592000;
-				break;
-			case self::WEEK:
-				$seconds = 604800;
-				break;
-			case self::DAY:
-				$seconds = 86400;
-				break;
-			case self::HOUR:
-				$seconds = 3600;
-				break;
-			case self::HALF_HOUR:
-				$seconds = 1800;
-				break;
-			case self::QUARTER_HOUR:
-				$seconds = 900;
-				break;
-			case self::FIVE_MINUTES:
-				$seconds = 300;
-				break;
-			case self::MINUTE:
-			default:
-				$seconds = 60;
-				break;
-		}
-		return $seconds;
 	}
 
 	/**

--- a/src/Core/Cache/DatabaseCacheDriver.php
+++ b/src/Core/Cache/DatabaseCacheDriver.php
@@ -37,7 +37,7 @@ class DatabaseCacheDriver implements ICacheDriver
 	{
 		$fields = [
 			'v'       => serialize($value),
-			'expires' => DateTimeFormat::utc('now + ' . Cache::duration($duration) . ' seconds'),
+			'expires' => DateTimeFormat::utc('now + ' . $duration . ' seconds'),
 			'updated' => DateTimeFormat::utcNow()
 		];
 

--- a/src/Core/Cache/MemcacheCacheDriver.php
+++ b/src/Core/Cache/MemcacheCacheDriver.php
@@ -61,7 +61,7 @@ class MemcacheCacheDriver extends BaseObject implements ICacheDriver
 			self::getApp()->get_hostname() . ":" . $key,
 			serialize($value),
 			MEMCACHE_COMPRESSED,
-			Cache::duration($duration)
+			time() + $duration
 		);
 	}
 

--- a/src/Core/Cache/MemcachedCacheDriver.php
+++ b/src/Core/Cache/MemcachedCacheDriver.php
@@ -52,7 +52,7 @@ class MemcachedCacheDriver extends BaseObject implements ICacheDriver
 		return $this->memcached->set(
 			self::getApp()->get_hostname() . ":" . $key,
 			$value,
-			Cache::duration($duration)
+			time() + $duration
 		);
 	}
 


### PR DESCRIPTION
Hotfix for #4549
Part of #4518

I found the issue with short-lived sessions with Memcache. The problem is that we used cache duration constants that we translated to duration in seconds. However, with a custom duration number, the final duration would be set to the default 60 seconds, enough to get logged in but not to do anything else.

This PR sets the duration in seconds directly into the cache duration constants, removing the need for a translation.

> `+11 −50`

🤩