### PR TITLE
Clear private message notifications

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -164,21 +164,21 @@ define('MAX_LIKERS',    75);
  * Email notification options
  * @{
  */
-define('NOTIFY_INTRO',    0x0001);
-define('NOTIFY_CONFIRM',  0x0002);
-define('NOTIFY_WALL',     0x0004);
-define('NOTIFY_COMMENT',  0x0008);
-define('NOTIFY_MAIL',     0x0010);
-define('NOTIFY_SUGGEST',  0x0020);
-define('NOTIFY_PROFILE',  0x0040);
-define('NOTIFY_TAGSELF',  0x0080);
-define('NOTIFY_TAGSHARE', 0x0100);
-define('NOTIFY_POKE',     0x0200);
-define('NOTIFY_SHARE',    0x0400);
+define('NOTIFY_INTRO',        1);
+define('NOTIFY_CONFIRM',      2);
+define('NOTIFY_WALL',         4);
+define('NOTIFY_COMMENT',      8);
+define('NOTIFY_MAIL',        16);
+define('NOTIFY_SUGGEST',     32);
+define('NOTIFY_PROFILE',     64);
+define('NOTIFY_TAGSELF',    128);
+define('NOTIFY_TAGSHARE',   256);
+define('NOTIFY_POKE',       512);
+define('NOTIFY_SHARE',     1024);
 
-define('SYSTEM_EMAIL',    0x4000);
+define('SYSTEM_EMAIL',    16384);
 
-define('NOTIFY_SYSTEM',   0x8000);
+define('NOTIFY_SYSTEM',   32768);
 /* @}*/
 
 

--- a/mod/message.php
+++ b/mod/message.php
@@ -499,7 +499,6 @@ function render_messages(array $msg, $t)
 			$participants = L10n::t("%s and You", $rr['from-name']);
 		}
 
-		$subject_e = (($rr['mailseen']) ? $rr['title'] : '<strong>' . $rr['title'] . '</strong>');
 		$body_e = $rr['body'];
 		$to_name_e = $rr['name'];
 
@@ -517,7 +516,7 @@ function render_messages(array $msg, $t)
 			'$from_addr' => defaults($contact, 'addr', ''),
 			'$sparkle' => ' sparkle',
 			'$from_photo' => ProxyUtils::proxifyUrl($from_photo, false, ProxyUtils::SIZE_THUMB),
-			'$subject' => $subject_e,
+			'$subject' => $rr['title'],
 			'$delete' => L10n::t('Delete conversation'),
 			'$body' => $body_e,
 			'$to_name' => $to_name_e,

--- a/mod/message.php
+++ b/mod/message.php
@@ -339,6 +339,13 @@ function message_content(App $a)
 			$messages = DBA::toArray($messages_stmt);
 
 			DBA::update('mail', ['seen' => 1], ['parent-uri' => $message['parent-uri'], 'uid' => local_user()]);
+
+			if ($message['convid']) {
+				// Clear Diaspora private message notifications
+				DBA::update('notify', ['seen' => 1], ['type' => NOTIFY_MAIL, 'parent' => $message['convid'], 'uid' => local_user()]);
+			}
+			// Clear DFRN private message notifications
+			DBA::update('notify', ['seen' => 1], ['type' => NOTIFY_MAIL, 'parent' => $message['parent-uri'], 'uid' => local_user()]);
 		} else {
 			$messages = false;
 		}

--- a/mod/ping.php
+++ b/mod/ping.php
@@ -64,14 +64,7 @@ function ping_init(App $a)
 		$format = 'json';
 	}
 
-	$tags          = [];
-	$comments      = [];
-	$likes         = [];
-	$dislikes      = [];
-	$friends       = [];
-	$posts         = [];
 	$regs          = [];
-	$mails         = [];
 	$notifications = [];
 
 	$intro_count    = 0;
@@ -427,8 +420,6 @@ function ping_get_notifications($uid)
 	$order   = "DESC";
 	$quit    = false;
 
-	$a = get_app();
-
 	do {
 		$r = q(
 			"SELECT `notify`.*, `item`.`visible`, `item`.`deleted`
@@ -505,8 +496,8 @@ function ping_get_notifications($uid)
  * @param array $notifs          Complete list of notification
  * @param array $sysmsgs         List of system notice messages
  * @param array $sysmsgs_info    List of system info messages
- * @param int   $groups_unseen   Number of unseen group items
- * @param int   $forums_unseen   Number of unseen forum items
+ * @param array $groups_unseen   List of unseen group messages
+ * @param array $forums_unseen   List of unseen forum messages
  *
  * @return array XML-transform ready data array
  */

--- a/mod/ping.php
+++ b/mod/ping.php
@@ -275,22 +275,6 @@ function ping_init(App $a)
 			}
 		}
 
