### PR TITLE
Frio - Bring back some padding space

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -1115,7 +1115,7 @@ aside .vcard #profile-photo-wrapper.crop-preview {
     padding: 0;
 }
 aside .vcard .profile-header {
-    padding: 5px 0px 5px 0px;
+    padding: 5px 0px 20px 0px;
 }
 aside .vcard .fn {
     font-weight: bold;

--- a/view/theme/frio/templates/search_item.tpl
+++ b/view/theme/frio/templates/search_item.tpl
@@ -117,7 +117,9 @@
 				</h5>
 			</div>
 
-			<hr class="clearfix" />
+			<div class="clearfix"></div>
+
+			<hr />
 
 			{{* item content *}}
 			<div class="wall-item-content {{$item.type}}" id="wall-item-content-{{$item.id}}">
@@ -135,8 +137,7 @@
 
 			<!-- TODO -->
 			<div class="wall-item-bottom">
-				<div class="wall-item-links">
-				</div>
+				<div class="wall-item-links"></div>
 				<div class="wall-item-tags">
 			{{if !$item.suppress_tags}}
 				{{foreach $item.hashtags as $tag}}

--- a/view/theme/frio/templates/wall_thread.tpl
+++ b/view/theme/frio/templates/wall_thread.tpl
@@ -239,12 +239,10 @@ as the value of $top_child_total (this is done at the end of this file)
 		</div>
 		{{/if}}
 
-		{{* Insert Line to seperate item header and item content visually *}}
-		{{if $item.thread_level==1}}
-		<hr class="clearfix" />
-		{{else}}
 		<div class="clearfix"></div>
-		{{/if}}
+
+		{{* Insert Line to seperate item header and item content visually *}}
+		{{if $item.thread_level==1}}<hr />{{/if}}
 
 		{{* item content *}}
 		<div class="wall-item-content {{$item.type}}" id="wall-item-content-{{$item.id}}">
@@ -262,8 +260,7 @@ as the value of $top_child_total (this is done at the end of this file)
 
 		<!-- TODO -->
 		<div class="wall-item-bottom">
-			<div class="wall-item-links">
-			</div>
+			<div class="wall-item-links"></div>
 			<div class="wall-item-tags">
 		{{if !$item.suppress_tags}}
 			{{foreach $item.hashtags as $tag}}


### PR DESCRIPTION
With https://github.com/friendica/friendica/pull/5498 and https://github.com/friendica/friendica/pull/5553 some margin/padding was lost. The margin/padding did have optical dividing character. So this PR brings it back