### PR TITLE
Fix return url when dropping post loaded by update_* in non-frio

### DIFF
--- a/include/items.php
+++ b/include/items.php
@@ -410,6 +410,10 @@ function drop_item($id, $return = '')
 		Item::deleteForUser(['id' => $item['id']], local_user());
 
 		$return_url = hex2bin($return);
+
+		// removes update_* from return_url to ignore Ajax refresh
+		$return_url = str_replace("update_", "", $return_url);
+
 		if (empty($return_url) || strpos($return_url, 'display') !== false) {
 			$a->internalRedirect('network');
 			//NOTREACHED

--- a/mod/update_contact.php
+++ b/mod/update_contact.php
@@ -7,7 +7,7 @@ use Friendica\Core\L10n;
 use Friendica\Core\PConfig;
 use Friendica\Module\Contact;
 
-function update_contacts_content(App $a)
+function update_contact_content(App $a)
 {
 	header("Content-type: text/html");
 	echo "<!DOCTYPE html><html><body>\r\n";

--- a/view/js/main.js
+++ b/view/js/main.js
@@ -390,7 +390,7 @@ function NavUpdate() {
 				$('nav').trigger('nav-update', data.result);
 
 				// start live update
-				['network', 'profile', 'community', 'notes', 'display', 'contacts'].forEach(function (src) {
+				['network', 'profile', 'community', 'notes', 'display', 'contact'].forEach(function (src) {
 					if ($('#live-' + src).length) {
 						liveUpdate(src);
 					}


### PR DESCRIPTION
To issue #6084 extending PR #5940.

When a new item is loaded in `/network` or `/profile/` etc. New posts are loaded via `/update_* `. 
This call overrides `$a->cmd` used to determine the return_url.
To fix this Issue I cutted `update_` from the return string.

