### PR TITLE
Ensure that local delivery is done via DFRN

### DIFF
--- a/src/Worker/Delivery.php
+++ b/src/Worker/Delivery.php
@@ -197,6 +197,11 @@ class Delivery
 			$contact['network'] = Protocol::DIASPORA;
 		}
 
+		// Ensure that local contacts are delivered locally
+		if (Model\Contact::isLocal($contact['url'])) {
+			$contact['network'] = Protocol::DFRN;
+		}
+
 		Logger::notice('Delivering', ['cmd' => $cmd, 'target' => $target_id, 'followup' => $followup, 'network' => $contact['network']]);
 
 		switch ($contact['network']) {
@@ -287,11 +292,8 @@ class Delivery
 
 		Logger::debug('Notifier entry: ' . $contact["url"] . ' ' . (($target_item['guid'] ?? '') ?: $target_item['id']) . ' entry: ' . $atom);
 
-		$basepath =  implode('/', array_slice(explode('/', $contact['url']), 0, 3));
-
 		// perform local delivery if we are on the same site
-
-		if (Strings::compareLink($basepath, DI::baseUrl())) {
+		if (Model\Contact::isLocal($contact['url'])) {
 			$condition = ['nurl' => Strings::normaliseLink($contact['url']), 'self' => true];
 			$target_self = DBA::selectFirst('contact', ['uid'], $condition);
 			if (!DBA::isResult($target_self)) {

--- a/src/Worker/Notifier.php
+++ b/src/Worker/Notifier.php
@@ -444,6 +444,11 @@ class Notifier
 
 			if (DBA::isResult($r)) {
 				foreach ($r as $rr) {
+					// Ensure that local contacts are delivered via DFRN
+					if (Contact::isLocal($rr['url'])) {
+						$contact['network'] == Protocol::DFRN;
+					}
+
 					if (!empty($rr['addr']) && ($rr['network'] == Protocol::ACTIVITYPUB) && !DBA::exists('fcontact', ['addr' => $rr['addr']])) {
 						Logger::info('Contact is AP omly', ['target' => $target_id, 'contact' => $rr['url']]);
 						continue;
@@ -489,6 +494,11 @@ class Notifier
 
 		// delivery loop
 		while ($contact = DBA::fetch($delivery_contacts_stmt)) {
+			// Ensure that local contacts are delivered via DFRN
+			if (Contact::isLocal($contact['url'])) {
+				$contact['network'] == Protocol::DFRN;
+			}
+
 			if (!empty($contact['addr']) && ($contact['network'] == Protocol::ACTIVITYPUB) && !DBA::exists('fcontact', ['addr' => $contact['addr']])) {
 				Logger::info('Contact is AP omly', ['target' => $target_id, 'contact' => $contact['url']]);
 				continue;

--- a/src/Worker/Notifier.php
+++ b/src/Worker/Notifier.php
@@ -446,7 +446,7 @@ class Notifier
 				foreach ($r as $rr) {
 					// Ensure that local contacts are delivered via DFRN
 					if (Contact::isLocal($rr['url'])) {
-						$contact['network'] == Protocol::DFRN;
+						$contact['network'] = Protocol::DFRN;
 					}
 
 					if (!empty($rr['addr']) && ($rr['network'] == Protocol::ACTIVITYPUB) && !DBA::exists('fcontact', ['addr' => $rr['addr']])) {
@@ -496,7 +496,7 @@ class Notifier
 		while ($contact = DBA::fetch($delivery_contacts_stmt)) {
 			// Ensure that local contacts are delivered via DFRN
 			if (Contact::isLocal($contact['url'])) {
-				$contact['network'] == Protocol::DFRN;
+				$contact['network'] = Protocol::DFRN;
 			}
 
 			if (!empty($contact['addr']) && ($contact['network'] == Protocol::ACTIVITYPUB) && !DBA::exists('fcontact', ['addr' => $contact['addr']])) {


### PR DESCRIPTION
We still seem to have issues with the forum delivery when the forum is local. Possibly there are other delivery issues with local contacts as well. We now (hopefully) ensure that the local delivery is always done via DFRN.

@nupplaphil There is a single removed line that contains the "DI" thingy. This will most likely create a merge conflict with your huge PR. But I wanted to unify the behaviour.