### PR TITLE
ActivityPub: Use the contentMap to transmit additional content encodings

### DIFF
--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -1270,6 +1270,9 @@ class Transmitter
 			$data['content'] = BBCode::convert($body, false, 9);
 		}
 
+		$data['contentMap']['text/html'] = BBCode::convert($item['body'], false);
+		$data['contentMap']['text/markdown'] = BBCode::toMarkdown($item["body"]);
+
 		$data['source'] = ['content' => $item['body'], 'mediaType' => "text/bbcode"];
 
 		if (!empty($item['signed_text']) && ($item['uri'] != $item['thr-parent'])) {


### PR DESCRIPTION
From now on we will distribute (additionally to the limited HTML in the `content` field) we will distribute the "rich" HTML and additionally Markdown in the `contentMap` field. This is not totally according to the standard, but some slightly loose interpretation.

This can be used (in the future) to work around the situation that we have to make some changes to our HTML output so that our posts look good on Mastodon as well. But there could be systems that want to display the full HTML (like embedded pictures). Same goes with Markdown that systems like Socialhome support. So Socialhome could use that field in the future.