### PR TITLE
Default theme = login theme

### DIFF
--- a/view/theme/frio/style.php
+++ b/view/theme/frio/style.php
@@ -15,6 +15,28 @@ $schemecssfile = false;
 $scheme_modified = 0;
 
 if ($a->module !== 'install') {
+
+	Config::load('frio');
+
+	// Load frios system config.
+	$scheme           = Config::get('frio', 'scheme', Config::get('frio', 'schema'));
+	$nav_bg           = Config::get('frio', 'nav_bg', '#708fa0');
+	$nav_icon_color   = Config::get('frio', 'nav_icon_color', '#fff');
+	$link_color       = Config::get('frio', 'link_color', '#6fdbe8');
+	$background_color = Config::get('frio', 'background_color', '#ededed');
+	$contentbg_transp = Config::get('frio', 'contentbg_transp');
+	$background_image = Config::get('frio', 'background_image', 'img/none.png');
+	$bg_image_option  = Config::get('frio', 'bg_image_option');
+	$login_bg_image   = Config::get('frio', 'login_bg_image');
+	$login_bg_color   = Config::get('frio', 'login_bg_color');
+	$modified         = Config::get('frio', 'css_modified');
+
+	// There is maybe the case that the user did never modify the theme settings.
+	// In this case we store the present time.
+	if (empty($modified)) {
+		Config::set('frio', 'css_modified', time());
+	}
+
 	// Get the UID of the profile owner.
 	$uid = defaults($_REQUEST, 'puid', 0);
 	if ($uid) {
@@ -35,27 +57,6 @@ if ($a->module !== 'install') {
 		// In this case we store the present time.
 		if (empty($modified)) {
 			PConfig::set($uid, 'frio', 'css_modified', time());
-		}
-	} else {
-		Config::load('frio');
-
-		// Load frios system config.
-		$scheme           = Config::get('frio', 'scheme', Config::get('frio', 'schema'));
-		$nav_bg           = Config::get('frio', 'nav_bg');
-		$nav_icon_color   = Config::get('frio', 'nav_icon_color');
-		$link_color       = Config::get('frio', 'link_color');
-		$background_color = Config::get('frio', 'background_color');
-		$contentbg_transp = Config::get('frio', 'contentbg_transp');
-		$background_image = Config::get('frio', 'background_image');
-		$bg_image_option  = Config::get('frio', 'bg_image_option');
-		$login_bg_image   = Config::get('frio', 'login_bg_image');
-		$login_bg_color   = Config::get('frio', 'login_bg_color');
-		$modified         = Config::get('frio', 'css_modified');
-
-		// There is maybe the case that the user did never modify the theme settings.
-		// In this case we store the present time.
-		if (empty($modified)) {
-			Config::set('frio', 'css_modified', time());
 		}
 	}
 }
@@ -93,24 +94,6 @@ if (!$scheme) {
 		$schemecssfile = 'view/theme/frio/scheme/default.css';
 	}
 }
-//If no scheme was set default to login theme.
-$nav_bg           = (empty($nav_bg)           ? Config::get('frio', 'nav_bg')           : $nav_bg);
-$nav_icon_color   = (empty($nav_icon_color)   ? Config::get('frio', 'nav_icon_color')   : $nav_icon_color);
-$link_color       = (empty($link_color)       ? Config::get('frio', 'link_color')       : $link_color);
-$background_color = (empty($background_color) ? Config::get('frio', 'background_color') : $background_color);
-$background_image = (empty($background_image) ? Config::get('frio', 'background_image') : $background_image);
-
-//If login theme unset default to master default
-//Set some defaults - we have to do this after pulling owner settings, and we have to check for each setting
-//individually.  If we don't, we'll have problems if a user has set one, but not all options.
-$nav_bg           = (empty($nav_bg)           ? '#708fa0'      : $nav_bg);
-$nav_icon_color   = (empty($nav_icon_color)   ? '#fff'         : $nav_icon_color);
-$link_color       = (empty($link_color)       ? '#6fdbe8'      : $link_color);
-$background_color = (empty($background_color) ? '#ededed'      : $background_color);
-// The background image can not be empty. So we use a dummy jpg if no image was set.
-$background_image = (empty($background_image) ? 'img/none.png' : $background_image);
-$modified         = (empty($modified)         ? time()         : $modified);
-
 
 // set a default login bg image if no custom image and no custom bg color are set.
 if (empty($login_bg_image) && empty($login_bg_color)) {

--- a/view/theme/frio/style.php
+++ b/view/theme/frio/style.php
@@ -93,7 +93,14 @@ if (!$scheme) {
 		$schemecssfile = 'view/theme/frio/scheme/default.css';
 	}
 }
