### PR TITLE
Rework theme session variables

### DIFF
--- a/include/api.php
+++ b/include/api.php
@@ -162,6 +162,7 @@ function api_register_func($path, $func, $auth = false, $method = API_METHOD_ANY
  * @brief Login API user
  *
  * @param App $a App
+ * @throws ForbiddenException
  * @throws InternalServerErrorException
  * @throws UnauthorizedException
  * @hook  'authenticate'
@@ -170,8 +171,6 @@ function api_register_func($path, $func, $auth = false, $method = API_METHOD_ANY
  *               'password' => password from login form
  *               'authenticated' => return status,
  *               'user_record' => return authenticated user record
- * @hook  'logged_in'
- *               array $user    logged user record
  */
 function api_login(App $a)
 {
@@ -182,7 +181,7 @@ function api_login(App $a)
 		list($consumer, $token) = $oauth1->verify_request($request);
 		if (!is_null($token)) {
 			$oauth1->loginUser($token->uid);
-			Hook::callAll('logged_in', $a->user);
+			Session::set('allow_api', true);
 			return;
 		}
 		echo __FILE__.__LINE__.__FUNCTION__ . "<pre>";

--- a/mod/community.php
+++ b/mod/community.php
@@ -17,14 +17,6 @@ use Friendica\Database\DBA;
 use Friendica\Model\Item;
 use Friendica\Model\User;
 
-function community_init(App $a)
-{
-	if (!local_user()) {
-		unset($_SESSION['theme']);
-		unset($_SESSION['mobile-theme']);
-	}
-}
-
 function community_content(App $a, $update = 0)
 {
 	$o = '';

--- a/mod/manage.php
+++ b/mod/manage.php
@@ -70,24 +70,8 @@ function manage_post(App $a) {
 	if (!DBA::isResult($user)) {
 		return;
 	}
-	unset($_SESSION['authenticated']);
-	unset($_SESSION['uid']);
-	unset($_SESSION['visitor_id']);
-	unset($_SESSION['administrator']);
-	unset($_SESSION['cid']);
-	unset($_SESSION['theme']);
-	unset($_SESSION['mobile-theme']);
-	unset($_SESSION['page_flags']);
-	unset($_SESSION['return_path']);
-	if (!empty($_SESSION['submanage'])) {
-		unset($_SESSION['submanage']);
-	}
-	if (!empty($_SESSION['sysmsg'])) {
-		unset($_SESSION['sysmsg']);
-	}
-	if (!empty($_SESSION['sysmsg_info'])) {
-		unset($_SESSION['sysmsg_info']);
-	}
+
+	Session::clear();
 
 	Session::setAuthenticatedForUser($a, $user, true, true);
 

--- a/mod/search.php
+++ b/mod/search.php
@@ -76,10 +76,6 @@ function search_init(App $a) {
 		}
 
 		$a->page['aside'] .= search_saved_searches();
-
-	} else {
-		unset($_SESSION['theme']);
-		unset($_SESSION['mobile-theme']);
 	}
 }
 

--- a/mod/uimport.php
+++ b/mod/uimport.php
@@ -41,14 +41,6 @@ function uimport_content(App $a)
 		}
 	}
 
-
-	if (!empty($_SESSION['theme'])) {
-		unset($_SESSION['theme']);
-	}
-	if (!empty($_SESSION['mobile-theme'])) {
-		unset($_SESSION['mobile-theme']);
-	}
-
 	$tpl = Renderer::getMarkupTemplate("uimport.tpl");
 	return Renderer::replaceMacros($tpl, [
 		'$regbutt' => L10n::t('Import'),

--- a/src/App.php
+++ b/src/App.php
@@ -587,7 +587,11 @@ class App
 	 *
 	 * This probably should change to limit the size of this monster method.
 	 *
-	 * @param App\Module $module The determined module
+	 * @param App\Module     $module The determined module
+	 * @param App\Router     $router
+	 * @param PConfiguration $pconfig
+	 * @throws HTTPException\InternalServerErrorException
+	 * @throws \ImagickException
 	 */
 	public function runFrontend(App\Module $module, App\Router $router, PConfiguration $pconfig)
 	{
@@ -733,8 +737,7 @@ class App
 			$module = $module->determineClass($this->args, $router, $this->config);
 
 			// Let the module run it's internal process (init, get, post, ...)
-			$module->run($this->l10n, $this, $this->logger, $this->getCurrentTheme(), $_SERVER, $_POST);
-
+			$module->run($this->l10n, $this, $this->logger, $_SERVER, $_POST);
 		} catch (HTTPException $e) {
 			ModuleHTTPException::rawContent($e);
 		}

--- a/src/App.php
+++ b/src/App.php
@@ -92,10 +92,10 @@ class App
 	 */
 	private $baseURL;
 
-	/**
-	 * @var string The name of the current theme
-	 */
+	/** @var string The name of the current theme */
 	private $currentTheme;
+	/** @var string The name of the current mobile theme */
+	private $currentMobileTheme;
 
 	/**
 	 * @var Configuration The config
@@ -450,15 +450,25 @@ class App
 	}
 
 	/**
-	 * Returns the current theme name.
+	 * Returns the current theme name. May be overriden by the mobile theme name.
 	 *
-	 * @return string the name of the current theme
-	 * @throws HTTPException\InternalServerErrorException
+	 * @return string
+	 * @throws Exception
 	 */
 	public function getCurrentTheme()
 	{
 		if ($this->mode->isInstall()) {
 			return '';
+		}
+
+		// Specific mobile theme override
+		if (($this->mode->isMobile() || $this->mode->isTablet()) && Core\Session::get('show-mobile', true)) {
+			$user_mobile_theme = $this->getCurrentMobileTheme();
+
+			// --- means same mobile theme as desktop
+			if (!empty($user_mobile_theme) && $user_mobile_theme !== '---') {
+				return $user_mobile_theme;
+			}
 		}
 
 		if (!$this->currentTheme) {
@@ -468,13 +478,37 @@ class App
 		return $this->currentTheme;
 	}
 
+	/**
+	 * Returns the current mobile theme name.
+	 *
+	 * @return string
+	 * @throws Exception
+	 */
+	public function getCurrentMobileTheme()
+	{
+		if ($this->mode->isInstall()) {
+			return '';
+		}
+
+		if (is_null($this->currentMobileTheme)) {
+			$this->computeCurrentMobileTheme();
+		}
+
+		return $this->currentMobileTheme;
+	}
+
 	public function setCurrentTheme($theme)
 	{
 		$this->currentTheme = $theme;
 	}
 
+	public function setCurrentMobileTheme($theme)
+	{
+		$this->currentMobileTheme = $theme;
+	}
+
 	/**
-	 * Computes the current theme name based on the node settings, the user settings and the device type
+	 * Computes the current theme name based on the node settings, the page owner settings and the user settings
 	 *
 	 * @throws Exception
 	 */
@@ -486,7 +520,7 @@ class App
 		}
 
 		// Sane default
-		$this->currentTheme = $system_theme;
+		$this->setCurrentTheme($system_theme);
 
 		$page_theme = null;
 		// Find the theme that belongs to the user whose stuff we are looking at
@@ -499,24 +533,7 @@ class App
 			}
 		}
 
-		$user_theme = Core\Session::get('theme', $system_theme);
-
-		// Specific mobile theme override
-		if (($this->is_mobile || $this->is_tablet) && Core\Session::get('show-mobile', true)) {
-			$system_mobile_theme = $this->config->get('system', 'mobile-theme');
-			$user_mobile_theme   = Core\Session::get('mobile-theme', $system_mobile_theme);
-
-			// --- means same mobile theme as desktop
-			if (!empty($user_mobile_theme) && $user_mobile_theme !== '---') {
-				$user_theme = $user_mobile_theme;
-			}
-		}
-
-		if ($page_theme) {
-			$theme_name = $page_theme;
-		} else {
-			$theme_name = $user_theme;
-		}
+		$theme_name = $page_theme ?: Core\Session::get('theme', $system_theme);
 
 		$theme_name = Strings::sanitizeFilePathItem($theme_name);
 		if ($theme_name
@@ -524,7 +541,40 @@ class App
 		    && (file_exists('view/theme/' . $theme_name . '/style.css')
 		        || file_exists('view/theme/' . $theme_name . '/style.php'))
 		) {
-			$this->currentTheme = $theme_name;
+			$this->setCurrentTheme($theme_name);
+		}
+	}
+
+	/**
+	 * Computes the current mobile theme name based on the node settings, the page owner settings and the user settings
+	 */
+	private function computeCurrentMobileTheme()
+	{
+		$system_mobile_theme = $this->config->get('system', 'mobile-theme', '');
+
+		// Sane default
+		$this->setCurrentMobileTheme($system_mobile_theme);
+
+		$page_mobile_theme = null;
+		// Find the theme that belongs to the user whose stuff we are looking at
+		if ($this->profile_uid && ($this->profile_uid != local_user())) {
+			// Allow folks to override user themes and always use their own on their own site.
+			// This works only if the user is on the same server
+			if (!Core\PConfig::get(local_user(), 'system', 'always_my_theme')) {
+				$page_mobile_theme = Core\PConfig::get($this->profile_uid, 'system', 'mobile-theme');
+			}
+		}
+
+		$mobile_theme_name = $page_mobile_theme ?: Core\Session::get('mobile-theme', $system_mobile_theme);
+
+		$mobile_theme_name = Strings::sanitizeFilePathItem($mobile_theme_name);
+		if ($mobile_theme_name == '---'
+			||
+			in_array($mobile_theme_name, Theme::getAllowedList())
+			&& (file_exists('view/theme/' . $mobile_theme_name . '/style.css')
+				|| file_exists('view/theme/' . $mobile_theme_name . '/style.php'))
+		) {
+			$this->setCurrentMobileTheme($mobile_theme_name);
 		}
 	}
 
