### PR TITLE
Support for fetching non-public content / preparations for forum posts

### DIFF
--- a/src/Protocol/ActivityPub.php
+++ b/src/Protocol/ActivityPub.php
@@ -7,6 +7,7 @@ namespace Friendica\Protocol;
 use Friendica\Util\Network;
 use Friendica\Core\Protocol;
 use Friendica\Model\APContact;
+use Friendica\Util\HTTPSignature;
 
 /**
  * @brief ActivityPub Protocol class
@@ -59,11 +60,16 @@ class ActivityPub
 	/**
 	 * Fetches ActivityPub content from the given url
 	 *
-	 * @param string $url content url
+	 * @param string  $url content url
+	 * @param integer $uid User ID for the signature
 	 * @return array
 	 */
-	public static function fetchContent($url)
+	public static function fetchContent($url, $uid = 0)
 	{
+		if (!empty($uid)) {
+			return HTTPSignature::fetch($url, 1);
+		}
+
 		$curlResult = Network::curl($url, false, $redirects, ['accept_content' => 'application/activity+json, application/ld+json']);
 		if (!$curlResult->isSuccess() || empty($curlResult->getBody())) {
 			return false;

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -301,7 +301,9 @@ class Processor
 			return;
 		}
 
-		$object = ActivityPub::fetchContent($url);
+		$uid = ActivityPub\Receiver::getFirstUserFromReceivers($child['receiver']);
+
+		$object = ActivityPub::fetchContent($url, $uid);
 		if (empty($object)) {
 			Logger::log('Activity ' . $url . ' was not fetchable, aborting.');
 			return;

--- a/src/Util/Network.php
+++ b/src/Util/Network.php
@@ -83,6 +83,7 @@ class Network
 	 *                           'novalidate' => do not validate SSL certs, default is to validate using our CA list
 	 *                           'nobody' => only return the header
 	 *                           'cookiejar' => path to cookie jar file
+	 *                           'header' => header array
 	 *
 	 * @return CurlResult
 	 */
@@ -134,6 +135,10 @@ class Network
 				CURLOPT_HTTPHEADER,
 				['Accept: ' . $opts['accept_content']]
 			);
+		}
+
+		if (!empty($opts['header'])) {
+			curl_setopt($ch, CURLOPT_HTTPHEADER, $opts['header']);
 		}
 
 		@curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);


### PR DESCRIPTION
We are now able fetching non public posts with signed GET requests. In the future we will use it for the supporting groups (forums).

The rest of the coding is for supporting forums as well (adding the forum user to the list of receivers when the conditions match)