### PR TITLE
Add routes to all current BaseModules

### DIFF
--- a/src/App/Router.php
+++ b/src/App/Router.php
@@ -42,6 +42,14 @@ class Router
 	{
 		$this->routeCollector->addRoute(['GET', 'POST'], '/itemsource[/{guid}]', Module\Itemsource::class);
 		$this->routeCollector->addRoute(['GET'],         '/amcd',                Module\AccountManagementControlDocument::class);
+		$this->routeCollector->addRoute(['GET'],         '/acctlink',            Module\Acctlink::class);
+		$this->routeCollector->addRoute(['GET'],         '/apps',                Module\Apps::class);
+		$this->routeCollector->addRoute(['GET'],         '/attach/{item:\d+}',   Module\Attach::class);
+		$this->routeCollector->addRoute(['GET'],         '/babel',               Module\Babel::class);
+		$this->routeCollector->addGroup('/contact', function (RouteCollector $collector) {
+			$collector->addRoute(['GET'], '[/]',                                  Module\Contact::class);
+			$collector->addRoute(['GET'], '/{id:\d+}[/posts|conversations]', Module\Contact::class);
+		});
 	}
 
 	public function __construct(RouteCollector $routeCollector = null)

--- a/src/App/Router.php
+++ b/src/App/Router.php
@@ -47,9 +47,67 @@ class Router
 		$this->routeCollector->addRoute(['GET'],         '/attach/{item:\d+}',   Module\Attach::class);
 		$this->routeCollector->addRoute(['GET'],         '/babel',               Module\Babel::class);
 		$this->routeCollector->addGroup('/contact', function (RouteCollector $collector) {
-			$collector->addRoute(['GET'], '[/]',                                  Module\Contact::class);
-			$collector->addRoute(['GET'], '/{id:\d+}[/posts|conversations]', Module\Contact::class);
+			$collector->addRoute(['GET'], '[/]',                                 Module\Contact::class);
+			$collector->addRoute(['GET'], '/{id:\d+}[/posts|conversations]',     Module\Contact::class);
 		});
