### PR TITLE
The post update version can now be set

### DIFF
--- a/src/Core/Console/PostUpdate.php
+++ b/src/Core/Console/PostUpdate.php
@@ -3,6 +3,7 @@
 namespace Friendica\Core\Console;
 
 use Friendica\Core\L10n;
+use Friendica\Core\Config;
 
 /**
  * @brief tool to block an account from the node
@@ -17,12 +18,39 @@ use Friendica\Core\L10n;
  */
 class PostUpdate extends \Asika\SimpleConsole\Console
 {
+        protected $helpOptions = ['h', 'help', '?'];
+
+        protected function getHelp()
+        {
+                $help = <<<HELP
+console postupdate - Does database post updates
+Usage
+        bin/console postupdate [-h|--help|-?] [--reset <version>]
+
+Options
+    -h|--help|-?      Show help information
+    --reset <version> Reset the post update version
+HELP;
+                return $help;
+        }
+
 	protected function doExecute()
 	{
 		$a = get_app();
 
-		if (count($this->args) > 0) {
-			throw new \Asika\SimpleConsole\CommandArgsException('Too many arguments');
+		if ($this->getOption($this->helpOptions)) {
+			$this->out($this->getHelp());
+			return 0;
+		}
+
+		$reset_version = $this->getOption('reset');
+		if (is_bool($reset_version)) {
+			$this->out($this->getHelp());
+			return 0;
+		} elseif ($reset_version) {
+			Config::set('system', 'post_update_version', $reset_version);
+			echo L10n::t('Post update version number has been set to %s.', $reset_version) . "\n";
+			return 0;
 		}
 
 		if ($a->isInstallMode()) {


### PR DESCRIPTION
See issue https://github.com/friendica/friendica/issues/5687

Instead of manually setting the config value, we can now execute ```bin/console postupdate --reset 1278```