### PR TITLE
Don't show multiple calls from the "dba" class 

### DIFF
--- a/src/Core/System.php
+++ b/src/Core/System.php
@@ -64,8 +64,8 @@ class System extends BaseObject
 
 		while ($func = array_pop($trace)) {
 			if (!empty($func['class'])) {
-				// Don't show multiple calls from the same function (mostly used for "dba" class)
-				if (($previous['class'] != $func['class']) && ($previous['function'] != 'q')) {
+				// Don't show multiple calls from the "dba" class to show the essential parts of the callstack
+				if ((($previous['class'] != $func['class']) || ($func['class'] != 'dba')) && ($previous['function'] != 'q')) {
 					$classparts = explode("\\", $func['class']);
 					$callstack[] = array_pop($classparts).'::'.$func['function'];
 					$previous = $func;


### PR DESCRIPTION
We better show the essential parts of the callstack.