### PR TITLE
Add missing space between PHP path and script in App->proc_run

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -1128,7 +1128,7 @@ class App
 			return;
 		}
 
-		$cmdline = $this->getConfigValue('config', 'php_path', 'php') . $command;
+		$cmdline = $this->getConfigValue('config', 'php_path', 'php') . ' ' . $command;
 
 		foreach ($args as $key => $value) {
 			if (!is_null($value) && is_bool($value) && !$value) {


### PR DESCRIPTION
Follow-up to #5446
Fixes #5467