### PR TITLE
Fixes the delivery counter for edits

### DIFF
--- a/src/Worker/Notifier.php
+++ b/src/Worker/Notifier.php
@@ -543,13 +543,13 @@ class Notifier
 			Hook::callAll('notifier_end', $target_item);
 
 			// Workaround for pure connector posts
-			if ($delivery_queue_count == 0) {
-				ItemDeliveryData::incrementQueueDone($target_item['id']);
-				$delivery_queue_count = 1;
-			}
-
 			if (in_array($cmd, [Delivery::POST, Delivery::POKE])) {
-				ItemDeliveryData::update($target_item['id'], ['queue_count' => $delivery_queue_count]);
+				if ($delivery_queue_count == 0) {
+					ItemDeliveryData::incrementQueueDone($target_item['id']);
+					$delivery_queue_count = 1;
+				}
+
+				ItemDeliveryData::incrementQueueCount($target_item['id'], $delivery_queue_count);
 			}
 		}
 


### PR DESCRIPTION
When editing a message, the notifier worker is started again, transmitting the changed content to all followers. This - of course - adds many finished jobs to the item-delivery-data - but the total number is overwritten on each edit. This means that after an edit the delivery counter can be like "600/1180" (original message plus a single edit). When editing twice it could be "600/1770".

We now simply increase the total number, so a double edit would be something like "1800/1770".