### PR TITLE
Fix a notice when setting a picture description via API

### DIFF
--- a/include/api.php
+++ b/include/api.php
@@ -343,11 +343,13 @@ function api_call(App $a)
 						break;
 					case "json":
 						header("Content-Type: application/json");
-						$json = json_encode(end($return));
-						if (!empty($_GET['callback'])) {
-							$json = $_GET['callback'] . "(" . $json . ")";
+						if (!empty($return)) {
+							$json = json_encode(end($return));
+							if (!empty($_GET['callback'])) {
+								$json = $_GET['callback'] . "(" . $json . ")";
+							}
+							$return = $json;
 						}
-						$return = $json;
 						break;
 					case "rss":
 						header("Content-Type: application/rss+xml");


### PR DESCRIPTION
The API function to set a picture description doesn't return anything (AFAIK this is the behaviour of the corresponding Twitter API call). This leads to a notice.