### PR TITLE
Force a database reconnection in the daemon to prevent lost connections

### DIFF
--- a/include/dba.php
+++ b/include/dba.php
@@ -93,6 +93,26 @@ class dba {
 	}
 
 	/**
+	 * Disconnects the current database connection
+	 */
+	public static function disconnect()
+	{
+		if (is_null(self::$db)) {
+			return;
+		}
+
+		switch (self::$driver) {
+			case 'pdo':
+				self::$db = null;
+				break;
+			case 'mysqli':
+				self::$db->close();
+				self::$db = null;
+				break;
+		}
+	}
+
+	/**
 	 * Return the database object.
 	 * @return PDO|mysqli
 	 */


### PR DESCRIPTION
The daemon is running for a long time. We have to prevent the problem of lost database connections. We now do a constant disconnect and connect with every cron call.