### PR TITLE
Prevent side effect with cascade => false in dba::delete

### DIFF
--- a/include/dba.php
+++ b/include/dba.php
@@ -894,7 +894,7 @@ class dba {
 		}
 
 		// Is there a relation entry for the table?
-		if (isset(self::$relation[$table])) {
+		if ($cascade && isset(self::$relation[$table])) {
 			// We only allow a simple "one field" relation.
 			$field = array_keys(self::$relation[$table])[0];
 			$rel_def = array_values(self::$relation[$table])[0];


### PR DESCRIPTION
Follow-up to #4892

If there was a previous `dba::delete` call in the same process, the relationship data will be available and the delete would cascade even with `cascade => false`.