### PR TITLE
vier theme, wider popup-menu

### DIFF
--- a/view/theme/vier/style.css
+++ b/view/theme/vier/style.css
@@ -862,7 +862,7 @@ ul.menu-popup {
 	transition:all 0.2s ease-in-out;
 	/* display: none; */
 	position: absolute;
-	width: 11em;
+	width: 13em;
 	background: #ffffff;
 	color: #2d2d2d;
 	margin: 0px;


### PR DESCRIPTION
Some German translations that cannot be shorten need a bit more space in the pop-up menus of the vier theme.