### PR TITLE
Added "selectToArray" functions in DBA and Item

### DIFF
--- a/src/Database/DBA.php
+++ b/src/Database/DBA.php
@@ -422,7 +422,7 @@ class DBA
 	 */
 	public static function selectToArray($table, array $fields = [], array $condition = [], array $params = [])
 	{
-		return self::$database->toArray(self::$database->select($table, $fields, $condition, $params));
+		return self::$database->selectToArray($table, $fields, $condition, $params);
 	}
 
 	/**

--- a/src/Database/DBA.php
+++ b/src/Database/DBA.php
@@ -409,6 +409,23 @@ class DBA
 	}
 
 	/**
+	 * @brief Select rows from a table and fills an array with the data
+	 *
+	 * @param string $table     Table name
+	 * @param array  $fields    Array of selected fields, empty for all
+	 * @param array  $condition Array of fields for condition
+	 * @param array  $params    Array of several parameters
+	 *
+	 * @return array Data array
+	 * @throws \Exception
+	 * @see   self::select
+	 */
+	public static function selectToArray($table, array $fields = [], array $condition = [], array $params = [])
+	{
+		return self::$database->toArray(self::$database->select($table, $fields, $condition, $params));
+	}
+
+	/**
 	 * @brief Select rows from a table
 	 *
 	 * @param string $table     Table name

--- a/src/Database/DBA.php
+++ b/src/Database/DBA.php
@@ -420,7 +420,7 @@ class DBA
 	 * @throws \Exception
 	 * @see   self::select
 	 */
-	public static function selectToArray($table, array $fields = [], array $condition = [], array $params = [])
+	public static function selectToArray(string $table, array $fields = [], array $condition = [], array $params = [])
 	{
 		return self::$database->selectToArray($table, $fields, $condition, $params);
 	}

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -1419,7 +1419,7 @@ class Database
 	 * @throws \Exception
 	 * @see   self::select
 	 */
-	public function selectToArray($table, array $fields = [], array $condition = [], array $params = [])
+	public function selectToArray(string $table, array $fields = [], array $condition = [], array $params = [])
 	{
 		return $this->toArray($this->select($table, $fields, $condition, $params));
 	}

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -1408,6 +1408,23 @@ class Database
 	}
 
 	/**
+	 * @brief Select rows from a table and fills an array with the data
+	 *
+	 * @param string $table     Table name
+	 * @param array  $fields    Array of selected fields, empty for all
+	 * @param array  $condition Array of fields for condition
+	 * @param array  $params    Array of several parameters
+	 *
+	 * @return array Data array
+	 * @throws \Exception
+	 * @see   self::select
+	 */
+	public function selectToArray($table, array $fields = [], array $condition = [], array $params = [])
+	{
+		return $this->toArray($this->select($table, $fields, $condition, $params));
+	}
+
+	/**
 	 * @brief Select rows from a table
 	 *
 	 * @param string $table     Table name

--- a/src/Model/Attach.php
+++ b/src/Model/Attach.php
@@ -55,8 +55,7 @@ class Attach extends BaseObject
 			$fields = self::getFields();
 		}
 
-		$r = DBA::select('attach', $fields, $conditions, $params);
-		return DBA::toArray($r);
+		$r = DBA::selectToArray('attach', $fields, $conditions, $params);
 	}
 
 	/**

--- a/src/Model/Attach.php
+++ b/src/Model/Attach.php
@@ -38,7 +38,7 @@ class Attach extends BaseObject
 	}
 
 	/**
-	 * @brief Select rows from the attach table
+	 * @brief Select rows from the attach table and return them as array
 	 *
 	 * @param array $fields     Array of selected fields, empty for all
 	 * @param array $conditions Array of fields for conditions
@@ -47,9 +47,9 @@ class Attach extends BaseObject
 	 * @return boolean|array
 	 *
 	 * @throws \Exception
-	 * @see   \Friendica\Database\DBA::select
+	 * @see   \Friendica\Database\DBA::selectToArray
 	 */
