### PR TITLE
Fix for displaying public items

### DIFF
--- a/include/security.php
+++ b/include/security.php
@@ -204,6 +204,10 @@ function can_write_wall($owner)
 		return true;
 	}
 
+	if (local_user() && ($owner == 0)) {
+		return true;
+	}
+
 	if (remote_user()) {
 		// use remembered decision and avoid a DB lookup for each and every display item
 		// DO NOT use this function if there are going to be multiple owners
@@ -339,7 +343,7 @@ function item_permissions_sql($owner_id, $remote_verified = false, $groups = nul
 			 AND `item`.allow_gid = ''
 			 AND `item`.deny_cid  = ''
 			 AND `item`.deny_gid  = ''
-			 AND `item`.private = 0
+			 AND `item`.private != 1
 	";
 
 	// Profile owner - everything is visible

--- a/include/text.php
+++ b/include/text.php
@@ -1137,7 +1137,7 @@ function redir_private_images($a, &$item)
 				continue;
 			}
 
-			if ((local_user() == $item['uid']) && ($item['private'] != 0) && ($item['contact-id'] != $a->contact['id']) && ($item['network'] == NETWORK_DFRN)) {
+			if ((local_user() == $item['uid']) && ($item['private'] == 1) && ($item['contact-id'] != $a->contact['id']) && ($item['network'] == NETWORK_DFRN)) {
 				$img_url = 'redir?f=1&quiet=1&url=' . urlencode($mtch[1]) . '&conurl=' . urlencode($item['author-link']);
 				$item['body'] = str_replace($mtch[0], '[img]' . $img_url . '[/img]', $item['body']);
 			}

--- a/mod/display.php
+++ b/mod/display.php
@@ -59,10 +59,10 @@ function display_init(App $a)
 
 		// Is it an item with uid=0?
 		if (!DBM::is_result($item)) {
-			$item = Item::selectFirstForUser(local_user(), $fields, ['guid' => $a->argv[1], 'private' => false, 'uid' => 0]);
+			$item = Item::selectFirstForUser(local_user(), $fields, ['guid' => $a->argv[1], 'private' => [0, 2], 'uid' => 0]);
 		}
 	} elseif (($a->argc == 3) && ($nick == 'feed-item')) {
-		$item = Item::selectFirstForUser(local_user(), $fields, ['id' => $a->argv[2], 'private' => false, 'uid' => 0]);
+		$item = Item::selectFirstForUser(local_user(), $fields, ['id' => $a->argv[2], 'private' => [0, 2], 'uid' => 0]);
 	}
 
 	if (!DBM::is_result($item)) {
@@ -229,7 +229,7 @@ function display_content(App $a, $update = false, $update_uid = 0)
 			}
 
 			if ($item_parent == 0) {
-				$condition = ['private' => false, 'guid' => $a->argv[1], 'uid' => 0];
+				$condition = ['private' => [0, 2], 'guid' => $a->argv[1], 'uid' => 0];
 				$item = Item::selectFirstForUser(local_user(), $fields, $condition);
 				if (DBM::is_result($item)) {
 					$item_id = $item["id"];
@@ -247,7 +247,7 @@ function display_content(App $a, $update = false, $update_uid = 0)
 	}
 
 	// We are displaying an "alternate" link if that post was public. See issue 2864
-	$is_public = dba::exists('item', ['id' => $item_id, 'private' => false]);
+	$is_public = dba::exists('item', ['id' => $item_id, 'private' => [0, 2]]);
 	if ($is_public) {
 		// For the atom feed the nickname doesn't matter at all, we only need the item id.
 		$alternate = System::baseUrl().'/display/feed-item/'.$item_id.'.atom';


### PR DESCRIPTION
Public items (uid = 0) hadn't been visible all the time and commenting them hadn't been possible sometimes. This is fixed.