### PR TITLE
Fix fatal error when using Logger::devLog

### DIFF
--- a/src/Factory/DependencyFactory.php
+++ b/src/Factory/DependencyFactory.php
@@ -31,6 +31,7 @@ class DependencyFactory
 		// needed to call PConfig::init()
 		Factory\ConfigFactory::createPConfig($configCache);
 		$logger = Factory\LoggerFactory::create($channel, $config);
+		Factory\LoggerFactory::createDev($channel, $config);
 
 		return new App($basePath, $config, $logger, $profiler, $isBackend);
 	}


### PR DESCRIPTION
- Error message is "Call to a member function log() on null in src/Core/Logger.php:304"