### PR TITLE
Hide silenced authors from public timeline

### DIFF
--- a/include/api.php
+++ b/include/api.php
@@ -1738,7 +1738,7 @@ function api_statuses_public_timeline($type)
 	$start = $page * $count;
 
 	if ($exclude_replies && !$conversation_id) {
-		$condition = ["`gravity` IN (?, ?) AND `iid` > ? AND NOT `private` AND `wall` AND NOT `user`.`hidewall`",
+		$condition = ["`gravity` IN (?, ?) AND `iid` > ? AND NOT `private` AND `wall` AND NOT `user`.`hidewall` AND NOT `author`.`hidden`",
 			GRAVITY_PARENT, GRAVITY_COMMENT, $since_id];
 
 		if ($max_id > 0) {
@@ -1751,7 +1751,7 @@ function api_statuses_public_timeline($type)
 
 		$r = Item::inArray($statuses);
 	} else {
-		$condition = ["`gravity` IN (?, ?) AND `id` > ? AND NOT `private` AND `wall` AND NOT `user`.`hidewall` AND `item`.`origin`",
+		$condition = ["`gravity` IN (?, ?) AND `id` > ? AND NOT `private` AND `wall` AND NOT `user`.`hidewall` AND `item`.`origin` AND NOT `author`.`hidden`",
 			GRAVITY_PARENT, GRAVITY_COMMENT, $since_id];
 
 		if ($max_id > 0) {


### PR DESCRIPTION
This should fix #6672 

I took the additional condition from
https://github.com/friendica/friendica/blob/caf60cae966b2b35819a55c9041fa22ef023c413/include/conversation.php#L823-L825
where @alfredsk said that it works

@annando please have a look if I did it right, because I reverse engineered some parts of `Item` for myself to fully understand why/where it works (=> `Item::constructJoins()` ).