### PR TITLE
Fix: Private transmission via Diaspora to Friendica servers

### DIFF
--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -3217,13 +3217,14 @@ class Diaspora
 		}
 
 		$logid = random_string(4);
-		$dest_url = ($public_batch ? $contact["batch"] : $contact["notify"]);
 
-		// Fetch the fcontact entry when there is missing data
-		// Will possibly happen when data is transmitted to a DFRN contact
-		if (empty($dest_url) && !empty($contact['addr'])) {
+		// We always try to use the data from the fcontact table.
+		// This is important for transmitting data to Friendica servers.
+		if (!empty($contact['addr'])) {
 			$fcontact = self::personByHandle($contact['addr']);
 			$dest_url = ($public_batch ? $fcontact["batch"] : $fcontact["notify"]);
+		} else {
+			$dest_url = ($public_batch ? $contact["batch"] : $contact["notify"]);
 		}
 
 		if (!$dest_url) {


### PR DESCRIPTION
We are having the situation to transmit data to Friendica servers via the Diaspora protocol. This is done under certain circumstances. For example when answering to public posts from users we aren't connected to, or when we send "participation" messages to items that had been transmitted via the Diaspora protocol (this can happen with relay posts).

We had the bug that we had used the DFRN endpoint to transmit Diaspora data - which can't work.

Now we always fetch the correct endpoints.