### PR TITLE
Add themed error page

### DIFF
--- a/mod/display.php
+++ b/mod/display.php
@@ -20,6 +20,7 @@ use Friendica\Model\Group;
 use Friendica\Model\Item;
 use Friendica\Model\Profile;
 use Friendica\Module\Objects;
+use Friendica\Network\HTTPException;
 use Friendica\Protocol\ActivityPub;
 use Friendica\Protocol\DFRN;
 use Friendica\Util\Strings;
@@ -76,7 +77,7 @@ function display_init(App $a)
 	}
 
 	if (!DBA::isResult($item)) {
-		System::httpExit(404);
+		return;
 	}
 
 	if ($a->argc >= 3 && $nick == 'feed-item') {
@@ -200,8 +201,7 @@ function display_fetchauthor($a, $item)
 function display_content(App $a, $update = false, $update_uid = 0)
 {
 	if (Config::get('system','block_public') && !local_user() && !remote_user()) {
-		notice(L10n::t('Public access denied.') . EOL);
-		return;
+		throw new HTTPException\ForbiddenException(L10n::t('Public access denied.'));
 	}
 
 	$o = '';
@@ -254,7 +254,7 @@ function display_content(App $a, $update = false, $update_uid = 0)
 	}
 
 	if (!$item_id) {
-		System::httpExit(404);
+		throw new HTTPException\NotFoundException(L10n::t('The requested item doesn\'t exist or has been deleted.'));
 	}
 
 	// We are displaying an "alternate" link if that post was public. See issue 2864
@@ -303,8 +303,7 @@ function display_content(App $a, $update = false, $update_uid = 0)
 	$is_owner = (local_user() && (in_array($a->profile['profile_uid'], [local_user(), 0])) ? true : false);
 
 	if (!empty($a->profile['hidewall']) && !$is_owner && !$is_remote_contact) {
-		notice(L10n::t('Access to this profile has been restricted.') . EOL);
-		return;
+		throw new HTTPException\ForbiddenException(L10n::t('Access to this profile has been restricted.'));
 	}
 
 	// We need the editor here to be able to reshare an item.
@@ -340,7 +339,7 @@ function display_content(App $a, $update = false, $update_uid = 0)
 	$item = Item::selectFirstForUser(local_user(), $fields, $condition);
 
 	if (!DBA::isResult($item)) {
-		System::httpExit(404);
+		throw new HTTPException\NotFoundException(L10n::t('The requested item doesn\'t exist or has been deleted.'));
 	}
 
 	$item['uri'] = $item['parent-uri'];
@@ -415,7 +414,7 @@ function displayShowFeed($item_id, $conversation)
 {
 	$xml = DFRN::itemFeed($item_id, $conversation);
 	if ($xml == '') {
-		System::httpExit(500);
+		throw new HTTPException\InternalServerErrorException(L10n::t('The feed for this item is unavailable.'));
 	}
 	header("Content-type: application/atom+xml");
 	echo $xml;

--- a/src/BaseObject.php
+++ b/src/BaseObject.php
@@ -6,8 +6,6 @@ namespace Friendica;
 
 require_once __DIR__ . '/../boot.php';
 
-use Friendica\Network\HTTPException\InternalServerErrorException;
-
 /**
  * Basic object
  *
@@ -31,7 +29,7 @@ class BaseObject
 	public static function getApp()
 	{
 		if (empty(self::$app)) {
-			throw new InternalServerErrorException('App isn\'t initialized.');
+			throw new \Exception('App isn\'t initialized.');
 		}
 
 		return self::$app;

--- a/src/Module/PageNotFound.php
+++ b/src/Module/PageNotFound.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Friendica\Module;
+
+use Friendica\BaseModule;
+use Friendica\Core\L10n;
+use Friendica\Network\HTTPException;
+
+class PageNotFound extends BaseModule
+{
+	public static function content()
+	{
+		throw new HTTPException\NotFoundException(L10n::t('Page not found.'));
+	}
+}

--- a/src/Network/HTTPException.php
+++ b/src/Network/HTTPException.php
@@ -14,5 +14,5 @@ use Exception;
 class HTTPException extends Exception
 {
 	var $httpcode = 200;
-	var $httpdesc = "";
+	var $httpdesc = "OK";
 }

--- a/src/Network/HTTPException.php
+++ b/src/Network/HTTPException.php
@@ -15,13 +15,4 @@ class HTTPException extends Exception
 {
 	var $httpcode = 200;
 	var $httpdesc = "";
-
-	public function __construct($message = '', $code = 0, Exception $previous = null)
-	{
-		if ($this->httpdesc == '') {
-			$classname = str_replace('Exception', '', str_replace('Friendica\Network\HTTPException\\', '', get_class($this)));
-			$this->httpdesc = preg_replace("|([a-z])([A-Z])|",'$1 $2', $classname);
-		}
-		parent::__construct($message, $code, $previous);
-	}
 }

--- a/src/Network/HTTPException/BadGatewayException.php
+++ b/src/Network/HTTPException/BadGatewayException.php
@@ -2,9 +2,18 @@
 
 namespace Friendica\Network\HTTPException;
 
+use Exception;
+use Friendica\Core\L10n;
 use Friendica\Network\HTTPException;
 
 class BadGatewayException extends HTTPException
 {
 	var $httpcode = 502;
+
+	public function __construct($message = '', $code = 0, Exception $previous = null)
+	{
+		parent::__construct($message, $code, $previous);
+
+		$this->httpdesc = L10n::t('Bad Gateway');
+	}
 }

--- a/src/Network/HTTPException/BadRequestException.php
+++ b/src/Network/HTTPException/BadRequestException.php
@@ -2,9 +2,18 @@
 
 namespace Friendica\Network\HTTPException;
 
+use Exception;
+use Friendica\Core\L10n;
 use Friendica\Network\HTTPException;
 
 class BadRequestException extends HTTPException
 {
 	var $httpcode = 400;
+
+	public function __construct($message = '', $code = 0, Exception $previous = null)
+	{
+		parent::__construct($message, $code, $previous);
+
+		$this->httpdesc = L10n::t('Bad Request');
+	}
 }

--- a/src/Network/HTTPException/ConflictException.php
+++ b/src/Network/HTTPException/ConflictException.php
@@ -2,9 +2,18 @@
 
 namespace Friendica\Network\HTTPException;
 
+use Exception;
+use Friendica\Core\L10n;
 use Friendica\Network\HTTPException;
 
 class ConflictException extends HTTPException
 {
 	var $httpcode = 409;
+
+	public function __construct($message = '', $code = 0, Exception $previous = null)
+	{
+		parent::__construct($message, $code, $previous);
+
+		$this->httpdesc = L10n::t('Conflict');
+	}
 }

--- a/src/Network/HTTPException/ExpectationFailedException.php
+++ b/src/Network/HTTPException/ExpectationFailedException.php
@@ -2,9 +2,18 @@
 
 namespace Friendica\Network\HTTPException;
 
+use Exception;
+use Friendica\Core\L10n;
 use Friendica\Network\HTTPException;
 
 class ExpectationFailedException extends HTTPException
 {
 	var $httpcode = 417;
+
+	public function __construct($message = '', $code = 0, Exception $previous = null)
+	{
+		parent::__construct($message, $code, $previous);
+
+		$this->httpdesc = L10n::t('Expectation Failed');
+	}
 }

--- a/src/Network/HTTPException/ForbiddenException.php
+++ b/src/Network/HTTPException/ForbiddenException.php
@@ -2,9 +2,18 @@
 
 namespace Friendica\Network\HTTPException;
 
+use Exception;
+use Friendica\Core\L10n;
 use Friendica\Network\HTTPException;
 
 class ForbiddenException extends HTTPException
 {
 	var $httpcode = 403;
+
+	public function __construct($message = '', $code = 0, Exception $previous = null)
+	{
+		parent::__construct($message, $code, $previous);
+
+		$this->httpdesc = L10n::t('Forbidden');
+	}
 }

--- a/src/Network/HTTPException/GatewayTimeoutException.php
+++ b/src/Network/HTTPException/GatewayTimeoutException.php
@@ -2,9 +2,18 @@
 
 namespace Friendica\Network\HTTPException;
 
+use Exception;
+use Friendica\Core\L10n;
 use Friendica\Network\HTTPException;
 
 class GatewayTimeoutException extends HTTPException
 {
 	var $httpcode = 504;
+
+	public function __construct($message = '', $code = 0, Exception $previous = null)
+	{
+		parent::__construct($message, $code, $previous);
+
+		$this->httpdesc = L10n::t('Gateway Timeout');
+	}
 }

--- a/src/Network/HTTPException/GoneException.php
+++ b/src/Network/HTTPException/GoneException.php
@@ -2,9 +2,18 @@
 
 namespace Friendica\Network\HTTPException;
 
+use Exception;
+use Friendica\Core\L10n;
 use Friendica\Network\HTTPException;
 
 class GoneException extends HTTPException
 {
 	var $httpcode = 410;
+
+	public function __construct($message = '', $code = 0, Exception $previous = null)
+	{
+		parent::__construct($message, $code, $previous);
+
+		$this->httpdesc = L10n::t('Gone');
+	}
 }

--- a/src/Network/HTTPException/ImATeapotException.php
+++ b/src/Network/HTTPException/ImATeapotException.php
@@ -2,10 +2,18 @@
 
 namespace Friendica\Network\HTTPException;
 
+use Exception;
+use Friendica\Core\L10n;
 use Friendica\Network\HTTPException;
 
 class ImATeapotException extends HTTPException
 {
 	var $httpcode = 418;
-	var $httpdesc = "I'm A Teapot";
+
+	public function __construct($message = '', $code = 0, Exception $previous = null)
+	{
+		parent::__construct($message, $code, $previous);
+
+		$this->httpdesc = L10n::t('I\'m A Teapot');
+	}
 }

--- a/src/Network/HTTPException/InternalServerErrorException.php
+++ b/src/Network/HTTPException/InternalServerErrorException.php
@@ -2,9 +2,18 @@
 
 namespace Friendica\Network\HTTPException;
 
+use Exception;
+use Friendica\Core\L10n;
 use Friendica\Network\HTTPException;
 
 class InternalServerErrorException extends HTTPException
 {
 	var $httpcode = 500;
+
+	public function __construct($message = '', $code = 0, Exception $previous = null)
+	{
+		parent::__construct($message, $code, $previous);
+
+		$this->httpdesc = L10n::t('Internal Server Error');
+	}
 }

--- a/src/Network/HTTPException/LenghtRequiredException.php
+++ b/src/Network/HTTPException/LenghtRequiredException.php
@@ -2,9 +2,18 @@
 
 namespace Friendica\Network\HTTPException;
 
+use Exception;
+use Friendica\Core\L10n;
 use Friendica\Network\HTTPException;
 
 class LenghtRequiredException extends HTTPException
 {
 	var $httpcode = 411;
+
+	public function __construct($message = '', $code = 0, Exception $previous = null)
+	{
+		parent::__construct($message, $code, $previous);
+
+		$this->httpdesc = L10n::t('Length Required');
+	}
 }

--- a/src/Network/HTTPException/MethodNotAllowedException.php
+++ b/src/Network/HTTPException/MethodNotAllowedException.php
@@ -2,9 +2,18 @@
 
 namespace Friendica\Network\HTTPException;
 
+use Exception;
+use Friendica\Core\L10n;
 use Friendica\Network\HTTPException;
 
 class MethodNotAllowedException extends HTTPException
 {
 	var $httpcode = 405;
+
+	public function __construct($message = '', $code = 0, Exception $previous = null)
+	{
+		parent::__construct($message, $code, $previous);
+
+		$this->httpdesc = L10n::t('Method Not Allowed');
+	}
 }

--- a/src/Network/HTTPException/NonAcceptableException.php
+++ b/src/Network/HTTPException/NonAcceptableException.php
@@ -2,9 +2,18 @@
 
 namespace Friendica\Network\HTTPException;
 
+use Exception;
+use Friendica\Core\L10n;
 use Friendica\Network\HTTPException;
 
 class NonAcceptableException extends HTTPException
 {
 	var $httpcode = 406;
+
+	public function __construct($message = '', $code = 0, Exception $previous = null)
+	{
+		parent::__construct($message, $code, $previous);
+
+		$this->httpdesc = L10n::t('Non Acceptable');
+	}
 }

--- a/src/Network/HTTPException/NotFoundException.php
+++ b/src/Network/HTTPException/NotFoundException.php
@@ -2,8 +2,18 @@
 
 namespace Friendica\Network\HTTPException;
 
+use Exception;
+use Friendica\Core\L10n;
 use Friendica\Network\HTTPException;
 
-class NotFoundException extends HTTPException {
+class NotFoundException extends HTTPException
+{
 	var $httpcode = 404;
+
+	public function __construct($message = '', $code = 0, Exception $previous = null)
+	{
+		parent::__construct($message, $code, $previous);
+
+		$this->httpdesc = L10n::t('Not Found');
+	}
 }

--- a/src/Network/HTTPException/NotImplementedException.php
+++ b/src/Network/HTTPException/NotImplementedException.php
@@ -2,9 +2,18 @@
 
 namespace Friendica\Network\HTTPException;
 
+use Exception;
+use Friendica\Core\L10n;
 use Friendica\Network\HTTPException;
 
 class NotImplementedException extends HTTPException
 {
 	var $httpcode = 501;
+
+	public function __construct($message = '', $code = 0, Exception $previous = null)
+	{
+		parent::__construct($message, $code, $previous);
+
+		$this->httpdesc = L10n::t('Not Implemented');
+	}
 }

--- a/src/Network/HTTPException/PreconditionFailedException.php
+++ b/src/Network/HTTPException/PreconditionFailedException.php
@@ -2,9 +2,18 @@
 
 namespace Friendica\Network\HTTPException;
 
+use Exception;
+use Friendica\Core\L10n;
 use Friendica\Network\HTTPException;
 
 class PreconditionFailedException extends HTTPException
 {
 	var $httpcode = 412;
+
+	public function __construct($message = '', $code = 0, Exception $previous = null)
+	{
+		parent::__construct($message, $code, $previous);
+
+		$this->httpdesc = L10n::t('Precondition Failed');
+	}
 }

--- a/src/Network/HTTPException/ServiceUnavaiableException.php
+++ b/src/Network/HTTPException/ServiceUnavaiableException.php
@@ -2,9 +2,18 @@
 
 namespace Friendica\Network\HTTPException;
 
+use Exception;
+use Friendica\Core\L10n;
 use Friendica\Network\HTTPException;
 
 class ServiceUnavaiableException extends HTTPException
 {
 	var $httpcode = 503;
+
+	public function __construct($message = '', $code = 0, Exception $previous = null)
+	{
+		parent::__construct($message, $code, $previous);
+
+		$this->httpdesc = L10n::t('Service Unavailable');
+	}
 }

--- a/src/Network/HTTPException/TooManyRequestsException.php
+++ b/src/Network/HTTPException/TooManyRequestsException.php
@@ -2,9 +2,18 @@
 
 namespace Friendica\Network\HTTPException;
 
+use Exception;
+use Friendica\Core\L10n;
 use Friendica\Network\HTTPException;
 
 class TooManyRequestsException extends HTTPException
 {
 	var $httpcode = 429;
+
+	public function __construct($message = '', $code = 0, Exception $previous = null)
+	{
+		parent::__construct($message, $code, $previous);
+
+		$this->httpdesc = L10n::t('Too Many Requests');
+	}
 }

--- a/src/Network/HTTPException/UnauthorizedException.php
+++ b/src/Network/HTTPException/UnauthorizedException.php
@@ -2,9 +2,18 @@
 
 namespace Friendica\Network\HTTPException;
 
+use Exception;
+use Friendica\Core\L10n;
 use Friendica\Network\HTTPException;
 
 class UnauthorizedException extends HTTPException
 {
 	var $httpcode = 401;
+
+	public function __construct($message = '', $code = 0, Exception $previous = null)
+	{
+		parent::__construct($message, $code, $previous);
+
+		$this->httpdesc = L10n::t('Unauthorized');
+	}
 }

--- a/src/Network/HTTPException/UnprocessableEntityException.php
+++ b/src/Network/HTTPException/UnprocessableEntityException.php
@@ -2,9 +2,18 @@
 
 namespace Friendica\Network\HTTPException;
 
+use Exception;
+use Friendica\Core\L10n;
 use Friendica\Network\HTTPException;
 
 class UnprocessableEntityException extends HTTPException
 {
 	var $httpcode = 422;
+
+	public function __construct($message = '', $code = 0, Exception $previous = null)
+	{
+		parent::__construct($message, $code, $previous);
+
+		$this->httpdesc = L10n::t('Unprocessable Entity');
+	}
 }

--- a/src/Network/HTTPException/UnsupportedMediaTypeException.php
+++ b/src/Network/HTTPException/UnsupportedMediaTypeException.php
@@ -2,9 +2,18 @@
 
 namespace Friendica\Network\HTTPException;
 
+use Exception;
+use Friendica\Core\L10n;
 use Friendica\Network\HTTPException;
 
 class UnsupportedMediaTypeException extends HTTPException
 {
 	var $httpcode = 415;
+
+	public function __construct($message = '', $code = 0, Exception $previous = null)
+	{
+		parent::__construct($message, $code, $previous);
+
+		$this->httpdesc = L10n::t('Unsupported Media Type');
+	}
 }

--- a/tests/include/ApiTest.php
+++ b/tests/include/ApiTest.php
@@ -610,7 +610,7 @@ class ApiTest extends DatabaseTest
 	public function testApiErrorWithJson()
 	{
 		$this->assertEquals(
-			'{"status":{"error":"error_message","code":"200 Friendica\\\\Network\\\\HTTP","request":""}}',
+			'{"status":{"error":"error_message","code":"200 OK","request":""}}',
 			api_error('json', new HTTPException('error_message'))
 		);
 	}
@@ -628,7 +628,7 @@ class ApiTest extends DatabaseTest
 				'xmlns:friendica="http://friendi.ca/schema/api/1/" '.
 				'xmlns:georss="http://www.georss.org/georss">'."\n".
 			'  <error>error_message</error>'."\n".
-			'  <code>200 Friendica\Network\HTTP</code>'."\n".
+			'  <code>200 OK</code>'."\n".
 			'  <request/>'."\n".
 			'</status>'."\n",
 			api_error('xml', new HTTPException('error_message'))
@@ -648,7 +648,7 @@ class ApiTest extends DatabaseTest
 				'xmlns:friendica="http://friendi.ca/schema/api/1/" '.
 				'xmlns:georss="http://www.georss.org/georss">'."\n".
 			'  <error>error_message</error>'."\n".
-			'  <code>200 Friendica\Network\HTTP</code>'."\n".
+			'  <code>200 OK</code>'."\n".
 			'  <request/>'."\n".
 			'</status>'."\n",
 			api_error('rss', new HTTPException('error_message'))
@@ -668,7 +668,7 @@ class ApiTest extends DatabaseTest
 				'xmlns:friendica="http://friendi.ca/schema/api/1/" '.
 				'xmlns:georss="http://www.georss.org/georss">'."\n".
 			'  <error>error_message</error>'."\n".
-			'  <code>200 Friendica\Network\HTTP</code>'."\n".
+			'  <code>200 OK</code>'."\n".
 			'  <request/>'."\n".
 			'</status>'."\n",
 			api_error('atom', new HTTPException('error_message'))

--- a/tests/src/BaseObjectTest.php
+++ b/tests/src/BaseObjectTest.php
@@ -45,7 +45,6 @@ class BaseObjectTest extends TestCase
 	 */
 	public function testGetAppFailed()
 	{
-		$baseObject = new BaseObject();
-		$baseObject->getApp();
+		BaseObject::getApp();
 	}
 }

--- a/tests/src/BaseObjectTest.php
+++ b/tests/src/BaseObjectTest.php
@@ -33,13 +33,13 @@ class BaseObjectTest extends TestCase
 		$this->setUpVfsDir();
 		$this->mockApp($this->root);
 
-		$this->assertNull($baseObject->setApp($this->app));
+		$baseObject->setApp($this->app);
 		$this->assertEquals($this->app, $baseObject->getApp());
 	}
 
 	/**
 	 * Test the getApp() function without App
-	 * @expectedException Friendica\Network\HTTPException\InternalServerErrorException
+	 * @expectedException \Exception
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
 	 */

--- a/view/templates/exception.tpl
+++ b/view/templates/exception.tpl
@@ -1,0 +1,4 @@
+<div id="exception" class="generic-page-wrapper">
+    <h1>{{$title}}</h1>
+    <p>{{$message}}</p>
+</div>


### PR DESCRIPTION
Closes #7047

From now on, throwing a `HTTPException` from a module content method will render the error nicely in the selected theme template. Other module methods (init, post) shouldn't throw these exceptions, there's no catch block for them.

Additionally, the `mod/display` module has been modified to show the use of this new feature.