### PR TITLE
[frio] Switch comment box closing event listener from click to mousedown

### DIFF
--- a/view/theme/frio/js/theme.js
+++ b/view/theme/frio/js/theme.js
@@ -282,7 +282,7 @@ $(document).ready(function(){
 	 * We are making an exception for buttons because of a race condition with the
 	 * comment opening button that results in an already closed comment UI.
 	 */
-	$(document).on('click', function(event) {
+	$(document).on('mousedown', function(event) {
 		if (event.target.type === 'button') {
 			return true;
 		}


### PR DESCRIPTION
Fixes #6947

Apparently Chrome 73 didn't suppress the comment box closing `click` event after the `onFocus` event attribute had been processed on the fake comment form textarea.

This resulted in the comment box appearing per the `onFocus` event, and then the `click` event to fire and close it. This timing is because the `click` event is actually fired when the mouse is released.

By changing the  comment box closing event to `mousedown`, it's fired immediately, before the comment box is opened, so nothing happens as expected.