### PR TITLE
Get rid of zombie introductions that reappear automatically

### DIFF
--- a/mod/notifications.php
+++ b/mod/notifications.php
@@ -49,11 +49,15 @@ function notifications_post(App $a)
 		if ($_POST['submit'] == L10n::t('Discard')) {
 			DBA::delete('intro', ['id' => $intro_id]);
 			if (!$fid) {
-				// The check for pending is in case the friendship was already approved
-				// and we just want to get rid of the pending contact
+				// When the contact entry had been created just for that intro, we want to get rid of it now
 				$condition = ['id' => $contact_id, 'uid' => local_user(),
 					'self' => false, 'pending' => true, 'rel' => [0, Contact::FOLLOWER]];
-				if (DBA::exists('contact', $condition)) {
+				$contact_pending = DBA::exists('contact', $condition);
+
+				// Remove the "pending" to stop the reappearing in any case
+				DBA::update('contact', ['pending' => false], ['id' => $contact_id]);
+
+				if ($contact_pending) {
 					Contact::remove($contact_id);
 				}
 			}

--- a/src/Worker/CronJobs.php
+++ b/src/Worker/CronJobs.php
@@ -304,8 +304,11 @@ class CronJobs
 		/// - set contact-id in item when not present
 
 		// Add intro entries for pending contacts
+		// We don't do this for DFRN entries since such revived contact requests seem to mostly fail.
 		$pending_contacts = DBA::p("SELECT `uid`, `id`, `url`, `network`, `created` FROM `contact`
-			WHERE `pending` AND `rel` IN (?, ?) AND NOT EXISTS (SELECT `id` FROM `intro` WHERE `contact-id` = `contact`.`id`)", 0, Contact::FOLLOWER);
+			WHERE `pending` AND `rel` IN (?, ?) AND `network` != ?
+				AND NOT EXISTS (SELECT `id` FROM `intro` WHERE `contact-id` = `contact`.`id`)",
+			0, Contact::FOLLOWER, Protocol::DFRN);
 		while ($contact = DBA::fetch($pending_contacts)) {
 			DBA::insert('intro', ['uid' => $contact['uid'], 'contact-id' => $contact['id'], 'blocked' => false,
 				'hash' => Strings::getRandomHex(), 'datetime' => $contact['created']]);


### PR DESCRIPTION
This should fix two problems:

1. It should help with the problem that some deleted contact requests had been revived all the time.
2. Contact requests from Friendica are very fragile. It is most likely that a revived contact request from Friendica doesn't work at all. So we don't touch them.