### PR TITLE
Put embedding of private images in item creation

### DIFF
--- a/mod/item.php
+++ b/mod/item.php
@@ -698,6 +698,8 @@ function item_post(App $a) {
 		Item::setHashtags($datarray);
 	}
 
+	$datarray["body"] = Item::fixPrivatePhotos( $datarray["body"], $datarray["uid"], $datarray, 0 );
+
 	// preview mode - prepare the body for display and send it via json
 	if ($preview) {
 		// We set the datarray ID to -1 because in preview mode the dataray


### PR DESCRIPTION
This is a proposed change to address #5276 by moving the embedding of private images to during the initial item processing rather than the delivery step.  See that issue for more notes.  Feedback is welcome, I'm not 100% sure that this doesn't mess up some cases that I'm not testing for.