### PR TITLE
Syslog Logger

### DIFF
--- a/config/defaults.config.php
+++ b/config/defaults.config.php
@@ -211,7 +211,7 @@ return [
 
 		// logger_adapter (String)
 		// Sets the logging adapter of Friendica globally (monolog, syslog)
-		'logger_adapter' => 'syslog',
+		'logger_adapter' => 'monolog',
 
 		// max_batch_queue (Integer)
 		// Maximum number of batched queue items for a single contact before subsequent messages are discarded.

--- a/config/defaults.config.php
+++ b/config/defaults.config.php
@@ -209,6 +209,10 @@ return [
 		// If activated, all hashtags will point to the local server.
 		'local_tags' => false,
 
+		// logger_adapter (String)
+		// Sets the logging adapter of Friendica globally (monolog, syslog)
+		'logger_adapter' => 'syslog',
+
 		// max_batch_queue (Integer)
 		// Maximum number of batched queue items for a single contact before subsequent messages are discarded.
 		'max_batch_queue' => 1000,

--- a/src/Util/Logger/Introspection.php
+++ b/src/Util/Logger/Introspection.php
@@ -69,8 +69,8 @@ class Introspection implements ProcessorInterface
 		$i += $this->skipStackFramesCount;
 
 		return [
-			'file' => isset($trace[$i - 1]['file']) ? basename($trace[$i - 1]['file']) : null,
-			'line' => isset($trace[$i - 1]['line']) ? $trace[$i - 1]['line'] : null,
+			'file'     => isset($trace[$i - 1]['file']) ? basename($trace[$i - 1]['file']) : null,
+			'line'     => isset($trace[$i - 1]['line']) ? $trace[$i - 1]['line'] : null,
 			'function' => isset($trace[$i]['function']) ? $trace[$i]['function'] : null,
 		];
 	}

--- a/src/Util/Logger/Introspection.php
+++ b/src/Util/Logger/Introspection.php
@@ -11,7 +11,7 @@ use Monolog\Processor\ProcessorInterface;
  * Based on the class IntrospectionProcessor without the "class" information
  * @see IntrospectionProcessor
  */
-class FriendicaIntrospectionProcessor implements ProcessorInterface
+class Introspection implements ProcessorInterface
 {
 	private $level;
 
@@ -42,7 +42,22 @@ class FriendicaIntrospectionProcessor implements ProcessorInterface
 		if ($record['level'] < $this->level) {
 			return $record;
 		}
+		// we should have the call source now
+		$record['extra'] = array_merge(
+			$record['extra'],
+			$this->getRecord()
+		);
 
+		return $record;
+	}
+
+	/**
+	 * Returns the introspection record of the current call
+	 *
+	 * @return array
+	 */
+	public function getRecord()
+	{
 		$trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
 
 		$i = 1;
@@ -53,17 +68,11 @@ class FriendicaIntrospectionProcessor implements ProcessorInterface
 
 		$i += $this->skipStackFramesCount;
 
-		// we should have the call source now
-		$record['extra'] = array_merge(
-			$record['extra'],
-			[
-				'file'      => isset($trace[$i - 1]['file']) ? basename($trace[$i - 1]['file']) : null,
-				'line'      => isset($trace[$i - 1]['line']) ? $trace[$i - 1]['line'] : null,
-				'function'  => isset($trace[$i]['function']) ? $trace[$i]['function'] : null,
-			]
-		);
-
-		return $record;
+		return [
+			'file' => isset($trace[$i - 1]['file']) ? basename($trace[$i - 1]['file']) : null,
+			'line' => isset($trace[$i - 1]['line']) ? $trace[$i - 1]['line'] : null,
+			'function' => isset($trace[$i]['function']) ? $trace[$i]['function'] : null,
+		];
 	}
 
 	/**

--- a/src/Util/Logger/SyslogLogger.php
+++ b/src/Util/Logger/SyslogLogger.php
@@ -1,0 +1,215 @@
+<?php
+
+namespace Friendica\Util\Logger;
+
+use Friendica\Network\HTTPException\InternalServerErrorException;
+use Psr\Log\InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+
+/**
+ * A Logger instance for syslogging (fast, but simple)
+ * @see http://php.net/manual/en/function.syslog.php
+ */
+class SyslogLogger implements LoggerInterface
+{
+	/**
+	 * Translates LogLevel log levels to syslog log priorities.
+	 */
+	private $logLevels = [
+		LogLevel::DEBUG     => LOG_DEBUG,
+		LogLevel::INFO      => LOG_INFO,
+		LogLevel::NOTICE    => LOG_NOTICE,
+		LogLevel::WARNING   => LOG_WARNING,
+		LogLevel::ERROR     => LOG_ERR,
+		LogLevel::CRITICAL  => LOG_CRIT,
+		LogLevel::ALERT     => LOG_ALERT,
+		LogLevel::EMERGENCY => LOG_EMERG,
+	];
+
+	/**
+	 * The standard ident of the syslog (added to each message)
+	 * @var string
+	 */
+	private $ident;
+
+	/**
+	 * Indicates what logging options will be used when generating a log message
+	 * @see http://php.net/manual/en/function.openlog.php#refsect1-function.openlog-parameters
+	 *
+	 * @var int
+	 */
+	private $logOpts;
+
+	/**
+	 * Used to specify what type of program is logging the message
+	 * @see http://php.net/manual/en/function.openlog.php#refsect1-function.openlog-parameters
+	 *
+	 * @var int
+	 */
+	private $logFacility;
+
+	/**
+	 * The minimum loglevel at which this logger will be triggered
+	 * @var int
+	 */
+	private $logLevel;
+
+	/**
+	 * The Introspector for the current call
+	 * @var Introspection
+	 */
+	private $introspection;
+
+	/**
+	 * @param string $channel     The channel (Syslog ident)
+	 * @param string $level    The minimum loglevel at which this logger will be triggered
+	 * @param int    $logOpts     Indicates what logging options will be used when generating a log message
+	 * @param int    $logFacility Used to specify what type of program is logging the message
+	 *
+	 * @throws InternalServerErrorException if the loglevel isn't valid
+	 */
+	public function __construct($channel, Introspection $introspection, $level = LogLevel::NOTICE, $logOpts = LOG_PID, $logFacility = LOG_USER)
+	{
+		$this->ident = $channel;
+		$this->logOpts = $logOpts;
+		$this->logFacility = $logFacility;
+		$this->logLevel = $this->mapLevelToPriority($level);
+		$this->introspection = $introspection;
+	}
+
+	/**
+	 * Maps the LogLevel (@see LogLevel ) to a SysLog priority (@see http://php.net/manual/en/function.syslog.php#refsect1-function.syslog-parameters )
+	 *
+	 * @param string $level A LogLevel
+	 *
+	 * @return int The SysLog priority
+	 *
+	 * @throws \Psr\Log\InvalidArgumentException If the loglevel isn't valid
+	 */
+	public function mapLevelToPriority($level)
+	{
+		if (!array_key_exists($level, $this->logLevels)) {
+			throw new InvalidArgumentException('LogLevel \'' . $level . '\' isn\'t valid.');
+		}
+
+		return $this->logLevels[$level];
+	}
+
+	/**
+	 * Writes a message to the syslog
+	 *
+	 * @param int    $priority The Priority ( @see http://php.net/manual/en/function.syslog.php#refsect1-function.syslog-parameters )
+	 * @param string $message The message of the log
+	 * @throws InternalServerErrorException if syslog cannot be used
+	 */
+	private function write($priority, $message)
+	{
+		if (!openlog($this->ident, $this->logOpts, $this->logFacility)) {
+			throw new InternalServerErrorException('Can\'t open syslog for ident "' . $this->ident . '" and facility "' . $this->logFacility . '""');
+		}
+
+		syslog($priority, $message);
+	}
+
+	public function close()
+	{
+		closelog();
+	}
+
+	private function formatLog($level, $message, $context = [])
+	{
+		$logMessage  = '';
+
+		$logMessage .= $this->ident . ' ';
+		$logMessage .= '[' . $level . ']: ';
+		$logMessage .= $message . ' ';
+		$logMessage .= json_encode($context) . ' - ';
+		$logMessage .= json_encode($this->introspection->getRecord());
+
+		return $logMessage;
+	}
+
+	private function addEntry($level, $message, $context = [])
+	{
+		if ($level >= $this->logLevel) {
+			return;
+		}
+
+		$formattedLog = $this->formatLog($level, $message, $context);
+		$this->write($level, $formattedLog);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function emergency($message, array $context = array())
+	{
+		$this->addEntry(LOG_EMERG, $message, $context);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function alert($message, array $context = array())
+	{
+		$this->addEntry(LOG_ALERT, $message, $context);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function critical($message, array $context = array())
+	{
+		$this->addEntry(LOG_CRIT, $message, $context);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function error($message, array $context = array())
+	{
+		$this->addEntry(LOG_ERR, $message, $context);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function warning($message, array $context = array())
+	{
+		$this->addEntry(LOG_WARNING, $message, $context);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function notice($message, array $context = array())
+	{
+		$this->addEntry(LOG_NOTICE, $message, $context);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function info($message, array $context = array())
+	{
+		$this->addEntry(LOG_INFO, $message, $context);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function debug($message, array $context = array())
+	{
+		$this->addEntry(LOG_DEBUG, $message, $context);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function log($level, $message, array $context = array())
+	{
+		$logLevel = $this->mapLevelToPriority($level);
+		$this->addEntry($logLevel, $message, $context);
+	}
+}


### PR DESCRIPTION
A (working) example of alternative Logging mechanism.

It's pretty fast - this is my reference:
https://www.loggly.com/blog/benchmarking-php-logging-frameworks-which-is-fastest-and-most-reliable-2/

To be honest I'm thinking about a simple FileLogger, which is capable of what Monolog does, but with less code/performance costs. Monolog is good for different types of logging, which is maybe useful for later stages of Friendica (f.e. hosting in clouds or enterprise environments - yes I said such bad things aloud ;-) ).

I tried it local with monolog and syslog and both worked for me :-)
And as far as I can see, there shouldn't be merge-problems with 2019.03-RC

Example output:
```console
Feb 27 16:30:01 friendica Friendica[10555]: worker [INFO]: DB: 0.0028 - DB-Count: 0.0008 - DB-Stat: 0.0000 - DB-Write: 0.0055 - Lock: 0.0000 - Rest: 0.0197 - Execution: 0.0006 [] - {"file":"Worker.php","line":420,"function":"execFunction","uid":"48496e"}
Feb 27 16:30:01 friendica Friendica[10555]: worker [INFO]: Process 10555 - Prio 30 - ID 317: Cron - done in 0.0006 seconds. Process PID:  [] - {"file":"Worker.php","line":440,"function":"execFunction","uid":"48496e"}
Feb 27 16:30:01 friendica Friendica[10555]: worker [INFO]: ID 317: Cron {"action":"profiling","database_read":0,"database_write":0,"cache_read":0,"cache_write":0,"network_io":0,"file_io":0,"other_io":0,"total":0} - {"file":"Worker.php","line":442,"function":"execFunction","uid":"48496e"}
Feb 27 16:30:01 friendica Friendica[10555]: worker [INFO]: Deferred: 0 - Total: 0 - Maximum: 1 - jobs per queue: 0 [] - {"file":"Worker.php","line":843,"function":"findWorkerProcesses","uid":"48496e"}
```

[edit] the output format is full under our control, so if we want, we can merge f.e both context arrays to one