### PR TITLE
Fetch Diaspora posts by url

### DIFF
--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -20,6 +20,7 @@ use Friendica\Core\Renderer;
 use Friendica\Core\System;
 use Friendica\Core\Worker;
 use Friendica\Database\DBA;
+use Friendica\Protocol\ActivityPub;
 use Friendica\Protocol\Diaspora;
 use Friendica\Protocol\OStatus;
 use Friendica\Util\DateTimeFormat;
@@ -29,7 +30,6 @@ use Friendica\Util\Security;
 use Friendica\Util\Strings;
 use Friendica\Util\XML;
 use Friendica\Worker\Delivery;
-use Friendica\Protocol\ActivityPub;
 use Text_LanguageDetect;
 
 class Item extends BaseObject
@@ -3628,11 +3628,12 @@ class Item extends BaseObject
 			return $item_id;
 		}
 
-		ActivityPub\Processor::fetchMissingActivity($uri);
+		if (ActivityPub\Processor::fetchMissingActivity($uri)) {
+			$item_id = self::searchByLink($uri, $uid);
+		} else {
+			$item_id = Diaspora::fetchByURL($uri);
+		}
 
-		/// @todo add Diaspora as well
-
-		$item_id = self::searchByLink($uri, $uid);
 		if (!empty($item_id)) {
 			return $item_id;
 		}

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -534,8 +534,9 @@ class Processor
 	/**
 	 * Fetches missing posts
 	 *
-	 * @param $url
-	 * @param $child
+	 * @param string $url message URL
+	 * @param array $child activity array with the child of this message
+	 * @return boolean success
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
 	public static function fetchMissingActivity($url, $child = [])
@@ -549,12 +550,12 @@ class Processor
 		$object = ActivityPub::fetchContent($url, $uid);
 		if (empty($object)) {
 			Logger::log('Activity ' . $url . ' was not fetchable, aborting.');
-			return;
+			return false;
 		}
 
 		if (empty($object['id'])) {
 			Logger::log('Activity ' . $url . ' has got not id, aborting. ' . json_encode($object));
-			return;
+			return false;
 		}
 
 		if (!empty($child['author'])) {
@@ -593,6 +594,8 @@ class Processor
 
 		ActivityPub\Receiver::processActivity($ldactivity);
 		Logger::log('Activity ' . $url . ' had been fetched and processed.');
+
+		return true;
 	}
 
 	/**

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -1425,23 +1425,21 @@ class Diaspora
 	 */
 	public static function fetchByURL($url, $uid = 0)
 	{
-		if (!preg_match("=([http|https].*)/(.*)/(.*)=ism", $url, $matches)) {
+		// Check for Diaspora (and Friendica) typical paths
+		if (!preg_match("=(https?://.+)/(?:posts|display)/([a-zA-Z0-9-_@.:%]+[a-zA-Z0-9])=i", $url, $matches)) {
 			return false;
 		}
 
-		// Check for Diaspora (and Friendica) typical path components
-		if (!in_array($matches[2], ['posts', 'display'])) {
-			return false;
-		}
+		$guid = urldecode($matches[2]);
 
-		$item = Item::selectFirst(['id'], ['guid' => $matches[3], 'uid' => $uid]);
+		$item = Item::selectFirst(['id'], ['guid' => $guid, 'uid' => $uid]);
 		if (DBA::isResult($item)) {
 			return $item['id'];
 		}
 
-		self::storeByGuid($matches[3], $matches[1], $uid);
+		self::storeByGuid($guid, $matches[1], $uid);
 
-		$item = Item::selectFirst(['id'], ['guid' => $matches[3], 'uid' => $uid]);
+		$item = Item::selectFirst(['id'], ['guid' => $guid, 'uid' => $uid]);
 		if (DBA::isResult($item)) {
 			return $item['id'];
 		} else {

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -1415,6 +1415,41 @@ class Diaspora
 	}
 
 	/**
+	 * @brief Fetches an item with a given URL
+	 *
+	 * @param string $url the message url
+	 *
+	 * @return int the message id of the stored message or false
+	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
+	 * @throws \ImagickException
+	 */
+	public static function fetchByURL($url, $uid = 0)
+	{
+		if (!preg_match("=([http|https].*)/(.*)/(.*)=ism", $url, $matches)) {
+			return false;
+		}
+
+		// Check for Diaspora (and Friendica) typical path components
+		if (!in_array($matches[2], ['posts', 'display'])) {
+			return false;
+		}
+
+		$item = Item::selectFirst(['id'], ['guid' => $matches[3], 'uid' => $uid]);
+		if (DBA::isResult($item)) {
+			return $item['id'];
+		}
+
+		self::storeByGuid($matches[3], $matches[1], $uid);
+
+		$item = Item::selectFirst(['id'], ['guid' => $matches[3], 'uid' => $uid]);
+		if (DBA::isResult($item)) {
+			return $item['id'];
+		} else {
+			return false;
+		}
+	}
+
+	/**
 	 * @brief Fetches the item record of a given guid
 	 *
 	 * @param int    $uid     The user id


### PR DESCRIPTION
We can now fetch Diaspora posts by searching for their URL as well. Since Diaspora posts don't have an URL but only a GUID, we need a path that contains the GUID and a path to a server containing the post.

This path can be found by clicking on the posting date on a Diaspora server. Then we get a path like ```https://pod.geraspora.de/posts/ed0505d08db70137d98e268acd52edbf```. With this we can fetch the content.