### PR TITLE
Fixing Monolog issues

### DIFF
--- a/doc/tools.md
+++ b/doc/tools.md
@@ -56,7 +56,7 @@ In */etc/fail2ban/jail.local* create a section for Friendica:
 And create a filter definition in */etc/fail2ban/filter.d/friendica.conf*:
 
 	[Definition]
-	failregex = ^.*Login\.php.*failed login attempt.*from IP <HOST>.*$
+	failregex = ^.*authenticate\: failed login attempt.*\"ip\"\:\"<HOST>\".*$
 	ignoreregex =
 
 Additionally you have to define the number of failed logins before the ban should be activated.

--- a/src/Core/Logger.php
+++ b/src/Core/Logger.php
@@ -83,9 +83,7 @@ class Logger extends BaseObject
 			return;
 		}
 
-		if (is_int($loglevel)) {
-			$loglevel = self::mapLegacyConfigDebugLevel($loglevel);
-		}
+		$loglevel = self::mapLegacyConfigDebugLevel((string)$loglevel);
 
 		LoggerFactory::addStreamHandler($logger, $logfile, $loglevel);
 
@@ -107,7 +105,7 @@ class Logger extends BaseObject
 	 * Mapping a legacy level to the PSR-3 compliant levels
 	 * @see https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-3-logger-interface.md#5-psrlogloglevel
 	 *
-	 * @param int $level the level to be mapped
+	 * @param mixed $level the level to be mapped
 	 *
 	 * @return string the PSR-3 compliant level
 	 */
@@ -115,26 +113,26 @@ class Logger extends BaseObject
 	{
 		switch ($level) {
 			// legacy WARNING
-			case 0:
+			case "0":
 				return LogLevel::ERROR;
 			// legacy INFO
-			case 1:
+			case "1":
 				return LogLevel::WARNING;
 			// legacy TRACE
-			case 2:
+			case "2":
 				return LogLevel::NOTICE;
 			// legacy DEBUG
-			case 3:
+			case "3":
 				return LogLevel::INFO;
 			// legacy DATA
-			case 4:
+			case "4":
 				return LogLevel::DEBUG;
 			// legacy ALL
-			case 5:
+			case "5":
 				return LogLevel::DEBUG;
 			// default if nothing set
 			default:
-				return LogLevel::NOTICE;
+				return $level;
 		}
 	}
 

--- a/src/Core/Logger.php
+++ b/src/Core/Logger.php
@@ -84,7 +84,7 @@ class Logger extends BaseObject
 		}
 
 		if (is_int($loglevel)) {
-			$loglevel = self::mapLegacyDebugLevel($loglevel);
+			$loglevel = self::mapLegacyConfigDebugLevel($loglevel);
 		}
 
 		LoggerFactory::addStreamHandler($logger, $logfile, $loglevel);
@@ -111,7 +111,7 @@ class Logger extends BaseObject
 	 *
 	 * @return string the PSR-3 compliant level
 	 */
-	private static function mapLegacyDebugLevel($level)
+	private static function mapLegacyConfigDebugLevel($level)
 	{
 		switch ($level) {
 			// legacy WARNING

--- a/src/Core/Logger.php
+++ b/src/Core/Logger.php
@@ -105,7 +105,7 @@ class Logger extends BaseObject
 	 * Mapping a legacy level to the PSR-3 compliant levels
 	 * @see https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-3-logger-interface.md#5-psrlogloglevel
 	 *
-	 * @param mixed $level the level to be mapped
+	 * @param string $level the level to be mapped
 	 *
 	 * @return string the PSR-3 compliant level
 	 */

--- a/src/Core/Logger.php
+++ b/src/Core/Logger.php
@@ -321,20 +321,18 @@ class Logger extends BaseObject
      * @brief Logs the given message at the given log level
      *
      * @param string $msg
-     * @param int    $level
+     * @param string $level
 	 *
 	 * @deprecated since 2019.03 Use Logger::debug() Logger::info() , ... instead
      */
-    public static function log($msg, $level = 3)
+    public static function log($msg, $level = LogLevel::INFO)
     {
 		if (!isset(self::$logger)) {
 			return;
 		}
 
-		$loglevel = self::mapLegacyDebugLevel($level);
-
         $stamp1 = microtime(true);
-		self::$logger->log($loglevel, $msg);
+		self::$logger->log($level, $msg);
         self::getApp()->saveTimestamp($stamp1, "file");
     }
 

--- a/src/Core/Logger.php
+++ b/src/Core/Logger.php
@@ -84,7 +84,7 @@ class Logger extends BaseObject
 		}
 
 		if (is_int($loglevel)) {
-			$loglevel = self::mapLegacyConfigDebugLevel($loglevel);
+			$loglevel = self::mapLegacyDebugLevel($loglevel);
 		}
 
 		LoggerFactory::addStreamHandler($logger, $logfile, $loglevel);
@@ -111,7 +111,7 @@ class Logger extends BaseObject
 	 *
 	 * @return string the PSR-3 compliant level
 	 */
-	private static function mapLegacyConfigDebugLevel($level)
+	private static function mapLegacyDebugLevel($level)
 	{
 		switch ($level) {
 			// legacy WARNING
@@ -321,18 +321,20 @@ class Logger extends BaseObject
      * @brief Logs the given message at the given log level
      *
      * @param string $msg
-     * @param int $level
+     * @param int    $level
 	 *
 	 * @deprecated since 2019.03 Use Logger::debug() Logger::info() , ... instead
      */
-    public static function log($msg, $level = LogLevel::NOTICE)
+    public static function log($msg, $level = 3)
     {
 		if (!isset(self::$logger)) {
 			return;
 		}
 
+		$loglevel = self::mapLegacyDebugLevel($level);
+
         $stamp1 = microtime(true);
-		self::$logger->log($level, $msg);
+		self::$logger->log($loglevel, $msg);
         self::getApp()->saveTimestamp($stamp1, "file");
     }
 

--- a/src/Module/Login.php
+++ b/src/Module/Login.php
@@ -149,7 +149,7 @@ class Login extends BaseModule
 				);
 			}
 		} catch (Exception $e) {
-			Logger::notice('authenticate: failed login attempt', ['username' => Strings::escapeTags($username), 'ip' => $_SERVER['REMOTE_ADDR']]);
+			Logger::notice('authenticate: failed login attempt', ['action' => 'login', 'username' => Strings::escapeTags($username), 'ip' => $_SERVER['REMOTE_ADDR']]);
 			info('Login failed. Please check your credentials.' . EOL);
 			$a->internalRedirect();
 		}

