### PR TITLE
Refactor Pager

### DIFF
--- a/include/conversation.php
+++ b/include/conversation.php
@@ -6,7 +6,6 @@
 use Friendica\App;
 use Friendica\Content\ContactSelector;
 use Friendica\Content\Feature;
-use Friendica\Content\Pager;
 use Friendica\Content\Text\BBCode;
 use Friendica\Core\Config;
 use Friendica\Core\Hook;
@@ -21,14 +20,15 @@ use Friendica\Model\Contact;
 use Friendica\Model\Item;
 use Friendica\Model\Profile;
 use Friendica\Model\Term;
+use Friendica\Object\Pager;
 use Friendica\Object\Post;
 use Friendica\Object\Thread;
+use Friendica\Util\Crypto;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Proxy as ProxyUtils;
-use Friendica\Util\Temporal;
 use Friendica\Util\Strings;
+use Friendica\Util\Temporal;
 use Friendica\Util\XML;
-use Friendica\Util\Crypto;
 
 function item_extract_images($body) {
 

--- a/mod/common.php
+++ b/mod/common.php
@@ -5,7 +5,7 @@
 
 use Friendica\App;
 use Friendica\Content\ContactSelector;
-use Friendica\Content\Pager;
+use Friendica\Content\RenderedPager;
 use Friendica\Core\L10n;
 use Friendica\Core\Renderer;
 use Friendica\Database\DBA;
@@ -91,7 +91,7 @@ function common_content(App $a)
 		return $o;
 	}
 
-	$pager = new Pager($a->query_string);
+	$pager = new RenderedPager($a->query_string, $a->page['page']);
 
 	if ($cid) {
 		$common_friends = Model\GContact::commonFriends($uid, $cid, $pager->getStart(), $pager->getItemsPerPage());

--- a/mod/community.php
+++ b/mod/community.php
@@ -5,14 +5,13 @@
 
 use Friendica\App;
 use Friendica\Content\Nav;
-use Friendica\Content\Pager;
+use Friendica\Content\RenderedPager;
 use Friendica\Core\ACL;
 use Friendica\Core\Config;
 use Friendica\Core\L10n;
 use Friendica\Core\PConfig;
 use Friendica\Core\Renderer;
 use Friendica\Database\DBA;
-use Friendica\Model\Contact;
 use Friendica\Model\Item;
 use Friendica\Model\User;
 
@@ -154,7 +153,7 @@ function community_content(App $a, $update = 0)
 		$itemspage_network = $a->force_max_items;
 	}
 
-	$pager = new Pager($a->query_string, $itemspage_network);
+	$pager = new RenderedPager($a->query_string, $a->page['page'], $itemspage_network);
 
 	$r = community_getitems($pager->getStart(), $pager->getItemsPerPage(), $content, $accounttype);
 

--- a/mod/display.php
+++ b/mod/display.php
@@ -4,7 +4,6 @@
  */
 
 use Friendica\App;
-use Friendica\Content\Pager;
 use Friendica\Content\Text\BBCode;
 use Friendica\Content\Text\HTML;
 use Friendica\Core\ACL;
@@ -21,6 +20,7 @@ use Friendica\Model\Item;
 use Friendica\Model\Profile;
 use Friendica\Module\Objects;
 use Friendica\Network\HTTPException;
+use Friendica\Object\Pager;
 use Friendica\Protocol\ActivityPub;
 use Friendica\Protocol\DFRN;
 use Friendica\Util\Strings;
@@ -353,7 +353,7 @@ function display_content(App $a, $update = false, $update_uid = 0)
 		$o .= "<script> var netargs = '?f=&item_id=" . $item_id . "'; </script>";
 	}
 
-	$o .= conversation($a, [$item], new Pager($a->query_string), 'display', $update_uid, false, 'commented', $item_uid);
+	$o .= conversation($a, [$item], new Pager($a->page['page']), 'display', $update_uid, false, 'commented', $item_uid);
 
 	// Preparing the meta header
 	$description = trim(HTML::toPlaintext(BBCode::convert($item["body"], false), 0, true));

--- a/mod/item.php
+++ b/mod/item.php
@@ -16,7 +16,6 @@
  */
 
 use Friendica\App;
-use Friendica\Content\Pager;
 use Friendica\Content\Text\BBCode;
 use Friendica\Content\Text\HTML;
 use Friendica\Core\Config;
@@ -34,6 +33,7 @@ use Friendica\Model\FileTag;
 use Friendica\Model\Item;
 use Friendica\Model\Photo;
 use Friendica\Model\Term;
+use Friendica\Object\Pager;
 use Friendica\Protocol\Diaspora;
 use Friendica\Protocol\Email;
 use Friendica\Util\DateTimeFormat;
