### PR TITLE
Fix table structure definition

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -1,6 +1,6 @@
 -- ------------------------------------------
 -- Friendica 2019.09-rc (Dalmatian Bellflower)
--- DB_UPDATE_VERSION 1321
+-- DB_UPDATE_VERSION 1322
 -- ------------------------------------------
 
 
@@ -15,7 +15,7 @@ CREATE TABLE IF NOT EXISTS `2fa_app_specific_password` (
 	`generated` datetime NOT NULL COMMENT 'Datetime the password was generated',
 	`last_used` datetime COMMENT 'Datetime the password was last used',
 	 PRIMARY KEY(`id`),
-	 INDEX `uid_description` (`uid`,`description`)
+	 INDEX `uid_description` (`uid`,`description`(190))
 ) DEFAULT COLLATE utf8mb4_general_ci COMMENT='Two-factor app-specific _password';
 
 --

--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -44,13 +44,13 @@ return [
 			"id" => ["type" => "mediumint unsigned", "not null" => "1", "extra" => "auto_increment", "primary" => "1", "comment" => "Password ID for revocation"],
 			"uid" => ["type" => "mediumint unsigned", "not null" => "1", "relation" => ["user" => "uid"], "comment" => "User ID"],
 			"description" => ["type" => "varchar(255)", "comment" => "Description of the usage of the password"],
-			"hashed_password" => ["type" => "varchar(255)", "not null" => "1", "primary" => "1", "comment" => "Hashed password"],
+			"hashed_password" => ["type" => "varchar(255)", "not null" => "1", "comment" => "Hashed password"],
 			"generated" => ["type" => "datetime", "not null" => "1", "comment" => "Datetime the password was generated"],
 			"last_used" => ["type" => "datetime", "comment" => "Datetime the password was last used"],
 		],
 		"indexes" => [
 			"PRIMARY" => ["id"],
-			"uid_description" => ["uid", "description"],
+			"uid_description" => ["uid", "description(190)"],
 		]
 	],
 	"2fa_recovery_codes" => [

--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -34,7 +34,7 @@
 use Friendica\Database\DBA;
 
 if (!defined('DB_UPDATE_VERSION')) {
-	define('DB_UPDATE_VERSION', 1321);
+	define('DB_UPDATE_VERSION', 1322);
 }
 
 return [


### PR DESCRIPTION
The table structure is fixed. Strings in indexes must kept under a specific length. Additionally the "primary" value confused the update script as well, since that field isn't in the primary index.