### PR TITLE
add server side check about note to admin

### DIFF
--- a/src/Module/Register.php
+++ b/src/Module/Register.php
@@ -259,6 +259,14 @@ class Register extends BaseModule
 				$a->internalRedirect();
 			}
 
+			// Check if the note to the admin is actually filled out
+			if (empty($_POST['permonlybox'])) {
+				\notice(L10n::t('You have to leave a request note for the admin.')
+					. L10n::t('Your registration can not be processed.') . EOL);
+
+				$a->internalRedirect('register/');
+			}
+
 			Model\Register::createForApproval($user['uid'], Config::get('system', 'language'), $_POST['permonlybox']);
 
 			// invite system


### PR DESCRIPTION
When the regisration is set to `requires approval` this PR adds a check if the *note to the admin* was filled in on the server side.
#7692 only added a client side check that could be ignored.

part of #7688
follow up of #7692