### PR TITLE
User lowercase for platform data

### DIFF
--- a/src/Model/GServer.php
+++ b/src/Model/GServer.php
@@ -424,11 +424,11 @@ class GServer
 		}
 
 		if (!empty($data['network'])) {
-			$serverdata['platform'] = $data['network'];
+			$serverdata['platform'] = strtolower($data['network']);
 
-			if ($serverdata['platform'] == 'Diaspora') {
+			if ($serverdata['platform'] == 'diaspora') {
 				$serverdata['network'] = Protocol::DIASPORA;
-			} elseif ($serverdata['platform'] == 'Friendica') {
+			} elseif ($serverdata['platform'] == 'friendica') {
 				$serverdata['network'] = Protocol::DFRN;
 			} elseif ($serverdata['platform'] == 'hubzilla') {
 				$serverdata['network'] = Protocol::ZOT;
@@ -528,7 +528,7 @@ class GServer
 
 		if (is_array($nodeinfo['software'])) {
 			if (!empty($nodeinfo['software']['name'])) {
-				$server['platform'] = $nodeinfo['software']['name'];
+				$server['platform'] = strtolower($nodeinfo['software']['name']);
 			}
 
 			if (!empty($nodeinfo['software']['version'])) {
@@ -605,7 +605,7 @@ class GServer
 
 		if (is_array($nodeinfo['software'])) {
 			if (!empty($nodeinfo['software']['name'])) {
-				$server['platform'] = $nodeinfo['software']['name'];
+				$server['platform'] = strtolower($nodeinfo['software']['name']);
 			}
 
 			if (!empty($nodeinfo['software']['version'])) {
@@ -673,7 +673,7 @@ class GServer
 		}
 
 		if (!empty($data['url'])) {
-			$serverdata['platform'] = $data['platform'];
+			$serverdata['platform'] = strtolower($data['platform']);
 			$serverdata['version'] = $data['version'];
 		}
 
@@ -940,7 +940,7 @@ class GServer
 		}
 
 		if (!empty($serverdata['version']) && preg_match('/.*?\(compatible;\s(.*)\s(.*)\)/ism', $serverdata['version'], $matches)) {
-			$serverdata['platform'] = $matches[1];
+			$serverdata['platform'] = strtolower($matches[1]);
 			$serverdata['version'] = $matches[2];
 		}
 
@@ -977,22 +977,22 @@ class GServer
 		}
 
 		if (!empty($data['site']['platform'])) {
-			$serverdata['platform'] = $data['site']['platform']['PLATFORM_NAME'];
+			$serverdata['platform'] = strtolower($data['site']['platform']['PLATFORM_NAME']);
 			$serverdata['version'] = $data['site']['platform']['STD_VERSION'];
 			$serverdata['network'] = Protocol::ZOT;
 		}
 
 		if (!empty($data['site']['hubzilla'])) {
-			$serverdata['platform'] = $data['site']['hubzilla']['PLATFORM_NAME'];
+			$serverdata['platform'] = strtolower($data['site']['hubzilla']['PLATFORM_NAME']);
 			$serverdata['version'] = $data['site']['hubzilla']['RED_VERSION'];
 			$serverdata['network'] = Protocol::ZOT;
 		}
 
 		if (!empty($data['site']['redmatrix'])) {
 			if (!empty($data['site']['redmatrix']['PLATFORM_NAME'])) {
-				$serverdata['platform'] = $data['site']['redmatrix']['PLATFORM_NAME'];
+				$serverdata['platform'] = strtolower($data['site']['redmatrix']['PLATFORM_NAME']);
 			} elseif (!empty($data['site']['redmatrix']['RED_PLATFORM'])) {
-				$serverdata['platform'] = $data['site']['redmatrix']['RED_PLATFORM'];
+				$serverdata['platform'] = strtolower($data['site']['redmatrix']['RED_PLATFORM']);
 			}
 
 			$serverdata['version'] = $data['site']['redmatrix']['RED_VERSION'];
@@ -1149,7 +1149,7 @@ class GServer
 				break;
 		}
 
-		$serverdata['platform'] = $data['platform'] ?? '';
+		$serverdata['platform'] = strtolower($data['platform'] ?? '');
 
 		return $serverdata;
 	}
@@ -1198,20 +1198,20 @@ class GServer
 			}
 
 			if ($attr['name'] == 'application-name') {
-				$serverdata['platform'] = $attr['content'];
+				$serverdata['platform'] = strtolower($attr['content']);
  				if (in_array($attr['content'], ['Misskey', 'Write.as'])) {
 					$serverdata['network'] = Protocol::ACTIVITYPUB;
 				}
 			}
 
 			if ($attr['name'] == 'generator') {
-				$serverdata['platform'] = $attr['content'];
+				$serverdata['platform'] = strtolower($attr['content']);
 
 				$version_part = explode(' ', $attr['content']);
 
 				if (count($version_part) == 2) {
 					if (in_array($version_part[0], ['WordPress'])) {
-						$serverdata['platform'] = $version_part[0];
+						$serverdata['platform'] = strtolower($version_part[0]);
 						$serverdata['version'] = $version_part[1];
 
 						// We still do need a reliable test if some AP plugin is activated
@@ -1222,7 +1222,7 @@ class GServer
 						}
 					}
 					if (in_array($version_part[0], ['Friendika', 'Friendica'])) {
-						$serverdata['platform'] = $version_part[0];
+						$serverdata['platform'] = strtolower($version_part[0]);
 						$serverdata['version'] = $version_part[1];
 						$serverdata['network'] = Protocol::DFRN;
 					}
@@ -1258,7 +1258,7 @@ class GServer
 			}
 
 			if ($attr['property'] == 'og:platform') {
-				$serverdata['platform'] = $attr['content'];
+				$serverdata['platform'] = strtolower($attr['content']);
 
 				if (in_array($attr['content'], ['PeerTube'])) {
 					$serverdata['network'] = Protocol::ACTIVITYPUB;
@@ -1266,7 +1266,7 @@ class GServer
 			}
 
 			if ($attr['property'] == 'generator') {
-				$serverdata['platform'] = $attr['content'];
+				$serverdata['platform'] = strtolower($attr['content']);
 
 				if (in_array($attr['content'], ['hubzilla'])) {
 					// We later check which compatible protocol modules are loaded.

--- a/src/Module/Admin/Federation.php
+++ b/src/Module/Admin/Federation.php
@@ -17,7 +17,7 @@ class Federation extends BaseAdminModule
 		// get counts on active federation systems this node is knowing
 		// We list the more common systems by name. The rest is counted as "other"
 		$systems = [
-			'Friendica'   => ['name' => 'Friendica', 'color' => '#ffc018'], // orange from the logo
+			'friendica'   => ['name' => 'Friendica', 'color' => '#ffc018'], // orange from the logo
 			'diaspora'    => ['name' => 'Diaspora', 'color' => '#a1a1a1'], // logo is black and white, makes a gray
 			'funkwhale'   => ['name' => 'Funkwhale', 'color' => '#4082B4'], // From the homepage
 			'gnusocial'   => ['name' => 'GNU Social/Statusnet', 'color' => '#a22430'], // dark red from the logo
@@ -66,11 +66,11 @@ class Federation extends BaseAdminModule
 			}
 			DBA::close($versions);
 
-			$platform = $gserver['platform'];
+			$platform = $gserver['platform'] = strtolower($gserver['platform']);
 
-			if ($platform == 'Friendika') {
-				$platform = 'Friendica';
-			} elseif (in_array($platform, ['Red Matrix', 'redmatrix', 'red'])) {
+			if ($platform == 'friendika') {
+				$platform = 'friendica';
+			} elseif (in_array($platform, ['red matrix', 'redmatrix', 'red'])) {
 				$platform = 'hubzilla';
 			} elseif(stristr($platform, 'pleroma')) {
 				$platform = 'pleroma';
@@ -96,7 +96,7 @@ class Federation extends BaseAdminModule
 				$gserver['users'] += $counts[$platform][0]['users'] ?? 0;
 			}
 
-			if ($platform == 'Friendica') {
+			if ($platform == 'friendica') {
 				$versionCounts = self::reformaFriendicaVersions($versionCounts);
 			} elseif ($platform == 'pleroma') {
 				$versionCounts = self::reformaPleromaVersions($versionCounts);

--- a/src/Module/Friendica.php
+++ b/src/Module/Friendica.php
@@ -154,7 +154,7 @@ class Friendica extends BaseModule
 			'register_policy'  => $register_policy,
 			'admin'            => $admin,
 			'site_name'        => $config->get('config', 'sitename'),
-			'platform'         => FRIENDICA_PLATFORM,
+			'platform'         => strtolower(FRIENDICA_PLATFORM),
 			'info'             => $config->get('config', 'info'),
 			'no_scrape_url'    => DI::baseUrl()->get() . '/noscrape',
 		];

--- a/src/Module/NodeInfo.php
+++ b/src/Module/NodeInfo.php
@@ -118,15 +118,15 @@ class NodeInfo extends BaseModule
 		$nodeinfo = [
 			'version'           => '1.0',
 			'software'          => [
-				'name'    => 'Friendica',
+				'name'    => 'friendica',
 				'version' => FRIENDICA_VERSION . '-' . DB_UPDATE_VERSION,
 			],
 			'protocols'         => [
 				'inbound'  => [
-					'friendica', 'activitypub'
+					'friendica'
 				],
 				'outbound' => [
-					'friendica', 'activitypub'
+					'friendica'
 				],
 			],
 			'services'          => [],
@@ -181,7 +181,7 @@ class NodeInfo extends BaseModule
 		$nodeinfo = [
 			'version'           => '2.0',
 			'software'          => [
-				'name'    => 'Friendica',
+				'name'    => 'friendica',
 				'version' => FRIENDICA_VERSION . '-' . DB_UPDATE_VERSION,
 			],
 			'protocols'         => ['dfrn', 'activitypub'],


### PR DESCRIPTION
We now store our platform data in lowercase. I realized that our published nodeinfo data had been invalid, due to uppercase letters. This is corrected. The behaviour is now unified so that we always publish in lowercase and we convert the platform data to lowercase as well.