### PR TITLE
Workaround for stalling worker processes when running the daemon

### DIFF
--- a/bin/daemon.php
+++ b/bin/daemon.php
@@ -106,8 +106,10 @@ if (!$foreground) {
 	}
 
 	fclose(STDIN);  // Close all of the standard
-	fclose(STDOUT); // file descriptors as we
-	fclose(STDERR); // are running as a daemon.
+
+	// Enabling this seem to block a running php process with 100% CPU usage when there is an outpout
+	// fclose(STDOUT); // file descriptors as we
+	// fclose(STDERR); // are running as a daemon.
 
 	dba::disconnect();
 

--- a/bin/worker.php
+++ b/bin/worker.php
@@ -63,4 +63,3 @@ Worker::unclaimProcess();
 Worker::endProcess();
 
 killme();
-

--- a/src/Core/Worker.php
+++ b/src/Core/Worker.php
@@ -597,7 +597,7 @@ class Worker
 						['id' => $entry["id"]]
 					);
 				} else {
-					logger("Worker process ".$entry["pid"]." (".implode(" ", $argv).") now runs for ".round($duration)." of ".$max_duration." allowed minutes. That's okay.", LOGGER_DEBUG);
+					logger("Worker process ".$entry["pid"]." (".substr(json_encode($argv), 0, 50).") now runs for ".round($duration)." of ".$max_duration." allowed minutes. That's okay.", LOGGER_DEBUG);
 				}
 			}
 		}

--- a/src/Model/GContact.php
+++ b/src/Model/GContact.php
@@ -564,15 +564,16 @@ class GContact
 
 		if (strlen(Config::get('system', 'directory'))) {
 			$x = Network::fetchUrl(get_server()."/pubsites");
-			if ($x) {
+			if (!empty($x)) {
 				$j = json_decode($x);
-				if ($j->entries) {
+				if (!empty($j->entries)) {
 					foreach ($j->entries as $entry) {
 						PortableContact::checkServer($entry->url);
 
 						$url = $entry->url . '/poco';
-						if (! in_array($url, $done)) {
-							PortableContact::loadWorker(0, 0, 0, $entry->url . '/poco');
+						if (!in_array($url, $done)) {
+							PortableContact::loadWorker(0, 0, 0, $url);
+							$done[] = $url;
 						}
 					}
 				}


### PR DESCRIPTION
Running the daemon to execute the worker seem to randomly set PHP processes to 100% CPU usage. This seem to be caused when the PHP process is creating a warning or notice.

This is just a quick fix.