### PR TITLE
Improved notification messages

### DIFF
--- a/include/enotify.php
+++ b/include/enotify.php
@@ -187,7 +187,7 @@ function notification($params)
 		if ($params['activity']['explicit_tagged']) {
 			$message = '%1$s tagged you on %2$s\'s %3$s %4$s';
 		} elseif ($params['activity']['origin_comment']) {
-			$message = '%1$s answered you on %2$s\'s %3$s %4$s';
+			$message = '%1$s replied to you on %2$s\'s %3$s %4$s';
 		} else {
 			$message = '%1$s commented on %2$s\'s %3$s %4$s';
 		}
@@ -201,7 +201,7 @@ function notification($params)
 			if ($params['activity']['explicit_tagged']) {
 				$message = '%1$s tagged you on your %2$s %3$s';
 			} elseif ($params['activity']['origin_comment']) {
-				$message = '%1$s answered you on your %2$s %3$s';
+				$message = '%1$s replied to you on your %2$s %3$s';
 			} else {
 				$message = '%1$s commented on your %2$s %3$s';
 			}
@@ -212,7 +212,7 @@ function notification($params)
 			if ($params['activity']['explicit_tagged']) {
 				$message = '%1$s tagged you on their %2$s %3$s';
 			} elseif ($params['activity']['origin_comment']) {
-				$message = '%1$s answered you on their %2$s %3$s';
+				$message = '%1$s replied to you on their %2$s %3$s';
 			} else {
 				$message = '%1$s commented on their %2$s %3$s';
 			}

--- a/include/enotify.php
+++ b/include/enotify.php
@@ -184,10 +184,10 @@ function notification($params)
 		// First go for the general message
 
 		// "George Bull's post"
