### PR TITLE
add option 'require' for textarea form elements

### DIFF
--- a/doc/smarty3-templates.md
+++ b/doc/smarty3-templates.md
@@ -177,6 +177,7 @@ Field parameter:
 1. Label for the input box,
 2. Current text for the box,
 3. Help text for the input box.
+4. if set to "required" modern browser will check that this input box is filled when submitting the form,
 
 ### field_yesno.tpl
 

--- a/src/Module/Register.php
+++ b/src/Module/Register.php
@@ -114,7 +114,7 @@ class Register extends BaseModule
 		$o = Renderer::replaceMacros($tpl, [
 			'$invitations'  => Config::get('system', 'invitation_only'),
 			'$permonly'     => intval(Config::get('config', 'register_policy')) === self::APPROVE,
-			'$permonlybox'  => ['permonlybox', L10n::t('Note for the admin'), '', L10n::t('Leave a message for the admin, why you want to join this node')],
+			'$permonlybox'  => ['permonlybox', L10n::t('Note for the admin'), '', L10n::t('Leave a message for the admin, why you want to join this node'), "required"],
 			'$invite_desc'  => L10n::t('Membership on this site is by invitation only.'),
 			'$invite_label' => L10n::t('Your invitation code: '),
 			'$invite_id'    => $invite_id,

--- a/src/Module/Register.php
+++ b/src/Module/Register.php
@@ -114,7 +114,7 @@ class Register extends BaseModule
 		$o = Renderer::replaceMacros($tpl, [
 			'$invitations'  => Config::get('system', 'invitation_only'),
 			'$permonly'     => intval(Config::get('config', 'register_policy')) === self::APPROVE,
-			'$permonlybox'  => ['permonlybox', L10n::t('Note for the admin'), '', L10n::t('Leave a message for the admin, why you want to join this node'), "required"],
+			'$permonlybox'  => ['permonlybox', L10n::t('Note for the admin'), '', L10n::t('Leave a message for the admin, why you want to join this node'), 'required'],
 			'$invite_desc'  => L10n::t('Membership on this site is by invitation only.'),
 			'$invite_label' => L10n::t('Your invitation code: '),
 			'$invite_id'    => $invite_id,

--- a/view/templates/field_textarea.tpl
+++ b/view/templates/field_textarea.tpl
@@ -1,7 +1,7 @@
 
 	<div class="field textarea">
 		<label for="id_{{$field.0}}">{{$field.1}}</label>
-		<textarea name="{{$field.0}}" id="id_{{$field.0}}" aria-describedby="{{$field.0}}_tip">{{$field.2}}</textarea>
+		<textarea name="{{$field.0}}" id="id_{{$field.0}}" aria-describedby="{{$field.0}}_tip"{{if $field.4 eq 'required'}} required{{/if}}>{{$field.2}}</textarea>
 	{{if $field.3}}
 		<span class="field_help" role="tooltip" id="{{$field.0}}_tip">{{$field.3 nofilter}}</span>
 	{{/if}}


### PR DESCRIPTION
With this PR I've added the possibility for "field_textarea" form elements to have the "required" attribute, which most modern browser will automatically apply to prevent sending the form without a text input in that field.
Documentation was updated alongside.

The required attribute has been activated for the "leave a note to the admin" input box that is shown on the registration page when the node has "requires approval" set for registration policy.

part of #7688