### PR TITLE
The "contact-uid" is now a reliable proof for contacts that we follow

### DIFF
--- a/include/conversation.php
+++ b/include/conversation.php
@@ -803,13 +803,13 @@ function conversation_fetch_comments($thread_items) {
 	$received = '';
 
 	while ($row = Item::fetch($thread_items)) {
-		if (($row['verb'] == ACTIVITY2_ANNOUNCE) && Contact::isSharing($row['author-id'], local_user()) && ($row['received'] > $received) && ($row['thr-parent'] == $row['parent-uri'])) {
+		if (($row['verb'] == ACTIVITY2_ANNOUNCE) && !empty($row['contact-uid']) && ($row['received'] > $received) && ($row['thr-parent'] == $row['parent-uri'])) {
 			$actor = ['link' => $row['author-link'], 'avatar' => $row['author-avatar'], 'name' => $row['author-name']];
 			$received = $row['received'];
 		}
 
 		if ((($row['gravity'] == GRAVITY_PARENT) && !$row['origin'] && !in_array($row['network'], [Protocol::DIASPORA])) &&
-			(!Contact::isSharing($row['author-id'], local_user()) || !in_array($row['network'], Protocol::NATIVE_SUPPORT))) {
+			(empty($row['contact-uid']) || !in_array($row['network'], Protocol::NATIVE_SUPPORT))) {
 			$parentlines[] = $lineno;
 		}
 


### PR DESCRIPTION
This reverts the changes from PR https://github.com/friendica/friendica/pull/7436 since by now the field ```contact-uid``` can be used to check if we follow that contact. This reduces the amount of needed database queries during the display of messages.