### PR TITLE
Improved worker performance (changed keys, changed queries)

### DIFF
--- a/config/dbstructure.config.php
+++ b/config/dbstructure.config.php
@@ -34,7 +34,7 @@
 use Friendica\Database\DBA;
 
 if (!defined('DB_UPDATE_VERSION')) {
-	define('DB_UPDATE_VERSION', 1301);
+	define('DB_UPDATE_VERSION', 1302);
 }
 
 return [
@@ -1377,12 +1377,12 @@ return [
 		"indexes" => [
 			"PRIMARY" => ["id"],
 			"done_parameter" => ["done", "parameter(64)"],
+			"done_executed" => ["done", "executed"],
+			"done_priority" => ["done", "priority"],
+			"done_priority_created" => ["done", "priority", "created"],
 			"done_pid" => ["done", "pid"],
-			"done_priority_created_next_try" => ["done", "priority", "created", "next_try"],
-			"done_priority_executed_next_try" => ["done", "priority", "executed", "next_try"],
-			"done_priority_next_try" => ["done", "priority", "next_try"],
-			"done_executed_next_try" => ["done", "executed", "next_try"],
-			"done_next_try" => ["done", "next_try"]
+			"done_pid_next_try" => ["done", "pid", "next_try"],
+			"done_pid_priority_created" => ["done", "pid", "priority", "created"]
 		]
 	],
 	"storage" => [

--- a/src/Worker/OnePoll.php
+++ b/src/Worker/OnePoll.php
@@ -138,18 +138,27 @@ class OnePoll
 		// We don't poll our followers
 		if ($contact["rel"] == Contact::FOLLOWER) {
 			Logger::log("Don't poll follower");
+
+			// set the last-update so we don't keep polling
+			DBA::update('contact', ['last-update' => DateTimeFormat::utcNow()], ['id' => $contact['id']]);
 			return;
 		}
 
 		// Don't poll if polling is deactivated (But we poll feeds and mails anyway)
 		if (!in_array($contact['network'], [Protocol::FEED, Protocol::MAIL]) && Config::get('system', 'disable_polling')) {
 			Logger::log('Polling is disabled');
+
+			// set the last-update so we don't keep polling
+			DBA::update('contact', ['last-update' => DateTimeFormat::utcNow()], ['id' => $contact['id']]);
 			return;
 		}
 
 		// We don't poll AP contacts by now
 		if ($contact['network'] === Protocol::ACTIVITYPUB) {
 			Logger::log("Don't poll AP contact");
+
+			// set the last-update so we don't keep polling
+			DBA::update('contact', ['last-update' => DateTimeFormat::utcNow()], ['id' => $contact['id']]);
 			return;
 		}
 


### PR DESCRIPTION
One of my servers had got massive performance problems in the last days in the background processing. Jobs had been created faster than they had been able to be processed.

On my system the changes lead to an improvement in the scale of 3 or 4 times of the previous speed. But I guess that this mostly will be visible on larger servers with a huge number of job entries.

The work at the worker showed me that even small changes can lead to massive performances improvements and drops. So every change in the Worker.php should be well thought.