### PR TITLE
Use already fetched data for magiclink

### DIFF
--- a/include/conversation.php
+++ b/include/conversation.php
@@ -262,14 +262,20 @@ function localize_item(&$item)
 	}
 
 	if (activity_match($item['verb'], ACTIVITY_TAG)) {
-		$fields = ['author-link', 'author-name', 'verb', 'object-type', 'resource-id', 'body', 'plink'];
+		$fields = ['author-id', 'author-link', 'author-name', 'author-network',
+			'verb', 'object-type', 'resource-id', 'body', 'plink'];
 		$obj = Item::selectFirst($fields, ['uri' => $item['parent-uri']]);
 		if (!DBM::is_result($obj)) {
 			return;
 		}
 
-		$author  = '[url=' . Contact::magicLinkById($item['author-id']) . ']' . $item['author-name'] . '[/url]';
-		$objauthor =  '[url=' . Contact::magicLinkById($obj['author-id']) . ']' . $obj['author-name'] . '[/url]';
+		$author_arr = ['uid' => 0, 'id' => $item['author-id'],
+			'network' => $item['author-network'], 'url' => $item['author-link']];
+		$author  = '[url=' . Contact::magicLinkByContact($author_arr) . ']' . $item['author-name'] . '[/url]';
+
+		$author_arr = ['uid' => 0, 'id' => $obj['author-id'],
+			'network' => $obj['author-network'], 'url' => $obj['author-link']];
+		$objauthor  = '[url=' . Contact::magicLinkByContact($author_arr) . ']' . $obj['author-name'] . '[/url]';
 
 		switch ($obj['verb']) {
 			case ACTIVITY_POST:
@@ -341,7 +347,9 @@ function localize_item(&$item)
 	}
 
 	// add sparkle links to appropriate permalinks
-	$item['plink'] = Contact::magicLinkById($item['author-id'], $item['plink']);
+	$author = ['uid' => 0, 'id' => $item['author-id'],
+		'network' => $item['author-network'], 'url' => $item['author-link']];
+	$item['plink'] = Contact::magicLinkbyContact($author, $item['plink']);
 }
 
 /**
@@ -569,7 +577,9 @@ function conversation(App $a, $items, $mode, $update, $preview = false, $order =
 
 				$tags = \Friendica\Model\Term::populateTagsFromItem($item);
 
-				$profile_link = Contact::magicLinkbyId($item['author-id']);
+				$author = ['uid' => 0, 'id' => $item['author-id'],
+					'network' => $item['author-network'], 'url' => $item['author-link']];
+				$profile_link = Contact::magicLinkbyContact($author);
 
 				if (strpos($profile_link, 'redir/') === 0) {
 					$sparkle = ' sparkle';
@@ -803,7 +813,9 @@ function item_photo_menu($item) {
 		$sub_link = 'javascript:dosubthread(' . $item['id'] . '); return false;';
 	}
 
-	$profile_link = Contact::magicLinkById($item['author-id']);
+	$author = ['uid' => 0, 'id' => $item['author-id'],
+		'network' => $item['author-network'], 'url' => $item['author-link']];
+	$profile_link = Contact::magicLinkbyContact($author);
 	$sparkle = (strpos($profile_link, 'redir/') === 0);
 
 	$cid = 0;
@@ -908,7 +920,9 @@ function builtin_activity_puller($item, &$conv_responses) {
 		}
 
 		if (activity_match($item['verb'], $verb) && ($item['id'] != $item['parent'])) {
-			$url = Contact::MagicLinkbyId($item['author-id']);
+			$author = ['uid' => 0, 'id' => $item['author-id'],
+				'network' => $item['author-network'], 'url' => $item['author-link']];
+			$url = Contact::magicLinkbyContact($author);
 			if (strpos($url, 'redir/') === 0) {
 				$sparkle = ' class="sparkle" ';
 			}

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -1732,8 +1732,21 @@ class Contact extends BaseObject
 	 */
 	public static function magicLinkbyId($cid, $url = '')
 	{
-		$contact = dba::selectFirst('contact', ['network', 'url', 'uid'], ['id' => $cid]);
+		$contact = dba::selectFirst('contact', ['id', 'network', 'url', 'uid'], ['id' => $cid]);
 
+		return self::magicLinkbyContact($contact, $url);
+        }
+
+	/**
+	 * @brief Returns a magic link to authenticate remote visitors
+	 *
+	 * @param array $contact The contact array with "uid", "network" and "url"
+	 * @param integer $url An url that we will be redirected to after the authentication
+	 *
+	 * @return string with "redir" link
+	 */
+	public static function magicLinkbyContact($contact, $url = '')
+	{
 		if ($contact['network'] != NETWORK_DFRN) {
 			return $url ?: $contact['url']; // Equivalent to ($url != '') ? $url : $contact['url'];
 		}
@@ -1747,7 +1760,7 @@ class Contact extends BaseObject
 			return self::magicLink($contact['url'], $url);
 		}
 
