### PR TITLE
Patch for #5202

### DIFF
--- a/mod/register.php
+++ b/mod/register.php
@@ -134,7 +134,7 @@ function register_post(App $a)
 		}
 
 		// send email to admins
-		$admin_mail_list = "'" . implode("','", array_map(dbesc, explode(",", str_replace(" ", "", $a->config['admin_email'])))) . "'";
+		$admin_mail_list = "'" . implode("','", array_map('dbesc', explode(",", str_replace(" ", "", $a->config['admin_email'])))) . "'";
 		$adminlist = q("SELECT uid, language, email FROM user WHERE email IN (%s)",
 			$admin_mail_list
 		);


### PR DESCRIPTION
Add quotes to an erroneously unquoted callback so that PHP doesn’t treat it as a global constant.