### PR TITLE
"Imported" Friendica\App instead of referencing it

### DIFF
--- a/src/Core/Config.php
+++ b/src/Core/Config.php
@@ -8,6 +8,7 @@
  */
 namespace Friendica\Core;
 
+use Friendica\App;
 use Friendica\BaseObject;
 use Friendica\Core\Config;
 
@@ -30,7 +31,7 @@ class Config extends BaseObject
 	public static function init()
 	{
 		// Database isn't ready or populated yet
-		if (!(self::getApp()->mode & \Friendica\App::MODE_DBCONFIGAVAILABLE)) {
+		if (!(self::getApp()->mode & App::MODE_DBCONFIGAVAILABLE)) {
 			return;
 		}
 
@@ -54,7 +55,7 @@ class Config extends BaseObject
 	public static function load($family = "config")
 	{
 		// Database isn't ready or populated yet
-		if (!(self::getApp()->mode & \Friendica\App::MODE_DBCONFIGAVAILABLE)) {
+		if (!(self::getApp()->mode & App::MODE_DBCONFIGAVAILABLE)) {
 			return;
 		}
 
@@ -87,7 +88,7 @@ class Config extends BaseObject
 	public static function get($family, $key, $default_value = null, $refresh = false)
 	{
 		// Database isn't ready or populated yet, fallback to file config
-		if (!(self::getApp()->mode & \Friendica\App::MODE_DBCONFIGAVAILABLE)) {
+		if (!(self::getApp()->mode & App::MODE_DBCONFIGAVAILABLE)) {
 			return self::getApp()->getConfigValue($family, $key, $default_value);
 		}
 
@@ -115,7 +116,7 @@ class Config extends BaseObject
 	public static function set($family, $key, $value)
 	{
 		// Database isn't ready or populated yet
-		if (!(self::getApp()->mode & \Friendica\App::MODE_DBCONFIGAVAILABLE)) {
+		if (!(self::getApp()->mode & App::MODE_DBCONFIGAVAILABLE)) {
 			return false;
 		}
 
@@ -140,7 +141,7 @@ class Config extends BaseObject
 	public static function delete($family, $key)
 	{
 		// Database isn't ready or populated yet
-		if (!(self::getApp()->mode & \Friendica\App::MODE_DBCONFIGAVAILABLE)) {
+		if (!(self::getApp()->mode & App::MODE_DBCONFIGAVAILABLE)) {
 			return false;
 		}
 

--- a/src/Core/PConfig.php
+++ b/src/Core/PConfig.php
@@ -8,6 +8,7 @@
  */
 namespace Friendica\Core;
 
+use Friendica\App;
 use Friendica\BaseObject;
 
 require_once 'include/dba.php';
@@ -29,7 +30,7 @@ class PConfig extends BaseObject
 	public static function init($uid)
 	{
 		// Database isn't ready or populated yet
-		if (!(self::getApp()->mode & \Friendica\App::MODE_DBCONFIGAVAILABLE)) {
+		if (!(self::getApp()->mode & App::MODE_DBCONFIGAVAILABLE)) {
 			return;
 		}
 
@@ -54,7 +55,7 @@ class PConfig extends BaseObject
 	public static function load($uid, $family)
 	{
 		// Database isn't ready or populated yet
-		if (!(self::getApp()->mode & \Friendica\App::MODE_DBCONFIGAVAILABLE)) {
+		if (!(self::getApp()->mode & App::MODE_DBCONFIGAVAILABLE)) {
 			return;
 		}
 
@@ -83,7 +84,7 @@ class PConfig extends BaseObject
 	public static function get($uid, $family, $key, $default_value = null, $refresh = false)
 	{
 		// Database isn't ready or populated yet
-		if (!(self::getApp()->mode & \Friendica\App::MODE_DBCONFIGAVAILABLE)) {
+		if (!(self::getApp()->mode & App::MODE_DBCONFIGAVAILABLE)) {
 			return;
 		}
 
@@ -112,7 +113,7 @@ class PConfig extends BaseObject
 	public static function set($uid, $family, $key, $value)
 	{
 		// Database isn't ready or populated yet
-		if (!(self::getApp()->mode & \Friendica\App::MODE_DBCONFIGAVAILABLE)) {
+		if (!(self::getApp()->mode & App::MODE_DBCONFIGAVAILABLE)) {
 			return false;
 		}
 
@@ -138,7 +139,7 @@ class PConfig extends BaseObject
 	public static function delete($uid, $family, $key)
 	{
 		// Database isn't ready or populated yet
-		if (!(self::getApp()->mode & \Friendica\App::MODE_DBCONFIGAVAILABLE)) {
+		if (!(self::getApp()->mode & App::MODE_DBCONFIGAVAILABLE)) {
 			return false;
 		}
 


### PR DESCRIPTION
Fixed:
- `App` is now "imported" to avoid having \Friendica\App::* everywhere