### PR TITLE
Diaspora signatures are now stored and transmitted correctly

### DIFF
--- a/mod/item.php
+++ b/mod/item.php
@@ -727,6 +727,11 @@ function item_post(App $a) {
 	unset($datarray['self']);
 	unset($datarray['api_source']);
 
+	$signed = Diaspora::createCommentSignature($author, $datarray);
+	if (!empty($signed)) {
+		$datarray['diaspora_signed_text'] = json_encode($signed);
+	}
+
 	$post_id = Item::insert($datarray);
 
 	if (!$post_id) {
@@ -765,9 +770,6 @@ function item_post(App $a) {
 				'parent_uri'   => $parent_item['uri']
 			]);
 		}
-
-		// Store the comment signature information in case we need to relay to Diaspora
-		Diaspora::storeCommentSignature($datarray, $author, ($self ? $user['prvkey'] : false), $post_id);
 	} else {
 		if (($contact_record != $author) && !count($forum_contact)) {
 			notification([

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -3113,7 +3113,7 @@ class Item extends BaseObject
 
 		$signed = Diaspora::createLikeSignature($item_contact, $new_item);
 		if (!empty($signed)) {
-			$new_item['diaspora_signed_text'] = $signed;
+			$new_item['diaspora_signed_text'] = json_encode($signed);
 		}
 
 		$new_item_id = self::insert($new_item);

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -144,6 +144,8 @@ class Processor
 			self::fetchMissingActivity($activity['reply-to-id'], $activity);
 		}
 
+		$item['diaspora_signed_text'] = defaults($activity, 'diaspora:comment', '');
+
 		self::postItem($activity, $item);
 	}
 
@@ -173,6 +175,8 @@ class Processor
 		$item['parent-uri'] = $activity['object_id'];
 		$item['gravity'] = GRAVITY_ACTIVITY;
 		$item['object-type'] = ACTIVITY_OBJ_NOTE;
+
+		$item['diaspora_signed_text'] = defaults($activity, 'diaspora:like', '');
 
 		self::postItem($activity, $item);
 	}
@@ -260,7 +264,6 @@ class Processor
 		$item['tag'] = self::constructTagList($activity['tags'], $activity['sensitive']);
 		$item['app'] = $activity['generator'];
 		$item['plink'] = defaults($activity, 'alternate-url', $item['uri']);
-		$item['diaspora_signed_text'] = defaults($activity, 'diaspora:comment', '');
 
 		$item = self::constructAttachList($activity['attachments'], $item);
 

--- a/src/Protocol/ActivityPub/Receiver.php
+++ b/src/Protocol/ActivityPub/Receiver.php
@@ -705,6 +705,7 @@ class Receiver
 
 		$object_data['diaspora:guid'] = JsonLD::fetchElement($object, 'diaspora:guid');
 		$object_data['diaspora:comment'] = JsonLD::fetchElement($object, 'diaspora:comment');
+		$object_data['diaspora:like'] = JsonLD::fetchElement($object, 'diaspora:like');
 		$object_data['actor'] = $object_data['author'] = $actor;
 		$object_data['context'] = JsonLD::fetchElement($object, 'as:context');
 		$object_data['conversation'] = JsonLD::fetchElement($object, 'ostatus:conversation');

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -627,6 +627,9 @@ class Transmitter
 			$data['object'] = self::createActivityFromItem($item_id, true);
 		} else {
 			$data['diaspora:guid'] = $item['guid'];
+			if (!empty($item['signed_text'])) {
+				$data['diaspora:like'] = $item['signed_text'];
+			}
 			$data['object'] = $item['thr-parent'];
 		}
 


### PR DESCRIPTION
The previous PR contained some bug, so that signatures hadn't been stored with likes. Additionally the storing of Diaspora signatures for comments had been improved. And finally the signature for likes is now transmitted and processed via AP.