### PR TITLE
Allow null $tags parameter in ActivityPub\Processor::constructTagString

### DIFF
--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -64,10 +64,9 @@ class Processor
 	 *
 	 * @param array   $tags
 	 * @param boolean $sensitive
-	 * @param array   $implicit_mentions List of profile URLs to skip
 	 * @return string with tags
 	 */
-	private static function constructTagString(array $tags, $sensitive)
+	private static function constructTagString(array $tags = null, $sensitive = false)
 	{
 		if (empty($tags)) {
 			return '';


### PR DESCRIPTION
Addresses https://github.com/friendica/friendica/issues/6916#issuecomment-493218564