### PR TITLE
Fix PHP cannot take a shell script

### DIFF
--- a/README.translate.md
+++ b/README.translate.md
@@ -37,7 +37,7 @@ Assuming you want to convert the German localization which is placed in view/lan
     2. Execute the po2php command, which will place the translation
        in the strings.php file that is used by friendica.
 
-       $> php bin/console po2php view/lang/de/messages.po
+       $> php bin/console.php po2php view/lang/de/messages.po
 
        The output of the script will be placed at view/lang/de/strings.php where
        friendica is expecting it, so you can test your translation immediately.
@@ -92,7 +92,7 @@ To update the translation files after you have translated strings of e.g. Espera
 
 And then use the `po2php` command described above to convert the `messages.po` file to the `strings.php` file Friendica is loading.
 
-    $> php bin/console po2php view/lang/eo/messages.po
+    $> php bin/console.php po2php view/lang/eo/messages.po
 
 Afterwards, just commit the two changed files to a feature branch of your Friendica repository, push the changes to github and open a pull request for your changes.
 

--- a/doc/Developer-How-To-Move-Classes-to-src.md
+++ b/doc/Developer-How-To-Move-Classes-to-src.md
@@ -94,7 +94,7 @@ Please remove all the `require_once` mentions of the former file, as they will p
 
 ## Miscellaneous tips
 
-When you are done with moving the class, please run `php bin/console typo` from the Friendica base directory to check for obvious mistakes.
+When you are done with moving the class, please run `php bin/console.php typo` from the Friendica base directory to check for obvious mistakes.
 Howevever, this tool isn't bullet-proof, and a staging install of Friendica is recommended to test your class move without impairing your production server if you host one.
 
 Most of Friendica processes are run in the background, so make sure to turn on your debug log to check for errors that wouldn't show up while simply browsing Friendica.

--- a/doc/Github.md
+++ b/doc/Github.md
@@ -70,7 +70,7 @@ Don't hesitate to ask us in case of doubt.
 3. Check your code for typos.
 There is a console command called *typo* for this.
 
-	$> php bin/console typo
+	$> php bin/console.php typo
 
 Check out how to work with [our Vagrant](help/Vagrant) to save a lot of setup time!
 

--- a/doc/translations.md
+++ b/doc/translations.md
@@ -39,7 +39,7 @@ Assuming you want to convert the German localization which is placed in view/lan
     2. Execute the po2php command, which will place the translation
        in the strings.php file that is used by friendica.
 
-       $> php bin/console po2php view/lang/de/messages.po
+       $> php bin/console.php po2php view/lang/de/messages.po
 
        The output of the script will be placed at view/lang/de/strings.php where
        friendica is expecting it, so you can test your translation immediately.
@@ -94,7 +94,7 @@ To update the translation files after you have translated strings of e.g. Espera
 
 And then use the `po2php` command described above to convert the `messages.po` file to the `strings.php` file Friendica is loading.
 
-    $> php bin/console po2php view/lang/eo/messages.po
+    $> php bin/console.php po2php view/lang/eo/messages.po
 
 Afterwards, just commit the two changed files to a feature branch of your Friendica repository, push the changes to github and open a pull request for your changes.
 

--- a/mod/admin.php
+++ b/mod/admin.php
@@ -718,7 +718,7 @@ function admin_page_summary(App $a)
 	$warningtext = [];
 	if (DBM::is_result($r)) {
 		$showwarning = true;
-		$warningtext[] = L10n::t('Your DB still runs with MyISAM tables. You should change the engine type to InnoDB. As Friendica will use InnoDB only features in the future, you should change this! See <a href="%s">here</a> for a guide that may be helpful converting the table engines. You may also use the command <tt>php bin/console dbstructure toinnodb</tt> of your Friendica installation for an automatic conversion.<br />', 'https://dev.mysql.com/doc/refman/5.7/en/converting-tables-to-innodb.html');
+		$warningtext[] = L10n::t('Your DB still runs with MyISAM tables. You should change the engine type to InnoDB. As Friendica will use InnoDB only features in the future, you should change this! See <a href="%s">here</a> for a guide that may be helpful converting the table engines. You may also use the command <tt>php bin/console.php dbstructure toinnodb</tt> of your Friendica installation for an automatic conversion.<br />', 'https://dev.mysql.com/doc/refman/5.7/en/converting-tables-to-innodb.html');
 	}
 	// Check if github.com/friendica/master/VERSION is higher then
 	// the local version of Friendica. Check is opt-in, source may be master or devel branch
@@ -735,7 +735,7 @@ function admin_page_summary(App $a)
 	}
 	if (Config::get('system', 'dbupdate') == DB_UPDATE_FAILED) {
 		$showwarning = true;
-		$warningtext[] = L10n::t('The database update failed. Please run "php bin/console dbstructure update" from the command line and have a look at the errors that might appear.');
+		$warningtext[] = L10n::t('The database update failed. Please run "php bin/console.php dbstructure update" from the command line and have a look at the errors that might appear.');
 	}
 
 	$last_worker_call = Config::get('system', 'last_poller_execution', false);

--- a/util/README
+++ b/util/README
@@ -1,6 +1,6 @@
 Utilities
 
-php bin/console typo - is a crude syntax checker to avoid checking in files with simple
+php bin/console.php typo - is a crude syntax checker to avoid checking in files with simple
 typos. It basically just loads each of our project files at once. Run from
 cmdline and see if any parsing errors are reported.
 
@@ -8,7 +8,7 @@ cmdline and see if any parsing errors are reported.
 
 Internationalisation
 
-php bin/console extract - extracts translatable strings from our project files. It
+php bin/console.php extract - extracts translatable strings from our project files. It
 currently doesn't pick up strings in other libraries we might be using such as
 the HTML parsers.
 
@@ -107,7 +107,7 @@ Xgettext and .po workflow
 	of the many .po editors out there, like QtLinguist
 
 5. run
-	$ php bin/console po2php view/lang/<language>/messages.po
+	$ php bin/console.php po2php view/lang/<language>/messages.po
  	to create the strings.php file
 
 When strings are added or modified in source, you could run
@@ -117,4 +117,4 @@ When strings are added or modified in source, you could run
 
 If you already translated Friendica using strings.php, you could import your old
 translation to messages.po. Run:
-$ php bin/console php2po view/lang/<language>/strings.php
+$ php bin/console.php php2po view/lang/<language>/strings.php


### PR DESCRIPTION
Fix part of https://github.com/friendica/friendica/issues/4665
`php [shell file]` does not work, so use `php [php file]` instead.
`php bin/console.php` is more robust than e.g. `bin/console` which does not work on Windows, or *nix systems without Bash