### PR TITLE
api_get_user() should not return false right away if the number in the URL is not a valid user

### DIFF
--- a/include/api.php
+++ b/include/api.php
@@ -577,14 +577,12 @@ function api_get_user(App $a, $contact_id = null)
 		if (is_numeric($user)) {
 			$user = dbesc(api_unique_id_to_nurl(intval($user)));
 
-			if ($user == "") {
-				return false;
-			}
-
-			$url = $user;
-			$extra_query = "AND `contact`.`nurl` = '%s' ";
-			if (api_user() !== false) {
-				$extra_query .= "AND `contact`.`uid`=" . intval(api_user());
+			if ($user != "") {
+				$url = $user;
+				$extra_query = "AND `contact`.`nurl` = '%s' ";
+				if (api_user() !== false) {
+					$extra_query .= "AND `contact`.`uid`=" . intval(api_user());
+				}
 			}
 		} else {
 			$user = dbesc($user);


### PR DESCRIPTION
https://github.com/friendica/friendica/pull/4793 introduced the following bug (mentionned in https://github.com/friendica/friendica/pull/4795#issuecomment-379992811):
If the URL ends with a number (e.g. `api/statusnet/conversation/3.json`), `api_get_user()` assumes it is the user ID: https://github.com/friendica/friendica/blob/799bd75fb26a29b48b597322b601131a52fdfe50/include/api.php#L577
However it is a not a valid user ID, it returns false immediately which with https://github.com/friendica/friendica/pull/4793 now throws a forbidden error.
This patch makes it fall back to using `$_SESSION['uid']` if no user ID could be found by other means.

I still think it does not really make sense to assume a number in the URL is an user ID (if I had an user with ID 3, it would mean that for a call to `api/statusnet/conversation/3.json`, `api_get_user()` would return this unrelated user instead of the logged in user) but I don't know what this part of the code is for so I won't touch it and at least this PR makes `api_conversation_show()` work again.

PS: I won't work on the API again until I have implemented phpunit tests for these functions, it is currently too easy to break something and not notice it.