### PR TITLE
Remove new lines from domain name part of autolinker regular expression in Util\Strings

### DIFF
--- a/src/Util/Strings.php
+++ b/src/Util/Strings.php
@@ -358,17 +358,17 @@ class Strings
 		return '@(?xi)
 (?<![=\'\]"/])          # Not preceded by [, =, \', ], ", /
 \b
-(                       # Capture 1: entire matched URL
-  https?://                 # http or https protocol
+(                              # Capture 1: entire matched URL
+  https?://                            # http or https protocol
   (?:
-    [^/.][^/]+[.][^/]+/?    # looks like domain name followed by a slash
+    [^/\s.][^/\s]+[.][^\s/]+/?         # looks like domain name followed by a slash
   )
-  (?:                       # One or more:
-    [^\s()<>]+                  # Run of non-space, non-()<>
-    |                           #   or
-    \(([^\s()<>]+|(\([^\s()<>]+\)))*\)  # balanced parens, up to 2 levels
-    |                               #   or
-    [^\s`!()\[\]{};:\'".,<>?«»“”‘’]        # not a space or one of these punct chars
+  (?:                                  # One or more:
+    [^\s()<>]+                         # Run of non-space, non-()<>
+    |                                  #   or
+    \(([^\s()<>]+|(\([^\s()<>]+\)))*\) # balanced parens, up to 2 levels
+    |                                  #   or
+    [^\s`!()\[\]{};:\'".,<>?«»“”‘’]    # not a space or one of these punct chars
   )*
 )@';
 	}

--- a/tests/src/Content/Text/BBCodeTest.php
+++ b/tests/src/Content/Text/BBCodeTest.php
@@ -86,6 +86,22 @@ class BBCodeTest extends MockedTest
 				'data' => 'http://example/path',
 				'assertHTML' => false
 			],
+			'bug-6857-domain-start' => [
+				'data' => "http://\nexample.com",
+				'assertHTML' => false
+			],
+			'bug-6857-domain-end' => [
+				'data' => "http://example\n.com",
+				'assertHTML' => false
+			],
+			'bug-6857-tld' => [
+				'data' => "http://example.\ncom",
+				'assertHTML' => false
+			],
+			'bug-6857-end' => [
+				'data' => "http://example.com\ntest",
+				'assertHTML' => false
+			],
 		];
 	}
 

--- a/tests/src/Content/Text/BBCodeTest.php
+++ b/tests/src/Content/Text/BBCodeTest.php
@@ -116,12 +116,11 @@ class BBCodeTest extends MockedTest
 	public function testAutoLinking($data, $assertHTML)
 	{
 		$output = BBCode::convert($data);
+		$assert = '<a href="' . $data . '" target="_blank">' . $data . '</a>';
 		if ($assertHTML) {
-			$assert = '<a href="' . $data . '" target="_blank">' . $data . '</a>';
+			$this->assertEquals($assert, $output);
 		} else {
-			$assert = $data;
+			$this->assertNotEquals($assert, $output);
 		}
-
-		$this->assertEquals($assert, $output);
 	}
 }


### PR DESCRIPTION
Follow-up to #6845 and #6841 

- Fixes issue where the autolinker would include the next paragraph is a pathless URL was followed by new lines.