### PR TITLE
beautification of pleroma stats

### DIFF
--- a/mod/admin.php
+++ b/mod/admin.php
@@ -680,6 +680,8 @@ function admin_page_federation(App $a)
 				do {
 					$part = array_pop($parts);
 				} while (!empty($parts) && ((strlen($part) >= 40) || (strlen($part) <= 3)));
+				// only take the x.x.x part of the version, not the "release" after the dash
+				$part = array_shift(explode('-', $part));
 
 				if (!empty($part)) {
 					if (empty($compacted[$part])) {


### PR DESCRIPTION
The part of the version number behind the - for pleroma was removed for the display of the known nodes of that project. This collapses the splittered graph for the project to only 4 pieces of different major.minor.revision versions.

As they don't use this stripped part of the version string for marking "dev" or "rc" branches (sometimes they use `+dev` for this) I think we can strip the part and fix #5850 for now again.