### PR TITLE
Moved CONTACT_* constants to Friendica\Model\Contact class, lesser in global namespace

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -153,19 +153,6 @@ define('REGISTER_OPEN',          2);
 */
 
 /**
- * @name Contact_is
- *
- * Relationship types
- * @{
- */
-define('CONTACT_IS_FOLLOWER', 1);
-define('CONTACT_IS_SHARING',  2);
-define('CONTACT_IS_FRIEND',   3);
-/**
- *  @}
- */
-
-/**
  * @name Update
  *
  * DB update return values

--- a/boot.php
+++ b/boot.php
@@ -168,10 +168,10 @@ define('UPDATE_FAILED',  1);
  * @name page/profile types
  *
  * PAGE_NORMAL is a typical personal profile account
- * PAGE_SOAPBOX automatically approves all friend requests as CONTACT_IS_SHARING, (readonly)
- * PAGE_COMMUNITY automatically approves all friend requests as CONTACT_IS_SHARING, but with
+ * PAGE_SOAPBOX automatically approves all friend requests as Contact::SHARING, (readonly)
+ * PAGE_COMMUNITY automatically approves all friend requests as Contact::SHARING, but with
  *      write access to wall and comments (no email and not included in page owner's ACL lists)
- * PAGE_FREELOVE automatically approves all friend requests as full friends (CONTACT_IS_FRIEND).
+ * PAGE_FREELOVE automatically approves all friend requests as full friends (Contact::FRIEND).
  *
  * @{
  */

--- a/include/api.php
+++ b/include/api.php
@@ -753,7 +753,7 @@ function api_get_user(App $a, $contact_id = null)
 		'contributors_enabled' => false,
 		'is_translator' => false,
 		'is_translation_enabled' => false,
-		'following' => (($uinfo[0]['rel'] == CONTACT_IS_FOLLOWER) || ($uinfo[0]['rel'] == CONTACT_IS_FRIEND)),
+		'following' => (($uinfo[0]['rel'] == Contact::CONTACT_IS_FOLLOWER) || ($uinfo[0]['rel'] == Contact::CONTACT_IS_FRIEND)),
 		'follow_request_sent' => false,
 		'statusnet_blocking' => false,
 		'notifications' => false,
@@ -3186,9 +3186,9 @@ function api_statuses_f($qtype)
 
 	$sql_extra = '';
 	if ($qtype == 'friends') {
-		$sql_extra = sprintf(" AND ( `rel` = %d OR `rel` = %d ) ", intval(CONTACT_IS_SHARING), intval(CONTACT_IS_FRIEND));
+		$sql_extra = sprintf(" AND ( `rel` = %d OR `rel` = %d ) ", intval(Contact::CONTACT_IS_SHARING), intval(Contact::CONTACT_IS_FRIEND));
 	} elseif ($qtype == 'followers') {
-		$sql_extra = sprintf(" AND ( `rel` = %d OR `rel` = %d ) ", intval(CONTACT_IS_FOLLOWER), intval(CONTACT_IS_FRIEND));
+		$sql_extra = sprintf(" AND ( `rel` = %d OR `rel` = %d ) ", intval(Contact::CONTACT_IS_FOLLOWER), intval(Contact::CONTACT_IS_FRIEND));
 	}
 
 	// friends and followers only for self

--- a/include/api.php
+++ b/include/api.php
@@ -753,7 +753,7 @@ function api_get_user(App $a, $contact_id = null)
 		'contributors_enabled' => false,
 		'is_translator' => false,
 		'is_translation_enabled' => false,
-		'following' => (($uinfo[0]['rel'] == Contact::CONTACT_IS_FOLLOWER) || ($uinfo[0]['rel'] == Contact::CONTACT_IS_FRIEND)),
+		'following' => (($uinfo[0]['rel'] == Contact::FOLLOWER) || ($uinfo[0]['rel'] == Contact::FRIEND)),
 		'follow_request_sent' => false,
 		'statusnet_blocking' => false,
 		'notifications' => false,
@@ -3186,9 +3186,9 @@ function api_statuses_f($qtype)
 
 	$sql_extra = '';
 	if ($qtype == 'friends') {
-		$sql_extra = sprintf(" AND ( `rel` = %d OR `rel` = %d ) ", intval(Contact::CONTACT_IS_SHARING), intval(Contact::CONTACT_IS_FRIEND));
+		$sql_extra = sprintf(" AND ( `rel` = %d OR `rel` = %d ) ", intval(Contact::SHARING), intval(Contact::FRIEND));
 	} elseif ($qtype == 'followers') {
-		$sql_extra = sprintf(" AND ( `rel` = %d OR `rel` = %d ) ", intval(Contact::CONTACT_IS_FOLLOWER), intval(Contact::CONTACT_IS_FRIEND));
+		$sql_extra = sprintf(" AND ( `rel` = %d OR `rel` = %d ) ", intval(Contact::FOLLOWER), intval(Contact::FRIEND));
 	}
 
 	// friends and followers only for self

--- a/include/conversation.php
+++ b/include/conversation.php
@@ -866,7 +866,7 @@ function item_photo_menu($item) {
 			$menu[L10n::t("Poke")] = $poke_link;
 		}
 
-		if ((($cid == 0) || ($rel == Contact::CONTACT_IS_FOLLOWER)) &&
+		if ((($cid == 0) || ($rel == Contact::FOLLOWER)) &&
 			in_array($item['network'], [NETWORK_DFRN, NETWORK_OSTATUS, NETWORK_DIASPORA])) {
 			$menu[L10n::t('Connect/Follow')] = 'follow?url=' . urlencode($item['author-link']);
 		}

--- a/include/conversation.php
+++ b/include/conversation.php
@@ -866,7 +866,7 @@ function item_photo_menu($item) {
 			$menu[L10n::t("Poke")] = $poke_link;
 		}
 
-		if ((($cid == 0) || ($rel == CONTACT_IS_FOLLOWER)) &&
+		if ((($cid == 0) || ($rel == Contact::CONTACT_IS_FOLLOWER)) &&
 			in_array($item['network'], [NETWORK_DFRN, NETWORK_OSTATUS, NETWORK_DIASPORA])) {
 			$menu[L10n::t('Connect/Follow')] = 'follow?url=' . urlencode($item['author-link']);
 		}

--- a/include/security.php
+++ b/include/security.php
@@ -242,8 +242,8 @@ function can_write_wall($owner)
 				AND `user`.`blockwall` = 0 AND `readonly` = 0  AND ( `contact`.`rel` IN ( %d , %d ) OR `user`.`page-flags` = %d ) LIMIT 1",
 				intval($owner),
 				intval($cid),
-				intval(Contact::CONTACT_IS_SHARING),
-				intval(Contact::CONTACT_IS_FRIEND),
+				intval(Contact::SHARING),
+				intval(Contact::FRIEND),
 				intval(PAGE_COMMUNITY)
 			);
 

--- a/include/security.php
+++ b/include/security.php
@@ -9,6 +9,7 @@ use Friendica\Core\L10n;
 use Friendica\Core\PConfig;
 use Friendica\Core\System;
 use Friendica\Database\DBA;
+use Friendica\Model\Contact;
 use Friendica\Model\Group;
 use Friendica\Util\DateTimeFormat;
 
@@ -241,8 +242,8 @@ function can_write_wall($owner)
 				AND `user`.`blockwall` = 0 AND `readonly` = 0  AND ( `contact`.`rel` IN ( %d , %d ) OR `user`.`page-flags` = %d ) LIMIT 1",
 				intval($owner),
 				intval($cid),
-				intval(CONTACT_IS_SHARING),
-				intval(CONTACT_IS_FRIEND),
+				intval(Contact::CONTACT_IS_SHARING),
+				intval(Contact::CONTACT_IS_FRIEND),
 				intval(PAGE_COMMUNITY)
 			);
 

