### PR TITLE
[frio] Use server theme settings for user's empty settings

### DIFF
--- a/view/theme/frio/style.php
+++ b/view/theme/frio/style.php
@@ -14,50 +14,41 @@ $schemecss = '';
 $schemecssfile = false;
 $scheme_modified = 0;
 
-if ($a->module !== 'install') {
-	// Get the UID of the profile owner.
-	$uid = defaults($_REQUEST, 'puid', 0);
-	if ($uid) {
-		PConfig::load($uid, 'frio');
+Config::load('frio');
 
-		// Load the profile owners pconfig.
-		$scheme           = PConfig::get($uid, 'frio', 'scheme', PConfig::get($uid, 'frio', 'schema'));
-		$nav_bg           = PConfig::get($uid, 'frio', 'nav_bg');
-		$nav_icon_color   = PConfig::get($uid, 'frio', 'nav_icon_color');
-		$link_color       = PConfig::get($uid, 'frio', 'link_color');
-		$background_color = PConfig::get($uid, 'frio', 'background_color');
-		$contentbg_transp = PConfig::get($uid, 'frio', 'contentbg_transp');
-		$background_image = PConfig::get($uid, 'frio', 'background_image');
-		$bg_image_option  = PConfig::get($uid, 'frio', 'bg_image_option');
-		$modified         = PConfig::get($uid, 'frio', 'css_modified');
+// Default to hard-coded values for empty settings
+$scheme           = Config::get('frio', 'scheme', Config::get('frio', 'schema'));
+$nav_bg           = Config::get('frio', 'nav_bg')           ?: '#708fa0';
+$nav_icon_color   = Config::get('frio', 'nav_icon_color')   ?: '#ffffff';
+$link_color       = Config::get('frio', 'link_color')       ?: '#6fdbe8';
+$background_color = Config::get('frio', 'background_color') ?: '#ededed';
+$contentbg_transp = Config::get('frio', 'contentbg_transp') ?: '';
+$background_image = Config::get('frio', 'background_image') ?: 'img/none.png';
+$bg_image_option  = Config::get('frio', 'bg_image_option')  ?: '';
+$login_bg_image   = Config::get('frio', 'login_bg_image')   ?: '';
+$login_bg_color   = Config::get('frio', 'login_bg_color')   ?: '';
+$modified         = Config::get('frio', 'css_modified')     ?: time();
 
-		// There is maybe the case that the user did never modify the theme settings.
-		// In this case we store the present time.
-		if (empty($modified)) {
-			PConfig::set($uid, 'frio', 'css_modified', time());
-		}
-	} else {
-		Config::load('frio');
+if (!$login_bg_image && !$login_bg_color) {
+	$login_bg_image = 'img/login_bg.jpg';
+}
+$login_bg_color = $login_bg_color ?: '#ededed';
 
-		// Load frios system config.
-		$scheme           = Config::get('frio', 'scheme', Config::get('frio', 'schema'));
-		$nav_bg           = Config::get('frio', 'nav_bg');
-		$nav_icon_color   = Config::get('frio', 'nav_icon_color');
-		$link_color       = Config::get('frio', 'link_color');
-		$background_color = Config::get('frio', 'background_color');
-		$contentbg_transp = Config::get('frio', 'contentbg_transp');
-		$background_image = Config::get('frio', 'background_image');
-		$bg_image_option  = Config::get('frio', 'bg_image_option');
-		$login_bg_image   = Config::get('frio', 'login_bg_image');
-		$login_bg_color   = Config::get('frio', 'login_bg_color');
-		$modified         = Config::get('frio', 'css_modified');
+// Get the UID of the profile owner.
+$uid = $_REQUEST['puid'] ?? 0;
+if ($uid) {
+	PConfig::load($uid, 'frio');
 
-		// There is maybe the case that the user did never modify the theme settings.
-		// In this case we store the present time.
-		if (empty($modified)) {
-			Config::set('frio', 'css_modified', time());
-		}
-	}
+	// Only override display settings that have actually been set
+	$scheme           = PConfig::get($uid, 'frio', 'scheme', PConfig::get($uid, 'frio', 'schema')) ?: $scheme;
+	$nav_bg           = PConfig::get($uid, 'frio', 'nav_bg')           ?: $nav_bg;
+	$nav_icon_color   = PConfig::get($uid, 'frio', 'nav_icon_color')   ?: $nav_icon_color;
+	$link_color       = PConfig::get($uid, 'frio', 'link_color')       ?: $link_color;
+	$background_color = PConfig::get($uid, 'frio', 'background_color') ?: $background_color;
+	$contentbg_transp = PConfig::get($uid, 'frio', 'contentbg_transp') ?: $contentbg_transp;
+	$background_image = PConfig::get($uid, 'frio', 'background_image') ?: $background_image;
+	$bg_image_option  = PConfig::get($uid, 'frio', 'bg_image_option')  ?: $bg_image_option;
+	$modified         = PConfig::get($uid, 'frio', 'css_modified')     ?: $modified;
 }
 
 // Now load the scheme.  If a value is changed above, we'll keep the settings
@@ -93,24 +84,6 @@ if (!$scheme) {
 		$schemecssfile = 'view/theme/frio/scheme/default.css';
 	}
 }
-
-//Set some defaults - we have to do this after pulling owner settings, and we have to check for each setting
-//individually.  If we don't, we'll have problems if a user has set one, but not all options.
-$nav_bg           = (empty($nav_bg)           ? '#708fa0'      : $nav_bg);
-$nav_icon_color   = (empty($nav_icon_color)   ? '#fff'         : $nav_icon_color);
-$link_color       = (empty($link_color)       ? '#6fdbe8'      : $link_color);
-$background_color = (empty($background_color) ? '#ededed'      : $background_color);
-// The background image can not be empty. So we use a dummy jpg if no image was set.
-$background_image = (empty($background_image) ? 'img/none.png' : $background_image);
-$modified         = (empty($modified)         ? time()         : $modified);
-
-
-// set a default login bg image if no custom image and no custom bg color are set.
-if (empty($login_bg_image) && empty($login_bg_color)) {
-	$login_bg_image = 'img/login_bg.jpg';
-}
-$login_bg_color   = (empty($login_bg_color)   ? '#ededed'      : $login_bg_color);
-$login_bg_image   = (empty($login_bg_image)   ? ''             : $login_bg_image);
 
 $contentbg_transp = ((isset($contentbg_transp) && $contentbg_transp != '') ? $contentbg_transp : 100);
 


### PR DESCRIPTION
Redux of #7374
Fixes #4854 

This now should produce the expected result: for each frio theme settings, there is a cascading fallback for empty settings: User -> Node -> Hardcoded default.

I'll need formal confirmation from @AlfredSK after merge.