### PR TITLE
Improved spam protection

### DIFF
--- a/src/Module/Register.php
+++ b/src/Module/Register.php
@@ -121,6 +121,7 @@ class Register extends BaseModule
 			'$openid'       => $openid_url,
 			'$namelabel'    => L10n::t('Your Full Name (e.g. Joe Smith, real or real-looking): '),
 			'$addrlabel'    => L10n::t('Your Email Address: (Initial information will be send there, so this has to be an existing address.)'),
+			'$addrlabel2'   => L10n::t('Please repeat your e-mail address:'),
 			'$ask_password' => $ask_password,
 			'$password1'    => ['password1', L10n::t('New Password:'), '', L10n::t('Leave empty for an auto generated password.')],
 			'$password2'    => ['confirm', L10n::t('Confirm:'), '', ''],
@@ -196,6 +197,24 @@ class Register extends BaseModule
 
 		$arr = $_POST;
 
+		// Is there text in the tar pit?
+		if (!empty($arr['email'])) {
+			Logger::info('Tar pit', $arr);
+			notice(L10n::t('You have entered too much information.'));
+			DI::baseUrl()->redirect('register/');
+		}
+
+
+		// Overwriting the "tar pit" field with the real one
+		$arr['email'] = $arr['field1'];
+
+		if ($arr['email'] != $arr['repeat']) {
+			Logger::info('Mail mismatch', $arr);
+			notice(L10n::t('Please enter the identical mail address in the second field.'));
+			$regdata = ['email' => $arr['email'], 'nickname' => $arr['nickname'], 'username' => $arr['username']];
+			DI::baseUrl()->redirect('register?' . http_build_query($regdata));
+		}
+
 		$arr['blocked'] = $blocked;
 		$arr['verified'] = $verified;
 		$arr['language'] = L10nClass::detectLanguage($_SERVER, $_GET, DI::config()->get('system', 'language'));
@@ -261,11 +280,6 @@ class Register extends BaseModule
 				\notice(L10n::t('You have to leave a request note for the admin.')
 					. L10n::t('Your registration can not be processed.') . EOL);
 
-				DI::baseUrl()->redirect('register/');
-			}
-			// Is there text in the tar pit?
-			if (!empty($_POST['registertarpit'])) {
-				\notice(L10n::t('You have entered too much information.'));
 				DI::baseUrl()->redirect('register/');
 			}
 

--- a/view/templates/register.tpl
+++ b/view/templates/register.tpl
@@ -14,7 +14,7 @@
 
 {{if $oidlabel}}
 	<div id="register-openid-wrapper" >
-    	<label for="register-openid" id="label-register-openid" >{{$oidlabel}}</label><input type="text" maxlength="60" size="32" name="openid_url" class="openid" id="register-openid" value="{{$openid}}" >
+	<label for="register-openid" id="label-register-openid" >{{$oidlabel}}</label><input type="text" maxlength="60" size="32" name="openid_url" class="openid" id="register-openid" value="{{$openid}}" >
 	</div>
 	<div id="register-openid-end" ></div>
 {{/if}}
@@ -30,16 +30,22 @@
 
 	<div id="register-name-wrapper" >
 		<label for="register-name" id="label-register-name" >{{$namelabel}}</label>
-		<input type="text" maxlength="60" size="32" name="username" id="register-name" value="{{$username}}" >
+		<input type="text" maxlength="60" size="32" name="username" id="register-name" value="{{$username}}" required>
 	</div>
 	<div id="register-name-end" ></div>
 
 
 	<div id="register-email-wrapper" >
 		<label for="register-email" id="label-register-email" >{{$addrlabel}}</label>
-		<input type="text" maxlength="60" size="32" name="email" id="register-email" value="{{$email}}" >
+		<input type="text" maxlength="60" size="32" name="field1" id="register-email" value="{{$email}}" required>
 	</div>
 	<div id="register-email-end" ></div>
+
+	<div id="register-repeat-wrapper" >
+		<label for="register-repeat" id="label-register-repeat" >{{$addrlabel2}}</label>
+		<input type="text" maxlength="60" size="32" name="repeat" id="register-repeat" value="" required>
+	</div>
+	<div id="register-repeat-end" ></div>
 
 {{if $ask_password}}
 	{{include file="field_password.tpl" field=$password1}}
