### PR TITLE
Issue 7659: Udate the "user-contact" value with the "contact" values

### DIFF
--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -34,7 +34,7 @@
 use Friendica\Database\DBA;
 
 if (!defined('DB_UPDATE_VERSION')) {
-	define('DB_UPDATE_VERSION', 1326);
+	define('DB_UPDATE_VERSION', 1327);
 }
 
 return [

--- a/update.php
+++ b/update.php
@@ -396,3 +396,15 @@ function update_1323()
 	return Update::SUCCESS;
 }
 
+function update_1327()
+{
+	$contacts = DBA::select('contact', ['uid', 'id', 'blocked', 'readonly'], ["`uid` != ? AND (`blocked` OR `readonly`) AND NOT `pending`", 0]);
+	while ($contact = DBA::fetch($contacts)) {
+		Contact::setBlockedForUser($contact['id'], $contact['uid'], $contact['blocked']);
+		Contact::setIgnoredForUser($contact['id'], $contact['uid'], $contact['readonly']);
+	}
+	DBA::close($contacts);
+
+	return Update::SUCCESS;
+}
+


### PR DESCRIPTION
This is a follow up for issue #7659

We now ensure that the "user-contact" table contains the values from the "contact" table for ignored and blocked contacts.