### PR TITLE
Repeated posts from OStatus, ActitivyPub and Twitter are now shown as is

### DIFF
--- a/include/api.php
+++ b/include/api.php
@@ -4827,8 +4827,18 @@ function api_share_as_retweet(&$item)
 {
 	$body = trim($item["body"]);
 
-	if (Diaspora::isReshare($body, false)===false) {
-		return false;
+	if (Diaspora::isReshare($body, false) === false) {
+		if ($item['author-id'] == $item['owner-id']) {
+			return false;
+		} else {
+			// Reshares from OStatus, ActivityPub and Twitter
+			$reshared_item = $item;
+			$reshared_item['owner-id'] = $reshared_item['author-id'];
+			$reshared_item['owner-link'] = $reshared_item['author-link'];
+			$reshared_item['owner-name'] = $reshared_item['author-name'];
+			$reshared_item['owner-avatar'] = $reshared_item['author-avatar'];
+			return $reshared_item;
+		}
 	}
 
 	/// @TODO "$1" should maybe mean '$1' ?


### PR DESCRIPTION
This is related to https://github.com/friendica/friendica/pull/5804

Until now we only showed repeated posts from Friendica and Diaspora in the API. 