### PR TITLE
Bugfix: Twitter "Reshares" are now appearing again on Diaspora

### DIFF
--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -965,7 +965,7 @@ class BBCode extends BaseObject
 				}
 
 				if (stripos(normalise_link($link), 'http://twitter.com/') === 0) {
-					$text .= '<br /><a href="' . $link . '">' . $link . '</a>';
+					$text .= '<br /><a href="' . $link . '" title="' . $link . '">' . $link . '</a>';
 				} else {
 					$text .= $headline . '<blockquote>' . trim($share[3]) . "</blockquote><br />";
 

--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -965,7 +965,7 @@ class BBCode extends BaseObject
 				}
 
 				if (stripos(normalise_link($link), 'http://twitter.com/') === 0) {
-					$text .= '<br /><a href="' . $link . '" title="' . $link . '">' . $link . '</a>';
+					$text .= '<br /><a href="' . $link . '">' . $link . '</a>';
 				} else {
 					$text .= $headline . '<blockquote>' . trim($share[3]) . "</blockquote><br />";
 

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -3571,7 +3571,11 @@ class Diaspora
 				$ret["root_guid"] = $guid;
 				return $ret;
 			}
+		} elseif (($guid == "") && $complete) {
+			return false;
 		}
+
+		$ret["root_guid"] = $guid;
 
 		$profile = "";
 		preg_match("/profile='(.*?)'/ism", $attributes, $matches);
@@ -3591,10 +3595,6 @@ class Diaspora
 				$author = Contact::getDetailsByURL($profile);
 				$ret["root_handle"] = $author['addr'];
 			}
-		}
-
-		if (!empty($guid)) {
-			$ret["root_guid"] = $guid;
 		}
 
 		if (empty($ret) && !$complete) {


### PR DESCRIPTION
Our [Markdown converter](https://github.com/thephpleague/html-to-markdown) and the Markdown interpreter from Diaspora are speaking a different dialect, it seems. Our converter shortens links to the format ```<http://domain.tld>``` which the Diaspora side doesn't seem to understand correctly. This here is just a quickfix, we should check with Diaspora and the converter people to fix this.