### PR TITLE
The "about" field shouldn't be escaped

### DIFF
--- a/view/theme/frio/templates/contact_edit.tpl
+++ b/view/theme/frio/templates/contact_edit.tpl
@@ -114,7 +114,7 @@
 								<div class="col-lg-12 col-md-12 col-sm-12 col-xs-12">
 									<hr class="profile-separator">
 									<div class="col-lg-4 col-md-4 col-sm-4 col-xs-12 text-muted">{{$about_label|escape}}</div>
-									<div class="col-lg-8 col-md-8 col-sm-8 col-xs-12">{{$about|escape}}</div>
+									<div class="col-lg-8 col-md-8 col-sm-8 col-xs-12">{{$about}}</div>
 								</div>
 								{{/if}}
 							</div>


### PR DESCRIPTION
See here: https://toot.chat/@crazypedia/101223649223232314