### PR TITLE
AP: We now send the previous followers collection as well

### DIFF
--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -289,7 +289,7 @@ class Transmitter
 
 			foreach ($activity[$element] as $receiver) {
 				if ($receiver == $profile['followers'] && !empty($item_profile['followers'])) {
-					$receiver = $item_profile['followers'];
+					$permissions[$element][] = $item_profile['followers'];
 				}
 				if (!in_array($receiver, $exclude)) {
 					$permissions[$element][] = $receiver;


### PR DESCRIPTION
It seems to be according to the standards that we copy all receivers from the previous post - including the collections. So we now do so.