### PR TITLE
Add some hook to check if hook should be forked

### DIFF
--- a/doc/Addons.md
+++ b/doc/Addons.md
@@ -693,6 +693,9 @@ Here is a complete list of all hook callbacks with file locations (as of 24-Sep-
 
     Addon::callHooks('logged_in', $a->user);
 
+### src/Core/Hook.php
+
+    self::callSingle(self::getApp(), 'hook_fork', $fork_hook, $hookdata);
 
 ### src/Core/Worker.php
 

--- a/src/Core/Hook.php
+++ b/src/Core/Hook.php
@@ -137,19 +137,19 @@ class Hook extends BaseObject
 		if (array_key_exists($name, self::$hooks)) {
 			foreach (self::$hooks[$name] as $hook) {
 				// Call a hook to check if this hook call needs to be forked
-				$hookdata = ['name' => $name, 'data' => $data, 'execute' => true];
-
 				if (array_key_exists('hook_fork', self::$hooks)) {
+					$hookdata = ['name' => $name, 'data' => $data, 'execute' => true];
+
 					foreach (self::$hooks['hook_fork'] as $fork_hook) {
 						if ($hook[0] != $fork_hook[0]) {
 							continue;
 						}
 						self::callSingle(self::getApp(), 'hook_fork', $fork_hook, $hookdata);
 					}
-				}
 
-				if (!$hookdata['execute']) {
-					continue;
+					if (!$hookdata['execute']) {
+						continue;
+					}
 				}
 
 				Worker::add($priority, 'ForkHook', $name, $hook, $data);

--- a/src/Core/Hook.php
+++ b/src/Core/Hook.php
@@ -7,7 +7,6 @@ namespace Friendica\Core;
 use Friendica\App;
 use Friendica\BaseObject;
 use Friendica\Database\DBA;
-use Friendica\Core\Logger;
 
 /**
  * Some functions to handle hooks


### PR DESCRIPTION
Checking if a hook needs to be forked though a worker before the worker is forked should increase the worker performance.