### PR TITLE
[vier] Add necessary required_once statement in theme/vier/config.php

### DIFF
--- a/view/theme/vier/config.php
+++ b/view/theme/vier/config.php
@@ -10,6 +10,8 @@ use Friendica\Core\PConfig;
 use Friendica\Core\Renderer;
 use Friendica\Core\System;
 
+require_once __DIR__ . '/theme.php';
+
 function theme_content(App $a)
 {
 	if (!local_user()) {


### PR DESCRIPTION
Fixes #7707

- Vier config.php depends on a function declared in theme.php