### PR TITLE
Fixed E_NOTICE in boot.php and DBA class

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -768,14 +768,14 @@ function run_update_function($x, $prefix)
 			return false;
 		} else {
 			Config::set('database', $funcname, 'success');
-			if ($post_update) {
+			if (isset($post_update)) {
 				Config::set('system', 'build', $x);
 			}
 			return true;
 		}
 	} else {
 		Config::set('database', $funcname, 'success');
-		if ($post_update) {
+		if (isset($post_update)) {
 			Config::set('system', 'build', $x);
 		}
 		return true;

--- a/boot.php
+++ b/boot.php
@@ -768,16 +768,20 @@ function run_update_function($x, $prefix)
 			return false;
 		} else {
 			Config::set('database', $funcname, 'success');
-			if (isset($post_update)) {
+
+			if ($prefix == 'update') {
 				Config::set('system', 'build', $x);
 			}
+
 			return true;
 		}
 	} else {
 		Config::set('database', $funcname, 'success');
-		if (isset($post_update)) {
+
+		if ($prefix == 'update') {
 			Config::set('system', 'build', $x);
 		}
+
 		return true;
 	}
 }

--- a/src/Database/DBA.php
+++ b/src/Database/DBA.php
@@ -93,7 +93,13 @@ class DBA
 
 		if (!self::$connected && class_exists('\mysqli')) {
 			self::$driver = 'mysqli';
-			self::$db = @new mysqli($server, $user, $pass, $db, $port);
+
+			if ($port > 0) {
+				self::$db = @new mysqli($server, $user, $pass, $db, $port);
+			} else {
+				self::$db = @new mysqli($server, $user, $pass, $db);
+			}
+
 			if (!mysqli_connect_errno()) {
 				self::$connected = true;
 

--- a/src/Database/DBA.php
+++ b/src/Database/DBA.php
@@ -51,7 +51,7 @@ class DBA
 		self::$db_name = $db;
 		self::$db_charset = $charset;
 
-		$port = false;
+		$port = 0;
 		$serveraddr = trim($serveraddr);
 
 		$serverdata = explode(':', $serveraddr);

--- a/src/Database/DBA.php
+++ b/src/Database/DBA.php
@@ -12,7 +12,6 @@ use mysqli;
 use PDO;
 use PDOException;
 use PDOStatement;
-use mysqli;
 
 /**
  * @class MySQL database class

--- a/src/Database/DBA.php
+++ b/src/Database/DBA.php
@@ -51,7 +51,7 @@ class DBA
 		self::$db_name = $db;
 		self::$db_charset = $charset;
 
-		$port = 3306;
+		$port = false;
 		$serveraddr = trim($serveraddr);
 
 		$serverdata = explode(':', $serveraddr);
@@ -75,7 +75,7 @@ class DBA
 			self::$driver = 'pdo';
 			$connect = "mysql:host=".$server.";dbname=".$db;
 
-			if (isset($port)) {
+			if ($port > 0) {
 				$connect .= ";port=".$port;
 			}
 

--- a/src/Database/DBA.php
+++ b/src/Database/DBA.php
@@ -8,6 +8,7 @@ namespace Friendica\Database;
 
 use Friendica\Core\System;
 use Friendica\Util\DateTimeFormat;
+use mysqli;
 use PDO;
 use PDOException;
 use PDOStatement;
@@ -50,6 +51,7 @@ class DBA
 		self::$db_name = $db;
 		self::$db_charset = $charset;
 
+		$port = 3306;
 		$serveraddr = trim($serveraddr);
 
 		$serverdata = explode(':', $serveraddr);
@@ -89,7 +91,7 @@ class DBA
 			}
 		}
 
-		if (!self::$connected && class_exists('mysqli')) {
+		if (!self::$connected && class_exists('\mysqli')) {
 			self::$driver = 'mysqli';
 			self::$db = @new mysqli($server, $user, $pass, $db, $port);
 			if (!mysqli_connect_errno()) {


### PR DESCRIPTION
This PR fixes some `E_NOTICE` in `boot.php` and `DBA` class when `mysqli` is being used as database backend.