-	public static function select(array $fields = [], array $conditions = [], array $params = [])
+	public static function selectToArray(array $fields = [], array $conditions = [], array $params = [])
 	{
 		if (empty($fields)) {
 			$fields = self::getFields();
@@ -264,7 +264,7 @@ class Attach extends BaseObject
 	{
 		if (!is_null($img)) {
 			// get items to update
-			$items = self::select(['backend-class','backend-ref'], $conditions);
+			$items = self::selectToArray(['backend-class','backend-ref'], $conditions);
 
 			foreach($items as $item) {
 				/** @var IStorage $backend_class */
@@ -297,7 +297,7 @@ class Attach extends BaseObject
 	public static function delete(array $conditions, array $options = [])
 	{
 		// get items to delete data info
-		$items = self::select(['backend-class','backend-ref'], $conditions);
+		$items = self::selectToArray(['backend-class','backend-ref'], $conditions);
 
 		foreach($items as $item) {
 			/** @var IStorage $backend_class */

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -117,11 +117,9 @@ class Contact extends BaseObject
 	 * @return array
 	 * @throws \Exception
 	 */
-	public static function select(array $fields = [], array $condition = [], array $params = [])
+	public static function selectToArray(array $fields = [], array $condition = [], array $params = [])
 	{
-		$statement = DBA::select('contact', $fields, $condition, $params);
-
-		return DBA::toArray($statement);
+		return DBA::selectToArray('contact', $fields, $condition, $params);
 	}
 
 	/**

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -369,6 +369,33 @@ class Item extends BaseObject
 	}
 
 	/**
+	 * @brief Select rows from the item table and returns them as an array
+	 *
+	 * @param array $selected  Array of selected fields, empty for all
+	 * @param array $condition Array of fields for condition
+	 * @param array $params    Array of several parameters
+	 *
+	 * @return array
+	 * @throws \Exception
+	 */
+	public static function selectToArray(array $fields = [], array $condition = [], $params = [])
+	{
+		$result = self::select($fields, $condition, $params);
+
+		if (is_bool($result)) {
+			return $result;
+		}
+
+		$data = [];
+		while ($row = self::fetch($result)) {
+			$data[] = $row;
+		}
+		DBA::close($result);
+
+                return $data;
+	}
+
+	/**
 	 * @brief Select rows from the item table
 	 *
 	 * @param array $selected  Array of selected fields, empty for all

--- a/src/Model/Photo.php
+++ b/src/Model/Photo.php
@@ -46,7 +46,7 @@ class Photo extends BaseObject
 			$fields = self::getFields();
 		}
 
-		return DBA::selectToArray("photo", $fields, $conditions, $params);
+		return DBA::selectToArray('photo', $fields, $conditions, $params);
 	}
 
 	/**
@@ -349,7 +349,7 @@ class Photo extends BaseObject
 	public static function delete(array $conditions, array $options = [])
 	{
 		// get photo to delete data info
-		$photos = self::selectToArray(["backend-class","backend-ref"], $conditions);
+		$photos = self::selectToArray(['backend-class', 'backend-ref'], $conditions);
 
 		foreach($photos as $photo) {
 			/** @var IStorage $backend_class */

--- a/src/Model/Photo.php
+++ b/src/Model/Photo.php
@@ -379,7 +379,7 @@ class Photo extends BaseObject
 	{
 		if (!is_null($img)) {
 			// get photo to update
-			$photos = self::selectToArray(["backend-class","backend-ref"], $conditions);
+			$photos = self::selectToArray(['backend-class', 'backend-ref'], $conditions);
 
 			foreach($photos as $photo) {
 				/** @var IStorage $backend_class */

--- a/src/Model/Photo.php
+++ b/src/Model/Photo.php
@@ -29,7 +29,7 @@ require_once "include/dba.php";
 class Photo extends BaseObject
 {
 	/**
-	 * @brief Select rows from the photo table
+	 * @brief Select rows from the photo table and returns them as array
 	 *
 	 * @param array $fields     Array of selected fields, empty for all
 	 * @param array $conditions Array of fields for conditions
@@ -38,16 +38,15 @@ class Photo extends BaseObject
 	 * @return boolean|array
 	 *
 	 * @throws \Exception
-	 * @see   \Friendica\Database\DBA::select
+	 * @see   \Friendica\Database\DBA::selectToArray
 	 */
-	public static function select(array $fields = [], array $conditions = [], array $params = [])
+	public static function selectToArray(array $fields = [], array $conditions = [], array $params = [])
 	{
 		if (empty($fields)) {
 			$fields = self::getFields();
 		}
 
-		$r = DBA::select("photo", $fields, $conditions, $params);
-		return DBA::toArray($r);
+		return DBA::selectToArray("photo", $fields, $conditions, $params);
 	}
 
 	/**
@@ -89,7 +88,7 @@ class Photo extends BaseObject
 		$conditions["resource-id"] = $resourceid;
 		$conditions["uid"] = $uid;
 
-		return self::select([], $conditions, $params);
+		return self::selectToArray([], $conditions, $params);
 	}
 
 	/**
@@ -350,7 +349,7 @@ class Photo extends BaseObject
 	public static function delete(array $conditions, array $options = [])
 	{
 		// get photo to delete data info
-		$photos = self::select(["backend-class","backend-ref"], $conditions);
+		$photos = self::selectToArray(["backend-class","backend-ref"], $conditions);
 
 		foreach($photos as $photo) {
 			/** @var IStorage $backend_class */
@@ -380,7 +379,7 @@ class Photo extends BaseObject
 	{
 		if (!is_null($img)) {
 			// get photo to update
-			$photos = self::select(["backend-class","backend-ref"], $conditions);
+			$photos = self::selectToArray(["backend-class","backend-ref"], $conditions);
 
 			foreach($photos as $photo) {
 				/** @var IStorage $backend_class */

--- a/src/Module/Admin/Blocklist/Contact.php
+++ b/src/Module/Admin/Blocklist/Contact.php
@@ -53,7 +53,7 @@ class Contact extends BaseAdminModule
 
 		$pager = new Pager($a->query_string, 30);
 
-		$contacts = Model\Contact::select([], $condition, ['limit' => [$pager->getStart(), $pager->getItemsPerPage()]]);
+		$contacts = Model\Contact::selectToArray([], $condition, ['limit' => [$pager->getStart(), $pager->getItemsPerPage()]]);
 
 		$t = Renderer::getMarkupTemplate('admin/blocklist/contact.tpl');
 		$o = Renderer::replaceMacros($t, [

--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -2176,7 +2176,7 @@ class DFRN
 		if (($entrytype == DFRN::TOP_LEVEL) && !empty($importer['id'])) {
 			// The filling of the the "contact" variable is done for legcy reasons
 			// The functions below are partly used by ostatus.php as well - where we have this variable
-			$contact = Contact::select([], ['id' => $importer['id']]);
+			$contact = Contact::selectFirst([], ['id' => $importer['id']]);
 
 			// Big question: Do we need these functions? They were part of the "consume_feed" function.
 			// This function once was responsible for DFRN and OStatus.


### PR DESCRIPTION
These functions are adding the functionality to select several rows and returning them as an array. This is in difference to the ```select``` functions that return just an object that has to be fetched by using the appropriate ```::fetch(...)``` functions.

I also renamed the ```::select(...``` functions in ```Contact.php```, ```Attach.php``` and ```Photo.php``` to ```::selectToArray(...```. This is done to avoid confusion about the functionality of these functions. Currently they do look like ```DBA::select(...``` but they don't behave like this. This shouldn't be.