### PR TITLE
Add timezone information to logger timestamp

### DIFF
--- a/src/Util/Logger/StreamLogger.php
+++ b/src/Util/Logger/StreamLogger.php
@@ -138,7 +138,7 @@ class StreamLogger extends AbstractLogger
 		$record = array_merge($record, ['uid' => $this->logUid, 'process_id' => $this->pid]);
 		$logMessage = '';
 
-		$logMessage .= DateTimeFormat::utcNow() . ' ';
+		$logMessage .= DateTimeFormat::utcNow(DateTimeFormat::ATOM) . ' ';
 		$logMessage .= $this->channel . ' ';
 		$logMessage .= '[' . strtoupper($level) . ']: ';
 		$logMessage .= $this->psrInterpolate($message, $context) . ' ';


### PR DESCRIPTION
Addresses #7994

We were wrongly using a timezone-less MySQL date/time format for the log lines. We now use the ISO 8601 format with the timezone.

This is a potentially backward-breaking change for log monitoring, so this change should be advertised when merged and when released.