### PR TITLE
Only call page_end hooks for standalone pages (no Ajax)

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -1302,8 +1302,9 @@ class App
 			header($_SERVER["SERVER_PROTOCOL"] . ' 403 ' . Core\L10n::t('Permission denied.'));
 		}
 
-		// Report anything which needs to be communicated in the notification area (before the main body)
-		Core\Hook::callAll('page_end', $this->page['content']);
+		if (!$this->isAjax()) {
+			Core\Hook::callAll('page_end', $this->page['content']);
+		}
 
 		// Add the navigation (menu) template
 		if ($this->module != 'install' && $this->module != 'maintenance') {


### PR DESCRIPTION
Fixes part of #7001 

The `page_end` hook is now only called for standalone pages (not loaded with Ajax. This enabled me to remove a hack to hide the bug link addon content in the file browser.

Thanks to @BinkaDroid for the report.