### PR TITLE
Fix: You can now register an account when you haven't done it before

### DIFF
--- a/src/Module/Settings/Delegation.php
+++ b/src/Module/Settings/Delegation.php
@@ -138,6 +138,8 @@ class Delegation extends BaseSettingsModule
 			$parent_password = ['parent_password', L10n::t('Parent Password:'), '', L10n::t('Please enter the password of the parent account to legitimize your request.')];
 		}
 
+		$is_child_user = !empty($user['parent-uid']);
+
 		$o = Renderer::replaceMacros(Renderer::getMarkupTemplate('settings/delegation.tpl'), [
 			'$form_security_token' => BaseModule::getFormSecurityToken('delegate'),
 			'$account_header' => L10n::t('Additional Accounts'),
@@ -147,6 +149,7 @@ class Delegation extends BaseSettingsModule
 			'$parent_user' => $parent_user,
 			'$parent_password' => $parent_password,
 			'$parent_desc' => L10n::t('Parent users have total control about this account, including the account settings. Please double check whom you give this access.'),
+			'$is_child_user' => $is_child_user,
 			'$submit' => L10n::t('Save Settings'),
 			'$header' => L10n::t('Manage Accounts'),
 			'$delegates_header' => L10n::t('Delegates'),

--- a/view/templates/settings/delegation.tpl
+++ b/view/templates/settings/delegation.tpl
@@ -1,5 +1,11 @@
 <h3>{{$header}}</h3>
 
+{{if !$is_child_user}}
+<h4>{{$account_header}}</h4>
+<div id="add-account-desc" class="add-account-desc">{{$account_desc}}</div>
+<a href='register'>{{$add_account}}</a>
+{{/if}}
+
 {{if $parent_user}}
 <h4>{{$parent_header}}</h4>
 <div id="delegate-parent-desc" class="delegate-parent-desc">{{$parent_desc}}</div>
@@ -11,10 +17,6 @@
 		<div class="submit"><input type="submit" name="delegate" value="{{$submit}}"/></div>
 	</form>
 </div>
-{{else}}
-<h4>{{$account_header}}</h4>
-<div id="add-account-desc" class="add-account-desc">{{$account_desc}}</div>
-<a href='register'>{{$add_account}}</a>
 {{/if}}
 
 <h4>{{$delegates_header}}</h4>


### PR DESCRIPTION
This is a fix for my recent PR. There had been some check to avoid that an account that is delegated can create delegated accounts by itself. We want to avoid delegation chains.

This check had some flaw. It prevented users from registering an additional account and only revealed that link after you registered an additional account :-)