### PR TITLE
Fix 7778: Don't return empty string in permissions

### DIFF
--- a/src/Util/ACLFormatter.php
+++ b/src/Util/ACLFormatter.php
@@ -36,7 +36,7 @@ final class ACLFormatter
 		} elseif (in_array($item, [Group::FOLLOWERS, Group::MUTUALS])) {
 			$item = '<' . $item . '>';
 		} else {
-			$item = '';
+			unset($item);
 		}
 	}
 


### PR DESCRIPTION
This fixes #7778 
caused by #7765

This partly restores the previous functionality.