### PR TITLE
Use default user permissions when creating new event

### DIFF
--- a/mod/events.php
+++ b/mod/events.php
@@ -18,6 +18,7 @@ use Friendica\DI;
 use Friendica\Model\Event;
 use Friendica\Model\Item;
 use Friendica\Model\Profile;
+use Friendica\Model\User;
 use Friendica\Module\Security\Login;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Strings;
@@ -427,7 +428,7 @@ function events_content(App $a)
 	// Passed parameters overrides anything found in the DB
 	if (in_array($mode, ['edit', 'new', 'copy'])) {
 		if (empty($orig_event)) {
-			$orig_event = [];
+			$orig_event = User::getById(local_user(), ['allow_cid', 'allow_gid', 'deny_cid', 'deny_gid']);;
 		}
 
 		// In case of an error the browser is redirected back here, with these parameters filled in with the previous values

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -2682,26 +2682,23 @@ class Contact
 	 * Remove the unavailable contact ids from the provided list
 	 *
 	 * @param array $contact_ids Contact id list
+	 * @return array
 	 * @throws \Exception
 	 */
-	public static function pruneUnavailable(array &$contact_ids)
+	public static function pruneUnavailable(array $contact_ids)
 	{
 		if (empty($contact_ids)) {
-			return;
+			return [];
 		}
 
-		$str = DBA::escape(implode(',', $contact_ids));
+		$contacts = Contact::selectToArray(['id'], [
+			'id'      => $contact_ids,
+			'blocked' => false,
+			'pending' => false,
+			'archive' => false,
+		]);
 
-		$stmt = DBA::p("SELECT `id` FROM `contact` WHERE `id` IN ( " . $str . ") AND `blocked` = 0 AND `pending` = 0 AND `archive` = 0");
-
-		$return = [];
-		while($contact = DBA::fetch($stmt)) {
-			$return[] = $contact['id'];
-		}
-
-		DBA::close($stmt);
-
-		$contact_ids = $return;
+		return array_column($contacts, 'id');
 	}
 
 	/**

--- a/src/Model/Group.php
+++ b/src/Model/Group.php
@@ -384,7 +384,7 @@ class Group
 		DBA::close($stmt);
 
 		if ($check_dead) {
-			Contact::pruneUnavailable($return);
+			$return = Contact::pruneUnavailable($return);
 		}
 
 		return $return;

--- a/src/Module/Item/Compose.php
+++ b/src/Module/Item/Compose.php
@@ -5,22 +5,15 @@ namespace Friendica\Module\Item;
 use Friendica\BaseModule;
 use Friendica\Content\Feature;
 use Friendica\Core\ACL;
-use Friendica\Core\Config;
 use Friendica\Core\Hook;
 use Friendica\Core\L10n;
 use Friendica\Core\Renderer;
-use Friendica\Core\System;
 use Friendica\Core\Theme;
-use Friendica\Database\DBA;
 use Friendica\DI;
-use Friendica\Model\Contact;
-use Friendica\Model\FileTag;
-use Friendica\Model\Group;
 use Friendica\Model\Item;
 use Friendica\Model\User;
 use Friendica\Module\Security\Login;
 use Friendica\Network\HTTPException\NotImplementedException;
-use Friendica\Util\ACLFormatter;
 use Friendica\Util\Crypto;
 
 class Compose extends BaseModule


### PR DESCRIPTION
Fixes #8058

This PR fixes a long-standing issue where user permissions weren't provided to the event creation form.

However, it doesn't fix the other long-standing issue whereas if the event form submission results in an error, permissions aren't kept.

However, I want to focus on #8049 and I will open [a new issue](http://github.com/friendica/friendica/pull/8064) for this.