### PR TITLE
Avoid double update runs

### DIFF
--- a/src/Core/Update.php
+++ b/src/Core/Update.php
@@ -79,7 +79,7 @@ class Update
 			if (Lock::acquire('dbupdate', 0, Cache::INFINITE)) {
 
 				// recheck again in case we accidentally spawned multiple updates
-				$stored = intval(self::getBuild());
+				$stored = self::getBuild();
 				if ($stored >= $current) {
 					Lock::release('dbupdate');
 					return '';

--- a/src/Core/Update.php
+++ b/src/Core/Update.php
@@ -24,19 +24,15 @@ class Update
 			return;
 		}
 
-		$build = Config::get('system', 'build');
-
-		if (empty($build)) {
-			Config::set('system', 'build', DB_UPDATE_VERSION - 1);
-			$build = DB_UPDATE_VERSION - 1;
-		}
+		$build = self::getBuild();
+		$current = intval(DB_UPDATE_VERSION);
 
 		// We don't support upgrading from very old versions anymore
 		if ($build < NEW_UPDATE_ROUTINE_VERSION) {
 			die('You try to update from a version prior to database version 1170. The direct upgrade path is not supported. Please update to version 3.5.4 before updating to this version.');
 		}
 
-		if ($build < DB_UPDATE_VERSION) {
+		if ($build < $current ) {
 			if ($via_worker) {
 				// Calling the database update directly via the worker enables us to perform database changes to the workerqueue table itself.
 				// This is a fallback, since normally the database update will be performed by a worker job.

--- a/src/Core/Update.php
+++ b/src/Core/Update.php
@@ -293,6 +293,11 @@ class Update
 		Logger::log("Database structure update successful.", Logger::TRACE);
 	}
 
+	/**
+	 * Returns the current build number of the instance
+	 *
+	 * @return int the build number
+	 */
 	private static function getBuild()
 	{
 		$build = Config::get('system', 'build');


### PR DESCRIPTION
I think I found the reason for #6788 at least.

The Update-Lock is after the initial "need to update" check, so it was possbile that different Worker called the same Update process. It wasn't possible to fire the updates again, but every run fires a success mail.

The issue is that after the successful release of the first `DBUpdate`, the following `DBUpdate` workers are still active (because the check is already done). They cannot update anything, but at least they send the "success" mail again (and again, ...).

So two things I did:
- Removing the initial double check ("not equal" and "less than") to one check ("less than")
- Added a recheck after successful acquiring the lock

This should fix it for now :-)