### PR TITLE
Basepath Hardening

### DIFF
--- a/src/Util/BasePath.php
+++ b/src/Util/BasePath.php
@@ -19,15 +19,21 @@ class BasePath
 	 */
 	public static function create($basePath, array $server = [])
 	{
-		if (!$basePath && !empty($server['DOCUMENT_ROOT'])) {
+		if ((!$basePath || !is_dir($basePath)) && !empty($server['DOCUMENT_ROOT'])) {
 			$basePath = $server['DOCUMENT_ROOT'];
 		}
 
-		if (!$basePath && !empty($server['PWD'])) {
+		if ((!$basePath || !is_dir($basePath)) && !empty($server['PWD'])) {
 			$basePath = $server['PWD'];
 		}
 
-		return self::getRealPath($basePath);
+		$basePath = self::getRealPath($basePath);
+
+		if (!is_dir($basePath)) {
+			throw new \Exception(sprintf('\'%s\' is not a valid basepath', $basePath));
+		}
+
+		return $basePath;
 	}
 
 	/**

--- a/tests/src/Util/BasePathTest.php
+++ b/tests/src/Util/BasePathTest.php
@@ -40,6 +40,14 @@ class BasePathTest extends MockedTest
 				],
 				'input' => 'config',
 				'output' => dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . 'config',
+			],
+			'no_overwrite_if_invalid' => [
+				'server' => [
+					'DOCUMENT_ROOT' => '/nopopop',
+					'PWD' => dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . 'config',
+				],
+				'input' => '/noatgawe22fafa',
+				'output' => dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . 'config',
 			]
 		];
 	}

--- a/tests/src/Util/BasePathTest.php
+++ b/tests/src/Util/BasePathTest.php
@@ -6,24 +6,60 @@ use Friendica\Util\BasePath;
 
 class BasePathTest extends MockedTest
 {
-	/**
-	 * Test the basepath determination
-	 */
-	public function testDetermineBasePath()
+	public function dataPaths()
 	{
-		$serverArr = ['DOCUMENT_ROOT' => '/invalid', 'PWD' => '/invalid2'];
-		$this->assertEquals('/valid', BasePath::create('/valid', $serverArr));
+		return [
+			'fullPath' => [
+				'server' => [],
+				'input' => dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . 'config',
+				'output' => dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . 'config',
+			],
+			'relative' => [
+				'server' => [],
+				'input' => 'config',
+				'output' => dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . 'config',
+			],
+			'document_root' => [
+				'server' => [
+					'DOCUMENT_ROOT' => dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . 'config',
+				],
+				'input' => '/noooop',
+				'output' => dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . 'config',
+			],
+			'pwd' => [
+				'server' => [
+					'PWD' => dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . 'config',
+				],
+				'input' => '/noooop',
+				'output' => dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . 'config',
+			],
+			'no_overwrite' => [
+				'server' => [
+					'DOCUMENT_ROOT' => dirname(__DIR__, 3),
+					'PWD' => dirname(__DIR__, 3),
+				],
+				'input' => 'config',
+				'output' => dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . 'config',
+			]
+		];
 	}
 
 	/**
-	 * Test the basepath determination with DOCUMENT_ROOT and PWD
+	 * Test the basepath determination
+	 * @dataProvider dataPaths
 	 */
-	public function testDetermineBasePathWithServer()
+	public function testDetermineBasePath(array $server, $input, $output)
 	{
-		$serverArr = ['DOCUMENT_ROOT' => '/valid'];
-		$this->assertEquals('/valid', BasePath::create('', $serverArr));
+		$this->assertEquals($output, BasePath::create($input, $server));
+	}
 
-		$serverArr = ['PWD' => '/valid_too'];
-		$this->assertEquals('/valid_too', BasePath::create('', $serverArr));
+	/**
+	 * Test the basepath determination with a complete wrong path
+	 * @expectedException \Exception
+	 * @expectedExceptionMessageRegExp /(.*) is not a valid basepath/
+	 */
+	public function testFailedBasePath()
+	{
+		BasePath::create('/now23452sgfgas', []);
 	}
 }


### PR DESCRIPTION
Avoid a basepath which isn't valid.

If no basepath can be found, throw an exception (better than using it for config/Friendica code determination if not valid ...)