### PR TITLE
AP: Transmitting and receiving with non AP contacts

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -41,7 +41,7 @@ define('FRIENDICA_PLATFORM',     'Friendica');
 define('FRIENDICA_CODENAME',     'The Tazmans Flax-lily');
 define('FRIENDICA_VERSION',      '2018.12-dev');
 define('DFRN_PROTOCOL_VERSION',  '2.23');
-define('DB_UPDATE_VERSION',      1288);
+define('DB_UPDATE_VERSION',      1289);
 define('NEW_UPDATE_ROUTINE_VERSION', 1170);
 
 /**

--- a/config/dbstructure.json
+++ b/config/dbstructure.json
@@ -40,6 +40,7 @@
 		"indexes": {
 			"PRIMARY": ["url"],
 			"addr": ["addr(32)"],
+			"alias": ["alias(190)"],
 			"url": ["followers(190)"]
 		}
 	},

--- a/src/Protocol/ActivityPub/Receiver.php
+++ b/src/Protocol/ActivityPub/Receiver.php
@@ -419,8 +419,9 @@ class Receiver
 				}
 
 				if (in_array($receiver, [$followers, self::PUBLIC_COLLECTION]) && !empty($actor)) {
+					$networks = [Protocol::ACTIVITYPUB, Protocol::DFRN, Protocol::DIASPORA, Protocol::OSTATUS];
 					$condition = ['nurl' => normalise_link($actor), 'rel' => [Contact::SHARING, Contact::FRIEND],
-						'network' => Protocol::ACTIVITYPUB, 'archive' => false, 'pending' => false];
+						'network' => $networks, 'archive' => false, 'pending' => false];
 					$contacts = DBA::select('contact', ['uid'], $condition);
 					while ($contact = DBA::fetch($contacts)) {
 						if ($contact['uid'] != 0) {

--- a/src/Worker/Notifier.php
+++ b/src/Worker/Notifier.php
@@ -512,6 +512,7 @@ class Notifier
 	private static function activityPubDelivery($a, $cmd, $item_id, $uid, $target_item, $parent)
 	{
 		$inboxes = [];
+		$personal = false;
 
 		if ($target_item['origin']) {
 			$inboxes = ActivityPub\Transmitter::fetchTargetInboxes($target_item, $uid);
@@ -520,11 +521,14 @@ class Notifier
 			logger('Remote item ' . $item_id . ' with URL ' . $target_item['uri'] . ' is no AP post. It will not be distributed.', LOGGER_DEBUG);
 			return;
 		} else {
+			// Remote items are transmitted via the personal inboxes.
+			// Doing so ensures that the dedicated receiver will get the message.
+			$personal = true;
 			logger('Remote item ' . $item_id . ' with URL ' . $target_item['uri'] . ' will be distributed.', LOGGER_DEBUG);
 		}
 
 		if ($parent['origin']) {
-			$parent_inboxes = ActivityPub\Transmitter::fetchTargetInboxes($parent, $uid);
+			$parent_inboxes = ActivityPub\Transmitter::fetchTargetInboxes($parent, $uid, $personal);
 			$inboxes = array_merge($inboxes, $parent_inboxes);
 		}
 


### PR DESCRIPTION
We now will process incoming AP content from contacts that are not primary AP contacts. Additionally it is prepared to transmit via AP to these contacts. (Which will be enabled in some later step when the queueing is working)

We also can now deliver to the personal inboxes. This is part of some continuing testing and possible future changing.