### PR TITLE
 Removed obsolete post update that sometimes never finishes

### DIFF
--- a/mod/ping.php
+++ b/mod/ping.php
@@ -510,13 +510,14 @@ function ping_get_notifications($uid)
  * @brief Backward-compatible XML formatting for ping.php output
  * @deprecated
  *
- * @param array $data          The initial ping data array
- * @param int   $sysnotify     Number of unseen system notifications
- * @param array $notifs        Complete list of notification
- * @param array $sysmsgs       List of system notice messages
- * @param array $sysmsgs_info  List of system info messages
- * @param int   $groups_unseen Number of unseen group items
- * @param int   $forums_unseen Number of unseen forum items
+ * @param array $data            The initial ping data array
+ * @param int   $sysnotify_count Number of unseen system notifications
+ * @param array $notifs          Complete list of notification
+ * @param array $sysmsgs         List of system notice messages
+ * @param array $sysmsgs_info    List of system info messages
+ * @param int   $groups_unseen   Number of unseen group items
+ * @param int   $forums_unseen   Number of unseen forum items
+ *
  * @return array XML-transform ready data array
  */
 function ping_format_xml_data($data, $sysnotify_count, $notifs, $sysmsgs, $sysmsgs_info, $groups_unseen, $forums_unseen)

--- a/src/Database/PostUpdate.php
+++ b/src/Database/PostUpdate.php
@@ -27,9 +27,6 @@ class PostUpdate
 		if (!self::update1194()) {
 			return false;
 		}
-		if (!self::update1198()) {
-			return false;
-		}
 		if (!self::update1206()) {
 			return false;
 		}
@@ -109,88 +106,6 @@ class PostUpdate
 			DBA::escape(Protocol::DFRN), DBA::escape(Protocol::DIASPORA), DBA::escape(Protocol::OSTATUS));
 
 		logger("Done", LOGGER_DEBUG);
-	}
-
-	/**
-	 * @brief set the author-id and owner-id in all item entries
-	 *
-	 * This job has to be started multiple times until all entries are set.
-	 * It isn't started in the update function since it would consume too much time and can be done in the background.
-	 *
-	 * @return bool "true" when the job is done
-	 */
-	private static function update1198()
-	{
-		// Was the script completed?
-		if (Config::get("system", "post_update_version") >= 1198) {
-			return true;
-		}
-
-		logger("Start", LOGGER_DEBUG);
-
-		// Check if the first step is done (Setting "author-id" and "owner-id" in the item table)
-		$fields = ['author-link', 'author-name', 'author-avatar', 'owner-link', 'owner-name', 'owner-avatar', 'network', 'uid'];
-		$r = DBA::select('item', $fields, ['author-id' => 0, 'owner-id' => 0], ['limit' => 1000]);
-		if (!$r) {
-			// Are there unfinished entries in the thread table?
-			$r = q("SELECT COUNT(*) AS `total` FROM `thread`
-				INNER JOIN `item` ON `item`.`id` =`thread`.`iid`
-				WHERE `thread`.`author-id` = 0 AND `thread`.`owner-id` = 0 AND
-					(`thread`.`uid` IN (SELECT `uid` from `user`) OR `thread`.`uid` = 0)");
-
-			if ($r && ($r[0]["total"] == 0)) {
-				Config::set("system", "post_update_version", 1198);
-				logger("Done", LOGGER_DEBUG);
-				return true;
-			}
-
-			// Update the thread table from the item table
-			$r = q("UPDATE `thread` INNER JOIN `item` ON `item`.`id`=`thread`.`iid`
-					SET `thread`.`author-id` = `item`.`author-id`,
-					`thread`.`owner-id` = `item`.`owner-id`
-				WHERE `thread`.`author-id` = 0 AND `thread`.`owner-id` = 0 AND
-					(`thread`.`uid` IN (SELECT `uid` from `user`) OR `thread`.`uid` = 0)");
-
-			logger("Updated threads", LOGGER_DEBUG);
-			if (DBA::isResult($r)) {
-				Config::set("system", "post_update_version", 1198);
-				logger("Done", LOGGER_DEBUG);
-				return true;
-			}
-			return false;
-		}
-
-		logger("Query done", LOGGER_DEBUG);
-
-		$item_arr = [];
-		foreach ($r as $item) {
-			$index = $item["author-link"]."-".$item["owner-link"]."-".$item["uid"];
-			$item_arr[$index] = ["author-link" => $item["author-link"],
-							"owner-link" => $item["owner-link"],
-							"uid" => $item["uid"]];
-		}
-
-		// Set the "author-id" and "owner-id" in the item table and add a new public contact entry if needed
-		foreach ($item_arr as $item) {
-			$default = ['url' => $item['author-link'], 'name' => $item['author-name'],
-				'photo' => $item['author-avatar'], 'network' => $item['network']];
-			$author_id = Contact::getIdForURL($item["author-link"], 0, false, $default);
-
-			$default = ['url' => $item['owner-link'], 'name' => $item['owner-name'],
-				'photo' => $item['owner-avatar'], 'network' => $item['network']];
-			$owner_id = Contact::getIdForURL($item["owner-link"], 0, false, $default);
-
-			if ($author_id == 0) {
-				$author_id = -1;
-			}
-			if ($owner_id == 0) {
-				$owner_id = -1;
-			}
-			DBA::update('item', ['author-id' => $author_id, 'owner-id' => $owner_id], ['uid' => $item['uid'], 'author-link' => $item['author-link'], 'owner-link' => $item['owner-link'], 'author-id' => 0, 'owner-id' => 0]);
-		}
-
-		logger("Updated items", LOGGER_DEBUG);
-		return false;
 	}
 
 	/**


### PR DESCRIPTION
This fixes the never ending post updates that are mentioned here: https://mass-trespass.uk/display/f83586ea175b8bb964f16cd991689047

There had been possible situations where the post update version 1198 never had been finished. Since the post update 1279 contains functionality that replaces 1198 completely, we can get rid of the old one.

Additionally some documentation had been updated.