### PR TITLE
HTML unescape existing albums

### DIFF
--- a/view/templates/photos_upload.tpl
+++ b/view/templates/photos_upload.tpl
@@ -14,7 +14,7 @@
 	<div id="photos-upload-exist-wrapper">
 		<div id="photos-upload-existing-album-text">{{$existalbumtext}}</div>
 		<select id="photos-upload-album-select" name="album" size="4">
-		{{$albumselect}}
+		{{$albumselect  nofilter}}
 		</select>
 	</div>
 	<div id="photos-upload-exist-end"></div>

--- a/view/theme/frio/templates/photos_upload.tpl
+++ b/view/theme/frio/templates/photos_upload.tpl
@@ -9,7 +9,7 @@
 			<label id="photos-upload-text" for="photos-upload-newalbum" >{{$newalbum}}</label>
 
 			<input id="photos-upload-album-select" class="form-control" placeholder="{{$existalbumtext}}" list="dl-photo-upload" type="text" name="album" size="4">
-			<datalist id="dl-photo-upload">{{$albumselect}}</datalist>
+			<datalist id="dl-photo-upload">{{$albumselect  nofilter}}</datalist>
 		</div>
 		<div id="photos-upload-end" class="clearfix"></div>
 


### PR DESCRIPTION
When uploading a new photo the selection list for choosing existing albums was not shown. With this PR it is now again.

Part of #6208