### PR TITLE
Add subject to DB Update email

### DIFF
--- a/src/Core/Update.php
+++ b/src/Core/Update.php
@@ -411,6 +411,7 @@ class Update
 					'uid'      => $admin['uid'],
 					'type'     => SYSTEM_EMAIL,
 					'to_email' => $admin['email'],
+					'subject'  => l10n::t('[Friendica Notify] Database update'),
 					'preamble' => $preamble,
 					'body'     => $body,
 					'language' => $lang]


### PR DESCRIPTION
The email notification about database updates was missing a subject line.