### PR TITLE
The getGUID function hadn't fetched the GUID from pictures with scale "0"

### DIFF
--- a/src/Model/Photo.php
+++ b/src/Model/Photo.php
@@ -690,7 +690,7 @@ class Photo extends BaseObject
 		}
 
 		$scale = intval(substr($guid, -1, 1));
-		if (empty($scale)) {
+		if (!is_numeric($scale)) {
 			return '';
 		}
 


### PR DESCRIPTION
This lead to the failing of the function "isLocal" which had been used for detecting pictures for example to post to Twitter.