### PR TITLE
Fix receiving of DFRN posts with public envelope

### DIFF
--- a/mod/dfrn_notify.php
+++ b/mod/dfrn_notify.php
@@ -190,13 +190,13 @@ function dfrn_dispatch_public($postdata)
 	}
 
 	// Fetch the corresponding public contact
-	$contact = Contact::getDetailsByAddr($msg['author'], 0);
-	if (!$contact) {
+	$contact_id = Contact::getIdForURL($msg['author']);
+	if (empty($contact_id)) {
 		Logger::log('Contact not found for address ' . $msg['author']);
 		System::xmlExit(3, 'Contact ' . $msg['author'] . ' not found');
 	}
 
-	$importer = DFRN::getImporter($contact['id']);
+	$importer = DFRN::getImporter($contact_id);
 
 	// This should never fail
 	if (empty($importer)) {


### PR DESCRIPTION
This is a fix for the problem that was described here: https://forum.friendi.ca/display/703b8751-155d-0d24-3322-9b7118046564

The function ```Contact::getDetailsByAddr``` cannot be used for this functionality since - under certain circumstances - it will return data from the gcontact table. But since we do need the contact id here, this won't work at every time. So it is replaced by a function that is more suitable for this purpose.

```dfrn_dispatch_public``` is not used for regular conversations. It is only used for relay stuff.