### PR TITLE
Fixed fatal error:

### DIFF
--- a/include/items.php
+++ b/include/items.php
@@ -146,7 +146,7 @@ function add_page_info($url, $no_photos = false, $photo = "", $keywords = false,
 
 	$text = '';
 
-	if (is_array($data) {
+	if (is_array($data)) {
 		$text = add_page_info_data($data, $no_photos);
 	}
 

--- a/include/items.php
+++ b/include/items.php
@@ -144,7 +144,11 @@ function add_page_keywords($url, $photo = "", $keywords = false, $keyword_blackl
 function add_page_info($url, $no_photos = false, $photo = "", $keywords = false, $keyword_blacklist = "") {
 	$data = query_page_info($url, $photo, $keywords, $keyword_blacklist);
 
-	$text = add_page_info_data($data, $no_photos);
+	$text = '';
+
+	if (is_array($data) {
+		$text = add_page_info_data($data, $no_photos);
+	}
 
 	return $text;
 }


### PR DESCRIPTION
Follow up of #5523 :
````
PHP Fatal error:  Uncaught TypeError: Argument 1 passed to add_page_info_data()
must be of the type array, boolean given, called in
/var/www/../include/items.php on line 153 and defined in
/var/www/../include/items.php:27
````

Fix for type-hint array when query_page_info() returned a non-array, this may
happen when the instance/node/pod owner decided to shutdown server and replace
all URLs with a replacement message.