### PR TITLE
Don't fork worker on frontend by default

### DIFF
--- a/mod/item.php
+++ b/mod/item.php
@@ -835,7 +835,7 @@ function item_post(App $a) {
 	// When we are doing some forum posting via ! we have to start the notifier manually.
 	// These kind of posts don't initiate the notifier call in the item class.
 	if ($only_to_forum) {
-		Worker::add(PRIORITY_HIGH, "Notifier", Delivery::POST, $post_id);
+		Worker::add(['priority' => PRIORITY_HIGH, 'dont_fork' => false], "Notifier", Delivery::POST, $post_id);
 	}
 
 	Logger::log('post_complete');

--- a/src/Core/Worker.php
+++ b/src/Core/Worker.php
@@ -1125,7 +1125,8 @@ class Worker
 		}
 
 		$priority = PRIORITY_MEDIUM;
-		$dont_fork = Config::get("system", "worker_dont_fork", false);
+		// Don't fork from frontend tasks by default
+		$dont_fork = Config::get("system", "worker_dont_fork", false) || !\get_app()->isBackend();
 		$created = DateTimeFormat::utcNow();
 		$force_priority = false;
 


### PR DESCRIPTION
On one of my server I experienced a huge performance problem when loading the /network page. The cause had been the starting of worker from the frontend. On that server the amount of workerqueue entries is really high, so counting (which is done when forking them) takes some time.

Now we only fork on backend processes - which extremely speeds up loading the /network page on that server.