### PR TITLE
AP: Follow a note to receive all upcoming activities

### DIFF
--- a/src/Protocol/ActivityPub/Receiver.php
+++ b/src/Protocol/ActivityPub/Receiver.php
@@ -208,7 +208,8 @@ class Receiver
 			}
 			// We had been able to retrieve the object data - so we can trust the source
 			$trust_source = true;
-		} elseif (in_array($type, ['as:Like', 'as:Dislike'])) {
+		} elseif (in_array($type, ['as:Like', 'as:Dislike']) ||
+			(($type == 'as:Follow') && in_array($object_type, self::CONTENT_TYPES))) {
 			// Create a mostly empty array out of the activity data (instead of the object).
 			// This way we later don't have to check for the existence of ech individual array element.
 			$object_data = self::processObject($activity);
@@ -394,6 +395,9 @@ class Receiver
 			case 'as:Follow':
 				if (in_array($object_data['object_type'], self::ACCOUNT_TYPES)) {
 					ActivityPub\Processor::followUser($object_data);
+				} elseif (in_array($object_data['object_type'], self::CONTENT_TYPES)) {
+					$object_data['reply-to-id'] = $object_data['object_id'];
+					ActivityPub\Processor::createActivity($object_data, ACTIVITY_FOLLOW);
 				}
 				break;
 


### PR DESCRIPTION
When we create a "follow" activity in Friendica, we now send a "Follow Note" activity. So we assure that we receive all future updates of this thread. Especially for reshares this needn't to be the case.

For the latter case there is a preparation in this PR. This function will be called in the future, when we receive a reshare. This will be part of a future PR. For now I want to assure that other servers can interpret the new command.