### PR TITLE
Fix delivery counter / archive relay contacts

### DIFF
--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -906,7 +906,7 @@ class Contact extends BaseObject
 		// Always unarchive the relay contact entry
 		if (!empty($contact['batch']) && !empty($contact['term-date']) && ($contact['term-date'] > DBA::NULL_DATETIME)) {
 			$fields = ['term-date' => DBA::NULL_DATETIME, 'archive' => false];
-			$condition = ['batch' => $contact['batch'], 'contact-type' => self::TYPE_RELAY];
+			$condition = ['batch' => $contact['batch'], 'contact-type' => self::TYPE_RELAY, 'uid' => 0];
 			DBA::update('contact', $fields, $condition);
 		}
 
@@ -1620,7 +1620,7 @@ class Contact extends BaseObject
 
 		// Check status of Diaspora endpoints
 		if (!empty($contact['batch'])) {
-			return DBA::exists('contact', ['archive' => true, 'batch' => $contact['batch'], 'contact-type' => self::TYPE_RELAY]);
+			return DBA::exists('contact', ['archive' => true, 'batch' => $contact['batch'], 'contact-type' => self::TYPE_RELAY, 'uid' => 0]);
                 }
 
 		return false;

--- a/src/Model/ItemDeliveryData.php
+++ b/src/Model/ItemDeliveryData.php
@@ -111,7 +111,7 @@ class ItemDeliveryData
 	 * @return bool
 	 * @throws \Exception
 	 */
-	public static function incrementQueueCount($item_id, $increment)
+	public static function incrementQueueCount(int $item_id, int $increment = 1)
 	{
 		return DBA::e('UPDATE `item-delivery-data` SET `queue_count` = `queue_count` + ? WHERE `iid` = ?', $increment, $item_id);
 	}

--- a/src/Model/ItemDeliveryData.php
+++ b/src/Model/ItemDeliveryData.php
@@ -104,6 +104,19 @@ class ItemDeliveryData
 	}
 
 	/**
+	 * Increments the queue_count for the given item ID.
+	 *
+	 * @param integer $item_id
+	 * @param integer $increment
+	 * @return bool
+	 * @throws \Exception
+	 */
+	public static function incrementQueueCount($item_id, $increment)
+	{
+		return DBA::e('UPDATE `item-delivery-data` SET `queue_count` = `queue_count` + ? WHERE `iid` = ?', $increment, $item_id);
+	}
+
+	/**
 	 * Insert a new item delivery data entry
 	 *
 	 * @param integer $item_id

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -55,7 +55,7 @@ class Diaspora
 	 *
 	 * @param array $contact of the relay contact
 	 */
