### PR TITLE
Bugfix: We hadn't deliverd AP posts to all intended receivers

### DIFF
--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -476,7 +476,7 @@ class Transmitter
 
 			foreach ($permissions[$element] as $receiver) {
 				if ($receiver == $item_profile['followers']) {
-					$inboxes = self::fetchTargetInboxesforUser($uid, $personal);
+					$inboxes = array_merge($inboxes, self::fetchTargetInboxesforUser($uid, $personal));
 				} else {
 					$profile = APContact::getByURL($receiver, false);
 					if (!empty($profile)) {


### PR DESCRIPTION
There had been reports that the posts hadn't always reached all destinations - this is now fixed.