### PR TITLE
Don't queue relay posts

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -212,12 +212,16 @@ define('PAGE_PRVGROUP',          5);
  *
  * ACCOUNT_TYPE_COMMUNITY - the account is community forum
  *	Associated page types: PAGE_COMMUNITY, PAGE_PRVGROUP
+ *
+ * ACCOUNT_TYPE_RELAY - the account is a relay
+ *      This will only be assigned to contacts, not to user accounts
  * @{
  */
 define('ACCOUNT_TYPE_PERSON',      0);
 define('ACCOUNT_TYPE_ORGANISATION', 1);
 define('ACCOUNT_TYPE_NEWS',        2);
 define('ACCOUNT_TYPE_COMMUNITY',   3);
+define('ACCOUNT_TYPE_RELAY',       4);
 /**
  * @}
  */

--- a/src/Worker/Queue.php
+++ b/src/Worker/Queue.php
@@ -136,7 +136,8 @@ class Queue
 				logger('queue: diaspora_delivery: item ' . $q_item['id'] . ' for ' . $contact['name'] . ' <' . $contact['url'] . '>');
 				$deliver_status = Diaspora::transmit($owner, $contact, $data, $public, true, 'Queue:' . $q_item['id'], true);
 
-				if (($deliver_status >= 200) && ($deliver_status <= 299)) {
+				if ((($deliver_status >= 200) && ($deliver_status <= 299)) ||
+					($contact['contact-type'] == ACCOUNT_TYPE_RELAY)) {
 					QueueModel::removeItem($q_item['id']);
 				} else {
 					QueueModel::updateTime($q_item['id']);


### PR DESCRIPTION
Relay contacts are now marked as such. This allows us to treat relay transmissions differently.