### PR TITLE
Fix mail delivery via AP when the contact is hidden

### DIFF
--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -498,13 +498,7 @@ class Transmitter
 			}
 		}
 
-		$receivers = ['to' => array_values($data['to']), 'cc' => array_values($data['cc']), 'bcc' => array_values($data['bcc'])];
-
-		if (!$blindcopy) {
-			unset($receivers['bcc']);
-		}
-
-		return $receivers;
+		return ['to' => array_values($data['to']), 'cc' => array_values($data['cc']), 'bcc' => array_values($data['bcc'])];
 	}
 
 	/**
@@ -699,8 +693,15 @@ class Transmitter
 		$mail = self::ItemArrayFromMail($mail_id);
 		$object = self::createNote($mail);
 
-		$object['to'] = $object['cc'];
-		unset($object['cc']);
+		if (!empty($object['cc'])) {
+			$object['to'] = array_merge($object['to'], $object['cc']);
+			unset($object['cc']);
+		}
+
+		if (!empty($object['bcc'])) {
+			$object['to'] = array_merge($object['to'], $object['bcc']);
+			unset($object['bcc']);
+		}
 
 		$object['tag'] = [['type' => 'Mention', 'href' => $object['to'][0], 'name' => 'test']];
 

--- a/src/Worker/Notifier.php
+++ b/src/Worker/Notifier.php
@@ -51,6 +51,8 @@ class Notifier
 
 		$delivery_contacts_stmt = null;
 		$target_item = [];
+		$parent = [];
+		$thr_parent = [];
 		$items = [];
 		$delivery_queue_count = 0;
 
@@ -594,6 +596,10 @@ class Notifier
 	 */
 	private static function skipDFRN($contact, $item, $parent, $thr_parent, $cmd)
 	{
+		if (empty($parent['network'])) {
+			return false;
+		}
+
 		// Don't skip when the starting post is delivered via Diaspora
 		if ($parent['network'] == Protocol::DIASPORA) {
 			return false;


### PR DESCRIPTION
When a contact had been set to hidden, no mails went out via AP. This is now fixed.

