### PR TITLE
Refactor ExAuth for DICE

### DIFF
--- a/bin/auth_ejabberd.php
+++ b/bin/auth_ejabberd.php
@@ -32,7 +32,6 @@
  *
  */
 
-use Friendica\App\Mode;
 use Friendica\BaseObject;
 use Friendica\Util\ExAuth;
 
@@ -56,9 +55,6 @@ $dice = new \Dice\Dice();
 $dice = $dice->addRules(include __DIR__ . '/../static/dependencies.config.php');
 BaseObject::setDependencyInjection($dice);
 
-$appMode = $dice->create(Mode::class);
-
-if ($appMode->isNormal()) {
-	$oAuth = new ExAuth();
-	$oAuth->readStdin();
-}
+/** @var ExAuth $oAuth */
+$oAuth = $dice->create(ExAuth::class);
+$oAuth->readStdin();


### PR DESCRIPTION
FollowUp #7417 

Easy change and we're almost perfect for DI with `ExAuth` (`User::authenticat()` still requires the whole `BaseObject` initialized ;-) )