### PR TITLE
Don't use the creation date when transmitting to Diaspora

### DIFF
--- a/src/Module/Diaspora/Fetch.php
+++ b/src/Module/Diaspora/Fetch.php
@@ -31,7 +31,7 @@ class Fetch extends BaseModule
 
 		// Fetch the item
 		$fields = [
-			'uid', 'title', 'body', 'guid', 'contact-id', 'private', 'created', 'app', 'location', 'coord', 'network',
+			'uid', 'title', 'body', 'guid', 'contact-id', 'private', 'created', 'received', 'app', 'location', 'coord', 'network',
 			'event-id', 'resource-id', 'author-link', 'author-avatar', 'author-name', 'plink', 'owner-link', 'attach'
 		];
 		$condition = ['wall' => true, 'private' => false, 'guid' => $guid, 'network' => [Protocol::DFRN, Protocol::DIASPORA]];

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -3565,8 +3565,7 @@ class Diaspora
 		$myaddr = self::myHandle($owner);
 
 		$public = ($item["private"] ? "false" : "true");
-
-		$created = DateTimeFormat::utc($item["created"], DateTimeFormat::ATOM);
+		$created = DateTimeFormat::utc($item['received'], DateTimeFormat::ATOM);
 		$edited = DateTimeFormat::utc($item["edited"] ?? $item["created"], DateTimeFormat::ATOM);
 
 		// Detect a share element and do a reshare


### PR DESCRIPTION
Diaspora does sort their timeline after the date of the posting, not after the ate it arrived at the system (yeah, I have to correct myself).

This is a huge problem for shared feed posts. Especially when we pull feeds only once a day or so, these posts will most likely never appear in the list of items that are visible on a Diaspora system.

So we now use the date that the item had been created on the system to have a much more current date.