### PR TITLE
Fix delivery counter for poking / unify delivery commands

### DIFF
--- a/mod/events.php
+++ b/mod/events.php
@@ -21,6 +21,7 @@ use Friendica\Module\Login;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Strings;
 use Friendica\Util\Temporal;
+use Friendica\Worker\Delivery;
 
 function events_init(App $a)
 {
@@ -195,7 +196,7 @@ function events_post(App $a)
 	$item_id = Event::store($datarray);
 
 	if (!$cid) {
-		Worker::add(PRIORITY_HIGH, "Notifier", "event", $item_id);
+		Worker::add(PRIORITY_HIGH, "Notifier", Delivery::POST, $item_id);
 	}
 
 	$a->internalRedirect('events');

--- a/mod/fsuggest.php
+++ b/mod/fsuggest.php
@@ -10,6 +10,7 @@ use Friendica\Core\Worker;
 use Friendica\Database\DBA;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Strings;
+use Friendica\Worker\Delivery;
 
 function fsuggest_post(App $a)
 {
@@ -51,7 +52,7 @@ function fsuggest_post(App $a)
 		'photo' => $contact['avatar'], 'note' => $note, 'created' => DateTimeFormat::utcNow()];
 	DBA::insert('fsuggest', $fields);
 
-	Worker::add(PRIORITY_HIGH, 'Notifier', 'suggest', DBA::lastInsertId());
+	Worker::add(PRIORITY_HIGH, 'Notifier', Delivery::SUGGESTION, DBA::lastInsertId());
 
 	info(L10n::t('Friend suggestion sent.') . EOL);
 }

--- a/mod/item.php
+++ b/mod/item.php
@@ -604,8 +604,6 @@ function item_post(App $a) {
 		$origin = $_REQUEST['origin'];
 	}
 
-	$notify_type = ($toplevel_item_id ? Delivery::COMMENT : Delivery::POST);
-
 	$uri = ($message_id ? $message_id : Item::newURI($api_source ? $profile_uid : $uid, $guid));
 
 	// Fallback so that we alway have a parent uri
