### PR TITLE
Fix Locks

### DIFF
--- a/src/Core/Lock/DatabaseLock.php
+++ b/src/Core/Lock/DatabaseLock.php
@@ -82,7 +82,11 @@ class DatabaseLock extends Lock
 			$where = ['name' => $key, 'pid' => $this->pid];
 		}
 
-		$return = $this->dba->delete('locks', $where);
+		if ($this->dba->exists('locks', $where)) {
+			$return = $this->dba->delete('locks', $where);
+		} else {
+			$return = false;
+		}
 
 		$this->markRelease($key);
 
@@ -105,7 +109,7 @@ class DatabaseLock extends Lock
 
 		$this->acquiredLocks = [];
 
-		return $return;
+		return $return && $success;
 	}
 
 	/**

--- a/src/Factory/LockFactory.php
+++ b/src/Factory/LockFactory.php
@@ -7,7 +7,6 @@ use Friendica\Core\Cache\IMemoryCache;
 use Friendica\Core\Config\Configuration;
 use Friendica\Core\Lock;
 use Friendica\Database\Database;
-use Friendica\Util\Profiler;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -40,16 +39,11 @@ class LockFactory
 	private $cacheFactory;
 
 	/**
-	 * @var Profiler The optional profiler if the cached should be profiled
-	 */
-	private $profiler;
-
-	/**
 	 * @var LoggerInterface The Friendica Logger
 	 */
 	private $logger;
 
-	public function __construct(CacheFactory $cacheFactory, Configuration $config, Database $dba, Profiler $profiler, LoggerInterface $logger)
+	public function __construct(CacheFactory $cacheFactory, Configuration $config, Database $dba, LoggerInterface $logger)
 	{
 		$this->cacheFactory = $cacheFactory;
 		$this->config       = $config;

--- a/tests/src/Core/Lock/LockTest.php
+++ b/tests/src/Core/Lock/LockTest.php
@@ -190,4 +190,13 @@ abstract class LockTest extends MockedTest
 		$this->assertFalse($this->instance->isLocked('foo'));
 		$this->assertFalse($this->instance->isLocked('bar'));
 	}
+
+	/**
+	 * Test if releasing a non-existing lock doesn't throw errors
+	 */
+	public function testReleaseLockWithoutLock()
+	{
+		$this->assertFalse($this->instance->isLocked('wrongLock'));
+		$this->assertFalse($this->instance->releaseLock('wrongLock'));
+	}
 }

--- a/tests/src/Core/Lock/SemaphoreLockTest.php
+++ b/tests/src/Core/Lock/SemaphoreLockTest.php
@@ -22,7 +22,7 @@ class SemaphoreLockTest extends LockTest
 		$configMock
 			->shouldReceive('get')
 			->with('system', 'temppath', NULL, false)
-			->andReturn('/tmp');
+			->andReturn('/tmp/');
 		$dice->shouldReceive('create')->with(Configuration::class)->andReturn($configMock);
 
 		// @todo Because "get_temppath()" is using static methods, we have to initialize the BaseObject
@@ -43,11 +43,13 @@ class SemaphoreLockTest extends LockTest
 	}
 
 	/**
-	 * Test if semaphore locking works even for
+	 * Test if semaphore locking works even when trying to release locks, where the file exists
+	 * but it shouldn't harm locking
 	 */
 	public function testMissingFileNotOverriding()
 	{
 		$file = get_temppath() . '/test.sem';
+		touch($file);
 
 		$this->assertTrue(file_exists($file));
 		$this->assertFalse($this->instance->releaseLock('test', false));
@@ -64,9 +66,24 @@ class SemaphoreLockTest extends LockTest
 	public function testMissingFileOverriding()
 	{
 		$file = get_temppath() . '/test.sem';
+		touch($file);
 
 		$this->assertTrue(file_exists($file));
 		$this->assertFalse($this->instance->releaseLock('test', true));
 		$this->assertTrue(file_exists($file));
+	}
+
+	/**
+	 * Test acquire lock even the semaphore file exists, but isn't used
+	 */
+	public function testOverrideSemFile()
+	{
+		$file = get_temppath() . '/test.sem';
+		touch($file);
+
+		$this->assertTrue(file_exists($file));
+		$this->assertTrue($this->instance->acquireLock('test'));
+		$this->assertTrue($this->instance->isLocked('test'));
+		$this->assertTrue($this->instance->releaseLock('test'));
 	}
 }

--- a/tests/src/Core/Lock/SemaphoreLockTest.php
+++ b/tests/src/Core/Lock/SemaphoreLockTest.php
@@ -22,7 +22,7 @@ class SemaphoreLockTest extends LockTest
 		$configMock
 			->shouldReceive('get')
 			->with('system', 'temppath', NULL, false)
-			->andReturn('/tmp/');
+			->andReturn('/tmp');
 		$dice->shouldReceive('create')->with(Configuration::class)->andReturn($configMock);
 
 		// @todo Because "get_temppath()" is using static methods, we have to initialize the BaseObject
@@ -40,5 +40,33 @@ class SemaphoreLockTest extends LockTest
 	{
 		// Semaphore doesn't work with TTL
 		return true;
+	}
+
+	/**
+	 * Test if semaphore locking works even for
+	 */
+	public function testMissingFileNotOverriding()
+	{
+		$file = get_temppath() . '/test.sem';
+
+		$this->assertTrue(file_exists($file));
+		$this->assertFalse($this->instance->releaseLock('test', false));
+		$this->assertTrue(file_exists($file));
+	}
+
+	/**
+	 * Test overriding semaphore release with already set semaphore
+	 * This test proves that semaphore locks cannot get released by other instances except themselves
+	 *
+	 * Check for Bug https://github.com/friendica/friendica/issues/7298#issuecomment-521996540
+	 * @see https://github.com/friendica/friendica/issues/7298#issuecomment-521996540
+	 */
+	public function testMissingFileOverriding()
+	{
+		$file = get_temppath() . '/test.sem';
+
+		$this->assertTrue(file_exists($file));
+		$this->assertFalse($this->instance->releaseLock('test', true));
+		$this->assertTrue(file_exists($file));
 	}
 }


### PR DESCRIPTION
- Wrong return of lock releasing with DBA provider
- It's not possible to maintain Semaphore locks, since they aren't accessible by other processes
Should solve https://github.com/friendica/friendica/issues/7298#issuecomment-521996540

FollowUp of #7518 and #7515 