### PR TITLE
Avoid beeing flooded by invalid requests

### DIFF
--- a/index.php
+++ b/index.php
@@ -48,6 +48,10 @@ if ($a->isMaxProcessesReached() || $a->isMaxLoadReached()) {
 	System::httpExit(503, ['title' => 'Error 503 - Service Temporarily Unavailable', 'description' => 'System is currently overloaded. Please try again later.']);
 }
 
+if (strstr($a->query_string, '.well-known/host-meta') and ($a->query_string != '.well-known/host-meta')) {
+	System::httpExit(404);
+}
+
 if (!$a->getMode()->isInstall()) {
 	if (Config::get('system', 'force_ssl') && ($a->get_scheme() == "http")
 		&& (intval(Config::get('system', 'ssl_policy')) == SSL_POLICY_FULL)

--- a/mod/xrd.php
+++ b/mod/xrd.php
@@ -13,7 +13,7 @@ function xrd_init(App $a)
 {
 	if ($a->argv[0] == 'xrd') {
 		if (empty($_GET['uri'])) {
-			killme();
+			System::httpExit(404);
 		}
 
 		$uri = urldecode(notags(trim($_GET['uri'])));
@@ -24,7 +24,7 @@ function xrd_init(App $a)
 		}
 	} else {
 		if (empty($_GET['resource'])) {
-			killme();
+			System::httpExit(404);
 		}
 
 		$uri = urldecode(notags(trim($_GET['resource'])));
@@ -48,7 +48,7 @@ function xrd_init(App $a)
 
 	$user = DBA::selectFirst('user', [], ['nickname' => $name]);
 	if (!DBA::isResult($user)) {
-		killme();
+		System::httpExit(404);
 	}
 
 	$profile_url = System::baseUrl().'/profile/'.$user['nickname'];


### PR DESCRIPTION
This morning my server greeted me with a very high load. The reason had been some endlessly repeated queries to (mostly) invalid paths or non existing profiles. By answering with "404" the remote server stopped.