### PR TITLE
Use multibyte string functions

### DIFF
--- a/include/api.php
+++ b/include/api.php
@@ -2444,8 +2444,8 @@ function api_convert_item($item)
 		$statustext = trim($statustitle."\n\n".$statusbody);
 	}
 
-	if ((defaults($item, 'network', Protocol::PHANTOM) == Protocol::FEED) && (strlen($statustext)> 1000)) {
-		$statustext = substr($statustext, 0, 1000) . "... \n" . defaults($item, 'plink', '');
+	if ((defaults($item, 'network', Protocol::PHANTOM) == Protocol::FEED) && (mb_strlen($statustext)> 1000)) {
+		$statustext = mb_substr($statustext, 0, 1000) . "... \n" . defaults($item, 'plink', '');
 	}
 
 	$statushtml = BBCode::convert(api_clean_attachments($body), false);


### PR DESCRIPTION
$statustext can be in utf8, so we should use mb_ functions. If not, substr can split some multibyte char and then json_encode() fails due to JSON_ERROR_UTF8.