### PR TITLE
API: Account class improved

### DIFF
--- a/src/Api/Mastodon/Account.php
+++ b/src/Api/Mastodon/Account.php
@@ -69,7 +69,7 @@ class Account
 		$account->username = $contact['nick'];
 		$account->acct = $contact['nick'];
 		$account->display_name = $contact['name'];
-		$account->locked = (bool)$apcontact['manually-approve'] ?? false;
+		$account->locked = !empty($apcontact['manually-approve']);
 		$account->created_at = DateTimeFormat::utc($contact['created'], DateTimeFormat::ATOM);
 		$account->followers_count = $apcontact['followers_count'] ?? 0;
 		$account->following_count = $apcontact['following_count'] ?? 0;

--- a/src/Api/Mastodon/Account.php
+++ b/src/Api/Mastodon/Account.php
@@ -4,6 +4,8 @@ namespace Friendica\Api\Mastodon;
 
 use Friendica\Content\Text\BBCode;
 use Friendica\Database\DBA;
+use Friendica\Model\APContact;
+use Friendica\Model\Contact;
 use Friendica\Util\DateTimeFormat;
 
 /**
@@ -65,13 +67,13 @@ class Account
 		$account->username = $contact['nick'];
 		$account->acct = $contact['nick'];
 		$account->display_name = $contact['name'];
-		$account->locked = $contact['blocked'];
+		$account->locked = false;
 		$account->created_at = DateTimeFormat::utc($contact['created'], DateTimeFormat::ATOM);
 		// No data is available from contact
 		$account->followers_count = 0;
 		$account->following_count = 0;
 		$account->statuses_count = 0;
-		$account->note = BBCode::convert($contact['about']);
+		$account->note = BBCode::convert($contact['about'], false);
 		$account->url = $contact['url'];
 		$account->avatar = $contact['avatar'];
 		$account->avatar_static = $contact['avatar'];
@@ -80,6 +82,12 @@ class Account
 		$account->header_static = '';
 		// No custom emojis per account in Friendica
 		$account->emojis = [];
+		$account->bot = ($contact['contact-type'] == Contact::TYPE_NEWS);
+
+		$apcontact = APContact::getByURL($contact['url'], false);
+		if (!empty($apcontact)) {
+			$account->locked = (bool)$apcontact['manually-approve'];
+		}
 
 		return $account;
 	}


### PR DESCRIPTION
Some fields had been filled or corrected:
* "locked" most likely indicates whether a contact works with manual contact approval
* "note" should be a HTML without OEmbed
* "bot" indicates whether this is some automatic account like the news contact type.