### PR TITLE
[frio] Get PHP Configuration for upload limit and display in /admin summary site

### DIFF
--- a/mod/admin.php
+++ b/mod/admin.php
@@ -908,6 +908,7 @@ function admin_page_summary(App $a)
 
 	$queues = ['label' => L10n::t('Message queues'), 'queue' => $queue, 'workerq' => $workerqueue];
 
+	$php_settings = [L10n::t('PHP Values'), ['upload_max_filesize' => ini_get('upload_max_filesize'), 'post_max_size' => ini_get('post_max_size'), 'memory_limit' => ini_get('memory_limit')]];
 
 	$t = get_markup_template('admin/summary.tpl');
 	return replace_macros($t, [
@@ -923,6 +924,7 @@ function admin_page_summary(App $a)
 		'$codename' => FRIENDICA_CODENAME,
 		'$build' => Config::get('system', 'build'),
 		'$addons' => [L10n::t('Active addons'), $a->addons],
+		'$php' => $php_settings,
 		'$showwarning' => $showwarning,
 		'$warningtext' => $warningtext
 	]);

--- a/mod/admin.php
+++ b/mod/admin.php
@@ -908,7 +908,15 @@ function admin_page_summary(App $a)
 
 	$queues = ['label' => L10n::t('Message queues'), 'queue' => $queue, 'workerq' => $workerqueue];
 
-	$php_settings = [L10n::t('PHP Values'), ['upload_max_filesize' => ini_get('upload_max_filesize'), 'post_max_size' => ini_get('post_max_size'), 'memory_limit' => ini_get('memory_limit')]];
+
+	$r = q("SHOW variables LIKE 'max_allowed_packet'");
+	$max_allowed_packet = (($r) ? $r[0]['Value'] : 0);
+
+	$server_settings = ['label' => L10n::t('Server Settings'), 
+				'php' => ['upload_max_filesize' => ini_get('upload_max_filesize'), 
+						  'post_max_size' => ini_get('post_max_size'), 
+						  'memory_limit' => ini_get('memory_limit')], 
+				'mysql' => ['max_allowed_packet' => $max_allowed_packet]];
 
 	$t = get_markup_template('admin/summary.tpl');
 	return replace_macros($t, [
@@ -924,7 +932,7 @@ function admin_page_summary(App $a)
 		'$codename' => FRIENDICA_CODENAME,
 		'$build' => Config::get('system', 'build'),
 		'$addons' => [L10n::t('Active addons'), $a->addons],
-		'$php' => $php_settings,
+		'$serversettings' => $server_settings,
 		'$showwarning' => $showwarning,
 		'$warningtext' => $warningtext
 	]);

--- a/view/templates/admin/summary.tpl
+++ b/view/templates/admin/summary.tpl
@@ -44,5 +44,22 @@
 		<dd> {{$platform}} '{{$codename}}' {{$version.1}} - {{$build}}</dt>
 	</dl>
 
+	<dl>
+		<dt>{{$serversettings.label}}</dt>
+		<dd>
+			<table>
+				<tbody>
+					<tr><td colspan="2"><b>PHP</b></td></tr>
+					{{foreach $serversettings.php as $k => $p}}
+						<tr><td>{{$k}}</td><td>{{$p}}</td></tr>
+					{{/foreach}}
+					<tr><td colspan="2"><b>MySQL / MariaDB</b></td></tr>
+					{{foreach $serversettings.mysql as $k => $p}}
+						<tr><td>{{$k}}</td><td>{{$p}}</td></tr>
+					{{/foreach}}
+				</tbody>
+			</table>
+		</dd>
+	</dl>
 
 </div>

--- a/view/theme/frio/templates/admin/summary.tpl
+++ b/view/theme/frio/templates/admin/summary.tpl
@@ -58,15 +58,19 @@
 			<div class="col-lg-8 col-md-8 col-sm-8 col-xs-12 admin-summary-entry">{{$platform}} '{{$codename}}' {{$version.1}} - {{$build}}</div>
 		</div>
 
