### PR TITLE
Fix reference non-existing "mobile-theme" field in user record

### DIFF
--- a/mod/settings.php
+++ b/mod/settings.php
@@ -916,7 +916,7 @@ function settings_content(App $a)
 		}
 
 		$theme_selected        = $a->user['theme'] ?: $default_theme;
-		$mobile_theme_selected = $a->user['mobile-theme'] ?: $default_mobile_theme;
+		$mobile_theme_selected = Session::get('mobile-theme', $default_mobile_theme);
 
 		$nowarn_insecure = intval(PConfig::get(local_user(), 'system', 'nowarn_insecure'));
 


### PR DESCRIPTION
Follow-up to #7400