### PR TITLE
The automatic follow request is currently deactivated

### DIFF
--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -1298,6 +1298,10 @@ class Transmitter
 	 */
 	public static function sendFollowObject($object, $target, $uid = 0)
 	{
+		// Currently deactivated, due to notification problems.
+		// The follow message is reflected back and then causes false notifications.
+		return true;
+
 		$profile = APContact::getByURL($target);
 
 		if (empty($uid)) {


### PR DESCRIPTION
The automatic follow message is reflected back by the target server, this then causes false notifications.

There will be some upcoming post that fixes the problem in a better way. Because of this upcoming work, the code is only deactivated, not removed.
