### PR TITLE
Possibly fixes 5137: Only execute "optimize table" when allowed

### DIFF
--- a/src/Worker/Cron.php
+++ b/src/Worker/Cron.php
@@ -102,7 +102,9 @@ Class Cron {
 			dba::delete('workerqueue', ['`done` AND `executed` < UTC_TIMESTAMP() - INTERVAL 1 HOUR']);
 
 			// Optimizing this table only last seconds
-			dba::e("OPTIMIZE TABLE `workerqueue`");
+			if (Config::get('system', 'optimize_workerqueue', false)) {
+				dba::e("OPTIMIZE TABLE `workerqueue`");
+			}
 
 			Config::set('system', 'last_cron_hourly', time());
 		}


### PR DESCRIPTION
This could - or could not - fix issue #5137 

I can imagine that an "optimize table" command could interfere with a mysql backup. 