### PR TITLE
Fix: The register mail contained variables in a wrong order

### DIFF
--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -615,9 +615,9 @@ class User
 		$body = deindent(L10n::t('
 			The login details are as follows:
 
-			Site Location:	%1$s
-			Login Name:		%2$s
-			Password:		%3$s
+			Site Location:	%3$s
+			Login Name:		%1$s
+			Password:		%5$s
 
 			You may change your password from your account "Settings" page after logging
 			in.
@@ -636,9 +636,9 @@ class User
 			If you are new and do not know anybody here, they may help
 			you to make some new and interesting friends.
 
-			If you ever want to delete your account, you can do so at %1$s/removeme
+			If you ever want to delete your account, you can do so at %3$s/removeme
 
-			Thank you and welcome to %4$s.'));
+			Thank you and welcome to %2$s.'));
 
 		$preamble = sprintf($preamble, $username, $sitename);
 		$body = sprintf($body, $email, $sitename, $siteurl, $username, $password);


### PR DESCRIPTION
It currently looks this way:
```
Hallo Username, 

danke für Deine Registrierung auf squeet.me.

Dein Account wurde eingerichtet.

The login details are as follows: 
Site Location: user@mail.tld
Login Name: squeet.me
Password: squeet.me

You may change your password from your account "Settings" page after logging in.

Please take a few moments to review the other account settings on that page. 

You may also wish to add some basic information to your default profile (on the "Profiles" page) so that other people can easily find you. 

We recommend setting your full name, adding a profile photo, adding some profile "keywords" (very useful in making new friends) - and perhaps what country you live in; if you do not wish to be more specific than that.

We fully respect your right to privacy, and none of these items are necessary. If you are new and do not know anybody here, they may help you to make some new and interesting friends. 

If you ever want to delete your account, you can do so at user@mail.tld/removeme 

Thank you and welcome to Username. 

Thank You,
```