### PR TITLE
[frio] Fix unarchive contact batch action

### DIFF
--- a/src/Module/Contact.php
+++ b/src/Module/Contact.php
@@ -138,7 +138,7 @@ class Contact extends BaseModule
 
 		$contacts_id = $_POST['contact_batch'];
 
-		$stmt = DBA::select('contact', ['id'], ['id' => $contacts_id, 'uid' => local_user(), 'self' => false]);
+		$stmt = DBA::select('contact', ['id', 'archive'], ['id' => $contacts_id, 'uid' => local_user(), 'self' => false]);
 		$orig_records = DBA::toArray($stmt);
 
 		$count_actions = 0;
@@ -336,7 +336,7 @@ class Contact extends BaseModule
 
 	private static function archiveContact($contact_id, $orig_record)
 	{
-		$archived = (($orig_record['archive']) ? 0 : 1);
+		$archived = (defaults($orig_record, 'archive', '') ? 0 : 1);
 		$r = DBA::update('contact', ['archive' => $archived], ['id' => $contact_id, 'uid' => local_user()]);
 
 		return DBA::isResult($r);


### PR DESCRIPTION
(I didn't found an issue about this, should I create one ?)
While creating a new message in frio noticed my autocomplete for a contact wasn't working. The reason was my (one and only test-) contact was still archived caused by former contact batch action tests.

`Unarchiving` a contact was triggering

    PHP Notice:  Undefined index: archive in /var/www/friendica/src/Module/Contact.php on line 339

https://github.com/JonnyTischbein/friendica/blob/76c9d370060d7da27126377eadd92746e9bf46eb/src/Module/Contact.php#L339

Caused by missing select argument

https://github.com/friendica/friendica/blob/fa1328625cfa539bba0f8b244ef1e6073030b5bf/src/Module/Contact.php#L141

https://github.com/JonnyTischbein/friendica/blob/76c9d370060d7da27126377eadd92746e9bf46eb/src/Module/Contact.php#L141

(Sorry Code Snippets seem to be broken)