### PR TITLE
regenerated the master messages.po file

### DIFF
--- a/bin/run_xgettext.sh
+++ b/bin/run_xgettext.sh
@@ -45,7 +45,7 @@ case "$MODE" in
 	;;
 	'default')
 		cd "$FULLPATH/.."
-		OUTFILE="$FULLPATH/messages.po"
+		OUTFILE="$FULLPATH/../util/messages.po"
 		FINDSTARTDIR="."
 		# skip addon folder
 		FINDOPTS="( -wholename */addon -or -wholename */addons-extra -or -wholename */smarty3 ) -prune -o"

--- a/util/messages.po
+++ b/util/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-03-05 16:37+0100\n"
+"POT-Creation-Date: 2018-03-28 08:41+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -36,253 +36,728 @@ msgid ""
 "form has been opened for too long (>3 hours) before submitting it."
 msgstr ""
 
-#: include/enotify.php:33
+#: include/api.php:1199
+#, php-format
+msgid "Daily posting limit of %d post reached. The post was rejected."
+msgid_plural "Daily posting limit of %d posts reached. The post was rejected."
+msgstr[0] ""
+msgstr[1] ""
+
+#: include/api.php:1223
+#, php-format
+msgid "Weekly posting limit of %d post reached. The post was rejected."
+msgid_plural "Weekly posting limit of %d posts reached. The post was rejected."
+msgstr[0] ""
+msgstr[1] ""
+
+#: include/api.php:1247
+#, php-format
+msgid "Monthly posting limit of %d post reached. The post was rejected."
+msgstr ""
+
+#: include/api.php:4400 mod/photos.php:88 mod/photos.php:194 mod/photos.php:722
+#: mod/photos.php:1149 mod/photos.php:1166 mod/photos.php:1684
+#: mod/profile_photo.php:85 mod/profile_photo.php:93 mod/profile_photo.php:101
+#: mod/profile_photo.php:211 mod/profile_photo.php:302
+#: mod/profile_photo.php:312 src/Model/User.php:539 src/Model/User.php:547
+#: src/Model/User.php:555
+msgid "Profile Photos"
+msgstr ""
+
+#: include/conversation.php:144 include/conversation.php:282
+#: include/text.php:1724 src/Model/Item.php:1795
+msgid "event"
+msgstr ""
+
+#: include/conversation.php:147 include/conversation.php:157
+#: include/conversation.php:285 include/conversation.php:294
+#: mod/subthread.php:97 mod/tagger.php:72 src/Model/Item.php:1793
+#: src/Protocol/Diaspora.php:2006
+msgid "status"
+msgstr ""
+
+#: include/conversation.php:152 include/conversation.php:290
+#: include/text.php:1726 mod/subthread.php:97 mod/tagger.php:72
+#: src/Model/Item.php:1793
+msgid "photo"
+msgstr ""
+
+#: include/conversation.php:164 src/Model/Item.php:1666
+#: src/Protocol/Diaspora.php:2002
+#, php-format
+msgid "%1$s likes %2$s's %3$s"
+msgstr ""
+
+#: include/conversation.php:167 src/Model/Item.php:1671
+#, php-format
+msgid "%1$s doesn't like %2$s's %3$s"
+msgstr ""
+
+#: include/conversation.php:170
+#, php-format
+msgid "%1$s attends %2$s's %3$s"
+msgstr ""
+
+#: include/conversation.php:173
+#, php-format
+msgid "%1$s doesn't attend %2$s's %3$s"
+msgstr ""
+
+#: include/conversation.php:176
+#, php-format
+msgid "%1$s attends maybe %2$s's %3$s"
+msgstr ""
+
+#: include/conversation.php:209 mod/dfrn_confirm.php:431
+#: src/Protocol/Diaspora.php:2477
+#, php-format
+msgid "%1$s is now friends with %2$s"
+msgstr ""
+
+#: include/conversation.php:250
+#, php-format
+msgid "%1$s poked %2$s"
+msgstr ""
+
+#: include/conversation.php:304 mod/tagger.php:110
+#, php-format
+msgid "%1$s tagged %2$s's %3$s with %4$s"
+msgstr ""
+
+#: include/conversation.php:331
+msgid "post/item"
+msgstr ""
+
+#: include/conversation.php:332
+#, php-format
+msgid "%1$s marked %2$s's %3$s as favorite"
+msgstr ""
+
+#: include/conversation.php:605 mod/photos.php:1501 mod/profiles.php:354
+msgid "Likes"
+msgstr ""
+
+#: include/conversation.php:605 mod/photos.php:1501 mod/profiles.php:358
+msgid "Dislikes"
+msgstr ""
+
+#: include/conversation.php:606 include/conversation.php:1680
+#: mod/photos.php:1502
+msgid "Attending"
+msgid_plural "Attending"
+msgstr[0] ""
+msgstr[1] ""
+
+#: include/conversation.php:606 mod/photos.php:1502
+msgid "Not attending"
+msgstr ""
+
+#: include/conversation.php:606 mod/photos.php:1502
+msgid "Might attend"
+msgstr ""
+
+#: include/conversation.php:744 mod/photos.php:1569 src/Object/Post.php:178
+msgid "Select"
+msgstr ""
+
+#: include/conversation.php:745 mod/photos.php:1570 mod/admin.php:1731
+#: mod/contacts.php:830 mod/contacts.php:1035 mod/settings.php:738
+#: src/Object/Post.php:179
+msgid "Delete"
+msgstr ""
+
+#: include/conversation.php:777 src/Object/Post.php:357 src/Object/Post.php:358
+#, php-format
+msgid "View %s's profile @ %s"
+msgstr ""
+
+#: include/conversation.php:789 src/Object/Post.php:345
+msgid "Categories:"
+msgstr ""
+
+#: include/conversation.php:790 src/Object/Post.php:346
+msgid "Filed under:"
+msgstr ""
+
+#: include/conversation.php:797 src/Object/Post.php:371
+#, php-format
+msgid "%s from %s"
+msgstr ""
+
+#: include/conversation.php:812
+msgid "View in context"
+msgstr ""
+
+#: include/conversation.php:814 include/conversation.php:1353
+#: mod/wallmessage.php:145 mod/editpost.php:125 mod/message.php:264
+#: mod/message.php:433 mod/photos.php:1473 src/Object/Post.php:396
+msgid "Please wait"
+msgstr ""
+
+#: include/conversation.php:885
+msgid "remove"
+msgstr ""
+
+#: include/conversation.php:889
+msgid "Delete Selected Items"
+msgstr ""
+
+#: include/conversation.php:1059 view/theme/frio/theme.php:352
+msgid "Follow Thread"
+msgstr ""
+
+#: include/conversation.php:1060 src/Model/Contact.php:640
+msgid "View Status"
+msgstr ""
+
+#: include/conversation.php:1061 include/conversation.php:1077
+#: mod/allfriends.php:73 mod/suggest.php:82 mod/match.php:89
+#: mod/directory.php:160 mod/dirfind.php:217 src/Model/Contact.php:580
+#: src/Model/Contact.php:593 src/Model/Contact.php:641
+msgid "View Profile"
+msgstr ""
+
+#: include/conversation.php:1062 src/Model/Contact.php:642
+msgid "View Photos"
+msgstr ""
+
+#: include/conversation.php:1063 src/Model/Contact.php:643
+msgid "Network Posts"
+msgstr ""
+
+#: include/conversation.php:1064 src/Model/Contact.php:644
+msgid "View Contact"
+msgstr ""
+
+#: include/conversation.php:1065 src/Model/Contact.php:646
+msgid "Send PM"
+msgstr ""
+
+#: include/conversation.php:1069 src/Model/Contact.php:647
+msgid "Poke"
+msgstr ""
+
+#: include/conversation.php:1074 mod/allfriends.php:74 mod/suggest.php:83
+#: mod/match.php:90 mod/contacts.php:596 mod/dirfind.php:218 mod/follow.php:143
+#: src/Content/Widget.php:61 src/Model/Contact.php:594
+msgid "Connect/Follow"
+msgstr ""
+
+#: include/conversation.php:1193
+#, php-format
+msgid "%s likes this."
+msgstr ""
+
+#: include/conversation.php:1196
+#, php-format
+msgid "%s doesn't like this."
+msgstr ""
+
+#: include/conversation.php:1199
+#, php-format
+msgid "%s attends."
+msgstr ""
+
+#: include/conversation.php:1202
+#, php-format
+msgid "%s doesn't attend."
+msgstr ""
+
+#: include/conversation.php:1205
+#, php-format
+msgid "%s attends maybe."
+msgstr ""
+
+#: include/conversation.php:1216
+msgid "and"
+msgstr ""
+
+#: include/conversation.php:1222
+#, php-format
+msgid "and %d other people"
+msgstr ""
+
+#: include/conversation.php:1231
+#, php-format
+msgid "<span  %1$s>%2$d people</span> like this"
+msgstr ""
+
+#: include/conversation.php:1232
+#, php-format
+msgid "%s like this."
+msgstr ""
+
+#: include/conversation.php:1235
+#, php-format
+msgid "<span  %1$s>%2$d people</span> don't like this"
+msgstr ""
+
+#: include/conversation.php:1236
+#, php-format
+msgid "%s don't like this."
+msgstr ""
+
+#: include/conversation.php:1239
+#, php-format
+msgid "<span  %1$s>%2$d people</span> attend"
+msgstr ""
+
+#: include/conversation.php:1240
+#, php-format
+msgid "%s attend."
+msgstr ""
+
+#: include/conversation.php:1243
+#, php-format
+msgid "<span  %1$s>%2$d people</span> don't attend"
+msgstr ""
+
+#: include/conversation.php:1244
+#, php-format
+msgid "%s don't attend."
+msgstr ""
+
+#: include/conversation.php:1247
+#, php-format
+msgid "<span  %1$s>%2$d people</span> attend maybe"
+msgstr ""
+
+#: include/conversation.php:1248
+#, php-format
+msgid "%s attend maybe."
+msgstr ""
+
+#: include/conversation.php:1278 include/conversation.php:1294
+msgid "Visible to <strong>everybody</strong>"
+msgstr ""
+
+#: include/conversation.php:1279 include/conversation.php:1295
+#: mod/wallmessage.php:120 mod/wallmessage.php:127 mod/message.php:200
+#: mod/message.php:207 mod/message.php:343 mod/message.php:350
+msgid "Please enter a link URL:"
+msgstr ""
+
+#: include/conversation.php:1280 include/conversation.php:1296
+msgid "Please enter a video link/URL:"
+msgstr ""
+
+#: include/conversation.php:1281 include/conversation.php:1297
+msgid "Please enter an audio link/URL:"
+msgstr ""
+
+#: include/conversation.php:1282 include/conversation.php:1298
+msgid "Tag term:"
+msgstr ""
+
+#: include/conversation.php:1283 include/conversation.php:1299 mod/filer.php:34
+msgid "Save to Folder:"
+msgstr ""
+
+#: include/conversation.php:1284 include/conversation.php:1300
+msgid "Where are you right now?"
+msgstr ""
+
+#: include/conversation.php:1285
+msgid "Delete item(s)?"
+msgstr ""
+
+#: include/conversation.php:1334
+msgid "Share"
+msgstr ""
+
+#: include/conversation.php:1335 mod/wallmessage.php:143 mod/editpost.php:111
+#: mod/message.php:262 mod/message.php:430
+msgid "Upload photo"
+msgstr ""
+
+#: include/conversation.php:1336 mod/editpost.php:112
+msgid "upload photo"
+msgstr ""
+
+#: include/conversation.php:1337 mod/editpost.php:113
+msgid "Attach file"
+msgstr ""
+
+#: include/conversation.php:1338 mod/editpost.php:114
+msgid "attach file"
+msgstr ""
+
+#: include/conversation.php:1339 mod/wallmessage.php:144 mod/editpost.php:115
+#: mod/message.php:263 mod/message.php:431
+msgid "Insert web link"
+msgstr ""
+
+#: include/conversation.php:1340 mod/editpost.php:116
+msgid "web link"
+msgstr ""
+
+#: include/conversation.php:1341 mod/editpost.php:117
+msgid "Insert video link"
+msgstr ""
+
+#: include/conversation.php:1342 mod/editpost.php:118
+msgid "video link"
+msgstr ""
+
+#: include/conversation.php:1343 mod/editpost.php:119
+msgid "Insert audio link"
+msgstr ""
+
+#: include/conversation.php:1344 mod/editpost.php:120
+msgid "audio link"
+msgstr ""
+
+#: include/conversation.php:1345 mod/editpost.php:121
+msgid "Set your location"
+msgstr ""
+
+#: include/conversation.php:1346 mod/editpost.php:122
+msgid "set location"
+msgstr ""
+
+#: include/conversation.php:1347 mod/editpost.php:123
+msgid "Clear browser location"
+msgstr ""
+
+#: include/conversation.php:1348 mod/editpost.php:124
+msgid "clear location"
+msgstr ""
+
+#: include/conversation.php:1350 mod/editpost.php:138
+msgid "Set title"
+msgstr ""
+
+#: include/conversation.php:1352 mod/editpost.php:140
+msgid "Categories (comma-separated list)"
+msgstr ""
+
+#: include/conversation.php:1354 mod/editpost.php:126
+msgid "Permission settings"
+msgstr ""
+
+#: include/conversation.php:1355 mod/editpost.php:155
+msgid "permissions"
+msgstr ""
+
+#: include/conversation.php:1363 mod/editpost.php:135
+msgid "Public post"
+msgstr ""
+
+#: include/conversation.php:1367 mod/editpost.php:146 mod/photos.php:1492
+#: mod/photos.php:1531 mod/photos.php:1604 mod/events.php:528
+#: src/Object/Post.php:799
+msgid "Preview"
+msgstr ""
+
+#: include/conversation.php:1371 include/items.php:387 mod/fbrowser.php:103
+#: mod/fbrowser.php:134 mod/suggest.php:41 mod/dfrn_request.php:663
+#: mod/tagrm.php:19 mod/tagrm.php:99 mod/editpost.php:149 mod/message.php:141
+#: mod/photos.php:248 mod/photos.php:324 mod/videos.php:147
+#: mod/contacts.php:475 mod/follow.php:161 mod/settings.php:676
+#: mod/settings.php:702 mod/unfollow.php:117
+msgid "Cancel"
+msgstr ""
+
+#: include/conversation.php:1376
+msgid "Post to Groups"
+msgstr ""
+
+#: include/conversation.php:1377
+msgid "Post to Contacts"
+msgstr ""
+
+#: include/conversation.php:1378
+msgid "Private post"
+msgstr ""
+
+#: include/conversation.php:1383 mod/editpost.php:153 src/Model/Profile.php:342
+msgid "Message"
+msgstr ""
+
+#: include/conversation.php:1384 mod/editpost.php:154
+msgid "Browser"
+msgstr ""
+
+#: include/conversation.php:1651
+msgid "View all"
+msgstr ""
+
+#: include/conversation.php:1674
+msgid "Like"
+msgid_plural "Likes"
+msgstr[0] ""
+msgstr[1] ""
+
+#: include/conversation.php:1677
+msgid "Dislike"
+msgid_plural "Dislikes"
+msgstr[0] ""
+msgstr[1] ""
+
+#: include/conversation.php:1683
+msgid "Not Attending"
+msgid_plural "Not Attending"
+msgstr[0] ""
+msgstr[1] ""
+
+#: include/conversation.php:1686 src/Content/ContactSelector.php:125
+msgid "Undecided"
+msgid_plural "Undecided"
+msgstr[0] ""
+msgstr[1] ""
+
+#: include/dba.php:57
+#, php-format
+msgid "Cannot locate DNS info for database server '%s'"
+msgstr ""
+
+#: include/enotify.php:31
 msgid "Friendica Notification"
 msgstr ""
 
-#: include/enotify.php:36
+#: include/enotify.php:34
 msgid "Thank You,"
 msgstr ""
 
-#: include/enotify.php:39
+#: include/enotify.php:37
 #, php-format
 msgid "%s Administrator"
 msgstr ""
 
-#: include/enotify.php:41
+#: include/enotify.php:39
 #, php-format
 msgid "%1$s, %2$s Administrator"
 msgstr ""
 
-#: include/enotify.php:52 src/Worker/Delivery.php:403
+#: include/enotify.php:50 src/Worker/Delivery.php:402
 msgid "noreply"
 msgstr ""
 
-#: include/enotify.php:100
+#: include/enotify.php:98
 #, php-format
 msgid "[Friendica:Notify] New mail received at %s"
 msgstr ""
 
-#: include/enotify.php:102
+#: include/enotify.php:100
 #, php-format
 msgid "%1$s sent you a new private message at %2$s."
 msgstr ""
 
-#: include/enotify.php:103
+#: include/enotify.php:101
 msgid "a private message"
 msgstr ""
 
-#: include/enotify.php:103
+#: include/enotify.php:101
 #, php-format
 msgid "%1$s sent you %2$s."
 msgstr ""
 
-#: include/enotify.php:105
+#: include/enotify.php:103
 #, php-format
 msgid "Please visit %s to view and/or reply to your private messages."
 msgstr ""
 
-#: include/enotify.php:143
+#: include/enotify.php:141
 #, php-format
 msgid "%1$s commented on [url=%2$s]a %3$s[/url]"
 msgstr ""
 
-#: include/enotify.php:151
+#: include/enotify.php:149
 #, php-format
 msgid "%1$s commented on [url=%2$s]%3$s's %4$s[/url]"
 msgstr ""
 
-#: include/enotify.php:161
+#: include/enotify.php:159
 #, php-format
 msgid "%1$s commented on [url=%2$s]your %3$s[/url]"
 msgstr ""
 
-#: include/enotify.php:173
+#: include/enotify.php:171
 #, php-format
 msgid "[Friendica:Notify] Comment to conversation #%1$d by %2$s"
 msgstr ""
 
-#: include/enotify.php:175
+#: include/enotify.php:173
 #, php-format
 msgid "%s commented on an item/conversation you have been following."
 msgstr ""
 
-#: include/enotify.php:178 include/enotify.php:193 include/enotify.php:208
-#: include/enotify.php:223 include/enotify.php:242 include/enotify.php:257
+#: include/enotify.php:176 include/enotify.php:191 include/enotify.php:206
+#: include/enotify.php:221 include/enotify.php:240 include/enotify.php:255
 #, php-format
 msgid "Please visit %s to view and/or reply to the conversation."
 msgstr ""
 
-#: include/enotify.php:185
+#: include/enotify.php:183
 #, php-format
 msgid "[Friendica:Notify] %s posted to your profile wall"
 msgstr ""
 
-#: include/enotify.php:187
+#: include/enotify.php:185
 #, php-format
 msgid "%1$s posted to your profile wall at %2$s"
 msgstr ""
 
-#: include/enotify.php:188
+#: include/enotify.php:186
 #, php-format
 msgid "%1$s posted to [url=%2$s]your wall[/url]"
 msgstr ""
 
-#: include/enotify.php:200
+#: include/enotify.php:198
 #, php-format
 msgid "[Friendica:Notify] %s tagged you"
 msgstr ""
 
-#: include/enotify.php:202
+#: include/enotify.php:200
 #, php-format
 msgid "%1$s tagged you at %2$s"
 msgstr ""
 
-#: include/enotify.php:203
+#: include/enotify.php:201
 #, php-format
 msgid "%1$s [url=%2$s]tagged you[/url]."
 msgstr ""
 
-#: include/enotify.php:215
+#: include/enotify.php:213
 #, php-format
 msgid "[Friendica:Notify] %s shared a new post"
 msgstr ""
 
-#: include/enotify.php:217
+#: include/enotify.php:215
 #, php-format
 msgid "%1$s shared a new post at %2$s"
 msgstr ""
 
-#: include/enotify.php:218
+#: include/enotify.php:216
 #, php-format
 msgid "%1$s [url=%2$s]shared a post[/url]."
 msgstr ""
 
-#: include/enotify.php:230
+#: include/enotify.php:228
 #, php-format
 msgid "[Friendica:Notify] %1$s poked you"
 msgstr ""
 
-#: include/enotify.php:232
+#: include/enotify.php:230
 #, php-format
 msgid "%1$s poked you at %2$s"
 msgstr ""
 
-#: include/enotify.php:233
+#: include/enotify.php:231
 #, php-format
 msgid "%1$s [url=%2$s]poked you[/url]."
 msgstr ""
 
-#: include/enotify.php:249
+#: include/enotify.php:247
 #, php-format
 msgid "[Friendica:Notify] %s tagged your post"
 msgstr ""
 
-#: include/enotify.php:251
+#: include/enotify.php:249
 #, php-format
 msgid "%1$s tagged your post at %2$s"
 msgstr ""
 
-#: include/enotify.php:252
+#: include/enotify.php:250
 #, php-format
 msgid "%1$s tagged [url=%2$s]your post[/url]"
 msgstr ""
 
-#: include/enotify.php:264
+#: include/enotify.php:262
 msgid "[Friendica:Notify] Introduction received"
 msgstr ""
 
-#: include/enotify.php:266
+#: include/enotify.php:264
 #, php-format
 msgid "You've received an introduction from '%1$s' at %2$s"
 msgstr ""
 
-#: include/enotify.php:267
+#: include/enotify.php:265
 #, php-format
 msgid "You've received [url=%1$s]an introduction[/url] from %2$s."
 msgstr ""
 
-#: include/enotify.php:272 include/enotify.php:318
+#: include/enotify.php:270 include/enotify.php:316
 #, php-format
 msgid "You may visit their profile at %s"
 msgstr ""
 
-#: include/enotify.php:274
+#: include/enotify.php:272
 #, php-format
 msgid "Please visit %s to approve or reject the introduction."
 msgstr ""
 
-#: include/enotify.php:282
+#: include/enotify.php:280
 msgid "[Friendica:Notify] A new person is sharing with you"
 msgstr ""
 
-#: include/enotify.php:284 include/enotify.php:285
+#: include/enotify.php:282 include/enotify.php:283
 #, php-format
 msgid "%1$s is sharing with you at %2$s"
 msgstr ""
 
-#: include/enotify.php:292
+#: include/enotify.php:290
 msgid "[Friendica:Notify] You have a new follower"
 msgstr ""
 
-#: include/enotify.php:294 include/enotify.php:295
+#: include/enotify.php:292 include/enotify.php:293
 #, php-format
 msgid "You have a new follower at %2$s : %1$s"
 msgstr ""
 
-#: include/enotify.php:307
+#: include/enotify.php:305
 msgid "[Friendica:Notify] Friend suggestion received"
 msgstr ""
 
-#: include/enotify.php:309
+#: include/enotify.php:307
 #, php-format
 msgid "You've received a friend suggestion from '%1$s' at %2$s"
 msgstr ""
 
-#: include/enotify.php:310
+#: include/enotify.php:308
 #, php-format
 msgid "You've received [url=%1$s]a friend suggestion[/url] for %2$s from %3$s."
 msgstr ""
 
-#: include/enotify.php:316
+#: include/enotify.php:314
 msgid "Name:"
 msgstr ""
 
-#: include/enotify.php:317
+#: include/enotify.php:315
 msgid "Photo:"
 msgstr ""
 
-#: include/enotify.php:320
+#: include/enotify.php:318
 #, php-format
 msgid "Please visit %s to approve or reject the suggestion."
 msgstr ""
 
-#: include/enotify.php:328 include/enotify.php:343
+#: include/enotify.php:326 include/enotify.php:341
 msgid "[Friendica:Notify] Connection accepted"
 msgstr ""
 
-#: include/enotify.php:330 include/enotify.php:345
+#: include/enotify.php:328 include/enotify.php:343
 #, php-format
 msgid "'%1$s' has accepted your connection request at %2$s"
 msgstr ""
 
-#: include/enotify.php:331 include/enotify.php:346
+#: include/enotify.php:329 include/enotify.php:344
 #, php-format
 msgid "%2$s has accepted your [url=%1$s]connection request[/url]."
 msgstr ""
 
-#: include/enotify.php:336
+#: include/enotify.php:334
 msgid ""
 "You are now mutual friends and may exchange status updates, photos, and "
 "email without restriction."
 msgstr ""
 
-#: include/enotify.php:338
+#: include/enotify.php:336
 #, php-format
 msgid "Please visit %s if you wish to make any changes to this relationship."
 msgstr ""
 
-#: include/enotify.php:351
+#: include/enotify.php:349
 #, php-format
 msgid ""
 "'%1$s' has chosen to accept you a fan, which restricts some forms of "
@@ -291,291 +766,45 @@ msgid ""
 "automatically."
 msgstr ""
 
-#: include/enotify.php:353
+#: include/enotify.php:351
 #, php-format
 msgid ""
 "'%1$s' may choose to extend this into a two-way or more permissive "
 "relationship in the future."
 msgstr ""
 
-#: include/enotify.php:355
+#: include/enotify.php:353
 #, php-format
 msgid "Please visit %s  if you wish to make any changes to this relationship."
 msgstr ""
 
-#: include/enotify.php:365
+#: include/enotify.php:363
 msgid "[Friendica System:Notify] registration request"
 msgstr ""
 
-#: include/enotify.php:367
+#: include/enotify.php:365
 #, php-format
 msgid "You've received a registration request from '%1$s' at %2$s"
 msgstr ""
 
-#: include/enotify.php:368
+#: include/enotify.php:366
 #, php-format
 msgid "You've received a [url=%1$s]registration request[/url] from %2$s."
 msgstr ""
 
-#: include/enotify.php:373
+#: include/enotify.php:371
 #, php-format
-msgid "Full Name:\t%1$s\\nSite Location:\t%2$s\\nLogin Name:\t%3$s (%4$s("
+msgid "Full Name:\t%1$s\\nSite Location:\t%2$s\\nLogin Name:\t%3$s (%4$s)"
 msgstr ""
 
-#: include/enotify.php:379
+#: include/enotify.php:377
 #, php-format
 msgid "Please visit %s to approve or reject the request."
 msgstr ""
 
-#: include/event.php:26 include/event.php:914 include/bb2diaspora.php:238
-#: mod/localtime.php:19
-msgid "l F d, Y \\@ g:i A"
-msgstr ""
-
-#: include/event.php:45 include/event.php:62 include/event.php:471
-#: include/event.php:992 include/bb2diaspora.php:245
-msgid "Starts:"
-msgstr ""
-
-#: include/event.php:48 include/event.php:68 include/event.php:472
-#: include/event.php:996 include/bb2diaspora.php:251
-msgid "Finishes:"
-msgstr ""
-
-#: include/event.php:52 include/event.php:77 include/event.php:473
-#: include/event.php:1010 include/bb2diaspora.php:258 mod/notifications.php:247
-#: mod/contacts.php:651 mod/directory.php:149 mod/events.php:521
-#: src/Model/Profile.php:417
-msgid "Location:"
-msgstr ""
-
-#: include/event.php:420
-msgid "all-day"
-msgstr ""
-
-#: include/event.php:422 include/text.php:1111
-msgid "Sun"
-msgstr ""
-
-#: include/event.php:423 include/text.php:1111
-msgid "Mon"
-msgstr ""
-
-#: include/event.php:424 include/text.php:1111
-msgid "Tue"
-msgstr ""
-
-#: include/event.php:425 include/text.php:1111
-msgid "Wed"
-msgstr ""
-
-#: include/event.php:426 include/text.php:1111
-msgid "Thu"
-msgstr ""
-
-#: include/event.php:427 include/text.php:1111
-msgid "Fri"
-msgstr ""
-
-#: include/event.php:428 include/text.php:1111
-msgid "Sat"
-msgstr ""
-
-#: include/event.php:430 include/text.php:1093 mod/settings.php:945
-msgid "Sunday"
-msgstr ""
-
-#: include/event.php:431 include/text.php:1093 mod/settings.php:945
-msgid "Monday"
-msgstr ""
-
-#: include/event.php:432 include/text.php:1093
-msgid "Tuesday"
-msgstr ""
-
-#: include/event.php:433 include/text.php:1093
-msgid "Wednesday"
-msgstr ""
-
-#: include/event.php:434 include/text.php:1093
-msgid "Thursday"
-msgstr ""
-
-#: include/event.php:435 include/text.php:1093
-msgid "Friday"
-msgstr ""
-
-#: include/event.php:436 include/text.php:1093
-msgid "Saturday"
-msgstr ""
-
-#: include/event.php:438 include/text.php:1114
-msgid "Jan"
-msgstr ""
-
-#: include/event.php:439 include/text.php:1114
-msgid "Feb"
-msgstr ""
-
-#: include/event.php:440 include/text.php:1114
-msgid "Mar"
-msgstr ""
-
-#: include/event.php:441 include/text.php:1114
-msgid "Apr"
-msgstr ""
-
-#: include/event.php:442 include/event.php:455 include/text.php:1097
-#: include/text.php:1114
-msgid "May"
-msgstr ""
-
-#: include/event.php:443
-msgid "Jun"
-msgstr ""
-
-#: include/event.php:444 include/text.php:1114
-msgid "Jul"
-msgstr ""
-
-#: include/event.php:445 include/text.php:1114
-msgid "Aug"
-msgstr ""
-
-#: include/event.php:446
-msgid "Sept"
-msgstr ""
-
-#: include/event.php:447 include/text.php:1114
-msgid "Oct"
-msgstr ""
-
-#: include/event.php:448 include/text.php:1114
-msgid "Nov"
-msgstr ""
-
-#: include/event.php:449 include/text.php:1114
-msgid "Dec"
-msgstr ""
-
-#: include/event.php:451 include/text.php:1097
-msgid "January"
-msgstr ""
-
-#: include/event.php:452 include/text.php:1097
-msgid "February"
-msgstr ""
-
-#: include/event.php:453 include/text.php:1097
-msgid "March"
-msgstr ""
-
-#: include/event.php:454 include/text.php:1097
-msgid "April"
-msgstr ""
-
-#: include/event.php:456 include/text.php:1097
-msgid "June"
-msgstr ""
-
-#: include/event.php:457 include/text.php:1097
-msgid "July"
-msgstr ""
-
-#: include/event.php:458 include/text.php:1097
-msgid "August"
-msgstr ""
-
-#: include/event.php:459 include/text.php:1097
-msgid "September"
-msgstr ""
-
-#: include/event.php:460 include/text.php:1097
-msgid "October"
-msgstr ""
-
-#: include/event.php:461 include/text.php:1097
-msgid "November"
-msgstr ""
-
-#: include/event.php:462 include/text.php:1097
-msgid "December"
-msgstr ""
-
-#: include/event.php:464 mod/cal.php:280 mod/events.php:401
-msgid "today"
-msgstr ""
-
-#: include/event.php:465 mod/cal.php:281 mod/events.php:402
-#: src/Util/Temporal.php:304
-msgid "month"
-msgstr ""
-
-#: include/event.php:466 mod/cal.php:282 mod/events.php:403
-#: src/Util/Temporal.php:305
-msgid "week"
-msgstr ""
-
-#: include/event.php:467 mod/cal.php:283 mod/events.php:404
-#: src/Util/Temporal.php:306
-msgid "day"
-msgstr ""
-
-#: include/event.php:469
-msgid "No events to display"
-msgstr ""
-
-#: include/event.php:583
-msgid "l, F j"
-msgstr ""
-
-#: include/event.php:607
-msgid "Edit event"
-msgstr ""
-
-#: include/event.php:608
-msgid "Duplicate event"
-msgstr ""
-
-#: include/event.php:609
-msgid "Delete event"
-msgstr ""
-
-#: include/event.php:636 include/text.php:1508 include/text.php:1515
-msgid "link to source"
-msgstr ""
-
-#: include/event.php:896
-msgid "Export"
-msgstr ""
-
-#: include/event.php:897
-msgid "Export calendar as ical"
-msgstr ""
-
-#: include/event.php:898
-msgid "Export calendar as csv"
-msgstr ""
-
-#: include/event.php:915
-msgid "D g:i A"
-msgstr ""
-
-#: include/event.php:916
-msgid "g:i A"
-msgstr ""
-
-#: include/event.php:1011 include/event.php:1013
-msgid "Show map"
-msgstr ""
-
-#: include/event.php:1012
-msgid "Hide map"
-msgstr ""
-
 #: include/items.php:342 mod/notice.php:22 mod/viewsrc.php:21 mod/admin.php:269
-#: mod/admin.php:1762 mod/admin.php:2010 mod/display.php:70 mod/display.php:247
-#: mod/display.php:349
+#: mod/admin.php:1787 mod/admin.php:2035 mod/display.php:72 mod/display.php:252
+#: mod/display.php:354
 msgid "Item not found."
 msgstr ""
 
@@ -584,43 +813,35 @@ msgid "Do you really want to delete this item?"
 msgstr ""
 
 #: include/items.php:384 mod/api.php:110 mod/suggest.php:38
-#: mod/profiles.php:649 mod/profiles.php:652 mod/profiles.php:674
-#: mod/contacts.php:464 mod/dfrn_request.php:653 mod/follow.php:148
-#: mod/register.php:237 mod/message.php:138 mod/settings.php:1109
-#: mod/settings.php:1115 mod/settings.php:1122 mod/settings.php:1126
-#: mod/settings.php:1130 mod/settings.php:1134 mod/settings.php:1138
-#: mod/settings.php:1142 mod/settings.php:1162 mod/settings.php:1163
-#: mod/settings.php:1164 mod/settings.php:1165 mod/settings.php:1166
+#: mod/dfrn_request.php:653 mod/register.php:237 mod/message.php:138
+#: mod/contacts.php:472 mod/follow.php:150 mod/profiles.php:635
+#: mod/profiles.php:638 mod/profiles.php:660 mod/settings.php:1103
+#: mod/settings.php:1109 mod/settings.php:1116 mod/settings.php:1120
+#: mod/settings.php:1124 mod/settings.php:1128 mod/settings.php:1132
+#: mod/settings.php:1136 mod/settings.php:1156 mod/settings.php:1157
+#: mod/settings.php:1158 mod/settings.php:1159 mod/settings.php:1160
 msgid "Yes"
-msgstr ""
-
-#: include/items.php:387 include/conversation.php:1373 mod/fbrowser.php:103
-#: mod/fbrowser.php:134 mod/suggest.php:41 mod/unfollow.php:117
-#: mod/contacts.php:467 mod/dfrn_request.php:663 mod/follow.php:159
-#: mod/tagrm.php:19 mod/tagrm.php:99 mod/editpost.php:151 mod/message.php:141
-#: mod/photos.php:248 mod/photos.php:324 mod/settings.php:680
-#: mod/settings.php:706 mod/videos.php:148
-msgid "Cancel"
 msgstr ""
 
 #: include/items.php:401 mod/allfriends.php:21 mod/api.php:35 mod/api.php:40
 #: mod/attach.php:38 mod/common.php:26 mod/crepair.php:98 mod/nogroup.php:28
