### PR TITLE
Fix displaying of reshared items

### DIFF
--- a/include/conversation.php
+++ b/include/conversation.php
@@ -803,13 +803,13 @@ function conversation_fetch_comments($thread_items) {
 	$received = '';
 
 	while ($row = Item::fetch($thread_items)) {
-		if (($row['verb'] == ACTIVITY2_ANNOUNCE) && !empty($row['contact-uid']) && ($row['received'] > $received) && ($row['thr-parent'] == $row['parent-uri'])) {
+		if (($row['verb'] == ACTIVITY2_ANNOUNCE) && Contact::isSharing($row['author-id'], local_user()) && ($row['received'] > $received) && ($row['thr-parent'] == $row['parent-uri'])) {
 			$actor = ['link' => $row['author-link'], 'avatar' => $row['author-avatar'], 'name' => $row['author-name']];
 			$received = $row['received'];
 		}
 
 		if ((($row['gravity'] == GRAVITY_PARENT) && !$row['origin'] && !in_array($row['network'], [Protocol::DIASPORA])) &&
-			(empty($row['contact-uid']) || !in_array($row['network'], Protocol::NATIVE_SUPPORT))) {
+			(!Contact::isSharing($row['author-id'], local_user()) || !in_array($row['network'], Protocol::NATIVE_SUPPORT))) {
 			$parentlines[] = $lineno;
 		}
 


### PR DESCRIPTION
There had been a bug that reshared items hadn't displayed as it. The origin of the bug is somewhere else, but this here is the correct way. Only contacts that share with us should be displayed. 