### PR TITLE
Add custom emojis Mastodon API endpoint

### DIFF
--- a/doc/API-Mastodon.md
+++ b/doc/API-Mastodon.md
@@ -15,6 +15,10 @@ These endpoints use the [Mastodon API entities](https://docs.joinmastodon.org/en
 
 ## Implemented endpoints
 
+- [`GET /api/v1/custom_emojis`](https://docs.joinmastodon.org/methods/instance/custom_emojis/)
+    - Doesn't return unicode emojis since they aren't using an image URL
+
+
 - [`GET /api/v1/follow_requests`](https://docs.joinmastodon.org/methods/accounts/follow_requests#pending-follows)
     - Returned IDs are specific to follow requests
 - [`POST /api/v1/follow_requests/:id/authorize`](https://docs.joinmastodon.org/methods/accounts/follow_requests#accept-follow)

--- a/src/BaseEntity.php
+++ b/src/BaseEntity.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Friendica\Api;
+namespace Friendica;
 
 /**
  * The API entity classes are meant as data transfer objects. As such, their member should be protected.

--- a/src/Collection/Api/Mastodon/Emojis.php
+++ b/src/Collection/Api/Mastodon/Emojis.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Friendica\Collection\Api\Mastodon;
+
+use Friendica\BaseCollection;
+
+class Emojis extends BaseCollection
+{
+
+}

--- a/src/DI.php
+++ b/src/DI.php
@@ -229,6 +229,14 @@ abstract class DI
 	}
 
 	/**
+	 * @return Factory\Api\Mastodon\Emoji
+	 */
+	public static function mstdnEmoji()
+	{
+		return self::$dice->create(Factory\Api\Mastodon\Emoji::class);
+	}
+
+	/**
 	 * @return Factory\Api\Mastodon\FollowRequest
 	 */
 	public static function mstdnFollowRequest()

--- a/src/DI.php
+++ b/src/DI.php
@@ -141,7 +141,7 @@ abstract class DI
 	}
 
 	/**
-	 * @return \Friendica\Core\PConfig\IPConfig
+	 * @return Core\PConfig\IPConfig
 	 */
 	public static function pConfig()
 	{
@@ -221,31 +221,31 @@ abstract class DI
 	//
 
 	/**
-	 * @return Factory\Mastodon\Account
+	 * @return Factory\Api\Mastodon\Account
 	 */
 	public static function mstdnAccount()
 	{
-		return self::$dice->create(Factory\Mastodon\Account::class);
+		return self::$dice->create(Factory\Api\Mastodon\Account::class);
 	}
 
 	/**
-	 * @return Factory\Mastodon\FollowRequest
+	 * @return Factory\Api\Mastodon\FollowRequest
 	 */
 	public static function mstdnFollowRequest()
 	{
-		return self::$dice->create(Factory\Mastodon\FollowRequest::class);
+		return self::$dice->create(Factory\Api\Mastodon\FollowRequest::class);
 	}
 
 	/**
-	 * @return Factory\Mastodon\Relationship
+	 * @return Factory\Api\Mastodon\Relationship
 	 */
 	public static function mstdnRelationship()
 	{
-		return self::$dice->create(Factory\Mastodon\Relationship::class);
+		return self::$dice->create(Factory\Api\Mastodon\Relationship::class);
 	}
 
 	/**
-	 * @return \Friendica\Factory\Notification\Notification
+	 * @return Factory\Notification\Notification
 	 */
 	public static function notification()
 	{
@@ -253,7 +253,7 @@ abstract class DI
 	}
 
 	/**
-	 * @return \Friendica\Factory\Notification\Introduction
+	 * @return Factory\Notification\Introduction
 	 */
 	public static function notificationIntro()
 	{

--- a/src/Factory/Api/Mastodon/Account.php
+++ b/src/Factory/Api/Mastodon/Account.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Friendica\Factory\Mastodon;
+namespace Friendica\Factory\Api\Mastodon;
 
 use Friendica\App\BaseURL;
+use Friendica\BaseFactory;
 use Friendica\Model\APContact;
 use Friendica\Model\Contact;
 use Friendica\Network\HTTPException;
-use Friendica\BaseFactory;
 use Psr\Log\LoggerInterface;
 
 class Account extends BaseFactory

--- a/src/Factory/Api/Mastodon/Emoji.php
+++ b/src/Factory/Api/Mastodon/Emoji.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Friendica\Factory\Api\Mastodon;
+
+use Friendica\App\BaseURL;
+use Friendica\BaseFactory;
+use Friendica\Model\APContact;
+use Friendica\Model\Contact;
+use Friendica\Network\HTTPException;
+use Psr\Log\LoggerInterface;
+
+class Emoji extends BaseFactory
+{
+	/** @var BaseURL */
+	protected $baseUrl;
+
+	public function __construct(LoggerInterface $logger, BaseURL $baseURL)
+	{
+		parent::__construct($logger);
+
+		$this->baseUrl = $baseURL;
+	}
+
+	/**
+	 * @param int $contactId
+	 * @param int $uid        User Id
+	 * @return \Friendica\Api\Entity\Mastodon\Account
+	 * @throws HTTPException\InternalServerErrorException
+	 * @throws \ImagickException
+	 */
+	public function createFromContactId(int $contactId, $uid = 0)
+	{
+		$cdata = Contact::getPublicAndUserContacID($contactId, $uid);
+		if (!empty($cdata)) {
+			$publicContact = Contact::getById($cdata['public']);
+			$userContact = Contact::getById($cdata['user']);
+		} else {
+			$publicContact = Contact::getById($contactId);
+			$userContact = [];
+		}
+
+		$apcontact = APContact::getByURL($publicContact['url'], false);
+
+		return new \Friendica\Api\Entity\Mastodon\Account($this->baseUrl, $publicContact, $apcontact, $userContact);
+	}
+}

--- a/src/Factory/Api/Mastodon/FollowRequest.php
+++ b/src/Factory/Api/Mastodon/FollowRequest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Friendica\Factory\Mastodon;
+namespace Friendica\Factory\Api\Mastodon;
 
 use Friendica\App\BaseURL;
+use Friendica\BaseFactory;
 use Friendica\Model\APContact;
 use Friendica\Model\Contact;
 use Friendica\Model\Introduction;
 use Friendica\Network\HTTPException;
-use Friendica\BaseFactory;
 use Psr\Log\LoggerInterface;
 
 class FollowRequest extends BaseFactory

--- a/src/Factory/Api/Mastodon/Relationship.php
+++ b/src/Factory/Api/Mastodon/Relationship.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Friendica\Factory\Mastodon;
+namespace Friendica\Factory\Api\Mastodon;
 
 use Friendica\Object\Api\Mastodon\Relationship as RelationshipEntity;
 use Friendica\BaseFactory;

--- a/src/Factory/Mastodon/Account.php
+++ b/src/Factory/Mastodon/Account.php
@@ -24,7 +24,7 @@ class Account extends BaseFactory
 	/**
 	 * @param int $contactId
 	 * @param int $uid        User Id
-	 * @return \Friendica\Api\Entity\Mastodon\Account
+	 * @return \Friendica\Object\Api\Mastodon\Account
 	 * @throws HTTPException\InternalServerErrorException
 	 * @throws \ImagickException
 	 */
@@ -41,6 +41,6 @@ class Account extends BaseFactory
 
 		$apcontact = APContact::getByURL($publicContact['url'], false);
 
-		return new \Friendica\Api\Entity\Mastodon\Account($this->baseUrl, $publicContact, $apcontact, $userContact);
+		return new \Friendica\Object\Api\Mastodon\Account($this->baseUrl, $publicContact, $apcontact, $userContact);
 	}
 }

--- a/src/Factory/Mastodon/FollowRequest.php
+++ b/src/Factory/Mastodon/FollowRequest.php
@@ -24,7 +24,7 @@ class FollowRequest extends BaseFactory
 
 	/**
 	 * @param Introduction $introduction
-	 * @return \Friendica\Api\Entity\Mastodon\FollowRequest
+	 * @return \Friendica\Object\Api\Mastodon\FollowRequest
 	 * @throws HTTPException\InternalServerErrorException
 	 * @throws \ImagickException
 	 */
@@ -42,6 +42,6 @@ class FollowRequest extends BaseFactory
 
 		$apcontact = APContact::getByURL($publicContact['url'], false);
 
-		return new \Friendica\Api\Entity\Mastodon\FollowRequest($this->baseUrl, $introduction->id, $publicContact, $apcontact, $userContact);
+		return new \Friendica\Object\Api\Mastodon\FollowRequest($this->baseUrl, $introduction->id, $publicContact, $apcontact, $userContact);
 	}
 }

--- a/src/Factory/Mastodon/Relationship.php
+++ b/src/Factory/Mastodon/Relationship.php
@@ -2,7 +2,7 @@
 
 namespace Friendica\Factory\Mastodon;
 
-use Friendica\Api\Entity\Mastodon\Relationship as RelationshipEntity;
+use Friendica\Object\Api\Mastodon\Relationship as RelationshipEntity;
 use Friendica\BaseFactory;
 use Friendica\Model\Contact;
 

--- a/src/Module/Api/Mastodon/CustomEmojis.php
+++ b/src/Module/Api/Mastodon/CustomEmojis.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Friendica\Module\Api\Mastodon;
+
+use Friendica\Content\Smilies;
+use Friendica\Core\System;
+use Friendica\DI;
+use Friendica\Module\BaseApi;
+use Friendica\Network\HTTPException;
+
+/**
+ * @see https://docs.joinmastodon.org/methods/accounts/follow_requests
+ */
+class CustomEmojis extends BaseApi
+{
+	/**
+	 * @param array $parameters
+	 * @throws HTTPException\InternalServerErrorException
+	 * @throws \ImagickException
+	 * @see https://docs.joinmastodon.org/methods/accounts/follow_requests#pending-follows
+	 */
+	public static function rawContent(array $parameters = [])
+	{
+		$emojis = DI::mstdnEmoji()->createCollectionFromSmilies(Smilies::getList());
+
+		System::jsonExit($emojis->getArrayCopy());
+	}
+}

--- a/src/Module/Api/Mastodon/FollowRequests.php
+++ b/src/Module/Api/Mastodon/FollowRequests.php
@@ -2,8 +2,8 @@
 
 namespace Friendica\Module\Api\Mastodon;
 
-use Friendica\Api\Entity\Mastodon;
-use Friendica\Api\Entity\Mastodon\Relationship;
+use Friendica\Object\Api\Mastodon;
+use Friendica\Object\Api\Mastodon\Relationship;
 use Friendica\Core\System;
 use Friendica\DI;
 use Friendica\Model\Contact;

--- a/src/Module/Api/Mastodon/FollowRequests.php
+++ b/src/Module/Api/Mastodon/FollowRequests.php
@@ -2,18 +2,15 @@
 
 namespace Friendica\Module\Api\Mastodon;
 
-use Friendica\Object\Api\Mastodon;
-use Friendica\Object\Api\Mastodon\Relationship;
 use Friendica\Core\System;
 use Friendica\DI;
-use Friendica\Model\Contact;
-use Friendica\Module\Base\Api;
+use Friendica\Module\BaseApi;
 use Friendica\Network\HTTPException;
 
 /**
  * @see https://docs.joinmastodon.org/methods/accounts/follow_requests
  */
-class FollowRequests extends Api
+class FollowRequests extends BaseApi
 {
 	public static function init(array $parameters = [])
 	{

--- a/src/Module/Api/Mastodon/Instance.php
+++ b/src/Module/Api/Mastodon/Instance.php
@@ -2,14 +2,14 @@
 
 namespace Friendica\Module\Api\Mastodon;
 
-use Friendica\Object\Api\Mastodon\Instance as InstanceEntity;
 use Friendica\Core\System;
-use Friendica\Module\Base\Api;
+use Friendica\Module\BaseApi;
+use Friendica\Object\Api\Mastodon\Instance as InstanceEntity;
 
 /**
  * @see https://docs.joinmastodon.org/api/rest/instances/
  */
-class Instance extends Api
+class Instance extends BaseApi
 {
 	/**
 	 * @param array $parameters

--- a/src/Module/Api/Mastodon/Instance.php
+++ b/src/Module/Api/Mastodon/Instance.php
@@ -2,7 +2,7 @@
 
 namespace Friendica\Module\Api\Mastodon;
 
-use Friendica\Api\Entity\Mastodon\Instance as InstanceEntity;
+use Friendica\Object\Api\Mastodon\Instance as InstanceEntity;
 use Friendica\Core\System;
 use Friendica\Module\Base\Api;
 

--- a/src/Module/Api/Mastodon/Instance/Peers.php
+++ b/src/Module/Api/Mastodon/Instance/Peers.php
@@ -5,14 +5,14 @@ namespace Friendica\Module\Api\Mastodon\Instance;
 use Friendica\Core\Protocol;
 use Friendica\Core\System;
 use Friendica\Database\DBA;
-use Friendica\Module\Base\Api;
+use Friendica\Module\BaseApi;
 use Friendica\Network\HTTPException;
 use Friendica\Util\Network;
 
 /**
  * Undocumented API endpoint that is implemented by both Mastodon and Pleroma
  */
-class Peers extends Api
+class Peers extends BaseApi
 {
 	/**
 	 * @param array $parameters

--- a/src/Module/BaseApi.php
+++ b/src/Module/BaseApi.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace Friendica\Module\Base;
+namespace Friendica\Module;
 
 use Friendica\BaseModule;
 use Friendica\DI;
 use Friendica\Network\HTTPException;
 
-require_once __DIR__ . '/../../../include/api.php';
+require_once __DIR__ . '/../../include/api.php';
 
-class Api extends BaseModule
+class BaseApi extends BaseModule
 {
 	/**
 	 * @var string json|xml|rss|atom

--- a/src/Object/Api/Mastodon/Account.php
+++ b/src/Object/Api/Mastodon/Account.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Friendica\Api\Entity\Mastodon;
+namespace Friendica\Object\Api\Mastodon;
 
-use Friendica\Api\BaseEntity;
 use Friendica\App\BaseURL;
+use Friendica\BaseEntity;
 use Friendica\Content\Text\BBCode;
 use Friendica\Database\DBA;
 use Friendica\Model\Contact;

--- a/src/Object/Api/Mastodon/Emoji.php
+++ b/src/Object/Api/Mastodon/Emoji.php
@@ -7,16 +7,50 @@ use Friendica\BaseEntity;
 /**
  * Class Emoji
  *
- * @see https://docs.joinmastodon.org/api/entities/#emoji
+ * @see https://docs.joinmastodon.org/entities/emoji/
  */
 class Emoji extends BaseEntity
 {
+	//Required attributes
 	/** @var string */
 	protected $shortcode;
-	/** @var string (URL) */
+	/** @var string (URL)*/
 	protected $static_url;
-	/** @var string (URL) */
+	/** @var string (URL)*/
 	protected $url;
-	/** @var bool */
-	protected $visible_in_picker;
+	/**
+	 * Unsupported
+	 * @var bool
+	 */
+	protected $visible_in_picker = true;
+
+	// Optional attributes
+	/**
+	 * Unsupported
+	 * @var string
+	 */
+	//protected $category;
+
+	public function __construct(string $shortcode, string $url)
+	{
+		$this->shortcode = $shortcode;
+		$this->url = $url;
+		$this->static_url = $url;
+	}
+
+	/**
+	 * @param Emoji  $prototype
+	 * @param string $shortcode
+	 * @param string $url
+	 * @return Emoji
+	 */
+	public static function createFromPrototype(Emoji $prototype, string $shortcode, string $url)
+	{
+		$emoji = clone $prototype;
+		$emoji->shortcode = $shortcode;
+		$emoji->url = $url;
+		$emoji->static_url = $url;
+
+		return $emoji;
+	}
 }

--- a/src/Object/Api/Mastodon/Emoji.php
+++ b/src/Object/Api/Mastodon/Emoji.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Friendica\Api\Entity\Mastodon;
+namespace Friendica\Object\Api\Mastodon;
 
-use Friendica\Api\BaseEntity;
+use Friendica\BaseEntity;
 
 /**
  * Class Emoji
@@ -13,9 +13,9 @@ class Emoji extends BaseEntity
 {
 	/** @var string */
 	protected $shortcode;
-	/** @var string (URL)*/
+	/** @var string (URL) */
 	protected $static_url;
-	/** @var string (URL)*/
+	/** @var string (URL) */
 	protected $url;
 	/** @var bool */
 	protected $visible_in_picker;

--- a/src/Object/Api/Mastodon/Field.php
+++ b/src/Object/Api/Mastodon/Field.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Friendica\Api\Entity\Mastodon;
+namespace Friendica\Object\Api\Mastodon;
 
-use Friendica\Api\BaseEntity;
+use Friendica\BaseEntity;
 
 /**
  * Class Field

--- a/src/Object/Api/Mastodon/FollowRequest.php
+++ b/src/Object/Api/Mastodon/FollowRequest.php
@@ -1,9 +1,8 @@
 <?php
 
-namespace Friendica\Api\Entity\Mastodon;
+namespace Friendica\Object\Api\Mastodon;
 
 use Friendica\App\BaseURL;
-use Friendica\Model\Introduction;
 
 /**
  * Virtual entity to separate Accounts from Follow Requests.

--- a/src/Object/Api/Mastodon/Instance.php
+++ b/src/Object/Api/Mastodon/Instance.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Friendica\Api\Entity\Mastodon;
+namespace Friendica\Object\Api\Mastodon;
 
-use Friendica\Api\BaseEntity;
+use Friendica\BaseEntity;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\User;

--- a/src/Object/Api/Mastodon/Relationship.php
+++ b/src/Object/Api/Mastodon/Relationship.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Friendica\Api\Entity\Mastodon;
+namespace Friendica\Object\Api\Mastodon;
 
-use Friendica\Api\BaseEntity;
+use Friendica\BaseEntity;
 use Friendica\Model\Contact;
 use Friendica\Util\Network;
 

--- a/src/Object/Api/Mastodon/Stats.php
+++ b/src/Object/Api/Mastodon/Stats.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Friendica\Api\Entity\Mastodon;
+namespace Friendica\Object\Api\Mastodon;
 
-use Friendica\Api\BaseEntity;
+use Friendica\BaseEntity;
 use Friendica\Core\Protocol;
 use Friendica\Database\DBA;
 use Friendica\DI;

--- a/static/routes.config.php
+++ b/static/routes.config.php
@@ -29,10 +29,11 @@ return [
 
 	'/api' => [
 		'/v1' => [
+			'/custom_emojis'                     => [Module\Api\Mastodon\CustomEmojis::class,   [R::GET         ]],
 			'/follow_requests'                   => [Module\Api\Mastodon\FollowRequests::class, [R::GET         ]],
 			'/follow_requests/{id:\d+}/{action}' => [Module\Api\Mastodon\FollowRequests::class, [        R::POST]],
-			'/instance'                          => [Module\Api\Mastodon\Instance::class, [R::GET]],
-			'/instance/peers'                    => [Module\Api\Mastodon\Instance\Peers::class, [R::GET]],
+			'/instance'                          => [Module\Api\Mastodon\Instance::class,       [R::GET         ]],
+			'/instance/peers'                    => [Module\Api\Mastodon\Instance\Peers::class, [R::GET         ]],
 		],
 	],
 


### PR DESCRIPTION
Part of #7967

I moved a bunch of stuff around in this PR for better consistency:
- `Api\BaseEntity` is now `BaseEntity`
- `Factory\Mastodon\*` is now `Factory\Api\Mastodon\*`
- `Module\Base\Api` is now `Module\BaseApi`
- `Api\Entity\*` is now `Object\Api\*`