### PR TITLE
Ensures node theme settings are used to render theme embed

### DIFF
--- a/src/Module/Admin/Themes/Embed.php
+++ b/src/Module/Admin/Themes/Embed.php
@@ -77,6 +77,9 @@ class Embed extends BaseAdminModule
 				}
 			}
 
+			// Overrides normal theme style include to strip user param to show embedded theme settings
+			Renderer::$theme['stylesheet'] = 'view/theme/' . $theme . '/style.pcss';
+
 			$t = Renderer::getMarkupTemplate('admin/addons/embed.tpl');
 			return Renderer::replaceMacros($t, [
 				'$action' => '/admin/themes/' . $theme . '/embed?mode=minimal',


### PR DESCRIPTION
Fixes #7401 

Actually, it was super simple, we already had an exception in place to substitute the generated stylesheet path including the user id.