### PR TITLE
Move Core\NotificationsManager to Model\Notify

### DIFF
--- a/include/api.php
+++ b/include/api.php
@@ -7,6 +7,7 @@
  */
 
 use Friendica\App;
+use Friendica\BaseObject;
 use Friendica\Content\ContactSelector;
 use Friendica\Content\Feature;
 use Friendica\Content\Text\BBCode;
@@ -1375,7 +1376,7 @@ function api_get_item(array $condition)
  */
 function api_users_show($type)
 {
-	$a = \Friendica\BaseObject::getApp();
+	$a = BaseObject::getApp();
 
 	$user_info = api_get_user($a);
 
@@ -2948,7 +2949,7 @@ function api_format_items_profiles($profile_row)
  */
 function api_format_items($items, $user_info, $filter_user = false, $type = "json")
 {
-	$a = \Friendica\BaseObject::getApp();
+	$a = BaseObject::getApp();
 
 	$ret = [];
 
@@ -2982,7 +2983,7 @@ function api_format_items($items, $user_info, $filter_user = false, $type = "jso
  */
 function api_format_item($item, $type = "json", $status_user = null, $author_user = null, $owner_user = null)
 {
-	$a = \Friendica\BaseObject::getApp();
+	$a = BaseObject::getApp();
 
 	if (empty($status_user) || empty($author_user) || empty($owner_user)) {
 		list($status_user, $author_user, $owner_user) = api_item_get_user($a, $item);
@@ -6040,7 +6041,8 @@ function api_friendica_notification($type)
 	if ($a->argc!==3) {
 		throw new BadRequestException("Invalid argument count");
 	}
-	$nm = new Notify();
+	/** @var Notify $nm */
+	$nm = BaseObject::getClass(Notify::class);
 
 	$notes = $nm->getAll([], ['seen' => 'ASC', 'date' => 'DESC'], 50);
 
@@ -6084,7 +6086,8 @@ function api_friendica_notification_seen($type)
 
 	$id = (!empty($_REQUEST['id']) ? intval($_REQUEST['id']) : 0);
 
-	$nm = new Notify();
+	/** @var Notify $nm */
+	$nm = BaseObject::getClass(Notify::class);
 	$note = $nm->getByID($id);
 	if (is_null($note)) {
 		throw new BadRequestException("Invalid argument");

--- a/include/api.php
+++ b/include/api.php
@@ -15,7 +15,6 @@ use Friendica\Core\Config;
 use Friendica\Core\Hook;
 use Friendica\Core\L10n;
 use Friendica\Core\Logger;
-use Friendica\Core\NotificationsManager;
 use Friendica\Core\PConfig;
 use Friendica\Core\Protocol;
 use Friendica\Core\Session;
@@ -26,6 +25,7 @@ use Friendica\Model\Contact;
 use Friendica\Model\Group;
 use Friendica\Model\Item;
 use Friendica\Model\Mail;
+use Friendica\Model\Notify;
 use Friendica\Model\Photo;
 use Friendica\Model\Profile;
 use Friendica\Model\User;
@@ -6040,7 +6040,7 @@ function api_friendica_notification($type)
 	if ($a->argc!==3) {
 		throw new BadRequestException("Invalid argument count");
 	}
-	$nm = new NotificationsManager();
+	$nm = new Notify();
 
 	$notes = $nm->getAll([], ['seen' => 'ASC', 'date' => 'DESC'], 50);
 
@@ -6084,7 +6084,7 @@ function api_friendica_notification_seen($type)
 
 	$id = (!empty($_REQUEST['id']) ? intval($_REQUEST['id']) : 0);
 
-	$nm = new NotificationsManager();
+	$nm = new Notify();
 	$note = $nm->getByID($id);
 	if (is_null($note)) {
 		throw new BadRequestException("Invalid argument");

--- a/mod/notifications.php
+++ b/mod/notifications.php
@@ -78,7 +78,7 @@ function notifications_content(App $a)
 	}
 
 	$page = ($_REQUEST['page'] ?? 0) ?: 1;
-	$show =  ($_REQUEST['show'] ?? '' === 'all');
+	$show =  isset($_REQUEST['show']) ? $_REQUEST['show'] : false;
 
 	Nav::setSelected('notifications');
 

--- a/mod/notifications.php
+++ b/mod/notifications.php
@@ -78,7 +78,7 @@ function notifications_content(App $a)
 	}
 
 	$page = ($_REQUEST['page'] ?? 0) ?: 1;
-	$show =  isset($_REQUEST['show']) ? $_REQUEST['show'] : false;
+	$show = ($_REQUEST['show'] ?? '') === 'all';
 
 	Nav::setSelected('notifications');
 

--- a/mod/notifications.php
+++ b/mod/notifications.php
@@ -84,7 +84,8 @@ function notifications_content(App $a)
 
 	$json = (($a->argc > 1 && $a->argv[$a->argc - 1] === 'json') ? true : false);
 
-	$nm = new Notify();
+	/** @var Notify $nm */
+	$nm = \Friendica\BaseObject::getClass(Notify::class);
 
 	$o = '';
 	// Get the nav tabs for the notification pages
@@ -111,27 +112,27 @@ function notifications_content(App $a)
 
 		$all = (($a->argc > 2) && ($a->argv[2] == 'all'));
 
-		$notifs = $nm->introNotifs($all, $startrec, $perpage, $id);
+		$notifs = $nm->getIntroNotifies($all, $startrec, $perpage, $id);
 
 	// Get the network notifications
 	} elseif (($a->argc > 1) && ($a->argv[1] == 'network')) {
 		$notif_header = L10n::t('Network Notifications');
-		$notifs = $nm->networkNotifs($show, $startrec, $perpage);
+		$notifs = $nm->getNetworkNotifies($show, $startrec, $perpage);
 
 	// Get the system notifications
 	} elseif (($a->argc > 1) && ($a->argv[1] == 'system')) {
 		$notif_header = L10n::t('System Notifications');
-		$notifs = $nm->systemNotifs($show, $startrec, $perpage);
+		$notifs = $nm->getSystemNotifies($show, $startrec, $perpage);
 
 	// Get the personal notifications
 	} elseif (($a->argc > 1) && ($a->argv[1] == 'personal')) {
 		$notif_header = L10n::t('Personal Notifications');
-		$notifs = $nm->personalNotifs($show, $startrec, $perpage);
+		$notifs = $nm->getPersonalNotifies($show, $startrec, $perpage);
 
 	// Get the home notifications
 	} elseif (($a->argc > 1) && ($a->argv[1] == 'home')) {
 		$notif_header = L10n::t('Home Notifications');
-		$notifs = $nm->homeNotifs($show, $startrec, $perpage);
+		$notifs = $nm->getHomeNotifies($show, $startrec, $perpage);
 	// fallback - redirect to main page
 	} else {
 		$a->internalRedirect('notifications');

--- a/mod/notifications.php
+++ b/mod/notifications.php
@@ -9,14 +9,13 @@ use Friendica\Content\ContactSelector;
 use Friendica\Content\Nav;
 use Friendica\Content\Pager;
 use Friendica\Core\L10n;
-use Friendica\Core\NotificationsManager;
 use Friendica\Core\Protocol;
 use Friendica\Core\Renderer;
-use Friendica\Core\Logger;
 use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\Module\Login;
 use Friendica\Model\Contact;
+use Friendica\Model\Notify;
 
 function notifications_post(App $a)
 {
@@ -85,7 +84,7 @@ function notifications_content(App $a)
 
 	$json = (($a->argc > 1 && $a->argv[$a->argc - 1] === 'json') ? true : false);
 
-	$nm = new NotificationsManager();
+	$nm = new Notify();
 
 	$o = '';
 	// Get the nav tabs for the notification pages

--- a/mod/notifications.php
+++ b/mod/notifications.php
@@ -78,7 +78,7 @@ function notifications_content(App $a)
 	}
 
 	$page = ($_REQUEST['page'] ?? 0) ?: 1;
-	$show =  $_REQUEST['show'] ?? 0;
+	$show =  ($_REQUEST['show'] ?? '' === 'all');
 
 	Nav::setSelected('notifications');
 

--- a/mod/notifications.php
+++ b/mod/notifications.php
@@ -112,27 +112,27 @@ function notifications_content(App $a)
 
 		$all = (($a->argc > 2) && ($a->argv[2] == 'all'));
 
-		$notifs = $nm->getIntroNotifies($all, $startrec, $perpage, $id);
+		$notifs = $nm->getIntroList($all, $startrec, $perpage, $id);
 
 	// Get the network notifications
 	} elseif (($a->argc > 1) && ($a->argv[1] == 'network')) {
 		$notif_header = L10n::t('Network Notifications');
-		$notifs = $nm->getNetworkNotifies($show, $startrec, $perpage);
+		$notifs = $nm->getNetworkList($show, $startrec, $perpage);
 
 	// Get the system notifications
 	} elseif (($a->argc > 1) && ($a->argv[1] == 'system')) {
 		$notif_header = L10n::t('System Notifications');
-		$notifs = $nm->getSystemNotifies($show, $startrec, $perpage);
+		$notifs = $nm->getSystemList($show, $startrec, $perpage);
 
 	// Get the personal notifications
 	} elseif (($a->argc > 1) && ($a->argv[1] == 'personal')) {
 		$notif_header = L10n::t('Personal Notifications');
-		$notifs = $nm->getPersonalNotifies($show, $startrec, $perpage);
+		$notifs = $nm->getPersonalList($show, $startrec, $perpage);
 
 	// Get the home notifications
 	} elseif (($a->argc > 1) && ($a->argv[1] == 'home')) {
 		$notif_header = L10n::t('Home Notifications');
-		$notifs = $nm->getHomeNotifies($show, $startrec, $perpage);
+		$notifs = $nm->getHomeList($show, $startrec, $perpage);
 	// fallback - redirect to main page
 	} else {
 		$a->internalRedirect('notifications');

--- a/src/Model/Notify.php
+++ b/src/Model/Notify.php
@@ -4,14 +4,12 @@
  * @brief Methods for read and write notifications from/to database
  *  or for formatting notifications
  */
-namespace Friendica\Core;
+namespace Friendica\Model;
 
 use Friendica\BaseObject;
 use Friendica\Content\Text\BBCode;
 use Friendica\Content\Text\HTML;
 use Friendica\Database\DBA;
-use Friendica\Model\Contact;
-use Friendica\Model\Item;
 use Friendica\Protocol\Activity;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Proxy as ProxyUtils;
@@ -22,7 +20,7 @@ use Friendica\Util\XML;
  * @brief Methods for read and write notifications from/to database
  *  or for formatting notifications
  */
-class NotificationsManager extends BaseObject
+final class Notify extends BaseObject
 {
 	/**
 	 * @brief set some extra note properties

--- a/src/Model/Notify.php
+++ b/src/Model/Notify.php
@@ -238,7 +238,7 @@ final class Notify extends BaseObject
 	 *                       bool 'seen' => Is the notification marked as "seen"
 	 * @throws Exception
 	 */
-	private function formatNotifies(array $notifies, string $ident = "")
+	private function formatList(array $notifies, string $ident = "")
 	{
 		$formattedNotifies = [];
 
@@ -422,7 +422,7 @@ final class Notify extends BaseObject
 	 *
 	 * @throws Exception
 	 */
-	public function getNetworkNotifies(bool $seen = false, int $start = 0, int $limit = self::DEFAULT_PAGE_LIMIT)
+	public function getNetworkList(bool $seen = false, int $start = 0, int $limit = self::DEFAULT_PAGE_LIMIT)
 	{
 		$ident    = self::NETWORK;
 		$notifies = [];
@@ -440,7 +440,7 @@ final class Notify extends BaseObject
 		$items = Item::selectForUser(local_user(), $fields, $condition, $params);
 
 		if ($this->dba->isResult($items)) {
-			$notifies = $this->formatNotifies(Item::inArray($items), $ident);
+			$notifies = $this->formatList(Item::inArray($items), $ident);
 		}
 
 		$arr = [
@@ -465,7 +465,7 @@ final class Notify extends BaseObject
 	 *
 	 * @throws Exception
 	 */
-	public function getSystemNotifies(bool $seen = false, int $start = 0, int $limit = self::DEFAULT_PAGE_LIMIT)
+	public function getSystemList(bool $seen = false, int $start = 0, int $limit = self::DEFAULT_PAGE_LIMIT)
 	{
 		$ident    = self::SYSTEM;
 		$notifies = [];
@@ -485,7 +485,7 @@ final class Notify extends BaseObject
 			$params);
 
 		if ($this->dba->isResult($stmtNotifies)) {
-			$notifies = $this->formatNotifies($this->dba->toArray($stmtNotifies), $ident);
+			$notifies = $this->formatList($this->dba->toArray($stmtNotifies), $ident);
 		}
 
 		$arr = [
@@ -510,7 +510,7 @@ final class Notify extends BaseObject
 	 *
 	 * @throws Exception
 	 */
-	public function getPersonalNotifies(bool $seen = false, int $start = 0, int $limit = self::DEFAULT_PAGE_LIMIT)
+	public function getPersonalList(bool $seen = false, int $start = 0, int $limit = self::DEFAULT_PAGE_LIMIT)
 	{
 		$ident    = self::PERSONAL;
 		$notifies = [];
@@ -532,7 +532,7 @@ final class Notify extends BaseObject
 		$items = Item::selectForUser(local_user(), $fields, $condition, $params);
 
 		if ($this->dba->isResult($items)) {
-			$notifies = $this->formatNotifies(Item::inArray($items), $ident);
+			$notifies = $this->formatList(Item::inArray($items), $ident);
 		}
 
 		$arr = [
@@ -557,7 +557,7 @@ final class Notify extends BaseObject
 	 *
 	 * @throws Exception
 	 */
-	public function getHomeNotifies(bool $seen = false, int $start = 0, int $limit = self::DEFAULT_PAGE_LIMIT)
+	public function getHomeList(bool $seen = false, int $start = 0, int $limit = self::DEFAULT_PAGE_LIMIT)
 	{
 		$ident    = self::HOME;
 		$notifies = [];
@@ -575,7 +575,7 @@ final class Notify extends BaseObject
 		$items = Item::selectForUser(local_user(), $fields, $condition, $params);
 
 		if ($this->dba->isResult($items)) {
-			$notifies = $this->formatNotifies(Item::inArray($items), $ident);
+			$notifies = $this->formatList(Item::inArray($items), $ident);
 		}
 
 		$arr = [
@@ -602,7 +602,7 @@ final class Notify extends BaseObject
 	 * @throws ImagickException
 	 * @throws Exception
 	 */
-	public function getIntroNotifies(bool $all = false, int $start = 0, int $limit = self::DEFAULT_PAGE_LIMIT, int $id = 0)
+	public function getIntroList(bool $all = false, int $start = 0, int $limit = self::DEFAULT_PAGE_LIMIT, int $id = 0)
 	{
 		/// @todo sanitize wording according to SELF::INTRO
 		$ident     = 'introductions';
@@ -638,7 +638,7 @@ final class Notify extends BaseObject
 			$limit
 		);
 		if ($this->dba->isResult($stmtNotifies)) {
-			$notifies = $this->formatIntros($this->dba->toArray($stmtNotifies));
+			$notifies = $this->formatIntroList($this->dba->toArray($stmtNotifies));
 		}
 
 		$arr = [
@@ -658,7 +658,7 @@ final class Notify extends BaseObject
 	 * @throws HTTPException\InternalServerErrorException
 	 * @throws ImagickException
 	 */
-	private function formatIntros(array $intros)
+	private function formatIntroList(array $intros)
 	{
 		$knowyou = '';
 

--- a/src/Module/Notifications/Notify.php
+++ b/src/Module/Notifications/Notify.php
@@ -3,6 +3,7 @@
 namespace Friendica\Module\Notifications;
 
 use Friendica\BaseModule;
+use Friendica\BaseObject;
 use Friendica\Core\L10n;
 use Friendica\Core\System;
 use Friendica\Model\Notify as ModelNotify;
@@ -26,7 +27,8 @@ class Notify extends BaseModule
 
 		// @TODO: Replace with parameter from router
 		if ($a->argc > 2 && $a->argv[1] === 'mark' && $a->argv[2] === 'all') {
-			$notificationsManager = new ModelNotify();
+			/** @var ModelNotify $notificationsManager */
+			$notificationsManager = self::getClass(ModelNotify::class);
 			$success              = $notificationsManager->setAllSeen();
 
 			header('Content-type: application/json; charset=utf-8');
@@ -49,7 +51,8 @@ class Notify extends BaseModule
 
 		// @TODO: Replace with parameter from router
 		if ($a->argc > 2 && $a->argv[1] === 'view' && intval($a->argv[2])) {
-			$notificationsManager = new ModelNotify();
+			/** @var ModelNotify $notificationsManager */
+			$notificationsManager = BaseObject::getClass(ModelNotify::class);
 			// @TODO: Replace with parameter from router
 			$note = $notificationsManager->getByID($a->argv[2]);
 			if (!empty($note)) {

--- a/src/Module/Notifications/Notify.php
+++ b/src/Module/Notifications/Notify.php
@@ -4,8 +4,8 @@ namespace Friendica\Module\Notifications;
 
 use Friendica\BaseModule;
 use Friendica\Core\L10n;
-use Friendica\Core\NotificationsManager;
 use Friendica\Core\System;
+use Friendica\Model\Notify as ModelNotify;
 use Friendica\Network\HTTPException;
 
 /**
@@ -26,7 +26,7 @@ class Notify extends BaseModule
 
 		// @TODO: Replace with parameter from router
 		if ($a->argc > 2 && $a->argv[1] === 'mark' && $a->argv[2] === 'all') {
-			$notificationsManager = new NotificationsManager();
+			$notificationsManager = new ModelNotify();
 			$success              = $notificationsManager->setAllSeen();
 
 			header('Content-type: application/json; charset=utf-8');
@@ -49,7 +49,7 @@ class Notify extends BaseModule
 
 		// @TODO: Replace with parameter from router
 		if ($a->argc > 2 && $a->argv[1] === 'view' && intval($a->argv[2])) {
-			$notificationsManager = new NotificationsManager();
+			$notificationsManager = new ModelNotify();
 			// @TODO: Replace with parameter from router
 			$note = $notificationsManager->getByID($a->argv[2]);
 			if (!empty($note)) {


### PR DESCRIPTION
Prerequisite to move `include/enotify.php` to a `Core\Notify.php` class (some cleanup before).

Because almost every method in `NotificationsManager` is an interaction with the database table `notify`, I moved the whole class to the `Friendica\Model` namespace.

=> Tested a lot of possible combinations on my local environment