### PR TITLE
Ensure that deleted contacts are really removed

### DIFF
--- a/src/Worker/RemoveContact.php
+++ b/src/Worker/RemoveContact.php
@@ -13,8 +13,7 @@ class RemoveContact {
 	public static function execute($id) {
 
 		// Only delete if the contact is to be deleted
-		$condition = ['network' => Protocol::PHANTOM, 'id' => $id];
-		$contact = DBA::selectFirst('contact', ['uid'], $condition);
+		$contact = DBA::selectFirst('contact', ['uid'], ['deleted' => true]);
 		if (!DBA::isResult($contact)) {
 			return;
 		}


### PR DESCRIPTION
Sometime the contact removal process doesn't seem to work. Contacts are marked as deleted, but aren't removed. This is a cleanup job.