### PR TITLE
[BUGFIX] Domain Check: Remove DNS_PTR from check

### DIFF
--- a/include/dba.php
+++ b/include/dba.php
@@ -53,7 +53,7 @@ class dba {
 
 		if ($install) {
 			if (strlen($server) && ($server !== 'localhost') && ($server !== '127.0.0.1')) {
-				if (! dns_get_record($server, DNS_A + DNS_CNAME + DNS_PTR)) {
+				if (! dns_get_record($server, DNS_A + DNS_CNAME)) {
 					self::$error = L10n::t('Cannot locate DNS info for database server \'%s\'', $server);
 					return false;
 				}

--- a/src/Util/Network.php
+++ b/src/Util/Network.php
@@ -446,7 +446,7 @@ class Network
 		/// @TODO Really suppress function outcomes? Why not find them + debug them?
 		$h = @parse_url($url);
 
-		if ((is_array($h)) && (@dns_get_record($h['host'], DNS_A + DNS_CNAME + DNS_PTR) || filter_var($h['host'], FILTER_VALIDATE_IP) )) {
+		if ((is_array($h)) && (@dns_get_record($h['host'], DNS_A + DNS_CNAME) || filter_var($h['host'], FILTER_VALIDATE_IP) )) {
 			return $url;
 		}
 
@@ -471,7 +471,7 @@ class Network
 
 		$h = substr($addr, strpos($addr, '@') + 1);
 
-		if (($h) && (dns_get_record($h, DNS_A + DNS_CNAME + DNS_PTR + DNS_MX) || filter_var($h, FILTER_VALIDATE_IP) )) {
+		if (($h) && (dns_get_record($h, DNS_A + DNS_CNAME + DNS_MX) || filter_var($h, FILTER_VALIDATE_IP) )) {
 			return true;
 		}
 		return false;


### PR DESCRIPTION
DNS_PTR checks fail on some domains and result in the return value `false`, even if the domain is valid and reachable.

Since DNS_A and DNS_CNAME are still getting checked, I would propose removing this constant from the DNS checks.

Also DNS_PTR fails inside docker when checking the host.