### PR TITLE
updated sample lighttpd config regarding the pagename parameter

### DIFF
--- a/mods/sample-Lighttpd.config
+++ b/mods/sample-Lighttpd.config
@@ -102,8 +102,8 @@ $HTTP["scheme"] == "https" {
         # Got the following 'Drupal Clean URL'after Mike suggested trying
         # something along those lines, from http://drupal.org/node/1414950
         url.rewrite-if-not-file = (
-            "^\/([^\?]*)\?(.*)$" => "/index.php?q=$1&$2",
-            "^\/(.*)$" => "/index.php?q=$1"
+            "^\/([^\?]*)\?(.*)$" => "/index.php?pagename=$1&$2",
+            "^\/(.*)$" => "/index.php?pagename=$1"
         )
     }
     else $HTTP["host"] !~ "(friendica.example.com|wordpress.example.com)" {


### PR DESCRIPTION
Some time ago the `q` parameter of the URLs got renamed to `pagename` but the lighttpd sample config file was never updated. This is now done.