### PR TITLE
Use h3 instead of h4 in contacts block

### DIFF
--- a/view/templates/contact_block.tpl
+++ b/view/templates/contact_block.tpl
@@ -1,6 +1,6 @@
 
 <div id="contact-block">
-<h4 class="contact-block-h4">{{$contacts}}</h4>
+<h3 class="contact-block-h4">{{$contacts}}</h3>
 {{if $micropro}}
 		<a class="allcontact-link" href="viewcontacts/{{$nickname}}">{{$viewcontacts}}</a>
 		<div class='contact-block-content'>


### PR DESCRIPTION
The contacts block in the network aside is using h4 instead of the (commonly used in aside widgets) h3.

Change /network contact aside to h3 header.