### PR TITLE
Fix for remote authentication when visiting contact's pages

### DIFF
--- a/include/conversation.php
+++ b/include/conversation.php
@@ -798,7 +798,7 @@ function conversation_add_children(array $parents, $block_authors, $order, $uid)
 
 	foreach ($parents AS $parent) {
 		$condition = ["`item`.`parent-uri` = ? AND `item`.`uid` IN (0, ?) ",
-			$parent['uri'], local_user()];
+			$parent['uri'], $uid];
 		if ($block_authors) {
 			$condition[0] .= "AND NOT `author`.`hidden`";
 		}

--- a/mod/delegate.php
+++ b/mod/delegate.php
@@ -163,6 +163,8 @@ function delegate_content(App $a)
 
 	if (!is_null($parent_user)) {
 		$parent_password = ['parent_password', L10n::t('Parent Password:'), '', L10n::t('Please enter the password of the parent account to legitimize your request.')];
+	} else {
+		$parent_password = '';
 	}
 
 	$o = Renderer::replaceMacros(Renderer::getMarkupTemplate('delegate.tpl'), [

--- a/mod/display.php
+++ b/mod/display.php
@@ -272,33 +272,17 @@ function display_content(App $a, $update = false, $update_uid = 0)
 
 	$groups = [];
 
-	$contact = null;
-	$is_remote_contact = false;
-
-	$contact_id = 0;
-
-	if (!empty($_SESSION['remote']) && is_array($_SESSION['remote'])) {
-		foreach ($_SESSION['remote'] as $v) {
-			if ($v['uid'] == $a->profile['uid']) {
-				$contact_id = $v['cid'];
-				break;
-			}
-		}
+	$parent = Item::selectFirst(['uid'], ['uri' => $item_parent_uri, 'wall' => true]);
+	if (DBA::isResult($parent)) {
+		$a->profile['profile_uid'] = $parent['uid'];
 	}
 
-	if ($contact_id) {
-		$groups = Group::getIdsByContactId($contact_id);
-		$remote_contact = DBA::selectFirst('contact', [], ['id' => $contact_id, 'uid' => $a->profile['uid']]);
-		if (DBA::isResult($remote_contact)) {
-			$contact = $remote_contact;
-			$is_remote_contact = true;
-		}
-	}
+	$is_remote_contact = Contact::isFollower(remote_user(), $a->profile['profile_uid']);
 
-	if (!$is_remote_contact) {
-		if (local_user()) {
-			$contact_id = $_SESSION['cid'];
-			$contact = $a->contact;
+	if ($is_remote_contact) {
+		$cdata = Contact::getPublicAndUserContacID(remote_user(), $a->profile['profile_uid']);
+		if (!empty($cdata['user'])) {
+			$groups = Group::getIdsByContactId($cdata['user']);
 		}
 	}
 

--- a/mod/display.php
+++ b/mod/display.php
@@ -26,6 +26,10 @@ use Friendica\Module\Objects;
 
 function display_init(App $a)
 {
+	if (ActivityPub::isRequest()) {
+		Objects::rawContent();
+	}
+
 	if (Config::get('system', 'block_public') && !local_user() && !remote_user()) {
 		return;
 	}
@@ -48,6 +52,7 @@ function display_init(App $a)
 	}
 
 	$item = null;
+	$item_user = local_user();
 
 	$fields = ['id', 'parent', 'author-id', 'body', 'uid', 'guid'];
 
@@ -61,6 +66,16 @@ function display_init(App $a)
 			if (DBA::isResult($item)) {
 				$nick = $a->user["nickname"];
 			}
+		// Is this item private but could be visible to the remove visitor?
+		} elseif (remote_user()) {
+			$item = Item::selectFirst($fields, ['guid' => $a->argv[1], 'private' => 1]);
+			if (DBA::isResult($item)) {
+				if (!Contact::isFollower(remote_user(), $item['uid'])) {
+					$item = null;
+				} else {
+					$item_user = $item['uid'];
+				}
+			}
 		}
 
 		// Is it an item with uid=0?
@@ -72,18 +87,12 @@ function display_init(App $a)
 	}
 
 	if (!DBA::isResult($item)) {
-		$a->error = 404;
-		notice(L10n::t('Item not found.') . EOL);
-		return;
+		System::httpExit(404);
 	}
 
 	if (!empty($_SERVER['HTTP_ACCEPT']) && strstr($_SERVER['HTTP_ACCEPT'], 'application/atom+xml')) {
 		Logger::log('Directly serving XML for id '.$item["id"], Logger::DEBUG);
 		displayShowFeed($item["id"], false);
-	}
-
-	if (ActivityPub::isRequest()) {
-		Objects::rawContent();
 	}
 
 	if ($item["id"] != $item["parent"]) {
@@ -225,12 +234,19 @@ function display_content(App $a, $update = false, $update_uid = 0)
 
 		if ($a->argc == 2) {
 			$item_parent = 0;
-			$fields = ['id', 'parent', 'parent-uri'];
+			$fields = ['id', 'parent', 'parent-uri', 'uid'];
 
 			if (local_user()) {
 				$condition = ['guid' => $a->argv[1], 'uid' => local_user()];
 				$item = Item::selectFirstForUser(local_user(), $fields, $condition);
 				if (DBA::isResult($item)) {
+					$item_id = $item["id"];
+					$item_parent = $item["parent"];
+					$item_parent_uri = $item['parent-uri'];
+				}
+			} elseif (remote_user()) {
+				$item = Item::selectFirst($fields, ['guid' => $a->argv[1], 'private' => 1]);
+				if (DBA::isResult($item) && Contact::isFollower(remote_user(), $item['uid'])) {
 					$item_id = $item["id"];
 					$item_parent = $item["parent"];
 					$item_parent_uri = $item['parent-uri'];
@@ -250,9 +266,7 @@ function display_content(App $a, $update = false, $update_uid = 0)
 	}
 
 	if (!$item_id) {
-		$a->error = 404;
-		notice(L10n::t('Item not found.').EOL);
-		return;
+		System::httpExit(404);
 	}
 
 	// We are displaying an "alternate" link if that post was public. See issue 2864
@@ -271,18 +285,22 @@ function display_content(App $a, $update = false, $update_uid = 0)
 					'$conversation' => $conversation]);
 
 	$groups = [];
+	$remote_cid = null;
+	$is_remote_contact = false;
+	$item_uid = local_user();
 
 	$parent = Item::selectFirst(['uid'], ['uri' => $item_parent_uri, 'wall' => true]);
 	if (DBA::isResult($parent)) {
 		$a->profile['profile_uid'] = $parent['uid'];
+		$is_remote_contact = Contact::isFollower(remote_user(), $a->profile['profile_uid']);
 	}
-
-	$is_remote_contact = Contact::isFollower(remote_user(), $a->profile['profile_uid']);
 
 	if ($is_remote_contact) {
 		$cdata = Contact::getPublicAndUserContacID(remote_user(), $a->profile['profile_uid']);
 		if (!empty($cdata['user'])) {
 			$groups = Group::getIdsByContactId($cdata['user']);
+			$remote_cid = $cdata['user'];
+			$item_uid = $parent['uid'];
 		}
 	}
 
@@ -312,10 +330,9 @@ function display_content(App $a, $update = false, $update_uid = 0)
 		];
 		$o .= status_editor($a, $x, 0, true);
 	}
+	$sql_extra = Item::getPermissionsSQLByUserId($a->profile['profile_uid'], $is_remote_contact, $groups, $remote_cid);
 
-	$sql_extra = Item::getPermissionsSQLByUserId($a->profile['uid'], $is_remote_contact, $groups);
-
-	if (local_user() && (local_user() == $a->profile['uid'])) {
+	if (local_user() && (local_user() == $a->profile['profile_uid'])) {
 		$condition = ['parent-uri' => $item_parent_uri, 'uid' => local_user(), 'unseen' => true];
 		$unseen = Item::exists($condition);
 	} else {
@@ -326,13 +343,12 @@ function display_content(App $a, $update = false, $update_uid = 0)
 		return '';
 	}
 
-	$condition = ["`id` = ? AND `item`.`uid` IN (0, ?) " . $sql_extra, $item_id, local_user()];
+	$condition = ["`id` = ? AND `item`.`uid` IN (0, ?) " . $sql_extra, $item_id, $item_uid];
 	$fields = ['parent-uri', 'body', 'title', 'author-name', 'author-avatar', 'plink'];
 	$item = Item::selectFirstForUser(local_user(), $fields, $condition);
 
 	if (!DBA::isResult($item)) {
-		notice(L10n::t('Item not found.') . EOL);
-		return $o;
+		System::httpExit(404);
 	}
 
 	$item['uri'] = $item['parent-uri'];
@@ -346,7 +362,7 @@ function display_content(App $a, $update = false, $update_uid = 0)
 		$o .= "<script> var netargs = '?f=&item_id=" . $item_id . "'; </script>";
 	}
 
-	$o .= conversation($a, [$item], new Pager($a->query_string), 'display', $update_uid, false, 'commented', local_user());
+	$o .= conversation($a, [$item], new Pager($a->query_string), 'display', $update_uid, false, 'commented', $item_uid);
 
 	// Preparing the meta header
 	$description = trim(HTML::toPlaintext(BBCode::convert($item["body"], false), 0, true));

--- a/mod/profile.php
+++ b/mod/profile.php
@@ -139,6 +139,7 @@ function profile_content(App $a, $update = 0)
 	require_once 'include/items.php';
 
 	$groups = [];
+	$remote_cid = null;
 
 	$tab = 'posts';
 	$o = '';
@@ -158,6 +159,7 @@ function profile_content(App $a, $update = 0)
 		$cdata = Contact::getPublicAndUserContacID(remote_user(), $a->profile['profile_uid']);
 		if (!empty($cdata['user'])) {
 			$groups = Group::getIdsByContactId($cdata['user']);
+			$remote_cid = $cdata['user'];
 		}
 	}
 
@@ -211,9 +213,8 @@ function profile_content(App $a, $update = 0)
 		}
 	}
 
