### PR TITLE
Do reshares as native as possible

### DIFF
--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -363,7 +363,7 @@ class Transmitter
 			}
 		}
 
-		if (Config::get('debug', 'total_ap_delivery')) {
+		if (self::isAnnounce($item) || Config::get('debug', 'total_ap_delivery')) {
 			// Will be activated in a later step
 			$networks = Protocol::FEDERATED;
 		} else {
@@ -1421,6 +1421,23 @@ class Transmitter
 		}
 
 		return ['object' => $reshared_item, 'actor' => $profile, 'comment' => $reshared['comment']];
+	}
+
+	/**
+	 * Checks if the provided item array is an announce
+	 *
+	 * @param array $item
+	 *
+	 * @return boolean
+	 */
+	public static function isAnnounce($item)
+	{
+		$announce = self::getAnnounceArray($item);
+		if (empty($announce)) {
+			return false;
+		}
+
+		return empty($announce['comment']);
 	}
 
 	/**

--- a/src/Worker/Delivery.php
+++ b/src/Worker/Delivery.php
@@ -16,7 +16,6 @@ use Friendica\Protocol\DFRN;
 use Friendica\Protocol\Diaspora;
 use Friendica\Protocol\Email;
 use Friendica\Protocol\Activity;
-use Friendica\Protocol\ActivityPub;
 use Friendica\Util\Strings;
 use Friendica\Util\Network;
 use Friendica\Core\Worker;
@@ -252,13 +251,6 @@ class Delivery extends BaseObject
 	 */
 	private static function deliverDFRN($cmd, $contact, $owner, $items, $target_item, $public_message, $top_level, $followup)
 	{
-		// Skip transmitting the announce via DFRN when it had already been done via AP
-		if (ActivityPub\Transmitter::isAnnounce($target_item) && !empty(Model\APContact::getByURL($contact['url'], false))) {
-			Logger::info('Announce had already been transmitted', ['url' => $contact['url'], 'guid' => ($target_item['guid'] ?? '') ?: $target_item['id']]);
-			Model\ItemDeliveryData::incrementQueueDone($target_item['id']);
-			return;
-		}
-
 		// Transmit Diaspora reshares via Diaspora if the Friendica contact support Diaspora
 		if (Diaspora::isReshare($target_item['body']) && !empty(Diaspora::personByHandle(contact['addr'], false))) {
 			Logger::info('Reshare will be transmitted via Diaspora', ['url' => $contact['url'], 'guid' => ($target_item['guid'] ?? '') ?: $target_item['id']]);

--- a/src/Worker/Delivery.php
+++ b/src/Worker/Delivery.php
@@ -16,6 +16,7 @@ use Friendica\Protocol\DFRN;
 use Friendica\Protocol\Diaspora;
 use Friendica\Protocol\Email;
 use Friendica\Protocol\Activity;
+use Friendica\Protocol\ActivityPub;
 use Friendica\Util\Strings;
 use Friendica\Util\Network;
 use Friendica\Core\Worker;
@@ -254,6 +255,7 @@ class Delivery extends BaseObject
 		// Skip transmitting the announce via DFRN when it had already been done via AP
 		if (ActivityPub\Transmitter::isAnnounce($target_item) && !empty(Model\APContact::getByURL($contact['url'], false))) {
 			Logger::info('Announce had already been transmitted', ['url' => $contact['url'], 'guid' => ($target_item['guid'] ?? '') ?: $target_item['id']]);
+			Model\ItemDeliveryData::incrementQueueDone($target_item['id']);
 			return;
 		}
 

--- a/src/Worker/Delivery.php
+++ b/src/Worker/Delivery.php
@@ -251,17 +251,19 @@ class Delivery extends BaseObject
 	 */
 	private static function deliverDFRN($cmd, $contact, $owner, $items, $target_item, $public_message, $top_level, $followup)
 	{
-/*
-		if (Diaspora::isReshare($target_item['body'])) {
-			// Transmit Diaspora reshares only via Diaspora
+		// Transmit Diaspora reshares via Diaspora if the Friendica contact support Diaspora
+		if (Diaspora::isReshare($target_item['body']) && !empty(Diaspora::personByHandle(contact['addr'], false))) {
+			Logger::info('Reshare will be transmitted via Diaspora', ['url' => $contact['url'], 'guid' => ($target_item['guid'] ?? '') ?: $target_item['id']]);
 			self::deliverDiaspora($cmd, $contact, $owner, $items, $target_item, $public_message, $top_level, $followup);
 			return;
 		}
 
-		if (ActivityPub\Transmitter::::isAnnounce($target_item) && getby) {
+		// Skip transmitting the announce via DFRN when it had already been done via AP
+		if (ActivityPub\Transmitter::isAnnounce($target_item) && !empty(Model\APContact::getByURL($contact['url'], false))) {
+			Logger::info('Announce had already been transmitted', ['url' => $contact['url'], 'guid' => ($target_item['guid'] ?? '') ?: $target_item['id']]);
 			return;
 		}
-*/
+
 		Logger::info('Deliver ' . (($target_item['guid'] ?? '') ?: $target_item['id']) . ' via DFRN to ' . (($contact['addr'] ?? '') ?: $contact['url']));
 
 		if ($cmd == self::MAIL) {

--- a/src/Worker/Delivery.php
+++ b/src/Worker/Delivery.php
@@ -251,16 +251,16 @@ class Delivery extends BaseObject
 	 */
 	private static function deliverDFRN($cmd, $contact, $owner, $items, $target_item, $public_message, $top_level, $followup)
 	{
+		// Skip transmitting the announce via DFRN when it had already been done via AP
+		if (ActivityPub\Transmitter::isAnnounce($target_item) && !empty(Model\APContact::getByURL($contact['url'], false))) {
+			Logger::info('Announce had already been transmitted', ['url' => $contact['url'], 'guid' => ($target_item['guid'] ?? '') ?: $target_item['id']]);
+			return;
+		}
+
 		// Transmit Diaspora reshares via Diaspora if the Friendica contact support Diaspora
 		if (Diaspora::isReshare($target_item['body']) && !empty(Diaspora::personByHandle(contact['addr'], false))) {
 			Logger::info('Reshare will be transmitted via Diaspora', ['url' => $contact['url'], 'guid' => ($target_item['guid'] ?? '') ?: $target_item['id']]);
 			self::deliverDiaspora($cmd, $contact, $owner, $items, $target_item, $public_message, $top_level, $followup);
-			return;
-		}
-
-		// Skip transmitting the announce via DFRN when it had already been done via AP
-		if (ActivityPub\Transmitter::isAnnounce($target_item) && !empty(Model\APContact::getByURL($contact['url'], false))) {
-			Logger::info('Announce had already been transmitted', ['url' => $contact['url'], 'guid' => ($target_item['guid'] ?? '') ?: $target_item['id']]);
 			return;
 		}
 

--- a/src/Worker/Delivery.php
+++ b/src/Worker/Delivery.php
@@ -251,6 +251,17 @@ class Delivery extends BaseObject
 	 */
 	private static function deliverDFRN($cmd, $contact, $owner, $items, $target_item, $public_message, $top_level, $followup)
 	{
+/*
+		if (Diaspora::isReshare($target_item['body'])) {
+			// Transmit Diaspora reshares only via Diaspora
+			self::deliverDiaspora($cmd, $contact, $owner, $items, $target_item, $public_message, $top_level, $followup);
+			return;
+		}
+
+		if (ActivityPub\Transmitter::::isAnnounce($target_item) && getby) {
+			return;
+		}
+*/
 		Logger::info('Deliver ' . (($target_item['guid'] ?? '') ?: $target_item['id']) . ' via DFRN to ' . (($contact['addr'] ?? '') ?: $contact['url']));
 
 		if ($cmd == self::MAIL) {

--- a/src/Worker/Notifier.php
+++ b/src/Worker/Notifier.php
@@ -625,6 +625,11 @@ class Notifier
 			return false;
 		}
 
+		// We deliver reshares via AP whenever possible
+		if (ActivityPub\Transmitter::isAnnounce($item)) {
+			return true;
+		}
+
 		// Skip DFRN when the item will be (forcefully) delivered via AP
 		if (Config::get('debug', 'total_ap_delivery') && ($contact['network'] == Protocol::DFRN) && !empty(APContact::getByURL($contact['url'], false))) {
 			return true;


### PR DESCRIPTION
Reshares ("announce" in AP) are still a big issue with Friendica. Our native protocol DFRN doesn't even know them. We just transmitting some really ugly workaround at the moment.

So now we will use the native methods whenever possible. 