### PR TITLE
check if BasePath is empty to prevent mangeled up CSS path

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -182,13 +182,11 @@ class App
 	 */
 	public function registerStylesheet($path)
 	{
-		if (!empty($this->getBasePath())) {
-			$url = str_replace($this->getBasePath() . DIRECTORY_SEPARATOR, '', $path);
-		} else {
-			$url = $path;
+		if (mb_strpos($path, $this->getBasePath() . DIRECTORY_SEPARATOR) == 0) {
+				$path = mb_substr($path, mb_strlen($this->getBasePath() . DIRECTORY_SEPARATOR));
 		}
 
-		$this->stylesheets[] = trim($url, '/');
+		$this->stylesheets[] = trim($path, '/');
 	}
 
 	/**

--- a/src/App.php
+++ b/src/App.php
@@ -182,7 +182,11 @@ class App
 	 */
 	public function registerStylesheet($path)
 	{
-		$url = str_replace($this->getBasePath() . DIRECTORY_SEPARATOR, '', $path);
+		if (!empty($this->getBasePath())) {
+			$url = str_replace($this->getBasePath() . DIRECTORY_SEPARATOR, '', $path);
+		} else {
+			$url = $path;
+		}
 
 		$this->stylesheets[] = trim($url, '/');
 	}


### PR DESCRIPTION
It seems that if the BasePath is not set, but replaced in the path information, this causes the removal of the / needed to have a correct path.