### PR TITLE
Ensure that "strtotime" returns the correct timestamp

### DIFF
--- a/mod/worker.php
+++ b/mod/worker.php
@@ -17,6 +17,9 @@ function worker_init()
 		return;
 	}
 
+	// Ensure that all "strtotime" operations do run timezone independent
+	date_default_timezone_set('UTC');
+
 	// We don't need the following lines if we can execute background jobs.
 	// So we just wake up the worker if it sleeps.
 	if (function_exists("proc_open")) {

--- a/src/Core/Worker.php
+++ b/src/Core/Worker.php
@@ -40,6 +40,9 @@ class Worker
 	{
 		$a = \get_app();
 
+		// Ensure that all "strtotime" operations do run timezone independent
+		date_default_timezone_set('UTC');
+
 		self::$up_start = microtime(true);
 
 		// At first check the maximum load. We shouldn't continue with a high load
@@ -650,8 +653,7 @@ class Worker
 				$argv[0] = basename($argv[0]);
 
 				// How long is the process already running?
-				// For some weird reasons we cannot use "time()" here. It doesn't seem to be in UTC.
-				$duration = (strtotime(DateTimeFormat::utcNow()) - strtotime($entry["executed"])) / 60;
+				$duration = (time() - strtotime($entry["executed"])) / 60;
 				if ($duration > $max_duration) {
 					Logger::log("Worker process ".$entry["pid"]." (".substr(json_encode($argv), 0, 50).") took more than ".$max_duration." minutes. It will be killed now.");
 					posix_kill($entry["pid"], SIGTERM);


### PR DESCRIPTION
```strtotime``` is executed in the context of the current timezone when the given string doesn't contain a timezone value. This leads to some unexpected behaviour when - for example - working with a ```strtotime``` on a database date field.

The worker is now always working in UTC, so it is fixed here. (But we have to check the code for other occurrences)