### PR TITLE
Fix constant display updates

### DIFF
--- a/mod/display.php
+++ b/mod/display.php
@@ -333,13 +333,9 @@ function display_content(App $a, $update = false, $update_uid = 0) {
 	$sql_extra = item_permissions_sql($a->profile['uid'], $remote_contact, $groups);
 
 	if ($update) {
-		$r = dba::p("SELECT `id` FROM `item` WHERE
-			`item`.`parent` = (SELECT `parent` FROM `item` WHERE `id` = ?)
-			$sql_extra AND `unseen`",
-			$item_id
-		);
-
-		if (dba::num_rows($r) == 0) {
+		if (!dba::exists('item',
+			["`item`.`parent` = (SELECT `parent` FROM `item` WHERE `id` = ?)
+			$sql_extra AND `unseen` AND `uid` != 0", $item_id])) {
 			return '';
 		}
 	}


### PR DESCRIPTION
This hopefully will fix the problem that under certain circumstances the "display" page got a constant refresh. This is bad with the "showmore" addon - since every refresh collapses the post again.