### PR TITLE
Restore show_connect flag in Model\Profile::sidebar

### DIFF
--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -343,7 +343,7 @@ class Profile
 			|| in_array($profile_contact['rel'] ?? 0, [Contact::FOLLOWER, Contact::FRIEND]);
 		$visitor_base_path = self::getMyURL() ? preg_replace('=/profile/(.*)=ism', '', self::getMyURL()) : '';
 
-		if (!$local_user_is_self) {
+		if (!$local_user_is_self && $show_connect) {
 			if (!$visitor_is_authenticated) {
 				$follow_link = 'dfrn_request/' . $profile['nickname'];
 			} elseif ($profile_is_native) {


### PR DESCRIPTION
Follow-up to #7250

The `$show_connect` parameter of the `Model\Profile::sidebar` method had been missing in the profile button conditions.