### PR TITLE
Don't use the "url" parameter on redir if it points to the same contact

### DIFF
--- a/mod/redir.php
+++ b/mod/redir.php
@@ -148,7 +148,8 @@ function redir_magic($a, $cid, $url)
 		Logger::info('Got my url', ['visitor' => $visitor]);
 	}
 
-	if (empty(visitor) && remote_user()) {
+	/// @todo Most likely these lines are superfluous. We will remove them in the next version
+	if (empty($visitor) && remote_user()) {
 		$contact = DBA::selectFirst('contact', ['url'], ['id' => remote_user()]);
 		if (!empty($contact['url'])) {
 			$visitor = $contact['url'];
@@ -156,7 +157,7 @@ function redir_magic($a, $cid, $url)
 		}
 	}
 
-	if (empty(visitor) && local_user()) {
+	if (empty($visitor) && local_user()) {
 		$contact = DBA::selectFirst('contact', ['url'], ['id' => local_user()]);
 		if (!empty($contact['url'])) {
 			$visitor = $contact['url'];

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -1193,7 +1193,7 @@ class Contact extends BaseObject
 		$sparkle = false;
 		if (($contact['network'] === Protocol::DFRN) && !$contact['self'] && empty($contact['pending'])) {
 			$sparkle = true;
-			$profile_link = System::baseUrl() . '/redir/' . $contact['id'] . '?url=' . $contact['url'];
+			$profile_link = System::baseUrl() . '/redir/' . $contact['id'];
 		} else {
 			$profile_link = $contact['url'];
 		}
@@ -2744,7 +2744,7 @@ class Contact extends BaseObject
 
 		$redirect = 'redir/' . $contact['id'];
 
-		if ($url != '') {
+		if (($url != '') && !Strings::compareLink($contact['url'], $url)) {
 			$redirect .= '?url=' . $url;
 		}
 


### PR DESCRIPTION
The id value in a redir link already points to the profile. We don't need to add that profile link in the "url" parameter.