### PR TITLE
Fix unsetting non-existent index in Addon::$addons on uninstall

### DIFF
--- a/src/Core/Addon.php
+++ b/src/Core/Addon.php
@@ -84,7 +84,7 @@ class Addon extends BaseObject
 			$func();
 		}
 
-		unset(self::$addons[$idx]);
+		unset(self::$addons[array_search($addon, self::$addons)]);
 	}
 
 	/**


### PR DESCRIPTION
Follow-up to #5981

See https://friendica.mrpetovan.com/display/ec054ce7-195b-d0bd-649a-219615906851

