### PR TITLE
[frio] Restyle album edit header.

### DIFF
--- a/mod/photos.php
+++ b/mod/photos.php
@@ -220,7 +220,7 @@ function photos_post(App $a)
 			// Update the photo albums cache
 			Photo::clearAlbumCache($page_owner_uid);
 
-			$newurl = str_replace(bin2hex($album), bin2hex($newalbum), $_SESSION['photo_return']);
+			$newurl = System::baseUrl() . '/photos/' . $a->user['nickname'] . '/album/' . bin2hex($newalbum);
 			goaway($newurl);
 			return; // NOTREACHED
 		}

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -2470,6 +2470,13 @@ ul li:hover .contact-wrapper .contact-action-link:hover {
 }
 
 /* photos */
+#photo-album-edit-name-label {
+    width: 100%;
+}
+.photo-album-edit-name {
+    width: 60%;
+}
+
 .photo-album-actions {
     margin-bottom: 10px;
 }

--- a/view/theme/frio/templates/album_edit.tpl
+++ b/view/theme/frio/templates/album_edit.tpl
@@ -1,0 +1,14 @@
+<div id="photo-album-edit-wrapper">
+<form name="photo-album-edit-form" id="photo-album-edit-form" action="photos/{{$nickname}}/album/{{$hexalbum}}" method="post" >
+	<label id="photo-album-edit-name-label" for="photo-album-edit-name" >{{$nametext}}</label>
+	<div class="pull-left photo-album-edit-name">
+	<input class="form-control" type="text" size="64" name="albumname" value="{{$album|escape:'html'}}" id="photo-album-edit-name" style="width: 100%;">
+	</div>
+	
+	<div class="pull-right">
+	<input class="btn-primary btn btn-small" id="photo-album-edit-submit" type="submit" name="submit" value="{{$submit|escape:'html'}}" />
+	<input class="btn-primary btn btn-small" id="photo-album-edit-drop" type="submit" name="dropalbum" value="{{$dropsubmit|escape:'html'}}" onclick="return confirmDelete();" />
+	</div>
+</form>
+</div>
+<div class="clear"></div>


### PR DESCRIPTION
The album editing in frio was quite unsightly:
![screenshot_2018-07-20 friendica social network photos](https://user-images.githubusercontent.com/206846/43021056-95edb2be-8c62-11e8-89c1-55acfb55dca8.png)

Frio'ize it:
![screenshot_2018-07-20 friendica social network photos 2](https://user-images.githubusercontent.com/206846/43021036-8350ff80-8c62-11e8-9e4c-544b60e131f8.png)

