### PR TITLE
Don't create contacts for unknown networks / improved content fetching

### DIFF
--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -1514,7 +1514,7 @@ class Contact extends BaseObject
 			$data = array_merge($data, $default);
 		}
 
-		if (empty($data)) {
+		if (empty($data) || ($data['network'] == Protocol::PHANTOM)) {
 			return 0;
 		}
 


### PR DESCRIPTION
When the network type is unknown, we mustn't create the contact. Also we now are using always our curl class to fetch content.