### PR TITLE
added nofilter to banner in smoothy and quaddro

### DIFF
--- a/view/theme/quattro/templates/nav.tpl
+++ b/view/theme/quattro/templates/nav.tpl
@@ -2,7 +2,7 @@
 	{{* {{$langselector}} *}}
 
 	<div id="site-location">{{$sitelocation}}</div>
-	<div id="banner">{{$banner}}</div>
+	<div id="banner">{{$banner nofilter}}</div>
 </header>
 <nav>
 	<ul>

--- a/view/theme/smoothly/templates/nav.tpl
+++ b/view/theme/smoothly/templates/nav.tpl
@@ -1,6 +1,6 @@
 
 <nav>
-	<span id="banner">{{$banner}}</span>
+	<span id="banner">{{$banner nofilter}}</span>
 
 	<div id="notifications">	
 		{{if $nav.network}}<a id="net-update" class="nav-ajax-update" href="{{$nav.network.0}}" title="{{$nav.network.1}}"></a>{{/if}}


### PR DESCRIPTION
Joe Slam [reported](https://forum.friendi.ca/display/6036f0c5-105c-4b53-437b-a7c338698533) that the banner in the Quattro and Smoothy themes needs an added `nofilter?.