### PR TITLE
Return early if user.uid isn't present in ACL::getFullSelectorHTML

### DIFF
--- a/src/Core/ACL.php
+++ b/src/Core/ACL.php
@@ -335,6 +335,10 @@ class ACL extends BaseObject
 	 */
 	public static function getFullSelectorHTML(Page $page, array $user = null, bool $for_federation = false, array $default_permissions = [])
 	{
+		if (empty($user['uid'])) {
+			return '';
+		}
+
 		$page->registerFooterScript(Theme::getPathForFile('asset/typeahead.js/dist/typeahead.bundle.js'));
 		$page->registerFooterScript(Theme::getPathForFile('js/friendica-tagsinput/friendica-tagsinput.js'));
 		$page->registerStylesheet(Theme::getPathForFile('js/friendica-tagsinput/friendica-tagsinput.css'));


### PR DESCRIPTION
- Addresses https://github.com/friendica/friendica/issues/7675#issuecomment-565533824