### PR TITLE
Don't transmit content to already archived contacts

### DIFF
--- a/src/Core/Worker.php
+++ b/src/Core/Worker.php
@@ -671,7 +671,7 @@ class Worker
 				$waiting_processes = 0;
 				// Now adding all processes with workerqueue entries
 				$stamp = (float)microtime(true);
-				$jobs = DBA::p("SELECT COUNT(*) AS `entries`, `priority` FROM `workerqueue` WHERE NOT `done` AND `next_try` < ? GROUP BY `priority`", DateTimeFormat::utcNow());
+				$jobs = DBA::p("SELECT COUNT(*) AS `entries`, `priority` FROM `workerqueue` WHERE NOT `done` GROUP BY `priority`");
 				self::$db_duration += (microtime(true) - $stamp);
 				self::$db_duration_stat += (microtime(true) - $stamp);
 				while ($entry = DBA::fetch($jobs)) {

--- a/src/Core/Worker.php
+++ b/src/Core/Worker.php
@@ -1243,7 +1243,7 @@ class Worker
 		$new_retrial = self::getNextRetrial($queue, $max_level);
 
 		if ($new_retrial > $max_level) {
-			Logger::info('The task exceeded the maximum retry count', ['id' => $id, 'max_level' => $max_level, 'retrial' => $new_retrial]);
+			Logger::info('The task exceeded the maximum retry count', ['id' => $id, 'created' => $queue['created'], 'old_prio' => $queue['priority'], 'old_retrial' => $queue['retrial'], 'max_level' => $max_level, 'retrial' => $new_retrial]);
 			return false;
 		}
 
@@ -1259,7 +1259,7 @@ class Worker
 			$priority = PRIORITY_NEGLIGIBLE;
 		}
 
-		Logger::info('Deferred task', ['id' => $id, 'retrial' => $new_retrial, 'next_execution' => $next, 'old_prio' => $queue['priority'], 'new_prio' => $priority]);
+		Logger::info('Deferred task', ['id' => $id, 'retrial' => $new_retrial, 'created' => $queue['created'], 'next_execution' => $next, 'old_prio' => $queue['priority'], 'new_prio' => $priority]);
 
 		$stamp = (float)microtime(true);
 		$fields = ['retrial' => $new_retrial, 'next_try' => $next, 'executed' => DBA::NULL_DATETIME, 'pid' => 0, 'priority' => $priority];

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -1592,6 +1592,7 @@ class Contact extends BaseObject
 			return true;
 		}
 
+		/// @todo Add tests for Diaspora endpoints as well
 		return false;
 	}
 

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -223,7 +223,7 @@ class Diaspora
 				`fcontact`.`batch` AS `fbatch`, `fcontact`.`network` AS `fnetwork` FROM `participation`
 				INNER JOIN `contact` ON `contact`.`id` = `participation`.`cid`
 				INNER JOIN `fcontact` ON `fcontact`.`id` = `participation`.`fid`
-				WHERE `participation`.`iid` = ?", $thread);
+				WHERE `participation`.`iid` = ? AND NOT `contact`.`archive`", $thread);
 
 		while ($contact = DBA::fetch($r)) {
 			if (!empty($contact['fnetwork'])) {

--- a/src/Worker/Delivery.php
+++ b/src/Worker/Delivery.php
@@ -33,7 +33,7 @@ class Delivery extends BaseObject
 
 	public static function execute($cmd, $target_id, $contact_id)
 	{
-		Logger::log('Invoked: ' . $cmd . ': ' . $target_id . ' to ' . $contact_id, Logger::DEBUG);
+		Logger::info('Invoked', ['cmd' => $cmd, 'target' => $target_id, 'contact' => $contact_id]);
 
 		$top_level = false;
 		$followup = false;
@@ -93,6 +93,14 @@ class Delivery extends BaseObject
 				$uid = $target_item['uid'];
 			} else {
 				Logger::log('Only public users for item ' . $target_id, Logger::DEBUG);
+				return;
+			}
+
+			if (!empty($contact_id) && Model\Contact::isArchived($contact_id)) {
+				Logger::info('Contact is archived', ['id' => $contact_id, 'cmd' => $cmd, 'item' => $target_item['id']]);
+				if (in_array($cmd, [Delivery::POST, Delivery::POKE])) {
+					Model\ItemDeliveryData::incrementQueueFailed($target_item['id']);
+				}
 				return;
 			}
 

--- a/src/Worker/Notifier.php
+++ b/src/Worker/Notifier.php
@@ -429,6 +429,11 @@ class Notifier
 
 			if (DBA::isResult($r)) {
 				foreach ($r as $rr) {
+					if (!empty($rr['id']) && Contact::isArchived($rr['id'])) {
+						Logger::info('Contact is archived', $rr);
+						continue;
+					}
+
 					if (self::isRemovalActivity($cmd, $owner, $rr['network'])) {
 						Logger::log('Skipping dropping for ' . $rr['url'] . ' since the network supports account removal commands.', Logger::DEBUG);
 						continue;
@@ -463,6 +468,11 @@ class Notifier
 
 		// delivery loop
 		while ($contact = DBA::fetch($delivery_contacts_stmt)) {
+			if (!empty($contact['id']) && Contact::isArchived($contact['id'])) {
+				Logger::info('Contact is archived', $contact);
+				continue;
+			}
+
 			if (self::isRemovalActivity($cmd, $owner, $contact['network'])) {
 				Logger::log('Skipping dropping for ' . $contact['url'] . ' since the network supports account removal commands.', Logger::DEBUG);
 				continue;


### PR DESCRIPTION
There is no need to retry the delivery to a contact that is already archived. In the future I plan to add a check for the "batch" endpoint of Diaspora as well (like already done for AP).