### PR TITLE
[BBCode] Improve support for strikethrough

### DIFF
--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -1583,7 +1583,7 @@ class BBCode extends BaseObject
 		$text = preg_replace("(\[u\](.*?)\[\/u\])ism", '<u>$1</u>', $text);
 
 		// Check for strike-through text
-		$text = preg_replace("(\[s\](.*?)\[\/s\])ism", '<strike>$1</strike>', $text);
+		$text = preg_replace("(\[s\](.*?)\[\/s\])ism", '<s>$1</s>', $text);
 
 		// Check for over-line text
 		$text = preg_replace("(\[o\](.*?)\[\/o\])ism", '<span class="overline">$1</span>', $text);

--- a/src/Content/Text/HTML.php
+++ b/src/Content/Text/HTML.php
@@ -221,6 +221,9 @@ class HTML
 		self::tagToBBCode($doc, 'b', [], '[b]', '[/b]');
 		self::tagToBBCode($doc, 'i', [], '[i]', '[/i]');
 		self::tagToBBCode($doc, 'u', [], '[u]', '[/u]');
+		self::tagToBBCode($doc, 's', [], '[s]', '[/s]');
+		self::tagToBBCode($doc, 'del', [], '[s]', '[/s]');
+		self::tagToBBCode($doc, 'strike', [], '[s]', '[/s]');
 
 		self::tagToBBCode($doc, 'big', [], "[size=large]", "[/size]");
 		self::tagToBBCode($doc, 'small', [], "[size=small]", "[/size]");


### PR DESCRIPTION
See this conversation: https://friendica.mrpetovan.com/display/d1d684301eba0136178d52540061b601

This PR doesn't add the support for `~~` Markdown strikethrough because only a couple of projects use this notation, to the notable exclusion of [the CommonMark standard](https://talk.commonmark.org/t/strikeout-threw-out-strikethrough-strikes-out-throughout/820) and the library we currently use to parse Markdown syntax.

However, Markdown allows literal HTML tags, so `<s>` should be displayed as striked text on Diaspora.