### PR TITLE
Delegations now work again

### DIFF
--- a/src/Module/Settings/Delegation.php
+++ b/src/Module/Settings/Delegation.php
@@ -28,7 +28,7 @@ class Delegation extends BaseSettingsModule
 
 		BaseModule::checkFormSecurityTokenRedirectOnError('settings/delegation', 'delegate');
 
-		$parent_uid = $_POST['parent_user'] ?? 0;
+		$parent_uid = (int)$_POST['parent_user'] ?? 0;
 		$parent_password = $_POST['parent_password'] ?? '';
 
 		if ($parent_uid != 0) {


### PR DESCRIPTION
In the user function `getAuthenticationInfo` there is a check for `is_int` of the provided user data. Depending on the type of the variable the one check is done - or the other. The user id wasn't casted as integer, so it was transmitted as string - and so the user couldn't be detected and delegations didn't work.