### PR TITLE
Disable drone except "develop" branch

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -32,10 +32,10 @@ volumes:
 - name: cache
   temp: {}
 
-#trigger:
-#  branch:
+trigger:
+  branch:
 #    - master
-#    - develop
+    - develop
 #    - "*-rc"
 #  event:
 #    - pull_request
@@ -75,10 +75,10 @@ volumes:
   - name: cache
     temp: {}
 
-#trigger:
-#  branch:
+trigger:
+  branch:
 #    - master
-#    - develop
+    - develop
 #    - "*-rc"
 #  event:
 #    - pull_request
@@ -118,10 +118,10 @@ volumes:
   - name: cache
     temp: {}
 
-#trigger:
-#  branch:
+trigger:
+  branch:
 #    - master
-#    - develop
+    - develop
 #    - "*-rc"
 #  event:
 #    - pull_request
@@ -165,10 +165,10 @@ volumes:
   - name: cache
     temp: {}
 
-#trigger:
-#  branch:
+trigger:
+  branch:
 #    - master
-#    - develop
+    - develop
 #    - "*-rc"
 #  event:
 #    - pull_request
@@ -207,10 +207,10 @@ volumes:
   - name: cache
     temp: {}
 
-#trigger:
-#  branch:
+trigger:
+  branch:
 #    - master
-#    - develop
+    - develop
 #    - "*-rc"
 #  event:
 #    - pull_request
@@ -249,10 +249,10 @@ volumes:
   - name: cache
     temp: {}
 
-#trigger:
-#  branch:
+trigger:
+  branch:
 #    - master
-#    - develop
+    - develop
 #    - "*-rc"
 #  event:
 #    - pull_request
@@ -278,10 +278,10 @@ services:
 - name: redis
   image: redis
 
-#trigger:
-#  branch:
+trigger:
+  branch:
 #    - master
-#    - develop
+    - develop
 #    - "*-rc"
 #  event:
 #    - pull_request
@@ -302,10 +302,10 @@ services:
 - name: redis
   image: redis
 
-#trigger:
-#  branch:
+trigger:
+  branch:
 #    - master
-#    - develop
+    - develop
 #    - "*-rc"
 #  event:
 #    - pull_request
@@ -326,10 +326,10 @@ services:
 - name: redis
   image: redis
 
-#trigger:
-#  branch:
+trigger:
+  branch:
 #    - master
-#    - develop
+    - develop
 #    - "*-rc"
 #  event:
 #    - pull_request
@@ -356,10 +356,10 @@ services:
 - name: memcached
   image: memcached
 
-#trigger:
-#  branch:
+trigger:
+  branch:
 #    - master
-#    - develop
+    - develop
 #    - "*-rc"
 #  event:
 #    - pull_request
@@ -380,10 +380,10 @@ services:
 - name: memcached
   image: memcached
 
-#trigger:
-#  branch:
+trigger:
+  branch:
 #    - master
-#    - develop
+    - develop
 #    - "*-rc"
 #  event:
 #    - pull_request
@@ -404,10 +404,10 @@ services:
 - name: memcached
   image: memcached
 
-#trigger:
-#  branch:
+trigger:
+  branch:
 #    - master
-#    - develop
+    - develop
 #    - "*-rc"
 #  event:
 #    - pull_request
@@ -435,10 +435,10 @@ services:
 - name: memcached
   image: memcached
 
-#trigger:
-#  branch:
+trigger:
+  branch:
 #    - master
-#    - develop
+    - develop
 #    - "*-rc"
 #  event:
 #    - pull_request
@@ -459,10 +459,10 @@ services:
 - name: memcached
   image: memcached
 
-#trigger:
-#  branch:
+trigger:
+  branch:
 #    - master
-#    - develop
+    - develop
 #    - "*-rc"
 #  event:
 #    - pull_request
@@ -483,10 +483,10 @@ services:
 - name: memcached
   image: memcached
 
-#trigger:
-#  branch:
+trigger:
+  branch:
 #    - master
-#    - develop
+    - develop
 #    - "*-rc"
 #  event:
 #    - pull_request

--- a/.drone.yml
+++ b/.drone.yml
@@ -24,7 +24,7 @@ services:
     MYSQL_USER: friendica
     MYSQL_PASSWORD: friendica
     MYSQL_DATABASE: friendica
-  volumes: 
+  volumes:
     - name: cache
       path: /var/lib/mysql
 
@@ -32,14 +32,14 @@ volumes:
 - name: cache
   temp: {}
 
-trigger:
-  branch:
-    - master
-    - develop
-    - "*-rc"
-  event:
-    - pull_request
-    - push
+#trigger:
+#  branch:
+#    - master
+#    - develop
+#    - "*-rc"
+#  event:
+#    - pull_request
+#    - push
 ---
 kind: pipeline
 name: mysql8.0-php7.2
@@ -75,14 +75,14 @@ volumes:
   - name: cache
     temp: {}
 
-trigger:
-  branch:
-    - master
-    - develop
-    - "*-rc"
-  event:
-    - pull_request
-    - push
+#trigger:
+#  branch:
+#    - master
+#    - develop
+#    - "*-rc"
+#  event:
+#    - pull_request
+#    - push
 ---
 kind: pipeline
 name: mysql8.0-php7.3
@@ -118,14 +118,14 @@ volumes:
   - name: cache
     temp: {}
 
