### PR TITLE
Fetch items by given uri

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -1,6 +1,6 @@
 -- ------------------------------------------
 -- Friendica 2019.09-dev (Dalmatian Bellflower)
--- DB_UPDATE_VERSION 1318
+-- DB_UPDATE_VERSION 1319
 -- ------------------------------------------
 
 
@@ -605,15 +605,15 @@ CREATE TABLE IF NOT EXISTS `item` (
 	 INDEX `extid` (`extid`(191)),
 	 INDEX `uid_id` (`uid`,`id`),
 	 INDEX `uid_contactid_id` (`uid`,`contact-id`,`id`),
-	 INDEX `uid_created` (`uid`,`created`),
+	 INDEX `uid_received` (`uid`,`received`),
 	 INDEX `uid_commented` (`uid`,`commented`),
 	 INDEX `uid_unseen_contactid` (`uid`,`unseen`,`contact-id`),
 	 INDEX `uid_network_received` (`uid`,`network`,`received`),
 	 INDEX `uid_network_commented` (`uid`,`network`,`commented`),
 	 INDEX `uid_thrparent` (`uid`,`thr-parent`(190)),
 	 INDEX `uid_parenturi` (`uid`,`parent-uri`(190)),
-	 INDEX `uid_contactid_created` (`uid`,`contact-id`,`created`),
-	 INDEX `authorid_created` (`author-id`,`created`),
+	 INDEX `uid_contactid_received` (`uid`,`contact-id`,`received`),
+	 INDEX `authorid_received` (`author-id`,`received`),
 	 INDEX `ownerid` (`owner-id`),
 	 INDEX `contact-id` (`contact-id`),
 	 INDEX `uid_uri` (`uid`,`uri`(190)),
@@ -667,6 +667,7 @@ CREATE TABLE IF NOT EXISTS `item-content` (
 	 PRIMARY KEY(`id`),
 	 UNIQUE INDEX `uri-plink-hash` (`uri-plink-hash`),
 	 INDEX `uri` (`uri`(191)),
+	 INDEX `plink` (`plink`(191)),
 	 INDEX `uri-id` (`uri-id`)
 ) DEFAULT COLLATE utf8mb4_general_ci COMMENT='Content for all posts';
 
@@ -1157,15 +1158,15 @@ CREATE TABLE IF NOT EXISTS `thread` (
 	`bookmark` boolean COMMENT '',
 	 PRIMARY KEY(`iid`),
 	 INDEX `uid_network_commented` (`uid`,`network`,`commented`),
-	 INDEX `uid_network_created` (`uid`,`network`,`created`),
+	 INDEX `uid_network_received` (`uid`,`network`,`received`),
 	 INDEX `uid_contactid_commented` (`uid`,`contact-id`,`commented`),
-	 INDEX `uid_contactid_created` (`uid`,`contact-id`,`created`),
+	 INDEX `uid_contactid_received` (`uid`,`contact-id`,`received`),
 	 INDEX `contactid` (`contact-id`),
 	 INDEX `ownerid` (`owner-id`),
 	 INDEX `authorid` (`author-id`),
-	 INDEX `uid_created` (`uid`,`created`),
+	 INDEX `uid_received` (`uid`,`received`),
 	 INDEX `uid_commented` (`uid`,`commented`),
-	 INDEX `uid_wall_created` (`uid`,`wall`,`created`),
+	 INDEX `uid_wall_received` (`uid`,`wall`,`received`),
 	 INDEX `private_wall_origin_commented` (`private`,`wall`,`origin`,`commented`)
 ) DEFAULT COLLATE utf8mb4_general_ci COMMENT='Thread related data';
 

--- a/mod/search.php
+++ b/mod/search.php
@@ -18,7 +18,6 @@ use Friendica\Module\BaseSearchModule;
 use Friendica\Util\Strings;
 
 function search_saved_searches() {
-
 	$o = '';
 	$search = (!empty($_GET['search']) ? Strings::escapeTags(trim(rawurldecode($_GET['search']))) : '');
 
@@ -50,12 +49,10 @@ function search_saved_searches() {
 	}
 
 	return $o;
-
 }
 
 
 function search_init(App $a) {
-
 	$search = (!empty($_GET['search']) ? Strings::escapeTags(trim(rawurldecode($_GET['search']))) : '');
 
 	if (local_user()) {
@@ -83,13 +80,9 @@ function search_init(App $a) {
 		unset($_SESSION['theme']);
 		unset($_SESSION['mobile-theme']);
 	}
-
-
-
 }
 
 function search_content(App $a) {
-
 	if (Config::get('system','block_public') && !local_user() && !remote_user()) {
 		notice(L10n::t('Public access denied.') . EOL);
 		return;
@@ -152,6 +145,16 @@ function search_content(App $a) {
 	}
 	if (strpos($search,'!') === 0) {
 		return BaseSearchModule::performSearch();
+	}
+
+	if (parse_url($search, PHP_URL_SCHEME) != '') {
+		$id = Item::fetchByLink($search);
+		if (!empty($id)) {
+			$item = Item::selectFirst(['guid'], ['id' => $id]);
+			if (DBA::isResult($item)) {
+				$a->internalRedirect('display/' . $item['guid']);
+			}
+		}
 	}
 
 	if (!empty($_GET['search-option']))

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -29,6 +29,7 @@ use Friendica\Util\Security;
 use Friendica\Util\Strings;
 use Friendica\Util\XML;
 use Friendica\Worker\Delivery;
+use Friendica\Protocol\ActivityPub;
 use Text_LanguageDetect;
 
 class Item extends BaseObject
@@ -3574,5 +3575,70 @@ class Item extends BaseObject
 		}
 
 		return Contact::isForum($item['contact-id']);
+	}
+
+	/**
+	 * Search item id for given URI or plink
+	 *
+	 * @param string $uri
+	 * @param integer $uid
+	 *
+	 * @return integer item id
+	 */
+	public static function searchByLink($uri, $uid = 0)
+	{
+		$ssl_uri = str_replace('http://', 'https://', $uri);
+		$uris = [$uri, $ssl_uri, Strings::normaliseLink($uri)];
+
+		$item = DBA::selectFirst('item', ['id'], ['uri' => $uris, 'uid' => $uid]);
+		if (DBA::isResult($item)) {
+			return $item['id'];
+		}
+
+		$itemcontent = DBA::selectFirst('item-content', ['uri-id'], ['plink' => $uris]);
+		if (!DBA::isResult($itemcontent)) {
+			return 0;
+		}
+
+		$itemuri = DBA::selectFirst('item-uri', ['uri'], ['id' => $itemcontent['uri-id']]);
+		if (!DBA::isResult($itemuri)) {
+			return 0;
+		}
+
+		$item = DBA::selectFirst('item', ['id'], ['uri' => $itemuri['uri'], 'uid' => $uid]);
+		if (DBA::isResult($item)) {
+			return $item['id'];
+		}
+
+		return 0;
+	}
+
+	/**
+	 * Fetches item for given URI or plink
+	 *
+	 * @param string $uri
+	 * @param integer $uid
+	 *
+	 * @return integer item id
+	 */
+	public static function fetchByLink($uri, $uid = 0)
+	{
+		$item_id = self::searchByLink($uri, $uid);
+		if (!empty($item_id)) {
+echo "a\n";
+			return $item_id;
+		}
+
+echo "b\n";
+		ActivityPub\Processor::fetchMissingActivity($uri);
+
+		$item_id = self::searchByLink($uri, $uid);
+		if (!empty($item_id)) {
+echo "c\n";
+			return $item_id;
+		}
+
+echo "d\n";
+		return 0;
 	}
 }

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -3625,20 +3625,18 @@ class Item extends BaseObject
 	{
 		$item_id = self::searchByLink($uri, $uid);
 		if (!empty($item_id)) {
-echo "a\n";
 			return $item_id;
 		}
 
-echo "b\n";
 		ActivityPub\Processor::fetchMissingActivity($uri);
+
+		/// @todo add Diaspora as well
 
 		$item_id = self::searchByLink($uri, $uid);
 		if (!empty($item_id)) {
-echo "c\n";
 			return $item_id;
 		}
 
-echo "d\n";
 		return 0;
 	}
 }

--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -34,7 +34,7 @@
 use Friendica\Database\DBA;
 
 if (!defined('DB_UPDATE_VERSION')) {
-	define('DB_UPDATE_VERSION', 1318);
+	define('DB_UPDATE_VERSION', 1319);
 }
 
 return [
@@ -736,6 +736,7 @@ return [
 			"PRIMARY" => ["id"],
 			"uri-plink-hash" => ["UNIQUE", "uri-plink-hash"],
 			"uri" => ["uri(191)"],
+			"plink" => ["plink(191)"],
 			"uri-id" => ["uri-id"]
 		]
 	],


### PR DESCRIPTION
From now on we can simply enter an url of a remote post in the search field and it will be fetched.

This is currently a draft since I'm unsure about the different classes. I want to add this stuff in some way to ```mod/search.php``` but there is some ```src/Module/BaseSearchModule.php``` as well.

My function will be short. Simply calling ```$id = Item::fetchByLink($uri);``` then jumping to the display page. But I'm unsure if I can place it directly into ```mod/search.php``` or if our new class structure suggests doing it differently from this.