### PR TITLE
Add profile url search

### DIFF
--- a/src/Module/BaseSearchModule.php
+++ b/src/Module/BaseSearchModule.php
@@ -22,7 +22,7 @@ use Friendica\Util\Strings;
 class BaseSearchModule extends BaseModule
 {
 	/**
-	 * Performs a search with an optional prefix
+	 * Performs a contact search with an optional prefix
 	 *
 	 * @param string $search Search query
 	 * @param string $prefix A optional prefix (e.g. @ or !) for searching
@@ -31,7 +31,7 @@ class BaseSearchModule extends BaseModule
 	 * @throws HTTPException\InternalServerErrorException
 	 * @throws \ImagickException
 	 */
-	public static function performSearch($search, $prefix = '')
+	public static function performContactSearch($search, $prefix = '')
 	{
 		$a      = self::getApp();
 		$config = $a->getConfig();

--- a/src/Module/Search/Directory.php
+++ b/src/Module/Search/Directory.php
@@ -31,6 +31,6 @@ class Directory extends BaseSearchModule
 		$a->page['aside'] .= Widget::findPeople();
 		$a->page['aside'] .= Widget::follow();
 
-		return self::performSearch($search);
+		return self::performContactSearch($search);
 	}
 }

--- a/src/Module/Search/Index.php
+++ b/src/Module/Search/Index.php
@@ -88,7 +88,7 @@ class Index extends BaseSearchModule
 		}
 
 		if (strpos($search, '@') === 0 || strpos($search, '!') === 0) {
-			return self::performSearch($search);
+			return self::performContactSearch($search);
 		}
 
 		if (parse_url($search, PHP_URL_SCHEME) != '') {
@@ -109,9 +109,9 @@ class Index extends BaseSearchModule
 					$tag = true;
 					break;
 				case 'contacts':
-					return self::performSearch($search, '@');
+					return self::performContactSearch($search, '@');
 				case 'forums':
-					return self::performSearch($search, '!');
+					return self::performContactSearch($search, '!');
 			}
 		}
 

--- a/src/Module/Search/Index.php
+++ b/src/Module/Search/Index.php
@@ -3,6 +3,7 @@
 namespace Friendica\Module\Search;
 
 use Friendica\App\Arguments;
+use Friendica\App\BaseURL;
 use Friendica\Content\Nav;
 use Friendica\Content\Pager;
 use Friendica\Content\Text\HTML;
@@ -96,11 +97,15 @@ class Index extends BaseSearchModule
 		}
 
 		if (parse_url($search, PHP_URL_SCHEME) != '') {
-			$id = Item::fetchByLink($search);
-			if (!empty($id)) {
-				$item = Item::selectFirst(['guid'], ['id' => $id]);
+			/** @var BaseURL $baseURL */
+			$baseURL = self::getClass(BaseURL::class);
+
+			// Post URL search
+			$item_id = Item::fetchByLink($search);
+			if (!empty($item_id)) {
+				$item = Item::selectFirst(['guid'], ['id' => $item_id]);
 				if (DBA::isResult($item)) {
-					self::getApp()->internalRedirect('display/' . $item['guid']);
+					$baseURL->redirect('display/' . $item['guid']);
 				}
 			}
 		}

--- a/src/Module/Search/Index.php
+++ b/src/Module/Search/Index.php
@@ -82,6 +82,10 @@ class Index extends BaseSearchModule
 			'$content' => HTML::search($search, 'search-box', false)
 		]);
 
+		if (!$search) {
+			return $o;
+		}
+
 		if (strpos($search, '#') === 0) {
 			$tag = true;
 			$search = substr($search, 1);
@@ -113,10 +117,6 @@ class Index extends BaseSearchModule
 				case 'forums':
 					return self::performContactSearch($search, '!');
 			}
-		}
-
-		if (!$search) {
-			return $o;
 		}
 
 		$tag = $tag || Config::get('system', 'only_tag_search');


### PR DESCRIPTION
Closes #7984 

This PR adds the profile URL search like we do with post URLs: it redirects to the contact page if it found one at the URL.

I separated the anonymous search from the logged in search to avoid contact probes by anonymous users. @annando can you please check to make sure I used the right `Model\Contact` method for this purpose?

Corollary question: Should I separate the post URL search between anonymous and logged in users?

Or third option, should those searches be logged-users only?