+//If no scheme was set default to login theme.
+$nav_bg           = (empty($nav_bg)           ? Config::get('frio', 'nav_bg')           : $nav_bg);
+$nav_icon_color   = (empty($nav_icon_color)   ? Config::get('frio', 'nav_icon_color')   : $nav_icon_color);
+$link_color       = (empty($link_color)       ? Config::get('frio', 'link_color')       : $link_color);
+$background_color = (empty($background_color) ? Config::get('frio', 'background_color') : $background_color);
+$background_image = (empty($background_image) ? Config::get('frio', 'background_image') : $background_image);
 
+//If login theme unset default to master default
 //Set some defaults - we have to do this after pulling owner settings, and we have to check for each setting
 //individually.  If we don't, we'll have problems if a user has set one, but not all options.
 $nav_bg           = (empty($nav_bg)           ? '#708fa0'      : $nav_bg);

--- a/view/theme/frio/style.php
+++ b/view/theme/frio/style.php
@@ -15,28 +15,6 @@ $schemecssfile = false;
 $scheme_modified = 0;
 
 if ($a->module !== 'install') {
-
-	Config::load('frio');
-
-	// Load frios system config.
-	$scheme           = Config::get('frio', 'scheme', Config::get('frio', 'schema'));
-	$nav_bg           = Config::get('frio', 'nav_bg', '#708fa0');
-	$nav_icon_color   = Config::get('frio', 'nav_icon_color', '#fff');
-	$link_color       = Config::get('frio', 'link_color', '#6fdbe8');
-	$background_color = Config::get('frio', 'background_color', '#ededed');
-	$contentbg_transp = Config::get('frio', 'contentbg_transp');
-	$background_image = Config::get('frio', 'background_image', 'img/none.png');
-	$bg_image_option  = Config::get('frio', 'bg_image_option');
-	$login_bg_image   = Config::get('frio', 'login_bg_image');
-	$login_bg_color   = Config::get('frio', 'login_bg_color');
-	$modified         = Config::get('frio', 'css_modified');
-
-	// There is maybe the case that the user did never modify the theme settings.
-	// In this case we store the present time.
-	if (empty($modified)) {
-		Config::set('frio', 'css_modified', time());
-	}
-
 	// Get the UID of the profile owner.
 	$uid = defaults($_REQUEST, 'puid', 0);
 	if ($uid) {
@@ -57,6 +35,27 @@ if ($a->module !== 'install') {
 		// In this case we store the present time.
 		if (empty($modified)) {
 			PConfig::set($uid, 'frio', 'css_modified', time());
+		}
+	} else {
+		Config::load('frio');
+
+		// Load frios system config.
+		$scheme           = Config::get('frio', 'scheme', Config::get('frio', 'schema'));
+		$nav_bg           = Config::get('frio', 'nav_bg');
+		$nav_icon_color   = Config::get('frio', 'nav_icon_color');
+		$link_color       = Config::get('frio', 'link_color');
+		$background_color = Config::get('frio', 'background_color');
+		$contentbg_transp = Config::get('frio', 'contentbg_transp');
+		$background_image = Config::get('frio', 'background_image');
+		$bg_image_option  = Config::get('frio', 'bg_image_option');
+		$login_bg_image   = Config::get('frio', 'login_bg_image');
+		$login_bg_color   = Config::get('frio', 'login_bg_color');
+		$modified         = Config::get('frio', 'css_modified');
+
+		// There is maybe the case that the user did never modify the theme settings.
+		// In this case we store the present time.
+		if (empty($modified)) {
+			Config::set('frio', 'css_modified', time());
 		}
 	}
 }
@@ -94,6 +93,24 @@ if (!$scheme) {
 		$schemecssfile = 'view/theme/frio/scheme/default.css';
 	}
 }
