### PR TITLE
Delete comment from its guid and return to parent guid

### DIFF
--- a/include/items.php
+++ b/include/items.php
@@ -429,6 +429,11 @@ function drop_item($id, $return = '')
 				$a->internalRedirect('display/' . $parentitem['guid']);
 				//NOTREACHED
 			}
+			// In case something goes wrong
+			else {
+				$a->internalRedirect('network');
+				//NOTREACHED
+			}
 		}
 		else {
 			// if unknown location or deleting top level post called from display


### PR DESCRIPTION
Again to issue  #6148

- fix the case when delete comment from it's guid
- return to parent-guid when deleting a comment