### PR TITLE
Fixing frio theme customization for admin

### DIFF
--- a/view/theme/frio/php/scheme.php
+++ b/view/theme/frio/php/scheme.php
@@ -24,7 +24,7 @@ function get_scheme_info($scheme)
 {
 	$theme = \get_app()->getCurrentTheme();
 	$themepath = 'view/theme/' . $theme . '/';
-	if (!isset($scheme)) {
+	if (empty($scheme)) {
 		$scheme = PConfig::get(local_user(), 'frio', 'scheme', PConfig::get(local_user(), 'frio', 'scheme'));
 	}
 

--- a/view/theme/frio/php/scheme.php
+++ b/view/theme/frio/php/scheme.php
@@ -17,13 +17,16 @@
  *    'version' => Scheme version
  *    'overwrites' => Variables which overwriting custom settings
  */
+
 use Friendica\Core\PConfig;
 
 function get_scheme_info($scheme)
 {
 	$theme = \get_app()->getCurrentTheme();
 	$themepath = 'view/theme/' . $theme . '/';
-	$scheme = PConfig::get(local_user(), 'frio', 'scheme', PConfig::get(local_user(), 'frio', 'scheme'));
+	if (!isset($scheme)) {
+		$scheme = PConfig::get(local_user(), 'frio', 'scheme', PConfig::get(local_user(), 'frio', 'scheme'));
+	}
 
 	$info = [
 		'name' => $scheme,


### PR DESCRIPTION
Fixing #6677 

The problem was that the scheme information of the admin session wasn't used. Instead the `PConfig::get()` was called, which retrieved the admin user settings again.