-#: mod/repair_ostatus.php:13 mod/suggest.php:60 mod/unfollow.php:15
-#: mod/unfollow.php:57 mod/unfollow.php:90 mod/uimport.php:28
-#: mod/dirfind.php:24 mod/notifications.php:73 mod/ostatus_subscribe.php:16
-#: mod/cal.php:304 mod/dfrn_confirm.php:68 mod/invite.php:20 mod/invite.php:106
-#: mod/manage.php:131 mod/profiles.php:181 mod/profiles.php:619
-#: mod/wall_attach.php:74 mod/wall_attach.php:77 mod/contacts.php:378
-#: mod/delegate.php:24 mod/delegate.php:38 mod/follow.php:16 mod/follow.php:53
-#: mod/follow.php:116 mod/poke.php:150 mod/profile_photo.php:29
-#: mod/profile_photo.php:188 mod/profile_photo.php:199
-#: mod/profile_photo.php:212 mod/regmod.php:108 mod/viewcontacts.php:57
-#: mod/wall_upload.php:103 mod/wall_upload.php:106 mod/wallmessage.php:16
-#: mod/wallmessage.php:40 mod/wallmessage.php:79 mod/wallmessage.php:103
-#: mod/item.php:160 mod/register.php:53 mod/editpost.php:20 mod/events.php:195
-#: mod/fsuggest.php:81 mod/group.php:26 mod/message.php:59 mod/message.php:104
+#: mod/repair_ostatus.php:13 mod/suggest.php:60 mod/uimport.php:28
+#: mod/notifications.php:73 mod/dfrn_confirm.php:68 mod/invite.php:20
+#: mod/invite.php:106 mod/manage.php:131 mod/wall_attach.php:74
+#: mod/wall_attach.php:77 mod/poke.php:150 mod/regmod.php:108
+#: mod/viewcontacts.php:57 mod/wall_upload.php:103 mod/wall_upload.php:106
+#: mod/wallmessage.php:16 mod/wallmessage.php:40 mod/wallmessage.php:79
+#: mod/wallmessage.php:103 mod/register.php:53 mod/editpost.php:18
+#: mod/fsuggest.php:80 mod/group.php:26 mod/message.php:59 mod/message.php:104
 #: mod/network.php:32 mod/notes.php:30 mod/photos.php:174 mod/photos.php:1051
-#: mod/settings.php:41 mod/settings.php:140 mod/settings.php:669 index.php:413
+#: mod/cal.php:304 mod/contacts.php:386 mod/delegate.php:25 mod/delegate.php:43
+#: mod/delegate.php:54 mod/dirfind.php:25 mod/events.php:194 mod/follow.php:17
+#: mod/follow.php:54 mod/follow.php:118 mod/item.php:160
+#: mod/ostatus_subscribe.php:16 mod/profile_photo.php:30
+#: mod/profile_photo.php:176 mod/profile_photo.php:187
+#: mod/profile_photo.php:200 mod/profiles.php:181 mod/profiles.php:605
+#: mod/settings.php:43 mod/settings.php:142 mod/settings.php:665
+#: mod/unfollow.php:15 mod/unfollow.php:57 mod/unfollow.php:90 index.php:416
 msgid "Permission denied."
 msgstr ""
 
@@ -630,7 +851,7 @@ msgstr ""
 
 #: include/items.php:477 view/theme/vier/theme.php:259
 #: src/Content/ForumManager.php:130 src/Content/Widget.php:312
-#: src/Object/Post.php:422 src/App.php:514
+#: src/Object/Post.php:424 src/App.php:518
 msgid "show more"
 msgstr ""
 
@@ -681,7 +902,7 @@ msgstr[1] ""
 msgid "View Contacts"
 msgstr ""
 
-#: include/text.php:1010 mod/filer.php:35 mod/editpost.php:112 mod/notes.php:68
+#: include/text.php:1010 mod/filer.php:35 mod/editpost.php:110 mod/notes.php:67
 msgid "Save"
 msgstr ""
 
@@ -706,10 +927,9 @@ msgstr ""
 msgid "Tags"
 msgstr ""
 
-#: include/text.php:1027 mod/contacts.php:805 mod/contacts.php:866
-#: mod/viewcontacts.php:131 view/theme/frio/theme.php:270
-#: src/Content/Nav.php:147 src/Content/Nav.php:212 src/Model/Profile.php:957
-#: src/Model/Profile.php:960
+#: include/text.php:1027 mod/viewcontacts.php:131 mod/contacts.php:814
+#: mod/contacts.php:875 view/theme/frio/theme.php:270 src/Content/Nav.php:147
+#: src/Content/Nav.php:212 src/Model/Profile.php:957 src/Model/Profile.php:960
 msgid "Contacts"
 msgstr ""
 
@@ -766,562 +986,199 @@ msgstr ""
 msgid "rebuffed"
 msgstr ""
 
+#: include/text.php:1093 mod/settings.php:941 src/Model/Event.php:379
+msgid "Monday"
+msgstr ""
+
+#: include/text.php:1093 src/Model/Event.php:380
+msgid "Tuesday"
+msgstr ""
+
+#: include/text.php:1093 src/Model/Event.php:381
+msgid "Wednesday"
+msgstr ""
+
+#: include/text.php:1093 src/Model/Event.php:382
+msgid "Thursday"
+msgstr ""
+
+#: include/text.php:1093 src/Model/Event.php:383
+msgid "Friday"
+msgstr ""
+
+#: include/text.php:1093 src/Model/Event.php:384
+msgid "Saturday"
+msgstr ""
+
+#: include/text.php:1093 mod/settings.php:941 src/Model/Event.php:378
+msgid "Sunday"
+msgstr ""
+
+#: include/text.php:1097 src/Model/Event.php:399
+msgid "January"
+msgstr ""
+
+#: include/text.php:1097 src/Model/Event.php:400
+msgid "February"
+msgstr ""
+
+#: include/text.php:1097 src/Model/Event.php:401
+msgid "March"
+msgstr ""
+
+#: include/text.php:1097 src/Model/Event.php:402
+msgid "April"
+msgstr ""
+
+#: include/text.php:1097 include/text.php:1114 src/Model/Event.php:390
+#: src/Model/Event.php:403
+msgid "May"
+msgstr ""
+
+#: include/text.php:1097 src/Model/Event.php:404
+msgid "June"
+msgstr ""
+
+#: include/text.php:1097 src/Model/Event.php:405
+msgid "July"
+msgstr ""
+
+#: include/text.php:1097 src/Model/Event.php:406
+msgid "August"
+msgstr ""
+
+#: include/text.php:1097 src/Model/Event.php:407
+msgid "September"
+msgstr ""
+
+#: include/text.php:1097 src/Model/Event.php:408
+msgid "October"
+msgstr ""
+
+#: include/text.php:1097 src/Model/Event.php:409
+msgid "November"
+msgstr ""
+
+#: include/text.php:1097 src/Model/Event.php:410
+msgid "December"
+msgstr ""
+
+#: include/text.php:1111 src/Model/Event.php:371
+msgid "Mon"
+msgstr ""
+
+#: include/text.php:1111 src/Model/Event.php:372
+msgid "Tue"
+msgstr ""
+
+#: include/text.php:1111 src/Model/Event.php:373
+msgid "Wed"
+msgstr ""
+
+#: include/text.php:1111 src/Model/Event.php:374
+msgid "Thu"
+msgstr ""
+
+#: include/text.php:1111 src/Model/Event.php:375
+msgid "Fri"
+msgstr ""
+
+#: include/text.php:1111 src/Model/Event.php:376
+msgid "Sat"
+msgstr ""
+
+#: include/text.php:1111 src/Model/Event.php:370
+msgid "Sun"
+msgstr ""
+
+#: include/text.php:1114 src/Model/Event.php:386
+msgid "Jan"
+msgstr ""
+
+#: include/text.php:1114 src/Model/Event.php:387
+msgid "Feb"
+msgstr ""
+
+#: include/text.php:1114 src/Model/Event.php:388
+msgid "Mar"
+msgstr ""
+
+#: include/text.php:1114 src/Model/Event.php:389
+msgid "Apr"
+msgstr ""
+
+#: include/text.php:1114 src/Model/Event.php:392
+msgid "Jul"
+msgstr ""
+
+#: include/text.php:1114 src/Model/Event.php:393
+msgid "Aug"
+msgstr ""
+
 #: include/text.php:1114
 msgid "Sep"
 msgstr ""
 
-#: include/text.php:1315 mod/videos.php:381
+#: include/text.php:1114 src/Model/Event.php:395
+msgid "Oct"
+msgstr ""
+
+#: include/text.php:1114 src/Model/Event.php:396
+msgid "Nov"
+msgstr ""
+
+#: include/text.php:1114 src/Model/Event.php:397
+msgid "Dec"
+msgstr ""
+
+#: include/text.php:1324 mod/videos.php:380
 msgid "View Video"
 msgstr ""
 
-#: include/text.php:1332
+#: include/text.php:1341
 msgid "bytes"
 msgstr ""
 
-#: include/text.php:1367 include/text.php:1378
+#: include/text.php:1374 include/text.php:1385
 msgid "Click to open/close"
 msgstr ""
 
-#: include/text.php:1502
+#: include/text.php:1509
 msgid "View on separate page"
 msgstr ""
 
-#: include/text.php:1503
+#: include/text.php:1510
 msgid "view on separate page"
 msgstr ""
 
-#: include/text.php:1717 include/conversation.php:146
-#: include/conversation.php:284 src/Model/Item.php:1785
-msgid "event"
+#: include/text.php:1515 include/text.php:1522 src/Model/Event.php:594
+msgid "link to source"
 msgstr ""
 
-#: include/text.php:1719 include/conversation.php:154
-#: include/conversation.php:292 mod/subthread.php:97 mod/tagger.php:72
-#: src/Model/Item.php:1783
-msgid "photo"
-msgstr ""
-
-#: include/text.php:1721
+#: include/text.php:1728
 msgid "activity"
 msgstr ""
 
-#: include/text.php:1723 src/Object/Post.php:421 src/Object/Post.php:433
+#: include/text.php:1730 src/Object/Post.php:423 src/Object/Post.php:435
 msgid "comment"
 msgid_plural "comments"
 msgstr[0] ""
 msgstr[1] ""
 
-#: include/text.php:1726
+#: include/text.php:1733
 msgid "post"
 msgstr ""
 
-#: include/text.php:1883
+#: include/text.php:1890
 msgid "Item filed"
-msgstr ""
-
-#: include/acl_selectors.php:355
-msgid "Post to Email"
-msgstr ""
-
-#: include/acl_selectors.php:360
-msgid "Hide your profile details from unknown viewers?"
-msgstr ""
-
-#: include/acl_selectors.php:360
-#, php-format
-msgid "Connectors disabled, since \"%s\" is enabled."
-msgstr ""
-
-#: include/acl_selectors.php:366
-msgid "Visible to everybody"
-msgstr ""
-
-#: include/acl_selectors.php:367 view/theme/vier/config.php:115
-msgid "show"
-msgstr ""
-
-#: include/acl_selectors.php:368 view/theme/vier/config.php:115
-msgid "don't show"
-msgstr ""
-
-#: include/acl_selectors.php:374 mod/editpost.php:136
-msgid "CC: email addresses"
-msgstr ""
-
-#: include/acl_selectors.php:375 mod/editpost.php:143
-msgid "Example: bob@example.com, mary@example.com"
-msgstr ""
-
-#: include/acl_selectors.php:377 mod/events.php:536 mod/photos.php:1098
-#: mod/photos.php:1441
-msgid "Permissions"
-msgstr ""
-
-#: include/acl_selectors.php:378
-msgid "Close"
-msgstr ""
-
-#: include/api.php:1181
-#, php-format
-msgid "Daily posting limit of %d post reached. The post was rejected."
-msgid_plural "Daily posting limit of %d posts reached. The post was rejected."
-msgstr[0] ""
-msgstr[1] ""
-
-#: include/api.php:1205
-#, php-format
-msgid "Weekly posting limit of %d post reached. The post was rejected."
-msgid_plural "Weekly posting limit of %d posts reached. The post was rejected."
-msgstr[0] ""
-msgstr[1] ""
-
-#: include/api.php:1229
-#, php-format
-msgid "Monthly posting limit of %d post reached. The post was rejected."
-msgstr ""
-
-#: include/api.php:4382 mod/profile_photo.php:84 mod/profile_photo.php:92
-#: mod/profile_photo.php:100 mod/profile_photo.php:223
-#: mod/profile_photo.php:317 mod/profile_photo.php:327 mod/photos.php:88
-#: mod/photos.php:194 mod/photos.php:722 mod/photos.php:1149
-#: mod/photos.php:1166 mod/photos.php:1684 src/Model/User.php:526
-#: src/Model/User.php:534 src/Model/User.php:542
-msgid "Profile Photos"
-msgstr ""
-
-#: include/conversation.php:149 include/conversation.php:159
-#: include/conversation.php:287 include/conversation.php:296
-#: mod/subthread.php:97 mod/tagger.php:72 src/Model/Item.php:1783
-#: src/Protocol/Diaspora.php:1946
-msgid "status"
-msgstr ""
-
-#: include/conversation.php:166 src/Model/Item.php:1656
-#: src/Protocol/Diaspora.php:1942
-#, php-format
-msgid "%1$s likes %2$s's %3$s"
-msgstr ""
-
-#: include/conversation.php:169 src/Model/Item.php:1661
-#, php-format
-msgid "%1$s doesn't like %2$s's %3$s"
-msgstr ""
-
-#: include/conversation.php:172
-#, php-format
-msgid "%1$s attends %2$s's %3$s"
-msgstr ""
-
-#: include/conversation.php:175
-#, php-format
-msgid "%1$s doesn't attend %2$s's %3$s"
-msgstr ""
-
-#: include/conversation.php:178
-#, php-format
-msgid "%1$s attends maybe %2$s's %3$s"
-msgstr ""
-
-#: include/conversation.php:211 mod/dfrn_confirm.php:431
-#: src/Protocol/Diaspora.php:2414
-#, php-format
-msgid "%1$s is now friends with %2$s"
-msgstr ""
-
-#: include/conversation.php:252
-#, php-format
-msgid "%1$s poked %2$s"
-msgstr ""
-
-#: include/conversation.php:306 mod/tagger.php:110
-#, php-format
-msgid "%1$s tagged %2$s's %3$s with %4$s"
-msgstr ""
-
-#: include/conversation.php:333
-msgid "post/item"
-msgstr ""
-
-#: include/conversation.php:334
-#, php-format
-msgid "%1$s marked %2$s's %3$s as favorite"
-msgstr ""
-
-#: include/conversation.php:607 mod/profiles.php:354 mod/photos.php:1501
-msgid "Likes"
-msgstr ""
-
-#: include/conversation.php:607 mod/profiles.php:358 mod/photos.php:1501
-msgid "Dislikes"
-msgstr ""
-
-#: include/conversation.php:608 include/conversation.php:1682
-#: mod/photos.php:1502
-msgid "Attending"
-msgid_plural "Attending"
-msgstr[0] ""
-msgstr[1] ""
-
-#: include/conversation.php:608 mod/photos.php:1502
-msgid "Not attending"
-msgstr ""
-
-#: include/conversation.php:608 mod/photos.php:1502
-msgid "Might attend"
-msgstr ""
-
-#: include/conversation.php:746 mod/photos.php:1569 src/Object/Post.php:177
-msgid "Select"
-msgstr ""
-
-#: include/conversation.php:747 mod/contacts.php:821 mod/contacts.php:1019
-#: mod/admin.php:1706 mod/photos.php:1570 mod/settings.php:742
-#: src/Object/Post.php:178
-msgid "Delete"
-msgstr ""
-
-#: include/conversation.php:779 src/Object/Post.php:355 src/Object/Post.php:356
-#, php-format
-msgid "View %s's profile @ %s"
-msgstr ""
-
-#: include/conversation.php:791 src/Object/Post.php:343
-msgid "Categories:"
-msgstr ""
-
-#: include/conversation.php:792 src/Object/Post.php:344
-msgid "Filed under:"
-msgstr ""
-
-#: include/conversation.php:799 src/Object/Post.php:369
-#, php-format
-msgid "%s from %s"
-msgstr ""
-
-#: include/conversation.php:814
-msgid "View in context"
-msgstr ""
-
-#: include/conversation.php:816 include/conversation.php:1355
-#: mod/wallmessage.php:145 mod/editpost.php:127 mod/message.php:264
-#: mod/message.php:433 mod/photos.php:1473 src/Object/Post.php:394
-msgid "Please wait"
-msgstr ""
-
-#: include/conversation.php:887
-msgid "remove"
-msgstr ""
-
-#: include/conversation.php:891
-msgid "Delete Selected Items"
-msgstr ""
-
-#: include/conversation.php:1061 view/theme/frio/theme.php:352
-msgid "Follow Thread"
-msgstr ""
-
-#: include/conversation.php:1062 src/Model/Contact.php:554
-msgid "View Status"
-msgstr ""
-
-#: include/conversation.php:1063 include/conversation.php:1079
-#: mod/allfriends.php:73 mod/suggest.php:82 mod/dirfind.php:220
-#: mod/match.php:89 mod/directory.php:160 src/Model/Contact.php:497
-#: src/Model/Contact.php:510 src/Model/Contact.php:555
-msgid "View Profile"
-msgstr ""
-
-#: include/conversation.php:1064 src/Model/Contact.php:556
-msgid "View Photos"
-msgstr ""
-
-#: include/conversation.php:1065 src/Model/Contact.php:557
-msgid "Network Posts"
-msgstr ""
-
-#: include/conversation.php:1066 src/Model/Contact.php:558
-msgid "View Contact"
-msgstr ""
-
-#: include/conversation.php:1067 src/Model/Contact.php:560
-msgid "Send PM"
-msgstr ""
-
-#: include/conversation.php:1071 src/Model/Contact.php:561
-msgid "Poke"
-msgstr ""
-
-#: include/conversation.php:1076 mod/allfriends.php:74 mod/suggest.php:83
-#: mod/dirfind.php:221 mod/match.php:90 mod/contacts.php:587 mod/follow.php:141
-#: src/Content/Widget.php:61 src/Model/Contact.php:511
-msgid "Connect/Follow"
-msgstr ""
-
-#: include/conversation.php:1195
-#, php-format
-msgid "%s likes this."
-msgstr ""
-
-#: include/conversation.php:1198
-#, php-format
-msgid "%s doesn't like this."
-msgstr ""
-
-#: include/conversation.php:1201
-#, php-format
-msgid "%s attends."
-msgstr ""
-
-#: include/conversation.php:1204
-#, php-format
-msgid "%s doesn't attend."
-msgstr ""
-
-#: include/conversation.php:1207
-#, php-format
-msgid "%s attends maybe."
-msgstr ""
-
-#: include/conversation.php:1218
-msgid "and"
-msgstr ""
-
-#: include/conversation.php:1224
-#, php-format
-msgid "and %d other people"
-msgstr ""
-
-#: include/conversation.php:1233
-#, php-format
-msgid "<span  %1$s>%2$d people</span> like this"
-msgstr ""
-
-#: include/conversation.php:1234
-#, php-format
-msgid "%s like this."
-msgstr ""
-
-#: include/conversation.php:1237
-#, php-format
-msgid "<span  %1$s>%2$d people</span> don't like this"
-msgstr ""
-
-#: include/conversation.php:1238
-#, php-format
-msgid "%s don't like this."
-msgstr ""
-
-#: include/conversation.php:1241
-#, php-format
-msgid "<span  %1$s>%2$d people</span> attend"
-msgstr ""
-
-#: include/conversation.php:1242
-#, php-format
-msgid "%s attend."
-msgstr ""
-
-#: include/conversation.php:1245
-#, php-format
-msgid "<span  %1$s>%2$d people</span> don't attend"
-msgstr ""
-
-#: include/conversation.php:1246
-#, php-format
-msgid "%s don't attend."
-msgstr ""
-
-#: include/conversation.php:1249
-#, php-format
-msgid "<span  %1$s>%2$d people</span> attend maybe"
-msgstr ""
-
-#: include/conversation.php:1250
-#, php-format
-msgid "%s attend maybe."
-msgstr ""
-
-#: include/conversation.php:1280 include/conversation.php:1296
-msgid "Visible to <strong>everybody</strong>"
-msgstr ""
-
-#: include/conversation.php:1281 include/conversation.php:1297
-#: mod/wallmessage.php:120 mod/wallmessage.php:127 mod/message.php:200
-#: mod/message.php:207 mod/message.php:343 mod/message.php:350
-msgid "Please enter a link URL:"
-msgstr ""
-
-#: include/conversation.php:1282 include/conversation.php:1298
-msgid "Please enter a video link/URL:"
-msgstr ""
-
-#: include/conversation.php:1283 include/conversation.php:1299
-msgid "Please enter an audio link/URL:"
-msgstr ""
-
-#: include/conversation.php:1284 include/conversation.php:1300
-msgid "Tag term:"
-msgstr ""
-
-#: include/conversation.php:1285 include/conversation.php:1301 mod/filer.php:34
-msgid "Save to Folder:"
-msgstr ""
-
-#: include/conversation.php:1286 include/conversation.php:1302
-msgid "Where are you right now?"
-msgstr ""
-
-#: include/conversation.php:1287
-msgid "Delete item(s)?"
-msgstr ""
-
-#: include/conversation.php:1336
-msgid "Share"
-msgstr ""
-
-#: include/conversation.php:1337 mod/wallmessage.php:143 mod/editpost.php:113
-#: mod/message.php:262 mod/message.php:430
-msgid "Upload photo"
-msgstr ""
-
-#: include/conversation.php:1338 mod/editpost.php:114
-msgid "upload photo"
-msgstr ""
-
-#: include/conversation.php:1339 mod/editpost.php:115
-msgid "Attach file"
-msgstr ""
-
-#: include/conversation.php:1340 mod/editpost.php:116
-msgid "attach file"
-msgstr ""
-
-#: include/conversation.php:1341 mod/wallmessage.php:144 mod/editpost.php:117
-#: mod/message.php:263 mod/message.php:431
-msgid "Insert web link"
-msgstr ""
-
-#: include/conversation.php:1342 mod/editpost.php:118
-msgid "web link"
-msgstr ""
-
-#: include/conversation.php:1343 mod/editpost.php:119
-msgid "Insert video link"
-msgstr ""
-
-#: include/conversation.php:1344 mod/editpost.php:120
-msgid "video link"
-msgstr ""
-
-#: include/conversation.php:1345 mod/editpost.php:121
-msgid "Insert audio link"
-msgstr ""
-
-#: include/conversation.php:1346 mod/editpost.php:122
-msgid "audio link"
-msgstr ""
-
-#: include/conversation.php:1347 mod/editpost.php:123
-msgid "Set your location"
-msgstr ""
-
-#: include/conversation.php:1348 mod/editpost.php:124
-msgid "set location"
-msgstr ""
-
-#: include/conversation.php:1349 mod/editpost.php:125
-msgid "Clear browser location"
-msgstr ""
-
-#: include/conversation.php:1350 mod/editpost.php:126
-msgid "clear location"
-msgstr ""
-
-#: include/conversation.php:1352 mod/editpost.php:140
-msgid "Set title"
-msgstr ""
-
-#: include/conversation.php:1354 mod/editpost.php:142
-msgid "Categories (comma-separated list)"
-msgstr ""
-
-#: include/conversation.php:1356 mod/editpost.php:128
-msgid "Permission settings"
-msgstr ""
-
-#: include/conversation.php:1357 mod/editpost.php:157
-msgid "permissions"
-msgstr ""
-
-#: include/conversation.php:1365 mod/editpost.php:137
-msgid "Public post"
-msgstr ""
-
-#: include/conversation.php:1369 mod/editpost.php:148 mod/events.php:531
-#: mod/photos.php:1492 mod/photos.php:1531 mod/photos.php:1604
-#: src/Object/Post.php:797
-msgid "Preview"
-msgstr ""
-
-#: include/conversation.php:1378
-msgid "Post to Groups"
-msgstr ""
-
-#: include/conversation.php:1379
-msgid "Post to Contacts"
-msgstr ""
-
-#: include/conversation.php:1380
-msgid "Private post"
-msgstr ""
-
-#: include/conversation.php:1385 mod/editpost.php:155 src/Model/Profile.php:342
-msgid "Message"
-msgstr ""
-
-#: include/conversation.php:1386 mod/editpost.php:156
-msgid "Browser"
-msgstr ""
-
-#: include/conversation.php:1653
-msgid "View all"
-msgstr ""
-
-#: include/conversation.php:1676
-msgid "Like"
-msgid_plural "Likes"
-msgstr[0] ""
-msgstr[1] ""
-
-#: include/conversation.php:1679
-msgid "Dislike"
-msgid_plural "Dislikes"
-msgstr[0] ""
-msgstr[1] ""
-
-#: include/conversation.php:1685
-msgid "Not Attending"
-msgid_plural "Not Attending"
-msgstr[0] ""
-msgstr[1] ""
-
-#: include/conversation.php:1688 src/Content/ContactSelector.php:125
-msgid "Undecided"
-msgid_plural "Undecided"
-msgstr[0] ""
-msgstr[1] ""
-
-#: include/dba.php:59
-#, php-format
-msgid "Cannot locate DNS info for database server '%s'"
 msgstr ""
 
 #: mod/allfriends.php:51
 msgid "No friends to display."
 msgstr ""
 
-#: mod/allfriends.php:90 mod/suggest.php:101 mod/dirfind.php:218
-#: mod/match.php:105 src/Content/Widget.php:37 src/Model/Profile.php:297
+#: mod/allfriends.php:90 mod/suggest.php:101 mod/match.php:105
+#: mod/dirfind.php:215 src/Content/Widget.php:37 src/Model/Profile.php:297
 msgid "Connect"
 msgstr ""
 
@@ -1343,17 +1200,17 @@ msgid ""
 "and/or create new posts for you?"
 msgstr ""
 
-#: mod/api.php:111 mod/profiles.php:649 mod/profiles.php:653
-#: mod/profiles.php:674 mod/dfrn_request.php:653 mod/follow.php:148
-#: mod/register.php:238 mod/settings.php:1109 mod/settings.php:1115
-#: mod/settings.php:1122 mod/settings.php:1126 mod/settings.php:1130
-#: mod/settings.php:1134 mod/settings.php:1138 mod/settings.php:1142
-#: mod/settings.php:1162 mod/settings.php:1163 mod/settings.php:1164
-#: mod/settings.php:1165 mod/settings.php:1166
+#: mod/api.php:111 mod/dfrn_request.php:653 mod/register.php:238
+#: mod/follow.php:150 mod/profiles.php:635 mod/profiles.php:639
+#: mod/profiles.php:660 mod/settings.php:1103 mod/settings.php:1109
+#: mod/settings.php:1116 mod/settings.php:1120 mod/settings.php:1124
+#: mod/settings.php:1128 mod/settings.php:1132 mod/settings.php:1136
+#: mod/settings.php:1156 mod/settings.php:1157 mod/settings.php:1158
+#: mod/settings.php:1159 mod/settings.php:1160
 msgid "No"
 msgstr ""
 
-#: mod/apps.php:14 index.php:242
+#: mod/apps.php:14 index.php:245
 msgid "You must be logged in to use addons. "
 msgstr ""
 
@@ -1377,7 +1234,7 @@ msgstr ""
 msgid "No contacts in common."
 msgstr ""
 
-#: mod/common.php:140 mod/contacts.php:877
+#: mod/common.php:140 mod/contacts.php:886
 msgid "Common Friends"
 msgstr ""
 
@@ -1400,8 +1257,8 @@ msgstr ""
 msgid "Contact update failed."
 msgstr ""
 
-#: mod/crepair.php:110 mod/dfrn_confirm.php:131 mod/fsuggest.php:29
-#: mod/fsuggest.php:97
+#: mod/crepair.php:110 mod/dfrn_confirm.php:131 mod/fsuggest.php:30
+#: mod/fsuggest.php:96
 msgid "Contact not found."
 msgstr ""
 
@@ -1438,14 +1295,14 @@ msgid "Refetch contact data"
 msgstr ""
 
 #: mod/crepair.php:148 mod/invite.php:150 mod/manage.php:184
-#: mod/profiles.php:685 mod/contacts.php:601 mod/install.php:251
-#: mod/install.php:290 mod/localtime.php:56 mod/poke.php:199 mod/events.php:533
-#: mod/fsuggest.php:116 mod/message.php:265 mod/message.php:432
-#: mod/photos.php:1080 mod/photos.php:1160 mod/photos.php:1445
-#: mod/photos.php:1491 mod/photos.php:1530 mod/photos.php:1603
-#: view/theme/duepuntozero/config.php:71 view/theme/frio/config.php:113
-#: view/theme/quattro/config.php:73 view/theme/vier/config.php:119
-#: src/Object/Post.php:788
+#: mod/localtime.php:56 mod/poke.php:199 mod/fsuggest.php:114
+#: mod/message.php:265 mod/message.php:432 mod/photos.php:1080
+#: mod/photos.php:1160 mod/photos.php:1445 mod/photos.php:1491
+#: mod/photos.php:1530 mod/photos.php:1603 mod/contacts.php:610
+#: mod/events.php:530 mod/install.php:251 mod/install.php:290
+#: mod/profiles.php:671 view/theme/duepuntozero/config.php:71
+#: view/theme/frio/config.php:113 view/theme/quattro/config.php:73
+#: view/theme/vier/config.php:119 src/Object/Post.php:790
 msgid "Submit"
 msgstr ""
 
@@ -1463,9 +1320,9 @@ msgid ""
 "entries from this contact."
 msgstr ""
 
-#: mod/crepair.php:158 mod/admin.php:439 mod/admin.php:1689 mod/admin.php:1701
-#: mod/admin.php:1714 mod/admin.php:1730 mod/settings.php:681
-#: mod/settings.php:707
+#: mod/crepair.php:158 mod/admin.php:439 mod/admin.php:1714 mod/admin.php:1726
+#: mod/admin.php:1739 mod/admin.php:1755 mod/settings.php:677
+#: mod/settings.php:703
 msgid "Name"
 msgstr ""
 
@@ -1513,7 +1370,7 @@ msgstr ""
 msgid "Contact Photos"
 msgstr ""
 
-#: mod/fbrowser.php:105 mod/fbrowser.php:136 mod/profile_photo.php:265
+#: mod/fbrowser.php:105 mod/fbrowser.php:136 mod/profile_photo.php:250
 msgid "Upload"
 msgstr ""
 
@@ -1522,7 +1379,7 @@ msgid "Files"
 msgstr ""
 
 #: mod/fetch.php:16 mod/fetch.php:52 mod/fetch.php:65 mod/help.php:60
-#: mod/p.php:21 mod/p.php:48 mod/p.php:57 index.php:289
+#: mod/p.php:21 mod/p.php:48 mod/p.php:57 index.php:292
 msgid "Not Found"
 msgstr ""
 
@@ -1538,7 +1395,7 @@ msgstr ""
 msgid "Help"
 msgstr ""
 
-#: mod/help.php:63 index.php:294
+#: mod/help.php:63 index.php:297
 msgid "Page not found."
 msgstr ""
 
@@ -1590,8 +1447,8 @@ msgid ""
 "join."
 msgstr ""
 
-#: mod/newmember.php:19 mod/admin.php:1814 mod/admin.php:2083
-#: mod/settings.php:122 view/theme/frio/theme.php:269 src/Content/Nav.php:206
+#: mod/newmember.php:19 mod/admin.php:1839 mod/admin.php:2108
+#: mod/settings.php:124 view/theme/frio/theme.php:269 src/Content/Nav.php:206
 msgid "Settings"
 msgstr ""
 
@@ -1614,14 +1471,14 @@ msgid ""
 "potential friends know exactly how to find you."
 msgstr ""
 
-#: mod/newmember.php:24 mod/contacts.php:662 mod/contacts.php:854
-#: mod/profperm.php:113 view/theme/frio/theme.php:260 src/Content/Nav.php:101
+#: mod/newmember.php:24 mod/profperm.php:113 mod/contacts.php:671
+#: mod/contacts.php:863 view/theme/frio/theme.php:260 src/Content/Nav.php:101
 #: src/Model/Profile.php:730 src/Model/Profile.php:863
 #: src/Model/Profile.php:896
 msgid "Profile"
 msgstr ""
 
-#: mod/newmember.php:26 mod/profiles.php:704 mod/profile_photo.php:264
+#: mod/newmember.php:26 mod/profile_photo.php:249 mod/profiles.php:690
 msgid "Upload Profile Photo"
 msgstr ""
 
@@ -1704,7 +1561,7 @@ msgid ""
 "hours."
 msgstr ""
 
-#: mod/newmember.php:43 src/Model/Group.php:402
+#: mod/newmember.php:43 src/Model/Group.php:401
 msgid "Groups"
 msgstr ""
 
@@ -1744,13 +1601,13 @@ msgid ""
 "features and resources."
 msgstr ""
 
-#: mod/nogroup.php:42 mod/contacts.php:610 mod/contacts.php:943
-#: mod/viewcontacts.php:112
+#: mod/nogroup.php:42 mod/viewcontacts.php:112 mod/contacts.php:619
+#: mod/contacts.php:959
 #, php-format
 msgid "Visit %s's profile [%s]"
 msgstr ""
 
-#: mod/nogroup.php:43 mod/contacts.php:944
+#: mod/nogroup.php:43 mod/contacts.php:960
 msgid "Edit contact"
 msgstr ""
 
@@ -1770,11 +1627,11 @@ msgstr ""
 msgid "Error"
 msgstr ""
 
-#: mod/repair_ostatus.php:48 mod/ostatus_subscribe.php:61
+#: mod/repair_ostatus.php:48 mod/ostatus_subscribe.php:64
 msgid "Done"
 msgstr ""
 
-#: mod/repair_ostatus.php:54 mod/ostatus_subscribe.php:85
+#: mod/repair_ostatus.php:54 mod/ostatus_subscribe.php:88
 msgid "Keep this window open until done."
 msgstr ""
 
@@ -1794,44 +1651,6 @@ msgstr ""
 
 #: mod/suggest.php:114 view/theme/vier/theme.php:203 src/Content/Widget.php:64
 msgid "Friend Suggestions"
-msgstr ""
-
-#: mod/unfollow.php:34
-msgid "Contact wasn't found or can't be unfollowed."
-msgstr ""
-
-#: mod/unfollow.php:47
-msgid "Contact unfollowed"
-msgstr ""
-
-#: mod/unfollow.php:65 mod/dfrn_request.php:662 mod/follow.php:61
-msgid "Submit Request"
-msgstr ""
-
-#: mod/unfollow.php:73
-msgid "You aren't a friend of this contact."
-msgstr ""
-
-#: mod/unfollow.php:79
-msgid "Unfollowing is currently not supported by your network."
-msgstr ""
-
-#: mod/unfollow.php:100 mod/contacts.php:590
-msgid "Disconnect/Unfollow"
-msgstr ""
-
-#: mod/unfollow.php:113 mod/dfrn_request.php:660 mod/follow.php:155
-msgid "Your Identity Address:"
-msgstr ""
-
-#: mod/unfollow.php:122 mod/notifications.php:258 mod/contacts.php:647
-#: mod/follow.php:164 mod/admin.php:439 mod/admin.php:449
-msgid "Profile URL"
-msgstr ""
-
-#: mod/unfollow.php:132 mod/contacts.php:849 mod/follow.php:181
-#: src/Model/Profile.php:891
-msgid "Status Messages and Posts"
 msgstr ""
 
 #: mod/update_community.php:27 mod/update_display.php:27
