### PR TITLE
[frio] Improve thread display

### DIFF
--- a/include/conversation.php
+++ b/include/conversation.php
@@ -1082,10 +1082,9 @@ function format_like($cnt, array $arr, $type, $id) {
 				break;
 		}
 
-		$expanded .= "\t" . '<div class="wall-item-' . $type . '-expanded" id="' . $type . 'list-' . $id . '" style="display: none;" >' . $explikers . EOL . '</div>';
+		$expanded .= "\t" . '<p class="wall-item-' . $type . '-expanded" id="' . $type . 'list-' . $id . '" style="display: none;" >' . $explikers . EOL . '</p>';
 	}
 
-	$phrase .= EOL;
 	$o .= Renderer::replaceMacros(Renderer::getMarkupTemplate('voting_fakelink.tpl'), [
 		'$phrase' => $phrase,
 		'$type' => $type,

--- a/src/App.php
+++ b/src/App.php
@@ -663,8 +663,6 @@ class App
 			'$local_user'      => local_user(),
 			'$generator'       => 'Friendica' . ' ' . FRIENDICA_VERSION,
 			'$delitem'         => Core\L10n::t('Delete this item?'),
-			'$showmore'        => Core\L10n::t('show more'),
-			'$showfewer'       => Core\L10n::t('show fewer'),
 			'$update_interval' => $interval,
 			'$shortcut_icon'   => $shortcut_icon,
 			'$touch_icon'      => $touch_icon,

--- a/src/Object/Post.php
+++ b/src/Object/Post.php
@@ -415,6 +415,7 @@ class Post extends BaseObject
 			'dislike'         => $responses['dislike']['output'],
 			'responses'       => $responses,
 			'switchcomment'   => L10n::t('Comment'),
+			'reply_label'     => L10n::t('Reply to %s', $name_e),
 			'comment'         => $comment,
 			'previewing'      => $conv->isPreview() ? ' preview ' : '',
 			'wait'            => L10n::t('Please wait'),
@@ -449,13 +450,13 @@ class Post extends BaseObject
 			foreach ($children as $child) {
 				$result['children'][] = $child->getTemplateData($conv_responses, $thread_level + 1);
 			}
+
 			// Collapse
 			if (($nb_children > 2) || ($thread_level > 1)) {
 				$result['children'][0]['comment_firstcollapsed'] = true;
 				$result['children'][0]['num_comments'] = L10n::tt('%d comment', '%d comments', $total_children);
-				$result['children'][0]['hidden_comments_num'] = $total_children;
-				$result['children'][0]['hidden_comments_text'] = L10n::tt('comment', 'comments', $total_children);
-				$result['children'][0]['hide_text'] = L10n::t('show more');
+				$result['children'][0]['show_text'] = L10n::t('Show more');
+				$result['children'][0]['hide_text'] = L10n::t('Show fewer');
 				if ($thread_level > 1) {
 					$result['children'][$nb_children - 1]['comment_lastcollapsed'] = true;
 				} else {

--- a/view/global.css
+++ b/view/global.css
@@ -90,6 +90,15 @@ span.connector {
   margin-right: 0px;
 }
 
+
+.wall-item-like-expanded,
+.wall-item-dislike-expanded,
+.wall-item-attendyes-expanded,
+.wall-item-attendno-expanded,
+.wall-item-attendmaybe-expanded {
+  margin: 0;
+}
+
 .type-link blockquote, .type-video blockquote {
   margin-left: 0px;
   max-height: 160px;

--- a/view/js/main.js
+++ b/view/js/main.js
@@ -17,25 +17,30 @@ function _resizeIframe(obj, desth) {
 }
 
 function openClose(theID) {
-	if (document.getElementById(theID).style.display == "block") {
-		document.getElementById(theID).style.display = "none"
-	} else {
-		document.getElementById(theID).style.display = "block"
+	var el = document.getElementById(theID);
+	if (el) {
+		if (window.getComputedStyle(el).display === "none") {
+			openMenu(theID);
+		} else {
+			closeMenu(theID);
+		}
 	}
 }
 
 function openMenu(theID) {
 	var el = document.getElementById(theID);
-
 	if (el) {
-		el.style.display = "block";
+		if (!el.dataset.display) {
+			el.dataset.display = 'block';
+		}
+		el.style.display = el.dataset.display;
 	}
 }
 
 function closeMenu(theID) {
-	var el = document.getElementById(theID)
-
+	var el = document.getElementById(theID);
 	if (el) {
+		el.dataset.display = window.getComputedStyle(el).display;
 		el.style.display = "none";
 	}
 }

--- a/view/js/main.js
+++ b/view/js/main.js
@@ -656,12 +656,14 @@ function preview_comment(id) {
 }
 
 function showHideComments(id) {
-	if ($("#collapsed-comments-" + id).is(":visible")) {
-		$("#collapsed-comments-" + id).hide();
-		$("#hide-comments-" + id).html(window.showMore);
+	if ($('#collapsed-comments-' + id).is(':visible')) {
+		$('#collapsed-comments-' + id).slideUp();
+		$('#hide-comments-' + id).hide();
+		$('#hide-comments-total-' + id).show();
 	} else {
-		$("#collapsed-comments-" + id).show();
-		$("#hide-comments-" + id).html(window.showFewer);
+		$('#collapsed-comments-' + id).slideDown();
+		$('#hide-comments-' + id).show();
+		$('#hide-comments-total-' + id).hide();
 	}
 }
 

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-02-10 08:14+0100\n"
+"POT-Creation-Date: 2019-02-15 09:33-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -41,13 +41,13 @@ msgstr ""
 #: mod/photos.php:1126 mod/photos.php:1143 mod/photos.php:1636
 #: mod/profile_photo.php:85 mod/profile_photo.php:94 mod/profile_photo.php:103
 #: mod/profile_photo.php:217 mod/profile_photo.php:305
-#: mod/profile_photo.php:315 src/Model/User.php:735 src/Model/User.php:743
-#: src/Model/User.php:751
+#: mod/profile_photo.php:315 src/Model/User.php:736 src/Model/User.php:744
+#: src/Model/User.php:752
 msgid "Profile Photos"
 msgstr ""
 
 #: include/conversation.php:160 include/conversation.php:297
-#: src/Model/Item.php:3265
+#: src/Model/Item.php:3283
 msgid "event"
 msgstr ""
 
@@ -58,7 +58,7 @@ msgid "status"
 msgstr ""
 
 #: include/conversation.php:168 include/conversation.php:305
-#: mod/subthread.php:88 mod/tagger.php:70 src/Model/Item.php:3267
+#: mod/subthread.php:88 mod/tagger.php:70 src/Model/Item.php:3285
 msgid "photo"
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr ""
 msgid "Dislikes"
 msgstr ""
 
-#: include/conversation.php:569 include/conversation.php:1506
+#: include/conversation.php:569 include/conversation.php:1505
 #: mod/photos.php:1468
 msgid "Attending"
 msgid_plural "Attending"
@@ -165,9 +165,9 @@ msgstr ""
 msgid "View in context"
 msgstr ""
 
-#: include/conversation.php:721 include/conversation.php:1172
+#: include/conversation.php:721 include/conversation.php:1171
 #: mod/editpost.php:88 mod/message.php:260 mod/message.php:442
-#: mod/photos.php:1440 mod/wallmessage.php:141 src/Object/Post.php:420
+#: mod/photos.php:1440 mod/wallmessage.php:141 src/Object/Post.php:421
 msgid "Please wait"
 msgstr ""
 
@@ -183,43 +183,43 @@ msgstr ""
 msgid "Follow Thread"
 msgstr ""
 
-#: include/conversation.php:894 src/Model/Contact.php:1032
+#: include/conversation.php:894 src/Model/Contact.php:1049
 msgid "View Status"
 msgstr ""
 
 #: include/conversation.php:895 include/conversation.php:911
 #: mod/allfriends.php:72 mod/directory.php:167 mod/dirfind.php:226
-#: mod/match.php:87 mod/suggest.php:87 src/Model/Contact.php:972
-#: src/Model/Contact.php:1025 src/Model/Contact.php:1033
+#: mod/match.php:87 mod/suggest.php:87 src/Model/Contact.php:989
+#: src/Model/Contact.php:1042 src/Model/Contact.php:1050
 msgid "View Profile"
 msgstr ""
 
-#: include/conversation.php:896 src/Model/Contact.php:1034
+#: include/conversation.php:896 src/Model/Contact.php:1051
 msgid "View Photos"
 msgstr ""
 
-#: include/conversation.php:897 src/Model/Contact.php:1026
-#: src/Model/Contact.php:1035
+#: include/conversation.php:897 src/Model/Contact.php:1043
+#: src/Model/Contact.php:1052
 msgid "Network Posts"
 msgstr ""
 
-#: include/conversation.php:898 src/Model/Contact.php:1027
-#: src/Model/Contact.php:1036
+#: include/conversation.php:898 src/Model/Contact.php:1044
+#: src/Model/Contact.php:1053
 msgid "View Contact"
 msgstr ""
 
-#: include/conversation.php:899 src/Model/Contact.php:1038
+#: include/conversation.php:899 src/Model/Contact.php:1055
 msgid "Send PM"
 msgstr ""
 
-#: include/conversation.php:903 src/Model/Contact.php:1039
+#: include/conversation.php:903 src/Model/Contact.php:1056
 msgid "Poke"
 msgstr ""
 
 #: include/conversation.php:908 mod/allfriends.php:73 mod/dirfind.php:227
 #: mod/follow.php:147 mod/match.php:88 mod/suggest.php:88
-#: view/theme/vier/theme.php:201 src/Content/Widget.php:63
-#: src/Model/Contact.php:1028 src/Module/Contact.php:574
+#: src/Content/Widget.php:63 src/Model/Contact.php:1045
+#: src/Module/Contact.php:574 view/theme/vier/theme.php:201
 msgid "Connect/Follow"
 msgstr ""
 
@@ -307,130 +307,130 @@ msgstr ""
 msgid "%s attend maybe."
 msgstr ""
 
-#: include/conversation.php:1111
+#: include/conversation.php:1110
 msgid "Visible to <strong>everybody</strong>"
 msgstr ""
 
-#: include/conversation.php:1112 src/Object/Post.php:882
+#: include/conversation.php:1111 src/Object/Post.php:883
 msgid "Please enter a image/video/audio/webpage URL:"
 msgstr ""
 
-#: include/conversation.php:1113
+#: include/conversation.php:1112
 msgid "Tag term:"
 msgstr ""
 
-#: include/conversation.php:1114 mod/filer.php:35
+#: include/conversation.php:1113 mod/filer.php:35
 msgid "Save to Folder:"
 msgstr ""
 
-#: include/conversation.php:1115
+#: include/conversation.php:1114
 msgid "Where are you right now?"
 msgstr ""
 
-#: include/conversation.php:1116
+#: include/conversation.php:1115
 msgid "Delete item(s)?"
 msgstr ""
 
-#: include/conversation.php:1148
+#: include/conversation.php:1147
 msgid "New Post"
 msgstr ""
 
-#: include/conversation.php:1151
+#: include/conversation.php:1150
 msgid "Share"
 msgstr ""
 
-#: include/conversation.php:1152 mod/editpost.php:74 mod/message.php:258
+#: include/conversation.php:1151 mod/editpost.php:74 mod/message.php:258
 #: mod/message.php:439 mod/wallmessage.php:139
 msgid "Upload photo"
 msgstr ""
 
-#: include/conversation.php:1153 mod/editpost.php:75
+#: include/conversation.php:1152 mod/editpost.php:75
 msgid "upload photo"
 msgstr ""
 
-#: include/conversation.php:1154 mod/editpost.php:76
+#: include/conversation.php:1153 mod/editpost.php:76
 msgid "Attach file"
 msgstr ""
 
-#: include/conversation.php:1155 mod/editpost.php:77
+#: include/conversation.php:1154 mod/editpost.php:77
 msgid "attach file"
 msgstr ""
 
-#: include/conversation.php:1156 src/Object/Post.php:874
+#: include/conversation.php:1155 src/Object/Post.php:875
 msgid "Bold"
 msgstr ""
 
-#: include/conversation.php:1157 src/Object/Post.php:875
+#: include/conversation.php:1156 src/Object/Post.php:876
 msgid "Italic"
 msgstr ""
 
-#: include/conversation.php:1158 src/Object/Post.php:876
+#: include/conversation.php:1157 src/Object/Post.php:877
 msgid "Underline"
 msgstr ""
 
-#: include/conversation.php:1159 src/Object/Post.php:877
+#: include/conversation.php:1158 src/Object/Post.php:878
 msgid "Quote"
 msgstr ""
 
-#: include/conversation.php:1160 src/Object/Post.php:878
+#: include/conversation.php:1159 src/Object/Post.php:879
 msgid "Code"
 msgstr ""
 
-#: include/conversation.php:1161 src/Object/Post.php:879
+#: include/conversation.php:1160 src/Object/Post.php:880
 msgid "Image"
 msgstr ""
 
-#: include/conversation.php:1162 src/Object/Post.php:880
+#: include/conversation.php:1161 src/Object/Post.php:881
 msgid "Link"
 msgstr ""
 
-#: include/conversation.php:1163 src/Object/Post.php:881
+#: include/conversation.php:1162 src/Object/Post.php:882
 msgid "Link or Media"
 msgstr ""
 
-#: include/conversation.php:1164 mod/editpost.php:84
+#: include/conversation.php:1163 mod/editpost.php:84
 msgid "Set your location"
 msgstr ""
 
-#: include/conversation.php:1165 mod/editpost.php:85
+#: include/conversation.php:1164 mod/editpost.php:85
 msgid "set location"
 msgstr ""
 
-#: include/conversation.php:1166 mod/editpost.php:86
+#: include/conversation.php:1165 mod/editpost.php:86
 msgid "Clear browser location"
 msgstr ""
 
-#: include/conversation.php:1167 mod/editpost.php:87
+#: include/conversation.php:1166 mod/editpost.php:87
 msgid "clear location"
 msgstr ""
 
-#: include/conversation.php:1169 mod/editpost.php:102
+#: include/conversation.php:1168 mod/editpost.php:102
 msgid "Set title"
 msgstr ""
 
-#: include/conversation.php:1171 mod/editpost.php:104
+#: include/conversation.php:1170 mod/editpost.php:104
 msgid "Categories (comma-separated list)"
 msgstr ""
 
-#: include/conversation.php:1173 mod/editpost.php:89
+#: include/conversation.php:1172 mod/editpost.php:89
 msgid "Permission settings"
 msgstr ""
 
-#: include/conversation.php:1174 mod/editpost.php:119
+#: include/conversation.php:1173 mod/editpost.php:119
 msgid "permissions"
 msgstr ""
 
-#: include/conversation.php:1183 mod/editpost.php:99
+#: include/conversation.php:1182 mod/editpost.php:99
 msgid "Public post"
 msgstr ""
 
-#: include/conversation.php:1187 mod/editpost.php:110 mod/events.php:551
+#: include/conversation.php:1186 mod/editpost.php:110 mod/events.php:551
 #: mod/photos.php:1458 mod/photos.php:1497 mod/photos.php:1557
-#: src/Object/Post.php:883
+#: src/Object/Post.php:884
 msgid "Preview"
 msgstr ""
 
-#: include/conversation.php:1191 include/items.php:396 mod/dfrn_request.php:650
+#: include/conversation.php:1190 include/items.php:396 mod/dfrn_request.php:650
 #: mod/editpost.php:113 mod/fbrowser.php:104 mod/fbrowser.php:134
 #: mod/follow.php:161 mod/message.php:153 mod/photos.php:257 mod/photos.php:325
 #: mod/settings.php:666 mod/settings.php:692 mod/suggest.php:44
@@ -439,49 +439,49 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: include/conversation.php:1196
+#: include/conversation.php:1195
 msgid "Post to Groups"
 msgstr ""
 
-#: include/conversation.php:1197
+#: include/conversation.php:1196
 msgid "Post to Contacts"
 msgstr ""
 
-#: include/conversation.php:1198
+#: include/conversation.php:1197
 msgid "Private post"
 msgstr ""
 
-#: include/conversation.php:1203 mod/editpost.php:117 src/Model/Profile.php:370
+#: include/conversation.php:1202 mod/editpost.php:117 src/Model/Profile.php:370
 msgid "Message"
 msgstr ""
 
-#: include/conversation.php:1204 mod/editpost.php:118
+#: include/conversation.php:1203 mod/editpost.php:118
 msgid "Browser"
 msgstr ""
 
-#: include/conversation.php:1476
+#: include/conversation.php:1475
 msgid "View all"
 msgstr ""
 
-#: include/conversation.php:1500
+#: include/conversation.php:1499
 msgid "Like"
 msgid_plural "Likes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: include/conversation.php:1503
+#: include/conversation.php:1502
 msgid "Dislike"
 msgid_plural "Dislikes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: include/conversation.php:1509
+#: include/conversation.php:1508
 msgid "Not Attending"
 msgid_plural "Not Attending"
 msgstr[0] ""
 msgstr[1] ""
 
-#: include/conversation.php:1512 src/Content/ContactSelector.php:167
+#: include/conversation.php:1511 src/Content/ContactSelector.php:167
 msgid "Undecided"
 msgid_plural "Undecided"
 msgstr[0] ""
@@ -829,16 +829,17 @@ msgstr ""
 #: mod/invite.php:111 mod/item.php:167 mod/manage.php:129 mod/message.php:56
 #: mod/message.php:101 mod/network.php:35 mod/nogroup.php:18 mod/notes.php:27
 #: mod/notifications.php:70 mod/ostatus_subscribe.php:18 mod/photos.php:186
-#: mod/photos.php:1020 mod/poke.php:141 mod/profile_photo.php:32
-#: mod/profile_photo.php:177 mod/profile_photo.php:204 mod/profiles.php:182
-#: mod/profiles.php:499 mod/regmod.php:89 mod/repair_ostatus.php:16
+#: mod/photos.php:1020 mod/poke.php:141 mod/profiles.php:182
+#: mod/profiles.php:499 mod/profile_photo.php:32 mod/profile_photo.php:177
+#: mod/profile_photo.php:204 mod/regmod.php:89 mod/repair_ostatus.php:16
 #: mod/settings.php:48 mod/settings.php:154 mod/settings.php:655
 #: mod/suggest.php:62 mod/uimport.php:17 mod/unfollow.php:22
 #: mod/unfollow.php:77 mod/unfollow.php:109 mod/viewcontacts.php:56
-#: mod/wall_attach.php:76 mod/wall_attach.php:79 mod/wall_upload.php:107
-#: mod/wall_upload.php:110 mod/wallmessage.php:19 mod/wallmessage.php:43
-#: mod/wallmessage.php:82 mod/wallmessage.php:106 src/Module/Attach.php:42
-#: src/Module/Contact.php:360 src/Module/Register.php:193 src/App.php:1482
+#: mod/wallmessage.php:19 mod/wallmessage.php:43 mod/wallmessage.php:82
+#: mod/wallmessage.php:106 mod/wall_attach.php:76 mod/wall_attach.php:79
+#: mod/wall_upload.php:107 mod/wall_upload.php:110 src/App.php:1480
+#: src/Module/Attach.php:42 src/Module/Contact.php:360
+#: src/Module/Register.php:193
 msgid "Permission denied."
 msgstr ""
 
@@ -846,26 +847,9 @@ msgstr ""
 msgid "Archives"
 msgstr ""
 
-#: include/items.php:520 view/theme/vier/theme.php:255
-#: src/Content/ForumManager.php:135 src/Content/Widget.php:329
-#: src/Object/Post.php:458 src/App.php:666
+#: include/items.php:520 src/Content/ForumManager.php:135
+#: src/Content/Widget.php:329 view/theme/vier/theme.php:255
 msgid "show more"
-msgstr ""
-
-#: mod/apps.php:15 src/App.php:1351
-msgid "You must be logged in to use addons. "
-msgstr ""
-
-#: mod/apps.php:20
-msgid "Applications"
-msgstr ""
-
-#: mod/apps.php:25
-msgid "No installed applications."
-msgstr ""
-
-#: mod/maintenance.php:26
-msgid "System down for maintenance"
 msgstr ""
 
 #: mod/admin.php:122
@@ -1035,7 +1019,7 @@ msgid "Save Settings"
 msgstr ""
 
 #: mod/admin.php:386 mod/admin.php:404 mod/dfrn_request.php:346
-#: mod/friendica.php:131 src/Model/Contact.php:1702
+#: mod/friendica.php:131 src/Model/Contact.php:1719
 msgid "Blocked domain"
 msgstr ""
 
@@ -1275,8 +1259,8 @@ msgstr ""
 msgid "Recipient Profile"
 msgstr ""
 
-#: mod/admin.php:828 view/theme/frio/theme.php:269
-#: src/Core/NotificationsManager.php:182 src/Content/Nav.php:239
+#: mod/admin.php:828 src/Content/Nav.php:239
+#: src/Core/NotificationsManager.php:182 view/theme/frio/theme.php:269
 msgid "Network"
 msgstr ""
 
@@ -2525,7 +2509,7 @@ msgid ""
 "\t\t\tThank you and welcome to %4$s."
 msgstr ""
 
-#: mod/admin.php:1871 src/Model/User.php:858
+#: mod/admin.php:1871 src/Model/User.php:859
 #, php-format
 msgid "Registration details for %s"
 msgstr ""
@@ -2727,7 +2711,7 @@ msgid "Toggle"
 msgstr ""
 
 #: mod/admin.php:2181 mod/admin.php:2438 mod/newmember.php:20
-#: mod/settings.php:136 view/theme/frio/theme.php:272 src/Content/Nav.php:263
+#: mod/settings.php:136 src/Content/Nav.php:263 view/theme/frio/theme.php:272
 msgid "Settings"
 msgstr ""
 
@@ -2891,6 +2875,18 @@ msgstr ""
 msgid "No"
 msgstr ""
 
+#: mod/apps.php:15 src/App.php:1349
+msgid "You must be logged in to use addons. "
+msgstr ""
+
+#: mod/apps.php:20
+msgid "Applications"
+msgstr ""
+
+#: mod/apps.php:25
+msgid "No installed applications."
+msgstr ""
+
 #: mod/babel.php:25
 msgid "Source input"
 msgstr ""
@@ -3013,7 +3009,7 @@ msgid "Access denied."
 msgstr ""
 
 #: mod/cal.php:46 mod/dfrn_poll.php:486 mod/help.php:68 mod/viewcontacts.php:34
-#: src/App.php:1402
+#: src/App.php:1400
 msgid "Page not found."
 msgstr ""
 
@@ -3021,9 +3017,9 @@ msgstr ""
 msgid "Access to this profile has been restricted."
 msgstr ""
 
-#: mod/cal.php:273 mod/events.php:384 view/theme/frio/theme.php:266
-#: view/theme/frio/theme.php:270 src/Content/Nav.php:160
+#: mod/cal.php:273 mod/events.php:384 src/Content/Nav.php:160
 #: src/Content/Nav.php:226 src/Model/Profile.php:937 src/Model/Profile.php:948
+#: view/theme/frio/theme.php:266 view/theme/frio/theme.php:270
 msgid "Events"
 msgstr ""
 
@@ -3039,22 +3035,22 @@ msgstr ""
 msgid "Next"
 msgstr ""
 
-#: mod/cal.php:279 mod/events.php:393 src/Model/Event.php:429
+#: mod/cal.php:279 mod/events.php:393 src/Model/Event.php:428
 msgid "today"
 msgstr ""
 
-#: mod/cal.php:280 mod/events.php:394 src/Util/Temporal.php:314
-#: src/Model/Event.php:430
+#: mod/cal.php:280 mod/events.php:394 src/Model/Event.php:429
+#: src/Util/Temporal.php:314
 msgid "month"
 msgstr ""
 
-#: mod/cal.php:281 mod/events.php:395 src/Util/Temporal.php:315
-#: src/Model/Event.php:431
+#: mod/cal.php:281 mod/events.php:395 src/Model/Event.php:430
+#: src/Util/Temporal.php:315
 msgid "week"
 msgstr ""
 
-#: mod/cal.php:282 mod/events.php:396 src/Util/Temporal.php:316
-#: src/Model/Event.php:432
+#: mod/cal.php:282 mod/events.php:396 src/Model/Event.php:431
+#: src/Util/Temporal.php:316
 msgid "day"
 msgstr ""
 
@@ -3062,7 +3058,7 @@ msgstr ""
 msgid "list"
 msgstr ""
 
-#: mod/cal.php:296 src/Core/Console/NewPassword.php:67 src/Model/User.php:323
+#: mod/cal.php:296 src/Core/Console/NewPassword.php:67 src/Model/User.php:324
 msgid "User not found"
 msgstr ""
 
@@ -3188,11 +3184,10 @@ msgstr ""
 #: mod/message.php:261 mod/message.php:441 mod/photos.php:1049
 #: mod/photos.php:1137 mod/photos.php:1412 mod/photos.php:1457
 #: mod/photos.php:1496 mod/photos.php:1556 mod/poke.php:188
-#: mod/profiles.php:562 view/theme/duepuntozero/config.php:72
-#: view/theme/frio/config.php:119 view/theme/quattro/config.php:74
-#: view/theme/vier/config.php:120 src/Module/Contact.php:594
-#: src/Module/Install.php:187 src/Module/Install.php:222
-#: src/Object/Post.php:873
+#: mod/profiles.php:562 src/Module/Contact.php:594 src/Module/Install.php:187
+#: src/Module/Install.php:222 src/Object/Post.php:874
+#: view/theme/duepuntozero/config.php:72 view/theme/frio/config.php:119
+#: view/theme/quattro/config.php:74 view/theme/vier/config.php:120
 msgid "Submit"
 msgstr ""
 
@@ -3383,7 +3378,7 @@ msgstr ""
 msgid "Unable to update your contact profile details on our system"
 msgstr ""
 
-#: mod/dfrn_confirm.php:612 mod/dfrn_request.php:560 src/Model/Contact.php:2026
+#: mod/dfrn_confirm.php:612 mod/dfrn_request.php:560 src/Model/Contact.php:2043
 msgid "[Name Withheld]"
 msgstr ""
 
@@ -3457,7 +3452,7 @@ msgstr ""
 msgid "Invalid profile URL."
 msgstr ""
 
-#: mod/dfrn_request.php:340 src/Model/Contact.php:1697
+#: mod/dfrn_request.php:340 src/Model/Contact.php:1714
 msgid "Disallowed profile URL."
 msgstr ""
 
@@ -3567,8 +3562,8 @@ msgid "Submit Request"
 msgstr ""
 
 #: mod/directory.php:154 mod/events.php:541 mod/notifications.php:253
-#: src/Model/Event.php:68 src/Model/Event.php:95 src/Model/Event.php:438
-#: src/Model/Event.php:934 src/Model/Profile.php:443 src/Module/Contact.php:643
+#: src/Model/Event.php:68 src/Model/Event.php:95 src/Model/Event.php:437
+#: src/Model/Event.php:933 src/Model/Profile.php:443 src/Module/Contact.php:643
 msgid "Location:"
 msgstr ""
 
@@ -3590,8 +3585,8 @@ msgstr ""
 msgid "About:"
 msgstr ""
 
-#: mod/directory.php:210 view/theme/vier/theme.php:208
-#: src/Content/Widget.php:70
+#: mod/directory.php:210 src/Content/Widget.php:70
+#: view/theme/vier/theme.php:208
 msgid "Global Directory"
 msgstr ""
 
@@ -3607,8 +3602,8 @@ msgstr ""
 msgid "Site Directory"
 msgstr ""
 
-#: mod/directory.php:217 view/theme/vier/theme.php:203
-#: src/Content/Widget.php:65 src/Module/Contact.php:817
+#: mod/directory.php:217 src/Content/Widget.php:65 src/Module/Contact.php:817
+#: view/theme/vier/theme.php:203
 msgid "Find"
 msgstr ""
 
@@ -3745,8 +3740,8 @@ msgstr ""
 msgid "Event removed"
 msgstr ""
 
-#: mod/fbrowser.php:36 view/theme/frio/theme.php:264 src/Content/Nav.php:158
-#: src/Model/Profile.php:917
+#: mod/fbrowser.php:36 src/Content/Nav.php:158 src/Model/Profile.php:917
+#: view/theme/frio/theme.php:264
 msgid "Photos"
 msgstr ""
 
@@ -3879,7 +3874,7 @@ msgstr ""
 msgid "Group name changed."
 msgstr ""
 
-#: mod/group.php:85 mod/profperm.php:30 src/App.php:1481
+#: mod/group.php:85 mod/profperm.php:30 src/App.php:1479
 msgid "Permission denied"
 msgstr ""
 
@@ -3952,11 +3947,11 @@ msgstr ""
 msgid "Help:"
 msgstr ""
 
-#: mod/help.php:59 view/theme/vier/theme.php:294 src/Content/Nav.php:190
+#: mod/help.php:59 src/Content/Nav.php:190 view/theme/vier/theme.php:294
 msgid "Help"
 msgstr ""
 
-#: mod/help.php:65 src/App.php:1399
+#: mod/help.php:65 src/App.php:1397
 msgid "Not Found"
 msgstr ""
 
@@ -4104,7 +4099,7 @@ msgstr ""
 msgid "%s posted an update."
 msgstr ""
 
-#: mod/localtime.php:19 src/Model/Event.php:34 src/Model/Event.php:848
+#: mod/localtime.php:19 src/Model/Event.php:34 src/Model/Event.php:847
 msgid "l F d, Y \\@ g:i A"
 msgstr ""
 
@@ -4279,6 +4274,10 @@ msgstr ""
 msgid "Your password has been changed at %s"
 msgstr ""
 
+#: mod/maintenance.php:26
+msgid "System down for maintenance"
+msgstr ""
+
 #: mod/manage.php:178
 msgid "Manage Identities and/or Pages"
 msgstr ""
@@ -4338,7 +4337,7 @@ msgstr ""
 msgid "Discard"
 msgstr ""
 
-#: mod/message.php:123 view/theme/frio/theme.php:271 src/Content/Nav.php:252
+#: mod/message.php:123 src/Content/Nav.php:252 view/theme/frio/theme.php:271
 msgid "Messages"
 msgstr ""
 
@@ -4569,13 +4568,14 @@ msgid ""
 "potential friends know exactly how to find you."
 msgstr ""
 
-#: mod/newmember.php:25 mod/profperm.php:117 view/theme/frio/theme.php:263
-#: src/Content/Nav.php:157 src/Model/Profile.php:876 src/Model/Profile.php:909
+#: mod/newmember.php:25 mod/profperm.php:117 src/Content/Nav.php:157
+#: src/Model/Profile.php:876 src/Model/Profile.php:909
 #: src/Module/Contact.php:654 src/Module/Contact.php:869
+#: view/theme/frio/theme.php:263
 msgid "Profile"
 msgstr ""
 
-#: mod/newmember.php:27 mod/profile_photo.php:253 mod/profiles.php:583
+#: mod/newmember.php:27 mod/profiles.php:583 mod/profile_photo.php:253
 msgid "Upload Profile Photo"
 msgstr ""
 
@@ -5083,12 +5083,12 @@ msgid "I don't like this (toggle)"
 msgstr ""
 
 #: mod/photos.php:1454 mod/photos.php:1493 mod/photos.php:1553
-#: src/Module/Contact.php:1018 src/Object/Post.php:870
+#: src/Module/Contact.php:1018 src/Object/Post.php:871
 msgid "This is you"
 msgstr ""
 
 #: mod/photos.php:1456 mod/photos.php:1495 mod/photos.php:1555
-#: src/Object/Post.php:417 src/Object/Post.php:872
+#: src/Object/Post.php:417 src/Object/Post.php:873
 msgid "Comment"
 msgstr ""
 
@@ -5130,62 +5130,6 @@ msgstr ""
 
 #: mod/probe.php:14 mod/webfinger.php:17
 msgid "Only logged in users are permitted to perform a probing."
-msgstr ""
-
-#: mod/profile_photo.php:58
-msgid "Image uploaded but image cropping failed."
-msgstr ""
-
-#: mod/profile_photo.php:88 mod/profile_photo.php:97 mod/profile_photo.php:106
-#: mod/profile_photo.php:318
-#, php-format
-msgid "Image size reduction [%s] failed."
-msgstr ""
-
-#: mod/profile_photo.php:125
-msgid ""
-"Shift-reload the page or clear browser cache if the new photo does not "
-"display immediately."
-msgstr ""
-
-#: mod/profile_photo.php:133
-msgid "Unable to process image"
-msgstr ""
-
-#: mod/profile_photo.php:251
-msgid "Upload File:"
-msgstr ""
-
-#: mod/profile_photo.php:252
-msgid "Select a profile:"
-msgstr ""
-
-#: mod/profile_photo.php:257
-msgid "or"
-msgstr ""
-
-#: mod/profile_photo.php:258
-msgid "skip this step"
-msgstr ""
-
-#: mod/profile_photo.php:258
-msgid "select a photo from your photo albums"
-msgstr ""
-
-#: mod/profile_photo.php:271
-msgid "Crop Image"
-msgstr ""
-
-#: mod/profile_photo.php:272
-msgid "Please adjust the image cropping for optimum viewing."
-msgstr ""
-
-#: mod/profile_photo.php:274
-msgid "Done Editing"
-msgstr ""
-
-#: mod/profile_photo.php:308
-msgid "Image uploaded successfully."
 msgstr ""
 
 #: mod/profiles.php:62
@@ -5512,6 +5456,62 @@ msgstr ""
 msgid "Create New Profile"
 msgstr ""
 
+#: mod/profile_photo.php:58
+msgid "Image uploaded but image cropping failed."
+msgstr ""
+
+#: mod/profile_photo.php:88 mod/profile_photo.php:97 mod/profile_photo.php:106
+#: mod/profile_photo.php:318
+#, php-format
+msgid "Image size reduction [%s] failed."
+msgstr ""
+
+#: mod/profile_photo.php:125
+msgid ""
+"Shift-reload the page or clear browser cache if the new photo does not "
+"display immediately."
+msgstr ""
+
+#: mod/profile_photo.php:133
+msgid "Unable to process image"
+msgstr ""
+
+#: mod/profile_photo.php:251
+msgid "Upload File:"
+msgstr ""
+
+#: mod/profile_photo.php:252
+msgid "Select a profile:"
+msgstr ""
+
+#: mod/profile_photo.php:257
+msgid "or"
+msgstr ""
+
+#: mod/profile_photo.php:258
+msgid "skip this step"
+msgstr ""
+
+#: mod/profile_photo.php:258
+msgid "select a photo from your photo albums"
+msgstr ""
+
+#: mod/profile_photo.php:271
+msgid "Crop Image"
+msgstr ""
+
+#: mod/profile_photo.php:272
+msgid "Please adjust the image cropping for optimum viewing."
+msgstr ""
+
+#: mod/profile_photo.php:274
+msgid "Done Editing"
+msgstr ""
+
+#: mod/profile_photo.php:308
+msgid "Image uploaded successfully."
+msgstr ""
+
 #: mod/profperm.php:36 mod/profperm.php:69
 msgid "Invalid profile identifier."
 msgstr ""
@@ -5590,7 +5590,7 @@ msgstr ""
 msgid "Only one search per minute is permitted for not logged in users."
 msgstr ""
 
-#: mod/search.php:149 src/Content/Text/HTML.php:900 src/Content/Nav.php:198
+#: mod/search.php:149 src/Content/Nav.php:198 src/Content/Text/HTML.php:900
 msgid "Search"
 msgstr ""
 
@@ -5918,11 +5918,11 @@ msgstr ""
 msgid "%s - (Experimental)"
 msgstr ""
 
-#: mod/settings.php:931 src/Core/L10n.php:368 src/Model/Event.php:396
+#: mod/settings.php:931 src/Core/L10n.php:368 src/Model/Event.php:395
 msgid "Sunday"
 msgstr ""
 
-#: mod/settings.php:931 src/Core/L10n.php:368 src/Model/Event.php:397
+#: mod/settings.php:931 src/Core/L10n.php:368 src/Model/Event.php:396
 msgid "Monday"
 msgstr ""
 
@@ -6451,7 +6451,7 @@ msgstr ""
 msgid "Ignore/Hide"
 msgstr ""
 
-#: mod/suggest.php:119 view/theme/vier/theme.php:204 src/Content/Widget.php:66
+#: mod/suggest.php:119 src/Content/Widget.php:66 view/theme/vier/theme.php:204
 msgid "Friend Suggestions"
 msgstr ""
 
@@ -6567,7 +6567,7 @@ msgstr ""
 msgid "No videos selected"
 msgstr ""
 
-#: mod/videos.php:309 src/Model/Item.php:3435
+#: mod/videos.php:309 src/Model/Item.php:3453
 msgid "View Video"
 msgstr ""
 
@@ -6589,11 +6589,31 @@ msgstr ""
 msgid "Visit %s's profile [%s]"
 msgstr ""
 
-#: mod/viewcontacts.php:114 view/theme/frio/theme.php:273
-#: src/Content/Text/HTML.php:911 src/Content/Nav.php:203
-#: src/Content/Nav.php:269 src/Model/Profile.php:980 src/Model/Profile.php:983
-#: src/Module/Contact.php:811 src/Module/Contact.php:881
+#: mod/viewcontacts.php:114 src/Content/Nav.php:203 src/Content/Nav.php:269
+#: src/Content/Text/HTML.php:911 src/Model/Profile.php:980
+#: src/Model/Profile.php:983 src/Module/Contact.php:811
+#: src/Module/Contact.php:881 view/theme/frio/theme.php:273
 msgid "Contacts"
+msgstr ""
+
+#: mod/wallmessage.php:52 mod/wallmessage.php:115
+#, php-format
+msgid "Number of daily wall messages for %s exceeded. Message failed."
+msgstr ""
+
+#: mod/wallmessage.php:63
+msgid "Unable to check your home location."
+msgstr ""
+
+#: mod/wallmessage.php:89 mod/wallmessage.php:98
+msgid "No recipient."
+msgstr ""
+
+#: mod/wallmessage.php:129
+#, php-format
+msgid ""
+"If you wish for %s to respond, please check that the privacy settings on "
+"your site allow private mail from unknown senders."
 msgstr ""
 
 #: mod/wall_attach.php:26 mod/wall_attach.php:33 mod/wall_attach.php:85
@@ -6624,1180 +6644,22 @@ msgstr ""
 msgid "Wall Photos"
 msgstr ""
 
-#: mod/wallmessage.php:52 mod/wallmessage.php:115
-#, php-format
-msgid "Number of daily wall messages for %s exceeded. Message failed."
+#: src/App.php:665
+msgid "Delete this item?"
 msgstr ""
 
-#: mod/wallmessage.php:63
-msgid "Unable to check your home location."
+#: src/App.php:707
+msgid "toggle mobile"
 msgstr ""
 
-#: mod/wallmessage.php:89 mod/wallmessage.php:98
-msgid "No recipient."
+#: src/App.php:1075
+msgid "No system theme config value set."
 msgstr ""
 
-#: mod/wallmessage.php:129
-#, php-format
+#: src/BaseModule.php:133
 msgid ""
-"If you wish for %s to respond, please check that the privacy settings on "
-"your site allow private mail from unknown senders."
-msgstr ""
-
-#: view/theme/duepuntozero/config.php:55 src/Model/User.php:684
-msgid "default"
-msgstr ""
-
-#: view/theme/duepuntozero/config.php:56
-msgid "greenzero"
-msgstr ""
-
-#: view/theme/duepuntozero/config.php:57
-msgid "purplezero"
-msgstr ""
-
-#: view/theme/duepuntozero/config.php:58
-msgid "easterbunny"
-msgstr ""
-
-#: view/theme/duepuntozero/config.php:59
-msgid "darkzero"
-msgstr ""
-
-#: view/theme/duepuntozero/config.php:60
-msgid "comix"
-msgstr ""
-
-#: view/theme/duepuntozero/config.php:61
-msgid "slackr"
-msgstr ""
-
-#: view/theme/duepuntozero/config.php:75
-msgid "Variations"
-msgstr ""
-
-#: view/theme/frio/php/Image.php:24
-msgid "Top Banner"
-msgstr ""
-
-#: view/theme/frio/php/Image.php:24
-msgid ""
-"Resize image to the width of the screen and show background color below on "
-"long pages."
-msgstr ""
-
-#: view/theme/frio/php/Image.php:25
-msgid "Full screen"
-msgstr ""
-
-#: view/theme/frio/php/Image.php:25
-msgid ""
-"Resize image to fill entire screen, clipping either the right or the bottom."
-msgstr ""
-
-#: view/theme/frio/php/Image.php:26
-msgid "Single row mosaic"
-msgstr ""
-
-#: view/theme/frio/php/Image.php:26
-msgid ""
-"Resize image to repeat it on a single row, either vertical or horizontal."
-msgstr ""
-
-#: view/theme/frio/php/Image.php:27
-msgid "Mosaic"
-msgstr ""
-
-#: view/theme/frio/php/Image.php:27
-msgid "Repeat image to fill the screen."
-msgstr ""
-
-#: view/theme/frio/config.php:103
-msgid "Custom"
-msgstr ""
-
-#: view/theme/frio/config.php:115
-msgid "Note"
-msgstr ""
-
-#: view/theme/frio/config.php:115
-msgid "Check image permissions if all users are allowed to see the image"
-msgstr ""
-
-#: view/theme/frio/config.php:122
-msgid "Select color scheme"
-msgstr ""
-
-#: view/theme/frio/config.php:123
-msgid "Navigation bar background color"
-msgstr ""
-
-#: view/theme/frio/config.php:124
-msgid "Navigation bar icon color "
-msgstr ""
-
-#: view/theme/frio/config.php:125
-msgid "Link color"
-msgstr ""
-
-#: view/theme/frio/config.php:126
-msgid "Set the background color"
-msgstr ""
-
-#: view/theme/frio/config.php:127
-msgid "Content background opacity"
-msgstr ""
-
-#: view/theme/frio/config.php:128
-msgid "Set the background image"
-msgstr ""
-
-#: view/theme/frio/config.php:129
-msgid "Background image style"
-msgstr ""
-
-#: view/theme/frio/config.php:134
-msgid "Login page background image"
-msgstr ""
-
-#: view/theme/frio/config.php:138
-msgid "Login page background color"
-msgstr ""
-
-#: view/theme/frio/config.php:138
-msgid "Leave background image and color empty for theme defaults"
-msgstr ""
-
-#: view/theme/frio/theme.php:239
-msgid "Guest"
-msgstr ""
-
-#: view/theme/frio/theme.php:244
-msgid "Visitor"
-msgstr ""
-
-#: view/theme/frio/theme.php:259 src/Content/Nav.php:153
-#: src/Module/Login.php:321
-msgid "Logout"
-msgstr ""
-
-#: view/theme/frio/theme.php:259 src/Content/Nav.php:153
-msgid "End this session"
-msgstr ""
-
-#: view/theme/frio/theme.php:262 src/Content/Nav.php:156
-#: src/Model/Profile.php:901 src/Module/Contact.php:652
-#: src/Module/Contact.php:853
-msgid "Status"
-msgstr ""
-
-#: view/theme/frio/theme.php:262 src/Content/Nav.php:156
-#: src/Content/Nav.php:242
-msgid "Your posts and conversations"
-msgstr ""
-
-#: view/theme/frio/theme.php:263 src/Content/Nav.php:157
-msgid "Your profile page"
-msgstr ""
-
-#: view/theme/frio/theme.php:264 src/Content/Nav.php:158
-msgid "Your photos"
-msgstr ""
-
-#: view/theme/frio/theme.php:265 src/Content/Nav.php:159
-#: src/Model/Profile.php:925 src/Model/Profile.php:928
-msgid "Videos"
-msgstr ""
-
-#: view/theme/frio/theme.php:265 src/Content/Nav.php:159
-msgid "Your videos"
-msgstr ""
-
-#: view/theme/frio/theme.php:266 src/Content/Nav.php:160
-msgid "Your events"
-msgstr ""
-
-#: view/theme/frio/theme.php:269 src/Content/Nav.php:239
-msgid "Conversations from your friends"
-msgstr ""
-
-#: view/theme/frio/theme.php:270 src/Content/Nav.php:226
-#: src/Model/Profile.php:940 src/Model/Profile.php:951
-msgid "Events and Calendar"
-msgstr ""
-
-#: view/theme/frio/theme.php:271 src/Content/Nav.php:252
-msgid "Private mail"
-msgstr ""
-
-#: view/theme/frio/theme.php:272 src/Content/Nav.php:263
-msgid "Account settings"
-msgstr ""
-
-#: view/theme/frio/theme.php:273 src/Content/Nav.php:269
-msgid "Manage/edit friends and contacts"
-msgstr ""
-
-#: view/theme/quattro/config.php:77
-msgid "Alignment"
-msgstr ""
-
-#: view/theme/quattro/config.php:77
-msgid "Left"
-msgstr ""
-
-#: view/theme/quattro/config.php:77
-msgid "Center"
-msgstr ""
-
-#: view/theme/quattro/config.php:78
-msgid "Color scheme"
-msgstr ""
-
-#: view/theme/quattro/config.php:79
-msgid "Posts font size"
-msgstr ""
-
-#: view/theme/quattro/config.php:80
-msgid "Textareas font size"
-msgstr ""
-
-#: view/theme/vier/config.php:76
-msgid "Comma separated list of helper forums"
-msgstr ""
-
-#: view/theme/vier/config.php:116 src/Core/ACL.php:301
-msgid "don't show"
-msgstr ""
-
-#: view/theme/vier/config.php:116 src/Core/ACL.php:300
-msgid "show"
-msgstr ""
-
-#: view/theme/vier/config.php:123
-msgid "Set style"
-msgstr ""
-
-#: view/theme/vier/config.php:124
-msgid "Community Pages"
-msgstr ""
-
-#: view/theme/vier/config.php:125 view/theme/vier/theme.php:151
-msgid "Community Profiles"
-msgstr ""
-
-#: view/theme/vier/config.php:126
-msgid "Help or @NewHere ?"
-msgstr ""
-
-#: view/theme/vier/config.php:127 view/theme/vier/theme.php:373
-msgid "Connect Services"
-msgstr ""
-
-#: view/theme/vier/config.php:128
-msgid "Find Friends"
-msgstr ""
-
-#: view/theme/vier/config.php:129 view/theme/vier/theme.php:181
-msgid "Last users"
-msgstr ""
-
-#: view/theme/vier/theme.php:199 src/Content/Widget.php:61
-msgid "Find People"
-msgstr ""
-
-#: view/theme/vier/theme.php:200 src/Content/Widget.php:62
-msgid "Enter name or interest"
-msgstr ""
-
-#: view/theme/vier/theme.php:202 src/Content/Widget.php:64
-msgid "Examples: Robert Morgenstein, Fishing"
-msgstr ""
-
-#: view/theme/vier/theme.php:205 src/Content/Widget.php:67
-msgid "Similar Interests"
-msgstr ""
-
-#: view/theme/vier/theme.php:206 src/Content/Widget.php:68
-msgid "Random Profile"
-msgstr ""
-
-#: view/theme/vier/theme.php:207 src/Content/Widget.php:69
-msgid "Invite Friends"
-msgstr ""
-
-#: view/theme/vier/theme.php:210 src/Content/Widget.php:72
-msgid "Local Directory"
-msgstr ""
-
-#: view/theme/vier/theme.php:250 src/Content/Text/HTML.php:914
-#: src/Content/ForumManager.php:130 src/Content/Nav.php:207
-msgid "Forums"
-msgstr ""
-
-#: view/theme/vier/theme.php:252 src/Content/ForumManager.php:132
-msgid "External link to forum"
-msgstr ""
-
-#: view/theme/vier/theme.php:288
-msgid "Quick Start"
-msgstr ""
-
-#: src/Core/Console/ArchiveContact.php:65
-#, php-format
-msgid "Could not find any unarchived contact entry for this URL (%s)"
-msgstr ""
-
-#: src/Core/Console/ArchiveContact.php:70
-msgid "The contact entries have been archived"
-msgstr ""
-
-#: src/Core/Console/NewPassword.php:72
-msgid "Enter new password: "
-msgstr ""
-
-#: src/Core/Console/PostUpdate.php:50
-#, php-format
-msgid "Post update version number has been set to %s."
-msgstr ""
-
-#: src/Core/Console/PostUpdate.php:58
-msgid "Check for pending update actions."
-msgstr ""
-
-#: src/Core/Console/PostUpdate.php:60
-msgid "Done."
-msgstr ""
-
-#: src/Core/Console/PostUpdate.php:62
-msgid "Execute pending post updates."
-msgstr ""
-
-#: src/Core/Console/PostUpdate.php:68
-msgid "All pending post updates are done."
-msgstr ""
-
-#: src/Core/ACL.php:287
-msgid "Post to Email"
-msgstr ""
-
-#: src/Core/ACL.php:293
-msgid "Hide your profile details from unknown viewers?"
-msgstr ""
-
-#: src/Core/ACL.php:292
-#, php-format
-msgid "Connectors disabled, since \"%s\" is enabled."
-msgstr ""
-
-#: src/Core/ACL.php:299
-msgid "Visible to everybody"
-msgstr ""
-
-#: src/Core/ACL.php:311
-msgid "Close"
-msgstr ""
-
-#: src/Core/Authentication.php:87
-msgid "Welcome "
-msgstr ""
-
-#: src/Core/Authentication.php:88
-msgid "Please upload a profile photo."
-msgstr ""
-
-#: src/Core/Authentication.php:90
-msgid "Welcome back "
-msgstr ""
-
-#: src/Core/Installer.php:162
-msgid ""
-"The database configuration file \"config/local.config.php\" could not be "
-"written. Please use the enclosed text to create a configuration file in your "
-"web server root."
-msgstr ""
-
-#: src/Core/Installer.php:181
-msgid ""
-"You may need to import the file \"database.sql\" manually using phpmyadmin "
-"or mysql."
-msgstr ""
-
-#: src/Core/Installer.php:182 src/Module/Install.php:132
-#: src/Module/Install.php:263
-msgid "Please see the file \"INSTALL.txt\"."
-msgstr ""
-
-#: src/Core/Installer.php:243
-msgid "Could not find a command line version of PHP in the web server PATH."
-msgstr ""
-
-#: src/Core/Installer.php:244
-msgid ""
-"If you don't have a command line version of PHP installed on your server, "
-"you will not be able to run the background processing. See <a href='https://"
-"github.com/friendica/friendica/blob/master/doc/Install.md#set-up-the-"
-"worker'>'Setup the worker'</a>"
-msgstr ""
-
-#: src/Core/Installer.php:248
-msgid "PHP executable path"
-msgstr ""
-
-#: src/Core/Installer.php:248
-msgid ""
-"Enter full path to php executable. You can leave this blank to continue the "
-"installation."
-msgstr ""
-
-#: src/Core/Installer.php:253
-msgid "Command line PHP"
-msgstr ""
-
-#: src/Core/Installer.php:262
-msgid "PHP executable is not the php cli binary (could be cgi-fgci version)"
-msgstr ""
-
-#: src/Core/Installer.php:263
-msgid "Found PHP version: "
-msgstr ""
-
-#: src/Core/Installer.php:265
-msgid "PHP cli binary"
-msgstr ""
-
-#: src/Core/Installer.php:278
-msgid ""
-"The command line version of PHP on your system does not have "
-"\"register_argc_argv\" enabled."
-msgstr ""
-
-#: src/Core/Installer.php:279
-msgid "This is required for message delivery to work."
-msgstr ""
-
-#: src/Core/Installer.php:284
-msgid "PHP register_argc_argv"
-msgstr ""
-
-#: src/Core/Installer.php:316
-msgid ""
-"Error: the \"openssl_pkey_new\" function on this system is not able to "
-"generate encryption keys"
-msgstr ""
-
-#: src/Core/Installer.php:317
-msgid ""
-"If running under Windows, please see \"http://www.php.net/manual/en/openssl."
-"installation.php\"."
-msgstr ""
-
-#: src/Core/Installer.php:320
-msgid "Generate encryption keys"
-msgstr ""
-
-#: src/Core/Installer.php:371
-msgid ""
-"Error: Apache webserver mod-rewrite module is required but not installed."
-msgstr ""
-
-#: src/Core/Installer.php:376
-msgid "Apache mod_rewrite module"
-msgstr ""
-
-#: src/Core/Installer.php:382
-msgid "Error: PDO or MySQLi PHP module required but not installed."
-msgstr ""
-
-#: src/Core/Installer.php:387
-msgid "Error: The MySQL driver for PDO is not installed."
-msgstr ""
-
-#: src/Core/Installer.php:391
-msgid "PDO or MySQLi PHP module"
-msgstr ""
-
-#: src/Core/Installer.php:399
-msgid "Error, XML PHP module required but not installed."
-msgstr ""
-
-#: src/Core/Installer.php:403
-msgid "XML PHP module"
-msgstr ""
-
-#: src/Core/Installer.php:406
-msgid "libCurl PHP module"
-msgstr ""
-
-#: src/Core/Installer.php:407
-msgid "Error: libCURL PHP module required but not installed."
-msgstr ""
-
-#: src/Core/Installer.php:413
-msgid "GD graphics PHP module"
-msgstr ""
-
-#: src/Core/Installer.php:414
-msgid ""
-"Error: GD graphics PHP module with JPEG support required but not installed."
-msgstr ""
-
-#: src/Core/Installer.php:420
-msgid "OpenSSL PHP module"
-msgstr ""
-
-#: src/Core/Installer.php:421
-msgid "Error: openssl PHP module required but not installed."
-msgstr ""
-
-#: src/Core/Installer.php:427
-msgid "mb_string PHP module"
-msgstr ""
-
-#: src/Core/Installer.php:428
-msgid "Error: mb_string PHP module required but not installed."
-msgstr ""
-
-#: src/Core/Installer.php:434
-msgid "iconv PHP module"
-msgstr ""
-
-#: src/Core/Installer.php:435
-msgid "Error: iconv PHP module required but not installed."
-msgstr ""
-
-#: src/Core/Installer.php:441
-msgid "POSIX PHP module"
-msgstr ""
-
-#: src/Core/Installer.php:442
-msgid "Error: POSIX PHP module required but not installed."
-msgstr ""
-
-#: src/Core/Installer.php:448
-msgid "JSON PHP module"
-msgstr ""
-
-#: src/Core/Installer.php:449
-msgid "Error: JSON PHP module required but not installed."
-msgstr ""
-
-#: src/Core/Installer.php:472
-msgid ""
-"The web installer needs to be able to create a file called \"local.config.php"
-"\" in the \"config\" folder of your web server and it is unable to do so."
-msgstr ""
-
-#: src/Core/Installer.php:473
-msgid ""
-"This is most often a permission setting, as the web server may not be able "
-"to write files in your folder - even if you can."
-msgstr ""
-
-#: src/Core/Installer.php:474
-msgid ""
-"At the end of this procedure, we will give you a text to save in a file "
-"named local.config.php in your Friendica \"config\" folder."
-msgstr ""
-
-#: src/Core/Installer.php:475
-msgid ""
-"You can alternatively skip this procedure and perform a manual installation. "
-"Please see the file \"INSTALL.txt\" for instructions."
-msgstr ""
-
-#: src/Core/Installer.php:478
-msgid "config/local.config.php is writable"
-msgstr ""
-
-#: src/Core/Installer.php:498
-msgid ""
-"Friendica uses the Smarty3 template engine to render its web views. Smarty3 "
-"compiles templates to PHP to speed up rendering."
-msgstr ""
-
-#: src/Core/Installer.php:499
-msgid ""
-"In order to store these compiled templates, the web server needs to have "
-"write access to the directory view/smarty3/ under the Friendica top level "
-"folder."
-msgstr ""
-
-#: src/Core/Installer.php:500
-msgid ""
-"Please ensure that the user that your web server runs as (e.g. www-data) has "
-"write access to this folder."
-msgstr ""
-
-#: src/Core/Installer.php:501
-msgid ""
-"Note: as a security measure, you should give the web server write access to "
-"view/smarty3/ only--not the template files (.tpl) that it contains."
-msgstr ""
-
-#: src/Core/Installer.php:504
-msgid "view/smarty3 is writable"
-msgstr ""
-
-#: src/Core/Installer.php:533
-msgid ""
-"Url rewrite in .htaccess is not working. Make sure you copied .htaccess-dist "
-"to .htaccess."
-msgstr ""
-
-#: src/Core/Installer.php:535
-msgid "Error message from Curl when fetching"
-msgstr ""
-
-#: src/Core/Installer.php:540
-msgid "Url rewrite is working"
-msgstr ""
-
-#: src/Core/Installer.php:569
-msgid "ImageMagick PHP extension is not installed"
-msgstr ""
-
-#: src/Core/Installer.php:571
-msgid "ImageMagick PHP extension is installed"
-msgstr ""
-
-#: src/Core/Installer.php:573 tests/src/Core/InstallerTest.php:329
-#: tests/src/Core/InstallerTest.php:355
-msgid "ImageMagick supports GIF"
-msgstr ""
-
-#: src/Core/Installer.php:595
-msgid "Could not connect to database."
-msgstr ""
-
-#: src/Core/Installer.php:602
-msgid "Database already in use."
-msgstr ""
-
-#: src/Core/L10n.php:368 src/Model/Event.php:398
-msgid "Tuesday"
-msgstr ""
-
-#: src/Core/L10n.php:368 src/Model/Event.php:399
-msgid "Wednesday"
-msgstr ""
-
-#: src/Core/L10n.php:368 src/Model/Event.php:400
-msgid "Thursday"
-msgstr ""
-
-#: src/Core/L10n.php:368 src/Model/Event.php:401
-msgid "Friday"
-msgstr ""
-
-#: src/Core/L10n.php:368 src/Model/Event.php:402
-msgid "Saturday"
-msgstr ""
-
-#: src/Core/L10n.php:372 src/Model/Event.php:417
-msgid "January"
-msgstr ""
-
-#: src/Core/L10n.php:372 src/Model/Event.php:418
-msgid "February"
-msgstr ""
-
-#: src/Core/L10n.php:372 src/Model/Event.php:419
-msgid "March"
-msgstr ""
-
-#: src/Core/L10n.php:372 src/Model/Event.php:420
-msgid "April"
-msgstr ""
-
-#: src/Core/L10n.php:372 src/Core/L10n.php:391 src/Model/Event.php:408
-msgid "May"
-msgstr ""
-
-#: src/Core/L10n.php:372 src/Model/Event.php:421
-msgid "June"
-msgstr ""
-
-#: src/Core/L10n.php:372 src/Model/Event.php:422
-msgid "July"
-msgstr ""
-
-#: src/Core/L10n.php:372 src/Model/Event.php:423
-msgid "August"
-msgstr ""
-
-#: src/Core/L10n.php:372 src/Model/Event.php:424
-msgid "September"
-msgstr ""
-
-#: src/Core/L10n.php:372 src/Model/Event.php:425
-msgid "October"
-msgstr ""
-
-#: src/Core/L10n.php:372 src/Model/Event.php:426
-msgid "November"
-msgstr ""
-
-#: src/Core/L10n.php:372 src/Model/Event.php:427
-msgid "December"
-msgstr ""
-
-#: src/Core/L10n.php:387 src/Model/Event.php:389
-msgid "Mon"
-msgstr ""
-
-#: src/Core/L10n.php:387 src/Model/Event.php:390
-msgid "Tue"
-msgstr ""
-
-#: src/Core/L10n.php:387 src/Model/Event.php:391
-msgid "Wed"
-msgstr ""
-
-#: src/Core/L10n.php:387 src/Model/Event.php:392
-msgid "Thu"
-msgstr ""
-
-#: src/Core/L10n.php:387 src/Model/Event.php:393
-msgid "Fri"
-msgstr ""
-
-#: src/Core/L10n.php:387 src/Model/Event.php:394
-msgid "Sat"
-msgstr ""
-
-#: src/Core/L10n.php:387 src/Model/Event.php:388
-msgid "Sun"
-msgstr ""
-
-#: src/Core/L10n.php:391 src/Model/Event.php:404
-msgid "Jan"
-msgstr ""
-
-#: src/Core/L10n.php:391 src/Model/Event.php:405
-msgid "Feb"
-msgstr ""
-
-#: src/Core/L10n.php:391 src/Model/Event.php:406
-msgid "Mar"
-msgstr ""
-
-#: src/Core/L10n.php:391 src/Model/Event.php:407
-msgid "Apr"
-msgstr ""
-
-#: src/Core/L10n.php:391 src/Model/Event.php:410
-msgid "Jul"
-msgstr ""
-
-#: src/Core/L10n.php:391 src/Model/Event.php:411
-msgid "Aug"
-msgstr ""
-
-#: src/Core/L10n.php:391
-msgid "Sep"
-msgstr ""
-
-#: src/Core/L10n.php:391 src/Model/Event.php:413
-msgid "Oct"
-msgstr ""
-
-#: src/Core/L10n.php:391 src/Model/Event.php:414
-msgid "Nov"
-msgstr ""
-
-#: src/Core/L10n.php:391 src/Model/Event.php:415
-msgid "Dec"
-msgstr ""
-
-#: src/Core/L10n.php:410
-msgid "poke"
-msgstr ""
-
-#: src/Core/L10n.php:410
-msgid "poked"
-msgstr ""
-
-#: src/Core/L10n.php:411
-msgid "ping"
-msgstr ""
-
-#: src/Core/L10n.php:411
-msgid "pinged"
-msgstr ""
-
-#: src/Core/L10n.php:412
-msgid "prod"
-msgstr ""
-
-#: src/Core/L10n.php:412
-msgid "prodded"
-msgstr ""
-
-#: src/Core/L10n.php:413
-msgid "slap"
-msgstr ""
-
-#: src/Core/L10n.php:413
-msgid "slapped"
-msgstr ""
-
-#: src/Core/L10n.php:414
-msgid "finger"
-msgstr ""
-
-#: src/Core/L10n.php:414
-msgid "fingered"
-msgstr ""
-
-#: src/Core/L10n.php:415
-msgid "rebuff"
-msgstr ""
-
-#: src/Core/L10n.php:415
-msgid "rebuffed"
-msgstr ""
-
-#: src/Core/NotificationsManager.php:175
-msgid "System"
-msgstr ""
-
-#: src/Core/NotificationsManager.php:196 src/Content/Nav.php:180
-#: src/Content/Nav.php:242
-msgid "Home"
-msgstr ""
-
-#: src/Core/NotificationsManager.php:203 src/Content/Nav.php:246
-msgid "Introductions"
-msgstr ""
-
-#: src/Core/NotificationsManager.php:265 src/Core/NotificationsManager.php:277
-#, php-format
-msgid "%s commented on %s's post"
-msgstr ""
-
-#: src/Core/NotificationsManager.php:276
-#, php-format
-msgid "%s created a new post"
-msgstr ""
-
-#: src/Core/NotificationsManager.php:290
-#, php-format
-msgid "%s liked %s's post"
-msgstr ""
-
-#: src/Core/NotificationsManager.php:303
-#, php-format
-msgid "%s disliked %s's post"
-msgstr ""
-
-#: src/Core/NotificationsManager.php:316
-#, php-format
-msgid "%s is attending %s's event"
-msgstr ""
-
-#: src/Core/NotificationsManager.php:329
-#, php-format
-msgid "%s is not attending %s's event"
-msgstr ""
-
-#: src/Core/NotificationsManager.php:342
-#, php-format
-msgid "%s may attend %s's event"
-msgstr ""
-
-#: src/Core/NotificationsManager.php:375
-#, php-format
-msgid "%s is now friends with %s"
-msgstr ""
-
-#: src/Core/NotificationsManager.php:651
-msgid "Friend Suggestion"
-msgstr ""
-
-#: src/Core/NotificationsManager.php:685
-msgid "Friend/Connect Request"
-msgstr ""
-
-#: src/Core/NotificationsManager.php:685
-msgid "New Follower"
-msgstr ""
-
-#: src/Core/System.php:137
-msgid "Error 400 - Bad Request"
-msgstr ""
-
-#: src/Core/System.php:138
-msgid "Error 401 - Unauthorized"
-msgstr ""
-
-#: src/Core/System.php:139
-msgid "Error 403 - Forbidden"
-msgstr ""
-
-#: src/Core/System.php:140
-msgid "Error 404 - Not Found"
-msgstr ""
-
-#: src/Core/System.php:141
-msgid "Error 500 - Internal Server Error"
-msgstr ""
-
-#: src/Core/System.php:142
-msgid "Error 503 - Service Unavailable"
-msgstr ""
-
-#: src/Core/System.php:150
-msgid ""
-"The server cannot or will not process the request due to an apparent client "
-"error."
-msgstr ""
-
-#: src/Core/System.php:151
-msgid "Authentication is required and has failed or has not yet been provided."
-msgstr ""
-
-#: src/Core/System.php:152
-msgid ""
-"The request was valid, but the server is refusing action. The user might not "
-"have the necessary permissions for a resource, or may need an account."
-msgstr ""
-
-#: src/Core/System.php:153
-msgid ""
-"The requested resource could not be found but may be available in the future."
-msgstr ""
-
-#: src/Core/System.php:154
-msgid ""
-"An unexpected condition was encountered and no more specific message is "
-"suitable."
-msgstr ""
-
-#: src/Core/System.php:155
-msgid ""
-"The server is currently unavailable (because it is overloaded or down for "
-"maintenance). Please try again later."
-msgstr ""
-
-#: src/Core/Update.php:168
-#, php-format
-msgid "Update %s failed. See error logs."
-msgstr ""
-
-#: src/Core/Update.php:225
-#, php-format
-msgid ""
-"\n"
-"\t\t\t\tThe friendica developers released update %s recently,\n"
-"\t\t\t\tbut when I tried to install it, something went terribly wrong.\n"
-"\t\t\t\tThis needs to be fixed soon and I can't do it alone. Please contact "
-"a\n"
-"\t\t\t\tfriendica developer if you can not help me on your own. My database "
-"might be invalid."
-msgstr ""
-
-#: src/Core/Update.php:231
-#, php-format
-msgid ""
-"The error message is\n"
-"[pre]%s[/pre]"
-msgstr ""
-
-#: src/Core/Update.php:260
-#, php-format
-msgid ""
-"\n"
-"\t\t\t\t\tThe friendica database was successfully updated from %s to %s."
-msgstr ""
-
-#: src/Core/UserImport.php:103
-msgid "Error decoding account file"
-msgstr ""
-
-#: src/Core/UserImport.php:109
-msgid "Error! No version data in file! This is not a Friendica account file?"
-msgstr ""
-
-#: src/Core/UserImport.php:117
-#, php-format
-msgid "User '%s' already exists on this server!"
-msgstr ""
-
-#: src/Core/UserImport.php:153
-msgid "User creation error"
-msgstr ""
-
-#: src/Core/UserImport.php:171
-msgid "User profile creation error"
-msgstr ""
-
-#: src/Core/UserImport.php:215
-#, php-format
-msgid "%d contact not imported"
-msgid_plural "%d contacts not imported"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/Core/UserImport.php:280
-msgid "Done. You can now login with your username and password"
-msgstr ""
-
-#: src/Util/Temporal.php:147 src/Model/Profile.php:771
-msgid "Birthday:"
-msgstr ""
-
-#: src/Util/Temporal.php:151
-msgid "YYYY-MM-DD or MM-DD"
-msgstr ""
-
-#: src/Util/Temporal.php:298
-msgid "never"
-msgstr ""
-
-#: src/Util/Temporal.php:305
-msgid "less than a second ago"
-msgstr ""
-
-#: src/Util/Temporal.php:313
-msgid "year"
-msgstr ""
-
-#: src/Util/Temporal.php:313
-msgid "years"
-msgstr ""
-
-#: src/Util/Temporal.php:314
-msgid "months"
-msgstr ""
-
-#: src/Util/Temporal.php:315
-msgid "weeks"
-msgstr ""
-
-#: src/Util/Temporal.php:316
-msgid "days"
-msgstr ""
-
-#: src/Util/Temporal.php:317
-msgid "hour"
-msgstr ""
-
-#: src/Util/Temporal.php:317
-msgid "hours"
-msgstr ""
-
-#: src/Util/Temporal.php:318
-msgid "minute"
-msgstr ""
-
-#: src/Util/Temporal.php:318
-msgid "minutes"
-msgstr ""
-
-#: src/Util/Temporal.php:319
-msgid "second"
-msgstr ""
-
-#: src/Util/Temporal.php:319
-msgid "seconds"
-msgstr ""
-
-#: src/Util/Temporal.php:329
-#, php-format
-msgid "in %1$d %2$s"
-msgstr ""
-
-#: src/Util/Temporal.php:332
-#, php-format
-msgid "%1$d %2$s ago"
-msgstr ""
-
-#: src/Content/Text/BBCode.php:429
-msgid "view full size"
-msgstr ""
-
-#: src/Content/Text/BBCode.php:863 src/Content/Text/BBCode.php:1596
-#: src/Content/Text/BBCode.php:1597
-msgid "Image/photo"
-msgstr ""
-
-#: src/Content/Text/BBCode.php:967
-#, php-format
-msgid "<a href=\"%1$s\" target=\"_blank\">%2$s</a> %3$s"
-msgstr ""
-
-#: src/Content/Text/BBCode.php:1523 src/Content/Text/BBCode.php:1545
-msgid "$1 wrote:"
-msgstr ""
-
-#: src/Content/Text/BBCode.php:1607 src/Content/Text/BBCode.php:1608
-msgid "Encrypted content"
-msgstr ""
-
-#: src/Content/Text/BBCode.php:1715
-msgid "Invalid source protocol"
-msgstr ""
-
-#: src/Content/Text/BBCode.php:1726
-msgid "Invalid link protocol"
-msgstr ""
-
-#: src/Content/Text/HTML.php:800
-msgid "Loading more entries..."
-msgstr ""
-
-#: src/Content/Text/HTML.php:801
-msgid "The end"
-msgstr ""
-
-#: src/Content/Text/HTML.php:894
-msgid "Follow"
-msgstr ""
-
-#: src/Content/Text/HTML.php:903 src/Content/Nav.php:79
-msgid "@name, !forum, #tags, content"
-msgstr ""
-
-#: src/Content/Text/HTML.php:909 src/Content/Nav.php:201
-msgid "Full Text"
-msgstr ""
-
-#: src/Content/Text/HTML.php:910 src/Content/Widget/TagCloud.php:54
-#: src/Content/Nav.php:202
-msgid "Tags"
-msgstr ""
-
-#: src/Content/Text/HTML.php:951 src/Model/Item.php:3485
-#: src/Model/Item.php:3496
-msgid "Click to open/close"
-msgstr ""
-
-#: src/Content/Widget/CalendarExport.php:64
-msgid "Export"
-msgstr ""
-
-#: src/Content/Widget/CalendarExport.php:65
-msgid "Export calendar as ical"
-msgstr ""
-
-#: src/Content/Widget/CalendarExport.php:66
-msgid "Export calendar as csv"
-msgstr ""
-
-#: src/Content/Widget/ContactBlock.php:58
-msgid "No contacts"
-msgstr ""
-
-#: src/Content/Widget/ContactBlock.php:90
-#, php-format
-msgid "%d Contact"
-msgid_plural "%d Contacts"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/Content/Widget/ContactBlock.php:109
-msgid "View Contacts"
+"The form security token was not correct. This probably happened because the "
+"form has been opened for too long (>3 hours) before submitting it."
 msgstr ""
 
 #: src/Content/ContactSelector.php:58
@@ -8020,7 +6882,7 @@ msgstr ""
 msgid "Sex Addict"
 msgstr ""
 
-#: src/Content/ContactSelector.php:241 src/Model/User.php:701
+#: src/Content/ContactSelector.php:241 src/Model/User.php:702
 msgid "Friends"
 msgstr ""
 
@@ -8237,12 +7099,65 @@ msgstr ""
 msgid "Display membership date in profile"
 msgstr ""
 
+#: src/Content/ForumManager.php:130 src/Content/Nav.php:207
+#: src/Content/Text/HTML.php:914 view/theme/vier/theme.php:250
+msgid "Forums"
+msgstr ""
+
+#: src/Content/ForumManager.php:132 view/theme/vier/theme.php:252
+msgid "External link to forum"
+msgstr ""
+
 #: src/Content/Nav.php:74
 msgid "Nothing new here"
 msgstr ""
 
 #: src/Content/Nav.php:78
 msgid "Clear notifications"
+msgstr ""
+
+#: src/Content/Nav.php:79 src/Content/Text/HTML.php:903
+msgid "@name, !forum, #tags, content"
+msgstr ""
+
+#: src/Content/Nav.php:153 src/Module/Login.php:321
+#: view/theme/frio/theme.php:259
+msgid "Logout"
+msgstr ""
+
+#: src/Content/Nav.php:153 view/theme/frio/theme.php:259
+msgid "End this session"
+msgstr ""
+
+#: src/Content/Nav.php:156 src/Model/Profile.php:901 src/Module/Contact.php:652
+#: src/Module/Contact.php:853 view/theme/frio/theme.php:262
+msgid "Status"
+msgstr ""
+
+#: src/Content/Nav.php:156 src/Content/Nav.php:242
+#: view/theme/frio/theme.php:262
+msgid "Your posts and conversations"
+msgstr ""
+
+#: src/Content/Nav.php:157 view/theme/frio/theme.php:263
+msgid "Your profile page"
+msgstr ""
+
+#: src/Content/Nav.php:158 view/theme/frio/theme.php:264
+msgid "Your photos"
+msgstr ""
+
+#: src/Content/Nav.php:159 src/Model/Profile.php:925 src/Model/Profile.php:928
+#: view/theme/frio/theme.php:265
+msgid "Videos"
+msgstr ""
+
+#: src/Content/Nav.php:159 view/theme/frio/theme.php:265
+msgid "Your videos"
+msgstr ""
+
+#: src/Content/Nav.php:160 view/theme/frio/theme.php:266
+msgid "Your events"
 msgstr ""
 
 #: src/Content/Nav.php:161
@@ -8255,6 +7170,11 @@ msgstr ""
 
 #: src/Content/Nav.php:170
 msgid "Sign in"
+msgstr ""
+
+#: src/Content/Nav.php:180 src/Content/Nav.php:242
+#: src/Core/NotificationsManager.php:196
+msgid "Home"
 msgstr ""
 
 #: src/Content/Nav.php:180
@@ -8285,12 +7205,26 @@ msgstr ""
 msgid "Search site content"
 msgstr ""
 
+#: src/Content/Nav.php:201 src/Content/Text/HTML.php:909
+msgid "Full Text"
+msgstr ""
+
+#: src/Content/Nav.php:202 src/Content/Text/HTML.php:910
+#: src/Content/Widget/TagCloud.php:54
+msgid "Tags"
+msgstr ""
+
 #: src/Content/Nav.php:222
 msgid "Community"
 msgstr ""
 
 #: src/Content/Nav.php:222
 msgid "Conversations on this and other servers"
+msgstr ""
+
+#: src/Content/Nav.php:226 src/Model/Profile.php:940 src/Model/Profile.php:951
+#: view/theme/frio/theme.php:270
+msgid "Events and Calendar"
 msgstr ""
 
 #: src/Content/Nav.php:229
@@ -8309,12 +7243,20 @@ msgstr ""
 msgid "Terms of Service of this Friendica instance"
 msgstr ""
 
+#: src/Content/Nav.php:239 view/theme/frio/theme.php:269
+msgid "Conversations from your friends"
+msgstr ""
+
 #: src/Content/Nav.php:240
 msgid "Network Reset"
 msgstr ""
 
 #: src/Content/Nav.php:240
 msgid "Load Network page with no filters"
+msgstr ""
+
+#: src/Content/Nav.php:246 src/Core/NotificationsManager.php:203
+msgid "Introductions"
 msgstr ""
 
 #: src/Content/Nav.php:246
@@ -8327,6 +7269,10 @@ msgstr ""
 
 #: src/Content/Nav.php:249
 msgid "Mark all system notifications seen"
+msgstr ""
+
+#: src/Content/Nav.php:252 view/theme/frio/theme.php:271
+msgid "Private mail"
 msgstr ""
 
 #: src/Content/Nav.php:253
@@ -8345,8 +7291,16 @@ msgstr ""
 msgid "Manage other pages"
 msgstr ""
 
+#: src/Content/Nav.php:263 view/theme/frio/theme.php:272
+msgid "Account settings"
+msgstr ""
+
 #: src/Content/Nav.php:266
 msgid "Manage/Edit Profiles"
+msgstr ""
+
+#: src/Content/Nav.php:269 view/theme/frio/theme.php:273
+msgid "Manage/edit friends and contacts"
 msgstr ""
 
 #: src/Content/Nav.php:274
@@ -8385,6 +7339,80 @@ msgstr ""
 msgid "last"
 msgstr ""
 
+#: src/Content/Text/BBCode.php:429
+msgid "view full size"
+msgstr ""
+
+#: src/Content/Text/BBCode.php:863 src/Content/Text/BBCode.php:1596
+#: src/Content/Text/BBCode.php:1597
+msgid "Image/photo"
+msgstr ""
+
+#: src/Content/Text/BBCode.php:967
+#, php-format
+msgid "<a href=\"%1$s\" target=\"_blank\">%2$s</a> %3$s"
+msgstr ""
+
+#: src/Content/Text/BBCode.php:1523 src/Content/Text/BBCode.php:1545
+msgid "$1 wrote:"
+msgstr ""
+
+#: src/Content/Text/BBCode.php:1607 src/Content/Text/BBCode.php:1608
+msgid "Encrypted content"
+msgstr ""
+
+#: src/Content/Text/BBCode.php:1715
+msgid "Invalid source protocol"
+msgstr ""
+
+#: src/Content/Text/BBCode.php:1726
+msgid "Invalid link protocol"
+msgstr ""
+
+#: src/Content/Text/HTML.php:800
+msgid "Loading more entries..."
+msgstr ""
+
+#: src/Content/Text/HTML.php:801
+msgid "The end"
+msgstr ""
+
+#: src/Content/Text/HTML.php:894
+msgid "Follow"
+msgstr ""
+
+#: src/Content/Text/HTML.php:951 src/Model/Item.php:3503
+#: src/Model/Item.php:3514
+msgid "Click to open/close"
+msgstr ""
+
+#: src/Content/Widget/CalendarExport.php:64
+msgid "Export"
+msgstr ""
+
+#: src/Content/Widget/CalendarExport.php:65
+msgid "Export calendar as ical"
+msgstr ""
+
+#: src/Content/Widget/CalendarExport.php:66
+msgid "Export calendar as csv"
+msgstr ""
+
+#: src/Content/Widget/ContactBlock.php:58
+msgid "No contacts"
+msgstr ""
+
+#: src/Content/Widget/ContactBlock.php:90
+#, php-format
+msgid "%d Contact"
+msgid_plural "%d Contacts"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/Content/Widget/ContactBlock.php:109
+msgid "View Contacts"
+msgstr ""
+
 #: src/Content/Widget.php:35
 msgid "Add New Contact"
 msgstr ""
@@ -8403,6 +7431,34 @@ msgid "%d invitation available"
 msgid_plural "%d invitations available"
 msgstr[0] ""
 msgstr[1] ""
+
+#: src/Content/Widget.php:61 view/theme/vier/theme.php:199
+msgid "Find People"
+msgstr ""
+
+#: src/Content/Widget.php:62 view/theme/vier/theme.php:200
+msgid "Enter name or interest"
+msgstr ""
+
+#: src/Content/Widget.php:64 view/theme/vier/theme.php:202
+msgid "Examples: Robert Morgenstein, Fishing"
+msgstr ""
+
+#: src/Content/Widget.php:67 view/theme/vier/theme.php:205
+msgid "Similar Interests"
+msgstr ""
+
+#: src/Content/Widget.php:68 view/theme/vier/theme.php:206
+msgid "Random Profile"
+msgstr ""
+
+#: src/Content/Widget.php:69 view/theme/vier/theme.php:207
+msgid "Invite Friends"
+msgstr ""
+
+#: src/Content/Widget.php:72 view/theme/vier/theme.php:210
+msgid "Local Directory"
+msgstr ""
 
 #: src/Content/Widget.php:158
 msgid "Protocols"
@@ -8431,6 +7487,705 @@ msgid_plural "%d contacts in common"
 msgstr[0] ""
 msgstr[1] ""
 
+#: src/Core/ACL.php:287
+msgid "Post to Email"
+msgstr ""
+
+#: src/Core/ACL.php:293
+msgid "Hide your profile details from unknown viewers?"
+msgstr ""
+
+#: src/Core/ACL.php:292
+#, php-format
+msgid "Connectors disabled, since \"%s\" is enabled."
+msgstr ""
+
+#: src/Core/ACL.php:299
+msgid "Visible to everybody"
+msgstr ""
+
+#: src/Core/ACL.php:300 view/theme/vier/config.php:116
+msgid "show"
+msgstr ""
+
+#: src/Core/ACL.php:301 view/theme/vier/config.php:116
+msgid "don't show"
+msgstr ""
+
+#: src/Core/ACL.php:311
+msgid "Close"
+msgstr ""
+
+#: src/Core/Authentication.php:87
+msgid "Welcome "
+msgstr ""
+
+#: src/Core/Authentication.php:88
+msgid "Please upload a profile photo."
+msgstr ""
+
+#: src/Core/Authentication.php:90
+msgid "Welcome back "
+msgstr ""
+
+#: src/Core/Console/ArchiveContact.php:65
+#, php-format
+msgid "Could not find any unarchived contact entry for this URL (%s)"
+msgstr ""
+
+#: src/Core/Console/ArchiveContact.php:70
+msgid "The contact entries have been archived"
+msgstr ""
+
+#: src/Core/Console/NewPassword.php:72
+msgid "Enter new password: "
+msgstr ""
+
+#: src/Core/Console/PostUpdate.php:50
+#, php-format
+msgid "Post update version number has been set to %s."
+msgstr ""
+
+#: src/Core/Console/PostUpdate.php:58
+msgid "Check for pending update actions."
+msgstr ""
+
+#: src/Core/Console/PostUpdate.php:60
+msgid "Done."
+msgstr ""
+
+#: src/Core/Console/PostUpdate.php:62
+msgid "Execute pending post updates."
+msgstr ""
+
+#: src/Core/Console/PostUpdate.php:68
+msgid "All pending post updates are done."
+msgstr ""
+
+#: src/Core/Installer.php:163
+msgid ""
+"The database configuration file \"config/local.config.php\" could not be "
+"written. Please use the enclosed text to create a configuration file in your "
+"web server root."
+msgstr ""
+
+#: src/Core/Installer.php:182
+msgid ""
+"You may need to import the file \"database.sql\" manually using phpmyadmin "
+"or mysql."
+msgstr ""
+
+#: src/Core/Installer.php:183 src/Module/Install.php:132
+#: src/Module/Install.php:263
+msgid "Please see the file \"INSTALL.txt\"."
+msgstr ""
+
+#: src/Core/Installer.php:244
+msgid "Could not find a command line version of PHP in the web server PATH."
+msgstr ""
+
+#: src/Core/Installer.php:245
+msgid ""
+"If you don't have a command line version of PHP installed on your server, "
+"you will not be able to run the background processing. See <a href='https://"
+"github.com/friendica/friendica/blob/master/doc/Install.md#set-up-the-"
+"worker'>'Setup the worker'</a>"
+msgstr ""
+
+#: src/Core/Installer.php:249
+msgid "PHP executable path"
+msgstr ""
+
+#: src/Core/Installer.php:249
+msgid ""
+"Enter full path to php executable. You can leave this blank to continue the "
+"installation."
+msgstr ""
+
+#: src/Core/Installer.php:254
+msgid "Command line PHP"
+msgstr ""
+
+#: src/Core/Installer.php:263
+msgid "PHP executable is not the php cli binary (could be cgi-fgci version)"
+msgstr ""
+
+#: src/Core/Installer.php:264
+msgid "Found PHP version: "
+msgstr ""
+
+#: src/Core/Installer.php:266
+msgid "PHP cli binary"
+msgstr ""
+
+#: src/Core/Installer.php:279
+msgid ""
+"The command line version of PHP on your system does not have "
+"\"register_argc_argv\" enabled."
+msgstr ""
+
+#: src/Core/Installer.php:280
+msgid "This is required for message delivery to work."
+msgstr ""
+
+#: src/Core/Installer.php:285
+msgid "PHP register_argc_argv"
+msgstr ""
+
+#: src/Core/Installer.php:317
+msgid ""
+"Error: the \"openssl_pkey_new\" function on this system is not able to "
+"generate encryption keys"
+msgstr ""
+
+#: src/Core/Installer.php:318
+msgid ""
+"If running under Windows, please see \"http://www.php.net/manual/en/openssl."
+"installation.php\"."
+msgstr ""
+
+#: src/Core/Installer.php:321
+msgid "Generate encryption keys"
+msgstr ""
+
+#: src/Core/Installer.php:372
+msgid ""
+"Error: Apache webserver mod-rewrite module is required but not installed."
+msgstr ""
+
+#: src/Core/Installer.php:377
+msgid "Apache mod_rewrite module"
+msgstr ""
+
+#: src/Core/Installer.php:383
+msgid "Error: PDO or MySQLi PHP module required but not installed."
+msgstr ""
+
+#: src/Core/Installer.php:388
+msgid "Error: The MySQL driver for PDO is not installed."
+msgstr ""
+
+#: src/Core/Installer.php:392
+msgid "PDO or MySQLi PHP module"
+msgstr ""
+
+#: src/Core/Installer.php:400
+msgid "Error, XML PHP module required but not installed."
+msgstr ""
+
+#: src/Core/Installer.php:404
+msgid "XML PHP module"
+msgstr ""
+
+#: src/Core/Installer.php:407
+msgid "libCurl PHP module"
+msgstr ""
+
+#: src/Core/Installer.php:408
+msgid "Error: libCURL PHP module required but not installed."
+msgstr ""
+
+#: src/Core/Installer.php:414
+msgid "GD graphics PHP module"
+msgstr ""
+
+#: src/Core/Installer.php:415
+msgid ""
+"Error: GD graphics PHP module with JPEG support required but not installed."
+msgstr ""
+
+#: src/Core/Installer.php:421
+msgid "OpenSSL PHP module"
+msgstr ""
+
+#: src/Core/Installer.php:422
+msgid "Error: openssl PHP module required but not installed."
+msgstr ""
+
+#: src/Core/Installer.php:428
+msgid "mb_string PHP module"
+msgstr ""
+
+#: src/Core/Installer.php:429
+msgid "Error: mb_string PHP module required but not installed."
+msgstr ""
+
+#: src/Core/Installer.php:435
+msgid "iconv PHP module"
+msgstr ""
+
+#: src/Core/Installer.php:436
+msgid "Error: iconv PHP module required but not installed."
+msgstr ""
+
+#: src/Core/Installer.php:442
+msgid "POSIX PHP module"
+msgstr ""
+
+#: src/Core/Installer.php:443
+msgid "Error: POSIX PHP module required but not installed."
+msgstr ""
+
+#: src/Core/Installer.php:449
+msgid "JSON PHP module"
+msgstr ""
+
+#: src/Core/Installer.php:450
+msgid "Error: JSON PHP module required but not installed."
+msgstr ""
+
+#: src/Core/Installer.php:473
+msgid ""
+"The web installer needs to be able to create a file called \"local.config.php"
+"\" in the \"config\" folder of your web server and it is unable to do so."
+msgstr ""
+
+#: src/Core/Installer.php:474
+msgid ""
+"This is most often a permission setting, as the web server may not be able "
+"to write files in your folder - even if you can."
+msgstr ""
+
+#: src/Core/Installer.php:475
+msgid ""
+"At the end of this procedure, we will give you a text to save in a file "
+"named local.config.php in your Friendica \"config\" folder."
+msgstr ""
+
+#: src/Core/Installer.php:476
+msgid ""
+"You can alternatively skip this procedure and perform a manual installation. "
+"Please see the file \"INSTALL.txt\" for instructions."
+msgstr ""
+
+#: src/Core/Installer.php:479
+msgid "config/local.config.php is writable"
+msgstr ""
+
+#: src/Core/Installer.php:499
+msgid ""
+"Friendica uses the Smarty3 template engine to render its web views. Smarty3 "
+"compiles templates to PHP to speed up rendering."
+msgstr ""
+
+#: src/Core/Installer.php:500
+msgid ""
+"In order to store these compiled templates, the web server needs to have "
+"write access to the directory view/smarty3/ under the Friendica top level "
+"folder."
+msgstr ""
+
+#: src/Core/Installer.php:501
+msgid ""
+"Please ensure that the user that your web server runs as (e.g. www-data) has "
+"write access to this folder."
+msgstr ""
+
+#: src/Core/Installer.php:502
+msgid ""
+"Note: as a security measure, you should give the web server write access to "
+"view/smarty3/ only--not the template files (.tpl) that it contains."
+msgstr ""
+
+#: src/Core/Installer.php:505
+msgid "view/smarty3 is writable"
+msgstr ""
+
+#: src/Core/Installer.php:534
+msgid ""
+"Url rewrite in .htaccess is not working. Make sure you copied .htaccess-dist "
+"to .htaccess."
+msgstr ""
+
+#: src/Core/Installer.php:536
+msgid "Error message from Curl when fetching"
+msgstr ""
+
+#: src/Core/Installer.php:541
+msgid "Url rewrite is working"
+msgstr ""
+
+#: src/Core/Installer.php:570
+msgid "ImageMagick PHP extension is not installed"
+msgstr ""
+
+#: src/Core/Installer.php:572
+msgid "ImageMagick PHP extension is installed"
+msgstr ""
+
+#: src/Core/Installer.php:574 tests/src/Core/InstallerTest.php:329
+#: tests/src/Core/InstallerTest.php:355
+msgid "ImageMagick supports GIF"
+msgstr ""
+
+#: src/Core/Installer.php:597
+msgid "Could not connect to database."
+msgstr ""
+
+#: src/Core/Installer.php:604
+msgid "Database already in use."
+msgstr ""
+
+#: src/Core/L10n.php:368 src/Model/Event.php:397
+msgid "Tuesday"
+msgstr ""
+
+#: src/Core/L10n.php:368 src/Model/Event.php:398
+msgid "Wednesday"
+msgstr ""
+
+#: src/Core/L10n.php:368 src/Model/Event.php:399
+msgid "Thursday"
+msgstr ""
+
+#: src/Core/L10n.php:368 src/Model/Event.php:400
+msgid "Friday"
+msgstr ""
+
+#: src/Core/L10n.php:368 src/Model/Event.php:401
+msgid "Saturday"
+msgstr ""
+
+#: src/Core/L10n.php:372 src/Model/Event.php:416
+msgid "January"
+msgstr ""
+
+#: src/Core/L10n.php:372 src/Model/Event.php:417
+msgid "February"
+msgstr ""
+
+#: src/Core/L10n.php:372 src/Model/Event.php:418
+msgid "March"
+msgstr ""
+
+#: src/Core/L10n.php:372 src/Model/Event.php:419
+msgid "April"
+msgstr ""
+
+#: src/Core/L10n.php:372 src/Core/L10n.php:391 src/Model/Event.php:407
+msgid "May"
+msgstr ""
+
+#: src/Core/L10n.php:372 src/Model/Event.php:420
+msgid "June"
+msgstr ""
+
+#: src/Core/L10n.php:372 src/Model/Event.php:421
+msgid "July"
+msgstr ""
+
+#: src/Core/L10n.php:372 src/Model/Event.php:422
+msgid "August"
+msgstr ""
+
+#: src/Core/L10n.php:372 src/Model/Event.php:423
+msgid "September"
+msgstr ""
+
+#: src/Core/L10n.php:372 src/Model/Event.php:424
+msgid "October"
+msgstr ""
+
+#: src/Core/L10n.php:372 src/Model/Event.php:425
+msgid "November"
+msgstr ""
+
+#: src/Core/L10n.php:372 src/Model/Event.php:426
+msgid "December"
+msgstr ""
+
+#: src/Core/L10n.php:387 src/Model/Event.php:388
+msgid "Mon"
+msgstr ""
+
+#: src/Core/L10n.php:387 src/Model/Event.php:389
+msgid "Tue"
+msgstr ""
+
+#: src/Core/L10n.php:387 src/Model/Event.php:390
+msgid "Wed"
+msgstr ""
+
+#: src/Core/L10n.php:387 src/Model/Event.php:391
+msgid "Thu"
+msgstr ""
+
+#: src/Core/L10n.php:387 src/Model/Event.php:392
+msgid "Fri"
+msgstr ""
+
+#: src/Core/L10n.php:387 src/Model/Event.php:393
+msgid "Sat"
+msgstr ""
+
+#: src/Core/L10n.php:387 src/Model/Event.php:387
+msgid "Sun"
+msgstr ""
+
+#: src/Core/L10n.php:391 src/Model/Event.php:403
+msgid "Jan"
+msgstr ""
+
+#: src/Core/L10n.php:391 src/Model/Event.php:404
+msgid "Feb"
+msgstr ""
+
+#: src/Core/L10n.php:391 src/Model/Event.php:405
+msgid "Mar"
+msgstr ""
+
+#: src/Core/L10n.php:391 src/Model/Event.php:406
+msgid "Apr"
+msgstr ""
+
+#: src/Core/L10n.php:391 src/Model/Event.php:409
+msgid "Jul"
+msgstr ""
+
+#: src/Core/L10n.php:391 src/Model/Event.php:410
+msgid "Aug"
+msgstr ""
+
+#: src/Core/L10n.php:391
+msgid "Sep"
+msgstr ""
+
+#: src/Core/L10n.php:391 src/Model/Event.php:412
+msgid "Oct"
+msgstr ""
+
+#: src/Core/L10n.php:391 src/Model/Event.php:413
+msgid "Nov"
+msgstr ""
+
+#: src/Core/L10n.php:391 src/Model/Event.php:414
+msgid "Dec"
+msgstr ""
+
+#: src/Core/L10n.php:410
+msgid "poke"
+msgstr ""
+
+#: src/Core/L10n.php:410
+msgid "poked"
+msgstr ""
+
+#: src/Core/L10n.php:411
+msgid "ping"
+msgstr ""
+
+#: src/Core/L10n.php:411
+msgid "pinged"
+msgstr ""
+
+#: src/Core/L10n.php:412
+msgid "prod"
+msgstr ""
+
+#: src/Core/L10n.php:412
+msgid "prodded"
+msgstr ""
+
+#: src/Core/L10n.php:413
+msgid "slap"
+msgstr ""
+
+#: src/Core/L10n.php:413
+msgid "slapped"
+msgstr ""
+
+#: src/Core/L10n.php:414
+msgid "finger"
+msgstr ""
+
+#: src/Core/L10n.php:414
+msgid "fingered"
+msgstr ""
+
+#: src/Core/L10n.php:415
+msgid "rebuff"
+msgstr ""
+
+#: src/Core/L10n.php:415
+msgid "rebuffed"
+msgstr ""
+
+#: src/Core/NotificationsManager.php:175
+msgid "System"
+msgstr ""
+
+#: src/Core/NotificationsManager.php:265 src/Core/NotificationsManager.php:277
+#, php-format
+msgid "%s commented on %s's post"
+msgstr ""
+
+#: src/Core/NotificationsManager.php:276
+#, php-format
+msgid "%s created a new post"
+msgstr ""
+
+#: src/Core/NotificationsManager.php:290
+#, php-format
+msgid "%s liked %s's post"
+msgstr ""
+
+#: src/Core/NotificationsManager.php:303
+#, php-format
+msgid "%s disliked %s's post"
+msgstr ""
+
+#: src/Core/NotificationsManager.php:316
+#, php-format
+msgid "%s is attending %s's event"
+msgstr ""
+
+#: src/Core/NotificationsManager.php:329
+#, php-format
+msgid "%s is not attending %s's event"
+msgstr ""
+
+#: src/Core/NotificationsManager.php:342
+#, php-format
+msgid "%s may attend %s's event"
+msgstr ""
+
+#: src/Core/NotificationsManager.php:375
+#, php-format
+msgid "%s is now friends with %s"
+msgstr ""
+
+#: src/Core/NotificationsManager.php:651
+msgid "Friend Suggestion"
+msgstr ""
+
+#: src/Core/NotificationsManager.php:685
+msgid "Friend/Connect Request"
+msgstr ""
+
+#: src/Core/NotificationsManager.php:685
+msgid "New Follower"
+msgstr ""
+
+#: src/Core/System.php:137
+msgid "Error 400 - Bad Request"
+msgstr ""
+
+#: src/Core/System.php:138
+msgid "Error 401 - Unauthorized"
+msgstr ""
+
+#: src/Core/System.php:139
+msgid "Error 403 - Forbidden"
+msgstr ""
+
+#: src/Core/System.php:140
+msgid "Error 404 - Not Found"
+msgstr ""
+
+#: src/Core/System.php:141
+msgid "Error 500 - Internal Server Error"
+msgstr ""
+
+#: src/Core/System.php:142
+msgid "Error 503 - Service Unavailable"
+msgstr ""
+
+#: src/Core/System.php:150
+msgid ""
+"The server cannot or will not process the request due to an apparent client "
+"error."
+msgstr ""
+
+#: src/Core/System.php:151
+msgid "Authentication is required and has failed or has not yet been provided."
+msgstr ""
+
+#: src/Core/System.php:152
+msgid ""
+"The request was valid, but the server is refusing action. The user might not "
+"have the necessary permissions for a resource, or may need an account."
+msgstr ""
+
+#: src/Core/System.php:153
+msgid ""
+"The requested resource could not be found but may be available in the future."
+msgstr ""
+
+#: src/Core/System.php:154
+msgid ""
+"An unexpected condition was encountered and no more specific message is "
+"suitable."
+msgstr ""
+
+#: src/Core/System.php:155
+msgid ""
+"The server is currently unavailable (because it is overloaded or down for "
+"maintenance). Please try again later."
+msgstr ""
+
+#: src/Core/Update.php:168
+#, php-format
+msgid "Update %s failed. See error logs."
+msgstr ""
+
+#: src/Core/Update.php:225
+#, php-format
+msgid ""
+"\n"
+"\t\t\t\tThe friendica developers released update %s recently,\n"
+"\t\t\t\tbut when I tried to install it, something went terribly wrong.\n"
+"\t\t\t\tThis needs to be fixed soon and I can't do it alone. Please contact "
+"a\n"
+"\t\t\t\tfriendica developer if you can not help me on your own. My database "
+"might be invalid."
+msgstr ""
+
+#: src/Core/Update.php:231
+#, php-format
+msgid ""
+"The error message is\n"
+"[pre]%s[/pre]"
+msgstr ""
+
+#: src/Core/Update.php:260
+#, php-format
+msgid ""
+"\n"
+"\t\t\t\t\tThe friendica database was successfully updated from %s to %s."
+msgstr ""
+
+#: src/Core/UserImport.php:103
+msgid "Error decoding account file"
+msgstr ""
+
+#: src/Core/UserImport.php:109
+msgid "Error! No version data in file! This is not a Friendica account file?"
+msgstr ""
+
+#: src/Core/UserImport.php:117
+#, php-format
+msgid "User '%s' already exists on this server!"
+msgstr ""
+
+#: src/Core/UserImport.php:153
+msgid "User creation error"
+msgstr ""
+
+#: src/Core/UserImport.php:171
+msgid "User profile creation error"
+msgstr ""
+
+#: src/Core/UserImport.php:215
+#, php-format
+msgid "%d contact not imported"
+msgid_plural "%d contacts not imported"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/Core/UserImport.php:280
+msgid "Done. You can now login with your username and password"
+msgstr ""
+
 #: src/Database/DBStructure.php:47
 msgid "There are no tables on MyISAM."
 msgstr ""
@@ -8457,147 +8212,152 @@ msgstr ""
 msgid "%s: updating %s table."
 msgstr ""
 
-#: src/Model/Contact.php:1037
+#: src/LegacyModule.php:30
+#, php-format
+msgid "Legacy module file not found: %s"
+msgstr ""
+
+#: src/Model/Contact.php:1054
 msgid "Drop Contact"
 msgstr ""
 
-#: src/Model/Contact.php:1509
+#: src/Model/Contact.php:1526
 msgid "Organisation"
 msgstr ""
 
-#: src/Model/Contact.php:1513
+#: src/Model/Contact.php:1530
 msgid "News"
 msgstr ""
 
-#: src/Model/Contact.php:1517
+#: src/Model/Contact.php:1534
 msgid "Forum"
 msgstr ""
 
-#: src/Model/Contact.php:1707
+#: src/Model/Contact.php:1724
 msgid "Connect URL missing."
 msgstr ""
 
-#: src/Model/Contact.php:1716
+#: src/Model/Contact.php:1733
 msgid ""
 "The contact could not be added. Please check the relevant network "
 "credentials in your Settings -> Social Networks page."
 msgstr ""
 
-#: src/Model/Contact.php:1755
+#: src/Model/Contact.php:1772
 msgid ""
 "This site is not configured to allow communications with other networks."
 msgstr ""
 
-#: src/Model/Contact.php:1756 src/Model/Contact.php:1769
+#: src/Model/Contact.php:1773 src/Model/Contact.php:1786
 msgid "No compatible communication protocols or feeds were discovered."
 msgstr ""
 
-#: src/Model/Contact.php:1767
+#: src/Model/Contact.php:1784
 msgid "The profile address specified does not provide adequate information."
 msgstr ""
 
-#: src/Model/Contact.php:1772
+#: src/Model/Contact.php:1789
 msgid "An author or name was not found."
 msgstr ""
 
-#: src/Model/Contact.php:1775
+#: src/Model/Contact.php:1792
 msgid "No browser URL could be matched to this address."
 msgstr ""
 
-#: src/Model/Contact.php:1778
+#: src/Model/Contact.php:1795
 msgid ""
 "Unable to match @-style Identity Address with a known protocol or email "
 "contact."
 msgstr ""
 
-#: src/Model/Contact.php:1779
+#: src/Model/Contact.php:1796
 msgid "Use mailto: in front of address to force email check."
 msgstr ""
 
-#: src/Model/Contact.php:1785
+#: src/Model/Contact.php:1802
 msgid ""
 "The profile address specified belongs to a network which has been disabled "
 "on this site."
 msgstr ""
 
-#: src/Model/Contact.php:1790
+#: src/Model/Contact.php:1807
 msgid ""
 "Limited profile. This person will be unable to receive direct/personal "
 "notifications from you."
 msgstr ""
 
-#: src/Model/Contact.php:1843
+#: src/Model/Contact.php:1860
 msgid "Unable to retrieve contact information."
 msgstr ""
 
-#: src/Model/Event.php:61 src/Model/Event.php:78 src/Model/Event.php:436
-#: src/Model/Event.php:916
+#: src/Model/Event.php:61 src/Model/Event.php:78 src/Model/Event.php:435
+#: src/Model/Event.php:915
 msgid "Starts:"
 msgstr ""
 
-#: src/Model/Event.php:64 src/Model/Event.php:84 src/Model/Event.php:437
-#: src/Model/Event.php:920
+#: src/Model/Event.php:64 src/Model/Event.php:84 src/Model/Event.php:436
+#: src/Model/Event.php:919
 msgid "Finishes:"
 msgstr ""
 
-#: src/Model/Event.php:386
+#: src/Model/Event.php:385
 msgid "all-day"
 msgstr ""
 
-#: src/Model/Event.php:409
+#: src/Model/Event.php:408
 msgid "Jun"
 msgstr ""
 
-#: src/Model/Event.php:412
+#: src/Model/Event.php:411
 msgid "Sept"
 msgstr ""
 
-#: src/Model/Event.php:434
+#: src/Model/Event.php:433
 msgid "No events to display"
 msgstr ""
 
-#: src/Model/Event.php:562
+#: src/Model/Event.php:561
 msgid "l, F j"
 msgstr ""
 
-#: src/Model/Event.php:593
+#: src/Model/Event.php:592
 msgid "Edit event"
 msgstr ""
 
-#: src/Model/Event.php:594
+#: src/Model/Event.php:593
 msgid "Duplicate event"
 msgstr ""
 
-#: src/Model/Event.php:595
+#: src/Model/Event.php:594
 msgid "Delete event"
 msgstr ""
 
-#: src/Model/Event.php:627 src/Model/Item.php:3536 src/Model/Item.php:3543
+#: src/Model/Event.php:626 src/Model/Item.php:3554 src/Model/Item.php:3561
 msgid "link to source"
 msgstr ""
 
-#: src/Model/Event.php:849
+#: src/Model/Event.php:848
 msgid "D g:i A"
 msgstr ""
 
-#: src/Model/Event.php:850
+#: src/Model/Event.php:849
 msgid "g:i A"
 msgstr ""
 
-#: src/Model/Event.php:935 src/Model/Event.php:937
+#: src/Model/Event.php:934 src/Model/Event.php:936
 msgid "Show map"
 msgstr ""
 
-#: src/Model/Event.php:936
+#: src/Model/Event.php:935
 msgid "Hide map"
 msgstr ""
 
-#: src/Model/Event.php:1028
+#: src/Model/Event.php:1027
 #, php-format
 msgid "%s's birthday"
 msgstr ""
 
-#: src/Model/Event.php:1029
+#: src/Model/Event.php:1028
 #, php-format
 msgid "Happy Birthday %s"
 msgstr ""
@@ -8637,34 +8397,34 @@ msgstr ""
 msgid "Edit groups"
 msgstr ""
 
-#: src/Model/Item.php:3269
+#: src/Model/Item.php:3287
 msgid "activity"
 msgstr ""
 
-#: src/Model/Item.php:3271 src/Object/Post.php:457 src/Object/Post.php:469
+#: src/Model/Item.php:3289 src/Object/Post.php:470
 msgid "comment"
 msgid_plural "comments"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3274
+#: src/Model/Item.php:3292
 msgid "post"
 msgstr ""
 
-#: src/Model/Item.php:3373
+#: src/Model/Item.php:3391
 #, php-format
 msgid "Content warning: %s"
 msgstr ""
 
-#: src/Model/Item.php:3452
+#: src/Model/Item.php:3470
 msgid "bytes"
 msgstr ""
 
-#: src/Model/Item.php:3530
+#: src/Model/Item.php:3548
 msgid "View on separate page"
 msgstr ""
 
-#: src/Model/Item.php:3531
+#: src/Model/Item.php:3549
 msgid "view on separate page"
 msgstr ""
 
@@ -8739,6 +8499,10 @@ msgstr ""
 
 #: src/Model/Profile.php:763
 msgid "j F"
+msgstr ""
+
+#: src/Model/Profile.php:771 src/Util/Temporal.php:147
+msgid "Birthday:"
 msgstr ""
 
 #: src/Model/Profile.php:778
@@ -8847,134 +8611,138 @@ msgstr ""
 msgid "Enter a valid existing folder"
 msgstr ""
 
-#: src/Model/User.php:270
+#: src/Model/User.php:271
 msgid "Login failed"
 msgstr ""
 
-#: src/Model/User.php:301
+#: src/Model/User.php:302
 msgid "Not enough information to authenticate"
 msgstr ""
 
-#: src/Model/User.php:379
+#: src/Model/User.php:380
 msgid "Password can't be empty"
 msgstr ""
 
-#: src/Model/User.php:398
+#: src/Model/User.php:399
 msgid "Empty passwords are not allowed."
 msgstr ""
 
-#: src/Model/User.php:402
+#: src/Model/User.php:403
 msgid ""
 "The new password has been exposed in a public data dump, please choose "
 "another."
 msgstr ""
 
-#: src/Model/User.php:408
+#: src/Model/User.php:409
 msgid ""
 "The password can't contain accentuated letters, white spaces or colons (:)"
 msgstr ""
 
-#: src/Model/User.php:508
+#: src/Model/User.php:509
 msgid "Passwords do not match. Password unchanged."
 msgstr ""
 
-#: src/Model/User.php:515
+#: src/Model/User.php:516
 msgid "An invitation is required."
 msgstr ""
 
-#: src/Model/User.php:519
+#: src/Model/User.php:520
 msgid "Invitation could not be verified."
 msgstr ""
 
-#: src/Model/User.php:526
+#: src/Model/User.php:527
 msgid "Invalid OpenID url"
 msgstr ""
 
-#: src/Model/User.php:539 src/Module/Login.php:106
+#: src/Model/User.php:540 src/Module/Login.php:106
 msgid ""
 "We encountered a problem while logging in with the OpenID you provided. "
 "Please check the correct spelling of the ID."
 msgstr ""
 
-#: src/Model/User.php:539 src/Module/Login.php:106
+#: src/Model/User.php:540 src/Module/Login.php:106
 msgid "The error message was:"
 msgstr ""
 
-#: src/Model/User.php:545
+#: src/Model/User.php:546
 msgid "Please enter the required information."
 msgstr ""
 
-#: src/Model/User.php:559
+#: src/Model/User.php:560
 #, php-format
 msgid ""
 "system.username_min_length (%s) and system.username_max_length (%s) are "
 "excluding each other, swapping values."
 msgstr ""
 
-#: src/Model/User.php:566
+#: src/Model/User.php:567
 #, php-format
 msgid "Username should be at least %s character."
 msgid_plural "Username should be at least %s characters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/User.php:570
+#: src/Model/User.php:571
 #, php-format
 msgid "Username should be at most %s character."
 msgid_plural "Username should be at most %s characters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/User.php:578
+#: src/Model/User.php:579
 msgid "That doesn't appear to be your full (First Last) name."
 msgstr ""
 
-#: src/Model/User.php:583
+#: src/Model/User.php:584
 msgid "Your email domain is not among those allowed on this site."
 msgstr ""
 
-#: src/Model/User.php:587
+#: src/Model/User.php:588
 msgid "Not a valid email address."
 msgstr ""
 
-#: src/Model/User.php:590
+#: src/Model/User.php:591
 msgid "The nickname was blocked from registration by the nodes admin."
 msgstr ""
 
-#: src/Model/User.php:594 src/Model/User.php:602
+#: src/Model/User.php:595 src/Model/User.php:603
 msgid "Cannot use that email."
 msgstr ""
 
-#: src/Model/User.php:609
+#: src/Model/User.php:610
 msgid "Your nickname can only contain a-z, 0-9 and _."
 msgstr ""
 
-#: src/Model/User.php:616 src/Model/User.php:673
+#: src/Model/User.php:617 src/Model/User.php:674
 msgid "Nickname is already registered. Please choose another."
 msgstr ""
 
-#: src/Model/User.php:626
+#: src/Model/User.php:627
 msgid "SERIOUS ERROR: Generation of security keys failed."
 msgstr ""
 
-#: src/Model/User.php:660 src/Model/User.php:664
+#: src/Model/User.php:661 src/Model/User.php:665
 msgid "An error occurred during registration. Please try again."
 msgstr ""
 
-#: src/Model/User.php:689
+#: src/Model/User.php:685 view/theme/duepuntozero/config.php:55
+msgid "default"
+msgstr ""
+
+#: src/Model/User.php:690
 msgid "An error occurred creating your default profile. Please try again."
 msgstr ""
 
-#: src/Model/User.php:696
+#: src/Model/User.php:697
 msgid "An error occurred creating your self contact. Please try again."
 msgstr ""
 
-#: src/Model/User.php:705
+#: src/Model/User.php:706
 msgid ""
 "An error occurred creating your default contact group. Please try again."
 msgstr ""
 
-#: src/Model/User.php:781
+#: src/Model/User.php:782
 #, php-format
 msgid ""
 "\n"
@@ -8990,12 +8758,12 @@ msgid ""
 "\t\t"
 msgstr ""
 
-#: src/Model/User.php:798
+#: src/Model/User.php:799
 #, php-format
 msgid "Registration at %s"
 msgstr ""
 
-#: src/Model/User.php:817
+#: src/Model/User.php:818
 #, php-format
 msgid ""
 "\n"
@@ -9004,7 +8772,7 @@ msgid ""
 "\t\t"
 msgstr ""
 
-#: src/Model/User.php:823
+#: src/Model/User.php:824
 #, php-format
 msgid ""
 "\n"
@@ -9041,52 +8809,6 @@ msgid ""
 "removeme\n"
 "\n"
 "\t\t\tThank you and welcome to %2$s."
-msgstr ""
-
-#: src/Protocol/Diaspora.php:2496
-msgid "Sharing notification from Diaspora network"
-msgstr ""
-
-#: src/Protocol/Diaspora.php:3613
-msgid "Attachments:"
-msgstr ""
-
-#: src/Protocol/OStatus.php:1302 src/Module/Profile.php:102
-#: src/Module/Profile.php:105
-#, php-format
-msgid "%s's timeline"
-msgstr ""
-
-#: src/Protocol/OStatus.php:1306 src/Module/Profile.php:103
-#, php-format
-msgid "%s's posts"
-msgstr ""
-
-#: src/Protocol/OStatus.php:1309 src/Module/Profile.php:104
-#, php-format
-msgid "%s's comments"
-msgstr ""
-
-#: src/Protocol/OStatus.php:1866
-#, php-format
-msgid "%s is now following %s."
-msgstr ""
-
-#: src/Protocol/OStatus.php:1867
-msgid "following"
-msgstr ""
-
-#: src/Protocol/OStatus.php:1870
-#, php-format
-msgid "%s stopped following %s."
-msgstr ""
-
-#: src/Protocol/OStatus.php:1871
-msgid "stopped following"
-msgstr ""
-
-#: src/Worker/Delivery.php:453
-msgid "(no subject)"
 msgstr ""
 
 #: src/Module/Attach.php:36 src/Module/Attach.php:48
@@ -9597,6 +9319,22 @@ msgstr ""
 msgid "Logged out."
 msgstr ""
 
+#: src/Module/Profile.php:102 src/Module/Profile.php:105
+#: src/Protocol/OStatus.php:1302
+#, php-format
+msgid "%s's timeline"
+msgstr ""
+
+#: src/Module/Profile.php:103 src/Protocol/OStatus.php:1306
+#, php-format
+msgid "%s's posts"
+msgstr ""
+
+#: src/Module/Profile.php:104 src/Protocol/OStatus.php:1309
+#, php-format
+msgid "%s's comments"
+msgstr ""
+
 #: src/Module/Proxy.php:73
 msgid "Bad Request."
 msgstr ""
@@ -9824,58 +9562,140 @@ msgstr ""
 msgid "via Wall-To-Wall:"
 msgstr ""
 
-#: src/Object/Post.php:432
-msgid "Notifier task is pending"
+#: src/Object/Post.php:418
+#, php-format
+msgid "Reply to %s"
 msgstr ""
 
 #: src/Object/Post.php:433
-msgid "Delivery to remote servers is pending"
+msgid "Notifier task is pending"
 msgstr ""
 
 #: src/Object/Post.php:434
-msgid "Delivery to remote servers is underway"
+msgid "Delivery to remote servers is pending"
 msgstr ""
 
 #: src/Object/Post.php:435
-msgid "Delivery to remote servers is mostly done"
+msgid "Delivery to remote servers is underway"
 msgstr ""
 
 #: src/Object/Post.php:436
+msgid "Delivery to remote servers is mostly done"
+msgstr ""
+
+#: src/Object/Post.php:437
 msgid "Delivery to remote servers is done"
 msgstr ""
 
-#: src/Object/Post.php:455
+#: src/Object/Post.php:457
 #, php-format
 msgid "%d comment"
 msgid_plural "%d comments"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/App.php:665
-msgid "Delete this item?"
+#: src/Object/Post.php:458
+msgid "Show more"
 msgstr ""
 
-#: src/App.php:667
-msgid "show fewer"
+#: src/Object/Post.php:459
+msgid "Show fewer"
 msgstr ""
 
-#: src/App.php:709
-msgid "toggle mobile"
+#: src/Protocol/Diaspora.php:2496
+msgid "Sharing notification from Diaspora network"
 msgstr ""
 
-#: src/App.php:1077
-msgid "No system theme config value set."
+#: src/Protocol/Diaspora.php:3613
+msgid "Attachments:"
 msgstr ""
 
-#: src/BaseModule.php:133
-msgid ""
-"The form security token was not correct. This probably happened because the "
-"form has been opened for too long (>3 hours) before submitting it."
-msgstr ""
-
-#: src/LegacyModule.php:30
+#: src/Protocol/OStatus.php:1866
 #, php-format
-msgid "Legacy module file not found: %s"
+msgid "%s is now following %s."
+msgstr ""
+
+#: src/Protocol/OStatus.php:1867
+msgid "following"
+msgstr ""
+
+#: src/Protocol/OStatus.php:1870
+#, php-format
+msgid "%s stopped following %s."
+msgstr ""
+
+#: src/Protocol/OStatus.php:1871
+msgid "stopped following"
+msgstr ""
+
+#: src/Util/Temporal.php:151
+msgid "YYYY-MM-DD or MM-DD"
+msgstr ""
+
+#: src/Util/Temporal.php:298
+msgid "never"
+msgstr ""
+
+#: src/Util/Temporal.php:305
+msgid "less than a second ago"
+msgstr ""
+
+#: src/Util/Temporal.php:313
+msgid "year"
+msgstr ""
+
+#: src/Util/Temporal.php:313
+msgid "years"
+msgstr ""
+
+#: src/Util/Temporal.php:314
+msgid "months"
+msgstr ""
+
+#: src/Util/Temporal.php:315
+msgid "weeks"
+msgstr ""
+
+#: src/Util/Temporal.php:316
+msgid "days"
+msgstr ""
+
+#: src/Util/Temporal.php:317
+msgid "hour"
+msgstr ""
+
+#: src/Util/Temporal.php:317
+msgid "hours"
+msgstr ""
+
+#: src/Util/Temporal.php:318
+msgid "minute"
+msgstr ""
+
+#: src/Util/Temporal.php:318
+msgid "minutes"
+msgstr ""
+
+#: src/Util/Temporal.php:319
+msgid "second"
+msgstr ""
+
+#: src/Util/Temporal.php:319
+msgid "seconds"
+msgstr ""
+
+#: src/Util/Temporal.php:329
+#, php-format
+msgid "in %1$d %2$s"
+msgstr ""
+
+#: src/Util/Temporal.php:332
+#, php-format
+msgid "%1$d %2$s ago"
+msgstr ""
+
+#: src/Worker/Delivery.php:453
+msgid "(no subject)"
 msgstr ""
 
 #: update.php:217
@@ -9886,4 +9706,192 @@ msgstr ""
 #: update.php:272
 #, php-format
 msgid "%s: Updating post-type."
+msgstr ""
+
+#: view/theme/duepuntozero/config.php:56
+msgid "greenzero"
+msgstr ""
+
+#: view/theme/duepuntozero/config.php:57
+msgid "purplezero"
+msgstr ""
+
+#: view/theme/duepuntozero/config.php:58
+msgid "easterbunny"
+msgstr ""
+
+#: view/theme/duepuntozero/config.php:59
+msgid "darkzero"
+msgstr ""
+
+#: view/theme/duepuntozero/config.php:60
+msgid "comix"
+msgstr ""
+
+#: view/theme/duepuntozero/config.php:61
+msgid "slackr"
+msgstr ""
+
+#: view/theme/duepuntozero/config.php:75
+msgid "Variations"
+msgstr ""
+
+#: view/theme/frio/config.php:103
+msgid "Custom"
+msgstr ""
+
+#: view/theme/frio/config.php:115
+msgid "Note"
+msgstr ""
+
+#: view/theme/frio/config.php:115
+msgid "Check image permissions if all users are allowed to see the image"
+msgstr ""
+
+#: view/theme/frio/config.php:122
+msgid "Select color scheme"
+msgstr ""
+
+#: view/theme/frio/config.php:123
+msgid "Navigation bar background color"
+msgstr ""
+
+#: view/theme/frio/config.php:124
+msgid "Navigation bar icon color "
+msgstr ""
+
+#: view/theme/frio/config.php:125
+msgid "Link color"
+msgstr ""
+
+#: view/theme/frio/config.php:126
+msgid "Set the background color"
+msgstr ""
+
+#: view/theme/frio/config.php:127
+msgid "Content background opacity"
+msgstr ""
+
+#: view/theme/frio/config.php:128
+msgid "Set the background image"
+msgstr ""
+
+#: view/theme/frio/config.php:129
+msgid "Background image style"
+msgstr ""
+
+#: view/theme/frio/config.php:134
+msgid "Login page background image"
+msgstr ""
+
+#: view/theme/frio/config.php:138
+msgid "Login page background color"
+msgstr ""
+
+#: view/theme/frio/config.php:138
+msgid "Leave background image and color empty for theme defaults"
+msgstr ""
+
+#: view/theme/frio/php/Image.php:24
+msgid "Top Banner"
+msgstr ""
+
+#: view/theme/frio/php/Image.php:24
+msgid ""
+"Resize image to the width of the screen and show background color below on "
+"long pages."
+msgstr ""
+
+#: view/theme/frio/php/Image.php:25
+msgid "Full screen"
+msgstr ""
+
+#: view/theme/frio/php/Image.php:25
+msgid ""
+"Resize image to fill entire screen, clipping either the right or the bottom."
+msgstr ""
+
+#: view/theme/frio/php/Image.php:26
+msgid "Single row mosaic"
+msgstr ""
+
+#: view/theme/frio/php/Image.php:26
+msgid ""
+"Resize image to repeat it on a single row, either vertical or horizontal."
+msgstr ""
+
+#: view/theme/frio/php/Image.php:27
+msgid "Mosaic"
+msgstr ""
+
+#: view/theme/frio/php/Image.php:27
+msgid "Repeat image to fill the screen."
+msgstr ""
+
+#: view/theme/frio/theme.php:239
+msgid "Guest"
+msgstr ""
+
+#: view/theme/frio/theme.php:244
+msgid "Visitor"
+msgstr ""
+
+#: view/theme/quattro/config.php:77
+msgid "Alignment"
+msgstr ""
+
+#: view/theme/quattro/config.php:77
+msgid "Left"
+msgstr ""
+
+#: view/theme/quattro/config.php:77
+msgid "Center"
+msgstr ""
+
+#: view/theme/quattro/config.php:78
+msgid "Color scheme"
+msgstr ""
+
+#: view/theme/quattro/config.php:79
+msgid "Posts font size"
+msgstr ""
+
+#: view/theme/quattro/config.php:80
+msgid "Textareas font size"
+msgstr ""
+
+#: view/theme/vier/config.php:76
+msgid "Comma separated list of helper forums"
+msgstr ""
+
+#: view/theme/vier/config.php:123
+msgid "Set style"
+msgstr ""
+
+#: view/theme/vier/config.php:124
+msgid "Community Pages"
+msgstr ""
+
+#: view/theme/vier/config.php:125 view/theme/vier/theme.php:151
+msgid "Community Profiles"
+msgstr ""
+
+#: view/theme/vier/config.php:126
+msgid "Help or @NewHere ?"
+msgstr ""
+
+#: view/theme/vier/config.php:127 view/theme/vier/theme.php:373
+msgid "Connect Services"
+msgstr ""
+
+#: view/theme/vier/config.php:128
+msgid "Find Friends"
+msgstr ""
+
+#: view/theme/vier/config.php:129 view/theme/vier/theme.php:181
+msgid "Last users"
+msgstr ""
+
+#: view/theme/vier/theme.php:288
+msgid "Quick Start"
 msgstr ""

--- a/view/templates/head.tpl
+++ b/view/templates/head.tpl
@@ -146,9 +146,6 @@
 		$(obj).val("");
 	}
 
-	window.showMore = "{{$showmore}}";
-	window.showFewer = "{{$showfewer}}";
-
 	function showHideCommentBox(id) {
 		if ($("#comment-edit-form-" + id).is(":visible")) {
 			$("#comment-edit-form-" + id).hide();

--- a/view/templates/head.tpl
+++ b/view/templates/head.tpl
@@ -88,7 +88,6 @@
 		$("#comment-edit-text-" + id).putCursorAtEnd();
 		$("#comment-edit-text-" + id).addClass("comment-edit-text-full");
 		$("#comment-edit-text-" + id).removeClass("comment-edit-text-empty");
-		$("#comment-edit-text-" + id).focus();
 		$("#mod-cmnt-wrap-" + id).show();
 		openMenu("comment-edit-submit-wrapper-" + id);
 		return true;

--- a/view/templates/jot-header.tpl
+++ b/view/templates/jot-header.tpl
@@ -42,7 +42,7 @@ function enableOnUser(){
 </script>
 <script type="text/javascript" src="{{$baseurl}}/view/js/ajaxupload.js" ></script>
 <script>
-	var ispublic = '{{$ispublic}}';
+	var ispublic = '{{$ispublic nofilter}}';
 
 
 	$(document).ready(function() {

--- a/view/templates/photos_head.tpl
+++ b/view/templates/photos_head.tpl
@@ -2,7 +2,7 @@
 
 <script>
 
-	var ispublic = "{{$ispublic}}";
+	var ispublic = "{{$ispublic nofilter}}";
 
 
 	$(document).ready(function() {

--- a/view/templates/settings/head.tpl
+++ b/view/templates/settings/head.tpl
@@ -1,7 +1,7 @@
 
 
 <script>
-	var ispublic = "{{$ispublic}}";
+	var ispublic = "{{$ispublic nofilter}}";
 
 
 	$(document).ready(function() {

--- a/view/templates/wall_thread.tpl
+++ b/view/templates/wall_thread.tpl
@@ -1,7 +1,12 @@
 
 {{if $item.comment_firstcollapsed}}
-	<div class="hide-comments-outer">
-	<span id="hide-comments-total-{{$item.id}}" class="hide-comments-total">{{$item.num_comments}}</span> <span id="hide-comments-{{$item.id}}" class="hide-comments fakelink" onclick="showHideComments({{$item.id}});">{{$item.hide_text}}</span>
+	<div class="hide-comments-outer fakelink" onclick="showHideComments({{$item.id}});">
+		<span id="hide-comments-total-{{$item.id}}" class="hide-comments-total">
+			{{$item.num_comments}} - {{$item.show_text}}
+		</span>
+		<span id="hide-comments-{{$item.id}}" class="hide-comments" style="display: none">
+			{{$item.num_comments}} - {{$item.hide_text}}
+		</span>
 	</div>
 	<div id="collapsed-comments-{{$item.id}}" class="collapsed-comments" style="display: none;">
 {{/if}}

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -1669,7 +1669,13 @@ aside .panel-body {
 
 /* wall items */
 .wall-item-container {
-    position: relative;
+    background-color: rgba(0, 0, 0, 0.03);
+    padding: 0.5em;
+    border-top: 1px solid rgba(255, 255, 255, 0.8);
+}
+
+.wall-item-container .media {
+    margin-top: 0;
 }
 
 /* wall items contact photo */
@@ -1914,12 +1920,13 @@ code > .hl-main {
 
 /* item social action buttons */
 .wall-item-actions {
-    margin-top: 15px;
+    display: flex;
+    margin: .5em 0;
+    justify-content: space-between;
 }
-.wall-item-actions, .wall-item-actions a, .wall-item-actions button {
+.wall-item-actions a, .wall-item-actions button {
     font-size: 13px;
     color: #555;
-    margin-bottom: 0;
 }
 .wall-item-actions .active {
     font-weight: bold;
@@ -2013,9 +2020,10 @@ code > .hl-main {
     position: relative!important;
     margin-top: 0;
 }
-.hide-comments-outer-wrapper {
-/*    text-align: center;
-    margin-top: -18px;*/
+.hide-comments-outer {
+    background-color: rgba(0, 0, 0, 0.03);
+    padding: 0.5em;
+    border-radius: 0.5em 0.5em 0 0;
 }
 .hide-comments-total {
     cursor: pointer;
@@ -2024,21 +2032,31 @@ code > .hl-main {
 /*
 * Comment Box
 */
-.thread_level_2 .wall-item-comment-wrapper {
-    padding-right: 5px;
+
+.comment-fake-form,
+.wall-item-comment-wrapper {
+    padding: 10px;
+    border-top: 1px solid rgba(255, 255, 255, 0.8);
+    background-color: rgba(0, 0, 0, 0.03);
+    border-radius: 0 0 10px 10px;
 }
+
+.comment-fake-form {
+    border-color: #d9d9d9;
+}
+
+.comment-container .wall-item-comment-wrapper {
+    margin-top: 0.5em;
+}
+
 .comment-edit-submit-wrapper {
-    margin-bottom: 25px;
+    display: flex;
+    justify-content: flex-end;
 }
-.comment-edit-submit-wrapper a,
-.comment-edit-submit-wrapper a:hover {
-    padding-top: 5px !important;
-    padding-bottom: 5px !important;
-}
-.comment-icon-list > li > .icon,
-.comment-icon-list > li > .icon:hover {
-    color: #555;
-    background-color: transparent;
+
+.comment-icon-list {
+    display: flex;
+    justify-content: space-between;
 }
 
 /* acpopup  + textcompletion*/

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -2050,8 +2050,7 @@ code > .hl-main {
 }
 
 .comment-edit-submit-wrapper {
-    display: flex;
-    justify-content: flex-end;
+    text-align: right;
 }
 
 .comment-icon-list {

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -2044,9 +2044,16 @@ code > .hl-main {
 .comment-fake-form {
     border-color: #d9d9d9;
 }
+.comment-fake-form textarea {
+    resize: none;
+}
 
 .comment-container .wall-item-comment-wrapper {
     margin-top: 0.5em;
+}
+
+.comment-edit-form textarea {
+    resize: vertical;
 }
 
 .comment-edit-submit-wrapper {

--- a/view/theme/frio/js/textedit.js
+++ b/view/theme/frio/js/textedit.js
@@ -82,7 +82,8 @@ function insertFormatting(BBcode, id) {
 	if (tmpStr == '') {
 		$("#comment-edit-text-" + id).addClass("comment-edit-text-full");
 		$("#comment-edit-text-" + id).removeClass("comment-edit-text-empty");
-		openMenu("comment-edit-submit-wrapper-" + id);
+		closeMenu("comment-fake-form-" + id);
+		openMenu("item-comments-" + id);
 	}
 
 	textarea = document.getElementById("comment-edit-text-" + id);
@@ -134,113 +135,97 @@ function cmtBbClose(id) {
 	$("#comment-edit-bb-" + id).hide();
 }
 
-function commentExpand(id) {
-	$("#comment-edit-text-" + id).putCursorAtEnd();
-	$("#comment-edit-text-" + id).addClass("comment-edit-text-full");
-	$("#comment-edit-text-" + id).removeClass("comment-edit-text-empty");
-	$("#comment-edit-text-" + id).focus();
+function commentExpand(id)
+{
 	$("#mod-cmnt-wrap-" + id).show();
-	openMenu("comment-edit-submit-wrapper-" + id);
+	closeMenu("comment-fake-form-" + id);
+	openMenu("item-comments-" + id);
+	$("#comment-edit-text-" + id)
+		.putCursorAtEnd()
+		.addClass("comment-edit-text-full")
+		.removeClass("comment-edit-text-empty");
+
 	return true;
 }
 
-function commentClose(obj, id) {
-	if (obj.value == '') {
-		$("#comment-edit-text-" + id).removeClass("comment-edit-text-full");
-		$("#comment-edit-text-" + id).addClass("comment-edit-text-empty");
+function commentClose(obj, id)
+{
+	if (obj.value === '' || obj.value === obj.dataset.default) {
+		$("#comment-edit-text-" + id)
+			.removeClass("comment-edit-text-full")
+			.addClass("comment-edit-text-empty");
 		$("#mod-cmnt-wrap-" + id).hide();
-		closeMenu("comment-edit-submit-wrapper-" + id);
+		openMenu("comment-fake-form-" + id);
+		closeMenu("item-comments-" + id);
 		return true;
 	}
 	return false;
 }
 
 function showHideCommentBox(id) {
-	if ($('#comment-edit-form-' + id).is(':visible')) {
-		$('#comment-edit-form-' + id).hide();
+	var $el = $('#comment-edit-form-' + id);
+	if ($el.is(':visible')) {
+		$el.hide();
 	} else {
-		$('#comment-edit-form-' + id).show();
+		$el.show();
 	}
 }
 
 function commentOpenUI(obj, id) {
-	$("#comment-edit-text-" + id).addClass("comment-edit-text-full").removeClass("comment-edit-text-empty");
-	// Choose an arbitrary tab index that's greater than what we're using in jot (3 of them)
-	// The submit button gets tabindex + 1
-	$("#comment-edit-text-" + id).attr('tabindex', '9');
-	$("#comment-edit-submit-" + id).attr('tabindex', '10');
-	$("#comment-edit-submit-wrapper-" + id).show();
+	closeMenu("comment-fake-form-" + id);
+	openMenu("item-comments-" + id);
+	$("#comment-edit-text-" + id)
+		.putCursorAtEnd()
+		.addClass("comment-edit-text-full").removeClass("comment-edit-text-empty")
+		.attr('tabindex', '9'); 	// Choose an arbitrary tab index that's greater than what we're using in jot (3 of them)
+	$("#comment-edit-submit-" + id).attr('tabindex', '10'); // The submit button gets tabindex + 1
 	// initialize autosize for this comment
 	autosize($("#comment-edit-text-" + id + ".text-autosize"));
 }
 
 function commentCloseUI(obj, id) {
-	if (obj.value === '') {
-		$("#comment-edit-text-" + id).removeClass("comment-edit-text-full").addClass("comment-edit-text-empty");
-		$("#comment-edit-text-" + id).removeAttr('tabindex');
+	if (obj.value === '' || obj.value === obj.dataset.default) {
+		$("#comment-edit-text-" + id)
+			.removeClass("comment-edit-text-full").addClass("comment-edit-text-empty")
+			.removeAttr('tabindex');
 		$("#comment-edit-submit-" + id).removeAttr('tabindex');
-		$("#comment-edit-submit-wrapper-" + id).hide();
+		openMenu("comment-fake-form-" + id);
+		closeMenu("item-comments-" + id);
 		// destroy the automatic textarea resizing
 		autosize.destroy($("#comment-edit-text-" + id + ".text-autosize"));
 	}
 }
 
 function jotTextOpenUI(obj) {
-	if (obj.value == '') {
-		$(".modal-body #profile-jot-text").addClass("profile-jot-text-full").removeClass("profile-jot-text-empty");
+	if (obj.value === '' || obj.value === obj.dataset.default) {
+		var $el = $(".modal-body #profile-jot-text");
+		$el.addClass("profile-jot-text-full").removeClass("profile-jot-text-empty");
 		// initiale autosize for the jot
-		autosize($(".modal-body #profile-jot-text"));
+		autosize($el);
 	}
 }
 
 function jotTextCloseUI(obj) {
-	if (obj.value === '') {
-		$(".modal-body #profile-jot-text").removeClass("profile-jot-text-full").addClass("profile-jot-text-empty");
+	if (obj.value === '' || obj.value === obj.dataset.default) {
+		var $el = $(".modal-body #profile-jot-text");
+		$el.removeClass("profile-jot-text-full").addClass("profile-jot-text-empty");
 		// destroy the automatic textarea resizing
-		autosize.destroy($(".modal-body #profile-jot-text"));
+		autosize.destroy($el);
 	}
 }
 
 function commentOpen(obj, id) {
-	if (obj.value == '') {
-		$("#comment-edit-text-" + id).addClass("comment-edit-text-full");
-		$("#comment-edit-text-" + id).removeClass("comment-edit-text-empty");
+	if (obj.value === '' || obj.value === obj.dataset.default) {
+		$("#comment-edit-text-" + id)
+			.putCursorAtEnd()
+			.addClass("comment-edit-text-full")
+			.removeClass("comment-edit-text-empty");
 		$("#mod-cmnt-wrap-" + id).show();
-		openMenu("comment-edit-submit-wrapper-" + id);
+		closeMenu("comment-fake-form-" + id);
+		openMenu("item-comments-" + id);
 		return true;
 	}
 	return false;
-}
-
-function commentInsert(obj, id) {
-	var tmpStr = $("#comment-edit-text-" + id).val();
-	if (tmpStr == '') {
-		$("#comment-edit-text-" + id).addClass("comment-edit-text-full");
-		$("#comment-edit-text-" + id).removeClass("comment-edit-text-empty");
-		openMenu("comment-edit-submit-wrapper-" + id);
-	}
-	var ins = $(obj).html();
-	ins = ins.replace('&lt;', '<');
-	ins = ins.replace('&gt;', '>');
-	ins = ins.replace('&amp;', '&');
-	ins = ins.replace('&quot;', '"');
-	$("#comment-edit-text-" + id).val(tmpStr + ins);
-}
-
-function qCommentInsert(obj, id) {
-	var tmpStr = $("#comment-edit-text-" + id).val();
-	if (tmpStr == '') {
-		$("#comment-edit-text-" + id).addClass("comment-edit-text-full");
-		$("#comment-edit-text-" + id).removeClass("comment-edit-text-empty");
-		openMenu("comment-edit-submit-wrapper-" + id);
-	}
-	var ins = $(obj).val();
-	ins = ins.replace('&lt;', '<');
-	ins = ins.replace('&gt;', '>');
-	ins = ins.replace('&amp;', '&');
-	ins = ins.replace('&quot;', '"');
-	$("#comment-edit-text-" + id).val(tmpStr + ins);
-	$(obj).val('');
 }
 
 function confirmDelete() {

--- a/view/theme/frio/js/theme.js
+++ b/view/theme/frio/js/theme.js
@@ -388,19 +388,6 @@ function showHide(theID) {
 	}
 }
 
-function showHideComments(id) {
-	if( $('#collapsed-comments-' + id).is(':visible')) {
-		$('#collapsed-comments-' + id).slideUp();
-		$('#hide-comments-' + id).html(window.showMore);
-		$('#hide-comments-total-' + id).show();
-	}
-	else {
-		$('#collapsed-comments-' + id).slideDown();
-		$('#hide-comments-' + id).html(window.showFewer);
-		$('#hide-comments-total-' + id).hide();
-	}
-}
-
 // Show & hide event map in the network stream by button click.
 function showHideEventMap(elm) {
 	// Get the id of the map element - it should be provided through

--- a/view/theme/frio/templates/comment_item.tpl
+++ b/view/theme/frio/templates/comment_item.tpl
@@ -54,12 +54,12 @@
 		</p>
 {{/if}}
 
-		<div class="comment-edit-submit-wrapper">
+		<p class="comment-edit-submit-wrapper">
 {{if $preview}}
 			<button type="button" class="btn btn-defaul btn-sm" onclick="preview_comment({{$id}});" id="comment-edit-preview-link-{{$id}}"><i class="fa fa-eye"></i> {{$preview}}</button>
 {{/if}}
 			<button type="submit" class="btn btn-primary btn-sm" id="comment-edit-submit-{{$id}}" name="submit"><i class="fa fa-envelope"></i> {{$submit}}</button>
-		</div>
+		</p>
 
 		<div class="comment-edit-end clear"></div>
 	</form>

--- a/view/theme/frio/templates/comment_item.tpl
+++ b/view/theme/frio/templates/comment_item.tpl
@@ -1,10 +1,10 @@
 
 {{if $threaded}}
-<div class="comment-wwedit-wrapper threaded" id="comment-edit-wrapper-{{$id}}" style="display: block;">
+<div class="comment-wwedit-wrapper threaded" id="comment-edit-wrapper-{{$id}}">
 {{else}}
-<div class="comment-wwedit-wrapper" id="comment-edit-wrapper-{{$id}}" style="display: block;">
+<div class="comment-wwedit-wrapper" id="comment-edit-wrapper-{{$id}}">
 {{/if}}
-	<form class="comment-edit-form" style="display: block;" data-item-id="{{$id}}" id="comment-edit-form-{{$id}}" action="item" method="post" onsubmit="post_comment({{$id}}); return false;">
+	<form class="comment-edit-form" data-item-id="{{$id}}" id="comment-edit-form-{{$id}}" action="item" method="post" onsubmit="post_comment({{$id}}); return false;">
 		<input type="hidden" name="type" value="{{$type}}" />
 		<input type="hidden" name="profile_uid" value="{{$profile_uid}}" />
 		<input type="hidden" name="parent" value="{{$parent}}" />
@@ -13,64 +13,56 @@
 		<input type="hidden" name="preview" id="comment-preview-inp-{{$id}}" value="0" />
 		<input type="hidden" name="post_id_random" value="{{$rand_num}}" />
 
-		<div class="bb form-group">
-			<textarea id="comment-edit-text-{{$id}}" class="comment-edit-text-empty form-control text-autosize" name="body" placeholder="{{$comment}}" onFocus="commentOpenUI(this,{{$id}});">{{$default}}</textarea>
-		</div>
-		{{if $qcomment}}
+		<p class="comment-edit-bb-{{$id}} comment-icon-list">
+			<span>
+				<button type="button" class="btn btn-sm icon bb-img" style="cursor: pointer;" aria-label="{{$edimg}}" title="{{$edimg}}" data-role="insert-formatting" data-bbcode="img" data-id="{{$id}}">
+					<i class="fa fa-picture-o"></i>
+				</button>
+				<button type="button" class="btn btn-sm icon bb-attach" style="cursor: pointer;" aria-label="{{$edattach}}" title="{{$edattach}}" ondragenter="return commentLinkDrop(event, {{$id}});" ondragover="return commentLinkDrop(event, {{$id}});" ondrop="commentLinkDropper(event);" onclick="commentGetLink({{$id}}, '{{$prompttext}}');">
+					<i class="fa fa-paperclip"></i>
+				</button>
+			</span>
+			<span>
+				<button type="button" class="btn btn-sm icon bb-url" style="cursor: pointer;" aria-label="{{$edurl}}" title="{{$edurl}}" onclick="insertFormatting('url',{{$id}});">
+					<i class="fa fa-link"></i>
+				</button>
+				<button type="button" class="btn btn-sm icon underline" style="cursor: pointer;" aria-label="{{$eduline}}" title="{{$eduline}}" onclick="insertFormatting('u',{{$id}});">
+					<i class="fa fa-underline"></i>
+				</button>
+				<button type="button" class="btn btn-sm icon italic" style="cursor: pointer;" aria-label="{{$editalic}}" title="{{$editalic}}" onclick="insertFormatting('i',{{$id}});">
+					<i class="fa fa-italic"></i>
+				</button>
+				<button type="button" class="btn btn-sm icon bold" style="cursor: pointer;" aria-label="{{$edbold}}" title="{{$edbold}}" onclick="insertFormatting('b',{{$id}});">
+					<i class="fa fa-bold"></i>
+				</button>
+				<button type="button" class="btn btn-sm icon quote" style="cursor: pointer;" aria-label="{{$edquote}}" title="{{$edquote}}" onclick="insertFormatting('quote',{{$id}});">
+					<i class="fa fa-quote-left"></i>
+				</button>
+			</span>
+		</p>
+		<p>
+			<textarea id="comment-edit-text-{{$id}}" class="comment-edit-text-empty form-control text-autosize" name="body" placeholder="{{$comment}}" rows="3" data-default="{{$default}}">{{$default}}</textarea>
+		</p>
+{{if $qcomment}}
+		<p>
 			<select id="qcomment-select-{{$id}}" name="qcomment-{{$id}}" class="qcomment" onchange="qCommentInsert(this,{{$id}});">
-			<option value=""></option>
-		{{foreach $qcomment as $qc}}
-			<option value="{{$qc}}">{{$qc}}</option>
-		{{/foreach}}
+				<option value=""></option>
+	{{foreach $qcomment as $qc}}
+				<option value="{{$qc}}">{{$qc}}</option>
+	{{/foreach}}
 			</select>
-		{{/if}}
+		</p>
+{{/if}}
 
-		<div class="comment-edit-text-end clear"></div>
-		<div class="comment-edit-submit-wrapper" id="comment-edit-submit-wrapper-{{$id}}" style="display: none;">
+		<div class="comment-edit-submit-wrapper">
+{{if $preview}}
+			<button type="button" class="btn btn-defaul btn-sm" onclick="preview_comment({{$id}});" id="comment-edit-preview-link-{{$id}}"><i class="fa fa-eye"></i> {{$preview}}</button>
+{{/if}}
 			<button type="submit" class="btn btn-primary btn-sm" id="comment-edit-submit-{{$id}}" name="submit"><i class="fa fa-envelope"></i> {{$submit}}</button>
-			{{if $preview}}
-				<button type="button" class="btn btn-defaul btn-sm" onclick="preview_comment({{$id}});" id="comment-edit-preview-link-{{$id}}"><i class="fa fa-eye"></i> {{$preview}}</button>
-			{{/if}}
-			<ul class="comment-edit-bb-{{$id}} comment-icon-list nav nav-pills pull-right">
-				<li>
-					<button type="button" class="btn-link icon bb-img" style="cursor: pointer;" aria-label="{{$edimg}}" title="{{$edimg}}" data-role="insert-formatting" data-bbcode="img" data-id="{{$id}}">
-						<i class="fa fa-picture-o"></i>
-					</button>
-				</li>
-				<li>
-					<button type="button" class="btn-link icon bb-url" style="cursor: pointer;" aria-label="{{$edurl}}" title="{{$edurl}}" onclick="insertFormatting('url',{{$id}});">
-						<i class="fa fa-link"></i>
-					</button>
-				</li>
-				<li>
-					<button type="button" class="btn-link icon" style="cursor: pointer;" aria-label="{{$edattach}}" title="{{$edattach}}" ondragenter="return commentLinkDrop(event, {{$id}});" ondragover="return commentLinkDrop(event, {{$id}});" ondrop="commentLinkDropper(event);" onclick="commentGetLink({{$id}}, '{{$prompttext}}');">
-						<i class="fa fa-paperclip"></i>
-					</button>
-				</li>
-				<li>
-					<button type="button" class="btn-link icon underline" style="cursor: pointer;" aria-label="{{$eduline}}" title="{{$eduline}}" onclick="insertFormatting('u',{{$id}});">
-						<i class="fa fa-underline"></i>
-					</button>
-				</li>
-				<li>
-					<button type="button" class="btn-link icon italic" style="cursor: pointer;" aria-label="{{$editalic}}" title="{{$editalic}}" onclick="insertFormatting('i',{{$id}});">
-						<i class="fa fa-italic"></i>
-					</button>
-				</li>
-				<li>
-					<button type="button" class="btn-link icon bold" style="cursor: pointer;" aria-label="{{$edbold}}" title="{{$edbold}}" onclick="insertFormatting('b',{{$id}});">
-						<i class="fa fa-bold"></i>
-					</button>
-				</li>
-				<li>
-					<button type="button" class="btn-link icon quote" style="cursor: pointer;" aria-label="{{$edquote}}" title="{{$edquote}}" onclick="insertFormatting('quote',{{$id}});">
-						<i class="fa fa-quote-left"></i>
-					</button>
-				</li>
-			</ul>
 		</div>
 
 		<div class="comment-edit-end clear"></div>
 	</form>
 	<div id="comment-edit-preview-{{$id}}" class="comment-edit-preview" style="display:none;"></div>
 </div>
+

--- a/view/theme/frio/templates/head.tpl
+++ b/view/theme/frio/templates/head.tpl
@@ -87,11 +87,6 @@
 {{/if}}
 <script type="text/javascript" src="view/theme/frio/js/textedit.js"></script>
 
-<script type="text/javascript">
-	window.showMore = "{{$showmore}}";
-	window.showFewer = "{{$showfewer}}";
-</script>
-
 {{* Include the strings which are needed for some js functions (e.g. translation)
 They are loaded into the html <head> so that js functions can use them *}}
 {{include file="js_strings.tpl"}}

--- a/view/theme/frio/templates/jot-header.tpl
+++ b/view/theme/frio/templates/jot-header.tpl
@@ -40,7 +40,7 @@
 </script>
 
 <script type="text/javascript">
-	var ispublic = '{{$ispublic}}';
+	var ispublic = '{{$ispublic nofilter}}';
 	aStr.linkurl = '{{$linkurl}}';
 
 

--- a/view/theme/frio/templates/photos_head.tpl
+++ b/view/theme/frio/templates/photos_head.tpl
@@ -1,5 +1,5 @@
 
 <script type="text/javascript" src="view/theme/frio/js/mod_photos.js"></script>
 <script type="text/javascript">
-	var ispublic = "{{$ispublic}}";
+	var ispublic = "{{$ispublic nofilter}}";
 </script>

--- a/view/theme/frio/templates/search_item.tpl
+++ b/view/theme/frio/templates/search_item.tpl
@@ -161,9 +161,9 @@
 			</div>
 			<!-- ./TODO -->
 
-			<div class="wall-item-actions">
+			<p class="wall-item-actions">
 				{{* Action buttons to interact with the item (like: like, dislike, share and so on *}}
-				<div class="wall-item-actions-left pull-left">
+				<span class="wall-item-actions-left">
 					<!--comment this out to try something different {{if $item.threaded}}{{if $item.comment}}
 					<div id="button-reply" class="pull-left">
 						<button type="button" class="btn-link" id="comment-{{$item.id}}" onclick="openClose('item-comments-{{$item.id}}'); commentExpand({{$item.id}});"><i class="fa fa-reply" title="{{$item.switchcomment}}"></i> </span>
@@ -204,28 +204,27 @@
 						{{/if}}
 					{{/if}}
 					<img id="like-rotator-{{$item.id}}" class="like-rotator" src="images/rotator.gif" alt="{{$item.wait}}" title="{{$item.wait}}" style="display: none;" />
-				</div>
+				</span>
 
 
-				<div class="wall-item-actions-right pull-right">
+				<span class="wall-item-actions-right">
 					{{* Event attendance buttons *}}
-					{{if $item.isevent}}
-					<div class="vote-event">
+				{{if $item.isevent}}
+					<span class="vote-event">
 						<button type="button" class="btn btn-defaultbutton-event{{if $item.responses.attendyes.self}} active" aria-pressed="true{{/if}}" id="attendyes-{{$item.id}}" title="{{$item.attend.0}}" onclick="doLikeAction({{$item.id}}, 'attendyes');"><i class="fa fa-check" aria-hidden="true"><span class="sr-only">{{$item.attend.0}}</span></i></button>
 						<button type="button" class="btn btn-defaultbutton-event{{if $item.responses.attendno.self}} active" aria-pressed="true{{/if}}" id="attendno-{{$item.id}}" title="{{$item.attend.1}}" onclick="doLikeAction({{$item.id}}, 'attendno');"><i class="fa fa-times" aria-hidden="true"><span class="sr-only">{{$item.attend.1}}</span></i></button>
 						<button type="button" class="btn btn-defaultbutton-event{{if $item.responses.attendmaybe.self}} active" aria-pressed="true{{/if}}" id="attendmaybe-{{$item.id}}" title="{{$item.attend.2}}" onclick="doLikeAction({{$item.id}}, 'attendmaybe');"><i class="fa fa-question" aria-hidden="true"><span class="sr-only">{{$item.attend.2}}</span></i></button>
-					</div>
-					{{/if}}
+					</span>
+				{{/if}}
 
-					<div class="pull-right checkbox">
-						{{if $item.drop.pagedrop}}
+					<span class="pull-right checkbox">
+				{{if $item.drop.pagedrop}}
 						<input type="checkbox" title="{{$item.drop.select}}" name="itemselected[]" id="checkbox-{{$item.id}}" class="item-select" value="{{$item.id}}" />
 						<label for="checkbox-{{$item.id}}"></label>
-						{{/if}}
-					</div>
-				</div>
-				<div class="clearfix"></div>
-			</div><!--./wall-item-actions-->
+				{{/if}}
+					</span>
+				</span>
+			</p><!--./wall-item-actions-->
 
 					{{* Display likes, dislike and attendance stats *}}
 			{{if $item.responses}}

--- a/view/theme/frio/templates/voting_fakelink.tpl
+++ b/view/theme/frio/templates/voting_fakelink.tpl
@@ -1,0 +1,2 @@
+
+<p>{{$phrase nofilter}}</p>

--- a/view/theme/frio/templates/wall_thread.tpl
+++ b/view/theme/frio/templates/wall_thread.tpl
@@ -20,7 +20,7 @@ as the value of $top_child_total (this is done at the end of this file)
 {{/if}}
 
 {{if $item.thread_level==2 && $top_child_nr==1}}
-<div class="comment-container well well-sm"> <!--top-child-begin-->
+<div class="comment-container"> <!--top-child-begin-->
 {{/if}}
 {{* end of hacky part to count childrens *}}
 
@@ -308,9 +308,9 @@ as the value of $top_child_total (this is done at the end of this file)
 		<!-- ./TODO -->
 
 		<!-- <hr /> -->
-		<div class="wall-item-actions">
+		<p class="wall-item-actions">
 			{{* Action buttons to interact with the item (like: like, dislike, share and so on *}}
-			<div class="wall-item-actions-left pull-left">
+			<span class="wall-item-actions-left">
 				<!--comment this out to try something different {{if $item.threaded}}{{if $item.comment}}
 				<div id="button-reply" class="pull-left">
 					<button type="button" class="btn-link" id="comment-{{$item.id}}" onclick="openClose('item-comments-{{$item.id}}'); commentExpand({{$item.id}});"><i class="fa fa-reply" title="{{$item.switchcomment}}"></i> </span>
@@ -338,7 +338,7 @@ as the value of $top_child_total (this is done at the end of this file)
 
 				{{* Button to open the comment text field *}}
 				{{if $item.comment}}
-				<button type="button" class="btn-link button-comments" id="comment-{{$item.id}}" title="{{$item.switchcomment}}" {{if $item.thread_level != 1}}onclick="openClose('item-comments-{{$item.id}}'); commentExpand({{$item.id}});" {{else}} onclick="showHide('item-comments-{{$item.id}}'); commentExpand({{$item.id}});"{{/if}}><i class="fa fa-commenting" aria-hidden="true"></i>&nbsp;{{$item.switchcomment}}</button>
+				<button type="button" class="btn-link button-comments" id="comment-{{$item.id}}" title="{{$item.switchcomment}}" {{if $item.thread_level != 1}}onclick="openClose('item-comments-{{$item.id}}'); commentExpand({{$item.id}});" {{else}} onclick="openClose('item-comments-{{$item.id}}'); commentExpand({{$item.id}});"{{/if}}><i class="fa fa-commenting" aria-hidden="true"></i>&nbsp;{{$item.switchcomment}}</button>
 				{{/if}}
 
 				{{* Button for sharing the item *}}
@@ -351,27 +351,26 @@ as the value of $top_child_total (this is done at the end of this file)
 					{{/if}}
 				{{/if}}
 				<img id="like-rotator-{{$item.id}}" class="like-rotator" src="images/rotator.gif" alt="{{$item.wait}}" title="{{$item.wait}}" style="display: none;" />
-			</div>
+			</span>
 
-			<div class="wall-item-actions-right pull-right">
+			<span class="wall-item-actions-right">
 				{{* Event attendance buttons *}}
-				{{if $item.isevent}}
-				<div class="vote-event">
+			{{if $item.isevent}}
+				<span class="vote-event">
 					<button type="button" class="btn btn-xs btn-default button-event{{if $item.responses.attendyes.self}} active" aria-pressed="true{{/if}}" id="attendyes-{{$item.id}}" title="{{$item.attend.0}}" onclick="doLikeAction({{$item.id}},'attendyes');"><i class="fa fa-check" aria-hidden="true"><span class="sr-only">{{$item.attend.0}}</span></i></button>
 					<button type="button" class="btn btn-xs btn-default button-event{{if $item.responses.attendno.self}} active" aria-pressed="true{{/if}}" id="attendno-{{$item.id}}" title="{{$item.attend.1}}" onclick="doLikeAction({{$item.id}},'attendno');"><i class="fa fa-times" aria-hidden="true"><span class="sr-only">{{$item.attend.1}}</span></i></button>
 					<button type="button" class="btn btn-xs btn-default button-event{{if $item.responses.attendmaybe.self}} active" aria-pressed="true{{/if}}" id="attendmaybe-{{$item.id}}" title="{{$item.attend.2}}" onclick="doLikeAction({{$item.id}},'attendmaybe');"><i class="fa fa-question" aria-hidden="true"><span class="sr-only">{{$item.attend.2}}</span></i></button>
-				</div>
-				{{/if}}
+				</span>
+			{{/if}}
 
-				<div class="pull-right checkbox">
-					{{if $item.drop.pagedrop}}
+				<span class="pull-right checkbox">
+			{{if $item.drop.pagedrop}}
 					<input type="checkbox" title="{{$item.drop.select}}" name="itemselected[]" id="checkbox-{{$item.id}}" class="item-select" value="{{$item.id}}" />
 					<label for="checkbox-{{$item.id}}"></label>
-				{{/if}}
-				</div>
-			</div>
-			<div class="clearfix"></div>
-		</div><!--./wall-item-actions-->
+			{{/if}}
+				</span>
+			</span>
+		</p><!--./wall-item-actions-->
 
 		<div class="wall-item-links"></div>
 
@@ -384,19 +383,16 @@ as the value of $top_child_total (this is done at the end of this file)
 			</div>
 		{{/if}}
 
-		{{if $item.thread_level!=1}}
-		</div><!--./media-body from for comments-->
-		<hr />
+		{{* Insert comment box of threaded children *}}
+		{{if $item.threaded && $item.comment && $item.indent==comment}}
+			<div class="wall-item-comment-wrapper" id="item-comments-{{$item.id}}" data-display="block" style="display: none;">
+				{{$item.comment nofilter}}
+			</div>
 		{{/if}}
 
-
-		{{* Insert comment box of threaded children *}}
-		{{if $item.threaded}}{{if $item.comment}}{{if $item.indent==comment}}
-		<div class="wall-item-comment-wrapper" id="item-comments-{{$item.id}}" style="display: none;">
-			{{$item.comment nofilter}}
-		</div>
-		{{/if}}{{/if}}{{/if}}
-
+		{{if $item.thread_level!=1}}
+		</div><!--./media-body from for comments-->
+		{{/if}}
 
 		{{foreach $item.children as $child}}
 			{{*
@@ -413,21 +409,12 @@ as the value of $top_child_total (this is done at the end of this file)
 			Display this comment box if there are any comments. If not hide it. In this
 			case it could be opend with the "comment" button *}}
 		{{if $item.total_comments_num}}
-			{{if $item.threaded}}{{if $item.comment}}{{if $item.thread_level==1}}
-				<div class="wall-item-comment-wrapper well well-small" id="item-comments-{{$item.id}}">{{$item.comment nofilter}}</div>
-			{{/if}}{{/if}}{{/if}}
-
-			{{if $item.flatten}}
-				<div class="wall-item-comment-wrapper well well-small" id="item-comments-{{$item.id}}">{{$item.comment nofilter}}</div>
-			{{/if}}
-		{{else}}
-			{{if $item.threaded}}{{if $item.comment}}{{if $item.thread_level==1}}
-				<div class="wall-item-comment-wrapper well well-small" id="item-comments-{{$item.id}}" style="display: none;">{{$item.comment nofilter}}</div>
-			{{/if}}{{/if}}{{/if}}
-
-			{{if $item.flatten}}
-				<div class="wall-item-comment-wrapper well well-small" id="item-comments-{{$item.id}}" style="display: none;">{{$item.comment nofilter}}</div>
-			{{/if}}
+			<div class="comment-fake-form" id="comment-fake-form-{{$item.id}}">
+				<textarea id="comment-fake-text-{{$item.id}}" class="comment-fake-text-empty form-control" placeholder="{{$item.reply_label}}" onFocus="commentOpenUI(this, {{$item.id}});"  rows="1"></textarea>
+			</div>
+		{{/if}}
+		{{if $item.comment && $item.thread_level==1}}
+			<div class="wall-item-comment-wrapper well well-small" id="item-comments-{{$item.id}}" data-display="block" style="display: none">{{$item.comment nofilter}}</div>
 		{{/if}}
 	</div><!-- /media -->
 </div><!-- ./panel-body or ./wall-item-container -->

--- a/view/theme/frio/templates/wall_thread.tpl
+++ b/view/theme/frio/templates/wall_thread.tpl
@@ -408,23 +408,21 @@ as the value of $top_child_total (this is done at the end of this file)
 		{{* Insert the comment box of the top level post at the bottom of the thread.
 			Display this comment box if there are any comments. If not hide it. In this
 			case it could be opend with the "comment" button *}}
-		{{if $item.total_comments_num}}
+		{{if $item.comment && $item.thread_level==1}}
+			{{if $item.total_comments_num}}
 			<div class="comment-fake-form" id="comment-fake-form-{{$item.id}}">
 				<textarea id="comment-fake-text-{{$item.id}}" class="comment-fake-text-empty form-control" placeholder="{{$item.reply_label}}" onFocus="commentOpenUI(this, {{$item.id}});"  rows="1"></textarea>
 			</div>
-		{{/if}}
-		{{if $item.comment && $item.thread_level==1}}
+			{{/if}}
 			<div class="wall-item-comment-wrapper well well-small" id="item-comments-{{$item.id}}" data-display="block" style="display: none">{{$item.comment nofilter}}</div>
 		{{/if}}
 	</div><!-- /media -->
 </div><!-- ./panel-body or ./wall-item-container -->
 
-
 {{if $mode == display}}
 {{else}}
 {{if $item.comment_lastcollapsed}}</div>{{/if}}
 {{/if}}
-
 
 {{* close the comment-container div if no more thread_level = 2 children are left *}}
 {{if $item.thread_level==2 && $top_child_nr==$top_child_total}}

--- a/view/theme/frio/templates/wall_thread.tpl
+++ b/view/theme/frio/templates/wall_thread.tpl
@@ -41,12 +41,15 @@ as the value of $top_child_total (this is done at the end of this file)
 	{{if $item.thread_level<3}}
 		<div class="hide-comments-outer-wrapper">
 			<div class="hide-comments-outer fakelink" onclick="showHideComments({{$item.id}});">
-				<span id="hide-comments-total-{{$item.id}}"
-					class="hide-comments-total">{{$item.num_comments}}</span>
-				<span id="hide-comments-{{$item.id}}"
-					class="hide-comments">{{$item.hide_text}}</span>
+				<span id="hide-comments-total-{{$item.id}}" class="hide-comments-total">
+					<i class="fa fa-plus-square" aria-hidden="true"></i>
+					{{$item.num_comments}} - {{$item.show_text}}
+				</span>
+				<span id="hide-comments-{{$item.id}}" class="hide-comments" style="display: none">
+					<i class="fa fa-minus-square" aria-hidden="true"></i>
+					{{$item.num_comments}} - {{$item.hide_text}}
+				</span>
 			</div>
-			<hr />
 		</div>
 		<div id="collapsed-comments-{{$item.id}}" class="collapsed-comments" style="display: none;">
 	{{else}}

--- a/view/theme/quattro/templates/wall_thread.tpl
+++ b/view/theme/quattro/templates/wall_thread.tpl
@@ -1,19 +1,13 @@
 {{if $mode == display}}
 {{else}}
 {{if $item.comment_firstcollapsed}}
-	<div class="hide-comments-outer">
-		<span id="hide-comments-total-{{$item.id}}"
-			class="hide-comments-total">{{$item.num_comments}}</span>
-			<span id="hide-comments-{{$item.id}}"
-				class="hide-comments fakelink"
-				onclick="showHideComments({{$item.id}});">{{$item.hide_text}}</span>
-			{{if $item.thread_level==3}} -
-			<span id="hide-thread-{{$item}}-id"
-				class="fakelink"
-				onclick="showThread({{$item.id}});">expand</span> /
-			<span id="hide-thread-{{$item}}-id"
-				class="fakelink"
-				onclick="hideThread({{$item.id}});">collapse</span> thread{{/if}}
+	<div class="hide-comments-outer fakelink" onclick="showHideComments({{$item.id}});">
+		<span id="hide-comments-total-{{$item.id}}" class="hide-comments-total">
+			{{$item.num_comments}} - {{$item.show_text}}
+		</span>
+		<span id="hide-comments-{{$item.id}}" class="hide-comments" style="display: none">
+			{{$item.num_comments}} - {{$item.hide_text}}
+		</span>
 	</div>
 	<div id="collapsed-comments-{{$item.id}}" class="collapsed-comments" style="display: none;">
 {{/if}}

--- a/view/theme/smoothly/templates/jot-header.tpl
+++ b/view/theme/smoothly/templates/jot-header.tpl
@@ -52,7 +52,7 @@ function enableOnUser(){
 </script>
 
 <script>
-	var ispublic = '{{$ispublic}}';
+	var ispublic = '{{$ispublic nofilter}}';
 
 	$(document).ready(function() {
 

--- a/view/theme/smoothly/templates/wall_thread.tpl
+++ b/view/theme/smoothly/templates/wall_thread.tpl
@@ -1,8 +1,12 @@
 
 {{if $item.comment_firstcollapsed}}
-	<div class="hide-comments-outer">
-		<span id="hide-comments-total-{{$item.id}}" class="hide-comments-total">{{$item.num_comments}}</span>
-		<span id="hide-comments-{{$item.id}}" class="hide-comments fakelink" onclick="showHideComments({{$item.id}});">{{$item.hide_text}}</span>
+	<div class="hide-comments-outer fakelink" onclick="showHideComments({{$item.id}});">
+		<span id="hide-comments-total-{{$item.id}}" class="hide-comments-total">
+			{{$item.num_comments}} - {{$item.show_text}}
+		</span>
+		<span id="hide-comments-{{$item.id}}" class="hide-comments" style="display: none">
+			{{$item.num_comments}} - {{$item.hide_text}}
+		</span>
 	</div>
 	<div id="collapsed-comments-{{$item.id}}" class="collapsed-comments" style="display: none;">
 {{/if}}

--- a/view/theme/vier/templates/wall_thread.tpl
+++ b/view/theme/vier/templates/wall_thread.tpl
@@ -2,12 +2,13 @@
 {{else}}
 {{if $item.comment_firstcollapsed}}
 	{{if $item.thread_level<3}}
-		<div class="hide-comments-outer">
-			<span id="hide-comments-total-{{$item.id}}"
-				class="hide-comments-total">{{$item.num_comments}}</span>
-			<span id="hide-comments-{{$item.id}}"
-				class="hide-comments fakelink"
-				onclick="showHideComments({{$item.id}});">{{$item.hide_text}}</span>
+		<div class="hide-comments-outer fakelink" onclick="showHideComments({{$item.id}});">
+			<span id="hide-comments-total-{{$item.id}}" class="hide-comments-total">
+				{{$item.num_comments}} - {{$item.show_text}}
+			</span>
+			<span id="hide-comments-{{$item.id}}" class="hide-comments" style="display: none">
+				{{$item.num_comments}} - {{$item.hide_text}}
+			</span>
 		</div>
 		<div id="collapsed-comments-{{$item.id}}" class="collapsed-comments" style="display: none;">
 	{{else}}


### PR DESCRIPTION
Last step of #6552

My initial goal was to fix the comment box behavior when explicit mentions were enabled, but I ended up redesigning the whole thread display in frio and touching other themes in the process because unfortunately, we are generating HTML in the common PHP files.

Here's the (almost) final display on frio:
![friendica_thread_redesign_final_1](https://user-images.githubusercontent.com/925415/52833386-7199f700-30aa-11e9-9d6f-599b4818ef39.png)
![friendica_thread_redesign_final_2](https://user-images.githubusercontent.com/925415/52833387-7199f700-30aa-11e9-8cb2-6837db72a246.png)
(I restored the margin between submit buttons after taking the screenshots)