### PR TITLE
Lock Abstraction FollowUp #5291

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -41,7 +41,7 @@ define('FRIENDICA_PLATFORM',     'Friendica');
 define('FRIENDICA_CODENAME',     'The Tazmans Flax-lily');
 define('FRIENDICA_VERSION',      '2018.08-dev');
 define('DFRN_PROTOCOL_VERSION',  '2.23');
-define('DB_UPDATE_VERSION',      1274);
+define('DB_UPDATE_VERSION',      1275);
 define('NEW_UPDATE_ROUTINE_VERSION', 1170);
 
 /**

--- a/src/Core/Cache/AbstractCacheDriver.php
+++ b/src/Core/Cache/AbstractCacheDriver.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Friendica\Core\Cache;
+use Friendica\BaseObject;
+
+
+/**
+ * Abstract class for common used functions
+ *
+ * Class AbstractCacheDriver
+ *
+ * @package Friendica\Core\Cache
+ */
+abstract class AbstractCacheDriver extends BaseObject implements IMemoryCacheDriver
+{
+	/**
+	 * @param string $key	The original key
+	 * @return string		The cache key used for the cache
+	 */
+	protected function getCacheKey($key) {
+		return self::getApp()->get_hostname() . ":" . $key;
+	}
+}

--- a/src/Core/Cache/AbstractCacheDriver.php
+++ b/src/Core/Cache/AbstractCacheDriver.php
@@ -11,7 +11,7 @@ use Friendica\BaseObject;
  *
  * @package Friendica\Core\Cache
  */
