### PR TITLE
Replace string namespace with *::class

### DIFF
--- a/src/Factory/LoggerFactory.php
+++ b/src/Factory/LoggerFactory.php
@@ -157,12 +157,6 @@ class LoggerFactory
 				$loglevel = LogLevel::NOTICE;
 			}
 
-			// if the stream is a file and it isn't writeable, add a null handler and return
-			if (is_file($stream) && !is_writable($stream)) {
-				$logger->pushHandler(new Monolog\Handler\NullHandler());
-				return;
-			}
-
 			$fileHandler = new Monolog\Handler\StreamHandler($stream, $loglevel);
 
 			$formatter = new Monolog\Formatter\LineFormatter("%datetime% %channel% [%level_name%]: %message% %context% %extra%\n");

--- a/src/Factory/ProfilerFactory.php
+++ b/src/Factory/ProfilerFactory.php
@@ -17,9 +17,9 @@ class ProfilerFactory
 	public static function create(IConfigCache $configCache)
 	{
 		$enabled = $configCache->get('system', 'profiler');
-		$enabled = isset($enabled) && $enabled !== '!<unset>!';
+		$enabled = isset($enabled) && $enabled !== '0';
 		$renderTime = $configCache->get('rendertime', 'callstack');
-		$renderTime = isset($renderTime) && $renderTime !== '!<unset>!';
+		$renderTime = isset($renderTime) && $renderTime !== '0';
 
 		return new Profiler($enabled, $renderTime);
 	}

--- a/tests/Util/DBAMockTrait.php
+++ b/tests/Util/DBAMockTrait.php
@@ -2,6 +2,7 @@
 
 namespace Friendica\Test\Util;
 
+use Friendica\Database\DBA;
 use Mockery\MockInterface;
 
 class DBAStub
@@ -22,7 +23,7 @@ trait DBAMockTrait
 	private function checkMock()
 	{
 		if (!isset($this->dbaMock)) {
-			$this->dbaMock = \Mockery::namedMock('Friendica\Database\DBA', 'Friendica\Test\Util\DBAStub');
+			$this->dbaMock = \Mockery::namedMock(DBA::class, DBAStub::class);
 		}
 	}
 

