### PR TITLE
add missing template for userexport

### DIFF
--- a/view/templates/settings/userexport.tpl
+++ b/view/templates/settings/userexport.tpl
@@ -1,0 +1,10 @@
+
+<h3>{{$title}}</h3>
+
+
+{{foreach $options as $o}}
+<dl>
+    <dt><a href="{{$o.0}}">{{$o.1}}</a></dt>
+    <dd>{{$o.2}}</dd>
+</dl>
+{{/foreach}}

--- a/view/theme/frio/templates/settings/userexport.tpl
+++ b/view/theme/frio/templates/settings/userexport.tpl
@@ -1,0 +1,12 @@
+
+<div class="generic-page-wrapper">
+	{{* include the title template for the settings title *}}
+	{{include file="section_title.tpl" title=$title}}
+
+	{{foreach $options as $o}}
+	<dl>
+		<dt><a href="{{$o.0}}">{{$o.1}}</a></dt>
+		<dd>{{$o.2}}</dd>
+	</dl>
+	{{/foreach}}
+</div>


### PR DESCRIPTION
During the rename of the `uexport.tpl` file to `userexport.tpl` git lost track of it. This PR puts it back into place. Additionally the frio theme was missing the template, it is created now.

Followup for #7806 
