### PR TITLE
Fix: Items with "uid=0" always had the "parent-uri" as "thr-parent"

### DIFF
--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -356,6 +356,10 @@ class Item extends BaseObject
 			}
 		}
 
+		if (!empty($item['thr-parent'])) {
+			$item['parent-uri'] = $item['thr-parent'];
+		}
+
 		if (x($item, 'gravity')) {
 			$item['gravity'] = intval($item['gravity']);
 		} elseif ($item['parent-uri'] === $item['uri']) {


### PR DESCRIPTION
See discussion here: https://forum.friendi.ca/display/4029d2ca105ab2371e0fe7d070172874