### PR TITLE
Fixed bug reported by Utzer

### DIFF
--- a/src/Protocol/PortableContact.php
+++ b/src/Protocol/PortableContact.php
@@ -1778,7 +1778,7 @@ class PortableContact
 				$curlResult = Network::curl($url);
 
 				if ($curlResult->isSuccess()) {
-					$data = json_decode($curlResult["body"], true);
+					$data = json_decode($curlResult[->getBody(), true);
 
 					if (!empty($data)) {
 						self::discoverServer($data, 3);

--- a/src/Protocol/PortableContact.php
+++ b/src/Protocol/PortableContact.php
@@ -1778,7 +1778,7 @@ class PortableContact
 				$curlResult = Network::curl($url);
 
 				if ($curlResult->isSuccess()) {
-					$data = json_decode($curlResult[->getBody(), true);
+					$data = json_decode($curlResult->getBody(), true);
 
 					if (!empty($data)) {
 						self::discoverServer($data, 3);


### PR DESCRIPTION
Ref: https://social.jeroened.be/display/cd9f100a-185c-1df4-192d-e8c648720060

This fixes a bug causing a fatal error Cannot use object of type Friendica\Network\CurlResult as array