### PR TITLE
Set Timezone to 'UTC' for every Logger (Develop)

### DIFF
--- a/src/Factory/LoggerFactory.php
+++ b/src/Factory/LoggerFactory.php
@@ -59,6 +59,9 @@ class LoggerFactory
 		switch ($config->get('system', 'logger_config', 'stream')) {
 
 			case 'monolog':
+				$loggerTimeZone = new \DateTimeZone('UTC');
+				Monolog\Logger::setTimezone($loggerTimeZone);
+
 				$logger = new Monolog\Logger($channel);
 				$logger->pushProcessor(new Monolog\Processor\PsrLogMessageProcessor());
 				$logger->pushProcessor(new Monolog\Processor\ProcessIdProcessor());
@@ -127,6 +130,9 @@ class LoggerFactory
 		switch ($config->get('system', 'logger_config', 'stream')) {
 
 			case 'monolog':
+				$loggerTimeZone = new \DateTimeZone('UTC');
+				Monolog\Logger::setTimezone($loggerTimeZone);
+
 				$logger = new Monolog\Logger($channel);
 				$logger->pushProcessor(new Monolog\Processor\PsrLogMessageProcessor());
 				$logger->pushProcessor(new Monolog\Processor\ProcessIdProcessor());

--- a/src/Util/Logger/StreamLogger.php
+++ b/src/Util/Logger/StreamLogger.php
@@ -134,7 +134,7 @@ class StreamLogger extends AbstractLogger
 		$record = array_merge($record, ['uid' => $this->logUid, 'process_id' => $this->pid]);
 		$logMessage = '';
 
-		$logMessage .= DateTimeFormat::localNow() . ' ';
+		$logMessage .= DateTimeFormat::utcNow() . ' ';
 		$logMessage .= $this->channel . ' ';
 		$logMessage .= '[' . strtoupper($level) . ']: ';
 		$logMessage .= $this->psrInterpolate($message, $context) . ' ';


### PR DESCRIPTION
Same as #6837 for #6822 , but for develop branch (including for the new `StreamLogger`).
For syslog, it isn't possible to set it through PHP, the timestamp is created implicit inside the syslog logic.