### PR TITLE
Fix: Sometimes the contact endpoints seem to be wrong

### DIFF
--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -206,6 +206,16 @@ class Contact extends BaseObject
 		$fields['forum'] = $user['page-flags'] == PAGE_COMMUNITY;
 		$fields['prv'] = $user['page-flags'] == PAGE_PRVGROUP;
 
+		// it seems as if ported accounts can have wrong values, so we make sure that now everything is fine.
+		$fields['url'] = System::baseUrl() . '/profile/' . $user['nickname'];
+		$fields['nurl'] = normalise_link($fields['url']);
+		$fields['addr'] = $user['nickname'] . '@' . substr(System::baseUrl(), strpos(System::baseUrl(), '://') + 3);
+		$fields['request'] = System::baseUrl() . '/dfrn_request/' . $user['nickname'];
+		$fields['notify'] = System::baseUrl() . '/dfrn_notify/'  . $user['nickname'];
+		$fields['poll'] = System::baseUrl() . '/dfrn_poll/'    . $user['nickname'];
+		$fields['confirm'] = System::baseUrl() . '/dfrn_confirm/' . $user['nickname'];
+		$fields['poco'] = System::baseUrl() . '/poco/'         . $user['nickname'];
+
 		$update = false;
 
 		foreach ($fields as $field => $content) {


### PR DESCRIPTION
While checking the OStatus subscription stuff, I saw that the "self" contact isn't always right with the endpoints. There seem to be a problem with moved accounts. This is some quick fix, so that there is one place where it will be fixed.

We have to apply further fixes somewhere else as well. (In a following PR)