### PR TITLE
Added missing "cron_interval" default value

### DIFF
--- a/config/defaults.config.php
+++ b/config/defaults.config.php
@@ -72,6 +72,10 @@ return [
 		// Deny public access to the local user directory.
 		'block_local_dir' => false,
 
+		// cron_interval (Integer)
+		// Minimal period in minutes between two calls of the "Cron" worker job.
+		'cron_interval' => 5,
+
 		// cache_driver (database|memcache|memcached|redis)
 		// Whether to use Memcache or Memcached or Redis to store temporary cache.
 		'cache_driver' => 'database',

--- a/src/Worker/Cron.php
+++ b/src/Worker/Cron.php
@@ -30,9 +30,6 @@ class Cron
 		$last = Config::get('system', 'last_cron');
 
 		$poll_interval = intval(Config::get('system', 'cron_interval'));
-		if (! $poll_interval) {
-			$poll_interval = 10;
-		}
 
 		if ($last) {
 			$next = $last + ($poll_interval * 60);


### PR DESCRIPTION
This should fix the issue that had been described here: https://github.com/friendica/friendica/pull/6978#issuecomment-481442756

Since there hadn't been a default value, the lifetime of the worker had been really short.