### PR TITLE
Logger Unique ID

### DIFF
--- a/src/Util/Logger/FriendicaIntrospectionProcessor.php
+++ b/src/Util/Logger/FriendicaIntrospectionProcessor.php
@@ -11,7 +11,7 @@ use Monolog\Processor\ProcessorInterface;
  * Based on the class IntrospectionProcessor without the "class" information
  * @see IntrospectionProcessor
  */
-class FriendicaProcessor implements ProcessorInterface
+class FriendicaIntrospectionProcessor implements ProcessorInterface
 {
 	private $level;
 

--- a/src/Util/Logger/FriendicaProcessor.php
+++ b/src/Util/Logger/FriendicaProcessor.php
@@ -48,19 +48,7 @@ class FriendicaProcessor implements ProcessorInterface
 		$i = 1;
 
 		while ($this->isTraceClassOrSkippedFunction($trace, $i)) {
-			if (isset($trace[$i]['class'])) {
-				foreach ($this->skipClassesPartials as $part) {
-					if (strpos($trace[$i]['class'], $part) !== false) {
-						$i++;
-						continue 2;
-					}
-				}
-			} elseif (in_array($trace[$i]['function'], $this->skipFunctions)) {
-				$i++;
-				continue;
-			}
-
-			break;
+			$i++;
 		}
 
 		$i += $this->skipStackFramesCount;
@@ -78,12 +66,29 @@ class FriendicaProcessor implements ProcessorInterface
 		return $record;
 	}
 
+	/**
+	 * Checks if the current trace class or function has to be skipped
+	 *
+	 * @param array $trace The current trace array
+	 * @param int   $index The index of the current hierarchy level
+	 * @return bool True if the class or function should get skipped, otherwise false
+	 */
 	private function isTraceClassOrSkippedFunction(array $trace, $index)
 	{
 		if (!isset($trace[$index])) {
 			return false;
 		}
 
-		return isset($trace[$index]['class']) || in_array($trace[$index]['function'], $this->skipFunctions);
+		if (isset($trace[$index]['class'])) {
+			foreach ($this->skipClassesPartials as $part) {
+				if (strpos($trace[$index]['class'], $part) !== false) {
+					return true;
+				}
+			}
+		} elseif (in_array($trace[$index]['function'], $this->skipFunctions)) {
+			return true;
+		}
+
+		return false;
 	}
 }

--- a/src/Util/Logger/FriendicaProcessor.php
+++ b/src/Util/Logger/FriendicaProcessor.php
@@ -29,7 +29,7 @@ class FriendicaProcessor implements ProcessorInterface
 	 * @param array $skipClassesPartials An array of classes to skip during logging
 	 * @param int $skipStackFramesCount If the logger should use information from other hierarchy levels of the call
 	 */
-	public function __construct($level = Logger::DEBUG, array $skipClassesPartials = array(), $skipStackFramesCount = 0)
+	public function __construct($level = Logger::DEBUG, $skipClassesPartials = array(), $skipStackFramesCount = 0)
 	{
 		$this->level = Logger::toMonologLevel($level);
 		$this->skipClassesPartials = array_merge(array('Monolog\\'), $skipClassesPartials);

--- a/src/Util/LoggerFactory.php
+++ b/src/Util/LoggerFactory.php
@@ -29,7 +29,7 @@ class LoggerFactory
 		$logger->pushProcessor(new Monolog\Processor\PsrLogMessageProcessor());
 		$logger->pushProcessor(new Monolog\Processor\ProcessIdProcessor());
 		$logger->pushProcessor(new Monolog\Processor\UidProcessor());
-		$logger->pushProcessor(new FriendicaProcessor(LogLevel::DEBUG, ['Friendica\Core\Logger']));
+		$logger->pushProcessor(new FriendicaProcessor(LogLevel::DEBUG, ['Friendica\\Core\\Logger']));
 
 		return $logger;
 	}
@@ -53,7 +53,7 @@ class LoggerFactory
 		$logger->pushProcessor(new Monolog\Processor\PsrLogMessageProcessor());
 		$logger->pushProcessor(new Monolog\Processor\ProcessIdProcessor());
 		$logger->pushProcessor(new Monolog\Processor\UidProcessor());
