### PR TITLE
Adding Profiler class

### DIFF
--- a/bin/auth_ejabberd.php
+++ b/bin/auth_ejabberd.php
@@ -58,8 +58,9 @@ $basedir = BasePath::create(dirname(__DIR__), $_SERVER);
 $configLoader = new Config\ConfigCacheLoader($basedir);
 $config = Factory\ConfigFactory::createCache($configLoader);
 $logger = Factory\LoggerFactory::create('auth_ejabberd', $config);
+$profiler = Factory\ProfilerFactory::create($config);
 
-$a = new App($config, $logger);
+$a = new App($config, $logger, $profiler);
 
 if ($a->getMode()->isNormal()) {
 	$oAuth = new ExAuth();

--- a/bin/auth_ejabberd.php
+++ b/bin/auth_ejabberd.php
@@ -58,7 +58,7 @@ $basedir = BasePath::create(dirname(__DIR__), $_SERVER);
 $configLoader = new Config\ConfigCacheLoader($basedir);
 $config = Factory\ConfigFactory::createCache($configLoader);
 $logger = Factory\LoggerFactory::create('auth_ejabberd', $config);
-$profiler = Factory\ProfilerFactory::create($config);
+$profiler = Factory\ProfilerFactory::create($logger, $config);
 
 $a = new App($config, $logger, $profiler);
 

--- a/bin/console.php
+++ b/bin/console.php
@@ -11,8 +11,9 @@ $basedir = BasePath::create(dirname(__DIR__), $_SERVER);
 $configLoader = new Config\ConfigCacheLoader($basedir);
 $config = Factory\ConfigFactory::createCache($configLoader);
 $logger = Factory\LoggerFactory::create('console', $config);
+$profiler = Factory\ProfilerFactory::create($config);
 
-$a = new Friendica\App($config, $logger);
+$a = new Friendica\App($config, $logger, $profiler);
 \Friendica\BaseObject::setApp($a);
 
 (new Friendica\Core\Console($argv))->execute();

--- a/bin/console.php
+++ b/bin/console.php
@@ -11,7 +11,7 @@ $basedir = BasePath::create(dirname(__DIR__), $_SERVER);
 $configLoader = new Config\ConfigCacheLoader($basedir);
 $config = Factory\ConfigFactory::createCache($configLoader);
 $logger = Factory\LoggerFactory::create('console', $config);
-$profiler = Factory\ProfilerFactory::create($config);
+$profiler = Factory\ProfilerFactory::create($logger, $config);
 
 $a = new Friendica\App($config, $logger, $profiler);
 \Friendica\BaseObject::setApp($a);

--- a/bin/daemon.php
+++ b/bin/daemon.php
@@ -37,8 +37,9 @@ $basedir = BasePath::create(dirname(__DIR__), $_SERVER);
 $configLoader = new Config\ConfigCacheLoader($basedir);
 $config = Factory\ConfigFactory::createCache($configLoader);
 $logger = Factory\LoggerFactory::create('daemon', $config);
+$profiler = Factory\ProfilerFactory::create($config);
 
-$a = new App($config, $logger);
+$a = new App($config, $logger, $profiler);
 
 if ($a->getMode()->isInstall()) {
 	die("Friendica isn't properly installed yet.\n");

--- a/bin/daemon.php
+++ b/bin/daemon.php
@@ -37,7 +37,7 @@ $basedir = BasePath::create(dirname(__DIR__), $_SERVER);
 $configLoader = new Config\ConfigCacheLoader($basedir);
 $config = Factory\ConfigFactory::createCache($configLoader);
 $logger = Factory\LoggerFactory::create('daemon', $config);
-$profiler = Factory\ProfilerFactory::create($config);
+$profiler = Factory\ProfilerFactory::create($logger, $config);
 
 $a = new App($config, $logger, $profiler);
 

--- a/bin/worker.php
+++ b/bin/worker.php
@@ -35,8 +35,9 @@ $basedir = BasePath::create(dirname(__DIR__), $_SERVER);
 $configLoader = new Config\ConfigCacheLoader($basedir);
 $config = Factory\ConfigFactory::createCache($configLoader);
 $logger = Factory\LoggerFactory::create('worker', $config);
+$profiler = Factory\ProfilerFactory::create($config);
 
-$a = new App($config, $logger);
+$a = new App($config, $logger, $profiler);
 
 // Check the database structure and possibly fixes it
 Update::check($a->getBasePath(), true);

--- a/bin/worker.php
+++ b/bin/worker.php
@@ -35,7 +35,7 @@ $basedir = BasePath::create(dirname(__DIR__), $_SERVER);
 $configLoader = new Config\ConfigCacheLoader($basedir);
 $config = Factory\ConfigFactory::createCache($configLoader);
 $logger = Factory\LoggerFactory::create('worker', $config);
-$profiler = Factory\ProfilerFactory::create($config);
+$profiler = Factory\ProfilerFactory::create($logger, $config);
 
 $a = new App($config, $logger, $profiler);
 

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
 		"mobiledetect/mobiledetectlib": "2.8.*",
 		"monolog/monolog": "^1.24",
 		"paragonie/random_compat": "^2.0",
-		"pear/text_languageDetect": "1.*",
+		"pear/text_languagedetect": "1.*",
 		"psr/container": "^1.0",
 		"seld/cli-prompt": "^1.0",
 		"smarty/smarty": "^3.1",

--- a/composer.json
+++ b/composer.json
@@ -35,12 +35,12 @@
 		"michelf/php-markdown": "^1.7",
 		"mobiledetect/mobiledetectlib": "2.8.*",
 		"paragonie/random_compat": "^2.0",
-		"pear/Text_LanguageDetect": "1.*",
+		"pear/text_languageDetect": "1.*",
 		"seld/cli-prompt": "^1.0",
 		"smarty/smarty": "^3.1",
 		"fxp/composer-asset-plugin": "~1.3",
 		"bower-asset/base64": "^1.0",
-		"bower-asset/Chart-js": "^2.7",
+		"bower-asset/chart-js": "^2.7",
 		"bower-asset/perfect-scrollbar": "^0.6",
 		"bower-asset/vue": "^2.5",
 		"npm-asset/jquery": "^2.0",
@@ -50,7 +50,8 @@
 		"npm-asset/fullcalendar": "^3.0.1",
 		"npm-asset/cropperjs": "1.2.2",
 		"npm-asset/imagesloaded": "4.1.4",
-		"monolog/monolog": "^1.24"
+		"monolog/monolog": "^1.24",
+		"psr/container": "^1.0"
 	},
 	"repositories": [
 		{
@@ -96,7 +97,7 @@
 		"phpunit/dbunit": "^2.0",
 		"phpdocumentor/reflection-docblock": "^3.0.2",
 		"phpunit/php-token-stream": "^1.4.2",
-		"mikey179/vfsStream": "^1.6",
+		"mikey179/vfsstream": "^1.6",
 		"mockery/mockery": "^1.2",
 		"johnkary/phpunit-speedtrap": "1.1"
 	},

--- a/composer.json
+++ b/composer.json
@@ -34,8 +34,10 @@
 		"lightopenid/lightopenid": "dev-master",
 		"michelf/php-markdown": "^1.7",
 		"mobiledetect/mobiledetectlib": "2.8.*",
+		"monolog/monolog": "^1.24",
 		"paragonie/random_compat": "^2.0",
 		"pear/text_languageDetect": "1.*",
+		"psr/container": "^1.0",
 		"seld/cli-prompt": "^1.0",
 		"smarty/smarty": "^3.1",
 		"fxp/composer-asset-plugin": "~1.3",
@@ -49,9 +51,7 @@
 		"npm-asset/jgrowl": "^1.4",
 		"npm-asset/fullcalendar": "^3.0.1",
 		"npm-asset/cropperjs": "1.2.2",
-		"npm-asset/imagesloaded": "4.1.4",
-		"monolog/monolog": "^1.24",
-		"psr/container": "^1.0"
+		"npm-asset/imagesloaded": "4.1.4"
 	},
 	"repositories": [
 		{

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b944adfb6ede89430ba3b7e9ebb45acb",
+    "content-hash": "19fabb14e0dd5d806ef841e51d5f6a0b",
     "packages": [
         {
             "name": "asika/simple-console",
@@ -1883,6 +1883,55 @@
             "time": "2016-08-06T20:24:11+00:00"
         },
         {
+            "name": "psr/container",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "time": "2017-02-14T16:28:37+00:00"
+        },
+        {
             "name": "psr/http-message",
             "version": "1.0.1",
             "source": {
@@ -2650,6 +2699,7 @@
                 "testing",
                 "xunit"
             ],
+            "abandoned": true,
             "time": "2016-12-02T14:39:14+00:00"
         },
         {

--- a/include/api.php
+++ b/include/api.php
@@ -326,69 +326,7 @@ function api_call(App $a)
 
 				Logger::info(API_LOG_PREFIX . 'username {username}', ['module' => 'api', 'action' => 'call', 'username' => $a->user['username'], 'duration' => round($duration, 2)]);
 
-				if (Config::get("system", "profiler")) {
-					$duration = microtime(true)-$a->performance["start"];
-
-					/// @TODO round() really everywhere?
-					Logger::debug(
-						API_LOG_PREFIX . 'performance',
-						[
-							'module' => 'api',
-							'action' => 'call',
-							'database_read' => round($a->performance["database"] - $a->performance["database_write"], 3),
-							'database_write' => round($a->performance["database_write"], 3),
-							'cache_read' => round($a->performance["cache"], 3),
-							'cache_write' => round($a->performance["cache_write"], 3),
-							'network_io' => round($a->performance["network"], 2),
-							'file_io' => round($a->performance["file"], 2),
-							'other_io' => round($duration - ($a->performance["database"]
-									+ $a->performance["cache"] + $a->performance["cache_write"]
-									+ $a->performance["network"] + $a->performance["file"]), 2),
-							'total' => round($duration, 2)
-						]
-					);
-
-					if (Config::get("rendertime", "callstack")) {
-						$o = "Database Read:\n";
-						foreach ($a->callstack["database"] as $func => $time) {
-							$time = round($time, 3);
-							if ($time > 0) {
-								$o .= $func . ": " . $time . "\n";
-							}
-						}
-						$o .= "\nDatabase Write:\n";
-						foreach ($a->callstack["database_write"] as $func => $time) {
-							$time = round($time, 3);
-							if ($time > 0) {
-								$o .= $func . ": " . $time . "\n";
-							}
-						}
-
-						$o = "Cache Read:\n";
-						foreach ($a->callstack["cache"] as $func => $time) {
-							$time = round($time, 3);
-							if ($time > 0) {
-								$o .= $func . ": " . $time . "\n";
-							}
-						}
-						$o .= "\nCache Write:\n";
-						foreach ($a->callstack["cache_write"] as $func => $time) {
-							$time = round($time, 3);
-							if ($time > 0) {
-								$o .= $func . ": " . $time . "\n";
-							}
-						}
-
-						$o .= "\nNetwork:\n";
-						foreach ($a->callstack["network"] as $func => $time) {
-							$time = round($time, 3);
-							if ($time > 0) {
-								$o .= $func . ": " . $time . "\n";
-							}
-						}
-						Logger::debug(API_LOG_PREFIX . $o, ['module' => 'api', 'action' => 'call']);
-					}
-				}
+				$a->getProfiler()->saveLog(API_LOG_PREFIX . 'performance');
 
 				if (false === $return) {
 					/*

--- a/index.php
+++ b/index.php
@@ -19,7 +19,7 @@ $basedir = BasePath::create(__DIR__, $_SERVER);
 $configLoader = new Config\ConfigCacheLoader($basedir);
 $config = Factory\ConfigFactory::createCache($configLoader);
 $logger = Factory\LoggerFactory::create('index', $config);
-$profiler = Factory\ProfilerFactory::create($config);
+$profiler = Factory\ProfilerFactory::create($logger, $config);
 
 // We assume that the index.php is called by a frontend process
 // The value is set to "true" by default in App

--- a/index.php
+++ b/index.php
@@ -19,9 +19,10 @@ $basedir = BasePath::create(__DIR__, $_SERVER);
 $configLoader = new Config\ConfigCacheLoader($basedir);
 $config = Factory\ConfigFactory::createCache($configLoader);
 $logger = Factory\LoggerFactory::create('index', $config);
+$profiler = Factory\ProfilerFactory::create($config);
 
 // We assume that the index.php is called by a frontend process
 // The value is set to "true" by default in App
-$a = new App($config, $logger, false);
+$a = new App($config, $logger, $profiler, false);
 
 $a->runFrontend();

--- a/src/App.php
+++ b/src/App.php
@@ -493,7 +493,7 @@ class App
 
 		unset($db_host, $db_user, $db_pass, $db_data, $charset);
 
-		$this->profiler->saveTimestamp($stamp1, 'network');
+		$this->profiler->saveTimestamp($stamp1, 'network', Core\System::callstack());
 	}
 
 	public function getScheme()
@@ -1189,7 +1189,7 @@ class App
 		if (!$this->isBackend()) {
 			$stamp1 = microtime(true);
 			session_start();
-			$this->profiler->saveTimestamp($stamp1, 'parser');
+			$this->profiler->saveTimestamp($stamp1, 'parser', Core\System::callstack());
 			Core\L10n::setSessionVariable();
 			Core\L10n::setLangFromSession();
 		} else {

--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -1027,7 +1027,7 @@ class BBCode extends BaseObject
 			@curl_exec($ch);
 			$curl_info = @curl_getinfo($ch);
 
-			$a->saveTimestamp($stamp1, "network");
+			$a->getProfiler()->saveTimestamp($stamp1, "network");
 
 			if (substr($curl_info["content_type"], 0, 6) == "image/") {
 				$text = "[url=" . $match[1] . "]" . $match[1] . "[/url]";
@@ -1086,7 +1086,7 @@ class BBCode extends BaseObject
 			@curl_exec($ch);
 			$curl_info = @curl_getinfo($ch);
 
-			$a->saveTimestamp($stamp1, "network");
+			$a->getProfiler()->saveTimestamp($stamp1, "network");
 
 			// if its a link to a picture then embed this picture
 			if (substr($curl_info["content_type"], 0, 6) == "image/") {
@@ -1915,7 +1915,7 @@ class BBCode extends BaseObject
 		// unmask the special chars back to HTML
 		$text = str_replace(['&\_lt\_;', '&\_gt\_;', '&\_amp\_;'], ['&lt;', '&gt;', '&amp;'], $text);
 
-		$a->saveTimestamp($stamp1, "parser");
+		$a->getProfiler()->saveTimestamp($stamp1, "parser");
 
 		// Libertree has a problem with escaped hashtags.
 		$text = str_replace(['\#'], ['#'], $text);

--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -1027,7 +1027,7 @@ class BBCode extends BaseObject
 			@curl_exec($ch);
 			$curl_info = @curl_getinfo($ch);
 
-			$a->getProfiler()->saveTimestamp($stamp1, "network");
+			$a->getProfiler()->saveTimestamp($stamp1, "network", System::callstack());
 
 			if (substr($curl_info["content_type"], 0, 6) == "image/") {
 				$text = "[url=" . $match[1] . "]" . $match[1] . "[/url]";
@@ -1086,7 +1086,7 @@ class BBCode extends BaseObject
 			@curl_exec($ch);
 			$curl_info = @curl_getinfo($ch);
 
-			$a->getProfiler()->saveTimestamp($stamp1, "network");
+			$a->getProfiler()->saveTimestamp($stamp1, "network", System::callstack());
 
 			// if its a link to a picture then embed this picture
 			if (substr($curl_info["content_type"], 0, 6) == "image/") {
@@ -1915,7 +1915,7 @@ class BBCode extends BaseObject
 		// unmask the special chars back to HTML
 		$text = str_replace(['&\_lt\_;', '&\_gt\_;', '&\_amp\_;'], ['&lt;', '&gt;', '&amp;'], $text);
 
-		$a->getProfiler()->saveTimestamp($stamp1, "parser");
+		$a->getProfiler()->saveTimestamp($stamp1, "parser", System::callstack());
 
 		// Libertree has a problem with escaped hashtags.
 		$text = str_replace(['\#'], ['#'], $text);

--- a/src/Content/Text/Markdown.php
+++ b/src/Content/Text/Markdown.php
@@ -7,6 +7,7 @@
 namespace Friendica\Content\Text;
 
 use Friendica\BaseObject;
+use Friendica\Core\System;
 use Friendica\Model\Contact;
 use Michelf\MarkdownExtra;
 
@@ -36,7 +37,7 @@ class Markdown extends BaseObject
 		$html = $MarkdownParser->transform($text);
 		$html = preg_replace('/<a(.*?)href="#/is', '<a$1href="' . ltrim($_SERVER['REQUEST_URI'], '/') . '#', $html);
 
-		self::getApp()->getProfiler()->saveTimestamp($stamp1, "parser");
+		self::getApp()->getProfiler()->saveTimestamp($stamp1, "parser", System::callstack());
 
 		return $html;
 	}

--- a/src/Content/Text/Markdown.php
+++ b/src/Content/Text/Markdown.php
@@ -36,7 +36,7 @@ class Markdown extends BaseObject
 		$html = $MarkdownParser->transform($text);
 		$html = preg_replace('/<a(.*?)href="#/is', '<a$1href="' . ltrim($_SERVER['REQUEST_URI'], '/') . '#', $html);
 
-		self::getApp()->saveTimestamp($stamp1, "parser");
+		self::getApp()->getProfiler()->saveTimestamp($stamp1, "parser");
 
 		return $html;
 	}

--- a/src/Core/Addon.php
+++ b/src/Core/Addon.php
@@ -219,7 +219,7 @@ class Addon extends BaseObject
 
 		$stamp1 = microtime(true);
 		$f = file_get_contents("addon/$addon/$addon.php");
-		$a->saveTimestamp($stamp1, "file");
+		$a->getProfiler()->saveTimestamp($stamp1, "file");
 
 		$r = preg_match("|/\*.*\*/|msU", $f, $m);
 

--- a/src/Core/Addon.php
+++ b/src/Core/Addon.php
@@ -219,7 +219,7 @@ class Addon extends BaseObject
 
 		$stamp1 = microtime(true);
 		$f = file_get_contents("addon/$addon/$addon.php");
-		$a->getProfiler()->saveTimestamp($stamp1, "file");
+		$a->getProfiler()->saveTimestamp($stamp1, "file", System::callstack());
 
 		$r = preg_match("|/\*.*\*/|msU", $f, $m);
 

--- a/src/Core/Cache.php
+++ b/src/Core/Cache.php
@@ -63,7 +63,7 @@ class Cache extends \Friendica\BaseObject
 
 		$return = self::getDriver()->getAllKeys($prefix);
 
-		self::getApp()->getProfiler()->saveTimestamp($time, 'cache');
+		self::getApp()->getProfiler()->saveTimestamp($time, 'cache', System::callstack());
 
 		return $return;
 	}
@@ -82,7 +82,7 @@ class Cache extends \Friendica\BaseObject
 
 		$return = self::getDriver()->get($key);
 
-		self::getApp()->getProfiler()->saveTimestamp($time, 'cache');
+		self::getApp()->getProfiler()->saveTimestamp($time, 'cache', System::callstack());
 
 		return $return;
 	}
@@ -105,7 +105,7 @@ class Cache extends \Friendica\BaseObject
 
 		$return = self::getDriver()->set($key, $value, $duration);
 
-		self::getApp()->getProfiler()->saveTimestamp($time, 'cache_write');
+		self::getApp()->getProfiler()->saveTimestamp($time, 'cache_write', System::callstack());
 
 		return $return;
 	}
@@ -124,7 +124,7 @@ class Cache extends \Friendica\BaseObject
 
 		$return = self::getDriver()->delete($key);
 
-		self::getApp()->getProfiler()->saveTimestamp($time, 'cache_write');
+		self::getApp()->getProfiler()->saveTimestamp($time, 'cache_write', System::callstack());
 
 		return $return;
 	}

--- a/src/Core/Cache.php
+++ b/src/Core/Cache.php
@@ -63,7 +63,7 @@ class Cache extends \Friendica\BaseObject
 
 		$return = self::getDriver()->getAllKeys($prefix);
 
-		self::getApp()->saveTimestamp($time, 'cache');
+		self::getApp()->getProfiler()->saveTimestamp($time, 'cache');
 
 		return $return;
 	}
@@ -82,7 +82,7 @@ class Cache extends \Friendica\BaseObject
 
 		$return = self::getDriver()->get($key);
 
-		self::getApp()->saveTimestamp($time, 'cache');
+		self::getApp()->getProfiler()->saveTimestamp($time, 'cache');
 
 		return $return;
 	}
