### PR TITLE
 fix redirection - works now with logged in users, remote users, guests and visitors

### DIFF
--- a/mod/dfrn_poll.php
+++ b/mod/dfrn_poll.php
@@ -119,6 +119,7 @@ function dfrn_poll_init(App $a)
 					$_SESSION['visitor_home'] = $r[0]['url'];
 					$_SESSION['visitor_handle'] = $r[0]['addr'];
 					$_SESSION['visitor_visiting'] = $r[0]['uid'];
+					$_SESSION['my_url'] = $r[0]['url'];
 					if (!$quiet) {
 						info(L10n::t('%1$s welcomes %2$s', $r[0]['username'], $r[0]['name']) . EOL);
 					}
@@ -535,6 +536,7 @@ function dfrn_poll_content(App $a)
 					$_SESSION['visitor_id'] = $r[0]['id'];
 					$_SESSION['visitor_home'] = $r[0]['url'];
 					$_SESSION['visitor_visiting'] = $r[0]['uid'];
+					$_SESSION['my_url'] = $r[0]['url'];
 					if (!$quiet) {
 						info(L10n::t('%1$s welcomes %2$s', $r[0]['username'], $r[0]['name']) . EOL);
 					}

--- a/mod/hovercard.php
+++ b/mod/hovercard.php
@@ -44,7 +44,7 @@ function hovercard_content()
 	// the contact. So we strip out the contact id from the internal url and look in the contact table for
 	// the real url (nurl)
 	$cid = 0;
