### PR TITLE
Fix unfollow sharing-only contacts (except connector protocols)

### DIFF
--- a/mod/contacts.php
+++ b/mod/contacts.php
@@ -595,17 +595,12 @@ function contacts_content(App $a, $update = 0)
 		/// @todo Only show the following link with DFRN when the remote version supports it
 		$follow = '';
 		$follow_text = '';
-		if ($contact['network'] != Protocol::STATUSNET) {
-			if (in_array($contact['rel'], [Contact::FRIEND, Contact::SHARING])) {
+		if (in_array($contact['rel'], [Contact::FRIEND, Contact::SHARING])) {
+			if (in_array($contact['network'], Protocol::NATIVE_SUPPORT)) {
 				$follow = System::baseUrl(true) . "/unfollow?url=" . urlencode($contact["url"]);
 				$follow_text = L10n::t("Disconnect/Unfollow");
-			} else {
-				$follow = System::baseUrl(true) . "/follow?url=" . urlencode($contact["url"]);
-				$follow_text = L10n::t("Connect/Follow");
 			}
-		}
-
-		if ($contact['uid'] == 0) {
+		} else {
 			$follow = System::baseUrl(true) . "/follow?url=" . urlencode($contact["url"]);
 			$follow_text = L10n::t("Connect/Follow");
 		}

--- a/mod/contacts.php
+++ b/mod/contacts.php
@@ -595,7 +595,7 @@ function contacts_content(App $a, $update = 0)
 		/// @todo Only show the following link with DFRN when the remote version supports it
 		$follow = '';
 		$follow_text = '';
-		if (in_array($contact['network'], [Protocol::DIASPORA, Protocol::OSTATUS, Protocol::DFRN])) {
+		if ($contact['network'] != Protocol::STATUSNET) {
 			if (in_array($contact['rel'], [Contact::FRIEND, Contact::SHARING])) {
 				$follow = System::baseUrl(true) . "/unfollow?url=" . urlencode($contact["url"]);
 				$follow_text = L10n::t("Disconnect/Unfollow");

--- a/mod/unfollow.php
+++ b/mod/unfollow.php
@@ -39,20 +39,18 @@ function unfollow_post()
 		// NOTREACHED
 	}
 
-	if ($contact['network'] == Protocol::STATUSNET) {
+	if (!in_array($contact['network'], Protocol::NATIVE_SUPPORT)) {
 		notice(L10n::t('Unfollowing is currently not supported by your network.'));
 		goaway($return_url);
 		// NOTREACHED
 	}
 
-	if (in_array($contact['network'], [Protocol::OSTATUS, Protocol::DIASPORA, Protocol::DFRN])) {
-		$r = q("SELECT `contact`.*, `user`.* FROM `contact` INNER JOIN `user` ON `contact`.`uid` = `user`.`uid`
-			WHERE `user`.`uid` = %d AND `contact`.`self` LIMIT 1",
-			intval($uid)
-		);
-		if (DBA::isResult($r)) {
-			Contact::terminateFriendship($r[0], $contact);
-		}
+	$r = q("SELECT `contact`.*, `user`.* FROM `contact` INNER JOIN `user` ON `contact`.`uid` = `user`.`uid`
+		WHERE `user`.`uid` = %d AND `contact`.`self` LIMIT 1",
+		intval($uid)
+	);
+	if (DBA::isResult($r)) {
+		Contact::terminateFriendship($r[0], $contact);
 	}
 
 	// Sharing-only contacts get deleted as there no relationship any more
@@ -92,7 +90,7 @@ function unfollow_content(App $a)
 		// NOTREACHED
 	}
 
-	if ($contact['network'] == Protocol::STATUSNET) {
+	if (!in_array($contact['network'], Protocol::NATIVE_SUPPORT)) {
 		notice(L10n::t('Unfollowing is currently not supported by your network.'));
 		goaway('contacts/' . $contact['id']);
 		// NOTREACHED

--- a/mod/unfollow.php
+++ b/mod/unfollow.php
@@ -27,29 +27,37 @@ function unfollow_post(App $a)
 	$url = notags(trim($_REQUEST['url']));
 	$return_url = $_SESSION['return_url'];
 
-	$condition = ["`uid` = ? AND `rel` = ? AND (`nurl` = ? OR `alias` = ? OR `alias` = ?) AND `network` != ?",
-			$uid, Contact::FRIEND, normalise_link($url),
+	$condition = ["`uid` = ? AND (`rel` = ? OR `rel` = ?) AND (`nurl` = ? OR `alias` = ? OR `alias` = ?) AND `network` != ?",
+			$uid, Contact::SHARING, Contact::FRIEND, normalise_link($url),
 			normalise_link($url), $url, Protocol::STATUSNET];
 	$contact = DBA::selectFirst('contact', [], $condition);
 
 	if (!DBA::isResult($contact)) {
 		notice(L10n::t("Contact wasn't found or can't be unfollowed."));
-	} else {
-		if (in_array($contact['network'], [Protocol::OSTATUS, Protocol::DIASPORA, Protocol::DFRN])) {
-			$r = q("SELECT `contact`.*, `user`.* FROM `contact` INNER JOIN `user` ON `contact`.`uid` = `user`.`uid`
-				WHERE `user`.`uid` = %d AND `contact`.`self` LIMIT 1",
-				intval($uid)
-			);
-			if (DBA::isResult($r)) {
-				Contact::terminateFriendship($r[0], $contact);
-			}
-		}
-		DBA::update('contact', ['rel' => Contact::FOLLOWER], ['id' => $contact['id']]);
-
-		info(L10n::t('Contact unfollowed').EOL);
-		goaway(System::baseUrl().'/contacts/'.$contact['id']);
+		goaway($return_url);
 	}
-	goaway($return_url);
+
+	if (in_array($contact['network'], [Protocol::OSTATUS, Protocol::DIASPORA, Protocol::DFRN])) {
+		$r = q("SELECT `contact`.*, `user`.* FROM `contact` INNER JOIN `user` ON `contact`.`uid` = `user`.`uid`
+			WHERE `user`.`uid` = %d AND `contact`.`self` LIMIT 1",
+			intval($uid)
+		);
+		if (DBA::isResult($r)) {
+			Contact::terminateFriendship($r[0], $contact);
+		}
+	}
+
+	// Sharing-only contacts get deleted as there no relationship any more
+	if ($contact['rel'] == Contact::SHARING) {
+		Contact::remove($contact['id']);
+		$return_path = 'contacts';
+	} else {
+		DBA::update('contact', ['rel' => Contact::FOLLOWER], ['id' => $contact['id']]);
+		$return_path = 'contacts/' . $contact['id'];
+	}
+
+	info(L10n::t('Contact unfollowed'));
+	goaway($return_path);
 	// NOTREACHED
 }
 
@@ -66,8 +74,8 @@ function unfollow_content(App $a)
 
 	$submit = L10n::t('Submit Request');
 
-	$condition = ["`uid` = ? AND `rel` = ? AND (`nurl` = ? OR `alias` = ? OR `alias` = ?) AND `network` != ?",
-			local_user(), Contact::FRIEND, normalise_link($url),
+	$condition = ["`uid` = ? AND (`rel` = ? OR `rel` = ?) AND (`nurl` = ? OR `alias` = ? OR `alias` = ?) AND `network` != ?",
+			local_user(), Contact::SHARING, Contact::FRIEND, normalise_link($url),
 			normalise_link($url), $url, Protocol::STATUSNET];
 
 	$contact = DBA::selectFirst('contact', ['url', 'network', 'addr', 'name'], $condition);

--- a/mod/unfollow.php
+++ b/mod/unfollow.php
@@ -10,6 +10,7 @@ use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\Model\Contact;
 use Friendica\Model\Profile;
+use Friendica\Model\User;
 
 function unfollow_post()
 {
@@ -45,12 +46,9 @@ function unfollow_post()
 		// NOTREACHED
 	}
 
-	$r = q("SELECT `contact`.*, `user`.* FROM `contact` INNER JOIN `user` ON `contact`.`uid` = `user`.`uid`
-		WHERE `user`.`uid` = %d AND `contact`.`self` LIMIT 1",
-		intval($uid)
-	);
-	if (DBA::isResult($r)) {
-		Contact::terminateFriendship($r[0], $contact);
+	$owner = User::getOwnerDataById($uid);
+	if ($owner) {
+		Contact::terminateFriendship($owner, $contact);
 	}
 
 	// Sharing-only contacts get deleted as there no relationship any more

--- a/src/Core/Protocol.php
+++ b/src/Core/Protocol.php
@@ -13,27 +13,33 @@ use Friendica\Util\Network;
  */
 class Protocol
 {
-	const DFRN      = 'dfrn';    // Friendica, Mistpark, other DFRN implementations
-	const DIASPORA  = 'dspr';    // Diaspora
-	const DIASPORA2 = 'dspc';    // Diaspora connector
-	const STATUSNET = 'stac';    // Statusnet connector
-	const OSTATUS   = 'stat';    // GNU-social, Pleroma, Mastodon, other OStatus implementations
-	const FEED      = 'feed';    // RSS/Atom feeds with no known "post/notify" protocol
-	const MAIL      = 'mail';    // IMAP/POP
-	const XMPP      = 'xmpp';    // XMPP - Currently unsupported
+	// Native support
+	const ACTIVITYPUB = 'apub';    // ActivityPub
+	const DFRN        = 'dfrn';    // Friendica, Mistpark, other DFRN implementations
+	const DIASPORA    = 'dspr';    // Diaspora
+	const FEED        = 'feed';    // RSS/Atom feeds with no known "post/notify" protocol
+	const MAIL        = 'mail';    // IMAP/POP
+	const OSTATUS     = 'stat';    // GNU-social, Pleroma, Mastodon, other OStatus implementations
 
-	const FACEBOOK  = 'face';    // Facebook API
-	const LINKEDIN  = 'lnkd';    // LinkedIn
-	const MYSPACE   = 'mysp';    // MySpace - Currently unsupported
-	const GPLUS     = 'goog';    // Google+
-	const PUMPIO    = 'pump';    // pump.io
-	const TWITTER   = 'twit';    // Twitter
+	const NATIVE_SUPPORT = [self::DFRN, self::DIASPORA, self::OSTATUS, self::FEED, self::MAIL, self::ACTIVITYPUB];
+
+	// Supported through a connector
 	const APPNET    = 'apdn';    // app.net - Dead protocol
+	const DIASPORA2 = 'dspc';    // Diaspora connector
+	const FACEBOOK  = 'face';    // Facebook API
+	const GPLUS     = 'goog';    // Google+
+	const LINKEDIN  = 'lnkd';    // LinkedIn
+	const PUMPIO    = 'pump';    // pump.io
+	const STATUSNET = 'stac';    // Statusnet connector
+	const TWITTER   = 'twit';    // Twitter
 
-	const NEWS      = 'nntp';    // Network News Transfer Protocol - Currently unsupported
-	const ICALENDAR = 'ical';    // iCalendar - Currently unsupported
-	const PNUT      = 'pnut';    // pnut.io - Currently unsupported
-	const ZOT       = 'zot!';    // Zot! - Currently unsupported
+	// Currently unsupported
+	const ICALENDAR = 'ical';    // iCalendar
+	const MYSPACE   = 'mysp';    // MySpace
+	const NEWS      = 'nntp';    // Network News Transfer Protocol
+	const PNUT      = 'pnut';    // pnut.io
+	const XMPP      = 'xmpp';    // XMPP
+	const ZOT       = 'zot!';    // Zot!
 
 	const PHANTOM   = 'unkn';    // Place holder
 


### PR DESCRIPTION
This new version of #5701 removes the contact for sharing-only contact unfollow requests, except for connector-supported protocols.