### PR TITLE
Fix: Prevent threads from being collapsed in network view

### DIFF
--- a/mod/update_network.php
+++ b/mod/update_network.php
@@ -12,7 +12,7 @@ require_once "mod/network.php";
 
 function update_network_content(App $a)
 {
-	if (empty($_GET['p']) || empty($_GET['item'])) {
+	if (!isset($_GET['p']) || !isset($_GET['item'])) {
 		killme();
 	}
 


### PR DESCRIPTION
This fixes a problem with the last "notice" PR that caused threads to collapse in network view.