### PR TITLE
solves 2337 Smiley Pack 1.04: some smiley keywords aren't replaced correctly

### DIFF
--- a/src/Content/Smilies.php
+++ b/src/Content/Smilies.php
@@ -145,6 +145,27 @@ class Smilies
 		return $params;
 	}
 
+
+	/**
+	 * Copied from http://php.net/manual/en/function.str-replace.php#88569
+	 * Modified for camel caps: renamed stro_replace -> strOrigReplace
+	 *
+	 * When using str_replace(...), values that did not exist in the original string (but were put there by previous
+	 * replacements) will be replaced continuously.  This string replacement function is designed to replace the values
+	 * in $search with those in $replace while not factoring in prior replacements.  Note that this function will
+	 * always look for the longest possible match first and then work its way down to individual characters.
+	 *
+	 * @param array $search list of strings or characters that need to be replaced
+	 * @param array $replace list of strings or characters that will replace the corresponding values in $search
+	 * @param string $subject the string on which this operation is being performed
+	 *
+	 * @return string $subject with all substrings in the $search array replaced by the values in the $replace array
+	 */
+	private static function strOrigReplace($search, $replace, $subject)
+	{
+		return strtr($subject, array_combine($search, $replace));
+	}
+
 	/**
 	 * @brief Replaces text emoticons with graphical images
 	 *
@@ -196,7 +217,7 @@ class Smilies
 			}
 		} else {
 			$params['string'] = preg_replace_callback('/&lt;(3+)/', 'self::pregHeart', $params['string']);
-			$s = str_replace($params['texts'], $params['icons'], $params['string']);
+			$s = self::strOrigReplace($params['texts'], $params['icons'], $params['string']);
 		}
 
 		$s = preg_replace_callback('/<pre>(.*?)<\/pre>/ism', 'self::decode', $s);


### PR DESCRIPTION
After some googling around, I found a pre-made solution for the problem that the standard php str_replace keeps replacing on the result of the previous replacements.

So when it found ":bunnyflowers", it would replace with the target which includes "alt:bunnyflowers", on which the replacement for ":bunny" will work. Hence the outcome in issue #2337 .

I added a function `strOrigReplace` which I copied from [the notes of the PHP str_replace manual](http://php.net/manual/en/function.str-replace.php#88569)

It's a lot of text for a small change. Possibly we don't even need the function and move the strtr() directly in place of the str_replace() call but that would make it more obscure why we don't just call str_replace. Or it could become a generic function if this would be needed in other places too. Up to you.