### PR TITLE
Contacts with protocol = AP are now delivered only via AP

### DIFF
--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -212,7 +212,7 @@ class Diaspora
 	 */
 	public static function participantsForThread($thread, array $contacts)
 	{
-		$r = DBA::p("SELECT `contact`.`batch`, `contact`.`id`, `contact`.`name`, `contact`.`network`,
+		$r = DBA::p("SELECT `contact`.`batch`, `contact`.`id`, `contact`.`name`, `contact`.`network`, `contact`.`protocol`,
 				`fcontact`.`batch` AS `fbatch`, `fcontact`.`network` AS `fnetwork` FROM `participation`
 				INNER JOIN `contact` ON `contact`.`id` = `participation`.`cid`
 				INNER JOIN `fcontact` ON `fcontact`.`id` = `participation`.`fid`
@@ -223,6 +223,10 @@ class Diaspora
 				$contact['network'] = $contact['fnetwork'];
 			}
 			unset($contact['fnetwork']);
+
+			if (empty($contact['protocol'])) {
+				$contact['protocol'] = $contact['network'];
+			}
 
 			if (empty($contact['batch']) && !empty($contact['fbatch'])) {
 				$contact['batch'] = $contact['fbatch'];


### PR DESCRIPTION
When two newer Friendica contacts do connect, then this is done via AP (see my recent PR). With this PR we now ensure that the message delivery is only done via AP to these contacts. (Except some currently unsupported or barely tested things)