### PR TITLE
Fix for receiving direct messages from Mastodon

### DIFF
--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -173,7 +173,7 @@ class Processor
 			$item['object-type'] = ACTIVITY_OBJ_COMMENT;
 		}
 
-		if (($activity['id'] != $activity['reply-to-id']) && !Item::exists(['uri' => $activity['reply-to-id']])) {
+		if (empty($activity['directmessage']) && ($activity['id'] != $activity['reply-to-id']) && !Item::exists(['uri' => $activity['reply-to-id']])) {
 			Logger::log('Parent ' . $activity['reply-to-id'] . ' not found. Try to refetch it.');
 			self::fetchMissingActivity($activity['reply-to-id'], $activity);
 		}

--- a/src/Protocol/ActivityPub/Receiver.php
+++ b/src/Protocol/ActivityPub/Receiver.php
@@ -207,7 +207,13 @@ class Receiver
 				return [];
 			}
 			$object_data['object_id'] = $object_id;
-			$object_data['directmessage'] = JsonLD::fetchElement($activity, 'litepub:directMessage');
+
+			// Test if it is an answer to a mail
+			if (DBA::exists('mail', ['uri' => $object_data['reply-to-id']])) {
+				$object_data['directmessage'] = true;
+			} else {
+				$object_data['directmessage'] = JsonLD::fetchElement($activity, 'litepub:directMessage');
+			}
 
 			// We had been able to retrieve the object data - so we can trust the source
 			$trust_source = true;
@@ -935,11 +941,6 @@ class Receiver
 		}
 
 		$object_data['receiver'] = self::getReceivers($object, $object_data['actor'], $object_data['tags']);
-
-		// Test if it is an answer to a mail
-		if (DBA::exists('mail', ['uri' => $object_data['reply-to-id']])) {
-			$object_data['directmessage'] = true;
-		}
 
 		// Common object data:
 


### PR DESCRIPTION
Since Mastodon doesn't send a reliable indicator if a note is a direct message, we have to rely on looking if this had been an answer to one of our direct messages. But this check had been at the wrong place.