### PR TITLE
Fixed some bugs with weird tagging in [code] blocks and tagging of multiple ##

### DIFF
--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -1178,7 +1178,7 @@ class BBCode extends BaseObject
 		// Extracting multi-line code blocks before the whitespace processing
 		$codeblocks = [];
 
-		$text = preg_replace_callback("#\[code(?:=([^\]]*))?\](.*?)\[\/code\]#is",
+		$text = preg_replace_callback("#\[code(?:=([^\]]*))?\](.*?)\[\/code\]#ism",
 			function ($matches) use (&$codeblocks) {
 				$return = $matches[0];
 				if (strpos($matches[2], "\n") !== false) {

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -2441,22 +2441,20 @@ class Item extends BaseObject
 				"&num;$2", $item["body"]);
 
 		foreach ($tags as $tag) {
-			if ((strpos($tag, '#') !== 0) || strpos($tag, '[url=')) {
+			if ((strpos($tag, '#') !== 0) || strpos($tag, '[url=') || $tag[1] == '#') {
 				continue;
 			}
 
 			$basetag = str_replace('_',' ',substr($tag,1));
-			if($basetag[0] != '#') { 
-				$newtag = '#[url=' . System::baseUrl() . '/search?tag=' . $basetag . ']' . $basetag . '[/url]';
+			$newtag = '#[url=' . System::baseUrl() . '/search?tag=' . $basetag . ']' . $basetag . '[/url]';
 
-				$item["body"] = str_replace($tag, $newtag, $item["body"]);
+			$item["body"] = str_replace($tag, $newtag, $item["body"]);
 
-				if (!stristr($item["tag"], "/search?tag=" . $basetag . "]" . $basetag . "[/url]")) {
-					if (strlen($item["tag"])) {
-						$item["tag"] = ',' . $item["tag"];
-					}
-					$item["tag"] = $newtag . $item["tag"];
+			if (!stristr($item["tag"], "/search?tag=" . $basetag . "]" . $basetag . "[/url]")) {
+				if (strlen($item["tag"])) {
+					$item["tag"] = ',' . $item["tag"];
 				}
+				$item["tag"] = $newtag . $item["tag"];
 			}
 		}
 

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -2472,9 +2472,6 @@ class Item extends BaseObject
 				$replace = ['#', '['];
 				return ("[code" . str_replace($find, $replace, $match[1]) . "]" . $match[2] . "[/code]");
 			}, $item["body"]);
-
-		// Convert back the masked hashtags
-		$item["body"] = str_replace("&num;", "#", $item["body"]);
 	}
 
 	public static function getGuidById($id)

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -2387,6 +2387,17 @@ class Item extends BaseObject
 	public static function setHashtags(&$item)
 	{
 
+		// What happens in [code], stays in [code]!
+		// escape the # and the [
+		// hint: we will also get in trouble with #tags, when we want markdown in posts -> ### Headline 3
+		$item["body"] = preg_replace_callback("/\[code(.*)\](.*?)\[\/code\]/ism",
+			function ($match) {
+				// we truly ESCape all # and [ to prevent gettin weird tags in [code] blocks
+				$find = ['#', '['];
+				$replace = [chr(27).'sharp', chr(27).'leftsquarebracket'];
+				return ("[code" . str_replace($find, $replace, $match[1]) . "]" . $match[2] . "[/code]");
+			}, $item["body"]);
+		
 		$tags = BBCode::getTags($item["body"]);
 
 		// No hashtags?
@@ -2400,17 +2411,6 @@ class Item extends BaseObject
 
 		$URLSearchString = "^\[\]";
 
-		// What happens in [code], stays in [code]!
-		// escape the # and the [
-		// hint: we will also get in trouble with #tags, when we want markdown in posts -> ### Headline 3
-		$item["body"] = preg_replace_callback("/\[code(.*)\](.*?)\[\/code\]/ism",
-			function ($match) {
-				// we truly ESCape all # and [ to prevent gettin weird tags in [code] blocks
-				$find = ['#', '['];
-				$replace = [chr(27).'sharp', chr(27).'leftsquarebracket'];
-				return ("[code" . str_replace($find, $replace, $match[1]) . "]" . $match[2] . "[/code]");
-			}, $item["body"]);
-		
 		// All hashtags should point to the home server if "local_tags" is activated
 		if (Config::get('system', 'local_tags')) {
 			$item["body"] = preg_replace("/#\[url\=([$URLSearchString]*)\](.*?)\[\/url\]/ism",


### PR DESCRIPTION
I dont get, how the `// Extracting multi-line code blocks before the whitespace processing` in BBCode.php:1178 could ever work, since it didnt use the m option?!

In Item::setHashTag() the [code] blocks werent processed at all.
I did some fancy ESCaping on it before tagging and unESCaped it right after.