### PR TITLE
Preload adapter fix

### DIFF
--- a/src/Core/Config/Adapter/JITConfigAdapter.php
+++ b/src/Core/Config/Adapter/JITConfigAdapter.php
@@ -33,10 +33,13 @@ class JITConfigAdapter extends AbstractDbaConfigAdapter implements IConfigAdapte
 
 		$configs = DBA::select('config', ['v', 'k'], ['cat' => $cat]);
 		while ($config = DBA::fetch($configs)) {
-			$key = $config['k'];
+			$key   = $config['k'];
+			$value = $config['v'];
 
-			$return[$key] = $config['v'];
-			$this->in_db[$cat][$key] = true;
+			if (isset($value) && $value !== '') {
+				$return[$key] = $value;
+				$this->in_db[$cat][$key] = true;
+			}
 		}
 		DBA::close($configs);
 

--- a/src/Core/Config/Adapter/JITPConfigAdapter.php
+++ b/src/Core/Config/Adapter/JITPConfigAdapter.php
@@ -29,10 +29,12 @@ class JITPConfigAdapter extends AbstractDbaConfigAdapter implements IPConfigAdap
 		if (DBA::isResult($pconfigs)) {
 			while ($pconfig = DBA::fetch($pconfigs)) {
 				$key = $pconfig['k'];
+				$value = $pconfig['v'];
 
-				$return[$key] = $pconfig['v'];
-
-				$this->in_db[$uid][$cat][$key] = true;
+				if (isset($value) && $value !== '') {
+					$return[$key] = $value;
+					$this->in_db[$uid][$cat][$key] = true;
+				}
 			}
 		} else if ($cat != 'config') {
 			// Negative caching

--- a/src/Core/Config/Adapter/PreloadConfigAdapter.php
+++ b/src/Core/Config/Adapter/PreloadConfigAdapter.php
@@ -35,6 +35,8 @@ class PreloadConfigAdapter extends AbstractDbaConfigAdapter implements IConfigAd
 			$value = $config['v'];
 			if (isset($value) && $value !== '') {
 				$return[$config['cat']][$config['k']] = $value;
+			} else {
+				$return[$config['cat']][$config['k']] = '!<unset>!';
 			}
 		}
 		DBA::close($configs);

--- a/src/Core/Config/Adapter/PreloadConfigAdapter.php
+++ b/src/Core/Config/Adapter/PreloadConfigAdapter.php
@@ -32,7 +32,10 @@ class PreloadConfigAdapter extends AbstractDbaConfigAdapter implements IConfigAd
 
 		$configs = DBA::select('config', ['cat', 'v', 'k']);
 		while ($config = DBA::fetch($configs)) {
-			$return[$config['cat']][$config['k']] = $config['v'];
+			$value = $config['v'];
+			if (isset($value) && $value !== '') {
+				$return[$config['cat']][$config['k']] = $value;
+			}
 		}
 		DBA::close($configs);
 

--- a/src/Core/Config/Adapter/PreloadPConfigAdapter.php
+++ b/src/Core/Config/Adapter/PreloadPConfigAdapter.php
@@ -44,7 +44,10 @@ class PreloadPConfigAdapter extends AbstractDbaConfigAdapter implements IPConfig
 
 		$pconfigs = DBA::select('pconfig', ['cat', 'v', 'k'], ['uid' => $uid]);
 		while ($pconfig = DBA::fetch($pconfigs)) {
-			$return[$pconfig['cat']][$pconfig['k']] = $pconfig['v'];
+			$value = $pconfig['v'];
+			if (isset($value) && $value !== '') {
+				$return[$pconfig['cat']][$pconfig['k']] = $value;
+			}
 		}
 		DBA::close($pconfigs);
 

