### PR TITLE
using \PDO instead PDO (bugfix)

### DIFF
--- a/src/Core/Install.php
+++ b/src/Core/Install.php
@@ -274,7 +274,7 @@ class Install extends BaseObject
 			$ck_funcs[3]['status'] = false;
 			$ck_funcs[3]['help'] = L10n::t('Error: PDO or MySQLi PHP module required but not installed.');
 		}
-		if (!function_exists('mysqli_connect') && class_exists('pdo') && !in_array('mysql', PDO::getAvailableDrivers())) {
+		if (!function_exists('mysqli_connect') && class_exists('pdo') && !in_array('mysql', \PDO::getAvailableDrivers())) {
 			$ck_funcs[3]['status'] = false;
 			$ck_funcs[3]['help'] = L10n::t('Error: The MySQL driver for PDO is not installed.');
 		}


### PR DESCRIPTION
I came across the error message 
> [Error] Class 'Friendica\Core\PDO' not found

It's because I accidentally forgot the "\\" before "PDO" in `src/Core/Install.php`