### PR TITLE
Skip DB tests if MYSQL_* environment variables are missing

### DIFF
--- a/tests/DatabaseTest.php
+++ b/tests/DatabaseTest.php
@@ -32,6 +32,10 @@ abstract class DatabaseTest extends TestCase
 	 */
 	protected function getConnection()
 	{
+		if (!getenv('MYSQL_DATABASE')) {
+			$this->markTestSkipped('Please set the MYSQL_* environment variables to your test database credentials.');
+		}
+
 		if (!DBA::connected()) {
 			$this->markTestSkipped('Could not connect to the database.');
 		}


### PR DESCRIPTION
Fixes #5405

Paging @Rudloff and @nupplaphil to verify the check for the MYSQL_* environment variables is appropriate, including for automatic install.

Paging @JeroenED to verify it is appropriate regarding the Ansible role.