### PR TITLE
Fix "redir" loop

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -413,7 +413,7 @@ function public_contact()
  *
  * @return int|bool visitor_id or false
  */
-function remote_user()
+function remote_user($uid = 0)
 {
 	// You cannot be both local and remote.
 	// Unncommented by rabuzarus because remote authentication to local
@@ -422,13 +422,22 @@ function remote_user()
 //		return false;
 //	}
 
-	if (empty($_SESSION)) {
+	if (empty($_SESSION['authenticated'])) {
 		return false;
 	}
 
-	if (!empty($_SESSION['authenticated']) && !empty($_SESSION['visitor_id'])) {
+	if (!empty($uid) && !empty($_SESSION['remote'])) {
+		foreach ($_SESSION['remote'] as $visitor) {
+			if ($visitor['uid'] == $uid) {
+				return $visitor['cid'];
+			}
+		}
+	}
+
+	if (!empty($_SESSION['visitor_id'])) {
 		return intval($_SESSION['visitor_id']);
 	}
+
 	return false;
 }
 

--- a/mod/photos.php
+++ b/mod/photos.php
@@ -154,17 +154,8 @@ function photos_post(App $a)
 
 	if (local_user() && (local_user() == $page_owner_uid)) {
 		$can_post = true;
-	} elseif ($community_page && remote_user()) {
-		$contact_id = 0;
-
-		if (!empty($_SESSION['remote']) && is_array($_SESSION['remote'])) {
-			foreach ($_SESSION['remote'] as $v) {
-				if ($v['uid'] == $page_owner_uid) {
-					$contact_id = $v['cid'];
-					break;
-				}
-			}
-		}
+	} elseif ($community_page && remote_user($page_owner_uid)) {
+		$contact_id = remote_user($page_owner_uid);
 
 		if ($contact_id > 0) {
 			if (DBA::exists('contact', ['id' => $contact_id, 'uid' => $page_owner_uid, 'blocked' => false, 'pending' => false])) {

--- a/src/Content/Widget.php
+++ b/src/Content/Widget.php
@@ -337,16 +337,9 @@ class Widget
 			return;
 		}
 
-		$cid = $zcid = 0;
+		$zcid = 0;
 
-		if (!empty($_SESSION['remote'])) {
-			foreach ($_SESSION['remote'] as $visitor) {
-				if ($visitor['uid'] == $profile_uid) {
-					$cid = $visitor['cid'];
-					break;
-				}
-			}
-		}
+		$cid = remote_user($profile_uid);
 
 		if (!$cid) {
 			if (Profile::getMyURL()) {

--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -248,7 +248,7 @@ class Profile
 	 */
 	public static function getByNickname($nickname, $uid = 0, $profile_id = 0)
 	{
-		if (remote_user() && !empty($_SESSION['remote'])) {
+		if (remote_user($uid) && !empty($_SESSION['remote'])) {
 			foreach ($_SESSION['remote'] as $visitor) {
 				if ($visitor['uid'] == $uid) {
 					$contact = DBA::selectFirst('contact', ['profile-id'], ['id' => $visitor['cid']]);

--- a/src/Util/Security.php
+++ b/src/Util/Security.php
@@ -33,7 +33,7 @@ class Security extends BaseObject
 			return true;
 		}
 
-		if (remote_user()) {
+		if (remote_user($owner)) {
 			// use remembered decision and avoid a DB lookup for each and every display item
 			// DO NOT use this function if there are going to be multiple owners
 			// We have a contact-id for an authenticated remote user, this block determines if the contact
@@ -44,17 +44,7 @@ class Security extends BaseObject
 			} elseif ($verified === 1) {
 				return false;
 			} else {
-				$cid = 0;
-
-				if (!empty($_SESSION['remote'])) {
-					foreach ($_SESSION['remote'] as $visitor) {
-						if ($visitor['uid'] == $owner) {
-							$cid = $visitor['cid'];
-							break;
-						}
-					}
-				}
-
+				$cid = remote_user($owner);
 				if (!$cid) {
 					return false;
 				}


### PR DESCRIPTION
This should help with the reported problem of "redir" loops between accounts on the same server.

We will now check at first if we can use the "magic" authentication. Also we don't perform any authentication when we stay on the same server.

To still be able to authenticate against a "remote" profile on the same server, we now always fill the "remote" session array - even for local users. This required some changes to the "remote_user" function.

This is highly untested code and surely not beautiful. I hadn't got much time today, but wanted to publish it as soon as possible to have a longer test time.