### PR TITLE
Return correctly after post deletion (Non-Ajax)

### DIFF
--- a/include/items.php
+++ b/include/items.php
@@ -345,7 +345,7 @@ function drop_items(array $items)
 	}
 }
 
-function drop_item($id)
+function drop_item($id, $return)
 {
 	$a = BaseObject::getApp();
 
@@ -409,8 +409,16 @@ function drop_item($id)
 		// delete the item
 		Item::deleteForUser(['id' => $item['id']], local_user());
 
-		$a->internalRedirect('network');
-		//NOTREACHED
+		$return_url = hex2bin($return);
+		notice("RETURN: " + $return_url);
+		if (empty($return_url) || strpos($return_url, 'display') ) {
+			$a->internalRedirect('network');
+			//NOTREACHED
+		}
+		else {
+			$a->internalRedirect($return_url);
+			//NOTREACHED
+		}
 	} else {
 		notice(L10n::t('Permission denied.') . EOL);
 		$a->internalRedirect('display/' . $item['guid']);

--- a/include/items.php
+++ b/include/items.php
@@ -345,7 +345,7 @@ function drop_items(array $items)
 	}
 }
 
-function drop_item($id, $return)
+function drop_item($id, $return = '')
 {
 	$a = BaseObject::getApp();
 
@@ -410,8 +410,7 @@ function drop_item($id, $return)
 		Item::deleteForUser(['id' => $item['id']], local_user());
 
 		$return_url = hex2bin($return);
-		notice("RETURN: " + $return_url);
-		if (empty($return_url) || strpos($return_url, 'display') ) {
+		if (empty($return_url) || strpos($return_url, 'display') !== false) {
 			$a->internalRedirect('network');
 			//NOTREACHED
 		}

--- a/mod/item.php
+++ b/mod/item.php
@@ -885,7 +885,12 @@ function item_content(App $a)
 		if ($a->isAjax()) {
 			$o = Item::deleteForUser(['id' => $a->argv[2]], local_user());
 		} else {
-			$o = drop_item($a->argv[2], $a->argv[3]);
+			if (!empty($a->argv[3])) {
+				$o = drop_item($a->argv[2], $a->argv[3]);
+			}
+			else {
+				$o = drop_item($a->argv[2]);
+			}
 		}
 
 		if ($a->isAjax()) {

--- a/mod/item.php
+++ b/mod/item.php
@@ -881,11 +881,11 @@ function item_content(App $a)
 
 	$o = '';
 
-	if (($a->argc == 3) && ($a->argv[1] === 'drop') && intval($a->argv[2])) {
+	if (($a->argc >= 3) && ($a->argv[1] === 'drop') && intval($a->argv[2])) {
 		if ($a->isAjax()) {
 			$o = Item::deleteForUser(['id' => $a->argv[2]], local_user());
 		} else {
-			$o = drop_item($a->argv[2]);
+			$o = drop_item($a->argv[2], $a->argv[3]);
 		}
 
 		if ($a->isAjax()) {

--- a/src/Object/Post.php
+++ b/src/Object/Post.php
@@ -414,6 +414,7 @@ class Post extends BaseObject
 			'received'        => $item['received'],
 			'commented'       => $item['commented'],
 			'created_date'    => $item['created'],
+			'return'          => ($a->cmd) ? bin2hex($a->cmd) : '',
 		];
 
 		$arr = ['item' => $item, 'output' => $tmp_item];

--- a/view/theme/frio/templates/wall_thread.tpl
+++ b/view/theme/frio/templates/wall_thread.tpl
@@ -141,7 +141,7 @@ as the value of $top_child_total (this is done at the end of this file)
 
 					{{if $item.drop.dropping}}
 					<li role="menuitem">
-						<button type="button" class="btn-link navicon delete" onclick="dropItem('item/drop/{{$item.id}}', 'item-{{$item.guid}}');" title="{{$item.drop.delete}}"><i class="fa fa-trash" aria-hidden="true"></i> {{$item.drop.delete}}</button>
+						<button type="button" class="btn-link navicon delete" onclick="dropItem('item/drop/{{$item.id}}/{{$item.return}}', 'item-{{$item.guid}}');" title="{{$item.drop.delete}}"><i class="fa fa-trash" aria-hidden="true"></i> {{$item.drop.delete}}</button>
 					</li>
 					{{/if}}
 				</ul>

--- a/view/theme/quattro/templates/wall_thread.tpl
+++ b/view/theme/quattro/templates/wall_thread.tpl
@@ -140,7 +140,7 @@
 					<input type="checkbox" title="{{$item.drop.select}}" name="itemselected[]" class="item-select" value="{{$item.id}}" />
 				{{/if}}
 				{{if $item.drop.dropping}}
-					<a href="item/drop/{{$item.id}}" onclick="return confirmDelete();" class="icon delete s16" title="{{$item.drop.delete}}">{{$item.drop.delete}}</a>
+					<a href="item/drop/{{$item.id}}/{{$item.return}}" onclick="return confirmDelete();" class="icon delete s16" title="{{$item.drop.delete}}">{{$item.drop.delete}}</a>
 				{{/if}}
 				{{if $item.edpost}}
 					<a class="icon edit s16" href="{{$item.edpost.0}}" title="{{$item.edpost.1}}"></a>

--- a/view/theme/vier/templates/wall_thread.tpl
+++ b/view/theme/vier/templates/wall_thread.tpl
@@ -1,4 +1,3 @@
-
 {{if $mode == display}}
 {{else}}
 {{if $item.comment_firstcollapsed}}
@@ -146,7 +145,7 @@
 					<input type="checkbox" title="{{$item.drop.select}}" name="itemselected[]" class="item-select" value="{{$item.id}}" />
 				{{/if}}
 				{{if $item.drop.dropping}}
-					<a role="button" href="item/drop/{{$item.id}}" onclick="return confirmDelete();" title="{{$item.drop.delete}}"><i class="icon-trash icon-large"><span class="sr-only">{{$item.drop.delete}}</span></i></a>
+					<a role="button" href="item/drop/{{$item.id}}/{{$item.return}}" onclick="return confirmDelete();" title="{{$item.drop.delete}}"><i class="icon-trash icon-large"><span class="sr-only">{{$item.drop.delete}}</span></i></a>
 				{{/if}}
 				{{if $item.edpost}}
 					<a role="button" href="{{$item.edpost.0}}" title="{{$item.edpost.1}}"><i class="icon-edit icon-large"><span class="sr-only">{{$item.edpost.1}}</span></i></a>


### PR DESCRIPTION
Fixing issue #6006 

- add second optional parameter when calling `drop_item` in `include/items.php`
- if no parameter provided or when calling from `/display/[guid]` return to `/network`
- enabled in 
  - quattro
  - vier
  - (frio -> already working while using Ajax, see https://github.com/friendica/friendica/issues/6006#issuecomment-433321123 )
