### PR TITLE
Fix SQL grammar error: ORDER BY clause is not in SELECT

### DIFF
--- a/mod/profile.php
+++ b/mod/profile.php
@@ -253,7 +253,7 @@ function profile_content(App $a, $update = 0)
 			$sql_extra4 = " AND `item`.`received` > '" . $gmupdate . "'";
 		}
 
-		$items = q("SELECT DISTINCT(`parent-uri`) AS `uri`
+		$items = q("SELECT DISTINCT(`parent-uri`) AS `uri`, `item`.`created`
 			FROM `item` INNER JOIN `contact` ON `contact`.`id` = `item`.`contact-id`
 			AND NOT `contact`.`blocked` AND NOT `contact`.`pending`
 			WHERE `item`.`uid` = %d AND `item`.`visible` AND


### PR DESCRIPTION
```
2018-11-21T08:31:28Z@e3393hprfvfqnblturqp56rjnp [Info]:DBA.php:557:p
DB Error 3065: Expression #1 of ORDER BY clause is not in SELECT list,
references column 'friendica.item.created' which is not in SELECT list;
this is incompatible with DISTINCT
q, profile_content, update_profile_content,
LegacyModule::runModuleFunction, LegacyModule::content, call_user_func,
App::runFrontend
SELECT DISTINCT(`parent-uri`) AS `uri` FROM `item` INNER JOIN `contact`
ON `contact`.`id` = `item`.`contact-id` AND NOT `contact`.`blocked` AND
NOT `contact`.`pending` WHERE `item`.`uid` = 1 AND `item`.`visible` AND
(NOT `item`.`deleted` OR `item`.`gravity` = 3) AND NOT
`item`.`moderated` AND `item`.`wall` AND `item`.`unseen` ORDER BY
`item`.`created` DESC
```