### PR TITLE
AP: Only reshare stuff that is AP content

### DIFF
--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -553,10 +553,7 @@ class Transmitter
 		// Only check for a reshare, if it is a real reshare and no quoted reshare
 		if (strpos($item['body'], "[share") === 0) {
 			$announce = api_share_as_retweet($item);
-			if (!empty($announce['plink'])) {
-				$data = ActivityPub::fetchContent($announce['plink'], $item['uid']);
-				$reshared = !empty($data);
-			}
+			$reshared = !empty($announce['plink']);
 		}
 
 		if ($reshared) {

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -755,7 +755,8 @@ class Transmitter
 		$terms = Term::tagArrayFromItemId($item['id']);
 		foreach ($terms as $term) {
 			if ($term['type'] == TERM_HASHTAG) {
-				$tags[] = ['type' => 'Hashtag', 'href' => $term['url'], 'name' => '#' . $term['term']];
+				$url = System::baseUrl() . '/search?tag=' . urlencode($term['term']);
+				$tags[] = ['type' => 'Hashtag', 'href' => $url, 'name' => '#' . $term['term']];
 			} elseif ($term['type'] == TERM_MENTION) {
 				$contact = Contact::getDetailsByURL($term['url']);
 				if (!empty($contact['addr'])) {

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -1029,8 +1029,17 @@ class Transmitter
 			return self::createNote($item);
 		}
 
-		/// @todo Better fetch the real object url.
-		return $announce['plink'];
+		// Fetch the original id of the object
+		$activity = ActivityPub::fetchContent($announce['plink'], $item['uid']);
+		if (!empty($activity)) {
+			$ldactivity = JsonLD::compact($activity);
+			$id = JsonLD::fetchElement($ldactivity, '@id');
+			if (!empty($id)) {
+				return $id;
+			}
+		}
+
+		return self::createNote($item);
 	}
 
 	/**


### PR DESCRIPTION
Today I realized that we currently do have problems with sending reshared content. This fixes it partly. In the next release we will improve it.