### PR TITLE
Issue 8067: Posts from Mastodon had been wrongly parsed

### DIFF
--- a/src/Protocol/ActivityPub/Receiver.php
+++ b/src/Protocol/ActivityPub/Receiver.php
@@ -907,18 +907,6 @@ class Receiver
 			return $object_data;
 		}
 
-		$markdown = JsonLD::fetchElement($object, 'as:content', '@value', '@language', 'text/markdown');
-		if (!empty($markdown)) {
-			$object_data['source'] = Markdown::toBBCode($markdown);
-			return $object_data;
-		}
-
-		$html = JsonLD::fetchElement($object, 'as:content', '@value', '@language', 'text/html');
-		if (!empty($html)) {
-			$object_data['source'] = HTML::toBBCode($markdown);
-			return $object_data;
-		}
-
 		return $object_data;
 	}
 


### PR DESCRIPTION
This handles issue https://github.com/friendica/friendica/issues/8067

Due to some weird circumstances the content had been sent through the Markdown parser - which removed HTML like elements.

The removed part handled some code that we already replaced on the sender side. So there is no loss of functionality at all.