### PR TITLE
Filestorage Backend and legacy label

### DIFF
--- a/doc/Settings.md
+++ b/doc/Settings.md
@@ -110,8 +110,9 @@ Two storage backends are avaiable with Friendica:
 - **Filesystem** : Data is stored as file on the filesystem.
 
 More storage backends can be avaiable from third-party addons.
+If you use those, please refer to the documentation of those addons for further information.
 
-Default value is 'None': it's the legacy way used to store data directly in database.
+Default value is 'Database (legacy)': it's the legacy way used to store data directly in database.
 
 Existing data can be moved to the current active backend using the ['storage move' console command](help/tools)
 

--- a/doc/de/Settings.md
+++ b/doc/de/Settings.md
@@ -12,7 +12,7 @@ Die zweite Zahl steht für die Anzahl der Aufgaben, die die Worker noch vor sich
 Die Worker arbeiten Hintergrundprozesse ab.
 Die Aufgaben der Worker sind priorisiert und werden anhand dieser Prioritäten abgearbeitet.
 
-Desweiteren findest du eine Übersicht über die Accounts auf dem Friendica Knoten, die unter dem Punkt "Nutzer" moderiert werden können.
+Des weiteren findest du eine Übersicht über die Accounts auf dem Friendica Knoten, die unter dem Punkt "Nutzer" moderiert werden können.
 Sowie eine Liste der derzeit aktivierten Addons.
 Diese Liste ist verlinkt, so dass du schnellen Zugriff auf die Informationsseiten der einzelnen Addons hast.
 Abschließend findest du auf der Startseite des Admin Panels die installierte Version von Friendica.
@@ -47,7 +47,7 @@ Mehr Informationen zum Übersetzungsprozess von Friendica findest du [auf dieser
 
 Hier kann das Theme bestimmt werden, welches standardmäßig zum Anzeigen der Seite verwendet werden soll.
 Nutzer können in ihren Einstellungen andere Themes wählen.
-Derzeit ist das "duepunto zero" Theme das vorausgewählte Theme.
+Derzeit ist das "vier" Theme das vorausgewählte Theme.
 
 Für mobile Geräte kannst du ein spezielles Theme wählen, wenn das Standardtheme ungeeignet für mobile Geräte sein sollte.
 Das `vier` Theme z.B. unterstützt kleine Anzeigen und benötigt kein zusätzliches mobiles Theme.
@@ -91,6 +91,32 @@ Wenn du die Erstellung weiterer Accounts blockieren willst, dann setze die Einst
 Standardmäßig ist hier "false" gesetzt.
 
 ### Datei hochladen
+
+#### Datenspeicher Backend
+
+Legt das Datenspeicher Backend fest, mit dem Friendica hoch geladene Daten speichert.
+Zwei Speicher Backends sind standardmäßig bei Friendica verfügbar:
+
+- **Database** : Die Daten werden in einer speziellen Tabelle in der Datenbank (`storage`) gespeichert.
+- **Filesystem** : Die Daten werden als Dateien im Dateisystem gespeichert.
+
+Weitere Speicher Backends können als Addons von Drittanbietern verfügbar sein.
+Falls ein solches verwendet wird, sei an dieser Stelle nur auf deren Dokumentation für weitere Informationen verwiesen.
+
+Die Grundeinstellung ist 'Datenbank (legacy)': Dies ist die alte Methode von Friendica Daten direkt in der Datenbank abzulegen.
+
+Bestehende Daten können zum aktuell ausgewählten Backend verschoben werden.
+Hierfür kann der ['storage move'](help/tools) Befehl der Friendica Konsole verwendet werden.
+
+Sollte das ausgewählte Speicher Backand zusätzliche Konfigurationsparameter besitzen, werden nach der Auswahl des Backends hier weitere Felder angezeigt.
+
+##### Dateipfad zum Speicher
+
+Der Basispfad unter dem das Filesystem Datenspeicher Backend die Daten speichern soll.
+
+Um zu verhindern, dass Daten unter Umgehung der Privatsphären-Einstellungen herunter geladen werden, sollte dieser Pfad außerhalb der Verzeichnisstruktur des Webservers liegen.
+
+Die Grundeinstellung ist `storage`, das ist das `storage` Unterverzeichnis innerhalb des Friendica Verzeichnisses.
 
 #### Maximale Bildgröße
 

--- a/mod/admin.php
+++ b/mod/admin.php
@@ -1551,7 +1551,7 @@ function admin_page_site(App $a)
 	$storage_current_backend = StorageManager::getBackend();
 
 	$storage_backends_choices = [
-		'' => L10n::t('None')
+		'' => L10n::t('Database (legacy)')
 	];
 	foreach($storage_backends as $name=>$class) {
 		$storage_backends_choices[$class] = $name;
@@ -1607,7 +1607,7 @@ function admin_page_site(App $a)
 		'$hide_help'        => ['hide_help', L10n::t("Hide help entry from navigation menu"), Config::get('system', 'hide_help'), L10n::t("Hides the menu entry for the Help pages from the navigation menu. You can still access it calling /help directly.")],
 		'$singleuser'       => ['singleuser', L10n::t("Single user instance"), Config::get('system', 'singleuser', '---'), L10n::t("Make this instance multi-user or single-user for the named user"), $user_names],
 
-		'$storagebackend'   => ['storagebackend', L10n::t("File storage backend"), $storage_current_backend, L10n::t('Backend used to store uploaded files data'), $storage_backends_choices],
+		'$storagebackend'   => ['storagebackend', L10n::t("File storage backend"), $storage_current_backend, L10n::t('The backend used to store uploaded files data. If you change the storage backend, you have to manually move the existing files see <a href="/help/Settings#1_2_3_1">the settings documentation</a> for more information about the choices and the moving procedure.'), $storage_backends_choices],
 		'$storageform'      => $storage_form,
 		'$maximagesize'     => ['maximagesize', L10n::t("Maximum image size"), Config::get('system', 'maximagesize'), L10n::t("Maximum size in bytes of uploaded images. Default is 0, which means no limits.")],
 		'$maximagelength'   => ['maximagelength', L10n::t("Maximum image length"), Config::get('system', 'max_image_length'), L10n::t("Maximum length in pixels of the longest side of uploaded images. Default is -1, which means no limits.")],


### PR DESCRIPTION
The legacy storage backend is now called "Database (legacy)".
The help text in the admin panel was a bit expanded and the documentation was translated to German.

Fixes #6533