### PR TITLE
Remove pagination when empty, move new Member Tips and use common widget to find people.

### DIFF
--- a/mod/profile.php
+++ b/mod/profile.php
@@ -191,7 +191,7 @@ function profile_content(App $a, $update = 0)
 		$o .= Widget::commonFriendsVisitor($a->profile['profile_uid']);
 
 		if (x($_SESSION, 'new_member') && $is_owner) {
-			$o .= '<a href="newmember" id="newmember-tips" style="font-size: 1.2em;"><b>' . L10n::t('Tips for New Members') . '</b></a>' . EOL;
+			$o .= '<div id="newmember-tips"><a href="newmember"><b>' . L10n::t('Tips for New Members') . '</b></a></div>';
 		}
 
 		$commpage = $a->profile['page-flags'] == PAGE_COMMUNITY;

--- a/src/Content/Widget.php
+++ b/src/Content/Widget.php
@@ -55,19 +55,24 @@ class Widget
 			}
 		}
 
-		return replace_macros(get_markup_template('peoplefind.tpl'), array(
-			'$findpeople' => L10n::t('Find People'),
-			'$desc' => L10n::t('Enter name or interest'),
-			'$label' => L10n::t('Connect/Follow'),
-			'$hint' => L10n::t('Examples: Robert Morgenstein, Fishing'),
-			'$findthem' => L10n::t('Find'),
-			'$suggest' => L10n::t('Friend Suggestions'),
-			'$similar' => L10n::t('Similar Interests'),
-			'$random' => L10n::t('Random Profile'),
-			'$inv' => L10n::t('Invite Friends'),
-			'$directory' => L10n::t('View Global Directory'),
-			'$global_dir' => $global_dir
-		));
+		$nv = [];
+		$nv['findpeople'] = L10n::t('Find People');
+		$nv['desc'] = L10n::t('Enter name or interest');
+		$nv['label'] = L10n::t('Connect/Follow');
+		$nv['hint'] = L10n::t('Examples: Robert Morgenstein, Fishing');
+		$nv['findthem'] = L10n::t('Find');
+		$nv['suggest'] = L10n::t('Friend Suggestions');
+		$nv['similar'] = L10n::t('Similar Interests');
+		$nv['random'] = L10n::t('Random Profile');
+		$nv['inv'] = L10n::t('Invite Friends');
+		$nv['directory'] = L10n::t('Global Directory');
+		$nv['global_dir'] = $global_dir;
+		$nv['local_directory'] = L10n::t('Local Directory');
+
+		$aside = [];
+		$aside['$nv'] = $nv;
+
+		return replace_macros(get_markup_template('peoplefind.tpl'), $aside);
 	}
 
 	/**

--- a/util/credits.txt
+++ b/util/credits.txt
@@ -12,6 +12,7 @@ Alexandre Alapetite
 AlfredSK
 Andi Stadler
 Andreas H.
+Andreas Neustifter
 Andrej Stieben
 André Alves
 André Lohan

--- a/view/global.css
+++ b/view/global.css
@@ -202,6 +202,7 @@ blockquote.shared_content {
 }
 
 #profile-photo-wrapper {
+  clear: both;
   overflow: hidden;
 }
 

--- a/view/global.css
+++ b/view/global.css
@@ -206,6 +206,13 @@ blockquote.shared_content {
   overflow: hidden;
 }
 
+#newmember-tips {
+  font-size: 1.2em;
+  float: right;
+  margin-top: -32px;
+  padding-right: 10px;
+}
+
 /* headers */
 h1, h2, h3, h4, h5, h6 {
   margin: 5px 0px 5px 0px;

--- a/view/templates/paginate.tpl
+++ b/view/templates/paginate.tpl
@@ -1,5 +1,5 @@
+{{if $pager && ($pager.prev || $pager.next)}}
 <div class="pager">
-	{{if $pager}}
 	{{if $pager.prev}}<span class="pager_prev {{$pager.prev.class}}"><a href="{{$pager.prev.url}}">{{$pager.prev.text}}</a></span>{{/if}}
 
 	{{if $pager.first}}<span class="pager_first {{$pager.first.class}}"><a href="{{$pager.first.url}}">{{$pager.first.text}}</a></span>{{/if}}
@@ -9,5 +9,5 @@
 	{{if $pager.last}}&nbsp;<span class="pager_last {{$pager.last.class}}"><a href="{{$pager.last.url}}">{{$pager.last.text}}</a></span>{{/if}}
 
 	{{if $pager.next}}<span class="pager_next {{$pager.next.class}}"><a href="{{$pager.next.url}}">{{$pager.next.text}}</a></span>{{/if}}
-	{{/if}}
 </div>
+{{/if}}

--- a/view/templates/peoplefind.tpl
+++ b/view/templates/peoplefind.tpl
@@ -1,16 +1,17 @@
 
 <div id="peoplefind-sidebar" class="widget">
-	<h3>{{$findpeople}}</h3>
-	<div id="peoplefind-desc">{{$desc}}</div>
+	<h3>{{$nv.findpeople}}</h3>
+	<div id="peoplefind-desc">{{$nv.desc}}</div>
 	<form action="dirfind" method="get" />
-		<input id="side-peoplefind-url" type="text" name="search" size="24" title="{{$hint|escape:'html'}}" /><input id="side-peoplefind-submit" type="submit" name="submit" value="{{$findthem|escape:'html'}}" />
+		<input id="side-peoplefind-url" type="text" name="search" size="24" title="{{$nv.hint|escape:'html'}}" /><input id="side-peoplefind-submit" type="submit" name="submit" value="{{$nv.findthem|escape:'html'}}" />
 	</form>
-	<div class="side-link" id="side-match-link"><a href="match" >{{$similar}}</a></div>
-	<div class="side-link" id="side-suggest-link"><a href="suggest" >{{$suggest}}</a></div>
-	<div class="side-link" id="side-directory-link"><a href="{{$global_dir}}" target="extlink" >{{$directory}}</a></div>
-	<div class="side-link" id="side-random-profile-link" ><a href="randprof" target="extlink" >{{$random}}</a></div>
-	{{if $inv}} 
-	<div class="side-link" id="side-invite-link" ><a href="invite" >{{$inv}}</a></div>
+	<div class="side-link" id="side-match-link"><a href="match" >{{$nv.similar}}</a></div>
+	<div class="side-link" id="side-suggest-link"><a href="suggest" >{{$nv.suggest}}</a></div>
+	<div class="side-link" id="side-directory-link"><a href="directory" >{{$nv.local_directory}}</a></div>
+	<div class="side-link" id="side-directory-link"><a href="{{$nv.global_dir}}" target="extlink" >{{$nv.directory}}</a></div>
+	<div class="side-link" id="side-random-profile-link" ><a href="randprof" target="extlink" >{{$nv.random}}</a></div>
+	{{if $nv.inv}} 
+	<div class="side-link" id="side-invite-link" ><a href="invite" >{{$nv.inv}}</a></div>
 	{{/if}}
 </div>
 

--- a/view/theme/vier/style.css
+++ b/view/theme/vier/style.css
@@ -1153,9 +1153,9 @@ aside #profiles-menu {
   left: 10px;
 }
 
