### PR TITLE
add new disallowed path for robots.txt

### DIFF
--- a/src/Module/RobotsTxt.php
+++ b/src/Module/RobotsTxt.php
@@ -15,6 +15,9 @@ class RobotsTxt extends BaseModule
 			'/settings/',
 			'/admin/',
 			'/message/',
+			'/search',
+			'/help',
+			'/proxy',
 		];
 
 		header('Content-Type: text/plain');


### PR DESCRIPTION
based on a heavy workload analysis on my server. I added these three paths. 
I think the most important is `/search`

```
cat /tmp/log.txt|grep "bot"|cut -d " " -f7|cut -d "/" -f2|cut -d "?" -f1|sort | uniq -c | sort -nr
151163 search
43331 display
32699 view
6081 robots.txt
4725 proxy
4284 toggle_mobile
4078 addon
2296 photo
1760 profile
1586 ping
```