### PR TITLE
Collapse connector list

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,9 +9,10 @@ Version 2019.06 (UNRELEASED) (2019-06-?)
     General Code cleaning and restructuring [nupplaphil]
     Added frio color scheme sharing [JeroenED]
     Added syslog and stream Logger [nupplaphil]
+    Added collapsible panel for connector permission fields [MrPetovan]
 
   Closed Issues:
-    6303, 6478, 6319, 6921
+    6303, 6478, 6319, 6921, 6903
 
 Version 2019.03 (2019-03-22)
   Friendica Core:

--- a/doc/Addons.md
+++ b/doc/Addons.md
@@ -411,6 +411,30 @@ Hook data:
     visitor => array with the contact record of the visitor
     url => the query string
 
+### jot_networks
+Called when displaying the post permission screen.
+Hook data is a list of form fields that need to be displayed along the ACL.
+Form field array structure is:
+
+- **type**: `checkbox` or `select`.
+- **field**: Standard field data structure to be used by `field_checkbox.tpl` and `field_select.tpl`.
+
+For `checkbox`, **field** is:
+  - [0] (String): Form field name; Mandatory. 
+  - [1]: (String): Form field label; Optional, default is none.
+  - [2]: (Boolean): Whether the checkbox should be checked by default; Optional, default is false.
+  - [3]: (String): Additional help text; Optional, default is none.
+  - [4]: (String): Additional HTML attributes; Optional, default is none.
+
+For `select`, **field** is:
+  - [0] (String): Form field name; Mandatory.
+  - [1] (String): Form field label; Optional, default is none.
+  - [2] (Boolean): Default value to be selected by default; Optional, default is none.
+  - [3] (String): Additional help text; Optional, default is none.
+  - [4] (Array): Associative array of options. Item key is option value, item value is option label; Mandatory. 
+
+
+
 ## Complete list of hook callbacks
 
 Here is a complete list of all hook callbacks with file locations (as of 24-Sep-2018). Please see the source for details of any hooks not documented above.

--- a/src/Core/ACL.php
+++ b/src/Core/ACL.php
@@ -266,14 +266,12 @@ class ACL extends BaseObject
 			$default_permissions = self::getDefaultUserPermissions($user);
 		}
 
