### PR TITLE
Replicate support for JS hooks (#5179) in frio theme

### DIFF
--- a/view/theme/frio/templates/head.tpl
+++ b/view/theme/frio/templates/head.tpl
@@ -68,6 +68,12 @@
 <script type="text/javascript" src="view/asset/perfect-scrollbar/js/perfect-scrollbar.jquery.min.js"></script>
 <script type="text/javascript" src="view/js/acl.js"></script>
 <script type="text/javascript" src="view/asset/base64/base64.min.js"></script>
+<script type="text/javascript" src="view/js/addon-hooks.js"></script>
+{{if is_array($addon_hooks)}}
+{{foreach $addon_hooks as $addon_hook}}
+<script type="text/javascript" src="addon/{{$addon_hook}}/{{$addon_hook}}.js"></script>
+{{/foreach}}
+{{/if}}
 <script type="text/javascript" src="view/js/main.js"></script>
 
 <script type="text/javascript" src="view/theme/frio/frameworks/bootstrap/js/bootstrap.min.js"></script>


### PR DESCRIPTION
When using the frio theme, I noticed that there were error messages in the browser console due to the call `callAddonHooks` that was added in `view/js/addon-hooks.js` in #5179.
Error message:

> ReferenceError: callAddonHooks is not defined

This turned out to be due to the fact that the frio theme overrides the `view/templates/head.tpl` file. In this PR, I replicate the changes in `head.tpl` to frio's version of `head.tpl`.
This makes e.g. the mathjax add-on work in liveupdate also when using the frio theme.