### PR TITLE
Improvement for PR 7854: Avoid leaking of BCC header data

### DIFF
--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -498,7 +498,13 @@ class Transmitter
 			}
 		}
 
-		return ['to' => array_values($data['to']), 'cc' => array_values($data['cc']), 'bcc' => array_values($data['bcc'])];
+		$receivers = ['to' => array_values($data['to']), 'cc' => array_values($data['cc']), 'bcc' => array_values($data['bcc'])];
+
+		if (!$blindcopy) {
+			unset($receivers['bcc']);
+		}
+
+		return $receivers;
 	}
 
 	/**
@@ -693,18 +699,6 @@ class Transmitter
 		$mail = self::ItemArrayFromMail($mail_id);
 		$object = self::createNote($mail);
 
-		if (!empty($object['cc'])) {
-			$object['to'] = array_merge($object['to'], $object['cc']);
-			unset($object['cc']);
-		}
-
-		if (!empty($object['bcc'])) {
-			$object['to'] = array_merge($object['to'], $object['bcc']);
-			unset($object['bcc']);
-		}
-
-		$object['tag'] = [['type' => 'Mention', 'href' => $object['to'][0], 'name' => 'test']];
-
 		if (!$object_mode) {
 			$data = ['@context' => ActivityPub::CONTEXT];
 		} else {
@@ -730,6 +724,8 @@ class Transmitter
 		unset($data['bcc']);
 
 		$object['to'] = $data['to'];
+		$object['tag'] = [['type' => 'Mention', 'href' => $object['to'][0], 'name' => 'test']];
+
 		unset($object['cc']);
 		unset($object['bcc']);
 

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -724,7 +724,7 @@ class Transmitter
 		unset($data['bcc']);
 
 		$object['to'] = $data['to'];
-		$object['tag'] = [['type' => 'Mention', 'href' => $object['to'][0], 'name' => 'test']];
+		$object['tag'] = [['type' => 'Mention', 'href' => $object['to'][0], 'name' => '']];
 
 		unset($object['cc']);
 		unset($object['bcc']);


### PR DESCRIPTION
This improves PR https://github.com/friendica/friendica/pull/7854

It restores the removal of the BCC field and fixes the problem from the previous PR in a better - and much simpler - way.