-		$logger->pushProcessor(new FriendicaProcessor(LogLevel::DEBUG, ['Friendica\Core\Logger']));
+		$logger->pushProcessor(new FriendicaProcessor(LogLevel::DEBUG, ['Friendica\\Core\\Logger']));
 
 
 		$logger->pushHandler(new FriendicaDevelopHandler($developerIp));

--- a/src/Util/LoggerFactory.php
+++ b/src/Util/LoggerFactory.php
@@ -28,7 +28,8 @@ class LoggerFactory
 		$logger = new Monolog\Logger($channel);
 		$logger->pushProcessor(new Monolog\Processor\PsrLogMessageProcessor());
 		$logger->pushProcessor(new Monolog\Processor\ProcessIdProcessor());
-		$logger->pushProcessor(new FriendicaProcessor(LogLevel::DEBUG, 1));
+		$logger->pushProcessor(new Monolog\Processor\UidProcessor());
+		$logger->pushProcessor(new FriendicaProcessor(LogLevel::DEBUG, ['Friendica\Core\Logger']));
 
 		return $logger;
 	}
@@ -51,7 +52,8 @@ class LoggerFactory
 		$logger = new Monolog\Logger($channel);
 		$logger->pushProcessor(new Monolog\Processor\PsrLogMessageProcessor());
 		$logger->pushProcessor(new Monolog\Processor\ProcessIdProcessor());
-		$logger->pushProcessor(new FriendicaProcessor(LogLevel::DEBUG, 1));
+		$logger->pushProcessor(new Monolog\Processor\UidProcessor());
+		$logger->pushProcessor(new FriendicaProcessor(LogLevel::DEBUG, ['Friendica\Core\Logger']));
 
 
 		$logger->pushHandler(new FriendicaDevelopHandler($developerIp));

--- a/src/Util/LoggerFactory.php
+++ b/src/Util/LoggerFactory.php
@@ -4,7 +4,7 @@ namespace Friendica\Util;
 
 use Friendica\Network\HTTPException\InternalServerErrorException;
 use Friendica\Util\Logger\FriendicaDevelopHandler;
-use Friendica\Util\Logger\FriendicaProcessor;
+use Friendica\Util\Logger\FriendicaIntrospectionProcessor;
 use Monolog;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
@@ -29,7 +29,7 @@ class LoggerFactory
 		$logger->pushProcessor(new Monolog\Processor\PsrLogMessageProcessor());
 		$logger->pushProcessor(new Monolog\Processor\ProcessIdProcessor());
 		$logger->pushProcessor(new Monolog\Processor\UidProcessor());
-		$logger->pushProcessor(new FriendicaProcessor(LogLevel::DEBUG, ['Friendica\\Core\\Logger']));
+		$logger->pushProcessor(new FriendicaIntrospectionProcessor(LogLevel::DEBUG, ['Friendica\\Core\\Logger']));
 
 		return $logger;
 	}
@@ -53,7 +53,7 @@ class LoggerFactory
 		$logger->pushProcessor(new Monolog\Processor\PsrLogMessageProcessor());
 		$logger->pushProcessor(new Monolog\Processor\ProcessIdProcessor());
 		$logger->pushProcessor(new Monolog\Processor\UidProcessor());
-		$logger->pushProcessor(new FriendicaProcessor(LogLevel::DEBUG, ['Friendica\\Core\\Logger']));
+		$logger->pushProcessor(new FriendicaIntrospectionProcessor(LogLevel::DEBUG, ['Friendica\\Core\\Logger']));
 
 
 		$logger->pushHandler(new FriendicaDevelopHandler($developerIp));


### PR DESCRIPTION
FollowUp #6510 
Bugfixing #6508 

- Adding an UniqueId per call
- Bugfixing that "skipFrameCount" didn't work (I forgot one line)

Is this enough information for now @annando ?
The only problem currently is that an unique id is generated per execution, meaning that manually calling an worker wouldn't generate a new ID.
I could accomplish this with a additionally generated "worker-id".

But I suggest merging this PR first because I need some additional code for the worker-id which I don't want to add to this PR.