@@ -870,7 +868,7 @@ function item_post(App $a) {
 	// When we are doing some forum posting via ! we have to start the notifier manually.
 	// These kind of posts don't initiate the notifier call in the item class.
 	if ($only_to_forum) {
-		Worker::add(PRIORITY_HIGH, "Notifier", $notify_type, $post_id);
+		Worker::add(PRIORITY_HIGH, "Notifier", Delivery::POST, $post_id);
 	}
 
 	Logger::log('post_complete');

--- a/mod/settings.php
+++ b/mod/settings.php
@@ -27,6 +27,7 @@ use Friendica\Protocol\Email;
 use Friendica\Util\Network;
 use Friendica\Util\Strings;
 use Friendica\Util\Temporal;
+use Friendica\Worker\Delivery;
 
 function get_theme_config_file($theme)
 {
@@ -389,7 +390,7 @@ function settings_post(App $a)
 	BaseModule::checkFormSecurityTokenRedirectOnError('/settings', 'settings');
 
 	if (!empty($_POST['resend_relocate'])) {
-		Worker::add(PRIORITY_HIGH, 'Notifier', 'relocate', local_user());
+		Worker::add(PRIORITY_HIGH, 'Notifier', Delivery::RELOCATION, local_user());
 		info(L10n::t("Relocate message has been send to your contacts"));
 		$a->internalRedirect('settings');
 	}

--- a/mod/tagger.php
+++ b/mod/tagger.php
@@ -12,6 +12,7 @@ use Friendica\Database\DBA;
 use Friendica\Model\Item;
 use Friendica\Util\Strings;
 use Friendica\Util\XML;
+use Friendica\Worker\Delivery;
 
 function tagger_content(App $a) {
 
@@ -194,7 +195,7 @@ EOT;
 
 	Hook::callAll('post_local_end', $arr);
 
-	Worker::add(PRIORITY_HIGH, "Notifier", "tag", $post_id);
+	Worker::add(PRIORITY_HIGH, "Notifier", Delivery::POST, $post_id);
 
 	exit();
 }

--- a/src/Core/UserImport.php
+++ b/src/Core/UserImport.php
@@ -10,6 +10,7 @@ use Friendica\Database\DBStructure;
 use Friendica\Model\Photo;
 use Friendica\Object\Image;
 use Friendica\Util\Strings;
+use Friendica\Worker\Delivery;
 
 /**
  * @brief UserImport class
@@ -278,7 +279,7 @@ class UserImport
 		}
 
 		// send relocate messages
-		Worker::add(PRIORITY_HIGH, 'Notifier', 'relocate', $newuid);
+		Worker::add(PRIORITY_HIGH, 'Notifier', Delivery::RELOCATION, $newuid);
 
 		info(L10n::t("Done. You can now login with your username and password"));
 		$a->internalRedirect('login');

--- a/src/Core/Worker.php
+++ b/src/Core/Worker.php
@@ -1100,7 +1100,7 @@ class Worker
 	 * @param (integer|array) priority or parameter array, strings are deprecated and are ignored
 	 *
 	 * next args are passed as $cmd command line
-	 * or: Worker::add(PRIORITY_HIGH, "Notifier", "drop", $drop_id);
+	 * or: Worker::add(PRIORITY_HIGH, "Notifier", Delivery::DELETION, $drop_id);
 	 * or: Worker::add(array('priority' => PRIORITY_HIGH, 'dont_fork' => true), "CreateShadowEntry", $post_id);
 	 *
 	 * @return boolean "false" if proc_run couldn't be executed

--- a/src/Model/Mail.php
+++ b/src/Model/Mail.php
@@ -13,6 +13,7 @@ use Friendica\Model\Item;
 use Friendica\Database\DBA;
 use Friendica\Network\Probe;
 use Friendica\Util\DateTimeFormat;
+use Friendica\Worker\Delivery;
 
 /**
  * Class to handle private messages
@@ -218,7 +219,7 @@ class Mail
 		}
 
 		if ($post_id) {
-			Worker::add(PRIORITY_HIGH, "Notifier", "mail", $post_id);
+			Worker::add(PRIORITY_HIGH, "Notifier", Delivery::MAIL, $post_id);
 			return intval($post_id);
 		} else {
 			return -3;

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -21,6 +21,7 @@ use Friendica\Util\Crypto;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Network;
 use Friendica\Util\Strings;
+use Friendica\Worker\Delivery;
 use LightOpenID;
 
 /**
@@ -912,7 +913,7 @@ class User
 
 		// The user and related data will be deleted in "cron_expire_and_remove_users" (cronjobs.php)
 		DBA::update('user', ['account_removed' => true, 'account_expires_on' => DateTimeFormat::utc('now + 7 day')], ['uid' => $uid]);
-		Worker::add(PRIORITY_HIGH, 'Notifier', 'removeme', $uid);
+		Worker::add(PRIORITY_HIGH, 'Notifier', Delivery::REMOVAL, $uid);
 
 		// Send an update to the directory
 		$self = DBA::selectFirst('contact', ['url'], ['uid' => $uid, 'self' => true]);

--- a/src/Module/Admin/Site.php
+++ b/src/Module/Admin/Site.php
@@ -16,6 +16,7 @@ use Friendica\Protocol\PortableContact;
 use Friendica\Util\BasePath;
 use Friendica\Util\BaseURL;
 use Friendica\Util\Strings;
+use Friendica\Worker\Delivery;
 
 require_once __DIR__ . '/../../../boot.php';
 
@@ -99,7 +100,7 @@ class Site extends BaseAdminModule
 			// send relocate
 			$usersStmt = DBA::select('user', ['uid'], ['account_removed' => false, 'account_expired' => false]);
 			while ($user = DBA::fetch($usersStmt)) {
-				Worker::add(PRIORITY_HIGH, 'Notifier', 'relocate', $user['uid']);
+				Worker::add(PRIORITY_HIGH, 'Notifier', Delivery::RELOCATION, $user['uid']);
 			}
 
 			info("Relocation started. Could take a while to complete.");

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -2148,13 +2148,9 @@ class Diaspora
 			if ($comment['id'] == $comment['parent']) {
 				continue;
 			}
-			if ($comment['verb'] == ACTIVITY_POST) {
-				$cmd = $comment['self'] ? Delivery::COMMENT : 'comment-import';
-			} else {
-				$cmd = $comment['self'] ? Delivery::ACTIVITY : 'activity-import';
-			}
-			Logger::log("Send ".$cmd." for item ".$comment['id']." to contact ".$contact_id, Logger::DEBUG);
-			Worker::add(PRIORITY_HIGH, 'Delivery', $cmd, $comment['id'], $contact_id);
+
+			Logger::info('Deliver participation', ['item' => $comment['id'], 'contact' => $contact_id]);
+			Worker::add(PRIORITY_HIGH, 'Delivery', Delivery::POST, $comment['id'], $contact_id);
 		}
 		DBA::close($comments);
 

--- a/src/Worker/APDelivery.php
+++ b/src/Worker/APDelivery.php
@@ -48,7 +48,7 @@ class APDelivery extends BaseObject
 			$data = ActivityPub\Transmitter::createCachedActivityFromItem($target_id);
 			if (!empty($data)) {
 				$success = HTTPSignature::transmit($data, $inbox, $uid);
-				if ($success && in_array($cmd, [Delivery::POST, Delivery::COMMENT])) {
+				if ($success && in_array($cmd, [Delivery::POST])) {
 					ItemDeliveryData::incrementQueueDone($target_id);
 				}
 			}

--- a/src/Worker/Delivery.php
+++ b/src/Worker/Delivery.php
@@ -27,8 +27,7 @@ class Delivery extends BaseObject
 	const DELETION      = 'drop';
 	const POST          = 'wall-new';
 	const POKE          = 'poke';
-	const COMMENT       = 'comment-new';
-	const ACTIVITY      = 'activity-new';
+	const UPLINK        = 'uplink';
 	const REMOVAL       = 'removeme';
 	const PROFILEUPDATE = 'profileupdate';
 
@@ -319,7 +318,7 @@ class Delivery extends BaseObject
 			// We successfully delivered a message, the contact is alive
 			Model\Contact::unmarkForArchival($contact);
 
-			if (in_array($cmd, [Delivery::POST, Delivery::COMMENT])) {
+			if (in_array($cmd, [Delivery::POST, Delivery::POKE])) {
 				Model\ItemDeliveryData::incrementQueueDone($target_item['id']);
 			}
 		} else {
@@ -400,7 +399,7 @@ class Delivery extends BaseObject
 			// We successfully delivered a message, the contact is alive
 			Model\Contact::unmarkForArchival($contact);
 
-			if (in_array($cmd, [Delivery::POST, Delivery::COMMENT])) {
+			if (in_array($cmd, [Delivery::POST, Delivery::POKE])) {
 				Model\ItemDeliveryData::incrementQueueDone($target_item['id']);
 			}
 		} else {
@@ -411,7 +410,7 @@ class Delivery extends BaseObject
 				Logger::info('Delivery failed: defer message', ['id' => defaults($target_item, 'guid', $target_item['id'])]);
 				// defer message for redelivery
 				Worker::defer();
-			} elseif (in_array($cmd, [Delivery::POST, Delivery::COMMENT])) {
+			} elseif (in_array($cmd, [Delivery::POST, Delivery::POKE])) {
 				Model\ItemDeliveryData::incrementQueueDone($target_item['id']);
 			}
 		}
@@ -439,7 +438,7 @@ class Delivery extends BaseObject
 			return;
 		}
 
-		if (!in_array($cmd, [self::POST, self::COMMENT])) {
+		if (!in_array($cmd, [self::POST, self::POKE])) {
 			return;
 		}
 

--- a/src/Worker/Notifier.php
+++ b/src/Worker/Notifier.php
@@ -32,23 +32,7 @@ require_once 'include/items.php';
  *
  *		Worker::add(PRIORITY_HIGH, "Notifier", COMMAND, ITEM_ID);
  *
- * where COMMAND is one of the following:
- *
- *		activity				(in diaspora.php, dfrn_confirm.php, profiles.php)
- *		comment-import			(in diaspora.php, items.php)
- *		comment-new				(in item.php)
- *		drop					(in diaspora.php, items.php, photos.php)
- *		edit_post				(in item.php)
- *		event					(in events.php)
- *		like					(in like.php, poke.php)
- *		mail					(in message.php)
- *		suggest					(in fsuggest.php)
- *		tag						(in photos.php, poke.php, tagger.php)
- *		tgroup					(in items.php)
- *		wall-new				(in photos.php, item.php)
- *		removeme				(in Contact.php)
- * 		relocate				(in uimport.php)
- *
+ * where COMMAND is one of the constants that are defined in Worker/Delivery.php
  * and ITEM_ID is the id of the item in the database that needs to be sent to others.
  */
 
@@ -199,7 +183,7 @@ class Notifier
 			}
 
 
-			if (($cmd === 'uplink') && (intval($parent['forum_mode']) == 1) && !$top_level) {
+			if (($cmd === Delivery::UPLINK) && (intval($parent['forum_mode']) == 1) && !$top_level) {
 				$relay_to_owner = true;
 			}
 
@@ -287,8 +271,8 @@ class Notifier
 				// if our parent is a public forum (forum_mode == 1), uplink to the origional author causing
 				// a delivery fork. private groups (forum_mode == 2) do not uplink
 
-				if ((intval($parent['forum_mode']) == 1) && !$top_level && ($cmd !== 'uplink')) {
-					Worker::add($a->queue['priority'], 'Notifier', 'uplink', $target_id);
+				if ((intval($parent['forum_mode']) == 1) && !$top_level && ($cmd !== Delivery::UPLINK)) {
+					Worker::add($a->queue['priority'], 'Notifier', Delivery::UPLINK, $target_id);
 				}
 
 				foreach ($items as $item) {
@@ -545,7 +529,7 @@ class Notifier
 		if (!empty($target_item)) {
 			Logger::log('Calling hooks for ' . $cmd . ' ' . $target_id, Logger::DEBUG);
 
-			if (in_array($cmd, [Delivery::POST, Delivery::COMMENT])) {
+			if (in_array($cmd, [Delivery::POST, Delivery::POKE])) {
 				ItemDeliveryData::update($target_item['id'], ['queue_count' => $delivery_queue_count]);
 			}
 

--- a/update.php
+++ b/update.php
@@ -362,14 +362,8 @@ function update_1309()
 			continue;
 		}
 
-		if ($item['gravity'] == GRAVITY_PARENT) {
-			$cmd = Delivery::POST;
-		} else {
-			$cmd = Delivery::COMMENT;
-		}
-
 		$deliver_options = ['priority' => PRIORITY_MEDIUM, 'dont_fork' => true];
-		Worker::add($deliver_options, 'Delivery', $cmd, $item['id'], $entry['cid']);
+		Worker::add($deliver_options, 'Delivery', Delivery::POST, $item['id'], $entry['cid']);
 		Logger::info('Added delivery worker', ['command' => $cmd, 'item' => $item['id'], 'contact' => $entry['cid']]);
 		DBA::delete('queue', ['id' => $entry['id']]);
 	}


### PR DESCRIPTION
The delivery counter hadn't worked for the poking. While fixing this, I had a look at all the delivery commands and unified them. Now only constant values are used. All the constants had been checked and are reduced to only the really needed values.