### PR TITLE
Show followers for pages, followed for users in ContactBlock widget

### DIFF
--- a/include/enotify.php
+++ b/include/enotify.php
@@ -78,7 +78,7 @@ function notification($params)
 			['uid' => $params['uid']]);
 
 		// There is no need to create notifications for forum accounts
-		if (!DBA::isResult($user) || in_array($user["page-flags"], [Contact::PAGE_COMMUNITY, Contact::PAGE_PRVGROUP])) {
+		if (!DBA::isResult($user) || in_array($user["page-flags"], [User::PAGE_FLAGS_COMMUNITY, User::PAGE_FLAGS_PRVGROUP])) {
 			return;
 		}
 		$nickname = $user["nickname"];

--- a/mod/admin.php
+++ b/mod/admin.php
@@ -1990,11 +1990,11 @@ function admin_page_users(App $a)
 	$adminlist = explode(",", str_replace(" ", "", Config::get('config', 'admin_email')));
 	$_setup_users = function ($e) use ($adminlist) {
 		$page_types = [
-			Contact::PAGE_NORMAL    => L10n::t('Normal Account Page'),
-			Contact::PAGE_SOAPBOX   => L10n::t('Soapbox Page'),
-			Contact::PAGE_COMMUNITY => L10n::t('Public Forum'),
-			Contact::PAGE_FREELOVE  => L10n::t('Automatic Friend Page'),
-			Contact::PAGE_PRVGROUP  => L10n::t('Private Forum')
+			User::PAGE_FLAGS_NORMAL    => L10n::t('Normal Account Page'),
+			User::PAGE_FLAGS_SOAPBOX   => L10n::t('Soapbox Page'),
+			User::PAGE_FLAGS_COMMUNITY => L10n::t('Public Forum'),
+			User::PAGE_FLAGS_FREELOVE  => L10n::t('Automatic Friend Page'),
+			User::PAGE_FLAGS_PRVGROUP  => L10n::t('Private Forum')
 		];
 		$account_types = [
 			Contact::ACCOUNT_TYPE_PERSON       => L10n::t('Personal Page'),

--- a/mod/admin.php
+++ b/mod/admin.php
@@ -1997,10 +1997,11 @@ function admin_page_users(App $a)
 			User::PAGE_FLAGS_PRVGROUP  => L10n::t('Private Forum')
 		];
 		$account_types = [
-			Contact::ACCOUNT_TYPE_PERSON       => L10n::t('Personal Page'),
-			Contact::ACCOUNT_TYPE_ORGANISATION => L10n::t('Organisation Page'),
-			Contact::ACCOUNT_TYPE_NEWS         => L10n::t('News Page'),
-			Contact::ACCOUNT_TYPE_COMMUNITY    => L10n::t('Community Forum')
+			User::ACCOUNT_TYPE_PERSON       => L10n::t('Personal Page'),
+			User::ACCOUNT_TYPE_ORGANISATION => L10n::t('Organisation Page'),
+			User::ACCOUNT_TYPE_NEWS         => L10n::t('News Page'),
+			User::ACCOUNT_TYPE_COMMUNITY    => L10n::t('Community Forum'),
+			User::ACCOUNT_TYPE_RELAY        => L10n::t('Relay'),
 		];
 
 		$e['page_flags_raw'] = $e['page-flags'];

--- a/mod/community.php
+++ b/mod/community.php
@@ -14,6 +14,7 @@ use Friendica\Core\Renderer;
 use Friendica\Database\DBA;
 use Friendica\Model\Contact;
 use Friendica\Model\Item;
+use Friendica\Model\User;
 
 function community_init(App $a)
 {
@@ -44,16 +45,16 @@ function community_content(App $a, $update = 0)
 	if ($a->argc > 2) {
 		switch ($a->argv[2]) {
 			case 'person':
-				$accounttype = Contact::ACCOUNT_TYPE_PERSON;
+				$accounttype = User::ACCOUNT_TYPE_PERSON;
 				break;
 			case 'organisation':
-				$accounttype = Contact::ACCOUNT_TYPE_ORGANISATION;
+				$accounttype = User::ACCOUNT_TYPE_ORGANISATION;
 				break;
 			case 'news':
-				$accounttype = Contact::ACCOUNT_TYPE_NEWS;
+				$accounttype = User::ACCOUNT_TYPE_NEWS;
 				break;
 			case 'community':
-				$accounttype = Contact::ACCOUNT_TYPE_COMMUNITY;
+				$accounttype = User::ACCOUNT_TYPE_COMMUNITY;
 				break;
 		}
 	}

--- a/mod/dfrn_confirm.php
+++ b/mod/dfrn_confirm.php
@@ -205,11 +205,11 @@ function dfrn_confirm_post(App $a, $handsfree = null)
 				$params['duplex'] = 1;
 			}
 
-			if ($user['page-flags'] == Contact::PAGE_COMMUNITY) {
+			if ($user['page-flags'] == User::PAGE_FLAGS_COMMUNITY) {
 				$params['page'] = 1;
 			}
 
-			if ($user['page-flags'] == Contact::PAGE_PRVGROUP) {
+			if ($user['page-flags'] == User::PAGE_FLAGS_PRVGROUP) {
 				$params['page'] = 2;
 			}
 

--- a/mod/dfrn_notify.php
+++ b/mod/dfrn_notify.php
@@ -12,6 +12,7 @@ use Friendica\Core\Logger;
 use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\Model\Contact;
+use Friendica\Model\User;
 use Friendica\Protocol\DFRN;
 use Friendica\Protocol\Diaspora;
 use Friendica\Util\Strings;

--- a/mod/dfrn_notify.php
+++ b/mod/dfrn_notify.php
@@ -353,7 +353,7 @@ function dfrn_notify_content(App $a) {
 			$rino = $rino_remote;
 		}
 
-		if (($importer['rel'] && ($importer['rel'] != Contact::SHARING)) || ($importer['page-flags'] == Contact::PAGE_COMMUNITY)) {
+		if (($importer['rel'] && ($importer['rel'] != Contact::SHARING)) || ($importer['page-flags'] == User::PAGE_FLAGS_COMMUNITY)) {
 			$perm = 'rw';
 		} else {
 			$perm = 'r';

--- a/mod/dfrn_request.php
+++ b/mod/dfrn_request.php
@@ -548,7 +548,7 @@ function dfrn_request_content(App $a)
 			$auto_confirm = false;
 
 			if (DBA::isResult($r)) {
-				if ($r[0]['page-flags'] != Contact::PAGE_NORMAL && $r[0]['page-flags'] != Contact::PAGE_PRVGROUP) {
+				if ($r[0]['page-flags'] != User::PAGE_FLAGS_NORMAL && $r[0]['page-flags'] != User::PAGE_FLAGS_PRVGROUP) {
 					$auto_confirm = true;
 				}
 
@@ -576,7 +576,7 @@ function dfrn_request_content(App $a)
 						'node'     => $r[0]['nickname'],
 						'dfrn_id'  => $r[0]['issued-id'],
 						'intro_id' => $intro[0]['id'],
-						'duplex'   => (($r[0]['page-flags'] == Contact::PAGE_FREELOVE) ? 1 : 0),
+						'duplex'   => (($r[0]['page-flags'] == User::PAGE_FLAGS_FREELOVE) ? 1 : 0),
 					];
 					dfrn_confirm_post($a, $handsfree);
 				}
@@ -627,7 +627,7 @@ function dfrn_request_content(App $a)
 		 * because nobody is going to read the comments and
 		 * it doesn't matter if they know you or not.
 		 */
-		if ($a->profile['page-flags'] == Contact::PAGE_NORMAL) {
+		if ($a->profile['page-flags'] == User::PAGE_FLAGS_NORMAL) {
 			$tpl = Renderer::getMarkupTemplate('dfrn_request.tpl');
 		} else {
 			$tpl = Renderer::getMarkupTemplate('auto_request.tpl');

--- a/mod/hcard.php
+++ b/mod/hcard.php
@@ -29,7 +29,7 @@ function hcard_init(App $a)
 
 	Profile::load($a, $which, $profile);
 
-	if (!empty($a->profile['page-flags']) && ($a->profile['page-flags'] == Contact::PAGE_COMMUNITY)) {
+	if (!empty($a->profile['page-flags']) && ($a->profile['page-flags'] == User::PAGE_FLAGS_COMMUNITY)) {
 		$a->page['htmlhead'] .= '<meta name="friendica.community" content="true" />';
 	}
 	if (!empty($a->profile['openidserver'])) {

--- a/mod/hcard.php
+++ b/mod/hcard.php
@@ -8,6 +8,7 @@ use Friendica\Core\L10n;
 use Friendica\Core\System;
 use Friendica\Model\Contact;
 use Friendica\Model\Profile;
+use Friendica\Model\User;
 
 function hcard_init(App $a)
 {

--- a/mod/noscrape.php
+++ b/mod/noscrape.php
@@ -9,6 +9,7 @@ use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\Model\Contact;
 use Friendica\Model\Profile;
+use Friendica\Model\User;
 
 function noscrape_init(App $a)
 {
@@ -32,7 +33,7 @@ function noscrape_init(App $a)
 		'guid'         => $a->profile['guid'],
 		'key'          => $a->profile['pubkey'],
 		'homepage'     => System::baseUrl()."/profile/{$which}",
-		'comm'         => ($a->profile['account-type'] == Contact::ACCOUNT_TYPE_COMMUNITY),
+		'comm'         => ($a->profile['account-type'] == User::ACCOUNT_TYPE_COMMUNITY),
 		'account-type' => $a->profile['account-type'],
 	];
 

--- a/mod/photos.php
+++ b/mod/photos.php
@@ -155,7 +155,7 @@ function photos_post(App $a)
 	$visitor   = 0;
 
 	$page_owner_uid = $a->data['user']['uid'];
-	$community_page = $a->data['user']['page-flags'] == Contact::PAGE_COMMUNITY;
+	$community_page = $a->data['user']['page-flags'] == User::PAGE_FLAGS_COMMUNITY;
 
 	if (local_user() && (local_user() == $page_owner_uid)) {
 		$can_post = true;
@@ -973,7 +973,7 @@ function photos_content(App $a)
 
 	$owner_uid = $a->data['user']['uid'];
 
-	$community_page = (($a->data['user']['page-flags'] == Contact::PAGE_COMMUNITY) ? true : false);
+	$community_page = (($a->data['user']['page-flags'] == User::PAGE_FLAGS_COMMUNITY) ? true : false);
 
 	if (local_user() && (local_user() == $owner_uid)) {
 		$can_post = true;

--- a/mod/profile.php
+++ b/mod/profile.php
@@ -19,6 +19,7 @@ use Friendica\Model\Contact;
 use Friendica\Model\Group;
 use Friendica\Model\Item;
 use Friendica\Model\Profile;
+use Friendica\Model\User;
 use Friendica\Module\Login;
 use Friendica\Protocol\ActivityPub;
 use Friendica\Protocol\DFRN;

--- a/mod/profile.php
+++ b/mod/profile.php
@@ -70,7 +70,7 @@ function profile_init(App $a)
 	$blocked   = !local_user() && !remote_user() && Config::get('system', 'block_public');
 	$userblock = !local_user() && !remote_user() && $a->profile['hidewall'];
 
-	if (!empty($a->profile['page-flags']) && $a->profile['page-flags'] == Contact::PAGE_COMMUNITY) {
+	if (!empty($a->profile['page-flags']) && $a->profile['page-flags'] == User::PAGE_FLAGS_COMMUNITY) {
 		$a->page['htmlhead'] .= '<meta name="friendica.community" content="true" />';
 	}
 
@@ -183,7 +183,7 @@ function profile_content(App $a, $update = 0)
 
 		$o .= Widget::commonFriendsVisitor($a->profile['profile_uid']);
 
-		$commpage = $a->profile['page-flags'] == Contact::PAGE_COMMUNITY;
+		$commpage = $a->profile['page-flags'] == User::PAGE_FLAGS_COMMUNITY;
 		$commvisitor = $commpage && $remote_contact;
 
 		$a->page['aside'] .= posted_date_widget(System::baseUrl(true) . '/profile/' . $a->profile['nickname'], $a->profile['profile_uid'], true);
@@ -267,7 +267,7 @@ function profile_content(App $a, $update = 0)
 
 		// Does the profile page belong to a forum?
 		// If not then we can improve the performance with an additional condition
-		$condition = ['uid' => $a->profile['profile_uid'], 'page-flags' => [Contact::PAGE_COMMUNITY, Contact::PAGE_PRVGROUP]];
+		$condition = ['uid' => $a->profile['profile_uid'], 'page-flags' => [User::PAGE_FLAGS_COMMUNITY, User::PAGE_FLAGS_PRVGROUP]];
 		if (!DBA::exists('user', $condition)) {
 			$sql_extra3 = sprintf(" AND `thread`.`contact-id` = %d ", intval(intval($a->profile['contact_id'])));
 		} else {

--- a/mod/profiles.php
+++ b/mod/profiles.php
@@ -19,6 +19,7 @@ use Friendica\Database\DBA;
 use Friendica\Model\Contact;
 use Friendica\Model\GContact;
 use Friendica\Model\Profile;
+use Friendica\Model\User;
 use Friendica\Module\Login;
 use Friendica\Network\Probe;
 use Friendica\Util\DateTimeFormat;

--- a/mod/profiles.php
+++ b/mod/profiles.php
@@ -532,7 +532,7 @@ function profiles_content(App $a) {
 		]);
 
 		$personal_account = !(in_array($a->user["page-flags"],
-					[Contact::PAGE_COMMUNITY, Contact::PAGE_PRVGROUP]));
+					[User::PAGE_FLAGS_COMMUNITY, User::PAGE_FLAGS_PRVGROUP]));
 
 		$detailled_profile = (PConfig::get(local_user(), 'system', 'detailled_profile') AND $personal_account);
 

--- a/mod/settings.php
+++ b/mod/settings.php
@@ -486,14 +486,14 @@ function settings_post(App $a)
 	}
 
 	// Adjust the page flag if the account type doesn't fit to the page flag.
-	if (($account_type == Contact::ACCOUNT_TYPE_PERSON) && !in_array($page_flags, [Contact::PAGE_NORMAL, Contact::PAGE_SOAPBOX, Contact::PAGE_FREELOVE])) {
-		$page_flags = Contact::PAGE_NORMAL;
-	} elseif (($account_type == Contact::ACCOUNT_TYPE_ORGANISATION) && !in_array($page_flags, [Contact::PAGE_SOAPBOX])) {
-		$page_flags = Contact::PAGE_SOAPBOX;
-	} elseif (($account_type == Contact::ACCOUNT_TYPE_NEWS) && !in_array($page_flags, [Contact::PAGE_SOAPBOX])) {
-		$page_flags = Contact::PAGE_SOAPBOX;
-	} elseif (($account_type == Contact::ACCOUNT_TYPE_COMMUNITY) && !in_array($page_flags, [Contact::PAGE_COMMUNITY, Contact::PAGE_PRVGROUP])) {
-		$page_flags = Contact::PAGE_COMMUNITY;
+	if (($account_type == Contact::ACCOUNT_TYPE_PERSON) && !in_array($page_flags, [User::PAGE_FLAGS_NORMAL, User::PAGE_FLAGS_SOAPBOX, User::PAGE_FLAGS_FREELOVE])) {
+		$page_flags = User::PAGE_FLAGS_NORMAL;
+	} elseif (($account_type == Contact::ACCOUNT_TYPE_ORGANISATION) && !in_array($page_flags, [User::PAGE_FLAGS_SOAPBOX])) {
+		$page_flags = User::PAGE_FLAGS_SOAPBOX;
+	} elseif (($account_type == Contact::ACCOUNT_TYPE_NEWS) && !in_array($page_flags, [User::PAGE_FLAGS_SOAPBOX])) {
+		$page_flags = User::PAGE_FLAGS_SOAPBOX;
+	} elseif (($account_type == Contact::ACCOUNT_TYPE_COMMUNITY) && !in_array($page_flags, [User::PAGE_FLAGS_COMMUNITY, User::PAGE_FLAGS_PRVGROUP])) {
+		$page_flags = User::PAGE_FLAGS_COMMUNITY;
 	}
 
 	$err = '';
@@ -567,7 +567,7 @@ function settings_post(App $a)
 	PConfig::set(local_user(), 'system', 'email_textonly', $email_textonly);
 	PConfig::set(local_user(), 'system', 'detailed_notif', $detailed_notif);
 
-	if ($page_flags == Contact::PAGE_PRVGROUP) {
+	if ($page_flags == User::PAGE_FLAGS_PRVGROUP) {
 		$hidewall = 1;
 		if (!$str_contact_allow && !$str_group_allow && !$str_contact_deny && !$str_group_deny) {
 			if ($def_gid) {
@@ -1026,7 +1026,7 @@ function settings_content(App $a)
 
 	// Set the account type to "Community" when the page is a community page but the account type doesn't fit
 	// This is only happening on the first visit after the update
-	if (in_array($a->user['page-flags'], [Contact::PAGE_COMMUNITY, Contact::PAGE_PRVGROUP]) &&
+	if (in_array($a->user['page-flags'], [User::PAGE_FLAGS_COMMUNITY, User::PAGE_FLAGS_PRVGROUP]) &&
 		($a->user['account-type'] != Contact::ACCOUNT_TYPE_COMMUNITY))
 		$a->user['account-type'] = Contact::ACCOUNT_TYPE_COMMUNITY;
 
@@ -1058,25 +1058,25 @@ function settings_content(App $a)
 									L10n::t('Account for community discussions.'),
 									($a->user['account-type'] == Contact::ACCOUNT_TYPE_COMMUNITY)],
 
-		'$page_normal'		=> ['page-flags', L10n::t('Normal Account Page'), Contact::PAGE_NORMAL,
+		'$page_normal'		=> ['page-flags', L10n::t('Normal Account Page'), User::PAGE_FLAGS_NORMAL,
 									L10n::t('Account for a regular personal profile that requires manual approval of "Friends" and "Followers".'),
-									($a->user['page-flags'] == Contact::PAGE_NORMAL)],
+									($a->user['page-flags'] == User::PAGE_FLAGS_NORMAL)],
 
-		'$page_soapbox' 	=> ['page-flags', L10n::t('Soapbox Page'), Contact::PAGE_SOAPBOX,
+		'$page_soapbox' 	=> ['page-flags', L10n::t('Soapbox Page'), User::PAGE_FLAGS_SOAPBOX,
 									L10n::t('Account for a public profile that automatically approves contact requests as "Followers".'),
-									($a->user['page-flags'] == Contact::PAGE_SOAPBOX)],
+									($a->user['page-flags'] == User::PAGE_FLAGS_SOAPBOX)],
 
-		'$page_community'	=> ['page-flags', L10n::t('Public Forum'), Contact::PAGE_COMMUNITY,
+		'$page_community'	=> ['page-flags', L10n::t('Public Forum'), User::PAGE_FLAGS_COMMUNITY,
 									L10n::t('Automatically approves all contact requests.'),
-									($a->user['page-flags'] == Contact::PAGE_COMMUNITY)],
+									($a->user['page-flags'] == User::PAGE_FLAGS_COMMUNITY)],
 
-		'$page_freelove' 	=> ['page-flags', L10n::t('Automatic Friend Page'), Contact::PAGE_FREELOVE,
+		'$page_freelove' 	=> ['page-flags', L10n::t('Automatic Friend Page'), User::PAGE_FLAGS_FREELOVE,
 									L10n::t('Account for a popular profile that automatically approves contact requests as "Friends".'),
-									($a->user['page-flags'] == Contact::PAGE_FREELOVE)],
+									($a->user['page-flags'] == User::PAGE_FLAGS_FREELOVE)],
 
-		'$page_prvgroup' 	=> ['page-flags', L10n::t('Private Forum [Experimental]'), Contact::PAGE_PRVGROUP,
+		'$page_prvgroup' 	=> ['page-flags', L10n::t('Private Forum [Experimental]'), User::PAGE_FLAGS_PRVGROUP,
 									L10n::t('Requires manual approval of contact requests.'),
-									($a->user['page-flags'] == Contact::PAGE_PRVGROUP)],
+									($a->user['page-flags'] == User::PAGE_FLAGS_PRVGROUP)],
 
 
 	]);

--- a/mod/settings.php
+++ b/mod/settings.php
@@ -486,13 +486,13 @@ function settings_post(App $a)
 	}
 
 	// Adjust the page flag if the account type doesn't fit to the page flag.
-	if (($account_type == Contact::ACCOUNT_TYPE_PERSON) && !in_array($page_flags, [User::PAGE_FLAGS_NORMAL, User::PAGE_FLAGS_SOAPBOX, User::PAGE_FLAGS_FREELOVE])) {
+	if (($account_type == User::ACCOUNT_TYPE_PERSON) && !in_array($page_flags, [User::PAGE_FLAGS_NORMAL, User::PAGE_FLAGS_SOAPBOX, User::PAGE_FLAGS_FREELOVE])) {
 		$page_flags = User::PAGE_FLAGS_NORMAL;
-	} elseif (($account_type == Contact::ACCOUNT_TYPE_ORGANISATION) && !in_array($page_flags, [User::PAGE_FLAGS_SOAPBOX])) {
+	} elseif (($account_type == User::ACCOUNT_TYPE_ORGANISATION) && !in_array($page_flags, [User::PAGE_FLAGS_SOAPBOX])) {
 		$page_flags = User::PAGE_FLAGS_SOAPBOX;
-	} elseif (($account_type == Contact::ACCOUNT_TYPE_NEWS) && !in_array($page_flags, [User::PAGE_FLAGS_SOAPBOX])) {
+	} elseif (($account_type == User::ACCOUNT_TYPE_NEWS) && !in_array($page_flags, [User::PAGE_FLAGS_SOAPBOX])) {
 		$page_flags = User::PAGE_FLAGS_SOAPBOX;
-	} elseif (($account_type == Contact::ACCOUNT_TYPE_COMMUNITY) && !in_array($page_flags, [User::PAGE_FLAGS_COMMUNITY, User::PAGE_FLAGS_PRVGROUP])) {
+	} elseif (($account_type == User::ACCOUNT_TYPE_COMMUNITY) && !in_array($page_flags, [User::PAGE_FLAGS_COMMUNITY, User::PAGE_FLAGS_PRVGROUP])) {
 		$page_flags = User::PAGE_FLAGS_COMMUNITY;
 	}
 
@@ -1027,8 +1027,8 @@ function settings_content(App $a)
 	// Set the account type to "Community" when the page is a community page but the account type doesn't fit
 	// This is only happening on the first visit after the update
 	if (in_array($a->user['page-flags'], [User::PAGE_FLAGS_COMMUNITY, User::PAGE_FLAGS_PRVGROUP]) &&
-		($a->user['account-type'] != Contact::ACCOUNT_TYPE_COMMUNITY))
-		$a->user['account-type'] = Contact::ACCOUNT_TYPE_COMMUNITY;
+		($a->user['account-type'] != User::ACCOUNT_TYPE_COMMUNITY))
+		$a->user['account-type'] = User::ACCOUNT_TYPE_COMMUNITY;
 
 	$pageset_tpl = Renderer::getMarkupTemplate('settings/pagetypes.tpl');
 
@@ -1037,26 +1037,26 @@ function settings_content(App $a)
 		'$user' 		=> L10n::t("Personal Page Subtypes"),
 		'$community'		=> L10n::t("Community Forum Subtypes"),
 		'$account_type'		=> $a->user['account-type'],
-		'$type_person'		=> Contact::ACCOUNT_TYPE_PERSON,
-		'$type_organisation' 	=> Contact::ACCOUNT_TYPE_ORGANISATION,
-		'$type_news'		=> Contact::ACCOUNT_TYPE_NEWS,
-		'$type_community' 	=> Contact::ACCOUNT_TYPE_COMMUNITY,
+		'$type_person'		=> User::ACCOUNT_TYPE_PERSON,
+		'$type_organisation' 	=> User::ACCOUNT_TYPE_ORGANISATION,
+		'$type_news'		=> User::ACCOUNT_TYPE_NEWS,
+		'$type_community' 	=> User::ACCOUNT_TYPE_COMMUNITY,
 
-		'$account_person' 	=> ['account-type', L10n::t('Personal Page'), Contact::ACCOUNT_TYPE_PERSON,
+		'$account_person' 	=> ['account-type', L10n::t('Personal Page'), User::ACCOUNT_TYPE_PERSON,
 									L10n::t('Account for a personal profile.'),
-									($a->user['account-type'] == Contact::ACCOUNT_TYPE_PERSON)],
+									($a->user['account-type'] == User::ACCOUNT_TYPE_PERSON)],
 
-		'$account_organisation'	=> ['account-type', L10n::t('Organisation Page'), Contact::ACCOUNT_TYPE_ORGANISATION,
+		'$account_organisation'	=> ['account-type', L10n::t('Organisation Page'), User::ACCOUNT_TYPE_ORGANISATION,
 									L10n::t('Account for an organisation that automatically approves contact requests as "Followers".'),
-									($a->user['account-type'] == Contact::ACCOUNT_TYPE_ORGANISATION)],
+									($a->user['account-type'] == User::ACCOUNT_TYPE_ORGANISATION)],
 
-		'$account_news'		=> ['account-type', L10n::t('News Page'), Contact::ACCOUNT_TYPE_NEWS,
+		'$account_news'		=> ['account-type', L10n::t('News Page'), User::ACCOUNT_TYPE_NEWS,
 									L10n::t('Account for a news reflector that automatically approves contact requests as "Followers".'),
-									($a->user['account-type'] == Contact::ACCOUNT_TYPE_NEWS)],
+									($a->user['account-type'] == User::ACCOUNT_TYPE_NEWS)],
 
-		'$account_community' 	=> ['account-type', L10n::t('Community Forum'), Contact::ACCOUNT_TYPE_COMMUNITY,
+		'$account_community' 	=> ['account-type', L10n::t('Community Forum'), User::ACCOUNT_TYPE_COMMUNITY,
 									L10n::t('Account for community discussions.'),
-									($a->user['account-type'] == Contact::ACCOUNT_TYPE_COMMUNITY)],
+									($a->user['account-type'] == User::ACCOUNT_TYPE_COMMUNITY)],
 
 		'$page_normal'		=> ['page-flags', L10n::t('Normal Account Page'), User::PAGE_FLAGS_NORMAL,
 									L10n::t('Account for a regular personal profile that requires manual approval of "Friends" and "Followers".'),

--- a/mod/videos.php
+++ b/mod/videos.php
@@ -16,6 +16,7 @@ use Friendica\Model\Contact;
 use Friendica\Model\Group;
 use Friendica\Model\Item;
 use Friendica\Model\Profile;
+use Friendica\Model\User;
 use Friendica\Protocol\DFRN;
 use Friendica\Util\Security;
 

--- a/mod/videos.php
+++ b/mod/videos.php
@@ -182,7 +182,7 @@ function videos_content(App $a)
 
 	$owner_uid = $a->data['user']['uid'];
 
-	$community_page = (($a->data['user']['page-flags'] == Contact::PAGE_COMMUNITY) ? true : false);
+	$community_page = (($a->data['user']['page-flags'] == User::PAGE_FLAGS_COMMUNITY) ? true : false);
 
 	if ((local_user()) && (local_user() == $owner_uid)) {
 		$can_post = true;

--- a/mod/wall_attach.php
+++ b/mod/wall_attach.php
@@ -41,7 +41,7 @@ function wall_attach_post(App $a) {
 
 	$page_owner_uid   = $r[0]['uid'];
 	$page_owner_cid   = $r[0]['id'];
-	$community_page   = (($r[0]['page-flags'] == Contact::PAGE_COMMUNITY) ? true : false);
+	$community_page   = (($r[0]['page-flags'] == User::PAGE_FLAGS_COMMUNITY) ? true : false);
 
 	if ((local_user()) && (local_user() == $page_owner_uid)) {
 		$can_post = true;

--- a/mod/wall_attach.php
+++ b/mod/wall_attach.php
@@ -8,7 +8,7 @@ use Friendica\Core\Config;
 use Friendica\Core\L10n;
 use Friendica\Database\DBA;
 use Friendica\Model\Attach;
-use Friendica\Model\Contact;
+use Friendica\Model\User;
 use Friendica\Util\Strings;
 
 function wall_attach_post(App $a) {

--- a/mod/wall_upload.php
+++ b/mod/wall_upload.php
@@ -69,7 +69,7 @@ function wall_upload_post(App $a, $desktopmode = true)
 	$page_owner_uid   = $r[0]['uid'];
 	$default_cid      = $r[0]['id'];
 	$page_owner_nick  = $r[0]['nickname'];
-	$community_page   = (($r[0]['page-flags'] == Contact::PAGE_COMMUNITY) ? true : false);
+	$community_page   = (($r[0]['page-flags'] == User::PAGE_FLAGS_COMMUNITY) ? true : false);
 
 	if ((local_user()) && (local_user() == $page_owner_uid)) {
 		$can_post = true;

--- a/mod/wall_upload.php
+++ b/mod/wall_upload.php
@@ -16,6 +16,7 @@ use Friendica\Core\Config;
 use Friendica\Database\DBA;
 use Friendica\Model\Contact;
 use Friendica\Model\Photo;
+use Friendica\Model\User;
 use Friendica\Object\Image;
 use Friendica\Util\Strings;
 

--- a/src/Content/Nav.php
+++ b/src/Content/Nav.php
@@ -245,7 +245,7 @@ class Nav
 			$nav['home'] = ['profile/' . $a->user['nickname'], L10n::t('Home'), '', L10n::t('Your posts and conversations')];
 
 			// Don't show notifications for public communities
-			if (defaults($_SESSION, 'page_flags', '') != Contact::PAGE_COMMUNITY) {
+			if (defaults($_SESSION, 'page_flags', '') != User::PAGE_FLAGS_COMMUNITY) {
 				$nav['introductions'] = ['notifications/intros', L10n::t('Introductions'), '', L10n::t('Friend Requests')];
 				$nav['notifications'] = ['notifications',	L10n::t('Notifications'), '', L10n::t('Notifications')];
 				$nav['notifications']['all'] = ['notifications/system', L10n::t('See all notifications'), '', ''];

--- a/src/Content/Text/HTML.php
+++ b/src/Content/Text/HTML.php
@@ -7,6 +7,7 @@ namespace Friendica\Content\Text;
 
 use DOMDocument;
 use DOMXPath;
+use Friendica\Content\Widget\ContactBlock;
 use Friendica\Core\Hook;
 use Friendica\Core\L10n;
 use Friendica\Core\Config;
@@ -805,94 +806,21 @@ class HTML
 	/**
 	 * Get html for contact block.
 	 *
-	 * @template contact_block.tpl
-	 * @hook     contact_block_end (contacts=>array, output=>string)
+	 * @deprecated since version 2019.03
+	 * @see ContactBlock::getHTML()
 	 * @return string
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 * @throws \ImagickException
 	 */
 	public static function contactBlock()
 	{
-		$o = '';
 		$a = get_app();
 
-		$shown = PConfig::get($a->profile['uid'], 'system', 'display_friend_count', 24);
-		if ($shown == 0) {
-			return;
-		}
-
-		if (!is_array($a->profile) || $a->profile['hide-friends']) {
-			return $o;
-		}
-
-		$r = q("SELECT COUNT(*) AS `total` FROM `contact`
-				WHERE `uid` = %d AND NOT `self` AND NOT `blocked`
-					AND NOT `pending` AND NOT `hidden` AND NOT `archive`
-					AND `network` IN ('%s', '%s', '%s')",
-			intval($a->profile['uid']),
-			DBA::escape(Protocol::DFRN),
-			DBA::escape(Protocol::OSTATUS),
-			DBA::escape(Protocol::DIASPORA)
-		);
-
-		if (DBA::isResult($r)) {
-			$total = intval($r[0]['total']);
-		}
-
-		if (!$total) {
-			$contacts = L10n::t('No contacts');
-			$micropro = null;
-		} else {
-			// Splitting the query in two parts makes it much faster
-			$r = q("SELECT `id` FROM `contact`
-					WHERE `uid` = %d AND NOT `self` AND NOT `blocked`
-						AND NOT `pending` AND NOT `hidden` AND NOT `archive`
-						AND `network` IN ('%s', '%s', '%s')
-					ORDER BY RAND() LIMIT %d",
-				intval($a->profile['uid']),
-				DBA::escape(Protocol::DFRN),
-				DBA::escape(Protocol::OSTATUS),
-				DBA::escape(Protocol::DIASPORA),
-				intval($shown)
-			);
-
-			if (DBA::isResult($r)) {
-				$contacts = [];
-				foreach ($r as $contact) {
-					$contacts[] = $contact["id"];
-				}
-
-				$r = q("SELECT `id`, `uid`, `addr`, `url`, `name`, `thumb`, `network` FROM `contact` WHERE `id` IN (%s)",
-					DBA::escape(implode(",", $contacts))
-				);
-
-				if (DBA::isResult($r)) {
-					$contacts = L10n::tt('%d Contact', '%d Contacts', $total);
-					$micropro = [];
-					foreach ($r as $rr) {
-						$micropro[] = self::micropro($rr, true, 'mpfriend');
-					}
-				}
-			}
-		}
-
-		$tpl = Renderer::getMarkupTemplate('contact_block.tpl');
-		$o = Renderer::replaceMacros($tpl, [
-			'$contacts' => $contacts,
-			'$nickname' => $a->profile['nickname'],
-			'$viewcontacts' => L10n::t('View Contacts'),
-			'$micropro' => $micropro,
-		]);
-
-		$arr = ['contacts' => $r, 'output' => $o];
-
-		Hook::callAll('contact_block_end', $arr);
-
-		return $o;
+		return ContactBlock::getHTML($a->profile);
 	}
 
 	/**
-	 * @brief Format contacts as picture links or as texxt links
+	 * @brief Format contacts as picture links or as text links
 	 *
 	 * @param array   $contact  Array with contacts which contains an array with
 	 *                          int 'id' => The ID of the contact

--- a/src/Content/Widget/ContactBlock.php
+++ b/src/Content/Widget/ContactBlock.php
@@ -14,6 +14,7 @@ use Friendica\Core\Protocol;
 use Friendica\Core\Renderer;
 use Friendica\Database\DBA;
 use Friendica\Model\Contact;
+use Friendica\Model\User;
 
 /**
  * ContactBlock widget
@@ -59,6 +60,13 @@ class ContactBlock
 		if (!$total) {
 			$micropro = [];
 		} else {
+			// Only show followed for personal accounts, followers for pages
+			if (defaults($profile, 'account-type', User::ACCOUNT_TYPE_PERSON) == User::ACCOUNT_TYPE_PERSON) {
+				$rel = [Contact::FOLLOWER, Contact::FRIEND];
+			} else {
+				$rel = [Contact::SHARING, Contact::FRIEND];
+			}
+
 			$contact_ids_stmt = DBA::select('contact', ['id'], [
 				'uid' => $profile['uid'],
 				'self' => false,
@@ -66,7 +74,7 @@ class ContactBlock
 				'pending' => false,
 				'hidden' => false,
 				'archive' => false,
-				'rel' => [Contact::FOLLOWER, Contact::FRIEND],
+				'rel' => $rel,
 				'network' => [Protocol::DFRN, Protocol::ACTIVITYPUB, Protocol::OSTATUS, Protocol::DIASPORA],
 			], ['limit' => $shown]);
 

--- a/src/Content/Widget/ContactBlock.php
+++ b/src/Content/Widget/ContactBlock.php
@@ -1,0 +1,111 @@
+<?php
+
+/*
+ * @file src/Content/Widget/ContactBlock.php
+ */
+
+namespace Friendica\Content\Widget;
+
+use Friendica\Content\Text\HTML;
+use Friendica\Core\Hook;
+use Friendica\Core\L10n;
+use Friendica\Core\PConfig;
+use Friendica\Core\Protocol;
+use Friendica\Core\Renderer;
+use Friendica\Database\DBA;
+use Friendica\Model\Contact;
+
+/**
+ * ContactBlock widget
+ *
+ * @author Hypolite Petovan
+ */
+class ContactBlock
+{
+	/**
+	 * Get HTML for contact block
+	 *
+	 * @template contact_block.tpl
+	 * @hook contact_block_end (contacts=>array, output=>string)
+	 * @return string
+	 */
+	public static function getHTML(array $profile)
+	{
+		$o = '';
+
+		$shown = PConfig::get($profile['uid'], 'system', 'display_friend_count', 24);
+		if ($shown == 0) {
+			return $o;
+		}
+
+		if (!empty($profile['hide-friends'])) {
+			return $o;
+		}
+
+		$contacts = [];
+
+		$total = DBA::count('contact', [
+			'uid' => $profile['uid'],
+			'self' => false,
+			'blocked' => false,
+			'pending' => false,
+			'hidden' => false,
+			'archive' => false,
+			'network' => [Protocol::DFRN, Protocol::ACTIVITYPUB, Protocol::OSTATUS, Protocol::DIASPORA],
+		]);
+
+		$contacts_title = L10n::t('No contacts');
+
+		if (!$total) {
+			$micropro = [];
+		} else {
+			$contact_ids_stmt = DBA::select('contact', ['id'], [
+				'uid' => $profile['uid'],
+				'self' => false,
+				'blocked' => false,
+				'pending' => false,
+				'hidden' => false,
+				'archive' => false,
+				'rel' => [Contact::FOLLOWER, Contact::FRIEND],
+				'network' => [Protocol::DFRN, Protocol::ACTIVITYPUB, Protocol::OSTATUS, Protocol::DIASPORA],
+			], ['limit' => $shown]);
+
+			if (DBA::isResult($contact_ids_stmt)) {
+				$contact_ids = [];
+				while($contact = DBA::fetch($contact_ids_stmt)) {
+					$contact_ids[] = $contact["id"];
+				}
+
+				$contacts_stmt = DBA::select('contact', ['id', 'uid', 'addr', 'url', 'name', 'thumb', 'network'], ['id' => $contact_ids]);
+
+				if (DBA::isResult($contacts_stmt)) {
+					$contacts_title = L10n::tt('%d Contact', '%d Contacts', $total);
+					$micropro = [];
+
+					while ($contact = DBA::fetch($contacts_stmt)) {
+						$contacts[] = $contact;
+						$micropro[] = HTML::micropro($contact, true, 'mpfriend');
+					}
+				}
+
+				DBA::close($contacts_stmt);
+			}
+
+			DBA::close($contact_ids_stmt);
+		}
+
+		$tpl = Renderer::getMarkupTemplate('contact_block.tpl');
+		$o = Renderer::replaceMacros($tpl, [
+			'$contacts' => $contacts_title,
+			'$nickname' => $profile['nickname'],
+			'$viewcontacts' => L10n::t('View Contacts'),
+			'$micropro' => $micropro,
+		]);
+
+		$arr = ['contacts' => $contacts, 'output' => $o];
+
+		Hook::callAll('contact_block_end', $arr);
+
+		return $o;
+	}
+}

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -36,15 +36,8 @@ require_once 'include/text.php';
 class Contact extends BaseObject
 {
 	/**
-	 * Page/profile types
-	 *
-	 * PAGE_NORMAL is a typical personal profile account
-	 * PAGE_SOAPBOX automatically approves all friend requests as Contact::SHARING, (readonly)
-	 * PAGE_COMMUNITY automatically approves all friend requests as Contact::SHARING, but with
-	 *      write access to wall and comments (no email and not included in page owner's ACL lists)
-	 * PAGE_FREELOVE automatically approves all friend requests as full friends (Contact::FRIEND).
-	 *
-	 * @{
+	 * @deprecated since version 2019.03
+	 * @see User::PAGE_FLAGS_NORMAL
 	 */
 	const PAGE_NORMAL    = 0;
 	const PAGE_SOAPBOX   = 1;
@@ -52,6 +45,32 @@ class Contact extends BaseObject
 	const PAGE_FREELOVE  = 3;
 	const PAGE_BLOG      = 4;
 	const PAGE_PRVGROUP  = 5;
+	const PAGE_NORMAL    = User::PAGE_FLAGS_NORMAL;
+	/**
+	 * @deprecated since version 2019.03
+	 * @see User::PAGE_FLAGS_SOAPBOX
+	 */
+	const PAGE_SOAPBOX   = User::PAGE_FLAGS_SOAPBOX;
+	/**
+	 * @deprecated since version 2019.03
+	 * @see User::PAGE_FLAGS_COMMUNITY
+	 */
+	const PAGE_COMMUNITY = User::PAGE_FLAGS_COMMUNITY;
+	/**
+	 * @deprecated since version 2019.03
+	 * @see User::PAGE_FLAGS_FREELOVE
+	 */
+	const PAGE_FREELOVE  = User::PAGE_FLAGS_FREELOVE;
+	/**
+	 * @deprecated since version 2019.03
+	 * @see User::PAGE_FLAGS_BLOG
+	 */
+	const PAGE_BLOG      = User::PAGE_FLAGS_BLOG;
+	/**
+	 * @deprecated since version 2019.03
+	 * @see User::PAGE_FLAGS_PRVGROUP
+	 */
+	const PAGE_PRVGROUP  = User::PAGE_FLAGS_PRVGROUP;
 	/**
 	 * @}
 	 */
@@ -531,8 +550,8 @@ class Contact extends BaseObject
 			$fields['micro'] = System::baseUrl() . '/images/person-48.jpg';
 		}
 
-		$fields['forum'] = $user['page-flags'] == self::PAGE_COMMUNITY;
-		$fields['prv'] = $user['page-flags'] == self::PAGE_PRVGROUP;
+		$fields['forum'] = $user['page-flags'] == User::PAGE_FLAGS_COMMUNITY;
+		$fields['prv'] = $user['page-flags'] == User::PAGE_FLAGS_PRVGROUP;
 
 		// it seems as if ported accounts can have wrong values, so we make sure that now everything is fine.
 		$fields['url'] = System::baseUrl() . '/profile/' . $user['nickname'];
@@ -1462,10 +1481,10 @@ class Contact extends BaseObject
 	{
 		// There are several fields that indicate that the contact or user is a forum
 		// "page-flags" is a field in the user table,
-		// "forum" and "prv" are used in the contact table. They stand for self::PAGE_COMMUNITY and self::PAGE_PRVGROUP.
-		// "community" is used in the gcontact table and is true if the contact is self::PAGE_COMMUNITY or self::PAGE_PRVGROUP.
-		if ((isset($contact['page-flags']) && (intval($contact['page-flags']) == self::PAGE_COMMUNITY))
-			|| (isset($contact['page-flags']) && (intval($contact['page-flags']) == self::PAGE_PRVGROUP))
+		// "forum" and "prv" are used in the contact table. They stand for User::PAGE_FLAGS_COMMUNITY and User::PAGE_FLAGS_PRVGROUP.
+		// "community" is used in the gcontact table and is true if the contact is User::PAGE_FLAGS_COMMUNITY or User::PAGE_FLAGS_PRVGROUP.
+		if ((isset($contact['page-flags']) && (intval($contact['page-flags']) == User::PAGE_FLAGS_COMMUNITY))
+			|| (isset($contact['page-flags']) && (intval($contact['page-flags']) == User::PAGE_FLAGS_PRVGROUP))
 			|| (isset($contact['forum']) && intval($contact['forum']))
 			|| (isset($contact['prv']) && intval($contact['prv']))
 			|| (isset($contact['community']) && intval($contact['community']))
@@ -1972,7 +1991,7 @@ class Contact extends BaseObject
 			/// @TODO Encapsulate this into a function/method
 			$fields = ['uid', 'username', 'email', 'page-flags', 'notify-flags', 'language'];
 			$user = DBA::selectFirst('user', $fields, ['uid' => $importer['uid']]);
-			if (DBA::isResult($user) && !in_array($user['page-flags'], [self::PAGE_SOAPBOX, self::PAGE_FREELOVE, self::PAGE_COMMUNITY])) {
+			if (DBA::isResult($user) && !in_array($user['page-flags'], [User::PAGE_FLAGS_SOAPBOX, User::PAGE_FLAGS_FREELOVE, User::PAGE_FLAGS_COMMUNITY])) {
 				// create notification
 				$hash = Strings::getRandomHex();
 
@@ -1985,7 +2004,7 @@ class Contact extends BaseObject
 				Group::addMember(User::getDefaultGroup($importer['uid'], $contact_record["network"]), $contact_record['id']);
 
 				if (($user['notify-flags'] & NOTIFY_INTRO) &&
-					in_array($user['page-flags'], [self::PAGE_NORMAL])) {
+					in_array($user['page-flags'], [User::PAGE_FLAGS_NORMAL])) {
 
 					notification([
 						'type'         => NOTIFY_INTRO,
@@ -2003,7 +2022,7 @@ class Contact extends BaseObject
 					]);
 
 				}
-			} elseif (DBA::isResult($user) && in_array($user['page-flags'], [self::PAGE_SOAPBOX, self::PAGE_FREELOVE, self::PAGE_COMMUNITY])) {
+			} elseif (DBA::isResult($user) && in_array($user['page-flags'], [User::PAGE_FLAGS_SOAPBOX, User::PAGE_FLAGS_FREELOVE, User::PAGE_FLAGS_COMMUNITY])) {
 				$condition = ['uid' => $importer['uid'], 'url' => $url, 'pending' => true];
 				DBA::update('contact', ['pending' => false], $condition);
 

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -78,27 +78,30 @@ class Contact extends BaseObject
 	/**
 	 * @name account types
 	 *
-	 * ACCOUNT_TYPE_PERSON - the account belongs to a person
+	 * TYPE_UNKNOWN - the account has been imported from gcontact where this is the default type value
+	 *
+	 * TYPE_PERSON - the account belongs to a person
 	 *	Associated page types: PAGE_NORMAL, PAGE_SOAPBOX, PAGE_FREELOVE
 	 *
-	 * ACCOUNT_TYPE_ORGANISATION - the account belongs to an organisation
+	 * TYPE_ORGANISATION - the account belongs to an organisation
 	 *	Associated page type: PAGE_SOAPBOX
 	 *
-	 * ACCOUNT_TYPE_NEWS - the account is a news reflector
+	 * TYPE_NEWS - the account is a news reflector
 	 *	Associated page type: PAGE_SOAPBOX
 	 *
-	 * ACCOUNT_TYPE_COMMUNITY - the account is community forum
+	 * TYPE_COMMUNITY - the account is community forum
 	 *	Associated page types: PAGE_COMMUNITY, PAGE_PRVGROUP
 	 *
-	 * ACCOUNT_TYPE_RELAY - the account is a relay
+	 * TYPE_RELAY - the account is a relay
 	 *      This will only be assigned to contacts, not to user accounts
 	 * @{
 	 */
-	const ACCOUNT_TYPE_PERSON =       0;
-	const ACCOUNT_TYPE_ORGANISATION = 1;
-	const ACCOUNT_TYPE_NEWS =         2;
-	const ACCOUNT_TYPE_COMMUNITY =    3;
-	const ACCOUNT_TYPE_RELAY =        4;
+	const TYPE_UNKNOWN =     -1;
+	const TYPE_PERSON =       User::ACCOUNT_TYPE_PERSON;
+	const TYPE_ORGANISATION = User::ACCOUNT_TYPE_ORGANISATION;
+	const TYPE_NEWS =         User::ACCOUNT_TYPE_NEWS;
+	const TYPE_COMMUNITY =    User::ACCOUNT_TYPE_COMMUNITY;
+	const TYPE_RELAY =        User::ACCOUNT_TYPE_RELAY;
 	/**
 	 * @}
 	 */
@@ -735,7 +738,7 @@ class Contact extends BaseObject
 		DBA::update('contact', $fields, ['nurl' => Strings::normaliseLink($contact['url'])]);
 
 		if (!empty($contact['batch'])) {
-			$condition = ['batch' => $contact['batch'], 'contact-type' => self::ACCOUNT_TYPE_RELAY];
+			$condition = ['batch' => $contact['batch'], 'contact-type' => self::TYPE_RELAY];
 			DBA::update('contact', $fields, $condition);
 		}
 	}
@@ -1433,7 +1436,7 @@ class Contact extends BaseObject
 			$sql = "`item`.`uid` = ?";
 		}
 
-		$contact_field = ($contact["contact-type"] == self::ACCOUNT_TYPE_COMMUNITY ? 'owner-id' : 'author-id');
+		$contact_field = ($contact["contact-type"] == self::TYPE_COMMUNITY ? 'owner-id' : 'author-id');
 
 		if ($thread_mode) {
 			$condition = ["`$contact_field` = ? AND `gravity` = ? AND " . $sql,
@@ -1489,9 +1492,9 @@ class Contact extends BaseObject
 			|| (isset($contact['prv']) && intval($contact['prv']))
 			|| (isset($contact['community']) && intval($contact['community']))
 		) {
-			$type = self::ACCOUNT_TYPE_COMMUNITY;
+			$type = self::TYPE_COMMUNITY;
 		} else {
-			$type = self::ACCOUNT_TYPE_PERSON;
+			$type = self::TYPE_PERSON;
 		}
 
 		// The "contact-type" (contact table) and "account-type" (user table) are more general then the chaos from above.
@@ -1504,15 +1507,15 @@ class Contact extends BaseObject
 		}
 
 		switch ($type) {
-			case self::ACCOUNT_TYPE_ORGANISATION:
+			case self::TYPE_ORGANISATION:
 				$account_type = L10n::t("Organisation");
 				break;
 
-			case self::ACCOUNT_TYPE_NEWS:
+			case self::TYPE_NEWS:
 				$account_type = L10n::t('News');
 				break;
 
-			case self::ACCOUNT_TYPE_COMMUNITY:
+			case self::TYPE_COMMUNITY:
 				$account_type = L10n::t("Forum");
 				break;
 

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -39,12 +39,6 @@ class Contact extends BaseObject
 	 * @deprecated since version 2019.03
 	 * @see User::PAGE_FLAGS_NORMAL
 	 */
-	const PAGE_NORMAL    = 0;
-	const PAGE_SOAPBOX   = 1;
-	const PAGE_COMMUNITY = 2;
-	const PAGE_FREELOVE  = 3;
-	const PAGE_BLOG      = 4;
-	const PAGE_PRVGROUP  = 5;
 	const PAGE_NORMAL    = User::PAGE_FLAGS_NORMAL;
 	/**
 	 * @deprecated since version 2019.03
@@ -76,7 +70,7 @@ class Contact extends BaseObject
 	 */
 
 	/**
-	 * @name account types
+	 * Account types
 	 *
 	 * TYPE_UNKNOWN - the account has been imported from gcontact where this is the default type value
 	 *

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -2530,8 +2530,8 @@ class Item extends BaseObject
 			return;
 		}
 
-		$community_page = (($user['page-flags'] == Contact::PAGE_COMMUNITY) ? true : false);
-		$prvgroup = (($user['page-flags'] == Contact::PAGE_PRVGROUP) ? true : false);
+		$community_page = (($user['page-flags'] == User::PAGE_FLAGS_COMMUNITY) ? true : false);
+		$prvgroup = (($user['page-flags'] == User::PAGE_FLAGS_PRVGROUP) ? true : false);
 
 		$item = self::selectFirst(self::ITEM_FIELDLIST, ['id' => $item_id]);
 		if (!DBA::isResult($item)) {

--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -9,6 +9,7 @@ use Friendica\Content\Feature;
 use Friendica\Content\ForumManager;
 use Friendica\Content\Text\BBCode;
 use Friendica\Content\Text\HTML;
+use Friendica\Content\Widget\ContactBlock;
 use Friendica\Core\Cache;
 use Friendica\Core\Config;
 use Friendica\Core\Hook;
@@ -472,9 +473,9 @@ class Profile
 
 		$contact_block = '';
 		$updated = '';
-		$contacts = 0;
+		$contact_count = 0;
 		if (!$block) {
-			$contact_block = HTML::contactBlock();
+			$contact_block = ContactBlock::getHTML($a->profile);
 
 			if (is_array($a->profile) && !$a->profile['hide-friends']) {
 				$r = q(
@@ -485,20 +486,15 @@ class Profile
 					$updated = date('c', strtotime($r[0]['updated']));
 				}
 
-				$r = q(
-					"SELECT COUNT(*) AS `total` FROM `contact`
-					WHERE `uid` = %d
-						AND NOT `self` AND NOT `blocked` AND NOT `pending`
-						AND NOT `hidden` AND NOT `archive`
-						AND `network` IN ('%s', '%s', '%s', '')",
-					intval($profile['uid']),
-					DBA::escape(Protocol::DFRN),
-					DBA::escape(Protocol::DIASPORA),
-					DBA::escape(Protocol::OSTATUS)
-				);
-				if (DBA::isResult($r)) {
-					$contacts = intval($r[0]['total']);
-				}
+				$contact_count = DBA::count('contact', [
+					'uid' => $profile['uid'],
+					'self' => false,
+					'blocked' => false,
+					'pending' => false,
+					'hidden' => false,
+					'archive' => false,
+					'network' => [Protocol::DFRN, Protocol::ACTIVITYPUB, Protocol::OSTATUS, Protocol::DIASPORA],
+				]);
 			}
 		}
 
@@ -540,7 +536,7 @@ class Profile
 			'$homepage' => $homepage,
 			'$about' => $about,
 			'$network' => L10n::t('Network:'),
-			'$contacts' => $contacts,
+			'$contacts' => $contact_count,
 			'$updated' => $updated,
 			'$diaspora' => $diaspora,
 			'$contact_block' => $contact_block,

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -33,6 +33,26 @@ require_once 'include/text.php';
 class User
 {
 	/**
+	 * @name page/profile types
+	 *
+	 * PAGE_NORMAL is a typical personal profile account
+	 * PAGE_SOAPBOX automatically approves all friend requests as Contact::SHARING, (readonly)
+	 * PAGE_COMMUNITY automatically approves all friend requests as Contact::SHARING, but with
+	 *      write access to wall and comments (no email and not included in page owner's ACL lists)
+	 * PAGE_FREELOVE automatically approves all friend requests as full friends (Contact::FRIEND).
+	 *
+	 * @{
+	 */
+	const PAGE_FLAGS_NORMAL    = 0;
+	const PAGE_FLAGS_SOAPBOX   = 1;
+	const PAGE_FLAGS_COMMUNITY = 2;
+	const PAGE_FLAGS_FREELOVE  = 3;
+	const PAGE_FLAGS_BLOG      = 4;
+	const PAGE_FLAGS_PRVGROUP  = 5;
+	/**
+	 * @}
+	 */
+	/**
 	 * Returns true if a user record exists with the provided id
 	 *
 	 * @param  integer $uid

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -52,6 +52,35 @@ class User
 	/**
 	 * @}
 	 */
+
+	/**
+	 * Account types
+	 *
+	 * ACCOUNT_TYPE_PERSON - the account belongs to a person
+	 *	Associated page types: PAGE_FLAGS_NORMAL, PAGE_FLAGS_SOAPBOX, PAGE_FLAGS_FREELOVE
+	 *
+	 * ACCOUNT_TYPE_ORGANISATION - the account belongs to an organisation
+	 *	Associated page type: PAGE_FLAGS_SOAPBOX
+	 *
+	 * ACCOUNT_TYPE_NEWS - the account is a news reflector
+	 *	Associated page type: PAGE_FLAGS_SOAPBOX
+	 *
+	 * ACCOUNT_TYPE_COMMUNITY - the account is community forum
+	 *	Associated page types: PAGE_COMMUNITY, PAGE_FLAGS_PRVGROUP
+	 *
+	 * ACCOUNT_TYPE_RELAY - the account is a relay
+	 *      This will only be assigned to contacts, not to user accounts
+	 * @{
+	 */
+	const ACCOUNT_TYPE_PERSON =       0;
+	const ACCOUNT_TYPE_ORGANISATION = 1;
+	const ACCOUNT_TYPE_NEWS =         2;
+	const ACCOUNT_TYPE_COMMUNITY =    3;
+	const ACCOUNT_TYPE_RELAY =        4;
+	/**
+	 * @}
+	 */
+
 	/**
 	 * Returns true if a user record exists with the provided id
 	 *

--- a/src/Network/Probe.php
+++ b/src/Network/Probe.php
@@ -419,7 +419,7 @@ class Probe
 				// This doesn't cover the case when a community isn't a community anymore
 				if (!empty($data['community']) && $data['community']) {
 					$fields['community'] = $data['community'];
-					$fields['contact-type'] = Contact::ACCOUNT_TYPE_COMMUNITY;
+					$fields['contact-type'] = Contact::TYPE_COMMUNITY;
 				}
 
 				$fieldnames = [];

--- a/src/Object/Image.php
+++ b/src/Object/Image.php
@@ -899,7 +899,7 @@ class Image
 
 		/// @TODO
 		/// $default_cid      = $r[0]['id'];
-		/// $community_page   = (($r[0]['page-flags'] == Contact::PAGE_COMMUNITY) ? true : false);
+		/// $community_page   = (($r[0]['page-flags'] == User::PAGE_FLAGS_COMMUNITY) ? true : false);
 
 		if ((strlen($imagedata) == 0) && ($url == "")) {
 			Logger::log("No image data and no url provided", Logger::DEBUG);

--- a/src/Protocol/ActivityPub/Receiver.php
+++ b/src/Protocol/ActivityPub/Receiver.php
@@ -499,13 +499,13 @@ class Receiver
 
 				// Check if the potential receiver is following the actor
 				// Exception: The receiver is targetted via "to" or this is a comment
-				if ((($element != 'as:to') && empty($replyto)) || ($contact['contact-type'] == Contact::ACCOUNT_TYPE_COMMUNITY)) {
+				if ((($element != 'as:to') && empty($replyto)) || ($contact['contact-type'] == Contact::TYPE_COMMUNITY)) {
 					$networks = [Protocol::ACTIVITYPUB, Protocol::DFRN, Protocol::DIASPORA, Protocol::OSTATUS];
 					$condition = ['nurl' => Strings::normaliseLink($actor), 'rel' => [Contact::SHARING, Contact::FRIEND],
 						'network' => $networks, 'archive' => false, 'pending' => false, 'uid' => $contact['uid']];
 
 					// Forum posts are only accepted from forum contacts
-					if ($contact['contact-type'] == Contact::ACCOUNT_TYPE_COMMUNITY) {
+					if ($contact['contact-type'] == Contact::TYPE_COMMUNITY) {
 						$condition['rel'] = [Contact::SHARING, Contact::FRIEND, Contact::FOLLOWER];
 					}
 
@@ -572,7 +572,7 @@ class Receiver
 
 		// When the possible receiver isn't a community, then it is no valid receiver
 		$owner = User::getOwnerDataById($contact['uid']);
-		if (empty($owner) || ($owner['contact-type'] != Contact::ACCOUNT_TYPE_COMMUNITY)) {
+		if (empty($owner) || ($owner['contact-type'] != Contact::TYPE_COMMUNITY)) {
 			return false;
 		}
 

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -232,7 +232,7 @@ class Transmitter
 			'vcard:region' => $profile['region'], 'vcard:locality' => $profile['locality']];
 		$data['summary'] = $contact['about'];
 		$data['url'] = $contact['url'];
-		$data['manuallyApprovesFollowers'] = in_array($user['page-flags'], [Contact::PAGE_NORMAL, Contact::PAGE_PRVGROUP]);
+		$data['manuallyApprovesFollowers'] = in_array($user['page-flags'], [User::PAGE_FLAGS_NORMAL, User::PAGE_FLAGS_PRVGROUP]);
 		$data['publicKey'] = ['id' => $contact['url'] . '#main-key',
 			'owner' => $contact['url'],
 			'publicKeyPem' => $user['pubkey']];

--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -2878,7 +2878,7 @@ class DFRN
 				DBA::update('contact', ['contact-type' => $accounttype], ['id' => $importer["id"]]);
 			}
 			// A forum contact can either have set "forum" or "prv" - but not both
-			if (($accounttype == Contact::ACCOUNT_TYPE_COMMUNITY) && (($forum != $importer["forum"]) || ($forum == $importer["prv"]))) {
+			if (($accounttype == User::ACCOUNT_TYPE_COMMUNITY) && (($forum != $importer["forum"]) || ($forum == $importer["prv"]))) {
 				$condition = ['(`forum` != ? OR `prv` != ?) AND `id` = ?', $forum, !$forum, $importer["id"]];
 				DBA::update('contact', ['forum' => $forum, 'prv' => !$forum], $condition);
 			}

--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -593,14 +593,14 @@ class DFRN
 		}
 
 		// For backward compatibility we keep this element
-		if ($owner['page-flags'] == Contact::PAGE_COMMUNITY) {
+		if ($owner['page-flags'] == User::PAGE_FLAGS_COMMUNITY) {
 			XML::addElement($doc, $root, "dfrn:community", 1);
 		}
 
 		// The former element is replaced by this one
 		XML::addElement($doc, $root, "dfrn:account_type", $owner["account-type"]);
 
-		/// @todo We need a way to transmit the different page flags like "Contact::PAGE_PRVGROUP"
+		/// @todo We need a way to transmit the different page flags like "User::PAGE_FLAGS_PRVGROUP"
 
 		XML::addElement($doc, $root, "updated", DateTimeFormat::utcNow(DateTimeFormat::ATOM));
 
@@ -1270,11 +1270,11 @@ class DFRN
 		$perm         = (($res->perm) ? $res->perm : null);
 		$dfrn_version = (float) (($res->dfrn_version) ? $res->dfrn_version : 2.0);
 		$rino_remote_version = intval($res->rino);
-		$page         = (($owner['page-flags'] == Contact::PAGE_COMMUNITY) ? 1 : 0);
+		$page         = (($owner['page-flags'] == User::PAGE_FLAGS_COMMUNITY) ? 1 : 0);
 
 		Logger::log("Remote rino version: ".$rino_remote_version." for ".$contact["url"], Logger::DEBUG);
 
-		if ($owner['page-flags'] == Contact::PAGE_PRVGROUP) {
+		if ($owner['page-flags'] == User::PAGE_FLAGS_PRVGROUP) {
 			$page = 2;
 		}
 
@@ -1291,7 +1291,7 @@ class DFRN
 		}
 
 		if (($contact['duplex'] && strlen($contact['pubkey']))
-			|| ($owner['page-flags'] == Contact::PAGE_COMMUNITY && strlen($contact['pubkey']))
+			|| ($owner['page-flags'] == User::PAGE_FLAGS_COMMUNITY && strlen($contact['pubkey']))
 			|| ($contact['rel'] == Contact::SHARING && strlen($contact['pubkey']))
 		) {
 			openssl_public_decrypt($sent_dfrn_id, $final_dfrn_id, $contact['pubkey']);
@@ -1320,7 +1320,7 @@ class DFRN
 			$postvars['dissolve'] = '1';
 		}
 
-		if ((($contact['rel']) && ($contact['rel'] != Contact::SHARING) && (! $contact['blocked'])) || ($owner['page-flags'] == Contact::PAGE_COMMUNITY)) {
+		if ((($contact['rel']) && ($contact['rel'] != Contact::SHARING) && (! $contact['blocked'])) || ($owner['page-flags'] == User::PAGE_FLAGS_COMMUNITY)) {
 			$postvars['data'] = $atom;
 			$postvars['perm'] = 'rw';
 		} else {
@@ -1355,7 +1355,7 @@ class DFRN
 
 			if ($dfrn_version >= 2.1) {
 				if (($contact['duplex'] && strlen($contact['pubkey']))
-					|| ($owner['page-flags'] == Contact::PAGE_COMMUNITY && strlen($contact['pubkey']))
+					|| ($owner['page-flags'] == User::PAGE_FLAGS_COMMUNITY && strlen($contact['pubkey']))
 					|| ($contact['rel'] == Contact::SHARING && strlen($contact['pubkey']))
 				) {
 					openssl_public_encrypt($key, $postvars['key'], $contact['pubkey']);
@@ -1363,7 +1363,7 @@ class DFRN
 					openssl_private_encrypt($key, $postvars['key'], $contact['prvkey']);
 				}
 			} else {
-				if (($contact['duplex'] && strlen($contact['prvkey'])) || ($owner['page-flags'] == Contact::PAGE_COMMUNITY)) {
+				if (($contact['duplex'] && strlen($contact['prvkey'])) || ($owner['page-flags'] == User::PAGE_FLAGS_COMMUNITY)) {
 					openssl_private_encrypt($key, $postvars['key'], $contact['prvkey']);
 				} else {
 					openssl_public_encrypt($key, $postvars['key'], $contact['pubkey']);
@@ -2151,7 +2151,7 @@ class DFRN
 		if ($item["parent-uri"] != $item["uri"]) {
 			$community = false;
 
-			if ($importer["page-flags"] == Contact::PAGE_COMMUNITY || $importer["page-flags"] == Contact::PAGE_PRVGROUP) {
+			if ($importer["page-flags"] == User::PAGE_FLAGS_COMMUNITY || $importer["page-flags"] == User::PAGE_FLAGS_PRVGROUP) {
 				$sql_extra = "";
 				$community = true;
 				Logger::log("possible community action");
@@ -3056,8 +3056,8 @@ class DFRN
 			return false;
 		}
 
-		$community_page = ($user['page-flags'] == Contact::PAGE_COMMUNITY);
-		$prvgroup = ($user['page-flags'] == Contact::PAGE_PRVGROUP);
+		$community_page = ($user['page-flags'] == User::PAGE_FLAGS_COMMUNITY);
+		$prvgroup = ($user['page-flags'] == User::PAGE_FLAGS_PRVGROUP);
 
 		$link = Strings::normaliseLink(System::baseUrl() . '/profile/' . $user['nickname']);
 

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -642,7 +642,7 @@ class Diaspora
 			return false;
 		}
 
-		$importer = ["uid" => 0, "page-flags" => Contact::PAGE_FREELOVE];
+		$importer = ["uid" => 0, "page-flags" => User::PAGE_FLAGS_FREELOVE];
 		$success = self::dispatch($importer, $msg, $fields);
 
 		return $success;
@@ -1126,7 +1126,7 @@ class Diaspora
 		 */
 		// It is deactivated by now, due to side effects. See issue https://github.com/friendica/friendica/pull/4033
 		// It is not removed by now. Possibly the code is needed?
-		//if (!$is_comment && $contact["rel"] == Contact::FOLLOWER && in_array($importer["page-flags"], array(Contact::PAGE_FREELOVE))) {
+		//if (!$is_comment && $contact["rel"] == Contact::FOLLOWER && in_array($importer["page-flags"], array(User::PAGE_FLAGS_FREELOVE))) {
 		//	DBA::update(
 		//		'contact',
 		//		array('rel' => Contact::FRIEND, 'writable' => true),
@@ -1146,7 +1146,7 @@ class Diaspora
 			// Yes, then it is fine.
 			return true;
 			// Is it a post to a community?
-		} elseif (($contact["rel"] == Contact::FOLLOWER) && in_array($importer["page-flags"], [Contact::PAGE_COMMUNITY, Contact::PAGE_PRVGROUP])) {
+		} elseif (($contact["rel"] == Contact::FOLLOWER) && in_array($importer["page-flags"], [User::PAGE_FLAGS_COMMUNITY, User::PAGE_FLAGS_PRVGROUP])) {
 			// That's good
 			return true;
 			// Is the message a global user or a comment?
@@ -2414,7 +2414,7 @@ class Diaspora
 			}
 		}
 
-		if (!$following && $sharing && in_array($importer["page-flags"], [Contact::PAGE_SOAPBOX, Contact::PAGE_NORMAL])) {
+		if (!$following && $sharing && in_array($importer["page-flags"], [User::PAGE_FLAGS_SOAPBOX, User::PAGE_FLAGS_NORMAL])) {
 			Logger::log("Author ".$author." wants to share with us - but doesn't want to listen. Request is ignored.", Logger::DEBUG);
 			return false;
 		} elseif (!$following && !$sharing) {
@@ -2472,7 +2472,7 @@ class Diaspora
 
 		Contact::updateAvatar($ret["photo"], $importer['uid'], $contact_record["id"], true);
 
-		if (in_array($importer["page-flags"], [Contact::PAGE_NORMAL, Contact::PAGE_PRVGROUP])) {
+		if (in_array($importer["page-flags"], [User::PAGE_FLAGS_NORMAL, User::PAGE_FLAGS_PRVGROUP])) {
 			Logger::log("Sending intra message for author ".$author.".", Logger::DEBUG);
 
 			$hash = Strings::getRandomHex().(string)time();   // Generate a confirm_key
@@ -2500,9 +2500,9 @@ class Diaspora
 			 * but if our page-type is Profile::PAGE_COMMUNITY or Profile::PAGE_SOAPBOX
 			 * we are going to change the relationship and make them a follower.
 			 */
-			if (($importer["page-flags"] == Contact::PAGE_FREELOVE) && $sharing && $following) {
+			if (($importer["page-flags"] == User::PAGE_FLAGS_FREELOVE) && $sharing && $following) {
 				$new_relation = Contact::FRIEND;
-			} elseif (($importer["page-flags"] == Contact::PAGE_FREELOVE) && $sharing) {
+			} elseif (($importer["page-flags"] == User::PAGE_FLAGS_FREELOVE) && $sharing) {
 				$new_relation = Contact::SHARING;
 			} else {
 				$new_relation = Contact::FOLLOWER;

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -150,7 +150,7 @@ class Diaspora
 
 		// Fetch the relay contact
 		$condition = ['uid' => 0, 'nurl' => Strings::normaliseLink($server_url),
-			'contact-type' => Contact::ACCOUNT_TYPE_RELAY];
+			'contact-type' => Contact::TYPE_RELAY];
 		$contact = DBA::selectFirst('contact', $fields, $condition);
 
 		if (DBA::isResult($contact)) {
@@ -190,7 +190,7 @@ class Diaspora
 		$fields = array_merge($fields, $network_fields);
 
 		$condition = ['uid' => 0, 'nurl' => Strings::normaliseLink($server_url),
-			'contact-type' => Contact::ACCOUNT_TYPE_RELAY];
+			'contact-type' => Contact::TYPE_RELAY];
 
 		if (DBA::exists('contact', $condition)) {
 			unset($fields['created']);
@@ -3157,7 +3157,7 @@ class Diaspora
 		Logger::log("transmit: ".$logid."-".$guid." to ".$dest_url." returns: ".$return_code);
 
 		if (!$return_code || (($return_code == 503) && (stristr($postResult->getHeader(), "retry-after")))) {
-			if (!$no_queue && !empty($contact['contact-type']) && ($contact['contact-type'] != Contact::ACCOUNT_TYPE_RELAY)) {
+			if (!$no_queue && !empty($contact['contact-type']) && ($contact['contact-type'] != Contact::TYPE_RELAY)) {
 				Logger::log("queue message");
 				// queue message for redelivery
 				Queue::add($contact["id"], Protocol::DIASPORA, $envelope, $public_batch, $guid);

--- a/src/Protocol/OStatus.php
+++ b/src/Protocol/OStatus.php
@@ -1352,7 +1352,7 @@ class OStatus
 		$attributes = ["href" => System::baseUrl() . $selfUri, "rel" => "self", "type" => "application/atom+xml"];
 		XML::addElement($doc, $root, "link", "", $attributes);
 
-		if ($owner['account-type'] == Contact::ACCOUNT_TYPE_COMMUNITY) {
+		if ($owner['account-type'] == Contact::TYPE_COMMUNITY) {
 			$condition = ['uid' => $owner['uid'], 'self' => false, 'pending' => false,
 					'archive' => false, 'hidden' => false, 'blocked' => false];
 			$members = DBA::count('contact', $condition);
@@ -1464,7 +1464,7 @@ class OStatus
 		$profile = DBA::selectFirst('profile', ['homepage', 'publish'], ['uid' => $owner['uid'], 'is-default' => true]);
 		$author = $doc->createElement("author");
 		XML::addElement($doc, $author, "id", $owner["url"]);
-		if ($owner['account-type'] == Contact::ACCOUNT_TYPE_COMMUNITY) {
+		if ($owner['account-type'] == User::ACCOUNT_TYPE_COMMUNITY) {
 			XML::addElement($doc, $author, "activity:object-type", ACTIVITY_OBJ_GROUP);
 		} else {
 			XML::addElement($doc, $author, "activity:object-type", ACTIVITY_OBJ_PERSON);
@@ -1946,7 +1946,7 @@ class OStatus
 				$title = sprintf("New note by %s", $owner["nick"]);
 			}
 
-			if ($owner['account-type'] == Contact::ACCOUNT_TYPE_COMMUNITY) {
+			if ($owner['account-type'] == User::ACCOUNT_TYPE_COMMUNITY) {
 				$contact = self::contactEntry($item['author-link'], $owner);
 				$author = self::addAuthor($doc, $contact, false);
 				$entry->appendChild($author);
@@ -2109,8 +2109,8 @@ class OStatus
 		foreach ($mentioned as $mention) {
 			$condition = ['uid' => $owner['uid'], 'nurl' => Strings::normaliseLink($mention)];
 			$contact = DBA::selectFirst('contact', ['forum', 'prv', 'self', 'contact-type'], $condition);
-			if ($contact["forum"] || $contact["prv"] || ($owner['contact-type'] == Contact::ACCOUNT_TYPE_COMMUNITY) ||
-				($contact['self'] && ($owner['account-type'] == Contact::ACCOUNT_TYPE_COMMUNITY))) {
+			if ($contact["forum"] || $contact["prv"] || ($owner['contact-type'] == Contact::TYPE_COMMUNITY) ||
+				($contact['self'] && ($owner['account-type'] == User::ACCOUNT_TYPE_COMMUNITY))) {
 				XML::addElement($doc, $entry, "link", "",
 					[
 						"rel" => "mentioned",
@@ -2127,7 +2127,7 @@ class OStatus
 			}
 		}
 
-		if ($owner['account-type'] == Contact::ACCOUNT_TYPE_COMMUNITY) {
+		if ($owner['account-type'] == User::ACCOUNT_TYPE_COMMUNITY) {
 			XML::addElement($doc, $entry, "link", "", [
 				"rel" => "mentioned",
 				"ostatus:object-type" => "http://activitystrea.ms/schema/1.0/group",
@@ -2237,7 +2237,7 @@ class OStatus
 			$condition[] = ACTIVITY_OBJ_COMMENT;
 		}
 
-		if ($owner['account-type'] != Contact::ACCOUNT_TYPE_COMMUNITY) {
+		if ($owner['account-type'] != User::ACCOUNT_TYPE_COMMUNITY) {
 			$condition[0] .= " AND `contact-id` = ? AND `author-id` = ?";
 			$condition[] = $owner["id"];
 			$condition[] = $authorid;

--- a/src/Util/Security.php
+++ b/src/Util/Security.php
@@ -9,6 +9,7 @@ use Friendica\BaseObject;
 use Friendica\Database\DBA;
 use Friendica\Model\Contact;
 use Friendica\Model\Group;
+use Friendica\Model\User;
 
 /**
  * Secures that User is allow to do requests
@@ -65,7 +66,7 @@ class Security extends BaseObject
 					intval($cid),
 					intval(Contact::SHARING),
 					intval(Contact::FRIEND),
-					intval(Contact::PAGE_COMMUNITY)
+					intval(User::PAGE_FLAGS_COMMUNITY)
 				);
 
 				if (DBA::isResult($r)) {

--- a/src/Worker/Delivery.php
+++ b/src/Worker/Delivery.php
@@ -296,7 +296,7 @@ class Delivery extends BaseObject
 		// Se we transmit with the new method and via Diaspora as a fallback
 		if (!empty($items) && (($items[0]['uid'] == 0) || ($contact['uid'] == 0))) {
 			// Transmit in public if it's a relay post
-			$public_dfrn = ($contact['contact-type'] == Contact::ACCOUNT_TYPE_RELAY);
+			$public_dfrn = ($contact['contact-type'] == Contact::TYPE_RELAY);
 
 			$deliver_status = DFRN::transmit($owner, $contact, $atom, $public_dfrn);
 
@@ -354,7 +354,7 @@ class Delivery extends BaseObject
 	private static function deliverDiaspora($cmd, $contact, $owner, $items, $target_item, $public_message, $top_level, $followup)
 	{
 		// We don't treat Forum posts as "wall-to-wall" to be able to post them via Diaspora
-		$walltowall = $top_level && ($owner['id'] != $items[0]['contact-id']) & ($owner['account-type'] != Contact::ACCOUNT_TYPE_COMMUNITY);
+		$walltowall = $top_level && ($owner['id'] != $items[0]['contact-id']) & ($owner['account-type'] != User::ACCOUNT_TYPE_COMMUNITY);
 
 		if ($public_message) {
 			$loc = 'public batch ' . $contact['batch'];

--- a/src/Worker/Queue.php
+++ b/src/Worker/Queue.php
@@ -141,7 +141,7 @@ class Queue
 				$deliver_status = Diaspora::transmit($owner, $contact, $data, $public, true, 'Queue:' . $q_item['id'], true);
 
 				if ((($deliver_status >= 200) && ($deliver_status <= 299)) ||
-					($contact['contact-type'] == Contact::ACCOUNT_TYPE_RELAY)) {
+					($contact['contact-type'] == Contact::TYPE_RELAY)) {
 					QueueModel::removeItem($q_item['id']);
 				} else {
 					QueueModel::updateTime($q_item['id']);

--- a/update.php
+++ b/update.php
@@ -164,8 +164,8 @@ function update_1203()
 {
 	$r = q("UPDATE `user` SET `account-type` = %d WHERE `page-flags` IN (%d, %d)",
 		DBA::escape(Contact::ACCOUNT_TYPE_COMMUNITY),
-		DBA::escape(Contact::PAGE_COMMUNITY),
-		DBA::escape(Contact::PAGE_PRVGROUP)
+		DBA::escape(User::PAGE_FLAGS_COMMUNITY),
+		DBA::escape(User::PAGE_FLAGS_PRVGROUP)
 	);
 }
 

--- a/update.php
+++ b/update.php
@@ -163,7 +163,7 @@ function update_1191()
 function update_1203()
 {
 	$r = q("UPDATE `user` SET `account-type` = %d WHERE `page-flags` IN (%d, %d)",
-		DBA::escape(Contact::ACCOUNT_TYPE_COMMUNITY),
+		DBA::escape(User::ACCOUNT_TYPE_COMMUNITY),
 		DBA::escape(User::PAGE_FLAGS_COMMUNITY),
 		DBA::escape(User::PAGE_FLAGS_PRVGROUP)
 	);


### PR DESCRIPTION
On my single-user instance it isn't really an issue, but I noticed that the Contact Block widget on the left aside showing my contacts on my top-level post page included both followers and followed. This is undesirable as many more people follow my account than I follow them, which means that this display doesn't accurately represent my contacts.

I changed it to only show people that are effectively followed, including mutuals. I also moved its code to a dedicated widget as its place wasn't in the HTML manipulation class.

Additionally, it wasn't including ActivityPub contacts, and it's now fixed.

Addon pendant: https://github.com/friendica/friendica-addons/pull/790