-abstract class AbstractCacheDriver extends BaseObject implements IMemoryCacheDriver
+abstract class AbstractCacheDriver extends BaseObject
 {
 	/**
 	 * @param string $key	The original key

--- a/src/Core/Cache/ArrayCache.php
+++ b/src/Core/Cache/ArrayCache.php
@@ -12,7 +12,7 @@ use Friendica\Core\Cache;
  *
  * @package Friendica\Core\Cache
  */
-class ArrayCache implements IMemoryCacheDriver
+class ArrayCache extends AbstractCacheDriver
 {
 	use TraitCompareDelete;
 

--- a/src/Core/Cache/ArrayCache.php
+++ b/src/Core/Cache/ArrayCache.php
@@ -12,7 +12,7 @@ use Friendica\Core\Cache;
  *
  * @package Friendica\Core\Cache
  */
-class ArrayCache extends AbstractCacheDriver
+class ArrayCache extends AbstractCacheDriver implements IMemoryCacheDriver
 {
 	use TraitCompareDelete;
 

--- a/src/Core/Cache/DatabaseCacheDriver.php
+++ b/src/Core/Cache/DatabaseCacheDriver.php
@@ -12,7 +12,7 @@ use Friendica\Util\DateTimeFormat;
  *
  * @author Hypolite Petovan <mrpetovan@gmail.com>
  */
-class DatabaseCacheDriver implements ICacheDriver
+class DatabaseCacheDriver extends AbstractCacheDriver implements ICacheDriver
 {
 	public function get($key)
 	{

--- a/src/Core/Cache/MemcacheCacheDriver.php
+++ b/src/Core/Cache/MemcacheCacheDriver.php
@@ -2,7 +2,6 @@
 
 namespace Friendica\Core\Cache;
 
-use Friendica\BaseObject;
 use Friendica\Core\Cache;
 
 /**
@@ -10,7 +9,7 @@ use Friendica\Core\Cache;
  *
  * @author Hypolite Petovan <mrpetovan@gmail.com>
  */
-class MemcacheCacheDriver extends BaseObject implements IMemoryCacheDriver
+class MemcacheCacheDriver extends AbstractCacheDriver
 {
 	use TraitCompareSet;
 	use TraitCompareDelete;
@@ -39,9 +38,10 @@ class MemcacheCacheDriver extends BaseObject implements IMemoryCacheDriver
 	public function get($key)
 	{
 		$return = null;
+		$cachekey = $this->getCacheKey($key);
 
 		// We fetch with the hostname as key to avoid problems with other applications
-		$cached = $this->memcache->get(self::getApp()->get_hostname() . ':' . $key);
+		$cached = $this->memcache->get($cachekey);
 
 		// @see http://php.net/manual/en/memcache.get.php#84275
 		if (is_bool($cached) || is_double($cached) || is_long($cached)) {
@@ -65,17 +65,19 @@ class MemcacheCacheDriver extends BaseObject implements IMemoryCacheDriver
 	 */
 	public function set($key, $value, $ttl = Cache::FIVE_MINUTES)
 	{
+		$cachekey = $this->getCacheKey($key);
+
 		// We store with the hostname as key to avoid problems with other applications
 		if ($ttl > 0) {
 			return $this->memcache->set(
-				self::getApp()->get_hostname() . ":" . $key,
+				$cachekey,
 				serialize($value),
 				MEMCACHE_COMPRESSED,
 				time() + $ttl
 			);
 		} else {
 			return $this->memcache->set(
-				self::getApp()->get_hostname() . ":" . $key,
+				$cachekey,
 				serialize($value),
 				MEMCACHE_COMPRESSED
 			);
@@ -87,7 +89,8 @@ class MemcacheCacheDriver extends BaseObject implements IMemoryCacheDriver
 	 */
 	public function delete($key)
 	{
-		return $this->memcache->delete($key);
+		$cachekey = $this->getCacheKey($key);
+		return $this->memcache->delete($cachekey);
 	}
 
 	/**
@@ -103,6 +106,7 @@ class MemcacheCacheDriver extends BaseObject implements IMemoryCacheDriver
 	 */
 	public function add($key, $value, $ttl = Cache::FIVE_MINUTES)
 	{
-		return $this->memcache->add(self::getApp()->get_hostname() . ":" . $key, $value, $ttl);
+		$cachekey = $this->getCacheKey($key);
+		return $this->memcache->add($cachekey, $value, $ttl);
 	}
 }

--- a/src/Core/Cache/MemcacheCacheDriver.php
+++ b/src/Core/Cache/MemcacheCacheDriver.php
@@ -9,7 +9,7 @@ use Friendica\Core\Cache;
  *
  * @author Hypolite Petovan <mrpetovan@gmail.com>
  */
-class MemcacheCacheDriver extends AbstractCacheDriver
+class MemcacheCacheDriver extends AbstractCacheDriver implements IMemoryCacheDriver
 {
 	use TraitCompareSet;
 	use TraitCompareDelete;

--- a/src/Core/Cache/MemcachedCacheDriver.php
+++ b/src/Core/Cache/MemcachedCacheDriver.php
@@ -2,7 +2,6 @@
 
 namespace Friendica\Core\Cache;
 
-use Friendica\BaseObject;
 use Friendica\Core\Cache;
 
 /**
@@ -10,7 +9,7 @@ use Friendica\Core\Cache;
  *
  * @author Hypolite Petovan <mrpetovan@gmail.com>
  */
-class MemcachedCacheDriver extends BaseObject implements IMemoryCacheDriver
+class MemcachedCacheDriver extends AbstractCacheDriver
 {
 	use TraitCompareSet;
 	use TraitCompareDelete;
@@ -38,9 +37,10 @@ class MemcachedCacheDriver extends BaseObject implements IMemoryCacheDriver
 	public function get($key)
 	{
 		$return = null;
+		$cachekey = $this->getCacheKey($key);
 
 		// We fetch with the hostname as key to avoid problems with other applications
-		$value = $this->memcached->get(self::getApp()->get_hostname() . ':' . $key);
+		$value = $this->memcached->get($cachekey);
 
 		if ($this->memcached->getResultCode() === \Memcached::RES_SUCCESS) {
 			$return = $value;
@@ -51,16 +51,18 @@ class MemcachedCacheDriver extends BaseObject implements IMemoryCacheDriver
 
 	public function set($key, $value, $ttl = Cache::FIVE_MINUTES)
 	{
+		$cachekey = $this->getCacheKey($key);
+
 		// We store with the hostname as key to avoid problems with other applications
 		if ($ttl > 0) {
 			return $this->memcached->set(
-				self::getApp()->get_hostname() . ':' . $key,
+				$cachekey,
 				$value,
 				time() + $ttl
 			);
 		} else {
 			return $this->memcached->set(
-				self::getApp()->get_hostname() . ':' . $key,
+				$cachekey,
 				$value
 			);
 		}
@@ -69,9 +71,8 @@ class MemcachedCacheDriver extends BaseObject implements IMemoryCacheDriver
 
 	public function delete($key)
 	{
-		$return = $this->memcached->delete(self::getApp()->get_hostname() . ':' . $key);
-
-		return $return;
+		$cachekey = $this->getCacheKey($key);
+		return $this->memcached->delete($cachekey);
 	}
 
 	public function clear()
@@ -89,6 +90,7 @@ class MemcachedCacheDriver extends BaseObject implements IMemoryCacheDriver
 	 */
 	public function add($key, $value, $ttl = Cache::FIVE_MINUTES)
 	{
-		return $this->memcached->add(self::getApp()->get_hostname() . ":" . $key, $value, $ttl);
+		$cachekey = $this->getCacheKey($key);
+		return $this->memcached->add($cachekey, $value, $ttl);
 	}
 }

--- a/src/Core/Cache/MemcachedCacheDriver.php
+++ b/src/Core/Cache/MemcachedCacheDriver.php
@@ -9,7 +9,7 @@ use Friendica\Core\Cache;
  *
  * @author Hypolite Petovan <mrpetovan@gmail.com>
  */
-class MemcachedCacheDriver extends AbstractCacheDriver
+class MemcachedCacheDriver extends AbstractCacheDriver implements IMemoryCacheDriver
 {
 	use TraitCompareSet;
 	use TraitCompareDelete;

--- a/src/Core/Cache/RedisCacheDriver.php
+++ b/src/Core/Cache/RedisCacheDriver.php
@@ -10,7 +10,7 @@ use Friendica\Core\Cache;
  * @author Hypolite Petovan <mrpetovan@gmail.com>
  * @author Roland Haeder <roland@mxchange.org>
  */
-class RedisCacheDriver extends AbstractCacheDriver
+class RedisCacheDriver extends AbstractCacheDriver implements IMemoryCacheDriver
 {
 	/**
 	 * @var \Redis

--- a/src/Core/Lock/CacheLockDriver.php
+++ b/src/Core/Lock/CacheLockDriver.php
@@ -29,7 +29,7 @@ class CacheLockDriver extends AbstractLockDriver
 		$got_lock = false;
 		$start = time();
 
-		$cachekey = self::getCacheKey($key);
+		$cachekey = self::getLockKey($key);
 
 		do {
 			$lock = $this->cache->get($cachekey);
@@ -62,7 +62,7 @@ class CacheLockDriver extends AbstractLockDriver
 	 */
 	public function releaseLock($key)
 	{
-		$cachekey = self::getCacheKey($key);
+		$cachekey = self::getLockKey($key);
 
 		$this->cache->compareDelete($cachekey, getmypid());
 		$this->markRelease($key);
@@ -73,7 +73,7 @@ class CacheLockDriver extends AbstractLockDriver
 	 */
 	public function isLocked($key)
 	{
-		$cachekey = self::getCacheKey($key);
+		$cachekey = self::getLockKey($key);
 		$lock = $this->cache->get($cachekey);
 		return isset($lock) && ($lock !== false);
 	}
@@ -82,7 +82,7 @@ class CacheLockDriver extends AbstractLockDriver
 	 * @param string $key	The original key
 	 * @return string		The cache key used for the cache
 	 */
-	private static function getCacheKey($key) {
-		return self::getApp()->get_hostname() . ";lock:" . $key;
+	private static function getLockKey($key) {
+		return "lock:" . $key;
 	}
 }


### PR DESCRIPTION
I'm sorry, the last merge was slightly to fast. Sorry for the inadequate quality :-(

I found a bug that we don't always use the cachekey at redis and therefor the compareSet function doesn't work => leads to endless loops until timeout finally occurs.
=> Therefore I generally added a method to create a cachekey or lockkey out of the given key (to avoid non-equal key-creations ;-) )

And I accidentally reverted my db-update version change, so nobody would get the "expired" field to the lock table.