### PR TITLE
Improved AP distribution / Only process trusted content

### DIFF
--- a/src/Protocol/ActivityPub/Receiver.php
+++ b/src/Protocol/ActivityPub/Receiver.php
@@ -208,6 +208,7 @@ class Receiver
 
 		if (!$trust_source) {
 			logger('No trust for activity type "' . $activity['type'] . '", so we quit now.', LOGGER_DEBUG);
+			return;
 		}
 
 		switch ($activity['type']) {

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -773,7 +773,7 @@ class Transmitter
 		$data['context'] = self::fetchContextURLForItem($item);
 
 		if (!empty($item['title'])) {
-			$data['name'] = BBCode::convert($item['title'], false, 7);
+			$data['name'] = BBCode::toPlaintext($item['title'], false);
 		}
 
 		$body = $item['body'];


### PR DESCRIPTION
Bugfix: When we don't trust the source, we mustn't continue.

And: we should only distribute content that is from our system or that we do have as conversation entry.

Edit: It additionally fixes issue https://github.com/tootsuite/mastodon/issues/8902