### PR TITLE
Issue 7367: Enhanced check when DFRN delivery can be skipped

### DIFF
--- a/src/Worker/Notifier.php
+++ b/src/Worker/Notifier.php
@@ -557,7 +557,7 @@ class Notifier
 			return false;
 		}
 
-		// Skip DFRN when the will be (forcefully) delivered via AP
+		// Skip DFRN when the item will be (forcefully) delivered via AP
 		if (Config::get('debug', 'total_ap_delivery') && ($contact['network'] == Protocol::DFRN) && !empty(APContact::getByURL($contact['url'], false))) {
 			return true;
 		}


### PR DESCRIPTION
We now only skip the DFRN delivery when both author and owner of the post do support AP.
Fixes https://github.com/friendica/friendica/issues/7367