### PR TITLE
Change (P)Config::set return value to bool

### DIFF
--- a/src/Core/Config.php
+++ b/src/Core/Config.php
@@ -95,7 +95,7 @@ class Config extends BaseObject
 	 * @param string $key    The configuration key to set
 	 * @param mixed  $value  The value to store
 	 *
-	 * @return mixed Stored $value or false if the database update failed
+	 * @return bool Operation success
 	 */
 	public static function set($family, $key, $value)
 	{

--- a/src/Core/Config/IConfigAdapter.php
+++ b/src/Core/Config/IConfigAdapter.php
@@ -53,7 +53,7 @@ interface IConfigAdapter
 	 * @param string $key    The configuration key to set
 	 * @param mixed  $value  The value to store
 	 *
-	 * @return mixed Stored $value or false if the database update failed
+	 * @return bool Operation success
 	 */
 	public function set($cat, $k, $value);
 

--- a/src/Core/Config/IPConfigAdapter.php
+++ b/src/Core/Config/IPConfigAdapter.php
@@ -57,7 +57,7 @@ interface IPConfigAdapter
 	 * @param string $k     The configuration key to set
 	 * @param string $value The value to store
 	 *
-	 * @return mixed Stored $value or false
+	 * @return bool Operation success
 	 */
 	public function set($uid, $cat, $k, $value);
 

--- a/src/Core/Config/JITConfigAdapter.php
+++ b/src/Core/Config/JITConfigAdapter.php
@@ -106,7 +106,6 @@ class JITConfigAdapter extends BaseObject implements IConfigAdapter
 
 		if ($result) {
 			$this->in_db[$cat][$k] = true;
-			return $value;
 		}
 
 		return $result;

--- a/src/Core/Config/JITPConfigAdapter.php
+++ b/src/Core/Config/JITPConfigAdapter.php
@@ -98,7 +98,6 @@ class JITPConfigAdapter extends BaseObject implements IPConfigAdapter
 
 		if ($result) {
 			$this->in_db[$uid][$cat][$k] = true;
-			return $value;
 		}
 
 		return $result;

--- a/src/Core/PConfig.php
+++ b/src/Core/PConfig.php
@@ -93,7 +93,7 @@ class PConfig extends BaseObject
 	 * @param string $key    The configuration key to set
 	 * @param string $value  The value to store
 	 *
-	 * @return mixed Stored $value or false
+	 * @return bool Operation success
 	 */
 	public static function set($uid, $family, $key, $value)
 	{


### PR DESCRIPTION
The `(P)Config::set` functions incorrectly returned the stored value on success. Not only this inconsistent return value isn't used anywhere in the project, but it made harder to know if the operation was actually successful.