### PR TITLE
vier mobile enhancements

### DIFF
--- a/view/theme/vier/mobile.css
+++ b/view/theme/vier/mobile.css
@@ -1,4 +1,4 @@
-aside, header, #nav-search-box, #nav-messages-linkmenu,  #activitiy-by-date-tab, #shared-links-tab,
+aside, header, #nav-search-box, #nav-admin-link, #nav-messages-linkmenu,  #activitiy-by-date-tab, #shared-links-tab,
 .wall-item-location {
   display: none;
 }

--- a/view/theme/vier/mobile.css
+++ b/view/theme/vier/mobile.css
@@ -1,4 +1,4 @@
-aside, header, #nav-events-link, #nav-search-box, #nav-admin-link, #activitiy-by-date-tab, #shared-links-tab,
+aside, header, #nav-search-box, #nav-messages-linkmenu,  #activitiy-by-date-tab, #shared-links-tab,
 .wall-item-location {
   display: none;
 }

--- a/view/theme/vier/templates/nav.tpl
+++ b/view/theme/vier/templates/nav.tpl
@@ -86,6 +86,11 @@
 					{{if $nav.manage}}<li role="menuitem"><a class="{{$nav.manage.2}}" href="{{$nav.manage.0}}" title="{{$nav.manage.3}}">{{$nav.manage.1}}</a></li>{{/if}}
 					{{if $nav.usermenu.1}}<li role="menuitem"><a class="{{$nav.usermenu.1.2}}" href="{{$nav.usermenu.1.0}}" title="{{$nav.usermenu.1.3}}">{{$nav.usermenu.1.1}}</a></li>{{/if}}
 					{{if $nav.settings}}<li role="menuitem"><a class="{{$nav.settings.2}}" href="{{$nav.settings.0}}" title="{{$nav.settings.3}}">{{$nav.settings.1}}</a></li>{{/if}}
+					{{if $nav.admin}}
+					<li role="menuitem">
+						<a accesskey="a" class="{{$nav.admin.2}}" href="{{$nav.admin.0}}" title="{{$nav.admin.3}}" >{{$nav.admin.1}}</a>
+					</li>
+					{{/if}}
 					{{if $nav.logout}}<li role="menuitem"><a class="menu-sep {{$nav.logout.2}}" href="{{$nav.logout.0}}" title="{{$nav.logout.3}}" >{{$nav.logout.1}}</a></li>{{/if}}
 				</ul>
 			</li>

--- a/view/theme/vier/templates/nav.tpl
+++ b/view/theme/vier/templates/nav.tpl
@@ -80,6 +80,7 @@
 			<li role="menu" aria-haspopup="true" id="nav-user-linkmenu" class="nav-menu">
 				<a accesskey="u" title="{{$sitelocation}}"><img src="{{$userinfo.icon}}" alt="{{$userinfo.name}}"><span id="nav-user-linklabel">{{$userinfo.name}}</span><span id="intro-update" class="nav-notify"></span></a>
 				<ul id="nav-user-menu" class="menu-popup">
+					<li role="menuitem"> <a  class="{{$nav.search.2}}" href="{{$nav.search.0}}" title="{{$nav.search.3}}" >{{$nav.search.1}}</a> </li>
 					{{if $nav.introductions}}<li role="menuitem"><a class="{{$nav.introductions.2}}" href="{{$nav.introductions.0}}" title="{{$nav.introductions.3}}" >{{$nav.introductions.1}}</a><span id="intro-update-li" class="nav-notify"></span></li>{{/if}}
 					{{if $nav.contacts}}<li role="menuitem"><a class="{{$nav.contacts.2}}" href="{{$nav.contacts.0}}" title="{{$nav.contacts.3}}" >{{$nav.contacts.1}}</a></li>{{/if}}
 					{{if $nav.messages}}<li role="menuitem"><a class="{{$nav.messages.2}}" href="{{$nav.messages.0}}" title="{{$nav.messages.3}}" >{{$nav.messages.1}} <span id="mail-update-li" class="nav-notify"></span></a></li>{{/if}}


### PR DESCRIPTION
concerning #6384

In mobile view the link to the events page was un-hidden.

The links to the admin interface was added to the menu (as some people did not find the icon) but keept in the top-bar in the desktob view as it is really handy there.
In mobile view the links to the admin panel and the message view are removed as those are in the user menu.

Please don't merge *now* I'll add something for the search ASAP


![vier-mobil](https://user-images.githubusercontent.com/433490/55287578-22362e80-53ab-11e9-97f3-42db74dfb591.png)
