### PR TITLE
Fix for issue 4994: Feed items now appear again

### DIFF
--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -804,7 +804,7 @@ class Contact extends BaseObject
 		$data = Probe::uri($url, "", $uid);
 
 		// Last try in gcontact for unsupported networks
-		if (!in_array($data["network"], [NETWORK_DFRN, NETWORK_OSTATUS, NETWORK_DIASPORA, NETWORK_PUMPIO, NETWORK_MAIL])) {
+		if (!in_array($data["network"], [NETWORK_DFRN, NETWORK_OSTATUS, NETWORK_DIASPORA, NETWORK_PUMPIO, NETWORK_MAIL, NETWORK_FEED])) {
 			if ($uid != 0) {
 				return 0;
 			}


### PR DESCRIPTION
See issue https://github.com/friendica/friendica/issues/4994

Past feed items don't appear automatically, but future ones will. For past feed items I'm thinking about some update routine in a separate PR.