### PR TITLE
Add Missing Fifth Argument to mail() Function Call

### DIFF
--- a/doc/htconfig.md
+++ b/doc/htconfig.md
@@ -85,6 +85,7 @@ Example: To set the automatic database cleanup process add this line to your .ht
 * **pushpoll_frequency** -
 * **qsearch_limit** - Default value is 100.
 * **remove_multiplicated_lines** (Boolean) - If enabled, multiple linefeeds in items are stripped to a single one.
+* **sendmail_params** (Boolean) - Normal sendmail command parameters will be added when the PHP mail() function is called for sending e-mails.  This ensures the Sender Email address setting is applied to the message envelope rather than the host's default address.
 * **show_unsupported_addons** (Boolean) - Show all addons including the unsupported ones.
 * **show_unsupported_themes** (Boolean) - Show all themes including the unsupported ones.
 * **show_global_community_hint** (Boolean) - When the global community page is enabled, use this option to display a hint above the stream, that this is a collection of all public top-level postings that arrive on your node.

--- a/doc/htconfig.md
+++ b/doc/htconfig.md
@@ -85,7 +85,7 @@ Example: To set the automatic database cleanup process add this line to your .ht
 * **pushpoll_frequency** -
 * **qsearch_limit** - Default value is 100.
 * **remove_multiplicated_lines** (Boolean) - If enabled, multiple linefeeds in items are stripped to a single one.
-* **sendmail_params** (Boolean) - Normal sendmail command parameters will be added when the PHP mail() function is called for sending e-mails.  This ensures the Sender Email address setting is applied to the message envelope rather than the host's default address.
+* **sendmail_params** (Boolean) - Normal sendmail command parameters will be added when the PHP mail() function is called for sending e-mails.  This ensures the Sender Email address setting is applied to the message envelope rather than the host's default address.  Default is true.  Set to false if your non-sendmail agent is incompatible, or to restore old behavior of using the host address.
 * **show_unsupported_addons** (Boolean) - Show all addons including the unsupported ones.
 * **show_unsupported_themes** (Boolean) - Show all themes including the unsupported ones.
 * **show_global_community_hint** (Boolean) - When the global community page is enabled, use this option to display a hint above the stream, that this is a collection of all public top-level postings that arrive on your node.

--- a/src/Util/Emailer.php
+++ b/src/Util/Emailer.php
@@ -72,20 +72,28 @@ class Emailer
 		$multipartMessageBody .=
 			"--" . $mimeBoundary . "--\n";					// message ending
 
+		if (Config::get("system", "sendmail_params", true)) {
+			$sendmail_params = '-f ' . $params['fromEmail'];
+		} else {
+			$sendmail_params = null;
+		}
+
 		// send the message
 		$hookdata = [
 			'to' => $params['toEmail'],
 			'subject' => $messageSubject,
 			'body' => $multipartMessageBody,
-			'headers' => $messageHeader
+			'headers' => $messageHeader,
+			'parameters' => $sendmail_params
 		];
 		//echo "<pre>"; var_dump($hookdata); killme();
 		Addon::callHooks("emailer_send", $hookdata);
 		$res = mail(
-			$hookdata['to'],							// send to address
-			$hookdata['subject'],						// subject
-			$hookdata['body'], 	 						// message body
-			$hookdata['headers']						// message headers
+			$hookdata['to'],
+			$hookdata['subject'],
+			$hookdata['body'],
+			$hookdata['headers'],
+			$hookdata['parameters']
 		);
 		logger("header " . 'To: ' . $params['toEmail'] . "\n" . $messageHeader, LOGGER_DEBUG);
 		logger("return value " . (($res)?"true":"false"), LOGGER_DEBUG);

--- a/src/Util/Emailer.php
+++ b/src/Util/Emailer.php
@@ -5,6 +5,7 @@
 namespace Friendica\Util;
 
 use Friendica\Core\Addon;
+use Friendica\Core\Config;
 use Friendica\Core\PConfig;
 use Friendica\Protocol\Email;
 


### PR DESCRIPTION
This is desperately needed to fix Issue #5190.  In case of any unexpected problem, the admin can use

`$a->config['system']['sendmail_params'] = false;`