@@ -105,7 +105,7 @@ class Cache extends \Friendica\BaseObject
 
 		$return = self::getDriver()->set($key, $value, $duration);
 
-		self::getApp()->saveTimestamp($time, 'cache_write');
+		self::getApp()->getProfiler()->saveTimestamp($time, 'cache_write');
 
 		return $return;
 	}
@@ -124,7 +124,7 @@ class Cache extends \Friendica\BaseObject
 
 		$return = self::getDriver()->delete($key);
 
-		self::getApp()->saveTimestamp($time, 'cache_write');
+		self::getApp()->getProfiler()->saveTimestamp($time, 'cache_write');
 
 		return $return;
 	}

--- a/src/Core/Console/AutomaticInstallation.php
+++ b/src/Core/Console/AutomaticInstallation.php
@@ -146,7 +146,7 @@ HELP;
 
 		$installer->resetChecks();
 
-		if (!$installer->checkDB($a->getConfig(), $db_host, $db_user, $db_pass, $db_data)) {
+		if (!$installer->checkDB($a->getConfig(), $a->getProfiler(), $db_host, $db_user, $db_pass, $db_data)) {
 			$errorMessage = $this->extractErrors($installer->getChecks());
 			throw new RuntimeException($errorMessage);
 		}

--- a/src/Core/Installer.php
+++ b/src/Core/Installer.php
@@ -11,6 +11,7 @@ use Friendica\Database\DBA;
 use Friendica\Database\DBStructure;
 use Friendica\Object\Image;
 use Friendica\Util\Network;
+use Friendica\Util\Profiler;
 use Friendica\Util\Strings;
 
 /**
@@ -583,6 +584,7 @@ class Installer
 	 * Checking the Database connection and if it is available for the current installation
 	 *
 	 * @param ConfigCache $configCache The configuration cache
+	 * @param Profiler    $profiler    The profiler of this app
 	 * @param string $dbhost           Hostname/IP of the Friendica Database
 	 * @param string $dbuser           Username of the Database connection credentials
 	 * @param string $dbpass           Password of the Database connection credentials
@@ -591,9 +593,9 @@ class Installer
 	 * @return bool true if the check was successful, otherwise false
 	 * @throws Exception
 	 */
-	public function checkDB(ConfigCache $configCache, $dbhost, $dbuser, $dbpass, $dbdata)
+	public function checkDB(ConfigCache $configCache, Profiler $profiler, $dbhost, $dbuser, $dbpass, $dbdata)
 	{
-		if (!DBA::connect($configCache, $dbhost, $dbuser, $dbpass, $dbdata)) {
+		if (!DBA::connect($configCache, $profiler, $dbhost, $dbuser, $dbpass, $dbdata)) {
 			$this->addCheck(L10n::t('Could not connect to database.'), false, true, '');
 
 			return false;

--- a/src/Core/Logger.php
+++ b/src/Core/Logger.php
@@ -354,7 +354,7 @@ class Logger extends BaseObject
 		}
 
         $stamp1 = microtime(true);
-        self::$devLogger->log($level, $msg);
+		self::$devLogger->log($level, $msg);
 		self::getApp()->getProfiler()->saveTimestamp($stamp1, "file", System::callstack());
     }
 }

--- a/src/Core/Logger.php
+++ b/src/Core/Logger.php
@@ -155,7 +155,7 @@ class Logger extends BaseObject
 
 		$stamp1 = microtime(true);
 		self::$logger->emergency($message, $context);
-		self::getApp()->saveTimestamp($stamp1, 'file');
+		self::getApp()->GetProfiler()->saveTimestamp($stamp1, 'file');
 	}
 
 	/**
@@ -179,7 +179,7 @@ class Logger extends BaseObject
 
 		$stamp1 = microtime(true);
 		self::$logger->alert($message, $context);
-		self::getApp()->saveTimestamp($stamp1, 'file');
+		self::getApp()->getProfiler()->saveTimestamp($stamp1, 'file');
 	}
 
 	/**
@@ -202,7 +202,7 @@ class Logger extends BaseObject
 
 		$stamp1 = microtime(true);
 		self::$logger->critical($message, $context);
-		self::getApp()->saveTimestamp($stamp1, 'file');
+		self::getApp()->getProfiler()->saveTimestamp($stamp1, 'file');
 	}
 
 	/**
@@ -225,7 +225,7 @@ class Logger extends BaseObject
 
 		$stamp1 = microtime(true);
 		self::$logger->error($message, $context);
-		self::getApp()->saveTimestamp($stamp1, 'file');
+		self::getApp()->getProfiler()->saveTimestamp($stamp1, 'file');
 	}
 
 	/**
@@ -249,7 +249,7 @@ class Logger extends BaseObject
 
 		$stamp1 = microtime(true);
 		self::$logger->warning($message, $context);
-		self::getApp()->saveTimestamp($stamp1, 'file');
+		self::getApp()->getProfiler()->saveTimestamp($stamp1, 'file');
 	}
 
 	/**
@@ -270,7 +270,7 @@ class Logger extends BaseObject
 
 		$stamp1 = microtime(true);
 		self::$logger->notice($message, $context);
-		self::getApp()->saveTimestamp($stamp1, 'file');
+		self::getApp()->getProfiler()->saveTimestamp($stamp1, 'file');
 	}
 
 	/**
@@ -293,7 +293,7 @@ class Logger extends BaseObject
 
 		$stamp1 = microtime(true);
 		self::$logger->info($message, $context);
-		self::getApp()->saveTimestamp($stamp1, 'file');
+		self::getApp()->getProfiler()->saveTimestamp($stamp1, 'file');
 	}
 
 	/**
@@ -314,7 +314,7 @@ class Logger extends BaseObject
 
 		$stamp1 = microtime(true);
 		self::$logger->debug($message, $context);
-		self::getApp()->saveTimestamp($stamp1, 'file');
+		self::getApp()->getProfiler()->saveTimestamp($stamp1, 'file');
 	}
 
     /**
@@ -334,7 +334,7 @@ class Logger extends BaseObject
 
         $stamp1 = microtime(true);
 		self::$logger->log($level, $msg);
-        self::getApp()->saveTimestamp($stamp1, "file");
+		self::getApp()->getProfiler()->saveTimestamp($stamp1, "file");
     }
 
 	/**
@@ -355,6 +355,6 @@ class Logger extends BaseObject
 
         $stamp1 = microtime(true);
         self::$devLogger->log($level, $msg);
-        self::getApp()->saveTimestamp($stamp1, "file");
+		self::getApp()->getProfiler()->saveTimestamp($stamp1, "file");
     }
 }

--- a/src/Core/Logger.php
+++ b/src/Core/Logger.php
@@ -317,25 +317,25 @@ class Logger extends BaseObject
 		self::getApp()->getProfiler()->saveTimestamp($stamp1, 'file', System::callstack());
 	}
 
-    /**
-     * @brief Logs the given message at the given log level
-     *
-     * @param string $msg
-     * @param string $level
+	    /**
+	 * @brief Logs the given message at the given log level
+	 *
+	 * @param string $msg
+	 * @param string $level
 	 *
 	 * @throws \Exception
 	 * @deprecated since 2019.03 Use Logger::debug() Logger::info() , ... instead
-     */
-    public static function log($msg, $level = LogLevel::INFO)
-    {
+	 */
+	public static function log($msg, $level = LogLevel::INFO)
+	{
 		if (!isset(self::$logger)) {
 			return;
 		}
 
-        $stamp1 = microtime(true);
+		$stamp1 = microtime(true);
 		self::$logger->log($level, $msg);
 		self::getApp()->getProfiler()->saveTimestamp($stamp1, "file", System::callstack());
-    }
+	}
 
 	/**
 	 * @brief An alternative logger for development.
@@ -347,14 +347,14 @@ class Logger extends BaseObject
 	 * @param string $level
 	 * @throws \Exception
 	 */
