### PR TITLE
Diaspora: Remove asterisk-meddling regular expression

### DIFF
--- a/mod/babel.php
+++ b/mod/babel.php
@@ -98,7 +98,7 @@ function babel_content()
 				$html = Text\Markdown::convert($markdown);
 				$results[] = [
 					'title' => L10n::t('Markdown::convert (raw HTML)'),
-					'content' => htmlspecialchars($html)
+					'content' => visible_whitespace(htmlspecialchars($html))
 				];
 
 				$results[] = [

--- a/src/Content/Text/Markdown.php
+++ b/src/Content/Text/Markdown.php
@@ -83,9 +83,6 @@ class Markdown extends BaseObject
 	{
 		$s = html_entity_decode($s, ENT_COMPAT, 'UTF-8');
 
-		// Replace lonely stars in lines not starting with it with literal stars
-		$s = preg_replace('/^([^\*]+)\*([^\*]*)$/im', '$1\*$2', $s);
-
 		// The parser cannot handle paragraphs correctly
 		$s = str_replace(['</p>', '<p>', '<p dir="ltr">'], ['<br>', '<br>', '<br>'], $s);
 


### PR DESCRIPTION
Fixes #6585 

Diaspora seem to have straightened their Markdown output when it comes to literal asterisks, we don't need this provision anymore.