### PR TITLE
Set shared instances in DICE

### DIFF
--- a/static/dependencies.config.php
+++ b/static/dependencies.config.php
@@ -25,6 +25,11 @@ use Psr\Log\LoggerInterface;
  *
  */
 return [
+	'*' => [
+		// marks all class result as shared for other creations, so there's just
+		// one instance for the whole execution
+		'shared' => true,
+	],
 	'$basepath' => [
 		'instanceOf' => Util\BasePath::class,
 		'call' => [
@@ -36,7 +41,6 @@ return [
 		]
 	],
 	Util\BasePath::class => [
-		'shared'          => true,
 		'constructParams' => [
 			dirname(__FILE__, 2),
 			$_SERVER
@@ -53,15 +57,11 @@ return [
 		'call'       => [
 			['createCache', [], Dice::CHAIN_CALL],
 		],
-		'shared'     => true,
 	],
 	App\Mode::class => [
 		'call'   => [
 			['determine', [], Dice::CHAIN_CALL],
 		],
-		// marks the result as shared for other creations, so there's just
-		// one instance for the whole execution
-		'shared' => true,
 	],
 	Config\Configuration::class => [
 		'shared' => true,
@@ -71,14 +71,12 @@ return [
 		],
 	],
 	Config\PConfiguration::class => [
-		'shared' => true,
 		'instanceOf' => Factory\ConfigFactory::class,
 		'call' => [
 			['createPConfig', [], Dice::CHAIN_CALL],
 		]
 	],
 	Database::class => [
-		'shared' => true,
 		'constructParams' => [
 			[DICE::INSTANCE => \Psr\Log\NullLogger::class],
 			$_SERVER,
@@ -91,7 +89,6 @@ return [
 	 *   $baseURL = new Util\BaseURL($configuration, $_SERVER);
 	 */
 	Util\BaseURL::class => [
-		'shared'          => true,
 		'constructParams' => [
 			$_SERVER,
 		],
@@ -109,17 +106,15 @@ return [
 	 *    and is automatically passed as an argument with the same name
 	 */
 	LoggerInterface::class => [
-		'shared'     => true,
 		'instanceOf' => Factory\LoggerFactory::class,
 		'call'       => [
 			['create', [], Dice::CHAIN_CALL],
 		],
 	],
 	'$devLogger' => [
-		'shared'     => true,
 		'instanceOf' => Factory\LoggerFactory::class,
 		'call'       => [
 			['createDev', [], Dice::CHAIN_CALL],
 		]
-	]
+	],
 ];

--- a/tests/functional/DependencyCheckTest.php
+++ b/tests/functional/DependencyCheckTest.php
@@ -83,6 +83,8 @@ class dependencyCheck extends TestCase
 			]
 		]);
 
+		// create new DI-library because of shared instance rule (so the Profiler wouldn't get created twice)
+		$this->dice = new Dice(include __DIR__ . '/../../static/dependencies.config.php');
 		$profiler = $this->dice->create(Profiler::class, [$configCache]);
 
 		$this->assertInstanceOf(Profiler::class, $profiler);

--- a/tests/src/Core/SystemTest.php
+++ b/tests/src/Core/SystemTest.php
@@ -9,7 +9,6 @@ class SystemTest extends TestCase
 {
 	private function assertGuid($guid, $length, $prefix = '')
 	{
-		print $guid;
 		$length -= strlen($prefix);
 		$this->assertRegExp("/^" . $prefix . "[a-z0-9]{" . $length . "}?$/", $guid);
 	}


### PR DESCRIPTION
FollowUp #7412 
Fixes #7426 

The problem is that - by default - each constructing class by DICE creates it's "own" dependencies.
f.e. Database and App requires both `Profiler`.
See here:
https://github.com/friendica/friendica/blob/92c1cbeeeccf31ae311b532866610b48c97dccfe/src/Database/Database.php#L49
https://github.com/friendica/friendica/blob/92c1cbeeeccf31ae311b532866610b48c97dccfe/src/App.php#L275
So until now the Profiler of Database is a different class than the Profiler of App

I now introduced the "global" setting `shared => true`, which forces DICE to re-use every class for each other class during the call.

A "anti-example" for `shared => true` is the `Friendica\Object\Post` class, because we do want to have a Post object for each posting ;-) . And not ONE Post class for every usage.