### PR TITLE
Fix relocate button label.

### DIFF
--- a/mod/admin.php
+++ b/mod/admin.php
@@ -1465,7 +1465,8 @@ function admin_page_site(App $a)
 		'$relay_server_tags' 	=> ['relay_server_tags', L10n::t("Server tags"), Config::get('system','relay_server_tags'), L10n::t("Comma separated list of tags for the 'tags' subscription.")],
 		'$relay_user_tags' 	=> ['relay_user_tags', L10n::t("Allow user tags"), Config::get('system', 'relay_user_tags', true), L10n::t("If enabled, the tags from the saved searches will used for the 'tags' subscription in addition to the 'relay_server_tags'.")],
 
-		'$form_security_token'	=> get_form_security_token("admin_site")
+		'$form_security_token'	=> get_form_security_token("admin_site"),
+		'$relocate_button'      => L10n::t('Start Relocation'),
 	]);
 }
 

--- a/view/templates/admin/site.tpl
+++ b/view/templates/admin/site.tpl
@@ -169,7 +169,7 @@
 	<h3>{{$relocate}}</h3>
 	{{include file="field_input.tpl" field=$relocate_url}}
 	<input type="hidden" name="page_site" value="{{$submit|escape:'html'}}">
-	<div class="submit"><input type="submit" name="relocate" value="{{$submit|escape:'html'}}" /></div>
+	<div class="submit"><input type="submit" name="relocate" value="{{$relocate_button|escape:'html'}}" /></div>
 	</form>
 
 </div>


### PR DESCRIPTION
In /admin/site/ the button that starts a site-relocation is also named 'Save Settings'. Fix that and label the button "Start Relocation".