### PR TITLE
[frio] Theme settings fallback on node settings

### DIFF
--- a/mod/settings.php
+++ b/mod/settings.php
@@ -912,8 +912,8 @@ function settings_content(App $a)
 			}
 		}
 
-		$theme_selected        = Session::get('theme', $default_theme);
-		$mobile_theme_selected = Session::get('mobile-theme', $default_mobile_theme);
+		$theme_selected        = $a->user['theme'] ?: $default_theme;
+		$mobile_theme_selected = $a->user['mobile-theme'] ?: $default_mobile_theme;
 
 		$nowarn_insecure = intval(PConfig::get(local_user(), 'system', 'nowarn_insecure'));
 

--- a/mod/settings.php
+++ b/mod/settings.php
@@ -369,19 +369,19 @@ function settings_post(App $a)
 		PConfig::set(local_user(), 'system', 'bandwidth_saver'         , $bandwidth_saver);
 		PConfig::set(local_user(), 'system', 'smart_threading'         , $smart_threading);
 
-		if ($theme == $a->user['theme']) {
-			// call theme_post only if theme has not been changed
-			if (($themeconfigfile = get_theme_config_file($theme)) !== null) {
-				require_once $themeconfigfile;
-				theme_post($a);
+		if (in_array($theme, Theme::getAllowedList())) {
+			if ($theme == $a->user['theme']) {
+				// call theme_post only if theme has not been changed
+				if (($themeconfigfile = get_theme_config_file($theme)) !== null) {
+					require_once $themeconfigfile;
+					theme_post($a);
+				}
+			} else {
+				$a->getDatabase()->update('user', ['theme' => $theme], ['uid' => local_user()]);
 			}
+		} else {
+			notice(L10n::t('The theme you chose isn\'t available.'));
 		}
-		Theme::install($theme);
-
-		q("UPDATE `user` SET `theme` = '%s' WHERE `uid` = %d",
-				DBA::escape($theme),
-				intval(local_user())
-		);
 
 		Hook::callAll('display_settings_post', $_POST);
 		$a->internalRedirect('settings/display');

--- a/view/theme/frio/config.php
+++ b/view/theme/frio/config.php
@@ -56,15 +56,17 @@ function theme_content(App $a)
 	}
 	$arr = [];
 
-	$arr['scheme']           = PConfig::get(local_user(), 'frio', 'scheme', PConfig::get(local_user(), 'frio', 'schema'));
+	$node_scheme = Config::get('frio', 'scheme', Config::get('frio', 'scheme'));
+
+	$arr['scheme']           = PConfig::get(local_user(), 'frio', 'scheme', PConfig::get(local_user(), 'frio', 'schema', $node_scheme));
 	$arr['share_string']     = '';
-	$arr['nav_bg']           = PConfig::get(local_user(), 'frio', 'nav_bg');
-	$arr['nav_icon_color']   = PConfig::get(local_user(), 'frio', 'nav_icon_color');
-	$arr['link_color']       = PConfig::get(local_user(), 'frio', 'link_color');
-	$arr['background_color'] = PConfig::get(local_user(), 'frio', 'background_color');
-	$arr['contentbg_transp'] = PConfig::get(local_user(), 'frio', 'contentbg_transp');
-	$arr['background_image'] = PConfig::get(local_user(), 'frio', 'background_image');
-	$arr['bg_image_option']  = PConfig::get(local_user(), 'frio', 'bg_image_option');
+	$arr['nav_bg']           = PConfig::get(local_user(), 'frio', 'nav_bg'          , Config::get('frio', 'nav_bg'));
+	$arr['nav_icon_color']   = PConfig::get(local_user(), 'frio', 'nav_icon_color'  , Config::get('frio', 'nav_icon_color'));
+	$arr['link_color']       = PConfig::get(local_user(), 'frio', 'link_color'      , Config::get('frio', 'link_color'));
+	$arr['background_color'] = PConfig::get(local_user(), 'frio', 'background_color', Config::get('frio', 'background_color'));
+	$arr['contentbg_transp'] = PConfig::get(local_user(), 'frio', 'contentbg_transp', Config::get('frio', 'contentbg_transp'));
+	$arr['background_image'] = PConfig::get(local_user(), 'frio', 'background_image', Config::get('frio', 'background_image'));
+	$arr['bg_image_option']  = PConfig::get(local_user(), 'frio', 'bg_image_option' , Config::get('frio', 'bg_image_option'));
 
 	return frio_form($arr);
 }


### PR DESCRIPTION
Fixes #7397

This PR fixes a side-bug where any user can force install a theme even if the admin didn't enable it.

To be clear about the `[frio]` label: the theme selection now matches the node's for new users, no matter which theme is selected for the node. However, only the frio theme settings have been updated to show the node's values for new users.