### PR TITLE
Remove group add restrictions

### DIFF
--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -406,11 +406,6 @@ class Contact extends BaseObject
 		}
 
 		DBA::update('user-contact', ['blocked' => $blocked], ['cid' => $cdata['public'], 'uid' => $uid], true);
-
-		if ($blocked) {
-			// Blocked contact can't be in any group
-			self::removeFromGroups($cid);
-		}
 	}
 
 	/**

--- a/src/Module/Group.php
+++ b/src/Module/Group.php
@@ -87,13 +87,9 @@ class Group extends BaseModule
 					throw new \Exception(L10n::t('Unknown group.'), 404);
 				}
 
-				$contact = DBA::selectFirst('contact', ['pending', 'blocked', 'deleted'], ['id' => $contact_id, 'uid' => local_user()]);
+				$contact = DBA::selectFirst('contact', ['deleted'], ['id' => $contact_id, 'uid' => local_user()]);
 				if (!DBA::isResult($contact)) {
 					throw new \Exception(L10n::t('Contact not found.'), 404);
-				}
-
-				if ($contact['pending']) {
-					throw new \Exception(L10n::t('Contact is unavailable.'), 400);
 				}
 
 				if ($contact['deleted']) {
@@ -102,19 +98,17 @@ class Group extends BaseModule
 
 				switch($command) {
 					case 'add':
-						if ($contact['blocked']) {
-							throw new \Exception(L10n::t('Contact is blocked, unable to add it to a group.'), 400);
-						}
-
 						if (!Model\Group::addMember($group_id, $contact_id)) {
 							throw new \Exception(L10n::t('Unable to add the contact to the group.'), 500);
 						}
+
 						$message = L10n::t('Contact successfully added to group.');
 						break;
 					case 'remove':
 						if (!Model\Group::removeMember($group_id, $contact_id)) {
 							throw new \Exception(L10n::t('Unable to remove the contact from the group.'), 500);
 						}
+
 						$message = L10n::t('Contact successfully removed from group.');
 						break;
 					default:


### PR DESCRIPTION
Closes #7991

Beyond the problem the related issue depicts about pending accounts, I also removed the restriction on blocked accounts, as well as the auto-removal from groups on contact block.

The reasoning is that these restrictions remove agency from the user. Groups are a personal thing and don't need to be artificially restricted like we're doing right now. Blocked and pending contacts don't appear in group lists anyway, whether for display or delivery, so even in pending or blocked accounts are added to contact groups, there won't be any unwanted interaction with them.

Additionally, we don't have any user documentation/warning about the auto-removal from groups, which could have been a bad surprise for users just wanting to block a contact.