### PR TITLE
Remove nested <link> tag in poke object creation in mod/poke

### DIFF
--- a/mod/poke.php
+++ b/mod/poke.php
@@ -123,10 +123,10 @@ function poke_init(App $a)
 	$arr['body']          = '[url=' . $poster['url'] . ']' . $poster['name'] . '[/url]' . ' ' . L10n::t($verbs[$verb][0]) . ' ' . '[url=' . $target['url'] . ']' . $target['name'] . '[/url]';
 
 	$arr['object'] = '<object><type>' . ACTIVITY_OBJ_PERSON . '</type><title>' . $target['name'] . '</title><id>' . $target['url'] . '</id>';
-	$arr['object'] .= '<link>' . XML::escape('<link rel="alternate" type="text/html" href="' . $target['url'] . '" />' . "\n");
+	$arr['object'] .= XML::escape('<link rel="alternate" type="text/html" href="' . $target['url'] . '" />' . "\n");
 
 	$arr['object'] .= XML::escape('<link rel="photo" type="image/jpeg" href="' . $target['photo'] . '" />' . "\n");
-	$arr['object'] .= '</link></object>' . "\n";
+	$arr['object'] .= '</object>' . "\n";
 
 	Item::insert($arr);
 


### PR DESCRIPTION
Should fix #3158 

I decided to go with the removal of the nested link tags because of this code in the receiving code:
https://github.com/friendica/friendica/blob/f1c044e3b65b27a1f4e4abec84731b0f1dfd89d6/src/Protocol/DFRN.php#L2152-L2173