### PR TITLE
Don't send single item deletions to protocols that support account removal

### DIFF
--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -134,7 +134,8 @@ class User
 			`user`.`spubkey`,
 			`user`.`page-flags`,
 			`user`.`account-type`,
-			`user`.`prvnets`
+			`user`.`prvnets`,
+			`user`.`account_removed`
 			FROM `contact`
 			INNER JOIN `user`
 				ON `user`.`uid` = `contact`.`uid`


### PR DESCRIPTION
Especially large servers do have massive problems delivering the item delete commands in time when someone removes their account when it contains many posts.

Diaspora and Activity do know account removal commands. So we don't need to send dedicated item deletion commands to them.