+		$this->routeCollector->addRoute(['GET'],         '/credits',             Module\Credits::class);
+		$this->routeCollector->addGroup('/feed', function (RouteCollector $collector) {
+			$collector->addRoute(['GET'], '/{nickname}',                         Module\Feed::class);
+			$collector->addRoute(['GET'], '/{nickname}/posts',                   Module\Feed::class);
+			$collector->addRoute(['GET'], '/{nickname}/comments',                Module\Feed::class);
+			$collector->addRoute(['GET'], '/{nickname}/replies',                 Module\Feed::class);
+			$collector->addRoute(['GET'], '/{nickname}/activity',                Module\Feed::class);
+		});
+		$this->routeCollector->addRoute(['GET'],         '/feedtest',            Module\Feedtest::class);
+		$this->routeCollector->addRoute(['GET'],         '/filer[/{id:\d+}]',    Module\Filer::class);
+		$this->routeCollector->addRoute(['GET'],         '/followers/{owner}',   Module\Followers::class);
+		$this->routeCollector->addRoute(['GET'],         '/following/{owner}',   Module\Following::class);
+		$this->routeCollector->addGroup('/group', function (RouteCollector $collector) {
+			$collector->addRoute(['GET', 'POST'], '[/]',                         Module\Group::class);
+			$collector->addRoute(['GET', 'POST'], '/{group:\d+}',                Module\Group::class);
+			$collector->addRoute(['GET', 'POST'], '/none',                       Module\Group::class);
+			$collector->addRoute(['GET', 'POST'], '/new',                        Module\Group::class);
+			$collector->addRoute(['GET', 'POST'], '/drop/{group:\d+}',           Module\Group::class);
+			$collector->addRoute(['GET', 'POST'], '/{group:\d+}/{contact:\d+}',  Module\Group::class);
+
+			$collector->addRoute(['POST'], '/{group:\d+}/add/{contact:\d+}',     Module\Group::class);
+			$collector->addRoute(['POST'], '/{group:\d+}/remove/{contact:\d+}',  Module\Group::class);
+		});
+		$this->routeCollector->addRoute(['GET'],         '/hashtag',             Module\Hashtag::class);
+		$this->routeCollector->addRoute(['GET'],         '/inbox[/{nickname}]',  Module\Inbox::class);
+		$this->routeCollector->addGroup('/install', function (RouteCollector $collector) {
+			$collector->addRoute(['GET', 'POST'], '[/]',                         Module\Install::class);
+			$collector->addRoute(['GET'],         '/testrewrite',                Module\Install::class);
+		});
+		$this->routeCollector->addRoute(['GET', 'POST'], '/localtime',           Module\Localtime::class);
+		$this->routeCollector->addRoute(['GET', 'POST'], '/login',               Module\Login::class);
+		$this->routeCollector->addRoute(['GET'],         '/magic',               Module\Magic::class);
+		$this->routeCollector->addRoute(['GET'],         '/manifest',            Module\Manifest::class);
+		$this->routeCollector->addRoute(['GET'],         '/objects/{guid}',      Module\Objects::class);
+		$this->routeCollector->addGroup('/oembed', function (RouteCollector $collector) {
+			$collector->addRoute(['GET'], '/[b2h|h2b]',                          Module\Oembed::class);
+			$collector->addRoute(['GET'], '/{hash}',                             Module\Oembed::class);
+		});
+		$this->routeCollector->addRoute(['GET'],         '/outbox/{owner}',      Module\Outbox::class);
+		$this->routeCollector->addRoute(['GET'],         '/owa',                 Module\Owa::class);
+		$this->routeCollector->addGroup('/photo', function (RouteCollector $collector) {
+			$collector->addRoute(['GET'], '/{name}',                             Module\Photo::class);
+			$collector->addRoute(['GET'], '/{type}/{name}',                      Module\Photo::class);
+			$collector->addRoute(['GET'], '/{type}/{customize}/{name}',          Module\Photo::class);
+		});
+		$this->routeCollector->addGroup('/profile', function (RouteCollector $collector) {
+			$collector->addRoute(['GET'], '/{nickname}',                         Module\Profile::class);
+			$collector->addRoute(['GET'], '/{profile:\d+}/view',                 Module\Profile::class);
+		});
+		$this->routeCollector->addGroup('/proxy', function (RouteCollector $collector) {
+			$collector->addRoute(['GET'], '[/]',                                 Module\Proxy::class);
+			$collector->addRoute(['GET'], '/{url}',                              Module\Proxy::class);
+			$collector->addRoute(['GET'], '/sub1/{url}',                         Module\Proxy::class);
+			$collector->addRoute(['GET'], '/sub1/sub2/{url}',                    Module\Proxy::class);
+		});
+		$this->routeCollector->addRoute(['GET', 'POST'], '/register',            Module\Register::class);
+		$this->routeCollector->addRoute(['GET'],         '/statistics.json',     Module\Statistics::class);
+		$this->routeCollector->addRoute(['GET'],         '/tos',                 Module\Tos::class);
 	}
 
 	public function __construct(RouteCollector $routeCollector = null)

--- a/src/Module/Attach.php
+++ b/src/Module/Attach.php
@@ -8,8 +8,8 @@ namespace Friendica\Module;
 
 use Friendica\BaseModule;
 use Friendica\Core\L10n;
-use Friendica\Core\System;
 use Friendica\Core\Logger;
