### PR TITLE
Fix Introduction Diaspore sendShare()

### DIFF
--- a/src/Model/Introduction.php
+++ b/src/Model/Introduction.php
@@ -97,7 +97,7 @@ final class Introduction extends BaseModel
 
 		if ($newRelation == Contact::FRIEND) {
 			if ($protocol == Protocol::DIASPORA) {
-				$ret = Diaspora::sendShare(Contact::getById($contact['uid']), $contact);
+				$ret = Diaspora::sendShare(User::getById($contact['uid']), $contact);
 				$this->logger->info('share returns', ['return' => $ret]);
 			} elseif ($protocol == Protocol::ACTIVITYPUB) {
 				ActivityPub\Transmitter::sendActivity('Follow', $contact['url'], $contact['uid']);

--- a/src/Model/Introduction.php
+++ b/src/Model/Introduction.php
@@ -24,7 +24,7 @@ use Psr\Log\LoggerInterface;
  * @property bool   blocked
  * @property bool   ignore
  */
-final class Introduction extends BaseModel
+class Introduction extends BaseModel
 {
 	/** @var Repository\Introduction */
 	protected $intro;


### PR DESCRIPTION
Addresses https://github.com/friendica/friendica/issues/7998#issuecomment-578206829
FollowUp #8074

@MrPetovan I'd like to revert this change:
https://github.com/friendica/friendica/pull/8074/files#diff-a0d9e8b02915801e9895e0da176ed20aR100
Was the model-class switch intended? If so, we'd load the same contact array like we already have. I'd say we would then be able to completely remove the `getById()`call and pass the same `$contact` array twice instead ...