### PR TITLE
vier: Fix layout issue introduced with PR #4873.

### DIFF
--- a/view/theme/vier/style.css
+++ b/view/theme/vier/style.css
@@ -1168,8 +1168,7 @@ aside #search-text, aside #side-follow-url, aside #side-peoplefind-url, right_as
 }
 
 aside #side-peoplefind-submit, right_aside #side-peoplefind-submit {
-  width: 25%;
-  float: right;
+  float: left;
 }
 
 #side-match-link {


### PR DESCRIPTION
The find button in the find-people widget was badly layouted on Firefox under Debian.
Remove the width constraint and float: left so the button gracely drops to the next
line when necessary.

(Tested on FF/Win, Chrome/Win, FF/Debian.)