### PR TITLE
Uncaught Error for getCurlCode()

### DIFF
--- a/src/Util/HTTPSignature.php
+++ b/src/Util/HTTPSignature.php
@@ -303,7 +303,7 @@ class HTTPSignature
 		$headers[] = 'Content-Type: application/activity+json';
 
 		Network::post($target, $content, $headers);
-		$return_code = BaseObject::getApp()->getCurlCode();
+		$return_code = Network::getCurl()->getCode();
 
 		logger('Transmit to ' . $target . ' returned ' . $return_code);
 	}


### PR DESCRIPTION
fixing #5875 

Searched for other `getCurlCode()` or `getCurlHeader()` or `getCurlContentType()` (and the curl_* analog) too. Should be fine now.