### PR TITLE
ConfigFile upgrade hardening

### DIFF
--- a/bin/worker.php
+++ b/bin/worker.php
@@ -33,7 +33,7 @@ require dirname(__DIR__) . '/vendor/autoload.php';
 $a = Factory\DependencyFactory::setUp('worker', dirname(__DIR__));
 
 // Check the database structure and possibly fixes it
-Update::check($a->getBasePath(), true);
+Update::check($a->getBasePath(), true, $a->getMode());
 
 // Quit when in maintenance
 if (!$a->getMode()->has(App\Mode::MAINTENANCEDISABLED)) {

--- a/src/App.php
+++ b/src/App.php
@@ -1187,7 +1187,7 @@ class App
 			$this->module = 'maintenance';
 		} else {
 			$this->checkURL();
-			Core\Update::check($this->getBasePath(), false);
+			Core\Update::check($this->getBasePath(), false, $this->getMode());
 			Core\Addon::loadAddons();
 			Core\Hook::loadHooks();
 		}

--- a/src/Core/Config/Cache/ConfigCache.php
+++ b/src/Core/Config/Cache/ConfigCache.php
@@ -188,4 +188,32 @@ class ConfigCache implements IConfigCache, IPConfigCache
 	{
 		return $this->config;
 	}
+
+    /**
+     * Returns an array with missing categories/Keys
+     *
+     * @param array $config The array to check
+     *
+     * @return array
+     */
+	public function keyDiff(array $config)
+    {
+        $return = [];
+
+        $categories = array_keys($config);
+
+        foreach ($categories as $category) {
+            if (is_array($config[$category])) {
+                $keys = array_keys($config[$category]);
+
+                foreach ($keys as $key) {
+                    if (!isset($this->config[$category][$key])) {
+                        $return[$category][$key] = $config[$category][$key];
+                    }
+                }
+            }
+        }
+
+        return $return;
+    }
 }

--- a/src/Core/Config/Cache/ConfigCache.php
+++ b/src/Core/Config/Cache/ConfigCache.php
@@ -189,31 +189,31 @@ class ConfigCache implements IConfigCache, IPConfigCache
 		return $this->config;
 	}
 
-    /**
-     * Returns an array with missing categories/Keys
-     *
-     * @param array $config The array to check
-     *
-     * @return array
-     */
+	/**
+	 * Returns an array with missing categories/Keys
+	 *
+	 * @param array $config The array to check
+	 *
+	 * @return array
+	 */
 	public function keyDiff(array $config)
-    {
-        $return = [];
+	{
+		$return = [];
 
-        $categories = array_keys($config);
+		$categories = array_keys($config);
 
-        foreach ($categories as $category) {
-            if (is_array($config[$category])) {
-                $keys = array_keys($config[$category]);
+		foreach ($categories as $category) {
+			if (is_array($config[$category])) {
+				$keys = array_keys($config[$category]);
 
-                foreach ($keys as $key) {
-                    if (!isset($this->config[$category][$key])) {
-                        $return[$category][$key] = $config[$category][$key];
-                    }
-                }
-            }
-        }
+				foreach ($keys as $key) {
+					if (!isset($this->config[$category][$key])) {
+						$return[$category][$key] = $config[$category][$key];
+					}
+				}
+			}
+		}
 
-        return $return;
-    }
+		return $return;
+	}
 }

--- a/src/Core/Update.php
+++ b/src/Core/Update.php
@@ -233,7 +233,7 @@ class Update
 	 * Checks the config settings and saves given config values into the config file
 	 *
 	 * @param string    $basePath The basepath of Friendica
-     * @param App\Mode  $$mode    The current App mode
+	 * @param App\Mode  $mode     The current App mode
 	 *
 	 * @return bool True, if something has been saved
 	 */
@@ -314,7 +314,7 @@ class Update
 	 * @param ConfigFileSaver $configFileSaver The config file saver
 	 * @param string          $cat             The config category
 	 * @param string          $key             The config key
-     * @param bool            $allowEmpty      If true, empty values are valid (Default there has to be a variable)
+	 * @param bool            $allowEmpty      If true, empty values are valid (Default there has to be a variable)
 	 * @param string          $default         A default value, if none of the settings are valid
 	 *
 	 * @return boolean True, if a value was updated

