### PR TITLE
Links of mentioned contacts hadn't looked great on Mastodon

### DIFF
--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -1293,7 +1293,7 @@ class BBCode extends BaseObject
 				$text);
 		} elseif ($simple_html == 7) {
 			$text = preg_replace("/([@!])\[url\=([$URLSearchString]*)\](.*?)\[\/url\]/ism",
-				'$1<span class="vcard"><a href="$2" class="url" title="$3"><span class="fn nickname mention">$3</span></a></span>',
+				'$1<span class="vcard"><a href="$2" class="url u-url mention" title="$3"><span class="fn nickname mention">$3</span></a></span>',
 				$text);
 		} elseif (!$simple_html) {
 			$text = preg_replace("/([@!])\[url\=([$URLSearchString]*)\](.*?)\[\/url\]/ism",


### PR DESCRIPTION
Before:
![bildschirmfoto 2019-01-30 um 22 59 17](https://user-images.githubusercontent.com/844208/52015658-bd617380-24e2-11e9-97d8-7c76320517ee.png)
(All links are blue, there is an automatic preview generated for the first link - which is just a contact link)

After:
![bildschirmfoto 2019-01-30 um 22 59 27](https://user-images.githubusercontent.com/844208/52015676-c6eadb80-24e2-11e9-94c0-e46e7538f602.png)
(Links do have a different colour, no preview had been generated)