### PR TITLE
[frio] Background wrapper + bootstrap buttons for newmember, un/follow

### DIFF
--- a/mod/newmember.php
+++ b/mod/newmember.php
@@ -8,7 +8,8 @@ use Friendica\Core\L10n;
 
 function newmember_content(App $a)
 {
-	$o = '<h1>' . L10n::t('Welcome to Friendica') . '</h1>';
+	$o = '<div class="generic-page-wrapper">';
+	$o .= '<h1>' . L10n::t('Welcome to Friendica') . '</h1>';
 	$o .= '<h3>' . L10n::t('New Member Checklist') . '</h3>';
 	$o .= '<div style="font-size: 120%;">';
 	$o .= L10n::t('We would like to offer some tips and links to help make your experience enjoyable. Click any item to visit the relevant page. A link to this page will be visible from your home page for two weeks after your initial registration and then will quietly disappear.');
@@ -53,6 +54,7 @@ function newmember_content(App $a)
 	$o .= '<ul>';
 	$o .= '<li>' . '<a target="newmember" href="help">' . L10n::t('Go to the Help Section') . '</a><br />' . L10n::t('Our <strong>help</strong> pages may be consulted for detail on other program features and resources.') . '</li>' . EOL;
 	$o .= '</ul>';
+	$o .= '</div>';
 	$o .= '</div>';
 
 	return $o;

--- a/view/templates/auto_request.tpl
+++ b/view/templates/auto_request.tpl
@@ -1,3 +1,4 @@
+<div class="generic-page-wrapper">
 <h1>{{$header}}</h1>
 
 {{if $myaddr == ""}}
@@ -53,8 +54,9 @@
 
 	<div id="dfrn-request-submit-wrapper">
 		{{if $submit}}
-			<input type="submit" name="submit" id="dfrn-request-submit-button" value="{{$submit|escape:'html'}}" />
+			<input class="btn btn-primary" type="submit" name="submit" id="dfrn-request-submit-button" value="{{$submit|escape:'html'}}" />
 		{{/if}}
-		<input type="submit" name="cancel" id="dfrn-request-cancel-button" value="{{$cancel|escape:'html'}}" />
+		<input class="btn btn-primary" type="submit" name="cancel" id="dfrn-request-cancel-button" value="{{$cancel|escape:'html'}}" />
 	</div>
 </form>
+</div>

--- a/view/templates/dfrn_request.tpl
+++ b/view/templates/dfrn_request.tpl
@@ -1,3 +1,4 @@
+<div class="generic-page-wrapper">
 <h1>{{$header}}</h1>
 
 {{if $myaddr}}
@@ -61,7 +62,7 @@
 		<label id="dfrn-request-knowyou-yes-label" for="dfrn-request-knowyouyes">{{$yes}}</label>
 		<input type="radio" name="knowyou" id="knowyouyes" value="1" />
 
-		<div id="dfrn-request-knowyou-break" ></div>	
+		<div id="dfrn-request-knowyou-break" ></div>
 		</div>
 		<div id="dfrn-request-know-no-wrapper">
 		<label id="dfrn-request-knowyou-no-label" for="dfrn-request-knowyouno">{{$no}}</label>
@@ -83,8 +84,9 @@
 
 	<div id="dfrn-request-submit-wrapper">
 		{{if $submit}}
-			<input type="submit" name="submit" id="dfrn-request-submit-button" value="{{$submit|escape:'html'}}" />
+			<input class="btn btn-primary" type="submit" name="submit" id="dfrn-request-submit-button" value="{{$submit|escape:'html'}}" />
 		{{/if}}
-		<input type="submit" name="cancel" id="dfrn-request-cancel-button" value="{{$cancel|escape:'html'}}" />
+		<input class="btn btn-primary" type="submit" name="cancel" id="dfrn-request-cancel-button" value="{{$cancel|escape:'html'}}" />
 	</div>
 </form>
+</div>


### PR DESCRIPTION
To issue #6157

- add `generic-content-wrapper` class to
  - newmember
  - unfollow
  - follow (auto + dfrn)
- also add bootstrap button class to pages above

Question:
- Should I move `dfrn_request.tpl` and `auto_request.tpl` to the frio folder since they use CSS classes only used by frio ?

![screenshot_2018-12-11_18-52-11](https://user-images.githubusercontent.com/10757520/49820538-6e1b8400-fd78-11e8-9dad-a4d2d0a68482.png)
![screenshot_2018-12-11_18-52-18](https://user-images.githubusercontent.com/10757520/49820539-6e1b8400-fd78-11e8-966f-b3c290081746.png)
![screenshot_2018-12-11_18-52-30](https://user-images.githubusercontent.com/10757520/49820541-6e1b8400-fd78-11e8-8260-d45b351aca96.png)

