### PR TITLE
vier mobile: private mail width

### DIFF
--- a/view/theme/vier/mobile.css
+++ b/view/theme/vier/mobile.css
@@ -300,4 +300,6 @@ select:focus {
 .event-start, .event-end { width: auto; }
 .event-start .dtstart, .event-end .dtend { float: none; display: block; }
 
-
+/** prv mail **/
+.mail-conv-detail { margin-left: 0px; width: 100%; }
+#prvmail-submit, #prvmail-text, #prvmail-subject { box-sizing: border-box; width: 100%; }


### PR DESCRIPTION
The mobile view of private mails had some width issues with the input fields for the mail subject and body. Additionally there was a superfluous margin in the display of the conversation inherited from the desktop display.