### PR TITLE
admins can mark their nodes for explicit content

### DIFF
--- a/mod/admin.php
+++ b/mod/admin.php
@@ -986,6 +986,7 @@ function admin_page_site_post(App $a)
 	$private_addons			=	((x($_POST,'private_addons'))		? True					: False);
 	$disable_embedded		=	((x($_POST,'disable_embedded'))		? True					: False);
 	$allow_users_remote_self	=	((x($_POST,'allow_users_remote_self'))	? True					: False);
+	$explicit_content	=	((x($_POST,'explicit_content'))	? True					: False);
 
 	$no_multi_reg		=	((x($_POST,'no_multi_reg'))		? True						: False);
 	$no_openid		=	!((x($_POST,'no_openid'))		? True						: False);
@@ -1153,6 +1154,7 @@ function admin_page_site_post(App $a)
 	Config::set('system', 'enotify_no_content', $enotify_no_content);
 	Config::set('system', 'disable_embedded', $disable_embedded);
 	Config::set('system', 'allow_users_remote_self', $allow_users_remote_self);
+	Config::set('system', 'explicit_content', $explicit_content);
 	Config::set('system', 'check_new_version_url', $check_new_version_url);
 
 	Config::set('system', 'block_extended_register', $no_multi_reg);
@@ -1405,6 +1407,7 @@ function admin_page_site(App $a)
 		'$enotify_no_content'	=> ['enotify_no_content', L10n::t("Don't include post content in email notifications"), Config::get('system','enotify_no_content'), L10n::t("Don't include the content of a post/comment/private message/etc. in the email notifications that are sent out from this site, as a privacy measure.")],
 		'$private_addons'	=> ['private_addons', L10n::t("Disallow public access to addons listed in the apps menu."), Config::get('config','private_addons'), L10n::t("Checking this box will restrict addons listed in the apps menu to members only.")],
 		'$disable_embedded'	=> ['disable_embedded', L10n::t("Don't embed private images in posts"), Config::get('system','disable_embedded'), L10n::t("Don't replace locally-hosted private photos in posts with an embedded copy of the image. This means that contacts who receive posts containing private photos will have to authenticate and load each image, which may take a while.")],
+		'$explicit_content' => ['explicit_content', L10n::t('Explicit Content'), Config::get('system', 'explicit_content', False), L10n::t('Set this to announce that your node is used mostly for explicit content that might not be suited for minors. This information will be published in the node information and might be used, e.g. by the global directory, to filter your node from listings of nodes to join. Additionally a note about this will be shown at the user registration page.')],
 		'$allow_users_remote_self' => ['allow_users_remote_self', L10n::t('Allow Users to set remote_self'), Config::get('system','allow_users_remote_self'), L10n::t('With checking this, every user is allowed to mark every contact as a remote_self in the repair contact dialog. Setting this flag on a contact causes mirroring every posting of that contact in the users stream.')],
 		'$no_multi_reg'		=> ['no_multi_reg', L10n::t("Block multiple registrations"),  Config::get('system','block_extended_register'), L10n::t("Disallow users to register additional accounts for use as pages.")],
 		'$no_openid'		=> ['no_openid', L10n::t("OpenID support"), !Config::get('system','no_openid'), L10n::t("OpenID support for registration and logins.")],

--- a/mod/nodeinfo.php
+++ b/mod/nodeinfo.php
@@ -142,7 +142,7 @@ function nodeinfo_init(App $a) {
 			$nodeinfo['metadata']['services']['inbound'][] = 'twitter';
 		}
 
-		$nodeinfo['metadata']['explicitContent'] = Config::get('system', 'explicit_content', False);;
+		$nodeinfo['metadata']['explicitContent'] = Config::get('system', 'explicit_content', False) == True;
 	}
 
 	header('Content-type: application/json; charset=utf-8');

--- a/mod/nodeinfo.php
+++ b/mod/nodeinfo.php
@@ -142,7 +142,7 @@ function nodeinfo_init(App $a) {
 			$nodeinfo['metadata']['services']['inbound'][] = 'twitter';
 		}
 