@@ -534,7 +584,7 @@ class App
 	 * Provide a sane default if nothing is chosen or the specified theme does not exist.
 	 *
 	 * @return string
-	 * @throws HTTPException\InternalServerErrorException
+	 * @throws Exception
 	 */
 	public function getCurrentThemeStylesheetPath()
 	{

--- a/src/App/Module.php
+++ b/src/App/Module.php
@@ -138,7 +138,7 @@ class Module
 	 *
 	 * @return Module The determined module of this call
 	 *
-	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
+	 * @throws \Exception
 	 */
 	public function determineClass(Arguments $args, Router $router, Core\Config\Configuration $config)
 	{
@@ -186,13 +186,12 @@ class Module
 	 * @param Core\L10n\L10n  $l10n         The L10n instance
 	 * @param App             $app          The whole Friendica app (for method arguments)
 	 * @param LoggerInterface $logger       The Friendica logger
-	 * @param string          $currentTheme The chosen theme
 	 * @param array           $server       The $_SERVER variable
 	 * @param array           $post         The $_POST variables
 	 *
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
-	public function run(Core\L10n\L10n $l10n, App $app, LoggerInterface $logger, string $currentTheme, array $server, array $post)
+	public function run(Core\L10n\L10n $l10n, App $app, LoggerInterface $logger, array $server, array $post)
 	{
 		if ($this->printNotAllowedAddon) {
 			info($l10n->t("You must be logged in to use addons. "));
@@ -231,17 +230,6 @@ class Module
 		// "rawContent" is especially meant for technical endpoints.
 		// This endpoint doesn't need any theme initialization or other comparable stuff.
 		call_user_func([$this->module_class, 'rawContent']);
-
-		// Load current theme info after module has been initialized as theme could have been set in module
-		$theme_info_file = 'view/theme/' . $currentTheme . '/theme.php';
-		if (file_exists($theme_info_file)) {
-			require_once $theme_info_file;
-		}
-
-		if (function_exists(str_replace('-', '_', $currentTheme) . '_init')) {
-			$func = str_replace('-', '_', $currentTheme) . '_init';
-			$func($app);
-		}
 
 		if ($server['REQUEST_METHOD'] === 'POST') {
 			Core\Hook::callAll($this->module . '_mod_post', $post);

--- a/src/App/Page.php
+++ b/src/App/Page.php
@@ -364,6 +364,18 @@ class Page implements ArrayAccess
 		 */
 		$this->initContent($module, $mode);
 
+		// Load current theme info after module has been initialized as theme could have been set in module
+		$currentTheme = $app->getCurrentTheme();
+		$theme_info_file = 'view/theme/' . $currentTheme . '/theme.php';
+		if (file_exists($theme_info_file)) {
+			require_once $theme_info_file;
+		}
+
+		if (function_exists(str_replace('-', '_', $currentTheme) . '_init')) {
+			$func = str_replace('-', '_', $currentTheme) . '_init';
+			$func($app);
+		}
+
 		/* Create the page head after setting the language
 		 * and getting any auth credentials.
 		 *

--- a/src/Core/Session.php
+++ b/src/Core/Session.php
@@ -100,6 +100,14 @@ class Session
 	}
 
 	/**
+	 * Clears the current session array
+	 */
+	public static function clear()
+	{
+		$_SESSION = [];
+	}
+
+	/**
 	 * @brief Sets the provided user's authenticated session
 	 *
 	 * @param App   $a
@@ -107,6 +115,7 @@ class Session
 	 * @param bool  $login_initial
 	 * @param bool  $interactive
 	 * @param bool  $login_refresh
+	 * @throws \Friendica\Network\HTTPException\ForbiddenException
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
 	public static function setAuthenticatedForUser(App $a, array $user_record, $login_initial = false, $interactive = false, $login_refresh = false)

--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -20,6 +20,7 @@ use Friendica\Core\Protocol;
 use Friendica\Core\Renderer;
 use Friendica\Core\Session;
 use Friendica\Core\System;
+use Friendica\Core\Theme;
 use Friendica\Core\Worker;
 use Friendica\Database\DBA;
 use Friendica\Protocol\Diaspora;
@@ -189,10 +190,9 @@ class Profile
 		$a->page['title'] = $a->profile['name'] . ' @ ' . Config::get('config', 'sitename');
 
 		if (!$profiledata && !PConfig::get(local_user(), 'system', 'always_my_theme')) {
-			$_SESSION['theme'] = $a->profile['theme'];
+			$a->setCurrentTheme($a->profile['theme']);
+			$a->setCurrentMobileTheme($a->profile['mobile-theme']);
 		}
-
-		$_SESSION['mobile-theme'] = $a->profile['mobile-theme'];
 
 		/*
 		* load/reload current theme info

--- a/src/Module/Directory.php
+++ b/src/Module/Directory.php
@@ -34,9 +34,6 @@ class Directory extends BaseModule
 		if (local_user()) {
 			$app->page['aside'] .= Widget::findPeople();
 			$app->page['aside'] .= Widget::follow();
-		} else {
-			unset($_SESSION['theme']);
-			unset($_SESSION['mobile-theme']);
 		}
 
 		$output = '';

--- a/src/Module/Home.php
+++ b/src/Module/Home.php
@@ -14,14 +14,6 @@ class Home extends BaseModule
 {
 	public static function content()
 	{
-		if (!empty($_SESSION['theme'])) {
-			unset($_SESSION['theme']);
-		}
-
-		if (!empty($_SESSION['mobile-theme'])) {
-			unset($_SESSION['mobile-theme']);
-		}
-
 		$app = self::getApp();
 		$config = $app->getConfig();
 

--- a/src/Module/Login.php
+++ b/src/Module/Login.php
@@ -32,9 +32,6 @@ class Login extends BaseModule
 	{
 		$a = self::getApp();
 
-		Session::remove('theme');
-		Session::remove('mobile-theme');
-
 		if (local_user()) {
 			$a->internalRedirect();
 		}

--- a/src/Module/Register.php
+++ b/src/Module/Register.php
@@ -61,13 +61,6 @@ class Register extends BaseModule
 			}
 		}
 
-		if (!empty($_SESSION['theme'])) {
-			unset($_SESSION['theme']);
-		}
-		if (!empty($_SESSION['mobile-theme'])) {
-			unset($_SESSION['mobile-theme']);
-		}
-
 		$username   = defaults($_REQUEST, 'username'  , '');
 		$email      = defaults($_REQUEST, 'email'     , '');
 		$openid_url = defaults($_REQUEST, 'openid_url', '');


### PR DESCRIPTION
I was moving the search module, and then i noticed this:
```php
function search_init(App $a) {
	...
	if (local_user()) {
		...
	} else {
		unset($_SESSION['theme']);
		unset($_SESSION['mobile-theme']);
	}
}
```
What was the point of these `unset` calls?

It turns out to be caused by the way we used to override the theme in `Profile::load`, which led me on a magical journey to get rid of those odd calls.

> +119 −140 

Goal achieved.