### PR TITLE
Remove App->error

### DIFF
--- a/mod/hcard.php
+++ b/mod/hcard.php
@@ -18,7 +18,6 @@ function hcard_init(App $a)
 		$which = $a->argv[1];
 	} else {
 		notice(L10n::t('No profile') . EOL);
-		$a->error = 404;
 		return;
 	}
 

--- a/mod/notice.php
+++ b/mod/notice.php
@@ -16,7 +16,6 @@ function notice_init(App $a)
 		$nick = $r[0]['nickname'];
 		$a->internalRedirect('display/' . $nick . '/' . $id);
 	} else {
-		$a->error = 404;
 		notice(L10n::t('Item not found.') . EOL);
 	}
 

--- a/mod/videos.php
+++ b/mod/videos.php
@@ -84,33 +84,6 @@ function videos_post(App $a)
 	}
 
 	if (($a->argc == 2) && !empty($_POST['delete']) && !empty($_POST['id'])) {
-		// Check if we should do HTML-based delete confirmation
-		if (empty($_REQUEST['confirm'])) {
-			if (!empty($_REQUEST['canceled'])) {
-				$a->internalRedirect('videos/' . $a->data['user']['nickname']);
-			}
-
-			$drop_url = $a->query_string;
-
-			$a->page['content'] = Renderer::replaceMacros(Renderer::getMarkupTemplate('confirm.tpl'), [
-				'$method' => 'post',
-				'$message' => L10n::t('Do you really want to delete this video?'),
-				'$extra_inputs' => [
-					['name' => 'id'    , 'value' => $_POST['id']],
-					['name' => 'delete', 'value' => 'x']
-				],
-				'$confirm' => L10n::t('Delete Video'),
-				'$confirm_url' => $drop_url,
-				'$confirm_name' => 'confirm', // Needed so that confirmation will bring us back into this if statement
-				'$cancel' => L10n::t('Cancel'),
-
-			]);
-
-			$a->error = 1; // Set $a->error so the other module functions don't execute
-
-			return;
-		}
-
 		$video_id = $_POST['id'];
 
 		if (Attach::exists(['id' => $video_id, 'uid' => local_user()])) {

--- a/mod/viewsrc.php
+++ b/mod/viewsrc.php
@@ -18,7 +18,6 @@ function viewsrc_content(App $a)
 	$item_id = (($a->argc > 1) ? intval($a->argv[1]) : 0);
 
 	if (!$item_id) {
-		$a->error = 404;
 		notice(L10n::t('Item not found.') . EOL);
 		return;
 	}

--- a/src/App.php
+++ b/src/App.php
@@ -49,7 +49,6 @@ class App
 	public $page_contact;
 	public $content;
 	public $data = [];
-	public $error = false;
 	public $cmd = '';
 	public $argv;
 	public $argc;
@@ -1252,9 +1251,7 @@ class App
 
 			// "rawContent" is especially meant for technical endpoints.
 			// This endpoint doesn't need any theme initialization or other comparable stuff.
-			if (!$this->error) {
 				call_user_func([$this->module_class, 'rawContent']);
-			}
 		}
 
 		// Load current theme info after module has been initialized as theme could have been set in module
@@ -1269,24 +1266,20 @@ class App
 		}
 
 		if ($this->module_class) {
-			if (! $this->error && $_SERVER['REQUEST_METHOD'] === 'POST') {
+			if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 				Core\Hook::callAll($this->module . '_mod_post', $_POST);
 				call_user_func([$this->module_class, 'post']);
 			}
 
-			if (! $this->error) {
 				Core\Hook::callAll($this->module . '_mod_afterpost', $placeholder);
 				call_user_func([$this->module_class, 'afterpost']);
-			}
 
-			if (! $this->error) {
 				$arr = ['content' => $content];
 				Core\Hook::callAll($this->module . '_mod_content', $arr);
 				$content = $arr['content'];
 				$arr = ['content' => call_user_func([$this->module_class, 'content'])];
 				Core\Hook::callAll($this->module . '_mod_aftercontent', $arr);
 				$content .= $arr['content'];
-			}
 		}
 
 		// initialise content region

--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -113,7 +113,6 @@ class Profile
 		if (!DBA::isResult($user) && empty($profiledata)) {
 			Logger::log('profile error: ' . $a->query_string, Logger::DEBUG);
 			notice(L10n::t('Requested account is not available.') . EOL);
-			$a->error = 404;
 			return;
 		}
 
