### PR TITLE
Fix trending tags variable name mistakes in Model\Term

### DIFF
--- a/src/Model/Term.php
+++ b/src/Model/Term.php
@@ -82,7 +82,7 @@ class Term
 				$limit
 			);
 
-			if (DBA::isResult($tags)) {
+			if (DBA::isResult($tagsStmt)) {
 				$tags = DBA::toArray($tagsStmt);
 				Cache::set('global_trending_tags', $tags, Cache::HOUR);
 			}
@@ -127,7 +127,7 @@ class Term
 				$limit
 			);
 
-			if (DBA::isResult($tags)) {
+			if (DBA::isResult($tagsStmt)) {
 				$tags = DBA::toArray($tagsStmt);
 				Cache::set('local_trending_tags', $tags, Cache::HOUR);
 			}

--- a/view/templates/widget/trending_tags.tpl
+++ b/view/templates/widget/trending_tags.tpl
@@ -2,7 +2,7 @@
 	<h3>{{$title}}</h3>
 	<ul>
 {{section name=ol loop=$tags max=10}}
-		<li><a href="search?tag={{$tags[ol].term}}">{{$tags[ol].term}}</a></li>
+		<li><a href="search?tag={{$tags[ol].term}}">#{{$tags[ol].term}}</a></li>
 {{/section}}
 	</ul>
 {{if $tags|count > 10}}
@@ -10,7 +10,7 @@
 		<summary>{{$more}}</summary>
 		<ul>
 	{{section name=ul loop=$tags start=10}}
-			<li><a href="search?tag={{$tags[ul].term}}">{{$tags[ul].term}}</a></li>
+			<li><a href="search?tag={{$tags[ul].term}}">#{{$tags[ul].term}}</a></li>
 	{{/section}}
 		</ul>
 	</details>


### PR DESCRIPTION
Follow-up to #7481 

That will teach me to add untested last minute edits.