--- a/src/Core/Config/Adapter/PreloadPConfigAdapter.php
+++ b/src/Core/Config/Adapter/PreloadPConfigAdapter.php
@@ -47,6 +47,8 @@ class PreloadPConfigAdapter extends AbstractDbaConfigAdapter implements IPConfig
 			$value = $pconfig['v'];
 			if (isset($value) && $value !== '') {
 				$return[$pconfig['cat']][$pconfig['k']] = $value;
+			} else {
+				$return[$pconfig['cat']][$pconfig['k']] = '!<unset>!';
 			}
 		}
 		DBA::close($pconfigs);

--- a/src/Core/Config/Adapter/PreloadPConfigAdapter.php
+++ b/src/Core/Config/Adapter/PreloadPConfigAdapter.php
@@ -25,11 +25,11 @@ class PreloadPConfigAdapter extends AbstractDbaConfigAdapter implements IPConfig
 	{
 		parent::__construct();
 
+		$this->config_loaded = [];
+
 		if (isset($uid)) {
 			$this->load($uid, 'config');
 		}
-
-		$this->config_loaded = [];
 	}
 
 	/**
@@ -43,7 +43,7 @@ class PreloadPConfigAdapter extends AbstractDbaConfigAdapter implements IPConfig
 			return $return;
 		}
 
-		if ($this->isLoaded($uid, $cat, null)) {
+		if (!$this->isLoaded($uid, $cat, null)) {
 			return $return;
 		}
 

--- a/src/Core/Config/Adapter/PreloadPConfigAdapter.php
+++ b/src/Core/Config/Adapter/PreloadPConfigAdapter.php
@@ -97,7 +97,7 @@ class PreloadPConfigAdapter extends AbstractDbaConfigAdapter implements IPConfig
 			return false;
 		}
 
-		if ($this->isLoaded($uid, $cat, $key)) {
+		if (!$this->isLoaded($uid, $cat, $key)) {
 			$this->load($uid, $cat);
 		}
 		// We store our setting values as strings.

--- a/src/Core/Config/Adapter/PreloadPConfigAdapter.php
+++ b/src/Core/Config/Adapter/PreloadPConfigAdapter.php
@@ -13,7 +13,10 @@ use Friendica\Database\DBA;
  */
 class PreloadPConfigAdapter extends AbstractDbaConfigAdapter implements IPConfigAdapter
 {
-	private $config_loaded = false;
+	/**
+	 * @var array true if config for user is loaded
+	 */
+	private $config_loaded;
 
 	/**
 	 * @param int $uid The UID of the current user
@@ -25,6 +28,8 @@ class PreloadPConfigAdapter extends AbstractDbaConfigAdapter implements IPConfig
 		if (isset($uid)) {
 			$this->load($uid, 'config');
 		}
+
+		$this->config_loaded = [];
 	}
 
 	/**
@@ -34,11 +39,11 @@ class PreloadPConfigAdapter extends AbstractDbaConfigAdapter implements IPConfig
 	{
 		$return = [];
 
-		if ($this->config_loaded) {
+		if (empty($uid)) {
 			return $return;
 		}
 
-		if (empty($uid)) {
+		if ($this->isLoaded($uid, $cat, null)) {
 			return $return;
 		}
 
@@ -53,7 +58,7 @@ class PreloadPConfigAdapter extends AbstractDbaConfigAdapter implements IPConfig
 		}
 		DBA::close($pconfigs);
 
-		$this->config_loaded = true;
+		$this->config_loaded[$uid] = true;
 
 		return $return;
 	}
@@ -67,7 +72,7 @@ class PreloadPConfigAdapter extends AbstractDbaConfigAdapter implements IPConfig
 			return '!<unset>!';
 		}
 
-		if (!$this->config_loaded) {
+		if (!$this->isLoaded($uid, $cat, $key)) {
 			$this->load($uid, $cat);
 		}
 
@@ -92,7 +97,7 @@ class PreloadPConfigAdapter extends AbstractDbaConfigAdapter implements IPConfig
 			return false;
 		}
 
-		if (!$this->config_loaded) {
+		if ($this->isLoaded($uid, $cat, $key)) {
 			$this->load($uid, $cat);
 		}
 		// We store our setting values as strings.
@@ -121,7 +126,7 @@ class PreloadPConfigAdapter extends AbstractDbaConfigAdapter implements IPConfig
 			return false;
 		}
 
-		if (!$this->config_loaded) {
+		if (!$this->isLoaded($uid, $cat, $key)) {
 			$this->load($uid, $cat);
 		}
 
@@ -139,6 +144,6 @@ class PreloadPConfigAdapter extends AbstractDbaConfigAdapter implements IPConfig
 			return false;
 		}
 
-		return $this->config_loaded;
+		return isset($this->config_loaded[$uid]) && $this->config_loaded[$uid];
 	}
 }

--- a/src/Core/Config/Cache/ConfigCache.php
+++ b/src/Core/Config/Cache/ConfigCache.php
@@ -36,11 +36,12 @@ class ConfigCache implements IConfigCache, IPConfigCache
 				$keys = array_keys($config[$category]);
 
 				foreach ($keys as $key) {
-					if (isset($config[$category][$key])) {
+					$value = $config[$category][$key];
+					if (isset($value) && $value !== '!<unset>!') {
 						if ($overwrite) {
-							$this->set($category, $key, $config[$category][$key]);
+							$this->set($category, $key, $value);
 						} else {
-							$this->setDefault($category, $key, $config[$category][$key]);
+							$this->setDefault($category, $key, $value);
 						}
 					}
 				}
@@ -132,9 +133,19 @@ class ConfigCache implements IConfigCache, IPConfigCache
 	 */
 	public function loadP($uid, array $config)
 	{
-		foreach ($config as $category => $values) {
-			foreach ($values as $key => $value) {
-				$this->setP($uid, $category, $key, $value);
+		$categories = array_keys($config);
+
+		foreach ($categories as $category) {
+			if (isset($config[$category]) && is_array($config[$category])) {
+
+				$keys = array_keys($config[$category]);
+
+				foreach ($keys as $key) {
+					$value = $config[$category][$key];
+					if (isset($value) && $value !== '!<unset>!') {
+						$this->setP($uid, $category, $key, $value);
+					}
+				}
 			}
 		}
 	}

--- a/view/theme/frio/style.php
+++ b/view/theme/frio/style.php
@@ -20,7 +20,6 @@ if ($a->module !== 'install') {
 
 		// Load the profile owners pconfig.
 		$scheme           = PConfig::get($uid, 'frio', 'scheme', PConfig::get($uid, 'frio', 'schema'));
-		\Friendica\Core\Logger::alert($scheme);
 		$nav_bg           = PConfig::get($uid, 'frio', 'nav_bg');
 		$nav_icon_color   = PConfig::get($uid, 'frio', 'nav_icon_color');
 		$link_color       = PConfig::get($uid, 'frio', 'link_color');

--- a/view/theme/frio/style.php
+++ b/view/theme/frio/style.php
@@ -2,9 +2,9 @@
 /**
  * @file view/theme/frio/style.php
  */
+
 use Friendica\Core\Config;
 use Friendica\Core\PConfig;
-use Friendica\Model\Profile;
 
 require_once 'view/theme/frio/php/PHPColors/Color.php';
 
@@ -20,6 +20,7 @@ if ($a->module !== 'install') {
 
 		// Load the profile owners pconfig.
 		$scheme           = PConfig::get($uid, 'frio', 'scheme', PConfig::get($uid, 'frio', 'schema'));
+		\Friendica\Core\Logger::alert($scheme);
 		$nav_bg           = PConfig::get($uid, 'frio', 'nav_bg');
 		$nav_icon_color   = PConfig::get($uid, 'frio', 'nav_icon_color');
 		$link_color       = PConfig::get($uid, 'frio', 'link_color');


### PR DESCRIPTION
Fixing https://github.com/friendica/friendica/pull/6682#issuecomment-464702823

The preload adapter for PConfig used a "whole" boolean flag for every user. So let's say user with "0" was loaded, a load for "1" was impossible.

I changed it to a bool-array for each uid and now it worked.

Bugfix #6641 

Tested both JIT and Preload on my node.