### PR TITLE
Normalize BBCode hashtags links

### DIFF
--- a/include/items.php
+++ b/include/items.php
@@ -97,7 +97,7 @@ function add_page_info_data(array $data, $no_photos = false)
 			/// @TODO make a positive list of allowed characters
 			$hashtag = str_replace([" ", "+", "/", ".", "#", "'", "’", "`", "(", ")", "„", "“"],
 						["", "", "", "", "", "", "", "", "", "", "", ""], $keyword);
-			$hashtags .= "#[url=" . System::baseUrl() . "/search?tag=" . rawurlencode($hashtag) . "]" . $hashtag . "[/url] ";
+			$hashtags .= "#[url=" . System::baseUrl() . "/search?tag=" . $hashtag . "]" . $hashtag . "[/url] ";
 		}
 	}
 
@@ -148,7 +148,7 @@ function add_page_keywords($url, $photo = "", $keywords = false, $keyword_blackl
 				$tags .= ", ";
 			}
 
-			$tags .= "#[url=" . System::baseUrl() . "/search?tag=" . rawurlencode($hashtag) . "]" . $hashtag . "[/url]";
+			$tags .= "#[url=" . System::baseUrl() . "/search?tag=" . $hashtag . "]" . $hashtag . "[/url]";
 		}
 	}
 

--- a/mod/photos.php
+++ b/mod/photos.php
@@ -613,7 +613,7 @@ function photos_post(App $a)
 							}
 
 							$profile = str_replace(',', '%2c', $profile);
-							$str_tags .= '@[url='.$profile.']'.$newname.'[/url]';
+							$str_tags .= '@[url=' . $profile . ']' . $newname . '[/url]';
 						}
 					} elseif (strpos($tag, '#') === 0) {
 						$tagname = substr($tag, 1);

--- a/mod/tagger.php
+++ b/mod/tagger.php
@@ -170,7 +170,7 @@ EOT;
 		   $term_objtype,
 		   TERM_HASHTAG,
 		   DBA::escape($term),
-		   DBA::escape(System::baseUrl() . '/search?tag=' . $term),
+		   '',
 		   intval($owner_uid)
 		);
 	}
@@ -192,7 +192,7 @@ EOT;
 				$term_objtype,
 				TERM_HASHTAG,
 				DBA::escape($term),
-				DBA::escape(System::baseUrl() . '/search?tag=' . $term),
+				'',
 				intval($owner_uid)
 			);
 		}

--- a/mod/tagger.php
+++ b/mod/tagger.php
@@ -93,7 +93,7 @@ function tagger_content(App $a) {
 	</target>
 EOT;
 
-	$tagid = System::baseUrl() . '/search?tag=' . $term;
+	$tagid = System::baseUrl() . '/search?tag=' . $xterm;
 	$objtype = ACTIVITY_OBJ_TAGTERM;
 
 	$obj = <<< EOT
@@ -113,7 +113,7 @@ EOT;
 		return;
 	}
 
-	$termlink = html_entity_decode('&#x2317;') . '[url=' . System::baseUrl() . '/search?tag=' . urlencode($term) . ']'. $term . '[/url]';
+	$termlink = html_entity_decode('&#x2317;') . '[url=' . System::baseUrl() . '/search?tag=' . $term . ']'. $term . '[/url]';
 
 	$arr = [];
 

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -2448,15 +2448,15 @@ class Item extends BaseObject
 
 			$basetag = str_replace('_',' ',substr($tag,1));
 
-			$newtag = '#[url=' . System::baseUrl() . '/search?tag=' . rawurlencode($basetag) . ']' . $basetag . '[/url]';
+			$newtag = '#[url=' . System::baseUrl() . '/search?tag=' . $basetag . ']' . $basetag . '[/url]';
 
 			$item["body"] = str_replace($tag, $newtag, $item["body"]);
 
 			if (!stristr($item["tag"], "/search?tag=" . $basetag . "]" . $basetag . "[/url]")) {
 				if (strlen($item["tag"])) {
-					$item["tag"] = ','.$item["tag"];
+					$item["tag"] = ',' . $item["tag"];
 				}
-				$item["tag"] = $newtag.$item["tag"];
+				$item["tag"] = $newtag . $item["tag"];
 			}
 		}
 

--- a/src/Model/Term.php
+++ b/src/Model/Term.php
@@ -140,6 +140,7 @@ class Term
 
 				$type = TERM_HASHTAG;
 				$term = substr($tag, 1);
