### PR TITLE
Issue 7610-2: Read the "hide" status for non DFRN profiles

### DIFF
--- a/src/Network/Probe.php
+++ b/src/Network/Probe.php
@@ -394,7 +394,7 @@ class Probe
 			$data['network'] = Protocol::PHANTOM;
 		}
 
-		if (empty($data['hide']) && ($data['network'] != Protocol::DFRN)) {
+		if (!isset($data['hide']) && in_array($data['network'], Protocol::FEDERATED)) {
 			$data['hide'] = self::getHideStatus($data['url']);
 		}
 


### PR DESCRIPTION
This is a follow up to PR https://github.com/friendica/friendica/pull/7611 and issue #7610 

We now do detect the "hide" status for all federated network via the appropriate "meta" header (see linked issue)