### PR TITLE
ConfigFileSave Hardening

### DIFF
--- a/src/Core/Config/Cache/ConfigCache.php
+++ b/src/Core/Config/Cache/ConfigCache.php
@@ -216,4 +216,14 @@ class ConfigCache implements IConfigCache, IPConfigCache
 
 		return $return;
 	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function combine(array $config, $overwrite = false)
+	{
+		$newConfigCache = new ConfigCache($this->config);
+		$newConfigCache->load($config, $overwrite);
+		return $newConfigCache;
+	}
 }

--- a/src/Core/Config/Cache/IConfigCache.php
+++ b/src/Core/Config/Cache/IConfigCache.php
@@ -53,4 +53,14 @@ interface IConfigCache
 	 * @return array
 	 */
 	function getAll();
+
+	/**
+	 * Combine the current config cache with a given config array and return the result
+	 *
+	 * @param array $config
+	 * @param bool  $overwrite   If true, the given config cache overrules this config cache
+	 *
+	 * @return IConfigCache
+	 */
+	function combine(array $config, $overwrite = false);
 }

--- a/src/Util/Config/ConfigFileLoader.php
+++ b/src/Util/Config/ConfigFileLoader.php
@@ -35,8 +35,6 @@ class ConfigFileLoader extends ConfigFileManager
 	 *
 	 * @param IConfigCache $config The config cache to load to
 	 * @param bool         $raw    Setup the raw config format
-	 *
-	 * @throws \Exception
 	 */
 	public function setupCache(IConfigCache $config, $raw = false)
 	{
@@ -61,8 +59,6 @@ class ConfigFileLoader extends ConfigFileManager
 	 * @param string $name The name of the configuration (default is empty, which means 'local')
 	 *
 	 * @return array The config array (empty if no config found)
-	 *
-	 * @throws \Exception if the configuration file isn't readable
 	 */
 	public function loadCoreConfig($name = '')
 	{
@@ -81,8 +77,6 @@ class ConfigFileLoader extends ConfigFileManager
 	 * @param string $name The name of the configuration
 	 *
 	 * @return array The config array (empty if no config found)
-	 *
-	 * @throws \Exception if the configuration file isn't readable
 	 */
 	public function loadAddonConfig($name)
 	{
@@ -97,124 +91,5 @@ class ConfigFileLoader extends ConfigFileManager
 		} else {
 			return [];
 		}
-	}
-
-	/**
-	 * Tries to load the legacy config files (.htconfig.php, .htpreconfig.php) and returns the config array.
-	 *
-	 * @param string $name The name of the config file (default is empty, which means .htconfig.php)
-	 *
-	 * @return array The configuration array (empty if no config found)
-	 *
-	 * @deprecated since version 2018.09
-	 */
-	private function loadLegacyConfig($name = '')
-	{
-		$config = [];
-		if (!empty($this->getHtConfigFullName($name))) {
-			$a = new \stdClass();
-			$a->config = [];
-			include $this->getHtConfigFullName($name);
-
-			$htConfigCategories = array_keys($a->config);
-
-			// map the legacy configuration structure to the current structure
-			foreach ($htConfigCategories as $htConfigCategory) {
-				if (is_array($a->config[$htConfigCategory])) {
-					$keys = array_keys($a->config[$htConfigCategory]);
-
-					foreach ($keys as $key) {
-						$config[$htConfigCategory][$key] = $a->config[$htConfigCategory][$key];
-					}
-				} else {
-					$config['config'][$htConfigCategory] = $a->config[$htConfigCategory];
-				}
-			}
-
-			unset($a);
-
-			if (isset($db_host)) {
-				$config['database']['hostname'] = $db_host;
-				unset($db_host);
-			}
-			if (isset($db_user)) {
-				$config['database']['username'] = $db_user;
-				unset($db_user);
-			}
-			if (isset($db_pass)) {
-				$config['database']['password'] = $db_pass;
-				unset($db_pass);
-			}
-			if (isset($db_data)) {
-				$config['database']['database'] = $db_data;
-				unset($db_data);
-			}
-			if (isset($config['system']['db_charset'])) {
-				$config['database']['charset'] = $config['system']['db_charset'];
-			}
-			if (isset($pidfile)) {
-				$config['system']['pidfile'] = $pidfile;
-				unset($pidfile);
-			}
-			if (isset($default_timezone)) {
-				$config['system']['default_timezone'] = $default_timezone;
-				unset($default_timezone);
-			}
-			if (isset($lang)) {
-				$config['system']['language'] = $lang;
-				unset($lang);
-			}
-		}
-
-		return $config;
-	}
-
-	/**
-	 * Tries to load the specified legacy configuration file and returns the config array.
-	 *
-	 * @deprecated since version 2018.12
-	 * @param string $filepath
-	 *
-	 * @return array The configuration array
-	 * @throws \Exception
-	 */
-	private function loadINIConfigFile($filepath)
-	{
-		$contents = include($filepath);
-
-		$config = parse_ini_string($contents, true, INI_SCANNER_TYPED);
-
-		if ($config === false) {
-			throw new \Exception('Error parsing INI config file ' . $filepath);
-		}
-
-		return $config;
-	}
-
-	/**
-	 * Tries to load the specified configuration file and returns the config array.
-	 *
-	 * The config format is PHP array and the template for configuration files is the following:
-	 *
-	 * <?php return [
-	 *      'section' => [
-	 *          'key' => 'value',
-	 *      ],
-	 * ];
-	 *
-	 * @param  string $filepath The filepath of the
-	 * @return array The config array0
-	 *
-	 * @throws \Exception if the config cannot get loaded.
-	 */
-	private function loadConfigFile($filepath)
-	{
-		$config = include($filepath);
-
-		if (!is_array($config)) {
-			throw new \Exception('Error loading config file ' . $filepath);
-		}
-
-		return $config;
 	}
 }

