### PR TITLE
[develop] Browser caching/loading improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,7 +53,8 @@ nbproject
 venv/
 
 #ignore Composer dependencies
-vendor
+/vendor
+/view/asset
 
 #ignore config files from JetBrains
 /.idea

--- a/composer.json
+++ b/composer.json
@@ -54,8 +54,8 @@
 		"preferred-install": "dist",
 		"fxp-asset": {
             "installer-paths": {
-                "npm-asset-library": "vendor/asset",
-                "bower-asset-library": "vendor/asset"
+                "npm-asset-library": "view/asset",
+                "bower-asset-library": "view/asset"
             }
         }
 	},

--- a/view/.htaccess
+++ b/view/.htaccess
@@ -1,5 +1,5 @@
 <FilesMatch "\.tpl">
-  <IfModule authz_host_module> 
+  <IfModule authz_host_module>
     #Apache 2.4
     Require all denied
   </IfModule>
@@ -8,3 +8,18 @@
     Deny from all
   </IfModule>
 </FilesMatch>
+
+<IfModule mod_expires.c>
+  ExpiresActive On
+  ExpiresByType image/gif       "access plus 1 year"
+  ExpiresByType image/jpeg      "access plus 1 year"
+  ExpiresByType image/png       "access plus 1 year"
+  ExpiresByType application/javascript "access plus 1 month"
+  ExpiresByType text/javascript "access plus 1 month"
+  ExpiresByType text/css        "access plus 1 month"
+</IfModule>
+<IfModule mod_headers.c>
+  <FilesMatch "\.(gif|jpe?g|png|js|css)$">
+    Header set Cache-Control "public"
+  </FilesMatch>
+</IfModule>

--- a/view/templates/admin/federation.tpl
+++ b/view/templates/admin/federation.tpl
@@ -1,4 +1,4 @@
-<script src="{{$baseurl}}/vendor/asset/Chart-js/dist/Chart.min.js"></script>
+<script src="{{$baseurl}}/view/asset/Chart-js/dist/Chart.min.js"></script>
 <div id="adminpage">
 	<h1>{{$title}} - {{$page}}</h1>
 

--- a/view/templates/event_head.tpl
+++ b/view/templates/event_head.tpl
@@ -1,8 +1,8 @@
 
