### PR TITLE
Limit smilies replacement to BBCode::convert

### DIFF
--- a/include/text.php
+++ b/include/text.php
@@ -140,7 +140,7 @@ function redir_private_images($a, &$item)
  * @brief Given a text string, convert from bbcode to html and add smilie icons.
  *
  * @param string $text String with bbcode.
- * @return string Formattet HTML.
+ * @return string Formatted HTML
  * @throws \Friendica\Network\HTTPException\InternalServerErrorException
  */
 function prepare_text($text)

--- a/include/text.php
+++ b/include/text.php
@@ -143,13 +143,9 @@ function redir_private_images($a, &$item)
  * @return string Formattet HTML.
  * @throws \Friendica\Network\HTTPException\InternalServerErrorException
  */
-function prepare_text($text) {
-	if (stristr($text, '[nosmile]')) {
-		$s = BBCode::convert($text);
-	} else {
-		$s = Smilies::replace(BBCode::convert($text));
-	}
-
+function prepare_text($text)
+{
+	$s = BBCode::convert($text);
 	return trim($s);
 }
 

--- a/mod/message.php
+++ b/mod/message.php
@@ -384,7 +384,7 @@ function message_content(App $a)
 
 			$from_name_e = $message['from-name'];
 			$subject_e = $message['title'];
-			$body_e = Smilies::replace(BBCode::convert($message['body']));
+			$body_e = BBCode::convert($message['body']);
 			$to_name_e = $message['name'];
 
 			$contact = Contact::getDetailsByURL($message['from-url']);

--- a/src/Content/Smilies.php
+++ b/src/Content/Smilies.php
@@ -267,17 +267,18 @@ class Smilies
 	 * @return string HTML Output
 	 *
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
-	 * @todo  : Rework because it doesn't work correctly
 	 */
 	private static function pregHeart($x)
 	{
 		if (strlen($x[1]) == 1) {
 			return $x[0];
 		}
+
 		$t = '';
 		for ($cnt = 0; $cnt < strlen($x[1]); $cnt ++) {
-			$t .= '<img class="smiley" src="' . System::baseUrl() . '/images/smiley-heart.gif" alt="&lt;3" />';
+			$t .= '❤';
 		}
+
 		$r =  str_replace($x[0], $t, $x[0]);
 		return $r;
 	}

--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -1395,6 +1395,7 @@ class BBCode extends BaseObject
 
 		// This is actually executed in Item::prepareBody()
 
+		$nosmile = strpos($text, '[nosmile]') !== false;
 		$text = str_replace('[nosmile]', '', $text);
 
 		// Check for font change text
@@ -1572,7 +1573,7 @@ class BBCode extends BaseObject
 		}
 
 		// Replace non graphical smilies for external posts
-		if ($simple_html) {
+		if (!$nosmile && !$for_plaintext) {
 			$text = Smilies::replace($text);
 		}
 

--- a/tests/src/Content/Text/BBCodeTest.php
+++ b/tests/src/Content/Text/BBCodeTest.php
@@ -40,6 +40,9 @@ class BBCodeTest extends MockedTest
 		$this->configMock->shouldReceive('get')
 			->with('system', 'url')
 			->andReturn('friendica.local');
+		$this->configMock->shouldReceive('get')
+			->with('system', 'no_smilies')
+			->andReturn(false);
 		$this->mockL10nT();
 	}
 


### PR DESCRIPTION
Extracted from #7286

Will rebase it to `develop` it after the 2019.06 release.