### PR TITLE
Poddibility to defer worker execution

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -41,7 +41,7 @@ define('FRIENDICA_PLATFORM',     'Friendica');
 define('FRIENDICA_CODENAME',     'The Tazmans Flax-lily');
 define('FRIENDICA_VERSION',      '2018.12-dev');
 define('DFRN_PROTOCOL_VERSION',  '2.23');
-define('DB_UPDATE_VERSION',      1285);
+define('DB_UPDATE_VERSION',      1286);
 define('NEW_UPDATE_ROUTINE_VERSION', 1170);
 
 /**

--- a/config/dbstructure.json
+++ b/config/dbstructure.json
@@ -1298,14 +1298,16 @@
 			"created": {"type": "datetime", "not null": "1", "default": "0001-01-01 00:00:00", "comment": "Creation date"},
 			"pid": {"type": "int unsigned", "not null": "1", "default": "0", "comment": "Process id of the worker"},
 			"executed": {"type": "datetime", "not null": "1", "default": "0001-01-01 00:00:00", "comment": "Execution date"},
+			"next_try": {"type": "datetime", "not null": "1", "default": "0001-01-01 00:00:00", "comment": "Next retrial date"},
+			"retrial": {"type": "tinyint", "not null": "1", "default": "0", "comment": "Retrial counter"},
 			"done": {"type": "boolean", "not null": "1", "default": "0", "comment": "Marked 1 when the task was done - will be deleted later"}
 		},
 		"indexes": {
 			"PRIMARY": ["id"],
 			"pid": ["pid"],
 			"parameter": ["parameter(64)"],
-			"priority_created": ["priority", "created"],
-			"done_executed": ["done", "executed"]
+			"priority_created_next_try": ["priority", "created", "next_try"],
+			"done_executed_next_try": ["done", "executed", "next_try"]
 		}
 	}
 }


### PR DESCRIPTION
This isn't in use yet. It is planned for handling the queueing of ActivityPub posts and could possibly be a replacement for the existing "queue" mechanism.

The PR is done now to free resources for an item storage rework which seems to be needed more at the moment. 