### PR TITLE
Fix feed blank reshare body

### DIFF
--- a/mod/share.php
+++ b/mod/share.php
@@ -15,7 +15,7 @@ function share_init(App $a) {
 		'guid', 'created', 'plink', 'title'];
 	$item = Item::selectFirst(local_user(), $fields, ['id' => $post_id]);
 
-	if (!DBM::is_result($item) || $item['private']) {
+	if (!DBM::is_result($item) || $item['private'] == 1) {
 		killme();
 	}
 


### PR DESCRIPTION
Fixes the issue described in https://forum.friendi.ca/display/0b6b25a8175b22a2c105a91106120054

Feed items have `private` set to `2` (?!), and we were preventing the output of the share body for any value of `private` above `0`.

But the button was showing for any value of `private` different from `1`.

The inconsistency is fixed.