### PR TITLE
Config Console Tests

### DIFF
--- a/tests/Util/Intercept.php
+++ b/tests/Util/Intercept.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Friendica\Test\Util;
+
+use php_user_filter;
+
+/**
+ * Output Interceptor for STDOUT to prevent outputing to the console
+ * Instead the $cache variable will get filled with the output
+ *
+ * @package Friendica\Test\Util
+ */
+class Intercept extends php_user_filter
+{
+	/**
+	 * @var string The cache which holds the current output of STDOUT
+	 */
+	public static $cache = '';
+
+	public function filter($in, $out, &$consumed, $closing)
+	{
+		while ($bucket = stream_bucket_make_writeable($in)) {
+			self::$cache .= $bucket->data;
+			$consumed += $bucket->datalen;
+			stream_bucket_append($out, $bucket);
+		}
+		return PSFS_FEED_ME;
+	}
+
+	/**
+	 * Registers the interceptor and prevents therefore the output to STDOUT
+	 */
+	public static function setUp() {
+		stream_filter_register("intercept", Intercept::class);
+		stream_filter_append(STDOUT, "intercept");
+		stream_filter_append(STDERR, "intercept");
+	}
+
+	/**
+	 * Resets the cache
+	 */
+	public static function reset() {
+		self::$cache = '';
+	}
+}

--- a/tests/src/Core/Console/ConfigConsoleTest.php
+++ b/tests/src/Core/Console/ConfigConsoleTest.php
@@ -7,6 +7,7 @@ use Friendica\Database\DBA;
 /**
  * @runTestsInSeparateProcesses
  * @preserveGlobalState disabled
+ * @requires PHP 7.0
  */
 class ConfigConsoleTest extends ConsoleTest
 {
@@ -65,7 +66,7 @@ Options: array (
   'v' => 1,
 )
 Command: config
-Executable: /vagrant/tests/src/Core/Console/ConfigConsoleTest.php
+Executable: {$this->app->basepath}/tests/src/Core/Console/ConfigConsoleTest.php
 Class: Friendica\Core\Console\Config
 Arguments: array (
   0 => 'test',

--- a/tests/src/Core/Console/ConfigConsoleTest.php
+++ b/tests/src/Core/Console/ConfigConsoleTest.php
@@ -6,6 +6,7 @@ use Friendica\Database\DBA;
 
 /**
  * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
  */
 class ConfigConsoleTest extends ConsoleTest
 {

--- a/tests/src/Core/Console/ConfigConsoleTest.php
+++ b/tests/src/Core/Console/ConfigConsoleTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Friendica\Test\src\Core\Console;
+
+use Friendica\Database\DBA;
+
+/**
+ * @runTestsInSeparateProcesses
+ */
+class ConfigConsoleTest extends ConsoleTest
+{
+	public function tearDown()
+	{
+		DBA::delete('config', ['k' => 'test']);
+
+		parent::tearDown();
+	}
+
+	private function assertGet($family, $key, $value) {
+		$config = $this->execute([__FILE__, 'config', $family, $key]);
+		$this->assertEquals($family . "." . $key . " => " . $value . "\n", $config);
+	}
+
+	private function assertSet($family, $key, $value) {
+		$config = $this->execute([__FILE__, 'config', $family, $key, $value]);
+		$this->assertEquals($family . "." . $key . " <= " . $value . "\n", $config);
+	}
+
+	function testSetGetKeyValue() {
+		$this->assertSet( 'config', 'test', 'now');
+		$this->assertGet('config', 'test', 'now');
+		$this->assertSet('config', 'test', '');
+		$this->assertGet('config', 'test', '');
+		DBA::delete('config', ['k' => 'test']);
+		$this->assertGet('config', 'test', null);
+	}
+
+	function testSetArrayValue() {
+		$testArray = [1, 2, 3];
+		DBA::insert('config', ['cat' => 'config', 'k' => 'test', 'v' => serialize($testArray)]);
+
+		$txt = $this->execute([__FILE__, 'config', 'config', 'test', 'now']);
+
+		$this->assertEquals("[Error] config.test is an array and can't be set using this command.\n", $txt);
+	}
+
+	function testTooManyArguments() {
+		$txt = $this->execute([__FILE__, 'config', 'config', 'test', 'it', 'now']);
+		$assertion = '[Warning] Too many arguments';
+		$firstline = substr($txt, 0, strlen($assertion));
+
+		$this->assertEquals($assertion, $firstline);
+	}
+
+	function testVerbose() {
+		$this->assertSet('test', 'it', 'now');
+		$assertion = <<<CONF
+Executable: {$this->app->basepath}/tests/src/Core/Console/ConfigConsoleTest.php
+Arguments: array (
+  0 => 'config',
+  1 => 'test',
+)
+Options: array (
+  'v' => 1,
+)
+Command: config
+Executable: /vagrant/tests/src/Core/Console/ConfigConsoleTest.php
+Class: Friendica\Core\Console\Config
+Arguments: array (
+  0 => 'test',
+)
+Options: array (
+  'v' => 1,
+)
+[test]
+it => now
+
+CONF;
+		$txt = $this->execute([__FILE__, 'config', 'test', '-v']);
+
+		$this->assertEquals($assertion, $txt);
+	}
+}

--- a/tests/src/Core/Console/ConsoleTest.php
+++ b/tests/src/Core/Console/ConsoleTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Friendica\Test\src\Core\Console;
+
+use Friendica\App;
+use Friendica\BaseObject;
+use Friendica\Test\Util\Intercept;
+use PHPUnit\Framework\TestCase;
+
+abstract class ConsoleTest extends TestCase
+{
+	/**
+	 * @var MultiUseConsole Extension of the basic Friendica Console for testing purpose
+	 */
+	private $console;
+	/**
+	 * @var App The Friendica App
+	 */
+	protected $app;
+
+	protected $stdout;
+
+	protected function setUp()
+	{
+		parent::setUp();
+
+		Intercept::setUp();
+
+		if (!getenv('MYSQL_DATABASE')) {
+			$this->markTestSkipped('Please set the MYSQL_* environment variables to your test database credentials.');
+		}
+
+		// Reusable App object
+		$this->app = BaseObject::getApp();
+		$this->console = new MultiUseConsole();
+	}
+
+	public function execute($args) {
+		Intercept::reset();
+		$this->console->reset();
+		$this->console->parseTestArgv($args);
+		$this->console->execute();
+
+		$returnStr = Intercept::$cache;
+		Intercept::reset();
+		return $returnStr;
+	}
+}

--- a/tests/src/Core/Console/MultiUseConsole.php
+++ b/tests/src/Core/Console/MultiUseConsole.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Friendica\Test\src\Core\Console;
+
+use Friendica\Core\Console;
+
+/**
+ * Adds two methods to the Friendica\Core\Console so we can reuse it during tests
+ *
+ * @package Friendica\Test\src\Core\Console
+ */
+class MultiUseConsole extends Console
+{
+	public function reset() {
+		$this->args = [];
+		$this->options = [];
+	}
+
+	public function parseTestArgv($argv)
+	{
+		$this->parseArgv($argv);
+	}
+}


### PR DESCRIPTION
- `MultiUseConsole` is now a testable console
- `ConsoleTest` is a abstract TestClass for console tests
- `ConfigConsoleTest` tests the config console commands

With this fix, I can now try to create tests for #5565  (which is - btw - not easy because of race conditions during DB/config reset)