### PR TITLE
Fix: Newer Friendica servers had been detected as ActivityPub

### DIFF
--- a/src/Model/GServer.php
+++ b/src/Model/GServer.php
@@ -549,7 +549,7 @@ class GServer
 				$protocols[$protocol] = true;
 			}
 
-			if (!empty($protocols['friendica'])) {
+			if (!empty($protocols['dfrn'])) {
 				$server['network'] = Protocol::DFRN;
 			} elseif (!empty($protocols['activitypub'])) {
 				$server['network'] = Protocol::ACTIVITYPUB;

--- a/src/Module/NodeInfo.php
+++ b/src/Module/NodeInfo.php
@@ -126,7 +126,7 @@ class NodeInfo extends BaseModule
 		$nodeinfo = [
 			'version'           => '1.0',
 			'software'          => [
-				'name'    => 'friendica',
+				'name'    => 'Friendica',
 				'version' => FRIENDICA_VERSION . '-' . DB_UPDATE_VERSION,
 			],
 			'protocols'         => [
@@ -191,7 +191,7 @@ class NodeInfo extends BaseModule
 		$nodeinfo = [
 			'version'           => '2.0',
 			'software'          => [
-				'name'    => 'friendica',
+				'name'    => 'Friendica',
 				'version' => FRIENDICA_VERSION . '-' . DB_UPDATE_VERSION,
 			],
 			'protocols'         => ['dfrn', 'activitypub'],


### PR DESCRIPTION
In version 2 of Nodeinfo Friendica is defined as "dfrn" and not "friendica".