### PR TITLE
local_user() could also be a remote_user()

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -953,10 +953,12 @@ function public_contact()
  */
 function remote_user()
 {
-	// You cannot be both local and remote
-	if (local_user()) {
-		return false;
-	}
+	// You cannot be both local and remote.
+	// Unncommented by rabuzarus because remote authentication to local
+	// profiles wasn't possible anymore (2018-04-12).
+//	if (local_user()) {
+//		return false;
+//	}
 	if (x($_SESSION, 'authenticated') && x($_SESSION, 'visitor_id')) {
 		return intval($_SESSION['visitor_id']);
 	}


### PR DESCRIPTION
Have a look at https://github.com/friendica/friendica/issues/3833 (especially the end of the discussion)

Summary:
Since https://github.com/friendica/friendica/commit/21d27c2124996e1eaa35541cc5092c651c1375b7#diff-7d46ee16e8c1fe64c3bda458889f3b79 it wasn't possible anymore to write directly on a contacts wall or to komment directly on the contacts wall if the contact is on the same friendica instance like the `local_user()`.

So this PR uncomments https://github.com/friendica/friendica/commit/21d27c2124996e1eaa35541cc5092c651c1375b7#diff-7d46ee16e8c1fe64c3bda458889f3b79 .

Note:
We have to track down issues that might arise from this PR.