### PR TITLE
Restore source storing for Twitter conversations

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -180,25 +180,6 @@ define('CP_USERS_AND_GLOBAL',       2);
  */
 
 /**
- * @name Protocols
- * @deprecated since version 3.6
- * @see Conversation
- *
- * Different protocols that we are storing
- * @{
- */
-define('PROTOCOL_UNKNOWN'        , Conversation::PROTOCOL_UNKNOWN);
-define('PROTOCOL_DFRN'           , Conversation::PROTOCOL_DFRN);
-define('PROTOCOL_DIASPORA'       , Conversation::PROTOCOL_DIASPORA);
-define('PROTOCOL_OSTATUS_SALMON' , Conversation::PROTOCOL_OSTATUS_SALMON);
-define('PROTOCOL_OSTATUS_FEED'   , Conversation::PROTOCOL_OSTATUS_FEED);    // Deprecated
-define('PROTOCOL_GS_CONVERSATION', Conversation::PROTOCOL_GS_CONVERSATION); // Deprecated
-define('PROTOCOL_SPLITTED_CONV'  , Conversation::PROTOCOL_SPLITTED_CONV);
-/**
- * @}
- */
-
-/**
  * @name Network constants
  * @deprecated since version 3.6
  * @see Protocol

--- a/mod/item.php
+++ b/mod/item.php
@@ -25,6 +25,7 @@ use Friendica\Core\System;
 use Friendica\Core\Worker;
 use Friendica\Database\DBA;
 use Friendica\Model\Contact;
+use Friendica\Model\Conversation;
 use Friendica\Model\Item;
 use Friendica\Protocol\Diaspora;
 use Friendica\Protocol\Email;
@@ -643,7 +644,7 @@ function item_post(App $a) {
 	$datarray['api_source'] = $api_source;
 
 	// This field is for storing the raw conversation data
-	$datarray['protocol'] = PROTOCOL_DFRN;
+	$datarray['protocol'] = Conversation::PARCEL_DFRN;
 
 	$conversation = DBA::selectFirst('conversation', ['conversation-uri', 'conversation-href'], ['item-uri' => $datarray['parent-uri']]);
 	if (DBA::isResult($conversation)) {

--- a/src/Model/Conversation.php
+++ b/src/Model/Conversation.php
@@ -21,6 +21,7 @@ class Conversation
 	const PARCEL_SALMON             = 3;
 	const PARCEL_FEED               = 4; // Deprecated
 	const PARCEL_SPLIT_CONVERSATION = 6;
+	const PARCEL_TWITTER            = 7;
 
 	/**
 	 * @brief Store the conversation data

--- a/src/Model/Conversation.php
+++ b/src/Model/Conversation.php
@@ -22,7 +22,7 @@ class Conversation
 	const PARCEL_SALMON             = 3;
 	const PARCEL_FEED               = 4; // Deprecated
 	const PARCEL_SPLIT_CONVERSATION = 6;
-	const PARCEL_TWITTER            = 7;
+	const PARCEL_TWITTER            = 67;
 
 	/**
 	 * @brief Store the conversation data

--- a/src/Model/Conversation.php
+++ b/src/Model/Conversation.php
@@ -11,13 +11,16 @@ require_once "include/dba.php";
 
 class Conversation
 {
-	const PROTOCOL_UNKNOWN         = 0;
-	const PROTOCOL_DFRN            = 1;
-	const PROTOCOL_DIASPORA        = 2;
-	const PROTOCOL_OSTATUS_SALMON  = 3;
-	const PROTOCOL_OSTATUS_FEED    = 4; // Deprecated
-	const PROTOCOL_GS_CONVERSATION = 5; // Deprecated
-	const PROTOCOL_SPLITTED_CONV   = 6;
+	/*
+	 * These constants represent the parcel format used to transport a conversation independently of the message protocol.
+	 * It currently is stored in the "protocol" field for legacy reasons.
+	 */
+	const PARCEL_UNKNOWN            = 0;
+	const PARCEL_DFRN               = 1;
+	const PARCEL_DIASPORA           = 2;
+	const PARCEL_SALMON             = 3;
+	const PARCEL_FEED               = 4; // Deprecated
+	const PARCEL_SPLIT_CONVERSATION = 6;
 
 	/**
 	 * @brief Store the conversation data

--- a/src/Model/Conversation.php
+++ b/src/Model/Conversation.php
@@ -2,6 +2,7 @@
 /**
  * @file src/Model/Conversation
  */
+
 namespace Friendica\Model;
 
 use Friendica\Database\DBA;
@@ -29,8 +30,10 @@ class Conversation
 	 * @param array $arr Item array with conversation data
 	 * @return array Item array with removed conversation data
 	 */