-
 	// Get permissions SQL - if $remote_contact is true, our remote user has been pre-verified and we already have fetched his/her groups
-	$sql_extra = Item::getPermissionsSQLByUserId($a->profile['profile_uid'], $remote_contact, $groups);
+	$sql_extra = Item::getPermissionsSQLByUserId($a->profile['profile_uid'], $remote_contact, $groups, $remote_cid);
 	$sql_extra2 = '';
 
 	if ($update) {
@@ -325,7 +326,7 @@ function profile_content(App $a, $update = 0)
 		}
 	}
 
-	$o .= conversation($a, $items, $pager, 'profile', $update, false, 'created', local_user());
+	$o .= conversation($a, $items, $pager, 'profile', $update, false, 'created', $a->profile['profile_uid']);
 
 	if (!$update) {
 		$o .= $pager->renderMinimal(count($items));

--- a/mod/profile.php
+++ b/mod/profile.php
@@ -150,41 +150,16 @@ function profile_content(App $a, $update = 0)
 		Nav::setSelected('home');
 	}
 
-	$contact = null;
-	$remote_contact = false;
-
-	$contact_id = 0;
-
-	if (!empty($_SESSION['remote'])) {
-		foreach ($_SESSION['remote'] as $v) {
-			if ($v['uid'] == $a->profile['profile_uid']) {
-				$contact_id = $v['cid'];
-				break;
-			}
-		}
-	}
-
-	if ($contact_id) {
-		$groups = Group::getIdsByContactId($contact_id);
-		$r = q("SELECT * FROM `contact` WHERE `id` = %d AND `uid` = %d LIMIT 1",
-			intval($contact_id),
-			intval($a->profile['profile_uid'])
-		);
-		if (DBA::isResult($r)) {
-			$contact = $r[0];
-			$remote_contact = true;
-		}
-	}
-
-	if (!$remote_contact) {
-		if (local_user()) {
-			$contact_id = $_SESSION['cid'];
-			$contact = $a->contact;
-		}
-	}
-
+	$remote_contact = Contact::isFollower(remote_user(), $a->profile['profile_uid']);
 	$is_owner = local_user() == $a->profile['profile_uid'];
 	$last_updated_key = "profile:" . $a->profile['profile_uid'] . ":" . local_user() . ":" . remote_user();
