### PR TITLE
[API] Improve show status

### DIFF
--- a/include/api.php
+++ b/include/api.php
@@ -2904,7 +2904,7 @@ function api_format_items($items, $user_info, $filter_user = false, $type = "jso
 			continue;
 		}
 
-		$status = api_format_item($item, $type, $status_user, $owner_user);
+		$status = api_format_item($item, $type, $status_user, $author_user, $owner_user);
 
 		$ret[] = $status;
 	}
@@ -2916,6 +2916,7 @@ function api_format_items($items, $user_info, $filter_user = false, $type = "jso
  * @param array  $item       Item record
  * @param string $type       Return format (atom, rss, xml, json)
  * @param array $status_user User record of the item author, can be provided by api_item_get_user()
+ * @param array $author_user User record of the item author, can be provided by api_item_get_user()
  * @param array $owner_user  User record of the item owner, can be provided by api_item_get_user()
  * @return array API-formatted status
  * @throws BadRequestException
@@ -2923,12 +2924,12 @@ function api_format_items($items, $user_info, $filter_user = false, $type = "jso
  * @throws InternalServerErrorException
  * @throws UnauthorizedException
  */
-function api_format_item($item, $type = "json", $status_user = null, $owner_user = null)
+function api_format_item($item, $type = "json", $status_user = null, $author_user = null, $owner_user = null)
 {
 	$a = \Friendica\BaseObject::getApp();
 
-	if (empty($status_user) || empty($owner_user)) {
-		list($status_user, $owner_user) = api_item_get_user($a, $item);
+	if (empty($status_user) || empty($author_user) || empty($owner_user)) {
+		list($status_user, $author_user, $owner_user) = api_item_get_user($a, $item);
 	}
 
 	localize_item($item);
@@ -2959,7 +2960,7 @@ function api_format_item($item, $type = "json", $status_user = null, $owner_user
 		'favorited' => $item['starred'] ? true : false,
 		'user' =>  $status_user,
 		'friendica_author' => $author_user,
-			'friendica_owner' => $owner_user,
+		'friendica_owner' => $owner_user,
 		'friendica_private' => $item['private'] == 1,
 		//'entities' => NULL,
 		'statusnet_html' => $converted["html"],

--- a/include/api.php
+++ b/include/api.php
@@ -953,9 +953,9 @@ function api_account_verify_credentials($type)
 
 	// - Adding last status
 	if (!$skip_status) {
-		$last_status = api_get_last_status($user_info['pid'], $user_info['uid'], $type);
-		if ($last_status) {
-			$user_info['status'] = $last_status;
+		$item = api_get_last_status($user_info['pid'], $user_info['uid']);
+		if ($item) {
+			$user_info['status'] = api_format_item($item, $type);
 		}
 	}
 
@@ -1265,11 +1265,10 @@ function api_status_show($type, $item_id)
  *
  * @param int    $ownerId Public contact Id
  * @param int    $uid     User Id
- * @param string $type    Return format (atom, rss, xml, json)
  * @return array
  * @throws Exception
  */
-function api_get_last_status($ownerId, $uid, $type = 'json')
+function api_get_last_status($ownerId, $uid)
 {
 	$condition = [
 		'owner-id' => $ownerId,
@@ -1280,9 +1279,7 @@ function api_get_last_status($ownerId, $uid, $type = 'json')
 
 	$item = api_get_item($condition);
 
-	$status_info = api_format_item($item, $type);
-
-	return $status_info;
+	return $item;
 }
 
 /**
@@ -1317,9 +1314,9 @@ function api_users_show($type)
 
 	$user_info = api_get_user($a);
 
-	$lastStatus = api_get_last_status($user_info['pid'], $user_info['uid'], $type);
-	if ($lastStatus) {
-		$user_info['status'] = $lastStatus;
+	$item = api_get_last_status($user_info['pid'], $user_info['uid']);
+	if ($item) {
+		$user_info['status'] = api_format_item($item, $type);
 	}
 
 	// "uid" and "self" are only needed for some internal stuff, so remove it from here

--- a/include/api.php
+++ b/include/api.php
@@ -1294,7 +1294,7 @@ function api_get_last_status($ownerId, $uid, $type = 'json')
  */
 function api_get_item(array $condition)
 {
-	$item = Item::selectFirst(Item::ITEM_FIELDLIST, $condition, ['order' => ['id' => true]]);
+	$item = Item::selectFirst(Item::DISPLAY_FIELDLIST, $condition, ['order' => ['id' => true]]);
 
 	return $item;
 }

--- a/tests/include/ApiTest.php
+++ b/tests/include/ApiTest.php
@@ -1274,8 +1274,10 @@ class ApiTest extends DatabaseTest
 	 * Test the api_status_show() function.
 	 * @return void
 	 */
-	public function testApiStatusShow()
+	public function testApiStatusShowWithJson()
 	{
+		$this->markTestSkipped('This test requires an item ID');
+
 		$result = api_status_show('json');
 		$this->assertStatus($result['status']);
 	}
@@ -1286,6 +1288,8 @@ class ApiTest extends DatabaseTest
 	 */
 	public function testApiStatusShowWithXml()
 	{
+		$this->markTestSkipped('This test requires an item ID');
+
 		$result = api_status_show('xml');
 		$this->assertXml($result, 'statuses');
 	}
@@ -1294,9 +1298,11 @@ class ApiTest extends DatabaseTest
 	 * Test the api_status_show() function with a raw result.
 	 * @return void
 	 */
-	public function testApiStatusShowWithRaw()
+	public function testApiGetLastStatus()
 	{
-		$this->assertStatus(api_status_show('raw'));
+		$user_info = api_get_user($this->app);
+
+		$this->assertStatus(api_get_last_status($user_info['pid'], $user_info['uid']));
 	}
 
 	/**

--- a/tests/include/ApiTest.php
+++ b/tests/include/ApiTest.php
@@ -31,6 +31,18 @@ class ApiTest extends DatabaseTest
 	 */
 	protected $logOutput;
 
+	/** @var App */
+	protected $app;
+
+	/** @var array */
+	protected $selfUser;
+	/** @var array */
+	protected $friendUser;
+	/** @var array */
+	protected $otherUser;
+
+	protected $wrongUserId;
+
 	/**
 	 * Create variables used by tests.
 	 */
@@ -1272,37 +1284,30 @@ class ApiTest extends DatabaseTest
 
 	/**
 	 * Test the api_status_show() function.
-	 * @return void
 	 */
 	public function testApiStatusShowWithJson()
 	{
-		$this->markTestSkipped('This test requires an item ID');
-
-		$result = api_status_show('json');
+		$result = api_status_show('json', 1);
 		$this->assertStatus($result['status']);
 	}
 
 	/**
 	 * Test the api_status_show() function with an XML result.
-	 * @return void
 	 */
 	public function testApiStatusShowWithXml()
 	{
-		$this->markTestSkipped('This test requires an item ID');
-
-		$result = api_status_show('xml');
+		$result = api_status_show('xml', 1);
 		$this->assertXml($result, 'statuses');
 	}
 
 	/**
-	 * Test the api_status_show() function with a raw result.
-	 * @return void
+	 * Test the api_get_last_status() function
 	 */
 	public function testApiGetLastStatus()
 	{
-		$user_info = api_get_user($this->app);
+		$item = api_get_last_status($this->selfUser['id'], $this->selfUser['id']);
 
-		$this->assertStatus(api_get_last_status($user_info['pid'], $user_info['uid']));
+		$this->assertNotNull($item);
 	}
 
 	/**


### PR DESCRIPTION
This PR extracts the single item retrieval/conversion to API status logic in a separate function because it was done not twice, but thrice throughout the API.

I stated this because I wanted to fix https://github.com/friendica/friendica/issues/6337#issuecomment-468839548 and then I got carried away, as usual.