--- a/src/Util/Config/ConfigFileManager.php
+++ b/src/Util/Config/ConfigFileManager.php
@@ -87,4 +87,121 @@ abstract class ConfigFileManager
 		$fullName = $this->baseDir  . DIRECTORY_SEPARATOR . '.' . $name . '.php';
 		return file_exists($fullName) ? $fullName : '';
 	}
+
+
+	/**
+	 * Tries to load the legacy config files (.htconfig.php, .htpreconfig.php) and returns the config array.
+	 *
+	 * @param string $name The name of the config file (default is empty, which means .htconfig.php)
+	 *
+	 * @return array The configuration array (empty if no config found)
+	 *
+	 * @deprecated since version 2018.09
+	 */
+	protected function loadLegacyConfig($name = '')
+	{
+		$config = [];
+		if (!empty($this->getHtConfigFullName($name))) {
+			$a = new \stdClass();
+			$a->config = [];
+			include $this->getHtConfigFullName($name);
+
+			$htConfigCategories = array_keys($a->config);
+
+			// map the legacy configuration structure to the current structure
+			foreach ($htConfigCategories as $htConfigCategory) {
+				if (is_array($a->config[$htConfigCategory])) {
+					$keys = array_keys($a->config[$htConfigCategory]);
+
+					foreach ($keys as $key) {
+						$config[$htConfigCategory][$key] = $a->config[$htConfigCategory][$key];
+					}
+				} else {
+					$config['config'][$htConfigCategory] = $a->config[$htConfigCategory];
+				}
+			}
+
+			unset($a);
+
+			if (isset($db_host)) {
+				$config['database']['hostname'] = $db_host;
+				unset($db_host);
+			}
+			if (isset($db_user)) {
+				$config['database']['username'] = $db_user;
+				unset($db_user);
+			}
+			if (isset($db_pass)) {
+				$config['database']['password'] = $db_pass;
+				unset($db_pass);
+			}
+			if (isset($db_data)) {
+				$config['database']['database'] = $db_data;
+				unset($db_data);
+			}
+			if (isset($config['system']['db_charset'])) {
+				$config['database']['charset'] = $config['system']['db_charset'];
+			}
+			if (isset($pidfile)) {
+				$config['system']['pidfile'] = $pidfile;
+				unset($pidfile);
+			}
+			if (isset($default_timezone)) {
+				$config['system']['default_timezone'] = $default_timezone;
+				unset($default_timezone);
+			}
+			if (isset($lang)) {
+				$config['system']['language'] = $lang;
+				unset($lang);
+			}
+		}
+
+		return $config;
+	}
+
+	/**
+	 * Tries to load the specified legacy configuration file and returns the config array.
+	 *
+	 * @deprecated since version 2018.12
+	 * @param string $filepath
+	 *
+	 * @return array The configuration array
+	 */
+	protected function loadINIConfigFile($filepath)
+	{
+		$contents = include($filepath);
+
+		$config = parse_ini_string($contents, true, INI_SCANNER_TYPED);
+
+		if (!is_array($config)) {
+			return [];
+		}
+
+		return $config;
+	}
+
+	/**
+	 * Tries to load the specified configuration file and returns the config array.
+	 *
+	 * The config format is PHP array and the template for configuration files is the following:
+	 *
+	 * <?php return [
+	 *      'section' => [
+	 *          'key' => 'value',
+	 *      ],
+	 * ];
+	 *
+	 * @param  string $filepath The filepath of the
+	 * @return array The config array0
+	 */
+	protected function loadConfigFile($filepath)
+	{
+		$config = include($filepath);
+
+		if (!is_array($config)) {
+			return [];
+		}
+
+		return $config;
+	}
 }

