### PR TITLE
Queue numbers corrected, only display 999 queue items

### DIFF
--- a/src/Module/Admin/Queue.php
+++ b/src/Module/Admin/Queue.php
@@ -30,17 +30,17 @@ class Queue extends BaseAdminModule
 
 		// get jobs from the workerqueue table
 		if ($deferred) {
-			$condition = ["NOT `done` AND `next_try` > ?", DateTimeFormat::utcNow()];
+			$condition = ["NOT `done` AND `retrial` > ?", 0];
 			$sub_title = L10n::t('Inspect Deferred Worker Queue');
 			$info = L10n::t("This page lists the deferred worker jobs. This are jobs that couldn't be executed at the first time.");
 		} else {
-			$condition = ["NOT `done` AND `next_try` < ?", DateTimeFormat::utcNow()];
+			$condition = ["NOT `done` AND `retrial` = ?", 0];
 			$sub_title = L10n::t('Inspect Worker Queue');
 			$info = L10n::t('This page lists the currently queued worker jobs. These jobs are handled by the worker cronjob you\'ve set up during install.');
 		}
 
 		// @TODO Move to Model\WorkerQueue::getEntries()
-		$entries = DBA::select('workerqueue', ['id', 'parameter', 'created', 'priority'], $condition, ['order' => ['priority']]);
+		$entries = DBA::select('workerqueue', ['id', 'parameter', 'created', 'priority'], $condition, ['limit' => 999, 'order' => ['created']]);
 
 		$r = [];
 		while ($entry = DBA::fetch($entries)) {

--- a/src/Module/Admin/Summary.php
+++ b/src/Module/Admin/Summary.php
@@ -146,11 +146,9 @@ class Summary extends BaseAdminModule
 
 		$pending = Register::getPendingCount();
 
-		$deferred = DBA::count('workerqueue', ['`executed` <= ? AND NOT `done` AND `next_try` > ?',
-			DBA::NULL_DATETIME, DateTimeFormat::utcNow()]);
+		$deferred = DBA::count('workerqueue', ['NOT `done` AND `retrial` > ?', 0]);
 
-		$workerqueue = DBA::count('workerqueue', ['`executed` <= ? AND NOT `done` AND `next_try` < ?',
-			DBA::NULL_DATETIME, DateTimeFormat::utcNow()]);
+		$workerqueue = DBA::count('workerqueue', ['NOT `done` AND `retrial` = ?', 0]);
 
 		// We can do better, but this is a quick queue status
 		$queues = ['label' => L10n::t('Message queues'), 'deferred' => $deferred, 'workerq' => $workerqueue];


### PR DESCRIPTION
The numbers for queued items had been wrong. Additionally we only display the first 999 entries and we order them to show the oldest ones first.