### PR TITLE
Fix for the automatic mentioning

### DIFF
--- a/src/Object/Post.php
+++ b/src/Object/Post.php
@@ -806,10 +806,9 @@ class Post extends BaseObject
 		}
 
 		$terms = Term::tagArrayFromItemId($this->getId(), [Term::MENTION, Term::IMPLICIT_MENTION]);
-
 		foreach ($terms as $term) {
 			$profile = Contact::getDetailsByURL($term['url']);
-			if (!empty($profile['addr']) && !empty($profile['contact-type']) && ($profile['contact-type'] != Contact::TYPE_COMMUNITY) &&
+			if (!empty($profile['addr']) && (defaults($profile, 'contact-type') != Contact::TYPE_COMMUNITY) &&
 				($profile['addr'] != $owner['addr']) && !strstr($text, $profile['addr'])) {
 				$text .= '@' . $profile['addr'] . ' ';
 			}


### PR DESCRIPTION
One mustn't use "empty" here since "0" is a valid value in this situation.