### PR TITLE
fix magic links for item mentions

### DIFF
--- a/src/Model/Term.php
+++ b/src/Model/Term.php
@@ -272,10 +272,10 @@ class Term
 
 			$author = ['uid' => 0, 'id' => $item['author-id'],
 				'network' => $item['author-network'], 'url' => $item['author-link']];
-			$tag['url'] = Contact::magicLinkByContact($author, $tag['url']);
 
 			$prefix = '';
 			if ($tag['type'] == TERM_HASHTAG) {
+				$tag['url'] = Contact::magicLinkByContact($author, $tag['url']);
 				if ($orig_tag != $tag['url']) {
 					$item['body'] = str_replace($orig_tag, $tag['url'], $item['body']);
 				}
@@ -283,6 +283,7 @@ class Term
 				$return['hashtags'][] = '#<a href="' . $tag['url'] . '" target="_blank">' . $tag['term'] . '</a>';
 				$prefix = '#';
 			} elseif ($tag['type'] == TERM_MENTION) {
+				$tag['url'] = Contact::magicLink($tag['url']);
 				$return['mentions'][] = '@<a href="' . $tag['url'] . '" target="_blank">' . $tag['term'] . '</a>';
 				$prefix = '@';
 			}


### PR DESCRIPTION
fixes https://github.com/friendica/friendica/issues/6669

problem was does mentions doesn't need an author. If an author is added then the author host name and the host name of the mentioned contact differ and `Contact::magicLinkByContact()'` will stop here https://github.com/friendica/friendica/blob/2019.01/src/Model/Contact.php#L2135

We have the same problem with plinks. It seems that in many cases the plink address uses the host name of the thread owner and not of the item author.

Actual code https://github.com/friendica/friendica/blob/2019.01/include/conversation.php#L357-L364
Can we use the owner instead of the author for this piece of code?
If yes I would add a commit to this PR