### PR TITLE
5118 Create Javascript hook mechanism

### DIFF
--- a/doc/Addons.md
+++ b/doc/Addons.md
@@ -25,22 +25,24 @@ Addons should contain a comment block with the four following parameters:
      * Author: John Q. Public <john@myfriendicasite.com>
      */
 
+Please also add a README or README.md file to the addon directory.
+It will be displayed in the admin panel and should include some further information in addition to the header information.
+
+PHP addon hooks
+---
+
 Register your addon hooks during installation.
 
     Addon::registerHook($hookname, $file, $function);
 
-$hookname is a string and corresponds to a known Friendica hook.
+$hookname is a string and corresponds to a known Friendica PHP hook.
 
 $file is a pathname relative to the top-level Friendica directory.
-This *should* be 'addon/addon_name/addon_name.php' in most cases.
+This *should* be 'addon/*addon_name*/*addon_name*.php' in most cases.
 
 $function is a string and is the name of the function which will be executed when the hook is called.
 
-Please also add a README or README.md file to the addon directory.
-It will be displayed in the admin panel and should include some further information in addition to the header information.
-
-Arguments
----
+#### Arguments
 Your hook callback functions will be called with at least one and possibly two arguments
 
     function myhook_function(App $a, &$b) {
@@ -50,7 +52,7 @@ Your hook callback functions will be called with at least one and possibly two a
 
 If you wish to make changes to the calling data, you must declare them as reference variables (with '&') during function declaration.
 
-#### $a
+##### $a
 $a is the Friendica 'App' class.
 It contains a wealth of information about the current state of Friendica:
 
@@ -61,10 +63,26 @@ It contains a wealth of information about the current state of Friendica:
 
 It is recommeded you call this '$a' to match its usage elsewhere.
 
-#### $b
+##### $b
 $b can be called anything you like.
 This is information specific to the hook currently being processed, and generally contains information that is being immediately processed or acted on that you can use, display, or alter.
 Remember to declare it with '&' if you wish to alter it.
+
+JavaScript addon hooks
+---
+
+Register your addon hooks in file 'addon/*addon_name*/*addon_name*.js'.
+
+    Addon_registerHook(type,hookfnstr);
+
+*type* is the name of the hook and corresponds to a known Friendica JavaScript hook.
+*hookfnstr* is the name of your JavaScript function to execute.
+
+No arguments are provided to your JavaScript callback function. Example:
+
+    function myhook_function() {
+  
+    }
 
 Modules
 ---
@@ -106,7 +124,7 @@ In your code, like in the function addon_name_content(), load the template file 
 
 See also the wiki page [Quick Template Guide](https://github.com/friendica/friendica/wiki/Quick-Template-Guide).
 
-Current hooks
+Current PHP hooks
 -------------
 
 ### 'authenticate'
@@ -315,6 +333,12 @@ Called at the end of prepare_body.
 Hook data:
     'item' => item array (input)
     'html' => converted item body (input/output)
+
+Current JavaScript hooks
+-------------
+
+### 'postprocess_liveupdate'
+Called at the end of the live update process (XmlHttpRequest)
 
 Complete list of hook callbacks
 ---
@@ -618,3 +642,7 @@ Here is a complete list of all hook callbacks with file locations (as of 01-Apr-
 
     Addon::callHooks('atom_feed_end', $atom);
     Addon::callHooks('atom_feed_end', $atom);
+
+### view/js/main.js
+
+    callAddonHooks("postprocess_liveupdate");

--- a/view/js/addon-hooks.js
+++ b/view/js/addon-hooks.js
@@ -1,5 +1,16 @@
+/**
+ * @file addon-hooks.js
+ * @brief Provide a way for add-ons to register a JavaScript hook
+ */
+
 var addon_hooks={};
 
+/**
+ * @brief Register a JavaScript hook to be called from other Javascript files
+ * @pre the .js file from which the hook will be called is included in the document response
+ * @param type which type of hook i.e. where should it be called along with other hooks of the same type
+ * @param hookfnstr name of the JavaScript function name that needs to be called
+ */
 function Addon_registerHook( type, hookfnstr )
 {
 	if (!addon_hooks.hasOwnProperty(type)) {
@@ -7,4 +18,21 @@ function Addon_registerHook( type, hookfnstr )
 	}
 
 	addon_hooks[type].push( hookfnstr );
+}
+
+/**
+ * @brief Call all registered hooks of a certain type, i.e. at the same point of the JavaScript code execution
+ * @param typeOfHook string indicating which type of hooks to be called among the registered hooks
+ */
+function callAddonHooks( typeOfHook ) {
+	if (typeof addon_hooks !== 'undefined') {
+		var myTypeOfHooks = addon_hooks[typeOfHook]; 
+		if (typeof myTypeOfHooks !== 'undefined') {
+			for (addon_hook_idx = 0; addon_hook_idx < myTypeOfHooks.length; addon_hook_idx++) {
+				var hookfnstr = myTypeOfHooks[addon_hook_idx];
+				var hookfn = window[hookfnstr];
+				if (typeof hookfn === "function") hookfn();
+			}
+		}
+	} 
 }

--- a/view/js/addon-hooks.js
+++ b/view/js/addon-hooks.js
@@ -7,6 +7,4 @@ function Addon_registerHook( type, hookfnstr )
 	}
 
 	addon_hooks[type].push( hookfnstr );
-	
-	console.log("addon_hooks type "+type+" has "+addon_hooks[type].length+" hooks registered");
 }

--- a/view/js/addon-hooks.js
+++ b/view/js/addon-hooks.js
@@ -1,0 +1,12 @@
+var addon_hooks={};
+
+function Addon_registerHook( type, hookfnstr )
+{
+	if (!addon_hooks.hasOwnProperty(type)) {
+		addon_hooks[type]=[];
+	}
+
+	addon_hooks[type].push( hookfnstr );
+	
+	console.log("addon_hooks type "+type+" has "+addon_hooks[type].length+" hooks registered");
+}

--- a/view/js/addon-hooks.js
+++ b/view/js/addon-hooks.js
@@ -3,7 +3,7 @@
  * @brief Provide a way for add-ons to register a JavaScript hook
  */
 
-var addon_hooks={};
+var addon_hooks = {};
 
 /**
  * @brief Register a JavaScript hook to be called from other Javascript files
@@ -11,28 +11,31 @@ var addon_hooks={};
  * @param type which type of hook i.e. where should it be called along with other hooks of the same type
  * @param hookfnstr name of the JavaScript function name that needs to be called
  */
-function Addon_registerHook( type, hookfnstr )
+function Addon_registerHook(type, hookfnstr)
 {
 	if (!addon_hooks.hasOwnProperty(type)) {
-		addon_hooks[type]=[];
+		addon_hooks[type] = [];
 	}
 
-	addon_hooks[type].push( hookfnstr );
+	addon_hooks[type].push(hookfnstr);
 }
 
 /**
  * @brief Call all registered hooks of a certain type, i.e. at the same point of the JavaScript code execution
  * @param typeOfHook string indicating which type of hooks to be called among the registered hooks
  */
-function callAddonHooks( typeOfHook ) {
+function callAddonHooks(typeOfHook)
+{
 	if (typeof addon_hooks !== 'undefined') {
-		var myTypeOfHooks = addon_hooks[typeOfHook]; 
+		var myTypeOfHooks = addon_hooks[typeOfHook];
 		if (typeof myTypeOfHooks !== 'undefined') {
 			for (addon_hook_idx = 0; addon_hook_idx < myTypeOfHooks.length; addon_hook_idx++) {
 				var hookfnstr = myTypeOfHooks[addon_hook_idx];
 				var hookfn = window[hookfnstr];
-				if (typeof hookfn === "function") hookfn();
+				if (typeof hookfn === "function") {
+					hookfn();
+				}
 			}
 		}
-	} 
+	}
 }

--- a/view/js/main.js
+++ b/view/js/main.js
@@ -395,19 +395,6 @@ function NavUpdate() {
 	timer = setTimeout(NavUpdate, updateInterval);
 }
 
-function callAddonHooks(typeOfHook) {
-	if (typeof addon_hooks !== 'undefined') {
-		var myTypeOfHooks = addon_hooks[typeOfHook]; 
-		if (typeof myTypeOfHooks !== 'undefined') {
-			for (addon_hook_idx = 0; addon_hook_idx < myTypeOfHooks.length; addon_hook_idx++) {
-				var hookfnstr = myTypeOfHooks[addon_hook_idx];
-				var hookfn = window[hookfnstr];
-				if (typeof hookfn === "function") hookfn();
-			}
-		}
-	} 
-}
-
 function liveUpdate(src) {
 	if ((src == null) || stopped || !profile_uid) {
 		$('.like-rotator').hide(); return;
@@ -473,7 +460,7 @@ function liveUpdate(src) {
 			prev = ident;
 		});
 
-		callAddonHooks("postprocess");
+		callAddonHooks("postprocess_liveupdate");
 
 		$('.like-rotator').hide();
 		if (commentBusy) {

--- a/view/js/main.js
+++ b/view/js/main.js
@@ -395,6 +395,19 @@ function NavUpdate() {
 	timer = setTimeout(NavUpdate, updateInterval);
 }
 
+function callAddonHooks(typeOfHook) {
+	if (typeof addon_hooks !== 'undefined') {
+		var myTypeOfHooks = addon_hooks[typeOfHook]; 
+		if (typeof myTypeOfHooks !== 'undefined') {
+			for (addon_hook_idx = 0; addon_hook_idx < myTypeOfHooks.length; addon_hook_idx++) {
+				var hookfnstr = myTypeOfHooks[addon_hook_idx];
+				var hookfn = window[hookfnstr];
+				if (typeof hookfn === "function") hookfn();
+			}
+		}
+	} 
+}
+
 function liveUpdate(src) {
 	if ((src == null) || stopped || !profile_uid) {
 		$('.like-rotator').hide(); return;
@@ -460,6 +473,8 @@ function liveUpdate(src) {
 			prev = ident;
 		});
 
+		callAddonHooks("postprocess");
+
 		$('.like-rotator').hide();
 		if (commentBusy) {
 			commentBusy = false;
@@ -469,7 +484,9 @@ function liveUpdate(src) {
 		$(".comment-edit-form  textarea").editor_autocomplete(baseurl+"/acl");
 		/* autocomplete bbcode */
 		$(".comment-edit-form  textarea").bbco_autocomplete('bbcode');
+
 	});
+
 }
 
 function imgbright(node) {

--- a/view/templates/head.tpl
+++ b/view/templates/head.tpl
@@ -44,6 +44,10 @@
 <script type="text/javascript" src="view/asset/perfect-scrollbar/js/perfect-scrollbar.jquery.min.js" ></script>
 <script type="text/javascript" src="view/js/acl.js" ></script>
 <script type="text/javascript" src="view/asset/base64/base64.min.js" ></script>
+<script type="text/javascript" src="view/js/addon-hooks.js" ></script>
+{{foreach $addon_hooks as $addon_hook}}
+<script type="text/javascript" src="addon/{{$addon_hook}}/{{$addon_hook}}.js"></script>
+{{/foreach}}
 <script type="text/javascript" src="view/js/main.js" ></script>
 <script>
 

--- a/view/templates/head.tpl
+++ b/view/templates/head.tpl
@@ -45,9 +45,11 @@
 <script type="text/javascript" src="view/js/acl.js" ></script>
 <script type="text/javascript" src="view/asset/base64/base64.min.js" ></script>
 <script type="text/javascript" src="view/js/addon-hooks.js" ></script>
+{{if is_array($addon_hooks)}}
 {{foreach $addon_hooks as $addon_hook}}
 <script type="text/javascript" src="addon/{{$addon_hook}}/{{$addon_hook}}.js"></script>
 {{/foreach}}
+{{/if}}
 <script type="text/javascript" src="view/js/main.js" ></script>
 <script>
 


### PR DESCRIPTION
hook system for JS to allow addons to register their JS hook
in analogy of php addons, the js addons must be named addon/`addon name`/`addon name`.js

This is a prerequisite to solve #5118 in the for the MathJax addon