### PR TITLE
Item content is now stored outside the item table

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -41,7 +41,7 @@ define('FRIENDICA_PLATFORM',     'Friendica');
 define('FRIENDICA_CODENAME',     'The Tazmans Flax-lily');
 define('FRIENDICA_VERSION',      '2018.08-dev');
 define('DFRN_PROTOCOL_VERSION',  '2.23');
-define('DB_UPDATE_VERSION',      1270);
+define('DB_UPDATE_VERSION',      1271);
 define('NEW_UPDATE_ROUTINE_VERSION', 1170);
 
 /**

--- a/database.sql
+++ b/database.sql
@@ -541,7 +541,8 @@ CREATE TABLE IF NOT EXISTS `item` (
 	 INDEX `contactid_verb` (`contact-id`,`verb`),
 	 INDEX `deleted_changed` (`deleted`,`changed`),
 	 INDEX `uid_wall_changed` (`uid`,`wall`,`changed`),
-	 INDEX `uid_eventid` (`uid`,`event-id`)
+	 INDEX `uid_eventid` (`uid`,`event-id`),
+	 INDEX `icid` (`icid`)
 ) DEFAULT COLLATE utf8mb4_general_ci COMMENT='Structure for all posts';
 
 --

--- a/database.sql
+++ b/database.sql
@@ -1,6 +1,6 @@
 -- ------------------------------------------
 -- Friendica 2018.08-dev (The Tazmans Flax-lily)
--- DB_UPDATE_VERSION 1270
+-- DB_UPDATE_VERSION 1271
 -- ------------------------------------------
 
 
@@ -477,6 +477,7 @@ CREATE TABLE IF NOT EXISTS `item` (
 	`author-name` varchar(255) NOT NULL DEFAULT '' COMMENT 'Name of the author of this item',
 	`author-link` varchar(255) NOT NULL DEFAULT '' COMMENT 'Link to the profile page of the author of this item',
 	`author-avatar` varchar(255) NOT NULL DEFAULT '' COMMENT 'Link to the avatar picture of the author of this item',
+	`icid` int unsigned COMMENT 'Id of the item-content table entry that contains the whole item content',
 	`title` varchar(255) NOT NULL DEFAULT '' COMMENT 'item title',
 	`content-warning` varchar(255) NOT NULL DEFAULT '' COMMENT '',
 	`body` mediumtext COMMENT 'item body content',
@@ -540,10 +541,33 @@ CREATE TABLE IF NOT EXISTS `item` (
 	 INDEX `contactid_verb` (`contact-id`,`verb`),
 	 INDEX `deleted_changed` (`deleted`,`changed`),
 	 INDEX `uid_wall_changed` (`uid`,`wall`,`changed`),
-	 INDEX `uid_eventid` (`uid`,`event-id`),
-	 INDEX `uid_authorlink` (`uid`,`author-link`(190)),
-	 INDEX `uid_ownerlink` (`uid`,`owner-link`(190))
-) DEFAULT COLLATE utf8mb4_general_ci COMMENT='All posts';
+	 INDEX `uid_eventid` (`uid`,`event-id`)
+) DEFAULT COLLATE utf8mb4_general_ci COMMENT='Structure for all posts';
+
+--
+-- TABLE item-content
+--
+CREATE TABLE IF NOT EXISTS `item-content` (
+	`id` int unsigned NOT NULL auto_increment,
+	`uri` varchar(255) NOT NULL DEFAULT '' COMMENT '',
+	`uri-plink-hash` char(80) NOT NULL DEFAULT '' COMMENT 'SHA-1 hash from uri and plink',
+	`title` varchar(255) NOT NULL DEFAULT '' COMMENT 'item title',
+	`content-warning` varchar(255) NOT NULL DEFAULT '' COMMENT '',
+	`body` mediumtext COMMENT 'item body content',
+	`location` varchar(255) NOT NULL DEFAULT '' COMMENT 'text location where this item originated',
+	`coord` varchar(255) NOT NULL DEFAULT '' COMMENT 'longitude/latitude pair representing location where this item originated',
+	`app` varchar(255) NOT NULL DEFAULT '' COMMENT 'application which generated this item',
+	`rendered-hash` varchar(32) NOT NULL DEFAULT '' COMMENT '',
+	`rendered-html` mediumtext COMMENT 'item.body converted to html',
+	`object-type` varchar(100) NOT NULL DEFAULT '' COMMENT 'ActivityStreams object type',
+	`object` text COMMENT 'JSON encoded object structure unless it is an implied object (normal post)',
+	`target-type` varchar(100) NOT NULL DEFAULT '' COMMENT 'ActivityStreams target type if applicable (URI)',
+	`target` text COMMENT 'JSON encoded target structure if used',
+	`plink` varchar(255) NOT NULL DEFAULT '' COMMENT 'permalink or URL to a displayable copy of the message at its source',
+	 PRIMARY KEY(`id`),
+	 UNIQUE INDEX `uri-plink-hash` (`uri-plink-hash`),
+	 INDEX `uri` (`uri`(191))
+) DEFAULT COLLATE utf8mb4_general_ci COMMENT='Content for all posts';
 
 --
 -- TABLE locks

--- a/mod/community.php
+++ b/mod/community.php
@@ -189,9 +189,10 @@ function community_content(App $a, $update = 0)
 function community_getitems($start, $itemspage, $content)
 {
 	if ($content == 'local') {
-		$r = dba::p("SELECT `item`.`uri`, `item`.`author-link` FROM `thread`
+		$r = dba::p("SELECT `item`.`uri`, `author`.`url` AS `author-link` FROM `thread`
 			INNER JOIN `user` ON `user`.`uid` = `thread`.`uid` AND NOT `user`.`hidewall`
 			INNER JOIN `item` ON `item`.`id` = `thread`.`iid`
+			INNER JOIN `contact` AS `author` ON `author`.`id`=`item`.`author-id`
 			WHERE `thread`.`visible` AND NOT `thread`.`deleted` AND NOT `thread`.`moderated`
 			AND NOT `thread`.`private` AND `thread`.`wall` AND `thread`.`origin`
 			ORDER BY `thread`.`commented` DESC LIMIT " . intval($start) . ", " . intval($itemspage)
@@ -200,7 +201,7 @@ function community_getitems($start, $itemspage, $content)
 	} elseif ($content == 'global') {
 		$r = dba::p("SELECT `uri` FROM `thread`
 				INNER JOIN `item` ON `item`.`id` = `thread`.`iid`
-		                INNER JOIN `contact` AS `author` ON `author`.`id`=`item`.`author-id`
+				INNER JOIN `contact` AS `author` ON `author`.`id`=`item`.`author-id`
 				WHERE `thread`.`uid` = 0 AND NOT `author`.`hidden` AND NOT `author`.`blocked`
 				ORDER BY `thread`.`commented` DESC LIMIT " . intval($start) . ", " . intval($itemspage));
 		return dba::inArray($r);

--- a/mod/item.php
+++ b/mod/item.php
@@ -93,9 +93,9 @@ function item_post(App $a) {
 
 	if ($thr_parent || $thr_parent_uri) {
 		if ($thr_parent) {
-			$parent_item = dba::selectFirst('item', [], ['id' => $thr_parent]);
+			$parent_item = Item::selectFirst([], ['id' => $thr_parent]);
 		} elseif ($thr_parent_uri) {
-			$parent_item = dba::selectFirst('item', [], ['uri' => $thr_parent_uri, 'uid' => $profile_uid]);
+			$parent_item = Item::selectFirst([], ['uri' => $thr_parent_uri, 'uid' => $profile_uid]);
 		}
 
 		// if this isn't the real parent of the conversation, find it

--- a/src/Database/DBStructure.php
+++ b/src/Database/DBStructure.php
@@ -1181,6 +1181,7 @@ class DBStructure
 						"author-name" => ["type" => "varchar(255)", "not null" => "1", "default" => "", "comment" => "Name of the author of this item"],
 						"author-link" => ["type" => "varchar(255)", "not null" => "1", "default" => "", "comment" => "Link to the profile page of the author of this item"],
 						"author-avatar" => ["type" => "varchar(255)", "not null" => "1", "default" => "", "comment" => "Link to the avatar picture of the author of this item"],
+						"icid" => ["type" => "int unsigned", "relation" => ["item-content" => "id"], "comment" => "Id of the item-content table entry that contains the whole item content"],
 						"title" => ["type" => "varchar(255)", "not null" => "1", "default" => "", "comment" => "item title"],
 						"content-warning" => ["type" => "varchar(255)", "not null" => "1", "default" => "", "comment" => ""],
 						"body" => ["type" => "mediumtext", "comment" => "item body content"],
@@ -1247,8 +1248,6 @@ class DBStructure
 						"deleted_changed" => ["deleted","changed"],
 						"uid_wall_changed" => ["uid","wall","changed"],
 						"uid_eventid" => ["uid","event-id"],
-						"uid_authorlink" => ["uid","author-link(190)"],
-						"uid_ownerlink" => ["uid","owner-link(190)"],
 						]
 				];
 		$database["item-content"] = [

--- a/src/Database/DBStructure.php
+++ b/src/Database/DBStructure.php
@@ -1154,7 +1154,7 @@ class DBStructure
 						]
 				];
 		$database["item"] = [
-				"comment" => "All posts",
+				"comment" => "Structure for all posts",
 				"fields" => [
 						"id" => ["type" => "int unsigned", "not null" => "1", "extra" => "auto_increment", "primary" => "1", "relation" => ["thread" => "iid"]],
 						"guid" => ["type" => "varchar(255)", "not null" => "1", "default" => "", "comment" => "A unique identifier for this item"],
@@ -1249,6 +1249,32 @@ class DBStructure
 						"uid_eventid" => ["uid","event-id"],
 						"uid_authorlink" => ["uid","author-link(190)"],
 						"uid_ownerlink" => ["uid","owner-link(190)"],
+						]
+				];
+		$database["item-content"] = [
+				"comment" => "Content for all posts",
+				"fields" => [
+						"id" => ["type" => "int unsigned", "not null" => "1", "extra" => "auto_increment", "primary" => "1", "relation" => ["thread" => "iid"]],
+						"uri" => ["type" => "varchar(255)", "not null" => "1", "default" => "", "comment" => ""],
+						"uri-plink-hash" => ["type" => "char(80)", "not null" => "1", "default" => "", "comment" => "SHA-1 hash from uri and plink"],
+						"title" => ["type" => "varchar(255)", "not null" => "1", "default" => "", "comment" => "item title"],
+						"content-warning" => ["type" => "varchar(255)", "not null" => "1", "default" => "", "comment" => ""],
+						"body" => ["type" => "mediumtext", "comment" => "item body content"],
+						"location" => ["type" => "varchar(255)", "not null" => "1", "default" => "", "comment" => "text location where this item originated"],
+						"coord" => ["type" => "varchar(255)", "not null" => "1", "default" => "", "comment" => "longitude/latitude pair representing location where this item originated"],
+						"app" => ["type" => "varchar(255)", "not null" => "1", "default" => "", "comment" => "application which generated this item"],
+						"rendered-hash" => ["type" => "varchar(32)", "not null" => "1", "default" => "", "comment" => ""],
+						"rendered-html" => ["type" => "mediumtext", "comment" => "item.body converted to html"],
+						"object-type" => ["type" => "varchar(100)", "not null" => "1", "default" => "", "comment" => "ActivityStreams object type"],
+						"object" => ["type" => "text", "comment" => "JSON encoded object structure unless it is an implied object (normal post)"],
+						"target-type" => ["type" => "varchar(100)", "not null" => "1", "default" => "", "comment" => "ActivityStreams target type if applicable (URI)"],
+						"target" => ["type" => "text", "comment" => "JSON encoded target structure if used"],
+						"plink" => ["type" => "varchar(255)", "not null" => "1", "default" => "", "comment" => "permalink or URL to a displayable copy of the message at its source"],
+						],
+				"indexes" => [
+						"PRIMARY" => ["id"],
+						"uri-plink-hash" => ["UNIQUE", "uri-plink-hash"],
+						"uri" => ["uri(191)"],
 						]
 				];
 		$database["locks"] = [

--- a/src/Database/DBStructure.php
+++ b/src/Database/DBStructure.php
@@ -1248,6 +1248,7 @@ class DBStructure
 						"deleted_changed" => ["deleted","changed"],
 						"uid_wall_changed" => ["uid","wall","changed"],
 						"uid_eventid" => ["uid","event-id"],
+						"icid" => ["icid"],
 						]
 				];
 		$database["item-content"] = [

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -1705,7 +1705,7 @@ class Item extends BaseObject
 	 */
 	public static function addShadowPost($itemid)
 	{
-		$item = dba::selectFirst('item', [], ['id' => $itemid]);
+		$item = self::selectFirst(self::ITEM_FIELDLIST, ['id' => $itemid]);
 		if (!DBM::is_result($item)) {
 			return;
 		}

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -56,9 +56,23 @@ class Item extends BaseObject
 			'author-id', 'author-link', 'owner-link', 'contact-uid',
 			'signed_text', 'signature', 'signer'];
 
