### PR TITLE
Revert "Escape all the HTML pre-formatted blocks in Smilies::replaceFromArray"

### DIFF
--- a/src/Content/Smilies.php
+++ b/src/Content/Smilies.php
@@ -213,7 +213,6 @@ class Smilies
 			return $text;
 		}
 
-		$text = preg_replace_callback('/<pre>(.*?)<\/pre>/ism', 'self::encode', $text);
 		$text = preg_replace_callback('/<code>(.*?)<\/code>/ism', 'self::encode', $text);
 
 		if ($no_images) {
@@ -232,7 +231,6 @@ class Smilies
 		$text = self::strOrigReplace($smilies['texts'], $smilies['icons'], $text);
 
 		$text = preg_replace_callback('/<code>(.*?)<\/code>/ism', 'self::decode', $text);
-		$text = preg_replace_callback('/<pre>(.*?)<\/pre>/ism', 'self::decode', $text);
 
 		return $text;
 	}


### PR DESCRIPTION
Reverts friendica/friendica#7286

I have to revert it. See the problem here: https://libranet.de/display/0b6b25a8-105d-0e40-d169-e3c257307209?zrl=https%3A%2F%2Fpirati.ca%2Fprofile%2Fheluecht

In fact the source of the problem is this PR.