### PR TITLE
Tests for BBCode

### DIFF
--- a/tests/src/Content/Text/BBCodeTest.php
+++ b/tests/src/Content/Text/BBCodeTest.php
@@ -50,30 +50,30 @@ class BBCodeTest extends MockedTest
 			/** @see https://github.com/friendica/friendica/issues/2487 */
 			'bug-2487-1' => [
 				'data' => 'https://de.wikipedia.org/wiki/Juha_Sipilä',
-				'link' => true,
+				'assertHTML' => true,
 			],
 			'bug-2487-2' => [
 				'data' => 'https://de.wikipedia.org/wiki/Dnepr_(Motorradmarke)',
-				'link' => true,
+				'assertHTML' => true,
 			],
 			'bug-2487-3' => [
 				'data' => 'https://friendica.wäckerlin.ch/friendica',
-				'link' => false,
+				'assertHTML' => false,
 			],
 			'bug-2487-4' => [
 				'data' => 'https://mastodon.social/@morevnaproject',
-				'link' => false,
+				'assertHTML' => false,
 			],
 			/** @see https://github.com/friendica/friendica/issues/5795 */
 			'bug-5795' => [
 				'data' => 'https://social.nasqueron.org/@liw/100798039015010628',
-				'link' => true,
+				'assertHTML' => true,
 			],
 			/** @see https://github.com/friendica/friendica/issues/6095 */
 			/** @todo skipped because this test fails
 			'bug-6095' => [
 				'data' => 'https://en.wikipedia.org/wiki/Solid_(web_decentralization_project)',
-				'link' => true,
+				'assertHTML' => true,
 			]
 			 */
 		];
@@ -83,14 +83,14 @@ class BBCodeTest extends MockedTest
 	 * Test convert different links inside a text
 	 * @dataProvider dataLinks
 	 *
-	 * @param string $data The data to text
-	 * @param bool   $link True, if the link is a external HTML link
+	 * @param string $data       The data to text
+	 * @param bool   $assertHTML True, if the link is a HTML link (<a href...>...</a>)
 	 */
-	public function testAutoLinking($data, $link)
+	public function testAutoLinking($data, $assertHTML)
 	{
 		$output = BBCode::convert($data);
 
-		if ($link) {
+		if ($assertHTML) {
 			$assert = "<a href=\"$data\" target=\"_blank\">$data</a>";
 		} else {
 			$assert = $data;

--- a/tests/src/Content/Text/BBCodeTest.php
+++ b/tests/src/Content/Text/BBCodeTest.php
@@ -96,6 +96,6 @@ class BBCodeTest extends MockedTest
 			$assert = $data;
 		}
 
-		self::assertEquals($assert, $output);
+		$this->assertEquals($assert, $output);
 	}
 }

--- a/tests/src/Content/Text/BBCodeTest.php
+++ b/tests/src/Content/Text/BBCodeTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Friendica\Test\src\Content\Text;
+
+use Friendica\Content\Text\BBCode;
+use Friendica\Test\MockedTest;
+use Friendica\Test\Util\AppMockTrait;
+use Friendica\Test\Util\L10nMockTrait;
+use Friendica\Test\Util\VFSTrait;
+
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class BBCodeTest extends MockedTest
+{
+	use VFSTrait;
+	use AppMockTrait;
+	use L10nMockTrait;
+
+	protected function setUp()
+	{
+		parent::setUp();
+
+		$this->setUpVfsDir();
+		$this->mockApp($this->root);
+
+		$this->app->videowidth = 425;
+		$this->app->videoheight = 350;
+
+		$this->configMock->shouldReceive('get')
+			->with('system', 'remove_multiplicated_lines')
+			->andReturn(false);
+		$this->configMock->shouldReceive('get')
+			->with('system', 'no_oembed')
+			->andReturn(false);
+		$this->configMock->shouldReceive('get')
+			->with('system', 'allowed_link_protocols')
+			->andReturn(null);
+		$this->configMock->shouldReceive('get')
+			->with('system', 'itemcache_duration')
+			->andReturn(-1);
+
+		$this->mockL10nT();
+	}
+
+	public function dataLinks()
+	{
+		return [
+			/** @see https://github.com/friendica/friendica/issues/2487 */
+			'bug-2487-1' => [
+				'data' => 'https://de.wikipedia.org/wiki/Juha_Sipilä',
+				'link' => true,
+			],
+			'bug-2487-2' => [
+				'data' => 'https://de.wikipedia.org/wiki/Dnepr_(Motorradmarke)',
+				'link' => true,
+			],
+			'bug-2487-3' => [
+				'data' => 'https://friendica.wäckerlin.ch/friendica',
+				'link' => false,
+			],
+			'bug-2487-4' => [
+				'data' => 'https://mastodon.social/@morevnaproject',
+				'link' => false,
+			],
+			/** @see https://github.com/friendica/friendica/issues/5795 */
+			'bug-5795' => [
+				'data' => 'https://social.nasqueron.org/@liw/100798039015010628',
+				'link' => true,
+			],
+			/** @see https://github.com/friendica/friendica/issues/6095 */
+			/** @todo skipped because this test fails
+			'bug-6095' => [
+				'data' => 'https://en.wikipedia.org/wiki/Solid_(web_decentralization_project)',
+				'link' => true,
+			]
+			 */
+		];
+	}
+
+	/**
+	 * Test convert different links inside a text
+	 * @dataProvider dataLinks
+	 *
+	 * @param string $data The data to text
+	 * @param bool   $link True, if the link is a external HTML link
+	 */
+	public function testAutoLinking($data, $link)
+	{
+		$output = BBCode::convert($data);
+
+		if ($link) {
+			$assert = "<a href=\"$data\" target=\"_blank\">$data</a>";
+		} else {
+			$assert = $data;
+		}
+
+		self::assertEquals($assert, $output);
+	}
+}


### PR DESCRIPTION
FollowUp to #6835 

@MrPetovan the test for Bug #6095 fails, so I skipped this test for now, but we should fix the issue behdind it..

And I'd like to remove some of the static dependencies in the develop later, so I can remove the separate process annotations (which is a performance issue for testing)