### PR TITLE
Store guid and plink with event

### DIFF
--- a/src/Model/Event.php
+++ b/src/Model/Event.php
@@ -307,7 +307,7 @@ class Event extends BaseObject
 
 			Addon::callHooks('event_updated', $event['id']);
 		} else {
-			$event['guid'] = System::createGUID(32);
+			$event['guid']  = defaults($arr, 'guid', System::createGUID(32));
 
 			// New event. Store it.
 			DBA::insert('event', $event);
@@ -321,6 +321,7 @@ class Event extends BaseObject
 			$item_arr['uri']           = $event['uri'];
 			$item_arr['parent-uri']    = $event['uri'];
 			$item_arr['guid']          = $event['guid'];
+			$item_arr['plink']         = defaults($arr, 'plink', '');
 			$item_arr['post-type']     = Item::PT_EVENT;
 			$item_arr['wall']          = $event['cid'] ? 0 : 1;
 			$item_arr['contact-id']    = $contact['id'];

--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -2642,7 +2642,7 @@ class DFRN
 					$ev["edited"]  = $item["edited"];
 					$ev["private"] = $item["private"];
 					$ev["guid"]    = $item["guid"];
-					$ev["plink"]    = $item["plink"];
+					$ev["plink"]   = $item["plink"];
 
 					$r = q(
 						"SELECT `id` FROM `event` WHERE `uri` = '%s' AND `uid` = %d LIMIT 1",

--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -2642,6 +2642,7 @@ class DFRN
 					$ev["edited"]  = $item["edited"];
 					$ev["private"] = $item["private"];
 					$ev["guid"]    = $item["guid"];
+					$ev["plink"]    = $item["plink"];
 
 					$r = q(
 						"SELECT `id` FROM `event` WHERE `uri` = '%s' AND `uid` = %d LIMIT 1",


### PR DESCRIPTION
I declare this a bugfix. We always created a new guid for a received event, although the guid (and plink) had been transported in the protocol payload.

This is now solved.