### PR TITLE
Update - query missmatch

### DIFF
--- a/src/Core/Update.php
+++ b/src/Core/Update.php
@@ -209,7 +209,7 @@ class Update
 	 */
 	private static function updateFailed($update_id, $error_message) {
 		//send the administrators an e-mail
-		$admin_mail_list = "'".implode("','", array_map(['Friendica\Database\DBA', 'escape'], explode(",", str_replace(" ", "", Config::get('config', 'admin_email')))))."'";
+		$admin_mail_list = explode(",", str_replace(" ", "", Config::get('config', 'admin_email')));
 		$adminlist = DBA::select('user', ['uid', 'language', 'email'], ['`email` IN (%s)', $admin_mail_list]);
 
 		// No valid result?
@@ -251,7 +251,7 @@ class Update
 	private static function updateSuccessfull($from_build, $to_build)
 	{
 		//send the administrators an e-mail
-		$admin_mail_list = "'".implode("','", array_map(['Friendica\Database\DBA', 'escape'], explode(",", str_replace(" ", "", Config::get('config', 'admin_email')))))."'";
+		$admin_mail_list = explode(",", str_replace(" ", "", Config::get('config', 'admin_email')));
 		$adminlist = DBA::select('user', ['uid', 'language', 'email'], ['`email` IN (%s)', $admin_mail_list]);
 
 		if (DBA::isResult($adminlist)) {

--- a/src/Core/Update.php
+++ b/src/Core/Update.php
@@ -209,8 +209,7 @@ class Update
 	 */
 	private static function updateFailed($update_id, $error_message) {
 		//send the administrators an e-mail
-		$admin_mail_list = explode(",", str_replace(" ", "", Config::get('config', 'admin_email')));
-		$adminlist = DBA::select('user', ['uid', 'language', 'email'], ['`email` IN (%s)', $admin_mail_list]);
+		$adminlist = DBA::select('user', ['uid', 'language', 'email'], ['email' => explode(",", str_replace(" ", "", Config::get('config', 'admin_email')))]);
 
 		// No valid result?
 		if (!DBA::isResult($adminlist)) {
@@ -251,8 +250,7 @@ class Update
 	private static function updateSuccessfull($from_build, $to_build)
 	{
 		//send the administrators an e-mail
-		$admin_mail_list = explode(",", str_replace(" ", "", Config::get('config', 'admin_email')));
-		$adminlist = DBA::select('user', ['uid', 'language', 'email'], ['`email` IN (%s)', $admin_mail_list]);
+		$adminlist = DBA::select('user', ['uid', 'language', 'email'], ['email' => explode(",", str_replace(" ", "", Config::get('config', 'admin_email')))]);
 
 		if (DBA::isResult($adminlist)) {
 			// every admin could had different language


### PR DESCRIPTION
Fixing #6772 

Worked at my node.

```console
2019-02-27 19:32:30 worker [INFO]: Update from '1301'  to '1303' - successful [] {"file":"Update.php","line":126,"function":"run","uid":"cdd093a","process_id":1339}
2019-02-27 19:32:30 worker [INFO]: sending notification email [] {"file":"enotify.php","line":572,"function":"notification","uid":"cdd093a","process_id":1339}
2019-02-27 19:32:30 worker [INFO]: header To: admin@philipp.info Precedence: list X-Friendica-Host: friendica.philipp.info X-Friendica-Account: <@friendica.philipp.info> X-Friendica-Platform: Friendica X-Friendica-Version: 2019.03-rc List-ID: <notification.friendica.philipp.info> List-Archive: <http://friendica.philipp.info/notifications/system> From: Philipp's Friendica <no-reply@friendica.philipp.info> Reply-To: Philipp's Friendica <no-reply@friendica.philipp.info> MIME-Version: 1.0 Content-Type: multipart/alternative; boundary="4-347225035-275253380=:26176" [] {"file":"Emailer.php","line":102,"function":"send","uid":"cdd093a","process_id":1339}
2019-02-27 19:32:30 worker [INFO]: return value false [] {"file":"Emailer.php","line":103,"function":"send","uid":"cdd093a","process_id":1339}
2019-02-27 19:32:30 worker [NOTICE]: Database structure update successful. [] {"file":"Update.php","line":278,"function":"updateSuccessfull","uid":"cdd093a","process_id":1339}
```