### PR TITLE
Fixed E_NOTICE in listing worker queue and new utilities class added

### DIFF
--- a/mod/admin.php
+++ b/mod/admin.php
@@ -21,6 +21,7 @@ use Friendica\Model\Item;
 use Friendica\Model\User;
 use Friendica\Module\Login;
 use Friendica\Module\Tos;
+use Friendica\Util\Arrays;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Temporal;
 
@@ -783,9 +784,9 @@ function admin_page_workerqueue(App $a)
 	$statement = DBA::select('workerqueue', ['id', 'parameter', 'created', 'priority'], ['done' => 0], ['order'=> ['priority']]);
 	$r = DBA::toArray($statement);
 
-	for($i = 0; $i < count($r); $i++) {
+	foreach ($r as $key => $rr) {
 		// fix GH-5469. ref: src/Core/Worker.php:217
-		$r[$i]['parameter'] = implode(json_decode($r[$i]['parameter'], true), ': ');
+		$r[$key]['parameter'] = Arrays::recursiveImplode(json_decode($rr['parameter'], true), ': ');
 	}
 
 	$t = get_markup_template('admin/workerqueue.tpl');

--- a/src/Util/Arrays.php
+++ b/src/Util/Arrays.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * @file src/Util/Arrays.php
+ * @author Roland Haeder<https://f.haeder.net/profile/roland>
+ */
+namespace Friendica\Util;
+
+/**
+ * @brief Array utility class
+ */
+class Arrays
+{
+	/**
+	 * @brief Private constructor
+	 */
+	private function __construct () {
+		// Utitlities don't have instances
+	}
+
+	/**
+	 * @briefs Implodes recursively a multi-dimensional array where a normal implode() will fail.
+	 *
+	 * @param array  $array Array to implode
+	 * @param string $glue  Glue for imploded elements
+	 * @return string String with elements from array
+	 */
+	public static function recursiveImplode (array $array, $glue) {
+		// Init returned string
+		$string = '';
+
+		// Loop through all records
+		foreach ($array as $element) {
+			// Is an array found?
+			if (is_array($element)) {
+				// Invoke cursively
+				$string .= '{' . self::recursiveImplode($element, $glue) . '}' . $glue;
+			} else {
+				// Append normally
+				$string .= $element . $glue;
+			}
+		}
+
+		// Remove last glue
+		$string = trim($string, $glue);
+
+		// Return it
+		return $string;
+	}
+}


### PR DESCRIPTION
Fixes for E_NOTICE in workqueue:
- introduced class `Friendica\Util\Arrays` which will hold static methods for handling arrays that cannot be done with PHP's functions, like implode() on multi-dimensional arrays
- rewrote old-school for() loop to foreach()