### PR TITLE
Fix: The ownership of forum items had been wrong

### DIFF
--- a/src/Protocol/OStatus.php
+++ b/src/Protocol/OStatus.php
@@ -2131,6 +2131,7 @@ class OStatus
 				AND NOT `item`.`deleted`
 				AND NOT `item`.`private`
 				AND `item`.`visible`
+				AND `item`.`wall`
 				AND `thread`.`network` IN ('%s', '%s')
 				$sql_extra
 				ORDER BY `item`.`created` DESC LIMIT %d",


### PR DESCRIPTION
Several fixes for forum posts:
* The contact-id of shadow posts have to belong to the owner, not the author
* The contact-id and owner-id of received forum posts that are about to be distributed had been wrong

And some (unrelated) small enhancement: We should query for the wall when collecting feed items.