### PR TITLE
Fix magic auth for redirects with non profile paths

### DIFF
--- a/mod/redir.php
+++ b/mod/redir.php
@@ -192,7 +192,7 @@ function redir_magic($a, $cid, $url)
 	$serverret = Network::curl($basepath . '/magic');
 	if ($serverret->isSuccess()) {
 		$separator = strpos($target_url, '?') ? '&' : '?';
-		$target_url .= $separator . 'zrl=' . urlencode($visitor);
+		$target_url .= $separator . 'zrl=' . urlencode($visitor) . '&addr=' . urlencode($contact_url);
 
 		Logger::info('Redirecting with magic', ['target' => $target_url, 'visitor' => $visitor, 'contact' => $contact_url]);
 		$a->redirect($target_url);

--- a/src/Module/Magic.php
+++ b/src/Module/Magic.php
@@ -33,13 +33,10 @@ class Magic extends BaseModule
 		$test = (!empty($_REQUEST['test']) ? intval($_REQUEST['test']) : 0);
 		$owa  = (!empty($_REQUEST['owa'])  ? intval($_REQUEST['owa'])  : 0);
 
-		// NOTE: I guess $dest isn't just the profile url (could be also
-		// other profile pages e.g. photo). We need to find a solution
-		// to be able to redirct to other pages than the contact profile.
-		$cid = Contact::getIdForURL($dest);
-
-		if (!$cid && !empty($addr)) {
+		if (!empty($addr)) {
 			$cid = Contact::getIdForURL($addr);
+		} else {
+			$cid = Contact::getIdForURL($dest);
 		}
 
 		if (!$cid) {


### PR DESCRIPTION
During my remote auth tests I realized that we have got just another bug in the authentication process as well. This is so small, that I think that we can include it.