### PR TITLE
Only transfer posts via mail

### DIFF
--- a/src/Worker/Delivery.php
+++ b/src/Worker/Delivery.php
@@ -500,7 +500,7 @@ class Delivery extends BaseObject
 		if (!in_array($cmd, [self::POST, self::POKE])) {
 			return;
 		}
-Logger::info('Blubb', $target_item);
+
 		if ($target_item['verb'] != Activity::POST) {
 			return;
 		}

--- a/src/Worker/Delivery.php
+++ b/src/Worker/Delivery.php
@@ -15,6 +15,7 @@ use Friendica\Model;
 use Friendica\Protocol\DFRN;
 use Friendica\Protocol\Diaspora;
 use Friendica\Protocol\Email;
+use Friendica\Protocol\Activity;
 use Friendica\Util\Strings;
 use Friendica\Util\Network;
 use Friendica\Core\Worker;
@@ -497,6 +498,10 @@ class Delivery extends BaseObject
 		}
 
 		if (!in_array($cmd, [self::POST, self::POKE])) {
+			return;
+		}
+Logger::info('Blubb', $target_item);
+		if ($target_item['verb'] != Activity::POST) {
 			return;
 		}
 


### PR DESCRIPTION
We should really only transfer posts via mail, not a "follow" message or anything else.