### PR TITLE
Update return path former via $_SESSION['return_url']

### DIFF
--- a/mod/contacts.php
+++ b/mod/contacts.php
@@ -168,11 +168,7 @@ function contacts_batch_actions(App $a)
 		info(L10n::tt("%d contact edited.", "%d contacts edited.", $count_actions));
 	}
 
-	if (x($_SESSION, 'return_url')) {
-		goaway('' . $_SESSION['return_url']);
-	} else {
-		goaway('contacts');
-	}
+	goaway('contacts');
 }
 
 function contacts_post(App $a)
@@ -476,20 +472,13 @@ function contacts_content(App $a, $update = 0)
 			}
 			// Now check how the user responded to the confirmation query
 			if (x($_REQUEST, 'canceled')) {
-				if (x($_SESSION, 'return_url')) {
-					goaway('' . $_SESSION['return_url']);
-				} else {
-					goaway('contacts');
-				}
+				goaway('contacts');
 			}
 
 			_contact_drop($orig_record);
 			info(L10n::t('Contact has been removed.') . EOL);
-			if (x($_SESSION, 'return_url')) {
-				goaway('' . $_SESSION['return_url']);
-			} else {
-				goaway('contacts');
-			}
+			
+			goaway('contacts');
 			return; // NOTREACHED
 		}
 		if ($cmd === 'posts') {

--- a/mod/follow.php
+++ b/mod/follow.php
@@ -25,7 +25,7 @@ function follow_post(App $a)
 
 	$uid = local_user();
 	$url = notags(trim($_REQUEST['url']));
-	$return_url = $_SESSION['return_url'];
+	$return_url = 'contacts';
 
 	// Makes the connection request for friendica contacts easier
 	// This is just a precaution if maybe this page is called somewhere directly via POST
@@ -39,7 +39,7 @@ function follow_post(App $a)
 		}
 		goaway($return_url);
 	} elseif ($result['cid']) {
-		goaway(System::baseUrl() . '/contacts/' . $result['cid']);
+		goaway('contacts/' . $result['cid']);
 	}
 
 	info(L10n::t('The contact could not be added.'));
@@ -50,9 +50,11 @@ function follow_post(App $a)
 
 function follow_content(App $a)
 {
+	$return_url = 'contacts';
+
 	if (!local_user()) {
 		notice(L10n::t('Permission denied.'));
-		goaway($_SESSION['return_url']);
+		goaway($return_url);
 		// NOTREACHED
 	}
 
@@ -116,7 +118,7 @@ function follow_content(App $a)
 
 	if (!$r) {
 		notice(L10n::t('Permission denied.'));
-		goaway($_SESSION['return_url']);
+		goaway($return_url);
 		// NOTREACHED
 	}
 

--- a/mod/follow.php
+++ b/mod/follow.php
@@ -20,7 +20,7 @@ function follow_post(App $a)
 	}
 
 	if (isset($_REQUEST['cancel'])) {
-		goaway($_SESSION['return_url']);
+		goaway('contacts');
 	}
 
 	$uid = local_user();

--- a/mod/message.php
+++ b/mod/message.php
@@ -181,7 +181,7 @@ function message_content(App $a)
 				goaway('/message');
 			}
 
-			goaway('/message/' . $conversation'id'] );
+			goaway('/message/' . $conversation['id'] );
 		} else {
 			$r = q("SELECT `parent-uri`,`convid` FROM `mail` WHERE `id` = %d AND `uid` = %d LIMIT 1",
 				intval($a->argv[2]),

--- a/mod/message.php
+++ b/mod/message.php
@@ -165,9 +165,9 @@ function message_content(App $a)
 
 		$cmd = $a->argv[1];
 		if ($cmd === 'drop') {
-			$r = DBA::SelectFirst('mail', ['convid'], ['id' => $a->argv[2], 'uid' => local_user()]);
+			$message = DBA::selectFirst('mail', ['convid'], ['id' => $a->argv[2], 'uid' => local_user()]);
 			if(!DBA::isResult($r)){
-				info(L10n::t('Conversation not founded.') . EOL);
+				info(L10n::t('Conversation not found.') . EOL);
 				goaway('/message');
 			}
 
@@ -175,13 +175,13 @@ function message_content(App $a)
 				info(L10n::t('Message deleted.') . EOL);
 			}
 
-			$rr = DBA::SelectFirst('mail', ['id'], ['convid' => $r['convid'], 'uid' => local_user()]);
-			if(!DBA::isResult($rr)){
+			$conversation = DBA::selectFirst('mail', ['id'], ['convid' => $message['convid'], 'uid' => local_user()]);
+			if(!DBA::isResult($conversation)){
 				info(L10n::t('Conversation removed.') . EOL);
 				goaway('/message');
 			}
 
-			goaway('/message/'.$rr['id'] );
+			goaway('/message/' . $conversation'id'] );
 		} else {
 			$r = q("SELECT `parent-uri`,`convid` FROM `mail` WHERE `id` = %d AND `uid` = %d LIMIT 1",
 				intval($a->argv[2]),

--- a/mod/message.php
+++ b/mod/message.php
@@ -160,7 +160,7 @@ function message_content(App $a)
 
 		// Now check how the user responded to the confirmation query
 		if (!empty($_REQUEST['canceled'])) {
-			goaway($_SESSION['return_url']);
+			goaway('/message');
 		}
 
 		$cmd = $a->argv[1];
@@ -169,8 +169,7 @@ function message_content(App $a)
 				info(L10n::t('Message deleted.') . EOL);
 			}
 
-			//goaway(System::baseUrl(true) . '/message' );
-			goaway($_SESSION['return_url']);
+			goaway('/message' );
 		} else {
 			$r = q("SELECT `parent-uri`,`convid` FROM `mail` WHERE `id` = %d AND `uid` = %d LIMIT 1",
 				intval($a->argv[2]),
@@ -184,8 +183,7 @@ function message_content(App $a)
 					info(L10n::t('Conversation removed.') . EOL);
 				}
 			}
-			//goaway(System::baseUrl(true) . '/message' );
-			goaway($_SESSION['return_url']);
+			goaway('/message' );
 		}
 	}
 

