### PR TITLE
Post update script for setting the uri-id

### DIFF
--- a/mod/friendica.php
+++ b/mod/friendica.php
@@ -75,9 +75,9 @@ function friendica_content(App $a)
 {
 	$o = '<h1>Friendica</h1>' . PHP_EOL;
 	$o .= '<p>';
-	$o .= L10n::t('This is Friendica, version') . ' <strong>' . FRIENDICA_VERSION .
-		' (' . DB_UPDATE_VERSION . '/' . Config::get("system", "post_update_version") . ') </strong> ';
-	$o .= L10n::t('running at web location') . ' ' . System::baseUrl();
+	$o .= L10n::t('This is Friendica, version %s that is running at the web location %s. The database version is %s, the post update version is %s.',
+		'<strong>' . FRIENDICA_VERSION . '</strong>', System::baseUrl(), '<strong>' . DB_UPDATE_VERSION . '</strong>',
+		'<strong>' . Config::get("system", "post_update_version") . '</strong>');
 	$o .= '</p>' . PHP_EOL;
 
 	$o .= '<p>';

--- a/mod/friendica.php
+++ b/mod/friendica.php
@@ -75,7 +75,8 @@ function friendica_content(App $a)
 {
 	$o = '<h1>Friendica</h1>' . PHP_EOL;
 	$o .= '<p>';
-	$o .= L10n::t('This is Friendica, version') . ' <strong>' . FRIENDICA_VERSION . '</strong> ';
+	$o .= L10n::t('This is Friendica, version') . ' <strong>' . FRIENDICA_VERSION .
+		' (' . DB_UPDATE_VERSION . '/' . Config::get("system", "post_update_version") . ') </strong> ';
 	$o .= L10n::t('running at web location') . ' ' . System::baseUrl();
 	$o .= '</p>' . PHP_EOL;
 

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -1888,7 +1888,7 @@ class Item extends BaseObject
 		}
 
 		$fields = ['uri' => $item['uri'], 'activity' => $activity_index,
-			'uri-hash' => $item['uri-hash']];
+			'uri-hash' => $item['uri-hash'], 'uri-id' => $item['uri-id']];
 
 		// We just remove everything that is content
 		foreach (array_merge(self::CONTENT_FIELDLIST, self::MIXED_CONTENT_FIELDLIST) as $field) {
@@ -1927,7 +1927,8 @@ class Item extends BaseObject
 	 */
 	private static function insertContent(&$item)
 	{
-		$fields = ['uri' => $item['uri'], 'uri-plink-hash' => $item['uri-hash']];
+		$fields = ['uri' => $item['uri'], 'uri-plink-hash' => $item['uri-hash'],
+			'uri-id' => $item['uri-id']];
 
 		foreach (array_merge(self::CONTENT_FIELDLIST, self::MIXED_CONTENT_FIELDLIST) as $field) {
 			if (isset($item[$field])) {


### PR DESCRIPTION
The new fields for the uri-id in item, item-content and item-activity are now set.

This is a prerequisite for a further planned item structure update in the next version.