### PR TITLE
Fix image links with descriptions in API and AP transmission

### DIFF
--- a/include/api.php
+++ b/include/api.php
@@ -2554,6 +2554,7 @@ function api_get_attachments(&$body)
 {
 	$text = $body;
 	$text = preg_replace("/\[img\=([0-9]*)x([0-9]*)\](.*?)\[\/img\]/ism", '[img]$3[/img]', $text);
+	$text = preg_replace("/\[img\=(.*?)\](.*?)\[\/img\]/ism", '[img]$1[/img]', $text);
 
 	$URLSearchString = "^\[\]";
 	$ret = preg_match_all("/\[img\]([$URLSearchString]*)\[\/img\]/ism", $text, $images);

--- a/src/Model/Photo.php
+++ b/src/Model/Photo.php
@@ -715,4 +715,25 @@ class Photo extends BaseObject
 
 		return DBA::exists('photo', ['resource-id' => $guid]);
 	}
+
+	/**
+	 * Tests if the link points to a locally stored picture page
+	 *
+	 * @param string $name Page link
+	 * @return boolean
+	 * @throws \Exception
+	 */
+	public static function isLocalLink($name)
+	{
+		$a = \get_app();
+		$base = $a->getBaseURL();
+
+		$guid = str_replace(Strings::normaliseLink($base), '', Strings::normaliseLink($name));
+		$guid = preg_replace("=/photos/.*/image/(.*)=ism", '$1', $guid);
+		if (empty($guid)) {
+			return false;
+		}
+
+		return DBA::exists('photo', ['resource-id' => $guid]);
+	}
 }

--- a/src/Model/Photo.php
+++ b/src/Model/Photo.php
@@ -723,7 +723,7 @@ class Photo extends BaseObject
 	 * @return boolean
 	 * @throws \Exception
 	 */
-	public static function isLocalLink($name)
+	public static function isLocalPage($name)
 	{
 		$a = \get_app();
 		$base = $a->getBaseURL();

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -19,6 +19,7 @@ use Friendica\Model\Contact;
 use Friendica\Model\Conversation;
 use Friendica\Model\Item;
 use Friendica\Model\Profile;
+use Friendica\Model\Photo;
 use Friendica\Model\Term;
 use Friendica\Model\User;
 use Friendica\Protocol\Activity;
@@ -1097,19 +1098,34 @@ class Transmitter
 	}
 
 	/**
-	 * Remove image elements and replaces them with links to the image
+	 * Remove image elements since they are added as attachment
 	 *
 	 * @param string $body
 	 *
-	 * @return string with replaced elements
+	 * @return string with removed images
 	 */
 	private static function removePictures($body)
 	{
 		// Simplify image codes
 		$body = preg_replace("/\[img\=([0-9]*)x([0-9]*)\](.*?)\[\/img\]/ism", '[img]$3[/img]', $body);
+		$body = preg_replace("/\[img\=(.*?)\](.*?)\[\/img\]/ism", '[img]$1[/img]', $body);
 
-		$body = preg_replace("/\[url=([^\[\]]*)\]\[img\](.*)\[\/img\]\[\/url\]/Usi", '[url]$1[/url]', $body);
-		$body = preg_replace("/\[img\]([^\[\]]*)\[\/img\]/Usi", '[url]$1[/url]', $body);
+		// Now remove local links
+		$body = preg_replace_callback(
+			'/\[url=([^\[\]]*)\]\[img\](.*)\[\/img\]\[\/url\]/Usi',
+			function ($match) {
+				// We remove the link when it is a link to a local photo page
+				if (Photo::isLocalLink($match[1])) {
+					return '';
+				}
+				// otherwise we just return the link
+				return '[url]' . $match[1] . '[/url]';
+			},
+			$body
+		);
+
+		// Remove all pictures
+		$body = preg_replace("/\[img\]([^\[\]]*)\[\/img\]/Usi", '', $body);
 
 		return $body;
 	}

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -1115,7 +1115,7 @@ class Transmitter
 			'/\[url=([^\[\]]*)\]\[img\](.*)\[\/img\]\[\/url\]/Usi',
 			function ($match) {
 				// We remove the link when it is a link to a local photo page
-				if (Photo::isLocalLink($match[1])) {
+				if (Photo::isLocalPage($match[1])) {
 					return '';
 				}
 				// otherwise we just return the link


### PR DESCRIPTION
Image links with picture descriptions hadn't worked well in API and AP transmission. Additionally we now remove picture links and we remove links when they are links to a local photo page.