### PR TITLE
ConfigFileSave Hardending/Fixing

### DIFF
--- a/src/Util/Config/ConfigFileSaver.php
+++ b/src/Util/Config/ConfigFileSaver.php
@@ -66,7 +66,7 @@ class ConfigFileSaver extends ConfigFileManager
 	 */
 	public function saveToConfigFile($name = '')
 	{
-		// If there aer no settings, return true
+		// If there are no settings, return true
 		if (count(array_keys($this->settings)) === 0) {
 			return true;
 		}

--- a/src/Util/Config/ConfigFileSaver.php
+++ b/src/Util/Config/ConfigFileSaver.php
@@ -314,7 +314,7 @@ class ConfigFileSaver extends ConfigFileManager
 					// we're still in the value setting mode, because all next values are values of the current key
 					// (this is because we split by whitespace, which includes multi string values, e.g. "Friendica Server")
 					if ($currentKeyArrowFound && isset($currentVal)) {
-						$currentVal = ' ' . str_replace('\'', '', $value);
+						$currentVal .= ' ' . str_replace('\'', '', $value);
 						continue;
 					}
 				}
@@ -583,9 +583,11 @@ class ConfigFileSaver extends ConfigFileManager
 	private function valueToString($value, $ini = false)
 	{
 		switch (true) {
-			case is_bool($value) && $value:
+			case ((is_bool($value) && $value) ||
+			       $value === 'true'):
 				return "true";
-			case is_bool($value) && !$value:
+			case ((is_bool($value) && !$value) ||
+				   $value === 'false'):
 				return "false";
 			case is_array($value):
 				if ($ini) {
@@ -594,6 +596,8 @@ class ConfigFileSaver extends ConfigFileManager
 					return "'" . addslashes(implode(',', $value)) . "'";
 				}
 			case is_numeric($value):
+				return "$value";
+			case defined($value):
 				return "$value";
 			default:
 				if ($ini) {

--- a/src/Util/Config/ConfigFileSaver.php
+++ b/src/Util/Config/ConfigFileSaver.php
@@ -66,7 +66,7 @@ class ConfigFileSaver extends ConfigFileManager
 	 */
 	public function saveToConfigFile($name = '')
 	{
-		// If no settings et, return true
+		// If there aer no settings, return true
 		if (count(array_keys($this->settings)) === 0) {
 			return true;
 		}
@@ -112,7 +112,7 @@ class ConfigFileSaver extends ConfigFileManager
 	}
 
 	/**
-	 * Opens a config file and returns two handler for reading and writing
+	 * Opens a config file and returns the current config file as an array
 	 *
 	 * @param string $fullName The full name of the current config
 	 *

--- a/src/Util/Config/ConfigFileSaver.php
+++ b/src/Util/Config/ConfigFileSaver.php
@@ -403,7 +403,7 @@ class ConfigFileSaver extends ConfigFileManager
 				if ($ini) {
 					return implode(',', $value);
 				} else {
-					return "'" . implode(',', $value) . "'";
+					return "'" . addslashes(implode(',', $value)) . "'";
 				}
 			case is_numeric($value):
 				return "$value";
@@ -411,7 +411,7 @@ class ConfigFileSaver extends ConfigFileManager
 				if ($ini) {
 					return (string)$value;
 				} else {
-					return "'" . (string)$value . "'";
+					return "'" . addslashes((string)$value) . "'";
 				}
 		}
 	}

--- a/tests/datasets/config/.htconfig.php
+++ b/tests/datasets/config/.htconfig.php
@@ -69,5 +69,6 @@ $a->config['system']['directory'] = 'http://another.url';
 $a->config
 ['system']
 ['numeric']
+// geht hier ein kommentar??
 	=
 	2.5;

--- a/tests/datasets/config/.htconfig.php
+++ b/tests/datasets/config/.htconfig.php
@@ -13,7 +13,11 @@ $pidfile = '/var/run/friendica.pid';
 // Set the database connection charset to UTF8.
 // Changing this value will likely corrupt the special characters.
 // You have been warned.
-$a->config['system']['db_charset'] = "anotherCharset";
+$a->config
+['system']
+['db_charset']
+	=
+	"anotherCharset";
 
 // Choose a legal default timezone. If you are unsure, use "America/Los_Angeles".
 // It can be changed later and only applies to timestamps for anonymous viewers.
@@ -55,11 +59,15 @@ $a->config['system']['allowed_themes'] = 'quattro,vier,duepuntozero';
 $a->config['system']['theme'] = 'frio';
 
 // By default allow pseudonyms
-$a->config['system']['no_regfullname'] = true;
+ $a->config['system']['no_regfullname'] = true;
 
 //Deny public access to the local directory
 //$a->config['system']['block_local_dir'] = false;
 // Location of the global directory
 $a->config['system']['directory'] = 'http://another.url';
 
-$a->config['system']['numeric'] = 2.5;
+$a->config
+['system']
+['numeric']
+	=
+	2.5;

--- a/tests/datasets/config/.htconfig.php
+++ b/tests/datasets/config/.htconfig.php
@@ -31,7 +31,7 @@ $a->config['sitename'] = "Friendica My Network";
 // and/or approve/deny the request.
 // In order to perform system administration via the admin panel, admin_email
 // must precisely match the email address of the person logged in.
-$a->config['register_policy'] = REGISTER_OPEN;
+$a->config['register_policy'] = \Friendica\Module\Register::OPEN;
 $a->config['register_text'] = 'A register text';
 $a->config['admin_email'] = 'admin@test.it';
 $a->config['admin_nickname'] = 'Friendly admin';
@@ -61,3 +61,5 @@ $a->config['system']['no_regfullname'] = true;
 //$a->config['system']['block_local_dir'] = false;
 // Location of the global directory
 $a->config['system']['directory'] = 'http://another.url';
+
+$a->config['system']['numeric'] = 2.5;

--- a/tests/datasets/config/local.config.php
+++ b/tests/datasets/config/local.config.php
@@ -6,23 +6,45 @@
  */
 
 return [
-	'database' => [
-		'hostname' => 'testhost',
-		'username' => 'testuser',
-		'password' => 'testpw',
-		'database' => 'testdb',
-		'charset' => 'utf8mb4',
-	],
-
-	'config' => [
-		'admin_email' => 'admin@test.it',
-		'sitename' => 'Friendica Social Network',
-		'register_policy' => \Friendica\Module\Register::OPEN,
-		'register_text' => '',
-	],
-	'system' => [
-		'default_timezone' => 'UTC',
-		'language' => 'en',
-		'theme' => 'frio',
-	],
+    'database' =>
+    /** Test it
+     * with comment
+     **/
+        [
+            'hostname' => 'testhost',
+            'username' => 'testuser',
+            'password' => 'testpw',
+            'database' => 'testdb',
+            'charset' => 'utf8mb4',
+        ],
+    // another try
+    /**
+     * What about this
+     */
+    'config' =>
+    // but with comment here
+        [
+            'admin_email' =>
+            // and here
+                'admin@test.it',
+            'sitename' => 'Friendica Social Network',
+            'register_policy' =>
+            // and here too
+                \Friendica\Module\Register::OPEN,
+            'register_text' => '',
+        ],
+    'system'
+    =>
+        [
+            'default_timezone' => 'UTC',
+            'language' => 'en',
+            'theme' => 'frio'
+        ],
+    'testcat' => [
+        'testarr' => ['1','2','3'],
+    ],
+    // closing it
+    \Friendica\App::class => [
+        \Friendica\App\Mode::class => true
+    ]
 ];

--- a/tests/datasets/config/local.config.php
+++ b/tests/datasets/config/local.config.php
@@ -24,25 +24,24 @@ return [
 	'config' =>
 	// but with comment here
 		[
-		'admin_email' =>
-		// and here
-			'admin@test.it',
-		'sitename' => 'Friendica Social Network',
-		'register_policy' =>
-		// and here too
-			\Friendica\Module\Register::OPEN,
-		'register_text' => '',
-		'max_import_size' => 999,
+			'admin_email' =>
+			// and here
+				'admin@test.it',
+			'sitename' => 'Friendica Social Network',
+			'register_policy' =>
+			// and here too
+				\Friendica\Module\Register::OPEN,
+			'register_text' => '',
+			'max_import_size' => 999,
 		],
 	'system'
-	=>
-		[
+			   =>
+		[ 'allowed_themes' => 'quattro,vier,duepuntozero',
 		'default_timezone' => 'UTC',
 		'language' => 'en',
 		'no_regfullname' => true,
 		'theme' => 'frio',
-		'numeric' => 2.5,
-		'allowed_themes' => 'quattro,vier,duepuntozero',
+		'numeric' => 2.5
 		],
 	'testcat' => [
 		'testarr' => ['1','2','3'],

--- a/tests/datasets/config/local.config.php
+++ b/tests/datasets/config/local.config.php
@@ -6,49 +6,49 @@
  */
 
 return [
-    'database' =>
-    /** Test it
-     * with comment
-     **/
-        [
-            'hostname' => 'testhost',
-            'username' => 'testuser',
-            'password' => 'testpw',
-            'database' => 'testdb',
-            'charset' => 'utf8mb4',
-        ],
-    // another try
-    /**
-     * What about this
-     */
-    'config' =>
-    // but with comment here
-        [
-            'admin_email' =>
-            // and here
-                'admin@test.it',
-            'sitename' => 'Friendica Social Network',
-            'register_policy' =>
-            // and here too
-                \Friendica\Module\Register::OPEN,
-            'register_text' => '',
-			'max_import_size' => 999,
-        ],
-    'system'
-    =>
-        [
-            'default_timezone' => 'UTC',
-            'language' => 'en',
-			'no_regfullname' => true,
-            'theme' => 'frio',
-			'numeric' => 2.5,
-			'allowed_themes' => 'quattro,vier,duepuntozero',
-        ],
-    'testcat' => [
-        'testarr' => ['1','2','3'],
-    ],
-    // closing it
-    \Friendica\App::class => [
-        \Friendica\App\Mode::class => true
-    ]
+	'database' =>
+	/** Test it
+	 * with comment
+	 **/
+		[
+			'hostname' => 'testhost',
+			'username' => 'testuser',
+			'password' => 'testpw',
+			'database' => 'testdb',
+			'charset' => 'utf8mb4',
+		],
+	// another try
+	/**
+	 * What about this
+	 */
+	'config' =>
+	// but with comment here
+		[
+		'admin_email' =>
+		// and here
+			'admin@test.it',
+		'sitename' => 'Friendica Social Network',
+		'register_policy' =>
+		// and here too
+			\Friendica\Module\Register::OPEN,
+		'register_text' => '',
+		'max_import_size' => 999,
+		],
+	'system'
+	=>
+		[
+		'default_timezone' => 'UTC',
+		'language' => 'en',
+		'no_regfullname' => true,
+		'theme' => 'frio',
+		'numeric' => 2.5,
+		'allowed_themes' => 'quattro,vier,duepuntozero',
+		],
+	'testcat' => [
+		'testarr' => ['1','2','3'],
+	],
+	// closing it
+	\Friendica\App::class => [
+		\Friendica\App\Mode::class => true
+	]
 ];

--- a/tests/datasets/config/local.config.php
+++ b/tests/datasets/config/local.config.php
@@ -32,13 +32,17 @@ return [
             // and here too
                 \Friendica\Module\Register::OPEN,
             'register_text' => '',
+			'max_import_size' => 999,
         ],
     'system'
     =>
         [
             'default_timezone' => 'UTC',
             'language' => 'en',
-            'theme' => 'frio'
+			'no_regfullname' => true,
+            'theme' => 'frio',
+			'numeric' => 2.5,
+			'allowed_themes' => 'quattro,vier,duepuntozero',
         ],
     'testcat' => [
         'testarr' => ['1','2','3'],

--- a/tests/datasets/config/local.ini.php
+++ b/tests/datasets/config/local.ini.php
@@ -13,7 +13,12 @@ database = testdb
 
 [system]
 theme = frio
+no_regfullname = true
+numeric = 2.5
+allowed_themes = quattro,vier,duepuntozero
 
 [config]
 admin_email = admin@test.it
+register_policy = 2
+max_import_size = 999
 INI;

--- a/tests/src/Util/Config/ConfigFileSaverTest.php
+++ b/tests/src/Util/Config/ConfigFileSaverTest.php
@@ -66,6 +66,7 @@ class ConfigFileSaverTest extends MockedTest
 	 * @dataProvider dataConfigFiles
 	 *
 	 * @todo 20190324 [nupplaphil] for ini-configs, it isn't possible to use $ or ! inside values
+	 * @todo 20190402 [nupplaphil] array, bool, numeric value checks
 	 */
 	public function testSaveToConfig($fileName, $filePath, $relativePath)
 	{
@@ -111,15 +112,18 @@ class ConfigFileSaverTest extends MockedTest
 		// save it
 		$this->assertTrue($configFileSaver->saveToConfigFile());
 
-		print_r(file_get_contents($this->root->getChild($relativeFullName)->url()));
-
 		$newConfigCache = new ConfigCache();
 		$configFileLoader->setupCache($newConfigCache);
 
+		// update values (system and config value)
 		$this->assertEquals('new@mail.it', $newConfigCache->get('config', 'admin_email'));
-		$this->assertEquals('Testingwith@all.we can', $newConfigCache->get('config', 'test_val'));
 		$this->assertEquals('vier', $newConfigCache->get('system', 'theme'));
+
+		// insert/overwritten values (system and config value)
+		$this->assertEquals('Testingwith@all.we can', $newConfigCache->get('config', 'test_val'));
 		$this->assertEquals('TestIt Now', $newConfigCache->get('system', 'test_val2'));
+
+		// new categories
 		$this->assertEquals('TestIt Again', $newConfigCache->get('newCat', 'test_val3'));
 		$this->assertEquals('TestIt Fourth', $newConfigCache->get('newCat', 'test_val4'));
 
@@ -140,10 +144,8 @@ class ConfigFileSaverTest extends MockedTest
 
 		if (empty($relativePath)) {
 			$root = $this->root;
-			$relativeFullName = $fileName;
 		} else {
 			$root = $this->root->getChild($relativePath);
-			$relativeFullName = $relativePath . DIRECTORY_SEPARATOR . $fileName;
 		}
 
 		$root->chmod(000);

--- a/tests/src/Util/Config/ConfigFileSaverTest.php
+++ b/tests/src/Util/Config/ConfigFileSaverTest.php
@@ -104,8 +104,14 @@ class ConfigFileSaverTest extends MockedTest
 		// overwrite value
 		$configFileSaver->addConfigValue('system', 'test_val2', 'TestIt Now');
 
+		// new category
+        $configFileSaver->addConfigValue('newCat', 'test_val3', 'TestIt Again');
+        $configFileSaver->addConfigValue('newCat', 'test_val4', 'TestIt Fourth');
+
 		// save it
 		$this->assertTrue($configFileSaver->saveToConfigFile());
+
+		print_r(file_get_contents($this->root->getChild($relativeFullName)->url()));
 
 		$newConfigCache = new ConfigCache();
 		$configFileLoader->setupCache($newConfigCache);
@@ -114,6 +120,8 @@ class ConfigFileSaverTest extends MockedTest
 		$this->assertEquals('Testingwith@all.we can', $newConfigCache->get('config', 'test_val'));
 		$this->assertEquals('vier', $newConfigCache->get('system', 'theme'));
 		$this->assertEquals('TestIt Now', $newConfigCache->get('system', 'test_val2'));
+		$this->assertEquals('TestIt Again', $newConfigCache->get('newCat', 'test_val3'));
+		$this->assertEquals('TestIt Fourth', $newConfigCache->get('newCat', 'test_val4'));
 
 		$this->assertTrue($this->root->hasChild($relativeFullName));
 		$this->assertTrue($this->root->hasChild($relativeFullName . '.old'));

--- a/tests/src/Util/Config/ConfigFileSaverTest.php
+++ b/tests/src/Util/Config/ConfigFileSaverTest.php
@@ -126,8 +126,6 @@ class ConfigFileSaverTest extends MockedTest
 		// save it
 		$this->assertTrue($configFileSaver->saveToConfigFile());
 
-		print_r(file_get_contents($this->root->getChild($relativeFullName)->url()));
-
 		$newConfigCache = new ConfigCache();
 		$configFileLoader->setupCache($newConfigCache);
 

--- a/tests/src/Util/Config/ConfigFileSaverTest.php
+++ b/tests/src/Util/Config/ConfigFileSaverTest.php
@@ -227,10 +227,8 @@ class ConfigFileSaverTest extends MockedTest
 
 		if (empty($relativePath)) {
 			$root = $this->root;
-			$relativeFullName = $fileName;
 		} else {
 			$root = $this->root->getChild($relativePath);
-			$relativeFullName = $relativePath . DIRECTORY_SEPARATOR . $fileName;
 		}
 
 		vfsStream::newFile($fileName)

--- a/tests/src/Util/Config/ConfigFileSaverTest.php
+++ b/tests/src/Util/Config/ConfigFileSaverTest.php
@@ -66,7 +66,6 @@ class ConfigFileSaverTest extends MockedTest
 	 * @dataProvider dataConfigFiles
 	 *
 	 * @todo 20190324 [nupplaphil] for ini-configs, it isn't possible to use $ or ! inside values
-	 * @todo 20190402 [nupplaphil] array, bool, numeric value checks
 	 */
 	public function testSaveToConfig($fileName, $filePath, $relativePath)
 	{
@@ -91,6 +90,10 @@ class ConfigFileSaverTest extends MockedTest
 
 		$this->assertEquals('admin@test.it', $configCache->get('config', 'admin_email'));
 		$this->assertEquals('frio', $configCache->get('system', 'theme'));
+		$this->assertEquals(true, $configCache->get('system', 'no_regfullname'));
+		$this->assertEquals(\Friendica\Module\Register::OPEN, $configCache->get('config', 'register_policy'));
+		$this->assertEquals(2.5, $configCache->get('system', 'numeric'));
+		$this->assertEquals('quattro,vier,duepuntozero', $configCache->get('system', 'allowed_themes'));
 		$this->assertNull($configCache->get('config', 'test_val'));
 		$this->assertNull($configCache->get('system', 'test_val2'));
 
@@ -109,8 +112,16 @@ class ConfigFileSaverTest extends MockedTest
         $configFileSaver->addConfigValue('newCat', 'test_val3', 'TestIt Again');
         $configFileSaver->addConfigValue('newCat', 'test_val4', 'TestIt Fourth');
 
+        // replace types
+		$configFileSaver->addConfigValue('config', 'register_policy', \Friendica\Module\Register::APPROVE);
+		$configFileSaver->addConfigValue('system', 'no_regfullname', false);
+		$configFileSaver->addConfigValue('system', 'numeric', 6.78);
+		$configFileSaver->addConfigValue('system', 'allowed_themes', ['quattro','frio']);
+
 		// save it
 		$this->assertTrue($configFileSaver->saveToConfigFile());
+
+		print_r(file_get_contents($this->root->getChild($relativeFullName)->url()));
 
 		$newConfigCache = new ConfigCache();
 		$configFileLoader->setupCache($newConfigCache);
@@ -126,6 +137,12 @@ class ConfigFileSaverTest extends MockedTest
 		// new categories
 		$this->assertEquals('TestIt Again', $newConfigCache->get('newCat', 'test_val3'));
 		$this->assertEquals('TestIt Fourth', $newConfigCache->get('newCat', 'test_val4'));
+
+		// check types
+		$this->assertEquals(\Friendica\Module\Register::APPROVE, $newConfigCache->get('config', 'register_policy'));
+		$this->assertEquals(false, $newConfigCache->get('system', 'no_regfullname'));
+		$this->assertEquals(6.78, $newConfigCache->get('system', 'numeric'));
+		$this->assertEquals('quattro,frio', $newConfigCache->get('system', 'allowed_themes'));
 
 		$this->assertTrue($this->root->hasChild($relativeFullName));
 		$this->assertTrue($this->root->hasChild($relativeFullName . '.old'));


### PR DESCRIPTION
Fixes #6941 
FollowUp #6920 

This was a lot of work, because there are uggly possibilities for the config files.

For all three types of config files:
- Adding multi-type support (numeric, array, bool, string, constant)
- Adding multi-line support (`PHP_EOL` between key, arrow, values, categories, ...)
- Adding missing comma fixing (for category and values)
- Adding auto-creation of missing categories

I added some really uggly datasets for testing and replaced/added values. So I think, this should work now.

I also reduced the interaction with the filesystem to a minimum.
- Read the whole config file into an array
- Replace/add lines
- Write the whole array back into a new temporary file