### PR TITLE
updateAvatar automatically repairs avatars when photos are deleted

### DIFF
--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -1899,7 +1899,7 @@ class Contact
 		foreach ($data as $image_uri) {
 			$image_rid = Photo::ridFromURI($image_uri);
 			if ($image_rid && !Photo::exists(['resource-id' => $image_rid, 'uid' => $uid])) {
-				Logger::info('Regenerating avatar for contact uid ' . $uid . ' cid ' . $cid . ' missing photo ' . $image_rid . ' avatar ' . $contact['avatar']);
+				Logger::info('Regenerating avatar', ['contact uid' => $uid, 'cid' => $cid, 'missing photo' => $image_rid, 'avatar' => $contact['avatar']]);
 				$force = true;
 			}
 		}

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -1896,6 +1896,14 @@ class Contact
 			$data = [$contact["photo"], $contact["thumb"], $contact["micro"]];
 		}
 
+		foreach ($data as $image_uri) {
+			$image_rid = Photo::ridFromURI($image_uri);
+			if ($image_rid && !Photo::exists(['resource-id' => $image_rid, 'uid' => $uid])) {
+				Logger::info('Regenerating avatar for contact uid ' . $uid . ' cid ' . $cid . ' missing photo ' . $image_rid . ' avatar ' . $contact['avatar']);
+				$force = true;
+			}
+		}
+
 		if (($contact["avatar"] != $avatar) || $force) {
 			$photos = Photo::importProfilePhoto($avatar, $uid, $cid, true);
 

--- a/src/Model/Mail.php
+++ b/src/Model/Mail.php
@@ -216,7 +216,7 @@ class Mail
 			if (count($images)) {
 				foreach ($images as $image) {
 					$image_rid = Photo::ridFromURI($image);
-					if ($image_rid) {
+					if (!empty($image_rid)) {
 						Photo::update(['allow-cid' => '<' . $recipient . '>'], ['resource-id' => $image_rid, 'album' => 'Wall Photos', 'uid' => local_user()]);
 					}
 				}

--- a/src/Model/Mail.php
+++ b/src/Model/Mail.php
@@ -215,12 +215,10 @@ class Mail
 			$images = $match[1];
 			if (count($images)) {
 				foreach ($images as $image) {
-					if (!stristr($image, DI::baseUrl() . '/photo/')) {
-						continue;
+					$image_rid = Photo::ridFromURI($image);
+					if ($image_rid) {
+						Photo::update(['allow-cid' => '<' . $recipient . '>'], ['resource-id' => $image_rid, 'album' => 'Wall Photos', 'uid' => local_user()]);
 					}
-					$image_uri = substr($image, strrpos($image, '/') + 1);
-					$image_uri = substr($image_uri, 0, strpos($image_uri, '-'));
-					Photo::update(['allow-cid' => '<' . $recipient . '>'], ['resource-id' => $image_uri, 'album' => 'Wall Photos', 'uid' => local_user()]);
 				}
 			}
 		}

--- a/src/Model/Photo.php
+++ b/src/Model/Photo.php
@@ -602,7 +602,7 @@ class Photo
 	 * @param string $image_uri The URI of the photo
 	 * @return string The rid of the photo, or an empty string if the URI is not local
 	 */
-	public static function ridFromURI($image_uri)
+	public static function ridFromURI(string $image_uri)
 	{
 		if (!stristr($image_uri, DI::baseUrl() . '/photo/')) {
 			return '';

--- a/src/Model/Photo.php
+++ b/src/Model/Photo.php
@@ -641,7 +641,7 @@ class Photo
 		}
 
 		foreach ($images as $image) {
-			$image_rid = ridFromURI($image);
+			$image_rid = self::ridFromURI($image);
 			if (!$image_rid) {
 				continue;
 			}

--- a/src/Model/Photo.php
+++ b/src/Model/Photo.php
@@ -605,12 +605,12 @@ class Photo
 	public static function ridFromURI($image_uri)
 	{
 		if (!stristr($image_uri, DI::baseUrl() . '/photo/')) {
-			return;
+			return '';
 		}
 		$image_uri = substr($image_uri, strrpos($image_uri, '/') + 1);
 		$image_uri = substr($image_uri, 0, strpos($image_uri, '-'));
 		if (!strlen($image_uri)) {
-			return;
+			return '';
 		}
 		return $image_uri;
 	}
@@ -642,7 +642,7 @@ class Photo
 
 		foreach ($images as $image) {
 			$image_rid = self::ridFromURI($image);
-			if (!$image_rid) {
+			if (empty($image_rid)) {
 				continue;
 			}
 


### PR DESCRIPTION
I wrote this patch to repair my instance after I accidentally deleted a bunch of contact photos.  Perhaps it's worth pulling in?

This makes updateAvatar check if the photos in "photo", "thumb" and "micro" exist in the database, if they are local URLs.  Without this change, if the photo is deleted, it never recovers, because the avatar URL doesn't change.  Now it'll be repaired the next time a message for that contact is received.  It makes things slightly more robust and self-healing, at the expense of a couple of database queries.

Also, the code to extract the resource ID from a URL was duplicated and I used it again here, so I refactored it out into a separate function.