### PR TITLE
frio: Fix hovercard vanish

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,7 @@
 		"fxp/composer-asset-plugin": "~1.3",
 		"bower-asset/base64": "^1.0",
 		"bower-asset/chart-js": "^2.7",
+		"bower-asset/dompurify": "^1.0",
 		"bower-asset/perfect-scrollbar": "^0.6",
 		"bower-asset/vue": "^2.5",
 		"npm-asset/jquery": "^2.0",
@@ -56,8 +57,7 @@
 		"npm-asset/fullcalendar": "^3.0.1",
 		"npm-asset/cropperjs": "1.2.2",
 		"npm-asset/imagesloaded": "4.1.4",
-		"pear/console_table": "^1.3",
-		"bower-asset/dompurify": "^1.0"
+		"pear/console_table": "^1.3"
 	},
 	"repositories": [
 		{

--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,8 @@
 		"npm-asset/fullcalendar": "^3.0.1",
 		"npm-asset/cropperjs": "1.2.2",
 		"npm-asset/imagesloaded": "4.1.4",
-		"pear/console_table": "^1.3"
+		"pear/console_table": "^1.3",
+		"bower-asset/dompurify": "^1.0"
 	},
 	"repositories": [
 		{

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d7302553201de079b72871c0b2922ce7",
+    "content-hash": "350fdeacf9fcc039538e00a9a943f6d6",
     "packages": [
         {
             "name": "asika/simple-console",
@@ -147,6 +147,51 @@
             ],
             "description": "Base64 encoding and decoding",
             "time": "2017-03-25T21:16:21+00:00"
+        },
+        {
+            "name": "bower-asset/dompurify",
+            "version": "1.0.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cure53/DOMPurify.git",
+                "reference": "b537cab466329b1b077e0e5e3c14edad2b7142f7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cure53/DOMPurify/zipball/b537cab466329b1b077e0e5e3c14edad2b7142f7",
+                "reference": "b537cab466329b1b077e0e5e3c14edad2b7142f7",
+                "shasum": ""
+            },
+            "type": "bower-asset-library",
+            "extra": {
+                "bower-asset-main": "src/purify.js",
+                "bower-asset-ignore": [
+                    "**/.*",
+                    "demos",
+                    "scripts",
+                    "test",
+                    "website"
+                ]
+            },
+            "license": [
+                "MPL-2.0",
+                "Apache-2.0"
+            ],
+            "description": "A DOM-only, super-fast, uber-tolerant XSS sanitizer for HTML, MathML and SVG",
+            "keywords": [
+                "cross site scripting",
+                "dom",
+                "filter",
+                "html",
+                "mathml",
+                "sanitize",
+                "sanitizer",
+                "secure",
+                "security",
+                "svg",
+                "xss"
+            ],
+            "time": "2019-02-19T13:27:01+00:00"
         },
         {
             "name": "bower-asset/perfect-scrollbar",
@@ -1175,6 +1220,22 @@
             "require": {
                 "npm-asset/ev-emitter": ">=1.0.0,<2.0.0"
             },
+            "require-dev": {
+                "npm-asset/chalk": ">=1.1.1,<2.0.0",
+                "npm-asset/cheerio": ">=0.19.0,<0.20.0",
+                "npm-asset/gulp": ">=3.9.0,<4.0.0",
+                "npm-asset/gulp-jshint": ">=1.11.2,<2.0.0",
+                "npm-asset/gulp-json-lint": ">=0.1.0,<0.2.0",
+                "npm-asset/gulp-rename": ">=1.2.2,<2.0.0",
+                "npm-asset/gulp-replace": ">=0.5.4,<0.6.0",
+                "npm-asset/gulp-requirejs-optimize": "dev-github:metafizzy/gulp-requirejs-optimize",
+                "npm-asset/gulp-uglify": ">=1.4.2,<2.0.0",
+                "npm-asset/gulp-util": ">=3.0.7,<4.0.0",
+                "npm-asset/highlight.js": ">=8.9.1,<9.0.0",
+                "npm-asset/marked": ">=0.3.5,<0.4.0",
+                "npm-asset/minimist": ">=1.2.0,<2.0.0",
+                "npm-asset/transfob": ">=1.0.0,<2.0.0"
+            },
             "type": "npm-asset-library",
             "extra": {
                 "npm-asset-bugs": {
@@ -1220,6 +1281,14 @@
                 "reference": null,
                 "shasum": "2736e332aaee73ccf0a14a5f0066391a0a13f4a3"
             },
+            "require-dev": {
+                "npm-asset/grunt": "~0.4.2",
+                "npm-asset/grunt-contrib-cssmin": "~0.9.0",
+                "npm-asset/grunt-contrib-jshint": "~0.6.3",
+                "npm-asset/grunt-contrib-less": "~0.11.0",
+                "npm-asset/grunt-contrib-uglify": "~0.4.0",
+                "npm-asset/grunt-contrib-watch": "~0.6.1"
+            },
             "type": "npm-asset-library",
             "extra": {
                 "npm-asset-bugs": {
@@ -1252,6 +1321,32 @@
                 "url": "https://registry.npmjs.org/jquery/-/jquery-2.2.4.tgz",
                 "reference": null,
                 "shasum": "2c89d6889b5eac522a7eea32c14521559c6cbf02"
+            },
+            "require-dev": {
+                "npm-asset/commitplease": "2.0.0",
+                "npm-asset/core-js": "0.9.17",
+                "npm-asset/grunt": "0.4.5",
+                "npm-asset/grunt-babel": "5.0.1",
+                "npm-asset/grunt-cli": "0.1.13",
+                "npm-asset/grunt-compare-size": "0.4.0",
+                "npm-asset/grunt-contrib-jshint": "0.11.2",
+                "npm-asset/grunt-contrib-uglify": "0.9.2",
+                "npm-asset/grunt-contrib-watch": "0.6.1",
+                "npm-asset/grunt-git-authors": "2.0.1",
+                "npm-asset/grunt-jscs": "2.1.0",
+                "npm-asset/grunt-jsonlint": "1.0.4",
+                "npm-asset/grunt-npmcopy": "0.1.0",
+                "npm-asset/gzip-js": "0.3.2",
+                "npm-asset/jsdom": "5.6.1",
+                "npm-asset/load-grunt-tasks": "1.0.0",
+                "npm-asset/qunit-assert-step": "1.0.3",
+                "npm-asset/qunitjs": "1.17.1",
+                "npm-asset/requirejs": "2.1.17",
+                "npm-asset/sinon": "1.10.3",
+                "npm-asset/sizzle": "2.2.1",
+                "npm-asset/strip-json-comments": "1.0.3",
+                "npm-asset/testswarm": "1.1.0",
+                "npm-asset/win-spawn": "2.0.0"
             },
             "type": "npm-asset-library",
             "extra": {
@@ -1402,6 +1497,12 @@
                 "url": "https://registry.npmjs.org/jquery-mousewheel/-/jquery-mousewheel-3.1.13.tgz",
                 "reference": null,
                 "shasum": "06f0335f16e353a695e7206bf50503cb523a6ee5"
+            },
+            "require-dev": {
+                "npm-asset/grunt": "~0.4.1",
+                "npm-asset/grunt-contrib-connect": "~0.5.0",
+                "npm-asset/grunt-contrib-jshint": "~0.7.1",
+                "npm-asset/grunt-contrib-uglify": "~0.2.7"
             },
             "type": "npm-asset-library",
             "extra": {
@@ -3600,7 +3701,7 @@
                 }
             ],
             "description": "Provides the functionality to compare PHP values for equality",
-            "homepage": "http://www.github.com/sebastianbergmann/comparator",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
             "keywords": [
                 "comparator",
                 "compare",
@@ -3702,7 +3803,7 @@
                 }
             ],
             "description": "Provides functionality to handle HHVM/PHP environments",
-            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "homepage": "https://github.com/sebastianbergmann/environment",
             "keywords": [
                 "Xdebug",
                 "environment",
@@ -3770,7 +3871,7 @@
                 }
             ],
             "description": "Provides the functionality to export PHP variables for visualization",
-            "homepage": "http://www.github.com/sebastianbergmann/exporter",
+            "homepage": "https://github.com/sebastianbergmann/exporter",
             "keywords": [
                 "export",
                 "exporter"
@@ -3822,7 +3923,7 @@
                 }
             ],
             "description": "Snapshotting of global state",
-            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "homepage": "https://github.com/sebastianbergmann/global-state",
             "keywords": [
                 "global state"
             ],
@@ -3924,7 +4025,7 @@
                 }
             ],
             "description": "Provides functionality to recursively process PHP variables",
