### PR TITLE
Add Frontend & Process class

### DIFF
--- a/index.php
+++ b/index.php
@@ -5,6 +5,7 @@
  */
 
 use Dice\Dice;
+use Friendica\Core\Frontend;
 
 if (!file_exists(__DIR__ . '/vendor/autoload.php')) {
 	die('Vendor path not found. Please execute "bin/composer.phar --no-dev install" on the command line in the web root.');
@@ -16,10 +17,4 @@ $dice = (new Dice())->addRules(include __DIR__ . '/static/dependencies.config.ph
 
 \Friendica\BaseObject::setDependencyInjection($dice);
 
-$a = \Friendica\BaseObject::getApp();
-
-$a->runFrontend(
-	$dice->create(\Friendica\App\Module::class),
-	$dice->create(\Friendica\App\Router::class),
-	$dice->create(\Friendica\Core\Config\PConfiguration::class)
-);
+$dice->create(Frontend::class);

--- a/index.php
+++ b/index.php
@@ -18,4 +18,4 @@ $dice = (new Dice())->addRules(include __DIR__ . '/static/dependencies.config.ph
 
 $a = \Friendica\BaseObject::getApp();
 
-$a->runFrontend();
+$a->runFrontend($dice->create(\Friendica\App\Module::class), $dice->create(\Friendica\App\Router::class), $dice->create(\Friendica\Core\Config\PConfiguration::class));

--- a/index.php
+++ b/index.php
@@ -18,4 +18,8 @@ $dice = (new Dice())->addRules(include __DIR__ . '/static/dependencies.config.ph
 
 $a = \Friendica\BaseObject::getApp();
 
-$a->runFrontend($dice->create(\Friendica\App\Module::class), $dice->create(\Friendica\App\Router::class), $dice->create(\Friendica\Core\Config\PConfiguration::class));
+$a->runFrontend(
+	$dice->create(\Friendica\App\Module::class),
+	$dice->create(\Friendica\App\Router::class),
+	$dice->create(\Friendica\Core\Config\PConfiguration::class)
+);

--- a/src/App.php
+++ b/src/App.php
@@ -5,26 +5,19 @@
 namespace Friendica;
 
 use Detection\MobileDetect;
-use DOMDocument;
-use DOMXPath;
 use Exception;
 use Friendica\App\Arguments;
-use Friendica\App\Module;
 use Friendica\Core\Config\Cache\ConfigCache;
 use Friendica\Core\Config\Configuration;
-use Friendica\Core\Config\PConfiguration;
+use Friendica\Core\Frontend;
 use Friendica\Core\L10n\L10n;
-use Friendica\Core\System;
+use Friendica\Core\Process;
 use Friendica\Core\Theme;
 use Friendica\Database\Database;
 use Friendica\Database\DBA;
-use Friendica\Model\Profile;
-use Friendica\Module\Login;
-use Friendica\Module\Special\HTTPException as ModuleHTTPException;
 use Friendica\Network\HTTPException;
 use Friendica\Util\BaseURL;
 use Friendica\Util\ConfigFileLoader;
-use Friendica\Util\HTTPSignature;
 use Friendica\Util\Profiler;
 use Friendica\Util\Strings;
 use Psr\Log\LoggerInterface;
@@ -46,7 +39,12 @@ class App
 {
 	/** @deprecated 2019.09 - use App\Arguments->getQueryString() */
 	public $query_string = '';
-	public $page = [];
+	/**
+	 * @var Frontend The Frontend Page
+	 *               All Parts of the frontend page are per array accessible (compatibility)
+	 * @deprecated 2019.09 - use Frontend instead
+	 */
+	public $page;
 	public $profile;
 	public $profile_uid;
 	public $user;
@@ -80,9 +78,6 @@ class App
 	public $force_max_items = 0;
 	public $theme_events_in_profile = true;
 
-	public $stylesheets = [];
-	public $footerScripts = [];
-
 	/**
 	 * @var App\Mode The Mode of the Application
 	 */
@@ -97,13 +92,6 @@ class App
 	 * @var BaseURL
 	 */
 	private $baseURL;
-
-	/**
-	 * @var bool true, if the call is from an backend node (f.e. worker)
-	 *
-	 * @deprecated 2019.09 - use App\Module->isBackend() instead
-	 */
-	private $isBackend;
 
 	/**
 	 * @var string The name of the current theme
@@ -149,11 +137,10 @@ class App
 	 * @var App\Arguments
 	 */
 	private $args;
-
 	/**
-	 * @var App\Module
+	 * @var Process
 	 */
-	private $moduleClass;
+	private $process;
 
 	/**
 	 * Returns the current config cache of this node
@@ -227,37 +214,21 @@ class App
 	}
 
 	/**
-	 * Register a stylesheet file path to be included in the <head> tag of every page.
-	 * Inclusion is done in App->initHead().
-	 * The path can be absolute or relative to the Friendica installation base folder.
-	 *
-	 * @see initHead()
-	 *
-	 * @param string $path
+	 * @deprecated 2019.09 - use Frontend->registerStylesheet instead
+	 * @see Frontend::registerStylesheet()
 	 */
 	public function registerStylesheet($path)
 	{
-		if (mb_strpos($path, $this->getBasePath() . DIRECTORY_SEPARATOR) === 0) {
-			$path = mb_substr($path, mb_strlen($this->getBasePath() . DIRECTORY_SEPARATOR));
-		}
-
-		$this->stylesheets[] = trim($path, '/');
+		$this->page->registerStylesheet($path);
 	}
 
 	/**
-	 * Register a javascript file path to be included in the <footer> tag of every page.
-	 * Inclusion is done in App->initFooter().
-	 * The path can be absolute or relative to the Friendica installation base folder.
-	 *
-	 * @see initFooter()
-	 *
-	 * @param string $path
+	 * @deprecated 2019.09 - use Frontend->registerFooterScript instead
+	 * @see Frontend::registerFooterScript()
 	 */
 	public function registerFooterScript($path)
 	{
-		$url = str_replace($this->getBasePath() . DIRECTORY_SEPARATOR, '', $path);
-
-		$this->footerScripts[] = trim($url, '/');
+		$this->page->registerFooterScript($path);
 	}
 
 	public $queue;
@@ -276,7 +247,7 @@ class App
 	 *
 	 * @throws Exception if the Basepath is not usable
 	 */
-	public function __construct(Database $database, Configuration $config, App\Mode $mode, App\Router $router, BaseURL $baseURL, LoggerInterface $logger, Profiler $profiler, L10n $l10n, Arguments $args, Module $module)
+	public function __construct(Database $database, Configuration $config, App\Mode $mode, App\Router $router, BaseURL $baseURL, LoggerInterface $logger, Profiler $profiler, L10n $l10n, Arguments $args, Frontend $frontend, Process $process)
 	{
 		$this->database = $database;
 		$this->config   = $config;
@@ -287,7 +258,8 @@ class App
 		$this->logger   = $logger;
 		$this->l10n     = $l10n;
 		$this->args = $args;
-		$this->isBackend = $module->isBackend();
+		$this->page = $frontend;
+		$this->process = $process;
 
 		$this->profiler->reset();
 
@@ -328,7 +300,7 @@ class App
 	 */
 	public function reload()
 	{
-		if ($this->getMode()->has(App\Mode::DBAVAILABLE)) {
+		if ($this->mode->has(App\Mode::DBAVAILABLE)) {
 			$this->profiler->update($this->config);
 
 			Core\Hook::loadHooks();
@@ -358,17 +330,6 @@ class App
 		if ($this->timezone) {
 			date_default_timezone_set($this->timezone);
 		}
-	}
-
-	/**
-	 * Returns the scheme of the current call
-	 * @return string
-	 *
-	 * @deprecated 2019.06 - use BaseURL->getScheme() instead
-	 */
-	public function getScheme()
-	{
-		return $this->baseURL->getScheme();
 	}
 
 	/**
@@ -424,119 +385,6 @@ class App
 	}
 
 	/**
-	 * Initializes App->page['htmlhead'].
-	 *
-	 * Includes:
-	 * - Page title
-	 * - Favicons
-	 * - Registered stylesheets (through App->registerStylesheet())
-	 * - Infinite scroll data
-	 * - head.tpl template
-	 */
-	private function initHead(App\Module $module, PConfiguration $pconfig)
-	{
-		$interval = ((local_user()) ? $pconfig->get(local_user(), 'system', 'update_interval') : 40000);
-
-		// If the update is 'deactivated' set it to the highest integer number (~24 days)
-		if ($interval < 0) {
-			$interval = 2147483647;
-		}
-
-		if ($interval < 10000) {
-			$interval = 40000;
-		}
-
-		// Default title: current module called
-		if (empty($this->page['title']) && $module->getName()) {
-			$this->page['title'] = ucfirst($module->getName());
-		}
-
-		// Prepend the sitename to the page title
-		$this->page['title'] = $this->config->get('config', 'sitename', '') . (!empty($this->page['title']) ? ' | ' . $this->page['title'] : '');
-
-		if (!empty(Core\Renderer::$theme['stylesheet'])) {
-			$stylesheet = Core\Renderer::$theme['stylesheet'];
-		} else {
-			$stylesheet = $this->getCurrentThemeStylesheetPath();
-		}
-
-		$this->registerStylesheet($stylesheet);
-
-		$shortcut_icon = $this->config->get('system', 'shortcut_icon');
-		if ($shortcut_icon == '') {
-			$shortcut_icon = 'images/friendica-32.png';
-		}
-
-		$touch_icon = $this->config->get('system', 'touch_icon');
-		if ($touch_icon == '') {
-			$touch_icon = 'images/friendica-128.png';
-		}
-
-		Core\Hook::callAll('head', $this->page['htmlhead']);
-
-		$tpl = Core\Renderer::getMarkupTemplate('head.tpl');
-		/* put the head template at the beginning of page['htmlhead']
-		 * since the code added by the modules frequently depends on it
-		 * being first
-		 */
-		$this->page['htmlhead'] = Core\Renderer::replaceMacros($tpl, [
-			'$local_user'      => local_user(),
-			'$generator'       => 'Friendica' . ' ' . FRIENDICA_VERSION,
-			'$delitem'         => $this->l10n->t('Delete this item?'),
-			'$update_interval' => $interval,
-			'$shortcut_icon'   => $shortcut_icon,
-			'$touch_icon'      => $touch_icon,
-			'$block_public'    => intval($this->config->get('system', 'block_public')),
-			'$stylesheets'     => $this->stylesheets,
-		]) . $this->page['htmlhead'];
-	}
-
-	/**
-	 * Initializes App->page['footer'].
-	 *
-	 * Includes:
-	 * - Javascript homebase
-	 * - Mobile toggle link
-	 * - Registered footer scripts (through App->registerFooterScript())
-	 * - footer.tpl template
-	 */
-	private function initFooter()
-	{
-		// If you're just visiting, let javascript take you home
-		if (!empty($_SESSION['visitor_home'])) {
-			$homebase = $_SESSION['visitor_home'];
-		} elseif (local_user()) {
-			$homebase = 'profile/' . $this->user['nickname'];
-		}
-
-		if (isset($homebase)) {
-			$this->page['footer'] .= '<script>var homebase="' . $homebase . '";</script>' . "\n";
-		}
-
-		/*
-		 * Add a "toggle mobile" link if we're using a mobile device
-		 */
-		if ($this->is_mobile || $this->is_tablet) {
-			if (isset($_SESSION['show-mobile']) && !$_SESSION['show-mobile']) {
-				$link = 'toggle_mobile?address=' . urlencode(curPageURL());
-			} else {
-				$link = 'toggle_mobile?off=1&address=' . urlencode(curPageURL());
-			}
-			$this->page['footer'] .= Core\Renderer::replaceMacros(Core\Renderer::getMarkupTemplate("toggle_mobile_footer.tpl"), [
-				'$toggle_link' => $link,
-				'$toggle_text' => $this->l10n->t('toggle mobile')
-			]);
-		}
-
-		Core\Hook::callAll('footer', $this->page['footer']);
-
-		$tpl = Core\Renderer::getMarkupTemplate('footer.tpl');
-		$this->page['footer'] = Core\Renderer::replaceMacros($tpl, [
-			'$footerScripts' => $this->footerScripts,
-		]) . $this->page['footer'];
-	}
-
-	/**
 	 * @brief Removes the base url from an url. This avoids some mixed content problems.
 	 *
 	 * @param string $origURL
@@ -576,162 +424,39 @@ class App
 	}
 
 	/**
-	 * @brief Checks if the maximum number of database processes is reached
-	 *
-	 * @return bool Is the limit reached?
+	 * @deprecated 2019.09 - use Process->isMaxProcessReached() instead
+	 * @see Process::isMaxProcessesReached()
 	 */
 	public function isMaxProcessesReached()
 	{
-		// Deactivated, needs more investigating if this check really makes sense
-		return false;
-
-		/*
-		 * Commented out to suppress static analyzer issues
-		 *
-		if ($this->is_backend()) {
-			$process = 'backend';
-			$max_processes = $this->config->get('system', 'max_processes_backend');
-			if (intval($max_processes) == 0) {
-				$max_processes = 5;
-			}
-		} else {
-			$process = 'frontend';
-			$max_processes = $this->config->get('system', 'max_processes_frontend');
-			if (intval($max_processes) == 0) {
-				$max_processes = 20;
-			}
-		}
-
-		$processlist = DBA::processlist();
-		if ($processlist['list'] != '') {
-			Core\Logger::log('Processcheck: Processes: ' . $processlist['amount'] . ' - Processlist: ' . $processlist['list'], Core\Logger::DEBUG);
-
-			if ($processlist['amount'] > $max_processes) {
-				Core\Logger::log('Processcheck: Maximum number of processes for ' . $process . ' tasks (' . $max_processes . ') reached.', Core\Logger::DEBUG);
-				return true;
-			}
-		}
-		return false;
-		 */
+		return $this->process->isMaxProcessesReached();
 	}
 
 	/**
-	 * @brief Checks if the minimal memory is reached
-	 *
-	 * @return bool Is the memory limit reached?
-	 * @throws HTTPException\InternalServerErrorException
+	 * @deprecated 2019.09 - use Process->isMinMemoryReached instead
+	 * @see Process::isMinMemoryReached()
 	 */
 	public function isMinMemoryReached()
 	{
-		$min_memory = $this->config->get('system', 'min_memory', 0);
-		if ($min_memory == 0) {
-			return false;
-		}
-
-		if (!is_readable('/proc/meminfo')) {
-			return false;
-		}
-
-		$memdata = explode("\n", file_get_contents('/proc/meminfo'));
-
-		$meminfo = [];
-		foreach ($memdata as $line) {
-			$data = explode(':', $line);
-			if (count($data) != 2) {
-				continue;
-			}
-			list($key, $val) = $data;
-			$meminfo[$key] = (int) trim(str_replace('kB', '', $val));
-			$meminfo[$key] = (int) ($meminfo[$key] / 1024);
-		}
-
-		if (!isset($meminfo['MemFree'])) {
-			return false;
-		}
-
-		$free = $meminfo['MemFree'];
-
-		$reached = ($free < $min_memory);
-
-		if ($reached) {
-			Core\Logger::log('Minimal memory reached: ' . $free . '/' . $meminfo['MemTotal'] . ' - limit ' . $min_memory, Core\Logger::DEBUG);
-		}
-
-		return $reached;
+		return $this->process->isMinMemoryReached();
 	}
 
 	/**
-	 * @brief Checks if the maximum load is reached
-	 *
-	 * @return bool Is the load reached?
-	 * @throws HTTPException\InternalServerErrorException
+	 * @deprecated 2019.09 - use Process->isMaxLoadReached instead
+	 * @see Process::isMaxLoadReached()
 	 */
 	public function isMaxLoadReached()
 	{
-		if ($this->isBackend) {
-			$process = 'backend';
-			$maxsysload = intval($this->config->get('system', 'maxloadavg'));
-			if ($maxsysload < 1) {
-				$maxsysload = 50;
-			}
-		} else {
-			$process = 'frontend';
-			$maxsysload = intval($this->config->get('system', 'maxloadavg_frontend'));
-			if ($maxsysload < 1) {
-				$maxsysload = 50;
-			}
-		}
-
-		$load = Core\System::currentLoad();
-		if ($load) {
-			if (intval($load) > $maxsysload) {
-				Core\Logger::log('system: load ' . $load . ' for ' . $process . ' tasks (' . $maxsysload . ') too high.');
-				return true;
-			}
-		}
-		return false;
+		return $this->process->isMaxLoadReached();
 	}
 
 	/**
-	 * Executes a child process with 'proc_open'
-	 *
-	 * @param string $command The command to execute
-	 * @param array  $args    Arguments to pass to the command ( [ 'key' => value, 'key2' => value2, ... ]
-	 * @throws HTTPException\InternalServerErrorException
+	 * @deprecated 2019.09 - use Process->run() instead
+	 * @see Process::run()
 	 */
 	public function proc_run($command, $args)
 	{
-		if (!function_exists('proc_open')) {
-			return;
-		}
-
-		$cmdline = $this->config->get('config', 'php_path', 'php') . ' ' . escapeshellarg($command);
-
-		foreach ($args as $key => $value) {
-			if (!is_null($value) && is_bool($value) && !$value) {
-				continue;
-			}
-
-			$cmdline .= ' --' . $key;
-			if (!is_null($value) && !is_bool($value)) {
-				$cmdline .= ' ' . $value;
-			}
-		}
-
-		if ($this->isMinMemoryReached()) {
-			return;
-		}
-
-		if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
-			$resource = proc_open('cmd /c start /b ' . $cmdline, [], $foo, $this->getBasePath());
-		} else {
-			$resource = proc_open($cmdline . ' &', [], $foo, $this->getBasePath());
-		}
-		if (!is_resource($resource)) {
-			Core\Logger::log('We got no resource for command ' . $cmdline, Core\Logger::DEBUG);
-			return;
-		}
-		proc_close($resource);
+		$this->process->run($command, $args);
 	}
 
 	/**
@@ -868,334 +593,12 @@ class App
 	}
 
 	/**
-	 * Sets the base url for use in cmdline programs which don't have
-	 * $_SERVER variables
-	 */
-	public function checkURL()
-	{
-		$url = $this->config->get('system', 'url');
-
-		// if the url isn't set or the stored url is radically different
-		// than the currently visited url, store the current value accordingly.
-		// "Radically different" ignores common variations such as http vs https
-		// and www.example.com vs example.com.
-		// We will only change the url to an ip address if there is no existing setting
-
-		if (empty($url) || (!Util\Strings::compareLink($url, $this->getBaseURL())) && (!preg_match("/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/", $this->baseURL->getHostname()))) {
-			$this->config->set('system', 'url', $this->getBaseURL());
-		}
-	}
-
-	/**
-	 * Frontend App script
-	 *
-	 * The App object behaves like a container and a dispatcher at the same time, including a representation of the
-	 * request and a representation of the response.
-	 *
-	 * This probably should change to limit the size of this monster method.
-	 *
-	 * @param App\Module $module The determined module
-	 */
-	public function runFrontend(App\Module $module, App\Router $router, PConfiguration $pconfig)
-	{
-		$moduleName = $module->getName();
-
-		try {
-			// Missing DB connection: ERROR
-			if ($this->getMode()->has(App\Mode::LOCALCONFIGPRESENT) && !$this->getMode()->has(App\Mode::DBAVAILABLE)) {
-				throw new HTTPException\InternalServerErrorException('Apologies but the website is unavailable at the moment.');
-			}
-
-			// Max Load Average reached: ERROR
-			if ($this->isMaxProcessesReached() || $this->isMaxLoadReached()) {
-				header('Retry-After: 120');
-				header('Refresh: 120; url=' . $this->baseURL->get() . "/" . $this->args->getQueryString());
-
-				throw new HTTPException\ServiceUnavailableException('The node is currently overloaded. Please try again later.');
-			}
-
-			if (!$this->getMode()->isInstall()) {
-				// Force SSL redirection
-				if ($this->baseURL->checkRedirectHttps()) {
-					System::externalRedirect($this->baseURL->get() . '/' . $this->args->getQueryString());
-				}
-
-				Core\Session::init();
-				Core\Hook::callAll('init_1');
-			}
-
-			// Exclude the backend processes from the session management
-			if (!$module->isBackend()) {
-				$stamp1 = microtime(true);
-				session_start();
-				$this->profiler->saveTimestamp($stamp1, 'parser', Core\System::callstack());
-				$this->l10n->setSessionVariable();
-				$this->l10n->setLangFromSession();
-			} else {
-				$_SESSION = [];
-				Core\Worker::executeIfIdle();
-			}
-
-			if ($this->getMode()->isNormal()) {
-				$requester = HTTPSignature::getSigner('', $_SERVER);
-				if (!empty($requester)) {
-					Profile::addVisitorCookieForHandle($requester);
-				}
-			}
-
-			// ZRL
-			if (!empty($_GET['zrl']) && $this->getMode()->isNormal()) {
-				if (!local_user()) {
-					// Only continue when the given profile link seems valid
-					// Valid profile links contain a path with "/profile/" and no query parameters
-					if ((parse_url($_GET['zrl'], PHP_URL_QUERY) == "") &&
-						strstr(parse_url($_GET['zrl'], PHP_URL_PATH), "/profile/")) {
-						if (Core\Session::get('visitor_home') != $_GET["zrl"]) {
-							Core\Session::set('my_url', $_GET['zrl']);
-							Core\Session::set('authenticated', 0);
-						}
-
-						Model\Profile::zrlInit($this);
-					} else {
-						// Someone came with an invalid parameter, maybe as a DDoS attempt
-						// We simply stop processing here
-						Core\Logger::log("Invalid ZRL parameter " . $_GET['zrl'], Core\Logger::DEBUG);
-						throw new HTTPException\ForbiddenException();
-					}
-				}
-			}
-
-			if (!empty($_GET['owt']) && $this->getMode()->isNormal()) {
-				$token = $_GET['owt'];
-				Model\Profile::openWebAuthInit($token);
-			}
-
-			Login::sessionAuth();
-
-			if (empty($_SESSION['authenticated'])) {
-				header('X-Account-Management-Status: none');
-			}
-
-			$_SESSION['sysmsg']       = Core\Session::get('sysmsg', []);
-			$_SESSION['sysmsg_info']  = Core\Session::get('sysmsg_info', []);
-			$_SESSION['last_updated'] = Core\Session::get('last_updated', []);
-
-			/*
-			 * check_config() is responsible for running update scripts. These automatically
-			 * update the DB schema whenever we push a new one out. It also checks to see if
-			 * any addons have been added or removed and reacts accordingly.
-			 */
-
-			// in install mode, any url loads install module
-			// but we need "view" module for stylesheet
-			if ($this->getMode()->isInstall() && $moduleName !== 'install') {
-				$this->internalRedirect('install');
-			} elseif (!$this->getMode()->isInstall() && !$this->getMode()->has(App\Mode::MAINTENANCEDISABLED) && $moduleName !== 'maintenance') {
-				$this->internalRedirect('maintenance');
-			} else {
-				$this->checkURL();
-				Core\Update::check($this->getBasePath(), false, $this->getMode());
-				Core\Addon::loadAddons();
-				Core\Hook::loadHooks();
-			}
-
-			$this->page = [
-				'aside' => '',
-				'bottom' => '',
-				'content' => '',
-				'footer' => '',
-				'htmlhead' => '',
-				'nav' => '',
-				'page_title' => '',
-				'right_aside' => '',
-				'template' => '',
-				'title' => ''
-			];
-
-			// Compatibility with the Android Diaspora client
-			if ($moduleName == 'stream') {
-				$this->internalRedirect('network?order=post');
-			}
-
-			if ($moduleName == 'conversations') {
-				$this->internalRedirect('message');
-			}
-
-			if ($moduleName == 'commented') {
-				$this->internalRedirect('network?order=comment');
-			}
-
-			if ($moduleName == 'liked') {
-				$this->internalRedirect('network?order=comment');
-			}
-
-			if ($moduleName == 'activity') {
-				$this->internalRedirect('network?conv=1');
-			}
-
-			if (($moduleName == 'status_messages') && ($this->args->getCommand() == 'status_messages/new')) {
-				$this->internalRedirect('bookmarklet');
-			}
-
-			if (($moduleName == 'user') && ($this->args->getCommand() == 'user/edit')) {
-				$this->internalRedirect('settings');
-			}
-
-			if (($moduleName == 'tag_followings') && ($this->args->getCommand() == 'tag_followings/manage')) {
-				$this->internalRedirect('search');
-			}
-
-			// Initialize module that can set the current theme in the init() method, either directly or via App->profile_uid
-			$this->page['page_title'] = $moduleName;
-
-			// determine the module class and save it to the module instance
-			// @todo there's an implicit dependency due SESSION::start(), so it has to be called here (yet)
-			$module = $module->determineClass($this->args, $router, $this->config);
-
-			// Let the module run it's internal process (init, get, post, ...)
-			$module->run($this->l10n, $this, $this->logger, $this->getCurrentTheme(), $_SERVER, $_POST);
-
-		} catch(HTTPException $e) {
-			ModuleHTTPException::rawContent($e);
-		}
-
-		$content = '';
-
-		try {
-			$moduleClass = $module->getClassName();
-
-			$arr = ['content' => $content];
-			Core\Hook::callAll($moduleClass . '_mod_content', $arr);
-			$content = $arr['content'];
-			$arr = ['content' => call_user_func([$moduleClass, 'content'])];
-			Core\Hook::callAll($moduleClass . '_mod_aftercontent', $arr);
-			$content .= $arr['content'];
-		} catch(HTTPException $e) {
-			$content = ModuleHTTPException::content($e);
-		}
-
-		// initialise content region
-		if ($this->getMode()->isNormal()) {
-			Core\Hook::callAll('page_content_top', $this->page['content']);
-		}
-
-		$this->page['content'] .= $content;
-
-		/* Create the page head after setting the language
-		 * and getting any auth credentials.
-		 *
-		 * Moved initHead() and initFooter() to after
-		 * all the module functions have executed so that all
-		 * theme choices made by the modules can take effect.
-		 */
-		$this->initHead($module, $pconfig);
-
-		/* Build the page ending -- this is stuff that goes right before
-		 * the closing </body> tag
-		 */
-		$this->initFooter();
-
-		if (!$this->isAjax()) {
-			Core\Hook::callAll('page_end', $this->page['content']);
-		}
-
-		// Add the navigation (menu) template
-		if ($moduleName != 'install' && $moduleName != 'maintenance') {
-			$this->page['htmlhead'] .= Core\Renderer::replaceMacros(Core\Renderer::getMarkupTemplate('nav_head.tpl'), []);
-			$this->page['nav']       = Content\Nav::build($this);
-		}
-
-		// Build the page - now that we have all the components
-		if (isset($_GET["mode"]) && (($_GET["mode"] == "raw") || ($_GET["mode"] == "minimal"))) {
-			$doc = new DOMDocument();
-
-			$target = new DOMDocument();
-			$target->loadXML("<root></root>");
-
-			$content = mb_convert_encoding($this->page["content"], 'HTML-ENTITIES', "UTF-8");
-
-			/// @TODO one day, kill those error-surpressing @ stuff, or PHP should ban it
-			@$doc->loadHTML($content);
-
-			$xpath = new DOMXPath($doc);
-
-			$list = $xpath->query("//*[contains(@id,'tread-wrapper-')]");  /* */
-
-			foreach ($list as $item) {
-				$item = $target->importNode($item, true);
-
-				// And then append it to the target
-				$target->documentElement->appendChild($item);
-			}
-
-			if ($_GET["mode"] == "raw") {
-				header("Content-type: text/html; charset=utf-8");
-
-				echo substr($target->saveHTML(), 6, -8);
-
-				exit();
-			}
-		}
-
-		$page    = $this->page;
-		$profile = $this->profile;
-
-		header("X-Friendica-Version: " . FRIENDICA_VERSION);
-		header("Content-type: text/html; charset=utf-8");
-
-		if ($this->config->get('system', 'hsts') && ($this->baseURL->getSSLPolicy() == BaseUrl::SSL_POLICY_FULL)) {
-			header("Strict-Transport-Security: max-age=31536000");
-		}
-
-		// Some security stuff
-		header('X-Content-Type-Options: nosniff');
-		header('X-XSS-Protection: 1; mode=block');
-		header('X-Permitted-Cross-Domain-Policies: none');
-		header('X-Frame-Options: sameorigin');
-
-		// Things like embedded OSM maps don't work, when this is enabled
-		// header("Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; connect-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' https: data:; media-src 'self' https:; child-src 'self' https:; object-src 'none'");
-
-		/* We use $_GET["mode"] for special page templates. So we will check if we have
-		 * to load another page template than the default one.
-		 * The page templates are located in /view/php/ or in the theme directory.
-		 */
-		if (isset($_GET["mode"])) {
-			$template = Core\Theme::getPathForFile($_GET["mode"] . '.php');
-		}
-
-		// If there is no page template use the default page template
-		if (empty($template)) {
-			$template = Core\Theme::getPathForFile("default.php");
-		}
-
-		// Theme templates expect $a as an App instance
-		$a = $this;
-
-		// Used as is in view/php/default.php
-		$lang = $this->l10n->getCurrentLang();
-
-		/// @TODO Looks unsafe (remote-inclusion), is maybe not but Core\Theme::getPathForFile() uses file_exists() but does not escape anything
-		require_once $template;
-	}
-
-	/**
-	 * Redirects to another module relative to the current Friendica base.
-	 * If you want to redirect to a external URL, use System::externalRedirectTo()
-	 *
-	 * @param string $toUrl The destination URL (Default is empty, which is the default page of the Friendica node)
-	 * @param bool $ssl if true, base URL will try to get called with https:// (works just for relative paths)
-	 *
-	 * @throws HTTPException\InternalServerErrorException In Case the given URL is not relative to the Friendica node
+	 * @deprecated 2019.09 - use BaseUrl->redirect() instead
+	 * @see BaseURL::redirect()
 	 */
 	public function internalRedirect($toUrl = '', $ssl = false)
 	{
-		if (!empty(parse_url($toUrl, PHP_URL_SCHEME))) {
-			throw new HTTPException\InternalServerErrorException("'$toUrl is not a relative path, please use System::externalRedirectTo");
-		}
-
-		$redirectTo = $this->getBaseURL($ssl) . '/' . ltrim($toUrl, '/');
-		Core\System::externalRedirect($redirectTo);
+		$this->baseURL->redirect($toUrl, $ssl);
 	}
 
 	/**

--- a/src/App/Arguments.php
+++ b/src/App/Arguments.php
@@ -1,0 +1,194 @@
+<?php
+
+namespace Friendica\App;
+
+/**
+ * Determine all arguments of the current call, including
+ * - The whole querystring (except the pagename/q parameter)
+ * - The command
+ * - The arguments (C-Style based)
+ * - The count of arguments
+ */
+class Arguments
+{
+	/**
+	 * @var string The complete query string
+	 */
+	private $queryString;
+	/**
+	 * @var string The current Friendica command
+	 */
+	private $command;
+	/**
+	 * @var array The arguments of the current execution
+	 */
+	private $argv;
+	/**
+	 * @var int The count of arguments
+	 */
+	private $argc;
+
+	public function __construct(string $queryString = '', string $command = '', array $argv = [Module::DEFAULT], int $argc = 1)
+	{
+		$this->queryString = $queryString;
+		$this->command     = $command;
+		$this->argv        = $argv;
+		$this->argc        = $argc;
+	}
+
+	/**
+	 * @return string The whole query string of this call
+	 */
+	public function getQueryString()
+	{
+		return $this->queryString;
+	}
+
+	/**
+	 * @return string The whole command of this call
+	 */
+	public function getCommand()
+	{
+		return $this->command;
+	}
+
+	/**
+	 * @return array All arguments of this call
+	 */
+	public function getArgv()
+	{
+		return $this->argv;
+	}
+
+	/**
+	 * @return int The count of arguments of this call
+	 */
+	public function getArgc()
+	{
+		return $this->argc;
+	}
+
+	/**
+	 * Returns the value of a argv key
+	 * @todo there are a lot of $a->argv usages in combination with defaults() which can be replaced with this method
+	 *
+	 * @param int   $position the position of the argument
+	 * @param mixed $default  the default value if not found
+	 *
+	 * @return mixed returns the value of the argument
+	 */
+	public function get(int $position, $default = '')
+	{
+		return $this->has($position) ? $this->argv[$position] : $default;
+	}
+
+	/**
+	 * @param int $position
+	 *
+	 * @return bool if the argument position exists
+	 */
+	public function has(int $position)
+	{
+		return array_key_exists($position, $this->argv);
+	}
+
+	/**
+	 * Determine the arguments of the current call
+	 *
+	 * @param array $server The $_SERVER variable
+	 * @param array $get    The $_GET variable
+	 *
+	 * @return Arguments The determined arguments
+	 */
+	public function determine(array $server, array $get)
+	{
+		$queryString = '';
+
+		if (!empty($server['QUERY_STRING']) && strpos($server['QUERY_STRING'], 'pagename=') === 0) {
+			$queryString = substr($server['QUERY_STRING'], 9);
+		} elseif (!empty($server['QUERY_STRING']) && strpos($server['QUERY_STRING'], 'q=') === 0) {
+			$queryString = substr($server['QUERY_STRING'], 2);
+		}
+
+		// eventually strip ZRL
+		$queryString = $this->stripZRLs($queryString);
+
+		// eventually strip OWT
+		$queryString = $this->stripQueryParam($queryString, 'owt');
+
+		// removing trailing / - maybe a nginx problem
+		$queryString = ltrim($queryString, '/');
+
+		if (!empty($get['pagename'])) {
+			$command = trim($get['pagename'], '/\\');
+		} elseif (!empty($get['q'])) {
+			$command = trim($get['q'], '/\\');
+		} else {
+			$command = Module::DEFAULT;
+		}
+
+
+		// fix query_string
+		if (!empty($command)) {
+			$queryString = str_replace(
+				$command . '&',
+				$command . '?',
+				$queryString
+			);
+		}
+
+		// unix style "homedir"
+		if (substr($command, 0, 1) === '~') {
+			$command = 'profile/' . substr($command, 1);
+		}
+
+		// Diaspora style profile url
+		if (substr($command, 0, 2) === 'u/') {
+			$command = 'profile/' . substr($command, 2);
+		}
+
+		/*
+		 * Break the URL path into C style argc/argv style arguments for our
+		 * modules. Given "http://example.com/module/arg1/arg2", $this->argc
+		 * will be 3 (integer) and $this->argv will contain:
+		 *   [0] => 'module'
+		 *   [1] => 'arg1'
+		 *   [2] => 'arg2'
+		 *
+		 *
+		 * There will always be one argument. If provided a naked domain
+		 * URL, $this->argv[0] is set to "home".
+		 */
+
+		$argv = explode('/', $command);
+		$argc = count($argv);
+
+
+		return new Arguments($queryString, $command, $argv, $argc);
+	}
+
+	/**
+	 * Strip zrl parameter from a string.
+	 *
+	 * @param string $queryString The input string.
+	 *
+	 * @return string The zrl.
+	 */
+	public function stripZRLs(string $queryString)
+	{
+		return preg_replace('/[?&]zrl=(.*?)(&|$)/ism', '$2', $queryString);
+	}
+
+	/**
+	 * Strip query parameter from a string.
+	 *
+	 * @param string $queryString The input string.
+	 * @param string $param
+	 *
+	 * @return string The query parameter.
+	 */
+	public function stripQueryParam(string $queryString, string $param)
+	{
+		return preg_replace('/[?&]' . $param . '=(.*?)(&|$)/ism', '$2', $queryString);
+	}
+}

--- a/src/App/Module.php
+++ b/src/App/Module.php
@@ -17,27 +17,6 @@ class Module
 {
 	const DEFAULT = 'home';
 	const DEFAULT_CLASS = Home::class;
-
-	/**
-	 * @var string The module name
-	 */
-	private $module;
-
-	/**
-	 * @var BaseObject The module class
-	 */
-	private $module_class;
-
-	/**
-	 * @var bool true, if the module is a backend module
-	 */
-	private $isBackend;
-
-	/**
-	 * @var bool true, if the loaded addon is private, so we have to print out not allowed
-	 */
-	private $printNotAllowedAddon;
-
 	/**
 	 * A list of modules, which are backend methods
 	 *
@@ -70,6 +49,26 @@ class Module
 		'statistics_json',
 		'xrd',
 	];
+
+	/**
+	 * @var string The module name
+	 */
+	private $module;
+
+	/**
+	 * @var BaseObject The module class
+	 */
+	private $module_class;
+
+	/**
+	 * @var bool true, if the module is a backend module
+	 */
+	private $isBackend;
+
+	/**
+	 * @var bool true, if the loaded addon is private, so we have to print out not allowed
+	 */
+	private $printNotAllowedAddon;
 
 	/**
 	 * @return string

--- a/src/App/Module.php
+++ b/src/App/Module.php
@@ -1,0 +1,280 @@
+<?php
+
+namespace Friendica\App;
+
+use Friendica\App;
+use Friendica\BaseObject;
+use Friendica\Core;
+use Friendica\LegacyModule;
+use Friendica\Module\Home;
+use Friendica\Module\PageNotFound;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Holds the common context of the current, loaded module
+ */
+class Module
+{
+	const DEFAULT = 'home';
+	const DEFAULT_CLASS = Home::class;
+
+	/**
+	 * @var string The module name
+	 */
+	private $module;
+
+	/**
+	 * @var BaseObject The module class
+	 */
+	private $module_class;
+
+	/**
+	 * @var bool true, if the module is a backend module
+	 */
+	private $isBackend;
+
+	/**
+	 * @var bool true, if the loaded addon is private, so we have to print out not allowed
+	 */
+	private $printNotAllowedAddon;
+
+	/**
+	 * A list of modules, which are backend methods
+	 *
+	 * @var array
+	 */
+	const BACKEND_MODULES = [
+		'_well_known',
+		'api',
+		'dfrn_notify',
+		'feed',
+		'fetch',
+		'followers',
+		'following',
+		'hcard',
+		'hostxrd',
+		'inbox',
+		'manifest',
+		'nodeinfo',
+		'noscrape',
+		'objects',
+		'outbox',
+		'poco',
+		'post',
+		'proxy',
+		'pubsub',
+		'pubsubhubbub',
+		'receive',
+		'rsd_xml',
+		'salmon',
+		'statistics_json',
+		'xrd',
+	];
+
+	/**
+	 * @return string
+	 */
+	public function getName()
+	{
+		return $this->module;
+	}
+
+	/**
+	 * @return string The base class name
+	 */
+	public function getClassName()
+	{
+		return $this->module_class;
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function isBackend()
+	{
+		return $this->isBackend;
+	}
+
+	public function __construct(string $module = self::DEFAULT, string $moduleClass = self::DEFAULT_CLASS, bool $isBackend = false, bool $printNotAllowedAddon = false)
+	{
+		$this->module       = $module;
+		$this->module_class = $moduleClass;
+		$this->isBackend    = $isBackend;
+		$this->printNotAllowedAddon = $printNotAllowedAddon;
+	}
+
+	/**
+	 * Determines the current module based on the App arguments and the server variable
+	 *
+	 * @param Arguments $args   The Friendica arguments
+	 * @param array     $server The $_SERVER variable
+	 *
+	 * @return Module The module with the determined module
+	 */
+	public function determineModule(Arguments $args, array $server)
+	{
+		if ($args->getArgc() > 0) {
+			$module = str_replace('.', '_', $args->get(0));
+			$module = str_replace('-', '_', $module);
+		} else {
+			$module = self::DEFAULT;
+		}
+
+		// Compatibility with the Firefox App
+		if (($module == "users") && ($args->getCommand() == "users/sign_in")) {
+			$module = "login";
+		}
+
+		$isBackend = $this->checkBackend($module, $server);
+
+		return new Module($module, $this->module_class, $isBackend, $this->printNotAllowedAddon);
+	}
+
+	/**
+	 * Determine the class of the current module
+	 *
+	 * @param Arguments                 $args   The Friendica execution arguments
+	 * @param Router                    $router The Friendica routing instance
+	 * @param Core\Config\Configuration $config The Friendica Configuration
+	 *
+	 * @return Module The determined module of this call
+	 *
+	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
+	 */
+	public function determineClass(Arguments $args, Router $router, Core\Config\Configuration $config)
+	{
+		$printNotAllowedAddon = false;
+
+		/**
+		 * ROUTING
+		 *
+		 * From the request URL, routing consists of obtaining the name of a BaseModule-extending class of which the
+		 * post() and/or content() static methods can be respectively called to produce a data change or an output.
+		 **/
+
+		// First we try explicit routes defined in App\Router
+		$router->collectRoutes();
+
+		$data = $router->getRouteCollector();
+		Core\Hook::callAll('route_collection', $data);
+
+		$module_class = $router->getModuleClass($args->getCommand());
+
+		// Then we try addon-provided modules that we wrap in the LegacyModule class
+		if (!$module_class && Core\Addon::isEnabled($this->module) && file_exists("addon/{$this->module}/{$this->module}.php")) {
+			//Check if module is an app and if public access to apps is allowed or not
+			$privateapps = $config->get('config', 'private_addons', false);
+			if ((!local_user()) && Core\Hook::isAddonApp($this->module) && $privateapps) {
+				$printNotAllowedAddon = true;
+			} else {
+				include_once "addon/{$this->module}/{$this->module}.php";
+				if (function_exists($this->module . '_module')) {
+					LegacyModule::setModuleFile("addon/{$this->module}/{$this->module}.php");
+					$module_class = LegacyModule::class;
+				}
+			}
+		}
+
+		/* Finally, we look for a 'standard' program module in the 'mod' directory
+		 * We emulate a Module class through the LegacyModule class
+		 */
+		if (!$module_class && file_exists("mod/{$this->module}.php")) {
+			LegacyModule::setModuleFile("mod/{$this->module}.php");
+			$module_class = LegacyModule::class;
+		}
+
+		$module_class = !isset($module_class) ? PageNotFound::class : $module_class;
+
+		return new Module($this->module, $module_class, $this->isBackend, $printNotAllowedAddon);
+	}
+
+	/**
+	 * Run the determined module class and calls all hooks applied to
+	 *
+	 * @param Core\L10n\L10n $l10n         The L10n instance
+	 * @param App            $app          The whole Friendica app (for method arguments)
+	 * @param LoggerInterface           $logger The Friendica logger
+	 * @param string         $currentTheme The chosen theme
+	 * @param array          $server       The $_SERVER variable
+	 * @param array          $post         The $_POST variables
+	 *
+	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
+	 */
+	public function run(Core\L10n\L10n $l10n, App $app,  LoggerInterface $logger, string $currentTheme, array $server, array $post)
+	{
+		if ($this->printNotAllowedAddon) {
+			info($l10n->t("You must be logged in to use addons. "));
+		}
+
+		/* The URL provided does not resolve to a valid module.
+		 *
+		 * On Dreamhost sites, quite often things go wrong for no apparent reason and they send us to '/internal_error.html'.
+		 * We don't like doing this, but as it occasionally accounts for 10-20% or more of all site traffic -
+		 * we are going to trap this and redirect back to the requested page. As long as you don't have a critical error on your page
+		 * this will often succeed and eventually do the right thing.
+		 *
+		 * Otherwise we are going to emit a 404 not found.
+		 */
+		if ($this->module_class === PageNotFound::class) {
+			$queryString = $server['QUERY_STRING'];
+			// Stupid browser tried to pre-fetch our Javascript img template. Don't log the event or return anything - just quietly exit.
+			if (!empty($queryString) && preg_match('/{[0-9]}/', $queryString) !== 0) {
+				exit();
+			}
+
+			if (!empty($queryString) && ($queryString === 'q=internal_error.html') && isset($dreamhost_error_hack)) {
+				$logger->info('index.php: dreamhost_error_hack invoked.', ['Original URI' => $server['REQUEST_URI']]);
+				$app->internalRedirect($server['REQUEST_URI']);
+			}
+
+			$logger->debug('index.php: page not found.', ['request_uri' => $server['REQUEST_URI'], 'address' => $server['REMOTE_ADDR'], 'query' => $server['QUERY_STRING']]);
+		}
+
+		$placeholder = '';
+
+		Core\Hook::callAll($this->module . '_mod_init', $placeholder);
+
+		call_user_func([$this->module_class, 'init']);
+
+		// "rawContent" is especially meant for technical endpoints.
+		// This endpoint doesn't need any theme initialization or other comparable stuff.
+		call_user_func([$this->module_class, 'rawContent']);
+
+		// Load current theme info after module has been initialized as theme could have been set in module
+		$theme_info_file = 'view/theme/' . $currentTheme . '/theme.php';
+		if (file_exists($theme_info_file)) {
+			require_once $theme_info_file;
+		}
+
+		if (function_exists(str_replace('-', '_', $currentTheme) . '_init')) {
+			$func = str_replace('-', '_', $currentTheme) . '_init';
+			$func($app);
+		}
+
+		if ($server['REQUEST_METHOD'] === 'POST') {
+			Core\Hook::callAll($this->module . '_mod_post', $post);
+			call_user_func([$this->module_class, 'post']);
+		}
+
+		Core\Hook::callAll($this->module . '_mod_afterpost', $placeholder);
+		call_user_func([$this->module_class, 'afterpost']);
+	}
+
+	/**
+	 * @brief Checks if the site is called via a backend process
+	 *
+	 * This isn't a perfect solution. But we need this check very early.
+	 * So we cannot wait until the modules are loaded.
+	 *
+	 * @param string $module The determined module
+	 * @param array  $server The $_SERVER variable
+	 *
+	 * @return bool True, if the current module is called at backend
+	 */
+	private function checkBackend($module, array $server)
+	{
+		// Check if current module is in backend or backend flag is set
+		return basename(($server['PHP_SELF'] ?? ''), '.php') !== 'index' &&
+		       in_array($module, Module::BACKEND_MODULES);
+	}
+}

--- a/src/Core/Frontend.php
+++ b/src/Core/Frontend.php
@@ -1,4 +1,4 @@
-<?php declare(strict_type=1);
+<?php
 
 namespace Friendica\Core;
 

--- a/src/Core/Frontend.php
+++ b/src/Core/Frontend.php
@@ -1,0 +1,606 @@
+<?php declare(strict_type=1);
+
+namespace Friendica\Core;
+
+use DOMDocument;
+use DOMXPath;
+use Friendica\App;
+use Friendica\Content\Nav;
+use Friendica\Core\Config\Configuration;
+use Friendica\Core\Config\PConfiguration;
+use Friendica\Model\Profile;
+use Friendica\Module\Login;
+use Friendica\Module\Special\HTTPException as ModuleHTTPException;
+use Friendica\Network\HTTPException;
+use Friendica\Util\BaseURL;
+use Friendica\Util\HTTPSignature;
+use Friendica\Util\Profiler;
+use Psr\Log\LoggerInterface;
+
+/**
+ * The Frontend class which acts as controller for the frontend related process
+ * 1) Initializes the environment of the Frontend
+ * 2) Load the Frontend page
+ *
+ * Additional, all frontend related properties are saved or altered here
+ *
+ * Currently, the Frontend class acts like an array for the page-settings to be compatible
+ * with the `$a->page[]` calls.
+ */
+final class Frontend implements \ArrayAccess
+{
+	/**
+	 * @var array Additional stylesheets to load during the call
+	 */
+	private $stylesheets = [];
+	/**
+	 * @var array Additional footer scripts to load during the call
+	 */
+	private $footerScripts = [];
+	/**
+	 * @var array The raw content of the page,
+	 * split into different parts
+	 */
+	private $page = [];
+	/**
+	 * @var string The basepath of Friendica
+	 */
+	private $basePath;
+
+	public function __construct(string $basepath)
+	{
+		$this->basePath = $basepath;
+	}
+
+	/**
+	 * Initialize the Frontend with all components, sessions and processes
+	 * 1) Check if the frontend is callable
+	 * 2) Start the Session/Hooks/...
+	 * 3) Check the login state
+	 * 4) Check if the URL should get directly redirected
+	 *
+	 * @param App\Arguments   $args     The Friendica call arguments
+	 * @param App\Mode        $mode     The Friendica mode of the exection
+	 * @param App\Module      $module   The current used Friendica module
+	 * @param L10n\L10n       $l10n     The Language environment
+	 * @param Process         $process  The process environment
+	 * @param LoggerInterface $logger   The Friendica Logger instance
+	 * @param Profiler        $profiler The Friendica Profiler instance
+	 * @param BaseURL         $baseURL  The Friendica BaseURL
+	 *
+	 * @return Frontend $this Returns itself
+	 *
+	 * @throws \ImagickException in case imagick isn't available
+	 */
+	public function init(App\Arguments $args, App\Mode $mode, App\Module $module, L10n\L10n $l10n, Process $process, LoggerInterface $logger, Profiler $profiler, BaseURL $baseURL)
+	{
+		$moduleName = $module->getName();
+
+		try {
+			// Missing DB connection: ERROR
+			if ($mode->has(App\Mode::LOCALCONFIGPRESENT) && !$mode->has(App\Mode::DBAVAILABLE)) {
+				throw new HTTPException\InternalServerErrorException('Apologies but the website is unavailable at the moment.');
+			}
+
+			// Max Load Average reached: ERROR
+			if ($process->isMaxProcessesReached() || $process->isMaxLoadReached()) {
+				header('Retry-After: 120');
+				header('Refresh: 120; url=' . $baseURL->get() . "/" . $args->getQueryString());
+
+				throw new HTTPException\ServiceUnavailableException('The node is currently overloaded. Please try again later.');
+			}
+
+			if (!$mode->isInstall()) {
+				// Force SSL redirection
+				if ($baseURL->checkRedirectHttps()) {
+					System::externalRedirect($baseURL->get() . '/' . $args->getQueryString());
+				}
+
+				Session::init();
+				Hook::callAll('init_1');
+			}
+
+			// Exclude the backend processes from the session management
+			if (!$module->isBackend()) {
+				$stamp1 = microtime(true);
+				session_start();
+				$profiler->saveTimestamp($stamp1, 'parser', System::callstack());
+				$l10n->setSessionVariable();
+				$l10n->setLangFromSession();
+			} else {
+				$_SESSION = [];
+				Worker::executeIfIdle();
+			}
+
+			if ($mode->isNormal()) {
+				$requester = HTTPSignature::getSigner('', $_SERVER);
+				if (!empty($requester)) {
+					Profile::addVisitorCookieForHandle($requester);
+				}
+			}
+
+			// ZRL
+			if (!empty($_GET['zrl']) && $mode->isNormal()) {
+				if (!local_user()) {
+					// Only continue when the given profile link seems valid
+					// Valid profile links contain a path with "/profile/" and no query parameters
+					if ((parse_url($_GET['zrl'], PHP_URL_QUERY) == "") &&
+					    strstr(parse_url($_GET['zrl'], PHP_URL_PATH), "/profile/")) {
+						if (Session::get('visitor_home') != $_GET["zrl"]) {
+							Session::set('my_url', $_GET['zrl']);
+							Session::set('authenticated', 0);
+						}
+
+						Profile::zrlInit($args, $baseURL);
+					} else {
+						// Someone came with an invalid parameter, maybe as a DDoS attempt
+						// We simply stop processing here
+						$logger->debug("Invalid ZRL parameter.", ['zrl' => $_GET['zrl']]);
+						throw new HTTPException\ForbiddenException();
+					}
+				}
+			}
+
+			if (!empty($_GET['owt']) && $mode->isNormal()) {
+				$token = $_GET['owt'];
+				Profile::openWebAuthInit($token);
+			}
+
+			Login::sessionAuth();
+
+			if (empty($_SESSION['authenticated'])) {
+				header('X-Account-Management-Status: none');
+			}
+
+			$_SESSION['sysmsg']       = Session::get('sysmsg', []);
+			$_SESSION['sysmsg_info']  = Session::get('sysmsg_info', []);
+			$_SESSION['last_updated'] = Session::get('last_updated', []);
+
+			/*
+			 * check_config() is responsible for running update scripts. These automatically
+			 * update the DB schema whenever we push a new one out. It also checks to see if
+			 * any addons have been added or removed and reacts accordingly.
+			 */
+
+			// in install mode, any url loads install module
+			// but we need "view" module for stylesheet
+			if ($mode->isInstall() && $moduleName !== 'install') {
+				$baseURL->redirect('install');
+			} elseif (!$mode->isInstall() && !$mode->has(App\Mode::MAINTENANCEDISABLED) && $moduleName !== 'maintenance') {
+				$baseURL->redirect('maintenance');
+			} else {
+				$baseURL->check();
+				Update::check($this->basePath, false, $mode);
+				Addon::loadAddons();
+				Hook::loadHooks();
+			}
+
+			$this->page = [
+				'aside'       => '',
+				'bottom'      => '',
+				'content'     => '',
+				'footer'      => '',
+				'htmlhead'    => '',
+				'nav'         => '',
+				'page_title'  => '',
+				'right_aside' => '',
+				'template'    => '',
+				'title'       => ''
+			];
+
+			// Compatibility with the Android Diaspora client
+			if ($moduleName == 'stream') {
+				$baseURL->redirect('network?order=post');
+			}
+
+			if ($moduleName == 'conversations') {
+				$baseURL->redirect('message');
+			}
+
+			if ($moduleName == 'commented') {
+				$baseURL->redirect('network?order=comment');
+			}
+
+			if ($moduleName == 'liked') {
+				$baseURL->redirect('network?order=comment');
+			}
+
+			if ($moduleName == 'activity') {
+				$baseURL->redirect('network?conv=1');
+			}
+
+			if (($moduleName == 'status_messages') && ($args->getCommand() == 'status_messages/new')) {
+				$baseURL->redirect('bookmarklet');
+			}
+
+			if (($moduleName == 'user') && ($args->getCommand() == 'user/edit')) {
+				$baseURL->redirect('settings');
+			}
+
+			if (($moduleName == 'tag_followings') && ($args->getCommand() == 'tag_followings/manage')) {
+				$baseURL->redirect('search');
+			}
+
+		} catch (HTTPException $e) {
+			ModuleHTTPException::rawContent($e);
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Shows the initialized frontend to the user
+	 * 1) Determine the module class
+	 * 2) Runs the module class with all hooks (init, post, get, ...)
+	 * 3) Initialize header/footer/nav-bar
+	 * 4) Render the whole page (minimized or normal)
+	 *
+	 * @param App             $app     The Friendica Application instance for Hook-calls
+	 * @param App\Arguments   $args    The Friendica call arguments
+	 * @param App\Mode        $mode    The Friendica mode of the exection
+	 * @param App\Module      $module  The current used Friendica module
+	 * @param App\Router      $router  The Friendica router to determine the used module class
+	 * @param L10n\L10n       $l10n    The Language environment
+	 * @param Configuration   $config  The Friendica configuration
+	 * @param PConfiguration  $pconfig The Friendica configuration for users
+	 * @param LoggerInterface $logger  The Friendica Logger instance
+	 * @param BaseURL         $baseURL The Friendica BaseURL
+	 *
+	 * @throws HTTPException\InternalServerErrorException
+	 */
+	public function show(App $app, App\Arguments $args, App\Mode $mode, App\Module $module, App\Router $router, L10n\L10n $l10n, Configuration $config, PConfiguration $pconfig, LoggerInterface $logger, BaseURL $baseURL)
+	{
+		$moduleName = $module->getName();
+		$content    = '';
+
+		try {
+			// Initialize module that can set the current theme in the init() method, either directly or via App->profile_uid
+			$this->page['page_title'] = $moduleName;
+
+			// determine the module class and save it to the module instance
+			// @todo there's an implicit dependency due SESSION::start(), so it has to be called here (yet)
+			$module = $module->determineClass($args, $router, $config);
+
+			// Let the module run it's internal process (init, get, post, ...)
+			$module->run($l10n, $app, $logger, $app->getCurrentTheme(), $_SERVER, $_POST);
+
+			$moduleClass = $module->getClassName();
+
+			$arr = ['content' => $content];
+			Hook::callAll($moduleClass . '_mod_content', $arr);
+			$content = $arr['content'];
+			$arr     = ['content' => call_user_func([$moduleClass, 'content'])];
+			Hook::callAll($moduleClass . '_mod_aftercontent', $arr);
+			$content .= $arr['content'];
+		} catch (HTTPException $e) {
+			$content = ModuleHTTPException::content($e);
+		}
+
+		// initialise content region
+		if ($mode->isNormal()) {
+			Hook::callAll('page_content_top', $this->page['content']);
+		}
+
+		$this->page['content'] .= $content;
+
+		/* Create the page head after setting the language
+		 * and getting any auth credentials.
+		 *
+		 * Moved initHead() and initFooter() to after
+		 * all the module functions have executed so that all
+		 * theme choices made by the modules can take effect.
+		 */
+		$this->initHead($app, $module, $pconfig, $config, $l10n);
+
+		/* Build the page ending -- this is stuff that goes right before
+		 * the closing </body> tag
+		 */
+		$this->initFooter($app, $l10n);
+
+		if (!$app->isAjax()) {
+			Hook::callAll('page_end', $this->page['content']);
+		}
+
+		// Add the navigation (menu) template
+		if ($moduleName != 'install' && $moduleName != 'maintenance') {
+			$this->page['htmlhead'] .= Renderer::replaceMacros(Renderer::getMarkupTemplate('nav_head.tpl'), []);
+			$this->page['nav']      = Nav::build($app);
+		}
+
+		// Build the page - now that we have all the components
+		if (isset($_GET["mode"]) && (($_GET["mode"] == "raw") || ($_GET["mode"] == "minimal"))) {
+			$doc = new DOMDocument();
+
+			$target = new DOMDocument();
+			$target->loadXML("<root></root>");
+
+			$content = mb_convert_encoding($this->page["content"], 'HTML-ENTITIES', "UTF-8");
+
+			/// @TODO one day, kill those error-surpressing @ stuff, or PHP should ban it
+			@$doc->loadHTML($content);
+
+			$xpath = new DOMXPath($doc);
+
+			$list = $xpath->query("//*[contains(@id,'tread-wrapper-')]");  /* */
+
+			foreach ($list as $item) {
+				$item = $target->importNode($item, true);
+
+				// And then append it to the target
+				$target->documentElement->appendChild($item);
+			}
+
+			if ($_GET["mode"] == "raw") {
+				header("Content-type: text/html; charset=utf-8");
+
+				echo substr($target->saveHTML(), 6, -8);
+
+				exit();
+			}
+		}
+
+		$page    = $this->page;
+		$profile = $app->profile;
+
+		header("X-Friendica-Version: " . FRIENDICA_VERSION);
+		header("Content-type: text/html; charset=utf-8");
+
+		if ($config->get('system', 'hsts') && ($baseURL->getSSLPolicy() == BaseUrl::SSL_POLICY_FULL)) {
+			header("Strict-Transport-Security: max-age=31536000");
+		}
+
+		// Some security stuff
+		header('X-Content-Type-Options: nosniff');
+		header('X-XSS-Protection: 1; mode=block');
+		header('X-Permitted-Cross-Domain-Policies: none');
+		header('X-Frame-Options: sameorigin');
+
+		// Things like embedded OSM maps don't work, when this is enabled
+		// header("Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; connect-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' https: data:; media-src 'self' https:; child-src 'self' https:; object-src 'none'");
+
+		/* We use $_GET["mode"] for special page templates. So we will check if we have
+		 * to load another page template than the default one.
+		 * The page templates are located in /view/php/ or in the theme directory.
+		 */
+		if (isset($_GET["mode"])) {
+			$template = Theme::getPathForFile($_GET["mode"] . '.php');
+		}
+
+		// If there is no page template use the default page template
+		if (empty($template)) {
+			$template = Theme::getPathForFile("default.php");
+		}
+
+		// Theme templates expect $a as an App instance
+		$a = $app;
+
+		// Used as is in view/php/default.php
+		$lang = $l10n->getCurrentLang();
+
+		/// @TODO Looks unsafe (remote-inclusion), is maybe not but Core\Theme::getPathForFile() uses file_exists() but does not escape anything
+		require_once $template;
+	}
+
+	/**
+	 * Initializes App->page['htmlhead'].
+	 *
+	 * Includes:
+	 * - Page title
+	 * - Favicons
+	 * - Registered stylesheets (through App->registerStylesheet())
+	 * - Infinite scroll data
+	 * - head.tpl template
+	 */
+	private function initHead(App $app, App\Module $module, PConfiguration $pconfig, Configuration $config, L10n\L10n $l10n)
+	{
+		$interval = ((local_user()) ? $pconfig->get(local_user(), 'system', 'update_interval') : 40000);
+
+		// If the update is 'deactivated' set it to the highest integer number (~24 days)
+		if ($interval < 0) {
+			$interval = 2147483647;
+		}
+
+		if ($interval < 10000) {
+			$interval = 40000;
+		}
+
+		// Default title: current module called
+		if (empty($this->page['title']) && $module->getName()) {
+			$this->page['title'] = ucfirst($module->getName());
+		}
+
+		// Prepend the sitename to the page title
+		$this->page['title'] = $config->get('config', 'sitename', '') . (!empty($this->page['title']) ? ' | ' . $this->page['title'] : '');
+
+		if (!empty(Renderer::$theme['stylesheet'])) {
+			$stylesheet = Renderer::$theme['stylesheet'];
+		} else {
+			$stylesheet = $app->getCurrentThemeStylesheetPath();
+		}
+
+		$this->registerStylesheet($stylesheet);
+
+		$shortcut_icon = $config->get('system', 'shortcut_icon');
+		if ($shortcut_icon == '') {
+			$shortcut_icon = 'images/friendica-32.png';
+		}
+
+		$touch_icon = $config->get('system', 'touch_icon');
+		if ($touch_icon == '') {
+			$touch_icon = 'images/friendica-128.png';
+		}
+
+		Hook::callAll('head', $this->page['htmlhead']);
+
+		$tpl = Renderer::getMarkupTemplate('head.tpl');
+		/* put the head template at the beginning of page['htmlhead']
+		 * since the code added by the modules frequently depends on it
+		 * being first
+		 */
+		$this->page['htmlhead'] = Renderer::replaceMacros($tpl, [
+				'$local_user'      => local_user(),
+				'$generator'       => 'Friendica' . ' ' . FRIENDICA_VERSION,
+				'$delitem'         => $l10n->t('Delete this item?'),
+				'$update_interval' => $interval,
+				'$shortcut_icon'   => $shortcut_icon,
+				'$touch_icon'      => $touch_icon,
+				'$block_public'    => intval($config->get('system', 'block_public')),
+				'$stylesheets'     => $this->stylesheets,
+			]) . $this->page['htmlhead'];
+	}
+
+	/**
+	 * Initializes App->page['footer'].
+	 *
+	 * Includes:
+	 * - Javascript homebase
+	 * - Mobile toggle link
+	 * - Registered footer scripts (through App->registerFooterScript())
+	 * - footer.tpl template
+	 */
+	private function initFooter(App $app, L10n\L10n $l10n)
+	{
+		// If you're just visiting, let javascript take you home
+		if (!empty($_SESSION['visitor_home'])) {
+			$homebase = $_SESSION['visitor_home'];
+		} elseif (local_user()) {
+			$homebase = 'profile/' . $app->user['nickname'];
+		}
+
+		if (isset($homebase)) {
+			$this->page['footer'] .= '<script>var homebase="' . $homebase . '";</script>' . "\n";
+		}
+
+		/*
+		 * Add a "toggle mobile" link if we're using a mobile device
+		 */
+		if ($app->is_mobile || $app->is_tablet) {
+			if (isset($_SESSION['show-mobile']) && !$_SESSION['show-mobile']) {
+				$link = 'toggle_mobile?address=' . urlencode(curPageURL());
+			} else {
+				$link = 'toggle_mobile?off=1&address=' . urlencode(curPageURL());
+			}
+			$this->page['footer'] .= Renderer::replaceMacros(Renderer::getMarkupTemplate("toggle_mobile_footer.tpl"), [
+				'$toggle_link' => $link,
+				'$toggle_text' => $l10n->t('toggle mobile')
+			]);
+		}
+
+		Hook::callAll('footer', $this->page['footer']);
+
+		$tpl                  = Renderer::getMarkupTemplate('footer.tpl');
+		$this->page['footer'] = Renderer::replaceMacros($tpl, [
+				'$footerScripts' => $this->footerScripts,
+			]) . $this->page['footer'];
+	}
+
+	/**
+	 * Register a stylesheet file path to be included in the <head> tag of every page.
+	 * Inclusion is done in App->initHead().
+	 * The path can be absolute or relative to the Friendica installation base folder.
+	 *
+	 * @param string $path
+	 *
+	 * @see initHead()
+	 *
+	 */
+	public function registerStylesheet($path)
+	{
+		if (mb_strpos($path, $this->basePath . DIRECTORY_SEPARATOR) === 0) {
+			$path = mb_substr($path, mb_strlen($this->basePath . DIRECTORY_SEPARATOR));
+		}
+
+		$this->stylesheets[] = trim($path, '/');
+	}
+
+	/**
+	 * Register a javascript file path to be included in the <footer> tag of every page.
+	 * Inclusion is done in App->initFooter().
+	 * The path can be absolute or relative to the Friendica installation base folder.
+	 *
+	 * @param string $path
+	 *
+	 * @see initFooter()
+	 *
+	 */
+	public function registerFooterScript($path)
+	{
+		$url = str_replace($this->basePath . DIRECTORY_SEPARATOR, '', $path);
+
+		$this->footerScripts[] = trim($url, '/');
+	}
+
+	/**
+	 * Whether a offset exists
+	 *
+	 * @link  https://php.net/manual/en/arrayaccess.offsetexists.php
+	 *
+	 * @param mixed $offset <p>
+	 *                      An offset to check for.
+	 *                      </p>
+	 *
+	 * @return boolean true on success or false on failure.
+	 * </p>
+	 * <p>
+	 * The return value will be casted to boolean if non-boolean was returned.
+	 * @since 5.0.0
+	 */
+	public function offsetExists($offset)
+	{
+		return isset($this->page[$offset]);
+	}
+
+	/**
+	 * Offset to retrieve
+	 *
+	 * @link  https://php.net/manual/en/arrayaccess.offsetget.php
+	 *
+	 * @param mixed $offset <p>
+	 *                      The offset to retrieve.
+	 *                      </p>
+	 *
+	 * @return mixed Can return all value types.
+	 * @since 5.0.0
+	 */
+	public function offsetGet($offset)
+	{
+		return $this->page[$offset] ?? null;
+	}
+
+	/**
+	 * Offset to set
+	 *
+	 * @link  https://php.net/manual/en/arrayaccess.offsetset.php
+	 *
+	 * @param mixed $offset <p>
+	 *                      The offset to assign the value to.
+	 *                      </p>
+	 * @param mixed $value  <p>
+	 *                      The value to set.
+	 *                      </p>
+	 *
+	 * @return void
+	 * @since 5.0.0
+	 */
+	public function offsetSet($offset, $value)
+	{
+		$this->page[$offset] = $value;
+	}
+
+	/**
+	 * Offset to unset
+	 *
+	 * @link  https://php.net/manual/en/arrayaccess.offsetunset.php
+	 *
+	 * @param mixed $offset <p>
+	 *                      The offset to unset.
+	 *                      </p>
+	 *
+	 * @return void
+	 * @since 5.0.0
+	 */
+	public function offsetUnset($offset)
+	{
+		unset($this->page[$offset]);
+	}
+}

--- a/src/Core/Installer.php
+++ b/src/Core/Installer.php
@@ -11,7 +11,6 @@ use Friendica\Database\Database;
 use Friendica\Database\DBStructure;
 use Friendica\Object\Image;
 use Friendica\Util\Network;
-use Friendica\Util\Profiler;
 use Friendica\Util\Strings;
 
 /**
@@ -591,8 +590,7 @@ class Installer
 	/**
 	 * Checking the Database connection and if it is available for the current installation
 	 *
-	 * @param ConfigCache $configCache The configuration cache
-	 * @param Profiler    $profiler    The profiler of this app
+	 * @param Database $dba
 	 *
 	 * @return bool true if the check was successful, otherwise false
 	 * @throws Exception

--- a/src/Core/Process.php
+++ b/src/Core/Process.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php
 
 namespace Friendica\Core;
 

--- a/src/Core/Process.php
+++ b/src/Core/Process.php
@@ -1,0 +1,191 @@
+<?php declare(strict_types=1);
+
+namespace Friendica\Core;
+
+use Friendica\App\Module;
+use Friendica\Core\Config\Configuration;
+use Psr\Log\LoggerInterface;
+
+final class Process
+{
+	/**
+	 * @var LoggerInterface The Friendica Logger
+	 */
+	private $logger;
+	/**
+	 * @var Configuration The Friendica configuration instance
+	 */
+	private $config;
+	/**
+	 * @var bool
+	 */
+	private $isBackend;
+	/**
+	 * @var string
+	 */
+	private $basePath;
+
+	public function __construct(LoggerInterface $logger, Configuration $config, Module $module, string $basepath)
+	{
+		$this->logger    = $logger;
+		$this->config    = $config;
+		$this->isBackend = $module->isBackend();
+		$this->basePath  = $basepath;
+	}
+
+	/**
+	 * @brief Checks if the maximum number of database processes is reached
+	 *
+	 * @return bool Is the limit reached?
+	 */
+	public function isMaxProcessesReached()
+	{
+		// Deactivated, needs more investigating if this check really makes sense
+		return false;
+
+		/*
+		 * Commented out to suppress static analyzer issues
+		 *
+		if ($this->isBackend) {
+			$process = 'backend';
+			$max_processes = $this->config->get('system', 'max_processes_backend');
+			if (intval($max_processes) == 0) {
+				$max_processes = 5;
+			}
+		} else {
+			$process = 'frontend';
+			$max_processes = $this->config->get('system', 'max_processes_frontend');
+			if (intval($max_processes) == 0) {
+				$max_processes = 20;
+			}
+		}
+
+		$processlist = DBA::processlist();
+		if ($processlist['list'] != '') {
+			$this->logger->debug('Processcheck: Processes: ' . $processlist['amount'] . ' - Processlist: ' . $processlist['list']);
+
+			if ($processlist['amount'] > $max_processes) {
+				$this->logger->debug('Processcheck: Maximum number of processes for ' . $process . ' tasks (' . $max_processes . ') reached.');
+				return true;
+			}
+		}
+		return false;
+		 */
+	}
+
+	/**
+	 * Checks if the minimal memory is reached
+	 *
+	 * @return bool Is the memory limit reached?
+	 */
+	public function isMinMemoryReached()
+	{
+		$min_memory = $this->config->get('system', 'min_memory', 0);
+		if ($min_memory == 0) {
+			return false;
+		}
+
+		if (!is_readable('/proc/meminfo')) {
+			return false;
+		}
+
+		$memdata = explode("\n", file_get_contents('/proc/meminfo'));
+
+		$meminfo = [];
+		foreach ($memdata as $line) {
+			$data = explode(':', $line);
+			if (count($data) != 2) {
+				continue;
+			}
+			list($key, $val) = $data;
+			$meminfo[$key] = (int)trim(str_replace('kB', '', $val));
+			$meminfo[$key] = (int)($meminfo[$key] / 1024);
+		}
+
+		if (!isset($meminfo['MemFree'])) {
+			return false;
+		}
+
+		$free = $meminfo['MemFree'];
+
+		$reached = ($free < $min_memory);
+
+		if ($reached) {
+			$this->logger->debug('Minimal memory reached: ' . $free . '/' . $meminfo['MemTotal'] . ' - limit ' . $min_memory);
+		}
+
+		return $reached;
+	}
+
+	/**
+	 * Checks if the maximum load is reached
+	 *
+	 * @return bool Is the load reached?
+	 */
+	public function isMaxLoadReached()
+	{
+		if ($this->isBackend) {
+			$process    = 'backend';
+			$maxsysload = intval($this->config->get('system', 'maxloadavg'));
+			if ($maxsysload < 1) {
+				$maxsysload = 50;
+			}
+		} else {
+			$process    = 'frontend';
+			$maxsysload = intval($this->config->get('system', 'maxloadavg_frontend'));
+			if ($maxsysload < 1) {
+				$maxsysload = 50;
+			}
+		}
+
+		$load = System::currentLoad();
+		if ($load) {
+			if (intval($load) > $maxsysload) {
+				$this->logger->notice('system: load ' . $load . ' for ' . $process . ' tasks (' . $maxsysload . ') too high.');
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Executes a child process with 'proc_open'
+	 *
+	 * @param string $command The command to execute
+	 * @param array  $args    Arguments to pass to the command ( [ 'key' => value, 'key2' => value2, ... ]
+	 */
+	public function run($command, $args)
+	{
+		if (!function_exists('proc_open')) {
+			return;
+		}
+
+		$cmdline = $this->config->get('config', 'php_path', 'php') . ' ' . escapeshellarg($command);
+
+		foreach ($args as $key => $value) {
+			if (!is_null($value) && is_bool($value) && !$value) {
+				continue;
+			}
+
+			$cmdline .= ' --' . $key;
+			if (!is_null($value) && !is_bool($value)) {
+				$cmdline .= ' ' . $value;
+			}
+		}
+
+		if ($this->isMinMemoryReached()) {
+			return;
+		}
+
+		if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+			$resource = proc_open('cmd /c start /b ' . $cmdline, [], $foo, $this->basePath);
+		} else {
+			$resource = proc_open($cmdline . ' &', [], $foo, $this->basePath);
+		}
+		if (!is_resource($resource)) {
+			$this->logger->debug('We got no resource for command ' . $cmdline);
+			return;
+		}
+		proc_close($resource);
+	}
+}

--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -1225,29 +1225,6 @@ class Profile
 	}
 
 	/**
-	* Strip zrl parameter from a string.
-	*
-	* @param string $s The input string.
-	* @return string The zrl.
-	*/
-	public static function stripZrls($s)
-	{
-		return preg_replace('/[\?&]zrl=(.*?)([\?&]|$)/is', '', $s);
-	}
-
-	/**
-	 * Strip query parameter from a string.
-	 *
-	 * @param string $s The input string.
-	 * @param        $param
-	 * @return string The query parameter.
-	 */
-	public static function stripQueryParam($s, $param)
-	{
-		return preg_replace('/[\?&]' . $param . '=(.*?)(&|$)/ism', '$2', $s);
-	}
-
-	/**
 	 * search for Profiles
 	 *
 	 * @param int  $start

--- a/src/Module/Install.php
+++ b/src/Module/Install.php
@@ -111,7 +111,7 @@ class Install extends BaseModule
 				self::checkSetting($configCache, $_POST, 'database', 'database', '');
 
 				// If we cannot connect to the database, return to the previous step
-				if (!self::$installer->checkDB($configCache, $a->getProfiler())) {
+				if (!self::$installer->checkDB($a->getDBA())) {
 					self::$currentWizardStep = self::DATABASE_CONFIG;
 				}
 
@@ -135,7 +135,7 @@ class Install extends BaseModule
 				self::checkSetting($configCache, $_POST, 'config', 'admin_email', '');
 
 				// If we cannot connect to the database, return to the Database config wizard
-				if (!self::$installer->checkDB($configCache, $a->getProfiler())) {
+				if (!self::$installer->checkDB($a->getDBA())) {
 					self::$currentWizardStep = self::DATABASE_CONFIG;
 					return;
 				}

--- a/static/dependencies.config.php
+++ b/static/dependencies.config.php
@@ -4,7 +4,9 @@ use Dice\Dice;
 use Friendica\App;
 use Friendica\Core\Cache;
 use Friendica\Core\Config;
+use Friendica\Core\Frontend;
 use Friendica\Core\Lock\ILock;
+use Friendica\Core\Process;
 use Friendica\Database\Database;
 use Friendica\Factory;
 use Friendica\Util;
@@ -49,7 +51,6 @@ return [
 		]
 	],
 	Util\ConfigFileLoader::class    => [
-		'shared'          => true,
 		'constructParams' => [
 			[Dice::INSTANCE => '$basepath'],
 		],
@@ -146,6 +147,21 @@ return [
 		'instanceOf' => App\Module::class,
 		'call' => [
 			['determineModule', [$_SERVER], Dice::CHAIN_CALL],
+		],
+	],
+	Frontend::class => [
+		'instanceOf' => Frontend::class,
+		'constructParams' => [
+			[Dice::INSTANCE => '$basepath'],
+		],
+		'call' => [
+			['init', [], Dice::CHAIN_CALL],
+			['show', [], Dice::CHAIN_CALL],
+		],
+	],
+	Process::class => [
+		'constructParams' => [
+			[Dice::INSTANCE => '$basepath'],
 		],
 	],
 ];

--- a/static/dependencies.config.php
+++ b/static/dependencies.config.php
@@ -27,14 +27,14 @@ use Psr\Log\LoggerInterface;
  *
  */
 return [
-	'*' => [
+	'*'                             => [
 		// marks all class result as shared for other creations, so there's just
 		// one instance for the whole execution
 		'shared' => true,
 	],
-	'$basepath' => [
-		'instanceOf' => Util\BasePath::class,
-		'call' => [
+	'$basepath'                     => [
+		'instanceOf'      => Util\BasePath::class,
+		'call'            => [
 			['getPath', [], Dice::CHAIN_CALL],
 		],
 		'constructParams' => [
@@ -42,14 +42,14 @@ return [
 			$_SERVER
 		]
 	],
-	Util\BasePath::class => [
+	Util\BasePath::class            => [
 		'constructParams' => [
 			dirname(__FILE__, 2),
 			$_SERVER
 		]
 	],
-	Util\ConfigFileLoader::class => [
-		'shared' => true,
+	Util\ConfigFileLoader::class    => [
+		'shared'          => true,
 		'constructParams' => [
 			[Dice::INSTANCE => '$basepath'],
 		],
@@ -60,24 +60,24 @@ return [
 			['createCache', [], Dice::CHAIN_CALL],
 		],
 	],
-	App\Mode::class => [
-		'call'   => [
+	App\Mode::class                 => [
+		'call' => [
 			['determine', [], Dice::CHAIN_CALL],
 		],
 	],
-	Config\Configuration::class => [
+	Config\Configuration::class     => [
 		'instanceOf' => Factory\ConfigFactory::class,
-		'call' => [
+		'call'       => [
 			['createConfig', [], Dice::CHAIN_CALL],
 		],
 	],
-	Config\PConfiguration::class => [
+	Config\PConfiguration::class    => [
 		'instanceOf' => Factory\ConfigFactory::class,
-		'call' => [
+		'call'       => [
 			['createPConfig', [], Dice::CHAIN_CALL],
 		]
 	],
-	Database::class => [
+	Database::class                 => [
 		'constructParams' => [
 			[DICE::INSTANCE => \Psr\Log\NullLogger::class],
 			$_SERVER,
@@ -89,7 +89,7 @@ return [
 	 * Same as:
 	 *   $baseURL = new Util\BaseURL($configuration, $_SERVER);
 	 */
-	Util\BaseURL::class => [
+	Util\BaseURL::class             => [
 		'constructParams' => [
 			$_SERVER,
 		],
@@ -106,34 +106,46 @@ return [
 	 *    $app = $dice->create(App::class, [], ['$channel' => 'index']);
 	 *    and is automatically passed as an argument with the same name
 	 */
-	LoggerInterface::class    => [
+	LoggerInterface::class          => [
 		'instanceOf' => Factory\LoggerFactory::class,
 		'call'       => [
 			['create', [], Dice::CHAIN_CALL],
 		],
 	],
-	'$devLogger'              => [
+	'$devLogger'                    => [
 		'instanceOf' => Factory\LoggerFactory::class,
 		'call'       => [
 			['createDev', [], Dice::CHAIN_CALL],
 		]
 	],
-	Cache\ICache::class       => [
+	Cache\ICache::class             => [
 		'instanceOf' => Factory\CacheFactory::class,
 		'call'       => [
 			['create', [], Dice::CHAIN_CALL],
 		],
 	],
-	Cache\IMemoryCache::class => [
+	Cache\IMemoryCache::class       => [
 		'instanceOf' => Factory\CacheFactory::class,
 		'call'       => [
 			['create', [], Dice::CHAIN_CALL],
 		],
 	],
-	ILock::class              => [
+	ILock::class                    => [
 		'instanceOf' => Factory\LockFactory::class,
 		'call'       => [
 			['create', [], Dice::CHAIN_CALL],
+		],
+	],
+	App\Arguments::class => [
+		'instanceOf' => App\Arguments::class,
+		'call' => [
+			['determine', [$_SERVER, $_GET], Dice::CHAIN_CALL],
+		],
+	],
+	App\Module::class => [
+		'instanceOf' => App\Module::class,
+		'call' => [
+			['determineModule', [$_SERVER], Dice::CHAIN_CALL],
 		],
 	],
 ];

--- a/tests/src/App/ArgumentsTest.php
+++ b/tests/src/App/ArgumentsTest.php
@@ -1,0 +1,242 @@
+<?php
+
+namespace Friendica\Test\src\App;
+
+use Friendica\App;
+use PHPUnit\Framework\TestCase;
+
+class ArgumentsTest extends TestCase
+{
+	private function assertArguments(array $assert, App\Arguments $arguments)
+	{
+		$this->assertEquals($assert['queryString'], $arguments->getQueryString());
+		$this->assertEquals($assert['command'], $arguments->getCommand());
+		$this->assertEquals($assert['argv'], $arguments->getArgv());
+		$this->assertEquals($assert['argc'], $arguments->getArgc());
+		$this->assertCount($assert['argc'], $arguments->getArgv());
+	}
+
+	/**
+	 * Test the default argument without any determinations
+	 */
+	public function testDefault()
+	{
+		$arguments = new App\Arguments();
+
+		$this->assertArguments([
+			'queryString' => '',
+			'command'     => '',
+			'argv'        => ['home'],
+			'argc'        => 1,
+		],
+			$arguments);
+	}
+
+	public function dataArguments()
+	{
+		return [
+			'withPagename'         => [
+				'assert' => [
+					'queryString' => 'profile/test/it?arg1=value1&arg2=value2',
+					'command'     => 'profile/test/it',
+					'argv'        => ['profile', 'test', 'it'],
+					'argc'        => 3,
+				],
+				'server' => [
+					'QUERY_STRING' => 'pagename=profile/test/it?arg1=value1&arg2=value2',
+				],
+				'get'    => [
+					'pagename' => 'profile/test/it',
+				],
+			],
+			'withQ'                => [
+				'assert' => [
+					'queryString' => 'profile/test/it?arg1=value1&arg2=value2',
+					'command'     => 'profile/test/it',
+					'argv'        => ['profile', 'test', 'it'],
+					'argc'        => 3,
+				],
+				'server' => [
+					'QUERY_STRING' => 'q=profile/test/it?arg1=value1&arg2=value2',
+				],
+				'get'    => [
+					'q' => 'profile/test/it',
+				],
+			],
+			'withWrongDelimiter'   => [
+				'assert' => [
+					'queryString' => 'profile/test/it?arg1=value1&arg2=value2',
+					'command'     => 'profile/test/it',
+					'argv'        => ['profile', 'test', 'it'],
+					'argc'        => 3,
+				],
+				'server' => [
+					'QUERY_STRING' => 'pagename=profile/test/it&arg1=value1&arg2=value2',
+				],
+				'get'    => [
+					'pagename' => 'profile/test/it',
+				],
+			],
+			'withUnixHomeDir'      => [
+				'assert' => [
+					'queryString' => '~test/it?arg1=value1&arg2=value2',
+					'command'     => 'profile/test/it',
+					'argv'        => ['profile', 'test', 'it'],
+					'argc'        => 3,
+				],
+				'server' => [
+					'QUERY_STRING' => 'pagename=~test/it?arg1=value1&arg2=value2',
+				],
+				'get'    => [
+					'pagename' => '~test/it',
+				],
+			],
+			'withDiasporaHomeDir'  => [
+				'assert' => [
+					'queryString' => 'u/test/it?arg1=value1&arg2=value2',
+					'command'     => 'profile/test/it',
+					'argv'        => ['profile', 'test', 'it'],
+					'argc'        => 3,
+				],
+				'server' => [
+					'QUERY_STRING' => 'pagename=u/test/it?arg1=value1&arg2=value2',
+				],
+				'get'    => [
+					'pagename' => 'u/test/it',
+				],
+			],
+			'withTrailingSlash'    => [
+				'assert' => [
+					'queryString' => 'profile/test/it?arg1=value1&arg2=value2/',
+					'command'     => 'profile/test/it',
+					'argv'        => ['profile', 'test', 'it'],
+					'argc'        => 3,
+				],
+				'server' => [
+					'QUERY_STRING' => 'pagename=profile/test/it?arg1=value1&arg2=value2/',
+				],
+				'get'    => [
+					'pagename' => 'profile/test/it',
+				],
+			],
+			'withWrongQueryString' => [
+				'assert' => [
+					// empty query string?!
+					'queryString' => '',
+					'command'     => 'profile/test/it',
+					'argv'        => ['profile', 'test', 'it'],
+					'argc'        => 3,
+				],
+				'server' => [
+					'QUERY_STRING' => 'wrong=profile/test/it?arg1=value1&arg2=value2/',
+				],
+				'get'    => [
+					'pagename' => 'profile/test/it',
+				],
+			],
+			'withMissingPageName'  => [
+				'assert' => [
+					'queryString' => 'notvalid/it?arg1=value1&arg2=value2/',
+					'command'     => App\Module::DEFAULT,
+					'argv'        => [App\Module::DEFAULT],
+					'argc'        => 1,
+				],
+				'server' => [
+					'QUERY_STRING' => 'pagename=notvalid/it?arg1=value1&arg2=value2/',
+				],
+				'get'    => [
+				],
+			],
+		];
+	}
+
+	/**
+	 * Test all variants of argument determination
+	 *
+	 * @dataProvider dataArguments
+	 */
+	public function testDetermine(array $assert, array $server, array $get)
+	{
+		$arguments = (new App\Arguments())
+			->determine($server, $get);
+
+		$this->assertArguments($assert, $arguments);
+	}
+
+	/**
+	 * Test if the get/has methods are working for the determined arguments
+	 *
+	 * @dataProvider dataArguments
+	 */
+	public function testGetHas(array $assert, array $server, array $get)
+	{
+		$arguments = (new App\Arguments())
+			->determine($server, $get);
+
+		for ($i = 0; $i < $arguments->getArgc(); $i++) {
+			$this->assertTrue($arguments->has($i));
+			$this->assertEquals($assert['argv'][$i], $arguments->get($i));
+		}
+
+		$this->assertFalse($arguments->has($arguments->getArgc()));
+		$this->assertEmpty($arguments->get($arguments->getArgc()));
+		$this->assertEquals('default', $arguments->get($arguments->getArgc(), 'default'));
+	}
+
+	public function dataStripped()
+	{
+		return [
+			'strippedZRLFirst'  => [
+				'assert' => '?arg1=value1',
+				'input'  => '?zrl=nope&arg1=value1',
+			],
+			'strippedZRLLast'   => [
+				'assert' => '?arg1=value1',
+				'input'  => '?arg1=value1&zrl=nope',
+			],
+			'strippedZTLMiddle' => [
+				'assert' => '?arg1=value1&arg2=value2',
+				'input'  => '?arg1=value1&zrl=nope&arg2=value2',
+			],
+			'strippedOWTFirst'  => [
+				'assert' => '?arg1=value1',
+				'input'  => '?owt=test&arg1=value1',
+			],
+			'strippedOWTLast'   => [
+				'assert' => '?arg1=value1',
+				'input'  => '?arg1=value1&owt=test',
+			],
+			'strippedOWTMiddle' => [
+				'assert' => '?arg1=value1&arg2=value2',
+				'input'  => '?arg1=value1&owt=test&arg2=value2',
+			],
+		];
+	}
+
+	/**
+	 * Test the ZRL and OWT stripping
+	 *
+	 * @dataProvider dataStripped
+	 */
+	public function testStrippedQueries(string $assert, string $input)
+	{
+		$command = 'test/it';
+
+		$arguments = (new App\Arguments())
+			->determine(['QUERY_STRING' => 'q=' . $command . $input,], ['pagename' => $command]);
+
+		$this->assertEquals($command . $assert, $arguments->getQueryString());
+	}
+
+	/**
+	 * Test that arguments are immutable
+	 */
+	public function testImmutable()
+	{
+		$argument = new App\Arguments();
+
+		$argNew = $argument->determine([], []);
+
+		$this->assertNotSame($argument, $argNew);
+	}
+}

--- a/tests/src/App/ModuleTest.php
+++ b/tests/src/App/ModuleTest.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace Friendica\Test\src\App;
+
+use Friendica\App;
+use Friendica\Core\Config\Configuration;
+use Friendica\LegacyModule;
+use Friendica\Module\PageNotFound;
+use Friendica\Module\WellKnown\HostMeta;
+use Friendica\Test\DatabaseTest;
+
+class ModuleTest extends DatabaseTest
+{
+	private function assertModule(array $assert, App\Module $module)
+	{
+		$this->assertEquals($assert['isBackend'], $module->isBackend());
+		$this->assertEquals($assert['name'], $module->getName());
+		$this->assertEquals($assert['class'], $module->getClassName());
+	}
+
+	/**
+	 * Test the default module mode
+	 */
+	public function testDefault()
+	{
+		$module = new App\Module();
+
+		$this->assertModule([
+			'isBackend' => false,
+			'name'      => App\Module::DEFAULT,
+			'class'     => App\Module::DEFAULT_CLASS,
+		], $module);
+	}
+
+	public function dataModuleName()
+	{
+		return [
+			'default'                   => [
+				'assert' => [
+					'isBackend' => false,
+					'name'      => 'network',
+					'class'     => App\Module::DEFAULT_CLASS,
+				],
+				'args'   => new App\Arguments('network/data/in',
+					'network/data/in',
+					['network', 'data', 'in'],
+					3),
+				'server' => [],
+			],
+			'withStrikeAndPoint'        => [
+				'assert' => [
+					'isBackend' => false,
+					'name'      => 'with_strike_and_point',
+					'class'     => App\Module::DEFAULT_CLASS,
+				],
+				'args'   => new App\Arguments('with-strike.and-point/data/in',
+					'with-strike.and-point/data/in',
+					['with-strike.and-point', 'data', 'in'],
+					3),
+				'server' => [],
+			],
+			'withNothing'               => [
+				'assert' => [
+					'isBackend' => false,
+					'name'      => App\Module::DEFAULT,
+					'class'     => App\Module::DEFAULT_CLASS,
+				],
+				'args'   => new App\Arguments(),
+				'server' => []
+			],
+			'withIndex'                 => [
+				'assert' => [
+					'isBackend' => false,
+					'name'      => App\Module::DEFAULT,
+					'class'     => App\Module::DEFAULT_CLASS,
+				],
+				'args'   => new App\Arguments(),
+				'server' => ['PHP_SELF' => 'index.php']
+			],
+			'withIndexButBackendMod'    => [
+				'assert' => [
+					'isBackend' => false,
+					'name'      => App\Module::BACKEND_MODULES[0],
+					'class'     => App\Module::DEFAULT_CLASS,
+				],
+				'args'   => new App\Arguments(App\Module::BACKEND_MODULES[0] . '/data/in',
+					App\Module::BACKEND_MODULES[0] . '/data/in',
+					[App\Module::BACKEND_MODULES[0], 'data', 'in'],
+					3),
+				'server' => ['PHP_SELF' => 'index.php']
+			],
+			'withNotIndexAndBackendMod' => [
+				'assert' => [
+					'isBackend' => true,
+					'name'      => App\Module::BACKEND_MODULES[0],
+					'class'     => App\Module::DEFAULT_CLASS,
+				],
+				'args'   => new App\Arguments(App\Module::BACKEND_MODULES[0] . '/data/in',
+					App\Module::BACKEND_MODULES[0] . '/data/in',
+					[App\Module::BACKEND_MODULES[0], 'data', 'in'],
+					3),
+				'server' => ['PHP_SELF' => 'daemon.php']
+			],
+			'withFirefoxApp'            => [
+				'assert' => [
+					'isBackend' => false,
+					'name'      => 'login',
+					'class'     => App\Module::DEFAULT_CLASS,
+				],
+				'args'   => new App\Arguments('users/sign_in',
+					'users/sign_in',
+					['users', 'sign_in'],
+					3),
+				'server' => ['PHP_SELF' => 'index.php'],
+			],
+		];
+	}
+
+	/**
+	 * Test the module name and backend determination
+	 *
+	 * @dataProvider dataModuleName
+	 */
+	public function testModuleName(array $assert, App\Arguments $args, array $server)
+	{
+		$module = (new App\Module())->determineModule($args, $server);
+
+		$this->assertModule($assert, $module);
+	}
+
+	public function dataModuleClass()
+	{
+		return [
+			'default' => [
+				'assert'  => App\Module::DEFAULT_CLASS,
+				'name'    => App\Module::DEFAULT,
+				'command' => App\Module::DEFAULT,
+				'privAdd' => false,
+			],
+			'legacy'  => [
+				'assert'  => LegacyModule::class,
+				// API is one of the last modules to switch from legacy to new BaseModule
+				// so this should be a stable test case until we completely switch ;-)
+				'name'    => 'api',
+				'command' => 'api/test/it',
+				'privAdd' => false,
+			],
+			'new'     => [
+				'assert'  => HostMeta::class,
+				'not_required',
+				'command' => '.well-known/host-meta',
+				'privAdd' => false,
+			],
+			'404'     => [
+				'assert'  => PageNotFound::class,
+				'name'    => 'invalid',
+				'command' => 'invalid',
+				'privAdd' => false,
+			]
+		];
+	}
+
+	/**
+	 * Test the determination of the module class
+	 *
+	 * @dataProvider dataModuleClass
+	 */
+	public function testModuleClass($assert, string $name, string $command, bool $privAdd)
+	{
+		$config = \Mockery::mock(Configuration::class);
+		$config->shouldReceive('get')->with('config', 'private_addons', false)->andReturn($privAdd)->atMost()->once();
+
+		$module = (new App\Module($name))->determineClass(new App\Arguments('', $command), new App\Router(), $config);
+
+		$this->assertEquals($assert, $module->getClassName());
+	}
+
+	/**
+	 * Test that modules are immutable
+	 */
+	public function testImmutable()
+	{
+		$module = new App\Module();
+
+		$moduleNew = $module->determineModule(new App\Arguments(), []);
+
+		$this->assertNotSame($moduleNew, $module);
+	}
+}


### PR DESCRIPTION
FollowUp of #7500 

- Move frontend related logic from `App` to the `Frontend` class
- Split the class into two states (init, show)
- Move process related logic from `App` to the `Process` class

This reduces the `App` content massively and encapsulates the whole frontend-logic into a class. So Worker or Daemons, which are now using the `App` class, don't necessarly load the whole frontend environment too.

ToDo
- [x] Merge #7500  first
- [ ] Add tests
- [x] Run on local node
- [ ] Run on friendica.philipp.info