### PR TITLE
Create a new GUID on user import

### DIFF
--- a/src/Core/UserImport.php
+++ b/src/Core/UserImport.php
@@ -7,6 +7,7 @@ namespace Friendica\Core;
 use Friendica\App;
 use Friendica\Core\Logger;
 use Friendica\Core\Protocol;
+use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\Model\Photo;
 use Friendica\Object\Image;

--- a/src/Core/UserImport.php
+++ b/src/Core/UserImport.php
@@ -129,6 +129,9 @@ class UserImport
 			$old_handle = $account['user']['nickname'].$oldaddr;
 		}
 
+		// Creating a new guid to avoid problems with Diaspora
+		$account['user']['guid'] = System::createUUID();
+
 		$olduid = $account['user']['uid'];
 
 		unset($account['user']['uid']);


### PR DESCRIPTION
To make Diaspora accept a relocated user, this user needs a new GUID.