### PR TITLE
Worker: Don't spawn without jobs

### DIFF
--- a/src/Core/Worker.php
+++ b/src/Core/Worker.php
@@ -702,7 +702,7 @@ class Worker
 
 			$processlist .= ' ('.implode(', ', $listitem).')';
 
-			if (Config::get("system", "worker_fastlane", false) && ($queues > 0) && self::entriesExists() && ($active >= $queues)) {
+			if (Config::get("system", "worker_fastlane", false) && ($queues > 0) && ($active >= $queues) && self::entriesExists()) {
 				$top_priority = self::highestPriority();
 				$high_running = self::processWithPriorityActive($top_priority);
 
@@ -715,7 +715,7 @@ class Worker
 			Logger::log("Load: " . $load ."/" . $maxsysload . " - processes: " . $deferred . "/" . $active . "/" . $waiting_processes . $processlist . " - maximum: " . $queues . "/" . $maxqueues, Logger::DEBUG);
 
 			// Are there fewer workers running as possible? Then fork a new one.
-			if (!Config::get("system", "worker_dont_fork", false) && ($queues > ($active + 1)) && ($entries > 1)) {
+			if (!Config::get("system", "worker_dont_fork", false) && ($queues > ($active + 1)) && self::entriesExists()) {
 				Logger::log("Active workers: ".$active."/".$queues." Fork a new worker.", Logger::DEBUG);
 				if (Config::get('system', 'worker_daemon_mode', false)) {
 					self::IPCSetJobState(true);

--- a/src/Worker/Notifier.php
+++ b/src/Worker/Notifier.php
@@ -446,7 +446,8 @@ class Notifier
 					// Ensure that posts with our own protocol arrives before Diaspora posts arrive.
 					// Situation is that sometimes Friendica servers receive Friendica posts over the Diaspora protocol first.
 					// The conversion in Markdown reduces the formatting, so these posts should arrive after the Friendica posts.
-					if ($rr['network'] == Protocol::DIASPORA) {
+					// This is only important for high and medium priority tasks and not for Low priority jobs like deletions.
+					if (($rr['network'] == Protocol::DIASPORA) && in_array($a->queue['priority'], [PRIORITY_HIGH, PRIORITY_MEDIUM])) {
 						$deliver_options = ['priority' => $a->queue['priority'], 'dont_fork' => true];
 					} else {
 						$deliver_options = ['priority' => $a->queue['priority'], 'created' => $a->queue['created'], 'dont_fork' => true];


### PR DESCRIPTION
See discussion here: https://forum.friendi.ca/display/0b6b25a8-205c-81ac-a35d-7fe490090364

This should avoid the situation that we spawn new processes when there is nothing to do at all.

Additionally it handles a small problem where low priority jobs could get piled up and are processed at a much later time when the system is really busy.