### PR TITLE
Add check for relationship with remote user for connect display

### DIFF
--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -99,7 +99,7 @@ class Profile
 	 *      load a lot of theme-specific content
 	 *
 	 * @brief Loads a profile into the page sidebar.
-	 * @param object  $a            App
+	 * @param App     $a
 	 * @param string  $nickname     string
 	 * @param int     $profile      int
 	 * @param array   $profiledata  array
@@ -335,6 +335,17 @@ class Profile
 			if (DBA::exists('contact', ['pending' => false, 'uid' => local_user(), 'nurl' => $profile_url])) {
 				$connect = false;
 			}
+		}
+
+		// Is the remote user already connected to that user?
+		if ($connect && remote_user()
+			&& DBA::exists('contact', [
+				'uid'  => $profile['uid'],
+				'nurl' => Strings::normaliseLink(self::getMyURL()),
+				'rel'  => [Contact::SHARING, Contact::FRIEND]
+			])
+		) {
+			$connect = false;
 		}
 
 		if ($connect && ($profile['network'] != Protocol::DFRN) && !isset($profile['remoteconnect'])) {

--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -338,13 +338,7 @@ class Profile
 		}
 
 		// Is the remote user already connected to that user?
-		if ($connect && remote_user()
-			&& DBA::exists('contact', [
-				'uid'  => $profile['uid'],
-				'nurl' => Strings::normaliseLink(self::getMyURL()),
-				'rel'  => [Contact::SHARING, Contact::FRIEND]
-			])
-		) {
+		if ($connect && Contact::isFollower(remote_user(), $profile['uid'])) {
 			$connect = false;
 		}
 


### PR DESCRIPTION
Should fix #6255

I can't be arsed to test on my own but this should hide the "Connect" button if the remote user is already connected to the visited profile.