### PR TITLE
Issue #5983: Ignore reshares from blocked and ignored contacts

### DIFF
--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -1453,7 +1453,7 @@ class Item extends BaseObject
 			return 0;
 		}
 
-		if (!empty($uid) && Contact::isBlockedByUser($item['author-link'], $uid)) {
+		if (!empty($uid) && Contact::isBlockedByUser($item['author-id'], $uid)) {
 			Logger::notice('Author is blocked by user', ['author-link' => $item['author-link'], 'uid' => $uid, 'item-uri' => $item['uri']]);
 			return 0;
 		}
@@ -1473,10 +1473,25 @@ class Item extends BaseObject
 			return 0;
 		}
 
-		if (!empty($uid) && Contact::isBlockedByUser($item['owner-link'], $uid)) {
+		if (!empty($uid) && Contact::isBlockedByUser($item['owner-id'], $uid)) {
 			Logger::notice('Owner is blocked by user', ['owner-link' => $item['owner-link'], 'uid' => $uid, 'item-uri' => $item['uri']]);
 			return 0;
 		}
+
+		// The causer is set during a thread completion, for example because of a reshare. It countains the responsible actor.
+		if (!empty($uid) && !empty($item['causer-id']) && Contact::isBlockedByUser($item['causer-id'], $uid)) {
+			Logger::notice('Causer is blocked by user', ['causer-link' => $item['causer-link'], 'uid' => $uid, 'item-uri' => $item['uri']]);
+			return 0;
+		}
+
+		if (!empty($uid) && !empty($item['causer-id']) && ($item['parent-uri'] == $item['uri']) && Contact::isIgnoredByUser($item['causer-id'], $uid)) {
+			Logger::notice('Causer is ignored by user', ['causer-link' => $item['causer-link'], 'uid' => $uid, 'item-uri' => $item['uri']]);
+			return 0;
+		}
+
+		// We don't store the causer, we only have it here for the checks above
+		unset($item['causer-id']);
+		unset($item['causer-link']);
 
 		if ($item['network'] == Protocol::PHANTOM) {
 			$item['network'] = Protocol::DFRN;

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -370,12 +370,15 @@ class Processor
 		$item['private'] = !in_array(0, $activity['receiver']);
 		$item['author-link'] = $activity['author'];
 		$item['author-id'] = Contact::getIdForURL($activity['author'], 0, true);
+		$item['owner-link'] = $activity['actor'];
+		$item['owner-id'] = Contact::getIdForURL($activity['actor'], 0, true);
 
-		if (empty($activity['thread-completion'])) {
-			$item['owner-link'] = $activity['actor'];
-			$item['owner-id'] = Contact::getIdForURL($activity['actor'], 0, true);
-		} else {
-			Logger::info('Ignoring actor because of thread completion.');
+		if (!empty($activity['thread-completion'])) {
+			// Store the original actor in the "causer" fields to enable the check for ignored or blocked contacts
+			$item['causer-link'] = $item['owner-link'];
+			$item['causer-id'] = $item['owner-id'];
+
+			Logger::info('Ignoring actor because of thread completion.', ['actor' => $item['owner-link']]);
 			$item['owner-link'] = $item['author-link'];
 			$item['owner-id'] = $item['author-id'];
 		}


### PR DESCRIPTION
Fixes #5983 

Additionally it fixes a bug where we checked for the url but had to check for the id.