### PR TITLE
Allow set empty string storage class for legacy

### DIFF
--- a/mod/admin.php
+++ b/mod/admin.php
@@ -1157,9 +1157,7 @@ function admin_page_site_post(App $a)
 
 	// save storage backend form
 	if (!is_null($storagebackend) && $storagebackend != "") {
-		if (!StorageManager::setBackend($storagebackend)) {
-			info(L10n::t('Invalid storage backend setting value.'));
-		} else {
+		if (StorageManager::setBackend($storagebackend)) {
 			$storage_opts = $storagebackend::getOptions();
 			$storage_form_prefix=preg_replace('|[^a-zA-Z0-9]|' ,'', $storagebackend);
 			$storage_opts_data = [];
@@ -1185,6 +1183,8 @@ function admin_page_site_post(App $a)
 				}
 				$a->internalRedirect('admin/site' . $active_panel);
 			}
+		} else {
+			info(L10n::t('Invalid storage backend setting value.'));
 		}
 	}
 

--- a/mod/admin.php
+++ b/mod/admin.php
@@ -1159,17 +1159,17 @@ function admin_page_site_post(App $a)
 	if (!is_null($storagebackend) && $storagebackend != "") {
 		if (StorageManager::setBackend($storagebackend)) {
 			$storage_opts = $storagebackend::getOptions();
-			$storage_form_prefix=preg_replace('|[^a-zA-Z0-9]|' ,'', $storagebackend);
+			$storage_form_prefix = preg_replace('|[^a-zA-Z0-9]|', '', $storagebackend);
 			$storage_opts_data = [];
-			foreach($storage_opts as $name => $info) {
+			foreach ($storage_opts as $name => $info) {
 				$fieldname = $storage_form_prefix . '_' . $name;
 				switch ($info[0]) { // type
-				case 'checkbox':
-				case 'yesno':
-					$value = !empty($_POST[$fieldname]);
-					break;
-				default:
-					$value = defaults($_POST, $fieldname, '');
+					case 'checkbox':
+					case 'yesno':
+						$value = !empty($_POST[$fieldname]);
+						break;
+					default:
+						$value = defaults($_POST, $fieldname, '');
 				}
 				$storage_opts_data[$name] = $value;
 			}
@@ -1178,7 +1178,7 @@ function admin_page_site_post(App $a)
 
 			$storage_form_errors = $storagebackend::saveOptions($storage_opts_data);
 			if (count($storage_form_errors)) {
-				foreach($storage_form_errors as $name => $err) {
+				foreach ($storage_form_errors as $name => $err) {
 					notice('Storage backend, ' . $storage_opts[$name][1] . ': ' . $err);
 				}
 				$a->internalRedirect('admin/site' . $active_panel);
@@ -1508,7 +1508,7 @@ function admin_page_site(App $a)
 		$storage_backends_choices[''] = L10n::t('Database (legacy)');
 	};
 
-	foreach($storage_backends as $name=>$class) {
+	foreach ($storage_backends as $name => $class) {
 		$storage_backends_choices[$class] = $name;
 	}
 	unset($storage_backends);

--- a/mod/admin.php
+++ b/mod/admin.php
@@ -1154,40 +1154,41 @@ function admin_page_site_post(App $a)
 	 * @var $storagebackend \Friendica\Model\Storage\IStorage
 	 */
 	$storagebackend    = Strings::escapeTags(trim(defaults($_POST, 'storagebackend', '')));
-	if (!StorageManager::setBackend($storagebackend)) {
-		info(L10n::t('Invalid storage backend setting value.'));
-	}
 
 	// save storage backend form
 	if (!is_null($storagebackend) && $storagebackend != "") {
-		$storage_opts = $storagebackend::getOptions();
-		$storage_form_prefix=preg_replace('|[^a-zA-Z0-9]|' ,'', $storagebackend);
-		$storage_opts_data = [];
-		foreach($storage_opts as $name => $info) {
-			$fieldname = $storage_form_prefix . '_' . $name;
-			switch ($info[0]) { // type
+		if (!StorageManager::setBackend($storagebackend)) {
+			info(L10n::t('Invalid storage backend setting value.'));
+		} else {
+			$storage_opts = $storagebackend::getOptions();
+			$storage_form_prefix=preg_replace('|[^a-zA-Z0-9]|' ,'', $storagebackend);
+			$storage_opts_data = [];
+			foreach($storage_opts as $name => $info) {
+				$fieldname = $storage_form_prefix . '_' . $name;
+				switch ($info[0]) { // type
 				case 'checkbox':
 				case 'yesno':
 					$value = !empty($_POST[$fieldname]);
 					break;
 				default:
 					$value = defaults($_POST, $fieldname, '');
+				}
+				$storage_opts_data[$name] = $value;
 			}
-			$storage_opts_data[$name] = $value;
-		}
-		unset($name);
-		unset($info);
-	
-		$storage_form_errors = $storagebackend::saveOptions($storage_opts_data);
-		if (count($storage_form_errors)) {
-			foreach($storage_form_errors as $name => $err) {
-				notice('Storage backend, ' . $storage_opts[$name][1] . ': ' . $err);
+			unset($name);
+			unset($info);
+
+			$storage_form_errors = $storagebackend::saveOptions($storage_opts_data);
+			if (count($storage_form_errors)) {
+				foreach($storage_form_errors as $name => $err) {
+					notice('Storage backend, ' . $storage_opts[$name][1] . ': ' . $err);
+				}
+				$a->internalRedirect('admin/site' . $active_panel);
 			}
-			$a->internalRedirect('admin/site' . $active_panel);
 		}
 	}
 
-	
+
 
 	// Has the directory url changed? If yes, then resubmit the existing profiles there
 	if ($global_directory != Config::get('system', 'directory') && ($global_directory != '')) {
@@ -1499,9 +1500,14 @@ function admin_page_site(App $a)
 	 */
 	$storage_current_backend = StorageManager::getBackend();
 
-	$storage_backends_choices = [
-		'' => L10n::t('Database (legacy)')
-	];
+	$storage_backends_choices = [];
+
+	// show legacy option only if it is the current backend:
+	// once changed can't be selected anymore
+	if ($storage_current_backend == '') {
+		$storage_backends_choices[''] = L10n::t('Database (legacy)');
+	};
+
 	foreach($storage_backends as $name=>$class) {
 		$storage_backends_choices[$class] = $name;
 	}
@@ -1509,7 +1515,7 @@ function admin_page_site(App $a)
 
 	// build storage config form,
 	$storage_form_prefix=preg_replace('|[^a-zA-Z0-9]|' ,'', $storage_current_backend);
-	
+
 	$storage_form = [];
 	if (!is_null($storage_current_backend) && $storage_current_backend != "") {
 		foreach ($storage_current_backend::getOptions() as $name => $info) {

--- a/src/Core/StorageManager.php
+++ b/src/Core/StorageManager.php
@@ -29,8 +29,8 @@ class StorageManager
 	}
 
 	/**
-	 * @brief Return current storage backend class 
-	 * 
+	 * @brief Return current storage backend class
+	 *
 	 * @return string
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
@@ -53,7 +53,6 @@ class StorageManager
 
 	/**
 	 * @brief Set current storage backend class
-	 * If $class is an empty string, legacy db storage is used.
 	 *
 	 * @param string $class Backend class name
 	 * @return bool
@@ -61,7 +60,7 @@ class StorageManager
 	 */
 	public static function setBackend($class)
 	{
-		if ($class !== "" && !in_array('Friendica\Model\Storage\IStorage', class_implements($class))) {
+		if (!in_array('Friendica\Model\Storage\IStorage', class_implements($class))) {
 			return false;
 		}
 

--- a/src/Core/StorageManager.php
+++ b/src/Core/StorageManager.php
@@ -29,7 +29,8 @@ class StorageManager
 	}
 
 	/**
-	 * @brief Return current storage backend class
+	 * @brief Return current storage backend class 
+	 * 
 	 * @return string
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
@@ -52,6 +53,7 @@ class StorageManager
 
 	/**
 	 * @brief Set current storage backend class
+	 * If $class is an empty string, legacy db storage is used.
 	 *
 	 * @param string $class Backend class name
 	 * @return bool
@@ -59,7 +61,7 @@ class StorageManager
 	 */
 	public static function setBackend($class)
 	{
-		if (!in_array('Friendica\Model\Storage\IStorage', class_implements($class))) {
+		if ($class !== "" && !in_array('Friendica\Model\Storage\IStorage', class_implements($class))) {
 			return false;
 		}
 


### PR DESCRIPTION
Legacy storage is defined by an empty string.
`StorageManager::setBackend()` now accept an empty string as a valid
backend storage.