### PR TITLE
[frio] Show error message on image upload

### DIFF
--- a/view/theme/frio/js/filebrowser.js
+++ b/view/theme/frio/js/filebrowser.js
@@ -176,6 +176,7 @@ var FileBrowser = {
 					},
 					onComplete: function(file,response) {
 						if (response['error'] != undefined) {
+							$(".fbrowser-content").show();
 							$(".error span").html(response['error']);
 							$(".error").removeClass('hidden');
 							$(".fbrowser .profile-rotator-wrapper").hide();

--- a/view/theme/frio/js/filebrowser.js
+++ b/view/theme/frio/js/filebrowser.js
@@ -176,10 +176,10 @@ var FileBrowser = {
 					},
 					onComplete: function(file,response) {
 						if (response['error'] != undefined) {
-							$(".fbrowser-content").show();
 							$(".error span").html(response['error']);
 							$(".error").removeClass('hidden');
 							$(".fbrowser .profile-rotator-wrapper").hide();
+							$(".fbrowser-content").show();
 							return;
 						}
 
@@ -210,6 +210,7 @@ var FileBrowser = {
 							$(".error span").html(response['error']);
 							$(".error").removeClass('hidden');
 							$('#profile-rotator').hide();
+							$(".fbrowser-content").show();
 							return;
 						}
 

--- a/view/theme/frio/templates/filebrowser.tpl
+++ b/view/theme/frio/templates/filebrowser.tpl
@@ -13,7 +13,7 @@
 		<input id="fb-type" type="hidden" name="type" value="{{$type}}" />
 
 		<div class="error hidden">
-			<span></span> <button type="button" class="btn btn-link" class="close" aria-label="Close">X</a>
+			<span></span> <button type="button" class="btn btn-link close" aria-label="Close">X</a>
 		</div>
 
 		{{* The breadcrumb navigation *}}


### PR DESCRIPTION
Fixes #6027

- show filebrowser after failed upload to display error message
- make close button closing message again

![screenshot_2018-10-29_23-12-09](https://user-images.githubusercontent.com/10757520/47683536-27126e80-dbd0-11e8-97e6-73dc80fedc70.png)