@@ -1885,20 +1704,6 @@ msgstr ""
 msgid "%1$s welcomes %2$s"
 msgstr ""
 
-#: mod/dirfind.php:48
-#, php-format
-msgid "People Search - %s"
-msgstr ""
-
-#: mod/dirfind.php:59
-#, php-format
-msgid "Forum Search - %s"
-msgstr ""
-
-#: mod/dirfind.php:256 mod/match.php:125
-msgid "No matches"
-msgstr ""
-
 #: mod/friendica.php:77
 msgid "This is Friendica, version"
 msgstr ""
@@ -1940,7 +1745,7 @@ msgid "On this server the following remote servers are blocked."
 msgstr ""
 
 #: mod/friendica.php:123 mod/dfrn_request.php:351 mod/admin.php:302
-#: mod/admin.php:320 src/Model/Contact.php:1142
+#: mod/admin.php:320 src/Model/Contact.php:1228
 msgid "Blocked domain"
 msgstr ""
 
@@ -1960,6 +1765,10 @@ msgstr ""
 msgid "Profile Match"
 msgstr ""
 
+#: mod/match.php:125 mod/dirfind.php:253
+msgid "No matches"
+msgstr ""
+
 #: mod/notifications.php:37
 msgid "Invalid request identifier."
 msgstr ""
@@ -1969,7 +1778,7 @@ msgid "Discard"
 msgstr ""
 
 #: mod/notifications.php:62 mod/notifications.php:182 mod/notifications.php:266
-#: mod/contacts.php:629 mod/contacts.php:819 mod/contacts.php:1003
+#: mod/contacts.php:638 mod/contacts.php:828 mod/contacts.php:1019
 msgid "Ignore"
 msgstr ""
 
@@ -2010,7 +1819,7 @@ msgstr ""
 msgid "suggested by %s"
 msgstr ""
 
-#: mod/notifications.php:175 mod/notifications.php:254 mod/contacts.php:637
+#: mod/notifications.php:175 mod/notifications.php:254 mod/contacts.php:646
 msgid "Hide this contact from others"
 msgstr ""
 
@@ -2022,7 +1831,7 @@ msgstr ""
 msgid "if applicable"
 msgstr ""
 
-#: mod/notifications.php:179 mod/notifications.php:264 mod/admin.php:1704
+#: mod/notifications.php:179 mod/notifications.php:264 mod/admin.php:1729
 msgid "Approve"
 msgstr ""
 
@@ -2075,12 +1884,18 @@ msgstr ""
 msgid "Subscriber"
 msgstr ""
 
-#: mod/notifications.php:249 mod/contacts.php:655 mod/directory.php:155
+#: mod/notifications.php:247 mod/contacts.php:660 mod/directory.php:149
+#: mod/events.php:518 src/Model/Profile.php:417 src/Model/Event.php:60
+#: src/Model/Event.php:85 src/Model/Event.php:421 src/Model/Event.php:900
+msgid "Location:"
+msgstr ""
+
+#: mod/notifications.php:249 mod/contacts.php:664 mod/directory.php:155
 #: src/Model/Profile.php:423 src/Model/Profile.php:806
 msgid "About:"
 msgstr ""
 
-#: mod/notifications.php:251 mod/contacts.php:657 mod/follow.php:172
+#: mod/notifications.php:251 mod/contacts.php:666 mod/follow.php:174
 #: src/Model/Profile.php:794
 msgid "Tags:"
 msgstr ""
@@ -2090,7 +1905,12 @@ msgstr ""
 msgid "Gender:"
 msgstr ""
 
-#: mod/notifications.php:261 mod/contacts.php:63 src/Model/Profile.php:518
+#: mod/notifications.php:258 mod/admin.php:439 mod/admin.php:449
+#: mod/contacts.php:656 mod/follow.php:166 mod/unfollow.php:122
+msgid "Profile URL"
+msgstr ""
+
+#: mod/notifications.php:261 mod/contacts.php:71 src/Model/Profile.php:518
 msgid "Network:"
 msgstr ""
 
@@ -2111,10 +1931,6 @@ msgstr ""
 msgid "No more %s notifications."
 msgstr ""
 
-#: mod/oexchange.php:30
-msgid "Post successful."
-msgstr ""
-
 #: mod/openid.php:29
 msgid "OpenID protocol error. No ID returned."
 msgstr ""
@@ -2128,78 +1944,8 @@ msgstr ""
 msgid "Login failed."
 msgstr ""
 
-#: mod/ostatus_subscribe.php:21
-msgid "Subscribing to OStatus contacts"
-msgstr ""
-
-#: mod/ostatus_subscribe.php:32
-msgid "No contact provided."
-msgstr ""
-
-#: mod/ostatus_subscribe.php:38
-msgid "Couldn't fetch information for contact."
-msgstr ""
-
-#: mod/ostatus_subscribe.php:47
-msgid "Couldn't fetch friends for contact."
-msgstr ""
-
-#: mod/ostatus_subscribe.php:75
-msgid "success"
-msgstr ""
-
-#: mod/ostatus_subscribe.php:77
-msgid "failed"
-msgstr ""
-
-#: mod/ostatus_subscribe.php:80 src/Object/Post.php:278
-msgid "ignored"
-msgstr ""
-
-#: mod/cal.php:142 mod/display.php:308 mod/profile.php:173
-msgid "Access to this profile has been restricted."
-msgstr ""
-
-#: mod/cal.php:274 mod/events.php:392 view/theme/frio/theme.php:263
-#: view/theme/frio/theme.php:267 src/Content/Nav.php:104
-#: src/Content/Nav.php:169 src/Model/Profile.php:924 src/Model/Profile.php:935
-msgid "Events"
-msgstr ""
-
-#: mod/cal.php:275 mod/events.php:393
-msgid "View"
-msgstr ""
-
-#: mod/cal.php:276 mod/events.php:395
-msgid "Previous"
-msgstr ""
-
-#: mod/cal.php:277 mod/install.php:209 mod/events.php:396
-msgid "Next"
-msgstr ""
-
-#: mod/cal.php:284 mod/events.php:405
-msgid "list"
-msgstr ""
-
-#: mod/cal.php:297 src/Model/User.php:202
-msgid "User not found"
-msgstr ""
-
-#: mod/cal.php:313
-msgid "This calendar format is not supported"
-msgstr ""
-
-#: mod/cal.php:315
-msgid "No exportable data found"
-msgstr ""
-
-#: mod/cal.php:332
-msgid "calendar"
-msgstr ""
-
 #: mod/dfrn_confirm.php:74 mod/profiles.php:38 mod/profiles.php:148
-#: mod/profiles.php:195 mod/profiles.php:631
+#: mod/profiles.php:195 mod/profiles.php:617
 msgid "Profile not found."
 msgstr ""
 
@@ -2273,7 +2019,7 @@ msgstr ""
 msgid "Unable to update your contact profile details on our system"
 msgstr ""
 
-#: mod/dfrn_confirm.php:661 mod/dfrn_request.php:568 src/Model/Contact.php:1434
+#: mod/dfrn_confirm.php:661 mod/dfrn_request.php:568 src/Model/Contact.php:1520
 msgid "[Name Withheld]"
 msgstr ""
 
@@ -2405,362 +2151,6 @@ msgstr ""
 msgid "Select an identity to manage: "
 msgstr ""
 
-#: mod/profiles.php:57
-msgid "Profile deleted."
-msgstr ""
-
-#: mod/profiles.php:73 mod/profiles.php:109
-msgid "Profile-"
-msgstr ""
-
-#: mod/profiles.php:92 mod/profiles.php:131
-msgid "New profile created."
-msgstr ""
-
-#: mod/profiles.php:115
-msgid "Profile unavailable to clone."
-msgstr ""
-
-#: mod/profiles.php:205
-msgid "Profile Name is required."
-msgstr ""
-
-#: mod/profiles.php:346
-msgid "Marital Status"
-msgstr ""
-
-#: mod/profiles.php:350
-msgid "Romantic Partner"
-msgstr ""
-
-#: mod/profiles.php:362
-msgid "Work/Employment"
-msgstr ""
-
-#: mod/profiles.php:365
-msgid "Religion"
-msgstr ""
-
-#: mod/profiles.php:369
-msgid "Political Views"
-msgstr ""
-
-#: mod/profiles.php:373
-msgid "Gender"
-msgstr ""
-
-#: mod/profiles.php:377
-msgid "Sexual Preference"
-msgstr ""
-
-#: mod/profiles.php:381
-msgid "XMPP"
-msgstr ""
-
-#: mod/profiles.php:385
-msgid "Homepage"
-msgstr ""
-
-#: mod/profiles.php:389 mod/profiles.php:699
-msgid "Interests"
-msgstr ""
-
-#: mod/profiles.php:393 mod/admin.php:439
-msgid "Address"
-msgstr ""
-
-#: mod/profiles.php:400 mod/profiles.php:695
-msgid "Location"
-msgstr ""
-
-#: mod/profiles.php:485
-msgid "Profile updated."
-msgstr ""
-
-#: mod/profiles.php:577
-msgid " and "
-msgstr ""
-
-#: mod/profiles.php:586
-msgid "public profile"
-msgstr ""
-
-#: mod/profiles.php:589
-#, php-format
-msgid "%1$s changed %2$s to &ldquo;%3$s&rdquo;"
-msgstr ""
-
-#: mod/profiles.php:590
-#, php-format
-msgid " - Visit %1$s's %2$s"
-msgstr ""
-
-#: mod/profiles.php:592
-#, php-format
-msgid "%1$s has an updated %2$s, changing %3$s."
-msgstr ""
-
-#: mod/profiles.php:646
-msgid "Hide contacts and friends:"
-msgstr ""
-
-#: mod/profiles.php:651
-msgid "Hide your contact/friend list from viewers of this profile?"
-msgstr ""
-
-#: mod/profiles.php:671
-msgid "Show more profile fields:"
-msgstr ""
-
-#: mod/profiles.php:683
-msgid "Profile Actions"
-msgstr ""
-
-#: mod/profiles.php:684
-msgid "Edit Profile Details"
-msgstr ""
-
-#: mod/profiles.php:686
-msgid "Change Profile Photo"
-msgstr ""
-
-#: mod/profiles.php:687
-msgid "View this profile"
-msgstr ""
-
-#: mod/profiles.php:688 mod/profiles.php:783 src/Model/Profile.php:393
-msgid "Edit visibility"
-msgstr ""
-
-#: mod/profiles.php:689
-msgid "Create a new profile using these settings"
-msgstr ""
-
-#: mod/profiles.php:690
-msgid "Clone this profile"
-msgstr ""
-
-#: mod/profiles.php:691
-msgid "Delete this profile"
-msgstr ""
-
-#: mod/profiles.php:693
-msgid "Basic information"
-msgstr ""
-
-#: mod/profiles.php:694
-msgid "Profile picture"
-msgstr ""
-
-#: mod/profiles.php:696
-msgid "Preferences"
-msgstr ""
-
-#: mod/profiles.php:697
-msgid "Status information"
-msgstr ""
-
-#: mod/profiles.php:698
-msgid "Additional information"
-msgstr ""
-
-#: mod/profiles.php:700 mod/network.php:940
-#: src/Core/NotificationsManager.php:185
-msgid "Personal"
-msgstr ""
-
-#: mod/profiles.php:701
-msgid "Relation"
-msgstr ""
-
-#: mod/profiles.php:702 src/Util/Temporal.php:81 src/Util/Temporal.php:83
-msgid "Miscellaneous"
-msgstr ""
-
-#: mod/profiles.php:705
-msgid "Your Gender:"
-msgstr ""
-
-#: mod/profiles.php:706
-msgid "<span class=\"heart\">&hearts;</span> Marital Status:"
-msgstr ""
-
-#: mod/profiles.php:707 src/Model/Profile.php:782
-msgid "Sexual Preference:"
-msgstr ""
-
-#: mod/profiles.php:708
-msgid "Example: fishing photography software"
-msgstr ""
-
-#: mod/profiles.php:713
-msgid "Profile Name:"
-msgstr ""
-
-#: mod/profiles.php:713 mod/events.php:511 mod/events.php:523
-msgid "Required"
-msgstr ""
-
-#: mod/profiles.php:715
-msgid ""
-"This is your <strong>public</strong> profile.<br />It <strong>may</strong> "
-"be visible to anybody using the internet."
-msgstr ""
-
-#: mod/profiles.php:716
-msgid "Your Full Name:"
-msgstr ""
-
-#: mod/profiles.php:717
-msgid "Title/Description:"
-msgstr ""
-
-#: mod/profiles.php:720
-msgid "Street Address:"
-msgstr ""
-
-#: mod/profiles.php:721
-msgid "Locality/City:"
-msgstr ""
-
-#: mod/profiles.php:722
-msgid "Region/State:"
-msgstr ""
-
-#: mod/profiles.php:723
-msgid "Postal/Zip Code:"
-msgstr ""
-
-#: mod/profiles.php:724
-msgid "Country:"
-msgstr ""
-
-#: mod/profiles.php:725 src/Util/Temporal.php:149
-msgid "Age: "
-msgstr ""
-
-#: mod/profiles.php:728
-msgid "Who: (if applicable)"
-msgstr ""
-
-#: mod/profiles.php:728
-msgid "Examples: cathy123, Cathy Williams, cathy@example.com"
-msgstr ""
-
-#: mod/profiles.php:729
-msgid "Since [date]:"
-msgstr ""
-
-#: mod/profiles.php:731
-msgid "Tell us about yourself..."
-msgstr ""
-
-#: mod/profiles.php:732
-msgid "XMPP (Jabber) address:"
-msgstr ""
-
-#: mod/profiles.php:732
-msgid ""
-"The XMPP address will be propagated to your contacts so that they can follow "
-"you."
-msgstr ""
-
-#: mod/profiles.php:733
-msgid "Homepage URL:"
-msgstr ""
-
-#: mod/profiles.php:734 src/Model/Profile.php:790
-msgid "Hometown:"
-msgstr ""
-
-#: mod/profiles.php:735 src/Model/Profile.php:798
-msgid "Political Views:"
-msgstr ""
-
-#: mod/profiles.php:736
-msgid "Religious Views:"
-msgstr ""
-
-#: mod/profiles.php:737
-msgid "Public Keywords:"
-msgstr ""
-
-#: mod/profiles.php:737
-msgid "(Used for suggesting potential friends, can be seen by others)"
-msgstr ""
-
-#: mod/profiles.php:738
-msgid "Private Keywords:"
-msgstr ""
-
-#: mod/profiles.php:738
-msgid "(Used for searching profiles, never shown to others)"
-msgstr ""
-
-#: mod/profiles.php:739 src/Model/Profile.php:814
-msgid "Likes:"
-msgstr ""
-
-#: mod/profiles.php:740 src/Model/Profile.php:818
-msgid "Dislikes:"
-msgstr ""
-
-#: mod/profiles.php:741
-msgid "Musical interests"
-msgstr ""
-
-#: mod/profiles.php:742
-msgid "Books, literature"
-msgstr ""
-
-#: mod/profiles.php:743
-msgid "Television"
-msgstr ""
-
-#: mod/profiles.php:744
-msgid "Film/dance/culture/entertainment"
-msgstr ""
-
-#: mod/profiles.php:745
-msgid "Hobbies/Interests"
-msgstr ""
-
-#: mod/profiles.php:746
-msgid "Love/romance"
-msgstr ""
-
-#: mod/profiles.php:747
-msgid "Work/employment"
-msgstr ""
-
-#: mod/profiles.php:748
-msgid "School/education"
-msgstr ""
-
-#: mod/profiles.php:749
-msgid "Contact information and Social Networks"
-msgstr ""
-
-#: mod/profiles.php:780 src/Model/Profile.php:389
-msgid "Profile Image"
-msgstr ""
-
-#: mod/profiles.php:782 src/Model/Profile.php:392
-msgid "visible to everybody"
-msgstr ""
-
-#: mod/profiles.php:789
-msgid "Edit/Manage Profiles"
-msgstr ""
-
-#: mod/profiles.php:790 src/Model/Profile.php:379 src/Model/Profile.php:401
-msgid "Change profile photo"
-msgstr ""
-
-#: mod/profiles.php:791 src/Model/Profile.php:380
-msgid "Create New Profile"
-msgstr ""
-
 #: mod/wall_attach.php:24 mod/wall_attach.php:32 mod/wall_attach.php:83
 #: mod/wall_upload.php:38 mod/wall_upload.php:54 mod/wall_upload.php:112
 #: mod/wall_upload.php:155 mod/wall_upload.php:158
@@ -2782,455 +2172,6 @@ msgstr ""
 
 #: mod/wall_attach.php:136 mod/wall_attach.php:152
 msgid "File upload failed."
-msgstr ""
-
-#: mod/contacts.php:149
-#, php-format
-msgid "%d contact edited."
-msgid_plural "%d contacts edited."
-msgstr[0] ""
-msgstr[1] ""
-
-#: mod/contacts.php:176 mod/contacts.php:392
-msgid "Could not access contact record."
-msgstr ""
-
-#: mod/contacts.php:186
-msgid "Could not locate selected profile."
-msgstr ""
-
-#: mod/contacts.php:220
-msgid "Contact updated."
-msgstr ""
-
-#: mod/contacts.php:222 mod/dfrn_request.php:419
-msgid "Failed to update contact record."
-msgstr ""
-
-#: mod/contacts.php:413
-msgid "Contact has been blocked"
-msgstr ""
-
-#: mod/contacts.php:413
-msgid "Contact has been unblocked"
-msgstr ""
-
-#: mod/contacts.php:424
-msgid "Contact has been ignored"
-msgstr ""
-
-#: mod/contacts.php:424
-msgid "Contact has been unignored"
-msgstr ""
-
-#: mod/contacts.php:435
-msgid "Contact has been archived"
-msgstr ""
-
-#: mod/contacts.php:435
-msgid "Contact has been unarchived"
-msgstr ""
-
-#: mod/contacts.php:459
-msgid "Drop contact"
-msgstr ""
-
-#: mod/contacts.php:462 mod/contacts.php:814
-msgid "Do you really want to delete this contact?"
-msgstr ""
-
-#: mod/contacts.php:480
-msgid "Contact has been removed."
-msgstr ""
-
-#: mod/contacts.php:511
-#, php-format
-msgid "You are mutual friends with %s"
-msgstr ""
-
-#: mod/contacts.php:515
-#, php-format
-msgid "You are sharing with %s"
-msgstr ""
-
-#: mod/contacts.php:519
-#, php-format
-msgid "%s is sharing with you"
-msgstr ""
-
-#: mod/contacts.php:539
-msgid "Private communications are not available for this contact."
-msgstr ""
-
-#: mod/contacts.php:541
-msgid "Never"
-msgstr ""
-
-#: mod/contacts.php:544
-msgid "(Update was successful)"
-msgstr ""
-
-#: mod/contacts.php:544
-msgid "(Update was not successful)"
-msgstr ""
-
-#: mod/contacts.php:546 mod/contacts.php:976
-msgid "Suggest friends"
-msgstr ""
-
-#: mod/contacts.php:550
-#, php-format
-msgid "Network type: %s"
-msgstr ""
-
-#: mod/contacts.php:555
-msgid "Communications lost with this contact!"
-msgstr ""
-
-#: mod/contacts.php:561
-msgid "Fetch further information for feeds"
-msgstr ""
-
-#: mod/contacts.php:563
-msgid ""
-"Fetch information like preview pictures, title and teaser from the feed "
-"item. You can activate this if the feed doesn't contain much text. Keywords "
-"are taken from the meta header in the feed item and are posted as hash tags."
-msgstr ""
-
-#: mod/contacts.php:564 mod/admin.php:1190
-msgid "Disabled"
-msgstr ""
-
-#: mod/contacts.php:565
-msgid "Fetch information"
-msgstr ""
-
-#: mod/contacts.php:566
-msgid "Fetch keywords"
-msgstr ""
-
-#: mod/contacts.php:567
-msgid "Fetch information and keywords"
-msgstr ""
-
-#: mod/contacts.php:599
-msgid "Contact"
-msgstr ""
-
-#: mod/contacts.php:602
-msgid "Profile Visibility"
-msgstr ""
-
-#: mod/contacts.php:603
-#, php-format
-msgid ""
-"Please choose the profile you would like to display to %s when viewing your "
-"profile securely."
-msgstr ""
-
-#: mod/contacts.php:604
-msgid "Contact Information / Notes"
-msgstr ""
-
-#: mod/contacts.php:605
-msgid "Their personal note"
-msgstr ""
-
-#: mod/contacts.php:607
-msgid "Edit contact notes"
-msgstr ""
-
-#: mod/contacts.php:611
-msgid "Block/Unblock contact"
-msgstr ""
-
-#: mod/contacts.php:612
-msgid "Ignore contact"
-msgstr ""
-
-#: mod/contacts.php:613
-msgid "Repair URL settings"
-msgstr ""
-
-#: mod/contacts.php:614
-msgid "View conversations"
-msgstr ""
-
-#: mod/contacts.php:619
-msgid "Last update:"
-msgstr ""
-
-#: mod/contacts.php:621
-msgid "Update public posts"
-msgstr ""
-
-#: mod/contacts.php:623 mod/contacts.php:986
-msgid "Update now"
-msgstr ""
-
-#: mod/contacts.php:628 mod/contacts.php:818 mod/contacts.php:995
-#: mod/admin.php:434 mod/admin.php:1708
-msgid "Unblock"
-msgstr ""
-
-#: mod/contacts.php:628 mod/contacts.php:818 mod/contacts.php:995
-#: mod/admin.php:433 mod/admin.php:1707
-msgid "Block"
-msgstr ""
-
-#: mod/contacts.php:629 mod/contacts.php:819 mod/contacts.php:1003
-msgid "Unignore"
-msgstr ""
-
-#: mod/contacts.php:633
-msgid "Currently blocked"
-msgstr ""
-
-#: mod/contacts.php:634
-msgid "Currently ignored"
-msgstr ""
-
-#: mod/contacts.php:635
-msgid "Currently archived"
-msgstr ""
-
-#: mod/contacts.php:636
-msgid "Awaiting connection acknowledge"
-msgstr ""
-
-#: mod/contacts.php:637
-msgid ""
-"Replies/likes to your public posts <strong>may</strong> still be visible"
-msgstr ""
-
-#: mod/contacts.php:638
-msgid "Notification for new posts"
-msgstr ""
-
-#: mod/contacts.php:638
-msgid "Send a notification of every new post of this contact"
-msgstr ""
-
-#: mod/contacts.php:641
-msgid "Blacklisted keywords"
-msgstr ""
-
-#: mod/contacts.php:641
-msgid ""
-"Comma separated list of keywords that should not be converted to hashtags, "
-"when \"Fetch information and keywords\" is selected"
-msgstr ""
-
-#: mod/contacts.php:653 src/Model/Profile.php:424
-msgid "XMPP:"
-msgstr ""
-
-#: mod/contacts.php:658
-msgid "Actions"
-msgstr ""
-
-#: mod/contacts.php:660 mod/contacts.php:846 view/theme/frio/theme.php:259
-#: src/Content/Nav.php:100 src/Model/Profile.php:888
-msgid "Status"
-msgstr ""
-
-#: mod/contacts.php:661
-msgid "Contact Settings"
-msgstr ""
-
-#: mod/contacts.php:702
-msgid "Suggestions"
-msgstr ""
-
-#: mod/contacts.php:705
-msgid "Suggest potential friends"
-msgstr ""
-
-#: mod/contacts.php:710 mod/group.php:216
-msgid "All Contacts"
-msgstr ""
-
-#: mod/contacts.php:713
-msgid "Show all contacts"
-msgstr ""
-
-#: mod/contacts.php:718
-msgid "Unblocked"
-msgstr ""
-
-#: mod/contacts.php:721
-msgid "Only show unblocked contacts"
-msgstr ""
-
-#: mod/contacts.php:726
-msgid "Blocked"
-msgstr ""
-
-#: mod/contacts.php:729
-msgid "Only show blocked contacts"
-msgstr ""
-
-#: mod/contacts.php:734
-msgid "Ignored"
-msgstr ""
-
-#: mod/contacts.php:737
-msgid "Only show ignored contacts"
-msgstr ""
-
-#: mod/contacts.php:742
-msgid "Archived"
-msgstr ""
-
-#: mod/contacts.php:745
-msgid "Only show archived contacts"
-msgstr ""
-
-#: mod/contacts.php:750
-msgid "Hidden"
-msgstr ""
-
-#: mod/contacts.php:753
-msgid "Only show hidden contacts"
-msgstr ""
-
-#: mod/contacts.php:809
-msgid "Search your contacts"
-msgstr ""
-
-#: mod/contacts.php:810 mod/search.php:236
-#, php-format
-msgid "Results for: %s"
-msgstr ""
-
-#: mod/contacts.php:811 mod/directory.php:210 src/Content/Widget.php:63
-msgid "Find"
-msgstr ""
-
-#: mod/contacts.php:817 mod/settings.php:169 mod/settings.php:705
-msgid "Update"
-msgstr ""
-
-#: mod/contacts.php:820 mod/contacts.php:1011
-msgid "Archive"
-msgstr ""
-
-#: mod/contacts.php:820 mod/contacts.php:1011
-msgid "Unarchive"
-msgstr ""
-
-#: mod/contacts.php:823
-msgid "Batch Actions"
-msgstr ""
-
-#: mod/contacts.php:857 src/Model/Profile.php:899
-msgid "Profile Details"
-msgstr ""
-
-#: mod/contacts.php:869
-msgid "View all contacts"
-msgstr ""
-
-#: mod/contacts.php:880
-msgid "View all common friends"
-msgstr ""
-
-#: mod/contacts.php:886 mod/admin.php:1269 mod/events.php:535
-#: src/Model/Profile.php:865
-msgid "Advanced"
-msgstr ""
-
-#: mod/contacts.php:889
-msgid "Advanced Contact Settings"
-msgstr ""
-
-#: mod/contacts.php:921
-msgid "Mutual Friendship"
-msgstr ""
-
-#: mod/contacts.php:925
-msgid "is a fan of yours"
-msgstr ""
-
-#: mod/contacts.php:929
-msgid "you are a fan of"
-msgstr ""
-
-#: mod/contacts.php:997
-msgid "Toggle Blocked status"
-msgstr ""
-
-#: mod/contacts.php:1005
-msgid "Toggle Ignored status"
-msgstr ""
-
-#: mod/contacts.php:1013
-msgid "Toggle Archive status"
-msgstr ""
-
-#: mod/contacts.php:1021
-msgid "Delete contact"
-msgstr ""
-
-#: mod/delegate.php:142
-msgid "No parent user"
-msgstr ""
-
-#: mod/delegate.php:158
-msgid "Parent User"
-msgstr ""
-
-#: mod/delegate.php:160
-msgid ""
-"Parent users have total control about this account, including the account "
-"settings. Please double check whom you give this access."
-msgstr ""
-
-#: mod/delegate.php:161 mod/admin.php:1264 mod/admin.php:1873
-#: mod/admin.php:2126 mod/admin.php:2200 mod/admin.php:2347
-#: mod/settings.php:679 mod/settings.php:788 mod/settings.php:874
-#: mod/settings.php:963 mod/settings.php:1198
-msgid "Save Settings"
-msgstr ""
-
-#: mod/delegate.php:162 src/Content/Nav.php:204
-msgid "Delegate Page Management"
-msgstr ""
-
-#: mod/delegate.php:163
-msgid "Delegates"
-msgstr ""
-
-#: mod/delegate.php:165
-msgid ""
-"Delegates are able to manage all aspects of this account/page except for "
-"basic account settings. Please do not delegate your personal account to "
-"anybody that you do not trust completely."
-msgstr ""
-
-#: mod/delegate.php:166
-msgid "Existing Page Managers"
-msgstr ""
-
-#: mod/delegate.php:168
-msgid "Existing Page Delegates"
-msgstr ""
-
-#: mod/delegate.php:170
-msgid "Potential Delegates"
-msgstr ""
-
-#: mod/delegate.php:172 mod/tagrm.php:98
-msgid "Remove"
-msgstr ""
-
-#: mod/delegate.php:173
-msgid "Add"
-msgstr ""
-
-#: mod/delegate.php:174
-msgid "No entries."
 msgstr ""
 
 #: mod/dfrn_request.php:94
@@ -3298,8 +2239,12 @@ msgstr ""
 msgid "Invalid profile URL."
 msgstr ""
 
-#: mod/dfrn_request.php:345 src/Model/Contact.php:1137
+#: mod/dfrn_request.php:345 src/Model/Contact.php:1223
 msgid "Disallowed profile URL."
+msgstr ""
+
+#: mod/dfrn_request.php:419 mod/contacts.php:230
+msgid "Failed to update contact record."
 msgstr ""
 
 #: mod/dfrn_request.php:439
@@ -3342,8 +2287,8 @@ msgstr ""
 
 #: mod/dfrn_request.php:607 mod/probe.php:13 mod/search.php:98
 #: mod/search.php:104 mod/viewcontacts.php:45 mod/webfinger.php:16
-#: mod/community.php:25 mod/directory.php:42 mod/display.php:201
-#: mod/photos.php:932 mod/videos.php:200
+#: mod/community.php:27 mod/photos.php:932 mod/videos.php:199
+#: mod/directory.php:42 mod/display.php:203
 msgid "Public access denied."
 msgstr ""
 
@@ -3370,16 +2315,16 @@ msgid ""
 "testuser@gnusocial.de"
 msgstr ""
 
-#: mod/dfrn_request.php:652 mod/follow.php:147
+#: mod/dfrn_request.php:652 mod/follow.php:149
 msgid "Please answer the following:"
 msgstr ""
 
-#: mod/dfrn_request.php:653 mod/follow.php:148
+#: mod/dfrn_request.php:653 mod/follow.php:150
 #, php-format
 msgid "Does %s know you?"
 msgstr ""
 
-#: mod/dfrn_request.php:654 mod/follow.php:149
+#: mod/dfrn_request.php:654 mod/follow.php:151
 msgid "Add a personal note:"
 msgstr ""
 
@@ -3402,376 +2347,20 @@ msgid ""
 "bar."
 msgstr ""
 
+#: mod/dfrn_request.php:660 mod/follow.php:157 mod/unfollow.php:113
+msgid "Your Identity Address:"
+msgstr ""
+
+#: mod/dfrn_request.php:662 mod/follow.php:62 mod/unfollow.php:65
+msgid "Submit Request"
+msgstr ""
+
 #: mod/filer.php:34
 msgid "- select -"
 msgstr ""
 
