### PR TITLE
Remove .well-known hardening

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -993,12 +993,6 @@ class App
 			);
 		}
 
-		if (strstr($this->query_string, '.well-known/host-meta') && ($this->query_string != '.well-known/host-meta')) {
-			Module\Special\HTTPException::rawContent(
-				new HTTPException\NotFoundException()
-			);
-		}
-
 		if (!$this->getMode()->isInstall()) {
 			// Force SSL redirection
 			if ($this->baseURL->checkRedirectHttps()) {


### PR DESCRIPTION
FollowUp #7062 

In some cases, the redirection adds an `?` (e.g. traefik sometimes)
Therefore, the `$a->query_string` would be `.well-known/host-meta?` and would redirect to a 404. Since the refactoring to src/Module, it doesn't matter anymore, so we can remove the check :-)