@@ -705,7 +705,7 @@ function item_post(App $a) {
 		$datarray["item_id"] = -1;
 		$datarray["author-network"] = Protocol::DFRN;
 
-		$o = conversation($a, [array_merge($contact_record, $datarray)], new Pager($a->query_string), 'search', false, true);
+		$o = conversation($a, [array_merge($contact_record, $datarray)], new Pager($a->page['page']), 'search', false, true);
 		Logger::log('preview: ' . $o);
 		echo json_encode(['preview' => $o]);
 		exit();

--- a/mod/match.php
+++ b/mod/match.php
@@ -4,7 +4,6 @@
  */
 
 use Friendica\App;
-use Friendica\Content\Pager;
 use Friendica\Content\Widget;
 use Friendica\Core\Config;
 use Friendica\Core\L10n;

--- a/mod/message.php
+++ b/mod/message.php
@@ -5,7 +5,7 @@
 
 use Friendica\App;
 use Friendica\Content\Nav;
-use Friendica\Content\Pager;
+use Friendica\Content\RenderedPager;
 use Friendica\Content\Smilies;
 use Friendica\Content\Text\BBCode;
 use Friendica\Core\ACL;
@@ -281,7 +281,7 @@ function message_content(App $a)
 			$total = $r[0]['total'];
 		}
 
-		$pager = new Pager($a->query_string);
+		$pager = new RenderedPager($a->query_string, $a->page['page']);
 
 		$r = get_messages(local_user(), $pager->getStart(), $pager->getItemsPerPage());
 

--- a/mod/network.php
+++ b/mod/network.php
@@ -8,9 +8,9 @@ use Friendica\App;
 use Friendica\Content\Feature;
 use Friendica\Content\ForumManager;
 use Friendica\Content\Nav;
-use Friendica\Content\Pager;
-use Friendica\Content\Widget;
+use Friendica\Content\RenderedPager;
 use Friendica\Content\Text\HTML;
+use Friendica\Content\Widget;
 use Friendica\Core\ACL;
 use Friendica\Core\Config;
 use Friendica\Core\Hook;
@@ -26,6 +26,7 @@ use Friendica\Model\Item;
 use Friendica\Model\Profile;
 use Friendica\Model\Term;
 use Friendica\Module\Login;
+use Friendica\Object\Pager;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Proxy as ProxyUtils;
 use Friendica\Util\Strings;
@@ -322,7 +323,7 @@ function networkSetSeen($condition)
  *
  * @param App     $a      The global App
  * @param array   $items  Items of the conversation
- * @param Pager   $pager
+ * @param RenderedPager   $pager
  * @param string  $mode   Display mode for the conversation
  * @param integer $update Used for the automatic reloading
  * @param string  $ordering
@@ -330,7 +331,7 @@ function networkSetSeen($condition)
  * @throws ImagickException
  * @throws \Friendica\Network\HTTPException\InternalServerErrorException
  */
-function networkConversation(App $a, $items, Pager $pager, $mode, $update, $ordering = '')
+function networkConversation(App $a, $items, RenderedPager $pager, $mode, $update, $ordering = '')
 {
 	// Set this so that the conversation function can find out contact info for our wall-wall items
 	$a->page_contact = $a->contact;
@@ -440,7 +441,7 @@ function networkFlatView(App $a, $update = 0)
 		}
 	}
 
-	$pager = new Pager($a->query_string);
+	$pager = new RenderedPager($a->query_string, $a->page['page']);
 
 	networkPager($a, $pager, $update);
 
@@ -732,7 +733,7 @@ function networkThreadedView(App $a, $update, $parent)
 		$sql_range = '';
 	}
 
-	$pager = new Pager($a->query_string);
+	$pager = new RenderedPager($a->query_string, $a->page['page']);
 
 	$pager_sql = networkPager($a, $pager, $update);
 

--- a/mod/notes.php
+++ b/mod/notes.php
@@ -5,7 +5,7 @@
 
 use Friendica\App;
 use Friendica\Content\Nav;
-use Friendica\Content\Pager;
+use Friendica\Content\RenderedPager;
 use Friendica\Core\L10n;
 use Friendica\Database\DBA;
 use Friendica\Model\Item;
@@ -53,7 +53,7 @@ function notes_content(App $a, $update = false)
 	$condition = ['uid' => local_user(), 'post-type' => Item::PT_PERSONAL_NOTE, 'gravity' => GRAVITY_PARENT,
 		'contact-id'=> $a->contact['id']];
 
-	$pager = new Pager($a->query_string, 40);
+	$pager = new RenderedPager($a->query_string, $a->page['page'], 40);
 
 	$params = ['order' => ['created' => true],
 		'limit' => [$pager->getStart(), $pager->getItemsPerPage()]];

--- a/mod/notifications.php
+++ b/mod/notifications.php
@@ -7,7 +7,7 @@
 use Friendica\App;
 use Friendica\Content\ContactSelector;
 use Friendica\Content\Nav;
-use Friendica\Content\Pager;
+use Friendica\Content\RenderedPager;
 use Friendica\Core\L10n;
 use Friendica\Core\NotificationsManager;
 use Friendica\Core\Protocol;
@@ -127,7 +127,7 @@ function notifications_content(App $a)
 	}
 
 	// Set the pager
-	$pager = new Pager($a->query_string, $perpage);
+	$pager = new RenderedPager($a->query_string, $a->page['page'], $perpage);
 
 	// Add additional informations (needed for json output)
 	$notifs['items_page'] = $pager->getItemsPerPage();

--- a/mod/photos.php
+++ b/mod/photos.php
@@ -6,7 +6,7 @@
 use Friendica\App;
 use Friendica\Content\Feature;
 use Friendica\Content\Nav;
-use Friendica\Content\Pager;
+use Friendica\Content\RenderedPager;
 use Friendica\Content\Text\BBCode;
 use Friendica\Core\ACL;
 use Friendica\Core\Config;
