### PR TITLE
APContact: Added follower count, following count and count of posts

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -1,6 +1,6 @@
 -- ------------------------------------------
--- Friendica 2019.12-dev (Dalmatian Bellflower)
--- DB_UPDATE_VERSION 1324
+-- Friendica 2019.12-rc (Dalmatian Bellflower)
+-- DB_UPDATE_VERSION 1325
 -- ------------------------------------------
 
 
@@ -66,6 +66,9 @@ CREATE TABLE IF NOT EXISTS `apcontact` (
 	`pubkey` text COMMENT '',
 	`baseurl` varchar(255) COMMENT 'baseurl of the ap contact',
 	`generator` varchar(255) COMMENT 'Name of the contact\'s system',
+	`following_count` int unsigned DEFAULT 0 COMMENT 'Number of following contacts',
+	`followers_count` int unsigned DEFAULT 0 COMMENT 'Number of followers',
+	`statuses_count` int unsigned DEFAULT 0 COMMENT 'Number of posts',
 	`updated` datetime NOT NULL DEFAULT '0001-01-01 00:00:00' COMMENT '',
 	 PRIMARY KEY(`url`),
 	 INDEX `addr` (`addr`(32)),

--- a/src/Model/APContact.php
+++ b/src/Model/APContact.php
@@ -229,9 +229,7 @@ class APContact extends BaseObject
 				}
 			}
 		}
-/*
-		$apcontact['inbox'] = JsonLD::fetchElement($compacted, 'ldp:inbox', '@id');
-*/
+
 		// To-Do
 
 		// Unhandled

--- a/src/Model/APContact.php
+++ b/src/Model/APContact.php
@@ -203,6 +203,35 @@ class APContact extends BaseObject
 			$apcontact['generator'] = JsonLD::fetchElement($compacted['as:generator'], 'as:name', '@value');
 		}
 
+		if (!empty($apcontact['following'])) {
+			$data = ActivityPub::fetchContent($apcontact['following']);
+			if (!empty($data)) {
+				if (!empty($data['totalItems'])) {
+					$apcontact['following_count'] = $data['totalItems'];
+				}
+			}
+		}
+
+		if (!empty($apcontact['followers'])) {
+			$data = ActivityPub::fetchContent($apcontact['followers']);
+			if (!empty($data)) {
+				if (!empty($data['totalItems'])) {
+					$apcontact['followers_count'] = $data['totalItems'];
+				}
+			}
+		}
+
+		if (!empty($apcontact['outbox'])) {
+			$data = ActivityPub::fetchContent($apcontact['outbox']);
+			if (!empty($data)) {
+				if (!empty($data['totalItems'])) {
+					$apcontact['statuses_count'] = $data['totalItems'];
+				}
+			}
+		}
+/*
+		$apcontact['inbox'] = JsonLD::fetchElement($compacted, 'ldp:inbox', '@id');
+*/
 		// To-Do
 
 		// Unhandled

--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -34,7 +34,7 @@
 use Friendica\Database\DBA;
 
 if (!defined('DB_UPDATE_VERSION')) {
-	define('DB_UPDATE_VERSION', 1324);
+	define('DB_UPDATE_VERSION', 1325);
 }
 
 return [
@@ -102,6 +102,9 @@ return [
 			"pubkey" => ["type" => "text", "comment" => ""],
 			"baseurl" => ["type" => "varchar(255)", "comment" => "baseurl of the ap contact"],
 			"generator" => ["type" => "varchar(255)", "comment" => "Name of the contact's system"],
+			"following_count" => ["type" => "int unsigned", "default" => 0, "comment" => "Number of following contacts"],
+			"followers_count" => ["type" => "int unsigned", "default" => 0, "comment" => "Number of followers"],
+			"statuses_count" => ["type" => "int unsigned", "default" => 0, "comment" => "Number of posts"],
 			"updated" => ["type" => "datetime", "not null" => "1", "default" => DBA::NULL_DATETIME, "comment" => ""]
 		],
 		"indexes" => [


### PR DESCRIPTION
The account class of the API does contain fields for the number of followers, number of following accounts and number of posts. We now fetch this data during the probing of ActivityPub contacts.