### PR TITLE
Refactoring/Optimizing Installer/Install usage

### DIFF
--- a/src/Core/Console/AutomaticInstallation.php
+++ b/src/Core/Console/AutomaticInstallation.php
@@ -220,7 +220,7 @@ HELP;
 		}
 
 		$php_path = null;
-		if (!$configCache->has('config', 'php_path')) {
+		if ($configCache->has('config', 'php_path')) {
 			$php_path = $configCache->get('config', 'php_path');
 		}
 

--- a/src/Core/Console/AutomaticInstallation.php
+++ b/src/Core/Console/AutomaticInstallation.php
@@ -74,6 +74,8 @@ HELP;
 
 		$installer = new Installer();
 
+		$configCache = $a->getConfigCache();
+
 		$this->out(" Complete!\n\n");
 
 		// Check Environment
@@ -81,7 +83,7 @@ HELP;
 
 		$installer->resetChecks();
 
-		if (!$this->runBasicChecks($installer)) {
+		if (!$this->runBasicChecks($installer, $configCache)) {
 			$errorMessage = $this->extractErrors($installer->getChecks());
 			throw new RuntimeException($errorMessage);
 		}
@@ -100,41 +102,51 @@ HELP;
 				}
 			}
 
-			$db_host = $a->getConfigCache()->get('database', 'hostname');
-			$db_user = $a->getConfigCache()->get('database', 'username');
-			$db_pass = $a->getConfigCache()->get('database', 'password');
-			$db_data = $a->getConfigCache()->get('database', 'database');
+			//reload the config cache
+			$loader = new Config\Cache\ConfigCacheLoader($a->getBasePath(), $a->getMode());
+			$loader->loadConfigFiles($configCache);
+
 		} else {
 			// Creating config file
 			$this->out("Creating config file...\n");
 
 			$save_db = $this->getOption(['s', 'savedb'], false);
 
-			$db_host = $this->getOption(['H', 'dbhost'], ($save_db) ? getenv('MYSQL_HOST') : '');
+			//$db_host = $this->getOption(['H', 'dbhost'], ($save_db) ? (getenv('MYSQL_HOST') ? getenv('MYSQL_HOST') : Installer::DEFAULT_HOST) : '');
+			$db_host = $this->getOption(['H', 'dbhost'], ($save_db) ? (getenv('MYSQL_HOST')) : Installer::DEFAULT_HOST);
 			$db_port = $this->getOption(['p', 'dbport'], ($save_db) ? getenv('MYSQL_PORT') : null);
-			$db_data = $this->getOption(['d', 'dbdata'], ($save_db) ? getenv('MYSQL_DATABASE') : '');
-			$db_user = $this->getOption(['U', 'dbuser'], ($save_db) ? getenv('MYSQL_USER') . getenv('MYSQL_USERNAME') : '');
-			$db_pass = $this->getOption(['P', 'dbpass'], ($save_db) ? getenv('MYSQL_PASSWORD') : '');
-			$url_path = $this->getOption(['u', 'urlpath'], !empty('FRIENDICA_URL_PATH') ? getenv('FRIENDICA_URL_PATH') : null);
+			$configCache->set('database', 'hostname', $db_host . (!empty($db_port) ? ':' . $db_port : ''));
+			$configCache->set('database', 'database',
+				$this->getOption(['d', 'dbdata'],
+					($save_db) ? getenv('MYSQL_DATABASE') : ''));
+			$configCache->set('database', 'username',
+				$this->getOption(['U', 'dbuser'],
+					($save_db) ? getenv('MYSQL_USER') . getenv('MYSQL_USERNAME') : ''));
+			$configCache->set('database', 'password',
+				$this->getOption(['P', 'dbpass'],
+					($save_db) ? getenv('MYSQL_PASSWORD') : ''));
 			$php_path = $this->getOption(['b', 'phppath'], !empty('FRIENDICA_PHP_PATH') ? getenv('FRIENDICA_PHP_PATH') : null);
-			$admin_mail = $this->getOption(['A', 'admin'], !empty('FRIENDICA_ADMIN_MAIL') ? getenv('FRIENDICA_ADMIN_MAIL') : '');
-			$tz = $this->getOption(['T', 'tz'], !empty('FRIENDICA_TZ') ? getenv('FRIENDICA_TZ') : '');
-			$lang = $this->getOption(['L', 'lang'], !empty('FRIENDICA_LANG') ? getenv('FRIENDICA_LANG') : '');
+			if (!empty($php_path)) {
+				$configCache->set('config', 'php_path', $php_path);
+			}
+			$configCache->set('config', 'admin_email',
+				$this->getOption(['A', 'admin'],
+					!empty(getenv('FRIENDICA_ADMIN_MAIL')) ? getenv('FRIENDICA_ADMIN_MAIL') : ''));
+			$configCache->set('system', 'default_timezone',
+				$this->getOption(['T', 'tz'],
+					!empty(getenv('FRIENDICA_TZ')) ? getenv('FRIENDICA_TZ') : Installer::DEFAULT_TZ));
+			$configCache->set('system', 'language',
+				$this->getOption(['L', 'lang'],
+					!empty(getenv('FRIENDICA_LANG')) ? getenv('FRIENDICA_LANG') : Installer::DEFAULT_LANG));
+
 
 			if (empty($php_path)) {
-				$php_path = $installer->getPHPPath();
+				$configCache->set('config', 'php_path', $installer->getPHPPath());
 			}
 
 			$installer->createConfig(
-				$php_path,
-				$url_path,
-				(!empty($db_port) ? $db_host . ':' . $db_port : $db_host),
-				$db_user,
-				$db_pass,
-				$db_data,
-				$tz,
-				$lang,
-				$admin_mail,
+				$a,
+				$configCache,
 				$a->getBasePath()
 			);
 		}
@@ -146,7 +158,7 @@ HELP;
 
 		$installer->resetChecks();
 
-		if (!$installer->checkDB($a->getConfigCache(), $a->getProfiler(), $db_host, $db_user, $db_pass, $db_data)) {
+		if (!$installer->checkDB($configCache, $a->getProfiler())) {
 			$errorMessage = $this->extractErrors($installer->getChecks());
 			throw new RuntimeException($errorMessage);
 		}
@@ -180,12 +192,13 @@ HELP;
 	}
 
 	/**
-	 * @param Installer $installer the Installer instance
+	 * @param Installer                 $installer   The Installer instance
+	 * @param Config\Cache\IConfigCache $configCache The config cache
 	 *
 	 * @return bool true if checks were successfully, otherwise false
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
-	private function runBasicChecks(Installer $installer)
+	private function runBasicChecks(Installer $installer, Config\Cache\IConfigCache $configCache)
 	{
 		$checked = true;
 
@@ -207,8 +220,8 @@ HELP;
 		}
 
 		$php_path = null;
-		if (!empty(Config::get('config', 'php_path'))) {
-			$php_path = Config::get('config', 'php_path');
+		if (!$configCache->has('config', 'php_path')) {
+			$php_path = $configCache->get('config', 'php_path');
 		}
 
 		if (!$installer->checkPHP($php_path, true)) {

--- a/src/Core/Installer.php
+++ b/src/Core/Installer.php
@@ -6,6 +6,7 @@ namespace Friendica\Core;
 
 use DOMDocument;
 use Exception;
+use Friendica\App;
 use Friendica\Core\Config\Cache\IConfigCache;
 use Friendica\Database\DBA;
 use Friendica\Database\DBStructure;
@@ -129,33 +130,28 @@ class Installer
 	 * - Creates `config/local.config.php`
 	 * - Installs Database Structure
 	 *
-	 * @param string $phppath   Path to the PHP-Binary (optional, if not set e.g. 'php' or '/usr/bin/php')
-	 * @param string $urlpath   Path based on the URL of Friendica (e.g. '/friendica')
-	 * @param string $dbhost    Hostname/IP of the Friendica Database
-	 * @param string $dbuser    Username of the Database connection credentials
-	 * @param string $dbpass    Password of the Database connection credentials
-	 * @param string $dbdata    Name of the Database
-	 * @param string $timezone  Timezone of the Friendica Installaton (e.g. 'Europe/Berlin')
-	 * @param string $language  2-letter ISO 639-1 code (eg. 'en')
-	 * @param string $adminmail Mail-Adress of the administrator
+	 * @param App          $app         The Friendica App
+	 * @param IConfigCache $configCache The config cache with all config relevant information
 	 * @param string $basepath  The basepath of Friendica
 	 *
 	 * @return bool true if the config was created, otherwise false
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
-	public function createConfig($phppath, $urlpath, $dbhost, $dbuser, $dbpass, $dbdata, $timezone, $language, $adminmail, $basepath)
+	public function createConfig(App $app, IConfigCache $configCache, $basepath)
 	{
 		$tpl = Renderer::getMarkupTemplate('local.config.tpl');
 		$txt = Renderer::replaceMacros($tpl, [
-			'$phpath' => $phppath,
-			'$dbhost' => $dbhost,
-			'$dbuser' => $dbuser,
-			'$dbpass' => $dbpass,
-			'$dbdata' => $dbdata,
-			'$timezone' => $timezone,
-			'$language' => $language,
-			'$urlpath' => $urlpath,
-			'$adminmail' => $adminmail,
+			'$dbhost'    => $configCache->get('database', 'hostname'),
+			'$dbuser'    => $configCache->get('database', 'username'),
+			'$dbpass'    => $configCache->get('database', 'password'),
+			'$dbdata'    => $configCache->get('database', 'database'),
+
+			'$phpath'    => $this->getPHPPath(),
+			'$adminmail' => $configCache->get('config', 'admin_email'),
+
+			'$timezone'  => $configCache->get('system', 'default_timezone'),
+			'$language'  => $configCache->get('system', 'language'),
+			'$urlpath'   => $app->getURLPath(),
 		]);
 
 		$result = file_put_contents($basepath . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR . 'local.config.php', $txt);
@@ -593,16 +589,17 @@ class Installer
 	 *
 	 * @param IConfigCache $configCache The configuration cache
 	 * @param Profiler    $profiler    The profiler of this app
-	 * @param string $dbhost           Hostname/IP of the Friendica Database
-	 * @param string $dbuser           Username of the Database connection credentials
-	 * @param string $dbpass           Password of the Database connection credentials
-	 * @param string $dbdata           Name of the Database
 	 *
 	 * @return bool true if the check was successful, otherwise false
 	 * @throws Exception
 	 */
