### PR TITLE
Use "uri-id" for item relations

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -41,7 +41,7 @@ define('FRIENDICA_PLATFORM',     'Friendica');
 define('FRIENDICA_CODENAME',     'The Tazmans Flax-lily');
 define('FRIENDICA_VERSION',      '2018.12-dev');
 define('DFRN_PROTOCOL_VERSION',  '2.23');
-define('DB_UPDATE_VERSION',      1287);
+define('DB_UPDATE_VERSION',      1288);
 define('NEW_UPDATE_ROUTINE_VERSION', 1170);
 
 /**

--- a/config/dbstructure.json
+++ b/config/dbstructure.json
@@ -620,7 +620,8 @@
 		"indexes": {
 			"PRIMARY": ["id"],
 			"uri-hash": ["UNIQUE", "uri-hash"],
-			"uri": ["uri(191)"]
+			"uri": ["uri(191)"],
+			"uri-id": ["uri-id"]
 		}
 	},
 	"item-content": {
@@ -649,7 +650,8 @@
 		"indexes": {
 			"PRIMARY": ["id"],
 			"uri-plink-hash": ["UNIQUE", "uri-plink-hash"],
-			"uri": ["uri(191)"]
+			"uri": ["uri(191)"],
+			"uri-id": ["uri-id"]
 		}
 	},
 	"item-delivery-data": {

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -665,11 +665,11 @@ class Item extends BaseObject
 		}
 
 		if (strpos($sql_commands, "`item-activity`.") !== false) {
-			$joins .= " LEFT JOIN `item-activity` ON `item-activity`.`id` = `item`.`iaid`";
+			$joins .= " LEFT JOIN `item-activity` ON `item-activity`.`uri-id` = `item`.`uri-id`";
 		}
 
 		if (strpos($sql_commands, "`item-content`.") !== false) {
-			$joins .= " LEFT JOIN `item-content` ON `item-content`.`id` = `item`.`icid`";
+			$joins .= " LEFT JOIN `item-content` ON `item-content`.`uri-id` = `item`.`uri-id`";
 		}
 
 		if (strpos($sql_commands, "`item-delivery-data`.") !== false) {

--- a/update.php
+++ b/update.php
@@ -246,3 +246,12 @@ function update_1278() {
 
 	return UPDATE_SUCCESS;
 }
+
+function update_1288() {
+	// Updates missing `uri-id` values
+
+	DBA::e("UPDATE `item-activity` INNER JOIN `item` ON `item`.`iaid` = `item-activity`.`id` SET `item-activity`.`uri-id` = `item`.`uri-id` WHERE `item-activity`.`uri-id` IS NULL OR `item-activity`.`uri-id` = 0");
+	DBA::e("UPDATE `item-content` INNER JOIN `item` ON `item`.`icid` = `item-content`.`id` SET `item-content`.`uri-id` = `item`.`uri-id` WHERE `item-content`.`uri-id` IS NULL OR `item-content`.`uri-id` = 0");
+
+	return UPDATE_SUCCESS;
+}


### PR DESCRIPTION
This is a preparation for some upcoming work to simplify the item storage. After this PR we will have to check the results (means: Do the users see their old content, do they have "null" values in the "uri-id" of item, "item-content" and "item-activity")