### PR TITLE
Fix adding / removing photo tags

### DIFF
--- a/mod/photos.php
+++ b/mod/photos.php
@@ -1419,12 +1419,13 @@ function photos_content(App $a)
 			// parse tags and add links
 			$tag_arr = [];
 			foreach ($arr as $tag) {
-				array_push($tag_arr, ['name' => BBCode::convert($tag), 'removeurl' => '/tagrm/'.$link_item['id'] . '/' . bin2hex($tag)]);
+				array_push($tag_arr, ['name' => BBCode::convert($tag),
+                   'removeurl' => '/tagrm/'.$link_item['id'] . '/' . bin2hex($tag)]);
 			}
 			$tags = ['title' => L10n::t('Tags: '), 'tags' => $tag_arr];
 			if ($cmd === 'edit') {
 				$tags += ['removeanyurl' => 'tagrm/' . $link_item['id']];
-				$tags += ['removetitle' => L10n::t('[Remove any tag]')];
+				$tags += ['removetitle' => L10n::t('[Select tags to remove]')];
 			}
 		}
 

--- a/mod/photos.php
+++ b/mod/photos.php
@@ -1418,9 +1418,8 @@ function photos_content(App $a)
 			$arr = explode(',', $link_item['tag']);
 			// parse tags and add links
 			$tag_arr = [];
-			foreach ($arr as $t) {
-				array_push($tag_arr, ['name' => BBCode::convert($t),
-					'removeurl' => '/tagrm/'.$link_item['id'] . '/' . bin2hex($t)]);
+			foreach ($arr as $tag) {
+				array_push($tag_arr, ['name' => BBCode::convert($tag), 'removeurl' => '/tagrm/'.$link_item['id'] . '/' . bin2hex($tag)]);
 			}
 			$tags = ['title' => L10n::t('Tags: '), 'tags' => $tag_arr];
 			if ($cmd === 'edit') {

--- a/mod/photos.php
+++ b/mod/photos.php
@@ -612,7 +612,7 @@ function photos_post(App $a)
 						}
 					} elseif (strpos($tag, '#') === 0) {
 						$tagname = substr($tag, 1);
-						$str_tags .= '#[url=' . System::baseUrl() . "/search?tag=" . $tagname . ']' . $tagname . '[/url]';
+						$str_tags .= '#[url=' . System::baseUrl() . "/search?tag=" . $tagname . ']' . $tagname . '[/url],';
 					}
 				}
 			}
@@ -1417,17 +1417,15 @@ function photos_content(App $a)
 		if (count($linked_items) && strlen($link_item['tag'])) {
 			$arr = explode(',', $link_item['tag']);
 			// parse tags and add links
-			$tag_str = '';
+			$tag_arr = [];
 			foreach ($arr as $t) {
-				if (strlen($tag_str)) {
-					$tag_str .= ', ';
-				}
-				$tag_str .= BBCode::convert($t);
+				array_push($tag_arr, ['name' => BBCode::convert($t),
+					'removeurl' => '/tagrm/'.$link_item['id'] . '/' . bin2hex($t)]);
 			}
-			$tags = [L10n::t('Tags: '), $tag_str];
+			$tags = ['title' => L10n::t('Tags: '), 'tags' => $tag_arr];
 			if ($cmd === 'edit') {
-				$tags[] = 'tagrm/' . $link_item['id'];
-				$tags[] = L10n::t('[Remove any tag]');
+				$tags += ['removeanyurl' => 'tagrm/' . $link_item['id']];
+				$tags += ['removetitle' => L10n::t('[Remove any tag]')];
 			}
 		}
 

--- a/mod/photos.php
+++ b/mod/photos.php
@@ -1419,13 +1419,15 @@ function photos_content(App $a)
 			// parse tags and add links
 			$tag_arr = [];
 			foreach ($arr as $tag) {
-				array_push($tag_arr, ['name' => BBCode::convert($tag), 
-					'removeurl' => '/tagrm/'.$link_item['id'] . '/' . bin2hex($tag)]);
+				$tag_arr[] = [
+					'name' => BBCode::convert($tag),
+					'removeurl' => '/tagrm/'.$link_item['id'] . '/' . bin2hex($tag)
+				];
 			}
 			$tags = ['title' => L10n::t('Tags: '), 'tags' => $tag_arr];
 			if ($cmd === 'edit') {
-				$tags += ['removeanyurl' => 'tagrm/' . $link_item['id']];
-				$tags += ['removetitle' => L10n::t('[Select tags to remove]')];
+				$tags['removeanyurl'] = 'tagrm/' . $link_item['id'];
+				$tags['removetitle'] = L10n::t('[Select tags to remove]');
 			}
 		}
 