-		if (DBA::isResult($mails)) {
-			foreach ($mails as $mail) {
-				$notif = [
-					'id'      => 0,
-					'href'    => System::baseUrl() . '/message/' . $mail['id'],
-					'name'    => $mail['from-name'],
-					'url'     => $mail['from-url'],
-					'photo'   => $mail['from-photo'],
-					'date'    => $mail['created'],
-					'seen'    => false,
-					'message' => L10n::t('{0} sent you a message'),
-				];
-				$notifs[] = $notif;
-			}
-		}
-
 		if (DBA::isResult($regs)) {
 			foreach ($regs as $reg) {
 				$notif = [
@@ -377,7 +361,7 @@ function ping_init(App $a)
 	if ($format == 'json') {
 		$data['groups'] = $groups_unseen;
 		$data['forums'] = $forums_unseen;
-		$data['notify'] = $sysnotify_count + $intro_count + $mail_count + $register_count;
+		$data['notify'] = $sysnotify_count + $intro_count + $register_count;
 		$data['notifications'] = $notifications;
 		$data['sysmsgs'] = [
 			'notice' => $sysmsgs,

--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -1870,6 +1870,7 @@ class DFRN
 			"to_email" => $importer["email"],
 			"uid" => $importer["importer_uid"],
 			"item" => $msg,
+			"parent" => $msg["parent-uri"],
 			"source_name" => $msg["from-name"],
 			"source_link" => $importer["url"],
 			"source_photo" => $importer["thumb"],

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -1807,31 +1807,28 @@ class Diaspora
 			return false;
 		}
 
-		q(
-			"INSERT INTO `mail` (`uid`, `guid`, `convid`, `from-name`,`from-photo`,`from-url`,`contact-id`,`title`,`body`,`seen`,`reply`,`uri`,`parent-uri`,`created`)
-			VALUES (%d, '%s', %d, '%s', '%s', '%s', %d, '%s', '%s', %d, %d, '%s','%s','%s')",
-			intval($importer["uid"]),
-			DBA::escape($msg_guid),
-			intval($conversation["id"]),
-			DBA::escape($person["name"]),
-			DBA::escape($person["photo"]),
-			DBA::escape($person["url"]),
-			intval($contact["id"]),
-			DBA::escape($subject),
-			DBA::escape($body),
-			0,
-			0,
-			DBA::escape($message_uri),
-			DBA::escape($author.":".$guid),
-			DBA::escape($msg_created_at)
-		);
+		DBA::insert('mail', [
+			'uid'        => $importer['uid'],
+			'guid'       => $msg_guid,
+			'convid'     => $conversation['id'],
+			'from-name'  => $person['name'],
+			'from-photo' => $person['photo'],
+			'from-url'   => $person['url'],
+			'contact-id' => $contact['id'],
+			'title'      => $subject,
+			'body'       => $body,
+			'seen'       => 0,
+			'reply'      => 0,
+			'uri'        => $message_uri,
+			'parent-uri' => $author . ':' . $guid,
+			'created'    => $msg_created_at
+		]);
 
 		DBA::unlock();
 
 		DBA::update('conv', ['updated' => DateTimeFormat::utcNow()], ['id' => $conversation["id"]]);
 
-		notification(
-			[
+		notification([
 			"type" => NOTIFY_MAIL,
 			"notify_flags" => $importer["notify-flags"],
 			"language" => $importer["language"],
@@ -1843,8 +1840,9 @@ class Diaspora
 			"source_link" => $person["url"],
 			"source_photo" => $person["photo"],
 			"verb" => ACTIVITY_POST,
-			"otype" => "mail"]
-		);
+			"otype" => "mail"
+		]);
+
 		return true;
 	}
 
@@ -2066,24 +2064,22 @@ class Diaspora
 			return false;
 		}
 
-		q(
-			"INSERT INTO `mail` (`uid`, `guid`, `convid`, `from-name`,`from-photo`,`from-url`,`contact-id`,`title`,`body`,`seen`,`reply`,`uri`,`parent-uri`,`created`)
-				VALUES ( %d, '%s', %d, '%s', '%s', '%s', %d, '%s', '%s', %d, %d, '%s','%s','%s')",
-			intval($importer["uid"]),
-			DBA::escape($guid),
-			intval($conversation["id"]),
-			DBA::escape($person["name"]),
-			DBA::escape($person["photo"]),
-			DBA::escape($person["url"]),
-			intval($contact["id"]),
-			DBA::escape($conversation["subject"]),
-			DBA::escape($body),
-			0,
-			1,
-			DBA::escape($message_uri),
-			DBA::escape($author.":".$conversation["guid"]),
-			DBA::escape($created_at)
-		);
+		DBA::insert('mail', [
+			'uid'        => $importer['uid'],
+			'guid'       => $guid,
+			'convid'     => $conversation['id'],
+			'from-name'  => $person['name'],
+			'from-photo' => $person['photo'],
+			'from-url'   => $person['url'],
+			'contact-id' => $contact['id'],
+			'title'      => $conversation['subject'],
+			'body'       => $body,
+			'seen'       => 0,
+			'reply'      => 1,
+			'uri'        => $message_uri,
+			'parent-uri' => $author.":".$conversation['guid'],
+			'created'    => $created_at
+		]);
 
 		DBA::unlock();
 

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -1824,6 +1824,8 @@ class Diaspora
 			'created'    => $msg_created_at
 		]);
 
