### PR TITLE
Issue 4772: Display posts with uid=0 as well

### DIFF
--- a/include/api.php
+++ b/include/api.php
@@ -2002,6 +2002,19 @@ function api_statuses_show($type)
 		$sql_extra .= " AND `item`.`id` = %d";
 	}
 
+	// try to fetch the item for the local user - or the public item, if there is no local one
+	$uri_item = dba::selectFirst('item', ['uri'], ['id' => $id]);
+	if (!DBM::is_result($uri_item)) {
+		throw new BadRequestException("There is no status with this id.");
+	}
+
+	$item = dba::selectFirst('item', ['id'], ['uri' => $uri_item['uri'], 'uid' => [0, api_user()]], ['order' => ['uid' => true]]);
+	if (!DBM::is_result($item)) {
+		throw new BadRequestException("There is no status with this id.");
+	}
+
+	$id = $item['id'];
+
 	$r = q(
 		"SELECT `item`.*, `item`.`id` AS `item_id`, `item`.`network` AS `item_network`,
 		`contact`.`name`, `contact`.`photo`, `contact`.`url`, `contact`.`rel`,
@@ -2011,7 +2024,7 @@ function api_statuses_show($type)
 		INNER JOIN `contact` ON `contact`.`id` = `item`.`contact-id` AND `contact`.`uid` = `item`.`uid`
 			AND (NOT `contact`.`blocked` OR `contact`.`pending`)
 		WHERE `item`.`visible` AND NOT `item`.`moderated` AND NOT `item`.`deleted`
-		AND `item`.`uid` = %d AND `item`.`verb` = '%s'
+		AND `item`.`uid` IN (0, %d) AND `item`.`verb` = '%s'
 		$sql_extra",
 		intval(api_user()),
 		dbesc(ACTIVITY_POST),
@@ -2075,21 +2088,24 @@ function api_conversation_show($type)
 
 	logger('API: api_conversation_show: '.$id);
 
-	$r = q("SELECT `parent` FROM `item` WHERE `id` = %d", intval($id));
-	if (DBM::is_result($r)) {
-		$id = $r[0]["parent"];
+	// try to fetch the item for the local user - or the public item, if there is no local one
+	$item = dba::selectFirst('item', ['parent-uri'], ['id' => $id]);
+	if (!DBM::is_result($item)) {
+		throw new BadRequestException("There is no status with this id.");
 	}
+
+	$parent = dba::selectFirst('item', ['id'], ['uri' => $item['parent-uri'], 'uid' => [0, api_user()]], ['order' => ['uid' => true]]);
+	if (!DBM::is_result($parent)) {
+		throw new BadRequestException("There is no status with this id.");
+	}
+
+	$id = $parent['id'];
 
 	$sql_extra = '';
 
 	if ($max_id > 0) {
 		$sql_extra = ' AND `item`.`id` <= ' . intval($max_id);
 	}
-
-	// Not sure why this query was so complicated. We should keep it here for a while,
-	// just to make sure that we really don't need it.
-	//	FROM `item` INNER JOIN (SELECT `uri`,`parent` FROM `item` WHERE `id` = %d) AS `temp1`
-	//	ON (`item`.`thr-parent` = `temp1`.`uri` AND `item`.`parent` = `temp1`.`parent`)
 
 	$r = q(
 		"SELECT `item`.*, `item`.`id` AS `item_id`, `item`.`network` AS `item_network`,
@@ -2101,7 +2117,7 @@ function api_conversation_show($type)
 			AND (NOT `contact`.`blocked` OR `contact`.`pending`)
 		WHERE `item`.`parent` = %d AND `item`.`visible`
 		AND NOT `item`.`moderated` AND NOT `item`.`deleted`
-		AND `item`.`uid` = %d AND `item`.`verb` = '%s'
+		AND `item`.`uid` IN (0, %d) AND `item`.`verb` = '%s'
 		AND `item`.`id`>%d $sql_extra
 		ORDER BY `item`.`id` DESC LIMIT %d ,%d",
 		intval($id),


### PR DESCRIPTION
See issue https://github.com/friendica/friendica/issues/4772

The public timeline will show items with the item id for "uid=0". When displaying the single item, we have to show items with "uid=0" as well. And we are defaulting to the item for the api user (when available).