### PR TITLE
Avoid contact update for non federated networks

### DIFF
--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -1459,11 +1459,15 @@ class Contact extends BaseObject
 			$contact_id = $contact["id"];
 
 			// Update the contact every 7 days
-			$update_contact = ($contact['updated'] < DateTimeFormat::utc('now -7 days'));
+			if (in_array($contact['network'], Protocol::NATIVE_SUPPORT)) {
+				$update_contact = ($contact['updated'] < DateTimeFormat::utc('now -7 days'));
 
-			// We force the update if the avatar is empty
-			if (empty($contact['avatar'])) {
-				$update_contact = true;
+				// We force the update if the avatar is empty
+				if (empty($contact['avatar'])) {
+					$update_contact = true;
+				}
+			} else {
+				$update_contact = false;
 			}
 
 			// Update the contact in the background if needed but it is called by the frontend


### PR DESCRIPTION
The function "getIdForURL" tries to update the fetched contact from time to time. This mustn't be done for non federated networks, since they cannot be probed.