### PR TITLE
pwdreset templated fixed HTML escaping

### DIFF
--- a/view/templates/pwdreset.tpl
+++ b/view/templates/pwdreset.tpl
@@ -11,8 +11,8 @@
 {{$newpass}}
 </p>
 <p>
-{{$lbl4}} {{$lbl5}}
+{{$lbl4 nofilter}} {{$lbl5 nofilter}}
 </p>
 <p>
-{{$lbl6}}
+{{$lbl6 nofilter}}
 </p>


### PR DESCRIPTION
In the template used during the password reset process the HTML formation of the text was filtered out due missing `nofilter` statements for the template.

Part of #6208