### PR TITLE
Show the received date along with the creation date of posts

### DIFF
--- a/src/Object/Post.php
+++ b/src/Object/Post.php
@@ -378,6 +378,11 @@ class Post extends BaseObject
 
 		$tags = Term::populateTagsFromItem($item);
 
+		$ago = Temporal::getRelativeDate($item['created']);
+		if (Config::get('system', 'show_received') && (abs(strtotime($item['created']) - strtotime($item['received'])) > Config::get('system', 'show_received_seconds'))) {
+			$ago = L10n::t('%s (Received %s)', $ago, Temporal::getRelativeDate($item['received']));
+		}
+
 		$tmp_item = [
 			'template'        => $this->getTemplate(),
 			'type'            => implode("", array_slice(explode("/", $item['verb']), -1)),
@@ -412,7 +417,7 @@ class Post extends BaseObject
 			'sparkle'         => $sparkle,
 			'title'           => $title_e,
 			'localtime'       => DateTimeFormat::local($item['created'], 'r'),
-			'ago'             => $item['app'] ? L10n::t('%s from %s', Temporal::getRelativeDate($item['created']), $item['app']) : Temporal::getRelativeDate($item['created']),
+			'ago'             => $item['app'] ? L10n::t('%s from %s', $ago, $item['app']) : $ago,
 			'app'             => $item['app'],
 			'created'         => Temporal::getRelativeDate($item['created']),
 			'lock'            => $lock,

--- a/static/defaults.config.php
+++ b/static/defaults.config.php
@@ -374,9 +374,13 @@ return [
 		// When the global community page is enabled, use this option to display a hint above the stream, that this is a collection of all public top-level postings that arrive on your node.
 		'show_global_community_hint' => false,
 
-		// show_unsupported_addons (Boolean)
-		// Show all addons including the unsupported ones.
-		'show_unsupported_addons' => false,
+		// show_received (Boolean)
+		// Show the receive data along with the post creation date
+		'show_received' => true,
+
+		// show_received_seconds (Integer)
+		// Display the received date when the difference between received and created is higher than this.
+		'show_received_seconds' => 500,
 
 		// show_unsupported_themes (Boolean)
 		// Show all themes including the unsupported ones.


### PR DESCRIPTION
It is only enabled when configured. It can help in analyzing situations like here: https://github.com/friendica/friendica/issues/7835