### PR TITLE
 vier: replace hard coded style paths

### DIFF
--- a/view/theme/vier/style.php
+++ b/view/theme/vier/style.php
@@ -18,32 +18,22 @@ if (empty($style)) {
 	$style = "plus";
 }
 
-if ($style == "flat") {
-	$stylecssfile = 'view/theme/vier/flat.css';
-} else if ($style == "netcolour") {
-	$stylecssfile = 'view/theme/vier/netcolour.css';
-} else if ($style == "breathe") {
-	$stylecssfile = 'view/theme/vier/breathe.css';
-} else if ($style == "plus") {
-	$stylecssfile = 'view/theme/vier/plus.css';
-} else if ($style == "dark") {
-	$stylecssfile = 'view/theme/vier/dark.css';
-} else if ($style == "plusminus") {
-	$stylecssfile = 'view/theme/vier/plusminus.css';
+$stylecss='';
+$modified = '';
+
+foreach (['style', $style] as $file) {
+	$stylecssfile = $THEMEPATH . DIRECTORY_SEPARATOR . $file .'.css';
+	if (file_exists($stylecssfile)) {
+		$stylecss .= file_get_contents($stylecssfile);
+		$stylemodified = filemtime($stylecssfile);
+		if ($stylemodified > $modified) {
+			$modified = $stylemodified;
+		}
+	} else {
+		//TODO: use LOGGER_ERROR?
+		logger('Error: missing file: "' . $stylecssfile .'" (userid: '. $uid .')');
+	}
 }
-
-if (file_exists($THEMEPATH."//style.css")) {
-	$stylecss = file_get_contents($THEMEPATH."//style.css")."\n";
-	$modified = filemtime($THEMEPATH."//style.css");
-}
-
-$stylemodified = filemtime($stylecssfile);
-$stylecss .= file_get_contents($stylecssfile);
-
-if ($stylemodified > $modified) {
-	$modified = $stylemodified;
-}
-
 $modified = gmdate('r', $modified);
 
 $etag = md5($stylecss);
@@ -54,7 +44,6 @@ header('ETag: "'.$etag.'"');
 header('Last-Modified: '.$modified);
 
 if (isset($_SERVER['HTTP_IF_MODIFIED_SINCE']) || isset($_SERVER['HTTP_IF_NONE_MATCH'])) {
-
 	$cached_modified = gmdate('r', strtotime($_SERVER['HTTP_IF_MODIFIED_SINCE']));
 	$cached_etag = str_replace(['"', "-gzip"], ['', ''],
 				stripslashes($_SERVER['HTTP_IF_NONE_MATCH']));

--- a/view/theme/vier/style.php
+++ b/view/theme/vier/style.php
@@ -18,7 +18,7 @@ if (empty($style)) {
 	$style = "plus";
 }
 
-$stylecss='';
+$stylecss = '';
 $modified = '';
 
 foreach (['style', $style] as $file) {


### PR DESCRIPTION
The Style "Shadow" works now as intended and don't produce "file_get_contents(): Filename cannot be empty" warnings.

I am not sure how to report intercepted errors.   The logger does not seem to be designed for this purpose.