### PR TITLE
Fix silent exit in ApiTest::testApiMediaUploadWithMedia()

### DIFF
--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -1202,7 +1202,8 @@ class ApiTest extends DatabaseTest
 	{
 		$_FILES = [
 			'media' => [
-				'id' => 666
+				'id' => 666,
+				'tmp_name' => 'tmp_name'
 			]
 		];
 		api_media_upload();


### PR DESCRIPTION
The tests were reaching an exit statement here: https://github.com/friendica/friendica/blob/2d0446bd38b8954247def42e70da735667cc2ed2/mod/wall_upload.php#L167
(Which should really be an exception so that phpunit can catch it.)

This PR fixes the tests silently dying but not the remaining test failures.

Edit: I just noticed something strange. testApiMediaUploadWithValidMedia passes when running by itself but fails when running all the tests. Probably some side effect of a previous test.