### PR TITLE
Prepare Model\Notify for include/enotify.php (Part 3)

### DIFF
--- a/include/enotify.php
+++ b/include/enotify.php
@@ -610,7 +610,7 @@ function notification($params)
 		]);
 
 		// use the Emailer class to send the message
-		return Emailer::send([
+		return DI::emailer()->send([
 			'uid' => $params['uid'],
 			'fromName' => $sender_name,
 			'fromEmail' => $sender_email,

--- a/include/enotify.php
+++ b/include/enotify.php
@@ -512,19 +512,19 @@ function notification($params)
 		Logger::log('sending notification email');
 
 		if (isset($params['parent']) && (intval($params['parent']) != 0)) {
-			$id_for_parent = $params['parent']."@".$hostname;
+			$id_for_parent = $params['parent'] . "@" . $hostname;
 
 			// Is this the first email notification for this parent item and user?
 			if (!DBA::exists('notify-threads', ['master-parent-item' => $params['parent'], 'receiver-uid' => $params['uid']])) {
-				Logger::log("notify_id:".intval($notify_id).", parent: ".intval($params['parent'])."uid: ".intval($params['uid']), Logger::DEBUG);
+				Logger::log("notify_id:" . intval($notify_id) . ", parent: " . intval($params['parent']) . "uid: " . intval($params['uid']), Logger::DEBUG);
 
-				$fields = ['notify-id' => $notify_id, 'master-parent-item' => $params['parent'],
-					'receiver-uid' => $params['uid'], 'parent-item' => 0];
+				$fields = ['notify-id'    => $notify_id, 'master-parent-item' => $params['parent'],
+				           'receiver-uid' => $params['uid'], 'parent-item' => 0];
 				DBA::insert('notify-threads', $fields);
 
 				$additional_mail_header .= "Message-ID: <${id_for_parent}>\n";
-				$log_msg = "include/enotify: No previous notification found for this parent:\n".
-						"  parent: ${params['parent']}\n"."  uid   : ${params['uid']}\n";
+				$log_msg                = "include/enotify: No previous notification found for this parent:\n" .
+				                          "  parent: ${params['parent']}\n" . "  uid   : ${params['uid']}\n";
 				Logger::log($log_msg, Logger::DEBUG);
 			} else {
 				// If not, just "follow" the thread.
@@ -536,30 +536,30 @@ function notification($params)
 		$textversion = BBCode::toPlaintext($body);
 		$htmlversion = BBCode::convert($body);
 
-		$datarray = [];
-		$datarray['banner'] = $banner;
-		$datarray['product'] = $product;
-		$datarray['preamble'] = $preamble;
-		$datarray['sitename'] = $sitename;
-		$datarray['siteurl'] = $siteurl;
-		$datarray['type'] = $params['type'];
-		$datarray['parent'] = $parent_id;
-		$datarray['source_name'] = $params['source_name'] ?? '';
-		$datarray['source_link'] = $params['source_link'] ?? '';
+		$datarray                 = [];
+		$datarray['banner']       = $banner;
+		$datarray['product']      = $product;
+		$datarray['preamble']     = $preamble;
+		$datarray['sitename']     = $sitename;
+		$datarray['siteurl']      = $siteurl;
+		$datarray['type']         = $params['type'];
+		$datarray['parent']       = $parent_id;
+		$datarray['source_name']  = $params['source_name'] ?? '';
+		$datarray['source_link']  = $params['source_link'] ?? '';
 		$datarray['source_photo'] = $params['source_photo'] ?? '';
-		$datarray['uid'] = $params['uid'];
-		$datarray['username'] = $params['to_name'] ?? '';
-		$datarray['hsitelink'] = $hsitelink;
-		$datarray['tsitelink'] = $tsitelink;
-		$datarray['hitemlink'] = '<a href="'.$itemlink.'">'.$itemlink.'</a>';
-		$datarray['titemlink'] = $itemlink;
-		$datarray['thanks'] = $thanks;
-		$datarray['site_admin'] = $site_admin;
-		$datarray['title'] = stripslashes($title);
-		$datarray['htmlversion'] = $htmlversion;
-		$datarray['textversion'] = $textversion;
-		$datarray['subject'] = $subject;
-		$datarray['headers'] = $additional_mail_header;
+		$datarray['uid']          = $params['uid'];
+		$datarray['username']     = $params['to_name'] ?? '';
+		$datarray['hsitelink']    = $hsitelink;
+		$datarray['tsitelink']    = $tsitelink;
+		$datarray['hitemlink']    = '<a href="' . $itemlink . '">' . $itemlink . '</a>';
+		$datarray['titemlink']    = $itemlink;
+		$datarray['thanks']       = $thanks;
+		$datarray['site_admin']   = $site_admin;
+		$datarray['title']        = stripslashes($title);
+		$datarray['htmlversion']  = $htmlversion;
+		$datarray['textversion']  = $textversion;
+		$datarray['subject']      = $subject;
+		$datarray['headers']      = $additional_mail_header;
 
 		Hook::callAll('enotify_mail', $datarray);
 
@@ -568,59 +568,52 @@ function notification($params)
 		$content_allowed = ((!DI::config()->get('system', 'enotify_no_content')) || ($params['type'] == SYSTEM_EMAIL));
 
 		// load the template for private message notifications
-		$tpl = Renderer::getMarkupTemplate('email_notify_html.tpl');
+		$tpl             = Renderer::getMarkupTemplate('email_notify_html.tpl');
 		$email_html_body = Renderer::replaceMacros($tpl, [
-			'$banner'       => $datarray['banner'],
-			'$product'      => $datarray['product'],
-			'$preamble'     => str_replace("\n", "<br>\n", $datarray['preamble']),
-			'$sitename'     => $datarray['sitename'],
-			'$siteurl'      => $datarray['siteurl'],
-			'$source_name'  => $datarray['source_name'],
-			'$source_link'  => $datarray['source_link'],
-			'$source_photo' => $datarray['source_photo'],
-			'$username'     => $datarray['username'],
-			'$hsitelink'    => $datarray['hsitelink'],
-			'$hitemlink'    => $datarray['hitemlink'],
-			'$thanks'       => $datarray['thanks'],
-			'$site_admin'   => $datarray['site_admin'],
-			'$title'	=> $datarray['title'],
-			'$htmlversion'	=> $datarray['htmlversion'],
-			'$content_allowed'	=> $content_allowed,
+			'$banner'          => $datarray['banner'],
+			'$product'         => $datarray['product'],
+			'$preamble'        => str_replace("\n", "<br>\n", $datarray['preamble']),
+			'$sitename'        => $datarray['sitename'],
+			'$siteurl'         => $datarray['siteurl'],
+			'$source_name'     => $datarray['source_name'],
+			'$source_link'     => $datarray['source_link'],
+			'$source_photo'    => $datarray['source_photo'],
+			'$username'        => $datarray['username'],
+			'$hsitelink'       => $datarray['hsitelink'],
+			'$hitemlink'       => $datarray['hitemlink'],
+			'$thanks'          => $datarray['thanks'],
+			'$site_admin'      => $datarray['site_admin'],
+			'$title'           => $datarray['title'],
+			'$htmlversion'     => $datarray['htmlversion'],
+			'$content_allowed' => $content_allowed,
 		]);
 
 		// load the template for private message notifications
-		$tpl = Renderer::getMarkupTemplate('email_notify_text.tpl');
+		$tpl             = Renderer::getMarkupTemplate('email_notify_text.tpl');
 		$email_text_body = Renderer::replaceMacros($tpl, [
-			'$banner'       => $datarray['banner'],
-			'$product'      => $datarray['product'],
-			'$preamble'     => $datarray['preamble'],
-			'$sitename'     => $datarray['sitename'],
-			'$siteurl'      => $datarray['siteurl'],
-			'$source_name'  => $datarray['source_name'],
-			'$source_link'  => $datarray['source_link'],
-			'$source_photo' => $datarray['source_photo'],
-			'$username'     => $datarray['username'],
-			'$tsitelink'    => $datarray['tsitelink'],
-			'$titemlink'    => $datarray['titemlink'],
-			'$thanks'       => $datarray['thanks'],
-			'$site_admin'   => $datarray['site_admin'],
-			'$title'	=> $datarray['title'],
-			'$textversion'	=> $datarray['textversion'],
-			'$content_allowed'	=> $content_allowed,
+			'$banner'          => $datarray['banner'],
+			'$product'         => $datarray['product'],
+			'$preamble'        => $datarray['preamble'],
+			'$sitename'        => $datarray['sitename'],
+			'$siteurl'         => $datarray['siteurl'],
+			'$source_name'     => $datarray['source_name'],
+			'$source_link'     => $datarray['source_link'],
+			'$source_photo'    => $datarray['source_photo'],
+			'$username'        => $datarray['username'],
+			'$tsitelink'       => $datarray['tsitelink'],
+			'$titemlink'       => $datarray['titemlink'],
+			'$thanks'          => $datarray['thanks'],
+			'$site_admin'      => $datarray['site_admin'],
+			'$title'           => $datarray['title'],
+			'$textversion'     => $datarray['textversion'],
+			'$content_allowed' => $content_allowed,
 		]);
 
 		// use the Emailer class to send the message
-		return DI::emailer()->send([
-			'uid' => $params['uid'],
-			'fromName' => $sender_name,
-			'fromEmail' => $sender_email,
-			'replyTo' => $sender_email,
-			'toEmail' => $params['to_email'],
-			'messageSubject' => $datarray['subject'],
-			'htmlVersion' => $email_html_body,
-			'textVersion' => $email_text_body,
-			'additionalMailHeader' => $datarray['headers']
-		]);
+		return DI::emailer()->send($sender_name, $sender_email, $sender_email, $params['to_email'],
+			$datarray['subject'], $email_html_body, $email_text_body,
+			$datarray['headers'], $params['uid']
+		);
 	}
 
 	return false;

--- a/include/enotify.php
+++ b/include/enotify.php
@@ -15,6 +15,7 @@ use Friendica\Model\ItemContent;
 use Friendica\Model\Notify;
 use Friendica\Model\User;
 use Friendica\Model\UserItem;
+use Friendica\Object\EMail;
 use Friendica\Protocol\Activity;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Emailer;
@@ -609,11 +610,12 @@ function notification($params)
 			'$content_allowed' => $content_allowed,
 		]);
 
-		// use the Emailer class to send the message
-		return DI::emailer()->send($sender_name, $sender_email, $sender_email, $params['to_email'],
+		$email = new EMail($sender_name, $sender_email, $sender_email, $params['to_email'],
 			$datarray['subject'], $email_html_body, $email_text_body,
-			$datarray['headers'], $params['uid']
-		);
+			$datarray['headers'], $params['uid']);
+
+		// use the Emailer class to send the message
+		return DI::emailer()->send($email);
 	}
 
 	return false;

--- a/include/enotify.php
+++ b/include/enotify.php
@@ -15,10 +15,8 @@ use Friendica\Model\ItemContent;
 use Friendica\Model\Notify;
 use Friendica\Model\User;
 use Friendica\Model\UserItem;
-use Friendica\Object\EMail;
+use Friendica\Object\Email;
 use Friendica\Protocol\Activity;
-use Friendica\Util\DateTimeFormat;
-use Friendica\Util\Emailer;
 
 /**
  * Creates a notification entry and possibly sends a mail
@@ -610,7 +608,7 @@ function notification($params)
 			'$content_allowed' => $content_allowed,
 		]);
 
-		$email = new EMail($sender_name, $sender_email, $sender_email, $params['to_email'],
+		$email = new Email($sender_name, $sender_email, $sender_email, $params['to_email'],
 			$datarray['subject'], $email_html_body, $email_text_body,
 			$datarray['headers'], $params['uid']);
 

--- a/mod/item.php
+++ b/mod/item.php
@@ -816,7 +816,7 @@ function item_post(App $a) {
 					'htmlVersion' => $message,
 					'textVersion' => HTML::toPlaintext($html.$disclaimer)
 				];
-				Emailer::send($params);
+				DI::emailer()->send($params);
 			}
 		}
 	}

--- a/mod/item.php
+++ b/mod/item.php
@@ -796,27 +796,20 @@ function item_post(App $a) {
 					continue;
 				}
 				$disclaimer = '<hr />' . DI::l10n()->t('This message was sent to you by %s, a member of the Friendica social network.', $a->user['username'])
-					. '<br />';
+				              . '<br />';
 				$disclaimer .= DI::l10n()->t('You may visit them online at %s', DI::baseUrl() . '/profile/' . $a->user['nickname']) . EOL;
 				$disclaimer .= DI::l10n()->t('Please contact the sender by replying to this post if you do not wish to receive these messages.') . EOL;
-				if (!$datarray['title']=='') {
+				if (!$datarray['title'] == '') {
 					$subject = Email::encodeHeader($datarray['title'], 'UTF-8');
 				} else {
 					$subject = Email::encodeHeader('[Friendica]' . ' ' . DI::l10n()->t('%s posted an update.', $a->user['username']), 'UTF-8');
 				}
-				$link = '<a href="' . DI::baseUrl() . '/profile/' . $a->user['nickname'] . '"><img src="' . $author['thumb'] . '" alt="' . $a->user['username'] . '" /></a><br /><br />';
+				$link    = '<a href="' . DI::baseUrl() . '/profile/' . $a->user['nickname'] . '"><img src="' . $author['thumb'] . '" alt="' . $a->user['username'] . '" /></a><br /><br />';
 				$html    = Item::prepareBody($datarray);
-				$message = '<html><body>' . $link . $html . $disclaimer . '</body></html>';
-				$params =  [
-					'fromName' => $a->user['username'],
-					'fromEmail' => $a->user['email'],
-					'toEmail' => $addr,
-					'replyTo' => $a->user['email'],
-					'messageSubject' => $subject,
-					'htmlVersion' => $message,
-					'textVersion' => HTML::toPlaintext($html.$disclaimer)
-				];
-				DI::emailer()->send($params);
+				$message = '<html><body>' . $link . $html . $disclaimer . '</body></html>';;
+				DI::emailer()->send($a->user['username'], $a->user['email'], $a->user['email'], $addr,
+					$subject, $message, HTML::toPlaintext($html . $disclaimer)
+				);
 			}
 		}
 	}

--- a/mod/item.php
+++ b/mod/item.php
@@ -18,7 +18,6 @@
 use Friendica\App;
 use Friendica\Content\Pager;
 use Friendica\Content\Text\BBCode;
-use Friendica\Content\Text\HTML;
 use Friendica\Core\Hook;
 use Friendica\Core\Logger;
 use Friendica\Core\Protocol;
@@ -34,11 +33,10 @@ use Friendica\Model\FileTag;
 use Friendica\Model\Item;
 use Friendica\Model\Photo;
 use Friendica\Model\Term;
+use Friendica\Object\EMail\ItemCCEMail;
 use Friendica\Protocol\Activity;
 use Friendica\Protocol\Diaspora;
-use Friendica\Protocol\Email;
 use Friendica\Util\DateTimeFormat;
-use Friendica\Util\Emailer;
 use Friendica\Util\Security;
 use Friendica\Util\Strings;
 use Friendica\Worker\Delivery;
@@ -788,28 +786,15 @@ function item_post(App $a) {
 	Hook::callAll('post_local_end', $datarray);
 
 	if (strlen($emailcc) && $profile_uid == local_user()) {
-		$erecips = explode(',', $emailcc);
-		if (count($erecips)) {
-			foreach ($erecips as $recip) {
-				$addr = trim($recip);
-				if (!strlen($addr)) {
+		$recipients = explode(',', $emailcc);
+		if (count($recipients)) {
+			foreach ($recipients as $recipient) {
+				$address = trim($recipient);
+				if (!strlen($address)) {
 					continue;
 				}
-				$disclaimer = '<hr />' . DI::l10n()->t('This message was sent to you by %s, a member of the Friendica social network.', $a->user['username'])
-				              . '<br />';
-				$disclaimer .= DI::l10n()->t('You may visit them online at %s', DI::baseUrl() . '/profile/' . $a->user['nickname']) . EOL;
-				$disclaimer .= DI::l10n()->t('Please contact the sender by replying to this post if you do not wish to receive these messages.') . EOL;
-				if (!$datarray['title'] == '') {
-					$subject = Email::encodeHeader($datarray['title'], 'UTF-8');
-				} else {
-					$subject = Email::encodeHeader('[Friendica]' . ' ' . DI::l10n()->t('%s posted an update.', $a->user['username']), 'UTF-8');
-				}
-				$link    = '<a href="' . DI::baseUrl() . '/profile/' . $a->user['nickname'] . '"><img src="' . $author['thumb'] . '" alt="' . $a->user['username'] . '" /></a><br /><br />';
-				$html    = Item::prepareBody($datarray);
-				$message = '<html><body>' . $link . $html . $disclaimer . '</body></html>';;
-				DI::emailer()->send($a->user['username'], $a->user['email'], $a->user['email'], $addr,
-					$subject, $message, HTML::toPlaintext($html . $disclaimer)
-				);
+				DI::emailer()->send(new ItemCCEMail(DI::app(), DI::l10n(), DI::baseUrl(),
+					$datarray, $address, $author['thumb'] ?? ''));
 			}
 		}
 	}

--- a/src/DI.php
+++ b/src/DI.php
@@ -363,4 +363,12 @@ abstract class DI
 	{
 		return self::$dice->create(Util\Profiler::class);
 	}
+
+	/**
+	 * @return Util\Emailer
+	 */
+	public static function emailer()
+	{
+		return self::$dice->create(Util\Emailer::class);
+	}
 }

--- a/src/Object/EMail.php
+++ b/src/Object/EMail.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Friendica\Object;
+
+use Friendica\Object\EMail\IEmail;
+
+/**
+ * The default implementation of the IEmail interface
+ *
+ * Provides the possibility to reuse the email instance with new recipients (@see EMail::withRecipient())
+ */
+class EMail implements IEmail
+{
+	/** @var string */
+	private $fromName;
+	/** @var string */
+	private $fromEmail;
+	/** @var string */
+	private $replyTo;
+
+	/** @var string */
+	private $toEmail;
+
+	/** @var string */
+	private $subject;
+	/** @var string */
+	private $msgHtml;
+	/** @var string */
+	private $msgText;
+
+	/** @var string */
+	private $additionalMailHeader = '';
+	/** @var int|null */
+	private $toUid = null;
+
+	public function __construct(string $fromName, string $fromEmail, string $replyTo, string $toEmail,
+	                            string $subject, string $msgHtml, string $msgText,
+	                            string $additionalMailHeader = '', int $toUid = null)
+	{
+		$this->fromName             = $fromName;
+		$this->fromEmail            = $fromEmail;
+		$this->replyTo              = $replyTo;
+		$this->toEmail              = $toEmail;
+		$this->subject              = $subject;
+		$this->msgHtml              = $msgHtml;
+		$this->msgText              = $msgText;
+		$this->additionalMailHeader = $additionalMailHeader;
+		$this->toUid                = $toUid;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getFromName()
+	{
+		return $this->fromName;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getFromEmail()
+	{
+		return $this->fromEmail;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getReplyTo()
+	{
+		return $this->replyTo;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getToEmail()
+	{
+		return $this->toEmail;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getSubject()
+	{
+		return $this->subject;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getMessage(bool $text = false)
+	{
+		if ($text) {
+			return $this->msgText;
+		} else {
+			return $this->msgHtml;
+		}
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getAdditionalMailHeader()
+	{
+		return $this->additionalMailHeader;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getRecipientUid()
+	{
+		return $this->toUid;
+	}
+
+	/**
+	 * Returns the current email with a new recipient
+	 *
+	 * @param string $email The email of the recipient
+	 * @param int    $uid   The (optional) UID of the recipient for further infos
+	 *
+	 * @return EMail
+	 */
+	public function withRecipient(string $email, int $uid = null)
+	{
+		$newEmail          = clone $this;
+		$newEmail->toEmail = $email;
+		$newEmail->toUid   = $uid;
+
+		return $newEmail;
+	}
+}

--- a/src/Object/EMail.php
+++ b/src/Object/EMail.php
@@ -122,7 +122,7 @@ class EMail implements IEmail
 	 * @param string $email The email of the recipient
 	 * @param int    $uid   The (optional) UID of the recipient for further infos
 	 *
-	 * @return EMail
+	 * @return static
 	 */
 	public function withRecipient(string $email, int $uid = null)
 	{

--- a/src/Object/EMail.php
+++ b/src/Object/EMail.php
@@ -91,9 +91,9 @@ class EMail implements IEmail
 	/**
 	 * {@inheritDoc}
 	 */
-	public function getMessage(bool $text = false)
+	public function getMessage(bool $plain = false)
 	{
-		if ($text) {
+		if ($plain) {
 			return $this->msgText;
 		} else {
 			return $this->msgHtml;

--- a/src/Object/EMail/IEmail.php
+++ b/src/Object/EMail/IEmail.php
@@ -23,7 +23,7 @@ interface IEmail
 	 *
 	 * @return string
 	 */
-	function getFromEmail();
+	function getFromAddress();
 
 	/**
 	 * Gets the UID of the sender of this email
@@ -44,7 +44,7 @@ interface IEmail
 	 *
 	 * @return string
 	 */
-	function getToEmail();
+	function getToAddress();
 
 	/**
 	 * Gets the subject of this email

--- a/src/Object/EMail/IEmail.php
+++ b/src/Object/EMail/IEmail.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Friendica\Object\EMail;
+
+use Friendica\Util\Emailer;
+
+/**
+ * Interface for a single mail, which can be send through Emailer::send()
+ *
+ * @see Emailer::send()
+ */
+interface IEmail
+{
+	/**
+	 * Gets the senders name for this email
+	 *
+	 * @return string
+	 */
+	function getFromName();
+
+	/**
+	 * Gets the senders email address for this email
+	 *
+	 * @return string
+	 */
+	function getFromEmail();
+
+	/**
+	 * Gets the UID of the sender of this email
+	 *
+	 * @return int|null
+	 */
+	function getRecipientUid();
+
+	/**
+	 * Gets the reply-to address for this email
+	 *
+	 * @return string
+	 */
+	function getReplyTo();
+
+	/**
+	 * Gets the senders email address
+	 *
+	 * @return string
+	 */
+	function getToEmail();
+
+	/**
+	 * Gets the subject of this email
+	 *
+	 * @return string
+	 */
+	function getSubject();
+
+	/**
+	 * Gets the message body of this email (either html or plaintext)
+	 *
+	 * @param boolean $text True, if returned as plaintext
+	 *
+	 * @return string
+	 */
+	function getMessage(bool $text = false);
+
+	/**
+	 * Gets any additional mail header
+	 *
+	 * @return string
+	 */
+	function getAdditionalMailHeader();
+}

--- a/src/Object/EMail/IEmail.php
+++ b/src/Object/EMail/IEmail.php
@@ -56,11 +56,11 @@ interface IEmail
 	/**
 	 * Gets the message body of this email (either html or plaintext)
 	 *
-	 * @param boolean $text True, if returned as plaintext
+	 * @param boolean $plain True, if returned as plaintext
 	 *
 	 * @return string
 	 */
-	function getMessage(bool $text = false);
+	function getMessage(bool $plain = false);
 
 	/**
 	 * Gets any additional mail header

--- a/src/Object/EMail/ItemCCEMail.php
+++ b/src/Object/EMail/ItemCCEMail.php
@@ -7,12 +7,12 @@ use Friendica\App\BaseURL;
 use Friendica\Content\Text\HTML;
 use Friendica\Core\L10n;
 use Friendica\Model\Item;
-use Friendica\Object\EMail;
+use Friendica\Object\Email;
 
 /**
  * Class for creating CC emails based on a received item
  */
-class ItemCCEMail extends EMail
+class ItemCCEMail extends Email
 {
 	public function __construct(App $a, L10n $l10n, BaseURL $baseUrl, array $item, string $toEmail, string $authorThumb)
 	{
@@ -21,7 +21,7 @@ class ItemCCEMail extends EMail
 		$disclaimer .= $l10n->t('You may visit them online at %s', $baseUrl . '/profile/' . $a->user['nickname']) . EOL;
 		$disclaimer .= $l10n->t('Please contact the sender by replying to this post if you do not wish to receive these messages.') . EOL;
 		if (!$item['title'] == '') {
-			$subject = EMail::encodeHeader($item['title'], 'UTF-8');
+			$subject = Email::encodeHeader($item['title'], 'UTF-8');
 		} else {
 			$subject = Email::encodeHeader('[Friendica]' . ' ' . $l10n->t('%s posted an update.', $a->user['username']), 'UTF-8');
 		}

--- a/src/Object/EMail/ItemCCEMail.php
+++ b/src/Object/EMail/ItemCCEMail.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Friendica\Object\EMail;
+
+use Friendica\App;
+use Friendica\App\BaseURL;
+use Friendica\Content\Text\HTML;
+use Friendica\Core\L10n;
+use Friendica\Model\Item;
+use Friendica\Object\EMail;
+
+/**
+ * Class for creating CC emails based on a received item
+ */
+class ItemCCEMail extends EMail
+{
+	public function __construct(App $a, L10n $l10n, BaseURL $baseUrl, array $item, string $toEmail, string $authorThumb)
+	{
+		$disclaimer = '<hr />' . $l10n->t('This message was sent to you by %s, a member of the Friendica social network.', $a->user['username'])
+		              . '<br />';
+		$disclaimer .= $l10n->t('You may visit them online at %s', $baseUrl . '/profile/' . $a->user['nickname']) . EOL;
+		$disclaimer .= $l10n->t('Please contact the sender by replying to this post if you do not wish to receive these messages.') . EOL;
+		if (!$item['title'] == '') {
+			$subject = EMail::encodeHeader($item['title'], 'UTF-8');
+		} else {
+			$subject = Email::encodeHeader('[Friendica]' . ' ' . $l10n->t('%s posted an update.', $a->user['username']), 'UTF-8');
+		}
+		$link    = '<a href="' . $baseUrl . '/profile/' . $a->user['nickname'] . '"><img src="' . $authorThumb . '" alt="' . $a->user['username'] . '" /></a><br /><br />';
+		$html    = Item::prepareBody($item);
+		$message = '<html><body>' . $link . $html . $disclaimer . '</body></html>';;
+
+		parent::__construct($a->user['username'], $a->user['email'], $a->user['email'], $toEmail,
+			$subject, $message, HTML::toPlaintext($html . $disclaimer));
+	}
+}

--- a/src/Object/EMail/ItemCCEMail.php
+++ b/src/Object/EMail/ItemCCEMail.php
@@ -14,7 +14,7 @@ use Friendica\Object\Email;
  */
 class ItemCCEMail extends Email
 {
-	public function __construct(App $a, L10n $l10n, BaseURL $baseUrl, array $item, string $toEmail, string $authorThumb)
+	public function __construct(App $a, L10n $l10n, BaseURL $baseUrl, array $item, string $toAddress, string $authorThumb)
 	{
 		$disclaimer = '<hr />' . $l10n->t('This message was sent to you by %s, a member of the Friendica social network.', $a->user['username'])
 		              . '<br />';
@@ -29,7 +29,7 @@ class ItemCCEMail extends Email
 		$html    = Item::prepareBody($item);
 		$message = '<html><body>' . $link . $html . $disclaimer . '</body></html>';;
 
-		parent::__construct($a->user['username'], $a->user['email'], $a->user['email'], $toEmail,
+		parent::__construct($a->user['username'], $a->user['email'], $a->user['email'], $toAddress,
 			$subject, $message, HTML::toPlaintext($html . $disclaimer));
 	}
 }

--- a/src/Object/Email.php
+++ b/src/Object/Email.php
@@ -33,14 +33,14 @@ class Email implements IEmail
 	/** @var int|null */
 	private $toUid = null;
 
-	public function __construct(string $fromName, string $fromEmail, string $replyTo, string $toEmail,
+	public function __construct(string $fromName, string $fromAddress, string $replyTo, string $toAddress,
 	                            string $subject, string $msgHtml, string $msgText,
 	                            string $additionalMailHeader = '', int $toUid = null)
 	{
 		$this->fromName             = $fromName;
-		$this->fromAddress          = $fromEmail;
+		$this->fromAddress          = $fromAddress;
 		$this->replyTo              = $replyTo;
-		$this->toAddress            = $toEmail;
+		$this->toAddress            = $toAddress;
 		$this->subject              = $subject;
 		$this->msgHtml              = $msgHtml;
 		$this->msgText              = $msgText;

--- a/src/Object/Email.php
+++ b/src/Object/Email.php
@@ -7,19 +7,19 @@ use Friendica\Object\EMail\IEmail;
 /**
  * The default implementation of the IEmail interface
  *
- * Provides the possibility to reuse the email instance with new recipients (@see EMail::withRecipient())
+ * Provides the possibility to reuse the email instance with new recipients (@see Email::withRecipient())
  */
-class EMail implements IEmail
+class Email implements IEmail
 {
 	/** @var string */
 	private $fromName;
 	/** @var string */
-	private $fromEmail;
+	private $fromAddress;
 	/** @var string */
 	private $replyTo;
 
 	/** @var string */
-	private $toEmail;
+	private $toAddress;
 
 	/** @var string */
 	private $subject;
@@ -38,9 +38,9 @@ class EMail implements IEmail
 	                            string $additionalMailHeader = '', int $toUid = null)
 	{
 		$this->fromName             = $fromName;
-		$this->fromEmail            = $fromEmail;
+		$this->fromAddress          = $fromEmail;
 		$this->replyTo              = $replyTo;
-		$this->toEmail              = $toEmail;
+		$this->toAddress            = $toEmail;
 		$this->subject              = $subject;
 		$this->msgHtml              = $msgHtml;
 		$this->msgText              = $msgText;
@@ -59,9 +59,9 @@ class EMail implements IEmail
 	/**
 	 * {@inheritDoc}
 	 */
-	public function getFromEmail()
+	public function getFromAddress()
 	{
-		return $this->fromEmail;
+		return $this->fromAddress;
 	}
 
 	/**
@@ -75,9 +75,9 @@ class EMail implements IEmail
 	/**
 	 * {@inheritDoc}
 	 */
-	public function getToEmail()
+	public function getToAddress()
 	{
-		return $this->toEmail;
+		return $this->toAddress;
 	}
 
 	/**
@@ -126,9 +126,9 @@ class EMail implements IEmail
 	 */
 	public function withRecipient(string $email, int $uid = null)
 	{
-		$newEmail          = clone $this;
-		$newEmail->toEmail = $email;
-		$newEmail->toUid   = $uid;
+		$newEmail            = clone $this;
+		$newEmail->toAddress = $email;
+		$newEmail->toUid     = $uid;
 
 		return $newEmail;
 	}

--- a/src/Util/Emailer.php
+++ b/src/Util/Emailer.php
@@ -59,7 +59,7 @@ class Emailer
 		}
 
 		$fromName       = Email::encodeHeader(html_entity_decode($email->getFromName(), ENT_QUOTES, 'UTF-8'), 'UTF-8');
-		$fromEmail      = $email->getFromEmail();
+		$fromEmail      = $email->getFromAddress();
 		$replyTo        = $email->getReplyTo();
 		$messageSubject = Email::encodeHeader(html_entity_decode($email->getSubject(), ENT_QUOTES, 'UTF-8'), 'UTF-8');
 
@@ -102,7 +102,7 @@ class Emailer
 
 		// send the message
 		$hookdata = [
-			'to'         => $email->getToEmail(),
+			'to'         => $email->getToAddress(),
 			'subject'    => $messageSubject,
 			'body'       => $multipartMessageBody,
 			'headers'    => $messageHeader,
@@ -123,7 +123,7 @@ class Emailer
 			$hookdata['headers'],
 			$hookdata['parameters']
 		);
-		$this->logger->debug('header ' . 'To: ' . $email->getToEmail() . '\n' . $messageHeader);
+		$this->logger->debug('header ' . 'To: ' . $email->getToAddress() . '\n' . $messageHeader);
 		$this->logger->debug('return value ' . (($res) ? 'true' : 'false'));
 		return $res;
 	}

--- a/src/Util/Emailer.php
+++ b/src/Util/Emailer.php
@@ -77,8 +77,8 @@ class Emailer
 		                 "Content-Type: multipart/alternative; boundary=\"{$mimeBoundary}\"";
 
 		// assemble the final multipart message body with the text and html types included
-		$textBody             = chunk_split(base64_encode($email->getMessage()));
-		$htmlBody             = chunk_split(base64_encode($email->getMessage(true)));
+		$textBody             = chunk_split(base64_encode($email->getMessage(true)));
+		$htmlBody             = chunk_split(base64_encode($email->getMessage()));
 		$multipartMessageBody = "--" . $mimeBoundary . "\n" .                    // plain text section
 		                        "Content-Type: text/plain; charset=UTF-8\n" .
 		                        "Content-Transfer-Encoding: base64\n\n" .

--- a/src/Util/Emailer.php
+++ b/src/Util/Emailer.php
@@ -59,7 +59,7 @@ class Emailer
 		}
 
 		$fromName       = Email::encodeHeader(html_entity_decode($email->getFromName(), ENT_QUOTES, 'UTF-8'), 'UTF-8');
-		$fromEmail      = $email->getFromAddress();
+		$fromAddress      = $email->getFromAddress();
 		$replyTo        = $email->getReplyTo();
 		$messageSubject = Email::encodeHeader(html_entity_decode($email->getSubject(), ENT_QUOTES, 'UTF-8'), 'UTF-8');
 
@@ -71,7 +71,7 @@ class Emailer
 
 		// generate a multipart/alternative message header
 		$messageHeader = $email->getAdditionalMailHeader() .
-		                 "From: $fromName <{$fromEmail}>\n" .
+		                 "From: $fromName <{$fromAddress}>\n" .
 		                 "Reply-To: $fromName <{$replyTo}>\n" .
 		                 "MIME-Version: 1.0\n" .
 		                 "Content-Type: multipart/alternative; boundary=\"{$mimeBoundary}\"";
@@ -95,7 +95,7 @@ class Emailer
 			"--" . $mimeBoundary . "--\n";                    // message ending
 
 		if ($this->config->get('system', 'sendmail_params', true)) {
-			$sendmail_params = '-f ' . $fromEmail;
+			$sendmail_params = '-f ' . $fromAddress;
 		} else {
 			$sendmail_params = null;
 		}

--- a/src/Util/Emailer.php
+++ b/src/Util/Emailer.php
@@ -31,7 +31,7 @@ class Emailer
 	 * @return bool
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
-	public static function send(array $params)
+	public function send(array $params)
 	{
 		$params['sent'] = false;
 


### PR DESCRIPTION
FollowUp #8170 
- Make `Util\EMailer` dynamic
- Introduce Interface `IEmail` for email sending
- Introduce `Email` Objects (including addons)

This is a preparation for splitting Item/Verb/Activity based Notifications and "just" System-Emails.
They share "some" common variables, which I will extract for both, but they are too much intertwined in the `enotify.php` file.

After this next PR (Part 4), I think it will be possible to refactor "just" the notifications (as @annando already planned) without taking all the side-effects into account.

Needs https://github.com/friendica/friendica-addons/pull/949 as well!