### PR TITLE
Switch to supported HTML entity for bullet in delivery indicator

### DIFF
--- a/view/templates/sub/delivery_count.tpl
+++ b/view/templates/sub/delivery_count.tpl
@@ -4,7 +4,7 @@
 *}}
 {{if $delivery.queue_count >= -1 && $delivery.queue_count !== '' && $delivery.queue_count !== null}}
 <span class="delivery">
-	&bullet;
+	&bull;
 	{{if $delivery.queue_count == 0}}
 		{{$delivery.notifier_pending}}
 	{{elseif $delivery.queue_done == 0}}

--- a/view/theme/frio/templates/sub/delivery_count.tpl
+++ b/view/theme/frio/templates/sub/delivery_count.tpl
@@ -1,6 +1,6 @@
 {{if $delivery.queue_count >= -1 && $delivery.queue_count !== '' && $delivery.queue_count !== null}}
 <span class="delivery">
-	&bullet;
+	&bull;
 	{{if $delivery.queue_count == 0}}
 		<i class="fa fa-hourglass-o" aria-hidden="true" title="{{$delivery.notifier_pending}}"></i>
 		<span class="sr-only">{{$delivery.notifier_pending}}</span>

--- a/view/theme/vier/templates/sub/delivery_count.tpl
+++ b/view/theme/vier/templates/sub/delivery_count.tpl
@@ -1,6 +1,6 @@
 {{if $delivery.queue_count >= -1 && $delivery.queue_count !== '' && $delivery.queue_count !== null}}
 <span class="delivery">
-	&bullet;
+	&bull;
 	{{if $delivery.queue_count == 0}}
 		<i class="icon-spinner" aria-hidden="true" title="{{$delivery.notifier_pending}}"></i>
 		<span class="sr-only">{{$delivery.notifier_pending}}</span>


### PR DESCRIPTION
Fixes #6514

It turns out that our way of outputting raw HTML requests (like the `/network` call in the infinite scroll mode) converts `&bullet;`, a valid HTML entity, into `&amp;bullet;` while `&bull;` isn't escaped.

Maybe the HTML parser of the PHP DOMDocument library is just really old.