### PR TITLE
New functions to check if a contact supports that protocol

### DIFF
--- a/src/Protocol/ActivityPub.php
+++ b/src/Protocol/ActivityPub.php
@@ -199,7 +199,7 @@ class ActivityPub
 	 * Checks if the given contact url does support ActivityPub
 	 *
 	 * @param string  $url    profile url
-	 * @param boolean $update Update the profile
+	 * @param boolean $update true = always update, false = never update, null = update when not found or outdated
 	 * @return boolean
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 * @throws \ImagickException

--- a/src/Protocol/ActivityPub.php
+++ b/src/Protocol/ActivityPub.php
@@ -194,4 +194,18 @@ class ActivityPub
 			ActivityPub\Receiver::processActivity($ldactivity, '', $uid, true);
 		}
 	}
+
+	/**
+	 * Checks if the given contact url does support ActivityPub
+	 *
+	 * @param string  $url    profile url
+	 * @param boolean $update Update the profile
+	 * @return boolean
+	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
+	 * @throws \ImagickException
+	 */
+	public static function isSupportedByContactUrl($url, $update = null)
+	{
+		return !empty(APContact::getByURL($url, $update));
+	}
 }

--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -29,6 +29,7 @@ use Friendica\Model\Mail;
 use Friendica\Model\PermissionSet;
 use Friendica\Model\Profile;
 use Friendica\Model\User;
+use Friendica\Network\Probe;
 use Friendica\Object\Image;
 use Friendica\Util\BaseURL;
 use Friendica\Util\Crypto;
@@ -3040,5 +3041,20 @@ class DFRN
 		$update_edited = DateTimeFormat::utc($update['edited']);
 
 		return (strcmp($existing_edited, $update_edited) < 0);
+	}
+
+	/**
+	 * Checks if the given contact url does support DFRN
+	 *
+	 * @param string  $url    profile url
+	 * @param boolean $update Update the profile
+	 * @return boolean
+	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
+	 * @throws \ImagickException
+	 */
+	public static function isSupportedByContactUrl($url, $update = false)
+	{
+		$probe = Probe::uri($url, Protocol::DFRN, 0, !$update);
+		return $probe['network'] == Protocol::DFRN;
 	}
 }

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -942,7 +942,7 @@ class Diaspora
 	 * @brief Fetches data for a given handle
 	 *
 	 * @param string $handle The handle
-	 * @param boolean $update Update the profile
+	 * @param boolean $update true = always update, false = never update, null = update when not found or outdated
 	 *
 	 * @return array the queried data
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
@@ -1126,7 +1126,7 @@ class Diaspora
 	 * Checks if the given contact url does support ActivityPub
 	 *
 	 * @param string  $url    profile url
-	 * @param boolean $update Update the profile
+	 * @param boolean $update true = always update, false = never update, null = update when not found or outdated
 	 * @return boolean
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 * @throws \ImagickException

--- a/src/Protocol/OStatus.php
+++ b/src/Protocol/OStatus.php
@@ -2302,4 +2302,19 @@ class OStatus
 
 		return trim($doc->saveXML());
 	}
+
+	/**
+	 * Checks if the given contact url does support OStatus
+	 *
+	 * @param string  $url    profile url
+	 * @param boolean $update Update the profile
+	 * @return boolean
+	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
+	 * @throws \ImagickException
+	 */
+	public static function isSupportedByContactUrl($url, $update = false)
+	{
+		$probe = Probe::uri($url, Protocol::OSTATUS, 0, !$update);
+		return $probe['network'] == Protocol::OSTATUS;
+	}
 }


### PR DESCRIPTION
I added functions that enable us to make a simple check if a contact does support a given protocol. These functions will later be used in the delivery process. There I want to add a functionality that we only send comments to comments to someone, when that contact had been able to read the comment we are commenting on. (I guess I could had been able to describe it even worse)

This is to avoid the constellation when - for example - people from Diaspora do read a comment to some comment that they never received since that comment had been from ActivityPub.

I really have to think about how to add that functionality in the best way, so I decided to split this task into this PR and some following.