### PR TITLE
Notifications: Now declare direct thread answers as replies

### DIFF
--- a/include/api.php
+++ b/include/api.php
@@ -2166,7 +2166,8 @@ function api_statuses_mentions($type)
 			AND `user-item`.`iid` > ?";
 	$condition = [GRAVITY_PARENT, GRAVITY_COMMENT, api_user(),
 		UserItem::NOTIF_EXPLICIT_TAGGED | UserItem::NOTIF_IMPLICIT_TAGGED |
-		UserItem::NOTIF_THREAD_COMMENT | UserItem::NOTIF_DIRECT_COMMENT,
+		UserItem::NOTIF_THREAD_COMMENT | UserItem::NOTIF_DIRECT_COMMENT |
+		UserItem::NOTIF_DIRECT_THREAD_COMMENT,
 		$since_id];
 
 	if ($max_id > 0) {

--- a/include/enotify.php
+++ b/include/enotify.php
@@ -704,6 +704,11 @@ function check_item_notification($itemid, $uid, $notification_type) {
 	$params['activity']['thread_comment'] = ($notification_type & UserItem::NOTIF_COMMENT_PARTICIPATION);
 	$params['activity']['thread_activity'] = ($notification_type & UserItem::NOTIF_ACTIVITY_PARTICIPATION);
 
+	// Tagging a user in a direct post (first comment level) means a direct comment
+	if ($params['activity']['explicit_tagged'] && ($notification_type & UserItem::NOTIF_DIRECT_THREAD_COMMENT)) {
+		$params['activity']['origin_comment'] = true;
+	}
+
 	if ($notification_type & UserItem::NOTIF_SHARED) {
 		$params['type'] = NOTIFY_SHARE;
 		$params['verb'] = Activity::POST;

--- a/src/Model/UserItem.php
+++ b/src/Model/UserItem.php
@@ -22,6 +22,7 @@ class UserItem
 	const NOTIF_DIRECT_COMMENT = 8;
 	const NOTIF_COMMENT_PARTICIPATION = 16;
 	const NOTIF_ACTIVITY_PARTICIPATION = 32;
+	const NOTIF_DIRECT_THREAD_COMMENT = 64;
 	const NOTIF_SHARED = 128;
 
 	/**
@@ -97,6 +98,10 @@ class UserItem
 
 		if (self::checkDirectComment($item, $contacts)) {
 			$notification_type = $notification_type | self::NOTIF_DIRECT_COMMENT;
+		}
+
+		if (self::checkDirectCommentedThread($item, $contacts)) {
+			$notification_type = $notification_type | self::NOTIF_DIRECT_THREAD_COMMENT;
 		}
 
 		if (self::checkCommentedParticipation($item, $contacts)) {
@@ -256,6 +261,18 @@ class UserItem
 	private static function checkDirectComment(array $item, array $contacts)
 	{
 		$condition = ['uri' => $item['thr-parent'], 'uid' => $item['uid'], 'author-id' => $contacts, 'deleted' => false, 'gravity' => GRAVITY_COMMENT];
+		return Item::exists($condition);
+	}
+
+	/**
+	 * Check for a direct comment to the starting post of the given user
+	 * @param array $item
+	 * @param array $contacts Array of contact IDs
+	 * @return bool The user had created this thread
+	 */
+	private static function checkDirectCommentedThread(array $item, array $contacts)
+	{
+		$condition = ['uri' => $item['thr-parent'], 'uid' => $item['uid'], 'author-id' => $contacts, 'deleted' => false, 'gravity' => GRAVITY_PARENT];
 		return Item::exists($condition);
 	}
 


### PR DESCRIPTION
First comment level answers with tagging of the user are now treated like comment, so you get this notification: ("... replied to you on your post"