-<link rel="stylesheet" type="text/css" href="{{$baseurl}}/vendor/asset/fullcalendar/dist/fullcalendar.min.css" />
-<link rel="stylesheet" type="text/css" href="{{$baseurl}}/vendor/asset/fullcalendar/dist/fullcalendar.print.min.css" media="print" />
-<script type="text/javascript" src="{{$baseurl}}/vendor/asset/moment/min/moment-with-locales.min.js"></script>
-<script type="text/javascript" src="{{$baseurl}}/vendor/asset/fullcalendar/dist/fullcalendar.min.js"></script>
+<link rel="stylesheet" type="text/css" href="{{$baseurl}}/view/asset/fullcalendar/dist/fullcalendar.min.css" />
+<link rel="stylesheet" type="text/css" href="{{$baseurl}}/view/asset/fullcalendar/dist/fullcalendar.print.min.css" media="print" />
+<script type="text/javascript" src="{{$baseurl}}/view/asset/moment/min/moment-with-locales.min.js"></script>
+<script type="text/javascript" src="{{$baseurl}}/view/asset/fullcalendar/dist/fullcalendar.min.js"></script>
 
 <script>
 	function showEvent(eventid) {

--- a/view/templates/head.tpl
+++ b/view/templates/head.tpl
@@ -3,10 +3,10 @@
 <base href="{{$baseurl}}/" />
 <meta name="generator" content="{{$generator}}" />
 <link rel="stylesheet" href="view/global.css" type="text/css" media="all" />
-<link rel="stylesheet" href="vendor/asset/jquery-colorbox/example5/colorbox.css" type="text/css" media="screen" />
-<link rel="stylesheet" href="vendor/asset/jgrowl/jquery.jgrowl.min.css" type="text/css" media="screen" />
-<link rel="stylesheet" href="vendor/asset/jquery-datetimepicker/build/jquery.datetimepicker.min.css" type="text/css" media="screen" />
-<link rel="stylesheet" href="vendor/asset/perfect-scrollbar/css/perfect-scrollbar.min.css" type="text/css" media="screen" />
+<link rel="stylesheet" href="view/asset/jquery-colorbox/example5/colorbox.css" type="text/css" media="screen" />
+<link rel="stylesheet" href="view/asset/jgrowl/jquery.jgrowl.min.css" type="text/css" media="screen" />
+<link rel="stylesheet" href="view/asset/jquery-datetimepicker/build/jquery.datetimepicker.min.css" type="text/css" media="screen" />
+<link rel="stylesheet" href="view/asset/perfect-scrollbar/css/perfect-scrollbar.min.css" type="text/css" media="screen" />
 <link rel="stylesheet" href="vendor/pear/text_highlighter/sample.css" type="text/css" media="screen" />
 
 <link rel="stylesheet" type="text/css" href="{{$stylesheet}}" media="all" />
@@ -34,16 +34,16 @@
 <script type="text/javascript" src="https://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
 <![endif]-->
 <script type="text/javascript" src="view/js/modernizr.js" ></script>
-<script type="text/javascript" src="vendor/asset/jquery/dist/jquery.min.js" ></script>
+<script type="text/javascript" src="view/asset/jquery/dist/jquery.min.js" ></script>
 <script type="text/javascript" src="view/js/jquery.textinputs.js" ></script>
 <script type="text/javascript" src="view/js/jquery-textcomplete/jquery.textcomplete.min.js" ></script>
 <script type="text/javascript" src="view/js/autocomplete.js" ></script>
-<script type="text/javascript" src="vendor/asset/jquery-colorbox/jquery.colorbox-min.js"></script>
-<script type="text/javascript" src="vendor/asset/jgrowl/jquery.jgrowl.min.js"></script>
-<script type="text/javascript" src="vendor/asset/jquery-datetimepicker/build/jquery.datetimepicker.full.min.js"></script>
-<script type="text/javascript" src="vendor/asset/perfect-scrollbar/js/perfect-scrollbar.jquery.min.js" ></script>
+<script type="text/javascript" src="view/asset/jquery-colorbox/jquery.colorbox-min.js"></script>
+<script type="text/javascript" src="view/asset/jgrowl/jquery.jgrowl.min.js"></script>
+<script type="text/javascript" src="view/asset/jquery-datetimepicker/build/jquery.datetimepicker.full.min.js"></script>
+<script type="text/javascript" src="view/asset/perfect-scrollbar/js/perfect-scrollbar.jquery.min.js" ></script>
 <script type="text/javascript" src="view/js/acl.js" ></script>
-<script type="text/javascript" src="vendor/asset/base64/base64.min.js" ></script>
+<script type="text/javascript" src="view/asset/base64/base64.min.js" ></script>
 <script type="text/javascript" src="view/js/main.js" ></script>
 <script>
 

--- a/view/theme/frio/templates/event_head.tpl
+++ b/view/theme/frio/templates/event_head.tpl
@@ -1,9 +1,9 @@
 
-<link rel="stylesheet" type="text/css" href="{{$baseurl}}/vendor/asset/fullcalendar/dist/fullcalendar.min.css" />
-<link rel="stylesheet" type="text/css" href="{{$baseurl}}/vendor/asset/fullcalendar/dist/fullcalendar.print.min.css" media="print" />
+<link rel="stylesheet" type="text/css" href="{{$baseurl}}/view/asset/fullcalendar/dist/fullcalendar.min.css" />
+<link rel="stylesheet" type="text/css" href="{{$baseurl}}/view/asset/fullcalendar/dist/fullcalendar.print.min.css" media="print" />
 <link rel="stylesheet" type="text/css" href="view/theme/frio/css/mod_events.css" />
-<script type="text/javascript" src="{{$baseurl}}/vendor/asset/moment/min/moment-with-locales.min.js"></script>
-<script type="text/javascript" src="{{$baseurl}}/vendor/asset/fullcalendar/dist/fullcalendar.min.js"></script>
+<script type="text/javascript" src="{{$baseurl}}/view/asset/moment/min/moment-with-locales.min.js"></script>
+<script type="text/javascript" src="{{$baseurl}}/view/asset/fullcalendar/dist/fullcalendar.min.js"></script>
 <script type="text/javascript" src="view/theme/frio/js/mod_events.js"></script>
 
 <script type="text/javascript">

--- a/view/theme/frio/templates/head.tpl
+++ b/view/theme/frio/templates/head.tpl
@@ -8,10 +8,10 @@
 
 {{* All needed css files - Note: css must be inserted before js files *}}
 <link rel="stylesheet" href="view/global.css" type="text/css" media="all" />
-<link rel="stylesheet" href="vendor/asset/jquery-colorbox/example5/colorbox.css" type="text/css" media="screen" />
-<link rel="stylesheet" href="vendor/asset/jgrowl/jquery.jgrowl.min.css" type="text/css" media="screen" />
-<link rel="stylesheet" href="vendor/asset/jquery-datetimepicker/build/jquery.datetimepicker.min.css" type="text/css" media="screen" />
-<link rel="stylesheet" href="vendor/asset/perfect-scrollbar/css/perfect-scrollbar.min.css" type="text/css" media="screen" />
+<link rel="stylesheet" href="view/asset/jquery-colorbox/example5/colorbox.css" type="text/css" media="screen" />
+<link rel="stylesheet" href="view/asset/jgrowl/jquery.jgrowl.min.css" type="text/css" media="screen" />
+<link rel="stylesheet" href="view/asset/jquery-datetimepicker/build/jquery.datetimepicker.min.css" type="text/css" media="screen" />
+<link rel="stylesheet" href="view/asset/perfect-scrollbar/css/perfect-scrollbar.min.css" type="text/css" media="screen" />
 <link rel="stylesheet" href="vendor/pear/text_highlighter/sample.css" type="text/css" media="screen" />
 
 <link rel="stylesheet" href="view/theme/frio/frameworks/bootstrap/css/bootstrap.min.css" type="text/css" media="screen"/>
@@ -57,18 +57,18 @@
 <!--[if IE]>
 <script type="text/javascript" src="https://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
 <![endif]-->
-<script type="text/javascript" src="view/js/modernizr.js" ></script>
-<script type="text/javascript" src="vendor/asset/jquery/dist/jquery.min.js"></script>
-<script type="text/javascript" src="view/js/jquery.textinputs.js" ></script>
-<script type="text/javascript" src="view/js/jquery-textcomplete/jquery.textcomplete.min.js" ></script>
-<script type="text/javascript" src="view/js/autocomplete.js" ></script>
-<script type="text/javascript" src="vendor/asset/jquery-colorbox/jquery.colorbox-min.js"></script>
-<script type="text/javascript" src="vendor/asset/jgrowl/jquery.jgrowl.min.js"></script>
-<script type="text/javascript" src="vendor/asset/jquery-datetimepicker/build/jquery.datetimepicker.full.min.js"></script>
-<script type="text/javascript" src="vendor/asset/perfect-scrollbar/js/perfect-scrollbar.jquery.min.js" ></script>
-<script type="text/javascript" src="view/js/acl.js" ></script>
-<script type="text/javascript" src="vendor/asset/base64/base64.min.js" ></script>
-<script type="text/javascript" src="view/js/main.js" ></script>
+<script type="text/javascript" src="view/js/modernizr.js"></script>
+<script type="text/javascript" src="view/asset/jquery/dist/jquery.min.js"></script>
+<script type="text/javascript" src="view/js/jquery.textinputs.js"></script>
+<script type="text/javascript" src="view/js/jquery-textcomplete/jquery.textcomplete.min.js"></script>
+<script type="text/javascript" src="view/js/autocomplete.js"></script>
+<script type="text/javascript" src="view/asset/jquery-colorbox/jquery.colorbox-min.js"></script>
+<script type="text/javascript" src="view/asset/jgrowl/jquery.jgrowl.min.js"></script>
+<script type="text/javascript" src="view/asset/jquery-datetimepicker/build/jquery.datetimepicker.full.min.js"></script>
+<script type="text/javascript" src="view/asset/perfect-scrollbar/js/perfect-scrollbar.jquery.min.js"></script>
+<script type="text/javascript" src="view/js/acl.js"></script>
+<script type="text/javascript" src="view/asset/base64/base64.min.js"></script>
+<script type="text/javascript" src="view/js/main.js"></script>
 
 <script type="text/javascript" src="view/theme/frio/frameworks/bootstrap/js/bootstrap.min.js"></script>
 <script type="text/javascript" src="view/theme/frio/frameworks/jasny/js/jasny-bootstrap.custom.js"></script>

--- a/view/theme/frio/templates/head.tpl
+++ b/view/theme/frio/templates/head.tpl
@@ -57,36 +57,36 @@
 <!--[if IE]>
 <script type="text/javascript" src="https://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
 <![endif]-->
-<script type="text/javascript" src="view/js/modernizr.js"></script>
+<script type="text/javascript" async src="view/js/modernizr.js"></script>
 <script type="text/javascript" src="view/asset/jquery/dist/jquery.min.js"></script>
-<script type="text/javascript" src="view/js/jquery.textinputs.js"></script>
+<script type="text/javascript" async src="view/js/jquery.textinputs.js"></script>
 <script type="text/javascript" src="view/js/jquery-textcomplete/jquery.textcomplete.min.js"></script>
 <script type="text/javascript" src="view/js/autocomplete.js"></script>
-<script type="text/javascript" src="view/asset/jquery-colorbox/jquery.colorbox-min.js"></script>
-<script type="text/javascript" src="view/asset/jgrowl/jquery.jgrowl.min.js"></script>
-<script type="text/javascript" src="view/asset/jquery-datetimepicker/build/jquery.datetimepicker.full.min.js"></script>
-<script type="text/javascript" src="view/asset/perfect-scrollbar/js/perfect-scrollbar.jquery.min.js"></script>
+<script type="text/javascript" async src="view/asset/jquery-colorbox/jquery.colorbox-min.js"></script>
+<script type="text/javascript" async src="view/asset/jgrowl/jquery.jgrowl.min.js"></script>
+<script type="text/javascript" async src="view/asset/jquery-datetimepicker/build/jquery.datetimepicker.full.min.js"></script>
+<script type="text/javascript" async src="view/asset/perfect-scrollbar/js/perfect-scrollbar.jquery.min.js"></script>
 <script type="text/javascript" src="view/js/acl.js"></script>
-<script type="text/javascript" src="view/asset/base64/base64.min.js"></script>
-<script type="text/javascript" src="view/js/main.js"></script>
+<script type="text/javascript" async src="view/asset/base64/base64.min.js"></script>
+<script type="text/javascript" async src="view/js/main.js"></script>
 
-<script type="text/javascript" src="view/theme/frio/frameworks/bootstrap/js/bootstrap.min.js"></script>
-<script type="text/javascript" src="view/theme/frio/frameworks/jasny/js/jasny-bootstrap.custom.js"></script>
-<script type="text/javascript" src="view/theme/frio/frameworks/bootstrap-select/js/bootstrap-select.min.js"></script>
-<script type="text/javascript" src="view/theme/frio/frameworks/ekko-lightbox/ekko-lightbox.min.js"></script>
-<script type="text/javascript" src="view/theme/frio/frameworks/justifiedGallery/jquery.justifiedGallery.min.js"></script>
-<script type="text/javascript" src="view/theme/frio/frameworks/bootstrap-colorpicker/js/bootstrap-colorpicker.min.js"></script>
-<script type="text/javascript" src="view/theme/frio/frameworks/flexMenu/flexmenu.custom.js"></script>
-<script type="text/javascript" src="view/theme/frio/frameworks/jsmart/jsmart.custom.js"></script>
-<script type="text/javascript" src="view/theme/frio/frameworks/jquery-scrollspy/jquery-scrollspy.js"></script>
-<script type="text/javascript" src="view/theme/frio/frameworks/autosize/autosize.min.js"></script>
-<script type="text/javascript" src="view/theme/frio/frameworks/sticky-kit/jquery.sticky-kit.min.js"></script>
+<script type="text/javascript" async src="view/theme/frio/frameworks/bootstrap/js/bootstrap.min.js"></script>
+<script type="text/javascript" async src="view/theme/frio/frameworks/jasny/js/jasny-bootstrap.custom.js"></script>
+<script type="text/javascript" async src="view/theme/frio/frameworks/bootstrap-select/js/bootstrap-select.min.js"></script>
+<script type="text/javascript" async src="view/theme/frio/frameworks/ekko-lightbox/ekko-lightbox.min.js"></script>
+<script type="text/javascript" async src="view/theme/frio/frameworks/justifiedGallery/jquery.justifiedGallery.min.js"></script>
+<script type="text/javascript" async src="view/theme/frio/frameworks/bootstrap-colorpicker/js/bootstrap-colorpicker.min.js"></script>
+<script type="text/javascript" async src="view/theme/frio/frameworks/flexMenu/flexmenu.custom.js"></script>
+<script type="text/javascript" async src="view/theme/frio/frameworks/jsmart/jsmart.custom.js"></script>
+<script type="text/javascript" async src="view/theme/frio/frameworks/jquery-scrollspy/jquery-scrollspy.js"></script>
+<script type="text/javascript" async src="view/theme/frio/frameworks/autosize/autosize.min.js"></script>
+<script type="text/javascript" async src="view/theme/frio/frameworks/sticky-kit/jquery.sticky-kit.min.js"></script>
 
 {{* own js files *}}
-<script type="text/javascript" src="view/theme/frio/js/theme.js"></script>
-<script type="text/javascript" src="view/theme/frio/js/modal.js"></script>
-<script type="text/javascript" src="view/theme/frio/js/hovercard.js"></script>
-<script type="text/javascript" src="view/theme/frio/js/textedit.js"></script>
+<script type="text/javascript" async src="view/theme/frio/js/theme.js"></script>
+<script type="text/javascript" async src="view/theme/frio/js/modal.js"></script>
+<script type="text/javascript" async src="view/theme/frio/js/hovercard.js"></script>
+<script type="text/javascript" async src="view/theme/frio/js/textedit.js"></script>
 
 <script type="text/javascript">
 	window.showMore = "{{$showmore}}";

--- a/view/theme/frost-mobile/templates/end.tpl
+++ b/view/theme/frost-mobile/templates/end.tpl
@@ -1,16 +1,16 @@
 <!--[if IE]>
 <script type="text/javascript" src="https://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
 <![endif]-->
-<script type="text/javascript" src="{{$baseurl}}/vendor/asset/jquery/dist/jquery.min.js" ></script>
+<script type="text/javascript" src="{{$baseurl}}/view/asset/jquery/dist/jquery.min.js" ></script>
 <script type="text/javascript" src="{{$baseurl}}/view/theme/frost-mobile/js/readmore.min.js" ></script>
 <script type="text/javascript" src="{{$baseurl}}/view/js/jquery.textinputs.js" ></script>
-<script type="text/javascript" src="{{$baseurl}}/vendor/asset/jgrowl/jquery.jgrowl.min.js"></script>
-<script type="text/javascript" src="{{$baseurl}}/vendor/asset/jquery-datetimepicker/build/jquery.datetimepicker.full.min.js"></script>
+<script type="text/javascript" src="{{$baseurl}}/view/asset/jgrowl/jquery.jgrowl.min.js"></script>
+<script type="text/javascript" src="{{$baseurl}}/view/asset/jquery-datetimepicker/build/jquery.datetimepicker.full.min.js"></script>
 
 <script type="text/javascript" src="{{$baseurl}}/view/js/jquery-textcomplete/jquery.textcomplete.min.js" ></script>
 <script type="text/javascript" src="{{$baseurl}}/view/js/autocomplete.js" ></script>
 <script type="text/javascript" src="{{$baseurl}}/view/theme/frost-mobile/js/acl.js" ></script>
-<script type="text/javascript" src="{{$baseurl}}/vendor/asset/base64/base64.min.js" ></script>
+<script type="text/javascript" src="{{$baseurl}}/view/asset/base64/base64.min.js" ></script>
 <script type="text/javascript" src="{{$baseurl}}/view/theme/frost-mobile/js/main.js" ></script>
 <script type="text/javascript" src="{{$baseurl}}/view/theme/frost-mobile/js/theme.js"></script>
 

--- a/view/theme/frost-mobile/templates/event_end.tpl
+++ b/view/theme/frost-mobile/templates/event_end.tpl
@@ -1,3 +1,3 @@
 
-<script type="text/javascript" src="{{$baseurl}}/vendor/asset/moment/min/moment-with-locales.min.js"></script>
-<script type="text/javascript" src="{{$baseurl}}/vendor/asset/fullcalendar/dist/fullcalendar.min.js"></script>
+<script type="text/javascript" src="{{$baseurl}}/view/asset/moment/min/moment-with-locales.min.js"></script>
+<script type="text/javascript" src="{{$baseurl}}/view/asset/fullcalendar/dist/fullcalendar.min.js"></script>

--- a/view/theme/frost-mobile/templates/event_head.tpl
+++ b/view/theme/frost-mobile/templates/event_head.tpl
@@ -1,6 +1,6 @@
 
-<link rel="stylesheet" type="text/css" href="{{$baseurl}}/vendor/asset/fullcalendar/dist/fullcalendar.min.css" />
-<link rel="stylesheet" type="text/css" href="{{$baseurl}}/vendor/asset/fullcalendar/dist/fullcalendar.print.min.css" media="print" />
+<link rel="stylesheet" type="text/css" href="{{$baseurl}}/view/asset/fullcalendar/dist/fullcalendar.min.css" />
+<link rel="stylesheet" type="text/css" href="{{$baseurl}}/view/asset/fullcalendar/dist/fullcalendar.print.min.css" media="print" />
 
 <script language="javascript" type="text/javascript">
 window.aclType = 'event_head';

--- a/view/theme/frost-mobile/templates/head.tpl
+++ b/view/theme/frost-mobile/templates/head.tpl
@@ -3,9 +3,9 @@
 
 <base href="{{$baseurl}}/" />
 <meta name="generator" content="{{$generator}}" />
-<link rel="stylesheet" href="{{$baseurl}}/vendor/asset/jgrowl/jquery.jgrowl.min.css" type="text/css" media="screen" />
-<link rel="stylesheet" href="{{$baseurl}}/vendor/asset/jquery-datetimepicker/build/jquery.datetimepicker.min.css" type="text/css" media="screen" />
-<script type="text/javascript" src="{{$baseurl}}/vendor/asset/jquery/dist/jquery.min.js"></script>
+<link rel="stylesheet" href="{{$baseurl}}/view/asset/jgrowl/jquery.jgrowl.min.css" type="text/css" media="screen" />
+<link rel="stylesheet" href="{{$baseurl}}/view/asset/jquery-datetimepicker/build/jquery.datetimepicker.min.css" type="text/css" media="screen" />
+<script type="text/javascript" src="{{$baseurl}}/view/asset/jquery/dist/jquery.min.js"></script>
 
 <link rel="stylesheet" type="text/css" href="{{$stylesheet}}" media="all" />
 

--- a/view/theme/frost/templates/end.tpl
+++ b/view/theme/frost/templates/end.tpl
@@ -3,15 +3,15 @@
 <script type="text/javascript" src="https://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
 <![endif]-->
 
-<script type="text/javascript" src="{{$baseurl}}/vendor/asset/jquery/dist/jquery.min.js" ></script>
+<script type="text/javascript" src="{{$baseurl}}/view/asset/jquery/dist/jquery.min.js" ></script>
 <script type="text/javascript" src="{{$baseurl}}/view/theme/frost/js/jquery.divgrow-1.3.1.f1.min.js" ></script>
 <script type="text/javascript" src="{{$baseurl}}/view/js/jquery.textinputs.js" ></script>
-<script type="text/javascript" src="{{$baseurl}}/vendor/asset/jquery-colorbox/jquery.colorbox-min.js"></script>
-<script type="text/javascript" src="{{$baseurl}}/vendor/asset/jgrowl/jquery.jgrowl.min.js"></script>
-<script type="text/javascript" src="{{$baseurl}}/vendor/asset/jquery-datetimepicker/build/jquery.datetimepicker.full.min.js"></script>
+<script type="text/javascript" src="{{$baseurl}}/view/asset/jquery-colorbox/jquery.colorbox-min.js"></script>
+<script type="text/javascript" src="{{$baseurl}}/view/asset/jgrowl/jquery.jgrowl.min.js"></script>
+<script type="text/javascript" src="{{$baseurl}}/view/asset/jquery-datetimepicker/build/jquery.datetimepicker.full.min.js"></script>
 
 <script type="text/javascript" src="{{$baseurl}}/view/theme/frost/js/acl.js" ></script>
-<script type="text/javascript" src="{{$baseurl}}/vendor/asset/base64/base64.min.js" ></script>
+<script type="text/javascript" src="{{$baseurl}}/view/asset/base64/base64.min.js" ></script>
 <script type="text/javascript" src="{{$baseurl}}/view/js/jquery-textcomplete/jquery.textcomplete.min.js" ></script>
 <script type="text/javascript" src="{{$baseurl}}/view/js/autocomplete.js" ></script>
 <script type="text/javascript" src="{{$baseurl}}/view/theme/frost/js/main.js" ></script>

--- a/view/theme/frost/templates/event_end.tpl
+++ b/view/theme/frost/templates/event_end.tpl
@@ -1,3 +1,3 @@
 
-<script type="text/javascript" src="{{$baseurl}}/vendor/asset/moment/min/moment-with-locales.min.js"></script>
-<script type="text/javascript" src="{{$baseurl}}/vendor/asset/fullcalendar/dist/fullcalendar.min.js"></script>
+<script type="text/javascript" src="{{$baseurl}}/view/asset/moment/min/moment-with-locales.min.js"></script>
+<script type="text/javascript" src="{{$baseurl}}/view/asset/fullcalendar/dist/fullcalendar.min.js"></script>

--- a/view/theme/frost/templates/event_head.tpl
+++ b/view/theme/frost/templates/event_head.tpl
@@ -1,6 +1,6 @@
 
-<link rel="stylesheet" type="text/css" href="{{$baseurl}}/vendor/asset/fullcalendar/dist/fullcalendar.min.css" />
-<link rel="stylesheet" type="text/css" href="{{$baseurl}}/vendor/asset/fullcalendar/dist/fullcalendar.print.min.css" media="print" />
+<link rel="stylesheet" type="text/css" href="{{$baseurl}}/view/asset/fullcalendar/dist/fullcalendar.min.css" />
+<link rel="stylesheet" type="text/css" href="{{$baseurl}}/view/asset/fullcalendar/dist/fullcalendar.print.min.css" media="print" />
 
 <script language="javascript" type="text/javascript">
 window.aclType = 'event_head';

--- a/view/theme/frost/templates/head.tpl
+++ b/view/theme/frost/templates/head.tpl
@@ -2,13 +2,13 @@
 <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
 <base href="{{$baseurl}}/" />
 <meta name="generator" content="{{$generator}}" />
-<link rel="stylesheet" href="{{$baseurl}}/vendor/asset/jquery-colorbox/example5/colorbox.css" type="text/css" media="screen" />
-<link rel="stylesheet" href="{{$baseurl}}/vendor/asset/jgrowl/jquery.jgrowl.min.css" type="text/css" media="screen" />
-<link rel="stylesheet" href="{{$baseurl}}/vendor/asset/jquery-datetimepicker/build/jquery.datetimepicker.min.css" type="text/css" media="screen" />
+<link rel="stylesheet" href="{{$baseurl}}/view/asset/jquery-colorbox/example5/colorbox.css" type="text/css" media="screen" />
+<link rel="stylesheet" href="{{$baseurl}}/view/asset/jgrowl/jquery.jgrowl.min.css" type="text/css" media="screen" />
+<link rel="stylesheet" href="{{$baseurl}}/view/asset/jquery-datetimepicker/build/jquery.datetimepicker.min.css" type="text/css" media="screen" />
 
 <link rel="stylesheet" type="text/css" href="{{$stylesheet}}" media="all" />
 
-<script type="text/javascript" src="{{$baseurl}}/vendor/asset/jquery/dist/jquery.min.js" ></script>
+<script type="text/javascript" src="{{$baseurl}}/view/asset/jquery/dist/jquery.min.js" ></script>
 
 <link rel="shortcut icon" href="{{$baseurl}}/images/friendica-32.png" />
 <link rel="search"

--- a/view/theme/quattro/templates/events_reminder.tpl
+++ b/view/theme/quattro/templates/events_reminder.tpl
@@ -1,8 +1,8 @@
 
-<link rel="stylesheet" type="text/css" href="{{$baseurl}}/vendor/asset/fullcalendar/dist/fullcalendar.min.css" />
-<link rel="stylesheet" type="text/css" href="{{$baseurl}}/vendor/asset/fullcalendar/dist/fullcalendar.print.min.css" />
-<script type="text/javascript" src="{{$baseurl}}/vendor/asset/moment/min/moment-with-locales.min.js"></script>
-<script type="text/javascript" src="{{$baseurl}}/vendor/asset/fullcalendar/dist/fullcalendar.min.js"></script>
+<link rel="stylesheet" type="text/css" href="{{$baseurl}}/view/asset/fullcalendar/dist/fullcalendar.min.css" />
+<link rel="stylesheet" type="text/css" href="{{$baseurl}}/view/asset/fullcalendar/dist/fullcalendar.print.min.css" />
+<script type="text/javascript" src="{{$baseurl}}/view/asset/moment/min/moment-with-locales.min.js"></script>
+<script type="text/javascript" src="{{$baseurl}}/view/asset/fullcalendar/dist/fullcalendar.min.js"></script>
 <script>
 	// start calendar from yesterday
 	var yesterday= new Date()

--- a/view/theme/vier/templates/event_head.tpl
+++ b/view/theme/vier/templates/event_head.tpl
@@ -1,8 +1,8 @@
 
-<link rel="stylesheet" type="text/css" href="{{$baseurl}}/vendor/asset/fullcalendar/dist/fullcalendar.min.css" />
-<link rel="stylesheet" type="text/css" href="{{$baseurl}}/vendor/asset/fullcalendar/dist/fullcalendar.print.min.css" media="print" />
-<script type="text/javascript" src="{{$baseurl}}/vendor/asset/moment/min/moment-with-locales.min.js"></script>
-<script type="text/javascript" src="{{$baseurl}}/vendor/asset/fullcalendar/dist/fullcalendar.min.js"></script>
+<link rel="stylesheet" type="text/css" href="{{$baseurl}}/view/asset/fullcalendar/dist/fullcalendar.min.css" />
+<link rel="stylesheet" type="text/css" href="{{$baseurl}}/view/asset/fullcalendar/dist/fullcalendar.print.min.css" media="print" />
+<script type="text/javascript" src="{{$baseurl}}/view/asset/moment/min/moment-with-locales.min.js"></script>
+<script type="text/javascript" src="{{$baseurl}}/view/asset/fullcalendar/dist/fullcalendar.min.js"></script>
 
 <script>
 	function showEvent(eventid) {


### PR DESCRIPTION
I ran a Friendica public status page through the google PageSpeed analyzer, and it suggested a number of improvements to increase the loading speed of Friendica.

This PR adds public asset caching for Apache, and asynchronous Javascript load for frio only until I make sure everything is working properly.

Additionally, this PR requires a `composer install` to move the Composer assets from `vendor/asset` to `view/asset`.