### PR TITLE
Some code hardenings for semaphore locking

### DIFF
--- a/src/Core/Lock/SemaphoreLock.php
+++ b/src/Core/Lock/SemaphoreLock.php
@@ -39,8 +39,8 @@ class SemaphoreLock extends Lock
 	public function acquireLock($key, $timeout = 120, $ttl = Cache\Cache::FIVE_MINUTES)
 	{
 		self::$semaphore[$key] = sem_get(self::semaphoreKey($key));
-		if (self::$semaphore[$key]) {
-			if (sem_acquire(self::$semaphore[$key], ($timeout == 0))) {
+		if (!empty(self::$semaphore[$key])) {
+			if ((bool)sem_acquire(self::$semaphore[$key], ($timeout === 0))) {
 				$this->markAcquire($key);
 				return true;
 			}


### PR DESCRIPTION
Maybe fixes https://github.com/friendica/friendica/issues/7298#issuecomment-523120336

To be honest I don't know how the identifier can get lost after calling `sem_get`.. But maybe there's a compare issue.. I cleaned it up