--- a/mod/photos.php
+++ b/mod/photos.php
@@ -1419,8 +1419,8 @@ function photos_content(App $a)
 			// parse tags and add links
 			$tag_arr = [];
 			foreach ($arr as $tag) {
-				array_push($tag_arr, ['name' => BBCode::convert($tag),
-                   'removeurl' => '/tagrm/'.$link_item['id'] . '/' . bin2hex($tag)]);
+				array_push($tag_arr, ['name' => BBCode::convert($tag), 
+					'removeurl' => '/tagrm/'.$link_item['id'] . '/' . bin2hex($tag)]);
 			}
 			$tags = ['title' => L10n::t('Tags: '), 'tags' => $tag_arr];
 			if ($cmd === 'edit') {

--- a/mod/tagrm.php
+++ b/mod/tagrm.php
@@ -71,9 +71,6 @@ function update_tags($item_id, $tags){
 	Item::update(['tag' => $tag_str], ['id' => $item_id]);
 
 	info(L10n::t('Tag(s) removed') . EOL );
-	$a->internalRedirect($_SESSION['photo_return']);
-
-	// NOTREACHED
 }
 
 function tagrm_content(App $a)

--- a/mod/tagrm.php
+++ b/mod/tagrm.php
@@ -29,8 +29,6 @@ function tagrm_post(App $a)
 	$item_id = defaults($_POST,'item', 0);
 	update_tags($item_id, $tags);
 
-	info(L10n::t('Tag(s) removed') . EOL );
-
 	$a->internalRedirect($_SESSION['photo_return']);
 
 	// NOTREACHED
@@ -43,12 +41,12 @@ function tagrm_post(App $a)
  */
 function update_tags($item_id, $tags){
 	if (empty($item_id) || empty($tags)){
-		$a->internalRedirect($_SESSION['photo_return']);
+		return;
 	}
 
 	$item = Item::selectFirst(['tag'], ['id' => $item_id, 'uid' => local_user()]);
 	if (!DBA::isResult($item)) {
-		$a->internalRedirect($_SESSION['photo_return']);
+		return;
 	}
 
 	$old_tags = explode(',', $item['tag']);
@@ -63,12 +61,7 @@ function update_tags($item_id, $tags){
 	}
 
 	$tag_str = implode(',',$old_tags);
-	if(!empty($tag_str)) {
-		Item::update(['tag' => $tag_str], ['id' => $item_id]);
-	}
-	else {
-		Term::deleteByItemId($item_id);
-	}
+	Term::insertFromTagFieldByItemId($item_id, $tag_str);
 
 	info(L10n::t('Tag(s) removed') . EOL );
 }

--- a/mod/tagrm.php
+++ b/mod/tagrm.php
@@ -22,14 +22,14 @@ function tagrm_post(App $a)
 
 	$tags = [];
 	foreach (defaults($_POST, 'tag', []) as $tag) {
-		array_push($tags, hex2bin(notags(trim($tag))));
+		$tags[] = hex2bin(notags(trim($tag)));
 	}
 
 	$item_id = defaults($_POST,'item', 0);
 	update_tags($item_id, $tags);
+	info(L10n::t('Tag(s) removed') . EOL);
 
 	$a->internalRedirect($_SESSION['photo_return']);
-
 	// NOTREACHED
 }
 
@@ -51,18 +51,16 @@ function update_tags($item_id, $tags){
 	$old_tags = explode(',', $item['tag']);
 
 	foreach ($tags as $new_tag) {
-		foreach ($old_tags as $count => $old_tag) {
+		foreach ($old_tags as $index => $old_tag) {
 			if (strcmp($old_tag, $new_tag) == 0) {
-				unset($old_tags[$count]);
+				unset($old_tags[$index]);
 				break;
 			}
 		}
 	}
 
-	$tag_str = implode(',',$old_tags);
+	$tag_str = implode(',', $old_tags);
 	Term::insertFromTagFieldByItemId($item_id, $tag_str);
-
-	info(L10n::t('Tag(s) removed') . EOL);
 }
 
 function tagrm_content(App $a)
@@ -75,7 +73,7 @@ function tagrm_content(App $a)
 	}
 
 	if ($a->argc == 3) {
-		update_tags($a->argv[1], [hex2bin(notags(trim($a->argv[2])))]);
+		update_tags($a->argv[1], [notags(trim(hex2bin($a->argv[2])))]);
 		$a->internalRedirect($_SESSION['photo_return']);
 	}
 

--- a/mod/tagrm.php
+++ b/mod/tagrm.php
@@ -63,7 +63,7 @@ function update_tags($item_id, $tags){
 	$tag_str = implode(',',$old_tags);
 	Term::insertFromTagFieldByItemId($item_id, $tag_str);
 
-	info(L10n::t('Tag(s) removed') . EOL );
+	info(L10n::t('Tag(s) removed') . EOL);
 }
 
 function tagrm_content(App $a)
