### PR TITLE
Fix insert multiple hashtags to term

### DIFF
--- a/src/Model/Term.php
+++ b/src/Model/Term.php
@@ -156,7 +156,7 @@ class Term
 				$link = '';
 			}
 
-			if (DBA::exists('term', ['uid' => $message['uid'], 'otype' => TERM_OBJ_POST, 'oid' => $itemid, 'url' => $link])) {
+			if (DBA::exists('term', ['uid' => $message['uid'], 'otype' => TERM_OBJ_POST, 'oid' => $itemid, 'term' => $term])) {
 				continue;
 			}
 


### PR DESCRIPTION
Fixes #6202 and PR #6184 / commit https://github.com/friendica/friendica/commit/81f89ccae82786c5a99de921e1a44e8b47d8d592#diff-9b6e5e7245832faa46e10a22f1e64812

- link isn't store in term anymore for hashtag
- now check for existing terms not relying on link but on hashtag term

Tested for

> #tag1 #tag2 ...

> #tag1, #tag2, ...

> #tag1,#tag2,...