### PR TITLE
Use OEmbed data when available no matter the type

### DIFF
--- a/src/Util/ParseUrl.php
+++ b/src/Util/ParseUrl.php
@@ -161,16 +161,14 @@ class ParseUrl
 					$siteinfo['type'] = $oembed_data->type;
 				}
 
-				if (($oembed_data->type == 'link') && ($siteinfo['type'] != 'photo')) {
-					if (isset($oembed_data->title)) {
-						$siteinfo['title'] = trim($oembed_data->title);
-					}
-					if (isset($oembed_data->description)) {
-						$siteinfo['text'] = trim($oembed_data->description);
-					}
-					if (isset($oembed_data->thumbnail_url)) {
-						$siteinfo['image'] = $oembed_data->thumbnail_url;
-					}
+				if (isset($oembed_data->title)) {
+					$siteinfo['title'] = trim($oembed_data->title);
+				}
+				if (isset($oembed_data->description)) {
+					$siteinfo['text'] = trim($oembed_data->description);
+				}
+				if (isset($oembed_data->thumbnail_url)) {
+					$siteinfo['image'] = $oembed_data->thumbnail_url;
 				}
 			}
 		}
@@ -337,7 +335,7 @@ class ParseUrl
 			$siteinfo['type'] = 'link';
 		}
 
-		if ((@$siteinfo['image'] == '') && !$no_guessing) {
+		if (empty($siteinfo['image']) && !$no_guessing) {
 			$list = $xpath->query('//img[@src]');
 			foreach ($list as $node) {
 				$img_tag = [];

--- a/src/Util/ParseUrl.php
+++ b/src/Util/ParseUrl.php
@@ -161,14 +161,17 @@ class ParseUrl
 					$siteinfo['type'] = $oembed_data->type;
 				}
 
-				if (isset($oembed_data->title)) {
-					$siteinfo['title'] = trim($oembed_data->title);
-				}
-				if (isset($oembed_data->description)) {
-					$siteinfo['text'] = trim($oembed_data->description);
-				}
-				if (isset($oembed_data->thumbnail_url)) {
-					$siteinfo['image'] = $oembed_data->thumbnail_url;
+				// See https://github.com/friendica/friendica/pull/5763#discussion_r217913178
+				if ($siteinfo['type'] != 'photo') {
+					if (isset($oembed_data->title)) {
+						$siteinfo['title'] = trim($oembed_data->title);
+					}
+					if (isset($oembed_data->description)) {
+						$siteinfo['text'] = trim($oembed_data->description);
+					}
+					if (isset($oembed_data->thumbnail_url)) {
+						$siteinfo['image'] = $oembed_data->thumbnail_url;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
I was having this issue where the attachement for my blog posts displayed the banner image in very small.

I found out that OEmbed structured data wasn't even considered when the type was `rich`, and that we relied instead on a haphazard image search based off arbitrary image sizes (height or width > 150), and that it was "resizing" them to be no bigger that 300x300px (???)

This small fix makes us trust OEmbed data if it exists no matter what.