### PR TITLE
6778 Part 2: Add storage move cron job

### DIFF
--- a/src/Core/Console/Storage.php
+++ b/src/Core/Console/Storage.php
@@ -84,7 +84,7 @@ HELP;
 
 		if ($current === '') {
 			$this->out();
-			$this->out('This sistem is using legacy storage system');
+			$this->out('This system is using legacy storage system');
 		}
 		if ($current !== '' && !$isregisterd) {
 			$this->out();

--- a/src/Core/StorageManager.php
+++ b/src/Core/StorageManager.php
@@ -65,6 +65,9 @@ class StorageManager
 
 		Config::set('storage', 'class', $class);
 
+		// Start background storage move task
+		Worker::add(PRIORITY_LOW, "CronJobs", "move_storage");
+
 		return true;
 	}
 

--- a/src/Worker/Cron.php
+++ b/src/Worker/Cron.php
@@ -82,6 +82,9 @@ class Cron
 
 			Worker::add(PRIORITY_LOW, "CronJobs", "update_photo_albums");
 
+			// Daily pickup if the expected storage move task started on setting change stopped for any reason
+			Worker::add(PRIORITY_LOW, "CronJobs", "move_storage");
+
 			// update nodeinfo data
 			Worker::add(PRIORITY_LOW, "CronJobs", "nodeinfo");
 

--- a/src/Worker/CronJobs.php
+++ b/src/Worker/CronJobs.php
@@ -10,6 +10,8 @@ use Friendica\Core\Cache;
 use Friendica\Core\Config;
 use Friendica\Core\Logger;
 use Friendica\Core\Protocol;
+use Friendica\Core\StorageManager;
+use Friendica\Core\Worker;
 use Friendica\Database\DBA;
 use Friendica\Database\PostUpdate;
 use Friendica\Model\Contact;
@@ -66,6 +68,10 @@ class CronJobs
 
 			case 'repair_database':
 				self::repairDatabase();
+				break;
+
+			case 'move_storage':
+				self::moveStorage();
 				break;
 
 			default:
@@ -288,5 +294,21 @@ class CronJobs
 		/// - remove sign entries without item
 		/// - remove children when parent got lost
 		/// - set contact-id in item when not present
+	}
+
+	/**
+	 * Moves up to 5000 attachments and photos to the current storage system.
+	 * Self-replicates if legacy items have been found and moved.
+	 *
+	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
+	 */
+	private static function moveStorage()
+	{
+		$current = StorageManager::getBackend();
+		$moved = StorageManager::move($current);
+
+		if ($moved) {
+			Worker::add(PRIORITY_LOW, "CronJobs", "move_storage");
+		}
 	}
 }


### PR DESCRIPTION
Retroactive follow-up to #6910

Actually, only the second commit fixes #6778, the rest is code formatting, honoring a `@todo` and taking the following bold initiative: As soon as the storage setting is successfully changed, a chained storage move task is started in the background so that it doesn't require a manual action.

In essence, this is option 4. from https://kirgroup.com/display/61b57c7e-185c-78e0-be81-496716522363 where we completely ditch the manual action entirely.

What do you think about it? Too bold? I can dial it down to the actual option 3. @fabrixxm suggested. But since we can move items back and forth between storage backends, I don't think it's a big deal if a move task starts right away when the setting is changed. Ultimately, through the cronjob task, the system will end up normalizing the items storage no matter how often the storage backend setting is changed in the mean time.

I deliberately didn't update the relevant documentation, including the admin setting help text before we can agree on it.