### PR TITLE
AP: Debug option to deliver via AP first

### DIFF
--- a/config/defaults.config.php
+++ b/config/defaults.config.php
@@ -421,9 +421,13 @@ return [
 		// Must be writable by the ejabberd process. if set then it will prevent the running of multiple processes.
 		'lockpath' => '',
 	],
-    'debug' => [
-        // ap_inbox_log (Boolean)
-        // Logs every call to /inbox as a JSON file in Friendica's temporary directory
-        'ap_inbox_log' => false,
-    ]
+	'debug' => [
+		// ap_inbox_log (Boolean)
+		// Logs every call to /inbox as a JSON file in Friendica's temporary directory
+		'ap_inbox_log' => false,
+
+		// total_ap_delivery (Boolean)
+		// Deliver via AP to every possible receiver and we suppress the delivery to these contacts with other protocols
+		'total_ap_delivery' => false,
+	]
 ];

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -325,11 +325,13 @@ class Transmitter
 			}
 		}
 
-		// Will be activated in a later step
-		// $networks = [Protocol::ACTIVITYPUB, Protocol::DFRN, Protocol::DIASPORA, Protocol::OSTATUS];
-
-		// For now only send to these contacts:
-		$networks = [Protocol::ACTIVITYPUB, Protocol::OSTATUS];
+		if (Config::get('debug', 'total_ap_delivery')) {
+			// Will be activated in a later step
+			$networks = [Protocol::ACTIVITYPUB, Protocol::DFRN, Protocol::DIASPORA, Protocol::OSTATUS];
+		} else {
+			// For now only send to these contacts:
+			$networks = [Protocol::ACTIVITYPUB, Protocol::OSTATUS];
+		}
 
 		$data = ['to' => [], 'cc' => [], 'bcc' => []];
 
@@ -473,11 +475,13 @@ class Transmitter
 	{
 		$inboxes = [];
 
-		// Will be activated in a later step
-		// $networks = [Protocol::ACTIVITYPUB, Protocol::DFRN, Protocol::DIASPORA, Protocol::OSTATUS];
-
-		// For now only send to these contacts:
-		$networks = [Protocol::ACTIVITYPUB, Protocol::OSTATUS];
+		if (Config::get('debug', 'total_ap_delivery')) {
+			// Will be activated in a later step
+			$networks = [Protocol::ACTIVITYPUB, Protocol::DFRN, Protocol::DIASPORA, Protocol::OSTATUS];
+		} else {
+			// For now only send to these contacts:
+			$networks = [Protocol::ACTIVITYPUB, Protocol::OSTATUS];
+		}
 
 		$condition = ['uid' => $uid, 'network' => $networks, 'archive' => false, 'pending' => false];
 


### PR DESCRIPTION
This is a new config value to test the direct Friendica -> Friendica delivery, for example with forum accounts.

When this works reliable, we can activate it all the time. (and remove the config variable)