### PR TITLE
Bugfix - the remote user also has magicLinks again

### DIFF
--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -2072,7 +2072,7 @@ class Contact extends BaseObject
 	 */
 	public static function magicLink($contact_url, $url = '')
 	{
-		if (!local_user()) {
+		if (!local_user() && remote_user()) {
 			return $url ?: $contact_url; // Equivalent to: ($url != '') ? $url : $contact_url;
 		}
 
@@ -2097,7 +2097,7 @@ class Contact extends BaseObject
 		$contact = DBA::selectFirst('contact', ['id', 'network', 'url', 'uid'], ['id' => $cid]);
 
 		return self::magicLinkbyContact($contact, $url);
-        }
+	}
 
 	/**
 	 * @brief Returns a magic link to authenticate remote visitors
@@ -2109,7 +2109,7 @@ class Contact extends BaseObject
 	 */
 	public static function magicLinkbyContact($contact, $url = '')
 	{
-		if (!local_user() || ($contact['network'] != Protocol::DFRN)) {
+		if ((!local_user() && !remote_user()) || ($contact['network'] != Protocol::DFRN)) {
 			return $url ?: $contact['url']; // Equivalent to ($url != '') ? $url : $contact['url'];
 		}
 


### PR DESCRIPTION
With https://github.com/friendica/friendica/pull/6244 magic links were only available for the local user. Wit this PR magic links were also enabled for remote users. By doing so the remote user can jump from friendica instance to friendica instance and would be always authenticated.

NOTE:
At the moment magic links (and dfrn auth or OWA) are only used for dfrn contacts. Many dfrn contacts were converted to be AP contacts. So authentication is disabled. We should try to support authentication for dfrn contacts who are on a friendica instance.

@annando 
do you no a fast and simple way to check if an AP contact is on a friendica instance?