### PR TITLE
Remove unnecessary code in "include/enotify"

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -793,7 +793,6 @@ CREATE TABLE IF NOT EXISTS `manage` (
 --
 CREATE TABLE IF NOT EXISTS `notify` (
 	`id` int unsigned NOT NULL auto_increment COMMENT 'sequential ID',
-	`hash` varchar(64) NOT NULL DEFAULT '' COMMENT '',
 	`type` smallint unsigned NOT NULL DEFAULT 0 COMMENT '',
 	`name` varchar(255) NOT NULL DEFAULT '' COMMENT '',
 	`url` varchar(255) NOT NULL DEFAULT '' COMMENT '',
@@ -810,7 +809,6 @@ CREATE TABLE IF NOT EXISTS `notify` (
 	`name_cache` tinytext COMMENT 'Cached bbcode parsing of name',
 	`msg_cache` mediumtext COMMENT 'Cached bbcode parsing of msg',
 	 PRIMARY KEY(`id`),
-	 INDEX `hash_uid` (`hash`,`uid`),
 	 INDEX `seen_uid_date` (`seen`,`uid`,`date`),
 	 INDEX `uid_date` (`uid`,`date`),
 	 INDEX `uid_type_link` (`uid`,`type`,`link`(190))

--- a/include/enotify.php
+++ b/include/enotify.php
@@ -537,26 +537,6 @@ function notification($params)
 
 		$notify_id = DBA::lastInsertId();
 
-		// we seem to have a lot of duplicate comment notifications due to race conditions, mostly from forums
-		// After we've stored everything, look again to see if there are any duplicates and if so remove them
-		$p = q("SELECT `id` FROM `notify` WHERE `type` IN (%d, %d) AND `link` = '%s' AND `uid` = %d ORDER BY `id`",
-			intval(NOTIFY_TAGSELF),
-			intval(NOTIFY_COMMENT),
-			DBA::escape($params['link']),
-			intval($params['uid'])
-		);
-		if ($p && (count($p) > 1)) {
-			for ($d = 1; $d < count($p); $d ++) {
-				DBA::delete('notify', ['id' => $p[$d]['id']]);
-			}
-
-			// only continue on if we stored the first one
-			if ($notify_id != $p[0]['id']) {
-				L10n::popLang();
-				return false;
-			}
-		}
-
 		$itemlink = System::baseUrl().'/notify/view/'.$notify_id;
 		$msg = Renderer::replaceMacros($epreamble, ['$itemlink' => $itemlink]);
 		$msg_cache = format_notification_message($datarray['name_cache'], strip_tags(BBCode::convert($msg)));

--- a/include/enotify.php
+++ b/include/enotify.php
@@ -503,17 +503,9 @@ function notification($params)
 
 	if ($show_in_notification_page) {
 		Logger::log("adding notification entry", Logger::DEBUG);
-		do {
-			$dups = false;
-			$hash = Strings::getRandomHex();
-			if (DBA::exists('notify', ['hash' => $hash])) {
-				$dups = true;
-			}
-		} while ($dups == true);
 
 		/// @TODO One statement is enough
 		$datarray = [];
-		$datarray['hash']  = $hash;
 		$datarray['name']  = $params['source_name'];
 		$datarray['name_cache'] = strip_tags(BBCode::convert($params['source_name']));
 		$datarray['url']   = $params['source_link'];
@@ -536,7 +528,7 @@ function notification($params)
 		}
 
 		// create notification entry in DB
-		$fields = ['hash' => $datarray['hash'], 'name' => $datarray['name'], 'url' => $datarray['url'],
+		$fields = ['name' => $datarray['name'], 'url' => $datarray['url'],
 			'photo' => $datarray['photo'], 'date' => $datarray['date'], 'uid' => $datarray['uid'],
 			'link' => $datarray['link'], 'iid' => $datarray['iid'], 'parent' => $datarray['parent'],
 			'type' => $datarray['type'], 'verb' => $datarray['verb'], 'otype' => $datarray['otype'],

--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -34,7 +34,7 @@
 use Friendica\Database\DBA;
 
 if (!defined('DB_UPDATE_VERSION')) {
-	define('DB_UPDATE_VERSION', 1323);
+	define('DB_UPDATE_VERSION', 1324);
 }
 
 return [
@@ -868,7 +868,6 @@ return [
 		"comment" => "notifications",
 		"fields" => [
 			"id" => ["type" => "int unsigned", "not null" => "1", "extra" => "auto_increment", "primary" => "1", "comment" => "sequential ID"],
-			"hash" => ["type" => "varchar(64)", "not null" => "1", "default" => "", "comment" => ""],
 			"type" => ["type" => "smallint unsigned", "not null" => "1", "default" => "0", "comment" => ""],
 			"name" => ["type" => "varchar(255)", "not null" => "1", "default" => "", "comment" => ""],
 			"url" => ["type" => "varchar(255)", "not null" => "1", "default" => "", "comment" => ""],
@@ -887,7 +886,6 @@ return [
 		],
 		"indexes" => [
 			"PRIMARY" => ["id"],
-			"hash_uid" => ["hash", "uid"],
 			"seen_uid_date" => ["seen", "uid", "date"],
 			"uid_date" => ["uid", "date"],
 			"uid_type_link" => ["uid", "type", "link(190)"],


### PR DESCRIPTION
Removed the hash field of enotify
- Was introduced for getting the last inserted ID before "lastInstertID()" was possible
- See https://github.com/duthied/Free-Friendika/commit/b821399f001cd4082707ba9fb6df9c419e0b8e5e#diff-a8e86a3c07531e66a3b0b4c8b4b07879R148
- The hash isn't used after storing it (as far as I could see, it's because it's usage was replaced by https://github.com/friendica/friendica/commit/7f3fb34c24e30b79d8c25f63dbb2c3c3da79e599#diff-a8e86a3c07531e66a3b0b4c8b4b07879R481 )