### PR TITLE
make the addon listing in the admin panel aside working again

### DIFF
--- a/view/templates/admin/aside.tpl
+++ b/view/templates/admin/aside.tpl
@@ -29,11 +29,14 @@
 {{/if}}
 
 
-{{if $admin.addons_admin}}<h4>{{$plugadmtxt}}</h4>{{/if}}
+{{if $admin.addons_admin}}<h4>{{$plugadmtxt}}</h4>
 <ul class='admin linklist'>
-	{{foreach $admin.addons_admin as $l}}
-	<li class='admin link button {{$l.2}}'><a href='{{$l.0}}'>{{$l.1}}</a></li>
+	{{foreach $admin.addons_admin as $name => $item}}
+	<li role="menuitem" class="admin link button {{$item.class}}">
+		<a href="{{$item.url}}">{{$item.name}}</a>
+	</li>
 	{{/foreach}}
 </ul>
+{{/if}}
 	
 	


### PR DESCRIPTION
The listing of the active addons with separate system wide settings in the aside menu of the admin panel was not working in various themes.