--- a/src/Module/Login.php
+++ b/src/Module/Login.php
@@ -149,7 +149,7 @@ class Login extends BaseModule
 				);
 			}
 		} catch (Exception $e) {
-			Logger::log('authenticate: failed login attempt: ' . Strings::escapeTags($username) . ' from IP ' . $_SERVER['REMOTE_ADDR']);
+			Logger::notice('authenticate: failed login attempt', ['username' => Strings::escapeTags($username), 'ip' => $_SERVER['REMOTE_ADDR']]);
 			info('Login failed. Please check your credentials.' . EOL);
 			$a->internalRedirect();
 		}

--- a/src/Module/Login.php
+++ b/src/Module/Login.php
@@ -149,7 +149,7 @@ class Login extends BaseModule
 				);
 			}
 		} catch (Exception $e) {
-			Logger::notice('authenticate: failed login attempt', ['action' => 'login', 'username' => Strings::escapeTags($username), 'ip' => $_SERVER['REMOTE_ADDR']]);
+			Logger::warning('authenticate: failed login attempt', ['action' => 'login', 'username' => Strings::escapeTags($username), 'ip' => $_SERVER['REMOTE_ADDR']]);
 			info('Login failed. Please check your credentials.' . EOL);
 			$a->internalRedirect();
 		}

--- a/src/Util/LoggerFactory.php
+++ b/src/Util/LoggerFactory.php
@@ -75,7 +75,13 @@ class LoggerFactory
 	public static function addStreamHandler($logger, $stream, $level = LogLevel::NOTICE)
 	{
 		if ($logger instanceof Monolog\Logger) {
-			$fileHandler = new Monolog\Handler\StreamHandler($stream, Monolog\Logger::toMonologLevel($level));
+			$loglevel = Monolog\Logger::toMonologLevel($level);
+
+			// fallback to notice if an invalid loglevel is set
+			if (!is_int($loglevel)) {
+				$loglevel = LogLevel::NOTICE;
+			}
+			$fileHandler = new Monolog\Handler\StreamHandler($stream, $loglevel);
 
 			$formatter = new Monolog\Formatter\LineFormatter("%datetime% %channel% [%level_name%]: %message% %context% %extra%\n");
 			$fileHandler->setFormatter($formatter);


### PR DESCRIPTION
related to #6376 
- Legacy log sets now level `info`, which is one level under `notice`.
- Default log config is `notice`, so enabling debugging doesn't mean to flood the log

- [x] Authentication is set to `notice`, which will automatically be added in case of enable debugging (#6303)  
- [x] Added new regex for fail2ban (#6403)

Tested with `fail2ban-regex`
```
|- Matched line(s):
|  2019-01-07 19:16:21 index [NOTICE]: authenticate: failed login attempt {"username":"admi","ip":"192.168.22.1"} {"process_id":1992}
|  2019-01-07 19:16:40 index [NOTICE]: authenticate: failed login attempt {"username":"admi","ip":"192.168.22.1"} {"process_id":1971}
|  2019-01-07 19:17:25 index [NOTICE]: authenticate: failed login attempt {"username":"admi","ip":"192.168.22.1"} {"process_id":1957}
|  2019-01-07 19:42:53 index [NOTICE]: authenticate: failed login attempt {"action":"login","username":"admi","ip":"192.168.22.1"} {"process_id":2226}
|  2019-01-07 19:43:27 index [NOTICE]: authenticate: failed login attempt {"action":"login","username":"admi","ip":"192.168.22.1"} {"process_id":2274}
|  2019-01-07 19:51:00 index [NOTICE]: authenticate: failed login attempt {"action":"login","username":"admi","ip":"192.168.22.1"} {"process_id":1989}
|  2019-01-07 19:51:20 index [NOTICE]: authenticate: failed login attempt {"action":"login","username":"admi","ip":"192.168.22.1"} {"process_id":2225}
```
- [x] Fixing legacy log level change (#6382)

I was against using `error` for logins because it isn't an application error, it's a "noticeable" information, which is `notice` ;-)
[edit] and the second reason against it is that starting with level `warning`, the logs will include several additional debugging information, which isn't necessary for a auth-failure 