### PR TITLE
frio: common_tabs.tpl has now accesskeys as well

### DIFF
--- a/view/theme/frio/templates/common_tabs.tpl
+++ b/view/theme/frio/templates/common_tabs.tpl
@@ -6,7 +6,7 @@
 		<li>
 			<ul class="tabs  flex-nav" role="menu" >
 			{{foreach $tabs as $tab}}
-				<li id="{{$tab.id}}" role="presentation" {{if $tab.sel}} class="{{$tab.sel}}" {{/if}}><a role="menuitem" href="{{$tab.url}}" {{if $tab.title}} title="{{$tab.title}}"{{/if}}>{{$tab.label}}</a></li>
+				<li id="{{$tab.id}}" role="presentation" {{if $tab.sel}} class="{{$tab.sel}}" {{/if}}><a role="menuitem" href="{{$tab.url}}" {{if $tab.accesskey}}accesskey="{{$tab.accesskey}}"{{/if}} {{if $tab.title}} title="{{$tab.title}}"{{/if}}>{{$tab.label}}</a></li>
 			{{/foreach}}
 			</ul>
 		</li>


### PR DESCRIPTION
With this the other modules should have the access keys as well. The exception is the private messages module, all other themes have a "new" button, frio does not, hence the access key is not there.

fixes #3840