### PR TITLE
Ensure NULL isn't passed to Feature::isEnabled

### DIFF
--- a/mod/cal.php
+++ b/mod/cal.php
@@ -110,7 +110,7 @@ function cal_content(App $a)
 	$remote_contact = false;
 	$contact_id = 0;
 
-	$owner_uid = $a->data['user']['uid'];
+	$owner_uid = intval($a->data['user']['uid']);
 	$nick = $a->data['user']['nickname'];
 
 	if (!empty($_SESSION['remote']) && is_array($_SESSION['remote'])) {
@@ -290,14 +290,14 @@ function cal_content(App $a)
 	}
 
 	if ($mode == 'export') {
-		if (!intval($owner_uid)) {
+		if (!$owner_uid) {
 			notice(L10n::t('User not found'));
 			return;
 		}
 
 		// Test permissions
 		// Respect the export feature setting for all other /cal pages if it's not the own profile
-		if ((local_user() !== intval($owner_uid)) && !Feature::isEnabled($owner_uid, "export_calendar")) {
+		if ((local_user() !== $owner_uid) && !Feature::isEnabled($owner_uid, "export_calendar")) {
 			notice(L10n::t('Permission denied.') . EOL);
 			$a->internalRedirect('cal/' . $nick);
 		}
@@ -314,7 +314,7 @@ function cal_content(App $a)
 
 			// If it the own calendar return to the events page
 			// otherwise to the profile calendar page
-			if (local_user() === intval($owner_uid)) {
+			if (local_user() === $owner_uid) {
 				$return_path = "events";
 			} else {
 				$return_path = "cal/" . $nick;

--- a/mod/photos.php
+++ b/mod/photos.php
@@ -149,7 +149,7 @@ function photos_post(App $a)
 	$can_post  = false;
 	$visitor   = 0;
 
-	$page_owner_uid = $a->data['user']['uid'];
+	$page_owner_uid = intval($a->data['user']['uid']);
 	$community_page = $a->data['user']['page-flags'] == User::PAGE_FLAGS_COMMUNITY;
 
 	if (local_user() && (local_user() == $page_owner_uid)) {

--- a/src/Content/Feature.php
+++ b/src/Content/Feature.php
@@ -20,7 +20,7 @@ class Feature
 	 * @return boolean
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
-	public static function isEnabled($uid, $feature)
+	public static function isEnabled(int $uid, $feature)
 	{
 		$x = Config::get('feature_lock', $feature, false);
 

--- a/src/Content/Widget.php
+++ b/src/Content/Widget.php
@@ -297,11 +297,13 @@ class Widget
 	{
 		$a = \get_app();
 
-		if (!Feature::isEnabled($a->profile['profile_uid'], 'categories')) {
+		$uid = intval($a->profile['profile_uid']);
+
+		if (!Feature::isEnabled($uid, 'categories')) {
 			return '';
 		}
 
-		$saved = PConfig::get($a->profile['profile_uid'], 'system', 'filetags');
+		$saved = PConfig::get($uid, 'system', 'filetags');
 		if (!strlen($saved)) {
 			return;
 		}
@@ -420,17 +422,19 @@ class Widget
 	{
 		$a = \get_app();
 
-		if (!$a->profile['profile_uid'] || !$a->profile['url']) {
+		$uid = intval($a->profile['profile_uid']);
+
+		if (!$uid || !$a->profile['url']) {
 			return '';
 		}
 
-		if (Feature::isEnabled($a->profile['profile_uid'], 'tagadelic')) {
+		if (Feature::isEnabled($uid, 'tagadelic')) {
 			$owner_id = Contact::getIdForURL($a->profile['url'], 0, true);
 
 			if (!$owner_id) {
 				return '';
 			}
-			return Widget\TagCloud::getHTML($a->profile['profile_uid'], $limit, $owner_id, 'wall');
+			return Widget\TagCloud::getHTML($uid, $limit, $owner_id, 'wall');
 		}
 
 		return '';

--- a/src/Content/Widget/CalendarExport.php
+++ b/src/Content/Widget/CalendarExport.php
@@ -30,7 +30,7 @@ class CalendarExport
 			return;
 		}
 
-		$owner_uid = $a->data['user']['uid'];
+		$owner_uid = intval($a->data['user']['uid']);
 
 		// The permission testing is a little bit tricky because we have to respect many cases.
 

--- a/src/Core/Config/JitPConfiguration.php
+++ b/src/Core/Config/JitPConfiguration.php
@@ -32,10 +32,10 @@ class JitPConfiguration extends PConfiguration
 	 * {@inheritDoc}
 	 *
 	 */
-	public function load($uid, string $cat = 'config')
+	public function load(int $uid, string $cat = 'config')
 	{
 		// If not connected or no uid, do nothing
-		if (!is_int($uid) || !$this->configModel->isConnected()) {
+		if (!$uid || !$this->configModel->isConnected()) {
 			return;
 		}
 
@@ -54,9 +54,9 @@ class JitPConfiguration extends PConfiguration
 	/**
 	 * {@inheritDoc}
 	 */
-	public function get($uid, string $cat, string $key, $default_value = null, bool $refresh = false)
+	public function get(int $uid, string $cat, string $key, $default_value = null, bool $refresh = false)
 	{
-		if (!is_int($uid)) {
+		if (!$uid) {
 			return $default_value;
 		}
 
@@ -84,9 +84,9 @@ class JitPConfiguration extends PConfiguration
 	/**
 	 * {@inheritDoc}
 	 */
-	public function set($uid, string $cat, string $key, $value)
+	public function set(int $uid, string $cat, string $key, $value)
 	{
-		if (!is_int($uid)) {
+		if (!$uid) {
 			return false;
 		}
 
@@ -108,9 +108,9 @@ class JitPConfiguration extends PConfiguration
 	/**
 	 * {@inheritDoc}
 	 */
-	public function delete($uid, string $cat, string $key)
+	public function delete(int $uid, string $cat, string $key)
 	{
-		if (!is_int($uid)) {
+		if (!$uid) {
 			return false;
 		}
 

--- a/src/Core/Config/PConfiguration.php
+++ b/src/Core/Config/PConfiguration.php
@@ -46,16 +46,16 @@ abstract class PConfiguration
 	/**
 	 * Loads all configuration values of a user's config family into a cached storage.
 	 *
-	 * All configuration values of the given user are stored with the $uid in
-	 * the cache ( @param int $uid The user_id
+	 * All configuration values of the given user are stored with the $uid in the cache
 	 *
+	 * @param int $uid The user_id
 	 * @param string $cat The category of the configuration value
 	 *
 	 * @return void
 	 * @see PConfigCache )
 	 *
 	 */
-	abstract public function load($uid, string $cat = 'config');
+	abstract public function load(int $uid, string $cat = 'config');
 
 	/**
 	 * Get a particular user's config variable given the category name
@@ -73,7 +73,7 @@ abstract class PConfiguration
 	 *
 	 * @return mixed Stored value or null if it does not exist
 	 */
-	abstract public function get($uid, string $cat, string $key, $default_value = null, bool $refresh = false);
+	abstract public function get(int $uid, string $cat, string $key, $default_value = null, bool $refresh = false);
 
 	/**
 	 * Sets a configuration value for a user
@@ -90,7 +90,7 @@ abstract class PConfiguration
 	 *
 	 * @return bool Operation success
 	 */
-	abstract public function set($uid, string $cat, string $key, $value);
+	abstract public function set(int $uid, string $cat, string $key, $value);
 
 	/**
 	 * Deletes the given key from the users's configuration.
@@ -105,5 +105,5 @@ abstract class PConfiguration
 	 *
 	 * @return bool
 	 */
-	abstract public function delete($uid, string $cat, string $key);
+	abstract public function delete(int $uid, string $cat, string $key);
 }

--- a/src/Core/Config/PreloadPConfiguration.php
+++ b/src/Core/Config/PreloadPConfiguration.php
@@ -31,10 +31,10 @@ class PreloadPConfiguration extends PConfiguration
 	 * This loads all config values everytime load is called
 	 *
 	 */
-	public function load($uid, string $cat = 'config')
+	public function load(int $uid, string $cat = 'config')
 	{
 		// Don't load the whole configuration twice or with invalid uid
-		if (!is_int($uid) || !empty($this->config_loaded[$uid])) {
+		if (!$uid || !empty($this->config_loaded[$uid])) {
 			return;
 		}
 
@@ -53,9 +53,9 @@ class PreloadPConfiguration extends PConfiguration
 	/**
 	 * {@inheritDoc}
 	 */
-	public function get($uid, string $cat, string $key, $default_value = null, bool $refresh = false)
+	public function get(int $uid, string $cat, string $key, $default_value = null, bool $refresh = false)
 	{
-		if (!is_int($uid)) {
+		if (!$uid) {
 			return $default_value;
 		}
 
@@ -79,9 +79,9 @@ class PreloadPConfiguration extends PConfiguration
 	/**
 	 * {@inheritDoc}
 	 */
-	public function set($uid, string $cat, string $key, $value)
+	public function set(int $uid, string $cat, string $key, $value)
 	{
-		if (!is_int($uid)) {
+		if (!$uid) {
 			return false;
 		}
 
@@ -105,9 +105,9 @@ class PreloadPConfiguration extends PConfiguration
 	/**
 	 * {@inheritDoc}
 	 */
-	public function delete($uid, string $cat, string $key)
+	public function delete(int $uid, string $cat, string $key)
 	{
-		if (!is_int($uid)) {
+		if (!$uid) {
 			return false;
 		}
 

--- a/src/Core/PConfig.php
+++ b/src/Core/PConfig.php
@@ -35,12 +35,12 @@ class PConfig
 	/**
 	 * @brief Loads all configuration values of a user's config family into a cached storage.
 	 *
-	 * @param string $uid The user_id
+	 * @param int    $uid The user_id
 	 * @param string $cat The category of the configuration value
 	 *
 	 * @return void
 	 */
-	public static function load($uid, $cat)
+	public static function load(int $uid, $cat)
 	{
 		self::$config->load($uid, $cat);
 	}
@@ -49,7 +49,7 @@ class PConfig
 	 * @brief Get a particular user's config variable given the category name
 	 * ($cat) and a key.
 	 *
-	 * @param string  $uid           The user_id
+	 * @param int     $uid           The user_id
 	 * @param string  $cat           The category of the configuration value
 	 * @param string  $key           The configuration key to query
 	 * @param mixed   $default_value optional, The value to return if key is not set (default: null)
@@ -57,7 +57,7 @@ class PConfig
 	 *
 	 * @return mixed Stored value or null if it does not exist
 	 */
-	public static function get($uid, $cat, $key, $default_value = null, $refresh = false)
+	public static function get(int $uid, $cat, $key, $default_value = null, $refresh = false)
 	{
 		return self::$config->get($uid, $cat, $key, $default_value, $refresh);
 	}
@@ -65,14 +65,14 @@ class PConfig
 	/**
 	 * @brief Sets a configuration value for a user
 	 *
-	 * @param string $uid    The user_id
+	 * @param int    $uid    The user_id
 	 * @param string $cat    The category of the configuration value
 	 * @param string $key    The configuration key to set
 	 * @param mixed  $value  The value to store
 	 *
 	 * @return bool Operation success
 	 */
-	public static function set($uid, $cat, $key, $value)
+	public static function set(int $uid, $cat, $key, $value)
 	{
 		return self::$config->set($uid, $cat, $key, $value);
 	}
@@ -80,13 +80,13 @@ class PConfig
 	/**
 	 * @brief Deletes the given key from the users's configuration.
 	 *
-	 * @param string $uid The user_id
+	 * @param int    $uid The user_id
 	 * @param string $cat The category of the configuration value
 	 * @param string $key The configuration key to delete
 	 *
 	 * @return bool
 	 */
-	public static function delete($uid, $cat, $key)
+	public static function delete(int $uid, $cat, $key)
 	{
 		return self::$config->delete($uid, $cat, $key);
 	}

--- a/src/Core/PConfig.php
+++ b/src/Core/PConfig.php
@@ -40,7 +40,7 @@ class PConfig
 	 *
 	 * @return void
 	 */
-	public static function load(int $uid, $cat)
+	public static function load(int $uid, string $cat)
 	{
 		self::$config->load($uid, $cat);
 	}
@@ -57,7 +57,7 @@ class PConfig
 	 *
 	 * @return mixed Stored value or null if it does not exist
 	 */
-	public static function get(int $uid, $cat, $key, $default_value = null, $refresh = false)
+	public static function get(int $uid, string $cat, string $key, $default_value = null, bool $refresh = false)
 	{
 		return self::$config->get($uid, $cat, $key, $default_value, $refresh);
 	}
@@ -72,7 +72,7 @@ class PConfig
 	 *
 	 * @return bool Operation success
 	 */
-	public static function set(int $uid, $cat, $key, $value)
+	public static function set(int $uid, string $cat, string $key, $value)
 	{
 		return self::$config->set($uid, $cat, $key, $value);
 	}
@@ -86,7 +86,7 @@ class PConfig
 	 *
 	 * @return bool
 	 */
-	public static function delete(int $uid, $cat, $key)
+	public static function delete(int $uid, string $cat, string $key)
 	{
 		return self::$config->delete($uid, $cat, $key);
 	}

--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -717,7 +717,7 @@ class Profile
 
 	public static function getAdvanced(App $a)
 	{
-		$uid = $a->profile['uid'];
+		$uid = intval($a->profile['uid']);
 
 		if ($a->profile['name']) {
 			$tpl = Renderer::getMarkupTemplate('profile_advanced.tpl');

--- a/tests/src/Core/Config/JitPConfigurationTest.php
+++ b/tests/src/Core/Config/JitPConfigurationTest.php
@@ -116,15 +116,6 @@ class JitPConfigurationTest extends PConfigurationTest
 		parent::testGetWithRefresh($uid, $data);
 	}
 
-	public function testGetWrongWithoutDB()
-	{
-		$this->configModel->shouldReceive('isConnected')
-		                  ->andReturn(false)
-		                  ->times(3);
-
-		parent::testGetWrongWithoutDB();
-	}
-
 	/**
 	 * @dataProvider dataTests
 	 */
@@ -145,7 +136,7 @@ class JitPConfigurationTest extends PConfigurationTest
 
 		// mocking one get without result
 		$this->configModel->shouldReceive('get')
-		                  ->with(0, 'test', 'it')
+		                  ->with(42, 'test', 'it')
 		                  ->andReturn(null)
 		                  ->once();
 

--- a/tests/src/Core/Config/PConfigurationTest.php
+++ b/tests/src/Core/Config/PConfigurationTest.php
@@ -365,22 +365,24 @@ abstract class PConfigurationTest extends MockedTest
 	 */
 	public function testDeleteWithDB()
 	{
-		$this->configCache->load(0, ['test' => ['it' => 'now', 'quarter' => 'true']]);
+		$uid = 42;
+
+		$this->configCache->load($uid, ['test' => ['it' => 'now', 'quarter' => 'true']]);
 
 		$this->configModel->shouldReceive('delete')
-		                  ->with(0, 'test', 'it')
+		                  ->with($uid, 'test', 'it')
 		                  ->andReturn(false)
 		                  ->once();
 		$this->configModel->shouldReceive('delete')
-		                  ->with(0, 'test', 'second')
+		                  ->with($uid, 'test', 'second')
 		                  ->andReturn(true)
 		                  ->once();
 		$this->configModel->shouldReceive('delete')
-		                  ->with(0, 'test', 'third')
+		                  ->with($uid, 'test', 'third')
 		                  ->andReturn(false)
 		                  ->once();
 		$this->configModel->shouldReceive('delete')
-		                  ->with(0, 'test', 'quarter')
+		                  ->with($uid, 'test', 'quarter')
 		                  ->andReturn(true)
 		                  ->once();
 
@@ -388,19 +390,19 @@ abstract class PConfigurationTest extends MockedTest
 		$this->assertInstanceOf(PConfigCache::class, $this->testedConfig->getCache());
 
 		// directly set the value to the cache
-		$this->testedConfig->getCache()->set(0, 'test', 'it', 'now');
+		$this->testedConfig->getCache()->set($uid, 'test', 'it', 'now');
 
-		$this->assertEquals('now', $this->testedConfig->get(0, 'test', 'it'));
-		$this->assertEquals('now', $this->testedConfig->getCache()->get(0, 'test', 'it'));
+		$this->assertEquals('now', $this->testedConfig->get($uid, 'test', 'it'));
+		$this->assertEquals('now', $this->testedConfig->getCache()->get($uid, 'test', 'it'));
 
 		// delete from cache only
-		$this->assertTrue($this->testedConfig->delete(0, 'test', 'it'));
+		$this->assertTrue($this->testedConfig->delete($uid, 'test', 'it'));
 		// delete from db only
-		$this->assertTrue($this->testedConfig->delete(0, 'test', 'second'));
+		$this->assertTrue($this->testedConfig->delete($uid, 'test', 'second'));
 		// no delete
-		$this->assertFalse($this->testedConfig->delete(0, 'test', 'third'));
+		$this->assertFalse($this->testedConfig->delete($uid, 'test', 'third'));
 		// delete both
-		$this->assertTrue($this->testedConfig->delete(0, 'test', 'quarter'));
+		$this->assertTrue($this->testedConfig->delete($uid, 'test', 'quarter'));
 
 		$this->assertEmpty($this->testedConfig->getCache()->getAll());
 	}

--- a/tests/src/Core/Config/PConfigurationTest.php
+++ b/tests/src/Core/Config/PConfigurationTest.php
@@ -460,7 +460,7 @@ abstract class PConfigurationTest extends MockedTest
 	public function testInvalidUid()
 	{
 		// bad UID!
-		$uid = null;
+		$uid = 0;
 
 		$this->testedConfig = $this->getInstance();
 

--- a/tests/src/Core/Config/PreloadPConfigurationTest.php
+++ b/tests/src/Core/Config/PreloadPConfigurationTest.php
@@ -108,16 +108,6 @@ class PreloadPConfigurationTest extends PConfigurationTest
 		parent::testGetWithRefresh($uid, $data);
 	}
 
-
-	public function testGetWrongWithoutDB()
-	{
-		$this->configModel->shouldReceive('isConnected')
-		                  ->andReturn(false)
-		                  ->times(3);
-
-		parent::testGetWrongWithoutDB();
-	}
-
 	/**
 	 * @dataProvider dataTests
 	 */
@@ -138,7 +128,7 @@ class PreloadPConfigurationTest extends PConfigurationTest
 
 		// constructor loading
 		$this->configModel->shouldReceive('load')
-		                  ->with(0)
+		                  ->with(42)
 		                  ->andReturn(['config' => []])
 		                  ->once();
 


### PR DESCRIPTION
Follow-up to #7387
Addresses https://github.com/friendica/friendica/issues/7297#issuecomment-511515108

In PHP, type-hinting doesn't just check the parameter value, it also coerces the value to the target type when it can.

See example below:
```php
function toInt(int $input) {
    var_dump($input);
}

toInt(1); // int(1)
toInt('1'); // int(1)
toInt(false); // int(0)

toInt([]); // triggers type exception
toInt(null); // triggers type exception
```

When @nupplaphil removed the type-hints, it restored a distinction between `PConfig::(1, 'cat', 'key')` and `PConfig::('1', 'cat', 'key')`. The problem is that theme settings are displayed and saved according to the first form, but accessed with the second form. `'1'` didn't pass the `is_int()` test at the start of each `PConfig` method and the default values were systematically returned.

This PR restores the type-hints (and the type coercion going with it) and simply ensures we can't have `null` as a parameter for `Feature::isEnabled`.

I'll let this PR stew on my main node for about 12 hours to check if nothing wrong happens.