### PR TITLE
Call asynchronous JS after complete page load

### DIFF
--- a/view/js/acl.js
+++ b/view/js/acl.js
@@ -42,9 +42,6 @@ function ACL(backend_url, preset, automention, is_mobile){
 	/* add/remove mentions  */
 	this.element = $("#profile-jot-text");
 	this.htmlelm = this.element.get()[0];
-
-	/* startup! */
-	this.get(0,100);
 }
 
 ACL.prototype.remove_mention = function(id) {
@@ -344,7 +341,7 @@ ACL.prototype.populate = function(data){
 
 /**
  * @brief Deselect previous selected contact.
- * 
+ *
  * @param {int} id The contact ID.
  * @returns {void}
  */

--- a/view/js/main.js
+++ b/view/js/main.js
@@ -302,7 +302,12 @@ $(function() {
 		$('#nav-notifications-menu').perfectScrollbar('update');
 	});
 
-	NavUpdate();
+	// Asynchronous calls are deferred until the very end of the page load to ease on slower connections
+	window.addEventListener("load", function(){
+		NavUpdate();
+		acl.get(0, 100);
+	});
+
 	// Allow folks to stop the ajax page updates with the pause/break key
 	$(document).keydown(function(event) {
 		if (event.keyCode == '8') {


### PR DESCRIPTION
Currently being on a 3G connection, I noticed that many more avatars were loaded than the page was supposed to be showing.

I realized that the asynchronous `/acl` call was loading all the permission picker avatars right in the middle of the current page load.

Same thing goes for the ping calls, there was multiple calls even before the page had been completely loaded.

This fixes this performance hog by forcing those calls at the very end of the page load. On faster connections it won't matter, but on slower connections the difference is palpable.