### PR TITLE
Reuse existing Strings::getRandomHex function

### DIFF
--- a/src/Util/Logger/WorkerLogger.php
+++ b/src/Util/Logger/WorkerLogger.php
@@ -2,6 +2,7 @@
 
 namespace Friendica\Util\Logger;
 
+use Friendica\Util\Strings;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -34,29 +35,7 @@ class WorkerLogger implements LoggerInterface
 	{
 		$this->logger = $logger;
 		$this->functionName = $functionName;
-		$this->workerId = $this->generateWorkerId($idLength);
-	}
-
-	/**
-	 * Generates an ID
-	 *
-	 * @param int $length
-	 *
-	 * @return string
-	 */
-	private function generateWorkerId($length)
-	{
-		if ($length <= 0) {
-			$this->logger->alert('id length must be greater than 0.');
-			return '';
-		}
-
-		try {
-			return substr(bin2hex(random_bytes(ceil($length / 2))), 0, $length);
-		} catch (\Exception $exception) {
-			$this->logger->alert('random_bytes threw an error', ['exception' => $exception]);
-			return '';
-		}
+		$this->workerId = Strings::getRandomHex($idLength);
 	}
 
 	/**

--- a/tests/src/Util/Logger/WorkerLoggerTest.php
+++ b/tests/src/Util/Logger/WorkerLoggerTest.php
@@ -15,15 +15,11 @@ class WorkerLoggerTest extends MockedTest
 
 	/**
 	 * Test the a id with length zero
-	 * @expectedException
+	 * @expectedException \Error
 	 */
 	public function testGetWorkerIdZero()
 	{
 		$logger = \Mockery::mock(LoggerInterface::class);
-		$logger
-			->shouldReceive('alert')
-			->with('id length must be greater than 0.')
-			->once();
 		new WorkerLogger($logger, 'test', 0);
 	}
 


### PR DESCRIPTION
I know it's an enhancement, but I'm sure I will forget once the PR is merged (because the `WorkerLogger` doesn't exist in the develop branch yet).
We discussed a lot about how to create a unique ID and now, after all, I found that we already solved this problem.

I would like to add it before the release because it's really ugly..