-            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
             "time": "2016-11-19T07:33:16+00:00"
         },
         {

--- a/view/templates/head.tpl
+++ b/view/templates/head.tpl
@@ -44,6 +44,7 @@
 <script type="text/javascript" src="view/asset/imagesloaded/imagesloaded.pkgd.min.js"></script>
 <script type="text/javascript" src="view/js/acl.js" ></script>
 <script type="text/javascript" src="view/asset/base64/base64.min.js" ></script>
+<script type="text/javascript" src="view/asset/dompurify/dist/purify.min.js"></script>
 <script type="text/javascript" src="view/js/main.js" ></script>
 <script>
 

--- a/view/theme/frio/js/hovercard.js
+++ b/view/theme/frio/js/hovercard.js
@@ -55,7 +55,7 @@ $(document).ready(function(){
 					var hctrigger = 'manual';
 			};
 
-			// Timeoute until the hover-card does appear
+			// Timeout until the hover-card does appear
 			setTimeout(function(){
 				if(targetElement.is(":hover") && parseInt(targetElement.attr('data-awaiting-hover-card'),10) == timeNow) {
 					if($('.hovercard').length == 0) {	// no card if there already is one open
@@ -81,6 +81,9 @@ $(document).ready(function(){
 									template: '<div class="popover hovercard" data-card-created="' + timeNow + '"><div class="arrow"></div><div class="popover-content hovercard-content"></div></div>',
 									content: data,
 									container: "body",
+									sanitizeFn: function (content) {
+										return DOMPurify.sanitize(content)
+									},
 								}).popover('show');
 							}
 						});

--- a/view/theme/frio/js/mod_events.js
+++ b/view/theme/frio/js/mod_events.js
@@ -82,6 +82,9 @@ $(document).ready(function() {
 				trigger: "hover",
 				placement: "auto",
 				template: '<div class="popover hovercard event-card"><div class="arrow"></div><div class="popover-content hovercard-content"></div></div>',
+				sanitizeFn: function (content) {
+					return DOMPurify.sanitize(content)
+				},
 			});
 
 		}

--- a/view/theme/frio/js/theme.js
+++ b/view/theme/frio/js/theme.js
@@ -106,7 +106,10 @@ $(document).ready(function(){
 		delay: {
 			show: 500,
 			hide: 100
-		}
+		},
+		sanitizeFn: function (content) {
+			return DOMPurify.sanitize(content)
+		},
 	});
 
 	// initialize the bootstrap-select

--- a/view/theme/frio/templates/head.tpl
+++ b/view/theme/frio/templates/head.tpl
@@ -65,6 +65,7 @@
 <script type="text/javascript" src="view/asset/imagesloaded/imagesloaded.pkgd.min.js"></script>
 <script type="text/javascript" src="view/js/acl.js"></script>
 <script type="text/javascript" src="view/asset/base64/base64.min.js"></script>
+<script type="text/javascript" src="view/asset/dompurify/dist/purify.min.js"></script>
 <script type="text/javascript" src="view/js/main.js"></script>
 
 <script type="text/javascript" src="view/theme/frio/frameworks/bootstrap/js/bootstrap.min.js"></script>


### PR DESCRIPTION
Fixes #7131
It's caused by the security-fix for 3.4.1, as described in the predecessor #6736 and here:
https://blog.getbootstrap.com/2019/02/13/bootstrap-4-3-1-and-3-4-1/

The sanitizer for tooltips and popovers is now more restricted:
https://getbootstrap.com/docs/4.3/getting-started/javascript/#sanitizer

Therefore I added the recommended library for fast DOM-sanitizing https://www.npmjs.com/package/dompurify and added the sanitize method as a parameter for each bootstrap `tooltip` and `popover`call. 

=> Now the hovercard vanish as expected :-)