### PR TITLE
Item distribution is now done via the public post

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -232,10 +232,11 @@ define('ACCOUNT_TYPE_RELAY',       4);
  * Type of the community page
  * @{
  */
-define('CP_NO_COMMUNITY_PAGE',  -1);
-define('CP_USERS_ON_SERVER',     0);
-define('CP_GLOBAL_COMMUNITY',    1);
-define('CP_USERS_AND_GLOBAL',    2);
+define('CP_NO_INTERNAL_COMMUNITY', -2);
+define('CP_NO_COMMUNITY_PAGE',     -1);
+define('CP_USERS_ON_SERVER',        0);
+define('CP_GLOBAL_COMMUNITY',       1);
+define('CP_USERS_AND_GLOBAL',       2);
 /**
  * @}
  */

--- a/mod/admin.php
+++ b/mod/admin.php
@@ -1262,6 +1262,7 @@ function admin_page_site(App $a)
 
 	/* Community page style */
 	$community_page_style_choices = [
+		CP_NO_INTERNAL_COMMUNITY => L10n::t("No community page for local users"),
 		CP_NO_COMMUNITY_PAGE => L10n::t("No community page"),
 		CP_USERS_ON_SERVER => L10n::t("Public postings from users of this site"),
 		CP_GLOBAL_COMMUNITY => L10n::t("Public postings from the federated network"),

--- a/mod/community.php
+++ b/mod/community.php
@@ -30,6 +30,11 @@ function community_content(App $a, $update = 0)
 
 	$page_style = Config::get('system', 'community_page_style');
 
+	if ($page_style == CP_NO_INTERNAL_COMMUNITY) {
+		notice(L10n::t('Access denied.') . EOL);
+		return;
+	}
+
 	if ($a->argc > 1) {
 		$content = $a->argv[1];
 	} else {

--- a/mod/dfrn_notify.php
+++ b/mod/dfrn_notify.php
@@ -198,9 +198,6 @@ function dfrn_notify_post(App $a) {
 
 function dfrn_dispatch_public($postdata)
 {
-	/// @todo Currently disabled, until there is a working item distribution for public posts
-	return false;
-
 	$msg = Diaspora::decodeRaw([], $postdata);
 	if (!$msg) {
 		// We have to fail silently to be able to hand it over to the salmon parser

--- a/src/Content/Nav.php
+++ b/src/Content/Nav.php
@@ -161,7 +161,8 @@ class Nav
 			}
 		}
 
-		if (local_user() || Config::get('system', 'community_page_style') != CP_NO_COMMUNITY_PAGE) {
+		if ((local_user() || Config::get('system', 'community_page_style') != CP_NO_COMMUNITY_PAGE) &&
+			!(Config::get('system', 'community_page_style') == CP_NO_INTERNAL_COMMUNITY)) {
 			$nav['community'] = ['community', L10n::t('Community'), '', L10n::t('Conversations on this and other servers')];
 		}
 

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -851,7 +851,7 @@ class Item extends BaseObject
 	public static function addShadow($itemid)
 	{
 		$fields = ['uid', 'wall', 'private', 'moderated', 'visible', 'contact-id', 'deleted', 'network', 'author-id', 'owner-id'];
-		$condition = ["`id` = ? AND (`parent` = ? OR `parent` = 0)", $itemid, $itemid];
+		$condition = ['id' => $itemid, 'parent' => [0, $itemid]];
 		$item = dba::selectFirst('item', $fields, $condition);
 
 		if (!DBM::is_result($item)) {
@@ -873,27 +873,9 @@ class Item extends BaseObject
 			return;
 		}
 
-		// Only do these checks if the post isn't a wall post
-		if (!$item["wall"]) {
-			// Check, if hide-friends is activated - then don't do a shadow entry
-			if (dba::exists('profile', ['is-default' => true, 'uid' => $item['uid'], 'hide-friends' => true])) {
-				return;
-			}
-
-			// Check if the contact is hidden or blocked
-			if (!dba::exists('contact', ['hidden' => false, 'blocked' => false, 'id' => $item['contact-id']])) {
-				return;
-			}
-		}
-
-		// Only add a shadow, if the profile isn't hidden
-		if (dba::exists('user', ['uid' => $item['uid'], 'hidewall' => true])) {
-			return;
-		}
-
 		$item = dba::selectFirst('item', [], ['id' => $itemid]);
 
-		if (DBM::is_result($item) && ($item["allow_cid"] == '')  && ($item["allow_gid"] == '') &&
+		if (DBM::is_result($item) && ($item["allow_cid"] == '') && ($item["allow_gid"] == '') &&
 			($item["deny_cid"] == '') && ($item["deny_gid"] == '')) {
 
 			if (!dba::exists('item', ['uri' => $item['uri'], 'uid' => 0])) {

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -865,32 +865,32 @@ class Item extends BaseObject
 
 		$condition = ["`nurl` IN (SELECT `nurl` FROM `contact` WHERE `id` = ?) AND `uid` != 0 AND NOT `blocked` AND `rel` IN (?, ?)",
 			$parent['owner-id'], CONTACT_IS_SHARING,  CONTACT_IS_FRIEND];
-		$contacts = dba::select('contact', [], $condition);
+		$contacts = dba::select('contact', ['uid'], $condition);
 		while ($contact = dba::fetch($contacts)) {
-			self::storeForUser($itemid, $item, $contact);
+			self::storeForUser($itemid, $item, $contact['uid']);
 		}
 	}
 
 	/**
 	 * @brief Store public items for the receivers
 	 *
-	 * @param integer $itemid  Item ID that should be added
-	 * @param array   $item    The item entry that will be stored
-	 * @param array   $contact The contact that will receive the item entry
+	 * @param integer $itemid Item ID that should be added
+	 * @param array   $item   The item entry that will be stored
+	 * @param integer $uid    The user that will receive the item entry
 	 */
-	private static function storeForUser($itemid, $item, $contact)
+	private static function storeForUser($itemid, $item, $uid)
 	{
-		$item['uid'] = $contact['uid'];
+		$item['uid'] = $uid;
 		$item['origin'] = 0;
 		$item['wall'] = 0;
 		if ($item['uri'] == $item['parent-uri']) {
-			$item['contact-id'] = Contact::getIdForURL($item['owner-link'], $contact['uid']);
+			$item['contact-id'] = Contact::getIdForURL($item['owner-link'], $uid);
 		} else {
-			$item['contact-id'] = Contact::getIdForURL($item['author-link'], $contact['uid']);
+			$item['contact-id'] = Contact::getIdForURL($item['author-link'], $uid);
 		}
 
 		if (empty($item['contact-id'])) {
-			$self = dba::selectFirst('contact', ['id'], ['self' => true, 'uid' => $contact['uid']]);
+			$self = dba::selectFirst('contact', ['id'], ['self' => true, 'uid' => $uid]);
 			if (!DBM::is_result($self)) {
 				return;
 			}
@@ -908,9 +908,9 @@ class Item extends BaseObject
 		$distributed = self::insert($item, false, false, true);
 
 		if (!$distributed) {
-			logger("Distributed public item " . $itemid . " for user " . $contact['uid'] . " wasn't stored", LOGGER_DEBUG);
+			logger("Distributed public item " . $itemid . " for user " . $uid . " wasn't stored", LOGGER_DEBUG);
 		} else {
-			logger("Distributed public item " . $itemid . " for user " . $contact['uid'] . " with id " . $distributed, LOGGER_DEBUG);
+			logger("Distributed public item " . $itemid . " for user " . $uid . " with id " . $distributed, LOGGER_DEBUG);
 		}
 	}
 

--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -2773,7 +2773,7 @@ class DFRN
 			if ($posted_id) {
 				logger("Reply from contact ".$item["contact-id"]." was stored with id ".$posted_id, LOGGER_DEBUG);
 
-				IF ($item['uid'] == 0) {
+				if ($item['uid'] == 0) {
 					Item::distribute($posted_id);
 				}
 

--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -2773,6 +2773,10 @@ class DFRN
 			if ($posted_id) {
 				logger("Reply from contact ".$item["contact-id"]." was stored with id ".$posted_id, LOGGER_DEBUG);
 
+				IF ($item['uid'] == 0) {
+					Item::distribute($posted_id);
+				}
+
 				$item["id"] = $posted_id;
 
 				$r = q(
@@ -2826,6 +2830,10 @@ class DFRN
 			$posted_id = Item::insert($item, false, $notify);
 
 			logger("Item was stored with id ".$posted_id, LOGGER_DEBUG);
+
+			if ($item['uid'] == 0) {
+				Item::distribute($posted_id);
+			}
 
 			if (stristr($item["verb"], ACTIVITY_POKE)) {
 				self::doPoke($item, $importer, $posted_id);


### PR DESCRIPTION
This is a preparation for the rework of the item handling. We will now store every public post with the "uid=0" at first and then create the posts for the different users.

We started with Diaspora posts. Additionally the endpoint for public DFRN posts is now working. Some time later we will implement the sending of DFRN posts via the relay. 