### PR TITLE
Make 2Factor "tel" field instead "number"

### DIFF
--- a/src/Module/TwoFactor/Verify.php
+++ b/src/Module/TwoFactor/Verify.php
@@ -64,7 +64,7 @@ class Verify extends BaseModule
 			'$errors_label'     => L10n::tt('Error', 'Errors', count(self::$errors)),
 			'$errors'           => self::$errors,
 			'$recovery_message' => L10n::t('Don’t have your phone? <a href="%s">Enter a two-factor recovery code</a>', '2fa/recovery'),
-			'$verify_code'      => ['verify_code', L10n::t('Please enter a code from your authentication app'), '', '', 'required', 'autofocus placeholder="000000"', 'number'],
+			'$verify_code'      => ['verify_code', L10n::t('Please enter a code from your authentication app'), '', '', 'required', 'autofocus placeholder="000000"', 'tel'],
 			'$verify_label'     => L10n::t('Verify code and complete login'),
 		]);
 	}


### PR DESCRIPTION
- because of missing copy&paste buttons at number
FollowUp #7905 #7906 

Maybe not a bug for RC, but it would be really annoying for users with android mobile phones (you couldn't use the keyboard-clipboard-button because the plain number pad doesn't contain such button)