### PR TITLE
Ugly bugfix: Public contacts had been blocked automatically when created

### DIFF
--- a/src/Network/Probe.php
+++ b/src/Network/Probe.php
@@ -447,6 +447,7 @@ class Probe
 				// When the contact doesn't exist, the value "true" will trigger an insert
 				if (!$old_fields) {
 					$old_fields = true;
+					$fields['blocked'] = false;
 				}
 
 				dba::update('contact', $fields, $condition, $old_fields);


### PR DESCRIPTION
This does also mean that every admin of a Friendica server has to unblock these contacts by hand with a command like this:
```
update contact set blocked=false where uid=0 and blocked;
```
Problem is that all manually blocked public contacts are unblocked with this as well. But on pirati.ca this bug had blocked over 2,000 contacts, on squeet.me it had been around 1,500. You can't do this by hand.