### PR TITLE
Fix some Notice messages

### DIFF
--- a/mod/notifications.php
+++ b/mod/notifications.php
@@ -79,6 +79,7 @@ function notifications_content(App $a)
 	// Get the nav tabs for the notification pages
 	$tabs = $nm->getTabs();
 	$notif_content = [];
+	$notif_nocontent = "";
 
 	// Notification results per page
 	$perpage = 20;

--- a/mod/settings.php
+++ b/mod/settings.php
@@ -26,13 +26,15 @@ use Friendica\Util\Temporal;
 function get_theme_config_file($theme)
 {
 	$a = get_app();
-	$base_theme = $a->theme_info['extends'];
 
 	if (file_exists("view/theme/$theme/config.php")) {
 		return "view/theme/$theme/config.php";
 	}
-	if (file_exists("view/theme/$base_theme/config.php")) {
-		return "view/theme/$base_theme/config.php";
+	if (isset($a->theme_info['extends'])){
+		$base_theme = $a->theme_info['extends'];
+		if (file_exists("view/theme/$base_theme/config.php")) {
+			return "view/theme/$base_theme/config.php";
+		}
 	}
 	return null;
 }

--- a/src/App.php
+++ b/src/App.php
@@ -174,7 +174,19 @@ class App
 		$this->callstack['parser'] = [];
 
 		$this->config = [];
-		$this->page = [];
+		$this->page = [
+			'aside' => '',
+			'bottom' => '',
+			'content' => '',
+			'end' => '',
+			'footer' => '',
+			'htmlhead' => '',
+			'nav' => '',
+			'page_title' => '',
+			'right_aside' => '',
+			'template' => '',
+			'title' => ''
+		];
 		$this->pager = [];
 
 		$this->query_string = '';

--- a/src/Core/Addon.php
+++ b/src/Core/Addon.php
@@ -313,7 +313,7 @@ class Addon
 			$ll = explode("\n", $m[0]);
 			foreach ($ll as $l) {
 				$l = trim($l, "\t\n\r */");
-				if ($l != "") {
+				if ($l != "" && strpos($l,":")>0) {
 					list($type, $v) = array_map("trim", explode(":", $l, 2));
 					$type = strtolower($type);
 					if ($type == "author" || $type == "maintainer") {

--- a/src/Database/DBStructure.php
+++ b/src/Database/DBStructure.php
@@ -366,7 +366,8 @@ class DBStructure
 				}
 
 				if (isset($database[$name]["table_status"]["Comment"])) {
-					if ($database[$name]["table_status"]["Comment"] != $structure['comment']) {
+					if (!isset($strcture["comment"])) $structure["comment"] = "";
+					if ($database[$name]["table_status"]["Comment"] != $structure["comment"]) {
 						$sql2 = "COMMENT = '".dbesc($structure['comment'])."'";
 
 						if ($sql3 == "") {


### PR DESCRIPTION
This PR just fix some notices I got running friendica in vagrant.

Most of the time is about undefined indexes or variables.

About the initialization of `$a->page` array:

In many cases the code is like

```php
   $a->page['aside'] .= "...";
```

(note the dot-equal) when the index in question has never defined before. So I just extracted all indexes used in code and added to the initialization.

I'm not sure if this has some consequences in themes base php files...
