### PR TITLE
Remove defaults() from $_SESSION

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -334,6 +334,7 @@ function get_app()
  * @param array $args
  * @brief Returns a defaut value if the provided variable or array key is falsy
  * @return mixed
+ * @deprecated since version 2019.06, use native coalesce operator (??) instead
  */
 function defaults(...$args)
 {

--- a/include/conversation.php
+++ b/include/conversation.php
@@ -15,6 +15,7 @@ use Friendica\Core\Logger;
 use Friendica\Core\PConfig;
 use Friendica\Core\Protocol;
 use Friendica\Core\Renderer;
+use Friendica\Core\Session;
 use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\Model\Contact;
@@ -528,7 +529,7 @@ function conversation(App $a, array $items, Pager $pager, $mode, $update, $previ
 
 		if (!$update) {
 			$live_update_div = '<div id="live-display"></div>' . "\r\n"
-				. "<script> var profile_uid = " . defaults($_SESSION, 'uid', 0) . ";"
+				. "<script> var profile_uid = " . Session::get('uid', 0) . ";"
 				. " var profile_page = 1; </script>";
 		}
 	} elseif ($mode === 'community') {

--- a/mod/network.php
+++ b/mod/network.php
@@ -19,6 +19,7 @@ use Friendica\Core\Logger;
 use Friendica\Core\PConfig;
 use Friendica\Core\Protocol;
 use Friendica\Core\Renderer;
+use Friendica\Core\Session;
 use Friendica\Database\DBA;
 use Friendica\Model\Contact;
 use Friendica\Model\Group;
@@ -854,7 +855,7 @@ function networkThreadedView(App $a, $update, $parent)
 			((time() - $_SESSION['network_last_date_timestamp']) < ($browser_update * 10))) {
 			$bottom_limit = $_SESSION['network_last_date'];
 		}
-		$_SESSION['network_last_date'] = defaults($_SESSION, 'network_last_top_limit', $top_limit);
+		$_SESSION['network_last_date'] = Session::get('network_last_top_limit', $top_limit);
 		$_SESSION['network_last_date_timestamp'] = time();
 
 		if ($last_date > $top_limit) {

--- a/mod/settings.php
+++ b/mod/settings.php
@@ -14,6 +14,7 @@ use Friendica\Core\L10n;
 use Friendica\Core\Logger;
 use Friendica\Core\PConfig;
 use Friendica\Core\Renderer;
+use Friendica\Core\Session;
 use Friendica\Core\System;
 use Friendica\Core\Theme;
 use Friendica\Core\Worker;
@@ -910,8 +911,8 @@ function settings_content(App $a)
 			}
 		}
 
-		$theme_selected        = defaults($_SESSION, 'theme'       , $default_theme);
-		$mobile_theme_selected = defaults($_SESSION, 'mobile-theme', $default_mobile_theme);
+		$theme_selected        = Session::get('theme', $default_theme);
+		$mobile_theme_selected = Session::get('mobile-theme', $default_mobile_theme);
 
 		$nowarn_insecure = intval(PConfig::get(local_user(), 'system', 'nowarn_insecure'));
 