-    public static function devLog($msg, $level = LogLevel::DEBUG)
-    {
+	public static function devLog($msg, $level = LogLevel::DEBUG)
+	{
 		if (!isset(self::$logger)) {
 			return;
 		}
 
-        $stamp1 = microtime(true);
+		$stamp1 = microtime(true);
 		self::$devLogger->log($level, $msg);
 		self::getApp()->getProfiler()->saveTimestamp($stamp1, "file", System::callstack());
-    }
+	}
 }

--- a/src/Core/Logger.php
+++ b/src/Core/Logger.php
@@ -155,7 +155,7 @@ class Logger extends BaseObject
 
 		$stamp1 = microtime(true);
 		self::$logger->emergency($message, $context);
-		self::getApp()->GetProfiler()->saveTimestamp($stamp1, 'file');
+		self::getApp()->GetProfiler()->saveTimestamp($stamp1, 'file', System::callstack());
 	}
 
 	/**
@@ -179,7 +179,7 @@ class Logger extends BaseObject
 
 		$stamp1 = microtime(true);
 		self::$logger->alert($message, $context);
-		self::getApp()->getProfiler()->saveTimestamp($stamp1, 'file');
+		self::getApp()->getProfiler()->saveTimestamp($stamp1, 'file', System::callstack());
 	}
 
 	/**
@@ -202,7 +202,7 @@ class Logger extends BaseObject
 
 		$stamp1 = microtime(true);
 		self::$logger->critical($message, $context);
-		self::getApp()->getProfiler()->saveTimestamp($stamp1, 'file');
+		self::getApp()->getProfiler()->saveTimestamp($stamp1, 'file', System::callstack());
 	}
 
 	/**
@@ -225,7 +225,7 @@ class Logger extends BaseObject
 
 		$stamp1 = microtime(true);
 		self::$logger->error($message, $context);
-		self::getApp()->getProfiler()->saveTimestamp($stamp1, 'file');
+		self::getApp()->getProfiler()->saveTimestamp($stamp1, 'file', System::callstack());
 	}
 
 	/**
@@ -249,7 +249,7 @@ class Logger extends BaseObject
 
 		$stamp1 = microtime(true);
 		self::$logger->warning($message, $context);
-		self::getApp()->getProfiler()->saveTimestamp($stamp1, 'file');
+		self::getApp()->getProfiler()->saveTimestamp($stamp1, 'file', System::callstack());
 	}
 
 	/**
@@ -270,7 +270,7 @@ class Logger extends BaseObject
 
 		$stamp1 = microtime(true);
 		self::$logger->notice($message, $context);
-		self::getApp()->getProfiler()->saveTimestamp($stamp1, 'file');
+		self::getApp()->getProfiler()->saveTimestamp($stamp1, 'file', System::callstack());
 	}
 
 	/**
@@ -293,7 +293,7 @@ class Logger extends BaseObject
 
 		$stamp1 = microtime(true);
 		self::$logger->info($message, $context);
-		self::getApp()->getProfiler()->saveTimestamp($stamp1, 'file');
+		self::getApp()->getProfiler()->saveTimestamp($stamp1, 'file', System::callstack());
 	}
 
 	/**
@@ -314,7 +314,7 @@ class Logger extends BaseObject
 
 		$stamp1 = microtime(true);
 		self::$logger->debug($message, $context);
-		self::getApp()->getProfiler()->saveTimestamp($stamp1, 'file');
+		self::getApp()->getProfiler()->saveTimestamp($stamp1, 'file', System::callstack());
 	}
 
     /**
@@ -334,7 +334,7 @@ class Logger extends BaseObject
 
         $stamp1 = microtime(true);
 		self::$logger->log($level, $msg);
-		self::getApp()->getProfiler()->saveTimestamp($stamp1, "file");
+		self::getApp()->getProfiler()->saveTimestamp($stamp1, "file", System::callstack());
     }
 
 	/**
@@ -355,6 +355,6 @@ class Logger extends BaseObject
 
         $stamp1 = microtime(true);
         self::$devLogger->log($level, $msg);
-		self::getApp()->getProfiler()->saveTimestamp($stamp1, "file");
+		self::getApp()->getProfiler()->saveTimestamp($stamp1, "file", System::callstack());
     }
 }

--- a/src/Core/Renderer.php
+++ b/src/Core/Renderer.php
@@ -74,7 +74,7 @@ class Renderer extends BaseObject
             exit();
         }
 
-        $a->saveTimestamp($stamp1, "rendering");
+		$a->getProfiler()->saveTimestamp($stamp1, "rendering");
 
         return $output;
     }
@@ -101,7 +101,7 @@ class Renderer extends BaseObject
             exit();
         }
 
-        $a->saveTimestamp($stamp1, "file");
+        $a->getProfiler()->saveTimestamp($stamp1, "file");
 
         return $template;
     }

--- a/src/Core/Renderer.php
+++ b/src/Core/Renderer.php
@@ -74,7 +74,7 @@ class Renderer extends BaseObject
             exit();
         }
 
-		$a->getProfiler()->saveTimestamp($stamp1, "rendering");
+		$a->getProfiler()->saveTimestamp($stamp1, "rendering", System::callstack());
 
         return $output;
     }
@@ -101,7 +101,7 @@ class Renderer extends BaseObject
             exit();
         }
 
-        $a->getProfiler()->saveTimestamp($stamp1, "file");
+        $a->getProfiler()->saveTimestamp($stamp1, "file", System::callstack());
 
         return $template;
     }

--- a/src/Core/Theme.php
+++ b/src/Core/Theme.php
@@ -51,7 +51,7 @@ class Theme
 		$a = \get_app();
 		$stamp1 = microtime(true);
 		$theme_file = file_get_contents("view/theme/$theme/theme.php");
-		$a->saveTimestamp($stamp1, "file");
+		$a->getProfiler()->saveTimestamp($stamp1, "file");
 
 		$result = preg_match("|/\*.*\*/|msU", $theme_file, $matches);
 