-		$redirect = 'redir/' . $cid;
+		$redirect = 'redir/' . $contact['id'];
 
 		if ($url != '') {
 			$redirect .= '?url=' . $url;

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -40,8 +40,8 @@ class Item extends BaseObject
 			'wall', 'private', 'starred', 'origin', 'title', 'body', 'file', 'attach', 'language',
 			'content-warning', 'location', 'coord', 'app', 'rendered-hash', 'rendered-html', 'object',
 			'allow_cid', 'allow_gid', 'deny_cid', 'deny_gid', 'item_id',
-			'author-id', 'author-link', 'author-name', 'author-avatar',
-			'owner-id', 'owner-link', 'owner-name', 'owner-avatar',
+			'author-id', 'author-link', 'author-name', 'author-avatar', 'author-network',
+			'owner-id', 'owner-link', 'owner-name', 'owner-avatar', 'owner-network',
 			'contact-id', 'contact-link', 'contact-name', 'contact-avatar',
 			'writable', 'self', 'cid', 'alias',
 			'event-id', 'event-created', 'event-edited', 'event-start', 'event-finish',
@@ -422,10 +422,10 @@ class Item extends BaseObject
 		$fields['item-content'] = array_merge(self::CONTENT_FIELDLIST, self::MIXED_CONTENT_FIELDLIST);
 
 		$fields['author'] = ['url' => 'author-link', 'name' => 'author-name',
-			'thumb' => 'author-avatar', 'nick' => 'author-nick'];
+			'thumb' => 'author-avatar', 'nick' => 'author-nick', 'network' => 'author-network'];
 
 		$fields['owner'] = ['url' => 'owner-link', 'name' => 'owner-name',
-			'thumb' => 'owner-avatar', 'nick' => 'owner-nick'];
+			'thumb' => 'owner-avatar', 'nick' => 'owner-nick', 'network' => 'owner-network'];
 
 		$fields['contact'] = ['url' => 'contact-link', 'name' => 'contact-name', 'thumb' => 'contact-avatar',
 			'writable', 'self', 'id' => 'cid', 'alias', 'uid' => 'contact-uid',

--- a/src/Model/Term.php
+++ b/src/Model/Term.php
@@ -237,7 +237,9 @@ class Term
 
 			$orig_tag = $tag["url"];
 
-			$tag["url"] = Contact::magicLinkById($item['author-id'], $tag['url']);
+			$author = ['uid' => 0, 'id' => $item['author-id'],
+				'network' => $item['author-network'], 'url' => $item['author-link']];
+			$tag["url"] = Contact::magicLinkByContact($author, $tag['url']);
 
 			if ($tag["type"] == TERM_HASHTAG) {
 				if ($orig_tag != $tag["url"]) {

--- a/src/Object/Post.php
+++ b/src/Object/Post.php
@@ -70,8 +70,10 @@ class Post extends BaseObject
 		}
 
 		$this->writable = $this->getDataValue('writable') || $this->getDataValue('self');
-		$this->redirect_url = Contact::magicLinkById($this->getDataValue('cid'));
-
+		$author = ['uid' => 0, 'id' => $this->getDataValue('author-id'),
+			'network' => $this->getDataValue('author-network'),
+			'url' => $this->getDataValue('author-link')];
+		$this->redirect_url = Contact::magicLinkbyContact($author);
 		if (!$this->isToplevel()) {
 			$this->threaded = true;
 		}
@@ -203,7 +205,9 @@ class Post extends BaseObject
 			$profile_name = $item['author-link'];
 		}
 
-		$profile_link = Contact::magicLinkById($item['author-id']);
+		$author = ['uid' => 0, 'id' => $item['author-id'],
+			'network' => $item['author-network'], 'url' => $item['author-link']];
+		$profile_link = Contact::magicLinkbyContact($author);
 		if (strpos($profile_link, 'redir/') === 0) {
 			$sparkle = ' sparkle';
 		}
@@ -839,7 +843,7 @@ class Post extends BaseObject
 					$alias_linkmatch = (($this->getDataValue('alias')) && link_compare($this->getDataValue('alias'), $this->getDataValue('author-link')));
 					$owner_namematch = (($this->getDataValue('owner-name')) && $this->getDataValue('owner-name') == $this->getDataValue('author-name'));
 
-					if ((!$owner_linkmatch) && (!$alias_linkmatch) && (!$owner_namematch)) {
+					if (!$owner_linkmatch && !$alias_linkmatch && !$owner_namematch) {
 						// The author url doesn't match the owner (typically the contact)
 						// and also doesn't match the contact alias.
 						// The name match is a hack to catch several weird cases where URLs are
@@ -852,7 +856,11 @@ class Post extends BaseObject
 						$this->owner_photo = $this->getDataValue('owner-avatar');
 						$this->owner_name = $this->getDataValue('owner-name');
 						$this->wall_to_wall = true;
-						$this->owner_url = Contact::magicLinkById($this->getDataValue('owner-id'));
+
+						$owner = ['uid' => 0, 'id' => $this->getDataValue('owner-id'),
+							'network' => $this->getDataValue('owner-network'),
+							'url' => $this->getDataValue('ownerr-link')];
+						$this->owner_url = Contact::magicLinkbyContact($owner);
 					}
 				}
 			}


### PR DESCRIPTION
Mostly we do have all data that is needed for the magic link. This means that we can remove unneeded sql queries - which improves page load speed.

Additionally this fixes a problem with some bad link in the "x tagged y status" message.