### PR TITLE
Fix ActivityPub with Nextcloud

### DIFF
--- a/src/Module/Inbox.php
+++ b/src/Module/Inbox.php
@@ -9,6 +9,7 @@ use Friendica\Protocol\ActivityPub;
 use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\Util\HTTPSignature;
+use Friendica\Core\Logger;
 
 /**
  * ActivityPub Inbox

--- a/src/Util/HTTPSignature.php
+++ b/src/Util/HTTPSignature.php
@@ -204,6 +204,8 @@ class HTTPSignature
 
 		if (preg_match('/algorithm="(.*?)"/ism', $header, $matches)) {
 			$ret['algorithm'] = $matches[1];
+		} else {
+			$ret['algorithm'] = 'rsa-sha256';
 		}
 
 		if (preg_match('/headers="(.*?)"/ism', $header, $matches)) {


### PR DESCRIPTION
Nextcloud isn't transmitting the ```algorithm``` field. We will now assume ```rsa-sha256``` when this field is missing.