### PR TITLE
Fix Notification issues

### DIFF
--- a/include/api.php
+++ b/include/api.php
@@ -5892,10 +5892,11 @@ api_register_func('api/friendica/activity/unattendmaybe', 'api_friendica_activit
  * Returns notifications
  *
  * @param string $type Known types are 'atom', 'rss', 'xml' and 'json'
+ *
  * @return string|array
- * @throws BadRequestException
  * @throws ForbiddenException
- * @throws InternalServerErrorException
+ * @throws BadRequestException
+ * @throws Exception
  */
 function api_friendica_notification($type)
 {
@@ -5908,7 +5909,7 @@ function api_friendica_notification($type)
 		throw new BadRequestException("Invalid argument count");
 	}
 
-	$notifications = DI::notify()->select(['uid' => api_user()], ['order' => ['seen' => 'ASC', 'date' => 'DESC'], 'limit' => 50]);
+	$notifications = DI::notification()->getApiList(local_user());
 
 	if ($type == "xml") {
 		$xmlnotes = false;

--- a/include/enotify.php
+++ b/include/enotify.php
@@ -484,6 +484,7 @@ function notification($params)
 	if ($show_in_notification_page) {
 		$notification = DI::notify()->insert([
 			'name'   => $params['source_name'],
+			'name_cache' => strip_tags(BBCode::convert($params['source_name'])),
 			'url'    => $params['source_link'],
 			'photo'  => $params['source_photo'],
 			'uid'    => $params['uid'],

--- a/include/enotify.php
+++ b/include/enotify.php
@@ -483,24 +483,24 @@ function notification($params)
 
 	if ($show_in_notification_page) {
 		$notification = DI::notify()->insert([
-			'name'   => $params['source_name'],
+			'name'       => $params['source_name'],
 			'name_cache' => strip_tags(BBCode::convert($params['source_name'])),
-			'url'    => $params['source_link'],
-			'photo'  => $params['source_photo'],
-			'uid'    => $params['uid'],
-			'iid'    => $item_id,
-			'parent' => $parent_id,
-			'type'   => $params['type'],
-			'verb'   => $params['verb'],
-			'otype'  => $params['otype'],
+			'url'        => $params['source_link'],
+			'photo'      => $params['source_photo'],
+			'link'       => $itemlink,
+			'uid'        => $params['uid'],
+			'iid'        => $item_id,
+			'parent'     => $parent_id,
+			'type'       => $params['type'],
+			'verb'       => $params['verb'],
+			'otype'      => $params['otype'],
 		]);
 
-		$notification->link = DI::baseUrl() . '/notification/view/' . $notification->id;
-		$notification->msg  = Renderer::replaceMacros($epreamble, ['$itemlink' => $notification->link]);
+		$notification->msg = Renderer::replaceMacros($epreamble, ['$itemlink' => $notification->link]);
 
 		DI::notify()->update($notification);
 
-		$itemlink  = $notification->link;
+		$itemlink  = DI::baseUrl() . '/notification/view/' . $notification->id;
 		$notify_id = $notification->id;
 	}
 

--- a/include/enotify.php
+++ b/include/enotify.php
@@ -483,17 +483,17 @@ function notification($params)
 
 	if ($show_in_notification_page) {
 		$notification = DI::notify()->insert([
-			'name'       => $params['source_name'],
-			'name_cache' => strip_tags(BBCode::convert($params['source_name'])),
-			'url'        => $params['source_link'],
-			'photo'      => $params['source_photo'],
-			'link'       => $itemlink,
-			'uid'        => $params['uid'],
-			'iid'        => $item_id,
-			'parent'     => $parent_id,
-			'type'       => $params['type'],
-			'verb'       => $params['verb'],
-			'otype'      => $params['otype'],
+			'name'       => $params['source_name'] ?? '',
+			'name_cache' => strip_tags(BBCode::convert($params['source_name'] ?? '')),
+			'url'        => $params['source_link'] ?? '',
+			'photo'      => $params['source_photo'] ?? '',
+			'link'       => $itemlink ?? '',
+			'uid'        => $params['uid'] ?? 0,
+			'iid'        => $item_id ?? 0,
+			'parent'     => $parent_id ?? 0,
+			'type'       => $params['type'] ?? '',
+			'verb'       => $params['verb'] ?? '',
+			'otype'      => $params['otype'] ?? '',
 		]);
 
 		$notification->msg = Renderer::replaceMacros($epreamble, ['$itemlink' => $notification->link]);

--- a/src/BaseCollection.php
+++ b/src/BaseCollection.php
@@ -17,14 +17,14 @@ abstract class BaseCollection extends \ArrayIterator
 	protected $totalCount = 0;
 
 	/**
-	 * @param BaseModel[] $models
-	 * @param int|null    $totalCount
+	 * @param BaseEntity[] $entities
+	 * @param int|null     $totalCount
 	 */
-	public function __construct(array $models = [], int $totalCount = null)
+	public function __construct(array $entities = [], int $totalCount = null)
 	{
-		parent::__construct($models);
+		parent::__construct($entities);
 
-		$this->totalCount = $totalCount ?? count($models);
+		$this->totalCount = $totalCount ?? count($entities);
 	}
 
 	/**

--- a/src/BaseEntity.php
+++ b/src/BaseEntity.php
@@ -11,7 +11,22 @@ namespace Friendica;
  */
 abstract class BaseEntity implements \JsonSerializable
 {
+	/**
+	 * Returns the current entity as an json array
+	 *
+	 * @return array
+	 */
 	public function jsonSerialize()
+	{
+		return $this->toArray();
+	}
+
+	/**
+	 * Returns the current entity as an array
+	 *
+	 * @return array
+	 */
+	public function toArray()
 	{
 		return get_object_vars($this);
 	}

--- a/src/BaseModel.php
+++ b/src/BaseModel.php
@@ -48,9 +48,23 @@ abstract class BaseModel
 		$this->originalData = $data;
 	}
 
+	/**
+	 * Maps a data array (original/current) to a known field list of the chosen model
+	 *
+	 * This is useful to filter out additional attributes, which aren't part of the db-table (like readonly cached fields)
+	 *
+	 * @param array $data The data array to map to db-fields
+	 *
+	 * @return array the mapped data array
+	 */
+	protected function mapFields(array $data)
+	{
+		return $data;
+	}
+
 	public function getOriginalData()
 	{
-		return $this->originalData;
+		return $this->mapFields($this->originalData);
 	}
 
 	public function resetOriginalData()
@@ -117,7 +131,7 @@ abstract class BaseModel
 
 	public function toArray()
 	{
-		return $this->data;
+		return $this->mapFields($this->data);
 	}
 
 	protected function checkValid()

--- a/src/BaseModel.php
+++ b/src/BaseModel.php
@@ -129,9 +129,16 @@ abstract class BaseModel
 		$this->data[$name] = $value;
 	}
 
-	public function toArray()
+	/**
+	 * Returns the values of the current model as an array
+	 *
+	 * @param bool $dbOnly True, if just the db-relevant fields should be returned
+	 *
+	 * @return array The values of the current model
+	 */
+	public function toArray(bool $dbOnly = false)
 	{
-		return $this->mapFields($this->data);
+		return $dbOnly ? $this->mapFields($this->data) : $this->data;
 	}
 
 	protected function checkValid()

--- a/src/BaseModel.php
+++ b/src/BaseModel.php
@@ -12,7 +12,7 @@ use Psr\Log\LoggerInterface;
  *
  * @property int id
  */
-abstract class BaseModel
+abstract class BaseModel extends BaseEntity
 {
 	/** @var Database */
 	protected $dba;
@@ -48,23 +48,9 @@ abstract class BaseModel
 		$this->originalData = $data;
 	}
 
-	/**
-	 * Maps a data array (original/current) to a known field list of the chosen model
-	 *
-	 * This is useful to filter out additional attributes, which aren't part of the db-table (like readonly cached fields)
-	 *
-	 * @param array $data The data array to map to db-fields
-	 *
-	 * @return array the mapped data array
-	 */
-	protected function mapFields(array $data)
-	{
-		return $data;
-	}
-
 	public function getOriginalData()
 	{
-		return $this->mapFields($this->originalData);
+		return $this->originalData;
 	}
 
 	public function resetOriginalData()
@@ -129,16 +115,9 @@ abstract class BaseModel
 		$this->data[$name] = $value;
 	}
 
-	/**
-	 * Returns the values of the current model as an array
-	 *
-	 * @param bool $dbOnly True, if just the db-relevant fields should be returned
-	 *
-	 * @return array The values of the current model
-	 */
-	public function toArray(bool $dbOnly = false)
+	public function toArray()
 	{
-		return $dbOnly ? $this->mapFields($this->data) : $this->data;
+		return $this->data;
 	}
 
 	protected function checkValid()

--- a/src/BaseRepository.php
+++ b/src/BaseRepository.php
@@ -122,7 +122,7 @@ abstract class BaseRepository extends BaseFactory
 	 */
 	public function update(BaseModel $model)
 	{
-		if ($this->dba->update(static::$table_name, $model->toArray(), ['id' => $model->id], $model->getOriginalData())) {
+		if ($this->dba->update(static::$table_name, $model->toArray(true), ['id' => $model->id], $model->getOriginalData())) {
 			$model->resetOriginalData();
 			return true;
 		}

--- a/src/BaseRepository.php
+++ b/src/BaseRepository.php
@@ -122,7 +122,7 @@ abstract class BaseRepository extends BaseFactory
 	 */
 	public function update(BaseModel $model)
 	{
-		if ($this->dba->update(static::$table_name, $model->toArray(true), ['id' => $model->id], $model->getOriginalData())) {
+		if ($this->dba->update(static::$table_name, $model->toArray(), ['id' => $model->id], $model->getOriginalData())) {
 			$model->resetOriginalData();
 			return true;
 		}

--- a/src/Collection/Api/Notifications.php
+++ b/src/Collection/Api/Notifications.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Friendica\Collection\Api;
+
+use Friendica\BaseCollection;
+use Friendica\Object\Api\Friendica\Notification;
+
+class Notifications extends BaseCollection
+{
+	/**
+	 * @return Notification
+	 */
+	public function current()
+	{
+		return parent::current();
+	}
+}

--- a/src/DI.php
+++ b/src/DI.php
@@ -281,14 +281,6 @@ abstract class DI
 	}
 
 	/**
-	 * @return Repository\Notify
-	 */
-	public static function notify()
-	{
-		return self::$dice->create(Repository\Notify::class);
-	}
-
-	/**
 	 * @return Model\Storage\IStorage
 	 */
 	public static function storage()
@@ -322,6 +314,14 @@ abstract class DI
 	public static function profileField()
 	{
 		return self::$dice->create(Repository\ProfileField::class);
+	}
+
+	/**
+	 * @return Repository\Notify
+	 */
+	public static function notify()
+	{
+		return self::$dice->create(Repository\Notify::class);
 	}
 
 	//

--- a/src/Factory/Notification/Notification.php
+++ b/src/Factory/Notification/Notification.php
@@ -6,6 +6,7 @@ use Exception;
 use Friendica\App;
 use Friendica\App\BaseURL;
 use Friendica\BaseFactory;
+use Friendica\Collection\Api\Notifications as ApiNotifications;
 use Friendica\Content\Text\BBCode;
 use Friendica\Core\L10n;
 use Friendica\Core\PConfig\IPConfig;
@@ -15,6 +16,7 @@ use Friendica\Database\Database;
 use Friendica\Model\Item;
 use Friendica\Module\BaseNotifications;
 use Friendica\Network\HTTPException\InternalServerErrorException;
+use Friendica\Object\Api\Friendica\Notification as ApiNotification;
 use Friendica\Protocol\Activity;
 use Friendica\Repository;
 use Friendica\Util\DateTimeFormat;
@@ -351,5 +353,27 @@ class Notification extends BaseFactory
 		}
 
 		return $formattedNotifications;
+	}
+
+	/**
+	 * @param int   $uid    The user id of the API call
+	 * @param array $params Additional parameters
+	 *
+	 * @return ApiNotifications
+	 *
+	 * @throws Exception
+	 */
+	public function getApiList(int $uid, array $params = ['order' => ['seen' => 'ASC', 'date' => 'DESC'], 'limit' => 50])
+	{
+		$notifies = $this->notification->select(['uid' => $uid], $params);
+
+		/** @var ApiNotification[] $notifications */
+		$notifications = [];
+
+		foreach ($notifies as $notify) {
+			$notifications[] = new ApiNotification($notify);
+		}
+
+		return new ApiNotifications($notifications);
 	}
 }

--- a/src/Model/Notify.php
+++ b/src/Model/Notify.php
@@ -163,4 +163,29 @@ class Notify extends BaseModel
 
 		return $message;
 	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function mapFields(array $data)
+	{
+		return [
+			'hash'       => $data['hash'] ?? '',
+			'type'       => $data['type'] ?? 0,
+			'name'       => $data['name'] ?? '',
+			'url'        => $data['url'] ?? '',
+			'photo'      => $data['photo'] ?? '',
+			'date'       => $data['date'] ?? DateTimeFormat::utcNow(),
+			'msg'        => $data['msg'] ?? '',
+			'uid'        => $data['uid'] ?? 0,
+			'link'       => $data['link'] ?? '',
+			'iid'        => $data['iid'] ?? 0,
+			'parent'     => $data['parent'] ?? 0,
+			'seen'       => $data['seen'] ?? false,
+			'verb'       => $data['verb'] ?? '',
+			'otype'      => $data['otype'] ?? '',
+			'name_cache' => $data['name_cache'] ?? null,
+			'msg_cache'  => $data['msg_cache'] ?? null,
+		];
+	}
 }

--- a/src/Object/Api/Friendica/Notification.php
+++ b/src/Object/Api/Friendica/Notification.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Friendica\Object\Api\Friendica;
+
+use Friendica\BaseEntity;
+use Friendica\Content\Text\BBCode;
+use Friendica\Content\Text\HTML;
+use Friendica\Model\Notify;
+use Friendica\Util\DateTimeFormat;
+use Friendica\Util\Temporal;
+
+/**
+ * Friendica Notification
+ *
+ * @see https://github.com/friendica/friendica/blob/develop/doc/API-Entities.md#notification
+ */
+class Notification extends BaseEntity
+{
+	/** @var integer */
+	protected $id;
+	/** @var string */
+	protected $hash;
+	/** @var integer */
+	protected $type;
+	/** @var string Full name of the contact subject */
+	protected $name;
+	/** @var string Profile page URL of the contact subject */
+	protected $url;
+	/** @var string Profile photo URL of the contact subject */
+	protected $photo;
+	/** @var string YYYY-MM-DD hh:mm:ss local server time */
+	protected $date;
+	/** @var string The message (BBCode) */
+	protected $msg;
+	/** @var integer Owner User Id */
+	protected $uid;
+	/** @var string Notification URL */
+	protected $link;
+	/** @var integer Item Id */
+	protected $iid;
+	/** @var integer Parent Item Id */
+	protected $parent;
+	/** @var boolean  Whether the notification was read or not. */
+	protected $seen;
+	/** @var string Verb URL @see http://activitystrea.ms */
+	protected $verb;
+	/** @var string Subject type (`item`, `intro` or `mail`) */
+	protected $otype;
+	/** @var string Full name of the contact subject (HTML) */
+	protected $name_cache;
+	/** @var string Plaintext version of the notification text with a placeholder (`{0}`) for the subject contact's name. (Plaintext) */
+	protected $msg_cache;
+	/** @var integer  Unix timestamp */
+	protected $timestamp;
+	/** @var string Time since the note was posted, eg "1 hour ago" */
+	protected $date_rel;
+	/** @var string Message (HTML) */
+	protected $msg_html;
+	/** @var string Message (Plaintext) */
+	protected $msg_plain;
+
+	public function __construct(Notify $notify)
+	{
+		// map each notify attribute to the entity
+		foreach ($notify->toArray() as $key => $value) {
+			$this->{$key} = $value;
+		}
+
+		// add additional attributes for the API
+		try {
+			$this->timestamp = strtotime(DateTimeFormat::local($this->date));
+			$this->msg_html  = BBCode::convert($this->msg, false);
+			$this->msg_plain = explode("\n", trim(HTML::toPlaintext($this->msg_html, 0)))[0];
+		} catch (\Exception $e) {
+		}
+
+		$this->date_rel = Temporal::getRelativeDate($this->date);
+	}
+}

--- a/src/Object/Notification/Introduction.php
+++ b/src/Object/Notification/Introduction.php
@@ -262,7 +262,7 @@ class Introduction implements \JsonSerializable
 	{
 		$this->label         = $data['label'] ?? '';
 		$this->type          = $data['str_type'] ?? '';
-		$this->intro_id      = $data['$intro_id'] ?? -1;
+		$this->intro_id      = $data['intro_id'] ?? -1;
 		$this->madeBy        = $data['madeBy'] ?? '';
 		$this->madeByUrl     = $data['madeByUrl'] ?? '';
 		$this->madeByZrl     = $data['madeByZrl'] ?? '';

--- a/src/Repository/Notify.php
+++ b/src/Repository/Notify.php
@@ -67,7 +67,7 @@ class Notify extends BaseRepository
 	/**
 	 * @param array $fields
 	 *
-	 * @return Model\Notify
+	 * @return Model\Notify|false
 	 *
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 * @throws Exception
@@ -75,16 +75,13 @@ class Notify extends BaseRepository
 	public function insert(array $fields)
 	{
 		$fields['date']  = DateTimeFormat::utcNow();
-		$fields['abort'] = false;
 
 		Hook::callAll('enotify_store', $fields);
 
-		if ($fields['abort']) {
+		if (empty($fields)) {
 			$this->logger->debug('Abort adding notification entry', ['fields' => $fields]);
-			return null;
+			return false;
 		}
-
-		unset($fields['abort']);
 
 		$this->logger->debug('adding notification entry', ['fields' => $fields]);
 

--- a/src/Repository/Notify.php
+++ b/src/Repository/Notify.php
@@ -84,6 +84,8 @@ class Notify extends BaseRepository
 			return null;
 		}
 
+		unset($fields['abort']);
+
 		$this->logger->debug('adding notification entry', ['fields' => $fields]);
 
 		return parent::insert($fields);

--- a/src/Repository/Notify.php
+++ b/src/Repository/Notify.php
@@ -37,8 +37,6 @@ class Notify extends BaseRepository
 	{
 		$params['order'] = $params['order'] ?? ['date' => 'DESC'];
 
-		$condition = array_merge($condition, ['uid' => local_user()]);
-
 		return parent::select($condition, $params);
 	}
 

--- a/src/Repository/Notify.php
+++ b/src/Repository/Notify.php
@@ -79,7 +79,7 @@ class Notify extends BaseRepository
 		Hook::callAll('enotify_store', $fields);
 
 		if (empty($fields)) {
-			$this->logger->debug('Abort adding notification entry', ['fields' => $fields]);
+			$this->logger->debug('Abort adding notification entry');
 			return false;
 		}
 

--- a/tests/datasets/api.fixture.php
+++ b/tests/datasets/api.fixture.php
@@ -189,6 +189,25 @@ return [
 			'origin'      => 1,
 		],
 	],
+	'notify' => [
+		[
+			'id' => 1,
+			'type' => 8,
+			'name' => 'Reply to',
+			'url' => 'http://localhost/display/1',
+			'photo' => 'http://localhost/',
+			'date' => '2020-01-01 12:12:02',
+			'msg' => 'A test reply from an item',
+			'uid' => 42,
+			'link' => 'http://localhost/notification/1',
+			'iid' => 4,
+			'seen' => 0,
+			'verb' => '',
+			'otype' => 'item',
+			'name_cache' => 'Reply to',
+			'msg_cache' => 'A test reply from an item',
+		],
+	],
 	'thread'  => [
 		[
 			'iid'        => 1,

--- a/tests/include/ApiTest.php
+++ b/tests/include/ApiTest.php
@@ -14,6 +14,7 @@ use Friendica\Core\Session;
 use Friendica\Core\Session\ISession;
 use Friendica\Core\System;
 use Friendica\Database\Database;
+use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Contact;
 use Friendica\Network\HTTPException;
@@ -3916,14 +3917,15 @@ class ApiTest extends DatabaseTest
 	}
 
 	/**
-	 * Test the api_friendica_notification() function with an argument count.
+	 * Test the api_friendica_notification() function with empty result
 	 *
 	 * @return void
 	 */
-	public function testApiFriendicaNotificationWithArgumentCount()
+	public function testApiFriendicaNotificationWithEmptyResult()
 	{
 		$this->app->argv = ['api', 'friendica', 'notification'];
 		$this->app->argc = count($this->app->argv);
+		$_SESSION['uid'] = 41;
 		$result          = api_friendica_notification('json');
 		$this->assertEquals(['note' => false], $result);
 	}
@@ -3938,7 +3940,26 @@ class ApiTest extends DatabaseTest
 		$this->app->argv = ['api', 'friendica', 'notification'];
 		$this->app->argc = count($this->app->argv);
 		$result          = api_friendica_notification('xml');
-		$this->assertXml($result, 'notes');
+		$assertXml=<<<XML
+<?xml version="1.0"?>
+<notes>
+  <note id="1" hash="" type="8" name="Reply to" url="http://localhost/display/1" photo="http://localhost/" date="2020-01-01 12:12:02" msg="A test reply from an item" uid="42" link="http://localhost/notification/1" iid="4" parent="0" seen="0" verb="" otype="item" name_cache="" msg_cache="A test reply from an item" timestamp="1577880722" date_rel="4 weeks ago" msg_html="A test reply from an item" msg_plain="A test reply from an item"/>
+</notes>
+XML;
+		$this->assertXmlStringEqualsXmlString($assertXml, $result);
+	}
+
+	/**
+	 * Test the api_friendica_notification() function with an JSON result.
+	 *
+	 * @return void
+	 */
+	public function testApiFriendicaNotificationWithJsonResult()
+	{
+		$this->app->argv = ['api', 'friendica', 'notification'];
+		$this->app->argc = count($this->app->argv);
+		$result          = json_encode(api_friendica_notification('json'));
+		$this->assertJson($result);
 	}
 
 	/**


### PR DESCRIPTION
FollowUp #8170 

- Add `name_cache` entry in enotify
- Add "unset()" in notify repository for additional field "abort"
- Fix enotify link generation
- Add new "API" notification object and factory

Tested on my friendica.philipp.info node and:
- Bell counter works again
- New entry for comments in the notification-dropdown (Fixes #8182 - see https://friendica.philipp.info/display/f3ad7b1c-155e-2e99-e325-a84095934917)
- Link in the notification dropdown is working (again)
- Click on the link reduces the counter again (see https://friendica.philipp.info/display/f3ad7b1c-515e-2e75-550e-1b1487841944 )
- Intro ignore is now working again (Fixes #8187 )
- Intro accept is now working again (Addresses https://github.com/friendica/friendica/issues/7999#issuecomment-576007661 )
- Adding new notifications are working again (Fixes #8193)