### PR TITLE
Add variable query parameter to stylesheet URL for iOS Safari

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -102,6 +102,11 @@ class App
 	private $isAjax;
 
 	/**
+	 * @var MobileDetect
+	 */
+	public $mobileDetect;
+
+	/**
 	 * Register a stylesheet file path to be included in the <head> tag of every page.
 	 * Inclusion is done in App->initHead().
 	 * The path can be absolute or relative to the Friendica installation base folder.
@@ -268,6 +273,9 @@ class App
 
 		// Detect mobile devices
 		$mobile_detect = new MobileDetect();
+
+		$this->mobileDetect = $mobile_detect;
+
 		$this->is_mobile = $mobile_detect->isMobile();
 		$this->is_tablet = $mobile_detect->isTablet();
 

--- a/src/Core/Theme.php
+++ b/src/Core/Theme.php
@@ -9,6 +9,7 @@ namespace Friendica\Core;
 use Friendica\BaseObject;
 use Friendica\Core\Logger;
 use Friendica\Core\System;
+use Friendica\Model\Profile;
 
 /**
  * Some functions to handle themes
@@ -196,15 +197,10 @@ class Theme
 
 		$query_params = [];
 
-		// Workaround for iOS Safari not initially sending the cookie for static files
-		if ($a->mobileDetect->isIos() && $a->mobileDetect->isSafari()) {
-			$query_params['t'] = time();
+		$puid = Profile::getThemeUid($a);
+		if ($puid) {
+			$query_params['puid'] = $puid;
 		}
-
-		if ($a->profile_uid) {
-			$query_params['puid'] = $a->profile_uid;
-		}
-
 
 		if (file_exists('view/theme/' . $theme . '/style.php')) {
 			return 'view/theme/' . $theme . '/style.pcss' . (!empty($query_params) ? '?' . http_build_query($query_params) : '');

--- a/src/Core/Theme.php
+++ b/src/Core/Theme.php
@@ -6,6 +6,7 @@
 
 namespace Friendica\Core;
 
+use Friendica\BaseObject;
 use Friendica\Core\Logger;
 use Friendica\Core\System;
 
@@ -191,11 +192,22 @@ class Theme
 	 */
 	public static function getStylesheetPath($theme)
 	{
-		$a = get_app();
+		$a = BaseObject::getApp();
 
-		$opts = (($a->profile_uid) ? '?f=&puid=' . $a->profile_uid : '');
+		$query_params = [];
+
+		// Workaround for iOS Safari not initially sending the cookie for static files
+		if ($a->mobileDetect->isIos() && $a->mobileDetect->isSafari()) {
+			$query_params['t'] = time();
+		}
+
+		if ($a->profile_uid) {
+			$query_params['puid'] = $a->profile_uid;
+		}
+
+
 		if (file_exists('view/theme/' . $theme . '/style.php')) {
-			return 'view/theme/' . $theme . '/style.pcss' . $opts;
+			return 'view/theme/' . $theme . '/style.pcss' . (!empty($query_params) ? '?' . http_build_query($query_params) : '');
 		}
 
 		return 'view/theme/' . $theme . '/style.css';

--- a/src/Core/Theme.php
+++ b/src/Core/Theme.php
@@ -193,6 +193,10 @@ class Theme
 	 */
 	public static function getStylesheetPath($theme)
 	{
+		if (!file_exists('view/theme/' . $theme . '/style.php')) {
+			return 'view/theme/' . $theme . '/style.css';
+		}
+
 		$a = BaseObject::getApp();
 
 		$query_params = [];
@@ -202,10 +206,6 @@ class Theme
 			$query_params['puid'] = $puid;
 		}
 
-		if (file_exists('view/theme/' . $theme . '/style.php')) {
-			return 'view/theme/' . $theme . '/style.pcss' . (!empty($query_params) ? '?' . http_build_query($query_params) : '');
-		}
-
-		return 'view/theme/' . $theme . '/style.css';
+		return 'view/theme/' . $theme . '/style.pcss' . (!empty($query_params) ? '?' . http_build_query($query_params) : '');
 	}
 }

--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -1176,7 +1176,7 @@ class Profile
 	 * Get the user ID of the page owner.
 	 *
 	 * Used from within PCSS themes to set theme parameters. If there's a
