### PR TITLE
Avoid memory issue in exception of JSON-LD parser

### DIFF
--- a/src/Util/JsonLD.php
+++ b/src/Util/JsonLD.php
@@ -68,7 +68,7 @@ class JsonLD
 		}
 		catch (Exception $e) {
 			$normalized = false;
-			Logger::log('normalise error:' . print_r($e, true), Logger::DEBUG);
+			Logger::log('normalise error:' . substr(print_r($e, true), 0, 10000), Logger::DEBUG);
 		}
 
 		return $normalized;
@@ -115,7 +115,7 @@ class JsonLD
 		}
 		catch (Exception $e) {
 			$compacted = false;
-			Logger::log('compacting error:' . print_r($e, true), Logger::DEBUG);
+			Logger::log('compacting error:' . substr(print_r($e, true), 0, 10000), Logger::DEBUG);
 		}
 
 		$json = json_decode(json_encode($compacted, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE), true);


### PR DESCRIPTION
This possibly does fix the problem with the memory issues and AP. Possibly the error happens not in the JSON-LD parser itself, but in the following error handling, since the output is that large.

I'm not totally certain if this really helps, but we can try.