### PR TITLE
Avoid problems with too long URI (should only happen with some RSS feeds)

### DIFF
--- a/src/Model/ItemURI.php
+++ b/src/Model/ItemURI.php
@@ -22,11 +22,14 @@ class ItemURI extends BaseObject
 	 */
 	public static function insert($fields)
 	{
-		if (!DBA::exists('item-uri', ['uri' => $fields['uri']])) {
+		// If the URI gets too long we only take the first parts and hope for best
+		$uri = substr($fields['uri'], 0, 255);
+
+		if (!DBA::exists('item-uri', ['uri' => $uri])) {
 			DBA::insert('item-uri', $fields, true);
 		}
 
-		$itemuri = DBA::selectFirst('item-uri', ['id'], ['uri' => $fields['uri']]);
+		$itemuri = DBA::selectFirst('item-uri', ['id'], ['uri' => $uri]);
 
 		if (!DBA::isResult($itemuri)) {
 			// This shouldn't happen
@@ -45,6 +48,9 @@ class ItemURI extends BaseObject
 	 */
 	public static function getIdByURI($uri)
 	{
+		// If the URI gets too long we only take the first parts and hope for best
+		$uri = substr($uri, 0, 255);
+
 		$itemuri = DBA::selectFirst('item-uri', ['id'], ['uri' => $uri]);
 
 		if (!DBA::isResult($itemuri)) {


### PR DESCRIPTION
URI at Friendica can have a maximum of 255 characters which is much longer than how the known systems are producing their URI. However often the links of RSS feeds are including the title of the post - and this one could really extend that limit.

This solution here is not perfect, but it should be okay until the uri storage is renewed. Plan for possibly the next version is to not store the uri anymore in the item table to reduce the needed storage space. Then we can possibly work with some hash based storage whenever the uri gets too long or so.