### PR TITLE
Critical Fix: Inbox needs to be accessed via POST

### DIFF
--- a/static/routes.config.php
+++ b/static/routes.config.php
@@ -130,7 +130,7 @@ return [
 	'/hashtag'            => [Module\Hashtag::class, [R::GET]],
 	'/home'               => [Module\Home::class,    [R::GET]],
 	'/help[/{doc:.+}]'    => [Module\Help::class,    [R::GET]],
-	'/inbox[/{nickname}]' => [Module\Inbox::class,   [R::GET]],
+	'/inbox[/{nickname}]' => [Module\Inbox::class,   [R::GET, R::POST]],
 	'/invite'             => [Module\Invite::class,  [R::GET, R::POST]],
 
 	'/install'         => [


### PR DESCRIPTION
PR https://github.com/friendica/friendica/pull/7670 introduced a new router mechanism. Although the configuration for the inbox route had been wrong before as well, it seemed that it never came to effect.

This bug completely blocked communication with ActivityPub systems.