### PR TITLE
[frio] Stop scrollToItem() animate twice.

### DIFF
--- a/view/theme/frio/js/theme.js
+++ b/view/theme/frio/js/theme.js
@@ -652,7 +652,7 @@ function scrollToItem(elementId) {
 		scrollTop: itemPos
 	}, 400).promise().done( function() {
 		// Highlight post/commenent with ID  (GUID)
-		$el.animate(colWhite, 1).animate(colShiny,200).animate(colWhite, 600);
+		$el.animate(colWhite, 1000).animate(colShiny).animate(colWhite, 600);
 	});
 }
 

--- a/view/theme/frio/js/theme.js
+++ b/view/theme/frio/js/theme.js
@@ -650,9 +650,9 @@ function scrollToItem(elementId) {
 	// Scroll to the DIV with the ID (GUID)
 	$('html, body').animate({
 		scrollTop: itemPos
-	}, 400, function() {
+	}, 400).promise().done( function() {
 		// Highlight post/commenent with ID  (GUID)
-		$el.animate(colWhite, 1000).animate(colShiny).animate(colWhite, 600);
+		$el.animate(colWhite, 1).animate(colShiny,200).animate(colWhite, 600);
 	});
 }
 


### PR DESCRIPTION
- Suppressed first fade-to-black animation with `animate(colWhite, 1)`. (Unintended?)
- Stopped animate `colShiny` twice  with `).promise().done(`
  - Callback of `$('body,html')` will fires twice, so needs to wrap animate with `promise()`