### PR TITLE
Process incoming tag add requests

### DIFF
--- a/src/Protocol/ActivityPub/Receiver.php
+++ b/src/Protocol/ActivityPub/Receiver.php
@@ -226,6 +226,13 @@ class Receiver
 			$object_data['author'] = JsonLD::fetchElement($activity, 'as:actor', '@id');
 			$object_data['object_id'] = $object_id;
 			$object_data['object_type'] = ''; // Since we don't fetch the object, we don't know the type
+		} elseif (in_array($type, ['as:Add'])) {
+			$object_data = [];
+			$object_data['id'] = JsonLD::fetchElement($activity, '@id');
+			$object_data['target_id'] = JsonLD::fetchElement($activity, 'as:target', '@id');
+			$object_data['object_id'] = JsonLD::fetchElement($activity, 'as:object', '@id');
+			$object_data['object_type'] = JsonLD::fetchElement($activity['as:object'], '@type');
+			$object_data['object_content'] = JsonLD::fetchElement($activity['as:object'], 'as:content', '@type');
 		} else {
 			$object_data = [];
 			$object_data['id'] = JsonLD::fetchElement($activity, '@id');
@@ -363,6 +370,12 @@ class Receiver
 			case 'as:Create':
 				if (in_array($object_data['object_type'], self::CONTENT_TYPES)) {
 					ActivityPub\Processor::createItem($object_data);
+				}
+				break;
+
+			case 'as:Add':
+				if ($object_data['object_type'] == 'as:tag') {
+					ActivityPub\Processor::addTag($object_data);
 				}
 				break;
 


### PR DESCRIPTION
For AP we now have reproduced the same behaviour like for DFRN. Means that we can now receive the "tag add" requests in the same way. There is still missing stuff like checking permissions and redistributing this request. We have to check how we could do this in the future.