### PR TITLE
(hopefully) fix preview issue with tags on Mastodon

### DIFF
--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -1746,7 +1746,7 @@ class BBCode extends BaseObject
 		 * - [url=<anything>]#<term>[/url]
 		 */
 		$text = preg_replace_callback("/(?:#\[url\=.*?\]|\[url\=.*?\]#)(.*?)\[\/url\]/ism", function($matches) {
-				return '#<a href="'
+			return '#<a href="'
 				. System::baseUrl()	. '/search?tag=' . rawurlencode($matches[1])
 				. '" class="tag" rel="tag" title="' . XML::escape($matches[1]) . '">'
 				. XML::escape($matches[1])

--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -1746,9 +1746,9 @@ class BBCode extends BaseObject
 		 * - [url=<anything>]#<term>[/url]
 		 */
 		$text = preg_replace_callback("/(?:#\[url\=.*?\]|\[url\=.*?\]#)(.*?)\[\/url\]/ism", function($matches) {
-			return '#<a href="'
+				return '#<a href="'
 				. System::baseUrl()	. '/search?tag=' . rawurlencode($matches[1])
-				. '" class="tag" title="' . XML::escape($matches[1]) . '">'
+				. '" class="tag" rel="tag" title="' . XML::escape($matches[1]) . '">'
 				. XML::escape($matches[1])
 				. '</a>';
 		}, $text);

--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -573,17 +573,17 @@ class BBCode extends BaseObject
 	 * Note: Can produce a [bookmark] tag in the returned string
 	 *
 	 * @brief Processes [attachment] tags
-	 * @param string   $return
+	 * @param string   $text
 	 * @param bool|int $simplehtml
 	 * @param bool     $tryoembed
 	 * @return string
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
-	private static function convertAttachment($return, $simplehtml = false, $tryoembed = true)
+	private static function convertAttachment($text, $simplehtml = false, $tryoembed = true)
 	{
-		$data = self::getAttachmentData($return);
+		$data = self::getAttachmentData($text);
 		if (empty($data) || empty($data['url'])) {
-			return $return;
+			return $text;
 		}
 
 		if (isset($data['title'])) {
@@ -600,7 +600,10 @@ class BBCode extends BaseObject
 
 		$return = '';
 		if (in_array($simplehtml, [7, 9])) {
-			$return = self::convertUrlForActivityPub($data['url']);
+			// Only add the link when it isn't already part of the body
+			if (substr_count($text, $data['url']) == 1) {
+				$return = self::convertUrlForActivityPub($data['url']);
+			}
 		} elseif (($simplehtml != 4) && ($simplehtml != 0)) {
 			$return = sprintf('<a href="%s" target="_blank">%s</a><br>', $data['url'], $data['title']);
 		} else {


### PR DESCRIPTION
I hope that now hashtags to Mastodon won't generate a preview anymore.

If possibly handles issue https://github.com/friendica/friendica/issues/7772 as well.