### PR TITLE
Hide posts from recently ignored/unfollowed contact

### DIFF
--- a/mod/network.php
+++ b/mod/network.php
@@ -837,7 +837,7 @@ function networkThreadedView(App $a, $update, $parent)
 			WHERE `item`.`uid` = 0 AND `item`.$ordering < ? AND `item`.$ordering > ?
 				AND NOT `contact`.`hidden` AND NOT `contact`.`blocked`" . $sql_tag_nets,
 			local_user(), TERM_OBJ_POST, TERM_HASHTAG,
-			intval(CONTACT_IS_SHARING),	intval(CONTACT_IS_FRIEND),
+			CONTACT_IS_SHARING, CONTACT_IS_FRIEND,
 			$top_limit, $bottom_limit);
 
 		$data = dba::inArray($items);

--- a/mod/network.php
+++ b/mod/network.php
@@ -771,6 +771,7 @@ function networkThreadedView(App $a, $update, $parent)
 			FROM `item` $sql_post_table
 			STRAIGHT_JOIN `contact` ON `contact`.`id` = `item`.`contact-id`
 				AND (NOT `contact`.`blocked` OR `contact`.`pending`)
+				AND (`item`.`parent-uri` != `item`.`uri` OR NOT (`contact`.`rel` < 2 OR `contact`.`readonly`))
 			WHERE `item`.`uid` = %d AND `item`.`visible` AND NOT `item`.`deleted`
 			AND NOT `item`.`moderated` AND $sql_extra4
 			$sql_extra3 $sql_extra $sql_range $sql_nets
@@ -783,6 +784,7 @@ function networkThreadedView(App $a, $update, $parent)
 			STRAIGHT_JOIN `contact` ON `contact`.`id` = `thread`.`contact-id`
 				AND (NOT `contact`.`blocked` OR `contact`.`pending`)
 			STRAIGHT_JOIN `item` ON `item`.`id` = `thread`.`iid`
+				AND (`item`.`parent-uri` != `item`.`uri` OR NOT (`contact`.`rel` < 2 OR `contact`.`readonly`))
 			WHERE `thread`.`uid` = %d AND `thread`.`visible` AND NOT `thread`.`deleted`
 			AND NOT `thread`.`moderated`
 			$sql_extra2 $sql_extra3 $sql_range $sql_extra $sql_nets
@@ -827,6 +829,7 @@ function networkThreadedView(App $a, $update, $parent)
 				(SELECT SUBSTR(`term`, 2) FROM `search` WHERE `uid` = ? AND `term` LIKE '#%') AND `otype` = ? AND `type` = ? AND `uid` = 0) AS `term`
 			ON `item`.`id` = `term`.`oid`
 			STRAIGHT_JOIN `contact` ON `contact`.`id` = `item`.`author-id`
+				AND (`item`.`parent-uri` != `item`.`uri` OR NOT (`contact`.`rel` < 2 OR `contact`.`readonly`))
 			WHERE `item`.`uid` = 0 AND `item`.$ordering < ? AND `item`.$ordering > ?
 				AND NOT `contact`.`hidden` AND NOT `contact`.`blocked`" . $sql_tag_nets,
 			local_user(), TERM_OBJ_POST, TERM_HASHTAG, $top_limit, $bottom_limit);

--- a/mod/network.php
+++ b/mod/network.php
@@ -771,12 +771,13 @@ function networkThreadedView(App $a, $update, $parent)
 			FROM `item` $sql_post_table
 			STRAIGHT_JOIN `contact` ON `contact`.`id` = `item`.`contact-id`
 				AND (NOT `contact`.`blocked` OR `contact`.`pending`)
-				AND (`item`.`parent-uri` != `item`.`uri` OR NOT (`contact`.`rel` IN (0, %d) OR `contact`.`readonly`))
+				AND (`item`.`parent-uri` != `item`.`uri` OR `contact`.`rel` IN (%d, %d) AND NOT `contact`.`readonly`)
 			WHERE `item`.`uid` = %d AND `item`.`visible` AND NOT `item`.`deleted`
 			AND NOT `item`.`moderated` AND $sql_extra4
 			$sql_extra3 $sql_extra $sql_range $sql_nets
 			ORDER BY `order_date` DESC LIMIT 100",
