### PR TITLE
Added info about the usage of the [abstract] in AP and especially in Mastodon to the documentation

### DIFF
--- a/doc/BBCode.md
+++ b/doc/BBCode.md
@@ -602,6 +602,9 @@ While taking pictures in the woods I had a really strange encounter...</td>
 The [abstract] element is not working with connectors where we post HTML directly, like Tumblr, Wordpress or Pump.io.
 For the native connections--that is to e.g. Friendica, Hubzilla, Diaspora or GNU Social--the full posting is used and the contacts instance will display the posting as desired.
 
+For postings that are delivered via ActivityPub, the text from the abstract is placed in the summary field.
+On Mastodon this field is used for the content warning.
+
 ## Special
 
 <table class="bbcodes">

--- a/doc/de/BBCode.md
+++ b/doc/de/BBCode.md
@@ -580,6 +580,9 @@ F&uuml;r Verbindungen zu Netzwerken, zu denen Friendica den HTML Code postet, wi
 Bei nativen Verbindungen; das hei&szlig;t zu z.B. Friendica, Hubzilla, Diaspora oder GNU Social Kontakten; wird der ungek&uuml;rzte Beitrag &uuml;bertragen.
 Die Instanz des Kontakts k&uuml;mmert sich um die Darstellung.
 
+Wird ein Beitrag über das ActivityPub Protokoll &uuml;bermittelt, wird der Text des Abstracts f&uuml;r das "summary" (Zusammenfassung) Feld verwendet.
+Dieses Feld wird von Mastodon f&uuml;r die Inhaltswarnung (content warning) verwendet.
+
 ## Special
 
 <table class="bbcodes">


### PR DESCRIPTION
I think the information about the ''[abstract]'' tag @annando mentioned in https://github.com/friendica/friendica/issues/3285#issuecomment-533841978 are worth a place in the documentation.