-	public function checkDB(IConfigCache $configCache, Profiler $profiler, $dbhost, $dbuser, $dbpass, $dbdata)
+	public function checkDB(IConfigCache $configCache, Profiler $profiler)
 	{
+		$dbhost = $configCache->get('database', 'hostname');
+		$dbuser = $configCache->get('database', 'username');
+		$dbpass = $configCache->get('database', 'password');
+		$dbdata = $configCache->get('database', 'database');
+
 		if (!DBA::connect($configCache, $profiler, $dbhost, $dbuser, $dbpass, $dbdata)) {
 			$this->addCheck(L10n::t('Could not connect to database.'), false, true, '');
 

--- a/src/Module/Install.php
+++ b/src/Module/Install.php
@@ -5,6 +5,7 @@ namespace Friendica\Module;
 use Friendica\App;
 use Friendica\BaseModule;
 use Friendica\Core;
+use Friendica\Core\Config\Cache\IConfigCache;
 use Friendica\Core\L10n;
 use Friendica\Core\Renderer;
 use Friendica\Util\Strings;
@@ -61,45 +62,48 @@ class Install extends BaseModule
 	public static function post()
 	{
 		$a = self::getApp();
+		$configCache = $a->getConfigCache();
 
 		switch (self::$currentWizardStep) {
 			case self::SYSTEM_CHECK:
 			case self::DATABASE_CONFIG:
-				// Nothing to do in these steps
+				self::checkSetting($configCache, $_POST, 'config', 'php_path');
 				break;
 
 			case self::SITE_SETTINGS:
-				$dbhost  = Strings::escapeTags(trim(defaults($_POST, 'dbhost', Core\Installer::DEFAULT_HOST)));
-				$dbuser  = Strings::escapeTags(trim(defaults($_POST, 'dbuser', '')));
-				$dbpass  = Strings::escapeTags(trim(defaults($_POST, 'dbpass', '')));
-				$dbdata  = Strings::escapeTags(trim(defaults($_POST, 'dbdata', '')));
+				self::checkSetting($configCache, $_POST, 'config', 'php_path');
+
+				self::checkSetting($configCache, $_POST, 'database', 'hostname', Core\Installer::DEFAULT_HOST);
+				self::checkSetting($configCache, $_POST, 'database', 'username', '');
+				self::checkSetting($configCache, $_POST, 'database', 'password', '');
+				self::checkSetting($configCache, $_POST, 'database', 'database', '');
 
 				// If we cannot connect to the database, return to the previous step
-				if (!self::$installer->checkDB($a->getConfigCache(), $a->getProfiler(), $dbhost, $dbuser, $dbpass, $dbdata)) {
+				if (!self::$installer->checkDB($configCache, $a->getProfiler())) {
 					self::$currentWizardStep = self::DATABASE_CONFIG;
 				}
 
 				break;
 
 			case self::FINISHED:
-				$urlpath   = $a->getURLPath();
-				$dbhost    = Strings::escapeTags(trim(defaults($_POST, 'dbhost', Core\Installer::DEFAULT_HOST)));
-				$dbuser    = Strings::escapeTags(trim(defaults($_POST, 'dbuser', '')));
-				$dbpass    = Strings::escapeTags(trim(defaults($_POST, 'dbpass', '')));
-				$dbdata    = Strings::escapeTags(trim(defaults($_POST, 'dbdata', '')));
-				$timezone  = Strings::escapeTags(trim(defaults($_POST, 'timezone', Core\Installer::DEFAULT_TZ)));
-				$language  = Strings::escapeTags(trim(defaults($_POST, 'language', Core\Installer::DEFAULT_LANG)));
-				$adminmail = Strings::escapeTags(trim(defaults($_POST, 'adminmail', '')));
+				self::checkSetting($configCache, $_POST, 'config', 'php_path');
+
+				self::checkSetting($configCache, $_POST, 'database', 'hostname', Core\Installer::DEFAULT_HOST);
+				self::checkSetting($configCache, $_POST, 'database', 'username', '');
+				self::checkSetting($configCache, $_POST, 'database', 'password', '');
+				self::checkSetting($configCache, $_POST, 'database', 'database', '');
+
+				self::checkSetting($configCache, $_POST, 'system', 'default_timezone', Core\Installer::DEFAULT_TZ);
+				self::checkSetting($configCache, $_POST, 'system', 'language', Core\Installer::DEFAULT_LANG);
+				self::checkSetting($configCache, $_POST, 'config', 'admin_email', '');
 
 				// If we cannot connect to the database, return to the Database config wizard
-				if (!self::$installer->checkDB($a->getConfigCache(), $a->getProfiler(), $dbhost, $dbuser, $dbpass, $dbdata)) {
+				if (!self::$installer->checkDB($configCache, $a->getProfiler())) {
 					self::$currentWizardStep = self::DATABASE_CONFIG;
 					return;
 				}
 
-				$phpath = self::$installer->getPHPPath();
-
-				if (!self::$installer->createConfig($phpath, $urlpath, $dbhost, $dbuser, $dbpass, $dbdata, $timezone, $language, $adminmail, $a->getBasePath())) {
+				if (!self::$installer->createConfig($a, $configCache, $a->getBasePath())) {
 					return;
 				}
 
@@ -112,6 +116,7 @@ class Install extends BaseModule
 	public static function content()
 	{
 		$a = self::getApp();
+		$configCache = $a->getConfigCache();
 
 		$output = '';
 
@@ -119,85 +124,62 @@ class Install extends BaseModule
 
 		switch (self::$currentWizardStep) {
 			case self::SYSTEM_CHECK:
-				$phppath = defaults($_POST, 'phpath', null);
+				$php_path = $configCache->get('config', 'php_path');
 
-				$status = self::$installer->checkEnvironment($a->getBaseURL(), $phppath);
+				$status = self::$installer->checkEnvironment($a->getBaseURL(), $php_path);
 
 				$tpl = Renderer::getMarkupTemplate('install_checks.tpl');
 				$output .= Renderer::replaceMacros($tpl, [
-					'$title'		=> $install_title,
-					'$pass'			=> L10n::t('System check'),
-					'$checks'		=> self::$installer->getChecks(),
-					'$passed'		=> $status,
-					'$see_install'	=> L10n::t('Please see the file "INSTALL.txt".'),
-					'$next' 		=> L10n::t('Next'),
-					'$reload' 		=> L10n::t('Check again'),
-					'$phpath' 		=> $phppath,
-					'$baseurl' 		=> $a->getBaseURL()
+					'$title'        => $install_title,
+					'$pass'         => L10n::t('System check'),
+					'$checks'       => self::$installer->getChecks(),
+					'$passed'       => $status,
+					'$see_install'  => L10n::t('Please see the file "INSTALL.txt".'),
+					'$next'         => L10n::t('Next'),
+					'$reload'       => L10n::t('Check again'),
+					'$php_path'     => $php_path,
+					'$baseurl'      => $a->getBaseURL()
 				]);
 				break;
 
 			case self::DATABASE_CONFIG:
-				$dbhost    = Strings::escapeTags(trim(defaults($_POST, 'dbhost'   , Core\Installer::DEFAULT_HOST)));
-				$dbuser    = Strings::escapeTags(trim(defaults($_POST, 'dbuser'   , ''                          )));
-				$dbpass    = Strings::escapeTags(trim(defaults($_POST, 'dbpass'   , ''                          )));
-				$dbdata    = Strings::escapeTags(trim(defaults($_POST, 'dbdata'   , ''                          )));
-				$phpath    = Strings::escapeTags(trim(defaults($_POST, 'phpath'   , ''                          )));
-				$adminmail = Strings::escapeTags(trim(defaults($_POST, 'adminmail', ''                          )));
-
 				$tpl = Renderer::getMarkupTemplate('install_db.tpl');
 				$output .= Renderer::replaceMacros($tpl, [
-					'$title' 	=> $install_title,
-					'$pass' 	=> L10n::t('Database connection'),
-					'$info_01' 	=> L10n::t('In order to install Friendica we need to know how to connect to your database.'),
-					'$info_02' 	=> L10n::t('Please contact your hosting provider or site administrator if you have questions about these settings.'),
-					'$info_03' 	=> L10n::t('The database you specify below should already exist. If it does not, please create it before continuing.'),
-					'checks' 	=> self::$installer->getChecks(),
-					'$dbhost' 	=> ['dbhost',
+					'$title'    => $install_title,
+					'$pass'     => L10n::t('Database connection'),
+					'$info_01'  => L10n::t('In order to install Friendica we need to know how to connect to your database.'),
+					'$info_02'  => L10n::t('Please contact your hosting provider or site administrator if you have questions about these settings.'),
+					'$info_03'  => L10n::t('The database you specify below should already exist. If it does not, please create it before continuing.'),
+					'checks'    => self::$installer->getChecks(),
+					'$dbhost'   => ['database-hostname',
 									L10n::t('Database Server Name'),
-									$dbhost,
+									$configCache->get('database', 'hostname'),
 									'',
 									'required'],
-					'$dbuser' 	=> ['dbuser',
+					'$dbuser'   => ['database-username',
 									L10n::t('Database Login Name'),
-									$dbuser,
+									$configCache->get('database', 'username'),
 									'',
 									'required',
 									'autofocus'],
-					'$dbpass' 	=> ['dbpass',
+					'$dbpass'   => ['database-password',
 									L10n::t('Database Login Password'),
-									$dbpass,
+									$configCache->get('database', 'password'),
 									L10n::t("For security reasons the password must not be empty"),
 									'required'],
-					'$dbdata' 	=> ['dbdata',
+					'$dbdata'   => ['database-database',
 									L10n::t('Database Name'),
-									$dbdata,
+									$configCache->get('database', 'database'),
 									'',
 									'required'],
-					'$adminmail' => ['adminmail',
-									L10n::t('Site administrator email address'),
-									$adminmail,
-									L10n::t('Your account email address must match this in order to use the web admin panel.'),
-									'required',
-									'autofocus',
-									'email'],
-					'$lbl_10' 	=> L10n::t('Please select a default timezone for your website'),
-					'$baseurl' 	=> $a->getBaseURL(),
-					'$phpath' 	=> $phpath,
-					'$submit' 	=> L10n::t('Submit')
+					'$lbl_10'   => L10n::t('Please select a default timezone for your website'),
+					'$baseurl'  => $a->getBaseURL(),
+					'$php_path' => $configCache->get('config', 'php_path'),
+					'$submit'   => L10n::t('Submit')
 				]);
 				break;
 
 			case self::SITE_SETTINGS:
-				$dbhost = Strings::escapeTags(trim(defaults($_POST, 'dbhost', Core\Installer::DEFAULT_HOST)));
-				$dbuser = Strings::escapeTags(trim(defaults($_POST, 'dbuser', ''                          )));
-				$dbpass = Strings::escapeTags(trim(defaults($_POST, 'dbpass', ''                          )));
-				$dbdata = Strings::escapeTags(trim(defaults($_POST, 'dbdata', ''                          )));
-				$phpath = Strings::escapeTags(trim(defaults($_POST, 'phpath', ''                          )));
-
-				$adminmail = Strings::escapeTags(trim(defaults($_POST, 'adminmail', '')));
-
-				$timezone = defaults($_POST, 'timezone', Core\Installer::DEFAULT_TZ);
 				/* Installed langs */
 				$lang_choices = L10n::getAvailableLanguages();
 
@@ -206,16 +188,23 @@ class Install extends BaseModule
 					'$title' 		=> $install_title,
 					'$checks' 		=> self::$installer->getChecks(),
 					'$pass' 		=> L10n::t('Site settings'),
-					'$dbhost' 		=> $dbhost,
-					'$dbuser' 		=> $dbuser,
-					'$dbpass' 		=> $dbpass,
-					'$dbdata' 		=> $dbdata,
-					'$phpath' 		=> $phpath,
-					'$adminmail'	=> ['adminmail', L10n::t('Site administrator email address'), $adminmail, L10n::t('Your account email address must match this in order to use the web admin panel.'), 'required', 'autofocus', 'email'],
-					'$timezone' 	=> Temporal::getTimezoneField('timezone', L10n::t('Please select a default timezone for your website'), $timezone, ''),
-					'$language' 	=> ['language',
+					'$dbhost' 		=> $configCache->get('database', 'hostname'),
+					'$dbuser' 		=> $configCache->get('database', 'username'),
+					'$dbpass' 		=> $configCache->get('database', 'password'),
+					'$dbdata' 		=> $configCache->get('database', 'database'),
+					'$phpath' 		=> $configCache->get('config', 'php_path'),
+					'$adminmail'	=> ['config-admin_email',
+										L10n::t('Site administrator email address'),
+										$configCache->get('config', 'admin_email'),
+										L10n::t('Your account email address must match this in order to use the web admin panel.'),
+										'required', 'autofocus', 'email'],
+					'$timezone' 	=> Temporal::getTimezoneField('system-default_timezone',
+										L10n::t('Please select a default timezone for your website'),
+										$configCache->get('system', 'default_timezone'),
+									''),
+					'$language' 	=> ['system-language',
 										L10n::t('System Language:'),
-										Core\Installer::DEFAULT_LANG,
+										$configCache->get('system', 'language'),
 										L10n::t('Set the default language for your Friendica installation interface and to send emails.'),
 										$lang_choices],
 					'$baseurl' 		=> $a->getBaseURL(),
@@ -264,5 +253,25 @@ class Install extends BaseModule
 			. "</p><p>"
 			. L10n::t('Go to your new Friendica node <a href="%s/register">registration page</a> and register as new user. Remember to use the same email you have entered as administrator email. This will allow you to enter the site admin panel.', $baseurl)
 			. "</p>";
+	}
+
+	/**
+	 * Checks the $_POST settings and updates the config Cache for it
+	 *
+	 * @param IConfigCache $configCache The current config cache
+	 * @param array        $post        The $_POST data
+	 * @param string       $cat         The category of the setting
+	 * @param string       $key         The key of the setting
+	 * @param null|string  $default     The default value
+	 */
+	private static function checkSetting(IConfigCache $configCache, array $post, $cat, $key, $default = null)
+	{
+		$configCache->set($cat, $key,
+			Strings::escapeTags(
+				trim(defaults($post, sprintf('%s-%s', $cat, $key),
+						(!isset($default) ? $configCache->get($cat, $key) : $default))
+				)
+			)
+		);
 	}
 }

--- a/tests/Util/AppMockTrait.php
+++ b/tests/Util/AppMockTrait.php
@@ -40,6 +40,7 @@ trait AppMockTrait
 	 *
 	 * @param vfsStreamDirectory $root The root directory
 	 * @param Config\Cache\ConfigCache $configCache
+	 * @param bool $raw If true, no config mocking will be done
 	 */
 	public function mockApp(vfsStreamDirectory $root, $configCache = null, $raw = false)
 	{
@@ -81,7 +82,7 @@ trait AppMockTrait
 		$this->app
 			->shouldReceive('getBaseUrl')
 			->andReturnUsing(function () {
-				return $this->configMock->get('system', 'url');
+				return $this->app->getConfigCache()->get('system', 'url');
 			});
 
 		BaseObject::setApp($this->app);
@@ -90,6 +91,9 @@ trait AppMockTrait
 			return;
 		}
 
+		$this->configMock
+			->shouldReceive('has')
+			->andReturn(true);
 		$this->configMock
 			->shouldReceive('get')
 			->with('database', 'hostname')

--- a/tests/Util/AppMockTrait.php
+++ b/tests/Util/AppMockTrait.php
@@ -31,6 +31,11 @@ trait AppMockTrait
 	protected $profilerMock;
 
 	/**
+	 * @var MockInterface|App\Mode The mocked App mode
+	 */
+	protected $mode;
+
+	/**
 	 * Mock the App
 	 *
 	 * @param vfsStreamDirectory $root The root directory
@@ -38,6 +43,7 @@ trait AppMockTrait
 	public function mockApp($root)
 	{
 		$this->configMock = \Mockery::mock(Config\Cache\IConfigCache::class);
+		$this->mode = \Mockery::mock(App\Mode::class);
 		$configAdapterMock = \Mockery::mock(Config\Adapter\IConfigAdapter::class);
 		// Disable the adapter
 		$configAdapterMock->shouldReceive('isConnected')->andReturn(false);
@@ -51,6 +57,10 @@ trait AppMockTrait
 		$this->app
 			->shouldReceive('getBasePath')
 			->andReturn($root->url());
+
+		$this->app
+			->shouldReceive('getMode')
+			->andReturn($this->mode);
 
 		$this->configMock
 			->shouldReceive('has')

--- a/tests/Util/RendererMockTrait.php
+++ b/tests/Util/RendererMockTrait.php
@@ -35,14 +35,18 @@ trait RendererMockTrait
 	 * Mocking the method 'Renderer::replaceMacros()'
 	 *
 	 * @param string $template The template to use (normally, it is the mock result of 'mockGetMarkupTemplate()'
-	 * @param array $args The arguments to pass to the macro
+	 * @param array|\Closure|null $args The arguments to pass to the macro
 	 * @param string $return the return value of the mock
 	 * @param null|int $times How often the method will get used
 	 */
-	public function mockReplaceMacros($template, $args = [], $return = '', $times = null)
+	public function mockReplaceMacros($template, $args = null, $return = '', $times = null)
 	{
 		if (!isset($this->rendererMock)) {
 			$this->rendererMock = \Mockery::mock('alias:Friendica\Core\Renderer');
+		}
+
+		if (!isset($args)) {
+			$args = [];
 		}
 
 		$this->rendererMock

--- a/tests/Util/VFSTrait.php
+++ b/tests/Util/VFSTrait.php
@@ -25,7 +25,7 @@ trait VFSTrait
 		];
 
 		// create a virtual directory and copy all needed files and folders to it
-		$this->root = vfsStream::setup('friendica', null, $structure);
+		$this->root = vfsStream::setup('friendica', 0777, $structure);
 
 		$this->setConfigFile('defaults.config.php');
 		$this->setConfigFile('settings.config.php');

--- a/tests/src/Core/Console/AutomaticInstallationConsoleTest.php
+++ b/tests/src/Core/Console/AutomaticInstallationConsoleTest.php
@@ -4,6 +4,7 @@ namespace Friendica\Test\src\Core\Console;
 
 use Friendica\Core\Config\Cache\ConfigCache;
 use Friendica\Core\Console\AutomaticInstallation;
+use Friendica\Core\Installer;
 use Friendica\Core\Logger;
 use Friendica\Test\Util\DBAMockTrait;
 use Friendica\Test\Util\DBStructureMockTrait;
@@ -14,8 +15,6 @@ use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamFile;
 
 /**
- * @runTestsInSeparateProcesses
- * @preserveGlobalState disabled
  * @requires PHP 7.0
  */
 class AutomaticInstallationConsoleTest extends ConsoleTest
@@ -59,33 +58,62 @@ class AutomaticInstallationConsoleTest extends ConsoleTest
 	}
 
 	/**
-	 * Creates the arguments which is asserted to be passed to 'replaceMacros()' for creating the local.config.php
+	 * Returns the dataset for each automatic installation test
 	 *
-	 * @param ConfigCache $config The config cache of this test
-	 *
-	 * @return array The arguments to pass to the mock for 'replaceMacros()'
+	 * @return array the dataset
 	 */
-	private function createArgumentsForMacro(ConfigCache $config)
+	public function dataInstaller()
 	{
-		$args = [
-			'$dbhost' => $config->get('database','hostname'),
-			'$dbuser' => $config->get('database','username'),
-			'$dbpass' => $config->get('database','password'),
-			'$dbdata' => $config->get('database','database'),
-
-			'$phpath' => $config->get('config','php_path'),
-			'$adminmail' => $config->get('config','admin_email'),
-			'$hostname' => $config->get('config','hostname'),
-
-			'$urlpath' => $config->get('system','urlpath'),
-			'$baseurl' => $config->get('system','url'),
-			'$sslpolicy' => $config->get('system','ssl_policy'),
-			'$timezone' => $config->get('system','default_timezone'),
-			'$language' => $config->get('system','language'),
-			'$basepath' => $config->get('system','basepath'),
+		return [
+			'empty' => [
+				'data' => [
+					'database' => [
+						'hostname'    => '',
+						'username'    => '',
+						'password'    => '',
+						'database'    => '',
+						'port'        => '',
+					],
+					'config' => [
+						'php_path'    => '',
+						'hostname'    => '',
+						'admin_email' => '',
+					],
+					'system' => [
+						'urlpath'     => '',
+						'url'         => '',
+						'basepath'    => '',
+						'ssl_policy'  => '',
+						'default_timezone' => '',
+						'language'    => '',
+					],
+				],
+			],
+			'normal' => [
+				'data' => [
+					'database' => [
+						'hostname'    => getenv('MYSQL_HOST'),
+						'port'        =>!empty(getenv('MYSQL_PORT')) ? getenv('MYSQL_PORT') : null,
+						'username'    => getenv('MYSQL_USERNAME'),
+						'password'    => getenv('MYSQL_PASSWORD'),
+						'database'    => getenv('MYSQL_DATABASE'),
+					],
+					'config' => [
+						'php_path'    => '',
+						'hostname'    => 'friendica.local',
+						'admin_email' => 'admin@philipp.info',
+					],
+					'system' => [
+						'urlpath'     => 'test/it',
+						'url'         => 'friendica.local/test/it',
+						'basepath'    => '',
+						'ssl_policy'  => '2',
+						'default_timezone' => 'en',
+						'language'    => 'Europe/Berlin',
+					],
+				],
+			],
 		];
-
-		return $args;
 	}
 
 	private function assertFinished($txt, $withconfig = false, $copyfile = false)
@@ -180,73 +208,24 @@ FIN;
 		$this->assertEquals($finished, $txt);
 	}
 
-	public function dataInstaller()
-	{
-		return [
-			'empty' => [
-				'data' => [
-					'database' => [
-						'hostname'    => '',
-						'username'    => '',
-						'password'    => '',
-						'database'    => '',
-					],
-					'config' => [
-						'php_path'    => '',
-						'hostname'    => '',
-						'admin_email' => '',
-					],
-					'system' => [
-						'urlpath'     => '',
-						'url'         => '',
-						'basepath'    => '',
-						'ssl_policy'  => '',
-						'default_timezone' => '',
-						'language'    => '',
-					],
-				],
-			],
-			'normal' => [
-				'data' => [
-					'database' => [
-						'hostname'    => getenv('MYSQL_HOST'),
-						'port'        =>!empty(getenv('MYSQL_PORT')) ? getenv('MYSQL_PORT') : null,
-						'username'    => getenv('MYSQL_USERNAME'),
-						'password'    => getenv('MYSQL_PASSWORD'),
-						'database'    => getenv('MYSQL_DATABASE'),
-					],
-					'config' => [
-						'php_path'    => '',
-						'hostname'    => 'friendica.local',
-						'admin_email' => 'admin@philipp.info',
-					],
-					'system' => [
-						'urlpath'     => 'test/it',
-						'url'         => 'friendica.local/test/it',
-						'basepath'    => '',
-						'ssl_policy'  => '2',
-						'default_timezone' => 'en',
-						'language'    => 'Europe/Berlin',
-					],
-				],
-			],
-		];
-	}
-
 	/**
-	 * Test the automatic installation without any parameter
-	 * @dataProvider dataInstaller
+	 * Test the automatic installation without any parameter/setting
 	 */
-	public function testEmpty(array $data)
+	public function testEmpty()
 	{
 		$configCache = new ConfigCache();
-		$configCache->load($data);
 		$configCache->set('system', 'basepath', $this->root->url());
 		$configCache->set('config', 'php_path', trim(shell_exec('which php')));
 
 		$this->mockApp($this->root, null, true);
 
-		$this->configMock->shouldReceive('set');
+		$this->configMock->shouldReceive('set')->andReturnUsing(function ($cat, $key, $value) use ($configCache) {
+			if ($key !== 'basepath') {
+				return $configCache->set($cat, $key, $value);
+			} else {
+				return true;
+			}
+		});;
 		$this->configMock->shouldReceive('has')->andReturn(true);
 		$this->configMock->shouldReceive('get')->andReturnUsing(function ($cat, $key) use ($configCache) {
 			return $configCache->get($cat, $key);
@@ -258,7 +237,7 @@ FIN;
 		$this->mockUpdate([$this->root->url(), false, true, true], null, 1);
 
 		$this->mockGetMarkupTemplate('local.config.tpl', 'testTemplate', 1);
-		$this->mockReplaceMacros('testTemplate', $this->createArgumentsForMacro($configCache), '', 1);
+		$this->mockReplaceMacros('testTemplate', \Mockery::any(), '', 1);
 
 		$console = new AutomaticInstallation($this->consoleArgv);
 
@@ -266,10 +245,26 @@ FIN;
 
 		$this->assertFinished($txt, true, false);
 		$this->assertTrue($this->root->hasChild('config' . DIRECTORY_SEPARATOR . 'local.config.php'));
+
+		// Assert the default values without any config
+		$this->assertEquals(Installer::DEFAULT_HOST, $configCache->get('database', 'hostname'));
+		$this->assertEmpty($configCache->get('database', 'username'));
+		$this->assertEmpty($configCache->get('database', 'password'));
+		$this->assertEmpty($configCache->get('database', 'database'));
+
+		$this->assertEmpty($configCache->get('config', 'hostname'), $configCache->get('config', 'hostname'));
+		$this->assertEmpty($configCache->get('config', 'admin_email'), $configCache->get('config', 'admin_email'));
+		$this->assertEquals(trim(shell_exec('which php')), $configCache->get('config', 'php_path'));
+
+		$this->assertEquals(Installer::DEFAULT_TZ, $configCache->get('system', 'default_timezone'));
+		$this->assertEquals(Installer::DEFAULT_LANG, $configCache->get('system', 'language'));
+		$this->assertEquals(SSL_POLICY_NONE, $configCache->get('system', 'ssl_policy'));
+		$this->assertEmpty($configCache->get('system', 'urlpath'), $configCache->get('system', 'urlpath'));
+		$this->assertEquals($this->root->url(), $configCache->get('system', 'basepath'));
 	}
 
 	/**
-	 * @medium
+	 * Test the automatic installation with a prepared config file
 	 * @dataProvider dataInstaller
 	 */
 	public function testWithConfig(array $data)
@@ -348,7 +343,8 @@ CONF;
 	}
 
 	/**
-	 * @medium
+	 * Test the automatic installation with environment variables
+	 * Includes saving the DB credentials to the file
 	 * @dataProvider dataInstaller
 	 */
 	public function testWithEnvironmentAndSave(array $data)
@@ -357,7 +353,19 @@ CONF;
 		$configCache->set('system', 'basepath', $this->root->url());
 		$configCache->set('config', 'php_path', trim(shell_exec('which php')));
 
-		$this->mockApp($this->root, $configCache);
+		$this->mockApp($this->root, null, true);
+
+		$this->configMock->shouldReceive('set')->andReturnUsing(function ($cat, $key, $value) use ($configCache) {
+			if ($key !== 'basepath') {
+				return $configCache->set($cat, $key, $value);
+			} else {
+				return true;
+			}
+		});;
+		$this->configMock->shouldReceive('has')->andReturn(true);
+		$this->configMock->shouldReceive('get')->andReturnUsing(function ($cat, $key) use ($configCache) {
+			return $configCache->get($cat, $key);
+		});
 
 		$this->mockConnect(true, 1);
 		$this->mockConnected(true, 1);
@@ -365,80 +373,219 @@ CONF;
 		$this->mockUpdate([$this->root->url(), false, true, true], null, 1);
 
 		$this->mockGetMarkupTemplate('local.config.tpl', 'testTemplate', 1);
-		$this->mockReplaceMacros('testTemplate', $this->createArgumentsForMacro($configCache), '', 1);
+		$this->mockReplaceMacros('testTemplate', \Mockery::any(), '', 1);
 
-		$this->assertTrue(putenv('FRIENDICA_ADMIN_MAIL=admin@friendica.local'));
-		$this->assertTrue(putenv('FRIENDICA_TZ=Europe/Berlin'));
-		$this->assertTrue(putenv('FRIENDICA_LANG=de'));
-		$this->assertTrue(putenv('FRIENDICA_URL_PATH=/friendica'));
+		$this->assertTrue(putenv('MYSQL_HOST='     . $data['database']['hostname']));
+		$this->assertTrue(putenv('MYSQL_PORT='     . $data['database']['port']));
+		$this->assertTrue(putenv('MYSQL_DATABASE=' . $data['database']['database']));
+		$this->assertTrue(putenv('MYSQL_USERNAME=' . $data['database']['username']));
+		$this->assertTrue(putenv('MYSQL_PASSWORD=' . $data['database']['password']));
+
+		$this->assertTrue(putenv('FRIENDICA_URL_PATH='   . $data['system']['urlpath']));
+		$this->assertTrue(putenv('FRIENDICA_BASE_PATH='  . $data['system']['basepath']));
+		$this->assertTrue(putenv('FRIENDICA_PHP_PATH='   . $data['config']['php_path']));
+		$this->assertTrue(putenv('FRIENDICA_SSL_POLICY=' . $data['system']['ssl_policy']));
+		$this->assertTrue(putenv('FRIENDICA_HOSTNAME='   . $data['config']['hostname']));
+		$this->assertTrue(putenv('FRIENDICA_ADMIN_MAIL=' . $data['config']['admin_email']));
+		$this->assertTrue(putenv('FRIENDICA_TZ='         . $data['system']['default_timezone']));
+		$this->assertTrue(putenv('FRIENDICA_LANG='       . $data['system']['language']));
 
 		$console = new AutomaticInstallation($this->consoleArgv);
 		$console->setOption('savedb', true);
 
 		$txt = $this->dumpExecute($console);
 
-		print_r($configCache);
+		// Assert the default values without any config
+		$dbhost = $data['database']['hostname'] . (!empty($data['database']['port']) ? ':' . $data['database']['port'] : '');
+		$this->assertEquals($dbhost, $configCache->get('database', 'hostname'));
+		$this->assertEquals($data['database']['username'], $configCache->get('database', 'username'));
+		$this->assertEquals($data['database']['database'], $configCache->get('database', 'database'));
+		$this->assertEquals($data['database']['password'], $configCache->get('database', 'password'));
+
+		$this->assertEquals($data['config']['hostname'], $configCache->get('config', 'hostname'));
+		$this->assertEquals($data['config']['admin_email'], $configCache->get('config', 'admin_email'));
+		$this->assertEquals(trim(shell_exec('which php')), $configCache->get('config', 'php_path'));
+
+		$this->assertEquals((!empty($data['system']['default_timezone']) ? $data['system']['default_timezone'] : Installer::DEFAULT_TZ),
+			$configCache->get('system', 'default_timezone'));
+		$this->assertEquals((!empty($data['system']['language']) ? $data['system']['language'] : Installer::DEFAULT_LANG),
+			$configCache->get('system', 'language'));
+		$this->assertEquals((!empty($data['system']['ssl_policy']) ? $data['system']['ssl_policy'] : SSL_POLICY_NONE),
+			$configCache->get('system', 'ssl_policy'));
+		$this->assertEquals((!empty($data['system']['urlpath']) ? $data['system']['urlpath'] : null),
+			$configCache->get('system', 'urlpath'));
 
 		$this->assertFinished($txt, true);
 	}
 
 	/**
-	 * @medium
+	 * Test the automatic installation with environment variables
+	 * Don't save the db credentials to the file
+	 * @dataProvider dataInstaller
 	 */
-	public function testWithEnvironmentWithoutSave()
+	public function testWithEnvironmentWithoutSave(array $data)
 	{
+		$configCache = new ConfigCache();
+		$configCache->set('system', 'basepath', $this->root->url());
+		$configCache->set('config', 'php_path', trim(shell_exec('which php')));
+
+		$this->mockApp($this->root, null, true);
+
+		$this->configMock->shouldReceive('set')->andReturnUsing(function ($cat, $key, $value) use ($configCache) {
+			if ($key !== 'basepath') {
+				return $configCache->set($cat, $key, $value);
+			} else {
+				return true;
+			}
+		});;
+		$this->configMock->shouldReceive('has')->andReturn(true);
+		$this->configMock->shouldReceive('get')->andReturnUsing(function ($cat, $key) use ($configCache) {
+			return $configCache->get($cat, $key);
+		});
+
 		$this->mockConnect(true, 1);
 		$this->mockConnected(true, 1);
 		$this->mockExistsTable('user', false, 1);
 		$this->mockUpdate([$this->root->url(), false, true, true], null, 1);
 
 		$this->mockGetMarkupTemplate('local.config.tpl', 'testTemplate', 1);
-		$this->mockReplaceMacros('testTemplate', $this->createArgumentsForMacro(false), '', 1);
+		$this->mockReplaceMacros('testTemplate', \Mockery::any(), '', 1);
 
-		$this->assertTrue(putenv('FRIENDICA_ADMIN_MAIL=admin@friendica.local'));
-		$this->assertTrue(putenv('FRIENDICA_TZ=Europe/Berlin'));
-		$this->assertTrue(putenv('FRIENDICA_LANG=de'));
-		$this->assertTrue(putenv('FRIENDICA_URL_PATH=/friendica'));
+		$this->assertTrue(putenv('MYSQL_HOST=' . $data['database']['hostname']));
+		$this->assertTrue(putenv('MYSQL_PORT=' . $data['database']['port']));
+		$this->assertTrue(putenv('MYSQL_DATABASE=' . $data['database']['database']));
+		$this->assertTrue(putenv('MYSQL_USERNAME=' . $data['database']['username']));
+		$this->assertTrue(putenv('MYSQL_PASSWORD=' . $data['database']['password']));
+
+		$this->assertTrue(putenv('FRIENDICA_URL_PATH=' . $data['system']['urlpath']));
+		$this->assertTrue(putenv('FRIENDICA_BASE_PATH=' . $data['system']['basepath']));
+		$this->assertTrue(putenv('FRIENDICA_PHP_PATH=' . $data['config']['php_path']));
+		$this->assertTrue(putenv('FRIENDICA_SSL_POLICY=' . $data['system']['ssl_policy']));
+		$this->assertTrue(putenv('FRIENDICA_HOSTNAME=' . $data['config']['hostname']));
+		$this->assertTrue(putenv('FRIENDICA_ADMIN_MAIL=' . $data['config']['admin_email']));
+		$this->assertTrue(putenv('FRIENDICA_TZ=' . $data['system']['default_timezone']));
+		$this->assertTrue(putenv('FRIENDICA_LANG=' . $data['system']['language']));
 
 		$console = new AutomaticInstallation($this->consoleArgv);
 
 		$txt = $this->dumpExecute($console);
 
+		$this->assertEquals(Installer::DEFAULT_HOST, $configCache->get('database', 'hostname'));
+		$this->assertEmpty($configCache->get('database', 'username'), $configCache->get('database', 'username'));
+		$this->assertEmpty($configCache->get('database', 'password'), $configCache->get('database', 'password'));
+		$this->assertEmpty($configCache->get('database', 'database'), $configCache->get('database', 'database'));
+
+		$this->assertEquals($data['config']['hostname'], $configCache->get('config', 'hostname'));
+		$this->assertEquals($data['config']['admin_email'], $configCache->get('config', 'admin_email'));
+		$this->assertEquals(trim(shell_exec('which php')), $configCache->get('config', 'php_path'));
+
+		$this->assertEquals((!empty($data['system']['default_timezone']) ? $data['system']['default_timezone'] : Installer::DEFAULT_TZ),
+			$configCache->get('system', 'default_timezone'));
+		$this->assertEquals((!empty($data['system']['language']) ? $data['system']['language'] : Installer::DEFAULT_LANG),
+			$configCache->get('system', 'language'));
+		$this->assertEquals((!empty($data['system']['ssl_policy']) ? $data['system']['ssl_policy'] : SSL_POLICY_NONE),
+			$configCache->get('system', 'ssl_policy'));
+		$this->assertEquals((!empty($data['system']['urlpath']) ? $data['system']['urlpath'] : null),
+			$configCache->get('system', 'urlpath'));
+
 		$this->assertFinished($txt, true);
 	}
 
 	/**
-	 * @medium
+	 * Test the automatic installation with arguments
+	 * @dataProvider dataInstaller
 	 */
-	public function testWithArguments()
+	public function testWithArguments(array $data)
 	{
+		$configCache = new ConfigCache();
+		$configCache->set('system', 'basepath', $this->root->url());
+		$configCache->set('config', 'php_path', trim(shell_exec('which php')));
+
+		$this->mockApp($this->root, null, true);
+
+		$this->configMock->shouldReceive('set')->andReturnUsing(function ($cat, $key, $value) use ($configCache) {
+			if ($key !== 'basepath') {
+				return $configCache->set($cat, $key, $value);
+			} else {
+				return true;
+			}
+		});;
+		$this->configMock->shouldReceive('has')->andReturn(true);
+		$this->configMock->shouldReceive('get')->andReturnUsing(function ($cat, $key) use ($configCache) {
+			return $configCache->get($cat, $key);
+		});
+
 		$this->mockConnect(true, 1);
 		$this->mockConnected(true, 1);
 		$this->mockExistsTable('user', false, 1);
 		$this->mockUpdate([$this->root->url(), false, true, true], null, 1);
 
 		$this->mockGetMarkupTemplate('local.config.tpl', 'testTemplate', 1);
-		$this->mockReplaceMacros('testTemplate', $this->createArgumentsForMacro(true), '', 1);
+		$this->mockReplaceMacros('testTemplate', \Mockery::any(), '', 1);
 
 		$console = new AutomaticInstallation($this->consoleArgv);
 
-		$console->setOption('dbhost', $this->db_host);
-		$console->setOption('dbuser', $this->db_user);
-		if (!empty($this->db_pass)) {
-			$console->setOption('dbpass', $this->db_pass);
+		if (!empty($data['database']['hostname'])) {
+			$console->setOption('dbhost', $data['database']['hostname']);
 		}
-		if (!empty($this->db_port)) {
-			$console->setOption('dbport', $this->db_port);
+		if (!empty($data['database']['port'])) {
+			$console->setOption('dbport', $data['database']['port']);
 		}
-		$console->setOption('dbdata', $this->db_data);
-
-		$console->setOption('admin', 'admin@friendica.local');
-		$console->setOption('tz', 'Europe/Berlin');
-		$console->setOption('lang', 'de');
-
-		$console->setOption('urlpath', '/friendica');
+		if (!empty($data['database']['username'])) {
+			$console->setOption('dbuser', $data['database']['username']);
+		}
+		if (!empty($data['database']['password'])) {
+			$console->setOption('dbpass', $data['database']['password']);
+		}
+		if (!empty($data['database']['database'])) {
+			$console->setOption('dbdata', $data['database']['database']);
+		}
+		if (!empty($data['system']['urlpath'])) {
+			$console->setOption('urlpath', $data['system']['urlpath']);
+		}
+		if (!empty($data['system']['basepath'])) {
+			$console->setOption('basepath', $data['system']['basepath']);
+		}
+		if (!empty($data['config']['php_path'])) {
+			$console->setOption('phppath', $data['config']['php_path']);
+		}
+		if (!empty($data['system']['ssl_policy'])) {
+			$console->setOption('sslpolicy', $data['system']['ssl_policy']);
+		}
+		if (!empty($data['config']['hostname'])) {
+			$console->setOption('hostname', $data['config']['hostname']);
+		}
+		if (!empty($data['config']['admin_email'])) {
+			$console->setOption('admin', $data['config']['admin_email']);
+		}
+		if (!empty($data['system']['default_timezone'])) {
+			$console->setOption('tz', $data['system']['default_timezone']);
+		}
+		if (!empty($data['system']['language'])) {
+			$console->setOption('lang', $data['system']['language']);
+		}
 
 		$txt = $this->dumpExecute($console);
+
+		$dbhost = (!empty($data['database']['hostname'])) ? $data['database']['hostname'] : Installer::DEFAULT_HOST;
+		$dbhost .= (!empty($data['database']['port']) ? ':' . $data['database']['port'] : '');
+		$this->assertEquals($dbhost, $configCache->get('database', 'hostname'));
+		$this->assertEquals($data['database']['username'], $configCache->get('database', 'username'));
+		$this->assertEquals($data['database']['database'], $configCache->get('database', 'database'));
+		$this->assertEquals($data['database']['password'], $configCache->get('database', 'password'));
+
+		$this->assertEquals($data['config']['hostname'], $configCache->get('config', 'hostname'));
+		$this->assertEquals($data['config']['admin_email'], $configCache->get('config', 'admin_email'));
+		$this->assertEquals(trim(shell_exec('which php')), $configCache->get('config', 'php_path'));
+
+		$this->assertEquals((!empty($data['system']['default_timezone']) ? $data['system']['default_timezone'] : Installer::DEFAULT_TZ),
+			$configCache->get('system', 'default_timezone'));
+		$this->assertEquals((!empty($data['system']['language']) ? $data['system']['language'] : Installer::DEFAULT_LANG),
+			$configCache->get('system', 'language'));
+		$this->assertEquals((!empty($data['system']['ssl_policy']) ? $data['system']['ssl_policy'] : SSL_POLICY_NONE),
+			$configCache->get('system', 'ssl_policy'));
+		$this->assertEquals((!empty($data['system']['urlpath']) ? $data['system']['urlpath'] : null),
+			$configCache->get('system', 'urlpath'));
 
 		$this->assertFinished($txt, true);
 	}
@@ -485,17 +632,19 @@ Options
     -v                      Show more debug information.
     -a                      All setup checks are required (except .htaccess)
     -f|--file <config>      prepared config file (e.g. "config/local.config.php" itself) which will override every other config option - except the environment variables)
-    -s|--savedb             Save the DB credentials to the file (if environment variables is used)
-    -H|--dbhost <host>      The host of the mysql/mariadb database (env MYSQL_HOST)
-    -p|--dbport <port>      The port of the mysql/mariadb database (env MYSQL_PORT)
-    -d|--dbdata <database>  The name of the mysql/mariadb database (env MYSQL_DATABASE)
-    -U|--dbuser <username>  The username of the mysql/mariadb database login (env MYSQL_USER or MYSQL_USERNAME)
-    -P|--dbpass <password>  The password of the mysql/mariadb database login (env MYSQL_PASSWORD)
-    -u|--urlpath <url_path> The URL path of Friendica - f.e. '/friendica' (env FRIENDICA_URL_PATH) 
-    -b|--phppath <php_path> The path of the PHP binary (env FRIENDICA_PHP_PATH) 
-    -A|--admin <mail>       The admin email address of Friendica (env FRIENDICA_ADMIN_MAIL)
-    -T|--tz <timezone>      The timezone of Friendica (env FRIENDICA_TZ)
-    -L|--lang <language>    The language of Friendica (env FRIENDICA_LANG)
+    -s|--savedb                 Save the DB credentials to the file (if environment variables is used)
+    -H|--dbhost <host>          The host of the mysql/mariadb database (env MYSQL_HOST)
+    -p|--dbport <port>          The port of the mysql/mariadb database (env MYSQL_PORT)
+    -d|--dbdata <database>      The name of the mysql/mariadb database (env MYSQL_DATABASE)
+    -U|--dbuser <username>      The username of the mysql/mariadb database login (env MYSQL_USER or MYSQL_USERNAME)
+    -P|--dbpass <password>      The password of the mysql/mariadb database login (env MYSQL_PASSWORD)
+    -U|--urlpath <url_path>     The URL path of Friendica - f.e. '/friendica' (env FRIENDICA_URL_PATH) 
+    -B|--phppath <php_path>     The path of the PHP binary (env FRIENDICA_PHP_PATH)
+    -b|--basepath <base_path>   The basepath of Friendica(env FRIENDICA_BASE_PATH)
+    -S|--sslpolicy <ssl_policy> The SSL policy of Friendica (env FRIENDICA_SSL_POLICY) 
+    -n|--hostname <hostname>    The hostname of Friendica (env FRIENDICA_PHP_HOSTNAME)  
+    -t|--tz <timezone>          The timezone of Friendica (env FRIENDICA_TZ)
+    -L|--lang <language>        The language of Friendica (env FRIENDICA_LANG)
  
 Environment variables
    MYSQL_HOST                  The host of the mysql/mariadb database (mandatory if mysql and environment is used)
@@ -503,9 +652,12 @@ Environment variables
    MYSQL_USERNAME|MYSQL_USER   The username of the mysql/mariadb database login (MYSQL_USERNAME is for mysql, MYSQL_USER for mariadb)
    MYSQL_PASSWORD              The password of the mysql/mariadb database login
    MYSQL_DATABASE              The name of the mysql/mariadb database
-   FRIENDICA_URL_PATH          The URL path of Friendica (f.e. '/friendica')
-   FRIENDICA_PHP_PATH          The path of the PHP binary
+   FRIENDICA_URL_PATH          The URL path of Friendica (f.e. '/friendica') - leave empty for auto detection
+   FRIENDICA_PHP_PATH          The path of the PHP binary - leave empty for auto detection
+   FRIENDICA_BASE_PATH         The basepath of Friendica - leave empty for auto detection
    FRIENDICA_ADMIN_MAIL        The admin email address of Friendica (this email will be used for admin access)
+   FRIENDICA_SSL_POLICY        The SSL policy of Friendica (default is NO SSL)
+   FRIENDICA_HOSTNAME          The hostname of Friendica - leave empty for auto detection
    FRIENDICA_TZ                The timezone of Friendica
    FRIENDICA_LANG              The langauge of Friendica
    

--- a/tests/src/Core/Console/AutomaticInstallationConsoleTest.php
+++ b/tests/src/Core/Console/AutomaticInstallationConsoleTest.php
@@ -15,6 +15,8 @@ use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamFile;
 
 /**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
  * @requires PHP 7.0
  */
 class AutomaticInstallationConsoleTest extends ConsoleTest

--- a/tests/src/Core/Console/AutomaticInstallationConsoleTest.php
+++ b/tests/src/Core/Console/AutomaticInstallationConsoleTest.php
@@ -96,14 +96,10 @@ class AutomaticInstallationConsoleTest extends ConsoleTest
 					],
 					'config' => [
 						'php_path'    => '',
-						'hostname'    => '',
 						'admin_email' => '',
 					],
 					'system' => [
-						'basepath'    => '',
 						'urlpath'     => '',
-						'url'         => '',
-						'ssl_policy'  => '',
 						'default_timezone' => '',
 						'language'    => '',
 					],
@@ -120,14 +116,10 @@ class AutomaticInstallationConsoleTest extends ConsoleTest
 					],
 					'config' => [
 						'php_path'    => '',
-						'hostname'    => 'friendica.local',
 						'admin_email' => 'admin@philipp.info',
 					],
 					'system' => [
 						'urlpath'     => 'test/it',
-						'url'         => 'friendica.local/test/it',
-						'basepath'    => '',
-						'ssl_policy'  => '2',
 						'default_timezone' => 'en',
 						'language'    => 'Europe/Berlin',
 					],
@@ -144,14 +136,10 @@ class AutomaticInstallationConsoleTest extends ConsoleTest
 					],
 					'config' => [
 						'php_path'    => '',
-						'hostname'    => 'friendica.local',
 						'admin_email' => 'admin@philipp.info',
 					],
 					'system' => [
 						'urlpath'     => 'test/it',
-						'url'         => 'friendica.local/test/it',
-						'basepath'    => '',
-						'ssl_policy'  => '1',
 						'default_timezone' => 'en',
 						'language'    => 'Europe/Berlin',
 					],
@@ -367,18 +355,14 @@ return [
 
 	'config' => [
 		'admin_email' => '{$conf('config', 'admin_email')}',
-		'hostname' => '{$conf('config', 'hostname')}',
 		'sitename' => 'Friendica Social Network',
 		'register_policy' => \Friendica\Module\Register::OPEN,
 		'register_text' => '',
 	],
 	'system' => [
-		'basepath' => '{$conf('system', 'basepath')}',
 		'urlpath' => '{$conf('system', 'urlpath')}',
-		'url' => '{$conf('system', 'url')}',
 		'default_timezone' => '{$conf('system', 'default_timezone')}',
 		'language' => '{$conf('system', 'language')}',
-		'ssl_policy' => '{$conf('system', 'ssl_policy')}',
 	],
 ];
 CONF;
@@ -424,10 +408,7 @@ CONF;
 		$this->assertTrue(putenv('MYSQL_PASSWORD=' . $data['database']['password']));
 
 		$this->assertTrue(putenv('FRIENDICA_URL_PATH='   . $data['system']['urlpath']));
-		$this->assertTrue(putenv('FRIENDICA_BASE_PATH='  . $data['system']['basepath']));
 		$this->assertTrue(putenv('FRIENDICA_PHP_PATH='   . $data['config']['php_path']));
-		$this->assertTrue(putenv('FRIENDICA_SSL_POLICY=' . $data['system']['ssl_policy']));
-		$this->assertTrue(putenv('FRIENDICA_HOSTNAME='   . $data['config']['hostname']));
 		$this->assertTrue(putenv('FRIENDICA_ADMIN_MAIL=' . $data['config']['admin_email']));
 		$this->assertTrue(putenv('FRIENDICA_TZ='         . $data['system']['default_timezone']));
 		$this->assertTrue(putenv('FRIENDICA_LANG='       . $data['system']['language']));
@@ -465,10 +446,7 @@ CONF;
 		$this->assertTrue(putenv('MYSQL_PASSWORD=' . $data['database']['password']));
 
 		$this->assertTrue(putenv('FRIENDICA_URL_PATH=' . $data['system']['urlpath']));
-		$this->assertTrue(putenv('FRIENDICA_BASE_PATH=' . $data['system']['basepath']));
 		$this->assertTrue(putenv('FRIENDICA_PHP_PATH=' . $data['config']['php_path']));
-		$this->assertTrue(putenv('FRIENDICA_SSL_POLICY=' . $data['system']['ssl_policy']));
-		$this->assertTrue(putenv('FRIENDICA_HOSTNAME=' . $data['config']['hostname']));
 		$this->assertTrue(putenv('FRIENDICA_ADMIN_MAIL=' . $data['config']['admin_email']));
 		$this->assertTrue(putenv('FRIENDICA_TZ=' . $data['system']['default_timezone']));
 		$this->assertTrue(putenv('FRIENDICA_LANG=' . $data['system']['language']));
@@ -510,10 +488,7 @@ CONF;
 		$option('dbpass'   , 'database', 'password');
 		$option('dbdata'   , 'database', 'database');
 		$option('urlpath'  , 'system'  , 'urlpath');
-		$option('basepath' , 'system'  , 'basepath');
 		$option('phppath'  , 'config'  , 'php_path');
-		$option('sslpolicy', 'system'  , 'ssl_policy');
-		$option('hostname' , 'config'  , 'hostname');
 		$option('admin'    , 'config'  , 'admin_email');
 		$option('tz'       , 'system'  , 'default_timezone');
 		$option('lang'     , 'system'  , 'language');

--- a/tests/src/Core/Console/ConfigConsoleTest.php
+++ b/tests/src/Core/Console/ConfigConsoleTest.php
@@ -2,6 +2,7 @@
 
 namespace Friendica\Test\src\Core\Console;
 
+use Friendica\App;
 use Friendica\Core\Console\Config;
 
 /**
@@ -15,20 +16,15 @@ class ConfigConsoleTest extends ConsoleTest
 	{
 		parent::setUp();
 
+		$this->mockApp($this->root);
+
 		\Mockery::getConfiguration()->setConstantsMap([
-			'Friendica\App\Mode' => [
+			App\Mode::class => [
 				'DBCONFIGAVAILABLE' => 0
 			]
 		]);
 
-		$mode = \Mockery::mock('Friendica\App\Mode');
-		$mode
-			->shouldReceive('has')
-			->andReturn(true);
-
-		$this->app
-			->shouldReceive('getMode')
-			->andReturn($mode);
+		$this->mode->shouldReceive('has')->andReturn(true);
 	}
 
 	function testSetGetKeyValue() {

--- a/tests/src/Core/Console/ConsoleTest.php
+++ b/tests/src/Core/Console/ConsoleTest.php
@@ -30,6 +30,7 @@ abstract class ConsoleTest extends MockedTest
 
 		$this->setUpVfsDir();
 		$this->mockApp($this->root);
+
 	}
 
 	/**

--- a/tests/src/Core/Console/ConsoleTest.php
+++ b/tests/src/Core/Console/ConsoleTest.php
@@ -29,8 +29,6 @@ abstract class ConsoleTest extends MockedTest
 		Intercept::setUp();
 
 		$this->setUpVfsDir();
-		$this->mockApp($this->root);
-
 	}
 
 	/**

--- a/tests/src/Core/Console/ConsoleTest.php
+++ b/tests/src/Core/Console/ConsoleTest.php
@@ -22,10 +22,6 @@ abstract class ConsoleTest extends MockedTest
 	{
 		parent::setUp();
 
-		if (!getenv('MYSQL_DATABASE')) {
-			$this->markTestSkipped('Please set the MYSQL_* environment variables to your test database credentials.');
-		}
-
 		Intercept::setUp();
 
 		$this->setUpVfsDir();

--- a/view/templates/install_checks.tpl
+++ b/view/templates/install_checks.tpl
@@ -28,7 +28,7 @@
 </table>
 
 {{if $phpath}}
-	<input type="hidden" name="phpath" value="{{$phpath}}">
+	<input type="hidden" name="config-php_path" value="{{$php_path}}">
 {{/if}}
 
 {{if $passed}}

--- a/view/templates/install_db.tpl
+++ b/view/templates/install_db.tpl
@@ -18,7 +18,7 @@
 
 <form id="install-form" action="{{$baseurl}}/install" method="post">
 
-	<input type="hidden" name="phpath" value="{{$phpath}}" />
+	<input type="hidden" name="config-php_path" value="{{$php_path}}" />
 	<input type="hidden" name="pass" value="3" />
 
 	{{include file="field_input.tpl" field=$dbhost}}

--- a/view/templates/install_settings.tpl
+++ b/view/templates/install_settings.tpl
@@ -6,11 +6,11 @@
 
 <form id="install-form" action="{{$baseurl}}/install" method="post">
 
-<input type="hidden" name="phpath" value="{{$phpath}}" />
-<input type="hidden" name="dbhost" value="{{$dbhost}}" />
-<input type="hidden" name="dbuser" value="{{$dbuser}}" />
-<input type="hidden" name="dbpass" value="{{$dbpass}}" />
-<input type="hidden" name="dbdata" value="{{$dbdata}}" />
+<input type="hidden" name="config-php_path" value="{{$php_path}}" />
+<input type="hidden" name="database-hostname" value="{{$dbhost}}" />
+<input type="hidden" name="database-username" value="{{$dbuser}}" />
+<input type="hidden" name="database-password" value="{{$dbpass}}" />
+<input type="hidden" name="database-database" value="{{$dbdata}}" />
 <input type="hidden" name="pass" value="4" />
 
 {{include file="field_input.tpl" field=$adminmail}}


### PR DESCRIPTION
Redux & Prerequisite of #6815 

I refactored the `Installer` core class and the `Install` module, so we use the config Cache for states and no more check on $_POST variables inside content functions :-)

In #6815, I use this base for the "real" enhancements :-)

- [x] console.php currently not working (see #6879 why)