-			intval(CONTACT_IS_FOLLOWER),
+			intval(CONTACT_IS_SHARING),
+			intval(CONTACT_IS_FRIEND),
 			intval(local_user())
 		);
 	} else {
@@ -785,12 +786,13 @@ function networkThreadedView(App $a, $update, $parent)
 			STRAIGHT_JOIN `contact` ON `contact`.`id` = `thread`.`contact-id`
 				AND (NOT `contact`.`blocked` OR `contact`.`pending`)
 			STRAIGHT_JOIN `item` ON `item`.`id` = `thread`.`iid`
-				AND (`item`.`parent-uri` != `item`.`uri` OR NOT (`contact`.`rel` IN (0, %d) OR `contact`.`readonly`))
+				AND (`item`.`parent-uri` != `item`.`uri` OR `contact`.`rel` IN (%d, %d) AND NOT `contact`.`readonly`)
 			WHERE `thread`.`uid` = %d AND `thread`.`visible` AND NOT `thread`.`deleted`
 			AND NOT `thread`.`moderated`
 			$sql_extra2 $sql_extra3 $sql_range $sql_extra $sql_nets
 			ORDER BY `order_date` DESC $pager_sql",
-			intval(CONTACT_IS_FOLLOWER),
+			intval(CONTACT_IS_SHARING),
+			intval(CONTACT_IS_FRIEND),
 			intval(local_user())
 		);
 	}
@@ -831,10 +833,12 @@ function networkThreadedView(App $a, $update, $parent)
 				(SELECT SUBSTR(`term`, 2) FROM `search` WHERE `uid` = ? AND `term` LIKE '#%') AND `otype` = ? AND `type` = ? AND `uid` = 0) AS `term`
 			ON `item`.`id` = `term`.`oid`
 			STRAIGHT_JOIN `contact` ON `contact`.`id` = `item`.`author-id`
-				AND (`item`.`parent-uri` != `item`.`uri` OR NOT (`contact`.`rel` IN (0, %d) OR `contact`.`readonly`))
+				AND (`item`.`parent-uri` != `item`.`uri` OR `contact`.`rel` IN (?, ?) AND NOT `contact`.`readonly`)
 			WHERE `item`.`uid` = 0 AND `item`.$ordering < ? AND `item`.$ordering > ?
 				AND NOT `contact`.`hidden` AND NOT `contact`.`blocked`" . $sql_tag_nets,
-			local_user(), TERM_OBJ_POST, TERM_HASHTAG, intval(CONTACT_IS_FOLLOWER), $top_limit, $bottom_limit);
+			local_user(), TERM_OBJ_POST, TERM_HASHTAG,
+			intval(CONTACT_IS_SHARING),	intval(CONTACT_IS_FRIEND),
+			$top_limit, $bottom_limit);
 
 		$data = dba::inArray($items);
 

--- a/mod/network.php
+++ b/mod/network.php
@@ -771,11 +771,12 @@ function networkThreadedView(App $a, $update, $parent)
 			FROM `item` $sql_post_table
 			STRAIGHT_JOIN `contact` ON `contact`.`id` = `item`.`contact-id`
 				AND (NOT `contact`.`blocked` OR `contact`.`pending`)
-				AND (`item`.`parent-uri` != `item`.`uri` OR NOT (`contact`.`rel` < 2 OR `contact`.`readonly`))
+				AND (`item`.`parent-uri` != `item`.`uri` OR NOT (`contact`.`rel` < %d OR `contact`.`readonly`))
 			WHERE `item`.`uid` = %d AND `item`.`visible` AND NOT `item`.`deleted`
 			AND NOT `item`.`moderated` AND $sql_extra4
 			$sql_extra3 $sql_extra $sql_range $sql_nets
 			ORDER BY `order_date` DESC LIMIT 100",
+			intval(CONTACT_IS_SHARING),
 			intval(local_user())
 		);
 	} else {
@@ -784,11 +785,12 @@ function networkThreadedView(App $a, $update, $parent)
 			STRAIGHT_JOIN `contact` ON `contact`.`id` = `thread`.`contact-id`
 				AND (NOT `contact`.`blocked` OR `contact`.`pending`)
 			STRAIGHT_JOIN `item` ON `item`.`id` = `thread`.`iid`
-				AND (`item`.`parent-uri` != `item`.`uri` OR NOT (`contact`.`rel` < 2 OR `contact`.`readonly`))
+				AND (`item`.`parent-uri` != `item`.`uri` OR NOT (`contact`.`rel` < %d OR `contact`.`readonly`))
 			WHERE `thread`.`uid` = %d AND `thread`.`visible` AND NOT `thread`.`deleted`
 			AND NOT `thread`.`moderated`
 			$sql_extra2 $sql_extra3 $sql_range $sql_extra $sql_nets
 			ORDER BY `order_date` DESC $pager_sql",
+			intval(CONTACT_IS_SHARING),
 			intval(local_user())
 		);
 	}
@@ -829,10 +831,10 @@ function networkThreadedView(App $a, $update, $parent)
 				(SELECT SUBSTR(`term`, 2) FROM `search` WHERE `uid` = ? AND `term` LIKE '#%') AND `otype` = ? AND `type` = ? AND `uid` = 0) AS `term`
 			ON `item`.`id` = `term`.`oid`
 			STRAIGHT_JOIN `contact` ON `contact`.`id` = `item`.`author-id`
