### PR TITLE
Ensure that the database update will be processed anyway

### DIFF
--- a/src/Core/Update.php
+++ b/src/Core/Update.php
@@ -36,11 +36,10 @@ class Update
 			die('You try to update from a version prior to database version 1170. The direct upgrade path is not supported. Please update to version 3.5.4 before updating to this version.');
 		}
 
-		if ($build < DB_UPDATE_VERSION) {
-			// When we cannot execute the database update via the worker, we will do it directly
-			if (!Worker::add(PRIORITY_CRITICAL, 'DBUpdate') && $via_worker) {
-				self::run($basePath);
-			}
+		// Calling the database update directly via the worker enables us to perform database changes to the workerqueue table itself.
+		// This is a fallback, since normally the database update will be performed by a worker job (which doesn't work for changes to the "workerqueue" table itself).
+		if (($build < DB_UPDATE_VERSION) && $via_worker) {
+			self::run($basePath);
 		}
 	}
 

--- a/src/Core/Update.php
+++ b/src/Core/Update.php
@@ -36,10 +36,15 @@ class Update
 			die('You try to update from a version prior to database version 1170. The direct upgrade path is not supported. Please update to version 3.5.4 before updating to this version.');
 		}
 
-		// Calling the database update directly via the worker enables us to perform database changes to the workerqueue table itself.
-		// This is a fallback, since normally the database update will be performed by a worker job (which doesn't work for changes to the "workerqueue" table itself).
-		if (($build < DB_UPDATE_VERSION) && $via_worker) {
-			self::run($basePath);
+		if ($build < DB_UPDATE_VERSION) {
+			if ($via_worker) {
+				// Calling the database update directly via the worker enables us to perform database changes to the workerqueue table itself.
+				// This is a fallback, since normally the database update will be performed by a worker job.
+				// This worker job doesn't work for changes to the "workerqueue" table itself.
+				self::run($basePath);
+			} else {
+				Worker::add(PRIORITY_CRITICAL, 'DBUpdate');
+			}
 		}
 	}
 


### PR DESCRIPTION
In the last version we had the problem that we changed the structure of the workerqueue table that is responsible for the tasks. But since the database update had to be done via these tasks as well, this hadn't worked out well.

We already had some check for a similar situation, but it hadn't covered this specific situation. Now we simply execute it directly whenever it had been executed via a worker call. In other case we stay with initiating a worker queue task.