### PR TITLE
Fix: Due to duplicated id values, some groups didn't appear

### DIFF
--- a/src/Core/ACL.php
+++ b/src/Core/ACL.php
@@ -305,7 +305,7 @@ class ACL extends BaseObject
 		];
 		foreach (Group::getByUserId($user_id) as $group) {
 			$acl_groups[] = [
-				'id' => $group['id'],
+				'id' => -$group['id'],
 				'name' => $group['name'],
 				'addr' => '',
 				'micro' => 'images/twopeople.png',


### PR DESCRIPTION
On my system a contact had got the same contact id as a group. Because of this the group was not reachable.