### PR TITLE
Issue 7142: Prevent respawn of "remote self" items

### DIFF
--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -2647,7 +2647,6 @@ class Item extends BaseObject
 				$datarray['author-link']   = $datarray['owner-link'];
 				$datarray['author-avatar'] = $datarray['owner-avatar'];
 
-				unset($datarray['created']);
 				unset($datarray['edited']);
 
 				unset($datarray['network']);


### PR DESCRIPTION
This could fix #7142 since we apply the check for items, created before expiry date, on the "created" field.