### PR TITLE
Fix ATOM feed entry titles encoding

### DIFF
--- a/src/Protocol/OStatus.php
+++ b/src/Protocol/OStatus.php
@@ -1945,11 +1945,7 @@ class OStatus
 		}
 
 		XML::addElement($doc, $entry, "id", $item["uri"]);
-		if ($feed_mode) {
-			XML::addElement($doc, $entry, "title", html_entity_decode($title, ENT_QUOTES, 'UTF-8'));
-		} else {
-			XML::addElement($doc, $entry, "title", $title);
-		}
+		XML::addElement($doc, $entry, "title", html_entity_decode($title, ENT_QUOTES, 'UTF-8'));
 
 		$body = self::formatPicturePost($item['body']);
 

--- a/src/Protocol/OStatus.php
+++ b/src/Protocol/OStatus.php
@@ -1945,7 +1945,11 @@ class OStatus
 		}
 
 		XML::addElement($doc, $entry, "id", $item["uri"]);
-		XML::addElement($doc, $entry, "title", $title);
+		if ($feed_mode) {
+			XML::addElement($doc, $entry, "title", html_entity_decode($title, ENT_QUOTES, 'UTF-8'));
+		} else {
+			XML::addElement($doc, $entry, "title", $title);
+		}
 
 		$body = self::formatPicturePost($item['body']);
 


### PR DESCRIPTION
Was HTML-encoded instead of plain Unicode.
Fixed only for feed_mode. Probably wrong as well for non feed_mode (not sure how to test)