### PR TITLE
Diaspora: Fix person/contact retraction

### DIFF
--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -2969,12 +2969,10 @@ class Diaspora
 			case "StatusMessage":
 				return self::itemRetraction($importer, $contact, $data);
 
-			case "Contact":
-			case "Person":
-				/// @todo What should we do with an "unshare"?
-				// Removing the contact isn't correct since we still can read the public items
-				Contact::remove($contact["id"]);
-				return true;
+			case "PollParticipation":
+			case "Photo":
+				// Currently unsupported
+				break;
 
 			default:
 				logger("Unknown target type ".$target_type);


### PR DESCRIPTION
Additionally - and unrelated to the dba changes - the retraction receiver had been updated to the protocol. You can't retract a "person", so this had been removed.