### PR TITLE
Only assign a uid to the profile if not defined by now

### DIFF
--- a/mod/display.php
+++ b/mod/display.php
@@ -291,8 +291,8 @@ function display_content(App $a, $update = false, $update_uid = 0)
 
 	$parent = Item::selectFirst(['uid'], ['uri' => $item_parent_uri, 'wall' => true]);
 	if (DBA::isResult($parent)) {
-		$a->profile['uid'] = $parent['uid'];
-		$a->profile['profile_uid'] = $parent['uid'];
+		$a->profile['uid'] = defaults($a->profile, 'uid', $parent['uid']);
+		$a->profile['profile_uid'] = defaults($a->profile, 'profile_uid', $parent['uid']);
 		$is_remote_contact = Contact::isFollower(remote_user(), $a->profile['profile_uid']);
 	}
 


### PR DESCRIPTION
This lead to the problem that some people weren't able to have a look at postings.
See here: https://forum.friendi.ca/display/39bbe52a-895c-1e9b-2751-b0a764420417 (German)