### PR TITLE
Avoid the warning of an unitialized variable in .htconfig.php

### DIFF
--- a/src/Core/Console/Config.php
+++ b/src/Core/Console/Config.php
@@ -79,6 +79,8 @@ HELP;
 
 	protected function doExecute()
 	{
+		$a = get_app();
+
 		if ($this->getOption('v')) {
 			$this->out('Executable: ' . $this->executable);
 			$this->out('Class: ' . __CLASS__);

--- a/src/Core/Console/DatabaseStructure.php
+++ b/src/Core/Console/DatabaseStructure.php
@@ -39,6 +39,8 @@ HELP;
 
 	protected function doExecute()
 	{
+		$a = get_app();
+
 		if ($this->getOption('v')) {
 			$this->out('Class: ' . __CLASS__);
 			$this->out('Arguments: ' . var_export($this->args, true));

--- a/src/Core/Console/GlobalCommunityBlock.php
+++ b/src/Core/Console/GlobalCommunityBlock.php
@@ -39,6 +39,8 @@ HELP;
 
 	protected function doExecute()
 	{
+		$a = get_app();
+
 		if ($this->getOption('v')) {
 			$this->out('Class: ' . __CLASS__);
 			$this->out('Arguments: ' . var_export($this->args, true));

--- a/src/Core/Console/GlobalCommunitySilence.php
+++ b/src/Core/Console/GlobalCommunitySilence.php
@@ -47,6 +47,8 @@ HELP;
 
 	protected function doExecute()
 	{
+		$a = get_app();
+
 		if ($this->getOption('v')) {
 			$this->out('Class: ' . __CLASS__);
 			$this->out('Arguments: ' . var_export($this->args, true));

--- a/src/Core/Console/Maintenance.php
+++ b/src/Core/Console/Maintenance.php
@@ -47,6 +47,8 @@ HELP;
 
 	protected function doExecute()
 	{
+		$a = get_app();
+
 		if ($this->getOption('v')) {
 			$this->out('Class: ' . __CLASS__);
 			$this->out('Arguments: ' . var_export($this->args, true));


### PR DESCRIPTION
The warning occurs because .htconfig.php is loaded when ```$a``` isn't initialized. So we have to load it before including the file.