### PR TITLE
Execute database update before post update is called

### DIFF
--- a/src/Core/Console/PostUpdate.php
+++ b/src/Core/Console/PostUpdate.php
@@ -4,6 +4,7 @@ namespace Friendica\Core\Console;
 
 use Friendica\Core\L10n;
 use Friendica\Core\Config;
+use Friendica\Core\Update;
 
 /**
  * Performs database post updates
@@ -53,6 +54,10 @@ HELP;
 		if ($a->getMode()->isInstall()) {
 			throw new \RuntimeException('Database isn\'t ready or populated yet');
 		}
+
+		echo L10n::t('Check for pending update actions.') . "\n";
+		Update::run(true, true, false);
+		echo L10n::t('Done.') . "\n";
 
 		echo L10n::t('Execute pending post updates.') . "\n";
 


### PR DESCRIPTION
See for example https://github.com/friendica/friendica/issues/6117

People are running into a problem since they execute the post update by hand before the update itself hadn't been started at all. So we have to make sure that the database update is finished before the post update can be executed.