### PR TITLE
CleanUp Cache namespace

### DIFF
--- a/mod/ping.php
+++ b/mod/ping.php
@@ -6,7 +6,7 @@
 use Friendica\App;
 use Friendica\Content\ForumManager;
 use Friendica\Content\Text\BBCode;
-use Friendica\Core\Cache\Cache;
+use Friendica\Core\Cache\Duration;
 use Friendica\Core\Config;
 use Friendica\Core\Hook;
 use Friendica\Core\L10n;
@@ -208,7 +208,7 @@ function ping_init(App $a)
 				DBA::escape(DateTimeFormat::utcNow())
 			);
 			if (DBA::isResult($ev)) {
-				DI::cache()->set($cachekey, $ev, Cache::HOUR);
+				DI::cache()->set($cachekey, $ev, Duration::HOUR);
 			}
 		}
 

--- a/src/Console/Cache.php
+++ b/src/Console/Cache.php
@@ -4,7 +4,7 @@ namespace Friendica\Console;
 
 use Asika\SimpleConsole\CommandArgsException;
 use Friendica\App;
-use Friendica\Core\Cache\Cache as CacheClass;
+use Friendica\Core\Cache\Duration;
 use Friendica\Core\Cache\ICache;
 use RuntimeException;
 
@@ -154,7 +154,7 @@ HELP;
 		if (count($this->args) >= 3) {
 			$key      = $this->getArgument(1);
 			$value    = $this->getArgument(2);
-			$duration = intval($this->getArgument(3, CacheClass::FIVE_MINUTES));
+			$duration = intval($this->getArgument(3, Duration::FIVE_MINUTES));
 
 			if (is_array($this->cache->get($key))) {
 				throw new RuntimeException("$key is an array and can't be set using this command.");

--- a/src/Content/OEmbed.php
+++ b/src/Content/OEmbed.php
@@ -10,7 +10,7 @@ use DOMNode;
 use DOMText;
 use DOMXPath;
 use Exception;
-use Friendica\Core\Cache\Cache;
+use Friendica\Core\Cache\Duration;
 use Friendica\Core\Config;
 use Friendica\Core\Hook;
 use Friendica\Core\L10n;
@@ -120,9 +120,9 @@ class OEmbed
 					'content' => $json_string,
 					'created' => DateTimeFormat::utcNow()
 				], true);
-				$cache_ttl = Cache::DAY;
+				$cache_ttl = Duration::DAY;
 			} else {
-				$cache_ttl = Cache::FIVE_MINUTES;
+				$cache_ttl = Duration::FIVE_MINUTES;
 			}
 
 			DI::cache()->set($cache_key, $json_string, $cache_ttl);

--- a/src/Core/BaseCache.php
+++ b/src/Core/BaseCache.php
@@ -1,33 +1,14 @@
 <?php
 
-namespace Friendica\Core\Cache;
+namespace Friendica\Core;
+
+use Friendica\Core\Cache\ICache;
 
 /**
  * Abstract class for common used functions
- *
- * Class AbstractCache
- *
- * @package Friendica\Core\Cache
  */
