### PR TITLE
AP: Avoid a misleading log entry / unneeded field removed

### DIFF
--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -196,12 +196,15 @@ class Processor
 
 		$item['network'] = Protocol::ACTIVITYPUB;
 		$item['private'] = !in_array(0, $activity['receiver']);
+		$item['author-link'] = $activity['author'];
 		$item['author-id'] = Contact::getIdForURL($activity['author'], 0, true);
 
 		if (empty($activity['thread-completion'])) {
+			$item['owner-link'] = $activity['actor'];
 			$item['owner-id'] = Contact::getIdForURL($activity['actor'], 0, true);
 		} else {
 			logger('Ignoring actor because of thread completion.', LOGGER_DEBUG);
+			$item['owner-link'] = $item['author-link'];
 			$item['owner-id'] = $item['author-id'];
 		}
 

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -778,7 +778,6 @@ class Transmitter
 
 		$data['url'] = $item['plink'];
 		$data['attributedTo'] = $item['author-link'];
-		$data['actor'] = $item['author-link'];
 		$data['sensitive'] = self::isSensitive($item['id']);
 		$data['context'] = self::fetchContextURLForItem($item);
 


### PR DESCRIPTION
Without filling "author-link" and "owner-link" there is some misleading log entry that a function tries to fetch the contact id of a contact with an empty url. This is fixed.

And: The "actor" doesn't belong to the object.