### PR TITLE
Centralise the item content processing in a single function

### DIFF
--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -252,7 +252,7 @@ class Processor
 	 *
 	 * @param array $activity Activity array
 	 * @param array $item
-	 * @return array
+	 * @return array|bool Returns the item array or false if there was an unexpected occurrence
 	 * @throws \Exception
 	 */
 	private static function processContent($activity, $item)

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -270,6 +270,7 @@ class Processor
 				$item_private = !in_array(0, $activity['item_receiver']);
 				$parent = Item::selectFirst(['id', 'private', 'author-link', 'alias'], ['uri' => $item['thr-parent']]);
 				if (!DBA::isResult($parent)) {
+					Logger::warning('Unknown parent item.', ['uri' => $item['thr-parent']]);
 					return false;
 				}
 				if ($item_private && !$parent['private']) {


### PR DESCRIPTION
This is a follow up to PR https://github.com/friendica/friendica/pull/6894

The processing of content should be identical during the creation of a new item or updating it. Best way to assure it is to use a central function for that.

In fact this PR is not only beautification but fixes a problem when an update of a video post wouldn't add the needed link in the body, since this line had been forgotten in the update function.