### PR TITLE
Exclude punctuation from domain in autolinker regular expression

### DIFF
--- a/src/Util/Strings.php
+++ b/src/Util/Strings.php
@@ -361,7 +361,10 @@ class Strings
 (                              # Capture 1: entire matched URL
   https?://                            # http or https protocol
   (?:
-    [^/\s.][^/\s]+[.][^\s/]+/?         # looks like domain name followed by a slash
+    [^/\s`!()\[\]{};:\'",<>?«»“”‘’.]    # Domain can\'t start with a . 
+    [^/\s`!()\[\]{};:\'",<>?«»“”‘’]+    # Domain can\'t end with a .
+    \.
+    [^/\s`!()\[\]{};:\'".,<>?«»“”‘’]+/? # Followed by a slash
   )
   (?:                                  # One or more:
     [^\s()<>]+                         # Run of non-space, non-()<>

--- a/tests/src/Content/Text/BBCodeTest.php
+++ b/tests/src/Content/Text/BBCodeTest.php
@@ -102,6 +102,10 @@ class BBCodeTest extends MockedTest
 				'data' => "http://example.com\ntest",
 				'assertHTML' => false
 			],
+			'bug-6901' => [
+				'data' => "http://example.com<ul>",
+				'assertHTML' => false
+			],
 		];
 	}
 


### PR DESCRIPTION
Fixes #6901 

Turns out it wasn't a problem with new lines.