### PR TITLE
Enable the possibility to fetch a specific header variable

### DIFF
--- a/src/Network/CurlResult.php
+++ b/src/Network/CurlResult.php
@@ -134,6 +134,7 @@ class CurlResult
 
 		$this->body = substr($result, strlen($header));
 		$this->header = $header;
+		$this->header_fields = []; // Is filled on demand
 	}
 
 	private function checkSuccess()

--- a/src/Network/CurlResult.php
+++ b/src/Network/CurlResult.php
@@ -230,7 +230,7 @@ class CurlResult
 	 *
 	 * @return string|bool the Curl headers, "false" when field isn't found
 	 */
-	public function getHeader($field = '')
+	public function getHeader(string $field = '')
 	{
 		if (empty($field)) {
 			return $this->header;
@@ -241,11 +241,34 @@ class CurlResult
 			$parts = explode(':', $line);
 			$headerfield = array_shift($parts);
 			if (strtolower(trim($field)) == strtolower(trim($headerfield))) {
-				return implode(':', $parts);
+				return trim(implode(':', $parts));
 			}
 		}
 
 		return false;
+	}
+
+	/**
+	 * Returns the Curl headers as an associated array
+	 *
+	 * @return array associated header array
+	 */
+	public function getHeaderArray()
+	{
+		$headers = [];
+
+		$lines = explode("\n", $this->header);
+		foreach ($lines as $line) {
+			$parts = explode(':', $line);
+			$headerfield = strtolower(trim(array_shift($parts)));
+			$headerdata = trim(implode(':', $parts));
+
+			if (!empty($headerdata)) {
+				$headers[$headerfield] = $headerdata;
+			}
+		}
+
+		return $headers;
 	}
 
 	/**

--- a/src/Network/CurlResult.php
+++ b/src/Network/CurlResult.php
@@ -238,7 +238,7 @@ class CurlResult
 
 		$field = strtolower(trim($field));
 
-		$headers = self::getHeaderArray();
+		$headers = $this->getHeaderArray();
 
 		if (isset($headers[$field])) {
 			return $headers[$field];
@@ -256,7 +256,7 @@ class CurlResult
 	{
 		$field = strtolower(trim($field));
 
-		$headers = self::getHeaderArray();
+		$headers = $this->getHeaderArray();
 
 		return array_key_exists($field, $headers);
 	}

--- a/src/Network/CurlResult.php
+++ b/src/Network/CurlResult.php
@@ -228,7 +228,7 @@ class CurlResult
 	 *
 	 * @param string $field optional header field. Return all fields if empty
 	 *
-	 * @return string|bool the Curl headers, "false" when field isn't found
+	 * @return string the Curl headers or the specified content of the header variable
 	 */
 	public function getHeader(string $field = '')
 	{
@@ -245,7 +245,7 @@ class CurlResult
 			}
 		}
 
-		return false;
+		return '';
 	}
 
 	/**

--- a/src/Network/CurlResult.php
+++ b/src/Network/CurlResult.php
@@ -249,6 +249,8 @@ class CurlResult
 		if (isset($headers[$field])) {
 			return $headers[$field];
 		}
+
+		return '';
 	}
 
 	/**

--- a/src/Network/CurlResult.php
+++ b/src/Network/CurlResult.php
@@ -258,7 +258,7 @@ class CurlResult
 	 *
 	 * @return boolean "true" if header exists
 	 */
