### PR TITLE
Separate config options to display the worker jobs per minute

### DIFF
--- a/config/defaults.config.php
+++ b/config/defaults.config.php
@@ -393,6 +393,10 @@ return [
 		// Number of worker tasks that are fetched in a single query.
 		'worker_fetch_limit' => 1,
 
+		// worker_jpm (Boolean)
+		// If enabled, it prints out the jobs per minute.
+		'worker_jpm' => false,
+
 		// worker_load_exponent (Integer)
 		// Default 3, which allows only 25% of the maximum worker queues when server load reaches around 37% of maximum load.
 		// For a linear response where 25% of worker queues are allowed at 75% of maximum load, set this to 1.


### PR DESCRIPTION
This had previously be part of the "worker_debug" option. But we are now able to display only the JPM value on itself. Possibly the calculations in the "worker_debug" part could slow down the system.