### PR TITLE
Remove obsolete hack in file browser template

### DIFF
--- a/view/templates/filebrowser.tpl
+++ b/view/templates/filebrowser.tpl
@@ -1,9 +1,6 @@
-	<!--
-		This is the template used by mod/fbrowser.php
-	-->
-<style>
-	#buglink_wrapper{display:none;} /* hide buglink. only in this page */
-</style>
+<!--
+	This is the template used by mod/fbrowser.php
+-->
 <script type="text/javascript" src="{{$baseurl}}/view/js/ajaxupload.js" ></script>
 <script type="text/javascript" src="{{$baseurl}}/view/js/filebrowser.js"></script>
 <script>

--- a/view/theme/frio/templates/filebrowser.tpl
+++ b/view/theme/frio/templates/filebrowser.tpl
@@ -1,12 +1,6 @@
-	<!--
-		This is the template used by mod/fbrowser.php
-	-->
-<style>
-	#buglink_wrapper{display:none;} /* hide buglink. only in this page */
-</style>
-{{*<script type="text/javascript" src="{{$baseurl}}/view/js/ajaxupload.js" ></script>*}}
-{{*<script type="text/javascript" src="view/theme/frio/js/filebrowser.js"></script>*}}
-
+<!--
+	This is the template used by mod/fbrowser.php
+-->
 <div class="fbrowser {{$type}}">
 	<div class="fbrowser-content">
 		<input id="fb-nickname" type="hidden" name="type" value="{{$nickname}}" />


### PR DESCRIPTION
Follow-up to #7003 

I forgot to push a commit to remove the CSS hacks in the file browser to neutralize the former `page_end` calls.