### PR TITLE
Improvement for the systemd timer unit

### DIFF
--- a/mods/sample-systemd.timer
+++ b/mods/sample-systemd.timer
@@ -4,6 +4,7 @@ Description=Run Friendica Poller every n minutes
 [Timer]
 OnBootSec=120
 OnUnitActiveSec=120
+RemainAfterElapse=False
 
 [Install]
 WantedBy=timers.target


### PR DESCRIPTION
Set RemainAfterElapse=False

> if RemainAfterElapse= is off, it might be started again if it is already elapsed, and thus be triggered multiple times

False will start the process again and again after the set time, this is the desired behavior for worker.php

Infos: https://www.freedesktop.org/software/systemd/man/systemd.timer.html