@@ -1046,7 +1046,7 @@ function photos_content(App $a)
 			$total = count($r);
 		}
 
-		$pager = new Pager($a->query_string, 20);
+		$pager = new RenderedPager($a->query_string, $a->page['page'], 20);
 
 		/// @TODO I have seen this many times, maybe generalize it script-wide and encapsulate it?
 		$order_field = defaults($_GET, 'order', '');
@@ -1325,7 +1325,7 @@ function photos_content(App $a)
 			$condition = ["`parent` = ? AND `parent` != `id`",  $link_item['parent']];
 			$total = DBA::count('item', $condition);
 
-			$pager = new Pager($a->query_string);
+			$pager = new RenderedPager($a->query_string, $a->page['page']);
 
 			$params = ['order' => ['id'], 'limit' => [$pager->getStart(), $pager->getItemsPerPage()]];
 			$result = Item::selectForUser($link_item['uid'], Item::ITEM_FIELDLIST, $condition, $params);
@@ -1586,7 +1586,7 @@ function photos_content(App $a)
 		$total = count($r);
 	}
 
-	$pager = new Pager($a->query_string, 20);
+	$pager = new RenderedPager($a->query_string, $a->page['page'], 20);
 
 	$r = q("SELECT `resource-id`, ANY_VALUE(`id`) AS `id`, ANY_VALUE(`filename`) AS `filename`,
 		ANY_VALUE(`type`) AS `type`, ANY_VALUE(`album`) AS `album`, max(`scale`) AS `scale`,

--- a/mod/search.php
+++ b/mod/search.php
@@ -5,7 +5,7 @@
 
 use Friendica\App;
 use Friendica\Content\Nav;
-use Friendica\Content\Pager;
+use Friendica\Content\RenderedPager;
 use Friendica\Content\Text\HTML;
 use Friendica\Core\Cache;
 use Friendica\Core\Config;
@@ -178,7 +178,7 @@ function search_content(App $a) {
 	// OR your own posts if you are a logged in member
 	// No items will be shown if the member has a blocked profile wall.
 
-	$pager = new Pager($a->query_string);
+	$pager = new RenderedPager($a->query_string, $a->page['page']);
 
 	if ($tag) {
 		Logger::log("Start tag search for '".$search."'", Logger::DEBUG);

--- a/mod/videos.php
+++ b/mod/videos.php
@@ -5,7 +5,7 @@
 
 use Friendica\App;
 use Friendica\Content\Nav;
-use Friendica\Content\Pager;
+use Friendica\Content\RenderedPager;
 use Friendica\Core\Config;
 use Friendica\Core\L10n;
 use Friendica\Core\Renderer;
@@ -253,7 +253,7 @@ function videos_content(App $a)
 		$total = count($r);
 	}
 
-	$pager = new Pager($a->query_string, 20);
+	$pager = new RenderedPager($a->query_string, $a->page['page'], 20);
 
 	$r = q("SELECT hash, ANY_VALUE(`id`) AS `id`, ANY_VALUE(`created`) AS `created`,
 		ANY_VALUE(`filename`) AS `filename`, ANY_VALUE(`filetype`) as `filetype`

--- a/src/App.php
+++ b/src/App.php
@@ -359,6 +359,8 @@ class App
 		$this->loadDefaultTimezone();
 
 		Core\L10n::init();
+
+		$this->page['page'] = defaults($_GET, 'page', 1);
 	}
 
 	/**

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -5,7 +5,7 @@
 namespace Friendica\Model;
 
 use Friendica\BaseObject;
-use Friendica\Content\Pager;
+use Friendica\Content\RenderedPager;
 use Friendica\Core\Config;
 use Friendica\Core\Hook;
 use Friendica\Core\L10n;
@@ -1586,7 +1586,7 @@ class Contact extends BaseObject
 				$cid, GRAVITY_PARENT, GRAVITY_COMMENT, local_user()];
 		}
 
-		$pager = new Pager($a->query_string);
+		$pager = new RenderedPager($a->query_string, $a->page['page']);
 
 		$params = ['order' => ['created' => true],
 			'limit' => [$pager->getStart(), $pager->getItemsPerPage()]];

--- a/src/Module/Admin/Blocklist/Contact.php
+++ b/src/Module/Admin/Blocklist/Contact.php
@@ -2,12 +2,12 @@
 
 namespace Friendica\Module\Admin\Blocklist;
 
-use Friendica\Content\Pager;
+use Friendica\Content\RenderedPager;
 use Friendica\Core\L10n;
 use Friendica\Core\Renderer;
 use Friendica\Database\DBA;
-use Friendica\Module\BaseAdminModule;
 use Friendica\Model;
+use Friendica\Module\BaseAdminModule;
 
 class Contact extends BaseAdminModule
 {
@@ -51,7 +51,7 @@ class Contact extends BaseAdminModule
 
 		$total = DBA::count('contact', $condition);
 
-		$pager = new Pager($a->query_string, 30);
+		$pager = new RenderedPager($a->query_string, $a->page['page'], 30);
 
 		$contacts = Model\Contact::select([], $condition, ['limit' => [$pager->getStart(), $pager->getItemsPerPage()]]);
 

--- a/src/Module/Admin/Users.php
+++ b/src/Module/Admin/Users.php
@@ -2,7 +2,7 @@
 
 namespace Friendica\Module\Admin;
 
-use Friendica\Content\Pager;
+use Friendica\Content\RenderedPager;
 use Friendica\Core\Config;
 use Friendica\Core\L10n;
 use Friendica\Core\Renderer;
@@ -180,7 +180,7 @@ class Users extends BaseAdminModule
 		/* get pending */
 		$pending = Register::getPending();
 
-		$pager = new Pager($a->query_string, 100);
+		$pager = new RenderedPager($a->query_string, $a->page['page'], 100);
 
 		// @TODO Move below block to Model\User::getUsers($start, $count, $order = 'contact.name', $order_direction = '+')
 		$valid_orders = [

--- a/src/Module/AllFriends.php
+++ b/src/Module/AllFriends.php
@@ -4,7 +4,7 @@ namespace Friendica\Module;
 
 use Friendica\BaseModule;
 use Friendica\Content\ContactSelector;
-use Friendica\Content\Pager;
+use Friendica\Content\RenderedPager;
 use Friendica\Core\L10n;
 use Friendica\Core\Renderer;
 use Friendica\Model;
@@ -48,7 +48,7 @@ class AllFriends extends BaseModule
 
 		$total = Model\GContact::countAllFriends(local_user(), $cid);
 
-		$pager = new Pager($app->query_string);
+		$pager = new RenderedPager($app->query_string, $app->page['page']);
 
 		$friends = Model\GContact::allFriends(local_user(), $cid, $pager->getStart(), $pager->getItemsPerPage());
 		if (empty($friends)) {

--- a/src/Module/BaseSearchModule.php
+++ b/src/Module/BaseSearchModule.php
@@ -4,16 +4,15 @@ namespace Friendica\Module;
 
 use Friendica\BaseModule;
 use Friendica\Content\ContactSelector;
-use Friendica\Content\Pager;
+use Friendica\Content\RenderedPager;
 use Friendica\Core\L10n;
 use Friendica\Core\Renderer;
-use Friendica\Core\Search;
 use Friendica\Model;
 use Friendica\Network\HTTPException;
+use Friendica\Object\Pager;
 use Friendica\Object\Search\ContactResult;
 use Friendica\Object\Search\ResultList;
 use Friendica\Util\Proxy as ProxyUtils;
-use Friendica\Util\Strings;
 
 /**
  * Base class for search modules
@@ -154,11 +153,13 @@ class BaseSearchModule extends BaseModule
 			}
 		}
 
+		$renderedPager = RenderedPager::createByPager($a->query_string, $pager);
+
 		$tpl = Renderer::getMarkupTemplate('viewcontact_template.tpl');
 		return Renderer::replaceMacros($tpl, [
 			'title'     => $header,
 			'$contacts' => $entries,
-			'$paginate' => $pager->renderFull($results->getTotal()),
+			'$paginate' => $renderedPager->renderFull($results->getTotal()),
 		]);
 	}
 }

--- a/src/Module/Contact.php
+++ b/src/Module/Contact.php
@@ -6,7 +6,7 @@ use Friendica\App;
 use Friendica\BaseModule;
 use Friendica\Content\ContactSelector;
 use Friendica\Content\Nav;
-use Friendica\Content\Pager;
+use Friendica\Content\RenderedPager;
 use Friendica\Content\Text\BBCode;
 use Friendica\Content\Widget;
 use Friendica\Core\ACL;
@@ -768,7 +768,7 @@ class Contact extends BaseModule
 		if (DBA::isResult($r)) {
 			$total = $r[0]['total'];
 		}
-		$pager = new Pager($a->query_string);
+		$pager = new RenderedPager($a->query_string, $a->page['page']);
 
 		$sql_extra3 = Widget::unavailableNetworks();
 
@@ -824,7 +824,7 @@ class Contact extends BaseModule
 				'contacts_batch_drop'    => L10n::t('Delete'),
 			],
 			'$h_batch_actions' => L10n::t('Batch Actions'),
-			'$paginate'   => $pager->renderFull($total),
+			'$paginate'   =>  $pager->renderFull($total),
 		]);
 
 		return $o;

--- a/src/Module/Directory.php
+++ b/src/Module/Directory.php
@@ -4,7 +4,7 @@ namespace Friendica\Module;
 
 use Friendica\BaseModule;
 use Friendica\Content\Nav;
-use Friendica\Content\Pager;
+use Friendica\Content\RenderedPager;
 use Friendica\Content\Widget;
 use Friendica\Core\Hook;
 use Friendica\Core\L10n;
@@ -58,7 +58,7 @@ class Directory extends BaseModule
 			$gDirPath = Profile::zrl($dirURL, true);
 		}
 
-		$pager = new Pager($app->query_string, 60);
+		$pager = new RenderedPager($app->query_string, $app->page['page'], 60);
 
 		$profiles = Profile::searchProfiles($pager->getStart(), $pager->getItemsPerPage(), $search);
 

--- a/src/Module/Profile.php
+++ b/src/Module/Profile.php
@@ -4,7 +4,7 @@ namespace Friendica\Module;
 
 use Friendica\BaseModule;
 use Friendica\Content\Nav;
-use Friendica\Content\Pager;
+use Friendica\Content\RenderedPager;
 use Friendica\Content\Widget;
 use Friendica\Core\ACL;
 use Friendica\Core\Config;
@@ -258,7 +258,7 @@ class Profile extends BaseModule
 				return '';
 			}
 
-			$pager = new Pager($a->query_string);
+			$pager = new RenderedPager($a->query_string, $a->page['page']);
 		} else {
 			$sql_post_table = "";
 
@@ -302,7 +302,7 @@ class Profile extends BaseModule
 				$itemspage_network = $a->force_max_items;
 			}
 
-			$pager = new Pager($a->query_string, $itemspage_network);
+			$pager = new RenderedPager($a->query_string, $a->page['page'], $itemspage_network);
 
 			$pager_sql = sprintf(" LIMIT %d, %d ", $pager->getStart(), $pager->getItemsPerPage());
 

--- a/src/Module/Profile/Contacts.php
+++ b/src/Module/Profile/Contacts.php
@@ -5,7 +5,7 @@ namespace Friendica\Module\Profile;
 use Friendica\BaseModule;
 use Friendica\Content\ContactSelector;
 use Friendica\Content\Nav;
-use Friendica\Content\Pager;
+use Friendica\Content\RenderedPager;
 use Friendica\Core\Config;
 use Friendica\Core\L10n;
 use Friendica\Core\Protocol;
@@ -68,7 +68,7 @@ class Contacts extends BaseModule
 
 		$total = DBA::count('contact', $condition);
 
-		$pager = new Pager($a->query_string);
+		$pager = new RenderedPager($a->query_string, $a->page['page']);
 
 		$params = ['order' => ['name' => false], 'limit' => [$pager->getStart(), $pager->getItemsPerPage()]];
 

--- a/src/Object/Pager.php
+++ b/src/Object/Pager.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Friendica\Object;
+
+/**
+ * A pager class.
+ */
+class Pager
+{
+	/**
+	 * The default item count per page
+	 * @var integer
+	 */
+	const DEFAULT_ITEMS_PER_PAGE = 50;
+
+	/**
+	 * @var integer
+	 */
+	private $page = 1;
+	/**
+	 * @var integer
+	 */
+	private $itemsPerPage = self::DEFAULT_ITEMS_PER_PAGE;
+
+	/**
+	 * Instantiates a new Pager with the base parameters.
+	 *
+	 * Guesses the page number from the GET parameter 'page'.
+	 *
+
+	 * @param integer $page         The current page (default is first page)
+	 * @param integer $itemsPerPage An optional number of items per page to override the default value
+	 */
+	public function __construct($page = 1, $itemsPerPage = self::DEFAULT_ITEMS_PER_PAGE)
+	{
+		$this->setPage($page);
+		$this->setItemsPerPage($itemsPerPage);
+	}
+
+	/**
+	 * Returns the start offset for a LIMIT clause. Starts at 0.
+	 *
+	 * @return integer
+	 */
+	public function getStart()
+	{
+		return max(0, ($this->page * $this->itemsPerPage) - $this->itemsPerPage);
+	}
+
+	/**
+	 * Returns the number of items per page
+	 *
+	 * @return integer
+	 */
+	public function getItemsPerPage()
+	{
+		return $this->itemsPerPage;
+	}
+
+	/**
+	 * Returns the current page number
+	 *
+	 * @return int
+	 */
+	public function getPage()
+	{
+		return $this->page;
+	}
+
+	/**
+	 * Sets the number of items per page, 1 minimum.
+	 *
+	 * @param integer $itemsPerPage
+	 */
+	public function setItemsPerPage($itemsPerPage)
+	{
+		$this->itemsPerPage = max(1, intval($itemsPerPage ?? self::DEFAULT_ITEMS_PER_PAGE));
+	}
+
+	/**
+	 * Sets the current page number. Starts at 1.
+	 *
+	 * @param integer $page
+	 */
+	public function setPage($page)
+	{
+		$this->page = max(1, intval($page ?? 1));
+	}
+}

--- a/tests/src/Content/RenderedPagerTest.php
+++ b/tests/src/Content/RenderedPagerTest.php
@@ -1,0 +1,402 @@
+<?php
+
+namespace Friendica\Test\src\Content;
+
+use Friendica\Content\RenderedPager;
+use Friendica\Test\MockedTest;
+use Friendica\Test\Util\AppMockTrait;
+use Friendica\Test\Util\L10nMockTrait;
+use Friendica\Test\Util\RendererMockTrait;
+use Friendica\Test\Util\VFSTrait;
+
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ *
+ * @note if you change the count of the pages at the full view (@see RenderedPager::DEFAULT_PAGE_LIMIT )
+ *       you have to change the pageFrom / pageTo accordingly
+ */
+class RenderedPagerTest extends MockedTest
+{
+	use VFSTrait;
+	use AppMockTrait;
+	use RendererMockTrait;
+	use L10nMockTrait;
+
+	protected function setUp()
+	{
+		parent::setUp();
+
+		$this->setUpVfsDir();
+		$this->mockApp($this->root);
+		$this->mockL10nT();
+	}
+
+	/**
+	 * Assertion of a minimal rendering pager
+	 *
+	 * @param string $urlPrev      The url of the previous page
+	 * @param string $urlNext      The url of the next page
+	 * @param bool   $prevDisabled true, if the link of the previous page is disabled
+	 * @param bool   $nextDisabled true, if the the link of the next page is disabled
+	 */
+	private function assertMinimal(string $urlPrev, string $urlNext, bool $prevDisabled, bool $nextDisabled)
+	{
+		$this->assertData([
+			'class' => 'pager',
+			'prev'  => [
+				'url'   => $urlPrev,
+				'text'  => 'newer',
+				'class' => $prevDisabled ? 'previous disabled' : 'previous',
+			],
+			'next'  => [
+				'url'   => $urlNext,
+				'text'  => 'older',
+				'class' => $nextDisabled ? 'next disabled' : 'next',
+			]
+		]);
+	}
+
+	/**
+	 * Assertion of a full rendering pager
+	 *
+	 * @param string $urlFirst      The url of the first page
+	 * @param string $urlPrev       The url of the previous page
+	 * @param string $urlNext       The url of the next page
+	 * @param string $urlLast       The url of the last page
+	 * @param bool   $firstDisabled true, if the url of the first page is disabled
+	 * @param bool   $prevDisabled  true, if the url of the previous page is disabled
+	 * @param bool   $nextDisabled  true, if the url of the next page is disabled
+	 * @param bool   $lastDisabled  true, if the url of the last page is disabled
+	 * @param string $urlPages      url-pattern for every url in the pager
+	 * @param int    $pagesFrom     first shown number/page of the pager (depends on the current page!)
+	 * @param int    $pagesTo       last shown number/page of the pager (depends on the current page!)
+	 * @param int    $current       The current page
+	 */
+	private function assertFull(string $urlFirst, string $urlPrev, string $urlNext, string $urlLast,
+	                            bool $firstDisabled, bool $prevDisabled, bool $nextDisabled, bool $lastDisabled,
+	                            string $urlPages, int $pagesFrom, int $pagesTo, int $current)
+	{
+		$pages = [];
+		for ($i = $pagesFrom; $i <= $pagesTo; $i++) {
+			if ($i === $current) {
+				$pages[$i] = [
+					'url'   => '#',
+					'text'  => $i,
+					'class' => 'current active',
+				];
+			} else {
+				$pages[$i] = [
+					'url'   => $urlPages . $i,
+					'text'  => $i,
+					'class' => 'n',
+				];
+			}
+		}
+
+		$this->assertData([
+			'class' => 'pagination',
+			'first' => [
+				'url'   => $urlFirst,
+				'text'  => 'first',
+				'class' => $firstDisabled ? 'disabled' : '',
+			],
+			'prev'  => [
+				'url'   => $urlPrev,
+				'text'  => 'prev',
+				'class' => $prevDisabled ? 'disabled' : '',
+			],
+			'pages' => $pages,
+			'next'  => [
+				'url'   => $urlNext,
+				'text'  => 'next',
+				'class' => $nextDisabled ? 'disabled' : '',
+			],
+			'last'  => [
+
+				'url'   => $urlLast,
+				'text'  => 'last',
+				'class' => $lastDisabled ? 'disabled' : '',
+			],
+		]);
+	}
+
+	/**
+	 * Assert a markup
+	 *
+	 * @todo In a perfect world, we don't have to use mocking-spies for unit-tests (they are now just failing with ugly exceptions..)
+	 *       depends on App/Config/Rendering mocking
+	 *
+	 * @param array $expect
+	 */
+	private function assertData(array $expect)
+	{
+		$this->mockGetMarkupTemplate('paginate.tpl', 'test', 1);
+		$this->mockReplaceMacros('test', ['pager' => $expect], '', 1);
+	}
+
+	public function dataMinimal()
+	{
+		return [
+			'firstPage'  => [
+				'data'   => [
+					'queryString'  => 'test.php',
+					'page'         => 1,
+					'itemsPerPage' => 20,
+					'itemCount'    => 200,
+				],
+				'assert' => [
+					'prev'         => 'test.php?page=0',
+					'next'         => 'test.php?page=2',
+					'prevDisabled' => true,
+					'nextDisabled' => false,
+				],
+			],
+			'lastPage'   => [
+				'data'   => [
+					'queryString'  => 'test.php',
+					'page'         => 5,
+					'itemsPerPage' => 20,
+					'itemCount'    => 19,
+				],
+				'assert' => [
+					'prev'         => 'test.php?page=4',
+					'next'         => 'test.php?page=6',
+					'prevDisabled' => false,
+					'nextDisabled' => true,
+				],
+			],
+			'middlePage' => [
+				'data'   => [
+					'queryString'  => 'test.php',
+					'page'         => 2,
+					'itemsPerPage' => 20,
+					'itemCount'    => 100,
+				],
+				'assert' => [
+					'prev'         => 'test.php?page=1',
+					'next'         => 'test.php?page=3',
+					'prevDisabled' => false,
+					'nextDisabled' => false,
+				],
+			],
+			'onePage'    => [
+				'data'   => [
+					'queryString'  => 'test.php',
+					'page'         => 1,
+					'itemsPerPage' => 20,
+					'itemCount'    => 19,
+				],
+				'assert' => [
+					'prev'         => 'test.php?page=0',
+					'next'         => 'test.php?page=2',
+					'prevDisabled' => true,
+					'nextDisabled' => true,
+				],
+			],
+		];
+	}
+
+	/**
+	 * Test the rendering of a minimal pager
+	 *
+	 * @dataProvider dataMinimal
+	 */
+	public function testMinimal(array $data, array $assert)
+	{
+		$this->assertMinimal($assert['prev'], $assert['next'], $assert['prevDisabled'], $assert['nextDisabled']);
+
+		if (isset($data['itemsPerPage'])) {
+			$pager = new RenderedPager($data['queryString'], $data['page'], $data['itemsPerPage']);
+		} elseif (isset($data['page'])) {
+			$pager = new RenderedPager($data['queryString'], $data['page']);
+		} else {
+			$pager = new RenderedPager($data['queryString']);
+		}
+
+		$pager->renderMinimal($data['itemCount']);
+	}
+
+	public function dataFull()
+	{
+		return [
+			'firstPage'              => [
+				'data'   => [
+					'queryString'  => 'test.php',
+					'page'         => 1,
+					'itemsPerPage' => 20,
+					'itemCount'    => 100,
+				],
+				'assert' => [
+					'urlFirst'      => 'test.php?page=1',
+					'urlPrev'       => 'test.php?page=0',
+					'urlNext'       => 'test.php?page=2',
+					'urlLast'       => 'test.php?page=5',
+					'firstDisabled' => true,
+					'prevDisabled'  => true,
+					'nextDisabled'  => false,
+					'lastDisabled'  => false,
+					'urlPages'      => 'test.php?page=',
+					'pagesFrom'     => 1,
+					'pagesTo'       => 5,
+					'current'       => 1,
+				],
+			],
+			'lastPage'               => [
+				'data'   => [
+					'queryString'  => 'test.php',
+					'page'         => 5,
+					'itemsPerPage' => 20,
+					'itemCount'    => 100,
+				],
+				'assert' => [
+					'urlFirst'      => 'test.php?page=1',
+					'urlPrev'       => 'test.php?page=4',
+					'urlNext'       => 'test.php?page=6',
+					'urlLast'       => 'test.php?page=5',
+					'firstDisabled' => false,
+					'prevDisabled'  => false,
+					'nextDisabled'  => true,
+					'lastDisabled'  => true,
+					'urlPages'      => 'test.php?page=',
+					'pagesFrom'     => 1,
+					'pagesTo'       => 5,
+					'current'       => 5,
+				],
+			],
+			'middlePage'             => [
+				'data'   => [
+					'queryString'  => 'test.php',
+					'page'         => 2,
+					'itemsPerPage' => 20,
+					'itemCount'    => 100,
+				],
+				'assert' => [
+					'urlFirst'      => 'test.php?page=1',
+					'urlPrev'       => 'test.php?page=1',
+					'urlNext'       => 'test.php?page=3',
+					'urlLast'       => 'test.php?page=5',
+					'firstDisabled' => false,
+					'prevDisabled'  => false,
+					'nextDisabled'  => false,
+					'lastDisabled'  => false,
+					'urlPages'      => 'test.php?page=',
+					'pagesFrom'     => 1,
+					'pagesTo'       => 5,
+					'current'       => 2,
+				],
+			],
+			'unevenCountMiddle'      => [
+				'data'   => [
+					'queryString'  => 'test.php',
+					'page'         => 5,
+					'itemsPerPage' => 11,
+					'itemCount'    => 100,
+				],
+				'assert' => [
+					'urlFirst'      => 'test.php?page=1',
+					'urlPrev'       => 'test.php?page=4',
+					'urlNext'       => 'test.php?page=6',
+					'urlLast'       => 'test.php?page=10',
+					'firstDisabled' => false,
+					'prevDisabled'  => false,
+					'nextDisabled'  => false,
+					'lastDisabled'  => false,
+					'urlPages'      => 'test.php?page=',
+					'pagesFrom'     => 1,
+					'pagesTo'       => 10,
+					'current'       => 5,
+				],
+			],
+			'unevenCountLast'        => [
+				'data'   => [
+					'queryString'  => 'test.php',
+					'page'         => 10,
+					'itemsPerPage' => 11,
+					'itemCount'    => 100,
+				],
+				'assert' => [
+					'urlFirst'      => 'test.php?page=1',
+					'urlPrev'       => 'test.php?page=9',
+					'urlNext'       => 'test.php?page=11',
+					'urlLast'       => 'test.php?page=10',
+					'firstDisabled' => false,
+					'prevDisabled'  => false,
+					'nextDisabled'  => true,
+					'lastDisabled'  => true,
+					'urlPages'      => 'test.php?page=',
+					'pagesFrom'     => 6,
+					'pagesTo'       => 10,
+					'current'       => 10,
+				],
+			],
+			'unevenCountFirst'       => [
+				'data'   => [
+					'queryString'  => 'test.php',
+					'page'         => 1,
+					'itemsPerPage' => 11,
+					'itemCount'    => 100,
+				],
+				'assert' => [
+					'urlFirst'      => 'test.php?page=1',
+					'urlPrev'       => 'test.php?page=0',
+					'urlNext'       => 'test.php?page=2',
+					'urlLast'       => 'test.php?page=10',
+					'firstDisabled' => true,
+					'prevDisabled'  => true,
+					'nextDisabled'  => false,
+					'lastDisabled'  => false,
+					'urlPages'      => 'test.php?page=',
+					'pagesFrom'     => 1,
+					'pagesTo'       => 10,
+					'current'       => 1,
+				],
+			],
+			'stripAfterDefaultPages' => [
+				'data'   => [
+					'queryString'  => 'test.php',
+					'page'         => 1,
+					'itemsPerPage' => 11,
+					'itemCount'    => 1000,
+				],
+				'assert' => [
+					'urlFirst'      => 'test.php?page=1',
+					'urlPrev'       => 'test.php?page=0',
+					'urlNext'       => 'test.php?page=2',
+					'urlLast'       => 'test.php?page=91',
+					'firstDisabled' => true,
+					'prevDisabled'  => true,
+					'nextDisabled'  => false,
+					'lastDisabled'  => false,
+					'urlPages'      => 'test.php?page=',
+					'pagesFrom'     => 1,
+					'pagesTo'       => 10, // Default to 10, change in case you change the default page count
+					'current'       => 1,
+				],
+			],
+		];
+	}
+
+	/**
+	 * Test the rendering of a full pager
+	 *
+	 * @dataProvider dataFull
+	 */
+	public function testFull(array $data, array $assert)
+	{
+		$this->assertFull($assert['urlFirst'], $assert['urlPrev'], $assert['urlNext'], $assert['urlLast'],
+			$assert['firstDisabled'], $assert['prevDisabled'], $assert['nextDisabled'], $assert['lastDisabled'],
+			$assert['urlPages'], $assert['pagesFrom'], $assert['pagesTo'], $assert['current']);
+
+
+		if (isset($data['itemsPerPage'])) {
+			$pager = new RenderedPager($data['queryString'], $data['page'], $data['itemsPerPage']);
+		} elseif (isset($data['page'])) {
+			$pager = new RenderedPager($data['queryString'], $data['page']);
+		} else {
+			$pager = new RenderedPager($data['queryString']);
+		}
+
+		$pager->renderFull($data['itemCount']);
+	}
+}

--- a/tests/src/Object/PagerTest.php
+++ b/tests/src/Object/PagerTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Friendica\Test\src\Object;
+
+use Friendica\Object\Pager;
+use PHPUnit\Framework\TestCase;
+
+class PagerTest extends TestCase
+{
+	public function dataPager()
+	{
+		return [
+			'default'          => [
+				'data'   => [
+					'page'         => null,
+					'itemsPerPage' => null,
+				],
+				'expect' => [
+					'start'           => 0,
+					'itemsPerPage'    => 50,
+					'page'            => 1,
+				],
+			],
+			'withStart'        => [
+				'data'   => [
+					'page'         => 5,
+					'itemsPerPage' => null,
+				],
+				'expect' => [
+					'start'           => 200,
+					'itemsPerPage'    => 50,
+					'page'            => 5,
+				],
+			],
+			'withItemsPerPage' => [
+				'data'   => [
+					'page'         => 3,
+					'itemsPerPage' => 77,
+				],
+				'expect' => [
+					'start'           => 154,
+					'itemsPerPage'    => 77,
+					'page'            => 3,
+				],
+			],
+			'negativeItemsPerPage' => [
+				'data'   => [
+					'page'         => 2,
+					'itemsPerPage' => -35,
+				],
+				'expect' => [
+					'start'           => 1,
+					'itemsPerPage'    => 1,
+					'page'            => 2,
+				],
+			],
+			'negativePage' => [
+				'data'   => [
+					'page'         => -24,
+					'itemsPerPage' => 20,
+				],
+				'expect' => [
+					'start'           => 0,
+					'itemsPerPage'    => 20,
+					'page'            => 1,
+				],
+			],
+			'negativePageItemsPerPage' => [
+				'data'   => [
+					'page'         => -24,
+					'itemsPerPage' => -52,
+				],
+				'expect' => [
+					'start'           => 0,
+					'itemsPerPage'    => 1,
+					'page'            => 1,
+				],
+			],
+		];
+	}
+
+	/**
+	 * Test some given data for constructing a Pager
+	 *
+	 * @dataProvider dataPager
+	 */
+	public function testConstructor(array $data, array $expect)
+	{
+		if (isset($data['itemsPerPage'])) {
+			$pager = new Pager($data['page'], $data['itemsPerPage']);
+		} elseif (isset($data['page'])) {
+			$pager = new Pager($data['page']);
+		} else {
+			$pager = new Pager();
+		}
+
+		$this->assertEquals($expect['itemsPerPage'], $pager->getItemsPerPage());
+		$this->assertEquals($expect['page'], $pager->getPage());
+		$this->assertEquals($expect['start'], $pager->getStart());
+	}
+
+	/**
+	 * Test some given data for the Setter of a Pager
+	 *
+	 * @dataProvider dataPager
+	 */
+	public function testSetter(array $data, array $expect)
+	{
+		$pager = new Pager('');
+
+		$pager->setPage($data['page']);
+		$pager->setItemsPerPage($data['itemsPerPage']);
+
+		$this->assertEquals($expect['start'], $pager->getStart());
+		$this->assertEquals($expect['itemsPerPage'], $pager->getItemsPerPage());
+		$this->assertEquals($expect['page'], $pager->getPage());
+	}
+}


### PR DESCRIPTION
What I did:

- Split backend pager logic and frontend rendering
  - Removed direct $_GET of the Pager
  - (Temporary) introduced $a->page['page'] for the current page
  - Moved the core-logic of Pager to Friendica\Object
- Adding tests for pager logic
- Adding tests for RenderedPager

I'd like to use the Pager class without the need of adding the whole Renderer dependencies for some followup work.

To improve stability, I added tests to each of the Pager & new RendererPager class.

I branched from 2019.06-rc because it should be easier to rebase it after the release ..