-		$jotnets = '';
+		$jotnets_fields = [];
 		if ($show_jotnets) {
-			$imap_disabled = !function_exists('imap_open') || Config::get('system', 'imap_disabled');
-
 			$mail_enabled = false;
 			$pubmail_enabled = false;
 
-			if (!$imap_disabled) {
+			if (function_exists('imap_open') && !Config::get('system', 'imap_disabled')) {
 				$mailacct = DBA::selectFirst('mailacct', ['pubmail'], ['`uid` = ? AND `server` != ""', local_user()]);
 				if (DBA::isResult($mailacct)) {
 					$mail_enabled = true;
@@ -283,17 +281,20 @@ class ACL extends BaseObject
 
 			if (empty($default_permissions['hidewall'])) {
 				if ($mail_enabled) {
-					$selected = $pubmail_enabled ? ' checked="checked"' : '';
-					$jotnets .= '<div class="profile-jot-net"><input type="checkbox" name="pubmail_enable"' . $selected . ' value="1" /> ' . L10n::t("Post to Email") . '</div>';
+					$jotnets_fields[] = [
+						'type' => 'checkbox',
+						'field' => [
+							'pubmail_enable',
+							L10n::t('Post to Email'),
+							$pubmail_enabled
+						]
+					];
 				}
 
-				Hook::callAll('jot_networks', $jotnets);
-			} else {
-				$jotnets .= L10n::t('Connectors disabled, since "%s" is enabled.',
-						L10n::t('Hide your profile details from unknown viewers?'));
+				Hook::callAll('jot_networks', $jotnets_fields);
 			}
 		}
-		
+
 		$tpl = Renderer::getMarkupTemplate('acl_selector.tpl');
 		$o = Renderer::replaceMacros($tpl, [
 			'$showall' => L10n::t('Visible to everybody'),
@@ -306,7 +307,10 @@ class ACL extends BaseObject
 			'$networks' => $show_jotnets,
 			'$emailcc' => L10n::t('CC: email addresses'),
 			'$emtitle' => L10n::t('Example: bob@example.com, mary@example.com'),
-			'$jotnets' => $jotnets,
+			'$jotnets_enabled' => empty($default_permissions['hidewall']),
+			'$jotnets_summary' => L10n::t('Connectors'),
+			'$jotnets_fields' => $jotnets_fields,
+			'$jotnets_disabled_label' => L10n::t('Connectors disabled, since "%s" is enabled.', L10n::t('Hide your profile details from unknown viewers?')),
 			'$aclModalTitle' => L10n::t('Permissions'),
 			'$aclModalDismiss' => L10n::t('Close'),
 			'$features' => [

--- a/view/global.css
+++ b/view/global.css
@@ -1,6 +1,10 @@
 /* General style rules .*/
 .pull-right { float: right }
 
+details > summary {
+  cursor: pointer;
+}
+
 /* General designing elements */
 .btn {
   outline: none;

--- a/view/js/acl.js
+++ b/view/js/acl.js
@@ -225,30 +225,41 @@ ACL.prototype.is_show_all = function() {
 		this.deny_gid.length==0 && this.deny_cid.length==0);
 };
 
-ACL.prototype.update_view = function(){
-	if (this.is_show_all()){
-			this.showall.addClass("selected");
-			/* jot acl */
-				$('#jot-perms-icon').removeClass('lock').addClass('unlock');
-				$('#jot-public').show();
-				$('.profile-jot-net input').attr('disabled', false);
-				if(typeof editor != 'undefined' && editor != false) {
-					$('#profile-jot-desc').html(ispublic);
-				}
+ACL.prototype.update_view = function () {
+	if (this.is_show_all()) {
+		this.showall.addClass("selected");
+		/* jot acl */
+		$('#jot-perms-icon').removeClass('lock').addClass('unlock');
+		$('#jot-public').show();
+		$('.profile-jot-net input[type=checkbox]').each(function() {
+			// Restores checkbox state if it had been saved
+			if ($(this).attr('data-checked') !== undefined) {
+				$(this).prop('checked', $(this).attr('data-checked') === 'true');
+			}
+		});
 
+		$('.profile-jot-net input').attr('disabled', false);
+		if (typeof editor != 'undefined' && editor != false) {
+			$('#profile-jot-desc').html(ispublic);
+		}
 	} else {
-			this.showall.removeClass("selected");
-			/* jot acl */
-				$('#jot-perms-icon').removeClass('unlock').addClass('lock');
-				$('#jot-public').hide();
-				$('.profile-jot-net input').attr('disabled', 'disabled');
-				$('#profile-jot-desc').html('&nbsp;');
+		this.showall.removeClass("selected");
+		/* jot acl */
+		$('#jot-perms-icon').removeClass('unlock').addClass('lock');
+		$('#jot-public').hide();
+		$('.profile-jot-net input[type=checkbox]').each(function() {
+			// Saves current checkbox state
+			$(this)
+				.attr('data-checked', $(this).prop('checked'))
+				.prop('checked', false);
+		});
+		$('.profile-jot-net input').attr('disabled', 'disabled');
+		$('#profile-jot-desc').html('&nbsp;');
 	}
-	$("#acl-list-content .acl-list-item").each(function(){
-		$(this).removeClass("groupshow grouphide");
-	});
 
-	$("#acl-list-content .acl-list-item").each(function(index, element){
+	$("#acl-list-content .acl-list-item").each(function (index, element) {
+		$(this).removeClass("groupshow grouphide");
+
 		itemid = $(element).attr('id');
 		type = itemid[0];
 		id 	 = parseInt(itemid.substr(1));
@@ -256,40 +267,40 @@ ACL.prototype.update_view = function(){
 		btshow = $(element).children(".acl-button-show").removeClass("selected");
 		bthide = $(element).children(".acl-button-hide").removeClass("selected");
 
-		switch(type){
+		switch (type) {
 			case "g":
 				var uclass = "";
-				if (this.allow_gid.indexOf(id)>=0){
+				if (this.allow_gid.indexOf(id) >= 0) {
 					btshow.addClass("selected");
 					bthide.removeClass("selected");
-					uclass="groupshow";
+					uclass = "groupshow";
 				}
-				if (this.deny_gid.indexOf(id)>=0){
+				if (this.deny_gid.indexOf(id) >= 0) {
 					btshow.removeClass("selected");
 					bthide.addClass("selected");
-					uclass="grouphide";
+					uclass = "grouphide";
 				}
 
-				$(this.group_uids[id]).each(function(i,v) {
-					if(uclass == "grouphide")
-						$("#c"+v).removeClass("groupshow");
-					if(uclass != "") {
-						var cls = $("#c"+v).attr('class');
-						if( cls == undefined)
+				$(this.group_uids[id]).each(function (i, v) {
+					if (uclass == "grouphide")
+						$("#c" + v).removeClass("groupshow");
+					if (uclass != "") {
+						var cls = $("#c" + v).attr('class');
+						if (cls == undefined)
 							return true;
 						var hiding = cls.indexOf('grouphide');
-						if(hiding == -1)
-							$("#c"+v).addClass(uclass);
+						if (hiding == -1)
+							$("#c" + v).addClass(uclass);
 					}
 				});
 
 				break;
 			case "c":
-				if (this.allow_cid.indexOf(id)>=0){
+				if (this.allow_cid.indexOf(id) >= 0) {
 					btshow.addClass("selected");
 					bthide.removeClass("selected");
 				}
-				if (this.deny_cid.indexOf(id)>=0){
+				if (this.deny_cid.indexOf(id) >= 0) {
 					btshow.removeClass("selected");
 					bthide.addClass("selected");
 				}
@@ -297,7 +308,7 @@ ACL.prototype.update_view = function(){
 
 	}.bind(this));
 
-}
+};
 
 ACL.prototype.get = function(start,count, search){
 	var postdata = {

--- a/view/templates/acl_selector.tpl
+++ b/view/templates/acl_selector.tpl
@@ -19,9 +19,30 @@
 <hr style="clear:both"/>
 <div id="profile-jot-email-label">{{$emailcc}}</div><input type="text" name="emailcc" id="profile-jot-email" title="{{$emtitle}}" />
 <div id="profile-jot-email-end"></div>
-{{if $jotnets}}
-{{$jotnets nofilter}}
-{{/if}}{{/if}}
+
+	{{if $jotnets_fields}}
+		{{if $jotnets_fields|count < 3}}
+<div class="profile-jot-net">
+		{{else}}
+<details class="profile-jot-net">
+	<summary>{{$jotnets_summary}}</summary>
+		{{/if}}
+
+		{{foreach $jotnets_fields as $jotnets_field}}
+			{{if $jotnets_field.type == 'checkbox'}}
+				{{include file="field_checkbox.tpl" field=$jotnets_field.field}}
+			{{elseif $jotnets_field.type == 'select'}}
+				{{include file="field_select.tpl" field=$jotnets_field.field}}
+			{{/if}}
+		{{/foreach}}
+
+		{{if $jotnets_fields|count >= 3}}
+</details>
+		{{else}}
+</div>
+		{{/if}}
+	{{/if}}
+{{/if}}
 
 <script>
 $(document).ready(function() {

--- a/view/theme/frio/templates/acl_selector.tpl
+++ b/view/theme/frio/templates/acl_selector.tpl
@@ -26,9 +26,29 @@
 </div>
 <div id="profile-jot-email-end"></div>
 
-{{if $jotnets}}
-{{$jotnets nofilter}}
-{{/if}}{{/if}}
+	{{if $jotnets_fields}}
+		{{if $jotnets_fields|count < 3}}
+<div class="profile-jot-net">
+		{{else}}
+<details class="profile-jot-net">
+	<summary>{{$jotnets_summary}}</summary>
+		{{/if}}
+
+		{{foreach $jotnets_fields as $jotnets_field}}
+			{{if $jotnets_field.type == 'checkbox'}}
+				{{include file="field_checkbox.tpl" field=$jotnets_field.field}}
+			{{elseif $jotnets_field.type == 'select'}}
+				{{include file="field_select.tpl" field=$jotnets_field.field}}
+			{{/if}}
+		{{/foreach}}
+
+		{{if $jotnets_fields|count >= 3}}
+</details>
+		{{else}}
+</div>
+		{{/if}}
+	{{/if}}
+{{/if}}
 
 <script type="text/javascript">
 $(document).ready(function() {


### PR DESCRIPTION
Somewhat fixes #6903 

**DON'T FORGET TO MERGE https://github.com/friendica/friendica-addons/pull/833 ALONG**

This PR adds a collapsible panel to hide connector permission fields by default when there are more than 2 in the permission tab/modal (yes, I checked `vier`).

In order to do that, however, I had to convert the `jot_networks` HTML string to a structured array.

I also took some time to make the connector checkboxes less confusing when the item is private: before, they became disabled but stayed checked, which could have indicated that the post would have been sent to the connector anyway. Now the checkboxes clear when the item is set to private, and their former state is restored if the item is set to public again.

Here's the new display by default:
![friendica_connectors_closed](https://user-images.githubusercontent.com/925415/54894745-74022480-4e92-11e9-8d31-9a3e2c2844dd.png)
Open:
![friendica_connectors_open](https://user-images.githubusercontent.com/925415/54894746-74022480-4e92-11e9-9d91-e60a49d63cea.png)
Item was set to private:
![friendica_connectors_open_private](https://user-images.githubusercontent.com/925415/54894747-749abb00-4e92-11e9-9f19-9e79fd43be4d.png)
