### PR TITLE
Issue 7691: We can now switch to BCC for ActivityPub

### DIFF
--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -363,6 +363,10 @@ class Transmitter
 			}
 		}
 
+		if (Config::get('system', 'ap_always_bcc')) {
+			$always_bcc = true;
+		}
+
 		if (self::isAnnounce($item) || Config::get('debug', 'total_ap_delivery')) {
 			// Will be activated in a later step
 			$networks = Protocol::FEDERATED;

--- a/static/defaults.config.php
+++ b/static/defaults.config.php
@@ -59,6 +59,10 @@ return [
 		// Only show small preview pictures.
 		'always_show_preview' => false,
 
+		// ap_always_bcc (Boolean)
+		// Adressing receivers via ActivityPub by BCC. Increases privacy, decreases performnce.
+		'ap_always_bcc' => false,
+
 		// archival_days (Integer)
 		// Number of days that we try to deliver content before we archive a contact.
 		'archival_days' => 32,

--- a/static/defaults.config.php
+++ b/static/defaults.config.php
@@ -60,7 +60,7 @@ return [
 		'always_show_preview' => false,
 
 		// ap_always_bcc (Boolean)
-		// Adressing receivers via ActivityPub by BCC. Increases privacy, decreases performnce.
+		// Adresses non-mentioned ActivityPub receivers by BCC instead of CC. Increases privacy, decreases performance.
 		'ap_always_bcc' => false,
 
 		// archival_days (Integer)


### PR DESCRIPTION
Handles issue https://github.com/friendica/friendica/issues/7691

To increase reliability with remote systems and to increase delivery speed, we normally address receivers on ActivityPub with the "cc" header (when not mentioned). This post is the delivered to the shared inbox once. With a new config value this can be switched to "bcc". Then the post will be delivered to every single personal inbox directly. This can cause compatibility problems with some implementations and it definitely reduces the delivery speed of a system. So this switch is not advised for bigger systems - also it is not tested if it works with all implementations. (although it should, when the systems do follow the specification)