### PR TITLE
Unify Worker Load Formulas

### DIFF
--- a/doc/htconfig.md
+++ b/doc/htconfig.md
@@ -94,7 +94,7 @@ Example: To set the automatic database cleanup process add this line to your .ht
 * **throttle_limit_month** - Maximum number of posts that a user can send per month with the API.
 * **wall-to-wall_share** (Boolean) - Displays forwarded posts like "wall-to-wall" posts.
 * **worker_cooldown** - Cooldown time after each worker function call. Default value is 0 seconds.
-* **worker_load_exponent** (Integer) - Default 3, which allows only 25% of the maximum worker queues when server load reaches around 37% of maximum load.  For a linear response where 25% of worker queues are allowed at 75% of maximum load, set this to 1.  Queues will always reduce to zero when the maximum load is exceeded.
+* **worker_load_exponent** (Integer) - Default 3, which allows only 25% of the maximum worker queues when server load reaches around 37% of maximum load.  For a linear response where 25% of worker queues are allowed at 75% of maximum load, set this to 1.  Setting 0 would allow maximum worker queues at all times, which is not recommended.
 * **xrd_timeout** - Timeout for fetching the XRD links. Default value is 20 seconds.
 
 ## experimental ##

--- a/doc/htconfig.md
+++ b/doc/htconfig.md
@@ -94,7 +94,7 @@ Example: To set the automatic database cleanup process add this line to your .ht
 * **throttle_limit_month** - Maximum number of posts that a user can send per month with the API.
 * **wall-to-wall_share** (Boolean) - Displays forwarded posts like "wall-to-wall" posts.
 * **worker_cooldown** - Cooldown time after each worker function call. Default value is 0 seconds.
-* **worker_linear_load** (Boolean) - Enables the linear calculation of maximum queues.
+* **worker_load_exponent** (Integer) - Default 3, which allows only 25% of the maximum worker queues when server load reaches around 37% of maximum load.  For a linear response where 25% of worker queues are allowed at 75% of maximum load, set this to 1.  Queues will always reduce to zero when the maximum load is exceeded.
 * **xrd_timeout** - Timeout for fetching the XRD links. Default value is 20 seconds.
 
 ## experimental ##

--- a/src/Core/Worker.php
+++ b/src/Core/Worker.php
@@ -625,6 +625,11 @@ class Worker
 		if ($load) {
 			$maxsysload = intval(Config::get("system", "maxloadavg", 50));
 
+			/* Default exponent 3 causes queues to rapidly decrease as load increases.
+			 * If you have 20 max queues at idle, then you get only 5 queues at 37.1% of $maxsysload.
+			 * For some environments, this rapid decrease is not needed.
+			 * With exponent 1, you could have 20 max queues at idle and 13 at 37% of $maxsysload.
+			 */
 			$exponent = intval(Config::get('system', 'worker_load_exponent', 3));
 			$slope = pow(max(0, $maxsysload - $load) / $maxsysload, $exponent);
 			$queues = intval(ceil($slope * $maxqueues));

--- a/src/Core/Worker.php
+++ b/src/Core/Worker.php
@@ -625,12 +625,7 @@ class Worker
 		if ($load) {
 			$maxsysload = intval(Config::get("system", "maxloadavg", 50));
 
-			if (Config::get('system', 'worker_linear_load', false)) {
-				$exponent = 1;
-			} else {
-				$exponent = 3;
-			}
-
+			$exponent = intval(Config::get('system', 'worker_load_exponent', 3));
 			$slope = pow(max(0, $maxsysload - $load) / $maxsysload, $exponent);
 			$queues = intval(ceil($slope * $maxqueues));
 

--- a/src/Core/Worker.php
+++ b/src/Core/Worker.php
@@ -626,33 +626,13 @@ class Worker
 			$maxsysload = intval(Config::get("system", "maxloadavg", 50));
 
 			if (Config::get('system', 'worker_linear_load', false)) {
-				/* The linear load calculation works fine if there is a low
-				 * number of maximum queues and a high load base level.
-				 * This can be present at shared hosters.
-				*/
-				$tinyload = 1;
-
-				if ($load > $maxsysload) {
-					$queues = 0;
-				} elseif ($load > $tinyload) {
-					//Provide $queues number between 1 (below max load) and $maxqueues - 1 (above tiny load).
-					$range = $maxsysload - $tinyload;
-					$slope = 1.00 - (($load - $tinyload) / $range);
-					$target = $slope * ($maxqueues - 1);
-					$queues = intval(ceil($target));
-				}
+				$exponent = 1;
 			} else {
-				/* The exponentional load calculation respects the load behaviour
-				 * of Linux systems with regular hardware that normally idles
-				 * with load values near 0.
-				*/
-				$maxworkers = $queues;
-
-				// Some magical mathemathics to reduce the workers
 				$exponent = 3;
-				$slope = $maxworkers / pow($maxsysload, $exponent);
-				$queues = ceil($slope * pow(max(0, $maxsysload - $load), $exponent));
 			}
+
+			$slope = pow(max(0, $maxsysload - $load) / $maxsysload, $exponent);
+			$queues = intval(ceil($slope * $maxqueues));
 
 			$processlist = '';
 


### PR DESCRIPTION
The two formulas created in #5249 accomplish exactly the same thing and are redundant.

These are refactored here for readability and overall simplification.