### PR TITLE
AP: We now transmit "add tag" activity

### DIFF
--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -3834,7 +3834,7 @@ class Diaspora
 		} elseif (in_array($item["verb"], [ACTIVITY_LIKE, ACTIVITY_DISLIKE])) {
 			$message = self::constructLike($item, $owner);
 			$type = "like";
-		} elseif (!in_array($item["verb"], [ACTIVITY_FOLLOW])) {
+		} elseif (!in_array($item["verb"], [ACTIVITY_FOLLOW, ACTIVITY_TAG])) {
 			$message = self::constructComment($item, $owner);
 			$type = "comment";
 		}


### PR DESCRIPTION
We recently discovered that adding tags hadn't worked over ActivityPub. This is the preparation to send this activity now. An upcoming PR will address the processing.

On Diaspora this message is now suppressed, since since this isn't supported there.