### PR TITLE
Added warning about an empty key

### DIFF
--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -1209,6 +1209,16 @@ class Transmitter
 	{
 		$owner = User::getOwnerDataById($uid);
 
+		if (empty($owner)) {
+			Logger::error('No owner data found, the deletion message cannot be processed.', ['user' => $uid]);
+			return false;
+		}
+
+		if (empty($owner['uprvkey'])) {
+			Logger::error('No private key for owner found, the deletion message cannot be processed.', ['user' => $uid]);
+			return false;
+		}
+
 		$data = ['@context' => ActivityPub::CONTEXT,
 			'id' => System::baseUrl() . '/activity/' . System::createGUID(),
 			'type' => 'Delete',

--- a/src/Util/Crypto.php
+++ b/src/Util/Crypto.php
@@ -24,6 +24,9 @@ class Crypto
 	 */
 	public static function rsaSign($data, $key, $alg = 'sha256')
 	{
+		if (empty($key)) {
+			logger::warning('Empty key parameter', ['callstack' => System::callstack()]);
+		}
 		openssl_sign($data, $sig, $key, (($alg == 'sha1') ? OPENSSL_ALGO_SHA1 : $alg));
 		return $sig;
 	}
@@ -37,6 +40,9 @@ class Crypto
 	 */
 	public static function rsaVerify($data, $sig, $key, $alg = 'sha256')
 	{
+		if (empty($key)) {
+			logger::warning('Empty key parameter', ['callstack' => System::callstack()]);
+		}
 		return openssl_verify($data, $sig, $key, (($alg == 'sha1') ? OPENSSL_ALGO_SHA1 : $alg));
 	}
 

--- a/src/Util/Crypto.php
+++ b/src/Util/Crypto.php
@@ -26,7 +26,7 @@ class Crypto
 	public static function rsaSign($data, $key, $alg = 'sha256')
 	{
 		if (empty($key)) {
-			logger::warning('Empty key parameter', ['callstack' => System::callstack()]);
+			Logger::warning('Empty key parameter', ['callstack' => System::callstack()]);
 		}
 		openssl_sign($data, $sig, $key, (($alg == 'sha1') ? OPENSSL_ALGO_SHA1 : $alg));
 		return $sig;
@@ -42,7 +42,7 @@ class Crypto
 	public static function rsaVerify($data, $sig, $key, $alg = 'sha256')
 	{
 		if (empty($key)) {
-			logger::warning('Empty key parameter', ['callstack' => System::callstack()]);
+			Logger::warning('Empty key parameter', ['callstack' => System::callstack()]);
 		}
 		return openssl_verify($data, $sig, $key, (($alg == 'sha1') ? OPENSSL_ALGO_SHA1 : $alg));
 	}

--- a/src/Util/Crypto.php
+++ b/src/Util/Crypto.php
@@ -7,6 +7,7 @@ namespace Friendica\Util;
 use Friendica\Core\Config;
 use Friendica\Core\Hook;
 use Friendica\Core\Logger;
+use Friendica\Core\System;
 use ASN_BASE;
 use ASNValue;
 


### PR DESCRIPTION
This should help finding the origin of warnings about empty parameters in calls to "openssl_sign" and "openssl_verify".