### PR TITLE
Fix for the slow spawning of workers

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -861,18 +861,6 @@ class App
 			return;
 		}
 
-		// If the last worker fork was less than 2 seconds before then don't fork another one.
-		// This should prevent the forking of masses of workers.
-		$cachekey = 'app:proc_run:started';
-		$result = Cache::get($cachekey);
-
-		if (!is_null($result) && ( time() - $result) < 2) {
-			return;
-		}
-
-		// Set the timestamp of the last proc_run
-		Cache::set($cachekey, time(), CACHE_MINUTE);
-
 		array_unshift($args, ((x($this->config, 'php_path')) && (strlen($this->config['php_path'])) ? $this->config['php_path'] : 'php'));
 
 		for ($x = 0; $x < count($args); $x ++) {

--- a/src/Core/Worker.php
+++ b/src/Core/Worker.php
@@ -999,6 +999,7 @@ class Worker
 	}
 
 	/**
+	 * @brief Spawns a new worker
 	 * @return void
 	 */
 	public static function spawnWorker()


### PR DESCRIPTION
While searching for a bug in the delivery process I saw that the workers spawned very slowly, which resulted in a slow delivery process. I finally found the reason. That removed is from older days of the workerqueue and doesn't seem to be needed anymore.