### PR TITLE
Fix contradicting wording by removing 'ago'.

### DIFF
--- a/src/Util/Temporal.php
+++ b/src/Util/Temporal.php
@@ -327,7 +327,7 @@ class Temporal
 						$format = L10n::t('in %1$d %2$s');
 					}
 					else {
-						$format = L10n::t('%1$d %2$s ago');
+						$format = ('%1$d %2$s');
 					}
 				}
 


### PR DESCRIPTION
Wording: 'Delete in' doesn't go with 'ago' 