### PR TITLE
DFRN: The relationship between contacts can now be changed afterwards

### DIFF
--- a/mod/contacts.php
+++ b/mod/contacts.php
@@ -581,7 +581,7 @@ function contacts_content(App $a)
 
 		$follow = '';
 		$follow_text = '';
-		if (in_array($contact['network'], [NETWORK_DIASPORA, NETWORK_OSTATUS])) {
+		if (in_array($contact['network'], [NETWORK_DIASPORA, NETWORK_OSTATUS, NETWORK_DFRN])) {
 			if ($contact['rel'] == CONTACT_IS_FOLLOWER) {
 				$follow = System::baseUrl(true) . "/follow?url=" . urlencode($contact["url"]);
 				$follow_text = L10n::t("Connect/Follow");

--- a/mod/contacts.php
+++ b/mod/contacts.php
@@ -579,6 +579,7 @@ function contacts_content(App $a)
 			$profile_select = ContactSelector::profileAssign($contact['profile-id'], (($contact['network'] !== NETWORK_DFRN) ? true : false));
 		}
 
+		/// @todo Only show the following link with DFRN when the remote version supports it
 		$follow = '';
 		$follow_text = '';
 		if (in_array($contact['network'], [NETWORK_DIASPORA, NETWORK_OSTATUS, NETWORK_DFRN])) {

--- a/mod/dfrn_notify.php
+++ b/mod/dfrn_notify.php
@@ -18,6 +18,12 @@ require_once 'include/event.php';
 
 function dfrn_notify_post(App $a) {
 	logger(__function__, LOGGER_TRACE);
+
+	if (empty($_POST)) {
+		require_once 'mod/salmon.php';
+		salmon_post($a);
+	}
+
 	$dfrn_id      = ((x($_POST,'dfrn_id'))      ? notags(trim($_POST['dfrn_id']))   : '');
 	$dfrn_version = ((x($_POST,'dfrn_version')) ? (float) $_POST['dfrn_version']    : 2.0);
 	$challenge    = ((x($_POST,'challenge'))    ? notags(trim($_POST['challenge'])) : '');

--- a/mod/unfollow.php
+++ b/mod/unfollow.php
@@ -33,7 +33,7 @@ function unfollow_post(App $a)
 	if (!DBM::is_result($contact)) {
 		notice(L10n::t("Contact wasn't found or can't be unfollowed."));
 	} else {
-		if (in_array($contact['network'], [NETWORK_OSTATUS, NETWORK_DIASPORA])) {
+		if (in_array($contact['network'], [NETWORK_OSTATUS, NETWORK_DIASPORA, NETWORK_DFRN])) {
 			$r = q("SELECT `contact`.*, `user`.* FROM `contact` INNER JOIN `user` ON `contact`.`uid` = `user`.`uid`
 				WHERE `user`.`uid` = %d AND `contact`.`self` LIMIT 1",
 				intval($uid)
@@ -75,7 +75,7 @@ function unfollow_content(App $a)
 		// NOTREACHED
 	}
 
-	if (!in_array($contact['network'], [NETWORK_DIASPORA, NETWORK_OSTATUS])) {
+	if (!in_array($contact['network'], [NETWORK_DIASPORA, NETWORK_OSTATUS, NETWORK_DFRN])) {
 		notice(L10n::t("Unfollowing is currently not supported by your network.").EOL);
 		$submit = "";
 		// NOTREACHED

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -185,8 +185,6 @@ class Contact extends BaseObject
 			}
 		} elseif ($contact['network'] == NETWORK_DIASPORA) {
 			Diaspora::sendUnshare($user, $contact);
-		//} elseif ($contact['network'] === NETWORK_DFRN) {
-		//	DFRN::deliver($user, $contact, 'placeholder', 1);
 		}
 	}
 
@@ -1377,7 +1375,7 @@ class Contact extends BaseObject
 		}
 
 		if (is_array($contact)) {
-			if (($contact['network'] == NETWORK_OSTATUS && $contact['rel'] == CONTACT_IS_SHARING)
+			if (($contact['rel'] == CONTACT_IS_SHARING)
 				|| ($sharing && $contact['rel'] == CONTACT_IS_FOLLOWER)) {
 				dba::update('contact', ['rel' => CONTACT_IS_FRIEND, 'writable' => true],
 						['id' => $contact['id'], 'uid' => $importer['uid']]);

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -173,20 +173,20 @@ class Contact extends BaseObject
 	 */
 	public static function terminateFriendship(array $user, array $contact)
 	{
-		if ($contact['network'] === NETWORK_OSTATUS) {
+		if (in_array($contact['network'], [NETWORK_OSTATUS, NETWORK_DFRN])) {
 			// create an unfollow slap
 			$item = [];
 			$item['verb'] = NAMESPACE_OSTATUS . "/unfollow";
 			$item['follow'] = $contact["url"];
 			$slap = OStatus::salmon($item, $user);
 
-			if ((x($contact, 'notify')) && (strlen($contact['notify']))) {
+			if (!empty($contact['notify'])) {
 				Salmon::slapper($user, $contact['notify'], $slap);
 			}
-		} elseif ($contact['network'] === NETWORK_DIASPORA) {
+		} elseif ($contact['network'] == NETWORK_DIASPORA) {
 			Diaspora::sendUnshare($user, $contact);
-		} elseif ($contact['network'] === NETWORK_DFRN) {
-			DFRN::deliver($user, $contact, 'placeholder', 1);
+		//} elseif ($contact['network'] === NETWORK_DFRN) {
+		//	DFRN::deliver($user, $contact, 'placeholder', 1);
 		}
 	}
 
@@ -1168,7 +1168,26 @@ class Contact extends BaseObject
 			return result;
 		}
 
-		if ($ret['network'] === NETWORK_DFRN) {
+		// check if we already have a contact
+		// the poll url is more reliable than the profile url, as we may have
+		// indirect links or webfinger links
+
+		$r = q("SELECT * FROM `contact` WHERE `uid` = %d AND `poll` IN ('%s', '%s') AND `network` = '%s' AND NOT `pending` LIMIT 1",
+			intval($uid),
+			dbesc($ret['poll']),
+			dbesc(normalise_link($ret['poll'])),
+			dbesc($ret['network'])
+		);
+
+		if (!DBM::is_result($r)) {
+			$r = q("SELECT * FROM `contact` WHERE `uid` = %d AND `nurl` = '%s' AND `network` = '%s' AND NOT `pending` LIMIT 1",
+				intval($uid),
+				dbesc(normalise_link($url)),
+				dbesc($ret['network'])
+			);
+		}
+
+		if (($ret['network'] === NETWORK_DFRN) && !DBM::is_result($r)) {
 			if ($interactive) {
 				if (strlen($a->path)) {
 					$myaddr = bin2hex(System::baseUrl() . '/profile/' . $a->user['nickname']);
@@ -1180,7 +1199,7 @@ class Contact extends BaseObject
 
 				// NOTREACHED
 			}
-		} elseif (Config::get('system', 'dfrn_only')) {
+		} elseif (Config::get('system', 'dfrn_only') && ($ret['network'] != NETWORK_DFRN)) {
 			$result['message'] = L10n::t('This site is not configured to allow communications with other networks.') . EOL;
 			$result['message'] != L10n::t('No compatible communication protocols or feeds were discovered.') . EOL;
 			return $result;
@@ -1228,25 +1247,6 @@ class Contact extends BaseObject
 
 		if (in_array($ret['network'], [NETWORK_MAIL, NETWORK_DIASPORA])) {
 			$writeable = 1;
-		}
-
-		// check if we already have a contact
-		// the poll url is more reliable than the profile url, as we may have
-		// indirect links or webfinger links
-
-		$r = q("SELECT * FROM `contact` WHERE `uid` = %d AND `poll` IN ('%s', '%s') AND `network` = '%s' LIMIT 1",
-			intval($uid),
-			dbesc($ret['poll']),
-			dbesc(normalise_link($ret['poll'])),
-			dbesc($ret['network'])
-		);
-
-		if (!DBM::is_result($r)) {
-			$r = q("SELECT * FROM `contact` WHERE `uid` = %d AND `nurl` = '%s' AND `network` = '%s' LIMIT 1",
-				intval($uid),
-				dbesc(normalise_link($url)),
-				dbesc($ret['network'])
-			);
 		}
 
 		if (DBM::is_result($r)) {
@@ -1309,16 +1309,16 @@ class Contact extends BaseObject
 		);
 
 		if (DBM::is_result($r)) {
-			if (($contact['network'] == NETWORK_OSTATUS) && (strlen($contact['notify']))) {
+			if (in_array($contact['network'], [NETWORK_OSTATUS, NETWORK_DFRN])) {
 				// create a follow slap
 				$item = [];
 				$item['verb'] = ACTIVITY_FOLLOW;
 				$item['follow'] = $contact["url"];
 				$slap = OStatus::salmon($item, $r[0]);
-				Salmon::slapper($r[0], $contact['notify'], $slap);
-			}
-
-			if ($contact['network'] == NETWORK_DIASPORA) {
+				if (!empty($contact['notify'])) {
+					Salmon::slapper($r[0], $contact['notify'], $slap);
+				}
+			} elseif ($contact['network'] == NETWORK_DIASPORA) {
 				$ret = Diaspora::sendShare($a->user, $contact);
 				logger('share returns: ' . $ret);
 			}


### PR DESCRIPTION
Only small changes had been needed to be able to change the relationship of Friendica contacts after they had connected.

The only downside is that it will only work when both sides are on 3.6.