### PR TITLE
[frio] Fix wrongly removed content wrapper and fix CSS instead. (#5496)

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -2165,7 +2165,7 @@ ul.dropdown-menu li:hover {
  .suggest-content-wrapper, .common-content-wrapper, .help-content-wrapper,
 .allfriends-content-wrapper, .match-content-wrapper, .dirfind-content-wrapper,
 .directory-content-wrapper, .manage-content-wrapper, .notes-content-wrapper,
-.message-content-wrapper, .apps-content-wrapper, .photos-content-wrapper,
+.message-content-wrapper, .apps-content-wrapper, 
 #adminpage, .delegate-content-wrapper, .uexport-content-wrapper,
 .viewcontacts-content-wrapper, .dfrn_request-content-wrapper,
 .friendica-content-wrapper, .credits-content-wrapper, .nogroup-content-wrapper,

--- a/view/theme/frio/templates/photo_album.tpl
+++ b/view/theme/frio/templates/photo_album.tpl
@@ -1,38 +1,40 @@
-<div class="pull-left">
-<h3 id="photo-album-title">{{$album}}</h3>
+<div class="generic-page-wrapper">
+	<div class="pull-left">
+	<h3 id="photo-album-title">{{$album}}</h3>
+	</div>
+	
+	<div class="photo-album-actions pull-right">
+		{{if $can_post}}
+		<a class="photos-upload-link" href="{{$upload.1}}" title="{{$upload.0}}" data-toggle="tooltip">
+		<i class="faded-icon fa fa-plus"></i></a>
+		{{/if}}
+		{{if $edit}}
+		<span class="icon-padding"> </span>
+		<a id="album-edit-link" href="{{$edit.1}}" title="{{$edit.0}}" data-toggle="tooltip">
+		<i class="faded-icon fa fa-pencil"></i></a>
+		{{/if}}
+		{{if ! $noorder}}
+		<span class="icon-padding"> </span>
+		<a class="photos-order-link" href="{{$order.1}}" title="{{$order.0}}" data-toggle="tooltip">
+		{{if $order.2 == "newest"}}
+		<i class="faded-icon fa fa-sort-numeric-desc"></i>
+		{{else}}
+		<i class="faded-icon fa fa-sort-numeric-asc"></i>
+		{{/if}}
+		</a>
+		{{/if}}
+	</div>
+	<div class="clear"></div>
+	
+	<div class="photo-album-wrapper" id="photo-album-contents">
+	{{foreach $photos as $photo}}
+		{{include file="photo_top.tpl"}}
+	{{/foreach}}
+	</div>
+	
+	<div class="photo-album-end"></div>
+	
+	{{$paginate}}
+	
+	<script type="text/javascript">$(document).ready(function() { loadingPage = false; justifyPhotos(); });</script>
 </div>
-
-<div class="photo-album-actions pull-right">
-	{{if $can_post}}
-	<a class="photos-upload-link" href="{{$upload.1}}" title="{{$upload.0}}" data-toggle="tooltip">
-	<i class="faded-icon fa fa-plus"></i></a>
-	{{/if}}
-	{{if $edit}}
-	<span class="icon-padding"> </span>
-	<a id="album-edit-link" href="{{$edit.1}}" title="{{$edit.0}}" data-toggle="tooltip">
-	<i class="faded-icon fa fa-pencil"></i></a>
-	{{/if}}
-	{{if ! $noorder}}
-	<span class="icon-padding"> </span>
-	<a class="photos-order-link" href="{{$order.1}}" title="{{$order.0}}" data-toggle="tooltip">
-	{{if $order.2 == "newest"}}
-	<i class="faded-icon fa fa-sort-numeric-desc"></i>
-	{{else}}
-	<i class="faded-icon fa fa-sort-numeric-asc"></i>
-	{{/if}}
-	</a>
-	{{/if}}
-</div>
-<div class="clear"></div>
-
-<div class="photo-album-wrapper" id="photo-album-contents">
-{{foreach $photos as $photo}}
-	{{include file="photo_top.tpl"}}
-{{/foreach}}
-</div>
-
-<div class="photo-album-end"></div>
-
-{{$paginate}}
-
-<script type="text/javascript">$(document).ready(function() { loadingPage = false; justifyPhotos(); });</script>

--- a/view/theme/frio/templates/vcard-widget.tpl
+++ b/view/theme/frio/templates/vcard-widget.tpl
@@ -23,14 +23,16 @@
 	</div>
 
 	<div class="panel-body">
-		<h3 class="fn p-name">{{$name}}</h3>
+		<div class="profile-header">
+			<h3 class="fn p-name">{{$name}}</h3>
 
-		{{if $addr}}<div class="p-addr">{{$addr}}</div>{{/if}}
+			{{if $addr}}<div class="p-addr">{{$addr}}</div>{{/if}}
 
-		{{if $pdesc}}<div class="title">{{$pdesc}}</div>{{/if}}
+			{{if $pdesc}}<div class="title">{{$pdesc}}</div>{{/if}}
 
-		{{if $account_type}}<div class="account-type">{{$account_type}}</div>{{/if}}
+			{{if $account_type}}<div class="account-type">{{$account_type}}</div>{{/if}}
 
-		{{if $network_name}}<dl class="network"><dt class="network-label">{{$network}}</dt><dd class="x-network">{{$network_name}}</dd></dl>{{/if}}
+			{{if $network_name}}<dl class="network"><dt class="network-label">{{$network}}</dt><dd class="x-network">{{$network_name}}</dd></dl>{{/if}}
+		</div>
 	</div>
 </div>


### PR DESCRIPTION
As discussed in PR #5499 re-add _generic-page-wrapper_ and fix CSS instead.