### PR TITLE
Improved delete text to clarify AP comment delete behaviour

### DIFF
--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -1011,10 +1011,8 @@ class Item extends BaseObject
 		$matches = false;
 		$cnt = preg_match_all('/<(.*?)>/', $item['file'], $matches, PREG_SET_ORDER);
 
-		if ($cnt)
-		{
-			foreach ($matches as $mtch)
-			{
+		if ($cnt) {
+			foreach ($matches as $mtch) {
 				FileTag::unsaveFile($item['uid'], $item['id'], $mtch[1],true);
 			}
 		}
@@ -1023,10 +1021,8 @@ class Item extends BaseObject
 
 		$cnt = preg_match_all('/\[(.*?)\]/', $item['file'], $matches, PREG_SET_ORDER);
 
-		if ($cnt)
-		{
-			foreach ($matches as $mtch)
-			{
+		if ($cnt) {
+			foreach ($matches as $mtch) {
 				FileTag::unsaveFile($item['uid'], $item['id'], $mtch[1],false);
 			}
 		}

--- a/src/Object/Post.php
+++ b/src/Object/Post.php
@@ -190,8 +190,13 @@ class Post extends BaseObject
 			}
 		}
 
-		// Showing the one or the other text, depending upon if we can only hide it or really delete it.
-		$delete = $origin ? L10n::t('Delete globally') : L10n::t('Remove locally');
+		if ($origin && ($item['id'] != $item['parent']) && ($item['network'] == Protocol::ACTIVITYPUB)) {
+			// ActivityPub doesn't allow removal of remote comments
+			$delete = L10n::t('Delete locally');
+		} else {
+			// Showing the one or the other text, depending upon if we can only hide it or really delete it.
+			$delete = $origin ? L10n::t('Delete globally') : L10n::t('Remove locally');
+		}
 
 		$drop = [
 			'dropping' => $dropping,


### PR DESCRIPTION
By now we had got two different behaviours of the delete functionality:
1. It is post from someone else or a comment from someone else on a post from someone else => "remove locally"
2. It is our post/comment or a a comment from someone else on our post => "delete globally"

With AP we cannot delete comments from someone else any more, due to the security model. So we change the delete text to clarify that the comment will be deleted for all users on this system, but that the deletion will not be propagated to other systems.