### PR TITLE
Additionally display the protocol together with the network

### DIFF
--- a/include/api.php
+++ b/include/api.php
@@ -613,7 +613,7 @@ function api_get_user(App $a, $contact_id = null)
 				'id_str' => (string) $contact["id"],
 				'name' => $contact["name"],
 				'screen_name' => (($contact['nick']) ? $contact['nick'] : $contact['name']),
-				'location' => ($contact["location"] != "") ? $contact["location"] : ContactSelector::networkToName($contact['network'], $contact['url']),
+				'location' => ($contact["location"] != "") ? $contact["location"] : ContactSelector::networkToName($contact['network'], $contact['url'], $contact['protocol']),
 				'description' => BBCode::toPlaintext($contact["about"]),
 				'profile_image_url' => $contact["micro"],
 				'profile_image_url_https' => $contact["micro"],
@@ -679,7 +679,7 @@ function api_get_user(App $a, $contact_id = null)
 	} elseif (!empty($uinfo[0]["location"])) {
 		$location = $uinfo[0]["location"];
 	} else {
-		$location = ContactSelector::networkToName($uinfo[0]['network'], $uinfo[0]['url']);
+		$location = ContactSelector::networkToName($uinfo[0]['network'], $uinfo[0]['url'], $uinfo[0]['protocol']);
 	}
 
 	$ret = [
@@ -3056,9 +3056,9 @@ function api_format_item($item, $type = "json", $status_user = null, $author_use
 	}
 
 	if ($status["source"] == 'web') {
-		$status["source"] = ContactSelector::networkToName($item['network'], $item['author-link']);
-	} elseif (ContactSelector::networkToName($item['network'], $item['author-link']) != $status["source"]) {
-		$status["source"] = trim($status["source"].' ('.ContactSelector::networkToName($item['network'], $item['author-link']).')');
+		$status["source"] = ContactSelector::networkToName($item['author-network'], $item['author-link'], $item['network']);
+	} elseif (ContactSelector::networkToName($item['author-network'], $item['author-link'], $item['network']) != $status["source"]) {
+		$status["source"] = trim($status["source"].' ('.ContactSelector::networkToName($item['author-network'], $item['author-link'], $item['network']).')');
 	}
 
 	$retweeted_item = [];

--- a/include/conversation.php
+++ b/include/conversation.php
@@ -684,7 +684,7 @@ function conversation(App $a, array $items, Pager $pager, $mode, $update, $previ
 					'id' => ($preview ? 'P0' : $item['id']),
 					'guid' => ($preview ? 'Q0' : $item['guid']),
 					'network' => $item['network'],
-					'network_name' => ContactSelector::networkToName($item['network'], $item['author-link']),
+					'network_name' => ContactSelector::networkToName($item['author-network'], $item['author-link'], $item['network']),
 					'network_icon' => ContactSelector::networkToIcon($item['network'], $item['author-link']),
 					'linktitle' => L10n::t('View %s\'s profile @ %s', $profile_name, $item['author-link']),
 					'profile_url' => $profile_link,

--- a/src/Content/ContactSelector.php
+++ b/src/Content/ContactSelector.php
@@ -105,12 +105,13 @@ class ContactSelector
 	}
 
 	/**
-	 * @param string $network network
-	 * @param string $profile optional, default empty
+	 * @param string $network  network
+	 * @param string $profile  optional, default empty
+	 * @param string $protocol optional, default empty
 	 * @return string
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
-	public static function networkToName($network, $profile = "")
+	public static function networkToName($network, $profile = '', $protocol = '')
 	{
 		$nets = [
 			Protocol::DFRN      =>   L10n::t('DFRN'),
@@ -160,6 +161,10 @@ class ContactSelector
 					}
 				}
 			}
+		}
+
+		if (!empty($protocol) && ($protocol != $network)) {
+			$networkname = L10n::t('%s (via %s)', $networkname, self::networkToName($protocol));
 		}
 
 		return $networkname;

--- a/src/Content/ContactSelector.php
+++ b/src/Content/ContactSelector.php
@@ -105,9 +105,9 @@ class ContactSelector
 	}
 
 	/**
-	 * @param string $network  network
+	 * @param string $network  network of the contact
 	 * @param string $profile  optional, default empty
-	 * @param string $protocol optional, default empty
+	 * @param string $protocol (Optional) Protocol that is used for the transmission
 	 * @return string
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */

--- a/src/Module/Contact.php
+++ b/src/Module/Contact.php
@@ -528,7 +528,7 @@ class Contact extends BaseModule
 
 			$poll_enabled = in_array($contact['network'], [Protocol::DFRN, Protocol::OSTATUS, Protocol::FEED, Protocol::MAIL]);
 
-			$nettype = L10n::t('Network type: %s', ContactSelector::networkToName($contact['network'], $contact['url']));
+			$nettype = L10n::t('Network type: %s', ContactSelector::networkToName($contact['network'], $contact['url'], $contact['protocol']));
 
 			// tabs
 			$tab_str = self::getTabsHTML($a, $contact, 3);
@@ -1043,7 +1043,7 @@ class Contact extends BaseModule
 			'sparkle'   => $sparkle,
 			'itemurl'   => ($rr['addr'] ?? '') ?: $rr['url'],
 			'url'       => $url,
-			'network'   => ContactSelector::networkToName($rr['network'], $rr['url']),
+			'network'   => ContactSelector::networkToName($rr['network'], $rr['url'], $rr['protocol']),
 			'nick'      => $rr['nick'],
 		];
 	}

--- a/src/Module/Profile/Contacts.php
+++ b/src/Module/Profile/Contacts.php
@@ -102,7 +102,7 @@ class Contacts extends BaseModule
 				'url'          => Contact::magicLink($contact['url']),
 				'sparkle'      => '',
 				'itemurl'      => $contact_details['addr'] ? : $contact['url'],
-				'network'      => ContactSelector::networkToName($contact['network'], $contact['url']),
+				'network'      => ContactSelector::networkToName($contact['network'], $contact['url'], $contact['protocol']),
 			];
 		}
 

--- a/src/Object/Post.php
+++ b/src/Object/Post.php
@@ -452,7 +452,7 @@ class Post extends BaseObject
 			'thread_level'    => $thread_level,
 			'edited'          => $edited,
 			'network'         => $item["network"],
-			'network_name'    => ContactSelector::networkToName($item['network'], $item['author-link']),
+			'network_name'    => ContactSelector::networkToName($item['author-network'], $item['author-link'], $item['network']),
 			'network_icon'    => ContactSelector::networkToIcon($item['network'], $item['author-link']),
 			'received'        => $item['received'],
 			'commented'       => $item['commented'],


### PR DESCRIPTION
This is used for two situations:

1. Display that a post from a Friendica contact had been transmitted via some other protocol (like ActivityPub, but also Diaspora)
2. Display that a contact had been established via AP.