### PR TITLE
Avoid a notice in HTTP signature check, preparation for authentication

### DIFF
--- a/src/Module/Objects.php
+++ b/src/Module/Objects.php
@@ -9,6 +9,7 @@ use Friendica\Protocol\ActivityPub;
 use Friendica\Core\System;
 use Friendica\Model\Item;
 use Friendica\Database\DBA;
+use Friendica\Util\HTTPSignature;
 
 /**
  * ActivityPub Objects
@@ -26,6 +27,9 @@ class Objects extends BaseModule
 		if (!ActivityPub::isRequest()) {
 			$a->internalRedirect(str_replace('objects/', 'display/', $a->query_string));
 		}
+
+		/// @todo Add Authentication to enable fetching of non public content
+		// $requester = HTTPSignature::getSigner('', $_SERVER);
 
 		$item = Item::selectFirst(['id'], ['guid' => $a->argv[1], 'origin' => true, 'private' => false]);
 		if (!DBA::isResult($item)) {

--- a/src/Module/Outbox.php
+++ b/src/Module/Outbox.php
@@ -8,6 +8,7 @@ use Friendica\BaseModule;
 use Friendica\Protocol\ActivityPub;
 use Friendica\Core\System;
 use Friendica\Model\User;
+use Friendica\Util\HTTPSignature;
 
 /**
  * ActivityPub Outbox
@@ -28,6 +29,9 @@ class Outbox extends BaseModule
 		}
 
 		$page = defaults($_REQUEST, 'page', null);
+
+		/// @todo Add Authentication to enable fetching of non public content
+		// $requester = HTTPSignature::getSigner('', $_SERVER);
 
 		$outbox = ActivityPub\Transmitter::getOutbox($owner, $page);
 

--- a/src/Util/HTTPSignature.php
+++ b/src/Util/HTTPSignature.php
@@ -217,7 +217,7 @@ class HTTPSignature
 			$ret['signature'] = base64_decode(preg_replace('/\s+/', '', $matches[1]));
 		}
 
-		if (($ret['signature']) && ($ret['algorithm']) && (!$ret['headers'])) {
+		if (!empty($ret['signature']) && !empty($ret['algorithm']) && empty($ret['headers'])) {
 			$ret['headers'] = ['date'];
 		}
 
@@ -376,13 +376,20 @@ class HTTPSignature
 	 */
 	public static function getSigner($content, $http_headers)
 	{
-		$object = json_decode($content, true);
-
-		if (empty($object)) {
+		if (empty($http_headers['HTTP_SIGNATURE'])) {
 			return false;
 		}
 
-		$actor = JsonLD::fetchElement($object, 'actor', 'id');
+		if (!empty($content)) {
+			$object = json_decode($content, true);
+			if (empty($object)) {
+				return false;
+			}
+
+			$actor = JsonLD::fetchElement($object, 'actor', 'id');
+		} else {
+			$actor = '';
+		}
 
 		$headers = [];
 		$headers['(request-target)'] = strtolower($http_headers['REQUEST_METHOD']) . ' ' . $http_headers['REQUEST_URI'];


### PR DESCRIPTION
Prevent a notice during HTTP authentication. Additionally some preparation (as a reminder) is added so that in future it will be possible to fetch non public content as well.