### PR TITLE
Fix handling table name during storage move

### DIFF
--- a/src/Core/Console/Storage.php
+++ b/src/Core/Console/Storage.php
@@ -112,19 +112,21 @@ HELP;
 
 	protected function do_move()
 	{
-		$table = null;
+		$tables = null;
 		if (count($this->args) < 1 || count($this->args) > 2) {
 			throw new CommandArgsException('Invalid arguments');
 		}
+
 		if (count($this->args) == 2) {
 			$table = strtolower($this->args[1]);
 			if (!in_array($table, ['photo', 'attach'])) {
 				throw new CommandArgsException('Invalid table');
 			}
+			$tables = [$table];
 		}
 
 		$current = StorageManager::getBackend();
-		$r = StorageManager::move($current);
+		$r = StorageManager::move($current, $tables);
 		$this->out(sprintf('Moved %d files', $r));
 	}
 }

--- a/src/Core/StorageManager.php
+++ b/src/Core/StorageManager.php
@@ -110,8 +110,8 @@ class StorageManager
 	 * Copy existing data to destination storage and delete from source.
 	 * This method cannot move to legacy in-table `data` field.
 	 *
-	 * @param string  $dest    Destination storage class name
-	 * @param array   $tables  Tables to look in for resources. Optional, defaults to ['photo', 'attach']
+	 * @param string     $dest    Destination storage class name
+	 * @param array|null $tables  Tables to look in for resources. Optional, defaults to ['photo', 'attach']
 	 *
 	 * @throws \Exception
 	 * @return int Number of moved resources


### PR DESCRIPTION
Fixing #6785 

This is a "quick" fix, because I don't want to refactor more at this state of the RC (f.e. I'd say instead of null, the default value of the parameter could be the whole list, so we wouldn't need the "nullable")