### PR TITLE
6778 Part 2: Add storage move cron job (redux)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,7 @@ Version 2019.06 (UNRELEASED) (2019-06-?)
     General Code cleaning and restructuring [nupplaphil]
     Added frio color scheme sharing [JeroenED]
     Added syslog and stream Logger [nupplaphil]
+    Added storage move cronjob [MrPetovan]
 
   Closed Issues:
     6303, 6478, 6319

--- a/src/Core/Console/Storage.php
+++ b/src/Core/Console/Storage.php
@@ -84,7 +84,7 @@ HELP;
 
 		if ($current === '') {
 			$this->out();
-			$this->out('This sistem is using legacy storage system');
+			$this->out('This system is using legacy storage system');
 		}
 		if ($current !== '' && !$isregisterd) {
 			$this->out();


### PR DESCRIPTION
Remotely related to #6778 
Split from #6910 
Same as #6902, except the automatic triggers for the storage move cronjobs have been removed after @fabrixxm 's [excellent point](https://github.com/friendica/friendica/pull/6902#issuecomment-475874723).

However, I can't bring myself to create the new necessary admin page to handle storage move from the frontend at the moment, so I'll detail my ideas and let someone™ else take care care of it.