### PR TITLE
Update Mastodon API documentation

### DIFF
--- a/doc/API-Mastodon.md
+++ b/doc/API-Mastodon.md
@@ -15,19 +15,21 @@ These endpoints use the [Mastodon API entities](https://docs.joinmastodon.org/en
 
 ## Implemented endpoints
 
-- [GET /api/v1/follow_requests](https://docs.joinmastodon.org/methods/accounts/follow_requests#pending-follows)
-- [POST /api/v1/follow_requests/:id/authorize](https://docs.joinmastodon.org/methods/accounts/follow_requests#accept-follow)
-    - Returns a [Relationship](https://docs.joinmastodon.org/entities/relationship) object.
-- [POST /api/v1/follow_requests/:id/reject](https://docs.joinmastodon.org/methods/accounts/follow_requests#reject-follow)
-    - Returns a [Relationship](https://docs.joinmastodon.org/entities/relationship) object.
-- POST /api/v1/follow_requests/:id/ignore
+- [`GET /api/v1/follow_requests`](https://docs.joinmastodon.org/methods/accounts/follow_requests#pending-follows)
+    - Returned IDs are specific to follow requests
+- [`POST /api/v1/follow_requests/:id/authorize`](https://docs.joinmastodon.org/methods/accounts/follow_requests#accept-follow)
+    - `:id` is a follow request ID, not a regular account id
+- [`POST /api/v1/follow_requests/:id/reject`](https://docs.joinmastodon.org/methods/accounts/follow_requests#reject-follow)
+    - `:id` is a follow request ID, not a regular account id
+- `POST /api/v1/follow_requests/:id/ignore`
     - Friendica-specific, hides the follow request from the list and prevents the remote contact from retrying.
+    - `:id` is a follow request ID, not a regular account id
     - Returns a [Relationship](https://docs.joinmastodon.org/entities/relationship) object.
-    
-
-- [GET /api/v1/instance](https://docs.joinmastodon.org/methods/instance#fetch-instance)
-- GET /api/v1/instance/peers - undocumented, but implemented by Mastodon and Pleroma
 
 
+- [`GET /api/v1/instance`](https://docs.joinmastodon.org/methods/instance#fetch-instance)
+- [`GET /api/v1/instance/peers`](https://docs.joinmastodon.org/methods/instance#list-of-connected-domains)
 
 ## Non-implemented endpoints
+
+- [`GET /api/v1/instance/activity`](https://docs.joinmastodon.org/methods/instance#weekly-activity)

--- a/doc/Home.md
+++ b/doc/Home.md
@@ -55,7 +55,7 @@ Friendica Documentation and Resources
 	* [Move classes to `src`](help/Developer-How-To-Move-Classes-to-src)
 	* [Run tests](help/Tests)
 * Reference
-	* [Twitter/GNU Social API Functions](help/api)
+	* [API endpoints](help/api)
 	* [Code (Doxygen generated - sets cookies)](doc/html/)
 	* [Protocol Documentation](help/Protocol)
 	* [Database schema documentation](help/database)


### PR DESCRIPTION
Follow-up to #7982

- Change endpoint label style to monospace
- Explicit expected IDs for follow_requests endpoints
- Add official documentation link for api/v1/instance/peers
- Add unimplemented endpoint api/v1/instance/activity