### PR TITLE
Don't allow deletion of public posts

### DIFF
--- a/src/Object/Post.php
+++ b/src/Object/Post.php
@@ -192,7 +192,7 @@ class Post extends BaseObject
 			'delete'   => $delete,
 		];
 
-		if (!local_user()) {
+		if (!local_user() || ($item['uid'] == 0)) {
 			$drop = false;
 		}
 


### PR DESCRIPTION
Deleting public posts do delete these posts for every user, so we have to forbid this.