### PR TITLE
Fix travis - Remove APCu setting for PHP 7.2/7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,6 @@ before_script:
  - mysql -utravis test < database.sql
  - pecl channel-update pecl.php.net
  - pecl config-set preferred_state beta
- - if [[ $TRAVIS_PHP_VERSION != "7.1" ]]; then echo yes | pecl upgrade apcu; fi
- - if [[ $TRAVIS_PHP_VERSION != "7.1" ]]; then phpenv config-add .travis/apcu.ini; fi
  - phpenv config-add .travis/redis.ini
  - phpenv config-add .travis/memcached.ini
 


### PR DESCRIPTION
Should fix
```console
1) Friendica\Test\ApiTest::testApiLoginWithoutLogin

PHPUnit_Framework_Exception: PHP Warning:  Module 'apcu' already loaded in Unknown on line 0
```