### PR TITLE
Fix invalid "emailer_send_prepare" Hook

### DIFF
--- a/doc/de/Addons.md
+++ b/doc/de/Addons.md
@@ -475,7 +475,7 @@ Eine komplette Liste aller Hook-Callbacks mit den zugehörigen Dateien (am 01-Ap
 
 ### src/Util/Emailer.php
 
-    Hook::callAll('emailer_send_prepare', $params);
+    Hook::callAll('emailer_send_prepare', $email);
     Hook::callAll("emailer_send", $hookdata);
 
 ### src/Util/Map.php

--- a/src/Object/Email.php
+++ b/src/Object/Email.php
@@ -132,4 +132,25 @@ class Email implements IEmail
 
 		return $newEmail;
 	}
+
+	/**
+	 * Creates a new Email instance based on a given prototype
+	 *
+	 * @param static $prototype The base prototype
+	 * @param array  $data      The delta-data (key must be an existing property)
+	 *
+	 * @return static The new email instance
+	 */
+	public static function createFromPrototype(Email $prototype, array $data = [])
+	{
+		$newMail = clone $prototype;
+
+		foreach ($data as $key => $value) {
+			if (property_exists($newMail, $key)) {
+				$newMail->{$key} = $value;
+			}
+		}
+
+		return $newMail;
+	}
 }

--- a/src/Util/Emailer.php
+++ b/src/Util/Emailer.php
@@ -45,11 +45,9 @@ class Emailer
 	 */
 	public function send(IEmail $email)
 	{
-		$params['sent'] = false;
+		Hook::callAll('emailer_send_prepare', $email);
 
-		Hook::callAll('emailer_send_prepare', $params);
-
-		if ($params['sent']) {
+		if (empty($email)) {
 			return true;
 		}
 


### PR DESCRIPTION
- Use IEmail instead of array data
- Introduce "composer" based library for phpmailer

Addresses https://github.com/friendica/friendica/issues/8000#issuecomment-579721154
Needs https://github.com/friendica/friendica-addons/pull/952 as well