### PR TITLE
 Added server discovery for their relais configuration

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -41,7 +41,7 @@ define('FRIENDICA_PLATFORM',     'Friendica');
 define('FRIENDICA_CODENAME',     'The Tazmans Flax-lily');
 define('FRIENDICA_VERSION',      '2018-05-dev');
 define('DFRN_PROTOCOL_VERSION',  '2.23');
-define('DB_UPDATE_VERSION',      1258);
+define('DB_UPDATE_VERSION',      1259);
 define('NEW_UPDATE_ROUTINE_VERSION', 1170);
 
 /**

--- a/database.sql
+++ b/database.sql
@@ -1,6 +1,6 @@
 -- ------------------------------------------
 -- Friendica 2018-05-dev (The Tazmans Flax-lily)
--- DB_UPDATE_VERSION 1258
+-- DB_UPDATE_VERSION 1259
 -- ------------------------------------------
 
 
@@ -397,12 +397,24 @@ CREATE TABLE IF NOT EXISTS `gserver` (
 	`noscrape` varchar(255) NOT NULL DEFAULT '' COMMENT '',
 	`network` char(4) NOT NULL DEFAULT '' COMMENT '',
 	`platform` varchar(255) NOT NULL DEFAULT '' COMMENT '',
+	`relay-subscribe` boolean NOT NULL DEFAULT '0' COMMENT 'Has the server subscribed to the relay system',
+	`relay-scope` varchar(10) NOT NULL DEFAULT '' COMMENT 'The scope of messages that the server wants to get',
 	`created` datetime NOT NULL DEFAULT '0001-01-01 00:00:00' COMMENT '',
 	`last_poco_query` datetime DEFAULT '0001-01-01 00:00:00' COMMENT '',
 	`last_contact` datetime DEFAULT '0001-01-01 00:00:00' COMMENT '',
 	`last_failure` datetime DEFAULT '0001-01-01 00:00:00' COMMENT '',
 	 PRIMARY KEY(`id`),
 	 UNIQUE INDEX `nurl` (`nurl`(190))
+) DEFAULT COLLATE utf8mb4_general_ci;
+
+--
+-- TABLE gserver-tag
+--
+CREATE TABLE IF NOT EXISTS `gserver-tag` (
+	`gserver-id` int unsigned NOT NULL DEFAULT 0 COMMENT 'The id of the gserver',
+	`tag` varchar(100) NOT NULL DEFAULT '' COMMENT 'Tag that the server has subscribed',
+	 PRIMARY KEY(`gserver-id`,`tag`),
+	 INDEX `tag` (`tag`)
 ) DEFAULT COLLATE utf8mb4_general_ci;
 
 --

--- a/src/Database/DBStructure.php
+++ b/src/Database/DBStructure.php
@@ -1074,6 +1074,8 @@ class DBStructure
 						"noscrape" => ["type" => "varchar(255)", "not null" => "1", "default" => "", "comment" => ""],
 						"network" => ["type" => "char(4)", "not null" => "1", "default" => "", "comment" => ""],
 						"platform" => ["type" => "varchar(255)", "not null" => "1", "default" => "", "comment" => ""],
+						"relay-subscribe" => ["type" => "boolean", "not null" => "1", "default" => "0", "comment" => "Has the server subscribed to the relay system"],
+						"relay-scope" => ["type" => "varchar(10)", "not null" => "1", "default" => "", "comment" => "The scope of messages that the server wants to get"],
 						"created" => ["type" => "datetime", "not null" => "1", "default" => NULL_DATE, "comment" => ""],
 						"last_poco_query" => ["type" => "datetime", "default" => NULL_DATE, "comment" => ""],
 						"last_contact" => ["type" => "datetime", "default" => NULL_DATE, "comment" => ""],
@@ -1082,6 +1084,17 @@ class DBStructure
 				"indexes" => [
 						"PRIMARY" => ["id"],
 						"nurl" => ["UNIQUE", "nurl(190)"],
+						]
+				];
+		$database["gserver-tag"] = [
+				"comment" => "Tags that the server has subscribed",
+				"fields" => [
+						"gserver-id" => ["type" => "int unsigned", "not null" => "1", "default" => "0", "relation" => ["gserver" => "id"], "primary" => "1", "comment" => "The id of the gserver"],
+						"tag" => ["type" => "varchar(100)", "not null" => "1", "default" => "", "primary" => "1", "comment" => "Tag that the server has subscribed"],
+						],
+				"indexes" => [
+						"PRIMARY" => ["gserver-id", "tag"],
+						"tag" => ["tag"],
 						]
 				];
 		$database["hook"] = [

--- a/src/Protocol/PortableContact.php
+++ b/src/Protocol/PortableContact.php
@@ -1378,7 +1378,7 @@ class PortableContact
 			dba::insert('gserver', $fields);
 		}
 
-		if (in_array($fields['network'], [NETWORK_DFRN, NETWORK_DIASPORA])) {
+		if (!$failure && in_array($fields['network'], [NETWORK_DFRN, NETWORK_DIASPORA])) {
 			self::discoverRelay(server_url);
 		}
 
@@ -1410,8 +1410,10 @@ class PortableContact
 		dba::update('gserver', $fields, ['id' => $gserver['id']]);
 
 		dba::delete('gserver-tag', ['gserver-id' => $gserver['id']]);
-		foreach ($data->tags as $tag) {
-			dba::insert('gserver-tag', ['gserver-id' => $gserver['id'], 'tag' => $tag]);
+		if ($data->scope == 'tags') {
+			foreach ($data->tags as $tag) {
+				dba::insert('gserver-tag', ['gserver-id' => $gserver['id'], 'tag' => $tag]);
+			}
 		}
 	}
 

--- a/src/Protocol/PortableContact.php
+++ b/src/Protocol/PortableContact.php
@@ -1379,7 +1379,7 @@ class PortableContact
 		}
 
 		if (!$failure && in_array($fields['network'], [NETWORK_DFRN, NETWORK_DIASPORA])) {
-			self::discoverRelay(server_url);
+			self::discoverRelay($server_url);
 		}
 
 		logger("End discovery for server " . $server_url, LOGGER_DEBUG);
@@ -1401,13 +1401,15 @@ class PortableContact
 			return;
 		}
 
-		$gserver = dba::selectFirst('gserver', ['id'], ['nurl' => normalise_link($server_url)]);
+		$gserver = dba::selectFirst('gserver', ['id', 'relay-subscribe', 'relay-scope'], ['nurl' => normalise_link($server_url)]);
 		if (!DBM::is_result($gserver)) {
 			return;
 		}
 
-		$fields = ['relay-subscribe' => $data->subscribe, 'relay-scope' => $data->scope];
-		dba::update('gserver', $fields, ['id' => $gserver['id']]);
+		if (($gserver['relay-subscribe'] != $data->subscribe) || ($gserver['relay-scope'] != $data->scope)) {
+			$fields = ['relay-subscribe' => $data->subscribe, 'relay-scope' => $data->scope];
+			dba::update('gserver', $fields, ['id' => $gserver['id']]);
+		}
 
 		dba::delete('gserver-tag', ['gserver-id' => $gserver['id']]);
 		if ($data->scope == 'tags') {


### PR DESCRIPTION
This is the first step of a slightly larger work. We already support sending stuff to relay servers so that our public content is distributed to other systems, although they hadn't subscribed to us.

Additionally there is a setup which content we want to have.

Now - as a first step - we fetch the relay configuration of the remote servers. The next step will be to send our posts depending on this data directly to the servers, without using a relay server. This is a better solution since the other solution depends upon remote servers that we don't have under our control. Additionally they rely upon publishing your data to the-federation.info.