### PR TITLE
Item notification data is now stored in the "user-item" table

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -1,6 +1,6 @@
 -- ------------------------------------------
--- Friendica 2019.12-rc (Dalmatian Bellflower)
--- DB_UPDATE_VERSION 1328
+-- Friendica 2020.03-dev (Dalmatian Bellflower)
+-- DB_UPDATE_VERSION 1329
 -- ------------------------------------------
 
 
@@ -1285,6 +1285,7 @@ CREATE TABLE IF NOT EXISTS `user-item` (
 	`hidden` boolean NOT NULL DEFAULT '0' COMMENT 'Marker to hide an item from the user',
 	`ignored` boolean COMMENT 'Ignore this thread if set',
 	`pinned` boolean COMMENT 'The item is pinned on the profile page',
+	`notification-type` tinyint unsigned NOT NULL DEFAULT 0 COMMENT '',
 	 PRIMARY KEY(`uid`,`iid`),
 	 INDEX `uid_pinned` (`uid`,`pinned`)
 ) DEFAULT COLLATE utf8mb4_general_ci COMMENT='User specific item data';

--- a/database.sql
+++ b/database.sql
@@ -1287,7 +1287,8 @@ CREATE TABLE IF NOT EXISTS `user-item` (
 	`pinned` boolean COMMENT 'The item is pinned on the profile page',
 	`notification-type` tinyint unsigned NOT NULL DEFAULT 0 COMMENT '',
 	 PRIMARY KEY(`uid`,`iid`),
-	 INDEX `uid_pinned` (`uid`,`pinned`)
+	 INDEX `uid_pinned` (`uid`,`pinned`),
+	 INDEX `iid_uid` (`iid`,`uid`)
 ) DEFAULT COLLATE utf8mb4_general_ci COMMENT='User specific item data';
 
 --

--- a/include/api.php
+++ b/include/api.php
@@ -2170,7 +2170,7 @@ function api_statuses_mentions($type)
 		$since_id];
 
 	if ($max_id > 0) {
-		$condition[0] .= " AND `item`.`id` <= ?";
+		$query .= " AND `item`.`id` <= ?";
 		$condition[] = $max_id;
 	}
 

--- a/src/Database/PostUpdate.php
+++ b/src/Database/PostUpdate.php
@@ -487,6 +487,8 @@ class PostUpdate
 		}
 
 		while ($item = DBA::fetch($items)) {
+			$id = $item['id'];
+
 			UserItem::setNotification($item['id']);
 
 			++$rows;

--- a/src/Database/PostUpdate.php
+++ b/src/Database/PostUpdate.php
@@ -10,6 +10,7 @@ use Friendica\Core\Protocol;
 use Friendica\Model\Contact;
 use Friendica\Model\Item;
 use Friendica\Model\ItemURI;
+use Friendica\Model\UserItem;
 use Friendica\Model\PermissionSet;
 
 /**
@@ -38,6 +39,9 @@ class PostUpdate
 			return false;
 		}
 		if (!self::update1322()) {
+			return false;
+		}
+		if (!self::update1329()) {
 			return false;
 		}
 
@@ -452,5 +456,53 @@ class PostUpdate
 		Logger::info('Done');
 
 		return true;
+	}
+
+	/**
+	 * @brief update user-item data with notifications
+	 *
+	 * @return bool "true" when the job is done
+	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
+	 */
+	private static function update1329()
+	{
+		// Was the script completed?
+		if (Config::get('system', 'post_update_version') >= 1329) {
+			return true;
+		}
+
+		$id = Config::get('system', 'post_update_version_1329_id', 0);
+
+		Logger::info('Start', ['item' => $id]);
+
+		$start_id = $id;
+		$rows = 0;
+		$condition = ["`id` > ?", $id];
+		$params = ['order' => ['id'], 'limit' => 10000];
+		$items = DBA::select('item', ['id'], $condition, $params);
+
+		if (DBA::errorNo() != 0) {
+			Logger::error('Database error', ['no' => DBA::errorNo(), 'message' => DBA::errorMessage()]);
+			return false;
+		}
+
+		while ($item = DBA::fetch($items)) {
+			UserItem::setNotification($item['id']);
+
+			++$rows;
+		}
+		DBA::close($items);
+
+		Config::set('system', 'post_update_version_1329_id', $id);
+
+		Logger::info('Processed', ['rows' => $rows, 'last' => $id]);
+
+		if ($start_id == $id) {
+			Config::set('system', 'post_update_version', 1329);
+			Logger::info('Done');
+			return true;
+		}
+
+		return false;
 	}
 }

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -2026,7 +2026,7 @@ class Item
 
 		self::updateContact($item);
 
