### PR TITLE
Avoid "Failed to parse time string (-001-11-30T00:00:00+00:00 + 32 days)"

### DIFF
--- a/src/Util/DateTimeFormat.php
+++ b/src/Util/DateTimeFormat.php
@@ -109,6 +109,9 @@ class DateTimeFormat
 		 * months and days always start with 1.
 		 */
 		if (substr($s, 0, 10) <= '0001-01-01') {
+			if ($s < '0000-00-00') {
+				$s = '0000-00-00';
+			}
 			$d = new DateTime($s . ' + 32 days', new DateTimeZone('UTC'));
 			return str_replace('1', '0', $d->format($format));
 		}


### PR DESCRIPTION
This fixes this bug:
```PHP Fatal error:  Uncaught Exception: DateTime::__construct(): Failed to parse time string (-001-11-30T00:00:00+00:00 + 32 days) at position 7 (-): Double timezone specification in /var/www/virtual/pirati.ca/htdocs/src/Util/DateTimeFormat.php:112```
