### PR TITLE
Add missing constructor parameter to User\Cookie in dependencies.config

### DIFF
--- a/static/dependencies.config.php
+++ b/static/dependencies.config.php
@@ -6,9 +6,11 @@ use Friendica\Core\Cache;
 use Friendica\Core\Config;
 use Friendica\Core\L10n\L10n;
 use Friendica\Core\Lock\ILock;
+use Friendica\Core\Process;
 use Friendica\Core\Session\ISession;
 use Friendica\Database\Database;
 use Friendica\Factory;
+use Friendica\Model\User\Cookie;
 use Friendica\Util;
 use Psr\Log\LoggerInterface;
 
@@ -82,7 +84,7 @@ return [
 	],
 	Database::class                 => [
 		'constructParams' => [
-			[DICE::INSTANCE => \Psr\Log\NullLogger::class],
+			[Dice::INSTANCE => \Psr\Log\NullLogger::class],
 			$_SERVER,
 		],
 	],
@@ -162,7 +164,7 @@ return [
 			['determineModule', [], Dice::CHAIN_CALL],
 		],
 	],
-	Friendica\Core\Process::class => [
+	Process::class => [
 		'constructParams' => [
 			[Dice::INSTANCE => '$basepath'],
 		],
@@ -187,4 +189,9 @@ return [
 			['start', [], Dice::CHAIN_CALL],
 		],
 	],
+	Cookie::class => [
+		'constructParams' => [
+			$_SERVER, $_COOKIE
+		],
+	]
 ];


### PR DESCRIPTION
Follow-up to #7907 

Fixes Remember Me feature, the only that uses the cookie value.

Addresses https://friendica.mrpetovan.com/display/735a2029-815e-0968-df34-4a0182080247