### PR TITLE
Possibly fix a memory issue with large posts

### DIFF
--- a/mod/display.php
+++ b/mod/display.php
@@ -291,6 +291,7 @@ function display_content(App $a, $update = false, $update_uid = 0)
 
 	$parent = Item::selectFirst(['uid'], ['uri' => $item_parent_uri, 'wall' => true]);
 	if (DBA::isResult($parent)) {
+		$a->profile['uid'] = $parent['uid'];
 		$a->profile['profile_uid'] = $parent['uid'];
 		$is_remote_contact = Contact::isFollower(remote_user(), $a->profile['profile_uid']);
 	}


### PR DESCRIPTION
There had been a report about memory issues in the JSON-LD parser library. This possibly is created with large embedded pictures in the "content" field.

This fix avoids the problem by temporarily removing the content.

Additionally included (and unrelated) is a fix for a notice.