### PR TITLE
friendica-5847 Console Cache List command doesn't work

### DIFF
--- a/src/Core/Cache.php
+++ b/src/Core/Cache.php
@@ -53,7 +53,7 @@ class Cache extends \Friendica\BaseObject
 	 *
 	 * @param string $prefix Prefix of the keys (optional)
 	 *
-	 * @return array|null Null if the driver doesn't support this feature
+	 * @return array Empty if the driver doesn't support this feature
 	 */
 	public static function getAllKeys($prefix = null)
 	{

--- a/src/Core/Cache.php
+++ b/src/Core/Cache.php
@@ -51,20 +51,15 @@ class Cache extends \Friendica\BaseObject
 	/**
 	 * @brief Returns all the cache keys sorted alphabetically
 	 *
+	 * @param string $prefix Prefix of the keys (optional)
+	 *
 	 * @return array|null Null if the driver doesn't support this feature
 	 */
-	public static function getAllKeys()
+	public static function getAllKeys($prefix = null)
 	{
 		$time = microtime(true);
 
-		$return = self::getDriver()->getAllKeys();
-
-		// Keys are prefixed with the node hostname, let's remove it
-		array_walk($return, function (&$value) {
-			$value = preg_replace('/^' . self::getApp()->get_hostname() . ':/', '', $value);
-		});
-
-		sort($return);
+		$return = self::getDriver()->getAllKeys($prefix);
 
 		self::getApp()->save_timestamp($time, 'cache');
 

--- a/src/Core/Cache/AbstractCacheDriver.php
+++ b/src/Core/Cache/AbstractCacheDriver.php
@@ -17,8 +17,55 @@ abstract class AbstractCacheDriver extends BaseObject
 	 * @param string $key	The original key
 	 * @return string		The cache key used for the cache
 	 */
-	protected function getCacheKey($key) {
+	protected function getCacheKey($key)
+	{
 		// We fetch with the hostname as key to avoid problems with other applications
 		return self::getApp()->get_hostname() . ":" . $key;
+	}
+
+	/**
+	 * @param array $keys   A list of cached keys
+	 * @return array        A list of original keys
+	 */
+	protected function getOriginalKeys($keys)
+	{
+		if (empty($keys)) {
+			return [];
+		} else {
+			// Keys are prefixed with the node hostname, let's remove it
+			array_walk($keys, function (&$value) {
+				$value = preg_replace('/^' . self::getApp()->get_hostname() . ':/', '', $value);
+			});
+
+			sort($keys);
+
+			return $keys;
+		}
+	}
+
+	/**
+	 * Filters a list for a given prefix
+	 *
+	 * @param array $list the list
+	 * @param string|null $prefix the prefix
+	 *
+	 * @return array the filtered list
+	 */
+	protected function filterPrefix($list, $prefix = null)
+	{
+		if (empty($prefix)) {
+			return array_keys($list);
+		} else {
+			$result = [];
+
+			foreach (array_keys($list) as $key) {
+				if (strpos($key, $prefix) === 0) {
+					array_push($result, $key);
+				}
+			}
+
+			return $result;
+		}
+
 	}
 }

--- a/src/Core/Cache/AbstractCacheDriver.php
+++ b/src/Core/Cache/AbstractCacheDriver.php
@@ -44,21 +44,22 @@ abstract class AbstractCacheDriver extends BaseObject
 	}
 
 	/**
-	 * Filters a list for a given prefix
+	 * Filters the keys of an array with a given prefix
+	 * Returns the filtered keys as an new array
 	 *
-	 * @param array $list the list
-	 * @param string|null $prefix the prefix
+	 * @param array $array The array, which should get filtered
+	 * @param string|null $prefix The prefix (if null, all keys will get returned)
 	 *
-	 * @return array the filtered list
+	 * @return array The filtered array with just the keys
 	 */
-	protected function filterPrefix($list, $prefix = null)
+	protected function filterArrayKeysByPrefix($array, $prefix = null)
 	{
 		if (empty($prefix)) {
-			return array_keys($list);
+			return array_keys($array);
 		} else {
 			$result = [];
 
-			foreach (array_keys($list) as $key) {
+			foreach (array_keys($array) as $key) {
 				if (strpos($key, $prefix) === 0) {
 					array_push($result, $key);
 				}

--- a/src/Core/Cache/ArrayCache.php
+++ b/src/Core/Cache/ArrayCache.php
@@ -22,9 +22,9 @@ class ArrayCache extends AbstractCacheDriver implements IMemoryCacheDriver
 	/**
 	 * (@inheritdoc)
 	 */
-	public function getAllKeys()
+	public function getAllKeys($prefix = null)
 	{
-		return array_keys($this->cachedData);
+		return $this->filterPrefix($this->cachedData, $prefix);
 	}
 
 	/**

--- a/src/Core/Cache/ArrayCache.php
+++ b/src/Core/Cache/ArrayCache.php
@@ -24,7 +24,7 @@ class ArrayCache extends AbstractCacheDriver implements IMemoryCacheDriver
 	 */
 	public function getAllKeys($prefix = null)
 	{
-		return $this->filterPrefix($this->cachedData, $prefix);
+		return $this->filterArrayKeysByPrefix($this->cachedData, $prefix);
 	}
 
 	/**

--- a/src/Core/Cache/DatabaseCacheDriver.php
+++ b/src/Core/Cache/DatabaseCacheDriver.php
@@ -21,18 +21,18 @@ class DatabaseCacheDriver extends AbstractCacheDriver implements ICacheDriver
 		if (empty($prefix)) {
 			$where = ['`expires` >= ?', DateTimeFormat::utcNow()];
 		} else {
-			$where = ['`expires` >= ? AND k LIKE CONCAT(?, \'%\')', DateTimeFormat::utcNow(), $prefix];
+			$where = ['`expires` >= ? AND `k` LIKE CONCAT(?, \'%\')', DateTimeFormat::utcNow(), $prefix];
 		}
 
 		$stmt = DBA::select('cache', ['k'], $where);
 
-		$list = [];
+		$keys = [];
 		while ($key = DBA::fetch($stmt)) {
-			array_push($list, $key['k']);
+			array_push($keys, $key['k']);
 		}
 		DBA::close($stmt);
 
-		return $list;
+		return $keys;
 	}
 
 	/**

--- a/src/Core/Cache/DatabaseCacheDriver.php
+++ b/src/Core/Cache/DatabaseCacheDriver.php
@@ -16,11 +16,23 @@ class DatabaseCacheDriver extends AbstractCacheDriver implements ICacheDriver
 	/**
 	 * (@inheritdoc)
 	 */
-	public function getAllKeys()
+	public function getAllKeys($prefix = null)
 	{
-		$stmt = DBA::select('cache', ['k'], ['`expires` >= ?', DateTimeFormat::utcNow()]);
+		if (empty($prefix)) {
+			$where = ['`expires` >= ?', DateTimeFormat::utcNow()];
+		} else {
+			$where = ['`expires` >= ? AND k LIKE CONCAT(?, \'%\')', DateTimeFormat::utcNow(), $prefix];
+		}
 
-		return DBA::toArray($stmt);
+		$stmt = DBA::select('cache', ['k'], $where);
+
+		$list = [];
+		while ($key = DBA::fetch($stmt)) {
+			array_push($list, $key['k']);
+		}
+		DBA::close($stmt);
+
+		return $list;
 	}
 
 	/**

--- a/src/Core/Cache/ICacheDriver.php
+++ b/src/Core/Cache/ICacheDriver.php
@@ -14,9 +14,11 @@ interface ICacheDriver
 	/**
 	 * Lists all cache keys
 	 *
+	 * @param string prefix optional a prefix to search
+	 *
 	 * @return array|null Null if it isn't supported by the cache driver
 	 */
-	public function getAllKeys();
+	public function getAllKeys($prefix = null);
 
 	/**
 	 * Fetches cached data according to the key

--- a/src/Core/Cache/ICacheDriver.php
+++ b/src/Core/Cache/ICacheDriver.php
@@ -16,7 +16,7 @@ interface ICacheDriver
 	 *
 	 * @param string prefix optional a prefix to search
 	 *
-	 * @return array|null Null if it isn't supported by the cache driver
+	 * @return array Empty if it isn't supported by the cache driver
 	 */
 	public function getAllKeys($prefix = null);
 

--- a/src/Core/Cache/MemcacheCacheDriver.php
+++ b/src/Core/Cache/MemcacheCacheDriver.php
@@ -45,23 +45,23 @@ class MemcacheCacheDriver extends AbstractCacheDriver implements IMemoryCacheDri
 	 */
 	public function getAllKeys($prefix = null)
 	{
-		$list = [];
+		$keys = [];
 		$allSlabs = $this->memcache->getExtendedStats('slabs');
 		foreach ($allSlabs as $slabs) {
 			foreach (array_keys($slabs) as $slabId) {
 				$cachedump = $this->memcache->getExtendedStats('cachedump', (int)$slabId);
-				foreach ($cachedump as $keys => $arrVal) {
+				foreach ($cachedump as $key => $arrVal) {
 					if (!is_array($arrVal)) {
 						continue;
 					}
-					$list = array_merge($list, array_keys($arrVal));
+					$keys = array_merge($keys, array_keys($arrVal));
 				}
 			}
 		}
 
-		$list = $this->getOriginalKeys($list);
+		$keys = $this->getOriginalKeys($keys);
 
-		return $this->filterPrefix($list, $prefix);
+		return $this->filterArrayKeysByPrefix($keys, $prefix);
 	}
 
 	/**

--- a/src/Core/Cache/MemcacheCacheDriver.php
+++ b/src/Core/Cache/MemcacheCacheDriver.php
@@ -43,7 +43,7 @@ class MemcacheCacheDriver extends AbstractCacheDriver implements IMemoryCacheDri
 	/**
 	 * (@inheritdoc)
 	 */
-	public function getAllKeys()
+	public function getAllKeys($prefix = null)
 	{
 		$list = [];
 		$allSlabs = $this->memcache->getExtendedStats('slabs');
@@ -59,7 +59,9 @@ class MemcacheCacheDriver extends AbstractCacheDriver implements IMemoryCacheDri
 			}
 		}
 
-		return $list;
+		$list = $this->getOriginalKeys($list);
+
+		return $this->filterPrefix($list, $prefix);
 	}
 
 	/**

--- a/src/Core/Cache/MemcachedCacheDriver.php
+++ b/src/Core/Cache/MemcachedCacheDriver.php
@@ -41,9 +41,6 @@ class MemcachedCacheDriver extends AbstractCacheDriver implements IMemoryCacheDr
 
 		$this->memcached = new Memcached();
 
-
-		$this->memcached->setOption(Memcached::OPT_BINARY_PROTOCOL, false);
-
 		array_walk($memcached_hosts, function (&$value) {
 			if (is_string($value)) {
 				$value = array_map('trim', explode(',', $value));
@@ -68,7 +65,7 @@ class MemcachedCacheDriver extends AbstractCacheDriver implements IMemoryCacheDr
 			return $this->filterArrayKeysByPrefix($keys, $prefix);
 		} else {
 			logger('Memcached \'getAllKeys\' failed with ' . $this->memcached->getResultMessage(), LOGGER_ALL);
-			return [];
+			return null;
 		}
 	}
 
@@ -77,17 +74,19 @@ class MemcachedCacheDriver extends AbstractCacheDriver implements IMemoryCacheDr
 	 */
 	public function get($key)
 	{
+		$return = null;
 		$cachekey = $this->getCacheKey($key);
 
 		// We fetch with the hostname as key to avoid problems with other applications
 		$value = $this->memcached->get($cachekey);
 
 		if ($this->memcached->getResultCode() === Memcached::RES_SUCCESS) {
-			return $value;
+			$return = $value;
 		} else {
 			logger('Memcached \'get\' failed with ' . $this->memcached->getResultMessage(), LOGGER_ALL);
-			return [];
 		}
+
+		return $return;
 	}
 
 	/**

--- a/src/Core/Cache/MemcachedCacheDriver.php
+++ b/src/Core/Cache/MemcachedCacheDriver.php
@@ -65,7 +65,7 @@ class MemcachedCacheDriver extends AbstractCacheDriver implements IMemoryCacheDr
 			return $this->filterArrayKeysByPrefix($keys, $prefix);
 		} else {
 			logger('Memcached \'getAllKeys\' failed with ' . $this->memcached->getResultMessage(), LOGGER_ALL);
-			return null;
+			return [];
 		}
 	}
 

--- a/src/Core/Cache/MemcachedCacheDriver.php
+++ b/src/Core/Cache/MemcachedCacheDriver.php
@@ -5,6 +5,7 @@ namespace Friendica\Core\Cache;
 use Friendica\Core\Cache;
 
 use Exception;
+use Friendica\Network\HTTPException\InternalServerErrorException;
 use Memcached;
 
 /**
@@ -40,6 +41,9 @@ class MemcachedCacheDriver extends AbstractCacheDriver implements IMemoryCacheDr
 
 		$this->memcached = new Memcached();
 
+
+		$this->memcached->setOption(Memcached::OPT_BINARY_PROTOCOL, false);
+
 		array_walk($memcached_hosts, function (&$value) {
 			if (is_string($value)) {
 				$value = array_map('trim', explode(',', $value));
@@ -56,9 +60,15 @@ class MemcachedCacheDriver extends AbstractCacheDriver implements IMemoryCacheDr
 	/**
 	 * (@inheritdoc)
 	 */
-	public function getAllKeys()
+	public function getAllKeys($prefix = null)
 	{
-		return $this->memcached->getAllKeys();
+		// Doesn't work because of https://github.com/php-memcached-dev/php-memcached/issues/367
+		// returns everytime an empty array
+		throw new InternalServerErrorException('getAllKeys for Memcached not supported yet');
+
+		$list = $this->getOriginalKeys($this->memcached->getAllKeys());
+
+		return $this->filterPrefix($list, $prefix);
 	}
 
 	/**

--- a/src/Core/Cache/RedisCacheDriver.php
+++ b/src/Core/Cache/RedisCacheDriver.php
@@ -41,9 +41,17 @@ class RedisCacheDriver extends AbstractCacheDriver implements IMemoryCacheDriver
 	/**
 	 * (@inheritdoc)
 	 */
-	public function getAllKeys()
+	public function getAllKeys($prefix = null)
 	{
-		return null;
+		if (empty($prefix)) {
+			$search = '*';
+		} else {
+			$search = $prefix . '*';
+		}
+
+		$list = $this->redis->keys($this->getCacheKey($search));
+
+		return $this->getOriginalKeys($list);
 	}
 
 	/**

--- a/src/Core/Console/Cache.php
+++ b/src/Core/Console/Cache.php
@@ -115,10 +115,7 @@ HELP;
 
 		$count = 0;
 		foreach ($keys as $key) {
-			if (empty($prefix) || strpos($key, $prefix) === 0) {
-				$this->out($key);
-				$count++;
-			}
+			$this->out($key);
 		}
 
 		$this->out($count . ' keys found');

--- a/src/Core/Console/Cache.php
+++ b/src/Core/Console/Cache.php
@@ -105,7 +105,7 @@ HELP;
 	private function executeList()
 	{
 		$prefix = $this->getArgument(1);
-		$keys = Core\Cache::getAllKeys();
+		$keys = Core\Cache::getAllKeys($prefix);
 
 		if (empty($prefix)) {
 			$this->out('Listing all cache keys:');

--- a/src/Core/Console/Cache.php
+++ b/src/Core/Console/Cache.php
@@ -116,6 +116,7 @@ HELP;
 		$count = 0;
 		foreach ($keys as $key) {
 			$this->out($key);
+			$count++;
 		}
 
 		$this->out($count . ' keys found');

--- a/tests/src/Core/Cache/ArrayCacheDriverTest.php
+++ b/tests/src/Core/Cache/ArrayCacheDriverTest.php
@@ -7,11 +7,6 @@ use Friendica\Core\Cache\ArrayCache;
 
 class ArrayCacheDriverTest extends MemoryCacheTest
 {
-	/**
-	 * @var \Friendica\Core\Cache\IMemoryCacheDriver
-	 */
-	private $cache;
-
 	protected function getInstance()
 	{
 		$this->cache = new ArrayCache();

--- a/tests/src/Core/Cache/CacheTest.php
+++ b/tests/src/Core/Cache/CacheTest.php
@@ -2,6 +2,7 @@
 
 namespace Friendica\Test\src\Core\Cache;
 
+use Friendica\Core\Cache\MemcachedCacheDriver;
 use Friendica\Core\Config;
 use Friendica\Test\DatabaseTest;
 use Friendica\Util\DateTimeFormat;
@@ -12,6 +13,12 @@ abstract class CacheTest extends DatabaseTest
 	 * @var \Friendica\Core\Cache\ICacheDriver
 	 */
 	protected $instance;
+
+	/**
+	 * @var \Friendica\Core\Cache\IMemoryCacheDriver
+	 */
+	protected $cache;
+
 
 	abstract protected function getInstance();
 
@@ -29,6 +36,8 @@ abstract class CacheTest extends DatabaseTest
 		Config::set('system', 'throttle_limit_week', 100);
 		Config::set('system', 'throttle_limit_month', 100);
 		Config::set('system', 'theme', 'system_theme');
+
+		$this->instance->clear(false);
 	}
 
 	/**
@@ -176,5 +185,28 @@ abstract class CacheTest extends DatabaseTest
 		$this->instance->set('objVal', $value);
 		$received = $this->instance->get('objVal');
 		$this->assertEquals($value, $received, 'Value type changed from ' . gettype($value) . ' to ' . gettype($received));
+	}
+
+	/**
+	 * @small
+	 */
+	public function testGetAllKeys() {
+		if ($this->cache instanceof MemcachedCacheDriver) {
+			$this->markTestSkipped('Memcached doesn\'t support getAllKeys anymore');
+		}
+
+		$this->assertTrue($this->instance->set('value1', 'test'));
+		$this->assertTrue($this->instance->set('value2', 'test'));
+		$this->assertTrue($this->instance->set('test_value3', 'test'));
+
+		$list = $this->instance->getAllKeys();
+
+		$this->assertContains('value1', $list);
+		$this->assertContains('value2', $list);
+		$this->assertContains('test_value3', $list);
+
+		$list = $this->instance->getAllKeys('test');
+
+		$this->assertContains('test_value3', $list);
 	}
 }

--- a/tests/src/Core/Cache/DatabaseCacheDriverTest.php
+++ b/tests/src/Core/Cache/DatabaseCacheDriverTest.php
@@ -6,11 +6,6 @@ use Friendica\Core\Cache\CacheDriverFactory;
 
 class DatabaseCacheDriverTest extends CacheTest
 {
-	/**
-	 * @var \Friendica\Core\Cache\IMemoryCacheDriver
-	 */
-	private $cache;
-
 	protected function getInstance()
 	{
 		$this->cache = CacheDriverFactory::create('database');

--- a/tests/src/Core/Cache/MemcacheCacheDriverTest.php
+++ b/tests/src/Core/Cache/MemcacheCacheDriverTest.php
@@ -11,11 +11,6 @@ use Friendica\Core\Cache\CacheDriverFactory;
  */
 class MemcacheCacheDriverTest extends MemoryCacheTest
 {
-	/**
-	 * @var \Friendica\Core\Cache\IMemoryCacheDriver
-	 */
-	private $cache;
-
 	protected function getInstance()
 	{
 		$this->cache = CacheDriverFactory::create('memcache');

--- a/tests/src/Core/Cache/MemcachedCacheDriverTest.php
+++ b/tests/src/Core/Cache/MemcachedCacheDriverTest.php
@@ -11,11 +11,6 @@ use Friendica\Core\Cache\CacheDriverFactory;
  */
 class MemcachedCacheDriverTest extends MemoryCacheTest
 {
-	/**
-	 * @var \Friendica\Core\Cache\IMemoryCacheDriver
-	 */
-	private $cache;
-
 	protected function getInstance()
 	{
 		$this->cache = CacheDriverFactory::create('memcached');

--- a/tests/src/Core/Cache/RedisCacheDriverTest.php
+++ b/tests/src/Core/Cache/RedisCacheDriverTest.php
@@ -11,11 +11,6 @@ use Friendica\Core\Cache\CacheDriverFactory;
  */
 class RedisCacheDriverTest extends MemoryCacheTest
 {
-	/**
-	 * @var \Friendica\Core\Cache\IMemoryCacheDriver
-	 */
-	private $cache;
-
 	protected function getInstance()
 	{
 		$this->cache = CacheDriverFactory::create('redis');


### PR DESCRIPTION
- Added $prefix to all CacheDriver
- Moved hostname magic to CacheDriver
- Added test for getAllKeys()

fixing #5847 

Redis looked good:
```
root@docker /opt/friendica # docker-compose exec app php bin/console.php cache list oembed
Listing all cache keys starting with "oembed":
oembed:425:https://twitter.com/GiveMeInternet/status/1048644070317445120
oembed:622:https://ramblinggit.com/2018/10/reduced-posting-working-on-directory-project/
oembed:622:https://twitter.com/GiveMeInternet/status/1048644070317445120
oembed:622:https://twitter.com/Nazifresser/status/1048637600687427585
oembed:622:https://www.youtube.com/watch?v=D5vxabBmyyw&feature=youtu.be
5 keys found
```