### PR TITLE
Fixing .htconfig loading

### DIFF
--- a/src/Core/Config/Cache/ConfigCache.php
+++ b/src/Core/Config/Cache/ConfigCache.php
@@ -30,7 +30,7 @@ class ConfigCache implements IConfigCache, IPConfigCache
 		$categories = array_keys($config);
 
 		foreach ($categories as $category) {
-			if (isset($config[$category]) && is_array($config[$category])) {
+			if (is_array($config[$category])) {
 				$keys = array_keys($config[$category]);
 
 				foreach ($keys as $key) {

--- a/src/Core/Config/Cache/ConfigCacheLoader.php
+++ b/src/Core/Config/Cache/ConfigCacheLoader.php
@@ -103,47 +103,61 @@ class ConfigCacheLoader
 	{
 		$filePath = $this->baseDir  . DIRECTORY_SEPARATOR . '.' . $name . '.php';
 
+		$config = [];
+
 		if (file_exists($filePath)) {
-			$a = new \stdClass();
-			$a->config = [];
 			include $filePath;
 
 			if (isset($db_host)) {
-				$a->config['database']['hostname'] = $db_host;
+				$config['database']['hostname'] = $db_host;
 				unset($db_host);
 			}
 			if (isset($db_user)) {
-				$a->config['database']['username'] = $db_user;
+				$config['database']['username'] = $db_user;
 				unset($db_user);
 			}
 			if (isset($db_pass)) {
-				$a->config['database']['password'] = $db_pass;
+				$config['database']['password'] = $db_pass;
 				unset($db_pass);
 			}
 			if (isset($db_data)) {
-				$a->config['database']['database'] = $db_data;
+				$config['database']['database'] = $db_data;
 				unset($db_data);
 			}
 			if (isset($a->config['system']['db_charset'])) {
-				$a->config['database']['charset'] = $a->config['system']['charset'];
+				$a->config['database']['charset'] = $config['system']['charset'];
 			}
 			if (isset($pidfile)) {
-				$a->config['system']['pidfile'] = $pidfile;
+				$config['system']['pidfile'] = $pidfile;
 				unset($pidfile);
 			}
 			if (isset($default_timezone)) {
-				$a->config['system']['default_timezone'] = $default_timezone;
+				$config['system']['default_timezone'] = $default_timezone;
 				unset($default_timezone);
 			}
 			if (isset($lang)) {
-				$a->config['system']['language'] = $lang;
+				$config['system']['language'] = $lang;
 				unset($lang);
 			}
-
-			return $a->config;
-		} else {
-			return [];
+			if (isset($admin_email)) {
+				$config['config']['admin_email'] = $admin_email;
+				unset($admin_email);
+			}
+			if (isset($admin_nickname)) {
+				$config['config']['admin_nickname'] = $admin_nickname;
+				unset($admin_nickname);
+			}
+			if (isset($php_path)) {
+				$config['config']['php_path'] = $php_path;
+				unset($php_path);
+			}
+			if (isset($max_import_size)) {
+				$config['config']['max_import_size'] = $max_import_size;
+				unset($max_import_size);
+			}
 		}
+
+		return $config;
 	}
 
 	/**

--- a/src/Core/Config/Cache/ConfigCacheLoader.php
+++ b/src/Core/Config/Cache/ConfigCacheLoader.php
@@ -110,18 +110,18 @@ class ConfigCacheLoader
 			$a->config = [];
 			include $filePath;
 
-			$htconfigAr = array_keys($a->config);
+			$htConfigCategories = array_keys($a->config);
 
 			// map the legacy configuration structure to the current structure
-			foreach ($htconfigAr as $htconfig) {
-				if (isset($a->config[$htconfig]) && is_array($a->config[$htconfig])) {
-					$keys = array_keys($a->config[$htconfig]);
+			foreach ($htConfigCategories as $htConfigCategory) {
+				if (is_array($a->config[$htConfigCategory])) {
+					$keys = array_keys($a->config[$htConfigCategory]);
 
 					foreach ($keys as $key) {
-						$config[$htconfig][$key] = $a->config[$htconfig][$key];
+						$config[$htConfigCategory][$key] = $a->config[$htConfigCategory][$key];
 					}
 				} else {
-					$config['config'][$htconfig] = $a->config[$htconfig];
+					$config['config'][$htConfigCategory] = $a->config[$htConfigCategory];
 				}
 			}
 

--- a/src/Core/Config/Cache/ConfigCacheLoader.php
+++ b/src/Core/Config/Cache/ConfigCacheLoader.php
@@ -106,7 +106,26 @@ class ConfigCacheLoader
 		$config = [];
 
 		if (file_exists($filePath)) {
+			$a = new \stdClass();
+			$a->config = [];
 			include $filePath;
+
+			$htconfigAr = array_keys($a->config);
+
+			// map the legacy configuration structure to the current structure
+			foreach ($htconfigAr as $htconfig) {
+				if (isset($a->config[$htconfig]) && is_array($a->config[$htconfig])) {
+					$keys = array_keys($a->config[$htconfig]);
+
+					foreach ($keys as $key) {
+						$config[$htconfig][$key] = $a->config[$htconfig][$key];
+					}
+				} else {
+					$config['config'][$htconfig] = $a->config[$htconfig];
+				}
+			}
+
+			unset($a);
 
 			if (isset($db_host)) {
 				$config['database']['hostname'] = $db_host;
@@ -124,8 +143,8 @@ class ConfigCacheLoader
 				$config['database']['database'] = $db_data;
 				unset($db_data);
 			}
-			if (isset($a->config['system']['db_charset'])) {
-				$a->config['database']['charset'] = $config['system']['charset'];
+			if (isset($config['system']['db_charset'])) {
+				$config['database']['charset'] = $config['system']['db_charset'];
 			}
 			if (isset($pidfile)) {
 				$config['system']['pidfile'] = $pidfile;
@@ -138,22 +157,6 @@ class ConfigCacheLoader
 			if (isset($lang)) {
 				$config['system']['language'] = $lang;
 				unset($lang);
-			}
-			if (isset($admin_email)) {
-				$config['config']['admin_email'] = $admin_email;
-				unset($admin_email);
-			}
-			if (isset($admin_nickname)) {
-				$config['config']['admin_nickname'] = $admin_nickname;
-				unset($admin_nickname);
-			}
-			if (isset($php_path)) {
-				$config['config']['php_path'] = $php_path;
-				unset($php_path);
-			}
-			if (isset($max_import_size)) {
-				$config['config']['max_import_size'] = $max_import_size;
-				unset($max_import_size);
 			}
 		}
 

--- a/tests/datasets/config/.htconfig.test.php
+++ b/tests/datasets/config/.htconfig.test.php
@@ -8,12 +8,56 @@ $db_user = 'testuser';
 $db_pass = 'testpw';
 $db_data = 'testdb';
 
-$admin_email = 'admin@friendica.local';
-$admin_nickname = 'Friendly admin';
-
 $pidfile = '/var/run/friendica.pid';
+
+// Set the database connection charset to UTF8.
+// Changing this value will likely corrupt the special characters.
+// You have been warned.
+$a->config['system']['db_charset'] = "anotherCharset";
+
+// Choose a legal default timezone. If you are unsure, use "America/Los_Angeles".
+// It can be changed later and only applies to timestamps for anonymous viewers.
 $default_timezone = 'Europe/Berlin';
 $lang = 'fr';
 
-$php_path = '/another/php';
-$max_import_size = 999;
+// What is your site name?
+$a->config['sitename'] = "Friendica My Network";
+
+// Your choices are REGISTER_OPEN, REGISTER_APPROVE, or REGISTER_CLOSED.
+// Be certain to create your own personal account before setting
+// REGISTER_CLOSED. 'register_text' (if set) will be displayed prominently on
+// the registration page. REGISTER_APPROVE requires you set 'admin_email'
+// to the email address of an already registered person who can authorise
+// and/or approve/deny the request.
+// In order to perform system administration via the admin panel, admin_email
+// must precisely match the email address of the person logged in.
+$a->config['register_policy'] = REGISTER_OPEN;
+$a->config['register_text'] = 'A register text';
+$a->config['admin_email'] = 'admin@friendica.local';
+$a->config['admin_nickname'] = 'Friendly admin';
+
+// Maximum size of an imported message, 0 is unlimited
+$a->config['max_import_size'] = 999;
+
+// maximum size of uploaded photos
+$a->config['system']['maximagesize'] = 666;
+
+// Location of PHP command line processor
+$a->config['php_path'] = '/another/php';
+
+// PuSH - aka pubsubhubbub URL. This makes delivery of public posts as fast as private posts
+$a->config['system']['huburl'] = '[internal]';
+
+// allowed themes (change this from admin panel after installation)
+$a->config['system']['allowed_themes'] = 'quattro,vier,duepuntozero';
+
+// default system theme
+$a->config['system']['theme'] = 'duepuntozero';
+
+// By default allow pseudonyms
+$a->config['system']['no_regfullname'] = true;
+
+//Deny public access to the local directory
+//$a->config['system']['block_local_dir'] = false;
+// Location of the global directory
+$a->config['system']['directory'] = 'http://another.url';

--- a/tests/datasets/config/.htconfig.test.php
+++ b/tests/datasets/config/.htconfig.test.php
@@ -8,6 +8,12 @@ $db_user = 'testuser';
 $db_pass = 'testpw';
 $db_data = 'testdb';
 
+$admin_email = 'admin@friendica.local';
+$admin_nickname = 'Friendly admin';
+
 $pidfile = '/var/run/friendica.pid';
 $default_timezone = 'Europe/Berlin';
 $lang = 'fr';
+
+$php_path = '/another/php';
+$max_import_size = 999;

--- a/tests/src/Core/Config/Cache/ConfigCacheLoaderTest.php
+++ b/tests/src/Core/Config/Cache/ConfigCacheLoaderTest.php
@@ -135,6 +135,12 @@ class ConfigCacheLoaderTest extends MockedTest
 		$this->assertEquals('/var/run/friendica.pid', $configCache->get('system', 'pidfile'));
 		$this->assertEquals('Europe/Berlin', $configCache->get('system', 'default_timezone'));
 		$this->assertEquals('fr', $configCache->get('system', 'language'));
+
+		$this->assertEquals('admin@friendica.local', $configCache->get('config', 'admin_email'));
+		$this->assertEquals('Friendly admin', $configCache->get('config', 'admin_nickname'));
+
+		$this->assertEquals('/another/php', $configCache->get('config', 'php_path'));
+		$this->assertEquals('999', $configCache->get('config', 'max_import_size'));
 	}
 
 	public function testLoadAddonConfig()

--- a/tests/src/Core/Config/Cache/ConfigCacheLoaderTest.php
+++ b/tests/src/Core/Config/Cache/ConfigCacheLoaderTest.php
@@ -131,6 +131,7 @@ class ConfigCacheLoaderTest extends MockedTest
 		$this->assertEquals('testuser', $configCache->get('database', 'username'));
 		$this->assertEquals('testpw', $configCache->get('database', 'password'));
 		$this->assertEquals('testdb', $configCache->get('database', 'database'));
+		$this->assertEquals('anotherCharset', $configCache->get('database', 'charset'));
 
 		$this->assertEquals('/var/run/friendica.pid', $configCache->get('system', 'pidfile'));
 		$this->assertEquals('Europe/Berlin', $configCache->get('system', 'default_timezone'));
@@ -141,6 +142,10 @@ class ConfigCacheLoaderTest extends MockedTest
 
 		$this->assertEquals('/another/php', $configCache->get('config', 'php_path'));
 		$this->assertEquals('999', $configCache->get('config', 'max_import_size'));
+		$this->assertEquals('666', $configCache->get('system', 'maximagesize'));
+
+		$this->assertEquals('quattro,vier,duepuntozero', $configCache->get('system', 'allowed_themes'));
+		$this->assertEquals('1', $configCache->get('system', 'no_regfullname'));
 	}
 
 	public function testLoadAddonConfig()


### PR DESCRIPTION
Fixing legacy .htconfig loading, described here
https://friendica.philipp.info/display/735a2029-435c-8d17-ec92-b96564712636

I reverted #6828 because in the legacy `.htconfig.php` file, the entry `$a->config['system']['db_charset']` was used.