--- a/tests/src/Core/Config/Cache/ConfigCacheTest.php
+++ b/tests/src/Core/Config/Cache/ConfigCacheTest.php
@@ -246,33 +246,33 @@ class ConfigCacheTest extends MockedTest
 		$this->assertEmpty($configCache->getAll());
 	}
 
-    /**
-     * Test the keyDiff() method with result
-     * @dataProvider dataTests
-     */
+	/**
+	 * Test the keyDiff() method with result
+	 * @dataProvider dataTests
+	 */
 	public function testKeyDiffWithResult($data)
-    {
-        $configCache = new ConfigCache($data);
+	{
+		$configCache = new ConfigCache($data);
 
-        $diffConfig = [
-            'fakeCat' => [
-                'fakeKey' => 'value',
-            ]
-        ];
+		$diffConfig = [
+			'fakeCat' => [
+				'fakeKey' => 'value',
+			]
+		];
 
-        $this->assertEquals($diffConfig, $configCache->keyDiff($diffConfig));
-    }
+		$this->assertEquals($diffConfig, $configCache->keyDiff($diffConfig));
+	}
 
-    /**
-     * Test the keyDiff() method without result
-     * @dataProvider dataTests
-     */
-    public function testKeyDiffWithoutResult($data)
-    {
-        $configCache = new ConfigCache($data);
+	/**
+	 * Test the keyDiff() method without result
+	 * @dataProvider dataTests
+	 */
+	public function testKeyDiffWithoutResult($data)
+	{
+		$configCache = new ConfigCache($data);
 
-        $diffConfig = $configCache->getAll();
+		$diffConfig = $configCache->getAll();
 
-        $this->assertEmpty($configCache->keyDiff($diffConfig));
-    }
+		$this->assertEmpty($configCache->keyDiff($diffConfig));
+	}
 }

--- a/tests/src/Core/Config/Cache/ConfigCacheTest.php
+++ b/tests/src/Core/Config/Cache/ConfigCacheTest.php
@@ -245,4 +245,34 @@ class ConfigCacheTest extends MockedTest
 
 		$this->assertEmpty($configCache->getAll());
 	}
+
+    /**
+     * Test the keyDiff() method with result
+     * @dataProvider dataTests
+     */
+	public function testKeyDiffWithResult($data)
+    {
+        $configCache = new ConfigCache($data);
+
+        $diffConfig = [
+            'fakeCat' => [
+                'fakeKey' => 'value',
+            ]
+        ];
+
+        $this->assertEquals($diffConfig, $configCache->keyDiff($diffConfig));
+    }
+
+    /**
+     * Test the keyDiff() method without result
+     * @dataProvider dataTests
+     */
+    public function testKeyDiffWithoutResult($data)
+    {
+        $configCache = new ConfigCache($data);
+
+        $diffConfig = $configCache->getAll();
+
+        $this->assertEmpty($configCache->keyDiff($diffConfig));
+    }
 }

--- a/update.php
+++ b/update.php
@@ -1,6 +1,5 @@
 <?php
 
-use Friendica\BaseObject;
 use Friendica\Core\Addon;
 use Friendica\Core\Config;
 use Friendica\Core\L10n;
@@ -346,18 +345,4 @@ function update_1298()
 		Logger::notice($translateKey . " fix completed", ['action' => 'update', 'translateKey' => $translateKey, 'Success' => $success, 'Fail' => $fail ]);
 	}
 	return Update::SUCCESS;
-}
-
-/**
- * @see https://github.com/friendica/friendica/pull/6920
- * @return int Success
- */
-function update_1307()
-{
-	$app = BaseObject::getApp();
-	if (Update::saveConfigToFile($app->getBasePath(), $app->getMode())) {
-		return Update::SUCCESS;
-	} else {
-		return Update::FAILED;
-	}
 }


### PR DESCRIPTION
This PR automatically checks the config file at each visit
- If the config file already contains all necessary categories/keys, skip the whole function (performance)
- For each missing category/key combination, check if we do have a DB value
- If `$allowEmpty` isn't set (per default), an empty value - even through the DB - results in using the detected value

This, in combination with #6953 , should solve the problem of missing/invalid `system.basepath` values.