+	// Field list for "item-content" table that is mixed with the item table
 	const CONTENT_FIELDLIST = ['title', 'content-warning', 'body', 'location',
 			'coord', 'app', 'rendered-hash', 'rendered-html',
 			'object-type', 'object', 'target-type', 'target'];
+
+	// All fields in the item table
+	const ITEM_FIELDLIST = ['id', 'uid', 'parent', 'uri', 'parent-uri', 'thr-parent', 'guid',
+			'contact-id', 'type', 'wall', 'gravity', 'extid', 'icid',
+			'created', 'edited', 'commented', 'received', 'changed', 'verb',
+			'postopts', 'plink', 'resource-id', 'event-id', 'tag', 'attach', 'inform',
+			'file', 'allow_cid', 'allow_gid', 'deny_cid', 'deny_gid',
+			'private', 'pubmail', 'moderated', 'visible', 'starred', 'bookmark',
+			'unseen', 'deleted', 'origin', 'forum_mode', 'mention', 'global', 'network',
+			'title', 'content-warning', 'body', 'location', 'coord', 'app',
+			'rendered-hash', 'rendered-html', 'object-type', 'object', 'target-type', 'target',
+			'author-id', 'author-link', 'author-name', 'author-avatar',
+			'owner-id', 'owner-link', 'owner-name', 'owner-avatar'];
 
 	/**
 	 * @brief Fetch a single item row
@@ -1523,18 +1537,9 @@ class Item extends BaseObject
 		$condition = ['id' => $itemid, 'uid' => 0,
 			'network' => [NETWORK_DFRN, NETWORK_DIASPORA, NETWORK_OSTATUS, ""],
 			'visible' => true, 'deleted' => false, 'moderated' => false, 'private' => false];
-		$item = dba::selectFirst('item', [], ['id' => $itemid]);
+		$item = self::selectFirst(self::ITEM_FIELDLIST, ['id' => $itemid]);
 		if (!DBM::is_result($item)) {
 			return;
-		}
-
-		$fields = self::CONTENT_FIELDLIST;
-		$fields[] = 'author-link';
-		$fields[] = 'owner-link';
-
-		$content = self::selectFirst($fields, ['id' => $itemid]);
-		if (DBM::is_result($content)) {
-			$item = array_merge($item, $content);
 		}
 
 		unset($item['id']);
@@ -1658,16 +1663,7 @@ class Item extends BaseObject
 			return;
 		}
 
-		$item = dba::selectFirst('item', [], ['id' => $itemid]);
-
-		$fields = self::CONTENT_FIELDLIST;
-		$fields[] = 'author-link';
-		$fields[] = 'owner-link';
-
-		$content = self::selectFirst($fields, ['id' => $itemid]);
-		if (DBM::is_result($content)) {
-			$item = array_merge($item, $content);
-		}
+		$item = self::selectFirst(self::ITEM_FIELDLIST, ['id' => $itemid]);
 
 		if (DBM::is_result($item) && ($item["allow_cid"] == '') && ($item["allow_gid"] == '') &&
 			($item["deny_cid"] == '') && ($item["deny_gid"] == '')) {

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -1528,8 +1528,6 @@ class Item extends BaseObject
 		unset($item['wall']);
 		unset($item['origin']);
 		unset($item['starred']);
-		unset($item['rendered-hash']);
-		unset($item['rendered-html']);
 
 		$users = [];
 
@@ -1659,8 +1657,6 @@ class Item extends BaseObject
 				unset($item['mention']);
 				unset($item['origin']);
 				unset($item['starred']);
-				unset($item['rendered-hash']);
-				unset($item['rendered-html']);
 				if ($item['uri'] == $item['parent-uri']) {
 					$item['contact-id'] = Contact::getIdForURL($item['owner-link']);
 				} else {
@@ -1727,8 +1723,6 @@ class Item extends BaseObject
 		unset($item['mention']);
 		unset($item['origin']);
 		unset($item['starred']);
-		unset($item['rendered-hash']);
-		unset($item['rendered-html']);
 		$item['contact-id'] = Contact::getIdForURL($item['author-link']);
 
 		if (in_array($item['type'], ["net-comment", "wall-comment"])) {
@@ -2696,9 +2690,9 @@ EOT;
 
 	private static function updateThread($itemid, $setmention = false)
 	{
-		$fields = ['uid', 'guid', 'title', 'body', 'created', 'edited', 'commented', 'received', 'changed',
+		$fields = ['uid', 'guid', 'created', 'edited', 'commented', 'received', 'changed',
 			'wall', 'private', 'pubmail', 'moderated', 'visible', 'starred', 'bookmark', 'contact-id',
-			'deleted', 'origin', 'forum_mode', 'network', 'author-id', 'owner-id', 'rendered-html', 'rendered-hash'];
+			'deleted', 'origin', 'forum_mode', 'network', 'author-id', 'owner-id'];
 		$condition = ["`id` = ? AND (`parent` = ? OR `parent` = 0)", $itemid, $itemid];
 
 		$item = dba::selectFirst('item', $fields, $condition);
@@ -2715,7 +2709,7 @@ EOT;
 		$fields = [];
 
 		foreach ($item as $field => $data) {
-			if (!in_array($field, ["guid", "title", "body", "rendered-html", "rendered-hash"])) {
+			if (!in_array($field, ["guid"])) {
 				$fields[$field] = $data;
 			}
 		}
@@ -2723,19 +2717,6 @@ EOT;
 		$result = dba::update('thread', $fields, ['iid' => $itemid]);
 
 		logger("Update thread for item ".$itemid." - guid ".$item["guid"]." - ".(int)$result, LOGGER_DEBUG);
-
-		// Updating a shadow item entry
-		$items = dba::selectFirst('item', ['id'], ['guid' => $item['guid'], 'uid' => 0]);
-
-		if (!DBM::is_result($items)) {
-			return;
-		}
-
-		$fields = ['title' => $item['title'], 'body' => $item['body'],
-			'rendered-html' => $item['rendered-html'], 'rendered-hash' => $item['rendered-hash']];
-		$result = dba::update('item', $fields, ['id' => $items['id']]);
-
-		logger("Updating public shadow for post ".$items["id"]." - guid ".$item["guid"]." Result: ".print_r($result, true), LOGGER_DEBUG);
 	}
 
 	private static function deleteThread($itemid, $itemuri = "")

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -1485,7 +1485,7 @@ class Item extends BaseObject
 		$item_content = dba::selectFirst('item-content', ['id'], ['uri' => $item['uri']]);
 		if (DBM::is_result($item_content)) {
 			$item['icid'] = $item_content['id'];
-			logger('Insert content for URI '.$item['uri'].' ('.$item['icid'].')');
+			logger('Insert content for URI ' . $item['uri'] . ' (' . $item['icid'] . ')');
 		}
 	}
 
@@ -1511,10 +1511,10 @@ class Item extends BaseObject
 
 		if (!empty($item['plink'])) {
 			$fields['plink'] = $item['plink'];
-			$fields['uri-plink-hash'] = hash('sha1', $item['plink']).hash('sha1', $condition['uri']);
+			$fields['uri-plink-hash'] = hash('sha1', $item['plink']) . hash('sha1', $condition['uri']);
 		}
 
-		logger('Update content for URI '.$condition['uri']);
+		logger('Update content for URI ' . $condition['uri']);
 
 		dba::update('item-content', $fields, $condition, true);
 	}

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -1075,11 +1075,12 @@ class Item extends BaseObject
 			return 0;
 		}
 
-		//unset($item['author-link']);
+		// These fields aren't stored anymore in the item table, they are fetched upon request
+		unset($item['author-link']);
 		unset($item['author-name']);
 		unset($item['author-avatar']);
 
-		//unset($item['owner-link']);
+		unset($item['owner-link']);
 		unset($item['owner-name']);
 		unset($item['owner-avatar']);
 

--- a/src/Worker/Expire.php
+++ b/src/Worker/Expire.php
@@ -26,9 +26,12 @@ class Expire {
 		if ($param == 'delete') {
 			logger('Delete expired items', LOGGER_DEBUG);
 			// physically remove anything that has been deleted for more than two months
-			$r = dba::p("SELECT `id` FROM `item` WHERE `deleted` AND `changed` < UTC_TIMESTAMP() - INTERVAL 60 DAY");
+			$r = dba::p("SELECT `id`, `icid` FROM `item` WHERE `deleted` AND `changed` < UTC_TIMESTAMP() - INTERVAL 60 DAY");
 			while ($row = dba::fetch($r)) {
 				dba::delete('item', ['id' => $row['id']]);
+				if (!dba::exists('item', ['icid' => $row['icid']])) {
+					dba::delete('item-content', ['id' => $row['icid']]);
+				}
 			}
 			dba::close($r);
 


### PR DESCRIPTION
I beg your attention and some drum-roll please ;-)

With this PR we now store the item content in the table "item-content" and not in the item table anymore. There is no conversion routine, so it will have an impact on new posts only.

By this time we will keep the old fields in the item table. Maybe one time we will remove the fields completely - but not now.

This is not the end of the story, there are still several fields in the item table that I want to relocate or replace. Additionally the code in the item table can be made slimmer somewhere in the future as well.