### PR TITLE
Log a message when data isn't the expected type in GContact::updateFromOutbox

### DIFF
--- a/src/Model/GContact.php
+++ b/src/Model/GContact.php
@@ -876,7 +876,11 @@ class GContact
 			self::updateFromOutbox($outbox['first']['href'], $data);
 			return;
 		} elseif (!empty($outbox['first'])) {
-			self::updateFromOutbox($outbox['first'], $data);
+			if (is_string($outbox['first'])) {
+				self::updateFromOutbox($outbox['first'], $data);
+			} else {
+				Logger::warning('Unexpected data', ['outbox' => $outbox]);
+			}
 			return;
 		} else {
 			$items = [];


### PR DESCRIPTION
Addresses https://github.com/friendica/friendica/issues/7675#issuecomment-564468543

Additionally, if this error would have been thrown again, the offending data is logged.