### PR TITLE
Issue login redirect

### DIFF
--- a/mod/contacts.php
+++ b/mod/contacts.php
@@ -22,6 +22,7 @@ use Friendica\Network\Probe;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Proxy as ProxyUtils;
 use Friendica\Core\ACL;
+use Friendica\Module\Login;
 
 function contacts_init(App $a)
 {
@@ -374,8 +375,8 @@ function contacts_content(App $a, $update = 0)
 	Nav::setSelected('contacts');
 
 	if (!local_user()) {
-		notice(L10n::t('Permission denied.') . EOL);
-		return;
+		notice(L10n::t('Permission denied.') . EOL);		
+		return Login::form();
 	}
 
 	if ($a->argc == 3) {
@@ -471,7 +472,7 @@ function contacts_content(App $a, $update = 0)
 
 			_contact_drop($orig_record);
 			info(L10n::t('Contact has been removed.') . EOL);
-
+			
 			goaway('contacts');
 			return; // NOTREACHED
 		}
@@ -544,7 +545,7 @@ function contacts_content(App $a, $update = 0)
 		}
 		$lblsuggest = (($contact['network'] === Protocol::DFRN) ? L10n::t('Suggest friends') : '');
 
-		$poll_enabled = in_array($contact['network'], [Protocol::DFRN, Protocol::OSTATUS, Protocol::FEED, Protocol::MAIL]);
+		$poll_enabled = in_array($contact['network'], [Protocol::ACTIVITYPUB, Protocol::DFRN, Protocol::OSTATUS, Protocol::FEED, Protocol::MAIL]);
 
 		$nettype = L10n::t('Network type: %s', ContactSelector::networkToName($contact['network'], $contact["url"]));
 
@@ -635,15 +636,15 @@ function contacts_content(App $a, $update = 0)
 			'$follow_text' => $follow_text,
 			'$profile_select' => $profile_select,
 			'$contact_id' => $contact['id'],
-			'$block_text' => ($contact['blocked'] ? L10n::t('Unblock') : L10n::t('Block')),
-			'$ignore_text' => ($contact['readonly'] ? L10n::t('Unignore') : L10n::t('Ignore')),
-			'$insecure' => (in_array($contact['network'], [Protocol::ACTIVITYPUB, Protocol::DFRN, Protocol::MAIL, Protocol::DIASPORA]) ? '' : $insecure),
+			'$block_text' => (($contact['blocked']) ? L10n::t('Unblock') : L10n::t('Block') ),
+			'$ignore_text' => (($contact['readonly']) ? L10n::t('Unignore') : L10n::t('Ignore') ),
+			'$insecure' => (($contact['network'] !== Protocol::DFRN && $contact['network'] !== Protocol::MAIL && $contact['network'] !== Protocol::DIASPORA) ? $insecure : ''),
 			'$info' => $contact['info'],
 			'$cinfo' => ['info', '', $contact['info'], ''],
-			'$blocked' => ($contact['blocked'] ? L10n::t('Currently blocked') : ''),
-			'$ignored' => ($contact['readonly'] ? L10n::t('Currently ignored') : ''),
-			'$archived' => ($contact['archive'] ? L10n::t('Currently archived') : ''),
-			'$pending' => ($contact['pending'] ? L10n::t('Awaiting connection acknowledge') : ''),
+			'$blocked' => (($contact['blocked']) ? L10n::t('Currently blocked') : ''),
+			'$ignored' => (($contact['readonly']) ? L10n::t('Currently ignored') : ''),
+			'$archived' => (($contact['archive']) ? L10n::t('Currently archived') : ''),
+			'$pending' => (($contact['pending']) ? L10n::t('Awaiting connection acknowledge') : ''),
 			'$hidden' => ['hidden', L10n::t('Hide this contact from others'), ($contact['hidden'] == 1), L10n::t('Replies/likes to your public posts <strong>may</strong> still be visible')],
 			'$notify' => ['notify', L10n::t('Notification for new posts'), ($contact['notify_new_posts'] == 1), L10n::t('Send a notification of every new post of this contact')],
 			'$fetch_further_information' => $fetch_further_information,
