### PR TITLE
Issue 7685: Just forward on remoteauth for non legacy-DFRN and other contacts

### DIFF
--- a/include/api.php
+++ b/include/api.php
@@ -5104,10 +5104,10 @@ function api_friendica_remoteauth()
 
 	$cid = $contact['id'];
 
-	$dfrn_id = $contact['issued-id'] ?? $contact['dfrn-id'];
+	$dfrn_id = $contact['issued-id'] ?: $contact['dfrn-id'];
 
 	if (($contact['network'] !== Protocol::DFRN) || empty($dfrn_id)) {
-		System::externalRedirect($url ?? $c_url);
+		System::externalRedirect($url ?: $c_url);
 	}
 
 	if ($contact['duplex'] && $contact['issued-id']) {

--- a/include/api.php
+++ b/include/api.php
@@ -5098,14 +5098,17 @@ function api_friendica_remoteauth()
 	// traditional DFRN
 
 	$contact = DBA::selectFirst('contact', [], ['uid' => api_user(), 'nurl' => $c_url]);
-
-	if (!DBA::isResult($contact) || ($contact['network'] !== Protocol::DFRN)) {
+	if (!DBA::isResult($contact)) {
 		throw new BadRequestException("Unknown contact");
 	}
 
 	$cid = $contact['id'];
 
 	$dfrn_id = $contact['issued-id'] ?? $contact['dfrn-id'];
+
+	if (($contact['network'] !== Protocol::DFRN) || empty($dfrn_id)) {
+		System::externalRedirect($url ?? $c_url);
+	}
 
 	if ($contact['duplex'] && $contact['issued-id']) {
 		$orig_id = $contact['issued-id'];


### PR DESCRIPTION
Fixes https://github.com/friendica/friendica/issues/7685
The remoteauth can only work for legacy DFRN contacts. For all other contacts (not only AP and Diaspora, but also non legacy DFRN contacts) this endpoint can't do anything.

So we just forward now.

In the future we possibly can use the magic auth there as well. But this has to be tested well and is no RC task.