### PR TITLE
Another preparation for forum posts via AP

### DIFF
--- a/src/Worker/Notifier.php
+++ b/src/Worker/Notifier.php
@@ -603,15 +603,20 @@ class Notifier
 			return false;
 		}
 
+		return self::isForum($item['contact-id']);
+	}
+
+	private static function isForum($contactid)
+	{
 		$fields = ['forum', 'prv'];
-		$condition = ['id' => $item['contact-id']];
+		$condition = ['id' => $contactid];
 		$contact = DBA::selectFirst('contact', $fields, $condition);
 		if (!DBA::isResult($contact)) {
 			// Should never happen
 			return false;
 		}
 
-		// Is the post from a forum?
+		// Is it a forum?
 		return ($contact['forum'] || $contact['prv']);
 	}
 }


### PR DESCRIPTION
Next step towards the forum support over AP. Forum posts are now distributed as reshared items over AP. Currently this will not affect the direct Friendica-Friendica communication. initial Forum posts are currently sent via DFRN.