+
+	if ($remote_contact) {
+		$cdata = Contact::getPublicAndUserContacID(remote_user(), $a->profile['profile_uid']);
+		if (!empty($cdata['user'])) {
+			$groups = Group::getIdsByContactId($cdata['user']);
+		}
+	}
 
 	if (!empty($a->profile['hidewall']) && !$is_owner && !$remote_contact) {
 		notice(L10n::t('Access to this profile has been restricted.') . EOL);

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -3214,7 +3214,7 @@ class Item extends BaseObject
 		}
 	}
 
-	public static function getPermissionsSQLByUserId($owner_id, $remote_verified = false, $groups = null)
+	public static function getPermissionsSQLByUserId($owner_id, $remote_verified = false, $groups = null, $remote_cid = null)
 	{
 		$local_user = local_user();
 		$remote_user = remote_user();
@@ -3237,7 +3237,7 @@ class Item extends BaseObject
 			 * If pre-verified, the caller is expected to have already
 			 * done this and passed the groups into this function.
 			 */
-			$set = PermissionSet::get($owner_id, $remote_user, $groups);
+			$set = PermissionSet::get($owner_id, $remote_cid, $groups);
 
 			if (!empty($set)) {
 				$sql_set = " OR (`item`.`private` IN (1,2) AND `item`.`wall` AND `item`.`psid` IN (" . implode(',', $set) . "))";


### PR DESCRIPTION
For some time we experienced the problem that visiting a contact's page had only shown the public stuff and had always failed with hidden profiles. This should/could be fixed now.