### PR TITLE
modified Vagrant devel VM (PHP 7.3, proper composer)

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,8 +6,8 @@ server_timezone = "UTC"
 public_folder = "/vagrant"
 
 Vagrant.configure(2) do |config|
-  # Set server to Ubuntu 16.04
-  config.vm.box = "ubuntu/xenial64"
+  # Set server to Debian 10 / Buster 64bit
+  config.vm.box = "debian/buster64"
 
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs

--- a/bin/dev/vagrant_provision.sh
+++ b/bin/dev/vagrant_provision.sh
@@ -37,9 +37,9 @@ sudo apt-get install -y apache2
 sudo a2enmod rewrite actions ssl
 sudo cp /vagrant/bin/dev/vagrant_vhost.sh /usr/local/bin/vhost
 sudo chmod guo+x /usr/local/bin/vhost
-    sudo vhost -s 192.168.22.10.xip.io -d /var/www -p /etc/ssl/xip.io -c xip.io -a friendica.local
-    sudo a2dissite 000-default
-    sudo service apache2 restart
+sudo vhost -s 192.168.22.10.xip.io -d /var/www -p /etc/ssl/xip.io -c xip.io -a friendica.local
+sudo a2dissite 000-default
+sudo service apache2 restart
 
 #Install php
 echo ">>> Installing PHP7"
@@ -48,9 +48,9 @@ sudo systemctl restart apache2
 
 #Install mysql
 echo ">>> Installing Mysql"
-sudo debconf-set-selections <<< "mysql-server mysql-server/root_password password root"
-sudo debconf-set-selections <<< "mysql-server mysql-server/root_password_again password root"
-sudo apt-get install -qq mysql-server
+sudo debconf-set-selections <<< "mariadb-server mariadb-server/root_password password root"
+sudo debconf-set-selections <<< "mariadb-server mariadb-server/root_password_again password root"
+sudo apt-get install -qq mariadb-server
 # enable remote access
 # setting the mysql bind-address to allow connections from everywhere
 sed -i "s/bind-address.*/bind-address = 0.0.0.0/" /etc/mysql/my.cnf

--- a/bin/dev/vagrant_provision.sh
+++ b/bin/dev/vagrant_provision.sh
@@ -76,6 +76,9 @@ debconf-set-selections <<< "postfix postfix/main_mailer_type string 'Local Only'
 sudo apt-get install -y postfix mailutils libmailutils-dev
 sudo echo -e "friendica1:	vagrant\nfriendica2:	vagrant\nfriendica3:	vagrant\nfriendica4:	vagrant\nfriendica5:	vagrant" >> /etc/aliases && sudo newaliases
 
+# Friendica needs git for fetching some dependencies
+sudo apt-get install -y git
+
 #make the vagrant directory the docroot
 sudo rm -rf /var/www/
 sudo ln -fs /vagrant /var/www
@@ -83,7 +86,7 @@ sudo ln -fs /vagrant /var/www
 # install deps with composer
 sudo apt install unzip
 cd /var/www
-php bin/composer.phar install
+sudo -u www-data php bin/composer.phar install
 
 # initial config file for friendica in vagrant
 cp /vagrant/mods/local.config.vagrant.php /vagrant/config/local.config.php


### PR DESCRIPTION
The Vagrant VM for developers was still using Ubuntu 16.04 as base OS underneath. Hence it provided only php7.0 which I thought was a bit low for development / testing as it is currently the bare minimum requirement of Friendica.

Simply updating to a later version of Ubuntu failed as they changed something in the network configuration. Hence I changed to Debian Buster, which has php 7.3 in the repositories by default which is now used.

During setup of the VM the composer dependencies are pulled in. This was done by the wrong user, so there was a warning and the VM did not work out of the box. So the run is now done as `www-data` user. Additionally the composer missed `git` to fetch some dependencies; so it is now installed in the VM.

As a small cosmetic thing, we are now using MariaDB explicitly and not via the mysql alias package only.