### PR TITLE
Prevent infinite loop when a dbstructure_definition hook is orphan

### DIFF
--- a/include/dba.php
+++ b/include/dba.php
@@ -863,7 +863,7 @@ class dba {
 	 *
 	 * @return boolean|array was the delete successful? When $in_process is set: deletion data
 	 */
-	public static function delete($table, array $conditions, $in_process = false, array &$callstack = [])
+	public static function delete($table, array $conditions, array $options = [], $in_process = false, array &$callstack = [])
 	{
 		if (empty($table) || empty($conditions)) {
 			logger('Table and conditions have to be set');
@@ -886,8 +886,10 @@ class dba {
 
 		$commands[$key] = ['table' => $table, 'conditions' => $conditions];
 
+		$cascade = defaults($options, 'cascade', true);
+
 		// To speed up the whole process we cache the table relations
-		if (count(self::$relation) == 0) {
+		if ($cascade && count(self::$relation) == 0) {
 			self::buildRelationData();
 		}
 
@@ -905,7 +907,7 @@ class dba {
 			if ((count($conditions) == 1) && ($field == array_keys($conditions)[0])) {
 				foreach ($rel_def AS $rel_table => $rel_fields) {
 					foreach ($rel_fields AS $rel_field) {
-						$retval = self::delete($rel_table, [$rel_field => array_values($conditions)[0]], true, $callstack);
+						$retval = self::delete($rel_table, [$rel_field => array_values($conditions)[0]], $options, true, $callstack);
 						$commands = array_merge($commands, $retval);
 					}
 				}
@@ -919,7 +921,7 @@ class dba {
 
 				while ($row = self::fetch($data)) {
 					// Now we accumulate the delete commands
-					$retval = self::delete($table, [$field => $row[$field]], true, $callstack);
+					$retval = self::delete($table, [$field => $row[$field]], $options, true, $callstack);
 					$commands = array_merge($commands, $retval);
 				}
 

--- a/src/Core/Addon.php
+++ b/src/Core/Addon.php
@@ -246,7 +246,7 @@ class Addon
 		} else {
 			// remove orphan hooks
 			$condition = ['hook' => $name, 'file' => $hook[0], 'function' => $hook[1]];
-			dba::delete('hook', $condition);
+			dba::delete('hook', $condition, ['cascade' => false]);
 		}
 	}
 


### PR DESCRIPTION
See https://friendica.mrpetovan.com/display/735a2029205adafcbd07c78454358405

- Add cascade option to dba::delete
- use cascade = false for orphan hook deletion