-	public static function insert($arr) {
-		if (in_array(defaults($arr, 'network', NETWORK_PHANTOM), [NETWORK_DFRN, NETWORK_DIASPORA, NETWORK_OSTATUS]) && !empty($arr['uri'])) {
+	public static function insert(array $arr)
+	{
+		if (in_array(defaults($arr, 'network', NETWORK_PHANTOM),
+				[NETWORK_DFRN, NETWORK_DIASPORA, NETWORK_OSTATUS, NETWORK_TWITTER]) && !empty($arr['uri'])) {
 			$conversation = ['item-uri' => $arr['uri'], 'received' => DateTimeFormat::utcNow()];
 
 			if (isset($arr['parent-uri']) && ($arr['parent-uri'] != $arr['uri'])) {
@@ -70,11 +73,13 @@ class Conversation
 					unset($conversation['source']);
 				}
 				if (!DBA::update('conversation', $conversation, ['item-uri' => $conversation['item-uri']], $old_conv)) {
-					logger('Conversation: update for '.$conversation['item-uri'].' from '.$old_conv['protocol'].' to '.$conversation['protocol'].' failed', LOGGER_DEBUG);
+					logger('Conversation: update for ' . $conversation['item-uri'] . ' from ' . $old_conv['protocol'] . ' to ' . $conversation['protocol'] . ' failed',
+						LOGGER_DEBUG);
 				}
 			} else {
 				if (!DBA::insert('conversation', $conversation, true)) {
-					logger('Conversation: insert for '.$conversation['item-uri'].' (protocol '.$conversation['protocol'].') failed', LOGGER_DEBUG);
+					logger('Conversation: insert for ' . $conversation['item-uri'] . ' (protocol ' . $conversation['protocol'] . ') failed',
+						LOGGER_DEBUG);
 				}
 			}
 		}

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -1239,7 +1239,7 @@ class Item extends BaseObject
 			$item['wall'] = 1;
 			$item['origin'] = 1;
 			$item['network'] = NETWORK_DFRN;
-			$item['protocol'] = PROTOCOL_DFRN;
+			$item['protocol'] = Conversation::PARCEL_DFRN;
 
 			if (is_int($notify)) {
 				$priority = $notify;

--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -20,12 +20,12 @@ use Friendica\Core\L10n;
 use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\Model\Contact;
+use Friendica\Model\Conversation;
 use Friendica\Model\Event;
 use Friendica\Model\GContact;
-use Friendica\Model\Group;
 use Friendica\Model\Item;
-use Friendica\Model\Profile;
 use Friendica\Model\PermissionSet;
+use Friendica\Model\Profile;
 use Friendica\Model\User;
 use Friendica\Object\Image;
 use Friendica\Util\Crypto;
@@ -2401,7 +2401,7 @@ class DFRN
 
 		$item = $header;
 
-		$item["protocol"] = PROTOCOL_DFRN;
+		$item["protocol"] = Conversation::PARCEL_DFRN;
 
 		$item["source"] = $xml;
 

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -20,6 +20,7 @@ use Friendica\Core\System;
 use Friendica\Core\Worker;
 use Friendica\Database\DBA;
 use Friendica\Model\Contact;
+use Friendica\Model\Conversation;
 use Friendica\Model\GContact;
 use Friendica\Model\Group;
 use Friendica\Model\Item;
@@ -1706,7 +1707,7 @@ class Diaspora
 
 		$datarray["object-type"] = ACTIVITY_OBJ_COMMENT;
 
-		$datarray["protocol"] = PROTOCOL_DIASPORA;
+		$datarray["protocol"] = Conversation::PARCEL_DIASPORA;
 		$datarray["source"] = $xml;
 
 		$datarray["changed"] = $datarray["created"] = $datarray["edited"] = $created_at;
@@ -1968,7 +1969,7 @@ class Diaspora
 
 		$datarray = [];
 
-		$datarray["protocol"] = PROTOCOL_DIASPORA;
+		$datarray["protocol"] = Conversation::PARCEL_DIASPORA;
 
 		$datarray["uid"] = $importer["uid"];
 		$datarray["contact-id"] = $author_contact["cid"];
@@ -2630,7 +2631,7 @@ class Diaspora
 		$datarray["verb"] = ACTIVITY_POST;
 		$datarray["gravity"] = GRAVITY_PARENT;
 
-		$datarray["protocol"] = PROTOCOL_DIASPORA;
+		$datarray["protocol"] = Conversation::PARCEL_DIASPORA;
 		$datarray["source"] = $xml;
 
 		$prefix = share_header(
@@ -2858,7 +2859,7 @@ class Diaspora
 		$datarray["verb"] = ACTIVITY_POST;
 		$datarray["gravity"] = GRAVITY_PARENT;
 
-		$datarray["protocol"] = PROTOCOL_DIASPORA;
+		$datarray["protocol"] = Conversation::PARCEL_DIASPORA;
 		$datarray["source"] = $xml;
 
 		$datarray["body"] = self::replacePeopleGuid($body, $contact["url"]);

--- a/src/Protocol/OStatus.php
+++ b/src/Protocol/OStatus.php
@@ -370,7 +370,7 @@ class OStatus
 			$doc2->formatOutput = true;
 			$xml2 = $doc2->saveXML();
 
-			$header["protocol"] = PROTOCOL_OSTATUS_SALMON;
+			$header["protocol"] = Conversation::PARCEL_SALMON;
 			$header["source"] = $xml2;
 		} elseif (!$initialize) {
 			return false;
@@ -798,7 +798,7 @@ class OStatus
 
 			$conv_data = [];
 
-			$conv_data['protocol'] = PROTOCOL_SPLITTED_CONV;
+			$conv_data['protocol'] = Conversation::PARCEL_SPLIT_CONVERSATION;
 			$conv_data['network'] = NETWORK_OSTATUS;
 			$conv_data['uri'] = XML::getFirstNodeValue($xpath, 'atom:id/text()', $entry);
 
@@ -839,7 +839,7 @@ class OStatus
 
 			$conv_data['source'] = $doc2->saveXML();
 
-			$condition = ['item-uri' => $conv_data['uri'],'protocol' => PROTOCOL_OSTATUS_FEED];
+			$condition = ['item-uri' => $conv_data['uri'],'protocol' => Conversation::PARCEL_FEED];
 			if (DBA::exists('conversation', $condition)) {
 				logger('Delete deprecated entry for URI '.$conv_data['uri'], LOGGER_DEBUG);
 				DBA::delete('conversation', ['item-uri' => $conv_data['uri']]);
@@ -863,7 +863,7 @@ class OStatus
 	 */
 	private static function fetchSelf($self, array &$item)
 	{
-		$condition = ['`item-uri` = ? AND `protocol` IN (?, ?)', $self, PROTOCOL_DFRN, PROTOCOL_OSTATUS_SALMON];
+		$condition = ['`item-uri` = ? AND `protocol` IN (?, ?)', $self, Conversation::PARCEL_DFRN, Conversation::PARCEL_SALMON];
 		if (DBA::exists('conversation', $condition)) {
 			logger('Conversation '.$item['uri'].' is already stored.', LOGGER_DEBUG);
 			return;
@@ -882,7 +882,7 @@ class OStatus
 		$doc->formatOutput = true;
 		$xml = $doc->saveXML();
 
-		$item["protocol"] = PROTOCOL_OSTATUS_SALMON;
+		$item["protocol"] = Conversation::PARCEL_SALMON;
 		$item["source"] = $xml;
 
 		logger('Conversation '.$item['uri'].' is now fetched.', LOGGER_DEBUG);
@@ -898,7 +898,7 @@ class OStatus
 	 */
 	private static function fetchRelated($related, $related_uri, $importer)
 	{
-		$condition = ['`item-uri` = ? AND `protocol` IN (?, ?)', $related_uri, PROTOCOL_DFRN, PROTOCOL_OSTATUS_SALMON];
+		$condition = ['`item-uri` = ? AND `protocol` IN (?, ?)', $related_uri, Conversation::PARCEL_DFRN, Conversation::PARCEL_SALMON];
 		$conversation = DBA::selectFirst('conversation', ['source', 'protocol'], $condition);
 		if (DBA::isResult($conversation)) {
 			$stored = true;
@@ -907,7 +907,7 @@ class OStatus
 				logger('Got valid cached XML for URI '.$related_uri, LOGGER_DEBUG);
 				return;
 			}
-			if ($conversation['protocol'] == PROTOCOL_OSTATUS_SALMON) {
+			if ($conversation['protocol'] == Conversation::PARCEL_SALMON) {
 				logger('Delete invalid cached XML for URI '.$related_uri, LOGGER_DEBUG);
 				DBA::delete('conversation', ['item-uri' => $related_uri]);
 			}
@@ -978,7 +978,7 @@ class OStatus
 
 		// Finally we take the data that we fetched from "ostatus:conversation"
 		if ($xml == '') {
-			$condition = ['item-uri' => $related_uri, 'protocol' => PROTOCOL_SPLITTED_CONV];
+			$condition = ['item-uri' => $related_uri, 'protocol' => Conversation::PARCEL_SPLIT_CONVERSATION];
 			$conversation = DBA::selectFirst('conversation', ['source'], $condition);
 			if (DBA::isResult($conversation)) {
 				$stored = true;


### PR DESCRIPTION
Related to #4584

This enables debugging future still images as legacy source objects have been cleaned in a recent item table post update procedure.