### PR TITLE
Discriminate between links and non-links in [url] BBCode tag insertion

### DIFF
--- a/view/js/linkPreview.js
+++ b/view/js/linkPreview.js
@@ -52,7 +52,6 @@
 			<div class="clear"></div>\
 			<hr class="previewseparator">';
 		var text;
-		var urlRegex = /^(?:https?\:\/\/|\s)[a-z0-9-]+(\.[a-z0-9-]+)*(\.[a-z]{2,4})(?:\/+[a-z0-9_.\:\;-]*)*(?:\?[\&\%\|\+a-z0-9_=,\.\:\;-]*)?(?:[\&\%\|\+&a-z0-9_=,\:\;\.-]*)(?:[\!\#\/\&\%\|\+a-z0-9_=,\:\;\.-]*)}*$/i;
 		var binurl;
 		var block = false;
 		var blockTitle = false;

--- a/view/js/main.js
+++ b/view/js/main.js
@@ -406,6 +406,61 @@ $(function() {
 	}
 });
 
+/**
+ * Inserts a BBCode tag in the comment textarea identified by id
+ *
+ * @param {string} BBCode
+ * @param {int} id
+ * @returns {boolean}
+ */
+function insertFormatting(BBCode, id) {
+	let textarea = document.getElementById('comment-edit-text-' + id);
+
+	if (textarea.value === '') {
+		$(textarea)
+			.addClass("comment-edit-text-full")
+			.removeClass("comment-edit-text-empty");
+		closeMenu("comment-fake-form-" + id);
+		openMenu("item-comments-" + id);
+	}
+
+	insertBBCodeInTextarea(BBCode, textarea);
+
+	return true;
+}
+
+/**
+ * Inserts a BBCode tag in the provided textarea element, wrapping the currently selected text.
+ * For URL BBCode, it discriminates between link text and non-link text to determine where to insert the selected text.
+ *
+ * @param {string} BBCode
+ * @param {HTMLTextAreaElement} textarea
+ */
+function insertBBCodeInTextarea(BBCode, textarea) {
+	let selectionStart = textarea.selectionStart;
+	let selectionEnd = textarea.selectionEnd;
+	let selectedText = textarea.value.substring(selectionStart, selectionEnd);
+	let openingTag = '[' + BBCode + ']';
+	let closingTag = '[/' + BBCode + ']';
+	let cursorPosition = selectionStart + openingTag.length + selectedText.length;
+
+	if (BBCode === 'url') {
+		if (urlRegex.test(selectedText)) {
+			openingTag = '[' + BBCode + '=' + selectedText + ']';
+			selectedText = '';
+			cursorPosition = selectionStart + openingTag.length;
+		} else {
+			openingTag = '[' + BBCode + '=]';
+			cursorPosition = selectionStart + openingTag.length - 1;
+		}
+	}
+
+	textarea.value = textarea.value.substring(0, selectionStart) + openingTag + selectedText + closingTag + textarea.value.substring(selectionEnd, textarea.value.length);
+	textarea.setSelectionRange(cursorPosition, cursorPosition);
+	textarea.dispatchEvent(new Event('change'));
+	textarea.focus();
+}
+
 function NavUpdate() {
 	if (!stopped) {
 		var pingCmd = 'ping?format=json' + ((localUser != 0) ? '&f=&uid=' + localUser : '');

--- a/view/js/main.js
+++ b/view/js/main.js
@@ -86,6 +86,8 @@ var last_popup_menu = null;
 var last_popup_button = null;
 var lockLoadContent = false;
 
+const urlRegex = /^(?:https?:\/\/|\s)[a-z0-9-]+(\.[a-z0-9-]+)*(\.[a-z]{2,4})(?:\/+[a-z0-9_.:;-]*)*(?:\?[&%|+a-z0-9_=,.:;-]*)?(?:[&%|+&a-z0-9_=,:;.-]*)(?:[!#\/&%|+a-z0-9_=,:;.-]*)}*$/i;
+
 $(function() {
 	$.ajaxSetup({cache: false});
 

--- a/view/theme/duepuntozero/theme.php
+++ b/view/theme/duepuntozero/theme.php
@@ -28,28 +28,6 @@ Renderer::setActiveTemplateEngine('smarty3');
     }
 $a->page['htmlhead'] .= <<< EOT
 <script>
-function insertFormatting(BBcode, id) {
-	var tmpStr = $("#comment-edit-text-" + id).val();
-	if (tmpStr == "") {
-		$("#comment-edit-text-" + id).addClass("comment-edit-text-full");
-		$("#comment-edit-text-" + id).removeClass("comment-edit-text-empty");
-		openMenu("comment-edit-submit-wrapper-" + id);
-	}
-
-	textarea = document.getElementById("comment-edit-text-" +id);
-	if (document.selection) {
-		textarea.focus();
-		selected = document.selection.createRange();
-		selected.text = "["+BBcode+"]" + selected.text + "[/"+BBcode+"]";
-	} else if (textarea.selectionStart || textarea.selectionStart == "0") {
-		var start = textarea.selectionStart;
-		var end = textarea.selectionEnd;
-		textarea.value = textarea.value.substring(0, start) + "["+BBcode+"]" + textarea.value.substring(start, end) + "[/"+BBcode+"]" + textarea.value.substring(end, textarea.value.length);
-	}
-
-	return true;
-}
-
 function cmtBbOpen(comment, id) {
 	if ($(comment).hasClass('comment-edit-text-full')) {
 		$(".comment-edit-bb-" + id).show();

--- a/view/theme/frio/js/textedit.js
+++ b/view/theme/frio/js/textedit.js
@@ -76,45 +76,10 @@ function commentLinkDropper(event) {
 	}
 }
 
-
-function insertFormatting(BBcode, id) {
-	var tmpStr = $("#comment-edit-text-" + id).val();
-	if (tmpStr == '') {
-		$("#comment-edit-text-" + id).addClass("comment-edit-text-full");
-		$("#comment-edit-text-" + id).removeClass("comment-edit-text-empty");
-		closeMenu("comment-fake-form-" + id);
-		openMenu("item-comments-" + id);
-	}
-
-	textarea = document.getElementById("comment-edit-text-" + id);
-	if (document.selection) {
-		textarea.focus();
-		selected = document.selection.createRange();
-		selected.text = "[" + BBcode + "]" + selected.text + "[/" + BBcode + "]";
-	} else if (textarea.selectionStart || textarea.selectionStart == "0") {
-		var start = textarea.selectionStart;
-		var end = textarea.selectionEnd;
-		textarea.value = textarea.value.substring(0, start) + "[" + BBcode + "]" + textarea.value.substring(start, end) + "[/" + BBcode + "]" + textarea.value.substring(end, textarea.value.length);
-	}
-
-	$(textarea).trigger('change');
-
-	return true;
-}
-
-function insertFormattingToPost(BBcode) {
+function insertFormattingToPost(BBCode) {
 	textarea = document.getElementById("profile-jot-text");
-	if (document.selection) {
-		textarea.focus();
-		selected = document.selection.createRange();
-		selected.text = "[" + BBcode + "]" + selected.text + "[/" + BBcode + "]";
-	} else if (textarea.selectionStart || textarea.selectionStart == "0") {
-		var start = textarea.selectionStart;
-		var end = textarea.selectionEnd;
-		textarea.value = textarea.value.substring(0, start) + "[" + BBcode + "]" + textarea.value.substring(start, end) + "[/" + BBcode + "]" + textarea.value.substring(end, textarea.value.length);
-	}
 
-	$(textarea).trigger('change');
+	insertBBCodeInTextarea(BBCode, textarea);
 
 	return true;
 }

--- a/view/theme/quattro/js/quattro.js
+++ b/view/theme/quattro/js/quattro.js
@@ -60,28 +60,6 @@ $(document).ready(function(){
 	});
 });
 
-function insertFormatting(BBcode, id) {
-	var tmpStr = $("#comment-edit-text-" + id).val();
-	if (tmpStr == "") {
-		$("#comment-edit-text-" + id).addClass("comment-edit-text-full");
-		$("#comment-edit-text-" + id).removeClass("comment-edit-text-empty");
-		openMenu("comment-edit-submit-wrapper-" + id);
-	}
-
-	textarea = document.getElementById("comment-edit-text-" +id);
-	if (document.selection) {
-		textarea.focus();
-		selected = document.selection.createRange();
-		selected.text = "["+BBcode+"]" + selected.text + "[/"+BBcode+"]";
-	} else if (textarea.selectionStart || textarea.selectionStart == "0") {
-		var start = textarea.selectionStart;
-		var end = textarea.selectionEnd;
-		textarea.value = textarea.value.substring(0, start) + "["+BBcode+"]" + textarea.value.substring(start, end) + "[/"+BBcode+"]" + textarea.value.substring(end, textarea.value.length);
-	}
-
-	return true;
-}
-
 function showThread(id) {
 	$("#collapsed-comments-" + id).show()
 	$("#collapsed-comments-" + id + " .collapsed-comments").show()

--- a/view/theme/smoothly/templates/bottom.tpl
+++ b/view/theme/smoothly/templates/bottom.tpl
@@ -1,41 +1,7 @@
 
 <script type="text/javascript" src="{{$baseurl}}/view/theme/smoothly/js/jquery.autogrow.textarea.js"></script>
 <script type="text/javascript">
-$(document).ready(function() {
-
-});
 function tautogrow(id) {
 	$("textarea#comment-edit-text-" + id).autogrow();
-};
-
-function insertFormatting(BBcode, id) {
-	var tmpStr = $("#comment-edit-text-" + id).val();
-	if (tmpStr == "") {
-		$("#comment-edit-text-" + id).addClass("comment-edit-text-full");
-		$("#comment-edit-text-" + id).removeClass("comment-edit-text-empty");
-		openMenu("comment-edit-submit-wrapper-" + id);
-	}
-
-	textarea = document.getElementById("comment-edit-text-" + id);
-	if (document.selection) {
-		textarea.focus();
-		selected = document.selection.createRange();
-		selected.text = "["+BBcode+"]" + selected.text + "[/"+BBcode+"]";
-	} else if (textarea.selectionStart || textarea.selectionStart == "0") {
-		var start = textarea.selectionStart;
-		var end = textarea.selectionEnd;
-		textarea.value = textarea.value.substring(0, start)
-			+ "["+BBcode+"]" + textarea.value.substring(start, end) + "[/"+BBcode+"]"
-			+ textarea.value.substring(end, textarea.value.length);
-	}
-
-	return true;
-}
-
-function cmtBbOpen(id) {
-	$(".comment-edit-bb-" + id).show();
-}
-function cmtBbClose(id) {
-    $(".comment-edit-bb-" + id).hide();
 }
 </script>

--- a/view/theme/smoothly/theme.php
+++ b/view/theme/smoothly/theme.php
@@ -23,28 +23,6 @@ function smoothly_init(App $a) {
 	$a->page['htmlhead'] .= <<< EOT
 
 <script>
-function insertFormatting(BBcode, id) {
-	var tmpStr = $("#comment-edit-text-" + id).val();
-	if (tmpStr == "") {
-		$("#comment-edit-text-" + id).addClass("comment-edit-text-full");
-		$("#comment-edit-text-" + id).removeClass("comment-edit-text-empty");
-		openMenu("comment-edit-submit-wrapper-" + id);
-	}
-
-	textarea = document.getElementById("comment-edit-text-" +id);
-	if (document.selection) {
-		textarea.focus();
-		selected = document.selection.createRange();
-		selected.text = "["+BBcode+"]" + selected.text + "[/"+BBcode+"]";
-	} else if (textarea.selectionStart || textarea.selectionStart == "0") {
-		var start = textarea.selectionStart;
-		var end = textarea.selectionEnd;
-		textarea.value = textarea.value.substring(0, start) + "["+BBcode+"]" + textarea.value.substring(start, end) + "[/"+BBcode+"]" + textarea.value.substring(end, textarea.value.length);
-	}
-
-	return true;
-}
-
 function cmtBbOpen(id) {
 	$(".comment-edit-bb-" + id).show();
 }

--- a/view/theme/vier/theme.php
+++ b/view/theme/vier/theme.php
@@ -45,29 +45,6 @@ function vier_init(App $a)
 	$a->page['htmlhead'] .= <<< EOT
 <link rel='stylesheet' type='text/css' href='view/theme/vier/narrow.css' media='screen and (max-width: 1100px)' />
 <script type="text/javascript">
-
-function insertFormatting(BBcode, id) {
-	var tmpStr = $("#comment-edit-text-" + id).val();
-	if (tmpStr == "") {
-		$("#comment-edit-text-" + id).addClass("comment-edit-text-full");
-		$("#comment-edit-text-" + id).removeClass("comment-edit-text-empty");
-		openMenu("comment-edit-submit-wrapper-" + id);
-	}
-
-	textarea = document.getElementById("comment-edit-text-" +id);
-	if (document.selection) {
-		textarea.focus();
-		selected = document.selection.createRange();
-		selected.text = "["+BBcode+"]" + selected.text + "[/"+BBcode+"]";
-	} else if (textarea.selectionStart || textarea.selectionStart == "0") {
-		var start = textarea.selectionStart;
-		var end = textarea.selectionEnd;
-		textarea.value = textarea.value.substring(0, start) + "["+BBcode+"]" + textarea.value.substring(start, end) + "[/"+BBcode+"]" + textarea.value.substring(end, textarea.value.length);
-	}
-
-	return true;
-}
-
 function showThread(id) {
 	$("#collapsed-comments-" + id).show()
 	$("#collapsed-comments-" + id + " .collapsed-comments").show()


### PR DESCRIPTION
Closes #7682 

This PR introduces a GitHub-style link BBCode tag button feature that is context-sensitive. Highlighting a URL will fill the url parameter of the BBCode while a non-link will be added as the BBCode content.

Examples:
- Highlight `https://example.com`
- Click the Link BBCode button
- Result: `[url=https://example.com][/url]`

Or:
- Highlight `Link label`
- Click the Link BBCode button
- Result: `[url=]Link label[/url]`

This effectively removes the possibility to add just `[url]https://example.com[/url]` to a post or comment textarea, but this case is already covered by the autolinker, meaning that `[url]https://example.com[/url]` is functionally equivalent to `https://example.com` in a post body.

This update covers all themes.

> +59 −161

😎