--- a/tests/Util/DBStructureMockTrait.php
+++ b/tests/Util/DBStructureMockTrait.php
@@ -26,7 +26,7 @@ trait DBStructureMockTrait
 	public function mockUpdate($args = [], $return = true, $times = null)
 	{
 		if (!isset($this->dbStructure)) {
-			$this->dbStructure = \Mockery::mock('alias:Friendica\Database\DBStructure');
+			$this->dbStructure = \Mockery::mock('alias:' . DBStructure::class);
 		}
 
 		$this->dbStructure
@@ -46,7 +46,7 @@ trait DBStructureMockTrait
 	public function mockExistsTable($tableName, $return = true, $times = null)
 	{
 		if (!isset($this->dbStructure)) {
-			$this->dbStructure = \Mockery::mock('alias:Friendica\Database\DBStructure');
+			$this->dbStructure = \Mockery::mock('alias:' . DBStructure::class);
 		}
 
 		$this->dbStructure

--- a/tests/Util/DateTimeFormatMockTrait.php
+++ b/tests/Util/DateTimeFormatMockTrait.php
@@ -2,6 +2,7 @@
 
 namespace Friendica\Test\Util;
 
+use Friendica\Util\DateTimeFormat;
 use Mockery\MockInterface;
 
 trait DateTimeFormatMockTrait
@@ -14,7 +15,7 @@ trait DateTimeFormatMockTrait
 	public function mockUtcNow($time, $times = null)
 	{
 		if (!isset($this->dtfMock)) {
-			$this->dtfMock = \Mockery::mock('alias:Friendica\Util\DateTimeFormat');
+			$this->dtfMock = \Mockery::mock('alias:'. DateTimeFormat::class);
 		}
 
 		$this->dtfMock
@@ -26,7 +27,7 @@ trait DateTimeFormatMockTrait
 	public function mockUtc($input, $time, $times = null)
 	{
 		if (!isset($this->dtfMock)) {
-			$this->dtfMock = \Mockery::mock('alias:Friendica\Util\DateTimeFormat');
+			$this->dtfMock = \Mockery::mock('alias:' . DateTimeFormat::class);
 		}
 
 		$this->dtfMock

--- a/tests/Util/L10nMockTrait.php
+++ b/tests/Util/L10nMockTrait.php
@@ -2,6 +2,7 @@
 
 namespace Friendica\Test\Util;
 
+use Friendica\Core\L10n;
 use Mockery\MockInterface;
 
 trait L10nMockTrait
@@ -21,7 +22,7 @@ trait L10nMockTrait
 	public function mockL10nT($input = null, $times = null, $return = null)
 	{
 		if (!isset($this->l10nMock)) {
-			$this->l10nMock = \Mockery::mock('alias:Friendica\Core\L10n');
+			$this->l10nMock = \Mockery::mock('alias:' . L10n::class);
 		}
 
 		$with = isset($input) ? $input : \Mockery::any();

--- a/tests/Util/RendererMockTrait.php
+++ b/tests/Util/RendererMockTrait.php
@@ -2,6 +2,7 @@
 
 namespace Friendica\Test\Util;
 
+use Friendica\Core\Renderer;
 use Mockery\MockInterface;
 
 trait RendererMockTrait
@@ -21,7 +22,7 @@ trait RendererMockTrait
 	public function mockGetMarkupTemplate($templateName, $return = '', $times = null)
 	{
 		if (!isset($this->rendererMock)) {
-			$this->rendererMock = \Mockery::mock('alias:Friendica\Core\Renderer');
+			$this->rendererMock = \Mockery::mock('alias:' . Renderer::class);
 		}
 
 		$this->rendererMock
@@ -42,7 +43,7 @@ trait RendererMockTrait
 	public function mockReplaceMacros($template, $args = [], $return = '', $times = null)
 	{
 		if (!isset($this->rendererMock)) {
-			$this->rendererMock = \Mockery::mock('alias:Friendica\Core\Renderer');
+			$this->rendererMock = \Mockery::mock('alias:' . Renderer::class);
 		}
 
 		$this->rendererMock

--- a/tests/src/Core/Console/ConfigConsoleTest.php
+++ b/tests/src/Core/Console/ConfigConsoleTest.php
@@ -2,6 +2,7 @@
 
 namespace Friendica\Test\src\Core\Console;
 
+use Friendica\App\Mode;
 use Friendica\Core\Console\Config;
 
 /**
@@ -16,12 +17,12 @@ class ConfigConsoleTest extends ConsoleTest
 		parent::setUp();
 
 		\Mockery::getConfiguration()->setConstantsMap([
-			'Friendica\App\Mode' => [
+			Mode::class => [
 				'DBCONFIGAVAILABLE' => 0
 			]
 		]);
 
-		$mode = \Mockery::mock('Friendica\App\Mode');
+		$mode = \Mockery::mock(Mode::class);
 		$mode
 			->shouldReceive('has')
 			->andReturn(true);

--- a/tests/src/Core/InstallerTest.php
+++ b/tests/src/Core/InstallerTest.php
@@ -3,9 +3,12 @@
 // this is in the same namespace as Install for mocking 'function_exists'
 namespace Friendica\Core;
 
+use Friendica\Network\CurlResult;
+use Friendica\Object\Image;
 use Friendica\Test\MockedTest;
 use Friendica\Test\Util\L10nMockTrait;
 use Friendica\Test\Util\VFSTrait;
+use Friendica\Util\Network;
 
 /**
  * @runTestsInSeparateProcesses
@@ -248,7 +251,7 @@ class InstallerTest extends MockedTest
 		$this->mockL10nT();
 
 		// Mocking the CURL Response
-		$curlResult = \Mockery::mock('Friendica\Network\CurlResult');
+		$curlResult = \Mockery::mock(CurlResult::class);
 		$curlResult
 			->shouldReceive('getReturnCode')
 			->andReturn('404');
@@ -260,7 +263,7 @@ class InstallerTest extends MockedTest
 			->andReturn('test Error');
 
 		// Mocking the CURL Request
-		$networkMock = \Mockery::mock('alias:Friendica\Util\Network');
+		$networkMock = \Mockery::mock('alias:' . Network::class);
 		$networkMock
 			->shouldReceive('fetchUrlFull')
 			->with('https://test/install/testrewrite')
@@ -287,19 +290,19 @@ class InstallerTest extends MockedTest
 		$this->mockL10nT();
 
 		// Mocking the failed CURL Response
-		$curlResultF = \Mockery::mock('Friendica\Network\CurlResult');
+		$curlResultF = \Mockery::mock(CurlResult::class);
 		$curlResultF
 			->shouldReceive('getReturnCode')
 			->andReturn('404');
 
 		// Mocking the working CURL Response
-		$curlResultW = \Mockery::mock('Friendica\Network\CurlResult');
+		$curlResultW = \Mockery::mock(CurlResult::class);
 		$curlResultW
 			->shouldReceive('getReturnCode')
 			->andReturn('204');
 
 		// Mocking the CURL Request
-		$networkMock = \Mockery::mock('alias:Friendica\Util\Network');
+		$networkMock = \Mockery::mock('alias:' . Network::class);
 		$networkMock
 			->shouldReceive('fetchUrlFull')
 			->with('https://test/install/testrewrite')
@@ -327,7 +330,7 @@ class InstallerTest extends MockedTest
 	{
 		$this->mockL10nT();
 
-		$imageMock = \Mockery::mock('alias:Friendica\Object\Image');
+		$imageMock = \Mockery::mock('alias:'. Image::class);
 		$imageMock
 			->shouldReceive('supportedTypes')
 			->andReturn(['image/gif' => 'gif']);
@@ -354,7 +357,7 @@ class InstallerTest extends MockedTest
 	{
 		$this->mockL10nT();
 
-		$imageMock = \Mockery::mock('alias:Friendica\Object\Image');
+		$imageMock = \Mockery::mock('alias:' . Image::class);
 		$imageMock
 			->shouldReceive('supportedTypes')
 			->andReturn([]);

--- a/tests/src/Util/Logger/WorkerLoggerTest.php
+++ b/tests/src/Util/Logger/WorkerLoggerTest.php
@@ -4,6 +4,7 @@ namespace src\Util\Logger;
 
 use Friendica\Test\MockedTest;
 use Friendica\Util\Logger\WorkerLogger;
+use Psr\Log\LoggerInterface;
 
 class WorkerLoggerTest extends MockedTest
 {
@@ -18,7 +19,7 @@ class WorkerLoggerTest extends MockedTest
 	 */
 	public function testGetWorkerIdZero()
 	{
-		$logger = \Mockery::mock('Psr\Log\LoggerInterface');
+		$logger = \Mockery::mock(LoggerInterface::class);
 		$logger
 			->shouldReceive('alert')
 			->with('id length must be greater than 0.')
@@ -31,7 +32,7 @@ class WorkerLoggerTest extends MockedTest
 	 */
 	public function testGetWorkerId()
 	{
-		$logger = \Mockery::mock('Psr\Log\LoggerInterface');
+		$logger = \Mockery::mock(LoggerInterface::class);
 		for ($i = 1; $i < 14; $i++) {
 			$workLogger = new WorkerLogger($logger, 'test', $i);
 			$uid = $workLogger->getWorkerId();
@@ -86,7 +87,7 @@ class WorkerLoggerTest extends MockedTest
 	 */
 	public function testEmergency($func, $msg, $context = [])
 	{
-		$logger = \Mockery::mock('Psr\Log\LoggerInterface');
+		$logger = \Mockery::mock(LoggerInterface::class);
 		$workLogger = new WorkerLogger($logger, 'test');
 		$testContext = $context;
 		$testContext['worker_id'] = $workLogger->getWorkerId();
@@ -104,7 +105,7 @@ class WorkerLoggerTest extends MockedTest
 	 */
 	public function testLog()
 	{
-		$logger = \Mockery::mock('Psr\Log\LoggerInterface');
+		$logger = \Mockery::mock(LoggerInterface::class);
 		$workLogger = new WorkerLogger($logger, 'test');
 		$context = $testContext = ['test' => 'it'];
 		$testContext['worker_id'] = $workLogger->getWorkerId();

--- a/tests/src/Util/ProfilerTest.php
+++ b/tests/src/Util/ProfilerTest.php
@@ -18,7 +18,7 @@ class ProfilerTest extends MockedTest
 	{
 		parent::setUp();
 
-		$this->logger = \Mockery::mock('Psr\Log\LoggerInterface');
+		$this->logger = \Mockery::mock(LoggerInterface::class);
 	}
 
 	/**


### PR DESCRIPTION
To avoid problems when changing namespaces of classes, I'm now using `*::class` constants, so the namespace will automatically change.

-> And I fixed two minor bugs