@@ -50,13 +56,14 @@
 
 	<div id="register-nickname-wrapper" >
 		<label for="register-nickname" id="label-register-nickname" >{{$nicklabel}}</label>
-		<input type="text" maxlength="60" size="32" name="nickname" id="register-nickname" value="{{$nickname}}" ><div id="register-sitename">@{{$sitename}}</div>
+		<input type="text" maxlength="60" size="32" name="nickname" id="register-nickname" value="{{$nickname}}" required><div id="register-sitename">@{{$sitename}}</div>
 	</div>
 	<div id="register-nickname-end" ></div>
 
+	<input type="input" id=tarpit" name="email" style="display: none;" placeholder="Don't enter anything here"/>
+
 {{if $permonly}}
-    {{include file="field_textarea.tpl" field=$permonlybox}}
-	<input type="input" id="registertarpit" style="display: none;" placeholder="Don't enter anything here" />
+	{{include file="field_textarea.tpl" field=$permonlybox}}
 {{/if}}
 
 	{{$publish nofilter}}

--- a/view/theme/frio/templates/register.tpl
+++ b/view/theme/frio/templates/register.tpl
@@ -31,16 +31,22 @@
 
 		<div id="register-name-wrapper" class="form-group">
 			<label for="register-name" id="label-register-name" >{{$namelabel}}</label>
-			<input type="text" maxlength="60" size="32" name="username" id="register-name" class="form-control" value="{{$username}}">
+			<input type="text" maxlength="60" size="32" name="username" id="register-name" class="form-control" value="{{$username}}" required>
 		</div>
 		<div id="register-name-end" ></div>
 
 
 		<div id="register-email-wrapper" class="form-group">
 			<label for="register-email" id="label-register-email" >{{$addrlabel}}</label>
-			<input type="text" maxlength="60" size="32" name="email" id="register-email" class="form-control" value="{{$email}}">
+			<input type="text" maxlength="60" size="32" name="field1" id="register-email" class="form-control" value="{{$email}}" required>
 		</div>
 		<div id="register-email-end" ></div>
+
+		<div id="register-repeat-wrapper" class="form-group">
+			<label for="register-repeat" id="label-register-repeat" >{{$addrlabel2}}</label>
+			<input type="text" maxlength="60" size="32" name="repeat" id="register-repeat" class="form-control" value="" required>
+		</div>
+		<div id="register-repeat-end" ></div>
 
 		{{if $ask_password}}
 		{{include file="field_password.tpl" field=$password1}}
@@ -49,14 +55,15 @@
 
 		<div id="register-nickname-wrapper" class="form-group">
 			<label for="register-nickname" id="label-register-nickname" >{{$nicklabel}}</label>
-			<input type="text" maxlength="60" size="32" name="nickname" id="register-nickname" class="form-control" value="{{$nickname}}">
+			<input type="text" maxlength="60" size="32" name="nickname" id="register-nickname" class="form-control" value="{{$nickname}}" required>
 			<span class="help-block" id="nickname_tip">{{$nickdesc nofilter}}</span>
 		</div>
 		<div id="register-nickname-end" ></div>
 
+		<input type="input" id=tarpit" name="email" style="display: none;" placeholder="Don't enter anything here"/>
+
 		{{if $permonly}}
 		{{include file="field_textarea.tpl" field=$permonlybox}}
-		<input type="input" id="registertarpit" style="display: none;" placeholder="Don't enter anything here"/>
 		{{/if}}
 
 		{{$publish nofilter}}

--- a/view/theme/vier/style.css
+++ b/view/theme/vier/style.css
@@ -2424,6 +2424,7 @@ aside #id_password {
 
 #register-name-end,
 #register-email-end,
+#register-repeat-end,
 #register-nickname-end {
 	clear: both;
 }


### PR DESCRIPTION
This improves the existing tar pit. The tar pit input field was missing a "name" attribute, so it wasn't usable at all.

Additionally I guess that spam tools look for the content of the name attribute to check which field contains the mail address (the rest of the fields seem to be entered just with random data). Based on this assumption the "email" field is now named differently and the tar pit is named "email".

Additionally you have to repeat your mail address (which does also make sense when someone mistyped it. Also the fields are now marked as "required.