### PR TITLE
Fix: Avoid getting spammed when an admin has got several accounts

### DIFF
--- a/mod/removeme.php
+++ b/mod/removeme.php
@@ -33,11 +33,12 @@ function removeme_post(App $a)
 
 	// send notification to admins so that they can clean um the backups
 	// send email to admins
-	$admin_mail_list = "'" . implode("','", array_map(dbesc, explode(",", str_replace(" ", "", $a->config['admin_email'])))) . "'";
-	$adminlist = q("SELECT uid, language, email FROM user WHERE email IN (%s)",
-		$admin_mail_list
-	);
-	foreach ($adminlist as $admin) {
+	$admin_mails = explode(",", str_replace(" ", "", $a->config['admin_email']));
+	foreach (admin_mails as $mail) {
+		$admin = dba::selectFirst('user', ['uid', 'language', 'email'], ['email' => $mail]);
+		if (!DBM::is_result($admin)) {
+			continue;
+		}
 		notification([
 			'type'         => SYSTEM_EMAIL,
 			'subject'      => L10n::t('[Friendica System Notify]') . ' ' . L10n::t('User deleted their account'),

--- a/mod/removeme.php
+++ b/mod/removeme.php
@@ -34,7 +34,7 @@ function removeme_post(App $a)
 	// send notification to admins so that they can clean um the backups
 	// send email to admins
 	$admin_mails = explode(",", str_replace(" ", "", $a->config['admin_email']));
-	foreach (admin_mails as $mail) {
+	foreach ($admin_mails as $mail) {
 		$admin = dba::selectFirst('user', ['uid', 'language', 'email'], ['email' => $mail]);
 		if (!DBM::is_result($admin)) {
 			continue;


### PR DESCRIPTION
The previous coding had got the problem that a mail had been sent to every user account with the administrator's name - which resulted in spamming when you have got a handful of news reflector accounts ...

See also here: https://forum.friendi.ca/display/c443a55c665aff4d4ad885c625972703