-#: mod/follow.php:44
-msgid "The contact could not be added."
-msgstr ""
-
-#: mod/follow.php:72
-msgid "You already added this contact."
-msgstr ""
-
-#: mod/follow.php:81
-msgid "Diaspora support isn't enabled. Contact can't be added."
-msgstr ""
-
-#: mod/follow.php:88
-msgid "OStatus support is disabled. Contact can't be added."
-msgstr ""
-
-#: mod/follow.php:95
-msgid "The network type couldn't be detected. Contact can't be added."
-msgstr ""
-
-#: mod/install.php:114
-msgid "Friendica Communications Server - Setup"
-msgstr ""
-
-#: mod/install.php:120
-msgid "Could not connect to database."
-msgstr ""
-
-#: mod/install.php:124
-msgid "Could not create table."
-msgstr ""
-
-#: mod/install.php:130
-msgid "Your Friendica site database has been installed."
-msgstr ""
-
-#: mod/install.php:135
-msgid ""
-"You may need to import the file \"database.sql\" manually using phpmyadmin "
-"or mysql."
-msgstr ""
-
-#: mod/install.php:136 mod/install.php:208 mod/install.php:553
-msgid "Please see the file \"INSTALL.txt\"."
-msgstr ""
-
-#: mod/install.php:148
-msgid "Database already in use."
-msgstr ""
-
-#: mod/install.php:205
-msgid "System check"
-msgstr ""
-
-#: mod/install.php:210
-msgid "Check again"
-msgstr ""
-
-#: mod/install.php:230
-msgid "Database connection"
-msgstr ""
-
-#: mod/install.php:231
-msgid ""
-"In order to install Friendica we need to know how to connect to your "
-"database."
-msgstr ""
-
-#: mod/install.php:232
-msgid ""
-"Please contact your hosting provider or site administrator if you have "
-"questions about these settings."
-msgstr ""
-
-#: mod/install.php:233
-msgid ""
-"The database you specify below should already exist. If it does not, please "
-"create it before continuing."
-msgstr ""
-
-#: mod/install.php:237
-msgid "Database Server Name"
-msgstr ""
-
-#: mod/install.php:238
-msgid "Database Login Name"
-msgstr ""
-
-#: mod/install.php:239
-msgid "Database Login Password"
-msgstr ""
-
-#: mod/install.php:239
-msgid "For security reasons the password must not be empty"
-msgstr ""
-
-#: mod/install.php:240
-msgid "Database Name"
-msgstr ""
-
-#: mod/install.php:241 mod/install.php:281
-msgid "Site administrator email address"
-msgstr ""
-
-#: mod/install.php:241 mod/install.php:281
-msgid ""
-"Your account email address must match this in order to use the web admin "
-"panel."
-msgstr ""
-
-#: mod/install.php:245 mod/install.php:284
-msgid "Please select a default timezone for your website"
-msgstr ""
-
-#: mod/install.php:271
-msgid "Site settings"
-msgstr ""
-
-#: mod/install.php:285
-msgid "System Language:"
-msgstr ""
-
-#: mod/install.php:285
-msgid ""
-"Set the default language for your Friendica installation interface and to "
-"send emails."
-msgstr ""
-
-#: mod/install.php:325
-msgid "Could not find a command line version of PHP in the web server PATH."
-msgstr ""
-
-#: mod/install.php:326
-msgid ""
-"If you don't have a command line version of PHP installed on your server, "
-"you will not be able to run the background processing. See <a href='https://"
-"github.com/friendica/friendica/blob/master/doc/Install.md#set-up-the-"
-"worker'>'Setup the worker'</a>"
-msgstr ""
-
-#: mod/install.php:330
-msgid "PHP executable path"
-msgstr ""
-
-#: mod/install.php:330
-msgid ""
-"Enter full path to php executable. You can leave this blank to continue the "
-"installation."
-msgstr ""
-
-#: mod/install.php:335
-msgid "Command line PHP"
-msgstr ""
-
-#: mod/install.php:344
-msgid "PHP executable is not the php cli binary (could be cgi-fgci version)"
-msgstr ""
-
-#: mod/install.php:345
-msgid "Found PHP version: "
-msgstr ""
-
-#: mod/install.php:347
-msgid "PHP cli binary"
-msgstr ""
-
-#: mod/install.php:358
-msgid ""
-"The command line version of PHP on your system does not have "
-"\"register_argc_argv\" enabled."
-msgstr ""
-
-#: mod/install.php:359
-msgid "This is required for message delivery to work."
-msgstr ""
-
-#: mod/install.php:361
-msgid "PHP register_argc_argv"
-msgstr ""
-
-#: mod/install.php:384
-msgid ""
-"Error: the \"openssl_pkey_new\" function on this system is not able to "
-"generate encryption keys"
-msgstr ""
-
-#: mod/install.php:385
-msgid ""
-"If running under Windows, please see \"http://www.php.net/manual/en/openssl."
-"installation.php\"."
-msgstr ""
-
-#: mod/install.php:387
-msgid "Generate encryption keys"
-msgstr ""
-
-#: mod/install.php:394
-msgid "libCurl PHP module"
-msgstr ""
-
-#: mod/install.php:395
-msgid "GD graphics PHP module"
-msgstr ""
-
-#: mod/install.php:396
-msgid "OpenSSL PHP module"
-msgstr ""
-
-#: mod/install.php:397
-msgid "PDO or MySQLi PHP module"
-msgstr ""
-
-#: mod/install.php:398
-msgid "mb_string PHP module"
-msgstr ""
-
-#: mod/install.php:399
-msgid "XML PHP module"
-msgstr ""
-
-#: mod/install.php:400
-msgid "iconv module"
-msgstr ""
-
-#: mod/install.php:404 mod/install.php:406
-msgid "Apache mod_rewrite module"
-msgstr ""
-
-#: mod/install.php:404
-msgid ""
-"Error: Apache webserver mod-rewrite module is required but not installed."
-msgstr ""
-
-#: mod/install.php:412
-msgid "Error: libCURL PHP module required but not installed."
-msgstr ""
-
-#: mod/install.php:416
-msgid ""
-"Error: GD graphics PHP module with JPEG support required but not installed."
-msgstr ""
-
-#: mod/install.php:420
-msgid "Error: openssl PHP module required but not installed."
-msgstr ""
-
-#: mod/install.php:424
-msgid "Error: PDO or MySQLi PHP module required but not installed."
-msgstr ""
-
-#: mod/install.php:428
-msgid "Error: The MySQL driver for PDO is not installed."
-msgstr ""
-
-#: mod/install.php:432
-msgid "Error: mb_string PHP module required but not installed."
-msgstr ""
-
-#: mod/install.php:436
-msgid "Error: iconv PHP module required but not installed."
-msgstr ""
-
-#: mod/install.php:446
-msgid "Error, XML PHP module required but not installed."
-msgstr ""
-
-#: mod/install.php:458
-msgid ""
-"The web installer needs to be able to create a file called \".htconfig.php\" "
-"in the top folder of your web server and it is unable to do so."
-msgstr ""
-
-#: mod/install.php:459
-msgid ""
-"This is most often a permission setting, as the web server may not be able "
-"to write files in your folder - even if you can."
-msgstr ""
-
-#: mod/install.php:460
-msgid ""
-"At the end of this procedure, we will give you a text to save in a file "
-"named .htconfig.php in your Friendica top folder."
-msgstr ""
-
-#: mod/install.php:461
-msgid ""
-"You can alternatively skip this procedure and perform a manual installation. "
-"Please see the file \"INSTALL.txt\" for instructions."
-msgstr ""
-
-#: mod/install.php:464
-msgid ".htconfig.php is writable"
-msgstr ""
-
-#: mod/install.php:474
-msgid ""
-"Friendica uses the Smarty3 template engine to render its web views. Smarty3 "
-"compiles templates to PHP to speed up rendering."
-msgstr ""
-
-#: mod/install.php:475
-msgid ""
-"In order to store these compiled templates, the web server needs to have "
-"write access to the directory view/smarty3/ under the Friendica top level "
-"folder."
-msgstr ""
-
-#: mod/install.php:476
-msgid ""
-"Please ensure that the user that your web server runs as (e.g. www-data) has "
-"write access to this folder."
-msgstr ""
-
-#: mod/install.php:477
-msgid ""
-"Note: as a security measure, you should give the web server write access to "
-"view/smarty3/ only--not the template files (.tpl) that it contains."
-msgstr ""
-
-#: mod/install.php:480
-msgid "view/smarty3 is writable"
-msgstr ""
-
-#: mod/install.php:496
-msgid ""
-"Url rewrite in .htaccess is not working. Check your server configuration."
-msgstr ""
-
-#: mod/install.php:498
-msgid "Url rewrite is working"
-msgstr ""
-
-#: mod/install.php:517
-msgid "ImageMagick PHP extension is not installed"
-msgstr ""
-
-#: mod/install.php:519
-msgid "ImageMagick PHP extension is installed"
-msgstr ""
-
-#: mod/install.php:521
-msgid "ImageMagick supports GIF"
-msgstr ""
-
-#: mod/install.php:528
-msgid ""
-"The database configuration file \".htconfig.php\" could not be written. "
-"Please use the enclosed text to create a configuration file in your web "
-"server root."
-msgstr ""
-
-#: mod/install.php:551
-msgid "<h1>What next</h1>"
-msgstr ""
-
-#: mod/install.php:552
-msgid ""
-"IMPORTANT: You will need to [manually] setup a scheduled task for the worker."
-msgstr ""
-
-#: mod/install.php:555
-#, php-format
-msgid ""
-"Go to your new Friendica node <a href=\"%s/register\">registration page</a> "
-"and register as new user. Remember to use the same email you have entered as "
-"administrator email. This will allow you to enter the site admin panel."
+#: mod/localtime.php:19 src/Model/Event.php:36 src/Model/Event.php:814
+msgid "l F d, Y \\@ g:i A"
 msgstr ""
 
 #: mod/localtime.php:33
@@ -3977,77 +2566,7 @@ msgstr ""
 msgid "Only logged in users are permitted to perform a probing."
 msgstr ""
 
-#: mod/profile_photo.php:54
-msgid "Image uploaded but image cropping failed."
-msgstr ""
-
-#: mod/profile_photo.php:87 mod/profile_photo.php:95 mod/profile_photo.php:103
-#: mod/profile_photo.php:330
-#, php-format
-msgid "Image size reduction [%s] failed."
-msgstr ""
-
-#: mod/profile_photo.php:137
-msgid ""
-"Shift-reload the page or clear browser cache if the new photo does not "
-"display immediately."
-msgstr ""
-
-#: mod/profile_photo.php:146
-msgid "Unable to process image"
-msgstr ""
-
-#: mod/profile_photo.php:165 mod/wall_upload.php:186 mod/photos.php:763
-#: mod/photos.php:766 mod/photos.php:795
-#, php-format
-msgid "Image exceeds size limit of %s"
-msgstr ""
-
-#: mod/profile_photo.php:174 mod/wall_upload.php:200 mod/photos.php:818
-msgid "Unable to process image."
-msgstr ""
-
-#: mod/profile_photo.php:262
-msgid "Upload File:"
-msgstr ""
-
-#: mod/profile_photo.php:263
-msgid "Select a profile:"
-msgstr ""
-
-#: mod/profile_photo.php:268
-msgid "or"
-msgstr ""
-
-#: mod/profile_photo.php:268
-msgid "skip this step"
-msgstr ""
-
-#: mod/profile_photo.php:268
-msgid "select a photo from your photo albums"
-msgstr ""
-
-#: mod/profile_photo.php:281
-msgid "Crop Image"
-msgstr ""
-
-#: mod/profile_photo.php:282
-msgid "Please adjust the image cropping for optimum viewing."
-msgstr ""
-
-#: mod/profile_photo.php:284
-msgid "Done Editing"
-msgstr ""
-
-#: mod/profile_photo.php:320
-msgid "Image uploaded successfully."
-msgstr ""
-
-#: mod/profile_photo.php:322 mod/wall_upload.php:239 mod/photos.php:847
-msgid "Image upload failed."
-msgstr ""
-
-#: mod/profperm.php:28 mod/group.php:83 index.php:412
+#: mod/profperm.php:28 mod/group.php:83 index.php:415
 msgid "Permission denied"
 msgstr ""
 
@@ -4059,7 +2578,7 @@ msgstr ""
 msgid "Profile Visibility Editor"
 msgstr ""
 
-#: mod/profperm.php:115 mod/group.php:266
+#: mod/profperm.php:115 mod/group.php:265
 msgid "Click on a contact to add or remove."
 msgstr ""
 
@@ -4118,13 +2637,18 @@ msgstr ""
 msgid "Only one search per minute is permitted for not logged in users."
 msgstr ""
 
-#: mod/search.php:228 mod/community.php:134
+#: mod/search.php:228 mod/community.php:136
 msgid "No results."
 msgstr ""
 
 #: mod/search.php:234
 #, php-format
 msgid "Items tagged with: %s"
+msgstr ""
+
+#: mod/search.php:236 mod/contacts.php:819
+#, php-format
+msgid "Results for: %s"
 msgstr ""
 
 #: mod/subthread.php:113
@@ -4142,6 +2666,10 @@ msgstr ""
 
 #: mod/tagrm.php:87
 msgid "Select a tag to remove: "
+msgstr ""
+
+#: mod/tagrm.php:98 mod/delegate.php:177
+msgid "Remove"
 msgstr ""
 
 #: mod/uexport.php:44
@@ -4165,7 +2693,7 @@ msgid ""
 "of your account (photos are not exported)"
 msgstr ""
 
-#: mod/uexport.php:52 mod/settings.php:106
+#: mod/uexport.php:52 mod/settings.php:108
 msgid "Export personal data"
 msgstr ""
 
@@ -4177,9 +2705,23 @@ msgstr ""
 msgid "Access denied."
 msgstr ""
 
-#: mod/wall_upload.php:231 mod/item.php:471 src/Object/Image.php:949
-#: src/Object/Image.php:965 src/Object/Image.php:973 src/Object/Image.php:998
+#: mod/wall_upload.php:186 mod/photos.php:763 mod/photos.php:766
+#: mod/photos.php:795 mod/profile_photo.php:153
+#, php-format
+msgid "Image exceeds size limit of %s"
+msgstr ""
+
+#: mod/wall_upload.php:200 mod/photos.php:818 mod/profile_photo.php:162
+msgid "Unable to process image."
+msgstr ""
+
+#: mod/wall_upload.php:231 mod/item.php:471 src/Object/Image.php:953
+#: src/Object/Image.php:969 src/Object/Image.php:977 src/Object/Image.php:1002
 msgid "Wall Photos"
+msgstr ""
+
+#: mod/wall_upload.php:239 mod/photos.php:847 mod/profile_photo.php:307
+msgid "Image upload failed."
 msgstr ""
 
 #: mod/wallmessage.php:49 mod/wallmessage.php:112
@@ -4228,36 +2770,6 @@ msgstr ""
 
 #: mod/wallmessage.php:135 mod/message.php:255 mod/message.php:423
 msgid "Subject:"
-msgstr ""
-
-#: mod/item.php:114
-msgid "Unable to locate original post."
-msgstr ""
-
-#: mod/item.php:274
-msgid "Empty post discarded."
-msgstr ""
-
-#: mod/item.php:799
-#, php-format
-msgid ""
-"This message was sent to you by %s, a member of the Friendica social network."
-msgstr ""
-
-#: mod/item.php:801
-#, php-format
-msgid "You may visit them online at %s"
-msgstr ""
-
-#: mod/item.php:802
-msgid ""
-"Please contact the sender by replying to this post if you do not wish to "
-"receive these messages."
-msgstr ""
-
-#: mod/item.php:806
-#, php-format
-msgid "%s posted an update."
 msgstr ""
 
 #: mod/register.php:99
@@ -4320,7 +2832,7 @@ msgstr ""
 msgid "Your invitation code: "
 msgstr ""
 
-#: mod/register.php:264 mod/admin.php:1266
+#: mod/register.php:264 mod/admin.php:1283
 msgid "Registration"
 msgstr ""
 
@@ -4334,7 +2846,7 @@ msgid ""
 "be an existing address.)"
 msgstr ""
 
-#: mod/register.php:273 mod/settings.php:1205
+#: mod/register.php:273 mod/settings.php:1199
 msgid "New Password:"
 msgstr ""
 
@@ -4342,7 +2854,7 @@ msgstr ""
 msgid "Leave empty for an auto generated password."
 msgstr ""
 
-#: mod/register.php:274 mod/settings.php:1206
+#: mod/register.php:274 mod/settings.php:1200
 msgid "Confirm:"
 msgstr ""
 
@@ -4365,6 +2877,563 @@ msgstr ""
 msgid "Import your profile to this friendica instance"
 msgstr ""
 
+#: mod/bookmarklet.php:23 src/Content/Nav.php:114 src/Module/Login.php:312
+msgid "Login"
+msgstr ""
+
+#: mod/bookmarklet.php:51
+msgid "The post was created"
+msgstr ""
+
+#: mod/community.php:46
+msgid "Community option not available."
+msgstr ""
+
+#: mod/community.php:63
+msgid "Not available."
+msgstr ""
+
+#: mod/community.php:76
+msgid "Local Community"
+msgstr ""
+
+#: mod/community.php:79
+msgid "Posts from local users on this server"
+msgstr ""
+
+#: mod/community.php:87
+msgid "Global Community"
+msgstr ""
+
+#: mod/community.php:90
+msgid "Posts from users of the whole federated network"
+msgstr ""
+
+#: mod/community.php:180
+msgid ""
+"This community stream shows all public posts received by this node. They may "
+"not reflect the opinions of this node’s users."
+msgstr ""
+
+#: mod/editpost.php:25 mod/editpost.php:35
+msgid "Item not found"
+msgstr ""
+
+#: mod/editpost.php:42
+msgid "Edit post"
+msgstr ""
+
+#: mod/editpost.php:134 src/Core/ACL.php:315
+msgid "CC: email addresses"
+msgstr ""
+
+#: mod/editpost.php:141 src/Core/ACL.php:316
+msgid "Example: bob@example.com, mary@example.com"
+msgstr ""
+
+#: mod/fsuggest.php:72
+msgid "Friend suggestion sent."
+msgstr ""
+
+#: mod/fsuggest.php:101
+msgid "Suggest Friends"
+msgstr ""
+
+#: mod/fsuggest.php:103
+#, php-format
+msgid "Suggest a friend for %s"
+msgstr ""
+
+#: mod/group.php:36
+msgid "Group created."
+msgstr ""
+
+#: mod/group.php:42
+msgid "Could not create group."
+msgstr ""
+
+#: mod/group.php:56 mod/group.php:157
+msgid "Group not found."
+msgstr ""
+
+#: mod/group.php:70
+msgid "Group name changed."
+msgstr ""
+
+#: mod/group.php:97
+msgid "Save Group"
+msgstr ""
+
+#: mod/group.php:102
+msgid "Create a group of contacts/friends."
+msgstr ""
+
+#: mod/group.php:103 mod/group.php:199 src/Model/Group.php:408
+msgid "Group Name: "
+msgstr ""
+
+#: mod/group.php:127
+msgid "Group removed."
+msgstr ""
+
+#: mod/group.php:129
+msgid "Unable to remove group."
+msgstr ""
+
+#: mod/group.php:192
+msgid "Delete Group"
+msgstr ""
+
+#: mod/group.php:198
+msgid "Group Editor"
+msgstr ""
+
+#: mod/group.php:203
+msgid "Edit Group Name"
+msgstr ""
+
+#: mod/group.php:213
+msgid "Members"
+msgstr ""
+
+#: mod/group.php:215 mod/contacts.php:719
+msgid "All Contacts"
+msgstr ""
+
+#: mod/group.php:216 mod/network.php:639
+msgid "Group is empty"
+msgstr ""
+
+#: mod/group.php:229
+msgid "Remove Contact"
+msgstr ""
+
+#: mod/group.php:253
+msgid "Add Contact"
+msgstr ""
+
+#: mod/message.php:30 src/Content/Nav.php:198
+msgid "New Message"
+msgstr ""
+
+#: mod/message.php:77
+msgid "Unable to locate contact information."
+msgstr ""
+
+#: mod/message.php:112 view/theme/frio/theme.php:268 src/Content/Nav.php:195
+msgid "Messages"
+msgstr ""
+
+#: mod/message.php:136
+msgid "Do you really want to delete this message?"
+msgstr ""
+
+#: mod/message.php:156
+msgid "Message deleted."
+msgstr ""
+
+#: mod/message.php:185
+msgid "Conversation removed."
+msgstr ""
+
+#: mod/message.php:291
+msgid "No messages."
+msgstr ""
+
+#: mod/message.php:330
+msgid "Message not available."
+msgstr ""
+
+#: mod/message.php:397
+msgid "Delete message"
+msgstr ""
+
+#: mod/message.php:399 mod/message.php:500
+msgid "D, d M Y - g:i A"
+msgstr ""
+
+#: mod/message.php:414 mod/message.php:497
+msgid "Delete conversation"
+msgstr ""
+
+#: mod/message.php:416
+msgid ""
+"No secure communications available. You <strong>may</strong> be able to "
+"respond from the sender's profile page."
+msgstr ""
+
+#: mod/message.php:420
+msgid "Send Reply"
+msgstr ""
+
+#: mod/message.php:471
+#, php-format
+msgid "Unknown sender - %s"
+msgstr ""
+
+#: mod/message.php:473
+#, php-format
+msgid "You and %s"
+msgstr ""
+
+#: mod/message.php:475
+#, php-format
+msgid "%s and You"
+msgstr ""
+
+#: mod/message.php:503
+#, php-format
+msgid "%d message"
+msgid_plural "%d messages"
+msgstr[0] ""
+msgstr[1] ""
+
+#: mod/network.php:202 src/Model/Group.php:400
+msgid "add"
+msgstr ""
+
+#: mod/network.php:547
+#, php-format
+msgid ""
+"Warning: This group contains %s member from a network that doesn't allow non "
+"public messages."
+msgid_plural ""
+"Warning: This group contains %s members from a network that doesn't allow "
+"non public messages."
+msgstr[0] ""
+msgstr[1] ""
+
+#: mod/network.php:550
+msgid "Messages in this group won't be send to these receivers."
+msgstr ""
+
+#: mod/network.php:618
+msgid "No such group"
+msgstr ""
+
+#: mod/network.php:643
+#, php-format
+msgid "Group: %s"
+msgstr ""
+
+#: mod/network.php:669
+msgid "Private messages to this person are at risk of public disclosure."
+msgstr ""
+
+#: mod/network.php:672
+msgid "Invalid contact."
+msgstr ""
+
+#: mod/network.php:921
+msgid "Commented Order"
+msgstr ""
+
+#: mod/network.php:924
+msgid "Sort by Comment Date"
+msgstr ""
+
+#: mod/network.php:929
+msgid "Posted Order"
+msgstr ""
+
+#: mod/network.php:932
+msgid "Sort by Post Date"
+msgstr ""
+
+#: mod/network.php:940 mod/profiles.php:686
+#: src/Core/NotificationsManager.php:185
+msgid "Personal"
+msgstr ""
+
+#: mod/network.php:943
+msgid "Posts that mention or involve you"
+msgstr ""
+
+#: mod/network.php:951
+msgid "New"
+msgstr ""
+
+#: mod/network.php:954
+msgid "Activity Stream - by date"
+msgstr ""
+
+#: mod/network.php:962
+msgid "Shared Links"
+msgstr ""
+
+#: mod/network.php:965
+msgid "Interesting Links"
+msgstr ""
+
+#: mod/network.php:973
+msgid "Starred"
+msgstr ""
+
+#: mod/network.php:976
+msgid "Favourite Posts"
+msgstr ""
+
+#: mod/notes.php:52 src/Model/Profile.php:946
+msgid "Personal Notes"
+msgstr ""
+
+#: mod/photos.php:108 src/Model/Profile.php:907
+msgid "Photo Albums"
+msgstr ""
+
+#: mod/photos.php:109 mod/photos.php:1713
+msgid "Recent Photos"
+msgstr ""
+
+#: mod/photos.php:112 mod/photos.php:1210 mod/photos.php:1715
+msgid "Upload New Photos"
+msgstr ""
+
+#: mod/photos.php:126 mod/settings.php:51
+msgid "everybody"
+msgstr ""
+
+#: mod/photos.php:184
+msgid "Contact information unavailable"
+msgstr ""
+
+#: mod/photos.php:204
+msgid "Album not found."
+msgstr ""
+
+#: mod/photos.php:234 mod/photos.php:245 mod/photos.php:1161
+msgid "Delete Album"
+msgstr ""
+
+#: mod/photos.php:243
+msgid "Do you really want to delete this photo album and all its photos?"
+msgstr ""
+
+#: mod/photos.php:310 mod/photos.php:321 mod/photos.php:1446
+msgid "Delete Photo"
+msgstr ""
+
+#: mod/photos.php:319
+msgid "Do you really want to delete this photo?"
+msgstr ""
+
+#: mod/photos.php:667
+msgid "a photo"
+msgstr ""
+
+#: mod/photos.php:667
+#, php-format
+msgid "%1$s was tagged in %2$s by %3$s"
+msgstr ""
+
+#: mod/photos.php:769
+msgid "Image upload didn't complete, please try again"
+msgstr ""
+
+#: mod/photos.php:772
+msgid "Image file is missing"
+msgstr ""
+
+#: mod/photos.php:777
+msgid ""
+"Server can't accept new file upload at this time, please contact your "
+"administrator"
+msgstr ""
+
+#: mod/photos.php:803
+msgid "Image file is empty."
+msgstr ""
+
+#: mod/photos.php:940
+msgid "No photos selected"
+msgstr ""
+
+#: mod/photos.php:1036 mod/videos.php:309
+msgid "Access to this item is restricted."
+msgstr ""
+
+#: mod/photos.php:1090
+msgid "Upload Photos"
+msgstr ""
+
+#: mod/photos.php:1094 mod/photos.php:1156
+msgid "New album name: "
+msgstr ""
+
+#: mod/photos.php:1095
+msgid "or existing album name: "
+msgstr ""
+
+#: mod/photos.php:1096
+msgid "Do not show a status post for this upload"
+msgstr ""
+
+#: mod/photos.php:1098 mod/photos.php:1441 mod/events.php:533
+#: src/Core/ACL.php:318
+msgid "Permissions"
+msgstr ""
+
+#: mod/photos.php:1106 mod/photos.php:1449 mod/settings.php:1227
+msgid "Show to Groups"
+msgstr ""
+
+#: mod/photos.php:1107 mod/photos.php:1450 mod/settings.php:1228
+msgid "Show to Contacts"
+msgstr ""
+
+#: mod/photos.php:1167
+msgid "Edit Album"
+msgstr ""
+
+#: mod/photos.php:1172
+msgid "Show Newest First"
+msgstr ""
+
+#: mod/photos.php:1174
+msgid "Show Oldest First"
+msgstr ""
+
+#: mod/photos.php:1195 mod/photos.php:1698
+msgid "View Photo"
+msgstr ""
+
+#: mod/photos.php:1236
+msgid "Permission denied. Access to this item may be restricted."
+msgstr ""
+
+#: mod/photos.php:1238
+msgid "Photo not available"
+msgstr ""
+
+#: mod/photos.php:1301
+msgid "View photo"
+msgstr ""
+
+#: mod/photos.php:1301
+msgid "Edit photo"
+msgstr ""
+
+#: mod/photos.php:1302
+msgid "Use as profile photo"
+msgstr ""
+
+#: mod/photos.php:1308 src/Object/Post.php:149
+msgid "Private Message"
+msgstr ""
+
+#: mod/photos.php:1327
+msgid "View Full Size"
+msgstr ""
+
+#: mod/photos.php:1414
+msgid "Tags: "
+msgstr ""
+
+#: mod/photos.php:1417
+msgid "[Remove any tag]"
+msgstr ""
+
+#: mod/photos.php:1432
+msgid "New album name"
+msgstr ""
+
+#: mod/photos.php:1433
+msgid "Caption"
+msgstr ""
+
+#: mod/photos.php:1434
+msgid "Add a Tag"
+msgstr ""
+
+#: mod/photos.php:1434
+msgid "Example: @bob, @Barbara_Jensen, @jim@example.com, #California, #camping"
+msgstr ""
+
+#: mod/photos.php:1435
+msgid "Do not rotate"
+msgstr ""
+
+#: mod/photos.php:1436
+msgid "Rotate CW (right)"
+msgstr ""
+
+#: mod/photos.php:1437
+msgid "Rotate CCW (left)"
+msgstr ""
+
+#: mod/photos.php:1471 src/Object/Post.php:296
+msgid "I like this (toggle)"
+msgstr ""
+
+#: mod/photos.php:1472 src/Object/Post.php:297
+msgid "I don't like this (toggle)"
+msgstr ""
+
+#: mod/photos.php:1488 mod/photos.php:1527 mod/photos.php:1600
+#: mod/contacts.php:953 src/Object/Post.php:787
+msgid "This is you"
+msgstr ""
+
+#: mod/photos.php:1490 mod/photos.php:1529 mod/photos.php:1602
+#: src/Object/Post.php:393 src/Object/Post.php:789
+msgid "Comment"
+msgstr ""
+
+#: mod/photos.php:1634
+msgid "Map"
+msgstr ""
+
+#: mod/photos.php:1704 mod/videos.php:387
+msgid "View Album"
+msgstr ""
+
+#: mod/profile.php:37 src/Model/Profile.php:118
+msgid "Requested profile is not available."
+msgstr ""
+
+#: mod/profile.php:78 src/Protocol/OStatus.php:1252
+#, php-format
+msgid "%s's posts"
+msgstr ""
+
+#: mod/profile.php:79 src/Protocol/OStatus.php:1253
+#, php-format
+msgid "%s's comments"
+msgstr ""
+
+#: mod/profile.php:80 src/Protocol/OStatus.php:1251
+#, php-format
+msgid "%s's timeline"
+msgstr ""
+
+#: mod/profile.php:173 mod/cal.php:142 mod/display.php:313
+msgid "Access to this profile has been restricted."
+msgstr ""
+
+#: mod/profile.php:194
+msgid "Tips for New Members"
+msgstr ""
+
+#: mod/videos.php:139
+msgid "Do you really want to delete this video?"
+msgstr ""
+
+#: mod/videos.php:144
+msgid "Delete Video"
+msgstr ""
+
+#: mod/videos.php:207
+msgid "No videos selected"
+msgstr ""
+
+#: mod/videos.php:396
+msgid "Recent Videos"
+msgstr ""
+
+#: mod/videos.php:398
+msgid "Upload New Videos"
+msgstr ""
+
 #: mod/admin.php:106
 msgid "Theme settings updated."
 msgstr ""
@@ -4385,23 +3454,23 @@ msgstr ""
 msgid "Configuration"
 msgstr ""
 
-#: mod/admin.php:180 mod/admin.php:1263
+#: mod/admin.php:180 mod/admin.php:1280
 msgid "Site"
 msgstr ""
 
-#: mod/admin.php:181 mod/admin.php:1191 mod/admin.php:1696 mod/admin.php:1712
+#: mod/admin.php:181 mod/admin.php:1208 mod/admin.php:1721 mod/admin.php:1737
 msgid "Users"
 msgstr ""
 
-#: mod/admin.php:182 mod/admin.php:1812 mod/admin.php:1872 mod/settings.php:85
+#: mod/admin.php:182 mod/admin.php:1837 mod/admin.php:1897 mod/settings.php:87
 msgid "Addons"
 msgstr ""
 
-#: mod/admin.php:183 mod/admin.php:2081 mod/admin.php:2125
+#: mod/admin.php:183 mod/admin.php:2106 mod/admin.php:2150
 msgid "Themes"
 msgstr ""
 
-#: mod/admin.php:184 mod/settings.php:63
+#: mod/admin.php:184 mod/settings.php:65
 msgid "Additional features"
 msgstr ""
 
@@ -4433,11 +3502,11 @@ msgstr ""
 msgid "Delete Item"
 msgstr ""
 
-#: mod/admin.php:192 mod/admin.php:193 mod/admin.php:2199
+#: mod/admin.php:192 mod/admin.php:193 mod/admin.php:2224
 msgid "Logs"
 msgstr ""
 
-#: mod/admin.php:194 mod/admin.php:2266
+#: mod/admin.php:194 mod/admin.php:2291
 msgid "View Logs"
 msgstr ""
 
@@ -4486,9 +3555,9 @@ msgid "Check to delete this entry from the blocklist"
 msgstr ""
 
 #: mod/admin.php:310 mod/admin.php:427 mod/admin.php:469 mod/admin.php:653
-#: mod/admin.php:688 mod/admin.php:784 mod/admin.php:1262 mod/admin.php:1695
-#: mod/admin.php:1811 mod/admin.php:1871 mod/admin.php:2080 mod/admin.php:2124
-#: mod/admin.php:2198 mod/admin.php:2265
+#: mod/admin.php:688 mod/admin.php:784 mod/admin.php:1279 mod/admin.php:1720
+#: mod/admin.php:1836 mod/admin.php:1896 mod/admin.php:2105 mod/admin.php:2149
+#: mod/admin.php:2223 mod/admin.php:2290
 msgid "Administration"
 msgstr ""
 
@@ -4552,11 +3621,11 @@ msgstr ""
 msgid "Site blocklist updated."
 msgstr ""
 
-#: mod/admin.php:390 util/global_community_block.php:53
+#: mod/admin.php:390 src/Core/Console/GlobalCommunityBlock.php:72
 msgid "The contact has been blocked from the node"
 msgstr ""
 
-#: mod/admin.php:392 util/global_community_block.php:48
+#: mod/admin.php:392 src/Core/Console/GlobalCommunityBlock.php:69
 #, php-format
 msgid "Could not find any contact entry for this URL (%s)"
 msgstr ""
@@ -4582,12 +3651,22 @@ msgstr ""
 msgid "Block Remote Contact"
 msgstr ""
 
-#: mod/admin.php:431 mod/admin.php:1698
+#: mod/admin.php:431 mod/admin.php:1723
 msgid "select all"
 msgstr ""
 
 #: mod/admin.php:432
 msgid "select none"
+msgstr ""
+
+#: mod/admin.php:433 mod/admin.php:1732 mod/contacts.php:637
+#: mod/contacts.php:827 mod/contacts.php:1011
+msgid "Block"
+msgstr ""
+
+#: mod/admin.php:434 mod/admin.php:1733 mod/contacts.php:637
+#: mod/contacts.php:827 mod/contacts.php:1011
+msgid "Unblock"
 msgstr ""
 
 #: mod/admin.php:435
@@ -4604,6 +3683,10 @@ msgstr ""
 
 #: mod/admin.php:439
 msgid "Photo"
+msgstr ""
+
+#: mod/admin.php:439 mod/profiles.php:393
+msgid "Address"
 msgstr ""
 
 #: mod/admin.php:447
@@ -4708,8 +3791,8 @@ msgid ""
 "Your DB still runs with MyISAM tables. You should change the engine type to "
 "InnoDB. As Friendica will use InnoDB only features in the future, you should "
 "change this! See <a href=\"%s\">here</a> for a guide that may be helpful "
-"converting the table engines. You may also use the command <tt>php scripts/"
-"dbstructure.php toinnodb</tt> of your Friendica installation for an "
+"converting the table engines. You may also use the command <tt>php bin/"
+"console.php dbstructure toinnodb</tt> of your Friendica installation for an "
 "automatic conversion.<br />"
 msgstr ""
 
@@ -4722,8 +3805,9 @@ msgstr ""
 
 #: mod/admin.php:738
 msgid ""
-"The database update failed. Please run \"php scripts/dbstructure.php update"
-"\" from the command line and have a look at the errors that might appear."
+"The database update failed. Please run \"php bin/console.php dbstructure "
+"update\" from the command line and have a look at the errors that might "
+"appear."
 msgstr ""
 
 #: mod/admin.php:744
@@ -4737,19 +3821,19 @@ msgid ""
 "check your crontab settings."
 msgstr ""
 
-#: mod/admin.php:752 mod/admin.php:1647
+#: mod/admin.php:752 mod/admin.php:1672
 msgid "Normal Account"
 msgstr ""
 
-#: mod/admin.php:753 mod/admin.php:1648
+#: mod/admin.php:753 mod/admin.php:1673
 msgid "Automatic Follower Account"
 msgstr ""
 
-#: mod/admin.php:754 mod/admin.php:1649
+#: mod/admin.php:754 mod/admin.php:1674
 msgid "Public Forum Account"
 msgstr ""
 
-#: mod/admin.php:755 mod/admin.php:1650
+#: mod/admin.php:755 mod/admin.php:1675
 msgid "Automatic Friend Account"
 msgstr ""
 
@@ -4789,607 +3873,628 @@ msgstr ""
 msgid "Can not parse base url. Must have at least <scheme>://<domain>"
 msgstr ""
 
-#: mod/admin.php:1127
+#: mod/admin.php:1144
 msgid "Site settings updated."
 msgstr ""
 
-#: mod/admin.php:1154 mod/settings.php:907
+#: mod/admin.php:1171 mod/settings.php:903
 msgid "No special theme for mobile devices"
 msgstr ""
 
-#: mod/admin.php:1183
+#: mod/admin.php:1200
 msgid "No community page"
 msgstr ""
 
-#: mod/admin.php:1184
+#: mod/admin.php:1201
 msgid "Public postings from users of this site"
 msgstr ""
 
-#: mod/admin.php:1185
+#: mod/admin.php:1202
 msgid "Public postings from the federated network"
 msgstr ""
 
-#: mod/admin.php:1186
+#: mod/admin.php:1203
 msgid "Public postings from local users and the federated network"
 msgstr ""
 
-#: mod/admin.php:1192
+#: mod/admin.php:1207 mod/admin.php:1370 mod/admin.php:1380
+#: mod/contacts.php:572
+msgid "Disabled"
+msgstr ""
+
+#: mod/admin.php:1209
 msgid "Users, Global Contacts"
 msgstr ""
 
-#: mod/admin.php:1193
+#: mod/admin.php:1210
 msgid "Users, Global Contacts/fallback"
 msgstr ""
 
-#: mod/admin.php:1197
+#: mod/admin.php:1214
 msgid "One month"
 msgstr ""
 
-#: mod/admin.php:1198
+#: mod/admin.php:1215
 msgid "Three months"
 msgstr ""
 
-#: mod/admin.php:1199
+#: mod/admin.php:1216
 msgid "Half a year"
 msgstr ""
 
-#: mod/admin.php:1200
+#: mod/admin.php:1217
 msgid "One year"
 msgstr ""
 
-#: mod/admin.php:1205
+#: mod/admin.php:1222
 msgid "Multi user instance"
 msgstr ""
 
-#: mod/admin.php:1228
+#: mod/admin.php:1245
 msgid "Closed"
 msgstr ""
 
-#: mod/admin.php:1229
+#: mod/admin.php:1246
 msgid "Requires approval"
 msgstr ""
 
-#: mod/admin.php:1230
+#: mod/admin.php:1247
 msgid "Open"
 msgstr ""
 
-#: mod/admin.php:1234
+#: mod/admin.php:1251
 msgid "No SSL policy, links will track page SSL state"
 msgstr ""
 
-#: mod/admin.php:1235
+#: mod/admin.php:1252
 msgid "Force all links to use SSL"
 msgstr ""
 
-#: mod/admin.php:1236
+#: mod/admin.php:1253
 msgid "Self-signed certificate, use SSL for local links only (discouraged)"
 msgstr ""
 
-#: mod/admin.php:1240
+#: mod/admin.php:1257
 msgid "Don't check"
 msgstr ""
 
-#: mod/admin.php:1241
+#: mod/admin.php:1258
 msgid "check the stable version"
 msgstr ""
 
-#: mod/admin.php:1242
+#: mod/admin.php:1259
 msgid "check the development version"
 msgstr ""
 