-abstract class Cache implements ICache
+abstract class BaseCache implements ICache
 {
-	const TYPE_APCU      = 'apcu';
-	const TYPE_ARRAY     = 'array';
-	const TYPE_DATABASE  = 'database';
-	const TYPE_MEMCACHE  = 'memcache';
-	const TYPE_MEMCACHED = 'memcached';
-	const TYPE_REDIS     = 'redis';
-
-	const MONTH        = 2592000;
-	const WEEK         = 604800;
-	const DAY          = 86400;
-	const HOUR         = 3600;
-	const HALF_HOUR    = 1800;
-	const QUARTER_HOUR = 900;
-	const FIVE_MINUTES = 300;
-	const MINUTE       = 60;
-	const INFINITE     = 0;
-
 	/**
 	 * @var string The hostname
 	 */

--- a/src/Core/Cache/APCuCache.php
+++ b/src/Core/Cache/APCuCache.php
@@ -3,13 +3,14 @@
 namespace Friendica\Core\Cache;
 
 use Exception;
+use Friendica\Core\BaseCache;
 
 /**
  * APCu Cache.
  *
  * @author Philipp Holzer <admin@philipp.info>
  */
-class APCuCache extends Cache implements IMemoryCache
+class APCuCache extends BaseCache implements IMemoryCache
 {
 	use TraitCompareSet;
 	use TraitCompareDelete;
@@ -76,7 +77,7 @@ class APCuCache extends Cache implements IMemoryCache
 	/**
 	 * (@inheritdoc)
 	 */
-	public function set($key, $value, $ttl = Cache::FIVE_MINUTES)
+	public function set($key, $value, $ttl = Duration::FIVE_MINUTES)
 	{
 		$cachekey = $this->getCacheKey($key);
 
@@ -129,7 +130,7 @@ class APCuCache extends Cache implements IMemoryCache
 	/**
 	 * (@inheritdoc)
 	 */
-	public function add($key, $value, $ttl = Cache::FIVE_MINUTES)
+	public function add($key, $value, $ttl = Duration::FIVE_MINUTES)
 	{
 		$cachekey = $this->getCacheKey($key);
 		$cached = serialize($value);
@@ -158,6 +159,6 @@ class APCuCache extends Cache implements IMemoryCache
 	 */
 	public function getName()
 	{
-		return self::TYPE_APCU;
+		return Type::APCU;
 	}
 }

--- a/src/Core/Cache/ArrayCache.php
+++ b/src/Core/Cache/ArrayCache.php
@@ -2,6 +2,8 @@
 
 namespace Friendica\Core\Cache;
 
+use Friendica\Core\BaseCache;
+
 /**
  * Implementation of the IMemoryCache mainly for testing purpose
  *
@@ -9,7 +11,7 @@ namespace Friendica\Core\Cache;
  *
  * @package Friendica\Core\Cache
  */
-class ArrayCache extends Cache implements IMemoryCache
+class ArrayCache extends BaseCache implements IMemoryCache
 {
 	use TraitCompareDelete;
 
@@ -38,7 +40,7 @@ class ArrayCache extends Cache implements IMemoryCache
 	/**
 	 * (@inheritdoc)
 	 */
-	public function set($key, $value, $ttl = Cache::FIVE_MINUTES)
+	public function set($key, $value, $ttl = Duration::FIVE_MINUTES)
 	{
 		$this->cachedData[$key] = $value;
 		return true;
@@ -70,7 +72,7 @@ class ArrayCache extends Cache implements IMemoryCache
 	/**
 	 * (@inheritdoc)
 	 */
-	public function add($key, $value, $ttl = Cache::FIVE_MINUTES)
+	public function add($key, $value, $ttl = Duration::FIVE_MINUTES)
 	{
 		if (isset($this->cachedData[$key])) {
 			return false;
@@ -82,7 +84,7 @@ class ArrayCache extends Cache implements IMemoryCache
 	/**
 	 * (@inheritdoc)
 	 */
-	public function compareSet($key, $oldValue, $newValue, $ttl = Cache::FIVE_MINUTES)
+	public function compareSet($key, $oldValue, $newValue, $ttl = Duration::FIVE_MINUTES)
 	{
 		if ($this->get($key) === $oldValue) {
 			return $this->set($key, $newValue);
@@ -96,6 +98,6 @@ class ArrayCache extends Cache implements IMemoryCache
 	 */
 	public function getName()
 	{
-		return self::TYPE_ARRAY;
+		return Type::ARRAY;
 	}
 }

--- a/src/Core/Cache/DatabaseCache.php
+++ b/src/Core/Cache/DatabaseCache.php
@@ -4,13 +4,14 @@ namespace Friendica\Core\Cache;
 
 use Friendica\Database\Database;
 use Friendica\Util\DateTimeFormat;
+use Friendica\Core\BaseCache;
 
 /**
  * Database Cache
  *
  * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
-class DatabaseCache extends Cache implements ICache
+class DatabaseCache extends BaseCache implements ICache
 {
 	/**
 	 * @var Database
@@ -71,7 +72,7 @@ class DatabaseCache extends Cache implements ICache
 	/**
 	 * (@inheritdoc)
 	 */
-	public function set($key, $value, $ttl = Cache::FIVE_MINUTES)
+	public function set($key, $value, $ttl = Duration::FIVE_MINUTES)
 	{
 		if ($ttl > 0) {
 			$fields = [
@@ -115,6 +116,6 @@ class DatabaseCache extends Cache implements ICache
 	 */
 	public function getName()
 	{
-		return self::TYPE_DATABASE;
+		return Type::DATABASE;
 	}
 }

--- a/src/Core/Cache/Duration.php
+++ b/src/Core/Cache/Duration.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Friendica\Core\Cache;
+
+/**
+ * Enumeration for cache durations
+ */
+abstract class Duration
+{
+	const MONTH        = 2592000;
+	const HOUR         = 3600;
+	const HALF_HOUR    = 1800;
+	const QUARTER_HOUR = 900;
+	const MINUTE       = 60;
+	const WEEK         = 604800;
+	const INFINITE     = 0;
+	const DAY          = 86400;
+	const FIVE_MINUTES = 300;
+}

--- a/src/Core/Cache/ICache.php
+++ b/src/Core/Cache/ICache.php
@@ -36,7 +36,7 @@ interface ICache
 	 *
 	 * @return bool
 	 */
-	public function set($key, $value, $ttl = Cache::FIVE_MINUTES);
+	public function set($key, $value, $ttl = Duration::FIVE_MINUTES);
 
 	/**
 	 * Delete a key from the cache

--- a/src/Core/Cache/IMemoryCache.php
+++ b/src/Core/Cache/IMemoryCache.php
@@ -19,7 +19,7 @@ interface IMemoryCache extends ICache
 	 * @param int    $ttl      The cache lifespan, must be one of the Cache constants
 	 * @return bool
 	 */
-	public function add($key, $value, $ttl = Cache::FIVE_MINUTES);
+	public function add($key, $value, $ttl = Duration::FIVE_MINUTES);
 
 	/**
 	 * Compares if the old value is set and sets the new value
@@ -31,7 +31,7 @@ interface IMemoryCache extends ICache
 	 *
 	 * @return bool
 	 */
-	public function compareSet($key, $oldValue, $newValue, $ttl = Cache::FIVE_MINUTES);
+	public function compareSet($key, $oldValue, $newValue, $ttl = Duration::FIVE_MINUTES);
 
 	/**
 	 * Compares if the old value is set and removes it

--- a/src/Core/Cache/MemcacheCache.php
+++ b/src/Core/Cache/MemcacheCache.php
@@ -3,6 +3,7 @@
 namespace Friendica\Core\Cache;
 
 use Exception;
+use Friendica\Core\BaseCache;
 use Friendica\Core\Config\IConfiguration;
 use Memcache;
 
@@ -11,7 +12,7 @@ use Memcache;
  *
  * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
-class MemcacheCache extends Cache implements IMemoryCache
+class MemcacheCache extends BaseCache implements IMemoryCache
 {
 	use TraitCompareSet;
 	use TraitCompareDelete;
@@ -84,7 +85,7 @@ class MemcacheCache extends Cache implements IMemoryCache
 	/**
 	 * (@inheritdoc)
 	 */
-	public function set($key, $value, $ttl = Cache::FIVE_MINUTES)
+	public function set($key, $value, $ttl = Duration::FIVE_MINUTES)
 	{
 		$cachekey = $this->getCacheKey($key);
 
@@ -129,7 +130,7 @@ class MemcacheCache extends Cache implements IMemoryCache
 	/**
 	 * (@inheritdoc)
 	 */
-	public function add($key, $value, $ttl = Cache::FIVE_MINUTES)
+	public function add($key, $value, $ttl = Duration::FIVE_MINUTES)
 	{
 		$cachekey = $this->getCacheKey($key);
 		return $this->memcache->add($cachekey, serialize($value), MEMCACHE_COMPRESSED, $ttl);
@@ -140,6 +141,6 @@ class MemcacheCache extends Cache implements IMemoryCache
 	 */
 	public function getName()
 	{
-		return self::TYPE_MEMCACHE;
+		return Type::MEMCACHE;
 	}
 }

--- a/src/Core/Cache/MemcachedCache.php
+++ b/src/Core/Cache/MemcachedCache.php
@@ -3,6 +3,7 @@
 namespace Friendica\Core\Cache;
 
 use Exception;
+use Friendica\Core\BaseCache;
 use Friendica\Core\Config\IConfiguration;
 use Memcached;
 use Psr\Log\LoggerInterface;
@@ -12,7 +13,7 @@ use Psr\Log\LoggerInterface;
  *
  * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
-class MemcachedCache extends Cache implements IMemoryCache
+class MemcachedCache extends BaseCache implements IMemoryCache
 {
 	use TraitCompareSet;
 	use TraitCompareDelete;
@@ -102,7 +103,7 @@ class MemcachedCache extends Cache implements IMemoryCache
 	/**
 	 * (@inheritdoc)
 	 */
-	public function set($key, $value, $ttl = Cache::FIVE_MINUTES)
+	public function set($key, $value, $ttl = Duration::FIVE_MINUTES)
 	{
 		$cachekey = $this->getCacheKey($key);
 
@@ -145,7 +146,7 @@ class MemcachedCache extends Cache implements IMemoryCache
 	/**
 	 * (@inheritdoc)
 	 */
-	public function add($key, $value, $ttl = Cache::FIVE_MINUTES)
+	public function add($key, $value, $ttl = Duration::FIVE_MINUTES)
 	{
 		$cachekey = $this->getCacheKey($key);
 		return $this->memcached->add($cachekey, $value, $ttl);
@@ -156,6 +157,6 @@ class MemcachedCache extends Cache implements IMemoryCache
 	 */
 	public function getName()
 	{
-		return self::TYPE_MEMCACHED;
+		return Type::MEMCACHED;
 	}
 }

--- a/src/Core/Cache/ProfilerCache.php
+++ b/src/Core/Cache/ProfilerCache.php
@@ -59,7 +59,7 @@ class ProfilerCache implements ICache, IMemoryCache
 	/**
 	 * {@inheritDoc}
 	 */
-	public function set($key, $value, $ttl = Cache::FIVE_MINUTES)
+	public function set($key, $value, $ttl = Duration::FIVE_MINUTES)
 	{
 		$time = microtime(true);
 
@@ -101,7 +101,7 @@ class ProfilerCache implements ICache, IMemoryCache
 	/**
 	 * {@inheritDoc}
 	 */
-	public function add($key, $value, $ttl = Cache::FIVE_MINUTES)
+	public function add($key, $value, $ttl = Duration::FIVE_MINUTES)
 	{
 		if ($this->cache instanceof IMemoryCache) {
 			$time = microtime(true);
@@ -119,7 +119,7 @@ class ProfilerCache implements ICache, IMemoryCache
 	/**
 	 * {@inheritDoc}
 	 */
-	public function compareSet($key, $oldValue, $newValue, $ttl = Cache::FIVE_MINUTES)
+	public function compareSet($key, $oldValue, $newValue, $ttl = Duration::FIVE_MINUTES)
 	{
 		if ($this->cache instanceof IMemoryCache) {
 			$time = microtime(true);

--- a/src/Core/Cache/RedisCache.php
+++ b/src/Core/Cache/RedisCache.php
@@ -3,6 +3,7 @@
 namespace Friendica\Core\Cache;
 
 use Exception;
+use Friendica\Core\BaseCache;
 use Friendica\Core\Config\IConfiguration;
 use Redis;
 
@@ -12,7 +13,7 @@ use Redis;
  * @author Hypolite Petovan <hypolite@mrpetovan.com>
  * @author Roland Haeder <roland@mxchange.org>
  */
-class RedisCache extends Cache implements IMemoryCache
+class RedisCache extends BaseCache implements IMemoryCache
 {
 	/**
 	 * @var Redis
@@ -96,7 +97,7 @@ class RedisCache extends Cache implements IMemoryCache
 	/**
 	 * (@inheritdoc)
 	 */
-	public function set($key, $value, $ttl = Cache::FIVE_MINUTES)
+	public function set($key, $value, $ttl = Duration::FIVE_MINUTES)
 	{
 		$cachekey = $this->getCacheKey($key);
 
@@ -140,7 +141,7 @@ class RedisCache extends Cache implements IMemoryCache
 	/**
 	 * (@inheritdoc)
 	 */
-	public function add($key, $value, $ttl = Cache::FIVE_MINUTES)
+	public function add($key, $value, $ttl = Duration::FIVE_MINUTES)
 	{
 		$cachekey = $this->getCacheKey($key);
 		$cached = serialize($value);
@@ -151,7 +152,7 @@ class RedisCache extends Cache implements IMemoryCache
 	/**
 	 * (@inheritdoc)
 	 */
-	public function compareSet($key, $oldValue, $newValue, $ttl = Cache::FIVE_MINUTES)
+	public function compareSet($key, $oldValue, $newValue, $ttl = Duration::FIVE_MINUTES)
 	{
 		$cachekey = $this->getCacheKey($key);
 
@@ -199,6 +200,6 @@ class RedisCache extends Cache implements IMemoryCache
 	 */
 	public function getName()
 	{
-		return self::TYPE_REDIS;
+		return Type::REDIS;
 	}
 }

--- a/src/Core/Cache/TraitCompareDelete.php
+++ b/src/Core/Cache/TraitCompareDelete.php
@@ -13,11 +13,11 @@ trait TraitCompareDelete
 {
 	abstract public function get($key);
 
-	abstract public function set($key, $value, $ttl = Cache::FIVE_MINUTES);
+	abstract public function set($key, $value, $ttl = Duration::FIVE_MINUTES);
 
 	abstract public function delete($key);
 
-	abstract public function add($key, $value, $ttl = Cache::FIVE_MINUTES);
+	abstract public function add($key, $value, $ttl = Duration::FIVE_MINUTES);
 
 	/**
 	 * NonNative - Compares if the old value is set and removes it

--- a/src/Core/Cache/TraitCompareSet.php
+++ b/src/Core/Cache/TraitCompareSet.php
@@ -13,11 +13,11 @@ trait TraitCompareSet
 {
 	abstract public function get($key);
 
-	abstract public function set($key, $value, $ttl = Cache::FIVE_MINUTES);
+	abstract public function set($key, $value, $ttl = Duration::FIVE_MINUTES);
 
 	abstract public function delete($key);
 
-	abstract public function add($key, $value, $ttl = Cache::FIVE_MINUTES);
+	abstract public function add($key, $value, $ttl = Duration::FIVE_MINUTES);
 
 	/**
 	 * NonNative - Compares if the old value is set and sets the new value
@@ -29,7 +29,7 @@ trait TraitCompareSet
 	 *
 	 * @return bool
 	 */
-	public function compareSet($key, $oldValue, $newValue, $ttl = Cache::FIVE_MINUTES) {
+	public function compareSet($key, $oldValue, $newValue, $ttl = Duration::FIVE_MINUTES) {
 		if ($this->add($key . "_lock", true)) {
 			if ($this->get($key) === $oldValue) {
 				$this->set($key, $newValue, $ttl);

--- a/src/Core/Cache/Type.php
+++ b/src/Core/Cache/Type.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Friendica\Core\Cache;
+
+/**
+ * Enumeration for cache types
+ */
+abstract class Type
+{
+	const APCU      = 'apcu';
+	const REDIS     = 'redis';
+	const ARRAY     = 'array';
+	const MEMCACHE  = 'memcache';
+	const DATABASE  = 'database';
+	const MEMCACHED = 'memcached';
+}

--- a/src/Core/Lock/CacheLock.php
+++ b/src/Core/Lock/CacheLock.php
@@ -30,7 +30,7 @@ class CacheLock extends Lock
 	/**
 	 * (@inheritdoc)
 	 */
-	public function acquire($key, $timeout = 120, $ttl = Cache\Cache::FIVE_MINUTES)
+	public function acquire($key, $timeout = 120, $ttl = Cache\Duration::FIVE_MINUTES)
 	{
 		$got_lock = false;
 		$start    = time();

--- a/src/Core/Lock/DatabaseLock.php
+++ b/src/Core/Lock/DatabaseLock.php
@@ -2,7 +2,7 @@
 
 namespace Friendica\Core\Lock;
 
-use Friendica\Core\Cache\Cache;
+use Friendica\Core\Cache\Duration;
 use Friendica\Database\Database;
 use Friendica\Util\DateTimeFormat;
 
@@ -35,7 +35,7 @@ class DatabaseLock extends Lock
 	/**
 	 * (@inheritdoc)
 	 */
-	public function acquire($key, $timeout = 120, $ttl = Cache::FIVE_MINUTES)
+	public function acquire($key, $timeout = 120, $ttl = Duration::FIVE_MINUTES)
 	{
 		$got_lock = false;
 		$start    = time();

--- a/src/Core/Lock/ILock.php
+++ b/src/Core/Lock/ILock.php
@@ -30,7 +30,7 @@ interface ILock
 	 *
 	 * @return boolean Was the lock successful?
 	 */
-	public function acquire($key, $timeout = 120, $ttl = Cache\Cache::FIVE_MINUTES);
+	public function acquire($key, $timeout = 120, $ttl = Cache\Duration::FIVE_MINUTES);
 
 	/**
 	 * Releases a lock if it was set by us

--- a/src/Core/Lock/Lock.php
+++ b/src/Core/Lock/Lock.php
@@ -2,7 +2,7 @@
 
 namespace Friendica\Core\Lock;
 
-use Friendica\Core\Cache\Cache;
+use Friendica\Core\Cache\Type;
 
 /**
  * Class AbstractLock
@@ -13,7 +13,7 @@ use Friendica\Core\Cache\Cache;
  */
 abstract class Lock implements ILock
 {
-	const TYPE_DATABASE  = Cache::TYPE_DATABASE;
+	const TYPE_DATABASE  = Type::DATABASE;
 	const TYPE_SEMAPHORE = 'semaphore';
 
 	/**

--- a/src/Core/Lock/SemaphoreLock.php
+++ b/src/Core/Lock/SemaphoreLock.php
@@ -36,7 +36,7 @@ class SemaphoreLock extends Lock
 	/**
 	 * (@inheritdoc)
 	 */
-	public function acquire($key, $timeout = 120, $ttl = Cache\Cache::FIVE_MINUTES)
+	public function acquire($key, $timeout = 120, $ttl = Cache\Duration::FIVE_MINUTES)
 	{
 		self::$semaphore[$key] = sem_get(self::semaphoreKey($key));
 		if (!empty(self::$semaphore[$key])) {

--- a/src/Core/Update.php
+++ b/src/Core/Update.php
@@ -7,7 +7,6 @@ use Friendica\Database\DBA;
 use Friendica\Database\DBStructure;
 use Friendica\DI;
 use Friendica\Util\Strings;
-use Friendica\Core\Cache\Cache;
 
 class Update
 {
@@ -97,7 +96,7 @@ class Update
 
 				// Compare the current structure with the defined structure
 				// If the Lock is acquired, never release it automatically to avoid double updates
-				if (DI::lock()->acquire('dbupdate', 120, Cache::INFINITE)) {
+				if (DI::lock()->acquire('dbupdate', 120, Cache\Duration::INFINITE)) {
 
 					// Checks if the build changed during Lock acquiring (so no double update occurs)
 					$retryBuild = Config::get('system', 'build', null, true);
@@ -183,7 +182,7 @@ class Update
 			// If the update fails or times-out completely you may need to
 			// delete the config entry to try again.
 
-			if (DI::lock()->acquire('dbupdate_function', 120,Cache::INFINITE)) {
+			if (DI::lock()->acquire('dbupdate_function', 120, Cache\Duration::INFINITE)) {
 
 				// call the specific update
 				$retval = $funcname();

--- a/src/Factory/CacheFactory.php
+++ b/src/Factory/CacheFactory.php
@@ -22,7 +22,7 @@ class CacheFactory
 	/**
 	 * @var string The default cache if nothing set
 	 */
-	const DEFAULT_TYPE = Cache\Cache::TYPE_DATABASE;
+	const DEFAULT_TYPE = Cache\Type::DATABASE;
 
 	/**
 	 * @var IConfiguration The IConfiguration to read parameters out of the config
@@ -73,16 +73,16 @@ class CacheFactory
 		}
 
 		switch ($type) {
-			case Cache\Cache::TYPE_MEMCACHE:
+			case Cache\Type::MEMCACHE:
 				$cache = new Cache\MemcacheCache($this->hostname, $this->config);
 				break;
-			case Cache\Cache::TYPE_MEMCACHED:
+			case Cache\Type::MEMCACHED:
 				$cache = new Cache\MemcachedCache($this->hostname, $this->config, $this->logger);
 				break;
-			case Cache\Cache::TYPE_REDIS:
+			case Cache\Type::REDIS:
 				$cache = new Cache\RedisCache($this->hostname, $this->config);
 				break;
-			case Cache\Cache::TYPE_APCU:
+			case Cache\Type::APCU:
 				$cache = new Cache\APCuCache($this->hostname);
 				break;
 			default:

--- a/src/Factory/LockFactory.php
+++ b/src/Factory/LockFactory.php
@@ -2,8 +2,8 @@
 
 namespace Friendica\Factory;
 
-use Friendica\Core\Cache\Cache;
 use Friendica\Core\Cache\IMemoryCache;
+use Friendica\Core\Cache\Type;
 use Friendica\Core\Config\IConfiguration;
 use Friendica\Core\Lock;
 use Friendica\Database\Database;
@@ -57,10 +57,10 @@ class LockFactory
 
 		try {
 			switch ($lock_type) {
-				case Cache::TYPE_MEMCACHE:
-				case Cache::TYPE_MEMCACHED:
-				case Cache::TYPE_REDIS:
-				case Cache::TYPE_APCU:
+				case Type::MEMCACHE:
+				case Type::MEMCACHED:
+				case Type::REDIS:
+				case Type::APCU:
 					$cache = $this->cacheFactory->create($lock_type);
 					if ($cache instanceof IMemoryCache) {
 						return new Lock\CacheLock($cache);
@@ -109,7 +109,7 @@ class LockFactory
 
 		// 2. Try to use Cache Locking (don't use the DB-Cache Locking because it works different!)
 		$cache_type = $this->config->get('system', 'cache_driver', 'database');
-		if ($cache_type != Cache::TYPE_DATABASE) {
+		if ($cache_type != Type::DATABASE) {
 			try {
 				$cache = $this->cacheFactory->create($cache_type);
 				if ($cache instanceof IMemoryCache) {

--- a/src/Factory/SessionFactory.php
+++ b/src/Factory/SessionFactory.php
@@ -3,8 +3,8 @@
 namespace Friendica\Factory;
 
 use Friendica\App;
-use Friendica\Core\Cache\Cache;
 use Friendica\Core\Cache\ICache;
+use Friendica\Core\Cache\Type;
 use Friendica\Core\Config\IConfiguration;
 use Friendica\Core\Session;
 use Friendica\Core\System;
@@ -55,7 +55,7 @@ class SessionFactory
 						break;
 					case self::HANDLER_CACHE:
 						// In case we're using the db as cache driver, use the native db session, not the cache
-						if ($config->get('system', 'cache_driver') === Cache::TYPE_DATABASE) {
+						if ($config->get('system', 'cache_driver') === Type::DATABASE) {
 							$handler = new Session\Handler\Database($dba, $logger, $server);
 						} else {
 							$handler = new Session\Handler\Cache($cache, $logger, $server);

--- a/src/Model/Photo.php
+++ b/src/Model/Photo.php
@@ -6,7 +6,7 @@
  */
 namespace Friendica\Model;
 
-use Friendica\Core\Cache\Cache;
+use Friendica\Core\Cache\Duration;
 use Friendica\Core\Config;
 use Friendica\Core\L10n;
 use Friendica\Core\Logger;
@@ -563,7 +563,7 @@ class Photo
 					DBA::escape(L10n::t("Contact Photos"))
 				);
 			}
-			DI::cache()->set($key, $albums, Cache::DAY);
+			DI::cache()->set($key, $albums, Duration::DAY);
 		}
 		return $albums;
 	}
@@ -576,7 +576,7 @@ class Photo
 	public static function clearAlbumCache($uid)
 	{
 		$key = "photo_albums:".$uid.":".local_user().":".remote_user();
-		DI::cache()->set($key, null, Cache::DAY);
+		DI::cache()->set($key, null, Duration::DAY);
 	}
 
 	/**

--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -10,7 +10,7 @@ use Friendica\Content\ForumManager;
 use Friendica\Content\Text\BBCode;
 use Friendica\Content\Text\HTML;
 use Friendica\Content\Widget\ContactBlock;
-use Friendica\Core\Cache\Cache;
+use Friendica\Core\Cache\Duration;
 use Friendica\Core\Config;
 use Friendica\Core\Hook;
 use Friendica\Core\L10n;
@@ -608,7 +608,7 @@ class Profile
 			);
 			if (DBA::isResult($s)) {
 				$r = DBA::toArray($s);
-				DI::cache()->set($cachekey, $r, Cache::HOUR);
+				DI::cache()->set($cachekey, $r, Duration::HOUR);
 			}
 		}
 
@@ -1070,7 +1070,7 @@ class Profile
 			Logger::log('URL ' . $my_url . ' already tried to authenticate.', Logger::DEBUG);
 			return;
 		} else {
-			DI::cache()->set($cachekey, true, Cache::MINUTE);
+			DI::cache()->set($cachekey, true, Duration::MINUTE);
 		}
 
 		Logger::log('Not authenticated. Invoking reverse magic-auth for ' . $my_url, Logger::DEBUG);

--- a/src/Model/Term.php
+++ b/src/Model/Term.php
@@ -4,7 +4,7 @@
  */
 namespace Friendica\Model;
 
-use Friendica\Core\Cache\Cache;
+use Friendica\Core\Cache\Duration;
 use Friendica\Core\Logger;
 use Friendica\Database\DBA;
 use Friendica\DI;
@@ -84,7 +84,7 @@ class Term
 
 			if (DBA::isResult($tagsStmt)) {
 				$tags = DBA::toArray($tagsStmt);
-				DI::cache()->set('global_trending_tags', $tags, Cache::HOUR);
+				DI::cache()->set('global_trending_tags', $tags, Duration::HOUR);
 			}
 		}
 
@@ -129,7 +129,7 @@ class Term
 
 			if (DBA::isResult($tagsStmt)) {
 				$tags = DBA::toArray($tagsStmt);
-				DI::cache()->set('local_trending_tags', $tags, Cache::HOUR);
+				DI::cache()->set('local_trending_tags', $tags, Duration::HOUR);
 			}
 		}
 

--- a/src/Module/Search/Index.php
+++ b/src/Module/Search/Index.php
@@ -6,7 +6,7 @@ use Friendica\Content\Nav;
 use Friendica\Content\Pager;
 use Friendica\Content\Text\HTML;
 use Friendica\Content\Widget;
-use Friendica\Core\Cache\Cache as CacheClass;
+use Friendica\Core\Cache\Duration;
 use Friendica\Core\Config;
 use Friendica\Core\L10n;
 use Friendica\Core\Logger;
@@ -56,9 +56,9 @@ class Index extends BaseSearchModule
 				if (($resultdata->time > (time() - $crawl_permit_period)) && ($resultdata->accesses > $free_crawls)) {
 					throw new HTTPException\TooManyRequestsException(L10n::t('Only one search per minute is permitted for not logged in users.'));
 				}
-				DI::cache()->set('remote_search:' . $remote, json_encode(['time' => time(), 'accesses' => $resultdata->accesses + 1]), CacheClass::HOUR);
+				DI::cache()->set('remote_search:' . $remote, json_encode(['time' => time(), 'accesses' => $resultdata->accesses + 1]), Duration::HOUR);
 			} else {
-				DI::cache()->set('remote_search:' . $remote, json_encode(['time' => time(), 'accesses' => 1]), CacheClass::HOUR);
+				DI::cache()->set('remote_search:' . $remote, json_encode(['time' => time(), 'accesses' => 1]), Duration::HOUR);
 			}
 		}
 

--- a/src/Network/Probe.php
+++ b/src/Network/Probe.php
@@ -11,7 +11,7 @@ namespace Friendica\Network;
 
 use DOMDocument;
 use DomXPath;
-use Friendica\Core\Cache\Cache;
+use Friendica\Core\Cache\Duration;
 use Friendica\Core\Config;
 use Friendica\Core\Logger;
 use Friendica\Core\Protocol;
@@ -414,7 +414,7 @@ class Probe
 
 		// Only store into the cache if the value seems to be valid
 		if (!in_array($data['network'], [Protocol::PHANTOM, Protocol::MAIL])) {
-			DI::cache()->set('Probe::uri:' . $network . ':' . $uri, $data, Cache::DAY);
+			DI::cache()->set('Probe::uri:' . $network . ':' . $uri, $data, Duration::DAY);
 		}
 
 		return $data;

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -7,7 +7,7 @@ namespace Friendica\Protocol\ActivityPub;
 use Friendica\Content\Feature;
 use Friendica\Content\Text\BBCode;
 use Friendica\Content\Text\Plaintext;
-use Friendica\Core\Cache\Cache;
+use Friendica\Core\Cache\Duration;
 use Friendica\Core\Config;
 use Friendica\Core\Logger;
 use Friendica\Core\Protocol;
@@ -827,7 +827,7 @@ class Transmitter
 
 		$data = ActivityPub\Transmitter::createActivityFromItem($item_id);
 
-		DI::cache()->set($cachekey, $data, Cache::QUARTER_HOUR);
+		DI::cache()->set($cachekey, $data, Duration::QUARTER_HOUR);
 		return $data;
 	}
 

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -13,7 +13,7 @@ namespace Friendica\Protocol;
 use Friendica\Content\Feature;
 use Friendica\Content\Text\BBCode;
 use Friendica\Content\Text\Markdown;
-use Friendica\Core\Cache\Cache;
+use Friendica\Core\Cache\Duration;
 use Friendica\Core\Config;
 use Friendica\Core\L10n;
 use Friendica\Core\Logger;
@@ -3272,7 +3272,7 @@ class Diaspora
 		Logger::log("Send participation for ".$item["guid"]." by ".$author, Logger::DEBUG);
 
 		// It doesn't matter what we store, we only want to avoid sending repeated notifications for the same item
-		DI::cache()->set($cachekey, $item["guid"], Cache::QUARTER_HOUR);
+		DI::cache()->set($cachekey, $item["guid"], Duration::QUARTER_HOUR);
 
 		return self::buildAndTransmit($owner, $contact, "participation", $message);
 	}
@@ -3628,7 +3628,7 @@ class Diaspora
 
 		$msg = ["type" => $type, "message" => $message];
 
-		DI::cache()->set($cachekey, $msg, Cache::QUARTER_HOUR);
+		DI::cache()->set($cachekey, $msg, Duration::QUARTER_HOUR);
 
 		return $msg;
 	}
@@ -3798,7 +3798,7 @@ class Diaspora
 			$comment['thread_parent_guid'] = $thread_parent_item['guid'];
 		}
 
-		DI::cache()->set($cachekey, $comment, Cache::QUARTER_HOUR);
+		DI::cache()->set($cachekey, $comment, Duration::QUARTER_HOUR);
 
 		return($comment);
 	}

--- a/src/Protocol/OStatus.php
+++ b/src/Protocol/OStatus.php
@@ -8,10 +8,9 @@ use DOMDocument;
 use DOMXPath;
 use Friendica\Content\Text\BBCode;
 use Friendica\Content\Text\HTML;
-use Friendica\Core\Cache\Cache;
+use Friendica\Core\Cache\Duration;
 use Friendica\Core\Config;
 use Friendica\Core\L10n;
-use Friendica\Core\Lock;
 use Friendica\Core\Logger;
 use Friendica\Core\PConfig;
 use Friendica\Core\Protocol;
@@ -2246,7 +2245,7 @@ class OStatus
 		$feeddata = trim($doc->saveXML());
 
 		$msg = ['feed' => $feeddata, 'last_update' => $last_update];
-		DI::cache()->set($cachekey, $msg, Cache::QUARTER_HOUR);
+		DI::cache()->set($cachekey, $msg, Duration::QUARTER_HOUR);
 
 		Logger::log('Feed duration: ' . number_format(microtime(true) - $stamp, 3) . ' - ' . $owner_nick . ' - ' . $filter . ' - ' . $previous_created, Logger::DEBUG);
 

--- a/src/Util/JsonLD.php
+++ b/src/Util/JsonLD.php
@@ -4,7 +4,7 @@
  */
 namespace Friendica\Util;
 
-use Friendica\Core\Cache\Cache;
+use Friendica\Core\Cache\Duration;
 use Friendica\Core\Logger;
 use Exception;
 use Friendica\DI;
@@ -46,7 +46,7 @@ class JsonLD
 		}
 
 		$data = jsonld_default_document_loader($url);
-		DI::cache()->set('documentLoader:' . $url, $data, Cache::DAY);
+		DI::cache()->set('documentLoader:' . $url, $data, Duration::DAY);
 		return $data;
 	}
 

--- a/src/Worker/SearchDirectory.php
+++ b/src/Worker/SearchDirectory.php
@@ -4,7 +4,7 @@
  */
 namespace Friendica\Worker;
 
-use Friendica\Core\Cache\Cache;
+use Friendica\Core\Cache\Duration;
 use Friendica\Core\Config;
 use Friendica\Core\Logger;
 use Friendica\Core\Protocol;
@@ -81,6 +81,6 @@ class SearchDirectory
 				}
 			}
 		}
-		DI::cache()->set('SearchDirectory:' . $search, time(), Cache::DAY);
+		DI::cache()->set('SearchDirectory:' . $search, time(), Duration::DAY);
 	}
 }

--- a/tests/Util/DbaLockMockTrait.php
+++ b/tests/Util/DbaLockMockTrait.php
@@ -2,7 +2,7 @@
 
 namespace Friendica\Test\Util;
 
-use Friendica\Core\Cache\Cache;
+use Friendica\Core\Cache\Duration;
 use Friendica\Core\Lock\DatabaseLock;
 
 trait DbaLockMockTrait
@@ -25,7 +25,7 @@ trait DbaLockMockTrait
 	 *@see DatabaseLock::acquire()
 	 *
 	 */
-	public function mockAcquireLock($key, $ttl = Cache::FIVE_MINUTES, $locked = false, $pid = null, $rowExists = true, $time = null, $times = null)
+	public function mockAcquireLock($key, $ttl = Duration::FIVE_MINUTES, $locked = false, $pid = null, $rowExists = true, $time = null, $times = null)
 	{
 		if ($time === null) {
 			$time = time();


### PR DESCRIPTION
- Introduce enum "Duration"
- Introduce enum "Type"
- Move "Cache\Cache" to "BaseCache"

Why?
- No more "Cache\Cache" irritations
- Adheres the `Base*` naming convention like `BaseRepository`, `BaseFactory`, ...
- I find it easier to use (If you want the cache duration, you use the enum `Cache\Duration` and no more a given "base class" and than `HOUR`) - and now the name of the new base class shouldn't be used in the codebase, just for extending the cache classes
- Makes @MrPetovan happy ;-)

Needs https://github.com/friendica/friendica-addons/pull/944 as well