### PR TITLE
Add "delivery done" label

### DIFF
--- a/src/Object/Post.php
+++ b/src/Object/Post.php
@@ -432,6 +432,7 @@ class Post extends BaseObject
 				'delivery_pending'  => L10n::t('Delivery to remote servers is pending'),
 				'delivery_underway' => L10n::t('Delivery to remote servers is underway'),
 				'delivery_almost'   => L10n::t('Delivery to remote servers is mostly done'),
+				'delivery_done'     => L10n::t('Delivery to remote servers is done'),
 			],
 		];
 

--- a/src/Worker/APDelivery.php
+++ b/src/Worker/APDelivery.php
@@ -41,10 +41,9 @@ class APDelivery extends BaseObject
 			$data = ActivityPub\Transmitter::createCachedActivityFromItem($target_id);
 			if (!empty($data)) {
 				$success = HTTPSignature::transmit($data, $inbox, $uid);
-			}
-
-			if ($success && in_array($cmd, [Delivery::POST, Delivery::COMMENT])) {
-				ItemDeliveryData::incrementQueueDone($target_id);
+				if ($success && in_array($cmd, [Delivery::POST, Delivery::COMMENT])) {
+					ItemDeliveryData::incrementQueueDone($target_id);
+				}
 			}
 		}
 

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: 2019.01\n"
+"Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-01-21 10:24-0500\n"
+"POT-Creation-Date: 2019-02-08 23:34-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,738 +18,738 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 
-#: include/api.php:1140
+#: include/api.php:1179
 #, php-format
 msgid "Daily posting limit of %d post reached. The post was rejected."
 msgid_plural "Daily posting limit of %d posts reached. The post was rejected."
 msgstr[0] ""
 msgstr[1] ""
 
-#: include/api.php:1154
+#: include/api.php:1193
 #, php-format
 msgid "Weekly posting limit of %d post reached. The post was rejected."
 msgid_plural "Weekly posting limit of %d posts reached. The post was rejected."
 msgstr[0] ""
 msgstr[1] ""
 
-#: include/api.php:1168
+#: include/api.php:1207
 #, php-format
 msgid "Monthly posting limit of %d post reached. The post was rejected."
 msgstr ""
 
-#: include/api.php:4352 mod/photos.php:93 mod/photos.php:201 mod/photos.php:694
-#: mod/photos.php:1125 mod/photos.php:1142 mod/photos.php:1635
-#: mod/profile_photo.php:86 mod/profile_photo.php:95 mod/profile_photo.php:104
-#: mod/profile_photo.php:218 mod/profile_photo.php:308
-#: mod/profile_photo.php:318 src/Model/User.php:681 src/Model/User.php:689
-#: src/Model/User.php:697
+#: include/api.php:4578 mod/photos.php:93 mod/photos.php:201 mod/photos.php:695
+#: mod/photos.php:1126 mod/photos.php:1143 mod/photos.php:1636
+#: mod/profile_photo.php:85 mod/profile_photo.php:94 mod/profile_photo.php:103
+#: mod/profile_photo.php:217 mod/profile_photo.php:305
+#: mod/profile_photo.php:315 src/Model/User.php:735 src/Model/User.php:743
+#: src/Model/User.php:751
 msgid "Profile Photos"
 msgstr ""
 
-#: include/conversation.php:156 include/conversation.php:292
-#: src/Model/Item.php:3221
+#: include/conversation.php:160 include/conversation.php:297
+#: src/Model/Item.php:3265
 msgid "event"
 msgstr ""
 
-#: include/conversation.php:159 include/conversation.php:169
-#: include/conversation.php:295 include/conversation.php:304
+#: include/conversation.php:163 include/conversation.php:173
+#: include/conversation.php:300 include/conversation.php:309
 #: mod/subthread.php:88 mod/tagger.php:70
 msgid "status"
 msgstr ""
 
-#: include/conversation.php:164 include/conversation.php:300
-#: mod/subthread.php:88 mod/tagger.php:70 src/Model/Item.php:3223
+#: include/conversation.php:168 include/conversation.php:305
+#: mod/subthread.php:88 mod/tagger.php:70 src/Model/Item.php:3267
 msgid "photo"
 msgstr ""
 
-#: include/conversation.php:176
+#: include/conversation.php:181
 #, php-format
 msgid "%1$s likes %2$s's %3$s"
 msgstr ""
 
-#: include/conversation.php:178
+#: include/conversation.php:183
 #, php-format
 msgid "%1$s doesn't like %2$s's %3$s"
 msgstr ""
 
-#: include/conversation.php:180
+#: include/conversation.php:185
 #, php-format
 msgid "%1$s attends %2$s's %3$s"
 msgstr ""
 
-#: include/conversation.php:182
+#: include/conversation.php:187
 #, php-format
 msgid "%1$s doesn't attend %2$s's %3$s"
 msgstr ""
 
-#: include/conversation.php:184
+#: include/conversation.php:189
 #, php-format
 msgid "%1$s attends maybe %2$s's %3$s"
 msgstr ""
 
-#: include/conversation.php:219
+#: include/conversation.php:224
 #, php-format
 msgid "%1$s is now friends with %2$s"
 msgstr ""
 
-#: include/conversation.php:260
+#: include/conversation.php:265
 #, php-format
 msgid "%1$s poked %2$s"
 msgstr ""
 
-#: include/conversation.php:314 mod/tagger.php:108
+#: include/conversation.php:319 mod/tagger.php:108
 #, php-format
 msgid "%1$s tagged %2$s's %3$s with %4$s"
 msgstr ""
 
-#: include/conversation.php:336
+#: include/conversation.php:341
 msgid "post/item"
 msgstr ""
 
-#: include/conversation.php:337
+#: include/conversation.php:342
 #, php-format
 msgid "%1$s marked %2$s's %3$s as favorite"
 msgstr ""
 
-#: include/conversation.php:551 mod/photos.php:1466 mod/profiles.php:356
+#: include/conversation.php:568 mod/photos.php:1467 mod/profiles.php:352
 msgid "Likes"
 msgstr ""
 
-#: include/conversation.php:551 mod/photos.php:1466 mod/profiles.php:360
+#: include/conversation.php:568 mod/photos.php:1467 mod/profiles.php:355
 msgid "Dislikes"
 msgstr ""
 
-#: include/conversation.php:552 include/conversation.php:1484
-#: mod/photos.php:1467
+#: include/conversation.php:569 include/conversation.php:1506
+#: mod/photos.php:1468
 msgid "Attending"
 msgid_plural "Attending"
 msgstr[0] ""
 msgstr[1] ""
 
-#: include/conversation.php:552 mod/photos.php:1467
+#: include/conversation.php:569 mod/photos.php:1468
 msgid "Not attending"
 msgstr ""
 
-#: include/conversation.php:552 mod/photos.php:1467
+#: include/conversation.php:569 mod/photos.php:1468
 msgid "Might attend"
 msgstr ""
 
-#: include/conversation.php:632 mod/photos.php:1523 src/Object/Post.php:204
+#: include/conversation.php:649 mod/photos.php:1524 src/Object/Post.php:206
 msgid "Select"
 msgstr ""
 
-#: include/conversation.php:633 mod/admin.php:2036 mod/photos.php:1524
-#: mod/settings.php:729 src/Module/Contact.php:830 src/Module/Contact.php:1105
+#: include/conversation.php:650 mod/admin.php:2071 mod/photos.php:1525
+#: mod/settings.php:726 src/Module/Contact.php:827 src/Module/Contact.php:1102
 msgid "Delete"
 msgstr ""
 
-#: include/conversation.php:667 src/Object/Post.php:377 src/Object/Post.php:378
+#: include/conversation.php:684 src/Object/Post.php:379 src/Object/Post.php:380
 #, php-format
 msgid "View %s's profile @ %s"
 msgstr ""
 
-#: include/conversation.php:679 src/Object/Post.php:365
+#: include/conversation.php:696 src/Object/Post.php:367
 msgid "Categories:"
 msgstr ""
 
-#: include/conversation.php:680 src/Object/Post.php:366
+#: include/conversation.php:697 src/Object/Post.php:368
 msgid "Filed under:"
 msgstr ""
 
-#: include/conversation.php:687 src/Object/Post.php:391
+#: include/conversation.php:704 src/Object/Post.php:393
 #, php-format
 msgid "%s from %s"
 msgstr ""
 
-#: include/conversation.php:702
+#: include/conversation.php:719
 msgid "View in context"
 msgstr ""
 
-#: include/conversation.php:704 include/conversation.php:1152
-#: mod/editpost.php:107 mod/message.php:262 mod/message.php:444
-#: mod/photos.php:1439 mod/wallmessage.php:141 src/Object/Post.php:417
+#: include/conversation.php:721 include/conversation.php:1172
+#: mod/editpost.php:88 mod/message.php:260 mod/message.php:442
+#: mod/photos.php:1440 mod/wallmessage.php:141 src/Object/Post.php:419
 msgid "Please wait"
 msgstr ""
 
-#: include/conversation.php:768
+#: include/conversation.php:785
 msgid "remove"
 msgstr ""
 
-#: include/conversation.php:772
+#: include/conversation.php:789
 msgid "Delete Selected Items"
 msgstr ""
 
-#: include/conversation.php:872 view/theme/frio/theme.php:356
+#: include/conversation.php:893 view/theme/frio/theme.php:358
 msgid "Follow Thread"
 msgstr ""
 
-#: include/conversation.php:873 src/Model/Contact.php:996
+#: include/conversation.php:894 src/Model/Contact.php:1032
 msgid "View Status"
 msgstr ""
 
-#: include/conversation.php:874 include/conversation.php:890
-#: mod/allfriends.php:74 mod/directory.php:167 mod/dirfind.php:228
-#: mod/match.php:84 mod/suggest.php:86 src/Model/Contact.php:936
-#: src/Model/Contact.php:989 src/Model/Contact.php:997
+#: include/conversation.php:895 include/conversation.php:911
+#: mod/allfriends.php:72 mod/directory.php:167 mod/dirfind.php:226
+#: mod/match.php:87 mod/suggest.php:87 src/Model/Contact.php:972
+#: src/Model/Contact.php:1025 src/Model/Contact.php:1033
 msgid "View Profile"
 msgstr ""
 
-#: include/conversation.php:875 src/Model/Contact.php:998
+#: include/conversation.php:896 src/Model/Contact.php:1034
 msgid "View Photos"
 msgstr ""
 
-#: include/conversation.php:876 src/Model/Contact.php:990
-#: src/Model/Contact.php:999
+#: include/conversation.php:897 src/Model/Contact.php:1026
+#: src/Model/Contact.php:1035
 msgid "Network Posts"
 msgstr ""
 
-#: include/conversation.php:877 src/Model/Contact.php:991
-#: src/Model/Contact.php:1000
+#: include/conversation.php:898 src/Model/Contact.php:1027
+#: src/Model/Contact.php:1036
 msgid "View Contact"
 msgstr ""
 
-#: include/conversation.php:878 src/Model/Contact.php:1002
+#: include/conversation.php:899 src/Model/Contact.php:1038
 msgid "Send PM"
 msgstr ""
 
-#: include/conversation.php:882 src/Model/Contact.php:1003
+#: include/conversation.php:903 src/Model/Contact.php:1039
 msgid "Poke"
 msgstr ""
 
-#: include/conversation.php:887 mod/allfriends.php:75 mod/dirfind.php:229
-#: mod/follow.php:148 mod/match.php:85 mod/suggest.php:87
-#: src/Content/Widget.php:63 src/Model/Contact.php:992
-#: src/Module/Contact.php:576 view/theme/vier/theme.php:201
+#: include/conversation.php:908 mod/allfriends.php:73 mod/dirfind.php:227
+#: mod/follow.php:147 mod/match.php:88 mod/suggest.php:88
+#: src/Content/Widget.php:63 src/Model/Contact.php:1028
+#: src/Module/Contact.php:574 view/theme/vier/theme.php:201
 msgid "Connect/Follow"
 msgstr ""
 
-#: include/conversation.php:1006
+#: include/conversation.php:1030
 #, php-format
 msgid "%s likes this."
 msgstr ""
 
-#: include/conversation.php:1009
+#: include/conversation.php:1033
 #, php-format
 msgid "%s doesn't like this."
 msgstr ""
 
-#: include/conversation.php:1012
+#: include/conversation.php:1036
 #, php-format
 msgid "%s attends."
 msgstr ""
 
-#: include/conversation.php:1015
+#: include/conversation.php:1039
 #, php-format
 msgid "%s doesn't attend."
 msgstr ""
 
-#: include/conversation.php:1018
+#: include/conversation.php:1042
 #, php-format
 msgid "%s attends maybe."
 msgstr ""
 
-#: include/conversation.php:1029
+#: include/conversation.php:1050
 msgid "and"
-msgstr ""
-
-#: include/conversation.php:1035
-#, php-format
-msgid "and %d other people"
-msgstr ""
-
-#: include/conversation.php:1044
-#, php-format
-msgid "<span  %1$s>%2$d people</span> like this"
-msgstr ""
-
-#: include/conversation.php:1045
-#, php-format
-msgid "%s like this."
-msgstr ""
-
-#: include/conversation.php:1048
-#, php-format
-msgid "<span  %1$s>%2$d people</span> don't like this"
-msgstr ""
-
-#: include/conversation.php:1049
-#, php-format
-msgid "%s don't like this."
-msgstr ""
-
-#: include/conversation.php:1052
-#, php-format
-msgid "<span  %1$s>%2$d people</span> attend"
-msgstr ""
-
-#: include/conversation.php:1053
-#, php-format
-msgid "%s attend."
 msgstr ""
 
 #: include/conversation.php:1056
 #, php-format
+msgid "and %d other people"
+msgstr ""
+
+#: include/conversation.php:1064
+#, php-format
+msgid "<span  %1$s>%2$d people</span> like this"
+msgstr ""
+
+#: include/conversation.php:1065
+#, php-format
+msgid "%s like this."
+msgstr ""
+
+#: include/conversation.php:1068
+#, php-format
+msgid "<span  %1$s>%2$d people</span> don't like this"
+msgstr ""
+
+#: include/conversation.php:1069
+#, php-format
+msgid "%s don't like this."
+msgstr ""
+
+#: include/conversation.php:1072
+#, php-format
+msgid "<span  %1$s>%2$d people</span> attend"
+msgstr ""
+
+#: include/conversation.php:1073
+#, php-format
+msgid "%s attend."
+msgstr ""
+
+#: include/conversation.php:1076
+#, php-format
 msgid "<span  %1$s>%2$d people</span> don't attend"
 msgstr ""
 
-#: include/conversation.php:1057
+#: include/conversation.php:1077
 #, php-format
 msgid "%s don't attend."
 msgstr ""
 
-#: include/conversation.php:1060
+#: include/conversation.php:1080
 #, php-format
 msgid "<span  %1$s>%2$d people</span> attend maybe"
 msgstr ""
 
-#: include/conversation.php:1061
+#: include/conversation.php:1081
 #, php-format
 msgid "%s attend maybe."
 msgstr ""
 
-#: include/conversation.php:1091
+#: include/conversation.php:1111
 msgid "Visible to <strong>everybody</strong>"
 msgstr ""
 
-#: include/conversation.php:1092 src/Object/Post.php:828
+#: include/conversation.php:1112 src/Object/Post.php:876
 msgid "Please enter a image/video/audio/webpage URL:"
 msgstr ""
 
-#: include/conversation.php:1093
+#: include/conversation.php:1113
 msgid "Tag term:"
 msgstr ""
 
-#: include/conversation.php:1094 mod/filer.php:35
+#: include/conversation.php:1114 mod/filer.php:35
 msgid "Save to Folder:"
 msgstr ""
 
-#: include/conversation.php:1095
+#: include/conversation.php:1115
 msgid "Where are you right now?"
 msgstr ""
 
-#: include/conversation.php:1096
+#: include/conversation.php:1116
 msgid "Delete item(s)?"
 msgstr ""
 
-#: include/conversation.php:1128
+#: include/conversation.php:1148
 msgid "New Post"
 msgstr ""
 
-#: include/conversation.php:1131
+#: include/conversation.php:1151
 msgid "Share"
 msgstr ""
 
-#: include/conversation.php:1132 mod/editpost.php:93 mod/message.php:260
-#: mod/message.php:441 mod/wallmessage.php:139
+#: include/conversation.php:1152 mod/editpost.php:74 mod/message.php:258
+#: mod/message.php:439 mod/wallmessage.php:139
 msgid "Upload photo"
 msgstr ""
 
-#: include/conversation.php:1133 mod/editpost.php:94
+#: include/conversation.php:1153 mod/editpost.php:75
 msgid "upload photo"
 msgstr ""
 
-#: include/conversation.php:1134 mod/editpost.php:95
+#: include/conversation.php:1154 mod/editpost.php:76
 msgid "Attach file"
 msgstr ""
 
-#: include/conversation.php:1135 mod/editpost.php:96
+#: include/conversation.php:1155 mod/editpost.php:77
 msgid "attach file"
 msgstr ""
 
-#: include/conversation.php:1136 src/Object/Post.php:820
+#: include/conversation.php:1156 src/Object/Post.php:868
 msgid "Bold"
 msgstr ""
 
-#: include/conversation.php:1137 src/Object/Post.php:821
+#: include/conversation.php:1157 src/Object/Post.php:869
 msgid "Italic"
 msgstr ""
 
-#: include/conversation.php:1138 src/Object/Post.php:822
+#: include/conversation.php:1158 src/Object/Post.php:870
 msgid "Underline"
 msgstr ""
 
-#: include/conversation.php:1139 src/Object/Post.php:823
+#: include/conversation.php:1159 src/Object/Post.php:871
 msgid "Quote"
 msgstr ""
 
-#: include/conversation.php:1140 src/Object/Post.php:824
+#: include/conversation.php:1160 src/Object/Post.php:872
 msgid "Code"
 msgstr ""
 
-#: include/conversation.php:1141 src/Object/Post.php:825
+#: include/conversation.php:1161 src/Object/Post.php:873
 msgid "Image"
 msgstr ""
 
-#: include/conversation.php:1142 src/Object/Post.php:826
+#: include/conversation.php:1162 src/Object/Post.php:874
 msgid "Link"
 msgstr ""
 
-#: include/conversation.php:1143 src/Object/Post.php:827
+#: include/conversation.php:1163 src/Object/Post.php:875
 msgid "Link or Media"
 msgstr ""
 
-#: include/conversation.php:1144 mod/editpost.php:103
+#: include/conversation.php:1164 mod/editpost.php:84
 msgid "Set your location"
 msgstr ""
 
-#: include/conversation.php:1145 mod/editpost.php:104
+#: include/conversation.php:1165 mod/editpost.php:85
 msgid "set location"
 msgstr ""
 
-#: include/conversation.php:1146 mod/editpost.php:105
+#: include/conversation.php:1166 mod/editpost.php:86
 msgid "Clear browser location"
 msgstr ""
 
-#: include/conversation.php:1147 mod/editpost.php:106
+#: include/conversation.php:1167 mod/editpost.php:87
 msgid "clear location"
 msgstr ""
 
-#: include/conversation.php:1149 mod/editpost.php:121
+#: include/conversation.php:1169 mod/editpost.php:102
 msgid "Set title"
 msgstr ""
 
-#: include/conversation.php:1151 mod/editpost.php:123
+#: include/conversation.php:1171 mod/editpost.php:104
 msgid "Categories (comma-separated list)"
 msgstr ""
 
-#: include/conversation.php:1153 mod/editpost.php:108
+#: include/conversation.php:1173 mod/editpost.php:89
 msgid "Permission settings"
 msgstr ""
 
-#: include/conversation.php:1154 mod/editpost.php:138
+#: include/conversation.php:1174 mod/editpost.php:119
 msgid "permissions"
 msgstr ""
 
-#: include/conversation.php:1163 mod/editpost.php:118
+#: include/conversation.php:1183 mod/editpost.php:99
 msgid "Public post"
 msgstr ""
 
-#: include/conversation.php:1167 mod/editpost.php:129 mod/events.php:566
-#: mod/photos.php:1457 mod/photos.php:1496 mod/photos.php:1556
-#: src/Object/Post.php:829
+#: include/conversation.php:1187 mod/editpost.php:110 mod/events.php:551
+#: mod/photos.php:1458 mod/photos.php:1497 mod/photos.php:1557
+#: src/Object/Post.php:877
 msgid "Preview"
 msgstr ""
 
-#: include/conversation.php:1171 include/items.php:398 mod/dfrn_request.php:650
-#: mod/editpost.php:132 mod/fbrowser.php:105 mod/fbrowser.php:136
-#: mod/follow.php:162 mod/message.php:153 mod/photos.php:257 mod/photos.php:325
-#: mod/settings.php:669 mod/settings.php:695 mod/suggest.php:44
-#: mod/tagrm.php:20 mod/tagrm.php:113 mod/unfollow.php:132 mod/videos.php:106
-#: src/Module/Contact.php:448
+#: include/conversation.php:1191 include/items.php:396 mod/dfrn_request.php:650
+#: mod/editpost.php:113 mod/fbrowser.php:104 mod/fbrowser.php:134
+#: mod/follow.php:161 mod/message.php:153 mod/photos.php:257 mod/photos.php:325
+#: mod/settings.php:666 mod/settings.php:692 mod/suggest.php:44
+#: mod/tagrm.php:20 mod/tagrm.php:115 mod/unfollow.php:132 mod/videos.php:105
+#: src/Module/Contact.php:447
 msgid "Cancel"
 msgstr ""
 
-#: include/conversation.php:1176
+#: include/conversation.php:1196
 msgid "Post to Groups"
 msgstr ""
 
-#: include/conversation.php:1177
+#: include/conversation.php:1197
 msgid "Post to Contacts"
 msgstr ""
 
-#: include/conversation.php:1178
+#: include/conversation.php:1198
 msgid "Private post"
 msgstr ""
 
-#: include/conversation.php:1183 mod/editpost.php:136 src/Model/Profile.php:364
+#: include/conversation.php:1203 mod/editpost.php:117 src/Model/Profile.php:370
 msgid "Message"
 msgstr ""
 
-#: include/conversation.php:1184 mod/editpost.php:137
+#: include/conversation.php:1204 mod/editpost.php:118
 msgid "Browser"
 msgstr ""
 
-#: include/conversation.php:1455
+#: include/conversation.php:1476
 msgid "View all"
 msgstr ""
 
-#: include/conversation.php:1478
+#: include/conversation.php:1500
 msgid "Like"
 msgid_plural "Likes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: include/conversation.php:1481
+#: include/conversation.php:1503
 msgid "Dislike"
 msgid_plural "Dislikes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: include/conversation.php:1487
+#: include/conversation.php:1509
 msgid "Not Attending"
 msgid_plural "Not Attending"
 msgstr[0] ""
 msgstr[1] ""
 
-#: include/conversation.php:1490 src/Content/ContactSelector.php:163
+#: include/conversation.php:1512 src/Content/ContactSelector.php:167
 msgid "Undecided"
 msgid_plural "Undecided"
 msgstr[0] ""
 msgstr[1] ""
 
-#: include/enotify.php:55
+#: include/enotify.php:57
 msgid "Friendica Notification"
 msgstr ""
 
-#: include/enotify.php:58
+#: include/enotify.php:60
 msgid "Thank You,"
-msgstr ""
-
-#: include/enotify.php:61
-#, php-format
-msgid "%1$s, %2$s Administrator"
 msgstr ""
 
 #: include/enotify.php:63
 #, php-format
+msgid "%1$s, %2$s Administrator"
+msgstr ""
+
+#: include/enotify.php:65
+#, php-format
 msgid "%s Administrator"
 msgstr ""
 
-#: include/enotify.php:126
+#: include/enotify.php:134
 #, php-format
 msgid "[Friendica:Notify] New mail received at %s"
 msgstr ""
 
-#: include/enotify.php:128
+#: include/enotify.php:136
 #, php-format
 msgid "%1$s sent you a new private message at %2$s."
 msgstr ""
 
-#: include/enotify.php:129
+#: include/enotify.php:137
 msgid "a private message"
 msgstr ""
 
-#: include/enotify.php:129
+#: include/enotify.php:137
 #, php-format
 msgid "%1$s sent you %2$s."
 msgstr ""
 
-#: include/enotify.php:131
+#: include/enotify.php:139
 #, php-format
 msgid "Please visit %s to view and/or reply to your private messages."
 msgstr ""
 
-#: include/enotify.php:164
+#: include/enotify.php:172
 #, php-format
 msgid "%1$s tagged you on [url=%2$s]a %3$s[/url]"
 msgstr ""
 
-#: include/enotify.php:170
+#: include/enotify.php:178
 #, php-format
 msgid "%1$s commented on [url=%2$s]a %3$s[/url]"
 msgstr ""
 
-#: include/enotify.php:180
+#: include/enotify.php:188
 #, php-format
 msgid "%1$s tagged you on [url=%2$s]%3$s's %4$s[/url]"
 msgstr ""
 
-#: include/enotify.php:187
+#: include/enotify.php:195
 #, php-format
 msgid "%1$s commented on [url=%2$s]%3$s's %4$s[/url]"
 msgstr ""
 
-#: include/enotify.php:199
+#: include/enotify.php:207
 #, php-format
 msgid "%1$s tagged you on [url=%2$s]your %3$s[/url]"
 msgstr ""
 
-#: include/enotify.php:205
+#: include/enotify.php:213
 #, php-format
 msgid "%1$s commented on [url=%2$s]your %3$s[/url]"
 msgstr ""
 
-#: include/enotify.php:216
+#: include/enotify.php:224
 #, php-format
 msgid "%1$s tagged you on [url=%2$s]their %3$s[/url]"
 msgstr ""
 
-#: include/enotify.php:222
+#: include/enotify.php:230
 #, php-format
 msgid "%1$s commented on [url=%2$s]their %3$s[/url]"
 msgstr ""
 
-#: include/enotify.php:235
+#: include/enotify.php:243
 #, php-format
 msgid "[Friendica:Notify] %s tagged you"
 msgstr ""
 
-#: include/enotify.php:237
+#: include/enotify.php:245
 #, php-format
 msgid "%1$s tagged you at %2$s"
 msgstr ""
 
-#: include/enotify.php:239
+#: include/enotify.php:247
 #, php-format
 msgid "[Friendica:Notify] Comment to conversation #%1$d by %2$s"
 msgstr ""
 
-#: include/enotify.php:241
+#: include/enotify.php:249
 #, php-format
 msgid "%s commented on an item/conversation you have been following."
 msgstr ""
 
-#: include/enotify.php:246 include/enotify.php:261 include/enotify.php:276
-#: include/enotify.php:295 include/enotify.php:311
+#: include/enotify.php:254 include/enotify.php:269 include/enotify.php:284
+#: include/enotify.php:303 include/enotify.php:319
 #, php-format
 msgid "Please visit %s to view and/or reply to the conversation."
 msgstr ""
 
-#: include/enotify.php:253
+#: include/enotify.php:261
 #, php-format
 msgid "[Friendica:Notify] %s posted to your profile wall"
 msgstr ""
 
-#: include/enotify.php:255
+#: include/enotify.php:263
 #, php-format
 msgid "%1$s posted to your profile wall at %2$s"
 msgstr ""
 
-#: include/enotify.php:256
+#: include/enotify.php:264
 #, php-format
 msgid "%1$s posted to [url=%2$s]your wall[/url]"
 msgstr ""
 
-#: include/enotify.php:268
+#: include/enotify.php:276
 #, php-format
 msgid "[Friendica:Notify] %s shared a new post"
 msgstr ""
 
-#: include/enotify.php:270
+#: include/enotify.php:278
 #, php-format
 msgid "%1$s shared a new post at %2$s"
 msgstr ""
 
-#: include/enotify.php:271
+#: include/enotify.php:279
 #, php-format
 msgid "%1$s [url=%2$s]shared a post[/url]."
 msgstr ""
 
-#: include/enotify.php:283
+#: include/enotify.php:291
 #, php-format
 msgid "[Friendica:Notify] %1$s poked you"
 msgstr ""
 
-#: include/enotify.php:285
+#: include/enotify.php:293
 #, php-format
 msgid "%1$s poked you at %2$s"
 msgstr ""
 
-#: include/enotify.php:286
+#: include/enotify.php:294
 #, php-format
 msgid "%1$s [url=%2$s]poked you[/url]."
 msgstr ""
 
-#: include/enotify.php:303
+#: include/enotify.php:311
 #, php-format
 msgid "[Friendica:Notify] %s tagged your post"
 msgstr ""
 
-#: include/enotify.php:305
+#: include/enotify.php:313
 #, php-format
 msgid "%1$s tagged your post at %2$s"
 msgstr ""
 
-#: include/enotify.php:306
+#: include/enotify.php:314
 #, php-format
 msgid "%1$s tagged [url=%2$s]your post[/url]"
 msgstr ""
 
-#: include/enotify.php:318
+#: include/enotify.php:326
 msgid "[Friendica:Notify] Introduction received"
-msgstr ""
-
-#: include/enotify.php:320
-#, php-format
-msgid "You've received an introduction from '%1$s' at %2$s"
-msgstr ""
-
-#: include/enotify.php:321
-#, php-format
-msgid "You've received [url=%1$s]an introduction[/url] from %2$s."
-msgstr ""
-
-#: include/enotify.php:326 include/enotify.php:372
-#, php-format
-msgid "You may visit their profile at %s"
 msgstr ""
 
 #: include/enotify.php:328
 #, php-format
+msgid "You've received an introduction from '%1$s' at %2$s"
+msgstr ""
+
+#: include/enotify.php:329
+#, php-format
+msgid "You've received [url=%1$s]an introduction[/url] from %2$s."
+msgstr ""
+
+#: include/enotify.php:334 include/enotify.php:380
+#, php-format
+msgid "You may visit their profile at %s"
+msgstr ""
+
+#: include/enotify.php:336
+#, php-format
 msgid "Please visit %s to approve or reject the introduction."
 msgstr ""
 
-#: include/enotify.php:335
+#: include/enotify.php:343
 msgid "[Friendica:Notify] A new person is sharing with you"
 msgstr ""
 
-#: include/enotify.php:337 include/enotify.php:338
+#: include/enotify.php:345 include/enotify.php:346
 #, php-format
 msgid "%1$s is sharing with you at %2$s"
 msgstr ""
 
-#: include/enotify.php:345
+#: include/enotify.php:353
 msgid "[Friendica:Notify] You have a new follower"
 msgstr ""
 
-#: include/enotify.php:347 include/enotify.php:348
+#: include/enotify.php:355 include/enotify.php:356
 #, php-format
 msgid "You have a new follower at %2$s : %1$s"
 msgstr ""
 
-#: include/enotify.php:361
+#: include/enotify.php:369
 msgid "[Friendica:Notify] Friend suggestion received"
 msgstr ""
 
-#: include/enotify.php:363
+#: include/enotify.php:371
 #, php-format
 msgid "You've received a friend suggestion from '%1$s' at %2$s"
 msgstr ""
 
-#: include/enotify.php:364
+#: include/enotify.php:372
 #, php-format
 msgid "You've received [url=%1$s]a friend suggestion[/url] for %2$s from %3$s."
 msgstr ""
 
-#: include/enotify.php:370
+#: include/enotify.php:378
 msgid "Name:"
 msgstr ""
 
-#: include/enotify.php:371
+#: include/enotify.php:379
 msgid "Photo:"
 msgstr ""
 
-#: include/enotify.php:374
+#: include/enotify.php:382
 #, php-format
 msgid "Please visit %s to approve or reject the suggestion."
 msgstr ""
 
-#: include/enotify.php:382 include/enotify.php:397
+#: include/enotify.php:390 include/enotify.php:405
 msgid "[Friendica:Notify] Connection accepted"
 msgstr ""
 
-#: include/enotify.php:384 include/enotify.php:399
+#: include/enotify.php:392 include/enotify.php:407
 #, php-format
 msgid "'%1$s' has accepted your connection request at %2$s"
 msgstr ""
 
-#: include/enotify.php:385 include/enotify.php:400
+#: include/enotify.php:393 include/enotify.php:408
 #, php-format
 msgid "%2$s has accepted your [url=%1$s]connection request[/url]."
 msgstr ""
 
-#: include/enotify.php:390
+#: include/enotify.php:398
 msgid ""
 "You are now mutual friends and may exchange status updates, photos, and "
 "email without restriction."
 msgstr ""
 
-#: include/enotify.php:392
+#: include/enotify.php:400
 #, php-format
 msgid "Please visit %s if you wish to make any changes to this relationship."
 msgstr ""
 
-#: include/enotify.php:405
+#: include/enotify.php:413
 #, php-format
 msgid ""
 "'%1$s' has chosen to accept you a fan, which restricts some forms of "
@@ -758,37 +758,37 @@ msgid ""
 "automatically."
 msgstr ""
 
-#: include/enotify.php:407
+#: include/enotify.php:415
 #, php-format
 msgid ""
 "'%1$s' may choose to extend this into a two-way or more permissive "
 "relationship in the future."
 msgstr ""
 
-#: include/enotify.php:409
+#: include/enotify.php:417
 #, php-format
 msgid "Please visit %s  if you wish to make any changes to this relationship."
 msgstr ""
 
-#: include/enotify.php:419 mod/removeme.php:47
+#: include/enotify.php:427 mod/removeme.php:46
 msgid "[Friendica System Notify]"
 msgstr ""
 
-#: include/enotify.php:419
+#: include/enotify.php:427
 msgid "registration request"
 msgstr ""
 
-#: include/enotify.php:421
+#: include/enotify.php:429
 #, php-format
 msgid "You've received a registration request from '%1$s' at %2$s"
 msgstr ""
 
-#: include/enotify.php:422
+#: include/enotify.php:430
 #, php-format
 msgid "You've received a [url=%1$s]registration request[/url] from %2$s."
 msgstr ""
 
-#: include/enotify.php:427
+#: include/enotify.php:435
 #, php-format
 msgid ""
 "Full Name:\t%s\n"
@@ -796,518 +796,519 @@ msgid ""
 "Login Name:\t%s (%s)"
 msgstr ""
 
-#: include/enotify.php:433
+#: include/enotify.php:441
 #, php-format
 msgid "Please visit %s to approve or reject the request."
 msgstr ""
 
-#: include/items.php:355 mod/admin.php:296 mod/admin.php:2094
-#: mod/admin.php:2340 mod/notice.php:21 mod/viewsrc.php:22
+#: include/items.php:353 mod/admin.php:301 mod/admin.php:2130
+#: mod/admin.php:2377 mod/notice.php:20 mod/viewsrc.php:22
 msgid "Item not found."
 msgstr ""
 
-#: include/items.php:393
+#: include/items.php:391
 msgid "Do you really want to delete this item?"
 msgstr ""
 
-#: include/items.php:395 mod/api.php:112 mod/dfrn_request.php:640
-#: mod/follow.php:151 mod/message.php:150 mod/profiles.php:542
-#: mod/profiles.php:545 mod/profiles.php:567 mod/register.php:232
-#: mod/settings.php:1088 mod/settings.php:1094 mod/settings.php:1101
-#: mod/settings.php:1105 mod/settings.php:1109 mod/settings.php:1113
-#: mod/settings.php:1117 mod/settings.php:1121 mod/settings.php:1141
-#: mod/settings.php:1142 mod/settings.php:1143 mod/settings.php:1144
-#: mod/settings.php:1145 mod/suggest.php:41 src/Module/Contact.php:445
+#: include/items.php:393 mod/api.php:109 mod/dfrn_request.php:640
+#: mod/follow.php:150 mod/message.php:150 mod/profiles.php:526
+#: mod/profiles.php:529 mod/profiles.php:551 mod/settings.php:1085
+#: mod/settings.php:1091 mod/settings.php:1098 mod/settings.php:1102
+#: mod/settings.php:1106 mod/settings.php:1110 mod/settings.php:1114
+#: mod/settings.php:1118 mod/settings.php:1138 mod/settings.php:1139
+#: mod/settings.php:1140 mod/settings.php:1141 mod/settings.php:1142
+#: mod/suggest.php:41 src/Module/Contact.php:444 src/Module/Register.php:97
 msgid "Yes"
 msgstr ""
 
-#: include/items.php:445 mod/allfriends.php:22 mod/api.php:37 mod/api.php:42
-#: mod/cal.php:304 mod/common.php:27 mod/crepair.php:101 mod/delegate.php:31
-#: mod/delegate.php:49 mod/delegate.php:60 mod/dfrn_confirm.php:66
-#: mod/dirfind.php:29 mod/editpost.php:22 mod/events.php:207 mod/follow.php:58
-#: mod/follow.php:122 mod/fsuggest.php:81 mod/group.php:30 mod/invite.php:25
+#: include/items.php:443 mod/allfriends.php:22 mod/api.php:34 mod/api.php:39
+#: mod/cal.php:303 mod/common.php:27 mod/crepair.php:101 mod/delegate.php:30
+#: mod/delegate.php:48 mod/delegate.php:59 mod/dfrn_confirm.php:66
+#: mod/dirfind.php:29 mod/editpost.php:22 mod/events.php:207 mod/follow.php:57
+#: mod/follow.php:121 mod/fsuggest.php:77 mod/group.php:28 mod/invite.php:23
 #: mod/invite.php:111 mod/item.php:167 mod/manage.php:129 mod/message.php:56
-#: mod/message.php:101 mod/network.php:35 mod/nogroup.php:23 mod/notes.php:33
+#: mod/message.php:101 mod/network.php:35 mod/nogroup.php:18 mod/notes.php:27
 #: mod/notifications.php:70 mod/ostatus_subscribe.php:18 mod/photos.php:186
-#: mod/photos.php:1019 mod/poke.php:141 mod/profiles.php:183
-#: mod/profiles.php:515 mod/profile_photo.php:33 mod/profile_photo.php:178
-#: mod/profile_photo.php:205 mod/register.php:53 mod/regmod.php:89
-#: mod/repair_ostatus.php:16 mod/settings.php:48 mod/settings.php:154
-#: mod/settings.php:658 mod/suggest.php:62 mod/uimport.php:17
-#: mod/unfollow.php:22 mod/unfollow.php:77 mod/unfollow.php:109
-#: mod/viewcontacts.php:56 mod/wallmessage.php:19 mod/wallmessage.php:43
-#: mod/wallmessage.php:82 mod/wallmessage.php:106 mod/wall_attach.php:79
-#: mod/wall_attach.php:82 mod/wall_upload.php:106 mod/wall_upload.php:109
-#: src/App.php:1823 src/Module/Attach.php:42 src/Module/Contact.php:361
+#: mod/photos.php:1020 mod/poke.php:141 mod/profiles.php:182
+#: mod/profiles.php:499 mod/profile_photo.php:32 mod/profile_photo.php:177
+#: mod/profile_photo.php:204 mod/regmod.php:89 mod/repair_ostatus.php:16
+#: mod/settings.php:48 mod/settings.php:154 mod/settings.php:655
+#: mod/suggest.php:62 mod/uimport.php:17 mod/unfollow.php:22
+#: mod/unfollow.php:77 mod/unfollow.php:109 mod/viewcontacts.php:56
+#: mod/wallmessage.php:19 mod/wallmessage.php:43 mod/wallmessage.php:82
+#: mod/wallmessage.php:106 mod/wall_attach.php:76 mod/wall_attach.php:79
+#: mod/wall_upload.php:107 mod/wall_upload.php:110 src/App.php:1482
+#: src/Module/Attach.php:42 src/Module/Contact.php:360
+#: src/Module/Register.php:193
 msgid "Permission denied."
 msgstr ""
 
-#: include/items.php:516 src/Content/Feature.php:95
+#: include/items.php:514 src/Content/Feature.php:98
 msgid "Archives"
 msgstr ""
 
-#: include/items.php:522 src/App.php:823 src/Content/ForumManager.php:131
-#: src/Content/Widget.php:321 src/Object/Post.php:454
+#: include/items.php:520 src/App.php:666 src/Content/ForumManager.php:135
+#: src/Content/Widget.php:329 src/Object/Post.php:457
 #: view/theme/vier/theme.php:255
 msgid "show more"
 msgstr ""
 
-#: mod/admin.php:117
+#: mod/admin.php:121
 msgid "Theme settings updated."
 msgstr ""
 
-#: mod/admin.php:190 src/Content/Nav.php:224
+#: mod/admin.php:195 src/Content/Nav.php:231
 msgid "Information"
 msgstr ""
 
-#: mod/admin.php:191
+#: mod/admin.php:196
 msgid "Overview"
 msgstr ""
 
-#: mod/admin.php:192 mod/admin.php:763
+#: mod/admin.php:197 mod/admin.php:778
 msgid "Federation Statistics"
 msgstr ""
 
-#: mod/admin.php:193
+#: mod/admin.php:198
 msgid "Configuration"
 msgstr ""
 
-#: mod/admin.php:194 mod/admin.php:1549
+#: mod/admin.php:199 mod/admin.php:1580
 msgid "Site"
 msgstr ""
 
-#: mod/admin.php:195 mod/admin.php:1453 mod/admin.php:2026 mod/admin.php:2043
+#: mod/admin.php:200 mod/admin.php:1481 mod/admin.php:2061 mod/admin.php:2078
 msgid "Users"
 msgstr ""
 
-#: mod/admin.php:196 mod/admin.php:2142 mod/admin.php:2202 mod/settings.php:99
+#: mod/admin.php:201 mod/admin.php:2178 mod/admin.php:2238 mod/settings.php:99
 msgid "Addons"
 msgstr ""
 
-#: mod/admin.php:197 mod/admin.php:2398 mod/admin.php:2442
+#: mod/admin.php:202 mod/admin.php:2435 mod/admin.php:2479
 msgid "Themes"
 msgstr ""
 
-#: mod/admin.php:198 mod/settings.php:77
+#: mod/admin.php:203 mod/settings.php:77
 msgid "Additional features"
 msgstr ""
 
-#: mod/admin.php:199 mod/admin.php:322 mod/register.php:280
-#: src/Content/Nav.php:227 src/Module/Tos.php:71
+#: mod/admin.php:204 mod/admin.php:328 src/Content/Nav.php:234
+#: src/Module/Register.php:144 src/Module/Tos.php:73
 msgid "Terms of Service"
 msgstr ""
 
-#: mod/admin.php:200
+#: mod/admin.php:205
 msgid "Database"
 msgstr ""
 
-#: mod/admin.php:201
+#: mod/admin.php:206
 msgid "DB updates"
 msgstr ""
 
-#: mod/admin.php:202 mod/admin.php:806
+#: mod/admin.php:207 mod/admin.php:822
 msgid "Inspect Queue"
 msgstr ""
 
-#: mod/admin.php:203
+#: mod/admin.php:208
 msgid "Inspect Deferred Workers"
 msgstr ""
 
-#: mod/admin.php:204
+#: mod/admin.php:209
 msgid "Inspect worker Queue"
 msgstr ""
 
-#: mod/admin.php:205
+#: mod/admin.php:210
 msgid "Tools"
 msgstr ""
 
-#: mod/admin.php:206
+#: mod/admin.php:211
 msgid "Contact Blocklist"
 msgstr ""
 
-#: mod/admin.php:207 mod/admin.php:386
+#: mod/admin.php:212 mod/admin.php:394
 msgid "Server Blocklist"
 msgstr ""
 
-#: mod/admin.php:208 mod/admin.php:544
+#: mod/admin.php:213 mod/admin.php:557
 msgid "Delete Item"
 msgstr ""
 
-#: mod/admin.php:209 mod/admin.php:210 mod/admin.php:2517
+#: mod/admin.php:214 mod/admin.php:215 mod/admin.php:2555
 msgid "Logs"
 msgstr ""
 
-#: mod/admin.php:211 mod/admin.php:2584
+#: mod/admin.php:216 mod/admin.php:2623
 msgid "View Logs"
 msgstr ""
 
-#: mod/admin.php:213
+#: mod/admin.php:218
 msgid "Diagnostics"
 msgstr ""
 
-#: mod/admin.php:214
+#: mod/admin.php:219
 msgid "PHP Info"
 msgstr ""
 
-#: mod/admin.php:215
+#: mod/admin.php:220
 msgid "probe address"
 msgstr ""
 
-#: mod/admin.php:216
+#: mod/admin.php:221
 msgid "check webfinger"
 msgstr ""
 
-#: mod/admin.php:236 src/Content/Nav.php:267
+#: mod/admin.php:241 src/Content/Nav.php:274
 msgid "Admin"
 msgstr ""
 
-#: mod/admin.php:237
+#: mod/admin.php:242
 msgid "Addon Features"
 msgstr ""
 
-#: mod/admin.php:238
+#: mod/admin.php:243
 msgid "User registrations waiting for confirmation"
 msgstr ""
 
-#: mod/admin.php:321 mod/admin.php:385 mod/admin.php:501 mod/admin.php:543
-#: mod/admin.php:762 mod/admin.php:805 mod/admin.php:856 mod/admin.php:974
-#: mod/admin.php:1548 mod/admin.php:2025 mod/admin.php:2141 mod/admin.php:2201
-#: mod/admin.php:2397 mod/admin.php:2441 mod/admin.php:2516 mod/admin.php:2583
+#: mod/admin.php:327 mod/admin.php:393 mod/admin.php:513 mod/admin.php:556
+#: mod/admin.php:777 mod/admin.php:821 mod/admin.php:874 mod/admin.php:997
+#: mod/admin.php:1579 mod/admin.php:2060 mod/admin.php:2177 mod/admin.php:2237
+#: mod/admin.php:2434 mod/admin.php:2478 mod/admin.php:2554 mod/admin.php:2622
 msgid "Administration"
 msgstr ""
 
-#: mod/admin.php:323
+#: mod/admin.php:329
 msgid "Display Terms of Service"
 msgstr ""
 
-#: mod/admin.php:323
+#: mod/admin.php:329
 msgid ""
 "Enable the Terms of Service page. If this is enabled a link to the terms "
 "will be added to the registration form and the general information page."
 msgstr ""
 
-#: mod/admin.php:324
+#: mod/admin.php:330
 msgid "Display Privacy Statement"
 msgstr ""
 
-#: mod/admin.php:324
+#: mod/admin.php:330
 #, php-format
 msgid ""
 "Show some informations regarding the needed information to operate the node "
 "according e.g. to <a href=\"%s\" target=\"_blank\">EU-GDPR</a>."
 msgstr ""
 
-#: mod/admin.php:325
+#: mod/admin.php:331
 msgid "Privacy Statement Preview"
 msgstr ""
 
-#: mod/admin.php:327
+#: mod/admin.php:333
 msgid "The Terms of Service"
 msgstr ""
 
-#: mod/admin.php:327
+#: mod/admin.php:333
 msgid ""
 "Enter the Terms of Service for your node here. You can use BBCode. Headers "
 "of sections should be [h2] and below."
 msgstr ""
 
-#: mod/admin.php:329 mod/admin.php:1550 mod/admin.php:2203 mod/admin.php:2443
-#: mod/admin.php:2518 mod/admin.php:2665 mod/delegate.php:176
-#: mod/settings.php:668 mod/settings.php:775 mod/settings.php:863
-#: mod/settings.php:952 mod/settings.php:1177
+#: mod/admin.php:335 mod/admin.php:1581 mod/admin.php:2239 mod/admin.php:2480
+#: mod/admin.php:2556 mod/admin.php:2706 mod/delegate.php:175
+#: mod/settings.php:665 mod/settings.php:772 mod/settings.php:860
+#: mod/settings.php:949 mod/settings.php:1174
 msgid "Save Settings"
 msgstr ""
 
-#: mod/admin.php:377 mod/admin.php:395 mod/dfrn_request.php:346
-#: mod/friendica.php:123 src/Model/Contact.php:1653
+#: mod/admin.php:385 mod/admin.php:403 mod/dfrn_request.php:346
+#: mod/friendica.php:130 src/Model/Contact.php:1702
 msgid "Blocked domain"
 msgstr ""
 
-#: mod/admin.php:377
+#: mod/admin.php:385
 msgid "The blocked domain"
 msgstr ""
 
-#: mod/admin.php:378 mod/admin.php:396 mod/friendica.php:123
+#: mod/admin.php:386 mod/admin.php:404 mod/friendica.php:130
 msgid "Reason for the block"
 msgstr ""
 
-#: mod/admin.php:378 mod/admin.php:391
+#: mod/admin.php:386 mod/admin.php:399
 msgid "The reason why you blocked this domain."
 msgstr ""
 
-#: mod/admin.php:379
+#: mod/admin.php:387
 msgid "Delete domain"
 msgstr ""
 
-#: mod/admin.php:379
+#: mod/admin.php:387
 msgid "Check to delete this entry from the blocklist"
 msgstr ""
 
-#: mod/admin.php:387
+#: mod/admin.php:395
 msgid ""
 "This page can be used to define a black list of servers from the federated "
 "network that are not allowed to interact with your node. For all entered "
 "domains you should also give a reason why you have blocked the remote server."
 msgstr ""
 
-#: mod/admin.php:388
+#: mod/admin.php:396
 msgid ""
 "The list of blocked servers will be made publically available on the /"
 "friendica page so that your users and people investigating communication "
 "problems can find the reason easily."
 msgstr ""
 
-#: mod/admin.php:389
+#: mod/admin.php:397
 msgid "Add new entry to block list"
 msgstr ""
 
-#: mod/admin.php:390
+#: mod/admin.php:398
 msgid "Server Domain"
 msgstr ""
 
-#: mod/admin.php:390
+#: mod/admin.php:398
 msgid ""
 "The domain of the new server to add to the block list. Do not include the "
 "protocol."
 msgstr ""
 
-#: mod/admin.php:391
+#: mod/admin.php:399
 msgid "Block reason"
 msgstr ""
 
-#: mod/admin.php:392
+#: mod/admin.php:400
 msgid "Add Entry"
 msgstr ""
 
-#: mod/admin.php:393
+#: mod/admin.php:401
 msgid "Save changes to the blocklist"
 msgstr ""
 
-#: mod/admin.php:394
+#: mod/admin.php:402
 msgid "Current Entries in the Blocklist"
 msgstr ""
 
-#: mod/admin.php:397
+#: mod/admin.php:405
 msgid "Delete entry from blocklist"
 msgstr ""
 
-#: mod/admin.php:400
+#: mod/admin.php:408
 msgid "Delete entry from blocklist?"
 msgstr ""
 
-#: mod/admin.php:426
+#: mod/admin.php:435
 msgid "Server added to blocklist."
 msgstr ""
 
-#: mod/admin.php:442
+#: mod/admin.php:451
 msgid "Site blocklist updated."
 msgstr ""
 
-#: mod/admin.php:465 src/Core/Console/GlobalCommunityBlock.php:68
+#: mod/admin.php:476 src/Core/Console/GlobalCommunityBlock.php:68
 msgid "The contact has been blocked from the node"
 msgstr ""
 
-#: mod/admin.php:467 src/Core/Console/GlobalCommunityBlock.php:65
+#: mod/admin.php:478 src/Core/Console/GlobalCommunityBlock.php:65
 #, php-format
 msgid "Could not find any contact entry for this URL (%s)"
 msgstr ""
 
-#: mod/admin.php:474
+#: mod/admin.php:485
 #, php-format
 msgid "%s contact unblocked"
 msgid_plural "%s contacts unblocked"
 msgstr[0] ""
 msgstr[1] ""
 
-#: mod/admin.php:502
+#: mod/admin.php:514
 msgid "Remote Contact Blocklist"
 msgstr ""
 
-#: mod/admin.php:503
+#: mod/admin.php:515
 msgid ""
 "This page allows you to prevent any message from a remote contact to reach "
 "your node."
 msgstr ""
 
-#: mod/admin.php:504
+#: mod/admin.php:516
 msgid "Block Remote Contact"
 msgstr ""
 
-#: mod/admin.php:505 mod/admin.php:2028
+#: mod/admin.php:517 mod/admin.php:2063
 msgid "select all"
 msgstr ""
 
-#: mod/admin.php:506
+#: mod/admin.php:518
 msgid "select none"
 msgstr ""
 
-#: mod/admin.php:507 mod/admin.php:2037 src/Module/Contact.php:623
-#: src/Module/Contact.php:827 src/Module/Contact.php:1080
+#: mod/admin.php:519 mod/admin.php:2072 src/Module/Contact.php:621
+#: src/Module/Contact.php:824 src/Module/Contact.php:1077
 msgid "Block"
 msgstr ""
 
-#: mod/admin.php:508 mod/admin.php:2039 src/Module/Contact.php:623
-#: src/Module/Contact.php:827 src/Module/Contact.php:1080
+#: mod/admin.php:520 mod/admin.php:2074 src/Module/Contact.php:621
+#: src/Module/Contact.php:824 src/Module/Contact.php:1077
 msgid "Unblock"
 msgstr ""
 
-#: mod/admin.php:509
+#: mod/admin.php:521
 msgid "No remote contact is blocked from this node."
 msgstr ""
 
-#: mod/admin.php:511
+#: mod/admin.php:523
 msgid "Blocked Remote Contacts"
 msgstr ""
 
-#: mod/admin.php:512
+#: mod/admin.php:524
 msgid "Block New Remote Contact"
 msgstr ""
 
-#: mod/admin.php:513
+#: mod/admin.php:525
 msgid "Photo"
 msgstr ""
 
-#: mod/admin.php:513 mod/admin.php:2020 mod/admin.php:2031 mod/admin.php:2045
-#: mod/admin.php:2061 mod/crepair.php:161 mod/settings.php:670
-#: mod/settings.php:696
+#: mod/admin.php:525 mod/admin.php:2055 mod/admin.php:2066 mod/admin.php:2080
+#: mod/admin.php:2096 mod/crepair.php:161 mod/settings.php:667
+#: mod/settings.php:693
 msgid "Name"
 msgstr ""
 
-#: mod/admin.php:513 mod/profiles.php:395
+#: mod/admin.php:525 mod/profiles.php:382
 msgid "Address"
 msgstr ""
 
-#: mod/admin.php:513 mod/admin.php:523 mod/follow.php:167
-#: mod/notifications.php:177 mod/notifications.php:261 mod/unfollow.php:137
-#: src/Module/Contact.php:642
+#: mod/admin.php:525 mod/admin.php:535 mod/follow.php:166
+#: mod/notifications.php:179 mod/notifications.php:263 mod/unfollow.php:137
+#: src/Module/Contact.php:639
 msgid "Profile URL"
 msgstr ""
 
-#: mod/admin.php:521
+#: mod/admin.php:533
 #, php-format
 msgid "%s total blocked contact"
 msgid_plural "%s total blocked contacts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: mod/admin.php:523
+#: mod/admin.php:535
 msgid "URL of the remote contact to block."
 msgstr ""
 
-#: mod/admin.php:545
+#: mod/admin.php:558
 msgid "Delete this Item"
 msgstr ""
 
-#: mod/admin.php:546
+#: mod/admin.php:559
 msgid ""
 "On this page you can delete an item from your node. If the item is a top "
 "level posting, the entire thread will be deleted."
 msgstr ""
 
-#: mod/admin.php:547
+#: mod/admin.php:560
 msgid ""
 "You need to know the GUID of the item. You can find it e.g. by looking at "
 "the display URL. The last part of http://example.com/display/123456 is the "
 "GUID, here 123456."
 msgstr ""
 
-#: mod/admin.php:548
+#: mod/admin.php:561
 msgid "GUID"
 msgstr ""
 
-#: mod/admin.php:548
+#: mod/admin.php:561
 msgid "The GUID of the item you want to delete."
 msgstr ""
 
-#: mod/admin.php:582
+#: mod/admin.php:596
 msgid "Item marked for deletion."
 msgstr ""
 
-#: mod/admin.php:653
+#: mod/admin.php:668
 msgid "unknown"
 msgstr ""
 
-#: mod/admin.php:756
+#: mod/admin.php:771
 msgid ""
 "This page offers you some numbers to the known part of the federated social "
 "network your Friendica node is part of. These numbers are not complete but "
 "only reflect the part of the network your node is aware of."
 msgstr ""
 
-#: mod/admin.php:757
+#: mod/admin.php:772
 msgid ""
 "The <em>Auto Discovered Contact Directory</em> feature is not enabled, it "
 "will improve the data displayed here."
 msgstr ""
 
-#: mod/admin.php:769
+#: mod/admin.php:784
 #, php-format
 msgid ""
 "Currently this node is aware of %d nodes with %d registered users from the "
 "following platforms:"
 msgstr ""
 
-#: mod/admin.php:808 mod/admin.php:859
+#: mod/admin.php:824 mod/admin.php:877
 msgid "ID"
 msgstr ""
 
-#: mod/admin.php:809
+#: mod/admin.php:825
 msgid "Recipient Name"
 msgstr ""
 
-#: mod/admin.php:810
+#: mod/admin.php:826
 msgid "Recipient Profile"
 msgstr ""
 
-#: mod/admin.php:811 src/Content/Nav.php:232
-#: src/Core/NotificationsManager.php:178 view/theme/frio/theme.php:267
+#: mod/admin.php:827 src/Content/Nav.php:239
+#: src/Core/NotificationsManager.php:182 view/theme/frio/theme.php:269
 msgid "Network"
 msgstr ""
 
-#: mod/admin.php:812 mod/admin.php:861
+#: mod/admin.php:828 mod/admin.php:879
 msgid "Created"
 msgstr ""
 
-#: mod/admin.php:813
+#: mod/admin.php:829
 msgid "Last Tried"
 msgstr ""
 
-#: mod/admin.php:814
+#: mod/admin.php:830
 msgid ""
 "This page lists the content of the queue for outgoing postings. These are "
 "postings the initial delivery failed for. They will be resend later and "
 "eventually deleted if the delivery fails permanently."
 msgstr ""
 
-#: mod/admin.php:835
+#: mod/admin.php:853
 msgid "Inspect Deferred Worker Queue"
 msgstr ""
 
-#: mod/admin.php:836
+#: mod/admin.php:854
 msgid ""
 "This page lists the deferred worker jobs. This are jobs that couldn't be "
 "executed at the first time."
 msgstr ""
 
-#: mod/admin.php:839
+#: mod/admin.php:857
 msgid "Inspect Worker Queue"
 msgstr ""
 
-#: mod/admin.php:840
+#: mod/admin.php:858
 msgid ""
 "This page lists the currently queued worker jobs. These jobs are handled by "
 "the worker cronjob you've set up during install."
 msgstr ""
 
-#: mod/admin.php:860
+#: mod/admin.php:878
 msgid "Job Parameters"
 msgstr ""
 
-#: mod/admin.php:862
+#: mod/admin.php:880
 msgid "Priority"
 msgstr ""
 
-#: mod/admin.php:887
+#: mod/admin.php:906
 #, php-format
 msgid ""
 "Your DB still runs with MyISAM tables. You should change the engine type to "
@@ -1318,32 +1319,32 @@ msgid ""
 "automatic conversion.<br />"
 msgstr ""
 
-#: mod/admin.php:894
+#: mod/admin.php:913
 #, php-format
 msgid ""
 "There is a new version of Friendica available for download. Your current "
 "version is %1$s, upstream version is %2$s"
 msgstr ""
 
-#: mod/admin.php:904
+#: mod/admin.php:923
 msgid ""
 "The database update failed. Please run \"php bin/console.php dbstructure "
 "update\" from the command line and have a look at the errors that might "
 "appear."
 msgstr ""
 
-#: mod/admin.php:910
+#: mod/admin.php:929
 msgid "The worker was never executed. Please check your database structure!"
 msgstr ""
 
-#: mod/admin.php:913
+#: mod/admin.php:932
 #, php-format
 msgid ""
 "The last worker execution was on %s UTC. This is older than one hour. Please "
 "check your crontab settings."
 msgstr ""
 
-#: mod/admin.php:919
+#: mod/admin.php:938
 #, php-format
 msgid ""
 "Friendica's configuration now is stored in config/local.config.php, please "
@@ -1352,7 +1353,16 @@ msgid ""
 "with the transition."
 msgstr ""
 
-#: mod/admin.php:926
+#: mod/admin.php:942
+#, php-format
+msgid ""
+"Friendica's configuration now is stored in config/local.config.php, please "
+"copy config/local-sample.config.php and move your config from <code>config/"
+"local.ini.php</code>. See <a href=\"%s\">the Config help page</a> for help "
+"with the transition."
+msgstr ""
+
+#: mod/admin.php:949
 #, php-format
 msgid ""
 "<a href=\"%s\">%s</a> is not reachable on your system. This is a severe "
@@ -1360,517 +1370,522 @@ msgid ""
 "href=\"%s\">the installation page</a> for help."
 msgstr ""
 
-#: mod/admin.php:932
+#: mod/admin.php:955
 msgid "Normal Account"
 msgstr ""
 
-#: mod/admin.php:933
+#: mod/admin.php:956
 msgid "Automatic Follower Account"
 msgstr ""
 
-#: mod/admin.php:934
+#: mod/admin.php:957
 msgid "Public Forum Account"
 msgstr ""
 
-#: mod/admin.php:935
+#: mod/admin.php:958
 msgid "Automatic Friend Account"
 msgstr ""
 
-#: mod/admin.php:936
+#: mod/admin.php:959
 msgid "Blog Account"
 msgstr ""
 
-#: mod/admin.php:937
+#: mod/admin.php:960
 msgid "Private Forum Account"
 msgstr ""
 
-#: mod/admin.php:960
+#: mod/admin.php:983
 msgid "Message queues"
 msgstr ""
 
-#: mod/admin.php:966
+#: mod/admin.php:989
 msgid "Server Settings"
 msgstr ""
 
-#: mod/admin.php:975
+#: mod/admin.php:998
 msgid "Summary"
 msgstr ""
 
-#: mod/admin.php:977
+#: mod/admin.php:1000
 msgid "Registered users"
 msgstr ""
 
-#: mod/admin.php:979
+#: mod/admin.php:1002
 msgid "Pending registrations"
 msgstr ""
 
-#: mod/admin.php:980
+#: mod/admin.php:1003
 msgid "Version"
 msgstr ""
 
-#: mod/admin.php:985
+#: mod/admin.php:1008
 msgid "Active addons"
 msgstr ""
 
-#: mod/admin.php:1017
+#: mod/admin.php:1041
 msgid "Can not parse base url. Must have at least <scheme>://<domain>"
 msgstr ""
 
-#: mod/admin.php:1387
+#: mod/admin.php:1414
 msgid "Site settings updated."
 msgstr ""
 
-#: mod/admin.php:1415 mod/settings.php:896
+#: mod/admin.php:1443 mod/settings.php:893
 msgid "No special theme for mobile devices"
 msgstr ""
 
-#: mod/admin.php:1444
+#: mod/admin.php:1472
 msgid "No community page for local users"
 msgstr ""
 
-#: mod/admin.php:1445
+#: mod/admin.php:1473
 msgid "No community page"
 msgstr ""
 
-#: mod/admin.php:1446
+#: mod/admin.php:1474
 msgid "Public postings from users of this site"
 msgstr ""
 
-#: mod/admin.php:1447
+#: mod/admin.php:1475
 msgid "Public postings from the federated network"
 msgstr ""
 
-#: mod/admin.php:1448
+#: mod/admin.php:1476
 msgid "Public postings from local users and the federated network"
 msgstr ""
 
-#: mod/admin.php:1452 mod/admin.php:1650 mod/admin.php:1660
-#: src/Module/Contact.php:548
+#: mod/admin.php:1480 mod/admin.php:1681 mod/admin.php:1691
+#: src/Module/Contact.php:546
 msgid "Disabled"
 msgstr ""
 
-#: mod/admin.php:1454
+#: mod/admin.php:1482
 msgid "Users, Global Contacts"
 msgstr ""
 
-#: mod/admin.php:1455
+#: mod/admin.php:1483
 msgid "Users, Global Contacts/fallback"
 msgstr ""
 
-#: mod/admin.php:1459
+#: mod/admin.php:1487
 msgid "One month"
 msgstr ""
 
-#: mod/admin.php:1460
+#: mod/admin.php:1488
 msgid "Three months"
 msgstr ""
 
-#: mod/admin.php:1461
+#: mod/admin.php:1489
 msgid "Half a year"
 msgstr ""
 
-#: mod/admin.php:1462
+#: mod/admin.php:1490
 msgid "One year"
 msgstr ""
 
-#: mod/admin.php:1467
+#: mod/admin.php:1495
 msgid "Multi user instance"
 msgstr ""
 
-#: mod/admin.php:1491
+#: mod/admin.php:1519
 msgid "Closed"
 msgstr ""
 
-#: mod/admin.php:1492
+#: mod/admin.php:1520
 msgid "Requires approval"
 msgstr ""
 
-#: mod/admin.php:1493
+#: mod/admin.php:1521
 msgid "Open"
 msgstr ""
 
-#: mod/admin.php:1497
+#: mod/admin.php:1525
 msgid "No SSL policy, links will track page SSL state"
 msgstr ""
 
-#: mod/admin.php:1498
+#: mod/admin.php:1526
 msgid "Force all links to use SSL"
 msgstr ""
 
-#: mod/admin.php:1499
+#: mod/admin.php:1527
 msgid "Self-signed certificate, use SSL for local links only (discouraged)"
 msgstr ""
 
-#: mod/admin.php:1503
+#: mod/admin.php:1531
 msgid "Don't check"
 msgstr ""
 
-#: mod/admin.php:1504
+#: mod/admin.php:1532
 msgid "check the stable version"
 msgstr ""
 
-#: mod/admin.php:1505
+#: mod/admin.php:1533
 msgid "check the development version"
 msgstr ""
 
-#: mod/admin.php:1524 mod/settings.php:856 mod/settings.php:861
-msgid "None"
+#: mod/admin.php:1555
+msgid "Database (legacy)"
 msgstr ""
 
-#: mod/admin.php:1551
+#: mod/admin.php:1582
 msgid "Republish users to directory"
 msgstr ""
 
-#: mod/admin.php:1552 mod/register.php:257
+#: mod/admin.php:1583 src/Module/Register.php:121
 msgid "Registration"
 msgstr ""
 
-#: mod/admin.php:1553
+#: mod/admin.php:1584
 msgid "File upload"
 msgstr ""
 
-#: mod/admin.php:1554
+#: mod/admin.php:1585
 msgid "Policies"
 msgstr ""
 
-#: mod/admin.php:1555 mod/events.php:570 src/Model/Profile.php:883
-#: src/Module/Contact.php:905
+#: mod/admin.php:1586 mod/events.php:555 src/Model/Profile.php:878
+#: src/Module/Contact.php:902
 msgid "Advanced"
 msgstr ""
 
-#: mod/admin.php:1556
+#: mod/admin.php:1587
 msgid "Auto Discovered Contact Directory"
 msgstr ""
 
-#: mod/admin.php:1557
+#: mod/admin.php:1588
 msgid "Performance"
 msgstr ""
 
-#: mod/admin.php:1558
+#: mod/admin.php:1589
 msgid "Worker"
 msgstr ""
 
-#: mod/admin.php:1559
+#: mod/admin.php:1590
 msgid "Message Relay"
 msgstr ""
 
-#: mod/admin.php:1560
+#: mod/admin.php:1591
 msgid "Relocate Instance"
 msgstr ""
 
-#: mod/admin.php:1561
+#: mod/admin.php:1592
 msgid "Warning! Advanced function. Could make this server unreachable."
 msgstr ""
 
-#: mod/admin.php:1565
+#: mod/admin.php:1596
 msgid "Site name"
 msgstr ""
 
-#: mod/admin.php:1566
+#: mod/admin.php:1597
 msgid "Host name"
 msgstr ""
 
-#: mod/admin.php:1567
+#: mod/admin.php:1598
 msgid "Sender Email"
 msgstr ""
 
-#: mod/admin.php:1567
+#: mod/admin.php:1598
 msgid ""
 "The email address your server shall use to send notification emails from."
 msgstr ""
 
-#: mod/admin.php:1568
+#: mod/admin.php:1599
 msgid "Banner/Logo"
 msgstr ""
 
-#: mod/admin.php:1569
+#: mod/admin.php:1600
 msgid "Shortcut icon"
 msgstr ""
 
-#: mod/admin.php:1569
+#: mod/admin.php:1600
 msgid "Link to an icon that will be used for browsers."
 msgstr ""
 
-#: mod/admin.php:1570
+#: mod/admin.php:1601
 msgid "Touch icon"
 msgstr ""
 
-#: mod/admin.php:1570
+#: mod/admin.php:1601
 msgid "Link to an icon that will be used for tablets and mobiles."
 msgstr ""
 
-#: mod/admin.php:1571
+#: mod/admin.php:1602
 msgid "Additional Info"
 msgstr ""
 
-#: mod/admin.php:1571
+#: mod/admin.php:1602
 #, php-format
 msgid ""
 "For public servers: you can add additional information here that will be "
 "listed at %s/servers."
 msgstr ""
 
-#: mod/admin.php:1572
+#: mod/admin.php:1603
 msgid "System language"
 msgstr ""
 
-#: mod/admin.php:1573
+#: mod/admin.php:1604
 msgid "System theme"
 msgstr ""
 
-#: mod/admin.php:1573
+#: mod/admin.php:1604
 msgid ""
 "Default system theme - may be over-ridden by user profiles - <a href='#' "
 "id='cnftheme'>change theme settings</a>"
 msgstr ""
 
-#: mod/admin.php:1574
+#: mod/admin.php:1605
 msgid "Mobile system theme"
 msgstr ""
 
-#: mod/admin.php:1574
+#: mod/admin.php:1605
 msgid "Theme for mobile devices"
 msgstr ""
 
-#: mod/admin.php:1575
+#: mod/admin.php:1606
 msgid "SSL link policy"
 msgstr ""
 
-#: mod/admin.php:1575
+#: mod/admin.php:1606
 msgid "Determines whether generated links should be forced to use SSL"
 msgstr ""
 
-#: mod/admin.php:1576
+#: mod/admin.php:1607
 msgid "Force SSL"
 msgstr ""
 
-#: mod/admin.php:1576
+#: mod/admin.php:1607
 msgid ""
 "Force all Non-SSL requests to SSL - Attention: on some systems it could lead "
 "to endless loops."
 msgstr ""
 
-#: mod/admin.php:1577
+#: mod/admin.php:1608
 msgid "Hide help entry from navigation menu"
 msgstr ""
 
-#: mod/admin.php:1577
+#: mod/admin.php:1608
 msgid ""
 "Hides the menu entry for the Help pages from the navigation menu. You can "
 "still access it calling /help directly."
 msgstr ""
 
-#: mod/admin.php:1578
+#: mod/admin.php:1609
 msgid "Single user instance"
 msgstr ""
 
-#: mod/admin.php:1578
+#: mod/admin.php:1609
 msgid "Make this instance multi-user or single-user for the named user"
 msgstr ""
 
-#: mod/admin.php:1580
+#: mod/admin.php:1611
 msgid "File storage backend"
 msgstr ""
 
-#: mod/admin.php:1580
-msgid "Backend used to store uploaded files data"
+#: mod/admin.php:1611
+msgid ""
+"The backend used to store uploaded data. If you change the storage backend, "
+"you can manually move the existing files. If you do not do so, the files "
+"uploaded before the change will still be available at the old backend. "
+"Please see <a href=\"/help/Settings#1_2_3_1\">the settings documentation</a> "
+"for more information about the choices and the moving procedure."
 msgstr ""
 
-#: mod/admin.php:1582
+#: mod/admin.php:1613
 msgid "Maximum image size"
 msgstr ""
 
-#: mod/admin.php:1582
+#: mod/admin.php:1613
 msgid ""
 "Maximum size in bytes of uploaded images. Default is 0, which means no "
 "limits."
 msgstr ""
 
-#: mod/admin.php:1583
+#: mod/admin.php:1614
 msgid "Maximum image length"
 msgstr ""
 
-#: mod/admin.php:1583
+#: mod/admin.php:1614
 msgid ""
 "Maximum length in pixels of the longest side of uploaded images. Default is "
 "-1, which means no limits."
 msgstr ""
 
-#: mod/admin.php:1584
+#: mod/admin.php:1615
 msgid "JPEG image quality"
 msgstr ""
 
-#: mod/admin.php:1584
+#: mod/admin.php:1615
 msgid ""
 "Uploaded JPEGS will be saved at this quality setting [0-100]. Default is "
 "100, which is full quality."
 msgstr ""
 
-#: mod/admin.php:1586
+#: mod/admin.php:1617
 msgid "Register policy"
 msgstr ""
 
-#: mod/admin.php:1587
+#: mod/admin.php:1618
 msgid "Maximum Daily Registrations"
 msgstr ""
 
-#: mod/admin.php:1587
+#: mod/admin.php:1618
 msgid ""
 "If registration is permitted above, this sets the maximum number of new user "
 "registrations to accept per day.  If register is set to closed, this setting "
 "has no effect."
 msgstr ""
 
-#: mod/admin.php:1588
+#: mod/admin.php:1619
 msgid "Register text"
 msgstr ""
 
-#: mod/admin.php:1588
+#: mod/admin.php:1619
 msgid ""
 "Will be displayed prominently on the registration page. You can use BBCode "
 "here."
 msgstr ""
 
-#: mod/admin.php:1589
+#: mod/admin.php:1620
 msgid "Forbidden Nicknames"
 msgstr ""
 
-#: mod/admin.php:1589
+#: mod/admin.php:1620
 msgid ""
 "Comma separated list of nicknames that are forbidden from registration. "
 "Preset is a list of role names according RFC 2142."
 msgstr ""
 
-#: mod/admin.php:1590
+#: mod/admin.php:1621
 msgid "Accounts abandoned after x days"
 msgstr ""
 
-#: mod/admin.php:1590
+#: mod/admin.php:1621
 msgid ""
 "Will not waste system resources polling external sites for abandonded "
 "accounts. Enter 0 for no time limit."
 msgstr ""
 
-#: mod/admin.php:1591
+#: mod/admin.php:1622
 msgid "Allowed friend domains"
 msgstr ""
 
-#: mod/admin.php:1591
+#: mod/admin.php:1622
 msgid ""
 "Comma separated list of domains which are allowed to establish friendships "
 "with this site. Wildcards are accepted. Empty to allow any domains"
 msgstr ""
 
-#: mod/admin.php:1592
+#: mod/admin.php:1623
 msgid "Allowed email domains"
 msgstr ""
 
-#: mod/admin.php:1592
+#: mod/admin.php:1623
 msgid ""
 "Comma separated list of domains which are allowed in email addresses for "
 "registrations to this site. Wildcards are accepted. Empty to allow any "
 "domains"
 msgstr ""
 
-#: mod/admin.php:1593
+#: mod/admin.php:1624
 msgid "No OEmbed rich content"
 msgstr ""
 
-#: mod/admin.php:1593
+#: mod/admin.php:1624
 msgid ""
 "Don't show the rich content (e.g. embedded PDF), except from the domains "
 "listed below."
 msgstr ""
 
-#: mod/admin.php:1594
+#: mod/admin.php:1625
 msgid "Allowed OEmbed domains"
 msgstr ""
 
-#: mod/admin.php:1594
+#: mod/admin.php:1625
 msgid ""
 "Comma separated list of domains which oembed content is allowed to be "
 "displayed. Wildcards are accepted."
 msgstr ""
 
-#: mod/admin.php:1595
+#: mod/admin.php:1626
 msgid "Block public"
 msgstr ""
 
-#: mod/admin.php:1595
+#: mod/admin.php:1626
 msgid ""
 "Check to block public access to all otherwise public personal pages on this "
 "site unless you are currently logged in."
 msgstr ""
 
-#: mod/admin.php:1596
+#: mod/admin.php:1627
 msgid "Force publish"
 msgstr ""
 
-#: mod/admin.php:1596
+#: mod/admin.php:1627
 msgid ""
 "Check to force all profiles on this site to be listed in the site directory."
 msgstr ""
 
-#: mod/admin.php:1596
+#: mod/admin.php:1627
 msgid "Enabling this may violate privacy laws like the GDPR"
 msgstr ""
 
-#: mod/admin.php:1597
+#: mod/admin.php:1628
 msgid "Global directory URL"
 msgstr ""
 
-#: mod/admin.php:1597
+#: mod/admin.php:1628
 msgid ""
 "URL to the global directory. If this is not set, the global directory is "
 "completely unavailable to the application."
 msgstr ""
 
-#: mod/admin.php:1598
+#: mod/admin.php:1629
 msgid "Private posts by default for new users"
 msgstr ""
 
-#: mod/admin.php:1598
+#: mod/admin.php:1629
 msgid ""
 "Set default post permissions for all new members to the default privacy "
 "group rather than public."
 msgstr ""
 
-#: mod/admin.php:1599
+#: mod/admin.php:1630
 msgid "Don't include post content in email notifications"
 msgstr ""
 
-#: mod/admin.php:1599
+#: mod/admin.php:1630
 msgid ""
 "Don't include the content of a post/comment/private message/etc. in the "
 "email notifications that are sent out from this site, as a privacy measure."
 msgstr ""
 
-#: mod/admin.php:1600
+#: mod/admin.php:1631
 msgid "Disallow public access to addons listed in the apps menu."
 msgstr ""
 
-#: mod/admin.php:1600
+#: mod/admin.php:1631
 msgid ""
 "Checking this box will restrict addons listed in the apps menu to members "
 "only."
 msgstr ""
 
-#: mod/admin.php:1601
+#: mod/admin.php:1632
 msgid "Don't embed private images in posts"
 msgstr ""
 
-#: mod/admin.php:1601
+#: mod/admin.php:1632
 msgid ""
 "Don't replace locally-hosted private photos in posts with an embedded copy "
 "of the image. This means that contacts who receive posts containing private "
 "photos will have to authenticate and load each image, which may take a while."
 msgstr ""
 
-#: mod/admin.php:1602
+#: mod/admin.php:1633
 msgid "Explicit Content"
 msgstr ""
 
-#: mod/admin.php:1602
+#: mod/admin.php:1633
 msgid ""
 "Set this to announce that your node is used mostly for explicit content that "
 "might not be suited for minors. This information will be published in the "
@@ -1879,210 +1894,210 @@ msgid ""
 "will be shown at the user registration page."
 msgstr ""
 
-#: mod/admin.php:1603
+#: mod/admin.php:1634
 msgid "Allow Users to set remote_self"
 msgstr ""
 
-#: mod/admin.php:1603
+#: mod/admin.php:1634
 msgid ""
 "With checking this, every user is allowed to mark every contact as a "
 "remote_self in the repair contact dialog. Setting this flag on a contact "
 "causes mirroring every posting of that contact in the users stream."
 msgstr ""
 
-#: mod/admin.php:1604
+#: mod/admin.php:1635
 msgid "Block multiple registrations"
 msgstr ""
 
-#: mod/admin.php:1604
+#: mod/admin.php:1635
 msgid "Disallow users to register additional accounts for use as pages."
 msgstr ""
 
-#: mod/admin.php:1605
+#: mod/admin.php:1636
 msgid "Disable OpenID"
 msgstr ""
 
-#: mod/admin.php:1605
+#: mod/admin.php:1636
 msgid "Disable OpenID support for registration and logins."
 msgstr ""
 
-#: mod/admin.php:1606
+#: mod/admin.php:1637
 msgid "No Fullname check"
 msgstr ""
 
-#: mod/admin.php:1606
+#: mod/admin.php:1637
 msgid ""
 "Allow users to register without a space between the first name and the last "
 "name in their full name."
 msgstr ""
 
-#: mod/admin.php:1607
+#: mod/admin.php:1638
 msgid "Community pages for visitors"
 msgstr ""
 
-#: mod/admin.php:1607
+#: mod/admin.php:1638
 msgid ""
 "Which community pages should be available for visitors. Local users always "
 "see both pages."
 msgstr ""
 
-#: mod/admin.php:1608
+#: mod/admin.php:1639
 msgid "Posts per user on community page"
 msgstr ""
 
-#: mod/admin.php:1608
+#: mod/admin.php:1639
 msgid ""
 "The maximum number of posts per user on the community page. (Not valid for "
 "'Global Community')"
 msgstr ""
 
-#: mod/admin.php:1609
+#: mod/admin.php:1640
 msgid "Disable OStatus support"
 msgstr ""
 
-#: mod/admin.php:1609
+#: mod/admin.php:1640
 msgid ""
 "Disable built-in OStatus (StatusNet, GNU Social etc.) compatibility. All "
 "communications in OStatus are public, so privacy warnings will be "
 "occasionally displayed."
 msgstr ""
 
-#: mod/admin.php:1610
+#: mod/admin.php:1641
 msgid "Only import OStatus/ActivityPub threads from our contacts"
 msgstr ""
 
-#: mod/admin.php:1610
+#: mod/admin.php:1641
 msgid ""
 "Normally we import every content from our OStatus and ActivityPub contacts. "
 "With this option we only store threads that are started by a contact that is "
 "known on our system."
 msgstr ""
 
-#: mod/admin.php:1611
+#: mod/admin.php:1642
 msgid "OStatus support can only be enabled if threading is enabled."
 msgstr ""
 
-#: mod/admin.php:1613
+#: mod/admin.php:1644
 msgid ""
 "Diaspora support can't be enabled because Friendica was installed into a sub "
 "directory."
 msgstr ""
 
-#: mod/admin.php:1614
+#: mod/admin.php:1645
 msgid "Enable Diaspora support"
 msgstr ""
 
-#: mod/admin.php:1614
+#: mod/admin.php:1645
 msgid "Provide built-in Diaspora network compatibility."
 msgstr ""
 
-#: mod/admin.php:1615
+#: mod/admin.php:1646
 msgid "Only allow Friendica contacts"
 msgstr ""
 
-#: mod/admin.php:1615
+#: mod/admin.php:1646
 msgid ""
 "All contacts must use Friendica protocols. All other built-in communication "
 "protocols disabled."
 msgstr ""
 
-#: mod/admin.php:1616
+#: mod/admin.php:1647
 msgid "Verify SSL"
 msgstr ""
 
-#: mod/admin.php:1616
+#: mod/admin.php:1647
 msgid ""
 "If you wish, you can turn on strict certificate checking. This will mean you "
 "cannot connect (at all) to self-signed SSL sites."
 msgstr ""
 
-#: mod/admin.php:1617
+#: mod/admin.php:1648
 msgid "Proxy user"
 msgstr ""
 
-#: mod/admin.php:1618
+#: mod/admin.php:1649
 msgid "Proxy URL"
 msgstr ""
 
-#: mod/admin.php:1619
+#: mod/admin.php:1650
 msgid "Network timeout"
 msgstr ""
 
-#: mod/admin.php:1619
+#: mod/admin.php:1650
 msgid "Value is in seconds. Set to 0 for unlimited (not recommended)."
 msgstr ""
 
-#: mod/admin.php:1620
+#: mod/admin.php:1651
 msgid "Maximum Load Average"
 msgstr ""
 
-#: mod/admin.php:1620
+#: mod/admin.php:1651
 msgid ""
 "Maximum system load before delivery and poll processes are deferred - "
 "default 50."
 msgstr ""
 
-#: mod/admin.php:1621
+#: mod/admin.php:1652
 msgid "Maximum Load Average (Frontend)"
 msgstr ""
 
-#: mod/admin.php:1621
+#: mod/admin.php:1652
 msgid "Maximum system load before the frontend quits service - default 50."
 msgstr ""
 
-#: mod/admin.php:1622
+#: mod/admin.php:1653
 msgid "Minimal Memory"
 msgstr ""
 
-#: mod/admin.php:1622
+#: mod/admin.php:1653
 msgid ""
 "Minimal free memory in MB for the worker. Needs access to /proc/meminfo - "
 "default 0 (deactivated)."
 msgstr ""
 
-#: mod/admin.php:1623
+#: mod/admin.php:1654
 msgid "Maximum table size for optimization"
 msgstr ""
 
-#: mod/admin.php:1623
+#: mod/admin.php:1654
 msgid ""
 "Maximum table size (in MB) for the automatic optimization. Enter -1 to "
 "disable it."
 msgstr ""
 
-#: mod/admin.php:1624
+#: mod/admin.php:1655
 msgid "Minimum level of fragmentation"
 msgstr ""
 
-#: mod/admin.php:1624
+#: mod/admin.php:1655
 msgid ""
 "Minimum fragmenation level to start the automatic optimization - default "
 "value is 30%."
 msgstr ""
 
-#: mod/admin.php:1626
+#: mod/admin.php:1657
 msgid "Periodical check of global contacts"
 msgstr ""
 
-#: mod/admin.php:1626
+#: mod/admin.php:1657
 msgid ""
 "If enabled, the global contacts are checked periodically for missing or "
 "outdated data and the vitality of the contacts and servers."
 msgstr ""
 
-#: mod/admin.php:1627
+#: mod/admin.php:1658
 msgid "Days between requery"
 msgstr ""
 
-#: mod/admin.php:1627
+#: mod/admin.php:1658
 msgid "Number of days after which a server is requeried for his contacts."
 msgstr ""
 
-#: mod/admin.php:1628
+#: mod/admin.php:1659
 msgid "Discover contacts from other servers"
 msgstr ""
 
-#: mod/admin.php:1628
+#: mod/admin.php:1659
 msgid ""
 "Periodically query other servers for contacts. You can choose between "
 "'users': the users on the remote system, 'Global Contacts': active contacts "
@@ -2092,32 +2107,32 @@ msgid ""
 "Global Contacts'."
 msgstr ""
 
-#: mod/admin.php:1629
+#: mod/admin.php:1660
 msgid "Timeframe for fetching global contacts"
 msgstr ""
 
-#: mod/admin.php:1629
+#: mod/admin.php:1660
 msgid ""
 "When the discovery is activated, this value defines the timeframe for the "
 "activity of the global contacts that are fetched from other servers."
 msgstr ""
 
-#: mod/admin.php:1630
+#: mod/admin.php:1661
 msgid "Search the local directory"
 msgstr ""
 
-#: mod/admin.php:1630
+#: mod/admin.php:1661
 msgid ""
 "Search the local directory instead of the global directory. When searching "
 "locally, every search will be executed on the global directory in the "
 "background. This improves the search results when the search is repeated."
 msgstr ""
 
-#: mod/admin.php:1632
+#: mod/admin.php:1663
 msgid "Publish server information"
 msgstr ""
 
-#: mod/admin.php:1632
+#: mod/admin.php:1663
 msgid ""
 "If enabled, general server and usage data will be published. The data "
 "contains the name and version of the server, number of users with public "
@@ -2125,50 +2140,50 @@ msgid ""
 "href='http://the-federation.info/'>the-federation.info</a> for details."
 msgstr ""
 
-#: mod/admin.php:1634
+#: mod/admin.php:1665
 msgid "Check upstream version"
 msgstr ""
 
-#: mod/admin.php:1634
+#: mod/admin.php:1665
 msgid ""
 "Enables checking for new Friendica versions at github. If there is a new "
 "version, you will be informed in the admin panel overview."
 msgstr ""
 
-#: mod/admin.php:1635
+#: mod/admin.php:1666
 msgid "Suppress Tags"
 msgstr ""
 
-#: mod/admin.php:1635
+#: mod/admin.php:1666
 msgid "Suppress showing a list of hashtags at the end of the posting."
 msgstr ""
 
-#: mod/admin.php:1636
+#: mod/admin.php:1667
 msgid "Clean database"
 msgstr ""
 
-#: mod/admin.php:1636
+#: mod/admin.php:1667
 msgid ""
 "Remove old remote items, orphaned database records and old content from some "
 "other helper tables."
 msgstr ""
 
-#: mod/admin.php:1637
+#: mod/admin.php:1668
 msgid "Lifespan of remote items"
 msgstr ""
 
-#: mod/admin.php:1637
+#: mod/admin.php:1668
 msgid ""
 "When the database cleanup is enabled, this defines the days after which "
 "remote items will be deleted. Own items, and marked or filed items are "
 "always kept. 0 disables this behaviour."
 msgstr ""
 
-#: mod/admin.php:1638
+#: mod/admin.php:1669
 msgid "Lifespan of unclaimed items"
 msgstr ""
 
-#: mod/admin.php:1638
+#: mod/admin.php:1669
 msgid ""
 "When the database cleanup is enabled, this defines the days after which "
 "unclaimed remote items (mostly content from the relay) will be deleted. "
@@ -2176,141 +2191,141 @@ msgid ""
 "items if set to 0."
 msgstr ""
 
-#: mod/admin.php:1639
+#: mod/admin.php:1670
 msgid "Lifespan of raw conversation data"
 msgstr ""
 
-#: mod/admin.php:1639
+#: mod/admin.php:1670
 msgid ""
 "The conversation data is used for ActivityPub and OStatus, as well as for "
 "debug purposes. It should be safe to remove it after 14 days, default is 90 "
 "days."
 msgstr ""
 
-#: mod/admin.php:1640
+#: mod/admin.php:1671
 msgid "Path to item cache"
 msgstr ""
 
-#: mod/admin.php:1640
+#: mod/admin.php:1671
 msgid "The item caches buffers generated bbcode and external images."
 msgstr ""
 
-#: mod/admin.php:1641
+#: mod/admin.php:1672
 msgid "Cache duration in seconds"
 msgstr ""
 
-#: mod/admin.php:1641
+#: mod/admin.php:1672
 msgid ""
 "How long should the cache files be hold? Default value is 86400 seconds (One "
 "day). To disable the item cache, set the value to -1."
 msgstr ""
 
-#: mod/admin.php:1642
+#: mod/admin.php:1673
 msgid "Maximum numbers of comments per post"
 msgstr ""
 
-#: mod/admin.php:1642
+#: mod/admin.php:1673
 msgid "How much comments should be shown for each post? Default value is 100."
 msgstr ""
 
-#: mod/admin.php:1643
+#: mod/admin.php:1674
 msgid "Temp path"
 msgstr ""
 
-#: mod/admin.php:1643
+#: mod/admin.php:1674
 msgid ""
 "If you have a restricted system where the webserver can't access the system "
 "temp path, enter another path here."
 msgstr ""
 
-#: mod/admin.php:1644
+#: mod/admin.php:1675
 msgid "Base path to installation"
 msgstr ""
 
-#: mod/admin.php:1644
+#: mod/admin.php:1675
 msgid ""
 "If the system cannot detect the correct path to your installation, enter the "
 "correct path here. This setting should only be set if you are using a "
 "restricted system and symbolic links to your webroot."
 msgstr ""
 
-#: mod/admin.php:1645
+#: mod/admin.php:1676
 msgid "Disable picture proxy"
 msgstr ""
 
-#: mod/admin.php:1645
+#: mod/admin.php:1676
 msgid ""
 "The picture proxy increases performance and privacy. It shouldn't be used on "
 "systems with very low bandwidth."
 msgstr ""
 
-#: mod/admin.php:1646
+#: mod/admin.php:1677
 msgid "Only search in tags"
 msgstr ""
 
-#: mod/admin.php:1646
+#: mod/admin.php:1677
 msgid "On large systems the text search can slow down the system extremely."
 msgstr ""
 
-#: mod/admin.php:1648
+#: mod/admin.php:1679
 msgid "New base url"
 msgstr ""
 
-#: mod/admin.php:1648
+#: mod/admin.php:1679
 msgid ""
 "Change base url for this server. Sends relocate message to all Friendica and "
 "Diaspora* contacts of all users."
 msgstr ""
 
-#: mod/admin.php:1650
+#: mod/admin.php:1681
 msgid "RINO Encryption"
 msgstr ""
 
-#: mod/admin.php:1650
+#: mod/admin.php:1681
 msgid "Encryption layer between nodes."
 msgstr ""
 
-#: mod/admin.php:1650
+#: mod/admin.php:1681
 msgid "Enabled"
 msgstr ""
 
-#: mod/admin.php:1652
+#: mod/admin.php:1683
 msgid "Maximum number of parallel workers"
 msgstr ""
 
-#: mod/admin.php:1652
+#: mod/admin.php:1683
 #, php-format
 msgid ""
 "On shared hosters set this to %d. On larger systems, values of %d are great. "
 "Default value is %d."
 msgstr ""
 
-#: mod/admin.php:1653
+#: mod/admin.php:1684
 msgid "Don't use 'proc_open' with the worker"
 msgstr ""
 
-#: mod/admin.php:1653
+#: mod/admin.php:1684
 msgid ""
 "Enable this if your system doesn't allow the use of 'proc_open'. This can "
 "happen on shared hosters. If this is enabled you should increase the "
 "frequency of worker calls in your crontab."
 msgstr ""
 
-#: mod/admin.php:1654
+#: mod/admin.php:1685
 msgid "Enable fastlane"
 msgstr ""
 
-#: mod/admin.php:1654
+#: mod/admin.php:1685
 msgid ""
 "When enabed, the fastlane mechanism starts an additional worker if processes "
 "with higher priority are blocked by processes of lower priority."
 msgstr ""
 
-#: mod/admin.php:1655
+#: mod/admin.php:1686
 msgid "Enable frontend worker"
 msgstr ""
 
-#: mod/admin.php:1655
+#: mod/admin.php:1686
 #, php-format
 msgid ""
 "When enabled the Worker process is triggered when backend access is "
@@ -2320,135 +2335,135 @@ msgid ""
 "on your server."
 msgstr ""
 
-#: mod/admin.php:1657
+#: mod/admin.php:1688
 msgid "Subscribe to relay"
 msgstr ""
 
-#: mod/admin.php:1657
+#: mod/admin.php:1688
 msgid ""
 "Enables the receiving of public posts from the relay. They will be included "
 "in the search, subscribed tags and on the global community page."
 msgstr ""
 
-#: mod/admin.php:1658
+#: mod/admin.php:1689
 msgid "Relay server"
 msgstr ""
 
-#: mod/admin.php:1658
+#: mod/admin.php:1689
 msgid ""
 "Address of the relay server where public posts should be send to. For "
 "example https://relay.diasp.org"
 msgstr ""
 
-#: mod/admin.php:1659
+#: mod/admin.php:1690
 msgid "Direct relay transfer"
 msgstr ""
 
-#: mod/admin.php:1659
+#: mod/admin.php:1690
 msgid ""
 "Enables the direct transfer to other servers without using the relay servers"
 msgstr ""
 
-#: mod/admin.php:1660
+#: mod/admin.php:1691
 msgid "Relay scope"
 msgstr ""
 
-#: mod/admin.php:1660
+#: mod/admin.php:1691
 msgid ""
 "Can be 'all' or 'tags'. 'all' means that every public post should be "
 "received. 'tags' means that only posts with selected tags should be received."
 msgstr ""
 
-#: mod/admin.php:1660
+#: mod/admin.php:1691
 msgid "all"
 msgstr ""
 
-#: mod/admin.php:1660
+#: mod/admin.php:1691
 msgid "tags"
 msgstr ""
 
-#: mod/admin.php:1661
+#: mod/admin.php:1692
 msgid "Server tags"
 msgstr ""
 
-#: mod/admin.php:1661
+#: mod/admin.php:1692
 msgid "Comma separated list of tags for the 'tags' subscription."
 msgstr ""
 
-#: mod/admin.php:1662
+#: mod/admin.php:1693
 msgid "Allow user tags"
 msgstr ""
 
-#: mod/admin.php:1662
+#: mod/admin.php:1693
 msgid ""
 "If enabled, the tags from the saved searches will used for the 'tags' "
 "subscription in addition to the 'relay_server_tags'."
 msgstr ""
 
-#: mod/admin.php:1665
+#: mod/admin.php:1696
 msgid "Start Relocation"
 msgstr ""
 
-#: mod/admin.php:1691
+#: mod/admin.php:1723
 msgid "Update has been marked successful"
 msgstr ""
 
-#: mod/admin.php:1698
+#: mod/admin.php:1730
 #, php-format
 msgid "Database structure update %s was successfully applied."
 msgstr ""
 
-#: mod/admin.php:1702
+#: mod/admin.php:1734
 #, php-format
 msgid "Executing of database structure update %s failed with error: %s"
 msgstr ""
 
-#: mod/admin.php:1718
+#: mod/admin.php:1750
 #, php-format
 msgid "Executing %s failed with error: %s"
 msgstr ""
 
-#: mod/admin.php:1720
+#: mod/admin.php:1752
 #, php-format
 msgid "Update %s was successfully applied."
 msgstr ""
 
-#: mod/admin.php:1723
+#: mod/admin.php:1755
 #, php-format
 msgid "Update %s did not return a status. Unknown if it succeeded."
 msgstr ""
 
-#: mod/admin.php:1726
+#: mod/admin.php:1758
 #, php-format
 msgid "There was no additional update function %s that needed to be called."
 msgstr ""
 
-#: mod/admin.php:1749
+#: mod/admin.php:1781
 msgid "No failed updates."
 msgstr ""
 
-#: mod/admin.php:1750
+#: mod/admin.php:1782
 msgid "Check database structure"
 msgstr ""
 
-#: mod/admin.php:1755
+#: mod/admin.php:1787
 msgid "Failed Updates"
 msgstr ""
 
-#: mod/admin.php:1756
+#: mod/admin.php:1788
 msgid ""
 "This does not include updates prior to 1139, which did not return a status."
 msgstr ""
 
-#: mod/admin.php:1757
+#: mod/admin.php:1789
 msgid "Mark success (if update was manually applied)"
 msgstr ""
 
-#: mod/admin.php:1758
+#: mod/admin.php:1790
 msgid "Attempt to execute this update step automatically"
 msgstr ""
 
-#: mod/admin.php:1797
+#: mod/admin.php:1830
 #, php-format
 msgid ""
 "\n"
@@ -2456,7 +2471,7 @@ msgid ""
 "\t\t\t\tthe administrator of %2$s has set up an account for you."
 msgstr ""
 
-#: mod/admin.php:1800
+#: mod/admin.php:1833
 #, php-format
 msgid ""
 "\n"
@@ -2495,221 +2510,225 @@ msgid ""
 "\t\t\tThank you and welcome to %4$s."
 msgstr ""
 
-#: mod/admin.php:1837 src/Model/User.php:802
+#: mod/admin.php:1870 src/Model/User.php:858
 #, php-format
 msgid "Registration details for %s"
 msgstr ""
 
-#: mod/admin.php:1847
+#: mod/admin.php:1880
 #, php-format
 msgid "%s user blocked/unblocked"
 msgid_plural "%s users blocked/unblocked"
 msgstr[0] ""
 msgstr[1] ""
 
-#: mod/admin.php:1854 mod/admin.php:1907
+#: mod/admin.php:1887 mod/admin.php:1941
 msgid "You can't remove yourself"
 msgstr ""
 
-#: mod/admin.php:1857
+#: mod/admin.php:1890
 #, php-format
 msgid "%s user deleted"
 msgid_plural "%s users deleted"
 msgstr[0] ""
 msgstr[1] ""
 
-#: mod/admin.php:1905
+#: mod/admin.php:1939
 #, php-format
 msgid "User '%s' deleted"
 msgstr ""
 
-#: mod/admin.php:1916
+#: mod/admin.php:1950
 #, php-format
 msgid "User '%s' unblocked"
 msgstr ""
 
-#: mod/admin.php:1916
+#: mod/admin.php:1950
 #, php-format
 msgid "User '%s' blocked"
 msgstr ""
 
-#: mod/admin.php:1964 mod/settings.php:1052
+#: mod/admin.php:1998 mod/settings.php:1049
 msgid "Normal Account Page"
 msgstr ""
 
-#: mod/admin.php:1965 mod/settings.php:1056
+#: mod/admin.php:1999 mod/settings.php:1053
 msgid "Soapbox Page"
 msgstr ""
 
-#: mod/admin.php:1966 mod/settings.php:1060
+#: mod/admin.php:2000 mod/settings.php:1057
 msgid "Public Forum"
 msgstr ""
 
-#: mod/admin.php:1967 mod/settings.php:1064
+#: mod/admin.php:2001 mod/settings.php:1061
 msgid "Automatic Friend Page"
 msgstr ""
 
-#: mod/admin.php:1968
+#: mod/admin.php:2002
 msgid "Private Forum"
 msgstr ""
 
-#: mod/admin.php:1971 mod/settings.php:1036
+#: mod/admin.php:2005 mod/settings.php:1033
 msgid "Personal Page"
 msgstr ""
 
-#: mod/admin.php:1972 mod/settings.php:1040
+#: mod/admin.php:2006 mod/settings.php:1037
 msgid "Organisation Page"
 msgstr ""
 
-#: mod/admin.php:1973 mod/settings.php:1044
+#: mod/admin.php:2007 mod/settings.php:1041
 msgid "News Page"
 msgstr ""
 
-#: mod/admin.php:1974 mod/settings.php:1048
+#: mod/admin.php:2008 mod/settings.php:1045
 msgid "Community Forum"
 msgstr ""
 
-#: mod/admin.php:2020 mod/admin.php:2031 mod/admin.php:2045 mod/admin.php:2063
-#: src/Content/ContactSelector.php:83
+#: mod/admin.php:2009
+msgid "Relay"
+msgstr ""
+
+#: mod/admin.php:2055 mod/admin.php:2066 mod/admin.php:2080 mod/admin.php:2098
+#: src/Content/ContactSelector.php:86
 msgid "Email"
 msgstr ""
 
-#: mod/admin.php:2020 mod/admin.php:2045
+#: mod/admin.php:2055 mod/admin.php:2080
 msgid "Register date"
 msgstr ""
 
-#: mod/admin.php:2020 mod/admin.php:2045
+#: mod/admin.php:2055 mod/admin.php:2080
 msgid "Last login"
 msgstr ""
 
-#: mod/admin.php:2020 mod/admin.php:2045
+#: mod/admin.php:2055 mod/admin.php:2080
 msgid "Last item"
 msgstr ""
 
-#: mod/admin.php:2020
+#: mod/admin.php:2055
 msgid "Type"
 msgstr ""
 
-#: mod/admin.php:2027
+#: mod/admin.php:2062
 msgid "Add User"
 msgstr ""
 
-#: mod/admin.php:2029
+#: mod/admin.php:2064
 msgid "User registrations waiting for confirm"
 msgstr ""
 
-#: mod/admin.php:2030
+#: mod/admin.php:2065
 msgid "User waiting for permanent deletion"
 msgstr ""
 
-#: mod/admin.php:2031
+#: mod/admin.php:2066
 msgid "Request date"
 msgstr ""
 
-#: mod/admin.php:2032
+#: mod/admin.php:2067
 msgid "No registrations."
 msgstr ""
 
-#: mod/admin.php:2033
+#: mod/admin.php:2068
 msgid "Note from the user"
 msgstr ""
 
-#: mod/admin.php:2034 mod/notifications.php:181 mod/notifications.php:267
+#: mod/admin.php:2069 mod/notifications.php:183 mod/notifications.php:269
 msgid "Approve"
 msgstr ""
 
-#: mod/admin.php:2035
+#: mod/admin.php:2070
 msgid "Deny"
 msgstr ""
 
-#: mod/admin.php:2038
+#: mod/admin.php:2073
 msgid "User blocked"
 msgstr ""
 
-#: mod/admin.php:2040
+#: mod/admin.php:2075
 msgid "Site admin"
 msgstr ""
 
-#: mod/admin.php:2041
+#: mod/admin.php:2076
 msgid "Account expired"
 msgstr ""
 
-#: mod/admin.php:2044
+#: mod/admin.php:2079
 msgid "New User"
 msgstr ""
 
-#: mod/admin.php:2045
+#: mod/admin.php:2080
 msgid "Permanent deletion"
 msgstr ""
 
-#: mod/admin.php:2050
+#: mod/admin.php:2085
 msgid ""
 "Selected users will be deleted!\\n\\nEverything these users had posted on "
 "this site will be permanently deleted!\\n\\nAre you sure?"
 msgstr ""
 
-#: mod/admin.php:2051
+#: mod/admin.php:2086
 msgid ""
 "The user {0} will be deleted!\\n\\nEverything this user has posted on this "
 "site will be permanently deleted!\\n\\nAre you sure?"
 msgstr ""
 
-#: mod/admin.php:2061
+#: mod/admin.php:2096
 msgid "Name of the new user."
 msgstr ""
 
-#: mod/admin.php:2062
+#: mod/admin.php:2097
 msgid "Nickname"
 msgstr ""
 
-#: mod/admin.php:2062
+#: mod/admin.php:2097
 msgid "Nickname of the new user."
 msgstr ""
 
-#: mod/admin.php:2063
+#: mod/admin.php:2098
 msgid "Email address of the new user."
 msgstr ""
 
-#: mod/admin.php:2104
+#: mod/admin.php:2140
 #, php-format
 msgid "Addon %s disabled."
 msgstr ""
 
-#: mod/admin.php:2107
+#: mod/admin.php:2143
 #, php-format
 msgid "Addon %s enabled."
 msgstr ""
 
-#: mod/admin.php:2118 mod/admin.php:2367
+#: mod/admin.php:2154 mod/admin.php:2404
 msgid "Disable"
 msgstr ""
 
-#: mod/admin.php:2121 mod/admin.php:2370
+#: mod/admin.php:2157 mod/admin.php:2407
 msgid "Enable"
 msgstr ""
 
-#: mod/admin.php:2143 mod/admin.php:2399
+#: mod/admin.php:2179 mod/admin.php:2436
 msgid "Toggle"
 msgstr ""
 
-#: mod/admin.php:2144 mod/admin.php:2400 mod/newmember.php:20
-#: mod/settings.php:136 src/Content/Nav.php:256 view/theme/frio/theme.php:270
+#: mod/admin.php:2180 mod/admin.php:2437 mod/newmember.php:20
+#: mod/settings.php:136 src/Content/Nav.php:263 view/theme/frio/theme.php:272
 msgid "Settings"
 msgstr ""
 
-#: mod/admin.php:2151 mod/admin.php:2408
+#: mod/admin.php:2187 mod/admin.php:2445
 msgid "Author: "
 msgstr ""
 
-#: mod/admin.php:2152 mod/admin.php:2409
+#: mod/admin.php:2188 mod/admin.php:2446
 msgid "Maintainer: "
 msgstr ""
 
-#: mod/admin.php:2204
+#: mod/admin.php:2240
 msgid "Reload active addons"
 msgstr ""
 
-#: mod/admin.php:2209
+#: mod/admin.php:2245
 #, php-format
 msgid ""
 "There are currently no addons available on your node. You can find the "
@@ -2717,70 +2736,70 @@ msgid ""
 "the open addon registry at %2$s"
 msgstr ""
 
-#: mod/admin.php:2329
+#: mod/admin.php:2366
 msgid "No themes found."
 msgstr ""
 
-#: mod/admin.php:2390
+#: mod/admin.php:2427
 msgid "Screenshot"
 msgstr ""
 
-#: mod/admin.php:2444
+#: mod/admin.php:2481
 msgid "Reload active themes"
 msgstr ""
 
-#: mod/admin.php:2449
+#: mod/admin.php:2486
 #, php-format
 msgid "No themes found on the system. They should be placed in %1$s"
 msgstr ""
 
-#: mod/admin.php:2450
+#: mod/admin.php:2487
 msgid "[Experimental]"
 msgstr ""
 
-#: mod/admin.php:2451
+#: mod/admin.php:2488
 msgid "[Unsupported]"
 msgstr ""
 
-#: mod/admin.php:2475
+#: mod/admin.php:2513
 msgid "Log settings updated."
 msgstr ""
 
-#: mod/admin.php:2508
+#: mod/admin.php:2546
 msgid "PHP log currently enabled."
 msgstr ""
 
-#: mod/admin.php:2510
+#: mod/admin.php:2548
 msgid "PHP log currently disabled."
 msgstr ""
 
-#: mod/admin.php:2519
+#: mod/admin.php:2557
 msgid "Clear"
 msgstr ""
 
-#: mod/admin.php:2523
+#: mod/admin.php:2561
 msgid "Enable Debugging"
 msgstr ""
 
-#: mod/admin.php:2524
+#: mod/admin.php:2562
 msgid "Log file"
 msgstr ""
 
-#: mod/admin.php:2524
+#: mod/admin.php:2562
 msgid ""
 "Must be writable by web server. Relative to your Friendica top-level "
 "directory."
 msgstr ""
 
-#: mod/admin.php:2525
+#: mod/admin.php:2563
 msgid "Log level"
 msgstr ""
 
-#: mod/admin.php:2527
+#: mod/admin.php:2565
 msgid "PHP logging"
 msgstr ""
 
-#: mod/admin.php:2528
+#: mod/admin.php:2566
 msgid ""
 "To temporarily enable logging of PHP errors and warnings you can prepend the "
 "following to the index.php file of your installation. The filename set in "
@@ -2789,34 +2808,34 @@ msgid ""
 "'display_errors' is to enable these options, set to '0' to disable them."
 msgstr ""
 
-#: mod/admin.php:2559
+#: mod/admin.php:2598
 #, php-format
 msgid ""
 "Error trying to open <strong>%1$s</strong> log file.\\r\\n<br/>Check to see "
 "if file %1$s exist and is readable."
 msgstr ""
 
-#: mod/admin.php:2563
+#: mod/admin.php:2602
 #, php-format
 msgid ""
 "Couldn't open <strong>%1$s</strong> log file.\\r\\n<br/>Check to see if file "
 "%1$s is readable."
 msgstr ""
 
-#: mod/admin.php:2654 mod/admin.php:2655 mod/settings.php:766
+#: mod/admin.php:2695 mod/admin.php:2696 mod/settings.php:763
 msgid "Off"
 msgstr ""
 
-#: mod/admin.php:2654 mod/admin.php:2655 mod/settings.php:766
+#: mod/admin.php:2695 mod/admin.php:2696 mod/settings.php:763
 msgid "On"
 msgstr ""
 
-#: mod/admin.php:2655
+#: mod/admin.php:2696
 #, php-format
 msgid "Lock feature %s"
 msgstr ""
 
-#: mod/admin.php:2663
+#: mod/admin.php:2704
 msgid "Manage Additional Features"
 msgstr ""
 
@@ -2824,40 +2843,40 @@ msgstr ""
 msgid "No friends to display."
 msgstr ""
 
-#: mod/allfriends.php:91 mod/dirfind.php:219 mod/match.php:99
-#: mod/suggest.php:105 src/Content/Widget.php:39 src/Model/Profile.php:307
+#: mod/allfriends.php:89 mod/dirfind.php:217 mod/match.php:102
+#: mod/suggest.php:106 src/Content/Widget.php:39 src/Model/Profile.php:313
 msgid "Connect"
 msgstr ""
 
-#: mod/api.php:87 mod/api.php:109
+#: mod/api.php:84 mod/api.php:106
 msgid "Authorize application connection"
 msgstr ""
 
-#: mod/api.php:88
+#: mod/api.php:85
 msgid "Return to your app and insert this Securty Code:"
 msgstr ""
 
-#: mod/api.php:97
+#: mod/api.php:94
 msgid "Please login to continue."
 msgstr ""
 
-#: mod/api.php:111
+#: mod/api.php:108
 msgid ""
 "Do you want to authorize this application to access your posts and contacts, "
 "and/or create new posts for you?"
 msgstr ""
 
-#: mod/api.php:113 mod/dfrn_request.php:640 mod/follow.php:151
-#: mod/profiles.php:542 mod/profiles.php:546 mod/profiles.php:567
-#: mod/register.php:233 mod/settings.php:1088 mod/settings.php:1094
-#: mod/settings.php:1101 mod/settings.php:1105 mod/settings.php:1109
-#: mod/settings.php:1113 mod/settings.php:1117 mod/settings.php:1121
-#: mod/settings.php:1141 mod/settings.php:1142 mod/settings.php:1143
-#: mod/settings.php:1144 mod/settings.php:1145
+#: mod/api.php:110 mod/dfrn_request.php:640 mod/follow.php:150
+#: mod/profiles.php:526 mod/profiles.php:530 mod/profiles.php:551
+#: mod/settings.php:1085 mod/settings.php:1091 mod/settings.php:1098
+#: mod/settings.php:1102 mod/settings.php:1106 mod/settings.php:1110
+#: mod/settings.php:1114 mod/settings.php:1118 mod/settings.php:1138
+#: mod/settings.php:1139 mod/settings.php:1140 mod/settings.php:1141
+#: mod/settings.php:1142 src/Module/Register.php:98
 msgid "No"
 msgstr ""
 
-#: mod/apps.php:15 src/App.php:1692
+#: mod/apps.php:15 src/App.php:1351
 msgid "You must be logged in to use addons. "
 msgstr ""
 
@@ -2905,67 +2924,75 @@ msgstr ""
 msgid "BBCode::toMarkdown =>  Markdown::convert => HTML::toBBCode"
 msgstr ""
 
-#: mod/babel.php:79
+#: mod/babel.php:83
+msgid "Item Body"
+msgstr ""
+
+#: mod/babel.php:87
+msgid "Item Tags"
+msgstr ""
+
+#: mod/babel.php:94
 msgid "Source input (Diaspora format)"
 msgstr ""
 
-#: mod/babel.php:85
+#: mod/babel.php:100
 msgid "Markdown::convert (raw HTML)"
 msgstr ""
 
-#: mod/babel.php:90
+#: mod/babel.php:105
 msgid "Markdown::convert"
 msgstr ""
 
-#: mod/babel.php:96
+#: mod/babel.php:111
 msgid "Markdown::toBBCode"
 msgstr ""
 
-#: mod/babel.php:103
+#: mod/babel.php:118
 msgid "Raw HTML input"
 msgstr ""
 
-#: mod/babel.php:108
+#: mod/babel.php:123
 msgid "HTML Input"
 msgstr ""
 
-#: mod/babel.php:114
+#: mod/babel.php:129
 msgid "HTML::toBBCode"
 msgstr ""
 
-#: mod/babel.php:120
+#: mod/babel.php:135
 msgid "HTML::toBBCode => BBCode::convert"
 msgstr ""
 
-#: mod/babel.php:125
+#: mod/babel.php:140
 msgid "HTML::toBBCode => BBCode::convert (raw HTML)"
 msgstr ""
 
-#: mod/babel.php:131
+#: mod/babel.php:146
 msgid "HTML::toMarkdown"
 msgstr ""
 
-#: mod/babel.php:137
+#: mod/babel.php:152
 msgid "HTML::toPlaintext"
 msgstr ""
 
-#: mod/babel.php:145
+#: mod/babel.php:160
 msgid "Source text"
 msgstr ""
 
-#: mod/babel.php:146
+#: mod/babel.php:161
 msgid "BBCode"
 msgstr ""
 
-#: mod/babel.php:147
+#: mod/babel.php:162
 msgid "Markdown"
 msgstr ""
 
-#: mod/babel.php:148
+#: mod/babel.php:163
 msgid "HTML"
 msgstr ""
 
-#: mod/bookmarklet.php:22 src/Content/Nav.php:163 src/Module/Login.php:319
+#: mod/bookmarklet.php:22 src/Content/Nav.php:170 src/Module/Login.php:322
 msgid "Login"
 msgstr ""
 
@@ -2977,74 +3004,74 @@ msgstr ""
 msgid "The post was created"
 msgstr ""
 
-#: mod/cal.php:35 mod/cal.php:39 mod/community.php:38 mod/follow.php:21
+#: mod/cal.php:34 mod/cal.php:38 mod/community.php:39 mod/follow.php:20
 #: mod/viewcontacts.php:23 mod/viewcontacts.php:27 mod/viewsrc.php:13
 msgid "Access denied."
 msgstr ""
 
-#: mod/cal.php:47 mod/dfrn_poll.php:490 mod/help.php:67 mod/viewcontacts.php:34
-#: src/App.php:1743
+#: mod/cal.php:46 mod/dfrn_poll.php:486 mod/help.php:68 mod/viewcontacts.php:34
+#: src/App.php:1402
 msgid "Page not found."
 msgstr ""
 
-#: mod/cal.php:142 mod/display.php:313 mod/profile.php:155
+#: mod/cal.php:141 mod/display.php:309 src/Module/Profile.php:168
 msgid "Access to this profile has been restricted."
 msgstr ""
 
-#: mod/cal.php:274 mod/events.php:399 src/Content/Nav.php:153
-#: src/Content/Nav.php:219 src/Model/Profile.php:942 src/Model/Profile.php:953
-#: view/theme/frio/theme.php:264 view/theme/frio/theme.php:268
+#: mod/cal.php:273 mod/events.php:384 src/Content/Nav.php:160
+#: src/Content/Nav.php:226 src/Model/Profile.php:937 src/Model/Profile.php:948
+#: view/theme/frio/theme.php:266 view/theme/frio/theme.php:270
 msgid "Events"
 msgstr ""
 
-#: mod/cal.php:275 mod/events.php:400
+#: mod/cal.php:274 mod/events.php:385
 msgid "View"
 msgstr ""
 
-#: mod/cal.php:276 mod/events.php:402
+#: mod/cal.php:275 mod/events.php:387
 msgid "Previous"
 msgstr ""
 
-#: mod/cal.php:277 mod/events.php:403 src/Module/Install.php:135
+#: mod/cal.php:276 mod/events.php:388 src/Module/Install.php:133
 msgid "Next"
 msgstr ""
 
-#: mod/cal.php:280 mod/events.php:408 src/Model/Event.php:426
+#: mod/cal.php:279 mod/events.php:393 src/Model/Event.php:429
 msgid "today"
 msgstr ""
 
-#: mod/cal.php:281 mod/events.php:409 src/Model/Event.php:427
-#: src/Util/Temporal.php:309
+#: mod/cal.php:280 mod/events.php:394 src/Model/Event.php:430
+#: src/Util/Temporal.php:314
 msgid "month"
 msgstr ""
 
-#: mod/cal.php:282 mod/events.php:410 src/Model/Event.php:428
-#: src/Util/Temporal.php:310
+#: mod/cal.php:281 mod/events.php:395 src/Model/Event.php:431
+#: src/Util/Temporal.php:315
 msgid "week"
 msgstr ""
 
-#: mod/cal.php:283 mod/events.php:411 src/Model/Event.php:429
-#: src/Util/Temporal.php:311
+#: mod/cal.php:282 mod/events.php:396 src/Model/Event.php:432
+#: src/Util/Temporal.php:316
 msgid "day"
 msgstr ""
 
-#: mod/cal.php:284 mod/events.php:412
+#: mod/cal.php:283 mod/events.php:397
 msgid "list"
 msgstr ""
 
-#: mod/cal.php:297 src/Core/Console/NewPassword.php:67 src/Model/User.php:269
+#: mod/cal.php:296 src/Core/Console/NewPassword.php:67 src/Model/User.php:323
 msgid "User not found"
 msgstr ""
 
-#: mod/cal.php:313
+#: mod/cal.php:312
 msgid "This calendar format is not supported"
 msgstr ""
 
-#: mod/cal.php:315
+#: mod/cal.php:314
 msgid "No exportable data found"
 msgstr ""
 
-#: mod/cal.php:332
+#: mod/cal.php:331
 msgid "calendar"
 msgstr ""
 
@@ -3052,46 +3079,46 @@ msgstr ""
 msgid "No contacts in common."
 msgstr ""
 
-#: mod/common.php:141 src/Module/Contact.php:895
+#: mod/common.php:141 src/Module/Contact.php:892
 msgid "Common Friends"
 msgstr ""
 
-#: mod/community.php:31 mod/dfrn_request.php:597 mod/directory.php:43
-#: mod/display.php:213 mod/photos.php:902 mod/probe.php:13 mod/search.php:97
-#: mod/search.php:103 mod/videos.php:148 mod/viewcontacts.php:46
+#: mod/community.php:32 mod/dfrn_request.php:597 mod/directory.php:43
+#: mod/display.php:209 mod/photos.php:903 mod/probe.php:13 mod/search.php:96
+#: mod/search.php:102 mod/videos.php:147 mod/viewcontacts.php:46
 #: mod/webfinger.php:16
 msgid "Public access denied."
 msgstr ""
 
-#: mod/community.php:74
+#: mod/community.php:75
 msgid "Community option not available."
 msgstr ""
 
-#: mod/community.php:91
+#: mod/community.php:92
 msgid "Not available."
 msgstr ""
 
-#: mod/community.php:101
+#: mod/community.php:102
 msgid "Local Community"
 msgstr ""
 
-#: mod/community.php:104
+#: mod/community.php:105
 msgid "Posts from local users on this server"
 msgstr ""
 
-#: mod/community.php:112
+#: mod/community.php:113
 msgid "Global Community"
 msgstr ""
 
-#: mod/community.php:115
+#: mod/community.php:116
 msgid "Posts from users of the whole federated network"
 msgstr ""
 
-#: mod/community.php:161 mod/search.php:230
+#: mod/community.php:162 mod/search.php:229
 msgid "No results."
 msgstr ""
 
-#: mod/community.php:205
+#: mod/community.php:206
 msgid ""
 "This community stream shows all public posts received by this node. They may "
 "not reflect the opinions of this node’s users."
@@ -3116,8 +3143,8 @@ msgstr ""
 msgid "Contact update failed."
 msgstr ""
 
-#: mod/crepair.php:113 mod/dfrn_confirm.php:127 mod/fsuggest.php:31
-#: mod/fsuggest.php:97 mod/redir.php:32 mod/redir.php:138
+#: mod/crepair.php:113 mod/dfrn_confirm.php:127 mod/fsuggest.php:28
+#: mod/fsuggest.php:89 mod/redir.php:31 mod/redir.php:137
 msgid "Contact not found."
 msgstr ""
 
@@ -3153,13 +3180,13 @@ msgstr ""
 msgid "Refetch contact data"
 msgstr ""
 
-#: mod/crepair.php:151 mod/events.php:568 mod/fsuggest.php:115
+#: mod/crepair.php:151 mod/events.php:553 mod/fsuggest.php:106
 #: mod/invite.php:154 mod/localtime.php:56 mod/manage.php:182
-#: mod/message.php:263 mod/message.php:443 mod/photos.php:1048
-#: mod/photos.php:1136 mod/photos.php:1411 mod/photos.php:1456
-#: mod/photos.php:1495 mod/photos.php:1555 mod/poke.php:188
-#: mod/profiles.php:578 src/Module/Contact.php:596 src/Module/Install.php:189
-#: src/Module/Install.php:224 src/Object/Post.php:819
+#: mod/message.php:261 mod/message.php:441 mod/photos.php:1049
+#: mod/photos.php:1137 mod/photos.php:1412 mod/photos.php:1457
+#: mod/photos.php:1496 mod/photos.php:1556 mod/poke.php:188
+#: mod/profiles.php:562 src/Module/Contact.php:594 src/Module/Install.php:187
+#: src/Module/Install.php:222 src/Object/Post.php:867
 #: view/theme/duepuntozero/config.php:72 view/theme/frio/config.php:119
 #: view/theme/quattro/config.php:74 view/theme/vier/config.php:120
 msgid "Submit"
@@ -3211,70 +3238,70 @@ msgstr ""
 msgid "New photo from this URL"
 msgstr ""
 
-#: mod/delegate.php:43
+#: mod/delegate.php:42
 msgid "Parent user not found."
 msgstr ""
 
-#: mod/delegate.php:150
+#: mod/delegate.php:149
 msgid "No parent user"
 msgstr ""
 
-#: mod/delegate.php:165
+#: mod/delegate.php:164
 msgid "Parent Password:"
 msgstr ""
 
-#: mod/delegate.php:165
+#: mod/delegate.php:164
 msgid ""
 "Please enter the password of the parent account to legitimize your request."
 msgstr ""
 
-#: mod/delegate.php:172
+#: mod/delegate.php:171
 msgid "Parent User"
 msgstr ""
 
-#: mod/delegate.php:175
+#: mod/delegate.php:174
 msgid ""
 "Parent users have total control about this account, including the account "
 "settings. Please double check whom you give this access."
 msgstr ""
 
-#: mod/delegate.php:177 src/Content/Nav.php:254
+#: mod/delegate.php:176 src/Content/Nav.php:261
 msgid "Delegate Page Management"
 msgstr ""
 
-#: mod/delegate.php:178
+#: mod/delegate.php:177
 msgid "Delegates"
 msgstr ""
 
-#: mod/delegate.php:180
+#: mod/delegate.php:179
 msgid ""
 "Delegates are able to manage all aspects of this account/page except for "
 "basic account settings. Please do not delegate your personal account to "
 "anybody that you do not trust completely."
 msgstr ""
 
-#: mod/delegate.php:181
+#: mod/delegate.php:180
 msgid "Existing Page Delegates"
 msgstr ""
 
-#: mod/delegate.php:183
+#: mod/delegate.php:182
 msgid "Potential Delegates"
 msgstr ""
 
-#: mod/delegate.php:185 mod/tagrm.php:112
+#: mod/delegate.php:184 mod/tagrm.php:114
 msgid "Remove"
 msgstr ""
 
-#: mod/delegate.php:186
+#: mod/delegate.php:185
 msgid "Add"
 msgstr ""
 
-#: mod/delegate.php:187
+#: mod/delegate.php:186
 msgid "No entries."
 msgstr ""
 
-#: mod/dfrn_confirm.php:72 mod/profiles.php:42 mod/profiles.php:152
-#: mod/profiles.php:197 mod/profiles.php:527
+#: mod/dfrn_confirm.php:72 mod/profiles.php:43 mod/profiles.php:152
+#: mod/profiles.php:196 mod/profiles.php:511
 msgid "Profile not found."
 msgstr ""
 
@@ -3348,60 +3375,60 @@ msgstr ""
 msgid "Unable to update your contact profile details on our system"
 msgstr ""
 
-#: mod/dfrn_confirm.php:612 mod/dfrn_request.php:560 src/Model/Contact.php:1976
+#: mod/dfrn_confirm.php:612 mod/dfrn_request.php:560 src/Model/Contact.php:2026
 msgid "[Name Withheld]"
 msgstr ""
 
-#: mod/dfrn_poll.php:126 mod/dfrn_poll.php:534
+#: mod/dfrn_poll.php:125 mod/dfrn_poll.php:530
 #, php-format
 msgid "%1$s welcomes %2$s"
 msgstr ""
 
-#: mod/dfrn_request.php:95
+#: mod/dfrn_request.php:98
 msgid "This introduction has already been accepted."
 msgstr ""
 
-#: mod/dfrn_request.php:113 mod/dfrn_request.php:354
+#: mod/dfrn_request.php:116 mod/dfrn_request.php:354
 msgid "Profile location is not valid or does not contain profile information."
 msgstr ""
 
-#: mod/dfrn_request.php:117 mod/dfrn_request.php:358
+#: mod/dfrn_request.php:120 mod/dfrn_request.php:358
 msgid "Warning: profile location has no identifiable owner name."
 msgstr ""
 
-#: mod/dfrn_request.php:120 mod/dfrn_request.php:361
+#: mod/dfrn_request.php:123 mod/dfrn_request.php:361
 msgid "Warning: profile location has no profile photo."
 msgstr ""
 
-#: mod/dfrn_request.php:124 mod/dfrn_request.php:365
+#: mod/dfrn_request.php:127 mod/dfrn_request.php:365
 #, php-format
 msgid "%d required parameter was not found at the given location"
 msgid_plural "%d required parameters were not found at the given location"
 msgstr[0] ""
 msgstr[1] ""
 
-#: mod/dfrn_request.php:162
+#: mod/dfrn_request.php:165
 msgid "Introduction complete."
 msgstr ""
 
-#: mod/dfrn_request.php:198
+#: mod/dfrn_request.php:201
 msgid "Unrecoverable protocol error."
 msgstr ""
 
-#: mod/dfrn_request.php:225
+#: mod/dfrn_request.php:228
 msgid "Profile unavailable."
 msgstr ""
 
-#: mod/dfrn_request.php:247
+#: mod/dfrn_request.php:249
 #, php-format
 msgid "%s has received too many connection requests today."
 msgstr ""
 
-#: mod/dfrn_request.php:248
+#: mod/dfrn_request.php:250
 msgid "Spam protection measures have been invoked."
 msgstr ""
 
-#: mod/dfrn_request.php:249
+#: mod/dfrn_request.php:251
 msgid "Friends are advised to please try again in 24 hours."
 msgstr ""
 
@@ -3422,11 +3449,11 @@ msgstr ""
 msgid "Invalid profile URL."
 msgstr ""
 
-#: mod/dfrn_request.php:340 src/Model/Contact.php:1648
+#: mod/dfrn_request.php:340 src/Model/Contact.php:1697
 msgid "Disallowed profile URL."
 msgstr ""
 
-#: mod/dfrn_request.php:413 src/Module/Contact.php:236
+#: mod/dfrn_request.php:413 src/Module/Contact.php:235
 msgid "Failed to update contact record."
 msgstr ""
 
@@ -3491,16 +3518,16 @@ msgid ""
 "testuser@gnusocial.de"
 msgstr ""
 
-#: mod/dfrn_request.php:639 mod/follow.php:150
+#: mod/dfrn_request.php:639 mod/follow.php:149
 msgid "Please answer the following:"
 msgstr ""
 
-#: mod/dfrn_request.php:640 mod/follow.php:151
+#: mod/dfrn_request.php:640 mod/follow.php:150
 #, php-format
 msgid "Does %s know you?"
 msgstr ""
 
-#: mod/dfrn_request.php:641 mod/follow.php:152
+#: mod/dfrn_request.php:641 mod/follow.php:151
 msgid "Add a personal note:"
 msgstr ""
 
@@ -3523,35 +3550,35 @@ msgid ""
 "bar."
 msgstr ""
 
-#: mod/dfrn_request.php:647 mod/follow.php:158 mod/unfollow.php:128
+#: mod/dfrn_request.php:647 mod/follow.php:157 mod/unfollow.php:128
 msgid "Your Identity Address:"
 msgstr ""
 
-#: mod/dfrn_request.php:649 mod/follow.php:66 mod/unfollow.php:131
+#: mod/dfrn_request.php:649 mod/follow.php:65 mod/unfollow.php:131
 msgid "Submit Request"
 msgstr ""
 
-#: mod/directory.php:154 mod/events.php:556 mod/notifications.php:251
-#: src/Model/Event.php:66 src/Model/Event.php:93 src/Model/Event.php:435
-#: src/Model/Event.php:926 src/Model/Profile.php:437 src/Module/Contact.php:646
+#: mod/directory.php:154 mod/events.php:541 mod/notifications.php:253
+#: src/Model/Event.php:68 src/Model/Event.php:95 src/Model/Event.php:438
+#: src/Model/Event.php:934 src/Model/Profile.php:443 src/Module/Contact.php:643
 msgid "Location:"
 msgstr ""
 
-#: mod/directory.php:159 mod/notifications.php:257 src/Model/Profile.php:440
-#: src/Model/Profile.php:763
+#: mod/directory.php:159 mod/notifications.php:259 src/Model/Profile.php:446
+#: src/Model/Profile.php:758
 msgid "Gender:"
 msgstr ""
 
-#: mod/directory.php:160 src/Model/Profile.php:441 src/Model/Profile.php:787
+#: mod/directory.php:160 src/Model/Profile.php:447 src/Model/Profile.php:782
 msgid "Status:"
 msgstr ""
 
-#: mod/directory.php:161 src/Model/Profile.php:442 src/Model/Profile.php:804
+#: mod/directory.php:161 src/Model/Profile.php:448 src/Model/Profile.php:799
 msgid "Homepage:"
 msgstr ""
 
-#: mod/directory.php:162 mod/notifications.php:253 src/Model/Profile.php:443
-#: src/Model/Profile.php:824 src/Module/Contact.php:650
+#: mod/directory.php:162 mod/notifications.php:255 src/Model/Profile.php:449
+#: src/Model/Profile.php:819 src/Module/Contact.php:647
 msgid "About:"
 msgstr ""
 
@@ -3572,7 +3599,7 @@ msgstr ""
 msgid "Site Directory"
 msgstr ""
 
-#: mod/directory.php:217 src/Content/Widget.php:65 src/Module/Contact.php:820
+#: mod/directory.php:217 src/Content/Widget.php:65 src/Module/Contact.php:817
 #: view/theme/vier/theme.php:203
 msgid "Find"
 msgstr ""
@@ -3591,7 +3618,7 @@ msgstr ""
 msgid "Forum Search - %s"
 msgstr ""
 
-#: mod/dirfind.php:261 mod/match.php:127
+#: mod/dirfind.php:259 mod/match.php:130
 msgid "No matches"
 msgstr ""
 
@@ -3603,41 +3630,41 @@ msgstr ""
 msgid "Edit post"
 msgstr ""
 
-#: mod/editpost.php:92 mod/filer.php:36 mod/notes.php:52
-#: src/Content/Text/HTML.php:962
+#: mod/editpost.php:73 mod/filer.php:36 mod/notes.php:46
+#: src/Content/Text/HTML.php:894
 msgid "Save"
 msgstr ""
 
-#: mod/editpost.php:97 mod/message.php:261 mod/message.php:442
+#: mod/editpost.php:78 mod/message.php:259 mod/message.php:440
 #: mod/wallmessage.php:140
 msgid "Insert web link"
 msgstr ""
 
-#: mod/editpost.php:98
+#: mod/editpost.php:79
 msgid "web link"
 msgstr ""
 
-#: mod/editpost.php:99
+#: mod/editpost.php:80
 msgid "Insert video link"
 msgstr ""
 
-#: mod/editpost.php:100
+#: mod/editpost.php:81
 msgid "video link"
 msgstr ""
 
-#: mod/editpost.php:101
+#: mod/editpost.php:82
 msgid "Insert audio link"
 msgstr ""
 
-#: mod/editpost.php:102
+#: mod/editpost.php:83
 msgid "audio link"
 msgstr ""
 
-#: mod/editpost.php:117 src/Core/ACL.php:303
+#: mod/editpost.php:98 src/Core/ACL.php:307
 msgid "CC: email addresses"
 msgstr ""
 
-#: mod/editpost.php:124 src/Core/ACL.php:304
+#: mod/editpost.php:105 src/Core/ACL.php:308
 msgid "Example: bob@example.com, mary@example.com"
 msgstr ""
 
@@ -3649,84 +3676,84 @@ msgstr ""
 msgid "Event title and start time are required."
 msgstr ""
 
-#: mod/events.php:401
+#: mod/events.php:386
 msgid "Create New Event"
 msgstr ""
 
-#: mod/events.php:524
+#: mod/events.php:509
 msgid "Event details"
 msgstr ""
 
-#: mod/events.php:525
+#: mod/events.php:510
 msgid "Starting date and Title are required."
 msgstr ""
 
-#: mod/events.php:526 mod/events.php:531
+#: mod/events.php:511 mod/events.php:516
 msgid "Event Starts:"
 msgstr ""
 
-#: mod/events.php:526 mod/events.php:558 mod/profiles.php:608
+#: mod/events.php:511 mod/events.php:543 mod/profiles.php:592
 msgid "Required"
 msgstr ""
 
-#: mod/events.php:539 mod/events.php:564
+#: mod/events.php:524 mod/events.php:549
 msgid "Finish date/time is not known or not relevant"
 msgstr ""
 
-#: mod/events.php:541 mod/events.php:546
+#: mod/events.php:526 mod/events.php:531
 msgid "Event Finishes:"
 msgstr ""
 
-#: mod/events.php:552 mod/events.php:565
+#: mod/events.php:537 mod/events.php:550
 msgid "Adjust for viewer timezone"
 msgstr ""
 
-#: mod/events.php:554
+#: mod/events.php:539
 msgid "Description:"
 msgstr ""
 
-#: mod/events.php:558 mod/events.php:560
+#: mod/events.php:543 mod/events.php:545
 msgid "Title:"
 msgstr ""
 
-#: mod/events.php:561 mod/events.php:562
+#: mod/events.php:546 mod/events.php:547
 msgid "Share this event"
 msgstr ""
 
-#: mod/events.php:569 src/Model/Profile.php:882
+#: mod/events.php:554 src/Model/Profile.php:877
 msgid "Basic"
 msgstr ""
 
-#: mod/events.php:571 mod/photos.php:1066 mod/photos.php:1407
-#: src/Core/ACL.php:306
+#: mod/events.php:556 mod/photos.php:1067 mod/photos.php:1408
+#: src/Core/ACL.php:310
 msgid "Permissions"
 msgstr ""
 
-#: mod/events.php:587
+#: mod/events.php:572
 msgid "Failed to remove event"
 msgstr ""
 
-#: mod/events.php:589
+#: mod/events.php:574
 msgid "Event removed"
 msgstr ""
 
-#: mod/fbrowser.php:36 src/Content/Nav.php:151 src/Model/Profile.php:922
-#: view/theme/frio/theme.php:262
+#: mod/fbrowser.php:36 src/Content/Nav.php:158 src/Model/Profile.php:917
+#: view/theme/frio/theme.php:264
 msgid "Photos"
 msgstr ""
 
-#: mod/fbrowser.php:45 mod/fbrowser.php:70 mod/photos.php:201
-#: mod/photos.php:1030 mod/photos.php:1125 mod/photos.php:1142
-#: mod/photos.php:1609 mod/photos.php:1624 src/Model/Photo.php:528
-#: src/Model/Photo.php:537
+#: mod/fbrowser.php:45 mod/fbrowser.php:69 mod/photos.php:201
+#: mod/photos.php:1031 mod/photos.php:1126 mod/photos.php:1143
+#: mod/photos.php:1610 mod/photos.php:1625 src/Model/Photo.php:547
+#: src/Model/Photo.php:556
 msgid "Contact Photos"
 msgstr ""
 
-#: mod/fbrowser.php:107 mod/fbrowser.php:138 mod/profile_photo.php:255
+#: mod/fbrowser.php:106 mod/fbrowser.php:136 mod/profile_photo.php:254
 msgid "Upload"
 msgstr ""
 
-#: mod/fbrowser.php:133
+#: mod/fbrowser.php:131
 msgid "Files"
 msgstr ""
 
@@ -3742,186 +3769,186 @@ msgstr ""
 msgid "- select -"
 msgstr ""
 
-#: mod/follow.php:47
+#: mod/follow.php:46
 msgid "The contact could not be added."
 msgstr ""
 
-#: mod/follow.php:77
+#: mod/follow.php:76
 msgid "You already added this contact."
 msgstr ""
 
-#: mod/follow.php:87
+#: mod/follow.php:86
 msgid "Diaspora support isn't enabled. Contact can't be added."
 msgstr ""
 
-#: mod/follow.php:94
+#: mod/follow.php:93
 msgid "OStatus support is disabled. Contact can't be added."
 msgstr ""
 
-#: mod/follow.php:101
+#: mod/follow.php:100
 msgid "The network type couldn't be detected. Contact can't be added."
 msgstr ""
 
-#: mod/follow.php:171 mod/notifications.php:255 src/Model/Profile.php:812
-#: src/Module/Contact.php:652
+#: mod/follow.php:170 mod/notifications.php:257 src/Model/Profile.php:807
+#: src/Module/Contact.php:649
 msgid "Tags:"
 msgstr ""
 
-#: mod/follow.php:183 mod/unfollow.php:147 src/Model/Profile.php:909
-#: src/Module/Contact.php:867
+#: mod/follow.php:182 mod/unfollow.php:147 src/Model/Profile.php:904
+#: src/Module/Contact.php:864
 msgid "Status Messages and Posts"
 msgstr ""
 
-#: mod/friendica.php:80
+#: mod/friendica.php:87
 #, php-format
 msgid ""
 "This is Friendica, version %s that is running at the web location %s. The "
 "database version is %s, the post update version is %s."
 msgstr ""
 
-#: mod/friendica.php:86
+#: mod/friendica.php:93
 msgid ""
 "Please visit <a href=\"https://friendi.ca\">Friendi.ca</a> to learn more "
 "about the Friendica project."
 msgstr ""
 
-#: mod/friendica.php:90
+#: mod/friendica.php:97
 msgid "Bug reports and issues: please visit"
 msgstr ""
 
-#: mod/friendica.php:90
+#: mod/friendica.php:97
 msgid "the bugtracker at github"
 msgstr ""
 
-#: mod/friendica.php:93
+#: mod/friendica.php:100
 msgid ""
 "Suggestions, praise, etc. - please email \"info\" at \"friendi - dot - ca"
 msgstr ""
 
-#: mod/friendica.php:98
+#: mod/friendica.php:105
 msgid "Installed addons/apps:"
 msgstr ""
 
-#: mod/friendica.php:112
+#: mod/friendica.php:119
 msgid "No installed addons/apps"
 msgstr ""
 
-#: mod/friendica.php:117
+#: mod/friendica.php:124
 #, php-format
 msgid "Read about the <a href=\"%1$s/tos\">Terms of Service</a> of this node."
 msgstr ""
 
-#: mod/friendica.php:122
+#: mod/friendica.php:129
 msgid "On this server the following remote servers are blocked."
 msgstr ""
 
-#: mod/fsuggest.php:73
+#: mod/fsuggest.php:69
 msgid "Friend suggestion sent."
 msgstr ""
 
-#: mod/fsuggest.php:102
+#: mod/fsuggest.php:93
 msgid "Suggest Friends"
 msgstr ""
 
-#: mod/fsuggest.php:104
+#: mod/fsuggest.php:95
 #, php-format
 msgid "Suggest a friend for %s"
 msgstr ""
 
-#: mod/group.php:40
+#: mod/group.php:38
 msgid "Group created."
 msgstr ""
 
-#: mod/group.php:46
+#: mod/group.php:44
 msgid "Could not create group."
 msgstr ""
 
-#: mod/group.php:60 mod/group.php:186
+#: mod/group.php:58 mod/group.php:184
 msgid "Group not found."
 msgstr ""
 
-#: mod/group.php:74
+#: mod/group.php:72
 msgid "Group name changed."
 msgstr ""
 
-#: mod/group.php:87 mod/profperm.php:30 src/App.php:1822
+#: mod/group.php:85 mod/profperm.php:30 src/App.php:1481
 msgid "Permission denied"
 msgstr ""
 
-#: mod/group.php:105
+#: mod/group.php:103
 msgid "Save Group"
 msgstr ""
 
-#: mod/group.php:106
+#: mod/group.php:104
 msgid "Filter"
 msgstr ""
 
-#: mod/group.php:111
+#: mod/group.php:109
 msgid "Create a group of contacts/friends."
 msgstr ""
 
-#: mod/group.php:112 mod/group.php:135 mod/group.php:226
-#: src/Model/Group.php:413
+#: mod/group.php:110 mod/group.php:133 mod/group.php:224
+#: src/Model/Group.php:423
 msgid "Group Name: "
 msgstr ""
 
-#: mod/group.php:127 src/Model/Group.php:410
+#: mod/group.php:125 src/Model/Group.php:420
 msgid "Contacts not in any group"
 msgstr ""
 
-#: mod/group.php:158
+#: mod/group.php:156
 msgid "Group removed."
 msgstr ""
 
-#: mod/group.php:160
+#: mod/group.php:158
 msgid "Unable to remove group."
 msgstr ""
 
-#: mod/group.php:219
+#: mod/group.php:217
 msgid "Delete Group"
 msgstr ""
 
-#: mod/group.php:230
+#: mod/group.php:228
 msgid "Edit Group Name"
 msgstr ""
 
-#: mod/group.php:241
+#: mod/group.php:239
 msgid "Members"
 msgstr ""
 
-#: mod/group.php:243 src/Module/Contact.php:707
+#: mod/group.php:241 src/Module/Contact.php:704
 msgid "All Contacts"
 msgstr ""
 
-#: mod/group.php:244 mod/network.php:650
+#: mod/group.php:242 mod/network.php:654
 msgid "Group is empty"
 msgstr ""
 
-#: mod/group.php:257
+#: mod/group.php:255
 msgid "Remove contact from group"
 msgstr ""
 
-#: mod/group.php:275 mod/profperm.php:119
+#: mod/group.php:273 mod/profperm.php:119
 msgid "Click on a contact to add or remove."
 msgstr ""
 
-#: mod/group.php:289
+#: mod/group.php:287
 msgid "Add contact to group"
 msgstr ""
 
-#: mod/hcard.php:19
+#: mod/hcard.php:20
 msgid "No profile"
 msgstr ""
 
-#: mod/help.php:51
+#: mod/help.php:52
 msgid "Help:"
 msgstr ""
 
-#: mod/help.php:58 src/Content/Nav.php:183 view/theme/vier/theme.php:294
+#: mod/help.php:59 src/Content/Nav.php:190 view/theme/vier/theme.php:294
 msgid "Help"
 msgstr ""
 
-#: mod/help.php:64 src/App.php:1740
+#: mod/help.php:65 src/App.php:1399
 msgid "Not Found"
 msgstr ""
 
@@ -3930,7 +3957,7 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: mod/invite.php:38
+#: mod/invite.php:36
 msgid "Total invitation limit exceeded."
 msgstr ""
 
@@ -4013,7 +4040,7 @@ msgstr ""
 msgid "Enter email addresses, one per line:"
 msgstr ""
 
-#: mod/invite.php:149 mod/message.php:257 mod/message.php:437
+#: mod/invite.php:149 mod/message.php:255 mod/message.php:435
 #: mod/wallmessage.php:137
 msgid "Your message:"
 msgstr ""
@@ -4039,37 +4066,37 @@ msgid ""
 "important, please visit http://friendi.ca"
 msgstr ""
 
-#: mod/item.php:118
+#: mod/item.php:120
 msgid "Unable to locate original post."
 msgstr ""
 
-#: mod/item.php:286
+#: mod/item.php:320
 msgid "Empty post discarded."
 msgstr ""
 
-#: mod/item.php:809
+#: mod/item.php:841
 #, php-format
 msgid ""
 "This message was sent to you by %s, a member of the Friendica social network."
 msgstr ""
 
-#: mod/item.php:811
+#: mod/item.php:843
 #, php-format
 msgid "You may visit them online at %s"
 msgstr ""
 
-#: mod/item.php:812
+#: mod/item.php:844
 msgid ""
 "Please contact the sender by replying to this post if you do not wish to "
 "receive these messages."
 msgstr ""
 
-#: mod/item.php:816
+#: mod/item.php:848
 #, php-format
 msgid "%s posted an update."
 msgstr ""
 
-#: mod/localtime.php:19 src/Model/Event.php:34 src/Model/Event.php:840
+#: mod/localtime.php:19 src/Model/Event.php:34 src/Model/Event.php:848
 msgid "l F d, Y \\@ g:i A"
 msgstr ""
 
@@ -4159,61 +4186,61 @@ msgstr ""
 msgid "Password reset requested at %s"
 msgstr ""
 
-#: mod/lostpass.php:90
+#: mod/lostpass.php:89
 msgid ""
 "Request could not be verified. (You may have previously submitted it.) "
 "Password reset failed."
 msgstr ""
 
-#: mod/lostpass.php:103
+#: mod/lostpass.php:102
 msgid "Request has expired, please make a new one."
 msgstr ""
 
-#: mod/lostpass.php:118
+#: mod/lostpass.php:117
 msgid "Forgot your Password?"
 msgstr ""
 
-#: mod/lostpass.php:119
+#: mod/lostpass.php:118
 msgid ""
 "Enter your email address and submit to have your password reset. Then check "
 "your email for further instructions."
 msgstr ""
 
-#: mod/lostpass.php:120 src/Module/Login.php:321
+#: mod/lostpass.php:119 src/Module/Login.php:324
 msgid "Nickname or Email: "
 msgstr ""
 
-#: mod/lostpass.php:121
+#: mod/lostpass.php:120
 msgid "Reset"
 msgstr ""
 
-#: mod/lostpass.php:137 src/Module/Login.php:333
+#: mod/lostpass.php:135 src/Module/Login.php:336
 msgid "Password Reset"
 msgstr ""
 
-#: mod/lostpass.php:138
+#: mod/lostpass.php:136
 msgid "Your password has been reset as requested."
 msgstr ""
 
-#: mod/lostpass.php:139
+#: mod/lostpass.php:137
 msgid "Your new password is"
 msgstr ""
 
-#: mod/lostpass.php:140
+#: mod/lostpass.php:138
 msgid "Save or copy your new password - and then"
 msgstr ""
 
-#: mod/lostpass.php:141
+#: mod/lostpass.php:139
 msgid "click here to login"
 msgstr ""
 
-#: mod/lostpass.php:142
+#: mod/lostpass.php:140
 msgid ""
 "Your password may be changed from the <em>Settings</em> page after "
 "successful login."
 msgstr ""
 
-#: mod/lostpass.php:150
+#: mod/lostpass.php:148
 #, php-format
 msgid ""
 "\n"
@@ -4224,7 +4251,7 @@ msgid ""
 "\t\t"
 msgstr ""
 
-#: mod/lostpass.php:156
+#: mod/lostpass.php:154
 #, php-format
 msgid ""
 "\n"
@@ -4239,7 +4266,7 @@ msgid ""
 "\t\t"
 msgstr ""
 
-#: mod/lostpass.php:172
+#: mod/lostpass.php:170
 #, php-format
 msgid "Your password has been changed at %s"
 msgstr ""
@@ -4262,23 +4289,23 @@ msgstr ""
 msgid "Select an identity to manage: "
 msgstr ""
 
-#: mod/match.php:46
+#: mod/match.php:49
 msgid "No keywords to match. Please add keywords to your default profile."
 msgstr ""
 
-#: mod/match.php:112 src/Content/Pager.php:196
+#: mod/match.php:115 src/Content/Pager.php:198
 msgid "first"
 msgstr ""
 
-#: mod/match.php:117 src/Content/Pager.php:256
+#: mod/match.php:120 src/Content/Pager.php:258
 msgid "next"
 msgstr ""
 
-#: mod/match.php:132
+#: mod/match.php:135
 msgid "Profile Match"
 msgstr ""
 
-#: mod/message.php:33 mod/message.php:116 src/Content/Nav.php:248
+#: mod/message.php:33 mod/message.php:116 src/Content/Nav.php:255
 msgid "New Message"
 msgstr ""
 
@@ -4302,12 +4329,12 @@ msgstr ""
 msgid "Message sent."
 msgstr ""
 
-#: mod/message.php:110 mod/notifications.php:47 mod/notifications.php:185
-#: mod/notifications.php:233
+#: mod/message.php:110 mod/notifications.php:47 mod/notifications.php:187
+#: mod/notifications.php:235
 msgid "Discard"
 msgstr ""
 
-#: mod/message.php:123 src/Content/Nav.php:245 view/theme/frio/theme.php:269
+#: mod/message.php:123 src/Content/Nav.php:252 view/theme/frio/theme.php:271
 msgid "Messages"
 msgstr ""
 
@@ -4323,91 +4350,91 @@ msgstr ""
 msgid "Message deleted."
 msgstr ""
 
-#: mod/message.php:176 mod/message.php:191
+#: mod/message.php:176 mod/message.php:190
 msgid "Conversation removed."
 msgstr ""
 
-#: mod/message.php:205 mod/message.php:362 mod/wallmessage.php:123
+#: mod/message.php:204 mod/message.php:360 mod/wallmessage.php:123
 msgid "Please enter a link URL:"
 msgstr ""
 
-#: mod/message.php:248 mod/wallmessage.php:128
+#: mod/message.php:246 mod/wallmessage.php:128
 msgid "Send Private Message"
 msgstr ""
 
-#: mod/message.php:249 mod/message.php:432 mod/wallmessage.php:130
+#: mod/message.php:247 mod/message.php:430 mod/wallmessage.php:130
 msgid "To:"
 msgstr ""
 
-#: mod/message.php:253 mod/message.php:434 mod/wallmessage.php:131
+#: mod/message.php:251 mod/message.php:432 mod/wallmessage.php:131
 msgid "Subject:"
 msgstr ""
 
-#: mod/message.php:291
+#: mod/message.php:289
 msgid "No messages."
 msgstr ""
 
-#: mod/message.php:354
+#: mod/message.php:352
 msgid "Message not available."
 msgstr ""
 
-#: mod/message.php:408
+#: mod/message.php:406
 msgid "Delete message"
 msgstr ""
 
-#: mod/message.php:410 mod/message.php:542
+#: mod/message.php:408 mod/message.php:540
 msgid "D, d M Y - g:i A"
 msgstr ""
 
-#: mod/message.php:425 mod/message.php:539
+#: mod/message.php:423 mod/message.php:537
 msgid "Delete conversation"
 msgstr ""
 
-#: mod/message.php:427
+#: mod/message.php:425
 msgid ""
 "No secure communications available. You <strong>may</strong> be able to "
 "respond from the sender's profile page."
 msgstr ""
 
-#: mod/message.php:431
+#: mod/message.php:429
 msgid "Send Reply"
 msgstr ""
 
-#: mod/message.php:514
+#: mod/message.php:512
 #, php-format
 msgid "Unknown sender - %s"
 msgstr ""
 
-#: mod/message.php:516
+#: mod/message.php:514
 #, php-format
 msgid "You and %s"
 msgstr ""
 
-#: mod/message.php:518
+#: mod/message.php:516
 #, php-format
 msgid "%s and You"
 msgstr ""
 
-#: mod/message.php:545
+#: mod/message.php:543
 #, php-format
 msgid "%d message"
 msgid_plural "%d messages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: mod/network.php:183 mod/search.php:39
+#: mod/network.php:183 mod/search.php:38
 msgid "Remove term"
 msgstr ""
 
-#: mod/network.php:190 mod/search.php:48
+#: mod/network.php:190 mod/search.php:47
 msgid "Saved Searches"
 msgstr ""
 
-#: mod/network.php:191 src/Model/Group.php:404
+#: mod/network.php:191 src/Model/Group.php:414
 msgid "add"
 msgstr ""
 
-#: mod/network.php:558
+#: mod/network.php:563
 #, php-format
 msgid ""
 "Warning: This group contains %s member from a network that doesn't allow non "
@@ -4418,73 +4445,73 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: mod/network.php:561
+#: mod/network.php:566
 msgid "Messages in this group won't be send to these receivers."
 msgstr ""
 
-#: mod/network.php:629
+#: mod/network.php:633
 msgid "No such group"
 msgstr ""
 
-#: mod/network.php:654
+#: mod/network.php:658
 #, php-format
 msgid "Group: %s"
 msgstr ""
 
-#: mod/network.php:680
+#: mod/network.php:684
 msgid "Private messages to this person are at risk of public disclosure."
 msgstr ""
 
-#: mod/network.php:683
+#: mod/network.php:687
 msgid "Invalid contact."
 msgstr ""
 
-#: mod/network.php:961
+#: mod/network.php:966
 msgid "Commented Order"
 msgstr ""
 
-#: mod/network.php:964
+#: mod/network.php:969
 msgid "Sort by Comment Date"
 msgstr ""
 
-#: mod/network.php:969
+#: mod/network.php:974
 msgid "Posted Order"
 msgstr ""
 
-#: mod/network.php:972
+#: mod/network.php:977
 msgid "Sort by Post Date"
 msgstr ""
 
-#: mod/network.php:979 mod/profiles.php:595
-#: src/Core/NotificationsManager.php:185
+#: mod/network.php:984 mod/profiles.php:579
+#: src/Core/NotificationsManager.php:189
 msgid "Personal"
 msgstr ""
 
-#: mod/network.php:982
+#: mod/network.php:987
 msgid "Posts that mention or involve you"
 msgstr ""
 
-#: mod/network.php:989
+#: mod/network.php:994
 msgid "New"
 msgstr ""
 
-#: mod/network.php:992
+#: mod/network.php:997
 msgid "Activity Stream - by date"
 msgstr ""
 
-#: mod/network.php:1000
+#: mod/network.php:1005
 msgid "Shared Links"
 msgstr ""
 
-#: mod/network.php:1003
+#: mod/network.php:1008
 msgid "Interesting Links"
 msgstr ""
 
-#: mod/network.php:1010
+#: mod/network.php:1015
 msgid "Starred"
 msgstr ""
 
-#: mod/network.php:1013
+#: mod/network.php:1018
 msgid "Favourite Posts"
 msgstr ""
 
@@ -4538,14 +4565,14 @@ msgid ""
 "potential friends know exactly how to find you."
 msgstr ""
 
-#: mod/newmember.php:25 mod/profperm.php:117 src/Content/Nav.php:150
-#: src/Model/Profile.php:748 src/Model/Profile.php:881
-#: src/Model/Profile.php:914 src/Module/Contact.php:657
-#: src/Module/Contact.php:872 view/theme/frio/theme.php:261
+#: mod/newmember.php:25 mod/profperm.php:117 src/Content/Nav.php:157
+#: src/Model/Profile.php:876 src/Model/Profile.php:909
+#: src/Module/Contact.php:654 src/Module/Contact.php:869
+#: view/theme/frio/theme.php:263
 msgid "Profile"
 msgstr ""
 
-#: mod/newmember.php:27 mod/profiles.php:599 mod/profile_photo.php:254
+#: mod/newmember.php:27 mod/profiles.php:583 mod/profile_photo.php:253
 msgid "Upload Profile Photo"
 msgstr ""
 
@@ -4628,7 +4655,7 @@ msgid ""
 "hours."
 msgstr ""
 
-#: mod/newmember.php:44 src/Model/Group.php:405 src/Module/Contact.php:755
+#: mod/newmember.php:44 src/Model/Group.php:415 src/Module/Contact.php:752
 msgid "Groups"
 msgstr ""
 
@@ -4668,7 +4695,7 @@ msgid ""
 "features and resources."
 msgstr ""
 
-#: mod/notes.php:40 src/Model/Profile.php:964
+#: mod/notes.php:34 src/Model/Profile.php:959
 msgid "Personal Notes"
 msgstr ""
 
@@ -4676,125 +4703,125 @@ msgstr ""
 msgid "Invalid request identifier."
 msgstr ""
 
-#: mod/notifications.php:60 mod/notifications.php:184 mod/notifications.php:269
-#: src/Module/Contact.php:624 src/Module/Contact.php:828
-#: src/Module/Contact.php:1088
+#: mod/notifications.php:60 mod/notifications.php:186 mod/notifications.php:271
+#: src/Module/Contact.php:622 src/Module/Contact.php:825
+#: src/Module/Contact.php:1085
 msgid "Ignore"
 msgstr ""
 
-#: mod/notifications.php:93 src/Content/Nav.php:240
+#: mod/notifications.php:93 src/Content/Nav.php:247
 msgid "Notifications"
 msgstr ""
 
-#: mod/notifications.php:105
+#: mod/notifications.php:107
 msgid "Network Notifications"
 msgstr ""
 
-#: mod/notifications.php:110 mod/notify.php:82
+#: mod/notifications.php:112 mod/notify.php:84
 msgid "System Notifications"
 msgstr ""
 
-#: mod/notifications.php:115
+#: mod/notifications.php:117
 msgid "Personal Notifications"
 msgstr ""
 
-#: mod/notifications.php:120
+#: mod/notifications.php:122
 msgid "Home Notifications"
 msgstr ""
 
-#: mod/notifications.php:140
+#: mod/notifications.php:142
 msgid "Show unread"
 msgstr ""
 
-#: mod/notifications.php:140
+#: mod/notifications.php:142
 msgid "Show all"
 msgstr ""
 
-#: mod/notifications.php:151
+#: mod/notifications.php:153
 msgid "Show Ignored Requests"
 msgstr ""
 
-#: mod/notifications.php:151
+#: mod/notifications.php:153
 msgid "Hide Ignored Requests"
 msgstr ""
 
-#: mod/notifications.php:164 mod/notifications.php:241
+#: mod/notifications.php:166 mod/notifications.php:243
 msgid "Notification type:"
 msgstr ""
 
-#: mod/notifications.php:167
+#: mod/notifications.php:169
 msgid "Suggested by:"
 msgstr ""
 
-#: mod/notifications.php:179 mod/notifications.php:258
-#: src/Module/Contact.php:632
+#: mod/notifications.php:181 mod/notifications.php:260
+#: src/Module/Contact.php:630
 msgid "Hide this contact from others"
 msgstr ""
 
-#: mod/notifications.php:201
+#: mod/notifications.php:203
 msgid "Claims to be known to you: "
 msgstr ""
 
-#: mod/notifications.php:202
+#: mod/notifications.php:204
 msgid "yes"
 msgstr ""
 
-#: mod/notifications.php:202
+#: mod/notifications.php:204
 msgid "no"
 msgstr ""
 
-#: mod/notifications.php:203 mod/notifications.php:207
+#: mod/notifications.php:205 mod/notifications.php:209
 msgid "Shall your connection be bidirectional or not?"
 msgstr ""
 
-#: mod/notifications.php:204 mod/notifications.php:208
+#: mod/notifications.php:206 mod/notifications.php:210
 #, php-format
 msgid ""
 "Accepting %s as a friend allows %s to subscribe to your posts, and you will "
 "also receive updates from them in your news feed."
 msgstr ""
 
-#: mod/notifications.php:205
+#: mod/notifications.php:207
 #, php-format
 msgid ""
 "Accepting %s as a subscriber allows them to subscribe to your posts, but you "
 "will not receive updates from them in your news feed."
 msgstr ""
 
-#: mod/notifications.php:209
+#: mod/notifications.php:211
 #, php-format
 msgid ""
 "Accepting %s as a sharer allows them to subscribe to your posts, but you "
 "will not receive updates from them in your news feed."
 msgstr ""
 
-#: mod/notifications.php:220
+#: mod/notifications.php:222
 msgid "Friend"
 msgstr ""
 
-#: mod/notifications.php:221
+#: mod/notifications.php:223
 msgid "Sharer"
 msgstr ""
 
-#: mod/notifications.php:221
+#: mod/notifications.php:223
 msgid "Subscriber"
 msgstr ""
 
-#: mod/notifications.php:264 src/Model/Profile.php:542
-#: src/Module/Contact.php:89
+#: mod/notifications.php:266 src/Model/Profile.php:543
+#: src/Module/Contact.php:88
 msgid "Network:"
 msgstr ""
 
-#: mod/notifications.php:277
+#: mod/notifications.php:279
 msgid "No introductions."
 msgstr ""
 
-#: mod/notifications.php:311
+#: mod/notifications.php:313
 #, php-format
 msgid "No more %s notifications."
 msgstr ""
 
-#: mod/notify.php:78
+#: mod/notify.php:80
 msgid "No more system notifications."
 msgstr ""
 
@@ -4802,16 +4829,16 @@ msgstr ""
 msgid "Post successful."
 msgstr ""
 
-#: mod/openid.php:32
+#: mod/openid.php:31
 msgid "OpenID protocol error. No ID returned."
 msgstr ""
 
-#: mod/openid.php:68
+#: mod/openid.php:67
 msgid ""
 "Account not found and OpenID registration is not permitted on this site."
 msgstr ""
 
-#: mod/openid.php:118 src/Module/Login.php:91 src/Module/Login.php:141
+#: mod/openid.php:117 src/Module/Login.php:92 src/Module/Login.php:143
 msgid "Login failed."
 msgstr ""
 
@@ -4843,7 +4870,7 @@ msgstr ""
 msgid "failed"
 msgstr ""
 
-#: mod/ostatus_subscribe.php:89 src/Object/Post.php:280
+#: mod/ostatus_subscribe.php:89 src/Object/Post.php:282
 msgid "ignored"
 msgstr ""
 
@@ -4851,15 +4878,15 @@ msgstr ""
 msgid "Keep this window open until done."
 msgstr ""
 
-#: mod/photos.php:115 src/Model/Profile.php:925
+#: mod/photos.php:115 src/Model/Profile.php:920
 msgid "Photo Albums"
 msgstr ""
 
-#: mod/photos.php:116 mod/photos.php:1664
+#: mod/photos.php:116 mod/photos.php:1665
 msgid "Recent Photos"
 msgstr ""
 
-#: mod/photos.php:119 mod/photos.php:1186 mod/photos.php:1666
+#: mod/photos.php:119 mod/photos.php:1187 mod/photos.php:1667
 msgid "Upload New Photos"
 msgstr ""
 
@@ -4875,7 +4902,7 @@ msgstr ""
 msgid "Album not found."
 msgstr ""
 
-#: mod/photos.php:241 mod/photos.php:254 mod/photos.php:1137
+#: mod/photos.php:241 mod/photos.php:254 mod/photos.php:1138
 msgid "Delete Album"
 msgstr ""
 
@@ -4883,7 +4910,7 @@ msgstr ""
 msgid "Do you really want to delete this photo album and all its photos?"
 msgstr ""
 
-#: mod/photos.php:310 mod/photos.php:322 mod/photos.php:1412
+#: mod/photos.php:310 mod/photos.php:322 mod/photos.php:1413
 msgid "Delete Photo"
 msgstr ""
 
@@ -4891,190 +4918,190 @@ msgstr ""
 msgid "Do you really want to delete this photo?"
 msgstr ""
 
-#: mod/photos.php:644
+#: mod/photos.php:645
 msgid "a photo"
 msgstr ""
 
-#: mod/photos.php:644
+#: mod/photos.php:645
 #, php-format
 msgid "%1$s was tagged in %2$s by %3$s"
 msgstr ""
 
-#: mod/photos.php:737 mod/photos.php:740 mod/photos.php:769
-#: mod/profile_photo.php:153 mod/wall_upload.php:197
+#: mod/photos.php:738 mod/photos.php:741 mod/photos.php:770
+#: mod/profile_photo.php:152 mod/wall_upload.php:198
 #, php-format
 msgid "Image exceeds size limit of %s"
 msgstr ""
 
-#: mod/photos.php:743
+#: mod/photos.php:744
 msgid "Image upload didn't complete, please try again"
 msgstr ""
 
-#: mod/photos.php:746
+#: mod/photos.php:747
 msgid "Image file is missing"
 msgstr ""
 
-#: mod/photos.php:751
+#: mod/photos.php:752
 msgid ""
 "Server can't accept new file upload at this time, please contact your "
 "administrator"
 msgstr ""
 
-#: mod/photos.php:777
+#: mod/photos.php:778
 msgid "Image file is empty."
 msgstr ""
 
-#: mod/photos.php:792 mod/profile_photo.php:162 mod/wall_upload.php:211
+#: mod/photos.php:793 mod/profile_photo.php:161 mod/wall_upload.php:212
 msgid "Unable to process image."
 msgstr ""
 
-#: mod/photos.php:821 mod/profile_photo.php:313 mod/wall_upload.php:250
+#: mod/photos.php:822 mod/profile_photo.php:310 mod/wall_upload.php:251
 msgid "Image upload failed."
 msgstr ""
 
-#: mod/photos.php:907
+#: mod/photos.php:908
 msgid "No photos selected"
 msgstr ""
 
-#: mod/photos.php:1004 mod/videos.php:254
+#: mod/photos.php:1005 mod/videos.php:239
 msgid "Access to this item is restricted."
 msgstr ""
 
-#: mod/photos.php:1058
+#: mod/photos.php:1059
 msgid "Upload Photos"
 msgstr ""
 
-#: mod/photos.php:1062 mod/photos.php:1132
+#: mod/photos.php:1063 mod/photos.php:1133
 msgid "New album name: "
 msgstr ""
 
-#: mod/photos.php:1063
+#: mod/photos.php:1064
 msgid "or select existing album:"
 msgstr ""
 
-#: mod/photos.php:1064
+#: mod/photos.php:1065
 msgid "Do not show a status post for this upload"
 msgstr ""
 
-#: mod/photos.php:1080 mod/photos.php:1415 mod/settings.php:1212
+#: mod/photos.php:1081 mod/photos.php:1416 mod/settings.php:1209
 msgid "Show to Groups"
 msgstr ""
 
-#: mod/photos.php:1081 mod/photos.php:1416 mod/settings.php:1213
+#: mod/photos.php:1082 mod/photos.php:1417 mod/settings.php:1210
 msgid "Show to Contacts"
 msgstr ""
 
-#: mod/photos.php:1143
+#: mod/photos.php:1144
 msgid "Edit Album"
 msgstr ""
 
-#: mod/photos.php:1148
+#: mod/photos.php:1149
 msgid "Show Newest First"
 msgstr ""
 
-#: mod/photos.php:1150
+#: mod/photos.php:1151
 msgid "Show Oldest First"
 msgstr ""
 
-#: mod/photos.php:1171 mod/photos.php:1649
+#: mod/photos.php:1172 mod/photos.php:1650
 msgid "View Photo"
 msgstr ""
 
-#: mod/photos.php:1212
+#: mod/photos.php:1213
 msgid "Permission denied. Access to this item may be restricted."
 msgstr ""
 
-#: mod/photos.php:1214
+#: mod/photos.php:1215
 msgid "Photo not available"
 msgstr ""
 
-#: mod/photos.php:1289
+#: mod/photos.php:1290
 msgid "View photo"
 msgstr ""
 
-#: mod/photos.php:1289
+#: mod/photos.php:1290
 msgid "Edit photo"
 msgstr ""
 
-#: mod/photos.php:1290
+#: mod/photos.php:1291
 msgid "Use as profile photo"
 msgstr ""
 
-#: mod/photos.php:1296 src/Object/Post.php:153
+#: mod/photos.php:1297 src/Object/Post.php:155
 msgid "Private Message"
 msgstr ""
 
-#: mod/photos.php:1316
+#: mod/photos.php:1317
 msgid "View Full Size"
 msgstr ""
 
-#: mod/photos.php:1380
+#: mod/photos.php:1381
 msgid "Tags: "
 msgstr ""
 
-#: mod/photos.php:1383
+#: mod/photos.php:1384
 msgid "[Select tags to remove]"
 msgstr ""
 
-#: mod/photos.php:1398
+#: mod/photos.php:1399
 msgid "New album name"
 msgstr ""
 
-#: mod/photos.php:1399
+#: mod/photos.php:1400
 msgid "Caption"
 msgstr ""
 
-#: mod/photos.php:1400
+#: mod/photos.php:1401
 msgid "Add a Tag"
 msgstr ""
 
-#: mod/photos.php:1400
+#: mod/photos.php:1401
 msgid "Example: @bob, @Barbara_Jensen, @jim@example.com, #California, #camping"
 msgstr ""
 
-#: mod/photos.php:1401
+#: mod/photos.php:1402
 msgid "Do not rotate"
 msgstr ""
 
-#: mod/photos.php:1402
+#: mod/photos.php:1403
 msgid "Rotate CW (right)"
 msgstr ""
 
-#: mod/photos.php:1403
+#: mod/photos.php:1404
 msgid "Rotate CCW (left)"
 msgstr ""
 
-#: mod/photos.php:1437 src/Object/Post.php:308
+#: mod/photos.php:1438 src/Object/Post.php:310
 msgid "I like this (toggle)"
 msgstr ""
 
-#: mod/photos.php:1438 src/Object/Post.php:309
+#: mod/photos.php:1439 src/Object/Post.php:311
 msgid "I don't like this (toggle)"
 msgstr ""
 
-#: mod/photos.php:1453 mod/photos.php:1492 mod/photos.php:1552
-#: src/Module/Contact.php:1021 src/Object/Post.php:816
+#: mod/photos.php:1454 mod/photos.php:1493 mod/photos.php:1553
+#: src/Module/Contact.php:1018 src/Object/Post.php:864
 msgid "This is you"
 msgstr ""
 
-#: mod/photos.php:1455 mod/photos.php:1494 mod/photos.php:1554
-#: src/Object/Post.php:414 src/Object/Post.php:818
+#: mod/photos.php:1456 mod/photos.php:1495 mod/photos.php:1555
+#: src/Object/Post.php:416 src/Object/Post.php:866
 msgid "Comment"
 msgstr ""
 
-#: mod/photos.php:1584
+#: mod/photos.php:1585
 msgid "Map"
 msgstr ""
 
-#: mod/photos.php:1655 mod/videos.php:331
+#: mod/photos.php:1656 mod/videos.php:316
 msgid "View Album"
 msgstr ""
 
-#: mod/ping.php:271
+#: mod/ping.php:272
 msgid "{0} wants to be your friend"
 msgstr ""
 
-#: mod/ping.php:287
+#: mod/ping.php:288
 msgid "{0} requested registration"
 msgstr ""
 
@@ -5102,398 +5129,383 @@ msgstr ""
 msgid "Only logged in users are permitted to perform a probing."
 msgstr ""
 
-#: mod/profile.php:86 mod/profile.php:89 src/Protocol/OStatus.php:1287
-#, php-format
-msgid "%s's timeline"
-msgstr ""
-
-#: mod/profile.php:87 src/Protocol/OStatus.php:1291
-#, php-format
-msgid "%s's posts"
-msgstr ""
-
-#: mod/profile.php:88 src/Protocol/OStatus.php:1294
-#, php-format
-msgid "%s's comments"
-msgstr ""
-
-#: mod/profiles.php:61
+#: mod/profiles.php:62
 msgid "Profile deleted."
 msgstr ""
 
-#: mod/profiles.php:77 mod/profiles.php:113
+#: mod/profiles.php:78 mod/profiles.php:114
 msgid "Profile-"
 msgstr ""
 
-#: mod/profiles.php:96 mod/profiles.php:135
+#: mod/profiles.php:97 mod/profiles.php:135
 msgid "New profile created."
 msgstr ""
 
-#: mod/profiles.php:119
+#: mod/profiles.php:120
 msgid "Profile unavailable to clone."
 msgstr ""
 
-#: mod/profiles.php:207
+#: mod/profiles.php:206
 msgid "Profile Name is required."
 msgstr ""
 
-#: mod/profiles.php:348
+#: mod/profiles.php:346
 msgid "Marital Status"
 msgstr ""
 
-#: mod/profiles.php:352
+#: mod/profiles.php:349
 msgid "Romantic Partner"
 msgstr ""
 
-#: mod/profiles.php:364
+#: mod/profiles.php:358
 msgid "Work/Employment"
 msgstr ""
 
-#: mod/profiles.php:367
+#: mod/profiles.php:361
 msgid "Religion"
 msgstr ""
 
-#: mod/profiles.php:371
+#: mod/profiles.php:364
 msgid "Political Views"
 msgstr ""
 
-#: mod/profiles.php:375
+#: mod/profiles.php:367
 msgid "Gender"
 msgstr ""
 
-#: mod/profiles.php:379
+#: mod/profiles.php:370
 msgid "Sexual Preference"
 msgstr ""
 
-#: mod/profiles.php:383
+#: mod/profiles.php:373
 msgid "XMPP"
 msgstr ""
 
-#: mod/profiles.php:387
+#: mod/profiles.php:376
 msgid "Homepage"
 msgstr ""
 
-#: mod/profiles.php:391 mod/profiles.php:594
+#: mod/profiles.php:379 mod/profiles.php:578
 msgid "Interests"
 msgstr ""
 
-#: mod/profiles.php:402 mod/profiles.php:590
+#: mod/profiles.php:389 mod/profiles.php:574
 msgid "Location"
 msgstr ""
 
-#: mod/profiles.php:485
+#: mod/profiles.php:469
 msgid "Profile updated."
 msgstr ""
 
-#: mod/profiles.php:539
+#: mod/profiles.php:523
 msgid "Hide contacts and friends:"
 msgstr ""
 
-#: mod/profiles.php:544
+#: mod/profiles.php:528
 msgid "Hide your contact/friend list from viewers of this profile?"
 msgstr ""
 
-#: mod/profiles.php:564
+#: mod/profiles.php:548
 msgid "Show more profile fields:"
 msgstr ""
 
-#: mod/profiles.php:576
+#: mod/profiles.php:560
 msgid "Profile Actions"
 msgstr ""
 
-#: mod/profiles.php:577
+#: mod/profiles.php:561
 msgid "Edit Profile Details"
 msgstr ""
 
-#: mod/profiles.php:579
+#: mod/profiles.php:563
 msgid "Change Profile Photo"
 msgstr ""
 
-#: mod/profiles.php:581
+#: mod/profiles.php:565
 msgid "View this profile"
 msgstr ""
 
-#: mod/profiles.php:582
+#: mod/profiles.php:566
 msgid "View all profiles"
 msgstr ""
 
-#: mod/profiles.php:583 mod/profiles.php:678 src/Model/Profile.php:413
+#: mod/profiles.php:567 mod/profiles.php:662 src/Model/Profile.php:419
 msgid "Edit visibility"
 msgstr ""
 
-#: mod/profiles.php:584
+#: mod/profiles.php:568
 msgid "Create a new profile using these settings"
 msgstr ""
 
-#: mod/profiles.php:585
+#: mod/profiles.php:569
 msgid "Clone this profile"
 msgstr ""
 
-#: mod/profiles.php:586
+#: mod/profiles.php:570
 msgid "Delete this profile"
 msgstr ""
 
-#: mod/profiles.php:588
+#: mod/profiles.php:572
 msgid "Basic information"
 msgstr ""
 
-#: mod/profiles.php:589
+#: mod/profiles.php:573
 msgid "Profile picture"
 msgstr ""
 
-#: mod/profiles.php:591
+#: mod/profiles.php:575
 msgid "Preferences"
 msgstr ""
 
-#: mod/profiles.php:592
+#: mod/profiles.php:576
 msgid "Status information"
 msgstr ""
 
-#: mod/profiles.php:593
+#: mod/profiles.php:577
 msgid "Additional information"
 msgstr ""
 
-#: mod/profiles.php:596
+#: mod/profiles.php:580
 msgid "Relation"
 msgstr ""
 
-#: mod/profiles.php:597 src/Util/Temporal.php:80 src/Util/Temporal.php:82
+#: mod/profiles.php:581 src/Util/Temporal.php:79 src/Util/Temporal.php:81
 msgid "Miscellaneous"
 msgstr ""
 
-#: mod/profiles.php:600
+#: mod/profiles.php:584
 msgid "Your Gender:"
 msgstr ""
 
-#: mod/profiles.php:601
+#: mod/profiles.php:585
 msgid "<span class=\"heart\">&hearts;</span> Marital Status:"
 msgstr ""
 
-#: mod/profiles.php:602 src/Model/Profile.php:800
+#: mod/profiles.php:586 src/Model/Profile.php:795
 msgid "Sexual Preference:"
 msgstr ""
 
-#: mod/profiles.php:603
+#: mod/profiles.php:587
 msgid "Example: fishing photography software"
 msgstr ""
 
-#: mod/profiles.php:608
+#: mod/profiles.php:592
 msgid "Profile Name:"
 msgstr ""
 
-#: mod/profiles.php:610
+#: mod/profiles.php:594
 msgid ""
 "This is your <strong>public</strong> profile.<br />It <strong>may</strong> "
 "be visible to anybody using the internet."
 msgstr ""
 
-#: mod/profiles.php:611
+#: mod/profiles.php:595
 msgid "Your Full Name:"
 msgstr ""
 
-#: mod/profiles.php:612
+#: mod/profiles.php:596
 msgid "Title/Description:"
 msgstr ""
 
-#: mod/profiles.php:615
+#: mod/profiles.php:599
 msgid "Street Address:"
 msgstr ""
 
-#: mod/profiles.php:616
+#: mod/profiles.php:600
 msgid "Locality/City:"
 msgstr ""
 
-#: mod/profiles.php:617
+#: mod/profiles.php:601
 msgid "Region/State:"
 msgstr ""
 
-#: mod/profiles.php:618
+#: mod/profiles.php:602
 msgid "Postal/Zip Code:"
 msgstr ""
 
-#: mod/profiles.php:619
+#: mod/profiles.php:603
 msgid "Country:"
 msgstr ""
 
-#: mod/profiles.php:620 src/Util/Temporal.php:148
+#: mod/profiles.php:604 src/Util/Temporal.php:149
 msgid "Age: "
 msgstr ""
 
-#: mod/profiles.php:623
+#: mod/profiles.php:607
 msgid "Who: (if applicable)"
 msgstr ""
 
-#: mod/profiles.php:623
+#: mod/profiles.php:607
 msgid "Examples: cathy123, Cathy Williams, cathy@example.com"
 msgstr ""
 
-#: mod/profiles.php:624
+#: mod/profiles.php:608
 msgid "Since [date]:"
 msgstr ""
 
-#: mod/profiles.php:626
+#: mod/profiles.php:610
 msgid "Tell us about yourself..."
 msgstr ""
 
-#: mod/profiles.php:627
+#: mod/profiles.php:611
 msgid "XMPP (Jabber) address:"
 msgstr ""
 
-#: mod/profiles.php:627
+#: mod/profiles.php:611
 msgid ""
 "The XMPP address will be propagated to your contacts so that they can follow "
 "you."
 msgstr ""
 
-#: mod/profiles.php:628
+#: mod/profiles.php:612
 msgid "Homepage URL:"
 msgstr ""
 
-#: mod/profiles.php:629 src/Model/Profile.php:808
+#: mod/profiles.php:613 src/Model/Profile.php:803
 msgid "Hometown:"
 msgstr ""
 
-#: mod/profiles.php:630 src/Model/Profile.php:816
+#: mod/profiles.php:614 src/Model/Profile.php:811
 msgid "Political Views:"
 msgstr ""
 
-#: mod/profiles.php:631
+#: mod/profiles.php:615
 msgid "Religious Views:"
 msgstr ""
 
-#: mod/profiles.php:632
+#: mod/profiles.php:616
 msgid "Public Keywords:"
 msgstr ""
 
-#: mod/profiles.php:632
+#: mod/profiles.php:616
 msgid "(Used for suggesting potential friends, can be seen by others)"
 msgstr ""
 
-#: mod/profiles.php:633
+#: mod/profiles.php:617
 msgid "Private Keywords:"
 msgstr ""
 
-#: mod/profiles.php:633
+#: mod/profiles.php:617
 msgid "(Used for searching profiles, never shown to others)"
 msgstr ""
 
-#: mod/profiles.php:634 src/Model/Profile.php:832
+#: mod/profiles.php:618 src/Model/Profile.php:827
 msgid "Likes:"
 msgstr ""
 
-#: mod/profiles.php:635 src/Model/Profile.php:836
+#: mod/profiles.php:619 src/Model/Profile.php:831
 msgid "Dislikes:"
 msgstr ""
 
-#: mod/profiles.php:636
+#: mod/profiles.php:620
 msgid "Musical interests"
 msgstr ""
 
-#: mod/profiles.php:637
+#: mod/profiles.php:621
 msgid "Books, literature"
 msgstr ""
 
-#: mod/profiles.php:638
+#: mod/profiles.php:622
 msgid "Television"
 msgstr ""
 
-#: mod/profiles.php:639
+#: mod/profiles.php:623
 msgid "Film/dance/culture/entertainment"
 msgstr ""
 
-#: mod/profiles.php:640
+#: mod/profiles.php:624
 msgid "Hobbies/Interests"
 msgstr ""
 
-#: mod/profiles.php:641
+#: mod/profiles.php:625
 msgid "Love/romance"
 msgstr ""
 
-#: mod/profiles.php:642
+#: mod/profiles.php:626
 msgid "Work/employment"
 msgstr ""
 
-#: mod/profiles.php:643
+#: mod/profiles.php:627
 msgid "School/education"
 msgstr ""
 
-#: mod/profiles.php:644
+#: mod/profiles.php:628
 msgid "Contact information and Social Networks"
 msgstr ""
 
-#: mod/profiles.php:675 src/Model/Profile.php:409
+#: mod/profiles.php:659 src/Model/Profile.php:415
 msgid "Profile Image"
 msgstr ""
 
-#: mod/profiles.php:677 src/Model/Profile.php:412
+#: mod/profiles.php:661 src/Model/Profile.php:418
 msgid "visible to everybody"
 msgstr ""
 
-#: mod/profiles.php:684
+#: mod/profiles.php:668
 msgid "Edit/Manage Profiles"
 msgstr ""
 
-#: mod/profiles.php:685 src/Model/Profile.php:399 src/Model/Profile.php:421
+#: mod/profiles.php:669 src/Model/Profile.php:405 src/Model/Profile.php:427
 msgid "Change profile photo"
 msgstr ""
 
-#: mod/profiles.php:686 src/Model/Profile.php:400
+#: mod/profiles.php:670 src/Model/Profile.php:406
 msgid "Create New Profile"
 msgstr ""
 
-#: mod/profile_photo.php:59
+#: mod/profile_photo.php:58
 msgid "Image uploaded but image cropping failed."
 msgstr ""
 
-#: mod/profile_photo.php:89 mod/profile_photo.php:98 mod/profile_photo.php:107
-#: mod/profile_photo.php:321
+#: mod/profile_photo.php:88 mod/profile_photo.php:97 mod/profile_photo.php:106
+#: mod/profile_photo.php:318
 #, php-format
 msgid "Image size reduction [%s] failed."
 msgstr ""
 
-#: mod/profile_photo.php:126
+#: mod/profile_photo.php:125
 msgid ""
 "Shift-reload the page or clear browser cache if the new photo does not "
 "display immediately."
 msgstr ""
 
-#: mod/profile_photo.php:134
+#: mod/profile_photo.php:133
 msgid "Unable to process image"
 msgstr ""
 
-#: mod/profile_photo.php:252
+#: mod/profile_photo.php:251
 msgid "Upload File:"
 msgstr ""
 
-#: mod/profile_photo.php:253
+#: mod/profile_photo.php:252
 msgid "Select a profile:"
 msgstr ""
 
-#: mod/profile_photo.php:258
+#: mod/profile_photo.php:257
 msgid "or"
 msgstr ""
 
-#: mod/profile_photo.php:259
+#: mod/profile_photo.php:258
 msgid "skip this step"
 msgstr ""
 
-#: mod/profile_photo.php:259
+#: mod/profile_photo.php:258
 msgid "select a photo from your photo albums"
 msgstr ""
 
-#: mod/profile_photo.php:272
+#: mod/profile_photo.php:271
 msgid "Crop Image"
 msgstr ""
 
-#: mod/profile_photo.php:273
+#: mod/profile_photo.php:272
 msgid "Please adjust the image cropping for optimum viewing."
 msgstr ""
 
-#: mod/profile_photo.php:275
+#: mod/profile_photo.php:274
 msgid "Done Editing"
 msgstr ""
 
-#: mod/profile_photo.php:311
+#: mod/profile_photo.php:308
 msgid "Image uploaded successfully."
 msgstr ""
 
@@ -5513,121 +5525,6 @@ msgstr ""
 msgid "All Contacts (with secure profile access)"
 msgstr ""
 
-#: mod/register.php:103
-msgid ""
-"Registration successful. Please check your email for further instructions."
-msgstr ""
-
-#: mod/register.php:107
-#, php-format
-msgid ""
-"Failed to send email message. Here your accout details:<br> login: %s<br> "
-"password: %s<br><br>You can change your password after login."
-msgstr ""
-
-#: mod/register.php:114
-msgid "Registration successful."
-msgstr ""
-
-#: mod/register.php:119
-msgid "Your registration can not be processed."
-msgstr ""
-
-#: mod/register.php:162
-msgid "Your registration is pending approval by the site owner."
-msgstr ""
-
-#: mod/register.php:191 mod/uimport.php:39
-msgid ""
-"This site has exceeded the number of allowed daily account registrations. "
-"Please try again tomorrow."
-msgstr ""
-
-#: mod/register.php:218
-msgid ""
-"You may (optionally) fill in this form via OpenID by supplying your OpenID "
-"and clicking 'Register'."
-msgstr ""
-
-#: mod/register.php:219
-msgid ""
-"If you are not familiar with OpenID, please leave that field blank and fill "
-"in the rest of the items."
-msgstr ""
-
-#: mod/register.php:220
-msgid "Your OpenID (optional): "
-msgstr ""
-
-#: mod/register.php:229
-msgid "Include your profile in member directory?"
-msgstr ""
-
-#: mod/register.php:253
-msgid "Note for the admin"
-msgstr ""
-
-#: mod/register.php:253
-msgid "Leave a message for the admin, why you want to join this node"
-msgstr ""
-
-#: mod/register.php:254
-msgid "Membership on this site is by invitation only."
-msgstr ""
-
-#: mod/register.php:255
-msgid "Your invitation code: "
-msgstr ""
-
-#: mod/register.php:263
-msgid "Your Full Name (e.g. Joe Smith, real or real-looking): "
-msgstr ""
-
-#: mod/register.php:264
-msgid ""
-"Your Email Address: (Initial information will be send there, so this has to "
-"be an existing address.)"
-msgstr ""
-
-#: mod/register.php:266 mod/settings.php:1184
-msgid "New Password:"
-msgstr ""
-
-#: mod/register.php:266
-msgid "Leave empty for an auto generated password."
-msgstr ""
-
-#: mod/register.php:267 mod/settings.php:1185
-msgid "Confirm:"
-msgstr ""
-
-#: mod/register.php:268
-#, php-format
-msgid ""
-"Choose a profile nickname. This must begin with a text character. Your "
-"profile address on this site will then be '<strong>nickname@%s</strong>'."
-msgstr ""
-
-#: mod/register.php:269
-msgid "Choose a nickname: "
-msgstr ""
-
-#: mod/register.php:272 src/Content/Nav.php:177 src/Module/Login.php:290
-msgid "Register"
-msgstr ""
-
-#: mod/register.php:277 mod/uimport.php:54
-msgid "Import"
-msgstr ""
-
-#: mod/register.php:278
-msgid "Import your profile to this friendica instance"
-msgstr ""
-
-#: mod/register.php:286
-msgid "Note: This node explicitly contains adult content"
-msgstr ""
-
 #: mod/regmod.php:53
 msgid "Account approved."
 msgstr ""
@@ -5641,32 +5538,32 @@ msgstr ""
 msgid "Please login."
 msgstr ""
 
-#: mod/removeme.php:47
+#: mod/removeme.php:46
 msgid "User deleted their account"
 msgstr ""
 
-#: mod/removeme.php:48
+#: mod/removeme.php:47
 msgid ""
 "On your Friendica node an user deleted their account. Please ensure that "
 "their data is removed from the backups."
 msgstr ""
 
-#: mod/removeme.php:49
+#: mod/removeme.php:48
 #, php-format
 msgid "The user id is %d"
 msgstr ""
 
-#: mod/removeme.php:85 mod/removeme.php:88
+#: mod/removeme.php:84 mod/removeme.php:87
 msgid "Remove My Account"
 msgstr ""
 
-#: mod/removeme.php:86
+#: mod/removeme.php:85
 msgid ""
 "This will completely remove your account. Once this has been done it is not "
 "recoverable."
 msgstr ""
 
-#: mod/removeme.php:87
+#: mod/removeme.php:86
 msgid "Please enter your password for verification:"
 msgstr ""
 
@@ -5678,28 +5575,28 @@ msgstr ""
 msgid "Error"
 msgstr ""
 
-#: mod/search.php:104
+#: mod/search.php:103
 msgid "Only logged in users are permitted to perform a search."
 msgstr ""
 
-#: mod/search.php:128
+#: mod/search.php:127
 msgid "Too Many Requests"
 msgstr ""
 
-#: mod/search.php:129
+#: mod/search.php:128
 msgid "Only one search per minute is permitted for not logged in users."
 msgstr ""
 
-#: mod/search.php:150 src/Content/Nav.php:191 src/Content/Text/HTML.php:968
+#: mod/search.php:149 src/Content/Nav.php:198 src/Content/Text/HTML.php:900
 msgid "Search"
 msgstr ""
 
-#: mod/search.php:236
+#: mod/search.php:235
 #, php-format
 msgid "Items tagged with: %s"
 msgstr ""
 
-#: mod/search.php:238 src/Module/Contact.php:819
+#: mod/search.php:237 src/Module/Contact.php:816
 #, php-format
 msgid "Results for: %s"
 msgstr ""
@@ -5708,7 +5605,7 @@ msgstr ""
 msgid "Account"
 msgstr ""
 
-#: mod/settings.php:69 src/Content/Nav.php:259 src/Model/Profile.php:392
+#: mod/settings.php:69 src/Content/Nav.php:266 src/Model/Profile.php:398
 msgid "Profiles"
 msgstr ""
 
@@ -5716,11 +5613,11 @@ msgstr ""
 msgid "Display"
 msgstr ""
 
-#: mod/settings.php:92 mod/settings.php:833
+#: mod/settings.php:92 mod/settings.php:830
 msgid "Social Networks"
 msgstr ""
 
-#: mod/settings.php:106 src/Content/Nav.php:254
+#: mod/settings.php:106 src/Content/Nav.php:261
 msgid "Delegations"
 msgstr ""
 
@@ -5740,7 +5637,7 @@ msgstr ""
 msgid "Missing some important data!"
 msgstr ""
 
-#: mod/settings.php:181 mod/settings.php:694 src/Module/Contact.php:826
+#: mod/settings.php:181 mod/settings.php:691 src/Module/Contact.php:823
 msgid "Update"
 msgstr ""
 
@@ -5776,128 +5673,128 @@ msgstr ""
 msgid "Password unchanged."
 msgstr ""
 
-#: mod/settings.php:493
+#: mod/settings.php:491
 msgid " Please use a shorter name."
 msgstr ""
 
-#: mod/settings.php:496
+#: mod/settings.php:494
 msgid " Name too short."
 msgstr ""
 
-#: mod/settings.php:504
+#: mod/settings.php:501
 msgid "Wrong Password"
 msgstr ""
 
-#: mod/settings.php:509
+#: mod/settings.php:506
 msgid "Invalid email."
 msgstr ""
 
-#: mod/settings.php:515
+#: mod/settings.php:512
 msgid "Cannot change to that email."
 msgstr ""
 
-#: mod/settings.php:565
+#: mod/settings.php:562
 msgid "Private forum has no privacy permissions. Using default privacy group."
 msgstr ""
 
-#: mod/settings.php:568
+#: mod/settings.php:565
 msgid "Private forum has no privacy permissions and no default privacy group."
 msgstr ""
 
-#: mod/settings.php:608
+#: mod/settings.php:605
 msgid "Settings updated."
 msgstr ""
 
-#: mod/settings.php:667 mod/settings.php:693 mod/settings.php:727
+#: mod/settings.php:664 mod/settings.php:690 mod/settings.php:724
 msgid "Add application"
 msgstr ""
 
-#: mod/settings.php:671 mod/settings.php:697
+#: mod/settings.php:668 mod/settings.php:694
 msgid "Consumer Key"
 msgstr ""
 
-#: mod/settings.php:672 mod/settings.php:698
+#: mod/settings.php:669 mod/settings.php:695
 msgid "Consumer Secret"
 msgstr ""
 
-#: mod/settings.php:673 mod/settings.php:699
+#: mod/settings.php:670 mod/settings.php:696
 msgid "Redirect"
 msgstr ""
 
-#: mod/settings.php:674 mod/settings.php:700
+#: mod/settings.php:671 mod/settings.php:697
 msgid "Icon url"
 msgstr ""
 
-#: mod/settings.php:685
+#: mod/settings.php:682
 msgid "You can't edit this application."
 msgstr ""
 
-#: mod/settings.php:726
+#: mod/settings.php:723
 msgid "Connected Apps"
 msgstr ""
 
-#: mod/settings.php:728 src/Object/Post.php:163 src/Object/Post.php:165
+#: mod/settings.php:725 src/Object/Post.php:165 src/Object/Post.php:167
 msgid "Edit"
 msgstr ""
 
-#: mod/settings.php:730
+#: mod/settings.php:727
 msgid "Client key starts with"
 msgstr ""
 
-#: mod/settings.php:731
+#: mod/settings.php:728
 msgid "No name"
 msgstr ""
 
-#: mod/settings.php:732
+#: mod/settings.php:729
 msgid "Remove authorization"
 msgstr ""
 
-#: mod/settings.php:743
+#: mod/settings.php:740
 msgid "No Addon settings configured"
 msgstr ""
 
-#: mod/settings.php:752
+#: mod/settings.php:749
 msgid "Addon Settings"
 msgstr ""
 
-#: mod/settings.php:773
+#: mod/settings.php:770
 msgid "Additional Features"
 msgstr ""
 
-#: mod/settings.php:796 src/Content/ContactSelector.php:84
+#: mod/settings.php:793 src/Content/ContactSelector.php:87
 msgid "Diaspora"
 msgstr ""
 
-#: mod/settings.php:796 mod/settings.php:797
+#: mod/settings.php:793 mod/settings.php:794
 msgid "enabled"
 msgstr ""
 
-#: mod/settings.php:796 mod/settings.php:797
+#: mod/settings.php:793 mod/settings.php:794
 msgid "disabled"
 msgstr ""
 
-#: mod/settings.php:796 mod/settings.php:797
+#: mod/settings.php:793 mod/settings.php:794
 #, php-format
 msgid "Built-in support for %s connectivity is %s"
 msgstr ""
 
-#: mod/settings.php:797
+#: mod/settings.php:794
 msgid "GNU Social (OStatus)"
 msgstr ""
 
-#: mod/settings.php:828
+#: mod/settings.php:825
 msgid "Email access is disabled on this site."
 msgstr ""
 
-#: mod/settings.php:838
+#: mod/settings.php:835
 msgid "General Social Media Settings"
 msgstr ""
 
-#: mod/settings.php:839
+#: mod/settings.php:836
 msgid "Disable Content Warning"
 msgstr ""
 
-#: mod/settings.php:839
+#: mod/settings.php:836
 msgid ""
 "Users on networks like Mastodon or Pleroma are able to set a content warning "
 "field which collapse their post by default. This disables the automatic "
@@ -5905,312 +5802,316 @@ msgid ""
 "any other content filtering you eventually set up."
 msgstr ""
 
-#: mod/settings.php:840
+#: mod/settings.php:837
 msgid "Disable intelligent shortening"
 msgstr ""
 
-#: mod/settings.php:840
+#: mod/settings.php:837
 msgid ""
 "Normally the system tries to find the best link to add to shortened posts. "
 "If this option is enabled then every shortened post will always point to the "
 "original friendica post."
 msgstr ""
 
-#: mod/settings.php:841
+#: mod/settings.php:838
 msgid "Automatically follow any GNU Social (OStatus) followers/mentioners"
 msgstr ""
 
-#: mod/settings.php:841
+#: mod/settings.php:838
 msgid ""
 "If you receive a message from an unknown OStatus user, this option decides "
 "what to do. If it is checked, a new contact will be created for every "
 "unknown user."
 msgstr ""
 
-#: mod/settings.php:842
+#: mod/settings.php:839
 msgid "Default group for OStatus contacts"
 msgstr ""
 
-#: mod/settings.php:843
+#: mod/settings.php:840
 msgid "Your legacy GNU Social account"
 msgstr ""
 
-#: mod/settings.php:843
+#: mod/settings.php:840
 msgid ""
 "If you enter your old GNU Social/Statusnet account name here (in the format "
 "user@domain.tld), your contacts will be added automatically. The field will "
 "be emptied when done."
 msgstr ""
 
-#: mod/settings.php:846
+#: mod/settings.php:843
 msgid "Repair OStatus subscriptions"
 msgstr ""
 
-#: mod/settings.php:850
+#: mod/settings.php:847
 msgid "Email/Mailbox Setup"
 msgstr ""
 
-#: mod/settings.php:851
+#: mod/settings.php:848
 msgid ""
 "If you wish to communicate with email contacts using this service "
 "(optional), please specify how to connect to your mailbox."
 msgstr ""
 
-#: mod/settings.php:852
+#: mod/settings.php:849
 msgid "Last successful email check:"
 msgstr ""
 
-#: mod/settings.php:854
+#: mod/settings.php:851
 msgid "IMAP server name:"
 msgstr ""
 
-#: mod/settings.php:855
+#: mod/settings.php:852
 msgid "IMAP port:"
 msgstr ""
 
-#: mod/settings.php:856
+#: mod/settings.php:853
 msgid "Security:"
 msgstr ""
 
-#: mod/settings.php:857
+#: mod/settings.php:853 mod/settings.php:858
+msgid "None"
+msgstr ""
+
+#: mod/settings.php:854
 msgid "Email login name:"
 msgstr ""
 
-#: mod/settings.php:858
+#: mod/settings.php:855
 msgid "Email password:"
 msgstr ""
 
-#: mod/settings.php:859
+#: mod/settings.php:856
 msgid "Reply-to address:"
 msgstr ""
 
-#: mod/settings.php:860
+#: mod/settings.php:857
 msgid "Send public posts to all email contacts:"
 msgstr ""
 
-#: mod/settings.php:861
+#: mod/settings.php:858
 msgid "Action after import:"
 msgstr ""
 
-#: mod/settings.php:861 src/Content/Nav.php:242
+#: mod/settings.php:858 src/Content/Nav.php:249
 msgid "Mark as seen"
 msgstr ""
 
-#: mod/settings.php:861
+#: mod/settings.php:858
 msgid "Move to folder"
 msgstr ""
 
-#: mod/settings.php:862
+#: mod/settings.php:859
 msgid "Move to folder:"
 msgstr ""
 
-#: mod/settings.php:905
+#: mod/settings.php:902
 #, php-format
 msgid "%s - (Unsupported)"
 msgstr ""
 
-#: mod/settings.php:907
+#: mod/settings.php:904
 #, php-format
 msgid "%s - (Experimental)"
 msgstr ""
 
-#: mod/settings.php:934 src/Core/L10n.php:361 src/Model/Event.php:392
+#: mod/settings.php:931 src/Core/L10n.php:368 src/Model/Event.php:396
 msgid "Sunday"
 msgstr ""
 
-#: mod/settings.php:934 src/Core/L10n.php:361 src/Model/Event.php:393
+#: mod/settings.php:931 src/Core/L10n.php:368 src/Model/Event.php:397
 msgid "Monday"
 msgstr ""
 
-#: mod/settings.php:950
+#: mod/settings.php:947
 msgid "Display Settings"
 msgstr ""
 
-#: mod/settings.php:956
+#: mod/settings.php:953
 msgid "Display Theme:"
 msgstr ""
 
-#: mod/settings.php:957
+#: mod/settings.php:954
 msgid "Mobile Theme:"
 msgstr ""
 
-#: mod/settings.php:958
+#: mod/settings.php:955
 msgid "Suppress warning of insecure networks"
 msgstr ""
 
-#: mod/settings.php:958
+#: mod/settings.php:955
 msgid ""
 "Should the system suppress the warning that the current group contains "
 "members of networks that can't receive non public postings."
 msgstr ""
 
-#: mod/settings.php:959
+#: mod/settings.php:956
 msgid "Update browser every xx seconds"
 msgstr ""
 
-#: mod/settings.php:959
+#: mod/settings.php:956
 msgid "Minimum of 10 seconds. Enter -1 to disable it."
 msgstr ""
 
-#: mod/settings.php:960
+#: mod/settings.php:957
 msgid "Number of items to display per page:"
 msgstr ""
 
-#: mod/settings.php:960 mod/settings.php:961
+#: mod/settings.php:957 mod/settings.php:958
 msgid "Maximum of 100 items"
 msgstr ""
 
-#: mod/settings.php:961
+#: mod/settings.php:958
 msgid "Number of items to display per page when viewed from mobile device:"
 msgstr ""
 
-#: mod/settings.php:962
+#: mod/settings.php:959
 msgid "Don't show emoticons"
 msgstr ""
 
-#: mod/settings.php:963
+#: mod/settings.php:960
 msgid "Calendar"
 msgstr ""
 
-#: mod/settings.php:964
+#: mod/settings.php:961
 msgid "Beginning of week:"
 msgstr ""
 
-#: mod/settings.php:965
+#: mod/settings.php:962
 msgid "Don't show notices"
 msgstr ""
 
-#: mod/settings.php:966
+#: mod/settings.php:963
 msgid "Infinite scroll"
 msgstr ""
 
-#: mod/settings.php:967
+#: mod/settings.php:964
 msgid "Automatic updates only at the top of the network page"
 msgstr ""
 
-#: mod/settings.php:967
+#: mod/settings.php:964
 msgid ""
 "When disabled, the network page is updated all the time, which could be "
 "confusing while reading."
 msgstr ""
 
-#: mod/settings.php:968
+#: mod/settings.php:965
 msgid "Bandwidth Saver Mode"
 msgstr ""
 
-#: mod/settings.php:968
+#: mod/settings.php:965
 msgid ""
 "When enabled, embedded content is not displayed on automatic updates, they "
 "only show on page reload."
 msgstr ""
 
-#: mod/settings.php:969
+#: mod/settings.php:966
 msgid "Smart Threading"
 msgstr ""
 
-#: mod/settings.php:969
+#: mod/settings.php:966
 msgid ""
 "When enabled, suppress extraneous thread indentation while keeping it where "
 "it matters. Only works if threading is available and enabled."
 msgstr ""
 
-#: mod/settings.php:971
+#: mod/settings.php:968
 msgid "General Theme Settings"
 msgstr ""
 
-#: mod/settings.php:972
+#: mod/settings.php:969
 msgid "Custom Theme Settings"
 msgstr ""
 
-#: mod/settings.php:973
+#: mod/settings.php:970
 msgid "Content Settings"
 msgstr ""
 
-#: mod/settings.php:974 view/theme/duepuntozero/config.php:74
+#: mod/settings.php:971 view/theme/duepuntozero/config.php:74
 #: view/theme/frio/config.php:121 view/theme/quattro/config.php:76
 #: view/theme/vier/config.php:122
 msgid "Theme settings"
 msgstr ""
 
-#: mod/settings.php:988
+#: mod/settings.php:985
 msgid "Unable to find your profile. Please contact your admin."
 msgstr ""
 
-#: mod/settings.php:1027
+#: mod/settings.php:1024
 msgid "Account Types"
 msgstr ""
 
-#: mod/settings.php:1028
+#: mod/settings.php:1025
 msgid "Personal Page Subtypes"
 msgstr ""
 
-#: mod/settings.php:1029
+#: mod/settings.php:1026
 msgid "Community Forum Subtypes"
 msgstr ""
 
-#: mod/settings.php:1037
+#: mod/settings.php:1034
 msgid "Account for a personal profile."
 msgstr ""
 
-#: mod/settings.php:1041
+#: mod/settings.php:1038
 msgid ""
 "Account for an organisation that automatically approves contact requests as "
 "\"Followers\"."
 msgstr ""
 
-#: mod/settings.php:1045
+#: mod/settings.php:1042
 msgid ""
 "Account for a news reflector that automatically approves contact requests as "
 "\"Followers\"."
 msgstr ""
 
-#: mod/settings.php:1049
+#: mod/settings.php:1046
 msgid "Account for community discussions."
 msgstr ""
 
-#: mod/settings.php:1053
+#: mod/settings.php:1050
 msgid ""
 "Account for a regular personal profile that requires manual approval of "
 "\"Friends\" and \"Followers\"."
 msgstr ""
 
-#: mod/settings.php:1057
+#: mod/settings.php:1054
 msgid ""
 "Account for a public profile that automatically approves contact requests as "
 "\"Followers\"."
 msgstr ""
 
-#: mod/settings.php:1061
+#: mod/settings.php:1058
 msgid "Automatically approves all contact requests."
 msgstr ""
 
-#: mod/settings.php:1065
+#: mod/settings.php:1062
 msgid ""
 "Account for a popular profile that automatically approves contact requests "
 "as \"Friends\"."
 msgstr ""
 
-#: mod/settings.php:1068
+#: mod/settings.php:1065
 msgid "Private Forum [Experimental]"
 msgstr ""
 
-#: mod/settings.php:1069
+#: mod/settings.php:1066
 msgid "Requires manual approval of contact requests."
 msgstr ""
 
-#: mod/settings.php:1080
+#: mod/settings.php:1077
 msgid "OpenID:"
 msgstr ""
 
-#: mod/settings.php:1080
+#: mod/settings.php:1077
 msgid "(Optional) Allow this OpenID to login to this account."
 msgstr ""
 
-#: mod/settings.php:1088
+#: mod/settings.php:1085
 msgid "Publish your default profile in your local site directory?"
 msgstr ""
 
-#: mod/settings.php:1088
+#: mod/settings.php:1085
 #, php-format
 msgid ""
 "Your profile will be published in this node's <a href=\"%s\">local "
@@ -6218,305 +6119,313 @@ msgid ""
 "system settings."
 msgstr ""
 
-#: mod/settings.php:1094
+#: mod/settings.php:1091
 msgid "Publish your default profile in the global social directory?"
 msgstr ""
 
-#: mod/settings.php:1094
+#: mod/settings.php:1091
 #, php-format
 msgid ""
 "Your profile will be published in the global friendica directories (e.g. <a "
 "href=\"%s\">%s</a>). Your profile will be visible in public."
 msgstr ""
 
-#: mod/settings.php:1101
+#: mod/settings.php:1098
 msgid "Hide your contact/friend list from viewers of your default profile?"
 msgstr ""
 
-#: mod/settings.php:1101
+#: mod/settings.php:1098
 msgid ""
 "Your contact list won't be shown in your default profile page. You can "
 "decide to show your contact list separately for each additional profile you "
 "create"
 msgstr ""
 
-#: mod/settings.php:1105
+#: mod/settings.php:1102
 msgid "Hide your profile details from anonymous viewers?"
 msgstr ""
 
-#: mod/settings.php:1105
+#: mod/settings.php:1102
 msgid ""
 "Anonymous visitors will only see your profile picture, your display name and "
 "the nickname you are using on your profile page. Your public posts and "
 "replies will still be accessible by other means."
 msgstr ""
 
-#: mod/settings.php:1109
+#: mod/settings.php:1106
 msgid "Allow friends to post to your profile page?"
 msgstr ""
 
-#: mod/settings.php:1109
+#: mod/settings.php:1106
 msgid ""
 "Your contacts may write posts on your profile wall. These posts will be "
 "distributed to your contacts"
 msgstr ""
 
-#: mod/settings.php:1113
+#: mod/settings.php:1110
 msgid "Allow friends to tag your posts?"
 msgstr ""
 
-#: mod/settings.php:1113
+#: mod/settings.php:1110
 msgid "Your contacts can add additional tags to your posts."
 msgstr ""
 
-#: mod/settings.php:1117
+#: mod/settings.php:1114
 msgid "Allow us to suggest you as a potential friend to new members?"
 msgstr ""
 
-#: mod/settings.php:1117
+#: mod/settings.php:1114
 msgid "If you like, Friendica may suggest new members to add you as a contact."
 msgstr ""
 
-#: mod/settings.php:1121
+#: mod/settings.php:1118
 msgid "Permit unknown people to send you private mail?"
 msgstr ""
 
-#: mod/settings.php:1121
+#: mod/settings.php:1118
 msgid ""
 "Friendica network users may send you private messages even if they are not "
 "in your contact list."
 msgstr ""
 
-#: mod/settings.php:1125
+#: mod/settings.php:1122
 msgid "Profile is <strong>not published</strong>."
 msgstr ""
 
-#: mod/settings.php:1131
+#: mod/settings.php:1128
 #, php-format
 msgid "Your Identity Address is <strong>'%s'</strong> or '%s'."
 msgstr ""
 
-#: mod/settings.php:1138
+#: mod/settings.php:1135
 msgid "Automatically expire posts after this many days:"
 msgstr ""
 
-#: mod/settings.php:1138
+#: mod/settings.php:1135
 msgid "If empty, posts will not expire. Expired posts will be deleted"
 msgstr ""
 
-#: mod/settings.php:1139
+#: mod/settings.php:1136
 msgid "Advanced expiration settings"
 msgstr ""
 
-#: mod/settings.php:1140
+#: mod/settings.php:1137
 msgid "Advanced Expiration"
 msgstr ""
 
-#: mod/settings.php:1141
+#: mod/settings.php:1138
 msgid "Expire posts:"
 msgstr ""
 
-#: mod/settings.php:1142
+#: mod/settings.php:1139
 msgid "Expire personal notes:"
 msgstr ""
 
-#: mod/settings.php:1143
+#: mod/settings.php:1140
 msgid "Expire starred posts:"
 msgstr ""
 
-#: mod/settings.php:1144
+#: mod/settings.php:1141
 msgid "Expire photos:"
 msgstr ""
 
-#: mod/settings.php:1145
+#: mod/settings.php:1142
 msgid "Only expire posts by others:"
 msgstr ""
 
-#: mod/settings.php:1175
+#: mod/settings.php:1172
 msgid "Account Settings"
 msgstr ""
 
-#: mod/settings.php:1183
+#: mod/settings.php:1180
 msgid "Password Settings"
 msgstr ""
 
-#: mod/settings.php:1184
+#: mod/settings.php:1181 src/Module/Register.php:130
+msgid "New Password:"
+msgstr ""
+
+#: mod/settings.php:1181
 msgid ""
 "Allowed characters are a-z, A-Z, 0-9 and special characters except white "
 "spaces, accentuated letters and colon (:)."
 msgstr ""
 
-#: mod/settings.php:1185
+#: mod/settings.php:1182 src/Module/Register.php:131
+msgid "Confirm:"
+msgstr ""
+
+#: mod/settings.php:1182
 msgid "Leave password fields blank unless changing"
 msgstr ""
 
-#: mod/settings.php:1186
+#: mod/settings.php:1183
 msgid "Current Password:"
 msgstr ""
 
-#: mod/settings.php:1186 mod/settings.php:1187
+#: mod/settings.php:1183 mod/settings.php:1184
 msgid "Your current password to confirm the changes"
 msgstr ""
 
-#: mod/settings.php:1187
+#: mod/settings.php:1184
 msgid "Password:"
 msgstr ""
 
-#: mod/settings.php:1191
+#: mod/settings.php:1188
 msgid "Basic Settings"
 msgstr ""
 
-#: mod/settings.php:1192 src/Model/Profile.php:756
+#: mod/settings.php:1189 src/Model/Profile.php:751
 msgid "Full Name:"
 msgstr ""
 
-#: mod/settings.php:1193
+#: mod/settings.php:1190
 msgid "Email Address:"
 msgstr ""
 
-#: mod/settings.php:1194
+#: mod/settings.php:1191
 msgid "Your Timezone:"
 msgstr ""
 
-#: mod/settings.php:1195
+#: mod/settings.php:1192
 msgid "Your Language:"
 msgstr ""
 
-#: mod/settings.php:1195
+#: mod/settings.php:1192
 msgid ""
 "Set the language we use to show you friendica interface and to send you "
 "emails"
 msgstr ""
 
-#: mod/settings.php:1196
+#: mod/settings.php:1193
 msgid "Default Post Location:"
 msgstr ""
 
-#: mod/settings.php:1197
+#: mod/settings.php:1194
 msgid "Use Browser Location:"
 msgstr ""
 
-#: mod/settings.php:1200
+#: mod/settings.php:1197
 msgid "Security and Privacy Settings"
 msgstr ""
 
-#: mod/settings.php:1202
+#: mod/settings.php:1199
 msgid "Maximum Friend Requests/Day:"
 msgstr ""
 
-#: mod/settings.php:1202 mod/settings.php:1231
+#: mod/settings.php:1199 mod/settings.php:1228
 msgid "(to prevent spam abuse)"
 msgstr ""
 
-#: mod/settings.php:1203
+#: mod/settings.php:1200
 msgid "Default Post Permissions"
 msgstr ""
 
-#: mod/settings.php:1204
+#: mod/settings.php:1201
 msgid "(click to open/close)"
 msgstr ""
 
-#: mod/settings.php:1214
+#: mod/settings.php:1211
 msgid "Default Private Post"
 msgstr ""
 
-#: mod/settings.php:1215
+#: mod/settings.php:1212
 msgid "Default Public Post"
 msgstr ""
 
-#: mod/settings.php:1219
+#: mod/settings.php:1216
 msgid "Default Permissions for New Posts"
 msgstr ""
 
-#: mod/settings.php:1231
+#: mod/settings.php:1228
 msgid "Maximum private messages per day from unknown people:"
 msgstr ""
 
-#: mod/settings.php:1234
+#: mod/settings.php:1231
 msgid "Notification Settings"
 msgstr ""
 
-#: mod/settings.php:1235
+#: mod/settings.php:1232
 msgid "Send a notification email when:"
 msgstr ""
 
-#: mod/settings.php:1236
+#: mod/settings.php:1233
 msgid "You receive an introduction"
 msgstr ""
 
-#: mod/settings.php:1237
+#: mod/settings.php:1234
 msgid "Your introductions are confirmed"
 msgstr ""
 
-#: mod/settings.php:1238
+#: mod/settings.php:1235
 msgid "Someone writes on your profile wall"
 msgstr ""
 
-#: mod/settings.php:1239
+#: mod/settings.php:1236
 msgid "Someone writes a followup comment"
 msgstr ""
 
-#: mod/settings.php:1240
+#: mod/settings.php:1237
 msgid "You receive a private message"
 msgstr ""
 
-#: mod/settings.php:1241
+#: mod/settings.php:1238
 msgid "You receive a friend suggestion"
 msgstr ""
 
-#: mod/settings.php:1242
+#: mod/settings.php:1239
 msgid "You are tagged in a post"
 msgstr ""
 
-#: mod/settings.php:1243
+#: mod/settings.php:1240
 msgid "You are poked/prodded/etc. in a post"
 msgstr ""
 
-#: mod/settings.php:1245
+#: mod/settings.php:1242
 msgid "Activate desktop notifications"
 msgstr ""
 
-#: mod/settings.php:1245
+#: mod/settings.php:1242
 msgid "Show desktop popup on new notifications"
 msgstr ""
 
-#: mod/settings.php:1247
+#: mod/settings.php:1244
 msgid "Text-only notification emails"
 msgstr ""
 
-#: mod/settings.php:1249
+#: mod/settings.php:1246
 msgid "Send text only notification emails, without the html part"
 msgstr ""
 
-#: mod/settings.php:1251
+#: mod/settings.php:1248
 msgid "Show detailled notifications"
 msgstr ""
 
-#: mod/settings.php:1253
+#: mod/settings.php:1250
 msgid ""
 "Per default, notifications are condensed to a single notification per item. "
 "When enabled every notification is displayed."
 msgstr ""
 
-#: mod/settings.php:1255
+#: mod/settings.php:1252
 msgid "Advanced Account/Page Type Settings"
 msgstr ""
 
-#: mod/settings.php:1256
+#: mod/settings.php:1253
 msgid "Change the behaviour of this account for special situations"
 msgstr ""
 
-#: mod/settings.php:1259
+#: mod/settings.php:1256
 msgid "Relocate"
 msgstr ""
 
-#: mod/settings.php:1260
+#: mod/settings.php:1257
 msgid ""
 "If you have moved this profile from another server, and some of your "
 "contacts don't receive your updates, try pushing this button."
 msgstr ""
 
-#: mod/settings.php:1261
+#: mod/settings.php:1258
 msgid "Resend relocate message to contacts"
 msgstr ""
 
@@ -6535,11 +6444,11 @@ msgid ""
 "hours."
 msgstr ""
 
-#: mod/suggest.php:88 mod/suggest.php:108
+#: mod/suggest.php:89 mod/suggest.php:109
 msgid "Ignore/Hide"
 msgstr ""
 
-#: mod/suggest.php:118 src/Content/Widget.php:66 view/theme/vier/theme.php:204
+#: mod/suggest.php:119 src/Content/Widget.php:66 view/theme/vier/theme.php:204
 msgid "Friend Suggestions"
 msgstr ""
 
@@ -6547,11 +6456,11 @@ msgstr ""
 msgid "Tag(s) removed"
 msgstr ""
 
-#: mod/tagrm.php:99
+#: mod/tagrm.php:101
 msgid "Remove Item Tag"
 msgstr ""
 
-#: mod/tagrm.php:101
+#: mod/tagrm.php:103
 msgid "Select a tag to remove: "
 msgstr ""
 
@@ -6578,6 +6487,16 @@ msgstr ""
 
 #: mod/uimport.php:30
 msgid "User imports on closed servers can only be done by an administrator."
+msgstr ""
+
+#: mod/uimport.php:39 src/Module/Register.php:59
+msgid ""
+"This site has exceeded the number of allowed daily account registrations. "
+"Please try again tomorrow."
+msgstr ""
+
+#: mod/uimport.php:54 src/Module/Register.php:141
+msgid "Import"
 msgstr ""
 
 #: mod/uimport.php:56
@@ -6623,37 +6542,37 @@ msgstr ""
 msgid "Contact unfollowed"
 msgstr ""
 
-#: mod/unfollow.php:118 src/Module/Contact.php:572
+#: mod/unfollow.php:118 src/Module/Contact.php:570
 msgid "Disconnect/Unfollow"
 msgstr ""
 
 #: mod/update_community.php:23 mod/update_contact.php:23
 #: mod/update_display.php:24 mod/update_network.php:33 mod/update_notes.php:36
-#: mod/update_profile.php:35
+#: mod/update_profile.php:34
 msgid "[Embedded content - reload page to view]"
 msgstr ""
 
-#: mod/videos.php:98
+#: mod/videos.php:97
 msgid "Do you really want to delete this video?"
 msgstr ""
 
-#: mod/videos.php:103
+#: mod/videos.php:102
 msgid "Delete Video"
 msgstr ""
 
-#: mod/videos.php:153
+#: mod/videos.php:152
 msgid "No videos selected"
 msgstr ""
 
-#: mod/videos.php:324 src/Model/Item.php:3388
+#: mod/videos.php:309 src/Model/Item.php:3435
 msgid "View Video"
 msgstr ""
 
-#: mod/videos.php:339
+#: mod/videos.php:324
 msgid "Recent Videos"
 msgstr ""
 
-#: mod/videos.php:341
+#: mod/videos.php:326
 msgid "Upload New Videos"
 msgstr ""
 
@@ -6661,16 +6580,16 @@ msgstr ""
 msgid "No contacts."
 msgstr ""
 
-#: mod/viewcontacts.php:94 src/Module/Contact.php:605
-#: src/Module/Contact.php:1027
+#: mod/viewcontacts.php:94 src/Module/Contact.php:603
+#: src/Module/Contact.php:1024
 #, php-format
 msgid "Visit %s's profile [%s]"
 msgstr ""
 
-#: mod/viewcontacts.php:114 src/Content/Nav.php:196 src/Content/Nav.php:262
-#: src/Content/Text/HTML.php:979 src/Model/Profile.php:985
-#: src/Model/Profile.php:988 src/Module/Contact.php:814
-#: src/Module/Contact.php:884 view/theme/frio/theme.php:271
+#: mod/viewcontacts.php:114 src/Content/Nav.php:203 src/Content/Nav.php:269
+#: src/Content/Text/HTML.php:911 src/Model/Profile.php:980
+#: src/Model/Profile.php:983 src/Module/Contact.php:811
+#: src/Module/Contact.php:881 view/theme/frio/theme.php:273
 msgid "Contacts"
 msgstr ""
 
@@ -6694,47 +6613,47 @@ msgid ""
 "your site allow private mail from unknown senders."
 msgstr ""
 
-#: mod/wall_attach.php:26 mod/wall_attach.php:33 mod/wall_attach.php:88
-#: mod/wall_upload.php:41 mod/wall_upload.php:57 mod/wall_upload.php:115
-#: mod/wall_upload.php:166 mod/wall_upload.php:169
+#: mod/wall_attach.php:26 mod/wall_attach.php:33 mod/wall_attach.php:85
+#: mod/wall_upload.php:42 mod/wall_upload.php:58 mod/wall_upload.php:116
+#: mod/wall_upload.php:167 mod/wall_upload.php:170
 msgid "Invalid request."
 msgstr ""
 
-#: mod/wall_attach.php:106
+#: mod/wall_attach.php:103
 msgid "Sorry, maybe your upload is bigger than the PHP configuration allows"
 msgstr ""
 
-#: mod/wall_attach.php:106
+#: mod/wall_attach.php:103
 msgid "Or - did you try to upload an empty file?"
 msgstr ""
 
-#: mod/wall_attach.php:117
+#: mod/wall_attach.php:114
 #, php-format
 msgid "File exceeds size limit of %s"
 msgstr ""
 
-#: mod/wall_attach.php:132
+#: mod/wall_attach.php:129
 msgid "File upload failed."
 msgstr ""
 
-#: mod/wall_upload.php:242 src/Object/Image.php:968 src/Object/Image.php:984
-#: src/Object/Image.php:992 src/Object/Image.php:1017
+#: mod/wall_upload.php:243 src/Object/Image.php:967 src/Object/Image.php:983
+#: src/Object/Image.php:991 src/Object/Image.php:1016
 msgid "Wall Photos"
 msgstr ""
 
-#: src/App.php:822
+#: src/App.php:665
 msgid "Delete this item?"
 msgstr ""
 
-#: src/App.php:824
+#: src/App.php:667
 msgid "show fewer"
 msgstr ""
 
-#: src/App.php:866
+#: src/App.php:709
 msgid "toggle mobile"
 msgstr ""
 
-#: src/App.php:1419
+#: src/App.php:1077
 msgid "No system theme config value set."
 msgstr ""
 
@@ -6744,741 +6663,745 @@ msgid ""
 "form has been opened for too long (>3 hours) before submitting it."
 msgstr ""
 
-#: src/Content/ContactSelector.php:56
+#: src/Content/ContactSelector.php:58
 msgid "Frequently"
 msgstr ""
 
-#: src/Content/ContactSelector.php:57
+#: src/Content/ContactSelector.php:59
 msgid "Hourly"
 msgstr ""
 
-#: src/Content/ContactSelector.php:58
+#: src/Content/ContactSelector.php:60
 msgid "Twice daily"
 msgstr ""
 
-#: src/Content/ContactSelector.php:59
+#: src/Content/ContactSelector.php:61
 msgid "Daily"
 msgstr ""
 
-#: src/Content/ContactSelector.php:60
+#: src/Content/ContactSelector.php:62
 msgid "Weekly"
 msgstr ""
 
-#: src/Content/ContactSelector.php:61
+#: src/Content/ContactSelector.php:63
 msgid "Monthly"
 msgstr ""
 
-#: src/Content/ContactSelector.php:80
+#: src/Content/ContactSelector.php:83
 msgid "DFRN"
 msgstr ""
 
-#: src/Content/ContactSelector.php:81
+#: src/Content/ContactSelector.php:84
 msgid "OStatus"
 msgstr ""
 
-#: src/Content/ContactSelector.php:82
+#: src/Content/ContactSelector.php:85
 msgid "RSS/Atom"
 msgstr ""
 
-#: src/Content/ContactSelector.php:85
+#: src/Content/ContactSelector.php:88
 msgid "Zot!"
 msgstr ""
 
-#: src/Content/ContactSelector.php:86
+#: src/Content/ContactSelector.php:89
 msgid "LinkedIn"
 msgstr ""
 
-#: src/Content/ContactSelector.php:87
+#: src/Content/ContactSelector.php:90
 msgid "XMPP/IM"
 msgstr ""
 
-#: src/Content/ContactSelector.php:88
+#: src/Content/ContactSelector.php:91
 msgid "MySpace"
 msgstr ""
 
-#: src/Content/ContactSelector.php:89
+#: src/Content/ContactSelector.php:92
 msgid "Google+"
 msgstr ""
 
-#: src/Content/ContactSelector.php:90
+#: src/Content/ContactSelector.php:93
 msgid "pump.io"
 msgstr ""
 
-#: src/Content/ContactSelector.php:91
+#: src/Content/ContactSelector.php:94
 msgid "Twitter"
 msgstr ""
 
-#: src/Content/ContactSelector.php:92
+#: src/Content/ContactSelector.php:95
 msgid "Diaspora Connector"
 msgstr ""
 
-#: src/Content/ContactSelector.php:93
+#: src/Content/ContactSelector.php:96
 msgid "GNU Social Connector"
 msgstr ""
 
-#: src/Content/ContactSelector.php:94
+#: src/Content/ContactSelector.php:97
 msgid "ActivityPub"
 msgstr ""
 
-#: src/Content/ContactSelector.php:95
+#: src/Content/ContactSelector.php:98
 msgid "pnut"
 msgstr ""
 
-#: src/Content/ContactSelector.php:150
+#: src/Content/ContactSelector.php:154
 msgid "Male"
 msgstr ""
 
-#: src/Content/ContactSelector.php:151
+#: src/Content/ContactSelector.php:155
 msgid "Female"
 msgstr ""
 
-#: src/Content/ContactSelector.php:152
+#: src/Content/ContactSelector.php:156
 msgid "Currently Male"
 msgstr ""
 
-#: src/Content/ContactSelector.php:153
+#: src/Content/ContactSelector.php:157
 msgid "Currently Female"
 msgstr ""
 
-#: src/Content/ContactSelector.php:154
+#: src/Content/ContactSelector.php:158
 msgid "Mostly Male"
 msgstr ""
 
-#: src/Content/ContactSelector.php:155
+#: src/Content/ContactSelector.php:159
 msgid "Mostly Female"
 msgstr ""
 
-#: src/Content/ContactSelector.php:156
+#: src/Content/ContactSelector.php:160
 msgid "Transgender"
 msgstr ""
 
-#: src/Content/ContactSelector.php:157
+#: src/Content/ContactSelector.php:161
 msgid "Intersex"
 msgstr ""
 
-#: src/Content/ContactSelector.php:158
+#: src/Content/ContactSelector.php:162
 msgid "Transsexual"
 msgstr ""
 
-#: src/Content/ContactSelector.php:159
+#: src/Content/ContactSelector.php:163
 msgid "Hermaphrodite"
 msgstr ""
 
-#: src/Content/ContactSelector.php:160
+#: src/Content/ContactSelector.php:164
 msgid "Neuter"
 msgstr ""
 
-#: src/Content/ContactSelector.php:161
+#: src/Content/ContactSelector.php:165
 msgid "Non-specific"
 msgstr ""
 
-#: src/Content/ContactSelector.php:162
+#: src/Content/ContactSelector.php:166
 msgid "Other"
 msgstr ""
 
-#: src/Content/ContactSelector.php:189
+#: src/Content/ContactSelector.php:194
 msgid "Males"
 msgstr ""
 
-#: src/Content/ContactSelector.php:190
+#: src/Content/ContactSelector.php:195
 msgid "Females"
 msgstr ""
 
-#: src/Content/ContactSelector.php:191
+#: src/Content/ContactSelector.php:196
 msgid "Gay"
 msgstr ""
 
-#: src/Content/ContactSelector.php:192
+#: src/Content/ContactSelector.php:197
 msgid "Lesbian"
 msgstr ""
 
-#: src/Content/ContactSelector.php:193
+#: src/Content/ContactSelector.php:198
 msgid "No Preference"
 msgstr ""
 
-#: src/Content/ContactSelector.php:194
+#: src/Content/ContactSelector.php:199
 msgid "Bisexual"
 msgstr ""
 
-#: src/Content/ContactSelector.php:195
+#: src/Content/ContactSelector.php:200
 msgid "Autosexual"
 msgstr ""
 
-#: src/Content/ContactSelector.php:196
+#: src/Content/ContactSelector.php:201
 msgid "Abstinent"
 msgstr ""
 
-#: src/Content/ContactSelector.php:197
+#: src/Content/ContactSelector.php:202
 msgid "Virgin"
 msgstr ""
 
-#: src/Content/ContactSelector.php:198
+#: src/Content/ContactSelector.php:203
 msgid "Deviant"
 msgstr ""
 
-#: src/Content/ContactSelector.php:199
+#: src/Content/ContactSelector.php:204
 msgid "Fetish"
 msgstr ""
 
-#: src/Content/ContactSelector.php:200
+#: src/Content/ContactSelector.php:205
 msgid "Oodles"
 msgstr ""
 
-#: src/Content/ContactSelector.php:201
+#: src/Content/ContactSelector.php:206
 msgid "Nonsexual"
 msgstr ""
 
-#: src/Content/ContactSelector.php:226
+#: src/Content/ContactSelector.php:232
 msgid "Single"
 msgstr ""
 
-#: src/Content/ContactSelector.php:227
+#: src/Content/ContactSelector.php:233
 msgid "Lonely"
 msgstr ""
 
-#: src/Content/ContactSelector.php:228
+#: src/Content/ContactSelector.php:234
 msgid "Available"
 msgstr ""
 
-#: src/Content/ContactSelector.php:229
+#: src/Content/ContactSelector.php:235
 msgid "Unavailable"
 msgstr ""
 
-#: src/Content/ContactSelector.php:230
+#: src/Content/ContactSelector.php:236
 msgid "Has crush"
 msgstr ""
 
-#: src/Content/ContactSelector.php:231
+#: src/Content/ContactSelector.php:237
 msgid "Infatuated"
 msgstr ""
 
-#: src/Content/ContactSelector.php:232
+#: src/Content/ContactSelector.php:238
 msgid "Dating"
 msgstr ""
 
-#: src/Content/ContactSelector.php:233
+#: src/Content/ContactSelector.php:239
 msgid "Unfaithful"
 msgstr ""
 
-#: src/Content/ContactSelector.php:234
+#: src/Content/ContactSelector.php:240
 msgid "Sex Addict"
 msgstr ""
 
-#: src/Content/ContactSelector.php:235 src/Model/User.php:647
+#: src/Content/ContactSelector.php:241 src/Model/User.php:701
 msgid "Friends"
 msgstr ""
 
-#: src/Content/ContactSelector.php:236
+#: src/Content/ContactSelector.php:242
 msgid "Friends/Benefits"
 msgstr ""
 
-#: src/Content/ContactSelector.php:237
+#: src/Content/ContactSelector.php:243
 msgid "Casual"
 msgstr ""
 
-#: src/Content/ContactSelector.php:238
+#: src/Content/ContactSelector.php:244
 msgid "Engaged"
 msgstr ""
 
-#: src/Content/ContactSelector.php:239
+#: src/Content/ContactSelector.php:245
 msgid "Married"
 msgstr ""
 
-#: src/Content/ContactSelector.php:240
+#: src/Content/ContactSelector.php:246
 msgid "Imaginarily married"
 msgstr ""
 
-#: src/Content/ContactSelector.php:241
+#: src/Content/ContactSelector.php:247
 msgid "Partners"
 msgstr ""
 
-#: src/Content/ContactSelector.php:242
+#: src/Content/ContactSelector.php:248
 msgid "Cohabiting"
 msgstr ""
 
-#: src/Content/ContactSelector.php:243
+#: src/Content/ContactSelector.php:249
 msgid "Common law"
 msgstr ""
 
-#: src/Content/ContactSelector.php:244
+#: src/Content/ContactSelector.php:250
 msgid "Happy"
 msgstr ""
 
-#: src/Content/ContactSelector.php:245
+#: src/Content/ContactSelector.php:251
 msgid "Not looking"
 msgstr ""
 
-#: src/Content/ContactSelector.php:246
+#: src/Content/ContactSelector.php:252
 msgid "Swinger"
 msgstr ""
 
-#: src/Content/ContactSelector.php:247
+#: src/Content/ContactSelector.php:253
 msgid "Betrayed"
 msgstr ""
 
-#: src/Content/ContactSelector.php:248
+#: src/Content/ContactSelector.php:254
 msgid "Separated"
 msgstr ""
 
-#: src/Content/ContactSelector.php:249
+#: src/Content/ContactSelector.php:255
 msgid "Unstable"
 msgstr ""
 
-#: src/Content/ContactSelector.php:250
+#: src/Content/ContactSelector.php:256
 msgid "Divorced"
 msgstr ""
 
-#: src/Content/ContactSelector.php:251
+#: src/Content/ContactSelector.php:257
 msgid "Imaginarily divorced"
 msgstr ""
 
-#: src/Content/ContactSelector.php:252
+#: src/Content/ContactSelector.php:258
 msgid "Widowed"
 msgstr ""
 
-#: src/Content/ContactSelector.php:253
+#: src/Content/ContactSelector.php:259
 msgid "Uncertain"
 msgstr ""
 
-#: src/Content/ContactSelector.php:254
+#: src/Content/ContactSelector.php:260
 msgid "It's complicated"
 msgstr ""
 
-#: src/Content/ContactSelector.php:255
+#: src/Content/ContactSelector.php:261
 msgid "Don't care"
 msgstr ""
 
-#: src/Content/ContactSelector.php:256
+#: src/Content/ContactSelector.php:262
 msgid "Ask me"
 msgstr ""
 
-#: src/Content/Feature.php:79
+#: src/Content/Feature.php:82
 msgid "General Features"
 msgstr ""
 
-#: src/Content/Feature.php:81
+#: src/Content/Feature.php:84
 msgid "Multiple Profiles"
 msgstr ""
 
-#: src/Content/Feature.php:81
+#: src/Content/Feature.php:84
 msgid "Ability to create multiple profiles"
 msgstr ""
 
-#: src/Content/Feature.php:82
+#: src/Content/Feature.php:85
 msgid "Photo Location"
 msgstr ""
 
-#: src/Content/Feature.php:82
+#: src/Content/Feature.php:85
 msgid ""
 "Photo metadata is normally stripped. This extracts the location (if present) "
 "prior to stripping metadata and links it to a map."
 msgstr ""
 
-#: src/Content/Feature.php:83
+#: src/Content/Feature.php:86
 msgid "Export Public Calendar"
 msgstr ""
 
-#: src/Content/Feature.php:83
+#: src/Content/Feature.php:86
 msgid "Ability for visitors to download the public calendar"
 msgstr ""
 
-#: src/Content/Feature.php:88
+#: src/Content/Feature.php:91
 msgid "Post Composition Features"
 msgstr ""
 
-#: src/Content/Feature.php:89
+#: src/Content/Feature.php:92
 msgid "Auto-mention Forums"
 msgstr ""
 
-#: src/Content/Feature.php:89
+#: src/Content/Feature.php:92
 msgid ""
 "Add/remove mention when a forum page is selected/deselected in ACL window."
 msgstr ""
 
-#: src/Content/Feature.php:94
+#: src/Content/Feature.php:97
 msgid "Network Sidebar"
 msgstr ""
 
-#: src/Content/Feature.php:95
+#: src/Content/Feature.php:98
 msgid "Ability to select posts by date ranges"
 msgstr ""
 
-#: src/Content/Feature.php:96
+#: src/Content/Feature.php:99
 msgid "Protocol Filter"
 msgstr ""
 
-#: src/Content/Feature.php:96
+#: src/Content/Feature.php:99
 msgid "Enable widget to display Network posts only from selected protocols"
 msgstr ""
 
-#: src/Content/Feature.php:101
+#: src/Content/Feature.php:104
 msgid "Network Tabs"
 msgstr ""
 
-#: src/Content/Feature.php:102
+#: src/Content/Feature.php:105
 msgid "Network New Tab"
 msgstr ""
 
-#: src/Content/Feature.php:102
+#: src/Content/Feature.php:105
 msgid "Enable tab to display only new Network posts (from the last 12 hours)"
 msgstr ""
 
-#: src/Content/Feature.php:103
+#: src/Content/Feature.php:106
 msgid "Network Shared Links Tab"
 msgstr ""
 
-#: src/Content/Feature.php:103
+#: src/Content/Feature.php:106
 msgid "Enable tab to display only Network posts with links in them"
 msgstr ""
 
-#: src/Content/Feature.php:108
+#: src/Content/Feature.php:111
 msgid "Post/Comment Tools"
 msgstr ""
 
-#: src/Content/Feature.php:109
+#: src/Content/Feature.php:112
 msgid "Post Categories"
 msgstr ""
 
-#: src/Content/Feature.php:109
+#: src/Content/Feature.php:112
 msgid "Add categories to your posts"
 msgstr ""
 
-#: src/Content/Feature.php:114
+#: src/Content/Feature.php:117
 msgid "Advanced Profile Settings"
 msgstr ""
 
-#: src/Content/Feature.php:115
+#: src/Content/Feature.php:118
 msgid "List Forums"
 msgstr ""
 
-#: src/Content/Feature.php:115
+#: src/Content/Feature.php:118
 msgid "Show visitors public community forums at the Advanced Profile Page"
 msgstr ""
 
-#: src/Content/Feature.php:116
+#: src/Content/Feature.php:119
 msgid "Tag Cloud"
 msgstr ""
 
-#: src/Content/Feature.php:116
+#: src/Content/Feature.php:119
 msgid "Provide a personal tag cloud on your profile page"
 msgstr ""
 
-#: src/Content/Feature.php:117
+#: src/Content/Feature.php:120
 msgid "Display Membership Date"
 msgstr ""
 
-#: src/Content/Feature.php:117
+#: src/Content/Feature.php:120
 msgid "Display membership date in profile"
 msgstr ""
 
-#: src/Content/ForumManager.php:126 src/Content/Nav.php:200
-#: src/Content/Text/HTML.php:982 view/theme/vier/theme.php:250
+#: src/Content/ForumManager.php:130 src/Content/Nav.php:207
+#: src/Content/Text/HTML.php:914 view/theme/vier/theme.php:250
 msgid "Forums"
 msgstr ""
 
-#: src/Content/ForumManager.php:128 view/theme/vier/theme.php:252
+#: src/Content/ForumManager.php:132 view/theme/vier/theme.php:252
 msgid "External link to forum"
 msgstr ""
 
-#: src/Content/Nav.php:68
+#: src/Content/Nav.php:74
 msgid "Nothing new here"
 msgstr ""
 
-#: src/Content/Nav.php:72
+#: src/Content/Nav.php:78
 msgid "Clear notifications"
 msgstr ""
 
-#: src/Content/Nav.php:73 src/Content/Text/HTML.php:971
+#: src/Content/Nav.php:79 src/Content/Text/HTML.php:903
 msgid "@name, !forum, #tags, content"
 msgstr ""
 
-#: src/Content/Nav.php:146 src/Module/Login.php:318
-#: view/theme/frio/theme.php:257
+#: src/Content/Nav.php:153 src/Module/Login.php:321
+#: view/theme/frio/theme.php:259
 msgid "Logout"
 msgstr ""
 
-#: src/Content/Nav.php:146 view/theme/frio/theme.php:257
+#: src/Content/Nav.php:153 view/theme/frio/theme.php:259
 msgid "End this session"
 msgstr ""
 
-#: src/Content/Nav.php:149 src/Model/Profile.php:906 src/Module/Contact.php:655
-#: src/Module/Contact.php:856 view/theme/frio/theme.php:260
+#: src/Content/Nav.php:156 src/Model/Profile.php:901 src/Module/Contact.php:652
+#: src/Module/Contact.php:853 view/theme/frio/theme.php:262
 msgid "Status"
 msgstr ""
 
-#: src/Content/Nav.php:149 src/Content/Nav.php:235
-#: view/theme/frio/theme.php:260
+#: src/Content/Nav.php:156 src/Content/Nav.php:242
+#: view/theme/frio/theme.php:262
 msgid "Your posts and conversations"
 msgstr ""
 
-#: src/Content/Nav.php:150 view/theme/frio/theme.php:261
+#: src/Content/Nav.php:157 view/theme/frio/theme.php:263
 msgid "Your profile page"
 msgstr ""
 
-#: src/Content/Nav.php:151 view/theme/frio/theme.php:262
+#: src/Content/Nav.php:158 view/theme/frio/theme.php:264
 msgid "Your photos"
 msgstr ""
 
-#: src/Content/Nav.php:152 src/Model/Profile.php:930 src/Model/Profile.php:933
-#: view/theme/frio/theme.php:263
+#: src/Content/Nav.php:159 src/Model/Profile.php:925 src/Model/Profile.php:928
+#: view/theme/frio/theme.php:265
 msgid "Videos"
 msgstr ""
 
-#: src/Content/Nav.php:152 view/theme/frio/theme.php:263
+#: src/Content/Nav.php:159 view/theme/frio/theme.php:265
 msgid "Your videos"
 msgstr ""
 
-#: src/Content/Nav.php:153 view/theme/frio/theme.php:264
+#: src/Content/Nav.php:160 view/theme/frio/theme.php:266
 msgid "Your events"
 msgstr ""
 
-#: src/Content/Nav.php:154
+#: src/Content/Nav.php:161
 msgid "Personal notes"
 msgstr ""
 
-#: src/Content/Nav.php:154
+#: src/Content/Nav.php:161
 msgid "Your personal notes"
 msgstr ""
 
-#: src/Content/Nav.php:163
+#: src/Content/Nav.php:170
 msgid "Sign in"
 msgstr ""
 
-#: src/Content/Nav.php:173 src/Content/Nav.php:235
-#: src/Core/NotificationsManager.php:192
+#: src/Content/Nav.php:180 src/Content/Nav.php:242
+#: src/Core/NotificationsManager.php:196
 msgid "Home"
 msgstr ""
 
-#: src/Content/Nav.php:173
+#: src/Content/Nav.php:180
 msgid "Home Page"
 msgstr ""
 
-#: src/Content/Nav.php:177
+#: src/Content/Nav.php:184 src/Module/Login.php:293 src/Module/Register.php:136
+msgid "Register"
+msgstr ""
+
+#: src/Content/Nav.php:184
 msgid "Create an account"
 msgstr ""
 
-#: src/Content/Nav.php:183
+#: src/Content/Nav.php:190
 msgid "Help and documentation"
 msgstr ""
 
-#: src/Content/Nav.php:187
+#: src/Content/Nav.php:194
 msgid "Apps"
 msgstr ""
 
-#: src/Content/Nav.php:187
+#: src/Content/Nav.php:194
 msgid "Addon applications, utilities, games"
 msgstr ""
 
-#: src/Content/Nav.php:191
+#: src/Content/Nav.php:198
 msgid "Search site content"
 msgstr ""
 
-#: src/Content/Nav.php:194 src/Content/Text/HTML.php:977
+#: src/Content/Nav.php:201 src/Content/Text/HTML.php:909
 msgid "Full Text"
 msgstr ""
 
-#: src/Content/Nav.php:195 src/Content/Text/HTML.php:978
-#: src/Content/Widget/TagCloud.php:53
+#: src/Content/Nav.php:202 src/Content/Text/HTML.php:910
+#: src/Content/Widget/TagCloud.php:54
 msgid "Tags"
 msgstr ""
 
-#: src/Content/Nav.php:215
+#: src/Content/Nav.php:222
 msgid "Community"
 msgstr ""
 
-#: src/Content/Nav.php:215
+#: src/Content/Nav.php:222
 msgid "Conversations on this and other servers"
 msgstr ""
 
-#: src/Content/Nav.php:219 src/Model/Profile.php:945 src/Model/Profile.php:956
-#: view/theme/frio/theme.php:268
+#: src/Content/Nav.php:226 src/Model/Profile.php:940 src/Model/Profile.php:951
+#: view/theme/frio/theme.php:270
 msgid "Events and Calendar"
 msgstr ""
 
-#: src/Content/Nav.php:222
+#: src/Content/Nav.php:229
 msgid "Directory"
 msgstr ""
 
-#: src/Content/Nav.php:222
+#: src/Content/Nav.php:229
 msgid "People directory"
 msgstr ""
 
-#: src/Content/Nav.php:224
+#: src/Content/Nav.php:231
 msgid "Information about this friendica instance"
 msgstr ""
 
-#: src/Content/Nav.php:227
+#: src/Content/Nav.php:234
 msgid "Terms of Service of this Friendica instance"
 msgstr ""
 
-#: src/Content/Nav.php:232 view/theme/frio/theme.php:267
+#: src/Content/Nav.php:239 view/theme/frio/theme.php:269
 msgid "Conversations from your friends"
 msgstr ""
 
-#: src/Content/Nav.php:233
+#: src/Content/Nav.php:240
 msgid "Network Reset"
 msgstr ""
 
-#: src/Content/Nav.php:233
+#: src/Content/Nav.php:240
 msgid "Load Network page with no filters"
 msgstr ""
 
-#: src/Content/Nav.php:239 src/Core/NotificationsManager.php:199
+#: src/Content/Nav.php:246 src/Core/NotificationsManager.php:203
 msgid "Introductions"
 msgstr ""
 
-#: src/Content/Nav.php:239
+#: src/Content/Nav.php:246
 msgid "Friend Requests"
 msgstr ""
 
-#: src/Content/Nav.php:241
+#: src/Content/Nav.php:248
 msgid "See all notifications"
 msgstr ""
 
-#: src/Content/Nav.php:242
+#: src/Content/Nav.php:249
 msgid "Mark all system notifications seen"
 msgstr ""
 
-#: src/Content/Nav.php:245 view/theme/frio/theme.php:269
+#: src/Content/Nav.php:252 view/theme/frio/theme.php:271
 msgid "Private mail"
 msgstr ""
 
-#: src/Content/Nav.php:246
+#: src/Content/Nav.php:253
 msgid "Inbox"
 msgstr ""
 
-#: src/Content/Nav.php:247
+#: src/Content/Nav.php:254
 msgid "Outbox"
 msgstr ""
 
-#: src/Content/Nav.php:251
+#: src/Content/Nav.php:258
 msgid "Manage"
 msgstr ""
 
-#: src/Content/Nav.php:251
+#: src/Content/Nav.php:258
 msgid "Manage other pages"
 msgstr ""
 
-#: src/Content/Nav.php:256 view/theme/frio/theme.php:270
+#: src/Content/Nav.php:263 view/theme/frio/theme.php:272
 msgid "Account settings"
 msgstr ""
 
-#: src/Content/Nav.php:259
+#: src/Content/Nav.php:266
 msgid "Manage/Edit Profiles"
 msgstr ""
 
-#: src/Content/Nav.php:262 view/theme/frio/theme.php:271
+#: src/Content/Nav.php:269 view/theme/frio/theme.php:273
 msgid "Manage/edit friends and contacts"
 msgstr ""
 
-#: src/Content/Nav.php:267
+#: src/Content/Nav.php:274
 msgid "Site setup and configuration"
 msgstr ""
 
-#: src/Content/Nav.php:270
+#: src/Content/Nav.php:277
 msgid "Navigation"
 msgstr ""
 
-#: src/Content/Nav.php:270
+#: src/Content/Nav.php:277
 msgid "Site map"
 msgstr ""
 
-#: src/Content/OEmbed.php:255
+#: src/Content/OEmbed.php:256
 msgid "Embedding disabled"
 msgstr ""
 
-#: src/Content/OEmbed.php:375
+#: src/Content/OEmbed.php:379
 msgid "Embedded content"
 msgstr ""
 
-#: src/Content/Pager.php:152
+#: src/Content/Pager.php:153
 msgid "newer"
 msgstr ""
 
-#: src/Content/Pager.php:157
+#: src/Content/Pager.php:158
 msgid "older"
 msgstr ""
 
-#: src/Content/Pager.php:201
+#: src/Content/Pager.php:203
 msgid "prev"
 msgstr ""
 
-#: src/Content/Pager.php:261
+#: src/Content/Pager.php:263
 msgid "last"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:426
+#: src/Content/Text/BBCode.php:429
 msgid "view full size"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:858 src/Content/Text/BBCode.php:1583
-#: src/Content/Text/BBCode.php:1584
+#: src/Content/Text/BBCode.php:863 src/Content/Text/BBCode.php:1596
+#: src/Content/Text/BBCode.php:1597
 msgid "Image/photo"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:961
+#: src/Content/Text/BBCode.php:967
 #, php-format
 msgid "<a href=\"%1$s\" target=\"_blank\">%2$s</a> %3$s"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:1510 src/Content/Text/BBCode.php:1532
+#: src/Content/Text/BBCode.php:1523 src/Content/Text/BBCode.php:1545
 msgid "$1 wrote:"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:1594 src/Content/Text/BBCode.php:1595
+#: src/Content/Text/BBCode.php:1607 src/Content/Text/BBCode.php:1608
 msgid "Encrypted content"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:1702
+#: src/Content/Text/BBCode.php:1715
 msgid "Invalid source protocol"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:1713
+#: src/Content/Text/BBCode.php:1726
 msgid "Invalid link protocol"
 msgstr ""
 
-#: src/Content/Text/HTML.php:798
+#: src/Content/Text/HTML.php:800
 msgid "Loading more entries..."
 msgstr ""
 
-#: src/Content/Text/HTML.php:799
+#: src/Content/Text/HTML.php:801
 msgid "The end"
 msgstr ""
 
-#: src/Content/Text/HTML.php:839
+#: src/Content/Text/HTML.php:894
+msgid "Follow"
+msgstr ""
+
+#: src/Content/Text/HTML.php:951 src/Model/Item.php:3485
+#: src/Model/Item.php:3496
+msgid "Click to open/close"
+msgstr ""
+
+#: src/Content/Widget/CalendarExport.php:64
+msgid "Export"
+msgstr ""
+
+#: src/Content/Widget/CalendarExport.php:65
+msgid "Export calendar as ical"
+msgstr ""
+
+#: src/Content/Widget/CalendarExport.php:66
+msgid "Export calendar as csv"
+msgstr ""
+
+#: src/Content/Widget/ContactBlock.php:58
 msgid "No contacts"
 msgstr ""
 
-#: src/Content/Text/HTML.php:866
+#: src/Content/Widget/ContactBlock.php:90
 #, php-format
 msgid "%d Contact"
 msgid_plural "%d Contacts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Content/Text/HTML.php:879
+#: src/Content/Widget/ContactBlock.php:109
 msgid "View Contacts"
-msgstr ""
-
-#: src/Content/Text/HTML.php:962
-msgid "Follow"
-msgstr ""
-
-#: src/Content/Text/HTML.php:1017 src/Model/Item.php:3438
-#: src/Model/Item.php:3449
-msgid "Click to open/close"
-msgstr ""
-
-#: src/Content/Widget/CalendarExport.php:63
-msgid "Export"
-msgstr ""
-
-#: src/Content/Widget/CalendarExport.php:64
-msgid "Export calendar as ical"
-msgstr ""
-
-#: src/Content/Widget/CalendarExport.php:65
-msgid "Export calendar as csv"
 msgstr ""
 
 #: src/Content/Widget.php:35
@@ -7528,80 +7451,80 @@ msgstr ""
 msgid "Local Directory"
 msgstr ""
 
-#: src/Content/Widget.php:156
+#: src/Content/Widget.php:158
 msgid "Protocols"
 msgstr ""
 
-#: src/Content/Widget.php:159
+#: src/Content/Widget.php:161
 msgid "All Protocols"
 msgstr ""
 
-#: src/Content/Widget.php:194
+#: src/Content/Widget.php:198
 msgid "Saved Folders"
 msgstr ""
 
-#: src/Content/Widget.php:197 src/Content/Widget.php:237
+#: src/Content/Widget.php:201 src/Content/Widget.php:243
 msgid "Everything"
 msgstr ""
 
-#: src/Content/Widget.php:234
+#: src/Content/Widget.php:240
 msgid "Categories"
 msgstr ""
 
-#: src/Content/Widget.php:316
+#: src/Content/Widget.php:324
 #, php-format
 msgid "%d contact in common"
 msgid_plural "%d contacts in common"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Core/ACL.php:283
+#: src/Core/ACL.php:287
 msgid "Post to Email"
 msgstr ""
 
-#: src/Core/ACL.php:289
+#: src/Core/ACL.php:293
 msgid "Hide your profile details from unknown viewers?"
 msgstr ""
 
-#: src/Core/ACL.php:288
+#: src/Core/ACL.php:292
 #, php-format
 msgid "Connectors disabled, since \"%s\" is enabled."
 msgstr ""
 
-#: src/Core/ACL.php:295
+#: src/Core/ACL.php:299
 msgid "Visible to everybody"
 msgstr ""
 
-#: src/Core/ACL.php:296 view/theme/vier/config.php:116
+#: src/Core/ACL.php:300 view/theme/vier/config.php:116
 msgid "show"
 msgstr ""
 
-#: src/Core/ACL.php:297 view/theme/vier/config.php:116
+#: src/Core/ACL.php:301 view/theme/vier/config.php:116
 msgid "don't show"
 msgstr ""
 
-#: src/Core/ACL.php:307
+#: src/Core/ACL.php:311
 msgid "Close"
 msgstr ""
 
-#: src/Core/Authentication.php:84
+#: src/Core/Authentication.php:87
 msgid "Welcome "
 msgstr ""
 
-#: src/Core/Authentication.php:85
+#: src/Core/Authentication.php:88
 msgid "Please upload a profile photo."
 msgstr ""
 
-#: src/Core/Authentication.php:87
+#: src/Core/Authentication.php:90
 msgid "Welcome back "
 msgstr ""
 
-#: src/Core/Console/ArchiveContact.php:66
+#: src/Core/Console/ArchiveContact.php:65
 #, php-format
 msgid "Could not find any unarchived contact entry for this URL (%s)"
 msgstr ""
 
-#: src/Core/Console/ArchiveContact.php:71
+#: src/Core/Console/ArchiveContact.php:70
 msgid "The contact entries have been archived"
 msgstr ""
 
@@ -7630,29 +7553,29 @@ msgstr ""
 msgid "All pending post updates are done."
 msgstr ""
 
-#: src/Core/Installer.php:160
+#: src/Core/Installer.php:162
 msgid ""
 "The database configuration file \"config/local.config.php\" could not be "
 "written. Please use the enclosed text to create a configuration file in your "
 "web server root."
 msgstr ""
 
-#: src/Core/Installer.php:176
+#: src/Core/Installer.php:181
 msgid ""
 "You may need to import the file \"database.sql\" manually using phpmyadmin "
 "or mysql."
 msgstr ""
 
-#: src/Core/Installer.php:177 src/Module/Install.php:134
-#: src/Module/Install.php:264
+#: src/Core/Installer.php:182 src/Module/Install.php:132
+#: src/Module/Install.php:263
 msgid "Please see the file \"INSTALL.txt\"."
 msgstr ""
 
-#: src/Core/Installer.php:239
+#: src/Core/Installer.php:243
 msgid "Could not find a command line version of PHP in the web server PATH."
 msgstr ""
 
-#: src/Core/Installer.php:240
+#: src/Core/Installer.php:244
 msgid ""
 "If you don't have a command line version of PHP installed on your server, "
 "you will not be able to run the background processing. See <a href='https://"
@@ -7660,544 +7583,543 @@ msgid ""
 "worker'>'Setup the worker'</a>"
 msgstr ""
 
-#: src/Core/Installer.php:244
+#: src/Core/Installer.php:248
 msgid "PHP executable path"
 msgstr ""
 
-#: src/Core/Installer.php:244
+#: src/Core/Installer.php:248
 msgid ""
 "Enter full path to php executable. You can leave this blank to continue the "
 "installation."
 msgstr ""
 
-#: src/Core/Installer.php:249
+#: src/Core/Installer.php:253
 msgid "Command line PHP"
 msgstr ""
 
-#: src/Core/Installer.php:258
+#: src/Core/Installer.php:262
 msgid "PHP executable is not the php cli binary (could be cgi-fgci version)"
 msgstr ""
 
-#: src/Core/Installer.php:259
+#: src/Core/Installer.php:263
 msgid "Found PHP version: "
 msgstr ""
 
-#: src/Core/Installer.php:261
+#: src/Core/Installer.php:265
 msgid "PHP cli binary"
 msgstr ""
 
-#: src/Core/Installer.php:274
+#: src/Core/Installer.php:278
 msgid ""
 "The command line version of PHP on your system does not have "
 "\"register_argc_argv\" enabled."
 msgstr ""
 
-#: src/Core/Installer.php:275
+#: src/Core/Installer.php:279
 msgid "This is required for message delivery to work."
 msgstr ""
 
-#: src/Core/Installer.php:280
+#: src/Core/Installer.php:284
 msgid "PHP register_argc_argv"
 msgstr ""
 
-#: src/Core/Installer.php:312
+#: src/Core/Installer.php:316
 msgid ""
 "Error: the \"openssl_pkey_new\" function on this system is not able to "
 "generate encryption keys"
 msgstr ""
 
-#: src/Core/Installer.php:313
+#: src/Core/Installer.php:317
 msgid ""
 "If running under Windows, please see \"http://www.php.net/manual/en/openssl."
 "installation.php\"."
 msgstr ""
 
-#: src/Core/Installer.php:316
+#: src/Core/Installer.php:320
 msgid "Generate encryption keys"
 msgstr ""
 
-#: src/Core/Installer.php:367
+#: src/Core/Installer.php:371
 msgid ""
 "Error: Apache webserver mod-rewrite module is required but not installed."
 msgstr ""
 
-#: src/Core/Installer.php:372
+#: src/Core/Installer.php:376
 msgid "Apache mod_rewrite module"
 msgstr ""
 
-#: src/Core/Installer.php:378
+#: src/Core/Installer.php:382
 msgid "Error: PDO or MySQLi PHP module required but not installed."
 msgstr ""
 
-#: src/Core/Installer.php:383
+#: src/Core/Installer.php:387
 msgid "Error: The MySQL driver for PDO is not installed."
 msgstr ""
 
-#: src/Core/Installer.php:387
+#: src/Core/Installer.php:391
 msgid "PDO or MySQLi PHP module"
 msgstr ""
 
-#: src/Core/Installer.php:395
+#: src/Core/Installer.php:399
 msgid "Error, XML PHP module required but not installed."
 msgstr ""
 
-#: src/Core/Installer.php:399
+#: src/Core/Installer.php:403
 msgid "XML PHP module"
 msgstr ""
 
-#: src/Core/Installer.php:402
+#: src/Core/Installer.php:406
 msgid "libCurl PHP module"
 msgstr ""
 
-#: src/Core/Installer.php:403
+#: src/Core/Installer.php:407
 msgid "Error: libCURL PHP module required but not installed."
 msgstr ""
 
-#: src/Core/Installer.php:409
+#: src/Core/Installer.php:413
 msgid "GD graphics PHP module"
 msgstr ""
 
-#: src/Core/Installer.php:410
+#: src/Core/Installer.php:414
 msgid ""
 "Error: GD graphics PHP module with JPEG support required but not installed."
 msgstr ""
 
-#: src/Core/Installer.php:416
+#: src/Core/Installer.php:420
 msgid "OpenSSL PHP module"
 msgstr ""
 
-#: src/Core/Installer.php:417
+#: src/Core/Installer.php:421
 msgid "Error: openssl PHP module required but not installed."
 msgstr ""
 
-#: src/Core/Installer.php:423
+#: src/Core/Installer.php:427
 msgid "mb_string PHP module"
 msgstr ""
 
-#: src/Core/Installer.php:424
+#: src/Core/Installer.php:428
 msgid "Error: mb_string PHP module required but not installed."
 msgstr ""
 
-#: src/Core/Installer.php:430
+#: src/Core/Installer.php:434
 msgid "iconv PHP module"
 msgstr ""
 
-#: src/Core/Installer.php:431
+#: src/Core/Installer.php:435
 msgid "Error: iconv PHP module required but not installed."
 msgstr ""
 
-#: src/Core/Installer.php:437
+#: src/Core/Installer.php:441
 msgid "POSIX PHP module"
 msgstr ""
 
-#: src/Core/Installer.php:438
+#: src/Core/Installer.php:442
 msgid "Error: POSIX PHP module required but not installed."
 msgstr ""
 
-#: src/Core/Installer.php:444
+#: src/Core/Installer.php:448
 msgid "JSON PHP module"
 msgstr ""
 
-#: src/Core/Installer.php:445
+#: src/Core/Installer.php:449
 msgid "Error: JSON PHP module required but not installed."
 msgstr ""
 
-#: src/Core/Installer.php:468
+#: src/Core/Installer.php:472
 msgid ""
 "The web installer needs to be able to create a file called \"local.config.php"
 "\" in the \"config\" folder of your web server and it is unable to do so."
 msgstr ""
 
-#: src/Core/Installer.php:469
+#: src/Core/Installer.php:473
 msgid ""
 "This is most often a permission setting, as the web server may not be able "
 "to write files in your folder - even if you can."
 msgstr ""
 
-#: src/Core/Installer.php:470
+#: src/Core/Installer.php:474
 msgid ""
 "At the end of this procedure, we will give you a text to save in a file "
 "named local.config.php in your Friendica \"config\" folder."
 msgstr ""
 
-#: src/Core/Installer.php:471
+#: src/Core/Installer.php:475
 msgid ""
 "You can alternatively skip this procedure and perform a manual installation. "
 "Please see the file \"INSTALL.txt\" for instructions."
 msgstr ""
 
-#: src/Core/Installer.php:474
+#: src/Core/Installer.php:478
 msgid "config/local.config.php is writable"
 msgstr ""
 
-#: src/Core/Installer.php:494
+#: src/Core/Installer.php:498
 msgid ""
 "Friendica uses the Smarty3 template engine to render its web views. Smarty3 "
 "compiles templates to PHP to speed up rendering."
 msgstr ""
 
-#: src/Core/Installer.php:495
+#: src/Core/Installer.php:499
 msgid ""
 "In order to store these compiled templates, the web server needs to have "
 "write access to the directory view/smarty3/ under the Friendica top level "
 "folder."
 msgstr ""
 
-#: src/Core/Installer.php:496
+#: src/Core/Installer.php:500
 msgid ""
 "Please ensure that the user that your web server runs as (e.g. www-data) has "
 "write access to this folder."
 msgstr ""
 
-#: src/Core/Installer.php:497
+#: src/Core/Installer.php:501
 msgid ""
 "Note: as a security measure, you should give the web server write access to "
 "view/smarty3/ only--not the template files (.tpl) that it contains."
 msgstr ""
 
-#: src/Core/Installer.php:500
+#: src/Core/Installer.php:504
 msgid "view/smarty3 is writable"
 msgstr ""
 
-#: src/Core/Installer.php:528
+#: src/Core/Installer.php:533
 msgid ""
 "Url rewrite in .htaccess is not working. Make sure you copied .htaccess-dist "
 "to .htaccess."
 msgstr ""
 
-#: src/Core/Installer.php:530
+#: src/Core/Installer.php:535
 msgid "Error message from Curl when fetching"
 msgstr ""
 
-#: src/Core/Installer.php:535
+#: src/Core/Installer.php:540
 msgid "Url rewrite is working"
 msgstr ""
 
-#: src/Core/Installer.php:564
+#: src/Core/Installer.php:569
 msgid "ImageMagick PHP extension is not installed"
 msgstr ""
 
-#: src/Core/Installer.php:566
+#: src/Core/Installer.php:571
 msgid "ImageMagick PHP extension is installed"
 msgstr ""
 
-#: src/Core/Installer.php:568 tests/src/Core/InstallerTest.php:319
-#: tests/src/Core/InstallerTest.php:343
+#: src/Core/Installer.php:573 tests/src/Core/InstallerTest.php:329
+#: tests/src/Core/InstallerTest.php:355
 msgid "ImageMagick supports GIF"
 msgstr ""
 
-#: src/Core/Installer.php:589
+#: src/Core/Installer.php:595
 msgid "Could not connect to database."
 msgstr ""
 
-#: src/Core/Installer.php:596
+#: src/Core/Installer.php:602
 msgid "Database already in use."
 msgstr ""
 
-#: src/Core/L10n.php:361 src/Model/Event.php:394
+#: src/Core/L10n.php:368 src/Model/Event.php:398
 msgid "Tuesday"
 msgstr ""
 
-#: src/Core/L10n.php:361 src/Model/Event.php:395
+#: src/Core/L10n.php:368 src/Model/Event.php:399
 msgid "Wednesday"
 msgstr ""
 
-#: src/Core/L10n.php:361 src/Model/Event.php:396
+#: src/Core/L10n.php:368 src/Model/Event.php:400
 msgid "Thursday"
 msgstr ""
 
-#: src/Core/L10n.php:361 src/Model/Event.php:397
+#: src/Core/L10n.php:368 src/Model/Event.php:401
 msgid "Friday"
 msgstr ""
 
-#: src/Core/L10n.php:361 src/Model/Event.php:398
+#: src/Core/L10n.php:368 src/Model/Event.php:402
 msgid "Saturday"
 msgstr ""
 
-#: src/Core/L10n.php:365 src/Model/Event.php:413
+#: src/Core/L10n.php:372 src/Model/Event.php:417
 msgid "January"
 msgstr ""
 
-#: src/Core/L10n.php:365 src/Model/Event.php:414
+#: src/Core/L10n.php:372 src/Model/Event.php:418
 msgid "February"
 msgstr ""
 
-#: src/Core/L10n.php:365 src/Model/Event.php:415
+#: src/Core/L10n.php:372 src/Model/Event.php:419
 msgid "March"
 msgstr ""
 
-#: src/Core/L10n.php:365 src/Model/Event.php:416
+#: src/Core/L10n.php:372 src/Model/Event.php:420
 msgid "April"
 msgstr ""
 
-#: src/Core/L10n.php:365 src/Core/L10n.php:384 src/Model/Event.php:404
-#: src/Model/Event.php:417
+#: src/Core/L10n.php:372 src/Core/L10n.php:391 src/Model/Event.php:408
 msgid "May"
 msgstr ""
 
-#: src/Core/L10n.php:365 src/Model/Event.php:418
+#: src/Core/L10n.php:372 src/Model/Event.php:421
 msgid "June"
 msgstr ""
 
-#: src/Core/L10n.php:365 src/Model/Event.php:419
+#: src/Core/L10n.php:372 src/Model/Event.php:422
 msgid "July"
 msgstr ""
 
-#: src/Core/L10n.php:365 src/Model/Event.php:420
+#: src/Core/L10n.php:372 src/Model/Event.php:423
 msgid "August"
 msgstr ""
 
-#: src/Core/L10n.php:365 src/Model/Event.php:421
+#: src/Core/L10n.php:372 src/Model/Event.php:424
 msgid "September"
 msgstr ""
 
-#: src/Core/L10n.php:365 src/Model/Event.php:422
+#: src/Core/L10n.php:372 src/Model/Event.php:425
 msgid "October"
 msgstr ""
 
-#: src/Core/L10n.php:365 src/Model/Event.php:423
+#: src/Core/L10n.php:372 src/Model/Event.php:426
 msgid "November"
 msgstr ""
 
-#: src/Core/L10n.php:365 src/Model/Event.php:424
+#: src/Core/L10n.php:372 src/Model/Event.php:427
 msgid "December"
 msgstr ""
 
-#: src/Core/L10n.php:380 src/Model/Event.php:385
+#: src/Core/L10n.php:387 src/Model/Event.php:389
 msgid "Mon"
 msgstr ""
 
-#: src/Core/L10n.php:380 src/Model/Event.php:386
+#: src/Core/L10n.php:387 src/Model/Event.php:390
 msgid "Tue"
 msgstr ""
 
-#: src/Core/L10n.php:380 src/Model/Event.php:387
+#: src/Core/L10n.php:387 src/Model/Event.php:391
 msgid "Wed"
 msgstr ""
 
-#: src/Core/L10n.php:380 src/Model/Event.php:388
+#: src/Core/L10n.php:387 src/Model/Event.php:392
 msgid "Thu"
 msgstr ""
 
-#: src/Core/L10n.php:380 src/Model/Event.php:389
+#: src/Core/L10n.php:387 src/Model/Event.php:393
 msgid "Fri"
 msgstr ""
 
-#: src/Core/L10n.php:380 src/Model/Event.php:390
+#: src/Core/L10n.php:387 src/Model/Event.php:394
 msgid "Sat"
 msgstr ""
 
-#: src/Core/L10n.php:380 src/Model/Event.php:384
+#: src/Core/L10n.php:387 src/Model/Event.php:388
 msgid "Sun"
 msgstr ""
 
-#: src/Core/L10n.php:384 src/Model/Event.php:400
+#: src/Core/L10n.php:391 src/Model/Event.php:404
 msgid "Jan"
 msgstr ""
 
-#: src/Core/L10n.php:384 src/Model/Event.php:401
+#: src/Core/L10n.php:391 src/Model/Event.php:405
 msgid "Feb"
 msgstr ""
 
-#: src/Core/L10n.php:384 src/Model/Event.php:402
+#: src/Core/L10n.php:391 src/Model/Event.php:406
 msgid "Mar"
 msgstr ""
 
-#: src/Core/L10n.php:384 src/Model/Event.php:403
+#: src/Core/L10n.php:391 src/Model/Event.php:407
 msgid "Apr"
 msgstr ""
 
-#: src/Core/L10n.php:384 src/Model/Event.php:406
+#: src/Core/L10n.php:391 src/Model/Event.php:410
 msgid "Jul"
 msgstr ""
 
-#: src/Core/L10n.php:384 src/Model/Event.php:407
+#: src/Core/L10n.php:391 src/Model/Event.php:411
 msgid "Aug"
 msgstr ""
 
-#: src/Core/L10n.php:384
+#: src/Core/L10n.php:391
 msgid "Sep"
 msgstr ""
 
-#: src/Core/L10n.php:384 src/Model/Event.php:409
+#: src/Core/L10n.php:391 src/Model/Event.php:413
 msgid "Oct"
 msgstr ""
 
-#: src/Core/L10n.php:384 src/Model/Event.php:410
+#: src/Core/L10n.php:391 src/Model/Event.php:414
 msgid "Nov"
 msgstr ""
 
-#: src/Core/L10n.php:384 src/Model/Event.php:411
+#: src/Core/L10n.php:391 src/Model/Event.php:415
 msgid "Dec"
 msgstr ""
 
-#: src/Core/L10n.php:402
+#: src/Core/L10n.php:410
 msgid "poke"
 msgstr ""
 
-#: src/Core/L10n.php:402
+#: src/Core/L10n.php:410
 msgid "poked"
 msgstr ""
 
-#: src/Core/L10n.php:403
+#: src/Core/L10n.php:411
 msgid "ping"
 msgstr ""
 
-#: src/Core/L10n.php:403
+#: src/Core/L10n.php:411
 msgid "pinged"
 msgstr ""
 
-#: src/Core/L10n.php:404
+#: src/Core/L10n.php:412
 msgid "prod"
 msgstr ""
 
-#: src/Core/L10n.php:404
+#: src/Core/L10n.php:412
 msgid "prodded"
 msgstr ""
 
-#: src/Core/L10n.php:405
+#: src/Core/L10n.php:413
 msgid "slap"
 msgstr ""
 
-#: src/Core/L10n.php:405
+#: src/Core/L10n.php:413
 msgid "slapped"
 msgstr ""
 
-#: src/Core/L10n.php:406
+#: src/Core/L10n.php:414
 msgid "finger"
 msgstr ""
 
-#: src/Core/L10n.php:406
+#: src/Core/L10n.php:414
 msgid "fingered"
 msgstr ""
 
-#: src/Core/L10n.php:407
+#: src/Core/L10n.php:415
 msgid "rebuff"
 msgstr ""
 
-#: src/Core/L10n.php:407
+#: src/Core/L10n.php:415
 msgid "rebuffed"
 msgstr ""
 
-#: src/Core/NotificationsManager.php:171
+#: src/Core/NotificationsManager.php:175
 msgid "System"
 msgstr ""
 
-#: src/Core/NotificationsManager.php:261 src/Core/NotificationsManager.php:273
+#: src/Core/NotificationsManager.php:265 src/Core/NotificationsManager.php:277
 #, php-format
 msgid "%s commented on %s's post"
 msgstr ""
 
-#: src/Core/NotificationsManager.php:272
+#: src/Core/NotificationsManager.php:276
 #, php-format
 msgid "%s created a new post"
 msgstr ""
 
-#: src/Core/NotificationsManager.php:286
+#: src/Core/NotificationsManager.php:290
 #, php-format
 msgid "%s liked %s's post"
 msgstr ""
 
-#: src/Core/NotificationsManager.php:299
+#: src/Core/NotificationsManager.php:303
 #, php-format
 msgid "%s disliked %s's post"
 msgstr ""
 
-#: src/Core/NotificationsManager.php:312
+#: src/Core/NotificationsManager.php:316
 #, php-format
 msgid "%s is attending %s's event"
 msgstr ""
 
-#: src/Core/NotificationsManager.php:325
+#: src/Core/NotificationsManager.php:329
 #, php-format
 msgid "%s is not attending %s's event"
 msgstr ""
 
-#: src/Core/NotificationsManager.php:338
+#: src/Core/NotificationsManager.php:342
 #, php-format
 msgid "%s may attend %s's event"
 msgstr ""
 
-#: src/Core/NotificationsManager.php:371
+#: src/Core/NotificationsManager.php:375
 #, php-format
 msgid "%s is now friends with %s"
 msgstr ""
 
-#: src/Core/NotificationsManager.php:637
+#: src/Core/NotificationsManager.php:651
 msgid "Friend Suggestion"
 msgstr ""
 
-#: src/Core/NotificationsManager.php:671
+#: src/Core/NotificationsManager.php:685
 msgid "Friend/Connect Request"
 msgstr ""
 
-#: src/Core/NotificationsManager.php:671
+#: src/Core/NotificationsManager.php:685
 msgid "New Follower"
 msgstr ""
 
-#: src/Core/System.php:133
+#: src/Core/System.php:137
 msgid "Error 400 - Bad Request"
 msgstr ""
 
-#: src/Core/System.php:134
+#: src/Core/System.php:138
 msgid "Error 401 - Unauthorized"
 msgstr ""
 
-#: src/Core/System.php:135
+#: src/Core/System.php:139
 msgid "Error 403 - Forbidden"
 msgstr ""
 
-#: src/Core/System.php:136
+#: src/Core/System.php:140
 msgid "Error 404 - Not Found"
 msgstr ""
 
-#: src/Core/System.php:137
+#: src/Core/System.php:141
 msgid "Error 500 - Internal Server Error"
 msgstr ""
 
-#: src/Core/System.php:138
+#: src/Core/System.php:142
 msgid "Error 503 - Service Unavailable"
 msgstr ""
 
-#: src/Core/System.php:146
+#: src/Core/System.php:150
 msgid ""
 "The server cannot or will not process the request due to an apparent client "
 "error."
 msgstr ""
 
-#: src/Core/System.php:147
+#: src/Core/System.php:151
 msgid "Authentication is required and has failed or has not yet been provided."
 msgstr ""
 
-#: src/Core/System.php:148
+#: src/Core/System.php:152
 msgid ""
 "The request was valid, but the server is refusing action. The user might not "
 "have the necessary permissions for a resource, or may need an account."
 msgstr ""
 
-#: src/Core/System.php:149
+#: src/Core/System.php:153
 msgid ""
 "The requested resource could not be found but may be available in the future."
 msgstr ""
 
-#: src/Core/System.php:150
+#: src/Core/System.php:154
 msgid ""
 "An unexpected condition was encountered and no more specific message is "
 "suitable."
 msgstr ""
 
-#: src/Core/System.php:151
+#: src/Core/System.php:155
 msgid ""
 "The server is currently unavailable (because it is overloaded or down for "
 "maintenance). Please try again later."
 msgstr ""
 
-#: src/Core/Update.php:163
+#: src/Core/Update.php:168
 #, php-format
 msgid "Update %s failed. See error logs."
 msgstr ""
 
-#: src/Core/Update.php:219
+#: src/Core/Update.php:225
 #, php-format
 msgid ""
 "\n"
@@ -8209,57 +8131,57 @@ msgid ""
 "might be invalid."
 msgstr ""
 
-#: src/Core/Update.php:225
+#: src/Core/Update.php:231
 #, php-format
 msgid ""
 "The error message is\n"
 "[pre]%s[/pre]"
 msgstr ""
 
-#: src/Core/Update.php:254
+#: src/Core/Update.php:260
 #, php-format
 msgid ""
 "\n"
 "\t\t\t\t\tThe friendica database was successfully updated from %s to %s."
 msgstr ""
 
-#: src/Core/UserImport.php:101
+#: src/Core/UserImport.php:103
 msgid "Error decoding account file"
 msgstr ""
 
-#: src/Core/UserImport.php:107
+#: src/Core/UserImport.php:109
 msgid "Error! No version data in file! This is not a Friendica account file?"
 msgstr ""
 
-#: src/Core/UserImport.php:115
+#: src/Core/UserImport.php:117
 #, php-format
 msgid "User '%s' already exists on this server!"
 msgstr ""
 
-#: src/Core/UserImport.php:151
+#: src/Core/UserImport.php:153
 msgid "User creation error"
 msgstr ""
 
-#: src/Core/UserImport.php:169
+#: src/Core/UserImport.php:171
 msgid "User profile creation error"
 msgstr ""
 
-#: src/Core/UserImport.php:213
+#: src/Core/UserImport.php:215
 #, php-format
 msgid "%d contact not imported"
 msgid_plural "%d contacts not imported"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Core/UserImport.php:278
+#: src/Core/UserImport.php:280
 msgid "Done. You can now login with your username and password"
 msgstr ""
 
-#: src/Database/DBStructure.php:45
+#: src/Database/DBStructure.php:47
 msgid "There are no tables on MyISAM."
 msgstr ""
 
-#: src/Database/DBStructure.php:69
+#: src/Database/DBStructure.php:71
 #, php-format
 msgid ""
 "\n"
@@ -8267,171 +8189,171 @@ msgid ""
 "%s\n"
 msgstr ""
 
-#: src/Database/DBStructure.php:72
+#: src/Database/DBStructure.php:74
 msgid "Errors encountered performing database changes: "
 msgstr ""
 
-#: src/Database/DBStructure.php:259
+#: src/Database/DBStructure.php:263
 #, php-format
 msgid "%s: Database update"
 msgstr ""
 
-#: src/Database/DBStructure.php:520
+#: src/Database/DBStructure.php:524
 #, php-format
 msgid "%s: updating %s table."
 msgstr ""
 
-#: src/LegacyModule.php:29
+#: src/LegacyModule.php:30
 #, php-format
 msgid "Legacy module file not found: %s"
 msgstr ""
 
-#: src/Model/Contact.php:1001
+#: src/Model/Contact.php:1037
 msgid "Drop Contact"
 msgstr ""
 
-#: src/Model/Contact.php:1468
+#: src/Model/Contact.php:1509
 msgid "Organisation"
 msgstr ""
 
-#: src/Model/Contact.php:1472
+#: src/Model/Contact.php:1513
 msgid "News"
 msgstr ""
 
-#: src/Model/Contact.php:1476
+#: src/Model/Contact.php:1517
 msgid "Forum"
 msgstr ""
 
-#: src/Model/Contact.php:1658
+#: src/Model/Contact.php:1707
 msgid "Connect URL missing."
 msgstr ""
 
-#: src/Model/Contact.php:1667
+#: src/Model/Contact.php:1716
 msgid ""
 "The contact could not be added. Please check the relevant network "
 "credentials in your Settings -> Social Networks page."
 msgstr ""
 
-#: src/Model/Contact.php:1706
+#: src/Model/Contact.php:1755
 msgid ""
 "This site is not configured to allow communications with other networks."
 msgstr ""
 
-#: src/Model/Contact.php:1707 src/Model/Contact.php:1720
+#: src/Model/Contact.php:1756 src/Model/Contact.php:1769
 msgid "No compatible communication protocols or feeds were discovered."
 msgstr ""
 
-#: src/Model/Contact.php:1718
+#: src/Model/Contact.php:1767
 msgid "The profile address specified does not provide adequate information."
 msgstr ""
 
-#: src/Model/Contact.php:1723
+#: src/Model/Contact.php:1772
 msgid "An author or name was not found."
 msgstr ""
 
-#: src/Model/Contact.php:1726
+#: src/Model/Contact.php:1775
 msgid "No browser URL could be matched to this address."
 msgstr ""
 
-#: src/Model/Contact.php:1729
+#: src/Model/Contact.php:1778
 msgid ""
 "Unable to match @-style Identity Address with a known protocol or email "
 "contact."
 msgstr ""
 
-#: src/Model/Contact.php:1730
+#: src/Model/Contact.php:1779
 msgid "Use mailto: in front of address to force email check."
 msgstr ""
 
-#: src/Model/Contact.php:1736
+#: src/Model/Contact.php:1785
 msgid ""
 "The profile address specified belongs to a network which has been disabled "
 "on this site."
 msgstr ""
 
-#: src/Model/Contact.php:1741
+#: src/Model/Contact.php:1790
 msgid ""
 "Limited profile. This person will be unable to receive direct/personal "
 "notifications from you."
 msgstr ""
 
-#: src/Model/Contact.php:1794
+#: src/Model/Contact.php:1843
 msgid "Unable to retrieve contact information."
 msgstr ""
 
-#: src/Model/Event.php:59 src/Model/Event.php:76 src/Model/Event.php:433
-#: src/Model/Event.php:908
+#: src/Model/Event.php:61 src/Model/Event.php:78 src/Model/Event.php:436
+#: src/Model/Event.php:916
 msgid "Starts:"
 msgstr ""
 
-#: src/Model/Event.php:62 src/Model/Event.php:82 src/Model/Event.php:434
-#: src/Model/Event.php:912
+#: src/Model/Event.php:64 src/Model/Event.php:84 src/Model/Event.php:437
+#: src/Model/Event.php:920
 msgid "Finishes:"
 msgstr ""
 
-#: src/Model/Event.php:382
+#: src/Model/Event.php:386
 msgid "all-day"
 msgstr ""
 
-#: src/Model/Event.php:405
+#: src/Model/Event.php:409
 msgid "Jun"
 msgstr ""
 
-#: src/Model/Event.php:408
+#: src/Model/Event.php:412
 msgid "Sept"
 msgstr ""
 
-#: src/Model/Event.php:431
+#: src/Model/Event.php:434
 msgid "No events to display"
 msgstr ""
 
-#: src/Model/Event.php:555
+#: src/Model/Event.php:562
 msgid "l, F j"
 msgstr ""
 
-#: src/Model/Event.php:586
+#: src/Model/Event.php:593
 msgid "Edit event"
 msgstr ""
 
-#: src/Model/Event.php:587
+#: src/Model/Event.php:594
 msgid "Duplicate event"
 msgstr ""
 
-#: src/Model/Event.php:588
+#: src/Model/Event.php:595
 msgid "Delete event"
 msgstr ""
 
-#: src/Model/Event.php:620 src/Model/Item.php:3487 src/Model/Item.php:3494
+#: src/Model/Event.php:627 src/Model/Item.php:3536 src/Model/Item.php:3543
 msgid "link to source"
 msgstr ""
 
-#: src/Model/Event.php:841
+#: src/Model/Event.php:849
 msgid "D g:i A"
 msgstr ""
 
-#: src/Model/Event.php:842
+#: src/Model/Event.php:850
 msgid "g:i A"
 msgstr ""
 
-#: src/Model/Event.php:927 src/Model/Event.php:929
+#: src/Model/Event.php:935 src/Model/Event.php:937
 msgid "Show map"
 msgstr ""
 
-#: src/Model/Event.php:928
+#: src/Model/Event.php:936
 msgid "Hide map"
 msgstr ""
 
-#: src/Model/Event.php:1018
+#: src/Model/Event.php:1028
 #, php-format
 msgid "%s's birthday"
 msgstr ""
 
-#: src/Model/Event.php:1019
+#: src/Model/Event.php:1029
 #, php-format
 msgid "Happy Birthday %s"
 msgstr ""
 
-#: src/Model/FileTag.php:255
+#: src/Model/FileTag.php:256
 msgid "Item filed"
 msgstr ""
 
@@ -8442,376 +8364,376 @@ msgid ""
 "not what you intended, please create another group with a different name."
 msgstr ""
 
-#: src/Model/Group.php:329
+#: src/Model/Group.php:338
 msgid "Default privacy group for new contacts"
 msgstr ""
 
-#: src/Model/Group.php:360
+#: src/Model/Group.php:370
 msgid "Everybody"
 msgstr ""
 
-#: src/Model/Group.php:380
+#: src/Model/Group.php:390
 msgid "edit"
 msgstr ""
 
-#: src/Model/Group.php:409
+#: src/Model/Group.php:419
 msgid "Edit group"
 msgstr ""
 
-#: src/Model/Group.php:412
+#: src/Model/Group.php:422
 msgid "Create a new group"
 msgstr ""
 
-#: src/Model/Group.php:414
+#: src/Model/Group.php:424
 msgid "Edit groups"
 msgstr ""
 
-#: src/Model/Item.php:3225
+#: src/Model/Item.php:3269
 msgid "activity"
 msgstr ""
 
-#: src/Model/Item.php:3227 src/Object/Post.php:453 src/Object/Post.php:465
+#: src/Model/Item.php:3271 src/Object/Post.php:456 src/Object/Post.php:468
 msgid "comment"
 msgid_plural "comments"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3230
+#: src/Model/Item.php:3274
 msgid "post"
 msgstr ""
 
-#: src/Model/Item.php:3326
+#: src/Model/Item.php:3373
 #, php-format
 msgid "Content warning: %s"
 msgstr ""
 
-#: src/Model/Item.php:3405
+#: src/Model/Item.php:3452
 msgid "bytes"
 msgstr ""
 
-#: src/Model/Item.php:3481
+#: src/Model/Item.php:3530
 msgid "View on separate page"
 msgstr ""
 
-#: src/Model/Item.php:3482
+#: src/Model/Item.php:3531
 msgid "view on separate page"
 msgstr ""
 
-#: src/Model/Mail.php:39 src/Model/Mail.php:171
+#: src/Model/Mail.php:40 src/Model/Mail.php:175
 msgid "[no subject]"
 msgstr ""
 
-#: src/Model/Profile.php:112
+#: src/Model/Profile.php:115
 msgid "Requested account is not available."
 msgstr ""
 
-#: src/Model/Profile.php:130
+#: src/Model/Profile.php:133
 msgid "Requested profile is not available."
 msgstr ""
 
-#: src/Model/Profile.php:178 src/Model/Profile.php:419
-#: src/Model/Profile.php:877
+#: src/Model/Profile.php:181 src/Model/Profile.php:425
+#: src/Model/Profile.php:872
 msgid "Edit profile"
 msgstr ""
 
-#: src/Model/Profile.php:353
+#: src/Model/Profile.php:359
 msgid "Atom feed"
 msgstr ""
 
-#: src/Model/Profile.php:392
+#: src/Model/Profile.php:398
 msgid "Manage/edit profiles"
 msgstr ""
 
-#: src/Model/Profile.php:444 src/Module/Contact.php:648
+#: src/Model/Profile.php:450 src/Module/Contact.php:645
 msgid "XMPP:"
 msgstr ""
 
-#: src/Model/Profile.php:572 src/Model/Profile.php:670
+#: src/Model/Profile.php:573 src/Model/Profile.php:671
 msgid "g A l F d"
 msgstr ""
 
-#: src/Model/Profile.php:573
+#: src/Model/Profile.php:574
 msgid "F d"
 msgstr ""
 
-#: src/Model/Profile.php:635 src/Model/Profile.php:721
+#: src/Model/Profile.php:636 src/Model/Profile.php:722
 msgid "[today]"
 msgstr ""
 
-#: src/Model/Profile.php:646
+#: src/Model/Profile.php:647
 msgid "Birthday Reminders"
 msgstr ""
 
-#: src/Model/Profile.php:647
+#: src/Model/Profile.php:648
 msgid "Birthdays this week:"
 msgstr ""
 
-#: src/Model/Profile.php:708
+#: src/Model/Profile.php:709
 msgid "[No description]"
 msgstr ""
 
-#: src/Model/Profile.php:735
+#: src/Model/Profile.php:736
 msgid "Event Reminders"
 msgstr ""
 
-#: src/Model/Profile.php:736
+#: src/Model/Profile.php:737
 msgid "Upcoming events the next 7 days:"
 msgstr ""
 
-#: src/Model/Profile.php:759
+#: src/Model/Profile.php:754
 msgid "Member since:"
 msgstr ""
 
-#: src/Model/Profile.php:767
+#: src/Model/Profile.php:762
 msgid "j F, Y"
 msgstr ""
 
-#: src/Model/Profile.php:768
+#: src/Model/Profile.php:763
 msgid "j F"
 msgstr ""
 
-#: src/Model/Profile.php:776 src/Util/Temporal.php:146
+#: src/Model/Profile.php:771 src/Util/Temporal.php:147
 msgid "Birthday:"
 msgstr ""
 
-#: src/Model/Profile.php:783
+#: src/Model/Profile.php:778
 msgid "Age:"
 msgstr ""
 
-#: src/Model/Profile.php:796
+#: src/Model/Profile.php:791
 #, php-format
 msgid "for %1$d %2$s"
 msgstr ""
 
-#: src/Model/Profile.php:820
+#: src/Model/Profile.php:815
 msgid "Religion:"
 msgstr ""
 
-#: src/Model/Profile.php:828
+#: src/Model/Profile.php:823
 msgid "Hobbies/Interests:"
 msgstr ""
 
-#: src/Model/Profile.php:840
+#: src/Model/Profile.php:835
 msgid "Contact information and Social Networks:"
 msgstr ""
 
-#: src/Model/Profile.php:844
+#: src/Model/Profile.php:839
 msgid "Musical interests:"
 msgstr ""
 
-#: src/Model/Profile.php:848
+#: src/Model/Profile.php:843
 msgid "Books, literature:"
 msgstr ""
 
-#: src/Model/Profile.php:852
+#: src/Model/Profile.php:847
 msgid "Television:"
 msgstr ""
 
-#: src/Model/Profile.php:856
+#: src/Model/Profile.php:851
 msgid "Film/dance/culture/entertainment:"
 msgstr ""
 
-#: src/Model/Profile.php:860
+#: src/Model/Profile.php:855
 msgid "Love/Romance:"
 msgstr ""
 
-#: src/Model/Profile.php:864
+#: src/Model/Profile.php:859
 msgid "Work/employment:"
 msgstr ""
 
-#: src/Model/Profile.php:868
+#: src/Model/Profile.php:863
 msgid "School/education:"
 msgstr ""
 
-#: src/Model/Profile.php:873
+#: src/Model/Profile.php:868
 msgid "Forums:"
 msgstr ""
 
-#: src/Model/Profile.php:917 src/Module/Contact.php:875
+#: src/Model/Profile.php:912 src/Module/Contact.php:872
 msgid "Profile Details"
 msgstr ""
 
-#: src/Model/Profile.php:967
+#: src/Model/Profile.php:962
 msgid "Only You Can See This"
 msgstr ""
 
-#: src/Model/Profile.php:975 src/Model/Profile.php:978
+#: src/Model/Profile.php:970 src/Model/Profile.php:973
 msgid "Tips for New Members"
 msgstr ""
 
-#: src/Model/Profile.php:1151
+#: src/Model/Profile.php:1150
 #, php-format
 msgid "OpenWebAuth: %1$s welcomes %2$s"
 msgstr ""
 
-#: src/Model/Storage/Database.php:37
+#: src/Model/Storage/Database.php:36
 #, php-format
 msgid "Database storage failed to update %s"
 msgstr ""
 
-#: src/Model/Storage/Database.php:44
+#: src/Model/Storage/Database.php:43
 msgid "Database storage failed to insert data"
 msgstr ""
 
-#: src/Model/Storage/Filesystem.php:61
+#: src/Model/Storage/Filesystem.php:63
 #, php-format
 msgid ""
 "Filesystem storage failed to create \"%s\". Check you write permissions."
 msgstr ""
 
-#: src/Model/Storage/Filesystem.php:101
+#: src/Model/Storage/Filesystem.php:105
 #, php-format
 msgid ""
 "Filesystem storage failed to save data to \"%s\". Check your write "
 "permissions"
 msgstr ""
 
-#: src/Model/Storage/Filesystem.php:122
+#: src/Model/Storage/Filesystem.php:126
 msgid "Storage base path"
 msgstr ""
 
-#: src/Model/Storage/Filesystem.php:124
+#: src/Model/Storage/Filesystem.php:128
 msgid ""
 "Folder were uploaded files are saved. For maximum security, This should be a "
 "path outside web server folder tree"
 msgstr ""
 
-#: src/Model/Storage/Filesystem.php:134
+#: src/Model/Storage/Filesystem.php:138
 msgid "Enter a valid existing folder"
 msgstr ""
 
-#: src/Model/User.php:216
+#: src/Model/User.php:270
 msgid "Login failed"
 msgstr ""
 
-#: src/Model/User.php:247
+#: src/Model/User.php:301
 msgid "Not enough information to authenticate"
 msgstr ""
 
-#: src/Model/User.php:325
+#: src/Model/User.php:379
 msgid "Password can't be empty"
 msgstr ""
 
-#: src/Model/User.php:344
+#: src/Model/User.php:398
 msgid "Empty passwords are not allowed."
 msgstr ""
 
-#: src/Model/User.php:348
+#: src/Model/User.php:402
 msgid ""
 "The new password has been exposed in a public data dump, please choose "
 "another."
 msgstr ""
 
-#: src/Model/User.php:354
+#: src/Model/User.php:408
 msgid ""
 "The password can't contain accentuated letters, white spaces or colons (:)"
 msgstr ""
 
-#: src/Model/User.php:452
+#: src/Model/User.php:508
 msgid "Passwords do not match. Password unchanged."
 msgstr ""
 
-#: src/Model/User.php:459
+#: src/Model/User.php:515
 msgid "An invitation is required."
 msgstr ""
 
-#: src/Model/User.php:463
+#: src/Model/User.php:519
 msgid "Invitation could not be verified."
 msgstr ""
 
-#: src/Model/User.php:470
+#: src/Model/User.php:526
 msgid "Invalid OpenID url"
 msgstr ""
 
-#: src/Model/User.php:483 src/Module/Login.php:105
+#: src/Model/User.php:539 src/Module/Login.php:106
 msgid ""
 "We encountered a problem while logging in with the OpenID you provided. "
 "Please check the correct spelling of the ID."
 msgstr ""
 
-#: src/Model/User.php:483 src/Module/Login.php:105
+#: src/Model/User.php:539 src/Module/Login.php:106
 msgid "The error message was:"
 msgstr ""
 
-#: src/Model/User.php:489
+#: src/Model/User.php:545
 msgid "Please enter the required information."
 msgstr ""
 
-#: src/Model/User.php:505
+#: src/Model/User.php:559
 #, php-format
 msgid ""
 "system.username_min_length (%s) and system.username_max_length (%s) are "
 "excluding each other, swapping values."
 msgstr ""
 
-#: src/Model/User.php:512
+#: src/Model/User.php:566
 #, php-format
 msgid "Username should be at least %s character."
 msgid_plural "Username should be at least %s characters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/User.php:516
+#: src/Model/User.php:570
 #, php-format
 msgid "Username should be at most %s character."
 msgid_plural "Username should be at most %s characters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/User.php:524
+#: src/Model/User.php:578
 msgid "That doesn't appear to be your full (First Last) name."
 msgstr ""
 
-#: src/Model/User.php:529
+#: src/Model/User.php:583
 msgid "Your email domain is not among those allowed on this site."
 msgstr ""
 
-#: src/Model/User.php:533
+#: src/Model/User.php:587
 msgid "Not a valid email address."
 msgstr ""
 
-#: src/Model/User.php:536
+#: src/Model/User.php:590
 msgid "The nickname was blocked from registration by the nodes admin."
 msgstr ""
 
-#: src/Model/User.php:540 src/Model/User.php:548
+#: src/Model/User.php:594 src/Model/User.php:602
 msgid "Cannot use that email."
 msgstr ""
 
-#: src/Model/User.php:555
+#: src/Model/User.php:609
 msgid "Your nickname can only contain a-z, 0-9 and _."
 msgstr ""
 
-#: src/Model/User.php:562 src/Model/User.php:619
+#: src/Model/User.php:616 src/Model/User.php:673
 msgid "Nickname is already registered. Please choose another."
 msgstr ""
 
-#: src/Model/User.php:572
+#: src/Model/User.php:626
 msgid "SERIOUS ERROR: Generation of security keys failed."
 msgstr ""
 
-#: src/Model/User.php:606 src/Model/User.php:610
+#: src/Model/User.php:660 src/Model/User.php:664
 msgid "An error occurred during registration. Please try again."
 msgstr ""
 
-#: src/Model/User.php:630 view/theme/duepuntozero/config.php:55
+#: src/Model/User.php:684 view/theme/duepuntozero/config.php:55
 msgid "default"
 msgstr ""
 
-#: src/Model/User.php:635
+#: src/Model/User.php:689
 msgid "An error occurred creating your default profile. Please try again."
 msgstr ""
 
-#: src/Model/User.php:642
+#: src/Model/User.php:696
 msgid "An error occurred creating your self contact. Please try again."
 msgstr ""
 
-#: src/Model/User.php:651
+#: src/Model/User.php:705
 msgid ""
 "An error occurred creating your default contact group. Please try again."
 msgstr ""
 
-#: src/Model/User.php:726
+#: src/Model/User.php:781
 #, php-format
 msgid ""
 "\n"
@@ -8827,12 +8749,12 @@ msgid ""
 "\t\t"
 msgstr ""
 
-#: src/Model/User.php:743
+#: src/Model/User.php:798
 #, php-format
 msgid "Registration at %s"
 msgstr ""
 
-#: src/Model/User.php:761
+#: src/Model/User.php:817
 #, php-format
 msgid ""
 "\n"
@@ -8841,7 +8763,7 @@ msgid ""
 "\t\t"
 msgstr ""
 
-#: src/Model/User.php:767
+#: src/Model/User.php:823
 #, php-format
 msgid ""
 "\n"
@@ -8884,459 +8806,459 @@ msgstr ""
 msgid "Item was not found."
 msgstr ""
 
-#: src/Module/Contact.php:167
+#: src/Module/Contact.php:166
 #, php-format
 msgid "%d contact edited."
 msgid_plural "%d contacts edited."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Module/Contact.php:192 src/Module/Contact.php:375
+#: src/Module/Contact.php:191 src/Module/Contact.php:374
 msgid "Could not access contact record."
 msgstr ""
 
-#: src/Module/Contact.php:202
+#: src/Module/Contact.php:201
 msgid "Could not locate selected profile."
 msgstr ""
 
-#: src/Module/Contact.php:234
+#: src/Module/Contact.php:233
 msgid "Contact updated."
 msgstr ""
 
-#: src/Module/Contact.php:396
+#: src/Module/Contact.php:395
 msgid "Contact has been blocked"
 msgstr ""
 
-#: src/Module/Contact.php:396
+#: src/Module/Contact.php:395
 msgid "Contact has been unblocked"
 msgstr ""
 
-#: src/Module/Contact.php:406
+#: src/Module/Contact.php:405
 msgid "Contact has been ignored"
 msgstr ""
 
-#: src/Module/Contact.php:406
+#: src/Module/Contact.php:405
 msgid "Contact has been unignored"
 msgstr ""
 
-#: src/Module/Contact.php:416
+#: src/Module/Contact.php:415
 msgid "Contact has been archived"
 msgstr ""
 
-#: src/Module/Contact.php:416
+#: src/Module/Contact.php:415
 msgid "Contact has been unarchived"
 msgstr ""
 
-#: src/Module/Contact.php:440
+#: src/Module/Contact.php:439
 msgid "Drop contact"
 msgstr ""
 
-#: src/Module/Contact.php:443 src/Module/Contact.php:823
+#: src/Module/Contact.php:442 src/Module/Contact.php:820
 msgid "Do you really want to delete this contact?"
 msgstr ""
 
-#: src/Module/Contact.php:457
+#: src/Module/Contact.php:456
 msgid "Contact has been removed."
 msgstr ""
 
-#: src/Module/Contact.php:488
+#: src/Module/Contact.php:486
 #, php-format
 msgid "You are mutual friends with %s"
 msgstr ""
 
-#: src/Module/Contact.php:493
+#: src/Module/Contact.php:491
 #, php-format
 msgid "You are sharing with %s"
 msgstr ""
 
-#: src/Module/Contact.php:498
+#: src/Module/Contact.php:496
 #, php-format
 msgid "%s is sharing with you"
 msgstr ""
 
-#: src/Module/Contact.php:522
+#: src/Module/Contact.php:520
 msgid "Private communications are not available for this contact."
 msgstr ""
 
-#: src/Module/Contact.php:524
+#: src/Module/Contact.php:522
 msgid "Never"
 msgstr ""
 
-#: src/Module/Contact.php:527
+#: src/Module/Contact.php:525
 msgid "(Update was successful)"
 msgstr ""
 
-#: src/Module/Contact.php:527
+#: src/Module/Contact.php:525
 msgid "(Update was not successful)"
 msgstr ""
 
-#: src/Module/Contact.php:529 src/Module/Contact.php:1061
+#: src/Module/Contact.php:527 src/Module/Contact.php:1058
 msgid "Suggest friends"
 msgstr ""
 
-#: src/Module/Contact.php:533
+#: src/Module/Contact.php:531
 #, php-format
 msgid "Network type: %s"
 msgstr ""
 
-#: src/Module/Contact.php:538
+#: src/Module/Contact.php:536
 msgid "Communications lost with this contact!"
 msgstr ""
 
-#: src/Module/Contact.php:544
+#: src/Module/Contact.php:542
 msgid "Fetch further information for feeds"
 msgstr ""
 
-#: src/Module/Contact.php:546
+#: src/Module/Contact.php:544
 msgid ""
 "Fetch information like preview pictures, title and teaser from the feed "
 "item. You can activate this if the feed doesn't contain much text. Keywords "
 "are taken from the meta header in the feed item and are posted as hash tags."
 msgstr ""
 
-#: src/Module/Contact.php:549
+#: src/Module/Contact.php:547
 msgid "Fetch information"
 msgstr ""
 
-#: src/Module/Contact.php:550
+#: src/Module/Contact.php:548
 msgid "Fetch keywords"
 msgstr ""
 
-#: src/Module/Contact.php:551
+#: src/Module/Contact.php:549
 msgid "Fetch information and keywords"
 msgstr ""
 
-#: src/Module/Contact.php:583
+#: src/Module/Contact.php:581
 msgid "Profile Visibility"
 msgstr ""
 
-#: src/Module/Contact.php:584
+#: src/Module/Contact.php:582
 msgid "Contact Information / Notes"
 msgstr ""
 
-#: src/Module/Contact.php:585
+#: src/Module/Contact.php:583
 msgid "Contact Settings"
 msgstr ""
 
-#: src/Module/Contact.php:594
+#: src/Module/Contact.php:592
 msgid "Contact"
 msgstr ""
 
-#: src/Module/Contact.php:598
+#: src/Module/Contact.php:596
 #, php-format
 msgid ""
 "Please choose the profile you would like to display to %s when viewing your "
 "profile securely."
 msgstr ""
 
-#: src/Module/Contact.php:600
+#: src/Module/Contact.php:598
 msgid "Their personal note"
 msgstr ""
 
-#: src/Module/Contact.php:602
+#: src/Module/Contact.php:600
 msgid "Edit contact notes"
 msgstr ""
 
-#: src/Module/Contact.php:606
+#: src/Module/Contact.php:604
 msgid "Block/Unblock contact"
 msgstr ""
 
-#: src/Module/Contact.php:607
+#: src/Module/Contact.php:605
 msgid "Ignore contact"
 msgstr ""
 
-#: src/Module/Contact.php:608
+#: src/Module/Contact.php:606
 msgid "Repair URL settings"
 msgstr ""
 
-#: src/Module/Contact.php:609
+#: src/Module/Contact.php:607
 msgid "View conversations"
 msgstr ""
 
-#: src/Module/Contact.php:614
+#: src/Module/Contact.php:612
 msgid "Last update:"
 msgstr ""
 
-#: src/Module/Contact.php:616
+#: src/Module/Contact.php:614
 msgid "Update public posts"
 msgstr ""
 
-#: src/Module/Contact.php:618 src/Module/Contact.php:1071
+#: src/Module/Contact.php:616 src/Module/Contact.php:1068
 msgid "Update now"
 msgstr ""
 
-#: src/Module/Contact.php:624 src/Module/Contact.php:828
-#: src/Module/Contact.php:1088
+#: src/Module/Contact.php:622 src/Module/Contact.php:825
+#: src/Module/Contact.php:1085
 msgid "Unignore"
 msgstr ""
 
-#: src/Module/Contact.php:628
+#: src/Module/Contact.php:626
 msgid "Currently blocked"
 msgstr ""
 
-#: src/Module/Contact.php:629
+#: src/Module/Contact.php:627
 msgid "Currently ignored"
 msgstr ""
 
-#: src/Module/Contact.php:630
+#: src/Module/Contact.php:628
 msgid "Currently archived"
 msgstr ""
 
-#: src/Module/Contact.php:631
+#: src/Module/Contact.php:629
 msgid "Awaiting connection acknowledge"
 msgstr ""
 
-#: src/Module/Contact.php:632
+#: src/Module/Contact.php:630
 msgid ""
 "Replies/likes to your public posts <strong>may</strong> still be visible"
 msgstr ""
 
-#: src/Module/Contact.php:633
+#: src/Module/Contact.php:631
 msgid "Notification for new posts"
 msgstr ""
 
-#: src/Module/Contact.php:633
+#: src/Module/Contact.php:631
 msgid "Send a notification of every new post of this contact"
 msgstr ""
 
-#: src/Module/Contact.php:636
+#: src/Module/Contact.php:633
 msgid "Blacklisted keywords"
 msgstr ""
 
-#: src/Module/Contact.php:636
+#: src/Module/Contact.php:633
 msgid ""
 "Comma separated list of keywords that should not be converted to hashtags, "
 "when \"Fetch information and keywords\" is selected"
 msgstr ""
 
-#: src/Module/Contact.php:653
+#: src/Module/Contact.php:650
 msgid "Actions"
 msgstr ""
 
-#: src/Module/Contact.php:699
+#: src/Module/Contact.php:696
 msgid "Suggestions"
 msgstr ""
 
-#: src/Module/Contact.php:702
+#: src/Module/Contact.php:699
 msgid "Suggest potential friends"
 msgstr ""
 
-#: src/Module/Contact.php:710
+#: src/Module/Contact.php:707
 msgid "Show all contacts"
 msgstr ""
 
-#: src/Module/Contact.php:715
+#: src/Module/Contact.php:712
 msgid "Unblocked"
 msgstr ""
 
-#: src/Module/Contact.php:718
+#: src/Module/Contact.php:715
 msgid "Only show unblocked contacts"
 msgstr ""
 
-#: src/Module/Contact.php:723
+#: src/Module/Contact.php:720
 msgid "Blocked"
 msgstr ""
 
-#: src/Module/Contact.php:726
+#: src/Module/Contact.php:723
 msgid "Only show blocked contacts"
 msgstr ""
 
-#: src/Module/Contact.php:731
+#: src/Module/Contact.php:728
 msgid "Ignored"
 msgstr ""
 
-#: src/Module/Contact.php:734
+#: src/Module/Contact.php:731
 msgid "Only show ignored contacts"
 msgstr ""
 
-#: src/Module/Contact.php:739
+#: src/Module/Contact.php:736
 msgid "Archived"
 msgstr ""
 
-#: src/Module/Contact.php:742
+#: src/Module/Contact.php:739
 msgid "Only show archived contacts"
 msgstr ""
 
-#: src/Module/Contact.php:747
+#: src/Module/Contact.php:744
 msgid "Hidden"
 msgstr ""
 
-#: src/Module/Contact.php:750
+#: src/Module/Contact.php:747
 msgid "Only show hidden contacts"
 msgstr ""
 
-#: src/Module/Contact.php:758
+#: src/Module/Contact.php:755
 msgid "Organize your contact groups"
 msgstr ""
 
-#: src/Module/Contact.php:818
+#: src/Module/Contact.php:815
 msgid "Search your contacts"
 msgstr ""
 
-#: src/Module/Contact.php:829 src/Module/Contact.php:1097
+#: src/Module/Contact.php:826 src/Module/Contact.php:1094
 msgid "Archive"
 msgstr ""
 
-#: src/Module/Contact.php:829 src/Module/Contact.php:1097
+#: src/Module/Contact.php:826 src/Module/Contact.php:1094
 msgid "Unarchive"
 msgstr ""
 
-#: src/Module/Contact.php:832
+#: src/Module/Contact.php:829
 msgid "Batch Actions"
 msgstr ""
 
-#: src/Module/Contact.php:859
+#: src/Module/Contact.php:856
 msgid "Conversations started by this contact"
 msgstr ""
 
-#: src/Module/Contact.php:864
+#: src/Module/Contact.php:861
 msgid "Posts and Comments"
 msgstr ""
 
-#: src/Module/Contact.php:887
+#: src/Module/Contact.php:884
 msgid "View all contacts"
 msgstr ""
 
-#: src/Module/Contact.php:898
+#: src/Module/Contact.php:895
 msgid "View all common friends"
 msgstr ""
 
-#: src/Module/Contact.php:908
+#: src/Module/Contact.php:905
 msgid "Advanced Contact Settings"
 msgstr ""
 
-#: src/Module/Contact.php:994
+#: src/Module/Contact.php:991
 msgid "Mutual Friendship"
 msgstr ""
 
-#: src/Module/Contact.php:999
+#: src/Module/Contact.php:996
 msgid "is a fan of yours"
 msgstr ""
 
-#: src/Module/Contact.php:1004
+#: src/Module/Contact.php:1001
 msgid "you are a fan of"
 msgstr ""
 
-#: src/Module/Contact.php:1028
+#: src/Module/Contact.php:1025
 msgid "Edit contact"
 msgstr ""
 
-#: src/Module/Contact.php:1082
+#: src/Module/Contact.php:1079
 msgid "Toggle Blocked status"
 msgstr ""
 
-#: src/Module/Contact.php:1090
+#: src/Module/Contact.php:1087
 msgid "Toggle Ignored status"
 msgstr ""
 
-#: src/Module/Contact.php:1099
+#: src/Module/Contact.php:1096
 msgid "Toggle Archive status"
 msgstr ""
 
-#: src/Module/Contact.php:1107
+#: src/Module/Contact.php:1104
 msgid "Delete contact"
 msgstr ""
 
-#: src/Module/Install.php:120
+#: src/Module/Install.php:118
 msgid "Friendica Communications Server - Setup"
 msgstr ""
 
-#: src/Module/Install.php:131
+#: src/Module/Install.php:129
 msgid "System check"
 msgstr ""
 
-#: src/Module/Install.php:136
+#: src/Module/Install.php:134
 msgid "Check again"
 msgstr ""
 
-#: src/Module/Install.php:153
+#: src/Module/Install.php:151
 msgid "Database connection"
 msgstr ""
 
-#: src/Module/Install.php:154
+#: src/Module/Install.php:152
 msgid ""
 "In order to install Friendica we need to know how to connect to your "
 "database."
 msgstr ""
 
-#: src/Module/Install.php:155
+#: src/Module/Install.php:153
 msgid ""
 "Please contact your hosting provider or site administrator if you have "
 "questions about these settings."
 msgstr ""
 
-#: src/Module/Install.php:156
+#: src/Module/Install.php:154
 msgid ""
 "The database you specify below should already exist. If it does not, please "
 "create it before continuing."
 msgstr ""
 
-#: src/Module/Install.php:159
+#: src/Module/Install.php:157
 msgid "Database Server Name"
 msgstr ""
 
-#: src/Module/Install.php:164
+#: src/Module/Install.php:162
 msgid "Database Login Name"
 msgstr ""
 
-#: src/Module/Install.php:170
+#: src/Module/Install.php:168
 msgid "Database Login Password"
 msgstr ""
 
-#: src/Module/Install.php:172
+#: src/Module/Install.php:170
 msgid "For security reasons the password must not be empty"
 msgstr ""
 
-#: src/Module/Install.php:175
+#: src/Module/Install.php:173
 msgid "Database Name"
 msgstr ""
 
-#: src/Module/Install.php:180 src/Module/Install.php:216
+#: src/Module/Install.php:178 src/Module/Install.php:214
 msgid "Site administrator email address"
 msgstr ""
 
-#: src/Module/Install.php:182 src/Module/Install.php:216
+#: src/Module/Install.php:180 src/Module/Install.php:214
 msgid ""
 "Your account email address must match this in order to use the web admin "
 "panel."
 msgstr ""
 
-#: src/Module/Install.php:186 src/Module/Install.php:217
+#: src/Module/Install.php:184 src/Module/Install.php:215
 msgid "Please select a default timezone for your website"
 msgstr ""
 
-#: src/Module/Install.php:210
+#: src/Module/Install.php:208
 msgid "Site settings"
 msgstr ""
 
-#: src/Module/Install.php:219
+#: src/Module/Install.php:217
 msgid "System Language:"
 msgstr ""
 
-#: src/Module/Install.php:221
+#: src/Module/Install.php:219
 msgid ""
 "Set the default language for your Friendica installation interface and to "
 "send emails."
 msgstr ""
 
-#: src/Module/Install.php:233
+#: src/Module/Install.php:231
 msgid "Your Friendica site database has been installed."
 msgstr ""
 
-#: src/Module/Install.php:241
+#: src/Module/Install.php:239
 msgid "Installation finished"
 msgstr ""
 
-#: src/Module/Install.php:262
+#: src/Module/Install.php:261
 msgid "<h1>What next</h1>"
 msgstr ""
 
-#: src/Module/Install.php:263
+#: src/Module/Install.php:262
 msgid ""
 "IMPORTANT: You will need to [manually] setup a scheduled task for the worker."
 msgstr ""
 
-#: src/Module/Install.php:266
+#: src/Module/Install.php:265
 #, php-format
 msgid ""
 "Go to your new Friendica node <a href=\"%s/register\">registration page</a> "
@@ -9348,39 +9270,39 @@ msgstr ""
 msgid "Item Guid"
 msgstr ""
 
-#: src/Module/Login.php:289
+#: src/Module/Login.php:292
 msgid "Create a New Account"
 msgstr ""
 
-#: src/Module/Login.php:322
+#: src/Module/Login.php:325
 msgid "Password: "
 msgstr ""
 
-#: src/Module/Login.php:323
+#: src/Module/Login.php:326
 msgid "Remember me"
 msgstr ""
 
-#: src/Module/Login.php:326
+#: src/Module/Login.php:329
 msgid "Or login using OpenID: "
 msgstr ""
 
-#: src/Module/Login.php:332
+#: src/Module/Login.php:335
 msgid "Forgot your password?"
 msgstr ""
 
-#: src/Module/Login.php:335
+#: src/Module/Login.php:338
 msgid "Website Terms of Service"
 msgstr ""
 
-#: src/Module/Login.php:336
+#: src/Module/Login.php:339
 msgid "terms of service"
 msgstr ""
 
-#: src/Module/Login.php:338
+#: src/Module/Login.php:341
 msgid "Website Privacy Policy"
 msgstr ""
 
-#: src/Module/Login.php:339
+#: src/Module/Login.php:342
 msgid "privacy policy"
 msgstr ""
 
@@ -9388,11 +9310,120 @@ msgstr ""
 msgid "Logged out."
 msgstr ""
 
-#: src/Module/Proxy.php:78
+#: src/Module/Profile.php:102 src/Module/Profile.php:105
+#: src/Protocol/OStatus.php:1302
+#, php-format
+msgid "%s's timeline"
+msgstr ""
+
+#: src/Module/Profile.php:103 src/Protocol/OStatus.php:1306
+#, php-format
+msgid "%s's posts"
+msgstr ""
+
+#: src/Module/Profile.php:104 src/Protocol/OStatus.php:1309
+#, php-format
+msgid "%s's comments"
+msgstr ""
+
+#: src/Module/Proxy.php:73
 msgid "Bad Request."
 msgstr ""
 
-#: src/Module/Tos.php:35 src/Module/Tos.php:75
+#: src/Module/Register.php:83
+msgid ""
+"You may (optionally) fill in this form via OpenID by supplying your OpenID "
+"and clicking \"Register\"."
+msgstr ""
+
+#: src/Module/Register.php:84
+msgid ""
+"If you are not familiar with OpenID, please leave that field blank and fill "
+"in the rest of the items."
+msgstr ""
+
+#: src/Module/Register.php:85
+msgid "Your OpenID (optional): "
+msgstr ""
+
+#: src/Module/Register.php:94
+msgid "Include your profile in member directory?"
+msgstr ""
+
+#: src/Module/Register.php:117
+msgid "Note for the admin"
+msgstr ""
+
+#: src/Module/Register.php:117
+msgid "Leave a message for the admin, why you want to join this node"
+msgstr ""
+
+#: src/Module/Register.php:118
+msgid "Membership on this site is by invitation only."
+msgstr ""
+
+#: src/Module/Register.php:119
+msgid "Your invitation code: "
+msgstr ""
+
+#: src/Module/Register.php:127
+msgid "Your Full Name (e.g. Joe Smith, real or real-looking): "
+msgstr ""
+
+#: src/Module/Register.php:128
+msgid ""
+"Your Email Address: (Initial information will be send there, so this has to "
+"be an existing address.)"
+msgstr ""
+
+#: src/Module/Register.php:130
+msgid "Leave empty for an auto generated password."
+msgstr ""
+
+#: src/Module/Register.php:132
+#, php-format
+msgid ""
+"Choose a profile nickname. This must begin with a text character. Your "
+"profile address on this site will then be \"<strong>nickname@%s</strong>\"."
+msgstr ""
+
+#: src/Module/Register.php:133
+msgid "Choose a nickname: "
+msgstr ""
+
+#: src/Module/Register.php:142
+msgid "Import your profile to this friendica instance"
+msgstr ""
+
+#: src/Module/Register.php:150
+msgid "Note: This node explicitly contains adult content"
+msgstr ""
+
+#: src/Module/Register.php:243
+msgid ""
+"Registration successful. Please check your email for further instructions."
+msgstr ""
+
+#: src/Module/Register.php:247
+#, php-format
+msgid ""
+"Failed to send email message. Here your accout details:<br> login: %s<br> "
+"password: %s<br><br>You can change your password after login."
+msgstr ""
+
+#: src/Module/Register.php:254
+msgid "Registration successful."
+msgstr ""
+
+#: src/Module/Register.php:259
+msgid "Your registration can not be processed."
+msgstr ""
+
+#: src/Module/Register.php:305
+msgid "Your registration is pending approval by the site owner."
+msgstr ""
+
+#: src/Module/Tos.php:35 src/Module/Tos.php:77
 msgid ""
 "At the time of registration, and for providing communications between the "
 "user account and their contacts, the user has to provide a display name (pen "
@@ -9405,14 +9436,14 @@ msgid ""
 "settings, it is not necessary for communication."
 msgstr ""
 
-#: src/Module/Tos.php:36 src/Module/Tos.php:76
+#: src/Module/Tos.php:36 src/Module/Tos.php:78
 msgid ""
 "This data is required for communication and is passed on to the nodes of the "
 "communication partners and is stored there. Users can enter additional "
 "private data that may be transmitted to the communication partners accounts."
 msgstr ""
 
-#: src/Module/Tos.php:37 src/Module/Tos.php:77
+#: src/Module/Tos.php:37 src/Module/Tos.php:79
 #, php-format
 msgid ""
 "At any point in time a logged in user can export their account data from the "
@@ -9422,222 +9453,226 @@ msgid ""
 "data will also be requested from the nodes of the communication partners."
 msgstr ""
 
-#: src/Module/Tos.php:40 src/Module/Tos.php:74
+#: src/Module/Tos.php:40 src/Module/Tos.php:76
 msgid "Privacy Statement"
 msgstr ""
 
-#: src/Object/Post.php:133
+#: src/Object/Post.php:135
 msgid "This entry was edited"
 msgstr ""
 
-#: src/Object/Post.php:195
+#: src/Object/Post.php:197
 msgid "Delete locally"
 msgstr ""
 
-#: src/Object/Post.php:198
+#: src/Object/Post.php:200
 msgid "Delete globally"
 msgstr ""
 
-#: src/Object/Post.php:198
+#: src/Object/Post.php:200
 msgid "Remove locally"
 msgstr ""
 
-#: src/Object/Post.php:212
+#: src/Object/Post.php:214
 msgid "save to folder"
 msgstr ""
 
-#: src/Object/Post.php:247
+#: src/Object/Post.php:249
 msgid "I will attend"
 msgstr ""
 
-#: src/Object/Post.php:247
+#: src/Object/Post.php:249
 msgid "I will not attend"
 msgstr ""
 
-#: src/Object/Post.php:247
+#: src/Object/Post.php:249
 msgid "I might attend"
 msgstr ""
 
-#: src/Object/Post.php:275
+#: src/Object/Post.php:277
 msgid "ignore thread"
 msgstr ""
 
-#: src/Object/Post.php:276
+#: src/Object/Post.php:278
 msgid "unignore thread"
 msgstr ""
 
-#: src/Object/Post.php:277
+#: src/Object/Post.php:279
 msgid "toggle ignore status"
 msgstr ""
 
-#: src/Object/Post.php:288
+#: src/Object/Post.php:290
 msgid "add star"
 msgstr ""
 
-#: src/Object/Post.php:289
+#: src/Object/Post.php:291
 msgid "remove star"
 msgstr ""
 
-#: src/Object/Post.php:290
+#: src/Object/Post.php:292
 msgid "toggle star status"
 msgstr ""
 
-#: src/Object/Post.php:293
+#: src/Object/Post.php:295
 msgid "starred"
 msgstr ""
 
-#: src/Object/Post.php:297
+#: src/Object/Post.php:299
 msgid "add tag"
 msgstr ""
 
-#: src/Object/Post.php:308
+#: src/Object/Post.php:310
 msgid "like"
 msgstr ""
 
-#: src/Object/Post.php:309
+#: src/Object/Post.php:311
 msgid "dislike"
 msgstr ""
 
-#: src/Object/Post.php:312
+#: src/Object/Post.php:314
 msgid "Share this"
 msgstr ""
 
-#: src/Object/Post.php:312
+#: src/Object/Post.php:314
 msgid "share"
 msgstr ""
 
-#: src/Object/Post.php:379
+#: src/Object/Post.php:381
 msgid "to"
 msgstr ""
 
-#: src/Object/Post.php:380
+#: src/Object/Post.php:382
 msgid "via"
 msgstr ""
 
-#: src/Object/Post.php:381
+#: src/Object/Post.php:383
 msgid "Wall-to-Wall"
 msgstr ""
 
-#: src/Object/Post.php:382
+#: src/Object/Post.php:384
 msgid "via Wall-To-Wall:"
 msgstr ""
 
-#: src/Object/Post.php:429
+#: src/Object/Post.php:431
 msgid "Notifier task is pending"
 msgstr ""
 
-#: src/Object/Post.php:430
+#: src/Object/Post.php:432
 msgid "Delivery to remote servers is pending"
 msgstr ""
 
-#: src/Object/Post.php:431
+#: src/Object/Post.php:433
 msgid "Delivery to remote servers is underway"
 msgstr ""
 
-#: src/Object/Post.php:432
+#: src/Object/Post.php:434
 msgid "Delivery to remote servers is mostly done"
 msgstr ""
 
-#: src/Object/Post.php:451
+#: src/Object/Post.php:435
+msgid "Delivery to remote servers is done"
+msgstr ""
+
+#: src/Object/Post.php:454
 #, php-format
 msgid "%d comment"
 msgid_plural "%d comments"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Protocol/Diaspora.php:2442
+#: src/Protocol/Diaspora.php:2495
 msgid "Sharing notification from Diaspora network"
 msgstr ""
 
-#: src/Protocol/Diaspora.php:3536
+#: src/Protocol/Diaspora.php:3612
 msgid "Attachments:"
 msgstr ""
 
-#: src/Protocol/OStatus.php:1838
+#: src/Protocol/OStatus.php:1866
 #, php-format
 msgid "%s is now following %s."
 msgstr ""
 
-#: src/Protocol/OStatus.php:1839
+#: src/Protocol/OStatus.php:1867
 msgid "following"
 msgstr ""
 
-#: src/Protocol/OStatus.php:1842
+#: src/Protocol/OStatus.php:1870
 #, php-format
 msgid "%s stopped following %s."
 msgstr ""
 
-#: src/Protocol/OStatus.php:1843
+#: src/Protocol/OStatus.php:1871
 msgid "stopped following"
 msgstr ""
 
-#: src/Util/Temporal.php:150
+#: src/Util/Temporal.php:151
 msgid "YYYY-MM-DD or MM-DD"
 msgstr ""
 
-#: src/Util/Temporal.php:293
+#: src/Util/Temporal.php:298
 msgid "never"
 msgstr ""
 
-#: src/Util/Temporal.php:300
+#: src/Util/Temporal.php:305
 msgid "less than a second ago"
 msgstr ""
 
-#: src/Util/Temporal.php:308
+#: src/Util/Temporal.php:313
 msgid "year"
 msgstr ""
 
-#: src/Util/Temporal.php:308
+#: src/Util/Temporal.php:313
 msgid "years"
 msgstr ""
 
-#: src/Util/Temporal.php:309
+#: src/Util/Temporal.php:314
 msgid "months"
 msgstr ""
 
-#: src/Util/Temporal.php:310
+#: src/Util/Temporal.php:315
 msgid "weeks"
 msgstr ""
 
-#: src/Util/Temporal.php:311
+#: src/Util/Temporal.php:316
 msgid "days"
 msgstr ""
 
-#: src/Util/Temporal.php:312
+#: src/Util/Temporal.php:317
 msgid "hour"
 msgstr ""
 
-#: src/Util/Temporal.php:312
+#: src/Util/Temporal.php:317
 msgid "hours"
 msgstr ""
 
-#: src/Util/Temporal.php:313
+#: src/Util/Temporal.php:318
 msgid "minute"
 msgstr ""
 
-#: src/Util/Temporal.php:313
+#: src/Util/Temporal.php:318
 msgid "minutes"
 msgstr ""
 
-#: src/Util/Temporal.php:314
+#: src/Util/Temporal.php:319
 msgid "second"
 msgstr ""
 
-#: src/Util/Temporal.php:314
+#: src/Util/Temporal.php:319
 msgid "seconds"
 msgstr ""
 
-#: src/Util/Temporal.php:324
+#: src/Util/Temporal.php:329
 #, php-format
 msgid "in %1$d %2$s"
 msgstr ""
 
-#: src/Util/Temporal.php:327
+#: src/Util/Temporal.php:332
 #, php-format
 msgid "%1$d %2$s ago"
 msgstr ""
 
-#: src/Worker/Delivery.php:447
+#: src/Worker/Delivery.php:453
 msgid "(no subject)"
 msgstr ""
 

--- a/view/templates/sub/delivery_count.tpl
+++ b/view/templates/sub/delivery_count.tpl
@@ -11,8 +11,10 @@
 		{{$delivery.delivery_pending}} {{$item.delivery.queue_done}}/{{$item.delivery.queue_count}}
 	{{elseif $delivery.queue_done / $delivery.queue_count < 0.75}}
 		{{$delivery.delivery_underway}} {{$item.delivery.queue_done}}/{{$item.delivery.queue_count}}
-	{{else}}
+	{{elseif $delivery.queue_done < $delivery.queue_count}}
 		{{$delivery.delivery_almost}} {{$item.delivery.queue_done}}/{{$item.delivery.queue_count}}
+	{{else}}
+		{{$delivery.delivery_done}} {{$item.delivery.queue_done}}/{{$item.delivery.queue_count}}
 	{{/if}}
 </span>
 {{/if}}

--- a/view/theme/frio/templates/sub/delivery_count.tpl
+++ b/view/theme/frio/templates/sub/delivery_count.tpl
@@ -10,9 +10,12 @@
 	{{elseif $delivery.queue_done / $delivery.queue_count < 0.75}}
 		<i class="fa fa-paper-plane-o" aria-hidden="true" title="{{$delivery.delivery_underway}} {{$item.delivery.queue_done}}/{{$item.delivery.queue_count}}"></i>
 		<span class="sr-only">{{$delivery.delivery_underway}}</span>
-	{{else}}
+	{{elseif $delivery.queue_done < $delivery.queue_count}}
 		<i class="fa fa-paper-plane" aria-hidden="true" title="{{$delivery.delivery_almost}} {{$item.delivery.queue_done}}/{{$item.delivery.queue_count}}"></i>
 		<span class="sr-only">{{$delivery.delivery_almost}}</span>
+	{{else}}
+		<i class="fa fa-paper-plane" aria-hidden="true" title="{{$delivery.delivery_done}} {{$item.delivery.queue_done}}/{{$item.delivery.queue_count}}"></i>
+		<span class="sr-only">{{$delivery.delivery_done}}</span>
 	{{/if}}
 </span>
 {{/if}}


### PR DESCRIPTION
Follow-up to #6238 

This adds the missing "Delivery done" label, and fixes a small logic error in APdelivery where the Queue Done counter would be incremented even if the `Transmitter::createCachedActivityFromItem` call it depends on failed.

Inspired by https://horche.demkontinuum.de/display/2196d4ee-795c-5304-d57b-7ed480908134