### PR TITLE
 Catch missing Certainty bundle exception when checking for exposed password

### DIFF
--- a/src/Core/Logger.php
+++ b/src/Core/Logger.php
@@ -64,7 +64,6 @@ class Logger extends BaseObject
 		self::TRACE => 'Trace',
 		self::DEBUG => 'Debug',
 		self::DATA => 'Data',
-		self::ALL => 'All',
 	];
 
 	/**

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -412,6 +412,7 @@ class User
 	 *
 	 * @param string $password
 	 * @return bool
+	 * @throws Exception
 	 */
 	public static function isPasswordExposed($password)
 	{
@@ -420,9 +421,20 @@ class User
 			'cacheDirectory' => get_temppath() . '/password-exposed-cache/',
 		]);
 
-		$PasswordExposedCHecker = new PasswordExposed\PasswordExposedChecker(null, $cache);
+		try {
+			$passwordExposedChecker = new PasswordExposed\PasswordExposedChecker(null, $cache);
 
-		return $PasswordExposedCHecker->passwordExposed($password) === PasswordExposed\PasswordStatus::EXPOSED;
+			return $passwordExposedChecker->passwordExposed($password) === PasswordExposed\PasswordStatus::EXPOSED;
+		} catch (\Exception $e) {
+			Logger::error('Password Exposed Exception: ' . $e->getMessage(), [
+				'code' => $e->getCode(),
+				'file' => $e->getFile(),
+				'line' => $e->getLine(),
+				'trace' => $e->getTraceAsString()
+			]);
+
+			return false;
+		}
 	}
 
 	/**


### PR DESCRIPTION
Fixes #7709 

Missing Certainty bundles won't crash password exposition check anymore. Exceptions are now logged.