### PR TITLE
Install selected theme during settings persistence.

### DIFF
--- a/mod/admin.php
+++ b/mod/admin.php
@@ -1120,6 +1120,7 @@ function admin_page_site_post(App $a)
 	}
 	Config::set('system', 'language', $language);
 	Config::set('system', 'theme', $theme);
+	Theme::install($theme);
 
 	if ($theme_mobile == '---') {
 		Config::delete('system', 'mobile-theme');

--- a/mod/settings.php
+++ b/mod/settings.php
@@ -12,6 +12,7 @@ use Friendica\Core\Config;
 use Friendica\Core\L10n;
 use Friendica\Core\PConfig;
 use Friendica\Core\System;
+use Friendica\Core\Theme;
 use Friendica\Core\Worker;
 use Friendica\Database\DBM;
 use Friendica\Model\Contact;
@@ -354,6 +355,7 @@ function settings_post(App $a)
 				theme_post($a);
 			}
 		}
+		Theme::install($theme);
 
 		$r = q("UPDATE `user` SET `theme` = '%s' WHERE `uid` = %d",
 				dbesc($theme),


### PR DESCRIPTION
Themes have to be installed to be usable by the system. This is not done
automatically which lead to the problems with the site when themes where
switched right after the install and before the "Reload themes" button
was pressed in the admin page.

This patch makes sure that the selected them is always installed when
it is selected by the user either in the admin or settings page.

Fixes #4921.