-#: mod/admin.php:1265
+#: mod/admin.php:1281 mod/admin.php:1898 mod/admin.php:2151 mod/admin.php:2225
+#: mod/admin.php:2372 mod/delegate.php:168 mod/settings.php:675
+#: mod/settings.php:784 mod/settings.php:870 mod/settings.php:959
+#: mod/settings.php:1192
+msgid "Save Settings"
+msgstr ""
+
+#: mod/admin.php:1282
 msgid "Republish users to directory"
 msgstr ""
 
-#: mod/admin.php:1267
+#: mod/admin.php:1284
 msgid "File upload"
 msgstr ""
 
-#: mod/admin.php:1268
+#: mod/admin.php:1285
 msgid "Policies"
 msgstr ""
 
-#: mod/admin.php:1270
+#: mod/admin.php:1286 mod/contacts.php:895 mod/events.php:532
+#: src/Model/Profile.php:865
+msgid "Advanced"
+msgstr ""
+
+#: mod/admin.php:1287
 msgid "Auto Discovered Contact Directory"
 msgstr ""
 
-#: mod/admin.php:1271
+#: mod/admin.php:1288
 msgid "Performance"
 msgstr ""
 
-#: mod/admin.php:1272
+#: mod/admin.php:1289
 msgid "Worker"
 msgstr ""
 
-#: mod/admin.php:1273
+#: mod/admin.php:1290
+msgid "Message Relay"
+msgstr ""
+
+#: mod/admin.php:1291
 msgid ""
 "Relocate - WARNING: advanced function. Could make this server unreachable."
 msgstr ""
 
-#: mod/admin.php:1276
+#: mod/admin.php:1294
 msgid "Site name"
 msgstr ""
 
-#: mod/admin.php:1277
+#: mod/admin.php:1295
 msgid "Host name"
 msgstr ""
 
-#: mod/admin.php:1278
+#: mod/admin.php:1296
 msgid "Sender Email"
 msgstr ""
 
-#: mod/admin.php:1278
+#: mod/admin.php:1296
 msgid ""
 "The email address your server shall use to send notification emails from."
 msgstr ""
 
-#: mod/admin.php:1279
+#: mod/admin.php:1297
 msgid "Banner/Logo"
 msgstr ""
 
-#: mod/admin.php:1280
+#: mod/admin.php:1298
 msgid "Shortcut icon"
 msgstr ""
 
-#: mod/admin.php:1280
+#: mod/admin.php:1298
 msgid "Link to an icon that will be used for browsers."
 msgstr ""
 
-#: mod/admin.php:1281
+#: mod/admin.php:1299
 msgid "Touch icon"
 msgstr ""
 
-#: mod/admin.php:1281
+#: mod/admin.php:1299
 msgid "Link to an icon that will be used for tablets and mobiles."
 msgstr ""
 
-#: mod/admin.php:1282
+#: mod/admin.php:1300
 msgid "Additional Info"
 msgstr ""
 
-#: mod/admin.php:1282
+#: mod/admin.php:1300
 #, php-format
 msgid ""
 "For public servers: you can add additional information here that will be "
 "listed at %s/servers."
 msgstr ""
 
-#: mod/admin.php:1283
+#: mod/admin.php:1301
 msgid "System language"
 msgstr ""
 
-#: mod/admin.php:1284
+#: mod/admin.php:1302
 msgid "System theme"
 msgstr ""
 
-#: mod/admin.php:1284
+#: mod/admin.php:1302
 msgid ""
 "Default system theme - may be over-ridden by user profiles - <a href='#' "
 "id='cnftheme'>change theme settings</a>"
 msgstr ""
 
-#: mod/admin.php:1285
+#: mod/admin.php:1303
 msgid "Mobile system theme"
 msgstr ""
 
-#: mod/admin.php:1285
+#: mod/admin.php:1303
 msgid "Theme for mobile devices"
 msgstr ""
 
-#: mod/admin.php:1286
+#: mod/admin.php:1304
 msgid "SSL link policy"
 msgstr ""
 
-#: mod/admin.php:1286
+#: mod/admin.php:1304
 msgid "Determines whether generated links should be forced to use SSL"
 msgstr ""
 
-#: mod/admin.php:1287
+#: mod/admin.php:1305
 msgid "Force SSL"
 msgstr ""
 
-#: mod/admin.php:1287
+#: mod/admin.php:1305
 msgid ""
 "Force all Non-SSL requests to SSL - Attention: on some systems it could lead "
 "to endless loops."
 msgstr ""
 
-#: mod/admin.php:1288
+#: mod/admin.php:1306
 msgid "Hide help entry from navigation menu"
 msgstr ""
 
-#: mod/admin.php:1288
+#: mod/admin.php:1306
 msgid ""
 "Hides the menu entry for the Help pages from the navigation menu. You can "
 "still access it calling /help directly."
 msgstr ""
 
-#: mod/admin.php:1289
+#: mod/admin.php:1307
 msgid "Single user instance"
 msgstr ""
 
-#: mod/admin.php:1289
+#: mod/admin.php:1307
 msgid "Make this instance multi-user or single-user for the named user"
 msgstr ""
 
-#: mod/admin.php:1290
+#: mod/admin.php:1308
 msgid "Maximum image size"
 msgstr ""
 
-#: mod/admin.php:1290
+#: mod/admin.php:1308
 msgid ""
 "Maximum size in bytes of uploaded images. Default is 0, which means no "
 "limits."
 msgstr ""
 
-#: mod/admin.php:1291
+#: mod/admin.php:1309
 msgid "Maximum image length"
 msgstr ""
 
-#: mod/admin.php:1291
+#: mod/admin.php:1309
 msgid ""
 "Maximum length in pixels of the longest side of uploaded images. Default is "
 "-1, which means no limits."
 msgstr ""
 
-#: mod/admin.php:1292
+#: mod/admin.php:1310
 msgid "JPEG image quality"
 msgstr ""
 
-#: mod/admin.php:1292
+#: mod/admin.php:1310
 msgid ""
 "Uploaded JPEGS will be saved at this quality setting [0-100]. Default is "
 "100, which is full quality."
 msgstr ""
 
-#: mod/admin.php:1294
+#: mod/admin.php:1312
 msgid "Register policy"
 msgstr ""
 
-#: mod/admin.php:1295
+#: mod/admin.php:1313
 msgid "Maximum Daily Registrations"
 msgstr ""
 
-#: mod/admin.php:1295
+#: mod/admin.php:1313
 msgid ""
 "If registration is permitted above, this sets the maximum number of new user "
 "registrations to accept per day.  If register is set to closed, this setting "
 "has no effect."
 msgstr ""
 
-#: mod/admin.php:1296
+#: mod/admin.php:1314
 msgid "Register text"
 msgstr ""
 
-#: mod/admin.php:1296
+#: mod/admin.php:1314
 msgid "Will be displayed prominently on the registration page."
 msgstr ""
 
-#: mod/admin.php:1297
+#: mod/admin.php:1315
 msgid "Accounts abandoned after x days"
 msgstr ""
 
-#: mod/admin.php:1297
+#: mod/admin.php:1315
 msgid ""
 "Will not waste system resources polling external sites for abandonded "
 "accounts. Enter 0 for no time limit."
 msgstr ""
 
-#: mod/admin.php:1298
+#: mod/admin.php:1316
 msgid "Allowed friend domains"
 msgstr ""
 
-#: mod/admin.php:1298
+#: mod/admin.php:1316
 msgid ""
 "Comma separated list of domains which are allowed to establish friendships "
 "with this site. Wildcards are accepted. Empty to allow any domains"
 msgstr ""
 
-#: mod/admin.php:1299
+#: mod/admin.php:1317
 msgid "Allowed email domains"
 msgstr ""
 
-#: mod/admin.php:1299
+#: mod/admin.php:1317
 msgid ""
 "Comma separated list of domains which are allowed in email addresses for "
 "registrations to this site. Wildcards are accepted. Empty to allow any "
 "domains"
 msgstr ""
 
-#: mod/admin.php:1300
+#: mod/admin.php:1318
 msgid "No OEmbed rich content"
 msgstr ""
 
-#: mod/admin.php:1300
+#: mod/admin.php:1318
 msgid ""
 "Don't show the rich content (e.g. embedded PDF), except from the domains "
 "listed below."
 msgstr ""
 
-#: mod/admin.php:1301
+#: mod/admin.php:1319
 msgid "Allowed OEmbed domains"
 msgstr ""
 
-#: mod/admin.php:1301
+#: mod/admin.php:1319
 msgid ""
 "Comma separated list of domains which oembed content is allowed to be "
 "displayed. Wildcards are accepted."
 msgstr ""
 
-#: mod/admin.php:1302
+#: mod/admin.php:1320
 msgid "Block public"
 msgstr ""
 
-#: mod/admin.php:1302
+#: mod/admin.php:1320
 msgid ""
 "Check to block public access to all otherwise public personal pages on this "
 "site unless you are currently logged in."
 msgstr ""
 
-#: mod/admin.php:1303
+#: mod/admin.php:1321
 msgid "Force publish"
 msgstr ""
 
-#: mod/admin.php:1303
+#: mod/admin.php:1321
 msgid ""
 "Check to force all profiles on this site to be listed in the site directory."
 msgstr ""
 
-#: mod/admin.php:1304
+#: mod/admin.php:1322
 msgid "Global directory URL"
 msgstr ""
 
-#: mod/admin.php:1304
+#: mod/admin.php:1322
 msgid ""
 "URL to the global directory. If this is not set, the global directory is "
 "completely unavailable to the application."
 msgstr ""
 
-#: mod/admin.php:1305
+#: mod/admin.php:1323
 msgid "Private posts by default for new users"
 msgstr ""
 
-#: mod/admin.php:1305
+#: mod/admin.php:1323
 msgid ""
 "Set default post permissions for all new members to the default privacy "
 "group rather than public."
 msgstr ""
 
-#: mod/admin.php:1306
+#: mod/admin.php:1324
 msgid "Don't include post content in email notifications"
 msgstr ""
 
-#: mod/admin.php:1306
+#: mod/admin.php:1324
 msgid ""
 "Don't include the content of a post/comment/private message/etc. in the "
 "email notifications that are sent out from this site, as a privacy measure."
 msgstr ""
 
-#: mod/admin.php:1307
+#: mod/admin.php:1325
 msgid "Disallow public access to addons listed in the apps menu."
 msgstr ""
 
-#: mod/admin.php:1307
+#: mod/admin.php:1325
 msgid ""
 "Checking this box will restrict addons listed in the apps menu to members "
 "only."
 msgstr ""
 
-#: mod/admin.php:1308
+#: mod/admin.php:1326
 msgid "Don't embed private images in posts"
 msgstr ""
 
-#: mod/admin.php:1308
+#: mod/admin.php:1326
 msgid ""
 "Don't replace locally-hosted private photos in posts with an embedded copy "
 "of the image. This means that contacts who receive posts containing private "
 "photos will have to authenticate and load each image, which may take a while."
 msgstr ""
 
-#: mod/admin.php:1309
+#: mod/admin.php:1327
 msgid "Allow Users to set remote_self"
 msgstr ""
 
-#: mod/admin.php:1309
+#: mod/admin.php:1327
 msgid ""
 "With checking this, every user is allowed to mark every contact as a "
 "remote_self in the repair contact dialog. Setting this flag on a contact "
 "causes mirroring every posting of that contact in the users stream."
 msgstr ""
 
-#: mod/admin.php:1310
+#: mod/admin.php:1328
 msgid "Block multiple registrations"
 msgstr ""
 
-#: mod/admin.php:1310
+#: mod/admin.php:1328
 msgid "Disallow users to register additional accounts for use as pages."
 msgstr ""
 
-#: mod/admin.php:1311
+#: mod/admin.php:1329
 msgid "OpenID support"
 msgstr ""
 
-#: mod/admin.php:1311
+#: mod/admin.php:1329
 msgid "OpenID support for registration and logins."
 msgstr ""
 
-#: mod/admin.php:1312
+#: mod/admin.php:1330
 msgid "Fullname check"
 msgstr ""
 
-#: mod/admin.php:1312
+#: mod/admin.php:1330
 msgid ""
 "Force users to register with a space between firstname and lastname in Full "
 "name, as an antispam measure"
 msgstr ""
 
-#: mod/admin.php:1313
+#: mod/admin.php:1331
 msgid "Community pages for visitors"
 msgstr ""
 
-#: mod/admin.php:1313
+#: mod/admin.php:1331
 msgid ""
 "Which community pages should be available for visitors. Local users always "
 "see both pages."
 msgstr ""
 
-#: mod/admin.php:1314
+#: mod/admin.php:1332
 msgid "Posts per user on community page"
 msgstr ""
 
-#: mod/admin.php:1314
+#: mod/admin.php:1332
 msgid ""
 "The maximum number of posts per user on the community page. (Not valid for "
 "'Global Community')"
 msgstr ""
 
-#: mod/admin.php:1315
+#: mod/admin.php:1333
 msgid "Enable OStatus support"
 msgstr ""
 
-#: mod/admin.php:1315
+#: mod/admin.php:1333
 msgid ""
 "Provide built-in OStatus (StatusNet, GNU Social etc.) compatibility. All "
 "communications in OStatus are public, so privacy warnings will be "
 "occasionally displayed."
 msgstr ""
 
-#: mod/admin.php:1316
+#: mod/admin.php:1334
 msgid "Only import OStatus threads from our contacts"
 msgstr ""
 
-#: mod/admin.php:1316
+#: mod/admin.php:1334
 msgid ""
 "Normally we import every content from our OStatus contacts. With this option "
 "we only store threads that are started by a contact that is known on our "
 "system."
 msgstr ""
 
-#: mod/admin.php:1317
+#: mod/admin.php:1335
 msgid "OStatus support can only be enabled if threading is enabled."
 msgstr ""
 
-#: mod/admin.php:1319
+#: mod/admin.php:1337
 msgid ""
 "Diaspora support can't be enabled because Friendica was installed into a sub "
 "directory."
 msgstr ""
 
-#: mod/admin.php:1320
+#: mod/admin.php:1338
 msgid "Enable Diaspora support"
 msgstr ""
 
-#: mod/admin.php:1320
+#: mod/admin.php:1338
 msgid "Provide built-in Diaspora network compatibility."
 msgstr ""
 
-#: mod/admin.php:1321
+#: mod/admin.php:1339
 msgid "Only allow Friendica contacts"
 msgstr ""
 
-#: mod/admin.php:1321
+#: mod/admin.php:1339
 msgid ""
 "All contacts must use Friendica protocols. All other built-in communication "
 "protocols disabled."
 msgstr ""
 
-#: mod/admin.php:1322
+#: mod/admin.php:1340
 msgid "Verify SSL"
 msgstr ""
 
-#: mod/admin.php:1322
+#: mod/admin.php:1340
 msgid ""
 "If you wish, you can turn on strict certificate checking. This will mean you "
 "cannot connect (at all) to self-signed SSL sites."
 msgstr ""
 
-#: mod/admin.php:1323
+#: mod/admin.php:1341
 msgid "Proxy user"
 msgstr ""
 
-#: mod/admin.php:1324
+#: mod/admin.php:1342
 msgid "Proxy URL"
 msgstr ""
 
-#: mod/admin.php:1325
+#: mod/admin.php:1343
 msgid "Network timeout"
 msgstr ""
 
-#: mod/admin.php:1325
+#: mod/admin.php:1343
 msgid "Value is in seconds. Set to 0 for unlimited (not recommended)."
 msgstr ""
 
-#: mod/admin.php:1326
+#: mod/admin.php:1344
 msgid "Maximum Load Average"
 msgstr ""
 
-#: mod/admin.php:1326
+#: mod/admin.php:1344
 msgid ""
 "Maximum system load before delivery and poll processes are deferred - "
 "default 50."
 msgstr ""
 
-#: mod/admin.php:1327
+#: mod/admin.php:1345
 msgid "Maximum Load Average (Frontend)"
 msgstr ""
 
-#: mod/admin.php:1327
+#: mod/admin.php:1345
 msgid "Maximum system load before the frontend quits service - default 50."
 msgstr ""
 
-#: mod/admin.php:1328
+#: mod/admin.php:1346
 msgid "Minimal Memory"
 msgstr ""
 
-#: mod/admin.php:1328
+#: mod/admin.php:1346
 msgid ""
 "Minimal free memory in MB for the worker. Needs access to /proc/meminfo - "
 "default 0 (deactivated)."
 msgstr ""
 
-#: mod/admin.php:1329
+#: mod/admin.php:1347
 msgid "Maximum table size for optimization"
 msgstr ""
 
-#: mod/admin.php:1329
+#: mod/admin.php:1347
 msgid ""
 "Maximum table size (in MB) for the automatic optimization - default 100 MB. "
 "Enter -1 to disable it."
 msgstr ""
 
-#: mod/admin.php:1330
+#: mod/admin.php:1348
 msgid "Minimum level of fragmentation"
 msgstr ""
 
-#: mod/admin.php:1330
+#: mod/admin.php:1348
 msgid ""
 "Minimum fragmenation level to start the automatic optimization - default "
 "value is 30%."
 msgstr ""
 
-#: mod/admin.php:1332
+#: mod/admin.php:1350
 msgid "Periodical check of global contacts"
 msgstr ""
 
-#: mod/admin.php:1332
+#: mod/admin.php:1350
 msgid ""
 "If enabled, the global contacts are checked periodically for missing or "
 "outdated data and the vitality of the contacts and servers."
 msgstr ""
 
-#: mod/admin.php:1333
+#: mod/admin.php:1351
 msgid "Days between requery"
 msgstr ""
 
-#: mod/admin.php:1333
+#: mod/admin.php:1351
 msgid "Number of days after which a server is requeried for his contacts."
 msgstr ""
 
-#: mod/admin.php:1334
+#: mod/admin.php:1352
 msgid "Discover contacts from other servers"
 msgstr ""
 
-#: mod/admin.php:1334
+#: mod/admin.php:1352
 msgid ""
 "Periodically query other servers for contacts. You can choose between "
 "'users': the users on the remote system, 'Global Contacts': active contacts "
@@ -5399,32 +4504,32 @@ msgid ""
 "Global Contacts'."
 msgstr ""
 
-#: mod/admin.php:1335
+#: mod/admin.php:1353
 msgid "Timeframe for fetching global contacts"
 msgstr ""
 
-#: mod/admin.php:1335
+#: mod/admin.php:1353
 msgid ""
 "When the discovery is activated, this value defines the timeframe for the "
 "activity of the global contacts that are fetched from other servers."
 msgstr ""
 
-#: mod/admin.php:1336
+#: mod/admin.php:1354
 msgid "Search the local directory"
 msgstr ""
 
-#: mod/admin.php:1336
+#: mod/admin.php:1354
 msgid ""
 "Search the local directory instead of the global directory. When searching "
 "locally, every search will be executed on the global directory in the "
 "background. This improves the search results when the search is repeated."
 msgstr ""
 
-#: mod/admin.php:1338
+#: mod/admin.php:1356
 msgid "Publish server information"
 msgstr ""
 
-#: mod/admin.php:1338
+#: mod/admin.php:1356
 msgid ""
 "If enabled, general server and usage data will be published. The data "
 "contains the name and version of the server, number of users with public "
@@ -5432,143 +4537,147 @@ msgid ""
 "href='http://the-federation.info/'>the-federation.info</a> for details."
 msgstr ""
 
-#: mod/admin.php:1340
+#: mod/admin.php:1358
 msgid "Check upstream version"
 msgstr ""
 
-#: mod/admin.php:1340
+#: mod/admin.php:1358
 msgid ""
 "Enables checking for new Friendica versions at github. If there is a new "
 "version, you will be informed in the admin panel overview."
 msgstr ""
 
-#: mod/admin.php:1341
+#: mod/admin.php:1359
 msgid "Suppress Tags"
 msgstr ""
 
-#: mod/admin.php:1341
+#: mod/admin.php:1359
 msgid "Suppress showing a list of hashtags at the end of the posting."
 msgstr ""
 
-#: mod/admin.php:1342
+#: mod/admin.php:1360
 msgid "Path to item cache"
 msgstr ""
 
-#: mod/admin.php:1342
+#: mod/admin.php:1360
 msgid "The item caches buffers generated bbcode and external images."
 msgstr ""
 
-#: mod/admin.php:1343
+#: mod/admin.php:1361
 msgid "Cache duration in seconds"
 msgstr ""
 
-#: mod/admin.php:1343
+#: mod/admin.php:1361
 msgid ""
 "How long should the cache files be hold? Default value is 86400 seconds (One "
 "day). To disable the item cache, set the value to -1."
 msgstr ""
 
-#: mod/admin.php:1344
+#: mod/admin.php:1362
 msgid "Maximum numbers of comments per post"
 msgstr ""
 
-#: mod/admin.php:1344
+#: mod/admin.php:1362
 msgid "How much comments should be shown for each post? Default value is 100."
 msgstr ""
 
-#: mod/admin.php:1345
+#: mod/admin.php:1363
 msgid "Temp path"
 msgstr ""
 
-#: mod/admin.php:1345
+#: mod/admin.php:1363
 msgid ""
 "If you have a restricted system where the webserver can't access the system "
 "temp path, enter another path here."
 msgstr ""
 
-#: mod/admin.php:1346
+#: mod/admin.php:1364
 msgid "Base path to installation"
 msgstr ""
 
-#: mod/admin.php:1346
+#: mod/admin.php:1364
 msgid ""
 "If the system cannot detect the correct path to your installation, enter the "
 "correct path here. This setting should only be set if you are using a "
 "restricted system and symbolic links to your webroot."
 msgstr ""
 
-#: mod/admin.php:1347
+#: mod/admin.php:1365
 msgid "Disable picture proxy"
 msgstr ""
 
-#: mod/admin.php:1347
+#: mod/admin.php:1365
 msgid ""
 "The picture proxy increases performance and privacy. It shouldn't be used on "
 "systems with very low bandwith."
 msgstr ""
 
-#: mod/admin.php:1348
+#: mod/admin.php:1366
 msgid "Only search in tags"
 msgstr ""
 
-#: mod/admin.php:1348
+#: mod/admin.php:1366
 msgid "On large systems the text search can slow down the system extremely."
 msgstr ""
 
-#: mod/admin.php:1350
+#: mod/admin.php:1368
 msgid "New base url"
 msgstr ""
 
-#: mod/admin.php:1350
+#: mod/admin.php:1368
 msgid ""
 "Change base url for this server. Sends relocate message to all Friendica and "
 "Diaspora* contacts of all users."
 msgstr ""
 
-#: mod/admin.php:1352
+#: mod/admin.php:1370
 msgid "RINO Encryption"
 msgstr ""
 
-#: mod/admin.php:1352
+#: mod/admin.php:1370
 msgid "Encryption layer between nodes."
 msgstr ""
 
-#: mod/admin.php:1354
+#: mod/admin.php:1370
+msgid "Enabled"
+msgstr ""
+
+#: mod/admin.php:1372
 msgid "Maximum number of parallel workers"
 msgstr ""
 
-#: mod/admin.php:1354
+#: mod/admin.php:1372
 msgid ""
 "On shared hosters set this to 2. On larger systems, values of 10 are great. "
 "Default value is 4."
 msgstr ""
 
-#: mod/admin.php:1355
+#: mod/admin.php:1373
 msgid "Don't use 'proc_open' with the worker"
 msgstr ""
 
-#: mod/admin.php:1355
+#: mod/admin.php:1373
 msgid ""
 "Enable this if your system doesn't allow the use of 'proc_open'. This can "
 "happen on shared hosters. If this is enabled you should increase the "
 "frequency of worker calls in your crontab."
 msgstr ""
 
-#: mod/admin.php:1356
+#: mod/admin.php:1374
 msgid "Enable fastlane"
 msgstr ""
 
-#: mod/admin.php:1356
+#: mod/admin.php:1374
 msgid ""
 "When enabed, the fastlane mechanism starts an additional worker if processes "
 "with higher priority are blocked by processes of lower priority."
 msgstr ""
 
-#: mod/admin.php:1357
+#: mod/admin.php:1375
 msgid "Enable frontend worker"
 msgstr ""
 
-#: mod/admin.php:1357
+#: mod/admin.php:1375
 #, php-format
 msgid ""
 "When enabled the Worker process is triggered when backend access is "
@@ -5578,66 +4687,131 @@ msgid ""
 "on your server."
 msgstr ""
 
-#: mod/admin.php:1385
+#: mod/admin.php:1377
+msgid "Subscribe to relay"
+msgstr ""
+
+#: mod/admin.php:1377
+msgid ""
+"Enables the receiving of public posts from the relay. They will be included "
+"in the search, subscribed tags and on the global community page."
+msgstr ""
+
+#: mod/admin.php:1378
+msgid "Relay server"
+msgstr ""
+
+#: mod/admin.php:1378
+msgid ""
+"Address of the relay server where public posts should be send to. For "
+"example https://relay.diasp.org"
+msgstr ""
+
+#: mod/admin.php:1379
+msgid "Direct relay transfer"
+msgstr ""
+
+#: mod/admin.php:1379
+msgid ""
+"Enables the direct transfer to other servers without using the relay servers"
+msgstr ""
+
+#: mod/admin.php:1380
+msgid "Relay scope"
+msgstr ""
+
+#: mod/admin.php:1380
+msgid ""
+"Can be 'all' or 'tags'. 'all' means that every public post should be "
+"received. 'tags' means that only posts with selected tags should be received."
+msgstr ""
+
+#: mod/admin.php:1380
+msgid "all"
+msgstr ""
+
+#: mod/admin.php:1380
+msgid "tags"
+msgstr ""
+
+#: mod/admin.php:1381
+msgid "Server tags"
+msgstr ""
+
+#: mod/admin.php:1381
+msgid "Comma separated list of tags for the 'tags' subscription."
+msgstr ""
+
+#: mod/admin.php:1382
+msgid "Allow user tags"
+msgstr ""
+
+#: mod/admin.php:1382
+msgid ""
+"If enabled, the tags from the saved searches will used for the 'tags' "
+"subscription in addition to the 'relay_server_tags'."
+msgstr ""
+
+#: mod/admin.php:1410
 msgid "Update has been marked successful"
 msgstr ""
 
-#: mod/admin.php:1392
+#: mod/admin.php:1417
 #, php-format
 msgid "Database structure update %s was successfully applied."
 msgstr ""
 
-#: mod/admin.php:1395
+#: mod/admin.php:1420
 #, php-format
 msgid "Executing of database structure update %s failed with error: %s"
 msgstr ""
 
-#: mod/admin.php:1408
+#: mod/admin.php:1433
 #, php-format
 msgid "Executing %s failed with error: %s"
 msgstr ""
 
-#: mod/admin.php:1410
+#: mod/admin.php:1435
 #, php-format
 msgid "Update %s was successfully applied."
 msgstr ""
 
-#: mod/admin.php:1413
+#: mod/admin.php:1438
 #, php-format
 msgid "Update %s did not return a status. Unknown if it succeeded."
 msgstr ""
 
-#: mod/admin.php:1416
+#: mod/admin.php:1441
 #, php-format
 msgid "There was no additional update function %s that needed to be called."
 msgstr ""
 
-#: mod/admin.php:1436
+#: mod/admin.php:1461
 msgid "No failed updates."
 msgstr ""
 
-#: mod/admin.php:1437
+#: mod/admin.php:1462
 msgid "Check database structure"
 msgstr ""
 
-#: mod/admin.php:1442
+#: mod/admin.php:1467
 msgid "Failed Updates"
 msgstr ""
 
-#: mod/admin.php:1443
+#: mod/admin.php:1468
 msgid ""
 "This does not include updates prior to 1139, which did not return a status."
 msgstr ""
 
-#: mod/admin.php:1444
+#: mod/admin.php:1469
 msgid "Mark success (if update was manually applied)"
 msgstr ""
 
-#: mod/admin.php:1445
+#: mod/admin.php:1470
 msgid "Attempt to execute this update step automatically"
 msgstr ""
 
-#: mod/admin.php:1484
+#: mod/admin.php:1509
 #, php-format
 msgid ""
 "\n"
@@ -5645,7 +4819,7 @@ msgid ""
 "\t\t\t\tthe administrator of %2$s has set up an account for you."
 msgstr ""
 
-#: mod/admin.php:1487
+#: mod/admin.php:1512
 #, php-format
 msgid ""
 "\n"
@@ -5681,168 +4855,168 @@ msgid ""
 "\t\t\tThank you and welcome to %4$s."
 msgstr ""
 
-#: mod/admin.php:1519 src/Model/User.php:634
+#: mod/admin.php:1544 src/Model/User.php:647
 #, php-format
 msgid "Registration details for %s"
 msgstr ""
 
-#: mod/admin.php:1529
+#: mod/admin.php:1554
 #, php-format
 msgid "%s user blocked/unblocked"
 msgid_plural "%s users blocked/unblocked"
 msgstr[0] ""
 msgstr[1] ""
 
-#: mod/admin.php:1535
+#: mod/admin.php:1560
 #, php-format
 msgid "%s user deleted"
 msgid_plural "%s users deleted"
 msgstr[0] ""
 msgstr[1] ""
 
-#: mod/admin.php:1582
+#: mod/admin.php:1607
 #, php-format
 msgid "User '%s' deleted"
 msgstr ""
 
-#: mod/admin.php:1590
+#: mod/admin.php:1615
 #, php-format
 msgid "User '%s' unblocked"
 msgstr ""
 
-#: mod/admin.php:1590
+#: mod/admin.php:1615
 #, php-format
 msgid "User '%s' blocked"
 msgstr ""
 
-#: mod/admin.php:1689 mod/admin.php:1701 mod/admin.php:1714 mod/admin.php:1732
+#: mod/admin.php:1714 mod/admin.php:1726 mod/admin.php:1739 mod/admin.php:1757
 #: src/Content/ContactSelector.php:82
 msgid "Email"
 msgstr ""
 
-#: mod/admin.php:1689 mod/admin.php:1714
+#: mod/admin.php:1714 mod/admin.php:1739
 msgid "Register date"
 msgstr ""
 
-#: mod/admin.php:1689 mod/admin.php:1714
+#: mod/admin.php:1714 mod/admin.php:1739
 msgid "Last login"
 msgstr ""
 
-#: mod/admin.php:1689 mod/admin.php:1714
+#: mod/admin.php:1714 mod/admin.php:1739
 msgid "Last item"
 msgstr ""
 
-#: mod/admin.php:1689 mod/settings.php:54
+#: mod/admin.php:1714 mod/settings.php:56
 msgid "Account"
 msgstr ""
 
-#: mod/admin.php:1697
+#: mod/admin.php:1722
 msgid "Add User"
 msgstr ""
 
-#: mod/admin.php:1699
+#: mod/admin.php:1724
 msgid "User registrations waiting for confirm"
 msgstr ""
 
-#: mod/admin.php:1700
+#: mod/admin.php:1725
 msgid "User waiting for permanent deletion"
 msgstr ""
 
-#: mod/admin.php:1701
+#: mod/admin.php:1726
 msgid "Request date"
 msgstr ""
 
-#: mod/admin.php:1702
+#: mod/admin.php:1727
 msgid "No registrations."
 msgstr ""
 
-#: mod/admin.php:1703
+#: mod/admin.php:1728
 msgid "Note from the user"
 msgstr ""
 
-#: mod/admin.php:1705
+#: mod/admin.php:1730
 msgid "Deny"
 msgstr ""
 
-#: mod/admin.php:1709
+#: mod/admin.php:1734
 msgid "Site admin"
 msgstr ""
 
-#: mod/admin.php:1710
+#: mod/admin.php:1735
 msgid "Account expired"
 msgstr ""
 
-#: mod/admin.php:1713
+#: mod/admin.php:1738
 msgid "New User"
 msgstr ""
 
-#: mod/admin.php:1714
+#: mod/admin.php:1739
 msgid "Deleted since"
 msgstr ""
 
-#: mod/admin.php:1719
+#: mod/admin.php:1744
 msgid ""
 "Selected users will be deleted!\\n\\nEverything these users had posted on "
 "this site will be permanently deleted!\\n\\nAre you sure?"
 msgstr ""
 
-#: mod/admin.php:1720
+#: mod/admin.php:1745
 msgid ""
 "The user {0} will be deleted!\\n\\nEverything this user has posted on this "
 "site will be permanently deleted!\\n\\nAre you sure?"
 msgstr ""
 
-#: mod/admin.php:1730
+#: mod/admin.php:1755
 msgid "Name of the new user."
 msgstr ""
 
-#: mod/admin.php:1731
+#: mod/admin.php:1756
 msgid "Nickname"
 msgstr ""
 
-#: mod/admin.php:1731
+#: mod/admin.php:1756
 msgid "Nickname of the new user."
 msgstr ""
 
-#: mod/admin.php:1732
+#: mod/admin.php:1757
 msgid "Email address of the new user."
 msgstr ""
 
-#: mod/admin.php:1774
+#: mod/admin.php:1799
 #, php-format
 msgid "Addon %s disabled."
 msgstr ""
 
-#: mod/admin.php:1778
+#: mod/admin.php:1803
 #, php-format
 msgid "Addon %s enabled."
 msgstr ""
 
-#: mod/admin.php:1788 mod/admin.php:2037
+#: mod/admin.php:1813 mod/admin.php:2062
 msgid "Disable"
 msgstr ""
 
-#: mod/admin.php:1791 mod/admin.php:2040
+#: mod/admin.php:1816 mod/admin.php:2065
 msgid "Enable"
 msgstr ""
 
-#: mod/admin.php:1813 mod/admin.php:2082
+#: mod/admin.php:1838 mod/admin.php:2107
 msgid "Toggle"
 msgstr ""
 
-#: mod/admin.php:1821 mod/admin.php:2091
+#: mod/admin.php:1846 mod/admin.php:2116
 msgid "Author: "
 msgstr ""
 
-#: mod/admin.php:1822 mod/admin.php:2092
+#: mod/admin.php:1847 mod/admin.php:2117
 msgid "Maintainer: "
 msgstr ""
 
-#: mod/admin.php:1874
+#: mod/admin.php:1899
 msgid "Reload active addons"
 msgstr ""
 
-#: mod/admin.php:1879
+#: mod/admin.php:1904
 #, php-format
 msgid ""
 "There are currently no addons available on your node. You can find the "
@@ -5850,70 +5024,70 @@ msgid ""
 "the open addon registry at %2$s"
 msgstr ""
 
-#: mod/admin.php:1999
+#: mod/admin.php:2024
 msgid "No themes found."
 msgstr ""
 
-#: mod/admin.php:2073
+#: mod/admin.php:2098
 msgid "Screenshot"
 msgstr ""
 
-#: mod/admin.php:2127
+#: mod/admin.php:2152
 msgid "Reload active themes"
 msgstr ""
 
-#: mod/admin.php:2132
+#: mod/admin.php:2157
 #, php-format
 msgid "No themes found on the system. They should be placed in %1$s"
 msgstr ""
 
-#: mod/admin.php:2133
+#: mod/admin.php:2158
 msgid "[Experimental]"
 msgstr ""
 
-#: mod/admin.php:2134
+#: mod/admin.php:2159
 msgid "[Unsupported]"
 msgstr ""
 
