### PR TITLE
style the warning in crepair

### DIFF
--- a/view/global.css
+++ b/view/global.css
@@ -537,6 +537,7 @@ td.pendingnote > p > span {
 }
 
 /* warning message */
+.crepair-error-message,
 .warning-message {
   padding: 10px;
   margin: 5px;


### PR DESCRIPTION
This PR applies the same styling to the `crepair` warning message as is used in the admin panel for warnings.

Before the "Warning" looked a bit harmless for my taste.