### PR TITLE
Add explicit mentions to ActivityPub/Diaspora comments

### DIFF
--- a/src/Content/Feature.php
+++ b/src/Content/Feature.php
@@ -90,6 +90,7 @@ class Feature
 			'composition' => [
 				L10n::t('Post Composition Features'),
 				['aclautomention', L10n::t('Auto-mention Forums'), L10n::t('Add/remove mention when a forum page is selected/deselected in ACL window.'), false, Config::get('feature_lock', 'aclautomention', false)],
+				['explicit_mentions', L10n::t('Explicit Mentions'), L10n::t('Add explicit mentions to comment box for manual control over who gets mentioned in replies.'), false, Config::get('feature_lock', 'explicit_mentions', false)],
 			],
 
 			// Network sidebar widgets

--- a/src/Model/APContact.php
+++ b/src/Model/APContact.php
@@ -192,7 +192,7 @@ class APContact extends BaseObject
 		DBA::update('apcontact', $apcontact, ['url' => $url], true);
 
 		// Update some data in the contact table with various ways to catch them all
-		$contact_fields = ['name' => $apcontact['name'], 'about' => $apcontact['about']];
+		$contact_fields = ['name' => $apcontact['name'], 'about' => $apcontact['about'], 'alias' => $apcontact['alias']];
 
 		// Fetch the type and match it with the contact type
 		$contact_types = array_keys(ActivityPub::ACCOUNT_TYPES, $apcontact['type']);

--- a/src/Module/Itemsource.php
+++ b/src/Module/Itemsource.php
@@ -17,10 +17,18 @@ class Itemsource extends \Friendica\BaseModule
 			return;
 		}
 
+		$a = self::getApp();
+
+		if (!empty($a->argv[1])) {
+			$guid = $a->argv[1];
+		}
+
+		$guid = defaults($_REQUEST['guid'], $guid);
+
 		$source = '';
 		$item_uri = '';
