### PR TITLE
Transmit via BCC if contact is hidden, don't store announces

### DIFF
--- a/src/Protocol/ActivityPub/Receiver.php
+++ b/src/Protocol/ActivityPub/Receiver.php
@@ -332,7 +332,10 @@ class Receiver
 			return;
 		}
 
-		self::storeConversation($object_data, $body);
+		// Only store content related stuff - and no announces, since they possibly overwrite the original content
+		if (in_array($object_data['object_type'], self::CONTENT_TYPES) && ($type != 'as:Announce')) {
+			self::storeConversation($object_data, $body);
+		}
 
 		// Internal flag for thread completion. See Processor.php
 		if (!empty($activity['thread-completion'])) {


### PR DESCRIPTION
I just found some "last minute" error while storing conversations: A received reshare had overwritten the original content.

Additionally I added the functionality to send receivers via BCC when the profile setting tells that the friend list is hidden or when the specific contact is hidden.