### PR TITLE
[frio] Add punctuation wrap on several profile fields

### DIFF
--- a/view/theme/frio/templates/profile_vcard.tpl
+++ b/view/theme/frio/templates/profile_vcard.tpl
@@ -39,7 +39,7 @@
 		<div class="profile-header">
 			<h3 class="fn p-name">{{$profile.name}}</h3>
 
-			{{if $profile.addr}}<div class="p-addr">{{$profile.addr}}</div>{{/if}}
+			{{if $profile.addr}}<div class="p-addr">{{include file="sub/punct_wrap.tpl" text=$profile.addr}}</div>{{/if}}
 
 			{{if $profile.pdesc}}<div class="title">{{$profile.pdesc}}</div>{{/if}}
 
@@ -92,7 +92,7 @@
 		{{if $profile.xmpp}}
 		<div class="xmpp">
 			<span class="xmpp-label icon"><i class="fa fa-comments"></i></span>
-			<span class="xmpp-data">{{$profile.xmpp}}</span>
+			<span class="xmpp-data"><a href="xmpp:{{$profile.xmpp}}" rel="me" target="_blank">{{include file="sub/punct_wrap.tpl" text=$profile.xmpp}}</a></span>
 		</div>
 		{{/if}}
 
@@ -119,7 +119,7 @@
 		{{if $homepage}}
 		<div class="homepage detail">
 			<span class="homepage-label icon"><i class="fa fa-external-link-square"></i></span>
-			<span class="homepage-url u-url"><a href="{{$profile.homepage}}" rel="me" target="_blank">{{$profile.homepage}}</a></span>
+			<span class="homepage-url u-url"><a href="{{$profile.homepage}}" rel="me" target="_blank">{{include file="sub/punct_wrap.tpl" text=$profile.homepage}}</a></span>
 		</div>
 		{{/if}}
 

--- a/view/theme/frio/templates/sub/punct_wrap.tpl
+++ b/view/theme/frio/templates/sub/punct_wrap.tpl
@@ -1,1 +1,1 @@
-{{$text|regex_replace:"/([@\.])/":"<wbr>$1" nofilter}}
+{{$text|regex_replace:"/([@\.\/])/":"<wbr>$1" nofilter}}

--- a/view/theme/frio/templates/sub/punct_wrap.tpl
+++ b/view/theme/frio/templates/sub/punct_wrap.tpl
@@ -1,0 +1,1 @@
+{{$text|regex_replace:"/([@\.])/":"<wbr>$1" nofilter}}


### PR DESCRIPTION
Fixes #6855 

@poVoq Here's the proposd result: wrapping on punctuation marks: https://friendica.mrpetovan.com/profile/hypolite

I made a copy of the display in case I forget to keep my profile as is until review:
![friendica-profile-wrap](https://user-images.githubusercontent.com/925415/54573157-84615d80-49c1-11e9-9124-991c856dfe4c.png)
