### PR TITLE
Onepoll hadn't polled anymore / small relocation in zrlinit for better logging

### DIFF
--- a/src/Worker/OnePoll.php
+++ b/src/Worker/OnePoll.php
@@ -333,7 +333,7 @@ class OnePoll
 			$curlResult = Network::curl($contact['poll'], false, $redirects, ['cookiejar' => $cookiejar]);
 			unlink($cookiejar);
 
-			if (!$curlResult->isTimeout()) {
+			if ($curlResult->isTimeout()) {
 				// set the last-update so we don't keep polling
 				DBA::update('contact', ['last-update' => DateTimeFormat::utcNow()], ['id' => $contact['id']]);
 				Contact::markForArchival($contact);


### PR DESCRIPTION
The most important part of this PR is the ```!``` on onepoll that created the problem that feeds hadn't been polled anymore.

The other part is just some rearrange so that we check at first if someone already is authenticated and then if the user already tried it. This improves the logging.