### PR TITLE
fixing links in photoMenu

### DIFF
--- a/include/conversation.php
+++ b/include/conversation.php
@@ -850,7 +850,7 @@ function item_photo_menu($item) {
 
 	$author = ['uid' => 0, 'id' => $item['author-id'],
 		'network' => $item['author-network'], 'url' => $item['author-link']];
-	$profile_link = Contact::magicLinkByContact($author);
+	$profile_link = Contact::magicLinkByContact($author, $item['author-link']);
 	$sparkle = (strpos($profile_link, 'redir/') === 0);
 
 	$cid = 0;
@@ -865,9 +865,9 @@ function item_photo_menu($item) {
 	}
 
 	if ($sparkle) {
-		$status_link = $profile_link . '?url=status';
-		$photos_link = $profile_link . '?url=photos';
-		$profile_link = $profile_link . '?url=profile';
+		$status_link = $profile_link . '?tab=status';
+		$photos_link = str_replace('/profile/', '/photos/', $profile_link);
+		$profile_link = $profile_link . '?=profile';
 	}
 
 	if ($cid && !$item['self']) {

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -1006,7 +1006,7 @@ class Contact extends BaseObject
 		$sparkle = false;
 		if (($contact['network'] === Protocol::DFRN) && !$contact['self']) {
 			$sparkle = true;
-			$profile_link = System::baseUrl() . '/redir/' . $contact['id'];
+			$profile_link = System::baseUrl() . '/redir/' . $contact['id'] . '?url=' . $contact['url'];
 		} else {
 			$profile_link = $contact['url'];
 		}
@@ -1016,9 +1016,9 @@ class Contact extends BaseObject
 		}
 
 		if ($sparkle) {
-			$status_link = $profile_link . '?url=status';
-			$photos_link = $profile_link . '?url=photos';
-			$profile_link = $profile_link . '?url=profile';
+			$status_link = $profile_link . '?tab=status';
+			$photos_link = str_replace('/profile/', '/photos/', $profile_link);
+			$profile_link = $profile_link . '?tab=profile';
 		}
 
 		if (in_array($contact['network'], [Protocol::DFRN, Protocol::DIASPORA]) && !$contact['self']) {


### PR DESCRIPTION
This PR adds the missing `hfef` argument to the `?url` argument of links in the photo menu for Friendica contacts.

Tested with duepunto, quattro and vier themes. Frio does not seem to use these links to the subpages of the contacts profile?

potentially a fix for #6532 