@@ -1085,7 +1086,7 @@ function contact_actions($contact)
 	}
 
 	$contact_actions['block'] = [
-		'label' => (intval($contact['blocked']) ? L10n::t('Unblock') : L10n::t('Block')),
+		'label' => (intval($contact['blocked']) ? L10n::t('Unblock') : L10n::t('Block') ),
 		'url'   => 'contacts/' . $contact['id'] . '/block',
 		'title' => L10n::t('Toggle Blocked status'),
 		'sel'   => (intval($contact['blocked']) ? 'active' : ''),
@@ -1093,7 +1094,7 @@ function contact_actions($contact)
 	];
 
 	$contact_actions['ignore'] = [
-		'label' => (intval($contact['readonly']) ? L10n::t('Unignore') : L10n::t('Ignore')),
+		'label' => (intval($contact['readonly']) ? L10n::t('Unignore') : L10n::t('Ignore') ),
 		'url'   => 'contacts/' . $contact['id'] . '/ignore',
 		'title' => L10n::t('Toggle Ignored status'),
 		'sel'   => (intval($contact['readonly']) ? 'active' : ''),
@@ -1102,7 +1103,7 @@ function contact_actions($contact)
 
 	if ($contact['uid'] != 0) {
 		$contact_actions['archive'] = [
-			'label' => (intval($contact['archive']) ? L10n::t('Unarchive') : L10n::t('Archive')),
+			'label' => (intval($contact['archive']) ? L10n::t('Unarchive') : L10n::t('Archive') ),
 			'url'   => 'contacts/' . $contact['id'] . '/archive',
 			'title' => L10n::t('Toggle Archive status'),
 			'sel'   => (intval($contact['archive']) ? 'active' : ''),

--- a/mod/events.php
+++ b/mod/events.php
@@ -17,7 +17,7 @@ use Friendica\Model\Item;
 use Friendica\Model\Profile;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Temporal;
-use Friendica\Model\Login;
+use Friendica\Module\Login;
 
 require_once 'include/items.php';
 

--- a/mod/events.php
+++ b/mod/events.php
@@ -17,6 +17,7 @@ use Friendica\Model\Item;
 use Friendica\Model\Profile;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Temporal;
+use Friendica\Model\Login;
 
 require_once 'include/items.php';
 
@@ -193,7 +194,7 @@ function events_content(App $a)
 {
 	if (!local_user()) {
 		notice(L10n::t('Permission denied.') . EOL);
-		return;
+		return Login::form();
 	}
 
 	if ($a->argc == 1) {

--- a/mod/fsuggest.php
+++ b/mod/fsuggest.php
@@ -36,7 +36,7 @@ function fsuggest_post(App $a)
 
 	$hash = random_string();
 
-	$note = escape_tags(trim(defaults($_POST, 'note', '')));
+	$note = escape_tags(trim($_POST['note']));
 
 	if ($new_contact) {
 		$r = q("SELECT * FROM `contact` WHERE `id` = %d AND `uid` = %d LIMIT 1",

--- a/mod/message.php
+++ b/mod/message.php
@@ -16,6 +16,7 @@ use Friendica\Model\Mail;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Proxy as ProxyUtils;
 use Friendica\Util\Temporal;
+use Friendica\Module\Login;
 
 require_once 'include/conversation.php';
 
@@ -97,7 +98,7 @@ function message_content(App $a)
 
 	if (!local_user()) {
 		notice(L10n::t('Permission denied.') . EOL);
-		return;
+		return Login::form();
 	}
 
 	$myprofile = System::baseUrl() . '/profile/' . $a->user['nickname'];

--- a/mod/notifications.php
+++ b/mod/notifications.php
@@ -12,7 +12,7 @@ use Friendica\Core\NotificationsManager;
 use Friendica\Core\Protocol;
 use Friendica\Core\System;
 use Friendica\Database\DBA;
-use Friendica\Model\Login;
+use Friendica\Module\Login;
 
 function notifications_post(App $a)
 {

--- a/mod/notifications.php
+++ b/mod/notifications.php
@@ -12,6 +12,7 @@ use Friendica\Core\NotificationsManager;
 use Friendica\Core\Protocol;
 use Friendica\Core\System;
 use Friendica\Database\DBA;
+use Friendica\Model\Login;
 
 function notifications_post(App $a)
 {
@@ -65,7 +66,7 @@ function notifications_content(App $a)
 {
 	if (!local_user()) {
 		notice(L10n::t('Permission denied.') . EOL);
-		return;
+		return Login::form();
 	}
 
 	$page = defaults($_REQUEST, 'page', 1);

--- a/mod/profiles.php
+++ b/mod/profiles.php
@@ -20,6 +20,7 @@ use Friendica\Model\Profile;
 use Friendica\Network\Probe;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Temporal;
+use Friendica\Module\Login;
 
 function profiles_init(App $a) {
 
@@ -509,7 +510,7 @@ function profiles_content(App $a) {
 
 	if (! local_user()) {
 		notice(L10n::t('Permission denied.') . EOL);
-		return;
+		return Login::form();
 	}
 
 	$o = '';

--- a/mod/settings.php
+++ b/mod/settings.php
@@ -22,6 +22,7 @@ use Friendica\Model\User;
 use Friendica\Protocol\Email;
 use Friendica\Util\Network;
 use Friendica\Util\Temporal;
+use Friendica\Module\Login;
 
 function get_theme_config_file($theme)
 {
@@ -658,7 +659,7 @@ function settings_content(App $a)
 
 	if (!local_user()) {
 		//notice(L10n::t('Permission denied.') . EOL);
-		return;
+		return Login::form();
 	}
 
 	if (x($_SESSION, 'submanage') && intval($_SESSION['submanage'])) {

--- a/src/Module/Login.php
+++ b/src/Module/Login.php
@@ -47,7 +47,10 @@ class Login extends BaseModule
 
 	public static function post()
 	{
+		$return_url = $_SESSION['return_url'];
 		session_unset();
+		$_SESSION['return_url'] = $return_url;
+		
 		// OpenId Login
 		if (
 			empty($_POST['password'])

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -798,36 +798,6 @@ class Transmitter
 	}
 
 	/**
-	 * Transmits a contact suggestion to a given inbox
-	 *
-	 * @param integer $uid User ID
-	 * @param string $inbox Target inbox
-	 * @param integer $suggestion_id Suggestion ID
-	 */
-	public static function sendContactSuggestion($uid, $inbox, $suggestion_id)
-	{
-		$owner = User::getOwnerDataById($uid);
-		$profile = APContact::getByURL($owner['url']);
-
-		$suggestion = DBA::selectFirst('fsuggest', ['url', 'note', 'created'], ['id' => $suggestion_id]);
-
-		$data = ['@context' => 'https://www.w3.org/ns/activitystreams',
-			'id' => System::baseUrl() . '/activity/' . System::createGUID(),
-			'type' => 'Announce',
-			'actor' => $owner['url'],
-			'object' => $suggestion['url'],
-			'content' => $suggestion['note'],
-			'published' => DateTimeFormat::utc($suggestion['created'] . '+00:00', DateTimeFormat::ATOM),
-			'to' => [ActivityPub::PUBLIC_COLLECTION],
-			'cc' => []];
-
-		$signed = LDSignature::sign($data, $owner);
-
-		logger('Deliver profile deletion for user ' . $uid . ' to ' . $inbox . ' via ActivityPub', LOGGER_DEBUG);
-		HTTPSignature::transmit($signed, $inbox, $uid);
-	}
-
-	/**
 	 * Transmits a profile deletion to a given inbox
 	 *
 	 * @param integer $uid User ID

--- a/src/Worker/APDelivery.php
+++ b/src/Worker/APDelivery.php
@@ -25,7 +25,6 @@ class APDelivery extends BaseObject
 
 		if ($cmd == Delivery::MAIL) {
 		} elseif ($cmd == Delivery::SUGGESTION) {
-			ActivityPub\Transmitter::sendContactSuggestion($uid, $inbox, $item_id);
 		} elseif ($cmd == Delivery::RELOCATION) {
 		} elseif ($cmd == Delivery::REMOVAL) {
 			ActivityPub\Transmitter::sendProfileDeletion($uid, $inbox);


### PR DESCRIPTION
To issue #5818 I fixed former unset `$_SESSION['return_url']` so if you access a site without logged in you will be redirected to this page after a successful login.
If a login failed you are redirected to `/login` and after successful login here to `/network`.

I added the login mask in many pages (like it was did in `/admin` and `/network`). Did I miss pages ?

For more information see https://github.com/friendica/friendica/issues/5818#issuecomment-427462884