### PR TITLE
Hide deprecated networks

### DIFF
--- a/src/Content/Widget.php
+++ b/src/Content/Widget.php
@@ -79,7 +79,8 @@ class Widget
 	 */
 	public static function unavailableNetworks()
 	{
-		$networks = array();
+		// Always hide content from these networks
+		$networks = ['face', 'apdn'];
 
 		if (!Addon::isEnabled("statusnet")) {
 			$networks[] = NETWORK_STATUSNET;


### PR DESCRIPTION
We are not using the constants here so that we can remove them from the rest of the code.