### PR TITLE
AP: Create a GUID out of an URL

### DIFF
--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -390,6 +390,26 @@ class Processor
 	}
 
 	/**
+	 * Generate a GUID out of an URL
+	 *
+	 * @param string $url message URL
+	 * @return string with GUID
+	 */
+	private static function getGUIDByURL(string $url)
+	{
+		$parsed = parse_url($url);
+
+		$host_hash = hash('crc32', $parsed['host']);
+
+		unset($parsed["scheme"]);
+		unset($parsed["host"]);
+
+		$path = implode("/", $parsed);
+
+		return $host_hash . '-'. hash('fnv164', $path) . '-'. hash('joaat', $path);
+	}
+
+	/**
 	 * Creates an item post
 	 *
 	 * @param array $activity Activity data
@@ -431,7 +451,7 @@ class Processor
 
 		$item['created'] = DateTimeFormat::utc($activity['published']);
 		$item['edited'] = DateTimeFormat::utc($activity['updated']);
-		$item['guid'] = $activity['diaspora:guid'];
+		$item['guid'] = $activity['diaspora:guid'] ?: self::getGUIDByURL($item['uri']);
 
 		$item = self::processContent($activity, $item);
 		if (empty($item)) {


### PR DESCRIPTION
For a better optical distinction between posts from Friendica, Diaspora and via AP we now generate the GUID differently.

Diaspora and Friendica are using a GUID for an unique identifier. AP does use the URL of the post for this (In fact Friendica does use both GUID and URL). So when a GUID is not provided, we generate it on our own.

With the different formats we can now easily separate between Friendica GUID, AP GUID and the rest. The rest are posts via the connectors or mirrored feed posts.