### PR TITLE
Add content_filter hook

### DIFF
--- a/doc/Addons.md
+++ b/doc/Addons.md
@@ -284,192 +284,221 @@ $b is an array with:
     'template' => filename of template
     'vars' => array of vars passed to template
 
-### ''acl_lookup_end'
+### 'acl_lookup_end'
 is called after the other queries have passed.
 The registered function can add, change or remove the acl_lookup() variables.
 
     'results' => array of the acl_lookup() vars
 
+### 'prepare_body_init'
+Called at the start of prepare_body
+Hook data:
+    'item' => item array (input/output)
+
+### 'content_filter'
+Called before the HTML conversion in prepare_body. If the item matches a content filter rule set by an addon, it should
+just add the reason to the filter_reasons element of the hook data.
+Hook data:
+    'item' => item array (input)
+    'filter_reasons' => reasons array (input/output)
+
+### 'prepare_body'
+Called after the HTML conversion in prepare_body.
+Hook data:
+    'item' => item array (input)
+	'html' => converted item body (input/output)
+	'is_preview' => post preview flag (input)
+    'filter_reasons' => reasons array (input)
+
+### 'prepare_body_final'
+Called at the end of prepare_body.
+Hook data:
+    'item' => item array (input)
+	'html' => converted item body (input/output)
 
 Complete list of hook callbacks
 ---
 
-Here is a complete list of all hook callbacks with file locations (as of 14-Feb-2012). Please see the source for details of any hooks not documented above.
-
-boot.php:	Addon::callHooks('login_hook',$o);
-
-boot.php:	Addon::callHooks('profile_sidebar_enter', $profile);
-
-boot.php:	Addon::callHooks('profile_sidebar', $arr);
-
-boot.php:	Addon::callHooks("proc_run", $arr);
-
-include/contact_selectors.php:	Addon::callHooks('network_to_name', $nets);
-
-include/api.php:				Addon::callHooks('logged_in', $a->user);
-
-include/api.php:		Addon::callHooks('logged_in', $a->user);
-
-include/queue.php:		Addon::callHooks('queue_predeliver', $a, $r);
-
-include/queue.php:				Addon::callHooks('queue_deliver', $a, $params);
-
-include/text.php:	Addon::callHooks('contact_block_end', $arr);
-
-include/text.php:	Addon::callHooks('smilie', $s);
-
-include/text.php:	Addon::callHooks('prepare_body_init', $item);
-
-include/text.php:	Addon::callHooks('prepare_body', $prep_arr);
-
-include/text.php:	Addon::callHooks('prepare_body_final', $prep_arr);
-
-include/nav.php:	Addon::callHooks('page_header', $a->page['nav']);
-
-include/auth.php:		Addon::callHooks('authenticate', $addon_auth);
-
-include/bbcode.php:	Addon::callHooks('bbcode',$Text);
-
-include/oauth.php:		Addon::callHooks('logged_in', $a->user);
-
-include/acl_selectors.php:	Addon::callHooks($a->module . '_pre_' . $selname, $arr);
-
-include/acl_selectors.php:	Addon::callHooks($a->module . '_post_' . $selname, $o);
-
-include/acl_selectors.php:	Addon::callHooks('contact_select_options', $x);
-
-include/acl_selectors.php:	Addon::callHooks($a->module . '_pre_' . $selname, $arr);
-
-include/acl_selectors.php:	Addon::callHooks($a->module . '_post_' . $selname, $o);
-
-include/acl_selectors.php:	Addon::callHooks($a->module . '_pre_' . $selname, $arr);
-
-include/acl_selectors.php:	Addon::callHooks($a->module . '_post_' . $selname, $o);
-
-include/acl_selectors.php	Addon::callHooks('acl_lookup_end', $results);
-
-include/notifier.php:		Addon::callHooks('notifier_normal',$target_item);
-
-include/notifier.php:	Addon::callHooks('notifier_end',$target_item);
-
-include/items.php:	Addon::callHooks('atom_feed', $atom);
-
-include/items.php:		Addon::callHooks('atom_feed_end', $atom);
-
-include/items.php:	Addon::callHooks('atom_feed_end', $atom);
-
-include/items.php:	Addon::callHooks('parse_atom', $arr);
-
-include/items.php:	Addon::callHooks('post_remote',$arr);
-
-include/items.php:	Addon::callHooks('atom_author', $o);
-
-include/items.php:	Addon::callHooks('atom_entry', $o);
-
-include/bb2diaspora.php:	Addon::callHooks('bb2diaspora',$Text);
-
-include/cronhooks.php:	Addon::callHooks('cron', $d);
-
-include/security.php:		Addon::callHooks('logged_in', $a->user);
-
-src/Content/Text/HTML.php:	Addon::callHooks('html2bbcode', $text);
-
-include/Contact.php:	Addon::callHooks('remove_user',$r[0]);
-
-include/Contact.php:	Addon::callHooks('contact_photo_menu', $args);
-
-include/conversation.php:	Addon::callHooks('conversation_start',$cb);
-
-include/conversation.php:				Addon::callHooks('render_location',$locate);
-
-include/conversation.php:				Addon::callHooks('display_item', $arr);
-
-include/conversation.php:				Addon::callHooks('render_location',$locate);
-
-include/conversation.php:				Addon::callHooks('display_item', $arr);
-
-include/conversation.php:	Addon::callHooks('item_photo_menu', $args);
-
-include/conversation.php:	Addon::callHooks('jot_tool', $jotplugins);
-
-include/conversation.php:	Addon::callHooks('jot_networks', $jotnets);
+Here is a complete list of all hook callbacks with file locations (as of 01-Apr-2018). Please see the source for details of any hooks not documented above.
 
 index.php:	Addon::callHooks('init_1');
+index.php:	Addon::callHooks('app_menu', $arr);
+index.php:	Addon::callHooks('page_content_top', $a->page['content']);
+index.php:	Addon::callHooks($a->module.'_mod_init', $placeholder);
+index.php:	Addon::callHooks($a->module.'_mod_init', $placeholder);
+index.php:	Addon::callHooks($a->module.'_mod_post', $_POST);
+index.php:	Addon::callHooks($a->module.'_mod_afterpost', $placeholder);
+index.php:	Addon::callHooks($a->module.'_mod_content', $arr);
+index.php:	Addon::callHooks($a->module.'_mod_aftercontent', $arr);
+index.php:	Addon::callHooks('page_end', $a->page['content']);
 
-index.php:Addon::callHooks('app_menu', $arr);
+include/api.php:	Addon::callHooks('logged_in', $a->user);
+include/api.php:	Addon::callHooks('authenticate', $addon_auth);
+include/api.php:	Addon::callHooks('logged_in', $a->user);
 
-index.php:Addon::callHooks('page_end', $a->page['content']);
+include/enotify.php:	Addon::callHooks('enotify', $h);
+include/enotify.php:	Addon::callHooks('enotify_store', $datarray);
+include/enotify.php:	Addon::callHooks('enotify_mail', $datarray);
+include/enotify.php:	Addon::callHooks('check_item_notification', $notification_data);
 
-mod/photos.php:	Addon::callHooks('photo_post_init', $_POST);
+include/conversation.php:	Addon::callHooks('conversation_start', $cb);
+include/conversation.php:	Addon::callHooks('render_location', $locate);
+include/conversation.php:	Addon::callHooks('display_item', $arr);
+include/conversation.php:	Addon::callHooks('display_item', $arr);
+include/conversation.php:	Addon::callHooks('item_photo_menu', $args);
+include/conversation.php:	Addon::callHooks('jot_tool', $jotplugins);
 
-mod/photos.php:	Addon::callHooks('photo_post_file',$ret);
+include/security.php:	Addon::callHooks('logged_in', $a->user);
 
-mod/photos.php:		Addon::callHooks('photo_post_end',$foo);
+include/text.php:	Addon::callHooks('contact_block_end', $arr);
+include/text.php:	Addon::callHooks('poke_verbs', $arr);
+include/text.php:	Addon::callHooks('prepare_body_init', $item);
+include/text.php:	Addon::callHooks('content_filter', $hook_data);
+include/text.php:	Addon::callHooks('prepare_body', $hook_data);
+include/text.php:	Addon::callHooks('prepare_body_final', $hook_data);
 
-mod/photos.php:		Addon::callHooks('photo_post_end',$foo);
+include/items.php:	Addon::callHooks('page_info_data', $data);
 
-mod/photos.php:		Addon::callHooks('photo_post_end',$foo);
-
-mod/photos.php:	Addon::callHooks('photo_post_end',intval($item_id));
-
-mod/photos.php:		Addon::callHooks('photo_upload_form',$ret);
-
-mod/friendica.php:	Addon::callHooks('about_hook', $o);
-
-mod/editpost.php:	Addon::callHooks('jot_tool', $jotplugins);
-
-mod/editpost.php:	Addon::callHooks('jot_networks', $jotnets);
-
-mod/parse_url.php:	Addon::callHooks('parse_link', $arr);
-
-mod/home.php:	Addon::callHooks('home_init',$ret);
-
-mod/home.php:	Addon::callHooks("home_content",$o);
-
-mod/contacts.php:	Addon::callHooks('contact_edit_post', $_POST);
-
-mod/contacts.php:		Addon::callHooks('contact_edit', $arr);
-
-mod/settings.php:		Addon::callHooks('addon_settings_post', $_POST);
-
-mod/settings.php:		Addon::callHooks('connector_settings_post', $_POST);
-
-mod/settings.php:	Addon::callHooks('settings_post', $_POST);
-
-mod/settings.php:		Addon::callHooks('addon_settings', $settings_addons);
-
-mod/settings.php:		Addon::callHooks('connector_settings', $settings_connectors);
-
-mod/settings.php:	Addon::callHooks('settings_form',$o);
-
-mod/register.php:	Addon::callHooks('register_account', $newuid);
-
-mod/like.php:	Addon::callHooks('post_local_end', $arr);
+mod/directory.php:	Addon::callHooks('directory_item', $arr);
 
 mod/xrd.php:	Addon::callHooks('personal_xrd', $arr);
 
-mod/item.php:	Addon::callHooks('post_local_start', $_REQUEST);
+mod/ping.php:	Addon::callHooks('network_ping', $arr);
 
-mod/item.php:	Addon::callHooks('post_local',$datarray);
+mod/parse_url.php:	Addon::callHooks("parse_link", $arr);
 
-mod/item.php:	Addon::callHooks('post_local_end', $datarray);
+mod/manage.php:	Addon::callHooks('home_init', $ret);
 
-mod/profile.php:			Addon::callHooks('profile_advanced',$o);
+mod/acl.php:	Addon::callHooks('acl_lookup_end', $results);
+
+mod/network.php:	Addon::callHooks('network_content_init', $arr);
+mod/network.php:	Addon::callHooks('network_tabs', $arr);
+
+mod/friendica.php:	Addon::callHooks('about_hook', $o);
+mod/subthread.php:	Addon::callHooks('post_local_end', $arr);
 
 mod/profiles.php:	Addon::callHooks('profile_post', $_POST);
+mod/profiles.php:	Addon::callHooks('profile_edit', $arr);
 
-mod/profiles.php:		Addon::callHooks('profile_edit', $arr);
+mod/settings.php:	Addon::callHooks('addon_settings_post', $_POST);
+mod/settings.php:	Addon::callHooks('connector_settings_post', $_POST);
+mod/settings.php:	Addon::callHooks('display_settings_post', $_POST);
+mod/settings.php:	Addon::callHooks('settings_post', $_POST);
+mod/settings.php:	Addon::callHooks('addon_settings', $settings_addons);
+mod/settings.php:	Addon::callHooks('connector_settings', $settings_connectors);
+mod/settings.php:	Addon::callHooks('display_settings', $o);
+mod/settings.php:	Addon::callHooks('settings_form', $o);
+
+mod/photos.php:	Addon::callHooks('photo_post_init', $_POST);
+mod/photos.php:	Addon::callHooks('photo_post_file', $ret);
+mod/photos.php:	Addon::callHooks('photo_post_end', $foo);
+mod/photos.php:	Addon::callHooks('photo_post_end', $foo);
+mod/photos.php:	Addon::callHooks('photo_post_end', $foo);
+mod/photos.php:	Addon::callHooks('photo_post_end', $foo);
+mod/photos.php:	Addon::callHooks('photo_post_end', intval($item_id));
+mod/photos.php:	Addon::callHooks('photo_upload_form', $ret);
+
+mod/profile.php:	Addon::callHooks('profile_advanced', $o);
+
+mod/home.php:	Addon::callHooks('home_init', $ret);
+mod/home.php:	Addon::callHooks("home_content", $content);
+
+mod/poke.php:	Addon::callHooks('post_local_end', $arr);
+
+mod/contacts.php:	Addon::callHooks('contact_edit_post', $_POST);
+mod/contacts.php:	Addon::callHooks('contact_edit', $arr);
 
 mod/tagger.php:	Addon::callHooks('post_local_end', $arr);
 
-mod/cb.php:	Addon::callHooks('cb_init');
+mod/lockview.php:	Addon::callHooks('lockview_content', $item);
 
-mod/cb.php:	Addon::callHooks('cb_post', $_POST);
+mod/uexport.php:	Addon::callHooks('uexport_options', $options);
 
-mod/cb.php:	Addon::callHooks('cb_afterpost');
+mod/register.php:	Addon::callHooks('register_post', $arr);
+mod/register.php:	Addon::callHooks('register_form', $arr);
 
-mod/cb.php:	Addon::callHooks('cb_content', $o);
+mod/item.php:	Addon::callHooks('post_local_start', $_REQUEST);
+mod/item.php:	Addon::callHooks('post_local', $datarray);
+mod/item.php:	Addon::callHooks('post_local_end', $datarray);
 
-mod/directory.php:			Addon::callHooks('directory_item', $arr);
+mod/editpost.php:	Addon::callHooks('jot_tool', $jotplugins);
 
-src/Model/Item.php Addon::callHooks('tagged', $arr);
+src/Network/FKOAuth1.php:	Addon::callHooks('logged_in', $a->user);
+
+src/Render/FriendicaSmartyEngine.php:	Addon::callHooks("template_vars", $arr);
+
+src/Model/Item.php:	Addon::callHooks('post_local', $item);
+src/Model/Item.php:	Addon::callHooks('post_remote', $item);
+src/Model/Item.php:	Addon::callHooks('post_local_end', $posted_item);
+src/Model/Item.php:	Addon::callHooks('post_remote_end', $posted_item);
+src/Model/Item.php:	Addon::callHooks('tagged', $arr);
+src/Model/Item.php:	Addon::callHooks('post_local_end', $new_item);
+
+src/Model/Contact.php:	Addon::callHooks('contact_photo_menu', $args);
+src/Model/Contact.php:	Addon::callHooks('follow', $arr);
+
+src/Model/Profile.php:	Addon::callHooks('profile_sidebar_enter', $profile);
+src/Model/Profile.php:	Addon::callHooks('profile_sidebar', $arr);
+src/Model/Profile.php:	Addon::callHooks('profile_tabs', $arr);
+src/Model/Profile.php:	Addon::callHooks('zrl_init', $arr);
+
+src/Model/Event.php:	Addon::callHooks('event_updated', $event['id']);
+src/Model/Event.php:	Addon::callHooks("event_created", $event['id']);
+
+src/Model/User.php:	Addon::callHooks('register_account', $uid);
+src/Model/User.php:	Addon::callHooks('remove_user', $user);
+
+src/Content/Text/BBCode.php:	Addon::callHooks('bbcode', $text);
+src/Content/Text/BBCode.php:	Addon::callHooks('bb2diaspora', $text);
+
+src/Content/Text/HTML.php:	Addon::callHooks('html2bbcode', $message);
+
+src/Content/Smilies.php:	Addon::callHooks('smilie', $params);
+
+src/Content/Feature.php:	Addon::callHooks('isEnabled', $arr);
+src/Content/Feature.php:	Addon::callHooks('get', $arr);
+
+src/Content/ContactSelector.php:	Addon::callHooks('network_to_name', $nets);
+src/Content/ContactSelector.php:	Addon::callHooks('gender_selector', $select);
+src/Content/ContactSelector.php:	Addon::callHooks('sexpref_selector', $select);
+src/Content/ContactSelector.php:	Addon::callHooks('marital_selector', $select);
+
+src/Content/OEmbed.php:	Addon::callHooks('oembed_fetch_url', $embedurl, $j);
+
+src/Content/Nav.php:	Addon::callHooks('page_header', $a->page['nav']);
+src/Content/Nav.php:	Addon::callHooks('nav_info', $nav);
+
+src/Worker/Directory.php:	Addon::callHooks('globaldir_update', $arr);
+src/Worker/Notifier.php:	Addon::callHooks('notifier_end', $target_item);
+src/Worker/Queue.php:	Addon::callHooks('queue_predeliver', $r);
+src/Worker/Queue.php:	Addon::callHooks('queue_deliver', $params);
+
+src/Module/Login.php:	Addon::callHooks('authenticate', $addon_auth);
+src/Module/Login.php:	Addon::callHooks('login_hook', $o);
+src/Module/Logout.php:	Addon::callHooks("logging_out");
+
+src/Object/Post.php:	Addon::callHooks('render_location', $locate);
+src/Object/Post.php:	Addon::callHooks('display_item', $arr);
+
+src/Core/ACL.php:	Addon::callHooks('contact_select_options', $x);
+src/Core/ACL.php:	Addon::callHooks($a->module.'_pre_'.$selname, $arr);
+src/Core/ACL.php:	Addon::callHooks($a->module.'_post_'.$selname, $o);
+src/Core/ACL.php:	Addon::callHooks($a->module.'_pre_'.$selname, $arr);
+src/Core/ACL.php:	Addon::callHooks($a->module.'_post_'.$selname, $o);
+src/Core/ACL.php:	Addon::callHooks('jot_networks', $jotnets);
+
+src/Core/Worker.php:	Addon::callHooks("proc_run", $arr);
+
+src/Util/Emailer.php:	Addon::callHooks('emailer_send_prepare', $params);
+src/Util/Emailer.php:	Addon::callHooks("emailer_send", $hookdata);
+
+src/Util/Map.php:	Addon::callHooks('generate_map', $arr);
+src/Util/Map.php:	Addon::callHooks('generate_named_map', $arr);
+src/Util/Map.php:	Addon::callHooks('Map::getCoordinates', $arr);
+
+src/Util/Network.php:	Addon::callHooks('avatar_lookup', $avatar);
+
+src/Util/ParseUrl.php:	Addon::callHooks("getsiteinfo", $siteinfo);
+
+src/Protocol/DFRN.php:	Addon::callHooks('atom_feed_end', $atom);
+src/Protocol/DFRN.php:	Addon::callHooks('atom_feed_end', $atom);

--- a/doc/Addons.md
+++ b/doc/Addons.md
@@ -295,7 +295,7 @@ Called at the start of prepare_body
 Hook data:
     'item' => item array (input/output)
 
-### 'content_filter'
+### 'prepare_body_content_filter'
 Called before the HTML conversion in prepare_body. If the item matches a content filter rule set by an addon, it should
 just add the reason to the filter_reasons element of the hook data.
 Hook data:
@@ -353,7 +353,7 @@ include/security.php:	Addon::callHooks('logged_in', $a->user);
 include/text.php:	Addon::callHooks('contact_block_end', $arr);
 include/text.php:	Addon::callHooks('poke_verbs', $arr);
 include/text.php:	Addon::callHooks('prepare_body_init', $item);
-include/text.php:	Addon::callHooks('content_filter', $hook_data);
+include/text.php:	Addon::callHooks('prepare_body_content_filter', $hook_data);
 include/text.php:	Addon::callHooks('prepare_body', $hook_data);
 include/text.php:	Addon::callHooks('prepare_body_final', $hook_data);
 

--- a/doc/de/Addons.md
+++ b/doc/de/Addons.md
@@ -189,178 +189,186 @@ Derzeitige Hooks
 Komplette Liste der Hook-Callbacks
 ---
 
-Eine komplette Liste aller Hook-Callbacks mit den zugehörigen Dateien (am 14-Feb-2012 generiert): Bitte schau in die Quellcodes für Details zu Hooks, die oben nicht dokumentiert sind.
+Eine komplette Liste aller Hook-Callbacks mit den zugehörigen Dateien (am 01-Apr-2018 generiert): Bitte schau in die Quellcodes für Details zu Hooks, die oben nicht dokumentiert sind.
 
-boot.php:			Addon::callHooks('login_hook',$o);
+index.php:	Addon::callHooks('init_1');
+index.php:	Addon::callHooks('app_menu', $arr);
+index.php:	Addon::callHooks('page_content_top', $a->page['content']);
+index.php:	Addon::callHooks($a->module.'_mod_init', $placeholder);
+index.php:	Addon::callHooks($a->module.'_mod_init', $placeholder);
+index.php:	Addon::callHooks($a->module.'_mod_post', $_POST);
+index.php:	Addon::callHooks($a->module.'_mod_afterpost', $placeholder);
+index.php:	Addon::callHooks($a->module.'_mod_content', $arr);
+index.php:	Addon::callHooks($a->module.'_mod_aftercontent', $arr);
+index.php:	Addon::callHooks('page_end', $a->page['content']);
 
-boot.php:			Addon::callHooks('profile_sidebar_enter', $profile);
+include/api.php:	Addon::callHooks('logged_in', $a->user);
+include/api.php:	Addon::callHooks('authenticate', $addon_auth);
+include/api.php:	Addon::callHooks('logged_in', $a->user);
 
-boot.php:			Addon::callHooks('profile_sidebar', $arr);
+include/enotify.php:	Addon::callHooks('enotify', $h);
+include/enotify.php:	Addon::callHooks('enotify_store', $datarray);
+include/enotify.php:	Addon::callHooks('enotify_mail', $datarray);
+include/enotify.php:	Addon::callHooks('check_item_notification', $notification_data);
 
-boot.php:			Addon::callHooks("proc_run", $arr);
-
-include/contact_selectors.php:	Addon::callHooks('network_to_name', $nets);
-
-include/api.php:		Addon::callHooks('logged_in', $a->user);
-
-include/api.php:		Addon::callHooks('logged_in', $a->user);
-
-include/queue.php:		Addon::callHooks('queue_predeliver', $a, $r);
-
-include/queue.php:		Addon::callHooks('queue_deliver', $a, $params);
-
-include/text.php:		Addon::callHooks('contact_block_end', $arr);
-
-include/text.php:		Addon::callHooks('smilie', $s);
-
-include/text.php:		Addon::callHooks('prepare_body_init', $item);
-
-include/text.php:		Addon::callHooks('prepare_body', $prep_arr);
-
-include/text.php:		Addon::callHooks('prepare_body_final', $prep_arr);
-
-include/nav.php:		Addon::callHooks('page_header', $a->page['nav']);
-
-include/auth.php:		Addon::callHooks('authenticate', $addon_auth);
-
-include/bbcode.php:		Addon::callHooks('bbcode',$Text);
-
-include/oauth.php:		Addon::callHooks('logged_in', $a->user);
-
-include/acl_selectors.php:	Addon::callHooks($a->module . '_pre_' . $selname, $arr);
-
-include/acl_selectors.php:	Addon::callHooks($a->module . '_post_' . $selname, $o);
-
-include/acl_selectors.php:	Addon::callHooks('contact_select_options', $x);
-
-include/acl_selectors.php:	Addon::callHooks($a->module . '_pre_' . $selname, $arr);
-
-include/acl_selectors.php:	Addon::callHooks($a->module . '_post_' . $selname, $o);
-
-include/acl_selectors.php:	Addon::callHooks($a->module . '_pre_' . $selname, $arr);
-
-include/acl_selectors.php:	Addon::callHooks($a->module . '_post_' . $selname, $o);
-
-include/notifier.php:		Addon::callHooks('notifier_normal',$target_item);
-
-include/notifier.php:		Addon::callHooks('notifier_end',$target_item);
-
-include/items.php:		Addon::callHooks('atom_feed', $atom);
-
-include/items.php:		Addon::callHooks('atom_feed_end', $atom);
-
-include/items.php:		Addon::callHooks('atom_feed_end', $atom);
-
-include/items.php:		Addon::callHooks('parse_atom', $arr);
-
-include/items.php:		Addon::callHooks('post_remote',$arr);
-
-include/items.php:		Addon::callHooks('atom_author', $o);
-
-include/items.php:		Addon::callHooks('atom_entry', $o);
-
-include/bb2diaspora.php:	Addon::callHooks('bb2diaspora',$Text);
-
-include/cronhooks.php:		Addon::callHooks('cron', $d);
-
-include/security.php:		Addon::callHooks('logged_in', $a->user);
-
-src/Content/Text/HTML.php:	Addon::callHooks('html2bbcode', $text);
-
-include/Contact.php:		Addon::callHooks('remove_user',$r[0]);
-
-include/Contact.php:		Addon::callHooks('contact_photo_menu', $args);
-
-include/conversation.php:	Addon::callHooks('conversation_start',$cb);
-
-include/conversation.php:	Addon::callHooks('render_location',$locate);
-
+include/conversation.php:	Addon::callHooks('conversation_start', $cb);
+include/conversation.php:	Addon::callHooks('render_location', $locate);
 include/conversation.php:	Addon::callHooks('display_item', $arr);
-
-include/conversation.php:	Addon::callHooks('render_location',$locate);
-
 include/conversation.php:	Addon::callHooks('display_item', $arr);
-
 include/conversation.php:	Addon::callHooks('item_photo_menu', $args);
-
 include/conversation.php:	Addon::callHooks('jot_tool', $jotplugins);
 
-include/conversation.php:	Addon::callHooks('jot_networks', $jotnets);
+include/security.php:	Addon::callHooks('logged_in', $a->user);
 
-index.php:			Addon::callHooks('init_1');
+include/text.php:	Addon::callHooks('contact_block_end', $arr);
+include/text.php:	Addon::callHooks('poke_verbs', $arr);
+include/text.php:	Addon::callHooks('prepare_body_init', $item);
+include/text.php:	Addon::callHooks('content_filter', $hook_data);
+include/text.php:	Addon::callHooks('prepare_body', $hook_data);
+include/text.php:	Addon::callHooks('prepare_body_final', $hook_data);
 
-index.php:			Addon::callHooks('app_menu', $arr);
+include/items.php:	Addon::callHooks('page_info_data', $data);
 
-index.php:			Addon::callHooks('page_end', $a->page['content']);
+mod/directory.php:	Addon::callHooks('directory_item', $arr);
 
-mod/photos.php:			Addon::callHooks('photo_post_init', $_POST);
+mod/xrd.php:	Addon::callHooks('personal_xrd', $arr);
 
-mod/photos.php:			Addon::callHooks('photo_post_file',$ret);
+mod/ping.php:	Addon::callHooks('network_ping', $arr);
 
-mod/photos.php:			Addon::callHooks('photo_post_end',$foo);
+mod/parse_url.php:	Addon::callHooks("parse_link", $arr);
 
-mod/photos.php:			Addon::callHooks('photo_post_end',$foo);
+mod/manage.php:	Addon::callHooks('home_init', $ret);
 
-mod/photos.php:			Addon::callHooks('photo_post_end',$foo);
+mod/acl.php:	Addon::callHooks('acl_lookup_end', $results);
 
-mod/photos.php:			Addon::callHooks('photo_post_end',intval($item_id));
+mod/network.php:	Addon::callHooks('network_content_init', $arr);
+mod/network.php:	Addon::callHooks('network_tabs', $arr);
 
-mod/photos.php:			Addon::callHooks('photo_upload_form',$ret);
+mod/friendica.php:	Addon::callHooks('about_hook', $o);
+mod/subthread.php:	Addon::callHooks('post_local_end', $arr);
 
-mod/friendica.php:		Addon::callHooks('about_hook', $o);
+mod/profiles.php:	Addon::callHooks('profile_post', $_POST);
+mod/profiles.php:	Addon::callHooks('profile_edit', $arr);
 
-mod/editpost.php:		Addon::callHooks('jot_tool', $jotplugins);
+mod/settings.php:	Addon::callHooks('addon_settings_post', $_POST);
+mod/settings.php:	Addon::callHooks('connector_settings_post', $_POST);
+mod/settings.php:	Addon::callHooks('display_settings_post', $_POST);
+mod/settings.php:	Addon::callHooks('settings_post', $_POST);
+mod/settings.php:	Addon::callHooks('addon_settings', $settings_addons);
+mod/settings.php:	Addon::callHooks('connector_settings', $settings_connectors);
+mod/settings.php:	Addon::callHooks('display_settings', $o);
+mod/settings.php:	Addon::callHooks('settings_form', $o);
 
-mod/editpost.php:		Addon::callHooks('jot_networks', $jotnets);
+mod/photos.php:	Addon::callHooks('photo_post_init', $_POST);
+mod/photos.php:	Addon::callHooks('photo_post_file', $ret);
+mod/photos.php:	Addon::callHooks('photo_post_end', $foo);
+mod/photos.php:	Addon::callHooks('photo_post_end', $foo);
+mod/photos.php:	Addon::callHooks('photo_post_end', $foo);
+mod/photos.php:	Addon::callHooks('photo_post_end', $foo);
+mod/photos.php:	Addon::callHooks('photo_post_end', intval($item_id));
+mod/photos.php:	Addon::callHooks('photo_upload_form', $ret);
 
-mod/parse_url.php:		Addon::callHooks('parse_link', $arr);
+mod/profile.php:	Addon::callHooks('profile_advanced', $o);
 
-mod/home.php:			Addon::callHooks('home_init',$ret);
+mod/home.php:	Addon::callHooks('home_init', $ret);
+mod/home.php:	Addon::callHooks("home_content", $content);
 
-mod/home.php:			Addon::callHooks("home_content",$o);
+mod/poke.php:	Addon::callHooks('post_local_end', $arr);
 
-mod/contacts.php:		Addon::callHooks('contact_edit_post', $_POST);
+mod/contacts.php:	Addon::callHooks('contact_edit_post', $_POST);
+mod/contacts.php:	Addon::callHooks('contact_edit', $arr);
 
-mod/contacts.php:		Addon::callHooks('contact_edit', $arr);
+mod/tagger.php:	Addon::callHooks('post_local_end', $arr);
 
-mod/settings.php:		Addon::callHooks('addon_settings_post', $_POST);
+mod/lockview.php:	Addon::callHooks('lockview_content', $item);
 
-mod/settings.php:		Addon::callHooks('connector_settings_post', $_POST);
+mod/uexport.php:	Addon::callHooks('uexport_options', $options);
 
-mod/settings.php:		Addon::callHooks('settings_post', $_POST);
+mod/register.php:	Addon::callHooks('register_post', $arr);
+mod/register.php:	Addon::callHooks('register_form', $arr);
 
-mod/settings.php:		Addon::callHooks('addon_settings', $settings_addons);
+mod/item.php:	Addon::callHooks('post_local_start', $_REQUEST);
+mod/item.php:	Addon::callHooks('post_local', $datarray);
+mod/item.php:	Addon::callHooks('post_local_end', $datarray);
 
-mod/settings.php:		Addon::callHooks('connector_settings', $settings_connectors);
+mod/editpost.php:	Addon::callHooks('jot_tool', $jotplugins);
 
-mod/settings.php:		Addon::callHooks('settings_form',$o);
+src/Network/FKOAuth1.php:	Addon::callHooks('logged_in', $a->user);
 
-mod/register.php:		Addon::callHooks('register_account', $newuid);
+src/Render/FriendicaSmartyEngine.php:	Addon::callHooks("template_vars", $arr);
 
-mod/like.php:			Addon::callHooks('post_local_end', $arr);
+src/Model/Item.php:	Addon::callHooks('post_local', $item);
+src/Model/Item.php:	Addon::callHooks('post_remote', $item);
+src/Model/Item.php:	Addon::callHooks('post_local_end', $posted_item);
+src/Model/Item.php:	Addon::callHooks('post_remote_end', $posted_item);
+src/Model/Item.php:	Addon::callHooks('tagged', $arr);
+src/Model/Item.php:	Addon::callHooks('post_local_end', $new_item);
 
-mod/xrd.php:			Addon::callHooks('personal_xrd', $arr);
+src/Model/Contact.php:	Addon::callHooks('contact_photo_menu', $args);
+src/Model/Contact.php:	Addon::callHooks('follow', $arr);
 
-mod/item.php:			Addon::callHooks('post_local_start', $_REQUEST);
+src/Model/Profile.php:	Addon::callHooks('profile_sidebar_enter', $profile);
+src/Model/Profile.php:	Addon::callHooks('profile_sidebar', $arr);
+src/Model/Profile.php:	Addon::callHooks('profile_tabs', $arr);
+src/Model/Profile.php:	Addon::callHooks('zrl_init', $arr);
 
-mod/item.php:			Addon::callHooks('post_local',$datarray);
+src/Model/Event.php:	Addon::callHooks('event_updated', $event['id']);
+src/Model/Event.php:	Addon::callHooks("event_created", $event['id']);
 
-mod/item.php:			Addon::callHooks('post_local_end', $datarray);
+src/Model/User.php:	Addon::callHooks('register_account', $uid);
+src/Model/User.php:	Addon::callHooks('remove_user', $user);
 
-mod/profile.php:		Addon::callHooks('profile_advanced',$o);
+src/Content/Text/BBCode.php:	Addon::callHooks('bbcode', $text);
+src/Content/Text/BBCode.php:	Addon::callHooks('bb2diaspora', $text);
 
-mod/profiles.php:		Addon::callHooks('profile_post', $_POST);
+src/Content/Text/HTML.php:	Addon::callHooks('html2bbcode', $message);
 
-mod/profiles.php:		Addon::callHooks('profile_edit', $arr);
+src/Content/Smilies.php:	Addon::callHooks('smilie', $params);
 
-mod/tagger.php:			Addon::callHooks('post_local_end', $arr);
+src/Content/Feature.php:	Addon::callHooks('isEnabled', $arr);
+src/Content/Feature.php:	Addon::callHooks('get', $arr);
 
-mod/cb.php:			Addon::callHooks('cb_init');
+src/Content/ContactSelector.php:	Addon::callHooks('network_to_name', $nets);
+src/Content/ContactSelector.php:	Addon::callHooks('gender_selector', $select);
+src/Content/ContactSelector.php:	Addon::callHooks('sexpref_selector', $select);
+src/Content/ContactSelector.php:	Addon::callHooks('marital_selector', $select);
 
-mod/cb.php:			Addon::callHooks('cb_post', $_POST);
+src/Content/OEmbed.php:	Addon::callHooks('oembed_fetch_url', $embedurl, $j);
 
-mod/cb.php:			Addon::callHooks('cb_afterpost');
+src/Content/Nav.php:	Addon::callHooks('page_header', $a->page['nav']);
+src/Content/Nav.php:	Addon::callHooks('nav_info', $nav);
 
-mod/cb.php:			Addon::callHooks('cb_content', $o);
+src/Worker/Directory.php:	Addon::callHooks('globaldir_update', $arr);
+src/Worker/Notifier.php:	Addon::callHooks('notifier_end', $target_item);
+src/Worker/Queue.php:	Addon::callHooks('queue_predeliver', $r);
+src/Worker/Queue.php:	Addon::callHooks('queue_deliver', $params);
 
-mod/directory.php:		Addon::callHooks('directory_item', $arr);
+src/Module/Login.php:	Addon::callHooks('authenticate', $addon_auth);
+src/Module/Login.php:	Addon::callHooks('login_hook', $o);
+src/Module/Logout.php:	Addon::callHooks("logging_out");
+
+src/Object/Post.php:	Addon::callHooks('render_location', $locate);
+src/Object/Post.php:	Addon::callHooks('display_item', $arr);
+
+src/Core/ACL.php:	Addon::callHooks('contact_select_options', $x);
+src/Core/ACL.php:	Addon::callHooks($a->module.'_pre_'.$selname, $arr);
+src/Core/ACL.php:	Addon::callHooks($a->module.'_post_'.$selname, $o);
+src/Core/ACL.php:	Addon::callHooks($a->module.'_pre_'.$selname, $arr);
+src/Core/ACL.php:	Addon::callHooks($a->module.'_post_'.$selname, $o);
+src/Core/ACL.php:	Addon::callHooks('jot_networks', $jotnets);
+
+src/Core/Worker.php:	Addon::callHooks("proc_run", $arr);
+
+src/Util/Emailer.php:	Addon::callHooks('emailer_send_prepare', $params);
+src/Util/Emailer.php:	Addon::callHooks("emailer_send", $hookdata);
+
+src/Util/Map.php:	Addon::callHooks('generate_map', $arr);
+src/Util/Map.php:	Addon::callHooks('generate_named_map', $arr);
+src/Util/Map.php:	Addon::callHooks('Map::getCoordinates', $arr);
+
+src/Util/Network.php:	Addon::callHooks('avatar_lookup', $avatar);
+
+src/Util/ParseUrl.php:	Addon::callHooks("getsiteinfo", $siteinfo);
+
+src/Protocol/DFRN.php:	Addon::callHooks('atom_feed_end', $atom);
+src/Protocol/DFRN.php:	Addon::callHooks('atom_feed_end', $atom);

--- a/doc/de/Addons.md
+++ b/doc/de/Addons.md
@@ -223,7 +223,7 @@ include/security.php:	Addon::callHooks('logged_in', $a->user);
 include/text.php:	Addon::callHooks('contact_block_end', $arr);
 include/text.php:	Addon::callHooks('poke_verbs', $arr);
 include/text.php:	Addon::callHooks('prepare_body_init', $item);
-include/text.php:	Addon::callHooks('content_filter', $hook_data);
+include/text.php:	Addon::callHooks('prepare_body_content_filter', $hook_data);
 include/text.php:	Addon::callHooks('prepare_body', $hook_data);
 include/text.php:	Addon::callHooks('prepare_body_final', $hook_data);
 

--- a/include/conversation.php
+++ b/include/conversation.php
@@ -756,7 +756,13 @@ function conversation(App $a, $items, $mode, $update, $preview = false, $order =
 				list($categories, $folders) = get_cats_and_terms($item);
 
 				$profile_name_e = $profile_name;
-				$item['title_e'] = $item['title'];
+
+				if (!empty($item['content-warning']) && PConfig::get(local_user(), 'social', 'disable_cw', false)) {
+					$title_e = ucfirst($item['content-warning']);
+				} else {
+					$title_e = $item['title'];
+				}
+
 				$body_e = $body;
 				$tags_e = $tags;
 				$hashtags_e = $hashtags;
@@ -781,7 +787,7 @@ function conversation(App $a, $items, $mode, $update, $preview = false, $order =
 					'sparkle' => $sparkle,
 					'lock' => $lock,
 					'thumb' => System::removedBaseUrl(proxy_url($item['author-thumb'], false, PROXY_SIZE_THUMB)),
-					'title' => $item['title_e'],
+					'title' => $title_e,
 					'body' => $body_e,
 					'tags' => $tags_e,
 					'hashtags' => $hashtags_e,

--- a/include/conversation.php
+++ b/include/conversation.php
@@ -757,7 +757,7 @@ function conversation(App $a, $items, $mode, $update, $preview = false, $order =
 
 				$profile_name_e = $profile_name;
 
-				if (!empty($item['content-warning']) && PConfig::get(local_user(), 'social', 'disable_cw', false)) {
+				if (!empty($item['content-warning']) && PConfig::get(local_user(), 'system', 'disable_cw', false)) {
 					$title_e = ucfirst($item['content-warning']);
 				} else {
 					$title_e = $item['title'];

--- a/include/text.php
+++ b/include/text.php
@@ -1431,15 +1431,15 @@ function apply_content_filter($html, array $reasons)
 {
 	if (count($reasons)) {
 		$rnd = random_string(8);
-		$content_filter_html = '<ul>';
+		$content_filter_html = '<ul class="content-filter-reasons">';
 		foreach ($reasons as $reason) {
 			$content_filter_html .= '<li>' . htmlspecialchars($reason) . '</li>' . PHP_EOL;
 		}
 		$content_filter_html .= '</ul>
-			<div id="content-filter-wrap-' . $rnd . '" class="fakelink" onclick=openClose(\'content-filter-' . $rnd . '\'); >' .
+			<p><span id="content-filter-wrap-' . $rnd . '" class="fakelink content-filter-button" onclick=openClose(\'content-filter-' . $rnd . '\'); >' .
 			L10n::t('Click to open/close') .
-			'</div>
-			<div id="content-filter-' . $rnd . '" style="display: none;">';
+			'</span></p>
+			<div id="content-filter-' . $rnd . '" class="content-filter-content" style="display: none;">';
 
 		$html = $content_filter_html . $html . '</div>';
 	}

--- a/include/text.php
+++ b/include/text.php
@@ -1271,7 +1271,7 @@ function prepare_body(array &$item, $attach = false, $is_preview = false)
 	// Compile eventual content filter reasons
 	$filter_reasons = [];
 	if (!$is_preview && !($item['self'] && local_user() == $item['uid'])) {
-		if (!empty($item['content-warning']) && (!local_user() || !PConfig::get(local_user(), 'social', 'disable_cw', false))) {
+		if (!empty($item['content-warning']) && (!local_user() || !PConfig::get(local_user(), 'system', 'disable_cw', false))) {
 			$filter_reasons[] = L10n::t('Content warning: %s', $item['content-warning']);
 		}
 

--- a/include/text.php
+++ b/include/text.php
@@ -1270,7 +1270,7 @@ function prepare_body(array &$item, $attach = false, $is_preview = false)
 
 	// Compile eventual content filter reasons
 	$filter_reasons = [];
-	if (!$is_preview && !$item['self']) {
+	if (!$is_preview && !($item['self'] && local_user() == $item['uid'])) {
 		if (!empty($item['content-warning']) && (!local_user() || !PConfig::get(local_user(), 'social', 'disable_cw', false))) {
 			$filter_reasons[] = L10n::t('Content warning: %s', $item['content-warning']);
 		}
@@ -1305,9 +1305,7 @@ function prepare_body(array &$item, $attach = false, $is_preview = false)
 	$s = $hook_data['html'];
 	unset($hook_data);
 
-	if (!$is_preview && !$item['self']) {
-		$s = apply_content_filter($s, $filter_reasons);
-	}
+	$s = apply_content_filter($s, $filter_reasons);
 
 	if (! $attach) {
 		// Replace the blockquotes with quotes that are used in mails.

--- a/include/text.php
+++ b/include/text.php
@@ -1183,11 +1183,6 @@ function put_item_in_cache(&$item, $update = false)
 {
 	$body = $item["body"];
 
-	// Add the content warning
-	if (!empty($item['content-warning'])) {
-		$item["body"] = $item['content-warning'] . '[spoiler]' . $item["body"] . '[/spoiler]';
-	}
-
 	$rendered_hash = defaults($item, 'rendered-hash', '');
 
 	if ($rendered_hash == ''

--- a/include/text.php
+++ b/include/text.php
@@ -1214,7 +1214,7 @@ function put_item_in_cache(&$item, $update = false)
  * @param boolean $is_preview
  * @return string item body html
  * @hook prepare_body_init item array before any work
- * @hook content_filter ('item'=>item array, 'filter_reasons'=>string array) before first bbcode to html
+ * @hook prepare_body_content_filter ('item'=>item array, 'filter_reasons'=>string array) before first bbcode to html
  * @hook prepare_body ('item'=>item array, 'html'=>body string, 'is_preview'=>boolean, 'filter_reasons'=>string array) after first bbcode to html
  * @hook prepare_body_final ('item'=>item array, 'html'=>body string) after attach icons and blockquote special case handling (spoiler, author)
  */
@@ -1279,7 +1279,7 @@ function prepare_body(array &$item, $attach = false, $is_preview = false)
 			'item' => $item,
 			'filter_reasons' => $filter_reasons
 		];
-		Addon::callHooks('content_filter', $hook_data);
+		Addon::callHooks('prepare_body_content_filter', $hook_data);
 		$filter_reasons = $hook_data['filter_reasons'];
 		unset($hook_data);
 	}

--- a/mod/settings.php
+++ b/mod/settings.php
@@ -845,7 +845,7 @@ function settings_content(App $a)
 			'$ostat_enabled' => $ostat_enabled,
 
 			'$general_settings' => L10n::t('General Social Media Settings'),
-			'$disable_cw' => ['disable_cw', L10n::t('Disable Content Warning'), $disable_cw, L10n::t('Users on networks like Mastodon or Pleroma are able to set a content warning field which collapse their post by default. You can disable this default behavior to always show post with an author-set content warning. Doesn\'t affect any other content filtering you eventually set up.')],
+			'$disable_cw' => ['disable_cw', L10n::t('Disable Content Warning'), $disable_cw, L10n::t('Users on networks like Mastodon or Pleroma are able to set a content warning field which collapse their post by default. This disables the automatic collapsing and sets the content warning as the post title. Doesn\'t affect any other content filtering you eventually set up.')],
 			'$no_intelligent_shortening' => ['no_intelligent_shortening', L10n::t('Disable intelligent shortening'), $no_intelligent_shortening, L10n::t('Normally the system tries to find the best link to add to shortened posts. If this option is enabled then every shortened post will always point to the original friendica post.')],
 			'$ostatus_autofriend' => ['snautofollow', L10n::t("Automatically follow any GNU Social \x28OStatus\x29 followers/mentioners"), $ostatus_autofriend, L10n::t('If you receive a message from an unknown OStatus user, this option decides what to do. If it is checked, a new contact will be created for every unknown user.')],
 			'$default_group' => Group::displayGroupSelection(local_user(), $default_group, L10n::t("Default group for OStatus contacts")),

--- a/mod/settings.php
+++ b/mod/settings.php
@@ -212,7 +212,7 @@ function settings_post(App $a)
 		check_form_security_token_redirectOnErr('/settings/connectors', 'settings_connectors');
 
 		if (x($_POST, 'general-submit')) {
-			PConfig::set(local_user(), 'social', 'disable_cw', intval($_POST['disable_cw']));
+			PConfig::set(local_user(), 'system', 'disable_cw', intval($_POST['disable_cw']));
 			PConfig::set(local_user(), 'system', 'no_intelligent_shortening', intval($_POST['no_intelligent_shortening']));
 			PConfig::set(local_user(), 'system', 'ostatus_autofriend', intval($_POST['snautofollow']));
 			PConfig::set(local_user(), 'ostatus', 'default_group', $_POST['group-selection']);
@@ -787,7 +787,7 @@ function settings_content(App $a)
 	}
 
 	if (($a->argc > 1) && ($a->argv[1] === 'connectors')) {
-		$disable_cw                = intval(PConfig::get(local_user(), 'social', 'disable_cw'));
+		$disable_cw                = intval(PConfig::get(local_user(), 'system', 'disable_cw'));
 		$no_intelligent_shortening = intval(PConfig::get(local_user(), 'system', 'no_intelligent_shortening'));
 		$ostatus_autofriend        = intval(PConfig::get(local_user(), 'system', 'ostatus_autofriend'));
 		$default_group             = PConfig::get(local_user(), 'ostatus', 'default_group');

--- a/mod/settings.php
+++ b/mod/settings.php
@@ -19,7 +19,6 @@ use Friendica\Model\GContact;
 use Friendica\Model\Group;
 use Friendica\Model\User;
 use Friendica\Protocol\Email;
-use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Network;
 use Friendica\Util\Temporal;
 
@@ -213,6 +212,7 @@ function settings_post(App $a)
 		check_form_security_token_redirectOnErr('/settings/connectors', 'settings_connectors');
 
 		if (x($_POST, 'general-submit')) {
+			PConfig::set(local_user(), 'social', 'disable_cw', intval($_POST['disable_cw']));
 			PConfig::set(local_user(), 'system', 'no_intelligent_shortening', intval($_POST['no_intelligent_shortening']));
 			PConfig::set(local_user(), 'system', 'ostatus_autofriend', intval($_POST['snautofollow']));
 			PConfig::set(local_user(), 'ostatus', 'default_group', $_POST['group-selection']);
@@ -787,6 +787,7 @@ function settings_content(App $a)
 	}
 
 	if (($a->argc > 1) && ($a->argv[1] === 'connectors')) {
+		$disable_cw                = intval(PConfig::get(local_user(), 'social', 'disable_cw'));
 		$no_intelligent_shortening = intval(PConfig::get(local_user(), 'system', 'no_intelligent_shortening'));
 		$ostatus_autofriend        = intval(PConfig::get(local_user(), 'system', 'ostatus_autofriend'));
 		$default_group             = PConfig::get(local_user(), 'ostatus', 'default_group');
@@ -844,6 +845,7 @@ function settings_content(App $a)
 			'$ostat_enabled' => $ostat_enabled,
 
 			'$general_settings' => L10n::t('General Social Media Settings'),
+			'$disable_cw' => ['disable_cw', L10n::t('Disable Content Warning'), $disable_cw, L10n::t('Users on networks like Mastodon or Pleroma are able to set a content warning field which collapse their post by default. You can disable this default behavior to always show post with an author-set content warning. Doesn\'t affect any other content filtering you eventually set up.')],
 			'$no_intelligent_shortening' => ['no_intelligent_shortening', L10n::t('Disable intelligent shortening'), $no_intelligent_shortening, L10n::t('Normally the system tries to find the best link to add to shortened posts. If this option is enabled then every shortened post will always point to the original friendica post.')],
 			'$ostatus_autofriend' => ['snautofollow', L10n::t("Automatically follow any GNU Social \x28OStatus\x29 followers/mentioners"), $ostatus_autofriend, L10n::t('If you receive a message from an unknown OStatus user, this option decides what to do. If it is checked, a new contact will be created for every unknown user.')],
 			'$default_group' => Group::displayGroupSelection(local_user(), $default_group, L10n::t("Default group for OStatus contacts")),

--- a/src/Object/Post.php
+++ b/src/Object/Post.php
@@ -317,7 +317,7 @@ class Post extends BaseObject
 		$text_e       = strip_tags($body);
 		$name_e       = $profile_name;
 
-		if (!empty($item['content-warning']) && PConfig::get(local_user(), 'social', 'disable_cw', false)) {
+		if (!empty($item['content-warning']) && PConfig::get(local_user(), 'system', 'disable_cw', false)) {
 			$title_e = ucfirst($item['content-warning']);
 		} else {
 			$title_e = $item['title'];

--- a/src/Object/Post.php
+++ b/src/Object/Post.php
@@ -316,7 +316,13 @@ class Post extends BaseObject
 		$body_e       = $body;
 		$text_e       = strip_tags($body);
 		$name_e       = $profile_name;
-		$title_e      = $item['title'];
+
+		if (!empty($item['content-warning']) && PConfig::get(local_user(), 'social', 'disable_cw', false)) {
+			$title_e = ucfirst($item['content-warning']);
+		} else {
+			$title_e = $item['title'];
+		}
+
 		$location_e   = $location;
 		$owner_name_e = $this->getOwnerName();
 

--- a/util/messages.po
+++ b/util/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-04-04 07:01+0200\n"
+"POT-Creation-Date: 2018-04-04 23:01-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,22 +18,9 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 
-#: include/security.php:81
-msgid "Welcome "
-msgstr ""
-
-#: include/security.php:82
-msgid "Please upload a profile photo."
-msgstr ""
-
-#: include/security.php:84
-msgid "Welcome back "
-msgstr ""
-
-#: include/security.php:431
-msgid ""
-"The form security token was not correct. This probably happened because the "
-"form has been opened for too long (>3 hours) before submitting it."
+#: boot.php:791
+#, php-format
+msgid "Update %s failed. See error logs."
 msgstr ""
 
 #: include/dba.php:57
@@ -70,7 +57,7 @@ msgid "Profile Photos"
 msgstr ""
 
 #: include/conversation.php:144 include/conversation.php:282
-#: include/text.php:1724 src/Model/Item.php:1795
+#: include/text.php:1774 src/Model/Item.php:1795
 msgid "event"
 msgstr ""
 
@@ -82,7 +69,7 @@ msgid "status"
 msgstr ""
 
 #: include/conversation.php:152 include/conversation.php:290
-#: include/text.php:1726 mod/subthread.php:97 mod/tagger.php:72
+#: include/text.php:1776 mod/subthread.php:97 mod/tagger.php:72
 #: src/Model/Item.php:1793
 msgid "photo"
 msgstr ""
@@ -146,7 +133,7 @@ msgstr ""
 msgid "Dislikes"
 msgstr ""
 
-#: include/conversation.php:606 include/conversation.php:1680
+#: include/conversation.php:606 include/conversation.php:1686
 #: mod/photos.php:1502
 msgid "Attending"
 msgid_plural "Attending"
@@ -165,347 +152,347 @@ msgstr ""
 msgid "Select"
 msgstr ""
 
-#: include/conversation.php:745 mod/photos.php:1570 mod/settings.php:738
-#: mod/contacts.php:830 mod/contacts.php:1035 mod/admin.php:1798
+#: include/conversation.php:745 mod/admin.php:1745 mod/contacts.php:830
+#: mod/contacts.php:1035 mod/photos.php:1570 mod/settings.php:738
 #: src/Object/Post.php:179
 msgid "Delete"
 msgstr ""
 
-#: include/conversation.php:777 src/Object/Post.php:357 src/Object/Post.php:358
+#: include/conversation.php:783 src/Object/Post.php:363 src/Object/Post.php:364
 #, php-format
 msgid "View %s's profile @ %s"
 msgstr ""
 
-#: include/conversation.php:789 src/Object/Post.php:345
+#: include/conversation.php:795 src/Object/Post.php:351
 msgid "Categories:"
 msgstr ""
 
-#: include/conversation.php:790 src/Object/Post.php:346
+#: include/conversation.php:796 src/Object/Post.php:352
 msgid "Filed under:"
 msgstr ""
 
-#: include/conversation.php:797 src/Object/Post.php:371
+#: include/conversation.php:803 src/Object/Post.php:377
 #, php-format
 msgid "%s from %s"
 msgstr ""
 
-#: include/conversation.php:812
+#: include/conversation.php:818
 msgid "View in context"
 msgstr ""
 
-#: include/conversation.php:814 include/conversation.php:1353
-#: mod/wallmessage.php:145 mod/editpost.php:125 mod/message.php:264
-#: mod/message.php:433 mod/photos.php:1473 src/Object/Post.php:396
+#: include/conversation.php:820 include/conversation.php:1359
+#: mod/editpost.php:125 mod/message.php:264 mod/message.php:433
+#: mod/photos.php:1473 mod/wallmessage.php:145 src/Object/Post.php:402
 msgid "Please wait"
 msgstr ""
 
-#: include/conversation.php:885
+#: include/conversation.php:891
 msgid "remove"
 msgstr ""
 
-#: include/conversation.php:889
+#: include/conversation.php:895
 msgid "Delete Selected Items"
 msgstr ""
 
-#: include/conversation.php:1059 view/theme/frio/theme.php:352
+#: include/conversation.php:1065 view/theme/frio/theme.php:352
 msgid "Follow Thread"
 msgstr ""
 
-#: include/conversation.php:1060 src/Model/Contact.php:640
+#: include/conversation.php:1066 src/Model/Contact.php:640
 msgid "View Status"
 msgstr ""
 
-#: include/conversation.php:1061 include/conversation.php:1077
-#: mod/allfriends.php:73 mod/suggest.php:82 mod/match.php:89
-#: mod/dirfind.php:217 mod/directory.php:159 src/Model/Contact.php:580
+#: include/conversation.php:1067 include/conversation.php:1083
+#: mod/allfriends.php:73 mod/directory.php:159 mod/dirfind.php:217
+#: mod/match.php:89 mod/suggest.php:82 src/Model/Contact.php:580
 #: src/Model/Contact.php:593 src/Model/Contact.php:641
 msgid "View Profile"
 msgstr ""
 
-#: include/conversation.php:1062 src/Model/Contact.php:642
+#: include/conversation.php:1068 src/Model/Contact.php:642
 msgid "View Photos"
 msgstr ""
 
-#: include/conversation.php:1063 src/Model/Contact.php:643
+#: include/conversation.php:1069 src/Model/Contact.php:643
 msgid "Network Posts"
 msgstr ""
 
-#: include/conversation.php:1064 src/Model/Contact.php:644
+#: include/conversation.php:1070 src/Model/Contact.php:644
 msgid "View Contact"
 msgstr ""
 
-#: include/conversation.php:1065 src/Model/Contact.php:646
+#: include/conversation.php:1071 src/Model/Contact.php:646
 msgid "Send PM"
 msgstr ""
 
-#: include/conversation.php:1069 src/Model/Contact.php:647
+#: include/conversation.php:1075 src/Model/Contact.php:647
 msgid "Poke"
 msgstr ""
 
-#: include/conversation.php:1074 mod/allfriends.php:74 mod/suggest.php:83
-#: mod/match.php:90 mod/dirfind.php:218 mod/follow.php:143 mod/contacts.php:596
+#: include/conversation.php:1080 mod/allfriends.php:74 mod/contacts.php:596
+#: mod/dirfind.php:218 mod/follow.php:143 mod/match.php:90 mod/suggest.php:83
 #: src/Content/Widget.php:61 src/Model/Contact.php:594
 msgid "Connect/Follow"
 msgstr ""
 
-#: include/conversation.php:1193
+#: include/conversation.php:1199
 #, php-format
 msgid "%s likes this."
 msgstr ""
 
-#: include/conversation.php:1196
+#: include/conversation.php:1202
 #, php-format
 msgid "%s doesn't like this."
 msgstr ""
 
-#: include/conversation.php:1199
+#: include/conversation.php:1205
 #, php-format
 msgid "%s attends."
 msgstr ""
 
-#: include/conversation.php:1202
+#: include/conversation.php:1208
 #, php-format
 msgid "%s doesn't attend."
 msgstr ""
 
-#: include/conversation.php:1205
+#: include/conversation.php:1211
 #, php-format
 msgid "%s attends maybe."
 msgstr ""
 
-#: include/conversation.php:1216
+#: include/conversation.php:1222
 msgid "and"
 msgstr ""
 
-#: include/conversation.php:1222
+#: include/conversation.php:1228
 #, php-format
 msgid "and %d other people"
 msgstr ""
 
-#: include/conversation.php:1231
+#: include/conversation.php:1237
 #, php-format
 msgid "<span  %1$s>%2$d people</span> like this"
 msgstr ""
 
-#: include/conversation.php:1232
+#: include/conversation.php:1238
 #, php-format
 msgid "%s like this."
 msgstr ""
 
-#: include/conversation.php:1235
+#: include/conversation.php:1241
 #, php-format
 msgid "<span  %1$s>%2$d people</span> don't like this"
 msgstr ""
 
-#: include/conversation.php:1236
+#: include/conversation.php:1242
 #, php-format
 msgid "%s don't like this."
 msgstr ""
 
-#: include/conversation.php:1239
+#: include/conversation.php:1245
 #, php-format
 msgid "<span  %1$s>%2$d people</span> attend"
 msgstr ""
 
-#: include/conversation.php:1240
+#: include/conversation.php:1246
 #, php-format
 msgid "%s attend."
 msgstr ""
 
-#: include/conversation.php:1243
+#: include/conversation.php:1249
 #, php-format
 msgid "<span  %1$s>%2$d people</span> don't attend"
 msgstr ""
 
-#: include/conversation.php:1244
+#: include/conversation.php:1250
 #, php-format
 msgid "%s don't attend."
 msgstr ""
 
-#: include/conversation.php:1247
+#: include/conversation.php:1253
 #, php-format
 msgid "<span  %1$s>%2$d people</span> attend maybe"
 msgstr ""
 
-#: include/conversation.php:1248
+#: include/conversation.php:1254
 #, php-format
 msgid "%s attend maybe."
 msgstr ""
 
-#: include/conversation.php:1278 include/conversation.php:1294
+#: include/conversation.php:1284 include/conversation.php:1300
 msgid "Visible to <strong>everybody</strong>"
 msgstr ""
 
-#: include/conversation.php:1279 include/conversation.php:1295
-#: mod/wallmessage.php:120 mod/wallmessage.php:127 mod/message.php:200
-#: mod/message.php:207 mod/message.php:343 mod/message.php:350
+#: include/conversation.php:1285 include/conversation.php:1301
+#: mod/message.php:200 mod/message.php:207 mod/message.php:343
+#: mod/message.php:350 mod/wallmessage.php:120 mod/wallmessage.php:127
 msgid "Please enter a link URL:"
 msgstr ""
 
-#: include/conversation.php:1280 include/conversation.php:1296
+#: include/conversation.php:1286 include/conversation.php:1302
 msgid "Please enter a video link/URL:"
 msgstr ""
 
-#: include/conversation.php:1281 include/conversation.php:1297
+#: include/conversation.php:1287 include/conversation.php:1303
 msgid "Please enter an audio link/URL:"
 msgstr ""
 
-#: include/conversation.php:1282 include/conversation.php:1298
+#: include/conversation.php:1288 include/conversation.php:1304
 msgid "Tag term:"
 msgstr ""
 
-#: include/conversation.php:1283 include/conversation.php:1299 mod/filer.php:34
+#: include/conversation.php:1289 include/conversation.php:1305 mod/filer.php:34
 msgid "Save to Folder:"
 msgstr ""
 
-#: include/conversation.php:1284 include/conversation.php:1300
+#: include/conversation.php:1290 include/conversation.php:1306
 msgid "Where are you right now?"
 msgstr ""
 
-#: include/conversation.php:1285
+#: include/conversation.php:1291
 msgid "Delete item(s)?"
 msgstr ""
 
-#: include/conversation.php:1334
+#: include/conversation.php:1340
 msgid "Share"
 msgstr ""
 
-#: include/conversation.php:1335 mod/wallmessage.php:143 mod/editpost.php:111
-#: mod/message.php:262 mod/message.php:430
+#: include/conversation.php:1341 mod/editpost.php:111 mod/message.php:262
+#: mod/message.php:430 mod/wallmessage.php:143
 msgid "Upload photo"
 msgstr ""
 
-#: include/conversation.php:1336 mod/editpost.php:112
+#: include/conversation.php:1342 mod/editpost.php:112
 msgid "upload photo"
 msgstr ""
 
-#: include/conversation.php:1337 mod/editpost.php:113
+#: include/conversation.php:1343 mod/editpost.php:113
 msgid "Attach file"
 msgstr ""
 
-#: include/conversation.php:1338 mod/editpost.php:114
+#: include/conversation.php:1344 mod/editpost.php:114
 msgid "attach file"
 msgstr ""
 
-#: include/conversation.php:1339 mod/wallmessage.php:144 mod/editpost.php:115
-#: mod/message.php:263 mod/message.php:431
+#: include/conversation.php:1345 mod/editpost.php:115 mod/message.php:263
+#: mod/message.php:431 mod/wallmessage.php:144
 msgid "Insert web link"
 msgstr ""
 
-#: include/conversation.php:1340 mod/editpost.php:116
+#: include/conversation.php:1346 mod/editpost.php:116
 msgid "web link"
 msgstr ""
 
-#: include/conversation.php:1341 mod/editpost.php:117
+#: include/conversation.php:1347 mod/editpost.php:117
 msgid "Insert video link"
 msgstr ""
 
-#: include/conversation.php:1342 mod/editpost.php:118
+#: include/conversation.php:1348 mod/editpost.php:118
 msgid "video link"
 msgstr ""
 
-#: include/conversation.php:1343 mod/editpost.php:119
+#: include/conversation.php:1349 mod/editpost.php:119
 msgid "Insert audio link"
 msgstr ""
 
-#: include/conversation.php:1344 mod/editpost.php:120
+#: include/conversation.php:1350 mod/editpost.php:120
 msgid "audio link"
 msgstr ""
 
-#: include/conversation.php:1345 mod/editpost.php:121
+#: include/conversation.php:1351 mod/editpost.php:121
 msgid "Set your location"
 msgstr ""
 
-#: include/conversation.php:1346 mod/editpost.php:122
+#: include/conversation.php:1352 mod/editpost.php:122
 msgid "set location"
 msgstr ""
 
-#: include/conversation.php:1347 mod/editpost.php:123
+#: include/conversation.php:1353 mod/editpost.php:123
 msgid "Clear browser location"
 msgstr ""
 
-#: include/conversation.php:1348 mod/editpost.php:124
+#: include/conversation.php:1354 mod/editpost.php:124
 msgid "clear location"
 msgstr ""
 
-#: include/conversation.php:1350 mod/editpost.php:138
+#: include/conversation.php:1356 mod/editpost.php:138
 msgid "Set title"
 msgstr ""
 
-#: include/conversation.php:1352 mod/editpost.php:140
+#: include/conversation.php:1358 mod/editpost.php:140
 msgid "Categories (comma-separated list)"
 msgstr ""
 
-#: include/conversation.php:1354 mod/editpost.php:126
+#: include/conversation.php:1360 mod/editpost.php:126
 msgid "Permission settings"
 msgstr ""
 
-#: include/conversation.php:1355 mod/editpost.php:155
+#: include/conversation.php:1361 mod/editpost.php:155
 msgid "permissions"
 msgstr ""
 
-#: include/conversation.php:1363 mod/editpost.php:135
+#: include/conversation.php:1369 mod/editpost.php:135
 msgid "Public post"
 msgstr ""
 
-#: include/conversation.php:1367 mod/editpost.php:146 mod/photos.php:1492
-#: mod/photos.php:1531 mod/photos.php:1604 mod/events.php:528
-#: src/Object/Post.php:799
+#: include/conversation.php:1373 mod/editpost.php:146 mod/events.php:528
+#: mod/photos.php:1492 mod/photos.php:1531 mod/photos.php:1604
+#: src/Object/Post.php:805
 msgid "Preview"
 msgstr ""
 
-#: include/conversation.php:1371 include/items.php:387 mod/fbrowser.php:103
-#: mod/fbrowser.php:134 mod/suggest.php:41 mod/dfrn_request.php:663
-#: mod/tagrm.php:19 mod/tagrm.php:99 mod/editpost.php:149 mod/message.php:141
-#: mod/photos.php:248 mod/photos.php:324 mod/videos.php:147
-#: mod/unfollow.php:117 mod/settings.php:676 mod/settings.php:702
-#: mod/follow.php:161 mod/contacts.php:475
+#: include/conversation.php:1377 include/items.php:387 mod/contacts.php:475
+#: mod/dfrn_request.php:663 mod/editpost.php:149 mod/fbrowser.php:103
+#: mod/fbrowser.php:134 mod/follow.php:161 mod/message.php:141
+#: mod/photos.php:248 mod/photos.php:324 mod/settings.php:676
+#: mod/settings.php:702 mod/suggest.php:41 mod/tagrm.php:19 mod/tagrm.php:99
+#: mod/unfollow.php:117 mod/videos.php:147
 msgid "Cancel"
 msgstr ""
 
-#: include/conversation.php:1376
+#: include/conversation.php:1382
 msgid "Post to Groups"
 msgstr ""
 
-#: include/conversation.php:1377
+#: include/conversation.php:1383
 msgid "Post to Contacts"
 msgstr ""
 
-#: include/conversation.php:1378
+#: include/conversation.php:1384
 msgid "Private post"
 msgstr ""
 
-#: include/conversation.php:1383 mod/editpost.php:153 src/Model/Profile.php:342
+#: include/conversation.php:1389 mod/editpost.php:153 src/Model/Profile.php:342
 msgid "Message"
 msgstr ""
 
-#: include/conversation.php:1384 mod/editpost.php:154
+#: include/conversation.php:1390 mod/editpost.php:154
 msgid "Browser"
 msgstr ""
 
-#: include/conversation.php:1651
+#: include/conversation.php:1657
 msgid "View all"
 msgstr ""
 
-#: include/conversation.php:1674
+#: include/conversation.php:1680
 msgid "Like"
 msgid_plural "Likes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: include/conversation.php:1677
+#: include/conversation.php:1683
 msgid "Dislike"
 msgid_plural "Dislikes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: include/conversation.php:1683
+#: include/conversation.php:1689
 msgid "Not Attending"
 msgid_plural "Not Attending"
 msgstr[0] ""
 msgstr[1] ""
 
-#: include/conversation.php:1686 src/Content/ContactSelector.php:125
+#: include/conversation.php:1692 src/Content/ContactSelector.php:125
 msgid "Undecided"
 msgid_plural "Undecided"
 msgstr[0] ""
@@ -802,9 +789,9 @@ msgstr ""
 msgid "Please visit %s to approve or reject the request."
 msgstr ""
 
-#: include/items.php:342 mod/notice.php:22 mod/viewsrc.php:21
-#: mod/display.php:72 mod/display.php:252 mod/display.php:354 mod/admin.php:276
-#: mod/admin.php:1854 mod/admin.php:2102
+#: include/items.php:342 mod/admin.php:269 mod/admin.php:1801
+#: mod/admin.php:2049 mod/display.php:72 mod/display.php:252
+#: mod/display.php:354 mod/notice.php:22 mod/viewsrc.php:21
 msgid "Item not found."
 msgstr ""
 
@@ -812,36 +799,36 @@ msgstr ""
 msgid "Do you really want to delete this item?"
 msgstr ""
 
-#: include/items.php:384 mod/api.php:110 mod/suggest.php:38
-#: mod/dfrn_request.php:653 mod/message.php:138 mod/settings.php:1103
-#: mod/settings.php:1109 mod/settings.php:1116 mod/settings.php:1120
-#: mod/settings.php:1124 mod/settings.php:1128 mod/settings.php:1132
-#: mod/settings.php:1136 mod/settings.php:1156 mod/settings.php:1157
+#: include/items.php:384 mod/api.php:110 mod/contacts.php:472
+#: mod/dfrn_request.php:653 mod/follow.php:150 mod/message.php:138
+#: mod/profiles.php:636 mod/profiles.php:639 mod/profiles.php:661
+#: mod/register.php:237 mod/settings.php:1105 mod/settings.php:1111
+#: mod/settings.php:1118 mod/settings.php:1122 mod/settings.php:1126
+#: mod/settings.php:1130 mod/settings.php:1134 mod/settings.php:1138
 #: mod/settings.php:1158 mod/settings.php:1159 mod/settings.php:1160
-#: mod/follow.php:150 mod/profiles.php:636 mod/profiles.php:639
-#: mod/profiles.php:661 mod/contacts.php:472 mod/register.php:237
+#: mod/settings.php:1161 mod/settings.php:1162 mod/suggest.php:38
 msgid "Yes"
 msgstr ""
 
-#: include/items.php:401 mod/allfriends.php:21 mod/api.php:35 mod/api.php:40
-#: mod/attach.php:38 mod/common.php:26 mod/crepair.php:98 mod/nogroup.php:28
-#: mod/repair_ostatus.php:13 mod/suggest.php:60 mod/uimport.php:28
-#: mod/notifications.php:73 mod/dfrn_confirm.php:68 mod/invite.php:20
-#: mod/invite.php:106 mod/wall_attach.php:74 mod/wall_attach.php:77
-#: mod/manage.php:131 mod/regmod.php:108 mod/viewcontacts.php:57
-#: mod/wallmessage.php:16 mod/wallmessage.php:40 mod/wallmessage.php:79
-#: mod/wallmessage.php:103 mod/poke.php:150 mod/wall_upload.php:103
-#: mod/wall_upload.php:106 mod/editpost.php:18 mod/fsuggest.php:80
-#: mod/group.php:26 mod/item.php:160 mod/message.php:59 mod/message.php:104
-#: mod/network.php:32 mod/notes.php:30 mod/photos.php:174 mod/photos.php:1051
-#: mod/delegate.php:25 mod/delegate.php:43 mod/delegate.php:54
-#: mod/dirfind.php:25 mod/ostatus_subscribe.php:16 mod/unfollow.php:15
-#: mod/unfollow.php:57 mod/unfollow.php:90 mod/cal.php:304 mod/events.php:194
-#: mod/profile_photo.php:30 mod/profile_photo.php:176 mod/profile_photo.php:187
-#: mod/profile_photo.php:200 mod/settings.php:43 mod/settings.php:142
-#: mod/settings.php:665 mod/follow.php:17 mod/follow.php:54 mod/follow.php:118
-#: mod/profiles.php:182 mod/profiles.php:606 mod/contacts.php:386
-#: mod/register.php:53 index.php:416
+#: include/items.php:401 index.php:416 mod/allfriends.php:21 mod/api.php:35
+#: mod/api.php:40 mod/attach.php:38 mod/cal.php:304 mod/common.php:26
+#: mod/contacts.php:386 mod/crepair.php:98 mod/delegate.php:25
+#: mod/delegate.php:43 mod/delegate.php:54 mod/dfrn_confirm.php:68
+#: mod/dirfind.php:25 mod/editpost.php:18 mod/events.php:194 mod/follow.php:17
+#: mod/follow.php:54 mod/follow.php:118 mod/fsuggest.php:80 mod/group.php:26
+#: mod/invite.php:20 mod/invite.php:106 mod/item.php:160 mod/manage.php:131
+#: mod/message.php:59 mod/message.php:104 mod/network.php:32 mod/nogroup.php:28
+#: mod/notes.php:30 mod/notifications.php:73 mod/ostatus_subscribe.php:16
+#: mod/photos.php:174 mod/photos.php:1051 mod/poke.php:150 mod/profiles.php:182
+#: mod/profiles.php:606 mod/profile_photo.php:30 mod/profile_photo.php:176
+#: mod/profile_photo.php:187 mod/profile_photo.php:200 mod/register.php:53
+#: mod/regmod.php:108 mod/repair_ostatus.php:13 mod/settings.php:42
+#: mod/settings.php:141 mod/settings.php:665 mod/suggest.php:60
+#: mod/uimport.php:28 mod/unfollow.php:15 mod/unfollow.php:57
+#: mod/unfollow.php:90 mod/viewcontacts.php:57 mod/wallmessage.php:16
+#: mod/wallmessage.php:40 mod/wallmessage.php:79 mod/wallmessage.php:103
+#: mod/wall_attach.php:74 mod/wall_attach.php:77 mod/wall_upload.php:103
+#: mod/wall_upload.php:106
 msgid "Permission denied."
 msgstr ""
 
@@ -849,10 +836,28 @@ msgstr ""
 msgid "Archives"
 msgstr ""
 
-#: include/items.php:477 src/Content/ForumManager.php:130
-#: src/Content/Widget.php:312 src/Object/Post.php:424 src/App.php:512
+#: include/items.php:477 src/App.php:512 src/Content/ForumManager.php:130
+#: src/Content/Widget.php:312 src/Object/Post.php:430
 #: view/theme/vier/theme.php:259
 msgid "show more"
+msgstr ""
+
+#: include/security.php:81
+msgid "Welcome "
+msgstr ""
+
+#: include/security.php:82
+msgid "Please upload a profile photo."
+msgstr ""
+
+#: include/security.php:84
+msgid "Welcome back "
+msgstr ""
+
+#: include/security.php:431
+msgid ""
+"The form security token was not correct. This probably happened because the "
+"form has been opened for too long (>3 hours) before submitting it."
 msgstr ""
 
 #: include/text.php:302
@@ -902,7 +907,7 @@ msgstr[1] ""
 msgid "View Contacts"
 msgstr ""
 
-#: include/text.php:1010 mod/filer.php:35 mod/editpost.php:110 mod/notes.php:67
+#: include/text.php:1010 mod/editpost.php:110 mod/filer.php:35 mod/notes.php:67
 msgid "Save"
 msgstr ""
 
@@ -927,8 +932,8 @@ msgstr ""
 msgid "Tags"
 msgstr ""
 
-#: include/text.php:1027 mod/viewcontacts.php:131 mod/contacts.php:814
-#: mod/contacts.php:875 src/Content/Nav.php:147 src/Content/Nav.php:212
+#: include/text.php:1027 mod/contacts.php:814 mod/contacts.php:875
+#: mod/viewcontacts.php:131 src/Content/Nav.php:147 src/Content/Nav.php:212
 #: src/Model/Profile.php:957 src/Model/Profile.php:960
 #: view/theme/frio/theme.php:270
 msgid "Contacts"
@@ -987,7 +992,7 @@ msgstr ""
 msgid "rebuffed"
 msgstr ""
 
-#: include/text.php:1093 mod/settings.php:941 src/Model/Event.php:379
+#: include/text.php:1093 mod/settings.php:943 src/Model/Event.php:379
 msgid "Monday"
 msgstr ""
 
@@ -1011,7 +1016,7 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
-#: include/text.php:1093 mod/settings.php:941 src/Model/Event.php:378
+#: include/text.php:1093 mod/settings.php:943 src/Model/Event.php:378
 msgid "Sunday"
 msgstr ""
 
@@ -1132,54 +1137,1806 @@ msgstr ""
 msgid "Dec"
 msgstr ""
 
-#: include/text.php:1324 mod/videos.php:380
+#: include/text.php:1275
+#, php-format
+msgid "Content warning: %s"
+msgstr ""
+
+#: include/text.php:1345 mod/videos.php:380
 msgid "View Video"
 msgstr ""
 
-#: include/text.php:1341
+#: include/text.php:1362
 msgid "bytes"
 msgstr ""
 
-#: include/text.php:1374 include/text.php:1385
+#: include/text.php:1395 include/text.php:1406 include/text.php:1442
 msgid "Click to open/close"
 msgstr ""
 
-#: include/text.php:1509
+#: include/text.php:1559
 msgid "View on separate page"
 msgstr ""
 
-#: include/text.php:1510
+#: include/text.php:1560
 msgid "view on separate page"
 msgstr ""
 
-#: include/text.php:1515 include/text.php:1522 src/Model/Event.php:594
+#: include/text.php:1565 include/text.php:1572 src/Model/Event.php:594
 msgid "link to source"
 msgstr ""
 
-#: include/text.php:1728
+#: include/text.php:1778
 msgid "activity"
 msgstr ""
 
-#: include/text.php:1730 src/Object/Post.php:423 src/Object/Post.php:435
+#: include/text.php:1780 src/Object/Post.php:429 src/Object/Post.php:441
 msgid "comment"
 msgid_plural "comments"
 msgstr[0] ""
 msgstr[1] ""
 
-#: include/text.php:1733
+#: include/text.php:1783
 msgid "post"
 msgstr ""
 
-#: include/text.php:1890
+#: include/text.php:1940
 msgid "Item filed"
+msgstr ""
+
+#: index.php:245 mod/apps.php:14
+msgid "You must be logged in to use addons. "
+msgstr ""
+
+#: index.php:292 mod/fetch.php:16 mod/fetch.php:52 mod/fetch.php:65
+#: mod/help.php:60 mod/p.php:21 mod/p.php:48 mod/p.php:57
+msgid "Not Found"
+msgstr ""
+
+#: index.php:297 mod/help.php:63
+msgid "Page not found."
+msgstr ""
+
+#: index.php:415 mod/group.php:83 mod/profperm.php:28
+msgid "Permission denied"
+msgstr ""
+
+#: index.php:444
+msgid "toggle mobile"
+msgstr ""
+
+#: mod/admin.php:106
+msgid "Theme settings updated."
+msgstr ""
+
+#: mod/admin.php:176 src/Content/Nav.php:174
+msgid "Information"
+msgstr ""
+
+#: mod/admin.php:177
+msgid "Overview"
+msgstr ""
+
+#: mod/admin.php:178 mod/admin.php:667
+msgid "Federation Statistics"
+msgstr ""
+
+#: mod/admin.php:179
+msgid "Configuration"
+msgstr ""
+
+#: mod/admin.php:180 mod/admin.php:1294
+msgid "Site"
+msgstr ""
+
+#: mod/admin.php:181 mod/admin.php:1222 mod/admin.php:1735 mod/admin.php:1751
+msgid "Users"
+msgstr ""
+
+#: mod/admin.php:182 mod/admin.php:1851 mod/admin.php:1911 mod/settings.php:86
+msgid "Addons"
+msgstr ""
+
+#: mod/admin.php:183 mod/admin.php:2120 mod/admin.php:2164
+msgid "Themes"
+msgstr ""
+
+#: mod/admin.php:184 mod/settings.php:64
+msgid "Additional features"
+msgstr ""
+
+#: mod/admin.php:185
+msgid "Database"
+msgstr ""
+
+#: mod/admin.php:186
+msgid "DB updates"
+msgstr ""
+
+#: mod/admin.php:187 mod/admin.php:702
+msgid "Inspect Queue"
+msgstr ""
+
+#: mod/admin.php:188
+msgid "Tools"
+msgstr ""
+
+#: mod/admin.php:189
+msgid "Contact Blocklist"
+msgstr ""
+
+#: mod/admin.php:190 mod/admin.php:311
+msgid "Server Blocklist"
+msgstr ""
+
+#: mod/admin.php:191 mod/admin.php:470
+msgid "Delete Item"
+msgstr ""
+
+#: mod/admin.php:192 mod/admin.php:193 mod/admin.php:2238
+msgid "Logs"
+msgstr ""
+
+#: mod/admin.php:194 mod/admin.php:2305
+msgid "View Logs"
+msgstr ""
+
+#: mod/admin.php:196
+msgid "Diagnostics"
+msgstr ""
+
+#: mod/admin.php:197
+msgid "PHP Info"
+msgstr ""
+
+#: mod/admin.php:198
+msgid "probe address"
+msgstr ""
+
+#: mod/admin.php:199
+msgid "check webfinger"
+msgstr ""
+
+#: mod/admin.php:218 src/Content/Nav.php:217
+msgid "Admin"
+msgstr ""
+
+#: mod/admin.php:219
+msgid "Addon Features"
+msgstr ""
+
+#: mod/admin.php:220
+msgid "User registrations waiting for confirmation"
+msgstr ""
+
+#: mod/admin.php:302 mod/admin.php:320 mod/dfrn_request.php:351
+#: mod/friendica.php:123 src/Model/Contact.php:1228
+msgid "Blocked domain"
+msgstr ""
+
+#: mod/admin.php:302
+msgid "The blocked domain"
+msgstr ""
+
+#: mod/admin.php:303 mod/admin.php:321 mod/friendica.php:123
+msgid "Reason for the block"
+msgstr ""
+
+#: mod/admin.php:303 mod/admin.php:316
+msgid "The reason why you blocked this domain."
+msgstr ""
+
+#: mod/admin.php:304
+msgid "Delete domain"
+msgstr ""
+
+#: mod/admin.php:304
+msgid "Check to delete this entry from the blocklist"
+msgstr ""
+
+#: mod/admin.php:310 mod/admin.php:427 mod/admin.php:469 mod/admin.php:666
+#: mod/admin.php:701 mod/admin.php:797 mod/admin.php:1293 mod/admin.php:1734
+#: mod/admin.php:1850 mod/admin.php:1910 mod/admin.php:2119 mod/admin.php:2163
+#: mod/admin.php:2237 mod/admin.php:2304
+msgid "Administration"
+msgstr ""
+
+#: mod/admin.php:312
+msgid ""
+"This page can be used to define a black list of servers from the federated "
+"network that are not allowed to interact with your node. For all entered "
+"domains you should also give a reason why you have blocked the remote server."
+msgstr ""
+
+#: mod/admin.php:313
+msgid ""
+"The list of blocked servers will be made publically available on the /"
+"friendica page so that your users and people investigating communication "
+"problems can find the reason easily."
+msgstr ""
+
+#: mod/admin.php:314
+msgid "Add new entry to block list"
+msgstr ""
+
+#: mod/admin.php:315
+msgid "Server Domain"
+msgstr ""
+
+#: mod/admin.php:315
+msgid ""
+"The domain of the new server to add to the block list. Do not include the "
+"protocol."
+msgstr ""
+
+#: mod/admin.php:316
+msgid "Block reason"
+msgstr ""
+
+#: mod/admin.php:317
+msgid "Add Entry"
+msgstr ""
+
+#: mod/admin.php:318
+msgid "Save changes to the blocklist"
+msgstr ""
+
+#: mod/admin.php:319
+msgid "Current Entries in the Blocklist"
+msgstr ""
+
+#: mod/admin.php:322
+msgid "Delete entry from blocklist"
+msgstr ""
+
+#: mod/admin.php:325
+msgid "Delete entry from blocklist?"
+msgstr ""
+
+#: mod/admin.php:351
+msgid "Server added to blocklist."
+msgstr ""
+
+#: mod/admin.php:367
+msgid "Site blocklist updated."
+msgstr ""
+
+#: mod/admin.php:390 src/Core/Console/GlobalCommunityBlock.php:72
+msgid "The contact has been blocked from the node"
+msgstr ""
+
+#: mod/admin.php:392 src/Core/Console/GlobalCommunityBlock.php:69
+#, php-format
+msgid "Could not find any contact entry for this URL (%s)"
+msgstr ""
+
+#: mod/admin.php:399
+#, php-format
+msgid "%s contact unblocked"
+msgid_plural "%s contacts unblocked"
+msgstr[0] ""
+msgstr[1] ""
+
+#: mod/admin.php:428
+msgid "Remote Contact Blocklist"
+msgstr ""
+
+#: mod/admin.php:429
+msgid ""
+"This page allows you to prevent any message from a remote contact to reach "
+"your node."
+msgstr ""
+
+#: mod/admin.php:430
+msgid "Block Remote Contact"
+msgstr ""
+
+#: mod/admin.php:431 mod/admin.php:1737
+msgid "select all"
+msgstr ""
+
+#: mod/admin.php:432
+msgid "select none"
+msgstr ""
+
+#: mod/admin.php:433 mod/admin.php:1746 mod/contacts.php:637
+#: mod/contacts.php:827 mod/contacts.php:1011
+msgid "Block"
+msgstr ""
+
+#: mod/admin.php:434 mod/admin.php:1747 mod/contacts.php:637
+#: mod/contacts.php:827 mod/contacts.php:1011
+msgid "Unblock"
+msgstr ""
+
+#: mod/admin.php:435
+msgid "No remote contact is blocked from this node."
+msgstr ""
+
+#: mod/admin.php:437
+msgid "Blocked Remote Contacts"
+msgstr ""
+
+#: mod/admin.php:438
+msgid "Block New Remote Contact"
+msgstr ""
+
+#: mod/admin.php:439
+msgid "Photo"
+msgstr ""
+
+#: mod/admin.php:439 mod/admin.php:1728 mod/admin.php:1740 mod/admin.php:1753
+#: mod/admin.php:1769 mod/crepair.php:158 mod/settings.php:677
+#: mod/settings.php:703
+msgid "Name"
+msgstr ""
+
+#: mod/admin.php:439 mod/profiles.php:394
+msgid "Address"
+msgstr ""
+
+#: mod/admin.php:439 mod/admin.php:449 mod/contacts.php:656 mod/follow.php:166
+#: mod/notifications.php:258 mod/unfollow.php:122
+msgid "Profile URL"
+msgstr ""
+
+#: mod/admin.php:447
+#, php-format
+msgid "%s total blocked contact"
+msgid_plural "%s total blocked contacts"
+msgstr[0] ""
+msgstr[1] ""
+
+#: mod/admin.php:449
+msgid "URL of the remote contact to block."
+msgstr ""
+
+#: mod/admin.php:471
+msgid "Delete this Item"
+msgstr ""
+
+#: mod/admin.php:472
+msgid ""
+"On this page you can delete an item from your node. If the item is a top "
+"level posting, the entire thread will be deleted."
+msgstr ""
+
+#: mod/admin.php:473
+msgid ""
+"You need to know the GUID of the item. You can find it e.g. by looking at "
+"the display URL. The last part of http://example.com/display/123456 is the "
+"GUID, here 123456."
+msgstr ""
+
+#: mod/admin.php:474
+msgid "GUID"
+msgstr ""
+
+#: mod/admin.php:474
+msgid "The GUID of the item you want to delete."
+msgstr ""
+
+#: mod/admin.php:513
+msgid "Item marked for deletion."
+msgstr ""
+
+#: mod/admin.php:584
+msgid "unknown"
+msgstr ""
+
+#: mod/admin.php:660
+msgid ""
+"This page offers you some numbers to the known part of the federated social "
+"network your Friendica node is part of. These numbers are not complete but "
+"only reflect the part of the network your node is aware of."
+msgstr ""
+
+#: mod/admin.php:661
+msgid ""
+"The <em>Auto Discovered Contact Directory</em> feature is not enabled, it "
+"will improve the data displayed here."
+msgstr ""
+
+#: mod/admin.php:673
+#, php-format
+msgid ""
+"Currently this node is aware of %d nodes with %d registered users from the "
+"following platforms:"
+msgstr ""
+
+#: mod/admin.php:704
+msgid "ID"
+msgstr ""
+
+#: mod/admin.php:705
+msgid "Recipient Name"
+msgstr ""
+
+#: mod/admin.php:706
+msgid "Recipient Profile"
+msgstr ""
+
+#: mod/admin.php:707 src/Content/Nav.php:178
+#: src/Core/NotificationsManager.php:178 view/theme/frio/theme.php:266
+msgid "Network"
+msgstr ""
+
+#: mod/admin.php:708
+msgid "Created"
+msgstr ""
+
+#: mod/admin.php:709
+msgid "Last Tried"
+msgstr ""
+
+#: mod/admin.php:710
+msgid ""
+"This page lists the content of the queue for outgoing postings. These are "
+"postings the initial delivery failed for. They will be resend later and "
+"eventually deleted if the delivery fails permanently."
+msgstr ""
+
+#: mod/admin.php:734
+#, php-format
+msgid ""
+"Your DB still runs with MyISAM tables. You should change the engine type to "
+"InnoDB. As Friendica will use InnoDB only features in the future, you should "
+"change this! See <a href=\"%s\">here</a> for a guide that may be helpful "
+"converting the table engines. You may also use the command <tt>php bin/"
+"console.php dbstructure toinnodb</tt> of your Friendica installation for an "
+"automatic conversion.<br />"
+msgstr ""
+
+#: mod/admin.php:741
+#, php-format
+msgid ""
+"There is a new version of Friendica available for download. Your current "
+"version is %1$s, upstream version is %2$s"
+msgstr ""
+
+#: mod/admin.php:751
+msgid ""
+"The database update failed. Please run \"php bin/console.php dbstructure "
+"update\" from the command line and have a look at the errors that might "
+"appear."
+msgstr ""
+
+#: mod/admin.php:757
+msgid "The worker was never executed. Please check your database structure!"
+msgstr ""
+
+#: mod/admin.php:760
+#, php-format
+msgid ""
+"The last worker execution was on %s UTC. This is older than one hour. Please "
+"check your crontab settings."
+msgstr ""
+
+#: mod/admin.php:765 mod/admin.php:1686
+msgid "Normal Account"
+msgstr ""
+
+#: mod/admin.php:766 mod/admin.php:1687
+msgid "Automatic Follower Account"
+msgstr ""
+
+#: mod/admin.php:767 mod/admin.php:1688
+msgid "Public Forum Account"
+msgstr ""
+
+#: mod/admin.php:768 mod/admin.php:1689
+msgid "Automatic Friend Account"
+msgstr ""
+
+#: mod/admin.php:769
+msgid "Blog Account"
+msgstr ""
+
+#: mod/admin.php:770
+msgid "Private Forum Account"
+msgstr ""
+
+#: mod/admin.php:792
+msgid "Message queues"
+msgstr ""
+
+#: mod/admin.php:798
+msgid "Summary"
+msgstr ""
+
+#: mod/admin.php:800
+msgid "Registered users"
+msgstr ""
+
+#: mod/admin.php:802
+msgid "Pending registrations"
+msgstr ""
+
+#: mod/admin.php:803
+msgid "Version"
+msgstr ""
+
+#: mod/admin.php:808
+msgid "Active addons"
+msgstr ""
+
+#: mod/admin.php:839
+msgid "Can not parse base url. Must have at least <scheme>://<domain>"
+msgstr ""
+
+#: mod/admin.php:1158
+msgid "Site settings updated."
+msgstr ""
+
+#: mod/admin.php:1185 mod/settings.php:905
+msgid "No special theme for mobile devices"
+msgstr ""
+
+#: mod/admin.php:1214
+msgid "No community page"
+msgstr ""
+
+#: mod/admin.php:1215
+msgid "Public postings from users of this site"
+msgstr ""
+
+#: mod/admin.php:1216
+msgid "Public postings from the federated network"
+msgstr ""
+
+#: mod/admin.php:1217
+msgid "Public postings from local users and the federated network"
+msgstr ""
+
+#: mod/admin.php:1221 mod/admin.php:1384 mod/admin.php:1394
+#: mod/contacts.php:572
+msgid "Disabled"
+msgstr ""
+
+#: mod/admin.php:1223
+msgid "Users, Global Contacts"
+msgstr ""
+
+#: mod/admin.php:1224
+msgid "Users, Global Contacts/fallback"
+msgstr ""
+
+#: mod/admin.php:1228
+msgid "One month"
+msgstr ""
+
+#: mod/admin.php:1229
+msgid "Three months"
+msgstr ""
+
+#: mod/admin.php:1230
+msgid "Half a year"
+msgstr ""
+
+#: mod/admin.php:1231
+msgid "One year"
+msgstr ""
+
+#: mod/admin.php:1236
+msgid "Multi user instance"
+msgstr ""
+
+#: mod/admin.php:1259
+msgid "Closed"
+msgstr ""
+
+#: mod/admin.php:1260
+msgid "Requires approval"
+msgstr ""
+
+#: mod/admin.php:1261
+msgid "Open"
+msgstr ""
+
+#: mod/admin.php:1265
+msgid "No SSL policy, links will track page SSL state"
+msgstr ""
+
+#: mod/admin.php:1266
+msgid "Force all links to use SSL"
+msgstr ""
+
+#: mod/admin.php:1267
+msgid "Self-signed certificate, use SSL for local links only (discouraged)"
+msgstr ""
+
+#: mod/admin.php:1271
+msgid "Don't check"
+msgstr ""
+
+#: mod/admin.php:1272
+msgid "check the stable version"
+msgstr ""
+
+#: mod/admin.php:1273
+msgid "check the development version"
+msgstr ""
+
+#: mod/admin.php:1295 mod/admin.php:1912 mod/admin.php:2165 mod/admin.php:2239
+#: mod/admin.php:2386 mod/delegate.php:168 mod/settings.php:675
+#: mod/settings.php:784 mod/settings.php:872 mod/settings.php:961
+#: mod/settings.php:1194
+msgid "Save Settings"
+msgstr ""
+
+#: mod/admin.php:1296
+msgid "Republish users to directory"
+msgstr ""
+
+#: mod/admin.php:1297 mod/register.php:264
+msgid "Registration"
+msgstr ""
+
+#: mod/admin.php:1298
+msgid "File upload"
+msgstr ""
+
+#: mod/admin.php:1299
+msgid "Policies"
+msgstr ""
+
+#: mod/admin.php:1300 mod/contacts.php:895 mod/events.php:532
+#: src/Model/Profile.php:865
+msgid "Advanced"
+msgstr ""
+
+#: mod/admin.php:1301
+msgid "Auto Discovered Contact Directory"
+msgstr ""
+
+#: mod/admin.php:1302
+msgid "Performance"
+msgstr ""
+
+#: mod/admin.php:1303
+msgid "Worker"
+msgstr ""
+
+#: mod/admin.php:1304
+msgid "Message Relay"
+msgstr ""
+
+#: mod/admin.php:1305
+msgid ""
+"Relocate - WARNING: advanced function. Could make this server unreachable."
+msgstr ""
+
+#: mod/admin.php:1308
+msgid "Site name"
+msgstr ""
+
+#: mod/admin.php:1309
+msgid "Host name"
+msgstr ""
+
+#: mod/admin.php:1310
+msgid "Sender Email"
+msgstr ""
+
+#: mod/admin.php:1310
+msgid ""
+"The email address your server shall use to send notification emails from."
+msgstr ""
+
+#: mod/admin.php:1311
+msgid "Banner/Logo"
+msgstr ""
+
+#: mod/admin.php:1312
+msgid "Shortcut icon"
+msgstr ""
+
+#: mod/admin.php:1312
+msgid "Link to an icon that will be used for browsers."
+msgstr ""
+
+#: mod/admin.php:1313
+msgid "Touch icon"
+msgstr ""
+
+#: mod/admin.php:1313
+msgid "Link to an icon that will be used for tablets and mobiles."
+msgstr ""
+
+#: mod/admin.php:1314
+msgid "Additional Info"
+msgstr ""
+
+#: mod/admin.php:1314
+#, php-format
+msgid ""
+"For public servers: you can add additional information here that will be "
+"listed at %s/servers."
+msgstr ""
+
+#: mod/admin.php:1315
+msgid "System language"
+msgstr ""
+
+#: mod/admin.php:1316
+msgid "System theme"
+msgstr ""
+
+#: mod/admin.php:1316
+msgid ""
+"Default system theme - may be over-ridden by user profiles - <a href='#' "
+"id='cnftheme'>change theme settings</a>"
+msgstr ""
+
+#: mod/admin.php:1317
+msgid "Mobile system theme"
+msgstr ""
+
+#: mod/admin.php:1317
+msgid "Theme for mobile devices"
+msgstr ""
+
+#: mod/admin.php:1318
+msgid "SSL link policy"
+msgstr ""
+
+#: mod/admin.php:1318
+msgid "Determines whether generated links should be forced to use SSL"
+msgstr ""
+
+#: mod/admin.php:1319
+msgid "Force SSL"
+msgstr ""
+
+#: mod/admin.php:1319
+msgid ""
+"Force all Non-SSL requests to SSL - Attention: on some systems it could lead "
+"to endless loops."
+msgstr ""
+
+#: mod/admin.php:1320
+msgid "Hide help entry from navigation menu"
+msgstr ""
+
+#: mod/admin.php:1320
+msgid ""
+"Hides the menu entry for the Help pages from the navigation menu. You can "
+"still access it calling /help directly."
+msgstr ""
+
+#: mod/admin.php:1321
+msgid "Single user instance"
+msgstr ""
+
+#: mod/admin.php:1321
+msgid "Make this instance multi-user or single-user for the named user"
+msgstr ""
+
+#: mod/admin.php:1322
+msgid "Maximum image size"
+msgstr ""
+
+#: mod/admin.php:1322
+msgid ""
+"Maximum size in bytes of uploaded images. Default is 0, which means no "
+"limits."
+msgstr ""
+
+#: mod/admin.php:1323
+msgid "Maximum image length"
+msgstr ""
+
+#: mod/admin.php:1323
+msgid ""
+"Maximum length in pixels of the longest side of uploaded images. Default is "
+"-1, which means no limits."
+msgstr ""
+
+#: mod/admin.php:1324
+msgid "JPEG image quality"
+msgstr ""
+
+#: mod/admin.php:1324
+msgid ""
+"Uploaded JPEGS will be saved at this quality setting [0-100]. Default is "
+"100, which is full quality."
+msgstr ""
+
+#: mod/admin.php:1326
+msgid "Register policy"
+msgstr ""
+
+#: mod/admin.php:1327
+msgid "Maximum Daily Registrations"
+msgstr ""
+
+#: mod/admin.php:1327
+msgid ""
+"If registration is permitted above, this sets the maximum number of new user "
+"registrations to accept per day.  If register is set to closed, this setting "
+"has no effect."
+msgstr ""
+
+#: mod/admin.php:1328
+msgid "Register text"
+msgstr ""
+
+#: mod/admin.php:1328
+msgid "Will be displayed prominently on the registration page."
+msgstr ""
+
+#: mod/admin.php:1329
+msgid "Accounts abandoned after x days"
+msgstr ""
+
+#: mod/admin.php:1329
+msgid ""
+"Will not waste system resources polling external sites for abandonded "
+"accounts. Enter 0 for no time limit."
+msgstr ""
+
+#: mod/admin.php:1330
+msgid "Allowed friend domains"
+msgstr ""
+
+#: mod/admin.php:1330
+msgid ""
+"Comma separated list of domains which are allowed to establish friendships "
+"with this site. Wildcards are accepted. Empty to allow any domains"
+msgstr ""
+
+#: mod/admin.php:1331
+msgid "Allowed email domains"
+msgstr ""
+
+#: mod/admin.php:1331
+msgid ""
+"Comma separated list of domains which are allowed in email addresses for "
+"registrations to this site. Wildcards are accepted. Empty to allow any "
+"domains"
+msgstr ""
+
+#: mod/admin.php:1332
+msgid "No OEmbed rich content"
+msgstr ""
+
+#: mod/admin.php:1332
+msgid ""
+"Don't show the rich content (e.g. embedded PDF), except from the domains "
+"listed below."
+msgstr ""
+
+#: mod/admin.php:1333
+msgid "Allowed OEmbed domains"
+msgstr ""
+
+#: mod/admin.php:1333
+msgid ""
+"Comma separated list of domains which oembed content is allowed to be "
+"displayed. Wildcards are accepted."
+msgstr ""
+
+#: mod/admin.php:1334
+msgid "Block public"
+msgstr ""
+
+#: mod/admin.php:1334
+msgid ""
+"Check to block public access to all otherwise public personal pages on this "
+"site unless you are currently logged in."
+msgstr ""
+
+#: mod/admin.php:1335
+msgid "Force publish"
+msgstr ""
+
+#: mod/admin.php:1335
+msgid ""
+"Check to force all profiles on this site to be listed in the site directory."
+msgstr ""
+
+#: mod/admin.php:1336
+msgid "Global directory URL"
+msgstr ""
+
+#: mod/admin.php:1336
+msgid ""
+"URL to the global directory. If this is not set, the global directory is "
+"completely unavailable to the application."
+msgstr ""
+
+#: mod/admin.php:1337
+msgid "Private posts by default for new users"
+msgstr ""
+
+#: mod/admin.php:1337
+msgid ""
+"Set default post permissions for all new members to the default privacy "
+"group rather than public."
+msgstr ""
+
+#: mod/admin.php:1338
+msgid "Don't include post content in email notifications"
+msgstr ""
+
+#: mod/admin.php:1338
+msgid ""
+"Don't include the content of a post/comment/private message/etc. in the "
+"email notifications that are sent out from this site, as a privacy measure."
+msgstr ""
+
+#: mod/admin.php:1339
+msgid "Disallow public access to addons listed in the apps menu."
+msgstr ""
+
+#: mod/admin.php:1339
+msgid ""
+"Checking this box will restrict addons listed in the apps menu to members "
+"only."
+msgstr ""
+
+#: mod/admin.php:1340
+msgid "Don't embed private images in posts"
+msgstr ""
+
+#: mod/admin.php:1340
+msgid ""
+"Don't replace locally-hosted private photos in posts with an embedded copy "
+"of the image. This means that contacts who receive posts containing private "
+"photos will have to authenticate and load each image, which may take a while."
+msgstr ""
+
+#: mod/admin.php:1341
+msgid "Allow Users to set remote_self"
+msgstr ""
+
+#: mod/admin.php:1341
+msgid ""
+"With checking this, every user is allowed to mark every contact as a "
+"remote_self in the repair contact dialog. Setting this flag on a contact "
+"causes mirroring every posting of that contact in the users stream."
+msgstr ""
+
+#: mod/admin.php:1342
+msgid "Block multiple registrations"
+msgstr ""
+
+#: mod/admin.php:1342
+msgid "Disallow users to register additional accounts for use as pages."
+msgstr ""
+
+#: mod/admin.php:1343
+msgid "OpenID support"
+msgstr ""
+
+#: mod/admin.php:1343
+msgid "OpenID support for registration and logins."
+msgstr ""
+
+#: mod/admin.php:1344
+msgid "Fullname check"
+msgstr ""
+
+#: mod/admin.php:1344
+msgid ""
+"Force users to register with a space between firstname and lastname in Full "
+"name, as an antispam measure"
+msgstr ""
+
+#: mod/admin.php:1345
+msgid "Community pages for visitors"
+msgstr ""
+
+#: mod/admin.php:1345
+msgid ""
+"Which community pages should be available for visitors. Local users always "
+"see both pages."
+msgstr ""
+
+#: mod/admin.php:1346
+msgid "Posts per user on community page"
+msgstr ""
+
+#: mod/admin.php:1346
+msgid ""
+"The maximum number of posts per user on the community page. (Not valid for "
+"'Global Community')"
+msgstr ""
+
+#: mod/admin.php:1347
+msgid "Enable OStatus support"
+msgstr ""
+
+#: mod/admin.php:1347
+msgid ""
+"Provide built-in OStatus (StatusNet, GNU Social etc.) compatibility. All "
+"communications in OStatus are public, so privacy warnings will be "
+"occasionally displayed."
+msgstr ""
+
+#: mod/admin.php:1348
+msgid "Only import OStatus threads from our contacts"
+msgstr ""
+
+#: mod/admin.php:1348
+msgid ""
+"Normally we import every content from our OStatus contacts. With this option "
+"we only store threads that are started by a contact that is known on our "
+"system."
+msgstr ""
+
+#: mod/admin.php:1349
+msgid "OStatus support can only be enabled if threading is enabled."
+msgstr ""
+
+#: mod/admin.php:1351
+msgid ""
+"Diaspora support can't be enabled because Friendica was installed into a sub "
+"directory."
+msgstr ""
+
+#: mod/admin.php:1352
+msgid "Enable Diaspora support"
+msgstr ""
+
+#: mod/admin.php:1352
+msgid "Provide built-in Diaspora network compatibility."
+msgstr ""
+
+#: mod/admin.php:1353
+msgid "Only allow Friendica contacts"
+msgstr ""
+
+#: mod/admin.php:1353
+msgid ""
+"All contacts must use Friendica protocols. All other built-in communication "
+"protocols disabled."
+msgstr ""
+
+#: mod/admin.php:1354
+msgid "Verify SSL"
+msgstr ""
+
+#: mod/admin.php:1354
+msgid ""
+"If you wish, you can turn on strict certificate checking. This will mean you "
+"cannot connect (at all) to self-signed SSL sites."
+msgstr ""
+
+#: mod/admin.php:1355
+msgid "Proxy user"
+msgstr ""
+
+#: mod/admin.php:1356
+msgid "Proxy URL"
+msgstr ""
+
+#: mod/admin.php:1357
+msgid "Network timeout"
+msgstr ""
+
+#: mod/admin.php:1357
+msgid "Value is in seconds. Set to 0 for unlimited (not recommended)."
+msgstr ""
+
+#: mod/admin.php:1358
+msgid "Maximum Load Average"
+msgstr ""
+
+#: mod/admin.php:1358
+msgid ""
+"Maximum system load before delivery and poll processes are deferred - "
+"default 50."
+msgstr ""
+
+#: mod/admin.php:1359
+msgid "Maximum Load Average (Frontend)"
+msgstr ""
+
+#: mod/admin.php:1359
+msgid "Maximum system load before the frontend quits service - default 50."
+msgstr ""
+
+#: mod/admin.php:1360
+msgid "Minimal Memory"
+msgstr ""
+
+#: mod/admin.php:1360
+msgid ""
+"Minimal free memory in MB for the worker. Needs access to /proc/meminfo - "
+"default 0 (deactivated)."
+msgstr ""
+
+#: mod/admin.php:1361
+msgid "Maximum table size for optimization"
+msgstr ""
+
+#: mod/admin.php:1361
+msgid ""
+"Maximum table size (in MB) for the automatic optimization - default 100 MB. "
+"Enter -1 to disable it."
+msgstr ""
+
+#: mod/admin.php:1362
+msgid "Minimum level of fragmentation"
+msgstr ""
+
+#: mod/admin.php:1362
+msgid ""
+"Minimum fragmenation level to start the automatic optimization - default "
+"value is 30%."
+msgstr ""
+
+#: mod/admin.php:1364
+msgid "Periodical check of global contacts"
+msgstr ""
+
+#: mod/admin.php:1364
+msgid ""
+"If enabled, the global contacts are checked periodically for missing or "
+"outdated data and the vitality of the contacts and servers."
+msgstr ""
+
+#: mod/admin.php:1365
+msgid "Days between requery"
+msgstr ""
+
+#: mod/admin.php:1365
+msgid "Number of days after which a server is requeried for his contacts."
+msgstr ""
+
+#: mod/admin.php:1366
+msgid "Discover contacts from other servers"
+msgstr ""
+
+#: mod/admin.php:1366
+msgid ""
+"Periodically query other servers for contacts. You can choose between "
+"'users': the users on the remote system, 'Global Contacts': active contacts "
+"that are known on the system. The fallback is meant for Redmatrix servers "
+"and older friendica servers, where global contacts weren't available. The "
+"fallback increases the server load, so the recommened setting is 'Users, "
+"Global Contacts'."
+msgstr ""
+
+#: mod/admin.php:1367
+msgid "Timeframe for fetching global contacts"
+msgstr ""
+
+#: mod/admin.php:1367
+msgid ""
+"When the discovery is activated, this value defines the timeframe for the "
+"activity of the global contacts that are fetched from other servers."
+msgstr ""
+
+#: mod/admin.php:1368
+msgid "Search the local directory"
+msgstr ""
+
+#: mod/admin.php:1368
+msgid ""
+"Search the local directory instead of the global directory. When searching "
+"locally, every search will be executed on the global directory in the "
+"background. This improves the search results when the search is repeated."
+msgstr ""
+
+#: mod/admin.php:1370
+msgid "Publish server information"
+msgstr ""
+
+#: mod/admin.php:1370
+msgid ""
+"If enabled, general server and usage data will be published. The data "
+"contains the name and version of the server, number of users with public "
+"profiles, number of posts and the activated protocols and connectors. See <a "
+"href='http://the-federation.info/'>the-federation.info</a> for details."
+msgstr ""
+
+#: mod/admin.php:1372
+msgid "Check upstream version"
+msgstr ""
+
+#: mod/admin.php:1372
+msgid ""
+"Enables checking for new Friendica versions at github. If there is a new "
+"version, you will be informed in the admin panel overview."
+msgstr ""
+
+#: mod/admin.php:1373
+msgid "Suppress Tags"
+msgstr ""
+
+#: mod/admin.php:1373
+msgid "Suppress showing a list of hashtags at the end of the posting."
+msgstr ""
+
+#: mod/admin.php:1374
+msgid "Path to item cache"
+msgstr ""
+
+#: mod/admin.php:1374
+msgid "The item caches buffers generated bbcode and external images."
+msgstr ""
+
+#: mod/admin.php:1375
+msgid "Cache duration in seconds"
+msgstr ""
+
+#: mod/admin.php:1375
+msgid ""
+"How long should the cache files be hold? Default value is 86400 seconds (One "
+"day). To disable the item cache, set the value to -1."
+msgstr ""
+
+#: mod/admin.php:1376
+msgid "Maximum numbers of comments per post"
+msgstr ""
+
+#: mod/admin.php:1376
+msgid "How much comments should be shown for each post? Default value is 100."
+msgstr ""
+
+#: mod/admin.php:1377
+msgid "Temp path"
+msgstr ""
+
+#: mod/admin.php:1377
+msgid ""
+"If you have a restricted system where the webserver can't access the system "
+"temp path, enter another path here."
+msgstr ""
+
+#: mod/admin.php:1378
+msgid "Base path to installation"
+msgstr ""
+
+#: mod/admin.php:1378
+msgid ""
+"If the system cannot detect the correct path to your installation, enter the "
+"correct path here. This setting should only be set if you are using a "
+"restricted system and symbolic links to your webroot."
+msgstr ""
+
+#: mod/admin.php:1379
+msgid "Disable picture proxy"
+msgstr ""
+
+#: mod/admin.php:1379
+msgid ""
+"The picture proxy increases performance and privacy. It shouldn't be used on "
+"systems with very low bandwith."
+msgstr ""
+
+#: mod/admin.php:1380
+msgid "Only search in tags"
+msgstr ""
+
+#: mod/admin.php:1380
+msgid "On large systems the text search can slow down the system extremely."
+msgstr ""
+
+#: mod/admin.php:1382
+msgid "New base url"
+msgstr ""
+
+#: mod/admin.php:1382
+msgid ""
+"Change base url for this server. Sends relocate message to all Friendica and "
+"Diaspora* contacts of all users."
+msgstr ""
+
+#: mod/admin.php:1384
+msgid "RINO Encryption"
+msgstr ""
+
+#: mod/admin.php:1384
+msgid "Encryption layer between nodes."
+msgstr ""
+
+#: mod/admin.php:1384
+msgid "Enabled"
+msgstr ""
+
+#: mod/admin.php:1386
+msgid "Maximum number of parallel workers"
+msgstr ""
+
+#: mod/admin.php:1386
+msgid ""
+"On shared hosters set this to 2. On larger systems, values of 10 are great. "
+"Default value is 4."
+msgstr ""
+
+#: mod/admin.php:1387
+msgid "Don't use 'proc_open' with the worker"
+msgstr ""
+
+#: mod/admin.php:1387
+msgid ""
+"Enable this if your system doesn't allow the use of 'proc_open'. This can "
+"happen on shared hosters. If this is enabled you should increase the "
+"frequency of worker calls in your crontab."
+msgstr ""
+
+#: mod/admin.php:1388
+msgid "Enable fastlane"
+msgstr ""
+
+#: mod/admin.php:1388
+msgid ""
+"When enabed, the fastlane mechanism starts an additional worker if processes "
+"with higher priority are blocked by processes of lower priority."
+msgstr ""
+
+#: mod/admin.php:1389
+msgid "Enable frontend worker"
+msgstr ""
+
+#: mod/admin.php:1389
+#, php-format
+msgid ""
+"When enabled the Worker process is triggered when backend access is "
+"performed \\x28e.g. messages being delivered\\x29. On smaller sites you "
+"might want to call %s/worker on a regular basis via an external cron job. "
+"You should only enable this option if you cannot utilize cron/scheduled jobs "
+"on your server."
+msgstr ""
+
+#: mod/admin.php:1391
+msgid "Subscribe to relay"
+msgstr ""
+
+#: mod/admin.php:1391
+msgid ""
+"Enables the receiving of public posts from the relay. They will be included "
+"in the search, subscribed tags and on the global community page."
+msgstr ""
+
+#: mod/admin.php:1392
+msgid "Relay server"
+msgstr ""
+
+#: mod/admin.php:1392
+msgid ""
+"Address of the relay server where public posts should be send to. For "
+"example https://relay.diasp.org"
+msgstr ""
+
+#: mod/admin.php:1393
+msgid "Direct relay transfer"
+msgstr ""
+
+#: mod/admin.php:1393
+msgid ""
+"Enables the direct transfer to other servers without using the relay servers"
+msgstr ""
+
+#: mod/admin.php:1394
+msgid "Relay scope"
+msgstr ""
+
+#: mod/admin.php:1394
+msgid ""
+"Can be 'all' or 'tags'. 'all' means that every public post should be "
+"received. 'tags' means that only posts with selected tags should be received."
+msgstr ""
+
+#: mod/admin.php:1394
+msgid "all"
+msgstr ""
+
+#: mod/admin.php:1394
+msgid "tags"
+msgstr ""
+
+#: mod/admin.php:1395
+msgid "Server tags"
+msgstr ""
+
+#: mod/admin.php:1395
+msgid "Comma separated list of tags for the 'tags' subscription."
+msgstr ""
+
+#: mod/admin.php:1396
+msgid "Allow user tags"
+msgstr ""
+
+#: mod/admin.php:1396
+msgid ""
+"If enabled, the tags from the saved searches will used for the 'tags' "
+"subscription in addition to the 'relay_server_tags'."
+msgstr ""
+
+#: mod/admin.php:1424
+msgid "Update has been marked successful"
+msgstr ""
+
+#: mod/admin.php:1431
+#, php-format
+msgid "Database structure update %s was successfully applied."
+msgstr ""
+
+#: mod/admin.php:1434
+#, php-format
+msgid "Executing of database structure update %s failed with error: %s"
+msgstr ""
+
+#: mod/admin.php:1447
+#, php-format
+msgid "Executing %s failed with error: %s"
+msgstr ""
+
+#: mod/admin.php:1449
+#, php-format
+msgid "Update %s was successfully applied."
+msgstr ""
+
+#: mod/admin.php:1452
+#, php-format
+msgid "Update %s did not return a status. Unknown if it succeeded."
+msgstr ""
+
+#: mod/admin.php:1455
+#, php-format
+msgid "There was no additional update function %s that needed to be called."
+msgstr ""
+
+#: mod/admin.php:1475
+msgid "No failed updates."
+msgstr ""
+
+#: mod/admin.php:1476
+msgid "Check database structure"
+msgstr ""
+
+#: mod/admin.php:1481
+msgid "Failed Updates"
+msgstr ""
+
+#: mod/admin.php:1482
+msgid ""
+"This does not include updates prior to 1139, which did not return a status."
+msgstr ""
+
+#: mod/admin.php:1483
+msgid "Mark success (if update was manually applied)"
+msgstr ""
+
+#: mod/admin.php:1484
+msgid "Attempt to execute this update step automatically"
+msgstr ""
+
+#: mod/admin.php:1523
+#, php-format
+msgid ""
+"\n"
+"\t\t\tDear %1$s,\n"
+"\t\t\t\tthe administrator of %2$s has set up an account for you."
+msgstr ""
+
+#: mod/admin.php:1526
+#, php-format
+msgid ""
+"\n"
+"\t\t\tThe login details are as follows:\n"
+"\n"
+"\t\t\tSite Location:\t%1$s\n"
+"\t\t\tLogin Name:\t\t%2$s\n"
+"\t\t\tPassword:\t\t%3$s\n"
+"\n"
+"\t\t\tYou may change your password from your account \"Settings\" page after "
+"logging\n"
+"\t\t\tin.\n"
+"\n"
+"\t\t\tPlease take a few moments to review the other account settings on that "
+"page.\n"
+"\n"
+"\t\t\tYou may also wish to add some basic information to your default "
+"profile\n"
+"\t\t\t(on the \"Profiles\" page) so that other people can easily find you.\n"
+"\n"
+"\t\t\tWe recommend setting your full name, adding a profile photo,\n"
+"\t\t\tadding some profile \"keywords\" (very useful in making new friends) - "
+"and\n"
+"\t\t\tperhaps what country you live in; if you do not wish to be more "
+"specific\n"
+"\t\t\tthan that.\n"
+"\n"
+"\t\t\tWe fully respect your right to privacy, and none of these items are "
+"necessary.\n"
+"\t\t\tIf you are new and do not know anybody here, they may help\n"
+"\t\t\tyou to make some new and interesting friends.\n"
+"\n"
+"\t\t\tThank you and welcome to %4$s."
+msgstr ""
+
+#: mod/admin.php:1558 src/Model/User.php:647
+#, php-format
+msgid "Registration details for %s"
+msgstr ""
+
+#: mod/admin.php:1568
+#, php-format
+msgid "%s user blocked/unblocked"
+msgid_plural "%s users blocked/unblocked"
+msgstr[0] ""
+msgstr[1] ""
+
+#: mod/admin.php:1574
+#, php-format
+msgid "%s user deleted"
+msgid_plural "%s users deleted"
+msgstr[0] ""
+msgstr[1] ""
+
+#: mod/admin.php:1621
+#, php-format
+msgid "User '%s' deleted"
+msgstr ""
+
+#: mod/admin.php:1629
+#, php-format
+msgid "User '%s' unblocked"
+msgstr ""
+
+#: mod/admin.php:1629
+#, php-format
+msgid "User '%s' blocked"
+msgstr ""
+
+#: mod/admin.php:1728 mod/admin.php:1740 mod/admin.php:1753 mod/admin.php:1771
+#: src/Content/ContactSelector.php:82
+msgid "Email"
+msgstr ""
+
+#: mod/admin.php:1728 mod/admin.php:1753
+msgid "Register date"
+msgstr ""
+
+#: mod/admin.php:1728 mod/admin.php:1753
+msgid "Last login"
+msgstr ""
+
+#: mod/admin.php:1728 mod/admin.php:1753
+msgid "Last item"
+msgstr ""
+
+#: mod/admin.php:1728 mod/settings.php:55
+msgid "Account"
+msgstr ""
+
+#: mod/admin.php:1736
+msgid "Add User"
+msgstr ""
+
+#: mod/admin.php:1738
+msgid "User registrations waiting for confirm"
+msgstr ""
+
+#: mod/admin.php:1739
+msgid "User waiting for permanent deletion"
+msgstr ""
+
+#: mod/admin.php:1740
+msgid "Request date"
+msgstr ""
+
+#: mod/admin.php:1741
+msgid "No registrations."
+msgstr ""
+
+#: mod/admin.php:1742
+msgid "Note from the user"
+msgstr ""
+
+#: mod/admin.php:1743 mod/notifications.php:179 mod/notifications.php:264
+msgid "Approve"
+msgstr ""
+
+#: mod/admin.php:1744
+msgid "Deny"
+msgstr ""
+
+#: mod/admin.php:1748
+msgid "Site admin"
+msgstr ""
+
+#: mod/admin.php:1749
+msgid "Account expired"
+msgstr ""
+
+#: mod/admin.php:1752
+msgid "New User"
+msgstr ""
+
+#: mod/admin.php:1753
+msgid "Deleted since"
+msgstr ""
+
+#: mod/admin.php:1758
+msgid ""
+"Selected users will be deleted!\\n\\nEverything these users had posted on "
+"this site will be permanently deleted!\\n\\nAre you sure?"
+msgstr ""
+
+#: mod/admin.php:1759
+msgid ""
+"The user {0} will be deleted!\\n\\nEverything this user has posted on this "
+"site will be permanently deleted!\\n\\nAre you sure?"
+msgstr ""
+
+#: mod/admin.php:1769
+msgid "Name of the new user."
+msgstr ""
+
+#: mod/admin.php:1770
+msgid "Nickname"
+msgstr ""
+
+#: mod/admin.php:1770
+msgid "Nickname of the new user."
+msgstr ""
+
+#: mod/admin.php:1771
+msgid "Email address of the new user."
+msgstr ""
+
+#: mod/admin.php:1813
+#, php-format
+msgid "Addon %s disabled."
+msgstr ""
+
+#: mod/admin.php:1817
+#, php-format
+msgid "Addon %s enabled."
+msgstr ""
+
+#: mod/admin.php:1827 mod/admin.php:2076
+msgid "Disable"
+msgstr ""
+
+#: mod/admin.php:1830 mod/admin.php:2079
+msgid "Enable"
+msgstr ""
+
+#: mod/admin.php:1852 mod/admin.php:2121
+msgid "Toggle"
+msgstr ""
+
+#: mod/admin.php:1853 mod/admin.php:2122 mod/newmember.php:19
+#: mod/settings.php:123 src/Content/Nav.php:206 view/theme/frio/theme.php:269
+msgid "Settings"
+msgstr ""
+
+#: mod/admin.php:1860 mod/admin.php:2130
+msgid "Author: "
+msgstr ""
+
+#: mod/admin.php:1861 mod/admin.php:2131
+msgid "Maintainer: "
+msgstr ""
+
+#: mod/admin.php:1913
+msgid "Reload active addons"
+msgstr ""
+
+#: mod/admin.php:1918
+#, php-format
+msgid ""
+"There are currently no addons available on your node. You can find the "
+"official addon repository at %1$s and might find other interesting addons in "
+"the open addon registry at %2$s"
+msgstr ""
+
+#: mod/admin.php:2038
+msgid "No themes found."
+msgstr ""
+
+#: mod/admin.php:2112
+msgid "Screenshot"
+msgstr ""
+
+#: mod/admin.php:2166
+msgid "Reload active themes"
+msgstr ""
+
+#: mod/admin.php:2171
+#, php-format
+msgid "No themes found on the system. They should be placed in %1$s"
+msgstr ""
+
+#: mod/admin.php:2172
+msgid "[Experimental]"
+msgstr ""
+
+#: mod/admin.php:2173
+msgid "[Unsupported]"
+msgstr ""
+
+#: mod/admin.php:2197
+msgid "Log settings updated."
+msgstr ""
+
+#: mod/admin.php:2229
+msgid "PHP log currently enabled."
+msgstr ""
+
+#: mod/admin.php:2231
+msgid "PHP log currently disabled."
+msgstr ""
+
+#: mod/admin.php:2240
+msgid "Clear"
+msgstr ""
+
+#: mod/admin.php:2244
+msgid "Enable Debugging"
+msgstr ""
+
+#: mod/admin.php:2245
+msgid "Log file"
+msgstr ""
+
+#: mod/admin.php:2245
+msgid ""
+"Must be writable by web server. Relative to your Friendica top-level "
+"directory."
+msgstr ""
+
+#: mod/admin.php:2246
+msgid "Log level"
+msgstr ""
+
+#: mod/admin.php:2248
+msgid "PHP logging"
+msgstr ""
+
+#: mod/admin.php:2249
+msgid ""
+"To enable logging of PHP errors and warnings you can add the following to "
+"the .htconfig.php file of your installation. The filename set in the "
+"'error_log' line is relative to the friendica top-level directory and must "
+"be writeable by the web server. The option '1' for 'log_errors' and "
+"'display_errors' is to enable these options, set to '0' to disable them."
+msgstr ""
+
+#: mod/admin.php:2280
+#, php-format
+msgid ""
+"Error trying to open <strong>%1$s</strong> log file.\\r\\n<br/>Check to see "
+"if file %1$s exist and is readable."
+msgstr ""
+
+#: mod/admin.php:2284
+#, php-format
+msgid ""
+"Couldn't open <strong>%1$s</strong> log file.\\r\\n<br/>Check to see if file "
+"%1$s is readable."
+msgstr ""
+
+#: mod/admin.php:2375 mod/admin.php:2376 mod/settings.php:775
+msgid "Off"
+msgstr ""
+
+#: mod/admin.php:2375 mod/admin.php:2376 mod/settings.php:775
+msgid "On"
+msgstr ""
+
+#: mod/admin.php:2376
+#, php-format
+msgid "Lock feature %s"
+msgstr ""
+
+#: mod/admin.php:2384
+msgid "Manage Additional Features"
 msgstr ""
 
 #: mod/allfriends.php:51
 msgid "No friends to display."
 msgstr ""
 
-#: mod/allfriends.php:90 mod/suggest.php:101 mod/match.php:105
-#: mod/dirfind.php:215 src/Content/Widget.php:37 src/Model/Profile.php:297
+#: mod/allfriends.php:90 mod/dirfind.php:215 mod/match.php:105
+#: mod/suggest.php:101 src/Content/Widget.php:37 src/Model/Profile.php:297
 msgid "Connect"
 msgstr ""
 
@@ -1201,18 +2958,14 @@ msgid ""
 "and/or create new posts for you?"
 msgstr ""
 
-#: mod/api.php:111 mod/dfrn_request.php:653 mod/settings.php:1103
-#: mod/settings.php:1109 mod/settings.php:1116 mod/settings.php:1120
-#: mod/settings.php:1124 mod/settings.php:1128 mod/settings.php:1132
-#: mod/settings.php:1136 mod/settings.php:1156 mod/settings.php:1157
+#: mod/api.php:111 mod/dfrn_request.php:653 mod/follow.php:150
+#: mod/profiles.php:636 mod/profiles.php:640 mod/profiles.php:661
+#: mod/register.php:238 mod/settings.php:1105 mod/settings.php:1111
+#: mod/settings.php:1118 mod/settings.php:1122 mod/settings.php:1126
+#: mod/settings.php:1130 mod/settings.php:1134 mod/settings.php:1138
 #: mod/settings.php:1158 mod/settings.php:1159 mod/settings.php:1160
-#: mod/follow.php:150 mod/profiles.php:636 mod/profiles.php:640
-#: mod/profiles.php:661 mod/register.php:238
+#: mod/settings.php:1161 mod/settings.php:1162
 msgid "No"
-msgstr ""
-
-#: mod/apps.php:14 index.php:245
-msgid "You must be logged in to use addons. "
 msgstr ""
 
 #: mod/apps.php:19
@@ -1231,12 +2984,636 @@ msgstr ""
 msgid "Item was not found."
 msgstr ""
 
+#: mod/babel.php:22
+msgid "Source input"
+msgstr ""
+
+#: mod/babel.php:28
+msgid "BBCode::convert (raw HTML)"
+msgstr ""
+
+#: mod/babel.php:33
+msgid "BBCode::convert"
+msgstr ""
+
+#: mod/babel.php:39
+msgid "BBCode::convert => HTML::toBBCode"
+msgstr ""
+
+#: mod/babel.php:45
+msgid "BBCode::toMarkdown"
+msgstr ""
+
+#: mod/babel.php:51
+msgid "BBCode::toMarkdown => Markdown::convert"
+msgstr ""
+
+#: mod/babel.php:57
+msgid "BBCode::toMarkdown => Markdown::toBBCode"
+msgstr ""
+
+#: mod/babel.php:63
+msgid "BBCode::toMarkdown =>  Markdown::convert => HTML::toBBCode"
+msgstr ""
+
+#: mod/babel.php:70
+msgid "Source input \\x28Diaspora format\\x29"
+msgstr ""
+
+#: mod/babel.php:76
+msgid "Markdown::toBBCode"
+msgstr ""
+
+#: mod/babel.php:83
+msgid "Raw HTML input"
+msgstr ""
+
+#: mod/babel.php:88
+msgid "HTML Input"
+msgstr ""
+
+#: mod/babel.php:94
+msgid "HTML::toBBCode"
+msgstr ""
+
+#: mod/babel.php:100
+msgid "HTML::toPlaintext"
+msgstr ""
+
+#: mod/babel.php:108
+msgid "Source text"
+msgstr ""
+
+#: mod/babel.php:109
+msgid "BBCode"
+msgstr ""
+
+#: mod/babel.php:110
+msgid "Markdown"
+msgstr ""
+
+#: mod/babel.php:111
+msgid "HTML"
+msgstr ""
+
+#: mod/bookmarklet.php:23 src/Content/Nav.php:114 src/Module/Login.php:312
+msgid "Login"
+msgstr ""
+
+#: mod/bookmarklet.php:51
+msgid "The post was created"
+msgstr ""
+
+#: mod/cal.php:142 mod/display.php:313 mod/profile.php:173
+msgid "Access to this profile has been restricted."
+msgstr ""
+
+#: mod/cal.php:274 mod/events.php:391 src/Content/Nav.php:104
+#: src/Content/Nav.php:169 src/Model/Profile.php:924 src/Model/Profile.php:935
+#: view/theme/frio/theme.php:263 view/theme/frio/theme.php:267
+msgid "Events"
+msgstr ""
+
+#: mod/cal.php:275 mod/events.php:392
+msgid "View"
+msgstr ""
+
+#: mod/cal.php:276 mod/events.php:394
+msgid "Previous"
+msgstr ""
+
+#: mod/cal.php:277 mod/events.php:395 mod/install.php:209
+msgid "Next"
+msgstr ""
+
+#: mod/cal.php:280 mod/events.php:400 src/Model/Event.php:412
+msgid "today"
+msgstr ""
+
+#: mod/cal.php:281 mod/events.php:401 src/Model/Event.php:413
+#: src/Util/Temporal.php:304
+msgid "month"
+msgstr ""
+
+#: mod/cal.php:282 mod/events.php:402 src/Model/Event.php:414
+#: src/Util/Temporal.php:305
+msgid "week"
+msgstr ""
+
+#: mod/cal.php:283 mod/events.php:403 src/Model/Event.php:415
+#: src/Util/Temporal.php:306
+msgid "day"
+msgstr ""
+
+#: mod/cal.php:284 mod/events.php:404
+msgid "list"
+msgstr ""
+
+#: mod/cal.php:297 src/Core/Console/NewPassword.php:74 src/Model/User.php:204
+msgid "User not found"
+msgstr ""
+
+#: mod/cal.php:313
+msgid "This calendar format is not supported"
+msgstr ""
+
+#: mod/cal.php:315
+msgid "No exportable data found"
+msgstr ""
+
+#: mod/cal.php:332
+msgid "calendar"
+msgstr ""
+
 #: mod/common.php:91
 msgid "No contacts in common."
 msgstr ""
 
 #: mod/common.php:140 mod/contacts.php:886
 msgid "Common Friends"
+msgstr ""
+
+#: mod/community.php:27 mod/dfrn_request.php:607 mod/directory.php:42
+#: mod/display.php:203 mod/photos.php:932 mod/probe.php:13 mod/search.php:98
+#: mod/search.php:104 mod/videos.php:199 mod/viewcontacts.php:45
+#: mod/webfinger.php:16
+msgid "Public access denied."
+msgstr ""
+
+#: mod/community.php:46
+msgid "Community option not available."
+msgstr ""
+
+#: mod/community.php:63
+msgid "Not available."
+msgstr ""
+
+#: mod/community.php:76
+msgid "Local Community"
+msgstr ""
+
+#: mod/community.php:79
+msgid "Posts from local users on this server"
+msgstr ""
+
+#: mod/community.php:87
+msgid "Global Community"
+msgstr ""
+
+#: mod/community.php:90
+msgid "Posts from users of the whole federated network"
+msgstr ""
+
+#: mod/community.php:136 mod/search.php:228
+msgid "No results."
+msgstr ""
+
+#: mod/community.php:180
+msgid ""
+"This community stream shows all public posts received by this node. They may "
+"not reflect the opinions of this node’s users."
+msgstr ""
+
+#: mod/contacts.php:71 mod/notifications.php:261 src/Model/Profile.php:518
+msgid "Network:"
+msgstr ""
+
+#: mod/contacts.php:157
+#, php-format
+msgid "%d contact edited."
+msgid_plural "%d contacts edited."
+msgstr[0] ""
+msgstr[1] ""
+
+#: mod/contacts.php:184 mod/contacts.php:400
+msgid "Could not access contact record."
+msgstr ""
+
+#: mod/contacts.php:194
+msgid "Could not locate selected profile."
+msgstr ""
+
+#: mod/contacts.php:228
+msgid "Contact updated."
+msgstr ""
+
+#: mod/contacts.php:230 mod/dfrn_request.php:419
+msgid "Failed to update contact record."
+msgstr ""
+
+#: mod/contacts.php:421
+msgid "Contact has been blocked"
+msgstr ""
+
+#: mod/contacts.php:421
+msgid "Contact has been unblocked"
+msgstr ""
+
+#: mod/contacts.php:432
+msgid "Contact has been ignored"
+msgstr ""
+
+#: mod/contacts.php:432
+msgid "Contact has been unignored"
+msgstr ""
+
+#: mod/contacts.php:443
+msgid "Contact has been archived"
+msgstr ""
+
+#: mod/contacts.php:443
+msgid "Contact has been unarchived"
+msgstr ""
+
+#: mod/contacts.php:467
+msgid "Drop contact"
+msgstr ""
+
+#: mod/contacts.php:470 mod/contacts.php:823
+msgid "Do you really want to delete this contact?"
+msgstr ""
+
+#: mod/contacts.php:488
+msgid "Contact has been removed."
+msgstr ""
+
+#: mod/contacts.php:519
+#, php-format
+msgid "You are mutual friends with %s"
+msgstr ""
+
+#: mod/contacts.php:523
+#, php-format
+msgid "You are sharing with %s"
+msgstr ""
+
+#: mod/contacts.php:527
+#, php-format
+msgid "%s is sharing with you"
+msgstr ""
+
+#: mod/contacts.php:547
+msgid "Private communications are not available for this contact."
+msgstr ""
+
+#: mod/contacts.php:549
+msgid "Never"
+msgstr ""
+
+#: mod/contacts.php:552
+msgid "(Update was successful)"
+msgstr ""
+
+#: mod/contacts.php:552
+msgid "(Update was not successful)"
+msgstr ""
+
+#: mod/contacts.php:554 mod/contacts.php:992
+msgid "Suggest friends"
+msgstr ""
+
+#: mod/contacts.php:558
+#, php-format
+msgid "Network type: %s"
+msgstr ""
+
+#: mod/contacts.php:563
+msgid "Communications lost with this contact!"
+msgstr ""
+
+#: mod/contacts.php:569
+msgid "Fetch further information for feeds"
+msgstr ""
+
+#: mod/contacts.php:571
+msgid ""
+"Fetch information like preview pictures, title and teaser from the feed "
+"item. You can activate this if the feed doesn't contain much text. Keywords "
+"are taken from the meta header in the feed item and are posted as hash tags."
+msgstr ""
+
+#: mod/contacts.php:573
+msgid "Fetch information"
+msgstr ""
+
+#: mod/contacts.php:574
+msgid "Fetch keywords"
+msgstr ""
+
+#: mod/contacts.php:575
+msgid "Fetch information and keywords"
+msgstr ""
+
+#: mod/contacts.php:599 mod/unfollow.php:100
+msgid "Disconnect/Unfollow"
+msgstr ""
+
+#: mod/contacts.php:608
+msgid "Contact"
+msgstr ""
+
+#: mod/contacts.php:610 mod/crepair.php:148 mod/events.php:530
+#: mod/fsuggest.php:114 mod/install.php:251 mod/install.php:290
+#: mod/invite.php:150 mod/localtime.php:56 mod/manage.php:184
+#: mod/message.php:265 mod/message.php:432 mod/photos.php:1080
+#: mod/photos.php:1160 mod/photos.php:1445 mod/photos.php:1491
+#: mod/photos.php:1530 mod/photos.php:1603 mod/poke.php:199
+#: mod/profiles.php:672 src/Object/Post.php:796
+#: view/theme/duepuntozero/config.php:71 view/theme/frio/config.php:113
+#: view/theme/quattro/config.php:73 view/theme/vier/config.php:119
+msgid "Submit"
+msgstr ""
+
+#: mod/contacts.php:611
+msgid "Profile Visibility"
+msgstr ""
+
+#: mod/contacts.php:612
+#, php-format
+msgid ""
+"Please choose the profile you would like to display to %s when viewing your "
+"profile securely."
+msgstr ""
+
+#: mod/contacts.php:613
+msgid "Contact Information / Notes"
+msgstr ""
+
+#: mod/contacts.php:614
+msgid "Their personal note"
+msgstr ""
+
+#: mod/contacts.php:616
+msgid "Edit contact notes"
+msgstr ""
+
+#: mod/contacts.php:619 mod/contacts.php:959 mod/nogroup.php:42
+#: mod/viewcontacts.php:112
+#, php-format
+msgid "Visit %s's profile [%s]"
+msgstr ""
+
+#: mod/contacts.php:620
+msgid "Block/Unblock contact"
+msgstr ""
+
+#: mod/contacts.php:621
+msgid "Ignore contact"
+msgstr ""
+
+#: mod/contacts.php:622
+msgid "Repair URL settings"
+msgstr ""
+
+#: mod/contacts.php:623
+msgid "View conversations"
+msgstr ""
+
+#: mod/contacts.php:628
+msgid "Last update:"
+msgstr ""
+
+#: mod/contacts.php:630
+msgid "Update public posts"
+msgstr ""
+
+#: mod/contacts.php:632 mod/contacts.php:1002
+msgid "Update now"
+msgstr ""
+
+#: mod/contacts.php:638 mod/contacts.php:828 mod/contacts.php:1019
+msgid "Unignore"
+msgstr ""
+
+#: mod/contacts.php:638 mod/contacts.php:828 mod/contacts.php:1019
+#: mod/notifications.php:62 mod/notifications.php:182 mod/notifications.php:266
+msgid "Ignore"
+msgstr ""
+
+#: mod/contacts.php:642
+msgid "Currently blocked"
+msgstr ""
+
+#: mod/contacts.php:643
+msgid "Currently ignored"
+msgstr ""
+
+#: mod/contacts.php:644
+msgid "Currently archived"
+msgstr ""
+
+#: mod/contacts.php:645
+msgid "Awaiting connection acknowledge"
+msgstr ""
+
+#: mod/contacts.php:646 mod/notifications.php:175 mod/notifications.php:254
+msgid "Hide this contact from others"
+msgstr ""
+
+#: mod/contacts.php:646
+msgid ""
+"Replies/likes to your public posts <strong>may</strong> still be visible"
+msgstr ""
+
+#: mod/contacts.php:647
+msgid "Notification for new posts"
+msgstr ""
+
+#: mod/contacts.php:647
+msgid "Send a notification of every new post of this contact"
+msgstr ""
+
+#: mod/contacts.php:650
+msgid "Blacklisted keywords"
+msgstr ""
+
+#: mod/contacts.php:650
+msgid ""
+"Comma separated list of keywords that should not be converted to hashtags, "
+"when \"Fetch information and keywords\" is selected"
+msgstr ""
+
+#: mod/contacts.php:660 mod/directory.php:148 mod/events.php:518
+#: mod/notifications.php:247 src/Model/Event.php:60 src/Model/Event.php:85
+#: src/Model/Event.php:421 src/Model/Event.php:900 src/Model/Profile.php:417
+msgid "Location:"
+msgstr ""
+
+#: mod/contacts.php:662 src/Model/Profile.php:424
+msgid "XMPP:"
+msgstr ""
+
+#: mod/contacts.php:664 mod/directory.php:154 mod/notifications.php:249
+#: src/Model/Profile.php:423 src/Model/Profile.php:806
+msgid "About:"
+msgstr ""
+
+#: mod/contacts.php:666 mod/follow.php:174 mod/notifications.php:251
+#: src/Model/Profile.php:794
+msgid "Tags:"
+msgstr ""
+
+#: mod/contacts.php:667
+msgid "Actions"
+msgstr ""
+
+#: mod/contacts.php:669 mod/contacts.php:855 src/Content/Nav.php:100
+#: src/Model/Profile.php:888 view/theme/frio/theme.php:259
+msgid "Status"
+msgstr ""
+
+#: mod/contacts.php:670
+msgid "Contact Settings"
+msgstr ""
+
+#: mod/contacts.php:671 mod/contacts.php:863 mod/newmember.php:24
+#: mod/profperm.php:113 src/Content/Nav.php:101 src/Model/Profile.php:730
+#: src/Model/Profile.php:863 src/Model/Profile.php:896
+#: view/theme/frio/theme.php:260
+msgid "Profile"
+msgstr ""
+
+#: mod/contacts.php:711
+msgid "Suggestions"
+msgstr ""
+
+#: mod/contacts.php:714
+msgid "Suggest potential friends"
+msgstr ""
+
+#: mod/contacts.php:719 mod/group.php:215
+msgid "All Contacts"
+msgstr ""
+
+#: mod/contacts.php:722
+msgid "Show all contacts"
+msgstr ""
+
+#: mod/contacts.php:727
+msgid "Unblocked"
+msgstr ""
+
+#: mod/contacts.php:730
+msgid "Only show unblocked contacts"
+msgstr ""
+
+#: mod/contacts.php:735
+msgid "Blocked"
+msgstr ""
+
+#: mod/contacts.php:738
+msgid "Only show blocked contacts"
+msgstr ""
+
+#: mod/contacts.php:743
+msgid "Ignored"
+msgstr ""
+
+#: mod/contacts.php:746
+msgid "Only show ignored contacts"
+msgstr ""
+
+#: mod/contacts.php:751
+msgid "Archived"
+msgstr ""
+
+#: mod/contacts.php:754
+msgid "Only show archived contacts"
+msgstr ""
+
+#: mod/contacts.php:759
+msgid "Hidden"
+msgstr ""
+
+#: mod/contacts.php:762
+msgid "Only show hidden contacts"
+msgstr ""
+
+#: mod/contacts.php:818
+msgid "Search your contacts"
+msgstr ""
+
+#: mod/contacts.php:819 mod/search.php:236
+#, php-format
+msgid "Results for: %s"
+msgstr ""
+
+#: mod/contacts.php:820 mod/directory.php:209 src/Content/Widget.php:63
+msgid "Find"
+msgstr ""
+
+#: mod/contacts.php:826 mod/settings.php:170 mod/settings.php:701
+msgid "Update"
+msgstr ""
+
+#: mod/contacts.php:829 mod/contacts.php:1027
+msgid "Archive"
+msgstr ""
+
+#: mod/contacts.php:829 mod/contacts.php:1027
+msgid "Unarchive"
+msgstr ""
+
+#: mod/contacts.php:832
+msgid "Batch Actions"
+msgstr ""
+
+#: mod/contacts.php:858 mod/follow.php:186 mod/unfollow.php:132
+#: src/Model/Profile.php:891
+msgid "Status Messages and Posts"
+msgstr ""
+
+#: mod/contacts.php:866 src/Model/Profile.php:899
+msgid "Profile Details"
+msgstr ""
+
+#: mod/contacts.php:878
+msgid "View all contacts"
+msgstr ""
+
+#: mod/contacts.php:889
+msgid "View all common friends"
+msgstr ""
+
+#: mod/contacts.php:898
+msgid "Advanced Contact Settings"
+msgstr ""
+
+#: mod/contacts.php:930
+msgid "Mutual Friendship"
+msgstr ""
+
+#: mod/contacts.php:934
+msgid "is a fan of yours"
+msgstr ""
+
+#: mod/contacts.php:938
+msgid "you are a fan of"
+msgstr ""
+
+#: mod/contacts.php:953 mod/photos.php:1488 mod/photos.php:1527
+#: mod/photos.php:1600 src/Object/Post.php:793
+msgid "This is you"
+msgstr ""
+
+#: mod/contacts.php:960 mod/nogroup.php:43
+msgid "Edit contact"
+msgstr ""
+
+#: mod/contacts.php:1013
+msgid "Toggle Blocked status"
+msgstr ""
+
+#: mod/contacts.php:1021
+msgid "Toggle Ignored status"
+msgstr ""
+
+#: mod/contacts.php:1029
+msgid "Toggle Archive status"
+msgstr ""
+
+#: mod/contacts.php:1037
+msgid "Delete contact"
 msgstr ""
 
 #: mod/credits.php:18
@@ -1295,18 +3672,6 @@ msgstr ""
 msgid "Refetch contact data"
 msgstr ""
 
-#: mod/crepair.php:148 mod/invite.php:150 mod/manage.php:184
-#: mod/localtime.php:56 mod/poke.php:199 mod/fsuggest.php:114
-#: mod/message.php:265 mod/message.php:432 mod/photos.php:1080
-#: mod/photos.php:1160 mod/photos.php:1445 mod/photos.php:1491
-#: mod/photos.php:1530 mod/photos.php:1603 mod/install.php:251
-#: mod/install.php:290 mod/events.php:530 mod/profiles.php:672
-#: mod/contacts.php:610 src/Object/Post.php:790
-#: view/theme/duepuntozero/config.php:71 view/theme/frio/config.php:113
-#: view/theme/quattro/config.php:73 view/theme/vier/config.php:119
-msgid "Submit"
-msgstr ""
-
 #: mod/crepair.php:149
 msgid "Remote Self"
 msgstr ""
@@ -1319,12 +3684,6 @@ msgstr ""
 msgid ""
 "Mark this contact as remote_self, this will cause friendica to repost new "
 "entries from this contact."
-msgstr ""
-
-#: mod/crepair.php:158 mod/settings.php:677 mod/settings.php:703
-#: mod/admin.php:490 mod/admin.php:1781 mod/admin.php:1793 mod/admin.php:1806
-#: mod/admin.php:1822
-msgid "Name"
 msgstr ""
 
 #: mod/crepair.php:159
@@ -1359,541 +3718,66 @@ msgstr ""
 msgid "New photo from this URL"
 msgstr ""
 
-#: mod/fbrowser.php:34 src/Content/Nav.php:102 src/Model/Profile.php:904
-#: view/theme/frio/theme.php:261
-msgid "Photos"
+#: mod/delegate.php:37
+msgid "Parent user not found."
 msgstr ""
 
-#: mod/fbrowser.php:43 mod/fbrowser.php:68 mod/photos.php:194
-#: mod/photos.php:1062 mod/photos.php:1149 mod/photos.php:1166
-#: mod/photos.php:1659 mod/photos.php:1673 src/Model/Photo.php:244
-#: src/Model/Photo.php:253
-msgid "Contact Photos"
+#: mod/delegate.php:144
+msgid "No parent user"
 msgstr ""
 
-#: mod/fbrowser.php:105 mod/fbrowser.php:136 mod/profile_photo.php:250
-msgid "Upload"
+#: mod/delegate.php:159
+msgid "Parent Password:"
 msgstr ""
 
-#: mod/fbrowser.php:131
-msgid "Files"
-msgstr ""
-
-#: mod/fetch.php:16 mod/fetch.php:52 mod/fetch.php:65 mod/help.php:60
-#: mod/p.php:21 mod/p.php:48 mod/p.php:57 index.php:292
-msgid "Not Found"
-msgstr ""
-
-#: mod/hcard.php:18
-msgid "No profile"
-msgstr ""
-
-#: mod/help.php:48
-msgid "Help:"
-msgstr ""
-
-#: mod/help.php:54 src/Content/Nav.php:134 view/theme/vier/theme.php:298
-msgid "Help"
-msgstr ""
-
-#: mod/help.php:63 index.php:297
-msgid "Page not found."
-msgstr ""
-
-#: mod/home.php:39
-#, php-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: mod/lockview.php:38 mod/lockview.php:46
-msgid "Remote privacy information not available."
-msgstr ""
-
-#: mod/lockview.php:55
-msgid "Visible to:"
-msgstr ""
-
-#: mod/maintenance.php:24
-msgid "System down for maintenance"
-msgstr ""
-
-#: mod/newmember.php:11
-msgid "Welcome to Friendica"
-msgstr ""
-
-#: mod/newmember.php:12
-msgid "New Member Checklist"
-msgstr ""
-
-#: mod/newmember.php:14
+#: mod/delegate.php:159
 msgid ""
-"We would like to offer some tips and links to help make your experience "
-"enjoyable. Click any item to visit the relevant page. A link to this page "
-"will be visible from your home page for two weeks after your initial "
-"registration and then will quietly disappear."
+"Please enter the password of the parent account to legitimize your request."
 msgstr ""
 
-#: mod/newmember.php:15
-msgid "Getting Started"
+#: mod/delegate.php:164
+msgid "Parent User"
 msgstr ""
 
-#: mod/newmember.php:17
-msgid "Friendica Walk-Through"
-msgstr ""
-
-#: mod/newmember.php:17
+#: mod/delegate.php:167
 msgid ""
-"On your <em>Quick Start</em> page - find a brief introduction to your "
-"profile and network tabs, make some new connections, and find some groups to "
-"join."
+"Parent users have total control about this account, including the account "
+"settings. Please double check whom you give this access."
 msgstr ""
 
-#: mod/newmember.php:19 mod/settings.php:124 mod/admin.php:1906
-#: mod/admin.php:2175 src/Content/Nav.php:206 view/theme/frio/theme.php:269
-msgid "Settings"
+#: mod/delegate.php:169 src/Content/Nav.php:204
+msgid "Delegate Page Management"
 msgstr ""
 
-#: mod/newmember.php:21
-msgid "Go to Your Settings"
+#: mod/delegate.php:170
+msgid "Delegates"
 msgstr ""
 
-#: mod/newmember.php:21
+#: mod/delegate.php:172
 msgid ""
-"On your <em>Settings</em> page -  change your initial password. Also make a "
-"note of your Identity Address. This looks just like an email address - and "
-"will be useful in making friends on the free social web."
+"Delegates are able to manage all aspects of this account/page except for "
+"basic account settings. Please do not delegate your personal account to "
+"anybody that you do not trust completely."
 msgstr ""
 
-#: mod/newmember.php:22
-msgid ""
-"Review the other settings, particularly the privacy settings. An unpublished "
-"directory listing is like having an unlisted phone number. In general, you "
-"should probably publish your listing - unless all of your friends and "
-"potential friends know exactly how to find you."
+#: mod/delegate.php:173
+msgid "Existing Page Delegates"
 msgstr ""
 
-#: mod/newmember.php:24 mod/profperm.php:113 mod/contacts.php:671
-#: mod/contacts.php:863 src/Content/Nav.php:101 src/Model/Profile.php:730
-#: src/Model/Profile.php:863 src/Model/Profile.php:896
-#: view/theme/frio/theme.php:260
-msgid "Profile"
+#: mod/delegate.php:175
+msgid "Potential Delegates"
 msgstr ""
 
-#: mod/newmember.php:26 mod/profile_photo.php:249 mod/profiles.php:691
-msgid "Upload Profile Photo"
+#: mod/delegate.php:177 mod/tagrm.php:98
+msgid "Remove"
 msgstr ""
 
-#: mod/newmember.php:26
-msgid ""
-"Upload a profile photo if you have not done so already. Studies have shown "
-"that people with real photos of themselves are ten times more likely to make "
-"friends than people who do not."
+#: mod/delegate.php:178
+msgid "Add"
 msgstr ""
 
-#: mod/newmember.php:27
-msgid "Edit Your Profile"
-msgstr ""
-
-#: mod/newmember.php:27
-msgid ""
-"Edit your <strong>default</strong> profile to your liking. Review the "
-"settings for hiding your list of friends and hiding the profile from unknown "
-"visitors."
-msgstr ""
-
-#: mod/newmember.php:28
-msgid "Profile Keywords"
-msgstr ""
-
-#: mod/newmember.php:28
-msgid ""
-"Set some public keywords for your default profile which describe your "
-"interests. We may be able to find other people with similar interests and "
-"suggest friendships."
-msgstr ""
-
-#: mod/newmember.php:30
-msgid "Connecting"
-msgstr ""
-
-#: mod/newmember.php:36
-msgid "Importing Emails"
-msgstr ""
-
-#: mod/newmember.php:36
-msgid ""
-"Enter your email access information on your Connector Settings page if you "
-"wish to import and interact with friends or mailing lists from your email "
-"INBOX"
-msgstr ""
-
-#: mod/newmember.php:39
-msgid "Go to Your Contacts Page"
-msgstr ""
-
-#: mod/newmember.php:39
-msgid ""
-"Your Contacts page is your gateway to managing friendships and connecting "
-"with friends on other networks. Typically you enter their address or site "
-"URL in the <em>Add New Contact</em> dialog."
-msgstr ""
-
-#: mod/newmember.php:40
-msgid "Go to Your Site's Directory"
-msgstr ""
-
-#: mod/newmember.php:40
-msgid ""
-"The Directory page lets you find other people in this network or other "
-"federated sites. Look for a <em>Connect</em> or <em>Follow</em> link on "
-"their profile page. Provide your own Identity Address if requested."
-msgstr ""
-
-#: mod/newmember.php:41
-msgid "Finding New People"
-msgstr ""
-
-#: mod/newmember.php:41
-msgid ""
-"On the side panel of the Contacts page are several tools to find new "
-"friends. We can match people by interest, look up people by name or "
-"interest, and provide suggestions based on network relationships. On a brand "
-"new site, friend suggestions will usually begin to be populated within 24 "
-"hours."
-msgstr ""
-
-#: mod/newmember.php:43 src/Model/Group.php:401
-msgid "Groups"
-msgstr ""
-
-#: mod/newmember.php:45
-msgid "Group Your Contacts"
-msgstr ""
-
-#: mod/newmember.php:45
-msgid ""
-"Once you have made some friends, organize them into private conversation "
-"groups from the sidebar of your Contacts page and then you can interact with "
-"each group privately on your Network page."
-msgstr ""
-
-#: mod/newmember.php:48
-msgid "Why Aren't My Posts Public?"
-msgstr ""
-
-#: mod/newmember.php:48
-msgid ""
-"Friendica respects your privacy. By default, your posts will only show up to "
-"people you've added as friends. For more information, see the help section "
-"from the link above."
-msgstr ""
-
-#: mod/newmember.php:52
-msgid "Getting Help"
-msgstr ""
-
-#: mod/newmember.php:54
-msgid "Go to the Help Section"
-msgstr ""
-
-#: mod/newmember.php:54
-msgid ""
-"Our <strong>help</strong> pages may be consulted for detail on other program "
-"features and resources."
-msgstr ""
-
-#: mod/nogroup.php:42 mod/viewcontacts.php:112 mod/contacts.php:619
-#: mod/contacts.php:959
-#, php-format
-msgid "Visit %s's profile [%s]"
-msgstr ""
-
-#: mod/nogroup.php:43 mod/contacts.php:960
-msgid "Edit contact"
-msgstr ""
-
-#: mod/nogroup.php:63
-msgid "Contacts who are not members of a group"
-msgstr ""
-
-#: mod/p.php:14
-msgid "Not Extended"
-msgstr ""
-
-#: mod/repair_ostatus.php:18
-msgid "Resubscribing to OStatus contacts"
-msgstr ""
-
-#: mod/repair_ostatus.php:34
-msgid "Error"
-msgstr ""
-
-#: mod/repair_ostatus.php:48 mod/ostatus_subscribe.php:64
-msgid "Done"
-msgstr ""
-
-#: mod/repair_ostatus.php:54 mod/ostatus_subscribe.php:88
-msgid "Keep this window open until done."
-msgstr ""
-
-#: mod/suggest.php:36
-msgid "Do you really want to delete this suggestion?"
-msgstr ""
-
-#: mod/suggest.php:73
-msgid ""
-"No suggestions available. If this is a new site, please try again in 24 "
-"hours."
-msgstr ""
-
-#: mod/suggest.php:84 mod/suggest.php:104
-msgid "Ignore/Hide"
-msgstr ""
-
-#: mod/suggest.php:114 src/Content/Widget.php:64 view/theme/vier/theme.php:203
-msgid "Friend Suggestions"
-msgstr ""
-
-#: mod/uimport.php:55 mod/register.php:191
-msgid ""
-"This site has exceeded the number of allowed daily account registrations. "
-"Please try again tomorrow."
-msgstr ""
-
-#: mod/uimport.php:70 mod/register.php:285
-msgid "Import"
-msgstr ""
-
-#: mod/uimport.php:72
-msgid "Move account"
-msgstr ""
-
-#: mod/uimport.php:73
-msgid "You can import an account from another Friendica server."
-msgstr ""
-
-#: mod/uimport.php:74
-msgid ""
-"You need to export your account from the old server and upload it here. We "
-"will recreate your old account here with all your contacts. We will try also "
-"to inform your friends that you moved here."
-msgstr ""
-
-#: mod/uimport.php:75
-msgid ""
-"This feature is experimental. We can't import contacts from the OStatus "
-"network (GNU Social/Statusnet) or from Diaspora"
-msgstr ""
-
-#: mod/uimport.php:76
-msgid "Account file"
-msgstr ""
-
-#: mod/uimport.php:76
-msgid ""
-"To export your account, go to \"Settings->Export your personal data\" and "
-"select \"Export account\""
-msgstr ""
-
-#: mod/update_community.php:27 mod/update_display.php:27
-#: mod/update_notes.php:40 mod/update_profile.php:39 mod/update_network.php:33
-msgid "[Embedded content - reload page to view]"
-msgstr ""
-
-#: mod/dfrn_poll.php:123 mod/dfrn_poll.php:543
-#, php-format
-msgid "%1$s welcomes %2$s"
-msgstr ""
-
-#: mod/match.php:48
-msgid "No keywords to match. Please add keywords to your default profile."
-msgstr ""
-
-#: mod/match.php:104
-msgid "is interested in:"
-msgstr ""
-
-#: mod/match.php:120
-msgid "Profile Match"
-msgstr ""
-
-#: mod/match.php:125 mod/dirfind.php:253
-msgid "No matches"
-msgstr ""
-
-#: mod/notifications.php:37
-msgid "Invalid request identifier."
-msgstr ""
-
-#: mod/notifications.php:46 mod/notifications.php:183 mod/notifications.php:230
-msgid "Discard"
-msgstr ""
-
-#: mod/notifications.php:62 mod/notifications.php:182 mod/notifications.php:266
-#: mod/contacts.php:638 mod/contacts.php:828 mod/contacts.php:1019
-msgid "Ignore"
-msgstr ""
-
-#: mod/notifications.php:98 src/Content/Nav.php:189
-msgid "Notifications"
-msgstr ""
-
-#: mod/notifications.php:107
-msgid "Network Notifications"
-msgstr ""
-
-#: mod/notifications.php:113 mod/notify.php:81
-msgid "System Notifications"
-msgstr ""
-
-#: mod/notifications.php:119
-msgid "Personal Notifications"
-msgstr ""
-
-#: mod/notifications.php:125
-msgid "Home Notifications"
-msgstr ""
-
-#: mod/notifications.php:155
-msgid "Show Ignored Requests"
-msgstr ""
-
-#: mod/notifications.php:155
-msgid "Hide Ignored Requests"
-msgstr ""
-
-#: mod/notifications.php:167 mod/notifications.php:237
-msgid "Notification type: "
-msgstr ""
-
-#: mod/notifications.php:170
-#, php-format
-msgid "suggested by %s"
-msgstr ""
-
-#: mod/notifications.php:175 mod/notifications.php:254 mod/contacts.php:646
-msgid "Hide this contact from others"
-msgstr ""
-
-#: mod/notifications.php:176 mod/notifications.php:255
-msgid "Post a new friend activity"
-msgstr ""
-
-#: mod/notifications.php:176 mod/notifications.php:255
-msgid "if applicable"
-msgstr ""
-
-#: mod/notifications.php:179 mod/notifications.php:264 mod/admin.php:1796
-msgid "Approve"
-msgstr ""
-
-#: mod/notifications.php:198
-msgid "Claims to be known to you: "
-msgstr ""
-
-#: mod/notifications.php:199
-msgid "yes"
-msgstr ""
-
-#: mod/notifications.php:199
-msgid "no"
-msgstr ""
-
-#: mod/notifications.php:200 mod/notifications.php:205
-msgid "Shall your connection be bidirectional or not?"
-msgstr ""
-
-#: mod/notifications.php:201 mod/notifications.php:206
-#, php-format
-msgid ""
-"Accepting %s as a friend allows %s to subscribe to your posts, and you will "
-"also receive updates from them in your news feed."
-msgstr ""
-
-#: mod/notifications.php:202
-#, php-format
-msgid ""
-"Accepting %s as a subscriber allows them to subscribe to your posts, but you "
-"will not receive updates from them in your news feed."
-msgstr ""
-
-#: mod/notifications.php:207
-#, php-format
-msgid ""
-"Accepting %s as a sharer allows them to subscribe to your posts, but you "
-"will not receive updates from them in your news feed."
-msgstr ""
-
-#: mod/notifications.php:218
-msgid "Friend"
-msgstr ""
-
-#: mod/notifications.php:219
-msgid "Sharer"
-msgstr ""
-
-#: mod/notifications.php:219
-msgid "Subscriber"
-msgstr ""
-
-#: mod/notifications.php:247 mod/events.php:518 mod/directory.php:148
-#: mod/contacts.php:660 src/Model/Profile.php:417 src/Model/Event.php:60
-#: src/Model/Event.php:85 src/Model/Event.php:421 src/Model/Event.php:900
-msgid "Location:"
-msgstr ""
-
-#: mod/notifications.php:249 mod/directory.php:154 mod/contacts.php:664
-#: src/Model/Profile.php:423 src/Model/Profile.php:806
-msgid "About:"
-msgstr ""
-
-#: mod/notifications.php:251 mod/follow.php:174 mod/contacts.php:666
-#: src/Model/Profile.php:794
-msgid "Tags:"
-msgstr ""
-
-#: mod/notifications.php:253 mod/directory.php:151 src/Model/Profile.php:420
-#: src/Model/Profile.php:745
-msgid "Gender:"
-msgstr ""
-
-#: mod/notifications.php:258 mod/unfollow.php:122 mod/follow.php:166
-#: mod/contacts.php:656 mod/admin.php:490 mod/admin.php:500
-msgid "Profile URL"
-msgstr ""
-
-#: mod/notifications.php:261 mod/contacts.php:71 src/Model/Profile.php:518
-msgid "Network:"
-msgstr ""
-
-#: mod/notifications.php:275
-msgid "No introductions."
-msgstr ""
-
-#: mod/notifications.php:316
-msgid "Show unread"
-msgstr ""
-
-#: mod/notifications.php:316
-msgid "Show all"
-msgstr ""
-
-#: mod/notifications.php:322
-#, php-format
-msgid "No more %s notifications."
-msgstr ""
-
-#: mod/openid.php:29
-msgid "OpenID protocol error. No ID returned."
-msgstr ""
-
-#: mod/openid.php:66
-msgid ""
-"Account not found and OpenID registration is not permitted on this site."
-msgstr ""
-
-#: mod/openid.php:116 src/Module/Login.php:86 src/Module/Login.php:134
-msgid "Login failed."
+#: mod/delegate.php:179
+msgid "No entries."
 msgstr ""
 
 #: mod/dfrn_confirm.php:74 mod/profiles.php:39 mod/profiles.php:149
@@ -1980,150 +3864,9 @@ msgstr ""
 msgid "%1$s has joined %2$s"
 msgstr ""
 
-#: mod/invite.php:33
-msgid "Total invitation limit exceeded."
-msgstr ""
-
-#: mod/invite.php:55
+#: mod/dfrn_poll.php:123 mod/dfrn_poll.php:543
 #, php-format
-msgid "%s : Not a valid email address."
-msgstr ""
-
-#: mod/invite.php:80
-msgid "Please join us on Friendica"
-msgstr ""
-
-#: mod/invite.php:91
-msgid "Invitation limit exceeded. Please contact your site administrator."
-msgstr ""
-
-#: mod/invite.php:95
-#, php-format
-msgid "%s : Message delivery failed."
-msgstr ""
-
-#: mod/invite.php:99
-#, php-format
-msgid "%d message sent."
-msgid_plural "%d messages sent."
-msgstr[0] ""
-msgstr[1] ""
-
-#: mod/invite.php:117
-msgid "You have no more invitations available"
-msgstr ""
-
-#: mod/invite.php:125
-#, php-format
-msgid ""
-"Visit %s for a list of public sites that you can join. Friendica members on "
-"other sites can all connect with each other, as well as with members of many "
-"other social networks."
-msgstr ""
-
-#: mod/invite.php:127
-#, php-format
-msgid ""
-"To accept this invitation, please visit and register at %s or any other "
-"public Friendica website."
-msgstr ""
-
-#: mod/invite.php:128
-#, php-format
-msgid ""
-"Friendica sites all inter-connect to create a huge privacy-enhanced social "
-"web that is owned and controlled by its members. They can also connect with "
-"many traditional social networks. See %s for a list of alternate Friendica "
-"sites you can join."
-msgstr ""
-
-#: mod/invite.php:132
-msgid ""
-"Our apologies. This system is not currently configured to connect with other "
-"public sites or invite members."
-msgstr ""
-
-#: mod/invite.php:136
-msgid ""
-"Friendica sites all inter-connect to create a huge privacy-enhanced social "
-"web that is owned and controlled by its members. They can also connect with "
-"many traditional social networks."
-msgstr ""
-
-#: mod/invite.php:135
-#, php-format
-msgid "To accept this invitation, please visit and register at %s."
-msgstr ""
-
-#: mod/invite.php:142
-msgid "Send invitations"
-msgstr ""
-
-#: mod/invite.php:143
-msgid "Enter email addresses, one per line:"
-msgstr ""
-
-#: mod/invite.php:144 mod/wallmessage.php:141 mod/message.php:259
-#: mod/message.php:426
-msgid "Your message:"
-msgstr ""
-
-#: mod/invite.php:145
-msgid ""
-"You are cordially invited to join me and other close friends on Friendica - "
-"and help us to create a better social web."
-msgstr ""
-
-#: mod/invite.php:147
-msgid "You will need to supply this invitation code: $invite_code"
-msgstr ""
-
-#: mod/invite.php:147
-msgid ""
-"Once you have registered, please connect with me via my profile page at:"
-msgstr ""
-
-#: mod/invite.php:149
-msgid ""
-"For more information about the Friendica project and why we feel it is "
-"important, please visit http://friendi.ca"
-msgstr ""
-
-#: mod/wall_attach.php:24 mod/wall_attach.php:32 mod/wall_attach.php:83
-#: mod/wall_upload.php:38 mod/wall_upload.php:54 mod/wall_upload.php:112
-#: mod/wall_upload.php:155 mod/wall_upload.php:158
-msgid "Invalid request."
-msgstr ""
-
-#: mod/wall_attach.php:101
-msgid "Sorry, maybe your upload is bigger than the PHP configuration allows"
-msgstr ""
-
-#: mod/wall_attach.php:101
-msgid "Or - did you try to upload an empty file?"
-msgstr ""
-
-#: mod/wall_attach.php:112
-#, php-format
-msgid "File exceeds size limit of %s"
-msgstr ""
-
-#: mod/wall_attach.php:136 mod/wall_attach.php:152
-msgid "File upload failed."
-msgstr ""
-
-#: mod/manage.php:180
-msgid "Manage Identities and/or Pages"
-msgstr ""
-
-#: mod/manage.php:181
-msgid ""
-"Toggle between different identities or community/group pages which share "
-"your account details or which you have been granted \"manage\" permissions"
-msgstr ""
-
-#: mod/manage.php:182
-msgid "Select an identity to manage: "
+msgid "%1$s welcomes %2$s"
 msgstr ""
 
 #: mod/dfrn_request.php:94
@@ -2195,15 +3938,6 @@ msgstr ""
 msgid "Disallowed profile URL."
 msgstr ""
 
-#: mod/dfrn_request.php:351 mod/friendica.php:128 mod/admin.php:353
-#: mod/admin.php:371 src/Model/Contact.php:1228
-msgid "Blocked domain"
-msgstr ""
-
-#: mod/dfrn_request.php:419 mod/contacts.php:230
-msgid "Failed to update contact record."
-msgstr ""
-
 #: mod/dfrn_request.php:439
 msgid "Your introduction has been sent."
 msgstr ""
@@ -2240,13 +3974,6 @@ msgstr ""
 #: mod/dfrn_request.php:531
 #, php-format
 msgid "Please confirm your introduction/connection request to %s."
-msgstr ""
-
-#: mod/dfrn_request.php:607 mod/probe.php:13 mod/viewcontacts.php:45
-#: mod/webfinger.php:16 mod/search.php:98 mod/search.php:104
-#: mod/community.php:27 mod/photos.php:932 mod/videos.php:199
-#: mod/display.php:203 mod/directory.php:42
-msgid "Public access denied."
 msgstr ""
 
 #: mod/dfrn_request.php:642
@@ -2304,333 +4031,59 @@ msgid ""
 "bar."
 msgstr ""
 
-#: mod/dfrn_request.php:660 mod/unfollow.php:113 mod/follow.php:157
+#: mod/dfrn_request.php:660 mod/follow.php:157 mod/unfollow.php:113
 msgid "Your Identity Address:"
 msgstr ""
 
-#: mod/dfrn_request.php:662 mod/unfollow.php:65 mod/follow.php:62
+#: mod/dfrn_request.php:662 mod/follow.php:62 mod/unfollow.php:65
 msgid "Submit Request"
 msgstr ""
 
-#: mod/localtime.php:19 src/Model/Event.php:36 src/Model/Event.php:814
-msgid "l F d, Y \\@ g:i A"
+#: mod/directory.php:151 mod/notifications.php:253 src/Model/Profile.php:420
+#: src/Model/Profile.php:745
+msgid "Gender:"
 msgstr ""
 
-#: mod/localtime.php:33
-msgid "Time Conversion"
+#: mod/directory.php:152 src/Model/Profile.php:421 src/Model/Profile.php:769
+msgid "Status:"
 msgstr ""
 
-#: mod/localtime.php:35
-msgid ""
-"Friendica provides this service for sharing events with other networks and "
-"friends in unknown timezones."
+#: mod/directory.php:153 src/Model/Profile.php:422 src/Model/Profile.php:786
+msgid "Homepage:"
 msgstr ""
 
-#: mod/localtime.php:39
+#: mod/directory.php:202 view/theme/vier/theme.php:201
+msgid "Global Directory"
+msgstr ""
+
+#: mod/directory.php:204
+msgid "Find on this site"
+msgstr ""
+
+#: mod/directory.php:206
+msgid "Results for:"
+msgstr ""
+
+#: mod/directory.php:208
+msgid "Site Directory"
+msgstr ""
+
+#: mod/directory.php:213
+msgid "No entries (some entries may be hidden)."
+msgstr ""
+
+#: mod/dirfind.php:49
 #, php-format
-msgid "UTC time: %s"
+msgid "People Search - %s"
 msgstr ""
 
-#: mod/localtime.php:42
+#: mod/dirfind.php:60
 #, php-format
-msgid "Current timezone: %s"
+msgid "Forum Search - %s"
 msgstr ""
 
-#: mod/localtime.php:46
-#, php-format
-msgid "Converted localtime: %s"
-msgstr ""
-
-#: mod/localtime.php:52
-msgid "Please select your timezone:"
-msgstr ""
-
-#: mod/probe.php:14 mod/webfinger.php:17
-msgid "Only logged in users are permitted to perform a probing."
-msgstr ""
-
-#: mod/profperm.php:28 mod/group.php:83 index.php:415
-msgid "Permission denied"
-msgstr ""
-
-#: mod/profperm.php:34 mod/profperm.php:65
-msgid "Invalid profile identifier."
-msgstr ""
-
-#: mod/profperm.php:111
-msgid "Profile Visibility Editor"
-msgstr ""
-
-#: mod/profperm.php:115 mod/group.php:265
-msgid "Click on a contact to add or remove."
-msgstr ""
-
-#: mod/profperm.php:124
-msgid "Visible To"
-msgstr ""
-
-#: mod/profperm.php:140
-msgid "All Contacts (with secure profile access)"
-msgstr ""
-
-#: mod/regmod.php:68
-msgid "Account approved."
-msgstr ""
-
-#: mod/regmod.php:93
-#, php-format
-msgid "Registration revoked for %s"
-msgstr ""
-
-#: mod/regmod.php:102
-msgid "Please login."
-msgstr ""
-
-#: mod/removeme.php:55 mod/removeme.php:58
-msgid "Remove My Account"
-msgstr ""
-
-#: mod/removeme.php:56
-msgid ""
-"This will completely remove your account. Once this has been done it is not "
-"recoverable."
-msgstr ""
-
-#: mod/removeme.php:57
-msgid "Please enter your password for verification:"
-msgstr ""
-
-#: mod/viewcontacts.php:87
-msgid "No contacts."
-msgstr ""
-
-#: mod/viewsrc.php:12
-msgid "Access denied."
-msgstr ""
-
-#: mod/wallmessage.php:49 mod/wallmessage.php:112
-#, php-format
-msgid "Number of daily wall messages for %s exceeded. Message failed."
-msgstr ""
-
-#: mod/wallmessage.php:57 mod/message.php:73
-msgid "No recipient selected."
-msgstr ""
-
-#: mod/wallmessage.php:60
-msgid "Unable to check your home location."
-msgstr ""
-
-#: mod/wallmessage.php:63 mod/message.php:80
-msgid "Message could not be sent."
-msgstr ""
-
-#: mod/wallmessage.php:66 mod/message.php:83
-msgid "Message collection failure."
-msgstr ""
-
-#: mod/wallmessage.php:69 mod/message.php:86
-msgid "Message sent."
-msgstr ""
-
-#: mod/wallmessage.php:86 mod/wallmessage.php:95
-msgid "No recipient."
-msgstr ""
-
-#: mod/wallmessage.php:132 mod/message.php:250
-msgid "Send Private Message"
-msgstr ""
-
-#: mod/wallmessage.php:133
-#, php-format
-msgid ""
-"If you wish for %s to respond, please check that the privacy settings on "
-"your site allow private mail from unknown senders."
-msgstr ""
-
-#: mod/wallmessage.php:134 mod/message.php:251 mod/message.php:421
-msgid "To:"
-msgstr ""
-
-#: mod/wallmessage.php:135 mod/message.php:255 mod/message.php:423
-msgid "Subject:"
-msgstr ""
-
-#: mod/uexport.php:44
-msgid "Export account"
-msgstr ""
-
-#: mod/uexport.php:44
-msgid ""
-"Export your account info and contacts. Use this to make a backup of your "
-"account and/or to move it to another server."
-msgstr ""
-
-#: mod/uexport.php:45
-msgid "Export all"
-msgstr ""
-
-#: mod/uexport.php:45
-msgid ""
-"Export your accout info, contacts and all your items as json. Could be a "
-"very big file, and could take a lot of time. Use this to make a full backup "
-"of your account (photos are not exported)"
-msgstr ""
-
-#: mod/uexport.php:52 mod/settings.php:108
-msgid "Export personal data"
-msgstr ""
-
-#: mod/filer.php:34
-msgid "- select -"
-msgstr ""
-
-#: mod/notify.php:77
-msgid "No more system notifications."
-msgstr ""
-
-#: mod/ping.php:292
-msgid "{0} wants to be your friend"
-msgstr ""
-
-#: mod/ping.php:307
-msgid "{0} sent you a message"
-msgstr ""
-
-#: mod/ping.php:322
-msgid "{0} requested registration"
-msgstr ""
-
-#: mod/poke.php:192
-msgid "Poke/Prod"
-msgstr ""
-
-#: mod/poke.php:193
-msgid "poke, prod or do other things to somebody"
-msgstr ""
-
-#: mod/poke.php:194
-msgid "Recipient"
-msgstr ""
-
-#: mod/poke.php:195
-msgid "Choose what you wish to do to recipient"
-msgstr ""
-
-#: mod/poke.php:198
-msgid "Make this post private"
-msgstr ""
-
-#: mod/subthread.php:113
-#, php-format
-msgid "%1$s is following %2$s's %3$s"
-msgstr ""
-
-#: mod/tagrm.php:47
-msgid "Tag removed"
-msgstr ""
-
-#: mod/tagrm.php:85
-msgid "Remove Item Tag"
-msgstr ""
-
-#: mod/tagrm.php:87
-msgid "Select a tag to remove: "
-msgstr ""
-
-#: mod/tagrm.php:98 mod/delegate.php:177
-msgid "Remove"
-msgstr ""
-
-#: mod/wall_upload.php:186 mod/photos.php:763 mod/photos.php:766
-#: mod/photos.php:795 mod/profile_photo.php:153
-#, php-format
-msgid "Image exceeds size limit of %s"
-msgstr ""
-
-#: mod/wall_upload.php:200 mod/photos.php:818 mod/profile_photo.php:162
-msgid "Unable to process image."
-msgstr ""
-
-#: mod/wall_upload.php:231 mod/item.php:471 src/Object/Image.php:953
-#: src/Object/Image.php:969 src/Object/Image.php:977 src/Object/Image.php:1002
-msgid "Wall Photos"
-msgstr ""
-
-#: mod/wall_upload.php:239 mod/photos.php:847 mod/profile_photo.php:307
-msgid "Image upload failed."
-msgstr ""
-
-#: mod/search.php:37 mod/network.php:194
-msgid "Remove term"
-msgstr ""
-
-#: mod/search.php:46 mod/network.php:201 src/Content/Feature.php:100
-msgid "Saved Searches"
-msgstr ""
-
-#: mod/search.php:105
-msgid "Only logged in users are permitted to perform a search."
-msgstr ""
-
-#: mod/search.php:129
-msgid "Too Many Requests"
-msgstr ""
-
-#: mod/search.php:130
-msgid "Only one search per minute is permitted for not logged in users."
-msgstr ""
-
-#: mod/search.php:228 mod/community.php:136
-msgid "No results."
-msgstr ""
-
-#: mod/search.php:234
-#, php-format
-msgid "Items tagged with: %s"
-msgstr ""
-
-#: mod/search.php:236 mod/contacts.php:819
-#, php-format
-msgid "Results for: %s"
-msgstr ""
-
-#: mod/bookmarklet.php:23 src/Content/Nav.php:114 src/Module/Login.php:312
-msgid "Login"
-msgstr ""
-
-#: mod/bookmarklet.php:51
-msgid "The post was created"
-msgstr ""
-
-#: mod/community.php:46
-msgid "Community option not available."
-msgstr ""
-
-#: mod/community.php:63
-msgid "Not available."
-msgstr ""
-
-#: mod/community.php:76
-msgid "Local Community"
-msgstr ""
-
-#: mod/community.php:79
-msgid "Posts from local users on this server"
-msgstr ""
-
-#: mod/community.php:87
-msgid "Global Community"
-msgstr ""
-
-#: mod/community.php:90
-msgid "Posts from users of the whole federated network"
-msgstr ""
-
-#: mod/community.php:180
-msgid ""
-"This community stream shows all public posts received by this node. They may "
-"not reflect the opinions of this node’s users."
+#: mod/dirfind.php:253 mod/match.php:125
+msgid "No matches"
 msgstr ""
 
 #: mod/editpost.php:25 mod/editpost.php:35
@@ -2649,12 +4102,165 @@ msgstr ""
 msgid "Example: bob@example.com, mary@example.com"
 msgstr ""
 
+#: mod/events.php:105 mod/events.php:107
+msgid "Event can not end before it has started."
+msgstr ""
+
+#: mod/events.php:114 mod/events.php:116
+msgid "Event title and start time are required."
+msgstr ""
+
+#: mod/events.php:393
+msgid "Create New Event"
+msgstr ""
+
+#: mod/events.php:506
+msgid "Event details"
+msgstr ""
+
+#: mod/events.php:507
+msgid "Starting date and Title are required."
+msgstr ""
+
+#: mod/events.php:508 mod/events.php:509
+msgid "Event Starts:"
+msgstr ""
+
+#: mod/events.php:508 mod/events.php:520 mod/profiles.php:700
+msgid "Required"
+msgstr ""
+
+#: mod/events.php:510 mod/events.php:526
+msgid "Finish date/time is not known or not relevant"
+msgstr ""
+
+#: mod/events.php:512 mod/events.php:513
+msgid "Event Finishes:"
+msgstr ""
+
+#: mod/events.php:514 mod/events.php:527
+msgid "Adjust for viewer timezone"
+msgstr ""
+
+#: mod/events.php:516
+msgid "Description:"
+msgstr ""
+
+#: mod/events.php:520 mod/events.php:522
+msgid "Title:"
+msgstr ""
+
+#: mod/events.php:523 mod/events.php:524
+msgid "Share this event"
+msgstr ""
+
+#: mod/events.php:531 src/Model/Profile.php:864
+msgid "Basic"
+msgstr ""
+
+#: mod/events.php:533 mod/photos.php:1098 mod/photos.php:1441
+#: src/Core/ACL.php:318
+msgid "Permissions"
+msgstr ""
+
+#: mod/events.php:552
+msgid "Failed to remove event"
+msgstr ""
+
+#: mod/events.php:554
+msgid "Event removed"
+msgstr ""
+
+#: mod/fbrowser.php:34 src/Content/Nav.php:102 src/Model/Profile.php:904
+#: view/theme/frio/theme.php:261
+msgid "Photos"
+msgstr ""
+
+#: mod/fbrowser.php:43 mod/fbrowser.php:68 mod/photos.php:194
+#: mod/photos.php:1062 mod/photos.php:1149 mod/photos.php:1166
+#: mod/photos.php:1659 mod/photos.php:1673 src/Model/Photo.php:244
+#: src/Model/Photo.php:253
+msgid "Contact Photos"
+msgstr ""
+
+#: mod/fbrowser.php:105 mod/fbrowser.php:136 mod/profile_photo.php:250
+msgid "Upload"
+msgstr ""
+
+#: mod/fbrowser.php:131
+msgid "Files"
+msgstr ""
+
 #: mod/feedtest.php:20
 msgid "You must be logged in to use this module"
 msgstr ""
 
 #: mod/feedtest.php:48
 msgid "Source URL"
+msgstr ""
+
+#: mod/filer.php:34
+msgid "- select -"
+msgstr ""
+
+#: mod/follow.php:45
+msgid "The contact could not be added."
+msgstr ""
+
+#: mod/follow.php:73
+msgid "You already added this contact."
+msgstr ""
+
+#: mod/follow.php:83
+msgid "Diaspora support isn't enabled. Contact can't be added."
+msgstr ""
+
+#: mod/follow.php:90
+msgid "OStatus support is disabled. Contact can't be added."
+msgstr ""
+
+#: mod/follow.php:97
+msgid "The network type couldn't be detected. Contact can't be added."
+msgstr ""
+
+#: mod/friendica.php:77
+msgid "This is Friendica, version"
+msgstr ""
+
+#: mod/friendica.php:78
+msgid "running at web location"
+msgstr ""
+
+#: mod/friendica.php:82
+msgid ""
+"Please visit <a href=\"https://friendi.ca\">Friendi.ca</a> to learn more "
+"about the Friendica project."
+msgstr ""
+
+#: mod/friendica.php:86
+msgid "Bug reports and issues: please visit"
+msgstr ""
+
+#: mod/friendica.php:86
+msgid "the bugtracker at github"
+msgstr ""
+
+#: mod/friendica.php:89
+msgid ""
+"Suggestions, praise, donations, etc. - please email \"Info\" at Friendica - "
+"dot com"
+msgstr ""
+
+#: mod/friendica.php:103
+msgid "Installed addons/apps:"
+msgstr ""
+
+#: mod/friendica.php:117
+msgid "No installed addons/apps"
+msgstr ""
+
+#: mod/friendica.php:122
+msgid "On this server the following remote servers are blocked."
 msgstr ""
 
 #: mod/fsuggest.php:72
@@ -2722,10 +4328,6 @@ msgstr ""
 msgid "Members"
 msgstr ""
 
-#: mod/group.php:215 mod/contacts.php:719
-msgid "All Contacts"
-msgstr ""
-
 #: mod/group.php:216 mod/network.php:639
 msgid "Group is empty"
 msgstr ""
@@ -2738,535 +4340,25 @@ msgstr ""
 msgid "Add Contact"
 msgstr ""
 
-#: mod/item.php:114
-msgid "Unable to locate original post."
+#: mod/group.php:265 mod/profperm.php:115
+msgid "Click on a contact to add or remove."
 msgstr ""
 
-#: mod/item.php:274
-msgid "Empty post discarded."
+#: mod/hcard.php:18
+msgid "No profile"
 msgstr ""
 
-#: mod/item.php:799
+#: mod/help.php:48
+msgid "Help:"
+msgstr ""
+
+#: mod/help.php:54 src/Content/Nav.php:134 view/theme/vier/theme.php:298
+msgid "Help"
+msgstr ""
+
+#: mod/home.php:39
 #, php-format
-msgid ""
-"This message was sent to you by %s, a member of the Friendica social network."
-msgstr ""
-
-#: mod/item.php:801
-#, php-format
-msgid "You may visit them online at %s"
-msgstr ""
-
-#: mod/item.php:802
-msgid ""
-"Please contact the sender by replying to this post if you do not wish to "
-"receive these messages."
-msgstr ""
-
-#: mod/item.php:806
-#, php-format
-msgid "%s posted an update."
-msgstr ""
-
-#: mod/message.php:30 src/Content/Nav.php:198
-msgid "New Message"
-msgstr ""
-
-#: mod/message.php:77
-msgid "Unable to locate contact information."
-msgstr ""
-
-#: mod/message.php:112 src/Content/Nav.php:195 view/theme/frio/theme.php:268
-msgid "Messages"
-msgstr ""
-
-#: mod/message.php:136
-msgid "Do you really want to delete this message?"
-msgstr ""
-
-#: mod/message.php:156
-msgid "Message deleted."
-msgstr ""
-
-#: mod/message.php:185
-msgid "Conversation removed."
-msgstr ""
-
-#: mod/message.php:291
-msgid "No messages."
-msgstr ""
-
-#: mod/message.php:330
-msgid "Message not available."
-msgstr ""
-
-#: mod/message.php:397
-msgid "Delete message"
-msgstr ""
-
-#: mod/message.php:399 mod/message.php:500
-msgid "D, d M Y - g:i A"
-msgstr ""
-
-#: mod/message.php:414 mod/message.php:497
-msgid "Delete conversation"
-msgstr ""
-
-#: mod/message.php:416
-msgid ""
-"No secure communications available. You <strong>may</strong> be able to "
-"respond from the sender's profile page."
-msgstr ""
-
-#: mod/message.php:420
-msgid "Send Reply"
-msgstr ""
-
-#: mod/message.php:471
-#, php-format
-msgid "Unknown sender - %s"
-msgstr ""
-
-#: mod/message.php:473
-#, php-format
-msgid "You and %s"
-msgstr ""
-
-#: mod/message.php:475
-#, php-format
-msgid "%s and You"
-msgstr ""
-
-#: mod/message.php:503
-#, php-format
-msgid "%d message"
-msgid_plural "%d messages"
-msgstr[0] ""
-msgstr[1] ""
-
-#: mod/network.php:202 src/Model/Group.php:400
-msgid "add"
-msgstr ""
-
-#: mod/network.php:547
-#, php-format
-msgid ""
-"Warning: This group contains %s member from a network that doesn't allow non "
-"public messages."
-msgid_plural ""
-"Warning: This group contains %s members from a network that doesn't allow "
-"non public messages."
-msgstr[0] ""
-msgstr[1] ""
-
-#: mod/network.php:550
-msgid "Messages in this group won't be send to these receivers."
-msgstr ""
-
-#: mod/network.php:618
-msgid "No such group"
-msgstr ""
-
-#: mod/network.php:643
-#, php-format
-msgid "Group: %s"
-msgstr ""
-
-#: mod/network.php:669
-msgid "Private messages to this person are at risk of public disclosure."
-msgstr ""
-
-#: mod/network.php:672
-msgid "Invalid contact."
-msgstr ""
-
-#: mod/network.php:921
-msgid "Commented Order"
-msgstr ""
-
-#: mod/network.php:924
-msgid "Sort by Comment Date"
-msgstr ""
-
-#: mod/network.php:929
-msgid "Posted Order"
-msgstr ""
-
-#: mod/network.php:932
-msgid "Sort by Post Date"
-msgstr ""
-
-#: mod/network.php:940 mod/profiles.php:687
-#: src/Core/NotificationsManager.php:185
-msgid "Personal"
-msgstr ""
-
-#: mod/network.php:943
-msgid "Posts that mention or involve you"
-msgstr ""
-
-#: mod/network.php:951
-msgid "New"
-msgstr ""
-
-#: mod/network.php:954
-msgid "Activity Stream - by date"
-msgstr ""
-
-#: mod/network.php:962
-msgid "Shared Links"
-msgstr ""
-
-#: mod/network.php:965
-msgid "Interesting Links"
-msgstr ""
-
-#: mod/network.php:973
-msgid "Starred"
-msgstr ""
-
-#: mod/network.php:976
-msgid "Favourite Posts"
-msgstr ""
-
-#: mod/notes.php:52 src/Model/Profile.php:946
-msgid "Personal Notes"
-msgstr ""
-
-#: mod/oexchange.php:30
-msgid "Post successful."
-msgstr ""
-
-#: mod/photos.php:108 src/Model/Profile.php:907
-msgid "Photo Albums"
-msgstr ""
-
-#: mod/photos.php:109 mod/photos.php:1713
-msgid "Recent Photos"
-msgstr ""
-
-#: mod/photos.php:112 mod/photos.php:1210 mod/photos.php:1715
-msgid "Upload New Photos"
-msgstr ""
-
-#: mod/photos.php:126 mod/settings.php:51
-msgid "everybody"
-msgstr ""
-
-#: mod/photos.php:184
-msgid "Contact information unavailable"
-msgstr ""
-
-#: mod/photos.php:204
-msgid "Album not found."
-msgstr ""
-
-#: mod/photos.php:234 mod/photos.php:245 mod/photos.php:1161
-msgid "Delete Album"
-msgstr ""
-
-#: mod/photos.php:243
-msgid "Do you really want to delete this photo album and all its photos?"
-msgstr ""
-
-#: mod/photos.php:310 mod/photos.php:321 mod/photos.php:1446
-msgid "Delete Photo"
-msgstr ""
-
-#: mod/photos.php:319
-msgid "Do you really want to delete this photo?"
-msgstr ""
-
-#: mod/photos.php:667
-msgid "a photo"
-msgstr ""
-
-#: mod/photos.php:667
-#, php-format
-msgid "%1$s was tagged in %2$s by %3$s"
-msgstr ""
-
-#: mod/photos.php:769
-msgid "Image upload didn't complete, please try again"
-msgstr ""
-
-#: mod/photos.php:772
-msgid "Image file is missing"
-msgstr ""
-
-#: mod/photos.php:777
-msgid ""
-"Server can't accept new file upload at this time, please contact your "
-"administrator"
-msgstr ""
-
-#: mod/photos.php:803
-msgid "Image file is empty."
-msgstr ""
-
-#: mod/photos.php:940
-msgid "No photos selected"
-msgstr ""
-
-#: mod/photos.php:1036 mod/videos.php:309
-msgid "Access to this item is restricted."
-msgstr ""
-
-#: mod/photos.php:1090
-msgid "Upload Photos"
-msgstr ""
-
-#: mod/photos.php:1094 mod/photos.php:1156
-msgid "New album name: "
-msgstr ""
-
-#: mod/photos.php:1095
-msgid "or existing album name: "
-msgstr ""
-
-#: mod/photos.php:1096
-msgid "Do not show a status post for this upload"
-msgstr ""
-
-#: mod/photos.php:1098 mod/photos.php:1441 mod/events.php:533
-#: src/Core/ACL.php:318
-msgid "Permissions"
-msgstr ""
-
-#: mod/photos.php:1106 mod/photos.php:1449 mod/settings.php:1227
-msgid "Show to Groups"
-msgstr ""
-
-#: mod/photos.php:1107 mod/photos.php:1450 mod/settings.php:1228
-msgid "Show to Contacts"
-msgstr ""
-
-#: mod/photos.php:1167
-msgid "Edit Album"
-msgstr ""
-
-#: mod/photos.php:1172
-msgid "Show Newest First"
-msgstr ""
-
-#: mod/photos.php:1174
-msgid "Show Oldest First"
-msgstr ""
-
-#: mod/photos.php:1195 mod/photos.php:1698
-msgid "View Photo"
-msgstr ""
-
-#: mod/photos.php:1236
-msgid "Permission denied. Access to this item may be restricted."
-msgstr ""
-
-#: mod/photos.php:1238
-msgid "Photo not available"
-msgstr ""
-
-#: mod/photos.php:1301
-msgid "View photo"
-msgstr ""
-
-#: mod/photos.php:1301
-msgid "Edit photo"
-msgstr ""
-
-#: mod/photos.php:1302
-msgid "Use as profile photo"
-msgstr ""
-
-#: mod/photos.php:1308 src/Object/Post.php:149
-msgid "Private Message"
-msgstr ""
-
-#: mod/photos.php:1327
-msgid "View Full Size"
-msgstr ""
-
-#: mod/photos.php:1414
-msgid "Tags: "
-msgstr ""
-
-#: mod/photos.php:1417
-msgid "[Remove any tag]"
-msgstr ""
-
-#: mod/photos.php:1432
-msgid "New album name"
-msgstr ""
-
-#: mod/photos.php:1433
-msgid "Caption"
-msgstr ""
-
-#: mod/photos.php:1434
-msgid "Add a Tag"
-msgstr ""
-
-#: mod/photos.php:1434
-msgid "Example: @bob, @Barbara_Jensen, @jim@example.com, #California, #camping"
-msgstr ""
-
-#: mod/photos.php:1435
-msgid "Do not rotate"
-msgstr ""
-
-#: mod/photos.php:1436
-msgid "Rotate CW (right)"
-msgstr ""
-
-#: mod/photos.php:1437
-msgid "Rotate CCW (left)"
-msgstr ""
-
-#: mod/photos.php:1471 src/Object/Post.php:296
-msgid "I like this (toggle)"
-msgstr ""
-
-#: mod/photos.php:1472 src/Object/Post.php:297
-msgid "I don't like this (toggle)"
-msgstr ""
-
-#: mod/photos.php:1488 mod/photos.php:1527 mod/photos.php:1600
-#: mod/contacts.php:953 src/Object/Post.php:787
-msgid "This is you"
-msgstr ""
-
-#: mod/photos.php:1490 mod/photos.php:1529 mod/photos.php:1602
-#: src/Object/Post.php:393 src/Object/Post.php:789
-msgid "Comment"
-msgstr ""
-
-#: mod/photos.php:1634
-msgid "Map"
-msgstr ""
-
-#: mod/photos.php:1704 mod/videos.php:387
-msgid "View Album"
-msgstr ""
-
-#: mod/profile.php:37 src/Model/Profile.php:118
-msgid "Requested profile is not available."
-msgstr ""
-
-#: mod/profile.php:78 src/Protocol/OStatus.php:1252
-#, php-format
-msgid "%s's posts"
-msgstr ""
-
-#: mod/profile.php:79 src/Protocol/OStatus.php:1253
-#, php-format
-msgid "%s's comments"
-msgstr ""
-
-#: mod/profile.php:80 src/Protocol/OStatus.php:1251
-#, php-format
-msgid "%s's timeline"
-msgstr ""
-
-#: mod/profile.php:173 mod/display.php:313 mod/cal.php:142
-msgid "Access to this profile has been restricted."
-msgstr ""
-
-#: mod/profile.php:194
-msgid "Tips for New Members"
-msgstr ""
-
-#: mod/videos.php:139
-msgid "Do you really want to delete this video?"
-msgstr ""
-
-#: mod/videos.php:144
-msgid "Delete Video"
-msgstr ""
-
-#: mod/videos.php:207
-msgid "No videos selected"
-msgstr ""
-
-#: mod/videos.php:396
-msgid "Recent Videos"
-msgstr ""
-
-#: mod/videos.php:398
-msgid "Upload New Videos"
-msgstr ""
-
-#: mod/delegate.php:37
-msgid "Parent user not found."
-msgstr ""
-
-#: mod/delegate.php:144
-msgid "No parent user"
-msgstr ""
-
-#: mod/delegate.php:159
-msgid "Parent Password:"
-msgstr ""
-
-#: mod/delegate.php:159
-msgid ""
-"Please enter the password of the parent account to legitimize your request."
-msgstr ""
-
-#: mod/delegate.php:164
-msgid "Parent User"
-msgstr ""
-
-#: mod/delegate.php:167
-msgid ""
-"Parent users have total control about this account, including the account "
-"settings. Please double check whom you give this access."
-msgstr ""
-
-#: mod/delegate.php:168 mod/settings.php:675 mod/settings.php:784
-#: mod/settings.php:870 mod/settings.php:959 mod/settings.php:1192
-#: mod/admin.php:307 mod/admin.php:1346 mod/admin.php:1965 mod/admin.php:2218
-#: mod/admin.php:2292 mod/admin.php:2439
-msgid "Save Settings"
-msgstr ""
-
-#: mod/delegate.php:169 src/Content/Nav.php:204
-msgid "Delegate Page Management"
-msgstr ""
-
-#: mod/delegate.php:170
-msgid "Delegates"
-msgstr ""
-
-#: mod/delegate.php:172
-msgid ""
-"Delegates are able to manage all aspects of this account/page except for "
-"basic account settings. Please do not delegate your personal account to "
-"anybody that you do not trust completely."
-msgstr ""
-
-#: mod/delegate.php:173
-msgid "Existing Page Delegates"
-msgstr ""
-
-#: mod/delegate.php:175
-msgid "Potential Delegates"
-msgstr ""
-
-#: mod/delegate.php:178
-msgid "Add"
-msgstr ""
-
-#: mod/delegate.php:179
-msgid "No entries."
-msgstr ""
-
-#: mod/dirfind.php:49
-#, php-format
-msgid "People Search - %s"
-msgstr ""
-
-#: mod/dirfind.php:60
-#, php-format
-msgid "Forum Search - %s"
+msgid "Welcome to %s"
 msgstr ""
 
 #: mod/install.php:114
@@ -3301,10 +4393,6 @@ msgstr ""
 
 #: mod/install.php:205
 msgid "System check"
-msgstr ""
-
-#: mod/install.php:209 mod/cal.php:277 mod/events.php:395
-msgid "Next"
 msgstr ""
 
 #: mod/install.php:210
@@ -3629,6 +4717,873 @@ msgid ""
 "administrator email. This will allow you to enter the site admin panel."
 msgstr ""
 
+#: mod/invite.php:33
+msgid "Total invitation limit exceeded."
+msgstr ""
+
+#: mod/invite.php:55
+#, php-format
+msgid "%s : Not a valid email address."
+msgstr ""
+
+#: mod/invite.php:80
+msgid "Please join us on Friendica"
+msgstr ""
+
+#: mod/invite.php:91
+msgid "Invitation limit exceeded. Please contact your site administrator."
+msgstr ""
+
+#: mod/invite.php:95
+#, php-format
+msgid "%s : Message delivery failed."
+msgstr ""
+
+#: mod/invite.php:99
+#, php-format
+msgid "%d message sent."
+msgid_plural "%d messages sent."
+msgstr[0] ""
+msgstr[1] ""
+
+#: mod/invite.php:117
+msgid "You have no more invitations available"
+msgstr ""
+
+#: mod/invite.php:125
+#, php-format
+msgid ""
+"Visit %s for a list of public sites that you can join. Friendica members on "
+"other sites can all connect with each other, as well as with members of many "
+"other social networks."
+msgstr ""
+
+#: mod/invite.php:127
+#, php-format
+msgid ""
+"To accept this invitation, please visit and register at %s or any other "
+"public Friendica website."
+msgstr ""
+
+#: mod/invite.php:128
+#, php-format
+msgid ""
+"Friendica sites all inter-connect to create a huge privacy-enhanced social "
+"web that is owned and controlled by its members. They can also connect with "
+"many traditional social networks. See %s for a list of alternate Friendica "
+"sites you can join."
+msgstr ""
+
+#: mod/invite.php:132
+msgid ""
+"Our apologies. This system is not currently configured to connect with other "
+"public sites or invite members."
+msgstr ""
+
+#: mod/invite.php:136
+msgid ""
+"Friendica sites all inter-connect to create a huge privacy-enhanced social "
+"web that is owned and controlled by its members. They can also connect with "
+"many traditional social networks."
+msgstr ""
+
+#: mod/invite.php:135
+#, php-format
+msgid "To accept this invitation, please visit and register at %s."
+msgstr ""
+
+#: mod/invite.php:142
+msgid "Send invitations"
+msgstr ""
+
+#: mod/invite.php:143
+msgid "Enter email addresses, one per line:"
+msgstr ""
+
+#: mod/invite.php:144 mod/message.php:259 mod/message.php:426
+#: mod/wallmessage.php:141
+msgid "Your message:"
+msgstr ""
+
+#: mod/invite.php:145
+msgid ""
+"You are cordially invited to join me and other close friends on Friendica - "
+"and help us to create a better social web."
+msgstr ""
+
+#: mod/invite.php:147
+msgid "You will need to supply this invitation code: $invite_code"
+msgstr ""
+
+#: mod/invite.php:147
+msgid ""
+"Once you have registered, please connect with me via my profile page at:"
+msgstr ""
+
+#: mod/invite.php:149
+msgid ""
+"For more information about the Friendica project and why we feel it is "
+"important, please visit http://friendi.ca"
+msgstr ""
+
+#: mod/item.php:114
+msgid "Unable to locate original post."
+msgstr ""
+
+#: mod/item.php:274
+msgid "Empty post discarded."
+msgstr ""
+
+#: mod/item.php:471 mod/wall_upload.php:231 src/Object/Image.php:953
+#: src/Object/Image.php:969 src/Object/Image.php:977 src/Object/Image.php:1002
+msgid "Wall Photos"
+msgstr ""
+
+#: mod/item.php:799
+#, php-format
+msgid ""
+"This message was sent to you by %s, a member of the Friendica social network."
+msgstr ""
+
+#: mod/item.php:801
+#, php-format
+msgid "You may visit them online at %s"
+msgstr ""
+
+#: mod/item.php:802
+msgid ""
+"Please contact the sender by replying to this post if you do not wish to "
+"receive these messages."
+msgstr ""
+
+#: mod/item.php:806
+#, php-format
+msgid "%s posted an update."
+msgstr ""
+
+#: mod/localtime.php:19 src/Model/Event.php:36 src/Model/Event.php:814
+msgid "l F d, Y \\@ g:i A"
+msgstr ""
+
+#: mod/localtime.php:33
+msgid "Time Conversion"
+msgstr ""
+
+#: mod/localtime.php:35
+msgid ""
+"Friendica provides this service for sharing events with other networks and "
+"friends in unknown timezones."
+msgstr ""
+
+#: mod/localtime.php:39
+#, php-format
+msgid "UTC time: %s"
+msgstr ""
+
+#: mod/localtime.php:42
+#, php-format
+msgid "Current timezone: %s"
+msgstr ""
+
+#: mod/localtime.php:46
+#, php-format
+msgid "Converted localtime: %s"
+msgstr ""
+
+#: mod/localtime.php:52
+msgid "Please select your timezone:"
+msgstr ""
+
+#: mod/lockview.php:38 mod/lockview.php:46
+msgid "Remote privacy information not available."
+msgstr ""
+
+#: mod/lockview.php:55
+msgid "Visible to:"
+msgstr ""
+
+#: mod/lostpass.php:27
+msgid "No valid account found."
+msgstr ""
+
+#: mod/lostpass.php:39
+msgid "Password reset request issued. Check your email."
+msgstr ""
+
+#: mod/lostpass.php:45
+#, php-format
+msgid ""
+"\n"
+"\t\tDear %1$s,\n"
+"\t\t\tA request was recently received at \"%2$s\" to reset your account\n"
+"\t\tpassword. In order to confirm this request, please select the "
+"verification link\n"
+"\t\tbelow or paste it into your web browser address bar.\n"
+"\n"
+"\t\tIf you did NOT request this change, please DO NOT follow the link\n"
+"\t\tprovided and ignore and/or delete this email, the request will expire "
+"shortly.\n"
+"\n"
+"\t\tYour password will not be changed unless we can verify that you\n"
+"\t\tissued this request."
+msgstr ""
+
+#: mod/lostpass.php:56
+#, php-format
+msgid ""
+"\n"
+"\t\tFollow this link soon to verify your identity:\n"
+"\n"
+"\t\t%1$s\n"
+"\n"
+"\t\tYou will then receive a follow-up message containing the new password.\n"
+"\t\tYou may change that password from your account settings page after "
+"logging in.\n"
+"\n"
+"\t\tThe login details are as follows:\n"
+"\n"
+"\t\tSite Location:\t%2$s\n"
+"\t\tLogin Name:\t%3$s"
+msgstr ""
+
+#: mod/lostpass.php:72
+#, php-format
+msgid "Password reset requested at %s"
+msgstr ""
+
+#: mod/lostpass.php:88
+msgid ""
+"Request could not be verified. (You may have previously submitted it.) "
+"Password reset failed."
+msgstr ""
+
+#: mod/lostpass.php:101
+msgid "Request has expired, please make a new one."
+msgstr ""
+
+#: mod/lostpass.php:116
+msgid "Forgot your Password?"
+msgstr ""
+
+#: mod/lostpass.php:117
+msgid ""
+"Enter your email address and submit to have your password reset. Then check "
+"your email for further instructions."
+msgstr ""
+
+#: mod/lostpass.php:118 src/Module/Login.php:314
+msgid "Nickname or Email: "
+msgstr ""
+
+#: mod/lostpass.php:119
+msgid "Reset"
+msgstr ""
+
+#: mod/lostpass.php:135 src/Module/Login.php:326
+msgid "Password Reset"
+msgstr ""
+
+#: mod/lostpass.php:136
+msgid "Your password has been reset as requested."
+msgstr ""
+
+#: mod/lostpass.php:137
+msgid "Your new password is"
+msgstr ""
+
+#: mod/lostpass.php:138
+msgid "Save or copy your new password - and then"
+msgstr ""
+
+#: mod/lostpass.php:139
+msgid "click here to login"
+msgstr ""
+
+#: mod/lostpass.php:140
+msgid ""
+"Your password may be changed from the <em>Settings</em> page after "
+"successful login."
+msgstr ""
+
+#: mod/lostpass.php:148
+#, php-format
+msgid ""
+"\n"
+"\t\t\tDear %1$s,\n"
+"\t\t\t\tYour password has been changed as requested. Please retain this\n"
+"\t\t\tinformation for your records (or change your password immediately to\n"
+"\t\t\tsomething that you will remember).\n"
+"\t\t"
+msgstr ""
+
+#: mod/lostpass.php:154
+#, php-format
+msgid ""
+"\n"
+"\t\t\tYour login details are as follows:\n"
+"\n"
+"\t\t\tSite Location:\t%1$s\n"
+"\t\t\tLogin Name:\t%2$s\n"
+"\t\t\tPassword:\t%3$s\n"
+"\n"
+"\t\t\tYou may change that password from your account settings page after "
+"logging in.\n"
+"\t\t"
+msgstr ""
+
+#: mod/lostpass.php:167
+#, php-format
+msgid "Your password has been changed at %s"
+msgstr ""
+
+#: mod/maintenance.php:24
+msgid "System down for maintenance"
+msgstr ""
+
+#: mod/manage.php:180
+msgid "Manage Identities and/or Pages"
+msgstr ""
+
+#: mod/manage.php:181
+msgid ""
+"Toggle between different identities or community/group pages which share "
+"your account details or which you have been granted \"manage\" permissions"
+msgstr ""
+
+#: mod/manage.php:182
+msgid "Select an identity to manage: "
+msgstr ""
+
+#: mod/match.php:48
+msgid "No keywords to match. Please add keywords to your default profile."
+msgstr ""
+
+#: mod/match.php:104
+msgid "is interested in:"
+msgstr ""
+
+#: mod/match.php:120
+msgid "Profile Match"
+msgstr ""
+
+#: mod/message.php:30 src/Content/Nav.php:198
+msgid "New Message"
+msgstr ""
+
+#: mod/message.php:73 mod/wallmessage.php:57
+msgid "No recipient selected."
+msgstr ""
+
+#: mod/message.php:77
+msgid "Unable to locate contact information."
+msgstr ""
+
+#: mod/message.php:80 mod/wallmessage.php:63
+msgid "Message could not be sent."
+msgstr ""
+
+#: mod/message.php:83 mod/wallmessage.php:66
+msgid "Message collection failure."
+msgstr ""
+
+#: mod/message.php:86 mod/wallmessage.php:69
+msgid "Message sent."
+msgstr ""
+
+#: mod/message.php:112 src/Content/Nav.php:195 view/theme/frio/theme.php:268
+msgid "Messages"
+msgstr ""
+
+#: mod/message.php:136
+msgid "Do you really want to delete this message?"
+msgstr ""
+
+#: mod/message.php:156
+msgid "Message deleted."
+msgstr ""
+
+#: mod/message.php:185
+msgid "Conversation removed."
+msgstr ""
+
+#: mod/message.php:250 mod/wallmessage.php:132
+msgid "Send Private Message"
+msgstr ""
+
+#: mod/message.php:251 mod/message.php:421 mod/wallmessage.php:134
+msgid "To:"
+msgstr ""
+
+#: mod/message.php:255 mod/message.php:423 mod/wallmessage.php:135
+msgid "Subject:"
+msgstr ""
+
+#: mod/message.php:291
+msgid "No messages."
+msgstr ""
+
+#: mod/message.php:330
+msgid "Message not available."
+msgstr ""
+
+#: mod/message.php:397
+msgid "Delete message"
+msgstr ""
+
+#: mod/message.php:399 mod/message.php:500
+msgid "D, d M Y - g:i A"
+msgstr ""
+
+#: mod/message.php:414 mod/message.php:497
+msgid "Delete conversation"
+msgstr ""
+
+#: mod/message.php:416
+msgid ""
+"No secure communications available. You <strong>may</strong> be able to "
+"respond from the sender's profile page."
+msgstr ""
+
+#: mod/message.php:420
+msgid "Send Reply"
+msgstr ""
+
+#: mod/message.php:471
+#, php-format
+msgid "Unknown sender - %s"
+msgstr ""
+
+#: mod/message.php:473
+#, php-format
+msgid "You and %s"
+msgstr ""
+
+#: mod/message.php:475
+#, php-format
+msgid "%s and You"
+msgstr ""
+
+#: mod/message.php:503
+#, php-format
+msgid "%d message"
+msgid_plural "%d messages"
+msgstr[0] ""
+msgstr[1] ""
+
+#: mod/network.php:194 mod/search.php:37
+msgid "Remove term"
+msgstr ""
+
+#: mod/network.php:201 mod/search.php:46 src/Content/Feature.php:100
+msgid "Saved Searches"
+msgstr ""
+
+#: mod/network.php:202 src/Model/Group.php:400
+msgid "add"
+msgstr ""
+
+#: mod/network.php:547
+#, php-format
+msgid ""
+"Warning: This group contains %s member from a network that doesn't allow non "
+"public messages."
+msgid_plural ""
+"Warning: This group contains %s members from a network that doesn't allow "
+"non public messages."
+msgstr[0] ""
+msgstr[1] ""
+
+#: mod/network.php:550
+msgid "Messages in this group won't be send to these receivers."
+msgstr ""
+
+#: mod/network.php:618
+msgid "No such group"
+msgstr ""
+
+#: mod/network.php:643
+#, php-format
+msgid "Group: %s"
+msgstr ""
+
+#: mod/network.php:669
+msgid "Private messages to this person are at risk of public disclosure."
+msgstr ""
+
+#: mod/network.php:672
+msgid "Invalid contact."
+msgstr ""
+
+#: mod/network.php:921
+msgid "Commented Order"
+msgstr ""
+
+#: mod/network.php:924
+msgid "Sort by Comment Date"
+msgstr ""
+
+#: mod/network.php:929
+msgid "Posted Order"
+msgstr ""
+
+#: mod/network.php:932
+msgid "Sort by Post Date"
+msgstr ""
+
+#: mod/network.php:940 mod/profiles.php:687
+#: src/Core/NotificationsManager.php:185
+msgid "Personal"
+msgstr ""
+
+#: mod/network.php:943
+msgid "Posts that mention or involve you"
+msgstr ""
+
+#: mod/network.php:951
+msgid "New"
+msgstr ""
+
+#: mod/network.php:954
+msgid "Activity Stream - by date"
+msgstr ""
+
+#: mod/network.php:962
+msgid "Shared Links"
+msgstr ""
+
+#: mod/network.php:965
+msgid "Interesting Links"
+msgstr ""
+
+#: mod/network.php:973
+msgid "Starred"
+msgstr ""
+
+#: mod/network.php:976
+msgid "Favourite Posts"
+msgstr ""
+
+#: mod/newmember.php:11
+msgid "Welcome to Friendica"
+msgstr ""
+
+#: mod/newmember.php:12
+msgid "New Member Checklist"
+msgstr ""
+
+#: mod/newmember.php:14
+msgid ""
+"We would like to offer some tips and links to help make your experience "
+"enjoyable. Click any item to visit the relevant page. A link to this page "
+"will be visible from your home page for two weeks after your initial "
+"registration and then will quietly disappear."
+msgstr ""
+
+#: mod/newmember.php:15
+msgid "Getting Started"
+msgstr ""
+
+#: mod/newmember.php:17
+msgid "Friendica Walk-Through"
+msgstr ""
+
+#: mod/newmember.php:17
+msgid ""
+"On your <em>Quick Start</em> page - find a brief introduction to your "
+"profile and network tabs, make some new connections, and find some groups to "
+"join."
+msgstr ""
+
+#: mod/newmember.php:21
+msgid "Go to Your Settings"
+msgstr ""
+
+#: mod/newmember.php:21
+msgid ""
+"On your <em>Settings</em> page -  change your initial password. Also make a "
+"note of your Identity Address. This looks just like an email address - and "
+"will be useful in making friends on the free social web."
+msgstr ""
+
+#: mod/newmember.php:22
+msgid ""
+"Review the other settings, particularly the privacy settings. An unpublished "
+"directory listing is like having an unlisted phone number. In general, you "
+"should probably publish your listing - unless all of your friends and "
+"potential friends know exactly how to find you."
+msgstr ""
+
+#: mod/newmember.php:26 mod/profiles.php:691 mod/profile_photo.php:249
+msgid "Upload Profile Photo"
+msgstr ""
+
+#: mod/newmember.php:26
+msgid ""
+"Upload a profile photo if you have not done so already. Studies have shown "
+"that people with real photos of themselves are ten times more likely to make "
+"friends than people who do not."
+msgstr ""
+
+#: mod/newmember.php:27
+msgid "Edit Your Profile"
+msgstr ""
+
+#: mod/newmember.php:27
+msgid ""
+"Edit your <strong>default</strong> profile to your liking. Review the "
+"settings for hiding your list of friends and hiding the profile from unknown "
+"visitors."
+msgstr ""
+
+#: mod/newmember.php:28
+msgid "Profile Keywords"
+msgstr ""
+
+#: mod/newmember.php:28
+msgid ""
+"Set some public keywords for your default profile which describe your "
+"interests. We may be able to find other people with similar interests and "
+"suggest friendships."
+msgstr ""
+
+#: mod/newmember.php:30
+msgid "Connecting"
+msgstr ""
+
+#: mod/newmember.php:36
+msgid "Importing Emails"
+msgstr ""
+
+#: mod/newmember.php:36
+msgid ""
+"Enter your email access information on your Connector Settings page if you "
+"wish to import and interact with friends or mailing lists from your email "
+"INBOX"
+msgstr ""
+
+#: mod/newmember.php:39
+msgid "Go to Your Contacts Page"
+msgstr ""
+
+#: mod/newmember.php:39
+msgid ""
+"Your Contacts page is your gateway to managing friendships and connecting "
+"with friends on other networks. Typically you enter their address or site "
+"URL in the <em>Add New Contact</em> dialog."
+msgstr ""
+
+#: mod/newmember.php:40
+msgid "Go to Your Site's Directory"
+msgstr ""
+
+#: mod/newmember.php:40
+msgid ""
+"The Directory page lets you find other people in this network or other "
+"federated sites. Look for a <em>Connect</em> or <em>Follow</em> link on "
+"their profile page. Provide your own Identity Address if requested."
+msgstr ""
+
+#: mod/newmember.php:41
+msgid "Finding New People"
+msgstr ""
+
+#: mod/newmember.php:41
+msgid ""
+"On the side panel of the Contacts page are several tools to find new "
+"friends. We can match people by interest, look up people by name or "
+"interest, and provide suggestions based on network relationships. On a brand "
+"new site, friend suggestions will usually begin to be populated within 24 "
+"hours."
+msgstr ""
+
+#: mod/newmember.php:43 src/Model/Group.php:401
+msgid "Groups"
+msgstr ""
+
+#: mod/newmember.php:45
+msgid "Group Your Contacts"
+msgstr ""
+
+#: mod/newmember.php:45
+msgid ""
+"Once you have made some friends, organize them into private conversation "
+"groups from the sidebar of your Contacts page and then you can interact with "
+"each group privately on your Network page."
+msgstr ""
+
+#: mod/newmember.php:48
+msgid "Why Aren't My Posts Public?"
+msgstr ""
+
+#: mod/newmember.php:48
+msgid ""
+"Friendica respects your privacy. By default, your posts will only show up to "
+"people you've added as friends. For more information, see the help section "
+"from the link above."
+msgstr ""
+
+#: mod/newmember.php:52
+msgid "Getting Help"
+msgstr ""
+
+#: mod/newmember.php:54
+msgid "Go to the Help Section"
+msgstr ""
+
+#: mod/newmember.php:54
+msgid ""
+"Our <strong>help</strong> pages may be consulted for detail on other program "
+"features and resources."
+msgstr ""
+
+#: mod/nogroup.php:63
+msgid "Contacts who are not members of a group"
+msgstr ""
+
+#: mod/notes.php:52 src/Model/Profile.php:946
+msgid "Personal Notes"
+msgstr ""
+
+#: mod/notifications.php:37
+msgid "Invalid request identifier."
+msgstr ""
+
+#: mod/notifications.php:46 mod/notifications.php:183 mod/notifications.php:230
+msgid "Discard"
+msgstr ""
+
+#: mod/notifications.php:98 src/Content/Nav.php:189
+msgid "Notifications"
+msgstr ""
+
+#: mod/notifications.php:107
+msgid "Network Notifications"
+msgstr ""
+
+#: mod/notifications.php:113 mod/notify.php:81
+msgid "System Notifications"
+msgstr ""
+
+#: mod/notifications.php:119
+msgid "Personal Notifications"
+msgstr ""
+
+#: mod/notifications.php:125
+msgid "Home Notifications"
+msgstr ""
+
+#: mod/notifications.php:155
+msgid "Show Ignored Requests"
+msgstr ""
+
+#: mod/notifications.php:155
+msgid "Hide Ignored Requests"
+msgstr ""
+
+#: mod/notifications.php:167 mod/notifications.php:237
+msgid "Notification type: "
+msgstr ""
+
+#: mod/notifications.php:170
+#, php-format
+msgid "suggested by %s"
+msgstr ""
+
+#: mod/notifications.php:176 mod/notifications.php:255
+msgid "Post a new friend activity"
+msgstr ""
+
+#: mod/notifications.php:176 mod/notifications.php:255
+msgid "if applicable"
+msgstr ""
+
+#: mod/notifications.php:198
+msgid "Claims to be known to you: "
+msgstr ""
+
+#: mod/notifications.php:199
+msgid "yes"
+msgstr ""
+
+#: mod/notifications.php:199
+msgid "no"
+msgstr ""
+
+#: mod/notifications.php:200 mod/notifications.php:205
+msgid "Shall your connection be bidirectional or not?"
+msgstr ""
+
+#: mod/notifications.php:201 mod/notifications.php:206
+#, php-format
+msgid ""
+"Accepting %s as a friend allows %s to subscribe to your posts, and you will "
+"also receive updates from them in your news feed."
+msgstr ""
+
+#: mod/notifications.php:202
+#, php-format
+msgid ""
+"Accepting %s as a subscriber allows them to subscribe to your posts, but you "
+"will not receive updates from them in your news feed."
+msgstr ""
+
+#: mod/notifications.php:207
+#, php-format
+msgid ""
+"Accepting %s as a sharer allows them to subscribe to your posts, but you "
+"will not receive updates from them in your news feed."
+msgstr ""
+
+#: mod/notifications.php:218
+msgid "Friend"
+msgstr ""
+
+#: mod/notifications.php:219
+msgid "Sharer"
+msgstr ""
+
+#: mod/notifications.php:219
+msgid "Subscriber"
+msgstr ""
+
+#: mod/notifications.php:275
+msgid "No introductions."
+msgstr ""
+
+#: mod/notifications.php:316
+msgid "Show unread"
+msgstr ""
+
+#: mod/notifications.php:316
+msgid "Show all"
+msgstr ""
+
+#: mod/notifications.php:322
+#, php-format
+msgid "No more %s notifications."
+msgstr ""
+
+#: mod/notify.php:77
+msgid "No more system notifications."
+msgstr ""
+
+#: mod/oexchange.php:30
+msgid "Post successful."
+msgstr ""
+
+#: mod/openid.php:29
+msgid "OpenID protocol error. No ID returned."
+msgstr ""
+
+#: mod/openid.php:66
+msgid ""
+"Account not found and OpenID registration is not permitted on this site."
+msgstr ""
+
+#: mod/openid.php:116 src/Module/Login.php:86 src/Module/Login.php:134
+msgid "Login failed."
+msgstr ""
+
 #: mod/ostatus_subscribe.php:21
 msgid "Subscribing to OStatus contacts"
 msgstr ""
@@ -3645,6 +5600,10 @@ msgstr ""
 msgid "Couldn't fetch friends for contact."
 msgstr ""
 
+#: mod/ostatus_subscribe.php:64 mod/repair_ostatus.php:48
+msgid "Done"
+msgstr ""
+
 #: mod/ostatus_subscribe.php:78
 msgid "success"
 msgstr ""
@@ -3657,1203 +5616,285 @@ msgstr ""
 msgid "ignored"
 msgstr ""
 
-#: mod/unfollow.php:34
-msgid "Contact wasn't found or can't be unfollowed."
+#: mod/ostatus_subscribe.php:88 mod/repair_ostatus.php:54
+msgid "Keep this window open until done."
 msgstr ""
 
-#: mod/unfollow.php:47
-msgid "Contact unfollowed"
+#: mod/p.php:14
+msgid "Not Extended"
 msgstr ""
 
-#: mod/unfollow.php:73
-msgid "You aren't a friend of this contact."
+#: mod/photos.php:108 src/Model/Profile.php:907
+msgid "Photo Albums"
 msgstr ""
 
-#: mod/unfollow.php:79
-msgid "Unfollowing is currently not supported by your network."
+#: mod/photos.php:109 mod/photos.php:1713
+msgid "Recent Photos"
 msgstr ""
 
-#: mod/unfollow.php:100 mod/contacts.php:599
-msgid "Disconnect/Unfollow"
+#: mod/photos.php:112 mod/photos.php:1210 mod/photos.php:1715
+msgid "Upload New Photos"
 msgstr ""
 
-#: mod/unfollow.php:132 mod/follow.php:186 mod/contacts.php:858
-#: src/Model/Profile.php:891
-msgid "Status Messages and Posts"
+#: mod/photos.php:126 mod/settings.php:50
+msgid "everybody"
 msgstr ""
 
-#: mod/cal.php:274 mod/events.php:391 src/Content/Nav.php:104
-#: src/Content/Nav.php:169 src/Model/Profile.php:924 src/Model/Profile.php:935
-#: view/theme/frio/theme.php:263 view/theme/frio/theme.php:267
-msgid "Events"
+#: mod/photos.php:184
+msgid "Contact information unavailable"
 msgstr ""
 
-#: mod/cal.php:275 mod/events.php:392
-msgid "View"
+#: mod/photos.php:204
+msgid "Album not found."
 msgstr ""
 
-#: mod/cal.php:276 mod/events.php:394
-msgid "Previous"
+#: mod/photos.php:234 mod/photos.php:245 mod/photos.php:1161
+msgid "Delete Album"
 msgstr ""
 
-#: mod/cal.php:280 mod/events.php:400 src/Model/Event.php:412
-msgid "today"
+#: mod/photos.php:243
+msgid "Do you really want to delete this photo album and all its photos?"
 msgstr ""
 
-#: mod/cal.php:281 mod/events.php:401 src/Util/Temporal.php:304
-#: src/Model/Event.php:413
-msgid "month"
+#: mod/photos.php:310 mod/photos.php:321 mod/photos.php:1446
+msgid "Delete Photo"
 msgstr ""
 
-#: mod/cal.php:282 mod/events.php:402 src/Util/Temporal.php:305
-#: src/Model/Event.php:414
-msgid "week"
+#: mod/photos.php:319
+msgid "Do you really want to delete this photo?"
 msgstr ""
 
-#: mod/cal.php:283 mod/events.php:403 src/Util/Temporal.php:306
-#: src/Model/Event.php:415
-msgid "day"
+#: mod/photos.php:667
+msgid "a photo"
 msgstr ""
 
-#: mod/cal.php:284 mod/events.php:404
-msgid "list"
-msgstr ""
-
-#: mod/cal.php:297 src/Core/Console/NewPassword.php:74 src/Model/User.php:204
-msgid "User not found"
-msgstr ""
-
-#: mod/cal.php:313
-msgid "This calendar format is not supported"
-msgstr ""
-
-#: mod/cal.php:315
-msgid "No exportable data found"
-msgstr ""
-
-#: mod/cal.php:332
-msgid "calendar"
-msgstr ""
-
-#: mod/events.php:105 mod/events.php:107
-msgid "Event can not end before it has started."
-msgstr ""
-
-#: mod/events.php:114 mod/events.php:116
-msgid "Event title and start time are required."
-msgstr ""
-
-#: mod/events.php:393
-msgid "Create New Event"
-msgstr ""
-
-#: mod/events.php:506
-msgid "Event details"
-msgstr ""
-
-#: mod/events.php:507
-msgid "Starting date and Title are required."
-msgstr ""
-
-#: mod/events.php:508 mod/events.php:509
-msgid "Event Starts:"
-msgstr ""
-
-#: mod/events.php:508 mod/events.php:520 mod/profiles.php:700
-msgid "Required"
-msgstr ""
-
-#: mod/events.php:510 mod/events.php:526
-msgid "Finish date/time is not known or not relevant"
-msgstr ""
-
-#: mod/events.php:512 mod/events.php:513
-msgid "Event Finishes:"
-msgstr ""
-
-#: mod/events.php:514 mod/events.php:527
-msgid "Adjust for viewer timezone"
-msgstr ""
-
-#: mod/events.php:516
-msgid "Description:"
-msgstr ""
-
-#: mod/events.php:520 mod/events.php:522
-msgid "Title:"
-msgstr ""
-
-#: mod/events.php:523 mod/events.php:524
-msgid "Share this event"
-msgstr ""
-
-#: mod/events.php:531 src/Model/Profile.php:864
-msgid "Basic"
-msgstr ""
-
-#: mod/events.php:532 mod/contacts.php:895 mod/admin.php:1351
-#: src/Model/Profile.php:865
-msgid "Advanced"
-msgstr ""
-
-#: mod/events.php:552
-msgid "Failed to remove event"
-msgstr ""
-
-#: mod/events.php:554
-msgid "Event removed"
-msgstr ""
-
-#: mod/profile_photo.php:55
-msgid "Image uploaded but image cropping failed."
-msgstr ""
-
-#: mod/profile_photo.php:88 mod/profile_photo.php:96 mod/profile_photo.php:104
-#: mod/profile_photo.php:315
+#: mod/photos.php:667
 #, php-format
-msgid "Image size reduction [%s] failed."
+msgid "%1$s was tagged in %2$s by %3$s"
 msgstr ""
 
-#: mod/profile_photo.php:125
-msgid ""
-"Shift-reload the page or clear browser cache if the new photo does not "
-"display immediately."
-msgstr ""
-
-#: mod/profile_photo.php:134
-msgid "Unable to process image"
-msgstr ""
-
-#: mod/profile_photo.php:247
-msgid "Upload File:"
-msgstr ""
-
-#: mod/profile_photo.php:248
-msgid "Select a profile:"
-msgstr ""
-
-#: mod/profile_photo.php:253
-msgid "or"
-msgstr ""
-
-#: mod/profile_photo.php:253
-msgid "skip this step"
-msgstr ""
-
-#: mod/profile_photo.php:253
-msgid "select a photo from your photo albums"
-msgstr ""
-
-#: mod/profile_photo.php:266
-msgid "Crop Image"
-msgstr ""
-
-#: mod/profile_photo.php:267
-msgid "Please adjust the image cropping for optimum viewing."
-msgstr ""
-
-#: mod/profile_photo.php:269
-msgid "Done Editing"
-msgstr ""
-
-#: mod/profile_photo.php:305
-msgid "Image uploaded successfully."
-msgstr ""
-
-#: mod/settings.php:56 mod/admin.php:1781
-msgid "Account"
-msgstr ""
-
-#: mod/settings.php:65 mod/admin.php:187
-msgid "Additional features"
-msgstr ""
-
-#: mod/settings.php:73
-msgid "Display"
-msgstr ""
-
-#: mod/settings.php:80 mod/settings.php:841
-msgid "Social Networks"
-msgstr ""
-
-#: mod/settings.php:87 mod/admin.php:185 mod/admin.php:1904 mod/admin.php:1964
-msgid "Addons"
-msgstr ""
-
-#: mod/settings.php:94 src/Content/Nav.php:204
-msgid "Delegations"
-msgstr ""
-
-#: mod/settings.php:101
-msgid "Connected apps"
-msgstr ""
-
-#: mod/settings.php:115
-msgid "Remove account"
-msgstr ""
-
-#: mod/settings.php:169
-msgid "Missing some important data!"
-msgstr ""
-
-#: mod/settings.php:171 mod/settings.php:701 mod/contacts.php:826
-msgid "Update"
-msgstr ""
-
-#: mod/settings.php:279
-msgid "Failed to connect with email account using the settings provided."
-msgstr ""
-
-#: mod/settings.php:284
-msgid "Email settings updated."
-msgstr ""
-
-#: mod/settings.php:300
-msgid "Features updated"
-msgstr ""
-
-#: mod/settings.php:372
-msgid "Relocate message has been send to your contacts"
-msgstr ""
-
-#: mod/settings.php:384 src/Model/User.php:325
-msgid "Passwords do not match. Password unchanged."
-msgstr ""
-
-#: mod/settings.php:389
-msgid "Empty passwords are not allowed. Password unchanged."
-msgstr ""
-
-#: mod/settings.php:394 src/Core/Console/NewPassword.php:78
-msgid ""
-"The new password has been exposed in a public data dump, please choose "
-"another."
-msgstr ""
-
-#: mod/settings.php:400
-msgid "Wrong password."
-msgstr ""
-
-#: mod/settings.php:407 src/Core/Console/NewPassword.php:85
-msgid "Password changed."
-msgstr ""
-
-#: mod/settings.php:409 src/Core/Console/NewPassword.php:82
-msgid "Password update failed. Please try again."
-msgstr ""
-
-#: mod/settings.php:496
-msgid " Please use a shorter name."
-msgstr ""
-
-#: mod/settings.php:499
-msgid " Name too short."
-msgstr ""
-
-#: mod/settings.php:507
-msgid "Wrong Password"
-msgstr ""
-
-#: mod/settings.php:512
-msgid "Invalid email."
-msgstr ""
-
-#: mod/settings.php:519
-msgid "Cannot change to that email."
-msgstr ""
-
-#: mod/settings.php:572
-msgid "Private forum has no privacy permissions. Using default privacy group."
-msgstr ""
-
-#: mod/settings.php:575
-msgid "Private forum has no privacy permissions and no default privacy group."
-msgstr ""
-
-#: mod/settings.php:615
-msgid "Settings updated."
-msgstr ""
-
-#: mod/settings.php:674 mod/settings.php:700 mod/settings.php:736
-msgid "Add application"
-msgstr ""
-
-#: mod/settings.php:678 mod/settings.php:704
-msgid "Consumer Key"
-msgstr ""
-
-#: mod/settings.php:679 mod/settings.php:705
-msgid "Consumer Secret"
-msgstr ""
-
-#: mod/settings.php:680 mod/settings.php:706
-msgid "Redirect"
-msgstr ""
-
-#: mod/settings.php:681 mod/settings.php:707
-msgid "Icon url"
-msgstr ""
-
-#: mod/settings.php:692
-msgid "You can't edit this application."
-msgstr ""
-
-#: mod/settings.php:735
-msgid "Connected Apps"
-msgstr ""
-
-#: mod/settings.php:737 src/Object/Post.php:155 src/Object/Post.php:157
-msgid "Edit"
-msgstr ""
-
-#: mod/settings.php:739
-msgid "Client key starts with"
-msgstr ""
-
-#: mod/settings.php:740
-msgid "No name"
-msgstr ""
-
-#: mod/settings.php:741
-msgid "Remove authorization"
-msgstr ""
-
-#: mod/settings.php:752
-msgid "No Addon settings configured"
-msgstr ""
-
-#: mod/settings.php:761
-msgid "Addon Settings"
-msgstr ""
-
-#: mod/settings.php:775 mod/admin.php:2428 mod/admin.php:2429
-msgid "Off"
-msgstr ""
-
-#: mod/settings.php:775 mod/admin.php:2428 mod/admin.php:2429
-msgid "On"
-msgstr ""
-
-#: mod/settings.php:782
-msgid "Additional Features"
-msgstr ""
-
-#: mod/settings.php:804 src/Content/ContactSelector.php:83
-msgid "Diaspora"
-msgstr ""
-
-#: mod/settings.php:804 mod/settings.php:805
-msgid "enabled"
-msgstr ""
-
-#: mod/settings.php:804 mod/settings.php:805
-msgid "disabled"
-msgstr ""
-
-#: mod/settings.php:804 mod/settings.php:805
+#: mod/photos.php:763 mod/photos.php:766 mod/photos.php:795
+#: mod/profile_photo.php:153 mod/wall_upload.php:186
 #, php-format
-msgid "Built-in support for %s connectivity is %s"
+msgid "Image exceeds size limit of %s"
 msgstr ""
 
-#: mod/settings.php:805
-msgid "GNU Social (OStatus)"
+#: mod/photos.php:769
+msgid "Image upload didn't complete, please try again"
 msgstr ""
 
-#: mod/settings.php:836
-msgid "Email access is disabled on this site."
+#: mod/photos.php:772
+msgid "Image file is missing"
 msgstr ""
 
-#: mod/settings.php:846
-msgid "General Social Media Settings"
-msgstr ""
-
-#: mod/settings.php:847
-msgid "Disable intelligent shortening"
-msgstr ""
-
-#: mod/settings.php:847
+#: mod/photos.php:777
 msgid ""
-"Normally the system tries to find the best link to add to shortened posts. "
-"If this option is enabled then every shortened post will always point to the "
-"original friendica post."
+"Server can't accept new file upload at this time, please contact your "
+"administrator"
 msgstr ""
 
-#: mod/settings.php:848
-msgid "Automatically follow any GNU Social (OStatus) followers/mentioners"
+#: mod/photos.php:803
+msgid "Image file is empty."
 msgstr ""
 
-#: mod/settings.php:848
-msgid ""
-"If you receive a message from an unknown OStatus user, this option decides "
-"what to do. If it is checked, a new contact will be created for every "
-"unknown user."
+#: mod/photos.php:818 mod/profile_photo.php:162 mod/wall_upload.php:200
+msgid "Unable to process image."
 msgstr ""
 
-#: mod/settings.php:849
-msgid "Default group for OStatus contacts"
+#: mod/photos.php:847 mod/profile_photo.php:307 mod/wall_upload.php:239
+msgid "Image upload failed."
 msgstr ""
 
-#: mod/settings.php:850
-msgid "Your legacy GNU Social account"
+#: mod/photos.php:940
+msgid "No photos selected"
 msgstr ""
 
-#: mod/settings.php:850
-msgid ""
-"If you enter your old GNU Social/Statusnet account name here (in the format "
-"user@domain.tld), your contacts will be added automatically. The field will "
-"be emptied when done."
+#: mod/photos.php:1036 mod/videos.php:309
+msgid "Access to this item is restricted."
 msgstr ""
 
-#: mod/settings.php:853
-msgid "Repair OStatus subscriptions"
+#: mod/photos.php:1090
+msgid "Upload Photos"
 msgstr ""
 
-#: mod/settings.php:857
-msgid "Email/Mailbox Setup"
+#: mod/photos.php:1094 mod/photos.php:1156
+msgid "New album name: "
 msgstr ""
 
-#: mod/settings.php:858
-msgid ""
-"If you wish to communicate with email contacts using this service "
-"(optional), please specify how to connect to your mailbox."
+#: mod/photos.php:1095
+msgid "or existing album name: "
 msgstr ""
 
-#: mod/settings.php:859
-msgid "Last successful email check:"
+#: mod/photos.php:1096
+msgid "Do not show a status post for this upload"
 msgstr ""
 
-#: mod/settings.php:861
-msgid "IMAP server name:"
+#: mod/photos.php:1106 mod/photos.php:1449 mod/settings.php:1229
+msgid "Show to Groups"
 msgstr ""
 
-#: mod/settings.php:862
-msgid "IMAP port:"
+#: mod/photos.php:1107 mod/photos.php:1450 mod/settings.php:1230
+msgid "Show to Contacts"
 msgstr ""
 
-#: mod/settings.php:863
-msgid "Security:"
+#: mod/photos.php:1167
+msgid "Edit Album"
 msgstr ""
 
-#: mod/settings.php:863 mod/settings.php:868
-msgid "None"
+#: mod/photos.php:1172
+msgid "Show Newest First"
 msgstr ""
 
-#: mod/settings.php:864
-msgid "Email login name:"
+#: mod/photos.php:1174
+msgid "Show Oldest First"
 msgstr ""
 
-#: mod/settings.php:865
-msgid "Email password:"
+#: mod/photos.php:1195 mod/photos.php:1698
+msgid "View Photo"
 msgstr ""
 
-#: mod/settings.php:866
-msgid "Reply-to address:"
+#: mod/photos.php:1236
+msgid "Permission denied. Access to this item may be restricted."
 msgstr ""
 
-#: mod/settings.php:867
-msgid "Send public posts to all email contacts:"
+#: mod/photos.php:1238
+msgid "Photo not available"
 msgstr ""
 
-#: mod/settings.php:868
-msgid "Action after import:"
+#: mod/photos.php:1301
+msgid "View photo"
 msgstr ""
 
-#: mod/settings.php:868 src/Content/Nav.php:191
-msgid "Mark as seen"
+#: mod/photos.php:1301
+msgid "Edit photo"
 msgstr ""
 
-#: mod/settings.php:868
-msgid "Move to folder"
+#: mod/photos.php:1302
+msgid "Use as profile photo"
 msgstr ""
 
-#: mod/settings.php:869
-msgid "Move to folder:"
+#: mod/photos.php:1308 src/Object/Post.php:149
+msgid "Private Message"
 msgstr ""
 
-#: mod/settings.php:903 mod/admin.php:1236
-msgid "No special theme for mobile devices"
+#: mod/photos.php:1327
+msgid "View Full Size"
 msgstr ""
 
-#: mod/settings.php:912
+#: mod/photos.php:1414
+msgid "Tags: "
+msgstr ""
+
+#: mod/photos.php:1417
+msgid "[Remove any tag]"
+msgstr ""
+
+#: mod/photos.php:1432
+msgid "New album name"
+msgstr ""
+
+#: mod/photos.php:1433
+msgid "Caption"
+msgstr ""
+
+#: mod/photos.php:1434
+msgid "Add a Tag"
+msgstr ""
+
+#: mod/photos.php:1434
+msgid "Example: @bob, @Barbara_Jensen, @jim@example.com, #California, #camping"
+msgstr ""
+
+#: mod/photos.php:1435
+msgid "Do not rotate"
+msgstr ""
+
+#: mod/photos.php:1436
+msgid "Rotate CW (right)"
+msgstr ""
+
+#: mod/photos.php:1437
+msgid "Rotate CCW (left)"
+msgstr ""
+
+#: mod/photos.php:1471 src/Object/Post.php:296
+msgid "I like this (toggle)"
+msgstr ""
+
+#: mod/photos.php:1472 src/Object/Post.php:297
+msgid "I don't like this (toggle)"
+msgstr ""
+
+#: mod/photos.php:1490 mod/photos.php:1529 mod/photos.php:1602
+#: src/Object/Post.php:399 src/Object/Post.php:795
+msgid "Comment"
+msgstr ""
+
+#: mod/photos.php:1634
+msgid "Map"
+msgstr ""
+
+#: mod/photos.php:1704 mod/videos.php:387
+msgid "View Album"
+msgstr ""
+
+#: mod/ping.php:292
+msgid "{0} wants to be your friend"
+msgstr ""
+
+#: mod/ping.php:307
+msgid "{0} sent you a message"
+msgstr ""
+
+#: mod/ping.php:322
+msgid "{0} requested registration"
+msgstr ""
+
+#: mod/poke.php:192
+msgid "Poke/Prod"
+msgstr ""
+
+#: mod/poke.php:193
+msgid "poke, prod or do other things to somebody"
+msgstr ""
+
+#: mod/poke.php:194
+msgid "Recipient"
+msgstr ""
+
+#: mod/poke.php:195
+msgid "Choose what you wish to do to recipient"
+msgstr ""
+
+#: mod/poke.php:198
+msgid "Make this post private"
+msgstr ""
+
+#: mod/probe.php:14 mod/webfinger.php:17
+msgid "Only logged in users are permitted to perform a probing."
+msgstr ""
+
+#: mod/profile.php:37 src/Model/Profile.php:118
+msgid "Requested profile is not available."
+msgstr ""
+
+#: mod/profile.php:78 src/Protocol/OStatus.php:1252
 #, php-format
-msgid "%s - (Unsupported)"
+msgid "%s's posts"
 msgstr ""
 
-#: mod/settings.php:914
+#: mod/profile.php:79 src/Protocol/OStatus.php:1253
 #, php-format
-msgid "%s - (Experimental)"
+msgid "%s's comments"
 msgstr ""
 
-#: mod/settings.php:957
-msgid "Display Settings"
-msgstr ""
-
-#: mod/settings.php:963 mod/settings.php:987
-msgid "Display Theme:"
-msgstr ""
-
-#: mod/settings.php:964
-msgid "Mobile Theme:"
-msgstr ""
-
-#: mod/settings.php:965
-msgid "Suppress warning of insecure networks"
-msgstr ""
-
-#: mod/settings.php:965
-msgid ""
-"Should the system suppress the warning that the current group contains "
-"members of networks that can't receive non public postings."
-msgstr ""
-
-#: mod/settings.php:966
-msgid "Update browser every xx seconds"
-msgstr ""
-
-#: mod/settings.php:966
-msgid "Minimum of 10 seconds. Enter -1 to disable it."
-msgstr ""
-
-#: mod/settings.php:967
-msgid "Number of items to display per page:"
-msgstr ""
-
-#: mod/settings.php:967 mod/settings.php:968
-msgid "Maximum of 100 items"
-msgstr ""
-
-#: mod/settings.php:968
-msgid "Number of items to display per page when viewed from mobile device:"
-msgstr ""
-
-#: mod/settings.php:969
-msgid "Don't show emoticons"
-msgstr ""
-
-#: mod/settings.php:970
-msgid "Calendar"
-msgstr ""
-
-#: mod/settings.php:971
-msgid "Beginning of week:"
-msgstr ""
-
-#: mod/settings.php:972
-msgid "Don't show notices"
-msgstr ""
-
-#: mod/settings.php:973
-msgid "Infinite scroll"
-msgstr ""
-
-#: mod/settings.php:974
-msgid "Automatic updates only at the top of the network page"
-msgstr ""
-
-#: mod/settings.php:974
-msgid ""
-"When disabled, the network page is updated all the time, which could be "
-"confusing while reading."
-msgstr ""
-
-#: mod/settings.php:975
-msgid "Bandwith Saver Mode"
-msgstr ""
-
-#: mod/settings.php:975
-msgid ""
-"When enabled, embedded content is not displayed on automatic updates, they "
-"only show on page reload."
-msgstr ""
-
-#: mod/settings.php:976
-msgid "Smart Threading"
-msgstr ""
-
-#: mod/settings.php:976
-msgid ""
-"When enabled, suppress extraneous thread indentation while keeping it where "
-"it matters. Only works if threading is available and enabled."
-msgstr ""
-
-#: mod/settings.php:978
-msgid "General Theme Settings"
-msgstr ""
-
-#: mod/settings.php:979
-msgid "Custom Theme Settings"
-msgstr ""
-
-#: mod/settings.php:980
-msgid "Content Settings"
-msgstr ""
-
-#: mod/settings.php:981 view/theme/duepuntozero/config.php:73
-#: view/theme/frio/config.php:115 view/theme/quattro/config.php:75
-#: view/theme/vier/config.php:121
-msgid "Theme settings"
-msgstr ""
-
-#: mod/settings.php:1000
-msgid "Unable to find your profile. Please contact your admin."
-msgstr ""
-
-#: mod/settings.php:1042
-msgid "Account Types"
-msgstr ""
-
-#: mod/settings.php:1043
-msgid "Personal Page Subtypes"
-msgstr ""
-
-#: mod/settings.php:1044
-msgid "Community Forum Subtypes"
-msgstr ""
-
-#: mod/settings.php:1051
-msgid "Personal Page"
-msgstr ""
-
-#: mod/settings.php:1052
-msgid "Account for a personal profile."
-msgstr ""
-
-#: mod/settings.php:1055
-msgid "Organisation Page"
-msgstr ""
-
-#: mod/settings.php:1056
-msgid ""
-"Account for an organisation that automatically approves contact requests as "
-"\"Followers\"."
-msgstr ""
-
-#: mod/settings.php:1059
-msgid "News Page"
-msgstr ""
-
-#: mod/settings.php:1060
-msgid ""
-"Account for a news reflector that automatically approves contact requests as "
-"\"Followers\"."
-msgstr ""
-
-#: mod/settings.php:1063
-msgid "Community Forum"
-msgstr ""
-
-#: mod/settings.php:1064
-msgid "Account for community discussions."
-msgstr ""
-
-#: mod/settings.php:1067
-msgid "Normal Account Page"
-msgstr ""
-
-#: mod/settings.php:1068
-msgid ""
-"Account for a regular personal profile that requires manual approval of "
-"\"Friends\" and \"Followers\"."
-msgstr ""
-
-#: mod/settings.php:1071
-msgid "Soapbox Page"
-msgstr ""
-
-#: mod/settings.php:1072
-msgid ""
-"Account for a public profile that automatically approves contact requests as "
-"\"Followers\"."
-msgstr ""
-
-#: mod/settings.php:1075
-msgid "Public Forum"
-msgstr ""
-
-#: mod/settings.php:1076
-msgid "Automatically approves all contact requests."
-msgstr ""
-
-#: mod/settings.php:1079
-msgid "Automatic Friend Page"
-msgstr ""
-
-#: mod/settings.php:1080
-msgid ""
-"Account for a popular profile that automatically approves contact requests "
-"as \"Friends\"."
-msgstr ""
-
-#: mod/settings.php:1083
-msgid "Private Forum [Experimental]"
-msgstr ""
-
-#: mod/settings.php:1084
-msgid "Requires manual approval of contact requests."
-msgstr ""
-
-#: mod/settings.php:1095
-msgid "OpenID:"
-msgstr ""
-
-#: mod/settings.php:1095
-msgid "(Optional) Allow this OpenID to login to this account."
-msgstr ""
-
-#: mod/settings.php:1103
-msgid "Publish your default profile in your local site directory?"
-msgstr ""
-
-#: mod/settings.php:1103
+#: mod/profile.php:80 src/Protocol/OStatus.php:1251
 #, php-format
-msgid ""
-"Your profile will be published in the global friendica directories (e.g. <a "
-"href=\"%s\">%s</a>). Your profile will be visible in public."
+msgid "%s's timeline"
 msgstr ""
 
-#: mod/settings.php:1109
-msgid "Publish your default profile in the global social directory?"
-msgstr ""
-
-#: mod/settings.php:1109
-#, php-format
-msgid ""
-"Your profile will be published in this node's <a href=\"%s\">local "
-"directory</a>. Your profile details may be publicly visible depending on the "
-"system settings."
-msgstr ""
-
-#: mod/settings.php:1116
-msgid "Hide your contact/friend list from viewers of your default profile?"
-msgstr ""
-
-#: mod/settings.php:1116
-msgid ""
-"Your contact list won't be shown in your default profile page. You can "
-"decide to show your contact list separately for each additional profile you "
-"create"
-msgstr ""
-
-#: mod/settings.php:1120
-msgid "Hide your profile details from anonymous viewers?"
-msgstr ""
-
-#: mod/settings.php:1120
-msgid ""
-"Anonymous visitors will only see your profile picture, your display name and "
-"the nickname you are using on your profile page. Disables posting public "
-"messages to Diaspora and other networks."
-msgstr ""
-
-#: mod/settings.php:1124
-msgid "Allow friends to post to your profile page?"
-msgstr ""
-
-#: mod/settings.php:1124
-msgid ""
-"Your contacts may write posts on your profile wall. These posts will be "
-"distributed to your contacts"
-msgstr ""
-
-#: mod/settings.php:1128
-msgid "Allow friends to tag your posts?"
-msgstr ""
-
-#: mod/settings.php:1128
-msgid "Your contacts can add additional tags to your posts."
-msgstr ""
-
-#: mod/settings.php:1132
-msgid "Allow us to suggest you as a potential friend to new members?"
-msgstr ""
-
-#: mod/settings.php:1132
-msgid "If you like, Friendica may suggest new members to add you as a contact."
-msgstr ""
-
-#: mod/settings.php:1136
-msgid "Permit unknown people to send you private mail?"
-msgstr ""
-
-#: mod/settings.php:1136
-msgid ""
-"Friendica network users may send you private messages even if they are not "
-"in your contact list."
-msgstr ""
-
-#: mod/settings.php:1140
-msgid "Profile is <strong>not published</strong>."
-msgstr ""
-
-#: mod/settings.php:1146
-#, php-format
-msgid "Your Identity Address is <strong>'%s'</strong> or '%s'."
-msgstr ""
-
-#: mod/settings.php:1153
-msgid "Automatically expire posts after this many days:"
-msgstr ""
-
-#: mod/settings.php:1153
-msgid "If empty, posts will not expire. Expired posts will be deleted"
-msgstr ""
-
-#: mod/settings.php:1154
-msgid "Advanced expiration settings"
-msgstr ""
-
-#: mod/settings.php:1155
-msgid "Advanced Expiration"
-msgstr ""
-
-#: mod/settings.php:1156
-msgid "Expire posts:"
-msgstr ""
-
-#: mod/settings.php:1157
-msgid "Expire personal notes:"
-msgstr ""
-
-#: mod/settings.php:1158
-msgid "Expire starred posts:"
-msgstr ""
-
-#: mod/settings.php:1159
-msgid "Expire photos:"
-msgstr ""
-
-#: mod/settings.php:1160
-msgid "Only expire posts by others:"
-msgstr ""
-
-#: mod/settings.php:1190
-msgid "Account Settings"
-msgstr ""
-
-#: mod/settings.php:1198
-msgid "Password Settings"
-msgstr ""
-
-#: mod/settings.php:1199 mod/register.php:273
-msgid "New Password:"
-msgstr ""
-
-#: mod/settings.php:1200 mod/register.php:274
-msgid "Confirm:"
-msgstr ""
-
-#: mod/settings.php:1200
-msgid "Leave password fields blank unless changing"
-msgstr ""
-
-#: mod/settings.php:1201
-msgid "Current Password:"
-msgstr ""
-
-#: mod/settings.php:1201 mod/settings.php:1202
-msgid "Your current password to confirm the changes"
-msgstr ""
-
-#: mod/settings.php:1202
-msgid "Password:"
-msgstr ""
-
-#: mod/settings.php:1206
-msgid "Basic Settings"
-msgstr ""
-
-#: mod/settings.php:1207 src/Model/Profile.php:738
-msgid "Full Name:"
-msgstr ""
-
-#: mod/settings.php:1208
-msgid "Email Address:"
-msgstr ""
-
-#: mod/settings.php:1209
-msgid "Your Timezone:"
-msgstr ""
-
-#: mod/settings.php:1210
-msgid "Your Language:"
-msgstr ""
-
-#: mod/settings.php:1210
-msgid ""
-"Set the language we use to show you friendica interface and to send you "
-"emails"
-msgstr ""
-
-#: mod/settings.php:1211
-msgid "Default Post Location:"
-msgstr ""
-
-#: mod/settings.php:1212
-msgid "Use Browser Location:"
-msgstr ""
-
-#: mod/settings.php:1215
-msgid "Security and Privacy Settings"
-msgstr ""
-
-#: mod/settings.php:1217
-msgid "Maximum Friend Requests/Day:"
-msgstr ""
-
-#: mod/settings.php:1217 mod/settings.php:1246
-msgid "(to prevent spam abuse)"
-msgstr ""
-
-#: mod/settings.php:1218
-msgid "Default Post Permissions"
-msgstr ""
-
-#: mod/settings.php:1219
-msgid "(click to open/close)"
-msgstr ""
-
-#: mod/settings.php:1229
-msgid "Default Private Post"
-msgstr ""
-
-#: mod/settings.php:1230
-msgid "Default Public Post"
-msgstr ""
-
-#: mod/settings.php:1234
-msgid "Default Permissions for New Posts"
-msgstr ""
-
-#: mod/settings.php:1246
-msgid "Maximum private messages per day from unknown people:"
-msgstr ""
-
-#: mod/settings.php:1249
-msgid "Notification Settings"
-msgstr ""
-
-#: mod/settings.php:1250
-msgid "By default post a status message when:"
-msgstr ""
-
-#: mod/settings.php:1251
-msgid "accepting a friend request"
-msgstr ""
-
-#: mod/settings.php:1252
-msgid "joining a forum/community"
-msgstr ""
-
-#: mod/settings.php:1253
-msgid "making an <em>interesting</em> profile change"
-msgstr ""
-
-#: mod/settings.php:1254
-msgid "Send a notification email when:"
-msgstr ""
-
-#: mod/settings.php:1255
-msgid "You receive an introduction"
-msgstr ""
-
-#: mod/settings.php:1256
-msgid "Your introductions are confirmed"
-msgstr ""
-
-#: mod/settings.php:1257
-msgid "Someone writes on your profile wall"
-msgstr ""
-
-#: mod/settings.php:1258
-msgid "Someone writes a followup comment"
-msgstr ""
-
-#: mod/settings.php:1259
-msgid "You receive a private message"
-msgstr ""
-
-#: mod/settings.php:1260
-msgid "You receive a friend suggestion"
-msgstr ""
-
-#: mod/settings.php:1261
-msgid "You are tagged in a post"
-msgstr ""
-
-#: mod/settings.php:1262
-msgid "You are poked/prodded/etc. in a post"
-msgstr ""
-
-#: mod/settings.php:1264
-msgid "Activate desktop notifications"
-msgstr ""
-
-#: mod/settings.php:1264
-msgid "Show desktop popup on new notifications"
-msgstr ""
-
-#: mod/settings.php:1266
-msgid "Text-only notification emails"
-msgstr ""
-
-#: mod/settings.php:1268
-msgid "Send text only notification emails, without the html part"
-msgstr ""
-
-#: mod/settings.php:1270
-msgid "Show detailled notifications"
-msgstr ""
-
-#: mod/settings.php:1272
-msgid ""
-"Per default, notifications are condensed to a single notification per item. "
-"When enabled every notification is displayed."
-msgstr ""
-
-#: mod/settings.php:1274
-msgid "Advanced Account/Page Type Settings"
-msgstr ""
-
-#: mod/settings.php:1275
-msgid "Change the behaviour of this account for special situations"
-msgstr ""
-
-#: mod/settings.php:1278
-msgid "Relocate"
-msgstr ""
-
-#: mod/settings.php:1279
-msgid ""
-"If you have moved this profile from another server, and some of your "
-"contacts don't receive your updates, try pushing this button."
-msgstr ""
-
-#: mod/settings.php:1280
-msgid "Resend relocate message to contacts"
-msgstr ""
-
-#: mod/directory.php:152 src/Model/Profile.php:421 src/Model/Profile.php:769
-msgid "Status:"
-msgstr ""
-
-#: mod/directory.php:153 src/Model/Profile.php:422 src/Model/Profile.php:786
-msgid "Homepage:"
-msgstr ""
-
-#: mod/directory.php:202 view/theme/vier/theme.php:201
-msgid "Global Directory"
-msgstr ""
-
-#: mod/directory.php:204
-msgid "Find on this site"
-msgstr ""
-
-#: mod/directory.php:206
-msgid "Results for:"
-msgstr ""
-
-#: mod/directory.php:208
-msgid "Site Directory"
-msgstr ""
-
-#: mod/directory.php:209 mod/contacts.php:820 src/Content/Widget.php:63
-msgid "Find"
-msgstr ""
-
-#: mod/directory.php:213
-msgid "No entries (some entries may be hidden)."
-msgstr ""
-
-#: mod/babel.php:22
-msgid "Source input"
-msgstr ""
-
-#: mod/babel.php:28
-msgid "BBCode::convert (raw HTML)"
-msgstr ""
-
-#: mod/babel.php:33
-msgid "BBCode::convert"
-msgstr ""
-
-#: mod/babel.php:39
-msgid "BBCode::convert => HTML::toBBCode"
-msgstr ""
-
-#: mod/babel.php:45
-msgid "BBCode::toMarkdown"
-msgstr ""
-
-#: mod/babel.php:51
-msgid "BBCode::toMarkdown => Markdown::convert"
-msgstr ""
-
-#: mod/babel.php:57
-msgid "BBCode::toMarkdown => Markdown::toBBCode"
-msgstr ""
-
-#: mod/babel.php:63
-msgid "BBCode::toMarkdown =>  Markdown::convert => HTML::toBBCode"
-msgstr ""
-
-#: mod/babel.php:70
-msgid "Source input \\x28Diaspora format\\x29"
-msgstr ""
-
-#: mod/babel.php:76
-msgid "Markdown::toBBCode"
-msgstr ""
-
-#: mod/babel.php:83
-msgid "Raw HTML input"
-msgstr ""
-
-#: mod/babel.php:88
-msgid "HTML Input"
-msgstr ""
-
-#: mod/babel.php:94
-msgid "HTML::toBBCode"
-msgstr ""
-
-#: mod/babel.php:100
-msgid "HTML::toPlaintext"
-msgstr ""
-
-#: mod/babel.php:108
-msgid "Source text"
-msgstr ""
-
-#: mod/babel.php:109
-msgid "BBCode"
-msgstr ""
-
-#: mod/babel.php:110
-msgid "Markdown"
-msgstr ""
-
-#: mod/babel.php:111
-msgid "HTML"
-msgstr ""
-
-#: mod/follow.php:45
-msgid "The contact could not be added."
-msgstr ""
-
-#: mod/follow.php:73
-msgid "You already added this contact."
-msgstr ""
-
-#: mod/follow.php:83
-msgid "Diaspora support isn't enabled. Contact can't be added."
-msgstr ""
-
-#: mod/follow.php:90
-msgid "OStatus support is disabled. Contact can't be added."
-msgstr ""
-
-#: mod/follow.php:97
-msgid "The network type couldn't be detected. Contact can't be added."
+#: mod/profile.php:194
+msgid "Tips for New Members"
 msgstr ""
 
 #: mod/profiles.php:58
@@ -4914,10 +5955,6 @@ msgstr ""
 
 #: mod/profiles.php:390 mod/profiles.php:686
 msgid "Interests"
-msgstr ""
-
-#: mod/profiles.php:394 mod/admin.php:490
-msgid "Address"
 msgstr ""
 
 #: mod/profiles.php:401 mod/profiles.php:682
@@ -5203,582 +6240,76 @@ msgstr ""
 msgid "Create New Profile"
 msgstr ""
 
-#: mod/contacts.php:157
+#: mod/profile_photo.php:55
+msgid "Image uploaded but image cropping failed."
+msgstr ""
+
+#: mod/profile_photo.php:88 mod/profile_photo.php:96 mod/profile_photo.php:104
+#: mod/profile_photo.php:315
 #, php-format
-msgid "%d contact edited."
-msgid_plural "%d contacts edited."
-msgstr[0] ""
-msgstr[1] ""
-
-#: mod/contacts.php:184 mod/contacts.php:400
-msgid "Could not access contact record."
+msgid "Image size reduction [%s] failed."
 msgstr ""
 
-#: mod/contacts.php:194
-msgid "Could not locate selected profile."
-msgstr ""
-
-#: mod/contacts.php:228
-msgid "Contact updated."
-msgstr ""
-
-#: mod/contacts.php:421
-msgid "Contact has been blocked"
-msgstr ""
-
-#: mod/contacts.php:421
-msgid "Contact has been unblocked"
-msgstr ""
-
-#: mod/contacts.php:432
-msgid "Contact has been ignored"
-msgstr ""
-
-#: mod/contacts.php:432
-msgid "Contact has been unignored"
-msgstr ""
-
-#: mod/contacts.php:443
-msgid "Contact has been archived"
-msgstr ""
-
-#: mod/contacts.php:443
-msgid "Contact has been unarchived"
-msgstr ""
-
-#: mod/contacts.php:467
-msgid "Drop contact"
-msgstr ""
-
-#: mod/contacts.php:470 mod/contacts.php:823
-msgid "Do you really want to delete this contact?"
-msgstr ""
-
-#: mod/contacts.php:488
-msgid "Contact has been removed."
-msgstr ""
-
-#: mod/contacts.php:519
-#, php-format
-msgid "You are mutual friends with %s"
-msgstr ""
-
-#: mod/contacts.php:523
-#, php-format
-msgid "You are sharing with %s"
-msgstr ""
-
-#: mod/contacts.php:527
-#, php-format
-msgid "%s is sharing with you"
-msgstr ""
-
-#: mod/contacts.php:547
-msgid "Private communications are not available for this contact."
-msgstr ""
-
-#: mod/contacts.php:549
-msgid "Never"
-msgstr ""
-
-#: mod/contacts.php:552
-msgid "(Update was successful)"
-msgstr ""
-
-#: mod/contacts.php:552
-msgid "(Update was not successful)"
-msgstr ""
-
-#: mod/contacts.php:554 mod/contacts.php:992
-msgid "Suggest friends"
-msgstr ""
-
-#: mod/contacts.php:558
-#, php-format
-msgid "Network type: %s"
-msgstr ""
-
-#: mod/contacts.php:563
-msgid "Communications lost with this contact!"
-msgstr ""
-
-#: mod/contacts.php:569
-msgid "Fetch further information for feeds"
-msgstr ""
-
-#: mod/contacts.php:571
+#: mod/profile_photo.php:125
 msgid ""
-"Fetch information like preview pictures, title and teaser from the feed "
-"item. You can activate this if the feed doesn't contain much text. Keywords "
-"are taken from the meta header in the feed item and are posted as hash tags."
+"Shift-reload the page or clear browser cache if the new photo does not "
+"display immediately."
 msgstr ""
 
-#: mod/contacts.php:572 mod/admin.php:1272 mod/admin.php:1435
-#: mod/admin.php:1445
-msgid "Disabled"
+#: mod/profile_photo.php:134
+msgid "Unable to process image"
 msgstr ""
 
-#: mod/contacts.php:573
-msgid "Fetch information"
+#: mod/profile_photo.php:247
+msgid "Upload File:"
 msgstr ""
 
-#: mod/contacts.php:574
-msgid "Fetch keywords"
+#: mod/profile_photo.php:248
+msgid "Select a profile:"
 msgstr ""
 
-#: mod/contacts.php:575
-msgid "Fetch information and keywords"
+#: mod/profile_photo.php:253
+msgid "or"
 msgstr ""
 
-#: mod/contacts.php:608
-msgid "Contact"
+#: mod/profile_photo.php:253
+msgid "skip this step"
 msgstr ""
 
-#: mod/contacts.php:611
-msgid "Profile Visibility"
+#: mod/profile_photo.php:253
+msgid "select a photo from your photo albums"
 msgstr ""
 
-#: mod/contacts.php:612
-#, php-format
-msgid ""
-"Please choose the profile you would like to display to %s when viewing your "
-"profile securely."
+#: mod/profile_photo.php:266
+msgid "Crop Image"
 msgstr ""
 
-#: mod/contacts.php:613
-msgid "Contact Information / Notes"
+#: mod/profile_photo.php:267
+msgid "Please adjust the image cropping for optimum viewing."
 msgstr ""
 
-#: mod/contacts.php:614
-msgid "Their personal note"
+#: mod/profile_photo.php:269
+msgid "Done Editing"
 msgstr ""
 
-#: mod/contacts.php:616
-msgid "Edit contact notes"
+#: mod/profile_photo.php:305
+msgid "Image uploaded successfully."
 msgstr ""
 
-#: mod/contacts.php:620
-msgid "Block/Unblock contact"
+#: mod/profperm.php:34 mod/profperm.php:65
+msgid "Invalid profile identifier."
 msgstr ""
 
-#: mod/contacts.php:621
-msgid "Ignore contact"
+#: mod/profperm.php:111
+msgid "Profile Visibility Editor"
 msgstr ""
 
-#: mod/contacts.php:622
-msgid "Repair URL settings"
+#: mod/profperm.php:124
+msgid "Visible To"
 msgstr ""
 
-#: mod/contacts.php:623
-msgid "View conversations"
-msgstr ""
-
-#: mod/contacts.php:628
-msgid "Last update:"
-msgstr ""
-
-#: mod/contacts.php:630
-msgid "Update public posts"
-msgstr ""
-
-#: mod/contacts.php:632 mod/contacts.php:1002
-msgid "Update now"
-msgstr ""
-
-#: mod/contacts.php:637 mod/contacts.php:827 mod/contacts.php:1011
-#: mod/admin.php:485 mod/admin.php:1800
-msgid "Unblock"
-msgstr ""
-
-#: mod/contacts.php:637 mod/contacts.php:827 mod/contacts.php:1011
-#: mod/admin.php:484 mod/admin.php:1799
-msgid "Block"
-msgstr ""
-
-#: mod/contacts.php:638 mod/contacts.php:828 mod/contacts.php:1019
-msgid "Unignore"
-msgstr ""
-
-#: mod/contacts.php:642
-msgid "Currently blocked"
-msgstr ""
-
-#: mod/contacts.php:643
-msgid "Currently ignored"
-msgstr ""
-
-#: mod/contacts.php:644
-msgid "Currently archived"
-msgstr ""
-
-#: mod/contacts.php:645
-msgid "Awaiting connection acknowledge"
-msgstr ""
-
-#: mod/contacts.php:646
-msgid ""
-"Replies/likes to your public posts <strong>may</strong> still be visible"
-msgstr ""
-
-#: mod/contacts.php:647
-msgid "Notification for new posts"
-msgstr ""
-
-#: mod/contacts.php:647
-msgid "Send a notification of every new post of this contact"
-msgstr ""
-
-#: mod/contacts.php:650
-msgid "Blacklisted keywords"
-msgstr ""
-
-#: mod/contacts.php:650
-msgid ""
-"Comma separated list of keywords that should not be converted to hashtags, "
-"when \"Fetch information and keywords\" is selected"
-msgstr ""
-
-#: mod/contacts.php:662 src/Model/Profile.php:424
-msgid "XMPP:"
-msgstr ""
-
-#: mod/contacts.php:667
-msgid "Actions"
-msgstr ""
-
-#: mod/contacts.php:669 mod/contacts.php:855 src/Content/Nav.php:100
-#: src/Model/Profile.php:888 view/theme/frio/theme.php:259
-msgid "Status"
-msgstr ""
-
-#: mod/contacts.php:670
-msgid "Contact Settings"
-msgstr ""
-
-#: mod/contacts.php:711
-msgid "Suggestions"
-msgstr ""
-
-#: mod/contacts.php:714
-msgid "Suggest potential friends"
-msgstr ""
-
-#: mod/contacts.php:722
-msgid "Show all contacts"
-msgstr ""
-
-#: mod/contacts.php:727
-msgid "Unblocked"
-msgstr ""
-
-#: mod/contacts.php:730
-msgid "Only show unblocked contacts"
-msgstr ""
-
-#: mod/contacts.php:735
-msgid "Blocked"
-msgstr ""
-
-#: mod/contacts.php:738
-msgid "Only show blocked contacts"
-msgstr ""
-
-#: mod/contacts.php:743
-msgid "Ignored"
-msgstr ""
-
-#: mod/contacts.php:746
-msgid "Only show ignored contacts"
-msgstr ""
-
-#: mod/contacts.php:751
-msgid "Archived"
-msgstr ""
-
-#: mod/contacts.php:754
-msgid "Only show archived contacts"
-msgstr ""
-
-#: mod/contacts.php:759
-msgid "Hidden"
-msgstr ""
-
-#: mod/contacts.php:762
-msgid "Only show hidden contacts"
-msgstr ""
-
-#: mod/contacts.php:818
-msgid "Search your contacts"
-msgstr ""
-
-#: mod/contacts.php:829 mod/contacts.php:1027
-msgid "Archive"
-msgstr ""
-
-#: mod/contacts.php:829 mod/contacts.php:1027
-msgid "Unarchive"
-msgstr ""
-
-#: mod/contacts.php:832
-msgid "Batch Actions"
-msgstr ""
-
-#: mod/contacts.php:866 src/Model/Profile.php:899
-msgid "Profile Details"
-msgstr ""
-
-#: mod/contacts.php:878
-msgid "View all contacts"
-msgstr ""
-
-#: mod/contacts.php:889
-msgid "View all common friends"
-msgstr ""
-
-#: mod/contacts.php:898
-msgid "Advanced Contact Settings"
-msgstr ""
-
-#: mod/contacts.php:930
-msgid "Mutual Friendship"
-msgstr ""
-
-#: mod/contacts.php:934
-msgid "is a fan of yours"
-msgstr ""
-
-#: mod/contacts.php:938
-msgid "you are a fan of"
-msgstr ""
-
-#: mod/contacts.php:1013
-msgid "Toggle Blocked status"
-msgstr ""
-
-#: mod/contacts.php:1021
-msgid "Toggle Ignored status"
-msgstr ""
-
-#: mod/contacts.php:1029
-msgid "Toggle Archive status"
-msgstr ""
-
-#: mod/contacts.php:1037
-msgid "Delete contact"
-msgstr ""
-
-#: mod/_tos.php:48 mod/register.php:288 mod/admin.php:188 mod/admin.php:302
-#: src/Module/Tos.php:48
-msgid "Terms of Service"
-msgstr ""
-
-#: mod/_tos.php:51 src/Module/Tos.php:51
-msgid "Privacy Statement"
-msgstr ""
-
-#: mod/_tos.php:52 src/Module/Tos.php:52
-msgid ""
-"At the time of registration, and for providing communications between the "
-"user account and their contacts, the user has to provide a display name (pen "
-"name), an username (nickname) and a working email address. The names will be "
-"accessible on the profile page of the account by any visitor of the page, "
-"even if other profile details are not displayed. The email address will only "
-"be used to send the user notifications about interactions, but wont be "
-"visibly displayed. The listing of an account in the node's user directory or "
-"the global user directory is optional and can be controlled in the user "
-"settings, it is not necessary for communication."
-msgstr ""
-
-#: mod/_tos.php:53 src/Module/Tos.php:53
-#, php-format
-msgid ""
-"At any point in time a logged in user can export their account data from the "
-"<a href=\"%1$s/settings/uexport\">account settings</a>. If the user wants to "
-"delete their account they can do so at <a href=\"%1$s/removeme\">%1$s/"
-"removeme</a>. The deletion of the account will be permanent."
-msgstr ""
-
-#: mod/friendica.php:77
-msgid "This is Friendica, version"
-msgstr ""
-
-#: mod/friendica.php:78
-msgid "running at web location"
-msgstr ""
-
-#: mod/friendica.php:82
-msgid ""
-"Please visit <a href=\"https://friendi.ca\">Friendi.ca</a> to learn more "
-"about the Friendica project."
-msgstr ""
-
-#: mod/friendica.php:86
-msgid "Bug reports and issues: please visit"
-msgstr ""
-
-#: mod/friendica.php:86
-msgid "the bugtracker at github"
-msgstr ""
-
-#: mod/friendica.php:89
-msgid ""
-"Suggestions, praise, donations, etc. - please email \"Info\" at Friendica - "
-"dot com"
-msgstr ""
-
-#: mod/friendica.php:103
-msgid "Installed addons/apps:"
-msgstr ""
-
-#: mod/friendica.php:117
-msgid "No installed addons/apps"
-msgstr ""
-
-#: mod/friendica.php:122
-#, php-format
-msgid "Read about the <a href=\"%1$s/tos\">Terms of Service</a> of this node."
-msgstr ""
-
-#: mod/friendica.php:127
-msgid "On this server the following remote servers are blocked."
-msgstr ""
-
-#: mod/friendica.php:128 mod/admin.php:354 mod/admin.php:372
-msgid "Reason for the block"
-msgstr ""
-
-#: mod/lostpass.php:27
-msgid "No valid account found."
-msgstr ""
-
-#: mod/lostpass.php:39
-msgid "Password reset request issued. Check your email."
-msgstr ""
-
-#: mod/lostpass.php:45
-#, php-format
-msgid ""
-"\n"
-"\t\tDear %1$s,\n"
-"\t\t\tA request was recently received at \"%2$s\" to reset your account\n"
-"\t\tpassword. In order to confirm this request, please select the "
-"verification link\n"
-"\t\tbelow or paste it into your web browser address bar.\n"
-"\n"
-"\t\tIf you did NOT request this change, please DO NOT follow the link\n"
-"\t\tprovided and ignore and/or delete this email, the request will expire "
-"shortly.\n"
-"\n"
-"\t\tYour password will not be changed unless we can verify that you\n"
-"\t\tissued this request."
-msgstr ""
-
-#: mod/lostpass.php:56
-#, php-format
-msgid ""
-"\n"
-"\t\tFollow this link soon to verify your identity:\n"
-"\n"
-"\t\t%1$s\n"
-"\n"
-"\t\tYou will then receive a follow-up message containing the new password.\n"
-"\t\tYou may change that password from your account settings page after "
-"logging in.\n"
-"\n"
-"\t\tThe login details are as follows:\n"
-"\n"
-"\t\tSite Location:\t%2$s\n"
-"\t\tLogin Name:\t%3$s"
-msgstr ""
-
-#: mod/lostpass.php:73
-#, php-format
-msgid "Password reset requested at %s"
-msgstr ""
-
-#: mod/lostpass.php:89
-msgid ""
-"Request could not be verified. (You may have previously submitted it.) "
-"Password reset failed."
-msgstr ""
-
-#: mod/lostpass.php:102
-msgid "Request has expired, please make a new one."
-msgstr ""
-
-#: mod/lostpass.php:117
-msgid "Forgot your Password?"
-msgstr ""
-
-#: mod/lostpass.php:118
-msgid ""
-"Enter your email address and submit to have your password reset. Then check "
-"your email for further instructions."
-msgstr ""
-
-#: mod/lostpass.php:119 src/Module/Login.php:314
-msgid "Nickname or Email: "
-msgstr ""
-
-#: mod/lostpass.php:120
-msgid "Reset"
-msgstr ""
-
-#: mod/lostpass.php:136 src/Module/Login.php:326
-msgid "Password Reset"
-msgstr ""
-
-#: mod/lostpass.php:137
-msgid "Your password has been reset as requested."
-msgstr ""
-
-#: mod/lostpass.php:138
-msgid "Your new password is"
-msgstr ""
-
-#: mod/lostpass.php:139
-msgid "Save or copy your new password - and then"
-msgstr ""
-
-#: mod/lostpass.php:140
-msgid "click here to login"
-msgstr ""
-
-#: mod/lostpass.php:141
-msgid ""
-"Your password may be changed from the <em>Settings</em> page after "
-"successful login."
-msgstr ""
-
-#: mod/lostpass.php:149
-#, php-format
-msgid ""
-"\n"
-"\t\t\tDear %1$s,\n"
-"\t\t\t\tYour password has been changed as requested. Please retain this\n"
-"\t\t\tinformation for your records (or change your password immediately to\n"
-"\t\t\tsomething that you will remember).\n"
-"\t\t"
-msgstr ""
-
-#: mod/lostpass.php:155
-#, php-format
-msgid ""
-"\n"
-"\t\t\tYour login details are as follows:\n"
-"\n"
-"\t\t\tSite Location:\t%1$s\n"
-"\t\t\tLogin Name:\t%2$s\n"
-"\t\t\tPassword:\t%3$s\n"
-"\n"
-"\t\t\tYou may change that password from your account settings page after "
-"logging in.\n"
-"\t\t"
-msgstr ""
-
-#: mod/lostpass.php:169
-#, php-format
-msgid "Your password has been changed at %s"
+#: mod/profperm.php:140
+msgid "All Contacts (with secure profile access)"
 msgstr ""
 
 #: mod/register.php:99
@@ -5803,6 +6334,12 @@ msgstr ""
 
 #: mod/register.php:162
 msgid "Your registration is pending approval by the site owner."
+msgstr ""
+
+#: mod/register.php:191 mod/uimport.php:55
+msgid ""
+"This site has exceeded the number of allowed daily account registrations. "
+"Please try again tomorrow."
 msgstr ""
 
 #: mod/register.php:220
@@ -5841,10 +6378,6 @@ msgstr ""
 msgid "Your invitation code: "
 msgstr ""
 
-#: mod/register.php:264 mod/admin.php:1348
-msgid "Registration"
-msgstr ""
-
 #: mod/register.php:270
 msgid "Your Full Name (e.g. Joe Smith, real or real-looking): "
 msgstr ""
@@ -5855,8 +6388,16 @@ msgid ""
 "be an existing address.)"
 msgstr ""
 
+#: mod/register.php:273 mod/settings.php:1201
+msgid "New Password:"
+msgstr ""
+
 #: mod/register.php:273
 msgid "Leave empty for an auto generated password."
+msgstr ""
+
+#: mod/register.php:274 mod/settings.php:1202
+msgid "Confirm:"
 msgstr ""
 
 #: mod/register.php:275
@@ -5874,1903 +6415,1103 @@ msgstr ""
 msgid "Register"
 msgstr ""
 
+#: mod/register.php:285 mod/uimport.php:70
+msgid "Import"
+msgstr ""
+
 #: mod/register.php:286
 msgid "Import your profile to this friendica instance"
 msgstr ""
 
-#: mod/admin.php:106
-msgid "Theme settings updated."
+#: mod/regmod.php:68
+msgid "Account approved."
 msgstr ""
 
-#: mod/admin.php:179 src/Content/Nav.php:174
-msgid "Information"
+#: mod/regmod.php:93
+#, php-format
+msgid "Registration revoked for %s"
 msgstr ""
 
-#: mod/admin.php:180
-msgid "Overview"
+#: mod/regmod.php:102
+msgid "Please login."
 msgstr ""
 
-#: mod/admin.php:181 mod/admin.php:718
-msgid "Federation Statistics"
+#: mod/removeme.php:55 mod/removeme.php:58
+msgid "Remove My Account"
 msgstr ""
 
-#: mod/admin.php:182
-msgid "Configuration"
-msgstr ""
-
-#: mod/admin.php:183 mod/admin.php:1345
-msgid "Site"
-msgstr ""
-
-#: mod/admin.php:184 mod/admin.php:1273 mod/admin.php:1788 mod/admin.php:1804
-msgid "Users"
-msgstr ""
-
-#: mod/admin.php:186 mod/admin.php:2173 mod/admin.php:2217
-msgid "Themes"
-msgstr ""
-
-#: mod/admin.php:189
-msgid "Database"
-msgstr ""
-
-#: mod/admin.php:190
-msgid "DB updates"
-msgstr ""
-
-#: mod/admin.php:191 mod/admin.php:753
-msgid "Inspect Queue"
-msgstr ""
-
-#: mod/admin.php:192
-msgid "Tools"
-msgstr ""
-
-#: mod/admin.php:193
-msgid "Contact Blocklist"
-msgstr ""
-
-#: mod/admin.php:194 mod/admin.php:362
-msgid "Server Blocklist"
-msgstr ""
-
-#: mod/admin.php:195 mod/admin.php:521
-msgid "Delete Item"
-msgstr ""
-
-#: mod/admin.php:196 mod/admin.php:197 mod/admin.php:2291
-msgid "Logs"
-msgstr ""
-
-#: mod/admin.php:198 mod/admin.php:2358
-msgid "View Logs"
-msgstr ""
-
-#: mod/admin.php:200
-msgid "Diagnostics"
-msgstr ""
-
-#: mod/admin.php:201
-msgid "PHP Info"
-msgstr ""
-
-#: mod/admin.php:202
-msgid "probe address"
-msgstr ""
-
-#: mod/admin.php:203
-msgid "check webfinger"
-msgstr ""
-
-#: mod/admin.php:222 src/Content/Nav.php:217
-msgid "Admin"
-msgstr ""
-
-#: mod/admin.php:223
-msgid "Addon Features"
-msgstr ""
-
-#: mod/admin.php:224
-msgid "User registrations waiting for confirmation"
-msgstr ""
-
-#: mod/admin.php:301 mod/admin.php:361 mod/admin.php:478 mod/admin.php:520
-#: mod/admin.php:717 mod/admin.php:752 mod/admin.php:848 mod/admin.php:1344
-#: mod/admin.php:1787 mod/admin.php:1903 mod/admin.php:1963 mod/admin.php:2172
-#: mod/admin.php:2216 mod/admin.php:2290 mod/admin.php:2357
-msgid "Administration"
-msgstr ""
-
-#: mod/admin.php:303
-msgid "Display Terms of Service"
-msgstr ""
-
-#: mod/admin.php:303
+#: mod/removeme.php:56
 msgid ""
-"Enable the Terms of Service page. If this is enabled a link to the terms "
-"will be added to the registration form and the general information page."
+"This will completely remove your account. Once this has been done it is not "
+"recoverable."
 msgstr ""
 
-#: mod/admin.php:304
-msgid "Display Privacy Statement"
+#: mod/removeme.php:57
+msgid "Please enter your password for verification:"
 msgstr ""
 
-#: mod/admin.php:304
+#: mod/repair_ostatus.php:18
+msgid "Resubscribing to OStatus contacts"
+msgstr ""
+
+#: mod/repair_ostatus.php:34
+msgid "Error"
+msgstr ""
+
+#: mod/search.php:105
+msgid "Only logged in users are permitted to perform a search."
+msgstr ""
+
+#: mod/search.php:129
+msgid "Too Many Requests"
+msgstr ""
+
+#: mod/search.php:130
+msgid "Only one search per minute is permitted for not logged in users."
+msgstr ""
+
+#: mod/search.php:234
+#, php-format
+msgid "Items tagged with: %s"
+msgstr ""
+
+#: mod/settings.php:72
+msgid "Display"
+msgstr ""
+
+#: mod/settings.php:79 mod/settings.php:842
+msgid "Social Networks"
+msgstr ""
+
+#: mod/settings.php:93 src/Content/Nav.php:204
+msgid "Delegations"
+msgstr ""
+
+#: mod/settings.php:100
+msgid "Connected apps"
+msgstr ""
+
+#: mod/settings.php:107 mod/uexport.php:52
+msgid "Export personal data"
+msgstr ""
+
+#: mod/settings.php:114
+msgid "Remove account"
+msgstr ""
+
+#: mod/settings.php:168
+msgid "Missing some important data!"
+msgstr ""
+
+#: mod/settings.php:279
+msgid "Failed to connect with email account using the settings provided."
+msgstr ""
+
+#: mod/settings.php:284
+msgid "Email settings updated."
+msgstr ""
+
+#: mod/settings.php:300
+msgid "Features updated"
+msgstr ""
+
+#: mod/settings.php:372
+msgid "Relocate message has been send to your contacts"
+msgstr ""
+
+#: mod/settings.php:384 src/Model/User.php:325
+msgid "Passwords do not match. Password unchanged."
+msgstr ""
+
+#: mod/settings.php:389
+msgid "Empty passwords are not allowed. Password unchanged."
+msgstr ""
+
+#: mod/settings.php:394 src/Core/Console/NewPassword.php:78
+msgid ""
+"The new password has been exposed in a public data dump, please choose "
+"another."
+msgstr ""
+
+#: mod/settings.php:400
+msgid "Wrong password."
+msgstr ""
+
+#: mod/settings.php:407 src/Core/Console/NewPassword.php:85
+msgid "Password changed."
+msgstr ""
+
+#: mod/settings.php:409 src/Core/Console/NewPassword.php:82
+msgid "Password update failed. Please try again."
+msgstr ""
+
+#: mod/settings.php:496
+msgid " Please use a shorter name."
+msgstr ""
+
+#: mod/settings.php:499
+msgid " Name too short."
+msgstr ""
+
+#: mod/settings.php:507
+msgid "Wrong Password"
+msgstr ""
+
+#: mod/settings.php:512
+msgid "Invalid email."
+msgstr ""
+
+#: mod/settings.php:519
+msgid "Cannot change to that email."
+msgstr ""
+
+#: mod/settings.php:572
+msgid "Private forum has no privacy permissions. Using default privacy group."
+msgstr ""
+
+#: mod/settings.php:575
+msgid "Private forum has no privacy permissions and no default privacy group."
+msgstr ""
+
+#: mod/settings.php:615
+msgid "Settings updated."
+msgstr ""
+
+#: mod/settings.php:674 mod/settings.php:700 mod/settings.php:736
+msgid "Add application"
+msgstr ""
+
+#: mod/settings.php:678 mod/settings.php:704
+msgid "Consumer Key"
+msgstr ""
+
+#: mod/settings.php:679 mod/settings.php:705
+msgid "Consumer Secret"
+msgstr ""
+
+#: mod/settings.php:680 mod/settings.php:706
+msgid "Redirect"
+msgstr ""
+
+#: mod/settings.php:681 mod/settings.php:707
+msgid "Icon url"
+msgstr ""
+
+#: mod/settings.php:692
+msgid "You can't edit this application."
+msgstr ""
+
+#: mod/settings.php:735
+msgid "Connected Apps"
+msgstr ""
+
+#: mod/settings.php:737 src/Object/Post.php:155 src/Object/Post.php:157
+msgid "Edit"
+msgstr ""
+
+#: mod/settings.php:739
+msgid "Client key starts with"
+msgstr ""
+
+#: mod/settings.php:740
+msgid "No name"
+msgstr ""
+
+#: mod/settings.php:741
+msgid "Remove authorization"
+msgstr ""
+
+#: mod/settings.php:752
+msgid "No Addon settings configured"
+msgstr ""
+
+#: mod/settings.php:761
+msgid "Addon Settings"
+msgstr ""
+
+#: mod/settings.php:782
+msgid "Additional Features"
+msgstr ""
+
+#: mod/settings.php:805 src/Content/ContactSelector.php:83
+msgid "Diaspora"
+msgstr ""
+
+#: mod/settings.php:805 mod/settings.php:806
+msgid "enabled"
+msgstr ""
+
+#: mod/settings.php:805 mod/settings.php:806
+msgid "disabled"
+msgstr ""
+
+#: mod/settings.php:805 mod/settings.php:806
+#, php-format
+msgid "Built-in support for %s connectivity is %s"
+msgstr ""
+
+#: mod/settings.php:806
+msgid "GNU Social (OStatus)"
+msgstr ""
+
+#: mod/settings.php:837
+msgid "Email access is disabled on this site."
+msgstr ""
+
+#: mod/settings.php:847
+msgid "General Social Media Settings"
+msgstr ""
+
+#: mod/settings.php:848
+msgid "Disable Content Warning"
+msgstr ""
+
+#: mod/settings.php:848
+msgid ""
+"Users on networks like Mastodon or Pleroma are able to set a content warning "
+"field which collapse their post by default. This disables the automatic "
+"collapsing and sets the content warning as the post title. Doesn't affect "
+"any other content filtering you eventually set up."
+msgstr ""
+
+#: mod/settings.php:849
+msgid "Disable intelligent shortening"
+msgstr ""
+
+#: mod/settings.php:849
+msgid ""
+"Normally the system tries to find the best link to add to shortened posts. "
+"If this option is enabled then every shortened post will always point to the "
+"original friendica post."
+msgstr ""
+
+#: mod/settings.php:850
+msgid "Automatically follow any GNU Social (OStatus) followers/mentioners"
+msgstr ""
+
+#: mod/settings.php:850
+msgid ""
+"If you receive a message from an unknown OStatus user, this option decides "
+"what to do. If it is checked, a new contact will be created for every "
+"unknown user."
+msgstr ""
+
+#: mod/settings.php:851
+msgid "Default group for OStatus contacts"
+msgstr ""
+
+#: mod/settings.php:852
+msgid "Your legacy GNU Social account"
+msgstr ""
+
+#: mod/settings.php:852
+msgid ""
+"If you enter your old GNU Social/Statusnet account name here (in the format "
+"user@domain.tld), your contacts will be added automatically. The field will "
+"be emptied when done."
+msgstr ""
+
+#: mod/settings.php:855
+msgid "Repair OStatus subscriptions"
+msgstr ""
+
+#: mod/settings.php:859
+msgid "Email/Mailbox Setup"
+msgstr ""
+
+#: mod/settings.php:860
+msgid ""
+"If you wish to communicate with email contacts using this service "
+"(optional), please specify how to connect to your mailbox."
+msgstr ""
+
+#: mod/settings.php:861
+msgid "Last successful email check:"
+msgstr ""
+
+#: mod/settings.php:863
+msgid "IMAP server name:"
+msgstr ""
+
+#: mod/settings.php:864
+msgid "IMAP port:"
+msgstr ""
+
+#: mod/settings.php:865
+msgid "Security:"
+msgstr ""
+
+#: mod/settings.php:865 mod/settings.php:870
+msgid "None"
+msgstr ""
+
+#: mod/settings.php:866
+msgid "Email login name:"
+msgstr ""
+
+#: mod/settings.php:867
+msgid "Email password:"
+msgstr ""
+
+#: mod/settings.php:868
+msgid "Reply-to address:"
+msgstr ""
+
+#: mod/settings.php:869
+msgid "Send public posts to all email contacts:"
+msgstr ""
+
+#: mod/settings.php:870
+msgid "Action after import:"
+msgstr ""
+
+#: mod/settings.php:870 src/Content/Nav.php:191
+msgid "Mark as seen"
+msgstr ""
+
+#: mod/settings.php:870
+msgid "Move to folder"
+msgstr ""
+
+#: mod/settings.php:871
+msgid "Move to folder:"
+msgstr ""
+
+#: mod/settings.php:914
+#, php-format
+msgid "%s - (Unsupported)"
+msgstr ""
+
+#: mod/settings.php:916
+#, php-format
+msgid "%s - (Experimental)"
+msgstr ""
+
+#: mod/settings.php:959
+msgid "Display Settings"
+msgstr ""
+
+#: mod/settings.php:965 mod/settings.php:989
+msgid "Display Theme:"
+msgstr ""
+
+#: mod/settings.php:966
+msgid "Mobile Theme:"
+msgstr ""
+
+#: mod/settings.php:967
+msgid "Suppress warning of insecure networks"
+msgstr ""
+
+#: mod/settings.php:967
+msgid ""
+"Should the system suppress the warning that the current group contains "
+"members of networks that can't receive non public postings."
+msgstr ""
+
+#: mod/settings.php:968
+msgid "Update browser every xx seconds"
+msgstr ""
+
+#: mod/settings.php:968
+msgid "Minimum of 10 seconds. Enter -1 to disable it."
+msgstr ""
+
+#: mod/settings.php:969
+msgid "Number of items to display per page:"
+msgstr ""
+
+#: mod/settings.php:969 mod/settings.php:970
+msgid "Maximum of 100 items"
+msgstr ""
+
+#: mod/settings.php:970
+msgid "Number of items to display per page when viewed from mobile device:"
+msgstr ""
+
+#: mod/settings.php:971
+msgid "Don't show emoticons"
+msgstr ""
+
+#: mod/settings.php:972
+msgid "Calendar"
+msgstr ""
+
+#: mod/settings.php:973
+msgid "Beginning of week:"
+msgstr ""
+
+#: mod/settings.php:974
+msgid "Don't show notices"
+msgstr ""
+
+#: mod/settings.php:975
+msgid "Infinite scroll"
+msgstr ""
+
+#: mod/settings.php:976
+msgid "Automatic updates only at the top of the network page"
+msgstr ""
+
+#: mod/settings.php:976
+msgid ""
+"When disabled, the network page is updated all the time, which could be "
+"confusing while reading."
+msgstr ""
+
+#: mod/settings.php:977
+msgid "Bandwith Saver Mode"
+msgstr ""
+
+#: mod/settings.php:977
+msgid ""
+"When enabled, embedded content is not displayed on automatic updates, they "
+"only show on page reload."
+msgstr ""
+
+#: mod/settings.php:978
+msgid "Smart Threading"
+msgstr ""
+
+#: mod/settings.php:978
+msgid ""
+"When enabled, suppress extraneous thread indentation while keeping it where "
+"it matters. Only works if threading is available and enabled."
+msgstr ""
+
+#: mod/settings.php:980
+msgid "General Theme Settings"
+msgstr ""
+
+#: mod/settings.php:981
+msgid "Custom Theme Settings"
+msgstr ""
+
+#: mod/settings.php:982
+msgid "Content Settings"
+msgstr ""
+
+#: mod/settings.php:983 view/theme/duepuntozero/config.php:73
+#: view/theme/frio/config.php:115 view/theme/quattro/config.php:75
+#: view/theme/vier/config.php:121
+msgid "Theme settings"
+msgstr ""
+
+#: mod/settings.php:1002
+msgid "Unable to find your profile. Please contact your admin."
+msgstr ""
+
+#: mod/settings.php:1044
+msgid "Account Types"
+msgstr ""
+
+#: mod/settings.php:1045
+msgid "Personal Page Subtypes"
+msgstr ""
+
+#: mod/settings.php:1046
+msgid "Community Forum Subtypes"
+msgstr ""
+
+#: mod/settings.php:1053
+msgid "Personal Page"
+msgstr ""
+
+#: mod/settings.php:1054
+msgid "Account for a personal profile."
+msgstr ""
+
+#: mod/settings.php:1057
+msgid "Organisation Page"
+msgstr ""
+
+#: mod/settings.php:1058
+msgid ""
+"Account for an organisation that automatically approves contact requests as "
+"\"Followers\"."
+msgstr ""
+
+#: mod/settings.php:1061
+msgid "News Page"
+msgstr ""
+
+#: mod/settings.php:1062
+msgid ""
+"Account for a news reflector that automatically approves contact requests as "
+"\"Followers\"."
+msgstr ""
+
+#: mod/settings.php:1065
+msgid "Community Forum"
+msgstr ""
+
+#: mod/settings.php:1066
+msgid "Account for community discussions."
+msgstr ""
+
+#: mod/settings.php:1069
+msgid "Normal Account Page"
+msgstr ""
+
+#: mod/settings.php:1070
+msgid ""
+"Account for a regular personal profile that requires manual approval of "
+"\"Friends\" and \"Followers\"."
+msgstr ""
+
+#: mod/settings.php:1073
+msgid "Soapbox Page"
+msgstr ""
+
+#: mod/settings.php:1074
+msgid ""
+"Account for a public profile that automatically approves contact requests as "
+"\"Followers\"."
+msgstr ""
+
+#: mod/settings.php:1077
+msgid "Public Forum"
+msgstr ""
+
+#: mod/settings.php:1078
+msgid "Automatically approves all contact requests."
+msgstr ""
+
+#: mod/settings.php:1081
+msgid "Automatic Friend Page"
+msgstr ""
+
+#: mod/settings.php:1082
+msgid ""
+"Account for a popular profile that automatically approves contact requests "
+"as \"Friends\"."
+msgstr ""
+
+#: mod/settings.php:1085
+msgid "Private Forum [Experimental]"
+msgstr ""
+
+#: mod/settings.php:1086
+msgid "Requires manual approval of contact requests."
+msgstr ""
+
+#: mod/settings.php:1097
+msgid "OpenID:"
+msgstr ""
+
+#: mod/settings.php:1097
+msgid "(Optional) Allow this OpenID to login to this account."
+msgstr ""
+
+#: mod/settings.php:1105
+msgid "Publish your default profile in your local site directory?"
+msgstr ""
+
+#: mod/settings.php:1105
 #, php-format
 msgid ""
-"Show some informations regarding the needed information to operate the node "
-"according e.g. to <a href=\"%s\" target=\"_blank\">EU-GDPR</a>."
+"Your profile will be published in the global friendica directories (e.g. <a "
+"href=\"%s\">%s</a>). Your profile will be visible in public."
 msgstr ""
 
-#: mod/admin.php:305
-msgid "The Terms of Service"
+#: mod/settings.php:1111
+msgid "Publish your default profile in the global social directory?"
 msgstr ""
 
-#: mod/admin.php:305
-msgid ""
-"Enter the Terms of Service for your node here. You can use BBCode. Headers "
-"of sections should be [h2] and below."
-msgstr ""
-
-#: mod/admin.php:353
-msgid "The blocked domain"
-msgstr ""
-
-#: mod/admin.php:354 mod/admin.php:367
-msgid "The reason why you blocked this domain."
-msgstr ""
-
-#: mod/admin.php:355
-msgid "Delete domain"
-msgstr ""
-
-#: mod/admin.php:355
-msgid "Check to delete this entry from the blocklist"
-msgstr ""
-
-#: mod/admin.php:363
-msgid ""
-"This page can be used to define a black list of servers from the federated "
-"network that are not allowed to interact with your node. For all entered "
-"domains you should also give a reason why you have blocked the remote server."
-msgstr ""
-
-#: mod/admin.php:364
-msgid ""
-"The list of blocked servers will be made publically available on the /"
-"friendica page so that your users and people investigating communication "
-"problems can find the reason easily."
-msgstr ""
-
-#: mod/admin.php:365
-msgid "Add new entry to block list"
-msgstr ""
-
-#: mod/admin.php:366
-msgid "Server Domain"
-msgstr ""
-
-#: mod/admin.php:366
-msgid ""
-"The domain of the new server to add to the block list. Do not include the "
-"protocol."
-msgstr ""
-
-#: mod/admin.php:367
-msgid "Block reason"
-msgstr ""
-
-#: mod/admin.php:368
-msgid "Add Entry"
-msgstr ""
-
-#: mod/admin.php:369
-msgid "Save changes to the blocklist"
-msgstr ""
-
-#: mod/admin.php:370
-msgid "Current Entries in the Blocklist"
-msgstr ""
-
-#: mod/admin.php:373
-msgid "Delete entry from blocklist"
-msgstr ""
-
-#: mod/admin.php:376
-msgid "Delete entry from blocklist?"
-msgstr ""
-
-#: mod/admin.php:402
-msgid "Server added to blocklist."
-msgstr ""
-
-#: mod/admin.php:418
-msgid "Site blocklist updated."
-msgstr ""
-
-#: mod/admin.php:441 src/Core/Console/GlobalCommunityBlock.php:72
-msgid "The contact has been blocked from the node"
-msgstr ""
-
-#: mod/admin.php:443 src/Core/Console/GlobalCommunityBlock.php:69
-#, php-format
-msgid "Could not find any contact entry for this URL (%s)"
-msgstr ""
-
-#: mod/admin.php:450
-#, php-format
-msgid "%s contact unblocked"
-msgid_plural "%s contacts unblocked"
-msgstr[0] ""
-msgstr[1] ""
-
-#: mod/admin.php:479
-msgid "Remote Contact Blocklist"
-msgstr ""
-
-#: mod/admin.php:480
-msgid ""
-"This page allows you to prevent any message from a remote contact to reach "
-"your node."
-msgstr ""
-
-#: mod/admin.php:481
-msgid "Block Remote Contact"
-msgstr ""
-
-#: mod/admin.php:482 mod/admin.php:1790
-msgid "select all"
-msgstr ""
-
-#: mod/admin.php:483
-msgid "select none"
-msgstr ""
-
-#: mod/admin.php:486
-msgid "No remote contact is blocked from this node."
-msgstr ""
-
-#: mod/admin.php:488
-msgid "Blocked Remote Contacts"
-msgstr ""
-
-#: mod/admin.php:489
-msgid "Block New Remote Contact"
-msgstr ""
-
-#: mod/admin.php:490
-msgid "Photo"
-msgstr ""
-
-#: mod/admin.php:498
-#, php-format
-msgid "%s total blocked contact"
-msgid_plural "%s total blocked contacts"
-msgstr[0] ""
-msgstr[1] ""
-
-#: mod/admin.php:500
-msgid "URL of the remote contact to block."
-msgstr ""
-
-#: mod/admin.php:522
-msgid "Delete this Item"
-msgstr ""
-
-#: mod/admin.php:523
-msgid ""
-"On this page you can delete an item from your node. If the item is a top "
-"level posting, the entire thread will be deleted."
-msgstr ""
-
-#: mod/admin.php:524
-msgid ""
-"You need to know the GUID of the item. You can find it e.g. by looking at "
-"the display URL. The last part of http://example.com/display/123456 is the "
-"GUID, here 123456."
-msgstr ""
-
-#: mod/admin.php:525
-msgid "GUID"
-msgstr ""
-
-#: mod/admin.php:525
-msgid "The GUID of the item you want to delete."
-msgstr ""
-
-#: mod/admin.php:564
-msgid "Item marked for deletion."
-msgstr ""
-
-#: mod/admin.php:635
-msgid "unknown"
-msgstr ""
-
-#: mod/admin.php:711
-msgid ""
-"This page offers you some numbers to the known part of the federated social "
-"network your Friendica node is part of. These numbers are not complete but "
-"only reflect the part of the network your node is aware of."
-msgstr ""
-
-#: mod/admin.php:712
-msgid ""
-"The <em>Auto Discovered Contact Directory</em> feature is not enabled, it "
-"will improve the data displayed here."
-msgstr ""
-
-#: mod/admin.php:724
+#: mod/settings.php:1111
 #, php-format
 msgid ""
-"Currently this node is aware of %d nodes with %d registered users from the "
-"following platforms:"
+"Your profile will be published in this node's <a href=\"%s\">local "
+"directory</a>. Your profile details may be publicly visible depending on the "
+"system settings."
 msgstr ""
 
-#: mod/admin.php:755
-msgid "ID"
+#: mod/settings.php:1118
+msgid "Hide your contact/friend list from viewers of your default profile?"
 msgstr ""
 
-#: mod/admin.php:756
-msgid "Recipient Name"
-msgstr ""
-
-#: mod/admin.php:757
-msgid "Recipient Profile"
-msgstr ""
-
-#: mod/admin.php:758 src/Core/NotificationsManager.php:178
-#: src/Content/Nav.php:178 view/theme/frio/theme.php:266
-msgid "Network"
-msgstr ""
-
-#: mod/admin.php:759
-msgid "Created"
-msgstr ""
-
-#: mod/admin.php:760
-msgid "Last Tried"
-msgstr ""
-
-#: mod/admin.php:761
+#: mod/settings.php:1118
 msgid ""
-"This page lists the content of the queue for outgoing postings. These are "
-"postings the initial delivery failed for. They will be resend later and "
-"eventually deleted if the delivery fails permanently."
+"Your contact list won't be shown in your default profile page. You can "
+"decide to show your contact list separately for each additional profile you "
+"create"
 msgstr ""
 
-#: mod/admin.php:785
+#: mod/settings.php:1122
+msgid "Hide your profile details from anonymous viewers?"
+msgstr ""
+
+#: mod/settings.php:1122
+msgid ""
+"Anonymous visitors will only see your profile picture, your display name and "
+"the nickname you are using on your profile page. Disables posting public "
+"messages to Diaspora and other networks."
+msgstr ""
+
+#: mod/settings.php:1126
+msgid "Allow friends to post to your profile page?"
+msgstr ""
+
+#: mod/settings.php:1126
+msgid ""
+"Your contacts may write posts on your profile wall. These posts will be "
+"distributed to your contacts"
+msgstr ""
+
+#: mod/settings.php:1130
+msgid "Allow friends to tag your posts?"
+msgstr ""
+
+#: mod/settings.php:1130
+msgid "Your contacts can add additional tags to your posts."
+msgstr ""
+
+#: mod/settings.php:1134
+msgid "Allow us to suggest you as a potential friend to new members?"
+msgstr ""
+
+#: mod/settings.php:1134
+msgid "If you like, Friendica may suggest new members to add you as a contact."
+msgstr ""
+
+#: mod/settings.php:1138
+msgid "Permit unknown people to send you private mail?"
+msgstr ""
+
+#: mod/settings.php:1138
+msgid ""
+"Friendica network users may send you private messages even if they are not "
+"in your contact list."
+msgstr ""
+
+#: mod/settings.php:1142
+msgid "Profile is <strong>not published</strong>."
+msgstr ""
+
+#: mod/settings.php:1148
+#, php-format
+msgid "Your Identity Address is <strong>'%s'</strong> or '%s'."
+msgstr ""
+
+#: mod/settings.php:1155
+msgid "Automatically expire posts after this many days:"
+msgstr ""
+
+#: mod/settings.php:1155
+msgid "If empty, posts will not expire. Expired posts will be deleted"
+msgstr ""
+
+#: mod/settings.php:1156
+msgid "Advanced expiration settings"
+msgstr ""
+
+#: mod/settings.php:1157
+msgid "Advanced Expiration"
+msgstr ""
+
+#: mod/settings.php:1158
+msgid "Expire posts:"
+msgstr ""
+
+#: mod/settings.php:1159
+msgid "Expire personal notes:"
+msgstr ""
+
+#: mod/settings.php:1160
+msgid "Expire starred posts:"
+msgstr ""
+
+#: mod/settings.php:1161
+msgid "Expire photos:"
+msgstr ""
+
+#: mod/settings.php:1162
+msgid "Only expire posts by others:"
+msgstr ""
+
+#: mod/settings.php:1192
+msgid "Account Settings"
+msgstr ""
+
+#: mod/settings.php:1200
+msgid "Password Settings"
+msgstr ""
+
+#: mod/settings.php:1202
+msgid "Leave password fields blank unless changing"
+msgstr ""
+
+#: mod/settings.php:1203
+msgid "Current Password:"
+msgstr ""
+
+#: mod/settings.php:1203 mod/settings.php:1204
+msgid "Your current password to confirm the changes"
+msgstr ""
+
+#: mod/settings.php:1204
+msgid "Password:"
+msgstr ""
+
+#: mod/settings.php:1208
+msgid "Basic Settings"
+msgstr ""
+
+#: mod/settings.php:1209 src/Model/Profile.php:738
+msgid "Full Name:"
+msgstr ""
+
+#: mod/settings.php:1210
+msgid "Email Address:"
+msgstr ""
+
+#: mod/settings.php:1211
+msgid "Your Timezone:"
+msgstr ""
+
+#: mod/settings.php:1212
+msgid "Your Language:"
+msgstr ""
+
+#: mod/settings.php:1212
+msgid ""
+"Set the language we use to show you friendica interface and to send you "
+"emails"
+msgstr ""
+
+#: mod/settings.php:1213
+msgid "Default Post Location:"
+msgstr ""
+
+#: mod/settings.php:1214
+msgid "Use Browser Location:"
+msgstr ""
+
+#: mod/settings.php:1217
+msgid "Security and Privacy Settings"
+msgstr ""
+
+#: mod/settings.php:1219
+msgid "Maximum Friend Requests/Day:"
+msgstr ""
+
+#: mod/settings.php:1219 mod/settings.php:1248
+msgid "(to prevent spam abuse)"
+msgstr ""
+
+#: mod/settings.php:1220
+msgid "Default Post Permissions"
+msgstr ""
+
+#: mod/settings.php:1221
+msgid "(click to open/close)"
+msgstr ""
+
+#: mod/settings.php:1231
+msgid "Default Private Post"
+msgstr ""
+
+#: mod/settings.php:1232
+msgid "Default Public Post"
+msgstr ""
+
+#: mod/settings.php:1236
+msgid "Default Permissions for New Posts"
+msgstr ""
+
+#: mod/settings.php:1248
+msgid "Maximum private messages per day from unknown people:"
+msgstr ""
+
+#: mod/settings.php:1251
+msgid "Notification Settings"
+msgstr ""
+
+#: mod/settings.php:1252
+msgid "By default post a status message when:"
+msgstr ""
+
+#: mod/settings.php:1253
+msgid "accepting a friend request"
+msgstr ""
+
+#: mod/settings.php:1254
+msgid "joining a forum/community"
+msgstr ""
+
+#: mod/settings.php:1255
+msgid "making an <em>interesting</em> profile change"
+msgstr ""
+
+#: mod/settings.php:1256
+msgid "Send a notification email when:"
+msgstr ""
+
+#: mod/settings.php:1257
+msgid "You receive an introduction"
+msgstr ""
+
+#: mod/settings.php:1258
+msgid "Your introductions are confirmed"
+msgstr ""
+
+#: mod/settings.php:1259
+msgid "Someone writes on your profile wall"
+msgstr ""
+
+#: mod/settings.php:1260
+msgid "Someone writes a followup comment"
+msgstr ""
+
+#: mod/settings.php:1261
+msgid "You receive a private message"
+msgstr ""
+
+#: mod/settings.php:1262
+msgid "You receive a friend suggestion"
+msgstr ""
+
+#: mod/settings.php:1263
+msgid "You are tagged in a post"
+msgstr ""
+
+#: mod/settings.php:1264
+msgid "You are poked/prodded/etc. in a post"
+msgstr ""
+
+#: mod/settings.php:1266
+msgid "Activate desktop notifications"
+msgstr ""
+
+#: mod/settings.php:1266
+msgid "Show desktop popup on new notifications"
+msgstr ""
+
+#: mod/settings.php:1268
+msgid "Text-only notification emails"
+msgstr ""
+
+#: mod/settings.php:1270
+msgid "Send text only notification emails, without the html part"
+msgstr ""
+
+#: mod/settings.php:1272
+msgid "Show detailled notifications"
+msgstr ""
+
+#: mod/settings.php:1274
+msgid ""
+"Per default, notifications are condensed to a single notification per item. "
+"When enabled every notification is displayed."
+msgstr ""
+
+#: mod/settings.php:1276
+msgid "Advanced Account/Page Type Settings"
+msgstr ""
+
+#: mod/settings.php:1277
+msgid "Change the behaviour of this account for special situations"
+msgstr ""
+
+#: mod/settings.php:1280
+msgid "Relocate"
+msgstr ""
+
+#: mod/settings.php:1281
+msgid ""
+"If you have moved this profile from another server, and some of your "
+"contacts don't receive your updates, try pushing this button."
+msgstr ""
+
+#: mod/settings.php:1282
+msgid "Resend relocate message to contacts"
+msgstr ""
+
+#: mod/subthread.php:113
+#, php-format
+msgid "%1$s is following %2$s's %3$s"
+msgstr ""
+
+#: mod/suggest.php:36
+msgid "Do you really want to delete this suggestion?"
+msgstr ""
+
+#: mod/suggest.php:73
+msgid ""
+"No suggestions available. If this is a new site, please try again in 24 "
+"hours."
+msgstr ""
+
+#: mod/suggest.php:84 mod/suggest.php:104
+msgid "Ignore/Hide"
+msgstr ""
+
+#: mod/suggest.php:114 src/Content/Widget.php:64 view/theme/vier/theme.php:203
+msgid "Friend Suggestions"
+msgstr ""
+
+#: mod/tagrm.php:47
+msgid "Tag removed"
+msgstr ""
+
+#: mod/tagrm.php:85
+msgid "Remove Item Tag"
+msgstr ""
+
+#: mod/tagrm.php:87
+msgid "Select a tag to remove: "
+msgstr ""
+
+#: mod/uexport.php:44
+msgid "Export account"
+msgstr ""
+
+#: mod/uexport.php:44
+msgid ""
+"Export your account info and contacts. Use this to make a backup of your "
+"account and/or to move it to another server."
+msgstr ""
+
+#: mod/uexport.php:45
+msgid "Export all"
+msgstr ""
+
+#: mod/uexport.php:45
+msgid ""
+"Export your accout info, contacts and all your items as json. Could be a "
+"very big file, and could take a lot of time. Use this to make a full backup "
+"of your account (photos are not exported)"
+msgstr ""
+
+#: mod/uimport.php:72
+msgid "Move account"
+msgstr ""
+
+#: mod/uimport.php:73
+msgid "You can import an account from another Friendica server."
+msgstr ""
+
+#: mod/uimport.php:74
+msgid ""
+"You need to export your account from the old server and upload it here. We "
+"will recreate your old account here with all your contacts. We will try also "
+"to inform your friends that you moved here."
+msgstr ""
+
+#: mod/uimport.php:75
+msgid ""
+"This feature is experimental. We can't import contacts from the OStatus "
+"network (GNU Social/Statusnet) or from Diaspora"
+msgstr ""
+
+#: mod/uimport.php:76
+msgid "Account file"
+msgstr ""
+
+#: mod/uimport.php:76
+msgid ""
+"To export your account, go to \"Settings->Export your personal data\" and "
+"select \"Export account\""
+msgstr ""
+
+#: mod/unfollow.php:34
+msgid "Contact wasn't found or can't be unfollowed."
+msgstr ""
+
+#: mod/unfollow.php:47
+msgid "Contact unfollowed"
+msgstr ""
+
+#: mod/unfollow.php:73
+msgid "You aren't a friend of this contact."
+msgstr ""
+
+#: mod/unfollow.php:79
+msgid "Unfollowing is currently not supported by your network."
+msgstr ""
+
+#: mod/update_community.php:27 mod/update_display.php:27
+#: mod/update_network.php:33 mod/update_notes.php:40 mod/update_profile.php:39
+msgid "[Embedded content - reload page to view]"
+msgstr ""
+
+#: mod/videos.php:139
+msgid "Do you really want to delete this video?"
+msgstr ""
+
+#: mod/videos.php:144
+msgid "Delete Video"
+msgstr ""
+
+#: mod/videos.php:207
+msgid "No videos selected"
+msgstr ""
+
+#: mod/videos.php:396
+msgid "Recent Videos"
+msgstr ""
+
+#: mod/videos.php:398
+msgid "Upload New Videos"
+msgstr ""
+
+#: mod/viewcontacts.php:87
+msgid "No contacts."
+msgstr ""
+
+#: mod/viewsrc.php:12
+msgid "Access denied."
+msgstr ""
+
+#: mod/wallmessage.php:49 mod/wallmessage.php:112
+#, php-format
+msgid "Number of daily wall messages for %s exceeded. Message failed."
+msgstr ""
+
+#: mod/wallmessage.php:60
+msgid "Unable to check your home location."
+msgstr ""
+
+#: mod/wallmessage.php:86 mod/wallmessage.php:95
+msgid "No recipient."
+msgstr ""
+
+#: mod/wallmessage.php:133
 #, php-format
 msgid ""
-"Your DB still runs with MyISAM tables. You should change the engine type to "
-"InnoDB. As Friendica will use InnoDB only features in the future, you should "
-"change this! See <a href=\"%s\">here</a> for a guide that may be helpful "
-"converting the table engines. You may also use the command <tt>php bin/"
-"console.php dbstructure toinnodb</tt> of your Friendica installation for an "
-"automatic conversion.<br />"
+"If you wish for %s to respond, please check that the privacy settings on "
+"your site allow private mail from unknown senders."
 msgstr ""
 
-#: mod/admin.php:792
+#: mod/wall_attach.php:24 mod/wall_attach.php:32 mod/wall_attach.php:83
+#: mod/wall_upload.php:38 mod/wall_upload.php:54 mod/wall_upload.php:112
+#: mod/wall_upload.php:155 mod/wall_upload.php:158
+msgid "Invalid request."
+msgstr ""
+
+#: mod/wall_attach.php:101
+msgid "Sorry, maybe your upload is bigger than the PHP configuration allows"
+msgstr ""
+
+#: mod/wall_attach.php:101
+msgid "Or - did you try to upload an empty file?"
+msgstr ""
+
+#: mod/wall_attach.php:112
 #, php-format
-msgid ""
-"There is a new version of Friendica available for download. Your current "
-"version is %1$s, upstream version is %2$s"
+msgid "File exceeds size limit of %s"
 msgstr ""
 
-#: mod/admin.php:802
-msgid ""
-"The database update failed. Please run \"php bin/console.php dbstructure "
-"update\" from the command line and have a look at the errors that might "
-"appear."
+#: mod/wall_attach.php:136 mod/wall_attach.php:152
+msgid "File upload failed."
 msgstr ""
 
-#: mod/admin.php:808
-msgid "The worker was never executed. Please check your database structure!"
+#: src/App.php:511
+msgid "Delete this item?"
 msgstr ""
 
-#: mod/admin.php:811
-#, php-format
-msgid ""
-"The last worker execution was on %s UTC. This is older than one hour. Please "
-"check your crontab settings."
-msgstr ""
-
-#: mod/admin.php:816 mod/admin.php:1739
-msgid "Normal Account"
-msgstr ""
-
-#: mod/admin.php:817 mod/admin.php:1740
-msgid "Automatic Follower Account"
-msgstr ""
-
-#: mod/admin.php:818 mod/admin.php:1741
-msgid "Public Forum Account"
-msgstr ""
-
-#: mod/admin.php:819 mod/admin.php:1742
-msgid "Automatic Friend Account"
-msgstr ""
-
-#: mod/admin.php:820
-msgid "Blog Account"
-msgstr ""
-
-#: mod/admin.php:821
-msgid "Private Forum Account"
-msgstr ""
-
-#: mod/admin.php:843
-msgid "Message queues"
-msgstr ""
-
-#: mod/admin.php:849
-msgid "Summary"
-msgstr ""
-
-#: mod/admin.php:851
-msgid "Registered users"
-msgstr ""
-
-#: mod/admin.php:853
-msgid "Pending registrations"
-msgstr ""
-
-#: mod/admin.php:854
-msgid "Version"
-msgstr ""
-
-#: mod/admin.php:859
-msgid "Active addons"
-msgstr ""
-
-#: mod/admin.php:890
-msgid "Can not parse base url. Must have at least <scheme>://<domain>"
-msgstr ""
-
-#: mod/admin.php:1209
-msgid "Site settings updated."
-msgstr ""
-
-#: mod/admin.php:1265
-msgid "No community page"
-msgstr ""
-
-#: mod/admin.php:1266
-msgid "Public postings from users of this site"
-msgstr ""
-
-#: mod/admin.php:1267
-msgid "Public postings from the federated network"
-msgstr ""
-
-#: mod/admin.php:1268
-msgid "Public postings from local users and the federated network"
-msgstr ""
-
-#: mod/admin.php:1274
-msgid "Users, Global Contacts"
-msgstr ""
-
-#: mod/admin.php:1275
-msgid "Users, Global Contacts/fallback"
-msgstr ""
-
-#: mod/admin.php:1279
-msgid "One month"
-msgstr ""
-
-#: mod/admin.php:1280
-msgid "Three months"
-msgstr ""
-
-#: mod/admin.php:1281
-msgid "Half a year"
-msgstr ""
-
-#: mod/admin.php:1282
-msgid "One year"
-msgstr ""
-
-#: mod/admin.php:1287
-msgid "Multi user instance"
-msgstr ""
-
-#: mod/admin.php:1310
-msgid "Closed"
-msgstr ""
-
-#: mod/admin.php:1311
-msgid "Requires approval"
-msgstr ""
-
-#: mod/admin.php:1312
-msgid "Open"
-msgstr ""
-
-#: mod/admin.php:1316
-msgid "No SSL policy, links will track page SSL state"
-msgstr ""
-
-#: mod/admin.php:1317
-msgid "Force all links to use SSL"
-msgstr ""
-
-#: mod/admin.php:1318
-msgid "Self-signed certificate, use SSL for local links only (discouraged)"
-msgstr ""
-
-#: mod/admin.php:1322
-msgid "Don't check"
-msgstr ""
-
-#: mod/admin.php:1323
-msgid "check the stable version"
-msgstr ""
-
-#: mod/admin.php:1324
-msgid "check the development version"
-msgstr ""
-
-#: mod/admin.php:1347
-msgid "Republish users to directory"
-msgstr ""
-
-#: mod/admin.php:1349
-msgid "File upload"
-msgstr ""
-
-#: mod/admin.php:1350
-msgid "Policies"
-msgstr ""
-
-#: mod/admin.php:1352
-msgid "Auto Discovered Contact Directory"
-msgstr ""
-
-#: mod/admin.php:1353
-msgid "Performance"
-msgstr ""
-
-#: mod/admin.php:1354
-msgid "Worker"
-msgstr ""
-
-#: mod/admin.php:1355
-msgid "Message Relay"
-msgstr ""
-
-#: mod/admin.php:1356
-msgid ""
-"Relocate - WARNING: advanced function. Could make this server unreachable."
-msgstr ""
-
-#: mod/admin.php:1359
-msgid "Site name"
-msgstr ""
-
-#: mod/admin.php:1360
-msgid "Host name"
-msgstr ""
-
-#: mod/admin.php:1361
-msgid "Sender Email"
-msgstr ""
-
-#: mod/admin.php:1361
-msgid ""
-"The email address your server shall use to send notification emails from."
-msgstr ""
-
-#: mod/admin.php:1362
-msgid "Banner/Logo"
-msgstr ""
-
-#: mod/admin.php:1363
-msgid "Shortcut icon"
-msgstr ""
-
-#: mod/admin.php:1363
-msgid "Link to an icon that will be used for browsers."
-msgstr ""
-
-#: mod/admin.php:1364
-msgid "Touch icon"
-msgstr ""
-
-#: mod/admin.php:1364
-msgid "Link to an icon that will be used for tablets and mobiles."
-msgstr ""
-
-#: mod/admin.php:1365
-msgid "Additional Info"
-msgstr ""
-
-#: mod/admin.php:1365
-#, php-format
-msgid ""
-"For public servers: you can add additional information here that will be "
-"listed at %s/servers."
-msgstr ""
-
-#: mod/admin.php:1366
-msgid "System language"
-msgstr ""
-
-#: mod/admin.php:1367
-msgid "System theme"
-msgstr ""
-
-#: mod/admin.php:1367
-msgid ""
-"Default system theme - may be over-ridden by user profiles - <a href='#' "
-"id='cnftheme'>change theme settings</a>"
-msgstr ""
-
-#: mod/admin.php:1368
-msgid "Mobile system theme"
-msgstr ""
-
-#: mod/admin.php:1368
-msgid "Theme for mobile devices"
-msgstr ""
-
-#: mod/admin.php:1369
-msgid "SSL link policy"
-msgstr ""
-
-#: mod/admin.php:1369
-msgid "Determines whether generated links should be forced to use SSL"
-msgstr ""
-
-#: mod/admin.php:1370
-msgid "Force SSL"
-msgstr ""
-
-#: mod/admin.php:1370
-msgid ""
-"Force all Non-SSL requests to SSL - Attention: on some systems it could lead "
-"to endless loops."
-msgstr ""
-
-#: mod/admin.php:1371
-msgid "Hide help entry from navigation menu"
-msgstr ""
-
-#: mod/admin.php:1371
-msgid ""
-"Hides the menu entry for the Help pages from the navigation menu. You can "
-"still access it calling /help directly."
-msgstr ""
-
-#: mod/admin.php:1372
-msgid "Single user instance"
-msgstr ""
-
-#: mod/admin.php:1372
-msgid "Make this instance multi-user or single-user for the named user"
-msgstr ""
-
-#: mod/admin.php:1373
-msgid "Maximum image size"
-msgstr ""
-
-#: mod/admin.php:1373
-msgid ""
-"Maximum size in bytes of uploaded images. Default is 0, which means no "
-"limits."
-msgstr ""
-
-#: mod/admin.php:1374
-msgid "Maximum image length"
-msgstr ""
-
-#: mod/admin.php:1374
-msgid ""
-"Maximum length in pixels of the longest side of uploaded images. Default is "
-"-1, which means no limits."
-msgstr ""
-
-#: mod/admin.php:1375
-msgid "JPEG image quality"
-msgstr ""
-
-#: mod/admin.php:1375
-msgid ""
-"Uploaded JPEGS will be saved at this quality setting [0-100]. Default is "
-"100, which is full quality."
-msgstr ""
-
-#: mod/admin.php:1377
-msgid "Register policy"
-msgstr ""
-
-#: mod/admin.php:1378
-msgid "Maximum Daily Registrations"
-msgstr ""
-
-#: mod/admin.php:1378
-msgid ""
-"If registration is permitted above, this sets the maximum number of new user "
-"registrations to accept per day.  If register is set to closed, this setting "
-"has no effect."
-msgstr ""
-
-#: mod/admin.php:1379
-msgid "Register text"
-msgstr ""
-
-#: mod/admin.php:1379
-msgid ""
-"Will be displayed prominently on the registration page. You can use BBCode "
-"here."
-msgstr ""
-
-#: mod/admin.php:1380
-msgid "Accounts abandoned after x days"
-msgstr ""
-
-#: mod/admin.php:1380
-msgid ""
-"Will not waste system resources polling external sites for abandonded "
-"accounts. Enter 0 for no time limit."
-msgstr ""
-
-#: mod/admin.php:1381
-msgid "Allowed friend domains"
-msgstr ""
-
-#: mod/admin.php:1381
-msgid ""
-"Comma separated list of domains which are allowed to establish friendships "
-"with this site. Wildcards are accepted. Empty to allow any domains"
-msgstr ""
-
-#: mod/admin.php:1382
-msgid "Allowed email domains"
-msgstr ""
-
-#: mod/admin.php:1382
-msgid ""
-"Comma separated list of domains which are allowed in email addresses for "
-"registrations to this site. Wildcards are accepted. Empty to allow any "
-"domains"
-msgstr ""
-
-#: mod/admin.php:1383
-msgid "No OEmbed rich content"
-msgstr ""
-
-#: mod/admin.php:1383
-msgid ""
-"Don't show the rich content (e.g. embedded PDF), except from the domains "
-"listed below."
-msgstr ""
-
-#: mod/admin.php:1384
-msgid "Allowed OEmbed domains"
-msgstr ""
-
-#: mod/admin.php:1384
-msgid ""
-"Comma separated list of domains which oembed content is allowed to be "
-"displayed. Wildcards are accepted."
-msgstr ""
-
-#: mod/admin.php:1385
-msgid "Block public"
-msgstr ""
-
-#: mod/admin.php:1385
-msgid ""
-"Check to block public access to all otherwise public personal pages on this "
-"site unless you are currently logged in."
-msgstr ""
-
-#: mod/admin.php:1386
-msgid "Force publish"
-msgstr ""
-
-#: mod/admin.php:1386
-msgid ""
-"Check to force all profiles on this site to be listed in the site directory."
-msgstr ""
-
-#: mod/admin.php:1387
-msgid "Global directory URL"
-msgstr ""
-
-#: mod/admin.php:1387
-msgid ""
-"URL to the global directory. If this is not set, the global directory is "
-"completely unavailable to the application."
-msgstr ""
-
-#: mod/admin.php:1388
-msgid "Private posts by default for new users"
-msgstr ""
-
-#: mod/admin.php:1388
-msgid ""
-"Set default post permissions for all new members to the default privacy "
-"group rather than public."
-msgstr ""
-
-#: mod/admin.php:1389
-msgid "Don't include post content in email notifications"
-msgstr ""
-
-#: mod/admin.php:1389
-msgid ""
-"Don't include the content of a post/comment/private message/etc. in the "
-"email notifications that are sent out from this site, as a privacy measure."
-msgstr ""
-
-#: mod/admin.php:1390
-msgid "Disallow public access to addons listed in the apps menu."
-msgstr ""
-
-#: mod/admin.php:1390
-msgid ""
-"Checking this box will restrict addons listed in the apps menu to members "
-"only."
-msgstr ""
-
-#: mod/admin.php:1391
-msgid "Don't embed private images in posts"
-msgstr ""
-
-#: mod/admin.php:1391
-msgid ""
-"Don't replace locally-hosted private photos in posts with an embedded copy "
-"of the image. This means that contacts who receive posts containing private "
-"photos will have to authenticate and load each image, which may take a while."
-msgstr ""
-
-#: mod/admin.php:1392
-msgid "Allow Users to set remote_self"
-msgstr ""
-
-#: mod/admin.php:1392
-msgid ""
-"With checking this, every user is allowed to mark every contact as a "
-"remote_self in the repair contact dialog. Setting this flag on a contact "
-"causes mirroring every posting of that contact in the users stream."
-msgstr ""
-
-#: mod/admin.php:1393
-msgid "Block multiple registrations"
-msgstr ""
-
-#: mod/admin.php:1393
-msgid "Disallow users to register additional accounts for use as pages."
-msgstr ""
-
-#: mod/admin.php:1394
-msgid "OpenID support"
-msgstr ""
-
-#: mod/admin.php:1394
-msgid "OpenID support for registration and logins."
-msgstr ""
-
-#: mod/admin.php:1395
-msgid "Fullname check"
-msgstr ""
-
-#: mod/admin.php:1395
-msgid ""
-"Force users to register with a space between firstname and lastname in Full "
-"name, as an antispam measure"
-msgstr ""
-
-#: mod/admin.php:1396
-msgid "Community pages for visitors"
-msgstr ""
-
-#: mod/admin.php:1396
-msgid ""
-"Which community pages should be available for visitors. Local users always "
-"see both pages."
-msgstr ""
-
-#: mod/admin.php:1397
-msgid "Posts per user on community page"
-msgstr ""
-
-#: mod/admin.php:1397
-msgid ""
-"The maximum number of posts per user on the community page. (Not valid for "
-"'Global Community')"
-msgstr ""
-
-#: mod/admin.php:1398
-msgid "Enable OStatus support"
-msgstr ""
-
-#: mod/admin.php:1398
-msgid ""
-"Provide built-in OStatus (StatusNet, GNU Social etc.) compatibility. All "
-"communications in OStatus are public, so privacy warnings will be "
-"occasionally displayed."
-msgstr ""
-
-#: mod/admin.php:1399
-msgid "Only import OStatus threads from our contacts"
-msgstr ""
-
-#: mod/admin.php:1399
-msgid ""
-"Normally we import every content from our OStatus contacts. With this option "
-"we only store threads that are started by a contact that is known on our "
-"system."
-msgstr ""
-
-#: mod/admin.php:1400
-msgid "OStatus support can only be enabled if threading is enabled."
-msgstr ""
-
-#: mod/admin.php:1402
-msgid ""
-"Diaspora support can't be enabled because Friendica was installed into a sub "
-"directory."
-msgstr ""
-
-#: mod/admin.php:1403
-msgid "Enable Diaspora support"
-msgstr ""
-
-#: mod/admin.php:1403
-msgid "Provide built-in Diaspora network compatibility."
-msgstr ""
-
-#: mod/admin.php:1404
-msgid "Only allow Friendica contacts"
-msgstr ""
-
-#: mod/admin.php:1404
-msgid ""
-"All contacts must use Friendica protocols. All other built-in communication "
-"protocols disabled."
-msgstr ""
-
-#: mod/admin.php:1405
-msgid "Verify SSL"
-msgstr ""
-
-#: mod/admin.php:1405
-msgid ""
-"If you wish, you can turn on strict certificate checking. This will mean you "
-"cannot connect (at all) to self-signed SSL sites."
-msgstr ""
-
-#: mod/admin.php:1406
-msgid "Proxy user"
-msgstr ""
-
-#: mod/admin.php:1407
-msgid "Proxy URL"
-msgstr ""
-
-#: mod/admin.php:1408
-msgid "Network timeout"
-msgstr ""
-
-#: mod/admin.php:1408
-msgid "Value is in seconds. Set to 0 for unlimited (not recommended)."
-msgstr ""
-
-#: mod/admin.php:1409
-msgid "Maximum Load Average"
-msgstr ""
-
-#: mod/admin.php:1409
-msgid ""
-"Maximum system load before delivery and poll processes are deferred - "
-"default 50."
-msgstr ""
-
-#: mod/admin.php:1410
-msgid "Maximum Load Average (Frontend)"
-msgstr ""
-
-#: mod/admin.php:1410
-msgid "Maximum system load before the frontend quits service - default 50."
-msgstr ""
-
-#: mod/admin.php:1411
-msgid "Minimal Memory"
-msgstr ""
-
-#: mod/admin.php:1411
-msgid ""
-"Minimal free memory in MB for the worker. Needs access to /proc/meminfo - "
-"default 0 (deactivated)."
-msgstr ""
-
-#: mod/admin.php:1412
-msgid "Maximum table size for optimization"
-msgstr ""
-
-#: mod/admin.php:1412
-msgid ""
-"Maximum table size (in MB) for the automatic optimization - default 100 MB. "
-"Enter -1 to disable it."
-msgstr ""
-
-#: mod/admin.php:1413
-msgid "Minimum level of fragmentation"
-msgstr ""
-
-#: mod/admin.php:1413
-msgid ""
-"Minimum fragmenation level to start the automatic optimization - default "
-"value is 30%."
-msgstr ""
-
-#: mod/admin.php:1415
-msgid "Periodical check of global contacts"
-msgstr ""
-
-#: mod/admin.php:1415
-msgid ""
-"If enabled, the global contacts are checked periodically for missing or "
-"outdated data and the vitality of the contacts and servers."
-msgstr ""
-
-#: mod/admin.php:1416
-msgid "Days between requery"
-msgstr ""
-
-#: mod/admin.php:1416
-msgid "Number of days after which a server is requeried for his contacts."
-msgstr ""
-
-#: mod/admin.php:1417
-msgid "Discover contacts from other servers"
-msgstr ""
-
-#: mod/admin.php:1417
-msgid ""
-"Periodically query other servers for contacts. You can choose between "
-"'users': the users on the remote system, 'Global Contacts': active contacts "
-"that are known on the system. The fallback is meant for Redmatrix servers "
-"and older friendica servers, where global contacts weren't available. The "
-"fallback increases the server load, so the recommened setting is 'Users, "
-"Global Contacts'."
-msgstr ""
-
-#: mod/admin.php:1418
-msgid "Timeframe for fetching global contacts"
-msgstr ""
-
-#: mod/admin.php:1418
-msgid ""
-"When the discovery is activated, this value defines the timeframe for the "
-"activity of the global contacts that are fetched from other servers."
-msgstr ""
-
-#: mod/admin.php:1419
-msgid "Search the local directory"
-msgstr ""
-
-#: mod/admin.php:1419
-msgid ""
-"Search the local directory instead of the global directory. When searching "
-"locally, every search will be executed on the global directory in the "
-"background. This improves the search results when the search is repeated."
-msgstr ""
-
-#: mod/admin.php:1421
-msgid "Publish server information"
-msgstr ""
-
-#: mod/admin.php:1421
-msgid ""
-"If enabled, general server and usage data will be published. The data "
-"contains the name and version of the server, number of users with public "
-"profiles, number of posts and the activated protocols and connectors. See <a "
-"href='http://the-federation.info/'>the-federation.info</a> for details."
-msgstr ""
-
-#: mod/admin.php:1423
-msgid "Check upstream version"
-msgstr ""
-
-#: mod/admin.php:1423
-msgid ""
-"Enables checking for new Friendica versions at github. If there is a new "
-"version, you will be informed in the admin panel overview."
-msgstr ""
-
-#: mod/admin.php:1424
-msgid "Suppress Tags"
-msgstr ""
-
-#: mod/admin.php:1424
-msgid "Suppress showing a list of hashtags at the end of the posting."
-msgstr ""
-
-#: mod/admin.php:1425
-msgid "Path to item cache"
-msgstr ""
-
-#: mod/admin.php:1425
-msgid "The item caches buffers generated bbcode and external images."
-msgstr ""
-
-#: mod/admin.php:1426
-msgid "Cache duration in seconds"
-msgstr ""
-
-#: mod/admin.php:1426
-msgid ""
-"How long should the cache files be hold? Default value is 86400 seconds (One "
-"day). To disable the item cache, set the value to -1."
-msgstr ""
-
-#: mod/admin.php:1427
-msgid "Maximum numbers of comments per post"
-msgstr ""
-
-#: mod/admin.php:1427
-msgid "How much comments should be shown for each post? Default value is 100."
-msgstr ""
-
-#: mod/admin.php:1428
-msgid "Temp path"
-msgstr ""
-
-#: mod/admin.php:1428
-msgid ""
-"If you have a restricted system where the webserver can't access the system "
-"temp path, enter another path here."
-msgstr ""
-
-#: mod/admin.php:1429
-msgid "Base path to installation"
-msgstr ""
-
-#: mod/admin.php:1429
-msgid ""
-"If the system cannot detect the correct path to your installation, enter the "
-"correct path here. This setting should only be set if you are using a "
-"restricted system and symbolic links to your webroot."
-msgstr ""
-
-#: mod/admin.php:1430
-msgid "Disable picture proxy"
-msgstr ""
-
-#: mod/admin.php:1430
-msgid ""
-"The picture proxy increases performance and privacy. It shouldn't be used on "
-"systems with very low bandwith."
-msgstr ""
-
-#: mod/admin.php:1431
-msgid "Only search in tags"
-msgstr ""
-
-#: mod/admin.php:1431
-msgid "On large systems the text search can slow down the system extremely."
-msgstr ""
-
-#: mod/admin.php:1433
-msgid "New base url"
-msgstr ""
-
-#: mod/admin.php:1433
-msgid ""
-"Change base url for this server. Sends relocate message to all Friendica and "
-"Diaspora* contacts of all users."
-msgstr ""
-
-#: mod/admin.php:1435
-msgid "RINO Encryption"
-msgstr ""
-
-#: mod/admin.php:1435
-msgid "Encryption layer between nodes."
-msgstr ""
-
-#: mod/admin.php:1435
-msgid "Enabled"
-msgstr ""
-
-#: mod/admin.php:1437
-msgid "Maximum number of parallel workers"
-msgstr ""
-
-#: mod/admin.php:1437
-msgid ""
-"On shared hosters set this to 2. On larger systems, values of 10 are great. "
-"Default value is 4."
-msgstr ""
-
-#: mod/admin.php:1438
-msgid "Don't use 'proc_open' with the worker"
-msgstr ""
-
-#: mod/admin.php:1438
-msgid ""
-"Enable this if your system doesn't allow the use of 'proc_open'. This can "
-"happen on shared hosters. If this is enabled you should increase the "
-"frequency of worker calls in your crontab."
-msgstr ""
-
-#: mod/admin.php:1439
-msgid "Enable fastlane"
-msgstr ""
-
-#: mod/admin.php:1439
-msgid ""
-"When enabed, the fastlane mechanism starts an additional worker if processes "
-"with higher priority are blocked by processes of lower priority."
-msgstr ""
-
-#: mod/admin.php:1440
-msgid "Enable frontend worker"
-msgstr ""
-
-#: mod/admin.php:1440
-#, php-format
-msgid ""
-"When enabled the Worker process is triggered when backend access is "
-"performed \\x28e.g. messages being delivered\\x29. On smaller sites you "
-"might want to call %s/worker on a regular basis via an external cron job. "
-"You should only enable this option if you cannot utilize cron/scheduled jobs "
-"on your server."
-msgstr ""
-
-#: mod/admin.php:1442
-msgid "Subscribe to relay"
-msgstr ""
-
-#: mod/admin.php:1442
-msgid ""
-"Enables the receiving of public posts from the relay. They will be included "
-"in the search, subscribed tags and on the global community page."
-msgstr ""
-
-#: mod/admin.php:1443
-msgid "Relay server"
-msgstr ""
-
-#: mod/admin.php:1443
-msgid ""
-"Address of the relay server where public posts should be send to. For "
-"example https://relay.diasp.org"
-msgstr ""
-
-#: mod/admin.php:1444
-msgid "Direct relay transfer"
-msgstr ""
-
-#: mod/admin.php:1444
-msgid ""
-"Enables the direct transfer to other servers without using the relay servers"
-msgstr ""
-
-#: mod/admin.php:1445
-msgid "Relay scope"
-msgstr ""
-
-#: mod/admin.php:1445
-msgid ""
-"Can be 'all' or 'tags'. 'all' means that every public post should be "
-"received. 'tags' means that only posts with selected tags should be received."
-msgstr ""
-
-#: mod/admin.php:1445
-msgid "all"
-msgstr ""
-
-#: mod/admin.php:1445
-msgid "tags"
-msgstr ""
-
-#: mod/admin.php:1446
-msgid "Server tags"
-msgstr ""
-
-#: mod/admin.php:1446
-msgid "Comma separated list of tags for the 'tags' subscription."
-msgstr ""
-
-#: mod/admin.php:1447
-msgid "Allow user tags"
-msgstr ""
-
-#: mod/admin.php:1447
-msgid ""
-"If enabled, the tags from the saved searches will used for the 'tags' "
-"subscription in addition to the 'relay_server_tags'."
-msgstr ""
-
-#: mod/admin.php:1475
-msgid "Update has been marked successful"
-msgstr ""
-
-#: mod/admin.php:1482
-#, php-format
-msgid "Database structure update %s was successfully applied."
-msgstr ""
-
-#: mod/admin.php:1485
-#, php-format
-msgid "Executing of database structure update %s failed with error: %s"
-msgstr ""
-
-#: mod/admin.php:1498
-#, php-format
-msgid "Executing %s failed with error: %s"
-msgstr ""
-
-#: mod/admin.php:1500
-#, php-format
-msgid "Update %s was successfully applied."
-msgstr ""
-
-#: mod/admin.php:1503
-#, php-format
-msgid "Update %s did not return a status. Unknown if it succeeded."
-msgstr ""
-
-#: mod/admin.php:1506
-#, php-format
-msgid "There was no additional update function %s that needed to be called."
-msgstr ""
-
-#: mod/admin.php:1526
-msgid "No failed updates."
-msgstr ""
-
-#: mod/admin.php:1527
-msgid "Check database structure"
-msgstr ""
-
-#: mod/admin.php:1532
-msgid "Failed Updates"
-msgstr ""
-
-#: mod/admin.php:1533
-msgid ""
-"This does not include updates prior to 1139, which did not return a status."
-msgstr ""
-
-#: mod/admin.php:1534
-msgid "Mark success (if update was manually applied)"
-msgstr ""
-
-#: mod/admin.php:1535
-msgid "Attempt to execute this update step automatically"
-msgstr ""
-
-#: mod/admin.php:1574
-#, php-format
-msgid ""
-"\n"
-"\t\t\tDear %1$s,\n"
-"\t\t\t\tthe administrator of %2$s has set up an account for you."
-msgstr ""
-
-#: mod/admin.php:1577 src/Model/User.php:615
-#, php-format
-msgid ""
-"\n"
-"\t\t\tThe login details are as follows:\n"
-"\n"
-"\t\t\tSite Location:\t%1$s\n"
-"\t\t\tLogin Name:\t\t%2$s\n"
-"\t\t\tPassword:\t\t%3$s\n"
-"\n"
-"\t\t\tYou may change your password from your account \"Settings\" page after "
-"logging\n"
-"\t\t\tin.\n"
-"\n"
-"\t\t\tPlease take a few moments to review the other account settings on that "
-"page.\n"
-"\n"
-"\t\t\tYou may also wish to add some basic information to your default "
-"profile\n"
-"\t\t\t(on the \"Profiles\" page) so that other people can easily find you.\n"
-"\n"
-"\t\t\tWe recommend setting your full name, adding a profile photo,\n"
-"\t\t\tadding some profile \"keywords\" (very useful in making new friends) - "
-"and\n"
-"\t\t\tperhaps what country you live in; if you do not wish to be more "
-"specific\n"
-"\t\t\tthan that.\n"
-"\n"
-"\t\t\tWe fully respect your right to privacy, and none of these items are "
-"necessary.\n"
-"\t\t\tIf you are new and do not know anybody here, they may help\n"
-"\t\t\tyou to make some new and interesting friends.\n"
-"\n"
-"\t\t\tIf you ever want to delete your account, you can do so at %1$s/"
-"removeme\n"
-"\n"
-"\t\t\tThank you and welcome to %4$s."
-msgstr ""
-
-#: mod/admin.php:1611 src/Model/User.php:649
-#, php-format
-msgid "Registration details for %s"
-msgstr ""
-
-#: mod/admin.php:1621
-#, php-format
-msgid "%s user blocked/unblocked"
-msgid_plural "%s users blocked/unblocked"
-msgstr[0] ""
-msgstr[1] ""
-
-#: mod/admin.php:1627
-#, php-format
-msgid "%s user deleted"
-msgid_plural "%s users deleted"
-msgstr[0] ""
-msgstr[1] ""
-
-#: mod/admin.php:1674
-#, php-format
-msgid "User '%s' deleted"
-msgstr ""
-
-#: mod/admin.php:1682
-#, php-format
-msgid "User '%s' unblocked"
-msgstr ""
-
-#: mod/admin.php:1682
-#, php-format
-msgid "User '%s' blocked"
-msgstr ""
-
-#: mod/admin.php:1781 mod/admin.php:1793 mod/admin.php:1806 mod/admin.php:1824
-#: src/Content/ContactSelector.php:82
-msgid "Email"
-msgstr ""
-
-#: mod/admin.php:1781 mod/admin.php:1806
-msgid "Register date"
-msgstr ""
-
-#: mod/admin.php:1781 mod/admin.php:1806
-msgid "Last login"
-msgstr ""
-
-#: mod/admin.php:1781 mod/admin.php:1806
-msgid "Last item"
-msgstr ""
-
-#: mod/admin.php:1789
-msgid "Add User"
-msgstr ""
-
-#: mod/admin.php:1791
-msgid "User registrations waiting for confirm"
-msgstr ""
-
-#: mod/admin.php:1792
-msgid "User waiting for permanent deletion"
-msgstr ""
-
-#: mod/admin.php:1793
-msgid "Request date"
-msgstr ""
-
-#: mod/admin.php:1794
-msgid "No registrations."
-msgstr ""
-
-#: mod/admin.php:1795
-msgid "Note from the user"
-msgstr ""
-
-#: mod/admin.php:1797
-msgid "Deny"
-msgstr ""
-
-#: mod/admin.php:1801
-msgid "Site admin"
-msgstr ""
-
-#: mod/admin.php:1802
-msgid "Account expired"
-msgstr ""
-
-#: mod/admin.php:1805
-msgid "New User"
-msgstr ""
-
-#: mod/admin.php:1806
-msgid "Deleted since"
-msgstr ""
-
-#: mod/admin.php:1811
-msgid ""
-"Selected users will be deleted!\\n\\nEverything these users had posted on "
-"this site will be permanently deleted!\\n\\nAre you sure?"
-msgstr ""
-
-#: mod/admin.php:1812
-msgid ""
-"The user {0} will be deleted!\\n\\nEverything this user has posted on this "
-"site will be permanently deleted!\\n\\nAre you sure?"
-msgstr ""
-
-#: mod/admin.php:1822
-msgid "Name of the new user."
-msgstr ""
-
-#: mod/admin.php:1823
-msgid "Nickname"
-msgstr ""
-
-#: mod/admin.php:1823
-msgid "Nickname of the new user."
-msgstr ""
-
-#: mod/admin.php:1824
-msgid "Email address of the new user."
-msgstr ""
-
-#: mod/admin.php:1866
-#, php-format
-msgid "Addon %s disabled."
-msgstr ""
-
-#: mod/admin.php:1870
-#, php-format
-msgid "Addon %s enabled."
-msgstr ""
-
-#: mod/admin.php:1880 mod/admin.php:2129
-msgid "Disable"
-msgstr ""
-
-#: mod/admin.php:1883 mod/admin.php:2132
-msgid "Enable"
-msgstr ""
-
-#: mod/admin.php:1905 mod/admin.php:2174
-msgid "Toggle"
-msgstr ""
-
-#: mod/admin.php:1913 mod/admin.php:2183
-msgid "Author: "
-msgstr ""
-
-#: mod/admin.php:1914 mod/admin.php:2184
-msgid "Maintainer: "
-msgstr ""
-
-#: mod/admin.php:1966
-msgid "Reload active addons"
-msgstr ""
-
-#: mod/admin.php:1971
-#, php-format
-msgid ""
-"There are currently no addons available on your node. You can find the "
-"official addon repository at %1$s and might find other interesting addons in "
-"the open addon registry at %2$s"
-msgstr ""
-
-#: mod/admin.php:2091
-msgid "No themes found."
-msgstr ""
-
-#: mod/admin.php:2165
-msgid "Screenshot"
-msgstr ""
-
-#: mod/admin.php:2219
-msgid "Reload active themes"
-msgstr ""
-
-#: mod/admin.php:2224
-#, php-format
-msgid "No themes found on the system. They should be placed in %1$s"
-msgstr ""
-
-#: mod/admin.php:2225
-msgid "[Experimental]"
-msgstr ""
-
-#: mod/admin.php:2226
-msgid "[Unsupported]"
-msgstr ""
-
-#: mod/admin.php:2250
-msgid "Log settings updated."
-msgstr ""
-
-#: mod/admin.php:2282
-msgid "PHP log currently enabled."
-msgstr ""
-
-#: mod/admin.php:2284
-msgid "PHP log currently disabled."
-msgstr ""
-
-#: mod/admin.php:2293
-msgid "Clear"
-msgstr ""
-
-#: mod/admin.php:2297
-msgid "Enable Debugging"
-msgstr ""
-
-#: mod/admin.php:2298
-msgid "Log file"
-msgstr ""
-
-#: mod/admin.php:2298
-msgid ""
-"Must be writable by web server. Relative to your Friendica top-level "
-"directory."
-msgstr ""
-
-#: mod/admin.php:2299
-msgid "Log level"
-msgstr ""
-
-#: mod/admin.php:2301
-msgid "PHP logging"
-msgstr ""
-
-#: mod/admin.php:2302
-msgid ""
-"To enable logging of PHP errors and warnings you can add the following to "
-"the .htconfig.php file of your installation. The filename set in the "
-"'error_log' line is relative to the friendica top-level directory and must "
-"be writeable by the web server. The option '1' for 'log_errors' and "
-"'display_errors' is to enable these options, set to '0' to disable them."
-msgstr ""
-
-#: mod/admin.php:2333
-#, php-format
-msgid ""
-"Error trying to open <strong>%1$s</strong> log file.\\r\\n<br/>Check to see "
-"if file %1$s exist and is readable."
-msgstr ""
-
-#: mod/admin.php:2337
-#, php-format
-msgid ""
-"Couldn't open <strong>%1$s</strong> log file.\\r\\n<br/>Check to see if file "
-"%1$s is readable."
-msgstr ""
-
-#: mod/admin.php:2429
-#, php-format
-msgid "Lock feature %s"
-msgstr ""
-
-#: mod/admin.php:2437
-msgid "Manage Additional Features"
-msgstr ""
-
-#: src/Core/UserImport.php:104
-msgid "Error decoding account file"
-msgstr ""
-
-#: src/Core/UserImport.php:110
-msgid "Error! No version data in file! This is not a Friendica account file?"
-msgstr ""
-
-#: src/Core/UserImport.php:118
-#, php-format
-msgid "User '%s' already exists on this server!"
-msgstr ""
-
-#: src/Core/UserImport.php:151
-msgid "User creation error"
-msgstr ""
-
-#: src/Core/UserImport.php:169
-msgid "User profile creation error"
-msgstr ""
-
-#: src/Core/UserImport.php:213
-#, php-format
-msgid "%d contact not imported"
-msgid_plural "%d contacts not imported"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/Core/UserImport.php:278
-msgid "Done. You can now login with your username and password"
-msgstr ""
-
-#: src/Core/NotificationsManager.php:171
-msgid "System"
-msgstr ""
-
-#: src/Core/NotificationsManager.php:192 src/Content/Nav.php:124
-#: src/Content/Nav.php:181
-msgid "Home"
-msgstr ""
-
-#: src/Core/NotificationsManager.php:199 src/Content/Nav.php:186
-msgid "Introductions"
-msgstr ""
-
-#: src/Core/NotificationsManager.php:256 src/Core/NotificationsManager.php:268
-#, php-format
-msgid "%s commented on %s's post"
-msgstr ""
-
-#: src/Core/NotificationsManager.php:267
-#, php-format
-msgid "%s created a new post"
-msgstr ""
-
-#: src/Core/NotificationsManager.php:281
-#, php-format
-msgid "%s liked %s's post"
-msgstr ""
-
-#: src/Core/NotificationsManager.php:294
-#, php-format
-msgid "%s disliked %s's post"
-msgstr ""
-
-#: src/Core/NotificationsManager.php:307
-#, php-format
-msgid "%s is attending %s's event"
-msgstr ""
-
-#: src/Core/NotificationsManager.php:320
-#, php-format
-msgid "%s is not attending %s's event"
-msgstr ""
-
-#: src/Core/NotificationsManager.php:333
-#, php-format
-msgid "%s may attend %s's event"
-msgstr ""
-
-#: src/Core/NotificationsManager.php:350
-#, php-format
-msgid "%s is now friends with %s"
-msgstr ""
-
-#: src/Core/NotificationsManager.php:825
-msgid "Friend Suggestion"
-msgstr ""
-
-#: src/Core/NotificationsManager.php:851
-msgid "Friend/Connect Request"
-msgstr ""
-
-#: src/Core/NotificationsManager.php:851
-msgid "New Follower"
-msgstr ""
-
-#: src/Core/ACL.php:295
-msgid "Post to Email"
-msgstr ""
-
-#: src/Core/ACL.php:301
-msgid "Hide your profile details from unknown viewers?"
-msgstr ""
-
-#: src/Core/ACL.php:300
-#, php-format
-msgid "Connectors disabled, since \"%s\" is enabled."
-msgstr ""
-
-#: src/Core/ACL.php:307
-msgid "Visible to everybody"
-msgstr ""
-
-#: src/Core/ACL.php:308 view/theme/vier/config.php:115
-msgid "show"
-msgstr ""
-
-#: src/Core/ACL.php:309 view/theme/vier/config.php:115
-msgid "don't show"
-msgstr ""
-
-#: src/Core/ACL.php:319
-msgid "Close"
-msgstr ""
-
-#: src/Util/Temporal.php:147 src/Model/Profile.php:758
-msgid "Birthday:"
-msgstr ""
-
-#: src/Util/Temporal.php:151
-msgid "YYYY-MM-DD or MM-DD"
-msgstr ""
-
-#: src/Util/Temporal.php:294
-msgid "never"
-msgstr ""
-
-#: src/Util/Temporal.php:300
-msgid "less than a second ago"
-msgstr ""
-
-#: src/Util/Temporal.php:303
-msgid "year"
-msgstr ""
-
-#: src/Util/Temporal.php:303
-msgid "years"
-msgstr ""
-
-#: src/Util/Temporal.php:304
-msgid "months"
-msgstr ""
-
-#: src/Util/Temporal.php:305
-msgid "weeks"
-msgstr ""
-
-#: src/Util/Temporal.php:306
-msgid "days"
-msgstr ""
-
-#: src/Util/Temporal.php:307
-msgid "hour"
-msgstr ""
-
-#: src/Util/Temporal.php:307
-msgid "hours"
-msgstr ""
-
-#: src/Util/Temporal.php:308
-msgid "minute"
-msgstr ""
-
-#: src/Util/Temporal.php:308
-msgid "minutes"
-msgstr ""
-
-#: src/Util/Temporal.php:309
-msgid "second"
-msgstr ""
-
-#: src/Util/Temporal.php:309
-msgid "seconds"
-msgstr ""
-
-#: src/Util/Temporal.php:318
-#, php-format
-msgid "%1$d %2$s ago"
-msgstr ""
-
-#: src/Content/Text/BBCode.php:552
-msgid "view full size"
-msgstr ""
-
-#: src/Content/Text/BBCode.php:978 src/Content/Text/BBCode.php:1739
-#: src/Content/Text/BBCode.php:1740
-msgid "Image/photo"
-msgstr ""
-
-#: src/Content/Text/BBCode.php:1116
-#, php-format
-msgid "<a href=\"%1$s\" target=\"_blank\">%2$s</a> %3$s"
-msgstr ""
-
-#: src/Content/Text/BBCode.php:1674 src/Content/Text/BBCode.php:1696
-msgid "$1 wrote:"
-msgstr ""
-
-#: src/Content/Text/BBCode.php:1748 src/Content/Text/BBCode.php:1749
-msgid "Encrypted content"
-msgstr ""
-
-#: src/Content/Text/BBCode.php:1866
-msgid "Invalid source protocol"
-msgstr ""
-
-#: src/Content/Text/BBCode.php:1877
-msgid "Invalid link protocol"
+#: src/App.php:513
+msgid "show fewer"
 msgstr ""
 
 #: src/Content/ForumManager.php:127 view/theme/vier/theme.php:256
@@ -7901,76 +7642,188 @@ msgstr ""
 msgid "See all notifications"
 msgstr ""
 
-#: src/Content/Nav.php:191
-msgid "Mark all system notifications seen"
+#: src/Content/ContactSelector.php:125
+msgid "Non-specific"
 msgstr ""
 
-#: src/Content/Nav.php:195 view/theme/frio/theme.php:268
-msgid "Private mail"
+#: src/Content/ContactSelector.php:125
+msgid "Other"
 msgstr ""
 
-#: src/Content/Nav.php:196
-msgid "Inbox"
+#: src/Content/ContactSelector.php:147
+msgid "Males"
 msgstr ""
 
-#: src/Content/Nav.php:197
-msgid "Outbox"
+#: src/Content/ContactSelector.php:147
+msgid "Females"
 msgstr ""
 
-#: src/Content/Nav.php:201
-msgid "Manage"
+#: src/Content/ContactSelector.php:147
+msgid "Gay"
 msgstr ""
 
-#: src/Content/Nav.php:201
-msgid "Manage other pages"
+#: src/Content/ContactSelector.php:147
+msgid "Lesbian"
 msgstr ""
 
-#: src/Content/Nav.php:206 view/theme/frio/theme.php:269
-msgid "Account settings"
+#: src/Content/ContactSelector.php:147
+msgid "No Preference"
 msgstr ""
 
-#: src/Content/Nav.php:209 src/Model/Profile.php:372
-msgid "Profiles"
+#: src/Content/ContactSelector.php:147
+msgid "Bisexual"
 msgstr ""
 
-#: src/Content/Nav.php:209
-msgid "Manage/Edit Profiles"
+#: src/Content/ContactSelector.php:147
+msgid "Autosexual"
 msgstr ""
 
-#: src/Content/Nav.php:212 view/theme/frio/theme.php:270
-msgid "Manage/edit friends and contacts"
+#: src/Content/ContactSelector.php:147
+msgid "Abstinent"
 msgstr ""
 
-#: src/Content/Nav.php:217
-msgid "Site setup and configuration"
+#: src/Content/ContactSelector.php:147
+msgid "Virgin"
 msgstr ""
 
-#: src/Content/Nav.php:220
-msgid "Navigation"
+#: src/Content/ContactSelector.php:147
+msgid "Deviant"
 msgstr ""
 
-#: src/Content/Nav.php:220
-msgid "Site map"
+#: src/Content/ContactSelector.php:147
+msgid "Fetish"
 msgstr ""
 
-#: src/Content/OEmbed.php:253
-msgid "Embedding disabled"
+#: src/Content/ContactSelector.php:147
+msgid "Oodles"
 msgstr ""
 
-#: src/Content/OEmbed.php:373
-msgid "Embedded content"
+#: src/Content/ContactSelector.php:147
+msgid "Nonsexual"
 msgstr ""
 
-#: src/Content/Widget/CalendarExport.php:61
-msgid "Export"
+#: src/Content/ContactSelector.php:169
+msgid "Single"
 msgstr ""
 
-#: src/Content/Widget/CalendarExport.php:62
-msgid "Export calendar as ical"
+#: src/Content/ContactSelector.php:169
+msgid "Lonely"
 msgstr ""
 
-#: src/Content/Widget/CalendarExport.php:63
-msgid "Export calendar as csv"
+#: src/Content/ContactSelector.php:169
+msgid "Available"
+msgstr ""
+
+#: src/Content/ContactSelector.php:169
+msgid "Unavailable"
+msgstr ""
+
+#: src/Content/ContactSelector.php:169
+msgid "Has crush"
+msgstr ""
+
+#: src/Content/ContactSelector.php:169
+msgid "Infatuated"
+msgstr ""
+
+#: src/Content/ContactSelector.php:169
+msgid "Dating"
+msgstr ""
+
+#: src/Content/ContactSelector.php:169
+msgid "Unfaithful"
+msgstr ""
+
+#: src/Content/ContactSelector.php:169
+msgid "Sex Addict"
+msgstr ""
+
+#: src/Content/ContactSelector.php:169 src/Model/User.php:505
+msgid "Friends"
+msgstr ""
+
+#: src/Content/ContactSelector.php:169
+msgid "Friends/Benefits"
+msgstr ""
+
+#: src/Content/ContactSelector.php:169
+msgid "Casual"
+msgstr ""
+
+#: src/Content/ContactSelector.php:169
+msgid "Engaged"
+msgstr ""
+
+#: src/Content/ContactSelector.php:169
+msgid "Married"
+msgstr ""
+
+#: src/Content/ContactSelector.php:169
+msgid "Imaginarily married"
+msgstr ""
+
+#: src/Content/ContactSelector.php:169
+msgid "Partners"
+msgstr ""
+
+#: src/Content/ContactSelector.php:169
+msgid "Cohabiting"
+msgstr ""
+
+#: src/Content/ContactSelector.php:169
+msgid "Common law"
+msgstr ""
+
+#: src/Content/ContactSelector.php:169
+msgid "Happy"
+msgstr ""
+
+#: src/Content/ContactSelector.php:169
+msgid "Not looking"
+msgstr ""
+
+#: src/Content/ContactSelector.php:169
+msgid "Swinger"
+msgstr ""
+
+#: src/Content/ContactSelector.php:169
+msgid "Betrayed"
+msgstr ""
+
+#: src/Content/ContactSelector.php:169
+msgid "Separated"
+msgstr ""
+
+#: src/Content/ContactSelector.php:169
+msgid "Unstable"
+msgstr ""
+
+#: src/Content/ContactSelector.php:169
+msgid "Divorced"
+msgstr ""
+
+#: src/Content/ContactSelector.php:169
+msgid "Imaginarily divorced"
+msgstr ""
+
+#: src/Content/ContactSelector.php:169
+msgid "Widowed"
+msgstr ""
+
+#: src/Content/ContactSelector.php:169
+msgid "Uncertain"
+msgstr ""
+
+#: src/Content/ContactSelector.php:169
+msgid "It's complicated"
+msgstr ""
+
+#: src/Content/ContactSelector.php:169
+msgid "Don't care"
+msgstr ""
+
+#: src/Content/ContactSelector.php:169
+msgid "Ask me"
 msgstr ""
 
 #: src/Content/Feature.php:79
@@ -8184,6 +8037,252 @@ msgstr ""
 msgid "Display membership date in profile"
 msgstr ""
 
+#: src/Content/ForumManager.php:127 view/theme/vier/theme.php:256
+msgid "External link to forum"
+msgstr ""
+
+#: src/Content/Nav.php:53
+msgid "Nothing new here"
+msgstr ""
+
+#: src/Content/Nav.php:57
+msgid "Clear notifications"
+msgstr ""
+
+#: src/Content/Nav.php:97 src/Module/Login.php:311
+#: view/theme/frio/theme.php:256
+msgid "Logout"
+msgstr ""
+
+#: src/Content/Nav.php:97 view/theme/frio/theme.php:256
+msgid "End this session"
+msgstr ""
+
+#: src/Content/Nav.php:100 src/Content/Nav.php:181
+#: view/theme/frio/theme.php:259
+msgid "Your posts and conversations"
+msgstr ""
+
+#: src/Content/Nav.php:101 view/theme/frio/theme.php:260
+msgid "Your profile page"
+msgstr ""
+
+#: src/Content/Nav.php:102 view/theme/frio/theme.php:261
+msgid "Your photos"
+msgstr ""
+
+#: src/Content/Nav.php:103 src/Model/Profile.php:912 src/Model/Profile.php:915
+#: view/theme/frio/theme.php:262
+msgid "Videos"
+msgstr ""
+
+#: src/Content/Nav.php:103 view/theme/frio/theme.php:262
+msgid "Your videos"
+msgstr ""
+
+#: src/Content/Nav.php:104 view/theme/frio/theme.php:263
+msgid "Your events"
+msgstr ""
+
+#: src/Content/Feature.php:121
+msgid "Ability to mute notifications for a thread"
+msgstr ""
+
+#: src/Content/Feature.php:126
+msgid "Advanced Profile Settings"
+msgstr ""
+
+#: src/Content/Feature.php:127
+msgid "Show visitors public community forums at the Advanced Profile Page"
+msgstr ""
+
+#: src/Content/Nav.php:124 src/Content/Nav.php:181
+#: src/Core/NotificationsManager.php:192
+msgid "Home"
+msgstr ""
+
+#: src/Content/Nav.php:124
+msgid "Home Page"
+msgstr ""
+
+#: src/Content/Feature.php:128
+msgid "Provide a personal tag cloud on your profile page"
+msgstr ""
+
+#: src/Content/Feature.php:129
+msgid "Display Membership Date"
+msgstr ""
+
+#: src/Content/Feature.php:129
+msgid "Display membership date in profile"
+msgstr ""
+
+#: src/Content/Widget.php:33
+msgid "Add New Contact"
+msgstr ""
+
+#: src/Content/Widget.php:34
+msgid "Enter address or web location"
+msgstr ""
+
+#: src/Content/Widget.php:35
+msgid "Example: bob@example.com, http://example.com/barbara"
+msgstr ""
+
+#: src/Content/Widget.php:53
+#, php-format
+msgid "%d invitation available"
+msgid_plural "%d invitations available"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/Content/Widget.php:59
+msgid "Find People"
+msgstr ""
+
+#: src/Content/Nav.php:169 src/Model/Profile.php:927 src/Model/Profile.php:938
+#: view/theme/frio/theme.php:267
+msgid "Events and Calendar"
+msgstr ""
+
+#: src/Content/Nav.php:172
+msgid "Directory"
+msgstr ""
+
+#: src/Content/Widget.php:62
+msgid "Examples: Robert Morgenstein, Fishing"
+msgstr ""
+
+#: src/Content/Widget.php:65 view/theme/vier/theme.php:202
+msgid "Similar Interests"
+msgstr ""
+
+#: src/Content/Nav.php:178 view/theme/frio/theme.php:266
+msgid "Conversations from your friends"
+msgstr ""
+
+#: src/Content/Nav.php:179
+msgid "Network Reset"
+msgstr ""
+
+#: src/Content/Nav.php:179
+msgid "Load Network page with no filters"
+msgstr ""
+
+#: src/Content/Nav.php:186 src/Core/NotificationsManager.php:199
+msgid "Introductions"
+msgstr ""
+
+#: src/Content/Nav.php:186
+msgid "Friend Requests"
+msgstr ""
+
+#: src/Content/Nav.php:190
+msgid "See all notifications"
+msgstr ""
+
+#: src/Content/Nav.php:191
+msgid "Mark all system notifications seen"
+msgstr ""
+
+#: src/Content/Nav.php:195 view/theme/frio/theme.php:268
+msgid "Private mail"
+msgstr ""
+
+#: src/Content/Nav.php:196
+msgid "Inbox"
+msgstr ""
+
+#: src/Content/Nav.php:197
+msgid "Outbox"
+msgstr ""
+
+#: src/Content/Nav.php:201
+msgid "Manage"
+msgstr ""
+
+#: src/Content/Nav.php:201
+msgid "Manage other pages"
+msgstr ""
+
+#: src/Content/Nav.php:206 view/theme/frio/theme.php:269
+msgid "Account settings"
+msgstr ""
+
+#: src/Content/Nav.php:209 src/Model/Profile.php:372
+msgid "Profiles"
+msgstr ""
+
+#: src/Content/Nav.php:209
+msgid "Manage/Edit Profiles"
+msgstr ""
+
+#: src/Content/Nav.php:212 view/theme/frio/theme.php:270
+msgid "Manage/edit friends and contacts"
+msgstr ""
+
+#: src/Content/Nav.php:217
+msgid "Site setup and configuration"
+msgstr ""
+
+#: src/Content/Nav.php:220
+msgid "Navigation"
+msgstr ""
+
+#: src/Content/Nav.php:220
+msgid "Site map"
+msgstr ""
+
+#: src/Content/OEmbed.php:253
+msgid "Embedding disabled"
+msgstr ""
+
+#: src/Content/OEmbed.php:373
+msgid "Embedded content"
+msgstr ""
+
+#: src/Content/Text/BBCode.php:552
+msgid "view full size"
+msgstr ""
+
+#: src/Content/Text/BBCode.php:978 src/Content/Text/BBCode.php:1739
+#: src/Content/Text/BBCode.php:1740
+msgid "Image/photo"
+msgstr ""
+
+#: src/Content/Text/BBCode.php:1116
+#, php-format
+msgid "<a href=\"%1$s\" target=\"_blank\">%2$s</a> %3$s"
+msgstr ""
+
+#: src/Content/Text/BBCode.php:1674 src/Content/Text/BBCode.php:1696
+msgid "$1 wrote:"
+msgstr ""
+
+#: src/Content/Text/BBCode.php:1748 src/Content/Text/BBCode.php:1749
+msgid "Encrypted content"
+msgstr ""
+
+#: src/Content/Text/BBCode.php:1866
+msgid "Invalid source protocol"
+msgstr ""
+
+#: src/Content/Text/BBCode.php:1877
+msgid "Invalid link protocol"
+msgstr ""
+
+#: src/Content/Widget/CalendarExport.php:61
+msgid "Export"
+msgstr ""
+
+#: src/Content/Widget/CalendarExport.php:62
+msgid "Export calendar as ical"
+msgstr ""
+
+#: src/Content/Widget/CalendarExport.php:63
+msgid "Export calendar as csv"
+msgstr ""
+
 #: src/Content/Widget.php:33
 msgid "Add New Contact"
 msgstr ""
@@ -8254,312 +8353,121 @@ msgid_plural "%d contacts in common"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Content/ContactSelector.php:55
-msgid "Frequently"
+#: src/Core/ACL.php:295
+msgid "Post to Email"
 msgstr ""
 
-#: src/Content/ContactSelector.php:56
-msgid "Hourly"
+#: src/Core/ACL.php:301
+msgid "Hide your profile details from unknown viewers?"
 msgstr ""
 
-#: src/Content/ContactSelector.php:57
-msgid "Twice daily"
+#: src/Core/ACL.php:300
+#, php-format
+msgid "Connectors disabled, since \"%s\" is enabled."
 msgstr ""
 
-#: src/Content/ContactSelector.php:58
-msgid "Daily"
+#: src/Core/ACL.php:307
+msgid "Visible to everybody"
 msgstr ""
 
-#: src/Content/ContactSelector.php:59
-msgid "Weekly"
+#: src/Core/ACL.php:308 view/theme/vier/config.php:115
+msgid "show"
 msgstr ""
 
-#: src/Content/ContactSelector.php:60
-msgid "Monthly"
+#: src/Core/ACL.php:309 view/theme/vier/config.php:115
+msgid "don't show"
 msgstr ""
 
-#: src/Content/ContactSelector.php:80
-msgid "OStatus"
+#: src/Core/ACL.php:319
+msgid "Close"
 msgstr ""
 
-#: src/Content/ContactSelector.php:81
-msgid "RSS/Atom"
+#: src/Core/NotificationsManager.php:171
+msgid "System"
 msgstr ""
 
-#: src/Content/ContactSelector.php:84
-msgid "Facebook"
+#: src/Core/NotificationsManager.php:256 src/Core/NotificationsManager.php:268
+#, php-format
+msgid "%s commented on %s's post"
 msgstr ""
 
-#: src/Content/ContactSelector.php:85
-msgid "Zot!"
+#: src/Core/NotificationsManager.php:267
+#, php-format
+msgid "%s created a new post"
 msgstr ""
 
-#: src/Content/ContactSelector.php:86
-msgid "LinkedIn"
+#: src/Core/NotificationsManager.php:281
+#, php-format
+msgid "%s liked %s's post"
 msgstr ""
 
-#: src/Content/ContactSelector.php:87
-msgid "XMPP/IM"
+#: src/Core/NotificationsManager.php:294
+#, php-format
+msgid "%s disliked %s's post"
 msgstr ""
 
-#: src/Content/ContactSelector.php:88
-msgid "MySpace"
+#: src/Core/NotificationsManager.php:307
+#, php-format
+msgid "%s is attending %s's event"
 msgstr ""
 
-#: src/Content/ContactSelector.php:89
-msgid "Google+"
+#: src/Core/NotificationsManager.php:320
+#, php-format
+msgid "%s is not attending %s's event"
 msgstr ""
 
-#: src/Content/ContactSelector.php:90
-msgid "pump.io"
+#: src/Core/NotificationsManager.php:333
+#, php-format
+msgid "%s may attend %s's event"
 msgstr ""
 
-#: src/Content/ContactSelector.php:91
-msgid "Twitter"
+#: src/Core/NotificationsManager.php:350
+#, php-format
+msgid "%s is now friends with %s"
 msgstr ""
 
-#: src/Content/ContactSelector.php:92
-msgid "Diaspora Connector"
+#: src/Core/NotificationsManager.php:825
+msgid "Friend Suggestion"
 msgstr ""
 
-#: src/Content/ContactSelector.php:93
-msgid "GNU Social Connector"
+#: src/Core/NotificationsManager.php:851
+msgid "Friend/Connect Request"
 msgstr ""
 
-#: src/Content/ContactSelector.php:94
-msgid "pnut"
+#: src/Core/NotificationsManager.php:851
+msgid "New Follower"
 msgstr ""
 
-#: src/Content/ContactSelector.php:95
-msgid "App.net"
+#: src/Core/UserImport.php:104
+msgid "Error decoding account file"
 msgstr ""
 
-#: src/Content/ContactSelector.php:125
-msgid "Male"
+#: src/Core/UserImport.php:110
+msgid "Error! No version data in file! This is not a Friendica account file?"
 msgstr ""
 
-#: src/Content/ContactSelector.php:125
-msgid "Female"
+#: src/Core/UserImport.php:118
+#, php-format
+msgid "User '%s' already exists on this server!"
 msgstr ""
 
-#: src/Content/ContactSelector.php:125
-msgid "Currently Male"
+#: src/Core/UserImport.php:151
+msgid "User creation error"
 msgstr ""
 
-#: src/Content/ContactSelector.php:125
-msgid "Currently Female"
+#: src/Core/UserImport.php:169
+msgid "User profile creation error"
 msgstr ""
 
-#: src/Content/ContactSelector.php:125
-msgid "Mostly Male"
-msgstr ""
-
-#: src/Content/ContactSelector.php:125
-msgid "Mostly Female"
-msgstr ""
-
-#: src/Content/ContactSelector.php:125
-msgid "Transgender"
-msgstr ""
-
-#: src/Content/ContactSelector.php:125
-msgid "Intersex"
-msgstr ""
-
-#: src/Content/ContactSelector.php:125
-msgid "Transsexual"
-msgstr ""
-
-#: src/Content/ContactSelector.php:125
-msgid "Hermaphrodite"
-msgstr ""
-
-#: src/Content/ContactSelector.php:125
-msgid "Neuter"
-msgstr ""
-
-#: src/Content/ContactSelector.php:125
-msgid "Non-specific"
-msgstr ""
-
-#: src/Content/ContactSelector.php:125
-msgid "Other"
-msgstr ""
-
-#: src/Content/ContactSelector.php:147
-msgid "Males"
-msgstr ""
-
-#: src/Content/ContactSelector.php:147
-msgid "Females"
-msgstr ""
-
-#: src/Content/ContactSelector.php:147
-msgid "Gay"
-msgstr ""
-
-#: src/Content/ContactSelector.php:147
-msgid "Lesbian"
-msgstr ""
-
-#: src/Content/ContactSelector.php:147
-msgid "No Preference"
-msgstr ""
-
-#: src/Content/ContactSelector.php:147
-msgid "Bisexual"
-msgstr ""
-
-#: src/Content/ContactSelector.php:147
-msgid "Autosexual"
-msgstr ""
-
-#: src/Content/ContactSelector.php:147
-msgid "Abstinent"
-msgstr ""
-
-#: src/Content/ContactSelector.php:147
-msgid "Virgin"
-msgstr ""
-
-#: src/Content/ContactSelector.php:147
-msgid "Deviant"
-msgstr ""
-
-#: src/Content/ContactSelector.php:147
-msgid "Fetish"
-msgstr ""
-
-#: src/Content/ContactSelector.php:147
-msgid "Oodles"
-msgstr ""
-
-#: src/Content/ContactSelector.php:147
-msgid "Nonsexual"
-msgstr ""
-
-#: src/Content/ContactSelector.php:169
-msgid "Single"
-msgstr ""
-
-#: src/Content/ContactSelector.php:169
-msgid "Lonely"
-msgstr ""
-
-#: src/Content/ContactSelector.php:169
-msgid "Available"
-msgstr ""
-
-#: src/Content/ContactSelector.php:169
-msgid "Unavailable"
-msgstr ""
-
-#: src/Content/ContactSelector.php:169
-msgid "Has crush"
-msgstr ""
-
-#: src/Content/ContactSelector.php:169
-msgid "Infatuated"
-msgstr ""
-
-#: src/Content/ContactSelector.php:169
-msgid "Dating"
-msgstr ""
-
-#: src/Content/ContactSelector.php:169
-msgid "Unfaithful"
-msgstr ""
-
-#: src/Content/ContactSelector.php:169
-msgid "Sex Addict"
-msgstr ""
-
-#: src/Content/ContactSelector.php:169 src/Model/User.php:505
-msgid "Friends"
-msgstr ""
-
-#: src/Content/ContactSelector.php:169
-msgid "Friends/Benefits"
-msgstr ""
-
-#: src/Content/ContactSelector.php:169
-msgid "Casual"
-msgstr ""
-
-#: src/Content/ContactSelector.php:169
-msgid "Engaged"
-msgstr ""
-
-#: src/Content/ContactSelector.php:169
-msgid "Married"
-msgstr ""
-
-#: src/Content/ContactSelector.php:169
-msgid "Imaginarily married"
-msgstr ""
-
-#: src/Content/ContactSelector.php:169
-msgid "Partners"
-msgstr ""
-
-#: src/Content/ContactSelector.php:169
-msgid "Cohabiting"
-msgstr ""
-
-#: src/Content/ContactSelector.php:169
-msgid "Common law"
-msgstr ""
-
-#: src/Content/ContactSelector.php:169
-msgid "Happy"
-msgstr ""
-
-#: src/Content/ContactSelector.php:169
-msgid "Not looking"
-msgstr ""
-
-#: src/Content/ContactSelector.php:169
-msgid "Swinger"
-msgstr ""
-
-#: src/Content/ContactSelector.php:169
-msgid "Betrayed"
-msgstr ""
-
-#: src/Content/ContactSelector.php:169
-msgid "Separated"
-msgstr ""
-
-#: src/Content/ContactSelector.php:169
-msgid "Unstable"
-msgstr ""
-
-#: src/Content/ContactSelector.php:169
-msgid "Divorced"
-msgstr ""
-
-#: src/Content/ContactSelector.php:169
-msgid "Imaginarily divorced"
-msgstr ""
-
-#: src/Content/ContactSelector.php:169
-msgid "Widowed"
-msgstr ""
-
-#: src/Content/ContactSelector.php:169
-msgid "Uncertain"
-msgstr ""
-
-#: src/Content/ContactSelector.php:169
-msgid "It's complicated"
-msgstr ""
-
-#: src/Content/ContactSelector.php:169
-msgid "Don't care"
-msgstr ""
+#: src/Core/UserImport.php:213
+#, php-format
+msgid "%d contact not imported"
+msgid_plural "%d contacts not imported"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/Content/ContactSelector.php:169
-msgid "Ask me"
+#: src/Core/UserImport.php:278
+msgid "Done. You can now login with your username and password"
 msgstr ""
 
 #: src/Database/DBStructure.php:32
@@ -8604,178 +8512,6 @@ msgstr ""
 #: src/Database/DBStructure.php:460
 #, php-format
 msgid "%s: updating %s table."
-msgstr ""
-
-#: src/Model/Mail.php:40 src/Model/Mail.php:174
-msgid "[no subject]"
-msgstr ""
-
-#: src/Model/Profile.php:97
-msgid "Requested account is not available."
-msgstr ""
-
-#: src/Model/Profile.php:168 src/Model/Profile.php:399
-#: src/Model/Profile.php:859
-msgid "Edit profile"
-msgstr ""
-
-#: src/Model/Profile.php:336
-msgid "Atom feed"
-msgstr ""
-
-#: src/Model/Profile.php:372
-msgid "Manage/edit profiles"
-msgstr ""
-
-#: src/Model/Profile.php:548 src/Model/Profile.php:641
-msgid "g A l F d"
-msgstr ""
-
-#: src/Model/Profile.php:549
-msgid "F d"
-msgstr ""
-
-#: src/Model/Profile.php:606 src/Model/Profile.php:703
-msgid "[today]"
-msgstr ""
-
-#: src/Model/Profile.php:617
-msgid "Birthday Reminders"
-msgstr ""
-
-#: src/Model/Profile.php:618
-msgid "Birthdays this week:"
-msgstr ""
-
-#: src/Model/Profile.php:690
-msgid "[No description]"
-msgstr ""
-
-#: src/Model/Profile.php:717
-msgid "Event Reminders"
-msgstr ""
-
-#: src/Model/Profile.php:718
-msgid "Events this week:"
-msgstr ""
-
-#: src/Model/Profile.php:741
-msgid "Member since:"
-msgstr ""
-
-#: src/Model/Profile.php:749
-msgid "j F, Y"
-msgstr ""
-
-#: src/Model/Profile.php:750
-msgid "j F"
-msgstr ""
-
-#: src/Model/Profile.php:765
-msgid "Age:"
-msgstr ""
-
-#: src/Model/Profile.php:778
-#, php-format
-msgid "for %1$d %2$s"
-msgstr ""
-
-#: src/Model/Profile.php:802
-msgid "Religion:"
-msgstr ""
-
-#: src/Model/Profile.php:810
-msgid "Hobbies/Interests:"
-msgstr ""
-
-#: src/Model/Profile.php:822
-msgid "Contact information and Social Networks:"
-msgstr ""
-
-#: src/Model/Profile.php:826
-msgid "Musical interests:"
-msgstr ""
-
-#: src/Model/Profile.php:830
-msgid "Books, literature:"
-msgstr ""
-
-#: src/Model/Profile.php:834
-msgid "Television:"
-msgstr ""
-
-#: src/Model/Profile.php:838
-msgid "Film/dance/culture/entertainment:"
-msgstr ""
-
-#: src/Model/Profile.php:842
-msgid "Love/Romance:"
-msgstr ""
-
-#: src/Model/Profile.php:846
-msgid "Work/employment:"
-msgstr ""
-
-#: src/Model/Profile.php:850
-msgid "School/education:"
-msgstr ""
-
-#: src/Model/Profile.php:855
-msgid "Forums:"
-msgstr ""
-
-#: src/Model/Profile.php:949
-msgid "Only You Can See This"
-msgstr ""
-
-#: src/Model/Item.php:1676
-#, php-format
-msgid "%1$s is attending %2$s's %3$s"
-msgstr ""
-
-#: src/Model/Item.php:1681
-#, php-format
-msgid "%1$s is not attending %2$s's %3$s"
-msgstr ""
-
-#: src/Model/Item.php:1686
-#, php-format
-msgid "%1$s may attend %2$s's %3$s"
-msgstr ""
-
-#: src/Model/Group.php:44
-msgid ""
-"A deleted group with this name was revived. Existing item permissions "
-"<strong>may</strong> apply to this group and any future members. If this is "
-"not what you intended, please create another group with a different name."
-msgstr ""
-
-#: src/Model/Group.php:328
-msgid "Default privacy group for new contacts"
-msgstr ""
-
-#: src/Model/Group.php:361
-msgid "Everybody"
-msgstr ""
-
-#: src/Model/Group.php:381
-msgid "edit"
-msgstr ""
-
-#: src/Model/Group.php:405
-msgid "Edit group"
-msgstr ""
-
-#: src/Model/Group.php:406
-msgid "Contacts not in any group"
-msgstr ""
-
-#: src/Model/Group.php:407
-msgid "Create a new group"
-msgstr ""
-
-#: src/Model/Group.php:409
-msgid "Edit groups"
 msgstr ""
 
 #: src/Model/Contact.php:645
@@ -8856,7 +8592,7 @@ msgstr ""
 msgid "%s's birthday"
 msgstr ""
 
-#: src/Model/Contact.php:1589 src/Protocol/DFRN.php:1478
+#: src/Model/Contact.php:1589 src/Protocol/DFRN.php:1397
 #, php-format
 msgid "Happy Birthday %s"
 msgstr ""
@@ -8917,6 +8653,182 @@ msgstr ""
 
 #: src/Model/Event.php:902
 msgid "Hide map"
+msgstr ""
+
+#: src/Model/Group.php:44
+msgid ""
+"A deleted group with this name was revived. Existing item permissions "
+"<strong>may</strong> apply to this group and any future members. If this is "
+"not what you intended, please create another group with a different name."
+msgstr ""
+
+#: src/Model/Group.php:328
+msgid "Default privacy group for new contacts"
+msgstr ""
+
+#: src/Model/Group.php:361
+msgid "Everybody"
+msgstr ""
+
+#: src/Model/Group.php:381
+msgid "edit"
+msgstr ""
+
+#: src/Model/Group.php:405
+msgid "Edit group"
+msgstr ""
+
+#: src/Model/Group.php:406
+msgid "Contacts not in any group"
+msgstr ""
+
+#: src/Model/Group.php:407
+msgid "Create a new group"
+msgstr ""
+
+#: src/Model/Group.php:409
+msgid "Edit groups"
+msgstr ""
+
+#: src/Model/Item.php:1676
+#, php-format
+msgid "%1$s is attending %2$s's %3$s"
+msgstr ""
+
+#: src/Model/Item.php:1681
+#, php-format
+msgid "%1$s is not attending %2$s's %3$s"
+msgstr ""
+
+#: src/Model/Item.php:1686
+#, php-format
+msgid "%1$s may attend %2$s's %3$s"
+msgstr ""
+
+#: src/Model/Mail.php:40 src/Model/Mail.php:174
+msgid "[no subject]"
+msgstr ""
+
+#: src/Model/Profile.php:97
+msgid "Requested account is not available."
+msgstr ""
+
+#: src/Model/Profile.php:168 src/Model/Profile.php:399
+#: src/Model/Profile.php:859
+msgid "Edit profile"
+msgstr ""
+
+#: src/Model/Profile.php:336
+msgid "Atom feed"
+msgstr ""
+
+#: src/Model/Profile.php:372
+msgid "Manage/edit profiles"
+msgstr ""
+
+#: src/Model/Profile.php:548 src/Model/Profile.php:641
+msgid "g A l F d"
+msgstr ""
+
+#: src/Model/Profile.php:549
+msgid "F d"
+msgstr ""
+
+#: src/Model/Profile.php:606 src/Model/Profile.php:703
+msgid "[today]"
+msgstr ""
+
+#: src/Model/Profile.php:617
+msgid "Birthday Reminders"
+msgstr ""
+
+#: src/Model/Profile.php:618
+msgid "Birthdays this week:"
+msgstr ""
+
+#: src/Model/Profile.php:690
+msgid "[No description]"
+msgstr ""
+
+#: src/Model/Profile.php:717
+msgid "Event Reminders"
+msgstr ""
+
+#: src/Model/Profile.php:718
+msgid "Events this week:"
+msgstr ""
+
+#: src/Model/Profile.php:741
+msgid "Member since:"
+msgstr ""
+
+#: src/Model/Profile.php:749
+msgid "j F, Y"
+msgstr ""
+
+#: src/Model/Profile.php:750
+msgid "j F"
+msgstr ""
+
+#: src/Model/Profile.php:758 src/Util/Temporal.php:147
+msgid "Birthday:"
+msgstr ""
+
+#: src/Model/Profile.php:765
+msgid "Age:"
+msgstr ""
+
+#: src/Model/Profile.php:778
+#, php-format
+msgid "for %1$d %2$s"
+msgstr ""
+
+#: src/Model/Profile.php:802
+msgid "Religion:"
+msgstr ""
+
+#: src/Model/Profile.php:810
+msgid "Hobbies/Interests:"
+msgstr ""
+
+#: src/Model/Profile.php:822
+msgid "Contact information and Social Networks:"
+msgstr ""
+
+#: src/Model/Profile.php:826
+msgid "Musical interests:"
+msgstr ""
+
+#: src/Model/Profile.php:830
+msgid "Books, literature:"
+msgstr ""
+
+#: src/Model/Profile.php:834
+msgid "Television:"
+msgstr ""
+
+#: src/Model/Profile.php:838
+msgid "Film/dance/culture/entertainment:"
+msgstr ""
+
+#: src/Model/Profile.php:842
+msgid "Love/Romance:"
+msgstr ""
+
+#: src/Model/Profile.php:846
+msgid "Work/employment:"
+msgstr ""
+
+#: src/Model/Profile.php:850
+msgid "School/education:"
+msgstr ""
+
+#: src/Model/Profile.php:855
+msgid "Forums:"
+msgstr ""
+
+#: src/Model/Profile.php:949
+msgid "Only You Can See This"
 msgstr ""
 
 #: src/Model/User.php:144
@@ -9034,39 +8946,80 @@ msgid ""
 "\t\t"
 msgstr ""
 
-#: src/Protocol/OStatus.php:1799
+#: src/Model/User.php:615
 #, php-format
-msgid "%s is now following %s."
+msgid ""
+"\n"
+"\t\t\tThe login details are as follows:\n"
+"\t\t\t\tSite Location:\t%3$s\n"
+"\t\t\t\tLogin Name:\t%1$s\n"
+"\t\t\t\tPassword:\t%5$s\n"
+"\n"
+"\t\t\tYou may change your password from your account Settings page after "
+"logging\n"
+"\t\t\tin.\n"
+"\n"
+"\t\t\tPlease take a few moments to review the other account settings on that "
+"page.\n"
+"\n"
+"\t\t\tYou may also wish to add some basic information to your default "
+"profile\n"
+"\t\t\t(on the \"Profiles\" page) so that other people can easily find you.\n"
+"\n"
+"\t\t\tWe recommend setting your full name, adding a profile photo,\n"
+"\t\t\tadding some profile keywords (very useful in making new friends) - "
+"and\n"
+"\t\t\tperhaps what country you live in; if you do not wish to be more "
+"specific\n"
+"\t\t\tthan that.\n"
+"\n"
+"\t\t\tWe fully respect your right to privacy, and none of these items are "
+"necessary.\n"
+"\t\t\tIf you are new and do not know anybody here, they may help\n"
+"\t\t\tyou to make some new and interesting friends.\n"
+"\n"
+"\n"
+"\t\t\tThank you and welcome to %2$s."
 msgstr ""
 
-#: src/Protocol/OStatus.php:1800
-msgid "following"
+#: src/Module/Login.php:282
+msgid "Create a New Account"
 msgstr ""
 
-#: src/Protocol/OStatus.php:1803
-#, php-format
-msgid "%s stopped following %s."
+#: src/Module/Login.php:315
+msgid "Password: "
 msgstr ""
 
-#: src/Protocol/OStatus.php:1804
-msgid "stopped following"
+#: src/Module/Login.php:316
+msgid "Remember me"
 msgstr ""
 
-#: src/Protocol/DFRN.php:1477
-#, php-format
-msgid "%s\\'s birthday"
+#: src/Module/Login.php:319
+msgid "Or login using OpenID: "
 msgstr ""
 
-#: src/Protocol/Diaspora.php:2651
-msgid "Sharing notification from Diaspora network"
+#: src/Module/Login.php:325
+msgid "Forgot your password?"
 msgstr ""
 
-#: src/Protocol/Diaspora.php:3736
-msgid "Attachments:"
+#: src/Module/Login.php:328
+msgid "Website Terms of Service"
 msgstr ""
 
-#: src/Worker/Delivery.php:392
-msgid "(no subject)"
+#: src/Module/Login.php:329
+msgid "terms of service"
+msgstr ""
+
+#: src/Module/Login.php:331
+msgid "Website Privacy Policy"
+msgstr ""
+
+#: src/Module/Login.php:332
+msgid "privacy policy"
+msgstr ""
+
+#: src/Module/Logout.php:28
+msgid "Logged out."
 msgstr ""
 
 #: src/Object/Post.php:128
@@ -9137,107 +9090,155 @@ msgstr ""
 msgid "share"
 msgstr ""
 
-#: src/Object/Post.php:359
+#: src/Object/Post.php:365
 msgid "to"
 msgstr ""
 
-#: src/Object/Post.php:360
+#: src/Object/Post.php:366
 msgid "via"
 msgstr ""
 
-#: src/Object/Post.php:361
+#: src/Object/Post.php:367
 msgid "Wall-to-Wall"
 msgstr ""
 
-#: src/Object/Post.php:362
+#: src/Object/Post.php:368
 msgid "via Wall-To-Wall:"
 msgstr ""
 
-#: src/Object/Post.php:421
+#: src/Object/Post.php:427
 #, php-format
 msgid "%d comment"
 msgid_plural "%d comments"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Object/Post.php:791
+#: src/Object/Post.php:797
 msgid "Bold"
 msgstr ""
 
-#: src/Object/Post.php:792
+#: src/Object/Post.php:798
 msgid "Italic"
 msgstr ""
 
-#: src/Object/Post.php:793
+#: src/Object/Post.php:799
 msgid "Underline"
 msgstr ""
 
-#: src/Object/Post.php:794
+#: src/Object/Post.php:800
 msgid "Quote"
 msgstr ""
 
-#: src/Object/Post.php:795
+#: src/Object/Post.php:801
 msgid "Code"
 msgstr ""
 
-#: src/Object/Post.php:796
+#: src/Object/Post.php:802
 msgid "Image"
 msgstr ""
 
-#: src/Object/Post.php:797
+#: src/Object/Post.php:803
 msgid "Link"
 msgstr ""
 
-#: src/Object/Post.php:798
+#: src/Object/Post.php:804
 msgid "Video"
 msgstr ""
 
-#: src/Module/Login.php:282
-msgid "Create a New Account"
+#: src/Protocol/DFRN.php:1396
+#, php-format
+msgid "%s\\'s birthday"
 msgstr ""
 
-#: src/Module/Login.php:315
-msgid "Password: "
+#: src/Protocol/Diaspora.php:2647
+msgid "Sharing notification from Diaspora network"
 msgstr ""
 
-#: src/Module/Login.php:316
-msgid "Remember me"
+#: src/Protocol/Diaspora.php:3732
+msgid "Attachments:"
 msgstr ""
 
-#: src/Module/Login.php:319
-msgid "Or login using OpenID: "
+#: src/Protocol/OStatus.php:1799
+#, php-format
+msgid "%s is now following %s."
 msgstr ""
 
-#: src/Module/Login.php:325
-msgid "Forgot your password?"
+#: src/Protocol/OStatus.php:1800
+msgid "following"
 msgstr ""
 
-#: src/Module/Login.php:328
-msgid "Website Terms of Service"
+#: src/Protocol/OStatus.php:1803
+#, php-format
+msgid "%s stopped following %s."
 msgstr ""
 
-#: src/Module/Login.php:329
-msgid "terms of service"
+#: src/Protocol/OStatus.php:1804
+msgid "stopped following"
 msgstr ""
 
-#: src/Module/Login.php:331
-msgid "Website Privacy Policy"
+#: src/Util/Temporal.php:151
+msgid "YYYY-MM-DD or MM-DD"
 msgstr ""
 
-#: src/Module/Login.php:332
-msgid "privacy policy"
+#: src/Util/Temporal.php:294
+msgid "never"
 msgstr ""
 
-#: src/Module/Logout.php:28
-msgid "Logged out."
+#: src/Util/Temporal.php:300
+msgid "less than a second ago"
 msgstr ""
 
-#: src/App.php:511
-msgid "Delete this item?"
+#: src/Util/Temporal.php:303
+msgid "year"
 msgstr ""
 
-#: src/App.php:513
-msgid "show fewer"
+#: src/Util/Temporal.php:303
+msgid "years"
+msgstr ""
+
+#: src/Util/Temporal.php:304
+msgid "months"
+msgstr ""
+
+#: src/Util/Temporal.php:305
+msgid "weeks"
+msgstr ""
+
+#: src/Util/Temporal.php:306
+msgid "days"
+msgstr ""
+
+#: src/Util/Temporal.php:307
+msgid "hour"
+msgstr ""
+
+#: src/Util/Temporal.php:307
+msgid "hours"
+msgstr ""
+
+#: src/Util/Temporal.php:308
+msgid "minute"
+msgstr ""
+
+#: src/Util/Temporal.php:308
+msgid "minutes"
+msgstr ""
+
+#: src/Util/Temporal.php:309
+msgid "second"
+msgstr ""
+
+#: src/Util/Temporal.php:309
+msgid "seconds"
+msgstr ""
+
+#: src/Util/Temporal.php:318
+#, php-format
+msgid "%1$d %2$s ago"
+msgstr ""
+
+#: src/Worker/Delivery.php:390
+msgid "(no subject)"
 msgstr ""
 
 #: view/theme/duepuntozero/config.php:55
@@ -9266,38 +9267,6 @@ msgstr ""
 
 #: view/theme/duepuntozero/config.php:74
 msgid "Variations"
-msgstr ""
-
-#: view/theme/frio/php/Image.php:25
-msgid "Repeat the image"
-msgstr ""
-
-#: view/theme/frio/php/Image.php:25
-msgid "Will repeat your image to fill the background."
-msgstr ""
-
-#: view/theme/frio/php/Image.php:27
-msgid "Stretch"
-msgstr ""
-
-#: view/theme/frio/php/Image.php:27
-msgid "Will stretch to width/height of the image."
-msgstr ""
-
-#: view/theme/frio/php/Image.php:29
-msgid "Resize fill and-clip"
-msgstr ""
-
-#: view/theme/frio/php/Image.php:29
-msgid "Resize to fill and retain aspect ratio."
-msgstr ""
-
-#: view/theme/frio/php/Image.php:31
-msgid "Resize best fit"
-msgstr ""
-
-#: view/theme/frio/php/Image.php:31
-msgid "Resize to best fit and retain aspect ratio."
 msgstr ""
 
 #: view/theme/frio/config.php:97
@@ -9350,6 +9319,38 @@ msgstr ""
 
 #: view/theme/frio/config.php:130
 msgid "Leave background image and color empty for theme defaults"
+msgstr ""
+
+#: view/theme/frio/php/Image.php:25
+msgid "Repeat the image"
+msgstr ""
+
+#: view/theme/frio/php/Image.php:25
+msgid "Will repeat your image to fill the background."
+msgstr ""
+
+#: view/theme/frio/php/Image.php:27
+msgid "Stretch"
+msgstr ""
+
+#: view/theme/frio/php/Image.php:27
+msgid "Will stretch to width/height of the image."
+msgstr ""
+
+#: view/theme/frio/php/Image.php:29
+msgid "Resize fill and-clip"
+msgstr ""
+
+#: view/theme/frio/php/Image.php:29
+msgid "Resize to fill and retain aspect ratio."
+msgstr ""
+
+#: view/theme/frio/php/Image.php:31
+msgid "Resize best fit"
+msgstr ""
+
+#: view/theme/frio/php/Image.php:31
+msgid "Resize to best fit and retain aspect ratio."
 msgstr ""
 
 #: view/theme/frio/theme.php:238
@@ -9422,10 +9423,6 @@ msgstr ""
 
 #: view/theme/vier/theme.php:292
 msgid "Quick Start"
-msgstr ""
-
-#: index.php:444
-msgid "toggle mobile"
 msgstr ""
 
 #: boot.php:791

--- a/view/templates/settings/connectors.tpl
+++ b/view/templates/settings/connectors.tpl
@@ -15,6 +15,7 @@
 		<h3 class="connector">{{$general_settings}}</h3>
 	</span>
 
+	{{include file="field_checkbox.tpl" field=$disable_cw}}
 	{{include file="field_checkbox.tpl" field=$no_intelligent_shortening}}
 	{{include file="field_checkbox.tpl" field=$ostatus_autofriend}}
 	{{$default_group}}

--- a/view/theme/frio/templates/settings/connectors.tpl
+++ b/view/theme/frio/templates/settings/connectors.tpl
@@ -20,6 +20,7 @@
 				<div id="content-settings-content" class="panel-collapse collapse" role="tabpanel" aria-labelledby="content-settings">
 					<div class="section-content-wrapper">
 
+						{{include file="field_checkbox.tpl" field=$disable_cw}}
 						{{include file="field_checkbox.tpl" field=$no_intelligent_shortening}}
 						{{include file="field_checkbox.tpl" field=$ostatus_autofriend}}
 						{{$default_group}}


### PR DESCRIPTION
See: https://friendica.mrpetovan.com/display/735a2029715ab80d1874cf6808556656

This hook collects all the potential filtering reasons for a single post and allows to display them all instead of having multiple collapsed posts.

Additionally, there is now a setting to disable the content warning set by authors on Mastodon and Pleroma.

It was an opportunity to update the Addons documentation dating from 2012!

Addon PR: https://github.com/friendica/friendica-addons/pull/566