### PR TITLE
[Suggestion] Move New User Tip Link

### DIFF
--- a/mod/profile.php
+++ b/mod/profile.php
@@ -191,10 +191,6 @@ function profile_content(App $a, $update = 0)
 
 		$o .= Widget::commonFriendsVisitor($a->profile['profile_uid']);
 
-		if (x($_SESSION, 'new_member') && $is_owner) {
-			$o .= '<div id="newmember-tips"><a href="newmember"><b>' . L10n::t('Tips for New Members') . '</b></a></div>';
-		}
-
 		$commpage = $a->profile['page-flags'] == PAGE_COMMUNITY;
 		$commvisitor = $commpage && $remote_contact;
 

--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -947,6 +947,16 @@ class Profile
 			];
 		}
 
+		if (x($_SESSION, 'new_member') && $is_owner) {
+			$tabs[] = [
+				'label' => L10n::t('Tips for New Members'),
+				'url'   => System::baseUrl() . '/newmember',
+				'sel'   => false,
+				'title' => L10n::t('Tips for New Members'),
+				'id'    => 'newmember-tab',
+			];
+		}
+
 		if (!$is_owner && empty($a->profile['hide-friends'])) {
 			$tabs[] = [
 				'label' => L10n::t('Contacts'),

--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -947,7 +947,7 @@ class Profile
 			];
 		}
 
-		if (x($_SESSION, 'new_member') && $is_owner) {
+		if (!empty($_SESSION['new_member']) && $is_owner) {
 			$tabs[] = [
 				'label' => L10n::t('Tips for New Members'),
 				'url'   => System::baseUrl() . '/newmember',

--- a/view/global.css
+++ b/view/global.css
@@ -207,10 +207,8 @@ blockquote.shared_content {
 }
 
 #newmember-tips {
+  margin-top: -3px;
   font-size: 1.2em;
-  float: right;
-  margin-top: -32px;
-  padding-right: 10px;
 }
 
 /* headers */

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -972,6 +972,10 @@ nav.navbar a, nav.navbar .btn-link {
     padding: 2px 10px;
 }
 
+#newmember-tab > a {
+  font-size: 1.2em;
+  font-weight: 800;
+}
 
 /*
  * Aside

--- a/view/theme/vier/style.css
+++ b/view/theme/vier/style.css
@@ -2340,6 +2340,11 @@ ul.tabs li .active, span.pager_current a {
   text-decoration: none;
 }
 
+#newmember-tab > a {
+  font-size: 1.2em;
+  font-weight: 800;
+}
+
 /**
  * Form fields
  */


### PR DESCRIPTION
In both frio and vier the link to the tips for new users is plugged into the page right between the second navbar and the actual content.

![screenshot_2018-07-09 friendic a stifter profile](https://user-images.githubusercontent.com/206846/42446826-fc0806b0-8377-11e8-9649-d979591e791d.png)

Granted, this makes the link very visible but it looks odd. I suggest moving the link to the second navbar instead.

![screenshot_2018-07-09 friendica social network profile](https://user-images.githubusercontent.com/206846/42446834-05979e2a-8378-11e8-86fa-a82ced5f2c4b.png)
