### PR TITLE
Fixing automention

### DIFF
--- a/src/Object/Post.php
+++ b/src/Object/Post.php
@@ -808,7 +808,7 @@ class Post extends BaseObject
 		$terms = Term::tagArrayFromItemId($this->getId(), [Term::MENTION, Term::IMPLICIT_MENTION]);
 		foreach ($terms as $term) {
 			$profile = Contact::getDetailsByURL($term['url']);
-			if (!empty($profile['addr']) && (defaults($profile, 'contact-type', Contact::TYPE_COMMUNITY) != Contact::TYPE_COMMUNITY) &&
+			if (!empty($profile['addr']) && (defaults($profile, 'contact-type', Contact::TYPE_UNKNOWN) != Contact::TYPE_COMMUNITY) &&
 				($profile['addr'] != $owner['addr']) && !strstr($text, $profile['addr'])) {
 				$text .= '@' . $profile['addr'] . ' ';
 			}


### PR DESCRIPTION
Since the "defaults" function checks for empty and the default contact type has got the value "0", the mentions mostly weren't displayed.