### PR TITLE
"Imported" name spaces

### DIFF
--- a/src/Core/Cache/MemcacheCacheDriver.php
+++ b/src/Core/Cache/MemcacheCacheDriver.php
@@ -4,6 +4,8 @@ namespace Friendica\Core\Cache;
 
 use Friendica\Core\Cache;
 
+use \Exception;
+
 /**
  * Memcache Cache Driver
  *
@@ -21,14 +23,14 @@ class MemcacheCacheDriver extends AbstractCacheDriver implements IMemoryCacheDri
 
 	public function __construct($memcache_host, $memcache_port)
 	{
-		if (!class_exists('Memcache', false)) {
-			throw new \Exception('Memcache class isn\'t available');
+		if (!class_exists('\Memcache', false)) {
+			throw new Exception('Memcache class isn\'t available');
 		}
 
 		$this->memcache = new \Memcache();
 
 		if (!$this->memcache->connect($memcache_host, $memcache_port)) {
-			throw new \Exception('Expected Memcache server at ' . $memcache_host . ':' . $memcache_port . ' isn\'t available');
+			throw new Exception('Expected Memcache server at ' . $memcache_host . ':' . $memcache_port . ' isn\'t available');
 		}
 	}
 

--- a/src/Core/Cache/MemcacheCacheDriver.php
+++ b/src/Core/Cache/MemcacheCacheDriver.php
@@ -4,7 +4,7 @@ namespace Friendica\Core\Cache;
 
 use Friendica\Core\Cache;
 
-use \Exception;
+use Exception;
 
 /**
  * Memcache Cache Driver

--- a/src/Core/Cache/MemcacheCacheDriver.php
+++ b/src/Core/Cache/MemcacheCacheDriver.php
@@ -5,6 +5,7 @@ namespace Friendica\Core\Cache;
 use Friendica\Core\Cache;
 
 use Exception;
+use Memcache;
 
 /**
  * Memcache Cache Driver
@@ -17,17 +18,17 @@ class MemcacheCacheDriver extends AbstractCacheDriver implements IMemoryCacheDri
 	use TraitCompareDelete;
 
 	/**
-	 * @var \Memcache
+	 * @var Memcache
 	 */
 	private $memcache;
 
 	public function __construct($memcache_host, $memcache_port)
 	{
-		if (!class_exists('\Memcache', false)) {
+		if (!class_exists('Memcache', false)) {
 			throw new Exception('Memcache class isn\'t available');
 		}
 
-		$this->memcache = new \Memcache();
+		$this->memcache = new Memcache();
 
 		if (!$this->memcache->connect($memcache_host, $memcache_port)) {
 			throw new Exception('Expected Memcache server at ' . $memcache_host . ':' . $memcache_port . ' isn\'t available');

--- a/src/Core/Cache/MemcachedCacheDriver.php
+++ b/src/Core/Cache/MemcachedCacheDriver.php
@@ -4,7 +4,7 @@ namespace Friendica\Core\Cache;
 
 use Friendica\Core\Cache;
 
-use \Exception;
+use Exception;
 
 /**
  * Memcached Cache Driver

--- a/src/Core/Cache/MemcachedCacheDriver.php
+++ b/src/Core/Cache/MemcachedCacheDriver.php
@@ -5,6 +5,7 @@ namespace Friendica\Core\Cache;
 use Friendica\Core\Cache;
 
 use Exception;
+use Memcached;
 
 /**
  * Memcached Cache Driver
@@ -23,11 +24,11 @@ class MemcachedCacheDriver extends AbstractCacheDriver implements IMemoryCacheDr
 
 	public function __construct(array $memcached_hosts)
 	{
-		if (!class_exists('\Memcached', false)) {
+		if (!class_exists('Memcached', false)) {
 			throw new Exception('Memcached class isn\'t available');
 		}
 
-		$this->memcached = new \Memcached();
+		$this->memcached = new Memcached();
 
 		$this->memcached->addServers($memcached_hosts);
 
@@ -44,7 +45,7 @@ class MemcachedCacheDriver extends AbstractCacheDriver implements IMemoryCacheDr
 		// We fetch with the hostname as key to avoid problems with other applications
 		$value = $this->memcached->get($cachekey);
 
-		if ($this->memcached->getResultCode() === \Memcached::RES_SUCCESS) {
+		if ($this->memcached->getResultCode() === Memcached::RES_SUCCESS) {
 			$return = $value;
 		}
 

--- a/src/Core/Cache/MemcachedCacheDriver.php
+++ b/src/Core/Cache/MemcachedCacheDriver.php
@@ -4,6 +4,8 @@ namespace Friendica\Core\Cache;
 
 use Friendica\Core\Cache;
 
+use \Exception;
+
 /**
  * Memcached Cache Driver
  *
@@ -21,8 +23,8 @@ class MemcachedCacheDriver extends AbstractCacheDriver implements IMemoryCacheDr
 
 	public function __construct(array $memcached_hosts)
 	{
-		if (!class_exists('Memcached', false)) {
-			throw new \Exception('Memcached class isn\'t available');
+		if (!class_exists('\Memcached', false)) {
+			throw new Exception('Memcached class isn\'t available');
 		}
 
 		$this->memcached = new \Memcached();
@@ -30,7 +32,7 @@ class MemcachedCacheDriver extends AbstractCacheDriver implements IMemoryCacheDr
 		$this->memcached->addServers($memcached_hosts);
 
 		if (count($this->memcached->getServerList()) == 0) {
-			throw new \Exception('Expected Memcached servers aren\'t available, config:' . var_export($memcached_hosts, true));
+			throw new Exception('Expected Memcached servers aren\'t available, config:' . var_export($memcached_hosts, true));
 		}
 	}
 

--- a/src/Core/Cache/RedisCacheDriver.php
+++ b/src/Core/Cache/RedisCacheDriver.php
@@ -4,8 +4,8 @@ namespace Friendica\Core\Cache;
 
 use Friendica\Core\Cache;
 
-use \Exception;
-use \Redis;
+use Exception;
+use Redis;
 
 /**
  * Redis Cache Driver. This driver is based on Memcache driver

--- a/src/Core/Cache/RedisCacheDriver.php
+++ b/src/Core/Cache/RedisCacheDriver.php
@@ -4,6 +4,9 @@ namespace Friendica\Core\Cache;
 
 use Friendica\Core\Cache;
 
+use \Exception;
+use \Redis;
+
 /**
  * Redis Cache Driver. This driver is based on Memcache driver
  *
@@ -13,20 +16,20 @@ use Friendica\Core\Cache;
 class RedisCacheDriver extends AbstractCacheDriver implements IMemoryCacheDriver
 {
 	/**
-	 * @var \Redis
+	 * @var Redis
 	 */
 	private $redis;
 
 	public function __construct($redis_host, $redis_port)
 	{
 		if (!class_exists('Redis', false)) {
-			throw new \Exception('Redis class isn\'t available');
+			throw new Exception('Redis class isn\'t available');
 		}
 
-		$this->redis = new \Redis();
+		$this->redis = new Redis();
 
 		if (!$this->redis->connect($redis_host, $redis_port)) {
-			throw new \Exception('Expected Redis server at ' . $redis_host . ':' . $redis_port . ' isn\'t available');
+			throw new Exception('Expected Redis server at ' . $redis_host . ':' . $redis_port . ' isn\'t available');
 		}
 	}
 


### PR DESCRIPTION
From the commit message:

> Fixes for #5355 :
> - let's import SPL/extension classes and then just use them without name spaces
>   like we do it with our own classes/interfaces, too.
> - need to add namespace \ (global)
> 