### PR TITLE
Makes the linear load calculation optional

### DIFF
--- a/doc/htconfig.md
+++ b/doc/htconfig.md
@@ -94,6 +94,7 @@ Example: To set the automatic database cleanup process add this line to your .ht
 * **throttle_limit_month** - Maximum number of posts that a user can send per month with the API.
 * **wall-to-wall_share** (Boolean) - Displays forwarded posts like "wall-to-wall" posts.
 * **worker_cooldown** - Cooldown time after each worker function call. Default value is 0 seconds.
+* **worker_linear_load** (Boolean) - Enables the linear calculation of maximum queues.
 * **xrd_timeout** - Timeout for fetching the XRD links. Default value is 20 seconds.
 
 ## experimental ##

--- a/mod/admin.php
+++ b/mod/admin.php
@@ -1029,7 +1029,7 @@ function admin_page_site_post(App $a)
 	$rino			=	((x($_POST,'rino'))			? intval($_POST['rino'])			: 0);
 	$check_new_version_url	=	((x($_POST, 'check_new_version_url'))	?	notags(trim($_POST['check_new_version_url']))	: 'none');
 
-	$worker_queues		=	((x($_POST,'worker_queues'))		? intval($_POST['worker_queues'])		: 4);
+	$worker_queues		=	((x($_POST,'worker_queues'))		? intval($_POST['worker_queues'])		: 10);
 	$worker_dont_fork	=	((x($_POST,'worker_dont_fork'))		? True						: False);
 	$worker_fastlane	=	((x($_POST,'worker_fastlane'))		? True						: False);
 	$worker_frontend	=	((x($_POST,'worker_frontend'))		? True						: False);
@@ -1448,7 +1448,7 @@ function admin_page_site(App $a)
 
 		'$rino' 		=> ['rino', L10n::t("RINO Encryption"), intval(Config::get('system','rino_encrypt')), L10n::t("Encryption layer between nodes."), [0 => L10n::t("Disabled"), 1 => L10n::t("Enabled")]],
 
-		'$worker_queues' 	=> ['worker_queues', L10n::t("Maximum number of parallel workers"), Config::get('system','worker_queues'), L10n::t("On shared hosters set this to 2. On larger systems, values of 10 are great. Default value is 4.")],
+		'$worker_queues' 	=> ['worker_queues', L10n::t("Maximum number of parallel workers"), Config::get('system','worker_queues'), L10n::t("On shared hosters set this to %d. On larger systems, values of %d are great. Default value is %d.", 5, 20, 10)],
 		'$worker_dont_fork'	=> ['worker_dont_fork', L10n::t("Don't use 'proc_open' with the worker"), Config::get('system','worker_dont_fork'), L10n::t("Enable this if your system doesn't allow the use of 'proc_open'. This can happen on shared hosters. If this is enabled you should increase the frequency of worker calls in your crontab.")],
 		'$worker_fastlane'	=> ['worker_fastlane', L10n::t("Enable fastlane"), Config::get('system','worker_fastlane'), L10n::t("When enabed, the fastlane mechanism starts an additional worker if processes with higher priority are blocked by processes of lower priority.")],
 		'$worker_frontend'	=> ['worker_frontend', L10n::t('Enable frontend worker'), Config::get('system','frontend_worker'), L10n::t('When enabled the Worker process is triggered when backend access is performed \x28e.g. messages being delivered\x29. On smaller sites you might want to call %s/worker on a regular basis via an external cron job. You should only enable this option if you cannot utilize cron/scheduled jobs on your server.', System::baseUrl())],

--- a/src/Core/Worker.php
+++ b/src/Core/Worker.php
@@ -624,16 +624,34 @@ class Worker
 		$load = current_load();
 		if ($load) {
 			$maxsysload = intval(Config::get("system", "maxloadavg", 50));
-			$tinyload = 1;
 
-			if ($load > $maxsysload) {
-				$queues = 0;
-			} elseif ($load > $tinyload) {
-				//Provide $queues number between 1 (below max load) and $maxqueues - 1 (above tiny load).
-				$range = $maxsysload - $tinyload;
-				$slope = 1.00 - (($load - $tinyload) / $range);
-				$target = $slope * ($maxqueues - 1);
-				$queues = intval(ceil($target));
+			if (Config::get('system', 'worker_linear_load', false)) {
+				/* The linear load calculation works fine if there is a low
+				 * number of maximum queues and a high load base level.
+				 * This can be present at shared hosters.
+				*/
+				$tinyload = 1;
+
+				if ($load > $maxsysload) {
+					$queues = 0;
+				} elseif ($load > $tinyload) {
+					//Provide $queues number between 1 (below max load) and $maxqueues - 1 (above tiny load).
+					$range = $maxsysload - $tinyload;
+					$slope = 1.00 - (($load - $tinyload) / $range);
+					$target = $slope * ($maxqueues - 1);
+					$queues = intval(ceil($target));
+				}
+			} else {
+				/* The exponentional load calculation respects the load behaviour
+				 * of Linux systems with regular hardware that normally idles
+				 * with load values near 0.
+				*/
+				$maxworkers = $queues;
+
+				// Some magical mathemathics to reduce the workers
+				$exponent = 3;
+				$slope = $maxworkers / pow($maxsysload, $exponent);
+				$queues = ceil($slope * pow(max(0, $maxsysload - $load), $exponent));
 			}
 
 			$processlist = '';


### PR DESCRIPTION
This mostly restores the behaviour before PR https://github.com/friendica/friendica/pull/5248 - but keeps the linear calculation of the maximum number of workers as an option.

The exponential method suits best the behaviour of regular Linux systems that are already half dead when the load is at the half value of the maximum load.