### PR TITLE
Add missing quotation

### DIFF
--- a/mod/settings.php
+++ b/mod/settings.php
@@ -1253,7 +1253,7 @@ function settings_content(App $a)
 		'$importcontact' => L10n::t('Import Contacts'),
 		'$importcontact_text' => L10n::t('Upload a CSV file that contains the handle of your followed accounts in the first column you exported from the old account.'),
 		'$importcontact_button' => L10n::t('Upload File'),
-		'$importcontact_maxsize' => Config::get('system', max_csv_file_size, 30720), 
+		'$importcontact_maxsize' => Config::get('system', 'max_csv_file_size', 30720), 
 		'$relocate' => L10n::t('Relocate'),
 		'$relocate_text' => L10n::t("If you have moved this profile from another server, and some of your contacts don't receive your updates, try pushing this button."),
 		'$relocate_button' => L10n::t("Resend relocate message to contacts"),


### PR DESCRIPTION
Followup for #7806 that hopefully solves https://github.com/friendica/friendica/issues/7676#issuecomment-549179179 by adding missing quotation marks around the config variable name.