-		if (!empty($_REQUEST['guid'])) {
-			$item = Model\Item::selectFirst([], ['guid' => $_REQUEST['guid']]);
+		if (!empty($guid)) {
+			$item = Model\Item::selectFirst([], ['guid' => $guid]);
 
 			$conversation = Model\Conversation::getByItemUri($item['uri']);
 

--- a/src/Object/Post.php
+++ b/src/Object/Post.php
@@ -6,6 +6,7 @@ namespace Friendica\Object;
 
 use Friendica\BaseObject;
 use Friendica\Content\ContactSelector;
+use Friendica\Content\Feature;
 use Friendica\Core\Addon;
 use Friendica\Core\Config;
 use Friendica\Core\Hook;
@@ -772,13 +773,18 @@ class Post extends BaseObject
 	 * Get default text for the comment box
 	 *
 	 * @return string
+	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
 	private function getDefaultText()
 	{
 		$a = self::getApp();
 
 		if (!local_user() || empty($a->profile['addr'])) {
-			return;
+			return '';
+		}
+
+		if (!Feature::isEnabled(local_user(), 'explicit_mentions')) {
+			return '';
 		}
 
 		$item = Item::selectFirst(['author-addr'], ['id' => $this->getId()]);

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -13,6 +13,7 @@ use Friendica\Model\Contact;
 use Friendica\Model\APContact;
 use Friendica\Model\Item;
 use Friendica\Model\Event;
+use Friendica\Model\Term;
 use Friendica\Model\User;
 use Friendica\Protocol\ActivityPub;
 use Friendica\Util\DateTimeFormat;
@@ -47,7 +48,7 @@ class Processor
 	 *
 	 * @return string with replaced emojis
 	 */
-	public static function replaceEmojis($emojis, $body)
+	public static function replaceEmojis($body, array $emojis)
 	{
 		foreach ($emojis as $emoji) {
 			$replace = '[class=emoji mastodon][img=' . $emoji['href'] . ']' . $emoji['name'] . '[/img][/class]';
@@ -59,12 +60,12 @@ class Processor
 	/**
 	 * Constructs a string with tags for a given tag array
 	 *
-	 * @param array $tags
+	 * @param array   $tags
 	 * @param boolean $sensitive
-	 *
+	 * @param array   $implicit_mentions List of profile URLs to skip
 	 * @return string with tags
 	 */
-	private static function constructTagList($tags, $sensitive)
+	private static function constructTagString($tags, $sensitive, array $implicit_mentions)
 	{
 		if (empty($tags)) {
 			return '';
@@ -72,7 +73,7 @@ class Processor
 
 		$tag_text = '';
 		foreach ($tags as $tag) {
-			if (in_array(defaults($tag, 'type', ''), ['Mention', 'Hashtag'])) {
+			if (in_array(defaults($tag, 'type', ''), ['Mention', 'Hashtag']) && !in_array($tag['href'], $implicit_mentions)) {
 				if (!empty($tag_text)) {
 					$tag_text .= ',';
 				}
@@ -128,14 +129,35 @@ class Processor
 	 */
 	public static function updateItem($activity)
 	{
-		$item = [];
+		$item = Item::selectFirst(['uri', 'parent-uri', 'gravity'], ['uri' => $activity['id']]);
+		if (!DBA::isResult($item)) {
+			Logger::warning('Unknown item with uri: ' . $activity['id']);
+			return;
+		}
+
 		$item['changed'] = DateTimeFormat::utcNow();
 		$item['edited'] = $activity['updated'];
 		$item['title'] = HTML::toBBCode($activity['name']);
 		$item['content-warning'] = HTML::toBBCode($activity['summary']);
-		$content = self::replaceEmojis($activity['emojis'], HTML::toBBCode($activity['content']));
-		$item['body'] = self::convertMentions($content);
-		$item['tag'] = self::constructTagList($activity['tags'], $activity['sensitive']);
+
+		$content = HTML::toBBCode($activity['content']);
+		$content = self::replaceEmojis($content, $activity['emojis']);
+		$content = self::convertMentions($content);
+
+		$implicit_mentions = [];
+		if (($item['parent-uri'] != $item['uri']) && ($item['gravity'] == GRAVITY_COMMENT)) {
+			$parent = Item::selectFirst(['id', 'author-link', 'alias'], ['uri' => $item['parent-uri']]);
+			if (!DBA::isResult($parent)) {
+				Logger::warning('Unknown item parent with uri: ' . $item['parent-uri']);
+				return;
+			}
+
+			$implicit_mentions = self::getImplicitMentionList($parent);
+			$content = self::removeImplicitMentionsFromBody($content, $implicit_mentions);
+		}
+
+		$item['body'] = $content;
+		$item['tag'] = self::constructTagString($activity['tags'], $activity['sensitive'], $implicit_mentions);
 
 		Item::update($item, ['uri' => $activity['id']]);
 	}
@@ -273,10 +295,15 @@ class Processor
 		}
 
 		$item['uri'] = $activity['id'];
+		$content = HTML::toBBCode($activity['content']);
+		$content = self::replaceEmojis($content, $activity['emojis']);
+		$content = self::convertMentions($content);
+
+		$implicit_mentions = [];
 
 		if (($item['parent-uri'] != $item['uri']) && ($item['gravity'] == GRAVITY_COMMENT)) {
 			$item_private = !in_array(0, $activity['item_receiver']);
-			$parent = Item::selectFirst(['private'], ['uri' => $item['parent-uri']]);
+			$parent = Item::selectFirst(['id', 'private', 'author-link', 'alias'], ['uri' => $item['parent-uri']]);
 			if (!DBA::isResult($parent)) {
 				return;
 			}
@@ -284,6 +311,9 @@ class Processor
 				Logger::log('Item ' . $item['uri'] . ' is private but the parent ' . $item['parent-uri'] . ' is not. So we drop it.');
 				return;
 			}
+
+			$implicit_mentions = self::getImplicitMentionList($parent);
+			$content = self::removeImplicitMentionsFromBody($content, $implicit_mentions);
 		}
 
 		$item['created'] = $activity['published'];
@@ -291,8 +321,7 @@ class Processor
 		$item['guid'] = $activity['diaspora:guid'];
 		$item['title'] = HTML::toBBCode($activity['name']);
 		$item['content-warning'] = HTML::toBBCode($activity['summary']);
-		$content = self::replaceEmojis($activity['emojis'], HTML::toBBCode($activity['content']));
-		$item['body'] = self::convertMentions($content);
+		$item['body'] = $content;
 
 		if (($activity['object_type'] == 'as:Video') && !empty($activity['alternate-url'])) {
 			$item['body'] .= "\n[video]" . $activity['alternate-url'] . '[/video]';
@@ -304,7 +333,7 @@ class Processor
 			$item['coord'] = $item['latitude'] . ' ' . $item['longitude'];
 		}
 
-		$item['tag'] = self::constructTagList($activity['tags'], $activity['sensitive']);
+		$item['tag'] = self::constructTagString($activity['tags'], $activity['sensitive'], $implicit_mentions);
 		$item['app'] = $activity['generator'];
 		$item['plink'] = defaults($activity, 'alternate-url', $item['uri']);
 
@@ -609,5 +638,63 @@ class Processor
 
 		Logger::log('Change existing contact ' . $cid . ' from ' . $contact['network'] . ' to ActivityPub.');
 		Contact::updateFromProbe($cid, Protocol::ACTIVITYPUB);
+	}
+
+	/**
+	 * Collects implicit mentions like:
+	 * - the author of the parent item
+	 * - all the mentioned conversants in the parent item
+	 *
+	 * @param array $parent Item array with at least ['id', 'author-link', 'alias']
+	 * @return array
+	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
+	 */
+	private static function getImplicitMentionList(array $parent)
+	{
+		$parent_terms = Term::tagArrayFromItemId($parent['id'], [TERM_MENTION]);
+
+		$implicit_mentions = [
+			$parent['author-link']
+		];
+
+		if ($parent['alias']) {
+			$implicit_mentions[] = $parent['alias'];
+		}
+
+		foreach ($parent_terms as $term) {
+			$contact = Contact::getDetailsByURL($term['url']);
+
+			$implicit_mentions[] = $contact['url'];
+			$implicit_mentions[] = $contact['nurl'];
+			$implicit_mentions[] = $contact['alias'];
+		}
+
+		return $implicit_mentions;
+	}
+
+	/**
+	 * Strips from the body prepended implicit mentions
+	 *
+	 * @param string $body
+	 * @param array  $implicit_mentions List of profile URLs
+	 * @return string
+	 */
+	private static function removeImplicitMentionsFromBody($body, array $implicit_mentions)
+	{
+		$kept_mentions = [];
+
+		// Extract one prepended mention at a time from the body
+		while(preg_match('#^(@\[url=([^\]]+)].*?\[\/url]\s)(.*)#mi', $body, $matches)) {
+			if (!in_array($matches[2], $implicit_mentions) ) {
+				$kept_mentions[] = $matches[1];
+			}
+
+			$body = $matches[3];
+		}
+
+		// Re-appending the kept mentions to the body after extraction
+		$kept_mentions[] = $body;
+
+		return implode('', $kept_mentions);
 	}
 }

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -131,7 +131,7 @@ class Processor
 	{
 		$item = Item::selectFirst(['uri', 'parent-uri', 'gravity'], ['uri' => $activity['id']]);
 		if (!DBA::isResult($item)) {
-			Logger::warning('Unknown item with uri: ' . $activity['id']);
+			Logger::warning('Unknown item', ['uri' => $activity['id']]);
 			return;
 		}
 
@@ -148,7 +148,7 @@ class Processor
 		if (($item['parent-uri'] != $item['uri']) && ($item['gravity'] == GRAVITY_COMMENT)) {
 			$parent = Item::selectFirst(['id', 'author-link', 'alias'], ['uri' => $item['parent-uri']]);
 			if (!DBA::isResult($parent)) {
-				Logger::warning('Unknown item parent with uri: ' . $item['parent-uri']);
+				Logger::warning('Unknown parent item.', ['uri' => $item['parent-uri']]);
 				return;
 			}
 

--- a/view/templates/crepair.tpl
+++ b/view/templates/crepair.tpl
@@ -27,6 +27,8 @@
 
 	{{include file="field_input.tpl" field=$url}}
 
+	{{include file="field_input.tpl" field=$alias}}
+
 	{{include file="field_input.tpl" field=$request}}
 
 	{{include file="field_input.tpl" field=$confirm}}

--- a/view/theme/frio/templates/crepair.tpl
+++ b/view/theme/frio/templates/crepair.tpl
@@ -29,6 +29,8 @@
 
 		{{include file="field_input.tpl" field=$url}}
 
+		{{include file="field_input.tpl" field=$alias}}
+
 		{{include file="field_input.tpl" field=$request}}
 
 		{{include file="field_input.tpl" field=$confirm}}


### PR DESCRIPTION
Most part of #6552 

This PR covers almost all the steps described in #6552 expect the redesign of the comment box for threads with at least one reply.

By default, this PR reverts the interface behavior of #6541 since it is now hidden behind an "Additional Feature" user admin/setting.

However, it still adds implicit mentions to comments delivered via ActivityPub or Diaspora, and strips implicit mentions from ActivityPub comments, decluttering thread display and clearing up notifications from irrelevant mentions.

Enabling the explicit mentions additional feature restores #6541 full behavior with pre-populated comment boxes and no implicit mentions added to outgoing messages. Incoming AP implicit mentions are still cleaned up.