### PR TITLE
Bugfix: Only send a notifier when the item was really edited

### DIFF
--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -75,8 +75,9 @@ class Item extends BaseObject
 			Term::insertFromFileFieldByItemId($item['id']);
 			self::updateThread($item['id']);
 
-			// We only need to notfiy others when it is an original entry from us
-			if ($item['origin']) {
+			// We only need to notfiy others when it is an original entry from us.
+			// Only call the notifier when the item has some content relevant change.
+			if ($item['origin'] && in_array('edited', array_keys($fields))) {
 				Worker::add(PRIORITY_HIGH, "Notifier", 'edit_post', $item['id']);
 			}
 		}

--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -2140,10 +2140,6 @@ class DFRN
 			Item::update($fields, $condition);
 
 			$changed = true;
-
-			if ($entrytype == DFRN::REPLY_RC) {
-				Worker::add(PRIORITY_HIGH, "Notifier", "comment-import", $current["id"]);
-			}
 		}
 		return $changed;
 	}

--- a/src/Worker/Notifier.php
+++ b/src/Worker/Notifier.php
@@ -510,7 +510,7 @@ class Notifier {
 					'PubSubPublish');
 		}
 
-		logger('notifier: calling hooks', LOGGER_DEBUG);
+		logger('notifier: calling hooks for ' . $cmd . ' ' . $item_id, LOGGER_DEBUG);
 
 		if ($normal_mode) {
 			Addon::forkHooks($a->queue['priority'], 'notifier_normal', $target_item);


### PR DESCRIPTION
Fixes https://github.com/friendica/friendica/issues/5063

And possibly fixes https://github.com/friendica/friendica/issues/5056 as well.