### PR TITLE
Fix wrong code block escaping in Smilies

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@ Version 2019.06 (UNRELEASED) (2019-06-?)
     Fixed the timezone of Friendica logs [nupplaphil]
     Fixed tag completion painfully slow [AlfredSK]
     Fixed a regression in notifications [MrPetovan]
+    Fixed an issue with smilies and code blocks [MrPetovan]
     General Code cleaning and restructuring [nupplaphil]
     Added frio color scheme sharing [JeroenED]
     Added syslog and stream Logger [nupplaphil]

--- a/src/Content/Smilies.php
+++ b/src/Content/Smilies.php
@@ -213,7 +213,6 @@ class Smilies
 			return $text;
 		}
 
-		$text = preg_replace_callback('/<pre>(.*?)<\/pre>/ism'  , 'self::encode', $text);
 		$text = preg_replace_callback('/<code>(.*?)<\/code>/ism', 'self::encode', $text);
 
 		if ($no_images) {
@@ -231,7 +230,6 @@ class Smilies
 		$text = preg_replace_callback('/&lt;(3+)/', 'self::pregHeart', $text);
 		$text = self::strOrigReplace($smilies['texts'], $smilies['icons'], $text);
 
-		$text = preg_replace_callback('/<pre>(.*?)<\/pre>/ism', 'self::decode', $text);
 		$text = preg_replace_callback('/<code>(.*?)<\/code>/ism', 'self::decode', $text);
 
 		return $text;
@@ -244,7 +242,7 @@ class Smilies
 	 */
 	private static function encode($m)
 	{
-		return(str_replace($m[1], Strings::base64UrlEncode($m[1]), $m[0]));
+		return '<code>' . Strings::base64UrlEncode($m[1]) . '</code>';
 	}
 
 	/**
@@ -255,7 +253,7 @@ class Smilies
 	 */
 	private static function decode($m)
 	{
-		return(str_replace($m[1], Strings::base64UrlDecode($m[1]), $m[0]));
+		return '<code>' . Strings::base64UrlDecode($m[1]) . '</code>';
 	}
 
 

--- a/tests/src/Content/SmiliesTest.php
+++ b/tests/src/Content/SmiliesTest.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: benlo
+ * Date: 25/03/19
+ * Time: 21:36
+ */
+
+namespace Friendica\Test\src\Content;
+
+use Friendica\Content\Smilies;
+use Friendica\Test\MockedTest;
+use Friendica\Test\Util\AppMockTrait;
+use Friendica\Test\Util\L10nMockTrait;
+use Friendica\Test\Util\VFSTrait;
+
+class SmiliesTest extends MockedTest
+{
+	use VFSTrait;
+	use AppMockTrait;
+	use L10nMockTrait;
+
+	protected function setUp()
+	{
+		parent::setUp();
+		$this->setUpVfsDir();
+		$this->mockApp($this->root);
+		$this->app->videowidth = 425;
+		$this->app->videoheight = 350;
+		$this->configMock->shouldReceive('get')
+			->with('system', 'no_smilies')
+			->andReturn(false);
+		$this->configMock->shouldReceive('get')
+			->with(false, 'system', 'no_smilies')
+			->andReturn(false);
+	}
+
+	public function dataLinks()
+	{
+		return [
+			/** @see https://github.com/friendica/friendica/pull/6933 */
+			'bug-6933-1' => [
+				'data' => '<code>/</code>',
+				'smilies' => ['texts' => [], 'icons' => []],
+				'expected' => '<code>/</code>',
+			],
+			'bug-6933-2' => [
+				'data' => '<code>code</code>',
+				'smilies' => ['texts' => [], 'icons' => []],
+				'expected' => '<code>code</code>',
+			],
+		];
+	}
+
+	/**
+	 * Test replace smilies in different texts
+	 * @dataProvider dataLinks
+	 *
+	 * @param string $text     Test string
+	 * @param array  $smilies  List of smilies to replace
+	 * @param string $expected Expected result
+	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
+	 */
+	public function testReplaceFromArray($text, $smilies, $expected)
+	{
+		$output = Smilies::replaceFromArray($text, $smilies);
+		$this->assertEquals($expected, $output);
+	}
+}


### PR DESCRIPTION
Directly from the Department of Edge Cases That Definitely Should Have Been Better Handled In The First Place, I present you the curious case of the code block escaping during smilies replacement.

The crux of the problem comes from the escaping callbacks string replacement:
```php
	public static function replaceFromArray($text, array $smilies, $no_images = false)
	{
		...
		$text = preg_replace_callback('/<pre>(.*?)<\/pre>/ism'  , 'self::encode', $text);
		$text = preg_replace_callback('/<code>(.*?)<\/code>/ism', 'self::encode', $text);

		...

		$text = preg_replace_callback('/<pre>(.*?)<\/pre>/ism', 'self::decode', $text);
		$text = preg_replace_callback('/<code>(.*?)<\/code>/ism', 'self::decode', $text);

		return $text;
	}

	private static function encode($m)
	{
		return(str_replace($m[1], Strings::base64UrlEncode($m[1]), $m[0]));
	}

	private static function decode($m)
	{
		return(str_replace($m[1], Strings::base64UrlDecode($m[1]), $m[0]));
	}
```

Their goal is to replace the original text with the encoded version inside the `<pre>` or `<code>` tags, and later replace the encoded version with the original text inside the `<pre>` or `<code>` tags. Unfortunately, they are at tad too zealous for what they need to do.

With interesting original texts comes interesting results.

For example:
- `<code>/</code>` gets encoded to `<code>Lw==<Lw==code>`
- `<code>code</code>` gets encoded to `<Y29kZQ==>Y29kZQ==</Y29kZQ==>`

It gets even better if there's another `<code>` block later in the text, because the above replacement destroys the original `</code>` tag the second decoding regular expression is expecting and ends up capturing the content of the second code blocks and everything in between. All of a sudden a mix of base64-encoded text and HTML gets fed to `Strings::base64UrlDecode`, which expectedly produces binary gibberish, which will make the preview fail and, if it's posted in an actual item, will produce the following item content ([example 1](https://friendica.mrpetovan.com/display/0b0dde58609ee234d5c6332891bfabf20874eaf2) and [example 2](https://friendica.mrpetovan.com/display/735a2029-795c-984d-9a09-975634248386)):
```
\excellent[choice=made, improvement=rapid] {silverwizard}
```

I have no clue whatsoever about what this is, nor why, when fed to DuckDuckGo, no result page shows up, instead redirecting to https://www.science.gov/topicpages/r/river+noxon+rapids.html (safe) ???

Anyway, this was another blast to the past thanks to @friendica : https://github.com/friendica/friendica/commit/91c334902565b2ceb7fd26735b4d501973e28557