### PR TITLE
Diaspora: Avoid warning "supplied key param cannot be coerced  …"

### DIFF
--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -221,6 +221,11 @@ class Diaspora
 
 		$signable_data = $msg.".".base64url_encode($type).".".base64url_encode($encoding).".".base64url_encode($alg);
 
+		if ($handle == '') {
+			logger('No author could be decoded. Discarding. Message: ' . $envelope);
+			return false;
+		}
+
 		$key = self::key($handle);
 		if ($key == '') {
 			logger("Couldn't get a key for handle " . $handle . ". Discarding.");
@@ -331,6 +336,10 @@ class Diaspora
 		}
 
 		$key = self::key($author_addr);
+		if ($key == '') {
+			logger("Couldn't get a key for handle " . $author_addr . ". Discarding.");
+			System::httpExit(400);
+		}
 
 		$verify = Crypto::rsaVerify($signed_data, $signature, $key);
 		if (!$verify) {

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -222,10 +222,14 @@ class Diaspora
 		$signable_data = $msg.".".base64url_encode($type).".".base64url_encode($encoding).".".base64url_encode($alg);
 
 		$key = self::key($handle);
+		if ($key == '') {
+			logger("Couldn't get a key for handle " . $handle . ". Discarding.");
+			return false;
+		}
 
 		$verify = Crypto::rsaVerify($signable_data, $sig, $key);
 		if (!$verify) {
-			logger('Message did not verify. Discarding.');
+			logger('Message from ' . $handle . ' did not verify. Discarding.');
 			return false;
 		}
 
@@ -321,6 +325,11 @@ class Diaspora
 		// Get the senders' public key
 		$key_id = $base->sig[0]->attributes()->key_id[0];
 		$author_addr = base64_decode($key_id);
+		if ($author_addr == '') {
+			logger('No author could be decoded. Discarding. Message: ' . $xml);
+			System::httpExit(400);
+		}
+
 		$key = self::key($author_addr);
 
 		$verify = Crypto::rsaVerify($signed_data, $signature, $key);


### PR DESCRIPTION
The last few days I had a lot of these warnings in my log:
```
 PHP Warning:  openssl_verify(): supplied key param cannot be coerced into a public key in /path/to/friendica/src/Util/Crypto.php on line 38
```
These checks handle this.