### PR TITLE
Fix <audio> tag conversion to/from BBCode

### DIFF
--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -1466,6 +1466,11 @@ class BBCode extends BaseObject
 
 		$text = str_replace('[hr]', '<hr />', $text);
 
+		if (!$for_plaintext) {
+			// Autolinker for isolated URLs
+			$text = preg_replace(Strings::autoLinkRegEx(), '[url]$1[/url]', $text);
+		}
+
 		// This is actually executed in Item::prepareBody()
 
 		$nosmile = strpos($text, '[nosmile]') !== false;
@@ -1648,9 +1653,7 @@ class BBCode extends BaseObject
 			$text = Smilies::replace($text);
 		}
 
-		// if the HTML is used to generate plain text, then don't do this search, but replace all URL of that kind to text
 		if (!$for_plaintext) {
-			$text = preg_replace(Strings::autoLinkRegEx(), '[url]$1[/url]', $text);
 			if (in_array($simple_html, [7, 9])) {
 				$text = preg_replace_callback("/\[url\](.*?)\[\/url\]/ism", 'self::convertUrlForOStatusCallback', $text);
 				$text = preg_replace_callback("/\[url\=(.*?)\](.*?)\[\/url\]/ism", 'self::convertUrlForOStatusCallback', $text);

--- a/src/Content/Text/HTML.php
+++ b/src/Content/Text/HTML.php
@@ -42,14 +42,32 @@ class HTML
 		return $cleaned;
 	}
 
-	private static function tagToBBCode(DOMDocument $doc, $tag, $attributes, $startbb, $endbb)
+	/**
+	 * Search all instances of a specific HTML tag node in the provided DOM document and replaces them with BBCode text nodes.
+	 *
+	 * @see HTML::tagToBBCodeSub()
+	 */
+	private static function tagToBBCode(DOMDocument $doc, string $tag, array $attributes, string $startbb, string $endbb, bool $ignoreChildren = false)
 	{
 		do {
-			$done = self::tagToBBCodeSub($doc, $tag, $attributes, $startbb, $endbb);
+			$done = self::tagToBBCodeSub($doc, $tag, $attributes, $startbb, $endbb, $ignoreChildren);
 		} while ($done);
 	}
 
-	private static function tagToBBCodeSub(DOMDocument $doc, $tag, $attributes, $startbb, $endbb)
+	/**
+	 * Search the first specific HTML tag node in the provided DOM document and replaces it with BBCode text nodes.
+	 *
+	 * @param DOMDocument $doc
+	 * @param string      $tag            HTML tag name
+	 * @param array       $attributes     Array of attributes to match and optionally use the value from
+	 * @param string      $startbb        BBCode tag opening
+	 * @param string      $endbb          BBCode tag closing
+	 * @param bool        $ignoreChildren If set to false, the HTML tag children will be appended as text inside the BBCode tag
+	 *                                    Otherwise, they will be entirely ignored. Useful for simple BBCode that draw their
+	 *                                    inner value from an attribute value and disregard the tag children.
+	 * @return bool Whether a replacement was done
+	 */
+	private static function tagToBBCodeSub(DOMDocument $doc, string $tag, array $attributes, string $startbb, string $endbb, bool $ignoreChildren = false)
 	{
 		$savestart = str_replace('$', '\x01', $startbb);
 		$replace = false;
@@ -98,7 +116,7 @@ class HTML
 
 				$node->parentNode->insertBefore($StartCode, $node);
 
-				if ($node->hasChildNodes()) {
+				if (!$ignoreChildren && $node->hasChildNodes()) {
 					/** @var \DOMNode $child */
 					foreach ($node->childNodes as $key => $child) {
 						/* Remove empty text nodes at the start or at the end of the children list */
@@ -296,14 +314,14 @@ class HTML
 		self::tagToBBCode($doc, 'a', ['href' => '/mailto:(.+)/'], '[mail=$1]', '[/mail]');
 		self::tagToBBCode($doc, 'a', ['href' => '/(.+)/'], '[url=$1]', '[/url]');
 
-		self::tagToBBCode($doc, 'img', ['src' => '/(.+)/', 'alt' => '/(.+)/'], '[img=$1]$2', '[/img]');
-		self::tagToBBCode($doc, 'img', ['src' => '/(.+)/', 'width' => '/(\d+)/', 'height' => '/(\d+)/'], '[img=$2x$3]$1', '[/img]');
-		self::tagToBBCode($doc, 'img', ['src' => '/(.+)/'], '[img]$1', '[/img]');
+		self::tagToBBCode($doc, 'img', ['src' => '/(.+)/', 'alt' => '/(.+)/'], '[img=$1]$2', '[/img]', true);
+		self::tagToBBCode($doc, 'img', ['src' => '/(.+)/', 'width' => '/(\d+)/', 'height' => '/(\d+)/'], '[img=$2x$3]$1', '[/img]', true);
+		self::tagToBBCode($doc, 'img', ['src' => '/(.+)/'], '[img]$1', '[/img]', true);
 
 
-		self::tagToBBCode($doc, 'video', ['src' => '/(.+)/'], '[video]$1', '[/video]');
-		self::tagToBBCode($doc, 'audio', ['src' => '/(.+)/'], '[audio]$1', '[/audio]');
-		self::tagToBBCode($doc, 'iframe', ['src' => '/(.+)/'], '[iframe]$1', '[/iframe]');
+		self::tagToBBCode($doc, 'video', ['src' => '/(.+)/'], '[video]$1', '[/video]', true);
+		self::tagToBBCode($doc, 'audio', ['src' => '/(.+)/'], '[audio]$1', '[/audio]', true);
+		self::tagToBBCode($doc, 'iframe', ['src' => '/(.+)/'], '[iframe]$1', '[/iframe]', true);
 
 		self::tagToBBCode($doc, 'key', [], '[code]', '[/code]');
 		self::tagToBBCode($doc, 'code', [], '[code]', '[/code]');

--- a/tests/src/Content/Text/BBCodeTest.php
+++ b/tests/src/Content/Text/BBCodeTest.php
@@ -179,41 +179,48 @@ class BBCodeTest extends MockedTest
 			'bug-2199-named-size' => [
 				'expectedHtml' => '<span style="font-size: xx-large; line-height: initial;">Test text</span>',
 				'text' => '[size=xx-large]Test text[/size]',
-				'simpleHtml' => 0,
 			],
 			'bug-2199-numeric-size' => [
 				'expectedHtml' => '<span style="font-size: 24px; line-height: initial;">Test text</span>',
 				'text' => '[size=24]Test text[/size]',
-				'simpleHtml' => 0,
 			],
 			'bug-2199-diaspora-no-named-size' => [
 				'expectedHtml' => 'Test text',
 				'text' => '[size=xx-large]Test text[/size]',
+				'try_oembed' => false,
 				// Triggers the diaspora compatible output
 				'simpleHtml' => 3,
 			],
 			'bug-2199-diaspora-no-numeric-size' => [
 				'expectedHtml' => 'Test text',
 				'text' => '[size=24]Test text[/size]',
+				'try_oembed' => false,
 				// Triggers the diaspora compatible output
 				'simpleHtml' => 3,
+			],
+			'bug-7665-audio-tag' => [
+				'expectedHtml' => '<audio src="http://www.cendrones.fr/colloque2017/jonathanbocquet.mp3" controls="controls"><a href="http://www.cendrones.fr/colloque2017/jonathanbocquet.mp3">http://www.cendrones.fr/colloque2017/jonathanbocquet.mp3</a></audio>',
+				'text' => '[audio]http://www.cendrones.fr/colloque2017/jonathanbocquet.mp3[/audio]',
+				'try_oembed' => true,
 			],
 		];
 	}
 
 	/**
 	 * Test convert bbcodes to HTML
+	 *
 	 * @dataProvider dataBBCodes
 	 *
 	 * @param string $expectedHtml Expected HTML output
 	 * @param string $text         BBCode text
+	 * @param bool   $try_oembed   Whether to convert multimedia BBCode tag
 	 * @param int    $simpleHtml   BBCode::convert method $simple_html parameter value, optional.
 	 * @param bool   $forPlaintext BBCode::convert method $for_plaintext parameter value, optional.
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
-	public function testConvert($expectedHtml, $text, $simpleHtml = 0, $forPlaintext = false)
+	public function testConvert($expectedHtml, $text, $try_oembed = false, $simpleHtml = 0, $forPlaintext = false)
 	{
-		$actual = BBCode::convert($text, false, $simpleHtml, $forPlaintext);
+		$actual = BBCode::convert($text, $try_oembed, $simpleHtml, $forPlaintext);
 
 		$this->assertEquals($expectedHtml, $actual);
 	}

--- a/tests/src/Content/Text/HTMLTest.php
+++ b/tests/src/Content/Text/HTMLTest.php
@@ -50,4 +50,30 @@ class HTMLTest extends MockedTest
 
 		$this->assertEquals($expected, $output);
 	}
+
+	public function dataHTMLText()
+	{
+		return [
+			'bug-7665-audio-tag' => [
+				'expectedBBCode' => '[audio]http://www.cendrones.fr/colloque2017/jonathanbocquet.mp3[/audio]',
+				'html' => '<audio src="http://www.cendrones.fr/colloque2017/jonathanbocquet.mp3" controls="controls"><a href="http://www.cendrones.fr/colloque2017/jonathanbocquet.mp3">http://www.cendrones.fr/colloque2017/jonathanbocquet.mp3</a></audio>',
+			],
+		];
+	}
+
+	/**
+	 * Test convert bbcodes to HTML
+	 *
+	 * @dataProvider dataHTMLText
+	 *
+	 * @param string $expectedBBCode Expected BBCode output
+	 * @param string $html           HTML text
+	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
+	 */
+	public function testToBBCode($expectedBBCode, $html)
+	{
+		$actual = HTML::toBBCode($html);
+
+		$this->assertEquals($expectedBBCode, $actual);
+	}
 }


### PR DESCRIPTION
Fixes #7665 

There was not one but two issues around the `<audio>` tag, one when we convert HTML to BBCode, and one when we convert BBCode to HTML.

Both have been squashed and anti-regression tests have been added.