### PR TITLE
Refactor Worker for own Logger ID

### DIFF
--- a/bin/worker.php
+++ b/bin/worker.php
@@ -39,7 +39,7 @@ $logger = Factory\LoggerFactory::create('worker', $config);
 $a = new App($config, $logger);
 
 // Check the database structure and possibly fixes it
-Update::check($a->getBasePath(), true);
+Update::check($a->getBasePath(), $logger, true);
 
 // Quit when in maintenance
 if (!$a->getMode()->has(App\Mode::MAINTENANCEDISABLED)) {

--- a/src/App.php
+++ b/src/App.php
@@ -393,8 +393,6 @@ class App
 
 		Core\L10n::init();
 
-		$this->process_id = Core\System::processID('log');
-
 		Core\Logger::setLogger($this->logger);
 	}
 
@@ -1287,7 +1285,7 @@ class App
 			$this->module = 'maintenance';
 		} else {
 			$this->checkURL();
-			Core\Update::check($this->basePath, false);
+			Core\Update::check($this->basePath, $this->getLogger(),false);
 			Core\Addon::loadAddons();
 			Core\Hook::loadHooks();
 		}

--- a/src/Core/Console/DatabaseStructure.php
+++ b/src/Core/Console/DatabaseStructure.php
@@ -69,7 +69,7 @@ HELP;
 				break;
 			case "update":
 				$force = $this->getOption(['f', 'force'], false);
-				$output = Update::run($a->getBasePath(), $force, true, false);
+				$output = Update::run($a->getBasePath(), $a->getLogger(), $force, true, false);
 				break;
 			case "dumpsql":
 				ob_start();

--- a/src/Core/Console/PostUpdate.php
+++ b/src/Core/Console/PostUpdate.php
@@ -56,7 +56,7 @@ HELP;
 		}
 
 		echo L10n::t('Check for pending update actions.') . "\n";
-		Update::run($a->getBasePath(), true, true, false);
+		Update::run($a->getBasePath(), $a->getLogger(), true, true, false);
 		echo L10n::t('Done.') . "\n";
 
 		echo L10n::t('Execute pending post updates.') . "\n";

--- a/src/Core/Logger.php
+++ b/src/Core/Logger.php
@@ -102,6 +102,19 @@ class Logger extends BaseObject
 	}
 
 	/**
+	 * Switches the Logger and returns the old logger
+	 *
+	 * @param LoggerInterface $logger The new logger
+	 * @return LoggerInterface the old logger
+	 */
+	public static function switchLogger(LoggerInterface $logger)
+	{
+		$oldLogger = self::$logger;
+		self::$logger = $logger;
+		return $oldLogger;
+	}
+
+	/**
 	 * Mapping a legacy level to the PSR-3 compliant levels
 	 * @see https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-3-logger-interface.md#5-psrlogloglevel
 	 *

--- a/src/Core/System.php
+++ b/src/Core/System.php
@@ -235,21 +235,6 @@ class System extends BaseObject
 	}
 
 	/**
-	 * Generates a process identifier for the logging
-	 *
-	 * @param string $prefix A given prefix
-	 *
-	 * @return string a generated process identifier
-	 */
-	public static function processID($prefix)
-	{
-		// We aren't calling any other function here.
-		// Doing so could easily create an endless loop
-		$trailer = $prefix . ':' . getmypid() . ':';
-		return substr($trailer . uniqid('') . mt_rand(), 0, 26);
-	}
-
-	/**
 	 * Returns the current Load of the System
 	 *
 	 * @return integer

--- a/src/Core/Worker.php
+++ b/src/Core/Worker.php
@@ -403,10 +403,6 @@ class Worker
 		if ($method_call) {
 			$oldLogger = Logger::switchLogger($workerLogger);
 			$worker = WorkerFactory::create($funcname, $a, $workerLogger);
-			/**
-			 * This call uses the array as a parameter because of this benchmark
-			 * https://github.com/fab2s/call_user_func/
-			 */
 			$worker->execute($argv);
 			Logger::switchLogger($oldLogger);
 		} else {

--- a/src/Core/Worker.php
+++ b/src/Core/Worker.php
@@ -370,9 +370,9 @@ class Worker
 
 		$mypid = getmypid();
 
-		$workerLogger = new WorkerLogger($a->getLogger());
-
 		$argc = count($argv);
+
+		$workerLogger = new WorkerLogger($a->getLogger());
 
 		Logger::log("Process ".$mypid." - Prio ".$queue["priority"]." - ID ".$queue["id"].": ".$funcname." ".$queue["parameter"]." - Process PID: " . $workerLogger->getWorkerId());
 

--- a/src/Core/Worker.php
+++ b/src/Core/Worker.php
@@ -372,7 +372,7 @@ class Worker
 
 		$argc = count($argv);
 
-		$workerLogger = new WorkerLogger($a->getLogger());
+		$workerLogger = new WorkerLogger($a->getLogger(), $funcname);
 
 		Logger::log("Process ".$mypid." - Prio ".$queue["priority"]." - ID ".$queue["id"].": ".$funcname." ".$queue["parameter"]." - Process PID: " . $workerLogger->getWorkerId());
 
@@ -450,7 +450,7 @@ class Worker
 			Logger::log("Prio ".$queue["priority"].": ".$queue["parameter"]." - longer than 2 minutes (".round($duration/60, 3).")", Logger::DEBUG);
 		}
 
