### PR TITLE
BBCode - added preg_replaces for local [url] links without target="_blank"

### DIFF
--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -1370,7 +1370,7 @@ class BBCode extends BaseObject
 		$text = preg_replace("/\[url\](\/[$URLSearchString]*)\[\/url\]/ism", '<a href="'.System::baseUrl().'$1">$1</a>', $text);
 		$text = preg_replace("/\[url\=(\/[$URLSearchString]*)\](.*?)\[\/url\]/ism", '<a href="'.System::baseUrl().'$1">$2</a>', $text);		
 
-        $text = preg_replace("/\[url\]([$URLSearchString]*)\[\/url\]/ism", '<a href="$1" target="_blank">$1</a>', $text);
+		$text = preg_replace("/\[url\]([$URLSearchString]*)\[\/url\]/ism", '<a href="$1" target="_blank">$1</a>', $text);
 		$text = preg_replace("/\[url\=([$URLSearchString]*)\](.*?)\[\/url\]/ism", '<a href="$1" target="_blank">$2</a>', $text);
 
 		// Red compatibility, though the link can't be authenticated on Friendica

--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -1361,7 +1361,16 @@ class BBCode extends BaseObject
 				. '</a>';
 		}, $text);
 
-		$text = preg_replace("/\[url\]([$URLSearchString]*)\[\/url\]/ism", '<a href="$1" target="_blank">$1</a>', $text);
+		// We need no target="_blank" for local links
+		// convert links start with System::baseUrl() as local link
+		$escapedBaseUrl = str_replace('://', '\:\/\/', System::baseUrl());
+		$text = preg_replace("/\[url\]($escapedBaseUrl)([$URLSearchString]*)\[\/url\]/ism", '<a href="$1$2">$1$2</a>', $text);
+		$text = preg_replace("/\[url\=($escapedBaseUrl)([$URLSearchString]*)\](.*?)\[\/url\]/ism", '<a href="$1$2">$3</a>', $text);		
+		// convert links that start with / as local link
+		$text = preg_replace("/\[url\](\/[$URLSearchString]*)\[\/url\]/ism", '<a href="'.System::baseUrl().'$1">$1</a>', $text);
+		$text = preg_replace("/\[url\=(\/[$URLSearchString]*)\](.*?)\[\/url\]/ism", '<a href="'.System::baseUrl().'$1">$2</a>', $text);		
+
+        $text = preg_replace("/\[url\]([$URLSearchString]*)\[\/url\]/ism", '<a href="$1" target="_blank">$1</a>', $text);
 		$text = preg_replace("/\[url\=([$URLSearchString]*)\](.*?)\[\/url\]/ism", '<a href="$1" target="_blank">$2</a>', $text);
 
 		// Red compatibility, though the link can't be authenticated on Friendica


### PR DESCRIPTION
it recognizes URLs that start with System::baseUrl() or such that start with a /
In this cases it creates an <a> tag without the target="_blank" attribute