### PR TITLE
Issue 6537: Transmit the real author of a post in a dedicated API field

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -654,6 +654,7 @@ Returned status object is conform to GNU Social/Twitter api.
 
 Friendica adds some addictional fields:
 
+- author: a user object, it's the author of the item. In case of a reshare for legacy reasons the "user" field doesn't show the real author. This field always contains the real author of a post.
 - owner: a user object, it's the owner of the item.
 - private: boolean, true if the item is marked as private
 - activities: map with activities related to the item. Every activity is a list of user objects.
@@ -667,6 +668,9 @@ JSON:
 [
 	{
 		// ...
+		'friendica_author' : {
+			// user object
+		},
 		'friendica_owner' : {
 			// user object
 		},

--- a/include/api.php
+++ b/include/api.php
@@ -775,15 +775,17 @@ function api_item_get_user(App $a, $item)
 {
 	$status_user = api_get_user($a, defaults($item, 'author-id', null));
 
+	$author_user = $status_user;
+
 	$status_user["protected"] = defaults($item, 'private', 0);
 
 	if (defaults($item, 'thr-parent', '') == defaults($item, 'uri', '')) {
 		$owner_user = api_get_user($a, defaults($item, 'owner-id', null));
 	} else {
-		$owner_user = $status_user;
+		$owner_user = $author_user;
 	}
 
-	return ([$status_user, $owner_user]);
+	return ([$status_user, $author_user, $owner_user]);
 }
 
 /**
@@ -2988,7 +2990,7 @@ function api_format_items($r, $user_info, $filter_user = false, $type = "json")
 
 	foreach ((array)$r as $item) {
 		localize_item($item);
-		list($status_user, $owner_user) = api_item_get_user($a, $item);
+		list($status_user, $author_user, $owner_user) = api_item_get_user($a, $item);
 
 		// Look if the posts are matching if they should be filtered by user id
 		if ($filter_user && ($status_user["id"] != $user_info["id"])) {
@@ -3020,6 +3022,7 @@ function api_format_items($r, $user_info, $filter_user = false, $type = "json")
 			$geo => null,
 			'favorited' => $item['starred'] ? true : false,
 			'user' =>  $status_user,
+			'friendica_author' => $author_user,
 			'friendica_owner' => $owner_user,
 			'friendica_private' => $item['private'] == 1,
 			//'entities' => NULL,
@@ -3063,6 +3066,7 @@ function api_format_items($r, $user_info, $filter_user = false, $type = "json")
 				$retweeted_status['friendica_activities'] = api_format_items_activities($retweeted_item, $type);
 				$retweeted_status['created_at'] =  api_date($retweeted_item['created']);
 				$status['retweeted_status'] = $retweeted_status;
+				$status['friendica_author'] = $retweeted_status['user'];
 			}
 		}
 

--- a/include/api.php
+++ b/include/api.php
@@ -3066,7 +3066,7 @@ function api_format_items($r, $user_info, $filter_user = false, $type = "json")
 				$retweeted_status['friendica_activities'] = api_format_items_activities($retweeted_item, $type);
 				$retweeted_status['created_at'] =  api_date($retweeted_item['created']);
 				$status['retweeted_status'] = $retweeted_status;
-				$status['friendica_author'] = $retweeted_status['user'];
+				$status['friendica_author'] = $retweeted_status['friendica_author'];
 			}
 		}
 


### PR DESCRIPTION
This fixes #6537 

To stay compatible with legacy clients, the "user" field in the API cannot always contain the name of the real author of a post. This happens with forum posts and reshares.

For this reason there is now an additional field that always contains the real author of a post.