### PR TITLE
Restore marking thread notifications as seen behavior

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,12 +5,13 @@ Version 2019.06 (UNRELEASED) (2019-06-?)
     Fixed the notification order [JeroenED]
     Fixed the timezone of Friendica logs [nupplaphil]
     Fixed tag completion painfully slow [AlfredSK]
+    Fixed a regression in notifications [MrPetovan]
     General Code cleaning and restructuring [nupplaphil]
     Added frio color scheme sharing [JeroenED]
     Added syslog and stream Logger [nupplaphil]
 
   Closed Issues:
-    6303, 6478, 6319
+    6303, 6478, 6319, 6921
 
 Version 2019.03 (2019-03-22)
   Friendica Core:

--- a/src/Core/NotificationsManager.php
+++ b/src/Core/NotificationsManager.php
@@ -108,7 +108,13 @@ class NotificationsManager extends BaseObject
 	 */
 	public function setSeen($note, $seen = true)
 	{
-		return DBA::update('notify', ['seen' => $seen], ['link' => $note['link'], 'parent' => $note['parent'], 'otype' => $note['otype'], 'uid' => local_user()]);
+		return DBA::update('notify', ['seen' => $seen], [
+			'(`link` = ? OR (`parent` != 0 AND `parent` = ? AND `otype` = ?)) AND `uid` = ?',
+			$note['link'],
+			$note['parent'],
+			$note['otype'],
+			local_user()
+		]);
 	}
 
 	/**


### PR DESCRIPTION
Follow-up to #6783 
Fixes #6921 

Restores the "mark all notifications in the same thread as seen" behavior.