### PR TITLE
Encapsulate legacy module functions in a BaseModule-inherited class

### DIFF
--- a/src/LegacyModule.php
+++ b/src/LegacyModule.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Friendica;
+
+/**
+ * This mock module enable class encapsulation of legacy global function modules.
+ * After having provided the module file name, all the methods will behave like a normal Module class.
+ *
+ * @author Hypolite Petovan <mrpetovan@gmail.com>
+ */
+class LegacyModule extends BaseModule
+{
+	/**
+	 * The module name, which is the name of the file (without the .php suffix)
+	 * It's used to check for existence of the module functions.
+	 *
+	 * @var string
+	 */
+	private static $moduleName = '';
+
+	/**
+	 * The only method that needs to be called, with the module/addon file name.
+	 *
+	 * @param string $file_path
+	 */
+	public static function setModuleFile($file_path)
+	{
+		if (!file_exists($file_path)) {
+			throw new Exception(Core\L10n::t('Legacy module file not found: %s', $file_path));
+		}
+
+		self::$moduleName = basename($file_path, '.php');
+
+		require_once $file_path;
+	}
+
+	public static function init()
+	{
+		self::runModuleFunction('init');
+	}
+
+	public static function content()
+	{
+		return self::runModuleFunction('content');
+	}
+
+	public static function post()
+	{
+		self::runModuleFunction('post');
+	}
+
+	public static function afterpost()
+	{
+		self::runModuleFunction('afterpost');
+	}
+
+	/**
+	 * Runs the module function designated by the provided suffix if it exists, the BaseModule method otherwise
+	 *
+	 * @param string $function_suffix
+	 * @return string
+	 */
+	private static function runModuleFunction($function_suffix)
+	{
+		$function_name = static::$moduleName . '_' . $function_suffix;
+
+		if (\function_exists($function_name)) {
+			return $function_name(self::getApp());
+		} else {
+			return parent::{$function_suffix}();
+		}
+	}
+}

--- a/src/LegacyModule.php
+++ b/src/LegacyModule.php
@@ -25,7 +25,7 @@ class LegacyModule extends BaseModule
 	 */
 	public static function setModuleFile($file_path)
 	{
-		if (!file_exists($file_path)) {
+		if (!is_readable($file_path)) {
 			throw new Exception(Core\L10n::t('Legacy module file not found: %s', $file_path));
 		}
 


### PR DESCRIPTION
Still eager to shave as much lines from `index.php` as possible, here comes the newest improvement: no more conditional to figure if we're dealing with a BaseModule class or global module functions.

The latter are now encapsulated in the LegacyModule class.

This may or may not pave the way for a fancier routing mechanism, but at least it's that many fewer conditionals in `index.php`.