### PR TITLE
OStatus: Fixed communication issues with deleted contacts

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -39,7 +39,7 @@ define('FRIENDICA_PLATFORM',     'Friendica');
 define('FRIENDICA_CODENAME',     'Asparagus');
 define('FRIENDICA_VERSION',      '3.6-rc');
 define('DFRN_PROTOCOL_VERSION',  '2.23');
-define('DB_UPDATE_VERSION',      1255);
+define('DB_UPDATE_VERSION',      1256);
 define('NEW_UPDATE_ROUTINE_VERSION', 1170);
 
 /**

--- a/database.sql
+++ b/database.sql
@@ -1,6 +1,6 @@
 -- ------------------------------------------
--- Friendica 3.6-dev (Asparagus)
--- DB_UPDATE_VERSION 1255
+-- Friendica 3.6-rc (Asparagus)
+-- DB_UPDATE_VERSION 1256
 -- ------------------------------------------
 
 
@@ -466,6 +466,7 @@ CREATE TABLE IF NOT EXISTS `item` (
 	`author-link` varchar(255) NOT NULL DEFAULT '' COMMENT '',
 	`author-avatar` varchar(255) NOT NULL DEFAULT '' COMMENT '',
 	`title` varchar(255) NOT NULL DEFAULT '' COMMENT '',
+	`content-warning` varchar(255) NOT NULL DEFAULT '' COMMENT '',
 	`body` mediumtext COMMENT '',
 	`app` varchar(255) NOT NULL DEFAULT '' COMMENT '',
 	`verb` varchar(100) NOT NULL DEFAULT '' COMMENT '',

--- a/doc/htconfig.md
+++ b/doc/htconfig.md
@@ -87,7 +87,6 @@ Example: To set the automatic database cleanup process add this line to your .ht
 * **relay_server_tags** - Comma separated list of tags for the "tags" subscription (see "relay_scrope")
 * **relay_user_tags** (Boolean) - If enabled, the tags from the saved searches will used for the "tags" subscription in addition to the "relay_server_tags".
 * **remove_multiplicated_lines** (Boolean) - If enabled, multiple linefeeds in items are stripped to a single one.
-* **remove_nsfw_with_cw** (Boolean) - If enabled, the "nsfw" will be removed from Mastodon posts with content warning.
 * **show_unsupported_addons** (Boolean) - Show all addons including the unsupported ones.
 * **show_unsupported_themes** (Boolean) - Show all themes including the unsupported ones.
 * **show_global_community_hint** (Boolean) - When the global community page is enabled, use this option to display a hint above the stream, that this is a collection of all public top-level postings that arrive on your node.

--- a/doc/htconfig.md
+++ b/doc/htconfig.md
@@ -87,6 +87,7 @@ Example: To set the automatic database cleanup process add this line to your .ht
 * **relay_server_tags** - Comma separated list of tags for the "tags" subscription (see "relay_scrope")
 * **relay_user_tags** (Boolean) - If enabled, the tags from the saved searches will used for the "tags" subscription in addition to the "relay_server_tags".
 * **remove_multiplicated_lines** (Boolean) - If enabled, multiple linefeeds in items are stripped to a single one.
+* **remove_nsfw_with_cw** (Boolean) - If enabled, the "nsfw" will be removed from Mastodon posts with content warning.
 * **show_unsupported_addons** (Boolean) - Show all addons including the unsupported ones.
 * **show_unsupported_themes** (Boolean) - Show all themes including the unsupported ones.
 * **show_global_community_hint** (Boolean) - When the global community page is enabled, use this option to display a hint above the stream, that this is a collection of all public top-level postings that arrive on your node.

--- a/include/conversation.php
+++ b/include/conversation.php
@@ -445,7 +445,7 @@ These Fields are not added below (yet). They are here to for bug search.
 	return "`item`.`author-id`, `item`.`author-link`, `item`.`author-name`, `item`.`author-avatar`,
 		`item`.`owner-id`, `item`.`owner-link`, `item`.`owner-name`, `item`.`owner-avatar`,
 		`item`.`contact-id`, `item`.`uid`, `item`.`id`, `item`.`parent`,
-		`item`.`uri`, `item`.`thr-parent`, `item`.`parent-uri`,
+		`item`.`uri`, `item`.`thr-parent`, `item`.`parent-uri`, `item`.`content-warning`,
 		`item`.`commented`, `item`.`created`, `item`.`edited`, `item`.`received`,
 		`item`.`verb`, `item`.`object-type`, `item`.`postopts`, `item`.`plink`,
 		`item`.`guid`, `item`.`wall`, `item`.`private`, `item`.`starred`,

--- a/include/items.php
+++ b/include/items.php
@@ -290,7 +290,7 @@ function subscribe_to_hub($url, $importer, $contact, $hubmode = 'subscribe') {
 		return;
 	}
 
-	$push_url = Config::get('system','url') . '/pubsub/' . $r[0]['nickname'] . '/' . $contact['id'];
+	$push_url = System::baseUrl() . '/pubsub/' . $r[0]['nickname'] . '/' . $contact['id'];
 
 	// Use a single verify token, even if multiple hubs
 	$verify_token = ((strlen($contact['hub-verify'])) ? $contact['hub-verify'] : random_string());

--- a/include/text.php
+++ b/include/text.php
@@ -1182,6 +1182,11 @@ function put_item_in_cache(&$item, $update = false)
 		// I'm not sure if we should store it permanently, so we save the old value.
 		$body = $item["body"];
 
+		// Add the content warning
+		if (!empty($item['content-warning'])) {
+			$item["body"] = $item['content-warning'] . '[spoiler]' . $item["body"] . '[/spoiler]';
+		}
+
 		$a = get_app();
 		redir_private_images($a, $item);
 

--- a/index.php
+++ b/index.php
@@ -72,7 +72,7 @@ if (!$install) {
 	if (Config::get('system', 'force_ssl') && ($a->get_scheme() == "http")
 		&& (intval(Config::get('system', 'ssl_policy')) == SSL_POLICY_FULL)
 		&& (substr(System::baseUrl(), 0, 8) == "https://")
-	) {
+		&& ($_SERVER['REQUEST_METHOD'] == 'GET')) {
 		header("HTTP/1.1 302 Moved Temporarily");
 		header("Location: " . System::baseUrl() . "/" . $a->query_string);
 		exit();

--- a/mod/ostatus_subscribe.php
+++ b/mod/ostatus_subscribe.php
@@ -29,12 +29,14 @@ function ostatus_subscribe_content(App $a) {
 	if (PConfig::get($uid, "ostatus", "legacy_friends") == "") {
 
 		if ($_REQUEST["url"] == "") {
+			PConfig::delete($uid, "ostatus", "legacy_contact");
 			return $o.L10n::t("No contact provided.");
 		}
 
 		$contact = Probe::uri($_REQUEST["url"]);
 
 		if (!$contact) {
+			PConfig::delete($uid, "ostatus", "legacy_contact");
 			return $o.L10n::t("Couldn't fetch information for contact.");
 		}
 
@@ -44,6 +46,7 @@ function ostatus_subscribe_content(App $a) {
 		$data = Network::curl($api."statuses/friends.json?screen_name=".$contact["nick"]);
 
 		if (!$data["success"]) {
+			PConfig::delete($uid, "ostatus", "legacy_contact");
 			return $o.L10n::t("Couldn't fetch friends for contact.");
 		}
 

--- a/mod/pubsub.php
+++ b/mod/pubsub.php
@@ -108,7 +108,7 @@ function pubsub_post(App $a)
 			logger('No record for ' . $nick .' with contact id ' . $contact_id . ' - using '.$author['contact-id'].' instead.');
 		}
 		if (!DBM::is_result($contact)) {
-			logger('Contact ' . $contact_id . ' for user ' . $nick . " wasn't found - ignored.");
+			logger('Contact ' . $contact_id . ' for user ' . $nick . " wasn't found - ignored. XML: " . $xml);
 			hub_post_return();
 		}
 	}

--- a/mod/pubsub.php
+++ b/mod/pubsub.php
@@ -108,7 +108,7 @@ function pubsub_post(App $a)
 			logger('No record for ' . $nick .' with contact id ' . $contact_id . ' - using '.$author['contact-id'].' instead.');
 		}
 		if (!DBM::is_result($contact)) {
-			logger('Contact ' . $contact_id . ' for user ' . $nick . " wasn't found - ignored. XML: " . $xml);
+			logger('Contact ' . $author["author-link"] . ' (' . $contact_id . ') for user ' . $nick . " wasn't found - ignored. XML: " . $xml);
 			hub_post_return();
 		}
 	}

--- a/mod/pubsub.php
+++ b/mod/pubsub.php
@@ -129,7 +129,7 @@ function pubsub_post(App $a)
 	consume_feed($xml, $importer, $contact, $feedhub);
 
 	// do it a second time for DFRN so that any children find their parents.
-        if ($contact['network'] === NETWORK_DFRN) {
+	if ($contact['network'] === NETWORK_DFRN) {
 		consume_feed($xml, $importer, $contact, $feedhub);
 	}
 

--- a/mod/pubsub.php
+++ b/mod/pubsub.php
@@ -4,164 +4,134 @@ use Friendica\App;
 use Friendica\Database\DBM;
 use Friendica\Protocol\OStatus;
 
-function hub_return($valid,$body) {
+require_once('include/security.php');
+require_once('include/items.php');
 
+function hub_return($valid, $body)
+{
 	if ($valid) {
-		header($_SERVER["SERVER_PROTOCOL"] . ' 200 ' . 'OK');
+		header($_SERVER["SERVER_PROTOCOL"] . ' 200 OK');
 		echo $body;
-		killme();
 	} else {
-		header($_SERVER["SERVER_PROTOCOL"] . ' 404 ' . 'Not Found');
-		killme();
+		header($_SERVER["SERVER_PROTOCOL"] . ' 404 Not Found');
 	}
-
-	// NOTREACHED
+	killme();
 }
 
 // when receiving an XML feed, always return OK
 
-function hub_post_return() {
-
-	header($_SERVER["SERVER_PROTOCOL"] . ' 200 ' . 'OK');
+function hub_post_return()
+{
+	header($_SERVER["SERVER_PROTOCOL"] . ' 200 OK');
 	killme();
-
 }
 
-
-
-function pubsub_init(App $a) {
-
+function pubsub_init(App $a)
+{
 	$nick       = (($a->argc > 1) ? notags(trim($a->argv[1])) : '');
 	$contact_id = (($a->argc > 2) ? intval($a->argv[2])       : 0 );
 
 	if ($_SERVER['REQUEST_METHOD'] === 'GET') {
-		$hub_mode      = ((x($_GET,'hub_mode'))          ? notags(trim($_GET['hub_mode']))          : '');
-		$hub_topic     = ((x($_GET,'hub_topic'))         ? notags(trim($_GET['hub_topic']))         : '');
-		$hub_challenge = ((x($_GET,'hub_challenge'))     ? notags(trim($_GET['hub_challenge']))     : '');
-		$hub_lease     = ((x($_GET,'hub_lease_seconds')) ? notags(trim($_GET['hub_lease_seconds'])) : '');
-		$hub_verify    = ((x($_GET,'hub_verify_token'))  ? notags(trim($_GET['hub_verify_token']))  : '');
+		$hub_mode      = notags(trim(defaults($_GET, 'hub_mode', '')));
+		$hub_topic     = notags(trim(defaults($_GET, 'hub_topic', '')));
+		$hub_challenge = notags(trim(defaults($_GET, 'hub_challenge', '')));
+		$hub_lease     = notags(trim(defaults($_GET, 'hub_lease_seconds', '')));
+		$hub_verify    = notags(trim(defaults($_GET, 'hub_verify_token', '')));
 
-		logger('pubsub: Subscription from ' . $_SERVER['REMOTE_ADDR'] . ' Mode: ' . $hub_mode . ' Nick: ' . $nick);
-		logger('pubsub: data: ' . print_r($_GET,true), LOGGER_DATA);
+		logger('Subscription from ' . $_SERVER['REMOTE_ADDR'] . ' Mode: ' . $hub_mode . ' Nick: ' . $nick);
+		logger('Data: ' . print_r($_GET,true), LOGGER_DATA);
 
 		$subscribe = (($hub_mode === 'subscribe') ? 1 : 0);
 
-		$r = q("SELECT * FROM `user` WHERE `nickname` = '%s' AND `account_expired` = 0 AND `account_removed` = 0 LIMIT 1",
-			dbesc($nick)
-		);
-		if (!DBM::is_result($r)) {
-			logger('pubsub: local account not found: ' . $nick);
+		$owner = dba::selectFirst('user', ['uid'], ['nickname' => $nick, 'account_expired' => false, 'account_removed' => false]);
+		if (!DBM::is_result($owner)) {
+			logger('Local account not found: ' . $nick);
 			hub_return(false, '');
 		}
 
-
-		$owner = $r[0];
+		$condition = ['uid' => $owner['uid'], 'id' => $contact_id, 'blocked' => false, 'pending' => false];
 
 		if (!empty($hub_verify)) {
-			$sql_extra = sprintf(" AND `hub-verify` = '%s' ", dbesc($hub_verify));
-			$log_info = 'hub-verify: ' . $hub_verify;
-		} else {
-			$sql_extra = sprintf(" AND `id` = %d ", intval($contact_id));
-			$log_info = 'contact-id: ' . $contact_id;
+			$condition['hub-verify'] = $hub_verify;
 		}
 
-		$r = q("SELECT * FROM `contact` WHERE `uid` = %d
-			AND NOT `blocked` AND NOT `pending` $sql_extra LIMIT 1",
-			intval($owner['uid'])
-		);
-		if (!DBM::is_result($r)) {
-			logger('pubsub: contact not found. ' . $log_info);
+		$contact = dba::selectFirst('contact', ['id', 'poll'], $condition);
+		if (!DBM::is_result($contact)) {
+			logger('Contact ' . $contact_id . ' not found.');
 			hub_return(false, '');
 		}
 
-		if (!empty($hub_topic)) {
-			if (!link_compare($hub_topic,$r[0]['poll'])) {
-				logger('pubsub: hub topic ' . $hub_topic . ' != ' . $r[0]['poll']);
-				// should abort but let's humour them.
-			}
+		if (!empty($hub_topic) && !link_compare($hub_topic, $contact['poll'])) {
+			logger('Hub topic ' . $hub_topic . ' != ' . $contact['poll']);
+			hub_return(false, '');
 		}
-
-		$contact = $r[0];
 
 		// We must initiate an unsubscribe request with a verify_token.
 		// Don't allow outsiders to unsubscribe us.
 
-		if ($hub_mode === 'unsubscribe') {
-			if (!strlen($hub_verify)) {
-				logger('pubsub: bogus unsubscribe');
-				hub_return(false, '');
-			}
+		if (($hub_mode === 'unsubscribe') && empty($hub_verify)) {
+			logger('Bogus unsubscribe');
+			hub_return(false, '');
 		}
 
 		if (!empty($hub_mode)) {
 			dba::update('contact', ['subhub' => $subscribe], ['id' => $contact['id']]);
-			logger('pubsub: ' . $hub_mode . ' success');
+			logger($hub_mode . ' success for contact ' . $contact_id . '.');
 		}
  		hub_return(true, $hub_challenge);
 	}
 }
 
-require_once('include/security.php');
-
-function pubsub_post(App $a) {
-
+function pubsub_post(App $a)
+{
 	$xml = file_get_contents('php://input');
 
-	logger('pubsub: feed arrived from ' . $_SERVER['REMOTE_ADDR'] . ' for ' .  $a->cmd );
-	logger('pubsub: user-agent: ' . $_SERVER['HTTP_USER_AGENT'] );
-	logger('pubsub: data: ' . $xml, LOGGER_DATA);
+	logger('Feed arrived from ' . $_SERVER['REMOTE_ADDR'] . ' for ' .  $a->cmd . ' with user-agent: ' . $_SERVER['HTTP_USER_AGENT']);
+	logger('Data: ' . $xml, LOGGER_DATA);
 
 	$nick       = (($a->argc > 1) ? notags(trim($a->argv[1])) : '');
 	$contact_id = (($a->argc > 2) ? intval($a->argv[2])       : 0 );
 
-	$r = q("SELECT * FROM `user` WHERE `nickname` = '%s' AND `account_expired` = 0 AND `account_removed` = 0 LIMIT 1",
-		dbesc($nick)
-	);
-	if (!DBM::is_result($r)) {
+	$importer = dba::selectFirst('user', [], ['nickname' => $nick, 'account_expired' => false, 'account_removed' => false]);
+	if (!DBM::is_result($importer)) {
 		hub_post_return();
 	}
 
-	$importer = $r[0];
+	$condition = ['id' => $contact_id, 'uid' => $importer['uid'], 'subhub' => true, 'blocked' => false];
+	$contact = dba::selectFirst('contact', [], $condition);
 
-	$r = q("SELECT * FROM `contact` WHERE `subhub` AND `id` = %d AND `uid` = %d
-		AND (`rel` = %d OR `rel` = %d OR network = '%s') AND NOT `blocked` LIMIT 1",
-		intval($contact_id),
-		intval($importer['uid']),
-		intval(CONTACT_IS_SHARING),
-		intval(CONTACT_IS_FRIEND),
-		dbesc(NETWORK_FEED)
-	);
-
-	if (!DBM::is_result($r)) {
+	if (!DBM::is_result($contact)) {
 		$author = OStatus::salmonAuthor($xml, $importer);
 		if (!empty($author['contact-id'])) {
-			$contact = dba::selectFirst('contact', [], ['id' => $author['contact-id']]);
-			if (!in_array($contact['rel'], [CONTACT_IS_SHARING, CONTACT_IS_FRIEND]) && ($contact['network'] != NETWORK_FEED)) {
-				logger('Contact ' . $author['contact-id'] . ' is not expected to share with us - ignored.');
-				hub_post_return();
-			}
-			logger('pubsub: no contact record for "'.$nick.' ('.$contact_id.')" - using '.$author['contact-id'].' instead.');
+			$condition = ['id' => $author['contact-id'], 'uid' => $importer['uid'], 'subhub' => true, 'blocked' => false];
+			$contact = dba::selectFirst('contact', [], $condition);
+			logger('No record for ' . $nick .' with contact id ' . $contact_id . ' - using '.$author['contact-id'].' instead.');
 		}
-	} else {
-		$contact = $r[0];
+		if (!DBM::is_result($contact)) {
+			logger('Contact ' . $contact_id . ' for user ' . $nick . " wasn't found - ignored.");
+			hub_post_return();
+		}
 	}
 
-	// we have no way to match Diaspora guid's with atom post id's and could get duplicates.
-	// we'll assume that direct delivery is robust (and this is a bad assumption, but the duplicates are messy).
-
-	if ($r[0]['network'] === NETWORK_DIASPORA) {
+	if (!in_array($contact['rel'], [CONTACT_IS_SHARING, CONTACT_IS_FRIEND]) && ($contact['network'] != NETWORK_FEED)) {
+		logger('Contact ' . $contact['id'] . ' is not expected to share with us - ignored.');
 		hub_post_return();
 	}
+
+	// We import feeds from OStatus, Friendica and ATOM/RSS.
+	/// @todo Check if Friendica posts really arrive here - otherwise we can discard some stuff
+	if (!in_array($contact['network'], [NETWORK_OSTATUS, NETWORK_DFRN, NETWORK_FEED])) {
+		hub_post_return();
+	}
+
+	logger('Import item for ' . $nick . ' from ' . $contact['nick'] . ' (' . $contact['id'] . ')');
 	$feedhub = '';
+	consume_feed($xml, $importer, $contact, $feedhub);
 
-	require_once('include/items.php');
-
-	consume_feed($xml,$importer,$contact,$feedhub,1,1);
-
-	// do it a second time so that any children find their parents.
-
-	consume_feed($xml,$importer,$contact,$feedhub,1,2);
+	// do it a second time for DFRN so that any children find their parents.
+        if ($contact['network'] === NETWORK_DFRN) {
+		consume_feed($xml, $importer, $contact, $feedhub);
+	}
 
 	hub_post_return();
-
 }

--- a/mod/settings.php
+++ b/mod/settings.php
@@ -207,8 +207,7 @@ function settings_post(App $a)
 		return;
 	}
 
-	if (($a->argc > 1) && ($a->argv[1] == 'connectors'))
-	{
+	if (($a->argc > 1) && ($a->argv[1] == 'connectors')) {
 		check_form_security_token_redirectOnErr('/settings/connectors', 'settings_connectors');
 
 		if (x($_POST, 'general-submit')) {

--- a/src/Database/DBStructure.php
+++ b/src/Database/DBStructure.php
@@ -1143,6 +1143,7 @@ class DBStructure
 						"author-link" => ["type" => "varchar(255)", "not null" => "1", "default" => "", "comment" => ""],
 						"author-avatar" => ["type" => "varchar(255)", "not null" => "1", "default" => "", "comment" => ""],
 						"title" => ["type" => "varchar(255)", "not null" => "1", "default" => "", "comment" => ""],
+						"content-warning" => ["type" => "varchar(255)", "not null" => "1", "default" => "", "comment" => ""],
 						"body" => ["type" => "mediumtext", "comment" => ""],
 						"app" => ["type" => "varchar(255)", "not null" => "1", "default" => "", "comment" => ""],
 						"verb" => ["type" => "varchar(100)", "not null" => "1", "default" => "", "comment" => ""],

--- a/src/Protocol/OStatus.php
+++ b/src/Protocol/OStatus.php
@@ -660,8 +660,9 @@ class OStatus
 		// Mastodon Content Warning
 		if (($item["verb"] == ACTIVITY_POST) && $xpath->evaluate('boolean(atom:summary)', $entry)) {
 			$clear_text = $xpath->query('atom:summary/text()', $entry)->item(0)->nodeValue;
-
-			$item["body"] = html2bbcode($clear_text) . '[spoiler]' . $item["body"] . '[/spoiler]';
+			if (!empty($clear_text)) {
+				$item["body"] = html2bbcode($clear_text) . '[spoiler]' . $item["body"] . '[/spoiler]';
+			}
 		}
 
 		if (($self != '') && empty($item['protocol'])) {

--- a/src/Protocol/OStatus.php
+++ b/src/Protocol/OStatus.php
@@ -679,9 +679,10 @@ class OStatus
 				foreach ($category->attributes as $attributes) {
 					if ($attributes->name == "term") {
 						$term = $attributes->textContent;
-						// don't add nsfw with content warning
-						// Background: "nsfw" is set automatically by Mastodon and superfluous
-						if (!$content_warning || ($term != 'nsfw')) {
+						// don't add nsfw with content warning if enabled.
+						// Background: "nsfw" is set automatically by Mastodon
+						if (!Config::get('system', 'remove_nsfw_with_cw', false) ||
+							!$content_warning || ($term != 'nsfw')) {
 							if (strlen($item["tag"])) {
 								$item["tag"] .= ',';
 							}

--- a/src/Protocol/OStatus.php
+++ b/src/Protocol/OStatus.php
@@ -246,13 +246,12 @@ class OStatus
 		$xpath->registerNamespace('ostatus', NAMESPACE_OSTATUS);
 		$xpath->registerNamespace('statusnet', NAMESPACE_STATUSNET);
 
-		$entries = $xpath->query('/atom:entry');
+		$contact = ["id" => 0];
 
-		foreach ($entries as $entry) {
-			// fetch the author
-			$author = self::fetchAuthor($xpath, $entry, $importer, $contact, true);
-			return $author;
-		}
+		// Fetch the first author
+		$authordata = $xpath->query('//author')->item(0);
+		$author = self::fetchAuthor($xpath, $authordata, $importer, $contact, true);
+		return $author;
 	}
 
 	/**

--- a/src/Protocol/OStatus.php
+++ b/src/Protocol/OStatus.php
@@ -662,7 +662,6 @@ class OStatus
 			$clear_text = $xpath->query('atom:summary/text()', $entry)->item(0)->nodeValue;
 			if (!empty($clear_text)) {
 				$item['content-warning'] = html2bbcode($clear_text);
-				//$item["body"] = html2bbcode($clear_text) . '[spoiler]' . $item["body"] . '[/spoiler]';
 			}
 		}
 

--- a/src/Protocol/OStatus.php
+++ b/src/Protocol/OStatus.php
@@ -604,21 +604,6 @@ class OStatus
 			$item["coord"] = $georsspoint->item(0)->nodeValue;
 		}
 
-		$categories = $xpath->query('atom:category', $entry);
-		if ($categories) {
-			foreach ($categories as $category) {
-				foreach ($category->attributes as $attributes) {
-					if ($attributes->name == "term") {
-						$term = $attributes->textContent;
-						if (strlen($item["tag"])) {
-							$item["tag"] .= ',';
-						}
-						$item["tag"] .= "#[url=".System::baseUrl()."/search?tag=".$term."]".$term."[/url]";
-					}
-				}
-			}
-		}
-
 		$self = '';
 		$add_body = '';
 
@@ -658,10 +643,12 @@ class OStatus
 		}
 
 		// Mastodon Content Warning
+		$content_warning = false;
 		if (($item["verb"] == ACTIVITY_POST) && $xpath->evaluate('boolean(atom:summary)', $entry)) {
 			$clear_text = $xpath->query('atom:summary/text()', $entry)->item(0)->nodeValue;
 			if (!empty($clear_text)) {
 				$item["body"] = html2bbcode($clear_text) . '[spoiler]' . $item["body"] . '[/spoiler]';
+				$content_warning = true;
 			}
 		}
 
@@ -684,6 +671,25 @@ class OStatus
 			$item["gravity"] = GRAVITY_COMMENT;
 		} else {
 			$item["parent-uri"] = $item["uri"];
+		}
+
+		$categories = $xpath->query('atom:category', $entry);
+		if ($categories) {
+			foreach ($categories as $category) {
+				foreach ($category->attributes as $attributes) {
+					if ($attributes->name == "term") {
+						$term = $attributes->textContent;
+						// don't add nsfw with content warning
+						// Background: "nsfw" is set automatically by Mastodon and superfluous
+						if (!$content_warning || ($term != 'nsfw')) {
+							if (strlen($item["tag"])) {
+								$item["tag"] .= ',';
+							}
+							$item["tag"] .= "#[url=".System::baseUrl()."/search?tag=".$term."]".$term."[/url]";
+						}
+					}
+				}
+			}
 		}
 
 		if (($item['author-link'] != '') && !empty($item['protocol'])) {

--- a/src/Util/Network.php
+++ b/src/Util/Network.php
@@ -217,7 +217,7 @@ class Network
 
 			$newurl = $curl_info['redirect_url'];
 
-			if (($new_location_info['path'] == '') && ( $new_location_info['host'] != '')) {
+			if (($new_location_info['path'] == '') && ($new_location_info['host'] != '')) {
 				$newurl = $new_location_info['scheme'] . '://' . $new_location_info['host'] . $old_location_info['path'];
 			}
 
@@ -228,6 +228,11 @@ class Network
 			}
 			if (strpos($newurl, '/') === 0) {
 				$newurl = $old_location_info["scheme"]."://".$old_location_info["host"].$newurl;
+			}
+			$old_location_query = @parse_url($url, PHP_URL_QUERY);
+
+			if ($old_location_query != '') {
+				$newurl .= '?' . $old_location_query;
 			}
 
 			if (filter_var($newurl, FILTER_VALIDATE_URL)) {

--- a/view/templates/settings/connectors.tpl
+++ b/view/templates/settings/connectors.tpl
@@ -22,7 +22,7 @@
 
 	<p><a href="{{$repair_ostatus_url}}">{{$repair_ostatus_text}}</a></p>
 
-	<div class="settings-submit-wrapper" ><input type="submit" name="general-submit" class="settings-submit" value="{{$submit}}" /></div>
+	<div class="settings-submit-wrapper" ><input type="submit" id="general-submit" name="general-submit" class="settings-submit" value="{{$submit}}" /></div>
 </div>
 <div class="clear"></div>
 

--- a/view/theme/frio/templates/settings/connectors.tpl
+++ b/view/theme/frio/templates/settings/connectors.tpl
@@ -28,7 +28,7 @@
 						<p><a href="{{$repair_ostatus_url}}">{{$repair_ostatus_text}}</a></p>
 
 						<div class="form-group pull-right settings-submit-wrapper" >
-							<button type="submit" name="submit" class="btn btn-primary" value="{{$submit|escape:'html'}}">{{$submit}}</button>
+							<button type="submit" id="general-submit" name="general-submit" class="btn btn-primary" value="{{$submit|escape:'html'}}">{{$submit}}</button>
 						</div>
 						<div class="clear"></div>
 					</div>


### PR DESCRIPTION
There had been multiple problems with the OStatus communication:

1. The returned pubsub address used the wrong method to get the own host url
2. We mustn't send a redirect header for "post" requests. Mostly they aren't followed and the content is lost.
3. When contacts had been deleted although active connections existed, the pubhub url became invalid. We now fetch the sender from the content.