### PR TITLE
Automatically create a .htaccess when not existing

### DIFF
--- a/src/Worker/Cron.php
+++ b/src/Worker/Cron.php
@@ -112,6 +112,13 @@ class Cron
 			Config::set('system', 'last_cron_hourly', time());
 		}
 
+		// Ensure to have a .htaccess file.
+		// this is a precaution for systems that update automatically
+		$basepath = $a->get_basepath();
+		if (!file_exists($basepath . '/.htaccess')) {
+			copy($basepath . '/.htaccess-dist', $basepath . '/.htaccess');
+		}
+
 		// Poll contacts
 		self::pollContacts($parameter, $generation);
 


### PR DESCRIPTION
After PR https://github.com/friendica/friendica/pull/5428 the .htaccess is removed now.

This PR will now copy automatically the .htaccess file from the default file.