### PR TITLE
Sharing color schemes

### DIFF
--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -14,6 +14,8 @@ User
 * **[Can I subscribe to a hashtag?](help/FAQ#hashtag)**
 * **[How to create a RSS feed of the stream?](help/FAQ#rss)**
 * **[Are there any clients for friendica I can use?](help/FAQ#clients)**
+* **[How can I share my color scheme with others?](help/FAQ#schemesharing)**
+* **[How can I apply a color scheme shared by others?](help/FAQ#schemesharingpaste)**
 * **[Where I can find help?](help/FAQ#help)**
 
 Admins
@@ -188,6 +190,20 @@ Here is a list of known working clients:
   * Hotot
 
 Depending on the features of the client you might encounter some glitches in usability, like being limited in the length of your postings to 140 characters and having no access to the [permission settings](help/Groups-and-Privacy).
+
+<a name="schemesharing"></a>
+
+### How can I share my color scheme with others?
+
+If you created a color scheme you want to share it with others, you can do this easily by sharing the schemestring.
+
+You can find this string within the `custom theme settings` of the [display settings](/settings/display) page. This input box is only available when custom color scheme is selected.
+
+
+<a name="schemesharingpaste"></a>
+
+### How can I apply a color scheme shared by others?
+People who want to apply a color scheme shared by others can paste the string in the schemestring box on `custom theme settings` of the [display settings](/settings/display) page and click `submit`. 
 
 <a name="help"></a>
 

--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -14,8 +14,6 @@ User
 * **[Can I subscribe to a hashtag?](help/FAQ#hashtag)**
 * **[How to create a RSS feed of the stream?](help/FAQ#rss)**
 * **[Are there any clients for friendica I can use?](help/FAQ#clients)**
-* **[How can I share my color scheme with others?](help/FAQ#schemesharing)**
-* **[How can I apply a color scheme shared by others?](help/FAQ#schemesharingpaste)**
 * **[Where I can find help?](help/FAQ#help)**
 
 Admins
@@ -190,20 +188,6 @@ Here is a list of known working clients:
   * Hotot
 
 Depending on the features of the client you might encounter some glitches in usability, like being limited in the length of your postings to 140 characters and having no access to the [permission settings](help/Groups-and-Privacy).
-
-<a name="schemesharing"></a>
-
-### How can I share my color scheme with others?
-
-If you created a color scheme you want to share it with others, you can do this easily by sharing the schemestring.
-
-You can find this string within the `custom theme settings` of the [display settings](/settings/display) page. This input box is only available when custom color scheme is selected.
-
-
-<a name="schemesharingpaste"></a>
-
-### How can I apply a color scheme shared by others?
-People who want to apply a color scheme shared by others can paste the string in the schemestring box on `custom theme settings` of the [display settings](/settings/display) page and click `submit`. 
 
 <a name="help"></a>
 

--- a/view/theme/frio/config.php
+++ b/view/theme/frio/config.php
@@ -57,7 +57,7 @@ function theme_content(App $a)
 	$arr = [];
 
 	$arr['scheme']           = PConfig::get(local_user(), 'frio', 'scheme', PConfig::get(local_user(), 'frio', 'schema'));
-    $arr['share_string']     = '';
+	$arr['share_string']     = '';
 	$arr['nav_bg']           = PConfig::get(local_user(), 'frio', 'nav_bg');
 	$arr['nav_icon_color']   = PConfig::get(local_user(), 'frio', 'nav_icon_color');
 	$arr['link_color']       = PConfig::get(local_user(), 'frio', 'link_color');

--- a/view/theme/frio/config.php
+++ b/view/theme/frio/config.php
@@ -57,6 +57,7 @@ function theme_content(App $a)
 	$arr = [];
 
 	$arr['scheme']           = PConfig::get(local_user(), 'frio', 'scheme', PConfig::get(local_user(), 'frio', 'schema'));
+    $arr['share_string']     = '';
 	$arr['nav_bg']           = PConfig::get(local_user(), 'frio', 'nav_bg');
 	$arr['nav_icon_color']   = PConfig::get(local_user(), 'frio', 'nav_icon_color');
 	$arr['link_color']       = PConfig::get(local_user(), 'frio', 'link_color');
@@ -76,6 +77,7 @@ function theme_admin(App $a)
 	$arr = [];
 
 	$arr['scheme']           = Config::get('frio', 'scheme', Config::get('frio', 'scheme'));
+	$arr['share_string']     = '';
 	$arr['nav_bg']           = Config::get('frio', 'nav_bg');
 	$arr['nav_icon_color']   = Config::get('frio', 'nav_icon_color');
 	$arr['link_color']       = Config::get('frio', 'link_color');
@@ -120,6 +122,7 @@ function frio_form($arr)
 		'$baseurl'          => System::baseUrl(),
 		'$title'            => L10n::t('Theme settings'),
 		'$scheme'           => ['frio_scheme', L10n::t('Select color scheme'), $arr['scheme'], '', $scheme_choices],
+		'$share_string'     => ['frio_share_string', L10n::t('Copy or paste schemestring'), $arr['share_string'], L10n::t('You can copy this string to share your theme with others. Pasting here applies the schemestring'), false, false],
 		'$nav_bg'           => array_key_exists('nav_bg', $disable) ? '' : ['frio_nav_bg', L10n::t('Navigation bar background color'), $arr['nav_bg'], '', false],
 		'$nav_icon_color'   => array_key_exists('nav_icon_color', $disable) ? '' : ['frio_nav_icon_color', L10n::t('Navigation bar icon color '), $arr['nav_icon_color'], '', false],
 		'$link_color'       => array_key_exists('link_color', $disable) ? '' : ['frio_link_color', L10n::t('Link color'), $arr['link_color'], '', false],

--- a/view/theme/frio/templates/theme_settings.tpl
+++ b/view/theme/frio/templates/theme_settings.tpl
@@ -38,18 +38,46 @@
 <script type="text/javascript">
 	$(document).ready(function() {
 
-	    // Parse initial share_string
-	    var nav_bg = $("#id_frio_nav_bg").val();
-	    var nav_icon_color = $("#id_frio_nav_icon_color").val();
-	    var link_color = $("#id_frio_link_color").val();
-	    var background_color = $("#id_frio_background_color").val();
-	    var contentbg_transp = $("#frio_contentbg_transp").val();
-	    var background_image = $("#id_frio_background_image").val();
+		function GenerateShareString() {
+			var theme = {};
+			// Parse initial share_string
+			if ($("#id_frio_nav_bg").length) {
+				theme.nav_bg = $("#id_frio_nav_bg").val();
+			}
 
-	    var share_string = "{nav_bg: '" + nav_bg + "', nav_icon_color: '" + nav_icon_color + "', link_color: '" + link_color + "',  background_color: '" + background_color + "', contentbg_transp: '" + contentbg_transp + "', background_image: '" + background_image + "'}";
-        $("#id_frio_share_string").val(share_string);
+			if ($("#id_frio_nav_icon_color").length) {
+				theme.nav_icon_color = $("#id_frio_nav_icon_color").val();
+			}
 
-	    // Create colorpickers
+			if ($("#id_frio_link_color").length) {
+				theme.link_color = $("#id_frio_link_color").val();
+			}
+
+			if ($("#id_frio_background_color").length) {
+				theme.background_color = $("#id_frio_background_color").val();
+			}
+
+			if ($("#frio_contentbg_transp").length) {
+				theme.contentbg_transp = $("#frio_contentbg_transp").val();
+			}
+
+			if ($("#id_frio_login_bg_image").length) {
+				theme.login_bg_image = $("#id_frio_login_bg_image").val();
+			}
+
+			if ($("#id_frio_login_bg_color").length) {
+				theme.login_bg_color = $("#id_frio_login_bg_color").val();
+			}
+
+			var share_string = JSON.stringify(theme);
+			$("#id_frio_share_string").val(share_string);
+		}
+
+		// interval because jquery.val does not trigger events
+		window.setInterval(GenerateShareString, 500);
+		GenerateShareString();
+
+		// Create colorpickers
 		$("#frio_nav_bg, #frio_nav_icon_color, #frio_background_color, #frio_link_color, #frio_login_bg_color").colorpicker({format: 'hex', align: 'left'});
 
 		// show image options when user user starts to type the address of the image
@@ -94,5 +122,5 @@
 <div class="clearfix"></div>
 
 <script type="text/javascript">
-    $(".inputRange").rangeinput();
+	$(".inputRange").rangeinput();
 </script>

--- a/view/theme/frio/templates/theme_settings.tpl
+++ b/view/theme/frio/templates/theme_settings.tpl
@@ -6,6 +6,7 @@
 
 {{include file="field_select.tpl" field=$scheme}}
 
+{{if $nav_bg}}{{include file="field_input.tpl" field=$share_string}}{{/if}}
 {{if $nav_bg}}{{include file="field_colorinput.tpl" field=$nav_bg}}{{/if}}
 {{if $nav_icon_color}}{{include file="field_colorinput.tpl" field=$nav_icon_color}}{{/if}}
 {{if $link_color}}{{include file="field_colorinput.tpl" field=$link_color}}{{/if}}

--- a/view/theme/frio/templates/theme_settings.tpl
+++ b/view/theme/frio/templates/theme_settings.tpl
@@ -77,6 +77,37 @@
 		window.setInterval(GenerateShareString, 500);
 		GenerateShareString();
 
+		$(document).on("keyup", "#id_frio_share_string", function() {
+			theme = JSON.parse($("#id_frio_share_string").val());
+
+			if ($("#id_frio_nav_bg").length) {
+				$("#id_frio_nav_bg").val(theme.nav_bg);
+			}
+
+			if ($("#id_frio_nav_icon_color").length) {
+				$("#id_frio_nav_icon_color").val(theme.nav_icon_color);
+			}
+
+			if ($("#id_frio_link_color").length) {
+				 $("#id_frio_link_color").val(theme.link_color);
+			}
+
+			if ($("#id_frio_background_color").length) {
+				$("#id_frio_background_color").val(theme.background_color);
+			}
+
+			if ($("#frio_contentbg_transp").length) {
+				$("#frio_contentbg_transp").val(theme.contentbg_transp);
+			}
+
+			if ($("#id_frio_login_bg_image").length) {
+				$("#id_frio_login_bg_image").val(theme.login_bg_image);
+			}
+
+			if ($("#id_frio_login_bg_color").length) {
+				$("#id_frio_login_bg_color").val(theme.login_bg_color);
+			}
+		});
 		// Create colorpickers
 		$("#frio_nav_bg, #frio_nav_icon_color, #frio_background_color, #frio_link_color, #frio_login_bg_color").colorpicker({format: 'hex', align: 'left'});
 

--- a/view/theme/frio/templates/theme_settings.tpl
+++ b/view/theme/frio/templates/theme_settings.tpl
@@ -87,9 +87,10 @@
 			if ($("#id_frio_login_bg_color").length) {
 				theme.login_bg_color = $("#id_frio_login_bg_color").val();
 			}
-
-			var share_string = JSON.stringify(theme);
-			$("#id_frio_share_string").val(share_string);
+			if (!($("#id_frio_share_string").is(":focus"))){
+				var share_string = JSON.stringify(theme);
+				$("#id_frio_share_string").val(share_string);
+			}
 		}
 
 		// interval because jquery.val does not trigger events

--- a/view/theme/frio/templates/theme_settings.tpl
+++ b/view/theme/frio/templates/theme_settings.tpl
@@ -57,6 +57,25 @@
 				theme.background_color = $("#id_frio_background_color").val();
 			}
 
+			if ($("#id_frio_background_image").length) {
+				theme.background_image = $("#id_frio_background_image").val();
+
+				var elText = theme.background_image;
+
+				if ($("#id_frio_bg_image_option_stretch").is(":checked") == true) {
+				    theme.background_image_option = "stretch";
+				}
+				if ($("#id_frio_bg_image_option_cover").is(":checked") == true) {
+				    theme.background_image_option = "cover";
+				}
+				if ($("#id_frio_bg_image_option_contain").is(":checked") == true) {
+				    theme.background_image_option = "contain";
+				}
+				if ($("#id_frio_bg_image_option_repeat").is(":checked") == true) {
+				    theme.background_image_option = "repeat";
+				}
+			}
+
 			if ($("#frio_contentbg_transp").length) {
 				theme.contentbg_transp = $("#frio_contentbg_transp").val();
 			}
@@ -94,6 +113,31 @@
 
 			if ($("#id_frio_background_color").length) {
 				$("#id_frio_background_color").val(theme.background_color);
+			}
+
+			if ($("#id_frio_background_image").length) {
+				$("#id_frio_background_image").val(theme.background_image);
+				var elText = theme.background_image;
+				if(elText.length !== 0) {
+					$("#frio_bg_image_options").show();
+			    } else {
+				    $("#frio_bg_image_options").hide();
+			    }
+
+				switch (theme.background_image_option) {
+				    case 'stretch':
+				        $("#id_frio_bg_image_option_stretch").prop("checked", true);
+				        break;
+				    case 'cover':
+				        $("#id_frio_bg_image_option_cover").prop("checked", true);
+				        break;
+				    case 'contain':
+				        $("#id_frio_bg_image_option_contain").prop("checked", true);
+				        break;
+				    case 'repeat':
+				        $("#id_frio_bg_image_option_repeat").prop("checked", true);
+				        break;
+				}
 			}
 
 			if ($("#frio_contentbg_transp").length) {

--- a/view/theme/frio/templates/theme_settings.tpl
+++ b/view/theme/frio/templates/theme_settings.tpl
@@ -43,7 +43,7 @@
 	    var nav_icon_color = $("#id_frio_nav_icon_color").val();
 	    var link_color = $("#id_frio_link_color").val();
 	    var background_color = $("#id_frio_background_color").val();
-	    var contentbg_transp = $("#id_frio_contentbg_transp").val();
+	    var contentbg_transp = $("#frio_contentbg_transp").val();
 	    var background_image = $("#id_frio_background_image").val();
 
 	    var share_string = "{nav_bg: '" + nav_bg + "', nav_icon_color: '" + nav_icon_color + "', link_color: '" + link_color + "',  background_color: '" + background_color + "', contentbg_transp: '" + contentbg_transp + "', background_image: '" + background_image + "'}";

--- a/view/theme/frio/templates/theme_settings.tpl
+++ b/view/theme/frio/templates/theme_settings.tpl
@@ -96,6 +96,7 @@
 		window.setInterval(GenerateShareString, 500);
 		GenerateShareString();
 
+		// Take advantage of the effects of previous comment
 		$(document).on("keyup", "#id_frio_share_string", function() {
 			theme = JSON.parse($("#id_frio_share_string").val());
 

--- a/view/theme/frio/templates/theme_settings.tpl
+++ b/view/theme/frio/templates/theme_settings.tpl
@@ -37,6 +37,19 @@
 
 <script type="text/javascript">
 	$(document).ready(function() {
+
+	    // Parse initial share_string
+	    var nav_bg = $("#id_frio_nav_bg").val();
+	    var nav_icon_color = $("#id_frio_nav_icon_color").val();
+	    var link_color = $("#id_frio_link_color").val();
+	    var background_color = $("#id_frio_background_color").val();
+	    var contentbg_transp = $("#id_frio_contentbg_transp").val();
+	    var background_image = $("#id_frio_background_image").val();
+
+	    var share_string = "{nav_bg: '" + nav_bg + "', nav_icon_color: '" + nav_icon_color + "', link_color: '" + link_color + "',  background_color: '" + background_color + "', contentbg_transp: '" + contentbg_transp + "', background_image: '" + background_image + "'}";
+        $("#id_frio_share_string").val(share_string);
+
+	    // Create colorpickers
 		$("#frio_nav_bg, #frio_nav_icon_color, #frio_background_color, #frio_link_color, #frio_login_bg_color").colorpicker({format: 'hex', align: 'left'});
 
 		// show image options when user user starts to type the address of the image

--- a/view/theme/frio/templates/theme_settings.tpl
+++ b/view/theme/frio/templates/theme_settings.tpl
@@ -60,20 +60,20 @@
 			if ($("#id_frio_background_image").length) {
 				theme.background_image = $("#id_frio_background_image").val();
 
-				var elText = theme.background_image;
-
-				if ($("#id_frio_bg_image_option_stretch").is(":checked") == true) {
-				    theme.background_image_option = "stretch";
-				}
-				if ($("#id_frio_bg_image_option_cover").is(":checked") == true) {
-				    theme.background_image_option = "cover";
-				}
-				if ($("#id_frio_bg_image_option_contain").is(":checked") == true) {
-				    theme.background_image_option = "contain";
-				}
-				if ($("#id_frio_bg_image_option_repeat").is(":checked") == true) {
-				    theme.background_image_option = "repeat";
-				}
+				if (theme.background_image.length > 0) {
+					if ($("#id_frio_bg_image_option_stretch").is(":checked") == true) {
+						theme.background_image_option = "stretch";
+					}
+					if ($("#id_frio_bg_image_option_cover").is(":checked") == true) {
+						theme.background_image_option = "cover";
+					}
+					if ($("#id_frio_bg_image_option_contain").is(":checked") == true) {
+						theme.background_image_option = "contain";
+					}
+					if ($("#id_frio_bg_image_option_repeat").is(":checked") == true) {
+						theme.background_image_option = "repeat";
+					}
+				 }
 			}
 
 			if ($("#frio_contentbg_transp").length) {
@@ -121,23 +121,23 @@
 				var elText = theme.background_image;
 				if(elText.length !== 0) {
 					$("#frio_bg_image_options").show();
-			    } else {
-				    $("#frio_bg_image_options").hide();
-			    }
+				} else {
+					$("#frio_bg_image_options").hide();
+				}
 
 				switch (theme.background_image_option) {
-				    case 'stretch':
-				        $("#id_frio_bg_image_option_stretch").prop("checked", true);
-				        break;
-				    case 'cover':
-				        $("#id_frio_bg_image_option_cover").prop("checked", true);
-				        break;
-				    case 'contain':
-				        $("#id_frio_bg_image_option_contain").prop("checked", true);
-				        break;
-				    case 'repeat':
-				        $("#id_frio_bg_image_option_repeat").prop("checked", true);
-				        break;
+					case 'stretch':
+						$("#id_frio_bg_image_option_stretch").prop("checked", true);
+						break;
+					case 'cover':
+						$("#id_frio_bg_image_option_cover").prop("checked", true);
+						break;
+					case 'contain':
+						$("#id_frio_bg_image_option_contain").prop("checked", true);
+						break;
+					case 'repeat':
+						$("#id_frio_bg_image_option_repeat").prop("checked", true);
+						break;
 				}
 			}
 


### PR DESCRIPTION
Closes #6574 

I know I'm a little too late for the new release but I finalized it anyway.

The sharestring is a json encoded object containing all editable fields of the frio theme.
For the fields only available to the admin the fields are there as well so admins can share their themes between each other. Moreover, a admin-shared theme (with login background) can be applied by a normal user who will only apply their editable fields.

Have fun sharing themes :)