### PR TITLE
Don't show deleted contacts, changed "pending" behaviour

### DIFF
--- a/mod/acl.php
+++ b/mod/acl.php
@@ -47,7 +47,7 @@ function acl_content(App $a)
 	// count groups and contacts
 	$group_count = 0;
 	if ($type == '' || $type == 'g') {
-		$r = q("SELECT COUNT(*) AS g FROM `group` WHERE `deleted` = 0 AND `uid` = %d $sql_extra",
+		$r = q("SELECT COUNT(*) AS g FROM `group` WHERE NOT `deleted` AND `uid` = %d $sql_extra",
 			intval(local_user())
 		);
 		$group_count = (int) $r[0]['g'];
@@ -59,7 +59,7 @@ function acl_content(App $a)
 	if ($type == '' || $type == 'c') {
 		// autocomplete for editor mentions
 		$r = q("SELECT COUNT(*) AS c FROM `contact`
-				WHERE `uid` = %d AND NOT `self`
+				WHERE `uid` = %d AND NOT `self` AND NOT `deleted`
 				AND NOT `blocked` AND NOT `pending` AND NOT `archive`
 				AND `success_update` >= `failure_update`
 				AND `notify` != '' $sql_extra2",
@@ -69,7 +69,7 @@ function acl_content(App $a)
 	} elseif ($type == 'f') {
 		// autocomplete for editor mentions of forums
 		$r = q("SELECT COUNT(*) AS c FROM `contact`
-				WHERE `uid` = %d AND NOT `self`
+				WHERE `uid` = %d AND NOT `self` AND NOT `deleted`
 				AND NOT `blocked` AND NOT `pending` AND NOT `archive`
 				AND (`forum` OR `prv`)
 				AND `success_update` >= `failure_update`
@@ -80,7 +80,7 @@ function acl_content(App $a)
 	} elseif ($type == 'm') {
 		// autocomplete for Private Messages
 		$r = q("SELECT COUNT(*) AS c FROM `contact`
-				WHERE `uid` = %d AND NOT `self`
+				WHERE `uid` = %d AND NOT `self` AND NOT `deleted`
 				AND NOT `blocked` AND NOT `pending` AND NOT `archive`
 				AND `success_update` >= `failure_update`
 				AND `network` IN ('%s', '%s', '%s') $sql_extra2",
@@ -94,7 +94,7 @@ function acl_content(App $a)
 		// autocomplete for Contacts
 		$r = q("SELECT COUNT(*) AS c FROM `contact`
 				WHERE `uid` = %d AND NOT `self`
-				AND NOT `pending` $sql_extra2",
+				AND NOT `pending` AND NOT `deleted` $sql_extra2",
 			intval(local_user())
 		);
 		$contact_count = (int) $r[0]['c'];
@@ -140,7 +140,7 @@ function acl_content(App $a)
 	$r = [];
 	if ($type == '') {
 		$r = q("SELECT `id`, `name`, `nick`, `micro`, `network`, `url`, `attag`, `addr`, `forum`, `prv`, (`prv` OR `forum`) AS `frm` FROM `contact`
-				WHERE `uid` = %d AND NOT `self` AND NOT `blocked` AND NOT `pending` AND NOT `archive` AND `notify` != ''
+				WHERE `uid` = %d AND NOT `self` AND NOT `deleted` AND NOT `blocked` AND NOT `pending` AND NOT `archive` AND `notify` != ''
 				AND `success_update` >= `failure_update` AND NOT (`network` IN ('%s', '%s'))
 				$sql_extra2
 				ORDER BY `name` ASC ",
@@ -150,7 +150,7 @@ function acl_content(App $a)
 		);
 	} elseif ($type == 'c') {
 		$r = q("SELECT `id`, `name`, `nick`, `micro`, `network`, `url`, `attag`, `addr`, `forum`, `prv` FROM `contact`
-				WHERE `uid` = %d AND NOT `self` AND NOT `blocked` AND NOT `pending` AND NOT `archive` AND `notify` != ''
+				WHERE `uid` = %d AND NOT `self` AND NOT `deleted` AND NOT `blocked` AND NOT `pending` AND NOT `archive` AND `notify` != ''
 				AND `success_update` >= `failure_update` AND NOT (`network` IN ('%s'))
 				$sql_extra2
 				ORDER BY `name` ASC ",
@@ -159,7 +159,7 @@ function acl_content(App $a)
 		);
 	} elseif ($type == 'f') {
 		$r = q("SELECT `id`, `name`, `nick`, `micro`, `network`, `url`, `attag`, `addr`, `forum`, `prv` FROM `contact`
-				WHERE `uid` = %d AND NOT `self` AND NOT `blocked` AND NOT `pending` AND NOT `archive` AND `notify` != ''
+				WHERE `uid` = %d AND NOT `self` AND NOT `deleted` AND NOT `blocked` AND NOT `pending` AND NOT `archive` AND `notify` != ''
 				AND `success_update` >= `failure_update` AND NOT (`network` IN ('%s'))
 				AND (`forum` OR `prv`)
 				$sql_extra2
@@ -169,7 +169,7 @@ function acl_content(App $a)
 		);
 	} elseif ($type == 'm') {
 		$r = q("SELECT `id`, `name`, `nick`, `micro`, `network`, `url`, `attag`, `addr` FROM `contact`
-				WHERE `uid` = %d AND NOT `self` AND NOT `blocked` AND NOT `pending` AND NOT `archive`
+				WHERE `uid` = %d AND NOT `self` AND NOT `deleted` AND NOT `blocked` AND NOT `pending` AND NOT `archive`
 				AND `success_update` >= `failure_update` AND `network` IN ('%s', '%s', '%s')
 				$sql_extra2
 				ORDER BY `name` ASC ",
@@ -180,7 +180,7 @@ function acl_content(App $a)
 		);
 	} elseif ($type == 'a') {
 		$r = q("SELECT `id`, `name`, `nick`, `micro`, `network`, `url`, `attag`, `addr`, `forum`, `prv` FROM `contact`
-				WHERE `uid` = %d AND `pending` = 0 AND `success_update` >= `failure_update`
+				WHERE `uid` = %d AND NOT `deleted` AND NOT `pending` AND `success_update` >= `failure_update`
 				$sql_extra2
 				ORDER BY `name` ASC ",
 			intval(local_user())

--- a/mod/dfrn_confirm.php
+++ b/mod/dfrn_confirm.php
@@ -337,7 +337,12 @@ function dfrn_confirm_post(App $a, $handsfree = null)
 		} else {
 			if ($network == Protocol::ACTIVITYPUB) {
 				ActivityPub\Transmitter::sendContactAccept($contact['url'], $contact['hub-verify'], $uid);
-				$pending = $duplex;
+				// Setting "pending" to true on a bidirectional contact request could create a problem when it isn't accepted on the other side
+				// Then we have got a situation where - although one direction is accepted - the contact still appears as pending.
+				// Possibly we need two different "pending" fields, one for incoming, one for outgoing?
+				// This has to be thought over, but for now this here is a better solution.
+				// $pending = $duplex;
+				$pending = false;
 			} else {
 				$pending = false;
 			}

--- a/src/Content/Widget.php
+++ b/src/Content/Widget.php
@@ -137,7 +137,7 @@ class Widget
 
 		$extra_sql = self::unavailableNetworks();
 
-		$r = DBA::p("SELECT DISTINCT(`network`) FROM `contact` WHERE `uid` = ? AND `network` != '' $extra_sql ORDER BY `network`",
+		$r = DBA::p("SELECT DISTINCT(`network`) FROM `contact` WHERE `uid` = ? AND NOT `deleted` AND `network` != '' $extra_sql ORDER BY `network`",
 			local_user()
 		);
 

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -358,6 +358,7 @@ class Contact extends BaseObject
 				WHERE `gid` = ?
 				AND `contact`.`uid` = ?
 				AND NOT `contact`.`self`
+				AND NOT `contact`.`deleted`
 				AND NOT `contact`.`blocked`
 				AND NOT `contact`.`pending`
 				ORDER BY `contact`.`name` ASC',
@@ -1030,6 +1031,7 @@ class Contact extends BaseObject
 			   FROM `contact`
 			   WHERE `uid` = %d
 			   AND NOT `self`
+			   AND NOT `deleted`
 			   AND NOT `blocked`
 			   AND NOT `pending`
 			   AND `id` NOT IN (

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -50,7 +50,7 @@ class Transmitter
 	public static function getFollowers($owner, $page = null)
 	{
 		$condition = ['rel' => [Contact::FOLLOWER, Contact::FRIEND], 'network' => Protocol::NATIVE_SUPPORT, 'uid' => $owner['uid'],
-			'self' => false, 'hidden' => false, 'archive' => false, 'pending' => false];
+			'self' => false, 'deleted' => false, 'hidden' => false, 'archive' => false, 'pending' => false];
 		$count = DBA::count('contact', $condition);
 
 		$data = ['@context' => ActivityPub::CONTEXT];
@@ -97,7 +97,7 @@ class Transmitter
 	public static function getFollowing($owner, $page = null)
 	{
 		$condition = ['rel' => [Contact::SHARING, Contact::FRIEND], 'network' => Protocol::NATIVE_SUPPORT, 'uid' => $owner['uid'],
-			'self' => false, 'hidden' => false, 'archive' => false, 'pending' => false];
+			'self' => false, 'deleted' => false, 'hidden' => false, 'archive' => false, 'pending' => false];
 		$count = DBA::count('contact', $condition);
 
 		$data = ['@context' => ActivityPub::CONTEXT];

--- a/view/theme/frio/theme.php
+++ b/view/theme/frio/theme.php
@@ -321,14 +321,14 @@ function frio_acl_lookup(App $a, &$results)
 
 	$total = 0;
 	$r = q("SELECT COUNT(*) AS `total` FROM `contact`
-		WHERE `uid` = %d AND NOT `self` AND NOT `pending` $sql_extra ", intval($_SESSION['uid']));
+		WHERE `uid` = %d AND NOT `self` AND NOT `deleted` AND NOT `pending` $sql_extra ", intval($_SESSION['uid']));
 	if (DBA::isResult($r)) {
 		$total = $r[0]['total'];
 	}
 
 	$sql_extra3 = Widget::unavailableNetworks();
 
-	$r = q("SELECT * FROM `contact` WHERE `uid` = %d AND NOT `self` AND NOT `pending` $sql_extra $sql_extra3 ORDER BY `name` ASC LIMIT %d, %d ",
+	$r = q("SELECT * FROM `contact` WHERE `uid` = %d AND NOT `self` AND NOT `deleted` AND NOT `pending` $sql_extra $sql_extra3 ORDER BY `name` ASC LIMIT %d, %d ",
 		intval($_SESSION['uid']), intval($results['start']), intval($results['count'])
 	);
 


### PR DESCRIPTION
We mustn't show deleted contacts. Additionally the behaviour for outgoing pending contact requests had been changed. We have to think about possibly having two different "pending" fields for incoming and outgoing requests. But this is something that we should touch in the next version.