### PR TITLE
Add link prompt in comment

### DIFF
--- a/mod/parse_url.php
+++ b/mod/parse_url.php
@@ -92,7 +92,7 @@ function parse_url_content(App $a)
 		}
 	}
 
-	if(!empty($_GET['isComment'])) {
+	if (!empty($_GET['isComment'])) {
 		echo $br . '[url]' . $url . '[/url]';
 		exit();
 	}

--- a/mod/parse_url.php
+++ b/mod/parse_url.php
@@ -92,6 +92,11 @@ function parse_url_content(App $a)
 		}
 	}
 
+	if(!empty($_GET['isComment'])) {
+		echo $br . '[url]' . $url . '[/url]';
+		exit();
+	}
+
 	$template = '[bookmark=%s]%s[/bookmark]%s';
 
 	$arr = ['url' => $url, 'text' => ''];

--- a/view/theme/frio/js/textedit.js
+++ b/view/theme/frio/js/textedit.js
@@ -2,15 +2,40 @@
  * @brief The file contains functions for text editing and commenting
  */
 
-function initComment(callback) {
-    if (typeof callback != "undefined") {
-        callback();
+var commentLink = "";
+var commentBefore = "";
+
+function getPasteLinks(event, id) {
+    if (!commentLink) {
+        commentLink = "";
     }
+    commentLink = event.clipboardData.getData('text/plain');
+    commentBefore = $("#comment-edit-text-" + id).val();
+    return false;
+}
+
+function handleLinks(id) {
+	var textfield = document.getElementById("comment-edit-text-" + id);
+
+	if (commentLink.includes("https://") | commentLink.includes("http://")) {
+        textfield.value = commentBefore;
+        var isAttachement = "";
+        if (commentBefore.includes("https://") || commentBefore.includes("http://")){
+        	isAttachement = "&isComment=1";
+		}
+		var link = bin2hex(commentLink);
+		$.get('parse_url?binurl=' + link + isAttachement, function (data) {
+			addcommenttext(data, id);
+		});
+	}
+
+	commentLink = "";
+	commentBefore = "";
 }
 
 function commentGetLink(id) {
     reply = prompt("Please enter a link URL:");
-    if(reply && reply.length) {
+    if (reply && reply.length) {
         reply = bin2hex(reply);
         $.get('parse_url?isComment=1&binurl=' + reply, function(data) {
             addcommenttext(data, id);
@@ -34,21 +59,19 @@ function commentlinkdrop(event, id) {
     var reply = event.dataTransfer.getData("text/uri-list");
     event.target.textContent = reply;
     event.preventDefault();
-    if(reply && reply.length) {
+    if (reply && reply.length) {
         reply = bin2hex(reply);
         $.get('parse_url?isComment=1&binurl=' + reply, function(data) {
-            if (!editor) $("comment-edit-text-" + id).val("");
-            initComment(function(){
-                addcommenttext(data, id);
-            });
+        	addcommenttext(data, id);
         });
     }
 }
 
 function commentlinkdropper(event) {
     var linkFound = event.dataTransfer.types.contains("text/uri-list");
-    if(linkFound)
+    if (linkFound) {
         event.preventDefault();
+    }
 }
 
 

--- a/view/theme/frio/js/textedit.js
+++ b/view/theme/frio/js/textedit.js
@@ -2,6 +2,55 @@
  * @brief The file contains functions for text editing and commenting
  */
 
+function initComment(callback) {
+    if (typeof callback != "undefined") {
+        callback();
+    }
+}
+
+function commentGetLink(id) {
+    reply = prompt("Please enter a link URL:");
+    if(reply && reply.length) {
+        reply = bin2hex(reply);
+        $.get('parse_url?isComment=1&binurl=' + reply, function(data) {
+            addcommenttext(data, id);
+        });
+    }
+}
+
+function addcommenttext(data, id) {
+    // get the textfield
+    var textfield = document.getElementById("comment-edit-text-" + id);
+    // check if the textfield does have the default-value
+    commentOpenUI(textfield, id);
+    // save already existent content
+    var currentText = $("#comment-edit-text-" + id).val();
+    //insert the data as new value
+    textfield.value = currentText + data;
+    autosize.update($("#comment-edit-text-" + id));
+}
+
+function commentlinkdrop(event, id) {
+    var reply = event.dataTransfer.getData("text/uri-list");
+    event.target.textContent = reply;
+    event.preventDefault();
+    if(reply && reply.length) {
+        reply = bin2hex(reply);
+        $.get('parse_url?isComment=1&binurl=' + reply, function(data) {
+            if (!editor) $("comment-edit-text-" + id).val("");
+            initComment(function(){
+                addcommenttext(data, id);
+            });
+        });
+    }
+}
+
+function commentlinkdropper(event) {
+    var linkFound = event.dataTransfer.types.contains("text/uri-list");
+    if(linkFound)
+        event.preventDefault();
+}
+
 
 function insertFormatting(BBcode, id) {
 	var tmpStr = $("#comment-edit-text-" + id).val();

--- a/view/theme/frio/templates/comment_item.tpl
+++ b/view/theme/frio/templates/comment_item.tpl
@@ -14,7 +14,7 @@
 		<input type="hidden" name="post_id_random" value="{{$rand_num}}" />
 
 		<div class="bb form-group">
-			<textarea id="comment-edit-text-{{$id}}" class="comment-edit-text-empty form-control text-autosize" name="body" placeholder="{{$comment}}" onFocus="commentOpenUI(this,{{$id}});"></textarea>
+			<textarea id="comment-edit-text-{{$id}}" class="comment-edit-text-empty form-control text-autosize" name="body" placeholder="{{$comment}}" onFocus="commentOpenUI(this,{{$id}});" onpaste="getPasteLinks(event, {{$id}})" onInput="handleLinks({{$id}})"></textarea>
 		</div>
 		{{if $qcomment}}
 			<select id="qcomment-select-{{$id}}" name="qcomment-{{$id}}" class="qcomment" onchange="qCommentInsert(this,{{$id}});">

--- a/view/theme/frio/templates/comment_item.tpl
+++ b/view/theme/frio/templates/comment_item.tpl
@@ -38,7 +38,7 @@
 					</button>
 				</li>
 				<li>
-					<button type="button" class="btn-link icon bb-url" style="cursor: pointer;" aria-label="{{$edurl}}" title="{{$edurl}}" onclick="insertFormatting('url',{{$id}});">
+					<button type="button" class="btn-link icon bb-url" style="cursor: pointer;" aria-label="{{$edurl}}" title="{{$edurl}}" ondragenter="return commentlinkdrop(event, {{$id}});" ondragover="return commentlinkdrop(event, {{$id}});" ondrop="commentlinkdropper(event);" onclick="commentGetLink({{$id}});">
 						<i class="fa fa-link"></i>
 					</button>
 				</li>


### PR DESCRIPTION
To issue #5929 I did

- add the link url prompt in comment bar (same behaviour when adding images or videos as in post)
- adjust `parse_url` with a bypass for a comment link to prevent `[attachement ...]` and use `[url]https://link[/url]` (a new line is inserted before but not after)
- add autosize of comment textarea after inserting link

I did not implement the "rotator" loading animation when waiting for `parse_url` to answer.

![screenshot_2018-10-17_21-39-40](https://user-images.githubusercontent.com/10757520/47112034-731af600-d255-11e8-9f2a-138503d9dd5b.png)
![screenshot_2018-10-17_21-40-00](https://user-images.githubusercontent.com/10757520/47112039-74e4b980-d255-11e8-8dd7-d282973ebbc2.png)
