### PR TITLE
warn in admin panel when legacy config is used

### DIFF
--- a/mod/admin.php
+++ b/mod/admin.php
@@ -936,7 +936,7 @@ function admin_page_summary(App $a)
 		$showwarning = true;
 		$warningtext[] = L10n::t('Friendica\'s configuration now is stored in config/local.config.php, please copy config/local-sample.config.php and move your config from <code>.htconfig.php</code>. See <a href="%s">the Config help page</a> for help with the transition.', $a->getBaseURL() . '/help/Config');
 	}
-	if (file_exists('local.ini.php')) {
+	if (file_exists('config/local.ini.php')) {
 		$showwarning = true;
 		$warningtext[] = L10n::t('Friendica\'s configuration now is stored in config/local.config.php, please copy config/local-sample.config.php and move your config from <code>config/local.ini.php</code>. See <a href="%s">the Config help page</a> for help with the transition.', $a->getBaseURL() . '/help/Config');
 	}

--- a/mod/admin.php
+++ b/mod/admin.php
@@ -936,6 +936,10 @@ function admin_page_summary(App $a)
 		$showwarning = true;
 		$warningtext[] = L10n::t('Friendica\'s configuration now is stored in config/local.config.php, please copy config/local-sample.config.php and move your config from <code>.htconfig.php</code>. See <a href="%s">the Config help page</a> for help with the transition.', $a->getBaseURL() . '/help/Config');
 	}
+	if (file_exists('local.ini.php')) {
+		$showwarning = true;
+		$warningtext[] = L10n::t('Friendica\'s configuration now is stored in config/local.config.php, please copy config/local-sample.config.php and move your config from <code>config/local.ini.php</code>. See <a href="%s">the Config help page</a> for help with the transition.', $a->getBaseURL() . '/help/Config');
+	}
 
 	// Check server vitality
 	if (!admin_page_server_vital()) {


### PR DESCRIPTION
If any legacy config model is used, a warning should be displayed in the admin panel about it.

This was already the case for the `.htconfig.php` file bug `config/local.ini.php` was not detected. With this PR this detection is now enabled as well and the admin notified.