### PR TITLE
Issue 6867: Only display direct mentions in the mentions API

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -1,6 +1,6 @@
 -- ------------------------------------------
 -- Friendica 2019.12-rc (Dalmatian Bellflower)
--- DB_UPDATE_VERSION 1325
+-- DB_UPDATE_VERSION 1326
 -- ------------------------------------------
 
 
@@ -637,6 +637,7 @@ CREATE TABLE IF NOT EXISTS `item` (
 	 INDEX `resource-id` (`resource-id`),
 	 INDEX `deleted_changed` (`deleted`,`changed`),
 	 INDEX `uid_wall_changed` (`uid`,`wall`,`changed`),
+	 INDEX `mention_uid_id` (`mention`,`uid`,`id`),
 	 INDEX `uid_eventid` (`uid`,`event-id`),
 	 INDEX `icid` (`icid`),
 	 INDEX `iaid` (`iaid`),

--- a/include/api.php
+++ b/include/api.php
@@ -2165,8 +2165,8 @@ function api_statuses_mentions($type)
 
 	$start = max(0, ($page - 1) * $count);
 
-	$condition = ["`uid` = ? AND `gravity` IN (?, ?) AND `item`.`id` > ? AND `author-id` != ?
-		AND `item`.`parent` IN (SELECT `iid` FROM `thread` WHERE `thread`.`uid` = ? AND `thread`.`mention` AND NOT `thread`.`ignored`)",
+	$condition = ["`uid` = ? AND `gravity` IN (?, ?) AND `item`.`id` > ? AND `author-id` != ? AND `mention`
+		AND `item`.`parent` IN (SELECT `iid` FROM `thread` WHERE `thread`.`uid` = ? AND NOT `thread`.`ignored`)",
 		api_user(), GRAVITY_PARENT, GRAVITY_COMMENT, $since_id, $user_info['pid'], api_user()];
 
 	if ($max_id > 0) {

--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -34,7 +34,7 @@
 use Friendica\Database\DBA;
 
 if (!defined('DB_UPDATE_VERSION')) {
-	define('DB_UPDATE_VERSION', 1325);
+	define('DB_UPDATE_VERSION', 1326);
 }
 
 return [
@@ -705,6 +705,7 @@ return [
 			"resource-id" => ["resource-id"],
 			"deleted_changed" => ["deleted", "changed"],
 			"uid_wall_changed" => ["uid", "wall", "changed"],
+			"mention_uid_id" => ["mention", "uid", "id"],
 			"uid_eventid" => ["uid", "event-id"],
 			"icid" => ["icid"],
 			"iaid" => ["iaid"],


### PR DESCRIPTION
This handles issue https://github.com/friendica/friendica/issues/6867 - but does not completely fixes it.

This does only cover direct mentions, but no direct answers to our post. To make this, we should add something to the "user-item" table like I described in the issue.