-	 * puid request variable, that is the "page owner" and normally their theme
+	 * profile_uid variable set in App, that is the "page owner" and normally their theme
 	 * settings take precedence; unless a local user sets the "always_my_theme"
 	 * system pconfig, which means they don't want to see anybody else's theme
 	 * settings except their own while on this site.
@@ -1184,13 +1184,12 @@ class Profile
 	 * @brief Get the user ID of the page owner
 	 * @return int user ID
 	 *
-	 * @note Returns local_user instead of user ID if "always_my_theme"
-	 *      is set to true
+	 * @note Returns local_user instead of user ID if "always_my_theme" is set to true
 	 */
-	public static function getThemeUid()
+	public static function getThemeUid(App $a)
 	{
-		$uid = (!empty($_REQUEST['puid']) ? intval($_REQUEST['puid']) : 0);
-		if ((local_user()) && ((PConfig::get(local_user(), 'system', 'always_my_theme')) || (!$uid))) {
+		$uid = !empty($a->profile_uid) ? intval($a->profile_uid) : 0;
+		if (local_user() && (PConfig::get(local_user(), 'system', 'always_my_theme') || !$uid)) {
 			return local_user();
 		}
 
@@ -1198,7 +1197,7 @@ class Profile
 	}
 
 	/**
-	* Stip zrl parameter from a string.
+	* Strip zrl parameter from a string.
 	*
 	* @param string $s The input string.
 	* @return string The zrl.

--- a/view/theme/duepuntozero/style.php
+++ b/view/theme/duepuntozero/style.php
@@ -10,7 +10,7 @@ if (file_exists("$THEMEPATH/style.css")) {
 	echo file_get_contents("$THEMEPATH/style.css");
 }
 
-$uid = Profile::getThemeUid();
+$uid = defaults($_REQUEST, 'puid', 0);
 
 $s_colorset = Config::get('duepuntozero', 'colorset');
 $colorset = PConfig::get($uid, 'duepuntozero', 'colorset');

--- a/view/theme/frio/php/default.php
+++ b/view/theme/frio/php/default.php
@@ -42,10 +42,7 @@ $is_singleuser_class = $is_singleuser ? "is-singleuser" : "is-not-singleuser";
 
 		// Add the theme color meta
 		// It makes mobile Chrome UI match Frio's top bar color.
-		$uid = $a->profile_uid;
-		if (is_null($uid)) {
-			$uid = Profile::getThemeUid();
-		}
+		$uid = Profile::getThemeUid($a);
 		$scheme = PConfig::get($uid, 'frio', 'scheme', PConfig::get($uid, 'frio', 'schema'));
 		if ($scheme && ($scheme != '---')) {
 			if (file_exists('view/theme/frio/scheme/' . $scheme . '.php')) {

--- a/view/theme/frio/style.php
+++ b/view/theme/frio/style.php
@@ -14,7 +14,7 @@ $scheme_modified = 0;
 
 if ($a->module !== 'install') {
 	// Get the UID of the profile owner.
-	$uid = Profile::getThemeUid();
+	$uid = defaults($_REQUEST, 'puid', 0);
 	if ($uid) {
 		PConfig::load($uid, 'frio');
 

--- a/view/theme/quattro/style.php
+++ b/view/theme/quattro/style.php
@@ -6,7 +6,7 @@ use Friendica\Core\Config;
 use Friendica\Core\PConfig;
 use Friendica\Model\Profile;
 
-$uid = Profile::getThemeUid();
+$uid = defaults($_REQUEST, 'puid', 0);
 
 $color = false;
 $quattro_align = false;

--- a/view/theme/vier/style.php
+++ b/view/theme/vier/style.php
@@ -7,7 +7,7 @@ use Friendica\Core\Config;
 use Friendica\Core\PConfig;
 use Friendica\Model\Profile;
 
-$uid = Profile::getThemeUid();
+$uid = defaults($_REQUEST, 'puid', 0);
 
 $style = PConfig::get($uid, 'vier', 'style');
 


### PR DESCRIPTION
Redux of #6380
Fixes #5148
Part of #2800 

This PR reduced scope (only concerns iOS Safari now) should bring less side-effects than #6380 did in #6424 for example.