@@ -75,7 +75,7 @@ function tagrm_content(App $a)
 		// NOTREACHED
 	}
 
-	if ($a->argc == 3){
+	if ($a->argc == 3) {
 		update_tags($a->argv[1], [hex2bin(notags(trim($a->argv[2])))]);
 		$a->internalRedirect($_SESSION['photo_return']);
 	}

--- a/mod/tagrm.php
+++ b/mod/tagrm.php
@@ -82,7 +82,7 @@ function tagrm_content(App $a)
 
 	if ($a->argc == 3){
 		update_tags($a->argv[1], [hex2bin(notags(trim($a->argv[2])))]);
-		goaway('/' . $_SESSION['photo_return']);
+		$a->internalRedirect($_SESSION['photo_return']);
 	}
 
 	$item_id = (($a->argc > 1) ? intval($a->argv[1]) : 0);

--- a/mod/tagrm.php
+++ b/mod/tagrm.php
@@ -37,6 +37,11 @@ function tagrm_post(App $a)
 	// NOTREACHED
 }
 
+/**
+ * Updates tags from an item
+ * @param $item_id
+ * @param $tags array
+ */
 function update_tags($item_id, $tags){
 	if (empty($item_id) || empty($tags)){
 		$a->internalRedirect($_SESSION['photo_return']);

--- a/mod/tagrm.php
+++ b/mod/tagrm.php
@@ -6,7 +6,6 @@
 use Friendica\App;
 use Friendica\Content\Text\BBCode;
 use Friendica\Core\L10n;
-use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\Model\Item;
 use Friendica\Model\Term;

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -816,7 +816,7 @@ class Item extends BaseObject
 			$tags = $fields['tag'];
 			$fields['tag'] = null;
 		} else {
-			$tags = '';
+			$tags = null;
 		}
 
 		if (array_key_exists('file', $fields)) {
@@ -895,10 +895,14 @@ class Item extends BaseObject
 				}
 			}
 
-			if (!empty($tags)) {
-				Term::insertFromTagFieldByItemId($item['id'], $tags);
-				if (!empty($item['tag'])) {
-					DBA::update('item', ['tag' => ''], ['id' => $item['id']]);
+			if (!is_null($tags)) {
+				Term::deleteAllTags($item['id']);
+
+				if ($tags) {
+					Term::insertFromTagFieldByItemId($item['id'], $tags);
+					if (!empty($item['tag'])) {
+						DBA::update('item', ['tag' => ''], ['id' => $item['id']]);
+					}
 				}
 			}
 

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -896,14 +896,9 @@ class Item extends BaseObject
 			}
 
 			if (!is_null($tags)) {
-				if ($tags) {
-					Term::insertFromTagFieldByItemId($item['id'], $tags);
-					if (!empty($item['tag'])) {
-						DBA::update('item', ['tag' => ''], ['id' => $item['id']]);
-					}
-				}
-				else {
-					Term::deleteAllTags($item['id']);
+				Term::insertFromTagFieldByItemId($item['id'], $tags);
+				if (!empty($item['tag'])) {
+					DBA::update('item', ['tag' => ''], ['id' => $item['id']]);
 				}
 			}
 

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -896,13 +896,14 @@ class Item extends BaseObject
 			}
 
 			if (!is_null($tags)) {
-				Term::deleteAllTags($item['id']);
-
 				if ($tags) {
 					Term::insertFromTagFieldByItemId($item['id'], $tags);
 					if (!empty($item['tag'])) {
 						DBA::update('item', ['tag' => ''], ['id' => $item['id']]);
 					}
+				}
+				else {
+					Term::deleteAllTags($item['id']);
 				}
 			}
 

--- a/src/Model/Term.php
+++ b/src/Model/Term.php
@@ -290,4 +290,19 @@ class Term
 
 		return $return;
 	}
+
+	/*
+	 * Deletes all Tags from an item
+	 */
+	public static function deleteAllTags($itemid)
+	{
+		$message = Item::selectFirst(['id'], ['id' => $itemid]);
+		if (!DBA::isResult($message)) {
+			return;
+		}
+
+		// Clean up all tags
+		DBA::delete('term', ['otype' => TERM_OBJ_POST, 'oid' => $itemid, 'type' => [TERM_HASHTAG, TERM_MENTION]]);
+
+	}
 }

--- a/src/Model/Term.php
+++ b/src/Model/Term.php
@@ -76,7 +76,7 @@ class Term
 		$message['tag'] = $tags;
 
 		// Clean up all tags
