### PR TITLE
Return to previous page after login

### DIFF
--- a/mod/contacts.php
+++ b/mod/contacts.php
@@ -22,6 +22,7 @@ use Friendica\Network\Probe;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Proxy as ProxyUtils;
 use Friendica\Core\ACL;
+use Friendica\Module\Login;
 
 function contacts_init(App $a)
 {
@@ -375,7 +376,7 @@ function contacts_content(App $a, $update = 0)
 
 	if (!local_user()) {
 		notice(L10n::t('Permission denied.') . EOL);
-		return;
+		return Login::form();
 	}
 
 	if ($a->argc == 3) {

--- a/mod/events.php
+++ b/mod/events.php
@@ -17,6 +17,7 @@ use Friendica\Model\Item;
 use Friendica\Model\Profile;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Temporal;
+use Friendica\Module\Login;
 
 require_once 'include/items.php';
 
@@ -193,7 +194,7 @@ function events_content(App $a)
 {
 	if (!local_user()) {
 		notice(L10n::t('Permission denied.') . EOL);
-		return;
+		return Login::form();
 	}
 
 	if ($a->argc == 1) {

--- a/mod/message.php
+++ b/mod/message.php
@@ -16,6 +16,7 @@ use Friendica\Model\Mail;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Proxy as ProxyUtils;
 use Friendica\Util\Temporal;
+use Friendica\Module\Login;
 
 require_once 'include/conversation.php';
 
@@ -97,7 +98,7 @@ function message_content(App $a)
 
 	if (!local_user()) {
 		notice(L10n::t('Permission denied.') . EOL);
-		return;
+		return Login::form();
 	}
 
 	$myprofile = System::baseUrl() . '/profile/' . $a->user['nickname'];

--- a/mod/notifications.php
+++ b/mod/notifications.php
@@ -12,6 +12,7 @@ use Friendica\Core\NotificationsManager;
 use Friendica\Core\Protocol;
 use Friendica\Core\System;
 use Friendica\Database\DBA;
+use Friendica\Module\Login;
 
 function notifications_post(App $a)
 {
@@ -65,7 +66,7 @@ function notifications_content(App $a)
 {
 	if (!local_user()) {
 		notice(L10n::t('Permission denied.') . EOL);
-		return;
+		return Login::form();
 	}
 
 	$page = defaults($_REQUEST, 'page', 1);

--- a/mod/profiles.php
+++ b/mod/profiles.php
@@ -20,6 +20,7 @@ use Friendica\Model\Profile;
 use Friendica\Network\Probe;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Temporal;
+use Friendica\Module\Login;
 
 function profiles_init(App $a) {
 
@@ -509,7 +510,7 @@ function profiles_content(App $a) {
 
 	if (! local_user()) {
 		notice(L10n::t('Permission denied.') . EOL);
-		return;
+		return Login::form();
 	}
 
 	$o = '';

--- a/mod/settings.php
+++ b/mod/settings.php
@@ -22,6 +22,7 @@ use Friendica\Model\User;
 use Friendica\Protocol\Email;
 use Friendica\Util\Network;
 use Friendica\Util\Temporal;
+use Friendica\Module\Login;
 
 function get_theme_config_file($theme)
 {
@@ -658,7 +659,7 @@ function settings_content(App $a)
 
 	if (!local_user()) {
 		//notice(L10n::t('Permission denied.') . EOL);
-		return;
+		return Login::form();
 	}
 
 	if (x($_SESSION, 'submanage') && intval($_SESSION['submanage'])) {

--- a/src/Module/Login.php
+++ b/src/Module/Login.php
@@ -47,7 +47,10 @@ class Login extends BaseModule
 
 	public static function post()
 	{
+		$return_url = $_SESSION['return_url'];
 		session_unset();
+		$_SESSION['return_url'] = $return_url;
+		
 		// OpenId Login
 		if (
 			empty($_POST['password'])


### PR DESCRIPTION
Reopen #5852 with fixed fork.
To issue #5818 I fixed former unset `$_SESSION['return_url']` so if you access a site without logged in you will be redirected to this page after a successful login.
If a login failed you are redirected to `/login` and after successful login here to `/network`.

I added the login mask in many pages (like it was did in `/admin` and `/network`). Did I miss pages ?

For more information see https://github.com/friendica/friendica/issues/5818#issuecomment-427462884