### PR TITLE
Fix fatal error for empty parameter for "System::removedBaseUrl"

### DIFF
--- a/mod/display.php
+++ b/mod/display.php
@@ -188,7 +188,9 @@ function display_fetchauthor($a, $item)
 
 	$profiledata = Contact::getDetailsByURL($profiledata["url"], local_user(), $profiledata);
 
-	$profiledata["photo"] = System::removedBaseUrl($profiledata["photo"]);
+	if (!empty($profiledata["photo"])) {
+		$profiledata["photo"] = System::removedBaseUrl($profiledata["photo"]);
+	}
 
 	return $profiledata;
 }


### PR DESCRIPTION
Under some weird constellation the parameter ```$profiledata["photo"]``` can be empty. Then we get a fatal error on the display page. This is fixed now.