### PR TITLE
Frio admin/users : follow up of  4861 - "more space"

### DIFF
--- a/mod/admin.php
+++ b/mod/admin.php
@@ -1735,13 +1735,27 @@ function admin_page_users(App $a)
 
 	$adminlist = explode(",", str_replace(" ", "", $a->config['admin_email']));
 	$_setup_users = function ($e) use ($adminlist) {
-		$accounts = [
-			L10n::t('Normal Account'),
-			L10n::t('Automatic Follower Account'),
-			L10n::t('Public Forum Account'),
-			L10n::t('Automatic Friend Account')
+		$page_types = [
+			PAGE_NORMAL => L10n::t('Normal Account Page'),
+			PAGE_SOAPBOX => L10n::t('Soapbox Page'),
+			PAGE_COMMUNITY => L10n::t('Public Forum'),
+			PAGE_FREELOVE => L10n::t('Automatic Friend Page'),
+			PAGE_PRVGROUP => L10n::t('Private Forum')
 		];
-		$e['page-flags'] = $accounts[$e['page-flags']];
+		$account_types = [
+			ACCOUNT_TYPE_PERSON => L10n::t('Personal Page'),
+			ACCOUNT_TYPE_ORGANISATION => L10n::t('Organisation Page'),
+			ACCOUNT_TYPE_NEWS => L10n::t('News Page'),
+			ACCOUNT_TYPE_COMMUNITY => L10n::t('Community Forum')
+		];
+
+
+
+		$e['page-flags-raw'] = $e['page-flags'];
+		$e['page-flags'] = $page_types[$e['page-flags']];
+		$e['account-type-raw'] = $e['account-type'];
+		$e['account-type'] = $account_types[$e['account-type']];
+
 		$e['register_date'] = Temporal::getRelativeDate($e['register_date']);
 		$e['login_date'] = Temporal::getRelativeDate($e['login_date']);
 		$e['lastitem_date'] = Temporal::getRelativeDate($e['lastitem_date']);
@@ -1778,8 +1792,7 @@ function admin_page_users(App $a)
 		array_push($users, array_pop($tmp_users));
 	}
 
-	$th_users = array_map(null, [L10n::t('Name'), L10n::t('Email'), L10n::t('Register date'), L10n::t('Last login'), L10n::t('Last item'), L10n::t('Account')], $valid_orders
-	);
+	$th_users = array_map(null, [L10n::t('Name'), L10n::t('Email'), L10n::t('Register date'), L10n::t('Last login'), L10n::t('Last item'), L10n::t('Type')], $valid_orders);
 
 	$t = get_markup_template('admin/users.tpl');
 	$o = replace_macros($t, [

--- a/mod/admin.php
+++ b/mod/admin.php
@@ -1753,8 +1753,9 @@ function admin_page_users(App $a)
 
 		$e['page-flags-raw'] = $e['page-flags'];
 		$e['page-flags'] = $page_types[$e['page-flags']];
-		$e['account-type-raw'] = $e['account-type'];
-		$e['account-type'] = $account_types[$e['account-type']];
+
+		$e['account-type-raw'] = ($e['page_flags_raw']==0) ? $e['account-type'] : -1;
+		$e['account-type'] = ($e['page_flags_raw']==0) ? $account_types[$e['account-type']] : "";
 
 		$e['register_date'] = Temporal::getRelativeDate($e['register_date']);
 		$e['login_date'] = Temporal::getRelativeDate($e['login_date']);

--- a/view/theme/frio/css/mod_admin.css
+++ b/view/theme/frio/css/mod_admin.css
@@ -1,7 +1,16 @@
 
 #admin-users.adminpage { padding-left:0; padding-right: 0;}
 #admin-users.adminpage > h1 { padding: 0 15px; }
-#users img.icon, #deleted img.icon { height: 24px; }
+
+#admin-users td { word-break: break-all; }
+
+#admin-users #users th:first-of-type { width: 1em; }
+#admin-users #users th:nth-of-type(2) { width: 40px; }
+#admin-users #users th:last-of-type { width: 1em; }
+
+#admin-users #deleted th:first-of-type { width: 40px; }
+
+#admin-users #users img.avatar-nano, #deleted img.avatar-nano { height: 24px; width: 24px; }
 .opened .caret { transform: rotate(180deg); }
 tr.details td,
 tr.details th

--- a/view/theme/frio/templates/admin/users.tpl
+++ b/view/theme/frio/templates/admin/users.tpl
@@ -173,7 +173,7 @@
 
 							{{if in_array($order_users,[$th_users.2.1, $th_users.3.1, $th_users.4.1]) }}
 								<p><a href="{{$baseurl}}/admin/users/?o={{if $order_direction_users == "+"}}-{{/if}}{{$th_users.5.1}}">
-										&#8597; {{$th_users.5.0}}</a> : {{$u.page_flags}} {{if $u.is_admin}}({{$siteadmin}}){{/if}} {{if $u.account_expired}}({{$accountexpired}}){{/if}}</p>
+										&#8597; {{$th_users.5.0}}</a> : {{$u.page_flags}}{{if $u.page_flags_raw==0 && $u.account_type_raw > 0}}, {{$u.account_type}}{{/if}} {{if $u.is_admin}}({{$siteadmin}}){{/if}} {{if $u.account_expired}}({{$accountexpired}}){{/if}}</p>
 							{{/if}}
 
 						</td>

--- a/view/theme/frio/templates/admin/users.tpl
+++ b/view/theme/frio/templates/admin/users.tpl
@@ -128,7 +128,26 @@
 						{{/if}}
 
 						{{if !in_array($order_users,[$th_users.2.1, $th_users.3.1, $th_users.4.1]) }}
-						<td>{{$u.page_flags}} {{if $u.is_admin}}({{$siteadmin}}){{/if}} {{if $u.account_expired}}({{$accountexpired}}){{/if}}</td>
+
+						<td>
+							<i class="fa
+								{{if $u.page_flags_raw==0}}fa-user{{/if}}					{{* PAGE_NORMAL *}}
+								{{if $u.page_flags_raw==1}}fa-bullhorn{{/if}}			{{* PAGE_SOAPBOX *}}
+								{{if $u.page_flags_raw==2}}fa-users{{/if}}				{{* PAGE_COMMUNITY *}}
+								{{if $u.page_flags_raw==3}}fa-heart{{/if}}				{{* PAGE_FREELOVE *}}
+								{{if $u.page_flags_raw==4}}fa-rss{{/if}}					{{* PAGE_BLOG *}}
+								{{if $u.page_flags_raw==5}}fa-user-secret{{/if}}	{{* PAGE_PRVGROUP *}}
+							" title="{{$u.page_flags}}"></i>
+							{{if $u.page_flags_raw==0 && $u.account_type_raw > 0}}
+							<i class="fa
+								{{if $u.account_type_raw==1}}fa-sitemap{{/if}}			{{* ACCOUNT_TYPE_ORGANISATION *}}
+								{{if $u.account_type_raw==2}}fa-newspaper-o{{/if}}	{{* ACCOUNT_TYPE_NEWS *}}
+								{{if $u.account_type_raw==3}}fa-comments{{/if}}			{{* ACCOUNT_TYPE_COMMUNITY *}}
+							" title="{{$u.account_type}}"></i>
+							{{/if}}
+							{{if $u.is_admin}}<i class="fa fa-user-md text-primary" title="{{$siteadmin}}"></i>{{/if}}
+							{{if $u.account_expired}}<i class="fa fa-clock-o text-warning" title="{{$accountexpired}}"></i>{{/if}}
+						</td>
 						{{/if}}
 						<td class="text-right">
 							<button type="button" class="btn-link" onclick="return details({{$u.uid}})"><span class="caret"></span></button>

--- a/view/theme/frio/templates/admin/users.tpl
+++ b/view/theme/frio/templates/admin/users.tpl
@@ -55,7 +55,7 @@
 								<button type="button" class="btn btn-default selectnone" data-select-none="pending_ckbx"><i class="fa fa-square-o" aria-hidden="true"></i></button>
 							</div>
 						</div>
-						<div class="col-xs-9">
+						<div class="col-xs-9 text-right">
 							<button type="submit" name="page_users_deny" class="btn btn-primary"><i class="fa fa-thumbs-down" aria-hidden="true"></i> {{$deny}}</button>
 							<button type="submit" name="page_users_approve" class="btn btn-warinig"><i class="fa fa-thumbs-up" aria-hidden="true"></i> {{$approve}}</button>
 						</div>
@@ -84,7 +84,7 @@
 					<th></th>
 					{{foreach $th_users as $k=>$th}}
 					{{if $k < 2 || $order_users == $th.1 || ($k==5 && !in_array($order_users,[$th_users.2.1, $th_users.3.1, $th_users.4.1])) }}
-					<th>
+					<th class="th-{{$k}}">
 						<a href="{{$baseurl}}/admin/users/?o={{if $order_direction_users == "+"}}-{{/if}}{{$th.1}}">
 							{{if $order_users == $th.1}}
 								{{if $order_direction_users == "+"}}
@@ -112,7 +112,7 @@
 							&nbsp;
 						{{/if}}
 						</td>
-						<td><img class="icon" src="{{$u.micro}}" title="{{$u.nickname}}"></td>
+						<td><img class="avatar-nano" src="{{$u.micro}}" title="{{$u.nickname}}"></td>
 						<td><a href="{{$u.url}}" title="{{$u.nickname}}"> {{$u.name}}</a></td>
 						<td>{{$u.email}}</td>
 						{{if $order_users == $th_users.2.1}}
@@ -227,7 +227,7 @@
 			<tbody>
 			{{foreach $deleted as $u}}
 				<tr>
-					<td><img class="icon" src="{{$u.micro}}" title="{{$u.nickname}}"></td>
+					<td><img class="avatar-nano" src="{{$u.micro}}" title="{{$u.nickname}}"></td>
 					<td><a href="{{$u.url}}" title="{{$u.nickname}}" >{{$u.name}}</a></td>
 					<td>{{$u.email}}</td>
 					<td>{{$u.deleted}}</td>


### PR DESCRIPTION
Followup of PR #4861 

In this episode

in `mod/admin.php` (so this is related to any theme)
- Updated page flag descriptions for consistency with `mod/settings.php`
- Added account type descriptions
- The column title "Account" has been changed to "Type": I like it better and save some space

in template
- Fixed user avatar size
- Added fixed width to checkbox, avatar and toggler table columns, to save some space
- When the column "Type" is shown icons are used, instead of textual description. To save space

I think the last point could need a discussion...
