### PR TITLE
Update every AP contact once a week

### DIFF
--- a/src/Worker/Cron.php
+++ b/src/Worker/Cron.php
@@ -213,8 +213,8 @@ class Cron
 				$contact['priority'] = (!is_null($poll_interval) ? intval($poll_interval) : 3);
 			}
 
-			// Check Diaspora contacts or followers once a week
-			if (($contact["network"] == Protocol::DIASPORA) || ($contact["rel"] == Contact::FOLLOWER)) {
+			// Check ActivityPub and Diaspora contacts or followers once a week
+			if (in_array($contact["network"], [Protocol::ACTIVITYPUB, Protocol::DIASPORA]) || ($contact["rel"] == Contact::FOLLOWER)) {
 				$contact['priority'] = 4;
 			}
 


### PR DESCRIPTION
We now will update every ActivityPub contact once a week. This also helps with the problem that for unknown reasons sometimes DFRN contacts are being switched to AP. Now they will be checked every week and will eventually being switched back to DFRN.