### PR TITLE
Update version constraint for password_exposed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
 		"ext-simplexml": "*",
 		"ext-xml": "*",
 		"asika/simple-console": "^1.0",
-		"divineomega/password_exposed": "^2.4",
+		"divineomega/password_exposed": "^2.4|^3.0",
 		"ezyang/htmlpurifier": "~4.7.0",
 		"friendica/json-ld": "^1.0",
 		"league/html-to-markdown": "~4.8.0",

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
 		"ext-simplexml": "*",
 		"ext-xml": "*",
 		"asika/simple-console": "^1.0",
-		"divineomega/password_exposed": "^2.4|^3.0",
+		"divineomega/password_exposed": "^2.4||^3.0",
 		"ezyang/htmlpurifier": "~4.7.0",
 		"friendica/json-ld": "^1.0",
 		"league/html-to-markdown": "~4.8.0",


### PR DESCRIPTION
A new major release of the `password_exposed` package has just been released. This PR simply updates the version constraint.