### PR TITLE
Fix message list query

### DIFF
--- a/mod/message.php
+++ b/mod/message.php
@@ -431,24 +431,56 @@ function message_content(App $a)
 	}
 }
 
-function get_messages($user, $lstart, $lend)
+/**
+ * @param int $uid
+ * @param int $start
+ * @param int $limit
+ * @return array
+ */
+function get_messages($uid, $start, $limit)
 {
-	//TODO: rewritte with a sub-query to get the first message of each private thread with certainty
-	return q("SELECT max(`mail`.`created`) AS `mailcreated`, min(`mail`.`seen`) AS `mailseen`,
-		ANY_VALUE(`mail`.`id`) AS `id`, ANY_VALUE(`mail`.`uid`) AS `uid`, ANY_VALUE(`mail`.`guid`) AS `guid`,
-		ANY_VALUE(`mail`.`from-name`) AS `from-name`, ANY_VALUE(`mail`.`from-photo`) AS `from-photo`,
-		ANY_VALUE(`mail`.`from-url`) AS `from-url`, ANY_VALUE(`mail`.`contact-id`) AS `contact-id`,
-		ANY_VALUE(`mail`.`convid`) AS `convid`, ANY_VALUE(`mail`.`title`) AS `title`, ANY_VALUE(`mail`.`body`) AS `body`,
-		ANY_VALUE(`mail`.`seen`) AS `seen`, ANY_VALUE(`mail`.`reply`) AS `reply`, ANY_VALUE(`mail`.`replied`) AS `replied`,
-		ANY_VALUE(`mail`.`unknown`) AS `unknown`, ANY_VALUE(`mail`.`uri`) AS `uri`,
-		`mail`.`parent-uri`,
-		ANY_VALUE(`mail`.`created`) AS `created`, ANY_VALUE(`contact`.`name`) AS `name`, ANY_VALUE(`contact`.`url`) AS `url`,
-		ANY_VALUE(`contact`.`thumb`) AS `thumb`, ANY_VALUE(`contact`.`network`) AS `network`,
-		count( * ) as `count`
-		FROM `mail` LEFT JOIN `contact` ON `mail`.`contact-id` = `contact`.`id`
-		WHERE `mail`.`uid` = %d GROUP BY `parent-uri` ORDER BY `mailcreated` DESC LIMIT %d , %d ",
-		intval($user), intval($lstart), intval($lend)
-	);
+	return DBA::toArray(DBA::p('SELECT
+			m.`id`,
+			m.`uid`,
+			m.`guid`,
+			m.`from-name`,
+			m.`from-photo`,
+			m.`from-url`,
+			m.`contact-id`,
+			m.`convid`,
+			m.`title`,
+			m.`body`,
+			m.`seen`,
+			m.`reply`,
+			m.`replied`,
+			m.`unknown`,
+			m.`uri`,
+			m.`parent-uri`,
+			m.`created`,
+			c.`name`,
+			c.`url`,
+			c.`thumb`,
+			c.`network`,
+       		m2.`count`,
+       		m2.`mailcreated`,
+       		m2.`mailseen`
+       	FROM `mail` m
+       	JOIN (
+       		SELECT
+       			`parent-uri`,
+       		    MIN(`id`)      AS `id`,
+       		    COUNT(*)       AS `count`,
+       		    MAX(`created`) AS `mailcreated`,
+       		    MIN(`seen`)    AS `mailseen`
+       		FROM `mail`
+       		WHERE `uid` = ?
+       		GROUP BY `parent-uri`
+       	) m2 ON m.`parent-uri` = m2.`parent-uri` AND m.`id` = m2.`id`
+		LEFT JOIN `contact` c ON m.`contact-id` = c.`id`
+		WHERE m.`uid` = ?
+		ORDER BY m2.`mailcreated` DESC
+		LIMIT ?, ?'
+		, $uid, $uid, $start, $limit));
 }
 
 function render_messages(array $msg, $t)

--- a/view/templates/mail_head.tpl
+++ b/view/templates/mail_head.tpl
@@ -1,4 +1,2 @@
 
 <h3>{{$messages}}</h3>
-
-{{$tab_content}}

--- a/view/theme/frio/templates/mail_head.tpl
+++ b/view/theme/frio/templates/mail_head.tpl
@@ -16,4 +16,3 @@
 </div>
 
 <div class="clear"></div>
-{{$tab_content}}


### PR DESCRIPTION
Fixes #4738

This is the quick fix for the message list display issue described in #4738.

This doesn't fix the inconsistency between `mail.uri` and `mail.parent-uri`.