### PR TITLE
Output better comparable log entries for the worker

### DIFF
--- a/src/Core/Worker.php
+++ b/src/Core/Worker.php
@@ -701,6 +701,8 @@ class Worker
 				DBA::close($jobs);
 			}
 
+			$waiting_processes -= $deferred;
+
 			$listitem[0] = "0:" . max(0, $idle_workers);
 
 			$processlist .= ' ('.implode(', ', $listitem).')';


### PR DESCRIPTION
The logger output for the worker (for example this one: ```Load: 1.55/20 - processes: 72598/23/13945 - jpm: 249```) now returns values that are comparable with the ones on the /admin page:

```
Nachrichten-Warteschlangen
72657 - 14631
```

Means: The left value is the number of deferred jobs, the right one is the number of non deferred jobs.