### PR TITLE
Restore the behaviour to remove the remote contact upon termination

### DIFF
--- a/mod/contacts.php
+++ b/mod/contacts.php
@@ -368,7 +368,7 @@ function _contact_drop($orig_record)
 		return;
 	}
 
-	Contact::terminateFriendship($r[0], $orig_record);
+	Contact::terminateFriendship($r[0], $orig_record, true);
 	Contact::remove($orig_record['id']);
 }
 

--- a/mod/dfrn_notify.php
+++ b/mod/dfrn_notify.php
@@ -322,8 +322,8 @@ function dfrn_notify_content(App $a) {
 		$encrypted_id = '';
 		$id_str       = $my_id . '.' . mt_rand(1000,9999);
 
-		$prv_key = trim($importer['prvkey']);
-		$pub_key = trim($importer['pubkey']);
+		$prv_key = trim($importer['cprvkey']);
+		$pub_key = trim($importer['cpubkey']);
 		$dplx    = intval($importer['duplex']);
 
 		if (($dplx && strlen($prv_key)) || (strlen($prv_key) && !strlen($pub_key))) {

--- a/mod/dirfind.php
+++ b/mod/dirfind.php
@@ -44,7 +44,7 @@ function dirfind_content(App $a, $prefix = "") {
 
 	$local = Config::get('system','poco_local_search');
 
-	$search = $prefix.notags(trim($_REQUEST['search']));
+	$search = $prefix.notags(trim(defaults($_REQUEST, 'search', '')));
 
 	$header = '';
 

--- a/mod/unfollow.php
+++ b/mod/unfollow.php
@@ -46,13 +46,15 @@ function unfollow_post()
 		// NOTREACHED
 	}
 
+	$dissolve = ($contact['rel'] == Contact::SHARING);
+
 	$owner = User::getOwnerDataById($uid);
 	if ($owner) {
-		Contact::terminateFriendship($owner, $contact);
+		Contact::terminateFriendship($owner, $contact, $dissolve);
 	}
 
 	// Sharing-only contacts get deleted as there no relationship any more
-	if ($contact['rel'] == Contact::SHARING) {
+	if ($dissolve) {
 		Contact::remove($contact['id']);
 		$return_path = 'contacts';
 	} else {

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -17,6 +17,7 @@ use Friendica\Model\Profile;
 use Friendica\Network\Probe;
 use Friendica\Object\Image;
 use Friendica\Protocol\Diaspora;
+use Friendica\Protocol\DFRN;
 use Friendica\Protocol\OStatus;
 use Friendica\Protocol\PortableContact;
 use Friendica\Protocol\Salmon;
@@ -528,13 +529,16 @@ class Contact extends BaseObject
 	/**
 	 * @brief Sends an unfriend message. Does not remove the contact
 	 *
-	 * @param array $user    User unfriending
-	 * @param array $contact Contact unfriended
+	 * @param array   $user     User unfriending
+	 * @param array   $contact  Contact unfriended
+	 * @param boolean $dissolve Remove the contact on the remote side
 	 * @return void
 	 */
-	public static function terminateFriendship(array $user, array $contact)
+	public static function terminateFriendship(array $user, array $contact, $dissolve = false)
 	{
-		if (in_array($contact['network'], [Protocol::OSTATUS, Protocol::DFRN])) {
+		if (($contact['network'] == Protocol::DFRN) && $dissolve) {
+			DFRN::deliver($user, $contact, 'placeholder', true);
+		} elseif (in_array($contact['network'], [Protocol::OSTATUS, Protocol::DFRN])) {
 			// create an unfollow slap
 			$item = [];
 			$item['verb'] = NAMESPACE_OSTATUS . "/unfollow";

--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -81,7 +81,8 @@ class DFRN
 				return [];
 			}
 
-			$user['importer_uid']  = $user['uid'];
+			$user['importer_uid'] = $user['uid'];
+			$user['uprvkey'] = $user['prvkey'];
 		} else {
 			$user = ['importer_uid' => 0, 'uprvkey' => '', 'timezone' => 'UTC',
 				'nickname' => '', 'sprvkey' => '', 'spubkey' => '',
@@ -1168,10 +1169,12 @@ class DFRN
 		$a = get_app();
 
 		// At first try the Diaspora transport layer
-		$ret = self::transmit($owner, $contact, $atom);
-		if ($ret >= 200) {
-			logger('Delivery via Diaspora transport layer was successful with status ' . $ret);
-			return $ret;
+		if (!$dissolve) {
+			$ret = self::transmit($owner, $contact, $atom);
+			if ($ret >= 200) {
+				logger('Delivery via Diaspora transport layer was successful with status ' . $ret);
+				return $ret;
+			}
 		}
 
 		$idtosend = $orig_id = (($contact['dfrn-id']) ? $contact['dfrn-id'] : $contact['issued-id']);

--- a/src/Worker/Notifier.php
+++ b/src/Worker/Notifier.php
@@ -96,7 +96,7 @@ class Notifier
 				return;
 			}
 			foreach ($r as $contact) {
-				Contact::terminateFriendship($user, $contact);
+				Contact::terminateFriendship($user, $contact, true);
 			}
 			return;
 		} elseif ($cmd == Delivery::RELOCATION) {


### PR DESCRIPTION
This should fix the issue described here: https://forum.friendi.ca/display/4029d2ca185b8bbc74442d3891030690

This should work in a way that upon removal of the local contact the remote contact will be removed as well. Same will happen upon account removal. When unfollowing, this should only happen when this hadn't been a bidirectional connection.

This also should fix (formerly undiscovered) communication issues with older Friendica versions, thanks to @rabuzarus 

Additionally - and unrelated - a small notice fix is included.