### PR TITLE
Redis serialize

### DIFF
--- a/src/Core/Cache/RedisCacheDriver.php
+++ b/src/Core/Cache/RedisCacheDriver.php
@@ -40,7 +40,7 @@ class RedisCacheDriver extends AbstractCacheDriver implements IMemoryCacheDriver
 			return null;
 		}
 
-		$value = json_decode($cached);
+		$value = unserialize($cached);
 
 		// Only return a value if the serialized value is valid.
 		// We also check if the db entry is a serialized
@@ -56,7 +56,7 @@ class RedisCacheDriver extends AbstractCacheDriver implements IMemoryCacheDriver
 	{
 		$cachekey = $this->getCacheKey($key);
 
-		$cached = json_encode($value);
+		$cached = serialize($value);
 
 		if ($ttl > 0) {
 			return $this->redis->setex(
@@ -93,7 +93,7 @@ class RedisCacheDriver extends AbstractCacheDriver implements IMemoryCacheDriver
 	public function add($key, $value, $ttl = Cache::FIVE_MINUTES)
 	{
 		$cachekey = $this->getCacheKey($key);
-		$cached = json_encode($value);
+		$cached = serialize($value);
 
 		return $this->redis->setnx($cachekey, $cached);
 	}
@@ -105,7 +105,7 @@ class RedisCacheDriver extends AbstractCacheDriver implements IMemoryCacheDriver
 	{
 		$cachekey = $this->getCacheKey($key);
 
-		$newCached = json_encode($newValue);
+		$newCached = serialize($newValue);
 
 		$this->redis->watch($cachekey);
 		// If the old value isn't what we expected, somebody else changed the key meanwhile

--- a/tests/src/Core/Cache/CacheTest.php
+++ b/tests/src/Core/Cache/CacheTest.php
@@ -5,6 +5,7 @@ namespace Friendica\Test\src\Core\Cache;
 use Friendica\App;
 use Friendica\Core\Config;
 use Friendica\Test\DatabaseTest;
+use Friendica\Util\DateTimeFormat;
 
 abstract class CacheTest extends DatabaseTest
 {
@@ -103,5 +104,54 @@ abstract class CacheTest extends DatabaseTest
 		sleep(2);
 
 		$this->assertNull($this->instance->get('value1'));
+	}
+
+	function testDifferentTypesInCache() {
+		// String test
+		$value = "foobar";
+		$this->instance->set('stringVal', $value);
+		$received = $this->instance->get('stringVal');
+		$this->assertEquals($value, $received, 'Value type changed from ' . gettype($value) . ' to ' . gettype($received));
+
+		// Integer test
+		$value = 1;
+		$this->instance->set('intVal', $value);
+		$received = $this->instance->get('intVal');
+		$this->assertEquals($value, $received, 'Value type changed from ' . gettype($value) . ' to ' . gettype($received));
+
+		// Boolean test
+		$value = true;
+		$this->instance->set('boolValTrue', $value);
+		$received = $this->instance->get('boolValTrue');
+		$this->assertEquals($value, $received, 'Value type changed from ' . gettype($value) . ' to ' . gettype($received));
+
+		$value = false;
+		$this->instance->set('boolValFalse', $value);
+		$received = $this->instance->get('boolValFalse');
+		$this->assertEquals($value, $received, 'Value type changed from ' . gettype($value) . ' to ' . gettype($received));
+
+		// float
+		$value = 4.6634234;
+		$this->instance->set('decVal', $value);
+		$received = $this->instance->get('decVal');
+		$this->assertEquals($value, $received, 'Value type changed from ' . gettype($value) . ' to ' . gettype($received));
+
+		// array
+		$value = array('1', '2', '3', '4', '5');
+		$this->instance->set('arrayVal', $value);
+		$received = $this->instance->get('arrayVal');
+		$this->assertEquals($value, $received, 'Value type changed from ' . gettype($value) . ' to ' . gettype($received));
+
+		// object
+		$value = new DateTimeFormat();
+		$this->instance->set('objVal', $value);
+		$received = $this->instance->get('objVal');
+		$this->assertEquals($value, $received, 'Value type changed from ' . gettype($value) . ' to ' . gettype($received));
+
+		// null
+		$value = null;
+		$this->instance->set('objVal', $value);
+		$received = $this->instance->get('objVal');
+		$this->assertEquals($value, $received, 'Value type changed from ' . gettype($value) . ' to ' . gettype($received));
 	}
 }


### PR DESCRIPTION
One of the issues I found was that jason cannot serialize objects without extending the class or implement a method.

So I switched back to serialize for redis cache

I added a type-safe unittest too.