### PR TITLE
Ignoring OEmbed array values

### DIFF
--- a/src/Object/OEmbed.php
+++ b/src/Object/OEmbed.php
@@ -45,6 +45,8 @@ class OEmbed
 			if (in_array($key, ['thumbnail_width', 'thumbnail_height', 'width', 'height'])) {
 				// These values should be numbers, so ensure that they really are numbers.
 				$value = (int)$value;
+			} elseif (is_array($value)) {
+				// Ignoring arrays.
 			} elseif ($key != 'html') {
 				// Avoid being able to inject some ugly stuff through these fields.
 				$value = htmlentities($value);


### PR DESCRIPTION
This avoids the notice ```htmlentities() expects parameter 1 to be string```