### PR TITLE
AP: Transmit the language in the contentMap

### DIFF
--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -1345,7 +1345,7 @@ class Transmitter
 	 *
 	 * @return string language string
 	 */
-	private static function getLanguage($item)
+	private static function getLanguage(array $item)
 	{
 		// Try to fetch the language from the post itself
 		if (!empty($item['language'])) {

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -1304,12 +1304,17 @@ class Transmitter
 			$data['content'] = BBCode::convert($body, false, 9);
 		}
 
-		$regexp = "/[@!]\[url\=([^\[\]]*)\].*?\[\/url\]/ism";
-		$richbody = preg_replace_callback($regexp, ['self', 'mentionCallback'], $item['body']);
-		$richbody = BBCode::removeAttachment($richbody);
+		// The regular "content" field does contain a minimized HTML. This is done since systems like
+		// Mastodon has got problems with - for example - embedded pictures.
+		// The contentMap does contain the unmodified HTML.
+		$language = self::getLanguage($item);
+		if (!empty($language)) {
+			$regexp = "/[@!]\[url\=([^\[\]]*)\].*?\[\/url\]/ism";
+			$richbody = preg_replace_callback($regexp, ['self', 'mentionCallback'], $item['body']);
+			$richbody = BBCode::removeAttachment($richbody);
 
-		$data['contentMap']['text/html'] = BBCode::convert($richbody, false);
-		$data['contentMap']['text/markdown'] = BBCode::toMarkdown($item["body"]);
+			$data['contentMap'][$language] = BBCode::convert($richbody, false);
+		}
 
 		$data['source'] = ['content' => $item['body'], 'mediaType' => "text/bbcode"];
 
@@ -1331,6 +1336,35 @@ class Transmitter
 		$data = array_merge($data, $permission_block);
 
 		return $data;
+	}
+
+	/**
+	 * Fetches the language from the post, the user or the system.
+	 *
+	 * @param array $item
+	 *
+	 * @return string language string
+	 */
+	private static function getLanguage($item)
+	{
+		// Try to fetch the language from the post itself
+		if (!empty($item['language'])) {
+			$languages = array_keys(json_decode($item['language'], true));
+			if (!empty($languages[0])) {
+				return $languages[0];
+			}
+		}
+
+		// Otherwise use the user's language
+		if (!empty($item['uid'])) {
+			$user = DBA::selectFirst('user', ['language'], ['uid' => $item['uid']]);
+			if (!empty($user['language'])) {
+				return $user['language'];
+			}
+		}
+
+		// And finally just use the system language
+		return Config::get('system', 'language');
 	}
 
 	/**


### PR DESCRIPTION
For the last version we used the "contentMap" array to transmit a mostly unmodified HTML in contrast to the "content" field that contains some stripped HTML to work around how especially Mastodon is treating it.

Transmitting a content-type in the language field is some kind of a dirty hack. And I thought about it again. Then I came to the conclusion to do it slightly different. Now we transmit the mostly unmodified HTML in the "contentMap" with the real language (since we do have that data). Of course the language is not always accurate, but I think it is a better way.