### PR TITLE
Console: Use $argv instead of $_SERVER['argv']

### DIFF
--- a/bin/console.php
+++ b/bin/console.php
@@ -6,4 +6,4 @@ include_once dirname(__DIR__) . '/boot.php';
 $a = new Friendica\App(dirname(__DIR__));
 \Friendica\BaseObject::setApp($a);
 
-(new Friendica\Core\Console())->execute();
+(new Friendica\Core\Console($argv))->execute();


### PR DESCRIPTION
See https://forum.friendi.ca/display/ec054ce7255abe539d63ace362184392

The problem was that the `$_SERVER['argv']` variable isn't populated with the same arguments as `$argv` in command-line mode.

In particular, `$_SERVER['argv']` ignores well-formed URLs when they are the last argument passed to the command.

I opened an issue at the remote project to inform them of this PHP behavior: https://github.com/asika32764/php-simple-console/issues/3