### PR TITLE
LOGGER_WARNING absent

### DIFF
--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -134,7 +134,7 @@ class DFRN
 		);
 
 		if (! DBM::is_result($r)) {
-			logger(sprintf('No contact found for nickname=%d', $owner_nick), LOGGER_WARNING);
+			logger(sprintf('No contact found for nickname=%d', $owner_nick), LOGGER_NORMAL);
 			killme();
 		}
 
@@ -170,7 +170,7 @@ class DFRN
 			);
 
 			if (! DBM::is_result($r)) {
-				logger(sprintf('No contact found for uid=%d', $owner_id), LOGGER_WARNING);
+				logger(sprintf('No contact found for uid=%d', $owner_id), LOGGER_NORMAL);
 				killme();
 			}
 


### PR DESCRIPTION
There is no `LOGGER_WARNING` (triggering `E_NOTICE` about absent constant). Either declare it and push all other numbers higher or use `LOGGER_NORMAL`.