### PR TITLE
Use appropriate redirect in dfrn_poll

### DIFF
--- a/mod/dfrn_poll.php
+++ b/mod/dfrn_poll.php
@@ -562,7 +562,11 @@ function dfrn_poll_content(App $a)
 					break;
 				default:
 					$appendix = (strstr($destination_url, '?') ? '&f=&redir=1' : '?f=&redir=1');
-					System::externalRedirect($destination_url . $appendix);
+					if (filter_var($url, FILTER_VALIDATE_URL)) {
+						System::externalRedirect($destination_url . $appendix);
+					} else {
+						$a->internalRedirect($destination_url . $appendix);
+					}
 					break;
 			}
 			// NOTREACHED


### PR DESCRIPTION
Got an error while remote auth to a local user, where $destination_url
is relative.