### PR TITLE
Hotfix: Bump database version number after RC merge

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -41,7 +41,7 @@ define('FRIENDICA_PLATFORM',     'Friendica');
 define('FRIENDICA_CODENAME',     'The Tazmans Flax-lily');
 define('FRIENDICA_VERSION',      '2018-05-dev');
 define('DFRN_PROTOCOL_VERSION',  '2.23');
-define('DB_UPDATE_VERSION',      1256);
+define('DB_UPDATE_VERSION',      1257);
 define('NEW_UPDATE_ROUTINE_VERSION', 1170);
 
 /**

--- a/database.sql
+++ b/database.sql
@@ -1,6 +1,6 @@
 -- ------------------------------------------
 -- Friendica 2018-05-dev (The Tazmans Flax-lily)
--- DB_UPDATE_VERSION 1256
+-- DB_UPDATE_VERSION 1257
 -- ------------------------------------------
 
 


### PR DESCRIPTION
During the RC period, database structure changes have been introduced in both parallel branches `develop` and `3.6-rc` and both incremented the database structure version number to 1256 based on the previous common version number.

When we merged the RC branch into the develop branch, database structure changes have been introduced but the version number hasn't been incremented, which would prevent systems from updating their database schema.

This corrects that unfortunate fact.