-#: mod/admin.php:2158
+#: mod/admin.php:2183
 msgid "Log settings updated."
 msgstr ""
 
-#: mod/admin.php:2190
+#: mod/admin.php:2215
 msgid "PHP log currently enabled."
 msgstr ""
 
-#: mod/admin.php:2192
+#: mod/admin.php:2217
 msgid "PHP log currently disabled."
 msgstr ""
 
-#: mod/admin.php:2201
+#: mod/admin.php:2226
 msgid "Clear"
 msgstr ""
 
-#: mod/admin.php:2205
+#: mod/admin.php:2230
 msgid "Enable Debugging"
 msgstr ""
 
-#: mod/admin.php:2206
+#: mod/admin.php:2231
 msgid "Log file"
 msgstr ""
 
-#: mod/admin.php:2206
+#: mod/admin.php:2231
 msgid ""
 "Must be writable by web server. Relative to your Friendica top-level "
 "directory."
 msgstr ""
 
-#: mod/admin.php:2207
+#: mod/admin.php:2232
 msgid "Log level"
 msgstr ""
 
-#: mod/admin.php:2209
+#: mod/admin.php:2234
 msgid "PHP logging"
 msgstr ""
 
-#: mod/admin.php:2210
+#: mod/admin.php:2235
 msgid ""
 "To enable logging of PHP errors and warnings you can add the following to "
 "the .htconfig.php file of your installation. The filename set in the "
@@ -5922,117 +5096,588 @@ msgid ""
 "'display_errors' is to enable these options, set to '0' to disable them."
 msgstr ""
 
-#: mod/admin.php:2241
+#: mod/admin.php:2266
 #, php-format
 msgid ""
 "Error trying to open <strong>%1$s</strong> log file.\\r\\n<br/>Check to see "
 "if file %1$s exist and is readable."
 msgstr ""
 
-#: mod/admin.php:2245
+#: mod/admin.php:2270
 #, php-format
 msgid ""
 "Couldn't open <strong>%1$s</strong> log file.\\r\\n<br/>Check to see if file "
 "%1$s is readable."
 msgstr ""
 
-#: mod/admin.php:2336 mod/admin.php:2337 mod/settings.php:779
+#: mod/admin.php:2361 mod/admin.php:2362 mod/settings.php:775
 msgid "Off"
 msgstr ""
 
-#: mod/admin.php:2336 mod/admin.php:2337 mod/settings.php:779
+#: mod/admin.php:2361 mod/admin.php:2362 mod/settings.php:775
 msgid "On"
 msgstr ""
 
-#: mod/admin.php:2337
+#: mod/admin.php:2362
 #, php-format
 msgid "Lock feature %s"
 msgstr ""
 
-#: mod/admin.php:2345
+#: mod/admin.php:2370
 msgid "Manage Additional Features"
 msgstr ""
 
-#: mod/babel.php:23
-msgid "Source (bbcode) text:"
+#: mod/babel.php:22
+msgid "Source input"
 msgstr ""
 
-#: mod/babel.php:30
-msgid "Source (Diaspora) text to convert to BBcode:"
+#: mod/babel.php:28
+msgid "BBCode::convert (raw HTML("
 msgstr ""
 
-#: mod/babel.php:38
-msgid "Source input: "
+#: mod/babel.php:33
+msgid "BBCode::convert"
 msgstr ""
 
-#: mod/babel.php:42
-msgid "bbcode (raw HTML(: "
+#: mod/babel.php:39
+msgid "BBCode::convert => HTML::toBBCode"
 msgstr ""
 
 #: mod/babel.php:45
-msgid "bbcode: "
+msgid "BBCode::toMarkdown"
 msgstr ""
 
-#: mod/babel.php:49 mod/babel.php:65
-msgid "bbcode => html2bbcode: "
-msgstr ""
-
-#: mod/babel.php:53
-msgid "bb2diaspora: "
+#: mod/babel.php:51
+msgid "BBCode::toMarkdown => Markdown::convert"
 msgstr ""
 
 #: mod/babel.php:57
-msgid "bb2diaspora => Markdown: "
+msgid "BBCode::toMarkdown => Markdown::toBBCode"
 msgstr ""
 
-#: mod/babel.php:61
-msgid "bb2diaspora => diaspora2bb: "
+#: mod/babel.php:63
+msgid "BBCode::toMarkdown =>  Markdown::convert => HTML::toBBCode"
 msgstr ""
 
-#: mod/babel.php:71
-msgid "Source input (Diaspora format): "
+#: mod/babel.php:70
+msgid "Source input \\x28Diaspora format\\x29"
 msgstr ""
 
-#: mod/babel.php:75
-msgid "diaspora2bb: "
+#: mod/babel.php:76
+msgid "Markdown::toBBCode"
 msgstr ""
 
-#: mod/bookmarklet.php:21 src/Content/Nav.php:114 src/Module/Login.php:312
-msgid "Login"
+#: mod/babel.php:83
+msgid "Raw HTML input"
 msgstr ""
 
-#: mod/bookmarklet.php:49
-msgid "The post was created"
+#: mod/babel.php:88
+msgid "HTML Input"
 msgstr ""
 
-#: mod/community.php:44
-msgid "Community option not available."
+#: mod/babel.php:94
+msgid "HTML::toBBCode"
 msgstr ""
 
-#: mod/community.php:61
-msgid "Not available."
+#: mod/babel.php:100
+msgid "HTML::toPlaintext"
 msgstr ""
 
-#: mod/community.php:74
-msgid "Local Community"
+#: mod/babel.php:108
+msgid "Source text"
 msgstr ""
 
-#: mod/community.php:77
-msgid "Posts from local users on this server"
+#: mod/babel.php:109
+msgid "BBCode"
 msgstr ""
 
-#: mod/community.php:85
-msgid "Global Community"
+#: mod/babel.php:110
+msgid "Markdown"
 msgstr ""
 
-#: mod/community.php:88
-msgid "Posts from users of the whole federated network"
+#: mod/babel.php:111
+msgid "HTML"
 msgstr ""
 
-#: mod/community.php:178
+#: mod/cal.php:274 mod/events.php:391 view/theme/frio/theme.php:263
+#: view/theme/frio/theme.php:267 src/Content/Nav.php:104
+#: src/Content/Nav.php:169 src/Model/Profile.php:924 src/Model/Profile.php:935
+msgid "Events"
+msgstr ""
+
+#: mod/cal.php:275 mod/events.php:392
+msgid "View"
+msgstr ""
+
+#: mod/cal.php:276 mod/events.php:394
+msgid "Previous"
+msgstr ""
+
+#: mod/cal.php:277 mod/events.php:395 mod/install.php:209
+msgid "Next"
+msgstr ""
+
+#: mod/cal.php:280 mod/events.php:400 src/Model/Event.php:412
+msgid "today"
+msgstr ""
+
+#: mod/cal.php:281 mod/events.php:401 src/Util/Temporal.php:304
+#: src/Model/Event.php:413
+msgid "month"
+msgstr ""
+
+#: mod/cal.php:282 mod/events.php:402 src/Util/Temporal.php:305
+#: src/Model/Event.php:414
+msgid "week"
+msgstr ""
+
+#: mod/cal.php:283 mod/events.php:403 src/Util/Temporal.php:306
+#: src/Model/Event.php:415
+msgid "day"
+msgstr ""
+
+#: mod/cal.php:284 mod/events.php:404
+msgid "list"
+msgstr ""
+
+#: mod/cal.php:297 src/Model/User.php:204
+msgid "User not found"
+msgstr ""
+
+#: mod/cal.php:313
+msgid "This calendar format is not supported"
+msgstr ""
+
+#: mod/cal.php:315
+msgid "No exportable data found"
+msgstr ""
+
+#: mod/cal.php:332
+msgid "calendar"
+msgstr ""
+
+#: mod/contacts.php:157
+#, php-format
+msgid "%d contact edited."
+msgid_plural "%d contacts edited."
+msgstr[0] ""
+msgstr[1] ""
+
+#: mod/contacts.php:184 mod/contacts.php:400
+msgid "Could not access contact record."
+msgstr ""
+
+#: mod/contacts.php:194
+msgid "Could not locate selected profile."
+msgstr ""
+
+#: mod/contacts.php:228
+msgid "Contact updated."
+msgstr ""
+
+#: mod/contacts.php:421
+msgid "Contact has been blocked"
+msgstr ""
+
+#: mod/contacts.php:421
+msgid "Contact has been unblocked"
+msgstr ""
+
+#: mod/contacts.php:432
+msgid "Contact has been ignored"
+msgstr ""
+
+#: mod/contacts.php:432
+msgid "Contact has been unignored"
+msgstr ""
+
+#: mod/contacts.php:443
+msgid "Contact has been archived"
+msgstr ""
+
+#: mod/contacts.php:443
+msgid "Contact has been unarchived"
+msgstr ""
+
+#: mod/contacts.php:467
+msgid "Drop contact"
+msgstr ""
+
+#: mod/contacts.php:470 mod/contacts.php:823
+msgid "Do you really want to delete this contact?"
+msgstr ""
+
+#: mod/contacts.php:488
+msgid "Contact has been removed."
+msgstr ""
+
+#: mod/contacts.php:519
+#, php-format
+msgid "You are mutual friends with %s"
+msgstr ""
+
+#: mod/contacts.php:523
+#, php-format
+msgid "You are sharing with %s"
+msgstr ""
+
+#: mod/contacts.php:527
+#, php-format
+msgid "%s is sharing with you"
+msgstr ""
+
+#: mod/contacts.php:547
+msgid "Private communications are not available for this contact."
+msgstr ""
+
+#: mod/contacts.php:549
+msgid "Never"
+msgstr ""
+
+#: mod/contacts.php:552
+msgid "(Update was successful)"
+msgstr ""
+
+#: mod/contacts.php:552
+msgid "(Update was not successful)"
+msgstr ""
+
+#: mod/contacts.php:554 mod/contacts.php:992
+msgid "Suggest friends"
+msgstr ""
+
+#: mod/contacts.php:558
+#, php-format
+msgid "Network type: %s"
+msgstr ""
+
+#: mod/contacts.php:563
+msgid "Communications lost with this contact!"
+msgstr ""
+
+#: mod/contacts.php:569
+msgid "Fetch further information for feeds"
+msgstr ""
+
+#: mod/contacts.php:571
 msgid ""
-"This community stream shows all public posts received by this node. They may "
-"not reflect the opinions of this node’s users."
+"Fetch information like preview pictures, title and teaser from the feed "
+"item. You can activate this if the feed doesn't contain much text. Keywords "
+"are taken from the meta header in the feed item and are posted as hash tags."
+msgstr ""
+
+#: mod/contacts.php:573
+msgid "Fetch information"
+msgstr ""
+
+#: mod/contacts.php:574
+msgid "Fetch keywords"
+msgstr ""
+
+#: mod/contacts.php:575
+msgid "Fetch information and keywords"
+msgstr ""
+
+#: mod/contacts.php:599 mod/unfollow.php:100
+msgid "Disconnect/Unfollow"
+msgstr ""
+
+#: mod/contacts.php:608
+msgid "Contact"
+msgstr ""
+
+#: mod/contacts.php:611
+msgid "Profile Visibility"
+msgstr ""
+
+#: mod/contacts.php:612
+#, php-format
+msgid ""
+"Please choose the profile you would like to display to %s when viewing your "
+"profile securely."
+msgstr ""
+
+#: mod/contacts.php:613
+msgid "Contact Information / Notes"
+msgstr ""
+
+#: mod/contacts.php:614
+msgid "Their personal note"
+msgstr ""
+
+#: mod/contacts.php:616
+msgid "Edit contact notes"
+msgstr ""
+
+#: mod/contacts.php:620
+msgid "Block/Unblock contact"
+msgstr ""
+
+#: mod/contacts.php:621
+msgid "Ignore contact"
+msgstr ""
+
+#: mod/contacts.php:622
+msgid "Repair URL settings"
+msgstr ""
+
+#: mod/contacts.php:623
+msgid "View conversations"
+msgstr ""
+
+#: mod/contacts.php:628
+msgid "Last update:"
+msgstr ""
+
+#: mod/contacts.php:630
+msgid "Update public posts"
+msgstr ""
+
+#: mod/contacts.php:632 mod/contacts.php:1002
+msgid "Update now"
+msgstr ""
+
+#: mod/contacts.php:638 mod/contacts.php:828 mod/contacts.php:1019
+msgid "Unignore"
+msgstr ""
+
+#: mod/contacts.php:642
+msgid "Currently blocked"
+msgstr ""
+
+#: mod/contacts.php:643
+msgid "Currently ignored"
+msgstr ""
+
+#: mod/contacts.php:644
+msgid "Currently archived"
+msgstr ""
+
+#: mod/contacts.php:645
+msgid "Awaiting connection acknowledge"
+msgstr ""
+
+#: mod/contacts.php:646
+msgid ""
+"Replies/likes to your public posts <strong>may</strong> still be visible"
+msgstr ""
+
+#: mod/contacts.php:647
+msgid "Notification for new posts"
+msgstr ""
+
+#: mod/contacts.php:647
+msgid "Send a notification of every new post of this contact"
+msgstr ""
+
+#: mod/contacts.php:650
+msgid "Blacklisted keywords"
+msgstr ""
+
+#: mod/contacts.php:650
+msgid ""
+"Comma separated list of keywords that should not be converted to hashtags, "
+"when \"Fetch information and keywords\" is selected"
+msgstr ""
+
+#: mod/contacts.php:662 src/Model/Profile.php:424
+msgid "XMPP:"
+msgstr ""
+
+#: mod/contacts.php:667
+msgid "Actions"
+msgstr ""
+
+#: mod/contacts.php:669 mod/contacts.php:855 view/theme/frio/theme.php:259
+#: src/Content/Nav.php:100 src/Model/Profile.php:888
+msgid "Status"
+msgstr ""
+
+#: mod/contacts.php:670
+msgid "Contact Settings"
+msgstr ""
+
+#: mod/contacts.php:711
+msgid "Suggestions"
+msgstr ""
+
+#: mod/contacts.php:714
+msgid "Suggest potential friends"
+msgstr ""
+
+#: mod/contacts.php:722
+msgid "Show all contacts"
+msgstr ""
+
+#: mod/contacts.php:727
+msgid "Unblocked"
+msgstr ""
+
+#: mod/contacts.php:730
+msgid "Only show unblocked contacts"
+msgstr ""
+
+#: mod/contacts.php:735
+msgid "Blocked"
+msgstr ""
+
+#: mod/contacts.php:738
+msgid "Only show blocked contacts"
+msgstr ""
+
+#: mod/contacts.php:743
+msgid "Ignored"
+msgstr ""
+
+#: mod/contacts.php:746
+msgid "Only show ignored contacts"
+msgstr ""
+
+#: mod/contacts.php:751
+msgid "Archived"
+msgstr ""
+
+#: mod/contacts.php:754
+msgid "Only show archived contacts"
+msgstr ""
+
+#: mod/contacts.php:759
+msgid "Hidden"
+msgstr ""
+
+#: mod/contacts.php:762
+msgid "Only show hidden contacts"
+msgstr ""
+
+#: mod/contacts.php:818
+msgid "Search your contacts"
+msgstr ""
+
+#: mod/contacts.php:820 mod/directory.php:210 src/Content/Widget.php:63
+msgid "Find"
+msgstr ""
+
+#: mod/contacts.php:826 mod/settings.php:171 mod/settings.php:701
+msgid "Update"
+msgstr ""
+
+#: mod/contacts.php:829 mod/contacts.php:1027
+msgid "Archive"
+msgstr ""
+
+#: mod/contacts.php:829 mod/contacts.php:1027
+msgid "Unarchive"
+msgstr ""
+
+#: mod/contacts.php:832
+msgid "Batch Actions"
+msgstr ""
+
+#: mod/contacts.php:858 mod/follow.php:183 mod/unfollow.php:132
+#: src/Model/Profile.php:891
+msgid "Status Messages and Posts"
+msgstr ""
+
+#: mod/contacts.php:866 src/Model/Profile.php:899
+msgid "Profile Details"
+msgstr ""
+
+#: mod/contacts.php:878
+msgid "View all contacts"
+msgstr ""
+
+#: mod/contacts.php:889
+msgid "View all common friends"
+msgstr ""
+
+#: mod/contacts.php:898
+msgid "Advanced Contact Settings"
+msgstr ""
+
+#: mod/contacts.php:930
+msgid "Mutual Friendship"
+msgstr ""
+
+#: mod/contacts.php:934
+msgid "is a fan of yours"
+msgstr ""
+
+#: mod/contacts.php:938
+msgid "you are a fan of"
+msgstr ""
+
+#: mod/contacts.php:1013
+msgid "Toggle Blocked status"
+msgstr ""
+
+#: mod/contacts.php:1021
+msgid "Toggle Ignored status"
+msgstr ""
+
+#: mod/contacts.php:1029
+msgid "Toggle Archive status"
+msgstr ""
+
+#: mod/contacts.php:1037
+msgid "Delete contact"
+msgstr ""
+
+#: mod/delegate.php:37
+msgid "Parent user not found."
+msgstr ""
+
+#: mod/delegate.php:144
+msgid "No parent user"
+msgstr ""
+
+#: mod/delegate.php:159
+msgid "Parent Password:"
+msgstr ""
+
+#: mod/delegate.php:159
+msgid ""
+"Please enter the password of the parent account to legitimize your request."
+msgstr ""
+
+#: mod/delegate.php:164
+msgid "Parent User"
+msgstr ""
+
+#: mod/delegate.php:167
+msgid ""
+"Parent users have total control about this account, including the account "
+"settings. Please double check whom you give this access."
+msgstr ""
+
+#: mod/delegate.php:169 src/Content/Nav.php:204
+msgid "Delegate Page Management"
+msgstr ""
+
+#: mod/delegate.php:170
+msgid "Delegates"
+msgstr ""
+
+#: mod/delegate.php:172
+msgid ""
+"Delegates are able to manage all aspects of this account/page except for "
+"basic account settings. Please do not delegate your personal account to "
+"anybody that you do not trust completely."
+msgstr ""
+
+#: mod/delegate.php:173
+msgid "Existing Page Delegates"
+msgstr ""
+
+#: mod/delegate.php:175
+msgid "Potential Delegates"
+msgstr ""
+
+#: mod/delegate.php:178
+msgid "Add"
+msgstr ""
+
+#: mod/delegate.php:179
+msgid "No entries."
 msgstr ""
 
 #: mod/directory.php:153 src/Model/Profile.php:421 src/Model/Profile.php:769
@@ -6063,1061 +5708,1453 @@ msgstr ""
 msgid "No entries (some entries may be hidden)."
 msgstr ""
 
-#: mod/editpost.php:27 mod/editpost.php:37
-msgid "Item not found"
+#: mod/dirfind.php:49
+#, php-format
+msgid "People Search - %s"
 msgstr ""
 
-#: mod/editpost.php:44
-msgid "Edit post"
+#: mod/dirfind.php:60
+#, php-format
+msgid "Forum Search - %s"
 msgstr ""
 
-#: mod/events.php:103 mod/events.php:105
+#: mod/events.php:105 mod/events.php:107
 msgid "Event can not end before it has started."
 msgstr ""
 
-#: mod/events.php:112 mod/events.php:114
+#: mod/events.php:114 mod/events.php:116
 msgid "Event title and start time are required."
 msgstr ""
 
-#: mod/events.php:394
+#: mod/events.php:393
 msgid "Create New Event"
 msgstr ""
 
-#: mod/events.php:509
+#: mod/events.php:506
 msgid "Event details"
 msgstr ""
 
-#: mod/events.php:510
+#: mod/events.php:507
 msgid "Starting date and Title are required."
 msgstr ""
 
-#: mod/events.php:511 mod/events.php:512
+#: mod/events.php:508 mod/events.php:509
 msgid "Event Starts:"
 msgstr ""
 
-#: mod/events.php:513 mod/events.php:529
+#: mod/events.php:508 mod/events.php:520 mod/profiles.php:699
+msgid "Required"
+msgstr ""
+
+#: mod/events.php:510 mod/events.php:526
 msgid "Finish date/time is not known or not relevant"
 msgstr ""
 
-#: mod/events.php:515 mod/events.php:516
+#: mod/events.php:512 mod/events.php:513
 msgid "Event Finishes:"
 msgstr ""
 
-#: mod/events.php:517 mod/events.php:530
+#: mod/events.php:514 mod/events.php:527
 msgid "Adjust for viewer timezone"
 msgstr ""
 
-#: mod/events.php:519
+#: mod/events.php:516
 msgid "Description:"
 msgstr ""
 
-#: mod/events.php:523 mod/events.php:525
+#: mod/events.php:520 mod/events.php:522
 msgid "Title:"
 msgstr ""
 
-#: mod/events.php:526 mod/events.php:527
+#: mod/events.php:523 mod/events.php:524
 msgid "Share this event"
 msgstr ""
 
-#: mod/events.php:534 src/Model/Profile.php:864
+#: mod/events.php:531 src/Model/Profile.php:864
 msgid "Basic"
 msgstr ""
 
-#: mod/events.php:556
+#: mod/events.php:552
 msgid "Failed to remove event"
 msgstr ""
 
-#: mod/events.php:558
+#: mod/events.php:554
 msgid "Event removed"
 msgstr ""
 
-#: mod/fsuggest.php:71
-msgid "Friend suggestion sent."
+#: mod/feedtest.php:20
+msgid "You must be logged in to use this module"
 msgstr ""
 
-#: mod/fsuggest.php:102
-msgid "Suggest Friends"
+#: mod/feedtest.php:48
+msgid "Source URL"
 msgstr ""
 
-#: mod/fsuggest.php:104
-#, php-format
-msgid "Suggest a friend for %s"
+#: mod/follow.php:45
+msgid "The contact could not be added."
 msgstr ""
 
-#: mod/group.php:36
-msgid "Group created."
+#: mod/follow.php:73
+msgid "You already added this contact."
 msgstr ""
 
-#: mod/group.php:42
-msgid "Could not create group."
+#: mod/follow.php:83
+msgid "Diaspora support isn't enabled. Contact can't be added."
 msgstr ""
 
-#: mod/group.php:56 mod/group.php:158
-msgid "Group not found."
+#: mod/follow.php:90
+msgid "OStatus support is disabled. Contact can't be added."
 msgstr ""
 
-#: mod/group.php:70
-msgid "Group name changed."
+#: mod/follow.php:97
+msgid "The network type couldn't be detected. Contact can't be added."
 msgstr ""
 
-#: mod/group.php:97
-msgid "Save Group"
+#: mod/install.php:114
+msgid "Friendica Communications Server - Setup"
 msgstr ""
 
-#: mod/group.php:102
-msgid "Create a group of contacts/friends."
+#: mod/install.php:120
+msgid "Could not connect to database."
 msgstr ""
 
-#: mod/group.php:103 mod/group.php:200 src/Model/Group.php:409
-msgid "Group Name: "
+#: mod/install.php:124
+msgid "Could not create table."
 msgstr ""
 
-#: mod/group.php:127
-msgid "Group removed."
+#: mod/install.php:130
+msgid "Your Friendica site database has been installed."
 msgstr ""
 
-#: mod/group.php:129
-msgid "Unable to remove group."
-msgstr ""
-
-#: mod/group.php:193
-msgid "Delete Group"
-msgstr ""
-
-#: mod/group.php:199
-msgid "Group Editor"
-msgstr ""
-
-#: mod/group.php:204
-msgid "Edit Group Name"
-msgstr ""
-
-#: mod/group.php:214
-msgid "Members"
-msgstr ""
-
-#: mod/group.php:217 mod/network.php:639
-msgid "Group is empty"
-msgstr ""
-
-#: mod/group.php:230
-msgid "Remove Contact"
-msgstr ""
-
-#: mod/group.php:254
-msgid "Add Contact"
-msgstr ""
-
-#: mod/message.php:30 src/Content/Nav.php:198
-msgid "New Message"
-msgstr ""
-
-#: mod/message.php:77
-msgid "Unable to locate contact information."
-msgstr ""
-
-#: mod/message.php:112 view/theme/frio/theme.php:268 src/Content/Nav.php:195
-msgid "Messages"
-msgstr ""
-
-#: mod/message.php:136
-msgid "Do you really want to delete this message?"
-msgstr ""
-
-#: mod/message.php:156
-msgid "Message deleted."
-msgstr ""
-
-#: mod/message.php:185
-msgid "Conversation removed."
-msgstr ""
-
-#: mod/message.php:291
-msgid "No messages."
-msgstr ""
-
-#: mod/message.php:330
-msgid "Message not available."
-msgstr ""
-
-#: mod/message.php:397
-msgid "Delete message"
-msgstr ""
-
-#: mod/message.php:399 mod/message.php:500
-msgid "D, d M Y - g:i A"
-msgstr ""
-
-#: mod/message.php:414 mod/message.php:497
-msgid "Delete conversation"
-msgstr ""
-
-#: mod/message.php:416
+#: mod/install.php:135
 msgid ""
-"No secure communications available. You <strong>may</strong> be able to "
-"respond from the sender's profile page."
+"You may need to import the file \"database.sql\" manually using phpmyadmin "
+"or mysql."
 msgstr ""
 
-#: mod/message.php:420
-msgid "Send Reply"
+#: mod/install.php:136 mod/install.php:208 mod/install.php:558
+msgid "Please see the file \"INSTALL.txt\"."
 msgstr ""
 
-#: mod/message.php:471
-#, php-format
-msgid "Unknown sender - %s"
+#: mod/install.php:148
+msgid "Database already in use."
 msgstr ""
 
-#: mod/message.php:473
-#, php-format
-msgid "You and %s"
+#: mod/install.php:205
+msgid "System check"
 msgstr ""
 
-#: mod/message.php:475
-#, php-format
-msgid "%s and You"
+#: mod/install.php:210
+msgid "Check again"
 msgstr ""
 
-#: mod/message.php:503
-#, php-format
-msgid "%d message"
-msgid_plural "%d messages"
-msgstr[0] ""
-msgstr[1] ""
-
-#: mod/network.php:202 src/Model/Group.php:401
-msgid "add"
+#: mod/install.php:230
+msgid "Database connection"
 msgstr ""
 
-#: mod/network.php:547
+#: mod/install.php:231
+msgid ""
+"In order to install Friendica we need to know how to connect to your "
+"database."
+msgstr ""
+
+#: mod/install.php:232
+msgid ""
+"Please contact your hosting provider or site administrator if you have "
+"questions about these settings."
+msgstr ""
+
+#: mod/install.php:233
+msgid ""
+"The database you specify below should already exist. If it does not, please "
+"create it before continuing."
+msgstr ""
+
+#: mod/install.php:237
+msgid "Database Server Name"
+msgstr ""
+
+#: mod/install.php:238
+msgid "Database Login Name"
+msgstr ""
+
+#: mod/install.php:239
+msgid "Database Login Password"
+msgstr ""
+
+#: mod/install.php:239
+msgid "For security reasons the password must not be empty"
+msgstr ""
+
+#: mod/install.php:240
+msgid "Database Name"
+msgstr ""
+
+#: mod/install.php:241 mod/install.php:281
+msgid "Site administrator email address"
+msgstr ""
+
+#: mod/install.php:241 mod/install.php:281
+msgid ""
+"Your account email address must match this in order to use the web admin "
+"panel."
+msgstr ""
+
+#: mod/install.php:245 mod/install.php:284
+msgid "Please select a default timezone for your website"
+msgstr ""
+
+#: mod/install.php:271
+msgid "Site settings"
+msgstr ""
+
+#: mod/install.php:285
+msgid "System Language:"
+msgstr ""
+
+#: mod/install.php:285
+msgid ""
+"Set the default language for your Friendica installation interface and to "
+"send emails."
+msgstr ""
+
+#: mod/install.php:325
+msgid "Could not find a command line version of PHP in the web server PATH."
+msgstr ""
+
+#: mod/install.php:326
+msgid ""
+"If you don't have a command line version of PHP installed on your server, "
+"you will not be able to run the background processing. See <a href='https://"
+"github.com/friendica/friendica/blob/master/doc/Install.md#set-up-the-"
+"worker'>'Setup the worker'</a>"
+msgstr ""
+
+#: mod/install.php:330
+msgid "PHP executable path"
+msgstr ""
+
+#: mod/install.php:330
+msgid ""
+"Enter full path to php executable. You can leave this blank to continue the "
+"installation."
+msgstr ""
+
+#: mod/install.php:335
+msgid "Command line PHP"
+msgstr ""
+
+#: mod/install.php:344
+msgid "PHP executable is not the php cli binary (could be cgi-fgci version)"
+msgstr ""
+
+#: mod/install.php:345
+msgid "Found PHP version: "
+msgstr ""
+
+#: mod/install.php:347
+msgid "PHP cli binary"
+msgstr ""
+
+#: mod/install.php:358
+msgid ""
+"The command line version of PHP on your system does not have "
+"\"register_argc_argv\" enabled."
+msgstr ""
+
+#: mod/install.php:359
+msgid "This is required for message delivery to work."
+msgstr ""
+
+#: mod/install.php:361
+msgid "PHP register_argc_argv"
+msgstr ""
+
+#: mod/install.php:384
+msgid ""
+"Error: the \"openssl_pkey_new\" function on this system is not able to "
+"generate encryption keys"
+msgstr ""
+
+#: mod/install.php:385
+msgid ""
+"If running under Windows, please see \"http://www.php.net/manual/en/openssl."
+"installation.php\"."
+msgstr ""
+
+#: mod/install.php:387
+msgid "Generate encryption keys"
+msgstr ""
+
+#: mod/install.php:394
+msgid "libCurl PHP module"
+msgstr ""
+
+#: mod/install.php:395
+msgid "GD graphics PHP module"
+msgstr ""
+
+#: mod/install.php:396
+msgid "OpenSSL PHP module"
+msgstr ""
+
+#: mod/install.php:397
+msgid "PDO or MySQLi PHP module"
+msgstr ""
+
+#: mod/install.php:398
+msgid "mb_string PHP module"
+msgstr ""
+
+#: mod/install.php:399
+msgid "XML PHP module"
+msgstr ""
+
+#: mod/install.php:400
+msgid "iconv PHP module"
+msgstr ""
+
+#: mod/install.php:401
+msgid "POSIX PHP module"
+msgstr ""
+
+#: mod/install.php:405 mod/install.php:407
+msgid "Apache mod_rewrite module"
+msgstr ""
+
+#: mod/install.php:405
+msgid ""
+"Error: Apache webserver mod-rewrite module is required but not installed."
+msgstr ""
+
+#: mod/install.php:413
+msgid "Error: libCURL PHP module required but not installed."
+msgstr ""
+
+#: mod/install.php:417
+msgid ""
+"Error: GD graphics PHP module with JPEG support required but not installed."
+msgstr ""
+
+#: mod/install.php:421
+msgid "Error: openssl PHP module required but not installed."
+msgstr ""
+
+#: mod/install.php:425
+msgid "Error: PDO or MySQLi PHP module required but not installed."
+msgstr ""
+
+#: mod/install.php:429
+msgid "Error: The MySQL driver for PDO is not installed."
+msgstr ""
+
+#: mod/install.php:433
+msgid "Error: mb_string PHP module required but not installed."
+msgstr ""
+
+#: mod/install.php:437
+msgid "Error: iconv PHP module required but not installed."
+msgstr ""
+
+#: mod/install.php:441
+msgid "Error: POSIX PHP module required but not installed."
+msgstr ""
+
+#: mod/install.php:451
+msgid "Error, XML PHP module required but not installed."
+msgstr ""
+
+#: mod/install.php:463
+msgid ""
+"The web installer needs to be able to create a file called \".htconfig.php\" "
+"in the top folder of your web server and it is unable to do so."
+msgstr ""
+
+#: mod/install.php:464
+msgid ""
+"This is most often a permission setting, as the web server may not be able "
+"to write files in your folder - even if you can."
+msgstr ""
+
+#: mod/install.php:465
+msgid ""
+"At the end of this procedure, we will give you a text to save in a file "
+"named .htconfig.php in your Friendica top folder."
+msgstr ""
+
+#: mod/install.php:466
+msgid ""
+"You can alternatively skip this procedure and perform a manual installation. "
+"Please see the file \"INSTALL.txt\" for instructions."
+msgstr ""
+
+#: mod/install.php:469
+msgid ".htconfig.php is writable"
+msgstr ""
+
+#: mod/install.php:479
+msgid ""
+"Friendica uses the Smarty3 template engine to render its web views. Smarty3 "
+"compiles templates to PHP to speed up rendering."
+msgstr ""
+
+#: mod/install.php:480
+msgid ""
+"In order to store these compiled templates, the web server needs to have "
+"write access to the directory view/smarty3/ under the Friendica top level "
+"folder."
+msgstr ""
+
+#: mod/install.php:481
+msgid ""
+"Please ensure that the user that your web server runs as (e.g. www-data) has "
+"write access to this folder."
+msgstr ""
+
+#: mod/install.php:482
+msgid ""
+"Note: as a security measure, you should give the web server write access to "
+"view/smarty3/ only--not the template files (.tpl) that it contains."
+msgstr ""
+
+#: mod/install.php:485
+msgid "view/smarty3 is writable"
+msgstr ""
+
+#: mod/install.php:501
+msgid ""
+"Url rewrite in .htaccess is not working. Check your server configuration."
+msgstr ""
+
+#: mod/install.php:503
+msgid "Url rewrite is working"
+msgstr ""
+
+#: mod/install.php:522
+msgid "ImageMagick PHP extension is not installed"
+msgstr ""
+
+#: mod/install.php:524
+msgid "ImageMagick PHP extension is installed"
+msgstr ""
+
+#: mod/install.php:526
+msgid "ImageMagick supports GIF"
+msgstr ""
+
+#: mod/install.php:533
+msgid ""
+"The database configuration file \".htconfig.php\" could not be written. "
+"Please use the enclosed text to create a configuration file in your web "
+"server root."
+msgstr ""
+
+#: mod/install.php:556
+msgid "<h1>What next</h1>"
+msgstr ""
+
+#: mod/install.php:557
+msgid ""
+"IMPORTANT: You will need to [manually] setup a scheduled task for the worker."
+msgstr ""
+
+#: mod/install.php:560
 #, php-format
 msgid ""
-"Warning: This group contains %s member from a network that doesn't allow non "
-"public messages."
-msgid_plural ""
-"Warning: This group contains %s members from a network that doesn't allow "
-"non public messages."
-msgstr[0] ""
-msgstr[1] ""
-
-#: mod/network.php:550
-msgid "Messages in this group won't be send to these receivers."
+"Go to your new Friendica node <a href=\"%s/register\">registration page</a> "
+"and register as new user. Remember to use the same email you have entered as "
+"administrator email. This will allow you to enter the site admin panel."
 msgstr ""
 
-#: mod/network.php:618
-msgid "No such group"
+#: mod/item.php:114
+msgid "Unable to locate original post."
 msgstr ""
 
-#: mod/network.php:643
+#: mod/item.php:274
+msgid "Empty post discarded."
+msgstr ""
+
+#: mod/item.php:799
 #, php-format
