### PR TITLE
[frio] remove basepath form field from admin panel site page

### DIFF
--- a/view/theme/frio/templates/admin/site.tpl
+++ b/view/theme/frio/templates/admin/site.tpl
@@ -189,7 +189,6 @@
 					{{include file="field_input.tpl" field=$optimize_fragmentation}}
 					{{include file="field_input.tpl" field=$abandon_days}}
 					{{include file="field_input.tpl" field=$temppath}}
-					{{include file="field_input.tpl" field=$basepath}}
 					{{include file="field_checkbox.tpl" field=$suppress_tags}}
 					{{include file="field_checkbox.tpl" field=$nodeinfo}}
 					{{include file="field_select.tpl" field=$check_new_version_url}}


### PR DESCRIPTION
The template for the admin panel "site" page of the frio theme still contained the field "basepath".

This should fix #7471