### PR TITLE
Fixes duplicated transmissions and not working undo of like/dislike

### DIFF
--- a/mod/item.php
+++ b/mod/item.php
@@ -830,9 +830,6 @@ function item_post(App $a) {
 	// We don't fork a new process since this is done anyway with the following command
 	Worker::add(['priority' => PRIORITY_HIGH, 'dont_fork' => true], "CreateShadowEntry", $post_id);
 
-	// Call the background process that is delivering the item to the receivers
-	Worker::add(PRIORITY_HIGH, "Notifier", $notify_type, $post_id);
-
 	logger('post_complete');
 
 	if ($api_source) {

--- a/mod/photos.php
+++ b/mod/photos.php
@@ -691,9 +691,6 @@ function photos_post(App $a)
 					$arr['target'] .= '<link>' . xmlify('<link rel="alternate" type="text/html" href="' . System::baseUrl() . '/photos/' . $owner_record['nickname'] . '/image/' . $p[0]['resource-id'] . '" />' . "\n" . '<link rel="preview" type="'.$p[0]['type'].'" href="' . System::baseUrl() . "/photo/" . $p[0]['resource-id'] . '-' . $best . '.' . $ext . '" />') . '</link></target>';
 
 					$item_id = Item::insert($arr);
-					if ($item_id) {
-						Worker::add(PRIORITY_HIGH, "Notifier", "tag", $item_id);
-					}
 				}
 			}
 		}
@@ -918,10 +915,6 @@ function photos_post(App $a)
 	$item_id = Item::insert($arr);
 	// Update the photo albums cache
 	Photo::clearAlbumCache($page_owner_uid);
-
-	if ($visible) {
-		Worker::add(PRIORITY_HIGH, "Notifier", 'wall-new', $item_id);
-	}
 
 	Addon::callHooks('photo_post_end', $item_id);
 

--- a/mod/poke.php
+++ b/mod/poke.php
@@ -128,9 +128,6 @@ function poke_init(App $a)
 	$arr['object'] .= '</link></object>' . "\n";
 
 	$item_id = Item::insert($arr);
-	if ($item_id) {
-		Worker::add(PRIORITY_HIGH, "Notifier", "tag", $item_id);
-	}
 
 	Addon::callHooks('post_local_end', $arr);
 

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -549,15 +549,19 @@ class Transmitter
 	 * Creates the activity or fetches it from the cache
 	 *
 	 * @param integer $item_id
+	 * @param boolean $force   Force new cache entry
 	 *
 	 * @return array with the activity
 	 */
-	public static function createCachedActivityFromItem($item_id)
+	public static function createCachedActivityFromItem($item_id, $force = false)
 	{
 		$cachekey = 'APDelivery:createActivity:' . $item_id;
-		$data = Cache::get($cachekey);
-		if (!is_null($data)) {
-			return $data;
+
+		if (!$force) {
+			$data = Cache::get($cachekey);
+			if (!is_null($data)) {
+				return $data;
+			}
 		}
 
 		$data = ActivityPub\Transmitter::createActivityFromItem($item_id);

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -4113,14 +4113,14 @@ class Diaspora
 	}
 
 	/**
-	 * @brief Stores the signature for likes that are created on our system
+	 * @brief Creates the signature for likes that are created on our system
 	 *
 	 * @param array $contact The contact array of the "like"
-	 * @param int   $post_id The post id of the "like"
+	 * @param array $item Item array
 	 *
-	 * @return bool Success
+	 * @return array Signed content
 	 */
-	public static function storeLikeSignature(array $contact, $post_id)
+	public static function createLikeSignature(array $contact, array $item)
 	{
 		// Is the contact the owner? Then fetch the private key
 		if (!$contact['self'] || ($contact['uid'] == 0)) {
@@ -4135,11 +4135,6 @@ class Diaspora
 
 		$contact["uprvkey"] = $user['prvkey'];
 
-		$item = Item::selectFirst([], ['id' => $post_id]);
-		if (!DBA::isResult($item)) {
-			return false;
-		}
-
 		if (!in_array($item["verb"], [ACTIVITY_LIKE, ACTIVITY_DISLIKE])) {
 			return false;
 		}
@@ -4151,14 +4146,7 @@ class Diaspora
 
 		$message["author_signature"] = self::signature($contact, $message);
 
-		/*
-		 * Now store the signature more flexible to dynamically support new fields.
-		 * This will break Diaspora compatibility with Friendica versions prior to 3.5.
-		 */
-		DBA::insert('sign', ['iid' => $post_id, 'signed_text' => json_encode($message)]);
-
-		logger('Stored diaspora like signature');
-		return true;
+		return $message;
 	}
 
 	/**

--- a/src/Worker/Notifier.php
+++ b/src/Worker/Notifier.php
@@ -539,7 +539,7 @@ class Notifier
 		}
 
 		// Fill the item cache
-		ActivityPub\Transmitter::createCachedActivityFromItem($item_id);
+		ActivityPub\Transmitter::createCachedActivityFromItem($item_id, true);
 
 		foreach ($inboxes as $inbox) {
 			logger('Deliver ' . $item_id .' to ' . $inbox .' via ActivityPub', LOGGER_DEBUG);


### PR DESCRIPTION
This fixes several problems:

1. We always delivered comments and likes twice, since we called the notifier at several places. This is now unified.
2. Undoing a like or dislike had only worked, when the undoing hadn't been done too quickly. This happened due to the caching.