### PR TITLE
API: Added endpoints /instance and /instance/peers

### DIFF
--- a/doc/API-Mastodon.md
+++ b/doc/API-Mastodon.md
@@ -16,6 +16,8 @@ These endpoints use the [Mastodon API entities](https://docs.joinmastodon.org/ap
 ## Implemented endpoints
 
 - [GET /api/v1/follow_requests](https://docs.joinmastodon.org/api/rest/follow-requests/#get-api-v1-follow-requests)
+- [GET /api/v1/instance](https://docs.joinmastodon.org/api/rest/instances)
+- GET /api/v1/instance/peers - undocumented, but implemented by Mastodon and Pleroma
 
 ## Non-implemented endpoints
 

--- a/src/Api/Mastodon/Instance.php
+++ b/src/Api/Mastodon/Instance.php
@@ -2,8 +2,7 @@
 
 namespace Friendica\Api\Mastodon;
 
-use Friendica\Core\Protocol;
-
+use Friendica\App;
 use Friendica\Api\Mastodon\Account;
 use Friendica\Api\Mastodon\Stats;
 use Friendica\Core\Config;
@@ -48,10 +47,12 @@ class Instance
 	/**
 	 * Creates an instance record
 	 *
+	 * @param App $app
+	 *
 	 * @return Instance
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
-	public static function get($app) {
+	public static function get(App $app) {
 		$register_policy = intval(Config::get('config', 'register_policy'));
 
 		$instance = new Instance();

--- a/src/Api/Mastodon/Instance.php
+++ b/src/Api/Mastodon/Instance.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Friendica\Api\Mastodon;
+
+use Friendica\Core\Protocol;
+
+use Friendica\Api\Mastodon\Account;
+use Friendica\Api\Mastodon\Stats;
+use Friendica\Core\Config;
+use Friendica\Database\DBA;
+use Friendica\Model\User;
+use Friendica\Module\Register;
+
+/**
+ * Class Account
+ *
+ * @see https://docs.joinmastodon.org/api/entities/#instance
+ */
+class Instance
+{
+	/** @var string (URL) */
+	var $uri;
+	/** @var string */
+	var $title;
+	/** @var string */
+	var $description;
+	/** @var string */
+	var $email;
+	/** @var string */
+	var $version;
+	/** @var array */
+	var $urls;
+	/** @var Stats */
+	var $stats;
+	/** @var string */
+	var $thumbnail;
+	/** @var array */
+	var $languages;
+	/** @var int */
+	var $max_toot_chars;
+	/** @var bool */
+	var $registrations;
+	/** @var bool */
+	var $approval_required;
+	/** @var Account|null */
+	var $contact_account;
+
+	/**
+	 * Creates an instance record
+	 *
+	 * @return Instance
+	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
+	 */
+	public static function get($app) {
+		$register_policy = intval(Config::get('config', 'register_policy'));
+
+		$instance = new Instance();
+		$instance->uri = $app->getBaseURL();
+		$instance->title = Config::get('config', 'sitename');
+		$instance->description = Config::get('config', 'info');
+		$instance->email = Config::get('config', 'admin_email');
+		$instance->version = FRIENDICA_VERSION;
+		$instance->urls = []; // Not supported
+		$instance->stats = Stats::get();
+		$instance->thumbnail = $app->getBaseURL() . (Config::get('system', 'shortcut_icon') ?? 'images/friendica-32.png');
+		$instance->languages = [Config::get('system', 'language')];
+		$instance->max_toot_chars = (int)Config::get('config', 'api_import_size', Config::get('config', 'max_import_size'));
+		$instance->registrations = ($register_policy != Register::CLOSED);
+		$instance->approval_required = ($register_policy == Register::APPROVE);
+		$instance->contact_account = [];
+
+		if (!empty(Config::get('config', 'admin_email'))) {
+			$adminList = explode(',', str_replace(' ', '', Config::get('config', 'admin_email')));
+			$administrator = User::getByEmail($adminList[0], ['nickname']);
+			if (!empty($administrator)) {
+				$adminContact = DBA::selectFirst('contact', [], ['nick' => $administrator['nickname'], 'self' => true]);
+				$instance->contact_account = Account::createFromContact($adminContact);
+			}
+		}
+
+		return $instance;
+	}
+}

--- a/src/Api/Mastodon/Stats.php
+++ b/src/Api/Mastodon/Stats.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Friendica\Api\Mastodon;
+
+use Friendica\Core\Config;
+use Friendica\Core\Protocol;
+use Friendica\Database\DBA;
+
+/**
+ * Class Stats
+ *
+ * @see https://docs.joinmastodon.org/api/entities/#stats
+ */
+class Stats
+{
+	/** @var int */
+	var $user_count;
+	/** @var int */
+	var $status_count;
+	/** @var int */
+	var $domain_count;
+
+	/**
+	 * Creates a stats record
+	 *
+	 * @return Stats
+	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
+	 */
+	public static function get() {
+		$stats = new Stats();
+		if (!empty(Config::get('system', 'nodeinfo'))) {
+			$stats->user_count = intval(Config::get('nodeinfo', 'total_users'));
+			$stats->status_count = Config::get('nodeinfo', 'local_posts') + Config::get('nodeinfo', 'local_comments');
+			$stats->domain_count = DBA::count('gserver', ["`network` in (?, ?) AND `last_contact` >= `last_failure`", Protocol::DFRN, Protocol::ACTIVITYPUB]);
+		}
+		return $stats;
+	}
+}

--- a/src/Module/Api/Mastodon/Instance.php
+++ b/src/Module/Api/Mastodon/Instance.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Friendica\Module\Api\Mastodon;
+
+use Friendica\Core\Config;
+use Friendica\Core\Protocol;
+use Friendica\Core\System;
+use Friendica\Database\DBA;
+use Friendica\Model\User;
+use Friendica\Module\Base\Api;
+use Friendica\Module\Register;
+use Friendica\Network\HTTPException;
+use Friendica\Util\Network;
+
+/**
+ * @see https://docs.joinmastodon.org/api/rest/instances/
+ */
+class Instance extends Api
+{
+	public static function init(array $parameters = [])
+	{
+		parent::init($parameters);
+	}
+
+	/**
+	 * @param array $parameters
+	 * @throws HTTPException\InternalServerErrorException
+	 */
+	public static function rawContent(array $parameters = [])
+	{
+		$app = self::getApp();
+
+                $register_policy = intval(Config::get('config', 'register_policy'));
+
+		$return = [
+			'uri' => $app->getBaseURL(),
+			'title' => Config::get('config', 'sitename'),
+			'short_description' => '', // Not supported
+			'description' => Config::get('config', 'info'),
+			'email' => Config::get('config', 'admin_email'),
+			'version' => FRIENDICA_VERSION,
+			'urls' => [], // Not supported
+			'stats' => [],
+			'thumbnail' => $app->getBaseURL() . (Config::get('system', 'shortcut_icon') ?? 'images/friendica-32.png'),
+			'languages' => [Config::get('system', 'language')],
+			'registrations' => ($register_policy != Register::CLOSED),
+			'approval_required' => ($register_policy == Register::APPROVE),
+			'contact_account' => [] // Currently unsupported
+		];
+
+		if (!empty(Config::get('system', 'nodeinfo'))) {
+			$count = DBA::count('gserver', ["`network` in (?, ?) AND `last_contact` >= `last_failure`", Protocol::DFRN, Protocol::ACTIVITYPUB]);
+			$return['stats'] = [
+				'user_count' => intval(Config::get('nodeinfo', 'total_users')),
+				'status_count' => Config::get('nodeinfo', 'local_posts') + Config::get('nodeinfo', 'local_comments'),
+				'domain_count' => $count
+			];
+		}
+
+		/// @ToDo will be done, once that we have an API function for that
+		/*
+		if (!empty(Config::get('config', 'admin_email'))) {
+			$adminList = explode(',', str_replace(' ', '', Config::get('config', 'admin_email')));
+			$administrator = User::getByEmail($adminList[0], ['nickname']);
+			if (!empty($administrator)) {
+				$adminContact = DBA::selectFirst('contact', [], ['nick' => $administrator['nickname'], 'self' => true]);
+				$return['contact_account'] = Api::getAccountArray($adminContact);
+			}
+		}
+		*/
+
+		System::jsonExit($return);
+	}
+}

--- a/src/Module/Api/Mastodon/Instance.php
+++ b/src/Module/Api/Mastodon/Instance.php
@@ -2,75 +2,21 @@
 
 namespace Friendica\Module\Api\Mastodon;
 
-use Friendica\Api\Mastodon\Account;
-use Friendica\Core\Config;
-use Friendica\Core\Protocol;
+use Friendica\Api\Mastodon\Instance as InstanceEntity;
 use Friendica\Core\System;
-use Friendica\Database\DBA;
-use Friendica\Model\User;
 use Friendica\Module\Base\Api;
-use Friendica\Module\Register;
-use Friendica\Network\HTTPException;
-use Friendica\Util\Network;
 
 /**
  * @see https://docs.joinmastodon.org/api/rest/instances/
  */
 class Instance extends Api
 {
-	public static function init(array $parameters = [])
-	{
-		parent::init($parameters);
-	}
-
 	/**
 	 * @param array $parameters
 	 * @throws HTTPException\InternalServerErrorException
 	 */
 	public static function rawContent(array $parameters = [])
 	{
-		$app = self::getApp();
-
-                $register_policy = intval(Config::get('config', 'register_policy'));
-
-		$return = [
-			'uri' => $app->getBaseURL(),
-			'title' => Config::get('config', 'sitename'),
-			'description' => Config::get('config', 'info'),
-			'email' => Config::get('config', 'admin_email'),
-			'version' => FRIENDICA_VERSION,
-			'urls' => [], // Not supported
-			'stats' => [],
-			'thumbnail' => $app->getBaseURL() . (Config::get('system', 'shortcut_icon') ?? 'images/friendica-32.png'),
-			'languages' => [Config::get('system', 'language')],
-			'max_toot_chars' => (int)Config::get('config', 'api_import_size', Config::get('config', 'max_import_size')),
-			'registrations' => ($register_policy != Register::CLOSED),
-			'approval_required' => ($register_policy == Register::APPROVE),
-			'contact_account' => []
-		];
-
-		if (!$return['registrations']) {
-			unset($return['approval_required']);
-		}
-
-		if (!empty(Config::get('system', 'nodeinfo'))) {
-			$count = DBA::count('gserver', ["`network` in (?, ?) AND `last_contact` >= `last_failure`", Protocol::DFRN, Protocol::ACTIVITYPUB]);
-			$return['stats'] = [
-				'user_count' => intval(Config::get('nodeinfo', 'total_users')),
-				'status_count' => Config::get('nodeinfo', 'local_posts') + Config::get('nodeinfo', 'local_comments'),
-				'domain_count' => $count
-			];
-		}
-
-		if (!empty(Config::get('config', 'admin_email'))) {
-			$adminList = explode(',', str_replace(' ', '', Config::get('config', 'admin_email')));
-			$administrator = User::getByEmail($adminList[0], ['nickname']);
-			if (!empty($administrator)) {
-				$adminContact = DBA::selectFirst('contact', [], ['nick' => $administrator['nickname'], 'self' => true]);
-				$return['contact_account'] = Account::createFromContact($adminContact);
-			}
-		}
-
-		System::jsonExit($return);
+		System::jsonExit(InstanceEntity::get(self::getApp()));
 	}
 }

--- a/src/Module/Api/Mastodon/Instance/Peers.php
+++ b/src/Module/Api/Mastodon/Instance/Peers.php
@@ -14,11 +14,6 @@ use Friendica\Util\Network;
  */
 class Peers extends Api
 {
-	public static function init(array $parameters = [])
-	{
-		parent::init($parameters);
-	}
-
 	/**
 	 * @param array $parameters
 	 * @throws HTTPException\InternalServerErrorException

--- a/src/Module/Api/Mastodon/Instance/Peers.php
+++ b/src/Module/Api/Mastodon/Instance/Peers.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Friendica\Module\Api\Mastodon\Instance;
+
+use Friendica\Core\Protocol;
+use Friendica\Core\System;
+use Friendica\Database\DBA;
+use Friendica\Module\Base\Api;
+use Friendica\Network\HTTPException;
+use Friendica\Util\Network;
+
+/**
+ * Undocumented API endpoint that is implemented by both Mastodon and Pleroma
+ */
+class Peers extends Api
+{
+	public static function init(array $parameters = [])
+	{
+		parent::init($parameters);
+	}
+
+	/**
+	 * @param array $parameters
+	 * @throws HTTPException\InternalServerErrorException
+	 */
+	public static function rawContent(array $parameters = [])
+	{
+		$return = [];
+
+		// We only select for Friendica and ActivityPub servers, since it is expected to only deliver AP compatible systems here.
+		$instances = DBA::select('gserver', ['url'], ["`network` in (?, ?) AND `last_contact` >= `last_failure`", Protocol::DFRN, Protocol::ACTIVITYPUB]);
+		while ($instance = DBA::fetch($instances)) {
+			$urldata = parse_url($instance['url']);
+			unset($urldata['scheme']);
+			$return[] = ltrim(Network::unparseURL($urldata), '/');
+		}
+		DBA::close($instances);
+
+		System::jsonExit($return);
+	}
+}

--- a/static/routes.config.php
+++ b/static/routes.config.php
@@ -30,6 +30,8 @@ return [
 	'/api' => [
 		'/v1' => [
 			'/follow_requests'                   => [Module\Api\Mastodon\FollowRequests::class, [R::GET         ]],
+			'/instance'                          => [Module\Api\Mastodon\Instance::class, [R::GET]],
+			'/instance/peers'                    => [Module\Api\Mastodon\Instance\Peers::class, [R::GET]],
 		],
 	],
 


### PR DESCRIPTION
This adds two widely used Mastodon endpoints that publish data about the instance and the connected systems. For the peer list I decided to only use systems that are Friendica systems or that identify as ActivityPub based systems. This endpoint is widely used in the AP world. So I thought that we should only publish systems here that are AP ready.

There is also a preparation for publishing the administrator contact. This data is in the "Account" format from Mastodon. At some point we will have a function that returns contact data in the needed format. Then we can implement it here.

There are differences on the "instance" output. The "uri" contains the scheme. This is how Pleroma is doing. And we just provide empty strings or arrays on unsupported values.