### PR TITLE
Escape event output

### DIFF
--- a/mod/events.php
+++ b/mod/events.php
@@ -97,9 +97,9 @@ function events_post(App $a)
 	// and we'll waste a bunch of time responding to it. Time that
 	// could've been spent doing something else.
 
-	$summary  = Strings::escapeHtml(trim(defaults($_POST, 'summary', '')));
-	$desc     = Strings::escapeHtml(trim(defaults($_POST, 'desc', '')));
-	$location = Strings::escapeHtml(trim(defaults($_POST, 'location', '')));
+	$summary  = trim(defaults($_POST, 'summary' , ''));
+	$desc     = trim(defaults($_POST, 'desc'    , ''));
+	$location = trim(defaults($_POST, 'location', ''));
 	$type     = 'event';
 
 	$params = [

--- a/src/Model/Event.php
+++ b/src/Model/Event.php
@@ -14,7 +14,6 @@ use Friendica\Core\PConfig;
 use Friendica\Core\Renderer;
 use Friendica\Core\System;
 use Friendica\Database\DBA;
-use Friendica\Model\Contact;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Map;
 use Friendica\Util\XML;

--- a/src/Model/Event.php
+++ b/src/Model/Event.php
@@ -16,6 +16,7 @@ use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Map;
+use Friendica\Util\Strings;
 use Friendica\Util\XML;
 
 require_once 'boot.php';
@@ -52,11 +53,11 @@ class Event extends BaseObject
 
 		if ($simple) {
 			if (!empty($event['summary'])) {
-				$o = "<h3>" . BBCode::convert($event['summary'], false, $simple) . "</h3>";
+				$o = "<h3>" . BBCode::convert(Strings::escapeHtml($event['summary']), false, $simple) . "</h3>";
 			}
 
 			if (!empty($event['desc'])) {
-				$o .= "<div>" . BBCode::convert($event['desc'], false, $simple) . "</div>";
+				$o .= "<div>" . BBCode::convert(Strings::escapeHtml($event['desc']), false, $simple) . "</div>";
 			}
 
 			$o .= "<h4>" . L10n::t('Starts:') . "</h4><p>" . $event_start . "</p>";
@@ -66,7 +67,7 @@ class Event extends BaseObject
 			}
 
 			if (!empty($event['location'])) {
-				$o .= "<h4>" . L10n::t('Location:') . "</h4><p>" . BBCode::convert($event['location'], false, $simple) . "</p>";
+				$o .= "<h4>" . L10n::t('Location:') . "</h4><p>" . BBCode::convert(Strings::escapeHtml($event['location']), false, $simple) . "</p>";
 			}
 
 			return $o;
@@ -74,7 +75,7 @@ class Event extends BaseObject
 
 		$o = '<div class="vevent">' . "\r\n";
 
-		$o .= '<div class="summary event-summary">' . BBCode::convert($event['summary'], false, $simple) . '</div>' . "\r\n";
+		$o .= '<div class="summary event-summary">' . BBCode::convert(Strings::escapeHtml($event['summary']), false, $simple) . '</div>' . "\r\n";
 
 		$o .= '<div class="event-start"><span class="event-label">' . L10n::t('Starts:') . '</span>&nbsp;<span class="dtstart" title="'
 			. DateTimeFormat::utc($event['start'], (!empty($event['adjust']) ? DateTimeFormat::ATOM : 'Y-m-d\TH:i:s'))
@@ -89,12 +90,12 @@ class Event extends BaseObject
 		}
 
 		if (!empty($event['desc'])) {
-			$o .= '<div class="description event-description">' . BBCode::convert($event['desc'], false, $simple) . '</div>' . "\r\n";
+			$o .= '<div class="description event-description">' . BBCode::convert(Strings::escapeHtml($event['desc']), false, $simple) . '</div>' . "\r\n";
 		}
 
 		if (!empty($event['location'])) {
 			$o .= '<div class="event-location"><span class="event-label">' . L10n::t('Location:') . '</span>&nbsp;<span class="location">'
-				. BBCode::convert($event['location'], false, $simple)
+				. BBCode::convert(Strings::escapeHtml($event['location']), false, $simple)
 				. '</span></div>' . "\r\n";
 
 			// Include a map of the location if the [map] BBCode is used.
@@ -591,10 +592,9 @@ class Event extends BaseObject
 				$drop =                  [System::baseUrl() . '/events/drop/' . $event['id'] , L10n::t('Delete event')   , '', ''];
 			}
 
