### PR TITLE
Add cookie clear failed validation in App\Authentication

### DIFF
--- a/src/App/Authentication.php
+++ b/src/App/Authentication.php
@@ -103,6 +103,7 @@ class Authentication
 					$user['prvkey'] ?? '')) {
 					$this->logger->notice("Hash doesn't fit.", ['user' => $data->uid]);
 					$this->session->clear();
+					$this->cookie->clear();
 					$this->baseUrl->redirect();
 				}
 


### PR DESCRIPTION
This fixes a nasty infinite redirection loop when there is a cookie with obsolete data. Since it isn't cleared, the browser resubmit the same stale cookie data, the check fails again, redirection occurs, etc...