### PR TITLE
Avoid a blocked workerqueue due to removed users

### DIFF
--- a/src/Worker/RemoveUser.php
+++ b/src/Worker/RemoveUser.php
@@ -24,7 +24,7 @@ class RemoveUser {
 		do {
 			$items = Item::select(['id'], $condition, ['limit' => 100]);
 			while ($item = Item::fetch($items)) {
-				Item::deleteById($item['id'], PRIORITY_LOW);
+				Item::deleteById($item['id'], PRIORITY_NEGLIGIBLE);
 			}
 			DBA::close($items);
 		} while (Item::exists($condition));


### PR DESCRIPTION
On one of my servers a user decided to remove himself. Normally this isn't a big deal - but this time the user had over 10,000 posts. This lead to the situation that several important workerqueue entries hadn't be processed any more.