### PR TITLE
Update vagrant_provision.sh

### DIFF
--- a/bin/dev/vagrant_provision.sh
+++ b/bin/dev/vagrant_provision.sh
@@ -16,14 +16,12 @@ DOMAIN="*.xip.io"
 EXTRADOMAIN="friendica.local"
 PASSPHRASE="vaprobash"
 SUBJ="
-C=US
-ST=Connecticut
-O=Vaprobash
-localityName=New Haven
-commonName=$DOMAIN
+C=US/
+ST=Connecticut/
+O=Vaprobash/
+localityName=New Haven/
+commonName=$DOMAIN/
 subjectAltName=DNS:$EXTRADOMAIN
-organizationalUnitName=
-emailAddress=
 "
 sudo mkdir -p "$SSL_DIR"
 sudo openssl genrsa -out "$SSL_DIR/xip.io.key" 4096


### PR DESCRIPTION
Line 20-27 -> add slash at the end of every entry and removed empty entries.
Caused error in creating .csr file (with openssl version 1.1.1)
PS. the virtualbox-guest-x11 is not in the given debian repository. Better take an Ubuntu repository
Also inserted:
sudo apt-get install -y ubuntu-desktop
sudo systemctl set-default graphical.target
to install a desktop environment