--- a/mod/message.php
+++ b/mod/message.php
@@ -165,11 +165,23 @@ function message_content(App $a)
 
 		$cmd = $a->argv[1];
 		if ($cmd === 'drop') {
+			$r = DBA::SelectFirst('mail', ['convid'], ['id' => $a->argv[2], 'uid' => local_user()]);
+			if(!DBA::isResult($r)){
+				info(L10n::t('Conversation not founded.') . EOL);
+				goaway('/message');
+			}
+
 			if (DBA::delete('mail', ['id' => $a->argv[2], 'uid' => local_user()])) {
 				info(L10n::t('Message deleted.') . EOL);
 			}
 
-			goaway('/message' );
+			$rr = DBA::SelectFirst('mail', ['id'], ['convid' => $r['convid'], 'uid' => local_user()]);
+			if(!DBA::isResult($rr)){
+				info(L10n::t('Conversation removed.') . EOL);
+				goaway('/message');
+			}
+
+			goaway('/message/'.$rr['id'] );
 		} else {
 			$r = q("SELECT `parent-uri`,`convid` FROM `mail` WHERE `id` = %d AND `uid` = %d LIMIT 1",
 				intval($a->argv[2]),

--- a/mod/message.php
+++ b/mod/message.php
@@ -166,7 +166,7 @@ function message_content(App $a)
 		$cmd = $a->argv[1];
 		if ($cmd === 'drop') {
 			$message = DBA::selectFirst('mail', ['convid'], ['id' => $a->argv[2], 'uid' => local_user()]);
-			if(!DBA::isResult($r)){
+			if(!DBA::isResult($message)){
 				info(L10n::t('Conversation not found.') . EOL);
 				goaway('/message');
 			}

--- a/mod/unfollow.php
+++ b/mod/unfollow.php
@@ -18,12 +18,8 @@ function unfollow_post()
 
 	if (!local_user()) {
 		notice(L10n::t('Permission denied.'));
-		goaway($return_url);
+		goaway('/login');
 		// NOTREACHED
-	}
-
-	if (!empty($_REQUEST['cancel'])) {
-		goaway($return_url);
 	}
 
 	$uid = local_user();
@@ -40,9 +36,13 @@ function unfollow_post()
 		// NOTREACHED
 	}
 
+	if (!empty($_REQUEST['cancel'])) {
+		goaway($return_url . '/' . $contact['id']);
+	}
+
 	if (!in_array($contact['network'], Protocol::NATIVE_SUPPORT)) {
 		notice(L10n::t('Unfollowing is currently not supported by your network.'));
-		goaway($return_url.'/'.$contact['id']);
+		goaway($return_url . '/' . $contact['id']);
 		// NOTREACHED
 	}
 
@@ -73,7 +73,7 @@ function unfollow_content(App $a)
 
 	if (!local_user()) {
 		notice(L10n::t('Permission denied.'));
-		goaway($return_url);
+		goaway('/login');
 		// NOTREACHED
 	}
 

--- a/mod/unfollow.php
+++ b/mod/unfollow.php
@@ -14,7 +14,7 @@ use Friendica\Model\User;
 
 function unfollow_post()
 {
-	$return_url = $_SESSION['return_url'];
+	$return_url = 'contacts';
 
 	if (!local_user()) {
 		notice(L10n::t('Permission denied.'));
@@ -42,7 +42,7 @@ function unfollow_post()
 
 	if (!in_array($contact['network'], Protocol::NATIVE_SUPPORT)) {
 		notice(L10n::t('Unfollowing is currently not supported by your network.'));
-		goaway($return_url);
+		goaway($return_url.'/'.$contact['id']);
 		// NOTREACHED
 	}
 
@@ -69,9 +69,11 @@ function unfollow_post()
 
 function unfollow_content(App $a)
 {
+	$return_url = 'contacts';
+
 	if (!local_user()) {
 		notice(L10n::t('Permission denied.'));
-		goaway($_SESSION['return_url']);
+		goaway($return_url);
 		// NOTREACHED
 	}
 
@@ -86,7 +88,7 @@ function unfollow_content(App $a)
 
 	if (!DBA::isResult($contact)) {
 		notice(L10n::t("You aren't following this contact."));
-		goaway('contacts');
+		goaway($return_url);
 		// NOTREACHED
 	}
 
@@ -103,7 +105,7 @@ function unfollow_content(App $a)
 
 	if (!DBA::isResult($self)) {
 		notice(L10n::t('Permission denied.'));
-		goaway($_SESSION['return_url']);
+		goaway($return_url);
 		// NOTREACHED
 	}
 


### PR DESCRIPTION
Following #3897 I changed the return path in

- `/contacts` (including batch action)
- `/unfollow` / `/follow`
- `/message`

Files I have problem with, because I couldn't determine from where it can be called:

- `/include/items`
- `/mod/filterm`

Also I'm troubling with testing my changes because it is hard to reproduce situations like

	if (!local_user()) {
		notice(L10n::t('Permission denied.'));
		goaway($return_url);
		// NOTREACHED
	}

Is there any tool to test things like that or how would I do it ?
