### PR TITLE
Remove redundant html encoding

### DIFF
--- a/mod/admin.php
+++ b/mod/admin.php
@@ -1444,9 +1444,7 @@ function admin_page_site(App $a)
 		$banner = '<a href="https://friendi.ca"><img id="logo-img" src="images/friendica-32.png" alt="logo" /></a><span id="logo-text"><a href="https://friendi.ca">Friendica</a></span>';
 	}
 
-	$banner = htmlspecialchars($banner);
 	$info = Config::get('config', 'info');
-	$info = htmlspecialchars($info);
 
 	// Automatically create temporary paths
 	get_temppath();

--- a/mod/allfriends.php
+++ b/mod/allfriends.php
@@ -81,9 +81,9 @@ function allfriends_content(App $a)
 		$entry = [
 			'url'          => $rr['url'],
 			'itemurl'      => defaults($contact_details, 'addr', $rr['url']),
-			'name'         => htmlentities($contact_details['name']),
+			'name'         => $contact_details['name'],
 			'thumb'        => ProxyUtils::proxifyUrl($contact_details['thumb'], false, ProxyUtils::SIZE_THUMB),
-			'img_hover'    => htmlentities($contact_details['name']),
+			'img_hover'    => $contact_details['name'],
 			'details'      => $contact_details['location'],
 			'tags'         => $contact_details['keywords'],
 			'about'        => $contact_details['about'],
@@ -100,9 +100,7 @@ function allfriends_content(App $a)
 	$tab_str = Module\Contact::getTabsHTML($a, $contact, 4);
 
 	$tpl = Renderer::getMarkupTemplate('viewcontact_template.tpl');
-
 	$o .= Renderer::replaceMacros($tpl, [
-		//'$title' => L10n::t('Friends of %s', htmlentities($c[0]['name'])),
 		'$tab_str' => $tab_str,
 		'$contacts' => $entries,
 		'$paginate' => $pager->renderFull($total),

--- a/mod/babel.php
+++ b/mod/babel.php
@@ -142,7 +142,7 @@ function babel_content()
 
 	$tpl = Renderer::getMarkupTemplate('babel.tpl');
 	$o = Renderer::replaceMacros($tpl, [
-		'$text'          => ['text', L10n::t('Source text'), htmlentities(defaults($_REQUEST, 'text', '')), ''],
+		'$text'          => ['text', L10n::t('Source text'), defaults($_REQUEST, 'text', ''), ''],
 		'$type_bbcode'   => ['type', L10n::t('BBCode'), 'bbcode', '', defaults($_REQUEST, 'type', 'bbcode') == 'bbcode'],
 		'$type_markdown' => ['type', L10n::t('Markdown'), 'markdown', '', defaults($_REQUEST, 'type', 'bbcode') == 'markdown'],
 		'$type_html'     => ['type', L10n::t('HTML'), 'html', '', defaults($_REQUEST, 'type', 'bbcode') == 'html'],

--- a/mod/common.php
+++ b/mod/common.php
@@ -50,7 +50,7 @@ function common_content(App $a)
 
 		if (DBA::isResult($contact)) {
 			$vcard_widget = Renderer::replaceMacros(Renderer::getMarkupTemplate("vcard-widget.tpl"), [
-				'$name'  => htmlentities($contact['name']),
+				'$name'  => $contact['name'],
 				'$photo' => $contact['photo'],
 				'url'    => 'contact/' . $cid
 			]);
@@ -123,7 +123,7 @@ function common_content(App $a)
 			'itemurl'      => defaults($contact_details, 'addr', $common_friend['url']),
 			'name'         => $contact_details['name'],
 			'thumb'        => ProxyUtils::proxifyUrl($contact_details['thumb'], false, ProxyUtils::SIZE_THUMB),
-			'img_hover'    => htmlentities($contact_details['name']),
+			'img_hover'    => $contact_details['name'],
 			'details'      => $contact_details['location'],
 			'tags'         => $contact_details['keywords'],
 			'about'        => $contact_details['about'],

--- a/mod/credits.php
+++ b/mod/credits.php
@@ -13,7 +13,7 @@ function credits_content()
 {
 	/* fill the page with credits */
 	$credits_string = file_get_contents('util/credits.txt');
-	$names = explode("\n", htmlspecialchars($credits_string));
+	$names = explode("\n", $credits_string);
 	$tpl = Renderer::getMarkupTemplate('credits.tpl');
 	return Renderer::replaceMacros($tpl, [
 		'$title'  => L10n::t('Credits'),

--- a/mod/crepair.php
+++ b/mod/crepair.php
@@ -158,8 +158,8 @@ function crepair_content(App $a)
 			$remote_self_options
 		],
 
-		'$name'		=> ['name', L10n::t('Name') , htmlentities($contact['name'])],
-		'$nick'		=> ['nick', L10n::t('Account Nickname'), htmlentities($contact['nick'])],
+		'$name'		=> ['name', L10n::t('Name') , $contact['name']],
+		'$nick'		=> ['nick', L10n::t('Account Nickname'), $contact['nick']],
 		'$attag'	=> ['attag', L10n::t('@Tagname - overrides Name/Nickname'), $contact['attag']],
 		'$url'		=> ['url', L10n::t('Account URL'), $contact['url']],
 		'$request'	=> ['request', L10n::t('Friend Request URL'), $contact['request']],

--- a/mod/editpost.php
+++ b/mod/editpost.php
@@ -6,6 +6,7 @@ use Friendica\App;
 use Friendica\Content\Feature;
 use Friendica\Core\Addon;
 use Friendica\Core\Config;
+use Friendica\Core\Hook;
 use Friendica\Core\L10n;
 use Friendica\Core\Renderer;
 use Friendica\Core\System;
@@ -54,8 +55,6 @@ function editpost_content(App $a)
 		'$nickname' => $a->user['nickname']
 	]);
 
-	$tpl = Renderer::getMarkupTemplate("jot.tpl");
-
 	if (strlen($item['allow_cid']) || strlen($item['allow_gid']) || strlen($item['deny_cid']) || strlen($item['deny_gid'])) {
 		$lockstate = 'lock';
 	} else {
@@ -84,9 +83,9 @@ function editpost_content(App $a)
 		}
 	}
 
-	Addon::callHooks('jot_tool', $jotplugins);
-	//Addon::callHooks('jot_networks', $jotnets);
+	Hook::callAll('jot_tool', $jotplugins);
 
+	$tpl = Renderer::getMarkupTemplate("jot.tpl");
 	$o .= Renderer::replaceMacros($tpl, [
 		'$is_edit' => true,
 		'$return_path' => '/display/' . $item['guid'],
@@ -119,7 +118,7 @@ function editpost_content(App $a)
 		'$emailcc' => L10n::t('CC: email addresses'),
 		'$public' => L10n::t('Public post'),
 		'$jotnets' => $jotnets,
-		'$title' => htmlspecialchars($item['title']),
+		'$title' => $item['title'],
 		'$placeholdertitle' => L10n::t('Set title'),
 		'$category' => FileTag::fileToList($item['file'], 'category'),
 		'$placeholdercategory' => (Feature::isEnabled(local_user(),'categories') ? L10n::t("Categories \x28comma-separated list\x29") : ''),

--- a/mod/follow.php
+++ b/mod/follow.php
@@ -144,11 +144,8 @@ function follow_content(App $a)
 		$r[0]['about'] = '';
 	}
 
-	$header = L10n::t('Connect/Follow');
-
 	$o = Renderer::replaceMacros($tpl, [
-		'$header'        => htmlentities($header),
-		//'$photo'         => ProxyUtils::proxifyUrl($ret['photo'], false, ProxyUtils::SIZE_SMALL),
+		'$header'        => L10n::t('Connect/Follow'),
 		'$desc'          => '',
 		'$pls_answer'    => L10n::t('Please answer the following:'),
 		'$does_know_you' => ['knowyou', L10n::t('Does %s know you?', $ret['name']), false, '', [L10n::t('No'), L10n::t('Yes')]],
@@ -170,13 +167,6 @@ function follow_content(App $a)
 		'$url_label'     => L10n::t('Profile URL'),
 		'$myaddr'        => $myaddr,
 		'$request'       => $request,
-		/*
-		 * @TODO commented out?
-		'$location'      => Friendica\Content\Text\BBCode::::convert($r[0]['location']),
-		'$location_label'=> L10n::t('Location:'),
-		'$about'         => Friendica\Content\Text\BBCode::::convert($r[0]['about'], false, false),
-		'$about_label'   => L10n::t('About:'),
-		*/
 		'$keywords'      => $r[0]['keywords'],
 		'$keywords_label'=> L10n::t('Tags:')
 	]);

--- a/mod/message.php
+++ b/mod/message.php
@@ -247,22 +247,22 @@ function message_content(App $a)
 
 		$tpl = Renderer::getMarkupTemplate('prv_message.tpl');
 		$o .= Renderer::replaceMacros($tpl, [
-			'$header' => L10n::t('Send Private Message'),
-			'$to' => L10n::t('To:'),
+			'$header'     => L10n::t('Send Private Message'),
+			'$to'         => L10n::t('To:'),
 			'$showinputs' => 'true',
-			'$prefill' => $prefill,
-			'$preid' => $preid,
-			'$subject' => L10n::t('Subject:'),
-			'$subjtxt' => !empty($_REQUEST['subject']) ? strip_tags($_REQUEST['subject']) : '',
-			'$text' => !empty($_REQUEST['body']) ? Strings::escapeHtml(htmlspecialchars($_REQUEST['body'])) : '',
-			'$readonly' => '',
-			'$yourmessage' => L10n::t('Your message:'),
-			'$select' => $select,
-			'$parent' => '',
-			'$upload' => L10n::t('Upload photo'),
-			'$insert' => L10n::t('Insert web link'),
-			'$wait' => L10n::t('Please wait'),
-			'$submit' => L10n::t('Submit')
+			'$prefill'    => $prefill,
+			'$preid'      => $preid,
+			'$subject'    => L10n::t('Subject:'),
+			'$subjtxt'    => defaults($_REQUEST, 'subject', ''),
+			'$text'       => defaults($_REQUEST, 'body', ''),
+			'$readonly'   => '',
+			'$yourmessage'=> L10n::t('Your message:'),
+			'$select'     => $select,
+			'$parent'     => '',
+			'$upload'     => L10n::t('Upload photo'),
+			'$insert'     => L10n::t('Insert web link'),
+			'$wait'       => L10n::t('Please wait'),
+			'$submit'     => L10n::t('Submit')
 		]);
 		return $o;
 	}

--- a/mod/network.php
+++ b/mod/network.php
@@ -667,7 +667,7 @@ function networkThreadedView(App $a, $update, $parent)
 
 			$entries[0] = [
 				'id' => 'network',
-				'name' => htmlentities($contact['name']),
+				'name' => $contact['name'],
 				'itemurl' => defaults($contact, 'addr', $contact['nurl']),
 				'thumb' => ProxyUtils::proxifyUrl($contact['thumb'], false, ProxyUtils::SIZE_THUMB),
 				'details' => $contact['location'],

--- a/mod/profile.php
+++ b/mod/profile.php
@@ -33,24 +33,16 @@ function profile_init(App $a)
 		$a->page['aside'] = '';
 	}
 
-	if ($a->argc > 1) {
-		$which = htmlspecialchars($a->argv[1]);
-	} else {
-		$r = q("SELECT `nickname` FROM `user` WHERE `blocked` = 0 AND `account_expired` = 0 AND `account_removed` = 0 AND `verified` = 1 ORDER BY RAND() LIMIT 1");
-		if (DBA::isResult($r)) {
-			$a->internalRedirect('profile/' . $r[0]['nickname']);
-		} else {
-			Logger::log('profile error: mod_profile ' . $a->query_string, Logger::DEBUG);
-			notice(L10n::t('Requested profile is not available.') . EOL);
-			$a->error = 404;
-			return;
-		}
+	if ($a->argc < 2) {
+		System::httpExit(400);
 	}
+
+	$which = filter_var($a->argv[1], FILTER_SANITIZE_STRING, FILTER_FLAG_STRIP_LOW | FILTER_FLAG_STRIP_HIGH | FILTER_FLAG_STRIP_BACKTICK);
 
 	$profile = 0;
 	if (local_user() && $a->argc > 2 && $a->argv[2] === 'view') {
 		$which = $a->user['nickname'];
-		$profile = htmlspecialchars($a->argv[1]);
+		$profile = filter_var($a->argv[1], FILTER_SANITIZE_NUMBER_INT);
 	} else {
 		DFRN::autoRedir($a, $which);
 	}

--- a/mod/unfollow.php
+++ b/mod/unfollow.php
@@ -114,10 +114,8 @@ function unfollow_content(App $a)
 	// Makes the connection request for friendica contacts easier
 	$_SESSION['fastlane'] = $contact['url'];
 
-	$header = L10n::t('Disconnect/Unfollow');
-
 	$o = Renderer::replaceMacros($tpl, [
-		'$header'        => htmlentities($header),
+		'$header'        => L10n::t('Disconnect/Unfollow'),
 		'$desc'          => '',
 		'$pls_answer'    => '',
 		'$does_know_you' => '',

--- a/mod/wallmessage.php
+++ b/mod/wallmessage.php
@@ -125,20 +125,20 @@ function wallmessage_content(App $a) {
 
 	$tpl = Renderer::getMarkupTemplate('wallmessage.tpl');
 	$o = Renderer::replaceMacros($tpl, [
-		'$header' => L10n::t('Send Private Message'),
-		'$subheader' => L10n::t('If you wish for %s to respond, please check that the privacy settings on your site allow private mail from unknown senders.', $user['username']),
-		'$to' => L10n::t('To:'),
-		'$subject' => L10n::t('Subject:'),
-		'$recipname' => $user['username'],
-		'$nickname' => $user['nickname'],
-		'$subjtxt' => (!empty($_REQUEST['subject']) ? strip_tags($_REQUEST['subject']) : ''),
-		'$text' => (!empty($_REQUEST['body']) ? Strings::escapeHtml(htmlspecialchars($_REQUEST['body'])) : ''),
-		'$readonly' => '',
-		'$yourmessage' => L10n::t('Your message:'),
-		'$parent' => '',
-		'$upload' => L10n::t('Upload photo'),
-		'$insert' => L10n::t('Insert web link'),
-		'$wait' => L10n::t('Please wait')
+		'$header'     => L10n::t('Send Private Message'),
+		'$subheader'  => L10n::t('If you wish for %s to respond, please check that the privacy settings on your site allow private mail from unknown senders.', $user['username']),
+		'$to'         => L10n::t('To:'),
+		'$subject'    => L10n::t('Subject:'),
+		'$recipname'  => $user['username'],
+		'$nickname'   => $user['nickname'],
+		'$subjtxt'    => defaults($_REQUEST, 'subject', ''),
+		'$text'       => defaults($_REQUEST, 'body', ''),
+		'$readonly'   => '',
+		'$yourmessage'=> L10n::t('Your message:'),
+		'$parent'     => '',
+		'$upload'     => L10n::t('Upload photo'),
+		'$insert'     => L10n::t('Insert web link'),
+		'$wait'       => L10n::t('Please wait')
 	]);
 
 	return $o;

--- a/src/Content/Text/HTML.php
+++ b/src/Content/Text/HTML.php
@@ -961,7 +961,7 @@ class HTML
 		$save_label = $mode === 'text' ? L10n::t('Save') : L10n::t('Follow');
 
 		$values = [
-				'$s' => htmlspecialchars($s),
+				'$s' => $s,
 				'$id' => $id,
 				'$action_url' => $url,
 				'$search_label' => L10n::t('Search'),

--- a/src/Module/Itemsource.php
+++ b/src/Module/Itemsource.php
@@ -25,12 +25,12 @@ class Itemsource extends \Friendica\BaseModule
 			$conversation = Model\Conversation::getByItemUri($item['uri']);
 
 			$item_uri = $item['uri'];
-			$source = htmlspecialchars($conversation['source']);
+			$source = $conversation['source'];
 		}
 
 		$tpl = Renderer::getMarkupTemplate('debug/itemsource.tpl');
 		$o = Renderer::replaceMacros($tpl, [
-			'$guid'          => ['guid', L10n::t('Item Guid'), htmlentities(defaults($_REQUEST, 'guid', '')), ''],
+			'$guid'          => ['guid', L10n::t('Item Guid'), defaults($_REQUEST, 'guid', ''), ''],
 			'$source'        => $source,
 			'$item_uri'      => $item_uri
 		]);

--- a/view/templates/babel.tpl
+++ b/view/templates/babel.tpl
@@ -21,7 +21,7 @@
 			<h3 class="panel-title">{{$result.title}}</h3>
 		</div>
 		<div class="panel-body">
-			{{$result.content}}
+			{{$result.content nofilter}}
 		</div>
 	</div>
 	{{/foreach}}

--- a/view/templates/wallmessage.tpl
+++ b/view/templates/wallmessage.tpl
@@ -1,4 +1,4 @@
-
+<div class="generic-page-wrapper">
 
 <h3>{{$header}}</h3>
 
@@ -30,4 +30,5 @@
 </div>
 <div id="prvmail-end"></div>
 </form>
+</div>
 </div>

--- a/view/theme/frio/templates/contact_template.tpl
+++ b/view/theme/frio/templates/contact_template.tpl
@@ -188,7 +188,7 @@ We use this part to filter the contacts with jquery.textcomplete *}}
 				{/if}
 				{if $photo_menu.edit}
 				<a class="contact-action-link btn-link" href="{$photo_menu.edit.1}" data-toggle="tooltip" title="{$photo_menu.edit.0}">
-					<i class="fa fa-pencil" aria-hidden="true"></i>
+					<i class="fa fa-user" aria-hidden="true"></i>
 				</a>
 				{/if}
 				{if $photo_menu.drop}

--- a/view/theme/frio/templates/field_textarea.tpl
+++ b/view/theme/frio/templates/field_textarea.tpl
@@ -1,7 +1,7 @@
 
 	<div class="form-group field textarea">
 		<label for="id_{{$field.0}}">{{$field.1}}</label>
-		<textarea class="form-control text-autosize" name="{{$field.0}}" id="id_{{$field.0}}" {{if $field.4}}{{$field.4}}{{/if}} aria-describedby="{{$field.0}}_tip">{{$field.2 nofilter}}</textarea>
+		<textarea class="form-control text-autosize" name="{{$field.0}}" id="id_{{$field.0}}" {{if $field.4}}{{$field.4}}{{/if}} aria-describedby="{{$field.0}}_tip">{{$field.2}}</textarea>
 		{{if $field.3}}
 		<span class="help-block" id="{{$field.0}}_tip" role="tooltip">{{$field.3 nofilter}}</span>
 		{{/if}}


### PR DESCRIPTION
Part of #6208 

Inspired by #6316, I figured that instead of waiting for people to come forward with display issues, I could also check that we weren't double-encoding using `htmlentities()`/`htmlspecialchars()`.

The result speaks for itself, with about a dozen issues preemptively fixed.