-		$nodeinfo['metadata']['explicitContent'] = Config::get('system', 'explicit_content', False) == True;
+		$nodeinfo['metadata']['explicitContent'] = Config::get('system', 'explicit_content', false) == true;
 	}
 
 	header('Content-type: application/json; charset=utf-8');

--- a/mod/nodeinfo.php
+++ b/mod/nodeinfo.php
@@ -141,6 +141,8 @@ function nodeinfo_init(App $a) {
 		if (Addon::isEnabled('twitter')) {
 			$nodeinfo['metadata']['services']['inbound'][] = 'twitter';
 		}
+
+		$nodeinfo['metadata']['explicitContent'] = Config::get('system', 'explicit_content', False);;
 	}
 
 	header('Content-type: application/json; charset=utf-8');

--- a/mod/register.php
+++ b/mod/register.php
@@ -292,7 +292,9 @@ function register_content(App $a)
 		'$showprivstatement' => Config::get('system', 'tosprivstatement'),
 		'$privstatement' => $tos->privacy_complete,
 		'$baseurl'   => System::baseurl(),
-		'$form_security_token' => get_form_security_token("register")
+		'$form_security_token' => get_form_security_token("register"),
+		'$explicit_content' => Config::get('system', 'explicit_content', False),
+		'$explicit_content_note' => L10n::t('Note: This node explicitly contains adult content')
 	]);
 	return $o;
 }

--- a/mod/register.php
+++ b/mod/register.php
@@ -293,7 +293,7 @@ function register_content(App $a)
 		'$privstatement' => $tos->privacy_complete,
 		'$baseurl'   => System::baseurl(),
 		'$form_security_token' => get_form_security_token("register"),
-		'$explicit_content' => Config::get('system', 'explicit_content', False),
+		'$explicit_content' => Config::get('system', 'explicit_content', false),
 		'$explicit_content_note' => L10n::t('Note: This node explicitly contains adult content')
 	]);
 	return $o;

--- a/view/global.css
+++ b/view/global.css
@@ -606,3 +606,7 @@ img.invalid-src:after { vertical-align: top;}
 .tag-cloud {
   word-wrap: break-word;
 }
+
+#register-explicid-content {
+  font-weight: bold;
+}

--- a/view/templates/admin/site.tpl
+++ b/view/templates/admin/site.tpl
@@ -105,6 +105,7 @@
 	{{include file="field_checkbox.tpl" field=$private_addons}}
 	{{include file="field_checkbox.tpl" field=$disable_embedded}}
 	{{include file="field_checkbox.tpl" field=$allow_users_remote_self}}
+	{{include file="field_checkbox.tpl" field=$explicit_content}}
 	<div class="submit"><input type="submit" name="page_site" value="{{$submit|escape:'html'}}" /></div>
 
 	<h3>{{$advanced}}</h3>

--- a/view/templates/register.tpl
+++ b/view/templates/register.tpl
@@ -7,6 +7,7 @@
 
 	{{if $registertext != ""}}<div class="error-message">{{$registertext}} </div>{{/if}}
 
+	{{if $explicit_content}} <p id="register-explicid-content">{{$explicit_content_note}}</p> {{/if}}
 
 	<p id="register-realpeople">{{$realpeople}}</p>
 

--- a/view/theme/frio/templates/register.tpl
+++ b/view/theme/frio/templates/register.tpl
@@ -10,6 +10,8 @@
 
 		{{if $registertext != ""}}<div class="error-message">{{$registertext}} </div>{{/if}}
 
+		{{if $explicit_content}} <p id="register-explicid-content">{{$explicit_content_note}}</p> {{/if}}
+
 
 		{{if $oidlabel}}
 		<div id="register-openid-wrapper" class="form-group">


### PR DESCRIPTION
With this PR node admins can set the config variable `explicit_content` (system, boolean) to mark their node accordingly.

This information will be published in the *metainformation* section of the nodeinfo. Additionally a note on the registration page is displayed if this config variable is set true.