### PR TITLE
Fixing PHP Fatal Error

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -4,6 +4,7 @@ namespace Friendica\Database;
 
 use Friendica\Core\Config\Cache\ConfigCache;
 use Friendica\Core\System;
+use Friendica\Network\HTTPException\InternalServerErrorException;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Profiler;
 use mysqli;
@@ -126,7 +127,7 @@ class Database
 				$this->connection->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
 				$this->connected = true;
 			} catch (PDOException $e) {
-				/// @TODO At least log exception, don't ignore it!
+				$this->connected = false;
 			}
 		}
 
@@ -483,6 +484,10 @@ class Database
 		}
 		// We are having an own error logging in the function "e"
 		$called_from_e = ($called_from['function'] == 'e');
+
+		if (!isset($this->connection)) {
+			throw new InternalServerErrorException('The Connection is empty, although connected is set true.');
+		}
 
 		switch ($this->driver) {
 			case 'pdo':


### PR DESCRIPTION
- https://github.com/friendica/friendica/issues/7297#issuecomment-522367163 - Incomplete array after probing, so `Contact` model throw errors.
- https://github.com/friendica/friendica/issues/7297#issuecomment-522695270 - @ben-utzer is right that this had something to do with the reconnect. It seems that the `connected` flag remaind true, but the `connection` threw an exception because of the limit. I'm now checking this situation for connect.