### PR TITLE
Fix: The event name mustn't be escaped, since it can contain converte…

### DIFF
--- a/view/theme/frio/templates/event_stream_item.tpl
+++ b/view/theme/frio/templates/event_stream_item.tpl
@@ -22,7 +22,7 @@
 						</span>
 						{{if $location.name}}
 						<span role="presentation" aria-hidden="true"> · </span>
-						<span class="event-location event-card-location">{{$location.name|escape}}</span>
+						<span class="event-location event-card-location">{{$location.name}}</span>
 						{{/if}}
 					</div>
 					<div class="event-card-profile-name profile-entry-name">


### PR DESCRIPTION
…d BBCode