### PR TITLE
Fetch profile data from different contact tables

### DIFF
--- a/config/dbstructure.config.php
+++ b/config/dbstructure.config.php
@@ -188,7 +188,7 @@ return [
 			"network" => ["type" => "char(4)", "not null" => "1", "default" => "", "comment" => "Network protocol of the contact"],
 			"name" => ["type" => "varchar(255)", "not null" => "1", "default" => "", "comment" => "Name that this contact is known by"],
 			"nick" => ["type" => "varchar(255)", "not null" => "1", "default" => "", "comment" => "Nick- and user name of the contact"],
-			"location" => ["type" => "varchar(255)", "not null" => "1", "default" => "", "comment" => ""],
+			"location" => ["type" => "varchar(255)", "default" => "", "comment" => ""],
 			"about" => ["type" => "text", "comment" => ""],
 			"keywords" => ["type" => "text", "comment" => "public keywords (interests) of the contact"],
 			"gender" => ["type" => "varchar(32)", "not null" => "1", "default" => "", "comment" => ""],

--- a/config/dbstructure.config.php
+++ b/config/dbstructure.config.php
@@ -34,7 +34,7 @@
 use Friendica\Database\DBA;
 
 if (!defined('DB_UPDATE_VERSION')) {
-	define('DB_UPDATE_VERSION', 1309);
+	define('DB_UPDATE_VERSION', 1310);
 }
 
 return [
@@ -180,6 +180,7 @@ return [
 			"id" => ["type" => "int unsigned", "not null" => "1", "extra" => "auto_increment", "primary" => "1", "comment" => "sequential ID"],
 			"uid" => ["type" => "mediumint unsigned", "not null" => "1", "default" => "0", "relation" => ["user" => "uid"], "comment" => "Owner User id"],
 			"created" => ["type" => "datetime", "not null" => "1", "default" => DBA::NULL_DATETIME, "comment" => ""],
+			"updated" => ["type" => "datetime", "default" => DBA::NULL_DATETIME, "comment" => "Date of last contact update"],
 			"self" => ["type" => "boolean", "not null" => "1", "default" => "0", "comment" => "1 if the contact is the user him/her self"],
 			"remote_self" => ["type" => "boolean", "not null" => "1", "default" => "0", "comment" => ""],
 			"rel" => ["type" => "tinyint unsigned", "not null" => "1", "default" => "0", "comment" => "The kind of the relation between the user and the contact"],

--- a/database.sql
+++ b/database.sql
@@ -1,6 +1,6 @@
 -- ------------------------------------------
 -- Friendica 2019.06-dev (Dalmatian Bellflower)
--- DB_UPDATE_VERSION 1309
+-- DB_UPDATE_VERSION 1310
 -- ------------------------------------------
 
 
@@ -138,6 +138,7 @@ CREATE TABLE IF NOT EXISTS `contact` (
 	`id` int unsigned NOT NULL auto_increment COMMENT 'sequential ID',
 	`uid` mediumint unsigned NOT NULL DEFAULT 0 COMMENT 'Owner User id',
 	`created` datetime NOT NULL DEFAULT '0001-01-01 00:00:00' COMMENT '',
+	`updated` datetime DEFAULT '0001-01-01 00:00:00' COMMENT 'Date of last contact update',
 	`self` boolean NOT NULL DEFAULT '0' COMMENT '1 if the contact is the user him/her self',
 	`remote_self` boolean NOT NULL DEFAULT '0' COMMENT '',
 	`rel` tinyint unsigned NOT NULL DEFAULT 0 COMMENT 'The kind of the relation between the user and the contact',
@@ -145,7 +146,7 @@ CREATE TABLE IF NOT EXISTS `contact` (
 	`network` char(4) NOT NULL DEFAULT '' COMMENT 'Network protocol of the contact',
 	`name` varchar(255) NOT NULL DEFAULT '' COMMENT 'Name that this contact is known by',
 	`nick` varchar(255) NOT NULL DEFAULT '' COMMENT 'Nick- and user name of the contact',
-	`location` varchar(255) NOT NULL DEFAULT '' COMMENT '',
+	`location` varchar(255) DEFAULT '' COMMENT '',
 	`about` text COMMENT '',
 	`keywords` text COMMENT 'public keywords (interests) of the contact',
 	`gender` varchar(32) NOT NULL DEFAULT '' COMMENT '',

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -1295,13 +1295,9 @@ class Contact extends BaseObject
 				return 0;
 			}
 
-			if (!empty($default)) {
-				$contact = $default;
-			} else {
-				$contact = self::getProbeDataFromDatabase($url);
-				if (empty($contact)) {
-					return 0;
-				}
+			$contact = array_merge(self::getProbeDataFromDatabase($url), $default);
+			if (empty($contact)) {
+				return 0;
 			}
 
 			$data = array_merge($data, $contact);

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -1255,11 +1255,6 @@ class Contact extends BaseObject
 				$update_contact = true;
 			}
 
-			// Update the contact in the background if needed
-			if ($update_contact && $no_update) {
-				Worker::add(PRIORITY_LOW, "UpdateContact", $contact_id);
-			}
-
 			if (!$update_contact || $no_update) {
 				return $contact_id;
 			}

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -1393,7 +1393,9 @@ class Contact extends BaseObject
 			}
 		}
 
-		self::updateAvatar($data["photo"], $uid, $contact_id);
+		if (!empty($data['photo'])) {
+			self::updateAvatar($data['photo'], $uid, $contact_id);
+		}
 
 		$fields = ['url', 'nurl', 'addr', 'alias', 'name', 'nick', 'keywords', 'location', 'about', 'avatar-date', 'pubkey'];
 		$contact = DBA::selectFirst('contact', $fields, ['id' => $contact_id]);

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -1121,11 +1121,12 @@ class Contact extends BaseObject
 	 * Have a look at all contact tables for a given profile url.
 	 * This function works as a replacement for probing the contact.
 	 *
-	 * @param string $url Contact URL
+	 * @param string  $url Contact URL
+	 * @param integer $cid Contact ID
 	 *
 	 * @return array Contact array in the "probe" structure
 	*/
-	private static function getProbeDataFromDatabase($url)
+	private static function getProbeDataFromDatabase($url, $cid)
 	{
 		// The link could be provided as http although we stored it as https
 		$ssl_url = str_replace('http://', 'https://', $url);
@@ -1133,6 +1134,14 @@ class Contact extends BaseObject
 		$fields = ['url', 'addr', 'alias', 'notify', 'poll', 'name', 'nick',
 			'photo', 'keywords', 'location', 'about', 'network',
 			'priority', 'batch', 'request', 'confirm', 'poco'];
+
+		if (!empty($cid)) {
+			$data = DBA::selectFirst('contact', $fields, ['id' => $cid]);
+			if (DBA::isResult($data)) {
+				return $data;
+			}
+		}
+
 		$data = DBA::selectFirst('contact', $fields, ['nurl' => Strings::normaliseLink($url)]);
 
 		if (!DBA::isResult($data)) {
@@ -1273,7 +1282,7 @@ class Contact extends BaseObject
 
 		// When we don't want to update, we look if we know this contact in any way
 		if ($no_update && empty($default)) {
-			$data = self::getProbeDataFromDatabase($url);
+			$data = self::getProbeDataFromDatabase($url, $contact_id);
 			$background_update = true;
 		} else {
 			$data = [];
@@ -1295,7 +1304,7 @@ class Contact extends BaseObject
 				return 0;
 			}
 
-			$contact = array_merge(self::getProbeDataFromDatabase($url), $default);
+			$contact = array_merge(self::getProbeDataFromDatabase($url, $contact_id), $default);
 			if (empty($contact)) {
 				return 0;
 			}

--- a/src/Protocol/ActivityPub.php
+++ b/src/Protocol/ActivityPub.php
@@ -89,14 +89,15 @@ class ActivityPub
 	/**
 	 * Fetches a profile from the given url into an array that is compatible to Probe::uri
 	 *
-	 * @param string $url profile url
+	 * @param string  $url    profile url
+	 * @param boolean $update Update the profile
 	 * @return array
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 * @throws \ImagickException
 	 */
-	public static function probeProfile($url)
+	public static function probeProfile($url, $update = true)
 	{
-		$apcontact = APContact::getByURL($url, true);
+		$apcontact = APContact::getByURL($url, $update);
 		if (empty($apcontact)) {
 			return false;
 		}

--- a/src/Worker/UpdateContact.php
+++ b/src/Worker/UpdateContact.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * @file src/Worker/UpdateContact.php
+ */
+
+namespace Friendica\Worker;
+
+use Friendica\Core\Logger;
+use Friendica\Model\Contact;
+
+class UpdateContact
+{
+	public static function execute($contact_id)
+	{
+		$success = Contact::updateFromProbe($contact_id);
+		Logger::info('Updated from probe', ['id' => $contact_id, 'success' => $success]);
+	}
+}

--- a/src/Worker/UpdateContact.php
+++ b/src/Worker/UpdateContact.php
@@ -8,12 +8,21 @@ namespace Friendica\Worker;
 
 use Friendica\Core\Logger;
 use Friendica\Model\Contact;
+use Friendica\Util\DateTimeFormat;
+use Friendica\Database\DBA;
 
 class UpdateContact
 {
 	public static function execute($contact_id)
 	{
 		$success = Contact::updateFromProbe($contact_id);
+		// Update the "updated" field if the contact could be probed.
+		// We don't do this in the function above, since we don't want to
+		// update the contact whenever that function is called from anywhere.
+		if ($success) {
+			DBA::update('contact', ['updated' => DateTimeFormat::utcNow()], ['id' => $contact_id]);
+		}
+
 		Logger::info('Updated from probe', ['id' => $contact_id, 'success' => $success]);
 	}
 }


### PR DESCRIPTION
This is done when we won't or can't probe via network.

There are situations where need an entry in the contact table but we don't want to probe via network, since this can take several seconds. This is normally done in frontend situations.

Then we are searching several contact tables ("contact" for all users, gcontact, apcontact and fcontact) for that profile.