### PR TITLE
We now store the diaspora comment data as well

### DIFF
--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -215,6 +215,7 @@ class Processor
 		$item['tag'] = self::constructTagList($activity['tags'], $activity['sensitive']);
 		$item['app'] = $activity['service'];
 		$item['plink'] = defaults($activity, 'alternate-url', $item['uri']);
+		$item['diaspora_signed_text'] = defaults($activity, 'diaspora:comment', '');
 
 		$item = self::constructAttachList($activity['attachments'], $item);
 


### PR DESCRIPTION
Now a comment that had been transported over AP should again be relayed over the Diaspora protocol.