### PR TITLE
Fixes for daemon script

### DIFF
--- a/bin/daemon.php
+++ b/bin/daemon.php
@@ -17,9 +17,9 @@ if (!file_exists("boot.php") && (sizeof($_SERVER["argv"]) != 0)) {
 	$directory = dirname($_SERVER["argv"][0]);
 
 	if (substr($directory, 0, 1) != "/") {
-		$directory = $_SERVER["PWD"]."/".$directory;
+		$directory = $_SERVER["PWD"] . "/" . $directory;
 	}
-	$directory = realpath($directory."/..");
+	$directory = realpath($directory . "/..");
 
 	chdir($directory);
 }
@@ -65,7 +65,11 @@ if (empty($_SERVER["argv"][0])) {
 	die("Unexpected script behaviour. This message should never occur.\n");
 }
 
-$pid = @file_get_contents($pidfile);
+$pid = null;
+
+if (is_readable($pidfile)) {
+	$pid = intval(file_get_contents($pidfile));
+}
 
 if (empty($pid) && in_array($mode, ["stop", "status"])) {
 	Config::set('system', 'worker_daemon_mode', false);


### PR DESCRIPTION
- rewrote to first check if PID file is readable, then if found load it
- next addition is to cast it's content to int. Any non-integer content will
  result in 0 (as I know).
- Give warnings a voice! (xdebug's scream option showed a warning)
- added some spaces for better readability