### PR TITLE
Contact requests blocked

### DIFF
--- a/include/api.php
+++ b/include/api.php
@@ -361,7 +361,7 @@ function api_call(App $a)
 			}
 		}
 
-		Logger::warning(API_LOG_PREFIX . 'not implemented', ['module' => 'api', 'action' => 'call']);
+		Logger::warning(API_LOG_PREFIX . 'not implemented', ['module' => 'api', 'action' => 'call', 'query' => $a->query_string]);
 		throw new NotImplementedException();
 	} catch (HTTPException $e) {
 		header("HTTP/1.1 {$e->getCode()} {$e->httpdesc}");

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -2137,10 +2137,15 @@ class Contact extends BaseObject
 			return false;
 		}
 
-		$fields = ['url', 'name', 'nick', 'photo', 'network'];
+		$fields = ['url', 'name', 'nick', 'photo', 'network', 'blocked'];
 		$pub_contact = DBA::selectFirst('contact', $fields, ['id' => $datarray['author-id']]);
 		if (!DBA::isResult($pub_contact)) {
 			// Should never happen
+			return false;
+		}
+
+		// Contact is blocked on node-level or user-level
+		if (!empty($pub_contact['blocked']) || !empty($contact['blocked'])) {
 			return false;
 		}
 

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -2144,8 +2144,8 @@ class Contact extends BaseObject
 			return false;
 		}
 
