### PR TITLE
Fix for E_NOTICE fix in mod/item.php

### DIFF
--- a/mod/item.php
+++ b/mod/item.php
@@ -182,6 +182,7 @@ function item_post(App $a) {
 
 	$categories = '';
 	$postopts = '';
+	$emailcc = '';
 
 	if (!empty($orig_post)) {
 		$str_group_allow   = $orig_post['allow_gid'];
@@ -192,7 +193,6 @@ function item_post(App $a) {
 		$coord             = $orig_post['coord'];
 		$verb              = $orig_post['verb'];
 		$objecttype        = $orig_post['object-type'];
-		$emailcc           = $orig_post['emailcc'];
 		$app               = $orig_post['app'];
 		$categories        = $orig_post['file'];
 		$title             = notags(trim($_REQUEST['title']));
@@ -210,7 +210,6 @@ function item_post(App $a) {
 		 * use the user default permissions - as they won't have
 		 * been supplied via a form.
 		 */
-		/// @TODO use x($_REQUEST, 'foo') here
 		if ($api_source
 			&& !array_key_exists('contact_allow', $_REQUEST)
 			&& !array_key_exists('group_allow', $_REQUEST)

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -72,7 +72,7 @@ class Item extends BaseObject
 			'title', 'content-warning', 'body', 'location', 'coord', 'app',
 			'rendered-hash', 'rendered-html', 'object-type', 'object', 'target-type', 'target',
 			'author-id', 'author-link', 'author-name', 'author-avatar',
-			'owner-id', 'owner-link', 'owner-name', 'owner-avatar', 'emailcc'];
+			'owner-id', 'owner-link', 'owner-name', 'owner-avatar'];
 
 	// Never reorder or remove entries from this list. Just add new ones at the end, if needed.
 	// The item-activity table only stores the index and needs this array to know the matching activity.


### PR DESCRIPTION
According to @annando and @MrPetovan, $emailcc is no `item` field (column) and should be initialized empty (I did it above the `if()` block). Also the internal TODO can be closed (`x()` is deprecated, so this TODO).