### PR TITLE
Remove obsolete function to guess the base url of a contact

### DIFF
--- a/src/Model/GContact.php
+++ b/src/Model/GContact.php
@@ -222,7 +222,7 @@ class GContact
 
 		if (!isset($gcontact['server_url'])) {
 			// We check the server url to be sure that it is a real one
-			$server_url = PortableContact::detectServer($gcontact['url']);
+			$server_url = Contact::getBasepath($gcontact['url']);
 
 			// We are now sure that it is a correct URL. So we use it in the future
 			if ($server_url != "") {

--- a/src/Worker/DiscoverPoCo.php
+++ b/src/Worker/DiscoverPoCo.php
@@ -11,6 +11,7 @@ use Friendica\Core\Protocol;
 use Friendica\Core\Worker;
 use Friendica\Database\DBA;
 use Friendica\Model\GContact;
+use Friendica\Model\Contact;
 use Friendica\Network\Probe;
 use Friendica\Protocol\PortableContact;
 use Friendica\Util\DateTimeFormat;
@@ -175,7 +176,7 @@ class DiscoverPoCo
 				continue;
 			}
 
-			$server_url = PortableContact::detectServer($user["url"]);
+			$server_url = Contact::getBasepath($user["url"]);
 			$force_update = false;
 
 			if ($user["server_url"] != "") {
@@ -234,7 +235,7 @@ class DiscoverPoCo
 					continue;
 				}
 
-				$server_url = PortableContact::detectServer($jj->url);
+				$server_url = Contact::getBasepath($jj->url);
 				if ($server_url != '') {
 					if (!PortableContact::checkServer($server_url)) {
 						Logger::log("Friendica server ".$server_url." doesn't answer.", Logger::DEBUG);


### PR DESCRIPTION
The ```detectServer``` function was some really old and ugly part of the system :-)

This is now replaced by a function that does the same - but in a better way.