### PR TITLE
Fix: The field "contact-id" now contains the correct contact id again

### DIFF
--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -415,9 +415,7 @@ class Processor
 
 			if ($isForum) {
 				$item['contact-id'] = Contact::getIdForURL($activity['actor'], $receiver, true);
-			}
-
-			if (empty($item['contact-id'])) {
+			} else {
 				$item['contact-id'] = Contact::getIdForURL($activity['author'], $receiver, true);
 			}
 


### PR DESCRIPTION
Notifications for new posts from our contacts hadn't worked anymore for AP contacts. Possibly there are some more bugs out there that are now fixed by this PR. One side effect of this bug for example had been the reason for PR https://github.com/friendica/friendica/pull/7436 (but that PR did make sense anyway)