### PR TITLE
The "Follow" activity shouldn't be send to Diaspora

### DIFF
--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -3727,12 +3727,12 @@ class Diaspora
 		} elseif (in_array($item["verb"], [ACTIVITY_LIKE, ACTIVITY_DISLIKE])) {
 			$message = self::constructLike($item, $owner);
 			$type = "like";
-		} else {
+		} elseif (!in_array($item["verb"], [ACTIVITY_FOLLOW])) {
 			$message = self::constructComment($item, $owner);
 			$type = "comment";
 		}
 
-		if (!$message) {
+		if (empty($message)) {
 			return false;
 		}
 


### PR DESCRIPTION
This message is without any meaning - and function - on the Diaspora side. So we shouldn't transmit it at all.