### PR TITLE
Added support of alt texts in images

### DIFF
--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -1718,6 +1718,14 @@ class BBCode extends BaseObject
 			$text
 		);
 
+		$text = preg_replace_callback("/\[img\=([$URLSearchString]*)\](.*?)\[\/img\]/ism",
+			function ($matches) {
+				$matches[1] = proxy_url($matches[1]);
+				$matches[2] = htmlspecialchars($matches[2], ENT_COMPAT);
+				return '<img src="' . $matches[1] . '" alt="' . $matches[2] . '">';
+			},
+			$text);
+
 		$text = preg_replace("/\[img\=([0-9]*)x([0-9]*)\](.*?)\[\/img\]/ism", '<img src="$3" style="width: $1px;" >', $text);
 		$text = preg_replace("/\[zmg\=([0-9]*)x([0-9]*)\](.*?)\[\/zmg\]/ism", '<img class="zrl" src="$3" style="width: $1px;" >', $text);
 
@@ -1852,10 +1860,12 @@ class BBCode extends BaseObject
 		$text = preg_replace_callback("/\[nobb\](.*?)\[\/nobb\]/ism", 'self::unescapeNoparseCallback', $text);
 		$text = preg_replace_callback("/\[pre\](.*?)\[\/pre\]/ism", 'self::unescapeNoparseCallback', $text);
 
-
+		/// @todo What is the meaning of these lines?
 		$text = preg_replace('/\[\&amp\;([#a-z0-9]+)\;\]/', '&$1;', $text);
 		$text = preg_replace('/\&\#039\;/', '\'', $text);
-		$text = preg_replace('/\&quot\;/', '"', $text);
+
+		// Currently deactivated, it made problems with " inside of alt texts.
+		//$text = preg_replace('/\&quot\;/', '"', $text);
 
 		// fix any escaped ampersands that may have been converted into links
 		$text = preg_replace('/\<([^>]*?)(src|href)=(.*?)\&amp\;(.*?)\>/ism', '<$1$2=$3&$4>', $text);


### PR DESCRIPTION
This adds support for alt texts in images, the format is ```[img=https://imgs.xkcd.com/comics/conversational_dynamics.png]'You should make it so people can search for and jump into hundreds of conversations at once if they want.' 'Ooh, good idea! I imagine only the most well-informed people with the most critical information to share will use that feature.'[/img]```