### PR TITLE
Fix BBCode::scaleExternalImage

### DIFF
--- a/mod/item.php
+++ b/mod/item.php
@@ -509,7 +509,7 @@ function item_post(App $a) {
 	// Fold multi-line [code] sequences
 	$body = preg_replace('/\[\/code\]\s*\[code\]/ism', "\n", $body);
 
-	$body = BBCode::scaleExternalImages($body, false);
+	$body = BBCode::scaleExternalImages($body);
 
 	// Setting the object type if not defined before
 	if (!$objecttype) {

--- a/mod/item.php
+++ b/mod/item.php
@@ -246,7 +246,7 @@ function item_post(App $a) {
 		$app               = $orig_post['app'];
 		$categories        = $orig_post['file'];
 		$title             = Strings::escapeTags(trim($_REQUEST['title']));
-		$body              = Strings::escapeHtml(trim($body));
+		$body              = trim($body);
 		$private           = $orig_post['private'];
 		$pubmail_enabled   = $orig_post['pubmail'];
 		$network           = $orig_post['network'];
@@ -285,7 +285,7 @@ function item_post(App $a) {
 		$coord             = Strings::escapeTags(trim($_REQUEST['coord']    ?? ''));
 		$verb              = Strings::escapeTags(trim($_REQUEST['verb']     ?? ''));
 		$emailcc           = Strings::escapeTags(trim($_REQUEST['emailcc']  ?? ''));
-		$body              = Strings::escapeHtml(trim($body));
+		$body              = trim($body);
 		$network           = Strings::escapeTags(trim(($_REQUEST['network']  ?? '') ?: Protocol::DFRN));
 		$guid              = System::createUUID();
 

--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -436,13 +436,8 @@ class BBCode
 		}
 	}
 
-	public static function scaleExternalImages($srctext, $include_link = true, $scale_replace = false)
+	public static function scaleExternalImages($srctext)
 	{
-		// Suppress "view full size"
-		if (intval(Config::get('system', 'no_view_full_size'))) {
-			$include_link = false;
-		}
-
 		// Picture addresses can contain special characters
 		$s = $srctext;
 
@@ -457,17 +452,7 @@ class BBCode
 					continue;
 				}
 
-				// $scale_replace, if passed, is an array of two elements. The
-				// first is the name of the full-size image. The second is the
-				// name of a remote, scaled-down version of the full size image.
-				// This allows Friendica to display the smaller remote image if
-				// one exists, while still linking to the full-size image
-				if ($scale_replace) {
-					$scaled = str_replace($scale_replace[0], $scale_replace[1], $mtch[1]);
-				} else {
-					$scaled = $mtch[1];
-				}
-				$i = Network::fetchUrl($scaled);
+				$i = Network::fetchUrl($mtch[1]);
 				if (!$i) {
 					return $srctext;
 				}
@@ -488,10 +473,8 @@ class BBCode
 							Logger::log('scale_external_images: ' . $orig_width . '->' . $new_width . 'w ' . $orig_height . '->' . $new_height . 'h' . ' match: ' . $mtch[0], Logger::DEBUG);
 							$s = str_replace(
 								$mtch[0],
-								'[img=' . $new_width . 'x' . $new_height. ']' . $scaled . '[/img]'
-								. "\n" . (($include_link)
-									? '[url=' . $mtch[1] . ']' . L10n::t('view full size') . '[/url]' . "\n"
-									: ''),
+								'[img=' . $new_width . 'x' . $new_height. ']' . $mtch[1] . '[/img]'
+								. "\n",
 								$s
 							);
 							Logger::log('scale_external_images: new string: ' . $s, Logger::DEBUG);

--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -438,7 +438,6 @@ class BBCode
 
 	public static function scaleExternalImages($srctext)
 	{
-		// Picture addresses can contain special characters
 		$s = $srctext;
 
 		$matches = null;

--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -444,7 +444,7 @@ class BBCode
 		}
 
 		// Picture addresses can contain special characters
-		$s = htmlspecialchars_decode($srctext);
+		$s = $srctext;
 
 		$matches = null;
 		$c = preg_match_all('/\[img.*?\](.*?)\[\/img\]/ism', $s, $matches, PREG_SET_ORDER);
@@ -501,8 +501,6 @@ class BBCode
 			}
 		}
 
-		// replace the special char encoding
-		$s = htmlspecialchars($s, ENT_NOQUOTES, 'UTF-8');
 		return $s;
 	}
 

--- a/src/Content/Text/Markdown.php
+++ b/src/Content/Text/Markdown.php
@@ -119,7 +119,7 @@ class Markdown
 		$s = preg_replace('/(\[code\])+(.*?)(\[\/code\])+/ism', '[code]$2[/code]', $s);
 
 		// Don't show link to full picture (until it is fixed)
-		$s = BBCode::scaleExternalImages($s, false);
+		$s = BBCode::scaleExternalImages($s);
 
 		return $s;
 	}

--- a/static/defaults.config.php
+++ b/static/defaults.config.php
@@ -297,10 +297,6 @@ return [
 		// Don't show smilies.
 		'no_smilies' => false,
 
-		// no_view_full_size (Boolean)
-		// Don't add the link "View full size" under a resized image.
-		'no_view_full_size' => false,
-
 		// optimize_items (Boolean)
 		// Triggers an SQL command to optimize the item table before expiring items.
 		'optimize_items' => false,


### PR DESCRIPTION
- Adresses https://forum.friendi.ca/display/0b6b25a8-445e-0da3-6ebf-6d4439784940

Another banger this one. `BBCode::scaleExternalImage` was silently HTML decoding/encoding the whole body of items. The body itself should never have been HTML encoded at this stage, the database doesn't care if your text is HTML encode or not. And to top it off, some parameters were never used, including a file-only config key that was de facto ineffective.

So, a code cleanup task.