--- a/src/Core/Theme.php
+++ b/src/Core/Theme.php
@@ -51,7 +51,7 @@ class Theme
 		$a = \get_app();
 		$stamp1 = microtime(true);
 		$theme_file = file_get_contents("view/theme/$theme/theme.php");
-		$a->getProfiler()->saveTimestamp($stamp1, "file");
+		$a->getProfiler()->saveTimestamp($stamp1, "file", System::callstack());
 
 		$result = preg_match("|/\*.*\*/|msU", $theme_file, $matches);
 

--- a/src/Database/DBA.php
+++ b/src/Database/DBA.php
@@ -587,7 +587,7 @@ class DBA
 			self::$errorno = $errorno;
 		}
 
-		self::$profiler->saveTimestamp($stamp1, 'database');
+		self::$profiler->saveTimestamp($stamp1, 'database', System::callstack());
 
 		if (self::$configCache->get('system', 'db_log')) {
 			$stamp2 = microtime(true);
@@ -658,7 +658,7 @@ class DBA
 			self::$errorno = $errorno;
 		}
 
-		self::$profiler->saveTimestamp($stamp, "database_write");
+		self::$profiler->saveTimestamp($stamp, "database_write", System::callstack());
 
 		return $retval;
 	}
@@ -827,7 +827,7 @@ class DBA
 				}
 		}
 
-		self::$profiler->saveTimestamp($stamp1, 'database');
+		self::$profiler->saveTimestamp($stamp1, 'database', System::callstack());
 
 		return $columns;
 	}
@@ -1564,7 +1564,7 @@ class DBA
 				break;
 		}
 