-	if (local_user() && strpos($profileurl, 'redir/') === 0) {
+	if (strpos($profileurl, 'redir/') === 0) {
 		$cid = intval(substr($profileurl, 6));
 		$remote_contact = dba::selectFirst('contact', ['nurl'], ['id' => $cid]);
 		$profileurl = defaults($remote_contact, 'nurl', '');

--- a/mod/redir.php
+++ b/mod/redir.php
@@ -13,7 +13,7 @@ function redir_init(App $a) {
 	$quiet = !empty($_GET['quiet']) ? '&quiet=1' : '';
 	$con_url = defaults($_GET, 'conurl', '');
 
-	if (local_user() && ($a->argc > 1) && intval($a->argv[1])) {
+	if ($a->argc > 1 && intval($a->argv[1])) {
 		$cid = intval($a->argv[1]);
 	} elseif (local_user() && !empty($con_url)) {
 		$cid = Contact::getIdForURL($con_url, local_user());
@@ -22,70 +22,104 @@ function redir_init(App $a) {
 	}
 
 	if (!empty($cid)) {
-		$fields = ['id', 'uid', 'nurl', 'url', 'name', 'network', 'poll', 'issued-id', 'dfrn-id', 'duplex'];
+		$fields = ['id', 'uid', 'nurl', 'url', 'addr', 'name', 'network', 'poll', 'issued-id', 'dfrn-id', 'duplex'];
 		$contact = dba::selectFirst('contact', $fields, ['id' => $cid, 'uid' => [0, local_user()]]);
 		if (!DBM::is_result($contact)) {
 			notice(L10n::t('Contact not found.'));
 			goaway(System::baseUrl());
 		}
 
-		if ($contact['network'] !== NETWORK_DFRN) {
-			goaway(($url != '' ? $url : $contact['url']));
+		$contact_url = $contact['url'];
+
+		if ($contact['network'] !== NETWORK_DFRN // Authentication isn't supported for non DFRN contacts.
+			|| (!local_user() && !remote_user()) // Visitors (not logged in or not remotes) can't authenticate.
+			|| (!empty($a->contact['id']) && $a->contact['id'] == $cid)) // Local user is already authenticated.
+		{
+			goaway($url != '' ? $url : $contact_url);
 		}
 
-		if ($contact['uid'] == 0) {
-			$contact_url = $contact['url'];
+		if ($contact['uid'] == 0 && local_user()) {
+			// Let's have a look if there is an established connection
+			// between the puplic contact we have found and the local user.
 			$contact = dba::selectFirst('contact', $fields, ['nurl' => $contact['nurl'], 'uid' => local_user()]);
-			if (!DBM::is_result($contact)) {
-				$target_url = ($url != '' ? $url : $contact_url);
 
-				$my_profile = Profile::getMyURL();
-
-				if (!empty($my_profile) && !link_compare($my_profile, $target_url)) {
-					$separator = strpos($target_url, '?') ? '&' : '?';
-
-					$target_url .= $separator . 'zrl=' . urlencode($my_profile);
-				}
-				goaway($target_url);
-			} else {
+			if (DBM::is_result($contact)) {
 				$cid = $contact['id'];
+			}
+
+			if (!empty($a->contact['id']) && $a->contact['id'] == $cid) {
+				// Local user is already authenticated.
+				$target_url = $url != '' ? $url : $contact_url;
+				logger($contact['name'] . " is already authenticated. Redirecting to " . $target_url, LOGGER_DEBUG);
+				goaway($target_url);
 			}
 		}
 
-		$dfrn_id = $orig_id = (($contact['issued-id']) ? $contact['issued-id'] : $contact['dfrn-id']);
+		if (remote_user()) {
+			$host = substr(System::baseUrl() . ($a->path ? '/' . $a->path : ''), strpos(System::baseUrl(), '://') + 3);
+			$remotehost = substr($contact['addr'], strpos($contact['addr'], '@') + 1);
 
-		if ($contact['duplex'] && $contact['issued-id']) {
-			$orig_id = $contact['issued-id'];
-			$dfrn_id = '1:' . $orig_id;
+			// On a local instance we have to check if the local user has already authenticated
+			// with the local contact. Otherwise the local user would ask the local contact
+			// for authentification everytime he/she is visiting a profile page of the local
+			// contact.
+			if ($host == $remotehost
+				&& x($_SESSION, 'remote')
+				&& is_array($_SESSION['remote']))
+			{
+				foreach ($_SESSION['remote'] as $v) {
+					if ($v['uid'] == $_SESSION['visitor_visiting'] && $v['cid'] == $_SESSION['visitor_id']) {
+						// Remote user is already authenticated.
+						$target_url = $url != '' ? $url : $contact_url;
+						logger($contact['name'] . " is already authenticated. Redirecting to " . $target_url, LOGGER_DEBUG);
+						goaway($target_url);
+					}
+				}
+			}
 		}
-		if ($contact['duplex'] && $contact['dfrn-id']) {
-			$orig_id = $contact['dfrn-id'];
-			$dfrn_id = '0:' . $orig_id;
+
+		// Doing remote auth with dfrn.
+		if (local_user()&& (!empty($contact['dfrn-id']) || !empty($contact['issued-id']))) {
+			$dfrn_id = $orig_id = (($contact['issued-id']) ? $contact['issued-id'] : $contact['dfrn-id']);
+
+			if ($contact['duplex'] && $contact['issued-id']) {
+				$orig_id = $contact['issued-id'];
+				$dfrn_id = '1:' . $orig_id;
+			}
+			if ($contact['duplex'] && $contact['dfrn-id']) {
+				$orig_id = $contact['dfrn-id'];
+				$dfrn_id = '0:' . $orig_id;
+			}
+
+			$sec = random_string();
+
+			$fields = ['uid' => local_user(), 'cid' => $cid, 'dfrn_id' => $dfrn_id,
+				'sec' => $sec, 'expire' => time() + 45];
+			dba::insert('profile_check', $fields);
+
+			logger('mod_redir: ' . $contact['name'] . ' ' . $sec, LOGGER_DEBUG);
+
+			$dest = (!empty($url) ? '&destination_url=' . $url : '');
+
+			goaway($contact['poll'] . '?dfrn_id=' . $dfrn_id
+				. '&dfrn_version=' . DFRN_PROTOCOL_VERSION . '&type=profile&sec=' . $sec . $dest . $quiet);
 		}
 
-		$sec = random_string();
-
-		$fields = ['uid' => local_user(), 'cid' => $cid, 'dfrn_id' => $dfrn_id,
-			'sec' => $sec, 'expire' => time() + 45];
-		dba::insert('profile_check', $fields);
-
-		logger('mod_redir: ' . $contact['name'] . ' ' . $sec, LOGGER_DEBUG);
-
-		$dest = (!empty($url) ? '&destination_url=' . $url : '');
-
-		goaway($contact['poll'] . '?dfrn_id=' . $dfrn_id
-			. '&dfrn_version=' . DFRN_PROTOCOL_VERSION . '&type=profile&sec=' . $sec . $dest . $quiet);
+		$url = $url != '' ? $url : $contact_url;
 	}
 
-	if (local_user()) {
-		$handle = $a->user['nickname'] . '@' . substr(System::baseUrl(), strpos(System::baseUrl(), '://') + 3);
-	}
-	if (remote_user()) {
-		$handle = $_SESSION['handle'];
-	}
-
+	// If we don't have a connected contact, redirect with
+	// the 'zrl' parameter.
 	if (!empty($url)) {
-		$url = str_replace('{zid}', '&zid=' . $handle, $url);
+		$my_profile = Profile::getMyURL();
+
+		if (!empty($my_profile) && !link_compare($my_profile, $url)) {
+			$separator = strpos($url, '?') ? '&' : '?';
+
+			$url .= $separator . 'zrl=' . urlencode($my_profile);
+		}
+
+		logger('redirecting to ' . $url, LOGGER_DEBUG);
 		goaway($url);
 	}
 

--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -1081,6 +1081,7 @@ class Profile
 		$_SESSION['visitor_id'] = $visitor['id'];
 		$_SESSION['visitor_handle'] = $visitor['addr'];
 		$_SESSION['visitor_home'] = $visitor['url'];
+		$_SESSION['my_url'] = $visitor['url'];
 
 		$arr = [
 			'visitor' => $visitor,


### PR DESCRIPTION
After the last restructuring of the `redir.php` redirection was broken for all other users than local user.

It was really hard to find all the use cases (local user, remote users, zrl visitors and normal visitors +managed accounts + if you doing remote auth on your own instance) and find solutions for all of them. After a lot of testing I hope I found all of them.

This fixes also https://github.com/friendica/friendica/issues/5222 . The problem was that the local user requested dfrn authentication for his/her own profile,

On question remains: Does anyone else than the local user get pictures with the `conurl` parameter?