### PR TITLE
Fixed fatal error about when returned 'body' field is empty

### DIFF
--- a/src/Protocol/PortableContact.php
+++ b/src/Protocol/PortableContact.php
@@ -1638,7 +1638,7 @@ class PortableContact
 
 		$retdata = Network::curl($url);
 
-		if ($retdata["success"]) {
+		if ($retdata["success"] && !empty($retdata["body"])) {
 			$data = json_decode($retdata["body"], true);
 
 			self::discoverServer($data, 2);
@@ -1659,7 +1659,7 @@ class PortableContact
 
 				$retdata = Network::curl($url);
 
-				if ($retdata["success"]) {
+				if ($retdata["success"] && !empty($retdata["body"])) {
 					logger("Fetch all global contacts from the server " . $server["nurl"], LOGGER_DEBUG);
 					$success = self::discoverServer(json_decode($retdata["body"], true));
 				}


### PR DESCRIPTION
The following error happened with introduced (and needed) type-hint `array`. The server in question was hubzilla and does return an empty body: https://hubzilla.schafshor.de/poco/@global?updatedSince=2018-06-29%2017:29:11&fields=displayName,urls,photos
````
PHP Fatal error:  Uncaught TypeError: Argument 1 passed to Friendica\Protocol\PortableContact::discoverServer() must be of the type array, null given, called in /var/www/../src/Protocol/PortableContact.php on line 1664 and defined in /var/www/../src/Protocol/PortableContact.php:1765
Stack trace:
````