-		UserItem::setNotification($current_post, $item['uid']);
+		UserItem::setNotification($current_post);
 
 		check_user_notification($current_post);
 

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -2026,6 +2026,8 @@ class Item
 
 		self::updateContact($item);
 
+		UserItem::setNotification($current_post, $item['uid']);
+
 		check_user_notification($current_post);
 
 		if ($notify || ($item['visible'] && ((!empty($parent) && $parent['origin']) || $item['origin']))) {

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -656,7 +656,7 @@ class Item
 			'iaid' => 'internal-iaid'];
 
 		if ($usermode) {
-			$fields['user-item'] = ['pinned', 'ignored' => 'internal-user-ignored'];
+			$fields['user-item'] = ['pinned', 'notification-type', 'ignored' => 'internal-user-ignored'];
 		}
 
 		$fields['item-activity'] = ['activity', 'activity' => 'internal-activity'];

--- a/src/Model/UserItem.php
+++ b/src/Model/UserItem.php
@@ -26,6 +26,8 @@ class UserItem
 
 	/**
 	 * Checks an item for notifications and sets the "notification-type" field
+	 * @ToDo:
+	 * - Check for mentions in posts with "uid=0" where the user hadn't interacted before
 	 *
 	 * @param int $iid Item ID
 	 */

