### PR TITLE
L10n, Arguments & Module class extraction

### DIFF
--- a/index.php
+++ b/index.php
@@ -18,4 +18,4 @@ $dice = (new Dice())->addRules(include __DIR__ . '/static/dependencies.config.ph
 
 $a = \Friendica\BaseObject::getApp();
 
-$a->runFrontend();
+$a->runFrontend($dice->create(\Friendica\App\Module::class), $dice->create(\Friendica\App\Router::class), $dice->create(\Friendica\Core\Config\PConfiguration::class));

--- a/src/App.php
+++ b/src/App.php
@@ -8,9 +8,11 @@ use Detection\MobileDetect;
 use DOMDocument;
 use DOMXPath;
 use Exception;
+use Friendica\App\Arguments;
+use Friendica\App\Module;
 use Friendica\Core\Config\Cache\ConfigCache;
 use Friendica\Core\Config\Configuration;
-use Friendica\Core\Hook;
+use Friendica\Core\Config\PConfiguration;
 use Friendica\Core\L10n\L10n;
 use Friendica\Core\System;
 use Friendica\Core\Theme;
@@ -18,6 +20,7 @@ use Friendica\Database\Database;
 use Friendica\Database\DBA;
 use Friendica\Model\Profile;
 use Friendica\Module\Login;
+use Friendica\Module\Special\HTTPException as ModuleHTTPException;
 use Friendica\Network\HTTPException;
 use Friendica\Util\BaseURL;
 use Friendica\Util\ConfigFileLoader;
@@ -41,7 +44,7 @@ use Psr\Log\LoggerInterface;
  */
 class App
 {
-	public $module_class = null;
+	/** @deprecated 2019.09 - use App\Arguments->getQueryString() */
 	public $query_string = '';
 	public $page = [];
 	public $profile;
@@ -53,9 +56,13 @@ class App
 	public $page_contact;
 	public $content;
 	public $data = [];
+	/** @deprecated 2019.09 - use App\Arguments->getCommand() */
 	public $cmd = '';
+	/** @deprecated 2019.09 - use App\Arguments->getArgv() or Arguments->get() */
 	public $argv;
+	/** @deprecated 2019.09 - use App\Arguments->getArgc() */
 	public $argc;
+	/** @deprecated 2019.09 - Use App\Module->getName() instead */
 	public $module;
 	public $timezone;
 	public $interactive = true;
@@ -93,6 +100,8 @@ class App
 
 	/**
 	 * @var bool true, if the call is from an backend node (f.e. worker)
+	 *
+	 * @deprecated 2019.09 - use App\Module->isBackend() instead
 	 */
 	private $isBackend;
 
@@ -135,6 +144,16 @@ class App
 	 * @var L10n The translator
 	 */
 	private $l10n;
+
+	/**
+	 * @var App\Arguments
+	 */
+	private $args;
+
+	/**
+	 * @var App\Module
+	 */
+	private $moduleClass;
 
 	/**
 	 * Returns the current config cache of this node
@@ -198,6 +217,16 @@ class App
 	}
 
 	/**
+	 * Returns the Database of the Application
+	 *
+	 * @return Database
+	 */
+	public function getDBA()
+	{
+		return $this->database;
+	}
+
+	/**
 	 * Register a stylesheet file path to be included in the <head> tag of every page.
 	 * Inclusion is done in App->initHead().
 	 * The path can be absolute or relative to the Friendica installation base folder.
@@ -247,7 +276,7 @@ class App
 	 *
 	 * @throws Exception if the Basepath is not usable
 	 */
-	public function __construct(Database $database, Configuration $config, App\Mode $mode, App\Router $router, BaseURL $baseURL, LoggerInterface $logger, Profiler $profiler, L10n $l10n)
+	public function __construct(Database $database, Configuration $config, App\Mode $mode, App\Router $router, BaseURL $baseURL, LoggerInterface $logger, Profiler $profiler, L10n $l10n, Arguments $args, Module $module)
 	{
 		$this->database = $database;
 		$this->config   = $config;
@@ -257,6 +286,8 @@ class App
 		$this->profiler = $profiler;
 		$this->logger   = $logger;
 		$this->l10n     = $l10n;
+		$this->args = $args;
+		$this->isBackend = $module->isBackend();
 
 		$this->profiler->reset();
 
@@ -273,59 +304,10 @@ class App
 			. $this->getBasePath() . DIRECTORY_SEPARATOR . 'library' . PATH_SEPARATOR
 			. $this->getBasePath());
 
-		if (!empty($_SERVER['QUERY_STRING']) && strpos($_SERVER['QUERY_STRING'], 'pagename=') === 0) {
-			$this->query_string = substr($_SERVER['QUERY_STRING'], 9);
-		} elseif (!empty($_SERVER['QUERY_STRING']) && strpos($_SERVER['QUERY_STRING'], 'q=') === 0) {
-			$this->query_string = substr($_SERVER['QUERY_STRING'], 2);
-		}
-
-		// removing trailing / - maybe a nginx problem
-		$this->query_string = ltrim($this->query_string, '/');
-
-		if (!empty($_GET['pagename'])) {
-			$this->cmd = trim($_GET['pagename'], '/\\');
-		} elseif (!empty($_GET['q'])) {
-			$this->cmd = trim($_GET['q'], '/\\');
-		}
-
-		// fix query_string
-		$this->query_string = str_replace($this->cmd . '&', $this->cmd . '?', $this->query_string);
-
-		// unix style "homedir"
-		if (substr($this->cmd, 0, 1) === '~') {
-			$this->cmd = 'profile/' . substr($this->cmd, 1);
-		}
-
-		// Diaspora style profile url
-		if (substr($this->cmd, 0, 2) === 'u/') {
-			$this->cmd = 'profile/' . substr($this->cmd, 2);
-		}
-
-		/*
-		 * Break the URL path into C style argc/argv style arguments for our
-		 * modules. Given "http://example.com/module/arg1/arg2", $this->argc
-		 * will be 3 (integer) and $this->argv will contain:
-		 *   [0] => 'module'
-		 *   [1] => 'arg1'
-		 *   [2] => 'arg2'
-		 *
-		 *
-		 * There will always be one argument. If provided a naked domain
-		 * URL, $this->argv[0] is set to "home".
-		 */
-
-		$this->argv = explode('/', $this->cmd);
-		$this->argc = count($this->argv);
-		if ((array_key_exists('0', $this->argv)) && strlen($this->argv[0])) {
-			$this->module = str_replace('.', '_', $this->argv[0]);
-			$this->module = str_replace('-', '_', $this->module);
-		} else {
-			$this->argc = 1;
-			$this->argv = ['home'];
-			$this->module = 'home';
-		}
-
-		$this->isBackend = $this->isBackend || $this->checkBackend($this->module);
+		$this->cmd = $args->getCommand();
+		$this->argv = $args->getArgv();
+		$this->argc = $args->getArgc();
+		$this->query_string = $args->getQueryString();
 
 		// Detect mobile devices
 		$mobile_detect = new MobileDetect();
@@ -346,10 +328,6 @@ class App
 	 */
 	public function reload()
 	{
-		$this->isBackend = basename($_SERVER['PHP_SELF'], '.php') !== 'index';
-
-		$this->getMode()->determine($this->getBasePath());
-
 		if ($this->getMode()->has(App\Mode::DBAVAILABLE)) {
 			$this->profiler->update($this->config);
 
@@ -399,6 +377,8 @@ class App
 	 * @param bool $ssl Whether to append http or https under BaseURL::SSL_POLICY_SELFSIGN
 	 *
 	 * @return string Friendica server base URL
+	 *
+	 * @deprecated 2019.09 - use BaseUrl->get($ssl) instead
 	 */
 	public function getBaseURL($ssl = false)
 	{
@@ -453,9 +433,9 @@ class App
 	 * - Infinite scroll data
 	 * - head.tpl template
 	 */
-	public function initHead()
+	private function initHead(App\Module $module, PConfiguration $pconfig)
 	{
-		$interval = ((local_user()) ? Core\PConfig::get(local_user(), 'system', 'update_interval') : 40000);
+		$interval = ((local_user()) ? $pconfig->get(local_user(), 'system', 'update_interval') : 40000);
 
 		// If the update is 'deactivated' set it to the highest integer number (~24 days)
 		if ($interval < 0) {
@@ -467,8 +447,8 @@ class App
 		}
 
 		// Default title: current module called
-		if (empty($this->page['title']) && $this->module) {
-			$this->page['title'] = ucfirst($this->module);
+		if (empty($this->page['title']) && $module->getName()) {
+			$this->page['title'] = ucfirst($module->getName());
 		}
 
 		// Prepend the sitename to the page title
@@ -520,7 +500,7 @@ class App
 	 * - Registered footer scripts (through App->registerFooterScript())
 	 * - footer.tpl template
 	 */
-	public function initFooter()
+	private function initFooter()
 	{
 		// If you're just visiting, let javascript take you home
 		if (!empty($_SESSION['visitor_home'])) {
@@ -593,58 +573,6 @@ class App
 			FRIENDICA_VERSION . '-' .
 			DB_UPDATE_VERSION . '; ' .
 			$this->getBaseURL();
-	}
-
-	/**
-	 * @brief Checks if the site is called via a backend process
-	 *
-	 * This isn't a perfect solution. But we need this check very early.
-	 * So we cannot wait until the modules are loaded.
-	 *
-	 * @param string $module
-	 * @return bool
-	 */
-	private function checkBackend($module) {
-		static $backends = [
-			'_well_known',
-			'api',
-			'dfrn_notify',
-			'feed',
-			'fetch',
-			'followers',
-			'following',
-			'hcard',
-			'hostxrd',
-			'inbox',
-			'manifest',
-			'nodeinfo',
-			'noscrape',
-			'objects',
-			'outbox',
-			'poco',
-			'post',
-			'proxy',
-			'pubsub',
-			'pubsubhubbub',
-			'receive',
-			'rsd_xml',
-			'salmon',
-			'statistics_json',
-			'xrd',
-		];
-
-		// Check if current module is in backend or backend flag is set
-		return in_array($module, $backends);
-	}
-
-	/**
-	 * Returns true, if the call is from a backend node (f.e. from a worker)
-	 *
-	 * @return bool Is it a known backend?
-	 */
-	public function isBackend()
-	{
-		return $this->isBackend;
 	}
 
 	/**
@@ -740,7 +668,7 @@ class App
 	 */
 	public function isMaxLoadReached()
 	{
-		if ($this->isBackend()) {
+		if ($this->isBackend) {
 			$process = 'backend';
 			$maxsysload = intval($this->config->get('system', 'maxloadavg'));
 			if ($maxsysload < 1) {
@@ -930,21 +858,13 @@ class App
 	}
 
 	/**
-	 * Returns the value of a argv key
-	 * TODO there are a lot of $a->argv usages in combination with defaults() which can be replaced with this method
+	 * @deprecated use Arguments->get() instead
 	 *
-	 * @param int $position the position of the argument
-	 * @param mixed $default the default value if not found
-	 *
-	 * @return mixed returns the value of the argument
+	 * @see App\Arguments
 	 */
 	public function getArgumentValue($position, $default = '')
 	{
-		if (array_key_exists($position, $this->argv)) {
-			return $this->argv[$position];
-		}
-
-		return $default;
+		return $this->args->get($position, $default);
 	}
 
 	/**
@@ -973,9 +893,13 @@ class App
 	 * request and a representation of the response.
 	 *
 	 * This probably should change to limit the size of this monster method.
+	 *
+	 * @param App\Module $module The determined module
 	 */
-	public function runFrontend()
+	public function runFrontend(App\Module $module, App\Router $router, PConfiguration $pconfig)
 	{
+		$moduleName = $module->getName();
+
 		try {
 			// Missing DB connection: ERROR
 			if ($this->getMode()->has(App\Mode::LOCALCONFIGPRESENT) && !$this->getMode()->has(App\Mode::DBAVAILABLE)) {
@@ -985,7 +909,7 @@ class App
 			// Max Load Average reached: ERROR
 			if ($this->isMaxProcessesReached() || $this->isMaxLoadReached()) {
 				header('Retry-After: 120');
-				header('Refresh: 120; url=' . $this->getBaseURL() . "/" . $this->query_string);
+				header('Refresh: 120; url=' . $this->baseURL->get() . "/" . $this->args->getQueryString());
 
 				throw new HTTPException\ServiceUnavailableException('The node is currently overloaded. Please try again later.');
 			}
@@ -993,7 +917,7 @@ class App
 			if (!$this->getMode()->isInstall()) {
 				// Force SSL redirection
 				if ($this->baseURL->checkRedirectHttps()) {
-					System::externalRedirect($this->getBaseURL() . '/' . $this->query_string);
+					System::externalRedirect($this->baseURL->get() . '/' . $this->args->getQueryString());
 				}
 
 				Core\Session::init();
@@ -1001,12 +925,8 @@ class App
 			}
 
 			// Exclude the backend processes from the session management
-			if (!$this->isBackend()) {
-				$stamp1 = microtime(true);
-				session_start();
-				$this->profiler->saveTimestamp($stamp1, 'parser', Core\System::callstack());
-				$this->l10n->setSessionVariable();
-				$this->l10n->setLangFromSession();
+			if (!$module->isBackend()) {
+				Core\Session::start();
 			} else {
 				$_SESSION = [];
 				Core\Worker::executeIfIdle();
@@ -1021,7 +941,6 @@ class App
 
 			// ZRL
 			if (!empty($_GET['zrl']) && $this->getMode()->isNormal()) {
-				$this->query_string = Model\Profile::stripZrls($this->query_string);
 				if (!local_user()) {
 					// Only continue when the given profile link seems valid
 					// Valid profile links contain a path with "/profile/" and no query parameters
@@ -1044,11 +963,10 @@ class App
 
 			if (!empty($_GET['owt']) && $this->getMode()->isNormal()) {
 				$token = $_GET['owt'];
-				$this->query_string = Model\Profile::stripQueryParam($this->query_string, 'owt');
 				Model\Profile::openWebAuthInit($token);
 			}
 
-			Module\Login::sessionAuth();
+			Login::sessionAuth();
 
 			if (empty($_SESSION['authenticated'])) {
 				header('X-Account-Management-Status: none');
@@ -1066,9 +984,9 @@ class App
 
 			// in install mode, any url loads install module
 			// but we need "view" module for stylesheet
-			if ($this->getMode()->isInstall() && $this->module !== 'install') {
+			if ($this->getMode()->isInstall() && $moduleName !== 'install') {
 				$this->internalRedirect('install');
-			} elseif (!$this->getMode()->isInstall() && !$this->getMode()->has(App\Mode::MAINTENANCEDISABLED) && $this->module !== 'maintenance') {
+			} elseif (!$this->getMode()->isInstall() && !$this->getMode()->has(App\Mode::MAINTENANCEDISABLED) && $moduleName !== 'maintenance') {
 				$this->internalRedirect('maintenance');
 			} else {
 				$this->checkURL();
@@ -1091,152 +1009,65 @@ class App
 			];
 
 			// Compatibility with the Android Diaspora client
-			if ($this->module == 'stream') {
+			if ($moduleName == 'stream') {
 				$this->internalRedirect('network?order=post');
 			}
 
-			if ($this->module == 'conversations') {
+			if ($moduleName == 'conversations') {
 				$this->internalRedirect('message');
 			}
 
-			if ($this->module == 'commented') {
+			if ($moduleName == 'commented') {
 				$this->internalRedirect('network?order=comment');
 			}
 
-			if ($this->module == 'liked') {
+			if ($moduleName == 'liked') {
 				$this->internalRedirect('network?order=comment');
 			}
 
-			if ($this->module == 'activity') {
+			if ($moduleName == 'activity') {
 				$this->internalRedirect('network?conv=1');
 			}
 
-			if (($this->module == 'status_messages') && ($this->cmd == 'status_messages/new')) {
+			if (($moduleName == 'status_messages') && ($this->args->getCommand() == 'status_messages/new')) {
 				$this->internalRedirect('bookmarklet');
 			}
 
-			if (($this->module == 'user') && ($this->cmd == 'user/edit')) {
+			if (($moduleName == 'user') && ($this->args->getCommand() == 'user/edit')) {
 				$this->internalRedirect('settings');
 			}
 
-			if (($this->module == 'tag_followings') && ($this->cmd == 'tag_followings/manage')) {
+			if (($moduleName == 'tag_followings') && ($this->args->getCommand() == 'tag_followings/manage')) {
 				$this->internalRedirect('search');
 			}
 
-			// Compatibility with the Firefox App
-			if (($this->module == "users") && ($this->cmd == "users/sign_in")) {
-				$this->module = "login";
-			}
-
-			/*
-			 * ROUTING
-			 *
-			 * From the request URL, routing consists of obtaining the name of a BaseModule-extending class of which the
-			 * post() and/or content() static methods can be respectively called to produce a data change or an output.
-			 */
-
-			// First we try explicit routes defined in App\Router
-			$this->router->collectRoutes();
-
-			$data = $this->router->getRouteCollector();
-			Hook::callAll('route_collection', $data);
-
-			$this->module_class = $this->router->getModuleClass($this->cmd);
-
-			// Then we try addon-provided modules that we wrap in the LegacyModule class
-			if (!$this->module_class && Core\Addon::isEnabled($this->module) && file_exists("addon/{$this->module}/{$this->module}.php")) {
-				//Check if module is an app and if public access to apps is allowed or not
-				$privateapps = $this->config->get('config', 'private_addons', false);
-				if ((!local_user()) && Core\Hook::isAddonApp($this->module) && $privateapps) {
-					info($this->l10n->t("You must be logged in to use addons. "));
-				} else {
-					include_once "addon/{$this->module}/{$this->module}.php";
-					if (function_exists($this->module . '_module')) {
-						LegacyModule::setModuleFile("addon/{$this->module}/{$this->module}.php");
-						$this->module_class = LegacyModule::class;
-					}
-				}
-			}
-
-			/* Finally, we look for a 'standard' program module in the 'mod' directory
-			 * We emulate a Module class through the LegacyModule class
-			 */
-			if (!$this->module_class && file_exists("mod/{$this->module}.php")) {
-				LegacyModule::setModuleFile("mod/{$this->module}.php");
-				$this->module_class = LegacyModule::class;
-			}
-
-			/* The URL provided does not resolve to a valid module.
-			 *
-			 * On Dreamhost sites, quite often things go wrong for no apparent reason and they send us to '/internal_error.html'.
-			 * We don't like doing this, but as it occasionally accounts for 10-20% or more of all site traffic -
-			 * we are going to trap this and redirect back to the requested page. As long as you don't have a critical error on your page
-			 * this will often succeed and eventually do the right thing.
-			 *
-			 * Otherwise we are going to emit a 404 not found.
-			 */
-			if (!$this->module_class) {
-				// Stupid browser tried to pre-fetch our Javascript img template. Don't log the event or return anything - just quietly exit.
-				if (!empty($_SERVER['QUERY_STRING']) && preg_match('/{[0-9]}/', $_SERVER['QUERY_STRING']) !== 0) {
-					exit();
-				}
-
-				if (!empty($_SERVER['QUERY_STRING']) && ($_SERVER['QUERY_STRING'] === 'q=internal_error.html') && isset($dreamhost_error_hack)) {
-					Core\Logger::log('index.php: dreamhost_error_hack invoked. Original URI =' . $_SERVER['REQUEST_URI']);
-					$this->internalRedirect($_SERVER['REQUEST_URI']);
-				}
-
-				Core\Logger::log('index.php: page not found: ' . $_SERVER['REQUEST_URI'] . ' ADDRESS: ' . $_SERVER['REMOTE_ADDR'] . ' QUERY: ' . $_SERVER['QUERY_STRING'], Core\Logger::DEBUG);
-
-				$this->module_class = Module\PageNotFound::class;
-			}
-
 			// Initialize module that can set the current theme in the init() method, either directly or via App->profile_uid
-			$this->page['page_title'] = $this->module;
+			$this->page['page_title'] = $moduleName;
 
-			$placeholder = '';
+			// determine the module class and save it to the module instance
+			// @todo there's an implicit dependency due SESSION::start(), so it has to be called here (yet)
+			$module = $module->determineClass($this->args, $router, $this->config);
 
-			Core\Hook::callAll($this->module . '_mod_init', $placeholder);
+			// Let the module run it's internal process (init, get, post, ...)
+			$module->run($this->l10n, $this, $this->logger, $this->getCurrentTheme(), $_SERVER, $_POST);
 
-			call_user_func([$this->module_class, 'init']);
-
-			// "rawContent" is especially meant for technical endpoints.
-			// This endpoint doesn't need any theme initialization or other comparable stuff.
-			call_user_func([$this->module_class, 'rawContent']);
-
-			// Load current theme info after module has been initialized as theme could have been set in module
-			$theme_info_file = 'view/theme/' . $this->getCurrentTheme() . '/theme.php';
-			if (file_exists($theme_info_file)) {
-				require_once $theme_info_file;
-			}
-
-			if (function_exists(str_replace('-', '_', $this->getCurrentTheme()) . '_init')) {
-				$func = str_replace('-', '_', $this->getCurrentTheme()) . '_init';
-				$func($this);
-			}
-
-			if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-				Core\Hook::callAll($this->module . '_mod_post', $_POST);
-				call_user_func([$this->module_class, 'post']);
-			}
-
-			Core\Hook::callAll($this->module . '_mod_afterpost', $placeholder);
-			call_user_func([$this->module_class, 'afterpost']);
 		} catch(HTTPException $e) {
-			Module\Special\HTTPException::rawContent($e);
+			ModuleHTTPException::rawContent($e);
 		}
 
 		$content = '';
 
 		try {
+			$moduleClass = $module->getClassName();
+
 			$arr = ['content' => $content];
-			Core\Hook::callAll($this->module . '_mod_content', $arr);
+			Core\Hook::callAll($moduleClass . '_mod_content', $arr);
 			$content = $arr['content'];
-			$arr = ['content' => call_user_func([$this->module_class, 'content'])];
-			Core\Hook::callAll($this->module . '_mod_aftercontent', $arr);
+			$arr = ['content' => call_user_func([$moduleClass, 'content'])];
+			Core\Hook::callAll($moduleClass . '_mod_aftercontent', $arr);
 			$content .= $arr['content'];
 		} catch(HTTPException $e) {
-			$content = Module\Special\HTTPException::content($e);
+			$content = ModuleHTTPException::content($e);
 		}
 
 		// initialise content region
@@ -1253,7 +1084,7 @@ class App
 		 * all the module functions have executed so that all
 		 * theme choices made by the modules can take effect.
 		 */
-		$this->initHead();
+		$this->initHead($module, $pconfig);
 
 		/* Build the page ending -- this is stuff that goes right before
 		 * the closing </body> tag
@@ -1265,7 +1096,7 @@ class App
 		}
 
 		// Add the navigation (menu) template
-		if ($this->module != 'install' && $this->module != 'maintenance') {
+		if ($moduleName != 'install' && $moduleName != 'maintenance') {
 			$this->page['htmlhead'] .= Core\Renderer::replaceMacros(Core\Renderer::getMarkupTemplate('nav_head.tpl'), []);
 			$this->page['nav']       = Content\Nav::build($this);
 		}

--- a/src/App/Arguments.php
+++ b/src/App/Arguments.php
@@ -1,0 +1,194 @@
+<?php
+
+namespace Friendica\App;
+
+/**
+ * Determine all arguments of the current call, including
+ * - The whole querystring (except the pagename/q parameter)
+ * - The command
+ * - The arguments (C-Style based)
+ * - The count of arguments
+ */
+class Arguments
+{
+	/**
+	 * @var string The complete query string
+	 */
+	private $queryString;
+	/**
+	 * @var string The current Friendica command
+	 */
+	private $command;
+	/**
+	 * @var array The arguments of the current execution
+	 */
+	private $argv;
+	/**
+	 * @var int The count of arguments
+	 */
+	private $argc;
+
+	public function __construct(string $queryString = '', string $command = '', array $argv = [Module::DEFAULT], int $argc = 1)
+	{
+		$this->queryString = $queryString;
+		$this->command     = $command;
+		$this->argv        = $argv;
+		$this->argc        = $argc;
+	}
+
+	/**
+	 * @return string The whole query string of this call
+	 */
+	public function getQueryString()
+	{
+		return $this->queryString;
+	}
+
+	/**
+	 * @return string The whole command of this call
+	 */
+	public function getCommand()
+	{
+		return $this->command;
+	}
+
+	/**
+	 * @return array All arguments of this call
+	 */
+	public function getArgv()
+	{
+		return $this->argv;
+	}
+
+	/**
+	 * @return int The count of arguments of this call
+	 */
+	public function getArgc()
+	{
+		return $this->argc;
+	}
+
+	/**
+	 * Returns the value of a argv key
+	 * TODO there are a lot of $a->argv usages in combination with defaults() which can be replaced with this method
+	 *
+	 * @param int   $position the position of the argument
+	 * @param mixed $default  the default value if not found
+	 *
+	 * @return mixed returns the value of the argument
+	 */
+	public function get(int $position, $default = '')
+	{
+		return $this->has($position) ? $this->argv[$position] : $default;
+	}
+
+	/**
+	 * @param int $position
+	 *
+	 * @return bool if the argument position exists
+	 */
+	public function has(int $position)
+	{
+		return array_key_exists($position, $this->argv);
+	}
+
+	/**
+	 * Determine the arguments of the current call
+	 *
+	 * @param array $server The $_SERVER variable
+	 * @param array $get    The $_GET variable
+	 *
+	 * @return Arguments The determined arguments
+	 */
+	public function determine(array $server, array $get)
+	{
+		$queryString = '';
+
+		if (!empty($server['QUERY_STRING']) && strpos($server['QUERY_STRING'], 'pagename=') === 0) {
+			$queryString = substr($server['QUERY_STRING'], 9);
+		} elseif (!empty($server['QUERY_STRING']) && strpos($server['QUERY_STRING'], 'q=') === 0) {
+			$queryString = substr($server['QUERY_STRING'], 2);
+		}
+
+		// eventually strip ZRL
+		$queryString = $this->stripZRLs($queryString);
+
+		// eventually strip OWT
+		$queryString = $this->stripQueryParam($queryString, 'owt');
+
+		// removing trailing / - maybe a nginx problem
+		$queryString = ltrim($queryString, '/');
+
+		if (!empty($get['pagename'])) {
+			$command = trim($get['pagename'], '/\\');
+		} elseif (!empty($get['q'])) {
+			$command = trim($get['q'], '/\\');
+		} else {
+			$command = Module::DEFAULT;
+		}
+
+
+		// fix query_string
+		if (!empty($command)) {
+			$queryString = str_replace(
+				$command . '&',
+				$command . '?',
+				$queryString
+			);
+		}
+
+		// unix style "homedir"
+		if (substr($command, 0, 1) === '~') {
+			$command = 'profile/' . substr($command, 1);
+		}
+
+		// Diaspora style profile url
+		if (substr($command, 0, 2) === 'u/') {
+			$command = 'profile/' . substr($command, 2);
+		}
+
+		/*
+		 * Break the URL path into C style argc/argv style arguments for our
+		 * modules. Given "http://example.com/module/arg1/arg2", $this->argc
+		 * will be 3 (integer) and $this->argv will contain:
+		 *   [0] => 'module'
+		 *   [1] => 'arg1'
+		 *   [2] => 'arg2'
+		 *
+		 *
+		 * There will always be one argument. If provided a naked domain
+		 * URL, $this->argv[0] is set to "home".
+		 */
+
+		$argv = explode('/', $command);
+		$argc = count($argv);
+
+
+		return new Arguments($queryString, $command, $argv, $argc);
+	}
+
+	/**
+	 * Strip zrl parameter from a string.
+	 *
+	 * @param string $queryString The input string.
+	 *
+	 * @return string The zrl.
+	 */
+	public function stripZRLs(string $queryString)
+	{
+		return preg_replace('/[?&]zrl=(.*?)(&|$)/ism', '$2', $queryString);
+	}
+
+	/**
+	 * Strip query parameter from a string.
+	 *
+	 * @param string $queryString The input string.
+	 * @param string $param
+	 *
+	 * @return string The query parameter.
+	 */
+	public function stripQueryParam(string $queryString, string $param)
+	{
+		return preg_replace('/[?&]' . $param . '=(.*?)(&|$)/ism', '$2', $queryString);
+	}
+}

--- a/src/App/Module.php
+++ b/src/App/Module.php
@@ -125,7 +125,6 @@ class Module
 			$module = "login";
 		}
 
-
 		$isBackend = $this->checkBackend($module, $server);
 
 		return new Module($module, $this->module_class, $isBackend, $this->printNotAllowedAddon);

--- a/src/App/Module.php
+++ b/src/App/Module.php
@@ -1,0 +1,281 @@
+<?php
+
+namespace Friendica\App;
+
+use Friendica\App;
+use Friendica\BaseObject;
+use Friendica\Core;
+use Friendica\LegacyModule;
+use Friendica\Module\Home;
+use Friendica\Module\PageNotFound;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Holds the common context of the current, loaded module
+ */
+class Module
+{
+	const DEFAULT = 'home';
+	const DEFAULT_CLASS = Home::class;
+
+	/**
+	 * @var string The module name
+	 */
+	private $module;
+
+	/**
+	 * @var BaseObject The module class
+	 */
+	private $module_class;
+
+	/**
+	 * @var bool true, if the module is a backend module
+	 */
+	private $isBackend;
+
+	/**
+	 * @var bool true, if the loaded addon is private, so we have to print out not allowed
+	 */
+	private $printNotAllowedAddon;
+
+	/**
+	 * A list of modules, which are backend methods
+	 *
+	 * @var array
+	 */
+	const BACKEND_MODULES = [
+		'_well_known',
+		'api',
+		'dfrn_notify',
+		'feed',
+		'fetch',
+		'followers',
+		'following',
+		'hcard',
+		'hostxrd',
+		'inbox',
+		'manifest',
+		'nodeinfo',
+		'noscrape',
+		'objects',
+		'outbox',
+		'poco',
+		'post',
+		'proxy',
+		'pubsub',
+		'pubsubhubbub',
+		'receive',
+		'rsd_xml',
+		'salmon',
+		'statistics_json',
+		'xrd',
+	];
+
+	/**
+	 * @return string
+	 */
+	public function getName()
+	{
+		return $this->module;
+	}
+
+	/**
+	 * @return string The base class name
+	 */
+	public function getClassName()
+	{
+		return $this->module_class;
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function isBackend()
+	{
+		return $this->isBackend;
+	}
+
+	public function __construct(string $module = self::DEFAULT, string $moduleClass = self::DEFAULT_CLASS, bool $isBackend = false, bool $printNotAllowedAddon = false)
+	{
+		$this->module       = $module;
+		$this->module_class = $moduleClass;
+		$this->isBackend    = $isBackend;
+		$this->printNotAllowedAddon = $printNotAllowedAddon;
+	}
+
+	/**
+	 * Determines the current module based on the App arguments and the server variable
+	 *
+	 * @param Arguments $args   The Friendica arguments
+	 * @param array     $server The $_SERVER variable
+	 *
+	 * @return Module The module with the determined module
+	 */
+	public function determineModule(Arguments $args, array $server)
+	{
+		if ($args->getArgc() > 0) {
+			$module = str_replace('.', '_', $args->get(0));
+			$module = str_replace('-', '_', $module);
+		} else {
+			$module = self::DEFAULT;
+		}
+
+		// Compatibility with the Firefox App
+		if (($module == "users") && ($args->getCommand() == "users/sign_in")) {
+			$module = "login";
+		}
+
+
+		$isBackend = $this->checkBackend($module, $server);
+
+		return new Module($module, $this->module_class, $isBackend, $this->printNotAllowedAddon);
+	}
+
+	/**
+	 * Determine the class of the current module
+	 *
+	 * @param Arguments                 $args   The Friendica execution arguments
+	 * @param Router                    $router The Friendica routing instance
+	 * @param Core\Config\Configuration $config The Friendica Configuration
+	 *
+	 * @return Module The determined module of this call
+	 *
+	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
+	 */
+	public function determineClass(Arguments $args, Router $router, Core\Config\Configuration $config)
+	{
+		$printNotAllowedAddon = false;
+
+		/**
+		 * ROUTING
+		 *
+		 * From the request URL, routing consists of obtaining the name of a BaseModule-extending class of which the
+		 * post() and/or content() static methods can be respectively called to produce a data change or an output.
+		 **/
+
+		// First we try explicit routes defined in App\Router
+		$router->collectRoutes();
+
+		$data = $router->getRouteCollector();
+		Core\Hook::callAll('route_collection', $data);
+
+		$module_class = $router->getModuleClass($args->getCommand());
+
+		// Then we try addon-provided modules that we wrap in the LegacyModule class
+		if (!$module_class && Core\Addon::isEnabled($this->module) && file_exists("addon/{$this->module}/{$this->module}.php")) {
+			//Check if module is an app and if public access to apps is allowed or not
+			$privateapps = $config->get('config', 'private_addons', false);
+			if ((!local_user()) && Core\Hook::isAddonApp($this->module) && $privateapps) {
+				$printNotAllowedAddon = true;
+			} else {
+				include_once "addon/{$this->module}/{$this->module}.php";
+				if (function_exists($this->module . '_module')) {
+					LegacyModule::setModuleFile("addon/{$this->module}/{$this->module}.php");
+					$module_class = LegacyModule::class;
+				}
+			}
+		}
+
+		/* Finally, we look for a 'standard' program module in the 'mod' directory
+		 * We emulate a Module class through the LegacyModule class
+		 */
+		if (!$module_class && file_exists("mod/{$this->module}.php")) {
+			LegacyModule::setModuleFile("mod/{$this->module}.php");
+			$module_class = LegacyModule::class;
+		}
+
+		$module_class = !isset($module_class) ? PageNotFound::class : $module_class;
+
+		return new Module($this->module, $module_class, $this->isBackend, $printNotAllowedAddon);
+	}
+
+	/**
+	 * Run the determined module class and calls all hooks applied to
+	 *
+	 * @param Core\L10n\L10n $l10n         The L10n instance
+	 * @param App            $app          The whole Friendica app (for method arguments)
+	 * @param LoggerInterface           $logger The Friendica logger
+	 * @param string         $currentTheme The chosen theme
+	 * @param array          $server       The $_SERVER variable
+	 * @param array          $post         The $_POST variables
+	 *
+	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
+	 */
+	public function run(Core\L10n\L10n $l10n, App $app,  LoggerInterface $logger, string $currentTheme, array $server, array $post)
+	{
+		if ($this->printNotAllowedAddon) {
+			info($l10n->t("You must be logged in to use addons. "));
+		}
+
+		/* The URL provided does not resolve to a valid module.
+		 *
+		 * On Dreamhost sites, quite often things go wrong for no apparent reason and they send us to '/internal_error.html'.
+		 * We don't like doing this, but as it occasionally accounts for 10-20% or more of all site traffic -
+		 * we are going to trap this and redirect back to the requested page. As long as you don't have a critical error on your page
+		 * this will often succeed and eventually do the right thing.
+		 *
+		 * Otherwise we are going to emit a 404 not found.
+		 */
+		if ($this->module_class === PageNotFound::class) {
+			$queryString = $server['QUERY_STRING'];
+			// Stupid browser tried to pre-fetch our Javascript img template. Don't log the event or return anything - just quietly exit.
+			if (!empty($queryString) && preg_match('/{[0-9]}/', $queryString) !== 0) {
+				exit();
+			}
+
+			if (!empty($queryString) && ($queryString === 'q=internal_error.html') && isset($dreamhost_error_hack)) {
+				$logger->info('index.php: dreamhost_error_hack invoked.', ['Original URI' => $server['REQUEST_URI']]);
+				$app->internalRedirect($server['REQUEST_URI']);
+			}
+
+			$logger->debug('index.php: page not found.', ['request_uri' => $server['REQUEST_URI'], 'address' => $server['REMOTE_ADDR'], 'query' => $server['QUERY_STRING']]);
+		}
+
+		$placeholder = '';
+
+		Core\Hook::callAll($this->module . '_mod_init', $placeholder);
+
+		call_user_func([$this->module_class, 'init']);
+
+		// "rawContent" is especially meant for technical endpoints.
+		// This endpoint doesn't need any theme initialization or other comparable stuff.
+		call_user_func([$this->module_class, 'rawContent']);
+
+		// Load current theme info after module has been initialized as theme could have been set in module
+		$theme_info_file = 'view/theme/' . $currentTheme . '/theme.php';
+		if (file_exists($theme_info_file)) {
+			require_once $theme_info_file;
+		}
+
+		if (function_exists(str_replace('-', '_', $currentTheme) . '_init')) {
+			$func = str_replace('-', '_', $currentTheme) . '_init';
+			$func($app);
+		}
+
+		if ($server['REQUEST_METHOD'] === 'POST') {
+			Core\Hook::callAll($this->module . '_mod_post', $post);
+			call_user_func([$this->module_class, 'post']);
+		}
+
+		Core\Hook::callAll($this->module . '_mod_afterpost', $placeholder);
+		call_user_func([$this->module_class, 'afterpost']);
+	}
+
+	/**
+	 * @brief Checks if the site is called via a backend process
+	 *
+	 * This isn't a perfect solution. But we need this check very early.
+	 * So we cannot wait until the modules are loaded.
+	 *
+	 * @param string $module The determined module
+	 * @param array  $server The $_SERVER variable
+	 *
+	 * @return bool True, if the current module is called at backend
+	 */
+	private function checkBackend($module, array $server)
+	{
+		// Check if current module is in backend or backend flag is set
+		return basename(($server['PHP_SELF'] ?? ''), '.php') !== 'index' &&
+		       in_array($module, Module::BACKEND_MODULES);
+	}
+}

--- a/src/BaseObject.php
+++ b/src/BaseObject.php
@@ -48,20 +48,21 @@ class BaseObject
 	/**
 	 * Returns the initialized class based on it's name
 	 *
-	 * @param string $name The name of the class
+	 * @param string $name   The name of the class
+	 * @param array  $params Parameters, which are used to load the class with
 	 *
 	 * @return object The initialized name
 	 *
 	 * @throws InternalServerErrorException
 	 */
-	protected static function getClass(string $name)
+	protected static function getClass(string $name, array $params = [])
 	{
 		if (empty(self::$dice)) {
 			throw new InternalServerErrorException('DICE isn\'t initialized.');
 		}
 
-		if (class_exists($name) || interface_exists($name   )) {
-			return self::$dice->create($name);
+		if (class_exists($name) || interface_exists($name)) {
+			return self::$dice->create($name, $params);
 		} else {
 			throw new InternalServerErrorException('Class \'' . $name . '\' isn\'t valid.');
 		}

--- a/src/Core/Installer.php
+++ b/src/Core/Installer.php
@@ -11,7 +11,6 @@ use Friendica\Database\Database;
 use Friendica\Database\DBStructure;
 use Friendica\Object\Image;
 use Friendica\Util\Network;
-use Friendica\Util\Profiler;
 use Friendica\Util\Strings;
 
 /**
@@ -591,8 +590,7 @@ class Installer
 	/**
 	 * Checking the Database connection and if it is available for the current installation
 	 *
-	 * @param ConfigCache $configCache The configuration cache
-	 * @param Profiler    $profiler    The profiler of this app
+	 * @param Database $dba
 	 *
 	 * @return bool true if the check was successful, otherwise false
 	 * @throws Exception

--- a/src/Core/L10n.php
+++ b/src/Core/L10n.php
@@ -13,6 +13,28 @@ use Friendica\Core\L10n\L10n as L10nClass;
  */
 class L10n extends BaseObject
 {
+	/** @var string an optional language parameter (push/pop language) */
+	private static $lang;
+
+	/**
+	 * Returns the global L10n instance
+	 * 1) Either the "normal" user specific L10n class
+	 * 2) Or a overriden L10n class (per push/pop)
+	 *
+	 * @param string $name The class name
+	 * @param array  $params Optional parameters
+	 *
+	 * @return L10nClass The class
+	 */
+	protected static function getClass(string $name, array $params = [])
+	{
+		if (empty(self::$lang)) {
+			return parent::getClass(L10nClass::class);
+		} else {
+			return parent::getClass('$rawL10n', [self::$lang]);
+		}
+	}
+
 	/**
 	 * Returns the current language code
 	 *
@@ -38,7 +60,7 @@ class L10n extends BaseObject
 	 */
 	public static function pushLang($lang)
 	{
-		self::getClass(L10nClass::class)->pushLang($lang);
+		self::$lang = $lang;
 	}
 
 	/**
@@ -46,7 +68,7 @@ class L10n extends BaseObject
 	 */
 	public static function popLang()
 	{
-		self::getClass(L10nClass::class)->popLang();
+		self::$lang = null;
 	}
 
 	/**

--- a/src/Core/Session.php
+++ b/src/Core/Session.php
@@ -67,12 +67,31 @@ class Session extends BaseObject
 		$module = self::getClass(App\Module::class);
 
 		if (!$module->isBackend()) {
-			$stamp1 = microtime(true);
-			session_start();
-			$profiler->saveTimestamp($stamp1, 'parser', System::callstack());
+			if (!self::isStarted()) {
+				$stamp1 = microtime(true);
+				session_start();
+				$profiler->saveTimestamp($stamp1, 'parser', System::callstack());
+			}
 		}
 
 		self::$started = true;
+	}
+
+	/**
+	 * Checks, if the session is already started
+	 *
+	 * @return bool True, if the session is already staretd
+	 */
+	public static function isStarted()
+	{
+		if (php_sapi_name() !== 'cli') {
+			if (version_compare(phpversion(), '5.4.0', '>=')) {
+				return session_status() === PHP_SESSION_ACTIVE ? true : false;
+			} else {
+				return session_id() === '' ? false : true;
+			}
+		}
+		return false;
 	}
 
 	public static function exists($name)

--- a/src/Core/Session.php
+++ b/src/Core/Session.php
@@ -67,11 +67,9 @@ class Session extends BaseObject
 		$module = self::getClass(App\Module::class);
 
 		if (!$module->isBackend()) {
-			if (!self::isStarted()) {
-				$stamp1 = microtime(true);
-				session_start();
-				$profiler->saveTimestamp($stamp1, 'parser', System::callstack());
-			}
+			$stamp1 = microtime(true);
+			session_start();
+			$profiler->saveTimestamp($stamp1, 'parser', System::callstack());
 		}
 
 		self::$started = true;

--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -1225,29 +1225,6 @@ class Profile
 	}
 
 	/**
-	* Strip zrl parameter from a string.
-	*
-	* @param string $s The input string.
-	* @return string The zrl.
-	*/
-	public static function stripZrls($s)
-	{
-		return preg_replace('/[\?&]zrl=(.*?)([\?&]|$)/is', '', $s);
-	}
-
-	/**
-	 * Strip query parameter from a string.
-	 *
-	 * @param string $s The input string.
-	 * @param        $param
-	 * @return string The query parameter.
-	 */
-	public static function stripQueryParam($s, $param)
-	{
-		return preg_replace('/[\?&]' . $param . '=(.*?)(&|$)/ism', '$2', $s);
-	}
-
-	/**
 	 * search for Profiles
 	 *
 	 * @param int  $start

--- a/src/Module/Admin/Addons/Details.php
+++ b/src/Module/Admin/Addons/Details.php
@@ -4,6 +4,7 @@ namespace Friendica\Module\Admin\Addons;
 
 use Friendica\Content\Text\Markdown;
 use Friendica\Core\Addon;
+use Friendica\Core\Config\Configuration;
 use Friendica\Core\L10n;
 use Friendica\Core\Renderer;
 use Friendica\Module\BaseAdminModule;
@@ -65,7 +66,7 @@ class Details extends BaseAdminModule
 					info(L10n::t('Addon %s enabled.', $addon));
 				}
 
-				Addon::saveEnabledList();
+				Addon::saveEnabledList(self::getClass(Configuration::class));
 
 				$a->internalRedirect('admin/addons/' . $addon);
 			}

--- a/src/Module/Install.php
+++ b/src/Module/Install.php
@@ -111,7 +111,7 @@ class Install extends BaseModule
 				self::checkSetting($configCache, $_POST, 'database', 'database', '');
 
 				// If we cannot connect to the database, return to the previous step
-				if (!self::$installer->checkDB($configCache, $a->getProfiler())) {
+				if (!self::$installer->checkDB($a->getDBA())) {
 					self::$currentWizardStep = self::DATABASE_CONFIG;
 				}
 
@@ -135,7 +135,7 @@ class Install extends BaseModule
 				self::checkSetting($configCache, $_POST, 'config', 'admin_email', '');
 
 				// If we cannot connect to the database, return to the Database config wizard
-				if (!self::$installer->checkDB($configCache, $a->getProfiler())) {
+				if (!self::$installer->checkDB($a->getDBA())) {
 					self::$currentWizardStep = self::DATABASE_CONFIG;
 					return;
 				}

--- a/static/dependencies.config.php
+++ b/static/dependencies.config.php
@@ -4,6 +4,7 @@ use Dice\Dice;
 use Friendica\App;
 use Friendica\Core\Cache;
 use Friendica\Core\Config;
+use Friendica\Core\L10n\L10n;
 use Friendica\Core\Lock\ILock;
 use Friendica\Database\Database;
 use Friendica\Factory;
@@ -27,14 +28,14 @@ use Psr\Log\LoggerInterface;
  *
  */
 return [
-	'*' => [
+	'*'                             => [
 		// marks all class result as shared for other creations, so there's just
 		// one instance for the whole execution
 		'shared' => true,
 	],
-	'$basepath' => [
-		'instanceOf' => Util\BasePath::class,
-		'call' => [
+	'$basepath'                     => [
+		'instanceOf'      => Util\BasePath::class,
+		'call'            => [
 			['getPath', [], Dice::CHAIN_CALL],
 		],
 		'constructParams' => [
@@ -42,14 +43,14 @@ return [
 			$_SERVER
 		]
 	],
-	Util\BasePath::class => [
+	Util\BasePath::class            => [
 		'constructParams' => [
 			dirname(__FILE__, 2),
 			$_SERVER
 		]
 	],
-	Util\ConfigFileLoader::class => [
-		'shared' => true,
+	Util\ConfigFileLoader::class    => [
+		'shared'          => true,
 		'constructParams' => [
 			[Dice::INSTANCE => '$basepath'],
 		],
@@ -60,24 +61,24 @@ return [
 			['createCache', [], Dice::CHAIN_CALL],
 		],
 	],
-	App\Mode::class => [
-		'call'   => [
+	App\Mode::class                 => [
+		'call' => [
 			['determine', [], Dice::CHAIN_CALL],
 		],
 	],
-	Config\Configuration::class => [
+	Config\Configuration::class     => [
 		'instanceOf' => Factory\ConfigFactory::class,
-		'call' => [
+		'call'       => [
 			['createConfig', [], Dice::CHAIN_CALL],
 		],
 	],
-	Config\PConfiguration::class => [
+	Config\PConfiguration::class    => [
 		'instanceOf' => Factory\ConfigFactory::class,
-		'call' => [
+		'call'       => [
 			['createPConfig', [], Dice::CHAIN_CALL],
 		]
 	],
-	Database::class => [
+	Database::class                 => [
 		'constructParams' => [
 			[DICE::INSTANCE => \Psr\Log\NullLogger::class],
 			$_SERVER,
@@ -89,7 +90,7 @@ return [
 	 * Same as:
 	 *   $baseURL = new Util\BaseURL($configuration, $_SERVER);
 	 */
-	Util\BaseURL::class => [
+	Util\BaseURL::class             => [
 		'constructParams' => [
 			$_SERVER,
 		],
@@ -106,34 +107,69 @@ return [
 	 *    $app = $dice->create(App::class, [], ['$channel' => 'index']);
 	 *    and is automatically passed as an argument with the same name
 	 */
-	LoggerInterface::class    => [
+	LoggerInterface::class          => [
 		'instanceOf' => Factory\LoggerFactory::class,
 		'call'       => [
 			['create', [], Dice::CHAIN_CALL],
 		],
 	],
-	'$devLogger'              => [
+	'$devLogger'                    => [
 		'instanceOf' => Factory\LoggerFactory::class,
 		'call'       => [
 			['createDev', [], Dice::CHAIN_CALL],
 		]
 	],
-	Cache\ICache::class       => [
+	Cache\ICache::class             => [
 		'instanceOf' => Factory\CacheFactory::class,
 		'call'       => [
 			['create', [], Dice::CHAIN_CALL],
 		],
 	],
-	Cache\IMemoryCache::class => [
+	Cache\IMemoryCache::class       => [
 		'instanceOf' => Factory\CacheFactory::class,
 		'call'       => [
 			['create', [], Dice::CHAIN_CALL],
 		],
 	],
-	ILock::class              => [
+	ILock::class                    => [
 		'instanceOf' => Factory\LockFactory::class,
 		'call'       => [
 			['create', [], Dice::CHAIN_CALL],
+		],
+	],
+	App\Arguments::class => [
+		'instanceOf' => App\Arguments::class,
+		'call' => [
+			['determine', [$_SERVER, $_GET], Dice::CHAIN_CALL],
+		],
+	],
+	App\Module::class => [
+		'instanceOf' => App\Module::class,
+		'call' => [
+			['determineModule', [$_SERVER], Dice::CHAIN_CALL],
+		],
+	],
+	// The default instance, which loads the user specific language settings
+	L10n::class                     => [
+		'instanceOf' => L10n::class,
+		'call'       => [
+			['userLanguage', [$_SERVER, $_GET], Dice::CHAIN_CALL],
+			['load', [], Dice::CHAIN_CALL],
+		],
+	],
+	// A system instance, which loads the system specific configuration settings
+	'$systemL10n'                   => [
+		'instanceOf' => L10n::class,
+		'call'       => [
+			['systemLanguage', [$_SERVER, $_GET], Dice::CHAIN_CALL],
+			['load', [], Dice::CHAIN_CALL],
+		],
+	],
+	// This loads the raw instance with the auto-detected settings (without addons)
+	'$rawL10n'                      => [
+		'instanceOf' => L10n::class,
+		'call'       => [
+			['load', [], Dice::CHAIN_CALL]
 		],
 	],
 ];

--- a/tests/Util/AppMockTrait.php
+++ b/tests/Util/AppMockTrait.php
@@ -54,11 +54,11 @@ trait AppMockTrait
 
 		$this->configMock = \Mockery::mock(Config\Cache\ConfigCache::class);
 		$this->dice->shouldReceive('create')
-		           ->with(Config\Cache\ConfigCache::class)
+		           ->with(Config\Cache\ConfigCache::class, [])
 		           ->andReturn($this->configMock);
-		$this->mode = \Mockery::mock(App\Mode::class);
+		$this->mode = new App\Mode(15);
 		$this->dice->shouldReceive('create')
-		           ->with(App\Mode::class)
+		           ->with(App\Mode::class, [])
 		           ->andReturn($this->mode);
 		$configModel= \Mockery::mock(\Friendica\Model\Config\Config::class);
 		// Disable the adapter
@@ -66,13 +66,13 @@ trait AppMockTrait
 
 		$config = new Config\JitConfiguration($this->configMock, $configModel);
 		$this->dice->shouldReceive('create')
-		           ->with(Config\Configuration::class)
+		           ->with(Config\Configuration::class, [])
 		           ->andReturn($config);
 
 		// Mocking App and most used functions
 		$this->app = \Mockery::mock(App::class);
 		$this->dice->shouldReceive('create')
-		           ->with(App::class)
+		           ->with(App::class, [])
 		           ->andReturn($this->app);
 		$this->app
 			->shouldReceive('getBasePath')
@@ -85,7 +85,7 @@ trait AppMockTrait
 		$this->profilerMock = \Mockery::mock(Profiler::class);
 		$this->profilerMock->shouldReceive('saveTimestamp');
 		$this->dice->shouldReceive('create')
-		           ->with(Profiler::class)
+		           ->with(Profiler::class, [])
 		           ->andReturn($this->profilerMock);
 
 		$this->app

--- a/tests/src/App/ArgumentsTest.php
+++ b/tests/src/App/ArgumentsTest.php
@@ -1,0 +1,242 @@
+<?php
+
+namespace Friendica\Test\src\App;
+
+use Friendica\App;
+use PHPUnit\Framework\TestCase;
+
+class ArgumentsTest extends TestCase
+{
+	private function assertArguments(array $assert, App\Arguments $arguments)
+	{
+		$this->assertEquals($assert['queryString'], $arguments->getQueryString());
+		$this->assertEquals($assert['command'], $arguments->getCommand());
+		$this->assertEquals($assert['argv'], $arguments->getArgv());
+		$this->assertEquals($assert['argc'], $arguments->getArgc());
+		$this->assertCount($assert['argc'], $arguments->getArgv());
+	}
+
+	/**
+	 * Test the default argument without any determinations
+	 */
+	public function testDefault()
+	{
+		$arguments = new App\Arguments();
+
+		$this->assertArguments([
+			'queryString' => '',
+			'command'     => '',
+			'argv'        => ['home'],
+			'argc'        => 1,
+		],
+			$arguments);
+	}
+
+	public function dataArguments()
+	{
+		return [
+			'withPagename'         => [
+				'assert' => [
+					'queryString' => 'profile/test/it?arg1=value1&arg2=value2',
+					'command'     => 'profile/test/it',
+					'argv'        => ['profile', 'test', 'it'],
+					'argc'        => 3,
+				],
+				'server' => [
+					'QUERY_STRING' => 'pagename=profile/test/it?arg1=value1&arg2=value2',
+				],
+				'get'    => [
+					'pagename' => 'profile/test/it',
+				],
+			],
+			'withQ'                => [
+				'assert' => [
+					'queryString' => 'profile/test/it?arg1=value1&arg2=value2',
+					'command'     => 'profile/test/it',
+					'argv'        => ['profile', 'test', 'it'],
+					'argc'        => 3,
+				],
+				'server' => [
+					'QUERY_STRING' => 'q=profile/test/it?arg1=value1&arg2=value2',
+				],
+				'get'    => [
+					'q' => 'profile/test/it',
+				],
+			],
+			'withWrongDelimiter'   => [
+				'assert' => [
+					'queryString' => 'profile/test/it?arg1=value1&arg2=value2',
+					'command'     => 'profile/test/it',
+					'argv'        => ['profile', 'test', 'it'],
+					'argc'        => 3,
+				],
+				'server' => [
+					'QUERY_STRING' => 'pagename=profile/test/it&arg1=value1&arg2=value2',
+				],
+				'get'    => [
+					'pagename' => 'profile/test/it',
+				],
+			],
+			'withUnixHomeDir'      => [
+				'assert' => [
+					'queryString' => '~test/it?arg1=value1&arg2=value2',
+					'command'     => 'profile/test/it',
+					'argv'        => ['profile', 'test', 'it'],
+					'argc'        => 3,
+				],
+				'server' => [
+					'QUERY_STRING' => 'pagename=~test/it?arg1=value1&arg2=value2',
+				],
+				'get'    => [
+					'pagename' => '~test/it',
+				],
+			],
+			'withDiasporaHomeDir'  => [
+				'assert' => [
+					'queryString' => 'u/test/it?arg1=value1&arg2=value2',
+					'command'     => 'profile/test/it',
+					'argv'        => ['profile', 'test', 'it'],
+					'argc'        => 3,
+				],
+				'server' => [
+					'QUERY_STRING' => 'pagename=u/test/it?arg1=value1&arg2=value2',
+				],
+				'get'    => [
+					'pagename' => 'u/test/it',
+				],
+			],
+			'withTrailingSlash'    => [
+				'assert' => [
+					'queryString' => 'profile/test/it?arg1=value1&arg2=value2/',
+					'command'     => 'profile/test/it',
+					'argv'        => ['profile', 'test', 'it'],
+					'argc'        => 3,
+				],
+				'server' => [
+					'QUERY_STRING' => 'pagename=profile/test/it?arg1=value1&arg2=value2/',
+				],
+				'get'    => [
+					'pagename' => 'profile/test/it',
+				],
+			],
+			'withWrongQueryString' => [
+				'assert' => [
+					// empty query string?!
+					'queryString' => '',
+					'command'     => 'profile/test/it',
+					'argv'        => ['profile', 'test', 'it'],
+					'argc'        => 3,
+				],
+				'server' => [
+					'QUERY_STRING' => 'wrong=profile/test/it?arg1=value1&arg2=value2/',
+				],
+				'get'    => [
+					'pagename' => 'profile/test/it',
+				],
+			],
+			'withMissingPageName'  => [
+				'assert' => [
+					'queryString' => 'test/it?arg1=value1&arg2=value2/',
+					'command'     => '',
+					'argv'        => [''],
+					'argc'        => 1,
+				],
+				'server' => [
+					'QUERY_STRING' => 'pagename=test/it?arg1=value1&arg2=value2/',
+				],
+				'get'    => [
+				],
+			],
+		];
+	}
+
+	/**
+	 * Test all variants of argument determination
+	 *
+	 * @dataProvider dataArguments
+	 */
+	public function testDetermine(array $assert, array $server, array $get)
+	{
+		$arguments = (new App\Arguments())
+			->determine($server, $get);
+
+		$this->assertArguments($assert, $arguments);
+	}
+
+	/**
+	 * Test if the get/has methods are working for the determined arguments
+	 *
+	 * @dataProvider dataArguments
+	 */
+	public function testGetHas(array $assert, array $server, array $get)
+	{
+		$arguments = (new App\Arguments())
+			->determine($server, $get);
+
+		for ($i = 0; $i < $arguments->getArgc(); $i++) {
+			$this->assertTrue($arguments->has($i));
+			$this->assertEquals($assert['argv'][$i], $arguments->get($i));
+		}
+
+		$this->assertFalse($arguments->has($arguments->getArgc()));
+		$this->assertEmpty($arguments->get($arguments->getArgc()));
+		$this->assertEquals('default', $arguments->get($arguments->getArgc(), 'default'));
+	}
+
+	public function dataStripped()
+	{
+		return [
+			'strippedZRLFirst'  => [
+				'assert' => '?arg1=value1',
+				'input'  => '?zrl=nope&arg1=value1',
+			],
+			'strippedZRLLast'   => [
+				'assert' => '?arg1=value1',
+				'input'  => '?arg1=value1&zrl=nope',
+			],
+			'strippedZTLMiddle' => [
+				'assert' => '?arg1=value1&arg2=value2',
+				'input'  => '?arg1=value1&zrl=nope&arg2=value2',
+			],
+			'strippedOWTFirst'  => [
+				'assert' => '?arg1=value1',
+				'input'  => '?owt=test&arg1=value1',
+			],
+			'strippedOWTLast'   => [
+				'assert' => '?arg1=value1',
+				'input'  => '?arg1=value1&owt=test',
+			],
+			'strippedOWTMiddle' => [
+				'assert' => '?arg1=value1&arg2=value2',
+				'input'  => '?arg1=value1&owt=test&arg2=value2',
+			],
+		];
+	}
+
+	/**
+	 * Test the ZRL and OWT stripping
+	 *
+	 * @dataProvider dataStripped
+	 */
+	public function testStrippedQueries(string $assert, string $input)
+	{
+		$command = 'test/it';
+
+		$arguments = (new App\Arguments())
+			->determine(['QUERY_STRING' => 'q=' . $command . $input,], ['pagename' => $command]);
+
+		$this->assertEquals($command . $assert, $arguments->getQueryString());
+	}
+
+	/**
+	 * Test that arguments are immutable
+	 */
+	public function testImmutable()
+	{
+		$argument = new App\Arguments();
+
+		$argNew = $argument->determine([], []);
+
+		$this->assertNotSame($argument, $argNew);
+	}
+}

--- a/tests/src/App/ModuleTest.php
+++ b/tests/src/App/ModuleTest.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace Friendica\Test\src\App;
+
+use Friendica\App;
+use Friendica\Core\Config\Configuration;
+use Friendica\LegacyModule;
+use Friendica\Module\PageNotFound;
+use Friendica\Module\WellKnown\HostMeta;
+use Friendica\Test\DatabaseTest;
+
+class ModuleTest extends DatabaseTest
+{
+	private function assertModule(array $assert, App\Module $module)
+	{
+		$this->assertEquals($assert['isBackend'], $module->isBackend());
+		$this->assertEquals($assert['name'], $module->getName());
+		$this->assertEquals($assert['class'], $module->getClassName());
+	}
+
+	/**
+	 * Test the default module mode
+	 */
+	public function testDefault()
+	{
+		$module = new App\Module();
+
+		$this->assertModule([
+			'isBackend' => false,
+			'name'      => App\Module::DEFAULT,
+			'class'     => App\Module::DEFAULT_CLASS,
+		], $module);
+	}
+
+	public function dataModuleName()
+	{
+		return [
+			'default'                   => [
+				'assert' => [
+					'isBackend' => false,
+					'name'      => 'network',
+					'class'     => App\Module::DEFAULT_CLASS,
+				],
+				'args'   => new App\Arguments('network/data/in',
+					'network/data/in',
+					['network', 'data', 'in'],
+					3),
+				'server' => [],
+			],
+			'withStrikeAndPoint'        => [
+				'assert' => [
+					'isBackend' => false,
+					'name'      => 'with_strike_and_point',
+					'class'     => App\Module::DEFAULT_CLASS,
+				],
+				'args'   => new App\Arguments('with-strike.and-point/data/in',
+					'with-strike.and-point/data/in',
+					['with-strike.and-point', 'data', 'in'],
+					3),
+				'server' => [],
+			],
+			'withNothing'               => [
+				'assert' => [
+					'isBackend' => false,
+					'name'      => App\Module::DEFAULT,
+					'class'     => App\Module::DEFAULT_CLASS,
+				],
+				'args'   => new App\Arguments(),
+				'server' => []
+			],
+			'withIndex'                 => [
+				'assert' => [
+					'isBackend' => false,
+					'name'      => App\Module::DEFAULT,
+					'class'     => App\Module::DEFAULT_CLASS,
+				],
+				'args'   => new App\Arguments(),
+				'server' => ['PHP_SELF' => 'index.php']
+			],
+			'withIndexButBackendMod'    => [
+				'assert' => [
+					'isBackend' => false,
+					'name'      => App\Module::BACKEND_MODULES[0],
+					'class'     => App\Module::DEFAULT_CLASS,
+				],
+				'args'   => new App\Arguments(App\Module::BACKEND_MODULES[0] . '/data/in',
+					App\Module::BACKEND_MODULES[0] . '/data/in',
+					[App\Module::BACKEND_MODULES[0], 'data', 'in'],
+					3),
+				'server' => ['PHP_SELF' => 'index.php']
+			],
+			'withNotIndexAndBackendMod' => [
+				'assert' => [
+					'isBackend' => true,
+					'name'      => App\Module::BACKEND_MODULES[0],
+					'class'     => App\Module::DEFAULT_CLASS,
+				],
+				'args'   => new App\Arguments(App\Module::BACKEND_MODULES[0] . '/data/in',
+					App\Module::BACKEND_MODULES[0] . '/data/in',
+					[App\Module::BACKEND_MODULES[0], 'data', 'in'],
+					3),
+				'server' => ['PHP_SELF' => 'daemon.php']
+			],
+			'withFirefoxApp'            => [
+				'assert' => [
+					'isBackend' => false,
+					'name'      => 'login',
+					'class'     => App\Module::DEFAULT_CLASS,
+				],
+				'args'   => new App\Arguments('users/sign_in',
+					'users/sign_in',
+					['users', 'sign_in'],
+					3),
+				'server' => ['PHP_SELF' => 'index.php'],
+			],
+		];
+	}
+
+	/**
+	 * Test the module name and backend determination
+	 *
+	 * @dataProvider dataModuleName
+	 */
+	public function testModuleName(array $assert, App\Arguments $args, array $server)
+	{
+		$module = (new App\Module())->determineModule($args, $server);
+
+		$this->assertModule($assert, $module);
+	}
+
+	public function dataModuleClass()
+	{
+		return [
+			'default' => [
+				'assert'  => App\Module::DEFAULT_CLASS,
+				'name'    => App\Module::DEFAULT,
+				'command' => App\Module::DEFAULT,
+				'privAdd' => false,
+			],
+			'legacy'  => [
+				'assert'  => LegacyModule::class,
+				// API is one of the last modules to switch from legacy to new BaseModule
+				// so this should be a stable test case until we completely switch ;-)
+				'name'    => 'api',
+				'command' => 'api/test/it',
+				'privAdd' => false,
+			],
+			'new'     => [
+				'assert'  => HostMeta::class,
+				'not_required',
+				'command' => '.well-known/host-meta',
+				'privAdd' => false,
+			],
+			'404'     => [
+				'assert'  => PageNotFound::class,
+				'name'    => 'invalid',
+				'command' => 'invalid',
+				'privAdd' => false,
+			]
+		];
+	}
+
+	/**
+	 * Test the determination of the module class
+	 *
+	 * @dataProvider dataModuleClass
+	 */
+	public function testModuleClass($assert, string $name, string $command, bool $privAdd)
+	{
+		$config = \Mockery::mock(Configuration::class);
+		$config->shouldReceive('get')->with('config', 'private_addons', false)->andReturn($privAdd)->atMost()->once();
+
+		$module = (new App\Module($name))->determineClass(new App\Arguments('', $command), new App\Router(), $config);
+
+		$this->assertEquals($assert, $module->getClassName());
+	}
+
+	/**
+	 * Test that modules are immutable
+	 */
+	public function testImmutable()
+	{
+		$module = new App\Module();
+
+		$moduleNew = $module->determineModule(new App\Arguments(), []);
+
+		$this->assertNotSame($moduleNew, $module);
+	}
+}

--- a/tests/src/Console/AutomaticInstallationConsoleTest.php
+++ b/tests/src/Console/AutomaticInstallationConsoleTest.php
@@ -75,7 +75,7 @@ class AutomaticInstallationConsoleTest extends ConsoleTest
 		$l10nMock->shouldReceive('t')->andReturnUsing(function ($args) { return $args; });
 
 		$this->dice->shouldReceive('create')
-		           ->with(L10n::class)
+		           ->with(L10n::class, [])
 		           ->andReturn($l10nMock);
 
 		BaseObject::setDependencyInjection($this->dice);

--- a/tests/src/Console/ConfigConsoleTest.php
+++ b/tests/src/Console/ConfigConsoleTest.php
@@ -25,9 +25,7 @@ class ConfigConsoleTest extends ConsoleTest
 			]
 		]);
 
-		$this->appMode = \Mockery::mock(App\Mode::class);
-		$this->appMode->shouldReceive('has')
-		        ->andReturn(true);
+		$this->appMode = new App\Mode(15);
 
 		$this->configMock = \Mockery::mock(Configuration::class);
 	}

--- a/tests/src/Content/Text/BBCodeTest.php
+++ b/tests/src/Content/Text/BBCodeTest.php
@@ -43,13 +43,13 @@ class BBCodeTest extends MockedTest
 		$l10nMock = \Mockery::mock(L10n::class);
 		$l10nMock->shouldReceive('t')->withAnyArgs()->andReturnUsing(function ($args) { return $args; });
 		$this->dice->shouldReceive('create')
-		           ->with(L10n::class)
+		           ->with(L10n::class, [])
 		           ->andReturn($l10nMock);
 
 		$baseUrlMock = \Mockery::mock(BaseURL::class);
 		$baseUrlMock->shouldReceive('get')->withAnyArgs()->andReturn('friendica.local');
 		$this->dice->shouldReceive('create')
-		           ->with(BaseURL::class)
+		           ->with(BaseURL::class, [])
 		           ->andReturn($baseUrlMock);
 	}
 

--- a/tests/src/Core/InstallerTest.php
+++ b/tests/src/Core/InstallerTest.php
@@ -35,7 +35,7 @@ class InstallerTest extends MockedTest
 		$dice = $dice->addRules(include __DIR__ . '/../../../static/dependencies.config.php');
 
 		$dice->shouldReceive('create')
-		           ->with(\Friendica\Core\L10n\L10n::class)
+		           ->with(\Friendica\Core\L10n\L10n::class, [])
 		           ->andReturn($this->l10nMock);
 
 		BaseObject::setDependencyInjection($dice);

--- a/tests/src/Core/L10n/L10nTest.php
+++ b/tests/src/Core/L10n/L10nTest.php
@@ -1,0 +1,306 @@
+<?php
+
+namespace Friendica\Test\src\Core\L10n;
+
+use Dice\Dice;
+use Friendica\App;
+use Friendica\BaseObject;
+use Friendica\Core\Config\Cache\ConfigCache;
+use Friendica\Core\Config\Configuration;
+use Friendica\Core\L10n\L10n;
+use Friendica\Database\Database;
+use Friendica\Test\MockedTest;
+use Friendica\Util\Profiler;
+
+class L10nTest extends MockedTest
+{
+	private function assertL10n(string $assertLang, array $assertStrings, L10n $l10n)
+	{
+		$this->assertEquals($assertLang, $l10n->getCurrentLang());
+
+		foreach ($assertStrings as $key => $data) {
+			$this->assertEquals($data['assert'], $l10n->t($key, ...$data['args']));
+		}
+	}
+
+	private function assertL10nPlural(string $assertLang, array $assertStrings, L10n $l10n)
+	{
+		$this->assertEquals($assertLang, $l10n->getCurrentLang());
+
+		foreach ($assertStrings as $key => $data) {
+			$this->assertEquals($data['assert'], $l10n->tt($key, $data['plural'], $data['count']));
+		}
+	}
+
+	/**
+	 * Test the default language setting
+	 */
+	public function testDefault()
+	{
+		$l10n = new L10n();
+
+		$this->assertL10n(L10n::DEFAULT_LANG, ['Thank You,' => ['assert' => 'Thank You,', 'args' => []]], $l10n);
+	}
+
+	/**
+	 * Test the default language loading
+	 */
+	public function testLoadDefault()
+	{
+		$l10n = new L10n();
+		$l10n->load();
+
+		$this->assertL10n(L10n::DEFAULT_LANG, ['Thank You,' => ['assert' => 'Thank You,', 'args' => []]], $l10n);
+	}
+
+	public function dataLangSettings()
+	{
+		return [
+			'withoutArg' => [
+				'lang'    => 'de',
+				'strings' => [
+					'Thank You,' => [
+						'assert' => 'Danke,',
+						'args' => [],
+					],
+				],
+			],
+			'oneArg' => [
+				'lang'    => 'es',
+				'strings' => [
+					'%s and You' => [
+						'assert' => 'Philipp y Tú',
+						'args' => ['Philipp'],
+					],
+				],
+			],
+			'twoArgs' => [
+				'lang'    => 'fr',
+				'strings' => [
+					'%1$s tagged you at %2$s' => [
+						'assert' => 'Philipp vous a étiqueté sur MrPetovan',
+						'args' => ['Philipp', 'MrPetovan'],
+					],
+				],
+			],
+			'empty' => [
+				'lang' => 'pl',
+				'string' => [
+					'' => [
+						'assert' => '',
+						'args' => [],
+					],
+				],
+			],
+			'unknownLang' => [
+				'lang' => 'not',
+				'string' => [
+					'Test' => [
+						'assert' => 'Test',
+						'args' => [],
+					],
+				],
+			],
+		];
+	}
+
+	/**
+	 * Test the singular function
+	 *
+	 * @dataProvider dataLangSettings
+	 */
+	public function testLoadedT(string $lang, array $strings)
+	{
+		$l10n = new L10n($lang);
+		$l10n->load();
+
+		$this->assertL10n($lang, $strings, $l10n);
+	}
+
+	public function dataPlural()
+	{
+		return [
+			'withPlural' => [
+				'lang' => 'de',
+				'strings' => [
+					'%d required parameter was not found at the given location' => [
+						'assert' => '2 benötigte Parameter wurden an der angegebenen Stelle nicht gefunden',
+						'plural' => '%d required parameters were not found at the given location',
+						'count' => 2,
+					],
+				],
+			],
+			'unknownLang' => [
+				'lang' => 'not',
+				'strings' => [
+					'Profile' => [
+						'assert' => 'Two Profiles',
+						'plural' => 'Two Profiles', // custom plural..
+						'count' => 2,
+					],
+				],
+			],
+			'unknownSingular' => [
+				'lang' => 'not',
+				'strings' => [
+					'Profile' => [
+						'assert' => 'Profile',
+						'plural' => 'Two Profiles', // custom plural..
+						'count' => 1,
+					],
+				],
+			],
+		];
+	}
+
+	/**
+	 * Test the plural function
+	 *
+	 * @dataProvider dataPlural
+	 */
+	public function testLoadedTT(string $lang, array $strings)
+	{
+		$l10n = new L10n($lang);
+		$l10n->load();
+
+		$this->assertL10nPlural($lang, $strings, $l10n);
+	}
+
+	public function testUserLoading()
+	{
+		$this->markTestSkipped('Until SESSION is a class');
+
+		$l10n = new L10n();
+
+		$dba = \Mockery::mock(Database::class)->makePartial();
+		$server = [];
+		$get = [];
+
+		$dice = \Mockery::mock(Dice::class);
+
+		$configCache = new ConfigCache(['system' => [ 'profiler' => false], 'rendertime' => [ 'callstack' => false]]);
+		$profiler = new Profiler($configCache);
+
+		$module = new App\Module(15);
+
+		$dice->shouldReceive('create')->with(Profiler::class, [])->andReturn($profiler);
+		$dice->shouldReceive('create')->with(App\Module::class, [])->andReturn($module);
+
+		BaseObject::setDependencyInjection($dice);
+
+		$userL10n = $l10n->userLanguage($dba, $module, $server, $get);
+
+		// Immutable test
+		$this->assertNotSame($l10n, $userL10n);
+	}
+
+
+	public function dataDetectLang()
+	{
+		return [
+			'empty' => [
+				'assertLang' => L10n::DEFAULT_LANG,
+				'configLang' => L10n::DEFAULT_LANG,
+				'configDefault' => L10n::DEFAULT_LANG,
+				'server' => [],
+				'get' => [],
+				'addons' => '',
+			],
+			'differentConfig' => [
+				'assertLang' => 'pl',
+				'configLang' => 'pl',
+				'configDefault' => L10n::DEFAULT_LANG,
+				'server' => [],
+				'get' => [],
+				'addons' => '',
+			],
+			'serverDefault' => [
+				'assertLAng' => 'nl',
+				'configLang' => 'nl',
+				'configDefault' => 'nl',
+				'server' => [
+					'HTTP_ACCEPT_LANGUAGE' => 'nl',
+				],
+				'get' => [],
+				'addons' => '',
+			],
+			'serverMultiDefaultEn' => [
+				'assertLAng' => 'en',
+				'configLang' => 'en',
+				'configDefault' => 'en',
+				'server' => [
+					'HTTP_ACCEPT_LANGUAGE' => 'en,en-US,en-AU;q=0.8,fr;q=0.6,en-GB;q=0.4',
+				],
+				'get' => [],
+				'addons' => '',
+			],
+			'serverMultiDefaultQ' => [
+				'assertLAng' => 'fr',
+				'configLang' => 'fr',
+				'configDefault' => 'fr',
+				'server' => [
+					// q=0.8 maps to fr
+					'HTTP_ACCEPT_LANGUAGE' => 'q=0.8,fr;q=0.6,q=0.4',
+				],
+				'get' => [],
+				'addons' => '',
+			],
+			'getOverride' => [
+				'assertLAng' => L10n::DEFAULT_LANG,
+				'configLang' => L10n::DEFAULT_LANG,
+				'configDefault' => L10n::DEFAULT_LANG,
+				'server' => [
+					// q=0.8 maps to fr
+					'HTTP_ACCEPT_LANGUAGE' => 'q=0.8,fr;q=0.6,q=0.4',
+				],
+				'get' => [
+					// get adds the default lang, which is preferred
+					'lang' => L10n::DEFAULT_LANG,
+				],
+				'addons' => '',
+			],
+			'loadAddonsToo' => [
+				'assertLAng' => L10n::DEFAULT_LANG,
+				'configLang' => L10n::DEFAULT_LANG,
+				'configDefault' => L10n::DEFAULT_LANG,
+				'server' => [
+					// q=0.8 maps to fr
+					'HTTP_ACCEPT_LANGUAGE' => 'q=0.8,fr;q=0.6,q=0.4',
+				],
+				'get' => [
+					// get adds the default lang, which is preferred
+					'lang' => L10n::DEFAULT_LANG,
+				],
+				'addons' => 'blogger',
+			],
+		];
+	}
+
+	/**
+	 * Test the language detection and system loading
+	 *
+	 * @dataProvider dataDetectLang
+	 */
+	public function testSystemLoading(string $assertLang, $configLang, $configDefault, array $server, array $get, string $addons)
+	{
+		$l10n = new L10n();
+
+		// mock the addons
+		$dba = \Mockery::mock(Database::class)->makePartial();
+		$dba->shouldReceive('select')
+		    ->with('addon', ['name'], ['installed' => true])
+		    ->andReturn($addons);
+
+		// Mock the config setting
+		$config = \Mockery::mock(Configuration::class);
+		$config->shouldReceive('get')
+		       ->with('system', 'language', $configDefault)
+		       ->andReturn($configLang);
+
+		$sysL10n = $l10n->systemLanguage($config, $dba, $server, $get);
+
+		$this->assertNotSame($l10n, $sysL10n);
+
+		$this->assertEquals($assertLang, $sysL10n->getCurrentLang());
+	}
+}

--- a/tests/src/Core/Lock/SemaphoreLockTest.php
+++ b/tests/src/Core/Lock/SemaphoreLockTest.php
@@ -18,14 +18,14 @@ class SemaphoreLockTest extends LockTest
 
 		$app = \Mockery::mock(App::class);
 		$app->shouldReceive('getHostname')->andReturn('friendica.local');
-		$dice->shouldReceive('create')->with(App::class)->andReturn($app);
+		$dice->shouldReceive('create')->with(App::class, [])->andReturn($app);
 
 		$configMock = \Mockery::mock(Configuration::class);
 		$configMock
 			->shouldReceive('get')
 			->with('system', 'temppath', NULL, false)
 			->andReturn('/tmp/');
-		$dice->shouldReceive('create')->with(Configuration::class)->andReturn($configMock);
+		$dice->shouldReceive('create')->with(Configuration::class, [])->andReturn($configMock);
 
 		// @todo Because "get_temppath()" is using static methods, we have to initialize the BaseObject
 		BaseObject::setDependencyInjection($dice);

--- a/tests/src/Network/CurlResultTest.php
+++ b/tests/src/Network/CurlResultTest.php
@@ -23,7 +23,7 @@ class CurlResultTest extends TestCase
 
 		$logger = new NullLogger();
 		$dice->shouldReceive('create')
-		           ->with(LoggerInterface::class)
+		           ->with(LoggerInterface::class, [])
 		           ->andReturn($logger);
 
 		BaseObject::setDependencyInjection($dice);


### PR DESCRIPTION
- With tests
- With dependency loading

ToDo:
- [x] Tested installer
- [x] Added a lot of tests
- [x] Tested on local node
- [ ] Tested on friendica.philipp.info (running for 24hours)
- [ ] Fixing API-Test (overwriting  argc/argv)

Prerequisite for #6998 , because we now can use L10n without loading the whole database, Session, Hooks, Modules, ... with it.