### PR TITLE
Add number of comments to API calls + add support for exclude_replies in API search

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -657,6 +657,7 @@ Friendica adds some addictional fields:
 - owner: a user object, it's the owner of the item.
 - private: boolean, true if the item is marked as private
 - activities: map with activities related to the item. Every activity is a list of user objects.
+- comments: comment numbers
 
 This properties are prefixed with "friendica_" in JSON responses and namespaced under "http://friendi.ca/schema/api/1/" in XML responses
 
@@ -681,7 +682,8 @@ JSON:
 			'attendyes': [],
 			'attendno': [],
 			'attendmaybe': []
-		}
+		},
+		'friendica_comments': 12
 	},
 	// ...
 ]
@@ -707,6 +709,7 @@ XML:
 		<friendica:attendno/>
 		<friendica:attendmaybe/>
 	</friendica:activities>	
+	<friendica:comments>21</friendica:comments>
 	</status>
 	<!-- ... -->
 </statuses>
@@ -756,6 +759,7 @@ Friendica doesn't allow showing followers of other users.
 * count: alias for the rpp parameter
 * since_id: returns statuses with ids greater than the given id
 * max_id: returns statuses with ids lower or equal to the given id
+* exclude_replies: don't show replies (default: false)
 
 #### Unsupported parameters
 

--- a/include/api.php
+++ b/include/api.php
@@ -1531,6 +1531,7 @@ function api_search($type)
 	$searchTerm = trim(rawurldecode($_REQUEST['q']));
 
 	$data = [];
+	$data['status'] = [];
 	$count = 15;
 	$exclude_replies = !empty($_REQUEST['exclude_replies']);
 	if (!empty($_REQUEST['rpp'])) {
@@ -1556,14 +1557,24 @@ function api_search($type)
 		}
 		$terms = DBA::select('term', ['oid'], $condition, []);
 		$itemIds = [];
-		while($term = DBA::fetch($terms)){ $itemIds[] = $term['oid']; }
+		while ( $term = DBA::fetch($terms) ) {
+			$itemIds[] = $term['oid'];
+		}
 		DBA::close($terms);
-		$condition = [$exclude_replies ? "`id` = `parent` AND " : ''];
-		$condition[0] .= empty($itemIds) ? '' : ' `id` IN ('.implode(", ", $itemIds).')' ;
 
+		if (empty($itemIds)) {
+			return api_format_data("statuses", $type, $data);
+		}
+
+		$tmpAr = ['`id` IN ('.implode(", ", $itemIds).')'];
+		if ($exclude_replies) {
+			$tmpAr[] = "`id` = `parent`";
+		}
+
+		$condition = [ implode(" AND ", $tmpAr) ];
 	} else {
 		$condition = ["`id` > ? 
-			". ($exclude_replies ? " AND `id` = `parent` " : ' ')."
+			" . ( $exclude_replies ? " AND `id` = `parent` " : ' ' ) . "
 			AND (`uid` = 0 OR (`uid` = ? AND NOT `global`))
 			AND `body` LIKE CONCAT('%',?,'%')",
 			$since_id, api_user(), $_REQUEST['q']];
@@ -1571,7 +1582,6 @@ function api_search($type)
 			$condition[0] .= " AND `id` <= ?";
 			$condition[] = $max_id;
 		}
-
 	}
 
 	$statuses = Item::selectForUser(api_user(), [], $condition, $params);
@@ -5998,22 +6008,28 @@ api_register_func('api/saved_searches/list', 'api_saved_searches_list', true);
  *
  * @return void
  */
