### PR TITLE
Fixed private messaging/relaying is controlled by the parent

### DIFF
--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -68,6 +68,12 @@ class Diaspora
 		}
 
 		if (Config::get("system", "relay_directly", false)) {
+			// We distribute our stuff based on the parent to ensure that the thread will be complete
+			$parent = dba::selectFirst('item', ['parent'], ['id' => $item_id]);
+			if (!DBM::is_result($parent)) {
+				return;
+			}
+
 			// Servers that want to get all content
 			$servers = dba::select('gserver', ['url'], ['relay-subscribe' => true, 'relay-scope' => 'all']);
 			while ($server = dba::fetch($servers)) {
@@ -75,7 +81,7 @@ class Diaspora
 			}
 
 			// All tags of the current post
-			$condition = ['otype' => TERM_OBJ_POST, 'type' => TERM_HASHTAG, 'oid' => $item_id];
+			$condition = ['otype' => TERM_OBJ_POST, 'type' => TERM_HASHTAG, 'oid' => $parent['parent']];
 			$tags = dba::select('term', ['term'], $condition);
 			$taglist = [];
 			while ($tag = dba::fetch($tags)) {

--- a/src/Worker/Delivery.php
+++ b/src/Worker/Delivery.php
@@ -28,6 +28,7 @@ class Delivery extends BaseObject
 	const DELETION =   'drop';
 	const POST =       'wall-new';
 	const COMMENT =    'comment-new';
+	const REMOVAL =    'removeme';
 
 	public static function execute($cmd, $item_id, $contact_id)
 	{
@@ -39,13 +40,13 @@ class Delivery extends BaseObject
 
 		if ($cmd == self::MAIL) {
 			$target_item = dba::selectFirst('mail', [], ['id' => $item_id]);
-			if (!DBM::is_result($message)) {
+			if (!DBM::is_result($target_item)) {
 				return;
 			}
 			$uid = $target_item['uid'];
 		} elseif ($cmd == self::SUGGESTION) {
 			$target_item = dba::selectFirst('fsuggest', [], ['id' => $item_id]);
-			if (!DBM::is_result($message)) {
+			if (!DBM::is_result($target_item)) {
 				return;
 			}
 			$uid = $target_item['uid'];


### PR DESCRIPTION
This PR fixes a serious problem that prevented private messages from being sent.

This was found during the work with improving the direct relay that now is controlled via the tags on the parent item. This should ensure that comments are also sent to all subscribers.