### PR TITLE
Changed keyup to oninput

### DIFF
--- a/view/theme/frio/templates/theme_settings.tpl
+++ b/view/theme/frio/templates/theme_settings.tpl
@@ -98,7 +98,7 @@
 		GenerateShareString();
 
 		// Take advantage of the effects of previous comment
-		$(document).on("keyup", "#id_frio_share_string", function() {
+		$(document).on("input", "#id_frio_share_string", function() {
 			theme = JSON.parse($("#id_frio_share_string").val());
 
 			if ($("#id_frio_nav_bg").length) {


### PR DESCRIPTION
Rework of #6830 because of too many merge conflicts (this was easier :p )

Because chromium mobile does not trigger a keyup event when pasting a string I changed the event to onchange because this does trigger the update making it possible to paste and save immediately. Workaround was pasting and adding/removing a space.