### PR TITLE
Enable OAEP padding

### DIFF
--- a/mod/dfrn_confirm.php
+++ b/mod/dfrn_confirm.php
@@ -512,7 +512,7 @@ function dfrn_confirm_post(App $a, $handsfree = null)
 		// verify everything
 
 		$decrypted_source_url = "";
-		openssl_private_decrypt($source_url, $decrypted_source_url, $my_prvkey);
+		Crypto::opensslPrivateDecrypt($source_url, $decrypted_source_url, $my_prvkey);
 
 
 		if (!strlen($decrypted_source_url)) {
@@ -555,7 +555,7 @@ function dfrn_confirm_post(App $a, $handsfree = null)
 
 		if (strlen($aes_key)) {
 			$decrypted_aes_key = "";
-			openssl_private_decrypt($aes_key, $decrypted_aes_key, $my_prvkey);
+			Crypto::opensslPrivateDecrypt($aes_key, $decrypted_aes_key, $my_prvkey);
 			$dfrn_pubkey = openssl_decrypt($public_key, 'AES-256-CBC', $decrypted_aes_key);
 		} else {
 			$dfrn_pubkey = $public_key;

--- a/mod/dfrn_confirm.php
+++ b/mod/dfrn_confirm.php
@@ -192,11 +192,11 @@ function dfrn_confirm_post(App $a, $handsfree = null)
 
 			$my_url = System::baseUrl() . '/profile/' . $user['nickname'];
 
-			openssl_public_encrypt($my_url, $params['source_url'], $site_pubkey);
+			openssl_public_encrypt($my_url, $params['source_url'], $site_pubkey, OPENSSL_PKCS1_OAEP_PADDING);
 			$params['source_url'] = bin2hex($params['source_url']);
 
 			if ($aes_allow && function_exists('openssl_encrypt')) {
-				openssl_public_encrypt($src_aes_key, $params['aes_key'], $site_pubkey);
+				openssl_public_encrypt($src_aes_key, $params['aes_key'], $site_pubkey, OPENSSL_PKCS1_OAEP_PADDING);
 				$params['aes_key'] = bin2hex($params['aes_key']);
 				$params['public_key'] = bin2hex(openssl_encrypt($public_key, 'AES-256-CBC', $src_aes_key));
 			}

--- a/mod/dfrn_notify.php
+++ b/mod/dfrn_notify.php
@@ -12,6 +12,7 @@ use Friendica\Core\System;
 use Friendica\Database\DBM;
 use Friendica\Model\Contact;
 use Friendica\Protocol\DFRN;
+use Friendica\Util\Crypto;
 
 require_once 'include/items.php';
 require_once 'include/event.php';
@@ -161,7 +162,7 @@ function dfrn_notify_post(App $a) {
 
 		if ($dfrn_version >= 2.1) {
 			if ((($importer['duplex']) && strlen($importer['cprvkey'])) || (! strlen($importer['cpubkey']))) {
-				openssl_private_decrypt($rawkey, $final_key, $importer['cprvkey']);
+				Crypto::opensslPrivateDecrypt($rawkey, $final_key, $importer['cprvkey']);
 			} else {
 				openssl_public_decrypt($rawkey, $final_key, $importer['cpubkey']);
 			}
@@ -169,7 +170,7 @@ function dfrn_notify_post(App $a) {
 			if ((($importer['duplex']) && strlen($importer['cpubkey'])) || (! strlen($importer['cprvkey']))) {
 				openssl_public_decrypt($rawkey, $final_key, $importer['cpubkey']);
 			} else {
-				openssl_private_decrypt($rawkey, $final_key, $importer['cprvkey']);
+				Crypto::opensslPrivateDecrypt($rawkey, $final_key, $importer['cprvkey']);
 			}
 		}
 

--- a/mod/dfrn_notify.php
+++ b/mod/dfrn_notify.php
@@ -279,8 +279,8 @@ function dfrn_notify_content(App $a) {
 			openssl_private_encrypt($hash, $challenge, $prv_key);
 			openssl_private_encrypt($id_str, $encrypted_id, $prv_key);
 		} elseif (strlen($pub_key)) {
-			openssl_public_encrypt($hash, $challenge, $pub_key);
-			openssl_public_encrypt($id_str, $encrypted_id, $pub_key);
+			openssl_public_encrypt($hash, $challenge, $pub_key, OPENSSL_PKCS1_OAEP_PADDING);
+			openssl_public_encrypt($id_str, $encrypted_id, $pub_key, OPENSSL_PKCS1_OAEP_PADDING);
 		} else {
 			/// @TODO these kind of else-blocks are making the code harder to understand
 			$status = 1;

--- a/mod/dfrn_poll.php
+++ b/mod/dfrn_poll.php
@@ -467,8 +467,8 @@ function dfrn_poll_content(App $a)
 			$id_str = $my_id . '.' . mt_rand(1000, 9999);
 
 			if (($r[0]['duplex'] && strlen($r[0]['pubkey'])) || !strlen($r[0]['prvkey'])) {
-				openssl_public_encrypt($hash, $challenge, $r[0]['pubkey']);
-				openssl_public_encrypt($id_str, $encrypted_id, $r[0]['pubkey']);
+				openssl_public_encrypt($hash, $challenge, $r[0]['pubkey'], OPENSSL_PKCS1_OAEP_PADDING);
+				openssl_public_encrypt($id_str, $encrypted_id, $r[0]['pubkey'], OPENSSL_PKCS1_OAEP_PADDING);
 			} else {
 				openssl_private_encrypt($hash, $challenge, $r[0]['prvkey']);
 				openssl_private_encrypt($id_str, $encrypted_id, $r[0]['prvkey']);

--- a/mod/dfrn_poll.php
+++ b/mod/dfrn_poll.php
@@ -3,6 +3,7 @@
 /**
  * @file mod/dfrn_poll.php
  */
+
 use Friendica\App;
 use Friendica\Core\Config;
 use Friendica\Core\L10n;
@@ -11,6 +12,7 @@ use Friendica\Database\DBM;
 use Friendica\Module\Login;
 use Friendica\Protocol\DFRN;
 use Friendica\Protocol\OStatus;
+use Friendica\Util\Crypto;
 use Friendica\Util\Network;
 use Friendica\Util\XML;
 
@@ -169,8 +171,8 @@ function dfrn_poll_init(App $a)
 			$final_dfrn_id = '';
 
 			if (($contact['duplex']) && strlen($contact['prvkey'])) {
-				openssl_private_decrypt($sent_dfrn_id, $final_dfrn_id, $contact['prvkey']);
-				openssl_private_decrypt($challenge, $decoded_challenge, $contact['prvkey']);
+				Crypto::opensslPrivateDecrypt($sent_dfrn_id, $final_dfrn_id, $contact['prvkey']);
+				Crypto::opensslPrivateDecrypt($challenge, $decoded_challenge, $contact['prvkey']);
 			} else {
 				openssl_public_decrypt($sent_dfrn_id, $final_dfrn_id, $contact['pubkey']);
 				openssl_public_decrypt($challenge, $decoded_challenge, $contact['pubkey']);
@@ -261,8 +263,8 @@ function dfrn_poll_post(App $a)
 			$final_dfrn_id = '';
 
 			if ($contact['duplex'] && strlen($contact['prvkey'])) {
-				openssl_private_decrypt($sent_dfrn_id, $final_dfrn_id, $contact['prvkey']);
-				openssl_private_decrypt($challenge, $decoded_challenge, $contact['prvkey']);
+				Crypto::opensslPrivateDecrypt($sent_dfrn_id, $final_dfrn_id, $contact['prvkey']);
+				Crypto::opensslPrivateDecrypt($challenge, $decoded_challenge, $contact['prvkey']);
 			} else {
 				openssl_public_decrypt($sent_dfrn_id, $final_dfrn_id, $contact['pubkey']);
 				openssl_public_decrypt($challenge, $decoded_challenge, $contact['pubkey']);

--- a/mod/settings.php
+++ b/mod/settings.php
@@ -18,6 +18,7 @@ use Friendica\Model\GContact;
 use Friendica\Model\Group;
 use Friendica\Model\User;
 use Friendica\Protocol\Email;
+use Friendica\Util\Crypto;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Network;
 use Friendica\Util\Temporal;
@@ -270,7 +271,7 @@ function settings_post(App $a)
 
 					if (strlen($eacct['server'])) {
 						$dcrpass = '';
-						openssl_private_decrypt(hex2bin($eacct['pass']), $dcrpass, $a->user['prvkey']);
+						Crypto::opensslPrivateDecrypt(hex2bin($eacct['pass']), $dcrpass, $a->user['prvkey']);
 						$mbox = Email::connect($mb, $mail_user, $dcrpass);
 						unset($dcrpass);
 						if (!$mbox) {

--- a/mod/settings.php
+++ b/mod/settings.php
@@ -245,7 +245,7 @@ function settings_post(App $a)
 				}
 				if (strlen($mail_pass)) {
 					$pass = '';
-					openssl_public_encrypt($mail_pass, $pass, $a->user['pubkey']);
+					openssl_public_encrypt($mail_pass, $pass, $a->user['pubkey'], OPENSSL_PKCS1_OAEP_PADDING);
 					dba::update('mailacct', ['pass' => bin2hex($pass)], ['uid' => local_user()]);
 				}
 				$r = q("UPDATE `mailacct` SET `server` = '%s', `port` = %d, `ssltype` = '%s', `user` = '%s',

--- a/src/Network/Probe.php
+++ b/src/Network/Probe.php
@@ -20,8 +20,8 @@ use Friendica\Util\Crypto;
 use Friendica\Util\Network;
 use Friendica\Util\XML;
 use dba;
-use DOMXPath;
 use DOMDocument;
+use DOMXPath;
 
 require_once 'include/dba.php';
 
@@ -1011,7 +1011,7 @@ class Probe
 			return false;
 		}
 
-		$xpath = new DomXPath($doc);
+		$xpath = new DOMXPath($doc);
 
 		$vcards = $xpath->query("//div[contains(concat(' ', @class, ' '), ' vcard ')]");
 		if (!is_object($vcards)) {
@@ -1325,7 +1325,7 @@ class Probe
 			return false;
 		}
 
-		$xpath = new DomXPath($doc);
+		$xpath = new DOMXPath($doc);
 
 		$data = [];
 
@@ -1437,7 +1437,7 @@ class Probe
 			return false;
 		}
 
-		$xpath = new DomXPath($doc);
+		$xpath = new DOMXPath($doc);
 
 		//$feeds = $xpath->query("/html/head/link[@type='application/rss+xml']");
 		$feeds = $xpath->query("/html/head/link[@type='application/rss+xml' and @rel='alternate']");

--- a/src/Network/Probe.php
+++ b/src/Network/Probe.php
@@ -9,10 +9,9 @@ namespace Friendica\Network;
  * @brief Functions for probing URL
  */
 
-use Friendica\App;
-use Friendica\Core\System;
 use Friendica\Core\Cache;
 use Friendica\Core\Config;
+use Friendica\Core\System;
 use Friendica\Database\DBM;
 use Friendica\Model\Profile;
 use Friendica\Protocol\Email;
@@ -20,7 +19,6 @@ use Friendica\Protocol\Feed;
 use Friendica\Util\Crypto;
 use Friendica\Util\Network;
 use Friendica\Util\XML;
-
 use dba;
 use DOMXPath;
 use DOMDocument;
@@ -1553,7 +1551,7 @@ class Probe
 		if (DBM::is_result($x) && DBM::is_result($r)) {
 			$mailbox = Email::constructMailboxName($r[0]);
 			$password = '';
-			openssl_private_decrypt(hex2bin($r[0]['pass']), $password, $x[0]['prvkey']);
+			Crypto::opensslPrivateDecrypt(hex2bin($r[0]['pass']), $password, $x[0]['prvkey']);
 			$mbox = Email::connect($mailbox, $r[0]['user'], $password);
 			if (!$mbox) {
 				return false;

--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -23,7 +23,6 @@ use Friendica\Model\GContact;
 use Friendica\Model\Group;
 use Friendica\Model\Item;
 use Friendica\Model\Profile;
-use Friendica\Model\Term;
 use Friendica\Model\User;
 use Friendica\Object\Image;
 use Friendica\Protocol\OStatus;
@@ -1254,8 +1253,8 @@ class DFRN
 			openssl_public_decrypt($sent_dfrn_id, $final_dfrn_id, $contact['pubkey']);
 			openssl_public_decrypt($challenge, $postvars['challenge'], $contact['pubkey']);
 		} else {
-			openssl_private_decrypt($sent_dfrn_id, $final_dfrn_id, $contact['prvkey']);
-			openssl_private_decrypt($challenge, $postvars['challenge'], $contact['prvkey']);
+			Crypto::opensslPrivateDecrypt($sent_dfrn_id, $final_dfrn_id, $contact['prvkey']);
+			Crypto::opensslPrivateDecrypt($challenge, $postvars['challenge'], $contact['prvkey']);
 		}
 
 		$final_dfrn_id = substr($final_dfrn_id, 0, strpos($final_dfrn_id, '.'));

--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -1312,7 +1312,7 @@ class DFRN
 					|| ($owner['page-flags'] == PAGE_COMMUNITY && strlen($contact['pubkey']))
 					|| ($contact['rel'] == CONTACT_IS_SHARING && strlen($contact['pubkey']))
 				) {
-					openssl_public_encrypt($key, $postvars['key'], $contact['pubkey']);
+					openssl_public_encrypt($key, $postvars['key'], $contact['pubkey'], OPENSSL_PKCS1_OAEP_PADDING);
 				} else {
 					openssl_private_encrypt($key, $postvars['key'], $contact['prvkey']);
 				}
@@ -1320,7 +1320,7 @@ class DFRN
 				if (($contact['duplex'] && strlen($contact['prvkey'])) || ($owner['page-flags'] == PAGE_COMMUNITY)) {
 					openssl_private_encrypt($key, $postvars['key'], $contact['prvkey']);
 				} else {
-					openssl_public_encrypt($key, $postvars['key'], $contact['pubkey']);
+					openssl_public_encrypt($key, $postvars['key'], $contact['pubkey'], OPENSSL_PKCS1_OAEP_PADDING);
 				}
 			}
 

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -292,7 +292,7 @@ class Diaspora
 			$ciphertext = base64_decode($data->encrypted_magic_envelope);
 
 			$outer_key_bundle = '';
-			@openssl_private_decrypt($encrypted_aes_key_bundle, $outer_key_bundle, $importer['prvkey']);
+			@Crypto::opensslPrivateDecrypt($encrypted_aes_key_bundle, $outer_key_bundle, $importer['prvkey']);
 			$j_outer_key_bundle = json_decode($outer_key_bundle);
 
 			if (!is_object($j_outer_key_bundle)) {
@@ -395,7 +395,7 @@ class Diaspora
 			$ciphertext = base64_decode($encrypted_header->ciphertext);
 
 			$outer_key_bundle = '';
-			openssl_private_decrypt($encrypted_aes_key_bundle, $outer_key_bundle, $importer['prvkey']);
+			Crypto::opensslPrivateDecrypt($encrypted_aes_key_bundle, $outer_key_bundle, $importer['prvkey']);
 
 			$j_outer_key_bundle = json_decode($outer_key_bundle);
 

--- a/src/Worker/OnePoll.php
+++ b/src/Worker/OnePoll.php
@@ -12,6 +12,7 @@ use Friendica\Model\Contact;
 use Friendica\Model\Item;
 use Friendica\Protocol\Email;
 use Friendica\Protocol\PortableContact;
+use Friendica\Util\Crypto;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Network;
 use Friendica\Util\XML;
@@ -258,8 +259,8 @@ class OnePoll
 			$final_dfrn_id = '';
 
 			if ($contact['duplex'] && strlen($contact['prvkey'])) {
-				openssl_private_decrypt($sent_dfrn_id, $final_dfrn_id, $contact['prvkey']);
-				openssl_private_decrypt($challenge, $postvars['challenge'], $contact['prvkey']);
+				Crypto::opensslPrivateDecrypt($sent_dfrn_id, $final_dfrn_id, $contact['prvkey']);
+				Crypto::opensslPrivateDecrypt($challenge, $postvars['challenge'], $contact['prvkey']);
 			} else {
 				openssl_public_decrypt($sent_dfrn_id, $final_dfrn_id, $contact['pubkey']);
 				openssl_public_decrypt($challenge, $postvars['challenge'], $contact['pubkey']);
@@ -350,7 +351,7 @@ class OnePoll
 			if (DBM::is_result($user) && DBM::is_result($mailconf)) {
 				$mailbox = Email::constructMailboxName($mailconf);
 				$password = '';
-				openssl_private_decrypt(hex2bin($mailconf['pass']), $password, $user['prvkey']);
+				Crypto::opensslPrivateDecrypt(hex2bin($mailconf['pass']), $password, $user['prvkey']);
 				$mbox = Email::connect($mailbox, $mailconf['user'], $password);
 				unset($password);
 				logger("Mail: Connect to " . $mailconf['user']);


### PR DESCRIPTION
Closes #4442

Redux of #4643 

Enabling OAEP was easy.

Making sure that Friendica nodes would stay compatible before and after the update (and with Diaspora!) was not.

Thankfully @paragonie-scott came to the rescue with a padding-agnostic `openssl_private_decrypt` function.