### PR TITLE
Missing use for Strings

### DIFF
--- a/mod/removeme.php
+++ b/mod/removeme.php
@@ -10,6 +10,7 @@ use Friendica\Core\Renderer;
 use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\Model\User;
+use Friendica\Util\Strings;
 
 require_once 'include/enotify.php';
 


### PR DESCRIPTION
In line 72 'Strings::' is used but the 'use Friendica\Util\Strings' was missing.