-msgid "Group: %s"
-msgstr ""
-
-#: mod/network.php:669
-msgid "Private messages to this person are at risk of public disclosure."
-msgstr ""
-
-#: mod/network.php:672
-msgid "Invalid contact."
-msgstr ""
-
-#: mod/network.php:921
-msgid "Commented Order"
-msgstr ""
-
-#: mod/network.php:924
-msgid "Sort by Comment Date"
-msgstr ""
-
-#: mod/network.php:929
-msgid "Posted Order"
-msgstr ""
-
-#: mod/network.php:932
-msgid "Sort by Post Date"
-msgstr ""
-
-#: mod/network.php:943
-msgid "Posts that mention or involve you"
-msgstr ""
-
-#: mod/network.php:951
-msgid "New"
-msgstr ""
-
-#: mod/network.php:954
-msgid "Activity Stream - by date"
-msgstr ""
-
-#: mod/network.php:962
-msgid "Shared Links"
-msgstr ""
-
-#: mod/network.php:965
-msgid "Interesting Links"
-msgstr ""
-
-#: mod/network.php:973
-msgid "Starred"
-msgstr ""
-
-#: mod/network.php:976
-msgid "Favourite Posts"
-msgstr ""
-
-#: mod/notes.php:53 src/Model/Profile.php:946
-msgid "Personal Notes"
-msgstr ""
-
-#: mod/photos.php:108 src/Model/Profile.php:907
-msgid "Photo Albums"
-msgstr ""
-
-#: mod/photos.php:109 mod/photos.php:1713
-msgid "Recent Photos"
-msgstr ""
-
-#: mod/photos.php:112 mod/photos.php:1210 mod/photos.php:1715
-msgid "Upload New Photos"
-msgstr ""
-
-#: mod/photos.php:126 mod/settings.php:49
-msgid "everybody"
-msgstr ""
-
-#: mod/photos.php:184
-msgid "Contact information unavailable"
-msgstr ""
-
-#: mod/photos.php:204
-msgid "Album not found."
-msgstr ""
-
-#: mod/photos.php:234 mod/photos.php:245 mod/photos.php:1161
-msgid "Delete Album"
-msgstr ""
-
-#: mod/photos.php:243
-msgid "Do you really want to delete this photo album and all its photos?"
-msgstr ""
-
-#: mod/photos.php:310 mod/photos.php:321 mod/photos.php:1446
-msgid "Delete Photo"
-msgstr ""
-
-#: mod/photos.php:319
-msgid "Do you really want to delete this photo?"
-msgstr ""
-
-#: mod/photos.php:667
-msgid "a photo"
-msgstr ""
-
-#: mod/photos.php:667
-#, php-format
-msgid "%1$s was tagged in %2$s by %3$s"
-msgstr ""
-
-#: mod/photos.php:769
-msgid "Image upload didn't complete, please try again"
-msgstr ""
-
-#: mod/photos.php:772
-msgid "Image file is missing"
-msgstr ""
-
-#: mod/photos.php:777
 msgid ""
-"Server can't accept new file upload at this time, please contact your "
-"administrator"
+"This message was sent to you by %s, a member of the Friendica social network."
 msgstr ""
 
-#: mod/photos.php:803
-msgid "Image file is empty."
-msgstr ""
-
-#: mod/photos.php:940
-msgid "No photos selected"
-msgstr ""
-
-#: mod/photos.php:1036 mod/videos.php:310
-msgid "Access to this item is restricted."
-msgstr ""
-
-#: mod/photos.php:1090
-msgid "Upload Photos"
-msgstr ""
-
-#: mod/photos.php:1094 mod/photos.php:1156
-msgid "New album name: "
-msgstr ""
-
-#: mod/photos.php:1095
-msgid "or existing album name: "
-msgstr ""
-
-#: mod/photos.php:1096
-msgid "Do not show a status post for this upload"
-msgstr ""
-
-#: mod/photos.php:1106 mod/photos.php:1449 mod/settings.php:1233
-msgid "Show to Groups"
-msgstr ""
-
-#: mod/photos.php:1107 mod/photos.php:1450 mod/settings.php:1234
-msgid "Show to Contacts"
-msgstr ""
-
-#: mod/photos.php:1167
-msgid "Edit Album"
-msgstr ""
-
-#: mod/photos.php:1172
-msgid "Show Newest First"
-msgstr ""
-
-#: mod/photos.php:1174
-msgid "Show Oldest First"
-msgstr ""
-
-#: mod/photos.php:1195 mod/photos.php:1698
-msgid "View Photo"
-msgstr ""
-
-#: mod/photos.php:1236
-msgid "Permission denied. Access to this item may be restricted."
-msgstr ""
-
-#: mod/photos.php:1238
-msgid "Photo not available"
-msgstr ""
-
-#: mod/photos.php:1301
-msgid "View photo"
-msgstr ""
-
-#: mod/photos.php:1301
-msgid "Edit photo"
-msgstr ""
-
-#: mod/photos.php:1302
-msgid "Use as profile photo"
-msgstr ""
-
-#: mod/photos.php:1308 src/Object/Post.php:148
-msgid "Private Message"
-msgstr ""
-
-#: mod/photos.php:1327
-msgid "View Full Size"
-msgstr ""
-
-#: mod/photos.php:1414
-msgid "Tags: "
-msgstr ""
-
-#: mod/photos.php:1417
-msgid "[Remove any tag]"
-msgstr ""
-
-#: mod/photos.php:1432
-msgid "New album name"
-msgstr ""
-
-#: mod/photos.php:1433
-msgid "Caption"
-msgstr ""
-
-#: mod/photos.php:1434
-msgid "Add a Tag"
-msgstr ""
-
-#: mod/photos.php:1434
-msgid "Example: @bob, @Barbara_Jensen, @jim@example.com, #California, #camping"
-msgstr ""
-
-#: mod/photos.php:1435
-msgid "Do not rotate"
-msgstr ""
-
-#: mod/photos.php:1436
-msgid "Rotate CW (right)"
-msgstr ""
-
-#: mod/photos.php:1437
-msgid "Rotate CCW (left)"
-msgstr ""
-
-#: mod/photos.php:1471 src/Object/Post.php:295
-msgid "I like this (toggle)"
-msgstr ""
-
-#: mod/photos.php:1472 src/Object/Post.php:296
-msgid "I don't like this (toggle)"
-msgstr ""
-
-#: mod/photos.php:1488 mod/photos.php:1527 mod/photos.php:1600
-#: src/Object/Post.php:785
-msgid "This is you"
-msgstr ""
-
-#: mod/photos.php:1490 mod/photos.php:1529 mod/photos.php:1602
-#: src/Object/Post.php:391 src/Object/Post.php:787
-msgid "Comment"
-msgstr ""
-
-#: mod/photos.php:1634
-msgid "Map"
-msgstr ""
-
-#: mod/photos.php:1704 mod/videos.php:388
-msgid "View Album"
-msgstr ""
-
-#: mod/profile.php:36 src/Model/Profile.php:118
-msgid "Requested profile is not available."
-msgstr ""
-
-#: mod/profile.php:77 src/Protocol/OStatus.php:1247
+#: mod/item.php:801
 #, php-format
-msgid "%s's posts"
+msgid "You may visit them online at %s"
 msgstr ""
 
-#: mod/profile.php:78 src/Protocol/OStatus.php:1248
+#: mod/item.php:802
+msgid ""
+"Please contact the sender by replying to this post if you do not wish to "
+"receive these messages."
+msgstr ""
+
+#: mod/item.php:806
 #, php-format
-msgid "%s's comments"
+msgid "%s posted an update."
 msgstr ""
 
-#: mod/profile.php:79 src/Protocol/OStatus.php:1246
+#: mod/oexchange.php:30
+msgid "Post successful."
+msgstr ""
+
+#: mod/ostatus_subscribe.php:21
+msgid "Subscribing to OStatus contacts"
+msgstr ""
+
+#: mod/ostatus_subscribe.php:33
+msgid "No contact provided."
+msgstr ""
+
+#: mod/ostatus_subscribe.php:40
+msgid "Couldn't fetch information for contact."
+msgstr ""
+
+#: mod/ostatus_subscribe.php:50
+msgid "Couldn't fetch friends for contact."
+msgstr ""
+
+#: mod/ostatus_subscribe.php:78
+msgid "success"
+msgstr ""
+
+#: mod/ostatus_subscribe.php:80
+msgid "failed"
+msgstr ""
+
+#: mod/ostatus_subscribe.php:83 src/Object/Post.php:279
+msgid "ignored"
+msgstr ""
+
+#: mod/profile_photo.php:55
+msgid "Image uploaded but image cropping failed."
+msgstr ""
+
+#: mod/profile_photo.php:88 mod/profile_photo.php:96 mod/profile_photo.php:104
+#: mod/profile_photo.php:315
 #, php-format
-msgid "%s's timeline"
+msgid "Image size reduction [%s] failed."
 msgstr ""
 
-#: mod/profile.php:194
-msgid "Tips for New Members"
+#: mod/profile_photo.php:125
+msgid ""
+"Shift-reload the page or clear browser cache if the new photo does not "
+"display immediately."
 msgstr ""
 
-#: mod/settings.php:71
+#: mod/profile_photo.php:134
+msgid "Unable to process image"
+msgstr ""
+
+#: mod/profile_photo.php:247
+msgid "Upload File:"
+msgstr ""
+
+#: mod/profile_photo.php:248
+msgid "Select a profile:"
+msgstr ""
+
+#: mod/profile_photo.php:253
+msgid "or"
+msgstr ""
+
+#: mod/profile_photo.php:253
+msgid "skip this step"
+msgstr ""
+
+#: mod/profile_photo.php:253
+msgid "select a photo from your photo albums"
+msgstr ""
+
+#: mod/profile_photo.php:266
+msgid "Crop Image"
+msgstr ""
+
+#: mod/profile_photo.php:267
+msgid "Please adjust the image cropping for optimum viewing."
+msgstr ""
+
+#: mod/profile_photo.php:269
+msgid "Done Editing"
+msgstr ""
+
+#: mod/profile_photo.php:305
+msgid "Image uploaded successfully."
+msgstr ""
+
+#: mod/profiles.php:57
+msgid "Profile deleted."
+msgstr ""
+
+#: mod/profiles.php:73 mod/profiles.php:109
+msgid "Profile-"
+msgstr ""
+
+#: mod/profiles.php:92 mod/profiles.php:131
+msgid "New profile created."
+msgstr ""
+
+#: mod/profiles.php:115
+msgid "Profile unavailable to clone."
+msgstr ""
+
+#: mod/profiles.php:205
+msgid "Profile Name is required."
+msgstr ""
+
+#: mod/profiles.php:346
+msgid "Marital Status"
+msgstr ""
+
+#: mod/profiles.php:350
+msgid "Romantic Partner"
+msgstr ""
+
+#: mod/profiles.php:362
+msgid "Work/Employment"
+msgstr ""
+
+#: mod/profiles.php:365
+msgid "Religion"
+msgstr ""
+
+#: mod/profiles.php:369
+msgid "Political Views"
+msgstr ""
+
+#: mod/profiles.php:373
+msgid "Gender"
+msgstr ""
+
+#: mod/profiles.php:377
+msgid "Sexual Preference"
+msgstr ""
+
+#: mod/profiles.php:381
+msgid "XMPP"
+msgstr ""
+
+#: mod/profiles.php:385
+msgid "Homepage"
+msgstr ""
+
+#: mod/profiles.php:389 mod/profiles.php:685
+msgid "Interests"
+msgstr ""
+
+#: mod/profiles.php:400 mod/profiles.php:681
+msgid "Location"
+msgstr ""
+
+#: mod/profiles.php:485
+msgid "Profile updated."
+msgstr ""
+
+#: mod/profiles.php:563
+msgid " and "
+msgstr ""
+
+#: mod/profiles.php:572
+msgid "public profile"
+msgstr ""
+
+#: mod/profiles.php:575
+#, php-format
+msgid "%1$s changed %2$s to &ldquo;%3$s&rdquo;"
+msgstr ""
+
+#: mod/profiles.php:576
+#, php-format
+msgid " - Visit %1$s's %2$s"
+msgstr ""
+
+#: mod/profiles.php:578
+#, php-format
+msgid "%1$s has an updated %2$s, changing %3$s."
+msgstr ""
+
+#: mod/profiles.php:632
+msgid "Hide contacts and friends:"
+msgstr ""
+
+#: mod/profiles.php:637
+msgid "Hide your contact/friend list from viewers of this profile?"
+msgstr ""
+
+#: mod/profiles.php:657
+msgid "Show more profile fields:"
+msgstr ""
+
+#: mod/profiles.php:669
+msgid "Profile Actions"
+msgstr ""
+
+#: mod/profiles.php:670
+msgid "Edit Profile Details"
+msgstr ""
+
+#: mod/profiles.php:672
+msgid "Change Profile Photo"
+msgstr ""
+
+#: mod/profiles.php:673
+msgid "View this profile"
+msgstr ""
+
+#: mod/profiles.php:674 mod/profiles.php:769 src/Model/Profile.php:393
+msgid "Edit visibility"
+msgstr ""
+
+#: mod/profiles.php:675
+msgid "Create a new profile using these settings"
+msgstr ""
+
+#: mod/profiles.php:676
+msgid "Clone this profile"
+msgstr ""
+
+#: mod/profiles.php:677
+msgid "Delete this profile"
+msgstr ""
+
+#: mod/profiles.php:679
+msgid "Basic information"
+msgstr ""
+
+#: mod/profiles.php:680
+msgid "Profile picture"
+msgstr ""
+
+#: mod/profiles.php:682
+msgid "Preferences"
+msgstr ""
+
+#: mod/profiles.php:683
+msgid "Status information"
+msgstr ""
+
+#: mod/profiles.php:684
+msgid "Additional information"
+msgstr ""
+
+#: mod/profiles.php:687
+msgid "Relation"
+msgstr ""
+
+#: mod/profiles.php:688 src/Util/Temporal.php:81 src/Util/Temporal.php:83
+msgid "Miscellaneous"
+msgstr ""
+
+#: mod/profiles.php:691
+msgid "Your Gender:"
+msgstr ""
+
+#: mod/profiles.php:692
+msgid "<span class=\"heart\">&hearts;</span> Marital Status:"
+msgstr ""
+
+#: mod/profiles.php:693 src/Model/Profile.php:782
+msgid "Sexual Preference:"
+msgstr ""
+
+#: mod/profiles.php:694
+msgid "Example: fishing photography software"
+msgstr ""
+
+#: mod/profiles.php:699
+msgid "Profile Name:"
+msgstr ""
+
+#: mod/profiles.php:701
+msgid ""
+"This is your <strong>public</strong> profile.<br />It <strong>may</strong> "
+"be visible to anybody using the internet."
+msgstr ""
+
+#: mod/profiles.php:702
+msgid "Your Full Name:"
+msgstr ""
+
+#: mod/profiles.php:703
+msgid "Title/Description:"
+msgstr ""
+
+#: mod/profiles.php:706
+msgid "Street Address:"
+msgstr ""
+
+#: mod/profiles.php:707
+msgid "Locality/City:"
+msgstr ""
+
+#: mod/profiles.php:708
+msgid "Region/State:"
+msgstr ""
+
+#: mod/profiles.php:709
+msgid "Postal/Zip Code:"
+msgstr ""
+
+#: mod/profiles.php:710
+msgid "Country:"
+msgstr ""
+
+#: mod/profiles.php:711 src/Util/Temporal.php:149
+msgid "Age: "
+msgstr ""
+
+#: mod/profiles.php:714
+msgid "Who: (if applicable)"
+msgstr ""
+
+#: mod/profiles.php:714
+msgid "Examples: cathy123, Cathy Williams, cathy@example.com"
+msgstr ""
+
+#: mod/profiles.php:715
+msgid "Since [date]:"
+msgstr ""
+
+#: mod/profiles.php:717
+msgid "Tell us about yourself..."
+msgstr ""
+
+#: mod/profiles.php:718
+msgid "XMPP (Jabber) address:"
+msgstr ""
+
+#: mod/profiles.php:718
+msgid ""
+"The XMPP address will be propagated to your contacts so that they can follow "
+"you."
+msgstr ""
+
+#: mod/profiles.php:719
+msgid "Homepage URL:"
+msgstr ""
+
+#: mod/profiles.php:720 src/Model/Profile.php:790
+msgid "Hometown:"
+msgstr ""
+
+#: mod/profiles.php:721 src/Model/Profile.php:798
+msgid "Political Views:"
+msgstr ""
+
+#: mod/profiles.php:722
+msgid "Religious Views:"
+msgstr ""
+
+#: mod/profiles.php:723
+msgid "Public Keywords:"
+msgstr ""
+
+#: mod/profiles.php:723
+msgid "(Used for suggesting potential friends, can be seen by others)"
+msgstr ""
+
+#: mod/profiles.php:724
+msgid "Private Keywords:"
+msgstr ""
+
+#: mod/profiles.php:724
+msgid "(Used for searching profiles, never shown to others)"
+msgstr ""
+
+#: mod/profiles.php:725 src/Model/Profile.php:814
+msgid "Likes:"
+msgstr ""
+
+#: mod/profiles.php:726 src/Model/Profile.php:818
+msgid "Dislikes:"
+msgstr ""
+
+#: mod/profiles.php:727
+msgid "Musical interests"
+msgstr ""
+
+#: mod/profiles.php:728
+msgid "Books, literature"
+msgstr ""
+
+#: mod/profiles.php:729
+msgid "Television"
+msgstr ""
+
+#: mod/profiles.php:730
+msgid "Film/dance/culture/entertainment"
+msgstr ""
+
+#: mod/profiles.php:731
+msgid "Hobbies/Interests"
+msgstr ""
+
+#: mod/profiles.php:732
+msgid "Love/romance"
+msgstr ""
+
+#: mod/profiles.php:733
+msgid "Work/employment"
+msgstr ""
+
+#: mod/profiles.php:734
+msgid "School/education"
+msgstr ""
+
+#: mod/profiles.php:735
+msgid "Contact information and Social Networks"
+msgstr ""
+
+#: mod/profiles.php:766 src/Model/Profile.php:389
+msgid "Profile Image"
+msgstr ""
+
+#: mod/profiles.php:768 src/Model/Profile.php:392
+msgid "visible to everybody"
+msgstr ""
+
+#: mod/profiles.php:775
+msgid "Edit/Manage Profiles"
+msgstr ""
+
+#: mod/profiles.php:776 src/Model/Profile.php:379 src/Model/Profile.php:401
+msgid "Change profile photo"
+msgstr ""
+
+#: mod/profiles.php:777 src/Model/Profile.php:380
+msgid "Create New Profile"
+msgstr ""
+
+#: mod/settings.php:73
 msgid "Display"
 msgstr ""
 
-#: mod/settings.php:78 mod/settings.php:845
+#: mod/settings.php:80 mod/settings.php:841
 msgid "Social Networks"
 msgstr ""
 
-#: mod/settings.php:92 src/Content/Nav.php:204
+#: mod/settings.php:94 src/Content/Nav.php:204
 msgid "Delegations"
 msgstr ""
 
-#: mod/settings.php:99
+#: mod/settings.php:101
 msgid "Connected apps"
 msgstr ""
 
-#: mod/settings.php:113
+#: mod/settings.php:115
 msgid "Remove account"
 msgstr ""
 
-#: mod/settings.php:167
+#: mod/settings.php:169
 msgid "Missing some important data!"
 msgstr ""
 
-#: mod/settings.php:278
+#: mod/settings.php:279
 msgid "Failed to connect with email account using the settings provided."
 msgstr ""
 
-#: mod/settings.php:283
+#: mod/settings.php:284
 msgid "Email settings updated."
 msgstr ""
 
-#: mod/settings.php:299
+#: mod/settings.php:300
 msgid "Features updated"
 msgstr ""
 
-#: mod/settings.php:371
+#: mod/settings.php:372
 msgid "Relocate message has been send to your contacts"
 msgstr ""
 
-#: mod/settings.php:383 src/Model/User.php:312
+#: mod/settings.php:384 src/Model/User.php:325
 msgid "Passwords do not match. Password unchanged."
 msgstr ""
 
-#: mod/settings.php:388
+#: mod/settings.php:389
 msgid "Empty passwords are not allowed. Password unchanged."
 msgstr ""
 
 #: mod/settings.php:394
+msgid ""
+"The new password has been exposed in a public data dump, please choose "
+"another."
+msgstr ""
+
+#: mod/settings.php:400
 msgid "Wrong password."
 msgstr ""
 
-#: mod/settings.php:401
+#: mod/settings.php:407
 msgid "Password changed."
 msgstr ""
 
-#: mod/settings.php:403
+#: mod/settings.php:409
 msgid "Password update failed. Please try again."
 msgstr ""
 
-#: mod/settings.php:493
+#: mod/settings.php:496
 msgid " Please use a shorter name."
 msgstr ""
 
-#: mod/settings.php:496
+#: mod/settings.php:499
 msgid " Name too short."
 msgstr ""
 
-#: mod/settings.php:504
+#: mod/settings.php:507
 msgid "Wrong Password"
 msgstr ""
 
-#: mod/settings.php:509
+#: mod/settings.php:512
 msgid "Invalid email."
 msgstr ""
 
-#: mod/settings.php:516
+#: mod/settings.php:519
 msgid "Cannot change to that email."
 msgstr ""
 
-#: mod/settings.php:569
+#: mod/settings.php:572
 msgid "Private forum has no privacy permissions. Using default privacy group."
 msgstr ""
 
-#: mod/settings.php:572
+#: mod/settings.php:575
 msgid "Private forum has no privacy permissions and no default privacy group."
 msgstr ""
 
-#: mod/settings.php:612
+#: mod/settings.php:615
 msgid "Settings updated."
 msgstr ""
 
-#: mod/settings.php:678 mod/settings.php:704 mod/settings.php:740
+#: mod/settings.php:674 mod/settings.php:700 mod/settings.php:736
 msgid "Add application"
 msgstr ""
 
-#: mod/settings.php:682 mod/settings.php:708
+#: mod/settings.php:678 mod/settings.php:704
 msgid "Consumer Key"
 msgstr ""
 
-#: mod/settings.php:683 mod/settings.php:709
+#: mod/settings.php:679 mod/settings.php:705
 msgid "Consumer Secret"
 msgstr ""
 
-#: mod/settings.php:684 mod/settings.php:710
+#: mod/settings.php:680 mod/settings.php:706
 msgid "Redirect"
 msgstr ""
 
-#: mod/settings.php:685 mod/settings.php:711
+#: mod/settings.php:681 mod/settings.php:707
 msgid "Icon url"
 msgstr ""
 
-#: mod/settings.php:696
+#: mod/settings.php:692
 msgid "You can't edit this application."
 msgstr ""
 
-#: mod/settings.php:739
+#: mod/settings.php:735
 msgid "Connected Apps"
 msgstr ""
 
-#: mod/settings.php:741 src/Object/Post.php:154 src/Object/Post.php:156
+#: mod/settings.php:737 src/Object/Post.php:155 src/Object/Post.php:157
 msgid "Edit"
 msgstr ""
 
-#: mod/settings.php:743
+#: mod/settings.php:739
 msgid "Client key starts with"
 msgstr ""
 
-#: mod/settings.php:744
+#: mod/settings.php:740
 msgid "No name"
 msgstr ""
 
-#: mod/settings.php:745
+#: mod/settings.php:741
 msgid "Remove authorization"
 msgstr ""
 
-#: mod/settings.php:756
+#: mod/settings.php:752
 msgid "No Addon settings configured"
 msgstr ""
 
-#: mod/settings.php:765
+#: mod/settings.php:761
 msgid "Addon Settings"
 msgstr ""
 
-#: mod/settings.php:786
+#: mod/settings.php:782
 msgid "Additional Features"
 msgstr ""
 
-#: mod/settings.php:808 src/Content/ContactSelector.php:83
+#: mod/settings.php:804 src/Content/ContactSelector.php:83
 msgid "Diaspora"
 msgstr ""
 
-#: mod/settings.php:808 mod/settings.php:809
+#: mod/settings.php:804 mod/settings.php:805
 msgid "enabled"
 msgstr ""
 
-#: mod/settings.php:808 mod/settings.php:809
+#: mod/settings.php:804 mod/settings.php:805
 msgid "disabled"
 msgstr ""
 
-#: mod/settings.php:808 mod/settings.php:809
+#: mod/settings.php:804 mod/settings.php:805
 #, php-format
 msgid "Built-in support for %s connectivity is %s"
 msgstr ""
 
-#: mod/settings.php:809
+#: mod/settings.php:805
 msgid "GNU Social (OStatus)"
 msgstr ""
 
-#: mod/settings.php:840
+#: mod/settings.php:836
 msgid "Email access is disabled on this site."
 msgstr ""
 
-#: mod/settings.php:850
+#: mod/settings.php:846
 msgid "General Social Media Settings"
 msgstr ""
 
-#: mod/settings.php:851
+#: mod/settings.php:847
 msgid "Disable intelligent shortening"
 msgstr ""
 
-#: mod/settings.php:851
+#: mod/settings.php:847
 msgid ""
 "Normally the system tries to find the best link to add to shortened posts. "
 "If this option is enabled then every shortened post will always point to the "
 "original friendica post."
 msgstr ""
 
-#: mod/settings.php:852
+#: mod/settings.php:848
 msgid "Automatically follow any GNU Social (OStatus) followers/mentioners"
 msgstr ""
 
-#: mod/settings.php:852
+#: mod/settings.php:848
 msgid ""
 "If you receive a message from an unknown OStatus user, this option decides "
 "what to do. If it is checked, a new contact will be created for every "
 "unknown user."
 msgstr ""
 
-#: mod/settings.php:853
+#: mod/settings.php:849
 msgid "Default group for OStatus contacts"
 msgstr ""
 
-#: mod/settings.php:854
+#: mod/settings.php:850
 msgid "Your legacy GNU Social account"
 msgstr ""
 
-#: mod/settings.php:854
+#: mod/settings.php:850
 msgid ""
 "If you enter your old GNU Social/Statusnet account name here (in the format "
 "user@domain.tld), your contacts will be added automatically. The field will "
 "be emptied when done."
 msgstr ""
 
-#: mod/settings.php:857
+#: mod/settings.php:853
 msgid "Repair OStatus subscriptions"
 msgstr ""
 
-#: mod/settings.php:861
+#: mod/settings.php:857
 msgid "Email/Mailbox Setup"
 msgstr ""
 
-#: mod/settings.php:862
+#: mod/settings.php:858
 msgid ""
 "If you wish to communicate with email contacts using this service "
 "(optional), please specify how to connect to your mailbox."
 msgstr ""
 
-#: mod/settings.php:863
+#: mod/settings.php:859
 msgid "Last successful email check:"
 msgstr ""
 
-#: mod/settings.php:865
+#: mod/settings.php:861
 msgid "IMAP server name:"
 msgstr ""
 
-#: mod/settings.php:866
+#: mod/settings.php:862
 msgid "IMAP port:"
 msgstr ""
 
-#: mod/settings.php:867
+#: mod/settings.php:863
 msgid "Security:"
 msgstr ""
 
-#: mod/settings.php:867 mod/settings.php:872
+#: mod/settings.php:863 mod/settings.php:868
 msgid "None"
 msgstr ""
 
-#: mod/settings.php:868
+#: mod/settings.php:864
 msgid "Email login name:"
 msgstr ""
 
-#: mod/settings.php:869
+#: mod/settings.php:865
 msgid "Email password:"
 msgstr ""
 
-#: mod/settings.php:870
+#: mod/settings.php:866
 msgid "Reply-to address:"
 msgstr ""
 
-#: mod/settings.php:871
+#: mod/settings.php:867
 msgid "Send public posts to all email contacts:"
 msgstr ""
 
-#: mod/settings.php:872
+#: mod/settings.php:868
 msgid "Action after import:"
 msgstr ""
 
-#: mod/settings.php:872 src/Content/Nav.php:191
+#: mod/settings.php:868 src/Content/Nav.php:191
 msgid "Mark as seen"
 msgstr ""
 
-#: mod/settings.php:872
+#: mod/settings.php:868
 msgid "Move to folder"
 msgstr ""
 
-#: mod/settings.php:873
+#: mod/settings.php:869
 msgid "Move to folder:"
 msgstr ""
 
-#: mod/settings.php:916
+#: mod/settings.php:912
 #, php-format
 msgid "%s - (Unsupported)"
 msgstr ""
 
-#: mod/settings.php:918
+#: mod/settings.php:914
 #, php-format
 msgid "%s - (Experimental)"
 msgstr ""
 
-#: mod/settings.php:961
+#: mod/settings.php:957
 msgid "Display Settings"
 msgstr ""
 
-#: mod/settings.php:967 mod/settings.php:991
+#: mod/settings.php:963 mod/settings.php:987
 msgid "Display Theme:"
 msgstr ""
 
-#: mod/settings.php:968
+#: mod/settings.php:964
 msgid "Mobile Theme:"
 msgstr ""
 
-#: mod/settings.php:969
+#: mod/settings.php:965
 msgid "Suppress warning of insecure networks"
 msgstr ""
 
-#: mod/settings.php:969
+#: mod/settings.php:965
 msgid ""
 "Should the system suppress the warning that the current group contains "
 "members of networks that can't receive non public postings."
 msgstr ""
 
-#: mod/settings.php:970
+#: mod/settings.php:966
 msgid "Update browser every xx seconds"
 msgstr ""
 
-#: mod/settings.php:970
+#: mod/settings.php:966
 msgid "Minimum of 10 seconds. Enter -1 to disable it."
 msgstr ""
 
-#: mod/settings.php:971
+#: mod/settings.php:967
 msgid "Number of items to display per page:"
 msgstr ""
 
-#: mod/settings.php:971 mod/settings.php:972
+#: mod/settings.php:967 mod/settings.php:968
 msgid "Maximum of 100 items"
 msgstr ""
 
-#: mod/settings.php:972
+#: mod/settings.php:968
 msgid "Number of items to display per page when viewed from mobile device:"
 msgstr ""
 
-#: mod/settings.php:973
+#: mod/settings.php:969
 msgid "Don't show emoticons"
 msgstr ""
 
-#: mod/settings.php:974
+#: mod/settings.php:970
 msgid "Calendar"
 msgstr ""
 
-#: mod/settings.php:975
+#: mod/settings.php:971
 msgid "Beginning of week:"
 msgstr ""
 
-#: mod/settings.php:976
+#: mod/settings.php:972
 msgid "Don't show notices"
 msgstr ""
 
-#: mod/settings.php:977
+#: mod/settings.php:973
 msgid "Infinite scroll"
 msgstr ""
 
-#: mod/settings.php:978
+#: mod/settings.php:974
 msgid "Automatic updates only at the top of the network page"
 msgstr ""
 
-#: mod/settings.php:978
+#: mod/settings.php:974
 msgid ""
 "When disabled, the network page is updated all the time, which could be "
 "confusing while reading."
 msgstr ""
 
-#: mod/settings.php:979
+#: mod/settings.php:975
 msgid "Bandwith Saver Mode"
 msgstr ""
 
-#: mod/settings.php:979
+#: mod/settings.php:975
 msgid ""
 "When enabled, embedded content is not displayed on automatic updates, they "
 "only show on page reload."
 msgstr ""
 
-#: mod/settings.php:980
+#: mod/settings.php:976
 msgid "Smart Threading"
 msgstr ""
 
-#: mod/settings.php:980
+#: mod/settings.php:976
 msgid ""
 "When enabled, suppress extraneous thread indentation while keeping it where "
 "it matters. Only works if threading is available and enabled."
 msgstr ""
 
-#: mod/settings.php:982
+#: mod/settings.php:978
 msgid "General Theme Settings"
 msgstr ""
 
-#: mod/settings.php:983
+#: mod/settings.php:979
 msgid "Custom Theme Settings"
 msgstr ""
 
-#: mod/settings.php:984
+#: mod/settings.php:980
 msgid "Content Settings"
 msgstr ""
 
-#: mod/settings.php:985 view/theme/duepuntozero/config.php:73
+#: mod/settings.php:981 view/theme/duepuntozero/config.php:73
 #: view/theme/frio/config.php:115 view/theme/quattro/config.php:75
 #: view/theme/vier/config.php:121
 msgid "Theme settings"
 msgstr ""
 
-#: mod/settings.php:1006
+#: mod/settings.php:1000
 msgid "Unable to find your profile. Please contact your admin."
 msgstr ""
 
-#: mod/settings.php:1048
+#: mod/settings.php:1042
 msgid "Account Types"
 msgstr ""
 
-#: mod/settings.php:1049
+#: mod/settings.php:1043
 msgid "Personal Page Subtypes"
 msgstr ""
 
-#: mod/settings.php:1050
+#: mod/settings.php:1044
 msgid "Community Forum Subtypes"
 msgstr ""
 
-#: mod/settings.php:1057
+#: mod/settings.php:1051
 msgid "Personal Page"
 msgstr ""
 
-#: mod/settings.php:1058
+#: mod/settings.php:1052
 msgid "Account for a personal profile."
 msgstr ""
 
-#: mod/settings.php:1061
+#: mod/settings.php:1055
 msgid "Organisation Page"
 msgstr ""
 
-#: mod/settings.php:1062
+#: mod/settings.php:1056
 msgid ""
 "Account for an organisation that automatically approves contact requests as "
 "\"Followers\"."
 msgstr ""
 
-#: mod/settings.php:1065
+#: mod/settings.php:1059
 msgid "News Page"
 msgstr ""
 
-#: mod/settings.php:1066
+#: mod/settings.php:1060
 msgid ""
 "Account for a news reflector that automatically approves contact requests as "
 "\"Followers\"."
 msgstr ""
 
-#: mod/settings.php:1069
+#: mod/settings.php:1063
 msgid "Community Forum"
 msgstr ""
 
-#: mod/settings.php:1070
+#: mod/settings.php:1064
 msgid "Account for community discussions."
 msgstr ""
 
-#: mod/settings.php:1073
+#: mod/settings.php:1067
 msgid "Normal Account Page"
 msgstr ""
 
-#: mod/settings.php:1074
+#: mod/settings.php:1068
 msgid ""
 "Account for a regular personal profile that requires manual approval of "
 "\"Friends\" and \"Followers\"."
 msgstr ""
 
-#: mod/settings.php:1077
+#: mod/settings.php:1071
 msgid "Soapbox Page"
 msgstr ""
 
-#: mod/settings.php:1078
+#: mod/settings.php:1072
 msgid ""
 "Account for a public profile that automatically approves contact requests as "
 "\"Followers\"."
 msgstr ""
 
-#: mod/settings.php:1081
+#: mod/settings.php:1075
 msgid "Public Forum"
 msgstr ""
 
-#: mod/settings.php:1082
+#: mod/settings.php:1076
 msgid "Automatically approves all contact requests."
 msgstr ""
 
-#: mod/settings.php:1085
+#: mod/settings.php:1079
 msgid "Automatic Friend Page"
 msgstr ""
 
-#: mod/settings.php:1086
+#: mod/settings.php:1080
 msgid ""
 "Account for a popular profile that automatically approves contact requests "
 "as \"Friends\"."
 msgstr ""
 
