### PR TITLE
Config Refactoring

### DIFF
--- a/bin/auth_ejabberd.php
+++ b/bin/auth_ejabberd.php
@@ -54,7 +54,7 @@ chdir($directory);
 
 require dirname(__DIR__) . '/vendor/autoload.php';
 
-$basedir = BasePath::create(dirname(__DIR__));
+$basedir = BasePath::create(dirname(__DIR__), $_SERVER);
 $configLoader = new Config\ConfigCacheLoader($basedir);
 $config = Factory\ConfigFactory::createCache($configLoader);
 $logger = Factory\LoggerFactory::create('auth_ejabberd', $config);

--- a/bin/auth_ejabberd.php
+++ b/bin/auth_ejabberd.php
@@ -33,8 +33,10 @@
  */
 
 use Friendica\App;
+use Friendica\Core\Config;
+use Friendica\Factory;
+use Friendica\Util\BasePath;
 use Friendica\Util\ExAuth;
-use Friendica\Util\LoggerFactory;
 
 if (sizeof($_SERVER["argv"]) == 0) {
 	die();
@@ -52,9 +54,12 @@ chdir($directory);
 
 require dirname(__DIR__) . '/vendor/autoload.php';
 
-$logger = LoggerFactory::create('auth_ejabberd');
+$basedir = BasePath::create(dirname(__DIR__));
+$configLoader = new Config\ConfigCacheLoader($basedir);
+$config = Factory\ConfigFactory::createCache($configLoader);
+$logger = Factory\LoggerFactory::create('auth_ejabberd', $config);
 
-$a = new App(dirname(__DIR__), $logger);
+$a = new App($config, $logger);
 
 if ($a->getMode()->isNormal()) {
 	$oAuth = new ExAuth();

--- a/bin/console.php
+++ b/bin/console.php
@@ -7,7 +7,7 @@ use Friendica\Core\Config;
 use Friendica\Factory;
 use Friendica\Util\BasePath;
 
-$basedir = BasePath::create(dirname(__DIR__));
+$basedir = BasePath::create(dirname(__DIR__), $_SERVER);
 $configLoader = new Config\ConfigCacheLoader($basedir);
 $config = Factory\ConfigFactory::createCache($configLoader);
 $logger = Factory\LoggerFactory::create('console', $config);

--- a/bin/console.php
+++ b/bin/console.php
@@ -3,11 +3,16 @@
 
 require dirname(__DIR__) . '/vendor/autoload.php';
 
-use Friendica\Util\LoggerFactory;
+use Friendica\Core\Config;
+use Friendica\Factory;
+use Friendica\Util\BasePath;
 
-$logger = LoggerFactory::create('console');
+$basedir = BasePath::create(dirname(__DIR__));
+$configLoader = new Config\ConfigCacheLoader($basedir);
+$config = Factory\ConfigFactory::createCache($configLoader);
+$logger = Factory\LoggerFactory::create('console', $config);
 
-$a = new Friendica\App(dirname(__DIR__), $logger);
+$a = new Friendica\App($config, $logger);
 \Friendica\BaseObject::setApp($a);
 
 (new Friendica\Core\Console($argv))->execute();

--- a/bin/daemon.php
+++ b/bin/daemon.php
@@ -11,7 +11,8 @@ use Friendica\App;
 use Friendica\Core\Config;
 use Friendica\Core\Worker;
 use Friendica\Database\DBA;
-use Friendica\Util\LoggerFactory;
+use Friendica\Factory;
+use Friendica\Util\BasePath;
 
 // Get options
 $shortopts = 'f';
@@ -32,9 +33,12 @@ if (!file_exists("boot.php") && (sizeof($_SERVER["argv"]) != 0)) {
 
 require dirname(__DIR__) . '/vendor/autoload.php';
 
-$logger = LoggerFactory::create('daemon');
+$basedir = BasePath::create(dirname(__DIR__));
+$configLoader = new Config\ConfigCacheLoader($basedir);
+$config = Factory\ConfigFactory::createCache($configLoader);
+$logger = Factory\LoggerFactory::create('daemon', $config);
 
-$a = new App(dirname(__DIR__), $logger);
+$a = new App($config, $logger);
 
 if ($a->getMode()->isInstall()) {
 	die("Friendica isn't properly installed yet.\n");

--- a/bin/daemon.php
+++ b/bin/daemon.php
@@ -33,7 +33,7 @@ if (!file_exists("boot.php") && (sizeof($_SERVER["argv"]) != 0)) {
 
 require dirname(__DIR__) . '/vendor/autoload.php';
 
-$basedir = BasePath::create(dirname(__DIR__));
+$basedir = BasePath::create(dirname(__DIR__), $_SERVER);
 $configLoader = new Config\ConfigCacheLoader($basedir);
 $config = Factory\ConfigFactory::createCache($configLoader);
 $logger = Factory\LoggerFactory::create('daemon', $config);

--- a/bin/worker.php
+++ b/bin/worker.php
@@ -31,7 +31,7 @@ if (!file_exists("boot.php") && (sizeof($_SERVER["argv"]) != 0)) {
 
 require dirname(__DIR__) . '/vendor/autoload.php';
 
-$basedir = BasePath::create(dirname(__DIR__));
+$basedir = BasePath::create(dirname(__DIR__), $_SERVER);
 $configLoader = new Config\ConfigCacheLoader($basedir);
 $config = Factory\ConfigFactory::createCache($configLoader);
 $logger = Factory\LoggerFactory::create('worker', $config);

--- a/bin/worker.php
+++ b/bin/worker.php
@@ -4,11 +4,13 @@
  * @file bin/worker.php
  * @brief Starts the background processing
  */
+
 use Friendica\App;
 use Friendica\Core\Config;
-use Friendica\Core\Worker;
 use Friendica\Core\Update;
-use Friendica\Util\LoggerFactory;
+use Friendica\Core\Worker;
+use Friendica\Factory;
+use Friendica\Util\BasePath;
 
 // Get options
 $shortopts = 'sn';
@@ -29,12 +31,15 @@ if (!file_exists("boot.php") && (sizeof($_SERVER["argv"]) != 0)) {
 
 require dirname(__DIR__) . '/vendor/autoload.php';
 
-$logger = LoggerFactory::create('worker');
+$basedir = BasePath::create(dirname(__DIR__));
+$configLoader = new Config\ConfigCacheLoader($basedir);
+$config = Factory\ConfigFactory::createCache($configLoader);
+$logger = Factory\LoggerFactory::create('worker', $config);
 
-$a = new App(dirname(__DIR__), $logger);
+$a = new App($config, $logger);
 
 // Check the database structure and possibly fixes it
-Update::check(true);
+Update::check($a->getBasePath(), true);
 
 // Quit when in maintenance
 if (!$a->getMode()->has(App\Mode::MAINTENANCEDISABLED)) {

--- a/boot.php
+++ b/boot.php
@@ -22,6 +22,7 @@ use Friendica\BaseObject;
 use Friendica\Core\Config;
 use Friendica\Core\PConfig;
 use Friendica\Core\Protocol;
+use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\Model\Contact;
 use Friendica\Util\BasePath;
@@ -634,7 +635,7 @@ function get_temppath()
 
 	$temppath = Config::get("system", "temppath");
 
-	if (($temppath != "") && BasePath::isDirectoryUsable($temppath)) {
+	if (($temppath != "") && System::isDirectoryUsable($temppath)) {
 		// We have a temp path and it is usable
 		return BasePath::getRealPath($temppath);
 	}
@@ -643,7 +644,7 @@ function get_temppath()
 	$temppath = sys_get_temp_dir();
 
 	// Check if it is usable
-	if (($temppath != "") && BasePath::isDirectoryUsable($temppath)) {
+	if (($temppath != "") && System::isDirectoryUsable($temppath)) {
 		// Always store the real path, not the path through symlinks
 		$temppath = BasePath::getRealPath($temppath);
 
@@ -654,7 +655,7 @@ function get_temppath()
 			mkdir($new_temppath);
 		}
 
-		if (BasePath::isDirectoryUsable($new_temppath)) {
+		if (System::isDirectoryUsable($new_temppath)) {
 			// The new path is usable, we are happy
 			Config::set("system", "temppath", $new_temppath);
 			return $new_temppath;
@@ -736,7 +737,7 @@ function get_itemcachepath()
 	}
 
 	$itemcache = Config::get('system', 'itemcache');
-	if (($itemcache != "") && BasePath::isDirectoryUsable($itemcache)) {
+	if (($itemcache != "") && System::isDirectoryUsable($itemcache)) {
 		return BasePath::getRealPath($itemcache);
 	}
 
@@ -748,7 +749,7 @@ function get_itemcachepath()
 			mkdir($itemcache);
 		}
 
-		if (BasePath::isDirectoryUsable($itemcache)) {
+		if (System::isDirectoryUsable($itemcache)) {
 			Config::set("system", "itemcache", $itemcache);
 			return $itemcache;
 		}
@@ -764,7 +765,7 @@ function get_itemcachepath()
 function get_spoolpath()
 {
 	$spoolpath = Config::get('system', 'spoolpath');
-	if (($spoolpath != "") && BasePath::isDirectoryUsable($spoolpath)) {
+	if (($spoolpath != "") && System::isDirectoryUsable($spoolpath)) {
 		// We have a spool path and it is usable
 		return $spoolpath;
 	}
@@ -779,7 +780,7 @@ function get_spoolpath()
 			mkdir($spoolpath);
 		}
 
-		if (BasePath::isDirectoryUsable($spoolpath)) {
+		if (System::isDirectoryUsable($spoolpath)) {
 			// The new path is usable, we are happy
 			Config::set("system", "spoolpath", $spoolpath);
 			return $spoolpath;

--- a/boot.php
+++ b/boot.php
@@ -19,18 +19,12 @@
 
 use Friendica\App;
 use Friendica\BaseObject;
-use Friendica\Core\Addon;
-use Friendica\Core\Cache;
 use Friendica\Core\Config;
-use Friendica\Core\L10n;
 use Friendica\Core\PConfig;
 use Friendica\Core\Protocol;
-use Friendica\Core\System;
-use Friendica\Core\Update;
-use Friendica\Core\Worker;
 use Friendica\Database\DBA;
 use Friendica\Model\Contact;
-use Friendica\Model\Conversation;
+use Friendica\Util\BasePath;
 use Friendica\Util\DateTimeFormat;
 
 define('FRIENDICA_PLATFORM',     'Friendica');
@@ -642,7 +636,7 @@ function get_temppath()
 
 	if (($temppath != "") && App::isDirectoryUsable($temppath)) {
 		// We have a temp path and it is usable
-		return App::getRealPath($temppath);
+		return BasePath::getRealPath($temppath);
 	}
 
 	// We don't have a working preconfigured temp path, so we take the system path.
@@ -651,7 +645,7 @@ function get_temppath()
 	// Check if it is usable
 	if (($temppath != "") && App::isDirectoryUsable($temppath)) {
 		// Always store the real path, not the path through symlinks
-		$temppath = App::getRealPath($temppath);
+		$temppath = BasePath::getRealPath($temppath);
 
 		// To avoid any interferences with other systems we create our own directory
 		$new_temppath = $temppath . "/" . $a->getHostName();
@@ -743,7 +737,7 @@ function get_itemcachepath()
 
 	$itemcache = Config::get('system', 'itemcache');
 	if (($itemcache != "") && App::isDirectoryUsable($itemcache)) {
-		return App::getRealPath($itemcache);
+		return BasePath::getRealPath($itemcache);
 	}
 
 	$temppath = get_temppath();

--- a/boot.php
+++ b/boot.php
@@ -634,7 +634,7 @@ function get_temppath()
 
 	$temppath = Config::get("system", "temppath");
 
-	if (($temppath != "") && App::isDirectoryUsable($temppath)) {
+	if (($temppath != "") && BasePath::isDirectoryUsable($temppath)) {
 		// We have a temp path and it is usable
 		return BasePath::getRealPath($temppath);
 	}
@@ -643,7 +643,7 @@ function get_temppath()
 	$temppath = sys_get_temp_dir();
 
 	// Check if it is usable
-	if (($temppath != "") && App::isDirectoryUsable($temppath)) {
+	if (($temppath != "") && BasePath::isDirectoryUsable($temppath)) {
 		// Always store the real path, not the path through symlinks
 		$temppath = BasePath::getRealPath($temppath);
 
@@ -654,7 +654,7 @@ function get_temppath()
 			mkdir($new_temppath);
 		}
 
-		if (App::isDirectoryUsable($new_temppath)) {
+		if (BasePath::isDirectoryUsable($new_temppath)) {
 			// The new path is usable, we are happy
 			Config::set("system", "temppath", $new_temppath);
 			return $new_temppath;
@@ -736,7 +736,7 @@ function get_itemcachepath()
 	}
 
 	$itemcache = Config::get('system', 'itemcache');
-	if (($itemcache != "") && App::isDirectoryUsable($itemcache)) {
+	if (($itemcache != "") && BasePath::isDirectoryUsable($itemcache)) {
 		return BasePath::getRealPath($itemcache);
 	}
 
@@ -748,7 +748,7 @@ function get_itemcachepath()
 			mkdir($itemcache);
 		}
 
-		if (App::isDirectoryUsable($itemcache)) {
+		if (BasePath::isDirectoryUsable($itemcache)) {
 			Config::set("system", "itemcache", $itemcache);
 			return $itemcache;
 		}
@@ -764,7 +764,7 @@ function get_itemcachepath()
 function get_spoolpath()
 {
 	$spoolpath = Config::get('system', 'spoolpath');
-	if (($spoolpath != "") && App::isDirectoryUsable($spoolpath)) {
+	if (($spoolpath != "") && BasePath::isDirectoryUsable($spoolpath)) {
 		// We have a spool path and it is usable
 		return $spoolpath;
 	}
@@ -779,7 +779,7 @@ function get_spoolpath()
 			mkdir($spoolpath);
 		}
 
-		if (App::isDirectoryUsable($spoolpath)) {
+		if (BasePath::isDirectoryUsable($spoolpath)) {
 			// The new path is usable, we are happy
 			Config::set("system", "spoolpath", $spoolpath);
 			return $spoolpath;

--- a/index.php
+++ b/index.php
@@ -15,7 +15,7 @@ if (!file_exists(__DIR__ . '/vendor/autoload.php')) {
 
 require __DIR__ . '/vendor/autoload.php';
 
-$basedir = BasePath::create(__DIR__);
+$basedir = BasePath::create(__DIR__, $_SERVER);
 $configLoader = new Config\ConfigCacheLoader($basedir);
 $config = Factory\ConfigFactory::createCache($configLoader);
 $logger = Factory\LoggerFactory::create('index', $config);

--- a/index.php
+++ b/index.php
@@ -5,7 +5,9 @@
  */
 
 use Friendica\App;
-use Friendica\Util\LoggerFactory;
+use Friendica\Core\Config;
+use Friendica\Factory;
+use Friendica\Util\BasePath;
 
 if (!file_exists(__DIR__ . '/vendor/autoload.php')) {
 	die('Vendor path not found. Please execute "bin/composer.phar --no-dev install" on the command line in the web root.');
@@ -13,10 +15,13 @@ if (!file_exists(__DIR__ . '/vendor/autoload.php')) {
 
 require __DIR__ . '/vendor/autoload.php';
 
-$logger = LoggerFactory::create('index');
+$basedir = BasePath::create(__DIR__);
+$configLoader = new Config\ConfigCacheLoader($basedir);
+$config = Factory\ConfigFactory::createCache($configLoader);
+$logger = Factory\LoggerFactory::create('index', $config);
 
 // We assume that the index.php is called by a frontend process
 // The value is set to "true" by default in App
-$a = new App(__DIR__, $logger, false);
+$a = new App($config, $logger, false);
 
 $a->runFrontend();

--- a/mod/admin.php
+++ b/mod/admin.php
@@ -15,11 +15,11 @@ use Friendica\Core\Config;
 use Friendica\Core\L10n;
 use Friendica\Core\Logger;
 use Friendica\Core\Renderer;
+use Friendica\Core\StorageManager;
 use Friendica\Core\System;
 use Friendica\Core\Theme;
 use Friendica\Core\Update;
 use Friendica\Core\Worker;
-use Friendica\Core\StorageManager;
 use Friendica\Database\DBA;
 use Friendica\Database\DBStructure;
 use Friendica\Model\Contact;
@@ -30,6 +30,7 @@ use Friendica\Module;
 use Friendica\Module\Login;
 use Friendica\Module\Tos;
 use Friendica\Util\Arrays;
+use Friendica\Util\BasePath;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Network;
 use Friendica\Util\Strings;
@@ -1375,7 +1376,7 @@ function admin_page_site_post(App $a)
 	Config::set('system', 'dbclean-expire-unclaimed', $dbclean_unclaimed);
 
 	if ($itemcache != '') {
-		$itemcache = App::getRealPath($itemcache);
+		$itemcache = BasePath::getRealPath($itemcache);
 	}
 
 	Config::set('system', 'itemcache', $itemcache);
@@ -1383,13 +1384,13 @@ function admin_page_site_post(App $a)
 	Config::set('system', 'max_comments', $max_comments);
 
 	if ($temppath != '') {
-		$temppath = App::getRealPath($temppath);
+		$temppath = BasePath::getRealPath($temppath);
 	}
 
 	Config::set('system', 'temppath', $temppath);
 
 	if ($basepath != '') {
-		$basepath = App::getRealPath($basepath);
+		$basepath = BasePath::getRealPath($basepath);
 	}
 
 	Config::set('system', 'basepath'         , $basepath);

--- a/mod/admin.php
+++ b/mod/admin.php
@@ -916,7 +916,7 @@ function admin_page_summary(App $a)
 	}
 
 	if (Config::get('system', 'dbupdate', DBStructure::UPDATE_NOT_CHECKED) == DBStructure::UPDATE_NOT_CHECKED) {
-		DBStructure::update(false, true);
+		DBStructure::update($a->getBasePath(), false, true);
 	}
 	if (Config::get('system', 'dbupdate') == DBStructure::UPDATE_FAILED) {
 		$showwarning = true;
@@ -1725,7 +1725,7 @@ function admin_page_dbsync(App $a)
 	}
 
 	if (($a->argc > 2) && (intval($a->argv[2]) || ($a->argv[2] === 'check'))) {
-		$retval = DBStructure::update(false, true);
+		$retval = DBStructure::update($a->getBasePath(), false, true);
 		if ($retval === '') {
 			$o .= L10n::t("Database structure update %s was successfully applied.", DB_UPDATE_VERSION) . "<br />";
 			Config::set('database', 'last_successful_update', DB_UPDATE_VERSION);

--- a/mod/friendica.php
+++ b/mod/friendica.php
@@ -12,7 +12,7 @@ use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\Module\Register;
 
-function friendica_init(App $a, Config\ConfigCache $config)
+function friendica_init(App $a)
 {
 	if (!empty($a->argv[1]) && ($a->argv[1] == "json")) {
 		$register_policies = [
@@ -29,7 +29,7 @@ function friendica_init(App $a, Config\ConfigCache $config)
 		}
 
 		$sql_extra = '';
-		if ($config->get('config', 'admin_nickname') !== null) {
+		if (Config::get('config', 'admin_nickname') !== null) {
 			$sql_extra = sprintf(" AND `nickname` = '%s' ", DBA::escape(Config::get('config', 'admin_nickname')));
 		}
 		if (!empty(Config::get('config', 'admin_email'))) {

--- a/mod/friendica.php
+++ b/mod/friendica.php
@@ -48,7 +48,7 @@ function friendica_init(App $a)
 
 		Config::load('feature_lock');
 		$locked_features = [];
-		$featureLock = $config->get('config', 'feature_lock');
+		$featureLock = Config::get('config', 'feature_lock');
 		if (isset($featureLock)) {
 			foreach ($featureLock as $k => $v) {
 				if ($k === 'config_loaded') {

--- a/mod/friendica.php
+++ b/mod/friendica.php
@@ -29,7 +29,7 @@ function friendica_init(App $a)
 		}
 
 		$sql_extra = '';
-		if (!empty($a->config['admin_nickname'])) {
+		if (Config::getConfigValue('config', 'admin_nickname') !== null) {
 			$sql_extra = sprintf(" AND `nickname` = '%s' ", DBA::escape(Config::get('config', 'admin_nickname')));
 		}
 		if (!empty(Config::get('config', 'admin_email'))) {
@@ -48,8 +48,9 @@ function friendica_init(App $a)
 
 		Config::load('feature_lock');
 		$locked_features = [];
-		if (!empty($a->config['feature_lock'])) {
-			foreach ($a->config['feature_lock'] as $k => $v) {
+		$featureLock = Config::getConfigValue('config', 'feature_lock');
+		if (isset($featureLock)) {
+			foreach ($featureLock as $k => $v) {
 				if ($k === 'config_loaded') {
 					continue;
 				}

--- a/mod/friendica.php
+++ b/mod/friendica.php
@@ -12,7 +12,7 @@ use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\Module\Register;
 
-function friendica_init(App $a)
+function friendica_init(App $a, Config\ConfigCache $config)
 {
 	if (!empty($a->argv[1]) && ($a->argv[1] == "json")) {
 		$register_policies = [
@@ -29,7 +29,7 @@ function friendica_init(App $a)
 		}
 
 		$sql_extra = '';
-		if (Config::getConfigValue('config', 'admin_nickname') !== null) {
+		if ($config->get('config', 'admin_nickname') !== null) {
 			$sql_extra = sprintf(" AND `nickname` = '%s' ", DBA::escape(Config::get('config', 'admin_nickname')));
 		}
 		if (!empty(Config::get('config', 'admin_email'))) {
@@ -48,7 +48,7 @@ function friendica_init(App $a)
 
 		Config::load('feature_lock');
 		$locked_features = [];
-		$featureLock = Config::getConfigValue('config', 'feature_lock');
+		$featureLock = $config->get('config', 'feature_lock');
 		if (isset($featureLock)) {
 			foreach ($featureLock as $k => $v) {
 				if ($k === 'config_loaded') {

--- a/src/App.php
+++ b/src/App.php
@@ -387,7 +387,7 @@ class App
 			Core\Hook::loadHooks();
 			$loader = new ConfigCacheLoader($this->basePath);
 			Core\Hook::callAll('load_config', $loader);
-			$this->config->loadConfigArray($loader->loadAddonConfig(), true);
+			$this->config->loadConfigArray($loader->loadCoreConfig('addon'), true);
 		}
 
 		$this->loadDefaultTimezone();

--- a/src/App.php
+++ b/src/App.php
@@ -1288,7 +1288,7 @@ class App
 			$this->module = 'maintenance';
 		} else {
 			$this->checkURL();
-			Core\Update::check(false);
+			Core\Update::check($this->basePath, false);
 			Core\Addon::loadAddons();
 			Core\Hook::loadHooks();
 		}

--- a/src/App.php
+++ b/src/App.php
@@ -375,7 +375,7 @@ class App
 			$adapterType = $this->config->get('system', 'config_adapter');
 			$adapter = ConfigFactory::createConfig($adapterType, $this->config);
 			Core\Config::setAdapter($adapter);
-			$adapterP = ConfigFactory::createConfig($adapterType, $this->config);
+			$adapterP = ConfigFactory::createPConfig($adapterType, $this->config);
 			Core\PConfig::setAdapter($adapterP);
 			Core\Config::load();
 		}

--- a/src/App.php
+++ b/src/App.php
@@ -13,7 +13,6 @@ use Friendica\Core\Config\ConfigCacheLoader;
 use Friendica\Database\DBA;
 use Friendica\Factory\ConfigFactory;
 use Friendica\Network\HTTPException\InternalServerErrorException;
-use Friendica\Util\BasePath;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -194,7 +193,7 @@ class App
 		$this->logger   = $logger;
 		$this->basePath = $this->config->get('system', 'basepath');
 
-		if (!BasePath::isDirectoryUsable($this->basePath, false)) {
+		if (!Core\System::isDirectoryUsable($this->basePath, false)) {
 			throw new Exception('Basepath ' . $this->basePath . ' isn\'t usable.');
 		}
 		$this->basePath = rtrim($this->basePath, DIRECTORY_SEPARATOR);

--- a/src/App.php
+++ b/src/App.php
@@ -30,7 +30,6 @@ class App
 	public $module_loaded = false;
 	public $module_class = null;
 	public $query_string = '';
-	public $config = [];
 	public $page = [];
 	public $profile;
 	public $profile_uid;
@@ -1215,67 +1214,6 @@ class App
 		}
 
 		return true;
-	}
-
-	/**
-	 * Retrieves a value from the user config cache
-	 *
-	 * @param int    $uid     User Id
-	 * @param string $cat     Config category
-	 * @param string $k       Config key
-	 * @param mixed  $default Default value if key isn't set
-	 *
-	 * @return string The value of the config entry
-	 */
-	public function getPConfigValue($uid, $cat, $k, $default = null)
-	{
-		$return = $default;
-
-		if (isset($this->config[$uid][$cat][$k])) {
-			$return = $this->config[$uid][$cat][$k];
-		}
-
-		return $return;
-	}
-
-	/**
-	 * Sets a value in the user config cache
-	 *
-	 * Accepts raw output from the pconfig table
-	 *
-	 * @param int    $uid User Id
-	 * @param string $cat Config category
-	 * @param string $k   Config key
-	 * @param mixed  $v   Value to set
-	 */
-	public function setPConfigValue($uid, $cat, $k, $v)
-	{
-		// Only arrays are serialized in database, so we have to unserialize sparingly
-		$value = is_string($v) && preg_match("|^a:[0-9]+:{.*}$|s", $v) ? unserialize($v) : $v;
-
-		if (!isset($this->config[$uid]) || !is_array($this->config[$uid])) {
-			$this->config[$uid] = [];
-		}
-
-		if (!isset($this->config[$uid][$cat]) || !is_array($this->config[$uid][$cat])) {
-			$this->config[$uid][$cat] = [];
-		}
-
-		$this->config[$uid][$cat][$k] = $value;
-	}
-
-	/**
-	 * Deletes a value from the user config cache
-	 *
-	 * @param int    $uid User Id
-	 * @param string $cat Config category
-	 * @param string $k   Config key
-	 */
-	public function deletePConfigValue($uid, $cat, $k)
-	{
-		if (isset($this->config[$uid][$cat][$k])) {
-			unset($this->config[$uid][$cat][$k]);
-		}
 	}
 
 	/**

--- a/src/BaseObject.php
+++ b/src/BaseObject.php
@@ -28,7 +28,7 @@ class BaseObject
 	public static function getApp()
 	{
 		if (empty(self::$app)) {
-			throw new InternalServerErrorException('App isn\' initialized.');
+			throw new InternalServerErrorException('App isn\'t initialized.');
 		}
 
 		return self::$app;

--- a/src/BaseObject.php
+++ b/src/BaseObject.php
@@ -6,7 +6,9 @@ namespace Friendica;
 
 require_once 'boot.php';
 
-use Friendica\Util\LoggerFactory;
+use Friendica\Core\Config;
+use Friendica\Factory;
+use Friendica\Util\BasePath;
 
 /**
  * Basic object
@@ -28,8 +30,11 @@ class BaseObject
 	public static function getApp()
 	{
 		if (empty(self::$app)) {
-			$logger = $logger = LoggerFactory::create('app');
-			self::$app = new App(dirname(__DIR__), $logger);
+			$basedir = BasePath::create(dirname(__DIR__));
+			$configLoader = new Config\ConfigCacheLoader($basedir);
+			$config = Factory\ConfigFactory::createCache($configLoader);
+			$logger = Factory\LoggerFactory::create('app', $config);
+			self::$app = new App($config, $logger);
 		}
 
 		return self::$app;

--- a/src/BaseObject.php
+++ b/src/BaseObject.php
@@ -6,9 +6,7 @@ namespace Friendica;
 
 require_once 'boot.php';
 
-use Friendica\Core\Config;
-use Friendica\Factory;
-use Friendica\Util\BasePath;
+use Friendica\Network\HTTPException\InternalServerErrorException;
 
 /**
  * Basic object
@@ -30,11 +28,7 @@ class BaseObject
 	public static function getApp()
 	{
 		if (empty(self::$app)) {
-			$basedir = BasePath::create(dirname(__DIR__));
-			$configLoader = new Config\ConfigCacheLoader($basedir);
-			$config = Factory\ConfigFactory::createCache($configLoader);
-			$logger = Factory\LoggerFactory::create('app', $config);
-			self::$app = new App($config, $logger);
+			throw new InternalServerErrorException('App isn\' initialized.');
 		}
 
 		return self::$app;

--- a/src/Core/Addon.php
+++ b/src/Core/Addon.php
@@ -16,7 +16,7 @@ class Addon extends BaseObject
 	 * The addon sub-directory
 	 * @var string
 	 */
-	const DIRECTORY = '/addon/';
+	const DIRECTORY = 'addon';
 
 	/**
 	 * List of the names of enabled addons

--- a/src/Core/Addon.php
+++ b/src/Core/Addon.php
@@ -13,6 +13,12 @@ use Friendica\Database\DBA;
 class Addon extends BaseObject
 {
 	/**
+	 * The addon sub-directory
+	 * @var string
+	 */
+	const DIRECTORY = '/addon/';
+
+	/**
 	 * List of the names of enabled addons
 	 *
 	 * @var array

--- a/src/Core/Config.php
+++ b/src/Core/Config.php
@@ -162,7 +162,7 @@ class Config extends BaseObject
 	 * @param array $config
 	 * @param bool  $overwrite Force value overwrite if the config key already exists
 	 */
-	public function loadConfigArray(array $config, $overwrite = false)
+	public static function loadConfigArray(array $config, $overwrite = false)
 	{
 		foreach ($config as $category => $values) {
 			foreach ($values as $key => $value) {

--- a/src/Core/Config.php
+++ b/src/Core/Config.php
@@ -25,16 +25,16 @@ class Config
 	/**
 	 * @var Config\IConfigCache
 	 */
-	private static $config;
+	private static $cache;
 
 	/**
 	 * Initialize the config with only the cache
 	 *
-	 * @param Config\IConfigCache $config  The configuration cache
+	 * @param Config\IConfigCache $cache  The configuration cache
 	 */
-	public static function init(Config\IConfigCache $config)
+	public static function init(Config\IConfigCache $cache)
 	{
-		self::$config  = $config;
+		self::$cache  = $cache;
 	}
 
 	/**
@@ -88,7 +88,7 @@ class Config
 	public static function get($family, $key, $default_value = null, $refresh = false)
 	{
 		if (!isset(self::$adapter)) {
-			return self::$config->get($family, $key, $default_value);
+			return self::$cache->get($family, $key, $default_value);
 		}
 
 		return self::$adapter->get($family, $key, $default_value, $refresh);
@@ -111,7 +111,7 @@ class Config
 	public static function set($family, $key, $value)
 	{
 		if (!isset(self::$adapter)) {
-			self::$config->set($family, $key, $value);
+			self::$cache->set($family, $key, $value);
 			return true;
 		}
 
@@ -132,7 +132,7 @@ class Config
 	public static function delete($family, $key)
 	{
 		if (!isset(self::$adapter)) {
-			self::$config->delete($family, $key);
+			self::$cache->delete($family, $key);
 		}
 
 		return self::$adapter->delete($family, $key);

--- a/src/Core/Config.php
+++ b/src/Core/Config.php
@@ -8,6 +8,10 @@
  */
 namespace Friendica\Core;
 
+use Friendica\Core\Config\ConfigCache;
+use Friendica\Core\Config\IConfigAdapter;
+use Friendica\Core\Config\IConfigCache;
+
 /**
  * @brief Arbitrary system configuration storage
  *
@@ -50,8 +54,7 @@ class Config
 	/**
 	 * @brief Loads all configuration values of family into a cached storage.
 	 *
-	 * All configuration values of the system are stored in global cache
-	 * which is available under the global variable self::$config
+	 * All configuration values of the system are stored in the cache ( @see IConfigCache )
 	 *
 	 * @param string $family The category of the configuration value
 	 *
@@ -71,12 +74,8 @@ class Config
 	 * ($family) and a key.
 	 *
 	 * Get a particular config value from the given category ($family)
-	 * and the $key from a cached storage in static::config[$uid].
-	 * $instore is only used by the set_config function
-	 * to determine if the key already exists in the DB
-	 * If a key is found in the DB but doesn't exist in
-	 * local config cache, pull it into the cache so we don't have
-	 * to hit the DB again for this item.
+	 * and the $key from a cached storage either from the self::$adapter
+	 * (@see IConfigAdapter ) or from the static::$cache (@see IConfigCache ).
 	 *
 	 * @param string  $family        The category of the configuration value
 	 * @param string  $key           The configuration key to query
@@ -98,7 +97,6 @@ class Config
 	 * @brief Sets a configuration value for system config
 	 *
 	 * Stores a config value ($value) in the category ($family) under the key ($key)
-	 * for the user_id $uid.
 	 *
 	 * Note: Please do not store booleans - convert to 0/1 integer values!
 	 *
@@ -121,8 +119,8 @@ class Config
 	/**
 	 * @brief Deletes the given key from the system configuration.
 	 *
-	 * Removes the configured value from the stored cache in Config::$config
-	 * and removes it from the database.
+	 * Removes the configured value from the stored cache in self::$config
+	 * (@see ConfigCache ) and removes it from the database (@see IConfigAdapter ).
 	 *
 	 * @param string $family The category of the configuration value
 	 * @param string $key    The configuration key to delete

--- a/src/Core/Config.php
+++ b/src/Core/Config.php
@@ -8,9 +8,6 @@
  */
 namespace Friendica\Core;
 
-use Friendica\Core\Config\IConfigAdapter;
-use Friendica\Core\Config\IConfigCache;
-
 /**
  * @brief Arbitrary system configuration storage
  *
@@ -21,19 +18,19 @@ use Friendica\Core\Config\IConfigCache;
 class Config
 {
 	/**
-	 * @var IConfigAdapter
+	 * @var Config\IConfigAdapter
 	 */
 	private static $adapter;
 
 	/**
-	 * @var IConfigCache
+	 * @var Config\IConfigCache
 	 */
 	private static $config;
 
 	/**
 	 * Initialize the config with only the cache
 	 *
-	 * @param IConfigCache $config  The configuration cache
+	 * @param Config\IConfigCache $config  The configuration cache
 	 */
 	public static function init($config)
 	{
@@ -43,7 +40,7 @@ class Config
 	/**
 	 * Add the adapter for DB-backend
 	 *
-	 * @param $adapter
+	 * @param Config\IConfigAdapter $adapter
 	 */
 	public static function setAdapter($adapter)
 	{

--- a/src/Core/Config.php
+++ b/src/Core/Config.php
@@ -32,7 +32,7 @@ class Config
 	 *
 	 * @param Config\IConfigCache $config  The configuration cache
 	 */
-	public static function init($config)
+	public static function init(Config\IConfigCache $config)
 	{
 		self::$config  = $config;
 	}
@@ -42,7 +42,7 @@ class Config
 	 *
 	 * @param Config\IConfigAdapter $adapter
 	 */
-	public static function setAdapter($adapter)
+	public static function setAdapter(Config\IConfigAdapter $adapter)
 	{
 		self::$adapter = $adapter;
 	}

--- a/src/Core/Config.php
+++ b/src/Core/Config.php
@@ -45,7 +45,7 @@ class Config extends BaseObject
 	 * @brief Loads all configuration values of family into a cached storage.
 	 *
 	 * All configuration values of the system are stored in global cache
-	 * which is available under the global variable $a->config
+	 * which is available under the global variable self::$config
 	 *
 	 * @param string $family The category of the configuration value
 	 *
@@ -132,7 +132,7 @@ class Config extends BaseObject
 	/**
 	 * @brief Deletes the given key from the system configuration.
 	 *
-	 * Removes the configured value from the stored cache in $a->config
+	 * Removes the configured value from the stored cache in Config::$config
 	 * and removes it from the database.
 	 *
 	 * @param string $family The category of the configuration value

--- a/src/Core/Config/ConfigCache.php
+++ b/src/Core/Config/ConfigCache.php
@@ -22,7 +22,7 @@ class ConfigCache implements IConfigCache, IPConfigCache
 	/**
 	 * @param array $config    A initial config array
 	 */
-	public function __construct($config = [])
+	public function __construct(array $config = [])
 	{
 		$this->config = [];
 
@@ -43,9 +43,9 @@ class ConfigCache implements IConfigCache, IPConfigCache
 		foreach ($config as $category => $values) {
 			foreach ($values as $key => $value) {
 				if ($overwrite) {
-					self::set($category, $key, $value);
+					$this->set($category, $key, $value);
 				} else {
-					self::setDefault($category, $key, $value);
+					$this->setDefault($category, $key, $value);
 				}
 			}
 		}
@@ -83,7 +83,7 @@ class ConfigCache implements IConfigCache, IPConfigCache
 	private function setDefault($cat, $k, $v)
 	{
 		if (!isset($this->config[$cat][$k])) {
-			self::set($cat, $k, $v);
+			$this->set($cat, $k, $v);
 		}
 	}
 

--- a/src/Core/Config/ConfigCache.php
+++ b/src/Core/Config/ConfigCache.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace Friendica\Core\Config;
+
+class ConfigCache implements IConfigCache, IPConfigCache
+{
+	/**
+	 * NEVER, EVER use this public config array outside of the class
+	 * It is only public due to backward compatibility to .htconfig.php
+	 *
+	 * @var array The cached config array
+	 */
+	public $config;
+
+	public function __construct($config = [], $overwrite = false)
+	{
+		$this->config = [];
+
+		if (isset($config)) {
+			$this->loadConfigArray($config, $overwrite);
+		}
+	}
+
+	/**
+	 * Tries to load the specified configuration array into the App->config array.
+	 * Doesn't overwrite previously set values by default to prevent default config files to supersede DB Config.
+	 *
+	 * @param array $config
+	 * @param bool  $overwrite Force value overwrite if the config key already exists
+	 */
+	public function loadConfigArray(array $config, $overwrite = false)
+	{
+		foreach ($config as $category => $values) {
+			foreach ($values as $key => $value) {
+				if ($overwrite) {
+					self::set($category, $key, $value);
+				} else {
+					self::setDefault($category, $key, $value);
+				}
+			}
+		}
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function get($cat, $key = null, $default = null)
+	{
+		$return = $default;
+
+		if ($cat === 'config') {
+			if (isset($this->config[$key])) {
+				$return = $this->config[$key];
+			}
+		} else {
+			if (isset($this->config[$cat][$key])) {
+				$return = $this->config[$cat][$key];
+			} elseif ($key == null && isset($this->config[$cat])) {
+				$return = $this->config[$cat];
+			}
+		}
+
+		return $return;
+	}
+
+	/**
+	 * Sets a default value in the config cache. Ignores already existing keys.
+	 *
+	 * @param string $cat Config category
+	 * @param string $k   Config key
+	 * @param mixed  $v   Default value to set
+	 */
+	private function setDefault($cat, $k, $v)
+	{
+		if (!isset($this->config[$cat][$k])) {
+			self::set($cat, $k, $v);
+		}
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function set($cat, $key, $value)
+	{
+		// Only arrays are serialized in database, so we have to unserialize sparingly
+		$value = is_string($value) && preg_match("|^a:[0-9]+:{.*}$|s", $value) ? unserialize($value) : $value;
+
+		if ($cat === 'config') {
+			$this->config[$key] = $value;
+		} else {
+			if (!isset($this->config[$cat])) {
+				$this->config[$cat] = [];
+			}
+
+			$this->config[$cat][$key] = $value;
+		}
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function delete($cat, $key)
+	{
+		if ($cat === 'config') {
+			if (isset($this->config[$key])) {
+				unset($this->config[$key]);
+			}
+		} else {
+			if (isset($this->config[$cat][$key])) {
+				unset($this->config[$cat][$key]);
+			}
+		}
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getP($uid, $cat, $key = null, $default = null)
+	{
+		$return = $default;
+
+		if (isset($this->config[$uid][$cat][$key])) {
+			$return = $this->config[$uid][$cat][$key];
+		} elseif ($key == null && isset($this->config[$uid][$cat])) {
+			$return = $this->config[$uid][$cat];
+		}
+
+		return $return;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function setP($uid, $cat, $key, $value)
+	{
+		// Only arrays are serialized in database, so we have to unserialize sparingly
+		$value = is_string($value) && preg_match("|^a:[0-9]+:{.*}$|s", $value) ? unserialize($value) : $value;
+
+		if (!isset($this->config[$uid]) || !is_array($this->config[$uid])) {
+			$this->config[$uid] = [];
+		}
+
+		if (!isset($this->config[$uid][$cat]) || !is_array($this->config[$uid][$cat])) {
+			$this->config[$uid][$cat] = [];
+		}
+
+		if ($key === null) {
+			$this->config[$uid][$cat] = $value;
+		} else {
+			$this->config[$uid][$cat][$key] = $value;
+		}
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function deleteP($uid, $cat, $key)
+	{
+		if (isset($this->config[$uid][$cat][$key])) {
+			unset($this->config[$uid][$cat][$key]);
+		}
+	}
+
+	/**
+	 * Returns the whole configuration
+	 *
+	 * @return array The configuration
+	 */
+	public function getAll()
+	{
+		return $this->config;
+	}
+}

--- a/src/Core/Config/ConfigCache.php
+++ b/src/Core/Config/ConfigCache.php
@@ -121,7 +121,7 @@ class ConfigCache implements IConfigCache, IPConfigCache
 
 		if (isset($this->config[$uid][$cat][$key])) {
 			$return = $this->config[$uid][$cat][$key];
-		} elseif ($key == null && isset($this->config[$uid][$cat])) {
+		} elseif ($key === null && isset($this->config[$uid][$cat])) {
 			$return = $this->config[$uid][$cat];
 		}
 

--- a/src/Core/Config/ConfigCache.php
+++ b/src/Core/Config/ConfigCache.php
@@ -11,24 +11,14 @@ namespace Friendica\Core\Config;
  */
 class ConfigCache implements IConfigCache, IPConfigCache
 {
-	/**
-	 * NEVER, EVER use this public config array outside of the class
-	 * It is only public due to backward compatibility to .htconfig.php
-	 *
-	 * @var array The cached config array
-	 */
-	public $config;
+	private $config;
 
 	/**
 	 * @param array $config    A initial config array
 	 */
 	public function __construct(array $config = [])
 	{
-		$this->config = [];
-
-		if (isset($config)) {
-			$this->loadConfigArray($config, true);
-		}
+		$this->config = $config;
 	}
 
 	/**

--- a/src/Core/Config/ConfigCache.php
+++ b/src/Core/Config/ConfigCache.php
@@ -2,6 +2,13 @@
 
 namespace Friendica\Core\Config;
 
+/**
+ * The Friendica config cache for the application
+ * Initial, all *.config.php files are loaded into this cache with the
+ * ConfigCacheLoader ( @see ConfigCacheLoader )
+ *
+ * Is used for further caching operations too (depending on the ConfigAdapter )
+ */
 class ConfigCache implements IConfigCache, IPConfigCache
 {
 	/**
@@ -12,12 +19,15 @@ class ConfigCache implements IConfigCache, IPConfigCache
 	 */
 	public $config;
 
-	public function __construct($config = [], $overwrite = false)
+	/**
+	 * @param array $config    A initial config array
+	 */
+	public function __construct($config = [])
 	{
 		$this->config = [];
 
 		if (isset($config)) {
-			$this->loadConfigArray($config, $overwrite);
+			$this->loadConfigArray($config, true);
 		}
 	}
 

--- a/src/Core/Config/ConfigCacheLoader.php
+++ b/src/Core/Config/ConfigCacheLoader.php
@@ -43,21 +43,66 @@ class ConfigCacheLoader
 		$config->loadConfigArray($this->loadCoreConfig('defaults'));
 		$config->loadConfigArray($this->loadCoreConfig('settings'));
 
-		$config->loadConfigArray($this->loadLegacyConfigFile('htpreconfig'), true);
-		$config->loadConfigArray($this->loadLegacyConfigFile('htconfig'), true);
+		$config->loadConfigArray($this->loadLegacyConfig('htpreconfig'), true);
+		$config->loadConfigArray($this->loadLegacyConfig('htconfig'), true);
 
 		$config->loadConfigArray($this->loadCoreConfig('local'), true);
 	}
 
 	/**
-	 * Tries to load the legacy config files (.htconfig.php, .htpreconfig.php)
+	 * Tries to load the specified core-configuration and returns the config array.
+	 *
+	 * @param string $name The name of the configuration
+	 *
+	 * @return array The config array (empty if no config found)
+	 *
+	 * @throws \Exception if the configuration file isn't readable
+	 */
+	public function loadCoreConfig($name)
+	{
+		if (file_exists($this->configDir . DIRECTORY_SEPARATOR . $name . '.config.php')) {
+			return $this->loadConfigFile($this->configDir . DIRECTORY_SEPARATOR . $name . '.config.php');
+		} elseif (file_exists($this->configDir . DIRECTORY_SEPARATOR . $name . '.ini.php')) {
+			return $this->loadINIConfigFile($this->configDir . DIRECTORY_SEPARATOR . $name . '.ini.php');
+		} else {
+			return [];
+		}
+	}
+
+	/**
+	 * Tries to load the specified addon-configuration and returns the config array.
+	 *
+	 * @param string $name The name of the configuration
+	 *
+	 * @return array The config array (empty if no config found)
+	 *
+	 * @throws \Exception if the configuration file isn't readable
+	 */
+	public function loadAddonConfig($name)
+	{
+		$filepath = $this->baseDir . DIRECTORY_SEPARATOR . // /var/www/html/
+			Addon::DIRECTORY       . DIRECTORY_SEPARATOR . // addon/
+			$name                  . DIRECTORY_SEPARATOR . // openstreetmap/
+			self::SUBDIRECTORY     . DIRECTORY_SEPARATOR . // config/
+			$name . ".config.php";                         // openstreetmap.config.php
+
+		if (file_exists($filepath)) {
+			return $this->loadConfigFile($filepath);
+		} else {
+			return [];
+		}
+	}
+
+	/**
+	 * Tries to load the legacy config files (.htconfig.php, .htpreconfig.php) and returns the config array.
 	 *
 	 * @param string $name The name of the config file
-	 * @return array The configuration array
+	 *
+	 * @return array The configuration array (empty if no config found)
 	 *
 	 * @deprecated since version 2018.09
 	 */
-	private function loadLegacyConfigFile($name)
+	private function loadLegacyConfig($name)
 	{
 		$filePath = $this->baseDir  . DIRECTORY_SEPARATOR . '.' . $name . '.php';
 
@@ -113,7 +158,7 @@ class ConfigCacheLoader
 	 * @return array The configuration array
 	 * @throws \Exception
 	 */
-	public function loadINIConfigFile($filepath)
+	private function loadINIConfigFile($filepath)
 	{
 		if (!file_exists($filepath)) {
 			throw new \Exception('Error parsing non-existent INI config file ' . $filepath);
@@ -159,49 +204,5 @@ class ConfigCacheLoader
 		}
 
 		return $config;
-	}
-
-	/**
-	 * Tries to load the specified core-configuration and returns the config array.
-	 *
-	 * @param string $name The name of the configuration
-	 *
-	 * @return array The config array (empty if no config found)
-	 *
-	 * @throws \Exception if the configuration file isn't readable
-	 */
-	public function loadCoreConfig($name)
-	{
-		if (file_exists($this->configDir . DIRECTORY_SEPARATOR . $name . '.config.php')) {
-			return $this->loadConfigFile($this->configDir . DIRECTORY_SEPARATOR . $name . '.config.php');
-		} elseif (file_exists($this->configDir . DIRECTORY_SEPARATOR . $name . '.ini.php')) {
-			return $this->loadINIConfigFile($this->configDir . DIRECTORY_SEPARATOR . $name . '.ini.php');
-		} else {
-			return [];
-		}
-	}
-
-	/**
-	 * Tries to load the specified addon-configuration and returns the config array.
-	 *
-	 * @param string $name The name of the configuration
-	 *
-	 * @return array The config array (empty if no config found)
-	 *
-	 * @throws \Exception if the configuration file isn't readable
-	 */
-	public function loadAddonConfig($name)
-	{
-		$filepath = $this->baseDir . DIRECTORY_SEPARATOR . // /var/www/html/
-			Addon::DIRECTORY       . DIRECTORY_SEPARATOR . // addon/
-			$name                  . DIRECTORY_SEPARATOR . // openstreetmap/
-			self::SUBDIRECTORY     . DIRECTORY_SEPARATOR . // config/
-			$name . ".config.php";                         // openstreetmap.config.php
-
-		if (file_exists($filepath)) {
-			return $this->loadConfigFile($filepath);
-		} else {
-			return [];
-		}
 	}
 }

--- a/src/Core/Config/ConfigCacheLoader.php
+++ b/src/Core/Config/ConfigCacheLoader.php
@@ -21,7 +21,7 @@ class ConfigCacheLoader
 	 * The addon sub-directory
 	 * @var string
 	 */
-	const ADDONSDIRECTORY = '/addons/';
+	const ADDONDIRECTORY = '/addon/';
 
 	private $baseDir;
 	private $configDir;
@@ -141,7 +141,7 @@ class ConfigCacheLoader
 	public function loadConfigFile($filename, $addon = false)
 	{
 		if ($addon) {
-			$filepath = $this->baseDir . self::ADDONSDIRECTORY . $filename . self::SUBDIRECTORY . $filename . ".config.php";
+			$filepath = $this->baseDir . self::ADDONDIRECTORY . $filename . self::SUBDIRECTORY . $filename . ".config.php";
 		} else {
 			$filepath = $this->configDir . $filename . ".config.php";
 		}

--- a/src/Core/Config/ConfigCacheLoader.php
+++ b/src/Core/Config/ConfigCacheLoader.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace Friendica\Core\Config;
+
+class ConfigCacheLoader
+{
+	private $baseDir;
+	private $configDir;
+
+	public function __construct($baseDir)
+	{
+		$this->baseDir = $baseDir;
+		$this->configDir = $baseDir . '/config/';
+	}
+
+	/**
+	 * Load the configuration files
+	 *
+	 * First loads the default value for all the configuration keys, then the legacy configuration files, then the
+	 * expected local.config.php
+	 */
+	public function loadConfigFiles(ConfigCache $config)
+	{
+		// Setting at least the basepath we know
+		$config->set('system', 'basepath', $this->baseDir);
+
+		$config->loadConfigArray($this->loadConfigFile('defaults'));
+		$config->loadConfigArray($this->loadConfigFile('settings'));
+
+		// Legacy .htconfig.php support
+		if (file_exists($this->baseDir  . '/.htpreconfig.php')) {
+			$a = $config;
+			include $this->baseDir . '/.htpreconfig.php';
+		}
+
+		// Legacy .htconfig.php support
+		if (file_exists($this->baseDir . '/.htconfig.php')) {
+			$a = $config;
+
+			include $this->baseDir . '/.htconfig.php';
+
+			$config->set('database', 'hostname', $db_host);
+			$config->set('database', 'username', $db_user);
+			$config->set('database', 'password', $db_pass);
+			$config->set('database', 'database', $db_data);
+			$charset = $config->get('system', 'db_charset');
+			if (isset($charset)) {
+				$config->set('database', 'charset', $charset);
+			}
+
+			unset($db_host, $db_user, $db_pass, $db_data);
+
+			if (isset($default_timezone)) {
+				$config->set('system', 'default_timezone', $default_timezone);
+				unset($default_timezone);
+			}
+
+			if (isset($pidfile)) {
+				$config->set('system', 'pidfile', $pidfile);
+				unset($pidfile);
+			}
+
+			if (isset($lang)) {
+				$config->set('system', 'language', $lang);
+				unset($lang);
+			}
+		}
+
+		if (file_exists($this->baseDir . '/config/local.config.php')) {
+			$config->loadConfigArray($this->loadConfigFile('local'), true);
+		} elseif (file_exists($this->baseDir . '/config/local.ini.php')) {
+			$config->loadConfigArray($this->loadINIConfigFile('local'), true);
+		}
+	}
+
+	/**
+	 * Tries to load the specified legacy configuration file into the App->config array.
+	 * Doesn't overwrite previously set values by default to prevent default config files to supersede DB Config.
+	 *
+	 * @deprecated since version 2018.12
+	 * @param string $filename
+	 *
+	 * @return array The configuration
+	 * @throws \Exception
+	 */
+	public function loadINIConfigFile($filename)
+	{
+		$filepath = $this->configDir . $filename . ".ini.php";
+
+		if (!file_exists($filepath)) {
+			throw new \Exception('Error parsing non-existent INI config file ' . $filepath);
+		}
+
+		$contents = include($filepath);
+
+		$config = parse_ini_string($contents, true, INI_SCANNER_TYPED);
+
+		if ($config === false) {
+			throw new \Exception('Error parsing INI config file ' . $filepath);
+		}
+
+		return $config;
+	}
+
+	/**
+	 * Tries to load the specified configuration file into the App->config array.
+	 * Doesn't overwrite previously set values by default to prevent default config files to supersede DB Config.
+	 *
+	 * The config format is PHP array and the template for configuration files is the following:
+	 *
+	 * <?php return [
+	 *      'section' => [
+	 *          'key' => 'value',
+	 *      ],
+	 * ];
+	 *
+	 * @param string $filename
+	 * @return array The configuration
+	 * @throws \Exception
+	 */
+	public function loadConfigFile($filename)
+	{
+		$filepath = $this->configDir . $filename . ".config.php";
+
+		if (!file_exists($filepath)) {
+			throw new \Exception('Error loading non-existent config file ' . $filepath);
+		}
+
+		$config = include($filepath);
+
+		if (!is_array($config)) {
+			throw new \Exception('Error loading config file ' . $filepath);
+		}
+
+		return $config;
+	}
+
+	/**
+	 * Loads addons configuration files
+	 *
+	 * First loads all activated addons default configuration through the load_config hook, then load the local.config.php
+	 * again to overwrite potential local addon configuration.
+	 *
+	 * @return array The config array
+	 *
+	 * @throws \Exception
+	 */
+	public function loadAddonConfig()
+	{
+		// Load the local addon config file to overwritten default addon config values
+		if (file_exists($this->configDir . 'addon.config.php')) {
+			return $this->loadConfigFile('addon');
+		} elseif (file_exists($this->configDir . 'addon.ini.php')) {
+			return $this->loadINIConfigFile('addon');
+		} else {
+			return [];
+		}
+	}
+}

--- a/src/Core/Config/ConfigCacheLoader.php
+++ b/src/Core/Config/ConfigCacheLoader.php
@@ -2,15 +2,29 @@
 
 namespace Friendica\Core\Config;
 
+/**
+ * The ConfigCacheLoader loads config-files and stores them in a ConfigCache ( @see ConfigCache )
+ *
+ * It is capable of loading the following config files:
+ * - *.config.php   (current)
+ * - *.ini.php      (deprecated)
+ * - *.htconfig.php (deprecated)
+ */
 class ConfigCacheLoader
 {
+	/**
+	 * The Sub directory of the config-files
+	 * @var string
+	 */
+	const SUBDIRECTORY = '/config/';
+
 	private $baseDir;
 	private $configDir;
 
 	public function __construct($baseDir)
 	{
 		$this->baseDir = $baseDir;
-		$this->configDir = $baseDir . '/config/';
+		$this->configDir = $baseDir . self::SUBDIRECTORY;
 	}
 
 	/**

--- a/src/Core/Config/ConfigCacheLoader.php
+++ b/src/Core/Config/ConfigCacheLoader.php
@@ -21,7 +21,7 @@ class ConfigCacheLoader
 	 * The addon sub-directory
 	 * @var string
 	 */
-	const ADDONDIRECTORY = '/addon/';
+	const ADDONSDIRECTORY = '/addons/';
 
 	private $baseDir;
 	private $configDir;
@@ -141,7 +141,7 @@ class ConfigCacheLoader
 	public function loadConfigFile($filename, $addon = false)
 	{
 		if ($addon) {
-			$filepath = $this->baseDir . self::ADDONDIRECTORY . self::SUBDIRECTORY . $filename . ".config.php";
+			$filepath = $this->baseDir . self::ADDONSDIRECTORY . self::SUBDIRECTORY . $filename . ".config.php";
 		} else {
 			$filepath = $this->configDir . $filename . ".config.php";
 		}

--- a/src/Core/Config/ConfigCacheLoader.php
+++ b/src/Core/Config/ConfigCacheLoader.php
@@ -18,7 +18,7 @@ class ConfigCacheLoader
 	 * The Sub directory of the config-files
 	 * @var string
 	 */
-	const SUBDIRECTORY   = '/config/';
+	const SUBDIRECTORY = 'config';
 
 	private $baseDir;
 	private $configDir;
@@ -26,7 +26,7 @@ class ConfigCacheLoader
 	public function __construct($baseDir)
 	{
 		$this->baseDir = $baseDir;
-		$this->configDir = $baseDir . self::SUBDIRECTORY;
+		$this->configDir = $baseDir . DIRECTORY_SEPARATOR . self::SUBDIRECTORY;
 	}
 
 	/**
@@ -43,60 +43,79 @@ class ConfigCacheLoader
 		$config->loadConfigArray($this->loadCoreConfig('defaults'));
 		$config->loadConfigArray($this->loadCoreConfig('settings'));
 
-		// Legacy .htconfig.php support
-		if (file_exists($this->baseDir  . '/.htpreconfig.php')) {
-			$a = $config;
-			include $this->baseDir . '/.htpreconfig.php';
-		}
-
-		// Legacy .htconfig.php support
-		if (file_exists($this->baseDir . '/.htconfig.php')) {
-			$a = $config;
-
-			include $this->baseDir . '/.htconfig.php';
-
-			$config->set('database', 'hostname', $db_host);
-			$config->set('database', 'username', $db_user);
-			$config->set('database', 'password', $db_pass);
-			$config->set('database', 'database', $db_data);
-			$charset = $config->get('system', 'db_charset');
-			if (isset($charset)) {
-				$config->set('database', 'charset', $charset);
-			}
-
-			unset($db_host, $db_user, $db_pass, $db_data);
-
-			if (isset($default_timezone)) {
-				$config->set('system', 'default_timezone', $default_timezone);
-				unset($default_timezone);
-			}
-
-			if (isset($pidfile)) {
-				$config->set('system', 'pidfile', $pidfile);
-				unset($pidfile);
-			}
-
-			if (isset($lang)) {
-				$config->set('system', 'language', $lang);
-				unset($lang);
-			}
-		}
+		$config->loadConfigArray($this->loadLegacyConfigFile('htpreconfig'), true);
+		$config->loadConfigArray($this->loadLegacyConfigFile('htconfig'), true);
 
 		$config->loadConfigArray($this->loadCoreConfig('local'), true);
 	}
 
 	/**
-	 * Tries to load the specified legacy configuration file into the ConfigCache (@see ConfigCache ).
+	 * Tries to load the legacy config files (.htconfig.php, .htpreconfig.php)
+	 *
+	 * @param string $name The name of the config file
+	 * @return array The configuration array
+	 *
+	 * @deprecated since version 2018.09
+	 */
+	private function loadLegacyConfigFile($name)
+	{
+		$filePath = $this->baseDir  . DIRECTORY_SEPARATOR . '.' . $name . '.php';
+
+		if (file_exists($filePath)) {
+			$a = new \stdClass();
+			$a->config = [];
+			include $filePath;
+
+			if (isset($db_host)) {
+				$a->config['database']['hostname'] = $db_host;
+				unset($db_host);
+			}
+			if (isset($db_user)) {
+				$a->config['database']['username'] = $db_user;
+				unset($db_user);
+			}
+			if (isset($db_pass)) {
+				$a->config['database']['password'] = $db_pass;
+				unset($db_pass);
+			}
+			if (isset($db_data)) {
+				$a->config['database']['database'] = $db_data;
+				unset($db_data);
+			}
+			if (isset($a->config['system']['db_charset'])) {
+				$a->config['database']['charset'] = $a->config['system']['charset'];
+			}
+			if (isset($pidfile)) {
+				$a->config['system']['pidfile'] = $pidfile;
+				unset($pidfile);
+			}
+			if (isset($default_timezone)) {
+				$a->config['system']['default_timezone'] = $default_timezone;
+				unset($default_timezone);
+			}
+			if (isset($lang)) {
+				$a->config['system']['language'] = $lang;
+				unset($lang);
+			}
+
+			return $a->config;
+		} else {
+			return [];
+		}
+	}
+
+	/**
+	 * Tries to load the specified legacy configuration file and returns the config array.
 	 *
 	 * @deprecated since version 2018.12
 	 * @param string $filename
 	 *
-	 * @return array The configuration
+	 * @return array The configuration array
 	 * @throws \Exception
 	 */
 	public function loadINIConfigFile($filename)
 	{
-		$filepath = $this->configDir . $filename . ".ini.php";
+		$filepath = $this->configDir . DIRECTORY_SEPARATOR . $filename . ".ini.php";
 
 		if (!file_exists($filepath)) {
 			throw new \Exception('Error parsing non-existent INI config file ' . $filepath);
@@ -155,10 +174,10 @@ class ConfigCacheLoader
 	 */
 	public function loadCoreConfig($name)
 	{
-		if (file_exists($this->configDir . $name . '.config.php')) {
-			return $this->loadConfigFile($this->configDir . $name . '.config.php');
-		} elseif (file_exists($this->configDir . $name . '.ini.php')) {
-			return $this->loadINIConfigFile($this->configDir . $name . '.ini.php');
+		if (file_exists($this->configDir . DIRECTORY_SEPARATOR . $name . '.config.php')) {
+			return $this->loadConfigFile($this->configDir . DIRECTORY_SEPARATOR . $name . '.config.php');
+		} elseif (file_exists($this->configDir . DIRECTORY_SEPARATOR . $name . '.ini.php')) {
+			return $this->loadINIConfigFile($this->configDir . DIRECTORY_SEPARATOR . $name . '.ini.php');
 		} else {
 			return [];
 		}
@@ -178,7 +197,11 @@ class ConfigCacheLoader
 	 */
 	public function loadAddonConfig($name)
 	{
-		$filepath = $this->baseDir . Addon::DIRECTORY . $name . self::SUBDIRECTORY . $name . ".config.php";
+		$filepath = $this->baseDir . DIRECTORY_SEPARATOR . // /var/www/html/
+			Addon::DIRECTORY       . DIRECTORY_SEPARATOR . // addon/
+			$name                  . DIRECTORY_SEPARATOR . // openstreetmap/
+			self::SUBDIRECTORY     . DIRECTORY_SEPARATOR . // config/
+			$name . ".config.php";                         // openstreetmap.config.php
 
 		if (file_exists($filepath)) {
 			return $this->loadConfigFile($filepath);

--- a/src/Core/Config/ConfigCacheLoader.php
+++ b/src/Core/Config/ConfigCacheLoader.php
@@ -2,6 +2,8 @@
 
 namespace Friendica\Core\Config;
 
+use Friendica\Core\Addon;
+
 /**
  * The ConfigCacheLoader loads config-files and stores them in a ConfigCache ( @see ConfigCache )
  *
@@ -17,11 +19,6 @@ class ConfigCacheLoader
 	 * @var string
 	 */
 	const SUBDIRECTORY   = '/config/';
-	/**
-	 * The addon sub-directory
-	 * @var string
-	 */
-	const ADDONDIRECTORY = '/addon/';
 
 	private $baseDir;
 	private $configDir;
@@ -141,7 +138,7 @@ class ConfigCacheLoader
 	public function loadConfigFile($filename, $addon = false)
 	{
 		if ($addon) {
-			$filepath = $this->baseDir . self::ADDONDIRECTORY . $filename . self::SUBDIRECTORY . $filename . ".config.php";
+			$filepath = $this->baseDir . Addon::DIRECTORY . $filename . self::SUBDIRECTORY . $filename . ".config.php";
 		} else {
 			$filepath = $this->configDir . $filename . ".config.php";
 		}

--- a/src/Core/Config/ConfigCacheLoader.php
+++ b/src/Core/Config/ConfigCacheLoader.php
@@ -108,15 +108,13 @@ class ConfigCacheLoader
 	 * Tries to load the specified legacy configuration file and returns the config array.
 	 *
 	 * @deprecated since version 2018.12
-	 * @param string $filename
+	 * @param string $filepath
 	 *
 	 * @return array The configuration array
 	 * @throws \Exception
 	 */
-	public function loadINIConfigFile($filename)
+	public function loadINIConfigFile($filepath)
 	{
-		$filepath = $this->configDir . DIRECTORY_SEPARATOR . $filename . ".ini.php";
-
 		if (!file_exists($filepath)) {
 			throw new \Exception('Error parsing non-existent INI config file ' . $filepath);
 		}

--- a/src/Core/Config/ConfigCacheLoader.php
+++ b/src/Core/Config/ConfigCacheLoader.php
@@ -184,9 +184,6 @@ class ConfigCacheLoader
 	/**
 	 * Tries to load the specified addon-configuration and returns the config array.
 	 *
-	 * First loads all activated addons default configuration through the load_config hook, then load the local.config.php
-	 * again to overwrite potential local addon configuration.
-	 *
 	 * @param string $name The name of the configuration
 	 *
 	 * @return array The config array (empty if no config found)

--- a/src/Core/Config/ConfigCacheLoader.php
+++ b/src/Core/Config/ConfigCacheLoader.php
@@ -141,7 +141,7 @@ class ConfigCacheLoader
 	public function loadConfigFile($filename, $addon = false)
 	{
 		if ($addon) {
-			$filepath = $this->baseDir . self::ADDONSDIRECTORY . self::SUBDIRECTORY . $filename . ".config.php";
+			$filepath = $this->baseDir . self::ADDONSDIRECTORY . $filename . self::SUBDIRECTORY . $filename . ".config.php";
 		} else {
 			$filepath = $this->configDir . $filename . ".config.php";
 		}

--- a/src/Core/Config/ConfigCacheLoader.php
+++ b/src/Core/Config/ConfigCacheLoader.php
@@ -16,7 +16,12 @@ class ConfigCacheLoader
 	 * The Sub directory of the config-files
 	 * @var string
 	 */
-	const SUBDIRECTORY = '/config/';
+	const SUBDIRECTORY   = '/config/';
+	/**
+	 * The addon sub-directory
+	 * @var string
+	 */
+	const ADDONDIRECTORY = '/addon/';
 
 	private $baseDir;
 	private $configDir;
@@ -129,12 +134,17 @@ class ConfigCacheLoader
 	 * ];
 	 *
 	 * @param string $filename
+	 * @param bool   $addon     True, if a config for an addon should be loaded
 	 * @return array The configuration
 	 * @throws \Exception
 	 */
-	public function loadConfigFile($filename)
+	public function loadConfigFile($filename, $addon = false)
 	{
-		$filepath = $this->configDir . $filename . ".config.php";
+		if ($addon) {
+			$filepath = $this->baseDir . self::ADDONDIRECTORY . self::SUBDIRECTORY . $filename . ".config.php";
+		} else {
+			$filepath = $this->configDir . $filename . ".config.php";
+		}
 
 		if (!file_exists($filepath)) {
 			throw new \Exception('Error loading non-existent config file ' . $filepath);

--- a/src/Core/Config/IConfigAdapter.php
+++ b/src/Core/Config/IConfigAdapter.php
@@ -12,7 +12,7 @@ interface IConfigAdapter
 	 * @brief Loads all configuration values into a cached storage.
 	 *
 	 * All configuration values of the system are stored in global cache
-	 * which is available under the global variable $a->config
+	 * which is available under the global variable Config::$config
 	 *
 	 * @param string  $cat The category of the configuration values to load
 	 *
@@ -60,7 +60,7 @@ interface IConfigAdapter
 	/**
 	 * @brief Deletes the given key from the system configuration.
 	 *
-	 * Removes the configured value from the stored cache in $a->config
+	 * Removes the configured value from the stored cache in Config::$config
 	 * and removes it from the database.
 	 *
 	 * @param string $cat The category of the configuration value

--- a/src/Core/Config/IConfigAdapter.php
+++ b/src/Core/Config/IConfigAdapter.php
@@ -9,10 +9,7 @@ namespace Friendica\Core\Config;
 interface IConfigAdapter
 {
 	/**
-	 * @brief Loads all configuration values into a cached storage.
-	 *
-	 * All configuration values of the system are stored in global cache
-	 * which is available under the global variable Config::$config
+	 * Loads all configuration values into a cached storage.
 	 *
 	 * @param string  $cat The category of the configuration values to load
 	 *
@@ -21,16 +18,8 @@ interface IConfigAdapter
 	public function load($cat = "config");
 
 	/**
-	 * @brief Get a particular user's config variable given the category name
+	 * Get a particular user's config variable given the category name
 	 * ($family) and a key.
-	 *
-	 * Get a particular config value from the given category ($family)
-	 * and the $key from a cached storage in static::$config[$uid].
-	 * $instore is only used by the set_config function
-	 * to determine if the key already exists in the DB
-	 * If a key is found in the DB but doesn't exist in
-	 * local config cache, pull it into the cache so we don't have
-	 * to hit the DB again for this item.
 	 *
 	 * @param string  $cat           The category of the configuration value
 	 * @param string  $k             The configuration key to query
@@ -42,8 +31,6 @@ interface IConfigAdapter
 	public function get($cat, $k, $default_value = null, $refresh = false);
 
 	/**
-	 * @brief Sets a configuration value for system config
-	 *
 	 * Stores a config value ($value) in the category ($family) under the key ($key)
 	 * for the user_id $uid.
 	 *
@@ -58,9 +45,7 @@ interface IConfigAdapter
 	public function set($cat, $k, $value);
 
 	/**
-	 * @brief Deletes the given key from the system configuration.
-	 *
-	 * Removes the configured value from the stored cache in Config::$config
+	 * Removes the configured value from the stored cache
 	 * and removes it from the database.
 	 *
 	 * @param string $cat The category of the configuration value

--- a/src/Core/Config/IConfigAdapter.php
+++ b/src/Core/Config/IConfigAdapter.php
@@ -25,7 +25,7 @@ interface IConfigAdapter
 	 * ($family) and a key.
 	 *
 	 * Get a particular config value from the given category ($family)
-	 * and the $key from a cached storage in $a->config[$uid].
+	 * and the $key from a cached storage in static::$config[$uid].
 	 * $instore is only used by the set_config function
 	 * to determine if the key already exists in the DB
 	 * If a key is found in the DB but doesn't exist in

--- a/src/Core/Config/IConfigCache.php
+++ b/src/Core/Config/IConfigCache.php
@@ -2,6 +2,9 @@
 
 namespace Friendica\Core\Config;
 
+/**
+ * The interface for a system-wide ConfigCache
+ */
 interface IConfigCache
 {
 	/**

--- a/src/Core/Config/IConfigCache.php
+++ b/src/Core/Config/IConfigCache.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Friendica\Core\Config;
+
+interface IConfigCache
+{
+	/**
+	 * @param string $cat     Config category
+	 * @param string $key       Config key
+	 * @param mixed  $default Default value if it isn't set
+	 *
+	 * @return mixed Returns the value of the Config entry
+	 */
+	function get($cat, $key = null, $default = null);
+
+	/**
+	 * Sets a value in the config cache. Accepts raw output from the config table
+	 *
+	 * @param string $cat   Config category
+	 * @param string $key   Config key
+	 * @param mixed  $value Value to set
+	 */
+	function set($cat, $key, $value);
+
+	/**
+	 * Deletes a value from the config cache
+	 *
+	 * @param string $cat  Config category
+	 * @param string $key  Config key
+	 */
+	function delete($cat, $key);
+
+	function getAll();
+}

--- a/src/Core/Config/IPConfigAdapter.php
+++ b/src/Core/Config/IPConfigAdapter.php
@@ -18,7 +18,7 @@ interface IPConfigAdapter
 	 * @brief Loads all configuration values of a user's config family into a cached storage.
 	 *
 	 * All configuration values of the given user are stored in global cache
-	 * which is available under the global variable $a->config[$uid].
+	 * which is available under the global variable self::$config[$uid].
 	 *
 	 * @param string $uid The user_id
 	 * @param string $cat The category of the configuration value
@@ -32,7 +32,7 @@ interface IPConfigAdapter
 	 * ($family) and a key.
 	 *
 	 * Get a particular user's config value from the given category ($family)
-	 * and the $key from a cached storage in $a->config[$uid].
+	 * and the $key from a cached storage in self::$config[$uid].
 	 *
 	 * @param string  $uid           The user_id
 	 * @param string  $cat           The category of the configuration value
@@ -64,7 +64,7 @@ interface IPConfigAdapter
 	/**
 	 * @brief Deletes the given key from the users's configuration.
 	 *
-	 * Removes the configured value from the stored cache in $a->config[$uid]
+	 * Removes the configured value from the stored cache in self::$config[$uid]
 	 * and removes it from the database.
 	 *
 	 * @param string $uid The user_id

--- a/src/Core/Config/IPConfigAdapter.php
+++ b/src/Core/Config/IPConfigAdapter.php
@@ -15,10 +15,7 @@ namespace Friendica\Core\Config;
 interface IPConfigAdapter
 {
 	/**
-	 * @brief Loads all configuration values of a user's config family into a cached storage.
-	 *
-	 * All configuration values of the given user are stored in global cache
-	 * which is available under the global variable self::$config[$uid].
+	 * Loads all configuration values of a user's config family into a cached storage.
 	 *
 	 * @param string $uid The user_id
 	 * @param string $cat The category of the configuration value
@@ -28,11 +25,8 @@ interface IPConfigAdapter
 	public function load($uid, $cat);
 
 	/**
-	 * @brief Get a particular user's config variable given the category name
+	 * Get a particular user's config variable given the category name
 	 * ($family) and a key.
-	 *
-	 * Get a particular user's config value from the given category ($family)
-	 * and the $key from a cached storage in self::$config[$uid].
 	 *
 	 * @param string  $uid           The user_id
 	 * @param string  $cat           The category of the configuration value
@@ -45,8 +39,6 @@ interface IPConfigAdapter
 	public function get($uid, $cat, $k, $default_value = null, $refresh = false);
 
 	/**
-	 * @brief Sets a configuration value for a user
-	 *
 	 * Stores a config value ($value) in the category ($family) under the key ($key)
 	 * for the user_id $uid.
 	 *
@@ -62,9 +54,7 @@ interface IPConfigAdapter
 	public function set($uid, $cat, $k, $value);
 
 	/**
-	 * @brief Deletes the given key from the users's configuration.
-	 *
-	 * Removes the configured value from the stored cache in self::$config[$uid]
+	 * Removes the configured value from the stored cache
 	 * and removes it from the database.
 	 *
 	 * @param string $uid The user_id

--- a/src/Core/Config/IPConfigCache.php
+++ b/src/Core/Config/IPConfigCache.php
@@ -2,6 +2,9 @@
 
 namespace Friendica\Core\Config;
 
+/**
+ * The interface for a user-specific config cache
+ */
 interface IPConfigCache
 {
 	/**

--- a/src/Core/Config/IPConfigCache.php
+++ b/src/Core/Config/IPConfigCache.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Friendica\Core\Config;
+
+interface IPConfigCache
+{
+	/**
+	 * Retrieves a value from the user config cache
+	 *
+	 * @param int    $uid     User Id
+	 * @param string $cat     Config category
+	 * @param string $key     Config key
+	 * @param mixed  $default Default value if key isn't set
+	 *
+	 * @return string The value of the config entry
+	 */
+	function getP($uid, $cat, $key = null, $default = null);
+
+	/**
+	 * Sets a value in the user config cache
+	 *
+	 * Accepts raw output from the pconfig table
+	 *
+	 * @param int    $uid   User Id
+	 * @param string $cat   Config category
+	 * @param string $key   Config key
+	 * @param mixed  $value Value to set
+	 */
+	function setP($uid, $cat, $key, $value);
+
+	/**
+	 * Deletes a value from the user config cache
+	 *
+	 * @param int    $uid User Id
+	 * @param string $cat Config category
+	 * @param string $key Config key
+	 */
+	function deleteP($uid, $cat, $key);
+
+	function getAll();
+}

--- a/src/Core/Config/JITConfigAdapter.php
+++ b/src/Core/Config/JITConfigAdapter.php
@@ -28,6 +28,9 @@ class JITConfigAdapter implements IConfigAdapter
 		$this->configCache = $configCache;
 	}
 
+	/**
+	 * {@inheritdoc}
+	 */
 	public function load($cat = "config")
 	{
 		// We don't preload "system" anymore.
@@ -50,6 +53,9 @@ class JITConfigAdapter implements IConfigAdapter
 		DBA::close($configs);
 	}
 
+	/**
+	 * {@inheritdoc}
+	 */
 	public function get($cat, $k, $default_value = null, $refresh = false)
 	{
 		if (!$refresh) {
@@ -92,6 +98,9 @@ class JITConfigAdapter implements IConfigAdapter
 		return $default_value;
 	}
 
+	/**
+	 * {@inheritdoc}
+	 */
 	public function set($cat, $k, $value)
 	{
 		// We store our setting values in a string variable.
@@ -129,6 +138,9 @@ class JITConfigAdapter implements IConfigAdapter
 		return $result;
 	}
 
+	/**
+	 * {@inheritdoc}
+	 */
 	public function delete($cat, $k)
 	{
 		if (isset($this->cache[$cat][$k])) {

--- a/src/Core/Config/JITConfigAdapter.php
+++ b/src/Core/Config/JITConfigAdapter.php
@@ -18,14 +18,14 @@ class JITConfigAdapter implements IConfigAdapter
 	/**
 	 * @var IConfigCache The config cache of this driver
 	 */
-	private $config;
+	private $configCache;
 
 	/**
-	 * @param IConfigCache $config The config cache of this driver
+	 * @param IConfigCache $configCache The config cache of this driver
 	 */
-	public function __construct($config)
+	public function __construct(IConfigCache $configCache)
 	{
-		$this->config = $config;
+		$this->configCache = $configCache;
 	}
 
 	public function load($cat = "config")
@@ -40,7 +40,7 @@ class JITConfigAdapter implements IConfigAdapter
 		while ($config = DBA::fetch($configs)) {
 			$k = $config['k'];
 
-			$this->config->set($cat, $k, $config['v']);
+			$this->configCache->set($cat, $k, $config['v']);
 
 			if ($cat !== 'config') {
 				$this->cache[$cat][$k] = $config['v'];
@@ -72,18 +72,18 @@ class JITConfigAdapter implements IConfigAdapter
 			$this->cache[$cat][$k] = $value;
 			$this->in_db[$cat][$k] = true;
 			return $value;
-		} elseif ($this->config->get($cat, $k) !== null) {
+		} elseif ($this->configCache->get($cat, $k) !== null) {
 			// Assign the value (mostly) from config/local.config.php file to the cache
-			$this->cache[$cat][$k] = $this->config->get($cat, $k);
+			$this->cache[$cat][$k] = $this->configCache->get($cat, $k);
 			$this->in_db[$cat][$k] = false;
 
-			return $this->config->get($cat, $k);
-		} elseif ($this->config->get('config', $k) !== null) {
+			return $this->configCache->get($cat, $k);
+		} elseif ($this->configCache->get('config', $k) !== null) {
 			// Assign the value (mostly) from config/local.config.php file to the cache
-			$this->cache[$k] = $this->config->get('config', $k);
+			$this->cache[$k] = $this->configCache->get('config', $k);
 			$this->in_db[$k] = false;
 
-			return $this->config->get('config', $k);
+			return $this->configCache->get('config', $k);
 		}
 
 		$this->cache[$cat][$k] = '!<unset>!';
@@ -112,7 +112,7 @@ class JITConfigAdapter implements IConfigAdapter
 			return true;
 		}
 
-		$this->config->set($cat, $k, $value);
+		$this->configCache->set($cat, $k, $value);
 
 		// Assign the just added value to the cache
 		$this->cache[$cat][$k] = $dbvalue;

--- a/src/Core/Config/JITPConfigAdapter.php
+++ b/src/Core/Config/JITPConfigAdapter.php
@@ -28,6 +28,9 @@ class JITPConfigAdapter implements IPConfigAdapter
 		$this->configCache = $configCache;
 	}
 
+	/**
+	 * {@inheritdoc}
+	 */
 	public function load($uid, $cat)
 	{
 		$pconfigs = DBA::select('pconfig', ['v', 'k'], ['cat' => $cat, 'uid' => $uid]);
@@ -46,6 +49,9 @@ class JITPConfigAdapter implements IPConfigAdapter
 		DBA::close($pconfigs);
 	}
 
+	/**
+	 * {@inheritdoc}
+	 */
 	public function get($uid, $cat, $k, $default_value = null, $refresh = false)
 	{
 		if (!$refresh) {
@@ -82,6 +88,9 @@ class JITPConfigAdapter implements IPConfigAdapter
 		}
 	}
 
+	/**
+	 * {@inheritdoc}
+	 */
 	public function set($uid, $cat, $k, $value)
 	{
 		// We store our setting values in a string variable.
@@ -109,6 +118,9 @@ class JITPConfigAdapter implements IPConfigAdapter
 		return $result;
 	}
 
+	/**
+	 * {@inheritdoc}
+	 */
 	public function delete($uid, $cat, $k)
 	{
 		$this->configCache->deleteP($uid, $cat, $k);

--- a/src/Core/Config/JITPConfigAdapter.php
+++ b/src/Core/Config/JITPConfigAdapter.php
@@ -18,14 +18,14 @@ class JITPConfigAdapter implements IPConfigAdapter
 	 * The config cache of this adapter
 	 * @var IPConfigCache
 	 */
-	private $config;
+	private $configCache;
 
 	/**
-	 * @param IPConfigCache $config The config cache of this adapter
+	 * @param IPConfigCache $configCache The config cache of this adapter
 	 */
-	public function __construct($config)
+	public function __construct(IPConfigCache $configCache)
 	{
-		$this->config = $config;
+		$this->configCache = $configCache;
 	}
 
 	public function load($uid, $cat)
@@ -35,13 +35,13 @@ class JITPConfigAdapter implements IPConfigAdapter
 			while ($pconfig = DBA::fetch($pconfigs)) {
 				$k = $pconfig['k'];
 
-				$this->config->setP($uid, $cat, $k, $pconfig['v']);
+				$this->configCache->setP($uid, $cat, $k, $pconfig['v']);
 
 				$this->in_db[$uid][$cat][$k] = true;
 			}
 		} else if ($cat != 'config') {
 			// Negative caching
-			$this->config->setP($uid, $cat, null, "!<unset>!");
+			$this->configCache->setP($uid, $cat, null, "!<unset>!");
 		}
 		DBA::close($pconfigs);
 	}
@@ -50,17 +50,17 @@ class JITPConfigAdapter implements IPConfigAdapter
 	{
 		if (!$refresh) {
 			// Looking if the whole family isn't set
-			if ($this->config->getP($uid, $cat) !== null) {
-				if ($this->config->getP($uid, $cat) === '!<unset>!') {
+			if ($this->configCache->getP($uid, $cat) !== null) {
+				if ($this->configCache->getP($uid, $cat) === '!<unset>!') {
 					return $default_value;
 				}
 			}
 
-			if ($this->config->getP($uid, $cat, $k) !== null) {
-				if ($this->config->getP($uid, $cat, $k) === '!<unset>!') {
+			if ($this->configCache->getP($uid, $cat, $k) !== null) {
+				if ($this->configCache->getP($uid, $cat, $k) === '!<unset>!') {
 					return $default_value;
 				}
-				return $this->config->getP($uid, $cat, $k);
+				return $this->configCache->getP($uid, $cat, $k);
 			}
 		}
 
@@ -68,13 +68,13 @@ class JITPConfigAdapter implements IPConfigAdapter
 		if (DBA::isResult($pconfig)) {
 			$val = (preg_match("|^a:[0-9]+:{.*}$|s", $pconfig['v']) ? unserialize($pconfig['v']) : $pconfig['v']);
 
-			$this->config->setP($uid, $cat, $k, $val);
+			$this->configCache->setP($uid, $cat, $k, $val);
 
 			$this->in_db[$uid][$cat][$k] = true;
 
 			return $val;
 		} else {
-			$this->config->setP($uid, $cat, $k, '!<unset>!');
+			$this->configCache->setP($uid, $cat, $k, '!<unset>!');
 
 			$this->in_db[$uid][$cat][$k] = false;
 
@@ -95,7 +95,7 @@ class JITPConfigAdapter implements IPConfigAdapter
 			return true;
 		}
 
-		$this->config->setP($uid, $cat, $k, $value);
+		$this->configCache->setP($uid, $cat, $k, $value);
 
 		// manage array value
 		$dbvalue = (is_array($value) ? serialize($value) : $dbvalue);
@@ -111,7 +111,7 @@ class JITPConfigAdapter implements IPConfigAdapter
 
 	public function delete($uid, $cat, $k)
 	{
-		$this->config->deleteP($uid, $cat, $k);
+		$this->configCache->deleteP($uid, $cat, $k);
 
 		if (!empty($this->in_db[$uid][$cat][$k])) {
 			unset($this->in_db[$uid][$cat][$k]);

--- a/src/Core/Config/JITPConfigAdapter.php
+++ b/src/Core/Config/JITPConfigAdapter.php
@@ -28,7 +28,7 @@ class JITPConfigAdapter implements IPConfigAdapter
 			}
 		} else if ($cat != 'config') {
 			// Negative caching
-			PConfig::setPConfigValue($uid, $cat, "!<unset>!");
+			PConfig::setPConfigValue($uid, $cat, null, "!<unset>!");
 		}
 		DBA::close($pconfigs);
 	}

--- a/src/Core/Config/PreloadConfigAdapter.php
+++ b/src/Core/Config/PreloadConfigAdapter.php
@@ -3,7 +3,7 @@
 namespace Friendica\Core\Config;
 
 use Exception;
-use Friendica\BaseObject;
+use Friendica\Core\Config;
 use Friendica\Database\DBA;
 
 /**
@@ -13,7 +13,7 @@ use Friendica\Database\DBA;
  *
  * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
-class PreloadConfigAdapter extends BaseObject implements IConfigAdapter
+class PreloadConfigAdapter implements IConfigAdapter
 {
 	private $config_loaded = false;
 
@@ -30,7 +30,7 @@ class PreloadConfigAdapter extends BaseObject implements IConfigAdapter
 
 		$configs = DBA::select('config', ['cat', 'v', 'k']);
 		while ($config = DBA::fetch($configs)) {
-			self::getApp()->setConfigValue($config['cat'], $config['k'], $config['v']);
+			Config::setConfigValue($config['cat'], $config['k'], $config['v']);
 		}
 		DBA::close($configs);
 
@@ -42,11 +42,11 @@ class PreloadConfigAdapter extends BaseObject implements IConfigAdapter
 		if ($refresh) {
 			$config = DBA::selectFirst('config', ['v'], ['cat' => $cat, 'k' => $k]);
 			if (DBA::isResult($config)) {
-				self::getApp()->setConfigValue($cat, $k, $config['v']);
+				Config::setConfigValue($cat, $k, $config['v']);
 			}
 		}
 
-		$return = self::getApp()->getConfigValue($cat, $k, $default_value);
+		$return = Config::getConfigValue($cat, $k, $default_value);
 
 		return $return;
 	}
@@ -58,11 +58,11 @@ class PreloadConfigAdapter extends BaseObject implements IConfigAdapter
 		// The exception are array values.
 		$compare_value = !is_array($value) ? (string)$value : $value;
 
-		if (self::getApp()->getConfigValue($cat, $k) === $compare_value) {
+		if (Config::getConfigValue($cat, $k) === $compare_value) {
 			return true;
 		}
 
-		self::getApp()->setConfigValue($cat, $k, $value);
+		Config::setConfigValue($cat, $k, $value);
 
 		// manage array value
 		$dbvalue = is_array($value) ? serialize($value) : $value;
@@ -77,7 +77,7 @@ class PreloadConfigAdapter extends BaseObject implements IConfigAdapter
 
 	public function delete($cat, $k)
 	{
-		self::getApp()->deleteConfigValue($cat, $k);
+		Config::deleteConfigValue($cat, $k);
 
 		$result = DBA::delete('config', ['cat' => $cat, 'k' => $k]);
 

--- a/src/Core/Config/PreloadConfigAdapter.php
+++ b/src/Core/Config/PreloadConfigAdapter.php
@@ -19,14 +19,14 @@ class PreloadConfigAdapter implements IConfigAdapter
 	/**
 	 * @var IConfigCache The config cache of this driver
 	 */
-	private $config;
+	private $configCache;
 
 	/**
-	 * @param IConfigCache $config The config cache of this driver
+	 * @param IConfigCache $configCache The config cache of this driver
 	 */
-	public function __construct($config)
+	public function __construct(IConfigCache $configCache)
 	{
-		$this->config = $config;
+		$this->configCache = $configCache;
 		$this->load();
 	}
 
@@ -38,7 +38,7 @@ class PreloadConfigAdapter implements IConfigAdapter
 
 		$configs = DBA::select('config', ['cat', 'v', 'k']);
 		while ($config = DBA::fetch($configs)) {
-			$this->config->set($config['cat'], $config['k'], $config['v']);
+			$this->configCache->set($config['cat'], $config['k'], $config['v']);
 		}
 		DBA::close($configs);
 
@@ -50,11 +50,11 @@ class PreloadConfigAdapter implements IConfigAdapter
 		if ($refresh) {
 			$config = DBA::selectFirst('config', ['v'], ['cat' => $cat, 'k' => $k]);
 			if (DBA::isResult($config)) {
-				$this->config->set($cat, $k, $config['v']);
+				$this->configCache->set($cat, $k, $config['v']);
 			}
 		}
 
-		$return = $this->config->get($cat, $k, $default_value);
+		$return = $this->configCache->get($cat, $k, $default_value);
 
 		return $return;
 	}
@@ -66,11 +66,11 @@ class PreloadConfigAdapter implements IConfigAdapter
 		// The exception are array values.
 		$compare_value = !is_array($value) ? (string)$value : $value;
 
-		if ($this->config->get($cat, $k) === $compare_value) {
+		if ($this->configCache->get($cat, $k) === $compare_value) {
 			return true;
 		}
 
-		$this->config->set($cat, $k, $value);
+		$this->configCache->set($cat, $k, $value);
 
 		// manage array value
 		$dbvalue = is_array($value) ? serialize($value) : $value;
@@ -85,7 +85,7 @@ class PreloadConfigAdapter implements IConfigAdapter
 
 	public function delete($cat, $k)
 	{
-		$this->config->delete($cat, $k);
+		$this->configCache->delete($cat, $k);
 
 		$result = DBA::delete('config', ['cat' => $cat, 'k' => $k]);
 

--- a/src/Core/Config/PreloadConfigAdapter.php
+++ b/src/Core/Config/PreloadConfigAdapter.php
@@ -30,6 +30,9 @@ class PreloadConfigAdapter implements IConfigAdapter
 		$this->load();
 	}
 
+	/**
+	 * {@inheritdoc}
+	 */
 	public function load($family = 'config')
 	{
 		if ($this->config_loaded) {
@@ -45,6 +48,9 @@ class PreloadConfigAdapter implements IConfigAdapter
 		$this->config_loaded = true;
 	}
 
+	/**
+	 * {@inheritdoc}
+	 */
 	public function get($cat, $k, $default_value = null, $refresh = false)
 	{
 		if ($refresh) {
@@ -59,6 +65,9 @@ class PreloadConfigAdapter implements IConfigAdapter
 		return $return;
 	}
 
+	/**
+	 * {@inheritdoc}
+	 */
 	public function set($cat, $k, $value)
 	{
 		// We store our setting values as strings.
@@ -83,6 +92,9 @@ class PreloadConfigAdapter implements IConfigAdapter
 		return true;
 	}
 
+	/**
+	 * {@inheritdoc}
+	 */
 	public function delete($cat, $k)
 	{
 		$this->configCache->delete($cat, $k);

--- a/src/Core/Config/PreloadPConfigAdapter.php
+++ b/src/Core/Config/PreloadPConfigAdapter.php
@@ -34,6 +34,9 @@ class PreloadPConfigAdapter implements IPConfigAdapter
 		}
 	}
 
+	/**
+	 * {@inheritdoc}
+	 */
 	public function load($uid, $family)
 	{
 		if ($this->config_loaded) {
@@ -53,6 +56,9 @@ class PreloadPConfigAdapter implements IPConfigAdapter
 		$this->config_loaded = true;
 	}
 
+	/**
+	 * {@inheritdoc}
+	 */
 	public function get($uid, $cat, $k, $default_value = null, $refresh = false)
 	{
 		if (!$this->config_loaded) {
@@ -71,6 +77,9 @@ class PreloadPConfigAdapter implements IPConfigAdapter
 		return $this->configCache->getP($uid, $cat, $k, $default_value);;
 	}
 
+	/**
+	 * {@inheritdoc}
+	 */
 	public function set($uid, $cat, $k, $value)
 	{
 		if (!$this->config_loaded) {
@@ -98,6 +107,9 @@ class PreloadPConfigAdapter implements IPConfigAdapter
 		return true;
 	}
 
+	/**
+	 * {@inheritdoc}
+	 */
 	public function delete($uid, $cat, $k)
 	{
 		if (!$this->config_loaded) {

--- a/src/Core/Config/PreloadPConfigAdapter.php
+++ b/src/Core/Config/PreloadPConfigAdapter.php
@@ -3,7 +3,7 @@
 namespace Friendica\Core\Config;
 
 use Exception;
-use Friendica\BaseObject;
+use Friendica\Core\PConfig;
 use Friendica\Database\DBA;
 
 /**
@@ -13,7 +13,7 @@ use Friendica\Database\DBA;
  *
  * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
-class PreloadPConfigAdapter extends BaseObject implements IPConfigAdapter
+class PreloadPConfigAdapter implements IPConfigAdapter
 {
 	private $config_loaded = false;
 
@@ -34,7 +34,7 @@ class PreloadPConfigAdapter extends BaseObject implements IPConfigAdapter
 
 		$pconfigs = DBA::select('pconfig', ['cat', 'v', 'k'], ['uid' => $uid]);
 		while ($pconfig = DBA::fetch($pconfigs)) {
-			self::getApp()->setPConfigValue($uid, $pconfig['cat'], $pconfig['k'], $pconfig['v']);
+			PConfig::setPConfigValue($uid, $pconfig['cat'], $pconfig['k'], $pconfig['v']);
 		}
 		DBA::close($pconfigs);
 
@@ -50,13 +50,13 @@ class PreloadPConfigAdapter extends BaseObject implements IPConfigAdapter
 		if ($refresh) {
 			$config = DBA::selectFirst('pconfig', ['v'], ['uid' => $uid, 'cat' => $cat, 'k' => $k]);
 			if (DBA::isResult($config)) {
-				self::getApp()->setPConfigValue($uid, $cat, $k, $config['v']);
+				PConfig::setPConfigValue($uid, $cat, $k, $config['v']);
 			} else {
-				self::getApp()->deletePConfigValue($uid, $cat, $k);
+				PConfig::deletePConfigValue($uid, $cat, $k);
 			}
 		}
 
-		$return = self::getApp()->getPConfigValue($uid, $cat, $k, $default_value);
+		$return = PConfig::getPConfigValue($uid, $cat, $k, $default_value);
 
 		return $return;
 	}
@@ -71,11 +71,11 @@ class PreloadPConfigAdapter extends BaseObject implements IPConfigAdapter
 		// The exception are array values.
 		$compare_value = !is_array($value) ? (string)$value : $value;
 
-		if (self::getApp()->getPConfigValue($uid, $cat, $k) === $compare_value) {
+		if (PConfig::getPConfigValue($uid, $cat, $k) === $compare_value) {
 			return true;
 		}
 
-		self::getApp()->setPConfigValue($uid, $cat, $k, $value);
+		PConfig::setPConfigValue($uid, $cat, $k, $value);
 
 		// manage array value
 		$dbvalue = is_array($value) ? serialize($value) : $value;
@@ -94,7 +94,7 @@ class PreloadPConfigAdapter extends BaseObject implements IPConfigAdapter
 			$this->load($uid, $cat);
 		}
 
-		self::getApp()->deletePConfigValue($uid, $cat, $k);
+		PConfig::deletePConfigValue($uid, $cat, $k);
 
 		$result = DBA::delete('pconfig', ['uid' => $uid, 'cat' => $cat, 'k' => $k]);
 

--- a/src/Core/Config/PreloadPConfigAdapter.php
+++ b/src/Core/Config/PreloadPConfigAdapter.php
@@ -20,15 +20,15 @@ class PreloadPConfigAdapter implements IPConfigAdapter
 	 * The config cache of this adapter
 	 * @var IPConfigCache
 	 */
-	private $config;
+	private $configCache;
 
 	/**
-	 * @param IPConfigCache $config The config cache of this adapter
+	 * @param IPConfigCache $configCache The config cache of this adapter
 	 * @param int           $uid    The UID of the current user
 	 */
-	public function __construct($config, $uid = null)
+	public function __construct(IPConfigCache $configCache, $uid = null)
 	{
-		$this->config = $config;
+		$this->configCache = $configCache;
 		if (isset($uid)) {
 			$this->load($uid, 'config');
 		}
@@ -46,7 +46,7 @@ class PreloadPConfigAdapter implements IPConfigAdapter
 
 		$pconfigs = DBA::select('pconfig', ['cat', 'v', 'k'], ['uid' => $uid]);
 		while ($pconfig = DBA::fetch($pconfigs)) {
-			$this->config->setP($uid, $pconfig['cat'], $pconfig['k'], $pconfig['v']);
+			$this->configCache->setP($uid, $pconfig['cat'], $pconfig['k'], $pconfig['v']);
 		}
 		DBA::close($pconfigs);
 
@@ -62,13 +62,13 @@ class PreloadPConfigAdapter implements IPConfigAdapter
 		if ($refresh) {
 			$config = DBA::selectFirst('pconfig', ['v'], ['uid' => $uid, 'cat' => $cat, 'k' => $k]);
 			if (DBA::isResult($config)) {
-				$this->config->setP($uid, $cat, $k, $config['v']);
+				$this->configCache->setP($uid, $cat, $k, $config['v']);
 			} else {
-				$this->config->deleteP($uid, $cat, $k);
+				$this->configCache->deleteP($uid, $cat, $k);
 			}
 		}
 
-		return $this->config->getP($uid, $cat, $k, $default_value);;
+		return $this->configCache->getP($uid, $cat, $k, $default_value);;
 	}
 
 	public function set($uid, $cat, $k, $value)
@@ -81,11 +81,11 @@ class PreloadPConfigAdapter implements IPConfigAdapter
 		// The exception are array values.
 		$compare_value = !is_array($value) ? (string)$value : $value;
 
-		if ($this->config->getP($uid, $cat, $k) === $compare_value) {
+		if ($this->configCache->getP($uid, $cat, $k) === $compare_value) {
 			return true;
 		}
 
-		$this->config->setP($uid, $cat, $k, $value);
+		$this->configCache->setP($uid, $cat, $k, $value);
 
 		// manage array value
 		$dbvalue = is_array($value) ? serialize($value) : $value;
@@ -104,7 +104,7 @@ class PreloadPConfigAdapter implements IPConfigAdapter
 			$this->load($uid, $cat);
 		}
 
-		$this->config->deleteP($uid, $cat, $k);
+		$this->configCache->deleteP($uid, $cat, $k);
 
 		$result = DBA::delete('pconfig', ['uid' => $uid, 'cat' => $cat, 'k' => $k]);
 

--- a/src/Core/Config/PreloadPConfigAdapter.php
+++ b/src/Core/Config/PreloadPConfigAdapter.php
@@ -23,13 +23,15 @@ class PreloadPConfigAdapter implements IPConfigAdapter
 	private $config;
 
 	/**
-	 * @param int           $uid    The UID of the current user
 	 * @param IPConfigCache $config The config cache of this adapter
+	 * @param int           $uid    The UID of the current user
 	 */
-	public function __construct($uid, $config)
+	public function __construct($config, $uid = null)
 	{
 		$this->config = $config;
-		$this->load($uid, 'config');
+		if (isset($uid)) {
+			$this->load($uid, 'config');
+		}
 	}
 
 	public function load($uid, $family)

--- a/src/Core/Console/AutomaticInstallation.php
+++ b/src/Core/Console/AutomaticInstallation.php
@@ -100,10 +100,10 @@ HELP;
 				}
 			}
 
-			$db_host = Config::getConfigValue('database', 'hostname');
-			$db_user = Config::getConfigValue('database', 'username');
-			$db_pass = Config::getConfigValue('database', 'password');
-			$db_data = Config::getConfigValue('database', 'database');
+			$db_host = $a->getConfig()->get('database', 'hostname');
+			$db_user = $a->getConfig()->get('database', 'username');
+			$db_pass = $a->getConfig()->get('database', 'password');
+			$db_data = $a->getConfig()->get('database', 'database');
 		} else {
 			// Creating config file
 			$this->out("Creating config file...\n");

--- a/src/Core/Console/AutomaticInstallation.php
+++ b/src/Core/Console/AutomaticInstallation.php
@@ -100,10 +100,10 @@ HELP;
 				}
 			}
 
-			$db_host = $a->getConfigValue('database', 'hostname');
-			$db_user = $a->getConfigValue('database', 'username');
-			$db_pass = $a->getConfigValue('database', 'password');
-			$db_data = $a->getConfigValue('database', 'database');
+			$db_host = Config::getConfigValue('database', 'hostname');
+			$db_user = Config::getConfigValue('database', 'username');
+			$db_pass = Config::getConfigValue('database', 'password');
+			$db_data = Config::getConfigValue('database', 'database');
 		} else {
 			// Creating config file
 			$this->out("Creating config file...\n");

--- a/src/Core/Console/AutomaticInstallation.php
+++ b/src/Core/Console/AutomaticInstallation.php
@@ -158,7 +158,7 @@ HELP;
 
 		$installer->resetChecks();
 
-		if (!$installer->installDatabase()) {
+		if (!$installer->installDatabase($a->getBasePath())) {
 			$errorMessage = $this->extractErrors($installer->getChecks());
 			throw new RuntimeException($errorMessage);
 		}

--- a/src/Core/Console/Config.php
+++ b/src/Core/Console/Config.php
@@ -124,9 +124,10 @@ HELP;
 			$cat = $this->getArgument(0);
 			Core\Config::load($cat);
 
-			if (!is_null($a->config[$cat])) {
+			if (Core\Config::getConfigValue($cat) !== null) {
 				$this->out("[{$cat}]");
-				foreach ($a->config[$cat] as $key => $value) {
+				$catVal = Core\Config::getConfigValue($cat);
+				foreach ($catVal as $key => $value) {
 					if (is_array($value)) {
 						foreach ($value as $k => $v) {
 							$this->out("{$key}[{$k}] => " . $v);
@@ -147,7 +148,8 @@ HELP;
 				$this->out('Warning: The JIT (Just In Time) Config adapter doesn\'t support loading the entire configuration, showing file config only');
 			}
 
-			foreach ($a->config as $cat => $section) {
+			$config = Core\Config::getAll();
+			foreach ($config as $cat => $section) {
 				if (is_array($section)) {
 					foreach ($section as $key => $value) {
 						if (is_array($value)) {

--- a/src/Core/Console/Config.php
+++ b/src/Core/Console/Config.php
@@ -113,7 +113,7 @@ HELP;
 
 			if (is_array($value)) {
 				foreach ($value as $k => $v) {
-					$this->out("{$cat}.{$key}[{$k}] => " . $v);
+					$this->out("{$cat}.{$key}[{$k}] => " . (is_array($v) ? implode(', ', $v) : $v));
 				}
 			} else {
 				$this->out("{$cat}.{$key} => " . $value);
@@ -130,7 +130,7 @@ HELP;
 				foreach ($catVal as $key => $value) {
 					if (is_array($value)) {
 						foreach ($value as $k => $v) {
-							$this->out("{$key}[{$k}] => " . $v);
+							$this->out("{$key}[{$k}] => " . (is_array($v) ? implode(', ', $v) : $v));
 						}
 					} else {
 						$this->out("{$key} => " . $value);
@@ -154,7 +154,7 @@ HELP;
 					foreach ($section as $key => $value) {
 						if (is_array($value)) {
 							foreach ($value as $k => $v) {
-								$this->out("{$cat}.{$key}[{$k}] => " . $v);
+								$this->out("{$cat}.{$key}[{$k}] => " . (is_array($v) ? implode(', ', $v) : $v));
 							}
 						} else {
 							$this->out("{$cat}.{$key} => " . $value);

--- a/src/Core/Console/Config.php
+++ b/src/Core/Console/Config.php
@@ -124,9 +124,9 @@ HELP;
 			$cat = $this->getArgument(0);
 			Core\Config::load($cat);
 
-			if (Core\Config::getConfigValue($cat) !== null) {
+			if ($a->getConfig()->get($cat) !== null) {
 				$this->out("[{$cat}]");
-				$catVal = Core\Config::getConfigValue($cat);
+				$catVal = $a->getConfig()->get($cat);
 				foreach ($catVal as $key => $value) {
 					if (is_array($value)) {
 						foreach ($value as $k => $v) {
@@ -148,7 +148,7 @@ HELP;
 				$this->out('Warning: The JIT (Just In Time) Config adapter doesn\'t support loading the entire configuration, showing file config only');
 			}
 
-			$config = Core\Config::getAll();
+			$config = $a->getConfig()->getAll();
 			foreach ($config as $cat => $section) {
 				if (is_array($section)) {
 					foreach ($section as $key => $value) {

--- a/src/Core/Console/DatabaseStructure.php
+++ b/src/Core/Console/DatabaseStructure.php
@@ -61,17 +61,19 @@ HELP;
 
 		Core\Config::load();
 
+		$a = get_app();
+
 		switch ($this->getArgument(0)) {
 			case "dryrun":
-				$output = DBStructure::update(true, false);
+				$output = DBStructure::update($a->getBasePath(), true, false);
 				break;
 			case "update":
 				$force = $this->getOption(['f', 'force'], false);
-				$output = Update::run($force, true, false);
+				$output = Update::run($a->getBasePath(), $force, true, false);
 				break;
 			case "dumpsql":
 				ob_start();
-				DBStructure::printStructure();
+				DBStructure::printStructure($a->getBasePath());
 				$output = ob_get_clean();
 				break;
 			case "toinnodb":

--- a/src/Core/Console/PostUpdate.php
+++ b/src/Core/Console/PostUpdate.php
@@ -2,8 +2,8 @@
 
 namespace Friendica\Core\Console;
 
-use Friendica\Core\L10n;
 use Friendica\Core\Config;
+use Friendica\Core\L10n;
 use Friendica\Core\Update;
 
 /**
@@ -56,7 +56,7 @@ HELP;
 		}
 
 		echo L10n::t('Check for pending update actions.') . "\n";
-		Update::run(true, true, false);
+		Update::run($a->getBasePath(), true, true, false);
 		echo L10n::t('Done.') . "\n";
 
 		echo L10n::t('Execute pending post updates.') . "\n";

--- a/src/Core/Console/Typo.php
+++ b/src/Core/Console/Typo.php
@@ -41,9 +41,7 @@ HELP;
 			throw new \Asika\SimpleConsole\CommandArgsException('Too many arguments');
 		}
 
-		$a = \get_app();
-
-		$php_path = $a->getConfigValue('config', 'php_path', 'php');
+		$php_path = \Friendica\Core\Config::getConfigValue('config', 'php_path', 'php');
 
 		if ($this->getOption('v')) {
 			$this->out('Directory: src');

--- a/src/Core/Console/Typo.php
+++ b/src/Core/Console/Typo.php
@@ -2,6 +2,8 @@
 
 namespace Friendica\Core\Console;
 
+use Friendica\BaseObject;
+
 /**
  * Tired of chasing typos and finding them after a commit.
  * Run this and quickly see if we've got any parse errors in our application files.
@@ -41,7 +43,7 @@ HELP;
 			throw new \Asika\SimpleConsole\CommandArgsException('Too many arguments');
 		}
 
-		$php_path = \Friendica\Core\Config::getConfigValue('config', 'php_path', 'php');
+		$php_path = BaseObject::getApp()->getConfig()->get('config', 'php_path', 'php');
 
 		if ($this->getOption('v')) {
 			$this->out('Directory: src');

--- a/src/Core/Installer.php
+++ b/src/Core/Installer.php
@@ -168,12 +168,14 @@ class Installer
 	/***
 	 * Installs the DB-Scheme for Friendica
 	 *
+	 * @param string $basePath The base path of this application
+	 *
 	 * @return bool true if the installation was successful, otherwise false
 	 * @throws Exception
 	 */
-	public function installDatabase()
+	public function installDatabase($basePath)
 	{
-		$result = DBStructure::update(false, true, true);
+		$result = DBStructure::update($basePath, false, true, true);
 
 		if ($result) {
 			$txt = L10n::t('You may need to import the file "database.sql" manually using phpmyadmin or mysql.') . EOL;

--- a/src/Core/Logger.php
+++ b/src/Core/Logger.php
@@ -5,8 +5,8 @@
 namespace Friendica\Core;
 
 use Friendica\BaseObject;
+use Friendica\Factory\LoggerFactory;
 use Friendica\Network\HTTPException\InternalServerErrorException;
-use Friendica\Util\LoggerFactory;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 

--- a/src/Core/PConfig.php
+++ b/src/Core/PConfig.php
@@ -34,7 +34,7 @@ class PConfig extends BaseObject
 			return;
 		}
 
-		if ($a->getConfigValue('system', 'config_adapter') == 'preload') {
+		if (Config::getConfigValue('system', 'config_adapter') == 'preload') {
 			self::$adapter = new Config\PreloadPConfigAdapter($uid);
 		} else {
 			self::$adapter = new Config\JITPConfigAdapter();

--- a/src/Core/PConfig.php
+++ b/src/Core/PConfig.php
@@ -25,16 +25,16 @@ class PConfig
 	/**
 	 * @var Config\IPConfigCache
 	 */
-	private static $config;
+	private static $cache;
 
 	/**
 	 * Initialize the config with only the cache
 	 *
-	 * @param Config\IPConfigCache $config  The configuration cache
+	 * @param Config\IPConfigCache $cache  The configuration cache
 	 */
-	public static function init($config)
+	public static function init(Config\IPConfigCache $cache)
 	{
-		self::$config  = $config;
+		self::$cache  = $cache;
 	}
 
 	/**
@@ -42,7 +42,7 @@ class PConfig
 	 *
 	 * @param Config\IPConfigAdapter $adapter
 	 */
-	public static function setAdapter($adapter)
+	public static function setAdapter(Config\IPConfigAdapter $adapter)
 	{
 		self::$adapter = $adapter;
 	}
@@ -85,7 +85,7 @@ class PConfig
 	public static function get($uid, $family, $key, $default_value = null, $refresh = false)
 	{
 		if (!isset(self::$adapter)) {
-			return self::$config->getP($uid, $family, $key, $default_value);
+			return self::$cache->getP($uid, $family, $key, $default_value);
 		}
 
 		return self::$adapter->get($uid, $family, $key, $default_value, $refresh);
@@ -109,7 +109,7 @@ class PConfig
 	public static function set($uid, $family, $key, $value)
 	{
 		if (!isset(self::$adapter)) {
-			return self::$config->setP($uid, $family, $key, $value);
+			return self::$cache->setP($uid, $family, $key, $value);
 		}
 
 		return self::$adapter->set($uid, $family, $key, $value);
@@ -130,7 +130,7 @@ class PConfig
 	public static function delete($uid, $family, $key)
 	{
 		if (!isset(self::$adapter)) {
-			return self::$config->deleteP($uid, $family, $key);
+			return self::$cache->deleteP($uid, $family, $key);
 		}
 
 		return self::$adapter->delete($uid, $family, $key);

--- a/src/Core/PConfig.php
+++ b/src/Core/PConfig.php
@@ -203,7 +203,11 @@ class PConfig extends BaseObject
 			self::$config[$uid][$cat] = [];
 		}
 
-		self::$config[$uid][$cat][$k] = $value;
+		if ($k === null) {
+			self::$config[$uid][$cat] = $value;
+		} else {
+			self::$config[$uid][$cat][$k] = $value;
+		}
 	}
 
 	/**

--- a/src/Core/PConfig.php
+++ b/src/Core/PConfig.php
@@ -50,8 +50,8 @@ class PConfig
 	/**
 	 * @brief Loads all configuration values of a user's config family into a cached storage.
 	 *
-	 * All configuration values of the given user are stored in global cache
-	 * which is available under the global variable self::$config[$uid].
+	 * All configuration values of the given user are stored with the $uid in
+	 * the cache ( @see IPConfigCache )
 	 *
 	 * @param string $uid    The user_id
 	 * @param string $family The category of the configuration value
@@ -72,7 +72,8 @@ class PConfig
 	 * ($family) and a key.
 	 *
 	 * Get a particular user's config value from the given category ($family)
-	 * and the $key from a cached storage in self::$config[$uid].
+	 * and the $key with the $uid from a cached storage either from the self::$adapter
+	 * (@see IConfigAdapter ) or from the static::$cache (@see IConfigCache ).
 	 *
 	 * @param string  $uid           The user_id
 	 * @param string  $family        The category of the configuration value
@@ -118,8 +119,9 @@ class PConfig
 	/**
 	 * @brief Deletes the given key from the users's configuration.
 	 *
-	 * Removes the configured value from the stored cache in self::$config[$uid]
-	 * and removes it from the database.
+	 * Removes the configured value from the stored cache in self::$config
+	 * (@see ConfigCache ) and removes it from the database (@see IConfigAdapter )
+	 * with the given $uid.
 	 *
 	 * @param string $uid    The user_id
 	 * @param string $family The category of the configuration value

--- a/src/Core/PConfig.php
+++ b/src/Core/PConfig.php
@@ -8,8 +8,6 @@
  */
 namespace Friendica\Core;
 
-use Friendica\Core\Config\IPConfigCache;
-
 /**
  * @brief Management of user configuration storage
  * Note:
@@ -20,19 +18,19 @@ use Friendica\Core\Config\IPConfigCache;
 class PConfig
 {
 	/**
-	 * @var \Friendica\Core\Config\IPConfigAdapter
+	 * @var Config\IPConfigAdapter
 	 */
 	private static $adapter;
 
 	/**
-	 * @var IPConfigCache
+	 * @var Config\IPConfigCache
 	 */
 	private static $config;
 
 	/**
 	 * Initialize the config with only the cache
 	 *
-	 * @param IPConfigCache $config  The configuration cache
+	 * @param Config\IPConfigCache $config  The configuration cache
 	 */
 	public static function init($config)
 	{
@@ -42,7 +40,7 @@ class PConfig
 	/**
 	 * Add the adapter for DB-backend
 	 *
-	 * @param $adapter
+	 * @param Config\IPConfigAdapter $adapter
 	 */
 	public static function setAdapter($adapter)
 	{
@@ -59,7 +57,6 @@ class PConfig
 	 * @param string $family The category of the configuration value
 	 *
 	 * @return void
-	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
 	public static function load($uid, $family)
 	{
@@ -129,7 +126,6 @@ class PConfig
 	 * @param string $key    The configuration key to delete
 	 *
 	 * @return mixed
-	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
 	public static function delete($uid, $family, $key)
 	{

--- a/src/Core/System.php
+++ b/src/Core/System.php
@@ -303,6 +303,44 @@ class System extends BaseObject
 		return $processUser['name'];
 	}
 
+	/**
+	 * @brief Checks if a given directory is usable for the system
+	 *
+	 * @param      $directory
+	 * @param bool $check_writable
+	 *
+	 * @return boolean the directory is usable
+	 */
+	public static function isDirectoryUsable($directory, $check_writable = true)
+	{
+		if ($directory == '') {
+			Logger::log('Directory is empty. This shouldn\'t happen.', Logger::DEBUG);
+			return false;
+		}
+
+		if (!file_exists($directory)) {
+			Logger::log('Path "' . $directory . '" does not exist for user ' . static::getUser(), Logger::DEBUG);
+			return false;
+		}
+
+		if (is_file($directory)) {
+			Logger::log('Path "' . $directory . '" is a file for user ' . static::getUser(), Logger::DEBUG);
+			return false;
+		}
+
+		if (!is_dir($directory)) {
+			Logger::log('Path "' . $directory . '" is not a directory for user ' . static::getUser(), Logger::DEBUG);
+			return false;
+		}
+
+		if ($check_writable && !is_writable($directory)) {
+			Logger::log('Path "' . $directory . '" is not writable for user ' . static::getUser(), Logger::DEBUG);
+			return false;
+		}
+
+		return true;
+	}
+
 	/// @todo Move the following functions from boot.php
 	/*
 	function killme()

--- a/src/Core/System.php
+++ b/src/Core/System.php
@@ -286,6 +286,23 @@ class System extends BaseObject
 		exit();
 	}
 
+	/**
+	 * @brief Returns the system user that is executing the script
+	 *
+	 * This mostly returns something like "www-data".
+	 *
+	 * @return string system username
+	 */
+	public static function getUser()
+	{
+		if (!function_exists('posix_getpwuid') || !function_exists('posix_geteuid')) {
+			return '';
+		}
+
+		$processUser = posix_getpwuid(posix_geteuid());
+		return $processUser['name'];
+	}
+
 	/// @todo Move the following functions from boot.php
 	/*
 	function killme()

--- a/src/Core/Update.php
+++ b/src/Core/Update.php
@@ -14,10 +14,11 @@ class Update
 	/**
 	 * @brief Function to check if the Database structure needs an update.
 	 *
+	 * @param string $basePath The base path of this application
 	 * @param boolean $via_worker boolean Is the check run via the worker?
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
-	public static function check($via_worker)
+	public static function check($basePath, $via_worker)
 	{
 		if (!DBA::connected()) {
 			return;
@@ -38,7 +39,7 @@ class Update
 		if ($build < DB_UPDATE_VERSION) {
 			// When we cannot execute the database update via the worker, we will do it directly
 			if (!Worker::add(PRIORITY_CRITICAL, 'DBUpdate') && $via_worker) {
-				self::run();
+				self::run($basePath);
 			}
 		}
 	}
@@ -46,14 +47,15 @@ class Update
 	/**
 	 * Automatic database updates
 	 *
-	 * @param bool $force    Force the Update-Check even if the lock is set
-	 * @param bool $verbose  Run the Update-Check verbose
-	 * @param bool $sendMail Sends a Mail to the administrator in case of success/failure
+	 * @param string $basePath The base path of this application
+	 * @param bool $force      Force the Update-Check even if the lock is set
+	 * @param bool $verbose    Run the Update-Check verbose
+	 * @param bool $sendMail   Sends a Mail to the administrator in case of success/failure
 	 *
 	 * @return string Empty string if the update is successful, error messages otherwise
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
-	public static function run($force = false, $verbose = false, $sendMail = true)
+	public static function run($basePath, $force = false, $verbose = false, $sendMail = true)
 	{
 		// In force mode, we release the dbupdate lock first
 		// Necessary in case of an stuck update
@@ -91,7 +93,7 @@ class Update
 					}
 
 					// update the structure in one call
-					$retval = DBStructure::update($verbose, true);
+					$retval = DBStructure::update($basePath, $verbose, true);
 					if ($retval) {
 						if ($sendMail) {
 							self::updateFailed(
@@ -125,7 +127,7 @@ class Update
 				}
 			}
 		} elseif ($force) {
-			DBStructure::update($verbose, true);
+			DBStructure::update($basePath, $verbose, true);
 		}
 
 		return '';

--- a/src/Database/DBA.php
+++ b/src/Database/DBA.php
@@ -423,7 +423,7 @@ class DBA
 
 		$orig_sql = $sql;
 
-		if (self::$config->get('system', 'db_callstack')) {
+		if (self::$config->get('system', 'db_callstack') !== null) {
 			$sql = "/*".System::callstack()." */ ".$sql;
 		}
 

--- a/src/Database/DBA.php
+++ b/src/Database/DBA.php
@@ -2,9 +2,7 @@
 
 namespace Friendica\Database;
 
-// Do not use native get/set/load of Core\Config in this class at risk of infinite loop.
-// Please use Core\Config::getConfigVariable() instead.
-use Friendica\Core\Config;
+use Friendica\Core\Config\ConfigCache;
 use Friendica\Core\Logger;
 use Friendica\Core\System;
 use Friendica\Util\DateTimeFormat;
@@ -33,6 +31,10 @@ class DBA
 
 	public static $connected = false;
 
+	/**
+	 * @var ConfigCache
+	 */
+	private static $config;
 	private static $server_info = '';
 	private static $connection;
 	private static $driver;
@@ -48,13 +50,14 @@ class DBA
 	private static $db_name = '';
 	private static $db_charset = '';
 
-	public static function connect($serveraddr, $user, $pass, $db, $charset = null)
+	public static function connect($config, $serveraddr, $user, $pass, $db, $charset = null)
 	{
 		if (!is_null(self::$connection) && self::connected()) {
 			return true;
 		}
 
 		// We are storing these values for being able to perform a reconnect
+		self::$config = $config;
 		self::$db_serveraddr = $serveraddr;
 		self::$db_user = $user;
 		self::$db_pass = $pass;
@@ -155,7 +158,7 @@ class DBA
 	public static function reconnect() {
 		self::disconnect();
 
-		$ret = self::connect(self::$db_serveraddr, self::$db_user, self::$db_pass, self::$db_name, self::$db_charset);
+		$ret = self::connect(self::$config, self::$db_serveraddr, self::$db_user, self::$db_pass, self::$db_name, self::$db_charset);
 		return $ret;
 	}
 
@@ -209,9 +212,8 @@ class DBA
 	 * @throws \Exception
 	 */
 	private static function logIndex($query) {
-		$a = \get_app();
 
-		if (!Config::getConfigValue('system', 'db_log_index')) {
+		if (!self::$config->get('system', 'db_log_index')) {
 			return;
 		}
 
@@ -230,18 +232,18 @@ class DBA
 			return;
 		}
 
-		$watchlist = explode(',', Config::getConfigValue('system', 'db_log_index_watch'));
-		$blacklist = explode(',', Config::getConfigValue('system', 'db_log_index_blacklist'));
+		$watchlist = explode(',', self::$config->get('system', 'db_log_index_watch'));
+		$blacklist = explode(',', self::$config->get('system', 'db_log_index_blacklist'));
 
 		while ($row = self::fetch($r)) {
-			if ((intval(Config::getConfigValue('system', 'db_loglimit_index')) > 0)) {
+			if ((intval(self::$config->get('system', 'db_loglimit_index')) > 0)) {
 				$log = (in_array($row['key'], $watchlist) &&
-					($row['rows'] >= intval(Config::getConfigValue('system', 'db_loglimit_index'))));
+					($row['rows'] >= intval(self::$config->get('system', 'db_loglimit_index'))));
 			} else {
 				$log = false;
 			}
 
-			if ((intval(Config::getConfigValue('system', 'db_loglimit_index_high')) > 0) && ($row['rows'] >= intval($Config::getConfigValue('system', 'db_loglimit_index_high')))) {
+			if ((intval(self::$config->get('system', 'db_loglimit_index_high')) > 0) && ($row['rows'] >= intval($Config::getConfigValue('system', 'db_loglimit_index_high')))) {
 				$log = true;
 			}
 
@@ -251,7 +253,7 @@ class DBA
 
 			if ($log) {
 				$backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
-				@file_put_contents(Config::getConfigValue('system', 'db_log_index'), DateTimeFormat::utcNow()."\t".
+				@file_put_contents(self::$config->get('system', 'db_log_index'), DateTimeFormat::utcNow()."\t".
 						$row['key']."\t".$row['rows']."\t".$row['Extra']."\t".
 						basename($backtrace[1]["file"])."\t".
 						$backtrace[1]["line"]."\t".$backtrace[2]["function"]."\t".
@@ -421,7 +423,7 @@ class DBA
 
 		$orig_sql = $sql;
 
-		if (Config::getConfigValue('system', 'db_callstack')) {
+		if (self::$config->get('system', 'db_callstack')) {
 			$sql = "/*".System::callstack()." */ ".$sql;
 		}
 
@@ -582,15 +584,15 @@ class DBA
 
 		$a->saveTimestamp($stamp1, 'database');
 
-		if (Config::getConfigValue('system', 'db_log')) {
+		if (self::$config->get('system', 'db_log')) {
 			$stamp2 = microtime(true);
 			$duration = (float)($stamp2 - $stamp1);
 
-			if (($duration > Config::getConfigValue('system', 'db_loglimit'))) {
+			if (($duration > self::$config->get('system', 'db_loglimit'))) {
 				$duration = round($duration, 3);
 				$backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
 
-				@file_put_contents(Config::getConfigValue('system', 'db_log'), DateTimeFormat::utcNow()."\t".$duration."\t".
+				@file_put_contents(self::$config->get('system', 'db_log'), DateTimeFormat::utcNow()."\t".$duration."\t".
 						basename($backtrace[1]["file"])."\t".
 						$backtrace[1]["line"]."\t".$backtrace[2]["function"]."\t".
 						substr(self::replaceParameters($sql, $args), 0, 2000)."\n", FILE_APPEND);

--- a/src/Database/DBA.php
+++ b/src/Database/DBA.php
@@ -2,7 +2,7 @@
 
 namespace Friendica\Database;
 
-use Friendica\Core\Config\ConfigCache;
+use Friendica\Core\Config\IConfigCache;
 use Friendica\Core\Logger;
 use Friendica\Core\System;
 use Friendica\Util\DateTimeFormat;
@@ -32,7 +32,7 @@ class DBA
 	public static $connected = false;
 
 	/**
-	 * @var ConfigCache
+	 * @var IConfigCache
 	 */
 	private static $config;
 	private static $server_info = '';
@@ -1031,7 +1031,7 @@ class DBA
 	 * This process must only be started once, since the value is cached.
 	 */
 	private static function buildRelationData() {
-		$definition = DBStructure::definition();
+		$definition = DBStructure::definition(self::$config->get('system', 'basepath'));
 
 		foreach ($definition AS $table => $structure) {
 			foreach ($structure['fields'] AS $field => $field_struct) {

--- a/src/Database/DBA.php
+++ b/src/Database/DBA.php
@@ -2,10 +2,9 @@
 
 namespace Friendica\Database;
 
-// Do not use Core\Config in this class at risk of infinite loop.
-// Please use App->getConfigVariable() instead.
-//use Friendica\Core\Config;
-
+// Do not use native get/set/load of Core\Config in this class at risk of infinite loop.
+// Please use Core\Config::getConfigVariable() instead.
+use Friendica\Core\Config;
 use Friendica\Core\Logger;
 use Friendica\Core\System;
 use Friendica\Util\DateTimeFormat;
@@ -212,7 +211,7 @@ class DBA
 	private static function logIndex($query) {
 		$a = \get_app();
 
-		if (!$a->getConfigVariable('system', 'db_log_index')) {
+		if (!Config::getConfigValue('system', 'db_log_index')) {
 			return;
 		}
 
@@ -231,18 +230,18 @@ class DBA
 			return;
 		}
 
-		$watchlist = explode(',', $a->getConfigVariable('system', 'db_log_index_watch'));
-		$blacklist = explode(',', $a->getConfigVariable('system', 'db_log_index_blacklist'));
+		$watchlist = explode(',', Config::getConfigValue('system', 'db_log_index_watch'));
+		$blacklist = explode(',', Config::getConfigValue('system', 'db_log_index_blacklist'));
 
 		while ($row = self::fetch($r)) {
-			if ((intval($a->getConfigVariable('system', 'db_loglimit_index')) > 0)) {
+			if ((intval(Config::getConfigValue('system', 'db_loglimit_index')) > 0)) {
 				$log = (in_array($row['key'], $watchlist) &&
-					($row['rows'] >= intval($a->getConfigVariable('system', 'db_loglimit_index'))));
+					($row['rows'] >= intval(Config::getConfigValue('system', 'db_loglimit_index'))));
 			} else {
 				$log = false;
 			}
 
-			if ((intval($a->getConfigVariable('system', 'db_loglimit_index_high')) > 0) && ($row['rows'] >= intval($a->getConfigVariable('system', 'db_loglimit_index_high')))) {
+			if ((intval(Config::getConfigValue('system', 'db_loglimit_index_high')) > 0) && ($row['rows'] >= intval($Config::getConfigValue('system', 'db_loglimit_index_high')))) {
 				$log = true;
 			}
 
@@ -252,7 +251,7 @@ class DBA
 
 			if ($log) {
 				$backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
-				@file_put_contents($a->getConfigVariable('system', 'db_log_index'), DateTimeFormat::utcNow()."\t".
+				@file_put_contents(Config::getConfigValue('system', 'db_log_index'), DateTimeFormat::utcNow()."\t".
 						$row['key']."\t".$row['rows']."\t".$row['Extra']."\t".
 						basename($backtrace[1]["file"])."\t".
 						$backtrace[1]["line"]."\t".$backtrace[2]["function"]."\t".
@@ -422,7 +421,7 @@ class DBA
 
 		$orig_sql = $sql;
 
-		if ($a->getConfigValue('system', 'db_callstack')) {
+		if (Config::getConfigValue('system', 'db_callstack')) {
 			$sql = "/*".System::callstack()." */ ".$sql;
 		}
 
@@ -583,15 +582,15 @@ class DBA
 
 		$a->saveTimestamp($stamp1, 'database');
 
-		if ($a->getConfigValue('system', 'db_log')) {
+		if (Config::getConfigValue('system', 'db_log')) {
 			$stamp2 = microtime(true);
 			$duration = (float)($stamp2 - $stamp1);
 
-			if (($duration > $a->getConfigValue('system', 'db_loglimit'))) {
+			if (($duration > Config::getConfigValue('system', 'db_loglimit'))) {
 				$duration = round($duration, 3);
 				$backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
 
-				@file_put_contents($a->getConfigValue('system', 'db_log'), DateTimeFormat::utcNow()."\t".$duration."\t".
+				@file_put_contents(Config::getConfigValue('system', 'db_log'), DateTimeFormat::utcNow()."\t".$duration."\t".
 						basename($backtrace[1]["file"])."\t".
 						$backtrace[1]["line"]."\t".$backtrace[2]["function"]."\t".
 						substr(self::replaceParameters($sql, $args), 0, 2000)."\n", FILE_APPEND);

--- a/src/Database/DBStructure.php
+++ b/src/Database/DBStructure.php
@@ -74,9 +74,9 @@ class DBStructure
 		return L10n::t('Errors encountered performing database changes: ') . $message . EOL;
 	}
 
-	public static function printStructure()
+	public static function printStructure($basePath)
 	{
-		$database = self::definition(false);
+		$database = self::definition($basePath, false);
 
 		echo "-- ------------------------------------------\n";
 		echo "-- " . FRIENDICA_PLATFORM . " " . FRIENDICA_VERSION . " (" . FRIENDICA_CODENAME, ")\n";
@@ -98,14 +98,15 @@ class DBStructure
 	 *
 	 * @see config/dbstructure.config.php
 	 * @param boolean $with_addons_structure Whether to tack on addons additional tables
+	 * @param string  $basePath              The base path of this application
 	 * @return array
 	 * @throws Exception
 	 */
-	public static function definition($basepath, $with_addons_structure = true)
+	public static function definition($basePath, $with_addons_structure = true)
 	{
 		if (!self::$definition) {
 
-			$filename = $basepath . '/config/dbstructure.config.php';
+			$filename = $basePath . '/config/dbstructure.config.php';
 
 			if (!is_readable($filename)) {
 				throw new Exception('Missing database structure config file config/dbstructure.config.php');
@@ -246,15 +247,16 @@ class DBStructure
 	/**
 	 * Updates DB structure and returns eventual errors messages
 	 *
-	 * @param bool  $verbose
-	 * @param bool  $action     Whether to actually apply the update
-	 * @param bool  $install    Is this the initial update during the installation?
-	 * @param array $tables     An array of the database tables
-	 * @param array $definition An array of the definition tables
+	 * @param string $basePath   The base path of this application
+	 * @param bool   $verbose
+	 * @param bool   $action     Whether to actually apply the update
+	 * @param bool   $install    Is this the initial update during the installation?
+	 * @param array  $tables     An array of the database tables
+	 * @param array  $definition An array of the definition tables
 	 * @return string Empty string if the update is successful, error messages otherwise
 	 * @throws Exception
 	 */
-	public static function update($verbose, $action, $install = false, array $tables = null, array $definition = null)
+	public static function update($basePath, $verbose, $action, $install = false, array $tables = null, array $definition = null)
 	{
 		if ($action && !$install) {
 			Config::set('system', 'maintenance', 1);
@@ -283,7 +285,7 @@ class DBStructure
 
 		// Get the definition
 		if (is_null($definition)) {
-			$definition = self::definition();
+			$definition = self::definition($basePath);
 		}
 
 		// MySQL >= 5.7.4 doesn't support the IGNORE keyword in ALTER TABLE statements

--- a/src/Database/DBStructure.php
+++ b/src/Database/DBStructure.php
@@ -101,12 +101,11 @@ class DBStructure
 	 * @return array
 	 * @throws Exception
 	 */
-	public static function definition($with_addons_structure = true)
+	public static function definition($basepath, $with_addons_structure = true)
 	{
 		if (!self::$definition) {
-			$a = \Friendica\BaseObject::getApp();
 
-			$filename = $a->getBasePath() . '/config/dbstructure.config.php';
+			$filename = $basepath . '/config/dbstructure.config.php';
 
 			if (!is_readable($filename)) {
 				throw new Exception('Missing database structure config file config/dbstructure.config.php');

--- a/src/Factory/ConfigFactory.php
+++ b/src/Factory/ConfigFactory.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Friendica\Factory;
+
+use Friendica\Core\Config;
+
+class ConfigFactory
+{
+	public static function createCache(Config\ConfigCacheLoader $loader)
+	{
+		$configCache = new Config\ConfigCache();
+		$loader->loadConfigFiles($configCache);
+
+		return $configCache;
+	}
+
+	/**
+	 * @param string              $type   The adapter type
+	 * @param Config\IConfigCache $config The config cache of this adapter
+	 * @return Config\IConfigAdapter
+	 */
+	public static function createConfig($type, $config)
+	{
+		if ($type == 'preload') {
+			return new Config\PreloadConfigAdapter($config);
+		} else {
+			return new Config\JITConfigAdapter($config);
+		}
+	}
+
+	/**
+	 * @param string               $type   The adapter type
+	 * @param int                  $uid    The UID of the current user
+	 * @param Config\IPConfigCache $config The config cache of this adapter
+	 * @return Config\IPConfigAdapter
+	 */
+	public static function createPConfig($type, $uid, $config)
+	{
+		if ($type == 'preload') {
+			return new Config\PreloadPConfigAdapter($uid, $config);
+		} else {
+			return new Config\JITPConfigAdapter($config);
+		}
+	}
+}

--- a/src/Factory/ConfigFactory.php
+++ b/src/Factory/ConfigFactory.php
@@ -6,6 +6,11 @@ use Friendica\Core\Config;
 
 class ConfigFactory
 {
+	/**
+	 * @param Config\ConfigCacheLoader $loader The Config Cache loader (INI/config/.htconfig)
+	 *
+	 * @return Config\ConfigCache
+	 */
 	public static function createCache(Config\ConfigCacheLoader $loader)
 	{
 		$configCache = new Config\ConfigCache();
@@ -17,6 +22,7 @@ class ConfigFactory
 	/**
 	 * @param string              $type   The adapter type
 	 * @param Config\IConfigCache $config The config cache of this adapter
+	 *
 	 * @return Config\IConfigAdapter
 	 */
 	public static function createConfig($type, $config)
@@ -32,6 +38,7 @@ class ConfigFactory
 	 * @param string               $type   The adapter type
 	 * @param int                  $uid    The UID of the current user
 	 * @param Config\IPConfigCache $config The config cache of this adapter
+	 *
 	 * @return Config\IPConfigAdapter
 	 */
 	public static function createPConfig($type, $uid, $config)

--- a/src/Factory/ConfigFactory.php
+++ b/src/Factory/ConfigFactory.php
@@ -25,7 +25,7 @@ class ConfigFactory
 	 *
 	 * @return Config\IConfigAdapter
 	 */
-	public static function createConfig($type, $config)
+	public static function createConfig($type, Config\IConfigCache $config)
 	{
 		if ($type == 'preload') {
 			return new Config\PreloadConfigAdapter($config);
@@ -41,7 +41,7 @@ class ConfigFactory
 	 *
 	 * @return Config\IPConfigAdapter
 	 */
-	public static function createPConfig($type, $config, $uid = null)
+	public static function createPConfig($type, Config\IPConfigCache $config, $uid = null)
 	{
 		if ($type == 'preload') {
 			return new Config\PreloadPConfigAdapter($config, $uid);

--- a/src/Factory/ConfigFactory.php
+++ b/src/Factory/ConfigFactory.php
@@ -36,15 +36,15 @@ class ConfigFactory
 
 	/**
 	 * @param string               $type   The adapter type
-	 * @param int                  $uid    The UID of the current user
 	 * @param Config\IPConfigCache $config The config cache of this adapter
+	 * @param int                  $uid    The UID of the current user
 	 *
 	 * @return Config\IPConfigAdapter
 	 */
-	public static function createPConfig($type, $uid, $config)
+	public static function createPConfig($type, $config, $uid = null)
 	{
 		if ($type == 'preload') {
-			return new Config\PreloadPConfigAdapter($uid, $config);
+			return new Config\PreloadPConfigAdapter($config, $uid);
 		} else {
 			return new Config\JITPConfigAdapter($config);
 		}

--- a/src/Factory/LoggerFactory.php
+++ b/src/Factory/LoggerFactory.php
@@ -25,7 +25,7 @@ class LoggerFactory
 	 *
 	 * @return LoggerInterface The PSR-3 compliant logger instance
 	 */
-	public static function create($channel, $config = null)
+	public static function create($channel, ConfigCache $config = null)
 	{
 		$logger = new Monolog\Logger($channel);
 		$logger->pushProcessor(new Monolog\Processor\PsrLogMessageProcessor());

--- a/src/LegacyModule.php
+++ b/src/LegacyModule.php
@@ -68,7 +68,7 @@ class LegacyModule extends BaseModule
 
 		if (\function_exists($function_name)) {
 			$a = self::getApp();
-			return $function_name($a, $a->getConfig());
+			return $function_name($a);
 		} else {
 			return parent::{$function_suffix}();
 		}

--- a/src/LegacyModule.php
+++ b/src/LegacyModule.php
@@ -68,7 +68,7 @@ class LegacyModule extends BaseModule
 
 		if (\function_exists($function_name)) {
 			$a = self::getApp();
-			return $function_name($a);
+			return $function_name($a, $a->getConfig());
 		} else {
 			return parent::{$function_suffix}();
 		}

--- a/src/Model/Attach.php
+++ b/src/Model/Attach.php
@@ -7,15 +7,15 @@
 namespace Friendica\Model;
 
 use Friendica\BaseObject;
-use Friendica\Core\System;
 use Friendica\Core\StorageManager;
+use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\Database\DBStructure;
 use Friendica\Model\Storage\IStorage;
 use Friendica\Object\Image;
-use Friendica\Util\Security;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Mimetype;
+use Friendica\Util\Security;
 
 /**
  * Class to handle attach dabatase table
@@ -31,7 +31,7 @@ class Attach extends BaseObject
 	 */
 	private static function getFields()
 	{
-		$allfields = DBStructure::definition(false);
+		$allfields = DBStructure::definition(self::getApp()->getBasePath(), false);
 		$fields = array_keys($allfields['attach']['fields']);
 		array_splice($fields, array_search('data', $fields), 1);
 		return $fields;

--- a/src/Module/Install.php
+++ b/src/Module/Install.php
@@ -103,7 +103,7 @@ class Install extends BaseModule
 					return;
 				}
 
-				self::$installer->installDatabase();
+				self::$installer->installDatabase($a->getBasePath());
 
 				break;
 		}

--- a/src/Util/BasePath.php
+++ b/src/Util/BasePath.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Friendica\Util;
+
+use Friendica\Core;
+
+class BasePath
+{
+	/**
+	 * @brief Returns the base filesystem path of the App
+	 *
+	 * It first checks for the internal variable, then for DOCUMENT_ROOT and
+	 * finally for PWD
+	 *
+	 * @param string|null $basepath
+	 *
+	 * @return string
+	 *
+	 * @throws \Exception if directory isn't usable
+	 */
+	public static function create($basepath)
+	{
+		if (!$basepath && !empty($_SERVER['DOCUMENT_ROOT'])) {
+			$basepath = $_SERVER['DOCUMENT_ROOT'];
+		}
+
+		if (!$basepath && !empty($_SERVER['PWD'])) {
+			$basepath = $_SERVER['PWD'];
+		}
+
+		return self::getRealPath($basepath);
+	}
+
+	/**
+	 * @brief Returns a normalized file path
+	 *
+	 * This is a wrapper for the "realpath" function.
+	 * That function cannot detect the real path when some folders aren't readable.
+	 * Since this could happen with some hosters we need to handle this.
+	 *
+	 * @param string $path The path that is about to be normalized
+	 * @return string normalized path - when possible
+	 */
+	public static function getRealPath($path)
+	{
+		$normalized = realpath($path);
+
+		if (!is_bool($normalized)) {
+			return $normalized;
+		} else {
+			return $path;
+		}
+	}
+
+
+	/**
+	 * @brief Checks if a given directory is usable for the system
+	 *
+	 * @param      $directory
+	 * @param bool $check_writable
+	 *
+	 * @return boolean the directory is usable
+	 */
+	public static function isDirectoryUsable($directory, $check_writable = true)
+	{
+		if ($directory == '') {
+			Core\Logger::log('Directory is empty. This shouldn\'t happen.', Core\Logger::DEBUG);
+			return false;
+		}
+
+		if (!file_exists($directory)) {
+			Core\Logger::log('Path "' . $directory . '" does not exist for user ' . Core\System::getUser(), Core\Logger::DEBUG);
+			return false;
+		}
+
+		if (is_file($directory)) {
+			Core\Logger::log('Path "' . $directory . '" is a file for user ' . Core\System::getUser(), Core\Logger::DEBUG);
+			return false;
+		}
+
+		if (!is_dir($directory)) {
+			Core\Logger::log('Path "' . $directory . '" is not a directory for user ' . Core\System::getUser(), Core\Logger::DEBUG);
+			return false;
+		}
+
+		if ($check_writable && !is_writable($directory)) {
+			Core\Logger::log('Path "' . $directory . '" is not writable for user ' . Core\System::getUser(), Core\Logger::DEBUG);
+			return false;
+		}
+
+		return true;
+	}
+}

--- a/src/Util/BasePath.php
+++ b/src/Util/BasePath.php
@@ -12,23 +12,24 @@ class BasePath
 	 * It first checks for the internal variable, then for DOCUMENT_ROOT and
 	 * finally for PWD
 	 *
-	 * @param string|null $basepath
+	 * @param string|null $basePath The default base path
+	 * @param array       $server   server arguments
 	 *
 	 * @return string
 	 *
 	 * @throws \Exception if directory isn't usable
 	 */
-	public static function create($basepath)
+	public static function create($basePath, $server = [])
 	{
-		if (!$basepath && !empty($_SERVER['DOCUMENT_ROOT'])) {
-			$basepath = $_SERVER['DOCUMENT_ROOT'];
+		if (!$basePath && !empty($server['DOCUMENT_ROOT'])) {
+			$basePath = $server['DOCUMENT_ROOT'];
 		}
 
-		if (!$basepath && !empty($_SERVER['PWD'])) {
-			$basepath = $_SERVER['PWD'];
+		if (!$basePath && !empty($server['PWD'])) {
+			$basePath = $server['PWD'];
 		}
 
-		return self::getRealPath($basepath);
+		return self::getRealPath($basePath);
 	}
 
 	/**
@@ -51,7 +52,6 @@ class BasePath
 			return $path;
 		}
 	}
-
 
 	/**
 	 * @brief Checks if a given directory is usable for the system

--- a/src/Util/BasePath.php
+++ b/src/Util/BasePath.php
@@ -2,8 +2,6 @@
 
 namespace Friendica\Util;
 
-use Friendica\Core;
-
 class BasePath
 {
 	/**
@@ -51,43 +49,5 @@ class BasePath
 		} else {
 			return $path;
 		}
-	}
-
-	/**
-	 * @brief Checks if a given directory is usable for the system
-	 *
-	 * @param      $directory
-	 * @param bool $check_writable
-	 *
-	 * @return boolean the directory is usable
-	 */
-	public static function isDirectoryUsable($directory, $check_writable = true)
-	{
-		if ($directory == '') {
-			Core\Logger::log('Directory is empty. This shouldn\'t happen.', Core\Logger::DEBUG);
-			return false;
-		}
-
-		if (!file_exists($directory)) {
-			Core\Logger::log('Path "' . $directory . '" does not exist for user ' . Core\System::getUser(), Core\Logger::DEBUG);
-			return false;
-		}
-
-		if (is_file($directory)) {
-			Core\Logger::log('Path "' . $directory . '" is a file for user ' . Core\System::getUser(), Core\Logger::DEBUG);
-			return false;
-		}
-
-		if (!is_dir($directory)) {
-			Core\Logger::log('Path "' . $directory . '" is not a directory for user ' . Core\System::getUser(), Core\Logger::DEBUG);
-			return false;
-		}
-
-		if ($check_writable && !is_writable($directory)) {
-			Core\Logger::log('Path "' . $directory . '" is not writable for user ' . Core\System::getUser(), Core\Logger::DEBUG);
-			return false;
-		}
-
-		return true;
 	}
 }

--- a/src/Worker/DBUpdate.php
+++ b/src/Worker/DBUpdate.php
@@ -5,12 +5,13 @@
  */
 namespace Friendica\Worker;
 
+use Friendica\BaseObject;
 use Friendica\Core\Update;
 
-class DBUpdate
+class DBUpdate extends BaseObject
 {
 	public static function execute()
 	{
-		Update::run();
+		Update::run(self::getApp()->getBasePath());
 	}
 }

--- a/tests/DatabaseTest.php
+++ b/tests/DatabaseTest.php
@@ -36,7 +36,9 @@ abstract class DatabaseTest extends MockedTest
 			$this->markTestSkipped('Please set the MYSQL_* environment variables to your test database credentials.');
 		}
 
-		DBA::connect(getenv('MYSQL_HOST'),
+		DBA::connect(
+			__DIR__,
+			getenv('MYSQL_HOST'),
 			getenv('MYSQL_USERNAME'),
 			getenv('MYSQL_PASSWORD'),
 			getenv('MYSQL_DATABASE'));

--- a/tests/DatabaseTest.php
+++ b/tests/DatabaseTest.php
@@ -5,7 +5,10 @@
 
 namespace Friendica\Test;
 
+use Friendica\Core\Config;
 use Friendica\Database\DBA;
+use Friendica\Factory;
+use Friendica\Util\BasePath;
 use PHPUnit\DbUnit\DataSet\YamlDataSet;
 use PHPUnit\DbUnit\TestCaseTrait;
 use PHPUnit_Extensions_Database_DB_IDatabaseConnection;
@@ -36,8 +39,12 @@ abstract class DatabaseTest extends MockedTest
 			$this->markTestSkipped('Please set the MYSQL_* environment variables to your test database credentials.');
 		}
 
+		$basedir = BasePath::create(dirname(__DIR__));
+		$configLoader = new Config\ConfigCacheLoader($basedir);
+		$config = Factory\ConfigFactory::createCache($configLoader);
+
 		DBA::connect(
-			__DIR__,
+			$config,
 			getenv('MYSQL_HOST'),
 			getenv('MYSQL_USERNAME'),
 			getenv('MYSQL_PASSWORD'),

--- a/tests/Util/AppMockTrait.php
+++ b/tests/Util/AppMockTrait.php
@@ -4,6 +4,7 @@ namespace Friendica\Test\Util;
 
 use Friendica\App;
 use Friendica\BaseObject;
+use Friendica\Core\Config\ConfigCache;
 use Friendica\Render\FriendicaSmartyEngine;
 use Mockery\MockInterface;
 use org\bovigo\vfs\vfsStreamDirectory;
@@ -24,8 +25,9 @@ trait AppMockTrait
 	 * Mock the App
 	 *
 	 * @param vfsStreamDirectory $root The root directory
+	 * @param MockInterface|ConfigCache $config The config cache
 	 */
-	public function mockApp($root)
+	public function mockApp($root, $config)
 	{
 		$this->mockConfigGet('system', 'theme', 'testtheme');
 
@@ -35,22 +37,26 @@ trait AppMockTrait
 			->shouldReceive('getBasePath')
 			->andReturn($root->url());
 
-		$this->app
-			->shouldReceive('getConfigValue')
+		$config
+			->shouldReceive('get')
 			->with('database', 'hostname')
 			->andReturn(getenv('MYSQL_HOST'));
-		$this->app
-			->shouldReceive('getConfigValue')
+		$config
+			->shouldReceive('get')
 			->with('database', 'username')
 			->andReturn(getenv('MYSQL_USERNAME'));
-		$this->app
-			->shouldReceive('getConfigValue')
+		$config
+			->shouldReceive('get')
 			->with('database', 'password')
 			->andReturn(getenv('MYSQL_PASSWORD'));
-		$this->app
-			->shouldReceive('getConfigValue')
+		$config
+			->shouldReceive('get')
 			->with('database', 'database')
 			->andReturn(getenv('MYSQL_DATABASE'));
+		$this->app
+			->shouldReceive('getConfig')
+			->andReturn($config);
+
 		$this->app
 			->shouldReceive('getTemplateEngine')
 			->andReturn(new FriendicaSmartyEngine());

--- a/tests/include/ApiTest.php
+++ b/tests/include/ApiTest.php
@@ -10,8 +10,8 @@ use Friendica\Core\Config;
 use Friendica\Core\PConfig;
 use Friendica\Core\Protocol;
 use Friendica\Core\System;
+use Friendica\Factory\LoggerFactory;
 use Friendica\Network\HTTPException;
-use Friendica\Util\LoggerFactory;
 use Monolog\Handler\TestHandler;
 
 require_once __DIR__ . '/../../include/api.php';

--- a/tests/include/ApiTest.php
+++ b/tests/include/ApiTest.php
@@ -5,13 +5,14 @@
 
 namespace Friendica\Test;
 
-use Friendica\BaseObject;
+use Friendica\App;
 use Friendica\Core\Config;
 use Friendica\Core\PConfig;
 use Friendica\Core\Protocol;
 use Friendica\Core\System;
-use Friendica\Factory\LoggerFactory;
+use Friendica\Factory;
 use Friendica\Network\HTTPException;
+use Friendica\Util\BasePath;
 use Monolog\Handler\TestHandler;
 
 require_once __DIR__ . '/../../include/api.php';
@@ -34,10 +35,14 @@ class ApiTest extends DatabaseTest
 	 */
 	public function setUp()
 	{
-		parent::setUp();
+		$basedir = BasePath::create(dirname(__DIR__) . '/../');
+		$configLoader = new Config\ConfigCacheLoader($basedir);
+		$config = Factory\ConfigFactory::createCache($configLoader);
+		$logger = Factory\LoggerFactory::create('test', $config);
+		$this->app = new App($config, $logger, false);
+		$this->logOutput = FActory\LoggerFactory::enableTest($this->app->getLogger());
 
-		$this->app = BaseObject::getApp();
-		$this->logOutput = LoggerFactory::enableTest($this->app->getLogger());
+		parent::setUp();
 
 		// User data that the test database is populated with
 		$this->selfUser = [

--- a/tests/src/BaseObjectTest.php
+++ b/tests/src/BaseObjectTest.php
@@ -31,10 +31,6 @@ class BaseObjectTest extends TestCase
 	 */
 	protected function setUp()
 	{
-		$this->setUpVfsDir();
-		$configMock = \Mockery::mock('Friendica\Core\Config\ConfigCache');
-		$this->mockApp($this->root, $configMock);
-
 		$this->baseObject = new BaseObject();
 	}
 
@@ -44,6 +40,10 @@ class BaseObjectTest extends TestCase
 	 */
 	public function testGetApp()
 	{
+		$this->setUpVfsDir();
+		$configMock = \Mockery::mock('Friendica\Core\Config\ConfigCache');
+		$this->mockApp($this->root, $configMock);
+
 		$this->assertInstanceOf(App::class, $this->baseObject->getApp());
 	}
 
@@ -53,7 +53,20 @@ class BaseObjectTest extends TestCase
 	 */
 	public function testSetApp()
 	{
+		$this->setUpVfsDir();
+		$configMock = \Mockery::mock('Friendica\Core\Config\ConfigCache');
+		$this->mockApp($this->root, $configMock);
+
 		$this->assertNull($this->baseObject->setApp($this->app));
 		$this->assertEquals($this->app, $this->baseObject->getApp());
+	}
+
+	/**
+	 * Test the getApp() function without App
+	 * @expectedException Friendica\Network\HTTPException\InternalServerErrorException
+	 */
+	public function testGetAppFailed()
+	{
+		BaseObject::getApp();
 	}
 }

--- a/tests/src/BaseObjectTest.php
+++ b/tests/src/BaseObjectTest.php
@@ -32,7 +32,8 @@ class BaseObjectTest extends TestCase
 	protected function setUp()
 	{
 		$this->setUpVfsDir();
-		$this->mockApp($this->root);
+		$configMock = \Mockery::mock('Friendica\Core\Config\ConfigCache');
+		$this->mockApp($this->root, $configMock);
 
 		$this->baseObject = new BaseObject();
 	}

--- a/tests/src/Core/Cache/CacheTest.php
+++ b/tests/src/Core/Cache/CacheTest.php
@@ -69,7 +69,8 @@ abstract class CacheTest extends MockedTest
 	protected function setUp()
 	{
 		$this->setUpVfsDir();
-		$this->mockApp($this->root);
+		$configMock = \Mockery::mock('Friendica\Core\Config\ConfigCache');
+		$this->mockApp($this->root, $configMock);
 		$this->app
 			->shouldReceive('getHostname')
 			->andReturn('friendica.local');

--- a/tests/src/Core/Console/AutomaticInstallationConsoleTest.php
+++ b/tests/src/Core/Console/AutomaticInstallationConsoleTest.php
@@ -181,7 +181,7 @@ FIN;
 		$this->mockConnect(true, 1);
 		$this->mockConnected(true, 1);
 		$this->mockExistsTable('user', false, 1);
-		$this->mockUpdate([false, true, true], null, 1);
+		$this->mockUpdate([$this->root->url(), false, true, true], null, 1);
 
 		$config = <<<CONF
 <?php
@@ -241,7 +241,7 @@ CONF;
 		$this->mockConnect(true, 1);
 		$this->mockConnected(true, 1);
 		$this->mockExistsTable('user', false, 1);
-		$this->mockUpdate([false, true, true], null, 1);
+		$this->mockUpdate([$this->root->url(), false, true, true], null, 1);
 
 		$this->mockGetMarkupTemplate('local.config.tpl', 'testTemplate', 1);
 		$this->mockReplaceMacros('testTemplate', $this->createArgumentsForMacro(true), '', 1);
@@ -267,7 +267,7 @@ CONF;
 		$this->mockConnect(true, 1);
 		$this->mockConnected(true, 1);
 		$this->mockExistsTable('user', false, 1);
-		$this->mockUpdate([false, true, true], null, 1);
+		$this->mockUpdate([$this->root->url(), false, true, true], null, 1);
 
 		$this->mockGetMarkupTemplate('local.config.tpl', 'testTemplate', 1);
 		$this->mockReplaceMacros('testTemplate', $this->createArgumentsForMacro(false), '', 1);
@@ -292,7 +292,7 @@ CONF;
 		$this->mockConnect(true, 1);
 		$this->mockConnected(true, 1);
 		$this->mockExistsTable('user', false, 1);
-		$this->mockUpdate([false, true, true], null, 1);
+		$this->mockUpdate([$this->root->url(), false, true, true], null, 1);
 
 		$this->mockGetMarkupTemplate('local.config.tpl', 'testTemplate', 1);
 		$this->mockReplaceMacros('testTemplate', $this->createArgumentsForMacro(true), '', 1);

--- a/tests/src/Core/Console/ConsoleTest.php
+++ b/tests/src/Core/Console/ConsoleTest.php
@@ -29,7 +29,8 @@ abstract class ConsoleTest extends MockedTest
 		Intercept::setUp();
 
 		$this->setUpVfsDir();
-		$this->mockApp($this->root);
+		$configMock = \Mockery::mock('Friendica\Core\Config\ConfigCache');
+		$this->mockApp($this->root, $configMock);
 	}
 
 	/**

--- a/tests/src/Core/Lock/LockTest.php
+++ b/tests/src/Core/Lock/LockTest.php
@@ -31,7 +31,8 @@ abstract class LockTest extends MockedTest
 
 		// Reusable App object
 		$this->setUpVfsDir();
-		$this->mockApp($this->root);
+		$configMock = \Mockery::mock('Friendica\Core\Config\ConfigCache');
+		$this->mockApp($this->root, $configMock);
 		$this->app
 			->shouldReceive('getHostname')
 			->andReturn('friendica.local');

--- a/tests/src/Database/DBATest.php
+++ b/tests/src/Database/DBATest.php
@@ -1,19 +1,25 @@
 <?php
 namespace Friendica\Test\Database;
 
-use Friendica\BaseObject;
+use Friendica\App;
 use Friendica\Core\Config;
 use Friendica\Database\DBA;
+use Friendica\Factory;
 use Friendica\Test\DatabaseTest;
+use Friendica\Util\BasePath;
 
 class DBATest extends DatabaseTest
 {
 	public function setUp()
 	{
-		parent::setUp();
+		$basedir = BasePath::create(dirname(__DIR__) . '/../../');
+		$configLoader = new Config\ConfigCacheLoader($basedir);
+		$config = Factory\ConfigFactory::createCache($configLoader);
+		$logger = Factory\LoggerFactory::create('test', $config);
+		$this->app = new App($config, $logger, false);
+		$this->logOutput = FActory\LoggerFactory::enableTest($this->app->getLogger());
 
-		// Reusable App object
-		$this->app = BaseObject::getApp();
+		parent::setUp();
 
 		// Default config
 		Config::set('config', 'hostname', 'localhost');

--- a/tests/src/Database/DBStructureTest.php
+++ b/tests/src/Database/DBStructureTest.php
@@ -2,19 +2,25 @@
 
 namespace Friendica\Test\Database;
 
-use Friendica\BaseObject;
+use Friendica\App;
 use Friendica\Core\Config;
 use Friendica\Database\DBStructure;
+use Friendica\Factory;
 use Friendica\Test\DatabaseTest;
+use Friendica\Util\BasePath;
 
 class DBStructureTest extends DatabaseTest
 {
 	public function setUp()
 	{
-		parent::setUp();
+		$basedir = BasePath::create(dirname(__DIR__) . '/../../');
+		$configLoader = new Config\ConfigCacheLoader($basedir);
+		$config = Factory\ConfigFactory::createCache($configLoader);
+		$logger = Factory\LoggerFactory::create('test', $config);
+		$this->app = new App($config, $logger, false);
+		$this->logOutput = FActory\LoggerFactory::enableTest($this->app->getLogger());
 
-		// Reusable App object
-		$this->app = BaseObject::getApp();
+		parent::setUp();
 
 		// Default config
 		Config::set('config', 'hostname', 'localhost');


### PR DESCRIPTION
This is "part one" to loose some hard dependencies.

- [x] `$a->config[]` is moved to a new class `Core\Config\ConfigCache()`
- [x] The `$a`-file-loading methods are moved to a new class `Core\Config\ConfigCacheLoader()`
- [x] The `$a`-base-path methods are moved to a new static class `Util\BasePath`
- [x] Testing, if `basepath` is correclty used if overriden by `Config` or with sub-path
- [x] Testing the Config `console` commands
- [x] Making some more "click around" tests if anything strange appears (login and clicking on some pages is working)
- [x] ~~**Fixing Addons**~~ (environment bug)

So I could get rid of almost every dependency in the static `Core\Config` and `Core\PConfig` (they are now just hulls for static callings).

There's a new `ConfigFactory` which creates the `ConfigCache` and the two config adapters `IConfigAdapter` and `IPConfigAdapter` too.

I'm using the `ConfigCache` to load the config-files stateful and inject them into the `App` class. There, I use them for all the `getConfigValue()` things until `$a->reload()`, where I use it to create the DB-backend Adapter for the `Config` and `PConfig` class.

In a later followup PR, all of the `ConfigFactory` calls and `setAdapter()` calls are encapsulated to a single `$dependency->get('config')` and `$dependency->get('pconfig')`, which will automatically create the right adapter and can be used in the static `Config` and `PConfig`, but also with other DI-classes.
This is important, because f.e. the long `getApp()->getConfig()->get()` call will vanish because of a dependency-container for such calls.

Another advantage (at least for me) is that we now have the full control over the instances. Because I really disliked that we initialized the `Config` and `PConfig` by themselves with  `self::init()`. I believe that this is a bad practice, because we should know when we can use classes and when not..

@MrPetovan I'll use [Dice](https://github.com/Level-2/Dice) as a DI-library in a follow up PR, because:
- It's the fastest DI I know (https://www.sitepoint.com/php-dependency-injection-container-performance-benchmarks/)
- It's just one class to include
- It is capable of all the things we want, but is easy to configure and use (I already tested it on another feature branch ;-) )
- It's perfect usable with Factories, which you like to use for dependency injection (https://r.je/dice.html#example4-7)

btw. I have the felling that this PR will increase the overall performance too. On my local machine, the tests are faster than before as far as I can see ...