### PR TITLE
Urgent bugfix: Fixes comments to Diaspora / empty posts

### DIFF
--- a/mod/item.php
+++ b/mod/item.php
@@ -737,7 +737,7 @@ function item_post(App $a) {
 		goaway($return_path);
 	}
 
-	$datarray = dba::selectFirst('item', [], ['id' => $post_id]);
+	$datarray = Item::selectFirst(Item::ITEM_FIELDLIST, ['id' => $post_id]);
 
 	if (!DBM::is_result($datarray)) {
 		logger("Item with id ".$post_id." couldn't be fetched.");

--- a/src/Worker/SetItemContentID.php
+++ b/src/Worker/SetItemContentID.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * @file src/Worker/SetItemContentID.php
+ * @brief This script sets the "icid" value in the item table if it couldn't set before.
+ *
+ * This script is started from mod/item.php to fix timing problems.
+ */
+
+namespace Friendica\Worker;
+
+use Friendica\Model\Item;
+
+class SetItemContentID {
+	public static function execute($uri = '') {
+		if (empty($uri)) {
+			return;
+		}
+
+		Item::setICIDforURI($uri);
+	}
+}


### PR DESCRIPTION
The last PRs had created a problem where comments wouldn't be transmitted to Diaspora anymore.

Additionally sometimes empty posts had been received. Hopefully this solves it as well.

And finally it fixed the wrong links to the original source of posts.