-		self::$profiler->saveTimestamp($stamp1, 'database');
+		self::$profiler->saveTimestamp($stamp1, 'database', System::callstack());
 
 		return $ret;
 	}

--- a/src/Database/DBA.php
+++ b/src/Database/DBA.php
@@ -6,6 +6,7 @@ use Friendica\Core\Config\IConfigCache;
 use Friendica\Core\Logger;
 use Friendica\Core\System;
 use Friendica\Util\DateTimeFormat;
+use Friendica\Util\Profiler;
 use mysqli;
 use mysqli_result;
 use mysqli_stmt;
@@ -35,6 +36,10 @@ class DBA
 	 * @var IConfigCache
 	 */
 	private static $configCache;
+	/**
+	 * @var Profiler
+	 */
+	private static $profiler;
 	private static $server_info = '';
 	private static $connection;
 	private static $driver;
@@ -50,7 +55,7 @@ class DBA
 	private static $db_name = '';
 	private static $db_charset = '';
 
-	public static function connect($configCache, $serveraddr, $user, $pass, $db, $charset = null)
+	public static function connect(IConfigCache $configCache, Profiler $profiler, $serveraddr, $user, $pass, $db, $charset = null)
 	{
 		if (!is_null(self::$connection) && self::connected()) {
 			return true;
@@ -58,6 +63,7 @@ class DBA
 
 		// We are storing these values for being able to perform a reconnect
 		self::$configCache = $configCache;
+		self::$profiler = $profiler;
 		self::$db_serveraddr = $serveraddr;
 		self::$db_user = $user;
 		self::$db_pass = $pass;
@@ -158,7 +164,7 @@ class DBA
 	public static function reconnect() {
 		self::disconnect();
 
-		$ret = self::connect(self::$configCache, self::$db_serveraddr, self::$db_user, self::$db_pass, self::$db_name, self::$db_charset);
+		$ret = self::connect(self::$configCache, self::$profiler, self::$db_serveraddr, self::$db_user, self::$db_pass, self::$db_name, self::$db_charset);
 		return $ret;
 	}
 
@@ -392,7 +398,6 @@ class DBA
 	 * @throws \Exception
 	 */
 	public static function p($sql) {
-		$a = \get_app();
 
 		$stamp1 = microtime(true);
 
@@ -582,7 +587,7 @@ class DBA
 			self::$errorno = $errorno;
 		}
 
-		$a->saveTimestamp($stamp1, 'database');
+		self::$profiler->saveTimestamp($stamp1, 'database');
 
 		if (self::$configCache->get('system', 'db_log')) {
 			$stamp2 = microtime(true);
@@ -611,7 +616,6 @@ class DBA
 	 * @throws \Exception
 	 */
 	public static function e($sql) {
-		$a = \get_app();
 
 		$stamp = microtime(true);
 
@@ -654,7 +658,7 @@ class DBA
 			self::$errorno = $errorno;
 		}
 
-		$a->saveTimestamp($stamp, "database_write");
+		self::$profiler->saveTimestamp($stamp, "database_write");
 
 		return $retval;
 	}
@@ -777,7 +781,6 @@ class DBA
 	 * @return array current row
 	 */
 	public static function fetch($stmt) {
-		$a = \get_app();
 
 		$stamp1 = microtime(true);
 
@@ -824,7 +827,7 @@ class DBA
 				}
 		}
 
-		$a->saveTimestamp($stamp1, 'database');
+		self::$profiler->saveTimestamp($stamp1, 'database');
 
 		return $columns;
 	}
@@ -1534,7 +1537,6 @@ class DBA
 	 * @return boolean was the close successful?
 	 */
 	public static function close($stmt) {
-		$a = \get_app();
 
 		$stamp1 = microtime(true);
 
@@ -1562,7 +1564,7 @@ class DBA
 				break;
 		}
 
-		$a->saveTimestamp($stamp1, 'database');
+		self::$profiler->saveTimestamp($stamp1, 'database');
 
 		return $ret;
 	}

--- a/src/Factory/LoggerFactory.php
+++ b/src/Factory/LoggerFactory.php
@@ -3,9 +3,11 @@
 namespace Friendica\Factory;
 
 use Friendica\Core\Config\ConfigCache;
+use Friendica\Core\Logger;
 use Friendica\Network\HTTPException\InternalServerErrorException;
 use Friendica\Util\Logger\FriendicaDevelopHandler;
 use Friendica\Util\Logger\FriendicaIntrospectionProcessor;
+use Friendica\Util\Profiler;
 use Monolog;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
@@ -31,7 +33,7 @@ class LoggerFactory
 		$logger->pushProcessor(new Monolog\Processor\PsrLogMessageProcessor());
 		$logger->pushProcessor(new Monolog\Processor\ProcessIdProcessor());
 		$logger->pushProcessor(new Monolog\Processor\UidProcessor());