-		// Contact is blocked on node-level or user-level
-		if (!empty($pub_contact['blocked']) || !empty($contact['blocked'])) {
+		// Contact is blocked at node-level
+		if (self::isBlocked($datarray['author-id'])) {
 			return false;
 		}
 
@@ -2156,6 +2156,11 @@ class Contact extends BaseObject
 		$network = $pub_contact['network'];
 
 		if (!empty($contact)) {
+            // Contact is blocked at user-level
+		    if (self::isBlockedByUser($contact['id'], $importer['id'])) {
+		        return false;
+            }
+
 			// Make sure that the existing contact isn't archived
 			self::unmarkForArchival($contact);
 

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -542,6 +542,13 @@ class Processor
 		self::switchContact($item['author-id']);
 
 		$result = Contact::addRelationship($owner, $contact, $item, false, $note);
+		if ($result === false) {
+			ActivityPub\Transmitter::sendContactReject($item['author-link'], $item['author-id'], $owner['uid']);
+			return;
+		}elseif ($result === true) {
+			ActivityPub\Transmitter::sendContactAccept($item['author-link'], $item['author-id'], $owner['uid']);
+		}
+
 		$cid = Contact::getIdForURL($activity['actor'], $uid);
 		if (empty($cid)) {
 			return;

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -530,7 +530,7 @@ class Processor
 			DBA::update('contact', ['hub-verify' => $activity['id'], 'protocol' => Protocol::ACTIVITYPUB], ['id' => $cid]);
 			$contact = DBA::selectFirst('contact', [], ['id' => $cid, 'network' => Protocol::NATIVE_SUPPORT]);
 		} else {
-			$contact = false;
+			$contact = [];
 		}
 
 		$item = ['author-id' => Contact::getIdForURL($activity['actor']),
@@ -541,7 +541,7 @@ class Processor
 		// Ensure that the contact has got the right network type
 		self::switchContact($item['author-id']);
 
-		Contact::addRelationship($owner, $contact, $item, '', false, $note);
+		$result = Contact::addRelationship($owner, $contact, $item, false, $note);
 		$cid = Contact::getIdForURL($activity['actor'], $uid);
 		if (empty($cid)) {
 			return;

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -542,10 +542,7 @@ class Processor
 		self::switchContact($item['author-id']);
 
 		$result = Contact::addRelationship($owner, $contact, $item, false, $note);
-		if ($result === false) {
-			ActivityPub\Transmitter::sendContactReject($item['author-link'], $item['author-id'], $owner['uid']);
-			return;
-		}elseif ($result === true) {
+		if ($result === true) {
 			ActivityPub\Transmitter::sendContactAccept($item['author-link'], $item['author-id'], $owner['uid']);
 		}
 

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -1538,13 +1538,16 @@ class Transmitter
 			'id' => System::baseUrl() . '/activity/' . System::createGUID(),
 			'type' => 'Accept',
 			'actor' => $owner['url'],
-			'object' => ['id' => $id, 'type' => 'Follow',
+			'object' => [
+				'id' => (string)$id,
+				'type' => 'Follow',
 				'actor' => $profile['url'],
-				'object' => $owner['url']],
+				'object' => $owner['url']
+			],
 			'instrument' => self::getService(),
 			'to' => [$profile['url']]];
 
-		Logger::log('Sending accept to ' . $target . ' for user ' . $uid . ' with id ' . $id, Logger::DEBUG);
+		Logger::debug('Sending accept to ' . $target . ' for user ' . $uid . ' with id ' . $id);
 
 		$signed = LDSignature::sign($data, $owner);
 		HTTPSignature::transmit($signed, $profile['inbox'], $uid);
@@ -1568,13 +1571,16 @@ class Transmitter
 			'id' => System::baseUrl() . '/activity/' . System::createGUID(),
 			'type' => 'Reject',
 			'actor' => $owner['url'],
-			'object' => ['id' => $id, 'type' => 'Follow',
+			'object' => [
+				'id' => (string)$id,
+				'type' => 'Follow',
 				'actor' => $profile['url'],
-				'object' => $owner['url']],
+				'object' => $owner['url']
+			],
 			'instrument' => self::getService(),
 			'to' => [$profile['url']]];
 
-		Logger::log('Sending reject to ' . $target . ' for user ' . $uid . ' with id ' . $id, Logger::DEBUG);
+		Logger::debug('Sending reject to ' . $target . ' for user ' . $uid . ' with id ' . $id);
 
 		$signed = LDSignature::sign($data, $owner);
 		HTTPSignature::transmit($signed, $profile['inbox'], $uid);

--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -2247,13 +2247,12 @@ class DFRN
 			// The functions below are partly used by ostatus.php as well - where we have this variable
 			$r = q("SELECT * FROM `contact` WHERE `id` = %d", intval($importer["id"]));
 			$contact = $r[0];
-			$nickname = $contact["nick"];
 
 			// Big question: Do we need these functions? They were part of the "consume_feed" function.
 			// This function once was responsible for DFRN and OStatus.
 			if (activity_match($item["verb"], ACTIVITY_FOLLOW)) {
 				Logger::log("New follower");
-				Contact::addRelationship($importer, $contact, $item, $nickname);
+				Contact::addRelationship($importer, $contact, $item);
 				return false;
 			}
 			if (activity_match($item["verb"], ACTIVITY_UNFOLLOW)) {
@@ -2263,7 +2262,7 @@ class DFRN
 			}
 			if (activity_match($item["verb"], ACTIVITY_REQ_FRIEND)) {
 				Logger::log("New friend request");
-				Contact::addRelationship($importer, $contact, $item, $nickname, true);
+				Contact::addRelationship($importer, $contact, $item, true);
 				return false;
 			}
 			if (activity_match($item["verb"], ACTIVITY_UNFRIEND)) {

--- a/src/Protocol/OStatus.php
+++ b/src/Protocol/OStatus.php
@@ -417,13 +417,6 @@ class OStatus
 				$author = self::fetchAuthor($xpath, $entry, $importer, $contact, $stored);
 			}
 
-			$value = XML::getFirstNodeValue($xpath, 'atom:author/poco:preferredUsername/text()', $entry);
-			if ($value != "") {
-				$nickname = $value;
-			} else {
-				$nickname = $author["author-name"];
-			}
-
 			$item = array_merge($header, $author);
 
 			$item["uri"] = XML::getFirstNodeValue($xpath, 'atom:id/text()', $entry);
@@ -463,7 +456,7 @@ class OStatus
 			}
 
 			if ($item["verb"] == ACTIVITY_FOLLOW) {
-				Contact::addRelationship($importer, $contact, $item, $nickname);
+				Contact::addRelationship($importer, $contact, $item);
 				continue;
 			}
 

--- a/src/Util/JsonLD.php
+++ b/src/Util/JsonLD.php
@@ -68,9 +68,16 @@ class JsonLD
 		}
 		catch (Exception $e) {
 			$normalized = false;
-			Logger::error('normalise error');
-			// Sooner or later we should log some details as well - but currently this leads to memory issues
-			// Logger::log('normalise error:' . substr(print_r($e, true), 0, 10000), Logger::DEBUG);
+			$messages = [];
+			$currentException = $e;
+			do {
+				$messages[] = $currentException->getMessage();
+			} while($currentException = $currentException->getPrevious());
+
+			Logger::warning('JsonLD normalize error');
+			Logger::notice('JsonLD normalize error', ['messages' => $messages]);
+			Logger::info('JsonLD normalize error', ['trace' => $e->getTraceAsString()]);
+			Logger::debug('JsonLD normalize error', ['jsonobj' => $jsonobj]);
 		}
 
 		return $normalized;


### PR DESCRIPTION
Fixes #6981 

The big change in this PR is `Model\Contact::addRelationship` returning a value, either `true` for relationship establishment success, `null` for relationship establishment pending, and `false` for relationship establishment failure.

This allowed me to move AP-specific code out of this method and properly add a contact block provision to it.

Side fixes/improvements:
- SQL error in admin summary
- JsonLD exception handling
- API call not implemented logging