### PR TITLE
fixed view of active embedded videos

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -1781,6 +1781,12 @@ code > .hl-main {
 .oembed.video .embed_video > div:hover {
     background-color: rgba(0,0,0,0);
 }
+.oembed.video .embed_video.active {
+	margin: 1em 0;
+}
+.oembed.video .embed_video.active iframe {
+	width: 100% !important;
+}
 .wall-item-tags,
 .itemedited {
     margin-top: 10px;


### PR DESCRIPTION
As I was freaking out with how active videos were viewed in the frio theme, I analyzed what was going wrong fixed it in the frio theme.

Tests done:
* Frio theme on my own node by uploading the files
(I didn't test other themes because I only edited frio-specific files and don't expect this file be included in Vier or any other file)