### PR TITLE
Fallback to Diaspora if DFRN transmission fails

### DIFF
--- a/src/Worker/Delivery.php
+++ b/src/Worker/Delivery.php
@@ -309,6 +309,10 @@ class Delivery extends BaseObject
 		} else {
 			// The message could not be delivered. We mark the contact as "dead"
 			Contact::markForArchival($contact);
+
+			// Transmit via Diaspora when all other methods (legacy DFRN and new one) are failing.
+			// This is a fallback for systems that don't know the new methods.
+			self::deliverDiaspora($cmd, $contact, $owner, $items, $target_item, $public_message, $top_level, $followup);
 		}
 	}
 


### PR DESCRIPTION
The legacy DFRN method is unreliable. We already switched to the new DFRN transport layer for newer version.

When this all fails we now try the Diaspora method.