-		Logger::log("Process ".$mypid." - Prio ".$queue["priority"]." - ID ".$queue["id"].": ".$funcname." - done in ".number_format($duration, 4)." seconds. Process PID: ".$new_process_id);
+		Logger::log("Process ".$mypid." - Prio ".$queue["priority"]." - ID ".$queue["id"].": ".$funcname." - done in ".number_format($duration, 4)." seconds.");
 
 		// Write down the performance values into the log
 		if (Config::get("system", "profiler")) {

--- a/src/Core/Worker.php
+++ b/src/Core/Worker.php
@@ -401,12 +401,14 @@ class Worker
 		unset($_SESSION);
 
 		if ($method_call) {
+			$oldLogger = Logger::switchLogger($workerLogger);
 			$worker = WorkerFactory::create($funcname, $a, $workerLogger);
 			/**
 			 * This call uses the array as a parameter because of this benchmark
 			 * https://github.com/fab2s/call_user_func/
 			 */
 			$worker->execute($argv);
+			Logger::switchLogger($oldLogger);
 		} else {
 			$funcname($argv, $argc);
 		}

--- a/src/Core/Worker.php
+++ b/src/Core/Worker.php
@@ -400,14 +400,14 @@ class Worker
 		// Reset global data to avoid interferences
 		unset($_SESSION);
 
+		$oldLogger = Logger::switchLogger($workerLogger);
 		if ($method_call) {
-			$oldLogger = Logger::switchLogger($workerLogger);
 			$worker = WorkerFactory::create($funcname, $a, $workerLogger);
 			$worker->execute($argv);
-			Logger::switchLogger($oldLogger);
 		} else {
 			$funcname($argv, $argc);
 		}
+		Logger::switchLogger($oldLogger);
 
 		unset($a->queue);
 

--- a/src/Factory/LoggerFactory.php
+++ b/src/Factory/LoggerFactory.php
@@ -3,9 +3,11 @@
 namespace Friendica\Factory;
 
 use Friendica\Core\Config\ConfigCache;
+use Friendica\Core\Logger;
 use Friendica\Network\HTTPException\InternalServerErrorException;
 use Friendica\Util\Logger\FriendicaDevelopHandler;
 use Friendica\Util\Logger\FriendicaIntrospectionProcessor;
+use Friendica\Util\Logger\WorkerLogger;
 use Monolog;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
@@ -31,7 +33,7 @@ class LoggerFactory
 		$logger->pushProcessor(new Monolog\Processor\PsrLogMessageProcessor());
 		$logger->pushProcessor(new Monolog\Processor\ProcessIdProcessor());
 		$logger->pushProcessor(new Monolog\Processor\UidProcessor());
-		$logger->pushProcessor(new FriendicaIntrospectionProcessor(LogLevel::DEBUG, ['Friendica\\Core\\Logger', 'Friendica\\Util\\WorkerLogger']));
+		$logger->pushProcessor(new FriendicaIntrospectionProcessor(LogLevel::DEBUG, [Logger::class, WorkerLogger::class]));
 
 		if (isset($config)) {
 			$debugging = $config->get('system', 'debugging');

--- a/src/Factory/LoggerFactory.php
+++ b/src/Factory/LoggerFactory.php
@@ -31,7 +31,7 @@ class LoggerFactory
 		$logger->pushProcessor(new Monolog\Processor\PsrLogMessageProcessor());
 		$logger->pushProcessor(new Monolog\Processor\ProcessIdProcessor());
 		$logger->pushProcessor(new Monolog\Processor\UidProcessor());
-		$logger->pushProcessor(new FriendicaIntrospectionProcessor(LogLevel::DEBUG, ['Friendica\\Core\\Logger']));
+		$logger->pushProcessor(new FriendicaIntrospectionProcessor(LogLevel::DEBUG, ['Friendica\\Core\\Logger', 'Friendica\\Util\\WorkerLogger']));
 
 		if (isset($config)) {
 			$debugging = $config->get('system', 'debugging');

--- a/src/Util/Logger/WorkerLogger.php
+++ b/src/Util/Logger/WorkerLogger.php
@@ -2,7 +2,6 @@
 
 namespace Friendica\Util\Logger;
 
-use Friendica\Core\System;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -25,7 +24,18 @@ class WorkerLogger implements LoggerInterface
 	public function __construct(LoggerInterface $logger)
 	{
 		$this->logger = $logger;
-		$this->workerId = System::processID("wrk");
+		$this->workerId = $this->generateUid(7);
+	}
+
+	/**
+	 * Generates an UID
+	 *
+	 * @param $length
+	 * @return bool|string
+	 */
+	private function generateUid($length)
+	{
+		return substr(hash('md5', uniqid('', true)), 0, $length);
 	}
 
 	/**

--- a/src/Util/Logger/WorkerLogger.php
+++ b/src/Util/Logger/WorkerLogger.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace Friendica\Util\Logger;
+
+use Friendica\Core\System;
+use Psr\Log\LoggerInterface;
+
+/**
+ * A Logger for specific Worker, which adds an additional id to it.
+ *
+ * uses the Decorator pattern (https://en.wikipedia.org/wiki/Decorator_pattern)
+ */
+class WorkerLogger implements LoggerInterface
+{
+	/**
+	 * @var LoggerInterface The original logger
+	 */
+	private $logger;
+
+	/**
+	 * @var string The worker ID
+	 */
+	private $workerId;
+
+	public function __construct(LoggerInterface $logger)
+	{
+		$this->logger = $logger;
+		$this->workerId = System::processID("wrk");
+	}
+
+	/**
+	 * @return string The worker I
+	 */
+	public function getWorkerId()
+	{
+		return $this->workerId;
+	}
+
+	/**
+	 * System is unusable.
+	 *
+	 * @param string $message
+	 * @param array $context
+	 *
+	 * @return void
+	 */
+	public function emergency($message, array $context = array())
+	{
+		$context['worker'] = $this->workerId;
+		$this->logger->emergency($message, $context);
+	}
+
+	/**
+	 * Action must be taken immediately.
+	 *
+	 * Example: Entire website down, database unavailable, etc. This should
+	 * trigger the SMS alerts and wake you up.
+	 *
+	 * @param string $message
+	 * @param array $context
+	 *
+	 * @return void
+	 */
+	public function alert($message, array $context = array())
+	{
+		$context['worker'] = $this->workerId;
+		$this->logger->alert($message, $context);
+	}
+
+	/**
+	 * Critical conditions.
+	 *
+	 * Example: Application component unavailable, unexpected exception.
+	 *
+	 * @param string $message
+	 * @param array $context
+	 *
+	 * @return void
+	 */
+	public function critical($message, array $context = array())
+	{
+		$context['worker'] = $this->workerId;
+		$this->logger->critical($message, $context);
+	}
+
+	/**
+	 * Runtime errors that do not require immediate action but should typically
+	 * be logged and monitored.
+	 *
+	 * @param string $message
+	 * @param array $context
+	 *
+	 * @return void
+	 */
+	public function error($message, array $context = array())
+	{
+		$context['worker'] = $this->workerId;
+		$this->logger->error($message, $context);
+	}
+
+	/**
+	 * Exceptional occurrences that are not errors.
+	 *
+	 * Example: Use of deprecated APIs, poor use of an API, undesirable things
+	 * that are not necessarily wrong.
+	 *
+	 * @param string $message
+	 * @param array $context
+	 *
+	 * @return void
+	 */
+	public function warning($message, array $context = array())
+	{
+		$context['worker'] = $this->workerId;
+		$this->logger->warning($message, $context);
+	}
+
+	/**
+	 * Normal but significant events.
+	 *
+	 * @param string $message
+	 * @param array $context
+	 *
+	 * @return void
+	 */
+	public function notice($message, array $context = array())
+	{
+		$context['worker'] = $this->workerId;
+		$this->logger->notice($message, $context);
+	}
+
+	/**
+	 * Interesting events.
+	 *
+	 * Example: User logs in, SQL logs.
+	 *
+	 * @param string $message
+	 * @param array $context
+	 *
+	 * @return void
+	 */
+	public function info($message, array $context = array())
+	{
+		$context['worker'] = $this->workerId;
+		$this->logger->info($message, $context);
+	}
+
+	/**
+	 * Detailed debug information.
+	 *
+	 * @param string $message
+	 * @param array $context
+	 *
+	 * @return void
+	 */
+	public function debug($message, array $context = array())
+	{
+		$context['worker'] = $this->workerId;
+		$this->logger->debug($message, $context);
+	}
+
+	/**
+	 * Logs with an arbitrary level.
+	 *
+	 * @param mixed $level
+	 * @param string $message
+	 * @param array $context
+	 *
+	 * @return void
+	 */
+	public function log($level, $message, array $context = array())
+	{
+		$context['worker'] = $this->workerId;
+		$this->logger->log($level, $message, $context);
+	}
+}

--- a/src/Util/Logger/WorkerLogger.php
+++ b/src/Util/Logger/WorkerLogger.php
@@ -21,9 +21,15 @@ class WorkerLogger implements LoggerInterface
 	 */
 	private $workerId;
 
-	public function __construct(LoggerInterface $logger)
+	/**
+	 * @var string The current function Name of the worker
+	 */
+	private $functionName;
+
+	public function __construct(LoggerInterface $logger, $functionName)
 	{
 		$this->logger = $logger;
+		$this->functionName = $functionName;
 		$this->workerId = $this->generateUid(7);
 	}
 
@@ -36,6 +42,17 @@ class WorkerLogger implements LoggerInterface
 	private function generateUid($length)
 	{
 		return substr(hash('md5', uniqid('', true)), 0, $length);
+	}
+
+	/**
+	 * Adds the worker context for each log entry
+	 *
+	 * @param array $context The context
+	 */
+	private function addContext(array &$context)
+	{
+		$context['worker_id'] = $this->workerId;
+		$context['worker_cmd'] = $this->functionName;
 	}
 
 	/**
@@ -56,7 +73,7 @@ class WorkerLogger implements LoggerInterface
 	 */
 	public function emergency($message, array $context = array())
 	{
-		$context['worker'] = $this->workerId;
+		$this->addContext($context);
 		$this->logger->emergency($message, $context);
 	}
 
@@ -73,7 +90,7 @@ class WorkerLogger implements LoggerInterface
 	 */
 	public function alert($message, array $context = array())
 	{
-		$context['worker'] = $this->workerId;
+		$this->addContext($context);
 		$this->logger->alert($message, $context);
 	}
 
@@ -89,7 +106,7 @@ class WorkerLogger implements LoggerInterface
 	 */
 	public function critical($message, array $context = array())
 	{
-		$context['worker'] = $this->workerId;
+		$this->addContext($context);
 		$this->logger->critical($message, $context);
 	}
 
@@ -104,7 +121,7 @@ class WorkerLogger implements LoggerInterface
 	 */
 	public function error($message, array $context = array())
 	{
-		$context['worker'] = $this->workerId;
+		$this->addContext($context);
 		$this->logger->error($message, $context);
 	}
 
@@ -121,7 +138,7 @@ class WorkerLogger implements LoggerInterface
 	 */
 	public function warning($message, array $context = array())
 	{
-		$context['worker'] = $this->workerId;
+		$this->addContext($context);
 		$this->logger->warning($message, $context);
 	}
 
@@ -135,7 +152,7 @@ class WorkerLogger implements LoggerInterface
 	 */
 	public function notice($message, array $context = array())
 	{
-		$context['worker'] = $this->workerId;
+		$this->addContext($context);
 		$this->logger->notice($message, $context);
 	}
 
@@ -151,7 +168,7 @@ class WorkerLogger implements LoggerInterface
 	 */
 	public function info($message, array $context = array())
 	{
-		$context['worker'] = $this->workerId;
+		$this->addContext($context);
 		$this->logger->info($message, $context);
 	}
 
@@ -165,7 +182,7 @@ class WorkerLogger implements LoggerInterface
 	 */
 	public function debug($message, array $context = array())
 	{
-		$context['worker'] = $this->workerId;
+		$this->addContext($context);
 		$this->logger->debug($message, $context);
 	}
 
@@ -180,7 +197,7 @@ class WorkerLogger implements LoggerInterface
 	 */
 	public function log($level, $message, array $context = array())
 	{
-		$context['worker'] = $this->workerId;
+		$this->addContext($context);
 		$this->logger->log($level, $message, $context);
 	}
 }

--- a/src/Util/Logger/WorkerLogger.php
+++ b/src/Util/Logger/WorkerLogger.php
@@ -30,7 +30,7 @@ class WorkerLogger implements LoggerInterface
 	{
 		$this->logger = $logger;
 		$this->functionName = $functionName;
-		$this->workerId = $this->generateUid(7);
+		$this->workerId = $this->generateUid(8);
 	}
 
 	/**

--- a/src/Util/Logger/WorkerLogger.php
+++ b/src/Util/Logger/WorkerLogger.php
@@ -37,11 +37,11 @@ class WorkerLogger implements LoggerInterface
 	 * Generates an UID
 	 *
 	 * @param $length
-	 * @return bool|string
+	 * @return string
 	 */
 	private function generateUid($length)
 	{
-		return substr(hash('md5', uniqid('', true)), 0, $length);
+		return bin2hex(random_bytes($length / 2));
 	}
 
 	/**

--- a/src/Worker/APDelivery.php
+++ b/src/Worker/APDelivery.php
@@ -4,28 +4,32 @@
  */
 namespace Friendica\Worker;
 
-use Friendica\BaseObject;
-use Friendica\Core\Logger;
 use Friendica\Core\Worker;
 use Friendica\Model\ItemDeliveryData;
 use Friendica\Protocol\ActivityPub;
 use Friendica\Util\HTTPSignature;
 
-class APDelivery extends BaseObject
+class APDelivery extends AbstractWorker
 {
 	/**
 	 * @brief Delivers ActivityPub messages
 	 *
-	 * @param string  $cmd
-	 * @param integer $target_id
-	 * @param string  $inbox
-	 * @param integer $uid
+	 * {@inheritdoc}
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 * @throws \ImagickException
 	 */
-	public static function execute($cmd, $target_id, $inbox, $uid)
+	public function execute(array $parameters = [])
 	{
-		Logger::log('Invoked: ' . $cmd . ': ' . $target_id . ' to ' . $inbox, Logger::DEBUG);
+		if (!$this->checkParameters($parameters, 4)) {
+			return;
+		}
+
+		$cmd       = $parameters[0];
+		$target_id = $parameters[1];
+		$inbox     = $parameters[2];
+		$uid       = $parameters[3];
+
+		$this->logger->debug('Invoked: ' . $target_id . ' to ' . $inbox, ['cmd' => $cmd]);
 
 		$success = true;
 

--- a/src/Worker/APDelivery.php
+++ b/src/Worker/APDelivery.php
@@ -24,10 +24,7 @@ class APDelivery extends AbstractWorker
 			return;
 		}
 
-		$cmd       = $parameters[0];
-		$target_id = $parameters[1];
-		$inbox     = $parameters[2];
-		$uid       = $parameters[3];
+		list($cmd, $target_id, $inbox, $uid) = $parameters;
 
 		$this->logger->debug('Invoked: ' . $target_id . ' to ' . $inbox, ['cmd' => $cmd]);
 

--- a/src/Worker/AbstractWorker.php
+++ b/src/Worker/AbstractWorker.php
@@ -48,7 +48,7 @@ abstract class AbstractWorker
 	protected function checkParameters(array $parameter, $expectedCount)
 	{
 		if (count($parameter) !== $expectedCount) {
-			$this->logger->alert('Invoked with wrong parameters', ['count' => $parameter, 'parameter' => $parameter]);
+			$this->logger->alert('Invoked with wrong parameters', ['count' => count($parameter), 'parameter' => $parameter]);
 			return false;
 		} else {
 			return true;

--- a/src/Worker/AbstractWorker.php
+++ b/src/Worker/AbstractWorker.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Friendica\Worker;
+
+use Friendica\App;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Defines a abstract worker
+ */
+abstract class AbstractWorker
+{
+	/**
+	 * @var LoggerInterface
+	 */
+	protected $logger;
+
+	/**
+	 * @var App
+	 */
+	protected $app;
+
+	/**
+	 * @param App             $app    The Application instance of this call
+	 * @param LoggerInterface $logger The Logger for the current worker
+	 */
+	public function __construct(App $app, LoggerInterface $logger)
+	{
+		$this->logger = $logger;
+		$this->app    = $app;
+	}
+
+	/**
+	 * Executes the current worker with given arguments
+	 *
+	 * @param array $parameters parameter, which are used for execution
+	 * @return void
+	 */
+	public abstract function execute(array $parameters = []);
+
+	/**
+	 * Global check for given parameters
+	 *
+	 * @param array $parameter     The parameters
+	 * @param int   $expectedCount The expected cound
+	 * @return bool true, if check is successful
+	 */
+	protected function checkParameters(array $parameter, $expectedCount)
+	{
+		if (count($parameter) !== $expectedCount) {
+			$this->logger->alert('Invoked with wrong parameters', ['count' => $parameter, 'parameter' => $parameter]);
+			return false;
+		} else {
+			return true;
+		}
+	}
+}

--- a/src/Worker/CheckVersion.php
+++ b/src/Worker/CheckVersion.php
@@ -8,7 +8,6 @@
 namespace Friendica\Worker;
 
 use Friendica\Core\Config;
-use Friendica\Core\Logger;
 use Friendica\Database\DBA;
 use Friendica\Util\Network;
 
@@ -18,11 +17,16 @@ use Friendica\Util\Network;
  * Checking the upstream version is optional (opt-in) and can be done to either
  * the master or the develop branch in the repository.
  */
-class CheckVersion
+class CheckVersion extends AbstractWorker
 {
-	public static function execute()
+	/**
+	 * {@inheritdoc}
+	 *
+	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
+	 */
+	public function execute(array $parameters = [])
 	{
-		Logger::log('checkversion: start');
+		$this->logger->info('Start.', ['cmd' => 'checkversion']);
 
 		$checkurl = Config::get('system', 'check_new_version_url', 'none');
 
@@ -37,16 +41,14 @@ class CheckVersion
 				// don't check
 				return;
 		}
-		Logger::log("Checking VERSION from: ".$checked_url, Logger::DEBUG);
+		$this->logger->debug("Checking VERSION.", ['url' => $checked_url]);
 
 		// fetch the VERSION file
 		$gitversion = DBA::escape(trim(Network::fetchUrl($checked_url)));
-		Logger::log("Upstream VERSION is: ".$gitversion, Logger::DEBUG);
+		$this->logger->debug("Upstream VERSION checked.", ['version' => $gitversion]);
 
 		Config::set('system', 'git_friendica_version', $gitversion);
 
-		Logger::log('checkversion: end');
-
-		return;
+		$this->logger->info('End.');
 	}
 }

--- a/src/Worker/CreateShadowEntry.php
+++ b/src/Worker/CreateShadowEntry.php
@@ -10,9 +10,21 @@ namespace Friendica\Worker;
 
 use Friendica\Model\Item;
 
-class CreateShadowEntry {
-	public static function execute($message_id = 0) {
-		if (empty($message_id)) {
+class CreateShadowEntry extends AbstractWorker
+{
+	/**
+	 * {@inheritdoc}
+	 * @throws \Exception
+	 */
+	public function execute(array $parameters = [])
+	{
+		if (!$this->checkParameters($parameters, 1)) {
+			return;
+		}
+
+		$message_id = $parameters[0];
+
+		if (empty($message_id) || !is_int($message_id)) {
 			return;
 		}
 

--- a/src/Worker/Cron.php
+++ b/src/Worker/Cron.php
@@ -4,7 +4,6 @@
  */
 namespace Friendica\Worker;
 
-use Friendica\BaseObject;
 use Friendica\Core\Addon;
 use Friendica\Core\Config;
 use Friendica\Core\Hook;
@@ -28,8 +27,6 @@ class Cron extends AbstractWorker
 
 		$parameter  = $parameters[0];
 		$generation = $parameters[1];
-
-		$a = BaseObject::getApp();
 
 		// Poll contacts with specific parameters
 		if (!empty($parameter)) {
@@ -55,7 +52,7 @@ class Cron extends AbstractWorker
 		$this->logger->info('Start.');
 
 		// Fork the cron jobs in separate parts to avoid problems when one of them is crashing
-		Hook::fork($a->queue['priority'], "cron");
+		Hook::fork($this->app->queue['priority'], "cron");
 
 		// run queue delivery process in the background
 		Worker::add(PRIORITY_NEGLIGIBLE, "Queue");
@@ -125,13 +122,13 @@ class Cron extends AbstractWorker
 
 		// Ensure to have a .htaccess file.
 		// this is a precaution for systems that update automatically
-		$basepath = $a->getBasePath();
+		$basepath = $this->app->getBasePath();
 		if (!file_exists($basepath . '/.htaccess')) {
 			copy($basepath . '/.htaccess-dist', $basepath . '/.htaccess');
 		}
 
 		// Poll contacts
-		self::pollContacts($parameter, $generation);
+		$this->pollContacts($parameter, $generation);
 
 		$this->logger->info('End.');
 

--- a/src/Worker/Cron.php
+++ b/src/Worker/Cron.php
@@ -25,8 +25,7 @@ class Cron extends AbstractWorker
 			return;
 		}
 
-		$parameter  = $parameters[0];
-		$generation = $parameters[1];
+		list($parameter, $generation) = $parameters;
 
 		// Poll contacts with specific parameters
 		if (!empty($parameter)) {

--- a/src/Worker/CronJobs.php
+++ b/src/Worker/CronJobs.php
@@ -33,7 +33,7 @@ class CronJobs extends AbstractWorker
 			return;
 		}
 
-		$command = $parameters[0];
+		list($command) = $parameters;
 
 		// No parameter set? So return
 		if ($command == '') {

--- a/src/Worker/DBClean.php
+++ b/src/Worker/DBClean.php
@@ -22,7 +22,7 @@ class DBClean extends AbstractWorker
 			return;
 		}
 
-		$stage = $parameters[0];
+		list($stage) = $parameters;
 
 		if (!Config::get('system', 'dbclean', false)) {
 			return;

--- a/src/Worker/DBUpdate.php
+++ b/src/Worker/DBUpdate.php
@@ -5,13 +5,12 @@
  */
 namespace Friendica\Worker;
 
-use Friendica\BaseObject;
 use Friendica\Core\Update;
 
-class DBUpdate extends BaseObject
+class DBUpdate extends AbstractWorker
 {
-	public static function execute()
+	public function execute(array $parameters = [])
 	{
-		Update::run(self::getApp()->getBasePath());
+		Update::run($this->app->getBasePath(), $this->logger);
 	}
 }

--- a/src/Worker/Delivery.php
+++ b/src/Worker/Delivery.php
@@ -42,11 +42,9 @@ class Delivery extends AbstractWorker
 		if (!$this->checkParameters($parameters, 3)) {
 			return;
 		}
-		
-		$cmd        = $parameters[0];
-		$target_id  = $parameters[1];
-		$contact_id = $parameters[2];
-		
+
+		list($cmd, $target_id, $contact_id) = $parameters;
+
 		$this->logger->info('Invoked: ' . $target_id . ' to ' . $contact_id, ['cmd' => $cmd]);
 
 		$top_level = false;

--- a/src/Worker/Directory.php
+++ b/src/Worker/Directory.php
@@ -25,7 +25,7 @@ class Directory extends AbstractWorker
 			return;
 		}
 
-		$url = $parameters[0];
+		list($url) = $parameters;
 
 		$dir = Config::get('system', 'directory');
 

--- a/src/Worker/ForkHook.php
+++ b/src/Worker/ForkHook.php
@@ -7,12 +7,22 @@ namespace Friendica\Worker;
 
 use Friendica\Core\Hook;
 
-Class ForkHook
+Class ForkHook extends AbstractWorker
 {
-	public static function execute($name, $hook, $data)
+	/**
+	 * {@inheritdoc}
+	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
+	 */
+	public function execute(array $parameters = [])
 	{
-		$a = \Friendica\BaseObject::getApp();
+		if (!$this->checkParameters($parameters, 3)) {
+			return;
+		}
 
-		Hook::callSingle($a, $name, $hook, $data);
+		$name = $parameters[0];
+		$hook = $parameters[1];
+		$data = $parameters[2];
+
+		Hook::callSingle($this->app, $name, $hook, $data);
 	}
 }

--- a/src/Worker/ForkHook.php
+++ b/src/Worker/ForkHook.php
@@ -19,9 +19,7 @@ Class ForkHook extends AbstractWorker
 			return;
 		}
 
-		$name = $parameters[0];
-		$hook = $parameters[1];
-		$data = $parameters[2];
+		list($name, $hook, $data) = $parameters;
 
 		Hook::callSingle($this->app, $name, $hook, $data);
 	}

--- a/src/Worker/Notifier.php
+++ b/src/Worker/Notifier.php
@@ -63,8 +63,7 @@ class Notifier extends AbstractWorker
 			return;
 		}
 
-		$cmd       = $parameters[0];
-		$target_id = $parameters[1];
+		list($cmd, $target_id) = $parameters;
 
 		$this->logger->info('Invoked: ' . $target_id, ['cmd' => $cmd]);
 

--- a/src/Worker/OnePoll.php
+++ b/src/Worker/OnePoll.php
@@ -561,7 +561,7 @@ class OnePoll extends AbstractWorker
 								}
 							}
 
-							$fromarr = imap_rfc822_parse_adrlist($fromdecoded, $a->getHostName());
+							$fromarr = imap_rfc822_parse_adrlist($fromdecoded, $this->app->getHostName());
 
 							$frommail = $fromarr[0]->mailbox."@".$fromarr[0]->host;
 

--- a/src/Worker/ProfileUpdate.php
+++ b/src/Worker/ProfileUpdate.php
@@ -20,7 +20,6 @@ class ProfileUpdate extends AbstractWorker
 	 */
 	public function execute(array $parameters = [])
 	{
-
 		$uid = (isset($parameters[0]) && is_int($parameters[0])) ? $parameters[0] : 0;
 
 		if (empty($uid)) {

--- a/src/Worker/RemoveContact.php
+++ b/src/Worker/RemoveContact.php
@@ -5,12 +5,24 @@
  */
 namespace Friendica\Worker;
 
-use Friendica\Database\DBA;
 use Friendica\Core\Protocol;
+use Friendica\Database\DBA;
 use Friendica\Model\Item;
 
-class RemoveContact {
-	public static function execute($id) {
+class RemoveContact extends AbstractWorker
+{
+	/**
+	 * {@inheritdoc}
+	 *
+	 * @throws \Exception
+	 */
+	public function execute(array $parameters = [])
+	{
+		if (!$this->checkParameters($parameters, 1)) {
+			return;
+		}
+
+		$id = $parameters[0];
 
 		// Only delete if the contact is to be deleted
 		$condition = ['network' => Protocol::PHANTOM, 'id' => $id];

--- a/src/Worker/RemoveContact.php
+++ b/src/Worker/RemoveContact.php
@@ -22,7 +22,7 @@ class RemoveContact extends AbstractWorker
 			return;
 		}
 
-		$id = $parameters[0];
+		list($id) = $parameters;
 
 		// Only delete if the contact is to be deleted
 		$condition = ['network' => Protocol::PHANTOM, 'id' => $id];

--- a/src/Worker/RemoveUser.php
+++ b/src/Worker/RemoveUser.php
@@ -8,9 +8,21 @@ namespace Friendica\Worker;
 use Friendica\Database\DBA;
 use Friendica\Model\Item;
 
-class RemoveUser {
-	public static function execute($uid)
+class RemoveUser extends AbstractWorker
+{
+	/**
+	 * {@inheritdoc}
+	 *
+	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
+	 */
+	public function execute(array $parameters = [])
 	{
+		if (!$this->checkParameters($parameters, 1)) {
+			return;
+		}
+
+		$uid = $parameters[0];
+
 		// Only delete if the user is archived
 		$condition = ['account_removed' => true, 'uid' => $uid];
 		if (!DBA::exists('user', $condition)) {

--- a/src/Worker/RemoveUser.php
+++ b/src/Worker/RemoveUser.php
@@ -21,7 +21,7 @@ class RemoveUser extends AbstractWorker
 			return;
 		}
 
-		$uid = $parameters[0];
+		list($uid) = $parameters;
 
 		// Only delete if the user is archived
 		$condition = ['account_removed' => true, 'uid' => $uid];

--- a/src/Worker/SpoolPost.php
+++ b/src/Worker/SpoolPost.php
@@ -5,11 +5,16 @@
  */
 namespace Friendica\Worker;
 
-use Friendica\Core\Logger;
 use Friendica\Model\Item;
 
-class SpoolPost {
-	public static function execute() {
+class SpoolPost extends AbstractWorker
+{
+	/**
+	 * {@inheritdoc}
+	 * 
+	 * @throws \Exception
+	 */
+	public function execute(array $parameters = []) {
 		$path = get_spoolpath();
 
 		if (($path != '') && is_writable($path)){
@@ -47,7 +52,7 @@ class SpoolPost {
 
 					$result = Item::insert($arr);
 
-					Logger::log("Spool file ".$file." stored: ".$result, Logger::DEBUG);
+					$this->logger->info("Spool file ".$file." stored: ".$result);
 					unlink($fullfile);
 				}
 				closedir($dh);

--- a/src/Worker/TagUpdate.php
+++ b/src/Worker/TagUpdate.php
@@ -2,16 +2,20 @@
 
 namespace Friendica\Worker;
 
-use Friendica\Core\Logger;
 use Friendica\Database\DBA;
 
-class TagUpdate
+class TagUpdate extends AbstractWorker
 {
-	public static function execute()
+	/**
+	 * {@inheritdoc}
+	 *
+	 * @throws \Exception
+	 */
+	public function execute(array $parameters = [])
 	{
 		$messages = DBA::p("SELECT `oid`,`item`.`guid`, `item`.`created`, `item`.`received` FROM `term` INNER JOIN `item` ON `item`.`id`=`term`.`oid` WHERE `term`.`otype` = 1 AND `term`.`guid` = ''");
 
-		Logger::log('fetched messages: ' . DBA::numRows($messages));
+		$this->logger->info('fetched messages: ' . DBA::numRows($messages));
 		while ($message = DBA::fetch($messages)) {
 			if ($message['uid'] == 0) {
 				$global = true;
@@ -30,7 +34,7 @@ class TagUpdate
 
 		$messages = DBA::select('item', ['guid'], ['uid' => 0]);
 
-		Logger::log('fetched messages: ' . DBA::numRows($messages));
+		$this->logger->info('fetched messages: ' . DBA::numRows($messages));
 		while ($message = DBA::fetch($messages)) {
 			DBA::update('item', ['global' => true], ['guid' => $message['guid']]);
 		}

--- a/src/Worker/UpdateGContact.php
+++ b/src/Worker/UpdateGContact.php
@@ -6,7 +6,6 @@
 
 namespace Friendica\Worker;
 
-use Friendica\Core\Logger;
 use Friendica\Core\Protocol;
 use Friendica\Database\DBA;
 use Friendica\Network\Probe;
@@ -14,14 +13,25 @@ use Friendica\Protocol\PortableContact;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Strings;
 
-class UpdateGContact
+class UpdateGContact extends AbstractWorker
 {
-	public static function execute($contact_id)
+	/**
+	 * {@inheritdoc}
+	 *
+	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
+	 * @throws \ImagickException
+	 */
+	public function execute(array $parameters = [])
 	{
-		Logger::log('update_gcontact: start');
+		if (!$this->checkParameters($parameters, 1)) {
+			return;
+		}
+
+		$contact_id = $parameters[0];
+		$this->logger->info('update_gcontact: start');
 
 		if (empty($contact_id)) {
-			Logger::log('update_gcontact: no contact');
+			$this->logger->info('update_gcontact: no contact');
 			return;
 		}
 

--- a/src/Worker/UpdateGContact.php
+++ b/src/Worker/UpdateGContact.php
@@ -27,7 +27,7 @@ class UpdateGContact extends AbstractWorker
 			return;
 		}
 
-		$contact_id = $parameters[0];
+		list($contact_id) = $parameters;
 		$this->logger->info('update_gcontact: start');
 
 		if (empty($contact_id)) {

--- a/src/Worker/WorkerFactory.php
+++ b/src/Worker/WorkerFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Friendica\Worker;
+
+use Friendica\App;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Creating a Worker instance
+ * @see AbstractWorker
+ */
+class WorkerFactory
+{
+	/**
+	 * @param string $workerName
+	 * @param LoggerInterface $logger
+	 * @return AbstractWorker#
+	 */
+	public static function create($workerName, App $app, LoggerInterface $logger)
+	{
+		$className = sprintf('Friendica\Worker\%s', $workerName);
+		return new $className($app, $logger);
+	}
+}

--- a/tests/Util/DBAMockTrait.php
+++ b/tests/Util/DBAMockTrait.php
@@ -322,7 +322,7 @@ trait DBAMockTrait
 	 * @param bool $return True, if the lock is set successful
 	 * @param null|int $times How often the method will get used
 	 */
-	public function mockDbaUnlock( $return = true, $times = null)
+	public function mockDbaUnlock($return = true, $times = null)
 	{
 		$this->checkMock();
 
@@ -330,5 +330,16 @@ trait DBAMockTrait
 			->shouldReceive('unlock')
 			->times($times)
 			->andReturn($return);
+	}
+
+	public function mockDbaEscape($input, $output = null, $times = null)
+	{
+		$this->checkMock();
+
+		$this->dbaMock
+			->shouldReceive('escape')
+			->with($input)
+			->andReturn((isset($output) ? $output : $input))
+			->times($times);
 	}
 }

--- a/tests/Util/DBAMockTrait.php
+++ b/tests/Util/DBAMockTrait.php
@@ -332,6 +332,13 @@ trait DBAMockTrait
 			->andReturn($return);
 	}
 
+	/**
+	 * Mocking DBA::escape()
+	 *
+	 * @param string $input the input for escape
+	 * @param null|string $output The output of the escape (null means same as input)
+	 * @param null|int $times How often the method will get used
+	 */
 	public function mockDbaEscape($input, $output = null, $times = null)
 	{
 		$this->checkMock();

--- a/tests/Util/NetworkMockTrait.php
+++ b/tests/Util/NetworkMockTrait.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Friendica\Test\Util;
+
+use Mockery\MockInterface;
+
+trait NetworkMockTrait
+{
+	/**
+	 * @var MockInterface The mocking interface of Friendica\Util\Network
+	 */
+	private $networkMock;
+
+	public function mockNetworkFetchUrl($url, $times = null)
+	{
+		if (!isset($this->networkMock)) {
+			$this->networkMock = \Mockery::mock('alias:Friendica\Util\Network');
+		}
+
+		$this->networkMock
+			->shouldReceive('fetchUrl')
+			->with($url)
+			->andReturn($url)
+			->times($times);
+	}
+}

--- a/tests/Util/UpdateMockTrait.php
+++ b/tests/Util/UpdateMockTrait.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Friendica\Test\Util;
+
+use Mockery\MockInterface;
+use Psr\Log\LoggerInterface;
+
+trait UpdateMockTrait
+{
+	/**
+	 * @var MockInterface The mocking interface of Friendica\Util\Network
+	 */
+	private $updateMock;
+
+	/**
+	 * Mocks an Update::run()
+	 *
+	 * @param $basePath
+	 * @param LoggerInterface $logger
+	 * @param bool $force
+	 * @param bool $verbose
+	 * @param bool $sendMail
+	 * @param string $return
+	 * @param null $times
+	 */
+	public function mockUpdateRun($expBasePath, LoggerInterface $expLogger, $expForce = false, $expVerbose = false, $expSendMail = false, $return = '', $times = null)
+	{
+		if (!isset($this->updateMock)) {
+			$this->updateMock = \Mockery::mock('alias:Friendica\Core\Update');
+		}
+
+		$closure = function($basePath, $logger, $force = false, $verbose = false, $sendMail = false)
+			use ($expBasePath, $expLogger, $expForce, $expVerbose, $expSendMail) {
+			return $expBasePath === $basePath
+				&& $expLogger   === $logger
+				&& $expForce    === $force
+				&& $expVerbose  === $verbose
+				&& $expSendMail === $sendMail;
+		};
+
+		$this->updateMock
+			->shouldReceive('run')
+			->withArgs($closure)
+			->andReturn($return)
+			->times($times);
+	}
+}

--- a/tests/src/Util/Logger/WorkerLoggerTest.php
+++ b/tests/src/Util/Logger/WorkerLoggerTest.php
@@ -15,7 +15,7 @@ class WorkerLoggerTest extends MockedTest
 		$logger = \Mockery::mock('Psr\Log\LoggerInterface');
 
 		for ($i = 0; $i < 10; $i++) {
-			$workLogger = new WorkerLogger($logger);
+			$workLogger = new WorkerLogger($logger, 'test');
 
 			$uid = $workLogger->getWorkerId();
 			$this->assertRegExp('/^[a-zA-Z0-9]{7}+$/', $uid);
@@ -70,12 +70,13 @@ class WorkerLoggerTest extends MockedTest
 	public function testEmergency($func, $msg, $context = [])
 	{
 		$logger = \Mockery::mock('Psr\Log\LoggerInterface');
-		$workLogger = new WorkerLogger($logger);
+		$workLogger = new WorkerLogger($logger, 'test');
 
 		$testContext = $context;
 
-		$testContext['worker'] = $workLogger->getWorkerId();
-		$this->assertRegExp('/^[a-zA-Z0-9]{7}+$/', $testContext['worker']);
+		$testContext['worker_id'] = $workLogger->getWorkerId();
+		$testContext['worker_cmd'] = 'test';
+		$this->assertRegExp('/^[a-zA-Z0-9]{7}+$/', $testContext['worker_id']);
 
 		$logger
 			->shouldReceive($func)
@@ -91,11 +92,12 @@ class WorkerLoggerTest extends MockedTest
 	public function testLog()
 	{
 		$logger = \Mockery::mock('Psr\Log\LoggerInterface');
-		$workLogger = new WorkerLogger($logger);
+		$workLogger = new WorkerLogger($logger, 'test');
 
 		$context = $testContext = ['test' => 'it'];
-		$testContext['worker'] = $workLogger->getWorkerId();
-		$this->assertRegExp('/^[a-zA-Z0-9]{7}+$/', $testContext['worker']);
+		$testContext['worker_id'] = $workLogger->getWorkerId();
+		$testContext['worker_cmd'] = 'test';
+		$this->assertRegExp('/^[a-zA-Z0-9]{7}+$/', $testContext['worker_id']);
 
 		$logger
 			->shouldReceive('log')

--- a/tests/src/Util/Logger/WorkerLoggerTest.php
+++ b/tests/src/Util/Logger/WorkerLoggerTest.php
@@ -7,6 +7,11 @@ use Friendica\Util\Logger\WorkerLogger;
 
 class WorkerLoggerTest extends MockedTest
 {
+	private function assertUid($uid)
+	{
+		$this->assertRegExp('/^[a-zA-Z0-9]{8}+$/', $uid);
+	}
+
 	/**
 	 * Test the generated Uid
 	 */
@@ -18,7 +23,7 @@ class WorkerLoggerTest extends MockedTest
 			$workLogger = new WorkerLogger($logger, 'test');
 
 			$uid = $workLogger->getWorkerId();
-			$this->assertRegExp('/^[a-zA-Z0-9]{7}+$/', $uid);
+			$this->assertUid($uid);
 		}
 	}
 
@@ -76,7 +81,7 @@ class WorkerLoggerTest extends MockedTest
 
 		$testContext['worker_id'] = $workLogger->getWorkerId();
 		$testContext['worker_cmd'] = 'test';
-		$this->assertRegExp('/^[a-zA-Z0-9]{7}+$/', $testContext['worker_id']);
+		$this->assertUid($testContext['worker_id']);
 
 		$logger
 			->shouldReceive($func)
@@ -97,7 +102,7 @@ class WorkerLoggerTest extends MockedTest
 		$context = $testContext = ['test' => 'it'];
 		$testContext['worker_id'] = $workLogger->getWorkerId();
 		$testContext['worker_cmd'] = 'test';
-		$this->assertRegExp('/^[a-zA-Z0-9]{7}+$/', $testContext['worker_id']);
+		$this->assertUid($testContext['worker_id']);
 
 		$logger
 			->shouldReceive('log')

--- a/tests/src/Util/Logger/WorkerLoggerTest.php
+++ b/tests/src/Util/Logger/WorkerLoggerTest.php
@@ -7,9 +7,9 @@ use Friendica\Util\Logger\WorkerLogger;
 
 class WorkerLoggerTest extends MockedTest
 {
-	private function assertUid($uid)
+	private function assertUid($uid, $length = 7)
 	{
-		$this->assertRegExp('/^[a-zA-Z0-9]{8}+$/', $uid);
+		$this->assertRegExp('/^[a-zA-Z0-9]{' . $length . '}+$/', $uid);
 	}
 
 	/**
@@ -19,11 +19,28 @@ class WorkerLoggerTest extends MockedTest
 	{
 		$logger = \Mockery::mock('Psr\Log\LoggerInterface');
 
-		for ($i = 0; $i < 10; $i++) {
-			$workLogger = new WorkerLogger($logger, 'test');
+		for ($i = 0; $i < 14; $i++) {
+			$workLogger = new WorkerLogger($logger, 'test', $i);
 
 			$uid = $workLogger->getWorkerId();
-			$this->assertUid($uid);
+			$this->assertUid($uid, $i);
+		}
+	}
+
+	/**
+	 * Test the generated Uid with wrong length
+	 * @expectedException Friendica\Network\HTTPException\InternalServerErrorException
+	 * @expectedExceptionMessageRegExp /Maximum of 13 characters for UID possible, used '\d+'/
+	 */
+	public function testWrongWorkerId()
+	{
+		$logger = \Mockery::mock('Psr\Log\LoggerInterface');
+
+		for ($i = 15; $i < 18; $i++) {
+			$workLogger = new WorkerLogger($logger, 'test', $i);
+
+			$uid = $workLogger->getWorkerId();
+			$this->assertUid($uid, $i);
 		}
 	}
 

--- a/tests/src/Util/Logger/WorkerLoggerTest.php
+++ b/tests/src/Util/Logger/WorkerLoggerTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace src\Util\Logger;
+
+use Friendica\Test\MockedTest;
+use Friendica\Util\Logger\WorkerLogger;
+
+class WorkerLoggerTest extends MockedTest
+{
+	/**
+	 * Test the generated Uid
+	 */
+	public function testGetWorkerId()
+	{
+		$logger = \Mockery::mock('Psr\Log\LoggerInterface');
+
+		for ($i = 0; $i < 10; $i++) {
+			$workLogger = new WorkerLogger($logger);
+
+			$uid = $workLogger->getWorkerId();
+			$this->assertRegExp('/^[a-zA-Z0-9]{7}+$/', $uid);
+		}
+	}
+
+	public function dataTest()
+	{
+		return [
+			'info' => [
+				'func' => 'info',
+				'msg' => 'the alert',
+				'context' => [],
+			],
+			'alert' => [
+				'func' => 'alert',
+				'msg' => 'another alert',
+				'context' => ['test' => 'it'],
+			],
+			'critical' => [
+				'func' => 'critical',
+				'msg' => 'Critical msg used',
+				'context' => ['test' => 'it', 'more' => 0.24545],
+			],
+			'error' => [
+				'func' => 'error',
+				'msg' => 21345623,
+				'context' => ['test' => 'it', 'yet' => true],
+			],
+			'warning' => [
+				'func' => 'warning',
+				'msg' => 'another alert' . 123523 . 324.54534 . 'test',
+				'context' => ['test' => 'it', 2 => 'nope'],
+			],
+			'notice' => [
+				'func' => 'notice',
+				'msg' => 'Notice' . ' alert' . true . 'with' . '\'strange\'' . 1.24. 'behavior',
+				'context' => ['test' => 'it'],
+			],
+			'debug' => [
+				'func' => 'debug',
+				'msg' => 'at last a debug',
+				'context' => ['test' => 'it'],
+			],
+		];
+	}
+
+	/**
+	 * Test the WorkerLogger with different log calls
+	 * @dataProvider dataTest
+	 */
+	public function testEmergency($func, $msg, $context = [])
+	{
+		$logger = \Mockery::mock('Psr\Log\LoggerInterface');
+		$workLogger = new WorkerLogger($logger);
+
+		$testContext = $context;
+
+		$testContext['worker'] = $workLogger->getWorkerId();
+		$this->assertRegExp('/^[a-zA-Z0-9]{7}+$/', $testContext['worker']);
+
+		$logger
+			->shouldReceive($func)
+			->with($msg, $testContext)
+			->once();
+
+		$workLogger->$func($msg, $context);
+	}
+
+	/**
+	 * Test the WorkerLogger with
+	 */
+	public function testLog()
+	{
+		$logger = \Mockery::mock('Psr\Log\LoggerInterface');
+		$workLogger = new WorkerLogger($logger);
+
+		$context = $testContext = ['test' => 'it'];
+		$testContext['worker'] = $workLogger->getWorkerId();
+		$this->assertRegExp('/^[a-zA-Z0-9]{7}+$/', $testContext['worker']);
+
+		$logger
+			->shouldReceive('log')
+			->with('debug', 'a test', $testContext)
+			->once();
+
+		$workLogger->log('debug', 'a test', $context);
+	}
+}

--- a/tests/src/Worker/CheckVersionTest.php
+++ b/tests/src/Worker/CheckVersionTest.php
@@ -11,6 +11,11 @@ use Friendica\Worker\CheckVersion;
 use Mockery\MockInterface;
 use Psr\Log\LoggerInterface;
 
+/**
+ * @todo Remove annotation when 'Network' isn't static
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
 class CheckVersionTest extends MockedTest
 {
 	use NetworkMockTrait;

--- a/tests/src/Worker/CheckVersionTest.php
+++ b/tests/src/Worker/CheckVersionTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Friendica\Test\Worker;
+
+use Friendica\App;
+use Friendica\Core\Config;
+use Friendica\Test\MockedTest;
+use Friendica\Test\Util\DBAMockTrait;
+use Friendica\Test\Util\NetworkMockTrait;
+use Friendica\Worker\CheckVersion;
+use Mockery\MockInterface;
+use Psr\Log\LoggerInterface;
+
+class CheckVersionTest extends MockedTest
+{
+	use NetworkMockTrait;
+	use DBAMockTrait;
+
+	/**
+	 * @var Config\ConfigCache|MockInterface
+	 */
+	private $configMock;
+
+	/**
+	 * @var LoggerInterface|MockInterface
+	 */
+	private $logger;
+
+	/**
+	 * @var App|MockInterface
+	 */
+	private $app;
+
+	protected function setUp()
+	{
+		parent::setUp();
+
+		$this->app = \Mockery::mock('Friendica\App');
+
+		$this->configMock = \Mockery::mock('Friendica\Core\Config\ConfigCache');
+		Config::init($this->configMock);
+
+		$this->logger = \Mockery::mock('Psr\Log\LoggerInterface');
+		$this->logger->shouldReceive('info')->with(\Mockery::any(), \Mockery::any());
+		$this->logger->shouldReceive('info')->with(\Mockery::any());
+		$this->logger->shouldReceive('debug')->with(\Mockery::any(), \Mockery::any());
+		$this->logger->shouldReceive('debug')->with(\Mockery::any());
+	}
+
+	/**
+	 * Test the Worker checkVersion with master branch
+	 */
+	public function testCheckVersionMaster()
+	{
+		$url = 'https://raw.githubusercontent.com/friendica/friendica/master/VERSION';
+
+		$this->configMock
+			->shouldReceive('get')
+			->with('system', 'check_new_version_url', 'none')
+			->andReturn('master')
+			->once();
+		$this->configMock
+			->shouldReceive('set')
+			->with('system', 'git_friendica_version', $url)
+			->once();
+		$this->mockNetworkFetchUrl($url, 1);
+		$this->mockDbaEscape($url, $url, 1);
+
+		$worker = new CheckVersion($this->app, $this->logger);
+		$worker->execute();
+	}
+
+	/**
+	 * Test the Worker checkVersion with develop branch
+	 */
+	public function testCheckVersionDevelop()
+	{
+		$url = 'https://raw.githubusercontent.com/friendica/friendica/develop/VERSION';
+
+		$this->configMock
+			->shouldReceive('get')
+			->with('system', 'check_new_version_url', 'none')
+			->andReturn('develop')
+			->once();
+		$this->configMock
+			->shouldReceive('set')
+			->with('system', 'git_friendica_version', $url)
+			->once();
+		$this->mockNetworkFetchUrl($url, 1);
+		$this->mockDbaEscape($url, $url, 1);
+
+		$worker = new CheckVersion($this->app, $this->logger);
+		$worker->execute();
+	}
+
+	/**
+	 * Test the Worker checkVersion with unknown branch
+	 */
+	public function testCheckVersionUnknown()
+	{
+		$url = 'https://raw.githubusercontent.com/friendica/friendica/develop/VERSION';
+
+		$this->configMock
+			->shouldReceive('get')
+			->with('system', 'check_new_version_url', 'none')
+			->andReturn('unknown')
+			->once();
+
+		$worker = new CheckVersion($this->app, $this->logger);
+		$worker->execute();
+	}
+}

--- a/tests/src/Worker/DBUpdateTest.php
+++ b/tests/src/Worker/DBUpdateTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Friendica\Test\Worker;
+
+use Friendica\App;
+use Friendica\Test\MockedTest;
+use Friendica\Test\Util\UpdateMockTrait;
+use Friendica\Worker\DBUpdate;
+use Mockery\MockInterface;
+use Psr\Log\LoggerInterface;
+
+class DBUpdateTest extends MockedTest
+{
+	use UpdateMockTrait;
+
+	/**
+	 * @var LoggerInterface|MockInterface
+	 */
+	private $logger;
+
+	/**
+	 * @var App|MockInterface
+	 */
+	private $app;
+
+	protected function setUp()
+	{
+		parent::setUp();
+
+		$this->app = \Mockery::mock('Friendica\App');
+		$this->app->shouldReceive('getBasePath')->andReturn('/temp');
+
+		$this->logger = \Mockery::mock('Psr\Log\LoggerInterface');
+		$this->logger->shouldReceive('info')->with(\Mockery::any(), \Mockery::any());
+		$this->logger->shouldReceive('info')->with(\Mockery::any());
+		$this->logger->shouldReceive('debug')->with(\Mockery::any(), \Mockery::any());
+		$this->logger->shouldReceive('debug')->with(\Mockery::any());
+	}
+
+	/**
+	 * Test the Worker DbUpdate
+	 */
+	public function testNormal()
+	{
+		$this->mockUpdateRun($this->app->getBasePath(), $this->logger);
+
+		$worker = new DBUpdate($this->app, $this->logger);
+		$worker->execute();
+	}
+}

--- a/tests/src/Worker/RemoveContactTest.php
+++ b/tests/src/Worker/RemoveContactTest.php
@@ -3,20 +3,26 @@
 namespace Friendica\Test\Worker;
 
 use Friendica\App;
+use Friendica\Core\Config;
 use Friendica\Test\MockedTest;
-use Friendica\Test\Util\UpdateMockTrait;
-use Friendica\Worker\DBUpdate;
+use Friendica\Test\Util\DBAMockTrait;
+use Friendica\Worker\RemoveContact;
 use Mockery\MockInterface;
 use Psr\Log\LoggerInterface;
 
 /**
- * @todo Remove annotation when 'Update' isn't static
+ * @todo Remove annotation when 'DBA' isn't static
  * @runTestsInSeparateProcesses
  * @preserveGlobalState disabled
  */
-class DBUpdateTest extends MockedTest
+class RemoveContactTest extends MockedTest
 {
-	use UpdateMockTrait;
+	use DBAMockTrait;
+
+	/**
+	 * @var Config\ConfigCache|MockInterface
+	 */
+	private $configMock;
 
 	/**
 	 * @var LoggerInterface|MockInterface
@@ -33,7 +39,9 @@ class DBUpdateTest extends MockedTest
 		parent::setUp();
 
 		$this->app = \Mockery::mock('Friendica\App');
-		$this->app->shouldReceive('getBasePath')->andReturn('/temp');
+
+		$this->configMock = \Mockery::mock('Friendica\Core\Config\ConfigCache');
+		Config::init($this->configMock);
 
 		$this->logger = \Mockery::mock('Psr\Log\LoggerInterface');
 		$this->logger->shouldReceive('info')->with(\Mockery::any(), \Mockery::any());
@@ -43,13 +51,15 @@ class DBUpdateTest extends MockedTest
 	}
 
 	/**
-	 * Test the Worker DbUpdate
+	 * Test the Worker checkVersion with wrong arguments
 	 */
-	public function testNormal()
+	public function testWrongArguments()
 	{
-		$this->mockUpdateRun($this->app->getBasePath(), $this->logger);
+		$this->logger->shouldReceive('alert')
+			->with('Invoked with wrong parameters', ['count' => 0, 'parameter' => []])
+			->once();
 
-		$worker = new DBUpdate($this->app, $this->logger);
-		$worker->execute();
+		$worker = new RemoveContact($this->app, $this->logger);
+		$worker->execute([]);
 	}
 }


### PR DESCRIPTION
Fixing #6658 

I first added a static variable at each worker, but this leads to failure due manual adding at every logging line.

Therefore I refactored the Worker a little bit, which maybe should lead to a more performant worker start too (see https://github.com/fab2s/call_user_func/).

What I did:
- Added `WorkerLogger`, which uses the Decorator pattern (see https://en.wikipedia.org/wiki/Decorator_pattern) for adding a worker id for each log entry
- Added `AbstractWorker`, which gets the `App` and the `WorkerLogger` (as `LoggerInterface`)
- Refactor each `Friendica\Worker\*` class extending `AbstractWorker`
- Replacing `Logger::log()` with `$this->logger->info()`
- Replacing `$a = BaseObject::GetApp()` with `$a = $this->app`
- I had to refactor `Update` a little bit to use the `WorkerLogger` instead the "global" `Logger::log()` because we can start up the update per Worker too.

ToDos
- [x] Creating tests for some of the Workers (they are now easily testable)
- [x] Running on https://friendica.philipp.info some time
- [x] I think `travis-ci.org` will fail first, so fixing the tests
- [x] Adding some more phpdoc and type-hints