### PR TITLE
Fixing Network::post() caused by wrong argument

### DIFF
--- a/mod/dfrn_confirm.php
+++ b/mod/dfrn_confirm.php
@@ -209,7 +209,7 @@ function dfrn_confirm_post(App $a, $handsfree = null)
 		 *
 		 */
 
-		$res = Network::post($dfrn_confirm, $params, null, 120)->getBody();
+		$res = Network::post($dfrn_confirm, $params, [], 120)->getBody();
 
 		Logger::log(' Confirm: received data: ' . $res, Logger::DATA);
 

--- a/src/Util/Network.php
+++ b/src/Util/Network.php
@@ -250,7 +250,7 @@ class Network
 	 * @return CurlResult The content
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
-	public static function post(string $url, $params, $headers = null, int $timeout = 0, int &$redirects = 0)
+	public static function post(string $url, $params, array $headers = [], int $timeout = 0, int &$redirects = 0)
 	{
 		$stamp1 = microtime(true);
 
@@ -286,7 +286,7 @@ class Network
 		}
 
 		if (defined('LIGHTTPD')) {
-			if (!is_array($headers)) {
+			if (empty($headers)) {
 				$headers = ['Expect:'];
 			} else {
 				if (!in_array('Expect:', $headers)) {
@@ -295,7 +295,7 @@ class Network
 			}
 		}
 
-		if ($headers) {
+		if (!empty($headers)) {
 			curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
 		}
 


### PR DESCRIPTION
Solves https://github.com/friendica/friendica/issues/6916#issuecomment-500491695
=> tried on my node without exceptions ..
```console
2019-06-10 17:26:23 index [NOTICE]: dfrn_notify_post [] - {"file":"dfrn_notify.php","line":21,"function":"dfrn_notify_post","uid":"a47c25","process_id":251} 
```