### PR TITLE
Now storing the "manually approve" data / fix update routine

### DIFF
--- a/config/dbstructure.config.php
+++ b/config/dbstructure.config.php
@@ -34,7 +34,7 @@
 use Friendica\Database\DBA;
 
 if (!defined('DB_UPDATE_VERSION')) {
-	define('DB_UPDATE_VERSION', 1292);
+	define('DB_UPDATE_VERSION', 1293);
 }
 
 return [
@@ -65,6 +65,7 @@ return [
 			"inbox" => ["type" => "varchar(255)", "not null" => "1", "comment" => ""],
 			"outbox" => ["type" => "varchar(255)", "comment" => ""],
 			"sharedinbox" => ["type" => "varchar(255)", "comment" => ""],
+			"manually-approve" => ["type" => "boolean", "comment" => ""],
 			"nick" => ["type" => "varchar(255)", "not null" => "1", "default" => "", "comment" => ""],
 			"name" => ["type" => "varchar(255)", "comment" => ""],
 			"about" => ["type" => "text", "comment" => ""],

--- a/database.sql
+++ b/database.sql
@@ -1,6 +1,6 @@
 -- ------------------------------------------
--- Friendica 2018.12-dev (The Tazmans Flax-lily)
--- DB_UPDATE_VERSION 1290
+-- Friendica 2019.01-rc (The Tazmans Flax-lily)
+-- DB_UPDATE_VERSION 1293
 -- ------------------------------------------
 
 
@@ -31,6 +31,7 @@ CREATE TABLE IF NOT EXISTS `apcontact` (
 	`inbox` varchar(255) NOT NULL COMMENT '',
 	`outbox` varchar(255) COMMENT '',
 	`sharedinbox` varchar(255) COMMENT '',
+	`manually-approve` boolean COMMENT '',
 	`nick` varchar(255) NOT NULL DEFAULT '' COMMENT '',
 	`name` varchar(255) COMMENT '',
 	`about` text COMMENT '',
@@ -578,6 +579,7 @@ CREATE TABLE IF NOT EXISTS `item` (
 	 INDEX `uid_contactid_created` (`uid`,`contact-id`,`created`),
 	 INDEX `authorid_created` (`author-id`,`created`),
 	 INDEX `ownerid` (`owner-id`),
+	 INDEX `contact-id` (`contact-id`),
 	 INDEX `uid_uri` (`uid`,`uri`(190)),
 	 INDEX `resource-id` (`resource-id`),
 	 INDEX `deleted_changed` (`deleted`,`changed`),
@@ -813,7 +815,9 @@ CREATE TABLE IF NOT EXISTS `participation` (
 	`server` varchar(60) NOT NULL COMMENT '',
 	`cid` int unsigned NOT NULL COMMENT '',
 	`fid` int unsigned NOT NULL COMMENT '',
-	 PRIMARY KEY(`iid`,`server`)
+	 PRIMARY KEY(`iid`,`server`),
+	 INDEX `cid` (`cid`),
+	 INDEX `fid` (`fid`)
 ) DEFAULT COLLATE utf8mb4_general_ci COMMENT='Storage for participation messages from Diaspora';
 
 --
@@ -967,7 +971,8 @@ CREATE TABLE IF NOT EXISTS `profile` (
 	`publish` boolean NOT NULL DEFAULT '0' COMMENT 'publish default profile in local directory',
 	`net-publish` boolean NOT NULL DEFAULT '0' COMMENT 'publish profile in global directory',
 	 PRIMARY KEY(`id`),
-	 INDEX `uid_is-default` (`uid`,`is-default`)
+	 INDEX `uid_is-default` (`uid`,`is-default`),
+	 FULLTEXT INDEX `pub_keywords` (`pub_keywords`)
 ) DEFAULT COLLATE utf8mb4_general_ci COMMENT='user profiles data';
 
 --

--- a/src/Database/DBA.php
+++ b/src/Database/DBA.php
@@ -1239,7 +1239,7 @@ class DBA
 
 		foreach ($old_fields AS $fieldname => $content) {
 			if (isset($fields[$fieldname])) {
-				if ($fields[$fieldname] == $content) {
+				if (($fields[$fieldname] == $content) && !is_null($content)) {
 					unset($fields[$fieldname]);
 				} else {
 					$do_update = true;

--- a/src/Model/APContact.php
+++ b/src/Model/APContact.php
@@ -157,7 +157,7 @@ class APContact extends BaseObject
 
 		$apcontact['pubkey'] = trim(JsonLD::fetchElement($compacted, 'w3id:publicKey', 'w3id:publicKeyPem'));
 
-		$manually_approve = JsonLD::fetchElement($compacted, 'as:manuallyApprovesFollowers');
+		$apcontact['manually-approve'] = (int)JsonLD::fetchElement($compacted, 'as:manuallyApprovesFollowers');
 
 		// To-Do
 
@@ -204,8 +204,8 @@ class APContact extends BaseObject
 					$contact_fields['prv'] = false;
 				} else {
 					// Otherwise set the corresponding forum type
-					$contact_fields['forum'] = !$manually_approve;
-					$contact_fields['prv'] = $manually_approve;
+					$contact_fields['forum'] = !$apcontact['manually-approve'];
+					$contact_fields['prv'] = $apcontact['manually-approve'];
 				}
 			}
 		}


### PR DESCRIPTION
This fixes the automatic update routine and updates the database.sql file. Additionally now the "manually approve" data is now stored. It will possibly be used in the future to control whether we will wait for an approval request or not.