-		DBA::delete('term', ['otype' => TERM_OBJ_POST, 'oid' => $itemid, 'type' => [TERM_HASHTAG, TERM_MENTION]]);
+		self::deleteByItemId($itemid);
 
 		if ($message['deleted']) {
 			return;
@@ -294,16 +294,16 @@ class Term
 	/**
 	 * Delete all tags from an item
 	 * @param int itemid - choose from which item the tags will be removed
+	 * @param array type - items type. default is [TERM_HASHTAG, TERM_MENTION]
 	 */
-	public static function deleteAllTags($itemid)
+	public static function deleteByItemId($itemid, $type = [TERM_HASHTAG, TERM_MENTION])
 	{
-		$message = Item::selectFirst(['id'], ['id' => $itemid]);
-		if (!DBA::isResult($message)) {
+		if (empty($itemid)) {
 			return;
 		}
 
 		// Clean up all tags
-		DBA::delete('term', ['otype' => TERM_OBJ_POST, 'oid' => $itemid, 'type' => [TERM_HASHTAG, TERM_MENTION]]);
+		DBA::delete('term', ['otype' => TERM_OBJ_POST, 'oid' => $itemid, 'type' => $type]);
 
 	}
 }

--- a/src/Model/Term.php
+++ b/src/Model/Term.php
@@ -291,8 +291,9 @@ class Term
 		return $return;
 	}
 
-	/*
-	 * Deletes all Tags from an item
+	/**
+	 * Delete all tags from an item
+	 * @param int itemid - choose from which item the tags will be removed
 	 */
 	public static function deleteAllTags($itemid)
 	{

--- a/view/theme/frio/templates/photo_view.tpl
+++ b/view/theme/frio/templates/photo_view.tpl
@@ -51,12 +51,19 @@
 
 		{{* Tags and mentions *}}
 		{{if $tags}}
-		<div id="photo-tags">{{$tags.1}}</div>
+		<div id="photo-tags">{{$tags.title}}
+		{{foreach $tags.tags as $t}}
+		<span class="category label btn-success sm">
+			<span class="p-category">{{$t.name}}</span>
+			{{if $t.removeurl}} (<a href="{{$t.removeurl}}">x</a>) {{/if}}
+		</span>
+		{{/foreach}}
+		</div>
 		{{/if}}
 
-		{{if $tags.2}}
+		{{if $tags.removeanyurl}}
 		<div id="tag-remove">
-			<a href="{{$tags.2}}">{{$tags.3}}</a>
+			<a href="{{$tags.removeanyurl}}">{{$tags.removetitle}}</a>
 		</div>
 		{{/if}}
 

--- a/view/theme/frio/templates/photo_view.tpl
+++ b/view/theme/frio/templates/photo_view.tpl
@@ -55,7 +55,7 @@
 			{{foreach $tags.tags as $t}}
 			<span class="category label btn-success sm">
 				<span class="p-category">{{$t.name}}</span>
-				{{if $t.removeurl}} (<a href="{{$t.removeurl}}">x</a>) {{/if}}
+				{{if $t.removeurl}} <a href="{{$t.removeurl}}">(X)</a> {{/if}}
 			</span>
 			{{/foreach}}
 		</div>

--- a/view/theme/frio/templates/photo_view.tpl
+++ b/view/theme/frio/templates/photo_view.tpl
@@ -52,12 +52,12 @@
 		{{* Tags and mentions *}}
 		{{if $tags}}
 		<div id="photo-tags">{{$tags.title}}
-		{{foreach $tags.tags as $t}}
-		<span class="category label btn-success sm">
-			<span class="p-category">{{$t.name}}</span>
-			{{if $t.removeurl}} (<a href="{{$t.removeurl}}">x</a>) {{/if}}
-		</span>
-		{{/foreach}}
+			{{foreach $tags.tags as $t}}
+			<span class="category label btn-success sm">
+				<span class="p-category">{{$t.name}}</span>
+				{{if $t.removeurl}} (<a href="{{$t.removeurl}}">x</a>) {{/if}}
+			</span>
+			{{/foreach}}
 		</div>
 		{{/if}}
 


### PR DESCRIPTION
reopen #6002 with fixed branch
To issue #5915

- changing the `Item:update` function for the field tag
- adding a `Term::deleteAllTags` function
- adding the possiblity to remove tag via GET `/tagrm/[id]/[hex(Tag)]`
- display photo tags like categories in post with delete button
![screenshot_2018-10-23_10-58-26](https://user-images.githubusercontent.com/10757520/47348865-ad035680-d6b2-11e8-8af5-62b5163e0a40.png)
- fix tagrm return when no photo has no tag
~~- remove `System::baseUrl()` from goaway~~