### PR TITLE
Group selection: Respect "pubmail" and ignore atchived or blocked contacts

### DIFF
--- a/src/Model/Group.php
+++ b/src/Model/Group.php
@@ -328,13 +328,28 @@ class Group extends BaseObject
 		}
 
 		$return = [];
+		$pubmail = false;
+		$networks = Protocol::SUPPORT_PRIVATE;
+
+		$mailacct = DBA::selectFirst('mailacct', ['pubmail'], ['`uid` = ? AND `server` != ""', $uid]);
+		if (DBA::isResult($mailacct)) {
+			$pubmail = $mailacct['pubmail'];
+		}
+
+		if (!$pubmail) {
+			$networks = array_diff($networks, [Protocol::MAIL]);
+		}
 
 		$key = array_search(self::FOLLOWERS, $group_ids);
 		if ($key !== false) {
 			$followers = Contact::selectToArray(['id'], [
 				'uid' => $uid,
 				'rel' => [Contact::FOLLOWER, Contact::FRIEND],
-				'network' => Protocol::SUPPORT_PRIVATE,
+				'network' => $networks,
+				'contact-type' => [Contact::TYPE_UNKNOWN, Contact::TYPE_PERSON],
+				'archive' => false,
+				'pending' => false,
+				'blocked' => false,
 			]);
 
 			foreach ($followers as $follower) {
@@ -349,7 +364,11 @@ class Group extends BaseObject
 			$mutuals = Contact::selectToArray(['id'], [
 				'uid' => $uid,
 				'rel' => [Contact::FRIEND],
-				'network' => Protocol::SUPPORT_PRIVATE,
+				'network' => $networks,
+				'contact-type' => [Contact::TYPE_UNKNOWN, Contact::TYPE_PERSON],
+				'archive' => false,
+				'pending' => false,
+				'blocked' => false,
 			]);
 
 			foreach ($mutuals as $mutual) {


### PR DESCRIPTION
This fixes the problem that selecting "followers" or "mutuals" always included mail addresses, which leads to the "funny" problems when you subscribed to several mailing lists via Friendica. (Then "mutuals" would include the mailing lists as well - and you would share your "mutual" content with all subscriber of all subscribed mailing lists - not ideal)

We now control this behaviour via the already existing "pubmail" setting (which is ideal for this check).

Additionally we now only include non archived, non blocked "real" contacts (no Forums or group accounts) in the list of receivers.