### PR TITLE
this label does not need a filter

### DIFF
--- a/view/theme/frio/templates/field_input.tpl
+++ b/view/theme/frio/templates/field_input.tpl
@@ -1,7 +1,7 @@
 
 	<div id="id_{{$field.0}}_wrapper" class="form-group field input">
 	{{if !isset($label) || $label != false }}
-		<label for="id_{{$field.0}}" id="label_{{$field.0}}">{{$field.1}}{{if $field.4}}<span class="required"> {{$field.4}}</span>{{/if}}</label>
+		<label for="id_{{$field.0}}" id="label_{{$field.0}}">{{$field.1 nofilter}}{{if $field.4}}<span class="required"> {{$field.4}}</span>{{/if}}</label>
 	{{/if}}
 		<input class="form-control" name="{{$field.0}}" id="id_{{$field.0}}"{{if $field.6 eq "email"}} type="email"{{elseif $field.6 eq "url"}} type="url"{{else}} type="text"{{/if}} value="{{$field.2 nofilter}}"{{if $field.4 eq "required"}} required{{/if}}{{if $field.5 eq "autofocus"}} autofocus{{elseif $field.5}} {{$field.5 nofilter}}{{/if}} aria-describedby="{{$field.0}}_tip">
 	{{if $field.3}}


### PR DESCRIPTION
apply the no filter rule for the label of input fields in frio as it is the case in other themes.