### PR TITLE
"pending" shouldn't be set as well by default ...

### DIFF
--- a/src/Network/Probe.php
+++ b/src/Network/Probe.php
@@ -448,6 +448,7 @@ class Probe
 				if (!$old_fields) {
 					$old_fields = true;
 					$fields['blocked'] = false;
+					$fields['pending'] = false;
 				}
 
 				dba::update('contact', $fields, $condition, $old_fields);


### PR DESCRIPTION
This is an addition to the previous PR.

And I found out how to keep the previously blocked contacts, just use this command to unblock all unwanted blocks:
```
update contact set blocked=false, pending=false where uid=0 and blocked and pending;
```