### PR TITLE
Allow for Integer Literals in PDO Database Driver

### DIFF
--- a/include/dba.php
+++ b/include/dba.php
@@ -427,7 +427,12 @@ class dba {
 				}
 
 				foreach ($args AS $param => $value) {
-					$stmt->bindParam($param, $args[$param]);
+					if (is_int($args[$param])) {
+						$data_type = PDO::PARAM_INT;
+					} else {
+						$data_type = PDO::PARAM_STR;
+					}
+					$stmt->bindParam($param, $args[$param], $data_type);
 				}
 
 				if (!$stmt->execute()) {


### PR DESCRIPTION
This should fix things like "LIMIT ?" for Issue #5266 

Note that integer literals are always SQL safe, so this change will not require much scrutiny.  Any additional data types would need to be evaluated for their appropriate usage.