+//If no scheme was set default to login theme.
+$nav_bg           = (empty($nav_bg)           ? Config::get('frio', 'nav_bg')           : $nav_bg);
+$nav_icon_color   = (empty($nav_icon_color)   ? Config::get('frio', 'nav_icon_color')   : $nav_icon_color);
+$link_color       = (empty($link_color)       ? Config::get('frio', 'link_color')       : $link_color);
+$background_color = (empty($background_color) ? Config::get('frio', 'background_color') : $background_color);
+$background_image = (empty($background_image) ? Config::get('frio', 'background_image') : $background_image);
+
+//If login theme unset default to master default
+//Set some defaults - we have to do this after pulling owner settings, and we have to check for each setting
+//individually.  If we don't, we'll have problems if a user has set one, but not all options.
+$nav_bg           = (empty($nav_bg)           ? '#708fa0'      : $nav_bg);
+$nav_icon_color   = (empty($nav_icon_color)   ? '#fff'         : $nav_icon_color);
+$link_color       = (empty($link_color)       ? '#6fdbe8'      : $link_color);
+$background_color = (empty($background_color) ? '#ededed'      : $background_color);
+// The background image can not be empty. So we use a dummy jpg if no image was set.
+$background_image = (empty($background_image) ? 'img/none.png' : $background_image);
+$modified         = (empty($modified)         ? time()         : $modified);
+
 
 // set a default login bg image if no custom image and no custom bg color are set.
 if (empty($login_bg_image) && empty($login_bg_color)) {

--- a/view/theme/frio/style.php
+++ b/view/theme/frio/style.php
@@ -16,6 +16,27 @@ $scheme_modified = 0;
 
 if ($a->module !== 'install') {
 
+	Config::load('frio');
+
+	// Load frios system config.
+	$scheme           = Config::get('frio', 'scheme', Config::get('frio', 'schema'));
+	$nav_bg           = Config::get('frio', 'nav_bg', '#708fa0');
+	$nav_icon_color   = Config::get('frio', 'nav_icon_color', '#fff');
+	$link_color       = Config::get('frio', 'link_color', '#6fdbe8');
+	$background_color = Config::get('frio', 'background_color', '#ededed');
+	$contentbg_transp = Config::get('frio', 'contentbg_transp');
+	$background_image = Config::get('frio', 'background_image', 'img/none.png');
+	$bg_image_option  = Config::get('frio', 'bg_image_option');
+	$login_bg_image   = Config::get('frio', 'login_bg_image');
+	$login_bg_color   = Config::get('frio', 'login_bg_color');
+	$modified         = Config::get('frio', 'css_modified');
+
+	// There is maybe the case that the user did never modify the theme settings.
+	// In this case we store the present time.
+	if (empty($modified)) {
+		Config::set('frio', 'css_modified', time());
+	}
+
 	// Get the UID of the profile owner.
 	$uid = defaults($_REQUEST, 'puid', 0);
 	if ($uid) {
@@ -37,27 +58,6 @@ if ($a->module !== 'install') {
 		if (empty($modified)) {
 			PConfig::set($uid, 'frio', 'css_modified', time());
 		}
-	}
-
-	Config::load('frio');
-
-	// Load frios system config.
-	$scheme           = (empty($scheme)           ? Config::get('frio', 'scheme', Config::get('frio', 'schema')) : $scheme);
-	$nav_bg           = (empty($nav_bg)           ? Config::get('frio', 'nav_bg', '#708fa0')                     : $nav_bg);
-	$nav_icon_color   = (empty($nav_icon_color)   ? Config::get('frio', 'nav_icon_color', '#fff')                : $nav_icon_color);
-	$link_color       = (empty($link_color)       ? Config::get('frio', 'link_color', '#6fdbe8')                 : $link_color);
-	$background_color = (empty($background_color) ? Config::get('frio', 'background_color', '#ededed')           : $background_color);
-	$contentbg_transp = (empty($contentbg_transp) ? Config::get('frio', 'contentbg_transp')                      : $contentbg_transp);
-	$background_image = (empty($background_image) ? Config::get('frio', 'background_image', 'img/none.png')      : $background_image);
-	$bg_image_option  = (empty($bg_image_option)  ? Config::get('frio', 'bg_image_option')                       : $bg_image_option);
-	$login_bg_image   = (empty($login_bg_image)   ? Config::get('frio', 'login_bg_image')                        : $login_bg_image);
-	$login_bg_color   = (empty($login_bg_color)   ? Config::get('frio', 'login_bg_color')                        : $login_bg_color;
-	$modified         = (empty($modified)         ? Config::get('frio', 'css_modified')                          : $modified);
-
-	// There is maybe the case that the user did never modify the theme settings.
-	// In this case we store the present time.
-	if (empty($modified)) {
-		Config::set('frio', 'css_modified', time());
 	}
 }
 

--- a/view/theme/frio/style.php
+++ b/view/theme/frio/style.php
@@ -93,22 +93,15 @@ if (!$scheme) {
 		$schemecssfile = 'view/theme/frio/scheme/default.css';
 	}
 }
-//If no scheme was set default to login theme.
-$nav_bg           = (empty($nav_bg)           ? Config::get('frio', 'nav_bg')           : $nav_bg);
-$nav_icon_color   = (empty($nav_icon_color)   ? Config::get('frio', 'nav_icon_color')   : $nav_icon_color);
-$link_color       = (empty($link_color)       ? Config::get('frio', 'link_color')       : $link_color);
-$background_color = (empty($background_color) ? Config::get('frio', 'background_color') : $background_color);
-$background_image = (empty($background_image) ? Config::get('frio', 'background_image') : $background_image);
 
-//If login theme unset default to master default
 //Set some defaults - we have to do this after pulling owner settings, and we have to check for each setting
 //individually.  If we don't, we'll have problems if a user has set one, but not all options.
-$nav_bg           = (empty($nav_bg)           ? '#708fa0'      : $nav_bg);
-$nav_icon_color   = (empty($nav_icon_color)   ? '#fff'         : $nav_icon_color);
-$link_color       = (empty($link_color)       ? '#6fdbe8'      : $link_color);
-$background_color = (empty($background_color) ? '#ededed'      : $background_color);
+$nav_bg           = (empty($nav_bg)           ? Config::get('frio', 'nav_bg', '#708fa0')                : $nav_bg);
+$nav_icon_color   = (empty($nav_icon_color)   ? Config::get('frio', 'nav_icon_color', '#fff')           : $nav_icon_color);
+$link_color       = (empty($link_color)       ? Config::get('frio', 'link_color', '#6fdbe8')            : $link_color);
+$background_color = (empty($background_color) ?  Config::get('frio', 'background_color', '#ededed')     : $background_color);
 // The background image can not be empty. So we use a dummy jpg if no image was set.
-$background_image = (empty($background_image) ? 'img/none.png' : $background_image);
+$background_image = (empty($background_image) ? Config::get('frio', 'background_image', 'img/none.png') : $background_image);
 $modified         = (empty($modified)         ? time()         : $modified);
 
 

--- a/view/theme/frio/style.php
+++ b/view/theme/frio/style.php
@@ -16,27 +16,6 @@ $scheme_modified = 0;
 
 if ($a->module !== 'install') {
 
-	Config::load('frio');
-
-	// Load frios system config.
-	$scheme           = Config::get('frio', 'scheme', Config::get('frio', 'schema'));
-	$nav_bg           = Config::get('frio', 'nav_bg', '#708fa0');
-	$nav_icon_color   = Config::get('frio', 'nav_icon_color', '#fff');
-	$link_color       = Config::get('frio', 'link_color', '#6fdbe8');
-	$background_color = Config::get('frio', 'background_color', '#ededed');
-	$contentbg_transp = Config::get('frio', 'contentbg_transp');
-	$background_image = Config::get('frio', 'background_image', 'img/none.png');
-	$bg_image_option  = Config::get('frio', 'bg_image_option');
-	$login_bg_image   = Config::get('frio', 'login_bg_image');
-	$login_bg_color   = Config::get('frio', 'login_bg_color');
-	$modified         = Config::get('frio', 'css_modified');
-
-	// There is maybe the case that the user did never modify the theme settings.
-	// In this case we store the present time.
-	if (empty($modified)) {
-		Config::set('frio', 'css_modified', time());
-	}
-
 	// Get the UID of the profile owner.
 	$uid = defaults($_REQUEST, 'puid', 0);
 	if ($uid) {
@@ -58,6 +37,27 @@ if ($a->module !== 'install') {
 		if (empty($modified)) {
 			PConfig::set($uid, 'frio', 'css_modified', time());
 		}
+	}
+
+	Config::load('frio');
+
+	// Load frios system config.
+	$scheme           = (empty($scheme)           ? Config::get('frio', 'scheme', Config::get('frio', 'schema')) : $scheme);
+	$nav_bg           = (empty($nav_bg)           ? Config::get('frio', 'nav_bg', '#708fa0')                     : $nav_bg);
+	$nav_icon_color   = (empty($nav_icon_color)   ? Config::get('frio', 'nav_icon_color', '#fff')                : $nav_icon_color);
+	$link_color       = (empty($link_color)       ? Config::get('frio', 'link_color', '#6fdbe8')                 : $link_color);
+	$background_color = (empty($background_color) ? Config::get('frio', 'background_color', '#ededed')           : $background_color);
+	$contentbg_transp = (empty($contentbg_transp) ? Config::get('frio', 'contentbg_transp')                      : $contentbg_transp);
+	$background_image = (empty($background_image) ? Config::get('frio', 'background_image', 'img/none.png')      : $background_image);
+	$bg_image_option  = (empty($bg_image_option)  ? Config::get('frio', 'bg_image_option')                       : $bg_image_option);
+	$login_bg_image   = (empty($login_bg_image)   ? Config::get('frio', 'login_bg_image')                        : $login_bg_image);
+	$login_bg_color   = (empty($login_bg_color)   ? Config::get('frio', 'login_bg_color')                        : $login_bg_color;
+	$modified         = (empty($modified)         ? Config::get('frio', 'css_modified')                          : $modified);
+
+	// There is maybe the case that the user did never modify the theme settings.
+	// In this case we store the present time.
+	if (empty($modified)) {
+		Config::set('frio', 'css_modified', time());
 	}
 }
 


### PR DESCRIPTION
When creating a new profile and a custom login theme was set, I would expect the default frio theme for the new user would become the login theme. No it isn't.

Follow-up to: #7361

Resolves: #4854 