-			$title = strip_tags(html_entity_decode(BBCode::convert($event['summary']), ENT_QUOTES, 'UTF-8'));
+			$title = BBCode::convert(Strings::escapeHtml($event['summary']));
 			if (!$title) {
-				list($title, $_trash) = explode("<br", BBCode::convert($event['desc']), 2);
-				$title = strip_tags(html_entity_decode($title, ENT_QUOTES, 'UTF-8'));
+				list($title, $_trash) = explode("<br", BBCode::convert(Strings::escapeHtml($event['desc'])), 2);
 			}
 
 			$author_link = $event['author-link'];
@@ -604,8 +604,9 @@ class Event extends BaseObject
 			$event['plink']       = Contact::magicLink($author_link, $plink);
 
 			$html = self::getHTML($event);
-			$event['desc']     = BBCode::convert($event['desc']);
-			$event['location'] = BBCode::convert($event['location']);
+			$event['summary']  = BBCode::convert(Strings::escapeHtml($event['summary']));
+			$event['desc']     = BBCode::convert(Strings::escapeHtml($event['desc']));
+			$event['location'] = BBCode::convert(Strings::escapeHtml($event['location']));
 			$event_list[] = [
 				'id'       => $event['id'],
 				'start'    => $start,

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -209,20 +209,20 @@ class Processor
 	 */
 	public static function createEvent($activity, $item)
 	{
-		$event['summary'] = $activity['name'];
-		$event['desc'] = $activity['content'];
-		$event['start'] = $activity['start-time'];
-		$event['finish'] = $activity['end-time'];
+		$event['summary']  = HTML::toBBCode($activity['name']);
+		$event['desc']     = HTML::toBBCode($activity['content']);
+		$event['start']    = $activity['start-time'];
+		$event['finish']   = $activity['end-time'];
 		$event['nofinish'] = empty($event['finish']);
 		$event['location'] = $activity['location'];
-		$event['adjust'] = true;
-		$event['cid'] = $item['contact-id'];
-		$event['uid'] = $item['uid'];
-		$event['uri'] = $item['uri'];
-		$event['edited'] = $item['edited'];
-		$event['private'] = $item['private'];
-		$event['guid'] = $item['guid'];
-		$event['plink'] = $item['plink'];
+		$event['adjust']   = true;
+		$event['cid']      = $item['contact-id'];
+		$event['uid']      = $item['uid'];
+		$event['uri']      = $item['uri'];
+		$event['edited']   = $item['edited'];
+		$event['private']  = $item['private'];
+		$event['guid']     = $item['guid'];
+		$event['plink']    = $item['plink'];
 
 		$condition = ['uri' => $item['uri'], 'uid' => $item['uid']];
 		$ev = DBA::selectFirst('event', ['id'], $condition);

--- a/view/theme/frio/templates/event_stream_item.tpl
+++ b/view/theme/frio/templates/event_stream_item.tpl
@@ -12,7 +12,8 @@
 					</span>
 				</div>
 				<div class="event-card-content media-body">
-					<div class="event-title event-card-title summary event-summary">{{$title}}</div>
+					<div class="event-title event-card-title summary event-summary">{{$title nofilter}}</div>
+
 					{{* If there is a map, we insert a button for showing/hiding the map *}}
 					{{if $location.map}}<button id="event-map-btn-{{$id}}" class="event-map-btn btn-link fakelink nav nav-pills preferences" data-map-id="event-location-map-{{$id}}" data-show-label="{{$show_map_label}}" data-hide-label="{{$hide_map_label}}">{{$map_btn_label}}</button>{{/if}}
 					<div class="event-property">


### PR DESCRIPTION
Part of #6316
Part of #6208

Investigating the event title wrong display, I found out that we were escaping HMTL for events title, description and location only if they had been manually submitted through the Friendica front-end.

This PR fixes this security loophole by escaping HTML on output no matter where it comes from (form submission, DFRN or ActivityPub messages), as it should be done.