### PR TITLE
Fix: Public items werent visible under certain circumstances

### DIFF
--- a/include/conversation.php
+++ b/include/conversation.php
@@ -473,7 +473,7 @@ function item_joins() {
 	return sprintf("STRAIGHT_JOIN `contact` ON `contact`.`id` = `item`.`contact-id`
 		AND NOT `contact`.`blocked`
 		AND ((NOT `contact`.`readonly` AND NOT `contact`.`pending` AND (`contact`.`rel` IN (%s, %s)))
-		OR `contact`.`self` OR (`item`.`id` != `item`.`parent`))
+		OR `contact`.`self` OR (`item`.`id` != `item`.`parent`) OR `contact`.`uid` = 0)
 		INNER JOIN `contact` AS `author` ON `author`.`id`=`item`.`author-id` AND NOT `author`.`blocked`
 		INNER JOIN `contact` AS `owner` ON `owner`.`id`=`item`.`owner-id` AND NOT `owner`.`blocked`
 		LEFT JOIN `event` ON `event-id` = `event`.`id`",


### PR DESCRIPTION
Public contacts may not have any meaningful value in "rel" at all. We will only look at the "blocked" state here.