### PR TITLE
Change stylesheet path name for mobile browsers

### DIFF
--- a/src/Core/Theme.php
+++ b/src/Core/Theme.php
@@ -6,6 +6,7 @@
 
 namespace Friendica\Core;
 
+use Friendica\BaseObject;
 use Friendica\Core\Logger;
 use Friendica\Core\System;
 
@@ -191,11 +192,16 @@ class Theme
 	 */
 	public static function getStylesheetPath($theme)
 	{
-		$a = get_app();
+		$a = BaseObject::getApp();
 
 		$opts = (($a->profile_uid) ? '?f=&puid=' . $a->profile_uid : '');
 		if (file_exists('view/theme/' . $theme . '/style.php')) {
-			return 'view/theme/' . $theme . '/style.pcss' . $opts;
+			if ($a->is_mobile) {
+				// Workaround for iOS Safari not sending the cookie for static files
+				return 'view/theme/' . $theme . '/style' . $opts;
+			} else {
+				return 'view/theme/' . $theme . '/style.pcss' . $opts;
+			}
 		}
 
 		return 'view/theme/' . $theme . '/style.css';


### PR DESCRIPTION
Fixes #5148 
Part of #2800

I considered changing the stylesheet path for everyone, but then I remembered that we have a mobile discrimination, so this is less a change overall.