### PR TITLE
Following a soapbox now works / rapid follow/unfollow should work now

### DIFF
--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -1917,6 +1917,12 @@ class Contact extends BaseObject
 			} elseif (DBA::isResult($user) && in_array($user['page-flags'], [self::PAGE_SOAPBOX, self::PAGE_FREELOVE, self::PAGE_COMMUNITY])) {
 				$condition = ['uid' => $importer['uid'], 'url' => $url, 'pending' => true];
 				DBA::update('contact', ['pending' => false], $condition);
+
+				$contact = DBA::selectFirst('contact', ['url', 'network', 'hub-verify'], ['id' => $contact_record['id']]);
+
+				if ($contact['network'] == Protocol::ACTIVITYPUB) {
+					ActivityPub\Transmitter::sendContactAccept($contact['url'], $contact['hub-verify'], $importer['uid']);
+				}
 			}
 		}
 	}

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -283,7 +283,7 @@ class Processor
 
 		$cid = Contact::getIdForURL($activity['owner'], $uid);
 		if (!empty($cid)) {
-			$contact = DBA::selectFirst('contact', [], ['id' => $cid]);
+			$contact = DBA::selectFirst('contact', [], ['id' => $cid, 'network' => Protocol::NATIVE_SUPPORT]);
 		} else {
 			$contact = false;
 		}


### PR DESCRIPTION
Two AP bugfixes:

1. When an AP user wanted to follow a soapbox, no contact accept message had been sent back.
2. Rapid unfollow/follow from a remote user hadn't worked well, since the old contact hadn't possibly been deleted in that time.