### PR TITLE
[Composer] Bump divineomega/password_exposed version to 2.5.1

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -135,16 +135,16 @@
         },
         {
             "name": "divineomega/password_exposed",
-            "version": "v2.4.0",
+            "version": "v2.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/DivineOmega/password_exposed.git",
-                "reference": "7e26898a280662529b3e5e472b16fcbda167ffce"
+                "reference": "c928bf722eb02398df11076add60df070cb55581"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/DivineOmega/password_exposed/zipball/7e26898a280662529b3e5e472b16fcbda167ffce",
-                "reference": "7e26898a280662529b3e5e472b16fcbda167ffce",
+                "url": "https://api.github.com/repos/DivineOmega/password_exposed/zipball/c928bf722eb02398df11076add60df070cb55581",
+                "reference": "c928bf722eb02398df11076add60df070cb55581",
                 "shasum": ""
             },
             "require": {
@@ -179,7 +179,7 @@
                 }
             ],
             "description": "This PHP package provides a `password_exposed` helper function, that uses the haveibeenpwned.com API to check if a password has been exposed in a data breach.",
-            "time": "2018-03-14T09:17:40+00:00"
+            "time": "2018-04-02T18:16:36+00:00"
         },
         {
             "name": "ezyang/htmlpurifier",


### PR DESCRIPTION
Follow-up to #4640

Thanks to @DivineOmega, the password_exposed package now uses the local Certainty bundle instead of remote fetching on systems with no write access and/or low computational capabilities for elliptic curve cryptography.

This should prevent @tobiasd's RasPi2b from imploding every time someone changes their password.