### PR TITLE
Avoid an error in OnePoll when the contact was "null".

### DIFF
--- a/include/items.php
+++ b/include/items.php
@@ -228,7 +228,7 @@ function add_page_info_to_body($body, $texturl = false, $no_photos = false) {
  *
  * @TODO find proper type-hints
  */
-function consume_feed($xml, $importer, &$contact, &$hub, $datedir = 0, $pass = 0) {
+function consume_feed($xml, $importer, $contact, &$hub, $datedir = 0, $pass = 0) {
 	if ($contact['network'] === NETWORK_OSTATUS) {
 		if ($pass < 2) {
 			// Test - remove before flight

--- a/src/Worker/OnePoll.php
+++ b/src/Worker/OnePoll.php
@@ -582,11 +582,15 @@ class OnePoll
 
 			logger("Consume feed of contact ".$contact['id']);
 
-			consume_feed($xml, $importer, $contact, $hub, 1, 1);
+			// Use a copy of the contact to avoid problems.
+			// The contact parameter is called by reference.
+			$contact2 = $contact;
+			consume_feed($xml, $importer, $contact2, $hub, 1, 1);
 
 			// do it twice. Ensures that children of parents which may be later in the stream aren't tossed
 
-			consume_feed($xml, $importer, $contact, $hub, 1, 2);
+			$contact2 = $contact;
+			consume_feed($xml, $importer, $contact2, $hub, 1, 2);
 
 			$hubmode = 'subscribe';
 			if ($contact['network'] === NETWORK_DFRN || $contact['blocked'] || $contact['readonly']) {

--- a/src/Worker/OnePoll.php
+++ b/src/Worker/OnePoll.php
@@ -582,15 +582,12 @@ class OnePoll
 
 			logger("Consume feed of contact ".$contact['id']);
 
-			// Use a copy of the contact to avoid problems.
-			// The contact parameter is called by reference.
-			$contact2 = $contact;
-			consume_feed($xml, $importer, $contact2, $hub, 1, 1);
+			consume_feed($xml, $importer, $contact, $hub);
 
-			// do it twice. Ensures that children of parents which may be later in the stream aren't tossed
-
-			$contact2 = $contact;
-			consume_feed($xml, $importer, $contact2, $hub, 1, 2);
+			// do it a second time for DFRN so that any children find their parents.
+			if ($contact['network'] === NETWORK_DFRN) {
+				consume_feed($xml, $importer, $contact, $hub);
+			}
 
 			$hubmode = 'subscribe';
 			if ($contact['network'] === NETWORK_DFRN || $contact['blocked'] || $contact['readonly']) {


### PR DESCRIPTION
This is done to avoid this error:
```
PHP Fatal error:  Uncaught TypeError: Argument 1 passed to Friendica\Model\Contact::unmarkForArchival() must be of the type array, null given, called in /path/to/friendica/src/Worker/OnePoll.php on line 624 and defined in /path/to/friendica/src/Model/Contact.php:249
```