-#: mod/settings.php:1089
+#: mod/settings.php:1083
 msgid "Private Forum [Experimental]"
 msgstr ""
 
-#: mod/settings.php:1090
+#: mod/settings.php:1084
 msgid "Requires manual approval of contact requests."
 msgstr ""
 
-#: mod/settings.php:1101
+#: mod/settings.php:1095
 msgid "OpenID:"
 msgstr ""
 
-#: mod/settings.php:1101
+#: mod/settings.php:1095
 msgid "(Optional) Allow this OpenID to login to this account."
 msgstr ""
 
-#: mod/settings.php:1109
+#: mod/settings.php:1103
 msgid "Publish your default profile in your local site directory?"
 msgstr ""
 
-#: mod/settings.php:1109
+#: mod/settings.php:1103
 #, php-format
 msgid ""
 "Your profile will be published in the global friendica directories (e.g. <a "
 "href=\"%s\">%s</a>). Your profile will be visible in public."
 msgstr ""
 
-#: mod/settings.php:1115
+#: mod/settings.php:1109
 msgid "Publish your default profile in the global social directory?"
 msgstr ""
 
-#: mod/settings.php:1115
+#: mod/settings.php:1109
 #, php-format
 msgid ""
 "Your profile will be published in this node's <a href=\"%s\">local "
@@ -7125,328 +7162,324 @@ msgid ""
 "system settings."
 msgstr ""
 
-#: mod/settings.php:1122
+#: mod/settings.php:1116
 msgid "Hide your contact/friend list from viewers of your default profile?"
 msgstr ""
 
-#: mod/settings.php:1122
+#: mod/settings.php:1116
 msgid ""
 "Your contact list won't be shown in your default profile page. You can "
 "decide to show your contact list separately for each additional profile you "
 "create"
 msgstr ""
 
-#: mod/settings.php:1126
+#: mod/settings.php:1120
 msgid "Hide your profile details from anonymous viewers?"
 msgstr ""
 
-#: mod/settings.php:1126
+#: mod/settings.php:1120
 msgid ""
 "Anonymous visitors will only see your profile picture, your display name and "
 "the nickname you are using on your profile page. Disables posting public "
 "messages to Diaspora and other networks."
 msgstr ""
 
-#: mod/settings.php:1130
+#: mod/settings.php:1124
 msgid "Allow friends to post to your profile page?"
 msgstr ""
 
-#: mod/settings.php:1130
+#: mod/settings.php:1124
 msgid ""
 "Your contacts may write posts on your profile wall. These posts will be "
 "distributed to your contacts"
 msgstr ""
 
-#: mod/settings.php:1134
+#: mod/settings.php:1128
 msgid "Allow friends to tag your posts?"
 msgstr ""
 
-#: mod/settings.php:1134
+#: mod/settings.php:1128
 msgid "Your contacts can add additional tags to your posts."
 msgstr ""
 
-#: mod/settings.php:1138
+#: mod/settings.php:1132
 msgid "Allow us to suggest you as a potential friend to new members?"
 msgstr ""
 
-#: mod/settings.php:1138
+#: mod/settings.php:1132
 msgid "If you like, Friendica may suggest new members to add you as a contact."
 msgstr ""
 
-#: mod/settings.php:1142
+#: mod/settings.php:1136
 msgid "Permit unknown people to send you private mail?"
 msgstr ""
 
-#: mod/settings.php:1142
+#: mod/settings.php:1136
 msgid ""
 "Friendica network users may send you private messages even if they are not "
 "in your contact list."
 msgstr ""
 
-#: mod/settings.php:1146
+#: mod/settings.php:1140
 msgid "Profile is <strong>not published</strong>."
 msgstr ""
 
-#: mod/settings.php:1152
+#: mod/settings.php:1146
 #, php-format
 msgid "Your Identity Address is <strong>'%s'</strong> or '%s'."
 msgstr ""
 
-#: mod/settings.php:1159
+#: mod/settings.php:1153
 msgid "Automatically expire posts after this many days:"
 msgstr ""
 
-#: mod/settings.php:1159
+#: mod/settings.php:1153
 msgid "If empty, posts will not expire. Expired posts will be deleted"
 msgstr ""
 
-#: mod/settings.php:1160
+#: mod/settings.php:1154
 msgid "Advanced expiration settings"
 msgstr ""
 
-#: mod/settings.php:1161
+#: mod/settings.php:1155
 msgid "Advanced Expiration"
 msgstr ""
 
-#: mod/settings.php:1162
+#: mod/settings.php:1156
 msgid "Expire posts:"
 msgstr ""
 
-#: mod/settings.php:1163
+#: mod/settings.php:1157
 msgid "Expire personal notes:"
 msgstr ""
 
-#: mod/settings.php:1164
+#: mod/settings.php:1158
 msgid "Expire starred posts:"
 msgstr ""
 
-#: mod/settings.php:1165
+#: mod/settings.php:1159
 msgid "Expire photos:"
 msgstr ""
 
-#: mod/settings.php:1166
+#: mod/settings.php:1160
 msgid "Only expire posts by others:"
 msgstr ""
 
-#: mod/settings.php:1196
+#: mod/settings.php:1190
 msgid "Account Settings"
 msgstr ""
 
-#: mod/settings.php:1204
+#: mod/settings.php:1198
 msgid "Password Settings"
 msgstr ""
 
-#: mod/settings.php:1206
+#: mod/settings.php:1200
 msgid "Leave password fields blank unless changing"
 msgstr ""
 
-#: mod/settings.php:1207
+#: mod/settings.php:1201
 msgid "Current Password:"
 msgstr ""
 
-#: mod/settings.php:1207 mod/settings.php:1208
+#: mod/settings.php:1201 mod/settings.php:1202
 msgid "Your current password to confirm the changes"
 msgstr ""
 
-#: mod/settings.php:1208
+#: mod/settings.php:1202
 msgid "Password:"
 msgstr ""
 
-#: mod/settings.php:1212
+#: mod/settings.php:1206
 msgid "Basic Settings"
 msgstr ""
 
-#: mod/settings.php:1213 src/Model/Profile.php:738
+#: mod/settings.php:1207 src/Model/Profile.php:738
 msgid "Full Name:"
 msgstr ""
 
-#: mod/settings.php:1214
+#: mod/settings.php:1208
 msgid "Email Address:"
 msgstr ""
 
-#: mod/settings.php:1215
+#: mod/settings.php:1209
 msgid "Your Timezone:"
 msgstr ""
 
-#: mod/settings.php:1216
+#: mod/settings.php:1210
 msgid "Your Language:"
 msgstr ""
 
-#: mod/settings.php:1216
+#: mod/settings.php:1210
 msgid ""
 "Set the language we use to show you friendica interface and to send you "
 "emails"
 msgstr ""
 
-#: mod/settings.php:1217
+#: mod/settings.php:1211
 msgid "Default Post Location:"
 msgstr ""
 
-#: mod/settings.php:1218
+#: mod/settings.php:1212
 msgid "Use Browser Location:"
 msgstr ""
 
-#: mod/settings.php:1221
+#: mod/settings.php:1215
 msgid "Security and Privacy Settings"
 msgstr ""
 
-#: mod/settings.php:1223
+#: mod/settings.php:1217
 msgid "Maximum Friend Requests/Day:"
 msgstr ""
 
-#: mod/settings.php:1223 mod/settings.php:1252
+#: mod/settings.php:1217 mod/settings.php:1246
 msgid "(to prevent spam abuse)"
 msgstr ""
 
-#: mod/settings.php:1224
+#: mod/settings.php:1218
 msgid "Default Post Permissions"
 msgstr ""
 
-#: mod/settings.php:1225
+#: mod/settings.php:1219
 msgid "(click to open/close)"
 msgstr ""
 
-#: mod/settings.php:1235
+#: mod/settings.php:1229
 msgid "Default Private Post"
 msgstr ""
 
-#: mod/settings.php:1236
+#: mod/settings.php:1230
 msgid "Default Public Post"
 msgstr ""
 
-#: mod/settings.php:1240
+#: mod/settings.php:1234
 msgid "Default Permissions for New Posts"
 msgstr ""
 
-#: mod/settings.php:1252
+#: mod/settings.php:1246
 msgid "Maximum private messages per day from unknown people:"
 msgstr ""
 
-#: mod/settings.php:1255
+#: mod/settings.php:1249
 msgid "Notification Settings"
 msgstr ""
 
-#: mod/settings.php:1256
+#: mod/settings.php:1250
 msgid "By default post a status message when:"
 msgstr ""
 
-#: mod/settings.php:1257
+#: mod/settings.php:1251
 msgid "accepting a friend request"
 msgstr ""
 
-#: mod/settings.php:1258
+#: mod/settings.php:1252
 msgid "joining a forum/community"
 msgstr ""
 
-#: mod/settings.php:1259
+#: mod/settings.php:1253
 msgid "making an <em>interesting</em> profile change"
 msgstr ""
 
-#: mod/settings.php:1260
+#: mod/settings.php:1254
 msgid "Send a notification email when:"
 msgstr ""
 
-#: mod/settings.php:1261
+#: mod/settings.php:1255
 msgid "You receive an introduction"
 msgstr ""
 
-#: mod/settings.php:1262
+#: mod/settings.php:1256
 msgid "Your introductions are confirmed"
 msgstr ""
 
-#: mod/settings.php:1263
+#: mod/settings.php:1257
 msgid "Someone writes on your profile wall"
 msgstr ""
 
-#: mod/settings.php:1264
+#: mod/settings.php:1258
 msgid "Someone writes a followup comment"
 msgstr ""
 
-#: mod/settings.php:1265
+#: mod/settings.php:1259
 msgid "You receive a private message"
 msgstr ""
 
-#: mod/settings.php:1266
+#: mod/settings.php:1260
 msgid "You receive a friend suggestion"
 msgstr ""
 
-#: mod/settings.php:1267
+#: mod/settings.php:1261
 msgid "You are tagged in a post"
 msgstr ""
 
-#: mod/settings.php:1268
+#: mod/settings.php:1262
 msgid "You are poked/prodded/etc. in a post"
 msgstr ""
 
-#: mod/settings.php:1270
+#: mod/settings.php:1264
 msgid "Activate desktop notifications"
 msgstr ""
 
-#: mod/settings.php:1270
+#: mod/settings.php:1264
 msgid "Show desktop popup on new notifications"
 msgstr ""
 
-#: mod/settings.php:1272
+#: mod/settings.php:1266
 msgid "Text-only notification emails"
 msgstr ""
 
-#: mod/settings.php:1274
+#: mod/settings.php:1268
 msgid "Send text only notification emails, without the html part"
 msgstr ""
 
-#: mod/settings.php:1276
+#: mod/settings.php:1270
 msgid "Show detailled notifications"
 msgstr ""
 
-#: mod/settings.php:1278
+#: mod/settings.php:1272
 msgid ""
-"Per default the notificiation are condensed to a single notification per "
-"item. When enabled, every notification is displayed."
+"Per default, notifications are condensed to a single notification per item. "
+"When enabled every notification is displayed."
 msgstr ""
 
-#: mod/settings.php:1280
+#: mod/settings.php:1274
 msgid "Advanced Account/Page Type Settings"
 msgstr ""
 
-#: mod/settings.php:1281
+#: mod/settings.php:1275
 msgid "Change the behaviour of this account for special situations"
 msgstr ""
 
-#: mod/settings.php:1284
+#: mod/settings.php:1278
 msgid "Relocate"
 msgstr ""
 
-#: mod/settings.php:1285
+#: mod/settings.php:1279
 msgid ""
 "If you have moved this profile from another server, and some of your "
 "contacts don't receive your updates, try pushing this button."
 msgstr ""
 
-#: mod/settings.php:1286
+#: mod/settings.php:1280
 msgid "Resend relocate message to contacts"
 msgstr ""
 
-#: mod/videos.php:140
-msgid "Do you really want to delete this video?"
+#: mod/unfollow.php:34
+msgid "Contact wasn't found or can't be unfollowed."
 msgstr ""
 
-#: mod/videos.php:145
-msgid "Delete Video"
+#: mod/unfollow.php:47
+msgid "Contact unfollowed"
 msgstr ""
 
-#: mod/videos.php:208
-msgid "No videos selected"
+#: mod/unfollow.php:73
+msgid "You aren't a friend of this contact."
 msgstr ""
 
-#: mod/videos.php:397
-msgid "Recent Videos"
+#: mod/unfollow.php:79
+msgid "Unfollowing is currently not supported by your network."
 msgstr ""
 
-#: mod/videos.php:399
-msgid "Upload New Videos"
-msgstr ""
-
-#: view/theme/duepuntozero/config.php:54 src/Model/User.php:475
+#: view/theme/duepuntozero/config.php:54 src/Model/User.php:488
 msgid "default"
 msgstr ""
 
@@ -7654,6 +7687,14 @@ msgstr ""
 msgid "Comma separated list of helper forums"
 msgstr ""
 
+#: view/theme/vier/config.php:115 src/Core/ACL.php:309
+msgid "don't show"
+msgstr ""
+
+#: view/theme/vier/config.php:115 src/Core/ACL.php:308
+msgid "show"
+msgstr ""
+
 #: view/theme/vier/config.php:122
 msgid "Set style"
 msgstr ""
@@ -7700,6 +7741,59 @@ msgstr ""
 
 #: view/theme/vier/theme.php:292
 msgid "Quick Start"
+msgstr ""
+
+#: src/Core/UserImport.php:104
+msgid "Error decoding account file"
+msgstr ""
+
+#: src/Core/UserImport.php:110
+msgid "Error! No version data in file! This is not a Friendica account file?"
+msgstr ""
+
+#: src/Core/UserImport.php:118
+#, php-format
+msgid "User '%s' already exists on this server!"
+msgstr ""
+
+#: src/Core/UserImport.php:151
+msgid "User creation error"
+msgstr ""
+
+#: src/Core/UserImport.php:169
+msgid "User profile creation error"
+msgstr ""
+
+#: src/Core/UserImport.php:213
+#, php-format
+msgid "%d contact not imported"
+msgid_plural "%d contacts not imported"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/Core/UserImport.php:278
+msgid "Done. You can now login with your username and password"
+msgstr ""
+
+#: src/Core/ACL.php:295
+msgid "Post to Email"
+msgstr ""
+
+#: src/Core/ACL.php:301
+msgid "Hide your profile details from unknown viewers?"
+msgstr ""
+
+#: src/Core/ACL.php:300
+#, php-format
+msgid "Connectors disabled, since \"%s\" is enabled."
+msgstr ""
+
+#: src/Core/ACL.php:307
+msgid "Visible to everybody"
+msgstr ""
+
+#: src/Core/ACL.php:319
+msgid "Close"
 msgstr ""
 
 #: src/Core/NotificationsManager.php:171
@@ -7755,48 +7849,16 @@ msgstr ""
 msgid "%s is now friends with %s"
 msgstr ""
 
-#: src/Core/NotificationsManager.php:813
+#: src/Core/NotificationsManager.php:825
 msgid "Friend Suggestion"
 msgstr ""
 
-#: src/Core/NotificationsManager.php:839
+#: src/Core/NotificationsManager.php:851
 msgid "Friend/Connect Request"
 msgstr ""
 
-#: src/Core/NotificationsManager.php:839
+#: src/Core/NotificationsManager.php:851
 msgid "New Follower"
-msgstr ""
-
-#: src/Core/UserImport.php:104
-msgid "Error decoding account file"
-msgstr ""
-
-#: src/Core/UserImport.php:110
-msgid "Error! No version data in file! This is not a Friendica account file?"
-msgstr ""
-
-#: src/Core/UserImport.php:118
-#, php-format
-msgid "User '%s' already exists on this server!"
-msgstr ""
-
-#: src/Core/UserImport.php:151
-msgid "User creation error"
-msgstr ""
-
-#: src/Core/UserImport.php:169
-msgid "User profile creation error"
-msgstr ""
-
-#: src/Core/UserImport.php:213
-#, php-format
-msgid "%d contact not imported"
-msgid_plural "%d contacts not imported"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/Core/UserImport.php:278
-msgid "Done. You can now login with your username and password"
 msgstr ""
 
 #: src/Util/Temporal.php:147 src/Model/Profile.php:758
@@ -7864,33 +7926,33 @@ msgstr ""
 msgid "%1$d %2$s ago"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:547
+#: src/Content/Text/BBCode.php:552
 msgid "view full size"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:1000 src/Content/Text/BBCode.php:1761
-#: src/Content/Text/BBCode.php:1762
+#: src/Content/Text/BBCode.php:978 src/Content/Text/BBCode.php:1735
+#: src/Content/Text/BBCode.php:1736
 msgid "Image/photo"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:1138
+#: src/Content/Text/BBCode.php:1116
 #, php-format
 msgid "<a href=\"%1$s\" target=\"_blank\">%2$s</a> %3$s"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:1696 src/Content/Text/BBCode.php:1718
+#: src/Content/Text/BBCode.php:1670 src/Content/Text/BBCode.php:1692
 msgid "$1 wrote:"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:1770 src/Content/Text/BBCode.php:1771
+#: src/Content/Text/BBCode.php:1744 src/Content/Text/BBCode.php:1745
 msgid "Encrypted content"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:1888
+#: src/Content/Text/BBCode.php:1862
 msgid "Invalid source protocol"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:1899
+#: src/Content/Text/BBCode.php:1873
 msgid "Invalid link protocol"
 msgstr ""
 
@@ -8114,7 +8176,7 @@ msgstr ""
 msgid "Sex Addict"
 msgstr ""
 
-#: src/Content/ContactSelector.php:169 src/Model/User.php:492
+#: src/Content/ContactSelector.php:169 src/Model/User.php:505
 msgid "Friends"
 msgstr ""
 
@@ -8541,6 +8603,18 @@ msgstr ""
 msgid "Embedded content"
 msgstr ""
 
+#: src/Content/Widget/CalendarExport.php:61
+msgid "Export"
+msgstr ""
+
+#: src/Content/Widget/CalendarExport.php:62
+msgid "Export calendar as ical"
+msgstr ""
+
+#: src/Content/Widget/CalendarExport.php:63
+msgid "Export calendar as csv"
+msgstr ""
+
 #: src/Content/Widget.php:33
 msgid "Add New Contact"
 msgstr ""
@@ -8638,32 +8712,17 @@ msgstr ""
 msgid "Errors encountered performing database changes: "
 msgstr ""
 
-#: src/Database/DBStructure.php:209
+#: src/Database/DBStructure.php:210
 msgid ": Database update"
 msgstr ""
 
-#: src/Database/DBStructure.php:458
+#: src/Database/DBStructure.php:460
 #, php-format
 msgid "%s: updating %s table."
 msgstr ""
 
 #: src/Model/Mail.php:40 src/Model/Mail.php:174
 msgid "[no subject]"
-msgstr ""
-
-#: src/Model/Item.php:1666
-#, php-format
-msgid "%1$s is attending %2$s's %3$s"
-msgstr ""
-
-#: src/Model/Item.php:1671
-#, php-format
-msgid "%1$s is not attending %2$s's %3$s"
-msgstr ""
-
-#: src/Model/Item.php:1676
-#, php-format
-msgid "%1$s may attend %2$s's %3$s"
 msgstr ""
 
 #: src/Model/Profile.php:97
@@ -8784,87 +8843,145 @@ msgstr ""
 msgid "Only You Can See This"
 msgstr ""
 
-#: src/Model/Contact.php:559
+#: src/Model/Contact.php:645
 msgid "Drop Contact"
 msgstr ""
 
-#: src/Model/Contact.php:962
+#: src/Model/Contact.php:1048
 msgid "Organisation"
 msgstr ""
 
-#: src/Model/Contact.php:965
+#: src/Model/Contact.php:1051
 msgid "News"
 msgstr ""
 
-#: src/Model/Contact.php:968
+#: src/Model/Contact.php:1054
 msgid "Forum"
 msgstr ""
 
-#: src/Model/Contact.php:1147
+#: src/Model/Contact.php:1233
 msgid "Connect URL missing."
 msgstr ""
 
-#: src/Model/Contact.php:1156
+#: src/Model/Contact.php:1242
 msgid ""
 "The contact could not be added. Please check the relevant network "
 "credentials in your Settings -> Social Networks page."
 msgstr ""
 
-#: src/Model/Contact.php:1184
+#: src/Model/Contact.php:1289
 msgid ""
 "This site is not configured to allow communications with other networks."
 msgstr ""
 
-#: src/Model/Contact.php:1185 src/Model/Contact.php:1199
+#: src/Model/Contact.php:1290 src/Model/Contact.php:1304
 msgid "No compatible communication protocols or feeds were discovered."
 msgstr ""
 
-#: src/Model/Contact.php:1197
+#: src/Model/Contact.php:1302
 msgid "The profile address specified does not provide adequate information."
 msgstr ""
 
-#: src/Model/Contact.php:1202
+#: src/Model/Contact.php:1307
 msgid "An author or name was not found."
 msgstr ""
 
-#: src/Model/Contact.php:1205
+#: src/Model/Contact.php:1310
 msgid "No browser URL could be matched to this address."
 msgstr ""
 
-#: src/Model/Contact.php:1208
+#: src/Model/Contact.php:1313
 msgid ""
 "Unable to match @-style Identity Address with a known protocol or email "
 "contact."
 msgstr ""
 
-#: src/Model/Contact.php:1209
+#: src/Model/Contact.php:1314
 msgid "Use mailto: in front of address to force email check."
 msgstr ""
 
-#: src/Model/Contact.php:1215
+#: src/Model/Contact.php:1320
 msgid ""
 "The profile address specified belongs to a network which has been disabled "
 "on this site."
 msgstr ""
 
-#: src/Model/Contact.php:1220
+#: src/Model/Contact.php:1325
 msgid ""
 "Limited profile. This person will be unable to receive direct/personal "
 "notifications from you."
 msgstr ""
 
-#: src/Model/Contact.php:1290
+#: src/Model/Contact.php:1376
 msgid "Unable to retrieve contact information."
 msgstr ""
 
-#: src/Model/Contact.php:1502
+#: src/Model/Contact.php:1588
 #, php-format
 msgid "%s's birthday"
 msgstr ""
 
-#: src/Model/Contact.php:1503 src/Protocol/DFRN.php:1398
+#: src/Model/Contact.php:1589 src/Protocol/DFRN.php:1397
 #, php-format
 msgid "Happy Birthday %s"
+msgstr ""
+
+#: src/Model/Event.php:53 src/Model/Event.php:70 src/Model/Event.php:419
+#: src/Model/Event.php:882
+msgid "Starts:"
+msgstr ""
+
+#: src/Model/Event.php:56 src/Model/Event.php:76 src/Model/Event.php:420
+#: src/Model/Event.php:886
+msgid "Finishes:"
+msgstr ""
+
+#: src/Model/Event.php:368
+msgid "all-day"
+msgstr ""
+
+#: src/Model/Event.php:391
+msgid "Jun"
+msgstr ""
+
+#: src/Model/Event.php:394
+msgid "Sept"
+msgstr ""
+
+#: src/Model/Event.php:417
+msgid "No events to display"
+msgstr ""
+
+#: src/Model/Event.php:543
+msgid "l, F j"
+msgstr ""
+
+#: src/Model/Event.php:566
+msgid "Edit event"
+msgstr ""
+
+#: src/Model/Event.php:567
+msgid "Duplicate event"
+msgstr ""
+
+#: src/Model/Event.php:568
+msgid "Delete event"
+msgstr ""
+
+#: src/Model/Event.php:815
+msgid "D g:i A"
+msgstr ""
+
+#: src/Model/Event.php:816
+msgid "g:i A"
+msgstr ""
+
+#: src/Model/Event.php:901 src/Model/Event.php:903
+msgid "Show map"
+msgstr ""
+
+#: src/Model/Event.php:902
+msgid "Hide map"
 msgstr ""
 
 #: src/Model/Group.php:44
@@ -8874,122 +8991,137 @@ msgid ""
 "not what you intended, please create another group with a different name."
 msgstr ""
 
-#: src/Model/Group.php:329
+#: src/Model/Group.php:328
 msgid "Default privacy group for new contacts"
 msgstr ""
 
-#: src/Model/Group.php:362
+#: src/Model/Group.php:361
 msgid "Everybody"
 msgstr ""
 
-#: src/Model/Group.php:382
+#: src/Model/Group.php:381
 msgid "edit"
 msgstr ""
 
-#: src/Model/Group.php:406
+#: src/Model/Group.php:405
 msgid "Edit group"
 msgstr ""
 
-#: src/Model/Group.php:407
+#: src/Model/Group.php:406
 msgid "Contacts not in any group"
 msgstr ""
 
-#: src/Model/Group.php:408
+#: src/Model/Group.php:407
 msgid "Create a new group"
 msgstr ""
 
-#: src/Model/Group.php:410
+#: src/Model/Group.php:409
 msgid "Edit groups"
 msgstr ""
 
-#: src/Model/User.php:142
+#: src/Model/Item.php:1676
+#, php-format
+msgid "%1$s is attending %2$s's %3$s"
+msgstr ""
+
+#: src/Model/Item.php:1681
+#, php-format
+msgid "%1$s is not attending %2$s's %3$s"
+msgstr ""
+
+#: src/Model/Item.php:1686
+#, php-format
+msgid "%1$s may attend %2$s's %3$s"
+msgstr ""
+
+#: src/Model/User.php:144
 msgid "Login failed"
 msgstr ""
 
-#: src/Model/User.php:173
+#: src/Model/User.php:175
 msgid "Not enough information to authenticate"
 msgstr ""
 
-#: src/Model/User.php:319
+#: src/Model/User.php:332
 msgid "An invitation is required."
 msgstr ""
 
-#: src/Model/User.php:323
+#: src/Model/User.php:336
 msgid "Invitation could not be verified."
 msgstr ""
 
-#: src/Model/User.php:330
+#: src/Model/User.php:343
 msgid "Invalid OpenID url"
 msgstr ""
 
-#: src/Model/User.php:343 src/Module/Login.php:100
+#: src/Model/User.php:356 src/Module/Login.php:100
 msgid ""
 "We encountered a problem while logging in with the OpenID you provided. "
 "Please check the correct spelling of the ID."
 msgstr ""
 
-#: src/Model/User.php:343 src/Module/Login.php:100
+#: src/Model/User.php:356 src/Module/Login.php:100
 msgid "The error message was:"
 msgstr ""
 
-#: src/Model/User.php:349
+#: src/Model/User.php:362
 msgid "Please enter the required information."
 msgstr ""
 
-#: src/Model/User.php:362
+#: src/Model/User.php:375
 msgid "Please use a shorter name."
 msgstr ""
 
-#: src/Model/User.php:365
+#: src/Model/User.php:378
 msgid "Name too short."
 msgstr ""
 
-#: src/Model/User.php:373
+#: src/Model/User.php:386
 msgid "That doesn't appear to be your full (First Last) name."
 msgstr ""
 
-#: src/Model/User.php:378
+#: src/Model/User.php:391
 msgid "Your email domain is not among those allowed on this site."
 msgstr ""
 
-#: src/Model/User.php:382
+#: src/Model/User.php:395
 msgid "Not a valid email address."
 msgstr ""
 
-#: src/Model/User.php:386 src/Model/User.php:394
+#: src/Model/User.php:399 src/Model/User.php:407
 msgid "Cannot use that email."
 msgstr ""
 
-#: src/Model/User.php:401
+#: src/Model/User.php:414
 msgid "Your nickname can only contain a-z, 0-9 and _."
 msgstr ""
 
-#: src/Model/User.php:408 src/Model/User.php:464
+#: src/Model/User.php:421 src/Model/User.php:477
 msgid "Nickname is already registered. Please choose another."
 msgstr ""
 
-#: src/Model/User.php:418
+#: src/Model/User.php:431
 msgid "SERIOUS ERROR: Generation of security keys failed."
 msgstr ""
 
-#: src/Model/User.php:451 src/Model/User.php:455
+#: src/Model/User.php:464 src/Model/User.php:468
 msgid "An error occurred during registration. Please try again."
 msgstr ""
 
-#: src/Model/User.php:480
+#: src/Model/User.php:493
 msgid "An error occurred creating your default profile. Please try again."
 msgstr ""
 
-#: src/Model/User.php:487
+#: src/Model/User.php:500
 msgid "An error occurred creating your self contact. Please try again."
 msgstr ""
 
-#: src/Model/User.php:496
+#: src/Model/User.php:509
 msgid ""
 "An error occurred creating your default contact group. Please try again."
 msgstr ""
 
-#: src/Model/User.php:570
+#: src/Model/User.php:583
 #, php-format
 msgid ""
 "\n"
@@ -8999,12 +9131,12 @@ msgid ""
 "\t\t"
 msgstr ""
 
-#: src/Model/User.php:580
+#: src/Model/User.php:593
 #, php-format
 msgid "Registration at %s"
 msgstr ""
 
-#: src/Model/User.php:598
+#: src/Model/User.php:611
 #, php-format
 msgid ""
 "\n"
@@ -9013,7 +9145,7 @@ msgid ""
 "\t\t"
 msgstr ""
 
-#: src/Model/User.php:602
+#: src/Model/User.php:615
 #, php-format
 msgid ""
 "\n"
@@ -9049,38 +9181,38 @@ msgid ""
 "\t\t\tThank you and welcome to %2$s."
 msgstr ""
 
-#: src/Protocol/DFRN.php:1397
+#: src/Protocol/DFRN.php:1396
 #, php-format
 msgid "%s\\'s birthday"
 msgstr ""
 
-#: src/Protocol/OStatus.php:1774
+#: src/Protocol/Diaspora.php:2647
+msgid "Sharing notification from Diaspora network"
+msgstr ""
+
+#: src/Protocol/Diaspora.php:3732
+msgid "Attachments:"
+msgstr ""
+
+#: src/Protocol/OStatus.php:1799
 #, php-format
 msgid "%s is now following %s."
 msgstr ""
 
-#: src/Protocol/OStatus.php:1775
+#: src/Protocol/OStatus.php:1800
 msgid "following"
 msgstr ""
 
-#: src/Protocol/OStatus.php:1778
+#: src/Protocol/OStatus.php:1803
 #, php-format
 msgid "%s stopped following %s."
 msgstr ""
 
-#: src/Protocol/OStatus.php:1779
+#: src/Protocol/OStatus.php:1804
 msgid "stopped following"
 msgstr ""
 
-#: src/Protocol/Diaspora.php:2584
-msgid "Sharing notification from Diaspora network"
-msgstr ""
-
-#: src/Protocol/Diaspora.php:3660
-msgid "Attachments:"
-msgstr ""
-
-#: src/Worker/Delivery.php:391
+#: src/Worker/Delivery.php:390
 msgid "(no subject)"
 msgstr ""
 
@@ -9124,142 +9256,142 @@ msgstr ""
 msgid "Logged out."
 msgstr ""
 
-#: src/Object/Post.php:127
+#: src/Object/Post.php:128
 msgid "This entry was edited"
 msgstr ""
 
-#: src/Object/Post.php:181
+#: src/Object/Post.php:182
 msgid "save to folder"
 msgstr ""
 
-#: src/Object/Post.php:234
+#: src/Object/Post.php:235
 msgid "I will attend"
 msgstr ""
 
-#: src/Object/Post.php:234
+#: src/Object/Post.php:235
 msgid "I will not attend"
 msgstr ""
 
-#: src/Object/Post.php:234
+#: src/Object/Post.php:235
 msgid "I might attend"
 msgstr ""
 
-#: src/Object/Post.php:262
+#: src/Object/Post.php:263
 msgid "add star"
 msgstr ""
 
-#: src/Object/Post.php:263
+#: src/Object/Post.php:264
 msgid "remove star"
 msgstr ""
 
-#: src/Object/Post.php:264
+#: src/Object/Post.php:265
 msgid "toggle star status"
 msgstr ""
 
-#: src/Object/Post.php:267
+#: src/Object/Post.php:268
 msgid "starred"
 msgstr ""
 
-#: src/Object/Post.php:273
+#: src/Object/Post.php:274
 msgid "ignore thread"
 msgstr ""
 
-#: src/Object/Post.php:274
+#: src/Object/Post.php:275
 msgid "unignore thread"
 msgstr ""
 
-#: src/Object/Post.php:275
+#: src/Object/Post.php:276
 msgid "toggle ignore status"
 msgstr ""
 
-#: src/Object/Post.php:284
+#: src/Object/Post.php:285
 msgid "add tag"
 msgstr ""
 
-#: src/Object/Post.php:295
+#: src/Object/Post.php:296
 msgid "like"
 msgstr ""
 
-#: src/Object/Post.php:296
+#: src/Object/Post.php:297
 msgid "dislike"
 msgstr ""
 
-#: src/Object/Post.php:299
+#: src/Object/Post.php:300
 msgid "Share this"
 msgstr ""
 
-#: src/Object/Post.php:299
+#: src/Object/Post.php:300
 msgid "share"
 msgstr ""
 
-#: src/Object/Post.php:357
+#: src/Object/Post.php:359
 msgid "to"
 msgstr ""
 
-#: src/Object/Post.php:358
+#: src/Object/Post.php:360
 msgid "via"
 msgstr ""
 
-#: src/Object/Post.php:359
+#: src/Object/Post.php:361
 msgid "Wall-to-Wall"
 msgstr ""
 
-#: src/Object/Post.php:360
+#: src/Object/Post.php:362
 msgid "via Wall-To-Wall:"
 msgstr ""
 
-#: src/Object/Post.php:419
+#: src/Object/Post.php:421
 #, php-format
 msgid "%d comment"
 msgid_plural "%d comments"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Object/Post.php:789
+#: src/Object/Post.php:791
 msgid "Bold"
 msgstr ""
 
-#: src/Object/Post.php:790
+#: src/Object/Post.php:792
 msgid "Italic"
 msgstr ""
 
-#: src/Object/Post.php:791
+#: src/Object/Post.php:793
 msgid "Underline"
 msgstr ""
 
-#: src/Object/Post.php:792
+#: src/Object/Post.php:794
 msgid "Quote"
 msgstr ""
 
-#: src/Object/Post.php:793
+#: src/Object/Post.php:795
 msgid "Code"
 msgstr ""
 
-#: src/Object/Post.php:794
+#: src/Object/Post.php:796
 msgid "Image"
 msgstr ""
 
-#: src/Object/Post.php:795
+#: src/Object/Post.php:797
 msgid "Link"
 msgstr ""
 
-#: src/Object/Post.php:796
+#: src/Object/Post.php:798
 msgid "Video"
 msgstr ""
 
-#: src/App.php:513
+#: src/App.php:517
 msgid "Delete this item?"
 msgstr ""
 
-#: src/App.php:515
+#: src/App.php:519
 msgid "show fewer"
 msgstr ""
 
-#: index.php:441
-msgid "toggle mobile"
-msgstr ""
-
-#: boot.php:786
+#: boot.php:791
 #, php-format
 msgid "Update %s failed. See error logs."
+msgstr ""
+
+#: index.php:444
+msgid "toggle mobile"
 msgstr ""


### PR DESCRIPTION
With the new strings for the relais server configuration, the master messages.po file was regenerated. Additionally there was a wrongly set path for the output file generation which was corrected.

Generation of addon messages.po files was tested and was unaffected by the wrong path setting.