### PR TITLE
[FRIO] fixing chromium mobile navbar color when not logged in

### DIFF
--- a/view/theme/frio/php/default.php
+++ b/view/theme/frio/php/default.php
@@ -53,6 +53,10 @@ $is_singleuser_class = $is_singleuser ? "is-singleuser" : "is-not-singleuser";
 			$nav_bg = PConfig::get($uid, 'frio', 'nav_bg');
 		}
 
+		if (empty($nav_bg)) {
+            $nav_bg = Config::get('frio', 'nav_bg');
+		}
+
 		if (empty($nav_bg) || !is_string($nav_bg)) {
 			$nav_bg = "#708fa0";
 		}

--- a/view/theme/frio/php/default.php
+++ b/view/theme/frio/php/default.php
@@ -54,7 +54,7 @@ $is_singleuser_class = $is_singleuser ? "is-singleuser" : "is-not-singleuser";
 		}
 
 		if (empty($nav_bg)) {
-            $nav_bg = Config::get('frio', 'nav_bg');
+			$nav_bg = Config::get('frio', 'nav_bg');
 		}
 
 		if (empty($nav_bg) || !is_string($nav_bg)) {
@@ -83,7 +83,7 @@ $is_singleuser_class = $is_singleuser ? "is-singleuser" : "is-not-singleuser";
 	// special minimal style for modal dialogs
 	if ($minimal) {
 ?>
-        <!-- <?php echo __FILE__ ?> -->
+		<!-- <?php echo __FILE__ ?> -->
 		<section class="minimal">
 			<?php if (!empty($page['content'])) echo $page['content']; ?>
 			<div id="page-footer"></div>


### PR DESCRIPTION
In chromium mobile it is possible to set the color of the navigation bar by adding the color in `<meta name="theme-color" content="#00000" />`. The frio theme does this as well. however, for some reason when a user is not logged in it defaults to the default color (`#708fa0`). On most systems this is OK as the login scheme is barely changed. However, if it is changed and $nav_bg color is different, the navbar does not change and still defaults to `#708fa0`.

This PR resolves this issue by using the global frio config $nav_bg color if not logged in. it still uses original default if global config would be empty.

Resolves: my neurotic brain thinking the color should be the same
Tested on: social.jeroened.be
Especially tested for: capitalization errors 😂