### PR TITLE
Move theme init after module init but before post/content

### DIFF
--- a/mod/admin.php
+++ b/mod/admin.php
@@ -34,6 +34,21 @@ use Friendica\Util\Strings;
 use Friendica\Util\Temporal;
 
 /**
+ * Sets the current theme for theme settings pages. This needs to be done before the post() or content() are called
+ *
+ * @param App $a
+ */
+function admin_init(App $a)
+{
+	if ($a->argc > 2 && $a->argv[1] == 'themes') {
+		$theme = $a->argv[2];
+		if (is_file("view/theme/$theme/config.php")) {
+			$a->setCurrentTheme($theme);
+		}
+	}
+}
+
+/**
  * @brief Process send data from the admin panels subpages
  *
  * This function acts as relay for processing the data send from the subpages
@@ -89,15 +104,8 @@ function admin_post(App $a)
 
 				$theme = $a->argv[2];
 				if (is_file("view/theme/$theme/config.php")) {
-					$a->setCurrentTheme($theme);
-
-					require_once "view/theme/$theme/theme.php";
 					require_once "view/theme/$theme/config.php";
 
-					$init = $theme . '_init';
-					if (function_exists($init)) {
-						$init($a);
-					}
 					if (function_exists('theme_admin_post')) {
 						theme_admin_post($a);
 					}
@@ -2306,15 +2314,7 @@ function admin_page_themes(App $a)
 
 		$admin_form = '';
 		if (is_file("view/theme/$theme/config.php")) {
-			$a->setCurrentTheme($theme);
-
-			require_once "view/theme/$theme/theme.php";
 			require_once "view/theme/$theme/config.php";
-
-			$init = $theme . "_init";
-			if (function_exists($init)) {
-				$init($a);
-			}
 
 			if (function_exists('theme_admin')) {
 				$admin_form = theme_admin($a);

--- a/mod/admin.php
+++ b/mod/admin.php
@@ -34,7 +34,9 @@ use Friendica\Util\Strings;
 use Friendica\Util\Temporal;
 
 /**
- * Sets the current theme for theme settings pages. This needs to be done before the post() or content() are called
+ * Sets the current theme for theme settings pages.
+ *
+ * This needs to be done before the post() or content() methods are called.
  *
  * @param App $a
  */

--- a/src/App.php
+++ b/src/App.php
@@ -1728,6 +1728,12 @@ class App
 			Core\Addon::callHooks($this->module . '_mod_init', $placeholder);
 
 			call_user_func([$this->module_class, 'init']);
+
+			// "rawContent" is especially meant for technical endpoints.
+			// This endpoint doesn't need any theme initialization or other comparable stuff.
+			if (!$this->error) {
+				call_user_func([$this->module_class, 'rawContent']);
+			}
 		}
 
 		// Load current theme info after module has been initialized as theme could have been set in module
@@ -1742,12 +1748,6 @@ class App
 		}
 
 		if ($this->module_loaded) {
-			// "rawContent" is especially meant for technical endpoints.
-			// This endpoint doesn't need any theme initialization or other comparable stuff.
-			if (!$this->error) {
-				call_user_func([$this->module_class, 'rawContent']);
-			}
-
 			if (! $this->error && $_SERVER['REQUEST_METHOD'] === 'POST') {
 				Core\Addon::callHooks($this->module . '_mod_post', $_POST);
 				call_user_func([$this->module_class, 'post']);

--- a/view/theme/frio/theme.php
+++ b/view/theme/frio/theme.php
@@ -22,25 +22,16 @@ use Friendica\Model;
 use Friendica\Module;
 use Friendica\Util\Strings;
 
-$frio = 'view/theme/frio';
-
-global $frio;
-
 function frio_init(App $a)
 {
+	global $frio;
+	$frio = 'view/theme/frio';
+
 	// disable the events module link in the profile tab
 	$a->theme_events_in_profile = false;
 	$a->videowidth = 622;
 
 	Renderer::setActiveTemplateEngine('smarty3');
-
-	$baseurl = System::baseUrl();
-
-	$style = PConfig::get(local_user(), 'frio', 'style');
-
-	$frio = 'view/theme/frio';
-
-	global $frio;
 
 	// if the device is a mobile device set js is_mobile
 	// variable so the js scripts can use this information
@@ -50,10 +41,6 @@ function frio_init(App $a)
 				var is_mobile = 1;
 			</script>
 EOT;
-	}
-
-	if ($style == '') {
-		$style = Config::get('frio', 'style');
 	}
 }
 


### PR DESCRIPTION
Fixes #5092 again
Doesn't break #6384 again
Follow-up to #6465
Last PR of 2019.01 (hopefully)

The final solution to the chicken-egg problem of setting the theme in modules but themes having an effect over modules has been to initialize the theme after the module has initialized but before the content has been processed.

This means theme selection can only be done in the module initialization, which was already the case except in #6340. This case has been simply moved in a newly created `admin_init()` function in `mod/admin.php`.