-		if ($params['activity']['explicit_tagged']) {
-			$message = '%1$s tagged you on %2$s\'s %3$s %4$s';
-		} elseif ($params['activity']['origin_comment']) {
+		if ($params['activity']['origin_comment']) {
 			$message = '%1$s replied to you on %2$s\'s %3$s %4$s';
+		} elseif ($params['activity']['explicit_tagged']) {
+			$message = '%1$s tagged you on %2$s\'s %3$s %4$s';
 		} else {
 			$message = '%1$s commented on %2$s\'s %3$s %4$s';
 		}
@@ -198,10 +198,10 @@ function notification($params)
 
 		// "your post"
 		if ($params['activity']['origin_thread']) {
-			if ($params['activity']['explicit_tagged']) {
-				$message = '%1$s tagged you on your %2$s %3$s';
-			} elseif ($params['activity']['origin_comment']) {
+			if ($params['activity']['origin_comment']) {
 				$message = '%1$s replied to you on your %2$s %3$s';
+			} elseif ($params['activity']['explicit_tagged']) {
+				$message = '%1$s tagged you on your %2$s %3$s';
 			} else {
 				$message = '%1$s commented on your %2$s %3$s';
 			}
@@ -209,10 +209,10 @@ function notification($params)
 			$dest_str = $l10n->t($message, $params['source_name'], $item_post_type, $title);
 		// "their post"
 		} elseif ($item['author-link'] == $params['source_link']) {
-			if ($params['activity']['explicit_tagged']) {
-				$message = '%1$s tagged you on their %2$s %3$s';
-			} elseif ($params['activity']['origin_comment']) {
+			if ($params['activity']['origin_comment']) {
 				$message = '%1$s replied to you on their %2$s %3$s';
+			} elseif ($params['activity']['explicit_tagged']) {
+				$message = '%1$s tagged you on their %2$s %3$s';
 			} else {
 				$message = '%1$s commented on their %2$s %3$s';
 			}

--- a/include/enotify.php
+++ b/include/enotify.php
@@ -14,6 +14,7 @@ use Friendica\Database\DBA;
 use Friendica\Model\Contact;
 use Friendica\DI;
 use Friendica\Model\Item;
+use Friendica\Model\ItemContent;
 use Friendica\Model\User;
 use Friendica\Model\UserItem;
 use Friendica\Protocol\Activity;
@@ -154,6 +155,7 @@ function notification($params)
 
 		// Check to see if there was already a tag notify or comment notify for this post.
 		// If so don't create a second notification
+		/// @todo In the future we should store the notification with the highest "value" and replace notifications
 		$condition = ['type' => [NOTIFY_TAGSELF, NOTIFY_COMMENT, NOTIFY_SHARE],
 			'link' => $params['link'], 'uid' => $params['uid']];
 		if (DBA::exists('notify', $condition)) {
@@ -166,82 +168,63 @@ function notification($params)
 			$item = Item::selectFirstForUser($params['uid'], Item::ITEM_FIELDLIST, ['id' => $parent_id, 'deleted' => false]);
 		}
 
-		$item_post_type = Item::postType($item);
-		$itemlink = $item['plink'];
-
-		// "a post"
-		if ($params['type'] == NOTIFY_TAGSELF) {
-			$dest_str = $l10n->t('%1$s tagged you on [url=%2$s]a %3$s[/url]',
-				'[url=' . $params['source_link'] . ']' . $params['source_name'] . '[/url]',
-				$itemlink,
-				$item_post_type
-			);
-		} else {
-			$dest_str = $l10n->t('%1$s commented on [url=%2$s]a %3$s[/url]',
-				'[url=' . $params['source_link'] . ']' . $params['source_name'] . '[/url]',
-				$itemlink,
-				$item_post_type
-			);
+		if (empty($item)) {
+			return false;
 		}
+
+		$item_post_type = Item::postType($item);
+
+		$content = ItemContent::getPlaintextPost($item, 70);
+		if (!empty($content['text'])) {
+			$title = '"' . trim(str_replace("\n", " ", $content['text'])) . '"';
+		} else {
+			$title = '';
+		}
+
+		// First go for the general message
 
 		// "George Bull's post"
-		if (DBA::isResult($item)) {
-			if ($params['type'] == NOTIFY_TAGSELF) {
-				$dest_str = $l10n->t('%1$s tagged you on [url=%2$s]%3$s\'s %4$s[/url]',
-					'[url=' . $params['source_link'] . ']' . $params['source_name'] . '[/url]',
-					$itemlink,
-					$item['author-name'],
-					$item_post_type
-				);
-			} else {
-				$dest_str = $l10n->t('%1$s commented on [url=%2$s]%3$s\'s %4$s[/url]',
-					'[url=' . $params['source_link'] . ']' . $params['source_name'] . '[/url]',
-					$itemlink,
-					$item['author-name'],
-					$item_post_type
-				);
-			}
+		if ($params['activity']['explicit_tagged']) {
+			$message = '%1$s tagged you on %2$s\'s %3$s %4$s';
+		} elseif ($params['activity']['origin_comment']) {
+			$message = '%1$s answered you on %2$s\'s %3$s %4$s';
+		} else {
+			$message = '%1$s commented on %2$s\'s %3$s %4$s';
 		}
+
+		$dest_str = $l10n->t($message, $params['source_name'], $item['author-name'], $item_post_type, $title);
+
+		// Then look for the special cases
 
 		// "your post"
-		if (DBA::isResult($item) && $item['owner-id'] == $item['author-id'] && $item['wall']) {
-			if ($params['type'] == NOTIFY_TAGSELF) {
-				$dest_str = $l10n->t('%1$s tagged you on [url=%2$s]your %3$s[/url]',
-					'[url=' . $params['source_link'] . ']' . $params['source_name'] . '[/url]',
-					$itemlink,
-					$item_post_type
-				);
+		if ($params['activity']['origin_thread']) {
+			if ($params['activity']['explicit_tagged']) {
+				$message = '%1$s tagged you on your %2$s %3$s';
+			} elseif ($params['activity']['origin_comment']) {
+				$message = '%1$s answered you on your %2$s %3$s';
 			} else {
-				$dest_str = $l10n->t('%1$s commented on [url=%2$s]your %3$s[/url]',
-					'[url=' . $params['source_link'] . ']' . $params['source_name'] . '[/url]',
-					$itemlink,
-					$item_post_type
-				);
+				$message = '%1$s commented on your %2$s %3$s';
 			}
-		}
 
+			$dest_str = $l10n->t($message, $params['source_name'], $item_post_type, $title);
 		// "their post"
-		if (DBA::isResult($item) && $item['author-link'] == $params['source_link']) {
-			if ($params['type'] == NOTIFY_TAGSELF) {
-				$dest_str = $l10n->t('%1$s tagged you on [url=%2$s]their %3$s[/url]',
-					'[url=' . $params['source_link'] . ']' . $params['source_name'] . '[/url]',
-					$itemlink,
-					$item_post_type
-				);
+		} elseif ($item['author-link'] == $params['source_link']) {
+			if ($params['activity']['explicit_tagged']) {
+				$message = '%1$s tagged you on their %2$s %3$s';
+			} elseif ($params['activity']['origin_comment']) {
+				$message = '%1$s answered you on their %2$s %3$s';
 			} else {
-				$dest_str = $l10n->t('%1$s commented on [url=%2$s]their %3$s[/url]',
-					'[url=' . $params['source_link'] . ']' . $params['source_name'] . '[/url]',
-					$itemlink,
-					$item_post_type
-				);
+				$message = '%1$s commented on their %2$s %3$s';
 			}
+
+			$dest_str = $l10n->t($message, $params['source_name'], $item_post_type, $title);
 		}
 
 		// Some mail software relies on subject field for threading.
 		// So, we cannot have different subjects for notifications of the same thread.
 		// Before this we have the name of the replier on the subject rendering
 		// different subjects for messages on the same thread.
-		if ($params['type'] == NOTIFY_TAGSELF) {
+		if ($params['activity']['explicit_tagged']) {
 			$subject = $l10n->t('[Friendica:Notify] %s tagged you', $params['source_name']);
 
 			$preamble = $l10n->t('%1$s tagged you at %2$s', $params['source_name'], $sitename);
@@ -713,15 +696,23 @@ function check_item_notification($itemid, $uid, $notification_type) {
 	$params['source_link'] = $item['author-link'];
 	$params['source_photo'] = $item['author-avatar'];
 
+	// Set the activity flags
+	$params['activity']['explicit_tagged'] = ($notification_type & UserItem::NOTIF_EXPLICIT_TAGGED);
+	$params['activity']['implicit_tagged'] = ($notification_type & UserItem::NOTIF_IMPLICIT_TAGGED);
+	$params['activity']['origin_comment'] = ($notification_type & UserItem::NOTIF_DIRECT_COMMENT);
+	$params['activity']['origin_thread'] = ($notification_type & UserItem::NOTIF_THREAD_COMMENT);
+	$params['activity']['thread_comment'] = ($notification_type & UserItem::NOTIF_COMMENT_PARTICIPATION);
+	$params['activity']['thread_activity'] = ($notification_type & UserItem::NOTIF_ACTIVITY_PARTICIPATION);
+
 	if ($notification_type & UserItem::NOTIF_SHARED) {
 		$params['type'] = NOTIFY_SHARE;
-		$params['verb'] = Activity::TAG;
+		$params['verb'] = Activity::POST;
 	} elseif ($notification_type & UserItem::NOTIF_EXPLICIT_TAGGED) {
 		$params['type'] = NOTIFY_TAGSELF;
 		$params['verb'] = Activity::TAG;
 	} elseif ($notification_type & UserItem::NOTIF_IMPLICIT_TAGGED) {
-		$params['type'] = NOTIFY_TAGSELF;
-		$params['verb'] = Activity::TAG;
+		$params['type'] = NOTIFY_COMMENT;
+		$params['verb'] = Activity::POST;
 	} elseif ($notification_type & UserItem::NOTIF_THREAD_COMMENT) {
 		$params['type'] = NOTIFY_COMMENT;
 		$params['verb'] = Activity::POST;

--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -967,9 +967,6 @@ class BBCode
 				$attributes['avatar']   = ($author_contact['micro'] ?? '') ?: $attributes['avatar'];
 				$attributes['profile']  = ($author_contact['url']   ?? '') ?: $attributes['profile'];
 
-				// $author_contact['url'] could be empty. So then we fill it with the profile
-				$author_contact['url']  = ($attributes['profile']   ?? '') ?: $author_contact['url'];
-
 				if ($attributes['avatar']) {
 					$attributes['avatar'] = ProxyUtils::proxifyUrl($attributes['avatar'], false, ProxyUtils::SIZE_THUMB);
 				}

--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -967,6 +967,9 @@ class BBCode
 				$attributes['avatar']   = ($author_contact['micro'] ?? '') ?: $attributes['avatar'];
 				$attributes['profile']  = ($author_contact['url']   ?? '') ?: $attributes['profile'];
 
+				// $author_contact['url'] could be empty. So then we fill it with the profile
+				$author_contact['url']  = ($attributes['profile']   ?? '') ?: $author_contact['url'];
+
 				if ($attributes['avatar']) {
 					$attributes['avatar'] = ProxyUtils::proxifyUrl($attributes['avatar'], false, ProxyUtils::SIZE_THUMB);
 				}


### PR DESCRIPTION
This is slight improvement to the notifications. It fixes https://github.com/friendica/friendica/issues/6757, fixes https://github.com/friendica/friendica/issues/6418 and fixes https://github.com/friendica/friendica/issues/6205

It also adds the first characters of the post to the notification. Also it removes the URLs from the notification text, since this is converted to plain text later on.

P.S.: I'm still unsure if we should some text to the notifications to separate being tagged on a post that one already interacted with in comparison to being tagged on a post you hadn't interacted with before.

P.P.S.: Should "replied to you" have priority before "tagged you"?