### PR TITLE
Replace not working "redir" link with a working one

### DIFF
--- a/include/text.php
+++ b/include/text.php
@@ -122,7 +122,7 @@ function redir_private_images($a, &$item)
 			}
 
 			if ((local_user() == $item['uid']) && ($item['private'] == 1) && ($item['contact-id'] != $a->contact['id']) && ($item['network'] == Protocol::DFRN)) {
-				$img_url = 'redir?f=1&quiet=1&url=' . urlencode($mtch[1]) . '&conurl=' . urlencode($item['author-link']);
+				$img_url = 'redir/' . $item['contact-id'] . '?url=' . urlencode($mtch[1]);
 				$item['body'] = str_replace($mtch[0], '[img]' . $img_url . '[/img]', $item['body']);
 			}
 		}

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -2700,8 +2700,10 @@ class Contact extends BaseObject
 	 */
 	public static function magicLinkByContact($contact, $url = '')
 	{
+		$destination = $url ?: $contact['url']; // Equivalent to ($url != '') ? $url : $contact['url'];
+
 		if ((!local_user() && !remote_user()) || ($contact['network'] != Protocol::DFRN)) {
-			return $url ?: $contact['url']; // Equivalent to ($url != '') ? $url : $contact['url'];
+			return $destination;
 		}
 
 		// Only redirections to the same host do make sense
@@ -2714,7 +2716,7 @@ class Contact extends BaseObject
 		}
 
 		if (empty($contact['id'])) {
-			return $url ?: $contact['url'];
+			return $destination;
 		}
 
 		$redirect = 'redir/' . $contact['id'];

--- a/src/Model/Photo.php
+++ b/src/Model/Photo.php
@@ -656,6 +656,8 @@ class Photo extends BaseObject
 				continue;
 			}
 
+			/// @todo Check if $str_contact_allow does contain a public forum. Then set the permissions to public.
+
 			$fields = ['allow_cid' => $str_contact_allow, 'allow_gid' => $str_group_allow,
 					'deny_cid' => $str_contact_deny, 'deny_gid' => $str_group_deny];
 			$condition = ['resource-id' => $image_uri, 'uid' => $uid];


### PR DESCRIPTION
Today (in some non public post, hence no link) it happened that a linked picture wasn't displayed. This happened due to a "redir" link that wasn't formed like expected (it was "redir?" and not "redir/").

Testing the "redir?" link showed, that this isn't working anymore, since normally we now are using the magic auth. So the link had been changed to the format that works.