### PR TITLE
Updated .well-known location within Nginx Sample Config:

### DIFF
--- a/mods/sample-nginx.config
+++ b/mods/sample-nginx.config
@@ -91,7 +91,7 @@ server {
   # by denying dot files and rewrite request to the front controller
   location ^~ /.well-known/ {
     allow all;
-    try_files $uri /index.php?pagename=$uri&$args;
+    rewrite ^ /index.php?pagename=$uri;
   }
 
   include mime.types;


### PR DESCRIPTION
As requested by @tobiasd my PR with updated sample Nginx config file:

Replaced try_files with a rewrite rule to prevent Nginx
from spitting out 404 errors on addresses like:
- <server.tld>/.well-known/host-meta
- <server.tld>/.well-known/x-social-ray
- <server.tld>/.well-known/nodeinfo
- <server.tld>/.well-known/webfinger?resource=<resource>