### PR TITLE
CacheLockDriverTest Fixings

### DIFF
--- a/tests/src/Core/Lock/ArrayCacheLockDriverTest.php
+++ b/tests/src/Core/Lock/ArrayCacheLockDriverTest.php
@@ -8,21 +8,9 @@ use Friendica\Core\Lock\CacheLockDriver;
 
 class ArrayCacheLockDriverTest extends LockTest
 {
-	/**
-	 * @var \Friendica\Core\Cache\IMemoryCacheDriver
-	 */
-	private $cache;
-
 	protected function getInstance()
 	{
-		$this->cache = new ArrayCache();
-		return new CacheLockDriver($this->cache);
-	}
-
-	public function tearDown()
-	{
-		$this->cache->clear();
-		parent::tearDown();
+		return new CacheLockDriver(new ArrayCache());
 	}
 
 	public function testLockTTL()

--- a/tests/src/Core/Lock/MemcacheCacheLockDriverTest.php
+++ b/tests/src/Core/Lock/MemcacheCacheLockDriverTest.php
@@ -3,7 +3,6 @@
 
 namespace Friendica\Test\src\Core\Lock;
 
-
 use Friendica\Core\Cache\CacheDriverFactory;
 use Friendica\Core\Lock\CacheLockDriver;
 
@@ -12,20 +11,8 @@ use Friendica\Core\Lock\CacheLockDriver;
  */
 class MemcacheCacheLockDriverTest extends LockTest
 {
-	/**
-	 * @var \Friendica\Core\Cache\IMemoryCacheDriver
-	 */
-	private $cache;
-
 	protected function getInstance()
 	{
-		$this->cache = CacheDriverFactory::create('memcache');
-		return new CacheLockDriver($this->cache);
-	}
-
-	public function tearDown()
-	{
-		$this->cache->clear();
-		parent::tearDown();
+		return new CacheLockDriver(CacheDriverFactory::create('memcache'));
 	}
 }

--- a/tests/src/Core/Lock/MemcachedCacheLockDriverTest.php
+++ b/tests/src/Core/Lock/MemcachedCacheLockDriverTest.php
@@ -3,7 +3,6 @@
 
 namespace Friendica\Test\src\Core\Lock;
 
-
 use Friendica\Core\Cache\CacheDriverFactory;
 use Friendica\Core\Lock\CacheLockDriver;
 
@@ -12,20 +11,8 @@ use Friendica\Core\Lock\CacheLockDriver;
  */
 class MemcachedCacheLockDriverTest extends LockTest
 {
-	/**
-	 * @var \Friendica\Core\Cache\IMemoryCacheDriver
-	 */
-	private $cache;
-
 	protected function getInstance()
 	{
-		$this->cache = CacheDriverFactory::create('memcached');
-		return new CacheLockDriver($this->cache);
-	}
-
-	public function tearDown()
-	{
-		$this->cache->clear();
-		parent::tearDown();
+		return new CacheLockDriver(CacheDriverFactory::create('memcached'));
 	}
 }

--- a/tests/src/Core/Lock/RedisCacheLockDriverTest.php
+++ b/tests/src/Core/Lock/RedisCacheLockDriverTest.php
@@ -3,7 +3,6 @@
 
 namespace Friendica\Test\src\Core\Lock;
 
-
 use Friendica\Core\Cache\CacheDriverFactory;
 use Friendica\Core\Lock\CacheLockDriver;
 
@@ -12,21 +11,9 @@ use Friendica\Core\Lock\CacheLockDriver;
  */
 class RedisCacheLockDriverTest extends LockTest
 {
-	/**
-	 * @var \Friendica\Core\Cache\IMemoryCacheDriver
-	 */
-	private $cache;
-
 	protected function getInstance()
 	{
-		$this->cache = CacheDriverFactory::create('redis');
-		return new CacheLockDriver($this->cache);
+		return new CacheLockDriver(CacheDriverFactory::create('redis'));
 
-	}
-
-	public function tearDown()
-	{
-		$this->cache->clear();
-		parent::tearDown();
 	}
 }

--- a/tests/src/Core/Lock/SemaphoreLockDriverTest.php
+++ b/tests/src/Core/Lock/SemaphoreLockDriverTest.php
@@ -2,26 +2,13 @@
 
 namespace Friendica\Test\src\Core\Lock;
 
-
 use Friendica\Core\Lock\SemaphoreLockDriver;
 
 class SemaphoreLockDriverTest extends LockTest
 {
-	/**
-	 * @var \Friendica\Core\Lock\SemaphoreLockDriver
-	 */
-	private $semaphoreLockDriver;
-
 	protected function getInstance()
 	{
-		$this->semaphoreLockDriver = new SemaphoreLockDriver();
-		return $this->semaphoreLockDriver;
-	}
-
-	public function tearDown()
-	{
-		$this->semaphoreLockDriver->releaseAll();
-		parent::tearDown();
+		return new SemaphoreLockDriver();
 	}
 
 	function testLockTTL()


### PR DESCRIPTION
Changing test behaviour

- `releaseAll()` before each test
- Assertion of each key

Should fix #5716 or at least make it more clear when it fails

=> branch `develop` on purpose because this will be a fix 2018.11 (as the issue is already)