### PR TITLE
DBA & Logger fix

### DIFF
--- a/src/Core/Installer.php
+++ b/src/Core/Installer.php
@@ -11,6 +11,7 @@ use Friendica\Core\Config\Cache\IConfigCache;
 use Friendica\Database\DBA;
 use Friendica\Database\DBStructure;
 use Friendica\Object\Image;
+use Friendica\Util\Logger\VoidLogger;
 use Friendica\Util\Network;
 use Friendica\Util\Profiler;
 use Friendica\Util\Strings;
@@ -601,7 +602,7 @@ class Installer
 		$dbpass = $configCache->get('database', 'password');
 		$dbdata = $configCache->get('database', 'database');
 
-		if (!DBA::connect($basePath, $configCache, $profiler, $dbhost, $dbuser, $dbpass, $dbdata)) {
+		if (!DBA::connect($basePath, $configCache, $profiler, new VoidLogger(), $dbhost, $dbuser, $dbpass, $dbdata)) {
 			$this->addCheck(L10n::t('Could not connect to database.'), false, true, '');
 
 			return false;

--- a/src/Database/DBA.php
+++ b/src/Database/DBA.php
@@ -586,10 +586,10 @@ class DBA
 			$errorno = self::$errorno;
 
 			self::$logger->error('DB Error', [
-				'code'      =>   self::$errorno,
-				'error    ' =>  self::$error,
+				'code'      => self::$errorno,
+				'error'     => self::$error,
 				'callstack' => System::callstack(8),
-				'params'     => self::replaceParameters($sql, $args),
+				'params'    => self::replaceParameters($sql, $args),
 			]);
 
 			// On a lost connection we try to reconnect - but only once.
@@ -598,21 +598,21 @@ class DBA
 					// It doesn't make sense to continue when the database connection was lost
 					if (self::$in_retrial) {
 						self::$logger->notice('Giving up retrial because of database error', [
-							'code'      =>   self::$errorno,
-							'error    ' =>  self::$error,
+							'code'  => self::$errorno,
+							'error' => self::$error,
 						]);
 					} else {
 						self::$logger->notice('Couldn\'t reconnect after database error', [
-							'code'      =>   self::$errorno,
-							'error    ' =>  self::$error,
+							'code'  => self::$errorno,
+							'error' => self::$error,
 						]);
 					}
 					exit(1);
 				} else {
 					// We try it again
 					self::$logger->notice('Reconnected after database error', [
-						'code'      =>   self::$errorno,
-						'error    ' =>  self::$error,
+						'code'  => self::$errorno,
+						'error' => self::$error,
 					]);
 					self::$in_retrial = true;
 					$ret = self::p($sql, $args);
@@ -683,18 +683,18 @@ class DBA
 			$errorno = self::$errorno;
 
 			self::$logger->error('DB Error', [
-				'code'      =>   self::$errorno,
-				'error    ' =>  self::$error,
+				'code'      => self::$errorno,
+				'error'     => self::$error,
 				'callstack' => System::callstack(8),
-				'params'     => self::replaceParameters($sql, $params),
+				'params'    => self::replaceParameters($sql, $params),
 			]);
 
 			// On a lost connection we simply quit.
 			// A reconnect like in self::p could be dangerous with modifications
 			if ($errorno == 2006) {
 				self::$logger->error('Giving up because of database error', [
-					'code'      =>   self::$errorno,
-					'error    ' =>  self::$error,
+					'code'  => self::$errorno,
+					'error' => self::$error,
 				]);
 				exit(1);
 			}

--- a/src/Database/DBA.php
+++ b/src/Database/DBA.php
@@ -692,7 +692,7 @@ class DBA
 			// On a lost connection we simply quit.
 			// A reconnect like in self::p could be dangerous with modifications
 			if ($errorno == 2006) {
-				self::$logger->error('Giving up because of database error', [
+				self::$logger->notice('Giving up because of database error', [
 					'code'  => self::$errorno,
 					'error' => self::$error,
 				]);

--- a/src/Factory/DBFactory.php
+++ b/src/Factory/DBFactory.php
@@ -4,6 +4,7 @@ namespace Friendica\Factory;
 
 use Friendica\Core\Config\Cache;
 use Friendica\Database;
+use Friendica\Util\Logger\VoidLogger;
 use Friendica\Util\Profiler;
 
 class DBFactory
@@ -51,7 +52,7 @@ class DBFactory
 			$db_data = $server['MYSQL_DATABASE'];
 		}
 
-		if (Database\DBA::connect($basePath, $configCache, $profiler, $db_host, $db_user, $db_pass, $db_data, $charset)) {
+		if (Database\DBA::connect($basePath, $configCache, $profiler, new VoidLogger(), $db_host, $db_user, $db_pass, $db_data, $charset)) {
 			// Loads DB_UPDATE_VERSION constant
 			Database\DBStructure::definition($basePath, false);
 		}

--- a/src/Factory/DependencyFactory.php
+++ b/src/Factory/DependencyFactory.php
@@ -3,6 +3,7 @@
 namespace Friendica\Factory;
 
 use Friendica\App;
+use Friendica\Database\DBA;
 use Friendica\Factory;
 use Friendica\Util\BasePath;
 use Friendica\Util\BaseURL;
@@ -34,6 +35,7 @@ class DependencyFactory
 		// needed to call PConfig::init()
 		Factory\ConfigFactory::createPConfig($configCache);
 		$logger = Factory\LoggerFactory::create($channel, $config, $profiler);
+		DBA::setLogger($logger);
 		Factory\LoggerFactory::createDev($channel, $config, $profiler);
 		$baseURL = new BaseURL($config, $_SERVER);
 

--- a/tests/DatabaseTest.php
+++ b/tests/DatabaseTest.php
@@ -10,6 +10,7 @@ use Friendica\Database\DBA;
 use Friendica\Factory;
 use Friendica\Util\BasePath;
 use Friendica\Util\Config\ConfigFileLoader;
+use Friendica\Util\Logger\VoidLogger;
 use Friendica\Util\Profiler;
 use PHPUnit\DbUnit\DataSet\YamlDataSet;
 use PHPUnit\DbUnit\TestCaseTrait;
@@ -52,6 +53,7 @@ abstract class DatabaseTest extends MockedTest
 			$basePath,
 			$config,
 			$profiler,
+			new VoidLogger(),
 			getenv('MYSQL_HOST'),
 			getenv('MYSQL_USERNAME'),
 			getenv('MYSQL_PASSWORD'),


### PR DESCRIPTION
This is necessary because if we want to load the logger configuration from the DB, but there's an error, we would print out an exception.

So the logger gets updated after the logger configuration can be retrieved from the database