### PR TITLE
Don't show deleted contacts, set new AP contacts as "pending" until accepted

### DIFF
--- a/src/Core/ACL.php
+++ b/src/Core/ACL.php
@@ -101,7 +101,7 @@ class ACL extends BaseObject
 		}
 
 		$stmt = DBA::p("SELECT `id`, `name`, `url`, `network` FROM `contact`
-			WHERE `uid` = ? AND NOT `self` AND NOT `blocked` AND NOT `pending` AND NOT `archive` AND `notify` != ''
+			WHERE `uid` = ? AND NOT `self` AND NOT `blocked` AND NOT `pending` AND NOT `archive` AND NOT `deleted` AND `notify` != ''
 			$sql_extra
 			ORDER BY `name` ASC ", intval(local_user())
 		);
@@ -166,7 +166,7 @@ class ACL extends BaseObject
 		$o .= "<select name=\"$selname\" id=\"$selclass\" class=\"$selclass\" size=\"$size\"$tabindex_attr$hidepreselected>\r\n";
 
 		$stmt = DBA::p("SELECT `id`, `name`, `url`, `network` FROM `contact`
-			WHERE `uid` = ? AND NOT `self` AND NOT `blocked` AND NOT `pending` AND NOT `archive` AND `notify` != ''
+			WHERE `uid` = ? AND NOT `self` AND NOT `blocked` AND NOT `pending` AND NOT `archive` AND NOT `deleted` AND `notify` != ''
 			$sql_extra
 			ORDER BY `name` ASC ", intval(local_user())
 		);

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -1739,6 +1739,8 @@ class Contact extends BaseObject
 
 		$hidden = (($ret['network'] === Protocol::MAIL) ? 1 : 0);
 
+		$pending = in_array($ret['network'], [Protocol::ACTIVITYPUB]);
+
 		if (in_array($ret['network'], [Protocol::MAIL, Protocol::DIASPORA, Protocol::ACTIVITYPUB])) {
 			$writeable = 1;
 		}
@@ -1774,7 +1776,7 @@ class Contact extends BaseObject
 				'hidden'  => $hidden,
 				'blocked' => 0,
 				'readonly'=> 0,
-				'pending' => 0,
+				'pending' => $pending,
 				'subhub'  => $subhub
 			]);
 		}

--- a/src/Module/Contact.php
+++ b/src/Module/Contact.php
@@ -51,10 +51,10 @@ class Contact extends BaseModule
 			|| $a->argc == 3 && intval($a->argv[1]) && in_array($a->argv[2], ['posts', 'conversations'])
 		) {
 			$contact_id = intval($a->argv[1]);
-			$contact = DBA::selectFirst('contact', [], ['id' => $contact_id, 'uid' => local_user()]);
+			$contact = DBA::selectFirst('contact', [], ['id' => $contact_id, 'uid' => local_user(), 'deleted' => false]);
 
 			if (!DBA::isResult($contact)) {
-				$contact = DBA::selectFirst('contact', [], ['id' => $contact_id, 'uid' => 0]);
+				$contact = DBA::selectFirst('contact', [], ['id' => $contact_id, 'uid' => 0, 'deleted' => false]);
 			}
 
 			// Don't display contacts that are about to be deleted
@@ -135,7 +135,7 @@ class Contact extends BaseModule
 
 		$contacts_id = $_POST['contact_batch'];
 
-		$stmt = DBA::select('contact', ['id', 'archive'], ['id' => $contacts_id, 'uid' => local_user(), 'self' => false]);
+		$stmt = DBA::select('contact', ['id', 'archive'], ['id' => $contacts_id, 'uid' => local_user(), 'self' => false, 'deleted' => false]);
 		$orig_records = DBA::toArray($stmt);
 
 		$count_actions = 0;
@@ -188,7 +188,7 @@ class Contact extends BaseModule
 			return;
 		}
 
