### PR TITLE
Add router config

### DIFF
--- a/src/App/Module.php
+++ b/src/App/Module.php
@@ -150,13 +150,6 @@ class Module
 		 * From the request URL, routing consists of obtaining the name of a BaseModule-extending class of which the
 		 * post() and/or content() static methods can be respectively called to produce a data change or an output.
 		 **/
-
-		// First we try explicit routes defined in App\Router
-		$router->collectRoutes();
-
-		$data = $router->getRouteCollector();
-		Core\Hook::callAll('route_collection', $data);
-
 		$module_class = $router->getModuleClass($args->getCommand());
 
 		// Then we try addon-provided modules that we wrap in the LegacyModule class

--- a/src/App/Router.php
+++ b/src/App/Router.php
@@ -7,7 +7,8 @@ use FastRoute\DataGenerator\GroupCountBased;
 use FastRoute\Dispatcher;
 use FastRoute\RouteCollector;
 use FastRoute\RouteParser\Std;
-use Friendica\Module;
+use Friendica\Core\Hook;
+use Friendica\Network\HTTPException\InternalServerErrorException;
 
 /**
  * Wrapper for FastRoute\Router
@@ -21,213 +22,129 @@ use Friendica\Module;
  */
 class Router
 {
+	const POST = 'POST';
+	const GET  = 'GET';
+
+	const ALLOWED_METHODS = [
+		self::POST,
+		self::GET,
+	];
+
 	/** @var RouteCollector */
 	protected $routeCollector;
 
 	/**
-	 * Static declaration of Friendica routes.
-	 *
-	 * Supports:
-	 * - Route groups
-	 * - Variable parts
-	 * Disregards:
-	 * - HTTP method other than GET
-	 * - Named parameters
-	 *
-	 * Handler must be the name of a class extending Friendica\BaseModule.
-	 *
-	 * @brief Static declaration of Friendica routes.
+	 * @var string The HTTP method
 	 */
-	public function collectRoutes()
+	private $httpMethod;
+
+	/**
+	 * @param array $server The $_SERVER variable
+	 * @param RouteCollector|null $routeCollector Optional the loaded Route collector
+	 */
+	public function __construct(array $server, RouteCollector $routeCollector = null)
 	{
-		$this->routeCollector->addRoute(['GET'],         '[/]',               Module\Home::class);
-		$this->routeCollector->addGroup('/.well-known', function (RouteCollector $collector) {
-			$collector->addRoute(['GET'], '/host-meta'       , Module\WellKnown\HostMeta::class);
-			$collector->addRoute(['GET'], '/nodeinfo[/1.0]'  , Module\NodeInfo::class);
-			$collector->addRoute(['GET'], '/webfinger'       , Module\Xrd::class);
-			$collector->addRoute(['GET'], '/x-social-relay'  , Module\WellKnown\XSocialRelay::class);
-		});
-		$this->routeCollector->addGroup('/2fa', function (RouteCollector $collector) {
-			$collector->addRoute(['GET', 'POST'], '[/]'                     , Module\TwoFactor\Verify::class);
-			$collector->addRoute(['GET', 'POST'], '/recovery'               , Module\TwoFactor\Recovery::class);
-		});
-		$this->routeCollector->addGroup('/admin', function (RouteCollector $collector) {
-			$collector->addRoute(['GET']        , '[/]'                     , Module\Admin\Summary::class);
+		$httpMethod = $server['REQUEST_METHOD'] ?? self::GET;
+		$this->httpMethod = in_array($httpMethod, self::ALLOWED_METHODS) ? $httpMethod : self::GET;
 
-			$collector->addRoute(['GET', 'POST'], '/addons'                 , Module\Admin\Addons\Index::class);
-			$collector->addRoute(['GET', 'POST'], '/addons/{addon}'         , Module\Admin\Addons\Details::class);
-
-			$collector->addRoute(['GET', 'POST'], '/blocklist/contact'      , Module\Admin\Blocklist\Contact::class);
-			$collector->addRoute(['GET', 'POST'], '/blocklist/server'       , Module\Admin\Blocklist\Server::class);
-
-			$collector->addRoute(['GET']        , '/dbsync[/check]'         , Module\Admin\DBSync::class);
-			$collector->addRoute(['GET']        , '/dbsync/{update:\d+}'    , Module\Admin\DBSync::class);
-			$collector->addRoute(['GET']        , '/dbsync/mark/{update:\d+}', Module\Admin\DBSync::class);
-
-			$collector->addRoute(['GET', 'POST'], '/features'               , Module\Admin\Features::class);
-			$collector->addRoute(['GET']        , '/federation'             , Module\Admin\Federation::class);
-
-			$collector->addRoute(['GET', 'POST'], '/item/delete'            , Module\Admin\Item\Delete::class);
-			$collector->addRoute(['GET', 'POST'], '/item/source[/{guid}]'   , Module\Admin\Item\Source::class);
-
-			$collector->addRoute(['GET']        , '/logs/view'              , Module\Admin\Logs\View::class);
-			$collector->addRoute(['GET', 'POST'], '/logs'                   , Module\Admin\Logs\Settings::class);
-
-			$collector->addRoute(['GET']        , '/phpinfo'                , Module\Admin\PhpInfo::class);
-
-			$collector->addRoute(['GET']        , '/queue[/deferred]'       , Module\Admin\Queue::class);
-
-			$collector->addRoute(['GET', 'POST'], '/site'                   , Module\Admin\Site::class);
-
-			$collector->addRoute(['GET', 'POST'], '/themes'                 , Module\Admin\Themes\Index::class);
-			$collector->addRoute(['GET', 'POST'], '/themes/{theme}'         , Module\Admin\Themes\Details::class);
-			$collector->addRoute(['GET', 'POST'], '/themes/{theme}/embed'   , Module\Admin\Themes\Embed::class);
-
-			$collector->addRoute(['GET', 'POST'], '/tos'                    , Module\Admin\Tos::class);
-
-			$collector->addRoute(['GET', 'POST'], '/users[/{action}/{uid}]' , Module\Admin\Users::class);
-		});
-		$this->routeCollector->addRoute(['GET'],         '/amcd',                Module\AccountManagementControlDocument::class);
-		$this->routeCollector->addRoute(['GET'],         '/acctlink',            Module\Acctlink::class);
-		$this->routeCollector->addRoute(['GET'],         '/allfriends/{id:\d+}', Module\AllFriends::class);
-		$this->routeCollector->addRoute(['GET'],         '/apps',                Module\Apps::class);
-		$this->routeCollector->addRoute(['GET'],         '/attach/{item:\d+}',   Module\Attach::class);
-		$this->routeCollector->addRoute(['GET'],         '/babel',               Module\Debug\Babel::class);
-		$this->routeCollector->addRoute(['GET'],         '/bookmarklet',         Module\Bookmarklet::class);
-		$this->routeCollector->addRoute(['GET', 'POST'], '/compose[/{type}]',    Module\Item\Compose::class);
-		$this->routeCollector->addGroup('/contact', function (RouteCollector $collector) {
-			$collector->addRoute(['GET'], '[/]',                                 Module\Contact::class);
-			$collector->addRoute(['GET', 'POST'], '/{id:\d+}[/]',                Module\Contact::class);
-			$collector->addRoute(['GET'], '/{id:\d+}/archive',                   Module\Contact::class);
-			$collector->addRoute(['GET'], '/{id:\d+}/block',                     Module\Contact::class);
-			$collector->addRoute(['GET'], '/{id:\d+}/conversations',             Module\Contact::class);
-			$collector->addRoute(['GET'], '/{id:\d+}/drop',                      Module\Contact::class);
-			$collector->addRoute(['GET'], '/{id:\d+}/ignore',                    Module\Contact::class);
-			$collector->addRoute(['GET'], '/{id:\d+}/posts',                     Module\Contact::class);
-			$collector->addRoute(['GET'], '/{id:\d+}/update',                    Module\Contact::class);
-			$collector->addRoute(['GET'], '/{id:\d+}/updateprofile',             Module\Contact::class);
-			$collector->addRoute(['GET'], '/archived',                           Module\Contact::class);
-			$collector->addRoute(['GET', 'POST'], '/batch',                      Module\Contact::class);
-			$collector->addRoute(['GET'], '/pending',                            Module\Contact::class);
-			$collector->addRoute(['GET'], '/blocked',                            Module\Contact::class);
-			$collector->addRoute(['GET'], '/hidden',                             Module\Contact::class);
-			$collector->addRoute(['GET'], '/ignored',                            Module\Contact::class);
-		});
-		$this->routeCollector->addRoute(['GET'],         '/credits',             Module\Credits::class);
-		$this->routeCollector->addRoute(['GET'],         '/dirfind',             Module\Search\Directory::class);
-		$this->routeCollector->addRoute(['GET'],         '/directory',           Module\Directory::class);
-		$this->routeCollector->addGroup('/feed', function (RouteCollector $collector) {
-			$collector->addRoute(['GET'], '/{nickname}',                         Module\Feed::class);
-			$collector->addRoute(['GET'], '/{nickname}/posts',                   Module\Feed::class);
-			$collector->addRoute(['GET'], '/{nickname}/comments',                Module\Feed::class);
-			$collector->addRoute(['GET'], '/{nickname}/replies',                 Module\Feed::class);
-			$collector->addRoute(['GET'], '/{nickname}/activity',                Module\Feed::class);
-		});
-		$this->routeCollector->addRoute(['GET'],         '/feedtest',            Module\Debug\Feed::class);
-		$this->routeCollector->addGroup('/fetch', function (RouteCollector $collector) {
-			$collector->addRoute(['GET'], '/post/{guid}',                        Module\Diaspora\Fetch::class);
-			$collector->addRoute(['GET'], '/status_message/{guid}',              Module\Diaspora\Fetch::class);
-			$collector->addRoute(['GET'], '/reshare/{guid}',                     Module\Diaspora\Fetch::class);
-		});
-		$this->routeCollector->addRoute(['GET'],         '/filer[/{id:\d+}]',    Module\Filer\SaveTag::class);
-		$this->routeCollector->addRoute(['GET'],         '/filerm/{id:\d+}',     Module\Filer\RemoveTag::class);
-		$this->routeCollector->addRoute(['GET', 'POST'], '/follow_confirm',      Module\FollowConfirm::class);
-		$this->routeCollector->addRoute(['GET'],         '/followers/{owner}',   Module\Followers::class);
-		$this->routeCollector->addRoute(['GET'],         '/following/{owner}',   Module\Following::class);
-		$this->routeCollector->addRoute(['GET'],         '/friendica[/json]',    Module\Friendica::class);
-		$this->routeCollector->addGroup('/group', function (RouteCollector $collector) {
-			$collector->addRoute(['GET', 'POST'], '[/]',                         Module\Group::class);
-			$collector->addRoute(['GET', 'POST'], '/{group:\d+}',                Module\Group::class);
-			$collector->addRoute(['GET', 'POST'], '/none',                       Module\Group::class);
-			$collector->addRoute(['GET', 'POST'], '/new',                        Module\Group::class);
-			$collector->addRoute(['GET', 'POST'], '/drop/{group:\d+}',           Module\Group::class);
-			$collector->addRoute(['GET', 'POST'], '/{group:\d+}/{contact:\d+}',  Module\Group::class);
-
-			$collector->addRoute(['GET', 'POST'], '/{group:\d+}/add/{contact:\d+}',     Module\Group::class);
-			$collector->addRoute(['GET', 'POST'], '/{group:\d+}/remove/{contact:\d+}',  Module\Group::class);
-		});
-		$this->routeCollector->addRoute(['GET'],         '/hashtag',             Module\Hashtag::class);
-		$this->routeCollector->addRoute(['GET'],         '/home',                Module\Home::class);
-		$this->routeCollector->addRoute(['GET'],         '/help[/{doc:.+}]',     Module\Help::class);
-		$this->routeCollector->addRoute(['GET'],         '/inbox[/{nickname}]',  Module\Inbox::class);
-		$this->routeCollector->addRoute(['GET', 'POST'], '/invite',              Module\Invite::class);
-		$this->routeCollector->addGroup('/install', function (RouteCollector $collector) {
-			$collector->addRoute(['GET', 'POST'], '[/]',                         Module\Install::class);
-			$collector->addRoute(['GET'],         '/testrewrite',                Module\Install::class);
-		});
-		$this->routeCollector->addRoute(['GET'],         '/like/{item:\d+}',     Module\Like::class);
-		$this->routeCollector->addRoute(['GET', 'POST'], '/localtime',           Module\Debug\Localtime::class);
-		$this->routeCollector->addRoute(['GET', 'POST'], '/login',               Module\Login::class);
-		$this->routeCollector->addRoute(['GET', 'POST'], '/logout',              Module\Logout::class);
-		$this->routeCollector->addRoute(['GET'],         '/magic',               Module\Magic::class);
-		$this->routeCollector->addRoute(['GET'],         '/maintenance',         Module\Maintenance::class);
-		$this->routeCollector->addRoute(['GET'],         '/manifest',            Module\Manifest::class);
-		$this->routeCollector->addRoute(['GET'],         '/modexp/{nick}',       Module\PublicRSAKey::class);
-		$this->routeCollector->addRoute(['GET'],         '/newmember',           Module\Welcome::class);
-		$this->routeCollector->addRoute(['GET'],         '/nodeinfo/1.0',        Module\NodeInfo::class);
-		$this->routeCollector->addRoute(['GET'],         '/nogroup',             Module\Group::class);
-		$this->routeCollector->addGroup('/notify', function (RouteCollector $collector) {
-			$collector->addRoute(['GET'], '[/]',                                 Module\Notifications\Notify::class);
-			$collector->addRoute(['GET'], '/view/{id:\d+}',                      Module\Notifications\Notify::class);
-			$collector->addRoute(['GET'], '/mark/all',                           Module\Notifications\Notify::class);
-		});
-		$this->routeCollector->addRoute(['GET'],         '/objects/{guid}',      Module\Objects::class);
-		$this->routeCollector->addGroup('/oembed', function (RouteCollector $collector) {
-			$collector->addRoute(['GET'], '/b2h',                                Module\Oembed::class);
-			$collector->addRoute(['GET'], '/h2b',                                Module\Oembed::class);
-			$collector->addRoute(['GET'], '/{hash}',                             Module\Oembed::class);
-		});
-		$this->routeCollector->addRoute(['GET'],         '/outbox/{owner}',      Module\Outbox::class);
-		$this->routeCollector->addRoute(['GET'],         '/owa',                 Module\Owa::class);
-		$this->routeCollector->addRoute(['GET'],         '/opensearch',          Module\OpenSearch::class);
-		$this->routeCollector->addGroup('/photo', function (RouteCollector $collector) {
-			$collector->addRoute(['GET'], '/{name}',                             Module\Photo::class);
-			$collector->addRoute(['GET'], '/{type}/{name}',                      Module\Photo::class);
-			$collector->addRoute(['GET'], '/{type}/{customize}/{name}',          Module\Photo::class);
-		});
-		$this->routeCollector->addRoute(['GET'],         '/pretheme',            Module\ThemeDetails::class);
-		$this->routeCollector->addRoute(['GET'],         '/probe',               Module\Debug\Probe::class);
-		$this->routeCollector->addGroup('/profile', function (RouteCollector $collector) {
-			$collector->addRoute(['GET'], '/{nickname}',                         Module\Profile::class);
-			$collector->addRoute(['GET'], '/{nickname}/{to:\d{4}-\d{2}-\d{2}}/{from:\d{4}-\d{2}-\d{2}}', Module\Profile::class);
-			$collector->addRoute(['GET'], '/{nickname}/contacts[/{type}]',       Module\Profile\Contacts::class);
-			$collector->addRoute(['GET'], '/{profile:\d+}/view',                 Module\Profile::class);
-		});
-		$this->routeCollector->addGroup('/proxy', function (RouteCollector $collector) {
-			$collector->addRoute(['GET'], '[/]'                                , Module\Proxy::class);
-			$collector->addRoute(['GET'], '/{url}'                             , Module\Proxy::class);
-			$collector->addRoute(['GET'], '/{sub1}/{url}'                      , Module\Proxy::class);
-			$collector->addRoute(['GET'], '/{sub1}/{sub2}/{url}'               , Module\Proxy::class);
-		});
-
-		$this->routeCollector->addGroup('/settings', function (RouteCollector $collector) {
-			$collector->addGroup('/2fa', function (RouteCollector $collector) {
-				$collector->addRoute(['GET', 'POST'], '[/]'                    , Module\Settings\TwoFactor\Index::class);
-				$collector->addRoute(['GET', 'POST'], '/recovery'              , Module\Settings\TwoFactor\Recovery::class);
-				$collector->addRoute(['GET', 'POST'], '/app_specific'          , Module\Settings\TwoFactor\AppSpecific::class);
-				$collector->addRoute(['GET', 'POST'], '/verify'                , Module\Settings\TwoFactor\Verify::class);
-			});
-		});
-		$this->routeCollector->addRoute(['GET'],         '/randprof',            Module\RandomProfile::class);
-		$this->routeCollector->addRoute(['GET', 'POST'], '/register',            Module\Register::class);
-		$this->routeCollector->addRoute(['GET'],         '/robots.txt',          Module\RobotsTxt::class);
-		$this->routeCollector->addRoute(['GET'],         '/rsd.xml',             Module\ReallySimpleDiscovery::class);
-		$this->routeCollector->addRoute(['GET'],         '/smilies[/json]',      Module\Smilies::class);
-		$this->routeCollector->addRoute(['GET'],         '/statistics.json',     Module\Statistics::class);
-		$this->routeCollector->addRoute(['GET'],         '/starred/{item:\d+}',  Module\Starred::class);
-		$this->routeCollector->addRoute(['GET'],         '/toggle_mobile',       Module\ToggleMobile::class);
-		$this->routeCollector->addRoute(['GET'],         '/tos',                 Module\Tos::class);
-		$this->routeCollector->addRoute(['GET'],         '/view/theme/{theme}/style.pcss',  Module\Theme::class);
-		$this->routeCollector->addRoute(['GET'],         '/viewsrc/{item:\d+}',  Module\Debug\ItemBody::class);
-		$this->routeCollector->addRoute(['GET'],         '/webfinger',           Module\Debug\WebFinger::class);
-		$this->routeCollector->addRoute(['GET'],         '/xrd',                 Module\Xrd::class);
+		$this->routeCollector = isset($routeCollector) ?
+			$routeCollector :
+			new RouteCollector(new Std(), new GroupCountBased());
 	}
 
-	public function __construct()
+	/**
+	 * @param array $routes The routes to add to the Router
+	 *
+	 * @return self The router instance with the loaded routes
+	 *
+	 * @throws InternalServerErrorException In case of invalid configs
+	 */
+	public function addRoutes(array $routes)
 	{
-		$this->routeCollector = new RouteCollector(new Std(), new GroupCountBased());
+		$routeCollector = (isset($this->routeCollector) ?
+			$this->routeCollector :
+			new RouteCollector(new Std(), new GroupCountBased()));
+
+		foreach ($routes as $route => $config) {
+			if ($this->isGroup($config)) {
+				$this->addGroup($route, $config, $routeCollector);
+			} elseif ($this->isRoute($config)) {
+				$routeCollector->addRoute($config[1], $route, $config[0]);
+			} else {
+				throw new InternalServerErrorException("Wrong route config for route '" . print_r($route, true) . "'");
+			}
+		}
+
+		$this->routeCollector = $routeCollector;
+
+		return $this;
 	}
 
+	/**
+	 * Adds a group of routes to a given group
+	 *
+	 * @param string         $groupRoute     The route of the group
+	 * @param array          $routes         The routes of the group
+	 * @param RouteCollector $routeCollector The route collector to add this group
+	 */
+	private function addGroup(string $groupRoute, array $routes, RouteCollector $routeCollector)
+	{
+		$routeCollector->addGroup($groupRoute, function (RouteCollector $routeCollector) use ($routes) {
+			foreach ($routes as $route => $config) {
+				if ($this->isGroup($config)) {
+					$this->addGroup($route, $config, $routeCollector);
+				} elseif ($this->isRoute($config)) {
+					$routeCollector->addRoute($config[1], $route, $config[0]);
+				}else {
+					throw new InternalServerErrorException("Wrong route config for route '" . print_r($route, true) . "'");
+				}
+			}
+		});
+	}
+
+	/**
+	 * Returns true in case the config is a group config
+	 *
+	 * @param array $config
+	 *
+	 * @return bool
+	 */
+	private function isGroup(array $config)
+	{
+		return
+			is_array($config) &&
+			is_string(array_keys($config)[0]) &&
+			// This entry should NOT be a BaseModule
+			(substr(array_keys($config)[0], 0, strlen('Friendica\Module')) !== 'Friendica\Module') &&
+			// The second argument is an array (another routes)
+			is_array(array_values($config)[0]);
+	}
+
+	/**
+	 * Returns true in case the config is a route config
+	 *
+	 * @param array $config
+	 *
+	 * @return bool
+	 */
+	private function isRoute(array $config)
+	{
+		return
+			// The config array should at least have one entry
+			!empty($config[0]) &&
+			// This entry should be a BaseModule
+			(substr($config[0], 0, strlen('Friendica\Module')) === 'Friendica\Module') &&
+			// Either there is no other argument
+			(empty($config[1]) ||
+			 // Or the second argument is an array (HTTP-Methods)
+			 is_array($config[1]));
+	}
+
+	/**
+	 * The current route collector
+	 *
+	 * @return RouteCollector|null
+	 */
 	public function getRouteCollector()
 	{
 		return $this->routeCollector;
@@ -237,19 +154,21 @@ class Router
 	 * Returns the relevant module class name for the given page URI or NULL if no route rule matched.
 	 *
 	 * @param string $cmd The path component of the request URL without the query string
+	 *
 	 * @return string|null A Friendica\BaseModule-extending class name if a route rule matched
 	 */
 	public function getModuleClass($cmd)
 	{
+		// Add routes from addons
+		Hook::callAll('route_collection', $this->routeCollector);
+
 		$cmd = '/' . ltrim($cmd, '/');
 
 		$dispatcher = new \FastRoute\Dispatcher\GroupCountBased($this->routeCollector->getData());
 
 		$moduleClass = null;
 
-		// @TODO: Enable method-specific modules
-		$httpMethod = 'GET';
-		$routeInfo = $dispatcher->dispatch($httpMethod, $cmd);
+		$routeInfo  = $dispatcher->dispatch($this->httpMethod, $cmd);
 		if ($routeInfo[0] === Dispatcher::FOUND) {
 			$moduleClass = $routeInfo[1];
 		}

--- a/src/BaseModule.php
+++ b/src/BaseModule.php
@@ -4,7 +4,6 @@ namespace Friendica;
 
 use Friendica\Core\L10n;
 use Friendica\Core\Logger;
-use Friendica\Core\System;
 
 /**
  * All modules in Friendica should extend BaseModule, although not all modules

--- a/static/dependencies.config.php
+++ b/static/dependencies.config.php
@@ -165,4 +165,12 @@ return [
 			[Dice::INSTANCE => '$basepath'],
 		],
 	],
+	App\Router::class => [
+		'constructParams' => [
+			$_SERVER, null
+		],
+		'call' => [
+			['addRoutes', [include __DIR__ . '/routes.config.php'], Dice::CHAIN_CALL],
+		],
+	],
 ];

--- a/static/routes.config.php
+++ b/static/routes.config.php
@@ -86,6 +86,7 @@ return [
 		'/{id:\d+}/updateprofile' => [Module\Contact::class, [R::GET]],
 		'/archived'               => [Module\Contact::class, [R::GET]],
 		'/batch'                  => [Module\Contact::class, [R::GET, R::POST]],
+		'/pending'                => [Module\Contact::class, [R::GET]],
 		'/blocked'                => [Module\Contact::class, [R::GET]],
 		'/hidden'                 => [Module\Contact::class, [R::GET]],
 		'/ignored'                => [Module\Contact::class, [R::GET]],

--- a/static/routes.config.php
+++ b/static/routes.config.php
@@ -1,0 +1,212 @@
+<?php
+
+use Friendica\App\Router as R;
+use Friendica\Module;
+
+/**
+* Configuration for the default routes in Friendica
+*
+* The syntax is either
+* - 'route' => [ Module::class , [ HTTPMethod(s) ] ]
+* - 'group' => [ 'route' => [ Module::class, [ HTTPMethod(s) ] ]
+*
+* It's possible to create recursive groups
+*/
+return [
+	'/' => [Module\Home::class, [R::GET]],
+
+	'/.well-known' => [
+		'/host-meta'      => [Module\WellKnown\HostMeta::class,     [R::GET]],
+		'/nodeinfo[/1.0]' => [Module\NodeInfo::class,               [R::GET]],
+		'/webfinger'      => [Module\Xrd::class,                    [R::GET]],
+		'/x-social-relay' => [Module\WellKnown\XSocialRelay::class, [R::GET]],
+	],
+
+	'/2fa' => [
+		'[/]'       => [Module\TwoFactor\Verify::class,   [R::GET, R::POST]],
+		'/recovery' => [Module\TwoFactor\Recovery::class, [R::GET, R::POST]],
+	],
+
+	'/admin'               => [
+		'[/]' => [Module\Admin\Summary::class, [R::GET]],
+
+		'/addons'         => [Module\Admin\Addons\Index::class,   [R::GET, R::POST]],
+		'/addons/{addon}' => [Module\Admin\Addons\Details::class, [R::GET, R::POST]],
+
+
+		'/blocklist/contact' => [Module\Admin\Blocklist\Contact::class, [R::GET, R::POST]],
+		'/blocklist/server'  => [Module\Admin\Blocklist\Server::class,  [R::GET, R::POST]],
+
+		'/dbsync[/check]'           => [Module\Admin\DBSync::class, [R::GET]],
+		'/dbsync/{update:\d+}'      => [Module\Admin\DBSync::class, [R::GET]],
+		'/dbsync/mark/{update:\d+}' => [Module\Admin\DBSync::class, [R::GET]],
+
+		'/features'   => [Module\Admin\Features::class,   [R::GET, R::POST]],
+		'/federation' => [Module\Admin\Federation::class, [R::GET]],
+
+		'/item/delete'          => [Module\Admin\Item\Delete::class, [R::GET, R::POST]],
+		'/item/source[/{guid}]' => [Module\Admin\Item\Source::class, [R::GET, R::POST]],
+
+		'/logs/view' => [Module\Admin\Logs\View::class,     [R::GET]],
+		'/logs'      => [Module\Admin\Logs\Settings::class, [R::GET, R::POST]],
+
+		'/phpinfo' => [Module\Admin\PhpInfo::class, [R::GET]],
+
+		'/queue[/deferred]' => [Module\Admin\Queue::class, [R::GET]],
+
+		'/site' => [Module\Admin\Site::class, [R::GET, R::POST]],
+
+		'/themes'               => [Module\Admin\Themes\Index::class,   [R::GET, R::POST]],
+		'/themes/{theme}'       => [Module\Admin\Themes\Details::class, [R::GET, R::POST]],
+		'/themes/{theme}/embed' => [Module\Admin\Themes\Embed::class,   [R::GET, R::POST]],
+
+		'/tos' => [Module\Admin\Tos::class, [R::GET, R::POST]],
+
+		'/users[/{action}/{uid}]' => [Module\Admin\Users::class, [R::GET, R::POST]],
+	],
+	'/amcd'                => [Module\AccountManagementControlDocument::class, [R::GET]],
+	'/acctlink'            => [Module\Acctlink::class,     [R::GET]],
+	'/allfriends/{id:\d+}' => [Module\AllFriends::class,   [R::GET]],
+	'/apps'                => [Module\Apps::class,         [R::GET]],
+	'/attach/{item:\d+}'   => [Module\Attach::class,       [R::GET]],
+	'/babel'               => [Module\Debug\Babel::class,  [R::GET]],
+	'/bookmarklet'         => [Module\Bookmarklet::class,  [R::GET]],
+	'/compose[/{type}]'    => [Module\Item\Compose::class, [R::GET, R::POST]],
+
+	'/contact'   => [
+		'[/]'                     => [Module\Contact::class, [R::GET]],
+		'/{id:\d+}[/]'            => [Module\Contact::class, [R::GET, R::POST]],
+		'/{id:\d+}/archive'       => [Module\Contact::class, [R::GET]],
+		'/{id:\d+}/block'         => [Module\Contact::class, [R::GET]],
+		'/{id:\d+}/conversations' => [Module\Contact::class, [R::GET]],
+		'/{id:\d+}/drop'          => [Module\Contact::class, [R::GET]],
+		'/{id:\d+}/ignore'        => [Module\Contact::class, [R::GET]],
+		'/{id:\d+}/posts'         => [Module\Contact::class, [R::GET]],
+		'/{id:\d+}/update'        => [Module\Contact::class, [R::GET]],
+		'/{id:\d+}/updateprofile' => [Module\Contact::class, [R::GET]],
+		'/archived'               => [Module\Contact::class, [R::GET]],
+		'/batch'                  => [Module\Contact::class, [R::GET, R::POST]],
+		'/blocked'                => [Module\Contact::class, [R::GET]],
+		'/hidden'                 => [Module\Contact::class, [R::GET]],
+		'/ignored'                => [Module\Contact::class, [R::GET]],
+	],
+	'/credits'   => [Module\Credits::class,          [R::GET]],
+	'/dirfind'   => [Module\Search\Directory::class, [R::GET]],
+	'/directory' => [Module\Directory::class,        [R::GET]],
+
+	'/feed'     => [
+		'/{nickname}'          => [Module\Feed::class, [R::GET]],
+		'/{nickname}/posts'    => [Module\Feed::class, [R::GET]],
+		'/{nickname}/comments' => [Module\Feed::class, [R::GET]],
+		'/{nickname}/replies'  => [Module\Feed::class, [R::GET]],
+		'/{nickname}/activity' => [Module\Feed::class, [R::GET]],
+	],
+	'/feedtest' => [Module\Debug\Feed::class, [R::GET]],
+
+	'/fetch'             => [
+		'/post/{guid}'           => [Module\Diaspora\Fetch::class, [R::GET]],
+		'/status_message/{guid}' => [Module\Diaspora\Fetch::class, [R::GET]],
+		'/reshare/{guid}'        => [Module\Diaspora\Fetch::class, [R::GET]],
+	],
+	'/filer[/{id:\d+}]'  => [Module\Filer\SaveTag::class,   [R::GET]],
+	'/filerm/{id:\d+}'   => [Module\Filer\RemoveTag::class, [R::GET]],
+	'/follow_confirm'    => [Module\FollowConfirm::class,   [R::GET, R::POST]],
+	'/followers/{owner}' => [Module\Followers::class,       [R::GET]],
+	'/following/{owner}' => [Module\Following::class,       [R::GET]],
+	'/friendica[/json]'  => [Module\Friendica::class,       [R::GET]],
+
+	'/group'              => [
+		'[/]'                        => [Module\Group::class, [R::GET, R::POST]],
+		'/{group:\d+}'               => [Module\Group::class, [R::GET, R::POST]],
+		'/none'                      => [Module\Group::class, [R::GET, R::POST]],
+		'/new'                       => [Module\Group::class, [R::GET, R::POST]],
+		'/drop/{group:\d+}'          => [Module\Group::class, [R::GET, R::POST]],
+		'/{group:\d+}/{contact:\d+}' => [Module\Group::class, [R::GET, R::POST]],
+
+		'/{group:\d+}/add/{contact:\d+}'    => [Module\Group::class, [R::GET, R::POST]],
+		'/{group:\d+}/remove/{contact:\d+}' => [Module\Group::class, [R::GET, R::POST]],
+	],
+	'/hashtag'            => [Module\Hashtag::class, [R::GET]],
+	'/home'               => [Module\Home::class,    [R::GET]],
+	'/help[/{doc:.+}]'    => [Module\Help::class,    [R::GET]],
+	'/inbox[/{nickname}]' => [Module\Inbox::class,   [R::GET]],
+	'/invite'             => [Module\Invite::class,  [R::GET, R::POST]],
+
+	'/install'         => [
+		'[/]'                    => [Module\Install::class, [R::GET, R::POST]],
+		'/testrewrite'           => [Module\Install::class, [R::GET]],
+	],
+	'/like/{item:\d+}' => [Module\Like::class,            [R::GET]],
+	'/localtime'       => [Module\Debug\Localtime::class, [R::GET, R::POST]],
+	'/login'           => [Module\Login::class,           [R::GET, R::POST]],
+	'/logout'          => [Module\Logout::class,          [R::GET, R::POST]],
+	'/magic'           => [Module\Magic::class,           [R::GET]],
+	'/maintenance'     => [Module\Maintenance::class,     [R::GET]],
+	'/manifest'        => [Module\Manifest::class,        [R::GET]],
+	'/modexp/{nick}'   => [Module\PublicRSAKey::class,    [R::GET]],
+	'/newmember'       => [Module\Welcome::class,         [R::GET]],
+	'/nodeinfo/1.0'    => [Module\NodeInfo::class,        [R::GET]],
+	'/nogroup'         => [Module\Group::class,           [R::GET]],
+
+	'/notify'         => [
+		'[/]'            => [Module\Notifications\Notify::class, [R::GET]],
+		'/view/{id:\d+}' => [Module\Notifications\Notify::class, [R::GET]],
+		'/mark/all'      => [Module\Notifications\Notify::class, [R::GET]],
+	],
+	'/objects/{guid}' => [Module\Objects::class, [R::GET]],
+
+	'/oembed'         => [
+		'/b2h'    => [Module\Oembed::class, [R::GET]],
+		'/h2b'    => [Module\Oembed::class, [R::GET]],
+		'/{hash}' => [Module\Oembed::class, [R::GET]],
+	],
+	'/outbox/{owner}' => [Module\Outbox::class,     [R::GET]],
+	'/owa'            => [Module\Owa::class,        [R::GET]],
+	'/opensearch'     => [Module\OpenSearch::class, [R::GET]],
+
+	'/photo' => [
+		'/{name}'                    => [Module\Photo::class, [R::GET]],
+		'/{type}/{name}'             => [Module\Photo::class, [R::GET]],
+		'/{type}/{customize}/{name}' => [Module\Photo::class, [R::GET]],
+	],
+
+	'/pretheme' => [Module\ThemeDetails::class, [R::GET]],
+	'/probe'    => [Module\Debug\Probe::class,  [R::GET]],
+
+	'/profile' => [
+		'/{nickname}'                                                 => [Module\Profile::class,          [R::GET]],
+		'/{nickname}/{to:\d{4}-\d{2}-\d{2}}/{from:\d{4}-\d{2}-\d{2}}' => [Module\Profile::class,          [R::GET]],
+		'/{nickname}/contacts[/{type}]'                               => [Module\Profile\Contacts::class, [R::GET]],
+		'/{profile:\d+}/view'                                         => [Module\Profile::class,          [R::GET]],
+	],
+
+	'/proxy' => [
+		'[/]'                  => [Module\Proxy::class, [R::GET]],
+		'/{url}'               => [Module\Proxy::class, [R::GET]],
+		'/{sub1}/{url}'        => [Module\Proxy::class, [R::GET]],
+		'/{sub1}/{sub2}/{url}' => [Module\Proxy::class, [R::GET]],
+	],
+
+	'/settings' => [
+		'/2fa' => [
+			'[/]'           => [Module\Settings\TwoFactor\Index::class,       [R::GET, R::POST]],
+			'/recovery'     => [Module\Settings\TwoFactor\Recovery::class,    [R::GET, R::POST]],
+			'/app_specific' => [Module\Settings\TwoFactor\AppSpecific::class, [R::GET, R::POST]],
+			'/verify'       => [Module\Settings\TwoFactor\Verify::class,      [R::GET, R::POST]],
+		],
+	],
+
+	'/randprof'                      => [Module\RandomProfile::class,         [R::GET]],
+	'/register'                      => [Module\Register::class,              [R::GET, R::POST]],
+	'/robots.txt'                    => [Module\RobotsTxt::class,             [R::GET]],
+	'/rsd.xml'                       => [Module\ReallySimpleDiscovery::class, [R::GET]],
+	'/smilies[/json]'                => [Module\Smilies::class,               [R::GET]],
+	'/statistics.json'               => [Module\Statistics::class,            [R::GET]],
+	'/starred/{item:\d+}'            => [Module\Starred::class,               [R::GET]],
+	'/toggle_mobile'                 => [Module\ToggleMobile::class,          [R::GET]],
+	'/tos'                           => [Module\Tos::class,                   [R::GET]],
+	'/view/theme/{theme}/style.pcss' => [Module\Theme::class,                 [R::GET]],
+	'/viewsrc/{item:\d+}'            => [Module\Debug\ItemBody::class,        [R::GET]],
+	'/webfinger'                     => [Module\Debug\WebFinger::class,       [R::GET]],
+	'/xrd'                           => [Module\Xrd::class,                   [R::GET]],
+];

--- a/tests/src/App/ModuleTest.php
+++ b/tests/src/App/ModuleTest.php
@@ -152,7 +152,9 @@ class ModuleTest extends DatabaseTest
 		$config = \Mockery::mock(Configuration::class);
 		$config->shouldReceive('get')->with('config', 'private_addons', false)->andReturn($privAdd)->atMost()->once();
 
-		$module = (new App\Module($name))->determineClass(new App\Arguments('', $command), new App\Router(), $config);
+		$router = (new App\Router([]))->addRoutes(include __DIR__ . '/../../../static/routes.config.php');
+
+		$module = (new App\Module($name))->determineClass(new App\Arguments('', $command), $router, $config);
 
 		$this->assertEquals($assert, $module->getClassName());
 	}


### PR DESCRIPTION
- Introduce `routes.config.php` structure
- Adding config loader for routes
- Adapt Module class (separation of duties -> moved Hook call and remove route collection)
- Add tests
- Enable HTTP method specific routing (POST and GET now considered)

*Motivation for this change*:
- Better overview and syntax of routes (I really didn't like these `function...` callback structure for groups)
- Not stuck to an instance
- Not bound to the `collectRoutes` call inside of the `Module` class (=> decoupling these classes)

Tested on local node with different groups (and sub-groups)