### PR TITLE
Fix deleting last element and displaying empty saved folder

### DIFF
--- a/mod/filerm.php
+++ b/mod/filerm.php
@@ -27,9 +27,8 @@ function filerm_content(App $a)
 
 	Logger::log('filerm: tag ' . $term . ' item ' . $item_id  . ' category ' . ($category ? 'true' :  'false'));
 
-	if ($item_id && strlen($term))
-	{
-		if (FileTag::unsaveFile(local_user(), $item_id, $term, $category)){
+	if ($item_id && strlen($term)) {
+		if (FileTag::unsaveFile(local_user(), $item_id, $term, $category)) {
 			info('Item removed');
 		}
 	}

--- a/mod/filerm.php
+++ b/mod/filerm.php
@@ -14,7 +14,7 @@ function filerm_content(App $a)
 	}
 
 	$term = XML::unescape(trim($_GET['term']));
-	$cat = XML::unescape(trim($_GET['cat']));
+	$cat = XML::unescape(trim(defaults($_GET, 'cat', '')));
 
 	$category = (($cat) ? true : false);
 
@@ -25,12 +25,18 @@ function filerm_content(App $a)
 
 	$item_id = (($a->argc > 1) ? intval($a->argv[1]) : 0);
 
-	Logger::log('filerm: tag ' . $term . ' item ' . $item_id);
+	Logger::log('filerm: tag ' . $term . ' item ' . $item_id  . ' category ' . ($category ? 'true' :  'false'));
 
 	if ($item_id && strlen($term))
 	{
-		FileTag::unsaveFile(local_user(), $item_id, $term, $category);
+		if (FileTag::unsaveFile(local_user(), $item_id, $term, $category)){
+			info('Item removed');
+		}
+	}
+	else {
+		info('Item was not deleted');
 	}
 
+	$a->internalRedirect('/network?f=&file=' . $term);
 	killme();
 }

--- a/mod/network.php
+++ b/mod/network.php
@@ -346,7 +346,7 @@ function networkConversation(App $a, $items, Pager $pager, $mode, $update, $orde
 	// Set this so that the conversation function can find out contact info for our wall-wall items
 	$a->page_contact = $a->contact;
 
-	if (!is_array($items)){
+	if (!is_array($items)) {
 		Logger::log("Expecting items to be an array. Got " . print_r($items, true));
 		$items = [];
 	}

--- a/mod/network.php
+++ b/mod/network.php
@@ -394,7 +394,7 @@ function network_content(App $a, $update = 0, $parent = 0)
 		$o = networkThreadedView($a, $update, $parent);
 	}
 
-	if ($o === ''){
+	if ($o === '') {
 		info("No items found");
 	}
 
@@ -472,7 +472,7 @@ function networkFlatView(App $a, $update = 0)
 		}
 		DBA::close($result);
 
-		if (count($posts) == 0){
+		if (count($posts) == 0) {
 			return '';
 		}
 		$condition = ['uid' => local_user(), 'id' => $posts];

--- a/mod/network.php
+++ b/mod/network.php
@@ -346,6 +346,7 @@ function networkConversation(App $a, $items, Pager $pager, $mode, $update, $orde
 	// Set this so that the conversation function can find out contact info for our wall-wall items
 	$a->page_contact = $a->contact;
 
+	$items = (empty($items) ? [] : $items);
 	$o = conversation($a, $items, $pager, $mode, $update, false, $ordering, local_user());
 
 	if (!$update) {

--- a/mod/network.php
+++ b/mod/network.php
@@ -346,7 +346,11 @@ function networkConversation(App $a, $items, Pager $pager, $mode, $update, $orde
 	// Set this so that the conversation function can find out contact info for our wall-wall items
 	$a->page_contact = $a->contact;
 
-	$items = (empty($items) ? [] : $items);
+	if (!is_array($items)){
+		Logger::log("Expecting items to be an array. Got " . print_r($items, true));
+		$items = [];
+	}
+
 	$o = conversation($a, $items, $pager, $mode, $update, false, $ordering, local_user());
 
 	if (!$update) {
@@ -388,6 +392,10 @@ function network_content(App $a, $update = 0, $parent = 0)
 		$o = networkFlatView($a, $update);
 	} else {
 		$o = networkThreadedView($a, $update, $parent);
+	}
+
+	if ($o === ''){
+		info("No items found");
 	}
 
 	return $o;
@@ -464,6 +472,9 @@ function networkFlatView(App $a, $update = 0)
 		}
 		DBA::close($result);
 
+		if (count($posts) == 0){
+			return '';
+		}
 		$condition = ['uid' => local_user(), 'id' => $posts];
 	} else {
 		$condition = ['uid' => local_user()];

--- a/src/Model/FileTag.php
+++ b/src/Model/FileTag.php
@@ -291,9 +291,6 @@ class FileTag
         }
 
         $fields = ['file' => str_replace($pattern, '', $item['file'])];
-        if ($fields === '') {
-        	$fields = null;
-        }
 
         Item::update($fields, ['id' => $item_id]);
 

--- a/src/Model/FileTag.php
+++ b/src/Model/FileTag.php
@@ -290,7 +290,7 @@ class FileTag
             return false;
         }
 
-        $fields = ['file' => str_replace($pattern, '', $item['file'])];
+        $fields = ['file' => str_replace($pattern, null, $item['file'])];
         Item::update($fields, ['id' => $item_id]);
 
         $r = q("SELECT `oid` FROM `term` WHERE `term` = '%s' AND `otype` = %d AND `type` = %d AND `uid` = %d",

--- a/src/Model/FileTag.php
+++ b/src/Model/FileTag.php
@@ -290,7 +290,11 @@ class FileTag
             return false;
         }
 
-        $fields = ['file' => str_replace($pattern, null, $item['file'])];
+        $fields = ['file' => str_replace($pattern, '', $item['file'])];
+        if ($fields === '') {
+        	$fields = null;
+        }
+
         Item::update($fields, ['id' => $item_id]);
 
         $r = q("SELECT `oid` FROM `term` WHERE `term` = '%s' AND `otype` = %d AND `type` = %d AND `uid` = %d",

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -832,7 +832,7 @@ class Item extends BaseObject
 			$files = $fields['file'];
 			$fields['file'] = null;
 		} else {
-			$files = '';
+			$files = null;
 		}
 
 		$delivery_data = ['postopts' => defaults($fields, 'postopts', ''),

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -911,7 +911,7 @@ class Item extends BaseObject
 				}
 			}
 
-			if (!empty($files)) {
+			if (!is_null($files)) {
 				Term::insertFromFileFieldByItemId($item['id'], $files);
 				if (!empty($item['file'])) {
 					DBA::update('item', ['file' => ''], ['id' => $item['id']]);


### PR DESCRIPTION
To issue #6125

- if no element remains in the save folder variable set to `null` instead of `''`
- `internalRedirect` was missing after #5861 --> now redirect to saved folder
- displaying empty folder doesn't crash anymore
- if last element is deleted returned to empty folder
- Adding info notification for deleting or if something goes wrong

**Edit**: 
- inform user that no item was found
