### PR TITLE
unescaping the HTML in the hint

### DIFF
--- a/view/templates/admin/federation.tpl
+++ b/view/templates/admin/federation.tpl
@@ -6,7 +6,7 @@
 	<p>{{$intro}}</p>
 
 	{{if not $autoactive}}
-	<p class="error-message">{{$hint}}</p>
+	<p class="error-message">{{$hint nofilter}}</p>
 	{{/if}}
 
 	<p>{{$legendtext}}</p>


### PR DESCRIPTION
If the "Auto Discovered Contact Directory" feature is disabled a hint is displayed at the Federation Stats page of the Adminpanel. This hint contains HTML formatting, which was wrongly escaped.

Part of #6208