### PR TITLE
Bugfix/notification order

### DIFF
--- a/src/Core/NotificationsManager.php
+++ b/src/Core/NotificationsManager.php
@@ -73,7 +73,7 @@ class NotificationsManager extends BaseObject
 
 		$dbFilter = array_merge($filter, ['uid' => local_user()]);
 
-		$stmtNotifies = DBA::select('notify', [], $dbFilter, $order, $params);
+		$stmtNotifies = DBA::select('notify', [], $dbFilter, $params);
 
 		if (DBA::isResult($stmtNotifies)) {
 			return $this->_set_extra(DBA::toArray($stmtNotifies));
@@ -429,6 +429,7 @@ class NotificationsManager extends BaseObject
 		}
 
 		$params = [];
+        $params['order'] = ['date' => 'DESC'];
 		$params['limit'] = [$start, $limit];
 
 		$stmtNotifies = DBA::select('notify',

--- a/src/Core/NotificationsManager.php
+++ b/src/Core/NotificationsManager.php
@@ -429,7 +429,7 @@ class NotificationsManager extends BaseObject
 		}
 
 		$params = [];
-        $params['order'] = ['date' => 'DESC'];
+		$params['order'] = ['date' => 'DESC'];
 		$params['limit'] = [$start, $limit];
 
 		$stmtNotifies = DBA::select('notify',


### PR DESCRIPTION
I found out that notifications in DiCa and all notifications on website were ordered wrongly. The oldest were on top while it should be vice versa. Also the 50 notifications limit was not put in DiCa/Api

Paging @nupplaphil as I found out #6783 was to blame.

