### PR TITLE
Respect picdate for profile picture in Frio

### DIFF
--- a/view/theme/frio/templates/profile_vcard.tpl
+++ b/view/theme/frio/templates/profile_vcard.tpl
@@ -26,10 +26,10 @@
 		<div id="vcard-short-info" class="media" style="display: none">
 			<div id="vcard-short-photo-wrapper" class="pull-left">
 				{{if $profile.picdate}}
-                <img class="media-object" src="{{$profile.photo}}?rev={{$profile.picdate}}" alt="{{$profile.name}}"></a>
-                {{else}}
-                <img class="media-object" src="{{$profile.photo}}" alt="{{$profile.name}}"></a>
-                {{/if}}
+				<img class="media-object" src="{{$profile.photo}}?rev={{$profile.picdate}}" alt="{{$profile.name}}"></a>
+				{{else}}
+				<img class="media-object" src="{{$profile.photo}}" alt="{{$profile.name}}"></a>
+				{{/if}}
 			</div>
 
 			<div id="vcard-short-desc" class="media-body">

--- a/view/theme/frio/templates/profile_vcard.tpl
+++ b/view/theme/frio/templates/profile_vcard.tpl
@@ -25,7 +25,11 @@
 	<div id="vcard-short-info-wrapper" style="display: none;">
 		<div id="vcard-short-info" class="media" style="display: none">
 			<div id="vcard-short-photo-wrapper" class="pull-left">
-				<img class="media-object" src="{{$profile.photo}}" alt="{{$profile.name}}" />
+				{{if $profile.picdate}}
+                <img class="media-object" src="{{$profile.photo}}?rev={{$profile.picdate}}" alt="{{$profile.name}}"></a>
+                {{else}}
+                <img class="media-object" src="{{$profile.photo}}" alt="{{$profile.name}}"></a>
+                {{/if}}
 			</div>
 
 			<div id="vcard-short-desc" class="media-body">


### PR DESCRIPTION
In the sticky header of the profile the profile pic was not displayed with a `?rev=` part in the URL and resulted in outdated profile pictures displaying.