### PR TITLE
Replace goaway location SESSION var return_url with page as string value

### DIFF
--- a/include/items.php
+++ b/include/items.php
@@ -349,7 +349,7 @@ function drop_item($id)
 
 	// locate item to be deleted
 
-	$fields = ['id', 'uid', 'contact-id', 'deleted'];
+	$fields = ['id', 'uid', 'guid', 'contact-id', 'deleted'];
 	$item = Item::selectFirstForUser(local_user(), $fields, ['id' => $id]);
 
 	if (!DBA::isResult($item)) {
@@ -401,7 +401,7 @@ function drop_item($id)
 		}
 		// Now check how the user responded to the confirmation query
 		if (!empty($_REQUEST['canceled'])) {
-			goaway('/item/drop/' . $id);
+			goaway('/display/' . $item['guid']);
 		}
 
 		// delete the item
@@ -411,7 +411,7 @@ function drop_item($id)
 		//NOTREACHED
 	} else {
 		notice(L10n::t('Permission denied.') . EOL);
-		goaway('/item/drop/' . $id);
+		goaway('/display/' . $item['guid']);
 		//NOTREACHED
 	}
 }

--- a/include/items.php
+++ b/include/items.php
@@ -354,7 +354,7 @@ function drop_item($id)
 
 	if (!DBA::isResult($item)) {
 		notice(L10n::t('Item not found.') . EOL);
-		goaway(System::baseUrl() . '/' . $_SESSION['return_url']);
+		goaway('/network');
 	}
 
 	if ($item['deleted']) {
@@ -401,17 +401,17 @@ function drop_item($id)
 		}
 		// Now check how the user responded to the confirmation query
 		if (!empty($_REQUEST['canceled'])) {
-			goaway(System::baseUrl() . '/' . $_SESSION['return_url']);
+			goaway('/item/drop/' . $id);
 		}
 
 		// delete the item
 		Item::deleteForUser(['id' => $item['id']], local_user());
 
-		goaway(System::baseUrl() . '/' . $_SESSION['return_url']);
+		goaway('/item/drop/' . $id);
 		//NOTREACHED
 	} else {
 		notice(L10n::t('Permission denied.') . EOL);
-		goaway(System::baseUrl() . '/' . $_SESSION['return_url']);
+		goaway('/item/drop/' . $id);
 		//NOTREACHED
 	}
 }

--- a/include/items.php
+++ b/include/items.php
@@ -407,7 +407,7 @@ function drop_item($id)
 		// delete the item
 		Item::deleteForUser(['id' => $item['id']], local_user());
 
-		goaway('/item/drop/' . $id);
+		goaway('/network');
 		//NOTREACHED
 	} else {
 		notice(L10n::t('Permission denied.') . EOL);

--- a/mod/events.php
+++ b/mod/events.php
@@ -187,7 +187,7 @@ function events_post(App $a)
 		Worker::add(PRIORITY_HIGH, "Notifier", "event", $item_id);
 	}
 
-	goaway($_SESSION['return_url']);
+	goaway('/events');
 }
 
 function events_content(App $a)

--- a/mod/filerm.php
+++ b/mod/filerm.php
@@ -25,9 +25,7 @@ function filerm_content(App $a) {
 		file_tag_unsave_file(local_user(),$item_id,$term, $category);
 	}
 
-	if (x($_SESSION,'return_url')) {
-		goaway(System::baseUrl() . '/' . $_SESSION['return_url']);
-	}
+	goaway('/network');
 
 	killme();
 }

--- a/mod/filerm.php
+++ b/mod/filerm.php
@@ -25,7 +25,7 @@ function filerm_content(App $a) {
 		file_tag_unsave_file(local_user(),$item_id,$term, $category);
 	}
 
-	goaway('/network');
+	//goaway('/network');
 
 	killme();
 }

--- a/mod/ostatus_subscribe.php
+++ b/mod/ostatus_subscribe.php
@@ -15,7 +15,7 @@ function ostatus_subscribe_content(App $a) {
 
 	if (! local_user()) {
 		notice(L10n::t('Permission denied.') . EOL);
-		goaway($_SESSION['return_url']);
+		goaway('/ostatus_subscribe');
 		// NOTREACHED
 	}
 

--- a/mod/repair_ostatus.php
+++ b/mod/repair_ostatus.php
@@ -14,7 +14,7 @@ function repair_ostatus_content(App $a) {
 
 	if (! local_user()) {
 		notice(L10n::t('Permission denied.') . EOL);
-		goaway($_SESSION['return_url']);
+		goaway('/ostatus_repair');
 		// NOTREACHED
 	}
 


### PR DESCRIPTION
To issue #3897 I replaced the last apparences of `$_SESSION['return_url']` with the needed return url as a string.

Open:
- Where should `filerm` return to ?