### PR TITLE
Item delivery data must only be stored when there is data

### DIFF
--- a/config/dbstructure.config.php
+++ b/config/dbstructure.config.php
@@ -34,7 +34,7 @@
 use Friendica\Database\DBA;
 
 if (!defined('DB_UPDATE_VERSION')) {
-	define('DB_UPDATE_VERSION', 1314);
+	define('DB_UPDATE_VERSION', 1315);
 }
 
 return [

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -1883,7 +1883,9 @@ class Item extends BaseObject
 			self::updateThread($parent_id);
 		}
 
-		ItemDeliveryData::insert($current_post, $delivery_data);
+		if (!empty($item['origin']) || !empty($item['wall']) || !empty($delivery_data['postopts']) || !empty($delivery_data['inform'])) {
+			ItemDeliveryData::insert($current_post, $delivery_data);
+		}
 
 		DBA::commit();
 

--- a/update.php
+++ b/update.php
@@ -369,3 +369,8 @@ function update_1309()
 	}
 	return Update::SUCCESS;
 }
+
+function update_1315()
+{
+	DBA::delete('item-delivery-data', ['postopts' => '', 'inform' => '', 'queue_count' => 0, 'queue_done' => 0]);
+}


### PR DESCRIPTION
The table ```item-delivery-data``` should only contain data for items that are supposed to be delivered. Currently it is saved all the time - which wastes much space. So this PR also contains an update routine that deletes unneeded data.