### PR TITLE
Remove target for notifications

### DIFF
--- a/view/templates/notifications/attend_item.tpl
+++ b/view/templates/notifications/attend_item.tpl
@@ -1,4 +1,4 @@
 
 <div class="notif-item {{if !$item_seen}}unseen{{/if}}">
-	<a href="{{$item_link}}" target="friendica-notification"><img src="{{$item_image}}" class="notif-image">{{$item_text nofilter}} <span class="notif-when">{{$item_ago}}</span></a>
+	<a href="{{$item_link}}"><img src="{{$item_image}}" class="notif-image">{{$item_text nofilter}} <span class="notif-when">{{$item_ago}}</span></a>
 </div>

--- a/view/templates/notifications/comments_item.tpl
+++ b/view/templates/notifications/comments_item.tpl
@@ -1,4 +1,4 @@
 
 <div class="notif-item {{if !$item_seen}}unseen{{/if}}">
-	<a href="{{$item_link}}" target="friendica-notifications"><img src="{{$item_image}}" class="notif-image">{{$item_text nofilter}} <span class="notif-when">{{$item_ago}}</span></a>
+	<a href="{{$item_link}}"><img src="{{$item_image}}" class="notif-image">{{$item_text nofilter}} <span class="notif-when">{{$item_ago}}</span></a>
 </div>

--- a/view/templates/notifications/dislikes_item.tpl
+++ b/view/templates/notifications/dislikes_item.tpl
@@ -1,4 +1,4 @@
 
 <div class="notif-item {{if !$item_seen}}unseen{{/if}}">
-	<a href="{{$item_link}}" target="friendica-notifications"><img src="{{$item_image}}" class="notif-image">{{$item_text nofilter}} <span class="notif-when">{{$item_ago}}</span></a>
+	<a href="{{$item_link}}"><img src="{{$item_image}}" class="notif-image">{{$item_text nofilter}} <span class="notif-when">{{$item_ago}}</span></a>
 </div>

--- a/view/templates/notifications/likes_item.tpl
+++ b/view/templates/notifications/likes_item.tpl
@@ -1,4 +1,4 @@
 
 <div class="notif-item {{if !$item_seen}}unseen{{/if}}">
-	<a href="{{$item_link}}" target="friendica-notification"><img src="{{$item_image}}" class="notif-image">{{$item_text nofilter}} <span class="notif-when">{{$item_ago}}</span></a>
+	<a href="{{$item_link}}"><img src="{{$item_image}}" class="notif-image">{{$item_text nofilter}} <span class="notif-when">{{$item_ago}}</span></a>
 </div>

--- a/view/templates/notifications/network_item.tpl
+++ b/view/templates/notifications/network_item.tpl
@@ -1,4 +1,4 @@
 
 <div class="notif-item {{if !$item_seen}}unseen{{/if}}">
-	<a href="{{$item_link}}" target="friendica-notifications"><img src="{{$item_image}}" class="notif-image">{{$item_text nofilter}} <span class="notif-when">{{$item_ago}}</span></a>
+	<a href="{{$item_link}}"><img src="{{$item_image}}" class="notif-image">{{$item_text nofilter}} <span class="notif-when">{{$item_ago}}</span></a>
 </div>

--- a/view/templates/notifications/notification.tpl
+++ b/view/templates/notifications/notification.tpl
@@ -1,4 +1,4 @@
 
 <div class="notif-item {{if !$item_seen}}unseen{{/if}}">
-	<a href="{{$item_link}}" target="friendica-notifications"><img src="{{$item_image}}" class="notif-image">{{$item_text nofilter}} <span class="notif-when">{{$item_ago}}</span></a>
+	<a href="{{$item_link}}"><img src="{{$item_image}}" class="notif-image">{{$item_text nofilter}} <span class="notif-when">{{$item_ago}}</span></a>
 </div>

--- a/view/templates/notifications/posts_item.tpl
+++ b/view/templates/notifications/posts_item.tpl
@@ -1,4 +1,4 @@
 
 <div class="notif-item {{if !$item_seen}}unseen{{/if}}">
-	<a href="{{$item_link}}" target="friendica-notifications"><img src="{{$item_image}}" class="notif-image">{{$item_text nofilter}} <span class="notif-when">{{$item_ago}}</span></a>
+	<a href="{{$item_link}}"><img src="{{$item_image}}" class="notif-image">{{$item_text nofilter}} <span class="notif-when">{{$item_ago}}</span></a>
 </div>


### PR DESCRIPTION
FollowUp #8155 
Fixes #8173 

I completely removed the `target` attribute in `a` for the items.
According to
https://wiki.selfhtml.org/wiki/Referenz:HTML/Attribute/target
> Vermeiden Sie das target-Attribut. Der Benutzer sollte selbst entscheiden, ob er einen neuen Tab öffnen möchte oder nicht! 

Translated: Avoid using the target-Attribute. The user should choose, if she/he wants a new tab or not!