### PR TITLE
Escape potential URL-containing BBCodes before running autolinker

### DIFF
--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -1507,8 +1507,29 @@ class BBCode extends BaseObject
 		$text = str_replace('[hr]', '<hr />', $text);
 
 		if (!$for_plaintext) {
+			$escaped = [];
+
+			// Escaping BBCodes susceptible to contain rogue URL we don'' want the autolinker to catch
+			$text = preg_replace_callback('#\[(url|img|audio|video|youtube|vimeo|share|attachment|iframe|bookmark).+?\[/\1\]#ism',
+				function ($matches) use (&$escaped) {
+					$return = '{escaped-' . count($escaped) . '}';
+					$escaped[] = $matches[0];
+
+					return $return;
+				},
+				$text
+			);
+
 			// Autolinker for isolated URLs
 			$text = preg_replace(Strings::autoLinkRegEx(), '[url]$1[/url]', $text);
+
+			// Restoring escaped blocks
+			$text = preg_replace_callback('/{escaped-([0-9]+)}/iU',
+				function ($matches) use ($escaped) {
+					return $escaped[intval($matches[1])] ?? $matches[0];
+				},
+				$text
+			);
 		}
 
 		// This is actually executed in Item::prepareBody()


### PR DESCRIPTION
Addresses #4451

We have been tweaking the autolinker regular expression a lot since the related issue was reported, but this is a more reliable way of avoiding unwarranted URL to link replacements.