### PR TITLE
Fix: Missing gserver entries - show correct server platform

### DIFF
--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -1076,6 +1076,11 @@ class Contact extends BaseObject
 
 		if (empty($data)) {
 			$data = Probe::uri($url, "", $uid);
+
+			// Ensure that there is a gserver entry
+			if (!empty($data['baseurl']) && ($data['network'] != Protocol::PHANTOM)) {
+				PortableContact::checkServer($data['baseurl']);
+			}
 		}
 
 		// Last try in gcontact for unsupported networks


### PR DESCRIPTION
This fixes the problem that sometimes the displayed server platform had only been filled with something like "ostatus" but not "GNU Social", "Pleroma" or whatever.