### PR TITLE
INSTALL.txt and doc/de/Install.md updates

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -70,6 +70,24 @@ OR
 	cd [web server folder]
 	php bin/composer.phar install
 
+Make sure the folder view/smarty3 exists and is writable by the webserver
+user, in this case `www-data`
+
+    mkdir view/smarty3
+    chown www-data:www-data view/smarty3
+    chmod 775 view/smarty3
+
+Get the addons by going into your website folder.
+
+    cd mywebsite
+
+Clone the addon repository (separately):
+
+    git clone https://github.com/friendica/friendica-addons.git addon
+
+If you copy the directory tree to your webserver, make sure that you also 
+copy .htaccess - as "dot" files are often hidden and aren't normally copied.
+
 3. Create an empty database and note the access details (hostname, username,
 password, database name).
 

--- a/doc/de/Install.md
+++ b/doc/de/Install.md
@@ -54,7 +54,7 @@ Der Linux-Code, mit dem man die Dateien direkt in ein Verzeichnis wie "meinewebs
 Stelle sicher, dass der Ordner *view/smarty3* existiert and von dem Webserver-Benutzer beschreibbar ist
 
     mkdir view/smarty3
-    chmod 777 view/smarty3
+    chmod 775 view/smarty3
 
 Falls Addons installiert werden sollen: Gehe in den Friendica-Ordner 
 


### PR DESCRIPTION
Follow up to #4836

* Adding missing parts to the INSTALL.txt about the smarty directory access rights and how to get the addons.
* Correcting the access rights in the doc/de/Install.md file for the smarty directory