### PR TITLE
Using CSS for custom emojis

### DIFF
--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -50,7 +50,8 @@ class Processor
 	public static function replaceEmojis($emojis, $body)
 	{
 		foreach ($emojis as $emoji) {
-			$body = str_replace($emoji['name'], '[img=16x16]' . $emoji['href'] . '[/img]', $body);
+			$replace = '[class=emoji mastodon][img=' . $emoji['href'] . ']' . $emoji['name'] . '[/img][/class]';
+			$body = str_replace($emoji['name'], $replace, $body);
 		}
 		return $body;
 	}

--- a/view/global.css
+++ b/view/global.css
@@ -602,3 +602,8 @@ img.invalid-src:after { vertical-align: top;}
 #register-explicid-content {
   font-weight: bold;
 }
+
+span.emoji.mastodon img {
+  height: 1.2em;
+  vertical-align: middle;
+}


### PR DESCRIPTION
It's better using CSS for styling. And we provide the emoji text - which is better for the accessibility.