### PR TITLE
Fixed E_NOTICE when no 'term' was provided

### DIFF
--- a/mod/filer.php
+++ b/mod/filer.php
@@ -15,7 +15,7 @@ function filer_content(App $a)
 		killme();
 	}
 
-	$term = unxmlify(trim($_GET['term']));
+	$term = unxmlify(isset($_GET['term']) ? trim($_GET['term']) : null);
 	$item_id = (($a->argc > 1) ? intval($a->argv[1]) : 0);
 
 	logger('filer: tag ' . $term . ' item ' . $item_id);

--- a/mod/filer.php
+++ b/mod/filer.php
@@ -15,7 +15,7 @@ function filer_content(App $a)
 		killme();
 	}
 
-	$term = unxmlify(isset($_GET['term']) ? trim($_GET['term']) : null);
+	$term = unxmlify(trim(defaults($_GET, 'term', '')));
 	$item_id = (($a->argc > 1) ? intval($a->argv[1]) : 0);
 
 	logger('filer: tag ' . $term . ' item ' . $item_id);


### PR DESCRIPTION
This code caused an `E_NOTICE` when no 'term' parameter was provided.