### PR TITLE
Pending contacts: Fix contact deletion / added cron job for repairs

### DIFF
--- a/mod/notifications.php
+++ b/mod/notifications.php
@@ -52,7 +52,7 @@ function notifications_post(App $a)
 				// The check for pending is in case the friendship was already approved
 				// and we just want to get rid of the pending contact
 				$condition = ['id' => $contact_id, 'uid' => local_user(),
-					'self' => false, 'pending' => true, 'rel' => Contact::FOLLOWER];
+					'self' => false, 'pending' => true, 'rel' => [0, Contact::FOLLOWER]];
 				if (DBA::exists('contact', $condition)) {
 					Contact::remove($contact_id);
 				}

--- a/mod/notifications.php
+++ b/mod/notifications.php
@@ -12,9 +12,11 @@ use Friendica\Core\L10n;
 use Friendica\Core\NotificationsManager;
 use Friendica\Core\Protocol;
 use Friendica\Core\Renderer;
+use Friendica\Core\Logger;
 use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\Module\Login;
+use Friendica\Model\Contact;
 
 function notifications_post(App $a)
 {
@@ -46,13 +48,14 @@ function notifications_post(App $a)
 
 		if ($_POST['submit'] == L10n::t('Discard')) {
 			DBA::delete('intro', ['id' => $intro_id]);
-
 			if (!$fid) {
-				// The check for blocked and pending is in case the friendship was already approved
-				// and we just want to get rid of the now pointless notification
+				// The check for pending is in case the friendship was already approved
+				// and we just want to get rid of the pending contact
 				$condition = ['id' => $contact_id, 'uid' => local_user(),
-					'self' => false, 'blocked' => true, 'pending' => true];
-				DBA::delete('contact', $condition);
+					'self' => false, 'pending' => true, 'rel' => Contact::FOLLOWER];
+				if (DBA::exists('contact', $condition)) {
+					Contact::remove($contact_id);
+				}
 			}
 			$a->internalRedirect('notifications/intros');
 		}

--- a/src/Worker/CronJobs.php
+++ b/src/Worker/CronJobs.php
@@ -305,7 +305,7 @@ class CronJobs
 
 		// Add intro entries for pending contacts
 		$pending_contacts = DBA::p("SELECT `uid`, `id`, `url`, `network`, `created` FROM `contact`
-			WHERE `pending` AND `rel` = ? AND NOT EXISTS (SELECT `id` FROM `intro` WHERE `contact-id` = `contact`.`id`)", 0); //Contact::FOLLOWER);
+			WHERE `pending` AND `rel` IN (?, ?) AND NOT EXISTS (SELECT `id` FROM `intro` WHERE `contact-id` = `contact`.`id`)", 0, Contact::FOLLOWER);
 		while ($contact = DBA::fetch($pending_contacts)) {
 			DBA::insert('intro', ['uid' => $contact['uid'], 'contact-id' => $contact['id'], 'blocked' => false,
 				'hash' => Strings::getRandomHex(), 'datetime' => $contact['created']]);

--- a/src/Worker/CronJobs.php
+++ b/src/Worker/CronJobs.php
@@ -23,6 +23,7 @@ use Friendica\Network\Probe;
 use Friendica\Protocol\PortableContact;
 use Friendica\Util\Network;
 use Friendica\Util\Proxy as ProxyUtils;
+use Friendica\Util\Strings;
 
 class CronJobs
 {
@@ -301,6 +302,15 @@ class CronJobs
 		/// - remove sign entries without item
 		/// - remove children when parent got lost
 		/// - set contact-id in item when not present
+
+		// Add intro entries for pending contacts
+		$pending_contacts = DBA::p("SELECT `uid`, `id`, `url`, `network`, `created` FROM `contact`
+			WHERE `pending` AND `rel` = ? AND NOT EXISTS (SELECT `id` FROM `intro` WHERE `contact-id` = `contact`.`id`)", 0); //Contact::FOLLOWER);
+		while ($contact = DBA::fetch($pending_contacts)) {
+			DBA::insert('intro', ['uid' => $contact['uid'], 'contact-id' => $contact['id'], 'blocked' => false,
+				'hash' => Strings::getRandomHex(), 'datetime' => $contact['created']]);
+		}
+		DBA::close($pending_contacts);
 	}
 
 	/**


### PR DESCRIPTION
Follow up to #7604

There had been the bug that contacts hadn't been deleted after the "intro" entry had been deleted. This happened due to the fact that "blocked" isn't set on those contacts.

Additionally we now do have a job that repairs missing "intro" entries. I had been unsure if the problem with the missing entries is a constant one, so I added it in the "cron" part and not the "update" part. Since this query is really fast, it doesn't have any impact on performance.

But: There is some side effect: It is very likely that this job will revive "intro" entries for long deleted contact requests (due to the bug fixed above). This is ugly, but sadly inevitable. 