### PR TITLE
This fixes a problem when the URL is too long

### DIFF
--- a/src/Util/Network.php
+++ b/src/Util/Network.php
@@ -96,6 +96,11 @@ class Network
 
 		$a = \get_app();
 
+		if (strlen($url) > 1000) {
+			Logger::log('URL is longer than 1000 characters. Callstack: ' . System::callstack(20), Logger::DEBUG);
+			return CurlResult::createErrorCurl(substr($url, 0, 200));
+		}
+
 		$parts = parse_url($url);
 		$path_parts = explode('/', defaults($parts, 'path', ''));
 		foreach ($path_parts as $part) {


### PR DESCRIPTION
This should address the issue that is described here: https://forum.friendi.ca/display/0b6b25a8-135c-3f9c-f2ed-e5c924980848

This adds logging and it will help not to flood the log file anymore.