### PR TITLE
Session - Remove unneeded cookie parameter

### DIFF
--- a/src/Core/Session/AbstractSession.php
+++ b/src/Core/Session/AbstractSession.php
@@ -3,21 +3,11 @@
 
 namespace Friendica\Core\Session;
 
-use Friendica\Model\User\Cookie;
-
 /**
  * Contains the base methods for $_SESSION interaction
  */
 class AbstractSession
 {
-	/** @var Cookie */
-	protected $cookie;
-
-	public function __construct( Cookie $cookie)
-	{
-		$this->cookie = $cookie;
-	}
-
 	/**
 	 * {@inheritDoc}
 	 */

--- a/src/Core/Session/Memory.php
+++ b/src/Core/Session/Memory.php
@@ -2,8 +2,6 @@
 
 namespace Friendica\Core\Session;
 
-use Friendica\Model\User\Cookie;
-
 /**
  * Usable for backend processes (daemon/worker) and testing
  *
@@ -11,10 +9,8 @@ use Friendica\Model\User\Cookie;
  */
 final class Memory extends AbstractSession implements ISession
 {
-	public function __construct(Cookie $cookie)
+	public function __construct()
 	{
-		parent::__construct($cookie);
-
 		// Backward compatibility until all Session variables are replaced
 		// with the Session class
 		$_SESSION = [];

--- a/src/Core/Session/Native.php
+++ b/src/Core/Session/Native.php
@@ -11,10 +11,8 @@ use SessionHandlerInterface;
  */
 final class Native extends AbstractSession implements ISession
 {
-	public function __construct(App\BaseURL $baseURL, Cookie $cookie, SessionHandlerInterface $handler = null)
+	public function __construct(App\BaseURL $baseURL, SessionHandlerInterface $handler = null)
 	{
-		parent::__construct($cookie);
-
 		ini_set('session.gc_probability', 50);
 		ini_set('session.use_only_cookies', 1);
 		ini_set('session.cookie_httponly', (int)Cookie::HTTPONLY);

--- a/src/Factory/SessionFactory.php
+++ b/src/Factory/SessionFactory.php
@@ -9,7 +9,6 @@ use Friendica\Core\Config\Configuration;
 use Friendica\Core\Session;
 use Friendica\Core\System;
 use Friendica\Database\Database;
-use Friendica\Model\User\Cookie;
 use Friendica\Util\Profiler;
 use Psr\Log\LoggerInterface;
 
@@ -31,7 +30,6 @@ class SessionFactory
 	 * @param App\Mode        $mode
 	 * @param App\BaseURL     $baseURL
 	 * @param Configuration   $config
-	 * @param Cookie          $cookie
 	 * @param Database        $dba
 	 * @param ICache          $cache
 	 * @param LoggerInterface $logger
@@ -39,14 +37,14 @@ class SessionFactory
 	 *
 	 * @return Session\ISession
 	 */
-	public function createSession(App\Mode $mode, App\BaseURL $baseURL, Configuration $config, Cookie $cookie, Database $dba, ICache $cache, LoggerInterface $logger, Profiler $profiler, array $server = [])
+	public function createSession(App\Mode $mode, App\BaseURL $baseURL, Configuration $config, Database $dba, ICache $cache, LoggerInterface $logger, Profiler $profiler, array $server = [])
 	{
 		$stamp1  = microtime(true);
 		$session = null;
 
 		try {
 			if ($mode->isInstall() || $mode->isBackend()) {
-				$session = new Session\Memory($cookie);
+				$session = new Session\Memory();
 			} else {
 				$session_handler = $config->get('system', 'session_handler', self::HANDLER_DEFAULT);
 				$handler = null;
@@ -65,7 +63,7 @@ class SessionFactory
 						break;
 				}
 
-				$session = new Session\Native($baseURL, $cookie, $handler);
+				$session = new Session\Native($baseURL, $handler);
 			}
 		} finally {
 			$profiler->saveTimestamp($stamp1, 'parser', System::callstack());


### PR DESCRIPTION
At first I needed it for something .. But I moved the whole logic to `Authentication::withSession()` and forgot to remove the parameter ;-)