### PR TITLE
Add hidden input in newpassword console

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
 		"paragonie/random_compat": "^2.0",
 		"pear/Text_LanguageDetect": "1.*",
 		"pear/Text_Highlighter": "dev-master",
+		"seld/cli-prompt": "^1.0",
 		"smarty/smarty": "^3.1",
 		"fxp/composer-asset-plugin": "~1.3",
 		"bower-asset/base64": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "96062c2020a40f14b52e5e91c79995a7",
+    "content-hash": "f97245142e60a521f048a667bec4e436",
     "packages": [
         {
             "name": "asika/simple-console",
@@ -1987,6 +1987,54 @@
             ],
             "description": "PSR-6 adapter for RW File Cache",
             "time": "2018-01-30T19:13:45+00:00"
+        },
+        {
+            "name": "seld/cli-prompt",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/cli-prompt.git",
+                "reference": "a19a7376a4689d4d94cab66ab4f3c816019ba8dd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/cli-prompt/zipball/a19a7376a4689d4d94cab66ab4f3c816019ba8dd",
+                "reference": "a19a7376a4689d4d94cab66ab4f3c816019ba8dd",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Seld\\CliPrompt\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be"
+                }
+            ],
+            "description": "Allows you to prompt for user input on the command line, and optionally hide the characters they type",
+            "keywords": [
+                "cli",
+                "console",
+                "hidden",
+                "input",
+                "prompt"
+            ],
+            "time": "2017-03-18T11:32:45+00:00"
         },
         {
             "name": "smarty/smarty",

--- a/src/Core/Console/NewPassword.php
+++ b/src/Core/Console/NewPassword.php
@@ -27,7 +27,7 @@ class NewPassword extends \Asika\SimpleConsole\Console
 		$help = <<<HELP
 console newpassword - Creates a new password for a given user
 Usage
-	bin/console newpassword <nickname> <password> [-h|--help|-?] [-v]
+	bin/console newpassword <nickname> [<password>] [-h|--help|-?] [-v]
 
 Description
 	Creates a new password for a user without using the "forgot password" functionality.
@@ -67,11 +67,20 @@ HELP;
 		}
 
 		$nick = $this->getArgument(0);
-		$password = $this->getArgument(1);
 
 		$user = dba::selectFirst('user', ['uid'], ['nickname' => $nick]);
 		if (!DBM::is_result($user)) {
 			throw new \RuntimeException(L10n::t('User not found'));
+		}
+
+		$password = $this->getArgument(1);
+		if (is_null($password)) {
+			$this->out(L10n::t('Enter new password: '), false);
+			$password = \Seld\CliPrompt\CliPrompt::hiddenPrompt(true);
+		}
+
+		if (!$password) {
+			throw new \RuntimeException(L10n::t('Password can\'t be empty'));
 		}
 
 		if (!Config::get('system', 'disable_password_exposed', false) && User::isPasswordExposed($password)) {

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -258,6 +258,10 @@ class User
 	 */
 	public static function hashPassword($password)
 	{
+		if (!trim($password)) {
+			throw new Exception(L10n::t('Password can\'t be empty'));
+		}
+
 		return password_hash($password, PASSWORD_DEFAULT);
 	}
 


### PR DESCRIPTION
Closes #4860

I didn't think I needed a dependency for this feature, but the Windows support requirement struck again.

Tested on my Windows machine and my Linux server.