### PR TITLE
Cache config adapter connection status to reduce number of calls to DBA::isConnected()

### DIFF
--- a/src/Core/Config/AbstractDbaConfigAdapter.php
+++ b/src/Core/Config/AbstractDbaConfigAdapter.php
@@ -6,8 +6,11 @@ use Friendica\Database\DBA;
 
 abstract class AbstractDbaConfigAdapter
 {
+	/** @var bool */
+	protected $connected = true;
+
 	public function isConnected()
 	{
-		return DBA::connected();
+		return $this->connected;
 	}
 }

--- a/src/Core/Config/JITConfigAdapter.php
+++ b/src/Core/Config/JITConfigAdapter.php
@@ -26,6 +26,7 @@ class JITConfigAdapter extends AbstractDbaConfigAdapter implements IConfigAdapte
 	public function __construct(IConfigCache $configCache)
 	{
 		$this->configCache = $configCache;
+		$this->connected = DBA::connected();
 	}
 
 	/**

--- a/src/Core/Config/PreloadConfigAdapter.php
+++ b/src/Core/Config/PreloadConfigAdapter.php
@@ -27,6 +27,7 @@ class PreloadConfigAdapter extends AbstractDbaConfigAdapter implements IConfigAd
 	public function __construct(IConfigCache $configCache)
 	{
 		$this->configCache = $configCache;
+		$this->connected = DBA::connected();
 		$this->load();
 	}
 


### PR DESCRIPTION
Follow-up to #6605

Each call to `DBA::connected` is costly and the initial PR made that each config value retrieval would call it.

See https://forum.friendi.ca/display/0b6b25a8-125c-5de5-475e-2b0127103035