### PR TITLE
Display attach with missing title

### DIFF
--- a/include/text.php
+++ b/include/text.php
@@ -1281,62 +1281,55 @@ function prepare_body(&$item, $attach = false, $preview = false) {
 
 	$as = '';
 	$vhead = false;
-	$arr = explode('[/attach],', $item['attach']);
-	if (count($arr)) {
-		foreach ($arr as $r) {
-			$matches = false;
-			$icon = '';
-			$cnt = preg_match_all('|\[attach\]href=\"(.*?)\" length=\"(.*?)\" type=\"(.*?)\" title=\"(.*?)\"|',$r ,$matches, PREG_SET_ORDER);
-			if ($cnt) {
-				foreach ($matches as $mtch) {
-					$mime = $mtch[3];
+	$matches = [];
+	preg_match_all('|\[attach\]href=\"(.*?)\" length=\"(.*?)\" type=\"(.*?)\"(?: title=\"(.*?)\")?|', $item['attach'], $matches, PREG_SET_ORDER);
+	foreach ($matches as $mtch) {
+		$mime = $mtch[3];
 
-					if ((local_user() == $item['uid']) && ($item['contact-id'] != $a->contact['id']) && ($item['network'] == NETWORK_DFRN)) {
-						$the_url = 'redir/' . $item['contact-id'] . '?f=1&url=' . $mtch[1];
-					} else {
-						$the_url = $mtch[1];
-					}
-
-					if (strpos($mime, 'video') !== false) {
-						if (!$vhead) {
-							$vhead = true;
-							$a->page['htmlhead'] .= replace_macros(get_markup_template('videos_head.tpl'), [
-								'$baseurl' => System::baseUrl(),
-							]);
-							$a->page['end'] .= replace_macros(get_markup_template('videos_end.tpl'), [
-								'$baseurl' => System::baseUrl(),
-							]);
-						}
-
-						$id = end(explode('/', $the_url));
-						$as .= replace_macros(get_markup_template('video_top.tpl'), [
-							'$video' => [
-								'id'     => $id,
-								'title'  => L10n::t('View Video'),
-								'src'    => $the_url,
-								'mime'   => $mime,
-							],
-						]);
-					}
-
-					$filetype = strtolower(substr($mime, 0, strpos($mime, '/')));
-					if ($filetype) {
-						$filesubtype = strtolower(substr($mime, strpos($mime, '/') + 1));
-						$filesubtype = str_replace('.', '-', $filesubtype);
-					} else {
-						$filetype = 'unkn';
-						$filesubtype = 'unkn';
-					}
-
-					$title = ((strlen(trim($mtch[4]))) ? escape_tags(trim($mtch[4])) : escape_tags($mtch[1]));
-					$title .= ' ' . $mtch[2] . ' ' . L10n::t('bytes');
-
-					$icon = '<div class="attachtype icon s22 type-' . $filetype . ' subtype-' . $filesubtype . '"></div>';
-					$as .= '<a href="' . strip_tags($the_url) . '" title="' . $title . '" class="attachlink" target="_blank" >' . $icon . '</a>';
-				}
-			}
+		if ((local_user() == $item['uid']) && ($item['contact-id'] != $a->contact['id']) && ($item['network'] == NETWORK_DFRN)) {
+			$the_url = 'redir/' . $item['contact-id'] . '?f=1&url=' . $mtch[1];
+		} else {
+			$the_url = $mtch[1];
 		}
+
+		if (strpos($mime, 'video') !== false) {
+			if (!$vhead) {
+				$vhead = true;
+				$a->page['htmlhead'] .= replace_macros(get_markup_template('videos_head.tpl'), [
+					'$baseurl' => System::baseUrl(),
+				]);
+				$a->page['end'] .= replace_macros(get_markup_template('videos_end.tpl'), [
+					'$baseurl' => System::baseUrl(),
+				]);
+			}
+
+			$id = end(explode('/', $the_url));
+			$as .= replace_macros(get_markup_template('video_top.tpl'), [
+				'$video' => [
+					'id'     => $id,
+					'title'  => L10n::t('View Video'),
+					'src'    => $the_url,
+					'mime'   => $mime,
+				],
+			]);
+		}
+
+		$filetype = strtolower(substr($mime, 0, strpos($mime, '/')));
+		if ($filetype) {
+			$filesubtype = strtolower(substr($mime, strpos($mime, '/') + 1));
+			$filesubtype = str_replace('.', '-', $filesubtype);
+		} else {
+			$filetype = 'unkn';
+			$filesubtype = 'unkn';
+		}
+
+		$title = escape_tags(trim(!empty($mtch[4]) ? $mtch[4] : $mtch[1]));
+		$title .= ' ' . $mtch[2] . ' ' . L10n::t('bytes');
+
+		$icon = '<div class="attachtype icon s22 type-' . $filetype . ' subtype-' . $filesubtype . '"></div>';
+		$as .= '<a href="' . strip_tags($the_url) . '" title="' . $title . '" class="attachlink" target="_blank" >' . $icon . '</a>';
 	}
+
 	if ($as != '') {
 		$s .= '<div class="body-attach">'.$as.'<div class="clear"></div></div>';
 	}


### PR DESCRIPTION
See https://forum.friendi.ca/display/a8e4f565105aa1227100af0391340282

The `Feed::import()` method converts `<enclosure>` tags into `[attach]` structures without a title. The regular expression we used was expecting a title, which stripped Atom feed enclosures from the imported posts.

Additionally, `preg_match_all()` was used suboptimally. I was able to remove 3 indentation levels.