-		$logger->pushProcessor(new FriendicaIntrospectionProcessor(LogLevel::DEBUG, ['Friendica\\Core\\Logger']));
+		$logger->pushProcessor(new FriendicaIntrospectionProcessor(LogLevel::DEBUG, [Logger::class, Profiler::class]));
 
 		if (isset($config)) {
 			$debugging = $config->get('system', 'debugging');

--- a/src/Factory/ProfilerFactory.php
+++ b/src/Factory/ProfilerFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Friendica\Factory;
+
+use Friendica\Core\Config\ConfigCache;
+use Friendica\Util\Profiler;
+use Psr\Log\LoggerInterface;
+
+class ProfilerFactory
+{
+	/**
+	 * Creates a Profiler for the current execution
+	 *
+	 * @param LoggerInterface $logger      The logger for saving the profiling data
+	 * @param ConfigCache     $configCache The configuration cache
+	 *
+	 * @return Profiler
+	 */
+	public static function create(LoggerInterface $logger, ConfigCache $configCache)
+	{
+		$enabled = $configCache->get('system', 'profiler', false);
+		$renderTime = $configCache->get('rendertime', 'callstack', false);
+		return new Profiler($logger, $enabled, $renderTime);
+	}
+}

--- a/src/Module/Install.php
+++ b/src/Module/Install.php
@@ -75,7 +75,7 @@ class Install extends BaseModule
 				$dbdata  = Strings::escapeTags(trim(defaults($_POST, 'dbdata', '')));
 
 				// If we cannot connect to the database, return to the previous step
-				if (!self::$installer->checkDB($a->getConfig(), $dbhost, $dbuser, $dbpass, $dbdata)) {
+				if (!self::$installer->checkDB($a->getConfig(), $a->getProfiler(), $dbhost, $dbuser, $dbpass, $dbdata)) {
 					self::$currentWizardStep = self::DATABASE_CONFIG;
 				}
 
@@ -92,7 +92,7 @@ class Install extends BaseModule
 				$adminmail = Strings::escapeTags(trim(defaults($_POST, 'adminmail', '')));
 
 				// If we cannot connect to the database, return to the Database config wizard
-				if (!self::$installer->checkDB($a->getConfig(), $dbhost, $dbuser, $dbpass, $dbdata)) {
+				if (!self::$installer->checkDB($a->getConfig(), $a->getProfiler(), $dbhost, $dbuser, $dbpass, $dbdata)) {
 					self::$currentWizardStep = self::DATABASE_CONFIG;
 					return;
 				}

--- a/src/Object/Image.php
+++ b/src/Object/Image.php
@@ -5,6 +5,7 @@
  */
 namespace Friendica\Object;
 
+use Exception;
 use Friendica\App;
 use Friendica\Core\Cache;
 use Friendica\Core\Config;
@@ -14,7 +15,6 @@ use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\Model\Photo;
 use Friendica\Util\Network;
-use Exception;
 use Imagick;
 use ImagickPixel;
 
@@ -656,7 +656,7 @@ class Image
 
 		$stamp1 = microtime(true);
 		file_put_contents($path, $string);
-		$a->saveTimestamp($stamp1, "file");
+		$a->getProfiler()->saveTimestamp($stamp1, "file");
 	}
 
 	/**
@@ -802,7 +802,7 @@ class Image
 					$a = \get_app();
 					$stamp1 = microtime(true);
 					file_put_contents($tempfile, $img_str);
-					$a->saveTimestamp($stamp1, "file");
+					$a->getProfiler()->saveTimestamp($stamp1, "file");
 
 					$data = getimagesize($tempfile);
 					unlink($tempfile);
@@ -910,7 +910,7 @@ class Image
 
 			$stamp1 = microtime(true);
 			$imagedata = @file_get_contents($url);
-			$a->saveTimestamp($stamp1, "file");
+			$a->getProfiler()->saveTimestamp($stamp1, "file");
 		}
 
 		$maximagesize = Config::get('system', 'maximagesize');
@@ -924,7 +924,7 @@ class Image
 
 		$stamp1 = microtime(true);
 		file_put_contents($tempfile, $imagedata);
-		$a->saveTimestamp($stamp1, "file");
+		$a->getProfiler()->saveTimestamp($stamp1, "file");
 
 		$data = getimagesize($tempfile);
 

--- a/src/Object/Image.php
+++ b/src/Object/Image.php
@@ -656,7 +656,7 @@ class Image
 
 		$stamp1 = microtime(true);
 		file_put_contents($path, $string);
-		$a->getProfiler()->saveTimestamp($stamp1, "file");
+		$a->getProfiler()->saveTimestamp($stamp1, "file", System::callstack());
 	}
 
 	/**
@@ -802,7 +802,7 @@ class Image
 					$a = \get_app();
 					$stamp1 = microtime(true);
 					file_put_contents($tempfile, $img_str);
-					$a->getProfiler()->saveTimestamp($stamp1, "file");
+					$a->getProfiler()->saveTimestamp($stamp1, "file", System::callstack());
 
 					$data = getimagesize($tempfile);
 					unlink($tempfile);
@@ -910,7 +910,7 @@ class Image
 
 			$stamp1 = microtime(true);
 			$imagedata = @file_get_contents($url);
-			$a->getProfiler()->saveTimestamp($stamp1, "file");
+			$a->getProfiler()->saveTimestamp($stamp1, "file", System::callstack());
 		}
 
 		$maximagesize = Config::get('system', 'maximagesize');
@@ -924,7 +924,7 @@ class Image
 
 		$stamp1 = microtime(true);
 		file_put_contents($tempfile, $imagedata);
-		$a->getProfiler()->saveTimestamp($stamp1, "file");
+		$a->getProfiler()->saveTimestamp($stamp1, "file", System::callstack());
 
 		$data = getimagesize($tempfile);
 

--- a/src/Util/Network.php
+++ b/src/Util/Network.php
@@ -4,13 +4,13 @@
  */
 namespace Friendica\Util;
 
+use DOMDocument;
+use DomXPath;
+use Friendica\Core\Config;
 use Friendica\Core\Hook;
 use Friendica\Core\Logger;
 use Friendica\Core\System;
-use Friendica\Core\Config;
 use Friendica\Network\CurlResult;
-use DOMDocument;
-use DomXPath;
 
 class Network
 {
@@ -232,7 +232,7 @@ class Network
 
 		@curl_close($ch);
 
-		$a->saveTimestamp($stamp1, 'network');
+		$a->getProfiler()->saveTimestamp($stamp1, 'network');
 
 		return $curlResponse;
 	}
@@ -334,7 +334,7 @@ class Network
 
 		curl_close($ch);
 
-		$a->saveTimestamp($stamp1, 'network');
+		$a->getProfiler()->saveTimestamp($stamp1, 'network');
 
 		Logger::log('post_url: end ' . $url, Logger::DATA);
 
@@ -641,7 +641,7 @@ class Network
 		$http_code = $curl_info['http_code'];
 		curl_close($ch);
 
-		$a->saveTimestamp($stamp1, "network");
+		$a->getProfiler()->saveTimestamp($stamp1, "network");
 
 		if ($http_code == 0) {
 			return $url;
@@ -683,7 +683,7 @@ class Network
 		$body = curl_exec($ch);
 		curl_close($ch);
 
-		$a->saveTimestamp($stamp1, "network");
+		$a->getProfiler()->saveTimestamp($stamp1, "network");
 
 		if (trim($body) == "") {
 			return $url;

--- a/src/Util/Network.php
+++ b/src/Util/Network.php
@@ -232,7 +232,7 @@ class Network
 
 		@curl_close($ch);
 
-		$a->getProfiler()->saveTimestamp($stamp1, 'network');
+		$a->getProfiler()->saveTimestamp($stamp1, 'network', System::callstack());
 
 		return $curlResponse;
 	}
@@ -334,7 +334,7 @@ class Network
 
 		curl_close($ch);
 
-		$a->getProfiler()->saveTimestamp($stamp1, 'network');
+		$a->getProfiler()->saveTimestamp($stamp1, 'network', System::callstack());
 
 		Logger::log('post_url: end ' . $url, Logger::DATA);
 
@@ -641,7 +641,7 @@ class Network
 		$http_code = $curl_info['http_code'];
 		curl_close($ch);
 
-		$a->getProfiler()->saveTimestamp($stamp1, "network");
+		$a->getProfiler()->saveTimestamp($stamp1, "network", System::callstack());
 
 		if ($http_code == 0) {
 			return $url;
@@ -683,7 +683,7 @@ class Network
 		$body = curl_exec($ch);
 		curl_close($ch);
 
-		$a->getProfiler()->saveTimestamp($stamp1, "network");
+		$a->getProfiler()->saveTimestamp($stamp1, "network", System::callstack());
 
 		if (trim($body) == "") {
 			return $url;

--- a/src/Util/Profiler.php
+++ b/src/Util/Profiler.php
@@ -1,0 +1,252 @@
+<?php
+
+namespace Friendica\Util;
+
+use Friendica\Core;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * A class to store profiling data
+ * It can handle different logging data for specific functions or global performance measures
+ *
+ * It stores the data as log entries (@see LoggerInterface )
+ */
+class Profiler implements ContainerInterface
+{
+	/**
+	 * @var array The global performance array
+	 */
+	private $performance;
+	/**
+	 * @var array The function specific callstack
+	 */
+	private $callstack;
+	/**
+	 * @var bool True, if the Profiler is enabled
+	 */
+	private $enabled;
+	/**
+	 * @var bool True, if the Profiler should measure the whole rendertime including functions
+	 */
+	private $rendertime;
+
+	/**
+	 * @var LoggerInterface The profiler logger
+	 */
+	private $logger;
+
+	/**
+	 * @param LoggerInterface $logger The profiler logger
+	 * @param bool $enabled           True, if the Profiler is enabled
+	 * @param bool $renderTime        True, if the Profiler should measure the whole rendertime including functions
+	 */
+	public function __construct(LoggerInterface $logger, $enabled = false, $renderTime = false)
+	{
+		$this->enabled = $enabled;
+		$this->rendertime = $renderTime;
+		$this->logger = $logger;
+		$this->performance = [];
+		$this->callstack   = [];
+	}
+
+	/**
+	 * Saves a timestamp for a value - f.e. a call
+	 * Necessary for profiling Friendica
+	 *
+	 * @param int $timestamp the Timestamp
+	 * @param string $value A value to profile
+	 */
+	public function saveTimestamp($timestamp, $value)
+	{
+		if (!$this->enabled) {
+			return;
+		}
+
+		$duration = (float) (microtime(true) - $timestamp);
+
+		if (!isset($this->performance[$value])) {
+			// Prevent ugly E_NOTICE
+			$this->performance[$value] = 0;
+		}
+
+		$this->performance[$value] += (float) $duration;
+		$this->performance['marktime'] += (float) $duration;
+
+		$callstack = Core\System::callstack();
+
+		if (!isset($this->callstack[$value][$callstack])) {
+			// Prevent ugly E_NOTICE
+			$this->callstack[$value][$callstack] = 0;
+		}
+
+		$this->callstack[$value][$callstack] += (float) $duration;
+	}
+
+	/**
+	 * Resets the performance and callstack profiling
+	 *
+	 * @param bool $performance If true, reset the performance (Default true)
+	 * @param bool $callstack   If true, reset the callstack (Default true)
+	 */
+	public function reset($performance = true, $callstack = true)
+	{
+		if ($performance) {
+			$this->performance = [];
+			$this->performance['start'] = microtime(true);
+			$this->performance['database'] = 0;
+			$this->performance['database_write'] = 0;
+			$this->performance['cache'] = 0;
+			$this->performance['cache_write'] = 0;
+			$this->performance['network'] = 0;
+			$this->performance['file'] = 0;
+			$this->performance['rendering'] = 0;
+			$this->performance['parser'] = 0;
+			$this->performance['marktime'] = 0;
+			$this->performance['markstart'] = microtime(true);
+		}
+
+		if ($callstack) {
+			$this->callstack['database'] = [];
+			$this->callstack['database_write'] = [];
+			$this->callstack['cache'] = [];
+			$this->callstack['cache_write'] = [];
+			$this->callstack['network'] = [];
+			$this->callstack['file'] = [];
+			$this->callstack['rendering'] = [];
+			$this->callstack['parser'] = [];
+		}
+	}
+
+	/**
+	 * Save the current profiling data to a log entry
+	 *
+	 * @param string $message Additional message for the log
+	 */
+	public function saveLog($message)
+	{
+		// Write down the performance values into the log
+		if ($this->enabled) {
+			$duration = microtime(true)-$this->get('start');
+			$this->logger->info(
+				$message,
+				[
+					'module' => 'api',
+					'action' => 'call',
+					'database_read' => round($this->get('database') - $this->get('database_write'), 3),
+					'database_write' => round($this->get('database_write'), 3),
+					'cache_read' => round($this->get('cache'), 3),
+					'cache_write' => round($this->get('cache_write'), 3),
+					'network_io' => round($this->get('network'), 2),
+					'file_io' => round($this->get('file'), 2),
+					'other_io' => round($duration - ($this->get('database')
+							+ $this->get('cache') + $this->get('cache_write')
+							+ $this->get('network') + $this->get('file')), 2),
+					'total' => round($duration, 2)
+				]
+			);
+
+			$o = '';
+			if ($this->rendertime) {
+				if (isset($this->callstack["database"])) {
+					$o .= "\nDatabase Read:\n";
+					foreach ($this->callstack["database"] as $func => $time) {
+						$time = round($time, 3);
+						if ($time > 0) {
+							$o .= $func.": ".$time."\n";
+						}
+					}
+				}
+				if (isset($this->callstack["database_write"])) {
+					$o .= "\nDatabase Write:\n";
+					foreach ($this->callstack["database_write"] as $func => $time) {
+						$time = round($time, 3);
+						if ($time > 0) {
+							$o .= $func.": ".$time."\n";
+						}
+					}
+				}
+				if (isset($this->callstack["dache"])) {
+					$o .= "\nCache Read:\n";
+					foreach ($this->callstack["dache"] as $func => $time) {
+						$time = round($time, 3);
+						if ($time > 0) {
+							$o .= $func.": ".$time."\n";
+						}
+					}
+				}
+				if (isset($this->callstack["dache_write"])) {
+					$o .= "\nCache Write:\n";
+					foreach ($this->callstack["dache_write"] as $func => $time) {
+						$time = round($time, 3);
+						if ($time > 0) {
+							$o .= $func.": ".$time."\n";
+						}
+					}
+				}
+				if (isset($this->callstack["network"])) {
+					$o .= "\nNetwork:\n";
+					foreach ($this->callstack["network"] as $func => $time) {
+						$time = round($time, 3);
+						if ($time > 0) {
+							$o .= $func.": ".$time."\n";
+						}
+					}
+				}
+			}
+
+			$this->logger->info(
+				$message . ": " . sprintf(
+					"DB: %s/%s, Cache: %s/%s, Net: %s, I/O: %s, Other: %s, Total: %s".$o,
+					number_format($this->get('database') - $this->get('database_write'), 2),
+					number_format($this->get('database_write'), 2),
+					number_format($this->get('cache'), 2),
+					number_format($this->get('cache_write'), 2),
+					number_format($this->get('network'), 2),
+					number_format($this->get('file'), 2),
+					number_format($duration - ($this->get('database')
+							+ $this->get('cache') + $this->get('cache_write')
+							+ $this->get('network') + $this->get('file')), 2),
+					number_format($duration, 2)
+				)
+			);
+		}
+	}
+
+	/**
+	 * Finds an entry of the container by its identifier and returns it.
+	 *
+	 * @param string $id Identifier of the entry to look for.
+	 *
+	 * @throws NotFoundExceptionInterface  No entry was found for **this** identifier.
+	 * @throws ContainerExceptionInterface Error while retrieving the entry.
+	 *
+	 * @return int Entry.
+	 */
+	public function get($id)
+	{
+		if (!$this->has($id)) {
+			return 0;
+		} else {
+			return $this->performance[$id];
+		}
+	}
+
+	/**
+	 * Returns true if the container can return an entry for the given identifier.
+	 * Returns false otherwise.
+	 *
+	 * `has($id)` returning true does not mean that `get($id)` will not throw an exception.
+	 * It does however mean that `get($id)` will not throw a `NotFoundExceptionInterface`.
+	 *
+	 * @param string $id Identifier of the entry to look for.
+	 *
+	 * @return bool
+	 */
+	public function has($id)
+	{
+		return isset($this->performance[$id]);
+	}
+}

--- a/src/Util/Profiler.php
+++ b/src/Util/Profiler.php
@@ -2,7 +2,6 @@
 
 namespace Friendica\Util;
 
-use Friendica\Core;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
@@ -58,8 +57,9 @@ class Profiler implements ContainerInterface
 	 *
 	 * @param int $timestamp the Timestamp
 	 * @param string $value A value to profile
+	 * @param string $callstack The callstack of the current profiling data
 	 */
-	public function saveTimestamp($timestamp, $value)
+	public function saveTimestamp($timestamp, $value, $callstack = '')
 	{
 		if (!$this->enabled) {
 			return;
@@ -74,8 +74,6 @@ class Profiler implements ContainerInterface
 
 		$this->performance[$value] += (float) $duration;
 		$this->performance['marktime'] += (float) $duration;
-
-		$callstack = Core\System::callstack();
 
 		if (!isset($this->callstack[$value][$callstack])) {
 			// Prevent ugly E_NOTICE

--- a/src/Util/Profiler.php
+++ b/src/Util/Profiler.php
@@ -84,19 +84,11 @@ class Profiler implements ContainerInterface
 
 	/**
 	 * Resets the performance and callstack profiling
-	 *
-	 * @param bool $performance If true, reset the performance (Default true)
-	 * @param bool $callstack   If true, reset the callstack (Default true)
 	 */
-	public function reset($performance = true, $callstack = true)
+	public function reset()
 	{
-		if ($performance) {
-			$this->resetPerformance();
-		}
-
-		if ($callstack) {
-			$this->resetCallstack();
-		}
+		$this->resetPerformance();
+		$this->resetCallstack();
 	}
 
 	/**

--- a/src/Util/Profiler.php
+++ b/src/Util/Profiler.php
@@ -149,8 +149,7 @@ class Profiler implements ContainerInterface
 		$this->logger->info(
 			$message,
 			[
-				'module' => 'api',
-				'action' => 'call',
+				'action' => 'profiling',
 				'database_read' => round($this->get('database') - $this->get('database_write'), 3),
 				'database_write' => round($this->get('database_write'), 3),
 				'cache_read' => round($this->get('cache'), 3),
@@ -214,7 +213,7 @@ class Profiler implements ContainerInterface
 				}
 			}
 		}
-		$this->logger->info($message . ": " . $o);
+		$this->logger->info($message . ": " . $o, ['action' => 'profiling']);
 	}
 
 	/**

--- a/src/Util/Profiler.php
+++ b/src/Util/Profiler.php
@@ -47,8 +47,7 @@ class Profiler implements ContainerInterface
 		$this->enabled = $enabled;
 		$this->rendertime = $renderTime;
 		$this->logger = $logger;
-		$this->performance = [];
-		$this->callstack   = [];
+		$this->reset();
 	}
 
 	/**
@@ -103,7 +102,7 @@ class Profiler implements ContainerInterface
 			$this->performance['rendering'] = 0;
 			$this->performance['parser'] = 0;
 			$this->performance['marktime'] = 0;
-			$this->performance['markstart'] = microtime(true);
+			$this->performance['marktime'] = microtime(true);
 		}
 
 		if ($callstack) {
@@ -123,7 +122,7 @@ class Profiler implements ContainerInterface
 	 *
 	 * @param string $message Additional message for the log
 	 */
-	public function saveLog($message)
+	public function saveLog($message = '')
 	{
 		// Write down the performance values into the log
 		if ($this->enabled) {
@@ -166,18 +165,18 @@ class Profiler implements ContainerInterface
 						}
 					}
 				}
-				if (isset($this->callstack["dache"])) {
+				if (isset($this->callstack["cache"])) {
 					$o .= "\nCache Read:\n";
-					foreach ($this->callstack["dache"] as $func => $time) {
+					foreach ($this->callstack["cache"] as $func => $time) {
 						$time = round($time, 3);
 						if ($time > 0) {
 							$o .= $func.": ".$time."\n";
 						}
 					}
 				}
-				if (isset($this->callstack["dache_write"])) {
+				if (isset($this->callstack["cache_write"])) {
 					$o .= "\nCache Write:\n";
-					foreach ($this->callstack["dache_write"] as $func => $time) {
+					foreach ($this->callstack["cache_write"] as $func => $time) {
 						$time = round($time, 3);
 						if ($time > 0) {
 							$o .= $func.": ".$time."\n";
@@ -193,23 +192,9 @@ class Profiler implements ContainerInterface
 						}
 					}
 				}
+				$this->logger->info($message . ": " . $o);
 			}
 
-			$this->logger->info(
-				$message . ": " . sprintf(
-					"DB: %s/%s, Cache: %s/%s, Net: %s, I/O: %s, Other: %s, Total: %s".$o,
-					number_format($this->get('database') - $this->get('database_write'), 2),
-					number_format($this->get('database_write'), 2),
-					number_format($this->get('cache'), 2),
-					number_format($this->get('cache_write'), 2),
-					number_format($this->get('network'), 2),
-					number_format($this->get('file'), 2),
-					number_format($duration - ($this->get('database')
-							+ $this->get('cache') + $this->get('cache_write')
-							+ $this->get('network') + $this->get('file')), 2),
-					number_format($duration, 2)
-				)
-			);
 		}
 	}
 

--- a/tests/DatabaseTest.php
+++ b/tests/DatabaseTest.php
@@ -9,6 +9,7 @@ use Friendica\Core\Config;
 use Friendica\Database\DBA;
 use Friendica\Factory;
 use Friendica\Util\BasePath;
+use Friendica\Util\Profiler;
 use PHPUnit\DbUnit\DataSet\YamlDataSet;
 use PHPUnit\DbUnit\TestCaseTrait;
 use PHPUnit_Extensions_Database_DB_IDatabaseConnection;
@@ -43,8 +44,11 @@ abstract class DatabaseTest extends MockedTest
 		$configLoader = new Config\ConfigCacheLoader($basedir);
 		$config = Factory\ConfigFactory::createCache($configLoader);
 
+		$profiler = \Mockery::mock(Profiler::class);
+
 		DBA::connect(
 			$config,
+			$profiler,
 			getenv('MYSQL_HOST'),
 			getenv('MYSQL_USERNAME'),
 			getenv('MYSQL_PASSWORD'),

--- a/tests/include/ApiTest.php
+++ b/tests/include/ApiTest.php
@@ -39,7 +39,8 @@ class ApiTest extends DatabaseTest
 		$configLoader = new Config\ConfigCacheLoader($basedir);
 		$config = Factory\ConfigFactory::createCache($configLoader);
 		$logger = Factory\LoggerFactory::create('test', $config);
-		$this->app = new App($config, $logger, false);
+		$profiler = Factory\ProfilerFactory::create($logger, $config);
+		$this->app = new App($config, $logger, $profiler, false);
 		$this->logOutput = FActory\LoggerFactory::enableTest($this->app->getLogger());
 
 		parent::setUp();

--- a/tests/src/Core/Console/ConsoleTest.php
+++ b/tests/src/Core/Console/ConsoleTest.php
@@ -3,10 +3,12 @@
 namespace Friendica\Test\src\Core\Console;
 
 use Asika\SimpleConsole\Console;
+use Friendica\Core\Config\ConfigCache;
 use Friendica\Test\MockedTest;
 use Friendica\Test\Util\AppMockTrait;
 use Friendica\Test\Util\Intercept;
 use Friendica\Test\Util\VFSTrait;
+use Friendica\Util\Profiler;
 
 abstract class ConsoleTest extends MockedTest
 {
@@ -29,8 +31,10 @@ abstract class ConsoleTest extends MockedTest
 		Intercept::setUp();
 
 		$this->setUpVfsDir();
-		$configMock = \Mockery::mock('Friendica\Core\Config\ConfigCache');
+		$configMock = \Mockery::mock(ConfigCache::class);
 		$this->mockApp($this->root, $configMock);
+		$profileMock = \Mockery::mock(Profiler::class);
+		$this->app->shouldReceive('getProfiler')->andReturn($profileMock);
 	}
 
 	/**

--- a/tests/src/Database/DBATest.php
+++ b/tests/src/Database/DBATest.php
@@ -16,7 +16,8 @@ class DBATest extends DatabaseTest
 		$configLoader = new Config\ConfigCacheLoader($basedir);
 		$config = Factory\ConfigFactory::createCache($configLoader);
 		$logger = Factory\LoggerFactory::create('test', $config);
-		$this->app = new App($config, $logger, false);
+		$profiler = Factory\ProfilerFactory::create($logger, $config);
+		$this->app = new App($config, $logger, $profiler, false);
 		$this->logOutput = FActory\LoggerFactory::enableTest($this->app->getLogger());
 
 		parent::setUp();

--- a/tests/src/Database/DBStructureTest.php
+++ b/tests/src/Database/DBStructureTest.php
@@ -17,7 +17,8 @@ class DBStructureTest extends DatabaseTest
 		$configLoader = new Config\ConfigCacheLoader($basedir);
 		$config = Factory\ConfigFactory::createCache($configLoader);
 		$logger = Factory\LoggerFactory::create('test', $config);
-		$this->app = new App($config, $logger, false);
+		$profiler = Factory\ProfilerFactory::create($logger, $config);
+		$this->app = new App($config, $logger, $profiler, false);
 		$this->logOutput = FActory\LoggerFactory::enableTest($this->app->getLogger());
 
 		parent::setUp();

--- a/tests/src/Util/ProfilerTest.php
+++ b/tests/src/Util/ProfilerTest.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace src\Util;
+
+use Friendica\Test\MockedTest;
+use Friendica\Util\Profiler;
+use Mockery\MockInterface;
+use Psr\Log\LoggerInterface;
+
+class ProfilerTest extends MockedTest
+{
+	/**
+	 * @var LoggerInterface|MockInterface
+	 */
+	private $logger;
+
+	protected function setUp()
+	{
+		parent::setUp();
+
+		$this->logger = \Mockery::mock('Psr\Log\LoggerInterface');
+	}
+
+	/**
+	 * Test the Profiler setup
+	 */
+	public function testSetUp()
+	{
+		$profiler = new Profiler($this->logger, true, true);
+	}
+
+	/**
+	 * A dataset for different profiling settings
+	 * @return array
+	 */
+	public function dataPerformance()
+	{
+		return [
+			'database' => [
+				'timestamp' => time(),
+				'name' => 'database',
+				'functions' => ['test', 'it'],
+			],
+			'database_write' => [
+				'timestamp' => time(),
+				'name' => 'database_write',
+				'functions' => ['test', 'it2'],
+			],
+			'cache' => [
+				'timestamp' => time(),
+				'name' => 'cache',
+				'functions' => ['test', 'it3'],
+			],
+			'cache_write' => [
+				'timestamp' => time(),
+				'name' => 'cache_write',
+				'functions' => ['test', 'it4'],
+			],
+			'network' => [
+				'timestamp' => time(),
+				'name' => 'network',
+				'functions' => ['test', 'it5'],
+			],
+			'file' => [
+				'timestamp' => time(),
+				'name' => 'file',
+				'functions' => [],
+			],
+			'rendering' => [
+				'timestamp' => time(),
+				'name' => 'rendering',
+				'functions' => ['test', 'it7'],
+			],
+			'parser' => [
+				'timestamp' => time(),
+				'name' => 'parser',
+				'functions' => ['test', 'it8'],
+			],
+			'marktime' => [
+				'timestamp' => time(),
+				'name' => 'parser',
+				'functions' => ['test'],
+			],
+			// This one isn't set during reset
+			'unknown' => [
+				'timestamp' => time(),
+				'name' => 'unknown',
+				'functions' => ['test'],
+			],
+		];
+	}
+
+	/**
+	 * Test the Profiler savetimestamp
+	 * @dataProvider dataPerformance
+	 */
+	public function testSaveTimestamp($timestamp, $name, array $functions)
+	{
+		$profiler = new Profiler($this->logger, true, true);
+
+		foreach ($functions as $function) {
+			$profiler->saveTimestamp($timestamp, $name, $function);
+		}
+
+		$this->assertGreaterThanOrEqual(0, $profiler->get($name));
+	}
+
+	/**
+	 * Test the Profiler reset
+	 * @dataProvider dataPerformance
+	 */
+	public function testReset($timestamp, $name, array $functions)
+	{
+		$profiler = new Profiler($this->logger, true, true);
+
+		$profiler->saveTimestamp($timestamp, $name);
+		$profiler->reset();
+
+		$this->assertEquals(0, $profiler->get($name));
+	}
+
+	public function dataBig()
+	{
+		return [
+			'big' => [
+				'data' => [
+					'database' => [
+						'timestamp' => time(),
+						'name' => 'database',
+						'functions' => ['test', 'it'],
+					],
+					'database_write' => [
+						'timestamp' => time(),
+						'name' => 'database_write',
+						'functions' => ['test', 'it2'],
+					],
+					'cache' => [
+						'timestamp' => time(),
+						'name' => 'cache',
+						'functions' => ['test', 'it3'],
+					],
+					'cache_write' => [
+						'timestamp' => time(),
+						'name' => 'cache_write',
+						'functions' => ['test', 'it4'],
+					],
+					'network' => [
+						'timestamp' => time(),
+						'name' => 'network',
+						'functions' => ['test', 'it5'],
+					],
+				]
+			]
+		];
+	}
+
+	/**
+	 * Test the output of the Profiler
+	 * @dataProvider dataBig
+	 */
+	public function testSaveLog($data)
+	{
+		$this->logger
+			->shouldReceive('info')
+			->with('test', \Mockery::any())
+			->once();
+		$this->logger
+			->shouldReceive('info')
+			->once();
+
+		$profiler = new Profiler($this->logger, true, true);
+
+		foreach ($data as $perf => $items) {
+			foreach ($items['functions'] as $function) {
+				$profiler->saveTimestamp($items['timestamp'], $items['name'], $function);
+			}
+		}
+
+		$profiler->saveLog('test');
+	}
+}


### PR DESCRIPTION
As a prerequisite for #6641 (see https://github.com/friendica/friendica/pull/6641#discussion_r255788812 ), we had to move the profiling data out of `App` to avoid the loopback at `DBA`.

This is done with this PR now. It was a lot of fun too because I reduced two complete log-output codings to one :-).

So what I did:
- New `Profiler` class which holds all `performance` and `callstack` information for profiling
- `Profiler` implements `ContainerInterface` for `get()` and `has()` methods of performance entries
- Every `$a->performance[]` accesor is refactored to `$a->getProfiler()->get()`
- `Profiler->saveLog()` is now writing the whole profiling data to the log
- New `ProfilerFactory` for creating the `Profiler` outside of `App`
- `DBA` is now `App` free :-)
- Created some `Profiler` tests

It is now possible to add a separate Logger (must implement `LoggerInterface`) to the `Profiler` class to avoid dumping profiling data to the normal log (or at least mark them with an own channel).