### PR TITLE
Pass Router parameters to module content method

### DIFF
--- a/src/App/Module.php
+++ b/src/App/Module.php
@@ -95,6 +95,14 @@ class Module
 	}
 
 	/**
+	 * @return array The module parameters extracted from the route
+	 */
+	public function getParameters()
+	{
+		return $this->module_parameters;
+	}
+
+	/**
 	 * @return bool True, if the current module is a backend module
 	 * @see Module::BACKEND_MODULES for a list
 	 */

--- a/src/App/Page.php
+++ b/src/App/Page.php
@@ -308,7 +308,7 @@ class Page implements ArrayAccess
 			$arr = ['content' => $content];
 			Hook::callAll($moduleClass . '_mod_content', $arr);
 			$content = $arr['content'];
-			$arr     = ['content' => call_user_func([$moduleClass, 'content'], [])];
+			$arr     = ['content' => call_user_func([$moduleClass, 'content'], $module->getParameters())];
 			Hook::callAll($moduleClass . '_mod_aftercontent', $arr);
 			$content .= $arr['content'];
 		} catch (HTTPException $e) {

--- a/static/dependencies.config.php
+++ b/static/dependencies.config.php
@@ -171,7 +171,7 @@ return [
 			$_SERVER, null
 		],
 		'call' => [
-			['addRoutes', [include __DIR__ . '/routes.config.php'], Dice::CHAIN_CALL],
+			['loadRoutes', [include __DIR__ . '/routes.config.php'], Dice::CHAIN_CALL],
 		],
 	],
 	L10n::class => [

--- a/tests/src/App/ModuleTest.php
+++ b/tests/src/App/ModuleTest.php
@@ -152,7 +152,7 @@ class ModuleTest extends DatabaseTest
 		$config = \Mockery::mock(Configuration::class);
 		$config->shouldReceive('get')->with('config', 'private_addons', false)->andReturn($privAdd)->atMost()->once();
 
-		$router = (new App\Router([]))->addRoutes(include __DIR__ . '/../../../static/routes.config.php');
+		$router = (new App\Router([]))->loadRoutes(include __DIR__ . '/../../../static/routes.config.php');
 
 		$module = (new App\Module($name))->determineClass(new App\Arguments('', $command), $router, $config);
 

--- a/tests/src/App/RouterTest.php
+++ b/tests/src/App/RouterTest.php
@@ -159,7 +159,7 @@ class RouterTest extends TestCase
 	{
 		$router = (new Router([
 			'REQUEST_METHOD' => Router::GET
-		]))->addRoutes($routes);
+		]))->loadRoutes($routes);
 
 		$this->assertEquals(Module\Home::class, $router->getModuleClass('/'));
 		$this->assertEquals(Module\Friendica::class, $router->getModuleClass('/group/route'));
@@ -174,7 +174,7 @@ class RouterTest extends TestCase
 	{
 		$router = (new Router([
 			'REQUEST_METHOD' => Router::POST
-		]))->addRoutes($routes);
+		]))->loadRoutes($routes);
 
 		// Don't find GET
 		$this->assertEquals(Module\NodeInfo::class, $router->getModuleClass('/post/it'));


### PR DESCRIPTION
Follow-up to #7818 and #7819, the parameters weren't actually passed to the `content` method of modules.

Additionally, I've removed duplicate content in the Router class itself.