### PR TITLE
Improve nginx Configuration Sample

### DIFF
--- a/mods/sample-nginx.config
+++ b/mods/sample-nginx.config
@@ -105,6 +105,14 @@ server {
     deny all;
   }
 
+  # statically serve these file types when possible otherwise fall back to
+  # front controller allow browser to cache them added .htm for advanced source
+  # code editor library
+  #location ~* \.(jpg|jpeg|gif|png|ico|css|js|htm|html|ttf|woff|svg)$ {
+  #  expires 30d;
+  #  try_files $uri /index.php?pagename=$uri&$args;
+  #}
+
   # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
   # or a unix socket
   location ~* \.php$ {

--- a/mods/sample-nginx.config
+++ b/mods/sample-nginx.config
@@ -93,9 +93,7 @@ server {
   # by denying dot files and rewrite request to the front controller
   location ^~ /.well-known/ {
     allow all;
-   if (!-e $request_filename) {
-     rewrite ^(.*)$ /index.php?pagename=$1;
-   }
+    try_files $uri /index.php?pagename=$uri&$args;
   }
 
   include mime.types;

--- a/mods/sample-nginx.config
+++ b/mods/sample-nginx.config
@@ -84,9 +84,7 @@ server {
 
   # rewrite to front controller as default rule
   location / {
-    if (!-e $request_filename) {
-      rewrite ^(.*)$ /index.php?pagename=$1;
-    }
+    try_file $uri /index.php?pagename=$uri&$args;
   }
 
   # make sure webfinger and other well known services aren't blocked

--- a/mods/sample-nginx.config
+++ b/mods/sample-nginx.config
@@ -72,10 +72,12 @@ server {
   charset utf-8;
   root /var/www/friendica;
   access_log /var/log/nginx/friendica.log;
-    #Uncomment the following line to include a standard configuration file
-    #Note that the most specific rule wins and your standard configuration
-    #will therefore *add* to this file, but not override it.
+
+  # Uncomment the following line to include a standard configuration file Note
+  # that the most specific rule wins and your standard configuration will
+  # therefore *add* to this file, but not override it.
   #include standard.conf
+
   # allow uploads up to 20MB in size
   client_max_body_size 20m;
   client_body_buffer_size 128k;

--- a/mods/sample-nginx.config
+++ b/mods/sample-nginx.config
@@ -100,11 +100,6 @@ server {
 
   include mime.types;
 
-  # block these file types
-  location ~* \.(tpl|md|tgz|log|out)$ {
-    deny all;
-  }
-
   # statically serve these file types when possible otherwise fall back to
   # front controller allow browser to cache them added .htm for advanced source
   # code editor library
@@ -136,6 +131,11 @@ server {
     include fastcgi_params;
     fastcgi_index index.php;
     fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+  }
+
+  # block these file types
+  location ~* \.(tpl|md|tgz|log|out)$ {
+    deny all;
   }
 
   # deny access to all dot files


### PR DESCRIPTION
The nginx configuration sample contains some deprecated/frownd upon constructs. Make nginx config as standard as possible.