### PR TITLE
Fix site theme settings modal form

### DIFF
--- a/mod/admin.php
+++ b/mod/admin.php
@@ -89,12 +89,10 @@ function admin_post(App $a)
 
 				$theme = $a->argv[2];
 				if (is_file("view/theme/$theme/config.php")) {
-					$orig_theme = Renderer::$theme;
-					$orig_page = $a->page;
-					$orig_session_theme = $_SESSION['theme'];
+					$a->setCurrentTheme($theme);
+
 					require_once "view/theme/$theme/theme.php";
 					require_once "view/theme/$theme/config.php";
-					$_SESSION['theme'] = $theme;
 
 					$init = $theme . '_init';
 					if (function_exists($init)) {
@@ -103,17 +101,13 @@ function admin_post(App $a)
 					if (function_exists('theme_admin_post')) {
 						theme_admin_post($a);
 					}
-
-					$_SESSION['theme'] = $orig_session_theme;
-					Renderer::$theme = $orig_theme;
-					$a->page = $orig_page;
 				}
 
 				info(L10n::t('Theme settings updated.'));
 				if ($a->isAjax()) {
 					return;
 				}
-				$return_path = 'admin/themes/' . $theme;
+				$return_path = 'admin/themes/' . $theme . (!empty($_GET['mode']) ? '?mode=' . $_GET['mode'] : '');
 				break;
 			case 'tos':
 				admin_page_tos_post($a);
@@ -2312,12 +2306,10 @@ function admin_page_themes(App $a)
 
 		$admin_form = '';
 		if (is_file("view/theme/$theme/config.php")) {
-			$orig_theme = Renderer::$theme;
-			$orig_page = $a->page;
-			$orig_session_theme = $_SESSION['theme'];
+			$a->setCurrentTheme($theme);
+
 			require_once "view/theme/$theme/theme.php";
 			require_once "view/theme/$theme/config.php";
-			$_SESSION['theme'] = $theme;
 
 			$init = $theme . "_init";
 			if (function_exists($init)) {
@@ -2327,10 +2319,6 @@ function admin_page_themes(App $a)
 			if (function_exists('theme_admin')) {
 				$admin_form = theme_admin($a);
 			}
-
-			$_SESSION['theme'] = $orig_session_theme;
-			Renderer::$theme = $orig_theme;
-			$a->page = $orig_page;
 		}
 
 		$screenshot = [Theme::getScreenshot($theme), L10n::t('Screenshot')];
@@ -2345,7 +2333,7 @@ function admin_page_themes(App $a)
 			'$toggle' => L10n::t('Toggle'),
 			'$settings' => L10n::t('Settings'),
 			'$baseurl' => System::baseUrl(true),
-			'$addon' => $theme,
+			'$addon' => $theme . (!empty($_GET['mode']) ? '?mode=' . $_GET['mode'] : ''),
 			'$status' => $status,
 			'$action' => $action,
 			'$info' => Theme::getInfo($theme),

--- a/view/templates/admin/addon_details.tpl
+++ b/view/templates/admin/addon_details.tpl
@@ -23,7 +23,7 @@
 
 	{{if $admin_form}}
 	<h3>{{$settings}}</h3>
-	<form method="post" action="{{$baseurl}}/admin/{{$function}}/{{$addon}}/">
+	<form method="post" action="{{$baseurl}}/admin/{{$function}}/{{$addon}}">
 		{{$admin_form nofilter}}
 	</form>
 	{{/if}}

--- a/view/templates/admin/site.tpl
+++ b/view/templates/admin/site.tpl
@@ -9,7 +9,8 @@
 					var theme = $("#id_theme :selected").val();
 					$("#cnftheme").attr('href',"{{$baseurl}}/admin/themes/"+theme);
 				},*/
-				href: "{{$baseurl}}/admin/themes/" + $("#id_theme :selected").val(),
+				iframe: true,
+				href: "{{$baseurl}}/admin/themes/" + $("#id_theme :selected").val() + "?mode=minimal",
 				onComplete: function(){
 					$("div#fancybox-content form").submit(function(e){
 						var url = $(this).attr('action');

--- a/view/theme/frio/README.md
+++ b/view/theme/frio/README.md
@@ -29,23 +29,23 @@ Don't blame me too much for ugly code and hacks. Fix it ;-)
 
 #### Screenshots
 **Default**
-![Default - Stream](https://github.com/rabuzarus/frio/blob/master/img/screenshots/screenshot.png)
+![Default - Stream](https://git.friendi.ca/friendica/friendica/raw/branch/master/view/theme/frio/img/screenshots/screenshot.png)
 
 **Modals**
-![Modals](https://github.com/rabuzarus/frio/blob/master/img/screenshots/screenshot-jot-modal.png)
+![Modals](https://git.friendi.ca/friendica/friendica/raw/branch/master/view/theme/frio/img/screenshots/screenshot-jot-modal.png)
 
 **Theme - Settings**
-![Theme - Settings](https://github.com/rabuzarus/frio/blob/master/img/screenshots/screenshot-settings.png)
+![Theme - Settings](https://git.friendi.ca/friendica/friendica/raw/branch/master/view/theme/frio/img/screenshots/screenshot-settings.png)
 
 **Red scheme**
-![Red scheme](https://github.com/rabuzarus/frio/blob/master/img/screenshots/screenshot-scheme-red.png)
+![Red scheme](https://git.friendi.ca/friendica/friendica/raw/branch/master/view/theme/frio/img/screenshots/screenshot-scheme-red.png)
 
 **Love Music scheme**
-![Love Music scheme](https://github.com/rabuzarus/frio/blob/master/img/screenshots/screenshot-scheme-love-music.png)
+![Love Music scheme](https://git.friendi.ca/friendica/friendica/raw/branch/master/view/theme/frio/img/screenshots/screenshot-scheme-love-music.png)
 
 **frio on mobile**
 
-![frio on mobile](https://github.com/rabuzarus/frio/blob/master/img/screenshots/screenshot-mobile.png)
+![frio on mobile](https://git.friendi.ca/friendica/friendica/raw/branch/master/view/theme/frio/img/screenshots/screenshot-mobile.png)
 
 #### Credits:
 HumHub - Social Network Kit - <https://github.com/humhub/humhub>

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -130,6 +130,15 @@ blockquote {
 /*
 * standard page elements
 */
+
+section.minimal {
+    top: 0px;
+    left: 0px;
+    position: absolute;
+    width: 100%;
+    height: 100%;
+}
+
 #back-to-top {
     display: none;
     cursor: pointer;

--- a/view/theme/frio/templates/admin/site.tpl
+++ b/view/theme/frio/templates/admin/site.tpl
@@ -10,7 +10,8 @@
 					var theme = $("#id_theme :selected").val();
 					$("#cnftheme").attr('href',"{{$baseurl}}/admin/themes/"+theme);
 				},*/
-				href: "{{$baseurl}}/admin/themes/" + $("#id_theme :selected").val(),
+                iframe: true,
+                href: "{{$baseurl}}/admin/themes/" + $("#id_theme :selected").val() + "?mode=minimal",
 				onComplete: function(){
 					$("div#fancybox-content form").submit(function(e){
 						var url = $(this).attr('action');


### PR DESCRIPTION
Fixes #1495 (oof)

This PR allows modules to set the current theme as it is needed in the specific case of setting the site theme settings from a different user theme. Setting the relevant theme in the site theme settings modal allows to load JS dependencies (like colorpicker for frio for example).