@@ -131,7 +130,6 @@ class Profile
 		if (empty($pdata) && empty($profiledata)) {
 			Logger::log('profile error: ' . $a->query_string, Logger::DEBUG);
 			notice(L10n::t('Requested profile is not available.') . EOL);
-			$a->error = 404;
 			return;
 		}
 

--- a/view/templates/album_edit.tpl
+++ b/view/templates/album_edit.tpl
@@ -9,7 +9,6 @@
 <div id="photo-album-edit-name-end"></div>
 
 <input id="photo-album-edit-submit" type="submit" name="submit" value="{{$submit}}" />
-<input id="photo-album-edit-drop" type="submit" name="dropalbum" value="{{$dropsubmit}}" onclick="return confirmDelete();" />
 
 </form>
 </div>

--- a/view/templates/photo_album.tpl
+++ b/view/templates/photo_album.tpl
@@ -3,6 +3,12 @@
 {{if $edit}}
 <div id="album-edit-link"><a href="{{$edit.1}}" title="{{$edit.0}}">{{$edit.0}}</a></div>
 {{/if}}
+{{if $edit}}
+<div id="album-edit-link"><a href="{{$edit.1}}" title="{{$edit.0}}">{{$edit.0}}</a></div>
+{{/if}}
+{{if $drop}}
+<div id="album-drop-link"><a href="{{$drop.1}}" title="{{$drop.0}}">{{$drop.0}}</a></div>
+{{/if}}
 <div class="photos-upload-link" ><a href="{{$order.1}}" title="{{$order.0}}">{{$order.0}}</a></div>
 {{if $can_post}}
 <div class="photos-upload-link" ><a href="{{$upload.1}}">{{$upload.0}}</a></div>

--- a/view/templates/photo_edit.tpl
+++ b/view/templates/photo_edit.tpl
@@ -1,6 +1,5 @@
 
-
-<form action="photos/{{$nickname}}/{{$resource_id}}" method="post" id="photo_edit_form" >
+<form action="photos/{{$nickname}}/image/{{$resource_id}}/edit" method="post" id="photo_edit_form" >
 
 	<input type="hidden" name="item_id" value="{{$item_id}}" />
 	<input type="hidden" name="origaname" value="{{$album.2}}" />
@@ -28,9 +27,6 @@
 	<div id="photo-edit-perms-end"></div>
 
 	<input id="photo-edit-submit-button" type="submit" name="submit" value="{{$submit}}" />
-	<input id="photo-edit-delete-button" type="submit" name="delete" value="{{$delete}}" onclick="return confirmDelete();" />
 
 	<div id="photo-edit-end"></div>
 </form>
-
-

--- a/view/templates/photo_view.tpl
+++ b/view/templates/photo_view.tpl
@@ -4,11 +4,22 @@
 
 <div id="photo-edit-link-wrap">
 {{if $tools}}
-<a id="photo-edit-link" href="{{$tools.edit.0}}">{{$tools.edit.1}}</a>
-|
-<a id="photo-toprofile-link" href="{{$tools.profile.0}}">{{$tools.profile.1}}</a>
+	{{if $tools.view}}
+		<a id="photo-view-link" href="{{$tools.view.0}}">{{$tools.view.1}}</a>
+	{{/if}}
+	{{if $tools.edit}}
+		<a id="photo-edit-link" href="{{$tools.edit.0}}">{{$tools.edit.1}}</a>
+	{{/if}}
+	{{if $tools.delete}}
+		| <a id="photo-edit-link" href="{{$tools.delete.0}}">{{$tools.delete.1}}</a>
+	{{/if}}
+	{{if $tools.profile}}
+		| <a id="photo-toprofile-link" href="{{$tools.profile.0}}">{{$tools.profile.1}}</a>
+	{{/if}}
+	{{if $tools.lock}}
+		| <img src="images/lock_icon.gif" class="lockview" alt="{{$tools.lock}}" onclick="lockview(event,'photo/{{$id}}');" />
+	{{/if}}
 {{/if}}
-{{if $lock}} | <img src="images/lock_icon.gif" class="lockview" alt="{{$lock}}" onclick="lockview(event,'photo/{{$id}}');" /> {{/if}}
 </div>
 
 {{if $prevlink}}<div id="photo-prev-link"><a href="{{$prevlink.0}}">{{$prevlink.1 nofilter}}</a></div>{{/if}}

--- a/view/theme/frio/js/mod_photos.js
+++ b/view/theme/frio/js/mod_photos.js
@@ -23,6 +23,15 @@ $(document).ready(function() {
 			addToModal(modalUrl, 'photo-album-edit-wrapper');
 		}
 	});
