### PR TITLE
Fix fatal errors, caused by an empty "verb"

### DIFF
--- a/include/conversation.php
+++ b/include/conversation.php
@@ -402,7 +402,7 @@ function visible_activity($item) {
 	/** @var Activity $activity */
 	$activity = BaseObject::getClass(Activity::class);
 
-	if ($activity->isHidden($item['verb'])) {
+	if (empty($item['verb']) || $activity->isHidden($item['verb'])) {
 		return false;
 	}
 
@@ -1034,7 +1034,7 @@ function builtin_activity_puller($item, &$conv_responses) {
 		/** @var Activity $activity */
 		$activity = BaseObject::getClass(Activity::class);
 
-		if ($activity->match($item['verb'], $verb) && ($item['id'] != $item['parent'])) {
+		if (!empty($item['verb']) && $activity->match($item['verb'], $verb) && ($item['id'] != $item['parent'])) {
 			$author = ['uid' => 0, 'id' => $item['author-id'],
 				'network' => $item['author-network'], 'url' => $item['author-link']];
 			$url = Contact::magicLinkByContact($author);


### PR DESCRIPTION
We have to have a deeper look, why the "verb" value can be "null". This is a quick fix, since I'm currently working on other stuff.