### PR TITLE
Restore legacy REGISTER_* constants for local config backward compatibility

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -92,6 +92,13 @@ define('SSL_POLICY_FULL',         1);
 define('SSL_POLICY_SELFSIGN',     2);
 /* @}*/
 
+/** @deprecated since version 2019.03, please use \Friendica\Module\Register::CLOSED instead */
+define('REGISTER_CLOSED',        \Friendica\Module\Register::CLOSED);
+/** @deprecated since version 2019.03, please use \Friendica\Module\Register::APPROVE instead */
+define('REGISTER_APPROVE',       \Friendica\Module\Register::APPROVE);
+/** @deprecated since version 2019.03, please use \Friendica\Module\Register::OPEN instead */
+define('REGISTER_OPEN',          \Friendica\Module\Register::OPEN);
+
 /**
  * @name CP
  *


### PR DESCRIPTION
Follow-up to #6336 

I found out the hard way I had to restore these deprecated constants because the local config file was using them and it bricked my whole site until I replaced them with the new constants.

I just made the upgrade to 2019.03 a lot less challenging.