### PR TITLE
ACL: Contact list is now sorted, forums reappeared

### DIFF
--- a/src/Core/ACL.php
+++ b/src/Core/ACL.php
@@ -258,10 +258,20 @@ class ACL extends BaseObject
 	 */
 	public static function getContactListByUserId(int $user_id)
 	{
-		$acl_contacts = Contact::selectToArray(
-			['id', 'name', 'addr', 'micro'],
-			['uid' => $user_id, 'pending' => false, 'rel' => [Contact::FOLLOWER, Contact::FRIEND]]
+		$fields = ['id', 'name', 'addr', 'micro'];
+		$params = ['order' => ['name']];
+		$acl_contacts = Contact::selectToArray($fields,
+			['uid' => $user_id, 'self' => false, 'blocked' => false, 'archive' => false, 'deleted' => false,
+			'pending' => false, 'rel' => [Contact::FOLLOWER, Contact::FRIEND]], $params
 		);
+
+		$acl_forums = Contact::selectToArray($fields,
+			['uid' => $user_id, 'self' => false, 'blocked' => false, 'archive' => false, 'deleted' => false,
+			'pending' => false, 'contact-type' => Contact::TYPE_COMMUNITY], $params
+		);
+
+		$acl_contacts = array_merge($acl_forums, $acl_contacts);
+
 		array_walk($acl_contacts, function (&$value) {
 			$value['type'] = 'contact';
 		});


### PR DESCRIPTION
Forums are now searchable again. Blocked and archived contacts don't appear. And the search is now sorted by name.