### PR TITLE
Remove $_SERVER['PHP_SELF'] usage

### DIFF
--- a/bin/auth_ejabberd.php
+++ b/bin/auth_ejabberd.php
@@ -36,6 +36,7 @@ use Dice\Dice;
 use Friendica\App\Mode;
 use Friendica\BaseObject;
 use Friendica\Util\ExAuth;
+use Psr\Log\LoggerInterface;
 
 if (sizeof($_SERVER["argv"]) == 0) {
 	die();
@@ -54,6 +55,8 @@ chdir($directory);
 require dirname(__DIR__) . '/vendor/autoload.php';
 
 $dice = (new Dice())->addRules(include __DIR__ . '/../static/dependencies.config.php');
+$dice = $dice->addRule(LoggerInterface::class,['constructParams' => ['auth_ejabberd']]);
+
 BaseObject::setDependencyInjection($dice);
 
 $appMode = $dice->create(Mode::class);

--- a/bin/console.php
+++ b/bin/console.php
@@ -2,9 +2,11 @@
 <?php
 
 use Dice\Dice;
+use Psr\Log\LoggerInterface;
 
 require dirname(__DIR__) . '/vendor/autoload.php';
 
 $dice = (new Dice())->addRules(include __DIR__ . '/../static/dependencies.config.php');
+$dice = $dice->addRule(LoggerInterface::class,['constructParams' => ['console']]);
 
 (new Friendica\Core\Console($dice, $argv))->execute();

--- a/bin/daemon.php
+++ b/bin/daemon.php
@@ -12,6 +12,7 @@ use Friendica\Core\Config;
 use Friendica\Core\Logger;
 use Friendica\Core\Worker;
 use Friendica\Database\DBA;
+use Psr\Log\LoggerInterface;
 
 // Get options
 $shortopts = 'f';
@@ -33,6 +34,7 @@ if (!file_exists("boot.php") && (sizeof($_SERVER["argv"]) != 0)) {
 require dirname(__DIR__) . '/vendor/autoload.php';
 
 $dice = (new Dice())->addRules(include __DIR__ . '/../static/dependencies.config.php');
+$dice = $dice->addRule(LoggerInterface::class,['constructParams' => ['daemon']]);
 
 \Friendica\BaseObject::setDependencyInjection($dice);
 $a = \Friendica\BaseObject::getApp();

--- a/bin/worker.php
+++ b/bin/worker.php
@@ -11,6 +11,7 @@ use Friendica\BaseObject;
 use Friendica\Core\Config;
 use Friendica\Core\Update;
 use Friendica\Core\Worker;
+use Psr\Log\LoggerInterface;
 
 // Get options
 $shortopts = 'sn';
@@ -32,6 +33,7 @@ if (!file_exists("boot.php") && (sizeof($_SERVER["argv"]) != 0)) {
 require dirname(__DIR__) . '/vendor/autoload.php';
 
 $dice = (new Dice())->addRules(include __DIR__ . '/../static/dependencies.config.php');
+$dice = $dice->addRule(LoggerInterface::class,['constructParams' => ['worker']]);
 
 BaseObject::setDependencyInjection($dice);
 $a = BaseObject::getApp();

--- a/index.php
+++ b/index.php
@@ -13,6 +13,7 @@ if (!file_exists(__DIR__ . '/vendor/autoload.php')) {
 require __DIR__ . '/vendor/autoload.php';
 
 $dice = (new Dice())->addRules(include __DIR__ . '/static/dependencies.config.php');
+$dice = $dice->addRule(Friendica\App\Mode::class, ['call' => [['determineRunMode', [false, $_SERVER], Dice::CHAIN_CALL]]]);
 
 \Friendica\BaseObject::setDependencyInjection($dice);
 

--- a/src/App/Mode.php
+++ b/src/App/Mode.php
@@ -106,15 +106,16 @@ class Mode
 	/**
 	 * Checks if the site is called via a backend process
 	 *
+	 * @param bool         $isBackend    True, if the call is from a backend script (daemon, worker, ...)
 	 * @param Module       $module       The pre-loaded module (just name, not class!)
 	 * @param array        $server       The $_SERVER variable
 	 * @param MobileDetect $mobileDetect The mobile detection library
 	 *
 	 * @return Mode returns the determined mode
 	 */
-	public function determineRunMode(Module $module, array $server, MobileDetect $mobileDetect)
+	public function determineRunMode(bool $isBackend, Module $module, array $server, MobileDetect $mobileDetect)
 	{
-		$isBackend = basename(($server['PHP_SELF'] ?? ''), '.php') !== 'index' ||
+		$isBackend = $isBackend ||
 		             $module->isBackend();
 		$isMobile  = $mobileDetect->isMobile();
 		$isTablet  = $mobileDetect->isTablet();

--- a/src/Factory/LoggerFactory.php
+++ b/src/Factory/LoggerFactory.php
@@ -38,19 +38,17 @@ class LoggerFactory
 		'Friendica\\Util\\Logger',
 	];
 
-	/**
-	 * Retrieve the channel based on the __FILE__
-	 *
-	 * @return string
-	 */
-	private function findChannel()
+	private $channel;
+
+	public function __construct(string $channel)
 	{
-		return basename($_SERVER['PHP_SELF'], '.php');
+		$this->channel = $channel;
 	}
 
 	/**
 	 * Creates a new PSR-3 compliant logger instances
 	 *
+	 * @param Database      $database The Friendica Database instance
 	 * @param Configuration $config   The config
 	 * @param Profiler      $profiler The profiler of the app
 	 *
@@ -59,7 +57,7 @@ class LoggerFactory
 	 * @throws \Exception
 	 * @throws InternalServerErrorException
 	 */
-	public function create(Database $database, Configuration $config, Profiler $profiler)
+	public function create( Database $database, Configuration $config, Profiler $profiler)
 	{
 		if (empty($config->get('system', 'debugging', false))) {
 			$logger = new VoidLogger();
@@ -76,7 +74,7 @@ class LoggerFactory
 				$loggerTimeZone = new \DateTimeZone('UTC');
 				Monolog\Logger::setTimezone($loggerTimeZone);
 
-				$logger = new Monolog\Logger($this->findChannel());
+				$logger = new Monolog\Logger($this->channel);
 				$logger->pushProcessor(new Monolog\Processor\PsrLogMessageProcessor());
 				$logger->pushProcessor(new Monolog\Processor\ProcessIdProcessor());
 				$logger->pushProcessor(new Monolog\Processor\UidProcessor());
@@ -91,7 +89,7 @@ class LoggerFactory
 				break;
 
 			case 'syslog':
-				$logger = new SyslogLogger($this->findChannel(), $introspection, $loglevel);
+				$logger = new SyslogLogger($this->channel, $introspection, $loglevel);
 				break;
 
 			case 'stream':
@@ -99,7 +97,7 @@ class LoggerFactory
 				$stream = $config->get('system', 'logfile');
 				// just add a stream in case it's either writable or not file
 				if (!is_file($stream) || is_writable($stream)) {
-					$logger = new StreamLogger($this->findChannel(), $stream, $introspection, $loglevel);
+					$logger = new StreamLogger($this->channel, $stream, $introspection, $loglevel);
 				} else {
 					$logger = new VoidLogger();
 				}

--- a/static/dependencies.config.php
+++ b/static/dependencies.config.php
@@ -62,7 +62,7 @@ return [
 	],
 	App\Mode::class                 => [
 		'call' => [
-			['determineRunMode', [$_SERVER], Dice::CHAIN_CALL],
+			['determineRunMode', [true, $_SERVER], Dice::CHAIN_CALL],
 			['determine', [], Dice::CHAIN_CALL],
 		],
 	],
@@ -114,12 +114,18 @@ return [
 	 */
 	LoggerInterface::class          => [
 		'instanceOf' => Factory\LoggerFactory::class,
+		'constructParams' => [
+			'index',
+		],
 		'call'       => [
-			['create', [], Dice::CHAIN_CALL],
+			['create', ['index'], Dice::CHAIN_CALL],
 		],
 	],
 	'$devLogger'                    => [
 		'instanceOf' => Factory\LoggerFactory::class,
+		'constructParams' => [
+			'dev',
+		],
 		'call'       => [
 			['createDev', [], Dice::CHAIN_CALL],
 		]

--- a/tests/src/App/ModeTest.php
+++ b/tests/src/App/ModeTest.php
@@ -183,13 +183,13 @@ class ModeTest extends MockedTest
 	/**
 	 * Test if not called by index is backend
 	 */
-	public function testIsBackendNotIndex()
+	public function testIsBackendNotIsBackend()
 	{
-		$server = ['PHP_SELF' => '/daemon.php'];
+		$server = [];
 		$module = new Module();
 		$mobileDetect = new MobileDetect();
 
-		$mode = (new Mode())->determineRunMode($module, $server, $mobileDetect);
+		$mode = (new Mode())->determineRunMode(true, $module, $server, $mobileDetect);
 
 		$this->assertTrue($mode->isBackend());
 	}
@@ -199,11 +199,11 @@ class ModeTest extends MockedTest
 	 */
 	public function testIsBackendButIndex()
 	{
-		$server = ['PHP_SELF' => '/index.php'];
+		$server = [];
 		$module = new Module(Module::DEFAULT, Module::DEFAULT_CLASS, true);
 		$mobileDetect = new MobileDetect();
 
-		$mode = (new Mode())->determineRunMode($module, $server, $mobileDetect);
+		$mode = (new Mode())->determineRunMode(false, $module, $server, $mobileDetect);
 
 		$this->assertTrue($mode->isBackend());
 	}
@@ -213,11 +213,11 @@ class ModeTest extends MockedTest
 	 */
 	public function testIsNotBackend()
 	{
-		$server = ['PHP_SELF' => '/index.php'];
+		$server = [];
 		$module = new Module(Module::DEFAULT, Module::DEFAULT_CLASS, false);
 		$mobileDetect = new MobileDetect();
 
-		$mode = (new Mode())->determineRunMode($module, $server, $mobileDetect);
+		$mode = (new Mode())->determineRunMode(false, $module, $server, $mobileDetect);
 
 		$this->assertFalse($mode->isBackend());
 	}
@@ -235,7 +235,7 @@ class ModeTest extends MockedTest
 		$module = new Module(Module::DEFAULT, Module::DEFAULT_CLASS, false);
 		$mobileDetect = new MobileDetect();
 
-		$mode = (new Mode())->determineRunMode($module, $server, $mobileDetect);
+		$mode = (new Mode())->determineRunMode(true, $module, $server, $mobileDetect);
 
 		$this->assertTrue($mode->isAjax());
 	}
@@ -249,7 +249,7 @@ class ModeTest extends MockedTest
 		$module = new Module(Module::DEFAULT, Module::DEFAULT_CLASS, false);
 		$mobileDetect = new MobileDetect();
 
-		$mode = (new Mode())->determineRunMode($module, $server, $mobileDetect);
+		$mode = (new Mode())->determineRunMode(true, $module, $server, $mobileDetect);
 
 		$this->assertFalse($mode->isAjax());
 	}
@@ -265,7 +265,7 @@ class ModeTest extends MockedTest
 		$mobileDetect->shouldReceive('isMobile')->andReturn(true);
 		$mobileDetect->shouldReceive('isTablet')->andReturn(true);
 
-		$mode = (new Mode())->determineRunMode($module, $server, $mobileDetect);
+		$mode = (new Mode())->determineRunMode(true, $module, $server, $mobileDetect);
 
 		$this->assertTrue($mode->isMobile());
 		$this->assertTrue($mode->isTablet());
@@ -283,7 +283,7 @@ class ModeTest extends MockedTest
 		$mobileDetect->shouldReceive('isMobile')->andReturn(false);
 		$mobileDetect->shouldReceive('isTablet')->andReturn(false);
 
-		$mode = (new Mode())->determineRunMode($module, $server, $mobileDetect);
+		$mode = (new Mode())->determineRunMode(true, $module, $server, $mobileDetect);
 
 		$this->assertFalse($mode->isMobile());
 		$this->assertFalse($mode->isTablet());


### PR DESCRIPTION
Fixes #7635 
- Remove of every `$_SERVER['PHP_SELF'] usage

Tested on local node (worker, daemon, install, normal usage)