### PR TITLE
Fix sending messages to relay servers

### DIFF
--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -3222,7 +3222,7 @@ class Diaspora
 
 		// We always try to use the data from the fcontact table.
 		// This is important for transmitting data to Friendica servers.
-		if (!empty($contact['addr'])) {
+		if (!empty($contact['addr']) && ($contact['network'] != NETWORK_DIASPORA)) {
 			$fcontact = self::personByHandle($contact['addr']);
 			$dest_url = ($public_batch ? $fcontact["batch"] : $fcontact["notify"]);
 		} else {


### PR DESCRIPTION
Relay contacts are no relay contacts, so ```personByHandle``` couldn't return any data. So we only execute this now when the target contact isn't Diaspora (where these values should be fetched already)