--- a/src/App.php
+++ b/src/App.php
@@ -1038,10 +1038,11 @@ class App
 				// Valid profile links contain a path with "/profile/" and no query parameters
 				if ((parse_url($_GET['zrl'], PHP_URL_QUERY) == "") &&
 					strstr(parse_url($_GET['zrl'], PHP_URL_PATH), "/profile/")) {
-					if (defaults($_SESSION, "visitor_home", "") != $_GET["zrl"]) {
-						$_SESSION['my_url'] = $_GET['zrl'];
-						$_SESSION['authenticated'] = 0;
+					if (Core\Session::get('visitor_home') != $_GET["zrl"]) {
+						Core\Session::set('my_url', $_GET['zrl']);
+						Core\Session::set('authenticated', 0);
 					}
+
 					Model\Profile::zrlInit($this);
 				} else {
 					// Someone came with an invalid parameter, maybe as a DDoS attempt
@@ -1066,9 +1067,9 @@ class App
 			header('X-Account-Management-Status: none');
 		}
 
-		$_SESSION['sysmsg']       = defaults($_SESSION, 'sysmsg'      , []);
-		$_SESSION['sysmsg_info']  = defaults($_SESSION, 'sysmsg_info' , []);
-		$_SESSION['last_updated'] = defaults($_SESSION, 'last_updated', []);
+		$_SESSION['sysmsg']       = Core\Session::get('sysmsg', []);
+		$_SESSION['sysmsg_info']  = Core\Session::get('sysmsg_info', []);
+		$_SESSION['last_updated'] = Core\Session::get('last_updated', []);
 
 		/*
 		 * check_config() is responsible for running update scripts. These automatically

--- a/src/Content/Nav.php
+++ b/src/Content/Nav.php
@@ -9,6 +9,7 @@ use Friendica\Core\Config;
 use Friendica\Core\Hook;
 use Friendica\Core\L10n;
 use Friendica\Core\Renderer;
+use Friendica\Core\Session;
 use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\Model\Profile;
@@ -172,7 +173,7 @@ class Nav
 		// "Home" should also take you home from an authenticated remote profile connection
 		$homelink = Profile::getMyURL();
 		if (! $homelink) {
-			$homelink = defaults($_SESSION, 'visitor_home', '');
+			$homelink = Session::get('visitor_home', '');
 		}
 
 		if (($a->module != 'home') && (! (local_user()))) {
@@ -241,7 +242,7 @@ class Nav
 			$nav['home'] = ['profile/' . $a->user['nickname'], L10n::t('Home'), '', L10n::t('Your posts and conversations')];
 
 			// Don't show notifications for public communities
-			if (defaults($_SESSION, 'page_flags', '') != User::PAGE_FLAGS_COMMUNITY) {
+			if (Session::get('page_flags', '') != User::PAGE_FLAGS_COMMUNITY) {
 				$nav['introductions'] = ['notifications/intros', L10n::t('Introductions'), '', L10n::t('Friend Requests')];
 				$nav['notifications'] = ['notifications',	L10n::t('Notifications'), '', L10n::t('Notifications')];
 				$nav['notifications']['all'] = ['notifications/system', L10n::t('See all notifications'), '', ''];

--- a/src/Core/Session.php
+++ b/src/Core/Session.php
@@ -62,13 +62,7 @@ class Session
 	 */
 	public static function get($name, $defaults = null)
 	{
-		if (isset($_SESSION)) {
-			$return = defaults($_SESSION, $name, $defaults);
-		} else {
-			$return = $defaults;
-		}
-
-		return $return;
+		return $_SESSION[$name] ?? $defaults;
 	}
 
 	/**

--- a/src/Module/Login.php
+++ b/src/Module/Login.php
@@ -32,26 +32,21 @@ class Login extends BaseModule
 	{
 		$a = self::getApp();
 
-		if (!empty($_SESSION['theme'])) {
-			unset($_SESSION['theme']);
-		}
-
-		if (!empty($_SESSION['mobile-theme'])) {
-			unset($_SESSION['mobile-theme']);
-		}
+		Session::remove('theme');
+		Session::remove('mobile-theme');
 
 		if (local_user()) {
 			$a->internalRedirect();
 		}
 
-		return self::form(defaults($_SESSION, 'return_path', null), intval(Config::get('config', 'register_policy')) !== \Friendica\Module\Register::CLOSED);
+		return self::form(Session::get('return_path'), intval(Config::get('config', 'register_policy')) !== \Friendica\Module\Register::CLOSED);
 	}
 
 	public static function post()
 	{
-		$return_path = defaults($_SESSION, 'return_path', '');
+		$return_path = Session::get('return_path');
 		session_unset();
-		$_SESSION['return_path'] = $return_path;
+		Session::set('return_path', $return_path);
 
 		// OpenId Login
 		if (
@@ -159,17 +154,13 @@ class Login extends BaseModule
 		}
 
 		// if we haven't failed up this point, log them in.
-		$_SESSION['remember'] = $remember;
-		$_SESSION['last_login_date'] = DateTimeFormat::utcNow();
+		Session::set('remember', $remember);
+		Session::set('last_login_date', DateTimeFormat::utcNow());
 
 		Session::setAuthenticatedForUser($a, $record, true, true);
 
-		if (!empty($_SESSION['return_path'])) {
-			$return_path = $_SESSION['return_path'];
-			unset($_SESSION['return_path']);
-		} else {
-			$return_path = '';
-		}
+		$return_path = Session::get('return_path', '');
+		Session::remove('return_path');
 
 		$a->internalRedirect($return_path);
 	}

--- a/src/Module/Profile.php
+++ b/src/Module/Profile.php
@@ -11,6 +11,7 @@ use Friendica\Core\Config;
 use Friendica\Core\Hook;
 use Friendica\Core\L10n;
 use Friendica\Core\PConfig;
+use Friendica\Core\Session;
 use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\Model\Contact as ContactModel;
@@ -226,8 +227,10 @@ class Profile extends BaseModule
 		$sql_extra = Item::getPermissionsSQLByUserId($a->profile['profile_uid'], $remote_contact, $groups, $remote_cid);
 		$sql_extra2 = '';
 
+		$last_updated_array = Session::get('last_updated', []);
+
 		if ($update) {
-			$last_updated = (defaults($_SESSION['last_updated'], $last_updated_key, 0));
+			$last_updated = $last_updated_array[$last_updated_key] ?? 0;
 
 			// If the page user is the owner of the page we should query for unseen
 			// items. Otherwise use a timestamp of the last succesful update request.
@@ -334,7 +337,8 @@ class Profile extends BaseModule
 
 		// Set a time stamp for this page. We will make use of it when we
 		// search for new items (update routine)
-		$_SESSION['last_updated'][$last_updated_key] = time();
+		$last_updated_array[$last_updated_key] = time();
+		Session::set('last_updated', $last_updated_array);
 
 		if ($is_owner && !$update && !Config::get('theme', 'hide_eventlist')) {
 			$o .= ProfileModel::getBirthdays();

--- a/src/Object/Post.php
+++ b/src/Object/Post.php
@@ -15,6 +15,7 @@ use Friendica\Core\Logger;
 use Friendica\Core\PConfig;
 use Friendica\Core\Protocol;
 use Friendica\Core\Renderer;
+use Friendica\Core\Session;
 use Friendica\Database\DBA;
 use Friendica\Model\Contact;
 use Friendica\Model\Item;
@@ -400,7 +401,7 @@ class Post extends BaseObject
 			'location'        => $location_e,
 			'indent'          => $indent,
 			'shiny'           => $shiny,
-			'owner_self'      => $item['author-link'] == defaults($_SESSION, 'my_url', null),
+			'owner_self'      => $item['author-link'] == Session::get('my_url'),
 			'owner_url'       => $this->getOwnerUrl(),
 			'owner_photo'     => $a->removeBaseURL(ProxyUtils::proxifyUrl($item['owner-avatar'], false, ProxyUtils::SIZE_THUMB)),
 			'owner_name'      => $owner_name_e,

--- a/view/theme/frio/theme.php
+++ b/view/theme/frio/theme.php
@@ -14,9 +14,8 @@ use Friendica\Core\Config;
 use Friendica\Core\Hook;
 use Friendica\Core\L10n;
 use Friendica\Core\Logger;
-use Friendica\Core\PConfig;
 use Friendica\Core\Renderer;
-use Friendica\Core\System;
+use Friendica\Core\Session;
 use Friendica\Database\DBA;
 use Friendica\Model;
 use Friendica\Module;
@@ -201,7 +200,7 @@ function frio_remote_nav($a, &$nav)
 	// get the homelink from $_XSESSION
 	$homelink = Model\Profile::getMyURL();
 	if (!$homelink) {
-		$homelink = defaults($_SESSION, 'visitor_home', '');
+		$homelink = Session::get('visitor_home', '');
 	}
 
 	// split up the url in it's parts (protocol,domain/directory, /profile/, nickname


### PR DESCRIPTION
Part of #7190 

I started replacing `defaults()` calls by `??` (introduced in PHP 7.0 that we now support as a minimum) when I realized that they aren't exactly similar, and as such each replacement has to be thoroughly tested.

Fortunately, this wasn't the case for `defaults($_SESSION, ...)` calls, so this will be the only dedicated PR towards #7190. The rest of the `defaults()` calls will have to be handled on a case-by-case basis.