### PR TITLE
 Frio - on mobiles the links in the thread will always have the link color (disabling thread hover effect)

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -1538,11 +1538,11 @@ aside .panel-body {
 }
 
 /* Thread hover effects */
-.wall-item-container .wall-item-content a,
-.wall-item-container a,
-.wall-item-container .fakelink,
-.toplevel_item .fakelink,
-.toplevel_item .wall-item-container .wall-item-responses a {
+.desktop-view .wall-item-container .wall-item-content a,
+.desktop-view .wall-item-container a,
+.desktop-view .wall-item-container .fakelink,
+.desktop-view .toplevel_item .fakelink,
+.desktop-view .toplevel_item .wall-item-container .wall-item-responses a {
     color: #555;
     -webkit-transition: all 0.25s ease-in-out;
     -moz-transition: all 0.25s ease-in-out;

--- a/view/theme/frio/php/default.php
+++ b/view/theme/frio/php/default.php
@@ -18,6 +18,8 @@ require_once 'view/theme/frio/php/frio_boot.php';
 if (!isset($minimal)) {
 	$minimal = false;
 }
+
+$view_mode_class = ($a->is_mobile || $a->is_tablet) ? 'mobile-view' : 'desktop-view';
 ?>
 <html>
 	<head>
@@ -63,7 +65,7 @@ if (!isset($minimal)) {
 ?>
 	</head>
 
-	<body id="top" class="mod-<?php echo $a->module." ".$is_singleuser_class;?>">
+	<body id="top" class="mod-<?php echo $a->module . " " . $is_singleuser_class . " " . $view_mode_class;?>">
 		<a href="#content" class="sr-only sr-only-focusable">Skip to main content</a>
 <?php
 	if (x($page, 'nav') && !$minimal) {

--- a/view/theme/frio/php/default.php
+++ b/view/theme/frio/php/default.php
@@ -19,7 +19,11 @@ if (!isset($minimal)) {
 	$minimal = false;
 }
 
+$basepath = $a->getURLPath() ? "/" . $a->getURLPath() . "/" : "/";
+$frio = "view/theme/frio";
 $view_mode_class = ($a->is_mobile || $a->is_tablet) ? 'mobile-view' : 'desktop-view';
+$is_singleuser = Config::get('system', 'singleuser');
+$is_singleuser_class = $is_singleuser ? "is-singleuser" : "is-not-singleuser";
 ?>
 <html>
 	<head>
@@ -28,9 +32,6 @@ $view_mode_class = ($a->is_mobile || $a->is_tablet) ? 'mobile-view' : 'desktop-v
 		<script  type="text/javascript">var baseurl = "<?php echo System::baseUrl(); ?>";</script>
 		<script type="text/javascript">var frio = "<?php echo 'view/theme/frio'; ?>";</script>
 <?php
-		$basepath = $a->getURLPath() ? "/" . $a->getURLPath() . "/" : "/";
-		$frio = "view/theme/frio";
-
 		// Because we use minimal for modals the header and the included js stuff should be only loaded
 		// if the page is an standard page (so we don't have it twice for modals)
 		//
@@ -54,14 +55,12 @@ $view_mode_class = ($a->is_mobile || $a->is_tablet) ? 'mobile-view' : 'desktop-v
 		} else {
 			$nav_bg = PConfig::get($uid, 'frio', 'nav_bg');
 		}
+
 		if (empty($nav_bg)) {
 			$nav_bg = "#708fa0";
 		}
-		echo '
-			<meta name="theme-color" content="' . $nav_bg . '" />';
 
-		$is_singleuser = Config::get('system','singleuser');
-		$is_singleuser_class = $is_singleuser ? "is-singleuser" : "is-not-singleuser";
+		echo '<meta name="theme-color" content="' . $nav_bg . '" />';
 ?>
 	</head>
 
@@ -83,7 +82,7 @@ $view_mode_class = ($a->is_mobile || $a->is_tablet) ? 'mobile-view' : 'desktop-v
 	// special minimal style for modal dialogs
 	if ($minimal) {
 ?>
-		<section class="minimal" style="margin:0px!important; padding:0px!important; float:none!important;display:block!important;">
+		<section class="minimal" style="margin:0px!important; padding:0px!important; float:none!important; display:block!important;">
 			<?php if (x($page, 'content')) echo $page['content']; ?>
 			<div id="page-footer"></div>
 		</section>


### PR DESCRIPTION
fixes https://github.com/friendica/friendica/issues/6018

This PR adds a `mobile-view` or `desktop-view` class to Frio's html body according to the used device. Because hover effects doesn't make that much sense on touchscreen devices, the link-highlight effects for threads (hover over a thread and all links will get the link color) are disabled by this PR. So links should be better recognizable on touchscreen devices.