### PR TITLE
Improve the look of fetched feeds and the BBCode processing of attachments

### DIFF
--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -1020,6 +1020,9 @@ class Transmitter
 	{
 		$attachments = [];
 
+		// Currently deactivated, since it creates side effects on Mastodon and Pleroma.
+		// It will be reactivated, once this cleared.
+		/*
 		$attach_data = BBCode::getAttachmentData($item['body']);
 		if (!empty($attach_data['url'])) {
 			$attachment = ['type' => 'Page',
@@ -1047,7 +1050,7 @@ class Transmitter
 
 			$attachments[] = $attachment;
 		}
-
+		*/
 		$arr = explode('[/attach],', $item['attach']);
 		if (count($arr)) {
 			foreach ($arr as $r) {


### PR DESCRIPTION
This PR touches two related topics. When we fetch feeds and we want to fetch further information, we now added some functionality to improve the fetched text. Additionally these posts to AP now include a link text. It is not needed to only post the URL.

We also deactivated the transmission of attached pages, since this causes side effects with Pleroma and Mastodon that need to be discussed with these developers.