### PR TITLE
Direct Relay is now working with DFRN as well

### DIFF
--- a/mod/_well_known.php
+++ b/mod/_well_known.php
@@ -70,9 +70,11 @@ function wk_social_relay()
 	}
 
 	$relay = [
-		"subscribe" => $subscribe,
-		"scope" => $scope,
-		"tags" => $taglist
+		'subscribe' => $subscribe,
+		'scope' => $scope,
+		'tags' => $taglist,
+		'protocols' => ['diaspora' => System::baseUrl() . '/receive/public',
+			'dfrn' => System::baseUrl() . '/dfrn_notify']
 	];
 
 	header('Content-type: application/json; charset=utf-8');

--- a/mod/dfrn_notify.php
+++ b/mod/dfrn_notify.php
@@ -208,7 +208,7 @@ function dfrn_dispatch_public($postdata)
 	$contact = Contact::getDetailsByAddr($msg['author'], 0);
 	if (!$contact) {
 		logger('Contact not found for address ' . $msg['author']);
-		System::xmlExit(3, 'Contact not found');
+		System::xmlExit(3, 'Contact ' . $msg['author'] . ' not found');
 	}
 
 	// We now have some contact, so we fetch it
@@ -222,7 +222,7 @@ function dfrn_dispatch_public($postdata)
 	// This should never fail
 	if (!DBM::is_result($importer)) {
 		logger('Contact not found for address ' . $msg['author']);
-		System::xmlExit(3, 'Contact not found');
+		System::xmlExit(3, 'Contact ' . $msg['author'] . ' not found');
 	}
 
 	logger('Importing post from ' . $msg['author'] . ' with the public envelope.', LOGGER_DEBUG);
@@ -246,7 +246,7 @@ function dfrn_dispatch_private($user, $postdata)
 		$cid = Contact::getIdForURL($msg['author']);
 		if (!$cid) {
 			logger('Contact not found for address ' . $msg['author']);
-			System::xmlExit(3, 'Contact not found');
+			System::xmlExit(3, 'Contact ' . $msg['author'] . ' not found');
 		}
 	}
 
@@ -259,7 +259,7 @@ function dfrn_dispatch_private($user, $postdata)
 	// This should never fail
 	if (!DBM::is_result($importer)) {
 		logger('Contact not found for address ' . $msg['author']);
-		System::xmlExit(3, 'Contact not found');
+		System::xmlExit(3, 'Contact ' . $msg['author'] . ' not found');
 	}
 
 	// Set the user id. This is important if this is a public contact

--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -1426,9 +1426,12 @@ class DFRN
 				Contact::markForArchival($contact);
 				return -22;
 			}
+			$pubkey = $fcontact['pubkey'];
+		} else {
+			$pubkey = '';
 		}
 
-		$envelope = Diaspora::buildMessage($atom, $owner, $contact, $owner['uprvkey'], $fcontact['pubkey'], $public_batch);
+		$envelope = Diaspora::buildMessage($atom, $owner, $contact, $owner['uprvkey'], $pubkey, $public_batch);
 
 		// Create the endpoint for public posts. This is some WIP and should later be added to the probing
 		if ($public_batch && empty($contact["batch"])) {

--- a/src/Protocol/PortableContact.php
+++ b/src/Protocol/PortableContact.php
@@ -18,6 +18,7 @@ use Friendica\Model\Profile;
 use Friendica\Network\Probe;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Network;
+use Friendica\Protocol\Diaspora;
 use dba;
 use DOMDocument;
 use DOMXPath;
@@ -1429,6 +1430,20 @@ class PortableContact
 				dba::insert('gserver-tag', ['gserver-id' => $gserver['id'], 'tag' => $tag]);
 			}
 		}
+
+		// Create or update the relay contact
+		$fields = [];
+		if (isset($data->protocols)) {
+			if (isset($data->protocols->diaspora)) {
+				$fields['network'] = NETWORK_DIASPORA;
+				$fields['batch'] = $data->protocols->diaspora;
+			}
+			if (isset($data->protocols->dfrn)) {
+				$fields['network'] = NETWORK_DFRN;
+				$fields['batch'] = $data->protocols->dfrn;
+			}
+		}
+		Diaspora::setRelayContact($server_url, $fields);
 	}
 
 	/**

--- a/src/Worker/Delivery.php
+++ b/src/Worker/Delivery.php
@@ -199,7 +199,7 @@ class Delivery extends BaseObject
 	 */
 	private static function deliverDFRN($cmd, $contact, $owner, $items, $target_item, $public_message, $top_level, $followup)
 	{
-		logger('Deliver ' . $target_item["guid"] . ' via DFRN to ' . empty($contact['addr']) ? $contact['url'] : $contact['addr']);
+		logger('Deliver ' . $target_item["guid"] . ' via DFRN to ' . (empty($contact['addr']) ? $contact['url'] : $contact['addr']));
 
 		if ($cmd == self::MAIL) {
 			$item = $target_item;

--- a/src/Worker/Delivery.php
+++ b/src/Worker/Delivery.php
@@ -199,7 +199,7 @@ class Delivery extends BaseObject
 	 */
 	private static function deliverDFRN($cmd, $contact, $owner, $items, $target_item, $public_message, $top_level, $followup)
 	{
-		logger('Deliver ' . $target_item["guid"] . ' via DFRN to ' . $contact['addr']);
+		logger('Deliver ' . $target_item["guid"] . ' via DFRN to ' . empty($contact['addr']) ? $contact['url'] : $contact['addr']);
 
 		if ($cmd == self::MAIL) {
 			$item = $target_item;

--- a/src/Worker/Delivery.php
+++ b/src/Worker/Delivery.php
@@ -275,6 +275,13 @@ class Delivery extends BaseObject
 			$public_dfrn = ($contact['contact-type'] == ACCOUNT_TYPE_RELAY);
 
 			$deliver_status = DFRN::transmit($owner, $contact, $atom, $public_dfrn);
+
+			// We never spool failed relay deliveries
+			if ($public_dfrn) {
+				logger('Relay delivery to ' . $contact["url"] . ' with guid ' . $target_item["guid"] . ' returns ' . $deliver_status);
+				return;
+			}
+
 			if (($deliver_status < 200) || ($deliver_status > 299)) {
 				// Transmit via Diaspora if not possible via Friendica
 				self::deliverDiaspora($cmd, $contact, $owner, $items, $target_item, $public_message, $top_level, $followup);


### PR DESCRIPTION
We no longer transfer our messages in the Diaspora format when using the direct relay.

There is an open issue that has to be solved before the release: We have to treat comments as well. But this will be covered in another PR.