### PR TITLE
Fix contact issues with fake reshares from Twitter

### DIFF
--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -905,7 +905,17 @@ class BBCode extends BaseObject
 				// We only call this so that a previously unknown contact can be added.
 				// This is important for the function "Model\Contact::getDetailsByURL()".
 				// This function then can fetch an entry from the contact table.
-				Contact::getIdForURL($attributes['profile'], 0, true);
+				$default['url'] = $attributes['profile'];
+
+				if (!empty($attributes['author'])) {
+					$default['name'] = $attributes['author'];
+				}
+
+				if (!empty($attributes['avatar'])) {
+					$default['photo'] = $attributes['avatar'];
+				}
+
+				Contact::getIdForURL($attributes['profile'], 0, true, $default);
 
 				$author_contact = Contact::getDetailsByURL($attributes['profile']);
 				$author_contact['addr'] = defaults($author_contact, 'addr' , Protocol::getAddrFromProfileUrl($attributes['profile']));

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -1419,7 +1419,7 @@ class Contact extends BaseObject
 			// When we don't want to update, we look if we know this contact in any way
 			$data = self::getProbeDataFromDatabase($url, $contact_id);
 			$background_update = true;
-		} elseif ($no_update && !empty($default)) {
+		} elseif ($no_update && !empty($default['network'])) {
 			// If there are default values, take these
 			$data = $default;
 			$background_update = false;

--- a/src/Network/Probe.php
+++ b/src/Network/Probe.php
@@ -471,7 +471,7 @@ class Probe
 			}
 
 			if ($host == 'twitter.com') {
-				return ["network" => Protocol::TWITTER];
+				return self::twitter($uri);
 			}
 			$lrdd = self::hostMeta($host);
 
@@ -512,7 +512,7 @@ class Probe
 			$nick = substr($uri, 0, strpos($uri, '@'));
 
 			if (strpos($uri, '@twitter.com')) {
-				return ["network" => Protocol::TWITTER];
+				return self::twitter($uri);
 			}
 			$lrdd = self::hostMeta($host);
 
@@ -1409,6 +1409,37 @@ class Probe
 		}
 
 		return $data;
+	}
+
+	/**
+	 * @brief Check for twitter contact
+	 *
+	 * @param string $uri
+	 *
+	 * @return array twitter data
+	 */
+	private static function twitter($uri)
+	{
+		if (preg_match('=(.*)@twitter.com=i', $uri, $matches)) {
+			$nick = $matches[1];
+		} elseif (preg_match('=https?://twitter.com/(.*)=i', $uri, $matches)) {
+			$nick = $matches[1];
+		} else {
+			return [];
+		}
+
+		$data = [];
+		$data['url'] = 'https://twitter.com/' . $nick;
+		$data['addr'] = $nick . '@twitter.com';
+		$data['nick'] = $data['name'] = $nick;
+		$data['network'] = Protocol::TWITTER;
+		$data['baseurl'] = 'https://twitter.com';
+
+		$curlResult = Network::curl($data['url'], false);
+		if ($curlResult->isSuccess()) {
+			return $data;
+		}
+		return [];
 	}
 
 	/**


### PR DESCRIPTION
Reshares of Twitter posts (for example via the mirroring functionality of the Twitter connector) often lead to posts with Twitter contacts without an avatar and without the correct name and nick.