### PR TITLE
Fix PHP 7.2 Warning in Model\Contact

### DIFF
--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -1070,9 +1070,11 @@ class Contact extends BaseObject
 			'limit' => [$a->pager['start'], $a->pager['itemspage']]];
 		$r = Item::select(local_user(), [], $condition, $params);
 
-		$o = conversation($a, dba::inArray($r), 'contact-posts', false);
+		$items = dba::inArray($r);
+		
+		$o = conversation($a, $items, 'contact-posts', false);
 
-		$o .= alt_pager($a, count($r));
+		$o .= alt_pager($a, count($items));
 
 		return $o;
 	}


### PR DESCRIPTION
Follow-up to #5184

Fixes the following warning: 
`PHP Warning:  count(): Parameter must be an array or an object that implements Countable in /home/friendica/friendica/friendica/src/Model/Contact.php on line 1075`