### PR TITLE
Fix database structure definition, primary keys must be marked as this

### DIFF
--- a/config/dbstructure.config.php
+++ b/config/dbstructure.config.php
@@ -41,8 +41,8 @@ return [
 	"2fa_recovery_codes" => [
 		"comment" => "Two-factor authentication recovery codes",
 		"fields" => [
-			"uid" => ["type" => "int unsigned", "not null" => "1", "comment" => "User ID"],
-			"code" => ["type" => "varchar(50)", "not null" => "1", "comment" => "Recovery code string"],
+			"uid" => ["type" => "mediumint unsigned", "not null" => "1", "primary" => "1", "relation" => ["user" => "uid"], "comment" => "User ID"],
+			"code" => ["type" => "varchar(50)", "not null" => "1", "primary" => "1", "comment" => "Recovery code string"],
 			"generated" => ["type" => "datetime", "not null" => "1", "comment" => "Datetime the code was generated"],
 			"used" => ["type" => "datetime", "comment" => "Datetime the code was used"],
 		],


### PR DESCRIPTION
Additionally ```uid``` fields are having a different type and the relation had been missing.