### PR TITLE
Calculate form return_url for post and message instead of using SESSION Variable

### DIFF
--- a/mod/editpost.php
+++ b/mod/editpost.php
@@ -21,7 +21,7 @@ function editpost_content(App $a)
 	}
 
 	$post_id = (($a->argc > 1) ? intval($a->argv[1]) : 0);
-	$return_url = (($a->argc > 1) ? base64_decode($a->argv[2]) : '');
+	$return_url = (($a->argc > 2) ? base64_decode($a->argv[2]) : '');
 
 	if (!$post_id) {
 		notice(L10n::t('Item not found') . EOL);

--- a/mod/editpost.php
+++ b/mod/editpost.php
@@ -21,10 +21,16 @@ function editpost_content(App $a)
 	}
 
 	$post_id = (($a->argc > 1) ? intval($a->argv[1]) : 0);
+	$return_url = (($a->argc > 1) ? base64_decode($a->argv[2]) : '');
 
 	if (!$post_id) {
 		notice(L10n::t('Item not found') . EOL);
 		return;
+	}
+
+	// Fallback to SESSION return_path
+	if (empty($return_url)) {
+		$return_url = $_SESSION['return_path'];
 	}
 
 	$fields = ['allow_cid', 'allow_gid', 'deny_cid', 'deny_gid',
@@ -95,7 +101,7 @@ function editpost_content(App $a)
 
 	$o .= replace_macros($tpl, [
 		'$is_edit' => true,
-		'$return_path' => $_SESSION['return_url'],
+		'$return_path' => $return_url,
 		'$action' => 'item',
 		'$share' => L10n::t('Save'),
 		'$upload' => L10n::t('Upload photo'),

--- a/mod/message.php
+++ b/mod/message.php
@@ -92,7 +92,7 @@ function message_post(App $a)
 		$a->argc = 2;
 		$a->argv[1] = 'new';
 	} else {
-		goaway($_SESSION['return_url']);
+		goaway(System::baseUrl() . '/' . $a->cmd . '/' . $ret);
 	}
 }
 

--- a/mod/message.php
+++ b/mod/message.php
@@ -92,7 +92,7 @@ function message_post(App $a)
 		$a->argc = 2;
 		$a->argv[1] = 'new';
 	} else {
-		goaway(System::baseUrl() . '/' . $a->cmd . '/' . $ret);
+		goaway($a->cmd . '/' . $ret);
 	}
 }
 

--- a/src/Object/Post.php
+++ b/src/Object/Post.php
@@ -157,7 +157,7 @@ class Post extends BaseObject
 			if ($item["event-id"] != 0) {
 				$edpost = ["events/event/" . $item['event-id'], L10n::t("Edit")];
 			} else {
-				$edpost = ["editpost/" . $item['id'], L10n::t("Edit")];
+				$edpost = ["editpost/" . $item['id'] . "/" . base64_encode($a->cmd), L10n::t("Edit")];
 			}
 			$dropping = in_array($item['uid'], [0, local_user()]);
 		} else {


### PR DESCRIPTION
Resubmit pull request for #3897 .
I calculate in `mod/message` and `mod/edipost` the correct return_url. 
Since there are many places from which you can edit a post I added the return_url as a GET parameter in the function call encoded in bas64 because the curl could contain subdirs like in `/profile/[user]`