-		{{* PHP Values. *}}
+		{{* Server Settings. *}}
 		<div id="admin-summary-php" class="col-lg-12 col-md-12 col-sm-12 col-xs-12 admin-summary">
 			<hr class="admin-summary-separator">
-			<div class="col-lg-4 col-md-4 col-sm-4 col-xs-12 admin-summary-label-name text-muted">{{$php.0}}</div>
+			<div class="col-lg-4 col-md-4 col-sm-4 col-xs-12 admin-summary-label-name text-muted">{{$serversettings.label}}</div>
 			<div class="col-lg-8 col-md-8 col-sm-8 col-xs-12 admin-summary-entry">
 				<table class="table">
-				<thead><tr><td>Configuration</td><td>Value</td></tr></thead>
 				<tbody>
-					{{foreach $php.1 as $k => $p}}
+					<tr class="info"><td colspan="2">PHP</td></tr>
+					{{foreach $serversettings.php as $k => $p}}
+						<tr><td>{{$k}}</td><td>{{$p}}</td></tr>
+					{{/foreach}}
+					<tr class="info"><td colspan="2">MySQL / MariaDB</td></tr>
+					{{foreach $serversettings.mysql as $k => $p}}
 						<tr><td>{{$k}}</td><td>{{$p}}</td></tr>
 					{{/foreach}}
 				</tbody>

--- a/view/theme/frio/templates/admin/summary.tpl
+++ b/view/theme/frio/templates/admin/summary.tpl
@@ -64,13 +64,13 @@
 			<div class="col-lg-4 col-md-4 col-sm-4 col-xs-12 admin-summary-label-name text-muted">{{$php.0}}</div>
 			<div class="col-lg-8 col-md-8 col-sm-8 col-xs-12 admin-summary-entry">
 				<table class="table">
-	                <thead><tr><td>Configuration</td><td>Value</td></tr></thead>
-	                <tbody>
-	                {{foreach $php.1 as $k => $p}}
-		                <tr><td>{{$k}}</td><td>{{$p}}</td></tr>
-	                {{/foreach}}
-	                </tbody>
-                </table>
+				<thead><tr><td>Configuration</td><td>Value</td></tr></thead>
+				<tbody>
+					{{foreach $php.1 as $k => $p}}
+						<tr><td>{{$k}}</td><td>{{$p}}</td></tr>
+					{{/foreach}}
+				</tbody>
+				</table>
 			</div>
 		</div>
 

--- a/view/theme/frio/templates/admin/summary.tpl
+++ b/view/theme/frio/templates/admin/summary.tpl
@@ -57,6 +57,23 @@
 			<div class="col-lg-4 col-md-4 col-sm-4 col-xs-12 admin-summary-label-name text-muted">{{$version.0}}</div>
 			<div class="col-lg-8 col-md-8 col-sm-8 col-xs-12 admin-summary-entry">{{$platform}} '{{$codename}}' {{$version.1}} - {{$build}}</div>
 		</div>
+
+		{{* PHP Values. *}}
+		<div id="admin-summary-php" class="col-lg-12 col-md-12 col-sm-12 col-xs-12 admin-summary">
+			<hr class="admin-summary-separator">
+			<div class="col-lg-4 col-md-4 col-sm-4 col-xs-12 admin-summary-label-name text-muted">{{$php.0}}</div>
+			<div class="col-lg-8 col-md-8 col-sm-8 col-xs-12 admin-summary-entry">
+				<table class="table">
+	                <thead><tr><td>Configuration</td><td>Value</td></tr></thead>
+	                <tbody>
+	                {{foreach $php.1 as $k => $p}}
+		                <tr><td>{{$k}}</td><td>{{$p}}</td></tr>
+	                {{/foreach}}
+	                </tbody>
+                </table>
+			</div>
+		</div>
+
 	</div>
 
 	<div class="clear"></div>


### PR DESCRIPTION
According to #5547 I get the PHP configuration values for upload limits and display them in the /admin summary site.

I still do not know how to adjust these values reliable (see https://github.com/friendica/friendica/issues/5547#issuecomment-425041824).

Does the place where I put the table fits?