### PR TITLE
fix vier mobile display

### DIFF
--- a/view/theme/vier/mobile.css
+++ b/view/theme/vier/mobile.css
@@ -1,4 +1,4 @@
-aside, header, #nav-search-box, #nav-admin-link, #nav-messages-linkmenu,  #activitiy-by-date-tab, #shared-links-tab,
+aside, header, #nav-search-box, #nav-admin-link, #nav-messages-linkmenu,  #activitiy-by-date-tab, #shared-links-tab, #nav-logout-link,
 .wall-item-location {
   display: none;
 }


### PR DESCRIPTION
The normalisation of the logout link in the navbar lead to a breakage in the mobile view of the vier theme. As the logout button is also part of the user menu in vier, it can be hidden in mobile view from the nax bar to fix the appearence.