### PR TITLE
ACL network - fixed preselected acl items

### DIFF
--- a/mod/network.php
+++ b/mod/network.php
@@ -525,7 +525,7 @@ function networkThreadedView(App $a, $update, $parent)
 				}
 			} elseif (intval($a->argv[$x])) {
 				$gid = intval($a->argv[$x]);
-				$default_permissions = ['allow_gid' => '<' . $gid . '>'];
+				$default_permissions['allow_gid'] = [$gid];
 			}
 		}
 	}
@@ -540,18 +540,18 @@ function networkThreadedView(App $a, $update, $parent)
 	$nets  =        defaults($_GET, 'nets' , '');
 
 	if ($cid) {
-		$default_permissions = ['allow_cid' => '<' . intval($cid) . '>'];
+		$default_permissions['allow_cid'] = [(int) $cid];
 	}
 
 	if ($nets) {
 		$r = DBA::select('contact', ['id'], ['uid' => local_user(), 'network' => $nets], ['self' => false]);
 
-		$str = '';
+		$str = [];
 		while ($rr = DBA::fetch($r)) {
-			$str .= '<' . $rr['id'] . '>';
+			$str[] = (int) $rr['id'];
 		}
 		if (strlen($str)) {
-			$default_permissions = ['allow_cid' => $str];
+			$default_permissions['allow_cid'] = $str;
 		}
 	}
 

--- a/src/Core/ACL.php
+++ b/src/Core/ACL.php
@@ -293,16 +293,16 @@ class ACL extends BaseObject
 						L10n::t('Hide your profile details from unknown viewers?'));
 			}
 		}
-
+		
 		$tpl = Renderer::getMarkupTemplate('acl_selector.tpl');
 		$o = Renderer::replaceMacros($tpl, [
 			'$showall' => L10n::t('Visible to everybody'),
 			'$show' => L10n::t('show'),
 			'$hide' => L10n::t('don\'t show'),
-			'$allowcid' => json_encode(defaults($default_permissions, 'allow_cid', '')),
-			'$allowgid' => json_encode(defaults($default_permissions, 'allow_gid', '')),
-			'$denycid' => json_encode(defaults($default_permissions, 'deny_cid', '')),
-			'$denygid' => json_encode(defaults($default_permissions, 'deny_gid', '')),
+			'$allowcid' => json_encode(defaults($default_permissions, 'allow_cid', [])), // we need arrays for Javascript since we call .remove() and .push() on this values
+			'$allowgid' => json_encode(defaults($default_permissions, 'allow_gid', [])),
+			'$denycid' => json_encode(defaults($default_permissions, 'deny_cid', [])),
+			'$denygid' => json_encode(defaults($default_permissions, 'deny_gid', [])),
 			'$networks' => $show_jotnets,
 			'$emailcc' => L10n::t('CC: email addresses'),
 			'$emtitle' => L10n::t('Example: bob@example.com, mary@example.com'),


### PR DESCRIPTION
#6579 

Sorry for my bad branch name .. forgot to create and switch to new branch. ;-)
Anyways .. the commit is clean

The problem was, we got strings like `"<4>"` for the initial acl item IDs when we instanciate ACL in JS in `acl_selector.tpl`.
We need arrays of integers! When we dont have an ID, we need an empty array, since we call .remove() and .push() on these values in class ACL in JS.
