### PR TITLE
Follow up to #7036: Automatically update AP contacts

### DIFF
--- a/src/Model/APContact.php
+++ b/src/Model/APContact.php
@@ -89,12 +89,12 @@ class APContact extends BaseObject
 				$apcontact = DBA::selectFirst('apcontact', [], ['addr' => $url]);
 			}
 
-			if (DBA::isResult($apcontact) && ($apcontact['updated'] > $ref_update)) {
+			if (DBA::isResult($apcontact) && ($apcontact['updated'] > $ref_update) && !empty($apcontact['pubkey'])) {
 				return $apcontact;
 			}
 
 			if (!is_null($update)) {
-				return false;
+				return DBA::isResult($apcontact) ? $apcontact : false;
 			}
 		}
 


### PR DESCRIPTION
This enhances PR #7040 that fixed #7036.

We now automatically update AP contacts when they are missing the key.  