+use Friendica\Core\System;
 use Friendica\Model\Attach as MAttach;
 
 /**
@@ -26,8 +26,8 @@ class Attach extends BaseModule
 		if ($a->argc != 2) {
 			System::httpExit(400); // Bad Request.
 		}
-	
 
+		// @TODO: Replace with parameter from router
 		$item_id = intval($a->argv[1]);
 		
 		// Check for existence

--- a/src/Module/Contact.php
+++ b/src/Module/Contact.php
@@ -46,6 +46,7 @@ class Contact extends BaseModule
 
 		$contact_id = null;
 		$contact = null;
+		// @TODO: Replace with parameter from router
 		if ($a->argc == 2 && intval($a->argv[1])
 			|| $a->argc == 3 && intval($a->argv[1]) && in_array($a->argv[2], ['posts', 'conversations'])
 		) {
@@ -64,6 +65,7 @@ class Contact extends BaseModule
 
 		if (DBA::isResult($contact)) {
 			if ($contact['self']) {
+				// @TODO: Replace with parameter from router
 				if (($a->argc == 3) && intval($a->argv[1]) && in_array($a->argv[2], ['posts', 'conversations'])) {
 					$a->internalRedirect('profile/' . $contact['nick']);
 				} else {

--- a/src/Module/Feed.php
+++ b/src/Module/Feed.php
@@ -31,11 +31,13 @@ class Feed extends BaseModule
 		$last_update = defaults($_GET, 'last_update', '');
 		$nocache     = !empty($_GET['nocache']) && local_user();
 
+		// @TODO: Replace with parameter from router
 		if ($a->argc < 2) {
 			System::httpExit(400);
 		}
 
 		$type = null;
+		// @TODO: Replace with parameter from router
 		if ($a->argc > 2) {
 			$type = $a->argv[2];
 		}
@@ -53,6 +55,7 @@ class Feed extends BaseModule
 				$type = 'posts';
 		}
 
+		// @TODO: Replace with parameter from router
 		$nickname = $a->argv[1];
 		header("Content-type: application/atom+xml; charset=utf-8");
 		echo OStatus::feed($nickname, $last_update, 10, $type, $nocache, true);

--- a/src/Module/Filer.php
+++ b/src/Module/Filer.php
@@ -28,6 +28,7 @@ class Filer extends BaseModule
 		$logger = $a->getLogger();
 
 		$term = XML::unescape(trim(defaults($_GET, 'term', '')));
+		// @TODO: Replace with parameter from router
 		$item_id = (($a->argc > 1) ? intval($a->argv[1]) : 0);
 
 		$logger->info('filer', ['tag' => $term, 'item' => $item_id]);

--- a/src/Module/Followers.php
+++ b/src/Module/Followers.php
@@ -5,9 +5,9 @@
 namespace Friendica\Module;
 
 use Friendica\BaseModule;
-use Friendica\Protocol\ActivityPub;
 use Friendica\Core\System;
 use Friendica\Model\User;
+use Friendica\Protocol\ActivityPub;
 
 /**
  * ActivityPub Followers
@@ -18,10 +18,12 @@ class Followers extends BaseModule
 	{
 		$a = self::getApp();
 
+		// @TODO: Replace with parameter from router
 		if (empty($a->argv[1])) {
 			System::httpExit(404);
 		}
 
+		// @TODO: Replace with parameter from router
 		$owner = User::getOwnerDataByNick($a->argv[1]);
 		if (empty($owner)) {
 			System::httpExit(404);

--- a/src/Module/Following.php
+++ b/src/Module/Following.php
@@ -5,9 +5,9 @@
 namespace Friendica\Module;
 
 use Friendica\BaseModule;
-use Friendica\Protocol\ActivityPub;
 use Friendica\Core\System;
 use Friendica\Model\User;
+use Friendica\Protocol\ActivityPub;
 
 /**
  * ActivityPub Following
@@ -18,10 +18,12 @@ class Following extends BaseModule
 	{
 		$a = self::getApp();
 
+		// @TODO: Replace with parameter from router
 		if (empty($a->argv[1])) {
 			System::httpExit(404);
 		}
 
+		// @TODO: Replace with parameter from router
 		$owner = User::getOwnerDataByNick($a->argv[1]);
 		if (empty($owner)) {
 			System::httpExit(404);

--- a/src/Module/Group.php
+++ b/src/Module/Group.php
@@ -32,6 +32,7 @@ class Group extends BaseModule
 			$a->internalRedirect();
 		}
 
+		// @TODO: Replace with parameter from router
 		if (($a->argc == 2) && ($a->argv[1] === 'new')) {
 			BaseModule::checkFormSecurityTokenRedirectOnError('/group/new', 'group_edit');
 
@@ -49,6 +50,7 @@ class Group extends BaseModule
 			$a->internalRedirect('group');
 		}
 
+		// @TODO: Replace with parameter from router
 		if (($a->argc == 2) && intval($a->argv[1])) {
 			BaseModule::checkFormSecurityTokenRedirectOnError('/group', 'group_edit');
 
@@ -77,6 +79,7 @@ class Group extends BaseModule
 
 			// POST /group/123/add/123
 			// POST /group/123/remove/123
+			// @TODO: Replace with parameter from router
 			if ($a->argc == 4) {
 				list($group_id, $command, $contact_id) = array_slice($a->argv, 1);
 
@@ -142,6 +145,7 @@ class Group extends BaseModule
 		$a->page['aside'] = Model\Group::sidebarWidget('contact', 'group', 'extended', (($a->argc > 1) ? $a->argv[1] : 'everyone'));
 
 		// With no group number provided we jump to the unassigned contacts as a starting point
+		// @TODO: Replace with parameter from router
 		if ($a->argc == 1) {
 			$a->internalRedirect('group/none');
 		}
@@ -160,6 +164,7 @@ class Group extends BaseModule
 			'$submit_filter' => L10n::t('Filter'),
 		];
 
+		// @TODO: Replace with parameter from router
 		if (($a->argc == 2) && ($a->argv[1] === 'new')) {
 			return Renderer::replaceMacros($tpl, $context + [
 				'$title' => L10n::t('Create a group of contacts/friends.'),
@@ -190,9 +195,11 @@ class Group extends BaseModule
 			];
 		}
 
+		// @TODO: Replace with parameter from router
 		if (($a->argc == 3) && ($a->argv[1] === 'drop')) {
 			BaseModule::checkFormSecurityTokenRedirectOnError('/group', 'group_drop', 't');
 
+			// @TODO: Replace with parameter from router
 			if (intval($a->argv[2])) {
 				if (!Model\Group::exists($a->argv[2], local_user())) {
 					notice(L10n::t('Group not found.'));
@@ -208,6 +215,7 @@ class Group extends BaseModule
 			$a->internalRedirect('group');
 		}
 
+		// @TODO: Replace with parameter from router
 		if (($a->argc > 2) && intval($a->argv[1]) && intval($a->argv[2])) {
 			BaseModule::checkFormSecurityTokenForbiddenOnError('group_member_change', 't');
 
@@ -216,6 +224,7 @@ class Group extends BaseModule
 			}
 		}
 
+		// @TODO: Replace with parameter from router
 		if (($a->argc > 1) && intval($a->argv[1])) {
 			$group = DBA::selectFirst('group', ['id', 'name'], ['id' => $a->argv[1], 'uid' => local_user(), 'deleted' => false]);
 			if (!DBA::isResult($group)) {

--- a/src/Module/Inbox.php
+++ b/src/Module/Inbox.php
@@ -6,12 +6,12 @@
 namespace Friendica\Module;
 
 use Friendica\BaseModule;
+use Friendica\Core\Config;
 use Friendica\Core\Logger;
-use Friendica\Protocol\ActivityPub;
 use Friendica\Core\System;
 use Friendica\Database\DBA;
+use Friendica\Protocol\ActivityPub;
 use Friendica\Util\HTTPSignature;
-use Friendica\Core\Config;
 
 /**
  * ActivityPub Inbox
@@ -39,6 +39,7 @@ class Inbox extends BaseModule
 			Logger::log('Incoming message stored under ' . $tempfile);
 		}
 
+		// @TODO: Replace with parameter from router
 		if (!empty($a->argv[1])) {
 			$user = DBA::selectFirst('user', ['uid'], ['nickname' => $a->argv[1]]);
 			if (!DBA::isResult($user)) {

--- a/src/Module/Install.php
+++ b/src/Module/Install.php
@@ -56,6 +56,7 @@ class Install extends BaseModule
 
 		// route: install/testrwrite
 		// $baseurl/install/testrwrite to test if rewrite in .htaccess is working
+		// @TODO: Replace with parameter from router
 		if ($a->getArgumentValue(1, '') == 'testrewrite') {
 			// Status Code 204 means that it worked without content
 			Core\System::httpExit(204);

--- a/src/Module/Itemsource.php
+++ b/src/Module/Itemsource.php
@@ -2,12 +2,9 @@
 
 namespace Friendica\Module;
 
-use Friendica\Content\Text\HTML;
 use Friendica\Core\L10n;
 use Friendica\Core\Renderer;
 use Friendica\Model;
-use Friendica\Protocol\ActivityPub\Processor;
-use Friendica\Protocol\Diaspora;
 
 /**
  * @author Hypolite Petovan <mrpetovan@gmail.com>
@@ -22,6 +19,7 @@ class Itemsource extends \Friendica\BaseModule
 
 		$a = self::getApp();
 
+		// @TODO: Replace with parameter from router
 		if (!empty($a->argv[1])) {
 			$guid = $a->argv[1];
 		}

--- a/src/Module/Objects.php
+++ b/src/Module/Objects.php
@@ -5,11 +5,10 @@
 namespace Friendica\Module;
 
 use Friendica\BaseModule;
-use Friendica\Protocol\ActivityPub;
 use Friendica\Core\System;
-use Friendica\Model\Item;
 use Friendica\Database\DBA;
-use Friendica\Util\HTTPSignature;
+use Friendica\Model\Item;
+use Friendica\Protocol\ActivityPub;
 
 /**
  * ActivityPub Objects
@@ -32,9 +31,11 @@ class Objects extends BaseModule
 		// $requester = HTTPSignature::getSigner('', $_SERVER);
 
 		// At first we try the original post with that guid
+		// @TODO: Replace with parameter from router
 		$item = Item::selectFirst(['id'], ['guid' => $a->argv[1], 'origin' => true, 'private' => false]);
 		if (!DBA::isResult($item)) {
 			// If no original post could be found, it could possibly be a forum post, there we remove the "origin" field.
+			// @TODO: Replace with parameter from router
 			$item = Item::selectFirst(['id', 'author-link'], ['guid' => $a->argv[1], 'private' => false]);
 			if (!DBA::isResult($item) || !strstr($item['author-link'], System::baseUrl())) {
 				System::httpExit(404);

--- a/src/Module/Oembed.php
+++ b/src/Module/Oembed.php
@@ -35,6 +35,7 @@ class Oembed extends BaseModule
 			exit();
 		}
 
+		// @TODO: Replace with parameter from router
 		if ($a->argc == 2) {
 			echo '<html><body>';
 			$url = Strings::base64UrlDecode($a->argv[1]);

--- a/src/Module/Outbox.php
+++ b/src/Module/Outbox.php
@@ -5,10 +5,9 @@
 namespace Friendica\Module;
 
 use Friendica\BaseModule;
-use Friendica\Protocol\ActivityPub;
 use Friendica\Core\System;
 use Friendica\Model\User;
-use Friendica\Util\HTTPSignature;
+use Friendica\Protocol\ActivityPub;
 
 /**
  * ActivityPub Outbox
@@ -19,6 +18,7 @@ class Outbox extends BaseModule
 	{
 		$a = self::getApp();
 
+		// @TODO: Replace with parameter from router
 		if (empty($a->argv[1])) {
 			System::httpExit(404);
 		}

--- a/src/Module/Photo.php
+++ b/src/Module/Photo.php
@@ -25,6 +25,7 @@ class Photo extends BaseModule
 	public static function init()
 	{
 		$a = self::getApp();
+		// @TODO: Replace with parameter from router
 		if ($a->argc <= 1 || $a->argc > 4) {
 			System::httpExit(400);
 		}
@@ -47,6 +48,7 @@ class Photo extends BaseModule
 
 		$customsize = 0;
 		$photo = false;
+		// @TODO: Replace with parameter from router
 		switch($a->argc) {
 			case 4:
 				$customsize = intval($a->argv[2]);

--- a/src/Module/Profile.php
+++ b/src/Module/Profile.php
@@ -16,7 +16,7 @@ use Friendica\Database\DBA;
 use Friendica\Model\Contact as ContactModel;
 use Friendica\Model\Group;
 use Friendica\Model\Item;
-use Friendica\Model\Profile AS ProfileModel;
+use Friendica\Model\Profile as ProfileModel;
 use Friendica\Model\User;
 use Friendica\Protocol\ActivityPub;
 use Friendica\Protocol\DFRN;
@@ -36,12 +36,14 @@ class Profile extends BaseModule
 	{
 		$a = self::getApp();
 
+		// @TODO: Replace with parameter from router
 		if ($a->argc < 2) {
 			System::httpExit(400);
 		}
 
 		self::$which = filter_var($a->argv[1], FILTER_SANITIZE_STRING, FILTER_FLAG_STRIP_LOW | FILTER_FLAG_STRIP_HIGH | FILTER_FLAG_STRIP_BACKTICK);
 
+		// @TODO: Replace with parameter from router
 		if (local_user() && $a->argc > 2 && $a->argv[2] === 'view') {
 			self::$which = $a->user['nickname'];
 			self::$profile = filter_var($a->argv[1], FILTER_SANITIZE_NUMBER_INT);

--- a/src/Module/Proxy.php
+++ b/src/Module/Proxy.php
@@ -12,7 +12,6 @@ use Friendica\Model\Photo;
 use Friendica\Object\Image;
 use Friendica\Util\HTTPSignature;
 use Friendica\Util\Proxy as ProxyUtils;
-use Friendica\Core\Logger;
 
 /**
  * @brief Module Proxy
@@ -159,6 +158,7 @@ class Proxy extends BaseModule
 		$sizetype = '';
 
 		// Look for filename in the arguments
+		// @TODO: Replace with parameter from router
 		if (($a->argc > 1) && !isset($_REQUEST['url'])) {
 			if (isset($a->argv[3])) {
 				$url = $a->argv[3];
@@ -169,6 +169,7 @@ class Proxy extends BaseModule
 			}
 
 			/// @TODO: Why? And what about $url in this case?
+			/// @TODO: Replace with parameter from router
 			if (isset($a->argv[3]) && ($a->argv[3] == 'thumb')) {
 				$size = 200;
 			}

--- a/src/Module/Register.php
+++ b/src/Module/Register.php
@@ -19,7 +19,7 @@ use Friendica\Util\Strings;
 /**
  * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
-abstract class Register extends BaseModule
+class Register extends BaseModule
 {
 	const CLOSED  = 0;
 	const APPROVE = 1;

--- a/src/Module/Statistics.php
+++ b/src/Module/Statistics.php
@@ -6,7 +6,7 @@ use Friendica\BaseModule;
 use Friendica\Core\Addon;
 use Friendica\Core\System;
 
-class Statistics_json extends BaseModule
+class Statistics extends BaseModule
 {
 	public static function init()
 	{


### PR DESCRIPTION
Part of #4090 
FollowUp #6969 

I added a routing rule for every Module, which extends `BaseModule`.
=> As a FollowUp, we can now remove the old `BaseModule` routing

- I tested every route once if it's possible
- I added `@TODO` to every used App-parameter inside a BaseModule

@MrPetovan we can think about a more general way to use the routing parameters instead of `App->argv` and `App->argc` in followups. I mark every occurrence I found so far ;-)