### PR TITLE
Improve text highlight

### DIFF
--- a/include/text.php
+++ b/include/text.php
@@ -2030,6 +2030,10 @@ function text_highlight($s, $lang) {
 		$lang = 'javascript';
 	}
 
+	if ($lang === 'bash') {
+		$lang = 'sh';
+	}
+
 	// @TODO: Replace Text_Highlighter_Renderer_Html by scrivo/highlight.php
 
 	// Autoload the library to make constants available

--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -1292,13 +1292,17 @@ class BBCode extends BaseObject
 
 	private static function textHighlightCallback($match)
 	{
+		// Fallback in case the language doesn't exist
+		$return = '[code]' . $match[2] . '[/code]';
+
 		if (in_array(strtolower($match[1]),
 				['php', 'css', 'mysql', 'sql', 'abap', 'diff', 'html', 'perl', 'ruby',
 				'vbscript', 'avrc', 'dtd', 'java', 'xml', 'cpp', 'python', 'javascript', 'js', 'sh', 'bash'])
 		) {
-			return text_highlight($match[2], strtolower($match[1]));
+			$return = text_highlight($match[2], strtolower($match[1]));
 		}
-		return $match[0];
+
+		return $return;
 	}
 
 	/**

--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -1294,7 +1294,7 @@ class BBCode extends BaseObject
 	{
 		if (in_array(strtolower($match[1]),
 				['php', 'css', 'mysql', 'sql', 'abap', 'diff', 'html', 'perl', 'ruby',
-				'vbscript', 'avrc', 'dtd', 'java', 'xml', 'cpp', 'python', 'javascript', 'js', 'sh'])
+				'vbscript', 'avrc', 'dtd', 'java', 'xml', 'cpp', 'python', 'javascript', 'js', 'sh', 'bash'])
 		) {
 			return text_highlight($match[2], strtolower($match[1]));
 		}


### PR DESCRIPTION
See https://friendica.mrpetovan.com/display/882327d015b50136ef090242ac150004

When a text highlighting language doesn't exist, we currently discard the whole code tag.

This PR adds the "bash" language (mapped to "sh" internally) and the fallback to a regular code block if the language doesn't exist.