### PR TITLE
Don't accept private answers to public parents

### DIFF
--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -264,6 +264,19 @@ class Processor
 		}
 
 		$item['uri'] = $activity['id'];
+
+		if (($item['parent-uri'] != $item['uri']) && ($item['gravity'] == GRAVITY_COMMENT)) {
+			$item_private = !in_array(0, $activity['item_receiver']);
+			$parent = Item::selectFirst(['private'], ['uri' => $item['parent-uri']]);
+			if (!DBA::isResult($parent)) {
+				return;
+			}
+			if ($item_private && !$parent['private']) {
+				Logger::log('Item ' . $item['uri'] . ' is private but the parent ' . $item['parent-uri'] . ' is not. So we drop it.');
+				return;
+			}
+		}
+
 		$item['created'] = $activity['published'];
 		$item['edited'] = $activity['updated'];
 		$item['guid'] = $activity['diaspora:guid'];

--- a/src/Protocol/ActivityPub/Receiver.php
+++ b/src/Protocol/ActivityPub/Receiver.php
@@ -233,6 +233,7 @@ class Receiver
 
 		$object_data['type'] = $type;
 		$object_data['actor'] = $actor;
+		$object_data['item_receiver'] = $receivers;
 		$object_data['receiver'] = array_merge(defaults($object_data, 'receiver', []), $receivers);
 
 		Logger::log('Processing ' . $object_data['type'] . ' ' . $object_data['object_type'] . ' ' . $object_data['id'], Logger::DEBUG);


### PR DESCRIPTION
This is a security thing: In Friendica permissions are defined by the starting post. On ActivityPub the permissions are defined per post. We have to avoid to accidentally show private pots on public posts, so we just don't store it here.