### PR TITLE
Fix Login return with pop-up menu form

### DIFF
--- a/src/Module/Login.php
+++ b/src/Module/Login.php
@@ -42,7 +42,7 @@ class Login extends BaseModule
 			goaway(self::getApp()->get_baseurl());
 		}
 
-		return self::form(self::getApp()->get_baseurl(), intval(Config::get('config', 'register_policy')) !== REGISTER_CLOSED);
+		return self::form($_SESSION['return_url'], intval(Config::get('config', 'register_policy')) !== REGISTER_CLOSED);
 	}
 
 	public static function post()


### PR DESCRIPTION
To Issue #5863 and PR #5853

Popup Login mask is called via `/login?mode=none&_=1234567` so the App values `query_string` and `cmd` couldn't be used.

Correct return path is stored in `$_SESSION['return_url']` and given to the form display function. The session var is empty if the login mask is called from an invalid (Page not found) Page. The form function handles the empty arguments and redirects to `/network` (or to baseUrl to be specific)