### PR TITLE
Wrong constant used in docs

### DIFF
--- a/doc/Config.md
+++ b/doc/Config.md
@@ -242,7 +242,7 @@ register_policty = REGISTER_CLOSED
 </pre></td>
         			<td><pre>
 'config' => [
-    'register_policty' => REGISTER_CLOSED,
+    'register_policy' => \Friendica\Module\Register::CLOSED,
 ],
 </pre></td>
         </tr>


### PR DESCRIPTION
The documentation about the config file contained the old constant for registration policy.