### PR TITLE
Documentation about the Community Pages

### DIFF
--- a/doc/Settings.md
+++ b/doc/Settings.md
@@ -126,6 +126,14 @@ Unauthorised persons will also not be able to request friendship with site membe
 Default is false.
 Available in version 2.2 or greater.
 
+#### Community pages for Visitors
+
+The community pages show all public postings, separated by their origin being local or the entire network.
+With this setting you can select which community pages will be shown to visitors of your Friendica node.
+Your local users will always have access to both pages.
+
+**Note**: Several settings, like users hiding their contacts from the public will prevent the postings to show up on the global community page.
+
 #### Allowed Friend Domains
 
 Comma separated list of domains which are allowed to establish friendships with this site.

--- a/doc/de/Settings.md
+++ b/doc/de/Settings.md
@@ -122,6 +122,15 @@ Unautorisierte Personen haben ebenfalls nicht die Möglichkeit, Freundschaftsanf
 Die Standardeinstellung ist deaktiviert. 
 Verfügbar in Version 2.2 und höher.
 
+#### Für Besucher verfügbare Gemeinschaftsseiten
+
+Die Gemeinschaftsseiten zeigen all öffentlichen Beiträge.
+Es gibt zwei Gemeinschaftsseiten, eine lokale auf der die Beiträge der Nutzer des Knotens gesammelt werden und eine globale auf der alle bekannten Beiträge aus dem gesamten Netzwerk erscheinen.
+Mit dieser Einstellung kann geregelt werden, welche dieser beiden Seiten Besucher aufrufen können.
+Angemeldete Nutzer des Knotens können grundsätzlich beide Seiten verwenden.
+
+**Hinweis**: Einige Einstellungen, wie z.B. das Verbergen von Kontakten auf der Profilseite, können die Sichtbarkeit der Beiträge auf der Gemeinschaftsseiten beeinflussen.
+
 #### Erlaubte Domains für Kontakte
 
 Kommagetrennte Liste von Domains, welche eine Freundschaft mit dieser Seite eingehen dürfen. 


### PR DESCRIPTION
This adds the documentation about the community pages, including a note about certain settings may prevent the display of postings on the community pages.

This should fix #4495