### PR TITLE
Use a process identifier for logging that contains the pid

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -193,7 +193,7 @@ class App
 
 		$this->query_string = '';
 
-		$this->process_id = uniqid('log', true);
+		$this->process_id = System::processID('log');
 
 		set_time_limit(0);
 

--- a/src/Core/System.php
+++ b/src/Core/System.php
@@ -203,6 +203,18 @@ EOT;
 		}
 	}
 
+	/**
+	 * Generates a process identifier for the logging
+	 *
+	 * @param string $prefix A given prefix
+	 *
+	 * @return string a generated process identifier
+	 */
+	public static function processID($prefix)
+	{
+		return uniqid($prefix . ':' . str_pad(getmypid() . ':', 8, '0') . ':');
+	}
+
 	/// @todo Move the following functions from boot.php
 	/*
 	function killme()

--- a/src/Core/Worker.php
+++ b/src/Core/Worker.php
@@ -141,7 +141,7 @@ class Worker
 		if (Config::get('system', 'worker_daemon_mode', false)) {
 			self::IPCSetJobState(false);
 		}
-		logger("Couldn't select a workerqueue entry, quitting.", LOGGER_DEBUG);
+		logger("Couldn't select a workerqueue entry, quitting process " . getmypid() . ".", LOGGER_DEBUG);
 	}
 
 	/**
@@ -309,7 +309,7 @@ class Worker
 
 		$argc = count($argv);
 
-		$new_process_id = uniqid("wrk", true);
+		$new_process_id = System::processID("wrk");
 
 		logger("Process ".$mypid." - Prio ".$queue["priority"]." - ID ".$queue["id"].": ".$funcname." ".$queue["parameter"]." - Process PID: ".$new_process_id);
 


### PR DESCRIPTION
The days I had got problems with workers processes that took a real long time and a high CPU usage. With this change we will now be able to look into the log file and to see what the system is doing right now.