-		if (!DBA::exists('contact', ['id' => $contact_id, 'uid' => local_user()])) {
+		if (!DBA::exists('contact', ['id' => $contact_id, 'uid' => local_user(), 'deleted' => false])) {
 			notice(L10n::t('Could not access contact record.') . EOL);
 			$a->internalRedirect('contact');
 			return; // NOTREACHED
@@ -198,7 +198,7 @@ class Contact extends BaseModule
 
 		$profile_id = intval(defaults($_POST, 'profile-assign', 0));
 		if ($profile_id) {
-			if (!DBA::exists('profile', ['id' => $profile_id, 'uid' => local_user()])) {
+			if (!DBA::exists('profile', ['id' => $profile_id, 'uid' => local_user(), 'deleted' => false])) {
 				notice(L10n::t('Could not locate selected profile.') . EOL);
 				return;
 			}
@@ -236,7 +236,7 @@ class Contact extends BaseModule
 			notice(L10n::t('Failed to update contact record.') . EOL);
 		}
 
-		$contact = DBA::selectFirst('contact', [], ['id' => $contact_id, 'uid' => local_user()]);
+		$contact = DBA::selectFirst('contact', [], ['id' => $contact_id, 'uid' => local_user(), 'deleted' => false]);
 		if (DBA::isResult($contact)) {
 			$a->data['contact'] = $contact;
 		}
@@ -248,7 +248,7 @@ class Contact extends BaseModule
 
 	private static function updateContactFromPoll($contact_id)
 	{
-		$contact = DBA::selectFirst('contact', ['uid', 'url', 'network'], ['id' => $contact_id, 'uid' => local_user()]);
+		$contact = DBA::selectFirst('contact', ['uid', 'url', 'network'], ['id' => $contact_id, 'uid' => local_user(), 'deleted' => false]);
 		if (!DBA::isResult($contact)) {
 			return;
 		}
@@ -269,7 +269,7 @@ class Contact extends BaseModule
 
 	private static function updateContactFromProbe($contact_id)
 	{
-		$contact = DBA::selectFirst('contact', ['uid', 'url', 'network'], ['id' => $contact_id, 'uid' => local_user()]);
+		$contact = DBA::selectFirst('contact', ['uid', 'url', 'network'], ['id' => $contact_id, 'uid' => local_user(), 'deleted' => false]);
 		if (!DBA::isResult($contact)) {
 			return;
 		}
@@ -370,7 +370,7 @@ class Contact extends BaseModule
 
 			$cmd = $a->argv[2];
 
-			$orig_record = DBA::selectFirst('contact', [], ['id' => $contact_id, 'uid' => [0, local_user()], 'self' => false]);
+			$orig_record = DBA::selectFirst('contact', [], ['id' => $contact_id, 'uid' => [0, local_user()], 'self' => false, 'deleted' => false]);
 			if (!DBA::isResult($orig_record)) {
 				notice(L10n::t('Could not access contact record.') . EOL);
 				$a->internalRedirect('contact');
@@ -778,6 +778,8 @@ class Contact extends BaseModule
 			$sql_extra .= sprintf(" AND network = '%s' ", DBA::escape($nets));
 		}
 
+		$sql_extra .=  " AND NOT `deleted` ";
+
 		$sql_extra2 = ((($sort_type > 0) && ($sort_type <= Model\Contact::FRIEND)) ? sprintf(" AND `rel` = %d ", intval($sort_type)) : '');
 
 		$r = q("SELECT COUNT(*) AS `total` FROM `contact`
@@ -937,7 +939,7 @@ class Contact extends BaseModule
 			}
 		}
 
-		$contact = DBA::selectFirst('contact', ['uid', 'url', 'id'], ['id' => $contact_id]);
+		$contact = DBA::selectFirst('contact', ['uid', 'url', 'id'], ['id' => $contact_id, 'deleted' => false]);
 
 		if (!$update) {
 			$o .= self::getTabsHTML($a, $contact, 1);
@@ -961,7 +963,7 @@ class Contact extends BaseModule
 
 	private static function getPostsHTML($a, $contact_id)
 	{
-		$contact = DBA::selectFirst('contact', ['uid', 'url', 'id'], ['id' => $contact_id]);
+		$contact = DBA::selectFirst('contact', ['uid', 'url', 'id'], ['id' => $contact_id, 'deleted' => false]);
 
 		$o = self::getTabsHTML($a, $contact, 2);
 

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -370,6 +370,7 @@ class Processor
 		$cid = Contact::getIdForURL($activity['actor'], $uid);
 		if (!empty($cid)) {
 			self::switchContact($cid);
+			DBA::update('contact', ['hub-verify' => $activity['id']], ['id' => $cid]);
 			$contact = DBA::selectFirst('contact', [], ['id' => $cid, 'network' => Protocol::NATIVE_SUPPORT]);
 		} else {
 			$contact = false;
@@ -387,7 +388,10 @@ class Processor
 			return;
 		}
 
-		DBA::update('contact', ['hub-verify' => $activity['id']], ['id' => $cid]);
+		if (empty($contact)) {
+			DBA::update('contact', ['hub-verify' => $activity['id']], ['id' => $cid]);
+		}
+
 		Logger::log('Follow user ' . $uid . ' from contact ' . $cid . ' with id ' . $activity['id']);
 	}
 


### PR DESCRIPTION
Deleted contacts shouldn't appear anywhere. Additionally new ActivityPub contacts have to be set as "pending" until the contact request has been accepted by the other side.