### PR TITLE
Fix webmentions and microformats ("redir" only for logged in users)

### DIFF
--- a/include/conversation.php
+++ b/include/conversation.php
@@ -353,7 +353,8 @@ function localize_item(&$item)
 	$author = ['uid' => 0, 'id' => $item['author-id'],
 		'network' => $item['author-network'], 'url' => $item['author-link']];
 
-	if (!empty($item['plink'])) {
+	// Only create a redirection to a magic link when logged in
+	if (!empty($item['plink']) && local_user()) {
 		$item['plink'] = Contact::magicLinkbyContact($author, $item['plink']);
 	}
 }

--- a/src/Object/Post.php
+++ b/src/Object/Post.php
@@ -209,7 +209,13 @@ class Post extends BaseObject
 
 		$author = ['uid' => 0, 'id' => $item['author-id'],
 			'network' => $item['author-network'], 'url' => $item['author-link']];
-		$profile_link = Contact::magicLinkbyContact($author);
+
+		if (local_user()) {
+			$profile_link = Contact::magicLinkbyContact($author);
+		} else {
+			$profile_link = $item['author-link'];
+		}
+
 		if (strpos($profile_link, 'redir/') === 0) {
 			$sparkle = ' sparkle';
 		}


### PR DESCRIPTION
There had been an issue with some AP implementation that also uses webmentions and microformats for content validation. The ```redir``` stuff irritated these standards. So we now don't apply them to some fields anymore with not logged in users.