### PR TITLE
added a hint to the htconfig file

### DIFF
--- a/htconfig.php
+++ b/htconfig.php
@@ -2,6 +2,11 @@
 
 // If automatic system installation fails:
 
+
+die('The configuration done manually contains some mistakes. Please have a look at your .htconfig.php file.');
+// If you are doing the configuration manually, please remove the line above
+
+
 // Copy or rename this file to .htconfig.php
 
 // Why .htconfig.php? Because it contains sensitive information which could

--- a/htconfig.php
+++ b/htconfig.php
@@ -3,7 +3,7 @@
 // If automatic system installation fails:
 
 
-die('The configuration done manually contains some mistakes. Please have a look at your .htconfig.php file.');
+die('The configuration you did manually contains some mistakes. Please have a look at your .htconfig.php file.');
 // If you are doing the configuration manually, please remove the line above
 
 


### PR DESCRIPTION
In a recent screencast by the Linux Journal the installation got stuck when the `htconfig.php` file was copied over to `.htconfig.php` but no other manual installation steps were performed.

I hope that hint will prevent such situations in the future.