### PR TITLE
Only fetch toplevel posts when searching for hashtags on network page

### DIFF
--- a/mod/network.php
+++ b/mod/network.php
@@ -868,10 +868,10 @@ function networkThreadedView(App $a, $update, $parent)
 				(SELECT SUBSTR(`term`, 2) FROM `search` WHERE `uid` = ? AND `term` LIKE '#%') AND `otype` = ? AND `type` = ? AND `uid` = 0) AS `term`
 			ON `item`.`id` = `term`.`oid`
 			STRAIGHT_JOIN `contact` AS `author` ON `author`.`id` = `item`.`author-id`
-			WHERE `item`.`uid` = 0 AND `item`.$ordering < ? AND `item`.$ordering > ?
+			WHERE `item`.`uid` = 0 AND `item`.$ordering < ? AND `item`.$ordering > ? AND `item`.`gravity` = ?
 				AND NOT `author`.`hidden` AND NOT `author`.`blocked`" . $sql_tag_nets,
 			local_user(), TERM_OBJ_POST, TERM_HASHTAG,
-			$top_limit, $bottom_limit);
+			$top_limit, $bottom_limit, GRAVITY_PARENT);
 
 		$data = DBA::toArray($items);
 


### PR DESCRIPTION
This could possibly solve the issue that sometimes the network page skips several hours of posts - but I'm not sure if this is the real reason. But anyway this ensures that you don't get a whole thread just because in one of the comments someone added a hashtag you subscribed to.

See issue https://github.com/friendica/friendica/issues/4835