### PR TITLE
php-zip module is needed for composer

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -37,7 +37,7 @@ local .htaccess file
 		- PHP *command line* access with register_argc_argv set to true in the
 php.ini file [or see 'poormancron' in section 8]
 
-		- curl, gd (with at least jpeg support), mysql, mbstring, xml and openssl extensions
+		- curl, gd (with at least jpeg support), mysql, mbstring, xml, zip and openssl extensions
 
 		- some form of email server or email gateway such that PHP mail() works
 

--- a/doc/Install.md
+++ b/doc/Install.md
@@ -28,7 +28,7 @@ Requirements
 * Apache with mod-rewrite enabled and "Options All" so you can use a local .htaccess file
 * PHP 5.6+ (PHP 7 is recommended for performance)
 * PHP *command line* access with register_argc_argv set to true in the php.ini file
-* Curl, GD, PDO, MySQLi, hash, xml and OpenSSL extensions
+* Curl, GD, PDO, MySQLi, hash, xml, zip and OpenSSL extensions
 * some form of email server or email gateway such that PHP mail() works
 * Mysql 5.5.3+ or an equivalant alternative for MySQL (MariaDB, Percona Server etc.)
 * the ability to schedule jobs with cron (Linux/Mac) or Scheduled Tasks (Windows) (Note: other options are presented in Section 7 of this document.)

--- a/doc/de/Install.md
+++ b/doc/de/Install.md
@@ -24,7 +24,7 @@ Wir planen, diese Einschränkung in einer zukünftigen Version zu beheben.
     - Apache mit einer aktiverten mod-rewrite-Funktion und dem Eintrag "Options All", so dass du die lokale .htaccess-Datei nutzen kannst
     - PHP  5.6+. Je neuer, desto besser.
         - PHP *Kommandozeilen*-Zugang mit register_argc_argv auf "true" gesetzt in der php.ini-Datei
-        - Curl, GD, PDO, MySQLi, xml und OpenSSL-Erweiterung
+        - Curl, GD, PDO, MySQLi, xml, zip und OpenSSL-Erweiterung
         - etwas in der Art eines Email-Servers oder eines Gateways wie PHP mail()
     - Mysql 5.5.3+
     - die Möglichkeit, wiederkehrende Aufgaben mit cron (Linux/Mac) oder "Scheduled Tasks" einzustellen (Windows) [Beachte: andere Optionen sind in Abschnitt 7 dieser Dokumentation zu finden]


### PR DESCRIPTION
Following the installation docs I missed a needed PHP module for the installation of the dependencies via composer.