### PR TITLE
Change Worker to use only MemFree in isMinMemoryReached

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -1013,11 +1013,11 @@ class App
 			$meminfo[$key] = (int) ($meminfo[$key] / 1024);
 		}
 
-		if (!isset($meminfo['MemAvailable']) || !isset($meminfo['MemFree'])) {
+		if (!isset($meminfo['MemFree'])) {
 			return false;
 		}
 
-		$free = $meminfo['MemAvailable'] + $meminfo['MemFree'];
+		$free = $meminfo['MemFree'];
 
 		$reached = ($free < $min_memory);
 


### PR DESCRIPTION
To issue #3351

- this should catch `PHP Warning:  proc_open(): fork failed - Cannot allocate memory` if Minimal memory is set in `/admin`

According to [Linux Kernel Documentation](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/Documentation/filesystems/proc.txt?id=HEAD#l883-891):

> MemFree: 
The sum of LowFree+HighFree
MemAvailable: 
An estimate of how much memory is available for starting new
              applications, without swapping. **Calculated from MemFree**,
              SReclaimable, the size of the file LRU lists, and the low
              watermarks in each zone.
              The estimate takes into account that the system needs some
              page cache to function well, and that not all reclaimable
              slab will be reclaimable, due to items being in use. The
              impact of those factors will vary from system to system.

but `$free = $meminfo['MemAvailable'] + $meminfo['MemFree']; ` works as if using `$min_memory / x ` since `MemAvailable` is calculated from `MemFree`. 
https://github.com/friendica/friendica/blob/956fe99591311f49652750fa17b1e4487df35a5c/src/App.php#L1010-L1022