### PR TITLE
Fix for delivering forum posts again

### DIFF
--- a/mod/item.php
+++ b/mod/item.php
@@ -839,6 +839,12 @@ function item_post(App $a) {
 	// We don't fork a new process since this is done anyway with the following command
 	Worker::add(['priority' => PRIORITY_HIGH, 'dont_fork' => true], "CreateShadowEntry", $post_id);
 
+	// When we are doing some forum posting via ! we have to start the notifier manually.
+	// These kind of posts don't initiate the notifier call in the item class.
+	if ($only_to_forum) {
+		Worker::add(PRIORITY_HIGH, "Notifier", $notify_type, $post_id);
+	}
+
 	Logger::log('post_complete');
 
 	if ($api_source) {

--- a/src/Model/Term.php
+++ b/src/Model/Term.php
@@ -86,7 +86,7 @@ class Term
 
 		$tags_string = '';
 		foreach ($taglist as $tag) {
-			if ((substr(trim($tag), 0, 1) == '#') || (substr(trim($tag), 0, 1) == '@')) {
+			if ((substr(trim($tag), 0, 1) == '#') || (substr(trim($tag), 0, 1) == '@') || (substr(trim($tag), 0, 1) == '!')) {
 				$tags_string .= ' ' . trim($tag);
 			} else {
 				$tags_string .= ' #' . trim($tag);
@@ -107,11 +107,11 @@ class Term
 			}
 		}
 
-		$pattern = '/\W([\#@])\[url\=(.*?)\](.*?)\[\/url\]/ism';
+		$pattern = '/\W([\#@!])\[url\=(.*?)\](.*?)\[\/url\]/ism';
 		if (preg_match_all($pattern, $data, $matches, PREG_SET_ORDER)) {
 			foreach ($matches as $match) {
 
-				if ($match[1] == '@') {
+				if (($match[1] == '@') || ($match[1] == '!')) {
 					$contact = Contact::getDetailsByURL($match[2], 0);
 					if (!empty($contact['addr'])) {
 						$match[3] = $contact['addr'];
@@ -140,7 +140,7 @@ class Term
 
 				$type = TERM_HASHTAG;
 				$term = substr($tag, 1);
-			} elseif (substr(trim($tag), 0, 1) == '@') {
+			} elseif ((substr(trim($tag), 0, 1) == '@') || (substr(trim($tag), 0, 1) == '!')) {
 				$type = TERM_MENTION;
 
 				$contact = Contact::getDetailsByURL($link, 0);
@@ -179,7 +179,7 @@ class Term
 			]);
 
 			// Search for mentions
-			if ((substr($tag, 0, 1) == '@') && (strpos($link, $profile_base_friendica) || strpos($link, $profile_base_diaspora))) {
+			if (((substr($tag, 0, 1) == '@') || (substr($tag, 0, 1) == '!')) && (strpos($link, $profile_base_friendica) || strpos($link, $profile_base_diaspora))) {
 				$users = q("SELECT `uid` FROM `contact` WHERE self AND (`url` = '%s' OR `nurl` = '%s')", $link, $link);
 				foreach ($users AS $user) {
 					if ($user['uid'] == $message['uid']) {


### PR DESCRIPTION
Some time ago the notifier call in mod/item.php had been removed since this resulted in duplicated calls - but for the direct forum posts we do need this.

Additionally some tagging problem had been solved that only seems to be of cosmetical nature.