### PR TITLE
Don't add contacts when not needed

### DIFF
--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -269,9 +269,9 @@ class Contact
 	 * @brief Get the basepath for a given contact link
 	 *
 	 * @param string $url The contact link
+	 * @param boolean $dont_update Don't update the contact
 	 *
 	 * @return string basepath
-	 * @return boolean $dont_update Don't update the contact
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 * @throws \ImagickException
 	 */

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -277,21 +277,29 @@ class Contact
 	 */
 	public static function getBasepath($url, $dont_update = false)
 	{
-		$contact = DBA::selectFirst('contact', ['baseurl'], ['uid' => 0, 'nurl' => Strings::normaliseLink($url)]);
+		$contact = DBA::selectFirst('contact', ['id', 'baseurl'], ['uid' => 0, 'nurl' => Strings::normaliseLink($url)]);
+		if (!DBA::isResult($contact)) {
+			return '';
+		}
+
 		if (!empty($contact['baseurl'])) {
 			return $contact['baseurl'];
 		} elseif ($dont_update) {
 			return '';
 		}
 
-		self::updateFromProbeByURL($url, true);
+		// Update the existing contact
+		self::updateFromProbe($contact['id'], '', true);
 
-		$contact = DBA::selectFirst('contact', ['baseurl'], ['uid' => 0, 'nurl' => Strings::normaliseLink($url)]);
-		if (!empty($contact['baseurl'])) {
-			return $contact['baseurl'];
+		// And fetch the result
+		$contact = DBA::selectFirst('contact', ['baseurl'], ['id' => $contact['id']]);
+		if (empty($contact['baseurl'])) {
+			Logger::info('No baseurl for contact', ['url' => $url]);
+			return '';
 		}
 
-		return '';
+		Logger::info('Found baseurl for contact', ['url' => $url, 'baseurl' => $contact['baseurl']]);
+		return $contact['baseurl'];
 	}
 
 	/**

--- a/src/Model/GContact.php
+++ b/src/Model/GContact.php
@@ -1128,13 +1128,13 @@ class GContact
 		self::update($gcontact);
 	}
 
-		/**
+	/**
 	 * @brief Get the basepath for a given contact link
 	 *
 	 * @param string $url The gcontact link
+	 * @param boolean $dont_update Don't update the contact
 	 *
 	 * @return string basepath
-	 * @return boolean $dont_update Don't update the contact
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 * @throws \ImagickException
 	 */

--- a/src/Model/GServer.php
+++ b/src/Model/GServer.php
@@ -44,7 +44,7 @@ class GServer
 	public static function reachable(string $profile, string $server = '', string $network = '', bool $force = false)
 	{
 		if ($server == '') {
-			$server = Contact::getBasepath($profile);
+			$server = GContact::getBasepath($profile);
 		}
 
 		if ($server == '') {

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -1133,12 +1133,6 @@ class Diaspora
 	{
 		$cid = Contact::getIdForURL($handle, $uid);
 		if (!$cid) {
-			$handle_parts = explode("@", $handle);
-			$nurl_sql = "%%://" . $handle_parts[1] . "%%/profile/" . $handle_parts[0];
-			$cid = Contact::getIdForURL($nurl_sql, $uid);
-		}
-
-		if (!$cid) {
 			Logger::log("Haven't found a contact for user " . $uid . " and handle " . $handle, Logger::DEBUG);
 			return false;
 		}

--- a/src/Worker/SearchDirectory.php
+++ b/src/Worker/SearchDirectory.php
@@ -10,7 +10,6 @@ use Friendica\Core\Logger;
 use Friendica\Core\Protocol;
 use Friendica\Database\DBA;
 use Friendica\Model\GContact;
-use Friendica\Model\Contact;
 use Friendica\Model\GServer;
 use Friendica\Network\Probe;
 use Friendica\Util\Network;
@@ -55,7 +54,7 @@ class SearchDirectory
 					continue;
 				}
 
-				$server_url = Contact::getBasepath($jj->url);
+				$server_url = GContact::getBasepath($jj->url, true);
 				if ($server_url != '') {
 					if (!GServer::check($server_url)) {
 						Logger::info("Friendica server doesn't answer.", ['server' => $server_url]);

--- a/src/Worker/UpdateGContacts.php
+++ b/src/Worker/UpdateGContacts.php
@@ -9,7 +9,7 @@ use Friendica\Core\Logger;
 use Friendica\Core\Protocol;
 use Friendica\Core\Worker;
 use Friendica\Database\DBA;
-use Friendica\Model\Contact;
+use Friendica\Model\GContact;
 use Friendica\Model\GServer;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Strings;
@@ -53,7 +53,7 @@ class UpdateGContacts
 				continue;
 			}
 
-			$server_url = Contact::getBasepath($contact['url']);
+			$server_url = GContact::getBasepath($contact['url'], true);
 			$force_update = false;
 
 			if (!empty($contact['server_url'])) {


### PR DESCRIPTION
In PR #8033 I added some logging for contacts that couldn't been added. Today I had a look at it and realized that many public contacts had been added without any need doing so.

The most often reason had been the function to fetch the basepath of a profile. This had been called from the gcontact/gserver part, so it has to stay there and shouldn't caused "contact" entries from being added.

Also some old ugly (and non working) code in the Diaspora part had been removed.