### PR TITLE
Make quoted announces look better / more announce improvements

### DIFF
--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -1052,8 +1052,11 @@ class BBCode extends BaseObject
 				$text = ($is_quote_share? '<br />' : '') . '<p>' . html_entity_decode('&#x2672; ', ENT_QUOTES, 'UTF-8') . ' ' . $author_contact['addr'] . ': </p>' . "\n" . $content;
 				break;
 			case 7: // statusnet/GNU Social
-			case 9: // ActivityPub
 				$text = ($is_quote_share? '<br />' : '') . '<p>' . html_entity_decode('&#x2672; ', ENT_QUOTES, 'UTF-8') . ' @' . $author_contact['addr'] . ': ' . $content . '</p>' . "\n";
+				break;
+			case 9: // ActivityPub
+				$author = '@<span class="vcard"><a href="' . $author_contact['url'] . '" class="url u-url mention" title="' . $author_contact['addr'] . '"><span class="fn nickname mention">' . $author_contact['addr'] . ':</span></a></span>';
+				$text = '<div><a href="' . $attributes['link'] . '">' . html_entity_decode('&#x2672;', ENT_QUOTES, 'UTF-8') . '</a> ' . $author . '<blockquote>' . $content . '</blockquote></div>' . "\n";
 				break;
 			default:
 				// Transforms quoted tweets in rich attachments to avoid nested tweets

--- a/src/Module/Objects.php
+++ b/src/Module/Objects.php
@@ -42,7 +42,14 @@ class Objects extends BaseModule
 			}
 		}
 
-		$data = ActivityPub\Transmitter::createObjectFromItemID($item['id']);
+		$activity = ActivityPub\Transmitter::createActivityFromItem($item['id'], true);
+		// Only display "Create" activity objects here, no reshares or anything else
+		if (!is_array($activity['object']) || ($activity['type'] != 'Create')) {
+			throw new \Friendica\Network\HTTPException\NotFoundException();
+		}
+
+		$data = ['@context' => ActivityPub::CONTEXT];
+		$data = array_merge($data, $activity['object']);
 
 		header('Content-Type: application/activity+json');
 		echo json_encode($data);

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -931,29 +931,6 @@ class Transmitter
 	}
 
 	/**
-	 * Creates an object array for a given item id
-	 *
-	 * @param integer $item_id
-	 *
-	 * @return array with the object data
-	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
-	 * @throws \ImagickException
-	 */
-	public static function createObjectFromItemID($item_id)
-	{
-		$item = Item::selectFirst([], ['id' => $item_id, 'parent-network' => Protocol::NATIVE_SUPPORT]);
-
-		if (!DBA::isResult($item)) {
-			return false;
-		}
-
-		$data = ['@context' => ActivityPub::CONTEXT];
-		$data = array_merge($data, self::createNote($item));
-
-		return $data;
-	}
-
-	/**
 	 * Creates a location entry for a given item array
 	 *
 	 * @param array $item

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -383,7 +383,7 @@ class Transmitter
 
 		// Directly mention the original author upon a quoted reshare.
 		// Else just ensure that the original author receives the reshare.
-		$announce = self::getAnnounceObject($item);
+		$announce = self::getAnnounceArray($item);
 		if (!empty($announce['comment'])) {
 			$data['to'][] = $announce['actor']['url'];
 		} elseif (!empty($announce)) {
@@ -768,7 +768,7 @@ class Transmitter
 
 		// Only check for a reshare, if it is a real reshare and no quoted reshare
 		if (strpos($item['body'], "[share") === 0) {
-			$announce = self::getAnnounceObject($item);
+			$announce = self::getAnnounceArray($item);
 			$reshared = !empty($announce);
 		}
 
@@ -993,7 +993,7 @@ class Transmitter
 			}
 		}
 
-		$announce = self::getAnnounceObject($item);
+		$announce = self::getAnnounceArray($item);
 		// Mention the original author upon commented reshares
 		if (!empty($announce['comment'])) {
 			$tags[] = ['type' => 'Mention', 'href' => $announce['actor']['url'], 'name' => '@' . $announce['actor']['addr']];
@@ -1366,7 +1366,7 @@ class Transmitter
 	private static function createAnnounce($item, $data)
 	{
 		$orig_body = $item['body'];
-		$announce = self::getAnnounceObject($item);
+		$announce = self::getAnnounceArray($item);
 		if (empty($announce)) {
 			$data['type'] = 'Create';
 			$data['object'] = self::createNote($item);
@@ -1399,7 +1399,7 @@ class Transmitter
 	 *
 	 * @return array
 	 */
-	public static function getAnnounceObject($item)
+	public static function getAnnounceArray($item)
 	{
 		if (!preg_match("/(.*?)\[share(.*?)\]\s?.*?\s?\[\/share\]\s?/ism", $item['body'], $matches)) {
 			return [];

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -1376,17 +1376,17 @@ class Transmitter
 		if (empty($announce['comment'])) {
 			// Pure announce, without a quote
 			$data['type'] = 'Announce';
-			$data['object'] = $announce['id'];
+			$data['object'] = $announce['object']['uri'];
 			return $data;
 		}
 
 		// Quote
 		$data['type'] = 'Create';
-		$item['body'] = $announce['comment'] . "\n" . $id;
+		$item['body'] = $announce['comment'] . "\n" . $announce['object']['plink'];
 		$data['object'] = self::createNote($item);
 
 		/// @todo Finally descide how to implement this in AP. This is a possible way:
-		$data['object']['attachment'][] = ['type' => $type, 'id' => $id];
+		$data['object']['attachment'][] = self::createNote($announce['object']);
 
 		$data['object']['source']['content'] = $orig_body;
 		return $data;
@@ -1417,7 +1417,7 @@ class Transmitter
 			return [];
 		}
 
-		$reshared_item = Item::selectFirst(['author-link', 'uri', 'network'], ['guid' => $matches[1]]);
+		$reshared_item = Item::selectFirst([], ['guid' => $matches[1]]);
 		if (!DBA::isResult($reshared_item)) {
 			return [];
 		}
@@ -1431,7 +1431,7 @@ class Transmitter
 			return [];
 		}
 
-		return ['id' => $reshared_item['uri'], 'actor' => $profile, 'comment' => trim($comment)];
+		return ['object' => $reshared_item, 'actor' => $profile, 'comment' => trim($comment)];
 	}
 
 	/**


### PR DESCRIPTION
(Hopefully) improve the visual impression of a quoted (false) announcement. We now link the author and the original item there as well.

Additionally we ensure that original authors get notified about resharing their content. And we ensure that we don't publish this Friendica reshare behemoth (the workaround that we currently are using for reshares) via AP.