### PR TITLE
Fix: Posts with pictures will now look good again on connector networks

### DIFF
--- a/mod/photos.php
+++ b/mod/photos.php
@@ -1633,7 +1633,7 @@ function photos_content(App $a)
 			'$paginate' => $paginate,
 		]);
 
-		$a->page['htmlhead'] .= "\n" . '<meta name="twitter:card" content="photo" />' . "\n";
+		$a->page['htmlhead'] .= "\n" . '<meta name="twitter:card" content="summary_large_image" />' . "\n";
 		$a->page['htmlhead'] .= '<meta name="twitter:title" content="' . $photo["album"] . '" />' . "\n";
 		$a->page['htmlhead'] .= '<meta name="twitter:image" content="' . $photo["href"] . '" />' . "\n";
 		$a->page['htmlhead'] .= '<meta name="twitter:image:width" content="' . $photo["width"] . '" />' . "\n";

--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -572,17 +572,17 @@ class BBCode extends BaseObject
 					$return = sprintf('<div class="type-%s">', $data["type"]);
 				}
 
-				if (!empty($data["image"])) {
-					$return .= sprintf('<a href="%s" target="_blank"><img src="%s" alt="" title="%s" class="attachment-image" /></a><br />', $data["url"], self::proxyUrl($data["image"], $simplehtml), $data["title"]);
-				} elseif (!empty($data["preview"])) {
-					$return .= sprintf('<a href="%s" target="_blank"><img src="%s" alt="" title="%s" class="attachment-preview" /></a><br />', $data["url"], self::proxyUrl($data["preview"], $simplehtml), $data["title"]);
-				}
-
-				// Show a picture only when the BBCode is meant for posts to connector networks
-				if (($simplehtml != 0) && ($data["type"] == "photo") && !empty($data["url"]) && !empty($data["image"])) {
-					$return .= sprintf('<a href="%s" target="_blank"><img src="%s" alt="" title="%s" class="attachment-image" /></a>', $data["url"], self::proxyUrl($data["image"], $simplehtml), $data["title"]);
-				} elseif (!empty($data['title']) && !empty($data['url'])) {
-					$return .= sprintf('<h4><a href="%s">%s</a></h4>', $data['url'], $data['title']);
+				if (!empty($data['title']) && !empty($data['url'])) {
+					if (!empty($data["image"]) && empty($data["text"]) && ($data["type"] == "photo")) {
+						$return .= sprintf('<a href="%s" target="_blank"><img src="%s" alt="" title="%s" class="attachment-image" /></a>', $data["url"], self::proxyUrl($data["image"], $simplehtml), $data["title"]);
+					} else {
+						if (!empty($data["image"])) {
+							$return .= sprintf('<a href="%s" target="_blank"><img src="%s" alt="" title="%s" class="attachment-image" /></a><br />', $data["url"], self::proxyUrl($data["image"], $simplehtml), $data["title"]);
+						} elseif (!empty($data["preview"])) {
+							$return .= sprintf('<a href="%s" target="_blank"><img src="%s" alt="" title="%s" class="attachment-preview" /></a><br />', $data["url"], self::proxyUrl($data["preview"], $simplehtml), $data["title"]);
+						}
+						$return .= sprintf('<h4><a href="%s">%s</a></h4>', $data['url'], $data['title']);
+					}
 				}
 
 				if (!empty($data["description"]) && $data["description"] != $data["title"]) {

--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -578,7 +578,10 @@ class BBCode extends BaseObject
 					$return .= sprintf('<a href="%s" target="_blank"><img src="%s" alt="" title="%s" class="attachment-preview" /></a><br />', $data["url"], self::proxyUrl($data["preview"], $simplehtml), $data["title"]);
 				}
 
-				if (!empty($data['title']) && !empty($data['url'])) {
+				// Show a picture only when the BBCode is meant for posts to connector networks
+				if (($simplehtml != 0) && ($data["type"] == "photo") && !empty($data["url"]) && !empty($data["image"])) {
+					$return .= sprintf('<a href="%s" target="_blank"><img src="%s" alt="" title="%s" class="attachment-image" /></a>', $data["url"], self::proxyUrl($data["image"], $simplehtml), $data["title"]);
+				} elseif (!empty($data['title']) && !empty($data['url'])) {
 					$return .= sprintf('<h4><a href="%s">%s</a></h4>', $data['url'], $data['title']);
 				}
 

--- a/src/Util/ParseUrl.php
+++ b/src/Util/ParseUrl.php
@@ -271,11 +271,9 @@ class ParseUrl
 					$siteinfo['image'] = $meta_tag['content'];
 					break;
 				case 'twitter:card':
-					// Convert Twitter types in our own
+					// Detect photo pages
 					if ($meta_tag['content'] == 'summary_large_image') {
 						$siteinfo['type'] = 'photo';
-					} else {
-						$siteinfo['type'] = $meta_tag['content'];
 					}
 					break;
 				case 'twitter:description':
@@ -332,6 +330,11 @@ class ParseUrl
 						break;
 				}
 			}
+		}
+
+		// Prevent to have a photo type without an image
+		if (empty($siteinfo['image']) && (siteinfo['type'] == 'photo')) {
+			$siteinfo['type'] = 'link';
 		}
 
 		if ((@$siteinfo['image'] == '') && !$no_guessing) {

--- a/src/Util/ParseUrl.php
+++ b/src/Util/ParseUrl.php
@@ -271,9 +271,9 @@ class ParseUrl
 					$siteinfo['image'] = $meta_tag['content'];
 					break;
 				case 'twitter:card':
-					// Obsolete card type
-					if ($meta_tag['content'] == 'photo') {
-						$siteinfo['type'] = 'summary_large_image';
+					// Convert Twitter types in our own
+					if ($meta_tag['content'] == 'summary_large_image') {
+						$siteinfo['type'] = 'photo';
 					} else {
 						$siteinfo['type'] = $meta_tag['content'];
 					}
@@ -297,10 +297,6 @@ class ParseUrl
 					$keywords = explode(',', $meta_tag['content']);
 					break;
 			}
-		}
-
-		if ($siteinfo['type'] == 'summary' || $siteinfo['type'] == 'summary_large_image') {
-			$siteinfo['type'] = 'link';
 		}
 
 		if (isset($keywords)) {

--- a/src/Util/ParseUrl.php
+++ b/src/Util/ParseUrl.php
@@ -333,7 +333,7 @@ class ParseUrl
 		}
 
 		// Prevent to have a photo type without an image
-		if (empty($siteinfo['image']) && (siteinfo['type'] == 'photo')) {
+		if (empty($siteinfo['image']) && ($siteinfo['type'] == 'photo')) {
 			$siteinfo['type'] = 'link';
 		}
 


### PR DESCRIPTION
The changes from pr https://github.com/friendica/friendica/pull/5715 caused the problem that picture posts via the connector networks now only contained a link to the picture - instead of attaching the picture to the post. This fixes it.

