### PR TITLE
Ignore function "call_user_func_array" in the callstack

### DIFF
--- a/src/Core/System.php
+++ b/src/Core/System.php
@@ -60,7 +60,7 @@ class System extends BaseObject
 		$previous = ['class' => '', 'function' => ''];
 
 		// The ignore list contains all functions that are only wrapper functions
-		$ignore = ['fetchUrl'];
+		$ignore = ['fetchUrl', 'call_user_func_array'];
 
 		while ($func = array_pop($trace)) {
 			if (!empty($func['class'])) {


### PR DESCRIPTION
The function "call_user_func_array" isn't displayed anymore in the callstack function. It doesn't serve any benefit to be present there. 