### PR TITLE
Hide registration button on login page when registration are closed

### DIFF
--- a/src/Module/Login.php
+++ b/src/Module/Login.php
@@ -281,7 +281,7 @@ class Login extends BaseModule
 		$a = self::getApp();
 		$o = '';
 		$reg = false;
-		if ($register) {
+		if ($register && intval($a->getConfig()->get('config', 'register_policy')) !== Register::CLOSED) {
 			$reg = [
 				'title' => L10n::t('Create a New Account'),
 				'desc' => L10n::t('Register')


### PR DESCRIPTION
Closes #7293 

Now the registration button should not appear when registrations are closed.

Question: Nodes by invite only have their registrations open but people without an invite can't register. Should the button be displayed still?