### PR TITLE
Fix storage backend class names

### DIFF
--- a/src/Core/StorageManager.php
+++ b/src/Core/StorageManager.php
@@ -17,8 +17,8 @@ use Friendica\Core\Logger;
 class StorageManager
 {
 	private static $default_backends = [
-		'Filesystem' => Friendica\Model\Storage\Filesystem::class,
-		'Database' => Friendica\Model\Storage\Database::class,
+		'Filesystem' => \Friendica\Model\Storage\Filesystem::class,
+		'Database' => \Friendica\Model\Storage\Database::class,
 	];
 
 	private static $backends = [];


### PR DESCRIPTION
On my system admin page raised something like 

> can't find class Friendica\Core\Friendica\Module\Storage\Filesystem

this patch fix the class path.

This should be tested on all supported PHP versions

Follow up of #6180 