### PR TITLE
New configuration to disable the automatic mentions removal

### DIFF
--- a/config/defaults.config.php
+++ b/config/defaults.config.php
@@ -135,6 +135,10 @@ return [
 		// Disables the check if a mail address is in a valid format and can be resolved via DNS.
 		'disable_email_validation' => false,
 
+		// disable_mentions_removal (Boolean)
+		// Disables the automatic removal of mentions in ActivityPub postings.
+		'disable_mentions_removal' => false,
+
 		// disable_url_validation (Boolean)
 		// Disables the DNS lookup of an URL.
 		'disable_url_validation' => false,

--- a/config/defaults.config.php
+++ b/config/defaults.config.php
@@ -136,7 +136,7 @@ return [
 		'disable_email_validation' => false,
 
 		// disable_mentions_removal (Boolean)
-		// Disables the automatic removal of mentions in ActivityPub postings.
+		// Disables the automatic removal of implicit mentions in ActivityPub postings.
 		'disable_mentions_removal' => false,
 
 		// disable_url_validation (Boolean)

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -689,6 +689,10 @@ class Processor
 	 */
 	private static function removeImplicitMentionsFromBody($body, array $implicit_mentions)
 	{
+		if (Config::get('system', 'disable_mentions_removal')) {
+			return;
+		}
+
 		$kept_mentions = [];
 
 		// Extract one prepended mention at a time from the body

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -690,7 +690,7 @@ class Processor
 	private static function removeImplicitMentionsFromBody($body, array $implicit_mentions)
 	{
 		if (Config::get('system', 'disable_mentions_removal')) {
-			return;
+			return $body;
 		}
 
 		$kept_mentions = [];


### PR DESCRIPTION
The behaviour to automatically remove mentions from the body of AP messages is now configurable.