### PR TITLE
Worker: Changed behaviour of "worker_fetch_limit" config value

### DIFF
--- a/src/Core/Worker.php
+++ b/src/Core/Worker.php
@@ -448,7 +448,7 @@ class Worker
 			Logger::log("Prio ".$queue["priority"].": ".$queue["parameter"]." - longer than 2 minutes (".round($duration/60, 3).")", Logger::DEBUG);
 		}
 
-		Logger::log("Process ".$mypid." - Prio ".$queue["priority"]." - ID ".$queue["id"].": ".$funcname." - done in ".$duration." seconds. Process PID: ".$new_process_id);
+		Logger::log("Process ".$mypid." - Prio ".$queue["priority"]." - ID ".$queue["id"].": ".$funcname." - done in ".number_format($duration, 4)." seconds. Process PID: ".$new_process_id);
 
 		// Write down the performance values into the log
 		if (Config::get("system", "profiler")) {
@@ -930,7 +930,7 @@ class Worker
 				['id'],
 				["`pid` = 0 AND `priority` < ? AND NOT `done` AND `next_try` < ?",
 				$highest_priority, DateTimeFormat::utcNow()],
-				['limit' => $limit, 'order' => ['priority', 'created']]
+				['limit' => 1, 'order' => ['priority', 'created']]
 			);
 			self::$db_duration += (microtime(true) - $stamp);
 
@@ -949,7 +949,7 @@ class Worker
 					['id'],
 					["`pid` = 0 AND `priority` > ? AND NOT `done` AND `next_try` < ?",
 					$highest_priority, DateTimeFormat::utcNow()],
-					['limit' => $limit, 'order' => ['priority', 'created']]
+					['limit' => 1, 'order' => ['priority', 'created']]
 				);
 				self::$db_duration += (microtime(true) - $stamp);
 
@@ -963,6 +963,26 @@ class Worker
 			}
 		}
 
+		// At first try to fetch a bunch of high or medium tasks
+		if (!$found && ($limit > 1)) {
+			$stamp = (float)microtime(true);
+			$result = DBA::select(
+				'workerqueue',
+				['id'],
+				["`pid` = 0 AND NOT `done` AND `priority` <= ? AND `next_try` < ? AND `retrial` = 0",
+				PRIORITY_MEDIUM, DateTimeFormat::utcNow()],
+				['limit' => $limit, 'order' => ['created']]
+			);
+			self::$db_duration += (microtime(true) - $stamp);
+
+			while ($id = DBA::fetch($result)) {
+				$ids[] = $id["id"];
+			}
+			DBA::close($result);
+
+			$found = (count($ids) > 0);
+		}
+
 		// If there is no result (or we shouldn't pass lower processes) we check without priority limit
 		if (!$found) {
 			$stamp = (float)microtime(true);
@@ -971,7 +991,7 @@ class Worker
 				['id'],
 				["`pid` = 0 AND NOT `done` AND `next_try` < ?",
 				DateTimeFormat::utcNow()],
-				['limit' => $limit, 'order' => ['priority', 'created']]
+				['limit' => 1, 'order' => ['priority', 'created']]
 			);
 			self::$db_duration += (microtime(true) - $stamp);
 

--- a/src/Core/Worker.php
+++ b/src/Core/Worker.php
@@ -370,7 +370,9 @@ class Worker
 
 		$argc = count($argv);
 
-		$new_process_id = System::processID("wrk");
+		// Currently deactivated, since the new logger doesn't support this
+		//$new_process_id = System::processID("wrk");
+		$new_process_id = '';
 
 		Logger::log("Process ".$mypid." - Prio ".$queue["priority"]." - ID ".$queue["id"].": ".$funcname." ".$queue["parameter"]." - Process PID: ".$new_process_id);
 


### PR DESCRIPTION
The config value "worker_fetch_limit" by now simply defined the number of worker tasks that had been assigned to a worker in a single step. This means that a worker is not only receiving the next task, but also a number of additional tasks that will be processed by this worker after the current task had been processed.

This process is fine for tasks that are processed very fast, but not very good for processes with lower priorities that could last for several minutes or for tasks that failed for the first time.

Because of this, the setting "worker_fetch_limit" now only has an effect on processes with high and medium priority and only when this isn't a process that had failed on the first time.