### PR TITLE
AP: Remove the link description from the "rich html" and adds it to the attachment

### DIFF
--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -386,6 +386,28 @@ class BBCode extends BaseObject
 	}
 
 	/**
+	 * Remove [attachment] BBCode and replaces it with a regular [url]
+	 *
+	 * @param string $body
+	 *
+	 * @return string with replaced body
+	 */
+	public static function removeAttachment($body)
+	{
+		return preg_replace_callback("/\[attachment (.*)\](.*?)\[\/attachment\]/ism",
+			function ($match) {
+				$attach_data = self::getAttachmentData($match[0]);
+				if (empty($attach_data['url'])) {
+					return $match[0];
+				} elseif (empty($attach_data['title'])) {
+					return '[url]' . $attach_data['url'] . '[/url]';
+				} else {
+					return '[url=' . $attach_data['url'] . ']' . $attach_data['title'] . '[/url]';
+				}
+		}, $body);
+	}
+
+	/**
 	 * @brief Converts a BBCode text into plaintext
 	 *
 	 * @param      $text

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -1294,6 +1294,7 @@ class Transmitter
 		} else {
 			$regexp = "/[@!]\[url\=([^\[\]]*)\].*?\[\/url\]/ism";
 			$body = preg_replace_callback($regexp, ['self', 'mentionCallback'], $body);
+
 			$data['content'] = BBCode::convert($body, false, 9);
 		}
 

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -1020,6 +1020,34 @@ class Transmitter
 	{
 		$attachments = [];
 
+		$attach_data = BBCode::getAttachmentData($item['body']);
+		if (!empty($attach_data['url'])) {
+			$attachment = ['type' => 'Page',
+				'mediaType' => 'text/html',
+				'url' => $attach_data['url']];
+
+			if (!empty($attach_data['title'])) {
+				$attachment['name'] = $attach_data['title'];
+			}
+
+			if (!empty($attach_data['description'])) {
+				$attachment['summary'] = $attach_data['description'];
+			}
+
+			if (!empty($attach_data['image'])) {
+				$imgdata = Images::getInfoFromURLCached($attach_data['image']);
+				if ($imgdata) {
+					$attachment['icon'] = ['type' => 'Image',
+						'mediaType' => $imgdata['mime'],
+						'width' => $imgdata[0],
+						'height' => $imgdata[1],
+						'url' => $attach_data['image']];
+				}
+			}
+
+			$attachments[] = $attachment;
+		}
+
 		$arr = explode('[/attach],', $item['attach']);
 		if (count($arr)) {
 			foreach ($arr as $r) {
@@ -1266,12 +1294,12 @@ class Transmitter
 		} else {
 			$regexp = "/[@!]\[url\=([^\[\]]*)\].*?\[\/url\]/ism";
 			$body = preg_replace_callback($regexp, ['self', 'mentionCallback'], $body);
-
 			$data['content'] = BBCode::convert($body, false, 9);
 		}
 
 		$regexp = "/[@!]\[url\=([^\[\]]*)\].*?\[\/url\]/ism";
 		$richbody = preg_replace_callback($regexp, ['self', 'mentionCallback'], $item['body']);
+		$richbody = BBCode::removeAttachment($richbody);
 
 		$data['contentMap']['text/html'] = BBCode::convert($richbody, false);
 		$data['contentMap']['text/markdown'] = BBCode::toMarkdown($item["body"]);


### PR DESCRIPTION
Since PR #7831 we transmit the "rich html" as well. Currently in this HTML we do transmit the data from the "attachment" BBCode. We now remove it from here and we transmit it in the "attachment" fields. 