### PR TITLE
Add space before Impressum.

### DIFF
--- a/mod/friendica.php
+++ b/mod/friendica.php
@@ -112,7 +112,7 @@ function friendica_content(App $a)
 				$s .= $p;
 			}
 		}
-		$o .= '<div style="margin-left: 25px; margin-right: 25px;">' . $s . '</div>' . PHP_EOL;
+		$o .= '<div style="margin-left: 25px; margin-right: 25px; margin-bottom: 25px;">' . $s . '</div>' . PHP_EOL;
 	} else {
 		$o .= '<p>' . L10n::t('No installed addons/apps') . '</p>' . PHP_EOL;
 	}


### PR DESCRIPTION
The page /friendica/ contains an Impressum section which is activated with an AddOn.
Add more space after last paragraph of information, before impressum, because site
looks quite cramped otherwise.