### PR TITLE
Ensure that pokes are always send only via DFRN

### DIFF
--- a/mod/item.php
+++ b/mod/item.php
@@ -40,6 +40,7 @@ use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Emailer;
 use Friendica\Util\Security;
 use Friendica\Util\Strings;
+use Friendica\Worker\Delivery;
 
 require_once 'include/items.php';
 
@@ -603,7 +604,7 @@ function item_post(App $a) {
 		$origin = $_REQUEST['origin'];
 	}
 
-	$notify_type = ($toplevel_item_id ? 'comment-new' : 'wall-new');
+	$notify_type = ($toplevel_item_id ? Delivery::COMMENT : Delivery::POST);
 
 	$uri = ($message_id ? $message_id : Item::newURI($api_source ? $profile_uid : $uid, $guid));
 

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -37,6 +37,7 @@ use Friendica\Util\Map;
 use Friendica\Util\Network;
 use Friendica\Util\Strings;
 use Friendica\Util\XML;
+use Friendica\Worker\Delivery;
 use SimpleXMLElement;
 
 /**
@@ -2148,9 +2149,9 @@ class Diaspora
 				continue;
 			}
 			if ($comment['verb'] == ACTIVITY_POST) {
-				$cmd = $comment['self'] ? 'comment-new' : 'comment-import';
+				$cmd = $comment['self'] ? Delivery::COMMENT : 'comment-import';
 			} else {
-				$cmd = $comment['self'] ? 'like' : 'comment-import';
+				$cmd = $comment['self'] ? Delivery::ACTIVITY : 'activity-import';
 			}
 			Logger::log("Send ".$cmd." for item ".$comment['id']." to contact ".$contact_id, Logger::DEBUG);
 			Worker::add(PRIORITY_HIGH, 'Delivery', $cmd, $comment['id'], $contact_id);

--- a/src/Worker/APDelivery.php
+++ b/src/Worker/APDelivery.php
@@ -37,7 +37,9 @@ class APDelivery extends BaseObject
 		} elseif ($cmd == Delivery::SUGGESTION) {
 			$success = ActivityPub\Transmitter::sendContactSuggestion($uid, $inbox, $target_id);
 		} elseif ($cmd == Delivery::RELOCATION) {
+			// @todo Implementation pending
 		} elseif ($cmd == Delivery::POKE) {
+			// Implementation not planned
 		} elseif ($cmd == Delivery::REMOVAL) {
 			$success = ActivityPub\Transmitter::sendProfileDeletion($uid, $inbox);
 		} elseif ($cmd == Delivery::PROFILEUPDATE) {

--- a/src/Worker/APDelivery.php
+++ b/src/Worker/APDelivery.php
@@ -37,6 +37,7 @@ class APDelivery extends BaseObject
 		} elseif ($cmd == Delivery::SUGGESTION) {
 			$success = ActivityPub\Transmitter::sendContactSuggestion($uid, $inbox, $target_id);
 		} elseif ($cmd == Delivery::RELOCATION) {
+		} elseif ($cmd == Delivery::POKE) {
 		} elseif ($cmd == Delivery::REMOVAL) {
 			$success = ActivityPub\Transmitter::sendProfileDeletion($uid, $inbox);
 		} elseif ($cmd == Delivery::PROFILEUPDATE) {

--- a/src/Worker/Delivery.php
+++ b/src/Worker/Delivery.php
@@ -26,7 +26,9 @@ class Delivery extends BaseObject
 	const RELOCATION    = 'relocate';
 	const DELETION      = 'drop';
 	const POST          = 'wall-new';
+	const POKE          = 'poke';
 	const COMMENT       = 'comment-new';
+	const ACTIVITY      = 'activity-new';
 	const REMOVAL       = 'removeme';
 	const PROFILEUPDATE = 'profileupdate';
 

--- a/src/Worker/Notifier.php
+++ b/src/Worker/Notifier.php
@@ -442,7 +442,7 @@ class Notifier
 					}
 
 					if (in_array($rr['network'], [Protocol::DFRN, Protocol::DIASPORA]) && ($rr['protocol'] == Protocol::ACTIVITYPUB) &&
-						!in_array($cmd, [Delivery::SUGGESTION, Delivery::REMOVAL, Delivery::RELOCATION])) {
+						!in_array($cmd, [Delivery::SUGGESTION, Delivery::REMOVAL, Delivery::RELOCATION, Delivery::POKE])) {
 						Logger::info('Contact is Friendica AP, so skipping delivery via legacy DFRN', ['url' => $rr['url']]);
 						continue;
 					}
@@ -482,7 +482,7 @@ class Notifier
 			}
 
 			if (in_array($contact['network'], [Protocol::DFRN, Protocol::DIASPORA]) && ($contact['protocol'] == Protocol::ACTIVITYPUB) &&
-				!in_array($cmd, [Delivery::SUGGESTION, Delivery::REMOVAL, Delivery::RELOCATION])) {
+				!in_array($cmd, [Delivery::SUGGESTION, Delivery::REMOVAL, Delivery::RELOCATION, Delivery::POKE])) {
 				Logger::info('Contact is Friendica AP, so skipping delivery via legacy DFRN', ['url' => $contact['url']]);
 				continue;
 			}


### PR DESCRIPTION
This ensures that pokes are sent via DFRN, even if the contact is a newer Friendica contact that primarily uses AP. 

In a future step we should have a look at the different deliver commands. I guess we can reduce many of them to the "POST" constant.