### PR TITLE
Commenting on public posts from Friendica users is now possible again

### DIFF
--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -3264,13 +3264,15 @@ class Diaspora
 
 		$logid = random_string(4);
 
+		$dest_url = ($public_batch ? $contact["batch"] : $contact["notify"]);
+
 		// We always try to use the data from the fcontact table.
 		// This is important for transmitting data to Friendica servers.
-		if (!empty($contact['addr']) && ($contact['network'] != NETWORK_DIASPORA)) {
+		if (!empty($contact['addr'])) {
 			$fcontact = self::personByHandle($contact['addr']);
-			$dest_url = ($public_batch ? $fcontact["batch"] : $fcontact["notify"]);
-		} else {
-			$dest_url = ($public_batch ? $contact["batch"] : $contact["notify"]);
+			if (!empty($fcontact)) {
+				$dest_url = ($public_batch ? $fcontact["batch"] : $fcontact["notify"]);
+			}
 		}
 
 		if (!$dest_url) {


### PR DESCRIPTION
When we comment on a public thread from a Friendica user who we don't follow, we currently have to use the Diaspora protocol. There had been a bug that prevented that our messages had been sent to the correct destination.