### PR TITLE
Fix for AP posts where the URL don't match

### DIFF
--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -3742,8 +3742,8 @@ class Item
 			return $item_id;
 		}
 
-		if (ActivityPub\Processor::fetchMissingActivity($uri)) {
-			$item_id = self::searchByLink($uri, $uid);
+		if ($fetched_uri = ActivityPub\Processor::fetchMissingActivity($uri)) {
+			$item_id = self::searchByLink($fetched_uri, $uid);
 		} else {
 			$item_id = Diaspora::fetchByURL($uri);
 		}

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -591,7 +591,7 @@ class Processor
 	 *
 	 * @param string $url message URL
 	 * @param array $child activity array with the child of this message
-	 * @return boolean success
+	 * @return string fetched message URL
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
 	public static function fetchMissingActivity($url, $child = [])
@@ -605,12 +605,12 @@ class Processor
 		$object = ActivityPub::fetchContent($url, $uid);
 		if (empty($object)) {
 			Logger::log('Activity ' . $url . ' was not fetchable, aborting.');
-			return false;
+			return '';
 		}
 
 		if (empty($object['id'])) {
 			Logger::log('Activity ' . $url . ' has got not id, aborting. ' . json_encode($object));
-			return false;
+			return '';
 		}
 
 		if (!empty($child['author'])) {
@@ -648,9 +648,9 @@ class Processor
 		$ldactivity['thread-completion'] = true;
 
 		ActivityPub\Receiver::processActivity($ldactivity);
-		Logger::log('Activity ' . $url . ' had been fetched and processed.');
+		Logger::notice('Activity had been fetched and processed.', ['url' => $url, 'object' => $activity['id']]);
 
-		return true;
+		return $activity['id'];
 	}
 
 	/**


### PR DESCRIPTION
There are some issue with Peertube. One is that we cannot seem to fetch posts from them. I found out that in case the message path doesn't need to be identical to the message URL.

This is now fixed.