### PR TITLE
Display pending contacts in the contact list

### DIFF
--- a/mod/notifications.php
+++ b/mod/notifications.php
@@ -98,9 +98,14 @@ function notifications_content(App $a)
 	if ((($a->argc > 1) && ($a->argv[1] == 'intros')) || (($a->argc == 1))) {
 		Nav::setSelected('introductions');
 
+		$id = 0;
+		if (!empty($a->argv[2]) && intval($a->argv[2]) != 0) {
+			$id = (int)$a->argv[2];
+		}
+
 		$all = (($a->argc > 2) && ($a->argv[2] == 'all'));
 
-		$notifs = $nm->introNotifs($all, $startrec, $perpage);
+		$notifs = $nm->introNotifs($all, $startrec, $perpage, $id);
 
 	// Get the network notifications
 	} elseif (($a->argc > 1) && ($a->argv[1] == 'network')) {

--- a/src/App/Router.php
+++ b/src/App/Router.php
@@ -108,6 +108,7 @@ class Router
 			$collector->addRoute(['GET'], '/{id:\d+}/updateprofile',             Module\Contact::class);
 			$collector->addRoute(['GET'], '/archived',                           Module\Contact::class);
 			$collector->addRoute(['GET', 'POST'], '/batch',                      Module\Contact::class);
+			$collector->addRoute(['GET'], '/pending',                            Module\Contact::class);
 			$collector->addRoute(['GET'], '/blocked',                            Module\Contact::class);
 			$collector->addRoute(['GET'], '/hidden',                             Module\Contact::class);
 			$collector->addRoute(['GET'], '/ignored',                            Module\Contact::class);

--- a/src/Core/NotificationsManager.php
+++ b/src/Core/NotificationsManager.php
@@ -549,6 +549,7 @@ class NotificationsManager extends BaseObject
 	 *                      which aren't marked as ignored
 	 * @param int  $start   Start the query at this point
 	 * @param int  $limit   Maximum number of query results
+	 * @param int  $id      When set, only the introduction with this id is displayed
 	 *
 	 * @return array with
 	 *    string 'ident' => Notification identifier
@@ -556,14 +557,20 @@ class NotificationsManager extends BaseObject
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 * @throws \ImagickException
 	 */
-	public function introNotifs($all = false, $start = 0, $limit = 80)
+	public function introNotifs($all = false, $start = 0, $limit = 80, $id = 0)
 	{
 		$ident = 'introductions';
 		$notifs = [];
 		$sql_extra = "";
 
-		if (!$all) {
-			$sql_extra = " AND NOT `ignore` ";
+		if (empty($id)) {
+			if (!$all) {
+				$sql_extra = " AND NOT `ignore` ";
+			}
+
+			$sql_extra .= " AND NOT `intro`.`blocked` ";
+		} else {
+			$sql_extra = sprintf(" AND `intro`.`id` = %d ", intval($id));
 		}
 
 		/// @todo Fetch contact details by "Contact::getDetailsByUrl" instead of queries to contact, fcontact and gcontact
@@ -578,7 +585,7 @@ class NotificationsManager extends BaseObject
 				LEFT JOIN `contact` ON `contact`.`id` = `intro`.`contact-id`
 				LEFT JOIN `gcontact` ON `gcontact`.`nurl` = `contact`.`nurl`
 				LEFT JOIN `fcontact` ON `intro`.`fid` = `fcontact`.`id`
-			WHERE `intro`.`uid` = ? $sql_extra AND `intro`.`blocked` = 0
+			WHERE `intro`.`uid` = ? $sql_extra
 			LIMIT ?, ?",
 			$_SESSION['uid'],
 			$start,

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -1175,7 +1175,7 @@ class Contact extends BaseObject
 		}
 
 		$sparkle = false;
-		if (($contact['network'] === Protocol::DFRN) && !$contact['self']) {
+		if (($contact['network'] === Protocol::DFRN) && !$contact['self'] && !$contact['pending']) {
 			$sparkle = true;
 			$profile_link = System::baseUrl() . '/redir/' . $contact['id'] . '?url=' . $contact['url'];
 		} else {
@@ -1192,11 +1192,11 @@ class Contact extends BaseObject
 			$profile_link = $profile_link . '?tab=profile';
 		}
 
-		if (self::canReceivePrivateMessages($contact)) {
+		if (self::canReceivePrivateMessages($contact) && !$contact['pending']) {
 			$pm_url = System::baseUrl() . '/message/new/' . $contact['id'];
 		}
 
-		if (($contact['network'] == Protocol::DFRN) && !$contact['self']) {
+		if (($contact['network'] == Protocol::DFRN) && !$contact['self'] && !$contact['pending']) {
 			$poke_link = System::baseUrl() . '/poke/?f=&c=' . $contact['id'];
 		}
 
@@ -1231,6 +1231,13 @@ class Contact extends BaseObject
 				'pm'      => [L10n::t('Send PM'),       $pm_url,            false],
 				'poke'    => [L10n::t('Poke'),          $poke_link,         false],
 			];
+
+			if ($contact['pending']) {
+				$intro = DBA::selectFirst('intro', ['id'], ['contact-id' => $contact['id']]);
+				if (DBA::isResult($intro)) {
+					$menu['follow'] = [L10n::t('Approve'), 'notifications/intros/' . $intro['id'], true];
+				}
+			}
 		}
 
 		$args = ['contact' => $contact, 'menu' => &$menu];

--- a/src/Module/Contact.php
+++ b/src/Module/Contact.php
@@ -642,7 +642,8 @@ class Contact extends BaseModule
 				$sql_extra = " AND `archive` AND NOT `blocked`";
 				break;
 			case 'pending':
-				$sql_extra = " AND `pending` AND NOT `archive`";
+				$sql_extra = " AND `pending` AND NOT `archive`
+					AND NOT EXISTS (SELECT `id` FROM `intro` WHERE `contact-id` = `contact`.`id` AND `ignore`)";
 				break;
 			default:
 				$sql_extra = " AND NOT `archive` AND NOT `blocked` AND NOT `pending`";
@@ -993,14 +994,6 @@ class Contact extends BaseModule
 				$alt_text = L10n::t('Pending outgoing contact request');
 			} else {
 				$alt_text = L10n::t('Pending incoming contact request');
-				$intro = DBA::selectFirst('intro', ['blocked', 'ignore'], ['contact-id' => $rr['id']]);
-				if (DBA::isResult($intro)) {
-					if ($intro['blocked']) {
-						$alt_text = L10n::t('Blocked incoming contact request');
-					} elseif ($intro['ignore']) {
-						$alt_text = L10n::t('Ignored incoming contact request');
-					}
-				}
 			}
 		}
 

--- a/src/Module/Contact.php
+++ b/src/Module/Contact.php
@@ -642,8 +642,8 @@ class Contact extends BaseModule
 				$sql_extra = " AND `archive` AND NOT `blocked`";
 				break;
 			case 'pending':
-				$sql_extra = " AND `pending` AND NOT `archive`
-					AND NOT EXISTS (SELECT `id` FROM `intro` WHERE `contact-id` = `contact`.`id` AND `ignore`)";
+				$sql_extra = sprintf(" AND `pending` AND NOT `archive` AND ((`rel` = %d)
+					OR EXISTS (SELECT `id` FROM `intro` WHERE `contact-id` = `contact`.`id` AND NOT `ignore`))", Model\Contact::SHARING);
 				break;
 			default:
 				$sql_extra = " AND NOT `archive` AND NOT `blocked` AND NOT `pending`";


### PR DESCRIPTION
This is an attempt to solve issue #7526 - but opens a whole can of worms :grin: 

We now display pending contacts, both incoming and outgoing. This is surely nice, but now we do have the problem to quickly get from the contact list to the contact request page. I'm open for suggestions on how to do this intuitively and without much changes.

But I also detected that I had got several incoming contact requests that never showed up. Possibly it was because of some issues while coding the AP part - or we do have a still existing problem. I will have a look at it in a future PR.