### PR TITLE
[frio] Do not loose place in /admin/addons on enable/disable addon.

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -2949,7 +2949,7 @@ section.help-content-wrapper li {
     padding-top: 10px;
 }
 #adminpage ul#pluginslist, li.plugin {
-    padding-top: 10px;
+    list-style: none;
 }
 #adminpage li .icon {
     display: inline-block;
@@ -3007,6 +3007,14 @@ section.help-content-wrapper li {
 }
 .adminpage .table-hover > tbody > tr:hover + tr.details {
     background-color: #f5f5f5;
+}
+.offset-anchor::before {
+    display: block; 
+    content: " "; 
+    margin-top: -100px; 
+    height: 100px;
+    visibility: hidden; 
+    pointer-events: none;
 }
 
 /* Register Page*/

--- a/view/theme/frio/templates/admin/addons.tpl
+++ b/view/theme/frio/templates/admin/addons.tpl
@@ -1,0 +1,22 @@
+
+<div id='adminpage'>
+	<h1>{{$title}} - {{$page}}</h1>
+		{{if $pcount eq 0}}
+		    <div class="error-message">
+		    {{$noplugshint}}
+		    </div>
+		{{else}}
+		<a class="btn" href="{{$baseurl}}/admin/{{$function}}?a=r&amp;t={{$form_security_token}}">{{$reload}}</a>
+		<ul id='pluginslist'>
+		{{foreach $addons as $p}}
+			<li class="plugin {{$p.1}}">
+				<span class="offset-anchor" id="{{$p.0}}"></span>
+				<a class='toggleplugin' href='{{$baseurl}}/admin/{{$function}}/{{$p.0}}?a=t&amp;t={{$form_security_token}}#{{$p.0}}' title="{{if $p.1==on}}Disable{{else}}Enable{{/if}}" ><span class='icon {{$p.1}}'></span></a>
+				<a href='{{$baseurl}}/admin/{{$function}}/{{$p.0}}'><span class='name'>{{$p.2.name}}</span></a> - <span class="version">{{$p.2.version}}</span>
+				{{if $p.2.experimental}} {{$experimental}} {{/if}}{{if $p.2.unsupported}} {{$unsupported}} {{/if}}
+				<div class='desc'>{{$p.2.description}}</div>
+			</li>
+		{{/foreach}}
+		</ul>
+		{{/if}}
+</div>


### PR DESCRIPTION
When an addon is enabled/disabled the page jumps right to the top, this is mighty inconvenient
when trying to enable/disable a bunch of addons at once.

This patch introduces an anchor with offset from top to make sure the last changed addon
is at the top of the screen.