### PR TITLE
Bugfix: missing "use"

### DIFF
--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -22,6 +22,7 @@ use Friendica\Object\Image;
 use Friendica\Protocol\Diaspora;
 use Friendica\Protocol\OStatus;
 use Friendica\Util\DateTimeFormat;
+use Friendica\Util\XML;
 use dba;
 use Text_LanguageDetect;
 


### PR DESCRIPTION
This fixes the following bug:
```
PHP Fatal error:  Uncaught Error: Class 'Friendica\Model\XML' not found in /path/to/friendica/src/Model/Item.php:195
```