### PR TITLE
Lock TTL fix

### DIFF
--- a/tests/src/Core/Cache/ArrayCacheDriverTest.php
+++ b/tests/src/Core/Cache/ArrayCacheDriverTest.php
@@ -5,6 +5,10 @@ namespace Friendica\Test\src\Core\Cache;
 
 use Friendica\Core\Cache\ArrayCache;
 
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
 class ArrayCacheDriverTest extends MemoryCacheTest
 {
 	protected function getInstance()

--- a/tests/src/Core/Cache/DatabaseCacheDriverTest.php
+++ b/tests/src/Core/Cache/DatabaseCacheDriverTest.php
@@ -4,6 +4,10 @@ namespace Friendica\Test\src\Core\Cache;
 
 use Friendica\Core\Cache\CacheDriverFactory;
 
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
 class DatabaseCacheDriverTest extends CacheTest
 {
 	protected function getInstance()

--- a/tests/src/Core/Cache/MemcacheCacheDriverTest.php
+++ b/tests/src/Core/Cache/MemcacheCacheDriverTest.php
@@ -3,7 +3,10 @@
 
 namespace Friendica\Test\src\Core\Cache;
 
-
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
 use Friendica\Core\Cache\CacheDriverFactory;
 
 /**

--- a/tests/src/Core/Cache/MemcachedCacheDriverTest.php
+++ b/tests/src/Core/Cache/MemcachedCacheDriverTest.php
@@ -3,7 +3,10 @@
 
 namespace Friendica\Test\src\Core\Cache;
 
-
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
 use Friendica\Core\Cache\CacheDriverFactory;
 
 /**

--- a/tests/src/Core/Cache/RedisCacheDriverTest.php
+++ b/tests/src/Core/Cache/RedisCacheDriverTest.php
@@ -3,7 +3,10 @@
 
 namespace Friendica\Test\src\Core\Cache;
 
-
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
 use Friendica\Core\Cache\CacheDriverFactory;
 
 /**

--- a/tests/src/Core/Lock/ArrayCacheLockDriverTest.php
+++ b/tests/src/Core/Lock/ArrayCacheLockDriverTest.php
@@ -6,6 +6,10 @@ namespace Friendica\Test\src\Core\Lock;
 use Friendica\Core\Cache\ArrayCache;
 use Friendica\Core\Lock\CacheLockDriver;
 
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
 class ArrayCacheLockDriverTest extends LockTest
 {
 	protected function getInstance()

--- a/tests/src/Core/Lock/DatabaseLockDriverTest.php
+++ b/tests/src/Core/Lock/DatabaseLockDriverTest.php
@@ -5,6 +5,10 @@ namespace Friendica\Test\src\Core\Lock;
 use Friendica\Core\Lock\DatabaseLockDriver;
 use Friendica\Database\DBA;
 
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
 class DatabaseLockDriverTest extends LockTest
 {
 	protected function getInstance()

--- a/tests/src/Core/Lock/MemcacheCacheLockDriverTest.php
+++ b/tests/src/Core/Lock/MemcacheCacheLockDriverTest.php
@@ -8,6 +8,8 @@ use Friendica\Core\Lock\CacheLockDriver;
 
 /**
  * @requires extension Memcache
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
  */
 class MemcacheCacheLockDriverTest extends LockTest
 {

--- a/tests/src/Core/Lock/MemcachedCacheLockDriverTest.php
+++ b/tests/src/Core/Lock/MemcachedCacheLockDriverTest.php
@@ -8,6 +8,8 @@ use Friendica\Core\Lock\CacheLockDriver;
 
 /**
  * @requires extension memcached
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
  */
 class MemcachedCacheLockDriverTest extends LockTest
 {

--- a/tests/src/Core/Lock/RedisCacheLockDriverTest.php
+++ b/tests/src/Core/Lock/RedisCacheLockDriverTest.php
@@ -8,6 +8,8 @@ use Friendica\Core\Lock\CacheLockDriver;
 
 /**
  * @requires extension redis
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
  */
 class RedisCacheLockDriverTest extends LockTest
 {

--- a/tests/src/Core/Lock/SemaphoreLockDriverTest.php
+++ b/tests/src/Core/Lock/SemaphoreLockDriverTest.php
@@ -4,6 +4,10 @@ namespace Friendica\Test\src\Core\Lock;
 
 use Friendica\Core\Lock\SemaphoreLockDriver;
 
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
 class SemaphoreLockDriverTest extends LockTest
 {
 	protected function getInstance()


### PR DESCRIPTION
Hopefully a fix for the TTL test issue.

We now force each test to run in separated processes and not saving any global state.
So no crossovers between cache-entries are possible anymore 