-				AND (`item`.`parent-uri` != `item`.`uri` OR NOT (`contact`.`rel` < 2 OR `contact`.`readonly`))
+				AND (`item`.`parent-uri` != `item`.`uri` OR NOT (`contact`.`rel` < ? OR `contact`.`readonly`))
 			WHERE `item`.`uid` = 0 AND `item`.$ordering < ? AND `item`.$ordering > ?
 				AND NOT `contact`.`hidden` AND NOT `contact`.`blocked`" . $sql_tag_nets,
-			local_user(), TERM_OBJ_POST, TERM_HASHTAG, $top_limit, $bottom_limit);
+			local_user(), TERM_OBJ_POST, TERM_HASHTAG, intval(CONTACT_IS_SHARING), $top_limit, $bottom_limit);
 
 		$data = dba::inArray($items);
 

--- a/mod/network.php
+++ b/mod/network.php
@@ -771,12 +771,12 @@ function networkThreadedView(App $a, $update, $parent)
 			FROM `item` $sql_post_table
 			STRAIGHT_JOIN `contact` ON `contact`.`id` = `item`.`contact-id`
 				AND (NOT `contact`.`blocked` OR `contact`.`pending`)
-				AND (`item`.`parent-uri` != `item`.`uri` OR NOT (`contact`.`rel` < %d OR `contact`.`readonly`))
+				AND (`item`.`parent-uri` != `item`.`uri` OR NOT (`contact`.`rel` IN (0, %d) OR `contact`.`readonly`))
 			WHERE `item`.`uid` = %d AND `item`.`visible` AND NOT `item`.`deleted`
 			AND NOT `item`.`moderated` AND $sql_extra4
 			$sql_extra3 $sql_extra $sql_range $sql_nets
 			ORDER BY `order_date` DESC LIMIT 100",
-			intval(CONTACT_IS_SHARING),
+			intval(CONTACT_IS_FOLLOWER),
 			intval(local_user())
 		);
 	} else {
@@ -785,12 +785,12 @@ function networkThreadedView(App $a, $update, $parent)
 			STRAIGHT_JOIN `contact` ON `contact`.`id` = `thread`.`contact-id`
 				AND (NOT `contact`.`blocked` OR `contact`.`pending`)
 			STRAIGHT_JOIN `item` ON `item`.`id` = `thread`.`iid`
-				AND (`item`.`parent-uri` != `item`.`uri` OR NOT (`contact`.`rel` < %d OR `contact`.`readonly`))
+				AND (`item`.`parent-uri` != `item`.`uri` OR NOT (`contact`.`rel` IN (0, %d) OR `contact`.`readonly`))
 			WHERE `thread`.`uid` = %d AND `thread`.`visible` AND NOT `thread`.`deleted`
 			AND NOT `thread`.`moderated`
 			$sql_extra2 $sql_extra3 $sql_range $sql_extra $sql_nets
 			ORDER BY `order_date` DESC $pager_sql",
-			intval(CONTACT_IS_SHARING),
+			intval(CONTACT_IS_FOLLOWER),
 			intval(local_user())
 		);
 	}
@@ -831,10 +831,10 @@ function networkThreadedView(App $a, $update, $parent)
 				(SELECT SUBSTR(`term`, 2) FROM `search` WHERE `uid` = ? AND `term` LIKE '#%') AND `otype` = ? AND `type` = ? AND `uid` = 0) AS `term`
 			ON `item`.`id` = `term`.`oid`
 			STRAIGHT_JOIN `contact` ON `contact`.`id` = `item`.`author-id`
-				AND (`item`.`parent-uri` != `item`.`uri` OR NOT (`contact`.`rel` < ? OR `contact`.`readonly`))
+				AND (`item`.`parent-uri` != `item`.`uri` OR NOT (`contact`.`rel` IN (0, %d) OR `contact`.`readonly`))
 			WHERE `item`.`uid` = 0 AND `item`.$ordering < ? AND `item`.$ordering > ?
 				AND NOT `contact`.`hidden` AND NOT `contact`.`blocked`" . $sql_tag_nets,
-			local_user(), TERM_OBJ_POST, TERM_HASHTAG, intval(CONTACT_IS_SHARING), $top_limit, $bottom_limit);
+			local_user(), TERM_OBJ_POST, TERM_HASHTAG, intval(CONTACT_IS_FOLLOWER), $top_limit, $bottom_limit);
 
 		$data = dba::inArray($items);
 


### PR DESCRIPTION
See https://friendica.mrpetovan.com/display/735a2029315ac842f7aafc0717133891

The idea is to immediately hides posts from a contact we just ignored/unfollowed. AFAIK we already do it with blocked.

Since they're only hidden, these posts will show up again if the contact is subsequently unignored/followed again.