-aside #search-text, aside #side-follow-url, aside #side-peoplefind-url, right_aside input {
-  width: 140px;
-  height: 17px;
+aside #search-text, aside #side-follow-url, aside #side-peoplefind-url, right_aside #side-peoplefind-url { 
+  width: 65%;
+  float: left;
   padding-left: 10px;
   /*border-top-left-radius: 15px;
   border-top-right-radius: 15px;
@@ -1165,6 +1165,15 @@ aside #search-text, aside #side-follow-url, aside #side-peoplefind-url, right_as
   -moz-border-top-colors: #999;
   -moz-border-left-colors: #999;
   -moz-border-right-colors: #dbdbdb;*/
+}
+
+aside #side-peoplefind-submit, right_aside #side-peoplefind-submit {
+  width: 25%;
+  float: right;
+}
+
+#side-match-link {
+  clear: both;
 }
 
 aside h4, right_aside h4 {

--- a/view/theme/vier/templates/communityhome.tpl
+++ b/view/theme/vier/templates/communityhome.tpl
@@ -39,17 +39,7 @@
 {{/if}}
 
 {{if $nv}}
-<div id="right_friends" class="widget">
-<h3>{{$nv.title.1}}</h3>
-<ul role="menu">
-<li class="tool" role="menuitem"><a class="{{$nv.directory.2}}" href="{{$nv.directory.0}}" title="{{$nv.directory.3}}" >{{$nv.directory.1}}</a></li>
-<li class="tool" role="menuitem"><a class="{{$nv.global_directory.2}}" href="{{$nv.global_directory.0}}" target="blank" title="{{$nv.global_directory.3}}" >{{$nv.global_directory.1}}</a></li>
-<li class="tool" role="menuitem"><a class="{{$nv.match.2}}" href="{{$nv.match.0}}" title="{{$nv.match.3}}" >{{$nv.match.1}}</a></li>
-<li class="tool" role="menuitem"><a class="{{$nv.suggest.2}}" href="{{$nv.suggest.0}}" title="{{$nv.suggest.3}}" >{{$nv.suggest.1}}</a></li>
-<li class="tool" role="menuitem"><a class="{{$nv.invite.2}}" href="{{$nv.invite.0}}" title="{{$nv.invite.3}}" >{{$nv.invite.1}}</a></li>
-</ul>
-{{$nv.search}}
-</div>
+{{include file='peoplefind.tpl' nv=$nv}}
 {{/if}}
 
 {{if $lastusers_title}}

--- a/view/theme/vier/theme.php
+++ b/view/theme/vier/theme.php
@@ -196,19 +196,18 @@ function vier_community_info()
 	//right_aside FIND FRIENDS
 	if ($show_friends && local_user()) {
 		$nv = [];
-		$nv['title'] = ["", L10n::t('Find Friends'), "", ""];
-		$nv['directory'] = ['directory', L10n::t('Local Directory'), "", ""];
-		$nv['global_directory'] = [get_server(), L10n::t('Global Directory'), "", ""];
-		$nv['match'] = ['match', L10n::t('Similar Interests'), "", ""];
-		$nv['suggest'] = ['suggest', L10n::t('Friend Suggestions'), "", ""];
-		$nv['invite'] = ['invite', L10n::t('Invite Friends'), "", ""];
-
-		$nv['search'] = '<form name="simple_bar" method="get" action="dirfind">
-						<span class="sbox_l"></span>
-						<span class="sbox">
-						<input type="text" name="search" size="13" maxlength="50">
-						</span>
-						<span class="sbox_r" id="srch_clear"></span>';
+		$nv['findpeople'] = L10n::t('Find People');
+		$nv['desc'] = L10n::t('Enter name or interest');
+		$nv['label'] = L10n::t('Connect/Follow');
+		$nv['hint'] = L10n::t('Examples: Robert Morgenstein, Fishing');
+		$nv['findthem'] = L10n::t('Find');
+		$nv['suggest'] = L10n::t('Friend Suggestions');
+		$nv['similar'] = L10n::t('Similar Interests');
+		$nv['random'] = L10n::t('Random Profile');
+		$nv['inv'] = L10n::t('Invite Friends');
+		$nv['directory'] = L10n::t('Global Directory');
+		$nv['global_dir'] = get_server();
+		$nv['local_directory'] = L10n::t('Local Directory');
 
 		$aside['$nv'] = $nv;
 	}


### PR DESCRIPTION
The commit messages tell the actual story:
- 4683356 and ac2b515  (the first two) are bugfixes.
- fd5131e moves the New Member Tips link around.
- caaac3a uses the same widget for adding people. 

This last one has to be review'ed properly, so I didn't do anything stupid.