+				$link = '';
 			} elseif ((substr(trim($tag), 0, 1) == '@') || (substr(trim($tag), 0, 1) == '!')) {
 				$type = TERM_MENTION;
 
@@ -152,6 +153,7 @@ class Term
 			} else { // This shouldn't happen
 				$type = TERM_HASHTAG;
 				$term = $tag;
+				$link = '';
 			}
 
 			if (DBA::exists('term', ['uid' => $message['uid'], 'otype' => TERM_OBJ_POST, 'oid' => $itemid, 'url' => $link])) {
@@ -262,8 +264,8 @@ class Term
 		);
 
 		while ($tag = DBA::fetch($taglist)) {
-			if ($tag["url"] == "") {
-				$tag["url"] = $searchpath . $tag["term"];
+			if ($tag['url'] == '') {
+				$tag['url'] = $searchpath . rawurlencode($tag['term']);
 			}
 
 			$orig_tag = $tag['url'];

--- a/src/Model/Term.php
+++ b/src/Model/Term.php
@@ -266,25 +266,25 @@ class Term
 				$tag["url"] = $searchpath . $tag["term"];
 			}
 
-			$orig_tag = $tag["url"];
+			$orig_tag = $tag['url'];
 
 			$author = ['uid' => 0, 'id' => $item['author-id'],
 				'network' => $item['author-network'], 'url' => $item['author-link']];
-			$tag["url"] = Contact::magicLinkByContact($author, $tag['url']);
+			$tag['url'] = Contact::magicLinkByContact($author, $tag['url']);
 
-			if ($tag["type"] == TERM_HASHTAG) {
-				if ($orig_tag != $tag["url"]) {
-					$item['body'] = str_replace($orig_tag, $tag["url"], $item['body']);
+			if ($tag['type'] == TERM_HASHTAG) {
+				if ($orig_tag != $tag['url']) {
+					$item['body'] = str_replace($orig_tag, $tag['url'], $item['body']);
 				}
 
-				$return['hashtags'][] = "#<a href=\"" . $tag["url"] . "\" target=\"_blank\">" . $tag["term"] . "</a>";
-				$prefix = "#";
-			} elseif ($tag["type"] == TERM_MENTION) {
-				$return['mentions'][] = "@<a href=\"" . $tag["url"] . "\" target=\"_blank\">" . $tag["term"] . "</a>";
-				$prefix = "@";
+				$return['hashtags'][] = '#<a href="' . $tag['url'] . '" target="_blank">' . $tag['term'] . '</a>';
+				$prefix = '#';
+			} elseif ($tag['type'] == TERM_MENTION) {
+				$return['mentions'][] = '@<a href="' . $tag['url'] . '" target="_blank">' . $tag['term'] . '</a>';
+				$prefix = '@';
 			}
 
-			$return['tags'][] = $prefix . "<a href=\"" . $tag["url"] . "\" target=\"_blank\">" . $tag["term"] . "</a>";
+			$return['tags'][] = $prefix . '<a href="' . $tag['url'] . '" target="_blank">' . $tag['term'] . '</a>';
 		}
 		DBA::close($taglist);
 

--- a/src/Protocol/Feed.php
+++ b/src/Protocol/Feed.php
@@ -350,7 +350,7 @@ class Feed {
 					$tags .= ', ';
 				}
 
-				$taglink = "#[url=" . System::baseUrl() . "/search?tag=" . rawurlencode($hashtag) . "]" . $hashtag . "[/url]";
+				$taglink = "#[url=" . System::baseUrl() . "/search?tag=" . $hashtag . "]" . $hashtag . "[/url]";
 				$tags .= $taglink;
 			}
 

--- a/src/Protocol/OStatus.php
+++ b/src/Protocol/OStatus.php
@@ -634,15 +634,15 @@ class OStatus
 		if ($categories) {
 			foreach ($categories as $category) {
 				foreach ($category->attributes as $attributes) {
-					if ($attributes->name == "term") {
+					if ($attributes->name == 'term') {
 						$term = $attributes->textContent;
-						if (!empty($item["tag"])) {
-							$item["tag"] .= ',';
+						if (!empty($item['tag'])) {
+							$item['tag'] .= ',';
 						} else {
-							$item["tag"] = '';
+							$item['tag'] = '';
 						}
 
-						$item["tag"] .= "#[url=".System::baseUrl()."/search?tag=".$term."]".$term."[/url]";
+						$item['tag'] .= '#[url=' . System::baseUrl() . '/search?tag=' . $term . ']' . $term . '[/url]';
 					}
 				}
 			}


### PR DESCRIPTION
Fixes #6124
Addresses https://github.com/friendica/friendica/issues/5913#issuecomment-440942527
Related to #5996

So far the policy around BBCOde hashtag links was pretty inconsistent. Most links properly encoded the search term included in the tag link, but ultimately the BBCode converter disregarded the link entirely in favor of the term that it wasn't encoding in the final URL.

This PR reverses the process, by not encoding the term when it's used to build a BBCode tag, but encoding it when the BBCode tag is converted to HTML.

Additionally, storing hashtags in the `term` table will stop adding the link URL that we can easily reconstruct ourselves.

Addon counterpart: https://github.com/friendica/friendica-addons/pull/776