### PR TITLE
Fix: Mail notifications arrive again

### DIFF
--- a/include/enotify.php
+++ b/include/enotify.php
@@ -510,7 +510,7 @@ function notification($params)
 	}
 
 	// send email notification if notification preferences permit
-	if ((!empty($params['notify_flags']) & intval($params['type']))
+	if ((intval($params['notify_flags']) & intval($params['type']))
 		|| $params['type'] == NOTIFY_SYSTEM
 		|| $params['type'] == SYSTEM_EMAIL) {
 

--- a/include/enotify.php
+++ b/include/enotify.php
@@ -32,6 +32,20 @@ function notification($params)
 		logger('Missing parameters.' . System::callstack());
 	}
 
+	// Ensure that the important fields are set at any time
+	$fields = ['notify-flags', 'language', 'username', 'email'];
+	$user = DBA::selectFirst('user', $fields, ['uid' => $params['uid']]);
+
+	if (!DBA::isResult($user)) {
+		logger('Unknown user ' . $params['uid']);
+		return;
+	}
+
+	$params['notify_flags'] = defaults($params, 'notify_flags', $user['notify-flags']);
+	$params['language'] = defaults($params, 'language', $user['language']);
+	$params['to_name'] = defaults($params, 'to_name', $user['username']);
+	$params['to_email'] = defaults($params, 'to_email', $user['email']);
+
 	// from here on everything is in the recipients language
 	L10n::pushLang($params['language']);
 
@@ -661,7 +675,7 @@ function check_item_notification($itemid, $uid, $defaulttype = "") {
 
 	$profiles = $notification_data["profiles"];
 
-	$fields = ['notify-flags', 'language', 'username', 'email', 'nickname'];
+	$fields = ['nickname'];
 	$user = DBA::selectFirst('user', $fields, ['uid' => $uid]);
 	if (!DBA::isResult($user)) {
 		return false;
@@ -724,10 +738,6 @@ function check_item_notification($itemid, $uid, $defaulttype = "") {
 	// Generate the notification array
 	$params = [];
 	$params["uid"] = $uid;
-	$params["notify_flags"] = $user["notify-flags"];
-	$params["language"] = $user["language"];
-	$params["to_name"] = $user["username"];
-	$params["to_email"] = $user["email"];
 	$params["item"] = $item;
 	$params["parent"] = $item["parent"];
 	$params["link"] = System::baseUrl().'/display/'.urlencode($item["guid"]);


### PR DESCRIPTION
This fixes https://github.com/friendica/friendica/issues/5651

One should never mix ```&``` with ```&&``` ...

This also contains some changes so that we don't have to provide data that we can generate on our own. In the future we have to clean all "notification" calls to remove this data. (And possibly some more)