### PR TITLE
We now send a summary via AP

### DIFF
--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -20,6 +20,7 @@ use Friendica\Model\Term;
 use Friendica\Model\User;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Content\Text\BBCode;
+use Friendica\Content\Text\Plaintext;
 use Friendica\Util\JsonLD;
 use Friendica\Util\LDSignature;
 use Friendica\Model\Profile;
@@ -1020,7 +1021,7 @@ class Transmitter
 			return $data;
 		}
 
-		$data['summary'] = null; // Ignore by now
+		$data['summary'] = BBCode::getAbstract($item['body'], Protocol::ACTIVITYPUB);
 
 		if ($item['uri'] != $item['thr-parent']) {
 			$data['inReplyTo'] = $item['thr-parent'];
@@ -1054,6 +1055,8 @@ class Transmitter
 
 		if ($type == 'Note') {
 			$body = self::removePictures($body);
+		} elseif (($type == 'Article') && empty($data['summary'])) {
+			$data['summary'] = Plaintext::shorten(self::removePictures($body), 1000);
 		}
 
 		if ($type == 'Event') {

--- a/src/Protocol/Feed.php
+++ b/src/Protocol/Feed.php
@@ -421,7 +421,7 @@ class Feed {
 				unset($item["attach"]);
 			} else {
 				if (!empty($summary)) {
-					$item["body"] = '[abstract]' . HTML::toBBCode($summary, $basepath) . '[/abstract]' . $item["body"];
+					$item["body"] = '[abstract]' . HTML::toBBCode($summary, $basepath) . "[/abstract]\n" . $item["body"];
 				}
 
 				if ($contact["fetch_further_information"] == 3) {

--- a/src/Protocol/Feed.php
+++ b/src/Protocol/Feed.php
@@ -356,11 +356,20 @@ class Feed {
 			if (empty($body)) {
 				$body = trim(XML::getFirstNodeValue($xpath, 'content:encoded/text()', $entry));
 			}
-			if (empty($body)) {
-				$body = trim(XML::getFirstNodeValue($xpath, 'description/text()', $entry));
+
+			$summary = trim(XML::getFirstNodeValue($xpath, 'atom:summary/text()', $entry));
+
+			if (empty($summary)) {
+				$summary = trim(XML::getFirstNodeValue($xpath, 'description/text()', $entry));
 			}
+
 			if (empty($body)) {
-				$body = trim(XML::getFirstNodeValue($xpath, 'atom:summary/text()', $entry));
+				$body = $summary;
+				$summary = '';
+			}
+
+			if ($body == $summary) {
+				$summary = '';
 			}
 
 			// remove the content of the title if it is identically to the body
@@ -411,6 +420,10 @@ class Feed {
 				$item["object-type"] = ACTIVITY_OBJ_BOOKMARK;
 				unset($item["attach"]);
 			} else {
+				if (!empty($summary)) {
+					$item["body"] = '[abstract]' . HTML::toBBCode($summary, $basepath) . '[/abstract]' . $item["body"];
+				}
+
 				if ($contact["fetch_further_information"] == 3) {
 					if (!empty($tags)) {
 						$item["tag"] = $tags;


### PR DESCRIPTION
This partially fixes the problem with Mastodon and Articles. Mastodon decided to not display the content of "Article" posts. But they display the content of the "summary" field. So we now transmit our "Article" posts (posts with title) with a "summary" field that contains a shortened version of the post.

When the "abstract" BBCode element is set, we transmit it in any case.

When importing feeds we now add this "abstract" BBCode element. This will improve the readability from mirrored feed items with Mastodon.

This PR addresses https://github.com/friendica/friendica/issues/6813