### PR TITLE
Strip base url from links before determining anchor status for iOS linker

### DIFF
--- a/view/templates/head.tpl
+++ b/view/templates/head.tpl
@@ -19,7 +19,7 @@
 <link rel="manifest" href="{{$baseurl}}/manifest" />
 <script>
 // Prevents links to switch to Safari in a home screen app - see https://gist.github.com/irae/1042167
-(function(a,b,c){if(c in b&&b[c]){var d,e=a.location,f=/^(a|html)$/i;a.addEventListener("click",function(a){d=a.target;while(!f.test(d.nodeName))d=d.parentNode;"href"in d&&(chref=d.href).replace(e.href,"").indexOf("#")&&(!/^[a-z\+\.\-]+:/i.test(chref)||chref.indexOf(e.protocol+"//"+e.host)===0)&&(a.preventDefault(),e.href=d.href)},!1)}})(document,window.navigator,"standalone");
+(function(a,b,c){if(c in b&&b[c]){var d,e=a.location,f=/^(a|html)$/i;a.addEventListener("click",function(a){d=a.target;while(!f.test(d.nodeName))d=d.parentNode;"href"in d&&(chref=d.href).replace("{{$baseurl}}/", "").replace(e.href,"").indexOf("#")&&(!/^[a-z\+\.\-]+:/i.test(chref)||chref.indexOf(e.protocol+"//"+e.host)===0)&&(a.preventDefault(),e.href=d.href)},!1)}})(document,window.navigator,"standalone");
 </script>
 
 <link rel="search"

--- a/view/theme/frio/templates/head.tpl
+++ b/view/theme/frio/templates/head.tpl
@@ -40,7 +40,7 @@
 <link rel="manifest" href="{{$baseurl}}/manifest" />
 <script type="text/javascript">
 // Prevents links to switch to Safari in a home screen app - see https://gist.github.com/irae/1042167
-(function(a,b,c){if(c in b&&b[c]){var d,e=a.location,f=/^(a|html)$/i;a.addEventListener("click",function(a){d=a.target;while(!f.test(d.nodeName))d=d.parentNode;"href"in d&&(chref=d.href).replace(e.href,"").indexOf("#")&&(!/^[a-z\+\.\-]+:/i.test(chref)||chref.indexOf(e.protocol+"//"+e.host)===0)&&(a.preventDefault(),e.href=d.href)},!1)}})(document,window.navigator,"standalone");
+(function(a,b,c){if(c in b&&b[c]){var d,e=a.location,f=/^(a|html)$/i;a.addEventListener("click",function(a){d=a.target;while(!f.test(d.nodeName))d=d.parentNode;"href"in d&&(chref=d.href).replace("{{$baseurl}}/", "").replace(e.href,"").indexOf("#")&&(!/^[a-z\+\.\-]+:/i.test(chref)||chref.indexOf(e.protocol+"//"+e.host)===0)&&(a.preventDefault(),e.href=d.href)},!1)}})(document,window.navigator,"standalone");
 </script>
 
 <link rel="search"


### PR DESCRIPTION
Part of #2800 

This one is far out.

The iOS linker is a small JS script that keeps Friendica in the iOS Home Screen window. It is supposed to avoid anchor links (with `href="#anchor"`) used for accordion links for example, but so far they still were reloading the app.

The reason may have to do with our use of `<base href="..." />`. iOS Safari seemingly append the base URL to every single link `href` property, which made anchor links look like internal links to the iOS linker.

The solution is to explicitly strip the base url from the `href` property when trying to decide if they are anchor links.

Successfully tested on my iPhone, no impact on anything else.