### PR TITLE
Handle URL with unicode characters

### DIFF
--- a/src/Util/Network.php
+++ b/src/Util/Network.php
@@ -79,6 +79,18 @@ class Network
 
 		$a = get_app();
 
+		$parts = parse_url($url);
+		$path_parts = explode('/', $parts['path']);
+		foreach ($path_parts as $part) {
+		        if (strlen($part) <> mb_strlen($part)) {
+				$parts2[] = rawurlencode($part);
+		        } else {
+		                $parts2[] = $part;
+		        }
+		}
+		$parts['path'] =  implode('/', $parts2);
+		$url = self::unparseURL($parts);
+
 		if (self::isUrlBlocked($url)) {
 			logger('domain of ' . $url . ' is blocked', LOGGER_DATA);
 			return $ret;


### PR DESCRIPTION
There had been a problem with URL that contained unicode characters in the path part. This is fixed now.