### PR TITLE
Bugfix: Avoid "Class not found" error

### DIFF
--- a/src/Content/Text/Markdown.php
+++ b/src/Content/Text/Markdown.php
@@ -9,6 +9,7 @@ namespace Friendica\Content\Text;
 use Friendica\BaseObject;
 use Friendica\Model\Contact;
 use Michelf\MarkdownExtra;
+use Friendica\Content\Text\HTML;
 
 /**
  * Friendica-specific usage of Markdown
@@ -92,7 +93,7 @@ class Markdown extends BaseObject
 
 		$s = str_replace('&#35;', '#', $s);
 
-		$s = Friendica\Content\Text\HTML::toBBCode($s);
+		$s = HTML::toBBCode($s);
 
 		// protect the recycle symbol from turning into a tag, but without unescaping angles and naked ampersands
 		$s = str_replace('&#x2672;', html_entity_decode('&#x2672;', ENT_QUOTES, 'UTF-8'), $s);

--- a/src/Core/NotificationsManager.php
+++ b/src/Core/NotificationsManager.php
@@ -8,6 +8,7 @@ namespace Friendica\Core;
 
 use Friendica\BaseObject;
 use Friendica\Content\Text\BBCode;
+use Friendica\Content\Text\HTML;
 use Friendica\Core\L10n;
 use Friendica\Core\PConfig;
 use Friendica\Core\System;
@@ -46,7 +47,7 @@ class NotificationsManager extends BaseObject
 			$n['timestamp'] = strtotime($local_time);
 			$n['date_rel'] = Temporal::getRelativeDate($n['date']);
 			$n['msg_html'] = BBCode::convert($n['msg'], false);
-			$n['msg_plain'] = explode("\n", trim(Friendica\Content\Text\HTML::toPlaintext($n['msg_html'], 0)))[0];
+			$n['msg_plain'] = explode("\n", trim(HTML::toPlaintext($n['msg_html'], 0)))[0];
 
 			$rets[] = $n;
 		}

--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -11,6 +11,7 @@ namespace Friendica\Protocol;
 use Friendica\App;
 use Friendica\Content\OEmbed;
 use Friendica\Content\Text\BBCode;
+use Friendica\Content\Text\HTML;
 use Friendica\Core\Addon;
 use Friendica\Core\Config;
 use Friendica\Core\L10n;
@@ -2453,7 +2454,7 @@ class DFRN
 			$purifier = new HTMLPurifier($config);
 			$item['body'] = $purifier->purify($item['body']);
 
-			$item['body'] = @Friendica\Content\Text\HTML::toBBCode($item['body']);
+			$item['body'] = @HTML::toBBCode($item['body']);
 		}
 
 		/// @todo We should check for a repeated post and if we know the repeated author.

--- a/src/Protocol/Email.php
+++ b/src/Protocol/Email.php
@@ -328,7 +328,7 @@ class Email
 		$body .= "Content-Transfer-Encoding: 8bit\n";
 		$body .= "Content-Type: text/plain; charset=utf-8; format=flowed\n\n";
 
-		$body .= Friendica\Content\Text\HTML::toPlaintext($html)."\n";
+		$body .= HTML::toPlaintext($html)."\n";
 
 		$body .= "--=_".$part."\n";
 		$body .= "Content-Transfer-Encoding: 8bit\n";

--- a/src/Protocol/Feed.php
+++ b/src/Protocol/Feed.php
@@ -10,6 +10,8 @@ use Friendica\Database\DBM;
 use Friendica\Core\System;
 use Friendica\Model\Item;
 use Friendica\Util\Network;
+use Friendica\Content\Text\HTML;
+
 use dba;
 use DOMDocument;
 use DOMXPath;
@@ -362,7 +364,7 @@ class Feed {
 			if (self::titleIsBody($item["title"], $body)) {
 				$item["title"] = "";
 			}
-			$item["body"] = Friendica\Content\Text\HTML::toBBCode($body, $basepath);
+			$item["body"] = HTML::toBBCode($body, $basepath);
 
 			if (($item["body"] == '') && ($item["title"] != '')) {
 				$item["body"] = $item["title"];


### PR DESCRIPTION
Shortly after the update I got errors like:
```
[08-Mar-2018 19:51:50 UTC] PHP Fatal error:  Uncaught Error: Class 'Friendica\Content\Text\Friendica\Content\Text\HTML' not found in /path/to/friendica/src/Content/Text/Markdown.php:95
[08-Mar-2018 19:51:51 UTC] PHP Fatal error:  Uncaught Error: Class 'Friendica\Protocol\Friendica\Content\Text\HTML' not found in /path/to/friendica/src/Protocol/Feed.php:365
```
This avoids it.

Caused by https://github.com/friendica/friendica/pull/4560