### PR TITLE
Convert links with empty descriptions

### DIFF
--- a/mod/item.php
+++ b/mod/item.php
@@ -229,6 +229,9 @@ function item_post(App $a) {
 		$body .= $att_bbcode;
 	}
 
+	// Convert links with empty descriptions to links without an explicit description
+	$body = preg_replace('(\[url=(.*?)\]\[\/url\])ism', '[url]$1[/url]', $body);
+
 	if (!empty($orig_post)) {
 		$str_group_allow   = $orig_post['allow_gid'];
 		$str_contact_allow = $orig_post['allow_cid'];


### PR DESCRIPTION
This will help with a potential usage issue with PR https://github.com/friendica/friendica/pull/7728. Possibly people could forget to enter a link description. In this case we will silently replace the URL into the format without an explicit description.