### PR TITLE
 2FA: Remove mod/ping from exception list

### DIFF
--- a/src/Core/Authentication.php
+++ b/src/Core/Authentication.php
@@ -7,6 +7,7 @@ namespace Friendica\Core;
 
 use Friendica\App;
 use Friendica\BaseObject;
+use Friendica\Network\HTTPException\ForbiddenException;
 use Friendica\Util\BaseURL;
 
 /**
@@ -71,7 +72,7 @@ class Authentication extends BaseObject
 		}
 
 		// Check current path, if 2fa authentication module return
-		if ($a->argc > 0 && in_array($a->argv[0], ['ping', '2fa', 'view', 'help', 'api', 'proxy', 'logout'])) {
+		if ($a->argc > 0 && in_array($a->argv[0], ['2fa', 'view', 'help', 'api', 'proxy', 'logout'])) {
 			return;
 		}
 
@@ -81,7 +82,11 @@ class Authentication extends BaseObject
 		}
 
 		// Case 2: No valid 2FA session: redirect to code verification page
-		$a->internalRedirect('2fa');
+		if ($a->isAjax()) {
+			throw new ForbiddenException();
+		} else {
+			$a->internalRedirect('2fa');
+		}
 	}
 }
 

--- a/src/Module/TwoFactor/Verify.php
+++ b/src/Module/TwoFactor/Verify.php
@@ -16,18 +16,20 @@ use PragmaRX\Google2FA\Google2FA;
  */
 class Verify extends BaseModule
 {
+	private static $errors = [];
+
 	public static function post()
 	{
 		if (!local_user()) {
 			return;
 		}
 
-		if (defaults($_POST, 'action', null) == 'verify') {
+		if (($_POST['action'] ?? '') == 'verify') {
 			self::checkFormSecurityTokenRedirectOnError('2fa', 'twofactor_verify');
 
 			$a = self::getApp();
 
-			$code = defaults($_POST, 'verify_code', '');
+			$code = $_POST['verify_code'] ?? '';
 
 			$valid = (new Google2FA())->verifyKey(PConfig::get(local_user(), '2fa', 'secret'), $code);
 
@@ -38,7 +40,7 @@ class Verify extends BaseModule
 				// Resume normal login workflow
 				Session::setAuthenticatedForUser($a, $a->user, true, true);
 			} else {
-				notice(L10n::t('Invalid code, please retry.'));
+				self::$errors[] = L10n::t('Invalid code, please retry.');
 			}
 		}
 	}
@@ -59,6 +61,8 @@ class Verify extends BaseModule
 
 			'$title'            => L10n::t('Two-factor authentication'),
 			'$message'          => L10n::t('<p>Open the two-factor authentication app on your device to get an authentication code and verify your identity.</p>'),
+			'$errors_label'     => L10n::tt('Error', 'Errors', count(self::$errors)),
+			'$errors'           => self::$errors,
 			'$recovery_message' => L10n::t('Don’t have your phone? <a href="%s">Enter a two-factor recovery code</a>', '2fa/recovery'),
 			'$verify_code'      => ['verify_code', L10n::t('Please enter a code from your authentication app'), '', '', 'required', 'autofocus placeholder="000000"'],
 			'$verify_label'     => L10n::t('Verify code and complete login'),

--- a/view/templates/twofactor/verify.tpl
+++ b/view/templates/twofactor/verify.tpl
@@ -2,6 +2,17 @@
 	<h1>{{$title}}</h1>
 	<div>{{$message nofilter}}</div>
 
+{{if $errors}}
+	<div class="panel panel-danger">
+		<div class="panel-heading">{{$errors_label}}</div>
+		<ul class="list-group">
+	{{foreach $errors as $error}}
+			<li class="list-group-item">{{$error}}</li>
+	{{/foreach}}
+		</ul>
+	</div>
+{{/if}}
+
 	<form action="" method="post">
 		<input type="hidden" name="form_security_token" value="{{$form_security_token}}">
 


### PR DESCRIPTION
On a suggestion from @lostinlight, the ping module is now removed from the 2fa module exception list. This has the immediate effect of not showing the notification numbers (and notification list) on the 2fa verification page.

To account for the missing jGrowl notices because of the unavailability of `/ping`, I had to add explicit template errors on this page.

I also had to implement a different behavior for asynchronous requests when they fail the 2fa session check because redirecting to `/2fa` wasn't going to cut it.