### PR TITLE
Hopefully fixes relocations that hadn't been executed

### DIFF
--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -1164,12 +1164,12 @@ class DFRN
 	 * @return int Deliver status. Negative values mean an error.
 	 * @todo Add array type-hint for $owner, $contact
 	 */
-	public static function deliver($owner, $contact, $atom, $dissolve = false)
+	public static function deliver($owner, $contact, $atom, $dissolve = false, $legacy_transport = false)
 	{
 		$a = get_app();
 
 		// At first try the Diaspora transport layer
-		if (!$dissolve) {
+		if (!$dissolve && !$legacy_transport) {
 			$ret = self::transmit($owner, $contact, $atom);
 			if ($ret >= 200) {
 				logger('Delivery via Diaspora transport layer was successful with status ' . $ret);

--- a/src/Worker/Delivery.php
+++ b/src/Worker/Delivery.php
@@ -292,8 +292,10 @@ class Delivery extends BaseObject
 				self::deliverDiaspora($cmd, $contact, $owner, $items, $target_item, $public_message, $top_level, $followup);
 				return;
 			}
-		} else {
+		} elseif ($cmd != self::RELOCATION) {
 			$deliver_status = DFRN::deliver($owner, $contact, $atom);
+		} else {
+			$deliver_status = DFRN::deliver($owner, $contact, $atom, false, true);
 		}
 
 		logger('Delivery to ' . $contact["url"] . ' with guid ' . $target_item["guid"] . ' returns ' . $deliver_status);


### PR DESCRIPTION
Yesterday a user had tried to move to another location. The relocation message hadn't been executed at the receivers. Hopefully this fixes it - but for sure it can't make this worse.