### PR TITLE
Move DBA to src/ part 3.1: Rename DBA methods

### DIFF
--- a/include/dba.php
+++ b/include/dba.php
@@ -41,7 +41,7 @@ function q($sql) {
 
 	$columns = DBA::columnCount($ret);
 
-	$data = DBA::inArray($ret);
+	$data = DBA::toArray($ret);
 
 	if ((count($data) == 0) && ($columns == 0)) {
 		return true;

--- a/include/dba.php
+++ b/include/dba.php
@@ -28,7 +28,7 @@ function q($sql) {
 		return false;
 	}
 
-	$sql = DBA::clean_query($sql);
+	$sql = DBA::cleanQuery($sql);
 	$sql = DBA::anyValueFallback($sql);
 
 	$stmt = @vsprintf($sql, $args);

--- a/include/dba.php
+++ b/include/dba.php
@@ -29,7 +29,7 @@ function q($sql) {
 	}
 
 	$sql = DBA::clean_query($sql);
-	$sql = DBA::any_value_fallback($sql);
+	$sql = DBA::anyValueFallback($sql);
 
 	$stmt = @vsprintf($sql, $args);
 

--- a/include/security.php
+++ b/include/security.php
@@ -116,7 +116,7 @@ function authenticate_success($user_record, $login_initial = false, $interactive
 		$r = DBA::select('user', ['uid', 'username', 'nickname'],
 			['parent-uid' => $master_record['uid'], 'account_removed' => false]);
 		if (DBM::is_result($r)) {
-			$a->identities = array_merge($a->identities, DBA::inArray($r));
+			$a->identities = array_merge($a->identities, DBA::toArray($r));
 		}
 	} else {
 		// Just ensure that the array is always defined
@@ -126,14 +126,14 @@ function authenticate_success($user_record, $login_initial = false, $interactive
 		$r = DBA::select('user', ['uid', 'username', 'nickname'],
 			['uid' => $master_record['parent-uid'], 'account_removed' => false]);
 		if (DBM::is_result($r)) {
-			$a->identities = DBA::inArray($r);
+			$a->identities = DBA::toArray($r);
 		}
 
 		// Then add all siblings
 		$r = DBA::select('user', ['uid', 'username', 'nickname'],
 			['parent-uid' => $master_record['parent-uid'], 'account_removed' => false]);
 		if (DBM::is_result($r)) {
-			$a->identities = array_merge($a->identities, DBA::inArray($r));
+			$a->identities = array_merge($a->identities, DBA::toArray($r));
 		}
 	}
 
@@ -144,7 +144,7 @@ function authenticate_success($user_record, $login_initial = false, $interactive
 		$master_record['uid']
 	);
 	if (DBM::is_result($r)) {
-		$a->identities = array_merge($a->identities, DBA::inArray($r));
+		$a->identities = array_merge($a->identities, DBA::toArray($r));
 	}
 
 	if ($login_initial) {

--- a/mod/admin.php
+++ b/mod/admin.php
@@ -479,7 +479,7 @@ function admin_page_contactblock(App $a)
 
 	$statement = DBA::select('contact', [], $condition, ['limit' => [$a->pager['start'], $a->pager['itemspage']]]);
 
-	$contacts = DBA::inArray($statement);
+	$contacts = DBA::toArray($statement);
 
 	$t = get_markup_template('admin/contactblock.tpl');
 	$o = replace_macros($t, [
@@ -782,7 +782,7 @@ function admin_page_workerqueue(App $a)
 {
 	// get jobs from the workerqueue table
 	$statement = DBA::select('workerqueue', ['id', 'parameter', 'created', 'priority'], ['done' => 0], ['order'=> ['priority']]);
-	$r = DBA::inArray($statement);
+	$r = DBA::toArray($statement);
 
 	for($i = 0; $i < count($r); $i++) {
 		$r[$i]['parameter'] = implode(json_decode($r[$i]['parameter']), ': ');

--- a/mod/admin.php
+++ b/mod/admin.php
@@ -816,7 +816,7 @@ function admin_page_workerqueue(App $a)
 function admin_page_summary(App $a)
 {
 	// are there MyISAM tables in the DB? If so, trigger a warning message
-	$r = q("SELECT `engine` FROM `information_schema`.`tables` WHERE `engine` = 'myisam' AND `table_schema` = '%s' LIMIT 1", dbesc(DBA::database_name()));
+	$r = q("SELECT `engine` FROM `information_schema`.`tables` WHERE `engine` = 'myisam' AND `table_schema` = '%s' LIMIT 1", dbesc(DBA::databaseName()));
 	$showwarning = false;
 	$warningtext = [];
 	if (DBM::is_result($r)) {

--- a/mod/community.php
+++ b/mod/community.php
@@ -198,14 +198,14 @@ function community_getitems($start, $itemspage, $content)
 			AND NOT `thread`.`private` AND `thread`.`wall` AND `thread`.`origin`
 			ORDER BY `thread`.`commented` DESC LIMIT " . intval($start) . ", " . intval($itemspage)
 		);
-		return DBA::inArray($r);
+		return DBA::toArray($r);
 	} elseif ($content == 'global') {
 		$r = DBA::p("SELECT `uri` FROM `thread`
 				INNER JOIN `item` ON `item`.`id` = `thread`.`iid`
 				INNER JOIN `contact` AS `author` ON `author`.`id`=`item`.`author-id`
 				WHERE `thread`.`uid` = 0 AND NOT `author`.`hidden` AND NOT `author`.`blocked`
 				ORDER BY `thread`.`commented` DESC LIMIT " . intval($start) . ", " . intval($itemspage));
-		return DBA::inArray($r);
+		return DBA::toArray($r);
 	}
 
 	// Should never happen

--- a/mod/dfrn_notify.php
+++ b/mod/dfrn_notify.php
@@ -213,7 +213,7 @@ function dfrn_dispatch_public($postdata)
 	}
 
 	// We now have some contact, so we fetch it
-	$importer = DBA::fetch_first("SELECT *, `name` as `senderName`
+	$importer = DBA::fetchFirst("SELECT *, `name` as `senderName`
 					FROM `contact`
 					WHERE NOT `blocked` AND `id` = ? LIMIT 1",
 					$contact['id']);
@@ -252,7 +252,7 @@ function dfrn_dispatch_private($user, $postdata)
 	}
 
 	// We now have some contact, so we fetch it
-	$importer = DBA::fetch_first("SELECT *, `name` as `senderName`
+	$importer = DBA::fetchFirst("SELECT *, `name` as `senderName`
 					FROM `contact`
 					WHERE NOT `blocked` AND `id` = ? LIMIT 1",
 					$cid);

--- a/mod/directory.php
+++ b/mod/directory.php
@@ -83,7 +83,7 @@ function directory_content(App $a)
 	$publish = (Config::get('system', 'publish_all') ? '' : " AND `publish` = 1 " );
 
 
-	$cnt = DBA::fetch_first("SELECT COUNT(*) AS `total` FROM `profile`
+	$cnt = DBA::fetchFirst("SELECT COUNT(*) AS `total` FROM `profile`
 				LEFT JOIN `user` ON `user`.`uid` = `profile`.`uid`
 				WHERE `is-default` $publish AND NOT `user`.`blocked` AND NOT `user`.`account_removed` $sql_extra");
 	if (DBM::is_result($cnt)) {

--- a/mod/display.php
+++ b/mod/display.php
@@ -87,7 +87,7 @@ function display_init(App $a)
 		$nickname = str_replace(normalise_link(System::baseUrl())."/profile/", "", normalise_link($profiledata["url"]));
 
 		if (($nickname != $a->user["nickname"])) {
-			$profile = DBA::fetch_first("SELECT `profile`.`uid` AS `profile_uid`, `profile`.* , `contact`.`avatar-date` AS picdate, `user`.* FROM `profile`
+			$profile = DBA::fetchFirst("SELECT `profile`.`uid` AS `profile_uid`, `profile`.* , `contact`.`avatar-date` AS picdate, `user`.* FROM `profile`
 				INNER JOIN `contact` on `contact`.`uid` = `profile`.`uid` INNER JOIN `user` ON `profile`.`uid` = `user`.`uid`
 				WHERE `user`.`nickname` = ? AND `profile`.`is-default` AND `contact`.`self` LIMIT 1",
 				$nickname

--- a/mod/network.php
+++ b/mod/network.php
@@ -845,7 +845,7 @@ function networkThreadedView(App $a, $update, $parent)
 			local_user(), TERM_OBJ_POST, TERM_HASHTAG,
 			$top_limit, $bottom_limit);
 
-		$data = DBA::inArray($items);
+		$data = DBA::toArray($items);
 
 		if (count($data) > 0) {
 			$tag_top_limit = current($data)['order_date'];

--- a/src/App.php
+++ b/src/App.php
@@ -496,7 +496,7 @@ class App
 
 		$this->mode |= App::MODE_DBAVAILABLE;
 
-		if (DBA::fetch_first("SHOW TABLES LIKE 'config'") === false) {
+		if (DBA::fetchFirst("SHOW TABLES LIKE 'config'") === false) {
 			return;
 		}
 

--- a/src/Content/ContactSelector.php
+++ b/src/Content/ContactSelector.php
@@ -27,7 +27,7 @@ class ContactSelector
 		$o .= "<select id=\"contact-profile-selector\" class=\"form-control\" $disabled name=\"profile-assign\" >\r\n";
 
 		$s = DBA::select('profile', ['id', 'profile-name', 'is-default'], ['uid' => $_SESSION['uid']]);
-		$r = DBA::inArray($s);
+		$r = DBA::toArray($s);
 
 		if (DBM::is_result($r)) {
 			foreach ($r as $rr) {

--- a/src/Content/ContactSelector.php
+++ b/src/Content/ContactSelector.php
@@ -102,7 +102,7 @@ class ContactSelector
 		$networkname = str_replace($search, $replace, $s);
 
 		if ((in_array($s, [NETWORK_DFRN, NETWORK_DIASPORA, NETWORK_OSTATUS])) && ($profile != "")) {
-			$r = DBA::fetch_first("SELECT `gserver`.`platform` FROM `gcontact`
+			$r = DBA::fetchFirst("SELECT `gserver`.`platform` FROM `gcontact`
 					INNER JOIN `gserver` ON `gserver`.`nurl` = `gcontact`.`server_url`
 					WHERE `gcontact`.`nurl` = ? AND `platform` != ''", normalise_link($profile));
 

--- a/src/Core/ACL.php
+++ b/src/Core/ACL.php
@@ -106,7 +106,7 @@ class ACL extends BaseObject
 			ORDER BY `name` ASC ", intval(local_user())
 		);
 
-		$contacts = DBA::inArray($stmt);
+		$contacts = DBA::toArray($stmt);
 
 		$arr = ['contact' => $contacts, 'entry' => $o];
 
@@ -171,7 +171,7 @@ class ACL extends BaseObject
 			ORDER BY `name` ASC ", intval(local_user())
 		);
 
-		$contacts = DBA::inArray($stmt);
+		$contacts = DBA::toArray($stmt);
 
 		$arr = ['contact' => $contacts, 'entry' => $o];
 

--- a/src/Core/Addon.php
+++ b/src/Core/Addon.php
@@ -81,7 +81,7 @@ class Addon
 		if (strlen($addons)) {
 			$r = DBA::select('addon', [], ['installed' => 1]);
 			if (DBM::is_result($r)) {
-				$installed = DBA::inArray($r);
+				$installed = DBA::toArray($r);
 			} else {
 				$installed = [];
 			}

--- a/src/Core/Worker.php
+++ b/src/Core/Worker.php
@@ -874,7 +874,7 @@ class Worker
 		$r = DBA::select('workerqueue', [], ['pid' => getmypid(), 'done' => false]);
 		if (DBM::is_result($r)) {
 			self::$db_duration += (microtime(true) - $stamp);
-			return DBA::inArray($r);
+			return DBA::toArray($r);
 		}
 		DBA::close($r);
 
@@ -892,7 +892,7 @@ class Worker
 
 		if ($found) {
 			$r = DBA::select('workerqueue', [], ['pid' => getmypid(), 'done' => false]);
-			return DBA::inArray($r);
+			return DBA::toArray($r);
 		}
 		return false;
 	}

--- a/src/Core/Worker.php
+++ b/src/Core/Worker.php
@@ -498,7 +498,7 @@ class Worker
 		// The processlist only shows entries of the current user
 		if ($max != 0) {
 			$r = DBA::p('SHOW PROCESSLIST');
-			$used = DBA::num_rows($r);
+			$used = DBA::numRows($r);
 			DBA::close($r);
 
 			logger("Connection usage (user values): ".$used."/".$max, LOGGER_DEBUG);

--- a/src/Core/Worker.php
+++ b/src/Core/Worker.php
@@ -477,7 +477,7 @@ class Worker
 
 		if ($max == 0) {
 			// the maximum number of possible user connections can be a system variable
-			$r = DBA::fetch_first("SHOW VARIABLES WHERE `variable_name` = 'max_user_connections'");
+			$r = DBA::fetchFirst("SHOW VARIABLES WHERE `variable_name` = 'max_user_connections'");
 			if (DBM::is_result($r)) {
 				$max = $r["Value"];
 			}
@@ -513,7 +513,7 @@ class Worker
 
 		// We will now check for the system values.
 		// This limit could be reached although the user limits are fine.
-		$r = DBA::fetch_first("SHOW VARIABLES WHERE `variable_name` = 'max_connections'");
+		$r = DBA::fetchFirst("SHOW VARIABLES WHERE `variable_name` = 'max_connections'");
 		if (!DBM::is_result($r)) {
 			return false;
 		}
@@ -521,7 +521,7 @@ class Worker
 		if ($max == 0) {
 			return false;
 		}
-		$r = DBA::fetch_first("SHOW STATUS WHERE `variable_name` = 'Threads_connected'");
+		$r = DBA::fetchFirst("SHOW STATUS WHERE `variable_name` = 'Threads_connected'");
 		if (!DBM::is_result($r)) {
 			return false;
 		}

--- a/src/Database/DBA.php
+++ b/src/Database/DBA.php
@@ -185,7 +185,7 @@ class DBA
 	 */
 	public static function databaseName() {
 		$ret = self::p("SELECT DATABASE() AS `db`");
-		$data = self::inArray($ret);
+		$data = self::toArray($ret);
 		return $data[0]['db'];
 	}
 
@@ -266,7 +266,7 @@ class DBA
 			case 'pdo':
 				$r = self::p("SELECT 1");
 				if (DBM::is_result($r)) {
-					$row = self::inArray($r);
+					$row = self::toArray($r);
 					$connected = ($row[0]['1'] == '1');
 				}
 				break;
@@ -1462,7 +1462,7 @@ class DBA
 	 * @param object $stmt statement object
 	 * @return array Data array
 	 */
-	public static function inArray($stmt, $do_close = true) {
+	public static function toArray($stmt, $do_close = true) {
 		if (is_bool($stmt)) {
 			return $stmt;
 		}

--- a/src/Database/DBA.php
+++ b/src/Database/DBA.php
@@ -183,7 +183,7 @@ class DBA
 	 *
 	 * @return string
 	 */
-	public static function database_name() {
+	public static function databaseName() {
 		$ret = self::p("SELECT DATABASE() AS `db`");
 		$data = self::inArray($ret);
 		return $data[0]['db'];

--- a/src/Database/DBA.php
+++ b/src/Database/DBA.php
@@ -288,7 +288,7 @@ class DBA
 	 * @param string $sql An SQL string without the values
 	 * @return string The input SQL string modified if necessary.
 	 */
-	public static function any_value_fallback($sql) {
+	public static function anyValueFallback($sql) {
 		$server_info = self::server_info();
 		if (version_compare($server_info, '5.7.5', '<') ||
 			(stripos($server_info, 'MariaDB') !== false)) {
@@ -397,7 +397,7 @@ class DBA
 		}
 
 		$sql = self::clean_query($sql);
-		$sql = self::any_value_fallback($sql);
+		$sql = self::anyValueFallback($sql);
 
 		$orig_sql = $sql;
 

--- a/src/Database/DBA.php
+++ b/src/Database/DBA.php
@@ -704,7 +704,7 @@ class DBA
 	 *
 	 * @return int Number of rows
 	 */
-	public static function affected_rows() {
+	public static function affectedRows() {
 		return self::$affected_rows;
 	}
 

--- a/src/Database/DBA.php
+++ b/src/Database/DBA.php
@@ -164,7 +164,7 @@ class DBA
 	 *
 	 * @return string
 	 */
-	public static function server_info() {
+	public static function serverInfo() {
 		if (self::$server_info == '') {
 			switch (self::$driver) {
 				case 'pdo':
@@ -289,7 +289,7 @@ class DBA
 	 * @return string The input SQL string modified if necessary.
 	 */
 	public static function anyValueFallback($sql) {
-		$server_info = self::server_info();
+		$server_info = self::serverInfo();
 		if (version_compare($server_info, '5.7.5', '<') ||
 			(stripos($server_info, 'MariaDB') !== false)) {
 			$sql = str_ireplace('ANY_VALUE(', 'MIN(', $sql);

--- a/src/Database/DBA.php
+++ b/src/Database/DBA.php
@@ -683,7 +683,7 @@ class DBA
 	 * @param string $sql SQL statement
 	 * @return array first row of query
 	 */
-	public static function fetch_first($sql) {
+	public static function fetchFirst($sql) {
 		$params = self::getParam(func_get_args());
 
 		$stmt = self::p($sql, $params);
@@ -1344,7 +1344,7 @@ class DBA
 
 		$sql = "SELECT COUNT(*) AS `count` FROM `".$table."`".$condition_string;
 
-		$row = self::fetch_first($sql, $condition);
+		$row = self::fetchFirst($sql, $condition);
 
 		return $row['count'];
 	}

--- a/src/Database/DBA.php
+++ b/src/Database/DBA.php
@@ -666,7 +666,7 @@ class DBA
 		if (is_bool($stmt)) {
 			$retval = $stmt;
 		} else {
-			$retval = (self::num_rows($stmt) > 0);
+			$retval = (self::numRows($stmt) > 0);
 		}
 
 		self::close($stmt);
@@ -732,7 +732,7 @@ class DBA
 	 * @param PDOStatement|mysqli_result|mysqli_stmt Statement object
 	 * @return int Number of rows
 	 */
-	public static function num_rows($stmt) {
+	public static function numRows($stmt) {
 		if (!is_object($stmt)) {
 			return 0;
 		}

--- a/src/Database/DBA.php
+++ b/src/Database/DBA.php
@@ -306,7 +306,7 @@ class DBA
 	 * @param string $sql An SQL string without the values
 	 * @return string The input SQL string modified if necessary.
 	 */
-	public static function clean_query($sql) {
+	public static function cleanQuery($sql) {
 		$search = ["\t", "\n", "\r", "  "];
 		$replace = [' ', ' ', ' ', ' '];
 		do {
@@ -396,7 +396,7 @@ class DBA
 			logger('Parameter mismatch. Query "'.$sql.'" - Parameters '.print_r($args, true), LOGGER_DEBUG);
 		}
 
-		$sql = self::clean_query($sql);
+		$sql = self::cleanQuery($sql);
 		$sql = self::anyValueFallback($sql);
 
 		$orig_sql = $sql;

--- a/src/Database/DBA.php
+++ b/src/Database/DBA.php
@@ -23,7 +23,7 @@ class DBA
 	public static $connected = false;
 
 	private static $server_info = '';
-	private static $db;
+	private static $connection;
 	private static $driver;
 	private static $error = false;
 	private static $errorno = 0;
@@ -39,7 +39,7 @@ class DBA
 
 	public static function connect($serveraddr, $user, $pass, $db, $charset = null)
 	{
-		if (!is_null(self::$db) && self::connected()) {
+		if (!is_null(self::$connection) && self::connected()) {
 			return true;
 		}
 
@@ -83,8 +83,8 @@ class DBA
 			}
 
 			try {
-				self::$db = @new PDO($connect, $user, $pass);
-				self::$db->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
+				self::$connection = @new PDO($connect, $user, $pass);
+				self::$connection->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
 				self::$connected = true;
 			} catch (PDOException $e) {
 			}
@@ -94,16 +94,16 @@ class DBA
 			self::$driver = 'mysqli';
 
 			if ($port > 0) {
-				self::$db = @new mysqli($server, $user, $pass, $db, $port);
+				self::$connection = @new mysqli($server, $user, $pass, $db, $port);
 			} else {
-				self::$db = @new mysqli($server, $user, $pass, $db);
+				self::$connection = @new mysqli($server, $user, $pass, $db);
 			}
 
 			if (!mysqli_connect_errno()) {
 				self::$connected = true;
 
 				if ($charset) {
-					self::$db->set_charset($charset);
+					self::$connection->set_charset($charset);
 				}
 			}
 		}
@@ -111,7 +111,7 @@ class DBA
 		// No suitable SQL driver was found.
 		if (!self::$connected) {
 			self::$driver = null;
-			self::$db = null;
+			self::$connection = null;
 		}
 
 		return self::$connected;
@@ -122,17 +122,17 @@ class DBA
 	 */
 	public static function disconnect()
 	{
-		if (is_null(self::$db)) {
+		if (is_null(self::$connection)) {
 			return;
 		}
 
 		switch (self::$driver) {
 			case 'pdo':
-				self::$db = null;
+				self::$connection = null;
 				break;
 			case 'mysqli':
-				self::$db->close();
-				self::$db = null;
+				self::$connection->close();
+				self::$connection = null;
 				break;
 		}
 	}
@@ -151,9 +151,9 @@ class DBA
 	 * Return the database object.
 	 * @return PDO|mysqli
 	 */
-	public static function get_db()
+	public static function getConnection()
 	{
-		return self::$db;
+		return self::$connection;
 	}
 
 	/**
@@ -168,10 +168,10 @@ class DBA
 		if (self::$server_info == '') {
 			switch (self::$driver) {
 				case 'pdo':
-					self::$server_info = self::$db->getAttribute(PDO::ATTR_SERVER_VERSION);
+					self::$server_info = self::$connection->getAttribute(PDO::ATTR_SERVER_VERSION);
 					break;
 				case 'mysqli':
-					self::$server_info = self::$db->server_info;
+					self::$server_info = self::$connection->server_info;
 					break;
 			}
 		}
@@ -249,16 +249,16 @@ class DBA
 	public static function escape($str) {
 		switch (self::$driver) {
 			case 'pdo':
-				return substr(@self::$db->quote($str, PDO::PARAM_STR), 1, -1);
+				return substr(@self::$connection->quote($str, PDO::PARAM_STR), 1, -1);
 			case 'mysqli':
-				return @self::$db->real_escape_string($str);
+				return @self::$connection->real_escape_string($str);
 		}
 	}
 
 	public static function connected() {
 		$connected = false;
 
-		if (is_null(self::$db)) {
+		if (is_null(self::$connection)) {
 			return false;
 		}
 
@@ -271,7 +271,7 @@ class DBA
 				}
 				break;
 			case 'mysqli':
-				$connected = self::$db->ping();
+				$connected = self::$connection->ping();
 				break;
 		}
 		return $connected;
@@ -425,8 +425,8 @@ class DBA
 			case 'pdo':
 				// If there are no arguments we use "query"
 				if (count($args) == 0) {
-					if (!$retval = self::$db->query($sql)) {
-						$errorInfo = self::$db->errorInfo();
+					if (!$retval = self::$connection->query($sql)) {
+						$errorInfo = self::$connection->errorInfo();
 						self::$error = $errorInfo[2];
 						self::$errorno = $errorInfo[1];
 						$retval = false;
@@ -436,8 +436,8 @@ class DBA
 					break;
 				}
 
-				if (!$stmt = self::$db->prepare($sql)) {
-					$errorInfo = self::$db->errorInfo();
+				if (!$stmt = self::$connection->prepare($sql)) {
+					$errorInfo = self::$connection->errorInfo();
 					self::$error = $errorInfo[2];
 					self::$errorno = $errorInfo[1];
 					$retval = false;
@@ -471,22 +471,22 @@ class DBA
 
 				// The fallback routine is called as well when there are no arguments
 				if (!$can_be_prepared || (count($args) == 0)) {
-					$retval = self::$db->query(self::replaceParameters($sql, $args));
-					if (self::$db->errno) {
-						self::$error = self::$db->error;
-						self::$errorno = self::$db->errno;
+					$retval = self::$connection->query(self::replaceParameters($sql, $args));
+					if (self::$connection->errno) {
+						self::$error = self::$connection->error;
+						self::$errorno = self::$connection->errno;
 						$retval = false;
 					} else {
 						if (isset($retval->num_rows)) {
 							self::$affected_rows = $retval->num_rows;
 						} else {
-							self::$affected_rows = self::$db->affected_rows;
+							self::$affected_rows = self::$connection->affected_rows;
 						}
 					}
 					break;
 				}
 
-				$stmt = self::$db->stmt_init();
+				$stmt = self::$connection->stmt_init();
 
 				if (!$stmt->prepare($sql)) {
 					self::$error = $stmt->error;
@@ -516,8 +516,8 @@ class DBA
 				}
 
 				if (!$stmt->execute()) {
-					self::$error = self::$db->error;
-					self::$errorno = self::$db->errno;
+					self::$error = self::$connection->error;
+					self::$errorno = self::$connection->errno;
 					$retval = false;
 				} else {
 					$stmt->store_result();
@@ -841,10 +841,10 @@ class DBA
 	public static function lastInsertId() {
 		switch (self::$driver) {
 			case 'pdo':
-				$id = self::$db->lastInsertId();
+				$id = self::$connection->lastInsertId();
 				break;
 			case 'mysqli':
-				$id = self::$db->insert_id;
+				$id = self::$connection->insert_id;
 				break;
 		}
 		return $id;
@@ -863,22 +863,22 @@ class DBA
 		// See here: https://dev.mysql.com/doc/refman/5.7/en/lock-tables-and-transactions.html
 		if (self::$driver == 'pdo') {
 			self::e("SET autocommit=0");
-			self::$db->setAttribute(PDO::ATTR_EMULATE_PREPARES, true);
+			self::$connection->setAttribute(PDO::ATTR_EMULATE_PREPARES, true);
 		} else {
-			self::$db->autocommit(false);
+			self::$connection->autocommit(false);
 		}
 
 		$success = self::e("LOCK TABLES `".self::escape($table)."` WRITE");
 
 		if (self::$driver == 'pdo') {
-			self::$db->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
+			self::$connection->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
 		}
 
 		if (!$success) {
 			if (self::$driver == 'pdo') {
 				self::e("SET autocommit=1");
 			} else {
-				self::$db->autocommit(true);
+				self::$connection->autocommit(true);
 			}
 		} else {
 			self::$in_transaction = true;
@@ -896,16 +896,16 @@ class DBA
 		self::performCommit();
 
 		if (self::$driver == 'pdo') {
-			self::$db->setAttribute(PDO::ATTR_EMULATE_PREPARES, true);
+			self::$connection->setAttribute(PDO::ATTR_EMULATE_PREPARES, true);
 		}
 
 		$success = self::e("UNLOCK TABLES");
 
 		if (self::$driver == 'pdo') {
-			self::$db->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
+			self::$connection->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
 			self::e("SET autocommit=1");
 		} else {
-			self::$db->autocommit(true);
+			self::$connection->autocommit(true);
 		}
 
 		self::$in_transaction = false;
@@ -924,15 +924,15 @@ class DBA
 
 		switch (self::$driver) {
 			case 'pdo':
-				if (self::$db->inTransaction()) {
+				if (self::$connection->inTransaction()) {
 					break;
 				}
-				if (!self::$db->beginTransaction()) {
+				if (!self::$connection->beginTransaction()) {
 					return false;
 				}
 				break;
 			case 'mysqli':
-				if (!self::$db->begin_transaction()) {
+				if (!self::$connection->begin_transaction()) {
 					return false;
 				}
 				break;
@@ -946,12 +946,12 @@ class DBA
 	{
 		switch (self::$driver) {
 			case 'pdo':
-				if (!self::$db->inTransaction()) {
+				if (!self::$connection->inTransaction()) {
 					return true;
 				}
-				return self::$db->commit();
+				return self::$connection->commit();
 			case 'mysqli':
-				return self::$db->commit();
+				return self::$connection->commit();
 		}
 		return true;
 	}
@@ -979,14 +979,14 @@ class DBA
 
 		switch (self::$driver) {
 			case 'pdo':
-				if (!self::$db->inTransaction()) {
+				if (!self::$connection->inTransaction()) {
 					$ret = true;
 					break;
 				}
-				$ret = self::$db->rollBack();
+				$ret = self::$connection->rollBack();
 				break;
 			case 'mysqli':
-				$ret = self::$db->rollback();
+				$ret = self::$connection->rollback();
 				break;
 		}
 		self::$in_transaction = false;

--- a/src/Database/DBM.php
+++ b/src/Database/DBM.php
@@ -64,7 +64,7 @@ class DBM
 		}
 
 		if (is_object($array)) {
-			return DBA::num_rows($array) > 0;
+			return DBA::numRows($array) > 0;
 		}
 
 		return (is_array($array) && (count($array) > 0));

--- a/src/Database/DBStructure.php
+++ b/src/Database/DBStructure.php
@@ -460,7 +460,7 @@ class DBStructure
 						if ($ignore != "") {
 							echo "SET session old_alter_table=0;\n";
 						} else {
-							echo "INSERT INTO `".$temp_name."` SELECT ".DBA::any_value_fallback($field_list)." FROM `".$name."`".$group_by.";\n";
+							echo "INSERT INTO `".$temp_name."` SELECT ".DBA::anyValueFallback($field_list)." FROM `".$name."`".$group_by.";\n";
 							echo "DROP TABLE `".$name."`;\n";
 							echo "RENAME TABLE `".$temp_name."` TO `".$name."`;\n";
 						}

--- a/src/Database/DBStructure.php
+++ b/src/Database/DBStructure.php
@@ -236,8 +236,8 @@ class DBStructure
 		}
 
 		// MySQL >= 5.7.4 doesn't support the IGNORE keyword in ALTER TABLE statements
-		if ((version_compare(DBA::server_info(), '5.7.4') >= 0) &&
-			!(strpos(DBA::server_info(), 'MariaDB') !== false)) {
+		if ((version_compare(DBA::serverInfo(), '5.7.4') >= 0) &&
+			!(strpos(DBA::serverInfo(), 'MariaDB') !== false)) {
 			$ignore = '';
 		} else {
 			$ignore = ' IGNORE';

--- a/src/Database/DBStructure.php
+++ b/src/Database/DBStructure.php
@@ -26,7 +26,7 @@ class DBStructure
 	 */
 	public static function convertToInnoDB() {
 		$r = q("SELECT `TABLE_NAME` FROM `information_schema`.`tables` WHERE `engine` = 'MyISAM' AND `table_schema` = '%s'",
-			dbesc(DBA::database_name()));
+			dbesc(DBA::databaseName()));
 
 		if (!DBM::is_result($r)) {
 			echo L10n::t('There are no tables on MyISAM.')."\n";

--- a/src/Database/DBStructure.php
+++ b/src/Database/DBStructure.php
@@ -706,7 +706,7 @@ class DBStructure
 		if (is_bool($stmt)) {
 			$retval = $stmt;
 		} else {
-			$retval = (DBA::num_rows($stmt) > 0);
+			$retval = (DBA::numRows($stmt) > 0);
 		}
 
 		DBA::close($stmt);
@@ -741,7 +741,7 @@ class DBStructure
 			if (is_bool($stmt)) {
 				$retval = $stmt;
 			} else {
-				$retval = (DBA::num_rows($stmt) > 0);
+				$retval = (DBA::numRows($stmt) > 0);
 			}
 
 			DBA::close($stmt);

--- a/src/Database/DBStructure.php
+++ b/src/Database/DBStructure.php
@@ -322,8 +322,8 @@ class DBStructure
 							$parameters['comment'] = "";
 						}
 
-						$current_field_definition = DBA::clean_query(implode(",", $field_definition));
-						$new_field_definition = DBA::clean_query(implode(",", $parameters));
+						$current_field_definition = DBA::cleanQuery(implode(",", $field_definition));
+						$new_field_definition = DBA::cleanQuery(implode(",", $parameters));
 						if ($current_field_definition != $new_field_definition) {
 							$sql2 = self::modifyTableField($fieldname, $parameters);
 							if ($sql3 == "") {

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -55,7 +55,7 @@ class Contact extends BaseObject
 				local_user()
 			);
 			if (DBM::is_result($stmt)) {
-				$return = DBA::inArray($stmt);
+				$return = DBA::toArray($stmt);
 			}
 		}
 
@@ -401,14 +401,14 @@ class Contact extends BaseObject
 		$s = DBA::p("SELECT `id`, `id` AS `cid`, 0 AS `gid`, 0 AS `zid`, `uid`, `url`, `nurl`, `alias`, `network`, `name`, `nick`, `addr`, `location`, `about`, `xmpp`,
 			`keywords`, `gender`, `photo`, `thumb`, `micro`, `forum`, `prv`, (`forum` | `prv`) AS `community`, `contact-type`, `bd` AS `birthday`, `self`
 		FROM `contact` WHERE `nurl` = ? AND `uid` = ?", normalise_link($url), $uid);
-		$r = DBA::inArray($s);
+		$r = DBA::toArray($s);
 
 		// Fetch contact data from the contact table for the given user, checking with the alias
 		if (!DBM::is_result($r)) {
 			$s = DBA::p("SELECT `id`, `id` AS `cid`, 0 AS `gid`, 0 AS `zid`, `uid`, `url`, `nurl`, `alias`, `network`, `name`, `nick`, `addr`, `location`, `about`, `xmpp`,
 				`keywords`, `gender`, `photo`, `thumb`, `micro`, `forum`, `prv`, (`forum` | `prv`) AS `community`, `contact-type`, `bd` AS `birthday`, `self`
 			FROM `contact` WHERE `alias` IN (?, ?, ?) AND `uid` = ?", normalise_link($url), $url, $ssl_url, $uid);
-			$r = DBA::inArray($s);
+			$r = DBA::toArray($s);
 		}
 
 		// Fetch the data from the contact table with "uid=0" (which is filled automatically)
@@ -416,7 +416,7 @@ class Contact extends BaseObject
 			$s = DBA::p("SELECT `id`, 0 AS `cid`, `id` AS `zid`, 0 AS `gid`, `uid`, `url`, `nurl`, `alias`, `network`, `name`, `nick`, `addr`, `location`, `about`, `xmpp`,
 			`keywords`, `gender`, `photo`, `thumb`, `micro`, `forum`, `prv`, (`forum` | `prv`) AS `community`, `contact-type`, `bd` AS `birthday`, 0 AS `self`
 			FROM `contact` WHERE `nurl` = ? AND `uid` = 0", normalise_link($url));
-			$r = DBA::inArray($s);
+			$r = DBA::toArray($s);
 		}
 
 		// Fetch the data from the contact table with "uid=0" (which is filled automatically) - checked with the alias
@@ -424,7 +424,7 @@ class Contact extends BaseObject
 			$s = DBA::p("SELECT `id`, 0 AS `cid`, `id` AS `zid`, 0 AS `gid`, `uid`, `url`, `nurl`, `alias`, `network`, `name`, `nick`, `addr`, `location`, `about`, `xmpp`,
 			`keywords`, `gender`, `photo`, `thumb`, `micro`, `forum`, `prv`, (`forum` | `prv`) AS `community`, `contact-type`, `bd` AS `birthday`, 0 AS `self`
 			FROM `contact` WHERE `alias` IN (?, ?, ?) AND `uid` = 0", normalise_link($url), $url, $ssl_url);
-			$r = DBA::inArray($s);
+			$r = DBA::toArray($s);
 		}
 
 		// Fetch the data from the gcontact table
@@ -432,7 +432,7 @@ class Contact extends BaseObject
 			$s = DBA::p("SELECT 0 AS `id`, 0 AS `cid`, `id` AS `gid`, 0 AS `zid`, 0 AS `uid`, `url`, `nurl`, `alias`, `network`, `name`, `nick`, `addr`, `location`, `about`, '' AS `xmpp`,
 			`keywords`, `gender`, `photo`, `photo` AS `thumb`, `photo` AS `micro`, 0 AS `forum`, 0 AS `prv`, `community`, `contact-type`, `birthday`, 0 AS `self`
 			FROM `gcontact` WHERE `nurl` = ?", normalise_link($url));
-			$r = DBA::inArray($s);
+			$r = DBA::toArray($s);
 		}
 
 		if (DBM::is_result($r)) {
@@ -866,7 +866,7 @@ class Contact extends BaseObject
 			);
 
 			$s = DBA::select('contact', ['id'], ['nurl' => normalise_link($data["url"]), 'uid' => $uid], ['order' => ['id'], 'limit' => 2]);
-			$contacts = DBA::inArray($s);
+			$contacts = DBA::toArray($s);
 			if (!DBM::is_result($contacts)) {
 				return 0;
 			}

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -72,7 +72,7 @@ class Contact extends BaseObject
 	{
 		$return = 0;
 		if (intval($gid)) {
-			$contacts = DBA::fetch_first('SELECT COUNT(*) AS `count`
+			$contacts = DBA::fetchFirst('SELECT COUNT(*) AS `count`
 				FROM `contact`
 				INNER JOIN `group_member`
 					ON `contact`.`id` = `group_member`.`contact-id`

--- a/src/Model/Event.php
+++ b/src/Model/Event.php
@@ -739,7 +739,7 @@ class Event extends BaseObject
 
 		$events = DBA::select('event', $fields, $conditions);
 		if (DBM::is_result($events)) {
-			$return = DBA::inArray($events);
+			$return = DBA::toArray($events);
 		}
 
 		return $return;

--- a/src/Model/Group.php
+++ b/src/Model/Group.php
@@ -114,7 +114,7 @@ class Group extends BaseObject
 			local_user()
 		);
 
-		return DBA::inArray($stmt);
+		return DBA::toArray($stmt);
 	}
 
 	/**

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -2427,7 +2427,7 @@ class Item extends BaseObject
 
 		// Does the given user have this item?
 		if ($uid) {
-			$item = DBA::fetch_first("SELECT `item`.`id`, `user`.`nickname` FROM `item`
+			$item = DBA::fetchFirst("SELECT `item`.`id`, `user`.`nickname` FROM `item`
 				INNER JOIN `user` ON `user`.`uid` = `item`.`uid`
 				WHERE `item`.`visible` AND NOT `item`.`deleted` AND NOT `item`.`moderated`
 					AND `item`.`guid` = ? AND `item`.`uid` = ?", $guid, $uid);
@@ -2439,7 +2439,7 @@ class Item extends BaseObject
 
 		// Or is it anywhere on the server?
 		if ($nick == "") {
-			$item = DBA::fetch_first("SELECT `item`.`id`, `user`.`nickname` FROM `item`
+			$item = DBA::fetchFirst("SELECT `item`.`id`, `user`.`nickname` FROM `item`
 				INNER JOIN `user` ON `user`.`uid` = `item`.`uid`
 				WHERE `item`.`visible` AND NOT `item`.`deleted` AND NOT `item`.`moderated`
 					AND NOT `item`.`private` AND `item`.`wall`

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -809,7 +809,7 @@ class Item extends BaseObject
 		}
 
 		// When there is no content for the "old" item table, this will count the fetched items
-		$rows = DBA::affected_rows();
+		$rows = DBA::affectedRows();
 
 		while ($item = DBA::fetch($items)) {
 

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -272,7 +272,7 @@ class Item extends BaseObject
 		if (is_bool($stmt)) {
 			$retval = $stmt;
 		} else {
-			$retval = (DBA::num_rows($stmt) > 0);
+			$retval = (DBA::numRows($stmt) > 0);
 		}
 
 		DBA::close($stmt);

--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -557,7 +557,7 @@ class Profile
 				DateTimeFormat::utcNow()
 			);
 			if (DBM::is_result($s)) {
-				$r = DBA::inArray($s);
+				$r = DBA::toArray($s);
 				Cache::set($cachekey, $r, CACHE_HOUR);
 			}
 		}

--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -210,7 +210,7 @@ class Profile
 		$profile = null;
 
 		if ($profile_id) {
-			$profile = DBA::fetch_first(
+			$profile = DBA::fetchFirst(
 				"SELECT `contact`.`id` AS `contact_id`, `contact`.`photo` AS `contact_photo`,
 					`contact`.`thumb` AS `contact_thumb`, `contact`.`micro` AS `contact_micro`,
 					`profile`.`uid` AS `profile_uid`, `profile`.*,
@@ -224,7 +224,7 @@ class Profile
 			);
 		}
 		if (!DBM::is_result($profile)) {
-			$profile = DBA::fetch_first(
+			$profile = DBA::fetchFirst(
 				"SELECT `contact`.`id` AS `contact_id`, `contact`.`photo` as `contact_photo`,
 					`contact`.`thumb` AS `contact_thumb`, `contact`.`micro` AS `contact_micro`,
 					`profile`.`uid` AS `profile_uid`, `profile`.*,

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -38,7 +38,7 @@ class User
 	 * @return boolean|array
 	 */
 	public static function getOwnerDataById($uid) {
-		$r = DBA::fetch_first("SELECT
+		$r = DBA::fetchFirst("SELECT
 			`contact`.*,
 			`user`.`prvkey` AS `uprvkey`,
 			`user`.`timezone`,

--- a/src/Network/FKOAuthDataStore.php
+++ b/src/Network/FKOAuthDataStore.php
@@ -43,7 +43,7 @@ class FKOAuthDataStore extends OAuthDataStore
 		logger(__function__ . ":" . $consumer_key);
 
 		$s = DBA::select('clients', ['client_id', 'pw', 'redirect_uri'], ['client_id' => $consumer_key]);
-		$r = DBA::inArray($s);
+		$r = DBA::toArray($s);
 
 		if (DBM::is_result($r)) {
 			return new OAuthConsumer($r[0]['client_id'], $r[0]['pw'], $r[0]['redirect_uri']);
@@ -63,7 +63,7 @@ class FKOAuthDataStore extends OAuthDataStore
 		logger(__function__ . ":" . $consumer . ", " . $token_type . ", " . $token);
 
 		$s = DBA::select('tokens', ['id', 'secret', 'scope', 'expires', 'uid'], ['client_id' => $consumer->key, 'scope' => $token_type, 'id' => $token]);
-		$r = DBA::inArray($s);
+		$r = DBA::toArray($s);
 
 		if (DBM::is_result($r)) {
 			$ot = new OAuthToken($r[0]['id'], $r[0]['secret']);

--- a/src/Worker/DBClean.php
+++ b/src/Worker/DBClean.php
@@ -85,7 +85,7 @@ class DBClean {
 						NOT EXISTS (SELECT `guid` FROM `item` AS `i` WHERE `item`.`guid` = `i`.`guid` AND `i`.`uid` != 0) AND
 						`received` < UTC_TIMESTAMP() - INTERVAL ? DAY AND `id` >= ?
 					ORDER BY `id` LIMIT ".intval($limit), $days_unclaimed, $last_id);
-			$count = DBA::num_rows($r);
+			$count = DBA::numRows($r);
 			if ($count > 0) {
 				logger("found global item orphans: ".$count);
 				while ($orphan = DBA::fetch($r)) {
@@ -107,7 +107,7 @@ class DBClean {
 			$r = DBA::p("SELECT `id` FROM `item`
 					WHERE NOT EXISTS (SELECT `id` FROM `item` AS `i` WHERE `item`.`parent` = `i`.`id`)
 					AND `id` >= ? ORDER BY `id` LIMIT ".intval($limit), $last_id);
-			$count = DBA::num_rows($r);
+			$count = DBA::numRows($r);
 			if ($count > 0) {
 				logger("found item orphans without parents: ".$count);
 				while ($orphan = DBA::fetch($r)) {
@@ -133,7 +133,7 @@ class DBClean {
 			$r = DBA::p("SELECT `iid` FROM `thread`
 					WHERE NOT EXISTS (SELECT `id` FROM `item` WHERE `item`.`parent` = `thread`.`iid`) AND `iid` >= ?
 					ORDER BY `iid` LIMIT ".intval($limit), $last_id);
-			$count = DBA::num_rows($r);
+			$count = DBA::numRows($r);
 			if ($count > 0) {
 				logger("found thread orphans: ".$count);
 				while ($orphan = DBA::fetch($r)) {
@@ -159,7 +159,7 @@ class DBClean {
 			$r = DBA::p("SELECT `iid`, `id` FROM `notify`
 					WHERE NOT EXISTS (SELECT `id` FROM `item` WHERE `item`.`id` = `notify`.`iid`) AND `id` >= ?
 					ORDER BY `id` LIMIT ".intval($limit), $last_id);
-			$count = DBA::num_rows($r);
+			$count = DBA::numRows($r);
 			if ($count > 0) {
 				logger("found notify orphans: ".$count);
 				while ($orphan = DBA::fetch($r)) {
@@ -185,7 +185,7 @@ class DBClean {
 			$r = DBA::p("SELECT `id` FROM `notify-threads`
 					WHERE NOT EXISTS (SELECT `id` FROM `item` WHERE `item`.`parent` = `notify-threads`.`master-parent-item`) AND `id` >= ?
 					ORDER BY `id` LIMIT ".intval($limit), $last_id);
-			$count = DBA::num_rows($r);
+			$count = DBA::numRows($r);
 			if ($count > 0) {
 				logger("found notify-threads orphans: ".$count);
 				while ($orphan = DBA::fetch($r)) {
@@ -211,7 +211,7 @@ class DBClean {
 			$r = DBA::p("SELECT `iid`, `id` FROM `sign`
 					WHERE NOT EXISTS (SELECT `id` FROM `item` WHERE `item`.`id` = `sign`.`iid`) AND `id` >= ?
 					ORDER BY `id` LIMIT ".intval($limit), $last_id);
-			$count = DBA::num_rows($r);
+			$count = DBA::numRows($r);
 			if ($count > 0) {
 				logger("found sign orphans: ".$count);
 				while ($orphan = DBA::fetch($r)) {
@@ -237,7 +237,7 @@ class DBClean {
 			$r = DBA::p("SELECT `oid`, `tid` FROM `term`
 					WHERE NOT EXISTS (SELECT `id` FROM `item` WHERE `item`.`id` = `term`.`oid`) AND `tid` >= ?
 					ORDER BY `tid` LIMIT ".intval($limit), $last_id);
-			$count = DBA::num_rows($r);
+			$count = DBA::numRows($r);
 			if ($count > 0) {
 				logger("found term orphans: ".$count);
 				while ($orphan = DBA::fetch($r)) {
@@ -276,7 +276,7 @@ class DBClean {
 	                                                                OR (`item`.`attach` != '') OR `item`.`wall` OR `item`.`origin`)
 	                                                                AND `item`.`parent` = `thread`.`iid`)
 	                                ORDER BY `thread`.`iid` LIMIT 1000", $days, $last_id);
-			$count = DBA::num_rows($r);
+			$count = DBA::numRows($r);
 			if ($count > 0) {
 				logger("found expired threads: ".$count);
 				while ($thread = DBA::fetch($r)) {
@@ -304,7 +304,7 @@ class DBClean {
 						NOT EXISTS (SELECT `guid` FROM `item` AS `i` WHERE `item`.`guid` = `i`.`guid` AND `i`.`uid` != 0) AND
 						`received` < UTC_TIMESTAMP() - INTERVAL 90 DAY AND `id` >= ? AND `id` <= ?
 					ORDER BY `id` LIMIT ".intval($limit), $last_id, $till_id);
-			$count = DBA::num_rows($r);
+			$count = DBA::numRows($r);
 			if ($count > 0) {
 				logger("found global item entries from expired threads: ".$count);
 				while ($orphan = DBA::fetch($r)) {
@@ -327,7 +327,7 @@ class DBClean {
 			$r = DBA::p("SELECT `received`, `item-uri` FROM `conversation`
 					WHERE `received` < UTC_TIMESTAMP() - INTERVAL ? DAY
 					ORDER BY `received` LIMIT ".intval($limit), $days);
-			$count = DBA::num_rows($r);
+			$count = DBA::numRows($r);
 			if ($count > 0) {
 				logger("found old conversations: ".$count);
 				while ($orphan = DBA::fetch($r)) {

--- a/src/Worker/Delivery.php
+++ b/src/Worker/Delivery.php
@@ -254,7 +254,7 @@ class Delivery extends BaseObject
 			}
 
 			// We now have some contact, so we fetch it
-			$target_importer = DBA::fetch_first("SELECT *, `name` as `senderName`
+			$target_importer = DBA::fetchFirst("SELECT *, `name` as `senderName`
 							FROM `contact`
 							WHERE NOT `blocked` AND `id` = ? LIMIT 1",
 							$cid);

--- a/src/Worker/Expire.php
+++ b/src/Worker/Expire.php
@@ -52,12 +52,12 @@ class Expire
 			logger('Deleting orphaned item activities - start', LOGGER_DEBUG);
 			$condition = ["NOT EXISTS (SELECT `iaid` FROM `item` WHERE `item`.`iaid` = `item-activity`.`id`)"];
 			DBA::delete('item-activity', $condition);
-			logger('Orphaned item activities deleted: ' . DBA::affected_rows(), LOGGER_DEBUG);
+			logger('Orphaned item activities deleted: ' . DBA::affectedRows(), LOGGER_DEBUG);
 
 			logger('Deleting orphaned item content - start', LOGGER_DEBUG);
 			$condition = ["NOT EXISTS (SELECT `icid` FROM `item` WHERE `item`.`icid` = `item-content`.`id`)"];
 			DBA::delete('item-content', $condition);
-			logger('Orphaned item content deleted: ' . DBA::affected_rows(), LOGGER_DEBUG);
+			logger('Orphaned item content deleted: ' . DBA::affectedRows(), LOGGER_DEBUG);
 
 			// make this optional as it could have a performance impact on large sites
 			if (intval(Config::get('system', 'optimize_items'))) {

--- a/src/Worker/Notifier.php
+++ b/src/Worker/Notifier.php
@@ -408,7 +408,7 @@ class Notifier
 				$condition['network'] = $networks;
 			}
 			$contacts = DBA::select('contact', ['id', 'url', 'network'], $condition);
-			$r = DBA::inArray($contacts);
+			$r = DBA::toArray($contacts);
 		}
 
 		// delivery loop
@@ -458,7 +458,7 @@ class Notifier
 
 			$condition = ['network' => NETWORK_DFRN, 'uid' => $owner['uid'], 'blocked' => false,
 				'pending' => false, 'archive' => false, 'rel' => [CONTACT_IS_FOLLOWER, CONTACT_IS_FRIEND]];
-			$r2 = DBA::inArray(DBA::select('contact', ['id', 'name', 'network'], $condition));
+			$r2 = DBA::toArray(DBA::select('contact', ['id', 'name', 'network'], $condition));
 
 			$r = array_merge($r2, $r1);
 

--- a/src/Worker/Queue.php
+++ b/src/Worker/Queue.php
@@ -36,7 +36,7 @@ class Queue
 			// Handling the pubsubhubbub requests
 			PushSubscriber::requeue();
 
-			$r = DBA::inArray(DBA::p("SELECT `id` FROM `queue` WHERE `next` < UTC_TIMESTAMP() ORDER BY `batch`, `cid`"));
+			$r = DBA::toArray(DBA::p("SELECT `id` FROM `queue` WHERE `next` < UTC_TIMESTAMP() ORDER BY `batch`, `cid`"));
 
 			Addon::callHooks('queue_predeliver', $r);
 

--- a/src/Worker/TagUpdate.php
+++ b/src/Worker/TagUpdate.php
@@ -10,7 +10,7 @@ class TagUpdate
 	{
 		$messages = DBA::p("SELECT `oid`,`item`.`guid`, `item`.`created`, `item`.`received` FROM `term` INNER JOIN `item` ON `item`.`id`=`term`.`oid` WHERE `term`.`otype` = 1 AND `term`.`guid` = ''");
 
-		logger('fetched messages: ' . DBA::num_rows($messages));
+		logger('fetched messages: ' . DBA::numRows($messages));
 		while ($message = DBA::fetch($messages)) {
 			if ($message['uid'] == 0) {
 				$global = true;
@@ -29,7 +29,7 @@ class TagUpdate
 
 		$messages = DBA::select('item', ['guid'], ['uid' => 0]);
 
-		logger('fetched messages: ' . DBA::num_rows($messages));
+		logger('fetched messages: ' . DBA::numRows($messages));
 		while ($message = DBA::fetch(messages)) {
 			DBA::update('item', ['global' => true], ['guid' => $message['guid']]);
 		}

--- a/tests/DatabaseTest.php
+++ b/tests/DatabaseTest.php
@@ -36,7 +36,7 @@ abstract class DatabaseTest extends TestCase
 			$this->markTestSkipped('Could not connect to the database.');
 		}
 
-		return $this->createDefaultDBConnection(DBA::get_db(), getenv('MYSQL_DATABASE'));
+		return $this->createDefaultDBConnection(DBA::getConnection(), getenv('MYSQL_DATABASE'));
 	}
 
 	/**


### PR DESCRIPTION
Part 3.1 of  #5410

This PR simply renames `DBA` methods that didn't comply with the PSR-2 code standards.

Next, `DBM` will be on the chopping block, as its existence isn't warranted anymore.

Addon pendant: https://github.com/friendica/friendica-addons/pull/657