### PR TITLE
enhance block users in admin panel

### DIFF
--- a/mod/admin.php
+++ b/mod/admin.php
@@ -1881,6 +1881,7 @@ function admin_page_users(App $a)
 		'$deny' => L10n::t('Deny'),
 		'$delete' => L10n::t('Delete'),
 		'$block' => L10n::t('Block'),
+		'$blocked' => L10n::t('User blocked'),
 		'$unblock' => L10n::t('Unblock'),
 		'$siteadmin' => L10n::t('Site admin'),
 		'$accountexpired' => L10n::t('Account expired'),

--- a/view/templates/admin/users.tpl
+++ b/view/templates/admin/users.tpl
@@ -85,7 +85,7 @@
 						<td class='register_date'>{{$u.register_date}}</td>
 						<td class='login_date'>{{$u.login_date}}</td>
 						<td class='lastitem_date'>{{$u.lastitem_date}}</td>
-						<td class='login_date'>{{$u.page_flags}} {{if $u.is_admin}}({{$siteadmin}}){{/if}} {{if $u.account_expired}}({{$accountexpired}}){{/if}}</td>
+						<td class='login_date'>{{$u.page_flags}} {{if $u.is_admin}}({{$siteadmin}}){{/if}} {{if $u.account_expired}}({{$accountexpired}}){{/if}} {{if $u.blocked}}{{$blocked}}{{/if}}</td>
 						<td class="checkbox"> 
 						{{if $u.is_deletable}}
 							<input type="checkbox" class="users_ckbx" id="id_user_{{$u.uid}}" name="user[]" value="{{$u.uid}}"/></td>

--- a/view/theme/vier/css/font2.css
+++ b/view/theme/vier/css/font2.css
@@ -335,6 +335,7 @@ li.icon.icon-large:before {
 .icon.drop:before                 { content: "\f014"; }
 .icon.drophide:before             { content: "\f014"; }
 .icon.copy:before                 { content: "\f0c5"; }
+.icon.block:before                { content: "\f05e"; }
 
 .small-pencil:before, .savedsearchdrop:before { 
   font-family: FontAwesome;


### PR DESCRIPTION
This PR contains two things

* the vier theme was missing an icon for un/block user in the admin panel
* all themes (except frio) were missing an indication that the user was blocked