### PR TITLE
Ensure that local contacts always are DFRN contacts

### DIFF
--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -315,6 +315,29 @@ class Contact
 	}
 
 	/**
+	 * Check if the given contact ID is on the same server
+	 *
+	 * @param string $url The contact link
+	 *
+	 * @return boolean Is it the same server?
+	 */
+	public static function isLocalById(int $cid)
+	{
+		$contact = DBA::selectFirst('contact', ['url', 'baseurl'], ['id' => $cid]);
+		if (!DBA::isResult($contact)) {
+			return false;
+		}
+
+		if (empty($contact['baseurl'])) {
+			$baseurl = self::getBasepath($contact['url'], true);
+		} else {
+			$baseurl = $contact['baseurl'];
+		}
+
+		return Strings::compareLink($baseurl, DI::baseUrl());
+	}
+
+	/**
 	 * Returns the public contact id of the given user id
 	 *
 	 * @param  integer $uid User ID
@@ -2126,6 +2149,12 @@ class Contact
 			if ($force) {
 				self::updateContact($id, $uid, $ret['url'], ['last-update' => $updated, 'success_update' => $updated]);
 			}
+
+			// Update the public contact
+			if ($uid != 0) {
+				self::updateFromProbeByURL($ret['url']);
+			}
+
 			return true;
 		}
 

--- a/src/Network/Probe.php
+++ b/src/Network/Probe.php
@@ -401,6 +401,11 @@ class Probe
 			$data['network'] = Protocol::PHANTOM;
 		}
 
+		// Ensure that local connections always are DFRN
+		if (($network == '') && ($data['network'] != Protocol::PHANTOM) && (self::ownHost($data['baseurl'] ?? '') || self::ownHost($data['url']))) {
+			$data['network'] = Protocol::DFRN;
+		}
+
 		if (!isset($data['hide']) && in_array($data['network'], Protocol::FEDERATED)) {
 			$data['hide'] = self::getHideStatus($data['url']);
 		}

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -857,13 +857,13 @@ class Processor
 	 */
 	private static function switchContact($cid)
 	{
-		$contact = DBA::selectFirst('contact', ['network'], ['id' => $cid, 'network' => Protocol::NATIVE_SUPPORT]);
-		if (!DBA::isResult($contact) || in_array($contact['network'], [Protocol::ACTIVITYPUB, Protocol::DFRN])) {
+		$contact = DBA::selectFirst('contact', ['network', 'url'], ['id' => $cid]);
+		if (!DBA::isResult($contact) || in_array($contact['network'], [Protocol::ACTIVITYPUB, Protocol::DFRN]) || Contact::isLocal($contact['url'])) {
 			return;
 		}
 
-		Logger::log('Change existing contact ' . $cid . ' from ' . $contact['network'] . ' to ActivityPub.');
-		Contact::updateFromProbe($cid, Protocol::ACTIVITYPUB);
+		Logger::info('Change existing contact', ['cid' => $cid, 'previous' => $contact['network']]);
+		Contact::updateFromProbe($cid);
 	}
 
 	/**

--- a/src/Worker/Cron.php
+++ b/src/Worker/Cron.php
@@ -177,12 +177,12 @@ class Cron
 				FROM `user`
 				STRAIGHT_JOIN `contact`
 				ON `contact`.`uid` = `user`.`uid` AND `contact`.`poll` != ''
-					AND `contact`.`network` IN (?, ?, ?, ?)
+					AND `contact`.`network` IN (?, ?, ?, ?, ?)
 					AND NOT `contact`.`self` AND NOT `contact`.`blocked`
 					AND `contact`.`rel` != ?
 				WHERE NOT `user`.`account_expired` AND NOT `user`.`account_removed`";
 
-		$parameters = [Protocol::DFRN, Protocol::OSTATUS, Protocol::FEED, Protocol::MAIL, Contact::FOLLOWER];
+		$parameters = [Protocol::DFRN, Protocol::ACTIVITYPUB, Protocol::OSTATUS, Protocol::FEED, Protocol::MAIL, Contact::FOLLOWER];
 
 		// Only poll from those with suitable relationships,
 		// and which have a polling address and ignore Diaspora since
@@ -207,6 +207,11 @@ class Cron
 			// Friendica and OStatus are checked once a day
 			if (in_array($contact['network'], [Protocol::DFRN, Protocol::OSTATUS])) {
 				$contact['priority'] = 3;
+			}
+
+			// ActivityPub is checked once a week
+			if ($contact['network'] == Protocol::ACTIVITYPUB) {
+				$contact['priority'] = 4;
 			}
 
 			// Check archived contacts once a month

--- a/src/Worker/OnePoll.php
+++ b/src/Worker/OnePoll.php
@@ -38,14 +38,18 @@ class OnePoll
 			return;
 		}
 
-		if ($force) {
-			Contact::updateFromProbe($contact_id, '', true);
-		}
+		Contact::updateFromProbe($contact_id, '', $force);
 
 		$contact = DBA::selectFirst('contact', [], ['id' => $contact_id]);
 		if (!DBA::isResult($contact)) {
 			Logger::log('Contact not found or cannot be used.');
 			return;
+		}
+
+		// Special treatment for wrongly detected local contacts
+		if (!$force && ($contact['network'] != Protocol::DFRN) && Contact::isLocalById($contact_id)) {
+			Contact::updateFromProbe($contact_id, Protocol::DFRN, true);
+			$contact = DBA::selectFirst('contact', [], ['id' => $contact_id]);
 		}
 
 		if (($contact['network'] == Protocol::DFRN) && !Contact::isLegacyDFRNContact($contact)) {


### PR DESCRIPTION
For some reason Friendica servers are sometimes detected as AP servers. This should be fixed for some time now. But now we do check AP contacts weekly, so the contacts will be repaired over time.

Also some additional checks are added that should ensure that local contacts are always detected as DFRN.

Possibly this solves the communication problems with local forums, possibly not.