### PR TITLE
Improve addon admin

### DIFF
--- a/src/Core/Addon.php
+++ b/src/Core/Addon.php
@@ -149,6 +149,8 @@ class Addon extends BaseObject
 			$func();
 		}
 
+		DBA::delete('hook', ['file' => 'addon/' . $addon . '/' . $addon . '.php']);
+
 		unset(self::$addons[array_search($addon, self::$addons)]);
 
 		Addon::saveEnabledList();

--- a/src/Module/Admin/Addons/Details.php
+++ b/src/Module/Admin/Addons/Details.php
@@ -48,7 +48,8 @@ class Details extends BaseAdminModule
 			$addon = $a->argv[2];
 			$addon = Strings::sanitizeFilePathItem($addon);
 			if (!is_file("addon/$addon/$addon.php")) {
-				notice(L10n::t('Item not found.'));
+				notice(L10n::t('Addon not found.'));
+				Addon::uninstall($addon);
 				$a->internalRedirect('admin/addons');
 			}
 


### PR DESCRIPTION
I wrote a couple of enhancements for the administration of addons:
1. Clicking on a now-deleted addon in the admin aside now uninstalls the removed addon. Otherwise there's no direct way of uninstalling an addon whose files have been removed and has a entry in the admin aside.
2. Uninstalling an addon removes all its hooks by default, removing the need of mentioning them one by one in the `addon_uninstall()` function, including past hooks that aren't in use anymore.

Please review https://github.com/friendica/friendica-addons/pull/854 as well that depends on this PR.