### PR TITLE
Fix wrong server detecting / improved Pleroma version numbers

### DIFF
--- a/mod/admin.php
+++ b/mod/admin.php
@@ -651,6 +651,29 @@ function admin_page_federation(App $a)
 				$v[$key] = ['total' => $v[$key]['total'], 'version' => L10n::t('unknown')];
 			}
 		}
+
+		// Reformat and compact version numbers
+		if ($p == 'Pleroma') {
+			$compacted = [];
+
+			foreach ($v as $key => $value) {
+				$version = $v[$key]['version'];
+				$parts = explode(' ', trim($version));
+				do {
+					$part = array_pop($parts);
+				} while (!empty($parts) && ((strlen($part) >= 40) || (strlen($part) <= 3)));
+
+				if (!empty($part)) {
+					$compacted[$part] += $v[$key]['total'];
+				}
+			}
+
+			$v = [];
+			foreach ($compacted as $version => $total) {
+				$v[] = ['version' => $version, 'total' => $total];
+			}
+		}
+
 		// in the DB the Diaspora versions have the format x.x.x.x-xx the last
 		// part (-xx) should be removed to clean up the versions from the "head
 		// commit" information and combined into a single entry for x.x.x.x

--- a/src/Network/CurlResult.php
+++ b/src/Network/CurlResult.php
@@ -133,6 +133,11 @@ class CurlResult
 	{
 		$this->isSuccess = ($this->returnCode >= 200 && $this->returnCode <= 299) || $this->errorNumber == 0;
 
+		// Everything higher than 299 is not an success
+		if ($this->returnCode > 299) {
+			$this->isSuccess = false;
+		}
+
 		if (!$this->isSuccess) {
 			Logger::log('error: ' . $this->url . ': ' . $this->returnCode . ' - ' . $this->error, Logger::INFO);
 			Logger::log('debug: ' . print_r($this->info, true), Logger::DATA);

--- a/src/Network/CurlResult.php
+++ b/src/Network/CurlResult.php
@@ -133,8 +133,8 @@ class CurlResult
 	{
 		$this->isSuccess = ($this->returnCode >= 200 && $this->returnCode <= 299) || $this->errorNumber == 0;
 
-		// Everything higher than 299 is not an success
-		if ($this->returnCode > 299) {
+		// Everything higher or equal 400 is not a success
+		if ($this->returnCode >= 400) {
 			$this->isSuccess = false;
 		}
 


### PR DESCRIPTION
Especially GNU Social servers hadn't been detected as offline. The cause had been that we falsely hadn't always detected HTTP errors as errors. Surely the existing check could be changed as well - but this is a very critical part of the communication, so it is safer doing an additional check.

A second task is the Pleroma version number - which is some ugly garbage. The version number is now cleaned up.