### PR TITLE
Admin: Change User deleted since to delete in

### DIFF
--- a/mod/admin.php
+++ b/mod/admin.php
@@ -1922,7 +1922,7 @@ function admin_page_users(App $a)
 
 		'$h_users' => L10n::t('Users'),
 		'$h_newuser' => L10n::t('New User'),
-		'$th_deleted' => [L10n::t('Name'), L10n::t('Email'), L10n::t('Register date'), L10n::t('Last login'), L10n::t('Last item'), L10n::t('Deleted since')],
+		'$th_deleted' => [L10n::t('Name'), L10n::t('Email'), L10n::t('Register date'), L10n::t('Last login'), L10n::t('Last item'), L10n::t('Delete in')],
 		'$th_users' => $th_users,
 		'$order_users' => $order,
 		'$order_direction_users' => $order_direction,

--- a/src/Util/Temporal.php
+++ b/src/Util/Temporal.php
@@ -294,10 +294,16 @@ class Temporal
 			return L10n::t('never');
 		}
 
+		$isfuture = false;
 		$etime = time() - $abs;
 
-		if ($etime < 1) {
+		if ($etime < 1 && $etime >= 0) {
 			return L10n::t('less than a second ago');
+		}
+
+		if ($etime < 0){
+			$etime = -$etime;
+			$isfuture = true;
 		}
 
 		$a = [12 * 30 * 24 * 60 * 60 => [L10n::t('year'), L10n::t('years')],
@@ -315,7 +321,12 @@ class Temporal
 				$r = round($d);
 				// translators - e.g. 22 hours ago, 1 minute ago
 				if (!$format) {
-					$format = L10n::t('%1$d %2$s ago');
+					if($isfuture){
+						$format = L10n::t('in %1$d %2$s');
+					}
+					else {
+						$format = L10n::t('%1$d %2$s ago');
+					}
 				}
 
 				return sprintf($format, $r, (($r == 1) ? $str[0] : $str[1]));


### PR DESCRIPTION
My suggestion to issue #5916

Since there is no date saved when setting a user for deletion and the value `account_expires_on` is shown but labeled wrongly I add support for showing relative Dates in future and updated the table header in the admin overview for deleted user

![screenshot](https://owncloud.riotcat.org/index.php/apps/files_sharing/ajax/publicpreview.php?x=1366&y=293&a=true&file=Screenshot_2018-10-14_23-01-28.png&t=BFa3HkE9xn3Af47&scalingup=0)