### PR TITLE
Fix lack of HTML encoding for stylesheet link

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -116,7 +116,7 @@ class App
 	public function registerStylesheet($path)
 	{
 		$url = str_replace($this->getBasePath() . DIRECTORY_SEPARATOR, '', $path);
-
+		$url = htmlspecialchars($url, ENT_COMPAT, 'UTF-8');
 		$this->stylesheets[] = trim($url, '/');
 	}
 

--- a/src/App.php
+++ b/src/App.php
@@ -116,7 +116,7 @@ class App
 	public function registerStylesheet($path)
 	{
 		$url = str_replace($this->getBasePath() . DIRECTORY_SEPARATOR, '', $path);
-		$url = htmlspecialchars($url, ENT_COMPAT, 'UTF-8');
+
 		$this->stylesheets[] = trim($url, '/');
 	}
 

--- a/view/templates/head.tpl
+++ b/view/templates/head.tpl
@@ -9,7 +9,7 @@
 <link rel="stylesheet" href="view/asset/perfect-scrollbar/css/perfect-scrollbar.min.css" type="text/css" media="screen" />
 
 {{foreach $stylesheets as $stylesheetUrl}}
-<link rel="stylesheet" href="{{$stylesheetUrl}}" type="text/css" media="screen" />
+<link rel="stylesheet" href="{{$stylesheetUrl|escape:"html":"UTF-8"}}" type="text/css" media="screen" />
 {{/foreach}}
 
 <link rel="shortcut icon" href="{{$shortcut_icon}}" />

--- a/view/theme/frio/templates/head.tpl
+++ b/view/theme/frio/templates/head.tpl
@@ -26,7 +26,7 @@
 <link rel="stylesheet" href="view/theme/frio/font/open_sans/open-sans.css" type="text/css" media="screen"/>
 
 {{foreach $stylesheets as $stylesheetUrl}}
-<link rel="stylesheet" href="{{$stylesheetUrl}}" type="text/css" media="screen" />
+<link rel="stylesheet" href="{{$stylesheetUrl|escape:"html":"UTF-8"}}" type="text/css" media="screen" />
 {{/foreach}}
 
 {{* own css files *}}


### PR DESCRIPTION
Before the fix, the home page had a line like (note the wrongly encoded `&`):

```html
<link rel="stylesheet" href="view/theme/frio/style.pcss?f=&puid=1" type="text/css" media="screen" />
```