--- a/src/Model/UserItem.php
+++ b/src/Model/UserItem.php
@@ -31,7 +31,7 @@ class UserItem
 	 */
 	public static function setNotification(int $iid)
 	{
-		$fields = ['id', 'uid', 'body', 'parent', 'gravity', 'tag', 'contact-id', 'thr-parent', 'author-id'];
+		$fields = ['id', 'uid', 'body', 'parent', 'gravity', 'tag', 'contact-id', 'thr-parent', 'parent-uri', 'author-id'];
 		$item = Item::selectFirst($fields, ['id' => $iid, 'origin' => false]);
 		if (!DBA::isResult($item)) {
 			return;
@@ -120,7 +120,7 @@ class UserItem
 	 *
 	 * @return array Profiles
 	 */
-	private static function getProfileForUser($uid)
+	private static function getProfileForUser(int $uid)
 	{
 		$notification_data = ['uid' => $uid, 'profiles' => []];
 		Hook::callAll('check_item_notification', $notification_data);
@@ -172,7 +172,7 @@ class UserItem
 	 * @param int   $uid  User ID
 	 * @return bool A contact had shared something
 	 */
-	private static function checkShared($item, $uid)
+	private static function checkShared(array $item, int $uid)
 	{
 		if ($item['gravity'] != GRAVITY_PARENT) {
 			return false;
@@ -198,9 +198,10 @@ class UserItem
 	/**
 	 * Check for an implicit mention (only tag, no body) of the given user
 	 * @param array $item
+	 * @param array $profiles
 	 * @return bool The user is mentioned
 	 */
-	private static function checkImplicitMention($item, $profiles)
+	private static function checkImplicitMention(array $item, array $profiles)
 	{
 		foreach ($profiles AS $profile) {
 			if (strpos($item['tag'], '='.$profile.']') || strpos($item['body'], '='.$profile.']')) {
@@ -216,9 +217,10 @@ class UserItem
 	/**
 	 * Check for an explicit mention (tag and body) of the given user
 	 * @param array $item
+	 * @param array $profiles
 	 * @return bool The user is mentioned
 	 */
-	private static function checkExplicitMention($item, $profiles)
+	private static function checkExplicitMention(array $item, array $profiles)
 	{
 		foreach ($profiles AS $profile) {
 			if (strpos($item['tag'], '='.$profile.']') || strpos($item['body'], '='.$profile.']')) {
@@ -234,9 +236,10 @@ class UserItem
 	/**
 	 * Check if the given user had created this thread
 	 * @param array $item
+	 * @param array $contacts Array of contact IDs
 	 * @return bool The user had created this thread
 	 */
-	private static function checkCommentedThread($item, $contacts)
+	private static function checkCommentedThread(array $item, array $contacts)
 	{
 		$condition = ['parent' => $item['parent'], 'author-id' => $contacts, 'deleted' => false, 'gravity' => GRAVITY_PARENT];
 		return Item::exists($condition);
@@ -246,10 +249,10 @@ class UserItem
 	 * Check for a direct comment to a post of the given user
 	 * @param array $item
 	 * @param int   $uid  User ID
-	 * @param array $contacts Array of contacts
+	 * @param array $contacts Array of contact IDs
 	 * @return bool The item is a direct comment to a user comment
 	 */
-	private static function checkDirectComment($item, $uid, $contacts)
+	private static function checkDirectComment(array $item, int $uid, array $contacts)
 	{
 		$condition = ['uri' => $item['thr-parent'], 'uid' => [0, $uid], 'author-id' => $contacts, 'deleted' => false, 'gravity' => GRAVITY_COMMENT];
 		return Item::exists($condition);
@@ -258,10 +261,10 @@ class UserItem
 	/**
 	 *  Check if the user had commented in this thread
 	 * @param array $item
-	 * @param array $contacts Array of contacts
+	 * @param array $contacts Array of contact IDs
 	 * @return bool The user had commented in the thread
 	 */
-	private static function checkCommentedParticipation($item, $contacts)
+	private static function checkCommentedParticipation(array $item, array $contacts)
 	{
 		$condition = ['parent' => $item['parent'], 'author-id' => $contacts, 'deleted' => false, 'gravity' => GRAVITY_COMMENT];
 		return Item::exists($condition);
@@ -270,10 +273,10 @@ class UserItem
 	/**
 	 * Check if the user had interacted in this thread (Like, Dislike, ...)
 	 * @param array $item
-	 * @param array $contacts Array of contacts
+	 * @param array $contacts Array of contact IDs
 	 * @return bool The user had interacted in the thread
 	 */
-	private static function checkActivityParticipation($item, $contacts)
+	private static function checkActivityParticipation(array $item, array $contacts)
 	{
 		$condition = ['parent' => $item['parent'], 'author-id' => $contacts, 'deleted' => false, 'gravity' => GRAVITY_ACTIVITY];
 		return Item::exists($condition);

--- a/src/Model/UserItem.php
+++ b/src/Model/UserItem.php
@@ -148,10 +148,8 @@ class UserItem
 
 		// Validate and add profile links
 		foreach ($profiles AS $key => $profile) {
-			// Check for invalid profile urls. 13 should be the shortest possible profile length:
-			// http://a.bc/d
-			// Additionally check for invalid urls that would return the normalised value "http:"
-			if ((strlen($profile) < 13) || (Strings::normaliseLink($profile) == 'http:')) {
+			// Check for invalid profile urls (without scheme, host or path) and remove them
+			if (empty(parse_url($profile, PHP_URL_SCHEME)) || empty(parse_url($profile, PHP_URL_HOST)) || empty(parse_url($profile, PHP_URL_PATH))) {
 				unset($profiles[$key]);
 				continue;
 			}

--- a/src/Model/UserItem.php
+++ b/src/Model/UserItem.php
@@ -154,25 +154,19 @@ class UserItem
 				continue;
 			}
 
-			// Add the profile if it wasn't already added
-			if (!in_array($profile, $profiles)) {
-				$profiles[] = $profile;
-			}
+			// Add the profile
+			$profiles[] = $profile;
 
 			// Add the normalized form
 			$profile = Strings::normaliseLink($profile);
-			if (!in_array($profile, $profiles)) {
-				$profiles[] = $profile;
-			}
+			$profiles[] = $profile;
 
 			// Add the SSL form
 			$profile = str_replace('http://', 'https://', $profile);
-			if (!in_array($profile, $profiles)) {
-				$profiles[] = $profile;
-			}
+			$profiles[] = $profile;
 		}
 
-		return $profiles;
+		return array_unique($profiles);
 	}
 
 	/**

--- a/src/Model/UserItem.php
+++ b/src/Model/UserItem.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * @file src/Model/UserItem.php
+ */
+
+namespace Friendica\Model;
+
+use Friendica\Database\DBA;
+
+class UserItem
+{
+	/**
+	 * Checks an item for notifications and sets the "notification-type" field
+	 *
+	 * @param array $item The message array that is checked for notifications
+	 * @param int   $uid  User ID
+	 */
+	public static function setNotification($item, $uid)
+	{
+	}
+
+	private static function checkShared($item, $uid)
+	{
+		if ($item['gravity'] != GRAVITY_PARENT) {
+			return false;
+		}
+
+		// Send a notification for every new post?
+		// Either the contact had posted something directly
+		if (DBA::exists('contact', ['id' => $item['contact-id'], 'notify_new_posts' => true])) {
+			return true;
+		}
+
+		// Or the contact is a mentioned forum
+		$tags = DBA::select('term', ['url'], ['otype' => TERM_OBJ_POST, 'oid' => $itemid, 'type' => TERM_MENTION, 'uid' => $uid]);
+		while ($tag = DBA::fetch($tags)) {
+			$condition = ['nurl' => Strings::normaliseLink($tag["url"]), 'uid' => $uid, 'notify_new_posts' => true, 'contact-type' => Contact::TYPE_COMMUNITY];
+			if (DBA::exists('contact', $condition)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	// Is the user mentioned in this post?
+	private static function checkTagged($item, $uid)
+	{
+		if ($item["mention"]) {
+			return true;
+		}
+
+		foreach ($profiles AS $profile) {
+			if (strpos($item["tag"], "=".$profile."]") || strpos($item["body"], "=".$profile."]"))
+				return true;
+		}
+
+		if ($defaulttype == NOTIFY_TAGSELF) {
+			return true;
+		}
+
+		return false;
+	}
+
+	private static function checkCommented($item, $uid)
+	{
+		// Is it a post that the user had started?
+		$fields = ['ignored', 'mention'];
+		$thread = Item::selectFirstThreadForUser($uid, $fields, ['iid' => $item["parent"], 'deleted' => false]);
+
+		if ($thread['mention'] && !$thread['ignored']) {
+			return true;
+		}
+
+		// And now we check for participation of one of our contacts in the thread
+		$condition = ['parent' => $item["parent"], 'author-id' => $contacts, 'deleted' => false];
+
+		if (!$thread['ignored'] && Item::exists($condition)) {
+			return true;
+		}
+
+		return false;
+	}
+}

--- a/src/Model/UserItem.php
+++ b/src/Model/UserItem.php
@@ -81,19 +81,19 @@ class UserItem
 			return;
 		}
 
-		if (self::checkImplicitMention($item, $uid, $profiles)) {
+		if (self::checkImplicitMention($item, $profiles)) {
 			$notification_type = $notification_type | self::NOTIF_IMPLICIT_TAGGED;
 		}
 
-		if (self::checkExplicitMention($item, $uid, $profiles)) {
+		if (self::checkExplicitMention($item, $profiles)) {
 			$notification_type = $notification_type | self::NOTIF_EXPLICIT_TAGGED;
 		}
 
-		if (self::checkCommentedThread($item, $uid, $contacts)) {
+		if (self::checkCommentedThread($item, $contacts)) {
 			$notification_type = $notification_type | self::NOTIF_THREAD_COMMENT;
 		}
 
-		if (self::checkDirectComment($item, $uid, $contacts, $thread)) {
+		if (self::checkDirectComment($item, $uid, $contacts)) {
 			$notification_type = $notification_type | self::NOTIF_DIRECT_COMMENT;
 		}
 
@@ -198,10 +198,9 @@ class UserItem
 	/**
 	 * Check for an implicit mention (only tag, no body) of the given user
 	 * @param array $item
-	 * @param int   $uid  User ID
 	 * @return bool The user is mentioned
 	 */
-	private static function checkImplicitMention($item, $uid, $profiles)
+	private static function checkImplicitMention($item, $profiles)
 	{
 		foreach ($profiles AS $profile) {
 			if (strpos($item['tag'], '='.$profile.']') || strpos($item['body'], '='.$profile.']')) {
@@ -217,10 +216,9 @@ class UserItem
 	/**
 	 * Check for an explicit mention (tag and body) of the given user
 	 * @param array $item
-	 * @param int   $uid  User ID
 	 * @return bool The user is mentioned
 	 */
-	private static function checkExplicitMention($item, $uid, $profiles)
+	private static function checkExplicitMention($item, $profiles)
 	{
 		foreach ($profiles AS $profile) {
 			if (strpos($item['tag'], '='.$profile.']') || strpos($item['body'], '='.$profile.']')) {
@@ -236,10 +234,9 @@ class UserItem
 	/**
 	 * Check if the given user had created this thread
 	 * @param array $item
-	 * @param int   $uid  User ID
 	 * @return bool The user had created this thread
 	 */
-	private static function checkCommentedThread($item, $uid, $contacts)
+	private static function checkCommentedThread($item, $contacts)
 	{
 		$condition = ['parent' => $item['parent'], 'author-id' => $contacts, 'deleted' => false, 'gravity' => GRAVITY_PARENT];
 		return Item::exists($condition);

--- a/src/Model/UserItem.php
+++ b/src/Model/UserItem.php
@@ -95,7 +95,7 @@ class UserItem
 			$notification_type = $notification_type | self::NOTIF_THREAD_COMMENT;
 		}
 
-		if (self::checkDirectComment($item, $uid, $contacts)) {
+		if (self::checkDirectComment($item, $contacts)) {
 			$notification_type = $notification_type | self::NOTIF_DIRECT_COMMENT;
 		}
 
@@ -250,13 +250,12 @@ class UserItem
 	/**
 	 * Check for a direct comment to a post of the given user
 	 * @param array $item
-	 * @param int   $uid  User ID
 	 * @param array $contacts Array of contact IDs
 	 * @return bool The item is a direct comment to a user comment
 	 */
-	private static function checkDirectComment(array $item, int $uid, array $contacts)
+	private static function checkDirectComment(array $item, array $contacts)
 	{
-		$condition = ['uri' => $item['thr-parent'], 'uid' => [0, $uid], 'author-id' => $contacts, 'deleted' => false, 'gravity' => GRAVITY_COMMENT];
+		$condition = ['uri' => $item['thr-parent'], 'uid' => $item['uid'], 'author-id' => $contacts, 'deleted' => false, 'gravity' => GRAVITY_COMMENT];
 		return Item::exists($condition);
 	}
 

--- a/src/Model/UserItem.php
+++ b/src/Model/UserItem.php
@@ -141,7 +141,7 @@ class UserItem
 		$profiles[] = $owner['url'];
 
 		// Notifications from Diaspora are often with an URL in the Diaspora format
-		$profiles[] = DI::baseUrl().'/u/'.$user['nickname'];
+		$profiles[] = DI::baseUrl() . '/u/' . $user['nickname'];
 
 		$profiles2 = [];
 
@@ -204,7 +204,7 @@ class UserItem
 	private static function checkImplicitMention(array $item, array $profiles)
 	{
 		foreach ($profiles AS $profile) {
-			if (strpos($item['tag'], '='.$profile.']') || strpos($item['body'], '='.$profile.']')) {
+			if (strpos($item['tag'], '=' . $profile.']') || strpos($item['body'], '=' . $profile . ']')) {
 				if (strpos($item['body'], $profile) === false) {
 					return true;
 				}
@@ -223,7 +223,7 @@ class UserItem
 	private static function checkExplicitMention(array $item, array $profiles)
 	{
 		foreach ($profiles AS $profile) {
-			if (strpos($item['tag'], '='.$profile.']') || strpos($item['body'], '='.$profile.']')) {
+			if (strpos($item['tag'], '=' . $profile.']') || strpos($item['body'], '=' . $profile . ']')) {
 				if (!(strpos($item['body'], $profile) === false)) {
 					return true;
 				}

--- a/src/Model/UserItem.php
+++ b/src/Model/UserItem.php
@@ -118,7 +118,7 @@ class UserItem
 	 * Fetch all profiles (contact URL) of a given user
 	 * @param int $uid User ID
 	 *
-	 * @return array Profiles
+	 * @return array Profile links
 	 */
 	private static function getProfileForUser(int $uid)
 	{
@@ -198,7 +198,7 @@ class UserItem
 	/**
 	 * Check for an implicit mention (only tag, no body) of the given user
 	 * @param array $item
-	 * @param array $profiles
+	 * @param array $profiles Profile links
 	 * @return bool The user is mentioned
 	 */
 	private static function checkImplicitMention(array $item, array $profiles)
@@ -217,7 +217,7 @@ class UserItem
 	/**
 	 * Check for an explicit mention (tag and body) of the given user
 	 * @param array $item
-	 * @param array $profiles
+	 * @param array $profiles Profile links
 	 * @return bool The user is mentioned
 	 */
 	private static function checkExplicitMention(array $item, array $profiles)

--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -34,7 +34,7 @@
 use Friendica\Database\DBA;
 
 if (!defined('DB_UPDATE_VERSION')) {
-	define('DB_UPDATE_VERSION', 1328);
+	define('DB_UPDATE_VERSION', 1329);
 }
 
 return [
@@ -1388,7 +1388,8 @@ return [
 			"uid" => ["type" => "mediumint unsigned", "not null" => "1", "default" => "0", "primary" => "1", "relation" => ["user" => "uid"], "comment" => "User id"],
 			"hidden" => ["type" => "boolean", "not null" => "1", "default" => "0", "comment" => "Marker to hide an item from the user"],
 			"ignored" => ["type" => "boolean", "comment" => "Ignore this thread if set"],
-			"pinned" => ["type" => "boolean", "comment" => "The item is pinned on the profile page"]
+			"pinned" => ["type" => "boolean", "comment" => "The item is pinned on the profile page"],
+			"notification-type" => ["type" => "tinyint unsigned", "not null" => "1", "default" => "0", "comment" => ""],
 		],
 		"indexes" => [
 			"PRIMARY" => ["uid", "iid"],

--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -1393,7 +1393,8 @@ return [
 		],
 		"indexes" => [
 			"PRIMARY" => ["uid", "iid"],
-			"uid_pinned" => ["uid", "pinned"]
+			"uid_pinned" => ["uid", "pinned"],
+			"iid_uid" => ["iid", "uid"]
 		]
 	],
 	"worker-ipc" => [


### PR DESCRIPTION
This PR adds the field "notification-type" to the "user-item" table. This field contains data where this item should cause a notification for the given user. The field has to be queried via a bit mask since several types can occur in parallel.

The types are now much more granular like before. The types are:

* NOTIF_NONE - No notification
* NOTIF_EXPLICIT_TAGGED - The user is tagged and mentioned in the body
* NOTIF_IMPLICIT_TAGGED - The user is tagged but not mentioned in the body
* NOTIF_THREAD_COMMENT - The item is a comment to the user's post
* NOTIF_DIRECT_COMMENT - The item is a comment to a user's comment
* NOTIF_COMMENT_PARTICIPATION - The item is a comment where the user had commented
* NOTIF_ACTIVITY_PARTICIPATION - The item is a comment where the user had performed an activity (like, dislike, ...)
* NOTIF_SHARED - The item is a new post from a contact where the user wants to get a notification for every new post

This should cover nearly every situation. We could additionally check for the situation when there had been an activity/comment in a sub thread where the user had interacted. Currently this wouldn't be treated differently to the situation when the user interaction had been only outside the sub thread. But from my point of view this is a very special situation.

This also fixes https://github.com/friendica/friendica/issues/6867 and fixes https://github.com/friendica/friendica/issues/5849
