### PR TITLE
Add typed parameter for methods in `Friendica\Util\Network`

### DIFF
--- a/mod/dfrn_confirm.php
+++ b/mod/dfrn_confirm.php
@@ -209,7 +209,7 @@ function dfrn_confirm_post(App $a, $handsfree = null)
 		 *
 		 */
 
-		$res = Network::post($dfrn_confirm, $params, null, $redirects, 120)->getBody();
+		$res = Network::post($dfrn_confirm, $params, null, 120)->getBody();
 
 		Logger::log(' Confirm: received data: ' . $res, Logger::DATA);
 

--- a/mod/parse_url.php
+++ b/mod/parse_url.php
@@ -70,9 +70,8 @@ function parse_url_content(App $a)
 
 	// Check if the URL is an image, video or audio file. If so format
 	// the URL with the corresponding BBCode media tag
-	$redirects = 0;
 	// Fetch the header of the URL
-	$curlResponse = Network::curl($url, false, $redirects, ['novalidate' => true, 'nobody' => true]);
+	$curlResponse = Network::curl($url, false, ['novalidate' => true, 'nobody' => true]);
 
 	if ($curlResponse->isSuccess()) {
 		// Convert the header fields into an array

--- a/src/Content/OEmbed.php
+++ b/src/Content/OEmbed.php
@@ -83,8 +83,7 @@ class OEmbed
 
 			if (!in_array($ext, $noexts)) {
 				// try oembed autodiscovery
-				$redirects = 0;
-				$html_text = Network::fetchUrl($embedurl, false, $redirects, 15, 'text/*');
+				$html_text = Network::fetchUrl($embedurl, false, 15, 'text/*');
 				if ($html_text) {
 					$dom = @DOMDocument::loadHTML($html_text);
 					if ($dom) {

--- a/src/Core/Search.php
+++ b/src/Core/Search.php
@@ -107,8 +107,7 @@ class Search extends BaseObject
 			$searchUrl .= '&page=' . $page;
 		}
 
-		$red        = 0;
-		$resultJson = Network::fetchUrl($searchUrl, false, $red, 0, 'application/json');
+		$resultJson = Network::fetchUrl($searchUrl, false, 0, 'application/json');
 
 		$results = json_decode($resultJson, true);
 

--- a/src/Core/Worker.php
+++ b/src/Core/Worker.php
@@ -983,7 +983,7 @@ class Worker
 		}
 
 		$url = System::baseUrl()."/worker";
-		Network::fetchUrl($url, false, $redirects, 1);
+		Network::fetchUrl($url, false, 1);
 	}
 
 	/**

--- a/src/Model/APContact.php
+++ b/src/Model/APContact.php
@@ -34,7 +34,7 @@ class APContact extends BaseObject
 
 		$webfinger = 'https://' . $addr_parts[1] . '/.well-known/webfinger?resource=acct:' . urlencode($addr);
 
-		$curlResult = Network::curl($webfinger, false, $redirects, ['accept_content' => 'application/jrd+json,application/json']);
+		$curlResult = Network::curl($webfinger, false, ['accept_content' => 'application/jrd+json,application/json']);
 		if (!$curlResult->isSuccess() || empty($curlResult->getBody())) {
 			return false;
 		}

--- a/src/Module/Magic.php
+++ b/src/Module/Magic.php
@@ -85,7 +85,7 @@ class Magic extends BaseModule
 				);
 
 				// Try to get an authentication token from the other instance.
-				$curlResult = Network::curl($basepath . '/owa', false, $redirects, ['headers' => $headers]);
+				$curlResult = Network::curl($basepath . '/owa', false, ['headers' => $headers]);
 
 				if ($curlResult->isSuccess()) {
 					$j = json_decode($curlResult->getBody(), true);

--- a/src/Network/Probe.php
+++ b/src/Network/Probe.php
@@ -109,12 +109,11 @@ class Probe
 		$url = "http://".$host."/.well-known/host-meta";
 
 		$xrd_timeout = Config::get('system', 'xrd_timeout', 20);
-		$redirects = 0;
 
 		Logger::log("Probing for ".$host, Logger::DEBUG);
 		$xrd = null;
 
-		$curlResult = Network::curl($ssl_url, false, $redirects, ['timeout' => $xrd_timeout, 'accept_content' => 'application/xrd+xml']);
+		$curlResult = Network::curl($ssl_url, false, ['timeout' => $xrd_timeout, 'accept_content' => 'application/xrd+xml']);
 		if ($curlResult->isSuccess()) {
 			$xml = $curlResult->getBody();
 			$xrd = XML::parseString($xml, false);
@@ -122,7 +121,7 @@ class Probe
 		}
 
 		if (!is_object($xrd)) {
-			$curlResult = Network::curl($url, false, $redirects, ['timeout' => $xrd_timeout, 'accept_content' => 'application/xrd+xml']);
+			$curlResult = Network::curl($url, false, ['timeout' => $xrd_timeout, 'accept_content' => 'application/xrd+xml']);
 			if ($curlResult->isTimeout()) {
 				Logger::log("Probing timeout for " . $url, Logger::DEBUG);
 				self::$istimeout = true;
@@ -738,9 +737,8 @@ class Probe
 	private static function webfinger($url, $type)
 	{
 		$xrd_timeout = Config::get('system', 'xrd_timeout', 20);
-		$redirects = 0;
 
-		$curlResult = Network::curl($url, false, $redirects, ['timeout' => $xrd_timeout, 'accept_content' => $type]);
+		$curlResult = Network::curl($url, false, ['timeout' => $xrd_timeout, 'accept_content' => $type]);
 		if ($curlResult->isTimeout()) {
 			self::$istimeout = true;
 			return false;

--- a/src/Object/Image.php
+++ b/src/Object/Image.php
@@ -781,7 +781,7 @@ class Image
 		$data = Cache::get($url);
 
 		if (is_null($data) || !$data || !is_array($data)) {
-			$img_str = Network::fetchUrl($url, true, $redirects, 4);
+			$img_str = Network::fetchUrl($url, true, 4);
 
 			if (!$img_str) {
 				return false;

--- a/src/Protocol/ActivityPub.php
+++ b/src/Protocol/ActivityPub.php
@@ -74,7 +74,7 @@ class ActivityPub
 			return HTTPSignature::fetch($url, $uid);
 		}
 
-		$curlResult = Network::curl($url, false, $redirects, ['accept_content' => 'application/activity+json, application/ld+json']);
+		$curlResult = Network::curl($url, false, ['accept_content' => 'application/activity+json, application/ld+json']);
 		if (!$curlResult->isSuccess() || empty($curlResult->getBody())) {
 			return false;
 		}

--- a/src/Protocol/OStatus.php
+++ b/src/Protocol/OStatus.php
@@ -738,7 +738,7 @@ class OStatus
 
 		self::$conv_list[$conversation] = true;
 
-		$curlResult = Network::curl($conversation, false, $redirects, ['accept_content' => 'application/atom+xml, text/html']);
+		$curlResult = Network::curl($conversation, false, ['accept_content' => 'application/atom+xml, text/html']);
 
 		if (!$curlResult->isSuccess()) {
 			return;
@@ -931,7 +931,7 @@ class OStatus
 		}
 
 		$stored = false;
-		$curlResult = Network::curl($related, false, $redirects, ['accept_content' => 'application/atom+xml, text/html']);
+		$curlResult = Network::curl($related, false, ['accept_content' => 'application/atom+xml, text/html']);
 
 		if (!$curlResult->isSuccess()) {
 			return;

--- a/src/Protocol/PortableContact.php
+++ b/src/Protocol/PortableContact.php
@@ -1004,7 +1004,7 @@ class PortableContact
 		$server_url = str_replace("http://", "https://", $server_url);
 
 		// We set the timeout to 20 seconds since this operation should be done in no time if the server was vital
-		$curlResult = Network::curl($server_url."/.well-known/host-meta", false, $redirects, ['timeout' => 20]);
+		$curlResult = Network::curl($server_url."/.well-known/host-meta", false, ['timeout' => 20]);
 
 		// Quit if there is a timeout.
 		// But we want to make sure to only quit if we are mostly sure that this server url fits.
@@ -1021,7 +1021,7 @@ class PortableContact
 			$server_url = str_replace("https://", "http://", $server_url);
 
 			// We set the timeout to 20 seconds since this operation should be done in no time if the server was vital
-			$curlResult = Network::curl($server_url."/.well-known/host-meta", false, $redirects, ['timeout' => 20]);
+			$curlResult = Network::curl($server_url."/.well-known/host-meta", false, ['timeout' => 20]);
 
 			// Quit if there is a timeout
 			if ($curlResult->isTimeout()) {
@@ -1624,7 +1624,7 @@ class PortableContact
 			if (!empty($accesstoken)) {
 				$api = 'https://instances.social/api/1.0/instances/list?count=0';
 				$header = ['Authorization: Bearer '.$accesstoken];
-				$curlResult = Network::curl($api, false, $redirects, ['headers' => $header]);
+				$curlResult = Network::curl($api, false, ['headers' => $header]);
 
 				if ($curlResult->isSuccess()) {
 					$servers = json_decode($curlResult->getBody(), true);

--- a/src/Util/HTTPSignature.php
+++ b/src/Util/HTTPSignature.php
@@ -455,7 +455,7 @@ class HTTPSignature
 		$curl_opts = $opts;
 		$curl_opts['header'] = $headers;
 
-		$curlResult = Network::curl($request, false, $redirects, $curl_opts);
+		$curlResult = Network::curl($request, false, $curl_opts);
 		$return_code = $curlResult->getReturnCode();
 
 		Logger::log('Fetched for user ' . $uid . ' from ' . $request . ' returned ' . $return_code, Logger::DEBUG);

--- a/src/Util/Network.php
+++ b/src/Util/Network.php
@@ -23,17 +23,17 @@ class Network
 	 *
 	 * @brief Curl wrapper
 	 * @param string  $url            URL to fetch
-	 * @param boolean $binary         default false
+	 * @param bool    $binary         default false
 	 *                                TRUE if asked to return binary results (file download)
-	 * @param integer $redirects      The recursion counter for internal use - default 0
-	 * @param integer $timeout        Timeout in seconds, default system config value or 60 seconds
+	 * @param int     $redirects      The recursion counter for internal use - default 0
+	 * @param int     $timeout        Timeout in seconds, default system config value or 60 seconds
 	 * @param string  $accept_content supply Accept: header with 'accept_content' as the value
 	 * @param string  $cookiejar      Path to cookie jar file
 	 *
 	 * @return string The fetched content
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
-	public static function fetchUrl($url, $binary = false, &$redirects = 0, $timeout = 0, $accept_content = null, $cookiejar = '')
+	public static function fetchUrl(string $url, bool $binary = false, int &$redirects = 0, int $timeout = 0, string $accept_content = null, string $cookiejar = '')
 	{
 		$ret = self::fetchUrlFull($url, $binary, $redirects, $timeout, $accept_content, $cookiejar);
 
@@ -48,17 +48,17 @@ class Network
 	 *
 	 * @brief Curl wrapper with array of return values.
 	 * @param string  $url            URL to fetch
-	 * @param boolean $binary         default false
+	 * @param bool    $binary         default false
 	 *                                TRUE if asked to return binary results (file download)
-	 * @param integer $redirects      The recursion counter for internal use - default 0
-	 * @param integer $timeout        Timeout in seconds, default system config value or 60 seconds
+	 * @param int     $redirects      The recursion counter for internal use - default 0
+	 * @param int     $timeout        Timeout in seconds, default system config value or 60 seconds
 	 * @param string  $accept_content supply Accept: header with 'accept_content' as the value
 	 * @param string  $cookiejar      Path to cookie jar file
 	 *
 	 * @return CurlResult With all relevant information, 'body' contains the actual fetched content.
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
-	public static function fetchUrlFull($url, $binary = false, &$redirects = 0, $timeout = 0, $accept_content = null, $cookiejar = '')
+	public static function fetchUrlFull(string $url, bool $binary = false, int &$redirects = 0, int $timeout = 0, string $accept_content = null, string $cookiejar = '')
 	{
 		return self::curl(
 			$url,
@@ -75,7 +75,7 @@ class Network
 	 * @brief fetches an URL.
 	 *
 	 * @param string  $url       URL to fetch
-	 * @param boolean $binary    default false
+	 * @param bool    $binary    default false
 	 *                           TRUE if asked to return binary results (file download)
 	 * @param int     $redirects The recursion counter for internal use - default 0
 	 * @param array   $opts      (optional parameters) assoziative array with:
@@ -90,7 +90,7 @@ class Network
 	 * @return CurlResult
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
-	public static function curl($url, $binary = false, &$redirects = 0, $opts = [])
+	public static function curl(string $url, bool $binary = false, int &$redirects = 0, array $opts = [])
 	{
 		$stamp1 = microtime(true);
 
@@ -243,13 +243,13 @@ class Network
 	 * @param string  $url       URL to post
 	 * @param mixed   $params    array of POST variables
 	 * @param string  $headers   HTTP headers
-	 * @param integer $redirects Recursion counter for internal use - default = 0
-	 * @param integer $timeout   The timeout in seconds, default system config value or 60 seconds
+	 * @param int     $redirects Recursion counter for internal use - default = 0
+	 * @param int     $timeout   The timeout in seconds, default system config value or 60 seconds
 	 *
 	 * @return CurlResult The content
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
-	public static function post($url, $params, $headers = null, &$redirects = 0, $timeout = 0)
+	public static function post(string $url, $params, string $headers = null, int &$redirects = 0, int $timeout = 0)
 	{
 		$stamp1 = microtime(true);
 
@@ -351,7 +351,7 @@ class Network
 	 * @return string|boolean The actual working URL, false else
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
-	public static function isUrlValid($url)
+	public static function isUrlValid(string $url)
 	{
 		if (Config::get('system', 'disable_url_validation')) {
 			return $url;
@@ -381,9 +381,8 @@ class Network
 	 *
 	 * @param string $addr The email address
 	 * @return boolean True if it's a valid email address, false if it's not
-	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
-	public static function isEmailDomainValid($addr)
+	public static function isEmailDomainValid(string $addr)
 	{
 		if (Config::get('system', 'disable_email_validation')) {
 			return true;
@@ -413,9 +412,8 @@ class Network
 	 *
 	 * @param string $url URL which get tested
 	 * @return boolean True if url is allowed otherwise return false
-	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
-	public static function isUrlAllowed($url)
+	public static function isUrlAllowed(string $url)
 	{
 		$h = @parse_url($url);
 
@@ -460,7 +458,7 @@ class Network
 	 *
 	 * @return boolean
 	 */
-	public static function isUrlBlocked($url)
+	public static function isUrlBlocked(string $url)
 	{
 		$host = @parse_url($url, PHP_URL_HOST);
 		if (!$host) {
@@ -491,7 +489,7 @@ class Network
 	 *                       or if allowed list is not configured
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
-	public static function isEmailDomainAllowed($email)
+	public static function isEmailDomainAllowed(string $email)
 	{
 		$domain = strtolower(substr($email, strpos($email, '@') + 1));
 		if (!$domain) {
@@ -516,7 +514,7 @@ class Network
 	 * @param array  $domain_list
 	 * @return boolean
 	 */
-	public static function isDomainAllowed($domain, array $domain_list)
+	public static function isDomainAllowed(string $domain, array $domain_list)
 	{
 		$found = false;
 
@@ -531,7 +529,7 @@ class Network
 		return $found;
 	}
 
-	public static function lookupAvatarByEmail($email)
+	public static function lookupAvatarByEmail(string $email)
 	{
 		$avatar['size'] = 300;
 		$avatar['email'] = $email;
@@ -554,7 +552,7 @@ class Network
 	 * @param string $url Any user-submitted URL that may contain tracking params
 	 * @return string The same URL stripped of tracking parameters
 	 */
-	public static function stripTrackingQueryParams($url)
+	public static function stripTrackingQueryParams(string $url)
 	{
 		$urldata = parse_url($url);
 		if (!empty($urldata["query"])) {
@@ -613,7 +611,7 @@ class Network
 	 * @return string A canonical URL
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
-	public static function finalUrl($url, $depth = 1, $fetchbody = false)
+	public static function finalUrl(string $url, int $depth = 1, bool $fetchbody = false)
 	{
 		$a = \get_app();
 
@@ -724,7 +722,7 @@ class Network
 	 * @param string $url2
 	 * @return string The matching part
 	 */
-	public static function getUrlMatch($url1, $url2)
+	public static function getUrlMatch(string $url1, string $url2)
 	{
 		if (($url1 == "") || ($url2 == "")) {
 			return "";
@@ -812,7 +810,7 @@ class Network
 	 *
 	 * @return string The glued URL
 	 */
-	public static function unparseURL($parsed)
+	public static function unparseURL(array $parsed)
 	{
 		$get = function ($key) use ($parsed) {
 			return isset($parsed[$key]) ? $parsed[$key] : null;
@@ -844,7 +842,7 @@ class Network
 	 *
 	 * @return string switched URL
 	 */
-	public static function switchScheme($url)
+	public static function switchScheme(string $url)
 	{
 		$scheme = parse_url($url, PHP_URL_SCHEME);
 		if (empty($scheme)) {

--- a/src/Worker/OnePoll.php
+++ b/src/Worker/OnePoll.php
@@ -371,7 +371,7 @@ class OnePoll
 			}
 
 			$cookiejar = tempnam(get_temppath(), 'cookiejar-onepoll-');
-			$curlResult = Network::curl($contact['poll'], false, $redirects, ['cookiejar' => $cookiejar]);
+			$curlResult = Network::curl($contact['poll'], false, ['cookiejar' => $cookiejar]);
 			unlink($cookiejar);
 
 			if ($curlResult->isTimeout()) {


### PR DESCRIPTION
Enables a more specific exception for https://github.com/friendica/friendica/issues/6917#issuecomment-500123485

I must confess I don't find any new occurrence of `Network::curl()` which could have lead to a array parameter, so I thought the explicit parameters should lead to a more specific exception (to the place where it's called).