### PR TITLE
use magic links for common/all friends and the directory

### DIFF
--- a/mod/allfriends.php
+++ b/mod/allfriends.php
@@ -77,7 +77,7 @@ function allfriends_content(App $a)
 		}
 
 		$entry = [
-			'url'          => $rr['url'],
+			'url'          => Model\Contact::magicLink($rr['url']),
 			'itemurl'      => defaults($contact_details, 'addr', $rr['url']),
 			'name'         => $contact_details['name'],
 			'thumb'        => ProxyUtils::proxifyUrl($contact_details['thumb'], false, ProxyUtils::SIZE_THUMB),

--- a/mod/common.php
+++ b/mod/common.php
@@ -117,7 +117,7 @@ function common_content(App $a)
 		$photo_menu = Model\Contact::photoMenu($common_friend);
 
 		$entry = [
-			'url'          => $common_friend['url'],
+			'url'          => Model\Contact::magicLink($common_friend['url']),
 			'itemurl'      => defaults($contact_details, 'addr', $common_friend['url']),
 			'name'         => $contact_details['name'],
 			'thumb'        => ProxyUtils::proxifyUrl($contact_details['thumb'], false, ProxyUtils::SIZE_THUMB),

--- a/mod/directory.php
+++ b/mod/directory.php
@@ -116,7 +116,7 @@ function directory_content(App $a)
 
 			$itemurl = (($rr['addr'] != "") ? $rr['addr'] : $rr['profile_url']);
 
-			$profile_link = 'profile/' . ((strlen($rr['nickname'])) ? $rr['nickname'] : $rr['profile_uid']);
+			$profile_link = $rr['profile_url'];
 
 			$pdesc = (($rr['pdesc']) ? $rr['pdesc'] . '<br />' : '');
 
@@ -169,7 +169,7 @@ function directory_content(App $a)
 
 			$entry = [
 				'id'           => $rr['id'],
-				'url'          => $profile_link,
+				'url'          => Contact::magicLInk($profile_link),
 				'itemurl'      => $itemurl,
 				'thumb'        => ProxyUtils::proxifyUrl($rr[$photo], false, ProxyUtils::SIZE_THUMB),
 				'img_hover'    => $rr['name'],

--- a/src/Content/Text/HTML.php
+++ b/src/Content/Text/HTML.php
@@ -889,7 +889,7 @@ class HTML
 	}
 
 	/**
-	 * @brief Format contacts as picture links or as texxt links
+	 * @brief Format contacts as picture links or as text links
 	 *
 	 * @param array $contact Array with contacts which contains an array with
 	 *	int 'id' => The ID of the contact

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -2089,7 +2089,7 @@ class Contact extends BaseObject
 	 */
 	public static function magicLink($contact_url, $url = '')
 	{
-		if (!local_user() && remote_user()) {
+		if (!local_user() && !remote_user()) {
 			return $url ?: $contact_url; // Equivalent to: ($url != '') ? $url : $contact_url;
 		}
 


### PR DESCRIPTION
Now the all friends, common friends and directory page uses also magic links to provide authentication.
In addition I fixed a bug in `Contact::magicLink()` which should also work know for remote users.

Follow-up to https://github.com/friendica/friendica/pull/6364