--- a/src/Util/Config/ConfigFileSaver.php
+++ b/src/Util/Config/ConfigFileSaver.php
@@ -49,9 +49,8 @@ class ConfigFileSaver extends ConfigFileManager
 
 		$configPath = $this->getConfigFullName($name);
 		if (!empty($configPath) && is_file($configPath)) {
-			$configFile  = file($configPath);
 			$configCache = $this->loadConfigFile($configPath);
-			$writeFile   = $this->saveConfigFile($configCache, $configFile);
+			$writeFile   = $this->saveConfigFile($configCache);
 			if ($this->saveToFile($configPath, $writeFile)) {
 				$saved = true;
 			}
@@ -60,9 +59,8 @@ class ConfigFileSaver extends ConfigFileManager
 		// Check for the *.ini.php file inside the /config/ path
 		$configPath = $this->getIniFullName($name);
 		if (!empty($configPath) && is_file($configPath)) {
-			$configFile  = file($configPath);
 			$configCache = $this->loadINIConfigFile($configPath);
-			$writeFile   = $this->saveINIConfigFile($configCache, $configFile);
+			$writeFile   = $this->saveINIConfigFile($configCache);
 			if ($this->saveToFile($configPath, $writeFile)) {
 				$saved = true;
 			}
@@ -71,9 +69,8 @@ class ConfigFileSaver extends ConfigFileManager
 		// Check for the *.php file (normally .htconfig.php) inside the / path
 		$configPath = $this->getHtConfigFullName($name);
 		if (!empty($configPath) && is_file($configPath)) {
-			$configFile  = file($configPath);
 			$configCache = $this->loadLegacyConfig($name);
-			$writeFile   = $this->saveLegacyConfig($configCache, $configFile);
+			$writeFile   = $this->saveLegacyConfig($configCache);
 			if ($this->saveToFile($configPath, $writeFile)) {
 				$saved = true;
 			}
@@ -121,14 +118,12 @@ class ConfigFileSaver extends ConfigFileManager
 
 	/**
 	 * Combines the config of the file with the config of the new settings
-	 * Respects comments too
 	 *
 	 * @param array  $configCache
-	 * @param string $configFile
 	 *
 	 * @return array
 	 */
-	private function saveConfigFile(array $configCache, $configFile)
+	private function saveConfigFile(array $configCache)
 	{
 		$newConfigCache = $this->configCache->combine($configCache);
 		$config = $newConfigCache->getAll();
@@ -155,14 +150,12 @@ class ConfigFileSaver extends ConfigFileManager
 
 	/**
 	 * Combines the config of the file with the config of the new settings
-	 * Respects comments too
 	 *
 	 * @param array  $configCache
-	 * @param string $configFile
 	 *
 	 * @return array
 	 */
-	private function saveINIConfigFile(array $configCache, $configFile)
+	private function saveINIConfigFile(array $configCache)
 	{
 		$newConfigCache = $this->configCache->combine($configCache);
 		$config = $newConfigCache->getAll();
@@ -191,14 +184,12 @@ class ConfigFileSaver extends ConfigFileManager
 
 	/**
 	 * Combines the config of the file with the config of the new settings
-	 * Respects comments too
 	 *
 	 * @param array  $configCache
-	 * @param string $configFile
 	 *
 	 * @return array
 	 */
-	private function saveLegacyConfig(array $configCache, $configFile)
+	private function saveLegacyConfig(array $configCache)
 	{
 		$newConfigCache = $this->configCache->combine($configCache);
 		$config = $newConfigCache->getAll();

--- a/tests/datasets/config/.htconfig.php
+++ b/tests/datasets/config/.htconfig.php
@@ -13,7 +13,12 @@ $pidfile = '/var/run/friendica.pid';
 // Set the database connection charset to UTF8.
 // Changing this value will likely corrupt the special characters.
 // You have been warned.
-$a->config['system']['db_charset'] = "anotherCharset";
+$a->config
+['system']
+['db_charset']
+	=
+	"anotherCharset";
+
 
 // Choose a legal default timezone. If you are unsure, use "America/Los_Angeles".
 // It can be changed later and only applies to timestamps for anonymous viewers.
@@ -31,7 +36,7 @@ $a->config['sitename'] = "Friendica My Network";
 // and/or approve/deny the request.
 // In order to perform system administration via the admin panel, admin_email
 // must precisely match the email address of the person logged in.
-$a->config['register_policy'] = REGISTER_OPEN;
+$a->config['register_policy'] = \Friendica\Module\Register::OPEN;
 $a->config['register_text'] = 'A register text';
 $a->config['admin_email'] = 'admin@test.it';
 $a->config['admin_nickname'] = 'Friendly admin';
@@ -55,9 +60,16 @@ $a->config['system']['allowed_themes'] = 'quattro,vier,duepuntozero';
 $a->config['system']['theme'] = 'frio';
 
 // By default allow pseudonyms
-$a->config['system']['no_regfullname'] = true;
+ $a->config['system']['no_regfullname'] = true;
 
 //Deny public access to the local directory
 //$a->config['system']['block_local_dir'] = false;
 // Location of the global directory
 $a->config['system']['directory'] = 'http://another.url';
+
+$a->config
+['system']
+['numeric']
+// geht hier ein kommentar??
+	=
+	2.5;

--- a/tests/datasets/config/local.config.php
+++ b/tests/datasets/config/local.config.php
@@ -1,28 +1,51 @@
 <?php
-
 /**
  * A test file for local configuration
  *
  */
-
 return [
-	'database' => [
-		'hostname' => 'testhost',
-		'username' => 'testuser',
-		'password' => 'testpw',
-		'database' => 'testdb',
-		'charset' => 'utf8mb4',
+	'database' =>
+	/** Test it
+	 * with comment
+	 **/
+		[
+			'hostname' => 'testhost',
+			'username' => 'testuser',
+			'password' => 'testpw',
+			'database' => 'testdb',
+			'charset' => 'utf8mb4',
+		],
+	// another try
+	/**
+	 * What about this
+	 */
+	'config' =>
+	// but with comment here
+		[
+			'admin_email' =>
+			// and here
+				'admin@test.it',
+			'sitename' => 'Friendica Social Network',
+			'register_policy' =>
+			// and here too
+				\Friendica\Module\Register::OPEN,
+			'register_text' => '',
+			'max_import_size' => 999,
+		],
+	'system'
+			   =>
+		[ 'allowed_themes' => 'quattro,vier,duepuntozero',
+		  'default_timezone' => 'UTC',
+		  'language' => 'en',
+		  'no_regfullname' => true,
+		  'theme' => 'frio',
+		  'numeric' => 2.5
+		],
+	'testcat' => [
+		'testarr' => ['1','2','3'],
 	],
-
-	'config' => [
-		'admin_email' => 'admin@test.it',
-		'sitename' => 'Friendica Social Network',
-		'register_policy' => \Friendica\Module\Register::OPEN,
-		'register_text' => '',
-	],
-	'system' => [
-		'default_timezone' => 'UTC',
-		'language' => 'en',
-		'theme' => 'frio',
-	],
+	// closing it
+	\Friendica\App::class => [
+		\Friendica\App\Mode::class => true
+	]
 ];

--- a/tests/datasets/config/local.config.php
+++ b/tests/datasets/config/local.config.php
@@ -48,4 +48,7 @@ return [
 	\Friendica\App::class => [
 		\Friendica\App\Mode::class => true
 	]
+	/*
+	 * Comment at the end of the category
+	 */
 ];

--- a/tests/datasets/config/local.ini.php
+++ b/tests/datasets/config/local.ini.php
@@ -13,7 +13,12 @@ database = testdb
 
 [system]
 theme = frio
+no_regfullname = true
+numeric = 2.5
+allowed_themes = quattro,vier,duepuntozero
 
 [config]
 admin_email = admin@test.it
+register_policy = 2
+max_import_size = 999
 INI;

--- a/tests/src/Core/Config/Cache/ConfigCacheTest.php
+++ b/tests/src/Core/Config/Cache/ConfigCacheTest.php
@@ -275,4 +275,60 @@ class ConfigCacheTest extends MockedTest
 
 		$this->assertEmpty($configCache->keyDiff($diffConfig));
 	}
+
+	/**
+	 * Test the combine() method with new config overwriting
+	 * @dataProvider dataTests
+	 */
+	public function testCombineOverwrite($data)
+	{
+		$configCache = new ConfigCache($data);
+
+		$newConfig = [
+			'system' => [
+				'test' => 'new',
+			]
+		];
+
+		$newConfigCache = $configCache->combine($newConfig, true);
+
+		$this->assertEquals('it', $configCache->get('system', 'test'));
+		$this->assertEquals('new', $newConfigCache->get('system', 'test'));
+	}
+
+	/**
+	 * Test the combine() method without new config overwriting
+	 * @dataProvider dataTests
+	 */
+	public function testCombineWithoutOverwrite($data)
+	{
+		$configCache = new ConfigCache($data);
+
+		$newConfig = [
+			'system' => [
+				'test' => 'new',
+			]
+		];
+
+		$newConfigCache = $configCache->combine($newConfig, false);
+
+		$this->assertEquals('it', $configCache->get('system', 'test'));
+		$this->assertEquals('it', $newConfigCache->get('system', 'test'));
+	}
+
+	/**
+	 * Test the combine() method without altering data
+	 * @dataProvider dataTests
+	 */
+	public function testCombineWithoutAlterData($data)
+	{
+		$configCache = new ConfigCache($data);
+
+		$newConfigCache = $configCache->combine([]);
+
+		$this->assertEquals($configCache->getAll(), $newConfigCache->getAll());
+
+		// the returned configCache is not the same as the input
+		$this->assertNotSame($configCache, $newConfigCache);
+	}
 }

--- a/tests/src/Util/Config/ConfigFileLoaderTest.php
+++ b/tests/src/Util/Config/ConfigFileLoaderTest.php
@@ -44,8 +44,6 @@ class ConfigFileLoaderTest extends MockedTest
 
 	/**
 	 * Test the loadConfigFiles() method with a wrong local.config.php
-	 * @expectedException \Exception
-	 * @expectedExceptionMessageRegExp /Error loading config file \w+/
 	 */
 	public function testLoadConfigWrong()
 	{
@@ -59,6 +57,12 @@ class ConfigFileLoaderTest extends MockedTest
 		$configCache = new ConfigCache();
 
 		$configFileLoader->setupCache($configCache);
+
+		$this->assertEmpty($configCache->get('database', 'hostname'));
+		$this->assertEmpty($configCache->get('database', 'username'));
+		$this->assertEmpty($configCache->get('database', 'password'));
+		$this->assertEmpty($configCache->get('database', 'database'));
+		$this->assertEmpty($configCache->get('config', 'admin_email'));
 	}
 
 	/**

--- a/tests/src/Util/Config/ConfigFileSaverTest.php
+++ b/tests/src/Util/Config/ConfigFileSaverTest.php
@@ -64,8 +64,6 @@ class ConfigFileSaverTest extends MockedTest
 	/**
 	 * Test the saveToConfigFile() method
 	 * @dataProvider dataConfigFiles
-	 *
-	 * @todo 20190324 [nupplaphil] for ini-configs, it isn't possible to use $ or ! inside values
 	 */
 	public function testSaveToConfig($fileName, $filePath, $relativePath)
 	{
@@ -83,26 +81,51 @@ class ConfigFileSaverTest extends MockedTest
 			->at($root)
 			->setContent(file_get_contents($filePath . DIRECTORY_SEPARATOR . $fileName));
 
-		$configFileSaver = new ConfigFileSaver($this->root->url());
+		// The parse_ini_string() method doesn't support every escaped character by definition
+		if (stristr($fileName, '.ini.')) {
+			$escapeString = 'Testingwith@all.we can';
+		} else {
+			$escapeString = 'Testingwith@all\'.we can?!, \$';
+		}
+
+
 		$configFileLoader = new ConfigFileLoader($this->root->url(), $this->mode);
 		$configCache = new ConfigCache();
 		$configFileLoader->setupCache($configCache);
 
 		$this->assertEquals('admin@test.it', $configCache->get('config', 'admin_email'));
 		$this->assertEquals('frio', $configCache->get('system', 'theme'));
+		$this->assertEquals(true, $configCache->get('system', 'no_regfullname'));
+		$this->assertEquals(\Friendica\Module\Register::OPEN, $configCache->get('config', 'register_policy'));
+		$this->assertEquals(2.5, $configCache->get('system', 'numeric'));
+		$this->assertEquals('quattro,vier,duepuntozero', $configCache->get('system', 'allowed_themes'));
 		$this->assertNull($configCache->get('config', 'test_val'));
 		$this->assertNull($configCache->get('system', 'test_val2'));
 
+		$newConfigCache = new ConfigCache();
+
 		// update values (system and config value)
-		$configFileSaver->addConfigValue('config', 'admin_email', 'new@mail.it');
-		$configFileSaver->addConfigValue('system', 'theme', 'vier');
+		$newConfigCache->set('config', 'admin_email', 'new@mail.it');
+		$newConfigCache->set('system', 'theme', 'vier');
 
 		// insert values (system and config value)
-		$configFileSaver->addConfigValue('config', 'test_val', 'Testingwith@all.we can');
-		$configFileSaver->addConfigValue('system', 'test_val2', 'TestIt First');
+		$newConfigCache->set('config', 'test_val', $escapeString);
+		$newConfigCache->set('system', 'test_val2', 'TestIt First');
 
 		// overwrite value
-		$configFileSaver->addConfigValue('system', 'test_val2', 'TestIt Now');
+		$newConfigCache->set('system', 'test_val2', 'TestIt Now');
+
+		// new category
+		$newConfigCache->set('newCat', 'test_val3', 'TestIt Again');
+		$newConfigCache->set('newCat', 'test_val4', 'TestIt Fourth');
+
+		// replace types
+		$newConfigCache->set('config', 'register_policy', \Friendica\Module\Register::APPROVE);
+		$newConfigCache->set('system', 'no_regfullname', false);
+		$newConfigCache->set('system', 'numeric', 6.78);
+		$newConfigCache->set('system', 'allowed_themes', "quattro,$escapeString");
+
+		$configFileSaver = new ConfigFileSaver($this->root->url(), $newConfigCache);
 
 		// save it
 		$this->assertTrue($configFileSaver->saveToConfigFile());
@@ -110,10 +133,23 @@ class ConfigFileSaverTest extends MockedTest
 		$newConfigCache = new ConfigCache();
 		$configFileLoader->setupCache($newConfigCache);
 
+		// update values (system and config value)
 		$this->assertEquals('new@mail.it', $newConfigCache->get('config', 'admin_email'));
-		$this->assertEquals('Testingwith@all.we can', $newConfigCache->get('config', 'test_val'));
 		$this->assertEquals('vier', $newConfigCache->get('system', 'theme'));
+
+		// insert/overwritten values (system and config value)
+		$this->assertEquals($escapeString, $newConfigCache->get('config', 'test_val'));
 		$this->assertEquals('TestIt Now', $newConfigCache->get('system', 'test_val2'));
+
+		// new categories
+		$this->assertEquals('TestIt Again', $newConfigCache->get('newCat', 'test_val3'));
+		$this->assertEquals('TestIt Fourth', $newConfigCache->get('newCat', 'test_val4'));
+
+		// check types
+		$this->assertEquals(\Friendica\Module\Register::APPROVE, $newConfigCache->get('config', 'register_policy'));
+		$this->assertEquals(false, $newConfigCache->get('system', 'no_regfullname'));
+		$this->assertEquals(6.78, $newConfigCache->get('system', 'numeric'));
+		$this->assertEquals('quattro,' . $escapeString, $newConfigCache->get('system', 'allowed_themes'));
 
 		$this->assertTrue($this->root->hasChild($relativeFullName));
 		$this->assertTrue($this->root->hasChild($relativeFullName . '.old'));
@@ -132,10 +168,8 @@ class ConfigFileSaverTest extends MockedTest
 
 		if (empty($relativePath)) {
 			$root = $this->root;
-			$relativeFullName = $fileName;
 		} else {
 			$root = $this->root->getChild($relativePath);
-			$relativeFullName = $relativePath . DIRECTORY_SEPARATOR . $fileName;
 		}
 
 		$root->chmod(000);
@@ -144,9 +178,10 @@ class ConfigFileSaverTest extends MockedTest
 			->at($root)
 			->setContent(file_get_contents($filePath . DIRECTORY_SEPARATOR . $fileName));
 
-		$configFileSaver = new ConfigFileSaver($this->root->url());
 
-		$configFileSaver->addConfigValue('system', 'test_val2', 'TestIt Now');
+		$newConfigCache = new ConfigCache();
+		$newConfigCache->set('system', 'test_val2', 'TestIt Now');
+		$configFileSaver = new ConfigFileSaver($this->root->url(), $newConfigCache);
 
 		// wrong mod, so return false if nothing to write
 		$this->assertFalse($configFileSaver->saveToConfigFile());
@@ -172,7 +207,7 @@ class ConfigFileSaverTest extends MockedTest
 			->at($root)
 			->setContent(file_get_contents($filePath . DIRECTORY_SEPARATOR . $fileName));
 
-		$configFileSaver = new ConfigFileSaver($this->root->url());
+		$configFileSaver = new ConfigFileSaver($this->root->url(), new ConfigCache());
 		$configFileLoader = new ConfigFileLoader($this->root->url(), $this->mode);
 		$configCache = new ConfigCache();
 		$configFileLoader->setupCache($configCache);
@@ -185,5 +220,38 @@ class ConfigFileSaverTest extends MockedTest
 		$this->assertFalse($this->root->hasChild($relativeFullName . '.tmp'));
 
 		$this->assertEquals(file_get_contents($filePath . DIRECTORY_SEPARATOR . $fileName), file_get_contents($this->root->getChild($relativeFullName)->url()));
+	}
+
+
+	/**
+	 * Test the saveToConfigFile() method doesn't accidentally alter data
+	 * @dataProvider dataConfigFiles
+	 */
+	public function testNoDataAltering($fileName, $filePath, $relativePath)
+	{
+		$this->delConfigFile('local.config.php');
+		if (empty($relativePath)) {
+			$root = $this->root;
+		} else {
+			$root = $this->root->getChild($relativePath);
+		}
+
+		vfsStream::newFile($fileName)
+			->at($root)
+			->setContent(file_get_contents($filePath . DIRECTORY_SEPARATOR . $fileName));
+
+		$configFileLoader = new ConfigFileLoader($this->root->url(), $this->mode);
+		$configCache = new ConfigCache();
+		$configFileLoader->setupCache($configCache);
+
+		// add the same value
+		$newConfigCache = new ConfigCache();
+		$newConfigCache->set('config', 'admin_email', $configCache->get('config', 'admin_email'));
+		$configFileSaver = new ConfigFileSaver($this->root->url(), $newConfigCache);
+		$this->assertTrue($configFileSaver->saveToConfigFile());
+
+		$newConfigCache = new ConfigCache();
+		$configFileLoader->setupCache($newConfigCache);
+		$this->assertEquals($configCache->getAll(), $newConfigCache->getAll());
 	}
 }


### PR DESCRIPTION
Alternative to #6961 
Fixes #6941 
FollowUp #6920 

This time I'm using the whole `ConfigCache` for generating the new config file.
=> This is still draft, because I need to add a method to find comments for the *.htconfig.php and *.config.php* file format.

But the rest of the logic is now much less complex than the idea before :-)
=> And all tests would work (if I don't have to manage comments ;-) )