### PR TITLE
Fix: Connector posts now do work again (postopts hadn't been stored)

### DIFF
--- a/src/Model/ItemDeliveryData.php
+++ b/src/Model/ItemDeliveryData.php
@@ -31,7 +31,7 @@ class ItemDeliveryData
 	public static function extractFields(array &$fields)
 	{
 		$delivery_data = [];
-		foreach (ItemDeliveryData::FIELD_LIST as $key => $field) {
+		foreach (array_merge(ItemDeliveryData::FIELD_LIST, ItemDeliveryData::LEGACY_FIELD_LIST) as $key => $field) {
 			if (is_int($key) && isset($fields[$field])) {
 				// Legacy field moved from item table
 				$delivery_data[$field] = $fields[$field];


### PR DESCRIPTION
Because that field hadn't been stored, no delivery had been executed at all.