### PR TITLE
Worker: The retrial value can now skip retrial levels

### DIFF
--- a/src/Core/Worker.php
+++ b/src/Core/Worker.php
@@ -1234,7 +1234,8 @@ class Worker
 		$id = $queue['id'];
 		$priority = $queue['priority'];
 
-		$max_level = 15;
+		$max_level = Config::get('system', 'worker_defer_limit');
+
 		$new_retrial = self::getNextRetrial($queue, $max_level);
 
 		if ($new_retrial > $max_level) {

--- a/static/defaults.config.php
+++ b/static/defaults.config.php
@@ -427,6 +427,10 @@ return [
 		// Setting 0 would allow maximum worker queues at all times, which is not recommended.
 		'worker_load_exponent' => 3,
 
+		// worker_defer_limit (Integer)
+		// Per default the systems tries delivering for 15 times before dropping it.
+		'worker_defer_limit' => 15,
+
 		// xrd_timeout (Integer)
 		// Timeout in seconds for fetching the XRD links.
 		'xrd_timeout' => 20,


### PR DESCRIPTION
When a delivery process doesn't work for the first time, we do defer it. We try 15 times with increasing wait intervals until we ditch that task. On highly stressed systems (lot of users, lots of deliveries) this can sum up to a huge amount of waiting jobs. And on one of my systems this lead to jobs that had been created more than a month ago and were still waiting for retry.

We now don't necessarily retry a delivery for 15 times, but we do set the retrial value depending on how old this job really is and which retrial level it would had achieved when delivery had been without delays. This means that on fast systems you won't recognize a difference. But large ones (or slow ones) will now skip levels.