+
+	// Click event listener for the album drop link/button.
+	$("body").on('click', '#album-drop-link', function() {
+		var modalUrl = $(this).attr("data-modal-url");
+
+		if (typeof modalUrl !== "undefined") {
+			addToModal(modalUrl);
+		}
+	});
 });
 
 $(window).load(function() {

--- a/view/theme/frio/templates/album_edit.tpl
+++ b/view/theme/frio/templates/album_edit.tpl
@@ -7,7 +7,6 @@
 
 		<div class="pull-right">
 			<input class="btn-primary btn btn-small" id="photo-album-edit-submit" type="submit" name="submit" value="{{$submit}}" />
-			<input class="btn-primary btn btn-small" id="photo-album-edit-drop" type="submit" name="dropalbum" value="{{$dropsubmit}}" onclick="return confirmDelete();" />
 		</div>
 	</form>
 	<div class="clear"></div>

--- a/view/theme/frio/templates/confirm.tpl
+++ b/view/theme/frio/templates/confirm.tpl
@@ -1,6 +1,5 @@
 
-<form action="{{$confirm_url}}" id="confirm-form" method="{{$method}}">
-
+<form action="{{$confirm_url}}" id="confirm-form" method="{{$method}}" class="generic-page-wrapper">
 	<div id="confirm-message">{{$message}}</div>
 	{{foreach $extra_inputs as $input}}
 	<input type="hidden" name="{{$input.name}}" value="{{$input.value}}" />
@@ -10,5 +9,4 @@
 		<button type="submit" name="{{$confirm_name}}" id="confirm-submit-button" class="btn btn-primary confirm-button" value="{{$confirm}}">{{$confirm}}</button>
 		<button type="submit" name="canceled" id="confirm-cancel-button" class="btn confirm-button" data-dismiss="modal">{{$cancel}}</button>
 	</div>
-
 </form>

--- a/view/theme/frio/templates/photo_album.tpl
+++ b/view/theme/frio/templates/photo_album.tpl
@@ -16,6 +16,12 @@
 			<i class="fa fa-pencil"></i>
 		</button>
 		{{/if}}
+		{{if $drop}}
+		<span class="icon-padding"> </span>
+		<button id="album-drop-link" class="btn-link page-action faded-icon" type="button" data-modal-url="{{$drop.1}}" title="{{$drop.0}}" data-toggle="tooltip">
+			<i class="fa fa-trash"></i>
+		</button>
+		{{/if}}
 
 		{{if ! $noorder}}
 		<span class="icon-padding"> </span>

--- a/view/theme/frio/templates/photo_view.tpl
+++ b/view/theme/frio/templates/photo_view.tpl
@@ -10,22 +10,38 @@
 		</a>
 	</div>
 	<div class="pull-right" id="photo-edit-link-wrap">
-		{{if $tools}}
+{{if $tools}}
+	{{if $tools.view}}
+		<span class="icon-padding"> </span>
+		<a id="photo-edit-link" href="{{$tools.view.0}}" title="{{$tools.view.1}}" data-toggle="tooltip">
+			<i class="page-action faded-icon fa fa-image"></i>
+		</a>
+	{{/if}}
+	{{if $tools.edit}}
 		<span class="icon-padding"> </span>
 		<a id="photo-edit-link" href="{{$tools.edit.0}}" title="{{$tools.edit.1}}" data-toggle="tooltip">
 			<i class="page-action faded-icon fa fa-pencil"></i>
 		</a>
+	{{/if}}
+	{{if $tools.delete}}
+		<span class="icon-padding"> </span>
+		<a id="photo-edit-link" href="{{$tools.delete.0}}" title="{{$tools.delete.1}}" data-toggle="tooltip">
+			<i class="page-action faded-icon fa fa-trash"></i>
+		</a>
+	{{/if}}
+	{{if $tools.profile}}
 		<span class="icon-padding"> </span>
 		<a id="photo-toprofile-link" href="{{$tools.profile.0}}" title="{{$tools.profile.1}}" data-toggle="tooltip">
 			<i class="page-action faded-icon fa fa-user"></i>
 		</a>
-		{{/if}}
-		{{if $lock}}
+	{{/if}}
+	{{if $tools.lock}}
 		<span class="icon-padding"> </span>
-		<a id="photo-lock-link" onclick="lockview(event,'photo/{{$id}}');" title="{{$lock}}" data-toggle="tooltip">
+		<a id="photo-lock-link" onclick="lockview(event,'photo/{{$id}}');" title="{{$tools.lock}}" data-toggle="tooltip">
 			<i class="page-action faded-icon fa fa-lock"></i>
 		</a>
-		{{/if}}
+	{{/if}}
+{{/if}}
 	</div>
 	<div class="clear"></div>
 
@@ -80,10 +96,12 @@
 		<hr>
 	</div>
 
+{{if !$edit}}
 	{{* Insert the comments *}}
 	<div id="photo-comment-wrapper-{{$id}}" class="photo-comment-wrapper">
 		{{$comments nofilter}}
 	</div>
 
 	{{$paginate nofilter}}
+{{/if}}
 </div>

--- a/view/theme/quattro/templates/photo_view.tpl
+++ b/view/theme/quattro/templates/photo_view.tpl
@@ -3,11 +3,22 @@
 
 <div id="photo-edit-link-wrap">
 {{if $tools}}
-<a id="photo-edit-link" href="{{$tools.edit.0}}">{{$tools.edit.1}}</a>
-|
-<a id="photo-toprofile-link" href="{{$tools.profile.0}}">{{$tools.profile.1}}</a>
+    {{if $tools.view}}
+        <a id="photo-view-link" href="{{$tools.view.0}}">{{$tools.view.1}}</a>
+    {{/if}}
+    {{if $tools.edit}}
+        <a id="photo-edit-link" href="{{$tools.edit.0}}">{{$tools.edit.1}}</a>
+    {{/if}}
+    {{if $tools.delete}}
+        | <a id="photo-edit-link" href="{{$tools.delete.0}}">{{$tools.delete.1}}</a>
+    {{/if}}
+    {{if $tools.profile}}
+        | <a id="photo-toprofile-link" href="{{$tools.profile.0}}">{{$tools.profile.1}}</a>
+    {{/if}}
+    {{if $tools.lock}}
+        | <img src="images/lock_icon.gif" class="lockview" alt="{{$tools.lock}}" onclick="lockview(event,'photo/{{$id}}');" />
+    {{/if}}
 {{/if}}
-{{if $lock}} | <img src="images/lock_icon.gif" class="lockview" alt="{{$lock}}" onclick="lockview(event,'photo/{{$id}}');" /> {{/if}}
 </div>
 
 <div id="photo-photo"><a href="{{$photo.href}}" title="{{$photo.title}}"><img src="{{$photo.src}}" /></a></div>

--- a/view/theme/vier/templates/photo_view.tpl
+++ b/view/theme/vier/templates/photo_view.tpl
@@ -4,11 +4,22 @@
 
 <div id="photo-edit-link-wrap">
 {{if $tools}}
-<a id="photo-edit-link" href="{{$tools.edit.0}}">{{$tools.edit.1}}</a>
-|
-<a id="photo-toprofile-link" href="{{$tools.profile.0}}">{{$tools.profile.1}}</a>
+	{{if $tools.view}}
+		<a id="photo-view-link" href="{{$tools.view.0}}">{{$tools.view.1}}</a>
+	{{/if}}
+	{{if $tools.edit}}
+		<a id="photo-edit-link" href="{{$tools.edit.0}}">{{$tools.edit.1}}</a>
+	{{/if}}
+	{{if $tools.delete}}
+		| <a id="photo-edit-link" href="{{$tools.delete.0}}">{{$tools.delete.1}}</a>
+	{{/if}}
+	{{if $tools.profile}}
+		| <a id="photo-toprofile-link" href="{{$tools.profile.0}}">{{$tools.profile.1}}</a>
+	{{/if}}
+	{{if $tools.lock}}
+		| <img src="images/lock_icon.gif" class="lockview" alt="{{$tools.lock}}" onclick="lockview(event,'photo/{{$id}}');" />
+	{{/if}}
 {{/if}}
-{{if $lock}} | <img src="images/lock_icon.gif" class="lockview" alt="{{$lock}}" onclick="lockview(event,'photo/{{$id}}');" /> {{/if}}
 </div>
 
 {{if $prevlink}}<div id="photo-prev-link"><a href="{{$prevlink.0}}">{{$prevlink.1 nofilter}}</a></div>{{/if}}


### PR DESCRIPTION
Part 1 of the breakdown of #7050 into smaller PRs.

I found out about the very convenient `App->error` class member that acts as a global flow modifier like an Exception without being an exception.

Before I introduce actual exception, this variable had to go. Unfortunately it was used in very questionable cases, like displaying content in `module_post` functions.

I took this opportunity to rework the UX of the `/photos` module, which is 43% less confusing to me now. Comments/interactions have been removed from the photo editing form and some confusing labels/icons have been fixed.

The removed `$a->error = 404;` statements will be replaced with proper exceptions in the next PR.