### PR TITLE
regen messages.po

### DIFF
--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2020.03-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-01-18 20:32+0000\n"
+"POT-Creation-Date: 2020-01-20 11:14+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,3335 +18,227 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 
-#: addon/piwik/piwik.php:95
-msgid ""
-"This website is tracked using the <a href='http://www.matomo.org'>Matomo</a> "
-"analytics tool."
-msgstr ""
-
-#: addon/piwik/piwik.php:98
-#, php-format
-msgid ""
-"If you do not want that your visits are logged in this way you <a "
-"href='%s'>can set a cookie to prevent Matomo / Piwik from tracking further "
-"visits of the site</a> (opt-out)."
-msgstr ""
-
-#: addon/piwik/piwik.php:105 addon/gravatar/gravatar.php:113
-#: addon/ifttt/ifttt.php:84 addon/pageheader/pageheader.php:39
-#: addon/impressum/impressum.php:107 addon/notimeline/notimeline.php:64
-#: addon/diaspora/diaspora.php:167 addon/mathjax/mathjax.php:58
-#: addon/blockbot/blockbot.php:35 addon/newmemberwidget/newmemberwidget.php:71
-#: addon/showmore/showmore.php:59 addon/blogger/blogger.php:122
-#: addon/libertree/libertree.php:112 addon/twitter/twitter.php:341
-#: addon/twitter/twitter.php:395 addon/twitter/twitter.php:730
-#: addon/jappixmini/jappixmini.php:384 addon/numfriends/numfriends.php:79
-#: addon/wppost/wppost.php:145 addon/curweather/curweather.php:203
-#: addon/curweather/curweather.php:243 addon/webrtc/webrtc.php:31
-#: addon/group_text/group_text.php:85 addon/gnot/gnot.php:85
-#: addon/randplace/randplace.php:180
-#: addon/windowsphonepush/windowsphonepush.php:135 addon/fromapp/fromapp.php:83
-#: addon/cookienotice/cookienotice.php:51 addon/statusnet/statusnet.php:296
-#: addon/statusnet/statusnet.php:313 addon/statusnet/statusnet.php:340
-#: addon/statusnet/statusnet.php:347 addon/statusnet/statusnet.php:394
-#: addon/statusnet/statusnet.php:720 addon/startpage/startpage.php:96
-#: addon/superblock/superblock.php:59 addon/nsfw/nsfw.php:93
-#: addon/remote_permissions/remote_permissions.php:55
-#: addon/remote_permissions/remote_permissions.php:205
-#: addon/securemail/securemail.php:63 addon/xmpp/xmpp.php:97
-#: addon/xmpp/xmpp.php:113 addon/markdown/markdown.php:33
-#: addon/tumblr/tumblr.php:80 addon/tumblr/tumblr.php:296
-#: addon/langfilter/langfilter.php:62 addon/public_server/public_server.php:171
-#: addon/krynn/krynn.php:172 addon/libravatar/libravatar.php:115
-#: addon/discourse/discourse.php:52 addon/blockem/blockem.php:68
-#: addon/ljpost/ljpost.php:106 addon/ijpost/ijpost.php:109
-#: addon/geonames/geonames.php:149 addon/geocoordinates/geocoordinates.php:95
-#: addon/pumpio/pumpio.php:330 addon/mailstream/mailstream.php:86
-#: addon/mailstream/mailstream.php:397 addon/dwpost/dwpost.php:110
-#: addon/blackout/blackout.php:106 addon/qcomment/qcomment.php:57
-#: addon/buffer/buffer.php:80 addon/buffer/buffer.php:230
-#: addon/planets/planets.php:169 addon/irc/irc.php:45 addon/irc/irc.php:146
-#: src/Module/Admin/Tos.php:50 src/Module/Admin/Addons/Index.php:50
-#: src/Module/Admin/Themes/Index.php:95 src/Module/Admin/Site.php:557
-#: src/Module/Admin/Features.php:69 src/Module/Admin/Logs/Settings.php:63
-#: src/Module/Settings/Delegation.php:150 mod/settings.php:664
-#: mod/settings.php:771 mod/settings.php:869 mod/settings.php:948
-#: mod/settings.php:1173
-msgid "Save Settings"
-msgstr ""
-
-#: addon/piwik/piwik.php:106
-msgid "Matomo (Piwik) Base URL"
-msgstr ""
-
-#: addon/piwik/piwik.php:106
-msgid ""
-"Absolute path to your Matomo (Piwik) installation. (without protocol (http/"
-"s), with trailing slash)"
-msgstr ""
-
-#: addon/piwik/piwik.php:107
-msgid "Site ID"
-msgstr ""
-
-#: addon/piwik/piwik.php:108
-msgid "Show opt-out cookie link?"
-msgstr ""
-
-#: addon/piwik/piwik.php:109
-msgid "Asynchronous tracking"
-msgstr ""
-
-#: addon/piwik/piwik.php:121 addon/impressum/impressum.php:102
-#: addon/blockbot/blockbot.php:46 addon/twitter/twitter.php:722
-#: addon/webrtc/webrtc.php:38
-#: addon/remote_permissions/remote_permissions.php:214 addon/xmpp/xmpp.php:127
-#: addon/tumblr/tumblr.php:95 addon/geocoordinates/geocoordinates.php:108
-#: addon/openstreetmap/openstreetmap.php:228 addon/buffer/buffer.php:95
-#: mod/settings.php:604
-msgid "Settings updated."
-msgstr ""
-
-#: addon/gravatar/gravatar.php:89 addon/libravatar/libravatar.php:89
-msgid "generic profile image"
-msgstr ""
-
-#: addon/gravatar/gravatar.php:90 addon/libravatar/libravatar.php:90
-msgid "random geometric pattern"
-msgstr ""
-
-#: addon/gravatar/gravatar.php:91 addon/libravatar/libravatar.php:91
-msgid "monster face"
-msgstr ""
-
-#: addon/gravatar/gravatar.php:92 addon/libravatar/libravatar.php:92
-msgid "computer generated face"
-msgstr ""
-
-#: addon/gravatar/gravatar.php:93 addon/libravatar/libravatar.php:93
-msgid "retro arcade style face"
-msgstr ""
-
-#: addon/gravatar/gravatar.php:107 addon/libravatar/libravatar.php:109
-#: src/Content/Nav.php:232 src/Module/BaseAdminModule.php:73
-msgid "Information"
-msgstr ""
-
-#: addon/gravatar/gravatar.php:107
-msgid ""
-"Libravatar addon is installed, too. Please disable Libravatar addon or this "
-"Gravatar addon.<br>The Libravatar addon will fall back to Gravatar if "
-"nothing was found at Libravatar."
-msgstr ""
-
-#: addon/gravatar/gravatar.php:114 addon/libravatar/libravatar.php:116
-msgid "Default avatar image"
-msgstr ""
-
-#: addon/gravatar/gravatar.php:114
-msgid "Select default avatar image if none was found at Gravatar. See README"
-msgstr ""
-
-#: addon/gravatar/gravatar.php:115
-msgid "Rating of images"
-msgstr ""
-
-#: addon/gravatar/gravatar.php:115
-msgid "Select the appropriate avatar rating for your site. See README"
-msgstr ""
-
-#: addon/gravatar/gravatar.php:129
-msgid "Gravatar settings updated."
-msgstr ""
-
-#: addon/advancedcontentfilter/src/middlewares.php:30
-msgid "Method not found"
-msgstr ""
-
-#: addon/advancedcontentfilter/advancedcontentfilter.php:142
-#, php-format
-msgid "Filtered by rule: %s"
-msgstr ""
-
-#: addon/advancedcontentfilter/advancedcontentfilter.php:156
-#: addon/advancedcontentfilter/advancedcontentfilter.php:213
-msgid "Advanced Content Filter"
-msgstr ""
-
-#: addon/advancedcontentfilter/advancedcontentfilter.php:212
-msgid "Back to Addon Settings"
-msgstr ""
-
-#: addon/advancedcontentfilter/advancedcontentfilter.php:214
-msgid "Add a Rule"
-msgstr ""
-
-#: addon/advancedcontentfilter/advancedcontentfilter.php:215
-#: view/theme/vier/theme.php:270 src/Content/Nav.php:191 src/Module/Help.php:50
-#: src/Module/Settings/TwoFactor/Verify.php:113
-#: src/Module/Settings/TwoFactor/AppSpecific.php:96
-#: src/Module/Settings/TwoFactor/Index.php:87
-#: src/Module/Settings/TwoFactor/Recovery.php:74
-msgid "Help"
-msgstr ""
-
-#: addon/advancedcontentfilter/advancedcontentfilter.php:216
-msgid ""
-"Add and manage your personal content filter rules in this screen. Rules have "
-"a name and an arbitrary expression that will be matched against post data. "
-"For a complete reference of the available operations and variables, check "
-"the help page."
-msgstr ""
-
-#: addon/advancedcontentfilter/advancedcontentfilter.php:217
-msgid "Your rules"
-msgstr ""
-
-#: addon/advancedcontentfilter/advancedcontentfilter.php:218
-msgid ""
-"You have no rules yet! Start adding one by clicking on the button above next "
-"to the title."
-msgstr ""
-
-#: addon/advancedcontentfilter/advancedcontentfilter.php:219
-#: addon/statusnet/statusnet.php:380 src/Module/Admin/Site.php:463
-#: src/Module/Admin/Site.php:654 src/Module/Admin/Site.php:664
-#: src/Module/Settings/TwoFactor/Index.php:94 src/Module/Contact.php:545
-msgid "Disabled"
-msgstr ""
-
-#: addon/advancedcontentfilter/advancedcontentfilter.php:220
-#: addon/mailstream/mailstream.php:379 src/Module/Admin/Site.php:654
-msgid "Enabled"
-msgstr ""
-
-#: addon/advancedcontentfilter/advancedcontentfilter.php:221
-msgid "Disable this rule"
-msgstr ""
-
-#: addon/advancedcontentfilter/advancedcontentfilter.php:222
-msgid "Enable this rule"
-msgstr ""
-
-#: addon/advancedcontentfilter/advancedcontentfilter.php:223
-msgid "Edit this rule"
-msgstr ""
-
-#: addon/advancedcontentfilter/advancedcontentfilter.php:224
-msgid "Edit the rule"
-msgstr ""
-
-#: addon/advancedcontentfilter/advancedcontentfilter.php:225
-msgid "Save this rule"
-msgstr ""
-
-#: addon/advancedcontentfilter/advancedcontentfilter.php:226
-msgid "Delete this rule"
-msgstr ""
-
-#: addon/advancedcontentfilter/advancedcontentfilter.php:227
-msgid "Rule"
-msgstr ""
-
-#: addon/advancedcontentfilter/advancedcontentfilter.php:228
-msgid "Close"
-msgstr ""
-
-#: addon/advancedcontentfilter/advancedcontentfilter.php:229
-msgid "Add new rule"
-msgstr ""
-
-#: addon/advancedcontentfilter/advancedcontentfilter.php:230
-msgid "Rule Name"
-msgstr ""
-
-#: addon/advancedcontentfilter/advancedcontentfilter.php:231
-msgid "Rule Expression"
-msgstr ""
-
-#: addon/advancedcontentfilter/advancedcontentfilter.php:232
-#: addon/js_upload/js_upload.php:36 include/conversation.php:1256
-#: include/items.php:386 src/Module/Contact.php:446 mod/dfrn_request.php:653
-#: mod/follow.php:173 mod/fbrowser.php:109 mod/fbrowser.php:138
-#: mod/unfollow.php:131 mod/photos.php:1041 mod/photos.php:1148
-#: mod/settings.php:665 mod/settings.php:691 mod/suggest.php:75
-#: mod/editpost.php:111 mod/message.php:151 mod/tagrm.php:20 mod/tagrm.php:115
-msgid "Cancel"
-msgstr ""
-
-#: addon/advancedcontentfilter/advancedcontentfilter.php:299
-#: addon/advancedcontentfilter/advancedcontentfilter.php:310
-#: addon/advancedcontentfilter/advancedcontentfilter.php:321
-#: addon/advancedcontentfilter/advancedcontentfilter.php:355
-#: addon/advancedcontentfilter/advancedcontentfilter.php:384
-#: addon/advancedcontentfilter/advancedcontentfilter.php:405
-msgid "You must be logged in to use this method"
-msgstr ""
-
-#: addon/advancedcontentfilter/advancedcontentfilter.php:325
-#: addon/advancedcontentfilter/advancedcontentfilter.php:359
-#: addon/advancedcontentfilter/advancedcontentfilter.php:388
-msgid "Invalid form security token, please refresh the page."
-msgstr ""
-
-#: addon/advancedcontentfilter/advancedcontentfilter.php:337
-msgid "The rule name and expression are required."
-msgstr ""
-
-#: addon/advancedcontentfilter/advancedcontentfilter.php:349
-msgid "Rule successfully added"
-msgstr ""
-
-#: addon/advancedcontentfilter/advancedcontentfilter.php:363
-#: addon/advancedcontentfilter/advancedcontentfilter.php:392
-msgid "Rule doesn't exist or doesn't belong to you."
-msgstr ""
-
-#: addon/advancedcontentfilter/advancedcontentfilter.php:378
-msgid "Rule successfully updated"
-msgstr ""
-
-#: addon/advancedcontentfilter/advancedcontentfilter.php:399
-msgid "Rule successfully deleted"
-msgstr ""
-
-#: addon/advancedcontentfilter/advancedcontentfilter.php:409
-msgid "Missing argument: guid."
-msgstr ""
-
-#: addon/advancedcontentfilter/advancedcontentfilter.php:417
-#, php-format
-msgid "Unknown post with guid: %s"
-msgstr ""
-
-#: addon/ifttt/ifttt.php:56 addon/ifttt/ifttt.php:60
-msgid "IFTTT Mirror"
-msgstr ""
-
-#: addon/ifttt/ifttt.php:64
-msgid ""
-"Create an account at <a href=\"http://www.ifttt.com\">IFTTT</a>. Create "
-"three Facebook recipes that are connected with <a href=\"https://ifttt.com/"
-"maker\">Maker</a> (In the form \"if Facebook then Maker\") with the "
-"following parameters:"
-msgstr ""
-
-#: addon/ifttt/ifttt.php:71
-msgid "Body for \"new status message\""
-msgstr ""
-
-#: addon/ifttt/ifttt.php:73
-msgid "Body for \"new photo upload\""
-msgstr ""
-
-#: addon/ifttt/ifttt.php:75
-msgid "Body for \"new link post\""
-msgstr ""
-
-#: addon/ifttt/ifttt.php:80 addon/widgets/widgets.php:65
-msgid "Generate new key"
-msgstr ""
-
-#: addon/pageheader/pageheader.php:37
-msgid "\"pageheader\" Settings"
-msgstr ""
-
-#: addon/pageheader/pageheader.php:38
-#: addon/newmemberwidget/newmemberwidget.php:72 include/conversation.php:1268
-#: src/Model/Profile.php:545 src/Module/Contact.php:321 mod/editpost.php:115
-msgid "Message"
-msgstr ""
-
-#: addon/pageheader/pageheader.php:38
-msgid ""
-"Message to display on every page on this server (or put a pageheader.html "
-"file in your docroot)"
-msgstr ""
-
-#: addon/pageheader/pageheader.php:55
-msgid "pageheader Settings saved."
-msgstr ""
-
-#: addon/impressum/impressum.php:61
-msgid "Impressum"
-msgstr ""
-
-#: addon/impressum/impressum.php:74 addon/impressum/impressum.php:76
-#: addon/impressum/impressum.php:108
-msgid "Site Owner"
-msgstr ""
-
-#: addon/impressum/impressum.php:74 addon/impressum/impressum.php:112
-#: addon/mailstream/mailstream.php:383
-msgid "Email Address"
-msgstr ""
-
-#: addon/impressum/impressum.php:79 addon/impressum/impressum.php:110
-msgid "Postal Address"
-msgstr ""
-
-#: addon/impressum/impressum.php:85
-msgid ""
-"The impressum addon needs to be configured!<br />Please add at least the "
-"<tt>owner</tt> variable to your config file. For other variables please "
-"refer to the README file of the addon."
-msgstr ""
-
-#: addon/impressum/impressum.php:108
-msgid "The page operators name."
-msgstr ""
-
-#: addon/impressum/impressum.php:109
-msgid "Site Owners Profile"
-msgstr ""
-
-#: addon/impressum/impressum.php:109
-msgid "Profile address of the operator."
-msgstr ""
-
-#: addon/impressum/impressum.php:110
-msgid "How to contact the operator via snail mail. You can use BBCode here."
-msgstr ""
-
-#: addon/impressum/impressum.php:111
-msgid "Notes"
-msgstr ""
-
-#: addon/impressum/impressum.php:111
-msgid ""
-"Additional notes that are displayed beneath the contact information. You can "
-"use BBCode here."
-msgstr ""
-
-#: addon/impressum/impressum.php:112
-msgid "How to contact the operator via email. (will be displayed obfuscated)"
-msgstr ""
-
-#: addon/impressum/impressum.php:113
-msgid "Footer note"
-msgstr ""
-
-#: addon/impressum/impressum.php:113
-msgid "Text for the footer. You can use BBCode here."
-msgstr ""
-
-#: addon/tictac/tictac.php:21
-msgid "Three Dimensional Tic-Tac-Toe"
-msgstr ""
-
-#: addon/tictac/tictac.php:54
-msgid "3D Tic-Tac-Toe"
-msgstr ""
-
-#: addon/tictac/tictac.php:59
-msgid "New game"
-msgstr ""
-
-#: addon/tictac/tictac.php:60
-msgid "New game with handicap"
-msgstr ""
-
-#: addon/tictac/tictac.php:61
-msgid ""
-"Three dimensional tic-tac-toe is just like the traditional game except that "
-"it is played on multiple levels simultaneously. "
-msgstr ""
-
-#: addon/tictac/tictac.php:62
-msgid ""
-"In this case there are three levels. You win by getting three in a row on "
-"any level, as well as up, down, and diagonally across the different levels."
-msgstr ""
-
-#: addon/tictac/tictac.php:64
-msgid ""
-"The handicap game disables the center position on the middle level because "
-"the player claiming this square often has an unfair advantage."
-msgstr ""
-
-#: addon/tictac/tictac.php:183
-msgid "You go first..."
-msgstr ""
-
-#: addon/tictac/tictac.php:188
-msgid "I'm going first this time..."
-msgstr ""
-
-#: addon/tictac/tictac.php:194
-msgid "You won!"
-msgstr ""
-
-#: addon/tictac/tictac.php:200 addon/tictac/tictac.php:225
-msgid "\"Cat\" game!"
-msgstr ""
-
-#: addon/tictac/tictac.php:223
-msgid "I won!"
-msgstr ""
-
-#: addon/notimeline/notimeline.php:33
-msgid "No Timeline settings updated."
-msgstr ""
-
-#: addon/notimeline/notimeline.php:56
-msgid "No Timeline Settings"
-msgstr ""
-
-#: addon/notimeline/notimeline.php:58
-msgid "Disable Archive selector on profile wall"
-msgstr ""
-
-#: addon/diaspora/diaspora.php:52
-msgid "Post to Diaspora"
-msgstr ""
-
-#: addon/diaspora/diaspora.php:88
-#, php-format
-msgid ""
-"Please remember: You can always be reached from Diaspora with your Friendica "
-"handle %s. "
-msgstr ""
-
-#: addon/diaspora/diaspora.php:89
-msgid ""
-"This connector is only meant if you still want to use your old Diaspora "
-"account for some time. "
-msgstr ""
-
-#: addon/diaspora/diaspora.php:90
-#, php-format
-msgid ""
-"However, it is preferred that you tell your Diaspora contacts the new handle "
-"%s instead."
-msgstr ""
-
-#: addon/diaspora/diaspora.php:101
-msgid ""
-"Can't login to your Diaspora account. Please check handle (in the format "
-"user@domain.tld) and password."
-msgstr ""
-
-#: addon/diaspora/diaspora.php:108 addon/diaspora/diaspora.php:112
-msgid "Diaspora Export"
-msgstr ""
-
-#: addon/diaspora/diaspora.php:122
-msgid "Enable Diaspora Post Addon"
-msgstr ""
-
-#: addon/diaspora/diaspora.php:127
-msgid "Diaspora handle"
-msgstr ""
-
-#: addon/diaspora/diaspora.php:132
-msgid "Diaspora password"
-msgstr ""
-
-#: addon/diaspora/diaspora.php:139
-msgid "All aspects"
-msgstr ""
-
-#: addon/diaspora/diaspora.php:144 src/Core/ACL.php:384
-msgid "Public"
-msgstr ""
-
-#: addon/diaspora/diaspora.php:147
-msgid "Post to aspect:"
-msgstr ""
-
-#: addon/diaspora/diaspora.php:161
-msgid "Post to Diaspora by default"
-msgstr ""
-
-#: addon/mathjax/mathjax.php:56
-msgid ""
-"The MathJax addon renders mathematical formulae written using the LaTeX "
-"syntax surrounded by the usual $$ or an eqnarray block in the postings of "
-"your wall,network tab and private mail."
-msgstr ""
-
-#: addon/mathjax/mathjax.php:57
-msgid "Use the MathJax renderer"
-msgstr ""
-
-#: addon/blockbot/blockbot.php:36
-msgid "Allow \"good\" crawlers"
-msgstr ""
-
-#: addon/blockbot/blockbot.php:37
-msgid "Block GabSocial"
-msgstr ""
-
-#: addon/blockbot/blockbot.php:38
-msgid "Training mode"
-msgstr ""
-
-#: addon/newmemberwidget/newmemberwidget.php:35
-msgid "New Member"
-msgstr ""
-
-#: addon/newmemberwidget/newmemberwidget.php:36 src/Model/Profile.php:981
-#: src/Model/Profile.php:984
-msgid "Tips for New Members"
-msgstr ""
-
-#: addon/newmemberwidget/newmemberwidget.php:39
-msgid "Global Support Forum"
-msgstr ""
-
-#: addon/newmemberwidget/newmemberwidget.php:43
-msgid "Local Support Forum"
-msgstr ""
-
-#: addon/newmemberwidget/newmemberwidget.php:72
-msgid "Your message for new members. You can use bbcode here."
-msgstr ""
-
-#: addon/newmemberwidget/newmemberwidget.php:73
-msgid "Add a link to global support forum"
-msgstr ""
-
-#: addon/newmemberwidget/newmemberwidget.php:73
-msgid "Should a link to the global support forum be displayed?"
-msgstr ""
-
-#: addon/newmemberwidget/newmemberwidget.php:74
-msgid "Add a link to the local support forum"
-msgstr ""
-
-#: addon/newmemberwidget/newmemberwidget.php:74
-msgid ""
-"If you have a local support forum and want to have a link displayed in the "
-"widget, check this box."
-msgstr ""
-
-#: addon/newmemberwidget/newmemberwidget.php:75
-msgid "Name of the local support group"
-msgstr ""
-
-#: addon/newmemberwidget/newmemberwidget.php:75
-msgid ""
-"If you checked the above, specify the <em>nickname</em> of the local support "
-"group here (i.e. helpers)"
-msgstr ""
-
-#: addon/testdrive/testdrive.php:78 addon/public_server/public_server.php:76
-msgid "Administrator"
-msgstr ""
-
-#: addon/testdrive/testdrive.php:103 addon/public_server/public_server.php:130
-#, php-format
-msgid "Your account on %s will expire in a few days."
-msgstr ""
-
-#: addon/testdrive/testdrive.php:104
-msgid "Your Friendica test account is about to expire."
-msgstr ""
-
-#: addon/testdrive/testdrive.php:105
-#, php-format
-msgid ""
-"Hi %1$s,\n"
-"\n"
-"Your test account on %2$s will expire in less than five days. We hope you "
-"enjoyed this test drive and use this opportunity to find a permanent "
-"Friendica website for your integrated social communications. A list of "
-"public sites is available at %s/siteinfo - and for more information on "
-"setting up your own Friendica server please see the Friendica project "
-"website at https://friendi.ca."
-msgstr ""
-
-#: addon/showmore/showmore.php:43 addon/showmore/showmore.php:47
-msgid "\"Show more\" Settings"
-msgstr ""
-
-#: addon/showmore/showmore.php:52
-msgid "Enable Show More"
-msgstr ""
-
-#: addon/showmore/showmore.php:55
-msgid "Cutting posts after how much characters"
-msgstr ""
-
-#: addon/showmore/showmore.php:77
-msgid "Show More Settings saved."
-msgstr ""
-
-#: addon/showmore/showmore.php:137 view/theme/vier/theme.php:231
-#: src/Content/Widget.php:405 src/Content/Widget.php:505
-#: src/Content/ForumManager.php:134
-msgid "show more"
-msgstr ""
-
-#: addon/blogger/blogger.php:55
-msgid "Post to blogger"
-msgstr ""
-
-#: addon/blogger/blogger.php:89 addon/blogger/blogger.php:93
-msgid "Blogger Export"
-msgstr ""
-
-#: addon/blogger/blogger.php:97
-msgid "Enable Blogger Post Addon"
-msgstr ""
-
-#: addon/blogger/blogger.php:102
-msgid "Blogger username"
-msgstr ""
-
-#: addon/blogger/blogger.php:107
-msgid "Blogger password"
-msgstr ""
-
-#: addon/blogger/blogger.php:112
-msgid "Blogger API URL"
-msgstr ""
-
-#: addon/blogger/blogger.php:117
-msgid "Post to Blogger by default"
-msgstr ""
-
-#: addon/blogger/blogger.php:206 addon/wppost/wppost.php:305
-msgid "Post from Friendica"
-msgstr ""
-
-#: addon/libertree/libertree.php:49
-msgid "Post to libertree"
-msgstr ""
-
-#: addon/libertree/libertree.php:83 addon/libertree/libertree.php:87
-msgid "libertree Export"
-msgstr ""
-
-#: addon/libertree/libertree.php:91
-msgid "Enable Libertree Post Addon"
-msgstr ""
-
-#: addon/libertree/libertree.php:96
-msgid "Libertree API token"
-msgstr ""
-
-#: addon/libertree/libertree.php:101
-msgid "Libertree site URL"
-msgstr ""
-
-#: addon/libertree/libertree.php:106
-msgid "Post to Libertree by default"
-msgstr ""
-
-#: addon/twitter/twitter.php:206
-msgid "Post to Twitter"
-msgstr ""
-
-#: addon/twitter/twitter.php:251
-msgid ""
-"You submitted an empty PIN, please Sign In with Twitter again to get a new "
-"one."
-msgstr ""
-
-#: addon/twitter/twitter.php:280
-msgid "Twitter settings updated."
-msgstr ""
-
-#: addon/twitter/twitter.php:310 addon/twitter/twitter.php:314
-msgid "Twitter Import/Export/Mirror"
-msgstr ""
-
-#: addon/twitter/twitter.php:321
-msgid ""
-"No consumer key pair for Twitter found. Please contact your site "
-"administrator."
-msgstr ""
-
-#: addon/twitter/twitter.php:333
-msgid ""
-"At this Friendica instance the Twitter addon was enabled but you have not "
-"yet connected your account to your Twitter account. To do so click the "
-"button below to get a PIN from Twitter which you have to copy into the input "
-"box below and submit the form. Only your <strong>public</strong> posts will "
-"be posted to Twitter."
-msgstr ""
-
-#: addon/twitter/twitter.php:334
-msgid "Log in with Twitter"
-msgstr ""
-
-#: addon/twitter/twitter.php:336
-msgid "Copy the PIN from Twitter here"
-msgstr ""
-
-#: addon/twitter/twitter.php:343 addon/twitter/twitter.php:397
-msgid "An error occured: "
-msgstr ""
-
-#: addon/twitter/twitter.php:360 addon/statusnet/statusnet.php:356
-msgid "Currently connected to: "
-msgstr ""
-
-#: addon/twitter/twitter.php:361
-msgid "Disconnect"
-msgstr ""
-
-#: addon/twitter/twitter.php:377
-msgid "Allow posting to Twitter"
-msgstr ""
-
-#: addon/twitter/twitter.php:377
-msgid ""
-"If enabled all your <strong>public</strong> postings can be posted to the "
-"associated Twitter account. You can choose to do so by default (here) or for "
-"every posting separately in the posting options when writing the entry."
-msgstr ""
-
-#: addon/twitter/twitter.php:380
-msgid ""
-"<strong>Note</strong>: Due to your privacy settings (<em>Hide your profile "
-"details from unknown viewers?</em>) the link potentially included in public "
-"postings relayed to Twitter will lead the visitor to a blank page informing "
-"the visitor that the access to your profile has been restricted."
-msgstr ""
-
-#: addon/twitter/twitter.php:383
-msgid "Send public postings to Twitter by default"
-msgstr ""
-
-#: addon/twitter/twitter.php:386
-msgid "Mirror all posts from twitter that are no replies"
-msgstr ""
-
-#: addon/twitter/twitter.php:389 addon/statusnet/statusnet.php:376
-#: addon/pumpio/pumpio.php:295
-msgid "Import the remote timeline"
-msgstr ""
-
-#: addon/twitter/twitter.php:392
-msgid "Automatically create contacts"
-msgstr ""
-
-#: addon/twitter/twitter.php:392
-msgid ""
-"This will automatically create a contact in Friendica as soon as you receive "
-"a message from an existing contact via the Twitter network. If you do not "
-"enable this, you need to manually add those Twitter contacts in Friendica "
-"from whom you would like to see posts here. However if enabled, you cannot "
-"merely remove a twitter contact from the Friendica contact list, as it will "
-"recreate this contact when they post again."
-msgstr ""
-
-#: addon/twitter/twitter.php:732
-msgid "Consumer key"
-msgstr ""
-
-#: addon/twitter/twitter.php:733
-msgid "Consumer secret"
-msgstr ""
-
-#: addon/viewsrc/viewsrc.php:55
-msgid "View Source"
-msgstr ""
-
-#: addon/jappixmini/jappixmini.php:334 addon/jappixmini/jappixmini.php:338
-msgid "Jappix Mini"
-msgstr ""
-
-#: addon/jappixmini/jappixmini.php:341
-msgid "Activate addon"
-msgstr ""
-
-#: addon/jappixmini/jappixmini.php:344
-msgid "Do <em>not</em> insert the Jappixmini Chat-Widget into the webinterface"
-msgstr ""
-
-#: addon/jappixmini/jappixmini.php:347
-msgid "Jabber username"
-msgstr ""
-
-#: addon/jappixmini/jappixmini.php:350
-msgid "Jabber server"
-msgstr ""
-
-#: addon/jappixmini/jappixmini.php:355 addon/xmpp/xmpp.php:88
-#: addon/xmpp/xmpp.php:114
-msgid "Jabber BOSH host"
-msgstr ""
-
-#: addon/jappixmini/jappixmini.php:360
-msgid "Jabber password"
-msgstr ""
-
-#: addon/jappixmini/jappixmini.php:365
-msgid "Encrypt Jabber password with Friendica password (recommended)"
-msgstr ""
-
-#: addon/jappixmini/jappixmini.php:368
-msgid "Friendica password"
-msgstr ""
-
-#: addon/jappixmini/jappixmini.php:371
-msgid "Approve subscription requests from Friendica contacts automatically"
-msgstr ""
-
-#: addon/jappixmini/jappixmini.php:374
-msgid "Subscribe to Friendica contacts automatically"
-msgstr ""
-
-#: addon/jappixmini/jappixmini.php:377
-msgid "Purge internal list of jabber addresses of contacts"
-msgstr ""
-
-#: addon/jappixmini/jappixmini.php:385
-msgid "Add contact"
-msgstr ""
-
-#: addon/numfriends/numfriends.php:44
-msgid "Numfriends settings updated."
-msgstr ""
-
-#: addon/numfriends/numfriends.php:71
-msgid "Numfriends Settings"
-msgstr ""
-
-#: addon/numfriends/numfriends.php:73
-msgid "How many contacts to display on profile sidebar"
-msgstr ""
-
-#: addon/wppost/wppost.php:57
-msgid "Post to Wordpress"
-msgstr ""
-
-#: addon/wppost/wppost.php:98 addon/wppost/wppost.php:102
-msgid "Wordpress Export"
-msgstr ""
-
-#: addon/wppost/wppost.php:105
-msgid "Enable WordPress Post Addon"
-msgstr ""
-
-#: addon/wppost/wppost.php:110
-msgid "WordPress username"
-msgstr ""
-
-#: addon/wppost/wppost.php:115
-msgid "WordPress password"
-msgstr ""
-
-#: addon/wppost/wppost.php:120
-msgid "WordPress API URL"
-msgstr ""
-
-#: addon/wppost/wppost.php:125
-msgid "Post to WordPress by default"
-msgstr ""
-
-#: addon/wppost/wppost.php:130
-msgid "Provide a backlink to the Friendica post"
-msgstr ""
-
-#: addon/wppost/wppost.php:134
-msgid ""
-"Text for the backlink, e.g. Read the original post and comment stream on "
-"Friendica."
-msgstr ""
-
-#: addon/wppost/wppost.php:139
-msgid "Don't post messages that are too short"
-msgstr ""
-
-#: addon/wppost/wppost.php:247
-msgid "Read the orig­i­nal post and com­ment stream on Friendica"
-msgstr ""
-
-#: addon/curweather/curweather.php:57
-msgid "Error fetching weather data. Error was: "
-msgstr ""
-
-#: addon/curweather/curweather.php:140 addon/curweather/curweather.php:204
-msgid "Current Weather"
-msgstr ""
-
-#: addon/curweather/curweather.php:147
-msgid "Relative Humidity"
-msgstr ""
-
-#: addon/curweather/curweather.php:148
-msgid "Pressure"
-msgstr ""
-
-#: addon/curweather/curweather.php:149
-msgid "Wind"
-msgstr ""
-
-#: addon/curweather/curweather.php:150
-msgid "Last Updated"
-msgstr ""
-
-#: addon/curweather/curweather.php:151
-msgid "Data by"
-msgstr ""
-
-#: addon/curweather/curweather.php:152
-msgid "Show on map"
-msgstr ""
-
-#: addon/curweather/curweather.php:157
-msgid "There was a problem accessing the weather data. But have a look"
-msgstr ""
-
-#: addon/curweather/curweather.php:159
-msgid "at OpenWeatherMap"
-msgstr ""
-
-#: addon/curweather/curweather.php:176
-msgid "Current Weather settings updated."
-msgstr ""
-
-#: addon/curweather/curweather.php:191
-msgid "No APPID found, please contact your admin to obtain one."
-msgstr ""
-
-#: addon/curweather/curweather.php:204 view/theme/frio/theme.php:277
-#: src/Content/Nav.php:261 src/Module/Admin/Addons/Details.php:102
-#: src/Module/Admin/Themes/Details.php:107 src/Module/Welcome.php:33
-#: src/Module/BaseSettingsModule.php:105 mod/settings.php:144
-msgid "Settings"
-msgstr ""
-
-#: addon/curweather/curweather.php:206
-msgid "Enter either the name of your location or the zip code."
-msgstr ""
-
-#: addon/curweather/curweather.php:207
-msgid "Your Location"
-msgstr ""
-
-#: addon/curweather/curweather.php:207
-msgid ""
-"Identifier of your location (name or zip code), e.g. <em>Berlin,DE</em> or "
-"<em>14476,DE</em>."
-msgstr ""
-
-#: addon/curweather/curweather.php:208
-msgid "Units"
-msgstr ""
-
-#: addon/curweather/curweather.php:208
-msgid "select if the temperature should be displayed in &deg;C or &deg;F"
-msgstr ""
-
-#: addon/curweather/curweather.php:209
-msgid "Show weather data"
-msgstr ""
-
-#: addon/curweather/curweather.php:227
-msgid "Curweather settings saved."
-msgstr ""
-
-#: addon/curweather/curweather.php:246
-msgid "Caching Interval"
-msgstr ""
-
-#: addon/curweather/curweather.php:248
-msgid ""
-"For how long should the weather data be cached? Choose according your "
-"OpenWeatherMap account type."
-msgstr ""
-
-#: addon/curweather/curweather.php:249
-msgid "no cache"
-msgstr ""
-
-#: addon/curweather/curweather.php:250 addon/curweather/curweather.php:251
-#: addon/curweather/curweather.php:252 addon/curweather/curweather.php:253
-#: src/Util/Temporal.php:316
-msgid "minutes"
-msgstr ""
-
-#: addon/curweather/curweather.php:256
-msgid "Your APPID"
-msgstr ""
-
-#: addon/curweather/curweather.php:256
-msgid "Your API key provided by OpenWeatherMap"
-msgstr ""
-
-#: addon/js_upload/js_upload.php:34
-msgid "Select files for upload"
-msgstr ""
-
-#: addon/js_upload/js_upload.php:35
-msgid "Drop files here to upload"
-msgstr ""
-
-#: addon/js_upload/js_upload.php:37
-msgid "Failed"
-msgstr ""
-
-#: addon/js_upload/js_upload.php:215
-msgid "No files were uploaded."
-msgstr ""
-
-#: addon/js_upload/js_upload.php:221
-msgid "Uploaded file is empty"
-msgstr ""
-
-#: addon/js_upload/js_upload.php:233
-msgid "Image exceeds size limit of "
-msgstr ""
-
-#: addon/js_upload/js_upload.php:247
-msgid "File has an invalid extension, it should be one of "
-msgstr ""
-
-#: addon/js_upload/js_upload.php:258
-msgid "Upload was cancelled, or server error encountered"
-msgstr ""
-
-#: addon/webrtc/webrtc.php:25
-msgid "WebRTC Videochat"
-msgstr ""
-
-#: addon/webrtc/webrtc.php:32
-msgid "WebRTC Base URL"
-msgstr ""
-
-#: addon/webrtc/webrtc.php:32
-msgid ""
-"Page your users will create a WebRTC chat room on. For example you could use "
-"https://live.mayfirst.org ."
-msgstr ""
-
-#: addon/webrtc/webrtc.php:52
-msgid "Video Chat"
-msgstr ""
-
-#: addon/webrtc/webrtc.php:53
-msgid ""
-"WebRTC is a video and audio conferencing tool that works with Firefox "
-"(version 21 and above) and Chrome/Chromium (version 25 and above). Just "
-"create a new chat room and send the link to someone you want to chat with."
-msgstr ""
-
-#: addon/webrtc/webrtc.php:55
-msgid ""
-"Please contact your friendica admin and send a reminder to configure the "
-"WebRTC addon."
-msgstr ""
-
-#: addon/notifyall/notifyall.php:33
-msgid "Send email to all members"
-msgstr ""
-
-#: addon/notifyall/notifyall.php:52 include/enotify.php:67
-#, php-format
-msgid "%s Administrator"
-msgstr ""
-
-#: addon/notifyall/notifyall.php:54 include/enotify.php:65
-#, php-format
-msgid "%1$s, %2$s Administrator"
-msgstr ""
-
-#: addon/notifyall/notifyall.php:81
-msgid "No recipients found."
-msgstr ""
-
-#: addon/notifyall/notifyall.php:97
-msgid "Emails sent"
-msgstr ""
-
-#: addon/notifyall/notifyall.php:107
-msgid "Send email to all members of this Friendica instance."
-msgstr ""
-
-#: addon/notifyall/notifyall.php:112
-msgid "Message subject"
-msgstr ""
-
-#: addon/notifyall/notifyall.php:113
-msgid "Test mode (only send to administrator)"
-msgstr ""
-
-#: addon/notifyall/notifyall.php:114 addon/openstreetmap/openstreetmap.php:208
-#: view/theme/vier/config.php:120 view/theme/duepuntozero/config.php:70
-#: view/theme/frio/config.php:125 view/theme/quattro/config.php:72
-#: src/Object/Post.php:904 src/Module/Delegation.php:131
-#: src/Module/Install.php:211 src/Module/Install.php:251
-#: src/Module/Install.php:287 src/Module/Debug/Localtime.php:45
-#: src/Module/Contact.php:580 src/Module/Invite.php:156
-#: src/Module/Item/Compose.php:125 mod/fsuggest.php:91 mod/events.php:551
-#: mod/crepair.php:149 mod/poke.php:185 mod/photos.php:952 mod/photos.php:1058
-#: mod/photos.php:1344 mod/photos.php:1389 mod/photos.php:1428
-#: mod/photos.php:1492 mod/profiles.php:560 mod/message.php:259
-#: mod/message.php:439
-msgid "Submit"
-msgstr ""
-
-#: addon/group_text/group_text.php:47
-msgid "Group Text settings updated."
-msgstr ""
-
-#: addon/group_text/group_text.php:77
-msgid "Group Text"
-msgstr ""
-
-#: addon/group_text/group_text.php:79
-msgid "Use a text only (non-image) group selector in the \"group edit\" menu"
-msgstr ""
-
-#: addon/morepokes/morepokes.php:24
-msgid "bitchslap"
-msgstr ""
-
-#: addon/morepokes/morepokes.php:24
-msgid "bitchslapped"
-msgstr ""
-
-#: addon/morepokes/morepokes.php:25
-msgid "shag"
-msgstr ""
-
-#: addon/morepokes/morepokes.php:25
-msgid "shagged"
-msgstr ""
-
-#: addon/morepokes/morepokes.php:26
-msgid "do something obscenely biological to"
-msgstr ""
-
-#: addon/morepokes/morepokes.php:26
-msgid "did something obscenely biological to"
-msgstr ""
-
-#: addon/morepokes/morepokes.php:27
-msgid "point out the poke feature to"
-msgstr ""
-
-#: addon/morepokes/morepokes.php:27
-msgid "pointed out the poke feature to"
-msgstr ""
-
-#: addon/morepokes/morepokes.php:28
-msgid "declare undying love for"
-msgstr ""
-
-#: addon/morepokes/morepokes.php:28
-msgid "declared undying love for"
-msgstr ""
-
-#: addon/morepokes/morepokes.php:29
-msgid "patent"
-msgstr ""
-
-#: addon/morepokes/morepokes.php:29
-msgid "patented"
-msgstr ""
-
-#: addon/morepokes/morepokes.php:30
-msgid "stroke beard"
-msgstr ""
-
-#: addon/morepokes/morepokes.php:30
-msgid "stroked their beard at"
-msgstr ""
-
-#: addon/morepokes/morepokes.php:31
-msgid ""
-"bemoan the declining standards of modern secondary and tertiary education to"
-msgstr ""
-
-#: addon/morepokes/morepokes.php:31
-msgid ""
-"bemoans the declining standards of modern secondary and tertiary education to"
-msgstr ""
-
-#: addon/morepokes/morepokes.php:32
-msgid "hug"
-msgstr ""
-
-#: addon/morepokes/morepokes.php:32
-msgid "hugged"
-msgstr ""
-
-#: addon/morepokes/morepokes.php:33
-msgid "kiss"
-msgstr ""
-
-#: addon/morepokes/morepokes.php:33
-msgid "kissed"
-msgstr ""
-
-#: addon/morepokes/morepokes.php:34
-msgid "raise eyebrows at"
-msgstr ""
-
-#: addon/morepokes/morepokes.php:34
-msgid "raised their eyebrows at"
-msgstr ""
-
-#: addon/morepokes/morepokes.php:35
-msgid "insult"
-msgstr ""
-
-#: addon/morepokes/morepokes.php:35
-msgid "insulted"
-msgstr ""
-
-#: addon/morepokes/morepokes.php:36
-msgid "praise"
-msgstr ""
-
-#: addon/morepokes/morepokes.php:36
-msgid "praised"
-msgstr ""
-
-#: addon/morepokes/morepokes.php:37
-msgid "be dubious of"
-msgstr ""
-
-#: addon/morepokes/morepokes.php:37
-msgid "was dubious of"
-msgstr ""
-
-#: addon/morepokes/morepokes.php:38
-msgid "eat"
-msgstr ""
-
-#: addon/morepokes/morepokes.php:38
-msgid "ate"
-msgstr ""
-
-#: addon/morepokes/morepokes.php:39
-msgid "giggle and fawn at"
-msgstr ""
-
-#: addon/morepokes/morepokes.php:39
-msgid "giggled and fawned at"
-msgstr ""
-
-#: addon/morepokes/morepokes.php:40
-msgid "doubt"
-msgstr ""
-
-#: addon/morepokes/morepokes.php:40
-msgid "doubted"
-msgstr ""
-
-#: addon/morepokes/morepokes.php:41
-msgid "glare"
-msgstr ""
-
-#: addon/morepokes/morepokes.php:41
-msgid "glared at"
-msgstr ""
-
-#: addon/gnot/gnot.php:52
-msgid "Gnot settings updated."
-msgstr ""
-
-#: addon/gnot/gnot.php:84
-msgid "Gnot Settings"
-msgstr ""
-
-#: addon/gnot/gnot.php:86
-msgid "Enable this addon?"
-msgstr ""
-
-#: addon/gnot/gnot.php:88
-msgid ""
-"Allows threading of email comment notifications on Gmail and anonymising the "
-"subject line."
-msgstr ""
-
-#: addon/gnot/gnot.php:97
-#, php-format
-msgid "[Friendica:Notify] Comment to conversation #%d"
-msgstr ""
-
-#: addon/randplace/randplace.php:172
-msgid "Randplace Settings"
-msgstr ""
-
-#: addon/randplace/randplace.php:174
-msgid "Enable Randplace Addon"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:34
-msgid "Androgyne"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:35
-msgid "Bear"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:36
-msgid "Bigender"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:37
-msgid "Cross dresser"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:38
-msgid "Drag queen"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:39
-msgid "Eunuch"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:40
-msgid "Faux queen"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:41
-msgid "Gender fluid"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:42
-msgid "Kathoey"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:43
-msgid "Lady"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:44
-msgid "Lipstick lesbian"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:45
-msgid "Metrosexual"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:46
-msgid "Monk"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:47
-msgid "Nun"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:48
-msgid "Soft butch"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:49
-msgid "Stone femme"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:50
-msgid "Tomboy"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:51
-msgid "Transman"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:52
-msgid "Transwoman"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:53
-msgid "Transvesti"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:54
-msgid "Trigender"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:55
-msgid "Can't remember"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:56
-msgid "Hard to tell these days"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:60
-msgid "Girls with big tits"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:61
-msgid "Millionaires"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:62
-msgid "Guys with big schlongs"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:63
-msgid "Easy women"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:64
-msgid "People with impaired mobility"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:65
-msgid "Amputees"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:66
-msgid "Statues, mannequins and immobility"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:67
-msgid "Pain"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:68
-msgid "Trans men"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:69
-msgid "Older women"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:70
-msgid "Asphyxiation"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:71
-msgid "In public"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:72
-msgid "In danger"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:73
-msgid "Pretending to be male"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:74
-msgid "Pretending to be female"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:75
-msgid "Breats"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:76
-msgid "Scat"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:77
-msgid "Crying"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:78
-msgid "Nappies/Diapers"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:79
-msgid "Trees"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:80
-msgid "Vomit"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:81
-msgid "Murder"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:82
-msgid "Fat people"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:83
-msgid "Feet"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:84
-msgid "Covered in insects"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:85
-msgid "Turning a human being into furniture"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:86
-msgid "Elderly people"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:87
-msgid "Transgender people"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:88
-msgid "Criminals"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:89
-msgid "Stealing"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:90
-msgid "Breast milk"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:91
-msgid "Immersing genitals in liquids"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:92
-msgid "Giants"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:93
-msgid "Masochism"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:94
-msgid "Cars"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:95
-msgid "Menstruation"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:96
-msgid "Mucus"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:97
-msgid "Obscene language"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:98
-msgid "Noses"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:99
-msgid "Navels"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:100
-msgid "Corpses"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:101
-msgid "Smells"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:102
-msgid "Buttocks"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:103
-msgid "Nonliving objects"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:104
-msgid "Sleeping people"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:105
-msgid "Urination"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:106
-msgid "Eating people"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:107
-msgid "Being eaten"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:108
-msgid "Animals"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:109
-msgid "I'd rather just have some chocolate"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:113
-msgid "Married to my job"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:114
-msgid "Polygamist"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:115
-msgid "Half married"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:116
-msgid "Living in the past"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:117
-msgid "Pretending to be over my ex"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:118
-msgid "Hurt in the past"
-msgstr ""
-
-#: addon/morechoice/morechoice.php:119
-msgid "Wallowing in self-pity"
-msgstr ""
-
-#: addon/windowsphonepush/windowsphonepush.php:96
-msgid "WindowsPhonePush settings updated."
-msgstr ""
-
-#: addon/windowsphonepush/windowsphonepush.php:122
-msgid "WindowsPhonePush Settings"
-msgstr ""
-
-#: addon/windowsphonepush/windowsphonepush.php:125
-msgid "Enable WindowsPhonePush Addon"
-msgstr ""
-
-#: addon/windowsphonepush/windowsphonepush.php:130
-msgid "Push text of new item"
-msgstr ""
-
-#: addon/fromapp/fromapp.php:40
-msgid "Fromapp settings updated."
-msgstr ""
-
-#: addon/fromapp/fromapp.php:65 addon/fromapp/fromapp.php:69
-msgid "FromApp Settings"
-msgstr ""
-
-#: addon/fromapp/fromapp.php:72
-msgid ""
-"The application name you would like to show your posts originating from. "
-"Separate different app names with a comma. A random one will then be "
-"selected for every posting."
-msgstr ""
-
-#: addon/fromapp/fromapp.php:76
-msgid "Use this application name even if another application was used."
-msgstr ""
-
-#: addon/cookienotice/cookienotice.php:43
-msgid ""
-"This website uses cookies. If you continue browsing this website, you agree "
-"to the usage of cookies."
-msgstr ""
-
-#: addon/cookienotice/cookienotice.php:44
-#: addon/cookienotice/cookienotice.php:110
-msgid "OK"
-msgstr ""
-
-#: addon/cookienotice/cookienotice.php:48
-msgid ""
-"<b>Configure your cookie usage notice.</b> It should just be a notice, "
-"saying that the website uses cookies. It is shown as long as a user didnt "
-"confirm clicking the OK button."
-msgstr ""
-
-#: addon/cookienotice/cookienotice.php:49
-msgid "Cookie Usage Notice"
-msgstr ""
-
-#: addon/cookienotice/cookienotice.php:50
-msgid "OK Button Text"
-msgstr ""
-
-#: addon/cookienotice/cookienotice.php:74
-msgid "cookienotice Settings saved."
-msgstr ""
-
-#: addon/cookienotice/cookienotice.php:109
-msgid ""
-"This website uses cookies to recognize revisiting and logged in users. You "
-"accept the usage of these cookies by continue browsing this website."
-msgstr ""
-
-#: addon/statusnet/statusnet.php:115
-msgid "Post to GNU Social"
-msgstr ""
-
-#: addon/statusnet/statusnet.php:166
-msgid ""
-"Please contact your site administrator.<br />The provided API URL is not "
-"valid."
-msgstr ""
-
-#: addon/statusnet/statusnet.php:195
-msgid "We could not contact the GNU Social API with the Path you entered."
-msgstr ""
-
-#: addon/statusnet/statusnet.php:229
-msgid "GNU Social settings updated."
-msgstr ""
-
-#: addon/statusnet/statusnet.php:270 addon/statusnet/statusnet.php:274
-msgid "GNU Social Import/Export/Mirror"
-msgstr ""
-
-#: addon/statusnet/statusnet.php:289
-msgid "Globally Available GNU Social OAuthKeys"
-msgstr ""
-
-#: addon/statusnet/statusnet.php:290
-msgid ""
-"There are preconfigured OAuth key pairs for some GNU Social servers "
-"available. If you are using one of them, please use these credentials. If "
-"not feel free to connect to any other GNU Social instance (see below)."
-msgstr ""
-
-#: addon/statusnet/statusnet.php:298
-msgid "Provide your own OAuth Credentials"
-msgstr ""
-
-#: addon/statusnet/statusnet.php:299
-msgid ""
-"No consumer key pair for GNU Social found. Register your Friendica Account "
-"as an desktop client on your GNU Social account, copy the consumer key pair "
-"here and enter the API base root.<br />Before you register your own OAuth "
-"key pair ask the administrator if there is already a key pair for this "
-"Friendica installation at your favorited GNU Social installation."
-msgstr ""
-
-#: addon/statusnet/statusnet.php:301
-msgid "OAuth Consumer Key"
-msgstr ""
-
-#: addon/statusnet/statusnet.php:304
-msgid "OAuth Consumer Secret"
-msgstr ""
-
-#: addon/statusnet/statusnet.php:307 addon/statusnet/statusnet.php:700
-#: addon/statusnet/statusnet.php:712
-msgid "Base API Path (remember the trailing /)"
-msgstr ""
-
-#: addon/statusnet/statusnet.php:332
-msgid ""
-"To connect to your GNU Social account click the button below to get a "
-"security code from GNU Social which you have to copy into the input box "
-"below and submit the form. Only your <strong>public</strong> posts will be "
-"posted to GNU Social."
-msgstr ""
-
-#: addon/statusnet/statusnet.php:333
-msgid "Log in with GNU Social"
-msgstr ""
-
-#: addon/statusnet/statusnet.php:335
-msgid "Copy the security code from GNU Social here"
-msgstr ""
-
-#: addon/statusnet/statusnet.php:341
-msgid "Cancel Connection Process"
-msgstr ""
-
-#: addon/statusnet/statusnet.php:343
-msgid "Current GNU Social API is"
-msgstr ""
-
-#: addon/statusnet/statusnet.php:344
-msgid "Cancel GNU Social Connection"
-msgstr ""
-
-#: addon/statusnet/statusnet.php:358
-msgid ""
-"If enabled all your <strong>public</strong> postings can be posted to the "
-"associated GNU Social account. You can choose to do so by default (here) or "
-"for every posting separately in the posting options when writing the entry."
-msgstr ""
-
-#: addon/statusnet/statusnet.php:360
-msgid ""
-"<strong>Note</strong>: Due your privacy settings (<em>Hide your profile "
-"details from unknown viewers?</em>) the link potentially included in public "
-"postings relayed to GNU Social will lead the visitor to a blank page "
-"informing the visitor that the access to your profile has been restricted."
-msgstr ""
-
-#: addon/statusnet/statusnet.php:363
-msgid "Allow posting to GNU Social"
-msgstr ""
-
-#: addon/statusnet/statusnet.php:366
-msgid "Send public postings to GNU Social by default"
-msgstr ""
-
-#: addon/statusnet/statusnet.php:370
-msgid ""
-"Mirror all posts from GNU Social that are no replies or repeated messages"
-msgstr ""
-
-#: addon/statusnet/statusnet.php:381
-msgid "Full Timeline"
-msgstr ""
-
-#: addon/statusnet/statusnet.php:382
-msgid "Only Mentions"
-msgstr ""
-
-#: addon/statusnet/statusnet.php:391
-msgid "Clear OAuth configuration"
-msgstr ""
-
-#: addon/statusnet/statusnet.php:711 src/Module/Admin/Site.php:572
-msgid "Site name"
-msgstr ""
-
-#: addon/statusnet/statusnet.php:713 addon/tumblr/tumblr.php:83
-#: mod/settings.php:668 mod/settings.php:694
-msgid "Consumer Secret"
-msgstr ""
-
-#: addon/statusnet/statusnet.php:714 addon/tumblr/tumblr.php:82
-#: mod/settings.php:667 mod/settings.php:693
-msgid "Consumer Key"
-msgstr ""
-
-#: addon/startpage/startpage.php:82 addon/startpage/startpage.php:86
-msgid "Startpage"
-msgstr ""
-
-#: addon/startpage/startpage.php:89
-msgid "Home page to load after login  - leave blank for profile wall"
-msgstr ""
-
-#: addon/startpage/startpage.php:92
-msgid "Examples: &quot;network&quot; or &quot;notifications/system&quot;"
-msgstr ""
-
-#: addon/superblock/superblock.php:48 addon/superblock/superblock.php:52
-msgid "Superblock"
-msgstr ""
-
-#: addon/superblock/superblock.php:55
-msgid "Comma separated profile URLS to block"
-msgstr ""
-
-#: addon/superblock/superblock.php:72
-msgid "SUPERBLOCK Settings saved."
-msgstr ""
-
-#: addon/superblock/superblock.php:145
-msgid "Block Completely"
-msgstr ""
-
-#: addon/superblock/superblock.php:166
-msgid "superblock settings updated"
-msgstr ""
-
-#: addon/nsfw/nsfw.php:77 addon/nsfw/nsfw.php:81
-msgid "Content Filter (NSFW and more)"
-msgstr ""
-
-#: addon/nsfw/nsfw.php:85
-msgid ""
-"This addon searches for specified words/text in posts and collapses them. It "
-"can be used to filter content tagged with for instance #NSFW that may be "
-"deemed inappropriate at certain times or places, such as being at work. It "
-"is also useful for hiding irrelevant or annoying content from direct view."
-msgstr ""
-
-#: addon/nsfw/nsfw.php:86
-msgid "Enable Content filter"
-msgstr ""
-
-#: addon/nsfw/nsfw.php:89
-msgid "Comma separated list of keywords to hide"
-msgstr ""
-
-#: addon/nsfw/nsfw.php:94
-msgid "Use /expression/ to provide regular expressions"
-msgstr ""
-
-#: addon/nsfw/nsfw.php:109
-msgid "NSFW Settings saved."
-msgstr ""
-
-#: addon/nsfw/nsfw.php:162
-#, php-format
-msgid "Filtered tag: %s"
-msgstr ""
-
-#: addon/nsfw/nsfw.php:164
-#, php-format
-msgid "Filtered word: %s"
-msgstr ""
-
-#: addon/remote_permissions/remote_permissions.php:52
-msgid "Remote Permissions Settings"
-msgstr ""
-
-#: addon/remote_permissions/remote_permissions.php:53
-msgid ""
-"Allow recipients of your private posts to see the other recipients of the "
-"posts"
-msgstr ""
-
-#: addon/remote_permissions/remote_permissions.php:65
-msgid "Remote Permissions settings updated."
-msgstr ""
-
-#: addon/remote_permissions/remote_permissions.php:133 mod/lockview.php:69
-msgid "Visible to:"
-msgstr ""
-
-#: addon/remote_permissions/remote_permissions.php:187
-msgid "Visible to"
-msgstr ""
-
-#: addon/remote_permissions/remote_permissions.php:187
-msgid "may only be a partial list"
-msgstr ""
-
-#: addon/remote_permissions/remote_permissions.php:206
-msgid "Global"
-msgstr ""
-
-#: addon/remote_permissions/remote_permissions.php:206
-msgid "The posts of every user on this server show the post recipients"
-msgstr ""
-
-#: addon/remote_permissions/remote_permissions.php:207
-msgid "Individual"
-msgstr ""
-
-#: addon/remote_permissions/remote_permissions.php:207
-msgid "Each user chooses whether his/her posts show the post recipients"
-msgstr ""
-
-#: addon/membersince/membersince.php:42 addon/membersince/membersince.php:57
-#: src/Model/Profile.php:762
-msgid "Member since:"
-msgstr ""
-
-#: addon/securemail/securemail.php:62
-msgid "\"Secure Mail\" Settings"
-msgstr ""
-
-#: addon/securemail/securemail.php:64 addon/securemail/securemail.php:92
-msgid "Save and send test"
-msgstr ""
-
-#: addon/securemail/securemail.php:65
-msgid "Enable Secure Mail"
-msgstr ""
-
-#: addon/securemail/securemail.php:66
-msgid "Public key"
-msgstr ""
-
-#: addon/securemail/securemail.php:66
-msgid "Your public PGP key, ascii armored format"
-msgstr ""
-
-#: addon/securemail/securemail.php:90
-msgid "Secure Mail Settings saved."
-msgstr ""
-
-#: addon/securemail/securemail.php:127
-msgid "Test email sent"
-msgstr ""
-
-#: addon/securemail/securemail.php:129
-msgid "There was an error sending the test email"
-msgstr ""
-
-#: addon/forumdirectory/forumdirectory.php:38
-#: addon/forumdirectory/forumdirectory.php:148
-msgid "Forum Directory"
-msgstr ""
-
-#: addon/forumdirectory/forumdirectory.php:58 src/Module/Directory.php:31
-#: src/Module/Debug/WebFinger.php:19 src/Module/Debug/Probe.php:20
-#: src/Module/Search/Index.php:30 src/Module/Search/Index.php:35
-#: mod/community.php:25 mod/display.php:168 mod/dfrn_request.php:600
-#: mod/photos.php:837 mod/videos.php:112
-msgid "Public access denied."
-msgstr ""
-
-#: addon/forumdirectory/forumdirectory.php:136 src/Module/Directory.php:59
-msgid "No entries (some entries may be hidden)."
-msgstr ""
-
-#: addon/forumdirectory/forumdirectory.php:142 view/theme/vier/theme.php:184
-#: src/Content/Widget.php:70 src/Module/Directory.php:76
-msgid "Global Directory"
-msgstr ""
-
-#: addon/forumdirectory/forumdirectory.php:144 src/Module/Directory.php:78
-msgid "Find on this site"
-msgstr ""
-
-#: addon/forumdirectory/forumdirectory.php:146 src/Module/Directory.php:80
-msgid "Results for:"
-msgstr ""
-
-#: addon/forumdirectory/forumdirectory.php:150 view/theme/vier/theme.php:179
-#: src/Content/Widget.php:65 src/Module/Directory.php:84
-#: src/Module/Contact.php:819
-msgid "Find"
-msgstr ""
-
-#: addon/xmpp/xmpp.php:44
-msgid "XMPP settings updated."
-msgstr ""
-
-#: addon/xmpp/xmpp.php:69 addon/xmpp/xmpp.php:73
-msgid "XMPP-Chat (Jabber)"
-msgstr ""
-
-#: addon/xmpp/xmpp.php:77
-msgid "Enable Webchat"
-msgstr ""
-
-#: addon/xmpp/xmpp.php:82
-msgid "Individual Credentials"
-msgstr ""
-
-#: addon/xmpp/xmpp.php:115
-msgid "Use central userbase"
-msgstr ""
-
-#: addon/xmpp/xmpp.php:115
-msgid ""
-"If enabled, users will automatically login to an ejabberd server that has to "
-"be installed on this machine with synchronized credentials via the "
-"\"auth_ejabberd.php\" script."
-msgstr ""
-
-#: addon/markdown/markdown.php:31 src/Module/Debug/Babel.php:184
-msgid "Markdown"
-msgstr ""
-
-#: addon/markdown/markdown.php:32
-msgid "Enable Markdown parsing"
-msgstr ""
-
-#: addon/markdown/markdown.php:32
-msgid ""
-"If enabled, self created items will additionally be parsed via Markdown."
-msgstr ""
-
-#: addon/tumblr/tumblr.php:50 addon/pumpio/pumpio.php:69
-#: addon/buffer/buffer.php:51 include/items.php:433
-#: src/Module/Delegation.php:98 src/Module/Notifications/Notify.php:18
-#: src/Module/Attach.php:41 src/Module/Settings/Delegation.php:23
-#: src/Module/Settings/Delegation.php:51 src/Module/Group.php:30
-#: src/Module/Group.php:76 src/Module/FollowConfirm.php:16
-#: src/Module/Profile/Contacts.php:50 src/Module/Contact.php:360
-#: src/Module/Invite.php:21 src/Module/Invite.php:109
-#: src/Module/Register.php:44 src/Module/Register.php:57
-#: src/Module/Register.php:177 src/Module/Register.php:216
-#: src/Module/Search/Directory.php:19 src/Module/Base/Api.php:40
-#: src/Module/Base/Api.php:46 mod/notes.php:27 mod/uimport.php:17
-#: mod/fsuggest.php:62 mod/common.php:27 mod/events.php:212 mod/api.php:35
-#: mod/api.php:40 mod/cal.php:288 mod/crepair.php:90 mod/notifications.php:49
-#: mod/wallmessage.php:18 mod/wallmessage.php:42 mod/wallmessage.php:81
-#: mod/wallmessage.php:105 mod/ostatus_subscribe.php:16 mod/follow.php:56
-#: mod/follow.php:133 mod/network.php:36 mod/unfollow.php:21
-#: mod/unfollow.php:76 mod/unfollow.php:108 mod/profile_photo.php:31
-#: mod/profile_photo.php:176 mod/profile_photo.php:196 mod/poke.php:142
-#: mod/photos.php:161 mod/photos.php:923 mod/profiles.php:180
-#: mod/profiles.php:497 mod/wall_attach.php:62 mod/wall_attach.php:65
-#: mod/item.php:172 mod/regmod.php:85 mod/settings.php:49 mod/settings.php:162
-#: mod/settings.php:654 mod/suggest.php:38 mod/dfrn_confirm.php:64
-#: mod/wall_upload.php:94 mod/wall_upload.php:97 mod/editpost.php:22
-#: mod/message.php:54 mod/message.php:99 mod/repair_ostatus.php:15
-msgid "Permission denied."
-msgstr ""
-
-#: addon/tumblr/tumblr.php:190
-msgid "You are now authenticated to tumblr."
-msgstr ""
-
-#: addon/tumblr/tumblr.php:191 addon/pumpio/pumpio.php:206
-#: addon/buffer/buffer.php:122
-msgid "return to the connector page"
-msgstr ""
-
-#: addon/tumblr/tumblr.php:207
-msgid "Post to Tumblr"
-msgstr ""
-
-#: addon/tumblr/tumblr.php:237 addon/tumblr/tumblr.php:241
-msgid "Tumblr Export"
-msgstr ""
-
-#: addon/tumblr/tumblr.php:245
-msgid "(Re-)Authenticate your tumblr page"
-msgstr ""
-
-#: addon/tumblr/tumblr.php:249
-msgid "Enable Tumblr Post Addon"
-msgstr ""
-
-#: addon/tumblr/tumblr.php:255
-msgid "Post to Tumblr by default"
-msgstr ""
-
-#: addon/tumblr/tumblr.php:276
-msgid "Post to page:"
-msgstr ""
-
-#: addon/tumblr/tumblr.php:290
-msgid "You are not authenticated to tumblr"
-msgstr ""
-
-#: addon/rendertime/rendertime.php:42
-#, php-format
-msgid ""
-"Database: %s/%s, Network: %s, Rendering: %s, Session: %s, I/O: %s, Other: "
-"%s, Total: %s"
-msgstr ""
-
-#: addon/langfilter/langfilter.php:56
-msgid "Language Filter"
-msgstr ""
-
-#: addon/langfilter/langfilter.php:57
-msgid ""
-"This addon tries to identify the language posts are writen in. If it does "
-"not match any language specifed below, posts will be hidden by collapsing "
-"them."
-msgstr ""
-
-#: addon/langfilter/langfilter.php:58
-msgid "Use the language filter"
-msgstr ""
-
-#: addon/langfilter/langfilter.php:59
-msgid "Able to read"
-msgstr ""
-
-#: addon/langfilter/langfilter.php:59
-msgid ""
-"List of abbreviations (iso2 codes) for languages you speak, comma separated. "
-"For example \"de,it\"."
-msgstr ""
-
-#: addon/langfilter/langfilter.php:60
-msgid "Minimum confidence in language detection"
-msgstr ""
-
-#: addon/langfilter/langfilter.php:60
-msgid ""
-"Minimum confidence in language detection being correct, from 0 to 100. Posts "
-"will not be filtered when the confidence of language detection is below this "
-"percent value."
-msgstr ""
-
-#: addon/langfilter/langfilter.php:61
-msgid "Minimum length of message body"
-msgstr ""
-
-#: addon/langfilter/langfilter.php:61
-msgid ""
-"Minimum number of characters in message body for filter to be used. Posts "
-"shorter than this will not be filtered. Note: Language detection is "
-"unreliable for short content (<200 characters)."
-msgstr ""
-
-#: addon/langfilter/langfilter.php:103
-msgid "Language Filter Settings saved."
-msgstr ""
-
-#: addon/langfilter/langfilter.php:200
-#, php-format
-msgid "Filtered language: %s"
-msgstr ""
-
-#: addon/public_server/public_server.php:131
-msgid "Your Friendica account is about to expire."
-msgstr ""
-
-#: addon/public_server/public_server.php:132
-#, php-format
-msgid ""
-"Hi %1$s,\n"
-"\n"
-"Your account on %2$s will expire in less than five days. You may keep your "
-"account by logging in at least once every 30 days"
-msgstr ""
-
-#: addon/public_server/public_server.php:163
-msgid "Settings saved"
-msgstr ""
-
-#: addon/public_server/public_server.php:173
-msgid "Set any of these options to 0 to deactivate it."
-msgstr ""
-
-#: addon/krynn/krynn.php:156 addon/krynn/krynn.php:160
-msgid "Krynn"
-msgstr ""
-
-#: addon/krynn/krynn.php:165
-msgid "Krynn Settings"
-msgstr ""
-
-#: addon/krynn/krynn.php:167
-msgid "Enable Krynn Addon"
-msgstr ""
-
-#: addon/libravatar/libravatar.php:98
-msgid "Warning"
-msgstr ""
-
-#: addon/libravatar/libravatar.php:99
-#, php-format
-msgid "Your PHP version %s is lower than the required PHP >= 5.3."
-msgstr ""
-
-#: addon/libravatar/libravatar.php:100
-msgid "This addon is not functional on your server."
-msgstr ""
-
-#: addon/libravatar/libravatar.php:109
-msgid ""
-"Gravatar addon is installed. Please disable the Gravatar addon.<br>The "
-"Libravatar addon will fall back to Gravatar if nothing was found at "
-"Libravatar."
-msgstr ""
-
-#: addon/libravatar/libravatar.php:116
-msgid "Select default avatar image if none was found. See README"
-msgstr ""
-
-#: addon/libravatar/libravatar.php:129
-msgid "Libravatar settings updated."
-msgstr ""
-
-#: addon/discourse/discourse.php:50 src/Content/ContactSelector.php:128
-msgid "Discourse"
-msgstr ""
-
-#: addon/discourse/discourse.php:51
-msgid "Enable processing of Discourse mailing list mails"
-msgstr ""
-
-#: addon/discourse/discourse.php:51
-msgid ""
-"If enabled, incoming mails from Discourse will be improved so they look much "
-"better. To make it work, you have to configure the e-mail settings in "
-"Friendica. You also have to enable the mailing list mode in Discourse. Then "
-"you have to add the Discourse mail account as contact."
-msgstr ""
-
-#: addon/blockem/blockem.php:55 addon/blockem/blockem.php:59
-msgid "Blockem"
-msgstr ""
-
-#: addon/blockem/blockem.php:63
-msgid ""
-"Hides user's content by collapsing posts. Also replaces their avatar with "
-"generic image."
-msgstr ""
-
-#: addon/blockem/blockem.php:64
-msgid "Comma separated profile URLS:"
-msgstr ""
-
-#: addon/blockem/blockem.php:82
-msgid "BLOCKEM Settings saved."
-msgstr ""
-
-#: addon/blockem/blockem.php:144
-#, php-format
-msgid "Filtered user: %s"
-msgstr ""
-
-#: addon/blockem/blockem.php:203
-msgid "Unblock Author"
-msgstr ""
-
-#: addon/blockem/blockem.php:205
-msgid "Block Author"
-msgstr ""
-
-#: addon/blockem/blockem.php:245
-msgid "blockem settings updated"
-msgstr ""
-
-#: addon/catavatar/catavatar.php:62
-msgid "Use Cat as Avatar"
-msgstr ""
-
-#: addon/catavatar/catavatar.php:63
-msgid "More Random Cat!"
-msgstr ""
-
-#: addon/catavatar/catavatar.php:64
-msgid "Reset to email Cat"
-msgstr ""
-
-#: addon/catavatar/catavatar.php:66
-msgid "Cat Avatar Settings"
-msgstr ""
-
-#: addon/catavatar/catavatar.php:91
-msgid "The cat hadn't found itself."
-msgstr ""
-
-#: addon/catavatar/catavatar.php:100
-msgid "There was an error, the cat ran away."
-msgstr ""
-
-#: addon/catavatar/catavatar.php:106 include/api.php:4618
-#: src/Model/User.php:839 src/Model/User.php:847 src/Model/User.php:855
-#: mod/profile_photo.php:84 mod/profile_photo.php:93 mod/profile_photo.php:102
-#: mod/profile_photo.php:209 mod/profile_photo.php:297
-#: mod/profile_photo.php:307 mod/photos.php:88 mod/photos.php:179
-#: mod/photos.php:625 mod/photos.php:1047 mod/photos.php:1064
-#: mod/photos.php:1571
-msgid "Profile Photos"
-msgstr ""
-
-#: addon/catavatar/catavatar.php:121
-msgid "Meow!"
-msgstr ""
-
-#: addon/ljpost/ljpost.php:49
-msgid "Post to LiveJournal"
-msgstr ""
-
-#: addon/ljpost/ljpost.php:83
-msgid "LiveJournal Post Settings"
-msgstr ""
-
-#: addon/ljpost/ljpost.php:85
-msgid "Enable LiveJournal Post Addon"
-msgstr ""
-
-#: addon/ljpost/ljpost.php:90
-msgid "LiveJournal username"
-msgstr ""
-
-#: addon/ljpost/ljpost.php:95
-msgid "LiveJournal password"
-msgstr ""
-
-#: addon/ljpost/ljpost.php:100
-msgid "Post to LiveJournal by default"
-msgstr ""
-
-#: addon/buglink/buglink.php:25
-msgid "Report Bug"
-msgstr ""
-
-#: addon/ijpost/ijpost.php:49
-msgid "Post to Insanejournal"
-msgstr ""
-
-#: addon/ijpost/ijpost.php:81 addon/ijpost/ijpost.php:85
-msgid "InsaneJournal Export"
-msgstr ""
-
-#: addon/ijpost/ijpost.php:89
-msgid "Enable InsaneJournal Post Addon"
-msgstr ""
-
-#: addon/ijpost/ijpost.php:94
-msgid "InsaneJournal username"
-msgstr ""
-
-#: addon/ijpost/ijpost.php:99
-msgid "InsaneJournal password"
-msgstr ""
-
-#: addon/ijpost/ijpost.php:104
-msgid "Post to InsaneJournal by default"
-msgstr ""
-
-#: addon/geonames/geonames.php:114
-msgid "Geonames settings updated."
-msgstr ""
-
-#: addon/geonames/geonames.php:146
-msgid "Geonames Settings"
-msgstr ""
-
-#: addon/geonames/geonames.php:147
-msgid ""
-"Replace numerical coordinates by the nearest populated location name in your "
-"posts."
-msgstr ""
-
-#: addon/geonames/geonames.php:148
-msgid "Enable Geonames Addon"
-msgstr ""
-
-#: addon/geocoordinates/geocoordinates.php:96
-msgid "API Key"
-msgstr ""
-
-#: addon/geocoordinates/geocoordinates.php:97
-msgid "Language code (IETF format)"
-msgstr ""
-
-#: addon/pumpio/pumpio.php:164
-#, php-format
-msgid "Unable to register the client at the pump.io server '%s'."
-msgstr ""
-
-#: addon/pumpio/pumpio.php:205
-msgid "You are now authenticated to pumpio."
-msgstr ""
-
-#: addon/pumpio/pumpio.php:226
-msgid "Post to pumpio"
-msgstr ""
-
-#: addon/pumpio/pumpio.php:267 addon/pumpio/pumpio.php:271
-msgid "Pump.io Import/Export/Mirror"
-msgstr ""
-
-#: addon/pumpio/pumpio.php:275
-msgid "pump.io username (without the servername)"
-msgstr ""
-
-#: addon/pumpio/pumpio.php:280
-msgid "pump.io servername (without \"http://\" or \"https://\" )"
-msgstr ""
-
-#: addon/pumpio/pumpio.php:291
-msgid "Authenticate your pump.io connection"
-msgstr ""
-
-#: addon/pumpio/pumpio.php:300
-msgid "Enable pump.io Post Addon"
-msgstr ""
-
-#: addon/pumpio/pumpio.php:305
-msgid "Post to pump.io by default"
-msgstr ""
-
-#: addon/pumpio/pumpio.php:310
-msgid "Should posts be public?"
-msgstr ""
-
-#: addon/pumpio/pumpio.php:315
-msgid "Mirror all public posts"
-msgstr ""
-
-#: addon/pumpio/pumpio.php:320 addon/buffer/buffer.php:198
-msgid "Check to delete this preset"
-msgstr ""
-
-#: addon/pumpio/pumpio.php:999 include/conversation.php:165
-#: include/conversation.php:175 include/conversation.php:302
-#: include/conversation.php:311 mod/tagger.php:72 mod/subthread.php:91
-msgid "status"
-msgstr ""
-
-#: addon/pumpio/pumpio.php:1003 include/conversation.php:183
-#, php-format
-msgid "%1$s likes %2$s's %3$s"
-msgstr ""
-
-#: addon/openstreetmap/openstreetmap.php:181
-msgid "View Larger"
-msgstr ""
-
-#: addon/openstreetmap/openstreetmap.php:209
-msgid "Tile Server URL"
-msgstr ""
-
-#: addon/openstreetmap/openstreetmap.php:209
-msgid ""
-"A list of <a href=\"http://wiki.openstreetmap.org/wiki/TMS\" target=\"_blank"
-"\">public tile servers</a>"
-msgstr ""
-
-#: addon/openstreetmap/openstreetmap.php:210
-msgid "Nominatim (reverse geocoding) Server URL"
-msgstr ""
-
-#: addon/openstreetmap/openstreetmap.php:210
-msgid ""
-"A list of <a href=\"http://wiki.openstreetmap.org/wiki/Nominatim\" target="
-"\"_blank\">Nominatim servers</a>"
-msgstr ""
-
-#: addon/openstreetmap/openstreetmap.php:211
-msgid "Default zoom"
-msgstr ""
-
-#: addon/openstreetmap/openstreetmap.php:211
-msgid ""
-"The default zoom level. (1:world, 18:highest, also depends on tile server)"
-msgstr ""
-
-#: addon/openstreetmap/openstreetmap.php:212
-msgid "Include marker on map"
-msgstr ""
-
-#: addon/openstreetmap/openstreetmap.php:212
-msgid "Include a marker on the map."
-msgstr ""
-
-#: addon/mailstream/mailstream.php:81
-msgid "From Address"
-msgstr ""
-
-#: addon/mailstream/mailstream.php:83
-msgid "Email address that stream items will appear to be from."
-msgstr ""
-
-#: addon/mailstream/mailstream.php:240
-msgid "Re:"
-msgstr ""
-
-#: addon/mailstream/mailstream.php:248
-msgid "Friendica post"
-msgstr ""
-
-#: addon/mailstream/mailstream.php:251
-msgid "Diaspora post"
-msgstr ""
-
-#: addon/mailstream/mailstream.php:261
-msgid "Feed item"
-msgstr ""
-
-#: addon/mailstream/mailstream.php:264 src/Content/ContactSelector.php:119
-#: src/Module/Admin/Users.php:270 src/Module/Admin/Users.php:281
-#: src/Module/Admin/Users.php:295 src/Module/Admin/Users.php:313
-msgid "Email"
-msgstr ""
-
-#: addon/mailstream/mailstream.php:266
-msgid "Friendica Item"
-msgstr ""
-
-#: addon/mailstream/mailstream.php:311
-msgid "Upstream"
-msgstr ""
-
-#: addon/mailstream/mailstream.php:312
-msgid "Local"
-msgstr ""
-
-#: addon/mailstream/mailstream.php:385
-msgid "Leave blank to use your account email address"
-msgstr ""
-
-#: addon/mailstream/mailstream.php:388
-msgid "Exclude Likes"
-msgstr ""
-
-#: addon/mailstream/mailstream.php:390
-msgid "Check this to omit mailing \"Like\" notifications"
-msgstr ""
-
-#: addon/mailstream/mailstream.php:393
-msgid "Attach Images"
-msgstr ""
-
-#: addon/mailstream/mailstream.php:395
-msgid ""
-"Download images in posts and attach them to the email.  Useful for reading "
-"email while offline."
-msgstr ""
-
-#: addon/mailstream/mailstream.php:396
-msgid "Mail Stream Settings"
-msgstr ""
-
-#: addon/dwpost/dwpost.php:51
-msgid "Post to Dreamwidth"
-msgstr ""
-
-#: addon/dwpost/dwpost.php:82 addon/dwpost/dwpost.php:86
-msgid "Dreamwidth Export"
-msgstr ""
-
-#: addon/dwpost/dwpost.php:90
-msgid "Enable dreamwidth Post Addon"
-msgstr ""
-
-#: addon/dwpost/dwpost.php:95
-msgid "dreamwidth username"
-msgstr ""
-
-#: addon/dwpost/dwpost.php:100
-msgid "dreamwidth password"
-msgstr ""
-
-#: addon/dwpost/dwpost.php:105
-msgid "Post to dreamwidth by default"
-msgstr ""
-
-#: addon/blackout/blackout.php:101
-msgid ""
-"The end-date is prior to the start-date of the blackout, you should fix this"
-msgstr ""
-
-#: addon/blackout/blackout.php:103
-#, php-format
-msgid ""
-"Please double check that the current settings for the blackout. Begin will "
-"be <strong>%s</strong> and it will end <strong>%s</strong>."
-msgstr ""
-
-#: addon/blackout/blackout.php:107
-msgid "Redirect URL"
-msgstr ""
-
-#: addon/blackout/blackout.php:107
-msgid "all your visitors from the web will be redirected to this URL"
-msgstr ""
-
-#: addon/blackout/blackout.php:108
-msgid "Begin of the Blackout"
-msgstr ""
-
-#: addon/blackout/blackout.php:108
-msgid ""
-"Format is <tt>YYYY-MM-DD hh:mm</tt>; <em>YYYY</em> year, <em>MM</em> month, "
-"<em>DD</em> day, <em>hh</em> hour and <em>mm</em> minute."
-msgstr ""
-
-#: addon/blackout/blackout.php:109
-msgid "End of the Blackout"
-msgstr ""
-
-#: addon/blackout/blackout.php:111
-msgid ""
-"<strong>Note</strong>: The redirect will be active from the moment you press "
-"the submit button. Users currently logged in will <strong>not</strong> be "
-"thrown out but can't login again after logging out should the blackout is "
-"still in place."
-msgstr ""
-
-#: addon/qcomment/qcomment.php:47
-msgid ":-)"
-msgstr ""
-
-#: addon/qcomment/qcomment.php:47
-msgid ":-("
-msgstr ""
-
-#: addon/qcomment/qcomment.php:47
-msgid "lol"
-msgstr ""
-
-#: addon/qcomment/qcomment.php:50
-msgid "Quick Comment Settings"
-msgstr ""
-
-#: addon/qcomment/qcomment.php:52
-msgid ""
-"Quick comments are found near comment boxes, sometimes hidden. Click them to "
-"provide simple replies."
-msgstr ""
-
-#: addon/qcomment/qcomment.php:53
-msgid "Enter quick comments, one per line"
-msgstr ""
-
-#: addon/qcomment/qcomment.php:71
-msgid "Quick Comment settings saved."
-msgstr ""
-
-#: addon/buffer/buffer.php:82
-msgid "Client ID"
-msgstr ""
-
-#: addon/buffer/buffer.php:83
-msgid "Client Secret"
-msgstr ""
-
-#: addon/buffer/buffer.php:101
-msgid "Error when registering buffer connection:"
-msgstr ""
-
-#: addon/buffer/buffer.php:121
-msgid "You are now authenticated to buffer. "
-msgstr ""
-
-#: addon/buffer/buffer.php:140
-msgid "Post to Buffer"
-msgstr ""
-
-#: addon/buffer/buffer.php:169 addon/buffer/buffer.php:173
-msgid "Buffer Export"
-msgstr ""
-
-#: addon/buffer/buffer.php:184
-msgid "Authenticate your Buffer connection"
-msgstr ""
-
-#: addon/buffer/buffer.php:188
-msgid "Enable Buffer Post Addon"
-msgstr ""
-
-#: addon/buffer/buffer.php:193
-msgid "Post to Buffer by default"
-msgstr ""
-
-#: addon/buffer/buffer.php:210
-msgid "Posts are going to all accounts that are enabled by default:"
-msgstr ""
-
-#: addon/planets/planets.php:153 addon/planets/planets.php:157
-msgid "Planets"
-msgstr ""
-
-#: addon/planets/planets.php:161
-msgid "Planets Settings"
-msgstr ""
-
-#: addon/planets/planets.php:163
-msgid "Enable Planets Addon"
-msgstr ""
-
-#: addon/irc/irc.php:43
-msgid "IRC Settings"
-msgstr ""
-
-#: addon/irc/irc.php:44
-msgid ""
-"Here you can change the system wide settings for the channels to "
-"automatically join and access via the side bar. Note the changes you do "
-"here, only effect the channel selection if you are logged in."
-msgstr ""
-
-#: addon/irc/irc.php:46 addon/irc/irc.php:147
-msgid "Channel(s) to auto connect (comma separated)"
-msgstr ""
-
-#: addon/irc/irc.php:46 addon/irc/irc.php:147
-msgid ""
-"List of channels that shall automatically connected to when the app is "
-"launched."
-msgstr ""
-
-#: addon/irc/irc.php:47 addon/irc/irc.php:148
-msgid "Popular Channels (comma separated)"
-msgstr ""
-
-#: addon/irc/irc.php:47 addon/irc/irc.php:148
-msgid ""
-"List of popular channels, will be displayed at the side and hotlinked for "
-"easy joining."
-msgstr ""
-
-#: addon/irc/irc.php:67 addon/irc/irc.php:138
-msgid "IRC settings saved."
-msgstr ""
-
-#: addon/irc/irc.php:72
-msgid "IRC Chatroom"
-msgstr ""
-
-#: addon/irc/irc.php:100
-msgid "Popular Channels"
-msgstr ""
-
-#: addon/infiniteimprobabilitydrive/infiniteimprobabilitydrive.php:23
-msgid "Infinite Improbability Drive"
-msgstr ""
-
-#: addon/widgets/widget_like.php:61
-#, php-format
-msgid "%d person likes this"
-msgid_plural "%d people like this"
-msgstr[0] ""
-msgstr[1] ""
-
-#: addon/widgets/widget_like.php:64
-#, php-format
-msgid "%d person doesn't like this"
-msgid_plural "%d people don't like this"
-msgstr[0] ""
-msgstr[1] ""
-
-#: addon/widgets/widget_friendheader.php:50
-msgid "Get added to this list!"
-msgstr ""
-
-#: addon/widgets/widget_friends.php:53
-msgid "Connect on Friendica!"
-msgstr ""
-
-#: addon/widgets/widgets.php:67
-msgid "Widgets key"
-msgstr ""
-
-#: addon/widgets/widgets.php:69
-msgid "Widgets available"
-msgstr ""
-
-#: addon/widgets/widgets.php:130 mod/settings.php:748
-msgid "Addon Settings"
-msgstr ""
-
-#: include/api.php:1113
+#: include/api.php:1108
 #, php-format
 msgid "Daily posting limit of %d post reached. The post was rejected."
 msgid_plural "Daily posting limit of %d posts reached. The post was rejected."
 msgstr[0] ""
 msgstr[1] ""
 
-#: include/api.php:1127
+#: include/api.php:1122
 #, php-format
 msgid "Weekly posting limit of %d post reached. The post was rejected."
 msgid_plural "Weekly posting limit of %d posts reached. The post was rejected."
 msgstr[0] ""
 msgstr[1] ""
 
-#: include/api.php:1141
+#: include/api.php:1136
 #, php-format
 msgid "Monthly posting limit of %d post reached. The post was rejected."
 msgstr ""
 
-#: include/enotify.php:59
-msgid "Friendica Notification"
+#: include/api.php:4599 mod/photos.php:87 mod/photos.php:178 mod/photos.php:624
+#: mod/photos.php:1046 mod/photos.php:1063 mod/photos.php:1570
+#: mod/profile_photo.php:83 mod/profile_photo.php:92 mod/profile_photo.php:101
+#: mod/profile_photo.php:208 mod/profile_photo.php:296
+#: mod/profile_photo.php:306 src/Model/User.php:838 src/Model/User.php:846
+#: src/Model/User.php:854
+msgid "Profile Photos"
 msgstr ""
 
-#: include/enotify.php:62
-msgid "Thank You,"
-msgstr ""
-
-#: include/enotify.php:136
-#, php-format
-msgid "[Friendica:Notify] New mail received at %s"
-msgstr ""
-
-#: include/enotify.php:138
-#, php-format
-msgid "%1$s sent you a new private message at %2$s."
-msgstr ""
-
-#: include/enotify.php:139
-msgid "a private message"
-msgstr ""
-
-#: include/enotify.php:139
-#, php-format
-msgid "%1$s sent you %2$s."
-msgstr ""
-
-#: include/enotify.php:141
-#, php-format
-msgid "Please visit %s to view and/or reply to your private messages."
-msgstr ""
-
-#: include/enotify.php:225
-#, php-format
-msgid "[Friendica:Notify] %s tagged you"
-msgstr ""
-
-#: include/enotify.php:227
-#, php-format
-msgid "%1$s tagged you at %2$s"
-msgstr ""
-
-#: include/enotify.php:229
-#, php-format
-msgid "[Friendica:Notify] Comment to conversation #%1$d by %2$s"
-msgstr ""
-
-#: include/enotify.php:231
-#, php-format
-msgid "%s commented on an item/conversation you have been following."
-msgstr ""
-
-#: include/enotify.php:236 include/enotify.php:251 include/enotify.php:266
-#: include/enotify.php:285 include/enotify.php:301
-#, php-format
-msgid "Please visit %s to view and/or reply to the conversation."
-msgstr ""
-
-#: include/enotify.php:243
-#, php-format
-msgid "[Friendica:Notify] %s posted to your profile wall"
-msgstr ""
-
-#: include/enotify.php:245
-#, php-format
-msgid "%1$s posted to your profile wall at %2$s"
-msgstr ""
-
-#: include/enotify.php:246
-#, php-format
-msgid "%1$s posted to [url=%2$s]your wall[/url]"
-msgstr ""
-
-#: include/enotify.php:258
-#, php-format
-msgid "[Friendica:Notify] %s shared a new post"
-msgstr ""
-
-#: include/enotify.php:260
-#, php-format
-msgid "%1$s shared a new post at %2$s"
-msgstr ""
-
-#: include/enotify.php:261
-#, php-format
-msgid "%1$s [url=%2$s]shared a post[/url]."
-msgstr ""
-
-#: include/enotify.php:273
-#, php-format
-msgid "[Friendica:Notify] %1$s poked you"
-msgstr ""
-
-#: include/enotify.php:275
-#, php-format
-msgid "%1$s poked you at %2$s"
-msgstr ""
-
-#: include/enotify.php:276
-#, php-format
-msgid "%1$s [url=%2$s]poked you[/url]."
-msgstr ""
-
-#: include/enotify.php:293
-#, php-format
-msgid "[Friendica:Notify] %s tagged your post"
-msgstr ""
-
-#: include/enotify.php:295
-#, php-format
-msgid "%1$s tagged your post at %2$s"
-msgstr ""
-
-#: include/enotify.php:296
-#, php-format
-msgid "%1$s tagged [url=%2$s]your post[/url]"
-msgstr ""
-
-#: include/enotify.php:308
-msgid "[Friendica:Notify] Introduction received"
-msgstr ""
-
-#: include/enotify.php:310
-#, php-format
-msgid "You've received an introduction from '%1$s' at %2$s"
-msgstr ""
-
-#: include/enotify.php:311
-#, php-format
-msgid "You've received [url=%1$s]an introduction[/url] from %2$s."
-msgstr ""
-
-#: include/enotify.php:316 include/enotify.php:362
-#, php-format
-msgid "You may visit their profile at %s"
-msgstr ""
-
-#: include/enotify.php:318
-#, php-format
-msgid "Please visit %s to approve or reject the introduction."
-msgstr ""
-
-#: include/enotify.php:325
-msgid "[Friendica:Notify] A new person is sharing with you"
-msgstr ""
-
-#: include/enotify.php:327 include/enotify.php:328
-#, php-format
-msgid "%1$s is sharing with you at %2$s"
-msgstr ""
-
-#: include/enotify.php:335
-msgid "[Friendica:Notify] You have a new follower"
-msgstr ""
-
-#: include/enotify.php:337 include/enotify.php:338
-#, php-format
-msgid "You have a new follower at %2$s : %1$s"
-msgstr ""
-
-#: include/enotify.php:351
-msgid "[Friendica:Notify] Friend suggestion received"
-msgstr ""
-
-#: include/enotify.php:353
-#, php-format
-msgid "You've received a friend suggestion from '%1$s' at %2$s"
-msgstr ""
-
-#: include/enotify.php:354
-#, php-format
-msgid "You've received [url=%1$s]a friend suggestion[/url] for %2$s from %3$s."
-msgstr ""
-
-#: include/enotify.php:360
-msgid "Name:"
-msgstr ""
-
-#: include/enotify.php:361
-msgid "Photo:"
-msgstr ""
-
-#: include/enotify.php:364
-#, php-format
-msgid "Please visit %s to approve or reject the suggestion."
-msgstr ""
-
-#: include/enotify.php:372 include/enotify.php:387
-msgid "[Friendica:Notify] Connection accepted"
-msgstr ""
-
-#: include/enotify.php:374 include/enotify.php:389
-#, php-format
-msgid "'%1$s' has accepted your connection request at %2$s"
-msgstr ""
-
-#: include/enotify.php:375 include/enotify.php:390
-#, php-format
-msgid "%2$s has accepted your [url=%1$s]connection request[/url]."
-msgstr ""
-
-#: include/enotify.php:380
-msgid ""
-"You are now mutual friends and may exchange status updates, photos, and "
-"email without restriction."
-msgstr ""
-
-#: include/enotify.php:382
-#, php-format
-msgid "Please visit %s if you wish to make any changes to this relationship."
-msgstr ""
-
-#: include/enotify.php:395
-#, php-format
-msgid ""
-"'%1$s' has chosen to accept you a fan, which restricts some forms of "
-"communication - such as private messaging and some profile interactions. If "
-"this is a celebrity or community page, these settings were applied "
-"automatically."
-msgstr ""
-
-#: include/enotify.php:397
-#, php-format
-msgid ""
-"'%1$s' may choose to extend this into a two-way or more permissive "
-"relationship in the future."
-msgstr ""
-
-#: include/enotify.php:399
-#, php-format
-msgid "Please visit %s  if you wish to make any changes to this relationship."
-msgstr ""
-
-#: include/enotify.php:409 mod/removeme.php:46
-msgid "[Friendica System Notify]"
-msgstr ""
-
-#: include/enotify.php:409
-msgid "registration request"
-msgstr ""
-
-#: include/enotify.php:411
-#, php-format
-msgid "You've received a registration request from '%1$s' at %2$s"
-msgstr ""
-
-#: include/enotify.php:412
-#, php-format
-msgid "You've received a [url=%1$s]registration request[/url] from %2$s."
-msgstr ""
-
-#: include/enotify.php:417
-#, php-format
-msgid ""
-"Full Name:\t%s\n"
-"Site Location:\t%s\n"
-"Login Name:\t%s (%s)"
-msgstr ""
-
-#: include/enotify.php:423
-#, php-format
-msgid "Please visit %s to approve or reject the request."
-msgstr ""
-
-#: include/conversation.php:162 include/conversation.php:299
-#: src/Model/Item.php:3394
+#: include/conversation.php:161 include/conversation.php:298
+#: src/Model/Item.php:3389
 msgid "event"
 msgstr ""
 
-#: include/conversation.php:170 include/conversation.php:307
-#: src/Model/Item.php:3396 mod/tagger.php:72 mod/subthread.php:91
+#: include/conversation.php:164 include/conversation.php:174
+#: include/conversation.php:301 include/conversation.php:310
+#: mod/subthread.php:91 mod/tagger.php:72
+msgid "status"
+msgstr ""
+
+#: include/conversation.php:169 include/conversation.php:306
+#: mod/subthread.php:91 mod/tagger.php:72 src/Model/Item.php:3391
 msgid "photo"
 msgstr ""
 
-#: include/conversation.php:185
+#: include/conversation.php:182
+#, php-format
+msgid "%1$s likes %2$s's %3$s"
+msgstr ""
+
+#: include/conversation.php:184
 #, php-format
 msgid "%1$s doesn't like %2$s's %3$s"
 msgstr ""
 
-#: include/conversation.php:187
+#: include/conversation.php:186
 #, php-format
 msgid "%1$s attends %2$s's %3$s"
 msgstr ""
 
-#: include/conversation.php:189
+#: include/conversation.php:188
 #, php-format
 msgid "%1$s doesn't attend %2$s's %3$s"
 msgstr ""
 
-#: include/conversation.php:191
+#: include/conversation.php:190
 #, php-format
 msgid "%1$s attends maybe %2$s's %3$s"
 msgstr ""
 
-#: include/conversation.php:226
+#: include/conversation.php:225
 #, php-format
 msgid "%1$s is now friends with %2$s"
 msgstr ""
 
-#: include/conversation.php:267
+#: include/conversation.php:266
 #, php-format
 msgid "%1$s poked %2$s"
 msgstr ""
 
-#: include/conversation.php:321 mod/tagger.php:105
+#: include/conversation.php:320 mod/tagger.php:105
 #, php-format
 msgid "%1$s tagged %2$s's %3$s with %4$s"
 msgstr ""
 
-#: include/conversation.php:343
+#: include/conversation.php:342
 msgid "post/item"
 msgstr ""
 
-#: include/conversation.php:344
+#: include/conversation.php:343
 #, php-format
 msgid "%1$s marked %2$s's %3$s as favorite"
 msgstr ""
 
-#: include/conversation.php:568 mod/photos.php:1399 mod/profiles.php:350
+#: include/conversation.php:567 mod/photos.php:1398 mod/profiles.php:349
 msgid "Likes"
 msgstr ""
 
-#: include/conversation.php:569 mod/photos.php:1399 mod/profiles.php:353
+#: include/conversation.php:568 mod/photos.php:1398 mod/profiles.php:352
 msgid "Dislikes"
 msgstr ""
 
-#: include/conversation.php:570 include/conversation.php:1591
-#: mod/photos.php:1400
+#: include/conversation.php:569 include/conversation.php:1588
+#: mod/photos.php:1399
 msgid "Attending"
 msgid_plural "Attending"
 msgstr[0] ""
 msgstr[1] ""
 
-#: include/conversation.php:571 mod/photos.php:1400
+#: include/conversation.php:570 mod/photos.php:1399
 msgid "Not attending"
 msgstr ""
 
-#: include/conversation.php:572 mod/photos.php:1400
+#: include/conversation.php:571 mod/photos.php:1399
 msgid "Might attend"
 msgstr ""
 
-#: include/conversation.php:573
+#: include/conversation.php:572
 msgid "Reshares"
 msgstr ""
 
-#: include/conversation.php:653 src/Object/Post.php:208 mod/photos.php:1460
+#: include/conversation.php:652 mod/photos.php:1459 src/Object/Post.php:207
 msgid "Select"
 msgstr ""
 
-#: include/conversation.php:654 src/Module/Admin/Users.php:286
-#: src/Module/Contact.php:829 src/Module/Contact.php:1110 mod/photos.php:1461
-#: mod/settings.php:725 mod/settings.php:867
+#: include/conversation.php:653 mod/photos.php:1460 mod/settings.php:724
+#: mod/settings.php:866 src/Module/Admin/Users.php:285
+#: src/Module/Contact.php:827 src/Module/Contact.php:1108
 msgid "Delete"
 msgstr ""
 
-#: include/conversation.php:680 src/Object/Post.php:401 src/Object/Post.php:402
+#: include/conversation.php:679 src/Object/Post.php:400 src/Object/Post.php:401
 #, php-format
 msgid "View %s's profile @ %s"
 msgstr ""
 
-#: include/conversation.php:693 src/Object/Post.php:389
+#: include/conversation.php:692 src/Object/Post.php:388
 msgid "Categories:"
 msgstr ""
 
-#: include/conversation.php:694 src/Object/Post.php:390
+#: include/conversation.php:693 src/Object/Post.php:389
 msgid "Filed under:"
 msgstr ""
 
-#: include/conversation.php:701 src/Object/Post.php:415
+#: include/conversation.php:700 src/Object/Post.php:414
 #, php-format
 msgid "%s from %s"
 msgstr ""
 
-#: include/conversation.php:716
+#: include/conversation.php:715
 msgid "View in context"
 msgstr ""
 
-#: include/conversation.php:718 include/conversation.php:1237
-#: src/Object/Post.php:445 src/Module/Item/Compose.php:140
-#: mod/wallmessage.php:140 mod/photos.php:1372 mod/editpost.php:87
-#: mod/message.php:258 mod/message.php:440
+#: include/conversation.php:717 include/conversation.php:1237
+#: mod/editpost.php:87 mod/message.php:258 mod/message.php:440
+#: mod/photos.php:1371 mod/wallmessage.php:140 src/Module/Item/Compose.php:140
+#: src/Object/Post.php:444
 msgid "Please wait"
 msgstr ""
 
-#: include/conversation.php:782
+#: include/conversation.php:781
 msgid "remove"
 msgstr ""
 
-#: include/conversation.php:786
+#: include/conversation.php:785
 msgid "Delete Selected Items"
 msgstr ""
 
-#: include/conversation.php:947 view/theme/frio/theme.php:363
+#: include/conversation.php:946 view/theme/frio/theme.php:362
 msgid "Follow Thread"
 msgstr ""
 
-#: include/conversation.php:948 src/Model/Contact.php:1279
+#: include/conversation.php:947 src/Model/Contact.php:1278
 msgid "View Status"
 msgstr ""
 
-#: include/conversation.php:949 include/conversation.php:967
-#: src/Model/Contact.php:1209 src/Model/Contact.php:1271
-#: src/Model/Contact.php:1280 src/Module/Directory.php:148
-#: src/Module/BaseSearchModule.php:132 src/Module/AllFriends.php:74
-#: mod/match.php:86 mod/suggest.php:86
+#: include/conversation.php:948 include/conversation.php:966 mod/match.php:85
+#: mod/suggest.php:86 src/Model/Contact.php:1208 src/Model/Contact.php:1270
+#: src/Model/Contact.php:1279 src/Module/AllFriends.php:74
+#: src/Module/BaseSearchModule.php:132 src/Module/Directory.php:148
 msgid "View Profile"
 msgstr ""
 
-#: include/conversation.php:950 src/Model/Contact.php:1281
+#: include/conversation.php:949 src/Model/Contact.php:1280
 msgid "View Photos"
+msgstr ""
+
+#: include/conversation.php:950 src/Model/Contact.php:1271
+#: src/Model/Contact.php:1281
+msgid "Network Posts"
 msgstr ""
 
 #: include/conversation.php:951 src/Model/Contact.php:1272
 #: src/Model/Contact.php:1282
-msgid "Network Posts"
-msgstr ""
-
-#: include/conversation.php:952 src/Model/Contact.php:1273
-#: src/Model/Contact.php:1283
 msgid "View Contact"
 msgstr ""
 
-#: include/conversation.php:953 src/Model/Contact.php:1285
+#: include/conversation.php:952 src/Model/Contact.php:1284
 msgid "Send PM"
 msgstr ""
 
-#: include/conversation.php:954 src/Module/Admin/Blocklist/Contact.php:65
-#: src/Module/Admin/Users.php:287 src/Module/Contact.php:605
-#: src/Module/Contact.php:826 src/Module/Contact.php:1085
+#: include/conversation.php:953 src/Module/Admin/Blocklist/Contact.php:65
+#: src/Module/Admin/Users.php:286 src/Module/Contact.php:603
+#: src/Module/Contact.php:824 src/Module/Contact.php:1083
 msgid "Block"
 msgstr ""
 
-#: include/conversation.php:955 src/Module/Contact.php:606
-#: src/Module/Contact.php:827 src/Module/Contact.php:1093
-#: mod/notifications.php:37 mod/notifications.php:173 mod/notifications.php:266
+#: include/conversation.php:954 mod/notifications.php:37
+#: mod/notifications.php:173 mod/notifications.php:266
+#: src/Module/Contact.php:604 src/Module/Contact.php:825
+#: src/Module/Contact.php:1091
 msgid "Ignore"
 msgstr ""
 
-#: include/conversation.php:959 src/Model/Contact.php:1286
+#: include/conversation.php:958 src/Model/Contact.php:1285
 msgid "Poke"
 msgstr ""
 
-#: include/conversation.php:964 view/theme/vier/theme.php:177
-#: src/Content/Widget.php:63 src/Model/Contact.php:1274
-#: src/Model/Contact.php:1287 src/Module/BaseSearchModule.php:133
-#: src/Module/AllFriends.php:75 mod/follow.php:159 mod/match.php:87
-#: mod/suggest.php:87
+#: include/conversation.php:963 mod/follow.php:158 mod/match.php:86
+#: mod/suggest.php:87 view/theme/vier/theme.php:176 src/Content/Widget.php:62
+#: src/Model/Contact.php:1273 src/Model/Contact.php:1286
+#: src/Module/AllFriends.php:75 src/Module/BaseSearchModule.php:133
 msgid "Connect/Follow"
 msgstr ""
 
@@ -3448,8 +340,8 @@ msgstr ""
 msgid "Visible to <strong>everybody</strong>"
 msgstr ""
 
-#: include/conversation.php:1177 src/Object/Post.php:913
-#: src/Module/Item/Compose.php:134
+#: include/conversation.php:1177 src/Module/Item/Compose.php:134
+#: src/Object/Post.php:912
 msgid "Please enter a image/video/audio/webpage URL:"
 msgstr ""
 
@@ -3477,8 +369,8 @@ msgstr ""
 msgid "Share"
 msgstr ""
 
-#: include/conversation.php:1217 mod/wallmessage.php:138 mod/editpost.php:73
-#: mod/message.php:256 mod/message.php:437
+#: include/conversation.php:1217 mod/editpost.php:73 mod/message.php:256
+#: mod/message.php:437 mod/wallmessage.php:138
 msgid "Upload photo"
 msgstr ""
 
@@ -3494,48 +386,48 @@ msgstr ""
 msgid "attach file"
 msgstr ""
 
-#: include/conversation.php:1221 src/Object/Post.php:905
-#: src/Module/Item/Compose.php:126
+#: include/conversation.php:1221 src/Module/Item/Compose.php:126
+#: src/Object/Post.php:904
 msgid "Bold"
 msgstr ""
 
-#: include/conversation.php:1222 src/Object/Post.php:906
-#: src/Module/Item/Compose.php:127
+#: include/conversation.php:1222 src/Module/Item/Compose.php:127
+#: src/Object/Post.php:905
 msgid "Italic"
 msgstr ""
 
-#: include/conversation.php:1223 src/Object/Post.php:907
-#: src/Module/Item/Compose.php:128
+#: include/conversation.php:1223 src/Module/Item/Compose.php:128
+#: src/Object/Post.php:906
 msgid "Underline"
 msgstr ""
 
-#: include/conversation.php:1224 src/Object/Post.php:908
-#: src/Module/Item/Compose.php:129
+#: include/conversation.php:1224 src/Module/Item/Compose.php:129
+#: src/Object/Post.php:907
 msgid "Quote"
 msgstr ""
 
-#: include/conversation.php:1225 src/Object/Post.php:909
-#: src/Module/Item/Compose.php:130
+#: include/conversation.php:1225 src/Module/Item/Compose.php:130
+#: src/Object/Post.php:908
 msgid "Code"
 msgstr ""
 
-#: include/conversation.php:1226 src/Object/Post.php:910
-#: src/Module/Item/Compose.php:131
+#: include/conversation.php:1226 src/Module/Item/Compose.php:131
+#: src/Object/Post.php:909
 msgid "Image"
 msgstr ""
 
-#: include/conversation.php:1227 src/Object/Post.php:911
-#: src/Module/Item/Compose.php:132
+#: include/conversation.php:1227 src/Module/Item/Compose.php:132
+#: src/Object/Post.php:910
 msgid "Link"
 msgstr ""
 
-#: include/conversation.php:1228 src/Object/Post.php:912
-#: src/Module/Item/Compose.php:133
+#: include/conversation.php:1228 src/Module/Item/Compose.php:133
+#: src/Object/Post.php:911
 msgid "Link or Media"
 msgstr ""
 
-#: include/conversation.php:1229 src/Module/Item/Compose.php:136
-#: mod/editpost.php:83
+#: include/conversation.php:1229 mod/editpost.php:83
+#: src/Module/Item/Compose.php:136
 msgid "Set your location"
 msgstr ""
 
@@ -3551,13 +443,13 @@ msgstr ""
 msgid "clear location"
 msgstr ""
 
-#: include/conversation.php:1234 src/Module/Item/Compose.php:141
-#: mod/editpost.php:100
+#: include/conversation.php:1234 mod/editpost.php:100
+#: src/Module/Item/Compose.php:141
 msgid "Set title"
 msgstr ""
 
-#: include/conversation.php:1236 src/Module/Item/Compose.php:142
-#: mod/editpost.php:102
+#: include/conversation.php:1236 mod/editpost.php:102
+#: src/Module/Item/Compose.php:142
 msgid "Categories (comma-separated list)"
 msgstr ""
 
@@ -3573,10 +465,19 @@ msgstr ""
 msgid "Public post"
 msgstr ""
 
-#: include/conversation.php:1252 src/Object/Post.php:914
-#: src/Module/Item/Compose.php:135 mod/events.php:549 mod/photos.php:1390
-#: mod/photos.php:1429 mod/photos.php:1493 mod/editpost.php:108
+#: include/conversation.php:1252 mod/editpost.php:108 mod/events.php:549
+#: mod/photos.php:1389 mod/photos.php:1428 mod/photos.php:1492
+#: src/Module/Item/Compose.php:135 src/Object/Post.php:913
 msgid "Preview"
+msgstr ""
+
+#: include/conversation.php:1256 include/items.php:385 mod/dfrn_request.php:652
+#: mod/editpost.php:111 mod/fbrowser.php:109 mod/fbrowser.php:138
+#: mod/follow.php:172 mod/message.php:151 mod/photos.php:1040
+#: mod/photos.php:1147 mod/settings.php:664 mod/settings.php:690
+#: mod/suggest.php:75 mod/tagrm.php:20 mod/tagrm.php:115 mod/unfollow.php:131
+#: src/Module/Contact.php:444
+msgid "Cancel"
 msgstr ""
 
 #: include/conversation.php:1261
@@ -3591,189 +492,3583 @@ msgstr ""
 msgid "Private post"
 msgstr ""
 
+#: include/conversation.php:1268 mod/editpost.php:115 src/Model/Profile.php:540
+#: src/Module/Contact.php:319
+msgid "Message"
+msgstr ""
+
 #: include/conversation.php:1269 mod/editpost.php:116
 msgid "Browser"
 msgstr ""
 
-#: include/conversation.php:1561
+#: include/conversation.php:1558
 msgid "View all"
 msgstr ""
 
-#: include/conversation.php:1585
+#: include/conversation.php:1582
 msgid "Like"
 msgid_plural "Likes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: include/conversation.php:1588
+#: include/conversation.php:1585
 msgid "Dislike"
 msgid_plural "Dislikes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: include/conversation.php:1594
+#: include/conversation.php:1591
 msgid "Not Attending"
 msgid_plural "Not Attending"
 msgstr[0] ""
 msgstr[1] ""
 
-#: include/conversation.php:1597 src/Content/ContactSelector.php:249
+#: include/conversation.php:1594 src/Content/ContactSelector.php:250
 msgid "Undecided"
 msgid_plural "Undecided"
 msgstr[0] ""
 msgstr[1] ""
 
-#: include/items.php:349 src/Module/Admin/Themes/Details.php:53
-#: src/Module/Admin/Themes/Index.php:41 src/Module/Debug/ItemBody.php:27
+#: include/enotify.php:58
+msgid "Friendica Notification"
+msgstr ""
+
+#: include/enotify.php:61
+msgid "Thank You,"
+msgstr ""
+
+#: include/enotify.php:64
+#, php-format
+msgid "%1$s, %2$s Administrator"
+msgstr ""
+
+#: include/enotify.php:66
+#, php-format
+msgid "%s Administrator"
+msgstr ""
+
+#: include/enotify.php:135
+#, php-format
+msgid "[Friendica:Notify] New mail received at %s"
+msgstr ""
+
+#: include/enotify.php:137
+#, php-format
+msgid "%1$s sent you a new private message at %2$s."
+msgstr ""
+
+#: include/enotify.php:138
+msgid "a private message"
+msgstr ""
+
+#: include/enotify.php:138
+#, php-format
+msgid "%1$s sent you %2$s."
+msgstr ""
+
+#: include/enotify.php:140
+#, php-format
+msgid "Please visit %s to view and/or reply to your private messages."
+msgstr ""
+
+#: include/enotify.php:224
+#, php-format
+msgid "[Friendica:Notify] %s tagged you"
+msgstr ""
+
+#: include/enotify.php:226
+#, php-format
+msgid "%1$s tagged you at %2$s"
+msgstr ""
+
+#: include/enotify.php:228
+#, php-format
+msgid "[Friendica:Notify] Comment to conversation #%1$d by %2$s"
+msgstr ""
+
+#: include/enotify.php:230
+#, php-format
+msgid "%s commented on an item/conversation you have been following."
+msgstr ""
+
+#: include/enotify.php:235 include/enotify.php:250 include/enotify.php:265
+#: include/enotify.php:284 include/enotify.php:300
+#, php-format
+msgid "Please visit %s to view and/or reply to the conversation."
+msgstr ""
+
+#: include/enotify.php:242
+#, php-format
+msgid "[Friendica:Notify] %s posted to your profile wall"
+msgstr ""
+
+#: include/enotify.php:244
+#, php-format
+msgid "%1$s posted to your profile wall at %2$s"
+msgstr ""
+
+#: include/enotify.php:245
+#, php-format
+msgid "%1$s posted to [url=%2$s]your wall[/url]"
+msgstr ""
+
+#: include/enotify.php:257
+#, php-format
+msgid "[Friendica:Notify] %s shared a new post"
+msgstr ""
+
+#: include/enotify.php:259
+#, php-format
+msgid "%1$s shared a new post at %2$s"
+msgstr ""
+
+#: include/enotify.php:260
+#, php-format
+msgid "%1$s [url=%2$s]shared a post[/url]."
+msgstr ""
+
+#: include/enotify.php:272
+#, php-format
+msgid "[Friendica:Notify] %1$s poked you"
+msgstr ""
+
+#: include/enotify.php:274
+#, php-format
+msgid "%1$s poked you at %2$s"
+msgstr ""
+
+#: include/enotify.php:275
+#, php-format
+msgid "%1$s [url=%2$s]poked you[/url]."
+msgstr ""
+
+#: include/enotify.php:292
+#, php-format
+msgid "[Friendica:Notify] %s tagged your post"
+msgstr ""
+
+#: include/enotify.php:294
+#, php-format
+msgid "%1$s tagged your post at %2$s"
+msgstr ""
+
+#: include/enotify.php:295
+#, php-format
+msgid "%1$s tagged [url=%2$s]your post[/url]"
+msgstr ""
+
+#: include/enotify.php:307
+msgid "[Friendica:Notify] Introduction received"
+msgstr ""
+
+#: include/enotify.php:309
+#, php-format
+msgid "You've received an introduction from '%1$s' at %2$s"
+msgstr ""
+
+#: include/enotify.php:310
+#, php-format
+msgid "You've received [url=%1$s]an introduction[/url] from %2$s."
+msgstr ""
+
+#: include/enotify.php:315 include/enotify.php:361
+#, php-format
+msgid "You may visit their profile at %s"
+msgstr ""
+
+#: include/enotify.php:317
+#, php-format
+msgid "Please visit %s to approve or reject the introduction."
+msgstr ""
+
+#: include/enotify.php:324
+msgid "[Friendica:Notify] A new person is sharing with you"
+msgstr ""
+
+#: include/enotify.php:326 include/enotify.php:327
+#, php-format
+msgid "%1$s is sharing with you at %2$s"
+msgstr ""
+
+#: include/enotify.php:334
+msgid "[Friendica:Notify] You have a new follower"
+msgstr ""
+
+#: include/enotify.php:336 include/enotify.php:337
+#, php-format
+msgid "You have a new follower at %2$s : %1$s"
+msgstr ""
+
+#: include/enotify.php:350
+msgid "[Friendica:Notify] Friend suggestion received"
+msgstr ""
+
+#: include/enotify.php:352
+#, php-format
+msgid "You've received a friend suggestion from '%1$s' at %2$s"
+msgstr ""
+
+#: include/enotify.php:353
+#, php-format
+msgid "You've received [url=%1$s]a friend suggestion[/url] for %2$s from %3$s."
+msgstr ""
+
+#: include/enotify.php:359
+msgid "Name:"
+msgstr ""
+
+#: include/enotify.php:360
+msgid "Photo:"
+msgstr ""
+
+#: include/enotify.php:363
+#, php-format
+msgid "Please visit %s to approve or reject the suggestion."
+msgstr ""
+
+#: include/enotify.php:371 include/enotify.php:386
+msgid "[Friendica:Notify] Connection accepted"
+msgstr ""
+
+#: include/enotify.php:373 include/enotify.php:388
+#, php-format
+msgid "'%1$s' has accepted your connection request at %2$s"
+msgstr ""
+
+#: include/enotify.php:374 include/enotify.php:389
+#, php-format
+msgid "%2$s has accepted your [url=%1$s]connection request[/url]."
+msgstr ""
+
+#: include/enotify.php:379
+msgid ""
+"You are now mutual friends and may exchange status updates, photos, and "
+"email without restriction."
+msgstr ""
+
+#: include/enotify.php:381
+#, php-format
+msgid "Please visit %s if you wish to make any changes to this relationship."
+msgstr ""
+
+#: include/enotify.php:394
+#, php-format
+msgid ""
+"'%1$s' has chosen to accept you a fan, which restricts some forms of "
+"communication - such as private messaging and some profile interactions. If "
+"this is a celebrity or community page, these settings were applied "
+"automatically."
+msgstr ""
+
+#: include/enotify.php:396
+#, php-format
+msgid ""
+"'%1$s' may choose to extend this into a two-way or more permissive "
+"relationship in the future."
+msgstr ""
+
+#: include/enotify.php:398
+#, php-format
+msgid "Please visit %s  if you wish to make any changes to this relationship."
+msgstr ""
+
+#: include/enotify.php:408 mod/removeme.php:45
+msgid "[Friendica System Notify]"
+msgstr ""
+
+#: include/enotify.php:408
+msgid "registration request"
+msgstr ""
+
+#: include/enotify.php:410
+#, php-format
+msgid "You've received a registration request from '%1$s' at %2$s"
+msgstr ""
+
+#: include/enotify.php:411
+#, php-format
+msgid "You've received a [url=%1$s]registration request[/url] from %2$s."
+msgstr ""
+
+#: include/enotify.php:416
+#, php-format
+msgid ""
+"Full Name:\t%s\n"
+"Site Location:\t%s\n"
+"Login Name:\t%s (%s)"
+msgstr ""
+
+#: include/enotify.php:422
+#, php-format
+msgid "Please visit %s to approve or reject the request."
+msgstr ""
+
+#: include/items.php:348 src/Module/Admin/Themes/Details.php:53
+#: src/Module/Admin/Themes/Index.php:40 src/Module/Debug/ItemBody.php:27
 #: src/Module/Debug/ItemBody.php:40
 msgid "Item not found."
 msgstr ""
 
-#: include/items.php:381
+#: include/items.php:380
 msgid "Do you really want to delete this item?"
 msgstr ""
 
-#: include/items.php:383 src/Module/Contact.php:443 src/Module/Register.php:97
-#: mod/api.php:110 mod/dfrn_request.php:643 mod/follow.php:162
-#: mod/profiles.php:524 mod/profiles.php:527 mod/profiles.php:549
-#: mod/settings.php:1084 mod/settings.php:1090 mod/settings.php:1097
-#: mod/settings.php:1101 mod/settings.php:1105 mod/settings.php:1109
-#: mod/settings.php:1113 mod/settings.php:1117 mod/settings.php:1137
+#: include/items.php:382 mod/api.php:109 mod/dfrn_request.php:642
+#: mod/follow.php:161 mod/message.php:148 mod/profiles.php:523
+#: mod/profiles.php:526 mod/profiles.php:548 mod/settings.php:1083
+#: mod/settings.php:1089 mod/settings.php:1096 mod/settings.php:1100
+#: mod/settings.php:1104 mod/settings.php:1108 mod/settings.php:1112
+#: mod/settings.php:1116 mod/settings.php:1136 mod/settings.php:1137
 #: mod/settings.php:1138 mod/settings.php:1139 mod/settings.php:1140
-#: mod/settings.php:1141 mod/suggest.php:72 mod/message.php:148
+#: mod/suggest.php:72 src/Module/Contact.php:441 src/Module/Register.php:96
 msgid "Yes"
 msgstr ""
 
-#: update.php:218
+#: include/items.php:432 mod/api.php:34 mod/api.php:39 mod/cal.php:288
+#: mod/common.php:27 mod/crepair.php:89 mod/dfrn_confirm.php:64
+#: mod/editpost.php:22 mod/events.php:212 mod/follow.php:55 mod/follow.php:132
+#: mod/fsuggest.php:63 mod/item.php:171 mod/message.php:54 mod/message.php:99
+#: mod/network.php:35 mod/notes.php:27 mod/notifications.php:49
+#: mod/ostatus_subscribe.php:16 mod/photos.php:160 mod/photos.php:922
+#: mod/poke.php:142 mod/profile_photo.php:30 mod/profile_photo.php:175
+#: mod/profile_photo.php:195 mod/profiles.php:179 mod/profiles.php:496
+#: mod/regmod.php:84 mod/repair_ostatus.php:15 mod/settings.php:48
+#: mod/settings.php:161 mod/settings.php:653 mod/suggest.php:38
+#: mod/uimport.php:16 mod/unfollow.php:21 mod/unfollow.php:76
+#: mod/unfollow.php:108 mod/wall_attach.php:62 mod/wall_attach.php:65
+#: mod/wall_upload.php:93 mod/wall_upload.php:96 mod/wallmessage.php:18
+#: mod/wallmessage.php:42 mod/wallmessage.php:81 mod/wallmessage.php:105
+#: src/Module/Notifications/Notify.php:18 src/Module/Profile/Contacts.php:49
+#: src/Module/Search/Directory.php:19 src/Module/Settings/Delegation.php:23
+#: src/Module/Settings/Delegation.php:51 src/Module/Attach.php:41
+#: src/Module/Base/Api.php:40 src/Module/Base/Api.php:46
+#: src/Module/Contact.php:358 src/Module/Delegation.php:98
+#: src/Module/FollowConfirm.php:16 src/Module/Group.php:29
+#: src/Module/Group.php:75 src/Module/Invite.php:21 src/Module/Invite.php:109
+#: src/Module/Register.php:43 src/Module/Register.php:56
+#: src/Module/Register.php:176 src/Module/Register.php:215
+msgid "Permission denied."
+msgstr ""
+
+#: mod/api.php:84 mod/api.php:106
+msgid "Authorize application connection"
+msgstr ""
+
+#: mod/api.php:85
+msgid "Return to your app and insert this Securty Code:"
+msgstr ""
+
+#: mod/api.php:94 src/Module/BaseAdminModule.php:54
+msgid "Please login to continue."
+msgstr ""
+
+#: mod/api.php:108
+msgid ""
+"Do you want to authorize this application to access your posts and contacts, "
+"and/or create new posts for you?"
+msgstr ""
+
+#: mod/api.php:110 mod/dfrn_request.php:642 mod/follow.php:161
+#: mod/profiles.php:523 mod/profiles.php:527 mod/profiles.php:548
+#: mod/settings.php:1083 mod/settings.php:1089 mod/settings.php:1096
+#: mod/settings.php:1100 mod/settings.php:1104 mod/settings.php:1108
+#: mod/settings.php:1112 mod/settings.php:1116 mod/settings.php:1136
+#: mod/settings.php:1137 mod/settings.php:1138 mod/settings.php:1139
+#: mod/settings.php:1140 src/Module/Register.php:97
+msgid "No"
+msgstr ""
+
+#: mod/cal.php:28 mod/cal.php:32 mod/community.php:31 mod/follow.php:18
+#: src/Module/Debug/ItemBody.php:18 src/Module/Diaspora/Receive.php:32
+#: src/Module/Item/Ignore.php:22
+msgid "Access denied."
+msgstr ""
+
+#: mod/cal.php:127 mod/display.php:269 src/Module/Profile.php:170
+msgid "Access to this profile has been restricted."
+msgstr ""
+
+#: mod/cal.php:258 mod/events.php:393 view/theme/frio/theme.php:270
+#: view/theme/frio/theme.php:274 src/Content/Nav.php:161
+#: src/Content/Nav.php:225 src/Model/Profile.php:943 src/Model/Profile.php:954
+msgid "Events"
+msgstr ""
+
+#: mod/cal.php:259 mod/events.php:394
+msgid "View"
+msgstr ""
+
+#: mod/cal.php:260 mod/events.php:396
+msgid "Previous"
+msgstr ""
+
+#: mod/cal.php:261 mod/events.php:397 src/Module/Install.php:173
+msgid "Next"
+msgstr ""
+
+#: mod/cal.php:264 mod/events.php:402 src/Model/Event.php:427
+msgid "today"
+msgstr ""
+
+#: mod/cal.php:265 mod/events.php:403 src/Util/Temporal.php:312
+#: src/Model/Event.php:428
+msgid "month"
+msgstr ""
+
+#: mod/cal.php:266 mod/events.php:404 src/Util/Temporal.php:313
+#: src/Model/Event.php:429
+msgid "week"
+msgstr ""
+
+#: mod/cal.php:267 mod/events.php:405 src/Util/Temporal.php:314
+#: src/Model/Event.php:430
+msgid "day"
+msgstr ""
+
+#: mod/cal.php:268 mod/events.php:406
+msgid "list"
+msgstr ""
+
+#: mod/cal.php:281 src/Model/User.php:413 src/Console/NewPassword.php:88
+msgid "User not found"
+msgstr ""
+
+#: mod/cal.php:297
+msgid "This calendar format is not supported"
+msgstr ""
+
+#: mod/cal.php:299
+msgid "No exportable data found"
+msgstr ""
+
+#: mod/cal.php:316
+msgid "calendar"
+msgstr ""
+
+#: mod/common.php:90
+msgid "No contacts in common."
+msgstr ""
+
+#: mod/common.php:141 src/Module/Contact.php:892
+msgid "Common Friends"
+msgstr ""
+
+#: mod/community.php:24 mod/dfrn_request.php:599 mod/display.php:167
+#: mod/photos.php:836 mod/videos.php:111 src/Module/Debug/Probe.php:20
+#: src/Module/Debug/WebFinger.php:19 src/Module/Search/Index.php:29
+#: src/Module/Search/Index.php:34 src/Module/Directory.php:31
+msgid "Public access denied."
+msgstr ""
+
+#: mod/community.php:67
+msgid "Community option not available."
+msgstr ""
+
+#: mod/community.php:84
+msgid "Not available."
+msgstr ""
+
+#: mod/community.php:94
+msgid "Local Community"
+msgstr ""
+
+#: mod/community.php:97
+msgid "Posts from local users on this server"
+msgstr ""
+
+#: mod/community.php:105
+msgid "Global Community"
+msgstr ""
+
+#: mod/community.php:108
+msgid "Posts from users of the whole federated network"
+msgstr ""
+
+#: mod/community.php:154 src/Module/Search/Index.php:168
+msgid "No results."
+msgstr ""
+
+#: mod/community.php:206
+msgid ""
+"This community stream shows all public posts received by this node. They may "
+"not reflect the opinions of this node’s users."
+msgstr ""
+
+#: mod/crepair.php:78
+msgid "Contact settings applied."
+msgstr ""
+
+#: mod/crepair.php:80
+msgid "Contact update failed."
+msgstr ""
+
+#: mod/crepair.php:101 mod/dfrn_confirm.php:125 mod/fsuggest.php:32
+#: mod/fsuggest.php:75 mod/redir.php:32 mod/redir.php:122 mod/redir.php:137
+#: src/Module/Group.php:90
+msgid "Contact not found."
+msgstr ""
+
+#: mod/crepair.php:114
+msgid ""
+"<strong>WARNING: This is highly advanced</strong> and if you enter incorrect "
+"information your communications with this contact may stop working."
+msgstr ""
+
+#: mod/crepair.php:115
+msgid ""
+"Please use your browser 'Back' button <strong>now</strong> if you are "
+"uncertain what to do on this page."
+msgstr ""
+
+#: mod/crepair.php:129 mod/crepair.php:131
+msgid "No mirroring"
+msgstr ""
+
+#: mod/crepair.php:129
+msgid "Mirror as forwarded posting"
+msgstr ""
+
+#: mod/crepair.php:129 mod/crepair.php:131
+msgid "Mirror as my own posting"
+msgstr ""
+
+#: mod/crepair.php:144
+msgid "Return to contact editor"
+msgstr ""
+
+#: mod/crepair.php:146
+msgid "Refetch contact data"
+msgstr ""
+
+#: mod/crepair.php:148 mod/events.php:551 mod/fsuggest.php:92
+#: mod/message.php:259 mod/message.php:439 mod/photos.php:951
+#: mod/photos.php:1057 mod/photos.php:1343 mod/photos.php:1388
+#: mod/photos.php:1427 mod/photos.php:1491 mod/poke.php:185
+#: mod/profiles.php:559 view/theme/duepuntozero/config.php:69
+#: view/theme/frio/config.php:124 view/theme/quattro/config.php:71
+#: view/theme/vier/config.php:119 src/Module/Debug/Localtime.php:45
+#: src/Module/Item/Compose.php:125 src/Module/Contact.php:578
+#: src/Module/Delegation.php:131 src/Module/Install.php:211
+#: src/Module/Install.php:251 src/Module/Install.php:287
+#: src/Module/Invite.php:156 src/Object/Post.php:903
+msgid "Submit"
+msgstr ""
+
+#: mod/crepair.php:149
+msgid "Remote Self"
+msgstr ""
+
+#: mod/crepair.php:152
+msgid "Mirror postings from this contact"
+msgstr ""
+
+#: mod/crepair.php:154
+msgid ""
+"Mark this contact as remote_self, this will cause friendica to repost new "
+"entries from this contact."
+msgstr ""
+
+#: mod/crepair.php:158 mod/settings.php:665 mod/settings.php:691
+#: src/Module/Admin/Blocklist/Contact.php:71 src/Module/Admin/Users.php:269
+#: src/Module/Admin/Users.php:280 src/Module/Admin/Users.php:294
+#: src/Module/Admin/Users.php:310
+msgid "Name"
+msgstr ""
+
+#: mod/crepair.php:159
+msgid "Account Nickname"
+msgstr ""
+
+#: mod/crepair.php:160
+msgid "@Tagname - overrides Name/Nickname"
+msgstr ""
+
+#: mod/crepair.php:161
+msgid "Account URL"
+msgstr ""
+
+#: mod/crepair.php:162
+msgid "Account URL Alias"
+msgstr ""
+
+#: mod/crepair.php:163
+msgid "Friend Request URL"
+msgstr ""
+
+#: mod/crepair.php:164
+msgid "Friend Confirm URL"
+msgstr ""
+
+#: mod/crepair.php:165
+msgid "Notification Endpoint URL"
+msgstr ""
+
+#: mod/crepair.php:166
+msgid "Poll/Feed URL"
+msgstr ""
+
+#: mod/crepair.php:167
+msgid "New photo from this URL"
+msgstr ""
+
+#: mod/dfrn_confirm.php:70 mod/profiles.php:40 mod/profiles.php:149
+#: mod/profiles.php:193 mod/profiles.php:508
+msgid "Profile not found."
+msgstr ""
+
+#: mod/dfrn_confirm.php:126
+msgid ""
+"This may occasionally happen if contact was requested by both persons and it "
+"has already been approved."
+msgstr ""
+
+#: mod/dfrn_confirm.php:227
+msgid "Response from remote site was not understood."
+msgstr ""
+
+#: mod/dfrn_confirm.php:234 mod/dfrn_confirm.php:240
+msgid "Unexpected response from remote site: "
+msgstr ""
+
+#: mod/dfrn_confirm.php:249
+msgid "Confirmation completed successfully."
+msgstr ""
+
+#: mod/dfrn_confirm.php:261
+msgid "Temporary failure. Please wait and try again."
+msgstr ""
+
+#: mod/dfrn_confirm.php:264
+msgid "Introduction failed or was revoked."
+msgstr ""
+
+#: mod/dfrn_confirm.php:269
+msgid "Remote site reported: "
+msgstr ""
+
+#: mod/dfrn_confirm.php:374
 #, php-format
-msgid "%s: Updating author-id and owner-id in item and thread table. "
+msgid "No user record found for '%s' "
 msgstr ""
 
-#: update.php:273
+#: mod/dfrn_confirm.php:384
+msgid "Our site encryption key is apparently messed up."
+msgstr ""
+
+#: mod/dfrn_confirm.php:395
+msgid "Empty site URL was provided or URL could not be decrypted by us."
+msgstr ""
+
+#: mod/dfrn_confirm.php:411
+msgid "Contact record was not found for you on our site."
+msgstr ""
+
+#: mod/dfrn_confirm.php:425
 #, php-format
-msgid "%s: Updating post-type."
+msgid "Site public key not available in contact record for URL %s."
 msgstr ""
 
-#: view/theme/vier/theme.php:127 view/theme/vier/config.php:124
-msgid "Community Profiles"
+#: mod/dfrn_confirm.php:441
+msgid ""
+"The ID provided by your system is a duplicate on our system. It should work "
+"if you try again."
 msgstr ""
 
-#: view/theme/vier/theme.php:157 view/theme/vier/config.php:128
-msgid "Last users"
+#: mod/dfrn_confirm.php:452
+msgid "Unable to set your contact credentials on our system."
 msgstr ""
 
-#: view/theme/vier/theme.php:175 src/Content/Widget.php:61
-msgid "Find People"
+#: mod/dfrn_confirm.php:508
+msgid "Unable to update your contact profile details on our system"
 msgstr ""
 
-#: view/theme/vier/theme.php:176 src/Content/Widget.php:62
-msgid "Enter name or interest"
+#: mod/dfrn_confirm.php:538 mod/dfrn_request.php:562 src/Model/Contact.php:2642
+msgid "[Name Withheld]"
 msgstr ""
 
-#: view/theme/vier/theme.php:178 src/Content/Widget.php:64
-msgid "Examples: Robert Morgenstein, Fishing"
+#: mod/dfrn_poll.php:121 mod/dfrn_poll.php:524
+#, php-format
+msgid "%1$s welcomes %2$s"
 msgstr ""
 
-#: view/theme/vier/theme.php:180 src/Content/Widget.php:66 mod/suggest.php:118
-msgid "Friend Suggestions"
+#: mod/dfrn_request.php:100
+msgid "This introduction has already been accepted."
 msgstr ""
 
-#: view/theme/vier/theme.php:181 src/Content/Widget.php:67
-msgid "Similar Interests"
+#: mod/dfrn_request.php:118 mod/dfrn_request.php:356
+msgid "Profile location is not valid or does not contain profile information."
 msgstr ""
 
-#: view/theme/vier/theme.php:182 src/Content/Widget.php:68
-msgid "Random Profile"
+#: mod/dfrn_request.php:122 mod/dfrn_request.php:360
+msgid "Warning: profile location has no identifiable owner name."
 msgstr ""
 
-#: view/theme/vier/theme.php:183 src/Content/Widget.php:69
-msgid "Invite Friends"
+#: mod/dfrn_request.php:125 mod/dfrn_request.php:363
+msgid "Warning: profile location has no profile photo."
 msgstr ""
 
-#: view/theme/vier/theme.php:186 src/Content/Widget.php:72
-msgid "Local Directory"
+#: mod/dfrn_request.php:129 mod/dfrn_request.php:367
+#, php-format
+msgid "%d required parameter was not found at the given location"
+msgid_plural "%d required parameters were not found at the given location"
+msgstr[0] ""
+msgstr[1] ""
+
+#: mod/dfrn_request.php:167
+msgid "Introduction complete."
 msgstr ""
 
-#: view/theme/vier/theme.php:226 src/Content/Text/HTML.php:915
-#: src/Content/ForumManager.php:129 src/Content/Nav.php:208
-msgid "Forums"
+#: mod/dfrn_request.php:203
+msgid "Unrecoverable protocol error."
 msgstr ""
 
-#: view/theme/vier/theme.php:228 src/Content/ForumManager.php:131
-msgid "External link to forum"
+#: mod/dfrn_request.php:230
+msgid "Profile unavailable."
 msgstr ""
 
-#: view/theme/vier/theme.php:264
-msgid "Quick Start"
+#: mod/dfrn_request.php:251
+#, php-format
+msgid "%s has received too many connection requests today."
 msgstr ""
 
-#: view/theme/vier/theme.php:349 view/theme/vier/config.php:126
-msgid "Connect Services"
+#: mod/dfrn_request.php:252
+msgid "Spam protection measures have been invoked."
 msgstr ""
 
-#: view/theme/vier/config.php:76
-msgid "Comma separated list of helper forums"
+#: mod/dfrn_request.php:253
+msgid "Friends are advised to please try again in 24 hours."
 msgstr ""
 
-#: view/theme/vier/config.php:116
-msgid "don't show"
+#: mod/dfrn_request.php:277
+msgid "Invalid locator"
 msgstr ""
 
-#: view/theme/vier/config.php:116
-msgid "show"
+#: mod/dfrn_request.php:313
+msgid "You have already introduced yourself here."
 msgstr ""
 
-#: view/theme/vier/config.php:121 view/theme/duepuntozero/config.php:71
-#: view/theme/frio/config.php:126 view/theme/quattro/config.php:73
-#: mod/settings.php:970
+#: mod/dfrn_request.php:316
+#, php-format
+msgid "Apparently you are already friends with %s."
+msgstr ""
+
+#: mod/dfrn_request.php:336
+msgid "Invalid profile URL."
+msgstr ""
+
+#: mod/dfrn_request.php:342 src/Model/Contact.php:2265
+msgid "Disallowed profile URL."
+msgstr ""
+
+#: mod/dfrn_request.php:348 src/Model/Contact.php:2270
+#: src/Module/Friendica.php:58
+msgid "Blocked domain"
+msgstr ""
+
+#: mod/dfrn_request.php:415 src/Module/Contact.php:140
+msgid "Failed to update contact record."
+msgstr ""
+
+#: mod/dfrn_request.php:435
+msgid "Your introduction has been sent."
+msgstr ""
+
+#: mod/dfrn_request.php:473
+msgid ""
+"Remote subscription can't be done for your network. Please subscribe "
+"directly on your system."
+msgstr ""
+
+#: mod/dfrn_request.php:489
+msgid "Please login to confirm introduction."
+msgstr ""
+
+#: mod/dfrn_request.php:497
+msgid ""
+"Incorrect identity currently logged in. Please login to <strong>this</"
+"strong> profile."
+msgstr ""
+
+#: mod/dfrn_request.php:511 mod/dfrn_request.php:526
+msgid "Confirm"
+msgstr ""
+
+#: mod/dfrn_request.php:522
+msgid "Hide this contact"
+msgstr ""
+
+#: mod/dfrn_request.php:524
+#, php-format
+msgid "Welcome home %s."
+msgstr ""
+
+#: mod/dfrn_request.php:525
+#, php-format
+msgid "Please confirm your introduction/connection request to %s."
+msgstr ""
+
+#: mod/dfrn_request.php:634
+msgid ""
+"Please enter your 'Identity Address' from one of the following supported "
+"communications networks:"
+msgstr ""
+
+#: mod/dfrn_request.php:636
+#, php-format
+msgid ""
+"If you are not yet a member of the free social web, <a href=\"%s\">follow "
+"this link to find a public Friendica site and join us today</a>."
+msgstr ""
+
+#: mod/dfrn_request.php:639
+msgid "Friend/Connection Request"
+msgstr ""
+
+#: mod/dfrn_request.php:640
+msgid ""
+"Examples: jojo@demo.friendica.com, http://demo.friendica.com/profile/jojo, "
+"testuser@gnusocial.de"
+msgstr ""
+
+#: mod/dfrn_request.php:641 mod/follow.php:160
+msgid "Please answer the following:"
+msgstr ""
+
+#: mod/dfrn_request.php:642 mod/follow.php:161
+#, php-format
+msgid "Does %s know you?"
+msgstr ""
+
+#: mod/dfrn_request.php:643 mod/follow.php:162
+msgid "Add a personal note:"
+msgstr ""
+
+#: mod/dfrn_request.php:645
+msgid "Friendica"
+msgstr ""
+
+#: mod/dfrn_request.php:646
+msgid "GNU Social (Pleroma, Mastodon)"
+msgstr ""
+
+#: mod/dfrn_request.php:647
+msgid "Diaspora (Socialhome, Hubzilla)"
+msgstr ""
+
+#: mod/dfrn_request.php:648
+#, php-format
+msgid ""
+" - please do not use this form.  Instead, enter %s into your Diaspora search "
+"bar."
+msgstr ""
+
+#: mod/dfrn_request.php:649 mod/follow.php:168 mod/unfollow.php:127
+msgid "Your Identity Address:"
+msgstr ""
+
+#: mod/dfrn_request.php:651 mod/follow.php:74 mod/unfollow.php:130
+msgid "Submit Request"
+msgstr ""
+
+#: mod/display.php:224 mod/display.php:305
+msgid "The requested item doesn't exist or has been deleted."
+msgstr ""
+
+#: mod/display.php:385
+msgid "The feed for this item is unavailable."
+msgstr ""
+
+#: mod/editpost.php:29 mod/editpost.php:39
+msgid "Item not found"
+msgstr ""
+
+#: mod/editpost.php:46
+msgid "Edit post"
+msgstr ""
+
+#: mod/editpost.php:72 mod/notes.php:46 src/Content/Text/HTML.php:894
+#: src/Module/Filer/SaveTag.php:48
+msgid "Save"
+msgstr ""
+
+#: mod/editpost.php:77 mod/message.php:257 mod/message.php:438
+#: mod/wallmessage.php:139
+msgid "Insert web link"
+msgstr ""
+
+#: mod/editpost.php:78
+msgid "web link"
+msgstr ""
+
+#: mod/editpost.php:79
+msgid "Insert video link"
+msgstr ""
+
+#: mod/editpost.php:80
+msgid "video link"
+msgstr ""
+
+#: mod/editpost.php:81
+msgid "Insert audio link"
+msgstr ""
+
+#: mod/editpost.php:82
+msgid "audio link"
+msgstr ""
+
+#: mod/editpost.php:96 src/Core/ACL.php:390
+msgid "CC: email addresses"
+msgstr ""
+
+#: mod/editpost.php:103 src/Core/ACL.php:391
+msgid "Example: bob@example.com, mary@example.com"
+msgstr ""
+
+#: mod/events.php:119 mod/events.php:121
+msgid "Event can not end before it has started."
+msgstr ""
+
+#: mod/events.php:128 mod/events.php:130
+msgid "Event title and start time are required."
+msgstr ""
+
+#: mod/events.php:395
+msgid "Create New Event"
+msgstr ""
+
+#: mod/events.php:507
+msgid "Event details"
+msgstr ""
+
+#: mod/events.php:508
+msgid "Starting date and Title are required."
+msgstr ""
+
+#: mod/events.php:509 mod/events.php:514
+msgid "Event Starts:"
+msgstr ""
+
+#: mod/events.php:509 mod/events.php:541 mod/profiles.php:589
+msgid "Required"
+msgstr ""
+
+#: mod/events.php:522 mod/events.php:547
+msgid "Finish date/time is not known or not relevant"
+msgstr ""
+
+#: mod/events.php:524 mod/events.php:529
+msgid "Event Finishes:"
+msgstr ""
+
+#: mod/events.php:535 mod/events.php:548
+msgid "Adjust for viewer timezone"
+msgstr ""
+
+#: mod/events.php:537
+msgid "Description:"
+msgstr ""
+
+#: mod/events.php:539 mod/notifications.php:248 src/Model/Event.php:67
+#: src/Model/Event.php:94 src/Model/Event.php:436 src/Model/Event.php:932
+#: src/Model/Profile.php:437 src/Module/Contact.php:625
+#: src/Module/Directory.php:135
+msgid "Location:"
+msgstr ""
+
+#: mod/events.php:541 mod/events.php:543
+msgid "Title:"
+msgstr ""
+
+#: mod/events.php:544 mod/events.php:545
+msgid "Share this event"
+msgstr ""
+
+#: mod/events.php:552 src/Model/Profile.php:880
+msgid "Basic"
+msgstr ""
+
+#: mod/events.php:553 src/Model/Profile.php:881 src/Module/Admin/Site.php:561
+#: src/Module/Contact.php:902
+msgid "Advanced"
+msgstr ""
+
+#: mod/events.php:554 mod/photos.php:969 mod/photos.php:1339
+msgid "Permissions"
+msgstr ""
+
+#: mod/events.php:570
+msgid "Failed to remove event"
+msgstr ""
+
+#: mod/events.php:572
+msgid "Event removed"
+msgstr ""
+
+#: mod/fbrowser.php:42 view/theme/frio/theme.php:268 src/Content/Nav.php:159
+#: src/Model/Profile.php:923
+msgid "Photos"
+msgstr ""
+
+#: mod/fbrowser.php:51 mod/fbrowser.php:75 mod/photos.php:178
+#: mod/photos.php:933 mod/photos.php:1046 mod/photos.php:1063
+#: mod/photos.php:1544 mod/photos.php:1559 src/Model/Photo.php:552
+#: src/Model/Photo.php:561
+msgid "Contact Photos"
+msgstr ""
+
+#: mod/fbrowser.php:111 mod/fbrowser.php:140 mod/profile_photo.php:245
+msgid "Upload"
+msgstr ""
+
+#: mod/fbrowser.php:135
+msgid "Files"
+msgstr ""
+
+#: mod/follow.php:44
+msgid "The contact could not be added."
+msgstr ""
+
+#: mod/follow.php:85
+msgid "You already added this contact."
+msgstr ""
+
+#: mod/follow.php:97
+msgid "Diaspora support isn't enabled. Contact can't be added."
+msgstr ""
+
+#: mod/follow.php:104
+msgid "OStatus support is disabled. Contact can't be added."
+msgstr ""
+
+#: mod/follow.php:111
+msgid "The network type couldn't be detected. Contact can't be added."
+msgstr ""
+
+#: mod/follow.php:177 mod/notifications.php:166 mod/notifications.php:258
+#: mod/unfollow.php:136 src/Module/Admin/Blocklist/Contact.php:81
+#: src/Module/Contact.php:621
+msgid "Profile URL"
+msgstr ""
+
+#: mod/follow.php:181 mod/notifications.php:252 src/Model/Profile.php:810
+#: src/Module/Contact.php:631
+msgid "Tags:"
+msgstr ""
+
+#: mod/follow.php:193 mod/unfollow.php:146 src/Model/Profile.php:910
+#: src/Module/Contact.php:864
+msgid "Status Messages and Posts"
+msgstr ""
+
+#: mod/fsuggest.php:44
+msgid "Suggested contact not found."
+msgstr ""
+
+#: mod/fsuggest.php:57
+msgid "Friend suggestion sent."
+msgstr ""
+
+#: mod/fsuggest.php:79
+msgid "Suggest Friends"
+msgstr ""
+
+#: mod/fsuggest.php:81
+#, php-format
+msgid "Suggest a friend for %s"
+msgstr ""
+
+#: mod/item.php:124
+msgid "Unable to locate original post."
+msgstr ""
+
+#: mod/item.php:326
+msgid "Empty post discarded."
+msgstr ""
+
+#: mod/item.php:798
+#, php-format
+msgid ""
+"This message was sent to you by %s, a member of the Friendica social network."
+msgstr ""
+
+#: mod/item.php:800
+#, php-format
+msgid "You may visit them online at %s"
+msgstr ""
+
+#: mod/item.php:801
+msgid ""
+"Please contact the sender by replying to this post if you do not wish to "
+"receive these messages."
+msgstr ""
+
+#: mod/item.php:805
+#, php-format
+msgid "%s posted an update."
+msgstr ""
+
+#: mod/lockview.php:47 mod/lockview.php:58
+msgid "Remote privacy information not available."
+msgstr ""
+
+#: mod/lockview.php:69
+msgid "Visible to:"
+msgstr ""
+
+#: mod/lockview.php:75 mod/lockview.php:110 src/Core/ACL.php:269
+#: src/Content/Widget.php:192 src/Module/Profile/Contacts.php:125
+#: src/Module/Contact.php:793
+msgid "Followers"
+msgstr ""
+
+#: mod/lockview.php:81 mod/lockview.php:116 src/Core/ACL.php:276
+msgid "Mutuals"
+msgstr ""
+
+#: mod/lostpass.php:25
+msgid "No valid account found."
+msgstr ""
+
+#: mod/lostpass.php:37
+msgid "Password reset request issued. Check your email."
+msgstr ""
+
+#: mod/lostpass.php:43
+#, php-format
+msgid ""
+"\n"
+"\t\tDear %1$s,\n"
+"\t\t\tA request was recently received at \"%2$s\" to reset your account\n"
+"\t\tpassword. In order to confirm this request, please select the "
+"verification link\n"
+"\t\tbelow or paste it into your web browser address bar.\n"
+"\n"
+"\t\tIf you did NOT request this change, please DO NOT follow the link\n"
+"\t\tprovided and ignore and/or delete this email, the request will expire "
+"shortly.\n"
+"\n"
+"\t\tYour password will not be changed unless we can verify that you\n"
+"\t\tissued this request."
+msgstr ""
+
+#: mod/lostpass.php:54
+#, php-format
+msgid ""
+"\n"
+"\t\tFollow this link soon to verify your identity:\n"
+"\n"
+"\t\t%1$s\n"
+"\n"
+"\t\tYou will then receive a follow-up message containing the new password.\n"
+"\t\tYou may change that password from your account settings page after "
+"logging in.\n"
+"\n"
+"\t\tThe login details are as follows:\n"
+"\n"
+"\t\tSite Location:\t%2$s\n"
+"\t\tLogin Name:\t%3$s"
+msgstr ""
+
+#: mod/lostpass.php:73
+#, php-format
+msgid "Password reset requested at %s"
+msgstr ""
+
+#: mod/lostpass.php:88
+msgid ""
+"Request could not be verified. (You may have previously submitted it.) "
+"Password reset failed."
+msgstr ""
+
+#: mod/lostpass.php:101
+msgid "Request has expired, please make a new one."
+msgstr ""
+
+#: mod/lostpass.php:116
+msgid "Forgot your Password?"
+msgstr ""
+
+#: mod/lostpass.php:117
+msgid ""
+"Enter your email address and submit to have your password reset. Then check "
+"your email for further instructions."
+msgstr ""
+
+#: mod/lostpass.php:118 src/Module/Security/Login.php:131
+msgid "Nickname or Email: "
+msgstr ""
+
+#: mod/lostpass.php:119
+msgid "Reset"
+msgstr ""
+
+#: mod/lostpass.php:134 src/Module/Security/Login.php:143
+msgid "Password Reset"
+msgstr ""
+
+#: mod/lostpass.php:135
+msgid "Your password has been reset as requested."
+msgstr ""
+
+#: mod/lostpass.php:136
+msgid "Your new password is"
+msgstr ""
+
+#: mod/lostpass.php:137
+msgid "Save or copy your new password - and then"
+msgstr ""
+
+#: mod/lostpass.php:138
+msgid "click here to login"
+msgstr ""
+
+#: mod/lostpass.php:139
+msgid ""
+"Your password may be changed from the <em>Settings</em> page after "
+"successful login."
+msgstr ""
+
+#: mod/lostpass.php:146
+#, php-format
+msgid ""
+"\n"
+"\t\t\tDear %1$s,\n"
+"\t\t\t\tYour password has been changed as requested. Please retain this\n"
+"\t\t\tinformation for your records (or change your password immediately to\n"
+"\t\t\tsomething that you will remember).\n"
+"\t\t"
+msgstr ""
+
+#: mod/lostpass.php:152
+#, php-format
+msgid ""
+"\n"
+"\t\t\tYour login details are as follows:\n"
+"\n"
+"\t\t\tSite Location:\t%1$s\n"
+"\t\t\tLogin Name:\t%2$s\n"
+"\t\t\tPassword:\t%3$s\n"
+"\n"
+"\t\t\tYou may change that password from your account settings page after "
+"logging in.\n"
+"\t\t"
+msgstr ""
+
+#: mod/lostpass.php:168
+#, php-format
+msgid "Your password has been changed at %s"
+msgstr ""
+
+#: mod/match.php:47
+msgid "No keywords to match. Please add keywords to your default profile."
+msgstr ""
+
+#: mod/match.php:100 mod/suggest.php:105 src/Content/Widget.php:39
+#: src/Module/AllFriends.php:91 src/Module/BaseSearchModule.php:130
+msgid "Connect"
+msgstr ""
+
+#: mod/match.php:113 src/Content/Pager.php:198
+msgid "first"
+msgstr ""
+
+#: mod/match.php:118 src/Content/Pager.php:258
+msgid "next"
+msgstr ""
+
+#: mod/match.php:128 src/Module/BaseSearchModule.php:93
+msgid "No matches"
+msgstr ""
+
+#: mod/match.php:133
+msgid "Profile Match"
+msgstr ""
+
+#: mod/message.php:31 mod/message.php:114 src/Content/Nav.php:253
+msgid "New Message"
+msgstr ""
+
+#: mod/message.php:68 mod/wallmessage.php:59
+msgid "No recipient selected."
+msgstr ""
+
+#: mod/message.php:72
+msgid "Unable to locate contact information."
+msgstr ""
+
+#: mod/message.php:75 mod/wallmessage.php:65
+msgid "Message could not be sent."
+msgstr ""
+
+#: mod/message.php:78 mod/wallmessage.php:68
+msgid "Message collection failure."
+msgstr ""
+
+#: mod/message.php:81 mod/wallmessage.php:71
+msgid "Message sent."
+msgstr ""
+
+#: mod/message.php:108 mod/notifications.php:34 mod/notifications.php:174
+#: mod/notifications.php:230
+msgid "Discard"
+msgstr ""
+
+#: mod/message.php:121 view/theme/frio/theme.php:275 src/Content/Nav.php:250
+msgid "Messages"
+msgstr ""
+
+#: mod/message.php:146
+msgid "Do you really want to delete this message?"
+msgstr ""
+
+#: mod/message.php:164
+msgid "Conversation not found."
+msgstr ""
+
+#: mod/message.php:169
+msgid "Message deleted."
+msgstr ""
+
+#: mod/message.php:174 mod/message.php:188
+msgid "Conversation removed."
+msgstr ""
+
+#: mod/message.php:202 mod/message.php:358 mod/wallmessage.php:122
+msgid "Please enter a link URL:"
+msgstr ""
+
+#: mod/message.php:244 mod/wallmessage.php:127
+msgid "Send Private Message"
+msgstr ""
+
+#: mod/message.php:245 mod/message.php:428 mod/wallmessage.php:129
+msgid "To:"
+msgstr ""
+
+#: mod/message.php:249 mod/message.php:430 mod/wallmessage.php:130
+msgid "Subject:"
+msgstr ""
+
+#: mod/message.php:253 mod/message.php:433 mod/wallmessage.php:136
+#: src/Module/Invite.php:149
+msgid "Your message:"
+msgstr ""
+
+#: mod/message.php:287
+msgid "No messages."
+msgstr ""
+
+#: mod/message.php:350
+msgid "Message not available."
+msgstr ""
+
+#: mod/message.php:404
+msgid "Delete message"
+msgstr ""
+
+#: mod/message.php:406 mod/message.php:538
+msgid "D, d M Y - g:i A"
+msgstr ""
+
+#: mod/message.php:421 mod/message.php:535
+msgid "Delete conversation"
+msgstr ""
+
+#: mod/message.php:423
+msgid ""
+"No secure communications available. You <strong>may</strong> be able to "
+"respond from the sender's profile page."
+msgstr ""
+
+#: mod/message.php:427
+msgid "Send Reply"
+msgstr ""
+
+#: mod/message.php:510
+#, php-format
+msgid "Unknown sender - %s"
+msgstr ""
+
+#: mod/message.php:512
+#, php-format
+msgid "You and %s"
+msgstr ""
+
+#: mod/message.php:514
+#, php-format
+msgid "%s and You"
+msgstr ""
+
+#: mod/message.php:541
+#, php-format
+msgid "%d message"
+msgid_plural "%d messages"
+msgstr[0] ""
+msgstr[1] ""
+
+#: mod/network.php:492
+#, php-format
+msgid ""
+"Warning: This group contains %s member from a network that doesn't allow non "
+"public messages."
+msgid_plural ""
+"Warning: This group contains %s members from a network that doesn't allow "
+"non public messages."
+msgstr[0] ""
+msgstr[1] ""
+
+#: mod/network.php:495
+msgid "Messages in this group won't be send to these receivers."
+msgstr ""
+
+#: mod/network.php:562
+msgid "No such group"
+msgstr ""
+
+#: mod/network.php:583 src/Module/Group.php:280
+msgid "Group is empty"
+msgstr ""
+
+#: mod/network.php:587
+#, php-format
+msgid "Group: %s"
+msgstr ""
+
+#: mod/network.php:613
+msgid "Private messages to this person are at risk of public disclosure."
+msgstr ""
+
+#: mod/network.php:616 src/Module/AllFriends.php:35
+#: src/Module/AllFriends.php:43
+msgid "Invalid contact."
+msgstr ""
+
+#: mod/network.php:900
+msgid "Latest Activity"
+msgstr ""
+
+#: mod/network.php:903
+msgid "Sort by latest activity"
+msgstr ""
+
+#: mod/network.php:908
+msgid "Latest Posts"
+msgstr ""
+
+#: mod/network.php:911
+msgid "Sort by post received date"
+msgstr ""
+
+#: mod/network.php:918 mod/profiles.php:576
+msgid "Personal"
+msgstr ""
+
+#: mod/network.php:921
+msgid "Posts that mention or involve you"
+msgstr ""
+
+#: mod/network.php:928
+msgid "New"
+msgstr ""
+
+#: mod/network.php:931
+msgid "Activity Stream - by date"
+msgstr ""
+
+#: mod/network.php:939
+msgid "Shared Links"
+msgstr ""
+
+#: mod/network.php:942
+msgid "Interesting Links"
+msgstr ""
+
+#: mod/network.php:949
+msgid "Starred"
+msgstr ""
+
+#: mod/network.php:952
+msgid "Favourite Posts"
+msgstr ""
+
+#: mod/notes.php:34 src/Model/Profile.php:965
+msgid "Personal Notes"
+msgstr ""
+
+#: mod/notifications.php:72 src/Content/Nav.php:245
+msgid "Notifications"
+msgstr ""
+
+#: mod/notifications.php:91
+msgid "Network Notifications"
+msgstr ""
+
+#: mod/notifications.php:96
+msgid "System Notifications"
+msgstr ""
+
+#: mod/notifications.php:101
+msgid "Personal Notifications"
+msgstr ""
+
+#: mod/notifications.php:106
+msgid "Home Notifications"
+msgstr ""
+
+#: mod/notifications.php:129
+msgid "Show unread"
+msgstr ""
+
+#: mod/notifications.php:129
+msgid "Show all"
+msgstr ""
+
+#: mod/notifications.php:140
+msgid "Show Ignored Requests"
+msgstr ""
+
+#: mod/notifications.php:140
+msgid "Hide Ignored Requests"
+msgstr ""
+
+#: mod/notifications.php:153 mod/notifications.php:238
+msgid "Notification type:"
+msgstr ""
+
+#: mod/notifications.php:156
+msgid "Suggested by:"
+msgstr ""
+
+#: mod/notifications.php:168 mod/notifications.php:255
+#: src/Module/Contact.php:612
+msgid "Hide this contact from others"
+msgstr ""
+
+#: mod/notifications.php:170 mod/notifications.php:264
+#: src/Model/Contact.php:1293 src/Module/Admin/Users.php:283
+msgid "Approve"
+msgstr ""
+
+#: mod/notifications.php:190
+msgid "Claims to be known to you: "
+msgstr ""
+
+#: mod/notifications.php:191
+msgid "yes"
+msgstr ""
+
+#: mod/notifications.php:191
+msgid "no"
+msgstr ""
+
+#: mod/notifications.php:192 mod/notifications.php:196
+msgid "Shall your connection be bidirectional or not?"
+msgstr ""
+
+#: mod/notifications.php:193 mod/notifications.php:197
+#, php-format
+msgid ""
+"Accepting %s as a friend allows %s to subscribe to your posts, and you will "
+"also receive updates from them in your news feed."
+msgstr ""
+
+#: mod/notifications.php:194
+#, php-format
+msgid ""
+"Accepting %s as a subscriber allows them to subscribe to your posts, but you "
+"will not receive updates from them in your news feed."
+msgstr ""
+
+#: mod/notifications.php:198
+#, php-format
+msgid ""
+"Accepting %s as a sharer allows them to subscribe to your posts, but you "
+"will not receive updates from them in your news feed."
+msgstr ""
+
+#: mod/notifications.php:209
+msgid "Friend"
+msgstr ""
+
+#: mod/notifications.php:210
+msgid "Sharer"
+msgstr ""
+
+#: mod/notifications.php:210
+msgid "Subscriber"
+msgstr ""
+
+#: mod/notifications.php:250 src/Model/Profile.php:443
+#: src/Model/Profile.php:822 src/Module/Contact.php:629
+#: src/Module/Directory.php:143
+msgid "About:"
+msgstr ""
+
+#: mod/notifications.php:254 src/Model/Profile.php:440
+#: src/Model/Profile.php:761 src/Module/Directory.php:140
+msgid "Gender:"
+msgstr ""
+
+#: mod/notifications.php:261 src/Model/Profile.php:548
+#: src/Module/Contact.php:313
+msgid "Network:"
+msgstr ""
+
+#: mod/notifications.php:275
+msgid "No introductions."
+msgstr ""
+
+#: mod/notifications.php:309
+#, php-format
+msgid "No more %s notifications."
+msgstr ""
+
+#: mod/oexchange.php:31
+msgid "Post successful."
+msgstr ""
+
+#: mod/ostatus_subscribe.php:21
+msgid "Subscribing to OStatus contacts"
+msgstr ""
+
+#: mod/ostatus_subscribe.php:31
+msgid "No contact provided."
+msgstr ""
+
+#: mod/ostatus_subscribe.php:38
+msgid "Couldn't fetch information for contact."
+msgstr ""
+
+#: mod/ostatus_subscribe.php:48
+msgid "Couldn't fetch friends for contact."
+msgstr ""
+
+#: mod/ostatus_subscribe.php:66 mod/repair_ostatus.php:49
+msgid "Done"
+msgstr ""
+
+#: mod/ostatus_subscribe.php:80
+msgid "success"
+msgstr ""
+
+#: mod/ostatus_subscribe.php:82
+msgid "failed"
+msgstr ""
+
+#: mod/ostatus_subscribe.php:85 src/Object/Post.php:283
+msgid "ignored"
+msgstr ""
+
+#: mod/ostatus_subscribe.php:90 mod/repair_ostatus.php:55
+msgid "Keep this window open until done."
+msgstr ""
+
+#: mod/photos.php:109 src/Model/Profile.php:926
+msgid "Photo Albums"
+msgstr ""
+
+#: mod/photos.php:110 mod/photos.php:1599
+msgid "Recent Photos"
+msgstr ""
+
+#: mod/photos.php:112 mod/photos.php:1108 mod/photos.php:1601
+msgid "Upload New Photos"
+msgstr ""
+
+#: mod/photos.php:130 mod/settings.php:56 src/Module/BaseSettingsModule.php:18
+msgid "everybody"
+msgstr ""
+
+#: mod/photos.php:167
+msgid "Contact information unavailable"
+msgstr ""
+
+#: mod/photos.php:189
+msgid "Album not found."
+msgstr ""
+
+#: mod/photos.php:247
+msgid "Album successfully deleted"
+msgstr ""
+
+#: mod/photos.php:249
+msgid "Album was empty."
+msgstr ""
+
+#: mod/photos.php:574
+msgid "a photo"
+msgstr ""
+
+#: mod/photos.php:574
+#, php-format
+msgid "%1$s was tagged in %2$s by %3$s"
+msgstr ""
+
+#: mod/photos.php:669 mod/photos.php:672 mod/photos.php:701
+#: mod/profile_photo.php:150 mod/wall_upload.php:184
+#, php-format
+msgid "Image exceeds size limit of %s"
+msgstr ""
+
+#: mod/photos.php:675
+msgid "Image upload didn't complete, please try again"
+msgstr ""
+
+#: mod/photos.php:678
+msgid "Image file is missing"
+msgstr ""
+
+#: mod/photos.php:683
+msgid ""
+"Server can't accept new file upload at this time, please contact your "
+"administrator"
+msgstr ""
+
+#: mod/photos.php:709
+msgid "Image file is empty."
+msgstr ""
+
+#: mod/photos.php:724 mod/profile_photo.php:159 mod/wall_upload.php:198
+msgid "Unable to process image."
+msgstr ""
+
+#: mod/photos.php:753 mod/profile_photo.php:301 mod/wall_upload.php:237
+msgid "Image upload failed."
+msgstr ""
+
+#: mod/photos.php:841
+msgid "No photos selected"
+msgstr ""
+
+#: mod/photos.php:907 mod/videos.php:164
+msgid "Access to this item is restricted."
+msgstr ""
+
+#: mod/photos.php:961
+msgid "Upload Photos"
+msgstr ""
+
+#: mod/photos.php:965 mod/photos.php:1053
+msgid "New album name: "
+msgstr ""
+
+#: mod/photos.php:966
+msgid "or select existing album:"
+msgstr ""
+
+#: mod/photos.php:967
+msgid "Do not show a status post for this upload"
+msgstr ""
+
+#: mod/photos.php:983 mod/photos.php:1347 mod/settings.php:1208
+msgid "Show to Groups"
+msgstr ""
+
+#: mod/photos.php:984 mod/photos.php:1348 mod/settings.php:1209
+msgid "Show to Contacts"
+msgstr ""
+
+#: mod/photos.php:1035
+msgid "Do you really want to delete this photo album and all its photos?"
+msgstr ""
+
+#: mod/photos.php:1037 mod/photos.php:1058
+msgid "Delete Album"
+msgstr ""
+
+#: mod/photos.php:1064
+msgid "Edit Album"
+msgstr ""
+
+#: mod/photos.php:1065
+msgid "Drop Album"
+msgstr ""
+
+#: mod/photos.php:1070
+msgid "Show Newest First"
+msgstr ""
+
+#: mod/photos.php:1072
+msgid "Show Oldest First"
+msgstr ""
+
+#: mod/photos.php:1093 mod/photos.php:1584
+msgid "View Photo"
+msgstr ""
+
+#: mod/photos.php:1130
+msgid "Permission denied. Access to this item may be restricted."
+msgstr ""
+
+#: mod/photos.php:1132
+msgid "Photo not available"
+msgstr ""
+
+#: mod/photos.php:1142
+msgid "Do you really want to delete this photo?"
+msgstr ""
+
+#: mod/photos.php:1144 mod/photos.php:1344
+msgid "Delete Photo"
+msgstr ""
+
+#: mod/photos.php:1235
+msgid "View photo"
+msgstr ""
+
+#: mod/photos.php:1237
+msgid "Edit photo"
+msgstr ""
+
+#: mod/photos.php:1238
+msgid "Delete photo"
+msgstr ""
+
+#: mod/photos.php:1239
+msgid "Use as profile photo"
+msgstr ""
+
+#: mod/photos.php:1246
+msgid "Private Photo"
+msgstr ""
+
+#: mod/photos.php:1252
+msgid "View Full Size"
+msgstr ""
+
+#: mod/photos.php:1312
+msgid "Tags: "
+msgstr ""
+
+#: mod/photos.php:1315
+msgid "[Select tags to remove]"
+msgstr ""
+
+#: mod/photos.php:1330
+msgid "New album name"
+msgstr ""
+
+#: mod/photos.php:1331
+msgid "Caption"
+msgstr ""
+
+#: mod/photos.php:1332
+msgid "Add a Tag"
+msgstr ""
+
+#: mod/photos.php:1332
+msgid "Example: @bob, @Barbara_Jensen, @jim@example.com, #California, #camping"
+msgstr ""
+
+#: mod/photos.php:1333
+msgid "Do not rotate"
+msgstr ""
+
+#: mod/photos.php:1334
+msgid "Rotate CW (right)"
+msgstr ""
+
+#: mod/photos.php:1335
+msgid "Rotate CCW (left)"
+msgstr ""
+
+#: mod/photos.php:1369 src/Object/Post.php:324
+msgid "I like this (toggle)"
+msgstr ""
+
+#: mod/photos.php:1370 src/Object/Post.php:325
+msgid "I don't like this (toggle)"
+msgstr ""
+
+#: mod/photos.php:1385 mod/photos.php:1424 mod/photos.php:1488
+#: src/Module/Item/Compose.php:123 src/Module/Contact.php:1024
+#: src/Object/Post.php:900
+msgid "This is you"
+msgstr ""
+
+#: mod/photos.php:1387 mod/photos.php:1426 mod/photos.php:1490
+#: src/Object/Post.php:440 src/Object/Post.php:902
+msgid "Comment"
+msgstr ""
+
+#: mod/photos.php:1519
+msgid "Map"
+msgstr ""
+
+#: mod/photos.php:1590 mod/videos.php:241
+msgid "View Album"
+msgstr ""
+
+#: mod/ping.php:269
+msgid "{0} wants to be your friend"
+msgstr ""
+
+#: mod/ping.php:285
+msgid "{0} requested registration"
+msgstr ""
+
+#: mod/poke.php:178
+msgid "Poke/Prod"
+msgstr ""
+
+#: mod/poke.php:179
+msgid "poke, prod or do other things to somebody"
+msgstr ""
+
+#: mod/poke.php:180
+msgid "Recipient"
+msgstr ""
+
+#: mod/poke.php:181
+msgid "Choose what you wish to do to recipient"
+msgstr ""
+
+#: mod/poke.php:184
+msgid "Make this post private"
+msgstr ""
+
+#: mod/profile_photo.php:56
+msgid "Image uploaded but image cropping failed."
+msgstr ""
+
+#: mod/profile_photo.php:86 mod/profile_photo.php:95 mod/profile_photo.php:104
+#: mod/profile_photo.php:309
+#, php-format
+msgid "Image size reduction [%s] failed."
+msgstr ""
+
+#: mod/profile_photo.php:123
+msgid ""
+"Shift-reload the page or clear browser cache if the new photo does not "
+"display immediately."
+msgstr ""
+
+#: mod/profile_photo.php:131
+msgid "Unable to process image"
+msgstr ""
+
+#: mod/profile_photo.php:242
+msgid "Upload File:"
+msgstr ""
+
+#: mod/profile_photo.php:243
+msgid "Select a profile:"
+msgstr ""
+
+#: mod/profile_photo.php:244 mod/profiles.php:580 src/Module/Welcome.php:39
+msgid "Upload Profile Photo"
+msgstr ""
+
+#: mod/profile_photo.php:248
+msgid "or"
+msgstr ""
+
+#: mod/profile_photo.php:249
+msgid "skip this step"
+msgstr ""
+
+#: mod/profile_photo.php:249
+msgid "select a photo from your photo albums"
+msgstr ""
+
+#: mod/profile_photo.php:262
+msgid "Crop Image"
+msgstr ""
+
+#: mod/profile_photo.php:263
+msgid "Please adjust the image cropping for optimum viewing."
+msgstr ""
+
+#: mod/profile_photo.php:265
+msgid "Done Editing"
+msgstr ""
+
+#: mod/profile_photo.php:299
+msgid "Image uploaded successfully."
+msgstr ""
+
+#: mod/profiles.php:59
+msgid "Profile deleted."
+msgstr ""
+
+#: mod/profiles.php:75 mod/profiles.php:111
+msgid "Profile-"
+msgstr ""
+
+#: mod/profiles.php:94 mod/profiles.php:132
+msgid "New profile created."
+msgstr ""
+
+#: mod/profiles.php:117
+msgid "Profile unavailable to clone."
+msgstr ""
+
+#: mod/profiles.php:203
+msgid "Profile Name is required."
+msgstr ""
+
+#: mod/profiles.php:343
+msgid "Marital Status"
+msgstr ""
+
+#: mod/profiles.php:346
+msgid "Romantic Partner"
+msgstr ""
+
+#: mod/profiles.php:355
+msgid "Work/Employment"
+msgstr ""
+
+#: mod/profiles.php:358
+msgid "Religion"
+msgstr ""
+
+#: mod/profiles.php:361
+msgid "Political Views"
+msgstr ""
+
+#: mod/profiles.php:364
+msgid "Gender"
+msgstr ""
+
+#: mod/profiles.php:367
+msgid "Sexual Preference"
+msgstr ""
+
+#: mod/profiles.php:370
+msgid "XMPP"
+msgstr ""
+
+#: mod/profiles.php:373
+msgid "Homepage"
+msgstr ""
+
+#: mod/profiles.php:376 mod/profiles.php:575
+msgid "Interests"
+msgstr ""
+
+#: mod/profiles.php:379
+msgid "Address"
+msgstr ""
+
+#: mod/profiles.php:386 mod/profiles.php:571
+msgid "Location"
+msgstr ""
+
+#: mod/profiles.php:466
+msgid "Profile updated."
+msgstr ""
+
+#: mod/profiles.php:520
+msgid "Hide contacts and friends:"
+msgstr ""
+
+#: mod/profiles.php:525
+msgid "Hide your contact/friend list from viewers of this profile?"
+msgstr ""
+
+#: mod/profiles.php:545
+msgid "Show more profile fields:"
+msgstr ""
+
+#: mod/profiles.php:557
+msgid "Profile Actions"
+msgstr ""
+
+#: mod/profiles.php:558
+msgid "Edit Profile Details"
+msgstr ""
+
+#: mod/profiles.php:560
+msgid "Change Profile Photo"
+msgstr ""
+
+#: mod/profiles.php:562
+msgid "View this profile"
+msgstr ""
+
+#: mod/profiles.php:563
+msgid "View all profiles"
+msgstr ""
+
+#: mod/profiles.php:564 mod/profiles.php:659 src/Model/Profile.php:413
+msgid "Edit visibility"
+msgstr ""
+
+#: mod/profiles.php:565
+msgid "Create a new profile using these settings"
+msgstr ""
+
+#: mod/profiles.php:566
+msgid "Clone this profile"
+msgstr ""
+
+#: mod/profiles.php:567
+msgid "Delete this profile"
+msgstr ""
+
+#: mod/profiles.php:569
+msgid "Basic information"
+msgstr ""
+
+#: mod/profiles.php:570
+msgid "Profile picture"
+msgstr ""
+
+#: mod/profiles.php:572
+msgid "Preferences"
+msgstr ""
+
+#: mod/profiles.php:573
+msgid "Status information"
+msgstr ""
+
+#: mod/profiles.php:574
+msgid "Additional information"
+msgstr ""
+
+#: mod/profiles.php:577
+msgid "Relation"
+msgstr ""
+
+#: mod/profiles.php:578 src/Util/Temporal.php:78 src/Util/Temporal.php:80
+msgid "Miscellaneous"
+msgstr ""
+
+#: mod/profiles.php:581
+msgid "Your Gender:"
+msgstr ""
+
+#: mod/profiles.php:582
+msgid "<span class=\"heart\">&hearts;</span> Marital Status:"
+msgstr ""
+
+#: mod/profiles.php:583 src/Model/Profile.php:798
+msgid "Sexual Preference:"
+msgstr ""
+
+#: mod/profiles.php:584
+msgid "Example: fishing photography software"
+msgstr ""
+
+#: mod/profiles.php:589
+msgid "Profile Name:"
+msgstr ""
+
+#: mod/profiles.php:591
+msgid ""
+"This is your <strong>public</strong> profile.<br />It <strong>may</strong> "
+"be visible to anybody using the internet."
+msgstr ""
+
+#: mod/profiles.php:592
+msgid "Your Full Name:"
+msgstr ""
+
+#: mod/profiles.php:593
+msgid "Title/Description:"
+msgstr ""
+
+#: mod/profiles.php:596
+msgid "Street Address:"
+msgstr ""
+
+#: mod/profiles.php:597
+msgid "Locality/City:"
+msgstr ""
+
+#: mod/profiles.php:598
+msgid "Region/State:"
+msgstr ""
+
+#: mod/profiles.php:599
+msgid "Postal/Zip Code:"
+msgstr ""
+
+#: mod/profiles.php:600
+msgid "Country:"
+msgstr ""
+
+#: mod/profiles.php:601 src/Util/Temporal.php:147
+msgid "Age: "
+msgstr ""
+
+#: mod/profiles.php:604
+msgid "Who: (if applicable)"
+msgstr ""
+
+#: mod/profiles.php:604
+msgid "Examples: cathy123, Cathy Williams, cathy@example.com"
+msgstr ""
+
+#: mod/profiles.php:605
+msgid "Since [date]:"
+msgstr ""
+
+#: mod/profiles.php:607
+msgid "Tell us about yourself..."
+msgstr ""
+
+#: mod/profiles.php:608
+msgid "XMPP (Jabber) address:"
+msgstr ""
+
+#: mod/profiles.php:608
+msgid ""
+"The XMPP address will be propagated to your contacts so that they can follow "
+"you."
+msgstr ""
+
+#: mod/profiles.php:609
+msgid "Homepage URL:"
+msgstr ""
+
+#: mod/profiles.php:610 src/Model/Profile.php:806
+msgid "Hometown:"
+msgstr ""
+
+#: mod/profiles.php:611 src/Model/Profile.php:814
+msgid "Political Views:"
+msgstr ""
+
+#: mod/profiles.php:612
+msgid "Religious Views:"
+msgstr ""
+
+#: mod/profiles.php:613
+msgid "Public Keywords:"
+msgstr ""
+
+#: mod/profiles.php:613
+msgid "(Used for suggesting potential friends, can be seen by others)"
+msgstr ""
+
+#: mod/profiles.php:614
+msgid "Private Keywords:"
+msgstr ""
+
+#: mod/profiles.php:614
+msgid "(Used for searching profiles, never shown to others)"
+msgstr ""
+
+#: mod/profiles.php:615 src/Model/Profile.php:830
+msgid "Likes:"
+msgstr ""
+
+#: mod/profiles.php:616 src/Model/Profile.php:834
+msgid "Dislikes:"
+msgstr ""
+
+#: mod/profiles.php:617
+msgid "Musical interests"
+msgstr ""
+
+#: mod/profiles.php:618
+msgid "Books, literature"
+msgstr ""
+
+#: mod/profiles.php:619
+msgid "Television"
+msgstr ""
+
+#: mod/profiles.php:620
+msgid "Film/dance/culture/entertainment"
+msgstr ""
+
+#: mod/profiles.php:621
+msgid "Hobbies/Interests"
+msgstr ""
+
+#: mod/profiles.php:622
+msgid "Love/romance"
+msgstr ""
+
+#: mod/profiles.php:623
+msgid "Work/employment"
+msgstr ""
+
+#: mod/profiles.php:624
+msgid "School/education"
+msgstr ""
+
+#: mod/profiles.php:625
+msgid "Contact information and Social Networks"
+msgstr ""
+
+#: mod/profiles.php:656 src/Model/Profile.php:409
+msgid "Profile Image"
+msgstr ""
+
+#: mod/profiles.php:658 src/Model/Profile.php:412
+msgid "visible to everybody"
+msgstr ""
+
+#: mod/profiles.php:665
+msgid "Edit/Manage Profiles"
+msgstr ""
+
+#: mod/profiles.php:666 src/Model/Profile.php:399 src/Model/Profile.php:420
+msgid "Change profile photo"
+msgstr ""
+
+#: mod/profiles.php:667 src/Model/Profile.php:400
+msgid "Create New Profile"
+msgstr ""
+
+#: mod/profperm.php:28
+msgid "Permission denied"
+msgstr ""
+
+#: mod/profperm.php:34 mod/profperm.php:67
+msgid "Invalid profile identifier."
+msgstr ""
+
+#: mod/profperm.php:113
+msgid "Profile Visibility Editor"
+msgstr ""
+
+#: mod/profperm.php:115 view/theme/frio/theme.php:267 src/Content/Nav.php:158
+#: src/Model/Profile.php:879 src/Model/Profile.php:915
+#: src/Module/Contact.php:636 src/Module/Contact.php:869
+#: src/Module/Welcome.php:38
+msgid "Profile"
+msgstr ""
+
+#: mod/profperm.php:117 src/Module/Group.php:313
+msgid "Click on a contact to add or remove."
+msgstr ""
+
+#: mod/profperm.php:126
+msgid "Visible To"
+msgstr ""
+
+#: mod/profperm.php:142
+msgid "All Contacts (with secure profile access)"
+msgstr ""
+
+#: mod/regmod.php:48
+msgid "Account approved."
+msgstr ""
+
+#: mod/regmod.php:72
+#, php-format
+msgid "Registration revoked for %s"
+msgstr ""
+
+#: mod/regmod.php:79
+msgid "Please login."
+msgstr ""
+
+#: mod/removeme.php:45
+msgid "User deleted their account"
+msgstr ""
+
+#: mod/removeme.php:46
+msgid ""
+"On your Friendica node an user deleted their account. Please ensure that "
+"their data is removed from the backups."
+msgstr ""
+
+#: mod/removeme.php:47
+#, php-format
+msgid "The user id is %d"
+msgstr ""
+
+#: mod/removeme.php:83 mod/removeme.php:86
+msgid "Remove My Account"
+msgstr ""
+
+#: mod/removeme.php:84
+msgid ""
+"This will completely remove your account. Once this has been done it is not "
+"recoverable."
+msgstr ""
+
+#: mod/removeme.php:85
+msgid "Please enter your password for verification:"
+msgstr ""
+
+#: mod/repair_ostatus.php:20
+msgid "Resubscribing to OStatus contacts"
+msgstr ""
+
+#: mod/repair_ostatus.php:34 src/Module/Security/TwoFactor/Verify.php:63
+msgid "Error"
+msgid_plural "Errors"
+msgstr[0] ""
+msgstr[1] ""
+
+#: mod/settings.php:61 src/Module/BaseSettingsModule.php:24
+msgid "Account"
+msgstr ""
+
+#: mod/settings.php:69 src/Module/Settings/TwoFactor/Index.php:86
+#: src/Module/BaseSettingsModule.php:31
+#: src/Module/Security/TwoFactor/Verify.php:61
+msgid "Two-factor authentication"
+msgstr ""
+
+#: mod/settings.php:76 src/Content/Nav.php:262 src/Model/Profile.php:392
+#: src/Module/BaseSettingsModule.php:38
+msgid "Profiles"
+msgstr ""
+
+#: mod/settings.php:84 src/Module/BaseAdminModule.php:82
+#: src/Module/BaseSettingsModule.php:46
+msgid "Additional features"
+msgstr ""
+
+#: mod/settings.php:92 src/Module/BaseSettingsModule.php:54
+msgid "Display"
+msgstr ""
+
+#: mod/settings.php:99 mod/settings.php:836
+#: src/Module/BaseSettingsModule.php:61
+msgid "Social Networks"
+msgstr ""
+
+#: mod/settings.php:106 src/Module/Admin/Addons/Details.php:100
+#: src/Module/Admin/Addons/Index.php:49 src/Module/BaseAdminModule.php:80
+#: src/Module/BaseSettingsModule.php:68
+msgid "Addons"
+msgstr ""
+
+#: mod/settings.php:113 src/Module/BaseSettingsModule.php:75
+msgid "Delegations"
+msgstr ""
+
+#: mod/settings.php:120 src/Module/BaseSettingsModule.php:82
+msgid "Connected apps"
+msgstr ""
+
+#: mod/settings.php:127 src/Module/Settings/UserExport.php:49
+#: src/Module/BaseSettingsModule.php:89
+msgid "Export personal data"
+msgstr ""
+
+#: mod/settings.php:134 src/Module/BaseSettingsModule.php:96
+msgid "Remove account"
+msgstr ""
+
+#: mod/settings.php:143 view/theme/frio/theme.php:276 src/Content/Nav.php:259
+#: src/Module/Admin/Addons/Details.php:102
+#: src/Module/Admin/Themes/Details.php:107
+#: src/Module/BaseSettingsModule.php:105 src/Module/Welcome.php:33
+msgid "Settings"
+msgstr ""
+
+#: mod/settings.php:186
+msgid "Missing some important data!"
+msgstr ""
+
+#: mod/settings.php:188 mod/settings.php:689 src/Module/Contact.php:823
+msgid "Update"
+msgstr ""
+
+#: mod/settings.php:296
+msgid "Failed to connect with email account using the settings provided."
+msgstr ""
+
+#: mod/settings.php:301
+msgid "Email settings updated."
+msgstr ""
+
+#: mod/settings.php:317
+msgid "Features updated"
+msgstr ""
+
+#: mod/settings.php:378
+msgid "The theme you chose isn't available."
+msgstr ""
+
+#: mod/settings.php:394
+msgid "Contact CSV file upload error"
+msgstr ""
+
+#: mod/settings.php:408
+msgid "Importing Contacts done"
+msgstr ""
+
+#: mod/settings.php:417
+msgid "Relocate message has been send to your contacts"
+msgstr ""
+
+#: mod/settings.php:429
+msgid "Passwords do not match."
+msgstr ""
+
+#: mod/settings.php:437 src/Console/NewPassword.php:101
+msgid "Password update failed. Please try again."
+msgstr ""
+
+#: mod/settings.php:440 src/Console/NewPassword.php:104
+msgid "Password changed."
+msgstr ""
+
+#: mod/settings.php:443
+msgid "Password unchanged."
+msgstr ""
+
+#: mod/settings.php:525
+msgid " Please use a shorter name."
+msgstr ""
+
+#: mod/settings.php:528
+msgid " Name too short."
+msgstr ""
+
+#: mod/settings.php:535 src/Module/Settings/TwoFactor/Index.php:69
+msgid "Wrong Password"
+msgstr ""
+
+#: mod/settings.php:540
+msgid "Invalid email."
+msgstr ""
+
+#: mod/settings.php:546
+msgid "Cannot change to that email."
+msgstr ""
+
+#: mod/settings.php:583
+msgid "Private forum has no privacy permissions. Using default privacy group."
+msgstr ""
+
+#: mod/settings.php:586
+msgid "Private forum has no privacy permissions and no default privacy group."
+msgstr ""
+
+#: mod/settings.php:603
+msgid "Settings updated."
+msgstr ""
+
+#: mod/settings.php:662 mod/settings.php:688 mod/settings.php:722
+msgid "Add application"
+msgstr ""
+
+#: mod/settings.php:663 mod/settings.php:770 mod/settings.php:868
+#: mod/settings.php:947 mod/settings.php:1172
+#: src/Module/Admin/Addons/Index.php:50 src/Module/Admin/Logs/Settings.php:62
+#: src/Module/Admin/Themes/Index.php:94 src/Module/Admin/Features.php:68
+#: src/Module/Admin/Site.php:556 src/Module/Admin/Tos.php:49
+#: src/Module/Settings/Delegation.php:150
+msgid "Save Settings"
+msgstr ""
+
+#: mod/settings.php:666 mod/settings.php:692
+msgid "Consumer Key"
+msgstr ""
+
+#: mod/settings.php:667 mod/settings.php:693
+msgid "Consumer Secret"
+msgstr ""
+
+#: mod/settings.php:668 mod/settings.php:694
+msgid "Redirect"
+msgstr ""
+
+#: mod/settings.php:669 mod/settings.php:695
+msgid "Icon url"
+msgstr ""
+
+#: mod/settings.php:680
+msgid "You can't edit this application."
+msgstr ""
+
+#: mod/settings.php:721
+msgid "Connected Apps"
+msgstr ""
+
+#: mod/settings.php:723 src/Object/Post.php:164 src/Object/Post.php:166
+msgid "Edit"
+msgstr ""
+
+#: mod/settings.php:725
+msgid "Client key starts with"
+msgstr ""
+
+#: mod/settings.php:726
+msgid "No name"
+msgstr ""
+
+#: mod/settings.php:727
+msgid "Remove authorization"
+msgstr ""
+
+#: mod/settings.php:738
+msgid "No Addon settings configured"
+msgstr ""
+
+#: mod/settings.php:747
+msgid "Addon Settings"
+msgstr ""
+
+#: mod/settings.php:761 src/Module/Admin/Features.php:57
+#: src/Module/Admin/Features.php:58
+msgid "Off"
+msgstr ""
+
+#: mod/settings.php:761 src/Module/Admin/Features.php:57
+#: src/Module/Admin/Features.php:58
+msgid "On"
+msgstr ""
+
+#: mod/settings.php:768
+msgid "Additional Features"
+msgstr ""
+
+#: mod/settings.php:793 src/Content/ContactSelector.php:121
+msgid "Diaspora"
+msgstr ""
+
+#: mod/settings.php:793 mod/settings.php:794
+msgid "enabled"
+msgstr ""
+
+#: mod/settings.php:793 mod/settings.php:794
+msgid "disabled"
+msgstr ""
+
+#: mod/settings.php:793 mod/settings.php:794
+#, php-format
+msgid "Built-in support for %s connectivity is %s"
+msgstr ""
+
+#: mod/settings.php:794
+msgid "GNU Social (OStatus)"
+msgstr ""
+
+#: mod/settings.php:825
+msgid "Email access is disabled on this site."
+msgstr ""
+
+#: mod/settings.php:830 mod/settings.php:866
+msgid "None"
+msgstr ""
+
+#: mod/settings.php:841
+msgid "General Social Media Settings"
+msgstr ""
+
+#: mod/settings.php:842
+msgid "Accept only top level posts by contacts you follow"
+msgstr ""
+
+#: mod/settings.php:842
+msgid ""
+"The system does an auto completion of threads when a comment arrives. This "
+"has got the side effect that you can receive posts that had been started by "
+"a non-follower but had been commented by someone you follow. This setting "
+"deactivates this behaviour. When activated, you strictly only will receive "
+"posts from people you really do follow."
+msgstr ""
+
+#: mod/settings.php:843
+msgid "Disable Content Warning"
+msgstr ""
+
+#: mod/settings.php:843
+msgid ""
+"Users on networks like Mastodon or Pleroma are able to set a content warning "
+"field which collapse their post by default. This disables the automatic "
+"collapsing and sets the content warning as the post title. Doesn't affect "
+"any other content filtering you eventually set up."
+msgstr ""
+
+#: mod/settings.php:844
+msgid "Disable intelligent shortening"
+msgstr ""
+
+#: mod/settings.php:844
+msgid ""
+"Normally the system tries to find the best link to add to shortened posts. "
+"If this option is enabled then every shortened post will always point to the "
+"original friendica post."
+msgstr ""
+
+#: mod/settings.php:845
+msgid "Attach the link title"
+msgstr ""
+
+#: mod/settings.php:845
+msgid ""
+"When activated, the title of the attached link will be added as a title on "
+"posts to Diaspora. This is mostly helpful with \"remote-self\" contacts that "
+"share feed content."
+msgstr ""
+
+#: mod/settings.php:846
+msgid "Automatically follow any GNU Social (OStatus) followers/mentioners"
+msgstr ""
+
+#: mod/settings.php:846
+msgid ""
+"If you receive a message from an unknown OStatus user, this option decides "
+"what to do. If it is checked, a new contact will be created for every "
+"unknown user."
+msgstr ""
+
+#: mod/settings.php:847
+msgid "Default group for OStatus contacts"
+msgstr ""
+
+#: mod/settings.php:848
+msgid "Your legacy GNU Social account"
+msgstr ""
+
+#: mod/settings.php:848
+msgid ""
+"If you enter your old GNU Social/Statusnet account name here (in the format "
+"user@domain.tld), your contacts will be added automatically. The field will "
+"be emptied when done."
+msgstr ""
+
+#: mod/settings.php:851
+msgid "Repair OStatus subscriptions"
+msgstr ""
+
+#: mod/settings.php:855
+msgid "Email/Mailbox Setup"
+msgstr ""
+
+#: mod/settings.php:856
+msgid ""
+"If you wish to communicate with email contacts using this service "
+"(optional), please specify how to connect to your mailbox."
+msgstr ""
+
+#: mod/settings.php:857
+msgid "Last successful email check:"
+msgstr ""
+
+#: mod/settings.php:859
+msgid "IMAP server name:"
+msgstr ""
+
+#: mod/settings.php:860
+msgid "IMAP port:"
+msgstr ""
+
+#: mod/settings.php:861
+msgid "Security:"
+msgstr ""
+
+#: mod/settings.php:862
+msgid "Email login name:"
+msgstr ""
+
+#: mod/settings.php:863
+msgid "Email password:"
+msgstr ""
+
+#: mod/settings.php:864
+msgid "Reply-to address:"
+msgstr ""
+
+#: mod/settings.php:865
+msgid "Send public posts to all email contacts:"
+msgstr ""
+
+#: mod/settings.php:866
+msgid "Action after import:"
+msgstr ""
+
+#: mod/settings.php:866 src/Content/Nav.php:247
+msgid "Mark as seen"
+msgstr ""
+
+#: mod/settings.php:866
+msgid "Move to folder"
+msgstr ""
+
+#: mod/settings.php:867
+msgid "Move to folder:"
+msgstr ""
+
+#: mod/settings.php:891 src/Module/Admin/Site.php:425
+msgid "No special theme for mobile devices"
+msgstr ""
+
+#: mod/settings.php:899
+#, php-format
+msgid "%s - (Unsupported)"
+msgstr ""
+
+#: mod/settings.php:901 src/Module/Admin/Site.php:442
+#, php-format
+msgid "%s - (Experimental)"
+msgstr ""
+
+#: mod/settings.php:929 src/Core/L10n.php:349 src/Model/Event.php:394
+msgid "Sunday"
+msgstr ""
+
+#: mod/settings.php:929 src/Core/L10n.php:349 src/Model/Event.php:395
+msgid "Monday"
+msgstr ""
+
+#: mod/settings.php:945
+msgid "Display Settings"
+msgstr ""
+
+#: mod/settings.php:951
+msgid "Display Theme:"
+msgstr ""
+
+#: mod/settings.php:952
+msgid "Mobile Theme:"
+msgstr ""
+
+#: mod/settings.php:953
+msgid "Suppress warning of insecure networks"
+msgstr ""
+
+#: mod/settings.php:953
+msgid ""
+"Should the system suppress the warning that the current group contains "
+"members of networks that can't receive non public postings."
+msgstr ""
+
+#: mod/settings.php:954
+msgid "Update browser every xx seconds"
+msgstr ""
+
+#: mod/settings.php:954
+msgid "Minimum of 10 seconds. Enter -1 to disable it."
+msgstr ""
+
+#: mod/settings.php:955
+msgid "Number of items to display per page:"
+msgstr ""
+
+#: mod/settings.php:955 mod/settings.php:956
+msgid "Maximum of 100 items"
+msgstr ""
+
+#: mod/settings.php:956
+msgid "Number of items to display per page when viewed from mobile device:"
+msgstr ""
+
+#: mod/settings.php:957
+msgid "Don't show emoticons"
+msgstr ""
+
+#: mod/settings.php:958
+msgid "Calendar"
+msgstr ""
+
+#: mod/settings.php:959
+msgid "Beginning of week:"
+msgstr ""
+
+#: mod/settings.php:960
+msgid "Don't show notices"
+msgstr ""
+
+#: mod/settings.php:961
+msgid "Infinite scroll"
+msgstr ""
+
+#: mod/settings.php:962
+msgid "Automatic updates only at the top of the network page"
+msgstr ""
+
+#: mod/settings.php:962
+msgid ""
+"When disabled, the network page is updated all the time, which could be "
+"confusing while reading."
+msgstr ""
+
+#: mod/settings.php:963
+msgid "Bandwidth Saver Mode"
+msgstr ""
+
+#: mod/settings.php:963
+msgid ""
+"When enabled, embedded content is not displayed on automatic updates, they "
+"only show on page reload."
+msgstr ""
+
+#: mod/settings.php:964
+msgid "Disable Smart Threading"
+msgstr ""
+
+#: mod/settings.php:964
+msgid "Disable the automatic suppression of extraneous thread indentation."
+msgstr ""
+
+#: mod/settings.php:966
+msgid "General Theme Settings"
+msgstr ""
+
+#: mod/settings.php:967
+msgid "Custom Theme Settings"
+msgstr ""
+
+#: mod/settings.php:968
+msgid "Content Settings"
+msgstr ""
+
+#: mod/settings.php:969 view/theme/duepuntozero/config.php:70
+#: view/theme/frio/config.php:125 view/theme/quattro/config.php:72
+#: view/theme/vier/config.php:120
 msgid "Theme settings"
 msgstr ""
 
-#: view/theme/vier/config.php:122
-msgid "Set style"
+#: mod/settings.php:983
+msgid "Unable to find your profile. Please contact your admin."
 msgstr ""
 
-#: view/theme/vier/config.php:123
-msgid "Community Pages"
+#: mod/settings.php:1022
+msgid "Account Types"
 msgstr ""
 
-#: view/theme/vier/config.php:125
-msgid "Help or @NewHere ?"
+#: mod/settings.php:1023
+msgid "Personal Page Subtypes"
 msgstr ""
 
-#: view/theme/vier/config.php:127
-msgid "Find Friends"
+#: mod/settings.php:1024
+msgid "Community Forum Subtypes"
 msgstr ""
 
-#: view/theme/duepuntozero/config.php:53 src/Model/User.php:788
+#: mod/settings.php:1031 src/Module/Admin/Users.php:226
+msgid "Personal Page"
+msgstr ""
+
+#: mod/settings.php:1032
+msgid "Account for a personal profile."
+msgstr ""
+
+#: mod/settings.php:1035 src/Module/Admin/Users.php:227
+msgid "Organisation Page"
+msgstr ""
+
+#: mod/settings.php:1036
+msgid ""
+"Account for an organisation that automatically approves contact requests as "
+"\"Followers\"."
+msgstr ""
+
+#: mod/settings.php:1039 src/Module/Admin/Users.php:228
+msgid "News Page"
+msgstr ""
+
+#: mod/settings.php:1040
+msgid ""
+"Account for a news reflector that automatically approves contact requests as "
+"\"Followers\"."
+msgstr ""
+
+#: mod/settings.php:1043 src/Module/Admin/Users.php:229
+msgid "Community Forum"
+msgstr ""
+
+#: mod/settings.php:1044
+msgid "Account for community discussions."
+msgstr ""
+
+#: mod/settings.php:1047 src/Module/Admin/Users.php:219
+msgid "Normal Account Page"
+msgstr ""
+
+#: mod/settings.php:1048
+msgid ""
+"Account for a regular personal profile that requires manual approval of "
+"\"Friends\" and \"Followers\"."
+msgstr ""
+
+#: mod/settings.php:1051 src/Module/Admin/Users.php:220
+msgid "Soapbox Page"
+msgstr ""
+
+#: mod/settings.php:1052
+msgid ""
+"Account for a public profile that automatically approves contact requests as "
+"\"Followers\"."
+msgstr ""
+
+#: mod/settings.php:1055 src/Module/Admin/Users.php:221
+msgid "Public Forum"
+msgstr ""
+
+#: mod/settings.php:1056
+msgid "Automatically approves all contact requests."
+msgstr ""
+
+#: mod/settings.php:1059 src/Module/Admin/Users.php:222
+msgid "Automatic Friend Page"
+msgstr ""
+
+#: mod/settings.php:1060
+msgid ""
+"Account for a popular profile that automatically approves contact requests "
+"as \"Friends\"."
+msgstr ""
+
+#: mod/settings.php:1063
+msgid "Private Forum [Experimental]"
+msgstr ""
+
+#: mod/settings.php:1064
+msgid "Requires manual approval of contact requests."
+msgstr ""
+
+#: mod/settings.php:1075
+msgid "OpenID:"
+msgstr ""
+
+#: mod/settings.php:1075
+msgid "(Optional) Allow this OpenID to login to this account."
+msgstr ""
+
+#: mod/settings.php:1083
+msgid "Publish your default profile in your local site directory?"
+msgstr ""
+
+#: mod/settings.php:1083
+#, php-format
+msgid ""
+"Your profile will be published in this node's <a href=\"%s\">local "
+"directory</a>. Your profile details may be publicly visible depending on the "
+"system settings."
+msgstr ""
+
+#: mod/settings.php:1089
+msgid "Publish your default profile in the global social directory?"
+msgstr ""
+
+#: mod/settings.php:1089
+#, php-format
+msgid ""
+"Your profile will be published in the global friendica directories (e.g. <a "
+"href=\"%s\">%s</a>). Your profile will be visible in public."
+msgstr ""
+
+#: mod/settings.php:1089
+msgid ""
+"This setting also determines whether Friendica will inform search engines "
+"that your profile should be indexed or not. Third-party search engines may "
+"or may not respect this setting."
+msgstr ""
+
+#: mod/settings.php:1096
+msgid "Hide your contact/friend list from viewers of your default profile?"
+msgstr ""
+
+#: mod/settings.php:1096
+msgid ""
+"Your contact list won't be shown in your default profile page. You can "
+"decide to show your contact list separately for each additional profile you "
+"create"
+msgstr ""
+
+#: mod/settings.php:1100
+msgid "Hide your profile details from anonymous viewers?"
+msgstr ""
+
+#: mod/settings.php:1100
+msgid ""
+"Anonymous visitors will only see your profile picture, your display name and "
+"the nickname you are using on your profile page. Your public posts and "
+"replies will still be accessible by other means."
+msgstr ""
+
+#: mod/settings.php:1104
+msgid "Allow friends to post to your profile page?"
+msgstr ""
+
+#: mod/settings.php:1104
+msgid ""
+"Your contacts may write posts on your profile wall. These posts will be "
+"distributed to your contacts"
+msgstr ""
+
+#: mod/settings.php:1108
+msgid "Allow friends to tag your posts?"
+msgstr ""
+
+#: mod/settings.php:1108
+msgid "Your contacts can add additional tags to your posts."
+msgstr ""
+
+#: mod/settings.php:1112
+msgid "Allow us to suggest you as a potential friend to new members?"
+msgstr ""
+
+#: mod/settings.php:1112
+msgid "If you like, Friendica may suggest new members to add you as a contact."
+msgstr ""
+
+#: mod/settings.php:1116
+msgid "Permit unknown people to send you private mail?"
+msgstr ""
+
+#: mod/settings.php:1116
+msgid ""
+"Friendica network users may send you private messages even if they are not "
+"in your contact list."
+msgstr ""
+
+#: mod/settings.php:1120
+msgid "Profile is <strong>not published</strong>."
+msgstr ""
+
+#: mod/settings.php:1126
+#, php-format
+msgid "Your Identity Address is <strong>'%s'</strong> or '%s'."
+msgstr ""
+
+#: mod/settings.php:1133
+msgid "Automatically expire posts after this many days:"
+msgstr ""
+
+#: mod/settings.php:1133
+msgid "If empty, posts will not expire. Expired posts will be deleted"
+msgstr ""
+
+#: mod/settings.php:1134
+msgid "Advanced expiration settings"
+msgstr ""
+
+#: mod/settings.php:1135
+msgid "Advanced Expiration"
+msgstr ""
+
+#: mod/settings.php:1136
+msgid "Expire posts:"
+msgstr ""
+
+#: mod/settings.php:1137
+msgid "Expire personal notes:"
+msgstr ""
+
+#: mod/settings.php:1138
+msgid "Expire starred posts:"
+msgstr ""
+
+#: mod/settings.php:1139
+msgid "Expire photos:"
+msgstr ""
+
+#: mod/settings.php:1140
+msgid "Only expire posts by others:"
+msgstr ""
+
+#: mod/settings.php:1170
+msgid "Account Settings"
+msgstr ""
+
+#: mod/settings.php:1178
+msgid "Password Settings"
+msgstr ""
+
+#: mod/settings.php:1179 src/Module/Register.php:130
+msgid "New Password:"
+msgstr ""
+
+#: mod/settings.php:1179
+msgid ""
+"Allowed characters are a-z, A-Z, 0-9 and special characters except white "
+"spaces, accentuated letters and colon (:)."
+msgstr ""
+
+#: mod/settings.php:1180 src/Module/Register.php:131
+msgid "Confirm:"
+msgstr ""
+
+#: mod/settings.php:1180
+msgid "Leave password fields blank unless changing"
+msgstr ""
+
+#: mod/settings.php:1181
+msgid "Current Password:"
+msgstr ""
+
+#: mod/settings.php:1181 mod/settings.php:1182
+msgid "Your current password to confirm the changes"
+msgstr ""
+
+#: mod/settings.php:1182
+msgid "Password:"
+msgstr ""
+
+#: mod/settings.php:1185
+msgid "Delete OpenID URL"
+msgstr ""
+
+#: mod/settings.php:1187
+msgid "Basic Settings"
+msgstr ""
+
+#: mod/settings.php:1188 src/Model/Profile.php:754
+msgid "Full Name:"
+msgstr ""
+
+#: mod/settings.php:1189
+msgid "Email Address:"
+msgstr ""
+
+#: mod/settings.php:1190
+msgid "Your Timezone:"
+msgstr ""
+
+#: mod/settings.php:1191
+msgid "Your Language:"
+msgstr ""
+
+#: mod/settings.php:1191
+msgid ""
+"Set the language we use to show you friendica interface and to send you "
+"emails"
+msgstr ""
+
+#: mod/settings.php:1192
+msgid "Default Post Location:"
+msgstr ""
+
+#: mod/settings.php:1193
+msgid "Use Browser Location:"
+msgstr ""
+
+#: mod/settings.php:1196
+msgid "Security and Privacy Settings"
+msgstr ""
+
+#: mod/settings.php:1198
+msgid "Maximum Friend Requests/Day:"
+msgstr ""
+
+#: mod/settings.php:1198 mod/settings.php:1227
+msgid "(to prevent spam abuse)"
+msgstr ""
+
+#: mod/settings.php:1199
+msgid "Default Post Permissions"
+msgstr ""
+
+#: mod/settings.php:1200
+msgid "(click to open/close)"
+msgstr ""
+
+#: mod/settings.php:1210
+msgid "Default Private Post"
+msgstr ""
+
+#: mod/settings.php:1211
+msgid "Default Public Post"
+msgstr ""
+
+#: mod/settings.php:1215
+msgid "Default Permissions for New Posts"
+msgstr ""
+
+#: mod/settings.php:1227
+msgid "Maximum private messages per day from unknown people:"
+msgstr ""
+
+#: mod/settings.php:1230
+msgid "Notification Settings"
+msgstr ""
+
+#: mod/settings.php:1231
+msgid "Send a notification email when:"
+msgstr ""
+
+#: mod/settings.php:1232
+msgid "You receive an introduction"
+msgstr ""
+
+#: mod/settings.php:1233
+msgid "Your introductions are confirmed"
+msgstr ""
+
+#: mod/settings.php:1234
+msgid "Someone writes on your profile wall"
+msgstr ""
+
+#: mod/settings.php:1235
+msgid "Someone writes a followup comment"
+msgstr ""
+
+#: mod/settings.php:1236
+msgid "You receive a private message"
+msgstr ""
+
+#: mod/settings.php:1237
+msgid "You receive a friend suggestion"
+msgstr ""
+
+#: mod/settings.php:1238
+msgid "You are tagged in a post"
+msgstr ""
+
+#: mod/settings.php:1239
+msgid "You are poked/prodded/etc. in a post"
+msgstr ""
+
+#: mod/settings.php:1241
+msgid "Activate desktop notifications"
+msgstr ""
+
+#: mod/settings.php:1241
+msgid "Show desktop popup on new notifications"
+msgstr ""
+
+#: mod/settings.php:1243
+msgid "Text-only notification emails"
+msgstr ""
+
+#: mod/settings.php:1245
+msgid "Send text only notification emails, without the html part"
+msgstr ""
+
+#: mod/settings.php:1247
+msgid "Show detailled notifications"
+msgstr ""
+
+#: mod/settings.php:1249
+msgid ""
+"Per default, notifications are condensed to a single notification per item. "
+"When enabled every notification is displayed."
+msgstr ""
+
+#: mod/settings.php:1251
+msgid "Advanced Account/Page Type Settings"
+msgstr ""
+
+#: mod/settings.php:1252
+msgid "Change the behaviour of this account for special situations"
+msgstr ""
+
+#: mod/settings.php:1255
+msgid "Import Contacts"
+msgstr ""
+
+#: mod/settings.php:1256
+msgid ""
+"Upload a CSV file that contains the handle of your followed accounts in the "
+"first column you exported from the old account."
+msgstr ""
+
+#: mod/settings.php:1257
+msgid "Upload File"
+msgstr ""
+
+#: mod/settings.php:1259
+msgid "Relocate"
+msgstr ""
+
+#: mod/settings.php:1260
+msgid ""
+"If you have moved this profile from another server, and some of your "
+"contacts don't receive your updates, try pushing this button."
+msgstr ""
+
+#: mod/settings.php:1261
+msgid "Resend relocate message to contacts"
+msgstr ""
+
+#: mod/subthread.php:107
+#, php-format
+msgid "%1$s is following %2$s's %3$s"
+msgstr ""
+
+#: mod/suggest.php:27
+msgid "Contact suggestion successfully ignored."
+msgstr ""
+
+#: mod/suggest.php:51
+msgid ""
+"No suggestions available. If this is a new site, please try again in 24 "
+"hours."
+msgstr ""
+
+#: mod/suggest.php:70
+msgid "Do you really want to delete this suggestion?"
+msgstr ""
+
+#: mod/suggest.php:88 mod/suggest.php:108
+msgid "Ignore/Hide"
+msgstr ""
+
+#: mod/suggest.php:118 view/theme/vier/theme.php:179 src/Content/Widget.php:65
+msgid "Friend Suggestions"
+msgstr ""
+
+#: mod/tagrm.php:31
+msgid "Tag(s) removed"
+msgstr ""
+
+#: mod/tagrm.php:101
+msgid "Remove Item Tag"
+msgstr ""
+
+#: mod/tagrm.php:103
+msgid "Select a tag to remove: "
+msgstr ""
+
+#: mod/tagrm.php:114 src/Module/Settings/Delegation.php:159
+msgid "Remove"
+msgstr ""
+
+#: mod/uimport.php:29
+msgid "User imports on closed servers can only be done by an administrator."
+msgstr ""
+
+#: mod/uimport.php:38 src/Module/Register.php:65
+msgid ""
+"This site has exceeded the number of allowed daily account registrations. "
+"Please try again tomorrow."
+msgstr ""
+
+#: mod/uimport.php:45 src/Module/Register.php:141
+msgid "Import"
+msgstr ""
+
+#: mod/uimport.php:47
+msgid "Move account"
+msgstr ""
+
+#: mod/uimport.php:48
+msgid "You can import an account from another Friendica server."
+msgstr ""
+
+#: mod/uimport.php:49
+msgid ""
+"You need to export your account from the old server and upload it here. We "
+"will recreate your old account here with all your contacts. We will try also "
+"to inform your friends that you moved here."
+msgstr ""
+
+#: mod/uimport.php:50
+msgid ""
+"This feature is experimental. We can't import contacts from the OStatus "
+"network (GNU Social/Statusnet) or from Diaspora"
+msgstr ""
+
+#: mod/uimport.php:51
+msgid "Account file"
+msgstr ""
+
+#: mod/uimport.php:51
+msgid ""
+"To export your account, go to \"Settings->Export your personal data\" and "
+"select \"Export account\""
+msgstr ""
+
+#: mod/unfollow.php:35 mod/unfollow.php:91
+msgid "You aren't following this contact."
+msgstr ""
+
+#: mod/unfollow.php:45 mod/unfollow.php:97
+msgid "Unfollowing is currently not supported by your network."
+msgstr ""
+
+#: mod/unfollow.php:66
+msgid "Contact unfollowed"
+msgstr ""
+
+#: mod/unfollow.php:117
+msgid "Disconnect/Unfollow"
+msgstr ""
+
+#: mod/update_community.php:22 mod/update_contact.php:22
+#: mod/update_display.php:23 mod/update_network.php:32 mod/update_notes.php:35
+#: mod/update_profile.php:33
+msgid "[Embedded content - reload page to view]"
+msgstr ""
+
+#: mod/videos.php:116
+msgid "No videos selected"
+msgstr ""
+
+#: mod/videos.php:234 src/Model/Item.php:3581
+msgid "View Video"
+msgstr ""
+
+#: mod/videos.php:249
+msgid "Recent Videos"
+msgstr ""
+
+#: mod/videos.php:251
+msgid "Upload New Videos"
+msgstr ""
+
+#: mod/wall_attach.php:26 mod/wall_attach.php:33 mod/wall_attach.php:71
+#: mod/wall_upload.php:41 mod/wall_upload.php:57 mod/wall_upload.php:102
+#: mod/wall_upload.php:153 mod/wall_upload.php:156
+msgid "Invalid request."
+msgstr ""
+
+#: mod/wall_attach.php:89
+msgid "Sorry, maybe your upload is bigger than the PHP configuration allows"
+msgstr ""
+
+#: mod/wall_attach.php:89
+msgid "Or - did you try to upload an empty file?"
+msgstr ""
+
+#: mod/wall_attach.php:100
+#, php-format
+msgid "File exceeds size limit of %s"
+msgstr ""
+
+#: mod/wall_attach.php:115
+msgid "File upload failed."
+msgstr ""
+
+#: mod/wall_upload.php:229
+msgid "Wall Photos"
+msgstr ""
+
+#: mod/wallmessage.php:51 mod/wallmessage.php:114
+#, php-format
+msgid "Number of daily wall messages for %s exceeded. Message failed."
+msgstr ""
+
+#: mod/wallmessage.php:62
+msgid "Unable to check your home location."
+msgstr ""
+
+#: mod/wallmessage.php:88 mod/wallmessage.php:97
+msgid "No recipient."
+msgstr ""
+
+#: mod/wallmessage.php:128
+#, php-format
+msgid ""
+"If you wish for %s to respond, please check that the privacy settings on "
+"your site allow private mail from unknown senders."
+msgstr ""
+
+#: view/theme/duepuntozero/config.php:52 src/Model/User.php:787
 msgid "default"
 msgstr ""
 
-#: view/theme/duepuntozero/config.php:54
+#: view/theme/duepuntozero/config.php:53
 msgid "greenzero"
 msgstr ""
 
-#: view/theme/duepuntozero/config.php:55
+#: view/theme/duepuntozero/config.php:54
 msgid "purplezero"
 msgstr ""
 
-#: view/theme/duepuntozero/config.php:56
+#: view/theme/duepuntozero/config.php:55
 msgid "easterbunny"
 msgstr ""
 
-#: view/theme/duepuntozero/config.php:57
+#: view/theme/duepuntozero/config.php:56
 msgid "darkzero"
 msgstr ""
 
-#: view/theme/duepuntozero/config.php:58
+#: view/theme/duepuntozero/config.php:57
 msgid "comix"
 msgstr ""
 
-#: view/theme/duepuntozero/config.php:59
+#: view/theme/duepuntozero/config.php:58
 msgid "slackr"
 msgstr ""
 
-#: view/theme/duepuntozero/config.php:72
+#: view/theme/duepuntozero/config.php:71
 msgid "Variations"
 msgstr ""
 
@@ -3813,2269 +4108,738 @@ msgstr ""
 msgid "Repeat image to fill the screen."
 msgstr ""
 
-#: view/theme/frio/theme.php:246
-msgid "Guest"
-msgstr ""
-
-#: view/theme/frio/theme.php:251
-msgid "Visitor"
-msgstr ""
-
-#: view/theme/frio/theme.php:267 src/Content/Nav.php:159
-#: src/Model/Profile.php:912 src/Module/Settings/TwoFactor/Index.php:88
-#: src/Module/Contact.php:636 src/Module/Contact.php:855
-msgid "Status"
-msgstr ""
-
-#: view/theme/frio/theme.php:267 src/Content/Nav.php:159
-#: src/Content/Nav.php:242
-msgid "Your posts and conversations"
-msgstr ""
-
-#: view/theme/frio/theme.php:268 src/Content/Nav.php:160
-#: src/Model/Profile.php:884 src/Model/Profile.php:920
-#: src/Module/Welcome.php:38 src/Module/Contact.php:638
-#: src/Module/Contact.php:871 mod/profperm.php:116
-msgid "Profile"
-msgstr ""
-
-#: view/theme/frio/theme.php:268 src/Content/Nav.php:160
-msgid "Your profile page"
-msgstr ""
-
-#: view/theme/frio/theme.php:269 src/Content/Nav.php:161
-#: src/Model/Profile.php:928 mod/fbrowser.php:42
-msgid "Photos"
-msgstr ""
-
-#: view/theme/frio/theme.php:269 src/Content/Nav.php:161
-msgid "Your photos"
-msgstr ""
-
-#: view/theme/frio/theme.php:270 src/Content/Nav.php:162
-#: src/Model/Profile.php:936 src/Model/Profile.php:939
-msgid "Videos"
-msgstr ""
-
-#: view/theme/frio/theme.php:270 src/Content/Nav.php:162
-msgid "Your videos"
-msgstr ""
-
-#: view/theme/frio/theme.php:271 view/theme/frio/theme.php:275
-#: src/Content/Nav.php:163 src/Content/Nav.php:227 src/Model/Profile.php:948
-#: src/Model/Profile.php:959 mod/events.php:393 mod/cal.php:258
-msgid "Events"
-msgstr ""
-
-#: view/theme/frio/theme.php:271 src/Content/Nav.php:163
-msgid "Your events"
-msgstr ""
-
-#: view/theme/frio/theme.php:274 src/Content/Nav.php:240
-msgid "Network"
-msgstr ""
-
-#: view/theme/frio/theme.php:274 src/Content/Nav.php:240
-msgid "Conversations from your friends"
-msgstr ""
-
-#: view/theme/frio/theme.php:275 src/Content/Nav.php:227
-#: src/Model/Profile.php:951 src/Model/Profile.php:962
-msgid "Events and Calendar"
-msgstr ""
-
-#: view/theme/frio/theme.php:276 src/Content/Nav.php:252 mod/message.php:121
-msgid "Messages"
-msgstr ""
-
-#: view/theme/frio/theme.php:276 src/Content/Nav.php:252
-msgid "Private mail"
-msgstr ""
-
-#: view/theme/frio/theme.php:277 src/Content/Nav.php:261
-msgid "Account settings"
-msgstr ""
-
-#: view/theme/frio/theme.php:278 src/Content/Text/HTML.php:911
-#: src/Content/Nav.php:204 src/Content/Nav.php:267 src/Model/Profile.php:991
-#: src/Model/Profile.php:994 src/Module/Contact.php:798
-#: src/Module/Contact.php:883
-msgid "Contacts"
-msgstr ""
-
-#: view/theme/frio/theme.php:278 src/Content/Nav.php:267
-msgid "Manage/edit friends and contacts"
-msgstr ""
-
-#: view/theme/frio/config.php:109
+#: view/theme/frio/config.php:108
 msgid "Custom"
 msgstr ""
 
-#: view/theme/frio/config.php:121
+#: view/theme/frio/config.php:120
 msgid "Note"
 msgstr ""
 
-#: view/theme/frio/config.php:121
+#: view/theme/frio/config.php:120
 msgid "Check image permissions if all users are allowed to see the image"
 msgstr ""
 
-#: view/theme/frio/config.php:127
+#: view/theme/frio/config.php:126
 msgid "Select color scheme"
 msgstr ""
 
-#: view/theme/frio/config.php:128
+#: view/theme/frio/config.php:127
 msgid "Copy or paste schemestring"
 msgstr ""
 
-#: view/theme/frio/config.php:128
+#: view/theme/frio/config.php:127
 msgid ""
 "You can copy this string to share your theme with others. Pasting here "
 "applies the schemestring"
 msgstr ""
 
-#: view/theme/frio/config.php:129
+#: view/theme/frio/config.php:128
 msgid "Navigation bar background color"
 msgstr ""
 
-#: view/theme/frio/config.php:130
+#: view/theme/frio/config.php:129
 msgid "Navigation bar icon color "
 msgstr ""
 
-#: view/theme/frio/config.php:131
+#: view/theme/frio/config.php:130
 msgid "Link color"
 msgstr ""
 
-#: view/theme/frio/config.php:132
+#: view/theme/frio/config.php:131
 msgid "Set the background color"
 msgstr ""
 
-#: view/theme/frio/config.php:133
+#: view/theme/frio/config.php:132
 msgid "Content background opacity"
 msgstr ""
 
-#: view/theme/frio/config.php:134
+#: view/theme/frio/config.php:133
 msgid "Set the background image"
 msgstr ""
 
-#: view/theme/frio/config.php:135
+#: view/theme/frio/config.php:134
 msgid "Background image style"
 msgstr ""
 
-#: view/theme/frio/config.php:137
+#: view/theme/frio/config.php:136
 msgid "Enable Compose page"
 msgstr ""
 
-#: view/theme/frio/config.php:137
+#: view/theme/frio/config.php:136
 msgid ""
 "This replaces the jot modal window for writing new posts with a link to <a "
 "href=\"compose\">the new Compose page</a>."
 msgstr ""
 
-#: view/theme/frio/config.php:141
+#: view/theme/frio/config.php:140
 msgid "Login page background image"
 msgstr ""
 
-#: view/theme/frio/config.php:145
+#: view/theme/frio/config.php:144
 msgid "Login page background color"
 msgstr ""
 
-#: view/theme/frio/config.php:145
+#: view/theme/frio/config.php:144
 msgid "Leave background image and color empty for theme defaults"
 msgstr ""
 
-#: view/theme/quattro/config.php:74
+#: view/theme/frio/theme.php:245
+msgid "Guest"
+msgstr ""
+
+#: view/theme/frio/theme.php:250
+msgid "Visitor"
+msgstr ""
+
+#: view/theme/frio/theme.php:266 src/Content/Nav.php:157
+#: src/Model/Profile.php:907 src/Module/Settings/TwoFactor/Index.php:88
+#: src/Module/Contact.php:634 src/Module/Contact.php:853
+msgid "Status"
+msgstr ""
+
+#: view/theme/frio/theme.php:266 src/Content/Nav.php:157
+#: src/Content/Nav.php:240
+msgid "Your posts and conversations"
+msgstr ""
+
+#: view/theme/frio/theme.php:267 src/Content/Nav.php:158
+msgid "Your profile page"
+msgstr ""
+
+#: view/theme/frio/theme.php:268 src/Content/Nav.php:159
+msgid "Your photos"
+msgstr ""
+
+#: view/theme/frio/theme.php:269 src/Content/Nav.php:160
+#: src/Model/Profile.php:931 src/Model/Profile.php:934
+msgid "Videos"
+msgstr ""
+
+#: view/theme/frio/theme.php:269 src/Content/Nav.php:160
+msgid "Your videos"
+msgstr ""
+
+#: view/theme/frio/theme.php:270 src/Content/Nav.php:161
+msgid "Your events"
+msgstr ""
+
+#: view/theme/frio/theme.php:273 src/Content/Nav.php:238
+msgid "Network"
+msgstr ""
+
+#: view/theme/frio/theme.php:273 src/Content/Nav.php:238
+msgid "Conversations from your friends"
+msgstr ""
+
+#: view/theme/frio/theme.php:274 src/Content/Nav.php:225
+#: src/Model/Profile.php:946 src/Model/Profile.php:957
+msgid "Events and Calendar"
+msgstr ""
+
+#: view/theme/frio/theme.php:275 src/Content/Nav.php:250
+msgid "Private mail"
+msgstr ""
+
+#: view/theme/frio/theme.php:276 src/Content/Nav.php:259
+msgid "Account settings"
+msgstr ""
+
+#: view/theme/frio/theme.php:277 src/Content/Text/HTML.php:911
+#: src/Content/Nav.php:202 src/Content/Nav.php:265 src/Model/Profile.php:986
+#: src/Model/Profile.php:989 src/Module/Contact.php:796
+#: src/Module/Contact.php:881
+msgid "Contacts"
+msgstr ""
+
+#: view/theme/frio/theme.php:277 src/Content/Nav.php:265
+msgid "Manage/edit friends and contacts"
+msgstr ""
+
+#: view/theme/quattro/config.php:73
 msgid "Alignment"
 msgstr ""
 
-#: view/theme/quattro/config.php:74
+#: view/theme/quattro/config.php:73
 msgid "Left"
 msgstr ""
 
-#: view/theme/quattro/config.php:74
+#: view/theme/quattro/config.php:73
 msgid "Center"
 msgstr ""
 
-#: view/theme/quattro/config.php:75
+#: view/theme/quattro/config.php:74
 msgid "Color scheme"
 msgstr ""
 
-#: view/theme/quattro/config.php:76
+#: view/theme/quattro/config.php:75
 msgid "Posts font size"
 msgstr ""
 
-#: view/theme/quattro/config.php:77
+#: view/theme/quattro/config.php:76
 msgid "Textareas font size"
 msgstr ""
 
-#: src/Database/DBStructure.php:49
-msgid "There are no tables on MyISAM."
+#: view/theme/vier/config.php:75
+msgid "Comma separated list of helper forums"
 msgstr ""
 
-#: src/Database/DBStructure.php:73
-#, php-format
+#: view/theme/vier/config.php:115
+msgid "don't show"
+msgstr ""
+
+#: view/theme/vier/config.php:115
+msgid "show"
+msgstr ""
+
+#: view/theme/vier/config.php:121
+msgid "Set style"
+msgstr ""
+
+#: view/theme/vier/config.php:122
+msgid "Community Pages"
+msgstr ""
+
+#: view/theme/vier/config.php:123 view/theme/vier/theme.php:126
+msgid "Community Profiles"
+msgstr ""
+
+#: view/theme/vier/config.php:124
+msgid "Help or @NewHere ?"
+msgstr ""
+
+#: view/theme/vier/config.php:125 view/theme/vier/theme.php:348
+msgid "Connect Services"
+msgstr ""
+
+#: view/theme/vier/config.php:126
+msgid "Find Friends"
+msgstr ""
+
+#: view/theme/vier/config.php:127 view/theme/vier/theme.php:156
+msgid "Last users"
+msgstr ""
+
+#: view/theme/vier/theme.php:174 src/Content/Widget.php:60
+msgid "Find People"
+msgstr ""
+
+#: view/theme/vier/theme.php:175 src/Content/Widget.php:61
+msgid "Enter name or interest"
+msgstr ""
+
+#: view/theme/vier/theme.php:177 src/Content/Widget.php:63
+msgid "Examples: Robert Morgenstein, Fishing"
+msgstr ""
+
+#: view/theme/vier/theme.php:178 src/Content/Widget.php:64
+#: src/Module/Contact.php:817 src/Module/Directory.php:84
+msgid "Find"
+msgstr ""
+
+#: view/theme/vier/theme.php:180 src/Content/Widget.php:66
+msgid "Similar Interests"
+msgstr ""
+
+#: view/theme/vier/theme.php:181 src/Content/Widget.php:67
+msgid "Random Profile"
+msgstr ""
+
+#: view/theme/vier/theme.php:182 src/Content/Widget.php:68
+msgid "Invite Friends"
+msgstr ""
+
+#: view/theme/vier/theme.php:183 src/Content/Widget.php:69
+#: src/Module/Directory.php:76
+msgid "Global Directory"
+msgstr ""
+
+#: view/theme/vier/theme.php:185 src/Content/Widget.php:71
+msgid "Local Directory"
+msgstr ""
+
+#: view/theme/vier/theme.php:225 src/Content/Text/HTML.php:915
+#: src/Content/ForumManager.php:129 src/Content/Nav.php:206
+msgid "Forums"
+msgstr ""
+
+#: view/theme/vier/theme.php:227 src/Content/ForumManager.php:131
+msgid "External link to forum"
+msgstr ""
+
+#: view/theme/vier/theme.php:230 src/Content/ForumManager.php:134
+#: src/Content/Widget.php:404 src/Content/Widget.php:503
+msgid "show more"
+msgstr ""
+
+#: view/theme/vier/theme.php:263
+msgid "Quick Start"
+msgstr ""
+
+#: view/theme/vier/theme.php:269 src/Content/Nav.php:189
+#: src/Module/Settings/TwoFactor/AppSpecific.php:96
+#: src/Module/Settings/TwoFactor/Index.php:87
+#: src/Module/Settings/TwoFactor/Recovery.php:74
+#: src/Module/Settings/TwoFactor/Verify.php:113 src/Module/Help.php:50
+msgid "Help"
+msgstr ""
+
+#: src/Core/ACL.php:366
+msgid "Post to Email"
+msgstr ""
+
+#: src/Core/ACL.php:384
+msgid "Public"
+msgstr ""
+
+#: src/Core/ACL.php:385
 msgid ""
-"\n"
-"Error %d occurred during database update:\n"
-"%s\n"
+"This content will be shown to all your followers and can be seen in the "
+"community pages and by anyone with its link."
 msgstr ""
 
-#: src/Database/DBStructure.php:76
-msgid "Errors encountered performing database changes: "
+#: src/Core/ACL.php:386
+msgid "Limited/Private"
 msgstr ""
 
-#: src/Database/DBStructure.php:265
-#, php-format
-msgid "%s: Database update"
-msgstr ""
-
-#: src/Database/DBStructure.php:526
-#, php-format
-msgid "%s: updating %s table."
-msgstr ""
-
-#: src/Object/Post.php:132
-msgid "This entry was edited"
-msgstr ""
-
-#: src/Object/Post.php:155
-msgid "Private Message"
-msgstr ""
-
-#: src/Object/Post.php:165 src/Object/Post.php:167 mod/settings.php:724
-msgid "Edit"
-msgstr ""
-
-#: src/Object/Post.php:194
-msgid "pinned item"
-msgstr ""
-
-#: src/Object/Post.php:199
-msgid "Delete locally"
-msgstr ""
-
-#: src/Object/Post.php:202
-msgid "Delete globally"
-msgstr ""
-
-#: src/Object/Post.php:202
-msgid "Remove locally"
-msgstr ""
-
-#: src/Object/Post.php:216
-msgid "save to folder"
-msgstr ""
-
-#: src/Object/Post.php:251
-msgid "I will attend"
-msgstr ""
-
-#: src/Object/Post.php:251
-msgid "I will not attend"
-msgstr ""
-
-#: src/Object/Post.php:251
-msgid "I might attend"
-msgstr ""
-
-#: src/Object/Post.php:279
-msgid "ignore thread"
-msgstr ""
-
-#: src/Object/Post.php:280
-msgid "unignore thread"
-msgstr ""
-
-#: src/Object/Post.php:281
-msgid "toggle ignore status"
-msgstr ""
-
-#: src/Object/Post.php:284 mod/ostatus_subscribe.php:85
-msgid "ignored"
-msgstr ""
-
-#: src/Object/Post.php:293
-msgid "pin"
-msgstr ""
-
-#: src/Object/Post.php:294
-msgid "unpin"
-msgstr ""
-
-#: src/Object/Post.php:295
-msgid "toggle pin status"
-msgstr ""
-
-#: src/Object/Post.php:298
-msgid "pinned"
-msgstr ""
-
-#: src/Object/Post.php:305
-msgid "add star"
-msgstr ""
-
-#: src/Object/Post.php:306
-msgid "remove star"
-msgstr ""
-
-#: src/Object/Post.php:307
-msgid "toggle star status"
-msgstr ""
-
-#: src/Object/Post.php:310
-msgid "starred"
-msgstr ""
-
-#: src/Object/Post.php:314
-msgid "add tag"
-msgstr ""
-
-#: src/Object/Post.php:325 mod/photos.php:1370
-msgid "I like this (toggle)"
-msgstr ""
-
-#: src/Object/Post.php:325
-msgid "like"
-msgstr ""
-
-#: src/Object/Post.php:326 mod/photos.php:1371
-msgid "I don't like this (toggle)"
-msgstr ""
-
-#: src/Object/Post.php:326
-msgid "dislike"
-msgstr ""
-
-#: src/Object/Post.php:329
-msgid "Share this"
-msgstr ""
-
-#: src/Object/Post.php:329
-msgid "share"
-msgstr ""
-
-#: src/Object/Post.php:378
-#, php-format
-msgid "%s (Received %s)"
-msgstr ""
-
-#: src/Object/Post.php:403
-msgid "to"
-msgstr ""
-
-#: src/Object/Post.php:404
-msgid "via"
-msgstr ""
-
-#: src/Object/Post.php:405
-msgid "Wall-to-Wall"
-msgstr ""
-
-#: src/Object/Post.php:406
-msgid "via Wall-To-Wall:"
-msgstr ""
-
-#: src/Object/Post.php:441 src/Object/Post.php:903 mod/photos.php:1388
-#: mod/photos.php:1427 mod/photos.php:1491
-msgid "Comment"
-msgstr ""
-
-#: src/Object/Post.php:442
-#, php-format
-msgid "Reply to %s"
-msgstr ""
-
-#: src/Object/Post.php:458
-msgid "Notifier task is pending"
-msgstr ""
-
-#: src/Object/Post.php:459
-msgid "Delivery to remote servers is pending"
-msgstr ""
-
-#: src/Object/Post.php:460
-msgid "Delivery to remote servers is underway"
-msgstr ""
-
-#: src/Object/Post.php:461
-msgid "Delivery to remote servers is mostly done"
-msgstr ""
-
-#: src/Object/Post.php:462
-msgid "Delivery to remote servers is done"
-msgstr ""
-
-#: src/Object/Post.php:482
-#, php-format
-msgid "%d comment"
-msgid_plural "%d comments"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/Object/Post.php:483
-msgid "Show more"
-msgstr ""
-
-#: src/Object/Post.php:484
-msgid "Show fewer"
-msgstr ""
-
-#: src/Object/Post.php:495 src/Model/Item.php:3400
-msgid "comment"
-msgid_plural "comments"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/Object/Post.php:901 src/Module/Contact.php:1026
-#: src/Module/Item/Compose.php:123 mod/photos.php:1386 mod/photos.php:1425
-#: mod/photos.php:1489
-msgid "This is you"
-msgstr ""
-
-#: src/App.php:333
-msgid "No system theme config value set."
-msgstr ""
-
-#: src/Content/Text/BBCode.php:908 src/Content/Text/BBCode.php:1604
-#: src/Content/Text/BBCode.php:1605
-msgid "Image/photo"
-msgstr ""
-
-#: src/Content/Text/BBCode.php:1025
-#, php-format
-msgid "<a href=\"%1$s\" target=\"_blank\">%2$s</a> %3$s"
-msgstr ""
-
-#: src/Content/Text/BBCode.php:1522 src/Content/Text/HTML.php:952
-msgid "Click to open/close"
-msgstr ""
-
-#: src/Content/Text/BBCode.php:1553
-msgid "$1 wrote:"
-msgstr ""
-
-#: src/Content/Text/BBCode.php:1607 src/Content/Text/BBCode.php:1608
-msgid "Encrypted content"
-msgstr ""
-
-#: src/Content/Text/BBCode.php:1833
-msgid "Invalid source protocol"
-msgstr ""
-
-#: src/Content/Text/BBCode.php:1848
-msgid "Invalid link protocol"
-msgstr ""
-
-#: src/Content/Text/HTML.php:800
-msgid "Loading more entries..."
-msgstr ""
-
-#: src/Content/Text/HTML.php:801
-msgid "The end"
-msgstr ""
-
-#: src/Content/Text/HTML.php:894 src/Module/Filer/SaveTag.php:48
-#: mod/notes.php:46 mod/editpost.php:72
-msgid "Save"
-msgstr ""
-
-#: src/Content/Text/HTML.php:894 src/Model/Profile.php:539
-#: src/Module/Contact.php:317
-msgid "Follow"
-msgstr ""
-
-#: src/Content/Text/HTML.php:900 src/Content/Nav.php:199
-#: src/Module/Search/Index.php:79
-msgid "Search"
-msgstr ""
-
-#: src/Content/Text/HTML.php:902 src/Content/Nav.php:78
-msgid "@name, !forum, #tags, content"
-msgstr ""
-
-#: src/Content/Text/HTML.php:909 src/Content/Nav.php:202
-msgid "Full Text"
-msgstr ""
-
-#: src/Content/Text/HTML.php:910 src/Content/Nav.php:203
-#: src/Content/Widget/TagCloud.php:53
-msgid "Tags"
-msgstr ""
-
-#: src/Content/ContactSelector.php:57
-msgid "Frequently"
-msgstr ""
-
-#: src/Content/ContactSelector.php:58
-msgid "Hourly"
-msgstr ""
-
-#: src/Content/ContactSelector.php:59
-msgid "Twice daily"
-msgstr ""
-
-#: src/Content/ContactSelector.php:60
-msgid "Daily"
-msgstr ""
-
-#: src/Content/ContactSelector.php:61
-msgid "Weekly"
-msgstr ""
-
-#: src/Content/ContactSelector.php:62
-msgid "Monthly"
-msgstr ""
-
-#: src/Content/ContactSelector.php:116
-msgid "DFRN"
-msgstr ""
-
-#: src/Content/ContactSelector.php:117
-msgid "OStatus"
-msgstr ""
-
-#: src/Content/ContactSelector.php:118
-msgid "RSS/Atom"
-msgstr ""
-
-#: src/Content/ContactSelector.php:120 mod/settings.php:794
-msgid "Diaspora"
-msgstr ""
-
-#: src/Content/ContactSelector.php:121
-msgid "Zot!"
-msgstr ""
-
-#: src/Content/ContactSelector.php:122
-msgid "LinkedIn"
-msgstr ""
-
-#: src/Content/ContactSelector.php:123
-msgid "XMPP/IM"
-msgstr ""
-
-#: src/Content/ContactSelector.php:124
-msgid "MySpace"
-msgstr ""
-
-#: src/Content/ContactSelector.php:125
-msgid "Google+"
-msgstr ""
-
-#: src/Content/ContactSelector.php:126
-msgid "pump.io"
-msgstr ""
-
-#: src/Content/ContactSelector.php:127
-msgid "Twitter"
-msgstr ""
-
-#: src/Content/ContactSelector.php:129
-msgid "Diaspora Connector"
-msgstr ""
-
-#: src/Content/ContactSelector.php:130
-msgid "GNU Social Connector"
-msgstr ""
-
-#: src/Content/ContactSelector.php:131
-msgid "ActivityPub"
-msgstr ""
-
-#: src/Content/ContactSelector.php:132
-msgid "pnut"
-msgstr ""
-
-#: src/Content/ContactSelector.php:166
-#, php-format
-msgid "%s (via %s)"
-msgstr ""
-
-#: src/Content/ContactSelector.php:235 src/Content/ContactSelector.php:275
-#: src/Content/ContactSelector.php:313
-msgid "No answer"
-msgstr ""
-
-#: src/Content/ContactSelector.php:236
-msgid "Male"
-msgstr ""
-
-#: src/Content/ContactSelector.php:237
-msgid "Female"
-msgstr ""
-
-#: src/Content/ContactSelector.php:238
-msgid "Currently Male"
-msgstr ""
-
-#: src/Content/ContactSelector.php:239
-msgid "Currently Female"
-msgstr ""
-
-#: src/Content/ContactSelector.php:240
-msgid "Mostly Male"
-msgstr ""
-
-#: src/Content/ContactSelector.php:241
-msgid "Mostly Female"
-msgstr ""
-
-#: src/Content/ContactSelector.php:242
-msgid "Transgender"
-msgstr ""
-
-#: src/Content/ContactSelector.php:243
-msgid "Intersex"
-msgstr ""
-
-#: src/Content/ContactSelector.php:244
-msgid "Transsexual"
-msgstr ""
-
-#: src/Content/ContactSelector.php:245
-msgid "Hermaphrodite"
-msgstr ""
-
-#: src/Content/ContactSelector.php:246
-msgid "Neuter"
-msgstr ""
-
-#: src/Content/ContactSelector.php:247
-msgid "Non-specific"
-msgstr ""
-
-#: src/Content/ContactSelector.php:248 src/Module/Admin/Federation.php:34
-msgid "Other"
-msgstr ""
-
-#: src/Content/ContactSelector.php:276
-msgid "Males"
-msgstr ""
-
-#: src/Content/ContactSelector.php:277
-msgid "Females"
-msgstr ""
-
-#: src/Content/ContactSelector.php:278
-msgid "Gay"
-msgstr ""
-
-#: src/Content/ContactSelector.php:279
-msgid "Lesbian"
-msgstr ""
-
-#: src/Content/ContactSelector.php:280
-msgid "No Preference"
-msgstr ""
-
-#: src/Content/ContactSelector.php:281
-msgid "Bisexual"
-msgstr ""
-
-#: src/Content/ContactSelector.php:282
-msgid "Autosexual"
-msgstr ""
-
-#: src/Content/ContactSelector.php:283
-msgid "Abstinent"
-msgstr ""
-
-#: src/Content/ContactSelector.php:284
-msgid "Virgin"
-msgstr ""
-
-#: src/Content/ContactSelector.php:285
-msgid "Deviant"
-msgstr ""
-
-#: src/Content/ContactSelector.php:286
-msgid "Fetish"
-msgstr ""
-
-#: src/Content/ContactSelector.php:287
-msgid "Oodles"
-msgstr ""
-
-#: src/Content/ContactSelector.php:288
-msgid "Nonsexual"
-msgstr ""
-
-#: src/Content/ContactSelector.php:314
-msgid "Single"
-msgstr ""
-
-#: src/Content/ContactSelector.php:315
-msgid "Lonely"
-msgstr ""
-
-#: src/Content/ContactSelector.php:316
-msgid "In a relation"
-msgstr ""
-
-#: src/Content/ContactSelector.php:317
-msgid "Has crush"
-msgstr ""
-
-#: src/Content/ContactSelector.php:318
-msgid "Infatuated"
-msgstr ""
-
-#: src/Content/ContactSelector.php:319
-msgid "Dating"
-msgstr ""
-
-#: src/Content/ContactSelector.php:320
-msgid "Unfaithful"
-msgstr ""
-
-#: src/Content/ContactSelector.php:321
-msgid "Sex Addict"
-msgstr ""
-
-#: src/Content/ContactSelector.php:322 src/Model/User.php:805
-msgid "Friends"
-msgstr ""
-
-#: src/Content/ContactSelector.php:323
-msgid "Friends/Benefits"
-msgstr ""
-
-#: src/Content/ContactSelector.php:324
-msgid "Casual"
-msgstr ""
-
-#: src/Content/ContactSelector.php:325
-msgid "Engaged"
-msgstr ""
-
-#: src/Content/ContactSelector.php:326
-msgid "Married"
-msgstr ""
-
-#: src/Content/ContactSelector.php:327
-msgid "Imaginarily married"
-msgstr ""
-
-#: src/Content/ContactSelector.php:328
-msgid "Partners"
-msgstr ""
-
-#: src/Content/ContactSelector.php:329
-msgid "Cohabiting"
-msgstr ""
-
-#: src/Content/ContactSelector.php:330
-msgid "Common law"
-msgstr ""
-
-#: src/Content/ContactSelector.php:331
-msgid "Happy"
-msgstr ""
-
-#: src/Content/ContactSelector.php:332
-msgid "Not looking"
-msgstr ""
-
-#: src/Content/ContactSelector.php:333
-msgid "Swinger"
-msgstr ""
-
-#: src/Content/ContactSelector.php:334
-msgid "Betrayed"
-msgstr ""
-
-#: src/Content/ContactSelector.php:335
-msgid "Separated"
-msgstr ""
-
-#: src/Content/ContactSelector.php:336
-msgid "Unstable"
-msgstr ""
-
-#: src/Content/ContactSelector.php:337
-msgid "Divorced"
-msgstr ""
-
-#: src/Content/ContactSelector.php:338
-msgid "Imaginarily divorced"
-msgstr ""
-
-#: src/Content/ContactSelector.php:339
-msgid "Widowed"
-msgstr ""
-
-#: src/Content/ContactSelector.php:340
-msgid "Uncertain"
-msgstr ""
-
-#: src/Content/ContactSelector.php:341
-msgid "It's complicated"
-msgstr ""
-
-#: src/Content/ContactSelector.php:342
-msgid "Don't care"
-msgstr ""
-
-#: src/Content/ContactSelector.php:343
-msgid "Ask me"
-msgstr ""
-
-#: src/Content/Widget.php:36
-msgid "Add New Contact"
-msgstr ""
-
-#: src/Content/Widget.php:37
-msgid "Enter address or web location"
-msgstr ""
-
-#: src/Content/Widget.php:38
-msgid "Example: bob@example.com, http://example.com/barbara"
-msgstr ""
-
-#: src/Content/Widget.php:40 src/Module/BaseSearchModule.php:130
-#: src/Module/AllFriends.php:91 mod/match.php:101 mod/suggest.php:105
-msgid "Connect"
-msgstr ""
-
-#: src/Content/Widget.php:55
-#, php-format
-msgid "%d invitation available"
-msgid_plural "%d invitations available"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/Content/Widget.php:193 src/Core/ACL.php:269
-#: src/Module/Profile/Contacts.php:126 src/Module/Contact.php:795
-#: mod/lockview.php:75 mod/lockview.php:110
-msgid "Followers"
-msgstr ""
-
-#: src/Content/Widget.php:194 src/Module/Profile/Contacts.php:127
-#: src/Module/Contact.php:796
-msgid "Following"
-msgstr ""
-
-#: src/Content/Widget.php:195 src/Module/Profile/Contacts.php:128
-#: src/Module/Contact.php:797
-msgid "Mutual friends"
-msgstr ""
-
-#: src/Content/Widget.php:200
-msgid "Relationships"
-msgstr ""
-
-#: src/Content/Widget.php:202 src/Module/Group.php:280
-#: src/Module/Contact.php:684
-msgid "All Contacts"
-msgstr ""
-
-#: src/Content/Widget.php:245
-msgid "Protocols"
-msgstr ""
-
-#: src/Content/Widget.php:247
-msgid "All Protocols"
-msgstr ""
-
-#: src/Content/Widget.php:284
-msgid "Saved Folders"
-msgstr ""
-
-#: src/Content/Widget.php:286 src/Content/Widget.php:325
-msgid "Everything"
-msgstr ""
-
-#: src/Content/Widget.php:323
-msgid "Categories"
-msgstr ""
-
-#: src/Content/Widget.php:400
-#, php-format
-msgid "%d contact in common"
-msgid_plural "%d contacts in common"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/Content/Widget.php:499 src/Content/Feature.php:99
-msgid "Archives"
-msgstr ""
-
-#: src/Content/OEmbed.php:253
-msgid "Embedding disabled"
-msgstr ""
-
-#: src/Content/OEmbed.php:376
-msgid "Embedded content"
-msgstr ""
-
-#: src/Content/Feature.php:81
-msgid "General Features"
-msgstr ""
-
-#: src/Content/Feature.php:83
-msgid "Multiple Profiles"
-msgstr ""
-
-#: src/Content/Feature.php:83
-msgid "Ability to create multiple profiles"
-msgstr ""
-
-#: src/Content/Feature.php:84
-msgid "Photo Location"
-msgstr ""
-
-#: src/Content/Feature.php:84
+#: src/Core/ACL.php:387
 msgid ""
-"Photo metadata is normally stripped. This extracts the location (if present) "
-"prior to stripping metadata and links it to a map."
+"This content will be shown only to the people in the first box, to the "
+"exception of the people mentioned in the second box. It won't appear "
+"anywhere public."
 msgstr ""
 
-#: src/Content/Feature.php:85
-msgid "Export Public Calendar"
+#: src/Core/ACL.php:388
+msgid "Show to:"
 msgstr ""
 
-#: src/Content/Feature.php:85
-msgid "Ability for visitors to download the public calendar"
+#: src/Core/ACL.php:389
+msgid "Except to:"
 msgstr ""
 
-#: src/Content/Feature.php:86
-msgid "Trending Tags"
+#: src/Core/ACL.php:392
+msgid "Connectors"
 msgstr ""
 
-#: src/Content/Feature.php:86
+#: src/Core/ACL.php:393
+msgid "Hide your profile details from unknown viewers?"
+msgstr ""
+
+#: src/Core/ACL.php:393
+#, php-format
+msgid "Connectors disabled, since \"%s\" is enabled."
+msgstr ""
+
+#: src/Core/Installer.php:163
 msgid ""
-"Show a community page widget with a list of the most popular tags in recent "
-"public posts."
+"The database configuration file \"config/local.config.php\" could not be "
+"written. Please use the enclosed text to create a configuration file in your "
+"web server root."
 msgstr ""
 
-#: src/Content/Feature.php:91
-msgid "Post Composition Features"
-msgstr ""
-
-#: src/Content/Feature.php:92
-msgid "Auto-mention Forums"
-msgstr ""
-
-#: src/Content/Feature.php:92
+#: src/Core/Installer.php:182
 msgid ""
-"Add/remove mention when a forum page is selected/deselected in ACL window."
+"You may need to import the file \"database.sql\" manually using phpmyadmin "
+"or mysql."
 msgstr ""
 
-#: src/Content/Feature.php:93
-msgid "Explicit Mentions"
+#: src/Core/Installer.php:183 src/Module/Install.php:172
+#: src/Module/Install.php:326
+msgid "Please see the file \"INSTALL.txt\"."
 msgstr ""
 
-#: src/Content/Feature.php:93
+#: src/Core/Installer.php:244
+msgid "Could not find a command line version of PHP in the web server PATH."
+msgstr ""
+
+#: src/Core/Installer.php:245
 msgid ""
-"Add explicit mentions to comment box for manual control over who gets "
-"mentioned in replies."
+"If you don't have a command line version of PHP installed on your server, "
+"you will not be able to run the background processing. See <a href='https://"
+"github.com/friendica/friendica/blob/master/doc/Install.md#set-up-the-"
+"worker'>'Setup the worker'</a>"
 msgstr ""
 
-#: src/Content/Feature.php:98
-msgid "Network Sidebar"
+#: src/Core/Installer.php:250
+msgid "PHP executable path"
 msgstr ""
 
-#: src/Content/Feature.php:99
-msgid "Ability to select posts by date ranges"
+#: src/Core/Installer.php:250
+msgid ""
+"Enter full path to php executable. You can leave this blank to continue the "
+"installation."
 msgstr ""
 
-#: src/Content/Feature.php:100
-msgid "Protocol Filter"
+#: src/Core/Installer.php:255
+msgid "Command line PHP"
 msgstr ""
 
-#: src/Content/Feature.php:100
-msgid "Enable widget to display Network posts only from selected protocols"
+#: src/Core/Installer.php:264
+msgid "PHP executable is not the php cli binary (could be cgi-fgci version)"
 msgstr ""
 
-#: src/Content/Feature.php:105
-msgid "Network Tabs"
+#: src/Core/Installer.php:265
+msgid "Found PHP version: "
 msgstr ""
 
-#: src/Content/Feature.php:106
-msgid "Network New Tab"
+#: src/Core/Installer.php:267
+msgid "PHP cli binary"
 msgstr ""
 
-#: src/Content/Feature.php:106
-msgid "Enable tab to display only new Network posts (from the last 12 hours)"
+#: src/Core/Installer.php:280
+msgid ""
+"The command line version of PHP on your system does not have "
+"\"register_argc_argv\" enabled."
 msgstr ""
 
-#: src/Content/Feature.php:107
-msgid "Network Shared Links Tab"
+#: src/Core/Installer.php:281
+msgid "This is required for message delivery to work."
 msgstr ""
 
-#: src/Content/Feature.php:107
-msgid "Enable tab to display only Network posts with links in them"
+#: src/Core/Installer.php:286
+msgid "PHP register_argc_argv"
 msgstr ""
 
-#: src/Content/Feature.php:112
-msgid "Post/Comment Tools"
+#: src/Core/Installer.php:318
+msgid ""
+"Error: the \"openssl_pkey_new\" function on this system is not able to "
+"generate encryption keys"
 msgstr ""
 
-#: src/Content/Feature.php:113
-msgid "Post Categories"
+#: src/Core/Installer.php:319
+msgid ""
+"If running under Windows, please see \"http://www.php.net/manual/en/openssl."
+"installation.php\"."
 msgstr ""
 
-#: src/Content/Feature.php:113
-msgid "Add categories to your posts"
+#: src/Core/Installer.php:322
+msgid "Generate encryption keys"
 msgstr ""
 
-#: src/Content/Feature.php:118
-msgid "Advanced Profile Settings"
+#: src/Core/Installer.php:374
+msgid ""
+"Error: Apache webserver mod-rewrite module is required but not installed."
 msgstr ""
 
-#: src/Content/Feature.php:119
-msgid "List Forums"
+#: src/Core/Installer.php:379
+msgid "Apache mod_rewrite module"
 msgstr ""
 
-#: src/Content/Feature.php:119
-msgid "Show visitors public community forums at the Advanced Profile Page"
+#: src/Core/Installer.php:385
+msgid "Error: PDO or MySQLi PHP module required but not installed."
 msgstr ""
 
-#: src/Content/Feature.php:120
-msgid "Tag Cloud"
+#: src/Core/Installer.php:390
+msgid "Error: The MySQL driver for PDO is not installed."
 msgstr ""
 
-#: src/Content/Feature.php:120
-msgid "Provide a personal tag cloud on your profile page"
+#: src/Core/Installer.php:394
+msgid "PDO or MySQLi PHP module"
 msgstr ""
 
-#: src/Content/Feature.php:121
-msgid "Display Membership Date"
+#: src/Core/Installer.php:402
+msgid "Error, XML PHP module required but not installed."
 msgstr ""
 
-#: src/Content/Feature.php:121
-msgid "Display membership date in profile"
+#: src/Core/Installer.php:406
+msgid "XML PHP module"
 msgstr ""
 
-#: src/Content/Nav.php:73
-msgid "Nothing new here"
+#: src/Core/Installer.php:409
+msgid "libCurl PHP module"
 msgstr ""
 
-#: src/Content/Nav.php:77
-msgid "Clear notifications"
+#: src/Core/Installer.php:410
+msgid "Error: libCURL PHP module required but not installed."
 msgstr ""
 
-#: src/Content/Nav.php:152 src/Module/Security/Login.php:129
-msgid "Logout"
+#: src/Core/Installer.php:416
+msgid "GD graphics PHP module"
 msgstr ""
 
-#: src/Content/Nav.php:152
-msgid "End this session"
+#: src/Core/Installer.php:417
+msgid ""
+"Error: GD graphics PHP module with JPEG support required but not installed."
 msgstr ""
 
-#: src/Content/Nav.php:154 src/Module/Security/Login.php:130
-#: src/Module/Bookmarklet.php:26
-msgid "Login"
+#: src/Core/Installer.php:423
+msgid "OpenSSL PHP module"
 msgstr ""
 
-#: src/Content/Nav.php:154
-msgid "Sign in"
+#: src/Core/Installer.php:424
+msgid "Error: openssl PHP module required but not installed."
 msgstr ""
 
-#: src/Content/Nav.php:164
-msgid "Personal notes"
+#: src/Core/Installer.php:430
+msgid "mb_string PHP module"
 msgstr ""
 
-#: src/Content/Nav.php:164
-msgid "Your personal notes"
+#: src/Core/Installer.php:431
+msgid "Error: mb_string PHP module required but not installed."
 msgstr ""
 
-#: src/Content/Nav.php:181 src/Content/Nav.php:242
-msgid "Home"
+#: src/Core/Installer.php:437
+msgid "iconv PHP module"
 msgstr ""
 
-#: src/Content/Nav.php:181
-msgid "Home Page"
+#: src/Core/Installer.php:438
+msgid "Error: iconv PHP module required but not installed."
 msgstr ""
 
-#: src/Content/Nav.php:185 src/Module/Security/Login.php:90
-#: src/Module/Register.php:137
-msgid "Register"
+#: src/Core/Installer.php:444
+msgid "POSIX PHP module"
 msgstr ""
 
-#: src/Content/Nav.php:185
-msgid "Create an account"
+#: src/Core/Installer.php:445
+msgid "Error: POSIX PHP module required but not installed."
 msgstr ""
 
-#: src/Content/Nav.php:191
-msgid "Help and documentation"
+#: src/Core/Installer.php:451
+msgid "JSON PHP module"
 msgstr ""
 
-#: src/Content/Nav.php:195
-msgid "Apps"
+#: src/Core/Installer.php:452
+msgid "Error: JSON PHP module required but not installed."
 msgstr ""
 
-#: src/Content/Nav.php:195
-msgid "Addon applications, utilities, games"
+#: src/Core/Installer.php:458
+msgid "File Information PHP module"
 msgstr ""
 
-#: src/Content/Nav.php:199
-msgid "Search site content"
+#: src/Core/Installer.php:459
+msgid "Error: File Information PHP module required but not installed."
 msgstr ""
 
-#: src/Content/Nav.php:223
-msgid "Community"
+#: src/Core/Installer.php:482
+msgid ""
+"The web installer needs to be able to create a file called \"local.config.php"
+"\" in the \"config\" folder of your web server and it is unable to do so."
 msgstr ""
 
-#: src/Content/Nav.php:223
-msgid "Conversations on this and other servers"
+#: src/Core/Installer.php:483
+msgid ""
+"This is most often a permission setting, as the web server may not be able "
+"to write files in your folder - even if you can."
 msgstr ""
 
-#: src/Content/Nav.php:230
-msgid "Directory"
+#: src/Core/Installer.php:484
+msgid ""
+"At the end of this procedure, we will give you a text to save in a file "
+"named local.config.php in your Friendica \"config\" folder."
 msgstr ""
 
-#: src/Content/Nav.php:230
-msgid "People directory"
+#: src/Core/Installer.php:485
+msgid ""
+"You can alternatively skip this procedure and perform a manual installation. "
+"Please see the file \"INSTALL.txt\" for instructions."
 msgstr ""
 
-#: src/Content/Nav.php:232
-msgid "Information about this friendica instance"
+#: src/Core/Installer.php:488
+msgid "config/local.config.php is writable"
 msgstr ""
 
-#: src/Content/Nav.php:235 src/Module/Tos.php:72
-#: src/Module/BaseAdminModule.php:83 src/Module/Admin/Tos.php:43
-#: src/Module/Register.php:145
-msgid "Terms of Service"
+#: src/Core/Installer.php:508
+msgid ""
+"Friendica uses the Smarty3 template engine to render its web views. Smarty3 "
+"compiles templates to PHP to speed up rendering."
 msgstr ""
 
-#: src/Content/Nav.php:235
-msgid "Terms of Service of this Friendica instance"
+#: src/Core/Installer.php:509
+msgid ""
+"In order to store these compiled templates, the web server needs to have "
+"write access to the directory view/smarty3/ under the Friendica top level "
+"folder."
 msgstr ""
 
-#: src/Content/Nav.php:246
-msgid "Introductions"
+#: src/Core/Installer.php:510
+msgid ""
+"Please ensure that the user that your web server runs as (e.g. www-data) has "
+"write access to this folder."
 msgstr ""
 
-#: src/Content/Nav.php:246
-msgid "Friend Requests"
+#: src/Core/Installer.php:511
+msgid ""
+"Note: as a security measure, you should give the web server write access to "
+"view/smarty3/ only--not the template files (.tpl) that it contains."
 msgstr ""
 
-#: src/Content/Nav.php:247 mod/notifications.php:72
-msgid "Notifications"
+#: src/Core/Installer.php:514
+msgid "view/smarty3 is writable"
 msgstr ""
 
-#: src/Content/Nav.php:248
-msgid "See all notifications"
+#: src/Core/Installer.php:543
+msgid ""
+"Url rewrite in .htaccess is not working. Make sure you copied .htaccess-dist "
+"to .htaccess."
 msgstr ""
 
-#: src/Content/Nav.php:249 mod/settings.php:867
-msgid "Mark as seen"
+#: src/Core/Installer.php:545
+msgid "Error message from Curl when fetching"
 msgstr ""
 
-#: src/Content/Nav.php:249
-msgid "Mark all system notifications seen"
+#: src/Core/Installer.php:550
+msgid "Url rewrite is working"
 msgstr ""
 
-#: src/Content/Nav.php:253
-msgid "Inbox"
+#: src/Core/Installer.php:579
+msgid "ImageMagick PHP extension is not installed"
 msgstr ""
 
-#: src/Content/Nav.php:254
-msgid "Outbox"
+#: src/Core/Installer.php:581
+msgid "ImageMagick PHP extension is installed"
 msgstr ""
 
-#: src/Content/Nav.php:255 mod/message.php:31 mod/message.php:114
-msgid "New Message"
+#: src/Core/Installer.php:583 tests/src/Core/InstallerTest.php:367
+#: tests/src/Core/InstallerTest.php:390
+msgid "ImageMagick supports GIF"
 msgstr ""
 
-#: src/Content/Nav.php:258
-msgid "Delegation"
+#: src/Core/Installer.php:605
+msgid "Database already in use."
 msgstr ""
 
-#: src/Content/Nav.php:258
-msgid "Manage other pages"
+#: src/Core/Installer.php:610
+msgid "Could not connect to database."
 msgstr ""
 
-#: src/Content/Nav.php:264 src/Model/Profile.php:397
-#: src/Module/BaseSettingsModule.php:38 mod/settings.php:77
-msgid "Profiles"
-msgstr ""
-
-#: src/Content/Nav.php:264
-msgid "Manage/Edit Profiles"
-msgstr ""
-
-#: src/Content/Nav.php:272 src/Module/BaseAdminModule.php:112
-msgid "Admin"
-msgstr ""
-
-#: src/Content/Nav.php:272
-msgid "Site setup and configuration"
-msgstr ""
-
-#: src/Content/Nav.php:275
-msgid "Navigation"
-msgstr ""
-
-#: src/Content/Nav.php:275
-msgid "Site map"
-msgstr ""
-
-#: src/Content/Widget/SavedSearches.php:29
-msgid "Remove term"
-msgstr ""
-
-#: src/Content/Widget/SavedSearches.php:37
-msgid "Saved Searches"
-msgstr ""
-
-#: src/Content/Widget/CalendarExport.php:64
-msgid "Export"
-msgstr ""
-
-#: src/Content/Widget/CalendarExport.php:65
-msgid "Export calendar as ical"
-msgstr ""
-
-#: src/Content/Widget/CalendarExport.php:66
-msgid "Export calendar as csv"
-msgstr ""
-
-#: src/Content/Widget/TrendingTags.php:32
-#, php-format
-msgid "Trending Tags (last %d hour)"
-msgid_plural "Trending Tags (last %d hours)"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/Content/Widget/TrendingTags.php:33
-msgid "More Trending Tags"
-msgstr ""
-
-#: src/Content/Widget/ContactBlock.php:57
-msgid "No contacts"
-msgstr ""
-
-#: src/Content/Widget/ContactBlock.php:89
-#, php-format
-msgid "%d Contact"
-msgid_plural "%d Contacts"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/Content/Widget/ContactBlock.php:108
-msgid "View Contacts"
-msgstr ""
-
-#: src/Content/Pager.php:153
-msgid "newer"
-msgstr ""
-
-#: src/Content/Pager.php:158
-msgid "older"
-msgstr ""
-
-#: src/Content/Pager.php:198 mod/match.php:114
-msgid "first"
-msgstr ""
-
-#: src/Content/Pager.php:203
-msgid "prev"
-msgstr ""
-
-#: src/Content/Pager.php:258 mod/match.php:119
-msgid "next"
-msgstr ""
-
-#: src/Content/Pager.php:263
-msgid "last"
-msgstr ""
-
-#: src/Model/Profile.php:210 src/Model/Profile.php:423
-#: src/Model/Profile.php:880
-msgid "Edit profile"
-msgstr ""
-
-#: src/Model/Profile.php:397
-msgid "Manage/edit profiles"
-msgstr ""
-
-#: src/Model/Profile.php:404 src/Model/Profile.php:425 mod/profiles.php:667
-msgid "Change profile photo"
-msgstr ""
-
-#: src/Model/Profile.php:405 mod/profiles.php:668
-msgid "Create New Profile"
-msgstr ""
-
-#: src/Model/Profile.php:414 mod/profiles.php:657
-msgid "Profile Image"
-msgstr ""
-
-#: src/Model/Profile.php:417 mod/profiles.php:659
-msgid "visible to everybody"
-msgstr ""
-
-#: src/Model/Profile.php:418 mod/profiles.php:565 mod/profiles.php:660
-msgid "Edit visibility"
-msgstr ""
-
-#: src/Model/Profile.php:442 src/Model/Event.php:67 src/Model/Event.php:94
-#: src/Model/Event.php:436 src/Model/Event.php:932 src/Module/Directory.php:135
-#: src/Module/Contact.php:627 mod/events.php:539 mod/notifications.php:248
-msgid "Location:"
-msgstr ""
-
-#: src/Model/Profile.php:445 src/Model/Profile.php:766
-#: src/Module/Directory.php:140 mod/notifications.php:254
-msgid "Gender:"
-msgstr ""
-
-#: src/Model/Profile.php:446 src/Model/Profile.php:790
-#: src/Module/Directory.php:141
-msgid "Status:"
-msgstr ""
-
-#: src/Model/Profile.php:447 src/Model/Profile.php:807
-#: src/Module/Directory.php:142
-msgid "Homepage:"
-msgstr ""
-
-#: src/Model/Profile.php:448 src/Model/Profile.php:827
-#: src/Module/Directory.php:143 src/Module/Contact.php:631
-#: mod/notifications.php:250
-msgid "About:"
-msgstr ""
-
-#: src/Model/Profile.php:449 src/Module/Contact.php:629
-msgid "XMPP:"
-msgstr ""
-
-#: src/Model/Profile.php:541 src/Module/Contact.php:319
-msgid "Unfollow"
-msgstr ""
-
-#: src/Model/Profile.php:543
-msgid "Atom feed"
-msgstr ""
-
-#: src/Model/Profile.php:553 src/Module/Contact.php:315
-#: mod/notifications.php:261
-msgid "Network:"
-msgstr ""
-
-#: src/Model/Profile.php:583 src/Model/Profile.php:680
-msgid "g A l F d"
-msgstr ""
-
-#: src/Model/Profile.php:584
-msgid "F d"
-msgstr ""
-
-#: src/Model/Profile.php:646 src/Model/Profile.php:731
-msgid "[today]"
-msgstr ""
-
-#: src/Model/Profile.php:656
-msgid "Birthday Reminders"
-msgstr ""
-
-#: src/Model/Profile.php:657
-msgid "Birthdays this week:"
-msgstr ""
-
-#: src/Model/Profile.php:718
-msgid "[No description]"
-msgstr ""
-
-#: src/Model/Profile.php:744
-msgid "Event Reminders"
-msgstr ""
-
-#: src/Model/Profile.php:745
-msgid "Upcoming events the next 7 days:"
-msgstr ""
-
-#: src/Model/Profile.php:759 mod/settings.php:1189
-msgid "Full Name:"
-msgstr ""
-
-#: src/Model/Profile.php:770
-msgid "j F, Y"
-msgstr ""
-
-#: src/Model/Profile.php:771
-msgid "j F"
-msgstr ""
-
-#: src/Model/Profile.php:779 src/Util/Temporal.php:145
-msgid "Birthday:"
-msgstr ""
-
-#: src/Model/Profile.php:786
-msgid "Age:"
-msgstr ""
-
-#: src/Model/Profile.php:799
-#, php-format
-msgid "for %1$d %2$s"
-msgstr ""
-
-#: src/Model/Profile.php:803 mod/profiles.php:584
-msgid "Sexual Preference:"
-msgstr ""
-
-#: src/Model/Profile.php:811 mod/profiles.php:611
-msgid "Hometown:"
-msgstr ""
-
-#: src/Model/Profile.php:815 src/Module/Contact.php:633
-#: mod/notifications.php:252 mod/follow.php:182
-msgid "Tags:"
-msgstr ""
-
-#: src/Model/Profile.php:819 mod/profiles.php:612
-msgid "Political Views:"
-msgstr ""
-
-#: src/Model/Profile.php:823
-msgid "Religion:"
-msgstr ""
-
-#: src/Model/Profile.php:831
-msgid "Hobbies/Interests:"
-msgstr ""
-
-#: src/Model/Profile.php:835 mod/profiles.php:616
-msgid "Likes:"
-msgstr ""
-
-#: src/Model/Profile.php:839 mod/profiles.php:617
-msgid "Dislikes:"
-msgstr ""
-
-#: src/Model/Profile.php:843
-msgid "Contact information and Social Networks:"
-msgstr ""
-
-#: src/Model/Profile.php:847
-msgid "Musical interests:"
-msgstr ""
-
-#: src/Model/Profile.php:851
-msgid "Books, literature:"
-msgstr ""
-
-#: src/Model/Profile.php:855
-msgid "Television:"
-msgstr ""
-
-#: src/Model/Profile.php:859
-msgid "Film/dance/culture/entertainment:"
-msgstr ""
-
-#: src/Model/Profile.php:863
-msgid "Love/Romance:"
-msgstr ""
-
-#: src/Model/Profile.php:867
-msgid "Work/employment:"
-msgstr ""
-
-#: src/Model/Profile.php:871
-msgid "School/education:"
-msgstr ""
-
-#: src/Model/Profile.php:876
-msgid "Forums:"
-msgstr ""
-
-#: src/Model/Profile.php:885 mod/events.php:552
-msgid "Basic"
-msgstr ""
-
-#: src/Model/Profile.php:886 src/Module/Admin/Site.php:562
-#: src/Module/Contact.php:904 mod/events.php:553
-msgid "Advanced"
-msgstr ""
-
-#: src/Model/Profile.php:915 src/Module/Contact.php:866 mod/follow.php:194
-#: mod/unfollow.php:146
-msgid "Status Messages and Posts"
-msgstr ""
-
-#: src/Model/Profile.php:923 src/Module/Contact.php:874
-msgid "Profile Details"
-msgstr ""
-
-#: src/Model/Profile.php:931 mod/photos.php:110
-msgid "Photo Albums"
-msgstr ""
-
-#: src/Model/Profile.php:970 mod/notes.php:34
-msgid "Personal Notes"
-msgstr ""
-
-#: src/Model/Profile.php:973
-msgid "Only You Can See This"
-msgstr ""
-
-#: src/Model/Profile.php:1177
-#, php-format
-msgid "OpenWebAuth: %1$s welcomes %2$s"
-msgstr ""
-
-#: src/Model/Event.php:33 src/Model/Event.php:846
-#: src/Module/Debug/Localtime.php:17
-msgid "l F d, Y \\@ g:i A"
-msgstr ""
-
-#: src/Model/Event.php:60 src/Model/Event.php:77 src/Model/Event.php:434
-#: src/Model/Event.php:914
-msgid "Starts:"
-msgstr ""
-
-#: src/Model/Event.php:63 src/Model/Event.php:83 src/Model/Event.php:435
-#: src/Model/Event.php:918
-msgid "Finishes:"
-msgstr ""
-
-#: src/Model/Event.php:384
-msgid "all-day"
-msgstr ""
-
-#: src/Model/Event.php:386 src/Core/L10n.php:369
-msgid "Sun"
-msgstr ""
-
-#: src/Model/Event.php:387 src/Core/L10n.php:369
-msgid "Mon"
-msgstr ""
-
-#: src/Model/Event.php:388 src/Core/L10n.php:369
-msgid "Tue"
-msgstr ""
-
-#: src/Model/Event.php:389 src/Core/L10n.php:369
-msgid "Wed"
-msgstr ""
-
-#: src/Model/Event.php:390 src/Core/L10n.php:369
-msgid "Thu"
-msgstr ""
-
-#: src/Model/Event.php:391 src/Core/L10n.php:369
-msgid "Fri"
-msgstr ""
-
-#: src/Model/Event.php:392 src/Core/L10n.php:369
-msgid "Sat"
-msgstr ""
-
-#: src/Model/Event.php:394 src/Core/L10n.php:349 mod/settings.php:930
-msgid "Sunday"
-msgstr ""
-
-#: src/Model/Event.php:395 src/Core/L10n.php:349 mod/settings.php:930
-msgid "Monday"
-msgstr ""
-
-#: src/Model/Event.php:396 src/Core/L10n.php:349
+#: src/Core/L10n.php:349 src/Model/Event.php:396
 msgid "Tuesday"
 msgstr ""
 
-#: src/Model/Event.php:397 src/Core/L10n.php:349
+#: src/Core/L10n.php:349 src/Model/Event.php:397
 msgid "Wednesday"
 msgstr ""
 
-#: src/Model/Event.php:398 src/Core/L10n.php:349
+#: src/Core/L10n.php:349 src/Model/Event.php:398
 msgid "Thursday"
 msgstr ""
 
-#: src/Model/Event.php:399 src/Core/L10n.php:349
+#: src/Core/L10n.php:349 src/Model/Event.php:399
 msgid "Friday"
 msgstr ""
 
-#: src/Model/Event.php:400 src/Core/L10n.php:349
+#: src/Core/L10n.php:349 src/Model/Event.php:400
 msgid "Saturday"
 msgstr ""
 
-#: src/Model/Event.php:402 src/Core/L10n.php:373
-msgid "Jan"
-msgstr ""
-
-#: src/Model/Event.php:403 src/Core/L10n.php:373
-msgid "Feb"
-msgstr ""
-
-#: src/Model/Event.php:404 src/Core/L10n.php:373
-msgid "Mar"
-msgstr ""
-
-#: src/Model/Event.php:405 src/Core/L10n.php:373
-msgid "Apr"
-msgstr ""
-
-#: src/Model/Event.php:406 src/Core/L10n.php:353 src/Core/L10n.php:373
-msgid "May"
-msgstr ""
-
-#: src/Model/Event.php:407 src/Core/L10n.php:373
-msgid "Jun"
-msgstr ""
-
-#: src/Model/Event.php:408 src/Core/L10n.php:373
-msgid "Jul"
-msgstr ""
-
-#: src/Model/Event.php:409 src/Core/L10n.php:373
-msgid "Aug"
-msgstr ""
-
-#: src/Model/Event.php:410
-msgid "Sept"
-msgstr ""
-
-#: src/Model/Event.php:411 src/Core/L10n.php:373
-msgid "Oct"
-msgstr ""
-
-#: src/Model/Event.php:412 src/Core/L10n.php:373
-msgid "Nov"
-msgstr ""
-
-#: src/Model/Event.php:413 src/Core/L10n.php:373
-msgid "Dec"
-msgstr ""
-
-#: src/Model/Event.php:415 src/Core/L10n.php:353
+#: src/Core/L10n.php:353 src/Model/Event.php:415
 msgid "January"
 msgstr ""
 
-#: src/Model/Event.php:416 src/Core/L10n.php:353
+#: src/Core/L10n.php:353 src/Model/Event.php:416
 msgid "February"
 msgstr ""
 
-#: src/Model/Event.php:417 src/Core/L10n.php:353
+#: src/Core/L10n.php:353 src/Model/Event.php:417
 msgid "March"
 msgstr ""
 
-#: src/Model/Event.php:418 src/Core/L10n.php:353
+#: src/Core/L10n.php:353 src/Model/Event.php:418
 msgid "April"
 msgstr ""
 
-#: src/Model/Event.php:419 src/Core/L10n.php:353
+#: src/Core/L10n.php:353 src/Core/L10n.php:373 src/Model/Event.php:406
+msgid "May"
+msgstr ""
+
+#: src/Core/L10n.php:353 src/Model/Event.php:419
 msgid "June"
 msgstr ""
 
-#: src/Model/Event.php:420 src/Core/L10n.php:353
+#: src/Core/L10n.php:353 src/Model/Event.php:420
 msgid "July"
 msgstr ""
 
-#: src/Model/Event.php:421 src/Core/L10n.php:353
+#: src/Core/L10n.php:353 src/Model/Event.php:421
 msgid "August"
 msgstr ""
 
-#: src/Model/Event.php:422 src/Core/L10n.php:353
+#: src/Core/L10n.php:353 src/Model/Event.php:422
 msgid "September"
 msgstr ""
 
-#: src/Model/Event.php:423 src/Core/L10n.php:353
+#: src/Core/L10n.php:353 src/Model/Event.php:423
 msgid "October"
 msgstr ""
 
-#: src/Model/Event.php:424 src/Core/L10n.php:353
+#: src/Core/L10n.php:353 src/Model/Event.php:424
 msgid "November"
 msgstr ""
 
-#: src/Model/Event.php:425 src/Core/L10n.php:353
+#: src/Core/L10n.php:353 src/Model/Event.php:425
 msgid "December"
 msgstr ""
 
-#: src/Model/Event.php:427 mod/events.php:402 mod/cal.php:264
-msgid "today"
+#: src/Core/L10n.php:369 src/Model/Event.php:387
+msgid "Mon"
 msgstr ""
 
-#: src/Model/Event.php:428 src/Util/Temporal.php:312 mod/events.php:403
-#: mod/cal.php:265
-msgid "month"
+#: src/Core/L10n.php:369 src/Model/Event.php:388
+msgid "Tue"
 msgstr ""
 
-#: src/Model/Event.php:429 src/Util/Temporal.php:313 mod/events.php:404
-#: mod/cal.php:266
-msgid "week"
+#: src/Core/L10n.php:369 src/Model/Event.php:389
+msgid "Wed"
 msgstr ""
 
-#: src/Model/Event.php:430 src/Util/Temporal.php:314 mod/events.php:405
-#: mod/cal.php:267
-msgid "day"
+#: src/Core/L10n.php:369 src/Model/Event.php:390
+msgid "Thu"
 msgstr ""
 
-#: src/Model/Event.php:432
-msgid "No events to display"
+#: src/Core/L10n.php:369 src/Model/Event.php:391
+msgid "Fri"
 msgstr ""
 
-#: src/Model/Event.php:560
-msgid "l, F j"
+#: src/Core/L10n.php:369 src/Model/Event.php:392
+msgid "Sat"
 msgstr ""
 
-#: src/Model/Event.php:591
-msgid "Edit event"
+#: src/Core/L10n.php:369 src/Model/Event.php:386
+msgid "Sun"
 msgstr ""
 
-#: src/Model/Event.php:592
-msgid "Duplicate event"
+#: src/Core/L10n.php:373 src/Model/Event.php:402
+msgid "Jan"
 msgstr ""
 
-#: src/Model/Event.php:593
-msgid "Delete event"
+#: src/Core/L10n.php:373 src/Model/Event.php:403
+msgid "Feb"
 msgstr ""
 
-#: src/Model/Event.php:625 src/Model/Item.php:3656 src/Model/Item.php:3663
-msgid "link to source"
+#: src/Core/L10n.php:373 src/Model/Event.php:404
+msgid "Mar"
 msgstr ""
 
-#: src/Model/Event.php:847
-msgid "D g:i A"
+#: src/Core/L10n.php:373 src/Model/Event.php:405
+msgid "Apr"
 msgstr ""
 
-#: src/Model/Event.php:848
-msgid "g:i A"
+#: src/Core/L10n.php:373 src/Model/Event.php:407
+msgid "Jun"
 msgstr ""
 
-#: src/Model/Event.php:933 src/Model/Event.php:935
-msgid "Show map"
+#: src/Core/L10n.php:373 src/Model/Event.php:408
+msgid "Jul"
 msgstr ""
 
-#: src/Model/Event.php:934
-msgid "Hide map"
-msgstr ""
-
-#: src/Model/Event.php:1026
-#, php-format
-msgid "%s's birthday"
-msgstr ""
-
-#: src/Model/Event.php:1027
-#, php-format
-msgid "Happy Birthday %s"
-msgstr ""
-
-#: src/Model/Photo.php:553 src/Model/Photo.php:562 mod/fbrowser.php:51
-#: mod/fbrowser.php:75 mod/photos.php:179 mod/photos.php:934
-#: mod/photos.php:1047 mod/photos.php:1064 mod/photos.php:1545
-#: mod/photos.php:1560
-msgid "Contact Photos"
-msgstr ""
-
-#: src/Model/User.php:356
-msgid "Login failed"
-msgstr ""
-
-#: src/Model/User.php:388
-msgid "Not enough information to authenticate"
-msgstr ""
-
-#: src/Model/User.php:414 src/Console/NewPassword.php:88 mod/cal.php:281
-msgid "User not found"
-msgstr ""
-
-#: src/Model/User.php:482
-msgid "Password can't be empty"
-msgstr ""
-
-#: src/Model/User.php:501
-msgid "Empty passwords are not allowed."
-msgstr ""
-
-#: src/Model/User.php:505
-msgid ""
-"The new password has been exposed in a public data dump, please choose "
-"another."
-msgstr ""
-
-#: src/Model/User.php:511
-msgid ""
-"The password can't contain accentuated letters, white spaces or colons (:)"
-msgstr ""
-
-#: src/Model/User.php:610
-msgid "Passwords do not match. Password unchanged."
-msgstr ""
-
-#: src/Model/User.php:617
-msgid "An invitation is required."
-msgstr ""
-
-#: src/Model/User.php:621
-msgid "Invitation could not be verified."
-msgstr ""
-
-#: src/Model/User.php:629
-msgid "Invalid OpenID url"
-msgstr ""
-
-#: src/Model/User.php:642 src/App/Authentication.php:209
-msgid ""
-"We encountered a problem while logging in with the OpenID you provided. "
-"Please check the correct spelling of the ID."
-msgstr ""
-
-#: src/Model/User.php:642 src/App/Authentication.php:209
-msgid "The error message was:"
-msgstr ""
-
-#: src/Model/User.php:648
-msgid "Please enter the required information."
-msgstr ""
-
-#: src/Model/User.php:662
-#, php-format
-msgid ""
-"system.username_min_length (%s) and system.username_max_length (%s) are "
-"excluding each other, swapping values."
-msgstr ""
-
-#: src/Model/User.php:669
-#, php-format
-msgid "Username should be at least %s character."
-msgid_plural "Username should be at least %s characters."
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/Model/User.php:673
-#, php-format
-msgid "Username should be at most %s character."
-msgid_plural "Username should be at most %s characters."
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/Model/User.php:681
-msgid "That doesn't appear to be your full (First Last) name."
-msgstr ""
-
-#: src/Model/User.php:686
-msgid "Your email domain is not among those allowed on this site."
-msgstr ""
-
-#: src/Model/User.php:690
-msgid "Not a valid email address."
-msgstr ""
-
-#: src/Model/User.php:693
-msgid "The nickname was blocked from registration by the nodes admin."
-msgstr ""
-
-#: src/Model/User.php:697 src/Model/User.php:705
-msgid "Cannot use that email."
-msgstr ""
-
-#: src/Model/User.php:712
-msgid "Your nickname can only contain a-z, 0-9 and _."
-msgstr ""
-
-#: src/Model/User.php:720 src/Model/User.php:777
-msgid "Nickname is already registered. Please choose another."
-msgstr ""
-
-#: src/Model/User.php:730
-msgid "SERIOUS ERROR: Generation of security keys failed."
-msgstr ""
-
-#: src/Model/User.php:764 src/Model/User.php:768
-msgid "An error occurred during registration. Please try again."
-msgstr ""
-
-#: src/Model/User.php:793
-msgid "An error occurred creating your default profile. Please try again."
-msgstr ""
-
-#: src/Model/User.php:800
-msgid "An error occurred creating your self contact. Please try again."
-msgstr ""
-
-#: src/Model/User.php:809
-msgid ""
-"An error occurred creating your default contact group. Please try again."
-msgstr ""
-
-#: src/Model/User.php:886
-#, php-format
-msgid ""
-"\n"
-"\t\t\tDear %1$s,\n"
-"\t\t\t\tThank you for registering at %2$s. Your account is pending for "
-"approval by the administrator.\n"
-"\n"
-"\t\t\tYour login details are as follows:\n"
-"\n"
-"\t\t\tSite Location:\t%3$s\n"
-"\t\t\tLogin Name:\t\t%4$s\n"
-"\t\t\tPassword:\t\t%5$s\n"
-"\t\t"
-msgstr ""
-
-#: src/Model/User.php:907
-#, php-format
-msgid "Registration at %s"
-msgstr ""
-
-#: src/Model/User.php:929
-#, php-format
-msgid ""
-"\n"
-"\t\t\t\tDear %1$s,\n"
-"\t\t\t\tThank you for registering at %2$s. Your account has been created.\n"
-"\t\t\t"
-msgstr ""
-
-#: src/Model/User.php:937
-#, php-format
-msgid ""
-"\n"
-"\t\t\tThe login details are as follows:\n"
-"\n"
-"\t\t\tSite Location:\t%3$s\n"
-"\t\t\tLogin Name:\t\t%1$s\n"
-"\t\t\tPassword:\t\t%5$s\n"
-"\n"
-"\t\t\tYou may change your password from your account \"Settings\" page after "
-"logging\n"
-"\t\t\tin.\n"
-"\n"
-"\t\t\tPlease take a few moments to review the other account settings on that "
-"page.\n"
-"\n"
-"\t\t\tYou may also wish to add some basic information to your default "
-"profile\n"
-"\t\t\t(on the \"Profiles\" page) so that other people can easily find you.\n"
-"\n"
-"\t\t\tWe recommend setting your full name, adding a profile photo,\n"
-"\t\t\tadding some profile \"keywords\" (very useful in making new friends) - "
-"and\n"
-"\t\t\tperhaps what country you live in; if you do not wish to be more "
-"specific\n"
-"\t\t\tthan that.\n"
-"\n"
-"\t\t\tWe fully respect your right to privacy, and none of these items are "
-"necessary.\n"
-"\t\t\tIf you are new and do not know anybody here, they may help\n"
-"\t\t\tyou to make some new and interesting friends.\n"
-"\n"
-"\t\t\tIf you ever want to delete your account, you can do so at %3$s/"
-"removeme\n"
-"\n"
-"\t\t\tThank you and welcome to %2$s."
-msgstr ""
-
-#: src/Model/User.php:976 src/Module/Admin/Users.php:86
-#, php-format
-msgid "Registration details for %s"
-msgstr ""
-
-#: src/Model/Mail.php:112 src/Model/Mail.php:247
-msgid "[no subject]"
-msgstr ""
-
-#: src/Model/Group.php:76
-msgid ""
-"A deleted group with this name was revived. Existing item permissions "
-"<strong>may</strong> apply to this group and any future members. If this is "
-"not what you intended, please create another group with a different name."
-msgstr ""
-
-#: src/Model/Group.php:425
-msgid "Default privacy group for new contacts"
-msgstr ""
-
-#: src/Model/Group.php:457
-msgid "Everybody"
-msgstr ""
-
-#: src/Model/Group.php:476
-msgid "edit"
-msgstr ""
-
-#: src/Model/Group.php:501
-msgid "add"
-msgstr ""
-
-#: src/Model/Group.php:502 src/Module/Welcome.php:57 src/Module/Contact.php:732
-msgid "Groups"
-msgstr ""
-
-#: src/Model/Group.php:506
-msgid "Edit group"
-msgstr ""
-
-#: src/Model/Group.php:507 src/Module/Group.php:179
-msgid "Contacts not in any group"
-msgstr ""
-
-#: src/Model/Group.php:509
-msgid "Create a new group"
-msgstr ""
-
-#: src/Model/Group.php:510 src/Module/Group.php:164 src/Module/Group.php:187
-#: src/Module/Group.php:264
-msgid "Group Name: "
-msgstr ""
-
-#: src/Model/Group.php:511
-msgid "Edit groups"
-msgstr ""
-
-#: src/Model/FileTag.php:264
-msgid "Item filed"
-msgstr ""
-
-#: src/Model/Contact.php:1275 src/Model/Contact.php:1288
-msgid "UnFollow"
-msgstr ""
-
-#: src/Model/Contact.php:1284
-msgid "Drop Contact"
-msgstr ""
-
-#: src/Model/Contact.php:1294 src/Module/Admin/Users.php:284
-#: mod/notifications.php:170 mod/notifications.php:264
-msgid "Approve"
-msgstr ""
-
-#: src/Model/Contact.php:1853
-msgid "Organisation"
-msgstr ""
-
-#: src/Model/Contact.php:1857
-msgid "News"
-msgstr ""
-
-#: src/Model/Contact.php:1861
-msgid "Forum"
-msgstr ""
-
-#: src/Model/Contact.php:2265 mod/dfrn_request.php:343
-msgid "Disallowed profile URL."
-msgstr ""
-
-#: src/Model/Contact.php:2270 src/Module/Friendica.php:58
-#: mod/dfrn_request.php:349
-msgid "Blocked domain"
-msgstr ""
-
-#: src/Model/Contact.php:2275
-msgid "Connect URL missing."
-msgstr ""
-
-#: src/Model/Contact.php:2284
-msgid ""
-"The contact could not be added. Please check the relevant network "
-"credentials in your Settings -> Social Networks page."
-msgstr ""
-
-#: src/Model/Contact.php:2325
-msgid ""
-"This site is not configured to allow communications with other networks."
-msgstr ""
-
-#: src/Model/Contact.php:2326 src/Model/Contact.php:2339
-msgid "No compatible communication protocols or feeds were discovered."
-msgstr ""
-
-#: src/Model/Contact.php:2337
-msgid "The profile address specified does not provide adequate information."
-msgstr ""
-
-#: src/Model/Contact.php:2342
-msgid "An author or name was not found."
-msgstr ""
-
-#: src/Model/Contact.php:2345
-msgid "No browser URL could be matched to this address."
-msgstr ""
-
-#: src/Model/Contact.php:2348
-msgid ""
-"Unable to match @-style Identity Address with a known protocol or email "
-"contact."
-msgstr ""
-
-#: src/Model/Contact.php:2349
-msgid "Use mailto: in front of address to force email check."
-msgstr ""
-
-#: src/Model/Contact.php:2355
-msgid ""
-"The profile address specified belongs to a network which has been disabled "
-"on this site."
-msgstr ""
-
-#: src/Model/Contact.php:2360
-msgid ""
-"Limited profile. This person will be unable to receive direct/personal "
-"notifications from you."
-msgstr ""
-
-#: src/Model/Contact.php:2421
-msgid "Unable to retrieve contact information."
-msgstr ""
-
-#: src/Model/Contact.php:2642 mod/dfrn_request.php:563 mod/dfrn_confirm.php:538
-msgid "[Name Withheld]"
-msgstr ""
-
-#: src/Model/Item.php:3398
-msgid "activity"
-msgstr ""
-
-#: src/Model/Item.php:3403
-msgid "post"
-msgstr ""
-
-#: src/Model/Item.php:3526
-#, php-format
-msgid "Content warning: %s"
-msgstr ""
-
-#: src/Model/Item.php:3586 mod/videos.php:235
-msgid "View Video"
-msgstr ""
-
-#: src/Model/Item.php:3603
-msgid "bytes"
-msgstr ""
-
-#: src/Model/Item.php:3650
-msgid "View on separate page"
-msgstr ""
-
-#: src/Model/Item.php:3651
-msgid "view on separate page"
-msgstr ""
-
-#: src/Model/Storage/Database.php:59
-#, php-format
-msgid "Database storage failed to update %s"
-msgstr ""
-
-#: src/Model/Storage/Database.php:67
-msgid "Database storage failed to insert data"
-msgstr ""
-
-#: src/Model/Storage/Filesystem.php:85
-#, php-format
-msgid ""
-"Filesystem storage failed to create \"%s\". Check you write permissions."
-msgstr ""
-
-#: src/Model/Storage/Filesystem.php:133
-#, php-format
-msgid ""
-"Filesystem storage failed to save data to \"%s\". Check your write "
-"permissions"
-msgstr ""
-
-#: src/Model/Storage/Filesystem.php:161
-msgid "Storage base path"
-msgstr ""
-
-#: src/Model/Storage/Filesystem.php:163
-msgid ""
-"Folder where uploaded files are saved. For maximum security, This should be "
-"a path outside web server folder tree"
-msgstr ""
-
-#: src/Model/Storage/Filesystem.php:176
-msgid "Enter a valid existing folder"
-msgstr ""
-
-#: src/Model/Notify.php:275 src/Model/Notify.php:287
-#, php-format
-msgid "%s commented on %s's post"
-msgstr ""
-
-#: src/Model/Notify.php:286
-#, php-format
-msgid "%s created a new post"
-msgstr ""
-
-#: src/Model/Notify.php:300
-#, php-format
-msgid "%s liked %s's post"
-msgstr ""
-
-#: src/Model/Notify.php:313
-#, php-format
-msgid "%s disliked %s's post"
-msgstr ""
-
-#: src/Model/Notify.php:326
-#, php-format
-msgid "%s is attending %s's event"
-msgstr ""
-
-#: src/Model/Notify.php:339
-#, php-format
-msgid "%s is not attending %s's event"
-msgstr ""
-
-#: src/Model/Notify.php:352
-#, php-format
-msgid "%s may attend %s's event"
-msgstr ""
-
-#: src/Model/Notify.php:385
-#, php-format
-msgid "%s is now friends with %s"
-msgstr ""
-
-#: src/Model/Notify.php:678
-msgid "Friend Suggestion"
-msgstr ""
-
-#: src/Model/Notify.php:712
-msgid "Friend/Connect Request"
-msgstr ""
-
-#: src/Model/Notify.php:712
-msgid "New Follower"
-msgstr ""
-
-#: src/Protocol/OStatus.php:1272 src/Module/Profile.php:116
-#: src/Module/Profile.php:119
-#, php-format
-msgid "%s's timeline"
-msgstr ""
-
-#: src/Protocol/OStatus.php:1276 src/Module/Profile.php:117
-#, php-format
-msgid "%s's posts"
-msgstr ""
-
-#: src/Protocol/OStatus.php:1279 src/Module/Profile.php:118
-#, php-format
-msgid "%s's comments"
-msgstr ""
-
-#: src/Protocol/OStatus.php:1834
-#, php-format
-msgid "%s is now following %s."
-msgstr ""
-
-#: src/Protocol/OStatus.php:1835
-msgid "following"
-msgstr ""
-
-#: src/Protocol/OStatus.php:1838
-#, php-format
-msgid "%s stopped following %s."
-msgstr ""
-
-#: src/Protocol/OStatus.php:1839
-msgid "stopped following"
-msgstr ""
-
-#: src/Protocol/Diaspora.php:3576
-msgid "Attachments:"
-msgstr ""
-
-#: src/LegacyModule.php:30
-#, php-format
-msgid "Legacy module file not found: %s"
+#: src/Core/L10n.php:373 src/Model/Event.php:409
+msgid "Aug"
 msgstr ""
 
 #: src/Core/L10n.php:373
 msgid "Sep"
+msgstr ""
+
+#: src/Core/L10n.php:373 src/Model/Event.php:411
+msgid "Oct"
+msgstr ""
+
+#: src/Core/L10n.php:373 src/Model/Event.php:412
+msgid "Nov"
+msgstr ""
+
+#: src/Core/L10n.php:373 src/Model/Event.php:413
+msgid "Dec"
 msgstr ""
 
 #: src/Core/L10n.php:392
@@ -6161,60 +4925,6 @@ msgid ""
 "\t\t\t\t\tThe friendica database was successfully updated from %s to %s."
 msgstr ""
 
-#: src/Core/ACL.php:276 mod/lockview.php:81 mod/lockview.php:116
-msgid "Mutuals"
-msgstr ""
-
-#: src/Core/ACL.php:366
-msgid "Post to Email"
-msgstr ""
-
-#: src/Core/ACL.php:385
-msgid ""
-"This content will be shown to all your followers and can be seen in the "
-"community pages and by anyone with its link."
-msgstr ""
-
-#: src/Core/ACL.php:386
-msgid "Limited/Private"
-msgstr ""
-
-#: src/Core/ACL.php:387
-msgid ""
-"This content will be shown only to the people in the first box, to the "
-"exception of the people mentioned in the second box. It won't appear "
-"anywhere public."
-msgstr ""
-
-#: src/Core/ACL.php:388
-msgid "Show to:"
-msgstr ""
-
-#: src/Core/ACL.php:389
-msgid "Except to:"
-msgstr ""
-
-#: src/Core/ACL.php:390 mod/editpost.php:96
-msgid "CC: email addresses"
-msgstr ""
-
-#: src/Core/ACL.php:391 mod/editpost.php:103
-msgid "Example: bob@example.com, mary@example.com"
-msgstr ""
-
-#: src/Core/ACL.php:392
-msgid "Connectors"
-msgstr ""
-
-#: src/Core/ACL.php:393
-msgid "Hide your profile details from unknown viewers?"
-msgstr ""
-
-#: src/Core/ACL.php:393
-#, php-format
-msgid "Connectors disabled, since \"%s\" is enabled."
-msgstr ""
-
 #: src/Core/UserImport.php:107
 msgid "Error decoding account file"
 msgstr ""
@@ -6247,1083 +4957,1628 @@ msgstr[1] ""
 msgid "Done. You can now login with your username and password"
 msgstr ""
 
-#: src/Core/Installer.php:162
-msgid ""
-"The database configuration file \"config/local.config.php\" could not be "
-"written. Please use the enclosed text to create a configuration file in your "
-"web server root."
+#: src/Util/Temporal.php:145 src/Model/Profile.php:774
+msgid "Birthday:"
 msgstr ""
 
-#: src/Core/Installer.php:181
-msgid ""
-"You may need to import the file \"database.sql\" manually using phpmyadmin "
-"or mysql."
+#: src/Util/Temporal.php:149
+msgid "YYYY-MM-DD or MM-DD"
 msgstr ""
 
-#: src/Core/Installer.php:182 src/Module/Install.php:172
-#: src/Module/Install.php:326
-msgid "Please see the file \"INSTALL.txt\"."
+#: src/Util/Temporal.php:296
+msgid "never"
 msgstr ""
 
-#: src/Core/Installer.php:243
-msgid "Could not find a command line version of PHP in the web server PATH."
+#: src/Util/Temporal.php:303
+msgid "less than a second ago"
 msgstr ""
 
-#: src/Core/Installer.php:244
-msgid ""
-"If you don't have a command line version of PHP installed on your server, "
-"you will not be able to run the background processing. See <a href='https://"
-"github.com/friendica/friendica/blob/master/doc/Install.md#set-up-the-"
-"worker'>'Setup the worker'</a>"
+#: src/Util/Temporal.php:311
+msgid "year"
 msgstr ""
 
-#: src/Core/Installer.php:249
-msgid "PHP executable path"
+#: src/Util/Temporal.php:311
+msgid "years"
 msgstr ""
 
-#: src/Core/Installer.php:249
-msgid ""
-"Enter full path to php executable. You can leave this blank to continue the "
-"installation."
+#: src/Util/Temporal.php:312
+msgid "months"
 msgstr ""
 
-#: src/Core/Installer.php:254
-msgid "Command line PHP"
+#: src/Util/Temporal.php:313
+msgid "weeks"
 msgstr ""
 
-#: src/Core/Installer.php:263
-msgid "PHP executable is not the php cli binary (could be cgi-fgci version)"
+#: src/Util/Temporal.php:314
+msgid "days"
 msgstr ""
 
-#: src/Core/Installer.php:264
-msgid "Found PHP version: "
+#: src/Util/Temporal.php:315
+msgid "hour"
 msgstr ""
 
-#: src/Core/Installer.php:266
-msgid "PHP cli binary"
+#: src/Util/Temporal.php:315
+msgid "hours"
 msgstr ""
 
-#: src/Core/Installer.php:279
-msgid ""
-"The command line version of PHP on your system does not have "
-"\"register_argc_argv\" enabled."
+#: src/Util/Temporal.php:316
+msgid "minute"
 msgstr ""
 
-#: src/Core/Installer.php:280
-msgid "This is required for message delivery to work."
+#: src/Util/Temporal.php:316
+msgid "minutes"
 msgstr ""
 
-#: src/Core/Installer.php:285
-msgid "PHP register_argc_argv"
+#: src/Util/Temporal.php:317
+msgid "second"
 msgstr ""
 
-#: src/Core/Installer.php:317
-msgid ""
-"Error: the \"openssl_pkey_new\" function on this system is not able to "
-"generate encryption keys"
+#: src/Util/Temporal.php:317
+msgid "seconds"
 msgstr ""
 
-#: src/Core/Installer.php:318
-msgid ""
-"If running under Windows, please see \"http://www.php.net/manual/en/openssl."
-"installation.php\"."
-msgstr ""
-
-#: src/Core/Installer.php:321
-msgid "Generate encryption keys"
-msgstr ""
-
-#: src/Core/Installer.php:373
-msgid ""
-"Error: Apache webserver mod-rewrite module is required but not installed."
-msgstr ""
-
-#: src/Core/Installer.php:378
-msgid "Apache mod_rewrite module"
-msgstr ""
-
-#: src/Core/Installer.php:384
-msgid "Error: PDO or MySQLi PHP module required but not installed."
-msgstr ""
-
-#: src/Core/Installer.php:389
-msgid "Error: The MySQL driver for PDO is not installed."
-msgstr ""
-
-#: src/Core/Installer.php:393
-msgid "PDO or MySQLi PHP module"
-msgstr ""
-
-#: src/Core/Installer.php:401
-msgid "Error, XML PHP module required but not installed."
-msgstr ""
-
-#: src/Core/Installer.php:405
-msgid "XML PHP module"
-msgstr ""
-
-#: src/Core/Installer.php:408
-msgid "libCurl PHP module"
-msgstr ""
-
-#: src/Core/Installer.php:409
-msgid "Error: libCURL PHP module required but not installed."
-msgstr ""
-
-#: src/Core/Installer.php:415
-msgid "GD graphics PHP module"
-msgstr ""
-
-#: src/Core/Installer.php:416
-msgid ""
-"Error: GD graphics PHP module with JPEG support required but not installed."
-msgstr ""
-
-#: src/Core/Installer.php:422
-msgid "OpenSSL PHP module"
-msgstr ""
-
-#: src/Core/Installer.php:423
-msgid "Error: openssl PHP module required but not installed."
-msgstr ""
-
-#: src/Core/Installer.php:429
-msgid "mb_string PHP module"
-msgstr ""
-
-#: src/Core/Installer.php:430
-msgid "Error: mb_string PHP module required but not installed."
-msgstr ""
-
-#: src/Core/Installer.php:436
-msgid "iconv PHP module"
-msgstr ""
-
-#: src/Core/Installer.php:437
-msgid "Error: iconv PHP module required but not installed."
-msgstr ""
-
-#: src/Core/Installer.php:443
-msgid "POSIX PHP module"
-msgstr ""
-
-#: src/Core/Installer.php:444
-msgid "Error: POSIX PHP module required but not installed."
-msgstr ""
-
-#: src/Core/Installer.php:450
-msgid "JSON PHP module"
-msgstr ""
-
-#: src/Core/Installer.php:451
-msgid "Error: JSON PHP module required but not installed."
-msgstr ""
-
-#: src/Core/Installer.php:457
-msgid "File Information PHP module"
-msgstr ""
-
-#: src/Core/Installer.php:458
-msgid "Error: File Information PHP module required but not installed."
-msgstr ""
-
-#: src/Core/Installer.php:481
-msgid ""
-"The web installer needs to be able to create a file called \"local.config.php"
-"\" in the \"config\" folder of your web server and it is unable to do so."
-msgstr ""
-
-#: src/Core/Installer.php:482
-msgid ""
-"This is most often a permission setting, as the web server may not be able "
-"to write files in your folder - even if you can."
-msgstr ""
-
-#: src/Core/Installer.php:483
-msgid ""
-"At the end of this procedure, we will give you a text to save in a file "
-"named local.config.php in your Friendica \"config\" folder."
-msgstr ""
-
-#: src/Core/Installer.php:484
-msgid ""
-"You can alternatively skip this procedure and perform a manual installation. "
-"Please see the file \"INSTALL.txt\" for instructions."
-msgstr ""
-
-#: src/Core/Installer.php:487
-msgid "config/local.config.php is writable"
-msgstr ""
-
-#: src/Core/Installer.php:507
-msgid ""
-"Friendica uses the Smarty3 template engine to render its web views. Smarty3 "
-"compiles templates to PHP to speed up rendering."
-msgstr ""
-
-#: src/Core/Installer.php:508
-msgid ""
-"In order to store these compiled templates, the web server needs to have "
-"write access to the directory view/smarty3/ under the Friendica top level "
-"folder."
-msgstr ""
-
-#: src/Core/Installer.php:509
-msgid ""
-"Please ensure that the user that your web server runs as (e.g. www-data) has "
-"write access to this folder."
-msgstr ""
-
-#: src/Core/Installer.php:510
-msgid ""
-"Note: as a security measure, you should give the web server write access to "
-"view/smarty3/ only--not the template files (.tpl) that it contains."
-msgstr ""
-
-#: src/Core/Installer.php:513
-msgid "view/smarty3 is writable"
-msgstr ""
-
-#: src/Core/Installer.php:542
-msgid ""
-"Url rewrite in .htaccess is not working. Make sure you copied .htaccess-dist "
-"to .htaccess."
-msgstr ""
-
-#: src/Core/Installer.php:544
-msgid "Error message from Curl when fetching"
-msgstr ""
-
-#: src/Core/Installer.php:549
-msgid "Url rewrite is working"
-msgstr ""
-
-#: src/Core/Installer.php:578
-msgid "ImageMagick PHP extension is not installed"
-msgstr ""
-
-#: src/Core/Installer.php:580
-msgid "ImageMagick PHP extension is installed"
-msgstr ""
-
-#: src/Core/Installer.php:582 tests/src/Core/InstallerTest.php:367
-#: tests/src/Core/InstallerTest.php:390
-msgid "ImageMagick supports GIF"
-msgstr ""
-
-#: src/Core/Installer.php:604
-msgid "Database already in use."
-msgstr ""
-
-#: src/Core/Installer.php:609
-msgid "Could not connect to database."
-msgstr ""
-
-#: src/Module/Directory.php:82
-msgid "Site Directory"
-msgstr ""
-
-#: src/Module/Special/HTTPException.php:30
-msgid "Bad Request"
-msgstr ""
-
-#: src/Module/Special/HTTPException.php:31
-msgid "Unauthorized"
-msgstr ""
-
-#: src/Module/Special/HTTPException.php:32
-msgid "Forbidden"
-msgstr ""
-
-#: src/Module/Special/HTTPException.php:33
-msgid "Not Found"
-msgstr ""
-
-#: src/Module/Special/HTTPException.php:34
-msgid "Internal Server Error"
-msgstr ""
-
-#: src/Module/Special/HTTPException.php:35
-msgid "Service Unavailable"
-msgstr ""
-
-#: src/Module/Special/HTTPException.php:42
-msgid ""
-"The server cannot or will not process the request due to an apparent client "
-"error."
-msgstr ""
-
-#: src/Module/Special/HTTPException.php:43
-msgid "Authentication is required and has failed or has not yet been provided."
-msgstr ""
-
-#: src/Module/Special/HTTPException.php:44
-msgid ""
-"The request was valid, but the server is refusing action. The user might not "
-"have the necessary permissions for a resource, or may need an account."
-msgstr ""
-
-#: src/Module/Special/HTTPException.php:45
-msgid ""
-"The requested resource could not be found but may be available in the future."
-msgstr ""
-
-#: src/Module/Special/HTTPException.php:46
-msgid ""
-"An unexpected condition was encountered and no more specific message is "
-"suitable."
-msgstr ""
-
-#: src/Module/Special/HTTPException.php:47
-msgid ""
-"The server is currently unavailable (because it is overloaded or down for "
-"maintenance). Please try again later."
-msgstr ""
-
-#: src/Module/Special/HTTPException.php:53
-msgid "Go back"
-msgstr ""
-
-#: src/Module/Help.php:43
-msgid "Help:"
-msgstr ""
-
-#: src/Module/Delegation.php:127
-msgid "Manage Identities and/or Pages"
-msgstr ""
-
-#: src/Module/Delegation.php:128
-msgid ""
-"Toggle between different identities or community/group pages which share "
-"your account details or which you have been granted \"manage\" permissions"
-msgstr ""
-
-#: src/Module/Delegation.php:129
-msgid "Select an identity to manage: "
-msgstr ""
-
-#: src/Module/Tos.php:34 src/Module/Tos.php:76
-msgid ""
-"At the time of registration, and for providing communications between the "
-"user account and their contacts, the user has to provide a display name (pen "
-"name), an username (nickname) and a working email address. The names will be "
-"accessible on the profile page of the account by any visitor of the page, "
-"even if other profile details are not displayed. The email address will only "
-"be used to send the user notifications about interactions, but wont be "
-"visibly displayed. The listing of an account in the node's user directory or "
-"the global user directory is optional and can be controlled in the user "
-"settings, it is not necessary for communication."
-msgstr ""
-
-#: src/Module/Tos.php:35 src/Module/Tos.php:77
-msgid ""
-"This data is required for communication and is passed on to the nodes of the "
-"communication partners and is stored there. Users can enter additional "
-"private data that may be transmitted to the communication partners accounts."
-msgstr ""
-
-#: src/Module/Tos.php:36 src/Module/Tos.php:78
+#: src/Util/Temporal.php:327
 #, php-format
-msgid ""
-"At any point in time a logged in user can export their account data from the "
-"<a href=\"%1$s/settings/userexport\">account settings</a>. If the user wants "
-"to delete their account they can do so at <a href=\"%1$s/removeme\">%1$s/"
-"removeme</a>. The deletion of the account will be permanent. Deletion of the "
-"data will also be requested from the nodes of the communication partners."
+msgid "in %1$d %2$s"
 msgstr ""
 
-#: src/Module/Tos.php:39 src/Module/Tos.php:75
-msgid "Privacy Statement"
-msgstr ""
-
-#: src/Module/Install.php:158
-msgid "Friendica Communications Server - Setup"
-msgstr ""
-
-#: src/Module/Install.php:169
-msgid "System check"
-msgstr ""
-
-#: src/Module/Install.php:173 mod/events.php:397 mod/cal.php:261
-msgid "Next"
-msgstr ""
-
-#: src/Module/Install.php:174
-msgid "Check again"
-msgstr ""
-
-#: src/Module/Install.php:181 src/Module/Admin/Site.php:507
-msgid "No SSL policy, links will track page SSL state"
-msgstr ""
-
-#: src/Module/Install.php:182 src/Module/Admin/Site.php:508
-msgid "Force all links to use SSL"
-msgstr ""
-
-#: src/Module/Install.php:183 src/Module/Admin/Site.php:509
-msgid "Self-signed certificate, use SSL for local links only (discouraged)"
-msgstr ""
-
-#: src/Module/Install.php:189
-msgid "Base settings"
-msgstr ""
-
-#: src/Module/Install.php:191 src/Module/Admin/Site.php:581
-msgid "SSL link policy"
-msgstr ""
-
-#: src/Module/Install.php:193 src/Module/Admin/Site.php:581
-msgid "Determines whether generated links should be forced to use SSL"
-msgstr ""
-
-#: src/Module/Install.php:196
-msgid "Host name"
-msgstr ""
-
-#: src/Module/Install.php:198
-msgid ""
-"Overwrite this field in case the determinated hostname isn't right, "
-"otherweise leave it as is."
-msgstr ""
-
-#: src/Module/Install.php:201
-msgid "Base path to installation"
-msgstr ""
-
-#: src/Module/Install.php:203
-msgid ""
-"If the system cannot detect the correct path to your installation, enter the "
-"correct path here. This setting should only be set if you are using a "
-"restricted system and symbolic links to your webroot."
-msgstr ""
-
-#: src/Module/Install.php:206
-msgid "Sub path of the URL"
-msgstr ""
-
-#: src/Module/Install.php:208
-msgid ""
-"Overwrite this field in case the sub path determination isn't right, "
-"otherwise leave it as is. Leaving this field blank means the installation is "
-"at the base URL without sub path."
-msgstr ""
-
-#: src/Module/Install.php:219
-msgid "Database connection"
-msgstr ""
-
-#: src/Module/Install.php:220
-msgid ""
-"In order to install Friendica we need to know how to connect to your "
-"database."
-msgstr ""
-
-#: src/Module/Install.php:221
-msgid ""
-"Please contact your hosting provider or site administrator if you have "
-"questions about these settings."
-msgstr ""
-
-#: src/Module/Install.php:222
-msgid ""
-"The database you specify below should already exist. If it does not, please "
-"create it before continuing."
-msgstr ""
-
-#: src/Module/Install.php:229
-msgid "Database Server Name"
-msgstr ""
-
-#: src/Module/Install.php:234
-msgid "Database Login Name"
-msgstr ""
-
-#: src/Module/Install.php:240
-msgid "Database Login Password"
-msgstr ""
-
-#: src/Module/Install.php:242
-msgid "For security reasons the password must not be empty"
-msgstr ""
-
-#: src/Module/Install.php:245
-msgid "Database Name"
-msgstr ""
-
-#: src/Module/Install.php:249 src/Module/Install.php:278
-msgid "Please select a default timezone for your website"
-msgstr ""
-
-#: src/Module/Install.php:263
-msgid "Site settings"
-msgstr ""
-
-#: src/Module/Install.php:273
-msgid "Site administrator email address"
-msgstr ""
-
-#: src/Module/Install.php:275
-msgid ""
-"Your account email address must match this in order to use the web admin "
-"panel."
-msgstr ""
-
-#: src/Module/Install.php:282
-msgid "System Language:"
-msgstr ""
-
-#: src/Module/Install.php:284
-msgid ""
-"Set the default language for your Friendica installation interface and to "
-"send emails."
-msgstr ""
-
-#: src/Module/Install.php:296
-msgid "Your Friendica site database has been installed."
-msgstr ""
-
-#: src/Module/Install.php:304
-msgid "Installation finished"
-msgstr ""
-
-#: src/Module/Install.php:324
-msgid "<h1>What next</h1>"
-msgstr ""
-
-#: src/Module/Install.php:325
-msgid ""
-"IMPORTANT: You will need to [manually] setup a scheduled task for the worker."
-msgstr ""
-
-#: src/Module/Install.php:328
+#: src/Util/Temporal.php:330
 #, php-format
+msgid "%1$d %2$s ago"
+msgstr ""
+
+#: src/Content/Text/BBCode.php:908 src/Content/Text/BBCode.php:1604
+#: src/Content/Text/BBCode.php:1605
+msgid "Image/photo"
+msgstr ""
+
+#: src/Content/Text/BBCode.php:1025
+#, php-format
+msgid "<a href=\"%1$s\" target=\"_blank\">%2$s</a> %3$s"
+msgstr ""
+
+#: src/Content/Text/BBCode.php:1522 src/Content/Text/HTML.php:952
+msgid "Click to open/close"
+msgstr ""
+
+#: src/Content/Text/BBCode.php:1553
+msgid "$1 wrote:"
+msgstr ""
+
+#: src/Content/Text/BBCode.php:1607 src/Content/Text/BBCode.php:1608
+msgid "Encrypted content"
+msgstr ""
+
+#: src/Content/Text/BBCode.php:1833
+msgid "Invalid source protocol"
+msgstr ""
+
+#: src/Content/Text/BBCode.php:1848
+msgid "Invalid link protocol"
+msgstr ""
+
+#: src/Content/Text/HTML.php:800
+msgid "Loading more entries..."
+msgstr ""
+
+#: src/Content/Text/HTML.php:801
+msgid "The end"
+msgstr ""
+
+#: src/Content/Text/HTML.php:894 src/Model/Profile.php:534
+#: src/Module/Contact.php:315
+msgid "Follow"
+msgstr ""
+
+#: src/Content/Text/HTML.php:900 src/Content/Nav.php:197
+#: src/Module/Search/Index.php:78
+msgid "Search"
+msgstr ""
+
+#: src/Content/Text/HTML.php:902 src/Content/Nav.php:77
+msgid "@name, !forum, #tags, content"
+msgstr ""
+
+#: src/Content/Text/HTML.php:909 src/Content/Nav.php:200
+msgid "Full Text"
+msgstr ""
+
+#: src/Content/Text/HTML.php:910 src/Content/Widget/TagCloud.php:52
+#: src/Content/Nav.php:201
+msgid "Tags"
+msgstr ""
+
+#: src/Content/Widget/CalendarExport.php:64
+msgid "Export"
+msgstr ""
+
+#: src/Content/Widget/CalendarExport.php:65
+msgid "Export calendar as ical"
+msgstr ""
+
+#: src/Content/Widget/CalendarExport.php:66
+msgid "Export calendar as csv"
+msgstr ""
+
+#: src/Content/Widget/ContactBlock.php:57
+msgid "No contacts"
+msgstr ""
+
+#: src/Content/Widget/ContactBlock.php:89
+#, php-format
+msgid "%d Contact"
+msgid_plural "%d Contacts"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/Content/Widget/ContactBlock.php:108
+msgid "View Contacts"
+msgstr ""
+
+#: src/Content/Widget/SavedSearches.php:29
+msgid "Remove term"
+msgstr ""
+
+#: src/Content/Widget/SavedSearches.php:37
+msgid "Saved Searches"
+msgstr ""
+
+#: src/Content/Widget/TrendingTags.php:32
+#, php-format
+msgid "Trending Tags (last %d hour)"
+msgid_plural "Trending Tags (last %d hours)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/Content/Widget/TrendingTags.php:33
+msgid "More Trending Tags"
+msgstr ""
+
+#: src/Content/ContactSelector.php:58
+msgid "Frequently"
+msgstr ""
+
+#: src/Content/ContactSelector.php:59
+msgid "Hourly"
+msgstr ""
+
+#: src/Content/ContactSelector.php:60
+msgid "Twice daily"
+msgstr ""
+
+#: src/Content/ContactSelector.php:61
+msgid "Daily"
+msgstr ""
+
+#: src/Content/ContactSelector.php:62
+msgid "Weekly"
+msgstr ""
+
+#: src/Content/ContactSelector.php:63
+msgid "Monthly"
+msgstr ""
+
+#: src/Content/ContactSelector.php:117
+msgid "DFRN"
+msgstr ""
+
+#: src/Content/ContactSelector.php:118
+msgid "OStatus"
+msgstr ""
+
+#: src/Content/ContactSelector.php:119
+msgid "RSS/Atom"
+msgstr ""
+
+#: src/Content/ContactSelector.php:120 src/Module/Admin/Users.php:269
+#: src/Module/Admin/Users.php:280 src/Module/Admin/Users.php:294
+#: src/Module/Admin/Users.php:312
+msgid "Email"
+msgstr ""
+
+#: src/Content/ContactSelector.php:122
+msgid "Zot!"
+msgstr ""
+
+#: src/Content/ContactSelector.php:123
+msgid "LinkedIn"
+msgstr ""
+
+#: src/Content/ContactSelector.php:124
+msgid "XMPP/IM"
+msgstr ""
+
+#: src/Content/ContactSelector.php:125
+msgid "MySpace"
+msgstr ""
+
+#: src/Content/ContactSelector.php:126
+msgid "Google+"
+msgstr ""
+
+#: src/Content/ContactSelector.php:127
+msgid "pump.io"
+msgstr ""
+
+#: src/Content/ContactSelector.php:128
+msgid "Twitter"
+msgstr ""
+
+#: src/Content/ContactSelector.php:129
+msgid "Discourse"
+msgstr ""
+
+#: src/Content/ContactSelector.php:130
+msgid "Diaspora Connector"
+msgstr ""
+
+#: src/Content/ContactSelector.php:131
+msgid "GNU Social Connector"
+msgstr ""
+
+#: src/Content/ContactSelector.php:132
+msgid "ActivityPub"
+msgstr ""
+
+#: src/Content/ContactSelector.php:133
+msgid "pnut"
+msgstr ""
+
+#: src/Content/ContactSelector.php:167
+#, php-format
+msgid "%s (via %s)"
+msgstr ""
+
+#: src/Content/ContactSelector.php:236 src/Content/ContactSelector.php:276
+#: src/Content/ContactSelector.php:314
+msgid "No answer"
+msgstr ""
+
+#: src/Content/ContactSelector.php:237
+msgid "Male"
+msgstr ""
+
+#: src/Content/ContactSelector.php:238
+msgid "Female"
+msgstr ""
+
+#: src/Content/ContactSelector.php:239
+msgid "Currently Male"
+msgstr ""
+
+#: src/Content/ContactSelector.php:240
+msgid "Currently Female"
+msgstr ""
+
+#: src/Content/ContactSelector.php:241
+msgid "Mostly Male"
+msgstr ""
+
+#: src/Content/ContactSelector.php:242
+msgid "Mostly Female"
+msgstr ""
+
+#: src/Content/ContactSelector.php:243
+msgid "Transgender"
+msgstr ""
+
+#: src/Content/ContactSelector.php:244
+msgid "Intersex"
+msgstr ""
+
+#: src/Content/ContactSelector.php:245
+msgid "Transsexual"
+msgstr ""
+
+#: src/Content/ContactSelector.php:246
+msgid "Hermaphrodite"
+msgstr ""
+
+#: src/Content/ContactSelector.php:247
+msgid "Neuter"
+msgstr ""
+
+#: src/Content/ContactSelector.php:248
+msgid "Non-specific"
+msgstr ""
+
+#: src/Content/ContactSelector.php:249 src/Module/Admin/Federation.php:33
+msgid "Other"
+msgstr ""
+
+#: src/Content/ContactSelector.php:277
+msgid "Males"
+msgstr ""
+
+#: src/Content/ContactSelector.php:278
+msgid "Females"
+msgstr ""
+
+#: src/Content/ContactSelector.php:279
+msgid "Gay"
+msgstr ""
+
+#: src/Content/ContactSelector.php:280
+msgid "Lesbian"
+msgstr ""
+
+#: src/Content/ContactSelector.php:281
+msgid "No Preference"
+msgstr ""
+
+#: src/Content/ContactSelector.php:282
+msgid "Bisexual"
+msgstr ""
+
+#: src/Content/ContactSelector.php:283
+msgid "Autosexual"
+msgstr ""
+
+#: src/Content/ContactSelector.php:284
+msgid "Abstinent"
+msgstr ""
+
+#: src/Content/ContactSelector.php:285
+msgid "Virgin"
+msgstr ""
+
+#: src/Content/ContactSelector.php:286
+msgid "Deviant"
+msgstr ""
+
+#: src/Content/ContactSelector.php:287
+msgid "Fetish"
+msgstr ""
+
+#: src/Content/ContactSelector.php:288
+msgid "Oodles"
+msgstr ""
+
+#: src/Content/ContactSelector.php:289
+msgid "Nonsexual"
+msgstr ""
+
+#: src/Content/ContactSelector.php:315
+msgid "Single"
+msgstr ""
+
+#: src/Content/ContactSelector.php:316
+msgid "Lonely"
+msgstr ""
+
+#: src/Content/ContactSelector.php:317
+msgid "In a relation"
+msgstr ""
+
+#: src/Content/ContactSelector.php:318
+msgid "Has crush"
+msgstr ""
+
+#: src/Content/ContactSelector.php:319
+msgid "Infatuated"
+msgstr ""
+
+#: src/Content/ContactSelector.php:320
+msgid "Dating"
+msgstr ""
+
+#: src/Content/ContactSelector.php:321
+msgid "Unfaithful"
+msgstr ""
+
+#: src/Content/ContactSelector.php:322
+msgid "Sex Addict"
+msgstr ""
+
+#: src/Content/ContactSelector.php:323 src/Model/User.php:804
+msgid "Friends"
+msgstr ""
+
+#: src/Content/ContactSelector.php:324
+msgid "Friends/Benefits"
+msgstr ""
+
+#: src/Content/ContactSelector.php:325
+msgid "Casual"
+msgstr ""
+
+#: src/Content/ContactSelector.php:326
+msgid "Engaged"
+msgstr ""
+
+#: src/Content/ContactSelector.php:327
+msgid "Married"
+msgstr ""
+
+#: src/Content/ContactSelector.php:328
+msgid "Imaginarily married"
+msgstr ""
+
+#: src/Content/ContactSelector.php:329
+msgid "Partners"
+msgstr ""
+
+#: src/Content/ContactSelector.php:330
+msgid "Cohabiting"
+msgstr ""
+
+#: src/Content/ContactSelector.php:331
+msgid "Common law"
+msgstr ""
+
+#: src/Content/ContactSelector.php:332
+msgid "Happy"
+msgstr ""
+
+#: src/Content/ContactSelector.php:333
+msgid "Not looking"
+msgstr ""
+
+#: src/Content/ContactSelector.php:334
+msgid "Swinger"
+msgstr ""
+
+#: src/Content/ContactSelector.php:335
+msgid "Betrayed"
+msgstr ""
+
+#: src/Content/ContactSelector.php:336
+msgid "Separated"
+msgstr ""
+
+#: src/Content/ContactSelector.php:337
+msgid "Unstable"
+msgstr ""
+
+#: src/Content/ContactSelector.php:338
+msgid "Divorced"
+msgstr ""
+
+#: src/Content/ContactSelector.php:339
+msgid "Imaginarily divorced"
+msgstr ""
+
+#: src/Content/ContactSelector.php:340
+msgid "Widowed"
+msgstr ""
+
+#: src/Content/ContactSelector.php:341
+msgid "Uncertain"
+msgstr ""
+
+#: src/Content/ContactSelector.php:342
+msgid "It's complicated"
+msgstr ""
+
+#: src/Content/ContactSelector.php:343
+msgid "Don't care"
+msgstr ""
+
+#: src/Content/ContactSelector.php:344
+msgid "Ask me"
+msgstr ""
+
+#: src/Content/Feature.php:80
+msgid "General Features"
+msgstr ""
+
+#: src/Content/Feature.php:82
+msgid "Multiple Profiles"
+msgstr ""
+
+#: src/Content/Feature.php:82
+msgid "Ability to create multiple profiles"
+msgstr ""
+
+#: src/Content/Feature.php:83
+msgid "Photo Location"
+msgstr ""
+
+#: src/Content/Feature.php:83
 msgid ""
-"Go to your new Friendica node <a href=\"%s/register\">registration page</a> "
-"and register as new user. Remember to use the same email you have entered as "
-"administrator email. This will allow you to enter the site admin panel."
+"Photo metadata is normally stripped. This extracts the location (if present) "
+"prior to stripping metadata and links it to a map."
 msgstr ""
 
-#: src/Module/BaseAdminModule.php:54 mod/api.php:95
-msgid "Please login to continue."
+#: src/Content/Feature.php:84
+msgid "Export Public Calendar"
 msgstr ""
 
-#: src/Module/BaseAdminModule.php:60
+#: src/Content/Feature.php:84
+msgid "Ability for visitors to download the public calendar"
+msgstr ""
+
+#: src/Content/Feature.php:85
+msgid "Trending Tags"
+msgstr ""
+
+#: src/Content/Feature.php:85
 msgid ""
-"Submanaged account can't access the administation pages. Please log back in "
-"as the master account."
+"Show a community page widget with a list of the most popular tags in recent "
+"public posts."
 msgstr ""
 
-#: src/Module/BaseAdminModule.php:74
-msgid "Overview"
+#: src/Content/Feature.php:90
+msgid "Post Composition Features"
 msgstr ""
 
-#: src/Module/BaseAdminModule.php:75 src/Module/Admin/Federation.php:123
-msgid "Federation Statistics"
+#: src/Content/Feature.php:91
+msgid "Auto-mention Forums"
 msgstr ""
 
-#: src/Module/BaseAdminModule.php:77
-msgid "Configuration"
+#: src/Content/Feature.php:91
+msgid ""
+"Add/remove mention when a forum page is selected/deselected in ACL window."
 msgstr ""
 
-#: src/Module/BaseAdminModule.php:78 src/Module/Admin/Site.php:556
-msgid "Site"
+#: src/Content/Feature.php:92
+msgid "Explicit Mentions"
 msgstr ""
 
-#: src/Module/BaseAdminModule.php:79 src/Module/Admin/Users.php:276
-#: src/Module/Admin/Users.php:293 src/Module/Admin/Site.php:464
-msgid "Users"
+#: src/Content/Feature.php:92
+msgid ""
+"Add explicit mentions to comment box for manual control over who gets "
+"mentioned in replies."
 msgstr ""
 
-#: src/Module/BaseAdminModule.php:80 src/Module/Admin/Addons/Details.php:100
-#: src/Module/Admin/Addons/Index.php:49 src/Module/BaseSettingsModule.php:68
-#: mod/settings.php:107
-msgid "Addons"
+#: src/Content/Feature.php:97
+msgid "Network Sidebar"
 msgstr ""
 
-#: src/Module/BaseAdminModule.php:81 src/Module/Admin/Themes/Details.php:105
-#: src/Module/Admin/Themes/Index.php:94
-msgid "Themes"
+#: src/Content/Feature.php:98 src/Content/Widget.php:497
+msgid "Archives"
 msgstr ""
 
-#: src/Module/BaseAdminModule.php:82 src/Module/BaseSettingsModule.php:46
-#: mod/settings.php:85
-msgid "Additional features"
+#: src/Content/Feature.php:98
+msgid "Ability to select posts by date ranges"
 msgstr ""
 
-#: src/Module/BaseAdminModule.php:85
-msgid "Database"
+#: src/Content/Feature.php:99
+msgid "Protocol Filter"
 msgstr ""
 
-#: src/Module/BaseAdminModule.php:86
-msgid "DB updates"
+#: src/Content/Feature.php:99
+msgid "Enable widget to display Network posts only from selected protocols"
 msgstr ""
 
-#: src/Module/BaseAdminModule.php:87
-msgid "Inspect Deferred Workers"
+#: src/Content/Feature.php:104
+msgid "Network Tabs"
 msgstr ""
 
-#: src/Module/BaseAdminModule.php:88
-msgid "Inspect worker Queue"
+#: src/Content/Feature.php:105
+msgid "Network New Tab"
 msgstr ""
 
-#: src/Module/BaseAdminModule.php:90
-msgid "Tools"
+#: src/Content/Feature.php:105
+msgid "Enable tab to display only new Network posts (from the last 12 hours)"
 msgstr ""
 
-#: src/Module/BaseAdminModule.php:91
-msgid "Contact Blocklist"
+#: src/Content/Feature.php:106
+msgid "Network Shared Links Tab"
 msgstr ""
 
-#: src/Module/BaseAdminModule.php:92
-msgid "Server Blocklist"
+#: src/Content/Feature.php:106
+msgid "Enable tab to display only Network posts with links in them"
 msgstr ""
 
-#: src/Module/BaseAdminModule.php:93 src/Module/Admin/Item/Delete.php:47
-msgid "Delete Item"
+#: src/Content/Feature.php:111
+msgid "Post/Comment Tools"
 msgstr ""
 
-#: src/Module/BaseAdminModule.php:95 src/Module/BaseAdminModule.php:96
-#: src/Module/Admin/Logs/Settings.php:62
-msgid "Logs"
+#: src/Content/Feature.php:112
+msgid "Post Categories"
 msgstr ""
 
-#: src/Module/BaseAdminModule.php:97 src/Module/Admin/Logs/View.php:47
-msgid "View Logs"
+#: src/Content/Feature.php:112
+msgid "Add categories to your posts"
 msgstr ""
 
-#: src/Module/BaseAdminModule.php:99
-msgid "Diagnostics"
+#: src/Content/Feature.php:117
+msgid "Advanced Profile Settings"
 msgstr ""
 
-#: src/Module/BaseAdminModule.php:100
-msgid "PHP Info"
+#: src/Content/Feature.php:118
+msgid "List Forums"
 msgstr ""
 
-#: src/Module/BaseAdminModule.php:101
-msgid "probe address"
+#: src/Content/Feature.php:118
+msgid "Show visitors public community forums at the Advanced Profile Page"
 msgstr ""
 
-#: src/Module/BaseAdminModule.php:102
-msgid "check webfinger"
+#: src/Content/Feature.php:119
+msgid "Tag Cloud"
 msgstr ""
 
-#: src/Module/BaseAdminModule.php:103
-msgid "Item Source"
+#: src/Content/Feature.php:119
+msgid "Provide a personal tag cloud on your profile page"
 msgstr ""
 
-#: src/Module/BaseAdminModule.php:104
-msgid "Babel"
+#: src/Content/Feature.php:120
+msgid "Display Membership Date"
 msgstr ""
 
-#: src/Module/BaseAdminModule.php:113
-msgid "Addon Features"
+#: src/Content/Feature.php:120
+msgid "Display membership date in profile"
 msgstr ""
 
-#: src/Module/BaseAdminModule.php:114
-msgid "User registrations waiting for confirmation"
+#: src/Content/Nav.php:72
+msgid "Nothing new here"
 msgstr ""
 
+#: src/Content/Nav.php:76
+msgid "Clear notifications"
+msgstr ""
+
+#: src/Content/Nav.php:150 src/Module/Security/Login.php:128
+msgid "Logout"
+msgstr ""
+
+#: src/Content/Nav.php:150
+msgid "End this session"
+msgstr ""
+
+#: src/Content/Nav.php:152 src/Module/Bookmarklet.php:26
+#: src/Module/Security/Login.php:129
+msgid "Login"
+msgstr ""
+
+#: src/Content/Nav.php:152
+msgid "Sign in"
+msgstr ""
+
+#: src/Content/Nav.php:162
+msgid "Personal notes"
+msgstr ""
+
+#: src/Content/Nav.php:162
+msgid "Your personal notes"
+msgstr ""
+
+#: src/Content/Nav.php:179 src/Content/Nav.php:240
+msgid "Home"
+msgstr ""
+
+#: src/Content/Nav.php:179
+msgid "Home Page"
+msgstr ""
+
+#: src/Content/Nav.php:183 src/Module/Register.php:136
 #: src/Module/Security/Login.php:89
-msgid "Create a New Account"
+msgid "Register"
 msgstr ""
 
-#: src/Module/Security/Login.php:114
-msgid "Your OpenID: "
+#: src/Content/Nav.php:183
+msgid "Create an account"
 msgstr ""
 
-#: src/Module/Security/Login.php:117
-msgid ""
-"Please enter your username and password to add the OpenID to your existing "
-"account."
+#: src/Content/Nav.php:189
+msgid "Help and documentation"
 msgstr ""
 
-#: src/Module/Security/Login.php:119
-msgid "Or login using OpenID: "
+#: src/Content/Nav.php:193
+msgid "Apps"
 msgstr ""
 
-#: src/Module/Security/Login.php:132 mod/lostpass.php:119
-msgid "Nickname or Email: "
+#: src/Content/Nav.php:193
+msgid "Addon applications, utilities, games"
 msgstr ""
 
-#: src/Module/Security/Login.php:133
-msgid "Password: "
+#: src/Content/Nav.php:197
+msgid "Search site content"
 msgstr ""
 
-#: src/Module/Security/Login.php:134
-msgid "Remember me"
+#: src/Content/Nav.php:221
+msgid "Community"
 msgstr ""
 
-#: src/Module/Security/Login.php:143
-msgid "Forgot your password?"
+#: src/Content/Nav.php:221
+msgid "Conversations on this and other servers"
 msgstr ""
 
-#: src/Module/Security/Login.php:144 mod/lostpass.php:135
-msgid "Password Reset"
+#: src/Content/Nav.php:228
+msgid "Directory"
 msgstr ""
 
-#: src/Module/Security/Login.php:146
-msgid "Website Terms of Service"
+#: src/Content/Nav.php:228
+msgid "People directory"
 msgstr ""
 
-#: src/Module/Security/Login.php:147
-msgid "terms of service"
+#: src/Content/Nav.php:230 src/Module/BaseAdminModule.php:73
+msgid "Information"
 msgstr ""
 
-#: src/Module/Security/Login.php:149
-msgid "Website Privacy Policy"
+#: src/Content/Nav.php:230
+msgid "Information about this friendica instance"
 msgstr ""
 
-#: src/Module/Security/Login.php:150
-msgid "privacy policy"
+#: src/Content/Nav.php:233 src/Module/Admin/Tos.php:42
+#: src/Module/BaseAdminModule.php:83 src/Module/Register.php:144
+#: src/Module/Tos.php:71
+msgid "Terms of Service"
 msgstr ""
 
-#: src/Module/Security/TwoFactor/Verify.php:42
-#: src/Module/Security/TwoFactor/Recovery.php:45
-#: src/Module/Settings/TwoFactor/Verify.php:63
-msgid "Invalid code, please retry."
+#: src/Content/Nav.php:233
+msgid "Terms of Service of this Friendica instance"
 msgstr ""
 
-#: src/Module/Security/TwoFactor/Verify.php:61
-#: src/Module/Settings/TwoFactor/Index.php:86
-#: src/Module/BaseSettingsModule.php:31 mod/settings.php:70
-msgid "Two-factor authentication"
+#: src/Content/Nav.php:244
+msgid "Introductions"
 msgstr ""
 
-#: src/Module/Security/TwoFactor/Verify.php:62
-msgid ""
-"<p>Open the two-factor authentication app on your device to get an "
-"authentication code and verify your identity.</p>"
+#: src/Content/Nav.php:244
+msgid "Friend Requests"
 msgstr ""
 
-#: src/Module/Security/TwoFactor/Verify.php:63 mod/repair_ostatus.php:34
-msgid "Error"
-msgid_plural "Errors"
+#: src/Content/Nav.php:246
+msgid "See all notifications"
+msgstr ""
+
+#: src/Content/Nav.php:247
+msgid "Mark all system notifications seen"
+msgstr ""
+
+#: src/Content/Nav.php:251
+msgid "Inbox"
+msgstr ""
+
+#: src/Content/Nav.php:252
+msgid "Outbox"
+msgstr ""
+
+#: src/Content/Nav.php:256
+msgid "Delegation"
+msgstr ""
+
+#: src/Content/Nav.php:256
+msgid "Manage other pages"
+msgstr ""
+
+#: src/Content/Nav.php:262
+msgid "Manage/Edit Profiles"
+msgstr ""
+
+#: src/Content/Nav.php:270 src/Module/BaseAdminModule.php:112
+msgid "Admin"
+msgstr ""
+
+#: src/Content/Nav.php:270
+msgid "Site setup and configuration"
+msgstr ""
+
+#: src/Content/Nav.php:273
+msgid "Navigation"
+msgstr ""
+
+#: src/Content/Nav.php:273
+msgid "Site map"
+msgstr ""
+
+#: src/Content/OEmbed.php:252
+msgid "Embedding disabled"
+msgstr ""
+
+#: src/Content/OEmbed.php:374
+msgid "Embedded content"
+msgstr ""
+
+#: src/Content/Pager.php:153
+msgid "newer"
+msgstr ""
+
+#: src/Content/Pager.php:158
+msgid "older"
+msgstr ""
+
+#: src/Content/Pager.php:203
+msgid "prev"
+msgstr ""
+
+#: src/Content/Pager.php:263
+msgid "last"
+msgstr ""
+
+#: src/Content/Widget.php:35
+msgid "Add New Contact"
+msgstr ""
+
+#: src/Content/Widget.php:36
+msgid "Enter address or web location"
+msgstr ""
+
+#: src/Content/Widget.php:37
+msgid "Example: bob@example.com, http://example.com/barbara"
+msgstr ""
+
+#: src/Content/Widget.php:54
+#, php-format
+msgid "%d invitation available"
+msgid_plural "%d invitations available"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Module/Security/TwoFactor/Verify.php:65
-#: src/Module/Security/TwoFactor/Recovery.php:66
+#: src/Content/Widget.php:193 src/Module/Profile/Contacts.php:126
+#: src/Module/Contact.php:794
+msgid "Following"
+msgstr ""
+
+#: src/Content/Widget.php:194 src/Module/Profile/Contacts.php:127
+#: src/Module/Contact.php:795
+msgid "Mutual friends"
+msgstr ""
+
+#: src/Content/Widget.php:199
+msgid "Relationships"
+msgstr ""
+
+#: src/Content/Widget.php:201 src/Module/Contact.php:682
+#: src/Module/Group.php:279
+msgid "All Contacts"
+msgstr ""
+
+#: src/Content/Widget.php:244
+msgid "Protocols"
+msgstr ""
+
+#: src/Content/Widget.php:246
+msgid "All Protocols"
+msgstr ""
+
+#: src/Content/Widget.php:283
+msgid "Saved Folders"
+msgstr ""
+
+#: src/Content/Widget.php:285 src/Content/Widget.php:324
+msgid "Everything"
+msgstr ""
+
+#: src/Content/Widget.php:322
+msgid "Categories"
+msgstr ""
+
+#: src/Content/Widget.php:399
 #, php-format
-msgid ""
-"Don’t have your phone? <a href=\"%s\">Enter a two-factor recovery code</a>"
-msgstr ""
-
-#: src/Module/Security/TwoFactor/Verify.php:66
-#: src/Module/Settings/TwoFactor/Verify.php:122
-msgid "Please enter a code from your authentication app"
-msgstr ""
-
-#: src/Module/Security/TwoFactor/Verify.php:67
-msgid "Verify code and complete login"
-msgstr ""
-
-#: src/Module/Security/TwoFactor/Recovery.php:41
-#, php-format
-msgid "Remaining recovery codes: %d"
-msgstr ""
-
-#: src/Module/Security/TwoFactor/Recovery.php:64
-msgid "Two-factor recovery"
-msgstr ""
-
-#: src/Module/Security/TwoFactor/Recovery.php:65
-msgid ""
-"<p>You can enter one of your one-time recovery codes in case you lost access "
-"to your mobile device.</p>"
-msgstr ""
-
-#: src/Module/Security/TwoFactor/Recovery.php:67
-msgid "Please enter a recovery code"
-msgstr ""
-
-#: src/Module/Security/TwoFactor/Recovery.php:68
-msgid "Submit recovery code and complete login"
-msgstr ""
-
-#: src/Module/Security/OpenID.php:35
-msgid "OpenID protocol error. No ID returned"
-msgstr ""
-
-#: src/Module/Security/OpenID.php:73
-msgid ""
-"Account not found. Please login to your existing account to add the OpenID "
-"to it."
-msgstr ""
-
-#: src/Module/Security/OpenID.php:75
-msgid ""
-"Account not found. Please register a new account or login to your existing "
-"account to add the OpenID to it."
-msgstr ""
-
-#: src/Module/Security/Logout.php:39
-msgid "Logged out."
-msgstr ""
-
-#: src/Module/Profile.php:171 mod/cal.php:127 mod/display.php:270
-msgid "Access to this profile has been restricted."
-msgstr ""
-
-#: src/Module/Maintenance.php:27
-msgid "System down for maintenance"
-msgstr ""
-
-#: src/Module/Bookmarklet.php:36
-msgid "This page is missing a url parameter."
-msgstr ""
-
-#: src/Module/Bookmarklet.php:58
-msgid "The post was created"
-msgstr ""
-
-#: src/Module/Photo.php:86
-#, php-format
-msgid "Invalid photo with id %s."
-msgstr ""
-
-#: src/Module/Attach.php:35 src/Module/Attach.php:47
-msgid "Item was not found."
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Server.php:31
-msgid "Server domain pattern added to blocklist."
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Server.php:47
-msgid "Site blocklist updated."
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Server.php:62
-#: src/Module/Admin/Blocklist/Server.php:87
-msgid "Blocked server domain pattern"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Server.php:63
-#: src/Module/Admin/Blocklist/Server.php:88 src/Module/Friendica.php:59
-msgid "Reason for the block"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Server.php:64
-msgid "Delete server domain pattern"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Server.php:64
-msgid "Check to delete this entry from the blocklist"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Server.php:71
-#: src/Module/Admin/Blocklist/Contact.php:59 src/Module/Admin/Tos.php:42
-#: src/Module/Admin/Addons/Details.php:99 src/Module/Admin/Addons/Index.php:48
-#: src/Module/Admin/Themes/Details.php:104 src/Module/Admin/Themes/Index.php:93
-#: src/Module/Admin/Users.php:275 src/Module/Admin/Site.php:555
-#: src/Module/Admin/Federation.php:122 src/Module/Admin/Queue.php:56
-#: src/Module/Admin/Item/Delete.php:46 src/Module/Admin/Logs/Settings.php:61
-#: src/Module/Admin/Logs/View.php:46 src/Module/Admin/Summary.php:190
-msgid "Administration"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Server.php:72
-msgid "Server Domain Pattern Blocklist"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Server.php:73
-msgid ""
-"This page can be used to define a blacklist of server domain patterns from "
-"the federated network that are not allowed to interact with your node. For "
-"each domain pattern you should also provide the reason why you block it."
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Server.php:74
-msgid ""
-"The list of blocked server domain patterns will be made publically available "
-"on the <a href=\"/friendica\">/friendica</a> page so that your users and "
-"people investigating communication problems can find the reason easily."
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Server.php:75
-msgid ""
-"<p>The server domain pattern syntax is case-insensitive shell wildcard, "
-"comprising the following special characters:</p>\n"
-"<ul>\n"
-"\t<li><code>*</code>: Any number of characters</li>\n"
-"\t<li><code>?</code>: Any single character</li>\n"
-"\t<li><code>[&lt;char1&gt;&lt;char2&gt;...]</code>: char1 or char2</li>\n"
-"</ul>"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Server.php:81
-msgid "Add new entry to block list"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Server.php:82
-msgid "Server Domain Pattern"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Server.php:82
-msgid ""
-"The domain pattern of the new server to add to the block list. Do not "
-"include the protocol."
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Server.php:83
-msgid "Block reason"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Server.php:83
-msgid "The reason why you blocked this server domain pattern."
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Server.php:84
-msgid "Add Entry"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Server.php:85
-msgid "Save changes to the blocklist"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Server.php:86
-msgid "Current Entries in the Blocklist"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Server.php:89
-msgid "Delete entry from blocklist"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Server.php:92
-msgid "Delete entry from blocklist?"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Contact.php:28
-#: src/Console/GlobalCommunityBlock.php:87
-msgid "The contact has been blocked from the node"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Contact.php:30
-#: src/Console/GlobalCommunityBlock.php:82
-#, php-format
-msgid "Could not find any contact entry for this URL (%s)"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Contact.php:38
-#, php-format
-msgid "%s contact unblocked"
-msgid_plural "%s contacts unblocked"
+msgid "%d contact in common"
+msgid_plural "%d contacts in common"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Module/Admin/Blocklist/Contact.php:60
-msgid "Remote Contact Blocklist"
+#: src/Database/DBStructure.php:47
+msgid "There are no tables on MyISAM."
 msgstr ""
 
-#: src/Module/Admin/Blocklist/Contact.php:61
-msgid ""
-"This page allows you to prevent any message from a remote contact to reach "
-"your node."
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Contact.php:62
-msgid "Block Remote Contact"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Contact.php:63 src/Module/Admin/Users.php:278
-msgid "select all"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Contact.php:64
-msgid "select none"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Contact.php:66 src/Module/Admin/Users.php:289
-#: src/Module/Contact.php:605 src/Module/Contact.php:826
-#: src/Module/Contact.php:1085
-msgid "Unblock"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Contact.php:67
-msgid "No remote contact is blocked from this node."
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Contact.php:69
-msgid "Blocked Remote Contacts"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Contact.php:70
-msgid "Block New Remote Contact"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Contact.php:71
-msgid "Photo"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Contact.php:71 src/Module/Admin/Users.php:270
-#: src/Module/Admin/Users.php:281 src/Module/Admin/Users.php:295
-#: src/Module/Admin/Users.php:311 mod/crepair.php:159 mod/settings.php:666
-#: mod/settings.php:692
-msgid "Name"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Contact.php:71
-msgid "Reason"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Contact.php:79
+#: src/Database/DBStructure.php:71
 #, php-format
-msgid "%s total blocked contact"
-msgid_plural "%s total blocked contacts"
+msgid ""
+"\n"
+"Error %d occurred during database update:\n"
+"%s\n"
+msgstr ""
+
+#: src/Database/DBStructure.php:74
+msgid "Errors encountered performing database changes: "
+msgstr ""
+
+#: src/Database/DBStructure.php:263
+#, php-format
+msgid "%s: Database update"
+msgstr ""
+
+#: src/Database/DBStructure.php:524
+#, php-format
+msgid "%s: updating %s table."
+msgstr ""
+
+#: src/Model/Storage/Database.php:59
+#, php-format
+msgid "Database storage failed to update %s"
+msgstr ""
+
+#: src/Model/Storage/Database.php:67
+msgid "Database storage failed to insert data"
+msgstr ""
+
+#: src/Model/Storage/Filesystem.php:85
+#, php-format
+msgid ""
+"Filesystem storage failed to create \"%s\". Check you write permissions."
+msgstr ""
+
+#: src/Model/Storage/Filesystem.php:133
+#, php-format
+msgid ""
+"Filesystem storage failed to save data to \"%s\". Check your write "
+"permissions"
+msgstr ""
+
+#: src/Model/Storage/Filesystem.php:161
+msgid "Storage base path"
+msgstr ""
+
+#: src/Model/Storage/Filesystem.php:163
+msgid ""
+"Folder where uploaded files are saved. For maximum security, This should be "
+"a path outside web server folder tree"
+msgstr ""
+
+#: src/Model/Storage/Filesystem.php:176
+msgid "Enter a valid existing folder"
+msgstr ""
+
+#: src/Model/Contact.php:1274 src/Model/Contact.php:1287
+msgid "UnFollow"
+msgstr ""
+
+#: src/Model/Contact.php:1283
+msgid "Drop Contact"
+msgstr ""
+
+#: src/Model/Contact.php:1852
+msgid "Organisation"
+msgstr ""
+
+#: src/Model/Contact.php:1856
+msgid "News"
+msgstr ""
+
+#: src/Model/Contact.php:1860
+msgid "Forum"
+msgstr ""
+
+#: src/Model/Contact.php:2275
+msgid "Connect URL missing."
+msgstr ""
+
+#: src/Model/Contact.php:2284
+msgid ""
+"The contact could not be added. Please check the relevant network "
+"credentials in your Settings -> Social Networks page."
+msgstr ""
+
+#: src/Model/Contact.php:2325
+msgid ""
+"This site is not configured to allow communications with other networks."
+msgstr ""
+
+#: src/Model/Contact.php:2326 src/Model/Contact.php:2339
+msgid "No compatible communication protocols or feeds were discovered."
+msgstr ""
+
+#: src/Model/Contact.php:2337
+msgid "The profile address specified does not provide adequate information."
+msgstr ""
+
+#: src/Model/Contact.php:2342
+msgid "An author or name was not found."
+msgstr ""
+
+#: src/Model/Contact.php:2345
+msgid "No browser URL could be matched to this address."
+msgstr ""
+
+#: src/Model/Contact.php:2348
+msgid ""
+"Unable to match @-style Identity Address with a known protocol or email "
+"contact."
+msgstr ""
+
+#: src/Model/Contact.php:2349
+msgid "Use mailto: in front of address to force email check."
+msgstr ""
+
+#: src/Model/Contact.php:2355
+msgid ""
+"The profile address specified belongs to a network which has been disabled "
+"on this site."
+msgstr ""
+
+#: src/Model/Contact.php:2360
+msgid ""
+"Limited profile. This person will be unable to receive direct/personal "
+"notifications from you."
+msgstr ""
+
+#: src/Model/Contact.php:2421
+msgid "Unable to retrieve contact information."
+msgstr ""
+
+#: src/Model/Event.php:33 src/Model/Event.php:846
+#: src/Module/Debug/Localtime.php:17
+msgid "l F d, Y \\@ g:i A"
+msgstr ""
+
+#: src/Model/Event.php:60 src/Model/Event.php:77 src/Model/Event.php:434
+#: src/Model/Event.php:914
+msgid "Starts:"
+msgstr ""
+
+#: src/Model/Event.php:63 src/Model/Event.php:83 src/Model/Event.php:435
+#: src/Model/Event.php:918
+msgid "Finishes:"
+msgstr ""
+
+#: src/Model/Event.php:384
+msgid "all-day"
+msgstr ""
+
+#: src/Model/Event.php:410
+msgid "Sept"
+msgstr ""
+
+#: src/Model/Event.php:432
+msgid "No events to display"
+msgstr ""
+
+#: src/Model/Event.php:560
+msgid "l, F j"
+msgstr ""
+
+#: src/Model/Event.php:591
+msgid "Edit event"
+msgstr ""
+
+#: src/Model/Event.php:592
+msgid "Duplicate event"
+msgstr ""
+
+#: src/Model/Event.php:593
+msgid "Delete event"
+msgstr ""
+
+#: src/Model/Event.php:625 src/Model/Item.php:3651 src/Model/Item.php:3658
+msgid "link to source"
+msgstr ""
+
+#: src/Model/Event.php:847
+msgid "D g:i A"
+msgstr ""
+
+#: src/Model/Event.php:848
+msgid "g:i A"
+msgstr ""
+
+#: src/Model/Event.php:933 src/Model/Event.php:935
+msgid "Show map"
+msgstr ""
+
+#: src/Model/Event.php:934
+msgid "Hide map"
+msgstr ""
+
+#: src/Model/Event.php:1026
+#, php-format
+msgid "%s's birthday"
+msgstr ""
+
+#: src/Model/Event.php:1027
+#, php-format
+msgid "Happy Birthday %s"
+msgstr ""
+
+#: src/Model/FileTag.php:264
+msgid "Item filed"
+msgstr ""
+
+#: src/Model/Group.php:76
+msgid ""
+"A deleted group with this name was revived. Existing item permissions "
+"<strong>may</strong> apply to this group and any future members. If this is "
+"not what you intended, please create another group with a different name."
+msgstr ""
+
+#: src/Model/Group.php:425
+msgid "Default privacy group for new contacts"
+msgstr ""
+
+#: src/Model/Group.php:457
+msgid "Everybody"
+msgstr ""
+
+#: src/Model/Group.php:476
+msgid "edit"
+msgstr ""
+
+#: src/Model/Group.php:501
+msgid "add"
+msgstr ""
+
+#: src/Model/Group.php:502 src/Module/Contact.php:730 src/Module/Welcome.php:57
+msgid "Groups"
+msgstr ""
+
+#: src/Model/Group.php:506
+msgid "Edit group"
+msgstr ""
+
+#: src/Model/Group.php:507 src/Module/Group.php:178
+msgid "Contacts not in any group"
+msgstr ""
+
+#: src/Model/Group.php:509
+msgid "Create a new group"
+msgstr ""
+
+#: src/Model/Group.php:510 src/Module/Group.php:163 src/Module/Group.php:186
+#: src/Module/Group.php:263
+msgid "Group Name: "
+msgstr ""
+
+#: src/Model/Group.php:511
+msgid "Edit groups"
+msgstr ""
+
+#: src/Model/Item.php:3393
+msgid "activity"
+msgstr ""
+
+#: src/Model/Item.php:3395 src/Object/Post.php:494
+msgid "comment"
+msgid_plural "comments"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Module/Admin/Blocklist/Contact.php:81 src/Module/Contact.php:623
-#: mod/notifications.php:166 mod/notifications.php:258 mod/follow.php:178
-#: mod/unfollow.php:136
-msgid "Profile URL"
+#: src/Model/Item.php:3398
+msgid "post"
 msgstr ""
 
-#: src/Module/Admin/Blocklist/Contact.php:81
-msgid "URL of the remote contact to block."
+#: src/Model/Item.php:3521
+#, php-format
+msgid "Content warning: %s"
 msgstr ""
 
-#: src/Module/Admin/Blocklist/Contact.php:82
-msgid "Block Reason"
+#: src/Model/Item.php:3598
+msgid "bytes"
 msgstr ""
 
-#: src/Module/Admin/Tos.php:30
-msgid "The Terms of Service settings have been updated."
+#: src/Model/Item.php:3645
+msgid "View on separate page"
 msgstr ""
 
-#: src/Module/Admin/Tos.php:44
-msgid "Display Terms of Service"
+#: src/Model/Item.php:3646
+msgid "view on separate page"
 msgstr ""
 
-#: src/Module/Admin/Tos.php:44
+#: src/Model/Mail.php:112 src/Model/Mail.php:247
+msgid "[no subject]"
+msgstr ""
+
+#: src/Model/Notify.php:275 src/Model/Notify.php:287
+#, php-format
+msgid "%s commented on %s's post"
+msgstr ""
+
+#: src/Model/Notify.php:286
+#, php-format
+msgid "%s created a new post"
+msgstr ""
+
+#: src/Model/Notify.php:300
+#, php-format
+msgid "%s liked %s's post"
+msgstr ""
+
+#: src/Model/Notify.php:313
+#, php-format
+msgid "%s disliked %s's post"
+msgstr ""
+
+#: src/Model/Notify.php:326
+#, php-format
+msgid "%s is attending %s's event"
+msgstr ""
+
+#: src/Model/Notify.php:339
+#, php-format
+msgid "%s is not attending %s's event"
+msgstr ""
+
+#: src/Model/Notify.php:352
+#, php-format
+msgid "%s may attend %s's event"
+msgstr ""
+
+#: src/Model/Notify.php:385
+#, php-format
+msgid "%s is now friends with %s"
+msgstr ""
+
+#: src/Model/Notify.php:678
+msgid "Friend Suggestion"
+msgstr ""
+
+#: src/Model/Notify.php:712
+msgid "Friend/Connect Request"
+msgstr ""
+
+#: src/Model/Notify.php:712
+msgid "New Follower"
+msgstr ""
+
+#: src/Model/Profile.php:207 src/Model/Profile.php:418
+#: src/Model/Profile.php:875
+msgid "Edit profile"
+msgstr ""
+
+#: src/Model/Profile.php:392
+msgid "Manage/edit profiles"
+msgstr ""
+
+#: src/Model/Profile.php:441 src/Model/Profile.php:785
+#: src/Module/Directory.php:141
+msgid "Status:"
+msgstr ""
+
+#: src/Model/Profile.php:442 src/Model/Profile.php:802
+#: src/Module/Directory.php:142
+msgid "Homepage:"
+msgstr ""
+
+#: src/Model/Profile.php:444 src/Module/Contact.php:627
+msgid "XMPP:"
+msgstr ""
+
+#: src/Model/Profile.php:536 src/Module/Contact.php:317
+msgid "Unfollow"
+msgstr ""
+
+#: src/Model/Profile.php:538
+msgid "Atom feed"
+msgstr ""
+
+#: src/Model/Profile.php:578 src/Model/Profile.php:675
+msgid "g A l F d"
+msgstr ""
+
+#: src/Model/Profile.php:579
+msgid "F d"
+msgstr ""
+
+#: src/Model/Profile.php:641 src/Model/Profile.php:726
+msgid "[today]"
+msgstr ""
+
+#: src/Model/Profile.php:651
+msgid "Birthday Reminders"
+msgstr ""
+
+#: src/Model/Profile.php:652
+msgid "Birthdays this week:"
+msgstr ""
+
+#: src/Model/Profile.php:713
+msgid "[No description]"
+msgstr ""
+
+#: src/Model/Profile.php:739
+msgid "Event Reminders"
+msgstr ""
+
+#: src/Model/Profile.php:740
+msgid "Upcoming events the next 7 days:"
+msgstr ""
+
+#: src/Model/Profile.php:757
+msgid "Member since:"
+msgstr ""
+
+#: src/Model/Profile.php:765
+msgid "j F, Y"
+msgstr ""
+
+#: src/Model/Profile.php:766
+msgid "j F"
+msgstr ""
+
+#: src/Model/Profile.php:781
+msgid "Age:"
+msgstr ""
+
+#: src/Model/Profile.php:794
+#, php-format
+msgid "for %1$d %2$s"
+msgstr ""
+
+#: src/Model/Profile.php:818
+msgid "Religion:"
+msgstr ""
+
+#: src/Model/Profile.php:826
+msgid "Hobbies/Interests:"
+msgstr ""
+
+#: src/Model/Profile.php:838
+msgid "Contact information and Social Networks:"
+msgstr ""
+
+#: src/Model/Profile.php:842
+msgid "Musical interests:"
+msgstr ""
+
+#: src/Model/Profile.php:846
+msgid "Books, literature:"
+msgstr ""
+
+#: src/Model/Profile.php:850
+msgid "Television:"
+msgstr ""
+
+#: src/Model/Profile.php:854
+msgid "Film/dance/culture/entertainment:"
+msgstr ""
+
+#: src/Model/Profile.php:858
+msgid "Love/Romance:"
+msgstr ""
+
+#: src/Model/Profile.php:862
+msgid "Work/employment:"
+msgstr ""
+
+#: src/Model/Profile.php:866
+msgid "School/education:"
+msgstr ""
+
+#: src/Model/Profile.php:871
+msgid "Forums:"
+msgstr ""
+
+#: src/Model/Profile.php:918 src/Module/Contact.php:872
+msgid "Profile Details"
+msgstr ""
+
+#: src/Model/Profile.php:968
+msgid "Only You Can See This"
+msgstr ""
+
+#: src/Model/Profile.php:976 src/Model/Profile.php:979
+msgid "Tips for New Members"
+msgstr ""
+
+#: src/Model/Profile.php:1172
+#, php-format
+msgid "OpenWebAuth: %1$s welcomes %2$s"
+msgstr ""
+
+#: src/Model/User.php:355
+msgid "Login failed"
+msgstr ""
+
+#: src/Model/User.php:387
+msgid "Not enough information to authenticate"
+msgstr ""
+
+#: src/Model/User.php:481
+msgid "Password can't be empty"
+msgstr ""
+
+#: src/Model/User.php:500
+msgid "Empty passwords are not allowed."
+msgstr ""
+
+#: src/Model/User.php:504
 msgid ""
-"Enable the Terms of Service page. If this is enabled a link to the terms "
-"will be added to the registration form and the general information page."
+"The new password has been exposed in a public data dump, please choose "
+"another."
 msgstr ""
 
-#: src/Module/Admin/Tos.php:45
-msgid "Display Privacy Statement"
+#: src/Model/User.php:510
+msgid ""
+"The password can't contain accentuated letters, white spaces or colons (:)"
 msgstr ""
 
-#: src/Module/Admin/Tos.php:45
+#: src/Model/User.php:609
+msgid "Passwords do not match. Password unchanged."
+msgstr ""
+
+#: src/Model/User.php:616
+msgid "An invitation is required."
+msgstr ""
+
+#: src/Model/User.php:620
+msgid "Invitation could not be verified."
+msgstr ""
+
+#: src/Model/User.php:628
+msgid "Invalid OpenID url"
+msgstr ""
+
+#: src/Model/User.php:641 src/App/Authentication.php:209
+msgid ""
+"We encountered a problem while logging in with the OpenID you provided. "
+"Please check the correct spelling of the ID."
+msgstr ""
+
+#: src/Model/User.php:641 src/App/Authentication.php:209
+msgid "The error message was:"
+msgstr ""
+
+#: src/Model/User.php:647
+msgid "Please enter the required information."
+msgstr ""
+
+#: src/Model/User.php:661
 #, php-format
 msgid ""
-"Show some informations regarding the needed information to operate the node "
-"according e.g. to <a href=\"%s\" target=\"_blank\">EU-GDPR</a>."
+"system.username_min_length (%s) and system.username_max_length (%s) are "
+"excluding each other, swapping values."
 msgstr ""
 
-#: src/Module/Admin/Tos.php:46
-msgid "Privacy Statement Preview"
+#: src/Model/User.php:668
+#, php-format
+msgid "Username should be at least %s character."
+msgid_plural "Username should be at least %s characters."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/Model/User.php:672
+#, php-format
+msgid "Username should be at most %s character."
+msgid_plural "Username should be at most %s characters."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/Model/User.php:680
+msgid "That doesn't appear to be your full (First Last) name."
 msgstr ""
 
-#: src/Module/Admin/Tos.php:48
-msgid "The Terms of Service"
+#: src/Model/User.php:685
+msgid "Your email domain is not among those allowed on this site."
 msgstr ""
 
-#: src/Module/Admin/Tos.php:48
+#: src/Model/User.php:689
+msgid "Not a valid email address."
+msgstr ""
+
+#: src/Model/User.php:692
+msgid "The nickname was blocked from registration by the nodes admin."
+msgstr ""
+
+#: src/Model/User.php:696 src/Model/User.php:704
+msgid "Cannot use that email."
+msgstr ""
+
+#: src/Model/User.php:711
+msgid "Your nickname can only contain a-z, 0-9 and _."
+msgstr ""
+
+#: src/Model/User.php:719 src/Model/User.php:776
+msgid "Nickname is already registered. Please choose another."
+msgstr ""
+
+#: src/Model/User.php:729
+msgid "SERIOUS ERROR: Generation of security keys failed."
+msgstr ""
+
+#: src/Model/User.php:763 src/Model/User.php:767
+msgid "An error occurred during registration. Please try again."
+msgstr ""
+
+#: src/Model/User.php:792
+msgid "An error occurred creating your default profile. Please try again."
+msgstr ""
+
+#: src/Model/User.php:799
+msgid "An error occurred creating your self contact. Please try again."
+msgstr ""
+
+#: src/Model/User.php:808
 msgid ""
-"Enter the Terms of Service for your node here. You can use BBCode. Headers "
-"of sections should be [h2] and below."
+"An error occurred creating your default contact group. Please try again."
+msgstr ""
+
+#: src/Model/User.php:885
+#, php-format
+msgid ""
+"\n"
+"\t\t\tDear %1$s,\n"
+"\t\t\t\tThank you for registering at %2$s. Your account is pending for "
+"approval by the administrator.\n"
+"\n"
+"\t\t\tYour login details are as follows:\n"
+"\n"
+"\t\t\tSite Location:\t%3$s\n"
+"\t\t\tLogin Name:\t\t%4$s\n"
+"\t\t\tPassword:\t\t%5$s\n"
+"\t\t"
+msgstr ""
+
+#: src/Model/User.php:906
+#, php-format
+msgid "Registration at %s"
+msgstr ""
+
+#: src/Model/User.php:928
+#, php-format
+msgid ""
+"\n"
+"\t\t\t\tDear %1$s,\n"
+"\t\t\t\tThank you for registering at %2$s. Your account has been created.\n"
+"\t\t\t"
+msgstr ""
+
+#: src/Model/User.php:936
+#, php-format
+msgid ""
+"\n"
+"\t\t\tThe login details are as follows:\n"
+"\n"
+"\t\t\tSite Location:\t%3$s\n"
+"\t\t\tLogin Name:\t\t%1$s\n"
+"\t\t\tPassword:\t\t%5$s\n"
+"\n"
+"\t\t\tYou may change your password from your account \"Settings\" page after "
+"logging\n"
+"\t\t\tin.\n"
+"\n"
+"\t\t\tPlease take a few moments to review the other account settings on that "
+"page.\n"
+"\n"
+"\t\t\tYou may also wish to add some basic information to your default "
+"profile\n"
+"\t\t\t(on the \"Profiles\" page) so that other people can easily find you.\n"
+"\n"
+"\t\t\tWe recommend setting your full name, adding a profile photo,\n"
+"\t\t\tadding some profile \"keywords\" (very useful in making new friends) - "
+"and\n"
+"\t\t\tperhaps what country you live in; if you do not wish to be more "
+"specific\n"
+"\t\t\tthan that.\n"
+"\n"
+"\t\t\tWe fully respect your right to privacy, and none of these items are "
+"necessary.\n"
+"\t\t\tIf you are new and do not know anybody here, they may help\n"
+"\t\t\tyou to make some new and interesting friends.\n"
+"\n"
+"\t\t\tIf you ever want to delete your account, you can do so at %3$s/"
+"removeme\n"
+"\n"
+"\t\t\tThank you and welcome to %2$s."
+msgstr ""
+
+#: src/Model/User.php:975 src/Module/Admin/Users.php:85
+#, php-format
+msgid "Registration details for %s"
+msgstr ""
+
+#: src/Protocol/Diaspora.php:3575
+msgid "Attachments:"
+msgstr ""
+
+#: src/Protocol/OStatus.php:1271 src/Module/Profile.php:115
+#: src/Module/Profile.php:118
+#, php-format
+msgid "%s's timeline"
+msgstr ""
+
+#: src/Protocol/OStatus.php:1275 src/Module/Profile.php:116
+#, php-format
+msgid "%s's posts"
+msgstr ""
+
+#: src/Protocol/OStatus.php:1278 src/Module/Profile.php:117
+#, php-format
+msgid "%s's comments"
+msgstr ""
+
+#: src/Protocol/OStatus.php:1833
+#, php-format
+msgid "%s is now following %s."
+msgstr ""
+
+#: src/Protocol/OStatus.php:1834
+msgid "following"
+msgstr ""
+
+#: src/Protocol/OStatus.php:1837
+#, php-format
+msgid "%s stopped following %s."
+msgstr ""
+
+#: src/Protocol/OStatus.php:1838
+msgid "stopped following"
+msgstr ""
+
+#: src/Worker/Delivery.php:538
+msgid "(no subject)"
 msgstr ""
 
 #: src/Module/Admin/Addons/Details.php:51
@@ -7348,6 +6603,17 @@ msgstr ""
 #: src/Module/Admin/Addons/Details.php:79
 #: src/Module/Admin/Themes/Details.php:63
 msgid "Enable"
+msgstr ""
+
+#: src/Module/Admin/Addons/Details.php:99 src/Module/Admin/Addons/Index.php:48
+#: src/Module/Admin/Blocklist/Contact.php:59
+#: src/Module/Admin/Blocklist/Server.php:70 src/Module/Admin/Item/Delete.php:46
+#: src/Module/Admin/Logs/Settings.php:60 src/Module/Admin/Logs/View.php:45
+#: src/Module/Admin/Themes/Details.php:104 src/Module/Admin/Themes/Index.php:92
+#: src/Module/Admin/Federation.php:121 src/Module/Admin/Queue.php:56
+#: src/Module/Admin/Site.php:554 src/Module/Admin/Summary.php:190
+#: src/Module/Admin/Tos.php:41 src/Module/Admin/Users.php:274
+msgid "Administration"
 msgstr ""
 
 #: src/Module/Admin/Addons/Details.php:101
@@ -7382,25 +6648,311 @@ msgid ""
 "the open addon registry at %2$s"
 msgstr ""
 
-#: src/Module/Admin/Themes/Embed.php:46 src/Module/Admin/Themes/Details.php:32
+#: src/Module/Admin/Blocklist/Contact.php:28
+#: src/Console/GlobalCommunityBlock.php:87
+msgid "The contact has been blocked from the node"
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Contact.php:30
+#: src/Console/GlobalCommunityBlock.php:82
+#, php-format
+msgid "Could not find any contact entry for this URL (%s)"
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Contact.php:38
+#, php-format
+msgid "%s contact unblocked"
+msgid_plural "%s contacts unblocked"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/Module/Admin/Blocklist/Contact.php:60
+msgid "Remote Contact Blocklist"
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Contact.php:61
+msgid ""
+"This page allows you to prevent any message from a remote contact to reach "
+"your node."
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Contact.php:62
+msgid "Block Remote Contact"
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Contact.php:63 src/Module/Admin/Users.php:277
+msgid "select all"
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Contact.php:64
+msgid "select none"
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Contact.php:66 src/Module/Admin/Users.php:288
+#: src/Module/Contact.php:603 src/Module/Contact.php:824
+#: src/Module/Contact.php:1083
+msgid "Unblock"
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Contact.php:67
+msgid "No remote contact is blocked from this node."
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Contact.php:69
+msgid "Blocked Remote Contacts"
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Contact.php:70
+msgid "Block New Remote Contact"
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Contact.php:71
+msgid "Photo"
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Contact.php:71
+msgid "Reason"
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Contact.php:79
+#, php-format
+msgid "%s total blocked contact"
+msgid_plural "%s total blocked contacts"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/Module/Admin/Blocklist/Contact.php:81
+msgid "URL of the remote contact to block."
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Contact.php:82
+msgid "Block Reason"
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Server.php:30
+msgid "Server domain pattern added to blocklist."
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Server.php:46
+msgid "Site blocklist updated."
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Server.php:61
+#: src/Module/Admin/Blocklist/Server.php:86
+msgid "Blocked server domain pattern"
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Server.php:62
+#: src/Module/Admin/Blocklist/Server.php:87 src/Module/Friendica.php:59
+msgid "Reason for the block"
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Server.php:63
+msgid "Delete server domain pattern"
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Server.php:63
+msgid "Check to delete this entry from the blocklist"
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Server.php:71
+msgid "Server Domain Pattern Blocklist"
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Server.php:72
+msgid ""
+"This page can be used to define a blacklist of server domain patterns from "
+"the federated network that are not allowed to interact with your node. For "
+"each domain pattern you should also provide the reason why you block it."
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Server.php:73
+msgid ""
+"The list of blocked server domain patterns will be made publically available "
+"on the <a href=\"/friendica\">/friendica</a> page so that your users and "
+"people investigating communication problems can find the reason easily."
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Server.php:74
+msgid ""
+"<p>The server domain pattern syntax is case-insensitive shell wildcard, "
+"comprising the following special characters:</p>\n"
+"<ul>\n"
+"\t<li><code>*</code>: Any number of characters</li>\n"
+"\t<li><code>?</code>: Any single character</li>\n"
+"\t<li><code>[&lt;char1&gt;&lt;char2&gt;...]</code>: char1 or char2</li>\n"
+"</ul>"
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Server.php:80
+msgid "Add new entry to block list"
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Server.php:81
+msgid "Server Domain Pattern"
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Server.php:81
+msgid ""
+"The domain pattern of the new server to add to the block list. Do not "
+"include the protocol."
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Server.php:82
+msgid "Block reason"
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Server.php:82
+msgid "The reason why you blocked this server domain pattern."
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Server.php:83
+msgid "Add Entry"
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Server.php:84
+msgid "Save changes to the blocklist"
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Server.php:85
+msgid "Current Entries in the Blocklist"
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Server.php:88
+msgid "Delete entry from blocklist"
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Server.php:91
+msgid "Delete entry from blocklist?"
+msgstr ""
+
+#: src/Module/Admin/Item/Delete.php:35
+msgid "Item marked for deletion."
+msgstr ""
+
+#: src/Module/Admin/Item/Delete.php:47 src/Module/BaseAdminModule.php:93
+msgid "Delete Item"
+msgstr ""
+
+#: src/Module/Admin/Item/Delete.php:48
+msgid "Delete this Item"
+msgstr ""
+
+#: src/Module/Admin/Item/Delete.php:49
+msgid ""
+"On this page you can delete an item from your node. If the item is a top "
+"level posting, the entire thread will be deleted."
+msgstr ""
+
+#: src/Module/Admin/Item/Delete.php:50
+msgid ""
+"You need to know the GUID of the item. You can find it e.g. by looking at "
+"the display URL. The last part of http://example.com/display/123456 is the "
+"GUID, here 123456."
+msgstr ""
+
+#: src/Module/Admin/Item/Delete.php:51
+msgid "GUID"
+msgstr ""
+
+#: src/Module/Admin/Item/Delete.php:51
+msgid "The GUID of the item you want to delete."
+msgstr ""
+
+#: src/Module/Admin/Item/Source.php:47
+msgid "Item Guid"
+msgstr ""
+
+#: src/Module/Admin/Logs/Settings.php:26
+#, php-format
+msgid "The logfile '%s' is not writable. No logging possible"
+msgstr ""
+
+#: src/Module/Admin/Logs/Settings.php:35
+msgid "Log settings updated."
+msgstr ""
+
+#: src/Module/Admin/Logs/Settings.php:52
+msgid "PHP log currently enabled."
+msgstr ""
+
+#: src/Module/Admin/Logs/Settings.php:54
+msgid "PHP log currently disabled."
+msgstr ""
+
+#: src/Module/Admin/Logs/Settings.php:61 src/Module/BaseAdminModule.php:95
+#: src/Module/BaseAdminModule.php:96
+msgid "Logs"
+msgstr ""
+
+#: src/Module/Admin/Logs/Settings.php:63
+msgid "Clear"
+msgstr ""
+
+#: src/Module/Admin/Logs/Settings.php:67
+msgid "Enable Debugging"
+msgstr ""
+
+#: src/Module/Admin/Logs/Settings.php:68
+msgid "Log file"
+msgstr ""
+
+#: src/Module/Admin/Logs/Settings.php:68
+msgid ""
+"Must be writable by web server. Relative to your Friendica top-level "
+"directory."
+msgstr ""
+
+#: src/Module/Admin/Logs/Settings.php:69
+msgid "Log level"
+msgstr ""
+
+#: src/Module/Admin/Logs/Settings.php:71
+msgid "PHP logging"
+msgstr ""
+
+#: src/Module/Admin/Logs/Settings.php:72
+msgid ""
+"To temporarily enable logging of PHP errors and warnings you can prepend the "
+"following to the index.php file of your installation. The filename set in "
+"the 'error_log' line is relative to the friendica top-level directory and "
+"must be writeable by the web server. The option '1' for 'log_errors' and "
+"'display_errors' is to enable these options, set to '0' to disable them."
+msgstr ""
+
+#: src/Module/Admin/Logs/View.php:21
+#, php-format
+msgid ""
+"Error trying to open <strong>%1$s</strong> log file.\\r\\n<br/>Check to see "
+"if file %1$s exist and is readable."
+msgstr ""
+
+#: src/Module/Admin/Logs/View.php:25
+#, php-format
+msgid ""
+"Couldn't open <strong>%1$s</strong> log file.\\r\\n<br/>Check to see if file "
+"%1$s is readable."
+msgstr ""
+
+#: src/Module/Admin/Logs/View.php:46 src/Module/BaseAdminModule.php:97
+msgid "View Logs"
+msgstr ""
+
+#: src/Module/Admin/Themes/Details.php:32 src/Module/Admin/Themes/Embed.php:46
 msgid "Theme settings updated."
 msgstr ""
 
-#: src/Module/Admin/Themes/Embed.php:67
-msgid "Unknown theme."
-msgstr ""
-
-#: src/Module/Admin/Themes/Details.php:71 src/Module/Admin/Themes/Index.php:47
+#: src/Module/Admin/Themes/Details.php:71 src/Module/Admin/Themes/Index.php:46
 #, php-format
 msgid "Theme %s disabled."
 msgstr ""
 
-#: src/Module/Admin/Themes/Details.php:73 src/Module/Admin/Themes/Index.php:49
+#: src/Module/Admin/Themes/Details.php:73 src/Module/Admin/Themes/Index.php:48
 #, php-format
 msgid "Theme %s successfully enabled."
 msgstr ""
 
-#: src/Module/Admin/Themes/Details.php:75 src/Module/Admin/Themes/Index.php:51
+#: src/Module/Admin/Themes/Details.php:75 src/Module/Admin/Themes/Index.php:50
 #, php-format
 msgid "Theme %s failed to install."
 msgstr ""
@@ -7409,1212 +6961,126 @@ msgstr ""
 msgid "Screenshot"
 msgstr ""
 
-#: src/Module/Admin/Themes/Index.php:96
+#: src/Module/Admin/Themes/Details.php:105 src/Module/Admin/Themes/Index.php:93
+#: src/Module/BaseAdminModule.php:81
+msgid "Themes"
+msgstr ""
+
+#: src/Module/Admin/Themes/Embed.php:67
+msgid "Unknown theme."
+msgstr ""
+
+#: src/Module/Admin/Themes/Index.php:95
 msgid "Reload active themes"
 msgstr ""
 
-#: src/Module/Admin/Themes/Index.php:101
+#: src/Module/Admin/Themes/Index.php:100
 #, php-format
 msgid "No themes found on the system. They should be placed in %1$s"
 msgstr ""
 
-#: src/Module/Admin/Themes/Index.php:102
+#: src/Module/Admin/Themes/Index.php:101
 msgid "[Experimental]"
 msgstr ""
 
-#: src/Module/Admin/Themes/Index.php:103
+#: src/Module/Admin/Themes/Index.php:102
 msgid "[Unsupported]"
 msgstr ""
 
-#: src/Module/Admin/Users.php:46
+#: src/Module/Admin/DBSync.php:31
+msgid "Update has been marked successful"
+msgstr ""
+
+#: src/Module/Admin/DBSync.php:41
 #, php-format
-msgid ""
-"\n"
-"\t\t\tDear %1$s,\n"
-"\t\t\t\tthe administrator of %2$s has set up an account for you."
+msgid "Database structure update %s was successfully applied."
 msgstr ""
 
-#: src/Module/Admin/Users.php:49
+#: src/Module/Admin/DBSync.php:45
 #, php-format
-msgid ""
-"\n"
-"\t\t\tThe login details are as follows:\n"
-"\n"
-"\t\t\tSite Location:\t%1$s\n"
-"\t\t\tLogin Name:\t\t%2$s\n"
-"\t\t\tPassword:\t\t%3$s\n"
-"\n"
-"\t\t\tYou may change your password from your account \"Settings\" page after "
-"logging\n"
-"\t\t\tin.\n"
-"\n"
-"\t\t\tPlease take a few moments to review the other account settings on that "
-"page.\n"
-"\n"
-"\t\t\tYou may also wish to add some basic information to your default "
-"profile\n"
-"\t\t\t(on the \"Profiles\" page) so that other people can easily find you.\n"
-"\n"
-"\t\t\tWe recommend setting your full name, adding a profile photo,\n"
-"\t\t\tadding some profile \"keywords\" (very useful in making new friends) - "
-"and\n"
-"\t\t\tperhaps what country you live in; if you do not wish to be more "
-"specific\n"
-"\t\t\tthan that.\n"
-"\n"
-"\t\t\tWe fully respect your right to privacy, and none of these items are "
-"necessary.\n"
-"\t\t\tIf you are new and do not know anybody here, they may help\n"
-"\t\t\tyou to make some new and interesting friends.\n"
-"\n"
-"\t\t\tIf you ever want to delete your account, you can do so at %1$s/"
-"removeme\n"
-"\n"
-"\t\t\tThank you and welcome to %4$s."
+msgid "Executing of database structure update %s failed with error: %s"
 msgstr ""
 
-#: src/Module/Admin/Users.php:94
+#: src/Module/Admin/DBSync.php:62
 #, php-format
-msgid "%s user blocked"
-msgid_plural "%s users blocked"
-msgstr[0] ""
-msgstr[1] ""
+msgid "Executing %s failed with error: %s"
+msgstr ""
 
-#: src/Module/Admin/Users.php:100
+#: src/Module/Admin/DBSync.php:64
 #, php-format
-msgid "%s user unblocked"
-msgid_plural "%s users unblocked"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/Module/Admin/Users.php:108 src/Module/Admin/Users.php:158
-msgid "You can't remove yourself"
+msgid "Update %s was successfully applied."
 msgstr ""
 
-#: src/Module/Admin/Users.php:112
+#: src/Module/Admin/DBSync.php:67
 #, php-format
-msgid "%s user deleted"
-msgid_plural "%s users deleted"
-msgstr[0] ""
-msgstr[1] ""
+msgid "Update %s did not return a status. Unknown if it succeeded."
+msgstr ""
 
-#: src/Module/Admin/Users.php:156
+#: src/Module/Admin/DBSync.php:70
 #, php-format
-msgid "User \"%s\" deleted"
+msgid "There was no additional update function %s that needed to be called."
 msgstr ""
 
-#: src/Module/Admin/Users.php:165
+#: src/Module/Admin/DBSync.php:90
+msgid "No failed updates."
+msgstr ""
+
+#: src/Module/Admin/DBSync.php:91
+msgid "Check database structure"
+msgstr ""
+
+#: src/Module/Admin/DBSync.php:96
+msgid "Failed Updates"
+msgstr ""
+
+#: src/Module/Admin/DBSync.php:97
+msgid ""
+"This does not include updates prior to 1139, which did not return a status."
+msgstr ""
+
+#: src/Module/Admin/DBSync.php:98
+msgid "Mark success (if update was manually applied)"
+msgstr ""
+
+#: src/Module/Admin/DBSync.php:99
+msgid "Attempt to execute this update step automatically"
+msgstr ""
+
+#: src/Module/Admin/Features.php:58
 #, php-format
-msgid "User \"%s\" blocked"
+msgid "Lock feature %s"
 msgstr ""
 
-#: src/Module/Admin/Users.php:171
-#, php-format
-msgid "User \"%s\" unblocked"
+#: src/Module/Admin/Features.php:66
+msgid "Manage Additional Features"
 msgstr ""
 
-#: src/Module/Admin/Users.php:220 mod/settings.php:1048
-msgid "Normal Account Page"
-msgstr ""
-
-#: src/Module/Admin/Users.php:221 mod/settings.php:1052
-msgid "Soapbox Page"
-msgstr ""
-
-#: src/Module/Admin/Users.php:222 mod/settings.php:1056
-msgid "Public Forum"
-msgstr ""
-
-#: src/Module/Admin/Users.php:223 mod/settings.php:1060
-msgid "Automatic Friend Page"
-msgstr ""
-
-#: src/Module/Admin/Users.php:224
-msgid "Private Forum"
-msgstr ""
-
-#: src/Module/Admin/Users.php:227 mod/settings.php:1032
-msgid "Personal Page"
-msgstr ""
-
-#: src/Module/Admin/Users.php:228 mod/settings.php:1036
-msgid "Organisation Page"
-msgstr ""
-
-#: src/Module/Admin/Users.php:229 mod/settings.php:1040
-msgid "News Page"
-msgstr ""
-
-#: src/Module/Admin/Users.php:230 mod/settings.php:1044
-msgid "Community Forum"
-msgstr ""
-
-#: src/Module/Admin/Users.php:231
-msgid "Relay"
-msgstr ""
-
-#: src/Module/Admin/Users.php:270 src/Module/Admin/Users.php:295
-msgid "Register date"
-msgstr ""
-
-#: src/Module/Admin/Users.php:270 src/Module/Admin/Users.php:295
-msgid "Last login"
-msgstr ""
-
-#: src/Module/Admin/Users.php:270 src/Module/Admin/Users.php:295
-msgid "Last item"
-msgstr ""
-
-#: src/Module/Admin/Users.php:270
-msgid "Type"
-msgstr ""
-
-#: src/Module/Admin/Users.php:277
-msgid "Add User"
-msgstr ""
-
-#: src/Module/Admin/Users.php:279
-msgid "User registrations waiting for confirm"
-msgstr ""
-
-#: src/Module/Admin/Users.php:280
-msgid "User waiting for permanent deletion"
-msgstr ""
-
-#: src/Module/Admin/Users.php:281
-msgid "Request date"
-msgstr ""
-
-#: src/Module/Admin/Users.php:282
-msgid "No registrations."
-msgstr ""
-
-#: src/Module/Admin/Users.php:283
-msgid "Note from the user"
-msgstr ""
-
-#: src/Module/Admin/Users.php:285
-msgid "Deny"
-msgstr ""
-
-#: src/Module/Admin/Users.php:288
-msgid "User blocked"
-msgstr ""
-
-#: src/Module/Admin/Users.php:290
-msgid "Site admin"
-msgstr ""
-
-#: src/Module/Admin/Users.php:291
-msgid "Account expired"
-msgstr ""
-
-#: src/Module/Admin/Users.php:294
-msgid "New User"
-msgstr ""
-
-#: src/Module/Admin/Users.php:295
-msgid "Permanent deletion"
-msgstr ""
-
-#: src/Module/Admin/Users.php:300
-msgid ""
-"Selected users will be deleted!\\n\\nEverything these users had posted on "
-"this site will be permanently deleted!\\n\\nAre you sure?"
-msgstr ""
-
-#: src/Module/Admin/Users.php:301
-msgid ""
-"The user {0} will be deleted!\\n\\nEverything this user has posted on this "
-"site will be permanently deleted!\\n\\nAre you sure?"
-msgstr ""
-
-#: src/Module/Admin/Users.php:311
-msgid "Name of the new user."
-msgstr ""
-
-#: src/Module/Admin/Users.php:312
-msgid "Nickname"
-msgstr ""
-
-#: src/Module/Admin/Users.php:312
-msgid "Nickname of the new user."
-msgstr ""
-
-#: src/Module/Admin/Users.php:313
-msgid "Email address of the new user."
-msgstr ""
-
-#: src/Module/Admin/Site.php:49
-msgid "Can not parse base url. Must have at least <scheme>://<domain>"
-msgstr ""
-
-#: src/Module/Admin/Site.php:230
-msgid "Invalid storage backend setting value."
-msgstr ""
-
-#: src/Module/Admin/Site.php:405
-msgid "Site settings updated."
-msgstr ""
-
-#: src/Module/Admin/Site.php:426 mod/settings.php:892
-msgid "No special theme for mobile devices"
-msgstr ""
-
-#: src/Module/Admin/Site.php:443 mod/settings.php:902
-#, php-format
-msgid "%s - (Experimental)"
-msgstr ""
-
-#: src/Module/Admin/Site.php:455
-msgid "No community page for local users"
-msgstr ""
-
-#: src/Module/Admin/Site.php:456
-msgid "No community page"
-msgstr ""
-
-#: src/Module/Admin/Site.php:457
-msgid "Public postings from users of this site"
-msgstr ""
-
-#: src/Module/Admin/Site.php:458
-msgid "Public postings from the federated network"
-msgstr ""
-
-#: src/Module/Admin/Site.php:459
-msgid "Public postings from local users and the federated network"
-msgstr ""
-
-#: src/Module/Admin/Site.php:465
-msgid "Users, Global Contacts"
-msgstr ""
-
-#: src/Module/Admin/Site.php:466
-msgid "Users, Global Contacts/fallback"
-msgstr ""
-
-#: src/Module/Admin/Site.php:470
-msgid "One month"
-msgstr ""
-
-#: src/Module/Admin/Site.php:471
-msgid "Three months"
-msgstr ""
-
-#: src/Module/Admin/Site.php:472
-msgid "Half a year"
-msgstr ""
-
-#: src/Module/Admin/Site.php:473
-msgid "One year"
-msgstr ""
-
-#: src/Module/Admin/Site.php:479
-msgid "Multi user instance"
-msgstr ""
-
-#: src/Module/Admin/Site.php:501
-msgid "Closed"
-msgstr ""
-
-#: src/Module/Admin/Site.php:502
-msgid "Requires approval"
-msgstr ""
-
-#: src/Module/Admin/Site.php:503
-msgid "Open"
-msgstr ""
-
-#: src/Module/Admin/Site.php:513
-msgid "Don't check"
-msgstr ""
-
-#: src/Module/Admin/Site.php:514
-msgid "check the stable version"
-msgstr ""
-
-#: src/Module/Admin/Site.php:515
-msgid "check the development version"
-msgstr ""
-
-#: src/Module/Admin/Site.php:532
-msgid "Database (legacy)"
-msgstr ""
-
-#: src/Module/Admin/Site.php:558
-msgid "Republish users to directory"
-msgstr ""
-
-#: src/Module/Admin/Site.php:559 src/Module/Register.php:121
-msgid "Registration"
-msgstr ""
-
-#: src/Module/Admin/Site.php:560
-msgid "File upload"
-msgstr ""
-
-#: src/Module/Admin/Site.php:561
-msgid "Policies"
-msgstr ""
-
-#: src/Module/Admin/Site.php:563
-msgid "Auto Discovered Contact Directory"
-msgstr ""
-
-#: src/Module/Admin/Site.php:564
-msgid "Performance"
-msgstr ""
-
-#: src/Module/Admin/Site.php:565
-msgid "Worker"
-msgstr ""
-
-#: src/Module/Admin/Site.php:566
-msgid "Message Relay"
-msgstr ""
-
-#: src/Module/Admin/Site.php:567
-msgid "Relocate Instance"
-msgstr ""
-
-#: src/Module/Admin/Site.php:568
-msgid "Warning! Advanced function. Could make this server unreachable."
-msgstr ""
-
-#: src/Module/Admin/Site.php:573
-msgid "Sender Email"
-msgstr ""
-
-#: src/Module/Admin/Site.php:573
-msgid ""
-"The email address your server shall use to send notification emails from."
-msgstr ""
-
-#: src/Module/Admin/Site.php:574
-msgid "Banner/Logo"
-msgstr ""
-
-#: src/Module/Admin/Site.php:575
-msgid "Shortcut icon"
-msgstr ""
-
-#: src/Module/Admin/Site.php:575
-msgid "Link to an icon that will be used for browsers."
-msgstr ""
-
-#: src/Module/Admin/Site.php:576
-msgid "Touch icon"
-msgstr ""
-
-#: src/Module/Admin/Site.php:576
-msgid "Link to an icon that will be used for tablets and mobiles."
-msgstr ""
-
-#: src/Module/Admin/Site.php:577
-msgid "Additional Info"
-msgstr ""
-
-#: src/Module/Admin/Site.php:577
-#, php-format
-msgid ""
-"For public servers: you can add additional information here that will be "
-"listed at %s/servers."
-msgstr ""
-
-#: src/Module/Admin/Site.php:578
-msgid "System language"
-msgstr ""
-
-#: src/Module/Admin/Site.php:579
-msgid "System theme"
-msgstr ""
-
-#: src/Module/Admin/Site.php:579
-msgid ""
-"Default system theme - may be over-ridden by user profiles - <a href=\"/"
-"admin/themes\" id=\"cnftheme\">Change default theme settings</a>"
-msgstr ""
-
-#: src/Module/Admin/Site.php:580
-msgid "Mobile system theme"
-msgstr ""
-
-#: src/Module/Admin/Site.php:580
-msgid "Theme for mobile devices"
-msgstr ""
-
-#: src/Module/Admin/Site.php:582
-msgid "Force SSL"
-msgstr ""
-
-#: src/Module/Admin/Site.php:582
-msgid ""
-"Force all Non-SSL requests to SSL - Attention: on some systems it could lead "
-"to endless loops."
-msgstr ""
-
-#: src/Module/Admin/Site.php:583
-msgid "Hide help entry from navigation menu"
-msgstr ""
-
-#: src/Module/Admin/Site.php:583
-msgid ""
-"Hides the menu entry for the Help pages from the navigation menu. You can "
-"still access it calling /help directly."
-msgstr ""
-
-#: src/Module/Admin/Site.php:584
-msgid "Single user instance"
-msgstr ""
-
-#: src/Module/Admin/Site.php:584
-msgid "Make this instance multi-user or single-user for the named user"
-msgstr ""
-
-#: src/Module/Admin/Site.php:586
-msgid "File storage backend"
-msgstr ""
-
-#: src/Module/Admin/Site.php:586
-msgid ""
-"The backend used to store uploaded data. If you change the storage backend, "
-"you can manually move the existing files. If you do not do so, the files "
-"uploaded before the change will still be available at the old backend. "
-"Please see <a href=\"/help/Settings#1_2_3_1\">the settings documentation</a> "
-"for more information about the choices and the moving procedure."
-msgstr ""
-
-#: src/Module/Admin/Site.php:588
-msgid "Maximum image size"
-msgstr ""
-
-#: src/Module/Admin/Site.php:588
-msgid ""
-"Maximum size in bytes of uploaded images. Default is 0, which means no "
-"limits."
-msgstr ""
-
-#: src/Module/Admin/Site.php:589
-msgid "Maximum image length"
-msgstr ""
-
-#: src/Module/Admin/Site.php:589
-msgid ""
-"Maximum length in pixels of the longest side of uploaded images. Default is "
-"-1, which means no limits."
-msgstr ""
-
-#: src/Module/Admin/Site.php:590
-msgid "JPEG image quality"
-msgstr ""
-
-#: src/Module/Admin/Site.php:590
-msgid ""
-"Uploaded JPEGS will be saved at this quality setting [0-100]. Default is "
-"100, which is full quality."
-msgstr ""
-
-#: src/Module/Admin/Site.php:592
-msgid "Register policy"
-msgstr ""
-
-#: src/Module/Admin/Site.php:593
-msgid "Maximum Daily Registrations"
-msgstr ""
-
-#: src/Module/Admin/Site.php:593
-msgid ""
-"If registration is permitted above, this sets the maximum number of new user "
-"registrations to accept per day.  If register is set to closed, this setting "
-"has no effect."
-msgstr ""
-
-#: src/Module/Admin/Site.php:594
-msgid "Register text"
-msgstr ""
-
-#: src/Module/Admin/Site.php:594
-msgid ""
-"Will be displayed prominently on the registration page. You can use BBCode "
-"here."
-msgstr ""
-
-#: src/Module/Admin/Site.php:595
-msgid "Forbidden Nicknames"
-msgstr ""
-
-#: src/Module/Admin/Site.php:595
-msgid ""
-"Comma separated list of nicknames that are forbidden from registration. "
-"Preset is a list of role names according RFC 2142."
-msgstr ""
-
-#: src/Module/Admin/Site.php:596
-msgid "Accounts abandoned after x days"
-msgstr ""
-
-#: src/Module/Admin/Site.php:596
-msgid ""
-"Will not waste system resources polling external sites for abandonded "
-"accounts. Enter 0 for no time limit."
-msgstr ""
-
-#: src/Module/Admin/Site.php:597
-msgid "Allowed friend domains"
-msgstr ""
-
-#: src/Module/Admin/Site.php:597
-msgid ""
-"Comma separated list of domains which are allowed to establish friendships "
-"with this site. Wildcards are accepted. Empty to allow any domains"
-msgstr ""
-
-#: src/Module/Admin/Site.php:598
-msgid "Allowed email domains"
-msgstr ""
-
-#: src/Module/Admin/Site.php:598
-msgid ""
-"Comma separated list of domains which are allowed in email addresses for "
-"registrations to this site. Wildcards are accepted. Empty to allow any "
-"domains"
-msgstr ""
-
-#: src/Module/Admin/Site.php:599
-msgid "No OEmbed rich content"
-msgstr ""
-
-#: src/Module/Admin/Site.php:599
-msgid ""
-"Don't show the rich content (e.g. embedded PDF), except from the domains "
-"listed below."
-msgstr ""
-
-#: src/Module/Admin/Site.php:600
-msgid "Allowed OEmbed domains"
-msgstr ""
-
-#: src/Module/Admin/Site.php:600
-msgid ""
-"Comma separated list of domains which oembed content is allowed to be "
-"displayed. Wildcards are accepted."
-msgstr ""
-
-#: src/Module/Admin/Site.php:601
-msgid "Block public"
-msgstr ""
-
-#: src/Module/Admin/Site.php:601
-msgid ""
-"Check to block public access to all otherwise public personal pages on this "
-"site unless you are currently logged in."
-msgstr ""
-
-#: src/Module/Admin/Site.php:602
-msgid "Force publish"
-msgstr ""
-
-#: src/Module/Admin/Site.php:602
-msgid ""
-"Check to force all profiles on this site to be listed in the site directory."
-msgstr ""
-
-#: src/Module/Admin/Site.php:602
-msgid "Enabling this may violate privacy laws like the GDPR"
-msgstr ""
-
-#: src/Module/Admin/Site.php:603
-msgid "Global directory URL"
-msgstr ""
-
-#: src/Module/Admin/Site.php:603
-msgid ""
-"URL to the global directory. If this is not set, the global directory is "
-"completely unavailable to the application."
-msgstr ""
-
-#: src/Module/Admin/Site.php:604
-msgid "Private posts by default for new users"
-msgstr ""
-
-#: src/Module/Admin/Site.php:604
-msgid ""
-"Set default post permissions for all new members to the default privacy "
-"group rather than public."
-msgstr ""
-
-#: src/Module/Admin/Site.php:605
-msgid "Don't include post content in email notifications"
-msgstr ""
-
-#: src/Module/Admin/Site.php:605
-msgid ""
-"Don't include the content of a post/comment/private message/etc. in the "
-"email notifications that are sent out from this site, as a privacy measure."
-msgstr ""
-
-#: src/Module/Admin/Site.php:606
-msgid "Disallow public access to addons listed in the apps menu."
-msgstr ""
-
-#: src/Module/Admin/Site.php:606
-msgid ""
-"Checking this box will restrict addons listed in the apps menu to members "
-"only."
-msgstr ""
-
-#: src/Module/Admin/Site.php:607
-msgid "Don't embed private images in posts"
-msgstr ""
-
-#: src/Module/Admin/Site.php:607
-msgid ""
-"Don't replace locally-hosted private photos in posts with an embedded copy "
-"of the image. This means that contacts who receive posts containing private "
-"photos will have to authenticate and load each image, which may take a while."
-msgstr ""
-
-#: src/Module/Admin/Site.php:608
-msgid "Explicit Content"
-msgstr ""
-
-#: src/Module/Admin/Site.php:608
-msgid ""
-"Set this to announce that your node is used mostly for explicit content that "
-"might not be suited for minors. This information will be published in the "
-"node information and might be used, e.g. by the global directory, to filter "
-"your node from listings of nodes to join. Additionally a note about this "
-"will be shown at the user registration page."
-msgstr ""
-
-#: src/Module/Admin/Site.php:609
-msgid "Allow Users to set remote_self"
-msgstr ""
-
-#: src/Module/Admin/Site.php:609
-msgid ""
-"With checking this, every user is allowed to mark every contact as a "
-"remote_self in the repair contact dialog. Setting this flag on a contact "
-"causes mirroring every posting of that contact in the users stream."
-msgstr ""
-
-#: src/Module/Admin/Site.php:610
-msgid "Block multiple registrations"
-msgstr ""
-
-#: src/Module/Admin/Site.php:610
-msgid "Disallow users to register additional accounts for use as pages."
-msgstr ""
-
-#: src/Module/Admin/Site.php:611
-msgid "Disable OpenID"
-msgstr ""
-
-#: src/Module/Admin/Site.php:611
-msgid "Disable OpenID support for registration and logins."
-msgstr ""
-
-#: src/Module/Admin/Site.php:612
-msgid "No Fullname check"
-msgstr ""
-
-#: src/Module/Admin/Site.php:612
-msgid ""
-"Allow users to register without a space between the first name and the last "
-"name in their full name."
-msgstr ""
-
-#: src/Module/Admin/Site.php:613
-msgid "Community pages for visitors"
-msgstr ""
-
-#: src/Module/Admin/Site.php:613
-msgid ""
-"Which community pages should be available for visitors. Local users always "
-"see both pages."
-msgstr ""
-
-#: src/Module/Admin/Site.php:614
-msgid "Posts per user on community page"
-msgstr ""
-
-#: src/Module/Admin/Site.php:614
-msgid ""
-"The maximum number of posts per user on the community page. (Not valid for "
-"\"Global Community\")"
-msgstr ""
-
-#: src/Module/Admin/Site.php:615
-msgid "Disable OStatus support"
-msgstr ""
-
-#: src/Module/Admin/Site.php:615
-msgid ""
-"Disable built-in OStatus (StatusNet, GNU Social etc.) compatibility. All "
-"communications in OStatus are public, so privacy warnings will be "
-"occasionally displayed."
-msgstr ""
-
-#: src/Module/Admin/Site.php:616
-msgid "OStatus support can only be enabled if threading is enabled."
-msgstr ""
-
-#: src/Module/Admin/Site.php:618
-msgid ""
-"Diaspora support can't be enabled because Friendica was installed into a sub "
-"directory."
-msgstr ""
-
-#: src/Module/Admin/Site.php:619
-msgid "Enable Diaspora support"
-msgstr ""
-
-#: src/Module/Admin/Site.php:619
-msgid "Provide built-in Diaspora network compatibility."
-msgstr ""
-
-#: src/Module/Admin/Site.php:620
-msgid "Only allow Friendica contacts"
-msgstr ""
-
-#: src/Module/Admin/Site.php:620
-msgid ""
-"All contacts must use Friendica protocols. All other built-in communication "
-"protocols disabled."
-msgstr ""
-
-#: src/Module/Admin/Site.php:621
-msgid "Verify SSL"
-msgstr ""
-
-#: src/Module/Admin/Site.php:621
-msgid ""
-"If you wish, you can turn on strict certificate checking. This will mean you "
-"cannot connect (at all) to self-signed SSL sites."
-msgstr ""
-
-#: src/Module/Admin/Site.php:622
-msgid "Proxy user"
-msgstr ""
-
-#: src/Module/Admin/Site.php:623
-msgid "Proxy URL"
-msgstr ""
-
-#: src/Module/Admin/Site.php:624
-msgid "Network timeout"
-msgstr ""
-
-#: src/Module/Admin/Site.php:624
-msgid "Value is in seconds. Set to 0 for unlimited (not recommended)."
-msgstr ""
-
-#: src/Module/Admin/Site.php:625
-msgid "Maximum Load Average"
-msgstr ""
-
-#: src/Module/Admin/Site.php:625
-#, php-format
-msgid ""
-"Maximum system load before delivery and poll processes are deferred - "
-"default %d."
-msgstr ""
-
-#: src/Module/Admin/Site.php:626
-msgid "Maximum Load Average (Frontend)"
-msgstr ""
-
-#: src/Module/Admin/Site.php:626
-msgid "Maximum system load before the frontend quits service - default 50."
-msgstr ""
-
-#: src/Module/Admin/Site.php:627
-msgid "Minimal Memory"
-msgstr ""
-
-#: src/Module/Admin/Site.php:627
-msgid ""
-"Minimal free memory in MB for the worker. Needs access to /proc/meminfo - "
-"default 0 (deactivated)."
-msgstr ""
-
-#: src/Module/Admin/Site.php:628
-msgid "Maximum table size for optimization"
-msgstr ""
-
-#: src/Module/Admin/Site.php:628
-msgid ""
-"Maximum table size (in MB) for the automatic optimization. Enter -1 to "
-"disable it."
-msgstr ""
-
-#: src/Module/Admin/Site.php:629
-msgid "Minimum level of fragmentation"
-msgstr ""
-
-#: src/Module/Admin/Site.php:629
-msgid ""
-"Minimum fragmenation level to start the automatic optimization - default "
-"value is 30%."
-msgstr ""
-
-#: src/Module/Admin/Site.php:631
-msgid "Periodical check of global contacts"
-msgstr ""
-
-#: src/Module/Admin/Site.php:631
-msgid ""
-"If enabled, the global contacts are checked periodically for missing or "
-"outdated data and the vitality of the contacts and servers."
-msgstr ""
-
-#: src/Module/Admin/Site.php:632
-msgid "Days between requery"
-msgstr ""
-
-#: src/Module/Admin/Site.php:632
-msgid "Number of days after which a server is requeried for his contacts."
-msgstr ""
-
-#: src/Module/Admin/Site.php:633
-msgid "Discover contacts from other servers"
-msgstr ""
-
-#: src/Module/Admin/Site.php:633
-msgid ""
-"Periodically query other servers for contacts. You can choose between \"Users"
-"\": the users on the remote system, \"Global Contacts\": active contacts "
-"that are known on the system. The fallback is meant for Redmatrix servers "
-"and older friendica servers, where global contacts weren't available. The "
-"fallback increases the server load, so the recommended setting is \"Users, "
-"Global Contacts\"."
-msgstr ""
-
-#: src/Module/Admin/Site.php:634
-msgid "Timeframe for fetching global contacts"
-msgstr ""
-
-#: src/Module/Admin/Site.php:634
-msgid ""
-"When the discovery is activated, this value defines the timeframe for the "
-"activity of the global contacts that are fetched from other servers."
-msgstr ""
-
-#: src/Module/Admin/Site.php:635
-msgid "Search the local directory"
-msgstr ""
-
-#: src/Module/Admin/Site.php:635
-msgid ""
-"Search the local directory instead of the global directory. When searching "
-"locally, every search will be executed on the global directory in the "
-"background. This improves the search results when the search is repeated."
-msgstr ""
-
-#: src/Module/Admin/Site.php:637
-msgid "Publish server information"
-msgstr ""
-
-#: src/Module/Admin/Site.php:637
-msgid ""
-"If enabled, general server and usage data will be published. The data "
-"contains the name and version of the server, number of users with public "
-"profiles, number of posts and the activated protocols and connectors. See <a "
-"href=\"http://the-federation.info/\">the-federation.info</a> for details."
-msgstr ""
-
-#: src/Module/Admin/Site.php:639
-msgid "Check upstream version"
-msgstr ""
-
-#: src/Module/Admin/Site.php:639
-msgid ""
-"Enables checking for new Friendica versions at github. If there is a new "
-"version, you will be informed in the admin panel overview."
-msgstr ""
-
-#: src/Module/Admin/Site.php:640
-msgid "Suppress Tags"
-msgstr ""
-
-#: src/Module/Admin/Site.php:640
-msgid "Suppress showing a list of hashtags at the end of the posting."
-msgstr ""
-
-#: src/Module/Admin/Site.php:641
-msgid "Clean database"
-msgstr ""
-
-#: src/Module/Admin/Site.php:641
-msgid ""
-"Remove old remote items, orphaned database records and old content from some "
-"other helper tables."
-msgstr ""
-
-#: src/Module/Admin/Site.php:642
-msgid "Lifespan of remote items"
-msgstr ""
-
-#: src/Module/Admin/Site.php:642
-msgid ""
-"When the database cleanup is enabled, this defines the days after which "
-"remote items will be deleted. Own items, and marked or filed items are "
-"always kept. 0 disables this behaviour."
-msgstr ""
-
-#: src/Module/Admin/Site.php:643
-msgid "Lifespan of unclaimed items"
-msgstr ""
-
-#: src/Module/Admin/Site.php:643
-msgid ""
-"When the database cleanup is enabled, this defines the days after which "
-"unclaimed remote items (mostly content from the relay) will be deleted. "
-"Default value is 90 days. Defaults to the general lifespan value of remote "
-"items if set to 0."
-msgstr ""
-
-#: src/Module/Admin/Site.php:644
-msgid "Lifespan of raw conversation data"
-msgstr ""
-
-#: src/Module/Admin/Site.php:644
-msgid ""
-"The conversation data is used for ActivityPub and OStatus, as well as for "
-"debug purposes. It should be safe to remove it after 14 days, default is 90 "
-"days."
-msgstr ""
-
-#: src/Module/Admin/Site.php:645
-msgid "Path to item cache"
-msgstr ""
-
-#: src/Module/Admin/Site.php:645
-msgid "The item caches buffers generated bbcode and external images."
-msgstr ""
-
-#: src/Module/Admin/Site.php:646
-msgid "Cache duration in seconds"
-msgstr ""
-
-#: src/Module/Admin/Site.php:646
-msgid ""
-"How long should the cache files be hold? Default value is 86400 seconds (One "
-"day). To disable the item cache, set the value to -1."
-msgstr ""
-
-#: src/Module/Admin/Site.php:647
-msgid "Maximum numbers of comments per post"
-msgstr ""
-
-#: src/Module/Admin/Site.php:647
-msgid "How much comments should be shown for each post? Default value is 100."
-msgstr ""
-
-#: src/Module/Admin/Site.php:648
-msgid "Temp path"
-msgstr ""
-
-#: src/Module/Admin/Site.php:648
-msgid ""
-"If you have a restricted system where the webserver can't access the system "
-"temp path, enter another path here."
-msgstr ""
-
-#: src/Module/Admin/Site.php:649
-msgid "Disable picture proxy"
-msgstr ""
-
-#: src/Module/Admin/Site.php:649
-msgid ""
-"The picture proxy increases performance and privacy. It shouldn't be used on "
-"systems with very low bandwidth."
-msgstr ""
-
-#: src/Module/Admin/Site.php:650
-msgid "Only search in tags"
-msgstr ""
-
-#: src/Module/Admin/Site.php:650
-msgid "On large systems the text search can slow down the system extremely."
-msgstr ""
-
-#: src/Module/Admin/Site.php:652
-msgid "New base url"
-msgstr ""
-
-#: src/Module/Admin/Site.php:652
-msgid ""
-"Change base url for this server. Sends relocate message to all Friendica and "
-"Diaspora* contacts of all users."
-msgstr ""
-
-#: src/Module/Admin/Site.php:654
-msgid "RINO Encryption"
-msgstr ""
-
-#: src/Module/Admin/Site.php:654
-msgid "Encryption layer between nodes."
-msgstr ""
-
-#: src/Module/Admin/Site.php:656
-msgid "Maximum number of parallel workers"
-msgstr ""
-
-#: src/Module/Admin/Site.php:656
-#, php-format
-msgid ""
-"On shared hosters set this to %d. On larger systems, values of %d are great. "
-"Default value is %d."
-msgstr ""
-
-#: src/Module/Admin/Site.php:657
-msgid "Don't use \"proc_open\" with the worker"
-msgstr ""
-
-#: src/Module/Admin/Site.php:657
-msgid ""
-"Enable this if your system doesn't allow the use of \"proc_open\". This can "
-"happen on shared hosters. If this is enabled you should increase the "
-"frequency of worker calls in your crontab."
-msgstr ""
-
-#: src/Module/Admin/Site.php:658
-msgid "Enable fastlane"
-msgstr ""
-
-#: src/Module/Admin/Site.php:658
-msgid ""
-"When enabed, the fastlane mechanism starts an additional worker if processes "
-"with higher priority are blocked by processes of lower priority."
-msgstr ""
-
-#: src/Module/Admin/Site.php:659
-msgid "Enable frontend worker"
-msgstr ""
-
-#: src/Module/Admin/Site.php:659
-#, php-format
-msgid ""
-"When enabled the Worker process is triggered when backend access is "
-"performed (e.g. messages being delivered). On smaller sites you might want "
-"to call %s/worker on a regular basis via an external cron job. You should "
-"only enable this option if you cannot utilize cron/scheduled jobs on your "
-"server."
-msgstr ""
-
-#: src/Module/Admin/Site.php:661
-msgid "Subscribe to relay"
-msgstr ""
-
-#: src/Module/Admin/Site.php:661
-msgid ""
-"Enables the receiving of public posts from the relay. They will be included "
-"in the search, subscribed tags and on the global community page."
-msgstr ""
-
-#: src/Module/Admin/Site.php:662
-msgid "Relay server"
-msgstr ""
-
-#: src/Module/Admin/Site.php:662
-msgid ""
-"Address of the relay server where public posts should be send to. For "
-"example https://relay.diasp.org"
-msgstr ""
-
-#: src/Module/Admin/Site.php:663
-msgid "Direct relay transfer"
-msgstr ""
-
-#: src/Module/Admin/Site.php:663
-msgid ""
-"Enables the direct transfer to other servers without using the relay servers"
-msgstr ""
-
-#: src/Module/Admin/Site.php:664
-msgid "Relay scope"
-msgstr ""
-
-#: src/Module/Admin/Site.php:664
-msgid ""
-"Can be \"all\" or \"tags\". \"all\" means that every public post should be "
-"received. \"tags\" means that only posts with selected tags should be "
-"received."
-msgstr ""
-
-#: src/Module/Admin/Site.php:664
-msgid "all"
-msgstr ""
-
-#: src/Module/Admin/Site.php:664
-msgid "tags"
-msgstr ""
-
-#: src/Module/Admin/Site.php:665
-msgid "Server tags"
-msgstr ""
-
-#: src/Module/Admin/Site.php:665
-msgid "Comma separated list of tags for the \"tags\" subscription."
-msgstr ""
-
-#: src/Module/Admin/Site.php:666
-msgid "Allow user tags"
-msgstr ""
-
-#: src/Module/Admin/Site.php:666
-msgid ""
-"If enabled, the tags from the saved searches will used for the \"tags\" "
-"subscription in addition to the \"relay_server_tags\"."
-msgstr ""
-
-#: src/Module/Admin/Site.php:669
-msgid "Start Relocation"
-msgstr ""
-
-#: src/Module/Admin/Federation.php:88 src/Module/Admin/Federation.php:250
+#: src/Module/Admin/Federation.php:87 src/Module/Admin/Federation.php:249
 msgid "unknown"
 msgstr ""
 
-#: src/Module/Admin/Federation.php:116
+#: src/Module/Admin/Federation.php:115
 msgid ""
 "This page offers you some numbers to the known part of the federated social "
 "network your Friendica node is part of. These numbers are not complete but "
 "only reflect the part of the network your node is aware of."
 msgstr ""
 
-#: src/Module/Admin/Federation.php:117
+#: src/Module/Admin/Federation.php:116
 msgid ""
 "The <em>Auto Discovered Contact Directory</em> feature is not enabled, it "
 "will improve the data displayed here."
 msgstr ""
 
-#: src/Module/Admin/Federation.php:129
+#: src/Module/Admin/Federation.php:122 src/Module/BaseAdminModule.php:75
+msgid "Federation Statistics"
+msgstr ""
+
+#: src/Module/Admin/Federation.php:128
 #, php-format
 msgid ""
 "Currently this node is aware of %d nodes with %d registered users from the "
 "following platforms:"
-msgstr ""
-
-#: src/Module/Admin/Features.php:58 src/Module/Admin/Features.php:59
-#: mod/settings.php:762
-msgid "Off"
-msgstr ""
-
-#: src/Module/Admin/Features.php:58 src/Module/Admin/Features.php:59
-#: mod/settings.php:762
-msgid "On"
-msgstr ""
-
-#: src/Module/Admin/Features.php:59
-#, php-format
-msgid "Lock feature %s"
-msgstr ""
-
-#: src/Module/Admin/Features.php:67
-msgid "Manage Additional Features"
 msgstr ""
 
 #: src/Module/Admin/Queue.php:34
@@ -8653,103 +7119,967 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: src/Module/Admin/Item/Delete.php:35
-msgid "Item marked for deletion."
+#: src/Module/Admin/Site.php:48
+msgid "Can not parse base url. Must have at least <scheme>://<domain>"
 msgstr ""
 
-#: src/Module/Admin/Item/Delete.php:48
-msgid "Delete this Item"
+#: src/Module/Admin/Site.php:229
+msgid "Invalid storage backend setting value."
 msgstr ""
 
-#: src/Module/Admin/Item/Delete.php:49
+#: src/Module/Admin/Site.php:404
+msgid "Site settings updated."
+msgstr ""
+
+#: src/Module/Admin/Site.php:454
+msgid "No community page for local users"
+msgstr ""
+
+#: src/Module/Admin/Site.php:455
+msgid "No community page"
+msgstr ""
+
+#: src/Module/Admin/Site.php:456
+msgid "Public postings from users of this site"
+msgstr ""
+
+#: src/Module/Admin/Site.php:457
+msgid "Public postings from the federated network"
+msgstr ""
+
+#: src/Module/Admin/Site.php:458
+msgid "Public postings from local users and the federated network"
+msgstr ""
+
+#: src/Module/Admin/Site.php:462 src/Module/Admin/Site.php:653
+#: src/Module/Admin/Site.php:663 src/Module/Settings/TwoFactor/Index.php:94
+#: src/Module/Contact.php:543
+msgid "Disabled"
+msgstr ""
+
+#: src/Module/Admin/Site.php:463 src/Module/Admin/Users.php:275
+#: src/Module/Admin/Users.php:292 src/Module/BaseAdminModule.php:79
+msgid "Users"
+msgstr ""
+
+#: src/Module/Admin/Site.php:464
+msgid "Users, Global Contacts"
+msgstr ""
+
+#: src/Module/Admin/Site.php:465
+msgid "Users, Global Contacts/fallback"
+msgstr ""
+
+#: src/Module/Admin/Site.php:469
+msgid "One month"
+msgstr ""
+
+#: src/Module/Admin/Site.php:470
+msgid "Three months"
+msgstr ""
+
+#: src/Module/Admin/Site.php:471
+msgid "Half a year"
+msgstr ""
+
+#: src/Module/Admin/Site.php:472
+msgid "One year"
+msgstr ""
+
+#: src/Module/Admin/Site.php:478
+msgid "Multi user instance"
+msgstr ""
+
+#: src/Module/Admin/Site.php:500
+msgid "Closed"
+msgstr ""
+
+#: src/Module/Admin/Site.php:501
+msgid "Requires approval"
+msgstr ""
+
+#: src/Module/Admin/Site.php:502
+msgid "Open"
+msgstr ""
+
+#: src/Module/Admin/Site.php:506 src/Module/Install.php:181
+msgid "No SSL policy, links will track page SSL state"
+msgstr ""
+
+#: src/Module/Admin/Site.php:507 src/Module/Install.php:182
+msgid "Force all links to use SSL"
+msgstr ""
+
+#: src/Module/Admin/Site.php:508 src/Module/Install.php:183
+msgid "Self-signed certificate, use SSL for local links only (discouraged)"
+msgstr ""
+
+#: src/Module/Admin/Site.php:512
+msgid "Don't check"
+msgstr ""
+
+#: src/Module/Admin/Site.php:513
+msgid "check the stable version"
+msgstr ""
+
+#: src/Module/Admin/Site.php:514
+msgid "check the development version"
+msgstr ""
+
+#: src/Module/Admin/Site.php:531
+msgid "Database (legacy)"
+msgstr ""
+
+#: src/Module/Admin/Site.php:555 src/Module/BaseAdminModule.php:78
+msgid "Site"
+msgstr ""
+
+#: src/Module/Admin/Site.php:557
+msgid "Republish users to directory"
+msgstr ""
+
+#: src/Module/Admin/Site.php:558 src/Module/Register.php:120
+msgid "Registration"
+msgstr ""
+
+#: src/Module/Admin/Site.php:559
+msgid "File upload"
+msgstr ""
+
+#: src/Module/Admin/Site.php:560
+msgid "Policies"
+msgstr ""
+
+#: src/Module/Admin/Site.php:562
+msgid "Auto Discovered Contact Directory"
+msgstr ""
+
+#: src/Module/Admin/Site.php:563
+msgid "Performance"
+msgstr ""
+
+#: src/Module/Admin/Site.php:564
+msgid "Worker"
+msgstr ""
+
+#: src/Module/Admin/Site.php:565
+msgid "Message Relay"
+msgstr ""
+
+#: src/Module/Admin/Site.php:566
+msgid "Relocate Instance"
+msgstr ""
+
+#: src/Module/Admin/Site.php:567
+msgid "Warning! Advanced function. Could make this server unreachable."
+msgstr ""
+
+#: src/Module/Admin/Site.php:571
+msgid "Site name"
+msgstr ""
+
+#: src/Module/Admin/Site.php:572
+msgid "Sender Email"
+msgstr ""
+
+#: src/Module/Admin/Site.php:572
 msgid ""
-"On this page you can delete an item from your node. If the item is a top "
-"level posting, the entire thread will be deleted."
+"The email address your server shall use to send notification emails from."
 msgstr ""
 
-#: src/Module/Admin/Item/Delete.php:50
-msgid ""
-"You need to know the GUID of the item. You can find it e.g. by looking at "
-"the display URL. The last part of http://example.com/display/123456 is the "
-"GUID, here 123456."
+#: src/Module/Admin/Site.php:573
+msgid "Banner/Logo"
 msgstr ""
 
-#: src/Module/Admin/Item/Delete.php:51
-msgid "GUID"
+#: src/Module/Admin/Site.php:574
+msgid "Shortcut icon"
 msgstr ""
 
-#: src/Module/Admin/Item/Delete.php:51
-msgid "The GUID of the item you want to delete."
+#: src/Module/Admin/Site.php:574
+msgid "Link to an icon that will be used for browsers."
 msgstr ""
 
-#: src/Module/Admin/Item/Source.php:47
-msgid "Item Guid"
+#: src/Module/Admin/Site.php:575
+msgid "Touch icon"
 msgstr ""
 
-#: src/Module/Admin/Logs/Settings.php:27
+#: src/Module/Admin/Site.php:575
+msgid "Link to an icon that will be used for tablets and mobiles."
+msgstr ""
+
+#: src/Module/Admin/Site.php:576
+msgid "Additional Info"
+msgstr ""
+
+#: src/Module/Admin/Site.php:576
 #, php-format
-msgid "The logfile '%s' is not writable. No logging possible"
-msgstr ""
-
-#: src/Module/Admin/Logs/Settings.php:36
-msgid "Log settings updated."
-msgstr ""
-
-#: src/Module/Admin/Logs/Settings.php:53
-msgid "PHP log currently enabled."
-msgstr ""
-
-#: src/Module/Admin/Logs/Settings.php:55
-msgid "PHP log currently disabled."
-msgstr ""
-
-#: src/Module/Admin/Logs/Settings.php:64
-msgid "Clear"
-msgstr ""
-
-#: src/Module/Admin/Logs/Settings.php:68
-msgid "Enable Debugging"
-msgstr ""
-
-#: src/Module/Admin/Logs/Settings.php:69
-msgid "Log file"
-msgstr ""
-
-#: src/Module/Admin/Logs/Settings.php:69
 msgid ""
-"Must be writable by web server. Relative to your Friendica top-level "
+"For public servers: you can add additional information here that will be "
+"listed at %s/servers."
+msgstr ""
+
+#: src/Module/Admin/Site.php:577
+msgid "System language"
+msgstr ""
+
+#: src/Module/Admin/Site.php:578
+msgid "System theme"
+msgstr ""
+
+#: src/Module/Admin/Site.php:578
+msgid ""
+"Default system theme - may be over-ridden by user profiles - <a href=\"/"
+"admin/themes\" id=\"cnftheme\">Change default theme settings</a>"
+msgstr ""
+
+#: src/Module/Admin/Site.php:579
+msgid "Mobile system theme"
+msgstr ""
+
+#: src/Module/Admin/Site.php:579
+msgid "Theme for mobile devices"
+msgstr ""
+
+#: src/Module/Admin/Site.php:580 src/Module/Install.php:191
+msgid "SSL link policy"
+msgstr ""
+
+#: src/Module/Admin/Site.php:580 src/Module/Install.php:193
+msgid "Determines whether generated links should be forced to use SSL"
+msgstr ""
+
+#: src/Module/Admin/Site.php:581
+msgid "Force SSL"
+msgstr ""
+
+#: src/Module/Admin/Site.php:581
+msgid ""
+"Force all Non-SSL requests to SSL - Attention: on some systems it could lead "
+"to endless loops."
+msgstr ""
+
+#: src/Module/Admin/Site.php:582
+msgid "Hide help entry from navigation menu"
+msgstr ""
+
+#: src/Module/Admin/Site.php:582
+msgid ""
+"Hides the menu entry for the Help pages from the navigation menu. You can "
+"still access it calling /help directly."
+msgstr ""
+
+#: src/Module/Admin/Site.php:583
+msgid "Single user instance"
+msgstr ""
+
+#: src/Module/Admin/Site.php:583
+msgid "Make this instance multi-user or single-user for the named user"
+msgstr ""
+
+#: src/Module/Admin/Site.php:585
+msgid "File storage backend"
+msgstr ""
+
+#: src/Module/Admin/Site.php:585
+msgid ""
+"The backend used to store uploaded data. If you change the storage backend, "
+"you can manually move the existing files. If you do not do so, the files "
+"uploaded before the change will still be available at the old backend. "
+"Please see <a href=\"/help/Settings#1_2_3_1\">the settings documentation</a> "
+"for more information about the choices and the moving procedure."
+msgstr ""
+
+#: src/Module/Admin/Site.php:587
+msgid "Maximum image size"
+msgstr ""
+
+#: src/Module/Admin/Site.php:587
+msgid ""
+"Maximum size in bytes of uploaded images. Default is 0, which means no "
+"limits."
+msgstr ""
+
+#: src/Module/Admin/Site.php:588
+msgid "Maximum image length"
+msgstr ""
+
+#: src/Module/Admin/Site.php:588
+msgid ""
+"Maximum length in pixels of the longest side of uploaded images. Default is "
+"-1, which means no limits."
+msgstr ""
+
+#: src/Module/Admin/Site.php:589
+msgid "JPEG image quality"
+msgstr ""
+
+#: src/Module/Admin/Site.php:589
+msgid ""
+"Uploaded JPEGS will be saved at this quality setting [0-100]. Default is "
+"100, which is full quality."
+msgstr ""
+
+#: src/Module/Admin/Site.php:591
+msgid "Register policy"
+msgstr ""
+
+#: src/Module/Admin/Site.php:592
+msgid "Maximum Daily Registrations"
+msgstr ""
+
+#: src/Module/Admin/Site.php:592
+msgid ""
+"If registration is permitted above, this sets the maximum number of new user "
+"registrations to accept per day.  If register is set to closed, this setting "
+"has no effect."
+msgstr ""
+
+#: src/Module/Admin/Site.php:593
+msgid "Register text"
+msgstr ""
+
+#: src/Module/Admin/Site.php:593
+msgid ""
+"Will be displayed prominently on the registration page. You can use BBCode "
+"here."
+msgstr ""
+
+#: src/Module/Admin/Site.php:594
+msgid "Forbidden Nicknames"
+msgstr ""
+
+#: src/Module/Admin/Site.php:594
+msgid ""
+"Comma separated list of nicknames that are forbidden from registration. "
+"Preset is a list of role names according RFC 2142."
+msgstr ""
+
+#: src/Module/Admin/Site.php:595
+msgid "Accounts abandoned after x days"
+msgstr ""
+
+#: src/Module/Admin/Site.php:595
+msgid ""
+"Will not waste system resources polling external sites for abandonded "
+"accounts. Enter 0 for no time limit."
+msgstr ""
+
+#: src/Module/Admin/Site.php:596
+msgid "Allowed friend domains"
+msgstr ""
+
+#: src/Module/Admin/Site.php:596
+msgid ""
+"Comma separated list of domains which are allowed to establish friendships "
+"with this site. Wildcards are accepted. Empty to allow any domains"
+msgstr ""
+
+#: src/Module/Admin/Site.php:597
+msgid "Allowed email domains"
+msgstr ""
+
+#: src/Module/Admin/Site.php:597
+msgid ""
+"Comma separated list of domains which are allowed in email addresses for "
+"registrations to this site. Wildcards are accepted. Empty to allow any "
+"domains"
+msgstr ""
+
+#: src/Module/Admin/Site.php:598
+msgid "No OEmbed rich content"
+msgstr ""
+
+#: src/Module/Admin/Site.php:598
+msgid ""
+"Don't show the rich content (e.g. embedded PDF), except from the domains "
+"listed below."
+msgstr ""
+
+#: src/Module/Admin/Site.php:599
+msgid "Allowed OEmbed domains"
+msgstr ""
+
+#: src/Module/Admin/Site.php:599
+msgid ""
+"Comma separated list of domains which oembed content is allowed to be "
+"displayed. Wildcards are accepted."
+msgstr ""
+
+#: src/Module/Admin/Site.php:600
+msgid "Block public"
+msgstr ""
+
+#: src/Module/Admin/Site.php:600
+msgid ""
+"Check to block public access to all otherwise public personal pages on this "
+"site unless you are currently logged in."
+msgstr ""
+
+#: src/Module/Admin/Site.php:601
+msgid "Force publish"
+msgstr ""
+
+#: src/Module/Admin/Site.php:601
+msgid ""
+"Check to force all profiles on this site to be listed in the site directory."
+msgstr ""
+
+#: src/Module/Admin/Site.php:601
+msgid "Enabling this may violate privacy laws like the GDPR"
+msgstr ""
+
+#: src/Module/Admin/Site.php:602
+msgid "Global directory URL"
+msgstr ""
+
+#: src/Module/Admin/Site.php:602
+msgid ""
+"URL to the global directory. If this is not set, the global directory is "
+"completely unavailable to the application."
+msgstr ""
+
+#: src/Module/Admin/Site.php:603
+msgid "Private posts by default for new users"
+msgstr ""
+
+#: src/Module/Admin/Site.php:603
+msgid ""
+"Set default post permissions for all new members to the default privacy "
+"group rather than public."
+msgstr ""
+
+#: src/Module/Admin/Site.php:604
+msgid "Don't include post content in email notifications"
+msgstr ""
+
+#: src/Module/Admin/Site.php:604
+msgid ""
+"Don't include the content of a post/comment/private message/etc. in the "
+"email notifications that are sent out from this site, as a privacy measure."
+msgstr ""
+
+#: src/Module/Admin/Site.php:605
+msgid "Disallow public access to addons listed in the apps menu."
+msgstr ""
+
+#: src/Module/Admin/Site.php:605
+msgid ""
+"Checking this box will restrict addons listed in the apps menu to members "
+"only."
+msgstr ""
+
+#: src/Module/Admin/Site.php:606
+msgid "Don't embed private images in posts"
+msgstr ""
+
+#: src/Module/Admin/Site.php:606
+msgid ""
+"Don't replace locally-hosted private photos in posts with an embedded copy "
+"of the image. This means that contacts who receive posts containing private "
+"photos will have to authenticate and load each image, which may take a while."
+msgstr ""
+
+#: src/Module/Admin/Site.php:607
+msgid "Explicit Content"
+msgstr ""
+
+#: src/Module/Admin/Site.php:607
+msgid ""
+"Set this to announce that your node is used mostly for explicit content that "
+"might not be suited for minors. This information will be published in the "
+"node information and might be used, e.g. by the global directory, to filter "
+"your node from listings of nodes to join. Additionally a note about this "
+"will be shown at the user registration page."
+msgstr ""
+
+#: src/Module/Admin/Site.php:608
+msgid "Allow Users to set remote_self"
+msgstr ""
+
+#: src/Module/Admin/Site.php:608
+msgid ""
+"With checking this, every user is allowed to mark every contact as a "
+"remote_self in the repair contact dialog. Setting this flag on a contact "
+"causes mirroring every posting of that contact in the users stream."
+msgstr ""
+
+#: src/Module/Admin/Site.php:609
+msgid "Block multiple registrations"
+msgstr ""
+
+#: src/Module/Admin/Site.php:609
+msgid "Disallow users to register additional accounts for use as pages."
+msgstr ""
+
+#: src/Module/Admin/Site.php:610
+msgid "Disable OpenID"
+msgstr ""
+
+#: src/Module/Admin/Site.php:610
+msgid "Disable OpenID support for registration and logins."
+msgstr ""
+
+#: src/Module/Admin/Site.php:611
+msgid "No Fullname check"
+msgstr ""
+
+#: src/Module/Admin/Site.php:611
+msgid ""
+"Allow users to register without a space between the first name and the last "
+"name in their full name."
+msgstr ""
+
+#: src/Module/Admin/Site.php:612
+msgid "Community pages for visitors"
+msgstr ""
+
+#: src/Module/Admin/Site.php:612
+msgid ""
+"Which community pages should be available for visitors. Local users always "
+"see both pages."
+msgstr ""
+
+#: src/Module/Admin/Site.php:613
+msgid "Posts per user on community page"
+msgstr ""
+
+#: src/Module/Admin/Site.php:613
+msgid ""
+"The maximum number of posts per user on the community page. (Not valid for "
+"\"Global Community\")"
+msgstr ""
+
+#: src/Module/Admin/Site.php:614
+msgid "Disable OStatus support"
+msgstr ""
+
+#: src/Module/Admin/Site.php:614
+msgid ""
+"Disable built-in OStatus (StatusNet, GNU Social etc.) compatibility. All "
+"communications in OStatus are public, so privacy warnings will be "
+"occasionally displayed."
+msgstr ""
+
+#: src/Module/Admin/Site.php:615
+msgid "OStatus support can only be enabled if threading is enabled."
+msgstr ""
+
+#: src/Module/Admin/Site.php:617
+msgid ""
+"Diaspora support can't be enabled because Friendica was installed into a sub "
 "directory."
 msgstr ""
 
-#: src/Module/Admin/Logs/Settings.php:70
-msgid "Log level"
+#: src/Module/Admin/Site.php:618
+msgid "Enable Diaspora support"
 msgstr ""
 
-#: src/Module/Admin/Logs/Settings.php:72
-msgid "PHP logging"
+#: src/Module/Admin/Site.php:618
+msgid "Provide built-in Diaspora network compatibility."
 msgstr ""
 
-#: src/Module/Admin/Logs/Settings.php:73
+#: src/Module/Admin/Site.php:619
+msgid "Only allow Friendica contacts"
+msgstr ""
+
+#: src/Module/Admin/Site.php:619
 msgid ""
-"To temporarily enable logging of PHP errors and warnings you can prepend the "
-"following to the index.php file of your installation. The filename set in "
-"the 'error_log' line is relative to the friendica top-level directory and "
-"must be writeable by the web server. The option '1' for 'log_errors' and "
-"'display_errors' is to enable these options, set to '0' to disable them."
+"All contacts must use Friendica protocols. All other built-in communication "
+"protocols disabled."
 msgstr ""
 
-#: src/Module/Admin/Logs/View.php:22
+#: src/Module/Admin/Site.php:620
+msgid "Verify SSL"
+msgstr ""
+
+#: src/Module/Admin/Site.php:620
+msgid ""
+"If you wish, you can turn on strict certificate checking. This will mean you "
+"cannot connect (at all) to self-signed SSL sites."
+msgstr ""
+
+#: src/Module/Admin/Site.php:621
+msgid "Proxy user"
+msgstr ""
+
+#: src/Module/Admin/Site.php:622
+msgid "Proxy URL"
+msgstr ""
+
+#: src/Module/Admin/Site.php:623
+msgid "Network timeout"
+msgstr ""
+
+#: src/Module/Admin/Site.php:623
+msgid "Value is in seconds. Set to 0 for unlimited (not recommended)."
+msgstr ""
+
+#: src/Module/Admin/Site.php:624
+msgid "Maximum Load Average"
+msgstr ""
+
+#: src/Module/Admin/Site.php:624
 #, php-format
 msgid ""
-"Error trying to open <strong>%1$s</strong> log file.\\r\\n<br/>Check to see "
-"if file %1$s exist and is readable."
+"Maximum system load before delivery and poll processes are deferred - "
+"default %d."
 msgstr ""
 
-#: src/Module/Admin/Logs/View.php:26
+#: src/Module/Admin/Site.php:625
+msgid "Maximum Load Average (Frontend)"
+msgstr ""
+
+#: src/Module/Admin/Site.php:625
+msgid "Maximum system load before the frontend quits service - default 50."
+msgstr ""
+
+#: src/Module/Admin/Site.php:626
+msgid "Minimal Memory"
+msgstr ""
+
+#: src/Module/Admin/Site.php:626
+msgid ""
+"Minimal free memory in MB for the worker. Needs access to /proc/meminfo - "
+"default 0 (deactivated)."
+msgstr ""
+
+#: src/Module/Admin/Site.php:627
+msgid "Maximum table size for optimization"
+msgstr ""
+
+#: src/Module/Admin/Site.php:627
+msgid ""
+"Maximum table size (in MB) for the automatic optimization. Enter -1 to "
+"disable it."
+msgstr ""
+
+#: src/Module/Admin/Site.php:628
+msgid "Minimum level of fragmentation"
+msgstr ""
+
+#: src/Module/Admin/Site.php:628
+msgid ""
+"Minimum fragmenation level to start the automatic optimization - default "
+"value is 30%."
+msgstr ""
+
+#: src/Module/Admin/Site.php:630
+msgid "Periodical check of global contacts"
+msgstr ""
+
+#: src/Module/Admin/Site.php:630
+msgid ""
+"If enabled, the global contacts are checked periodically for missing or "
+"outdated data and the vitality of the contacts and servers."
+msgstr ""
+
+#: src/Module/Admin/Site.php:631
+msgid "Days between requery"
+msgstr ""
+
+#: src/Module/Admin/Site.php:631
+msgid "Number of days after which a server is requeried for his contacts."
+msgstr ""
+
+#: src/Module/Admin/Site.php:632
+msgid "Discover contacts from other servers"
+msgstr ""
+
+#: src/Module/Admin/Site.php:632
+msgid ""
+"Periodically query other servers for contacts. You can choose between \"Users"
+"\": the users on the remote system, \"Global Contacts\": active contacts "
+"that are known on the system. The fallback is meant for Redmatrix servers "
+"and older friendica servers, where global contacts weren't available. The "
+"fallback increases the server load, so the recommended setting is \"Users, "
+"Global Contacts\"."
+msgstr ""
+
+#: src/Module/Admin/Site.php:633
+msgid "Timeframe for fetching global contacts"
+msgstr ""
+
+#: src/Module/Admin/Site.php:633
+msgid ""
+"When the discovery is activated, this value defines the timeframe for the "
+"activity of the global contacts that are fetched from other servers."
+msgstr ""
+
+#: src/Module/Admin/Site.php:634
+msgid "Search the local directory"
+msgstr ""
+
+#: src/Module/Admin/Site.php:634
+msgid ""
+"Search the local directory instead of the global directory. When searching "
+"locally, every search will be executed on the global directory in the "
+"background. This improves the search results when the search is repeated."
+msgstr ""
+
+#: src/Module/Admin/Site.php:636
+msgid "Publish server information"
+msgstr ""
+
+#: src/Module/Admin/Site.php:636
+msgid ""
+"If enabled, general server and usage data will be published. The data "
+"contains the name and version of the server, number of users with public "
+"profiles, number of posts and the activated protocols and connectors. See <a "
+"href=\"http://the-federation.info/\">the-federation.info</a> for details."
+msgstr ""
+
+#: src/Module/Admin/Site.php:638
+msgid "Check upstream version"
+msgstr ""
+
+#: src/Module/Admin/Site.php:638
+msgid ""
+"Enables checking for new Friendica versions at github. If there is a new "
+"version, you will be informed in the admin panel overview."
+msgstr ""
+
+#: src/Module/Admin/Site.php:639
+msgid "Suppress Tags"
+msgstr ""
+
+#: src/Module/Admin/Site.php:639
+msgid "Suppress showing a list of hashtags at the end of the posting."
+msgstr ""
+
+#: src/Module/Admin/Site.php:640
+msgid "Clean database"
+msgstr ""
+
+#: src/Module/Admin/Site.php:640
+msgid ""
+"Remove old remote items, orphaned database records and old content from some "
+"other helper tables."
+msgstr ""
+
+#: src/Module/Admin/Site.php:641
+msgid "Lifespan of remote items"
+msgstr ""
+
+#: src/Module/Admin/Site.php:641
+msgid ""
+"When the database cleanup is enabled, this defines the days after which "
+"remote items will be deleted. Own items, and marked or filed items are "
+"always kept. 0 disables this behaviour."
+msgstr ""
+
+#: src/Module/Admin/Site.php:642
+msgid "Lifespan of unclaimed items"
+msgstr ""
+
+#: src/Module/Admin/Site.php:642
+msgid ""
+"When the database cleanup is enabled, this defines the days after which "
+"unclaimed remote items (mostly content from the relay) will be deleted. "
+"Default value is 90 days. Defaults to the general lifespan value of remote "
+"items if set to 0."
+msgstr ""
+
+#: src/Module/Admin/Site.php:643
+msgid "Lifespan of raw conversation data"
+msgstr ""
+
+#: src/Module/Admin/Site.php:643
+msgid ""
+"The conversation data is used for ActivityPub and OStatus, as well as for "
+"debug purposes. It should be safe to remove it after 14 days, default is 90 "
+"days."
+msgstr ""
+
+#: src/Module/Admin/Site.php:644
+msgid "Path to item cache"
+msgstr ""
+
+#: src/Module/Admin/Site.php:644
+msgid "The item caches buffers generated bbcode and external images."
+msgstr ""
+
+#: src/Module/Admin/Site.php:645
+msgid "Cache duration in seconds"
+msgstr ""
+
+#: src/Module/Admin/Site.php:645
+msgid ""
+"How long should the cache files be hold? Default value is 86400 seconds (One "
+"day). To disable the item cache, set the value to -1."
+msgstr ""
+
+#: src/Module/Admin/Site.php:646
+msgid "Maximum numbers of comments per post"
+msgstr ""
+
+#: src/Module/Admin/Site.php:646
+msgid "How much comments should be shown for each post? Default value is 100."
+msgstr ""
+
+#: src/Module/Admin/Site.php:647
+msgid "Temp path"
+msgstr ""
+
+#: src/Module/Admin/Site.php:647
+msgid ""
+"If you have a restricted system where the webserver can't access the system "
+"temp path, enter another path here."
+msgstr ""
+
+#: src/Module/Admin/Site.php:648
+msgid "Disable picture proxy"
+msgstr ""
+
+#: src/Module/Admin/Site.php:648
+msgid ""
+"The picture proxy increases performance and privacy. It shouldn't be used on "
+"systems with very low bandwidth."
+msgstr ""
+
+#: src/Module/Admin/Site.php:649
+msgid "Only search in tags"
+msgstr ""
+
+#: src/Module/Admin/Site.php:649
+msgid "On large systems the text search can slow down the system extremely."
+msgstr ""
+
+#: src/Module/Admin/Site.php:651
+msgid "New base url"
+msgstr ""
+
+#: src/Module/Admin/Site.php:651
+msgid ""
+"Change base url for this server. Sends relocate message to all Friendica and "
+"Diaspora* contacts of all users."
+msgstr ""
+
+#: src/Module/Admin/Site.php:653
+msgid "RINO Encryption"
+msgstr ""
+
+#: src/Module/Admin/Site.php:653
+msgid "Encryption layer between nodes."
+msgstr ""
+
+#: src/Module/Admin/Site.php:653
+msgid "Enabled"
+msgstr ""
+
+#: src/Module/Admin/Site.php:655
+msgid "Maximum number of parallel workers"
+msgstr ""
+
+#: src/Module/Admin/Site.php:655
 #, php-format
 msgid ""
-"Couldn't open <strong>%1$s</strong> log file.\\r\\n<br/>Check to see if file "
-"%1$s is readable."
+"On shared hosters set this to %d. On larger systems, values of %d are great. "
+"Default value is %d."
+msgstr ""
+
+#: src/Module/Admin/Site.php:656
+msgid "Don't use \"proc_open\" with the worker"
+msgstr ""
+
+#: src/Module/Admin/Site.php:656
+msgid ""
+"Enable this if your system doesn't allow the use of \"proc_open\". This can "
+"happen on shared hosters. If this is enabled you should increase the "
+"frequency of worker calls in your crontab."
+msgstr ""
+
+#: src/Module/Admin/Site.php:657
+msgid "Enable fastlane"
+msgstr ""
+
+#: src/Module/Admin/Site.php:657
+msgid ""
+"When enabed, the fastlane mechanism starts an additional worker if processes "
+"with higher priority are blocked by processes of lower priority."
+msgstr ""
+
+#: src/Module/Admin/Site.php:658
+msgid "Enable frontend worker"
+msgstr ""
+
+#: src/Module/Admin/Site.php:658
+#, php-format
+msgid ""
+"When enabled the Worker process is triggered when backend access is "
+"performed (e.g. messages being delivered). On smaller sites you might want "
+"to call %s/worker on a regular basis via an external cron job. You should "
+"only enable this option if you cannot utilize cron/scheduled jobs on your "
+"server."
+msgstr ""
+
+#: src/Module/Admin/Site.php:660
+msgid "Subscribe to relay"
+msgstr ""
+
+#: src/Module/Admin/Site.php:660
+msgid ""
+"Enables the receiving of public posts from the relay. They will be included "
+"in the search, subscribed tags and on the global community page."
+msgstr ""
+
+#: src/Module/Admin/Site.php:661
+msgid "Relay server"
+msgstr ""
+
+#: src/Module/Admin/Site.php:661
+msgid ""
+"Address of the relay server where public posts should be send to. For "
+"example https://relay.diasp.org"
+msgstr ""
+
+#: src/Module/Admin/Site.php:662
+msgid "Direct relay transfer"
+msgstr ""
+
+#: src/Module/Admin/Site.php:662
+msgid ""
+"Enables the direct transfer to other servers without using the relay servers"
+msgstr ""
+
+#: src/Module/Admin/Site.php:663
+msgid "Relay scope"
+msgstr ""
+
+#: src/Module/Admin/Site.php:663
+msgid ""
+"Can be \"all\" or \"tags\". \"all\" means that every public post should be "
+"received. \"tags\" means that only posts with selected tags should be "
+"received."
+msgstr ""
+
+#: src/Module/Admin/Site.php:663
+msgid "all"
+msgstr ""
+
+#: src/Module/Admin/Site.php:663
+msgid "tags"
+msgstr ""
+
+#: src/Module/Admin/Site.php:664
+msgid "Server tags"
+msgstr ""
+
+#: src/Module/Admin/Site.php:664
+msgid "Comma separated list of tags for the \"tags\" subscription."
+msgstr ""
+
+#: src/Module/Admin/Site.php:665
+msgid "Allow user tags"
+msgstr ""
+
+#: src/Module/Admin/Site.php:665
+msgid ""
+"If enabled, the tags from the saved searches will used for the \"tags\" "
+"subscription in addition to the \"relay_server_tags\"."
+msgstr ""
+
+#: src/Module/Admin/Site.php:668
+msgid "Start Relocation"
 msgstr ""
 
 #: src/Module/Admin/Summary.php:31
@@ -8904,243 +8234,521 @@ msgstr ""
 msgid "Active addons"
 msgstr ""
 
-#: src/Module/Admin/DBSync.php:32
-msgid "Update has been marked successful"
+#: src/Module/Admin/Tos.php:29
+msgid "The Terms of Service settings have been updated."
 msgstr ""
 
-#: src/Module/Admin/DBSync.php:42
+#: src/Module/Admin/Tos.php:43
+msgid "Display Terms of Service"
+msgstr ""
+
+#: src/Module/Admin/Tos.php:43
+msgid ""
+"Enable the Terms of Service page. If this is enabled a link to the terms "
+"will be added to the registration form and the general information page."
+msgstr ""
+
+#: src/Module/Admin/Tos.php:44
+msgid "Display Privacy Statement"
+msgstr ""
+
+#: src/Module/Admin/Tos.php:44
 #, php-format
-msgid "Database structure update %s was successfully applied."
+msgid ""
+"Show some informations regarding the needed information to operate the node "
+"according e.g. to <a href=\"%s\" target=\"_blank\">EU-GDPR</a>."
 msgstr ""
 
-#: src/Module/Admin/DBSync.php:46
+#: src/Module/Admin/Tos.php:45
+msgid "Privacy Statement Preview"
+msgstr ""
+
+#: src/Module/Admin/Tos.php:47
+msgid "The Terms of Service"
+msgstr ""
+
+#: src/Module/Admin/Tos.php:47
+msgid ""
+"Enter the Terms of Service for your node here. You can use BBCode. Headers "
+"of sections should be [h2] and below."
+msgstr ""
+
+#: src/Module/Admin/Users.php:45
 #, php-format
-msgid "Executing of database structure update %s failed with error: %s"
+msgid ""
+"\n"
+"\t\t\tDear %1$s,\n"
+"\t\t\t\tthe administrator of %2$s has set up an account for you."
 msgstr ""
 
-#: src/Module/Admin/DBSync.php:63
+#: src/Module/Admin/Users.php:48
 #, php-format
-msgid "Executing %s failed with error: %s"
+msgid ""
+"\n"
+"\t\t\tThe login details are as follows:\n"
+"\n"
+"\t\t\tSite Location:\t%1$s\n"
+"\t\t\tLogin Name:\t\t%2$s\n"
+"\t\t\tPassword:\t\t%3$s\n"
+"\n"
+"\t\t\tYou may change your password from your account \"Settings\" page after "
+"logging\n"
+"\t\t\tin.\n"
+"\n"
+"\t\t\tPlease take a few moments to review the other account settings on that "
+"page.\n"
+"\n"
+"\t\t\tYou may also wish to add some basic information to your default "
+"profile\n"
+"\t\t\t(on the \"Profiles\" page) so that other people can easily find you.\n"
+"\n"
+"\t\t\tWe recommend setting your full name, adding a profile photo,\n"
+"\t\t\tadding some profile \"keywords\" (very useful in making new friends) - "
+"and\n"
+"\t\t\tperhaps what country you live in; if you do not wish to be more "
+"specific\n"
+"\t\t\tthan that.\n"
+"\n"
+"\t\t\tWe fully respect your right to privacy, and none of these items are "
+"necessary.\n"
+"\t\t\tIf you are new and do not know anybody here, they may help\n"
+"\t\t\tyou to make some new and interesting friends.\n"
+"\n"
+"\t\t\tIf you ever want to delete your account, you can do so at %1$s/"
+"removeme\n"
+"\n"
+"\t\t\tThank you and welcome to %4$s."
 msgstr ""
 
-#: src/Module/Admin/DBSync.php:65
+#: src/Module/Admin/Users.php:93
 #, php-format
-msgid "Update %s was successfully applied."
-msgstr ""
+msgid "%s user blocked"
+msgid_plural "%s users blocked"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/Module/Admin/DBSync.php:68
+#: src/Module/Admin/Users.php:99
 #, php-format
-msgid "Update %s did not return a status. Unknown if it succeeded."
+msgid "%s user unblocked"
+msgid_plural "%s users unblocked"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/Module/Admin/Users.php:107 src/Module/Admin/Users.php:157
+msgid "You can't remove yourself"
 msgstr ""
 
-#: src/Module/Admin/DBSync.php:71
+#: src/Module/Admin/Users.php:111
 #, php-format
-msgid "There was no additional update function %s that needed to be called."
+msgid "%s user deleted"
+msgid_plural "%s users deleted"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/Module/Admin/Users.php:155
+#, php-format
+msgid "User \"%s\" deleted"
 msgstr ""
 
-#: src/Module/Admin/DBSync.php:91
-msgid "No failed updates."
+#: src/Module/Admin/Users.php:164
+#, php-format
+msgid "User \"%s\" blocked"
 msgstr ""
 
-#: src/Module/Admin/DBSync.php:92
-msgid "Check database structure"
+#: src/Module/Admin/Users.php:170
+#, php-format
+msgid "User \"%s\" unblocked"
 msgstr ""
 
-#: src/Module/Admin/DBSync.php:97
-msgid "Failed Updates"
+#: src/Module/Admin/Users.php:223
+msgid "Private Forum"
 msgstr ""
 
-#: src/Module/Admin/DBSync.php:98
+#: src/Module/Admin/Users.php:230
+msgid "Relay"
+msgstr ""
+
+#: src/Module/Admin/Users.php:269 src/Module/Admin/Users.php:294
+msgid "Register date"
+msgstr ""
+
+#: src/Module/Admin/Users.php:269 src/Module/Admin/Users.php:294
+msgid "Last login"
+msgstr ""
+
+#: src/Module/Admin/Users.php:269 src/Module/Admin/Users.php:294
+msgid "Last item"
+msgstr ""
+
+#: src/Module/Admin/Users.php:269
+msgid "Type"
+msgstr ""
+
+#: src/Module/Admin/Users.php:276
+msgid "Add User"
+msgstr ""
+
+#: src/Module/Admin/Users.php:278
+msgid "User registrations waiting for confirm"
+msgstr ""
+
+#: src/Module/Admin/Users.php:279
+msgid "User waiting for permanent deletion"
+msgstr ""
+
+#: src/Module/Admin/Users.php:280
+msgid "Request date"
+msgstr ""
+
+#: src/Module/Admin/Users.php:281
+msgid "No registrations."
+msgstr ""
+
+#: src/Module/Admin/Users.php:282
+msgid "Note from the user"
+msgstr ""
+
+#: src/Module/Admin/Users.php:284
+msgid "Deny"
+msgstr ""
+
+#: src/Module/Admin/Users.php:287
+msgid "User blocked"
+msgstr ""
+
+#: src/Module/Admin/Users.php:289
+msgid "Site admin"
+msgstr ""
+
+#: src/Module/Admin/Users.php:290
+msgid "Account expired"
+msgstr ""
+
+#: src/Module/Admin/Users.php:293
+msgid "New User"
+msgstr ""
+
+#: src/Module/Admin/Users.php:294
+msgid "Permanent deletion"
+msgstr ""
+
+#: src/Module/Admin/Users.php:299
 msgid ""
-"This does not include updates prior to 1139, which did not return a status."
+"Selected users will be deleted!\\n\\nEverything these users had posted on "
+"this site will be permanently deleted!\\n\\nAre you sure?"
 msgstr ""
 
-#: src/Module/Admin/DBSync.php:99
-msgid "Mark success (if update was manually applied)"
-msgstr ""
-
-#: src/Module/Admin/DBSync.php:100
-msgid "Attempt to execute this update step automatically"
-msgstr ""
-
-#: src/Module/Settings/Delegation.php:34
-msgid "Delegation successfully granted."
-msgstr ""
-
-#: src/Module/Settings/Delegation.php:36
-msgid "Parent user not found, unavailable or password doesn't match."
-msgstr ""
-
-#: src/Module/Settings/Delegation.php:40
-msgid "Delegation successfully revoked."
-msgstr ""
-
-#: src/Module/Settings/Delegation.php:62 src/Module/Settings/Delegation.php:84
+#: src/Module/Admin/Users.php:300
 msgid ""
-"Delegated administrators can view but not change delegation permissions."
+"The user {0} will be deleted!\\n\\nEverything this user has posted on this "
+"site will be permanently deleted!\\n\\nAre you sure?"
 msgstr ""
 
-#: src/Module/Settings/Delegation.php:76
-msgid "Delegate user not found."
+#: src/Module/Admin/Users.php:310
+msgid "Name of the new user."
 msgstr ""
 
-#: src/Module/Settings/Delegation.php:123
-msgid "No parent user"
+#: src/Module/Admin/Users.php:311
+msgid "Nickname"
 msgstr ""
 
-#: src/Module/Settings/Delegation.php:135 src/Module/Register.php:152
-msgid "Parent Password:"
+#: src/Module/Admin/Users.php:311
+msgid "Nickname of the new user."
 msgstr ""
 
-#: src/Module/Settings/Delegation.php:135 src/Module/Register.php:152
+#: src/Module/Admin/Users.php:312
+msgid "Email address of the new user."
+msgstr ""
+
+#: src/Module/Debug/Babel.php:32
+msgid "Source input"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:38
+msgid "BBCode::toPlaintext"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:44
+msgid "BBCode::convert (raw HTML)"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:49
+msgid "BBCode::convert"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:55
+msgid "BBCode::convert => HTML::toBBCode"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:61
+msgid "BBCode::toMarkdown"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:67
+msgid "BBCode::toMarkdown => Markdown::convert (raw HTML)"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:71
+msgid "BBCode::toMarkdown => Markdown::convert"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:77
+msgid "BBCode::toMarkdown => Markdown::toBBCode"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:83
+msgid "BBCode::toMarkdown =>  Markdown::convert => HTML::toBBCode"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:94
+msgid "Item Body"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:98
+msgid "Item Tags"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:105
+msgid "Source input (Diaspora format)"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:111
+msgid "Markdown::convert (raw HTML)"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:116
+msgid "Markdown::convert"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:122
+msgid "Markdown::toBBCode"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:129
+msgid "Raw HTML input"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:134
+msgid "HTML Input"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:140
+msgid "HTML::toBBCode"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:146
+msgid "HTML::toBBCode => BBCode::convert"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:151
+msgid "HTML::toBBCode => BBCode::convert (raw HTML)"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:157
+msgid "HTML::toBBCode => BBCode::toPlaintext"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:163
+msgid "HTML::toMarkdown"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:169
+msgid "HTML::toPlaintext"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:175
+msgid "HTML::toPlaintext (compact)"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:183
+msgid "Source text"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:184
+msgid "BBCode"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:185
+msgid "Markdown"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:186
+msgid "HTML"
+msgstr ""
+
+#: src/Module/Debug/Feed.php:20 src/Module/Filer/SaveTag.php:19
+msgid "You must be logged in to use this module"
+msgstr ""
+
+#: src/Module/Debug/Feed.php:46
+msgid "Source URL"
+msgstr ""
+
+#: src/Module/Debug/Localtime.php:30
+msgid "Time Conversion"
+msgstr ""
+
+#: src/Module/Debug/Localtime.php:31
 msgid ""
-"Please enter the password of the parent account to legitimize your request."
+"Friendica provides this service for sharing events with other networks and "
+"friends in unknown timezones."
 msgstr ""
 
-#: src/Module/Settings/Delegation.php:142
-msgid "Additional Accounts"
+#: src/Module/Debug/Localtime.php:32
+#, php-format
+msgid "UTC time: %s"
 msgstr ""
 
-#: src/Module/Settings/Delegation.php:143
+#: src/Module/Debug/Localtime.php:35
+#, php-format
+msgid "Current timezone: %s"
+msgstr ""
+
+#: src/Module/Debug/Localtime.php:39
+#, php-format
+msgid "Converted localtime: %s"
+msgstr ""
+
+#: src/Module/Debug/Localtime.php:43
+msgid "Please select your timezone:"
+msgstr ""
+
+#: src/Module/Debug/Probe.php:19 src/Module/Debug/WebFinger.php:18
+msgid "Only logged in users are permitted to perform a probing."
+msgstr ""
+
+#: src/Module/Debug/Probe.php:35
+msgid "Lookup address"
+msgstr ""
+
+#: src/Module/Filer/SaveTag.php:38
+#, php-format
+msgid "Filetag %s saved to item"
+msgstr ""
+
+#: src/Module/Filer/SaveTag.php:47
+msgid "- select -"
+msgstr ""
+
+#: src/Module/Item/Compose.php:27
+msgid "Please enter a post body."
+msgstr ""
+
+#: src/Module/Item/Compose.php:40
+msgid "This feature is only available with the frio theme."
+msgstr ""
+
+#: src/Module/Item/Compose.php:67
+msgid "Compose new personal note"
+msgstr ""
+
+#: src/Module/Item/Compose.php:76
+msgid "Compose new post"
+msgstr ""
+
+#: src/Module/Item/Compose.php:116
+msgid "Visibility"
+msgstr ""
+
+#: src/Module/Item/Compose.php:137
+msgid "Clear the location"
+msgstr ""
+
+#: src/Module/Item/Compose.php:138
+msgid "Location services are unavailable on your device"
+msgstr ""
+
+#: src/Module/Item/Compose.php:139
 msgid ""
-"Register additional accounts that are automatically connected to your "
-"existing account so you can manage it from this account."
+"Location services are disabled. Please check the website's permissions on "
+"your device"
 msgstr ""
 
-#: src/Module/Settings/Delegation.php:144
-msgid "Register an additional account"
+#: src/Module/Profile/Contacts.php:23 src/Module/Profile/Contacts.php:36
+#: src/Module/Register.php:241
+msgid "User not found."
 msgstr ""
 
-#: src/Module/Settings/Delegation.php:145
-msgid "Parent User"
+#: src/Module/Profile/Contacts.php:77
+msgid "No contacts."
 msgstr ""
 
-#: src/Module/Settings/Delegation.php:148
-msgid ""
-"Parent users have total control about this account, including the account "
-"settings. Please double check whom you give this access."
+#: src/Module/Profile/Contacts.php:92 src/Module/Contact.php:587
+#: src/Module/Contact.php:1030
+#, php-format
+msgid "Visit %s's profile [%s]"
 msgstr ""
 
-#: src/Module/Settings/Delegation.php:151
-msgid "Manage Accounts"
+#: src/Module/Profile/Contacts.php:111
+#, php-format
+msgid "Follower (%s)"
+msgid_plural "Followers (%s)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/Module/Profile/Contacts.php:112
+#, php-format
+msgid "Following (%s)"
+msgid_plural "Following (%s)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/Module/Profile/Contacts.php:113
+#, php-format
+msgid "Mutual friend (%s)"
+msgid_plural "Mutual friends (%s)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/Module/Profile/Contacts.php:115
+#, php-format
+msgid "Contact (%s)"
+msgid_plural "Contacts (%s)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/Module/Profile/Contacts.php:124
+msgid "All contacts"
 msgstr ""
 
-#: src/Module/Settings/Delegation.php:152
-msgid "Delegates"
+#: src/Module/Search/Acl.php:37
+msgid "You must be logged in to use this module."
 msgstr ""
 
-#: src/Module/Settings/Delegation.php:154
-msgid ""
-"Delegates are able to manage all aspects of this account/page except for "
-"basic account settings. Please do not delegate your personal account to "
-"anybody that you do not trust completely."
+#: src/Module/Search/Index.php:33
+msgid "Only logged in users are permitted to perform a search."
 msgstr ""
 
-#: src/Module/Settings/Delegation.php:155
-msgid "Existing Page Delegates"
+#: src/Module/Search/Index.php:55
+msgid "Only one search per minute is permitted for not logged in users."
 msgstr ""
 
-#: src/Module/Settings/Delegation.php:157
-msgid "Potential Delegates"
+#: src/Module/Search/Index.php:173
+#, php-format
+msgid "Items tagged with: %s"
 msgstr ""
 
-#: src/Module/Settings/Delegation.php:159 mod/tagrm.php:114
-msgid "Remove"
+#: src/Module/Search/Index.php:175 src/Module/Contact.php:816
+#, php-format
+msgid "Results for: %s"
 msgstr ""
 
-#: src/Module/Settings/Delegation.php:160
-msgid "Add"
+#: src/Module/Search/Saved.php:25
+msgid "Search term successfully saved."
 msgstr ""
 
-#: src/Module/Settings/Delegation.php:161
-msgid "No entries."
+#: src/Module/Search/Saved.php:27
+msgid "Search term already saved."
 msgstr ""
 
-#: src/Module/Settings/UserExport.php:41
-msgid "Export account"
+#: src/Module/Search/Saved.php:33
+msgid "Search term successfully removed."
 msgstr ""
 
-#: src/Module/Settings/UserExport.php:41
-msgid ""
-"Export your account info and contacts. Use this to make a backup of your "
-"account and/or to move it to another server."
-msgstr ""
-
-#: src/Module/Settings/UserExport.php:42
-msgid "Export all"
-msgstr ""
-
-#: src/Module/Settings/UserExport.php:42
-msgid ""
-"Export your accout info, contacts and all your items as json. Could be a "
-"very big file, and could take a lot of time. Use this to make a full backup "
-"of your account (photos are not exported)"
-msgstr ""
-
-#: src/Module/Settings/UserExport.php:43
-msgid "Export Contacts to CSV"
-msgstr ""
-
-#: src/Module/Settings/UserExport.php:43
-msgid ""
-"Export the list of the accounts you are following as CSV file. Compatible to "
-"e.g. Mastodon."
-msgstr ""
-
-#: src/Module/Settings/UserExport.php:49 src/Module/BaseSettingsModule.php:89
-#: mod/settings.php:128
-msgid "Export personal data"
-msgstr ""
-
-#: src/Module/Settings/TwoFactor/Verify.php:37
 #: src/Module/Settings/TwoFactor/AppSpecific.php:33
 #: src/Module/Settings/TwoFactor/Recovery.php:31
+#: src/Module/Settings/TwoFactor/Verify.php:37
 msgid "Please enter your password to access this page."
-msgstr ""
-
-#: src/Module/Settings/TwoFactor/Verify.php:59
-msgid "Two-factor authentication successfully activated."
-msgstr ""
-
-#: src/Module/Settings/TwoFactor/Verify.php:92
-#, php-format
-msgid ""
-"<p>Or you can submit the authentication settings manually:</p>\n"
-"<dl>\n"
-"\t<dt>Issuer</dt>\n"
-"\t<dd>%s</dd>\n"
-"\t<dt>Account Name</dt>\n"
-"\t<dd>%s</dd>\n"
-"\t<dt>Secret Key</dt>\n"
-"\t<dd>%s</dd>\n"
-"\t<dt>Type</dt>\n"
-"\t<dd>Time-based</dd>\n"
-"\t<dt>Number of digits</dt>\n"
-"\t<dd>6</dd>\n"
-"\t<dt>Hashing algorithm</dt>\n"
-"\t<dd>SHA-1</dd>\n"
-"</dl>"
-msgstr ""
-
-#: src/Module/Settings/TwoFactor/Verify.php:112
-msgid "Two-factor code verification"
-msgstr ""
-
-#: src/Module/Settings/TwoFactor/Verify.php:114
-msgid ""
-"<p>Please scan this QR Code with your authenticator app and submit the "
-"provided code.</p>"
-msgstr ""
-
-#: src/Module/Settings/TwoFactor/Verify.php:116
-#, php-format
-msgid ""
-"<p>Or you can open the following URL in your mobile devicde:</p><p><a href="
-"\"%s\">%s</a></p>"
-msgstr ""
-
-#: src/Module/Settings/TwoFactor/Verify.php:123
-msgid "Verify code and enable two-factor authentication"
 msgstr ""
 
 #: src/Module/Settings/TwoFactor/AppSpecific.php:51
@@ -9219,10 +8827,6 @@ msgstr ""
 msgid "Two-factor authentication successfully disabled."
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Index.php:69 mod/settings.php:536
-msgid "Wrong Password"
-msgstr ""
-
 #: src/Module/Settings/TwoFactor/Index.php:89
 msgid ""
 "<p>Use an application on a mobile device to get two-factor authentication "
@@ -9277,7 +8881,7 @@ msgid ""
 "supporting two-factor authentication.</p>"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Index.php:108 src/Module/Contact.php:634
+#: src/Module/Settings/TwoFactor/Index.php:108 src/Module/Contact.php:632
 msgid "Actions"
 msgstr ""
 
@@ -9341,12 +8945,340 @@ msgstr ""
 msgid "Next: Verification"
 msgstr ""
 
+#: src/Module/Settings/TwoFactor/Verify.php:59
+msgid "Two-factor authentication successfully activated."
+msgstr ""
+
+#: src/Module/Settings/TwoFactor/Verify.php:63
+#: src/Module/Security/TwoFactor/Recovery.php:45
+#: src/Module/Security/TwoFactor/Verify.php:42
+msgid "Invalid code, please retry."
+msgstr ""
+
+#: src/Module/Settings/TwoFactor/Verify.php:92
+#, php-format
+msgid ""
+"<p>Or you can submit the authentication settings manually:</p>\n"
+"<dl>\n"
+"\t<dt>Issuer</dt>\n"
+"\t<dd>%s</dd>\n"
+"\t<dt>Account Name</dt>\n"
+"\t<dd>%s</dd>\n"
+"\t<dt>Secret Key</dt>\n"
+"\t<dd>%s</dd>\n"
+"\t<dt>Type</dt>\n"
+"\t<dd>Time-based</dd>\n"
+"\t<dt>Number of digits</dt>\n"
+"\t<dd>6</dd>\n"
+"\t<dt>Hashing algorithm</dt>\n"
+"\t<dd>SHA-1</dd>\n"
+"</dl>"
+msgstr ""
+
+#: src/Module/Settings/TwoFactor/Verify.php:112
+msgid "Two-factor code verification"
+msgstr ""
+
+#: src/Module/Settings/TwoFactor/Verify.php:114
+msgid ""
+"<p>Please scan this QR Code with your authenticator app and submit the "
+"provided code.</p>"
+msgstr ""
+
+#: src/Module/Settings/TwoFactor/Verify.php:116
+#, php-format
+msgid ""
+"<p>Or you can open the following URL in your mobile devicde:</p><p><a href="
+"\"%s\">%s</a></p>"
+msgstr ""
+
+#: src/Module/Settings/TwoFactor/Verify.php:122
+#: src/Module/Security/TwoFactor/Verify.php:66
+msgid "Please enter a code from your authentication app"
+msgstr ""
+
+#: src/Module/Settings/TwoFactor/Verify.php:123
+msgid "Verify code and enable two-factor authentication"
+msgstr ""
+
+#: src/Module/Settings/Delegation.php:34
+msgid "Delegation successfully granted."
+msgstr ""
+
+#: src/Module/Settings/Delegation.php:36
+msgid "Parent user not found, unavailable or password doesn't match."
+msgstr ""
+
+#: src/Module/Settings/Delegation.php:40
+msgid "Delegation successfully revoked."
+msgstr ""
+
+#: src/Module/Settings/Delegation.php:62 src/Module/Settings/Delegation.php:84
+msgid ""
+"Delegated administrators can view but not change delegation permissions."
+msgstr ""
+
+#: src/Module/Settings/Delegation.php:76
+msgid "Delegate user not found."
+msgstr ""
+
+#: src/Module/Settings/Delegation.php:123
+msgid "No parent user"
+msgstr ""
+
+#: src/Module/Settings/Delegation.php:134
+#: src/Module/Settings/Delegation.php:145
+msgid "Parent User"
+msgstr ""
+
+#: src/Module/Settings/Delegation.php:135 src/Module/Register.php:151
+msgid "Parent Password:"
+msgstr ""
+
+#: src/Module/Settings/Delegation.php:135 src/Module/Register.php:151
+msgid ""
+"Please enter the password of the parent account to legitimize your request."
+msgstr ""
+
+#: src/Module/Settings/Delegation.php:142
+msgid "Additional Accounts"
+msgstr ""
+
+#: src/Module/Settings/Delegation.php:143
+msgid ""
+"Register additional accounts that are automatically connected to your "
+"existing account so you can manage them from this account."
+msgstr ""
+
+#: src/Module/Settings/Delegation.php:144
+msgid "Register an additional account"
+msgstr ""
+
+#: src/Module/Settings/Delegation.php:148
+msgid ""
+"Parent users have total control about this account, including the account "
+"settings. Please double check whom you give this access."
+msgstr ""
+
+#: src/Module/Settings/Delegation.php:151
+msgid "Manage Accounts"
+msgstr ""
+
+#: src/Module/Settings/Delegation.php:152
+msgid "Delegates"
+msgstr ""
+
+#: src/Module/Settings/Delegation.php:154
+msgid ""
+"Delegates are able to manage all aspects of this account/page except for "
+"basic account settings. Please do not delegate your personal account to "
+"anybody that you do not trust completely."
+msgstr ""
+
+#: src/Module/Settings/Delegation.php:155
+msgid "Existing Page Delegates"
+msgstr ""
+
+#: src/Module/Settings/Delegation.php:157
+msgid "Potential Delegates"
+msgstr ""
+
+#: src/Module/Settings/Delegation.php:160
+msgid "Add"
+msgstr ""
+
+#: src/Module/Settings/Delegation.php:161
+msgid "No entries."
+msgstr ""
+
+#: src/Module/Settings/UserExport.php:41
+msgid "Export account"
+msgstr ""
+
+#: src/Module/Settings/UserExport.php:41
+msgid ""
+"Export your account info and contacts. Use this to make a backup of your "
+"account and/or to move it to another server."
+msgstr ""
+
+#: src/Module/Settings/UserExport.php:42
+msgid "Export all"
+msgstr ""
+
+#: src/Module/Settings/UserExport.php:42
+msgid ""
+"Export your accout info, contacts and all your items as json. Could be a "
+"very big file, and could take a lot of time. Use this to make a full backup "
+"of your account (photos are not exported)"
+msgstr ""
+
+#: src/Module/Settings/UserExport.php:43
+msgid "Export Contacts to CSV"
+msgstr ""
+
+#: src/Module/Settings/UserExport.php:43
+msgid ""
+"Export the list of the accounts you are following as CSV file. Compatible to "
+"e.g. Mastodon."
+msgstr ""
+
+#: src/Module/Special/HTTPException.php:30
+msgid "Bad Request"
+msgstr ""
+
+#: src/Module/Special/HTTPException.php:31
+msgid "Unauthorized"
+msgstr ""
+
+#: src/Module/Special/HTTPException.php:32
+msgid "Forbidden"
+msgstr ""
+
+#: src/Module/Special/HTTPException.php:33
+msgid "Not Found"
+msgstr ""
+
+#: src/Module/Special/HTTPException.php:34
+msgid "Internal Server Error"
+msgstr ""
+
+#: src/Module/Special/HTTPException.php:35
+msgid "Service Unavailable"
+msgstr ""
+
+#: src/Module/Special/HTTPException.php:42
+msgid ""
+"The server cannot or will not process the request due to an apparent client "
+"error."
+msgstr ""
+
+#: src/Module/Special/HTTPException.php:43
+msgid "Authentication is required and has failed or has not yet been provided."
+msgstr ""
+
+#: src/Module/Special/HTTPException.php:44
+msgid ""
+"The request was valid, but the server is refusing action. The user might not "
+"have the necessary permissions for a resource, or may need an account."
+msgstr ""
+
+#: src/Module/Special/HTTPException.php:45
+msgid ""
+"The requested resource could not be found but may be available in the future."
+msgstr ""
+
+#: src/Module/Special/HTTPException.php:46
+msgid ""
+"An unexpected condition was encountered and no more specific message is "
+"suitable."
+msgstr ""
+
+#: src/Module/Special/HTTPException.php:47
+msgid ""
+"The server is currently unavailable (because it is overloaded or down for "
+"maintenance). Please try again later."
+msgstr ""
+
+#: src/Module/Special/HTTPException.php:53
+msgid "Go back"
+msgstr ""
+
 #: src/Module/HTTPException/MethodNotAllowed.php:13
 msgid "Method Not Allowed."
 msgstr ""
 
-#: src/Module/HTTPException/PageNotFound.php:13 src/App/Router.php:185
+#: src/Module/HTTPException/PageNotFound.php:13 src/App/Router.php:192
 msgid "Page not found."
+msgstr ""
+
+#: src/Module/AllFriends.php:55
+msgid "No friends to display."
+msgstr ""
+
+#: src/Module/Apps.php:28
+msgid "No installed applications."
+msgstr ""
+
+#: src/Module/Apps.php:33
+msgid "Applications"
+msgstr ""
+
+#: src/Module/Attach.php:35 src/Module/Attach.php:47
+msgid "Item was not found."
+msgstr ""
+
+#: src/Module/BaseAdminModule.php:60
+msgid ""
+"Submanaged account can't access the administation pages. Please log back in "
+"as the master account."
+msgstr ""
+
+#: src/Module/BaseAdminModule.php:74
+msgid "Overview"
+msgstr ""
+
+#: src/Module/BaseAdminModule.php:77
+msgid "Configuration"
+msgstr ""
+
+#: src/Module/BaseAdminModule.php:85
+msgid "Database"
+msgstr ""
+
+#: src/Module/BaseAdminModule.php:86
+msgid "DB updates"
+msgstr ""
+
+#: src/Module/BaseAdminModule.php:87
+msgid "Inspect Deferred Workers"
+msgstr ""
+
+#: src/Module/BaseAdminModule.php:88
+msgid "Inspect worker Queue"
+msgstr ""
+
+#: src/Module/BaseAdminModule.php:90
+msgid "Tools"
+msgstr ""
+
+#: src/Module/BaseAdminModule.php:91
+msgid "Contact Blocklist"
+msgstr ""
+
+#: src/Module/BaseAdminModule.php:92
+msgid "Server Blocklist"
+msgstr ""
+
+#: src/Module/BaseAdminModule.php:99
+msgid "Diagnostics"
+msgstr ""
+
+#: src/Module/BaseAdminModule.php:100
+msgid "PHP Info"
+msgstr ""
+
+#: src/Module/BaseAdminModule.php:101
+msgid "probe address"
+msgstr ""
+
+#: src/Module/BaseAdminModule.php:102
+msgid "check webfinger"
+msgstr ""
+
+#: src/Module/BaseAdminModule.php:103
+msgid "Item Source"
+msgstr ""
+
+#: src/Module/BaseAdminModule.php:104
+msgid "Babel"
+msgstr ""
+
+#: src/Module/BaseAdminModule.php:113
+msgid "Addon Features"
+msgstr ""
+
+#: src/Module/BaseAdminModule.php:114
+msgid "User registrations waiting for confirmation"
 msgstr ""
 
 #: src/Module/BaseSearchModule.php:52
@@ -9359,297 +9291,1071 @@ msgstr ""
 msgid "Forum Search - %s"
 msgstr ""
 
-#: src/Module/BaseSearchModule.php:93 mod/match.php:129
-msgid "No matches"
+#: src/Module/Bookmarklet.php:36
+msgid "This page is missing a url parameter."
 msgstr ""
 
-#: src/Module/Apps.php:29
-msgid "No installed applications."
+#: src/Module/Bookmarklet.php:58
+msgid "The post was created"
 msgstr ""
 
-#: src/Module/Apps.php:34
-msgid "Applications"
+#: src/Module/Contact.php:69
+#, php-format
+msgid "%d contact edited."
+msgid_plural "%d contacts edited."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/Module/Contact.php:96
+msgid "Could not access contact record."
 msgstr ""
 
-#: src/Module/Credits.php:24
-msgid "Credits"
+#: src/Module/Contact.php:106
+msgid "Could not locate selected profile."
+msgstr ""
+
+#: src/Module/Contact.php:138
+msgid "Contact updated."
+msgstr ""
+
+#: src/Module/Contact.php:373
+msgid "Contact not found"
+msgstr ""
+
+#: src/Module/Contact.php:392
+msgid "Contact has been blocked"
+msgstr ""
+
+#: src/Module/Contact.php:392
+msgid "Contact has been unblocked"
+msgstr ""
+
+#: src/Module/Contact.php:402
+msgid "Contact has been ignored"
+msgstr ""
+
+#: src/Module/Contact.php:402
+msgid "Contact has been unignored"
+msgstr ""
+
+#: src/Module/Contact.php:412
+msgid "Contact has been archived"
+msgstr ""
+
+#: src/Module/Contact.php:412
+msgid "Contact has been unarchived"
+msgstr ""
+
+#: src/Module/Contact.php:436
+msgid "Drop contact"
+msgstr ""
+
+#: src/Module/Contact.php:439 src/Module/Contact.php:820
+msgid "Do you really want to delete this contact?"
+msgstr ""
+
+#: src/Module/Contact.php:453
+msgid "Contact has been removed."
+msgstr ""
+
+#: src/Module/Contact.php:483
+#, php-format
+msgid "You are mutual friends with %s"
+msgstr ""
+
+#: src/Module/Contact.php:488
+#, php-format
+msgid "You are sharing with %s"
+msgstr ""
+
+#: src/Module/Contact.php:493
+#, php-format
+msgid "%s is sharing with you"
+msgstr ""
+
+#: src/Module/Contact.php:517
+msgid "Private communications are not available for this contact."
+msgstr ""
+
+#: src/Module/Contact.php:519
+msgid "Never"
+msgstr ""
+
+#: src/Module/Contact.php:522
+msgid "(Update was successful)"
+msgstr ""
+
+#: src/Module/Contact.php:522
+msgid "(Update was not successful)"
+msgstr ""
+
+#: src/Module/Contact.php:524 src/Module/Contact.php:1064
+msgid "Suggest friends"
+msgstr ""
+
+#: src/Module/Contact.php:528
+#, php-format
+msgid "Network type: %s"
+msgstr ""
+
+#: src/Module/Contact.php:533
+msgid "Communications lost with this contact!"
+msgstr ""
+
+#: src/Module/Contact.php:539
+msgid "Fetch further information for feeds"
+msgstr ""
+
+#: src/Module/Contact.php:541
+msgid ""
+"Fetch information like preview pictures, title and teaser from the feed "
+"item. You can activate this if the feed doesn't contain much text. Keywords "
+"are taken from the meta header in the feed item and are posted as hash tags."
+msgstr ""
+
+#: src/Module/Contact.php:544
+msgid "Fetch information"
+msgstr ""
+
+#: src/Module/Contact.php:545
+msgid "Fetch keywords"
+msgstr ""
+
+#: src/Module/Contact.php:546
+msgid "Fetch information and keywords"
+msgstr ""
+
+#: src/Module/Contact.php:565
+msgid "Profile Visibility"
+msgstr ""
+
+#: src/Module/Contact.php:566
+msgid "Contact Information / Notes"
+msgstr ""
+
+#: src/Module/Contact.php:567
+msgid "Contact Settings"
+msgstr ""
+
+#: src/Module/Contact.php:576
+msgid "Contact"
+msgstr ""
+
+#: src/Module/Contact.php:580
+#, php-format
+msgid ""
+"Please choose the profile you would like to display to %s when viewing your "
+"profile securely."
+msgstr ""
+
+#: src/Module/Contact.php:582
+msgid "Their personal note"
+msgstr ""
+
+#: src/Module/Contact.php:584
+msgid "Edit contact notes"
+msgstr ""
+
+#: src/Module/Contact.php:588
+msgid "Block/Unblock contact"
+msgstr ""
+
+#: src/Module/Contact.php:589
+msgid "Ignore contact"
+msgstr ""
+
+#: src/Module/Contact.php:590
+msgid "Repair URL settings"
+msgstr ""
+
+#: src/Module/Contact.php:591
+msgid "View conversations"
+msgstr ""
+
+#: src/Module/Contact.php:596
+msgid "Last update:"
+msgstr ""
+
+#: src/Module/Contact.php:598
+msgid "Update public posts"
+msgstr ""
+
+#: src/Module/Contact.php:600 src/Module/Contact.php:1074
+msgid "Update now"
+msgstr ""
+
+#: src/Module/Contact.php:604 src/Module/Contact.php:825
+#: src/Module/Contact.php:1091
+msgid "Unignore"
+msgstr ""
+
+#: src/Module/Contact.php:608
+msgid "Currently blocked"
+msgstr ""
+
+#: src/Module/Contact.php:609
+msgid "Currently ignored"
+msgstr ""
+
+#: src/Module/Contact.php:610
+msgid "Currently archived"
+msgstr ""
+
+#: src/Module/Contact.php:611
+msgid "Awaiting connection acknowledge"
+msgstr ""
+
+#: src/Module/Contact.php:612
+msgid ""
+"Replies/likes to your public posts <strong>may</strong> still be visible"
+msgstr ""
+
+#: src/Module/Contact.php:613
+msgid "Notification for new posts"
+msgstr ""
+
+#: src/Module/Contact.php:613
+msgid "Send a notification of every new post of this contact"
+msgstr ""
+
+#: src/Module/Contact.php:615
+msgid "Blacklisted keywords"
+msgstr ""
+
+#: src/Module/Contact.php:615
+msgid ""
+"Comma separated list of keywords that should not be converted to hashtags, "
+"when \"Fetch information and keywords\" is selected"
+msgstr ""
+
+#: src/Module/Contact.php:685
+msgid "Show all contacts"
+msgstr ""
+
+#: src/Module/Contact.php:690 src/Module/Contact.php:800
+msgid "Pending"
+msgstr ""
+
+#: src/Module/Contact.php:693
+msgid "Only show pending contacts"
+msgstr ""
+
+#: src/Module/Contact.php:698 src/Module/Contact.php:801
+msgid "Blocked"
+msgstr ""
+
+#: src/Module/Contact.php:701
+msgid "Only show blocked contacts"
+msgstr ""
+
+#: src/Module/Contact.php:706 src/Module/Contact.php:803
+msgid "Ignored"
+msgstr ""
+
+#: src/Module/Contact.php:709
+msgid "Only show ignored contacts"
+msgstr ""
+
+#: src/Module/Contact.php:714 src/Module/Contact.php:804
+msgid "Archived"
+msgstr ""
+
+#: src/Module/Contact.php:717
+msgid "Only show archived contacts"
+msgstr ""
+
+#: src/Module/Contact.php:722 src/Module/Contact.php:802
+msgid "Hidden"
+msgstr ""
+
+#: src/Module/Contact.php:725
+msgid "Only show hidden contacts"
+msgstr ""
+
+#: src/Module/Contact.php:733
+msgid "Organize your contact groups"
+msgstr ""
+
+#: src/Module/Contact.php:815
+msgid "Search your contacts"
+msgstr ""
+
+#: src/Module/Contact.php:826 src/Module/Contact.php:1100
+msgid "Archive"
+msgstr ""
+
+#: src/Module/Contact.php:826 src/Module/Contact.php:1100
+msgid "Unarchive"
+msgstr ""
+
+#: src/Module/Contact.php:829
+msgid "Batch Actions"
+msgstr ""
+
+#: src/Module/Contact.php:856
+msgid "Conversations started by this contact"
+msgstr ""
+
+#: src/Module/Contact.php:861
+msgid "Posts and Comments"
+msgstr ""
+
+#: src/Module/Contact.php:884
+msgid "View all contacts"
+msgstr ""
+
+#: src/Module/Contact.php:895
+msgid "View all common friends"
+msgstr ""
+
+#: src/Module/Contact.php:905
+msgid "Advanced Contact Settings"
+msgstr ""
+
+#: src/Module/Contact.php:988
+msgid "Mutual Friendship"
+msgstr ""
+
+#: src/Module/Contact.php:993
+msgid "is a fan of yours"
+msgstr ""
+
+#: src/Module/Contact.php:998
+msgid "you are a fan of"
+msgstr ""
+
+#: src/Module/Contact.php:1016
+msgid "Pending outgoing contact request"
+msgstr ""
+
+#: src/Module/Contact.php:1018
+msgid "Pending incoming contact request"
+msgstr ""
+
+#: src/Module/Contact.php:1031
+msgid "Edit contact"
+msgstr ""
+
+#: src/Module/Contact.php:1085
+msgid "Toggle Blocked status"
+msgstr ""
+
+#: src/Module/Contact.php:1093
+msgid "Toggle Ignored status"
+msgstr ""
+
+#: src/Module/Contact.php:1102
+msgid "Toggle Archive status"
+msgstr ""
+
+#: src/Module/Contact.php:1110
+msgid "Delete contact"
 msgstr ""
 
 #: src/Module/Credits.php:25
+msgid "Credits"
+msgstr ""
+
+#: src/Module/Credits.php:26
 msgid ""
 "Friendica is a community project, that would not be possible without the "
 "help of many people. Here is a list of those who have contributed to the "
 "code or the translation of Friendica. Thank you all!"
 msgstr ""
 
-#: src/Module/Group.php:41
+#: src/Module/Delegation.php:127
+msgid "Manage Identities and/or Pages"
+msgstr ""
+
+#: src/Module/Delegation.php:128
+msgid ""
+"Toggle between different identities or community/group pages which share "
+"your account details or which you have been granted \"manage\" permissions"
+msgstr ""
+
+#: src/Module/Delegation.php:129
+msgid "Select an identity to manage: "
+msgstr ""
+
+#: src/Module/Directory.php:59
+msgid "No entries (some entries may be hidden)."
+msgstr ""
+
+#: src/Module/Directory.php:78
+msgid "Find on this site"
+msgstr ""
+
+#: src/Module/Directory.php:80
+msgid "Results for:"
+msgstr ""
+
+#: src/Module/Directory.php:82
+msgid "Site Directory"
+msgstr ""
+
+#: src/Module/Friendica.php:39
+msgid "Installed addons/apps:"
+msgstr ""
+
+#: src/Module/Friendica.php:44
+msgid "No installed addons/apps"
+msgstr ""
+
+#: src/Module/Friendica.php:49
+#, php-format
+msgid "Read about the <a href=\"%1$s/tos\">Terms of Service</a> of this node."
+msgstr ""
+
+#: src/Module/Friendica.php:56
+msgid "On this server the following remote servers are blocked."
+msgstr ""
+
+#: src/Module/Friendica.php:74
+#, php-format
+msgid ""
+"This is Friendica, version %s that is running at the web location %s. The "
+"database version is %s, the post update version is %s."
+msgstr ""
+
+#: src/Module/Friendica.php:79
+msgid ""
+"Please visit <a href=\"https://friendi.ca\">Friendi.ca</a> to learn more "
+"about the Friendica project."
+msgstr ""
+
+#: src/Module/Friendica.php:80
+msgid "Bug reports and issues: please visit"
+msgstr ""
+
+#: src/Module/Friendica.php:80
+msgid "the bugtracker at github"
+msgstr ""
+
+#: src/Module/Friendica.php:81
+msgid ""
+"Suggestions, praise, etc. - please email \"info\" at \"friendi - dot - ca"
+msgstr ""
+
+#: src/Module/Group.php:40
 msgid "Group created."
 msgstr ""
 
-#: src/Module/Group.php:47
+#: src/Module/Group.php:46
 msgid "Could not create group."
 msgstr ""
 
-#: src/Module/Group.php:58 src/Module/Group.php:200 src/Module/Group.php:226
+#: src/Module/Group.php:57 src/Module/Group.php:199 src/Module/Group.php:225
 msgid "Group not found."
 msgstr ""
 
-#: src/Module/Group.php:64
+#: src/Module/Group.php:63
 msgid "Group name changed."
 msgstr ""
 
-#: src/Module/Group.php:86
+#: src/Module/Group.php:85
 msgid "Unknown group."
 msgstr ""
 
-#: src/Module/Group.php:91 mod/fsuggest.php:31 mod/fsuggest.php:74
-#: mod/crepair.php:102 mod/dfrn_confirm.php:125 mod/redir.php:32
-#: mod/redir.php:122 mod/redir.php:137
-msgid "Contact not found."
-msgstr ""
-
-#: src/Module/Group.php:95
+#: src/Module/Group.php:94
 msgid "Contact is deleted."
 msgstr ""
 
-#: src/Module/Group.php:101
+#: src/Module/Group.php:100
 msgid "Unable to add the contact to the group."
 msgstr ""
 
-#: src/Module/Group.php:104
+#: src/Module/Group.php:103
 msgid "Contact successfully added to group."
 msgstr ""
 
-#: src/Module/Group.php:108
+#: src/Module/Group.php:107
 msgid "Unable to remove the contact from the group."
 msgstr ""
 
-#: src/Module/Group.php:111
+#: src/Module/Group.php:110
 msgid "Contact successfully removed from group."
 msgstr ""
 
-#: src/Module/Group.php:114
+#: src/Module/Group.php:113
 msgid "Unknown group command."
 msgstr ""
 
-#: src/Module/Group.php:117
+#: src/Module/Group.php:116
 msgid "Bad request."
 msgstr ""
 
-#: src/Module/Group.php:156
+#: src/Module/Group.php:155
 msgid "Save Group"
 msgstr ""
 
-#: src/Module/Group.php:157
+#: src/Module/Group.php:156
 msgid "Filter"
 msgstr ""
 
-#: src/Module/Group.php:163
+#: src/Module/Group.php:162
 msgid "Create a group of contacts/friends."
 msgstr ""
 
-#: src/Module/Group.php:205
+#: src/Module/Group.php:204
 msgid "Group removed."
 msgstr ""
 
-#: src/Module/Group.php:207
+#: src/Module/Group.php:206
 msgid "Unable to remove group."
 msgstr ""
 
-#: src/Module/Group.php:258
+#: src/Module/Group.php:257
 msgid "Delete Group"
 msgstr ""
 
-#: src/Module/Group.php:268
+#: src/Module/Group.php:267
 msgid "Edit Group Name"
 msgstr ""
 
-#: src/Module/Group.php:278
+#: src/Module/Group.php:277
 msgid "Members"
 msgstr ""
 
-#: src/Module/Group.php:281 mod/network.php:584
-msgid "Group is empty"
-msgstr ""
-
-#: src/Module/Group.php:294
+#: src/Module/Group.php:293
 msgid "Remove contact from group"
 msgstr ""
 
-#: src/Module/Group.php:314 mod/profperm.php:118
-msgid "Click on a contact to add or remove."
-msgstr ""
-
-#: src/Module/Group.php:328
+#: src/Module/Group.php:327
 msgid "Add contact to group"
 msgstr ""
 
-#: src/Module/Debug/WebFinger.php:18 src/Module/Debug/Probe.php:19
-msgid "Only logged in users are permitted to perform a probing."
-msgstr ""
-
-#: src/Module/Debug/Localtime.php:30
-msgid "Time Conversion"
-msgstr ""
-
-#: src/Module/Debug/Localtime.php:31
-msgid ""
-"Friendica provides this service for sharing events with other networks and "
-"friends in unknown timezones."
-msgstr ""
-
-#: src/Module/Debug/Localtime.php:32
-#, php-format
-msgid "UTC time: %s"
-msgstr ""
-
-#: src/Module/Debug/Localtime.php:35
-#, php-format
-msgid "Current timezone: %s"
-msgstr ""
-
-#: src/Module/Debug/Localtime.php:39
-#, php-format
-msgid "Converted localtime: %s"
-msgstr ""
-
-#: src/Module/Debug/Localtime.php:43
-msgid "Please select your timezone:"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:31
-msgid "Source input"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:37
-msgid "BBCode::toPlaintext"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:43
-msgid "BBCode::convert (raw HTML)"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:48
-msgid "BBCode::convert"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:54
-msgid "BBCode::convert => HTML::toBBCode"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:60
-msgid "BBCode::toMarkdown"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:66
-msgid "BBCode::toMarkdown => Markdown::convert (raw HTML)"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:70
-msgid "BBCode::toMarkdown => Markdown::convert"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:76
-msgid "BBCode::toMarkdown => Markdown::toBBCode"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:82
-msgid "BBCode::toMarkdown =>  Markdown::convert => HTML::toBBCode"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:93
-msgid "Item Body"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:97
-msgid "Item Tags"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:104
-msgid "Source input (Diaspora format)"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:110
-msgid "Markdown::convert (raw HTML)"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:115
-msgid "Markdown::convert"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:121
-msgid "Markdown::toBBCode"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:128
-msgid "Raw HTML input"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:133
-msgid "HTML Input"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:139
-msgid "HTML::toBBCode"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:145
-msgid "HTML::toBBCode => BBCode::convert"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:150
-msgid "HTML::toBBCode => BBCode::convert (raw HTML)"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:156
-msgid "HTML::toBBCode => BBCode::toPlaintext"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:162
-msgid "HTML::toMarkdown"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:168
-msgid "HTML::toPlaintext"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:174
-msgid "HTML::toPlaintext (compact)"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:182
-msgid "Source text"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:183
-msgid "BBCode"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:185
-msgid "HTML"
-msgstr ""
-
-#: src/Module/Debug/ItemBody.php:18 src/Module/Item/Ignore.php:22
-#: src/Module/Diaspora/Receive.php:32 mod/community.php:32 mod/cal.php:28
-#: mod/cal.php:32 mod/follow.php:19
-msgid "Access denied."
-msgstr ""
-
-#: src/Module/Debug/Feed.php:20 src/Module/Filer/SaveTag.php:19
-msgid "You must be logged in to use this module"
-msgstr ""
-
-#: src/Module/Debug/Feed.php:46
-msgid "Source URL"
-msgstr ""
-
-#: src/Module/Debug/Probe.php:35
-msgid "Lookup address"
+#: src/Module/Help.php:43
+msgid "Help:"
 msgstr ""
 
 #: src/Module/Home.php:35
 #, php-format
 msgid "Welcome to %s"
+msgstr ""
+
+#: src/Module/HoverCard.php:30
+msgid "No profile"
+msgstr ""
+
+#: src/Module/Install.php:158
+msgid "Friendica Communications Server - Setup"
+msgstr ""
+
+#: src/Module/Install.php:169
+msgid "System check"
+msgstr ""
+
+#: src/Module/Install.php:174
+msgid "Check again"
+msgstr ""
+
+#: src/Module/Install.php:189
+msgid "Base settings"
+msgstr ""
+
+#: src/Module/Install.php:196
+msgid "Host name"
+msgstr ""
+
+#: src/Module/Install.php:198
+msgid ""
+"Overwrite this field in case the determinated hostname isn't right, "
+"otherweise leave it as is."
+msgstr ""
+
+#: src/Module/Install.php:201
+msgid "Base path to installation"
+msgstr ""
+
+#: src/Module/Install.php:203
+msgid ""
+"If the system cannot detect the correct path to your installation, enter the "
+"correct path here. This setting should only be set if you are using a "
+"restricted system and symbolic links to your webroot."
+msgstr ""
+
+#: src/Module/Install.php:206
+msgid "Sub path of the URL"
+msgstr ""
+
+#: src/Module/Install.php:208
+msgid ""
+"Overwrite this field in case the sub path determination isn't right, "
+"otherwise leave it as is. Leaving this field blank means the installation is "
+"at the base URL without sub path."
+msgstr ""
+
+#: src/Module/Install.php:219
+msgid "Database connection"
+msgstr ""
+
+#: src/Module/Install.php:220
+msgid ""
+"In order to install Friendica we need to know how to connect to your "
+"database."
+msgstr ""
+
+#: src/Module/Install.php:221
+msgid ""
+"Please contact your hosting provider or site administrator if you have "
+"questions about these settings."
+msgstr ""
+
+#: src/Module/Install.php:222
+msgid ""
+"The database you specify below should already exist. If it does not, please "
+"create it before continuing."
+msgstr ""
+
+#: src/Module/Install.php:229
+msgid "Database Server Name"
+msgstr ""
+
+#: src/Module/Install.php:234
+msgid "Database Login Name"
+msgstr ""
+
+#: src/Module/Install.php:240
+msgid "Database Login Password"
+msgstr ""
+
+#: src/Module/Install.php:242
+msgid "For security reasons the password must not be empty"
+msgstr ""
+
+#: src/Module/Install.php:245
+msgid "Database Name"
+msgstr ""
+
+#: src/Module/Install.php:249 src/Module/Install.php:278
+msgid "Please select a default timezone for your website"
+msgstr ""
+
+#: src/Module/Install.php:263
+msgid "Site settings"
+msgstr ""
+
+#: src/Module/Install.php:273
+msgid "Site administrator email address"
+msgstr ""
+
+#: src/Module/Install.php:275
+msgid ""
+"Your account email address must match this in order to use the web admin "
+"panel."
+msgstr ""
+
+#: src/Module/Install.php:282
+msgid "System Language:"
+msgstr ""
+
+#: src/Module/Install.php:284
+msgid ""
+"Set the default language for your Friendica installation interface and to "
+"send emails."
+msgstr ""
+
+#: src/Module/Install.php:296
+msgid "Your Friendica site database has been installed."
+msgstr ""
+
+#: src/Module/Install.php:304
+msgid "Installation finished"
+msgstr ""
+
+#: src/Module/Install.php:324
+msgid "<h1>What next</h1>"
+msgstr ""
+
+#: src/Module/Install.php:325
+msgid ""
+"IMPORTANT: You will need to [manually] setup a scheduled task for the worker."
+msgstr ""
+
+#: src/Module/Install.php:328
+#, php-format
+msgid ""
+"Go to your new Friendica node <a href=\"%s/register\">registration page</a> "
+"and register as new user. Remember to use the same email you have entered as "
+"administrator email. This will allow you to enter the site admin panel."
+msgstr ""
+
+#: src/Module/Invite.php:36
+msgid "Total invitation limit exceeded."
+msgstr ""
+
+#: src/Module/Invite.php:59
+#, php-format
+msgid "%s : Not a valid email address."
+msgstr ""
+
+#: src/Module/Invite.php:86
+msgid "Please join us on Friendica"
+msgstr ""
+
+#: src/Module/Invite.php:95
+msgid "Invitation limit exceeded. Please contact your site administrator."
+msgstr ""
+
+#: src/Module/Invite.php:99
+#, php-format
+msgid "%s : Message delivery failed."
+msgstr ""
+
+#: src/Module/Invite.php:103
+#, php-format
+msgid "%d message sent."
+msgid_plural "%d messages sent."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/Module/Invite.php:121
+msgid "You have no more invitations available"
+msgstr ""
+
+#: src/Module/Invite.php:128
+#, php-format
+msgid ""
+"Visit %s for a list of public sites that you can join. Friendica members on "
+"other sites can all connect with each other, as well as with members of many "
+"other social networks."
+msgstr ""
+
+#: src/Module/Invite.php:130
+#, php-format
+msgid ""
+"To accept this invitation, please visit and register at %s or any other "
+"public Friendica website."
+msgstr ""
+
+#: src/Module/Invite.php:131
+#, php-format
+msgid ""
+"Friendica sites all inter-connect to create a huge privacy-enhanced social "
+"web that is owned and controlled by its members. They can also connect with "
+"many traditional social networks. See %s for a list of alternate Friendica "
+"sites you can join."
+msgstr ""
+
+#: src/Module/Invite.php:135
+msgid ""
+"Our apologies. This system is not currently configured to connect with other "
+"public sites or invite members."
+msgstr ""
+
+#: src/Module/Invite.php:138
+msgid ""
+"Friendica sites all inter-connect to create a huge privacy-enhanced social "
+"web that is owned and controlled by its members. They can also connect with "
+"many traditional social networks."
+msgstr ""
+
+#: src/Module/Invite.php:137
+#, php-format
+msgid "To accept this invitation, please visit and register at %s."
+msgstr ""
+
+#: src/Module/Invite.php:145
+msgid "Send invitations"
+msgstr ""
+
+#: src/Module/Invite.php:146
+msgid "Enter email addresses, one per line:"
+msgstr ""
+
+#: src/Module/Invite.php:150
+msgid ""
+"You are cordially invited to join me and other close friends on Friendica - "
+"and help us to create a better social web."
+msgstr ""
+
+#: src/Module/Invite.php:152
+msgid "You will need to supply this invitation code: $invite_code"
+msgstr ""
+
+#: src/Module/Invite.php:152
+msgid ""
+"Once you have registered, please connect with me via my profile page at:"
+msgstr ""
+
+#: src/Module/Invite.php:154
+msgid ""
+"For more information about the Friendica project and why we feel it is "
+"important, please visit http://friendi.ca"
+msgstr ""
+
+#: src/Module/Maintenance.php:27
+msgid "System down for maintenance"
+msgstr ""
+
+#: src/Module/Photo.php:86
+#, php-format
+msgid "Invalid photo with id %s."
+msgstr ""
+
+#: src/Module/Register.php:50
+msgid "Only parent users can create additional accounts."
+msgstr ""
+
+#: src/Module/Register.php:82
+msgid ""
+"You may (optionally) fill in this form via OpenID by supplying your OpenID "
+"and clicking \"Register\"."
+msgstr ""
+
+#: src/Module/Register.php:83
+msgid ""
+"If you are not familiar with OpenID, please leave that field blank and fill "
+"in the rest of the items."
+msgstr ""
+
+#: src/Module/Register.php:84
+msgid "Your OpenID (optional): "
+msgstr ""
+
+#: src/Module/Register.php:93
+msgid "Include your profile in member directory?"
+msgstr ""
+
+#: src/Module/Register.php:116
+msgid "Note for the admin"
+msgstr ""
+
+#: src/Module/Register.php:116
+msgid "Leave a message for the admin, why you want to join this node"
+msgstr ""
+
+#: src/Module/Register.php:117
+msgid "Membership on this site is by invitation only."
+msgstr ""
+
+#: src/Module/Register.php:118
+msgid "Your invitation code: "
+msgstr ""
+
+#: src/Module/Register.php:126
+msgid "Your Full Name (e.g. Joe Smith, real or real-looking): "
+msgstr ""
+
+#: src/Module/Register.php:127
+msgid ""
+"Your Email Address: (Initial information will be send there, so this has to "
+"be an existing address.)"
+msgstr ""
+
+#: src/Module/Register.php:128
+msgid "Please repeat your e-mail address:"
+msgstr ""
+
+#: src/Module/Register.php:130
+msgid "Leave empty for an auto generated password."
+msgstr ""
+
+#: src/Module/Register.php:132
+#, php-format
+msgid ""
+"Choose a profile nickname. This must begin with a text character. Your "
+"profile address on this site will then be \"<strong>nickname@%s</strong>\"."
+msgstr ""
+
+#: src/Module/Register.php:133
+msgid "Choose a nickname: "
+msgstr ""
+
+#: src/Module/Register.php:142
+msgid "Import your profile to this friendica instance"
+msgstr ""
+
+#: src/Module/Register.php:149
+msgid "Note: This node explicitly contains adult content"
+msgstr ""
+
+#: src/Module/Register.php:182
+msgid "Password doesn't match."
+msgstr ""
+
+#: src/Module/Register.php:188
+msgid "Please enter your password."
+msgstr ""
+
+#: src/Module/Register.php:230
+msgid "You have entered too much information."
+msgstr ""
+
+#: src/Module/Register.php:254
+msgid "Please enter the identical mail address in the second field."
+msgstr ""
+
+#: src/Module/Register.php:281
+msgid "The additional account was created."
+msgstr ""
+
+#: src/Module/Register.php:306
+msgid ""
+"Registration successful. Please check your email for further instructions."
+msgstr ""
+
+#: src/Module/Register.php:310
+#, php-format
+msgid ""
+"Failed to send email message. Here your accout details:<br> login: %s<br> "
+"password: %s<br><br>You can change your password after login."
+msgstr ""
+
+#: src/Module/Register.php:316
+msgid "Registration successful."
+msgstr ""
+
+#: src/Module/Register.php:321 src/Module/Register.php:328
+msgid "Your registration can not be processed."
+msgstr ""
+
+#: src/Module/Register.php:327
+msgid "You have to leave a request note for the admin."
+msgstr ""
+
+#: src/Module/Register.php:375
+msgid "Your registration is pending approval by the site owner."
+msgstr ""
+
+#: src/Module/Security/Login.php:88
+msgid "Create a New Account"
+msgstr ""
+
+#: src/Module/Security/Login.php:113
+msgid "Your OpenID: "
+msgstr ""
+
+#: src/Module/Security/Login.php:116
+msgid ""
+"Please enter your username and password to add the OpenID to your existing "
+"account."
+msgstr ""
+
+#: src/Module/Security/Login.php:118
+msgid "Or login using OpenID: "
+msgstr ""
+
+#: src/Module/Security/Login.php:132
+msgid "Password: "
+msgstr ""
+
+#: src/Module/Security/Login.php:133
+msgid "Remember me"
+msgstr ""
+
+#: src/Module/Security/Login.php:142
+msgid "Forgot your password?"
+msgstr ""
+
+#: src/Module/Security/Login.php:145
+msgid "Website Terms of Service"
+msgstr ""
+
+#: src/Module/Security/Login.php:146
+msgid "terms of service"
+msgstr ""
+
+#: src/Module/Security/Login.php:148
+msgid "Website Privacy Policy"
+msgstr ""
+
+#: src/Module/Security/Login.php:149
+msgid "privacy policy"
+msgstr ""
+
+#: src/Module/Security/Logout.php:39
+msgid "Logged out."
+msgstr ""
+
+#: src/Module/Security/OpenID.php:35
+msgid "OpenID protocol error. No ID returned"
+msgstr ""
+
+#: src/Module/Security/OpenID.php:73
+msgid ""
+"Account not found. Please login to your existing account to add the OpenID "
+"to it."
+msgstr ""
+
+#: src/Module/Security/OpenID.php:75
+msgid ""
+"Account not found. Please register a new account or login to your existing "
+"account to add the OpenID to it."
+msgstr ""
+
+#: src/Module/Security/TwoFactor/Recovery.php:41
+#, php-format
+msgid "Remaining recovery codes: %d"
+msgstr ""
+
+#: src/Module/Security/TwoFactor/Recovery.php:64
+msgid "Two-factor recovery"
+msgstr ""
+
+#: src/Module/Security/TwoFactor/Recovery.php:65
+msgid ""
+"<p>You can enter one of your one-time recovery codes in case you lost access "
+"to your mobile device.</p>"
+msgstr ""
+
+#: src/Module/Security/TwoFactor/Recovery.php:66
+#: src/Module/Security/TwoFactor/Verify.php:65
+#, php-format
+msgid ""
+"Don’t have your phone? <a href=\"%s\">Enter a two-factor recovery code</a>"
+msgstr ""
+
+#: src/Module/Security/TwoFactor/Recovery.php:67
+msgid "Please enter a recovery code"
+msgstr ""
+
+#: src/Module/Security/TwoFactor/Recovery.php:68
+msgid "Submit recovery code and complete login"
+msgstr ""
+
+#: src/Module/Security/TwoFactor/Verify.php:62
+msgid ""
+"<p>Open the two-factor authentication app on your device to get an "
+"authentication code and verify your identity.</p>"
+msgstr ""
+
+#: src/Module/Security/TwoFactor/Verify.php:67
+msgid "Verify code and complete login"
+msgstr ""
+
+#: src/Module/Tos.php:33 src/Module/Tos.php:75
+msgid ""
+"At the time of registration, and for providing communications between the "
+"user account and their contacts, the user has to provide a display name (pen "
+"name), an username (nickname) and a working email address. The names will be "
+"accessible on the profile page of the account by any visitor of the page, "
+"even if other profile details are not displayed. The email address will only "
+"be used to send the user notifications about interactions, but wont be "
+"visibly displayed. The listing of an account in the node's user directory or "
+"the global user directory is optional and can be controlled in the user "
+"settings, it is not necessary for communication."
+msgstr ""
+
+#: src/Module/Tos.php:34 src/Module/Tos.php:76
+msgid ""
+"This data is required for communication and is passed on to the nodes of the "
+"communication partners and is stored there. Users can enter additional "
+"private data that may be transmitted to the communication partners accounts."
+msgstr ""
+
+#: src/Module/Tos.php:35 src/Module/Tos.php:77
+#, php-format
+msgid ""
+"At any point in time a logged in user can export their account data from the "
+"<a href=\"%1$s/settings/userexport\">account settings</a>. If the user wants "
+"to delete their account they can do so at <a href=\"%1$s/removeme\">%1$s/"
+"removeme</a>. The deletion of the account will be permanent. Deletion of the "
+"data will also be requested from the nodes of the communication partners."
+msgstr ""
+
+#: src/Module/Tos.php:38 src/Module/Tos.php:74
+msgid "Privacy Statement"
 msgstr ""
 
 #: src/Module/Welcome.php:25
@@ -9700,10 +10406,6 @@ msgid ""
 "directory listing is like having an unlisted phone number. In general, you "
 "should probably publish your listing - unless all of your friends and "
 "potential friends know exactly how to find you."
-msgstr ""
-
-#: src/Module/Welcome.php:39 mod/profile_photo.php:245 mod/profiles.php:581
-msgid "Upload Profile Photo"
 msgstr ""
 
 #: src/Module/Welcome.php:40
@@ -9821,868 +10523,169 @@ msgid ""
 "features and resources."
 msgstr ""
 
-#: src/Module/Profile/Contacts.php:24 src/Module/Profile/Contacts.php:37
-#: src/Module/Register.php:242
-msgid "User not found."
+#: src/Object/Post.php:131
+msgid "This entry was edited"
 msgstr ""
 
-#: src/Module/Profile/Contacts.php:78
-msgid "No contacts."
+#: src/Object/Post.php:154
+msgid "Private Message"
 msgstr ""
 
-#: src/Module/Profile/Contacts.php:93 src/Module/Contact.php:589
-#: src/Module/Contact.php:1032
+#: src/Object/Post.php:193
+msgid "pinned item"
+msgstr ""
+
+#: src/Object/Post.php:198
+msgid "Delete locally"
+msgstr ""
+
+#: src/Object/Post.php:201
+msgid "Delete globally"
+msgstr ""
+
+#: src/Object/Post.php:201
+msgid "Remove locally"
+msgstr ""
+
+#: src/Object/Post.php:215
+msgid "save to folder"
+msgstr ""
+
+#: src/Object/Post.php:250
+msgid "I will attend"
+msgstr ""
+
+#: src/Object/Post.php:250
+msgid "I will not attend"
+msgstr ""
+
+#: src/Object/Post.php:250
+msgid "I might attend"
+msgstr ""
+
+#: src/Object/Post.php:278
+msgid "ignore thread"
+msgstr ""
+
+#: src/Object/Post.php:279
+msgid "unignore thread"
+msgstr ""
+
+#: src/Object/Post.php:280
+msgid "toggle ignore status"
+msgstr ""
+
+#: src/Object/Post.php:292
+msgid "pin"
+msgstr ""
+
+#: src/Object/Post.php:293
+msgid "unpin"
+msgstr ""
+
+#: src/Object/Post.php:294
+msgid "toggle pin status"
+msgstr ""
+
+#: src/Object/Post.php:297
+msgid "pinned"
+msgstr ""
+
+#: src/Object/Post.php:304
+msgid "add star"
+msgstr ""
+
+#: src/Object/Post.php:305
+msgid "remove star"
+msgstr ""
+
+#: src/Object/Post.php:306
+msgid "toggle star status"
+msgstr ""
+
+#: src/Object/Post.php:309
+msgid "starred"
+msgstr ""
+
+#: src/Object/Post.php:313
+msgid "add tag"
+msgstr ""
+
+#: src/Object/Post.php:324
+msgid "like"
+msgstr ""
+
+#: src/Object/Post.php:325
+msgid "dislike"
+msgstr ""
+
+#: src/Object/Post.php:328
+msgid "Share this"
+msgstr ""
+
+#: src/Object/Post.php:328
+msgid "share"
+msgstr ""
+
+#: src/Object/Post.php:377
 #, php-format
-msgid "Visit %s's profile [%s]"
+msgid "%s (Received %s)"
 msgstr ""
 
-#: src/Module/Profile/Contacts.php:112
+#: src/Object/Post.php:402
+msgid "to"
+msgstr ""
+
+#: src/Object/Post.php:403
+msgid "via"
+msgstr ""
+
+#: src/Object/Post.php:404
+msgid "Wall-to-Wall"
+msgstr ""
+
+#: src/Object/Post.php:405
+msgid "via Wall-To-Wall:"
+msgstr ""
+
+#: src/Object/Post.php:441
 #, php-format
-msgid "Follower (%s)"
-msgid_plural "Followers (%s)"
+msgid "Reply to %s"
+msgstr ""
+
+#: src/Object/Post.php:457
+msgid "Notifier task is pending"
+msgstr ""
+
+#: src/Object/Post.php:458
+msgid "Delivery to remote servers is pending"
+msgstr ""
+
+#: src/Object/Post.php:459
+msgid "Delivery to remote servers is underway"
+msgstr ""
+
+#: src/Object/Post.php:460
+msgid "Delivery to remote servers is mostly done"
+msgstr ""
+
+#: src/Object/Post.php:461
+msgid "Delivery to remote servers is done"
+msgstr ""
+
+#: src/Object/Post.php:481
+#, php-format
+msgid "%d comment"
+msgid_plural "%d comments"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Module/Profile/Contacts.php:113
-#, php-format
-msgid "Following (%s)"
-msgid_plural "Following (%s)"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/Module/Profile/Contacts.php:114
-#, php-format
-msgid "Mutual friend (%s)"
-msgid_plural "Mutual friends (%s)"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/Module/Profile/Contacts.php:116
-#, php-format
-msgid "Contact (%s)"
-msgid_plural "Contacts (%s)"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/Module/Profile/Contacts.php:125
-msgid "All contacts"
-msgstr ""
-
-#: src/Module/Filer/SaveTag.php:38
-#, php-format
-msgid "Filetag %s saved to item"
-msgstr ""
-
-#: src/Module/Filer/SaveTag.php:47
-msgid "- select -"
-msgstr ""
-
-#: src/Module/AllFriends.php:35 src/Module/AllFriends.php:43
-#: mod/network.php:617
-msgid "Invalid contact."
-msgstr ""
-
-#: src/Module/AllFriends.php:55
-msgid "No friends to display."
-msgstr ""
-
-#: src/Module/Contact.php:71
-#, php-format
-msgid "%d contact edited."
-msgid_plural "%d contacts edited."
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/Module/Contact.php:98
-msgid "Could not access contact record."
-msgstr ""
-
-#: src/Module/Contact.php:108
-msgid "Could not locate selected profile."
-msgstr ""
-
-#: src/Module/Contact.php:140
-msgid "Contact updated."
-msgstr ""
-
-#: src/Module/Contact.php:142 mod/dfrn_request.php:416
-msgid "Failed to update contact record."
-msgstr ""
-
-#: src/Module/Contact.php:375
-msgid "Contact not found"
-msgstr ""
-
-#: src/Module/Contact.php:394
-msgid "Contact has been blocked"
-msgstr ""
-
-#: src/Module/Contact.php:394
-msgid "Contact has been unblocked"
-msgstr ""
-
-#: src/Module/Contact.php:404
-msgid "Contact has been ignored"
-msgstr ""
-
-#: src/Module/Contact.php:404
-msgid "Contact has been unignored"
-msgstr ""
-
-#: src/Module/Contact.php:414
-msgid "Contact has been archived"
-msgstr ""
-
-#: src/Module/Contact.php:414
-msgid "Contact has been unarchived"
-msgstr ""
-
-#: src/Module/Contact.php:438
-msgid "Drop contact"
-msgstr ""
-
-#: src/Module/Contact.php:441 src/Module/Contact.php:822
-msgid "Do you really want to delete this contact?"
-msgstr ""
-
-#: src/Module/Contact.php:455
-msgid "Contact has been removed."
-msgstr ""
-
-#: src/Module/Contact.php:485
-#, php-format
-msgid "You are mutual friends with %s"
-msgstr ""
-
-#: src/Module/Contact.php:490
-#, php-format
-msgid "You are sharing with %s"
-msgstr ""
-
-#: src/Module/Contact.php:495
-#, php-format
-msgid "%s is sharing with you"
-msgstr ""
-
-#: src/Module/Contact.php:519
-msgid "Private communications are not available for this contact."
-msgstr ""
-
-#: src/Module/Contact.php:521
-msgid "Never"
-msgstr ""
-
-#: src/Module/Contact.php:524
-msgid "(Update was successful)"
-msgstr ""
-
-#: src/Module/Contact.php:524
-msgid "(Update was not successful)"
-msgstr ""
-
-#: src/Module/Contact.php:526 src/Module/Contact.php:1066
-msgid "Suggest friends"
-msgstr ""
-
-#: src/Module/Contact.php:530
-#, php-format
-msgid "Network type: %s"
-msgstr ""
-
-#: src/Module/Contact.php:535
-msgid "Communications lost with this contact!"
-msgstr ""
-
-#: src/Module/Contact.php:541
-msgid "Fetch further information for feeds"
-msgstr ""
-
-#: src/Module/Contact.php:543
-msgid ""
-"Fetch information like preview pictures, title and teaser from the feed "
-"item. You can activate this if the feed doesn't contain much text. Keywords "
-"are taken from the meta header in the feed item and are posted as hash tags."
-msgstr ""
-
-#: src/Module/Contact.php:546
-msgid "Fetch information"
-msgstr ""
-
-#: src/Module/Contact.php:547
-msgid "Fetch keywords"
-msgstr ""
-
-#: src/Module/Contact.php:548
-msgid "Fetch information and keywords"
-msgstr ""
-
-#: src/Module/Contact.php:567
-msgid "Profile Visibility"
-msgstr ""
-
-#: src/Module/Contact.php:568
-msgid "Contact Information / Notes"
-msgstr ""
-
-#: src/Module/Contact.php:569
-msgid "Contact Settings"
-msgstr ""
-
-#: src/Module/Contact.php:578
-msgid "Contact"
-msgstr ""
-
-#: src/Module/Contact.php:582
-#, php-format
-msgid ""
-"Please choose the profile you would like to display to %s when viewing your "
-"profile securely."
-msgstr ""
-
-#: src/Module/Contact.php:584
-msgid "Their personal note"
-msgstr ""
-
-#: src/Module/Contact.php:586
-msgid "Edit contact notes"
-msgstr ""
-
-#: src/Module/Contact.php:590
-msgid "Block/Unblock contact"
-msgstr ""
-
-#: src/Module/Contact.php:591
-msgid "Ignore contact"
-msgstr ""
-
-#: src/Module/Contact.php:592
-msgid "Repair URL settings"
-msgstr ""
-
-#: src/Module/Contact.php:593
-msgid "View conversations"
-msgstr ""
-
-#: src/Module/Contact.php:598
-msgid "Last update:"
-msgstr ""
-
-#: src/Module/Contact.php:600
-msgid "Update public posts"
-msgstr ""
-
-#: src/Module/Contact.php:602 src/Module/Contact.php:1076
-msgid "Update now"
-msgstr ""
-
-#: src/Module/Contact.php:606 src/Module/Contact.php:827
-#: src/Module/Contact.php:1093
-msgid "Unignore"
-msgstr ""
-
-#: src/Module/Contact.php:610
-msgid "Currently blocked"
-msgstr ""
-
-#: src/Module/Contact.php:611
-msgid "Currently ignored"
-msgstr ""
-
-#: src/Module/Contact.php:612
-msgid "Currently archived"
-msgstr ""
-
-#: src/Module/Contact.php:613
-msgid "Awaiting connection acknowledge"
-msgstr ""
-
-#: src/Module/Contact.php:614 mod/notifications.php:168
-#: mod/notifications.php:255
-msgid "Hide this contact from others"
-msgstr ""
-
-#: src/Module/Contact.php:614
-msgid ""
-"Replies/likes to your public posts <strong>may</strong> still be visible"
-msgstr ""
-
-#: src/Module/Contact.php:615
-msgid "Notification for new posts"
-msgstr ""
-
-#: src/Module/Contact.php:615
-msgid "Send a notification of every new post of this contact"
-msgstr ""
-
-#: src/Module/Contact.php:617
-msgid "Blacklisted keywords"
-msgstr ""
-
-#: src/Module/Contact.php:617
-msgid ""
-"Comma separated list of keywords that should not be converted to hashtags, "
-"when \"Fetch information and keywords\" is selected"
-msgstr ""
-
-#: src/Module/Contact.php:687
-msgid "Show all contacts"
-msgstr ""
-
-#: src/Module/Contact.php:692 src/Module/Contact.php:802
-msgid "Pending"
-msgstr ""
-
-#: src/Module/Contact.php:695
-msgid "Only show pending contacts"
-msgstr ""
-
-#: src/Module/Contact.php:700 src/Module/Contact.php:803
-msgid "Blocked"
-msgstr ""
-
-#: src/Module/Contact.php:703
-msgid "Only show blocked contacts"
-msgstr ""
-
-#: src/Module/Contact.php:708 src/Module/Contact.php:805
-msgid "Ignored"
-msgstr ""
-
-#: src/Module/Contact.php:711
-msgid "Only show ignored contacts"
-msgstr ""
-
-#: src/Module/Contact.php:716 src/Module/Contact.php:806
-msgid "Archived"
-msgstr ""
-
-#: src/Module/Contact.php:719
-msgid "Only show archived contacts"
-msgstr ""
-
-#: src/Module/Contact.php:724 src/Module/Contact.php:804
-msgid "Hidden"
-msgstr ""
-
-#: src/Module/Contact.php:727
-msgid "Only show hidden contacts"
-msgstr ""
-
-#: src/Module/Contact.php:735
-msgid "Organize your contact groups"
-msgstr ""
-
-#: src/Module/Contact.php:817
-msgid "Search your contacts"
-msgstr ""
-
-#: src/Module/Contact.php:818 src/Module/Search/Index.php:176
-#, php-format
-msgid "Results for: %s"
-msgstr ""
-
-#: src/Module/Contact.php:825 mod/settings.php:189 mod/settings.php:690
-msgid "Update"
-msgstr ""
-
-#: src/Module/Contact.php:828 src/Module/Contact.php:1102
-msgid "Archive"
-msgstr ""
-
-#: src/Module/Contact.php:828 src/Module/Contact.php:1102
-msgid "Unarchive"
-msgstr ""
-
-#: src/Module/Contact.php:831
-msgid "Batch Actions"
-msgstr ""
-
-#: src/Module/Contact.php:858
-msgid "Conversations started by this contact"
-msgstr ""
-
-#: src/Module/Contact.php:863
-msgid "Posts and Comments"
-msgstr ""
-
-#: src/Module/Contact.php:886
-msgid "View all contacts"
-msgstr ""
-
-#: src/Module/Contact.php:894 mod/common.php:141
-msgid "Common Friends"
-msgstr ""
-
-#: src/Module/Contact.php:897
-msgid "View all common friends"
-msgstr ""
-
-#: src/Module/Contact.php:907
-msgid "Advanced Contact Settings"
-msgstr ""
-
-#: src/Module/Contact.php:990
-msgid "Mutual Friendship"
-msgstr ""
-
-#: src/Module/Contact.php:995
-msgid "is a fan of yours"
-msgstr ""
-
-#: src/Module/Contact.php:1000
-msgid "you are a fan of"
-msgstr ""
-
-#: src/Module/Contact.php:1018
-msgid "Pending outgoing contact request"
-msgstr ""
-
-#: src/Module/Contact.php:1020
-msgid "Pending incoming contact request"
-msgstr ""
-
-#: src/Module/Contact.php:1033
-msgid "Edit contact"
-msgstr ""
-
-#: src/Module/Contact.php:1087
-msgid "Toggle Blocked status"
-msgstr ""
-
-#: src/Module/Contact.php:1095
-msgid "Toggle Ignored status"
-msgstr ""
-
-#: src/Module/Contact.php:1104
-msgid "Toggle Archive status"
-msgstr ""
-
-#: src/Module/Contact.php:1112
-msgid "Delete contact"
-msgstr ""
-
-#: src/Module/Invite.php:36
-msgid "Total invitation limit exceeded."
-msgstr ""
-
-#: src/Module/Invite.php:59
-#, php-format
-msgid "%s : Not a valid email address."
-msgstr ""
-
-#: src/Module/Invite.php:86
-msgid "Please join us on Friendica"
-msgstr ""
-
-#: src/Module/Invite.php:95
-msgid "Invitation limit exceeded. Please contact your site administrator."
-msgstr ""
-
-#: src/Module/Invite.php:99
-#, php-format
-msgid "%s : Message delivery failed."
-msgstr ""
-
-#: src/Module/Invite.php:103
-#, php-format
-msgid "%d message sent."
-msgid_plural "%d messages sent."
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/Module/Invite.php:121
-msgid "You have no more invitations available"
-msgstr ""
-
-#: src/Module/Invite.php:128
-#, php-format
-msgid ""
-"Visit %s for a list of public sites that you can join. Friendica members on "
-"other sites can all connect with each other, as well as with members of many "
-"other social networks."
-msgstr ""
-
-#: src/Module/Invite.php:130
-#, php-format
-msgid ""
-"To accept this invitation, please visit and register at %s or any other "
-"public Friendica website."
-msgstr ""
-
-#: src/Module/Invite.php:131
-#, php-format
-msgid ""
-"Friendica sites all inter-connect to create a huge privacy-enhanced social "
-"web that is owned and controlled by its members. They can also connect with "
-"many traditional social networks. See %s for a list of alternate Friendica "
-"sites you can join."
-msgstr ""
-
-#: src/Module/Invite.php:135
-msgid ""
-"Our apologies. This system is not currently configured to connect with other "
-"public sites or invite members."
-msgstr ""
-
-#: src/Module/Invite.php:138
-msgid ""
-"Friendica sites all inter-connect to create a huge privacy-enhanced social "
-"web that is owned and controlled by its members. They can also connect with "
-"many traditional social networks."
-msgstr ""
-
-#: src/Module/Invite.php:137
-#, php-format
-msgid "To accept this invitation, please visit and register at %s."
-msgstr ""
-
-#: src/Module/Invite.php:145
-msgid "Send invitations"
-msgstr ""
-
-#: src/Module/Invite.php:146
-msgid "Enter email addresses, one per line:"
-msgstr ""
-
-#: src/Module/Invite.php:149 mod/wallmessage.php:136 mod/message.php:253
-#: mod/message.php:433
-msgid "Your message:"
-msgstr ""
-
-#: src/Module/Invite.php:150
-msgid ""
-"You are cordially invited to join me and other close friends on Friendica - "
-"and help us to create a better social web."
-msgstr ""
-
-#: src/Module/Invite.php:152
-msgid "You will need to supply this invitation code: $invite_code"
-msgstr ""
-
-#: src/Module/Invite.php:152
-msgid ""
-"Once you have registered, please connect with me via my profile page at:"
-msgstr ""
-
-#: src/Module/Invite.php:154
-msgid ""
-"For more information about the Friendica project and why we feel it is "
-"important, please visit http://friendi.ca"
-msgstr ""
-
-#: src/Module/BaseSettingsModule.php:18 mod/photos.php:131 mod/settings.php:57
-msgid "everybody"
-msgstr ""
-
-#: src/Module/BaseSettingsModule.php:24 mod/settings.php:62
-msgid "Account"
-msgstr ""
-
-#: src/Module/BaseSettingsModule.php:54 mod/settings.php:93
-msgid "Display"
-msgstr ""
-
-#: src/Module/BaseSettingsModule.php:61 mod/settings.php:100
-#: mod/settings.php:837
-msgid "Social Networks"
-msgstr ""
-
-#: src/Module/BaseSettingsModule.php:75 mod/settings.php:114
-msgid "Delegations"
-msgstr ""
-
-#: src/Module/BaseSettingsModule.php:82 mod/settings.php:121
-msgid "Connected apps"
-msgstr ""
-
-#: src/Module/BaseSettingsModule.php:96 mod/settings.php:135
-msgid "Remove account"
-msgstr ""
-
-#: src/Module/Item/Compose.php:27
-msgid "Please enter a post body."
-msgstr ""
-
-#: src/Module/Item/Compose.php:40
-msgid "This feature is only available with the frio theme."
-msgstr ""
-
-#: src/Module/Item/Compose.php:67
-msgid "Compose new personal note"
-msgstr ""
-
-#: src/Module/Item/Compose.php:76
-msgid "Compose new post"
-msgstr ""
-
-#: src/Module/Item/Compose.php:116
-msgid "Visibility"
-msgstr ""
-
-#: src/Module/Item/Compose.php:137
-msgid "Clear the location"
-msgstr ""
-
-#: src/Module/Item/Compose.php:138
-msgid "Location services are unavailable on your device"
-msgstr ""
-
-#: src/Module/Item/Compose.php:139
-msgid ""
-"Location services are disabled. Please check the website's permissions on "
-"your device"
-msgstr ""
-
-#: src/Module/Friendica.php:39
-msgid "Installed addons/apps:"
-msgstr ""
-
-#: src/Module/Friendica.php:44
-msgid "No installed addons/apps"
-msgstr ""
-
-#: src/Module/Friendica.php:49
-#, php-format
-msgid "Read about the <a href=\"%1$s/tos\">Terms of Service</a> of this node."
-msgstr ""
-
-#: src/Module/Friendica.php:56
-msgid "On this server the following remote servers are blocked."
-msgstr ""
-
-#: src/Module/Friendica.php:74
-#, php-format
-msgid ""
-"This is Friendica, version %s that is running at the web location %s. The "
-"database version is %s, the post update version is %s."
-msgstr ""
-
-#: src/Module/Friendica.php:79
-msgid ""
-"Please visit <a href=\"https://friendi.ca\">Friendi.ca</a> to learn more "
-"about the Friendica project."
-msgstr ""
-
-#: src/Module/Friendica.php:80
-msgid "Bug reports and issues: please visit"
-msgstr ""
-
-#: src/Module/Friendica.php:80
-msgid "the bugtracker at github"
-msgstr ""
-
-#: src/Module/Friendica.php:81
-msgid ""
-"Suggestions, praise, etc. - please email \"info\" at \"friendi - dot - ca"
-msgstr ""
-
-#: src/Module/HoverCard.php:30
-msgid "No profile"
-msgstr ""
-
-#: src/Module/Register.php:51
-msgid "Only parent users can create additional accounts."
-msgstr ""
-
-#: src/Module/Register.php:66 mod/uimport.php:39
-msgid ""
-"This site has exceeded the number of allowed daily account registrations. "
-"Please try again tomorrow."
-msgstr ""
-
-#: src/Module/Register.php:83
-msgid ""
-"You may (optionally) fill in this form via OpenID by supplying your OpenID "
-"and clicking \"Register\"."
-msgstr ""
-
-#: src/Module/Register.php:84
-msgid ""
-"If you are not familiar with OpenID, please leave that field blank and fill "
-"in the rest of the items."
-msgstr ""
-
-#: src/Module/Register.php:85
-msgid "Your OpenID (optional): "
-msgstr ""
-
-#: src/Module/Register.php:94
-msgid "Include your profile in member directory?"
-msgstr ""
-
-#: src/Module/Register.php:98 mod/api.php:111 mod/dfrn_request.php:643
-#: mod/follow.php:162 mod/profiles.php:524 mod/profiles.php:528
-#: mod/profiles.php:549 mod/settings.php:1084 mod/settings.php:1090
-#: mod/settings.php:1097 mod/settings.php:1101 mod/settings.php:1105
-#: mod/settings.php:1109 mod/settings.php:1113 mod/settings.php:1117
-#: mod/settings.php:1137 mod/settings.php:1138 mod/settings.php:1139
-#: mod/settings.php:1140 mod/settings.php:1141
-msgid "No"
-msgstr ""
-
-#: src/Module/Register.php:117
-msgid "Note for the admin"
-msgstr ""
-
-#: src/Module/Register.php:117
-msgid "Leave a message for the admin, why you want to join this node"
-msgstr ""
-
-#: src/Module/Register.php:118
-msgid "Membership on this site is by invitation only."
-msgstr ""
-
-#: src/Module/Register.php:119
-msgid "Your invitation code: "
-msgstr ""
-
-#: src/Module/Register.php:127
-msgid "Your Full Name (e.g. Joe Smith, real or real-looking): "
-msgstr ""
-
-#: src/Module/Register.php:128
-msgid ""
-"Your Email Address: (Initial information will be send there, so this has to "
-"be an existing address.)"
-msgstr ""
-
-#: src/Module/Register.php:129
-msgid "Please repeat your e-mail address:"
-msgstr ""
-
-#: src/Module/Register.php:131 mod/settings.php:1180
-msgid "New Password:"
-msgstr ""
-
-#: src/Module/Register.php:131
-msgid "Leave empty for an auto generated password."
-msgstr ""
-
-#: src/Module/Register.php:132 mod/settings.php:1181
-msgid "Confirm:"
-msgstr ""
-
-#: src/Module/Register.php:133
-#, php-format
-msgid ""
-"Choose a profile nickname. This must begin with a text character. Your "
-"profile address on this site will then be \"<strong>nickname@%s</strong>\"."
-msgstr ""
-
-#: src/Module/Register.php:134
-msgid "Choose a nickname: "
-msgstr ""
-
-#: src/Module/Register.php:142 mod/uimport.php:46
-msgid "Import"
-msgstr ""
-
-#: src/Module/Register.php:143
-msgid "Import your profile to this friendica instance"
-msgstr ""
-
-#: src/Module/Register.php:150
-msgid "Note: This node explicitly contains adult content"
-msgstr ""
-
-#: src/Module/Register.php:183
-msgid "Password doesn't match."
-msgstr ""
-
-#: src/Module/Register.php:189
-msgid "Please enter your password."
-msgstr ""
-
-#: src/Module/Register.php:231
-msgid "You have entered too much information."
-msgstr ""
-
-#: src/Module/Register.php:255
-msgid "Please enter the identical mail address in the second field."
-msgstr ""
-
-#: src/Module/Register.php:282
-msgid "The additional account was created."
-msgstr ""
-
-#: src/Module/Register.php:307
-msgid ""
-"Registration successful. Please check your email for further instructions."
-msgstr ""
-
-#: src/Module/Register.php:311
-#, php-format
-msgid ""
-"Failed to send email message. Here your accout details:<br> login: %s<br> "
-"password: %s<br><br>You can change your password after login."
-msgstr ""
-
-#: src/Module/Register.php:317
-msgid "Registration successful."
-msgstr ""
-
-#: src/Module/Register.php:322 src/Module/Register.php:329
-msgid "Your registration can not be processed."
-msgstr ""
-
-#: src/Module/Register.php:328
-msgid "You have to leave a request note for the admin."
-msgstr ""
-
-#: src/Module/Register.php:376
-msgid "Your registration is pending approval by the site owner."
-msgstr ""
-
-#: src/Module/Search/Saved.php:25
-msgid "Search term successfully saved."
-msgstr ""
-
-#: src/Module/Search/Saved.php:27
-msgid "Search term already saved."
-msgstr ""
-
-#: src/Module/Search/Saved.php:33
-msgid "Search term successfully removed."
-msgstr ""
-
-#: src/Module/Search/Index.php:34
-msgid "Only logged in users are permitted to perform a search."
-msgstr ""
-
-#: src/Module/Search/Index.php:56
-msgid "Only one search per minute is permitted for not logged in users."
-msgstr ""
-
-#: src/Module/Search/Index.php:169 mod/community.php:155
-msgid "No results."
-msgstr ""
-
-#: src/Module/Search/Index.php:174
-#, php-format
-msgid "Items tagged with: %s"
-msgstr ""
-
-#: src/Module/Search/Acl.php:36
-msgid "You must be logged in to use this module."
-msgstr ""
-
-#: src/BaseModule.php:132
-msgid ""
-"The form security token was not correct. This probably happened because the "
-"form has been opened for too long (>3 hours) before submitting it."
-msgstr ""
-
-#: src/App/Page.php:228
-msgid "Delete this item?"
-msgstr ""
-
-#: src/App/Page.php:276
-msgid "toggle mobile"
+#: src/Object/Post.php:482
+msgid "Show more"
 msgstr ""
 
-#: src/App/Router.php:183
-#, php-format
-msgid "Method not allowed for this module. Allowed method(s): %s"
+#: src/Object/Post.php:483
+msgid "Show fewer"
 msgstr ""
 
 #: src/App/Authentication.php:195 src/App/Authentication.php:247
@@ -10711,78 +10714,30 @@ msgstr ""
 msgid "You must be logged in to use addons. "
 msgstr ""
 
-#: src/Util/Temporal.php:78 src/Util/Temporal.php:80 mod/profiles.php:579
-msgid "Miscellaneous"
+#: src/App/Page.php:228
+msgid "Delete this item?"
 msgstr ""
 
-#: src/Util/Temporal.php:147 mod/profiles.php:602
-msgid "Age: "
+#: src/App/Page.php:276
+msgid "toggle mobile"
 msgstr ""
 
-#: src/Util/Temporal.php:149
-msgid "YYYY-MM-DD or MM-DD"
-msgstr ""
-
-#: src/Util/Temporal.php:296
-msgid "never"
-msgstr ""
-
-#: src/Util/Temporal.php:303
-msgid "less than a second ago"
-msgstr ""
-
-#: src/Util/Temporal.php:311
-msgid "year"
-msgstr ""
-
-#: src/Util/Temporal.php:311
-msgid "years"
-msgstr ""
-
-#: src/Util/Temporal.php:312
-msgid "months"
-msgstr ""
-
-#: src/Util/Temporal.php:313
-msgid "weeks"
-msgstr ""
-
-#: src/Util/Temporal.php:314
-msgid "days"
-msgstr ""
-
-#: src/Util/Temporal.php:315
-msgid "hour"
-msgstr ""
-
-#: src/Util/Temporal.php:315
-msgid "hours"
-msgstr ""
-
-#: src/Util/Temporal.php:316
-msgid "minute"
-msgstr ""
-
-#: src/Util/Temporal.php:317
-msgid "second"
-msgstr ""
-
-#: src/Util/Temporal.php:317
-msgid "seconds"
-msgstr ""
-
-#: src/Util/Temporal.php:327
+#: src/App/Router.php:190
 #, php-format
-msgid "in %1$d %2$s"
+msgid "Method not allowed for this module. Allowed method(s): %s"
 msgstr ""
 
-#: src/Util/Temporal.php:330
+#: src/Console/ArchiveContact.php:86
 #, php-format
-msgid "%1$d %2$s ago"
+msgid "Could not find any unarchived contact entry for this URL (%s)"
 msgstr ""
 
-#: src/Worker/Delivery.php:539
-msgid "(no subject)"
+#: src/Console/ArchiveContact.php:89
+msgid "The contact entries have been archived"
+msgstr ""
+
+#: src/Console/NewPassword.php:93
+msgid "Enter new password: "
 msgstr ""
 
 #: src/Console/PostUpdate.php:73
@@ -10806,2634 +10761,27 @@ msgstr ""
 msgid "All pending post updates are done."
 msgstr ""
 
-#: src/Console/NewPassword.php:93
-msgid "Enter new password: "
+#: src/App.php:333
+msgid "No system theme config value set."
 msgstr ""
 
-#: src/Console/NewPassword.php:101 mod/settings.php:438
-msgid "Password update failed. Please try again."
+#: src/BaseModule.php:132
+msgid ""
+"The form security token was not correct. This probably happened because the "
+"form has been opened for too long (>3 hours) before submitting it."
 msgstr ""
 
-#: src/Console/NewPassword.php:104 mod/settings.php:441
-msgid "Password changed."
-msgstr ""
-
-#: src/Console/ArchiveContact.php:85
+#: src/LegacyModule.php:30
 #, php-format
-msgid "Could not find any unarchived contact entry for this URL (%s)"
+msgid "Legacy module file not found: %s"
 msgstr ""
 
-#: src/Console/ArchiveContact.php:88
-msgid "The contact entries have been archived"
-msgstr ""
-
-#: mod/lostpass.php:26
-msgid "No valid account found."
-msgstr ""
-
-#: mod/lostpass.php:38
-msgid "Password reset request issued. Check your email."
-msgstr ""
-
-#: mod/lostpass.php:44
+#: update.php:217
 #, php-format
-msgid ""
-"\n"
-"\t\tDear %1$s,\n"
-"\t\t\tA request was recently received at \"%2$s\" to reset your account\n"
-"\t\tpassword. In order to confirm this request, please select the "
-"verification link\n"
-"\t\tbelow or paste it into your web browser address bar.\n"
-"\n"
-"\t\tIf you did NOT request this change, please DO NOT follow the link\n"
-"\t\tprovided and ignore and/or delete this email, the request will expire "
-"shortly.\n"
-"\n"
-"\t\tYour password will not be changed unless we can verify that you\n"
-"\t\tissued this request."
+msgid "%s: Updating author-id and owner-id in item and thread table. "
 msgstr ""
 
-#: mod/lostpass.php:55
+#: update.php:272
 #, php-format
-msgid ""
-"\n"
-"\t\tFollow this link soon to verify your identity:\n"
-"\n"
-"\t\t%1$s\n"
-"\n"
-"\t\tYou will then receive a follow-up message containing the new password.\n"
-"\t\tYou may change that password from your account settings page after "
-"logging in.\n"
-"\n"
-"\t\tThe login details are as follows:\n"
-"\n"
-"\t\tSite Location:\t%2$s\n"
-"\t\tLogin Name:\t%3$s"
-msgstr ""
-
-#: mod/lostpass.php:74
-#, php-format
-msgid "Password reset requested at %s"
-msgstr ""
-
-#: mod/lostpass.php:89
-msgid ""
-"Request could not be verified. (You may have previously submitted it.) "
-"Password reset failed."
-msgstr ""
-
-#: mod/lostpass.php:102
-msgid "Request has expired, please make a new one."
-msgstr ""
-
-#: mod/lostpass.php:117
-msgid "Forgot your Password?"
-msgstr ""
-
-#: mod/lostpass.php:118
-msgid ""
-"Enter your email address and submit to have your password reset. Then check "
-"your email for further instructions."
-msgstr ""
-
-#: mod/lostpass.php:120
-msgid "Reset"
-msgstr ""
-
-#: mod/lostpass.php:136
-msgid "Your password has been reset as requested."
-msgstr ""
-
-#: mod/lostpass.php:137
-msgid "Your new password is"
-msgstr ""
-
-#: mod/lostpass.php:138
-msgid "Save or copy your new password - and then"
-msgstr ""
-
-#: mod/lostpass.php:139
-msgid "click here to login"
-msgstr ""
-
-#: mod/lostpass.php:140
-msgid ""
-"Your password may be changed from the <em>Settings</em> page after "
-"successful login."
-msgstr ""
-
-#: mod/lostpass.php:147
-#, php-format
-msgid ""
-"\n"
-"\t\t\tDear %1$s,\n"
-"\t\t\t\tYour password has been changed as requested. Please retain this\n"
-"\t\t\tinformation for your records (or change your password immediately to\n"
-"\t\t\tsomething that you will remember).\n"
-"\t\t"
-msgstr ""
-
-#: mod/lostpass.php:153
-#, php-format
-msgid ""
-"\n"
-"\t\t\tYour login details are as follows:\n"
-"\n"
-"\t\t\tSite Location:\t%1$s\n"
-"\t\t\tLogin Name:\t%2$s\n"
-"\t\t\tPassword:\t%3$s\n"
-"\n"
-"\t\t\tYou may change that password from your account settings page after "
-"logging in.\n"
-"\t\t"
-msgstr ""
-
-#: mod/lostpass.php:169
-#, php-format
-msgid "Your password has been changed at %s"
-msgstr ""
-
-#: mod/update_contact.php:22 mod/update_profile.php:33 mod/update_notes.php:35
-#: mod/update_community.php:22 mod/update_display.php:23
-#: mod/update_network.php:32
-msgid "[Embedded content - reload page to view]"
-msgstr ""
-
-#: mod/uimport.php:30
-msgid "User imports on closed servers can only be done by an administrator."
-msgstr ""
-
-#: mod/uimport.php:48
-msgid "Move account"
-msgstr ""
-
-#: mod/uimport.php:49
-msgid "You can import an account from another Friendica server."
-msgstr ""
-
-#: mod/uimport.php:50
-msgid ""
-"You need to export your account from the old server and upload it here. We "
-"will recreate your old account here with all your contacts. We will try also "
-"to inform your friends that you moved here."
-msgstr ""
-
-#: mod/uimport.php:51
-msgid ""
-"This feature is experimental. We can't import contacts from the OStatus "
-"network (GNU Social/Statusnet) or from Diaspora"
-msgstr ""
-
-#: mod/uimport.php:52
-msgid "Account file"
-msgstr ""
-
-#: mod/uimport.php:52
-msgid ""
-"To export your account, go to \"Settings->Export your personal data\" and "
-"select \"Export account\""
-msgstr ""
-
-#: mod/community.php:68
-msgid "Community option not available."
-msgstr ""
-
-#: mod/community.php:85
-msgid "Not available."
-msgstr ""
-
-#: mod/community.php:95
-msgid "Local Community"
-msgstr ""
-
-#: mod/community.php:98
-msgid "Posts from local users on this server"
-msgstr ""
-
-#: mod/community.php:106
-msgid "Global Community"
-msgstr ""
-
-#: mod/community.php:109
-msgid "Posts from users of the whole federated network"
-msgstr ""
-
-#: mod/community.php:207
-msgid ""
-"This community stream shows all public posts received by this node. They may "
-"not reflect the opinions of this node’s users."
-msgstr ""
-
-#: mod/fsuggest.php:43
-msgid "Suggested contact not found."
-msgstr ""
-
-#: mod/fsuggest.php:56
-msgid "Friend suggestion sent."
-msgstr ""
-
-#: mod/fsuggest.php:78
-msgid "Suggest Friends"
-msgstr ""
-
-#: mod/fsuggest.php:80
-#, php-format
-msgid "Suggest a friend for %s"
-msgstr ""
-
-#: mod/common.php:90
-msgid "No contacts in common."
-msgstr ""
-
-#: mod/ping.php:270
-msgid "{0} wants to be your friend"
-msgstr ""
-
-#: mod/ping.php:286
-msgid "{0} requested registration"
-msgstr ""
-
-#: mod/lockview.php:47 mod/lockview.php:58
-msgid "Remote privacy information not available."
-msgstr ""
-
-#: mod/events.php:119 mod/events.php:121
-msgid "Event can not end before it has started."
-msgstr ""
-
-#: mod/events.php:128 mod/events.php:130
-msgid "Event title and start time are required."
-msgstr ""
-
-#: mod/events.php:394 mod/cal.php:259
-msgid "View"
-msgstr ""
-
-#: mod/events.php:395
-msgid "Create New Event"
-msgstr ""
-
-#: mod/events.php:396 mod/cal.php:260
-msgid "Previous"
-msgstr ""
-
-#: mod/events.php:406 mod/cal.php:268
-msgid "list"
-msgstr ""
-
-#: mod/events.php:507
-msgid "Event details"
-msgstr ""
-
-#: mod/events.php:508
-msgid "Starting date and Title are required."
-msgstr ""
-
-#: mod/events.php:509 mod/events.php:514
-msgid "Event Starts:"
-msgstr ""
-
-#: mod/events.php:509 mod/events.php:541 mod/profiles.php:590
-msgid "Required"
-msgstr ""
-
-#: mod/events.php:522 mod/events.php:547
-msgid "Finish date/time is not known or not relevant"
-msgstr ""
-
-#: mod/events.php:524 mod/events.php:529
-msgid "Event Finishes:"
-msgstr ""
-
-#: mod/events.php:535 mod/events.php:548
-msgid "Adjust for viewer timezone"
-msgstr ""
-
-#: mod/events.php:537
-msgid "Description:"
-msgstr ""
-
-#: mod/events.php:541 mod/events.php:543
-msgid "Title:"
-msgstr ""
-
-#: mod/events.php:544 mod/events.php:545
-msgid "Share this event"
-msgstr ""
-
-#: mod/events.php:554 mod/photos.php:970 mod/photos.php:1340
-msgid "Permissions"
-msgstr ""
-
-#: mod/events.php:570
-msgid "Failed to remove event"
-msgstr ""
-
-#: mod/events.php:572
-msgid "Event removed"
-msgstr ""
-
-#: mod/api.php:85 mod/api.php:107
-msgid "Authorize application connection"
-msgstr ""
-
-#: mod/api.php:86
-msgid "Return to your app and insert this Securty Code:"
-msgstr ""
-
-#: mod/api.php:109
-msgid ""
-"Do you want to authorize this application to access your posts and contacts, "
-"and/or create new posts for you?"
-msgstr ""
-
-#: mod/dfrn_poll.php:122 mod/dfrn_poll.php:525
-#, php-format
-msgid "%1$s welcomes %2$s"
-msgstr ""
-
-#: mod/cal.php:297
-msgid "This calendar format is not supported"
-msgstr ""
-
-#: mod/cal.php:299
-msgid "No exportable data found"
-msgstr ""
-
-#: mod/cal.php:316
-msgid "calendar"
-msgstr ""
-
-#: mod/display.php:225 mod/display.php:306
-msgid "The requested item doesn't exist or has been deleted."
-msgstr ""
-
-#: mod/display.php:386
-msgid "The feed for this item is unavailable."
-msgstr ""
-
-#: mod/dfrn_request.php:101
-msgid "This introduction has already been accepted."
-msgstr ""
-
-#: mod/dfrn_request.php:119 mod/dfrn_request.php:357
-msgid "Profile location is not valid or does not contain profile information."
-msgstr ""
-
-#: mod/dfrn_request.php:123 mod/dfrn_request.php:361
-msgid "Warning: profile location has no identifiable owner name."
-msgstr ""
-
-#: mod/dfrn_request.php:126 mod/dfrn_request.php:364
-msgid "Warning: profile location has no profile photo."
-msgstr ""
-
-#: mod/dfrn_request.php:130 mod/dfrn_request.php:368
-#, php-format
-msgid "%d required parameter was not found at the given location"
-msgid_plural "%d required parameters were not found at the given location"
-msgstr[0] ""
-msgstr[1] ""
-
-#: mod/dfrn_request.php:168
-msgid "Introduction complete."
-msgstr ""
-
-#: mod/dfrn_request.php:204
-msgid "Unrecoverable protocol error."
-msgstr ""
-
-#: mod/dfrn_request.php:231
-msgid "Profile unavailable."
-msgstr ""
-
-#: mod/dfrn_request.php:252
-#, php-format
-msgid "%s has received too many connection requests today."
-msgstr ""
-
-#: mod/dfrn_request.php:253
-msgid "Spam protection measures have been invoked."
-msgstr ""
-
-#: mod/dfrn_request.php:254
-msgid "Friends are advised to please try again in 24 hours."
-msgstr ""
-
-#: mod/dfrn_request.php:278
-msgid "Invalid locator"
-msgstr ""
-
-#: mod/dfrn_request.php:314
-msgid "You have already introduced yourself here."
-msgstr ""
-
-#: mod/dfrn_request.php:317
-#, php-format
-msgid "Apparently you are already friends with %s."
-msgstr ""
-
-#: mod/dfrn_request.php:337
-msgid "Invalid profile URL."
-msgstr ""
-
-#: mod/dfrn_request.php:436
-msgid "Your introduction has been sent."
-msgstr ""
-
-#: mod/dfrn_request.php:474
-msgid ""
-"Remote subscription can't be done for your network. Please subscribe "
-"directly on your system."
-msgstr ""
-
-#: mod/dfrn_request.php:490
-msgid "Please login to confirm introduction."
-msgstr ""
-
-#: mod/dfrn_request.php:498
-msgid ""
-"Incorrect identity currently logged in. Please login to <strong>this</"
-"strong> profile."
-msgstr ""
-
-#: mod/dfrn_request.php:512 mod/dfrn_request.php:527
-msgid "Confirm"
-msgstr ""
-
-#: mod/dfrn_request.php:523
-msgid "Hide this contact"
-msgstr ""
-
-#: mod/dfrn_request.php:525
-#, php-format
-msgid "Welcome home %s."
-msgstr ""
-
-#: mod/dfrn_request.php:526
-#, php-format
-msgid "Please confirm your introduction/connection request to %s."
-msgstr ""
-
-#: mod/dfrn_request.php:635
-msgid ""
-"Please enter your 'Identity Address' from one of the following supported "
-"communications networks:"
-msgstr ""
-
-#: mod/dfrn_request.php:637
-#, php-format
-msgid ""
-"If you are not yet a member of the free social web, <a href=\"%s\">follow "
-"this link to find a public Friendica site and join us today</a>."
-msgstr ""
-
-#: mod/dfrn_request.php:640
-msgid "Friend/Connection Request"
-msgstr ""
-
-#: mod/dfrn_request.php:641
-msgid ""
-"Examples: jojo@demo.friendica.com, http://demo.friendica.com/profile/jojo, "
-"testuser@gnusocial.de"
-msgstr ""
-
-#: mod/dfrn_request.php:642 mod/follow.php:161
-msgid "Please answer the following:"
-msgstr ""
-
-#: mod/dfrn_request.php:643 mod/follow.php:162
-#, php-format
-msgid "Does %s know you?"
-msgstr ""
-
-#: mod/dfrn_request.php:644 mod/follow.php:163
-msgid "Add a personal note:"
-msgstr ""
-
-#: mod/dfrn_request.php:646
-msgid "Friendica"
-msgstr ""
-
-#: mod/dfrn_request.php:647
-msgid "GNU Social (Pleroma, Mastodon)"
-msgstr ""
-
-#: mod/dfrn_request.php:648
-msgid "Diaspora (Socialhome, Hubzilla)"
-msgstr ""
-
-#: mod/dfrn_request.php:649
-#, php-format
-msgid ""
-" - please do not use this form.  Instead, enter %s into your Diaspora search "
-"bar."
-msgstr ""
-
-#: mod/dfrn_request.php:650 mod/follow.php:169 mod/unfollow.php:127
-msgid "Your Identity Address:"
-msgstr ""
-
-#: mod/dfrn_request.php:652 mod/follow.php:75 mod/unfollow.php:130
-msgid "Submit Request"
-msgstr ""
-
-#: mod/crepair.php:79
-msgid "Contact settings applied."
-msgstr ""
-
-#: mod/crepair.php:81
-msgid "Contact update failed."
-msgstr ""
-
-#: mod/crepair.php:115
-msgid ""
-"<strong>WARNING: This is highly advanced</strong> and if you enter incorrect "
-"information your communications with this contact may stop working."
-msgstr ""
-
-#: mod/crepair.php:116
-msgid ""
-"Please use your browser 'Back' button <strong>now</strong> if you are "
-"uncertain what to do on this page."
-msgstr ""
-
-#: mod/crepair.php:130 mod/crepair.php:132
-msgid "No mirroring"
-msgstr ""
-
-#: mod/crepair.php:130
-msgid "Mirror as forwarded posting"
-msgstr ""
-
-#: mod/crepair.php:130 mod/crepair.php:132
-msgid "Mirror as my own posting"
-msgstr ""
-
-#: mod/crepair.php:145
-msgid "Return to contact editor"
-msgstr ""
-
-#: mod/crepair.php:147
-msgid "Refetch contact data"
-msgstr ""
-
-#: mod/crepair.php:150
-msgid "Remote Self"
-msgstr ""
-
-#: mod/crepair.php:153
-msgid "Mirror postings from this contact"
-msgstr ""
-
-#: mod/crepair.php:155
-msgid ""
-"Mark this contact as remote_self, this will cause friendica to repost new "
-"entries from this contact."
-msgstr ""
-
-#: mod/crepair.php:160
-msgid "Account Nickname"
-msgstr ""
-
-#: mod/crepair.php:161
-msgid "@Tagname - overrides Name/Nickname"
-msgstr ""
-
-#: mod/crepair.php:162
-msgid "Account URL"
-msgstr ""
-
-#: mod/crepair.php:163
-msgid "Account URL Alias"
-msgstr ""
-
-#: mod/crepair.php:164
-msgid "Friend Request URL"
-msgstr ""
-
-#: mod/crepair.php:165
-msgid "Friend Confirm URL"
-msgstr ""
-
-#: mod/crepair.php:166
-msgid "Notification Endpoint URL"
-msgstr ""
-
-#: mod/crepair.php:167
-msgid "Poll/Feed URL"
-msgstr ""
-
-#: mod/crepair.php:168
-msgid "New photo from this URL"
-msgstr ""
-
-#: mod/notifications.php:34 mod/notifications.php:174 mod/notifications.php:230
-#: mod/message.php:108
-msgid "Discard"
-msgstr ""
-
-#: mod/notifications.php:91
-msgid "Network Notifications"
-msgstr ""
-
-#: mod/notifications.php:96
-msgid "System Notifications"
-msgstr ""
-
-#: mod/notifications.php:101
-msgid "Personal Notifications"
-msgstr ""
-
-#: mod/notifications.php:106
-msgid "Home Notifications"
-msgstr ""
-
-#: mod/notifications.php:129
-msgid "Show unread"
-msgstr ""
-
-#: mod/notifications.php:129
-msgid "Show all"
-msgstr ""
-
-#: mod/notifications.php:140
-msgid "Show Ignored Requests"
-msgstr ""
-
-#: mod/notifications.php:140
-msgid "Hide Ignored Requests"
-msgstr ""
-
-#: mod/notifications.php:153 mod/notifications.php:238
-msgid "Notification type:"
-msgstr ""
-
-#: mod/notifications.php:156
-msgid "Suggested by:"
-msgstr ""
-
-#: mod/notifications.php:190
-msgid "Claims to be known to you: "
-msgstr ""
-
-#: mod/notifications.php:191
-msgid "yes"
-msgstr ""
-
-#: mod/notifications.php:191
-msgid "no"
-msgstr ""
-
-#: mod/notifications.php:192 mod/notifications.php:196
-msgid "Shall your connection be bidirectional or not?"
-msgstr ""
-
-#: mod/notifications.php:193 mod/notifications.php:197
-#, php-format
-msgid ""
-"Accepting %s as a friend allows %s to subscribe to your posts, and you will "
-"also receive updates from them in your news feed."
-msgstr ""
-
-#: mod/notifications.php:194
-#, php-format
-msgid ""
-"Accepting %s as a subscriber allows them to subscribe to your posts, but you "
-"will not receive updates from them in your news feed."
-msgstr ""
-
-#: mod/notifications.php:198
-#, php-format
-msgid ""
-"Accepting %s as a sharer allows them to subscribe to your posts, but you "
-"will not receive updates from them in your news feed."
-msgstr ""
-
-#: mod/notifications.php:209
-msgid "Friend"
-msgstr ""
-
-#: mod/notifications.php:210
-msgid "Sharer"
-msgstr ""
-
-#: mod/notifications.php:210
-msgid "Subscriber"
-msgstr ""
-
-#: mod/notifications.php:275
-msgid "No introductions."
-msgstr ""
-
-#: mod/notifications.php:309
-#, php-format
-msgid "No more %s notifications."
-msgstr ""
-
-#: mod/wallmessage.php:51 mod/wallmessage.php:114
-#, php-format
-msgid "Number of daily wall messages for %s exceeded. Message failed."
-msgstr ""
-
-#: mod/wallmessage.php:59 mod/message.php:68
-msgid "No recipient selected."
-msgstr ""
-
-#: mod/wallmessage.php:62
-msgid "Unable to check your home location."
-msgstr ""
-
-#: mod/wallmessage.php:65 mod/message.php:75
-msgid "Message could not be sent."
-msgstr ""
-
-#: mod/wallmessage.php:68 mod/message.php:78
-msgid "Message collection failure."
-msgstr ""
-
-#: mod/wallmessage.php:71 mod/message.php:81
-msgid "Message sent."
-msgstr ""
-
-#: mod/wallmessage.php:88 mod/wallmessage.php:97
-msgid "No recipient."
-msgstr ""
-
-#: mod/wallmessage.php:122 mod/message.php:202 mod/message.php:358
-msgid "Please enter a link URL:"
-msgstr ""
-
-#: mod/wallmessage.php:127 mod/message.php:244
-msgid "Send Private Message"
-msgstr ""
-
-#: mod/wallmessage.php:128
-#, php-format
-msgid ""
-"If you wish for %s to respond, please check that the privacy settings on "
-"your site allow private mail from unknown senders."
-msgstr ""
-
-#: mod/wallmessage.php:129 mod/message.php:245 mod/message.php:428
-msgid "To:"
-msgstr ""
-
-#: mod/wallmessage.php:130 mod/message.php:249 mod/message.php:430
-msgid "Subject:"
-msgstr ""
-
-#: mod/wallmessage.php:139 mod/editpost.php:77 mod/message.php:257
-#: mod/message.php:438
-msgid "Insert web link"
-msgstr ""
-
-#: mod/ostatus_subscribe.php:21
-msgid "Subscribing to OStatus contacts"
-msgstr ""
-
-#: mod/ostatus_subscribe.php:31
-msgid "No contact provided."
-msgstr ""
-
-#: mod/ostatus_subscribe.php:38
-msgid "Couldn't fetch information for contact."
-msgstr ""
-
-#: mod/ostatus_subscribe.php:48
-msgid "Couldn't fetch friends for contact."
-msgstr ""
-
-#: mod/ostatus_subscribe.php:66 mod/repair_ostatus.php:49
-msgid "Done"
-msgstr ""
-
-#: mod/ostatus_subscribe.php:80
-msgid "success"
-msgstr ""
-
-#: mod/ostatus_subscribe.php:82
-msgid "failed"
-msgstr ""
-
-#: mod/ostatus_subscribe.php:90 mod/repair_ostatus.php:55
-msgid "Keep this window open until done."
-msgstr ""
-
-#: mod/follow.php:45
-msgid "The contact could not be added."
-msgstr ""
-
-#: mod/follow.php:86
-msgid "You already added this contact."
-msgstr ""
-
-#: mod/follow.php:98
-msgid "Diaspora support isn't enabled. Contact can't be added."
-msgstr ""
-
-#: mod/follow.php:105
-msgid "OStatus support is disabled. Contact can't be added."
-msgstr ""
-
-#: mod/follow.php:112
-msgid "The network type couldn't be detected. Contact can't be added."
-msgstr ""
-
-#: mod/fbrowser.php:111 mod/fbrowser.php:140 mod/profile_photo.php:246
-msgid "Upload"
-msgstr ""
-
-#: mod/fbrowser.php:135
-msgid "Files"
-msgstr ""
-
-#: mod/network.php:493
-#, php-format
-msgid ""
-"Warning: This group contains %s member from a network that doesn't allow non "
-"public messages."
-msgid_plural ""
-"Warning: This group contains %s members from a network that doesn't allow "
-"non public messages."
-msgstr[0] ""
-msgstr[1] ""
-
-#: mod/network.php:496
-msgid "Messages in this group won't be send to these receivers."
-msgstr ""
-
-#: mod/network.php:563
-msgid "No such group"
-msgstr ""
-
-#: mod/network.php:588
-#, php-format
-msgid "Group: %s"
-msgstr ""
-
-#: mod/network.php:614
-msgid "Private messages to this person are at risk of public disclosure."
-msgstr ""
-
-#: mod/network.php:901
-msgid "Latest Activity"
-msgstr ""
-
-#: mod/network.php:904
-msgid "Sort by latest activity"
-msgstr ""
-
-#: mod/network.php:909
-msgid "Latest Posts"
-msgstr ""
-
-#: mod/network.php:912
-msgid "Sort by post received date"
-msgstr ""
-
-#: mod/network.php:919 mod/profiles.php:577
-msgid "Personal"
-msgstr ""
-
-#: mod/network.php:922
-msgid "Posts that mention or involve you"
-msgstr ""
-
-#: mod/network.php:929
-msgid "New"
-msgstr ""
-
-#: mod/network.php:932
-msgid "Activity Stream - by date"
-msgstr ""
-
-#: mod/network.php:940
-msgid "Shared Links"
-msgstr ""
-
-#: mod/network.php:943
-msgid "Interesting Links"
-msgstr ""
-
-#: mod/network.php:950
-msgid "Starred"
-msgstr ""
-
-#: mod/network.php:953
-msgid "Favourite Posts"
-msgstr ""
-
-#: mod/unfollow.php:35 mod/unfollow.php:91
-msgid "You aren't following this contact."
-msgstr ""
-
-#: mod/unfollow.php:45 mod/unfollow.php:97
-msgid "Unfollowing is currently not supported by your network."
-msgstr ""
-
-#: mod/unfollow.php:66
-msgid "Contact unfollowed"
-msgstr ""
-
-#: mod/unfollow.php:117
-msgid "Disconnect/Unfollow"
-msgstr ""
-
-#: mod/profile_photo.php:57
-msgid "Image uploaded but image cropping failed."
-msgstr ""
-
-#: mod/profile_photo.php:87 mod/profile_photo.php:96 mod/profile_photo.php:105
-#: mod/profile_photo.php:310
-#, php-format
-msgid "Image size reduction [%s] failed."
-msgstr ""
-
-#: mod/profile_photo.php:124
-msgid ""
-"Shift-reload the page or clear browser cache if the new photo does not "
-"display immediately."
-msgstr ""
-
-#: mod/profile_photo.php:132
-msgid "Unable to process image"
-msgstr ""
-
-#: mod/profile_photo.php:151 mod/photos.php:670 mod/photos.php:673
-#: mod/photos.php:702 mod/wall_upload.php:185
-#, php-format
-msgid "Image exceeds size limit of %s"
-msgstr ""
-
-#: mod/profile_photo.php:160 mod/photos.php:725 mod/wall_upload.php:199
-msgid "Unable to process image."
-msgstr ""
-
-#: mod/profile_photo.php:243
-msgid "Upload File:"
-msgstr ""
-
-#: mod/profile_photo.php:244
-msgid "Select a profile:"
-msgstr ""
-
-#: mod/profile_photo.php:249
-msgid "or"
-msgstr ""
-
-#: mod/profile_photo.php:250
-msgid "skip this step"
-msgstr ""
-
-#: mod/profile_photo.php:250
-msgid "select a photo from your photo albums"
-msgstr ""
-
-#: mod/profile_photo.php:263
-msgid "Crop Image"
-msgstr ""
-
-#: mod/profile_photo.php:264
-msgid "Please adjust the image cropping for optimum viewing."
-msgstr ""
-
-#: mod/profile_photo.php:266
-msgid "Done Editing"
-msgstr ""
-
-#: mod/profile_photo.php:300
-msgid "Image uploaded successfully."
-msgstr ""
-
-#: mod/profile_photo.php:302 mod/photos.php:754 mod/wall_upload.php:238
-msgid "Image upload failed."
-msgstr ""
-
-#: mod/poke.php:178
-msgid "Poke/Prod"
-msgstr ""
-
-#: mod/poke.php:179
-msgid "poke, prod or do other things to somebody"
-msgstr ""
-
-#: mod/poke.php:180
-msgid "Recipient"
-msgstr ""
-
-#: mod/poke.php:181
-msgid "Choose what you wish to do to recipient"
-msgstr ""
-
-#: mod/poke.php:184
-msgid "Make this post private"
-msgstr ""
-
-#: mod/photos.php:111 mod/photos.php:1600
-msgid "Recent Photos"
-msgstr ""
-
-#: mod/photos.php:113 mod/photos.php:1109 mod/photos.php:1602
-msgid "Upload New Photos"
-msgstr ""
-
-#: mod/photos.php:168
-msgid "Contact information unavailable"
-msgstr ""
-
-#: mod/photos.php:190
-msgid "Album not found."
-msgstr ""
-
-#: mod/photos.php:248
-msgid "Album successfully deleted"
-msgstr ""
-
-#: mod/photos.php:250
-msgid "Album was empty."
-msgstr ""
-
-#: mod/photos.php:575
-msgid "a photo"
-msgstr ""
-
-#: mod/photos.php:575
-#, php-format
-msgid "%1$s was tagged in %2$s by %3$s"
-msgstr ""
-
-#: mod/photos.php:676
-msgid "Image upload didn't complete, please try again"
-msgstr ""
-
-#: mod/photos.php:679
-msgid "Image file is missing"
-msgstr ""
-
-#: mod/photos.php:684
-msgid ""
-"Server can't accept new file upload at this time, please contact your "
-"administrator"
-msgstr ""
-
-#: mod/photos.php:710
-msgid "Image file is empty."
-msgstr ""
-
-#: mod/photos.php:842
-msgid "No photos selected"
-msgstr ""
-
-#: mod/photos.php:908 mod/videos.php:165
-msgid "Access to this item is restricted."
-msgstr ""
-
-#: mod/photos.php:962
-msgid "Upload Photos"
-msgstr ""
-
-#: mod/photos.php:966 mod/photos.php:1054
-msgid "New album name: "
-msgstr ""
-
-#: mod/photos.php:967
-msgid "or select existing album:"
-msgstr ""
-
-#: mod/photos.php:968
-msgid "Do not show a status post for this upload"
-msgstr ""
-
-#: mod/photos.php:984 mod/photos.php:1348 mod/settings.php:1209
-msgid "Show to Groups"
-msgstr ""
-
-#: mod/photos.php:985 mod/photos.php:1349 mod/settings.php:1210
-msgid "Show to Contacts"
-msgstr ""
-
-#: mod/photos.php:1036
-msgid "Do you really want to delete this photo album and all its photos?"
-msgstr ""
-
-#: mod/photos.php:1038 mod/photos.php:1059
-msgid "Delete Album"
-msgstr ""
-
-#: mod/photos.php:1065
-msgid "Edit Album"
-msgstr ""
-
-#: mod/photos.php:1066
-msgid "Drop Album"
-msgstr ""
-
-#: mod/photos.php:1071
-msgid "Show Newest First"
-msgstr ""
-
-#: mod/photos.php:1073
-msgid "Show Oldest First"
-msgstr ""
-
-#: mod/photos.php:1094 mod/photos.php:1585
-msgid "View Photo"
-msgstr ""
-
-#: mod/photos.php:1131
-msgid "Permission denied. Access to this item may be restricted."
-msgstr ""
-
-#: mod/photos.php:1133
-msgid "Photo not available"
-msgstr ""
-
-#: mod/photos.php:1143
-msgid "Do you really want to delete this photo?"
-msgstr ""
-
-#: mod/photos.php:1145 mod/photos.php:1345
-msgid "Delete Photo"
-msgstr ""
-
-#: mod/photos.php:1236
-msgid "View photo"
-msgstr ""
-
-#: mod/photos.php:1238
-msgid "Edit photo"
-msgstr ""
-
-#: mod/photos.php:1239
-msgid "Delete photo"
-msgstr ""
-
-#: mod/photos.php:1240
-msgid "Use as profile photo"
-msgstr ""
-
-#: mod/photos.php:1247
-msgid "Private Photo"
-msgstr ""
-
-#: mod/photos.php:1253
-msgid "View Full Size"
-msgstr ""
-
-#: mod/photos.php:1313
-msgid "Tags: "
-msgstr ""
-
-#: mod/photos.php:1316
-msgid "[Select tags to remove]"
-msgstr ""
-
-#: mod/photos.php:1331
-msgid "New album name"
-msgstr ""
-
-#: mod/photos.php:1332
-msgid "Caption"
-msgstr ""
-
-#: mod/photos.php:1333
-msgid "Add a Tag"
-msgstr ""
-
-#: mod/photos.php:1333
-msgid "Example: @bob, @Barbara_Jensen, @jim@example.com, #California, #camping"
-msgstr ""
-
-#: mod/photos.php:1334
-msgid "Do not rotate"
-msgstr ""
-
-#: mod/photos.php:1335
-msgid "Rotate CW (right)"
-msgstr ""
-
-#: mod/photos.php:1336
-msgid "Rotate CCW (left)"
-msgstr ""
-
-#: mod/photos.php:1520
-msgid "Map"
-msgstr ""
-
-#: mod/photos.php:1591 mod/videos.php:242
-msgid "View Album"
-msgstr ""
-
-#: mod/profiles.php:41 mod/profiles.php:150 mod/profiles.php:194
-#: mod/profiles.php:509 mod/dfrn_confirm.php:70
-msgid "Profile not found."
-msgstr ""
-
-#: mod/profiles.php:60
-msgid "Profile deleted."
-msgstr ""
-
-#: mod/profiles.php:76 mod/profiles.php:112
-msgid "Profile-"
-msgstr ""
-
-#: mod/profiles.php:95 mod/profiles.php:133
-msgid "New profile created."
-msgstr ""
-
-#: mod/profiles.php:118
-msgid "Profile unavailable to clone."
-msgstr ""
-
-#: mod/profiles.php:204
-msgid "Profile Name is required."
-msgstr ""
-
-#: mod/profiles.php:344
-msgid "Marital Status"
-msgstr ""
-
-#: mod/profiles.php:347
-msgid "Romantic Partner"
-msgstr ""
-
-#: mod/profiles.php:356
-msgid "Work/Employment"
-msgstr ""
-
-#: mod/profiles.php:359
-msgid "Religion"
-msgstr ""
-
-#: mod/profiles.php:362
-msgid "Political Views"
-msgstr ""
-
-#: mod/profiles.php:365
-msgid "Gender"
-msgstr ""
-
-#: mod/profiles.php:368
-msgid "Sexual Preference"
-msgstr ""
-
-#: mod/profiles.php:371
-msgid "XMPP"
-msgstr ""
-
-#: mod/profiles.php:374
-msgid "Homepage"
-msgstr ""
-
-#: mod/profiles.php:377 mod/profiles.php:576
-msgid "Interests"
-msgstr ""
-
-#: mod/profiles.php:380
-msgid "Address"
-msgstr ""
-
-#: mod/profiles.php:387 mod/profiles.php:572
-msgid "Location"
-msgstr ""
-
-#: mod/profiles.php:467
-msgid "Profile updated."
-msgstr ""
-
-#: mod/profiles.php:521
-msgid "Hide contacts and friends:"
-msgstr ""
-
-#: mod/profiles.php:526
-msgid "Hide your contact/friend list from viewers of this profile?"
-msgstr ""
-
-#: mod/profiles.php:546
-msgid "Show more profile fields:"
-msgstr ""
-
-#: mod/profiles.php:558
-msgid "Profile Actions"
-msgstr ""
-
-#: mod/profiles.php:559
-msgid "Edit Profile Details"
-msgstr ""
-
-#: mod/profiles.php:561
-msgid "Change Profile Photo"
-msgstr ""
-
-#: mod/profiles.php:563
-msgid "View this profile"
-msgstr ""
-
-#: mod/profiles.php:564
-msgid "View all profiles"
-msgstr ""
-
-#: mod/profiles.php:566
-msgid "Create a new profile using these settings"
-msgstr ""
-
-#: mod/profiles.php:567
-msgid "Clone this profile"
-msgstr ""
-
-#: mod/profiles.php:568
-msgid "Delete this profile"
-msgstr ""
-
-#: mod/profiles.php:570
-msgid "Basic information"
-msgstr ""
-
-#: mod/profiles.php:571
-msgid "Profile picture"
-msgstr ""
-
-#: mod/profiles.php:573
-msgid "Preferences"
-msgstr ""
-
-#: mod/profiles.php:574
-msgid "Status information"
-msgstr ""
-
-#: mod/profiles.php:575
-msgid "Additional information"
-msgstr ""
-
-#: mod/profiles.php:578
-msgid "Relation"
-msgstr ""
-
-#: mod/profiles.php:582
-msgid "Your Gender:"
-msgstr ""
-
-#: mod/profiles.php:583
-msgid "<span class=\"heart\">&hearts;</span> Marital Status:"
-msgstr ""
-
-#: mod/profiles.php:585
-msgid "Example: fishing photography software"
-msgstr ""
-
-#: mod/profiles.php:590
-msgid "Profile Name:"
-msgstr ""
-
-#: mod/profiles.php:592
-msgid ""
-"This is your <strong>public</strong> profile.<br />It <strong>may</strong> "
-"be visible to anybody using the internet."
-msgstr ""
-
-#: mod/profiles.php:593
-msgid "Your Full Name:"
-msgstr ""
-
-#: mod/profiles.php:594
-msgid "Title/Description:"
-msgstr ""
-
-#: mod/profiles.php:597
-msgid "Street Address:"
-msgstr ""
-
-#: mod/profiles.php:598
-msgid "Locality/City:"
-msgstr ""
-
-#: mod/profiles.php:599
-msgid "Region/State:"
-msgstr ""
-
-#: mod/profiles.php:600
-msgid "Postal/Zip Code:"
-msgstr ""
-
-#: mod/profiles.php:601
-msgid "Country:"
-msgstr ""
-
-#: mod/profiles.php:605
-msgid "Who: (if applicable)"
-msgstr ""
-
-#: mod/profiles.php:605
-msgid "Examples: cathy123, Cathy Williams, cathy@example.com"
-msgstr ""
-
-#: mod/profiles.php:606
-msgid "Since [date]:"
-msgstr ""
-
-#: mod/profiles.php:608
-msgid "Tell us about yourself..."
-msgstr ""
-
-#: mod/profiles.php:609
-msgid "XMPP (Jabber) address:"
-msgstr ""
-
-#: mod/profiles.php:609
-msgid ""
-"The XMPP address will be propagated to your contacts so that they can follow "
-"you."
-msgstr ""
-
-#: mod/profiles.php:610
-msgid "Homepage URL:"
-msgstr ""
-
-#: mod/profiles.php:613
-msgid "Religious Views:"
-msgstr ""
-
-#: mod/profiles.php:614
-msgid "Public Keywords:"
-msgstr ""
-
-#: mod/profiles.php:614
-msgid "(Used for suggesting potential friends, can be seen by others)"
-msgstr ""
-
-#: mod/profiles.php:615
-msgid "Private Keywords:"
-msgstr ""
-
-#: mod/profiles.php:615
-msgid "(Used for searching profiles, never shown to others)"
-msgstr ""
-
-#: mod/profiles.php:618
-msgid "Musical interests"
-msgstr ""
-
-#: mod/profiles.php:619
-msgid "Books, literature"
-msgstr ""
-
-#: mod/profiles.php:620
-msgid "Television"
-msgstr ""
-
-#: mod/profiles.php:621
-msgid "Film/dance/culture/entertainment"
-msgstr ""
-
-#: mod/profiles.php:622
-msgid "Hobbies/Interests"
-msgstr ""
-
-#: mod/profiles.php:623
-msgid "Love/romance"
-msgstr ""
-
-#: mod/profiles.php:624
-msgid "Work/employment"
-msgstr ""
-
-#: mod/profiles.php:625
-msgid "School/education"
-msgstr ""
-
-#: mod/profiles.php:626
-msgid "Contact information and Social Networks"
-msgstr ""
-
-#: mod/profiles.php:666
-msgid "Edit/Manage Profiles"
-msgstr ""
-
-#: mod/wall_attach.php:26 mod/wall_attach.php:33 mod/wall_attach.php:71
-#: mod/wall_upload.php:42 mod/wall_upload.php:58 mod/wall_upload.php:103
-#: mod/wall_upload.php:154 mod/wall_upload.php:157
-msgid "Invalid request."
-msgstr ""
-
-#: mod/wall_attach.php:89
-msgid "Sorry, maybe your upload is bigger than the PHP configuration allows"
-msgstr ""
-
-#: mod/wall_attach.php:89
-msgid "Or - did you try to upload an empty file?"
-msgstr ""
-
-#: mod/wall_attach.php:100
-#, php-format
-msgid "File exceeds size limit of %s"
-msgstr ""
-
-#: mod/wall_attach.php:115
-msgid "File upload failed."
-msgstr ""
-
-#: mod/item.php:125
-msgid "Unable to locate original post."
-msgstr ""
-
-#: mod/item.php:327
-msgid "Empty post discarded."
-msgstr ""
-
-#: mod/item.php:799
-#, php-format
-msgid ""
-"This message was sent to you by %s, a member of the Friendica social network."
-msgstr ""
-
-#: mod/item.php:801
-#, php-format
-msgid "You may visit them online at %s"
-msgstr ""
-
-#: mod/item.php:802
-msgid ""
-"Please contact the sender by replying to this post if you do not wish to "
-"receive these messages."
-msgstr ""
-
-#: mod/item.php:806
-#, php-format
-msgid "%s posted an update."
-msgstr ""
-
-#: mod/oexchange.php:31
-msgid "Post successful."
-msgstr ""
-
-#: mod/regmod.php:49
-msgid "Account approved."
-msgstr ""
-
-#: mod/regmod.php:73
-#, php-format
-msgid "Registration revoked for %s"
-msgstr ""
-
-#: mod/regmod.php:80
-msgid "Please login."
-msgstr ""
-
-#: mod/match.php:48
-msgid "No keywords to match. Please add keywords to your default profile."
-msgstr ""
-
-#: mod/match.php:134
-msgid "Profile Match"
-msgstr ""
-
-#: mod/settings.php:187
-msgid "Missing some important data!"
-msgstr ""
-
-#: mod/settings.php:297
-msgid "Failed to connect with email account using the settings provided."
-msgstr ""
-
-#: mod/settings.php:302
-msgid "Email settings updated."
-msgstr ""
-
-#: mod/settings.php:318
-msgid "Features updated"
-msgstr ""
-
-#: mod/settings.php:379
-msgid "The theme you chose isn't available."
-msgstr ""
-
-#: mod/settings.php:395
-msgid "Contact CSV file upload error"
-msgstr ""
-
-#: mod/settings.php:409
-msgid "Importing Contacts done"
-msgstr ""
-
-#: mod/settings.php:418
-msgid "Relocate message has been send to your contacts"
-msgstr ""
-
-#: mod/settings.php:430
-msgid "Passwords do not match."
-msgstr ""
-
-#: mod/settings.php:444
-msgid "Password unchanged."
-msgstr ""
-
-#: mod/settings.php:526
-msgid " Please use a shorter name."
-msgstr ""
-
-#: mod/settings.php:529
-msgid " Name too short."
-msgstr ""
-
-#: mod/settings.php:541
-msgid "Invalid email."
-msgstr ""
-
-#: mod/settings.php:547
-msgid "Cannot change to that email."
-msgstr ""
-
-#: mod/settings.php:584
-msgid "Private forum has no privacy permissions. Using default privacy group."
-msgstr ""
-
-#: mod/settings.php:587
-msgid "Private forum has no privacy permissions and no default privacy group."
-msgstr ""
-
-#: mod/settings.php:663 mod/settings.php:689 mod/settings.php:723
-msgid "Add application"
-msgstr ""
-
-#: mod/settings.php:669 mod/settings.php:695
-msgid "Redirect"
-msgstr ""
-
-#: mod/settings.php:670 mod/settings.php:696
-msgid "Icon url"
-msgstr ""
-
-#: mod/settings.php:681
-msgid "You can't edit this application."
-msgstr ""
-
-#: mod/settings.php:722
-msgid "Connected Apps"
-msgstr ""
-
-#: mod/settings.php:726
-msgid "Client key starts with"
-msgstr ""
-
-#: mod/settings.php:727
-msgid "No name"
-msgstr ""
-
-#: mod/settings.php:728
-msgid "Remove authorization"
-msgstr ""
-
-#: mod/settings.php:739
-msgid "No Addon settings configured"
-msgstr ""
-
-#: mod/settings.php:769
-msgid "Additional Features"
-msgstr ""
-
-#: mod/settings.php:794 mod/settings.php:795
-msgid "enabled"
-msgstr ""
-
-#: mod/settings.php:794 mod/settings.php:795
-msgid "disabled"
-msgstr ""
-
-#: mod/settings.php:794 mod/settings.php:795
-#, php-format
-msgid "Built-in support for %s connectivity is %s"
-msgstr ""
-
-#: mod/settings.php:795
-msgid "GNU Social (OStatus)"
-msgstr ""
-
-#: mod/settings.php:826
-msgid "Email access is disabled on this site."
-msgstr ""
-
-#: mod/settings.php:831 mod/settings.php:867
-msgid "None"
-msgstr ""
-
-#: mod/settings.php:842
-msgid "General Social Media Settings"
-msgstr ""
-
-#: mod/settings.php:843
-msgid "Accept only top level posts by contacts you follow"
-msgstr ""
-
-#: mod/settings.php:843
-msgid ""
-"The system does an auto completion of threads when a comment arrives. This "
-"has got the side effect that you can receive posts that had been started by "
-"a non-follower but had been commented by someone you follow. This setting "
-"deactivates this behaviour. When activated, you strictly only will receive "
-"posts from people you really do follow."
-msgstr ""
-
-#: mod/settings.php:844
-msgid "Disable Content Warning"
-msgstr ""
-
-#: mod/settings.php:844
-msgid ""
-"Users on networks like Mastodon or Pleroma are able to set a content warning "
-"field which collapse their post by default. This disables the automatic "
-"collapsing and sets the content warning as the post title. Doesn't affect "
-"any other content filtering you eventually set up."
-msgstr ""
-
-#: mod/settings.php:845
-msgid "Disable intelligent shortening"
-msgstr ""
-
-#: mod/settings.php:845
-msgid ""
-"Normally the system tries to find the best link to add to shortened posts. "
-"If this option is enabled then every shortened post will always point to the "
-"original friendica post."
-msgstr ""
-
-#: mod/settings.php:846
-msgid "Attach the link title"
-msgstr ""
-
-#: mod/settings.php:846
-msgid ""
-"When activated, the title of the attached link will be added as a title on "
-"posts to Diaspora. This is mostly helpful with \"remote-self\" contacts that "
-"share feed content."
-msgstr ""
-
-#: mod/settings.php:847
-msgid "Automatically follow any GNU Social (OStatus) followers/mentioners"
-msgstr ""
-
-#: mod/settings.php:847
-msgid ""
-"If you receive a message from an unknown OStatus user, this option decides "
-"what to do. If it is checked, a new contact will be created for every "
-"unknown user."
-msgstr ""
-
-#: mod/settings.php:848
-msgid "Default group for OStatus contacts"
-msgstr ""
-
-#: mod/settings.php:849
-msgid "Your legacy GNU Social account"
-msgstr ""
-
-#: mod/settings.php:849
-msgid ""
-"If you enter your old GNU Social/Statusnet account name here (in the format "
-"user@domain.tld), your contacts will be added automatically. The field will "
-"be emptied when done."
-msgstr ""
-
-#: mod/settings.php:852
-msgid "Repair OStatus subscriptions"
-msgstr ""
-
-#: mod/settings.php:856
-msgid "Email/Mailbox Setup"
-msgstr ""
-
-#: mod/settings.php:857
-msgid ""
-"If you wish to communicate with email contacts using this service "
-"(optional), please specify how to connect to your mailbox."
-msgstr ""
-
-#: mod/settings.php:858
-msgid "Last successful email check:"
-msgstr ""
-
-#: mod/settings.php:860
-msgid "IMAP server name:"
-msgstr ""
-
-#: mod/settings.php:861
-msgid "IMAP port:"
-msgstr ""
-
-#: mod/settings.php:862
-msgid "Security:"
-msgstr ""
-
-#: mod/settings.php:863
-msgid "Email login name:"
-msgstr ""
-
-#: mod/settings.php:864
-msgid "Email password:"
-msgstr ""
-
-#: mod/settings.php:865
-msgid "Reply-to address:"
-msgstr ""
-
-#: mod/settings.php:866
-msgid "Send public posts to all email contacts:"
-msgstr ""
-
-#: mod/settings.php:867
-msgid "Action after import:"
-msgstr ""
-
-#: mod/settings.php:867
-msgid "Move to folder"
-msgstr ""
-
-#: mod/settings.php:868
-msgid "Move to folder:"
-msgstr ""
-
-#: mod/settings.php:900
-#, php-format
-msgid "%s - (Unsupported)"
-msgstr ""
-
-#: mod/settings.php:946
-msgid "Display Settings"
-msgstr ""
-
-#: mod/settings.php:952
-msgid "Display Theme:"
-msgstr ""
-
-#: mod/settings.php:953
-msgid "Mobile Theme:"
-msgstr ""
-
-#: mod/settings.php:954
-msgid "Suppress warning of insecure networks"
-msgstr ""
-
-#: mod/settings.php:954
-msgid ""
-"Should the system suppress the warning that the current group contains "
-"members of networks that can't receive non public postings."
-msgstr ""
-
-#: mod/settings.php:955
-msgid "Update browser every xx seconds"
-msgstr ""
-
-#: mod/settings.php:955
-msgid "Minimum of 10 seconds. Enter -1 to disable it."
-msgstr ""
-
-#: mod/settings.php:956
-msgid "Number of items to display per page:"
-msgstr ""
-
-#: mod/settings.php:956 mod/settings.php:957
-msgid "Maximum of 100 items"
-msgstr ""
-
-#: mod/settings.php:957
-msgid "Number of items to display per page when viewed from mobile device:"
-msgstr ""
-
-#: mod/settings.php:958
-msgid "Don't show emoticons"
-msgstr ""
-
-#: mod/settings.php:959
-msgid "Calendar"
-msgstr ""
-
-#: mod/settings.php:960
-msgid "Beginning of week:"
-msgstr ""
-
-#: mod/settings.php:961
-msgid "Don't show notices"
-msgstr ""
-
-#: mod/settings.php:962
-msgid "Infinite scroll"
-msgstr ""
-
-#: mod/settings.php:963
-msgid "Automatic updates only at the top of the network page"
-msgstr ""
-
-#: mod/settings.php:963
-msgid ""
-"When disabled, the network page is updated all the time, which could be "
-"confusing while reading."
-msgstr ""
-
-#: mod/settings.php:964
-msgid "Bandwidth Saver Mode"
-msgstr ""
-
-#: mod/settings.php:964
-msgid ""
-"When enabled, embedded content is not displayed on automatic updates, they "
-"only show on page reload."
-msgstr ""
-
-#: mod/settings.php:965
-msgid "Disable Smart Threading"
-msgstr ""
-
-#: mod/settings.php:965
-msgid "Disable the automatic suppression of extraneous thread indentation."
-msgstr ""
-
-#: mod/settings.php:967
-msgid "General Theme Settings"
-msgstr ""
-
-#: mod/settings.php:968
-msgid "Custom Theme Settings"
-msgstr ""
-
-#: mod/settings.php:969
-msgid "Content Settings"
-msgstr ""
-
-#: mod/settings.php:984
-msgid "Unable to find your profile. Please contact your admin."
-msgstr ""
-
-#: mod/settings.php:1023
-msgid "Account Types"
-msgstr ""
-
-#: mod/settings.php:1024
-msgid "Personal Page Subtypes"
-msgstr ""
-
-#: mod/settings.php:1025
-msgid "Community Forum Subtypes"
-msgstr ""
-
-#: mod/settings.php:1033
-msgid "Account for a personal profile."
-msgstr ""
-
-#: mod/settings.php:1037
-msgid ""
-"Account for an organisation that automatically approves contact requests as "
-"\"Followers\"."
-msgstr ""
-
-#: mod/settings.php:1041
-msgid ""
-"Account for a news reflector that automatically approves contact requests as "
-"\"Followers\"."
-msgstr ""
-
-#: mod/settings.php:1045
-msgid "Account for community discussions."
-msgstr ""
-
-#: mod/settings.php:1049
-msgid ""
-"Account for a regular personal profile that requires manual approval of "
-"\"Friends\" and \"Followers\"."
-msgstr ""
-
-#: mod/settings.php:1053
-msgid ""
-"Account for a public profile that automatically approves contact requests as "
-"\"Followers\"."
-msgstr ""
-
-#: mod/settings.php:1057
-msgid "Automatically approves all contact requests."
-msgstr ""
-
-#: mod/settings.php:1061
-msgid ""
-"Account for a popular profile that automatically approves contact requests "
-"as \"Friends\"."
-msgstr ""
-
-#: mod/settings.php:1064
-msgid "Private Forum [Experimental]"
-msgstr ""
-
-#: mod/settings.php:1065
-msgid "Requires manual approval of contact requests."
-msgstr ""
-
-#: mod/settings.php:1076
-msgid "OpenID:"
-msgstr ""
-
-#: mod/settings.php:1076
-msgid "(Optional) Allow this OpenID to login to this account."
-msgstr ""
-
-#: mod/settings.php:1084
-msgid "Publish your default profile in your local site directory?"
-msgstr ""
-
-#: mod/settings.php:1084
-#, php-format
-msgid ""
-"Your profile will be published in this node's <a href=\"%s\">local "
-"directory</a>. Your profile details may be publicly visible depending on the "
-"system settings."
-msgstr ""
-
-#: mod/settings.php:1090
-msgid "Publish your default profile in the global social directory?"
-msgstr ""
-
-#: mod/settings.php:1090
-#, php-format
-msgid ""
-"Your profile will be published in the global friendica directories (e.g. <a "
-"href=\"%s\">%s</a>). Your profile will be visible in public."
-msgstr ""
-
-#: mod/settings.php:1090
-msgid ""
-"This setting also determines whether Friendica will inform search engines "
-"that your profile should be indexed or not. Third-party search engines may "
-"or may not respect this setting."
-msgstr ""
-
-#: mod/settings.php:1097
-msgid "Hide your contact/friend list from viewers of your default profile?"
-msgstr ""
-
-#: mod/settings.php:1097
-msgid ""
-"Your contact list won't be shown in your default profile page. You can "
-"decide to show your contact list separately for each additional profile you "
-"create"
-msgstr ""
-
-#: mod/settings.php:1101
-msgid "Hide your profile details from anonymous viewers?"
-msgstr ""
-
-#: mod/settings.php:1101
-msgid ""
-"Anonymous visitors will only see your profile picture, your display name and "
-"the nickname you are using on your profile page. Your public posts and "
-"replies will still be accessible by other means."
-msgstr ""
-
-#: mod/settings.php:1105
-msgid "Allow friends to post to your profile page?"
-msgstr ""
-
-#: mod/settings.php:1105
-msgid ""
-"Your contacts may write posts on your profile wall. These posts will be "
-"distributed to your contacts"
-msgstr ""
-
-#: mod/settings.php:1109
-msgid "Allow friends to tag your posts?"
-msgstr ""
-
-#: mod/settings.php:1109
-msgid "Your contacts can add additional tags to your posts."
-msgstr ""
-
-#: mod/settings.php:1113
-msgid "Allow us to suggest you as a potential friend to new members?"
-msgstr ""
-
-#: mod/settings.php:1113
-msgid "If you like, Friendica may suggest new members to add you as a contact."
-msgstr ""
-
-#: mod/settings.php:1117
-msgid "Permit unknown people to send you private mail?"
-msgstr ""
-
-#: mod/settings.php:1117
-msgid ""
-"Friendica network users may send you private messages even if they are not "
-"in your contact list."
-msgstr ""
-
-#: mod/settings.php:1121
-msgid "Profile is <strong>not published</strong>."
-msgstr ""
-
-#: mod/settings.php:1127
-#, php-format
-msgid "Your Identity Address is <strong>'%s'</strong> or '%s'."
-msgstr ""
-
-#: mod/settings.php:1134
-msgid "Automatically expire posts after this many days:"
-msgstr ""
-
-#: mod/settings.php:1134
-msgid "If empty, posts will not expire. Expired posts will be deleted"
-msgstr ""
-
-#: mod/settings.php:1135
-msgid "Advanced expiration settings"
-msgstr ""
-
-#: mod/settings.php:1136
-msgid "Advanced Expiration"
-msgstr ""
-
-#: mod/settings.php:1137
-msgid "Expire posts:"
-msgstr ""
-
-#: mod/settings.php:1138
-msgid "Expire personal notes:"
-msgstr ""
-
-#: mod/settings.php:1139
-msgid "Expire starred posts:"
-msgstr ""
-
-#: mod/settings.php:1140
-msgid "Expire photos:"
-msgstr ""
-
-#: mod/settings.php:1141
-msgid "Only expire posts by others:"
-msgstr ""
-
-#: mod/settings.php:1171
-msgid "Account Settings"
-msgstr ""
-
-#: mod/settings.php:1179
-msgid "Password Settings"
-msgstr ""
-
-#: mod/settings.php:1180
-msgid ""
-"Allowed characters are a-z, A-Z, 0-9 and special characters except white "
-"spaces, accentuated letters and colon (:)."
-msgstr ""
-
-#: mod/settings.php:1181
-msgid "Leave password fields blank unless changing"
-msgstr ""
-
-#: mod/settings.php:1182
-msgid "Current Password:"
-msgstr ""
-
-#: mod/settings.php:1182 mod/settings.php:1183
-msgid "Your current password to confirm the changes"
-msgstr ""
-
-#: mod/settings.php:1183
-msgid "Password:"
-msgstr ""
-
-#: mod/settings.php:1186
-msgid "Delete OpenID URL"
-msgstr ""
-
-#: mod/settings.php:1188
-msgid "Basic Settings"
-msgstr ""
-
-#: mod/settings.php:1190
-msgid "Email Address:"
-msgstr ""
-
-#: mod/settings.php:1191
-msgid "Your Timezone:"
-msgstr ""
-
-#: mod/settings.php:1192
-msgid "Your Language:"
-msgstr ""
-
-#: mod/settings.php:1192
-msgid ""
-"Set the language we use to show you friendica interface and to send you "
-"emails"
-msgstr ""
-
-#: mod/settings.php:1193
-msgid "Default Post Location:"
-msgstr ""
-
-#: mod/settings.php:1194
-msgid "Use Browser Location:"
-msgstr ""
-
-#: mod/settings.php:1197
-msgid "Security and Privacy Settings"
-msgstr ""
-
-#: mod/settings.php:1199
-msgid "Maximum Friend Requests/Day:"
-msgstr ""
-
-#: mod/settings.php:1199 mod/settings.php:1228
-msgid "(to prevent spam abuse)"
-msgstr ""
-
-#: mod/settings.php:1200
-msgid "Default Post Permissions"
-msgstr ""
-
-#: mod/settings.php:1201
-msgid "(click to open/close)"
-msgstr ""
-
-#: mod/settings.php:1211
-msgid "Default Private Post"
-msgstr ""
-
-#: mod/settings.php:1212
-msgid "Default Public Post"
-msgstr ""
-
-#: mod/settings.php:1216
-msgid "Default Permissions for New Posts"
-msgstr ""
-
-#: mod/settings.php:1228
-msgid "Maximum private messages per day from unknown people:"
-msgstr ""
-
-#: mod/settings.php:1231
-msgid "Notification Settings"
-msgstr ""
-
-#: mod/settings.php:1232
-msgid "Send a notification email when:"
-msgstr ""
-
-#: mod/settings.php:1233
-msgid "You receive an introduction"
-msgstr ""
-
-#: mod/settings.php:1234
-msgid "Your introductions are confirmed"
-msgstr ""
-
-#: mod/settings.php:1235
-msgid "Someone writes on your profile wall"
-msgstr ""
-
-#: mod/settings.php:1236
-msgid "Someone writes a followup comment"
-msgstr ""
-
-#: mod/settings.php:1237
-msgid "You receive a private message"
-msgstr ""
-
-#: mod/settings.php:1238
-msgid "You receive a friend suggestion"
-msgstr ""
-
-#: mod/settings.php:1239
-msgid "You are tagged in a post"
-msgstr ""
-
-#: mod/settings.php:1240
-msgid "You are poked/prodded/etc. in a post"
-msgstr ""
-
-#: mod/settings.php:1242
-msgid "Activate desktop notifications"
-msgstr ""
-
-#: mod/settings.php:1242
-msgid "Show desktop popup on new notifications"
-msgstr ""
-
-#: mod/settings.php:1244
-msgid "Text-only notification emails"
-msgstr ""
-
-#: mod/settings.php:1246
-msgid "Send text only notification emails, without the html part"
-msgstr ""
-
-#: mod/settings.php:1248
-msgid "Show detailled notifications"
-msgstr ""
-
-#: mod/settings.php:1250
-msgid ""
-"Per default, notifications are condensed to a single notification per item. "
-"When enabled every notification is displayed."
-msgstr ""
-
-#: mod/settings.php:1252
-msgid "Advanced Account/Page Type Settings"
-msgstr ""
-
-#: mod/settings.php:1253
-msgid "Change the behaviour of this account for special situations"
-msgstr ""
-
-#: mod/settings.php:1256
-msgid "Import Contacts"
-msgstr ""
-
-#: mod/settings.php:1257
-msgid ""
-"Upload a CSV file that contains the handle of your followed accounts in the "
-"first column you exported from the old account."
-msgstr ""
-
-#: mod/settings.php:1258
-msgid "Upload File"
-msgstr ""
-
-#: mod/settings.php:1260
-msgid "Relocate"
-msgstr ""
-
-#: mod/settings.php:1261
-msgid ""
-"If you have moved this profile from another server, and some of your "
-"contacts don't receive your updates, try pushing this button."
-msgstr ""
-
-#: mod/settings.php:1262
-msgid "Resend relocate message to contacts"
-msgstr ""
-
-#: mod/suggest.php:27
-msgid "Contact suggestion successfully ignored."
-msgstr ""
-
-#: mod/suggest.php:51
-msgid ""
-"No suggestions available. If this is a new site, please try again in 24 "
-"hours."
-msgstr ""
-
-#: mod/suggest.php:70
-msgid "Do you really want to delete this suggestion?"
-msgstr ""
-
-#: mod/suggest.php:88 mod/suggest.php:108
-msgid "Ignore/Hide"
-msgstr ""
-
-#: mod/dfrn_confirm.php:126
-msgid ""
-"This may occasionally happen if contact was requested by both persons and it "
-"has already been approved."
-msgstr ""
-
-#: mod/dfrn_confirm.php:227
-msgid "Response from remote site was not understood."
-msgstr ""
-
-#: mod/dfrn_confirm.php:234 mod/dfrn_confirm.php:240
-msgid "Unexpected response from remote site: "
-msgstr ""
-
-#: mod/dfrn_confirm.php:249
-msgid "Confirmation completed successfully."
-msgstr ""
-
-#: mod/dfrn_confirm.php:261
-msgid "Temporary failure. Please wait and try again."
-msgstr ""
-
-#: mod/dfrn_confirm.php:264
-msgid "Introduction failed or was revoked."
-msgstr ""
-
-#: mod/dfrn_confirm.php:269
-msgid "Remote site reported: "
-msgstr ""
-
-#: mod/dfrn_confirm.php:374
-#, php-format
-msgid "No user record found for '%s' "
-msgstr ""
-
-#: mod/dfrn_confirm.php:384
-msgid "Our site encryption key is apparently messed up."
-msgstr ""
-
-#: mod/dfrn_confirm.php:395
-msgid "Empty site URL was provided or URL could not be decrypted by us."
-msgstr ""
-
-#: mod/dfrn_confirm.php:411
-msgid "Contact record was not found for you on our site."
-msgstr ""
-
-#: mod/dfrn_confirm.php:425
-#, php-format
-msgid "Site public key not available in contact record for URL %s."
-msgstr ""
-
-#: mod/dfrn_confirm.php:441
-msgid ""
-"The ID provided by your system is a duplicate on our system. It should work "
-"if you try again."
-msgstr ""
-
-#: mod/dfrn_confirm.php:452
-msgid "Unable to set your contact credentials on our system."
-msgstr ""
-
-#: mod/dfrn_confirm.php:508
-msgid "Unable to update your contact profile details on our system"
-msgstr ""
-
-#: mod/removeme.php:46
-msgid "User deleted their account"
-msgstr ""
-
-#: mod/removeme.php:47
-msgid ""
-"On your Friendica node an user deleted their account. Please ensure that "
-"their data is removed from the backups."
-msgstr ""
-
-#: mod/removeme.php:48
-#, php-format
-msgid "The user id is %d"
-msgstr ""
-
-#: mod/removeme.php:84 mod/removeme.php:87
-msgid "Remove My Account"
-msgstr ""
-
-#: mod/removeme.php:85
-msgid ""
-"This will completely remove your account. Once this has been done it is not "
-"recoverable."
-msgstr ""
-
-#: mod/removeme.php:86
-msgid "Please enter your password for verification:"
-msgstr ""
-
-#: mod/wall_upload.php:230
-msgid "Wall Photos"
-msgstr ""
-
-#: mod/editpost.php:29 mod/editpost.php:39
-msgid "Item not found"
-msgstr ""
-
-#: mod/editpost.php:46
-msgid "Edit post"
-msgstr ""
-
-#: mod/editpost.php:78
-msgid "web link"
-msgstr ""
-
-#: mod/editpost.php:79
-msgid "Insert video link"
-msgstr ""
-
-#: mod/editpost.php:80
-msgid "video link"
-msgstr ""
-
-#: mod/editpost.php:81
-msgid "Insert audio link"
-msgstr ""
-
-#: mod/editpost.php:82
-msgid "audio link"
-msgstr ""
-
-#: mod/subthread.php:107
-#, php-format
-msgid "%1$s is following %2$s's %3$s"
-msgstr ""
-
-#: mod/message.php:72
-msgid "Unable to locate contact information."
-msgstr ""
-
-#: mod/message.php:146
-msgid "Do you really want to delete this message?"
-msgstr ""
-
-#: mod/message.php:164
-msgid "Conversation not found."
-msgstr ""
-
-#: mod/message.php:169
-msgid "Message deleted."
-msgstr ""
-
-#: mod/message.php:174 mod/message.php:188
-msgid "Conversation removed."
-msgstr ""
-
-#: mod/message.php:287
-msgid "No messages."
-msgstr ""
-
-#: mod/message.php:350
-msgid "Message not available."
-msgstr ""
-
-#: mod/message.php:404
-msgid "Delete message"
-msgstr ""
-
-#: mod/message.php:406 mod/message.php:538
-msgid "D, d M Y - g:i A"
-msgstr ""
-
-#: mod/message.php:421 mod/message.php:535
-msgid "Delete conversation"
-msgstr ""
-
-#: mod/message.php:423
-msgid ""
-"No secure communications available. You <strong>may</strong> be able to "
-"respond from the sender's profile page."
-msgstr ""
-
-#: mod/message.php:427
-msgid "Send Reply"
-msgstr ""
-
-#: mod/message.php:510
-#, php-format
-msgid "Unknown sender - %s"
-msgstr ""
-
-#: mod/message.php:512
-#, php-format
-msgid "You and %s"
-msgstr ""
-
-#: mod/message.php:514
-#, php-format
-msgid "%s and You"
-msgstr ""
-
-#: mod/message.php:541
-#, php-format
-msgid "%d message"
-msgid_plural "%d messages"
-msgstr[0] ""
-msgstr[1] ""
-
-#: mod/repair_ostatus.php:20
-msgid "Resubscribing to OStatus contacts"
-msgstr ""
-
-#: mod/profperm.php:29
-msgid "Permission denied"
-msgstr ""
-
-#: mod/profperm.php:35 mod/profperm.php:68
-msgid "Invalid profile identifier."
-msgstr ""
-
-#: mod/profperm.php:114
-msgid "Profile Visibility Editor"
-msgstr ""
-
-#: mod/profperm.php:127
-msgid "Visible To"
-msgstr ""
-
-#: mod/profperm.php:143
-msgid "All Contacts (with secure profile access)"
-msgstr ""
-
-#: mod/tagrm.php:31
-msgid "Tag(s) removed"
-msgstr ""
-
-#: mod/tagrm.php:101
-msgid "Remove Item Tag"
-msgstr ""
-
-#: mod/tagrm.php:103
-msgid "Select a tag to remove: "
-msgstr ""
-
-#: mod/videos.php:117
-msgid "No videos selected"
-msgstr ""
-
-#: mod/videos.php:250
-msgid "Recent Videos"
-msgstr ""
-
-#: mod/videos.php:252
-msgid "Upload New Videos"
+msgid "%s: Updating post-type."
 msgstr ""


### PR DESCRIPTION
I believe in acd75f54d57eb3d8a423d9a432eac425e4d0cbb7 the strings for the addon translations was added to the `messages.po` resulting in 600 new strings for the translators. This PR regenerates the core `messages.po` file.