### PR TITLE
Issue 7418: connections to forums should now work again

### DIFF
--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -2332,7 +2332,7 @@ class Contact extends BaseObject
 			$apcontact = APContact::getByURL($url, false);
 			if (isset($apcontact['manually-approve'])) {
 				$pending = (bool)$apcontact['manually-approve'];
-			}			
+			}
 		}
 
 		if (in_array($protocol, [Protocol::MAIL, Protocol::DIASPORA, Protocol::ACTIVITYPUB])) {

--- a/src/Worker/OnePoll.php
+++ b/src/Worker/OnePoll.php
@@ -41,7 +41,7 @@ class OnePoll
 		}
 
 		if ($force) {
-			Contact::updateFromProbe($contact_id, true);
+			Contact::updateFromProbe($contact_id, '', true);
 		}
 
 		$contact = DBA::selectFirst('contact', [], ['id' => $contact_id]);


### PR DESCRIPTION
This is expected to fix #7418

When connecting to other (Friendica) accounts, we are pulling the contact feed - and this pulling with the parameter "force" also updates the contact entry. Due to a parameter mismatch, this lead to the problem that Friendica contacts had been switched to AP contacts - which is not a big deal, since AP is working fine. But this doesn't seem to be true for forums (on the same machine). 