### PR TITLE
Use the contact id whenever we are following the contact

### DIFF
--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -1243,6 +1243,8 @@ class Item extends BaseObject
 	{
 		if (!empty($item['contact-id']) && DBA::exists('contact', ['self' => true, 'id' => $item['contact-id']])) {
 			return $item['contact-id'];
+		} elseif (($item['gravity'] == GRAVITY_PARENT) && !empty($item['uid']) && !empty($item['contact-id']) && Contact::isSharing($item['contact-id'], $item['uid'])) {
+			return $item['contact-id'];
 		} elseif (!empty($item['uid']) && !Contact::isSharing($item['author-id'], $item['uid'])) {
 			return $item['author-id'];
 		} elseif (!empty($item['contact-id'])) {


### PR DESCRIPTION
The "contactId" function had an issue with forum posts from people that we do not follow. This resulted in using the "author-id" field. Now we do use the "contact-id" field whenever we really follow this contact.

At some time in the future I would like to assign the contact id in the item class only. This would reduce the code in the protocol classes. But until now this isn't possible.