### PR TITLE
Fixed E_NOTICE when 'title' is absent (uninitialized array key)

### DIFF
--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -547,6 +547,8 @@ class BBCode extends BaseObject
 		if (isset($data["title"])) {
 			$data["title"] = strip_tags($data["title"]);
 			$data["title"] = str_replace(["http://", "https://"], "", $data["title"]);
+		} else {
+			$data["title"] = null;
 		}
 
 		if (((strpos($data["text"], "[img=") !== false) || (strpos($data["text"], "[img]") !== false) || Config::get('system', 'always_show_preview')) && !empty($data["image"])) {


### PR DESCRIPTION
This fixes an `E_NOTICE` when `error_reporting` is set to `E_ALL`.