### PR TITLE
Issue 7559: Merge contact duplicates

### DIFF
--- a/src/Worker/MergeContact.php
+++ b/src/Worker/MergeContact.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * @file src/Worker/MergeContact.php
+ */
+
+namespace Friendica\Worker;
+
+use Friendica\Core\Logger;
+use Friendica\Database\DBA;
+
+class MergeContact
+{
+	public static function execute($first, $dup_id, $uid)
+	{
+		if (empty($first) || empty($dup_id) || ($first == $dup_id)) {
+			// Invalid request
+			return;
+		}
+
+		Logger::info('Handling duplicate', ['search' => $dup_id, 'replace' => $first]);
+
+		// Search and replace
+		DBA::update('item', ['contact-id' => $first], ['contact-id' => $dup_id]);
+		DBA::update('thread', ['contact-id' => $first], ['contact-id' => $dup_id]);
+		DBA::update('mail', ['contact-id' => $first], ['contact-id' => $dup_id]);
+		DBA::update('photo', ['contact-id' => $first], ['contact-id' => $dup_id]);
+		DBA::update('event', ['cid' => $first], ['cid' => $dup_id]);
+		if ($uid == 0) {
+			DBA::update('item', ['author-id' => $first], ['author-id' => $dup_id]);
+			DBA::update('item', ['owner-id' => $first], ['owner-id' => $dup_id]);
+			DBA::update('thread', ['author-id' => $first], ['author-id' => $dup_id]);
+			DBA::update('thread', ['owner-id' => $first], ['owner-id' => $dup_id]);
+		} else {
+			/// @todo Check if some other data needs to be adjusted as well, possibly the "rel" status?
+		}
+
+		// Remove the duplicate
+		DBA::delete('contact', ['id' => $dup_id]);
+	}
+}


### PR DESCRIPTION
This should fix https://github.com/friendica/friendica/issues/7559

When we detect a duplicated contact we now will merge the duplicates. We did this before, but only for public ones. In my tests it did work fine for personal contacts as well.

This will not work for Friendica contacts since there we do negotiate individual keys. This means that we cannot handle duplicates there.

The changes won't fix the problem immediately, but the next time that one of these contacts is refreshed. One can trigger it manually by updating the contact from the "crepair" page. Then all duplicates will disappear and only the first one will stay.