### PR TITLE
[frio] Fix setting permisson as post for uploaded photo in album via modal create post

### DIFF
--- a/mod/item.php
+++ b/mod/item.php
@@ -468,7 +468,7 @@ function item_post(App $a) {
 
 				$fields = ['allow_cid' => $str_contact_allow, 'allow_gid' => $str_group_allow,
 						'deny_cid' => $str_contact_deny, 'deny_gid' => $str_group_deny];
-				$condition = ['resource-id' => $image_uri, 'uid' => $profile_uid, 'album' => L10n::t('Wall Photos')];
+				$condition = ['resource-id' => $image_uri, 'uid' => $profile_uid];
 				DBA::update('photo', $fields, $condition);
 			}
 		}


### PR DESCRIPTION

To issue #5805 

Setting:
- use modal popup window 
- use photo album (not wall upload)
- upload photo 
- permissions were set to only visible to yourself until post the photo
- when post photo, photo gets permission as post

Problem was:
- Only photos in wall upload get permissions as post because of hard coded condition