### PR TITLE
Fix Broken Profile Links

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -531,6 +531,7 @@ class App
 			'$touch_icon'      => $touch_icon,
 			'$stylesheet'      => $stylesheet,
 			'$infinite_scroll' => $invinite_scroll,
+			'$block_public'    => intval(Config::get('system', 'block_public')),
 		]) . $this->page['htmlhead'];
 	}
 

--- a/view/theme/frio/templates/head.tpl
+++ b/view/theme/frio/templates/head.tpl
@@ -92,7 +92,9 @@
 {{* own js files *}}
 <script type="text/javascript" src="view/theme/frio/js/theme.js"></script>
 <script type="text/javascript" src="view/theme/frio/js/modal.js"></script>
+{{if ! $block_public}}
 <script type="text/javascript" src="view/theme/frio/js/hovercard.js"></script>
+{{/if}}
 <script type="text/javascript" src="view/theme/frio/js/textedit.js"></script>
 
 <script type="text/javascript">


### PR DESCRIPTION
Existing logic in /mod/hovercard.php generates an error for every hovercard request while block_public is true.

On desktop browsers, this behavior has the effect of cancelling the hovercard.

On mobile browsers, this completely breaks all profile links, making it impossible to navigate any non-public site with the Frio theme.

This patch does not correct hovercard.php, but instead removes hovercard.js any time block_public is true.  The difference for desktop browsers is trivial (performance) as no features are lost by this patch.  The difference for mobile browsers is a major improvement in functionality.

Fixes #5205