-function bindComments(&$data){
-	if(count($data) == 0) return;
+function bindComments(&$data) 
+{
+	if (count($data) == 0) {
+		return;
+	}
 	
 	$ids = [];
 	$comments = [];
-	foreach($data as $item){ $ids[] = $item['id']; }
-
-	$sql = "SELECT `parent`,COUNT(*) as comments FROM `item` 
-		WHERE `parent` IN ( %s ) AND `deleted` = %d AND `gravity`= %d GROUP BY `parent`";
-	$result = q($sql, implode(",", $ids), 0, GRAVITY_COMMENT);
-
-	foreach($result as $records) {
-		$comments[$records['parent']] = $records['comments'];
+	foreach ($data as $item) {
+		$ids[] = $item['id'];
 	}
 
-	foreach($data as $idx => $item){
+	$idStr = DBA::escape(implode(", ", $ids));
+	$sql = "SELECT `parent`, COUNT(*) as comments FROM `item` WHERE `parent` IN ($idStr) AND `deleted` = ? AND `gravity`= ? GROUP BY `parent`";
+	$items = DBA::p($sql, 0, GRAVITY_COMMENT);
+	$itemsData = DBA::toArray($items);
+
+	foreach ($itemsData as $item) {
+		$comments[$item['parent']] = $item['comments'];
+	}
+
+	foreach ($data as $idx => $item) {
 		$id = $item['id'];
 		$data[$idx]['friendica_comments'] = isset($comments[$id]) ? $comments[$id] : 0;
 	}

--- a/include/api.php
+++ b/include/api.php
@@ -1526,7 +1526,7 @@ function api_search($type)
 
 	if (api_user() === false || $user_info === false) { throw new ForbiddenException(); }
 
-	if (empty($_REQUEST['q'])) { throw new BadRequestException("q parameter is required."); }
+	if (empty($_REQUEST['q'])) { throw new BadRequestException('q parameter is required.'); }
 	
 	$searchTerm = trim(rawurldecode($_REQUEST['q']));
 
@@ -1552,34 +1552,34 @@ function api_search($type)
 			AND `otype` = ? AND `type` = ? AND `term` = ?",
 			$since_id, local_user(), TERM_OBJ_POST, TERM_HASHTAG, $searchTerm];
 		if ($max_id > 0) {
-			$condition[0] .= " AND `oid` <= ?";
+			$condition[0] .= ' AND `oid` <= ?';
 			$condition[] = $max_id;
 		}
 		$terms = DBA::select('term', ['oid'], $condition, []);
 		$itemIds = [];
-		while ( $term = DBA::fetch($terms) ) {
+		while ($term = DBA::fetch($terms)) {
 			$itemIds[] = $term['oid'];
 		}
 		DBA::close($terms);
 
 		if (empty($itemIds)) {
-			return api_format_data("statuses", $type, $data);
+			return api_format_data('statuses', $type, $data);
 		}
 
-		$tmpAr = ['`id` IN ('.implode(", ", $itemIds).')'];
+		$preCondition = ['`id` IN (' . implode(', ', $itemIds) . ')'];
 		if ($exclude_replies) {
-			$tmpAr[] = "`id` = `parent`";
+			$preCondition[] = '`id` = `parent`';
 		}
 
-		$condition = [ implode(" AND ", $tmpAr) ];
+		$condition = [implode(' AND ', $preCondition)];
 	} else {
 		$condition = ["`id` > ? 
-			" . ( $exclude_replies ? " AND `id` = `parent` " : ' ' ) . "
+			" . ($exclude_replies ? " AND `id` = `parent` " : ' ') . "
 			AND (`uid` = 0 OR (`uid` = ? AND NOT `global`))
 			AND `body` LIKE CONCAT('%',?,'%')",
 			$since_id, api_user(), $_REQUEST['q']];
 		if ($max_id > 0) {
-			$condition[0] .= " AND `id` <= ?";
+			$condition[0] .= ' AND `id` <= ?';
 			$condition[] = $max_id;
 		}
 	}
@@ -1590,7 +1590,7 @@ function api_search($type)
 
 	bindComments($data['status']);
 
-	return api_format_data("statuses", $type, $data);
+	return api_format_data('statuses', $type, $data);
 }
 
 /// @TODO move to top of file or somewhere better
@@ -6020,7 +6020,7 @@ function bindComments(&$data)
 		$ids[] = $item['id'];
 	}
 
-	$idStr = DBA::escape(implode(", ", $ids));
+	$idStr = DBA::escape(implode(', ', $ids));
 	$sql = "SELECT `parent`, COUNT(*) as comments FROM `item` WHERE `parent` IN ($idStr) AND `deleted` = ? AND `gravity`= ? GROUP BY `parent`";
 	$items = DBA::p($sql, 0, GRAVITY_COMMENT);
 	$itemsData = DBA::toArray($items);

--- a/tests/include/ApiTest.php
+++ b/tests/include/ApiTest.php
@@ -1427,6 +1427,7 @@ class ApiTest extends DatabaseTest
 	{
 		$_REQUEST['max_id'] = 10;
 		$_REQUEST['exclude_replies'] = true;
+		$_REQUEST['q'] = 'friendica';
 		$result = api_search('json');
 		foreach ($result['status'] as $status) {
 			$this->assertStatus($status);

--- a/tests/include/ApiTest.php
+++ b/tests/include/ApiTest.php
@@ -1420,6 +1420,20 @@ class ApiTest extends DatabaseTest
 	}
 
 	/**
+	 * Test the api_search() function with an exclude_replies parameter.
+	 * @return void
+	 */
+	public function testApiSearchWithExcludeReplies()
+	{
+		$_REQUEST['max_id'] = 10;
+		$_REQUEST['exclude_replies'] = true;
+		$result = api_search('json');
+		foreach ($result['status'] as $status) {
+			$this->assertStatus($status);
+		}
+	}
+
+	/**
 	 * Test the api_search() function without an authenticated user.
 	 * @return void
 	 * @expectedException Friendica\Network\HTTPException\ForbiddenException


### PR DESCRIPTION
Closes #6292

APIs show number of comments
- /api/statuses/*_timeline
- /api/search
- /api/favorites

/api/search enhacement
- support exclude_replies parameter