### PR TITLE
Prevent fatal error in ACL::getFullSelectorHTML when accessing a profile as a remote visitor

### DIFF
--- a/src/Core/ACL.php
+++ b/src/Core/ACL.php
@@ -259,7 +259,7 @@ class ACL extends BaseObject
 	 * @return string
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
-	public static function getFullSelectorHTML(array $user, $show_jotnets = false, array $default_permissions = [])
+	public static function getFullSelectorHTML(array $user = null, $show_jotnets = false, array $default_permissions = [])
 	{
 		// Defaults user permissions
 		if (empty($default_permissions)) {
@@ -314,7 +314,7 @@ class ACL extends BaseObject
 			'$aclModalTitle' => L10n::t('Permissions'),
 			'$aclModalDismiss' => L10n::t('Close'),
 			'$features' => [
-				'aclautomention' => Feature::isEnabled($user['uid'], 'aclautomention') ? 'true' : 'false'
+				'aclautomention' => !empty($user['uid']) && Feature::isEnabled($user['uid'], 'aclautomention') ? 'true' : 'false'
 			],
 		]);
 


### PR DESCRIPTION
See https://github.com/friendica/friendica/issues/6916#issuecomment-495724811

The ways we authenticate users and visitors are really different and in the last case, there's no user info available. This was not accounted for by `ACL::getFullSelectorHTML`