### PR TITLE
Road to Router Part 3: Move $strings out of App

### DIFF
--- a/bin/worker.php
+++ b/bin/worker.php
@@ -7,7 +7,6 @@
 use Friendica\App;
 use Friendica\Core\Config;
 use Friendica\Core\Worker;
-use Friendica\Core\L10n;
 
 // Get options
 $shortopts = 'sn';
@@ -29,9 +28,6 @@ if (!file_exists("boot.php") && (sizeof($_SERVER["argv"]) != 0)) {
 require_once "boot.php";
 
 $a = new App(dirname(__DIR__));
-
-$lang = L10n::getBrowserLanguage();
-L10n::loadTranslationTable($lang);
 
 // Check the database structure and possibly fixes it
 check_db(true);

--- a/mod/register.php
+++ b/mod/register.php
@@ -63,7 +63,7 @@ function register_post(App $a)
 
 	$arr['blocked'] = $blocked;
 	$arr['verified'] = $verified;
-	$arr['language'] = L10n::getBrowserLanguage();
+	$arr['language'] = L10n::detectLanguage();
 
 	try {
 		$result = Model\User::create($arr);

--- a/src/Core/Console/Maintenance.php
+++ b/src/Core/Console/Maintenance.php
@@ -68,11 +68,6 @@ HELP;
 			throw new \RuntimeException('Database isn\'t ready or populated yet');
 		}
 
-		Core\Config::load();
-
-		$lang = Core\L10n::getBrowserLanguage();
-		Core\L10n::loadTranslationTable($lang);
-
 		$enabled = intval($this->getArgument(0));
 
 		Core\Config::set('system', 'maintenance', $enabled);

--- a/src/Core/L10n.php
+++ b/src/Core/L10n.php
@@ -23,26 +23,26 @@ class L10n extends BaseObject
 	 * - Two-letter ISO 639-1 code + dash + Two-letter ISO 3166-1 alpha-2 country code.
 	 * @var string
 	 */
-	private $lang = '';
+	private static $lang = '';
 	/**
 	 * A language code saved for later after pushLang() has been called.
 	 *
 	 * @var string
 	 */
-	private $langSave = '';
+	private static $langSave = '';
 
 	/**
 	 * An array of translation strings whose key is the neutral english message.
 	 *
 	 * @var array
 	 */
-	private $strings = [];
+	private static $strings = [];
 	/**
 	 * An array of translation strings saved for later after pushLang() has been called.
 	 *
 	 * @var array
 	 */
-	private $stringsSave = [];
+	private static $stringsSave = [];
 
 	/**
 	 * Detects the language and sets the translation table

--- a/src/Util/Temporal.php
+++ b/src/Util/Temporal.php
@@ -217,13 +217,13 @@ class Temporal
 		// First day of the week (0 = Sunday)
 		$firstDay = PConfig::get(local_user(), 'system', 'first_day_of_week', 0);
 
-		$lang = substr(L10n::getBrowserLanguage(), 0, 2);
+		$lang = substr(L10n::getCurrentLang(), 0, 2);
 
 		// Check if the detected language is supported by the picker
 		if (!in_array($lang,
 				["ar", "ro", "id", "bg", "fa", "ru", "uk", "en", "el", "de", "nl", "tr", "fr", "es", "th", "pl", "pt", "ch", "se", "kr",
 				"it", "da", "no", "ja", "vi", "sl", "cs", "hu"])) {
-			$lang = Config::get('system', 'language', 'en');
+			$lang = 'en';
 		}
 
 		$o = '';


### PR DESCRIPTION
Follow-up to #5979
Follow-up to #5987

Now that `index.php` is completely shaved of all unrelated code, it's time for the `App`.

This time, we move all localization-related code in the already existing `L10n` class that gets 4 new static properties that used to be tacked on the App object for a bad reason.