--- a/mod/contacts.php
+++ b/mod/contacts.php
@@ -514,17 +514,17 @@ function contacts_content(App $a)
 		$dir_icon = '';
 		$relation_text = '';
 		switch ($contact['rel']) {
-			case Contact::CONTACT_IS_FRIEND:
+			case Contact::FRIEND:
 				$dir_icon = 'images/lrarrow.gif';
 				$relation_text = L10n::t('You are mutual friends with %s');
 				break;
 
-			case Contact::CONTACT_IS_FOLLOWER;
+			case Contact::FOLLOWER;
 				$dir_icon = 'images/larrow.gif';
 				$relation_text = L10n::t('You are sharing with %s');
 				break;
 
-			case Contact::CONTACT_IS_SHARING;
+			case Contact::SHARING;
 				$dir_icon = 'images/rarrow.gif';
 				$relation_text = L10n::t('%s is sharing with you');
 				break;
@@ -593,10 +593,10 @@ function contacts_content(App $a)
 		$follow = '';
 		$follow_text = '';
 		if (in_array($contact['network'], [NETWORK_DIASPORA, NETWORK_OSTATUS, NETWORK_DFRN])) {
-			if ($contact['rel'] == Contact::CONTACT_IS_FOLLOWER) {
+			if ($contact['rel'] == Contact::FOLLOWER) {
 				$follow = System::baseUrl(true) . "/follow?url=" . urlencode($contact["url"]);
 				$follow_text = L10n::t("Connect/Follow");
-			} elseif ($contact['rel'] == Contact::CONTACT_IS_FRIEND) {
+			} elseif ($contact['rel'] == Contact::FRIEND) {
 				$follow = System::baseUrl(true) . "/unfollow?url=" . urlencode($contact["url"]);
 				$follow_text = L10n::t("Disconnect/Unfollow");
 			}
@@ -784,7 +784,7 @@ function contacts_content(App $a)
 		$sql_extra .= sprintf(" AND network = '%s' ", DBA::escape($nets));
 	}
 
-	$sql_extra2 = ((($sort_type > 0) && ($sort_type <= Contact::CONTACT_IS_FRIEND)) ? sprintf(" AND `rel` = %d ", intval($sort_type)) : '');
+	$sql_extra2 = ((($sort_type > 0) && ($sort_type <= Contact::FRIEND)) ? sprintf(" AND `rel` = %d ", intval($sort_type)) : '');
 
 	$r = q("SELECT COUNT(*) AS `total` FROM `contact`
 		WHERE `uid` = %d AND `self` = 0 AND `pending` = 0 $sql_extra $sql_extra2 ",
@@ -929,17 +929,17 @@ function _contact_detail_for_template(array $rr)
 	$alt_text = '';
 
 	switch ($rr['rel']) {
-		case Contact::CONTACT_IS_FRIEND:
+		case Contact::FRIEND:
 			$dir_icon = 'images/lrarrow.gif';
 			$alt_text = L10n::t('Mutual Friendship');
 			break;
 
-		case Contact::CONTACT_IS_FOLLOWER;
+		case Contact::FOLLOWER;
 			$dir_icon = 'images/larrow.gif';
 			$alt_text = L10n::t('is a fan of yours');
 			break;
 
-		case Contact::CONTACT_IS_SHARING;
+		case Contact::SHARING;
 			$dir_icon = 'images/rarrow.gif';
 			$alt_text = L10n::t('you are a fan of');
 			break;

--- a/mod/contacts.php
+++ b/mod/contacts.php
@@ -514,18 +514,21 @@ function contacts_content(App $a)
 		$dir_icon = '';
 		$relation_text = '';
 		switch ($contact['rel']) {
-			case CONTACT_IS_FRIEND:
+			case Contact::CONTACT_IS_FRIEND:
 				$dir_icon = 'images/lrarrow.gif';
 				$relation_text = L10n::t('You are mutual friends with %s');
 				break;
-			case CONTACT_IS_FOLLOWER;
+
+			case Contact::CONTACT_IS_FOLLOWER;
 				$dir_icon = 'images/larrow.gif';
 				$relation_text = L10n::t('You are sharing with %s');
 				break;
-			case CONTACT_IS_SHARING;
+
+			case Contact::CONTACT_IS_SHARING;
 				$dir_icon = 'images/rarrow.gif';
 				$relation_text = L10n::t('%s is sharing with you');
 				break;
+
 			default:
 				break;
 		}
@@ -590,10 +593,10 @@ function contacts_content(App $a)
 		$follow = '';
 		$follow_text = '';
 		if (in_array($contact['network'], [NETWORK_DIASPORA, NETWORK_OSTATUS, NETWORK_DFRN])) {
-			if ($contact['rel'] == CONTACT_IS_FOLLOWER) {
+			if ($contact['rel'] == Contact::CONTACT_IS_FOLLOWER) {
 				$follow = System::baseUrl(true) . "/follow?url=" . urlencode($contact["url"]);
 				$follow_text = L10n::t("Connect/Follow");
-			} elseif ($contact['rel'] == CONTACT_IS_FRIEND) {
+			} elseif ($contact['rel'] == Contact::CONTACT_IS_FRIEND) {
 				$follow = System::baseUrl(true) . "/unfollow?url=" . urlencode($contact["url"]);
 				$follow_text = L10n::t("Disconnect/Unfollow");
 			}
@@ -781,7 +784,7 @@ function contacts_content(App $a)
 		$sql_extra .= sprintf(" AND network = '%s' ", DBA::escape($nets));
 	}
 
-	$sql_extra2 = ((($sort_type > 0) && ($sort_type <= CONTACT_IS_FRIEND)) ? sprintf(" AND `rel` = %d ", intval($sort_type)) : '');
+	$sql_extra2 = ((($sort_type > 0) && ($sort_type <= Contact::CONTACT_IS_FRIEND)) ? sprintf(" AND `rel` = %d ", intval($sort_type)) : '');
 
 	$r = q("SELECT COUNT(*) AS `total` FROM `contact`
 		WHERE `uid` = %d AND `self` = 0 AND `pending` = 0 $sql_extra $sql_extra2 ",
@@ -905,11 +908,12 @@ function contacts_tab($a, $contact_id, $active_tab)
 	return $tab_str;
 }
 
-function contact_posts($a, $contact_id)
+function contact_posts(App $a, $contact_id)
 {
 	$o = contacts_tab($a, $contact_id, 1);
 
 	$contact = DBA::selectFirst('contact', ['url'], ['id' => $contact_id]);
+
 	if (DBA::isResult($contact)) {
 		$a->page['aside'] = "";
 		Profile::load($a, "", 0, Contact::getDetailsByURL($contact["url"]));
@@ -919,28 +923,33 @@ function contact_posts($a, $contact_id)
 	return $o;
 }
 
-function _contact_detail_for_template($rr)
+function _contact_detail_for_template(array $rr)
 {
 	$dir_icon = '';
 	$alt_text = '';
+
 	switch ($rr['rel']) {
-		case CONTACT_IS_FRIEND:
+		case Contact::CONTACT_IS_FRIEND:
 			$dir_icon = 'images/lrarrow.gif';
 			$alt_text = L10n::t('Mutual Friendship');
 			break;
-		case CONTACT_IS_FOLLOWER;
+
+		case Contact::CONTACT_IS_FOLLOWER;
 			$dir_icon = 'images/larrow.gif';
 			$alt_text = L10n::t('is a fan of yours');
 			break;
-		case CONTACT_IS_SHARING;
+
+		case Contact::CONTACT_IS_SHARING;
 			$dir_icon = 'images/rarrow.gif';
 			$alt_text = L10n::t('you are a fan of');
 			break;
+
 		default:
 			break;
 	}
 
 	$url = Contact::magicLink($rr['url']);
+
 	if (strpos($url, 'redir/') === 0) {
 		$sparkle = ' class="sparkle" ';
 	} else {

--- a/mod/dfrn_confirm.php
+++ b/mod/dfrn_confirm.php
@@ -305,12 +305,12 @@ function dfrn_confirm_post(App $a, $handsfree = null)
 		logger('dfrn_confirm: confirm - imported photos');
 
 		if ($network === NETWORK_DFRN) {
-			$new_relation = CONTACT_IS_FOLLOWER;
-			if (($relation == CONTACT_IS_SHARING) || ($duplex)) {
-				$new_relation = CONTACT_IS_FRIEND;
+			$new_relation = Contact::CONTACT_IS_FOLLOWER;
+			if (($relation == Contact::CONTACT_IS_SHARING) || ($duplex)) {
+				$new_relation = Contact::CONTACT_IS_FRIEND;
 			}
 
-			if (($relation == CONTACT_IS_SHARING) && ($duplex)) {
+			if (($relation == Contact::CONTACT_IS_SHARING) && ($duplex)) {
 				$duplex = 0;
 			}
 
@@ -347,12 +347,12 @@ function dfrn_confirm_post(App $a, $handsfree = null)
 
 			if ($network === NETWORK_DIASPORA) {
 				if ($duplex) {
-					$new_relation = CONTACT_IS_FRIEND;
+					$new_relation = Contact::CONTACT_IS_FRIEND;
 				} else {
-					$new_relation = CONTACT_IS_FOLLOWER;
+					$new_relation = Contact::CONTACT_IS_FOLLOWER;
 				}
 
-				if ($new_relation != CONTACT_IS_FOLLOWER) {
+				if ($new_relation != Contact::CONTACT_IS_FOLLOWER) {
 					$writable = 1;
 				}
 			}
@@ -391,7 +391,7 @@ function dfrn_confirm_post(App $a, $handsfree = null)
 
 		// reload contact info
 		$contact = DBA::selectFirst('contact', [], ['id' => $contact_id]);
-		if ((isset($new_relation) && $new_relation == CONTACT_IS_FRIEND)) {
+		if ((isset($new_relation) && $new_relation == Contact::CONTACT_IS_FRIEND)) {
 			if (DBA::isResult($contact) && ($contact['network'] === NETWORK_DIASPORA)) {
 				$ret = Diaspora::sendShare($user, $contact);
 				logger('share returns: ' . $ret);
@@ -547,12 +547,12 @@ function dfrn_confirm_post(App $a, $handsfree = null)
 
 		logger('dfrn_confirm: request - photos imported');
 
-		$new_relation = CONTACT_IS_SHARING;
-		if (($relation == CONTACT_IS_FOLLOWER) || ($duplex)) {
-			$new_relation = CONTACT_IS_FRIEND;
+		$new_relation = Contact::CONTACT_IS_SHARING;
+		if (($relation == Contact::CONTACT_IS_FOLLOWER) || ($duplex)) {
+			$new_relation = Contact::CONTACT_IS_FRIEND;
 		}
 
-		if (($relation == CONTACT_IS_FOLLOWER) && ($duplex)) {
+		if (($relation == Contact::CONTACT_IS_FOLLOWER) && ($duplex)) {
 			$duplex = 0;
 		}
 
@@ -598,7 +598,7 @@ function dfrn_confirm_post(App $a, $handsfree = null)
 			$combined = $r[0];
 
 			if ($combined['notify-flags'] & NOTIFY_CONFIRM) {
-				$mutual = ($new_relation == CONTACT_IS_FRIEND);
+				$mutual = ($new_relation == Contact::CONTACT_IS_FRIEND);
 				notification([
 					'type'         => NOTIFY_CONFIRM,
 					'notify_flags' => $combined['notify-flags'],

--- a/mod/dfrn_confirm.php
+++ b/mod/dfrn_confirm.php
@@ -305,12 +305,12 @@ function dfrn_confirm_post(App $a, $handsfree = null)
 		logger('dfrn_confirm: confirm - imported photos');
 
 		if ($network === NETWORK_DFRN) {
-			$new_relation = Contact::CONTACT_IS_FOLLOWER;
-			if (($relation == Contact::CONTACT_IS_SHARING) || ($duplex)) {
-				$new_relation = Contact::CONTACT_IS_FRIEND;
+			$new_relation = Contact::FOLLOWER;
+			if (($relation == Contact::SHARING) || ($duplex)) {
+				$new_relation = Contact::FRIEND;
 			}
 
-			if (($relation == Contact::CONTACT_IS_SHARING) && ($duplex)) {
+			if (($relation == Contact::SHARING) && ($duplex)) {
 				$duplex = 0;
 			}
 
@@ -347,12 +347,12 @@ function dfrn_confirm_post(App $a, $handsfree = null)
 
 			if ($network === NETWORK_DIASPORA) {
 				if ($duplex) {
-					$new_relation = Contact::CONTACT_IS_FRIEND;
+					$new_relation = Contact::FRIEND;
 				} else {
-					$new_relation = Contact::CONTACT_IS_FOLLOWER;
+					$new_relation = Contact::FOLLOWER;
 				}
 
-				if ($new_relation != Contact::CONTACT_IS_FOLLOWER) {
+				if ($new_relation != Contact::FOLLOWER) {
 					$writable = 1;
 				}
 			}
@@ -391,7 +391,7 @@ function dfrn_confirm_post(App $a, $handsfree = null)
 
 		// reload contact info
 		$contact = DBA::selectFirst('contact', [], ['id' => $contact_id]);
-		if ((isset($new_relation) && $new_relation == Contact::CONTACT_IS_FRIEND)) {
+		if ((isset($new_relation) && $new_relation == Contact::FRIEND)) {
 			if (DBA::isResult($contact) && ($contact['network'] === NETWORK_DIASPORA)) {
 				$ret = Diaspora::sendShare($user, $contact);
 				logger('share returns: ' . $ret);
@@ -547,12 +547,12 @@ function dfrn_confirm_post(App $a, $handsfree = null)
 
 		logger('dfrn_confirm: request - photos imported');
 
-		$new_relation = Contact::CONTACT_IS_SHARING;
-		if (($relation == Contact::CONTACT_IS_FOLLOWER) || ($duplex)) {
-			$new_relation = Contact::CONTACT_IS_FRIEND;
+		$new_relation = Contact::SHARING;
+		if (($relation == Contact::FOLLOWER) || ($duplex)) {
+			$new_relation = Contact::FRIEND;
 		}
 
-		if (($relation == Contact::CONTACT_IS_FOLLOWER) && ($duplex)) {
+		if (($relation == Contact::FOLLOWER) && ($duplex)) {
 			$duplex = 0;
 		}
 
@@ -598,7 +598,7 @@ function dfrn_confirm_post(App $a, $handsfree = null)
 			$combined = $r[0];
 
 			if ($combined['notify-flags'] & NOTIFY_CONFIRM) {
-				$mutual = ($new_relation == Contact::CONTACT_IS_FRIEND);
+				$mutual = ($new_relation == Contact::FRIEND);
 				notification([
 					'type'         => NOTIFY_CONFIRM,
 					'notify_flags' => $combined['notify-flags'],

--- a/mod/dfrn_notify.php
+++ b/mod/dfrn_notify.php
@@ -375,7 +375,7 @@ function dfrn_notify_content(App $a) {
 			$rino = $rino_remote;
 		}
 
-		if (($r[0]['rel'] && ($r[0]['rel'] != Contact::CONTACT_IS_SHARING)) || ($r[0]['page-flags'] == PAGE_COMMUNITY)) {
+		if (($r[0]['rel'] && ($r[0]['rel'] != Contact::SHARING)) || ($r[0]['page-flags'] == PAGE_COMMUNITY)) {
 			$perm = 'rw';
 		} else {
 			$perm = 'r';

--- a/mod/dfrn_notify.php
+++ b/mod/dfrn_notify.php
@@ -375,7 +375,7 @@ function dfrn_notify_content(App $a) {
 			$rino = $rino_remote;
 		}
 
-		if (($r[0]['rel'] && ($r[0]['rel'] != CONTACT_IS_SHARING)) || ($r[0]['page-flags'] == PAGE_COMMUNITY)) {
+		if (($r[0]['rel'] && ($r[0]['rel'] != Contact::CONTACT_IS_SHARING)) || ($r[0]['page-flags'] == PAGE_COMMUNITY)) {
 			$perm = 'rw';
 		} else {
 			$perm = 'r';

--- a/mod/dfrn_request.php
+++ b/mod/dfrn_request.php
@@ -309,7 +309,7 @@ function dfrn_request_post(App $a)
 				if (strlen($ret[0]['issued-id'])) {
 					notice(L10n::t('You have already introduced yourself here.') . EOL);
 					return;
-				} elseif ($ret[0]['rel'] == Contact::CONTACT_IS_FRIEND) {
+				} elseif ($ret[0]['rel'] == Contact::FRIEND) {
 					notice(L10n::t('Apparently you are already friends with %s.', $a->profile['name']) . EOL);
 					return;
 				} else {

--- a/mod/dfrn_request.php
+++ b/mod/dfrn_request.php
@@ -309,7 +309,7 @@ function dfrn_request_post(App $a)
 				if (strlen($ret[0]['issued-id'])) {
 					notice(L10n::t('You have already introduced yourself here.') . EOL);
 					return;
-				} elseif ($ret[0]['rel'] == CONTACT_IS_FRIEND) {
+				} elseif ($ret[0]['rel'] == Contact::CONTACT_IS_FRIEND) {
 					notice(L10n::t('Apparently you are already friends with %s.', $a->profile['name']) . EOL);
 					return;
 				} else {

--- a/mod/follow.php
+++ b/mod/follow.php
@@ -65,7 +65,7 @@ function follow_content(App $a)
 	$r = q("SELECT `pending` FROM `contact` WHERE `uid` = %d AND ((`rel` != %d) OR (`network` = '%s')) AND
 		(`nurl` = '%s' OR `alias` = '%s' OR `alias` = '%s') AND
 		`network` != '%s' LIMIT 1",
-		intval(local_user()), DBA::escape(Contact::CONTACT_IS_FOLLOWER), DBA::escape(NETWORK_DFRN), DBA::escape(normalise_link($url)),
+		intval(local_user()), DBA::escape(Contact::FOLLOWER), DBA::escape(NETWORK_DFRN), DBA::escape(normalise_link($url)),
 		DBA::escape(normalise_link($url)), DBA::escape($url), DBA::escape(NETWORK_STATUSNET));
 
 	if ($r) {

--- a/mod/follow.php
+++ b/mod/follow.php
@@ -65,7 +65,7 @@ function follow_content(App $a)
 	$r = q("SELECT `pending` FROM `contact` WHERE `uid` = %d AND ((`rel` != %d) OR (`network` = '%s')) AND
 		(`nurl` = '%s' OR `alias` = '%s' OR `alias` = '%s') AND
 		`network` != '%s' LIMIT 1",
-		intval(local_user()), DBA::escape(CONTACT_IS_FOLLOWER), DBA::escape(NETWORK_DFRN), DBA::escape(normalise_link($url)),
+		intval(local_user()), DBA::escape(Contact::CONTACT_IS_FOLLOWER), DBA::escape(NETWORK_DFRN), DBA::escape(normalise_link($url)),
 		DBA::escape(normalise_link($url)), DBA::escape($url), DBA::escape(NETWORK_STATUSNET));
 
 	if ($r) {

--- a/mod/network.php
+++ b/mod/network.php
@@ -776,8 +776,8 @@ function networkThreadedView(App $a, $update, $parent)
 			AND NOT `item`.`moderated` AND $sql_extra4
 			$sql_extra3 $sql_extra $sql_range $sql_nets
 			ORDER BY `order_date` DESC LIMIT 100",
-			intval(CONTACT_IS_SHARING),
-			intval(CONTACT_IS_FRIEND),
+			intval(Contact::CONTACT_IS_SHARING),
+			intval(Contact::CONTACT_IS_FRIEND),
 			intval(local_user()),
 			intval(local_user())
 		);
@@ -796,8 +796,8 @@ function networkThreadedView(App $a, $update, $parent)
 			AND (`user-item`.`hidden` IS NULL OR NOT `user-item`.`hidden`)
 			$sql_extra2 $sql_extra3 $sql_range $sql_extra $sql_nets
 			ORDER BY `order_date` DESC $pager_sql",
-			intval(CONTACT_IS_SHARING),
-			intval(CONTACT_IS_FRIEND),
+			intval(Contact::CONTACT_IS_SHARING),
+			intval(Contact::CONTACT_IS_FRIEND),
 			intval(local_user()),
 			intval(local_user())
 		);

--- a/mod/network.php
+++ b/mod/network.php
@@ -776,8 +776,8 @@ function networkThreadedView(App $a, $update, $parent)
 			AND NOT `item`.`moderated` AND $sql_extra4
 			$sql_extra3 $sql_extra $sql_range $sql_nets
 			ORDER BY `order_date` DESC LIMIT 100",
-			intval(Contact::CONTACT_IS_SHARING),
-			intval(Contact::CONTACT_IS_FRIEND),
+			intval(Contact::SHARING),
+			intval(Contact::FRIEND),
 			intval(local_user()),
 			intval(local_user())
 		);
@@ -796,8 +796,8 @@ function networkThreadedView(App $a, $update, $parent)
 			AND (`user-item`.`hidden` IS NULL OR NOT `user-item`.`hidden`)
 			$sql_extra2 $sql_extra3 $sql_range $sql_extra $sql_nets
 			ORDER BY `order_date` DESC $pager_sql",
-			intval(Contact::CONTACT_IS_SHARING),
-			intval(Contact::CONTACT_IS_FRIEND),
+			intval(Contact::SHARING),
+			intval(Contact::FRIEND),
 			intval(local_user()),
 			intval(local_user())
 		);

--- a/mod/pubsub.php
+++ b/mod/pubsub.php
@@ -2,6 +2,7 @@
 
 use Friendica\App;
 use Friendica\Database\DBA;
+use Friendica\Model\Contact;
 use Friendica\Protocol\OStatus;
 
 require_once('include/security.php');
@@ -113,7 +114,7 @@ function pubsub_post(App $a)
 		}
 	}
 
-	if (!in_array($contact['rel'], [CONTACT_IS_SHARING, CONTACT_IS_FRIEND]) && ($contact['network'] != NETWORK_FEED)) {
+	if (!in_array($contact['rel'], [Contact::CONTACT_IS_SHARING, Contact::CONTACT_IS_FRIEND]) && ($contact['network'] != NETWORK_FEED)) {
 		logger('Contact ' . $contact['id'] . ' is not expected to share with us - ignored.');
 		hub_post_return();
 	}

--- a/mod/pubsub.php
+++ b/mod/pubsub.php
@@ -114,7 +114,7 @@ function pubsub_post(App $a)
 		}
 	}
 
-	if (!in_array($contact['rel'], [Contact::CONTACT_IS_SHARING, Contact::CONTACT_IS_FRIEND]) && ($contact['network'] != NETWORK_FEED)) {
+	if (!in_array($contact['rel'], [Contact::SHARING, Contact::FRIEND]) && ($contact['network'] != NETWORK_FEED)) {
 		logger('Contact ' . $contact['id'] . ' is not expected to share with us - ignored.');
 		hub_post_return();
 	}

--- a/mod/repair_ostatus.php
+++ b/mod/repair_ostatus.php
@@ -29,8 +29,8 @@ function repair_ostatus_content(App $a) {
                 `uid` = %d AND `network` = '%s' AND `rel` IN (%d, %d)",
                 intval($uid),
                 DBA::escape(NETWORK_OSTATUS),
-                intval(CONTACT_IS_FRIEND),
-                intval(CONTACT_IS_SHARING));
+                intval(Contact::CONTACT_IS_FRIEND),
+                intval(Contact::CONTACT_IS_SHARING));
 
 	if (!$r)
 		return($o.L10n::t("Error"));
@@ -43,8 +43,8 @@ function repair_ostatus_content(App $a) {
 		LIMIT %d, 1",
                 intval($uid),
                 DBA::escape(NETWORK_OSTATUS),
-                intval(CONTACT_IS_FRIEND),
-                intval(CONTACT_IS_SHARING), $counter++);
+                intval(Contact::CONTACT_IS_FRIEND),
+                intval(Contact::CONTACT_IS_SHARING), $counter++);
 
 	if (!$r) {
 		$o .= L10n::t("Done");

--- a/mod/repair_ostatus.php
+++ b/mod/repair_ostatus.php
@@ -29,8 +29,8 @@ function repair_ostatus_content(App $a) {
                 `uid` = %d AND `network` = '%s' AND `rel` IN (%d, %d)",
                 intval($uid),
                 DBA::escape(NETWORK_OSTATUS),
-                intval(Contact::CONTACT_IS_FRIEND),
-                intval(Contact::CONTACT_IS_SHARING));
+                intval(Contact::FRIEND),
+                intval(Contact::SHARING));
 
 	if (!$r)
 		return($o.L10n::t("Error"));
@@ -43,8 +43,8 @@ function repair_ostatus_content(App $a) {
 		LIMIT %d, 1",
                 intval($uid),
                 DBA::escape(NETWORK_OSTATUS),
-                intval(Contact::CONTACT_IS_FRIEND),
-                intval(Contact::CONTACT_IS_SHARING), $counter++);
+                intval(Contact::FRIEND),
+                intval(Contact::SHARING), $counter++);
 
 	if (!$r) {
 		$o .= L10n::t("Done");

--- a/mod/salmon.php
+++ b/mod/salmon.php
@@ -171,7 +171,7 @@ function salmon_post(App $a, $xml = '') {
 	// Have we ignored the person?
 	// If so we can not accept this post.
 
-	//if((DBA::isResult($r)) && (($r[0]['readonly']) || ($r[0]['rel'] == Contact::CONTACT_IS_FOLLOWER) || ($r[0]['blocked']))) {
+	//if((DBA::isResult($r)) && (($r[0]['readonly']) || ($r[0]['rel'] == Contact::FOLLOWER) || ($r[0]['blocked']))) {
 	if (DBA::isResult($r) && $r[0]['blocked']) {
 		logger('Ignoring this author.');
 		System::httpExit(202);

--- a/mod/salmon.php
+++ b/mod/salmon.php
@@ -171,7 +171,7 @@ function salmon_post(App $a, $xml = '') {
 	// Have we ignored the person?
 	// If so we can not accept this post.
 
-	//if((DBA::isResult($r)) && (($r[0]['readonly']) || ($r[0]['rel'] == CONTACT_IS_FOLLOWER) || ($r[0]['blocked']))) {
+	//if((DBA::isResult($r)) && (($r[0]['readonly']) || ($r[0]['rel'] == Contact::CONTACT_IS_FOLLOWER) || ($r[0]['blocked']))) {
 	if (DBA::isResult($r) && $r[0]['blocked']) {
 		logger('Ignoring this author.');
 		System::httpExit(202);

--- a/mod/unfollow.php
+++ b/mod/unfollow.php
@@ -27,7 +27,7 @@ function unfollow_post(App $a)
 	$return_url = $_SESSION['return_url'];
 
 	$condition = ["`uid` = ? AND `rel` = ? AND (`nurl` = ? OR `alias` = ? OR `alias` = ?) AND `network` != ?",
-			$uid, CONTACT_IS_FRIEND, normalise_link($url),
+			$uid, Contact::CONTACT_IS_FRIEND, normalise_link($url),
 			normalise_link($url), $url, NETWORK_STATUSNET];
 	$contact = DBA::selectFirst('contact', [], $condition);
 
@@ -43,7 +43,7 @@ function unfollow_post(App $a)
 				Contact::terminateFriendship($r[0], $contact);
 			}
 		}
-		DBA::update('contact', ['rel' => CONTACT_IS_FOLLOWER], ['id' => $contact['id']]);
+		DBA::update('contact', ['rel' => Contact::CONTACT_IS_FOLLOWER], ['id' => $contact['id']]);
 
 		info(L10n::t('Contact unfollowed').EOL);
 		goaway(System::baseUrl().'/contacts/'.$contact['id']);
@@ -66,7 +66,7 @@ function unfollow_content(App $a)
 	$submit = L10n::t('Submit Request');
 
 	$condition = ["`uid` = ? AND `rel` = ? AND (`nurl` = ? OR `alias` = ? OR `alias` = ?) AND `network` != ?",
-			local_user(), CONTACT_IS_FRIEND, normalise_link($url),
+			local_user(), Contact::CONTACT_IS_FRIEND, normalise_link($url),
 			normalise_link($url), $url, NETWORK_STATUSNET];
 	$contact = DBA::selectFirst('contact', ['url', 'network', 'addr', 'name'], $condition);
 

--- a/mod/unfollow.php
+++ b/mod/unfollow.php
@@ -27,7 +27,7 @@ function unfollow_post(App $a)
 	$return_url = $_SESSION['return_url'];
 
 	$condition = ["`uid` = ? AND `rel` = ? AND (`nurl` = ? OR `alias` = ? OR `alias` = ?) AND `network` != ?",
-			$uid, Contact::CONTACT_IS_FRIEND, normalise_link($url),
+			$uid, Contact::FRIEND, normalise_link($url),
 			normalise_link($url), $url, NETWORK_STATUSNET];
 	$contact = DBA::selectFirst('contact', [], $condition);
 
@@ -43,7 +43,7 @@ function unfollow_post(App $a)
 				Contact::terminateFriendship($r[0], $contact);
 			}
 		}
-		DBA::update('contact', ['rel' => Contact::CONTACT_IS_FOLLOWER], ['id' => $contact['id']]);
+		DBA::update('contact', ['rel' => Contact::FOLLOWER], ['id' => $contact['id']]);
 
 		info(L10n::t('Contact unfollowed').EOL);
 		goaway(System::baseUrl().'/contacts/'.$contact['id']);
@@ -66,7 +66,7 @@ function unfollow_content(App $a)
 	$submit = L10n::t('Submit Request');
 
 	$condition = ["`uid` = ? AND `rel` = ? AND (`nurl` = ? OR `alias` = ? OR `alias` = ?) AND `network` != ?",
-			local_user(), Contact::CONTACT_IS_FRIEND, normalise_link($url),
+			local_user(), Contact::FRIEND, normalise_link($url),
 			normalise_link($url), $url, NETWORK_STATUSNET];
 	$contact = DBA::selectFirst('contact', ['url', 'network', 'addr', 'name'], $condition);
 

--- a/src/Core/ACL.php
+++ b/src/Core/ACL.php
@@ -75,7 +75,7 @@ class ACL extends BaseObject
 		$sql_extra = '';
 
 		if (!empty($x['mutual'])) {
-			$sql_extra .= sprintf(" AND `rel` = %d ", intval(CONTACT_IS_FRIEND));
+			$sql_extra .= sprintf(" AND `rel` = %d ", intval(Contact::CONTACT_IS_FRIEND));
 		}
 
 		if (!empty($x['exclude'])) {
@@ -151,7 +151,7 @@ class ACL extends BaseObject
 
 		// When used for private messages, we limit correspondence to mutual DFRN/Friendica friends and the selector
 		// to one recipient. By default our selector allows multiple selects amongst all contacts.
-		$sql_extra = sprintf(" AND `rel` = %d ", intval(CONTACT_IS_FRIEND));
+		$sql_extra = sprintf(" AND `rel` = %d ", intval(Contact::CONTACT_IS_FRIEND));
 		$sql_extra .= sprintf(" AND `network` IN ('%s' , '%s') ", NETWORK_DFRN, NETWORK_DIASPORA);
 
 		$tabindex_attr = !empty($tabindex) ? ' tabindex="' . intval($tabindex) . '"' : '';

--- a/src/Core/ACL.php
+++ b/src/Core/ACL.php
@@ -75,7 +75,7 @@ class ACL extends BaseObject
 		$sql_extra = '';
 
 		if (!empty($x['mutual'])) {
-			$sql_extra .= sprintf(" AND `rel` = %d ", intval(Contact::CONTACT_IS_FRIEND));
+			$sql_extra .= sprintf(" AND `rel` = %d ", intval(Contact::FRIEND));
 		}
 
 		if (!empty($x['exclude'])) {
@@ -151,7 +151,7 @@ class ACL extends BaseObject
 
 		// When used for private messages, we limit correspondence to mutual DFRN/Friendica friends and the selector
 		// to one recipient. By default our selector allows multiple selects amongst all contacts.
-		$sql_extra = sprintf(" AND `rel` = %d ", intval(Contact::CONTACT_IS_FRIEND));
+		$sql_extra = sprintf(" AND `rel` = %d ", intval(Contact::FRIEND));
 		$sql_extra .= sprintf(" AND `network` IN ('%s' , '%s') ", NETWORK_DFRN, NETWORK_DIASPORA);
 
 		$tabindex_attr = !empty($tabindex) ? ' tabindex="' . intval($tabindex) . '"' : '';

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -31,6 +31,19 @@ require_once 'include/text.php';
 class Contact extends BaseObject
 {
 	/**
+	 * @name Contact_is
+	 *
+	 * Relationship types
+	 * @{
+	 */
+	const CONTACT_IS_FOLLOWER = 1;
+	const CONTACT_IS_SHARING  = 2;
+	const CONTACT_IS_FRIEND   = 3;
+	/**
+	 * @}
+	 */
+
+	/**
 	 * @brief Returns a list of contacts belonging in a group
 	 *
 	 * @param int $gid
@@ -849,7 +862,7 @@ class Contact extends BaseObject
 				'about'     => $data["about"],
 				'network'   => $data["network"],
 				'pubkey'    => $data["pubkey"],
-				'rel'       => CONTACT_IS_SHARING,
+				'rel'       => self::CONTACT_IS_SHARING,
 				'priority'  => $data["priority"],
 				'batch'     => $data["batch"],
 				'request'   => $data["request"],
@@ -1374,12 +1387,12 @@ class Contact extends BaseObject
 
 		if (DBA::isResult($r)) {
 			// update contact
-			$new_relation = (($r[0]['rel'] == CONTACT_IS_FOLLOWER) ? CONTACT_IS_FRIEND : CONTACT_IS_SHARING);
+			$new_relation = (($r[0]['rel'] == self::CONTACT_IS_FOLLOWER) ? self::CONTACT_IS_FRIEND : self::CONTACT_IS_SHARING);
 
 			$fields = ['rel' => $new_relation, 'subhub' => $subhub, 'readonly' => false];
 			DBA::update('contact', $fields, ['id' => $r[0]['id']]);
 		} else {
-			$new_relation = ((in_array($ret['network'], [NETWORK_MAIL])) ? CONTACT_IS_FRIEND : CONTACT_IS_SHARING);
+			$new_relation = ((in_array($ret['network'], [NETWORK_MAIL])) ? self::CONTACT_IS_FRIEND : self::CONTACT_IS_SHARING);
 
 			// create contact record
 			DBA::insert('contact', [
@@ -1500,9 +1513,9 @@ class Contact extends BaseObject
 		}
 
 		if (is_array($contact)) {
-			if (($contact['rel'] == CONTACT_IS_SHARING)
-				|| ($sharing && $contact['rel'] == CONTACT_IS_FOLLOWER)) {
-				DBA::update('contact', ['rel' => CONTACT_IS_FRIEND, 'writable' => true],
+			if (($contact['rel'] == self::CONTACT_IS_SHARING)
+				|| ($sharing && $contact['rel'] == self::CONTACT_IS_FOLLOWER)) {
+				DBA::update('contact', ['rel' => self::CONTACT_IS_FRIEND, 'writable' => true],
 						['id' => $contact['id'], 'uid' => $importer['uid']]);
 			}
 			// send email notification to owner?
@@ -1524,7 +1537,7 @@ class Contact extends BaseObject
 				DBA::escape($nick),
 				DBA::escape($photo),
 				DBA::escape(NETWORK_OSTATUS),
-				intval(CONTACT_IS_FOLLOWER)
+				intval(self::CONTACT_IS_FOLLOWER)
 			);
 
 			$contact_record = [
@@ -1580,19 +1593,19 @@ class Contact extends BaseObject
 		}
 	}
 
-	public static function removeFollower($importer, $contact, array $datarray = [], $item = "") {
-
-		if (($contact['rel'] == CONTACT_IS_FRIEND) || ($contact['rel'] == CONTACT_IS_SHARING)) {
-			DBA::update('contact', ['rel' => CONTACT_IS_SHARING], ['id' => $contact['id']]);
+	public static function removeFollower($importer, $contact, array $datarray = [], $item = "")
+	{
+		if (($contact['rel'] == self::CONTACT_IS_FRIEND) || ($contact['rel'] == self::CONTACT_IS_SHARING)) {
+			DBA::update('contact', ['rel' => self::CONTACT_IS_SHARING], ['id' => $contact['id']]);
 		} else {
 			Contact::remove($contact['id']);
 		}
 	}
 
-	public static function removeSharer($importer, $contact, array $datarray = [], $item = "") {
-
-		if (($contact['rel'] == CONTACT_IS_FRIEND) || ($contact['rel'] == CONTACT_IS_FOLLOWER)) {
-			DBA::update('contact', ['rel' => CONTACT_IS_FOLLOWER], ['id' => $contact['id']]);
+	public static function removeSharer($importer, $contact, array $datarray = [], $item = "")
+	{
+		if (($contact['rel'] == self::CONTACT_IS_FRIEND) || ($contact['rel'] == self::CONTACT_IS_FOLLOWER)) {
+			DBA::update('contact', ['rel' => self::CONTACT_IS_FOLLOWER], ['id' => $contact['id']]);
 		} else {
 			Contact::remove($contact['id']);
 		}

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -36,9 +36,9 @@ class Contact extends BaseObject
 	 * Relationship types
 	 * @{
 	 */
-	const CONTACT_IS_FOLLOWER = 1;
-	const CONTACT_IS_SHARING  = 2;
-	const CONTACT_IS_FRIEND   = 3;
+	const FOLLOWER = 1;
+	const SHARING  = 2;
+	const FRIEND   = 3;
 	/**
 	 * @}
 	 */
@@ -862,7 +862,7 @@ class Contact extends BaseObject
 				'about'     => $data["about"],
 				'network'   => $data["network"],
 				'pubkey'    => $data["pubkey"],
-				'rel'       => self::CONTACT_IS_SHARING,
+				'rel'       => self::SHARING,
 				'priority'  => $data["priority"],
 				'batch'     => $data["batch"],
 				'request'   => $data["request"],
@@ -1387,12 +1387,12 @@ class Contact extends BaseObject
 
 		if (DBA::isResult($r)) {
 			// update contact
-			$new_relation = (($r[0]['rel'] == self::CONTACT_IS_FOLLOWER) ? self::CONTACT_IS_FRIEND : self::CONTACT_IS_SHARING);
+			$new_relation = (($r[0]['rel'] == self::FOLLOWER) ? self::FRIEND : self::SHARING);
 
 			$fields = ['rel' => $new_relation, 'subhub' => $subhub, 'readonly' => false];
 			DBA::update('contact', $fields, ['id' => $r[0]['id']]);
 		} else {
-			$new_relation = ((in_array($ret['network'], [NETWORK_MAIL])) ? self::CONTACT_IS_FRIEND : self::CONTACT_IS_SHARING);
+			$new_relation = ((in_array($ret['network'], [NETWORK_MAIL])) ? self::FRIEND : self::SHARING);
 
 			// create contact record
 			DBA::insert('contact', [
@@ -1513,9 +1513,9 @@ class Contact extends BaseObject
 		}
 
 		if (is_array($contact)) {
-			if (($contact['rel'] == self::CONTACT_IS_SHARING)
-				|| ($sharing && $contact['rel'] == self::CONTACT_IS_FOLLOWER)) {
-				DBA::update('contact', ['rel' => self::CONTACT_IS_FRIEND, 'writable' => true],
+			if (($contact['rel'] == self::SHARING)
+				|| ($sharing && $contact['rel'] == self::FOLLOWER)) {
+				DBA::update('contact', ['rel' => self::FRIEND, 'writable' => true],
 						['id' => $contact['id'], 'uid' => $importer['uid']]);
 			}
 			// send email notification to owner?
@@ -1537,7 +1537,7 @@ class Contact extends BaseObject
 				DBA::escape($nick),
 				DBA::escape($photo),
 				DBA::escape(NETWORK_OSTATUS),
-				intval(self::CONTACT_IS_FOLLOWER)
+				intval(self::FOLLOWER)
 			);
 
 			$contact_record = [
@@ -1595,8 +1595,8 @@ class Contact extends BaseObject
 
 	public static function removeFollower($importer, $contact, array $datarray = [], $item = "")
 	{
-		if (($contact['rel'] == self::CONTACT_IS_FRIEND) || ($contact['rel'] == self::CONTACT_IS_SHARING)) {
-			DBA::update('contact', ['rel' => self::CONTACT_IS_SHARING], ['id' => $contact['id']]);
+		if (($contact['rel'] == self::FRIEND) || ($contact['rel'] == self::SHARING)) {
+			DBA::update('contact', ['rel' => self::SHARING], ['id' => $contact['id']]);
 		} else {
 			Contact::remove($contact['id']);
 		}
@@ -1604,8 +1604,8 @@ class Contact extends BaseObject
 
 	public static function removeSharer($importer, $contact, array $datarray = [], $item = "")
 	{
-		if (($contact['rel'] == self::CONTACT_IS_FRIEND) || ($contact['rel'] == self::CONTACT_IS_FOLLOWER)) {
-			DBA::update('contact', ['rel' => self::CONTACT_IS_FOLLOWER], ['id' => $contact['id']]);
+		if (($contact['rel'] == self::FRIEND) || ($contact['rel'] == self::FOLLOWER)) {
+			DBA::update('contact', ['rel' => self::FOLLOWER], ['id' => $contact['id']]);
 		} else {
 			Contact::remove($contact['id']);
 		}

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -15,6 +15,7 @@ use Friendica\Core\PConfig;
 use Friendica\Core\System;
 use Friendica\Core\Worker;
 use Friendica\Database\DBA;
+use Friendica\Model\Contact;
 use Friendica\Object\Image;
 use Friendica\Protocol\Diaspora;
 use Friendica\Protocol\OStatus;
@@ -600,7 +601,7 @@ class Item extends BaseObject
 				STRAIGHT_JOIN `contact` AS `author` ON `author`.`id` = $master_table.`author-id` AND NOT `author`.`blocked`
 				STRAIGHT_JOIN `contact` AS `owner` ON `owner`.`id` = $master_table.`owner-id` AND NOT `owner`.`blocked`
 				LEFT JOIN `user-item` ON `user-item`.`iid` = $master_table_key AND `user-item`.`uid` = %d",
-				CONTACT_IS_SHARING, CONTACT_IS_FRIEND, GRAVITY_PARENT, intval($uid));
+				Contact::CONTACT_IS_SHARING, Contact::CONTACT_IS_FRIEND, GRAVITY_PARENT, intval($uid));
 		} else {
 			if (strpos($sql_commands, "`contact`.") !== false) {
 				$joins .= "LEFT JOIN `contact` ON `contact`.`id` = $master_table.`contact-id`";
@@ -2025,8 +2026,10 @@ class Item extends BaseObject
 		$users = [];
 
 		$condition = ["`nurl` IN (SELECT `nurl` FROM `contact` WHERE `id` = ?) AND `uid` != 0 AND NOT `blocked` AND `rel` IN (?, ?)",
-			$parent['owner-id'], CONTACT_IS_SHARING,  CONTACT_IS_FRIEND];
+			$parent['owner-id'], Contact::CONTACT_IS_SHARING,  Contact::CONTACT_IS_FRIEND];
+
 		$contacts = DBA::select('contact', ['uid'], $condition);
+
 		while ($contact = DBA::fetch($contacts)) {
 			$users[$contact['uid']] = $contact['uid'];
 		}

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -601,7 +601,7 @@ class Item extends BaseObject
 				STRAIGHT_JOIN `contact` AS `author` ON `author`.`id` = $master_table.`author-id` AND NOT `author`.`blocked`
 				STRAIGHT_JOIN `contact` AS `owner` ON `owner`.`id` = $master_table.`owner-id` AND NOT `owner`.`blocked`
 				LEFT JOIN `user-item` ON `user-item`.`iid` = $master_table_key AND `user-item`.`uid` = %d",
-				Contact::CONTACT_IS_SHARING, Contact::CONTACT_IS_FRIEND, GRAVITY_PARENT, intval($uid));
+				Contact::SHARING, Contact::FRIEND, GRAVITY_PARENT, intval($uid));
 		} else {
 			if (strpos($sql_commands, "`contact`.") !== false) {
 				$joins .= "LEFT JOIN `contact` ON `contact`.`id` = $master_table.`contact-id`";
@@ -2026,7 +2026,7 @@ class Item extends BaseObject
 		$users = [];
 
 		$condition = ["`nurl` IN (SELECT `nurl` FROM `contact` WHERE `id` = ?) AND `uid` != 0 AND NOT `blocked` AND `rel` IN (?, ?)",
-			$parent['owner-id'], Contact::CONTACT_IS_SHARING,  Contact::CONTACT_IS_FRIEND];
+			$parent['owner-id'], Contact::SHARING,  Contact::FRIEND];
 
 		$contacts = DBA::select('contact', ['uid'], $condition);
 

--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -16,6 +16,7 @@ use Friendica\Core\PConfig;
 use Friendica\Core\System;
 use Friendica\Core\Worker;
 use Friendica\Database\DBA;
+use Friendica\Model\Contact;
 use Friendica\Protocol\Diaspora;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Network;
@@ -340,14 +341,14 @@ class Profile
 					"SELECT `url` FROM `contact` WHERE `uid` = %d AND `id` = '%s' AND `rel` = %d",
 					intval($profile['uid']),
 					intval(remote_user()),
-					intval(CONTACT_IS_FRIEND)
+					intval(Contact::CONTACT_IS_FRIEND)
 				);
 			} else {
 				$r = q(
 					"SELECT `url` FROM `contact` WHERE `uid` = %d AND `nurl` = '%s' AND `rel` = %d",
 					intval($profile['uid']),
 					DBA::escape(normalise_link(self::getMyURL())),
-					intval(CONTACT_IS_FRIEND)
+					intval(Contact::CONTACT_IS_FRIEND)
 				);
 			}
 			if ($r) {

--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -341,14 +341,14 @@ class Profile
 					"SELECT `url` FROM `contact` WHERE `uid` = %d AND `id` = '%s' AND `rel` = %d",
 					intval($profile['uid']),
 					intval(remote_user()),
-					intval(Contact::CONTACT_IS_FRIEND)
+					intval(Contact::FRIEND)
 				);
 			} else {
 				$r = q(
 					"SELECT `url` FROM `contact` WHERE `uid` = %d AND `nurl` = '%s' AND `rel` = %d",
 					intval($profile['uid']),
 					DBA::escape(normalise_link(self::getMyURL())),
-					intval(Contact::CONTACT_IS_FRIEND)
+					intval(Contact::FRIEND)
 				);
 			}
 			if ($r) {

--- a/src/Network/Probe.php
+++ b/src/Network/Probe.php
@@ -448,7 +448,7 @@ class Probe
 						'pubkey' => $data['pubkey'],
 						'priority' => $data['priority'],
 						'writable' => true,
-						'rel' => Contact::CONTACT_IS_SHARING];
+						'rel' => Contact::SHARING];
 
 				$fieldnames = [];
 

--- a/src/Network/Probe.php
+++ b/src/Network/Probe.php
@@ -14,6 +14,7 @@ use Friendica\Core\Cache;
 use Friendica\Core\Config;
 use Friendica\Core\System;
 use Friendica\Database\DBA;
+use Friendica\Model\Contact;
 use Friendica\Model\Profile;
 use Friendica\Protocol\Email;
 use Friendica\Protocol\Feed;
@@ -447,7 +448,7 @@ class Probe
 						'pubkey' => $data['pubkey'],
 						'priority' => $data['priority'],
 						'writable' => true,
-						'rel' => CONTACT_IS_SHARING];
+						'rel' => Contact::CONTACT_IS_SHARING];
 
 				$fieldnames = [];
 

--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -1260,7 +1260,7 @@ class DFRN
 
 		if (($contact['duplex'] && strlen($contact['pubkey']))
 			|| ($owner['page-flags'] == PAGE_COMMUNITY && strlen($contact['pubkey']))
-			|| ($contact['rel'] == Contact::CONTACT_IS_SHARING && strlen($contact['pubkey']))
+			|| ($contact['rel'] == Contact::SHARING && strlen($contact['pubkey']))
 		) {
 			openssl_public_decrypt($sent_dfrn_id, $final_dfrn_id, $contact['pubkey']);
 			openssl_public_decrypt($challenge, $postvars['challenge'], $contact['pubkey']);
@@ -1288,7 +1288,7 @@ class DFRN
 			$postvars['dissolve'] = '1';
 		}
 
-		if ((($contact['rel']) && ($contact['rel'] != Contact::CONTACT_IS_SHARING) && (! $contact['blocked'])) || ($owner['page-flags'] == PAGE_COMMUNITY)) {
+		if ((($contact['rel']) && ($contact['rel'] != Contact::SHARING) && (! $contact['blocked'])) || ($owner['page-flags'] == PAGE_COMMUNITY)) {
 			$postvars['data'] = $atom;
 			$postvars['perm'] = 'rw';
 		} else {
@@ -1323,7 +1323,7 @@ class DFRN
 			if ($dfrn_version >= 2.1) {
 				if (($contact['duplex'] && strlen($contact['pubkey']))
 					|| ($owner['page-flags'] == PAGE_COMMUNITY && strlen($contact['pubkey']))
-					|| ($contact['rel'] == Contact::CONTACT_IS_SHARING && strlen($contact['pubkey']))
+					|| ($contact['rel'] == Contact::SHARING && strlen($contact['pubkey']))
 				) {
 					openssl_public_encrypt($key, $postvars['key'], $contact['pubkey']);
 				} else {
@@ -2712,7 +2712,7 @@ class DFRN
 				$item["owner-id"] = Contact::getIdForURL($importer["url"], 0);
 			}
 
-			if (($importer["rel"] == Contact::CONTACT_IS_FOLLOWER) && (!self::tgroupCheck($importer["importer_uid"], $item))) {
+			if (($importer["rel"] == Contact::FOLLOWER) && (!self::tgroupCheck($importer["importer_uid"], $item))) {
 				logger("Contact ".$importer["id"]." is only follower and tgroup check was negative.", LOGGER_DEBUG);
 				return;
 			}

--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -1260,7 +1260,7 @@ class DFRN
 
 		if (($contact['duplex'] && strlen($contact['pubkey']))
 			|| ($owner['page-flags'] == PAGE_COMMUNITY && strlen($contact['pubkey']))
-			|| ($contact['rel'] == CONTACT_IS_SHARING && strlen($contact['pubkey']))
+			|| ($contact['rel'] == Contact::CONTACT_IS_SHARING && strlen($contact['pubkey']))
 		) {
 			openssl_public_decrypt($sent_dfrn_id, $final_dfrn_id, $contact['pubkey']);
 			openssl_public_decrypt($challenge, $postvars['challenge'], $contact['pubkey']);
@@ -1288,7 +1288,7 @@ class DFRN
 			$postvars['dissolve'] = '1';
 		}
 
-		if ((($contact['rel']) && ($contact['rel'] != CONTACT_IS_SHARING) && (! $contact['blocked'])) || ($owner['page-flags'] == PAGE_COMMUNITY)) {
+		if ((($contact['rel']) && ($contact['rel'] != Contact::CONTACT_IS_SHARING) && (! $contact['blocked'])) || ($owner['page-flags'] == PAGE_COMMUNITY)) {
 			$postvars['data'] = $atom;
 			$postvars['perm'] = 'rw';
 		} else {
@@ -1323,7 +1323,7 @@ class DFRN
 			if ($dfrn_version >= 2.1) {
 				if (($contact['duplex'] && strlen($contact['pubkey']))
 					|| ($owner['page-flags'] == PAGE_COMMUNITY && strlen($contact['pubkey']))
-					|| ($contact['rel'] == CONTACT_IS_SHARING && strlen($contact['pubkey']))
+					|| ($contact['rel'] == Contact::CONTACT_IS_SHARING && strlen($contact['pubkey']))
 				) {
 					openssl_public_encrypt($key, $postvars['key'], $contact['pubkey']);
 				} else {
@@ -2712,7 +2712,7 @@ class DFRN
 				$item["owner-id"] = Contact::getIdForURL($importer["url"], 0);
 			}
 
-			if (($importer["rel"] == CONTACT_IS_FOLLOWER) && (!self::tgroupCheck($importer["importer_uid"], $item))) {
+			if (($importer["rel"] == Contact::CONTACT_IS_FOLLOWER) && (!self::tgroupCheck($importer["importer_uid"], $item))) {
 				logger("Contact ".$importer["id"]." is only follower and tgroup check was negative.", LOGGER_DEBUG);
 				return;
 			}

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -177,7 +177,7 @@ class Diaspora
 			'name' => 'relay', 'nick' => 'relay',
 			'url' => $server_url, 'network' => NETWORK_DIASPORA,
 			'batch' => $server_url . '/receive/public',
-			'rel' => CONTACT_IS_FOLLOWER, 'blocked' => false,
+			'rel' => Contact::CONTACT_IS_FOLLOWER, 'blocked' => false,
 			'pending' => false, 'writable' => true];
 
 		$fields = array_merge($fields, $network_fields);
@@ -1079,14 +1079,14 @@ class Diaspora
 		 */
 		// It is deactivated by now, due to side effects. See issue https://github.com/friendica/friendica/pull/4033
 		// It is not removed by now. Possibly the code is needed?
-		//if (!$is_comment && $contact["rel"] == CONTACT_IS_FOLLOWER && in_array($importer["page-flags"], array(PAGE_FREELOVE))) {
+		//if (!$is_comment && $contact["rel"] == Contact::CONTACT_IS_FOLLOWER && in_array($importer["page-flags"], array(PAGE_FREELOVE))) {
 		//	dba::update(
 		//		'contact',
-		//		array('rel' => CONTACT_IS_FRIEND, 'writable' => true),
+		//		array('rel' => Contact::CONTACT_IS_FRIEND, 'writable' => true),
 		//		array('id' => $contact["id"], 'uid' => $contact["uid"])
 		//	);
 		//
-		//	$contact["rel"] = CONTACT_IS_FRIEND;
+		//	$contact["rel"] = Contact::CONTACT_IS_FRIEND;
 		//	logger("defining user ".$contact["nick"]." as friend");
 		//}
 
@@ -1095,11 +1095,11 @@ class Diaspora
 			// Maybe blocked, don't accept.
 			return false;
 			// We are following this person?
-		} elseif (($contact["rel"] == CONTACT_IS_SHARING) || ($contact["rel"] == CONTACT_IS_FRIEND)) {
+		} elseif (($contact["rel"] == Contact::CONTACT_IS_SHARING) || ($contact["rel"] == Contact::CONTACT_IS_FRIEND)) {
 			// Yes, then it is fine.
 			return true;
 			// Is it a post to a community?
-		} elseif (($contact["rel"] == CONTACT_IS_FOLLOWER) && in_array($importer["page-flags"], [PAGE_COMMUNITY, PAGE_PRVGROUP])) {
+		} elseif (($contact["rel"] == Contact::CONTACT_IS_FOLLOWER) && in_array($importer["page-flags"], [PAGE_COMMUNITY, PAGE_PRVGROUP])) {
 			// That's good
 			return true;
 			// Is the message a global user or a comment?
@@ -2305,10 +2305,10 @@ class Diaspora
 	{
 		$a = get_app();
 
-		if ($contact["rel"] == CONTACT_IS_SHARING) {
+		if ($contact["rel"] == Contact::CONTACT_IS_SHARING) {
 			DBA::update(
 				'contact',
-				['rel' => CONTACT_IS_FRIEND, 'writable' => true],
+				['rel' => Contact::CONTACT_IS_FRIEND, 'writable' => true],
 				['id' => $contact["id"], 'uid' => $importer["uid"]]
 			);
 		}
@@ -2359,7 +2359,7 @@ class Diaspora
 
 				// If we are now friends, we are sending a share message.
 				// Normally we needn't to do so, but the first message could have been vanished.
-				if (in_array($contact["rel"], [CONTACT_IS_FRIEND])) {
+				if (in_array($contact["rel"], [Contact::CONTACT_IS_FRIEND])) {
 					$u = q("SELECT * FROM `user` WHERE `uid` = %d LIMIT 1", intval($importer["uid"]));
 					if ($u) {
 						logger("Sending share message to author ".$author." - Contact: ".$contact["id"]." - User: ".$importer["uid"], LOGGER_DEBUG);
@@ -2455,16 +2455,16 @@ class Diaspora
 
 			Contact::updateAvatar($contact_record["photo"], $importer["uid"], $contact_record["id"]);
 
-			// technically they are sharing with us (CONTACT_IS_SHARING),
+			// technically they are sharing with us (Contact::CONTACT_IS_SHARING),
 			// but if our page-type is PAGE_COMMUNITY or PAGE_SOAPBOX
 			// we are going to change the relationship and make them a follower.
 
 			if (($importer["page-flags"] == PAGE_FREELOVE) && $sharing && $following) {
-				$new_relation = CONTACT_IS_FRIEND;
+				$new_relation = Contact::CONTACT_IS_FRIEND;
 			} elseif (($importer["page-flags"] == PAGE_FREELOVE) && $sharing) {
-				$new_relation = CONTACT_IS_SHARING;
+				$new_relation = Contact::CONTACT_IS_SHARING;
 			} else {
-				$new_relation = CONTACT_IS_FOLLOWER;
+				$new_relation = Contact::CONTACT_IS_FOLLOWER;
 			}
 
 			$r = q(
@@ -3269,13 +3269,15 @@ class Diaspora
 
 		/*
 		switch ($contact["rel"]) {
-			case CONTACT_IS_FRIEND:
+			case Contact::CONTACT_IS_FRIEND:
 				$following = true;
 				$sharing = true;
-			case CONTACT_IS_SHARING:
+
+			case Contact::CONTACT_IS_SHARING:
 				$following = false;
 				$sharing = true;
-			case CONTACT_IS_FOLLOWER:
+
+			case Contact::CONTACT_IS_FOLLOWER:
 				$following = true;
 				$sharing = false;
 		}
@@ -4131,7 +4133,7 @@ class Diaspora
 				AND `uid` = %d AND `rel` != %d",
 				DBA::escape(NETWORK_DIASPORA),
 				intval($uid),
-				intval(CONTACT_IS_SHARING)
+				intval(Contact::CONTACT_IS_SHARING)
 			);
 		}
 

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -177,7 +177,7 @@ class Diaspora
 			'name' => 'relay', 'nick' => 'relay',
 			'url' => $server_url, 'network' => NETWORK_DIASPORA,
 			'batch' => $server_url . '/receive/public',
-			'rel' => Contact::CONTACT_IS_FOLLOWER, 'blocked' => false,
+			'rel' => Contact::FOLLOWER, 'blocked' => false,
 			'pending' => false, 'writable' => true];
 
 		$fields = array_merge($fields, $network_fields);
@@ -1079,14 +1079,14 @@ class Diaspora
 		 */
 		// It is deactivated by now, due to side effects. See issue https://github.com/friendica/friendica/pull/4033
 		// It is not removed by now. Possibly the code is needed?
-		//if (!$is_comment && $contact["rel"] == Contact::CONTACT_IS_FOLLOWER && in_array($importer["page-flags"], array(PAGE_FREELOVE))) {
+		//if (!$is_comment && $contact["rel"] == Contact::FOLLOWER && in_array($importer["page-flags"], array(PAGE_FREELOVE))) {
 		//	dba::update(
 		//		'contact',
-		//		array('rel' => Contact::CONTACT_IS_FRIEND, 'writable' => true),
+		//		array('rel' => Contact::FRIEND, 'writable' => true),
 		//		array('id' => $contact["id"], 'uid' => $contact["uid"])
 		//	);
 		//
-		//	$contact["rel"] = Contact::CONTACT_IS_FRIEND;
+		//	$contact["rel"] = Contact::FRIEND;
 		//	logger("defining user ".$contact["nick"]." as friend");
 		//}
 
@@ -1095,11 +1095,11 @@ class Diaspora
 			// Maybe blocked, don't accept.
 			return false;
 			// We are following this person?
-		} elseif (($contact["rel"] == Contact::CONTACT_IS_SHARING) || ($contact["rel"] == Contact::CONTACT_IS_FRIEND)) {
+		} elseif (($contact["rel"] == Contact::SHARING) || ($contact["rel"] == Contact::FRIEND)) {
 			// Yes, then it is fine.
 			return true;
 			// Is it a post to a community?
-		} elseif (($contact["rel"] == Contact::CONTACT_IS_FOLLOWER) && in_array($importer["page-flags"], [PAGE_COMMUNITY, PAGE_PRVGROUP])) {
+		} elseif (($contact["rel"] == Contact::FOLLOWER) && in_array($importer["page-flags"], [PAGE_COMMUNITY, PAGE_PRVGROUP])) {
 			// That's good
 			return true;
 			// Is the message a global user or a comment?
@@ -2305,10 +2305,10 @@ class Diaspora
 	{
 		$a = get_app();
 
-		if ($contact["rel"] == Contact::CONTACT_IS_SHARING) {
+		if ($contact["rel"] == Contact::SHARING) {
 			DBA::update(
 				'contact',
-				['rel' => Contact::CONTACT_IS_FRIEND, 'writable' => true],
+				['rel' => Contact::FRIEND, 'writable' => true],
 				['id' => $contact["id"], 'uid' => $importer["uid"]]
 			);
 		}
@@ -2359,7 +2359,7 @@ class Diaspora
 
 				// If we are now friends, we are sending a share message.
 				// Normally we needn't to do so, but the first message could have been vanished.
-				if (in_array($contact["rel"], [Contact::CONTACT_IS_FRIEND])) {
+				if (in_array($contact["rel"], [Contact::FRIEND])) {
 					$u = q("SELECT * FROM `user` WHERE `uid` = %d LIMIT 1", intval($importer["uid"]));
 					if ($u) {
 						logger("Sending share message to author ".$author." - Contact: ".$contact["id"]." - User: ".$importer["uid"], LOGGER_DEBUG);
@@ -2455,16 +2455,16 @@ class Diaspora
 
 			Contact::updateAvatar($contact_record["photo"], $importer["uid"], $contact_record["id"]);
 
-			// technically they are sharing with us (Contact::CONTACT_IS_SHARING),
+			// technically they are sharing with us (Contact::SHARING),
 			// but if our page-type is PAGE_COMMUNITY or PAGE_SOAPBOX
 			// we are going to change the relationship and make them a follower.
 
 			if (($importer["page-flags"] == PAGE_FREELOVE) && $sharing && $following) {
-				$new_relation = Contact::CONTACT_IS_FRIEND;
+				$new_relation = Contact::FRIEND;
 			} elseif (($importer["page-flags"] == PAGE_FREELOVE) && $sharing) {
-				$new_relation = Contact::CONTACT_IS_SHARING;
+				$new_relation = Contact::SHARING;
 			} else {
-				$new_relation = Contact::CONTACT_IS_FOLLOWER;
+				$new_relation = Contact::FOLLOWER;
 			}
 
 			$r = q(
@@ -3269,15 +3269,15 @@ class Diaspora
 
 		/*
 		switch ($contact["rel"]) {
-			case Contact::CONTACT_IS_FRIEND:
+			case Contact::FRIEND:
 				$following = true;
 				$sharing = true;
 
-			case Contact::CONTACT_IS_SHARING:
+			case Contact::SHARING:
 				$following = false;
 				$sharing = true;
 
-			case Contact::CONTACT_IS_FOLLOWER:
+			case Contact::FOLLOWER:
 				$following = true;
 				$sharing = false;
 		}
@@ -4133,7 +4133,7 @@ class Diaspora
 				AND `uid` = %d AND `rel` != %d",
 				DBA::escape(NETWORK_DIASPORA),
 				intval($uid),
-				intval(Contact::CONTACT_IS_SHARING)
+				intval(Contact::SHARING)
 			);
 		}
 

--- a/src/Protocol/OStatus.php
+++ b/src/Protocol/OStatus.php
@@ -76,7 +76,7 @@ class OStatus
 		if ($aliaslink != '') {
 			$condition = ["`uid` = ? AND `alias` = ? AND `network` != ? AND `rel` IN (?, ?)",
 					$importer["uid"], $aliaslink, NETWORK_STATUSNET,
-					Contact::CONTACT_IS_SHARING, Contact::CONTACT_IS_FRIEND];
+					Contact::SHARING, Contact::FRIEND];
 			$contact = DBA::selectFirst('contact', [], $condition);
 		}
 
@@ -87,14 +87,14 @@ class OStatus
 
 			$condition = ["`uid` = ? AND `nurl` IN (?, ?) AND `network` != ? AND `rel` IN (?, ?)",
 					$importer["uid"], normalise_link($author["author-link"]), normalise_link($aliaslink),
-					NETWORK_STATUSNET, Contact::CONTACT_IS_SHARING, Contact::CONTACT_IS_FRIEND];
+					NETWORK_STATUSNET, Contact::SHARING, Contact::FRIEND];
 			$contact = DBA::selectFirst('contact', [], $condition);
 		}
 
 		if (!DBA::isResult($contact) && ($addr != '')) {
 			$condition = ["`uid` = ? AND `addr` = ? AND `network` != ? AND `rel` IN (?, ?)",
 					$importer["uid"], $addr, NETWORK_STATUSNET,
-					Contact::CONTACT_IS_SHARING, Contact::CONTACT_IS_FRIEND];
+					Contact::SHARING, Contact::FRIEND];
 			$contact = DBA::selectFirst('contact', [], $condition);
 		}
 

--- a/src/Protocol/OStatus.php
+++ b/src/Protocol/OStatus.php
@@ -76,7 +76,7 @@ class OStatus
 		if ($aliaslink != '') {
 			$condition = ["`uid` = ? AND `alias` = ? AND `network` != ? AND `rel` IN (?, ?)",
 					$importer["uid"], $aliaslink, NETWORK_STATUSNET,
-					CONTACT_IS_SHARING, CONTACT_IS_FRIEND];
+					Contact::CONTACT_IS_SHARING, Contact::CONTACT_IS_FRIEND];
 			$contact = DBA::selectFirst('contact', [], $condition);
 		}
 
@@ -87,14 +87,14 @@ class OStatus
 
 			$condition = ["`uid` = ? AND `nurl` IN (?, ?) AND `network` != ? AND `rel` IN (?, ?)",
 					$importer["uid"], normalise_link($author["author-link"]), normalise_link($aliaslink),
-					NETWORK_STATUSNET, CONTACT_IS_SHARING, CONTACT_IS_FRIEND];
+					NETWORK_STATUSNET, Contact::CONTACT_IS_SHARING, Contact::CONTACT_IS_FRIEND];
 			$contact = DBA::selectFirst('contact', [], $condition);
 		}
 
 		if (!DBA::isResult($contact) && ($addr != '')) {
 			$condition = ["`uid` = ? AND `addr` = ? AND `network` != ? AND `rel` IN (?, ?)",
 					$importer["uid"], $addr, NETWORK_STATUSNET,
-					CONTACT_IS_SHARING, CONTACT_IS_FRIEND];
+					Contact::CONTACT_IS_SHARING, Contact::CONTACT_IS_FRIEND];
 			$contact = DBA::selectFirst('contact', [], $condition);
 		}
 

--- a/src/Worker/Cron.php
+++ b/src/Worker/Cron.php
@@ -222,7 +222,7 @@ class Cron
 			}
 
 			// Check Diaspora contacts or followers once a week
-			if (($contact["network"] == NETWORK_DIASPORA) || ($contact["rel"] == Contact::CONTACT_IS_FOLLOWER)) {
+			if (($contact["network"] == NETWORK_DIASPORA) || ($contact["rel"] == Contact::FOLLOWER)) {
 				$contact['priority'] = 4;
 			}
 

--- a/src/Worker/Cron.php
+++ b/src/Worker/Cron.php
@@ -9,6 +9,7 @@ use Friendica\Core\Addon;
 use Friendica\Core\Config;
 use Friendica\Core\Worker;
 use Friendica\Database\DBA;
+use Friendica\Model\Contact;
 use Friendica\Util\DateTimeFormat;
 
 require_once 'include/dba.php';
@@ -221,7 +222,7 @@ class Cron
 			}
 
 			// Check Diaspora contacts or followers once a week
-			if (($contact["network"] == NETWORK_DIASPORA) || ($contact["rel"] == CONTACT_IS_FOLLOWER)) {
+			if (($contact["network"] == NETWORK_DIASPORA) || ($contact["rel"] == Contact::CONTACT_IS_FOLLOWER)) {
 				$contact['priority'] = 4;
 			}
 

--- a/src/Worker/Delivery.php
+++ b/src/Worker/Delivery.php
@@ -424,7 +424,7 @@ class Delivery extends BaseObject
 
 		// only expose our real email address to true friends
 
-		if (($contact['rel'] == CONTACT_IS_FRIEND) && !$contact['blocked']) {
+		if (($contact['rel'] == Contact::CONTACT_IS_FRIEND) && !$contact['blocked']) {
 			if ($reply_to) {
 				$headers  = 'From: ' . Email::encodeHeader($local_user['username'],'UTF-8') . ' <' . $reply_to.'>' . "\n";
 				$headers .= 'Sender: ' . $local_user['email'] . "\n";

--- a/src/Worker/Delivery.php
+++ b/src/Worker/Delivery.php
@@ -424,7 +424,7 @@ class Delivery extends BaseObject
 
 		// only expose our real email address to true friends
 
-		if (($contact['rel'] == Contact::CONTACT_IS_FRIEND) && !$contact['blocked']) {
+		if (($contact['rel'] == Contact::FRIEND) && !$contact['blocked']) {
 			if ($reply_to) {
 				$headers  = 'From: ' . Email::encodeHeader($local_user['username'],'UTF-8') . ' <' . $reply_to.'>' . "\n";
 				$headers .= 'Sender: ' . $local_user['email'] . "\n";

--- a/src/Worker/Notifier.php
+++ b/src/Worker/Notifier.php
@@ -442,7 +442,7 @@ class Notifier
 					AND `uid` = %d AND `rel` != %d AND NOT `blocked` AND NOT `pending` AND NOT `archive` GROUP BY `batch`",
 					DBA::escape(NETWORK_DIASPORA),
 					intval($owner['uid']),
-					intval(Contact::CONTACT_IS_SHARING)
+					intval(Contact::SHARING)
 				);
 
 				// Fetch the participation list
@@ -456,7 +456,7 @@ class Notifier
 			}
 
 			$condition = ['network' => NETWORK_DFRN, 'uid' => $owner['uid'], 'blocked' => false,
-				'pending' => false, 'archive' => false, 'rel' => [Contact::CONTACT_IS_FOLLOWER, Contact::CONTACT_IS_FRIEND]];
+				'pending' => false, 'archive' => false, 'rel' => [Contact::FOLLOWER, Contact::FRIEND]];
 
 			$r2 = DBA::toArray(DBA::select('contact', ['id', 'name', 'network'], $condition));
 

--- a/src/Worker/Notifier.php
+++ b/src/Worker/Notifier.php
@@ -442,7 +442,7 @@ class Notifier
 					AND `uid` = %d AND `rel` != %d AND NOT `blocked` AND NOT `pending` AND NOT `archive` GROUP BY `batch`",
 					DBA::escape(NETWORK_DIASPORA),
 					intval($owner['uid']),
-					intval(CONTACT_IS_SHARING)
+					intval(Contact::CONTACT_IS_SHARING)
 				);
 
 				// Fetch the participation list
@@ -456,7 +456,8 @@ class Notifier
 			}
 
 			$condition = ['network' => NETWORK_DFRN, 'uid' => $owner['uid'], 'blocked' => false,
-				'pending' => false, 'archive' => false, 'rel' => [CONTACT_IS_FOLLOWER, CONTACT_IS_FRIEND]];
+				'pending' => false, 'archive' => false, 'rel' => [Contact::CONTACT_IS_FOLLOWER, Contact::CONTACT_IS_FRIEND]];
+
 			$r2 = DBA::toArray(DBA::select('contact', ['id', 'name', 'network'], $condition));
 
 			$r = array_merge($r2, $r1);

--- a/src/Worker/OnePoll.php
+++ b/src/Worker/OnePoll.php
@@ -68,9 +68,10 @@ class OnePoll
 		}
 
 		// Diaspora users, archived users and followers are only checked if they still exist.
-		if ($contact['archive'] || ($contact["network"] == NETWORK_DIASPORA) || ($contact["rel"] == Contact::CONTACT_IS_FOLLOWER)) {
+		if ($contact['archive'] || ($contact["network"] == NETWORK_DIASPORA) || ($contact["rel"] == Contact::FOLLOWER)) {
 			$last_updated = PortableContact::lastUpdated($contact["url"], true);
 			$updated = DateTimeFormat::utcNow();
+
 			if ($last_updated) {
 				logger('Contact '.$contact['id'].' had last update on '.$last_updated, LOGGER_DEBUG);
 
@@ -87,6 +88,7 @@ class OnePoll
 				Contact::markForArchival($contact);
 				logger('Contact '.$contact['id'].' is marked for archival', LOGGER_DEBUG);
 			}
+
 			return;
 		}
 
@@ -197,7 +199,6 @@ class OnePoll
 
 			logger('handshake with url ' . $url . ' returns xml: ' . $handshake_xml, LOGGER_DATA);
 
-
 			if (!strlen($handshake_xml) || ($html_code >= 400) || !$html_code) {
 				logger("$url appears to be dead - marking for death ");
 
@@ -296,7 +297,7 @@ class OnePoll
 			// Will only do this once per notify-enabled OStatus contact
 			// or if relationship changes
 
-			$stat_writeable = ((($contact['notify']) && ($contact['rel'] == Contact::CONTACT_IS_FOLLOWER || $contact['rel'] == Contact::CONTACT_IS_FRIEND)) ? 1 : 0);
+			$stat_writeable = ((($contact['notify']) && ($contact['rel'] == Contact::FOLLOWER || $contact['rel'] == Contact::FRIEND)) ? 1 : 0);
 
 			// Contacts from OStatus are always writable
 			if ($contact['network'] === NETWORK_OSTATUS) {
@@ -310,7 +311,7 @@ class OnePoll
 
 			// Are we allowed to import from this person?
 
-			if ($contact['rel'] == Contact::CONTACT_IS_FOLLOWER || $contact['blocked']) {
+			if ($contact['rel'] == Contact::FOLLOWER || $contact['blocked']) {
 				// set the last-update so we don't keep polling
 				DBA::update('contact', ['last-update' => DateTimeFormat::utcNow()], ['id' => $contact['id']]);
 				return;
@@ -330,7 +331,6 @@ class OnePoll
 			$xml = $ret['body'];
 
 		} elseif ($contact['network'] === NETWORK_MAIL) {
-
 			logger("Mail: Fetching for ".$contact['addr'], LOGGER_DEBUG);
 
 			$mail_disabled = ((function_exists('imap_open') && (! Config::get('system', 'imap_disabled'))) ? 0 : 1);
@@ -371,6 +371,7 @@ class OnePoll
 					logger("Mail: Parsing ".count($msgs)." mails from ".$contact['addr']." for ".$mailconf['user'], LOGGER_DEBUG);
 
 					$metas = Email::messageMeta($mbox, implode(',', $msgs));
+
 					if (count($metas) != count($msgs)) {
 						logger("for " . $mailconf['user'] . " there are ". count($msgs) . " messages but received " . count($metas) . " metas", LOGGER_DEBUG);
 					} else {
@@ -602,7 +603,7 @@ class OnePoll
 
 			logger("Contact ".$contact['id']." returned hub: ".$hub." Network: ".$contact['network']." Relation: ".$contact['rel']." Update: ".$hub_update);
 
-			if (strlen($hub) && $hub_update && (($contact['rel'] != Contact::CONTACT_IS_FOLLOWER) || $contact['network'] == NETWORK_FEED)) {
+			if (strlen($hub) && $hub_update && (($contact['rel'] != Contact::FOLLOWER) || $contact['network'] == NETWORK_FEED)) {
 				logger('hub ' . $hubmode . ' : ' . $hub . ' contact name : ' . $contact['name'] . ' local user : ' . $importer['name']);
 				$hubs = explode(',', $hub);
 				if (count($hubs)) {

--- a/src/Worker/OnePoll.php
+++ b/src/Worker/OnePoll.php
@@ -68,7 +68,7 @@ class OnePoll
 		}
 
 		// Diaspora users, archived users and followers are only checked if they still exist.
-		if ($contact['archive'] || ($contact["network"] == NETWORK_DIASPORA) || ($contact["rel"] == CONTACT_IS_FOLLOWER)) {
+		if ($contact['archive'] || ($contact["network"] == NETWORK_DIASPORA) || ($contact["rel"] == Contact::CONTACT_IS_FOLLOWER)) {
 			$last_updated = PortableContact::lastUpdated($contact["url"], true);
 			$updated = DateTimeFormat::utcNow();
 			if ($last_updated) {
@@ -296,7 +296,7 @@ class OnePoll
 			// Will only do this once per notify-enabled OStatus contact
 			// or if relationship changes
 
-			$stat_writeable = ((($contact['notify']) && ($contact['rel'] == CONTACT_IS_FOLLOWER || $contact['rel'] == CONTACT_IS_FRIEND)) ? 1 : 0);
+			$stat_writeable = ((($contact['notify']) && ($contact['rel'] == Contact::CONTACT_IS_FOLLOWER || $contact['rel'] == Contact::CONTACT_IS_FRIEND)) ? 1 : 0);
 
 			// Contacts from OStatus are always writable
 			if ($contact['network'] === NETWORK_OSTATUS) {
@@ -310,7 +310,7 @@ class OnePoll
 
 			// Are we allowed to import from this person?
 
-			if ($contact['rel'] == CONTACT_IS_FOLLOWER || $contact['blocked']) {
+			if ($contact['rel'] == Contact::CONTACT_IS_FOLLOWER || $contact['blocked']) {
 				// set the last-update so we don't keep polling
 				DBA::update('contact', ['last-update' => DateTimeFormat::utcNow()], ['id' => $contact['id']]);
 				return;
@@ -602,7 +602,7 @@ class OnePoll
 
 			logger("Contact ".$contact['id']." returned hub: ".$hub." Network: ".$contact['network']." Relation: ".$contact['rel']." Update: ".$hub_update);
 
-			if (strlen($hub) && $hub_update && (($contact['rel'] != CONTACT_IS_FOLLOWER) || $contact['network'] == NETWORK_FEED)) {
+			if (strlen($hub) && $hub_update && (($contact['rel'] != Contact::CONTACT_IS_FOLLOWER) || $contact['network'] == NETWORK_FEED)) {
 				logger('hub ' . $hubmode . ' : ' . $hub . ' contact name : ' . $contact['name'] . ' local user : ' . $importer['name']);
 				$hubs = explode(',', $hub);
 				if (count($hubs)) {


### PR DESCRIPTION
This PR moves all `CONTACT_*` constants from `boot.php` to `Friendica\Model\Contact` class. Also a fix for addon repository is finished and **depends** on this change!