-	public function headerExists(string $field)
+	public function inHeader(string $field)
 	{
 		$field = strtolower(trim($field));
 

--- a/src/Network/CurlResult.php
+++ b/src/Network/CurlResult.php
@@ -226,11 +226,26 @@ class CurlResult
 	/**
 	 * Returns the Curl headers
 	 *
-	 * @return string the Curl headers
+	 * @param string $field optional header field. Return all fields if empty
+	 *
+	 * @return string|bool the Curl headers, "false" when field isn't found
 	 */
-	public function getHeader()
+	public function getHeader($field = '')
 	{
-		return $this->header;
+		if (empty($field)) {
+			return $this->header;
+		}
+
+		$lines = explode("\n", $this->header);
+		foreach ($lines as $line) {
+			$parts = explode(':', $line);
+			$headerfield = array_shift($parts);
+			if (strtolower(trim($field)) == strtolower(trim($headerfield))) {
+				return implode(':', $parts);
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/src/Network/CurlResult.php
+++ b/src/Network/CurlResult.php
@@ -27,6 +27,11 @@ class CurlResult
 	private $header;
 
 	/**
+	 * @var array the HTTP headers of the Curl call
+	 */
+	private $header_fields;
+
+	/**
 	 * @var boolean true (if HTTP 2xx result) or false
 	 */
 	private $isSuccess;
@@ -268,20 +273,21 @@ class CurlResult
 	 */
 	public function getHeaderArray()
 	{
-		$headers = [];
+		if (!empty($this->header_fields)) {
+			return $this->header_fields;
+		}
 
-		$lines = explode("\n", $this->header);
+		$this->header_fields = [];
+
+		$lines = explode("\n", trim($this->header));
 		foreach ($lines as $line) {
 			$parts = explode(':', $line);
 			$headerfield = strtolower(trim(array_shift($parts)));
 			$headerdata = trim(implode(':', $parts));
-
-			if (!empty($headerdata)) {
-				$headers[$headerfield] = $headerdata;
-			}
+			$this->header_fields[$headerfield] = $headerdata;
 		}
 
-		return $headers;
+		return $this->header_fields;
 	}
 
 	/**

--- a/src/Network/CurlResult.php
+++ b/src/Network/CurlResult.php
@@ -236,16 +236,29 @@ class CurlResult
 			return $this->header;
 		}
 
-		$lines = explode("\n", $this->header);
-		foreach ($lines as $line) {
-			$parts = explode(':', $line);
-			$headerfield = array_shift($parts);
-			if (strtolower(trim($field)) == strtolower(trim($headerfield))) {
-				return trim(implode(':', $parts));
-			}
-		}
+		$field = strtolower(trim($field));
 
-		return '';
+		$headers = self::getHeaderArray();
+
+		if (isset($headers[$field])) {
+			return $headers[$field];
+		}
+	}
+
+	/**
+	 * Check if a specified header exists
+	 *
+	 * @param string $field header field
+	 *
+	 * @return boolean "true" if header exists
+	 */
+	public function headerExists(string $field)
+	{
+		$field = strtolower(trim($field));
+
+		$headers = self::getHeaderArray();
+
+		return array_key_exists($field, $headers);
 	}
 
 	/**

--- a/tests/src/Network/CurlResultTest.php
+++ b/tests/src/Network/CurlResultTest.php
@@ -134,4 +134,59 @@ class CurlResultTest extends TestCase
 		$this->assertSame('https://test.local/test/it?key=value', $curlResult->getUrl());
 		$this->assertSame('https://test.other/some/?key=value', $curlResult->getRedirectUrl());
 	}
+
+	/**
+	 * @small
+	 */
+	public function testInHeader()
+	{
+		$header = file_get_contents(__DIR__ . '/../../datasets/curl/about.head');
+		$body = file_get_contents(__DIR__ . '/../../datasets/curl/about.body');
+
+		$curlResult = new CurlResult('https://test.local', $header . $body, [
+			'http_code' => 200,
+			'content_type' => 'text/html; charset=utf-8',
+			'url' => 'https://test.local'
+		]);
+		$this->assertTrue($curlResult->inHeader('vary'));
+		$this->assertFalse($curlResult->inHeader('wrongHeader'));
+	}
+
+	 /**
+	 * @small
+	 */
+	public function testGetHeaderArray()
+	{
+		$header = file_get_contents(__DIR__ . '/../../datasets/curl/about.head');
+		$body = file_get_contents(__DIR__ . '/../../datasets/curl/about.body');
+
+		$curlResult = new CurlResult('https://test.local', $header . $body, [
+			'http_code' => 200,
+			'content_type' => 'text/html; charset=utf-8',
+			'url' => 'https://test.local'
+		]);
+
+		$headers = $curlResult->getHeaderArray();
+
+		$this->assertNotEmpty($headers);
+		$this->assertArrayHasKey('vary', $headers);
+	}
+
+	 /**
+	 * @small
+	 */
+	public function testGetHeaderWithParam()
+	{
+		$header = file_get_contents(__DIR__ . '/../../datasets/curl/about.head');
+		$body = file_get_contents(__DIR__ . '/../../datasets/curl/about.body');
+
+		$curlResult = new CurlResult('https://test.local', $header . $body, [
+			'http_code' => 200,
+			'content_type' => 'text/html; charset=utf-8',
+			'url' => 'https://test.local'
+		]);
+
+		$this->assertNotEmpty($curlResult->getHeader());
+		$this->assertEmpty('vary', $curlResult->getHeader('wrongHeader'));
+	}
 }

--- a/tests/src/Network/CurlResultTest.php
+++ b/tests/src/Network/CurlResultTest.php
@@ -187,6 +187,6 @@ class CurlResultTest extends TestCase
 		]);
 
 		$this->assertNotEmpty($curlResult->getHeader());
-		$this->assertEmpty('vary', $curlResult->getHeader('wrongHeader'));
+		$this->assertEmpty($curlResult->getHeader('wrongHeader'));
 	}
 }


### PR DESCRIPTION
While analyzing some code that searches for header values I saw that this had been done "by hand" at every place. So we had to reinvent the wheel all the time.