### PR TITLE
Edits to Vagrant dev env

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,7 +17,7 @@ Vagrant.configure(2) do |config|
   # Create a hostname, don't forget to put it to the `hosts` file
   # This will point to the server's default virtual host
   # TO DO: Make this work with virtualhost along-side xip.io URL
-  config.vm.hostname = "friendica.dev"
+  config.vm.hostname = "friendica.local"
 
   # Create a static IP
   config.vm.network :private_network, ip: server_ip
@@ -36,7 +36,7 @@ Vagrant.configure(2) do |config|
     vb.memory = server_memory
   end
 
-  # Enable provisioning with a shell script. 
+  # Enable provisioning with a shell script.
   config.vm.provision "shell", path: "./util/vagrant_provision.sh"
     # run: "always"
     # run: "once"


### PR DESCRIPTION
- more consistent use of hostname
- use .local hostname instead of .dev . Looks like Firefox is more
  happy with a self-signed certificate on .local than .dev
- add friendica.local to altname in certificate
- run composer install while provisioning

Firefox didn't show me the "Add exception" button while on ".dev" hostname. Works on ".local".
