### PR TITLE
Move Console namespace one level up

### DIFF
--- a/src/Console/ArchiveContact.php
+++ b/src/Console/ArchiveContact.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Friendica\Core\Console;
+namespace Friendica\Console;
 
 use Friendica\Core\L10n;
 use Friendica\Database\DBA;

--- a/src/Console/AutomaticInstallation.php
+++ b/src/Console/AutomaticInstallation.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Friendica\Core\Console;
+namespace Friendica\Console;
 
 use Asika\SimpleConsole\Console;
 use Friendica\BaseObject;

--- a/src/Console/Cache.php
+++ b/src/Console/Cache.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Friendica\Core\Console;
+namespace Friendica\Console;
 
 use Asika\SimpleConsole\CommandArgsException;
 use Friendica\App;

--- a/src/Console/Config.php
+++ b/src/Console/Config.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Friendica\Core\Console;
+namespace Friendica\Console;
 
 use Asika\SimpleConsole\CommandArgsException;
 use Friendica\App;

--- a/src/Console/CreateDoxygen.php
+++ b/src/Console/CreateDoxygen.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Friendica\Core\Console;
+namespace Friendica\Console;
 
 /**
  * Description of CreateDoxygen

--- a/src/Console/DatabaseStructure.php
+++ b/src/Console/DatabaseStructure.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Friendica\Core\Console;
+namespace Friendica\Console;
 
 use Friendica\Core;
 use Friendica\Core\Update;

--- a/src/Console/DocBloxErrorChecker.php
+++ b/src/Console/DocBloxErrorChecker.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Friendica\Core\Console;
+namespace Friendica\Console;
 
 /**
  * When I installed docblox, I had the experience that it does not generate any output at all.

--- a/src/Console/Extract.php
+++ b/src/Console/Extract.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Friendica\Core\Console;
+namespace Friendica\Console;
 
 /**
  * Extracts translation strings from the Friendica project's files to be exported

--- a/src/Console/GlobalCommunityBlock.php
+++ b/src/Console/GlobalCommunityBlock.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Friendica\Core\Console;
+namespace Friendica\Console;
 
 use Friendica\Core\L10n;
 use Friendica\Model\Contact;

--- a/src/Console/GlobalCommunitySilence.php
+++ b/src/Console/GlobalCommunitySilence.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Friendica\Core\Console;
+namespace Friendica\Console;
 
 use Friendica\Core\Protocol;
 use Friendica\Database\DBA;

--- a/src/Console/Maintenance.php
+++ b/src/Console/Maintenance.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Friendica\Core\Console;
+namespace Friendica\Console;
 
 use Friendica\Core;
 

--- a/src/Console/NewPassword.php
+++ b/src/Console/NewPassword.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Friendica\Core\Console;
+namespace Friendica\Console;
 
 use Friendica\Core\L10n;
 use Friendica\Database\DBA;

--- a/src/Console/PhpToPo.php
+++ b/src/Console/PhpToPo.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Friendica\Core\Console;
+namespace Friendica\Console;
 
 /**
  * Read a strings.php file and create messages.po in the same directory

--- a/src/Console/PoToPhp.php
+++ b/src/Console/PoToPhp.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Friendica\Core\Console;
+namespace Friendica\Console;
 
 /**
  * Read a messages.po file and create strings.php in the same directory

--- a/src/Console/PostUpdate.php
+++ b/src/Console/PostUpdate.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Friendica\Core\Console;
+namespace Friendica\Console;
 
 use Friendica\Core\Config;
 use Friendica\Core\L10n;

--- a/src/Console/ServerBlock.php
+++ b/src/Console/ServerBlock.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Friendica\Core\Console;
+namespace Friendica\Console;
 
 use Asika\SimpleConsole\CommandArgsException;
 use Asika\SimpleConsole\Console;

--- a/src/Console/Storage.php
+++ b/src/Console/Storage.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Friendica\Core\Console;
+namespace Friendica\Console;
 
 use Asika\SimpleConsole\CommandArgsException;
 use Friendica\Core\StorageManager;

--- a/src/Console/Typo.php
+++ b/src/Console/Typo.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Friendica\Core\Console;
+namespace Friendica\Console;
 
 use Friendica\BaseObject;
 

--- a/src/Core/Console.php
+++ b/src/Core/Console.php
@@ -2,6 +2,8 @@
 
 namespace Friendica\Core;
 
+use Friendica;
+
 /**
  * Description of Console
  *
@@ -47,24 +49,24 @@ HELP;
 	}
 
 	protected $subConsoles = [
-		'cache'                  => __NAMESPACE__ . '\Console\Cache',
-		'config'                 => __NAMESPACE__ . '\Console\Config',
-		'createdoxygen'          => __NAMESPACE__ . '\Console\CreateDoxygen',
-		'docbloxerrorchecker'    => __NAMESPACE__ . '\Console\DocBloxErrorChecker',
-		'dbstructure'            => __NAMESPACE__ . '\Console\DatabaseStructure',
-		'extract'                => __NAMESPACE__ . '\Console\Extract',
-		'globalcommunityblock'   => __NAMESPACE__ . '\Console\GlobalCommunityBlock',
-		'globalcommunitysilence' => __NAMESPACE__ . '\Console\GlobalCommunitySilence',
-		'archivecontact'         => __NAMESPACE__ . '\Console\ArchiveContact',
-		'autoinstall'            => __NAMESPACE__ . '\Console\AutomaticInstallation',
-		'maintenance'            => __NAMESPACE__ . '\Console\Maintenance',
-		'newpassword'            => __NAMESPACE__ . '\Console\NewPassword',
-		'php2po'                 => __NAMESPACE__ . '\Console\PhpToPo',
-		'po2php'                 => __NAMESPACE__ . '\Console\PoToPhp',
-		'typo'                   => __NAMESPACE__ . '\Console\Typo',
-		'postupdate'             => __NAMESPACE__ . '\Console\PostUpdate',
-		'serverblock'            => __NAMESPACE__ . '\Console\ServerBlock',
-		'storage'                => __NAMESPACE__ . '\Console\Storage',
+		'cache'                  => Friendica\Console\Cache::class,
+		'config'                 => Friendica\Console\Config::class,
+		'createdoxygen'          => Friendica\Console\CreateDoxygen::class,
+		'docbloxerrorchecker'    => Friendica\Console\DocBloxErrorChecker::class,
+		'dbstructure'            => Friendica\Console\DatabaseStructure::class,
+		'extract'                => Friendica\Console\Extract::class,
+		'globalcommunityblock'   => Friendica\Console\GlobalCommunityBlock::class,
+		'globalcommunitysilence' => Friendica\Console\GlobalCommunitySilence::class,
+		'archivecontact'         => Friendica\Console\ArchiveContact::class,
+		'autoinstall'            => Friendica\Console\AutomaticInstallation::class,
+		'maintenance'            => Friendica\Console\Maintenance::class,
+		'newpassword'            => Friendica\Console\NewPassword::class,
+		'php2po'                 => Friendica\Console\PhpToPo::class,
+		'po2php'                 => Friendica\Console\PoToPhp::class,
+		'typo'                   => Friendica\Console\Typo::class,
+		'postupdate'             => Friendica\Console\PostUpdate::class,
+		'serverblock'            => Friendica\Console\ServerBlock::class,
+		'storage'                => Friendica\Console\Storage::class,
 	];
 
 	protected function doExecute()

--- a/tests/src/Console/AutomaticInstallationConsoleTest.php
+++ b/tests/src/Console/AutomaticInstallationConsoleTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Friendica\Test\src\Core\Console;
+namespace Friendica\Test\src\Console;
 
+use Friendica\Console\AutomaticInstallation;
 use Friendica\Core\Config\Cache\ConfigCache;
-use Friendica\Core\Console\AutomaticInstallation;
 use Friendica\Core\Installer;
 use Friendica\Core\Logger;
 use Friendica\Test\Util\DBAMockTrait;

--- a/tests/src/Console/ConfigConsoleTest.php
+++ b/tests/src/Console/ConfigConsoleTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Friendica\Test\src\Core\Console;
+namespace Friendica\Test\src\Console;
 
 use Friendica\App\Mode;
-use Friendica\Core\Console\Config;
+use Friendica\Console\Config;
 
 /**
  * @runTestsInSeparateProcesses
@@ -116,7 +116,7 @@ class ConfigConsoleTest extends ConsoleTest
 		$executable = $this->consoleArgv[0];
 		$assertion = <<<CONF
 Executable: {$executable}
-Class: Friendica\Core\Console\Config
+Class: Friendica\Console\Config
 Arguments: array (
   0 => 'test',
   1 => 'it',

--- a/tests/src/Console/ConsoleTest.php
+++ b/tests/src/Console/ConsoleTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Friendica\Test\src\Core\Console;
+namespace Friendica\Test\src\Console;
 
 use Asika\SimpleConsole\Console;
 use Friendica\Test\MockedTest;

--- a/tests/src/Console/ServerBlockConsoleTest.php
+++ b/tests/src/Console/ServerBlockConsoleTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Friendica\Test\src\Core\Console;
+namespace Friendica\Test\src\Console;
 
-use Friendica\Core\Console\ServerBlock;
+use Friendica\Console\ServerBlock;
 
 /**
  * @runTestsInSeparateProcesses


### PR DESCRIPTION
I think that the `Friendica\Core\Console` namespace should be one hierarchy level up.

Because Console isn't a Core functionality. It's the same type of class like a Worker or a Module.
- You can directly interact (per user or per daemon)
- It mostly interacts with models/backend services
- It get's triggered by a own *.php file (console.php) like index.php or daemon.php