### PR TITLE
Fix implicit mention regex

### DIFF
--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -743,30 +743,4 @@ class Processor
 
 		return $activity_tags;
 	}
-
-	public static function testImplicitMentions($item, $source)
-	{
-		$parent = Item::selectFirst(['id', 'guid', 'author-link', 'alias'], ['uri' => $item['thr-parent']]);
-
-		$implicit_mentions = self::getImplicitMentionList($parent);
-		var_dump($implicit_mentions);
-
-		$object = json_decode($source, true)['object'];
-		var_dump($object);
-
-		$content = HTML::toBBCode($object['content']);
-		$content = self::convertMentions($content);
-
-		$activity = [
-			'tags' => $object['tag'],
-			'content' => $content
-		];
-
-		var_dump($activity);
-
-		$activity['content'] = Processor::removeImplicitMentionsFromBody($activity['content'], $implicit_mentions);
-		$activity['tags'] = Processor::convertImplicitMentionsInTags($activity['tags'], $implicit_mentions);
-
-		return $activity;
-	}
 }

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -710,7 +710,7 @@ class Processor
 		$kept_mentions = [];
 
 		// Extract one prepended mention at a time from the body
-		while(preg_match('#^(@\[url=([^\]]+)].*?\[\/url]\s)(.*)#mis', $body, $matches)) {
+		while(preg_match('#^(@\[url=([^\]]+)].*?\[\/url]\s)(.*)#is', $body, $matches)) {
 			if (!in_array($matches[2], $potential_mentions) ) {
 				$kept_mentions[] = $matches[1];
 			}


### PR DESCRIPTION
Fixes #6829
Follow-up to #6649
Part of #6552

There was a wrong flag in the implicit mention detection regular expression that treated every line start as the start of the string. This lead to mentions being added at the end of the message in a new line to be treated as the start of the message, truncating it.