### PR TITLE
Add missing closing tags

### DIFF
--- a/view/templates/admin/summary.tpl
+++ b/view/templates/admin/summary.tpl
@@ -11,7 +11,7 @@
 
 	<dl>
 		<dt>{{$queues.label}}</dt>
-		<dd><a href="{{$baseurl}}/admin/queue">{{$queues.queue}}</a> - <a href="{{$baseurl}}/admin/deferred">{{$queues.deferred}} - <a href="{{$baseurl}}/admin/workerqueue">{{$queues.workerq}}</a></dd>
+		<dd><a href="{{$baseurl}}/admin/queue">{{$queues.queue}}</a> - <a href="{{$baseurl}}/admin/deferred">{{$queues.deferred}}</a> - <a href="{{$baseurl}}/admin/workerqueue">{{$queues.workerq}}</a></dd>
 	</dl>
 	<dl>
 		<dt>{{$pending.0}}</dt>

--- a/view/theme/frio/templates/admin/summary.tpl
+++ b/view/theme/frio/templates/admin/summary.tpl
@@ -14,7 +14,7 @@
 		{{* The work queues short statistic. *}}
 		<div id="admin-summary-queues" class="col-lg-12 col-md-12 col-sm-12 col-xs-12 admin-summary">
 			<div class="col-lg-4 col-md-4 col-sm-4 col-xs-12 admin-summary-label-name text-muted">{{$queues.label}}</div>
-			<div class="col-lg-8 col-md-8 col-sm-8 col-xs-12 admin-summary-entry"><a href="{{$baseurl}}/admin/queue">{{$queues.queue}}</a> - <a href="{{$baseurl}}/admin/deferred">{{$queues.deferred}} - <a href="{{$baseurl}}/admin/workerqueue">{{$queues.workerq}}</a></div>
+			<div class="col-lg-8 col-md-8 col-sm-8 col-xs-12 admin-summary-entry"><a href="{{$baseurl}}/admin/queue">{{$queues.queue}}</a> - <a href="{{$baseurl}}/admin/deferred">{{$queues.deferred}}</a> - <a href="{{$baseurl}}/admin/workerqueue">{{$queues.workerq}}</a></div>
 		</div>
 
 		{{* Number of pending registrations. *}}


### PR DESCRIPTION
The summery template for the admin panel was missing a closing link tag
for the deferred worker queue. This tag has been added for the general
template and the template used by the frio theme.