### PR TITLE
Fixing basepath issue

### DIFF
--- a/config/dbstructure.config.php
+++ b/config/dbstructure.config.php
@@ -34,7 +34,7 @@
 use Friendica\Database\DBA;
 
 if (!defined('DB_UPDATE_VERSION')) {
-	define('DB_UPDATE_VERSION', 1306);
+	define('DB_UPDATE_VERSION', 1307);
 }
 
 return [

--- a/src/Core/Update.php
+++ b/src/Core/Update.php
@@ -285,22 +285,24 @@ class Update
 
 		$savedConfig = DBA::selectFirst('config', ['v'], ['cat' => $cat, 'k' => $key]);
 
-		if (!DBA::isResult($savedConfig)) {
-			$savedConfig = null;
-		}
-
-		if ($fileConfig !== $savedConfig['v']) {
+		// If the db contains a config value, check it
+		if (DBA::isResult($savedConfig) && $fileConfig !== $savedConfig['v']) {
 			Logger::info('Difference in config found', ['cat' => $cat, 'key' => $key, 'file' => $fileConfig, 'saved' => $savedConfig['v']]);
 			$configFileSaver->addConfigValue($cat, $key, $savedConfig['v']);
-		} elseif (empty($fileConfig) && empty($savedConfig)) {
+			return true;
+
+		// If both config values are empty, use the default value
+		} elseif (empty($fileConfig) && !DBA::isResult($savedConfig)) {
 			Logger::info('Using default for config', ['cat' => $cat, 'key' => $key, 'value' => $default]);
 			$configFileSaver->addConfigValue($cat, $key, $default);
+			return true;
+
+		// If either the file config value isn't empty or the db value is the same as the
+		// file config value, skip it
 		} else {
 			Logger::info('No Difference in config found', ['cat' => $cat, 'key' => $key, 'value' => $fileConfig, 'saved' => $savedConfig['v']]);
 			return false;
 		}
-
-		return true;
 	}
 
 	/**

--- a/src/Core/Update.php
+++ b/src/Core/Update.php
@@ -285,14 +285,20 @@ class Update
 
 		$savedConfig = DBA::selectFirst('config', ['v'], ['cat' => $cat, 'k' => $key]);
 
+		if (DBA::isResult($savedConfig)) {
+			$savedValue = $savedConfig['v'];
+		} else {
+			$savedValue = null;
+		}
+
 		// If the db contains a config value, check it
-		if (DBA::isResult($savedConfig) && $fileConfig !== $savedConfig['v']) {
-			Logger::info('Difference in config found', ['cat' => $cat, 'key' => $key, 'file' => $fileConfig, 'saved' => $savedConfig['v']]);
-			$configFileSaver->addConfigValue($cat, $key, $savedConfig['v']);
+		if (isset($savedValue) && $fileConfig !== $savedValue) {
+			Logger::info('Difference in config found', ['cat' => $cat, 'key' => $key, 'file' => $fileConfig, 'saved' => $savedValue]);
+			$configFileSaver->addConfigValue($cat, $key, $savedValue);
 			return true;
 
-		// If both config values are empty, use the default value
-		} elseif (empty($fileConfig) && !DBA::isResult($savedConfig)) {
+		// If both config values are not set, use the default value
+		} elseif (!isset($fileConfig) && !isset($savedValue)) {
 			Logger::info('Using default for config', ['cat' => $cat, 'key' => $key, 'value' => $default]);
 			$configFileSaver->addConfigValue($cat, $key, $default);
 			return true;
@@ -300,7 +306,7 @@ class Update
 		// If either the file config value isn't empty or the db value is the same as the
 		// file config value, skip it
 		} else {
-			Logger::info('No Difference in config found', ['cat' => $cat, 'key' => $key, 'value' => $fileConfig, 'saved' => $savedConfig['v']]);
+			Logger::info('No Difference in config found', ['cat' => $cat, 'key' => $key, 'value' => $fileConfig, 'saved' => $savedValue]);
 			return false;
 		}
 	}

--- a/src/Core/Update.php
+++ b/src/Core/Update.php
@@ -245,7 +245,7 @@ class Update
 			$updated = true;
 		};
 
-		if (self::updateConfigEntry($configCache, $configFileSaver,'system', 'basepath', BasePath::create(dirname(__DIR__)))) {
+		if (self::updateConfigEntry($configCache, $configFileSaver,'system', 'basepath', BasePath::create(dirname(__DIR__) . '/../'))) {
 			$updated = true;
 		}
 
@@ -286,7 +286,7 @@ class Update
 		$savedConfig = DBA::selectFirst('config', ['v'], ['cat' => $cat, 'k' => $key]);
 
 		if (!DBA::isResult($savedConfig)) {
-			return false;
+			$savedConfig = null;
 		}
 
 		if ($fileConfig !== $savedConfig['v']) {
@@ -297,6 +297,7 @@ class Update
 			$configFileSaver->addConfigValue($cat, $key, $default);
 		} else {
 			Logger::info('No Difference in config found', ['cat' => $cat, 'key' => $key, 'value' => $fileConfig, 'saved' => $savedConfig['v']]);
+			return false;
 		}
 
 		return true;

--- a/src/Util/Config/ConfigFileLoader.php
+++ b/src/Util/Config/ConfigFileLoader.php
@@ -34,10 +34,11 @@ class ConfigFileLoader extends ConfigFileManager
 	 * expected local.config.php
 	 *
 	 * @param IConfigCache $config The config cache to load to
+	 * @param bool         $raw    Setup the raw config format
 	 *
 	 * @throws \Exception
 	 */
-	public function setupCache(IConfigCache $config)
+	public function setupCache(IConfigCache $config, $raw = false)
 	{
 		$config->load($this->loadCoreConfig('defaults'));
 		$config->load($this->loadCoreConfig('settings'));
@@ -48,7 +49,7 @@ class ConfigFileLoader extends ConfigFileManager
 		$config->load($this->loadCoreConfig('local'), true);
 
 		// In case of install mode, add the found basepath (because there isn't a basepath set yet
-		if ($this->appMode->isInstall()) {
+		if (!$raw && ($this->appMode->isInstall() || empty($config->get('system', 'basepath')))) {
 			// Setting at least the basepath we know
 			$config->set('system', 'basepath', $this->baseDir);
 		}

--- a/update.php
+++ b/update.php
@@ -352,7 +352,7 @@ function update_1298()
  * @see https://github.com/friendica/friendica/pull/6920
  * @return int Success
  */
-function update_1305()
+function update_1307()
 {
 	$app = BaseObject::getApp();
 	if (Update::saveConfigToFile($app->getBasePath(), $app->getMode())) {


### PR DESCRIPTION
FollowUp #6920 

<strike>I'm not finished yet, but I've to leave for now.</strike>

- I'd like to automatically add `system.basepath` with the determined in case there is nothing in the config file as a fallback.
- In case of an update, if both values are empty, take a default value for the config (= determined basepath)