### PR TITLE
Fix namespaces for Tests

### DIFF
--- a/tests/src/BaseObjectTest.php
+++ b/tests/src/BaseObjectTest.php
@@ -3,7 +3,7 @@
  * BaseObjectTest class.
  */
 
-namespace Friendica\Test;
+namespace Friendica\Test\src;
 
 use Friendica\BaseObject;
 use Friendica\Test\Util\AppMockTrait;

--- a/tests/src/Core/Config/Cache/ConfigCacheLoaderTest.php
+++ b/tests/src/Core/Config/Cache/ConfigCacheLoaderTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Friendica\Test\Core\Config\Cache;
+namespace Friendica\Test\src\Core\Config\Cache;
 
 use Friendica\Core\Config\Cache\ConfigCache;
 use Friendica\Core\Config\Cache\ConfigCacheLoader;

--- a/tests/src/Core/Config/Cache/ConfigCacheTest.php
+++ b/tests/src/Core/Config/Cache/ConfigCacheTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Friendica\Test\Core\Config\Cache;
+namespace Friendica\Test\src\Core\Config\Cache;
 
 use Friendica\Core\Config\Cache\ConfigCache;
 use Friendica\Test\MockedTest;

--- a/tests/src/Core/Config/ConfigurationTest.php
+++ b/tests/src/Core/Config/ConfigurationTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Friendica\Test\Core\Config;
+namespace Friendica\Test\src\Core\Config;
 
 use Friendica\Core\Config\Adapter\IConfigAdapter;
 use Friendica\Core\Config\Cache\ConfigCache;

--- a/tests/src/Core/Config/PConfigurationTest.php
+++ b/tests/src/Core/Config/PConfigurationTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Friendica\Test\Core\Config;
+namespace Friendica\Test\src\Core\Config;
 
 use Friendica\Core\Config\Adapter\IPConfigAdapter;
 use Friendica\Core\Config\Cache\ConfigCache;

--- a/tests/src/Database/DBATest.php
+++ b/tests/src/Database/DBATest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Friendica\Test\Database;
+namespace Friendica\Test\src\Database;
 
 use Friendica\App;
 use Friendica\Core\Config;

--- a/tests/src/Database/DBStructureTest.php
+++ b/tests/src/Database/DBStructureTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Friendica\Test\Database;
+namespace Friendica\Test\src\Database;
 
 use Friendica\App;
 use Friendica\Core\Config\Cache;

--- a/tests/src/Model/UserTest.php
+++ b/tests/src/Model/UserTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Friendica\Test\Model;
+namespace Friendica\Test\src\Model;
 
 use Friendica\Model\User;
 use Friendica\Test\MockedTest;

--- a/tests/src/Util/ArraysTest.php
+++ b/tests/src/Util/ArraysTest.php
@@ -3,7 +3,7 @@
  * @file tests/src/Util/Arrays.php
  * @author Roland Haeder<https://f.haeder.net/profile/roland>
  */
-namespace Friendica\Test\Util;
+namespace Friendica\Test\src\Util;
 
 use Friendica\Util\Arrays;
 use PHPUnit\Framework\TestCase;

--- a/tests/src/Util/Logger/WorkerLoggerTest.php
+++ b/tests/src/Util/Logger/WorkerLoggerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace src\Util\Logger;
+namespace Friendica\Test\src\Util\Logger;
 
 use Friendica\Test\MockedTest;
 use Friendica\Util\Logger\WorkerLogger;

--- a/tests/src/Util/ProfilerTest.php
+++ b/tests/src/Util/ProfilerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace src\Util;
+namespace Friendica\Test\src\Util;
 
 use Friendica\Test\MockedTest;
 use Friendica\Util\Profiler;

--- a/tests/src/Util/StringsTest.php
+++ b/tests/src/Util/StringsTest.php
@@ -2,7 +2,7 @@
 /**
  * @file tests/src/Util/StringsTest.php
  */
-namespace Friendica\Test\Util;
+namespace Friendica\Test\src\Util;
 
 use Friendica\Util\Strings;
 use PHPUnit\Framework\TestCase;

--- a/tests/src/Util/XmlTest.php
+++ b/tests/src/Util/XmlTest.php
@@ -2,7 +2,7 @@
 /**
  * @file tests/src/Util/XmlTest.php
  */
-namespace Friendica\Test\Util;
+namespace Friendica\Test\src\Util;
 
 use Friendica\Util\XML;
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
There were several wrong namespaces in the tests.
This is just a minor bug, but I had to solve this kind of issue during the creation of new tests.
=> Wrong namespaces leads to problems with the autoloader