### PR TITLE
Allow protocol-less links

### DIFF
--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -1753,18 +1753,24 @@ class BBCode extends BaseObject
 		$text = preg_replace('/\<([^>]*?)(src|href)=(.*?)\&amp\;(.*?)\>/ism', '<$1$2=$3&$4>', $text);
 
 		// sanitizes src attributes (http and redir URLs for displaying in a web page, cid used for inline images in emails)
-		$allowed_src_protocols = ['//', 'http', 'redir', 'cid'];
+		$allowed_src_protocols = ['//', 'http://', 'https://', 'redir/', 'cid:'];
+
+		array_walk($allowed_src_protocols, function(&$value) { $value = preg_quote($value, '#');});
+
 		$text = preg_replace('#<([^>]*?)(src)="(?!' . implode('|', $allowed_src_protocols) . ')(.*?)"(.*?)>#ism',
 					 '<$1$2=""$4 data-original-src="$3" class="invalid-src" title="' . L10n::t('Invalid source protocol') . '">', $text);
 
 		// sanitize href attributes (only whitelisted protocols URLs)
 		// default value for backward compatibility
-		$allowed_link_protocols = Config::get('system', 'allowed_link_protocols', ['ftp', 'mailto', 'gopher', 'cid']);
+		$allowed_link_protocols = Config::get('system', 'allowed_link_protocols', []);
 
 		// Always allowed protocol even if config isn't set or not including it
-		$allowed_link_protocols[] = 'http';
 		$allowed_link_protocols[] = '//';
+		$allowed_link_protocols[] = 'http://';
+		$allowed_link_protocols[] = 'https://';
 		$allowed_link_protocols[] = 'redir/';
+
+		array_walk($allowed_link_protocols, function(&$value) { $value = preg_quote($value, '#');});
 
 		$regex = '#<([^>]*?)(href)="(?!' . implode('|', $allowed_link_protocols) . ')(.*?)"(.*?)>#ism';
 		$text = preg_replace($regex, '<$1$2="javascript:void(0)"$4 data-original-href="$3" class="invalid-href" title="' . L10n::t('Invalid link protocol') . '">', $text);

--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -1753,7 +1753,7 @@ class BBCode extends BaseObject
 		$text = preg_replace('/\<([^>]*?)(src|href)=(.*?)\&amp\;(.*?)\>/ism', '<$1$2=$3&$4>', $text);
 
 		// sanitizes src attributes (http and redir URLs for displaying in a web page, cid used for inline images in emails)
-		$allowed_src_protocols = ['http', 'redir', 'cid'];
+		$allowed_src_protocols = ['//', 'http', 'redir', 'cid'];
 		$text = preg_replace('#<([^>]*?)(src)="(?!' . implode('|', $allowed_src_protocols) . ')(.*?)"(.*?)>#ism',
 					 '<$1$2=""$4 data-original-src="$3" class="invalid-src" title="' . L10n::t('Invalid source protocol') . '">', $text);
 
@@ -1763,6 +1763,7 @@ class BBCode extends BaseObject
 
 		// Always allowed protocol even if config isn't set or not including it
 		$allowed_link_protocols[] = 'http';
+		$allowed_link_protocols[] = '//';
 		$allowed_link_protocols[] = 'redir/';
 
 		$regex = '#<([^>]*?)(href)="(?!' . implode('|', $allowed_link_protocols) . ')(.*?)"(.*?)>#ism';

--- a/static/defaults.config.php
+++ b/static/defaults.config.php
@@ -52,8 +52,8 @@ return [
 	],
 	'system' => [
 		// allowed_link_protocols (Array)
-		// Allowed protocols in links URLs, add at your own risk. http is always allowed.
-		'allowed_link_protocols' => ['ftp', 'ftps', 'mailto', 'cid', 'gopher'],
+		// Allowed protocols in links URLs, add at your own risk. http(s) is always allowed.
+		'allowed_link_protocols' => ['ftp://', 'ftps://', 'mailto:', 'cid:', 'gopher://'],
 
 		// always_show_preview (Boolean)
 		// Only show small preview pictures.


### PR DESCRIPTION
This PR adds support for protocol-less links, depending on the node's HTTPS status, it will open the target link with the same protocol as the parent page.

It also makes the default allowed protocols more specific (by adding more characters to the prefix-matching regular expression). This changes covers a ridiculously small amount of edge cases so it shouldn't affect any display.