### PR TITLE
Make `htconfig.php` fit for MariaDB

### DIFF
--- a/htconfig.php
+++ b/htconfig.php
@@ -24,11 +24,15 @@ $db_data = 'mysqldatabasename';
 // Use environment variables for mysql if they are set beforehand
 if (!empty(getenv('MYSQL_HOST'))
 	&& !empty(getenv('MYSQL_PORT'))
-	&& !empty(getenv('MYSQL_USERNAME'))
+	&& (!empty(getenv('MYSQL_USERNAME')) || !empty(getenv('MYSQL_USER')))
 	&& !empty(getenv('MYSQL_PASSWORD'))
 	&& !empty(getenv('MYSQL_DATABASE'))) {
 	$db_host = getenv('MYSQL_HOST') . ':' . getenv('MYSQL_PORT');
-	$db_user = getenv('MYSQL_USERNAME');
+	if (!empty(getenv('MYSQL_USERNAME'))) {
+		$db_user = getenv('MYSQL_USERNAME');
+	} elseif (!empty(getenv('MYSQL_USER'))) {
+		$db_user = getenv('MYSQL_USER');
+	}
 	$db_pass = getenv('MYSQL_PASSWORD');
 	$db_data = getenv('MYSQL_DATABASE');
 }

--- a/view/templates/htconfig.tpl
+++ b/view/templates/htconfig.tpl
@@ -19,15 +19,20 @@ $db_data = '{{$dbdata}}';
 
 // Use environment variables for mysql if they are set beforehand
 if (!empty(getenv('MYSQL_HOST'))
-   && !empty(getenv('MYSQL_PORT'))
-   && !empty(getenv('MYSQL_USERNAME'))
-   && !empty(getenv('MYSQL_PASSWORD'))
-   && !empty(getenv('MYSQL_DATABASE'))) {
+	&& !empty(getenv('MYSQL_PORT'))
+	&& (!empty(getenv('MYSQL_USERNAME')) || !empty(getenv('MYSQL_USER')))
+	&& !empty(getenv('MYSQL_PASSWORD'))
+	&& !empty(getenv('MYSQL_DATABASE'))) {
 	$db_host = getenv('MYSQL_HOST') . ':' . getenv('MYSQL_PORT');
-	$db_user = getenv('MYSQL_USERNAME');
+	if (!empty(getenv('MYSQL_USERNAME'))) {
+		$db_user = getenv('MYSQL_USERNAME');
+	} elseif (!empty(getenv('MYSQL_USER'))) {
+		$db_user = getenv('MYSQL_USER');
+	}
 	$db_pass = getenv('MYSQL_PASSWORD');
 	$db_data = getenv('MYSQL_DATABASE');
 }
+
 
 // Set the database connection charset to full Unicode (utf8mb4).
 // Changing this value will likely corrupt the special characters.


### PR DESCRIPTION
The environment variables for the MYSQL-settings are not fit for MariaDB.

MariaDB uses "MYSQL_USER" for the username of the database
MySQL however uses "MYSQL_USERNAME" for it.

I made it fit for both :-)