### PR TITLE
Rename conflicted variable $info in admin settings

### DIFF
--- a/mod/admin.php
+++ b/mod/admin.php
@@ -1104,7 +1104,7 @@ function admin_page_site_post(App $a)
 	$banner           = (!empty($_POST['banner'])           ? trim($_POST['banner'])                             : false);
 	$shortcut_icon    = (!empty($_POST['shortcut_icon'])    ? Strings::escapeTags(trim($_POST['shortcut_icon'])) : '');
 	$touch_icon       = (!empty($_POST['touch_icon'])       ? Strings::escapeTags(trim($_POST['touch_icon']))    : '');
-	$info             = (!empty($_POST['info'])             ? trim($_POST['info'])                               : false);
+	$additional_info  = (!empty($_POST['additional_info'])  ? trim($_POST['additional_info'])                    : '');
 	$language         = (!empty($_POST['language'])         ? Strings::escapeTags(trim($_POST['language']))      : '');
 	$theme            = (!empty($_POST['theme'])            ? Strings::escapeTags(trim($_POST['theme']))         : '');
 	$theme_mobile     = (!empty($_POST['theme_mobile'])     ? Strings::escapeTags(trim($_POST['theme_mobile']))  : '');
@@ -1300,10 +1300,10 @@ function admin_page_site_post(App $a)
 		Config::set('system', 'banner', $banner);
 	}
 
-	if (empty($info)) {
+	if (empty($additional_info)) {
 		Config::delete('config', 'info');
 	} else {
-		Config::set('config', 'info', $info);
+		Config::set('config', 'info', $additional_info);
 	}
 	Config::set('system', 'language', $language);
 	Config::set('system', 'theme', $theme);
@@ -1501,7 +1501,7 @@ function admin_page_site(App $a)
 		$banner = '<a href="https://friendi.ca"><img id="logo-img" src="images/friendica-32.png" alt="logo" /></a><span id="logo-text"><a href="https://friendi.ca">Friendica</a></span>';
 	}
 
-	$info = Config::get('config', 'info');
+	$additional_info = Config::get('config', 'info');
 
 	// Automatically create temporary paths
 	get_temppath();
@@ -1594,7 +1594,7 @@ function admin_page_site(App $a)
 		'$banner'           => ['banner', L10n::t("Banner/Logo"), $banner, ""],
 		'$shortcut_icon'    => ['shortcut_icon', L10n::t("Shortcut icon"), Config::get('system', 'shortcut_icon'), L10n::t("Link to an icon that will be used for browsers.")],
 		'$touch_icon'       => ['touch_icon', L10n::t("Touch icon"), Config::get('system', 'touch_icon'), L10n::t("Link to an icon that will be used for tablets and mobiles.")],
-		'$info'             => ['info', L10n::t('Additional Info'), $info, L10n::t('For public servers: you can add additional information here that will be listed at %s/servers.', get_server())],
+		'$additional_info'  => ['additional_info', L10n::t('Additional Info'), $additional_info, L10n::t('For public servers: you can add additional information here that will be listed at %s/servers.', get_server())],
 		'$language'         => ['language', L10n::t("System language"), Config::get('system', 'language'), "", $lang_choices],
 		'$theme'            => ['theme', L10n::t("System theme"), Config::get('system', 'theme'), L10n::t("Default system theme - may be over-ridden by user profiles - <a href='#' id='cnftheme'>change theme settings</a>"), $theme_choices],
 		'$theme_mobile'     => ['theme_mobile', L10n::t("Mobile system theme"), Config::get('system', 'mobile-theme', '---'), L10n::t("Theme for mobile devices"), $theme_choices_mobile],

--- a/view/templates/admin/site.tpl
+++ b/view/templates/admin/site.tpl
@@ -51,7 +51,7 @@
 	{{include file="field_textarea.tpl" field=$banner}}
 	{{include file="field_input.tpl" field=$shortcut_icon}}
 	{{include file="field_input.tpl" field=$touch_icon}}
-	{{include file="field_textarea.tpl" field=$info}}
+	{{include file="field_textarea.tpl" field=$additional_info}}
 	{{include file="field_select.tpl" field=$language}}
 	{{include file="field_select.tpl" field=$theme}}
 	{{include file="field_select.tpl" field=$theme_mobile}}

--- a/view/theme/frio/templates/admin/site.tpl
+++ b/view/theme/frio/templates/admin/site.tpl
@@ -80,7 +80,7 @@
 					{{include file="field_textarea.tpl" field=$banner}}
 					{{include file="field_input.tpl" field=$shortcut_icon}}
 					{{include file="field_input.tpl" field=$touch_icon}}
-					{{include file="field_textarea.tpl" field=$info}}
+					{{include file="field_textarea.tpl" field=$additional_info}}
 					{{include file="field_select.tpl" field=$language}}
 					{{include file="field_select.tpl" field=$theme}}
 					{{include file="field_select.tpl" field=$theme_mobile}}


### PR DESCRIPTION
Follow-up to #6180

A variable used by the storage backend setting was overwriting the variable used for setting the server description, clearing it inadvertently. Thanks @copiis for the report!

See: https://forum.friendi.ca/display/00d81f2c-175c-4f08-0b80-a8c279210744