### PR TITLE
Adding safer kill for `worker.php`

### DIFF
--- a/bin/worker.php
+++ b/bin/worker.php
@@ -51,7 +51,7 @@ $spawn = (($_SERVER["argc"] == 2) && ($_SERVER["argv"][1] == "spawn"));
 
 if ($spawn) {
 	Worker::spawnWorker();
-	killme();
+	Worker::killWorker();
 }
 
 $run_cron = (($_SERVER["argc"] <= 1) || ($_SERVER["argv"][1] != "no_cron"));
@@ -62,5 +62,4 @@ Worker::unclaimProcess();
 
 Worker::endProcess();
 
-killme();
-
+Worker::killWorker();

--- a/src/Core/Worker.php
+++ b/src/Core/Worker.php
@@ -1121,6 +1121,11 @@ class Worker
 		return Process::deleteByPid();
 	}
 
+	/**
+	 * Kills the current worker
+	 *
+	 * @brief Kills the current worker
+	 */
 	public static function killWorker()
 	{
 		session_write_close();

--- a/src/Core/Worker.php
+++ b/src/Core/Worker.php
@@ -1127,6 +1127,6 @@ class Worker
 		if (!function_exists('fastcgi_finish_request')) {
 			fastcgi_finish_request();
 		}
-		killme();
+		exit();
 	}
 }

--- a/src/Core/Worker.php
+++ b/src/Core/Worker.php
@@ -1120,4 +1120,13 @@ class Worker
 	{
 		return Process::deleteByPid();
 	}
+
+	public static function killWorker()
+	{
+		session_write_close();
+		if (!function_exists('fastcgi_finish_request')) {
+			fastcgi_finish_request();
+		}
+		killme();
+	}
 }


### PR DESCRIPTION
When using `bin/worker.php` in a php-fpm environment, I got a lot of zombie processes:
```console
root      3500  0.0  0.0   1512     4 ?        Ss   23:22   0:00  |   |   \_ busybox crond -f -l 0 -L /dev/stdout
82        5833  0.1  0.0      0     0 ?        Z    23:31   0:00  |   |       \_ [php] <defunct>
82        5835  0.1  0.0      0     0 ?        Z    23:31   0:00  |   |       \_ [php] <defunct>
82        5837  0.1  0.0      0     0 ?        Z    23:31   0:00  |   |       \_ [php] <defunct>
82        6125  1.0  0.2  82784 20640 ?        S    23:32   0:00  |   |       \_ php bin/worker.php no_cron
82        6127  1.0  0.2  82784 20580 ?        S    23:32   0:00  |   |       \_ php bin/worker.php no_cron
82        6129  1.0  0.2  82784 20584 ?        S    23:32   0:00  |   |       \_ php bin/worker.php no_cron
```
After adding the following exit-functions, these zombie processes disappear:
- Adding `session_write_close()`
- Adding `fastcgi_finish_request()` if possible