-	public static function markRelayForArchival($contact)
+	public static function markRelayForArchival(array $contact)
 	{
 		if (!empty($contact['contact-type']) && ($contact['contact-type'] == Contact::TYPE_RELAY)) {
 			// This is already the relay contact, we don't need to fetch it
@@ -174,7 +174,7 @@ class Diaspora
 	 * @return array with the contact
 	 * @throws \Exception
 	 */
-	private static function getRelayContact($server_url, $fields = ['batch', 'id', 'name', 'network', 'protocol', 'archive', 'blocked'])
+	private static function getRelayContact(string $server_url, array $fields = ['batch', 'id', 'name', 'network', 'protocol', 'archive', 'blocked'])
 	{
 		// Fetch the relay contact
 		$condition = ['uid' => 0, 'nurl' => Strings::normaliseLink($server_url),

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -27,6 +27,7 @@ use Friendica\Model\Conversation;
 use Friendica\Model\GContact;
 use Friendica\Model\Group;
 use Friendica\Model\Item;
+use Friendica\Model\ItemDeliveryData;
 use Friendica\Model\Mail;
 use Friendica\Model\Profile;
 use Friendica\Model\User;
@@ -46,6 +47,35 @@ use SimpleXMLElement;
  */
 class Diaspora
 {
+	/**
+	 * Mark the relay contact of the given contact for archival
+	 * This is called whenever there is a communication issue with the server.
+	 * It avoids sending stuff to servers who don't exist anymore.
+	 * The relay contact is a technical contact entry that exists once per server.
+	 *
+	 * @param array $contact of the relay contact
+	 */
+	public static function markRelayForArchival($contact)
+	{
+		if (!empty($contact['contact-type']) && ($contact['contact-type'] == Contact::TYPE_RELAY)) {
+			// This is already the relay contact, we don't need to fetch it
+			$relay_contact = $contact;
+		} elseif (empty($contact['baseurl'])) {
+			if (!empty($contact['batch'])) {
+				$relay_contact = DBA::selectFirst('contact', [], ['batch' => $contact['batch'], 'contact-type' => Contact::TYPE_RELAY, 'uid' => 0]);
+			} else {
+				return;
+			}
+		} else {
+			$relay_contact = self::getRelayContact($contact['baseurl'], []);
+		}
+
+		if (!empty($relay_contact)) {
+			Logger::info('Relay contact will be marked for archival', ['id' => $relay_contact['id'], 'url' => $relay_contact['url']]);
+			Contact::markForArchival($relay_contact);
+		}
+	}
+
 	/**
 	 * @brief Return a list of relay servers
 	 *
@@ -140,13 +170,12 @@ class Diaspora
 	 * @brief Return a contact for a given server address or creates a dummy entry
 	 *
 	 * @param string $server_url The url of the server
+	 * @param array $fields Fieldlist
 	 * @return array with the contact
 	 * @throws \Exception
 	 */
-	private static function getRelayContact($server_url)
+	private static function getRelayContact($server_url, $fields = ['batch', 'id', 'name', 'network', 'protocol', 'archive', 'blocked'])
 	{
-		$fields = ['batch', 'id', 'name', 'network', 'protocol', 'archive', 'blocked'];
-
 		// Fetch the relay contact
 		$condition = ['uid' => 0, 'nurl' => Strings::normaliseLink($server_url),
 			'contact-type' => Contact::TYPE_RELAY];
@@ -2208,7 +2237,9 @@ class Diaspora
 			}
 
 			Logger::info('Deliver participation', ['item' => $comment['id'], 'contact' => $contact_id]);
-			Worker::add(PRIORITY_HIGH, 'Delivery', Delivery::POST, $comment['id'], $contact_id);
+			if (Worker::add(PRIORITY_HIGH, 'Delivery', Delivery::POST, $comment['id'], $contact_id)) {
+				ItemDeliveryData::incrementQueueCount($comment['id'], 1);
+			}
 		}
 		DBA::close($comments);
 
@@ -3181,8 +3212,6 @@ class Diaspora
 
 		$logid = Strings::getRandomHex(4);
 
-		$dest_url = ($public_batch ? $contact["batch"] : $contact["notify"]);
-
 		// We always try to use the data from the fcontact table.
 		// This is important for transmitting data to Friendica servers.
 		if (!empty($contact['addr'])) {
@@ -3190,6 +3219,10 @@ class Diaspora
 			if (!empty($fcontact)) {
 				$dest_url = ($public_batch ? $fcontact["batch"] : $fcontact["notify"]);
 			}
+		}
+
+		if (empty($dest_url)) {
+			$dest_url = ($public_batch ? $contact["batch"] : $contact["notify"]);
 		}
 
 		if (!$dest_url) {

--- a/src/Worker/APDelivery.php
+++ b/src/Worker/APDelivery.php
@@ -48,14 +48,13 @@ class APDelivery extends BaseObject
 			$data = ActivityPub\Transmitter::createCachedActivityFromItem($target_id);
 			if (!empty($data)) {
 				$success = HTTPSignature::transmit($data, $inbox, $uid);
-				if ($success && in_array($cmd, [Delivery::POST])) {
-					ItemDeliveryData::incrementQueueDone($target_id, ItemDeliveryData::ACTIVITYPUB);
-				}
 			}
 		}
 
 		if (!$success && !Worker::defer() && in_array($cmd, [Delivery::POST])) {
 			ItemDeliveryData::incrementQueueFailed($target_id);
+		} elseif ($success && in_array($cmd, [Delivery::POST])) {
+			ItemDeliveryData::incrementQueueDone($target_id, ItemDeliveryData::ACTIVITYPUB);
 		}
 	}
 }

--- a/src/Worker/Delivery.php
+++ b/src/Worker/Delivery.php
@@ -318,7 +318,11 @@ class Delivery extends BaseObject
 				Logger::log('Relay delivery to ' . $contact["url"] . ' with guid ' . $target_item["guid"] . ' returns ' . $deliver_status);
 
 				if (in_array($cmd, [Delivery::POST, Delivery::POKE])) {
-					Model\ItemDeliveryData::incrementQueueDone($target_item['id'], $protocol);
+					if (($deliver_status >= 200) && ($deliver_status <= 299)) {
+						Model\ItemDeliveryData::incrementQueueDone($target_item['id'], $protocol);
+					} else {
+						Model\ItemDeliveryData::incrementQueueFailed($target_item['id']);
+					}
 				}
 				return;
 			}
@@ -448,10 +452,10 @@ class Delivery extends BaseObject
 				Logger::info('Delivery failed: defer message', ['id' => defaults($target_item, 'guid', $target_item['id'])]);
 				// defer message for redelivery
 				if (!Worker::defer() && in_array($cmd, [Delivery::POST, Delivery::POKE])) {
-					Model\ItemDeliveryData::incrementQueueFailed($target_item['id'], Model\ItemDeliveryData::DIASPORA);
+					Model\ItemDeliveryData::incrementQueueFailed($target_item['id']);
 				}
 			} elseif (in_array($cmd, [Delivery::POST, Delivery::POKE])) {
-				Model\ItemDeliveryData::incrementQueueDone($target_item['id'], Model\ItemDeliveryData::DIASPORA);
+				Model\ItemDeliveryData::incrementQueueFailed($target_item['id']);
 			}
 		}
 	}

--- a/src/Worker/Delivery.php
+++ b/src/Worker/Delivery.php
@@ -211,7 +211,13 @@ class Delivery extends BaseObject
 		return;
 	}
 
-	private static function setFailedQueue($cmd, $id)
+	/**
+	 * Increased the "failed" counter in the item delivery data
+	 *
+	 * @param string  $cmd Command
+	 * @param integer $id  Item id
+	 */
+	private static function setFailedQueue(string $cmd, int $id)
 	{
 		if (!in_array($cmd, [Delivery::POST, Delivery::POKE])) {
 			return;


### PR DESCRIPTION
This PR includes two related fixes.

The delivery counter now does also counts upon relay delivery. Additionally it works correctly with "participation" messages from Diaspora. There we resend the comments - but hadn't increased the queue count. Also we only increment the queue count when the worker task had been added successfully.

The second part is the archival of relay contacts. In some previous PR we already had used the relay contact to check a contact for it's archival status. We now explicitly set the archival status when we delivery via the public endpoint. This fixes the long time problem that we kept delivering content to long time deceased Diaspora servers because we had to archive each single contact of that server separately. 