### PR TITLE
Avoid duplicated contacts, improve contact deletion, avoid memory issues

### DIFF
--- a/config/dbstructure.config.php
+++ b/config/dbstructure.config.php
@@ -34,7 +34,7 @@
 use Friendica\Database\DBA;
 
 if (!defined('DB_UPDATE_VERSION')) {
-	define('DB_UPDATE_VERSION', 1290);
+	define('DB_UPDATE_VERSION', 1291);
 }
 
 return [
@@ -643,6 +643,7 @@ return [
 			"uid_contactid_created" => ["uid", "contact-id", "created"],
 			"authorid_created" => ["author-id", "created"],
 			"ownerid" => ["owner-id"],
+			"contact-id" => ["contact-id"],
 			"uid_uri" => ["uid", "uri(190)"],
 			"resource-id" => ["resource-id"],
 			"deleted_changed" => ["deleted", "changed"],
@@ -894,7 +895,9 @@ return [
 			"fid" => ["type" => "int unsigned", "not null" => "1", "relation" => ["fcontact" => "id"], "comment" => ""],
 		],
 		"indexes" => [
-			"PRIMARY" => ["iid", "server"]
+			"PRIMARY" => ["iid", "server"],
+			"cid" => ["cid"],
+			"fid" => ["fid"]
 		]
 	],
 	"pconfig" => [

--- a/src/Core/Update.php
+++ b/src/Core/Update.php
@@ -118,6 +118,8 @@ class Update
 					Lock::release('dbupdate');
 				}
 			}
+		} elseif ($force) {
+			DBStructure::update($verbose, true);
 		}
 
 		return '';


### PR DESCRIPTION
This PR handles several connected issues:
* under certain weird circumstances public contacts got created over and over again. Replacing the "insert" command with the "update" command and the parameter to insert the content if not present, solves this.
* The mass deletion of contacts had been slow due to not fitting indexes.
* The mass deletion had been in a single transaction with the commands being added in a huge array - which created memory issues from time to time.
* Forcing a database update has to do a structure check when forced, even when the database versions fit.