### PR TITLE
expand permission check to remote array

### DIFF
--- a/src/Util/Security.php
+++ b/src/Util/Security.php
@@ -120,9 +120,21 @@ class Security extends BaseObject
 			 */
 
 			if (!$remote_verified) {
-				if (DBA::exists('contact', ['id' => $remote_user, 'uid' => $owner_id, 'blocked' => false])) {
+				$cid = 0;
+
+				if (!empty($_SESSION['remote'])) {
+					foreach ($_SESSION['remote'] as $visitor) {
+						Logger::log("this remote array entry is".$visitor);
+						if ($visitor['uid'] == $owner_id) {
+							$cid = $visitor['cid'];
+							break;
+						}
+					}
+				}
+
+				if ($cid && DBA::exists('contact', ['id' => $cid, 'uid' => $owner_id, 'blocked' => false])) {
 					$remote_verified = true;
-					$groups = Group::getIdsByContactId($remote_user);
+					$groups = Group::getIdsByContactId($cid);
 				}
 			}
 
@@ -140,9 +152,9 @@ class Security extends BaseObject
 					  AND ( allow_cid REGEXP '<%d>' OR allow_gid REGEXP '%s' OR ( allow_cid = '' AND allow_gid = '') )
 					  )
 					",
-					intval($remote_user),
+					intval($cid),
 					DBA::escape($gs),
-					intval($remote_user),
+					intval($cid),
 					DBA::escape($gs)
 				);
 			}

--- a/src/Util/Security.php
+++ b/src/Util/Security.php
@@ -124,7 +124,6 @@ class Security extends BaseObject
 
 				if (!empty($_SESSION['remote'])) {
 					foreach ($_SESSION['remote'] as $visitor) {
-						Logger::log("this remote array entry is".$visitor);
 						if ($visitor['uid'] == $owner_id) {
 							$cid = $visitor['cid'];
 							break;

--- a/src/Util/Security.php
+++ b/src/Util/Security.php
@@ -122,12 +122,10 @@ class Security extends BaseObject
 			if (!$remote_verified) {
 				$cid = 0;
 
-				if (!empty($_SESSION['remote'])) {
-					foreach ($_SESSION['remote'] as $visitor) {
-						if ($visitor['uid'] == $owner_id) {
-							$cid = $visitor['cid'];
-							break;
-						}
+				foreach (\Friendica\Core\Session::get('remote', []) as $visitor) {
+					if ($visitor['uid'] == $owner_id) {
+						$cid = $visitor['cid'];
+						break;
 					}
 				}
 


### PR DESCRIPTION
This check was preventing multiple private images from different
users on the same server from loading on the same page.
It was only checking for permission for the single id returned by the
remote_user() function rather than the multiple possible autheniticated
id's stored in the "remote" array stored in the session.

This partially fixes #5276.  I think is probably good to update independent of that.  Even the other function in the same file processes the remote array rather than the single remote_user.