### PR TITLE
Fixing initial load config (Simplify Config Part 3a)

### DIFF
--- a/tests/Util/AppMockTrait.php
+++ b/tests/Util/AppMockTrait.php
@@ -44,7 +44,6 @@ trait AppMockTrait
 	public function mockApp(vfsStreamDirectory $root, $raw = false)
 	{
 		$this->configMock = \Mockery::mock(Config\Cache\ConfigCache::class);
-		$this->configMock->shouldReceive('getAll')->andReturn([])->once();
 		$this->mode = \Mockery::mock(App\Mode::class);
 		$configModel= \Mockery::mock(\Friendica\Model\Config\Config::class);
 		// Disable the adapter

--- a/tests/src/Core/Config/JitConfigurationTest.php
+++ b/tests/src/Core/Config/JitConfigurationTest.php
@@ -114,7 +114,13 @@ class JitConfigurationTest extends ConfigurationTest
 		                  ->andReturn(['config' => []])
 		                  ->once();
 
-		// mocking one get
+		// mocking one get without result
+		$this->configModel->shouldReceive('get')
+		                  ->with('test', 'it')
+		                  ->andReturn(null)
+		                  ->once();
+
+		// mocking the data get
 		$this->configModel->shouldReceive('get')
 		                  ->with('test', 'it')
 		                  ->andReturn($data)
@@ -160,6 +166,12 @@ class JitConfigurationTest extends ConfigurationTest
 		$this->configModel->shouldReceive('load')
 		                  ->with('config')
 		                  ->andReturn(['config' => []])
+		                  ->once();
+
+		// mocking one get without result
+		$this->configModel->shouldReceive('get')
+		                  ->with('test', 'it')
+		                  ->andReturn(null)
 		                  ->once();
 
 		parent::testDeleteWithDB();


### PR DESCRIPTION
FollowUp #7372 

- Don't use config values as "in_db" values -> causes side effects
- Set "in_db" even in case a db-select was set without return to avoid selects over and over again