### PR TITLE
Update sample-nginx.config

### DIFF
--- a/mods/sample-nginx.config
+++ b/mods/sample-nginx.config
@@ -126,8 +126,8 @@ server {
     # With php5-cgi alone:
     # fastcgi_pass 127.0.0.1:9000;
 
-    # With php5-fpm:
-    fastcgi_pass unix:/var/run/php5-fpm.sock;
+    # With php7.0-fpm:
+    fastcgi_pass unix:/var/run/php/php7.0-fpm.sock;
 
     include fastcgi_params;
     fastcgi_index index.php;


### PR DESCRIPTION
Updated default path to PHP7.0

PHP5.0 is not considered standard any more.