+		$message_id = DBA::lastInsertId();
+
 		DBA::unlock();
 
 		DBA::update('conv', ['updated' => DateTimeFormat::utcNow()], ['id' => $conversation["id"]]);
@@ -1834,8 +1836,9 @@ class Diaspora
 			"language" => $importer["language"],
 			"to_name" => $importer["username"],
 			"to_email" => $importer["email"],
-			"uid" =>$importer["uid"],
-			"item" => ["id" => $conversation["id"], "title" => $subject, "subject" => $subject, "body" => $body],
+			"uid" => $importer["uid"],
+			"item" => ["id" => $message_id, "title" => $subject, "subject" => $subject, "body" => $body],
+			"parent" => $conversation["id"],
 			"source_name" => $person["name"],
 			"source_link" => $person["url"],
 			"source_photo" => $person["photo"],
@@ -2081,9 +2084,28 @@ class Diaspora
 			'created'    => $created_at
 		]);
 
+		$message_id = DBA::lastInsertId();
+
 		DBA::unlock();
 
 		DBA::update('conv', ['updated' => DateTimeFormat::utcNow()], ['id' => $conversation["id"]]);
+
+		notification([
+			"type" => NOTIFY_MAIL,
+			"notify_flags" => $importer["notify-flags"],
+			"language" => $importer["language"],
+			"to_name" => $importer["username"],
+			"to_email" => $importer["email"],
+			"uid" => $importer["uid"],
+			"item" => ["id" => $message_id, "title" => $conversation["subject"], "subject" => $conversation["subject"], "body" => $body],
+			"parent" => $conversation["id"],
+			"source_name" => $person["name"],
+			"source_link" => $person["url"],
+			"source_photo" => $person["photo"],
+			"verb" => ACTIVITY_POST,
+			"otype" => "mail"
+		]);
+
 		return true;
 	}
 

--- a/view/theme/frio/templates/mail_list.tpl
+++ b/view/theme/frio/templates/mail_list.tpl
@@ -12,7 +12,16 @@
 				<div class="text-muted time ago pull-right" title="{{$date}}">{{$ago}}</div>
 
 				<h4 class="media-heading">{{$from_name}}</h4>
-				<div class="mail-list-subject"><a href="message/{{$id}}">{{$subject}}</a></div>
+				<div class="mail-list-subject">
+					<a href="message/{{$id}}">
+					{{if !$seen}}
+						<strong>
+					{{/if}}
+						{{$subject}}
+					{{if !$seen}}
+						</strong>
+					{{/if}}
+					</a></div>
 				<a href="message/dropconv/{{$id}}" onclick="return confirmDelete();"  title="{{$delete}}" class="pull-right" onmouseover="imgbright(this);" onmouseout="imgdull(this);">
 				<i class="faded-icon fa fa-trash"></i>
 				</a>


### PR DESCRIPTION
Fixes #6283 
Part of #6208 

This PR essentially clears the private message notifications when viewing a private message conversation.

On top of that, it removes the private message notifications from the ping output because:
- They were made up (while they were existing in the `notify` table)
- The display is redundant with the private message badge

Private message notifications are still available in the `/notifications` page, mainly used on mobile.