### PR TITLE
Perform link replacement at the end of BBCode::convert

### DIFF
--- a/src/Console/Typo.php
+++ b/src/Console/Typo.php
@@ -43,13 +43,25 @@ HELP;
 			throw new \Asika\SimpleConsole\CommandArgsException('Too many arguments');
 		}
 
-		$php_path = BaseObject::getApp()->getConfigCache()->get('config', 'php_path', 'php');
+		$php_path = BaseObject::getApp()->getConfig()->get('config', 'php_path', 'php');
 
 		if ($this->getOption('v')) {
 			$this->out('Directory: src');
 		}
 
 		$Iterator = new \RecursiveDirectoryIterator('src');
+
+		foreach (new \RecursiveIteratorIterator($Iterator) as $file) {
+			if (substr($file, -4) === '.php') {
+				$this->checkFile($php_path, $file);
+			}
+		}
+
+		if ($this->getOption('v')) {
+			$this->out('Directory: tests');
+		}
+
+		$Iterator = new \RecursiveDirectoryIterator('tests');
 
 		foreach (new \RecursiveIteratorIterator($Iterator) as $file) {
 			if (substr($file, -4) === '.php') {

--- a/tests/src/Content/Text/BBCodeTest.php
+++ b/tests/src/Content/Text/BBCodeTest.php
@@ -113,6 +113,14 @@ class BBCodeTest extends MockedTest
 				'data' => html_entity_decode('http://example.com&nbsp;', ENT_QUOTES, 'UTF-8'),
 				'assertHTML' => false
 			],
+			'bug-7271-query-string-brackets' => [
+				'data' => 'https://example.com/search?q=square+brackets+[url]',
+				'assertHTML' => true
+			],
+			'bug-7271-path-brackets' => [
+				'data' => 'http://example.com/path/to/file[3].html',
+				'assertHTML' => true
+			],
 		];
 	}
 

--- a/tests/src/Content/Text/BBCodeTest.php
+++ b/tests/src/Content/Text/BBCodeTest.php
@@ -134,4 +134,47 @@ class BBCodeTest extends MockedTest
 			$this->assertNotEquals($assert, $output);
 		}
 	}
+
+	public function dataBBCodes()
+	{
+		return [
+			'bug-7271-condensed-space' => [
+				'expectedHtml' => '<ul class="listdecimal" style="list-style-type: decimal;"><li> <a href="http://example.com/" target="_blank">http://example.com/</a></li></ul>',
+				'text' => '[ol][*] http://example.com/[/ol]',
+			],
+			'bug-7271-condensed-nospace' => [
+				'expectedHtml' => '<ul class="listdecimal" style="list-style-type: decimal;"><li><a href="http://example.com/" target="_blank">http://example.com/</a></li></ul>',
+				'text' => '[ol][*]http://example.com/[/ol]',
+			],
+			'bug-7271-indented-space' => [
+				'expectedHtml' => '<ul class="listbullet" style="list-style-type: circle;"><li> <a href="http://example.com/" target="_blank">http://example.com/</a></li></ul>',
+				'text' => '[ul]
+[*] http://example.com/
+[/ul]',
+			],
+			'bug-7271-indented-nospace' => [
+				'expectedHtml' => '<ul class="listbullet" style="list-style-type: circle;"><li><a href="http://example.com/" target="_blank">http://example.com/</a></li></ul>',
+				'text' => '[ul]
+[*]http://example.com/
+[/ul]',
+			],
+		];
+	}
+
+	/**
+	 * Test convert bbcodes to HTML
+	 * @dataProvider dataBBCodes
+	 *
+	 * @param string $expectedHtml Expected HTML output
+	 * @param string $text         BBCode text
+	 * @param int    $simpleHtml   BBCode::convert method $simple_html parameter value, optional.
+	 * @param bool   $forPlaintext BBCode::convert method $for_plaintext parameter value, optional.
+	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
+	 */
+	public function testConvert($expectedHtml, $text, $simpleHtml = 0, $forPlaintext = false)
+	{
+		$actual = BBCode::convert($text, false, $simpleHtml, $forPlaintext);
+
+		$this->assertEquals($expectedHtml, $actual);
+	}
 }


### PR DESCRIPTION
Fixes #7271 

Additionally, now BBCode tags including a URL with brackets in the path or query string will be correctly converted.