### PR TITLE
Fixes issue 7914: Reshares got crumbled

### DIFF
--- a/mod/item.php
+++ b/mod/item.php
@@ -652,6 +652,9 @@ function item_post(App $a) {
 	if ($orig_post) {
 		$datarray['edit'] = true;
 	} else {
+		// If this was a share, add missing data here
+		$datarray = Item::addShareDataFromOriginal($datarray);
+
 		$datarray['edit'] = false;
 	}
 
@@ -729,9 +732,6 @@ function item_post(App $a) {
 			$datarray['diaspora_signed_text'] = json_encode($signed);
 		}
 	}
-
-	// If this was a share, add missing data here
-	$datarray = Item::addShareDataFromOriginal($datarray);
 
 	$post_id = Item::insert($datarray);
 

--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -953,12 +953,11 @@ class BBCode extends BaseObject
 	public static function convertShare($text, callable $callback)
 	{
 		$return = preg_replace_callback(
-			"/(.*?)\[share(.*?)\](.*?)\[\/share\]/ism",
+			"/(.*?)\[share(.*?)\](.*)\[\/share\]/ism",
 			function ($match) use ($callback) {
 				$attribute_string = $match[2];
-
 				$attributes = [];
-				foreach(['author', 'profile', 'avatar', 'link', 'posted'] as $field) {
+				foreach (['author', 'profile', 'avatar', 'link', 'posted'] as $field) {
 					preg_match("/$field=(['\"])(.+?)\\1/ism", $attribute_string, $matches);
 					$attributes[$field] = html_entity_decode($matches[2] ?? '', ENT_QUOTES, 'UTF-8');
 				}

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -3833,7 +3833,7 @@ class Item extends BaseObject
 			$body = $shared_item['body'];
 		}
 
-		$item['body'] = preg_replace("/(.*?\[share.*?\]\s?).*?(\s?\[\/share\]\s?)/ism", '$1' . $body . '$2', $item['body']);
+		$item['body'] = preg_replace("/\[share ([^\[\]]*)\].*\[\/share\]/ism", '[share $1]' . $body . '[/share]', $item['body']);
 		unset($shared_item['body']);
 
 		return array_merge($item, $shared_item);


### PR DESCRIPTION
Fixes https://github.com/friendica/friendica/issues/7914

The regexps had been improved to be more greedy. Since there can be only one "share" element in a single post, greediness is good here.