### PR TITLE
Restore Preload config adapter features

### DIFF
--- a/src/Factory/ConfigFactory.php
+++ b/src/Factory/ConfigFactory.php
@@ -46,14 +46,13 @@ class ConfigFactory
 
 	/**
 	 * @param Cache\ConfigCache  $configCache The config cache of this adapter
-	 * @param int                $uid         The UID of the current user
 	 *
 	 * @return Config\PConfiguration
 	 */
-	public static function createPConfig(Cache\ConfigCache $configCache, $uid = null)
+	public static function createPConfig(Cache\ConfigCache $configCache)
 	{
 		if ($configCache->get('system', 'config_adapter') === 'preload') {
-			$configAdapter = new Adapter\PreloadPConfigAdapter($uid);
+			$configAdapter = new Adapter\PreloadPConfigAdapter();
 		} else {
 			$configAdapter = new Adapter\JITPConfigAdapter();
 		}


### PR DESCRIPTION
While working on #7316 qith the DB profiler on, I realized there were more than one DB query coming from the PreloadPConfigAdapter, which was odd since the whole point of this adapter is to have a single query loading the whole config in memory for quicker access.

I found out that the Preload adapters had been transformed into yet another JIT adapters. I blame @nupplaphil .

This PR restores the Preload adapter to their former glory, and in doing so shaves 600ms out of 2.4s (25%) from the `/contact/xxx/conversation` page load time.