### PR TITLE
Send AP Tombstone activity on deleted profiles

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@ Version 2019.06 (UNRELEASED) (2019-06-?)
     Fixed tag completion painfully slow [AlfredSK]
     Fixed a regression in notifications [MrPetovan]
     Fixed an issue with smilies and code blocks [MrPetovan]
+    Fixed an AP issue with unavailable local profiles [MrPetovan]
     General Code cleaning and restructuring [nupplaphil]
     Added frio color scheme sharing [JeroenED]
     Added syslog and stream Logger [nupplaphil]
@@ -14,7 +15,7 @@ Version 2019.06 (UNRELEASED) (2019-06-?)
     Added collapsible panel for connector permission fields [MrPetovan]
 
   Closed Issues:
-    6303, 6478, 6319, 6921, 6903
+    6303, 6478, 6319, 6921, 6903, 6943
 
 Version 2019.03 (2019-03-22)
   Friendica Core:

--- a/src/Module/Profile.php
+++ b/src/Module/Profile.php
@@ -63,14 +63,7 @@ class Profile extends BaseModule
 				System::jsonExit($data, 'application/activity+json');
 			} elseif (DBA::exists('userd', ['username' => self::$which])) {
 				// Known deleted user
-				$data = [
-					'@context' => ActivityPub::CONTEXT,
-					'id' => self::getApp()->getBaseUrl() . '/profile/' . self::$which,
-					'type' => 'Tombstone',
-					'published' => DateTimeFormat::utcNow(DateTimeFormat::ATOM),
-					'updated' => DateTimeFormat::utcNow(DateTimeFormat::ATOM),
-					'deleted' => DateTimeFormat::utcNow(DateTimeFormat::ATOM),
-				];
+				$data = ActivityPub\Transmitter::getDeletedUser(self::$which);
 
 				System::jsonError(410, $data);
 			} else {

--- a/src/Module/Profile.php
+++ b/src/Module/Profile.php
@@ -65,7 +65,7 @@ class Profile extends BaseModule
 				// Known deleted user
 				$data = [
 					'@context' => ActivityPub::CONTEXT,
-					'id' => System::baseUrl() . '/profile/' . self::$which,
+					'id' => self::getApp()->getBaseUrl() . '/profile/' . self::$which,
 					'type' => 'Tombstone',
 					'published' => DateTimeFormat::utcNow(DateTimeFormat::ATOM),
 					'updated' => DateTimeFormat::utcNow(DateTimeFormat::ATOM),

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -248,6 +248,23 @@ class Transmitter
 	}
 
 	/**
+	 * @param string $username
+	 * @return array
+	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
+	 */
+	public static function getDeletedUser($username)
+	{
+		return [
+			'@context' => ActivityPub::CONTEXT,
+			'id' => System::baseUrl() . '/profile/' . $username,
+			'type' => 'Tombstone',
+			'published' => DateTimeFormat::utcNow(DateTimeFormat::ATOM),
+			'updated' => DateTimeFormat::utcNow(DateTimeFormat::ATOM),
+			'deleted' => DateTimeFormat::utcNow(DateTimeFormat::ATOM),
+		];
+	}
+
+	/**
 	 * Returns an array with permissions of a given item array
 	 *
 	 * @param array $item


### PR DESCRIPTION
Fixes #6943
Follow-up to #6562 

Additionally, this PR normalizes the response for unavailable local profiles to 404 status code.

We don't store the deletion date and time for users, so all the three activity date fields I'm not sure are optional have been populated with the current time.