-trigger:
-  branch:
-    - master
-    - develop
-    - "*-rc"
-  event:
-    - pull_request
-    - push
+#trigger:
+#  branch:
+#    - master
+#    - develop
+#    - "*-rc"
+#  event:
+#    - pull_request
+#    - push
 ---
 kind: pipeline
 name: mariadb10.1-php7.1
@@ -165,14 +165,14 @@ volumes:
   - name: cache
     temp: {}
 
-trigger:
-  branch:
-    - master
-    - develop
-    - "*-rc"
-  event:
-    - pull_request
-    - push
+#trigger:
+#  branch:
+#    - master
+#    - develop
+#    - "*-rc"
+#  event:
+#    - pull_request
+#    - push
 ---
 kind: pipeline
 name: mariadb10.1-php7.2
@@ -207,14 +207,14 @@ volumes:
   - name: cache
     temp: {}
 
-trigger:
-  branch:
-    - master
-    - develop
-    - "*-rc"
-  event:
-    - pull_request
-    - push
+#trigger:
+#  branch:
+#    - master
+#    - develop
+#    - "*-rc"
+#  event:
+#    - pull_request
+#    - push
 ---
 kind: pipeline
 name: mariadb10.1-php7.3
@@ -249,6 +249,14 @@ volumes:
   - name: cache
     temp: {}
 
+#trigger:
+#  branch:
+#    - master
+#    - develop
+#    - "*-rc"
+#  event:
+#    - pull_request
+#    - push
 ---
 kind: pipeline
 name: redis-php7.1
@@ -270,14 +278,14 @@ services:
 - name: redis
   image: redis
 
-trigger:
-  branch:
-    - master
-    - develop
-    - "*-rc"
-  event:
-    - pull_request
-    - push
+#trigger:
+#  branch:
+#    - master
+#    - develop
+#    - "*-rc"
+#  event:
+#    - pull_request
+#    - push
 ---
 kind: pipeline
 name: redis-php7.2
@@ -294,14 +302,14 @@ services:
 - name: redis
   image: redis
 
-trigger:
-  branch:
-    - master
-    - develop
-    - "*-rc"
-  event:
-    - pull_request
-    - push
+#trigger:
+#  branch:
+#    - master
+#    - develop
+#    - "*-rc"
+#  event:
+#    - pull_request
+#    - push
 ---
 kind: pipeline
 name: redis-php7.3
@@ -317,6 +325,15 @@ steps:
 services:
 - name: redis
   image: redis
+
+#trigger:
+#  branch:
+#    - master
+#    - develop
+#    - "*-rc"
+#  event:
+#    - pull_request
+#    - push
 
 ---
 kind: pipeline
@@ -339,14 +356,14 @@ services:
 - name: memcached
   image: memcached
 
-trigger:
-  branch:
-    - master
-    - develop
-    - "*-rc"
-  event:
-    - pull_request
-    - push
+#trigger:
+#  branch:
+#    - master
+#    - develop
+#    - "*-rc"
+#  event:
+#    - pull_request
+#    - push
 ---
 kind: pipeline
 name: memcache-php7.2
@@ -363,14 +380,14 @@ services:
 - name: memcached
   image: memcached
 
-trigger:
-  branch:
-    - master
-    - develop
-    - "*-rc"
-  event:
-    - pull_request
-    - push
+#trigger:
+#  branch:
+#    - master
+#    - develop
+#    - "*-rc"
+#  event:
+#    - pull_request
+#    - push
 ---
 kind: pipeline
 name: memcache-php7.3
@@ -386,6 +403,16 @@ steps:
 services:
 - name: memcached
   image: memcached
+
+#trigger:
+#  branch:
+#    - master
+#    - develop
+#    - "*-rc"
+#  event:
+#    - pull_request
+#    - push
+
 
 ---
 kind: pipeline
@@ -408,14 +435,14 @@ services:
 - name: memcached
   image: memcached
 
-trigger:
-  branch:
-    - master
-    - develop
-    - "*-rc"
-  event:
-    - pull_request
-    - push
+#trigger:
+#  branch:
+#    - master
+#    - develop
+#    - "*-rc"
+#  event:
+#    - pull_request
+#    - push
 ---
 kind: pipeline
 name: memcached-php7.2
@@ -432,14 +459,14 @@ services:
 - name: memcached
   image: memcached
 
-trigger:
-  branch:
-    - master
-    - develop
-    - "*-rc"
-  event:
-    - pull_request
-    - push
+#trigger:
+#  branch:
+#    - master
+#    - develop
+#    - "*-rc"
+#  event:
+#    - pull_request
+#    - push
 ---
 kind: pipeline
 name: memcached-php7.3
@@ -455,3 +482,12 @@ steps:
 services:
 - name: memcached
   image: memcached
+
+#trigger:
+#  branch:
+#    - master
+#    - develop
+#    - "*-rc"
+#  event:
+#    - pull_request
+#    - push

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,6 @@ before_script:
  - phpenv config-add .travis/redis.ini
  - phpenv config-add .travis/memcached.ini
 
-script: vendor/bin/phpunit --configuration tests/phpunit.xml
+script: vendor/bin/phpunit --configuration tests/phpunit.xml --coverage-clover clover.xml
+
+after_success: bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
Because drone doesn't work well enough and the release 2019.12 will be released "soon" ;-), I disable the drone-environment for everything except the "develop" branch itself (for testing), and reenable the travis codecoverage-check again.

Maybe @ben-utzer and I can make progress for 2020.01 :-)