### PR TITLE
Converting timezone in admin queues

### DIFF
--- a/mod/admin.php
+++ b/mod/admin.php
@@ -790,7 +790,6 @@ function admin_page_workerqueue(App $a)
 {
 	// get jobs from the workerqueue table
 	$entries = DBA::select('workerqueue', ['id', 'parameter', 'created', 'priority'], ['done' => 0], ['order'=> ['priority']]);
-	$r = DBA::toArray($statement);
 
 	$r = [];
 	while ($entry = DBA::fetch($entries)) {
@@ -799,6 +798,7 @@ function admin_page_workerqueue(App $a)
 		$entry['created'] = DateTimeFormat::local($entry['created']);
 		$r[] = $entry;
 	}
+	DBA::close($entries);
 
 	$t = get_markup_template('admin/workerqueue.tpl');
 	return replace_macros($t, [

--- a/mod/admin.php
+++ b/mod/admin.php
@@ -746,25 +746,19 @@ function admin_page_federation(App $a)
 function admin_page_queue(App $a)
 {
 	// get content from the queue table
-	/*
-	//todo: convert q() to DBA::Select()
-	$statement = DBA::Select('`queue` AS `q`, `contact` AS `c`',
-		[ '`c`.`name`', '`c`.`nurl`', '`q`.`id`', '`q`.`network`', "CONVERT_TZ(`q`.`created`, 'UTC' " . Config::get('system', 'default_timezone') . ') as created', "CONVERT_TZ(`q`.`last`, 'UTC', " . Config::get('system', 'default_timezone') . "') as last" ],
-		'`c`.`id`' => '`q`.`cid`',
-		['order'=> ['`q`.`cid`, `q`.`created`']]
-	);
-	$r = DBA::toArray($statement);
-	*/
-	
-	$r = q("SELECT `c`.`name`, `c`.`nurl`, `q`.`id`, `q`.`network`, `q`.`created`, `q`.`last`
-			FROM `queue` AS `q`, `contact` AS `c`
-			WHERE `c`.`id` = `q`.`cid`
-			ORDER BY `q`.`cid`, `q`.`created`;");
+	$entries = DBA::p("SELECT `contact`.`name`, `contact`.`nurl`,
+                `queue`.`id`, `queue`.`network`, `queue`.`created`, `queue`.`last`
+                FROM `queue` INNER JOIN `contact` ON `contact`.`id` = `queue`.`cid`
+                ORDER BY `queue`.`cid`, `queue`.`created`");
 
-	foreach ($r as $key => $rr) {
-		$r[$key]['created'] = DateTimeFormat::local($rr['created']);
-		$r[$key]['last'] = DateTimeFormat::local($rr['last']);
+	$r = [];
+	while ($entry = DBA::fetch($entries)) {
+		$entry['created'] = DateTimeFormat::local($entry['created']);
+		$entry['last'] = DateTimeFormat::local($entry['last']);
+		$r[] = $entry;
 	}
+	DBA::close($entries);
+
 	$t = get_markup_template('admin/queue.tpl');
 	return replace_macros($t, [
 		'$title' => L10n::t('Administration'),
@@ -795,13 +789,15 @@ function admin_page_queue(App $a)
 function admin_page_workerqueue(App $a)
 {
 	// get jobs from the workerqueue table
-	$statement = DBA::select('workerqueue', ['id', 'parameter', 'created', 'priority'], ['done' => 0], ['order'=> ['priority']]);
+	$entries = DBA::select('workerqueue', ['id', 'parameter', 'created', 'priority'], ['done' => 0], ['order'=> ['priority']]);
 	$r = DBA::toArray($statement);
 
-	foreach ($r as $key => $rr) {
+	$r = [];
+	while ($entry = DBA::fetch($entries)) {
 		// fix GH-5469. ref: src/Core/Worker.php:217
-		$r[$key]['parameter'] = Arrays::recursiveImplode(json_decode($rr['parameter'], true), ': ');
-		$r[$key]['created'] = DateTimeFormat::local($rr['created']);
+		$entry['parameter'] = Arrays::recursiveImplode(json_decode($entry['parameter'], true), ': ');
+		$entry['created'] = DateTimeFormat::local($entry['created']);
+		$r[] = $entry;
 	}
 
 	$t = get_markup_template('admin/workerqueue.tpl');

--- a/mod/admin.php
+++ b/mod/admin.php
@@ -746,11 +746,21 @@ function admin_page_federation(App $a)
 function admin_page_queue(App $a)
 {
 	// get content from the queue table
+	// PLEASE REVIEW (not 100% sure about my code)
+	$statement = DBA::Select('`queue` AS `q`, `contact` AS `c`',
+		[ '`c`.`name`', '`c`.`nurl`', '`q`.`id`', '`q`.`network`', "CONVERT_TZ(`q`.`created`, 'UTC' " . Config::get('system', 'default_timezone') . ') as created', "CONVERT_TZ(`q`.`last`, 'UTC', " . Config::get('system', 'default_timezone') . "') as last" ],
+		'`c`.`id`' => '`q`.`cid`',
+		['order'=> ['`q`.`cid`, `q`.`created`']]
+	);
+	$r = DBA::toArray($statement);
+
+	/*
+	// Leaving this one here for the code review as well as backup
 	$r = q("SELECT `c`.`name`, `c`.`nurl`, `q`.`id`, `q`.`network`, `q`.`created`, `q`.`last`
 			FROM `queue` AS `q`, `contact` AS `c`
 			WHERE `c`.`id` = `q`.`cid`
 			ORDER BY `q`.`cid`, `q`.`created`;");
-
+	*/
 	$t = get_markup_template('admin/queue.tpl');
 	return replace_macros($t, [
 		'$title' => L10n::t('Administration'),
@@ -781,7 +791,7 @@ function admin_page_queue(App $a)
 function admin_page_workerqueue(App $a)
 {
 	// get jobs from the workerqueue table
-	$statement = DBA::select('workerqueue', ['id', 'parameter', 'created', 'priority'], ['done' => 0], ['order'=> ['priority']]);
+	$statement = DBA::select('workerqueue', ['id', 'parameter', "CONVERT_TZ(created', 'UTC', " . Config::get('system', 'default_timezone') . "') as created", 'priority'], ['done' => 0], ['order'=> ['priority']]);
 	$r = DBA::toArray($statement);
 
 	foreach ($r as $key => $rr) {


### PR DESCRIPTION
Please review the code as I'm not 100% sure about the DBA::Select lines.

I converted the timezones of the queues to the default-timezone of the node. For admins I believe it's handier to see their local time when something was created, instead a generic UTC time.
(at least it is for me)

Meanwhile, I converted the q() function of the normal queue to DBA::select. However, please review the lines thoroughly as I'm not 100% sure about the lines. Esspecially because I added functions to the fields to be get and the queue-query required another table to be queried.