### PR TITLE
Pass the parameters from the router to the modules

### DIFF
--- a/src/App/Router.php
+++ b/src/App/Router.php
@@ -40,6 +40,11 @@ class Router
 	private $httpMethod;
 
 	/**
+	 * @var array Module parameters
+	 */
+	private $parameters = [];
+
+	/**
 	 * @param array $server The $_SERVER variable
 	 * @param RouteCollector|null $routeCollector Optional the loaded Route collector
 	 */
@@ -172,10 +177,12 @@ class Router
 		$dispatcher = new \FastRoute\Dispatcher\GroupCountBased($this->routeCollector->getData());
 
 		$moduleClass = null;
+		$this->parameters = [];
 
 		$routeInfo  = $dispatcher->dispatch($this->httpMethod, $cmd);
 		if ($routeInfo[0] === Dispatcher::FOUND) {
 			$moduleClass = $routeInfo[1];
+			$this->parameters = $routeInfo[2];
 		} elseif ($routeInfo[0] === Dispatcher::METHOD_NOT_ALLOWED) {
 			throw new HTTPException\MethodNotAllowedException(L10n::t('Method not allowed for this module. Allowed method(s): %s', implode(', ', $routeInfo[1])));
 		} else {
@@ -183,5 +190,15 @@ class Router
 		}
 
 		return $moduleClass;
+	}
+
+	/**
+	 * Returns the module parameters.
+	 *
+	 * @return array parameters
+	 */
+	public function getModuleParameters()
+	{
+		return $this->parameters;
 	}
 }

--- a/tests/src/App/ModeTest.php
+++ b/tests/src/App/ModeTest.php
@@ -200,7 +200,7 @@ class ModeTest extends MockedTest
 	public function testIsBackendButIndex()
 	{
 		$server = [];
-		$module = new Module(Module::DEFAULT, Module::DEFAULT_CLASS, true);
+		$module = new Module(Module::DEFAULT, Module::DEFAULT_CLASS, [], true);
 		$mobileDetect = new MobileDetect();
 
 		$mode = (new Mode())->determineRunMode(false, $module, $server, $mobileDetect);
@@ -214,7 +214,7 @@ class ModeTest extends MockedTest
 	public function testIsNotBackend()
 	{
 		$server = [];
-		$module = new Module(Module::DEFAULT, Module::DEFAULT_CLASS, false);
+		$module = new Module(Module::DEFAULT, Module::DEFAULT_CLASS, [], false);
 		$mobileDetect = new MobileDetect();
 
 		$mode = (new Mode())->determineRunMode(false, $module, $server, $mobileDetect);
@@ -232,7 +232,7 @@ class ModeTest extends MockedTest
 			'HTTP_X_REQUESTED_WITH' => 'xmlhttprequest',
 		];
 
-		$module = new Module(Module::DEFAULT, Module::DEFAULT_CLASS, false);
+		$module = new Module(Module::DEFAULT, Module::DEFAULT_CLASS, [], false);
 		$mobileDetect = new MobileDetect();
 
 		$mode = (new Mode())->determineRunMode(true, $module, $server, $mobileDetect);
@@ -246,7 +246,7 @@ class ModeTest extends MockedTest
 	public function testIsNotAjax()
 	{
 		$server = [];
-		$module = new Module(Module::DEFAULT, Module::DEFAULT_CLASS, false);
+		$module = new Module(Module::DEFAULT, Module::DEFAULT_CLASS, [], false);
 		$mobileDetect = new MobileDetect();
 
 		$mode = (new Mode())->determineRunMode(true, $module, $server, $mobileDetect);
@@ -260,7 +260,7 @@ class ModeTest extends MockedTest
 	public function testIsMobileIsTablet()
 	{
 		$server = [];
-		$module = new Module(Module::DEFAULT, Module::DEFAULT_CLASS, false);
+		$module = new Module(Module::DEFAULT, Module::DEFAULT_CLASS, [], false);
 		$mobileDetect = \Mockery::mock(MobileDetect::class);
 		$mobileDetect->shouldReceive('isMobile')->andReturn(true);
 		$mobileDetect->shouldReceive('isTablet')->andReturn(true);
@@ -278,7 +278,7 @@ class ModeTest extends MockedTest
 	public function testIsNotMobileIsNotTablet()
 	{
 		$server = [];
-		$module = new Module(Module::DEFAULT, Module::DEFAULT_CLASS, false);
+		$module = new Module(Module::DEFAULT, Module::DEFAULT_CLASS, [], false);
 		$mobileDetect = \Mockery::mock(MobileDetect::class);
 		$mobileDetect->shouldReceive('isMobile')->andReturn(false);
 		$mobileDetect->shouldReceive('isTablet')->andReturn(false);


### PR DESCRIPTION
While working at the "pinned" functionality, I realized that currently we don't have a possibility to use the parameters that we define in the router configuration.

Now we have.