### PR TITLE
Add link to user groups from /contact

### DIFF
--- a/doc/Accesskeys.md
+++ b/doc/Accesskeys.md
@@ -46,6 +46,7 @@ General
 * i - Only show ignored contacts
 * y - Only show archived contacts
 * h - Only show hidden contacts
+* e - Edit contact groups
 
 ../contacts (single contact view)
 -------------------------------

--- a/src/Module/Contact.php
+++ b/src/Module/Contact.php
@@ -755,6 +755,14 @@ class Contact extends BaseModule
 				'id'    => 'showhidden-tab',
 				'accesskey' => 'h',
 			],
+			[
+				'label' => L10n::t('Groups'),
+				'url'   => 'group',
+				'sel'   => ($hidden) ? 'active' : '',
+				'title' => L10n::t('Organize your contact groups'),
+				'id'    => 'contactgroups-tab',
+				'accesskey' => 'e',
+			],
 		];
 
 		$tab_tpl = Renderer::getMarkupTemplate('common_tabs.tpl');


### PR DESCRIPTION
There was no way to get to the contact group editor from the contact overview.

Additionally the documentation about the used accesskeys was updated.