### PR TITLE
Attachment encode

### DIFF
--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -705,7 +705,7 @@ class BBCode
 				}
 
 				if ($data["description"] != "" && $data["description"] != $data["title"]) {
-					$return .= sprintf('<blockquote>%s</blockquote>', trim(BBCode::convert($data["description"])));
+					$return .= sprintf('<blockquote>%s</blockquote>', trim($data["description"]));
 				}
 
 				if ($data["type"] == "link") {

--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -25,6 +25,7 @@ use Friendica\Util\ParseUrl;
 
 require_once "include/event.php";
 require_once "include/html2plain.php";
+require_once "include/html2bbcode.php";
 require_once "mod/proxy.php";
 
 class BBCode
@@ -705,9 +706,10 @@ class BBCode
 				}
 
 				if ($data["description"] != "" && $data["description"] != $data["title"]) {
-					$return .= sprintf('<blockquote>%s</blockquote>', trim($data["description"]));
+					// Sanitize the HTML by converting it to BBCode
+					$bbcode = html2bbcode($data["description"]);
+					$return .= sprintf('<blockquote>%s</blockquote>', trim(self::convert($bbcode)));
 				}
-
 				if ($data["type"] == "link") {
 					$return .= sprintf('<sup><a href="%s">%s</a></sup>', $data['url'], parse_url($data['url'], PHP_URL_HOST));
 				}


### PR DESCRIPTION
The fetched attachment data can contain HTML. Sending this through the BBCode encoder will double encode the HTML. We now convert it to BBCode at first. This sanitizes the HTML.