### PR TITLE
Fix tag rendering which was displayed as escaped HTML

### DIFF
--- a/view/theme/frio/templates/photo_view.tpl
+++ b/view/theme/frio/templates/photo_view.tpl
@@ -70,7 +70,7 @@
 		<div id="photo-tags">{{$tags.title}}
 			{{foreach $tags.tags as $t}}
 			<span class="category label btn-success sm">
-				<span class="p-category">{{$t.name}}</span>
+				<span class="p-category">{{$t.name nofilter}}</span>
 				{{if $t.removeurl}} <a href="{{$t.removeurl}}">(X)</a> {{/if}}
 			</span>
 			{{/foreach}}


### PR DESCRIPTION
The tags in the detail view of photos for the Frio theme are displayed like:

```
#<a href="https/...search?tag=foobar">foobar</a> (x)
```

This PR fixed the rendering of the tags so the HTML gets not escaped by Smarty anymore.