### PR TITLE
Release Cache Buster

### DIFF
--- a/src/App/Page.php
+++ b/src/App/Page.php
@@ -15,6 +15,7 @@ use Friendica\Core\Renderer;
 use Friendica\Core\Theme;
 use Friendica\Module\Special\HTTPException as ModuleHTTPException;
 use Friendica\Network\HTTPException;
+use Friendica\Util\Network;
 use Friendica\Util\Strings;
 
 /**
@@ -151,6 +152,8 @@ class Page implements ArrayAccess
 	 */
 	public function registerStylesheet($path)
 	{
+		$path = Network::appendQueryParam($path, ['v' => FRIENDICA_VERSION]);
+
 		if (mb_strpos($path, $this->basePath . DIRECTORY_SEPARATOR) === 0) {
 			$path = mb_substr($path, mb_strlen($this->basePath . DIRECTORY_SEPARATOR));
 		}
@@ -334,6 +337,8 @@ class Page implements ArrayAccess
 	 */
 	public function registerFooterScript($path)
 	{
+		$path = Network::appendQueryParam($path, ['v' => FRIENDICA_VERSION]);
+
 		$url = str_replace($this->basePath . DIRECTORY_SEPARATOR, '', $path);
 
 		$this->footerScripts[] = trim($url, '/');

--- a/src/Util/Network.php
+++ b/src/Util/Network.php
@@ -870,4 +870,27 @@ class Network
 
 		return $url;
 	}
+
+	/**
+	 * Adds query string parameters to the provided URI. Replace the value of existing keys.
+	 *
+	 * @param string $path
+	 * @param array  $additionalParams Associative array of parameters
+	 * @return string
+	 */
+	public static function appendQueryParam(string $path, array $additionalParams)
+	{
+		$parsed = parse_url($path);
+
+		$params = [];
+		if (!empty($parsed['query'])) {
+			parse_str($parsed['query'], $params);
+		}
+
+		$params = array_merge($params, $additionalParams);
+
+		$parsed['query'] = http_build_query($params);
+
+		return self::unparseURL($parsed);
+	}
 }

--- a/view/templates/admin/federation.tpl
+++ b/view/templates/admin/federation.tpl
@@ -1,4 +1,4 @@
-<script src="{{$baseurl}}/view/asset/Chart-js/dist/Chart.min.js"></script>
+<script src="{{$baseurl}}/view/asset/Chart-js/dist/Chart.min.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>
 <div id="adminpage">
 	<h1>{{$title}} - {{$page}}</h1>
 

--- a/view/templates/event_head.tpl
+++ b/view/templates/event_head.tpl
@@ -1,8 +1,8 @@
 
-<link rel="stylesheet" type="text/css" href="{{$baseurl}}/view/asset/fullcalendar/dist/fullcalendar.min.css" />
-<link rel="stylesheet" type="text/css" href="{{$baseurl}}/view/asset/fullcalendar/dist/fullcalendar.print.min.css" media="print" />
-<script type="text/javascript" src="{{$baseurl}}/view/asset/moment/min/moment-with-locales.min.js"></script>
-<script type="text/javascript" src="{{$baseurl}}/view/asset/fullcalendar/dist/fullcalendar.min.js"></script>
+<link rel="stylesheet" type="text/css" href="{{$baseurl}}/view/asset/fullcalendar/dist/fullcalendar.min.css?v={{$smarty.const.FRIENDICA_VERSION}}" />
+<link rel="stylesheet" type="text/css" href="{{$baseurl}}/view/asset/fullcalendar/dist/fullcalendar.print.min.css?v={{$smarty.const.FRIENDICA_VERSION}}" media="print" />
+<script type="text/javascript" src="{{$baseurl}}/view/asset/moment/min/moment-with-locales.min.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>
+<script type="text/javascript" src="{{$baseurl}}/view/asset/fullcalendar/dist/fullcalendar.min.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>
 
 <script>
 	function showEvent(eventid) {

--- a/view/templates/filebrowser.tpl
+++ b/view/templates/filebrowser.tpl
@@ -1,8 +1,8 @@
 <!--
 	This is the template used by mod/fbrowser.php
 -->
-<script type="text/javascript" src="{{$baseurl}}/view/js/ajaxupload.js" ></script>
-<script type="text/javascript" src="{{$baseurl}}/view/js/filebrowser.js"></script>
+<script type="text/javascript" src="{{$baseurl}}/view/js/ajaxupload.js?v={{$smarty.const.FRIENDICA_VERSION}}" ></script>
+<script type="text/javascript" src="{{$baseurl}}/view/js/filebrowser.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>
 <script>
 	$(function() {
 		FileBrowser.init("{{$nickname}}", "{{$type}}");

--- a/view/templates/head.tpl
+++ b/view/templates/head.tpl
@@ -2,11 +2,11 @@
 <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
 <base href="{{$baseurl}}/" />
 <meta name="generator" content="{{$generator}}" />
-<link rel="stylesheet" href="view/global.css" type="text/css" media="all" />
-<link rel="stylesheet" href="view/asset/jquery-colorbox/example5/colorbox.css" type="text/css" media="screen" />
-<link rel="stylesheet" href="view/asset/jgrowl/jquery.jgrowl.min.css" type="text/css" media="screen" />
-<link rel="stylesheet" href="view/asset/jquery-datetimepicker/build/jquery.datetimepicker.min.css" type="text/css" media="screen" />
-<link rel="stylesheet" href="view/asset/perfect-scrollbar/css/perfect-scrollbar.min.css" type="text/css" media="screen" />
+<link rel="stylesheet" href="view/global.css?v={{$smarty.const.FRIENDICA_VERSION}}" type="text/css" media="all" />
+<link rel="stylesheet" href="view/asset/jquery-colorbox/example5/colorbox.css?v={{$smarty.const.FRIENDICA_VERSION}}" type="text/css" media="screen" />
+<link rel="stylesheet" href="view/asset/jgrowl/jquery.jgrowl.min.css?v={{$smarty.const.FRIENDICA_VERSION}}" type="text/css" media="screen" />
+<link rel="stylesheet" href="view/asset/jquery-datetimepicker/build/jquery.datetimepicker.min.css?v={{$smarty.const.FRIENDICA_VERSION}}" type="text/css" media="screen" />
+<link rel="stylesheet" href="view/asset/perfect-scrollbar/css/perfect-scrollbar.min.css?v={{$smarty.const.FRIENDICA_VERSION}}" type="text/css" media="screen" />
 
 {{foreach $stylesheets as $stylesheetUrl}}
 <link rel="stylesheet" href="{{$stylesheetUrl}}" type="text/css" media="screen" />
@@ -30,21 +30,21 @@
          title="Search in Friendica" />
 
 <!--[if IE]>
-<script type="text/javascript" src="https://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
+<script type="text/javascript" src="https://html5shiv.googlecode.com/svn/trunk/html5.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>
 <![endif]-->
-<script type="text/javascript" src="view/js/modernizr.js" ></script>
-<script type="text/javascript" src="view/asset/jquery/dist/jquery.min.js" ></script>
-<script type="text/javascript" src="view/js/jquery.textinputs.js" ></script>
-<script type="text/javascript" src="view/js/jquery-textcomplete/jquery.textcomplete.min.js" ></script>
-<script type="text/javascript" src="view/js/autocomplete.js" ></script>
-<script type="text/javascript" src="view/asset/jquery-colorbox/jquery.colorbox-min.js"></script>
-<script type="text/javascript" src="view/asset/jgrowl/jquery.jgrowl.min.js"></script>
-<script type="text/javascript" src="view/asset/jquery-datetimepicker/build/jquery.datetimepicker.full.min.js"></script>
-<script type="text/javascript" src="view/asset/perfect-scrollbar/js/perfect-scrollbar.jquery.min.js" ></script>
-<script type="text/javascript" src="view/asset/imagesloaded/imagesloaded.pkgd.min.js"></script>
-<script type="text/javascript" src="view/asset/base64/base64.min.js" ></script>
-<script type="text/javascript" src="view/asset/dompurify/dist/purify.min.js"></script>
-<script type="text/javascript" src="view/js/main.js" ></script>
+<script type="text/javascript" src="view/js/modernizr.js?v={{$smarty.const.FRIENDICA_VERSION}}" ></script>
+<script type="text/javascript" src="view/asset/jquery/dist/jquery.min.js?v={{$smarty.const.FRIENDICA_VERSION}}" ></script>
+<script type="text/javascript" src="view/js/jquery.textinputs.js?v={{$smarty.const.FRIENDICA_VERSION}}" ></script>
+<script type="text/javascript" src="view/js/jquery-textcomplete/jquery.textcomplete.min.js?v={{$smarty.const.FRIENDICA_VERSION}}" ></script>
+<script type="text/javascript" src="view/js/autocomplete.js?v={{$smarty.const.FRIENDICA_VERSION}}" ></script>
+<script type="text/javascript" src="view/asset/jquery-colorbox/jquery.colorbox-min.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>
+<script type="text/javascript" src="view/asset/jgrowl/jquery.jgrowl.min.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>
+<script type="text/javascript" src="view/asset/jquery-datetimepicker/build/jquery.datetimepicker.full.min.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>
+<script type="text/javascript" src="view/asset/perfect-scrollbar/js/perfect-scrollbar.jquery.min.js?v={{$smarty.const.FRIENDICA_VERSION}}" ></script>
+<script type="text/javascript" src="view/asset/imagesloaded/imagesloaded.pkgd.min.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>
+<script type="text/javascript" src="view/asset/base64/base64.min.js?v={{$smarty.const.FRIENDICA_VERSION}}" ></script>
+<script type="text/javascript" src="view/asset/dompurify/dist/purify.min.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>
+<script type="text/javascript" src="view/js/main.js?v={{$smarty.const.FRIENDICA_VERSION}}" ></script>
 <script>
 
 	// Lifted from https://css-tricks.com/snippets/jquery/move-cursor-to-end-of-textarea-or-input/

--- a/view/templates/jot-header.tpl
+++ b/view/templates/jot-header.tpl
@@ -40,7 +40,7 @@ function enableOnUser(){
 }
 
 </script>
-<script type="text/javascript" src="{{$baseurl}}/view/js/ajaxupload.js" ></script>
+<script type="text/javascript" src="{{$baseurl}}/view/js/ajaxupload.js?v={{$smarty.const.FRIENDICA_VERSION}}" ></script>
 <script>
 	var ispublic = '{{$ispublic nofilter}}';
 

--- a/view/templates/msg-header.tpl
+++ b/view/templates/msg-header.tpl
@@ -1,7 +1,7 @@
 <script language="javascript" type="text/javascript">
 	$("#prvmail-text").editor_autocomplete(baseurl + '/search/acl');
 </script>
-<script type="text/javascript" src="view/js/ajaxupload.js" ></script>
+<script type="text/javascript" src="view/js/ajaxupload.js?v={{$smarty.const.FRIENDICA_VERSION}}" ></script>
 <script>
 	$(document).ready(function() {
 		var uploader = new window.AjaxUpload(

--- a/view/templates/settings/profile/index_head.tpl
+++ b/view/templates/settings/profile/index_head.tpl
@@ -1,1 +1,1 @@
-<script type="text/javascript" src="view/js/country.js" ></script>
+<script type="text/javascript" src="view/js/country.js?v={{$smarty.const.FRIENDICA_VERSION}}" ></script>

--- a/view/templates/settings/profile/photo/crop_head.tpl
+++ b/view/templates/settings/profile/photo/crop_head.tpl
@@ -1,2 +1,2 @@
-<script type="text/javascript" src="view/asset/cropperjs/dist/cropper.min.js"></script>
-<link rel="stylesheet" href="view/asset/cropperjs/dist/cropper.min.css" type="text/css" />
+<script type="text/javascript" src="view/asset/cropperjs/dist/cropper.min.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>
+<link rel="stylesheet" href="view/asset/cropperjs/dist/cropper.min.css?v={{$smarty.const.FRIENDICA_VERSION}}" type="text/css" />

--- a/view/theme/duepuntozero/templates/theme_settings.tpl
+++ b/view/theme/duepuntozero/templates/theme_settings.tpl
@@ -1,4 +1,4 @@
-<script src="{{$baseurl}}/view/theme/quattro/jquery.tools.min.js"></script>
+<script src="{{$baseurl}}/view/theme/quattro/jquery.tools.min.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>
 
 {{include file="field_select.tpl" field=$colorset}} 
 

--- a/view/theme/frio/templates/admin/blocklist/contact.tpl
+++ b/view/theme/frio/templates/admin/blocklist/contact.tpl
@@ -1,5 +1,5 @@
-<script type="text/javascript" src="view/theme/frio/js/mod_admin.js"></script>
-<link rel="stylesheet" href="view/theme/frio/css/mod_admin.css" type="text/css" media="screen"/>
+<script type="text/javascript" src="view/theme/frio/js/mod_admin.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>
+<link rel="stylesheet" href="view/theme/frio/css/mod_admin.css?v={{$smarty.const.FRIENDICA_VERSION}}" type="text/css" media="screen"/>
 
 <div id="admin-contactblock" class="adminpage generic-page-wrapper">
 	<h1>{{$title}} - {{$page}}</h1>

--- a/view/theme/frio/templates/admin/site.tpl
+++ b/view/theme/frio/templates/admin/site.tpl
@@ -18,7 +18,7 @@
 		});
 	});
 </script>
-<link rel="stylesheet" href="view/theme/frio/css/mod_admin.css" type="text/css" media="screen"/>
+<link rel="stylesheet" href="view/theme/frio/css/mod_admin.css?v={{$smarty.const.FRIENDICA_VERSION}}" type="text/css" media="screen"/>
 
 <div id='adminpage' class="adminpage generic-page-wrapper">
 	<h1>{{$title}} - {{$page}}</h1>

--- a/view/theme/frio/templates/admin/users.tpl
+++ b/view/theme/frio/templates/admin/users.tpl
@@ -1,5 +1,5 @@
-<script type="text/javascript" src="view/theme/frio/js/mod_admin.js"></script>
-<link rel="stylesheet" href="view/theme/frio/css/mod_admin.css" type="text/css" media="screen"/>
+<script type="text/javascript" src="view/theme/frio/js/mod_admin.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>
+<link rel="stylesheet" href="view/theme/frio/css/mod_admin.css?v={{$smarty.const.FRIENDICA_VERSION}}" type="text/css" media="screen"/>
 
 <div id="admin-users" class="adminpage generic-page-wrapper">
 	<h1>{{$title}} - {{$page}}</h1>

--- a/view/theme/frio/templates/contacts-head.tpl
+++ b/view/theme/frio/templates/contacts-head.tpl
@@ -1,2 +1,2 @@
 
-<script type="text/javascript" src="view/theme/frio/js/mod_contacts.js"></script>
+<script type="text/javascript" src="view/theme/frio/js/mod_contacts.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>

--- a/view/theme/frio/templates/event_form.tpl
+++ b/view/theme/frio/templates/event_form.tpl
@@ -1,5 +1,5 @@
 
-<script type="text/javascript" src="{{$baseurl}}/view/theme/frio/js/event_edit.js"></script>
+<script type="text/javascript" src="{{$baseurl}}/view/theme/frio/js/event_edit.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>
 
 <div id="event-form-wrapper">
 	<h3 class="heading">{{$title}}</h3>

--- a/view/theme/frio/templates/event_head.tpl
+++ b/view/theme/frio/templates/event_head.tpl
@@ -1,10 +1,10 @@
 
-<link rel="stylesheet" type="text/css" href="{{$baseurl}}/view/asset/fullcalendar/dist/fullcalendar.min.css" />
-<link rel="stylesheet" type="text/css" href="{{$baseurl}}/view/asset/fullcalendar/dist/fullcalendar.print.min.css" media="print" />
-<link rel="stylesheet" type="text/css" href="view/theme/frio/css/mod_events.css" />
-<script type="text/javascript" src="{{$baseurl}}/view/asset/moment/min/moment-with-locales.min.js"></script>
-<script type="text/javascript" src="{{$baseurl}}/view/asset/fullcalendar/dist/fullcalendar.min.js"></script>
-<script type="text/javascript" src="view/theme/frio/js/mod_events.js"></script>
+<link rel="stylesheet" type="text/css" href="{{$baseurl}}/view/asset/fullcalendar/dist/fullcalendar.min.css?v={{$smarty.const.FRIENDICA_VERSION}}" />
+<link rel="stylesheet" type="text/css" href="{{$baseurl}}/view/asset/fullcalendar/dist/fullcalendar.print.min.css?v={{$smarty.const.FRIENDICA_VERSION}}" media="print" />
+<link rel="stylesheet" type="text/css" href="view/theme/frio/css/mod_events.css?v={{$smarty.const.FRIENDICA_VERSION}}" />
+<script type="text/javascript" src="{{$baseurl}}/view/asset/moment/min/moment-with-locales.min.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>
+<script type="text/javascript" src="{{$baseurl}}/view/asset/fullcalendar/dist/fullcalendar.min.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>
+<script type="text/javascript" src="view/theme/frio/js/mod_events.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>
 
 <script type="text/javascript">
 	// pass php translation strings to js variables/arrays so we can make use of it in js files

--- a/view/theme/frio/templates/group_edit.tpl
+++ b/view/theme/frio/templates/group_edit.tpl
@@ -3,7 +3,7 @@
     add or remove contacts to the contact group.
 *}}
 
-<script type="text/javascript" src="view/theme/frio/js/mod_group.js"></script>
+<script type="text/javascript" src="view/theme/frio/js/mod_group.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>
 
 <div class="generic-page-wrapper">
 	{{if $editable == 1}}

--- a/view/theme/frio/templates/head.tpl
+++ b/view/theme/frio/templates/head.tpl
@@ -7,31 +7,31 @@
 <meta name="viewport" content="initial-scale=1.0">
 
 {{* All needed css files - Note: css must be inserted before js files *}}
-<link rel="stylesheet" href="view/global.css" type="text/css" media="all" />
-<link rel="stylesheet" href="view/asset/jquery-colorbox/example5/colorbox.css" type="text/css" media="screen" />
-<link rel="stylesheet" href="view/asset/jgrowl/jquery.jgrowl.min.css" type="text/css" media="screen" />
-<link rel="stylesheet" href="view/asset/jquery-datetimepicker/build/jquery.datetimepicker.min.css" type="text/css" media="screen" />
-<link rel="stylesheet" href="view/asset/perfect-scrollbar/css/perfect-scrollbar.min.css" type="text/css" media="screen" />
+<link rel="stylesheet" href="view/global.css?v={{$smarty.const.FRIENDICA_VERSION}}" type="text/css" media="all" />
+<link rel="stylesheet" href="view/asset/jquery-colorbox/example5/colorbox.css?v={{$smarty.const.FRIENDICA_VERSION}}" type="text/css" media="screen" />
+<link rel="stylesheet" href="view/asset/jgrowl/jquery.jgrowl.min.css?v={{$smarty.const.FRIENDICA_VERSION}}" type="text/css" media="screen" />
+<link rel="stylesheet" href="view/asset/jquery-datetimepicker/build/jquery.datetimepicker.min.css?v={{$smarty.const.FRIENDICA_VERSION}}" type="text/css" media="screen" />
+<link rel="stylesheet" href="view/asset/perfect-scrollbar/css/perfect-scrollbar.min.css?v={{$smarty.const.FRIENDICA_VERSION}}" type="text/css" media="screen" />
 
-<link rel="stylesheet" href="view/theme/frio/frameworks/bootstrap/css/bootstrap.min.css" type="text/css" media="screen"/>
-<link rel="stylesheet" href="view/theme/frio/frameworks/bootstrap/css/bootstrap-theme.min.css" type="text/css" media="screen"/>
-<link rel="stylesheet" href="view/asset/fork-awesome/css/fork-awesome.min.css" type="text/css" media="screen"/>
-<link rel="stylesheet" href="view/theme/frio/frameworks/jasny/css/jasny-bootstrap.min.css" type="text/css" media="screen"/>
-<link rel="stylesheet" href="view/theme/frio/frameworks/bootstrap-select/css/bootstrap-select.min.css" type="text/css" media="screen"/>
-<link rel="stylesheet" href="view/theme/frio/frameworks/ekko-lightbox/ekko-lightbox.min.css" type="text/css" media="screen"/>
-<link rel="stylesheet" href="view/theme/frio/frameworks/awesome-bootstrap-checkbox/awesome-bootstrap-checkbox.css" type="text/css" media="screen"/>
-<link rel="stylesheet" href="view/theme/frio/frameworks/justifiedGallery/justifiedGallery.min.css" type="text/css" media="screen"/>
-<link rel="stylesheet" href="view/theme/frio/frameworks/bootstrap-colorpicker/css/bootstrap-colorpicker.min.css" type="text/css" media="screen"/>
-<link rel="stylesheet" href="view/theme/frio/frameworks/bootstrap-toggle/css/bootstrap-toggle.min.css" type="text/css" media="screen"/>
-<link rel="stylesheet" href="view/theme/frio/font/open_sans/open-sans.css" type="text/css" media="screen"/>
+<link rel="stylesheet" href="view/theme/frio/frameworks/bootstrap/css/bootstrap.min.css?v={{$smarty.const.FRIENDICA_VERSION}}" type="text/css" media="screen"/>
+<link rel="stylesheet" href="view/theme/frio/frameworks/bootstrap/css/bootstrap-theme.min.css?v={{$smarty.const.FRIENDICA_VERSION}}" type="text/css" media="screen"/>
+<link rel="stylesheet" href="view/asset/fork-awesome/css/fork-awesome.min.css?v={{$smarty.const.FRIENDICA_VERSION}}" type="text/css" media="screen"/>
+<link rel="stylesheet" href="view/theme/frio/frameworks/jasny/css/jasny-bootstrap.min.css?v={{$smarty.const.FRIENDICA_VERSION}}" type="text/css" media="screen"/>
+<link rel="stylesheet" href="view/theme/frio/frameworks/bootstrap-select/css/bootstrap-select.min.css?v={{$smarty.const.FRIENDICA_VERSION}}" type="text/css" media="screen"/>
+<link rel="stylesheet" href="view/theme/frio/frameworks/ekko-lightbox/ekko-lightbox.min.css?v={{$smarty.const.FRIENDICA_VERSION}}" type="text/css" media="screen"/>
+<link rel="stylesheet" href="view/theme/frio/frameworks/awesome-bootstrap-checkbox/awesome-bootstrap-checkbox.css?v={{$smarty.const.FRIENDICA_VERSION}}" type="text/css" media="screen"/>
+<link rel="stylesheet" href="view/theme/frio/frameworks/justifiedGallery/justifiedGallery.min.css?v={{$smarty.const.FRIENDICA_VERSION}}" type="text/css" media="screen"/>
+<link rel="stylesheet" href="view/theme/frio/frameworks/bootstrap-colorpicker/css/bootstrap-colorpicker.min.css?v={{$smarty.const.FRIENDICA_VERSION}}" type="text/css" media="screen"/>
+<link rel="stylesheet" href="view/theme/frio/frameworks/bootstrap-toggle/css/bootstrap-toggle.min.css?v={{$smarty.const.FRIENDICA_VERSION}}" type="text/css" media="screen"/>
+<link rel="stylesheet" href="view/theme/frio/font/open_sans/open-sans.css?v={{$smarty.const.FRIENDICA_VERSION}}" type="text/css" media="screen"/>
 
 {{foreach $stylesheets as $stylesheetUrl}}
 <link rel="stylesheet" href="{{$stylesheetUrl}}" type="text/css" media="screen" />
 {{/foreach}}
 
 {{* own css files *}}
-<link rel="stylesheet" href="view/theme/frio/css/hovercard.css" type="text/css" media="screen"/>
-<link rel="stylesheet" href="view/theme/frio/css/font-awesome.custom.css" type="text/css" media="screen"/>
+<link rel="stylesheet" href="view/theme/frio/css/hovercard.css?v={{$smarty.const.FRIENDICA_VERSION}}" type="text/css" media="screen"/>
+<link rel="stylesheet" href="view/theme/frio/css/font-awesome.custom.css?v={{$smarty.const.FRIENDICA_VERSION}}" type="text/css" media="screen"/>
 
 <link rel="shortcut icon" href="{{$shortcut_icon}}" />
 <link rel="apple-touch-icon" href="{{$touch_icon}}"/>
@@ -51,40 +51,40 @@
 
 {{* The js files we use *}}
 <!--[if IE]>
-<script type="text/javascript" src="https://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
+<script type="text/javascript" src="https://html5shiv.googlecode.com/svn/trunk/html5.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>
 <![endif]-->
-<script type="text/javascript" src="view/js/modernizr.js"></script>
-<script type="text/javascript" src="view/asset/jquery/dist/jquery.min.js"></script>
-<script type="text/javascript" src="view/js/jquery.textinputs.js"></script>
-<script type="text/javascript" src="view/js/jquery-textcomplete/jquery.textcomplete.min.js"></script>
-<script type="text/javascript" src="view/js/autocomplete.js"></script>
-<script type="text/javascript" src="view/asset/jquery-colorbox/jquery.colorbox-min.js"></script>
-<script type="text/javascript" src="view/asset/jgrowl/jquery.jgrowl.min.js"></script>
-<script type="text/javascript" src="view/asset/jquery-datetimepicker/build/jquery.datetimepicker.full.min.js"></script>
-<script type="text/javascript" src="view/asset/perfect-scrollbar/js/perfect-scrollbar.jquery.min.js"></script>
-<script type="text/javascript" src="view/asset/imagesloaded/imagesloaded.pkgd.min.js"></script>
-<script type="text/javascript" src="view/asset/base64/base64.min.js"></script>
-<script type="text/javascript" src="view/asset/dompurify/dist/purify.min.js"></script>
-<script type="text/javascript" src="view/js/main.js"></script>
+<script type="text/javascript" src="view/js/modernizr.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>
+<script type="text/javascript" src="view/asset/jquery/dist/jquery.min.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>
+<script type="text/javascript" src="view/js/jquery.textinputs.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>
+<script type="text/javascript" src="view/js/jquery-textcomplete/jquery.textcomplete.min.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>
+<script type="text/javascript" src="view/js/autocomplete.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>
+<script type="text/javascript" src="view/asset/jquery-colorbox/jquery.colorbox-min.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>
+<script type="text/javascript" src="view/asset/jgrowl/jquery.jgrowl.min.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>
+<script type="text/javascript" src="view/asset/jquery-datetimepicker/build/jquery.datetimepicker.full.min.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>
+<script type="text/javascript" src="view/asset/perfect-scrollbar/js/perfect-scrollbar.jquery.min.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>
+<script type="text/javascript" src="view/asset/imagesloaded/imagesloaded.pkgd.min.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>
+<script type="text/javascript" src="view/asset/base64/base64.min.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>
+<script type="text/javascript" src="view/asset/dompurify/dist/purify.min.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>
+<script type="text/javascript" src="view/js/main.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>
 
-<script type="text/javascript" src="view/theme/frio/frameworks/bootstrap/js/bootstrap.min.js"></script>
-<script type="text/javascript" src="view/theme/frio/frameworks/jasny/js/jasny-bootstrap.custom.js"></script>
-<script type="text/javascript" src="view/theme/frio/frameworks/bootstrap-select/js/bootstrap-select.min.js"></script>
-<script type="text/javascript" src="view/theme/frio/frameworks/ekko-lightbox/ekko-lightbox.min.js"></script>
-<script type="text/javascript" src="view/theme/frio/frameworks/justifiedGallery/jquery.justifiedGallery.min.js"></script>
-<script type="text/javascript" src="view/theme/frio/frameworks/bootstrap-colorpicker/js/bootstrap-colorpicker.min.js"></script>
-<script type="text/javascript" src="view/theme/frio/frameworks/flexMenu/flexmenu.custom.js"></script>
-<script type="text/javascript" src="view/theme/frio/frameworks/jquery-scrollspy/jquery-scrollspy.js"></script>
-<script type="text/javascript" src="view/theme/frio/frameworks/autosize/autosize.min.js"></script>
-<script type="text/javascript" src="view/theme/frio/frameworks/sticky-kit/jquery.sticky-kit.min.js"></script>
+<script type="text/javascript" src="view/theme/frio/frameworks/bootstrap/js/bootstrap.min.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>
+<script type="text/javascript" src="view/theme/frio/frameworks/jasny/js/jasny-bootstrap.custom.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>
+<script type="text/javascript" src="view/theme/frio/frameworks/bootstrap-select/js/bootstrap-select.min.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>
+<script type="text/javascript" src="view/theme/frio/frameworks/ekko-lightbox/ekko-lightbox.min.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>
+<script type="text/javascript" src="view/theme/frio/frameworks/justifiedGallery/jquery.justifiedGallery.min.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>
+<script type="text/javascript" src="view/theme/frio/frameworks/bootstrap-colorpicker/js/bootstrap-colorpicker.min.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>
+<script type="text/javascript" src="view/theme/frio/frameworks/flexMenu/flexmenu.custom.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>
+<script type="text/javascript" src="view/theme/frio/frameworks/jquery-scrollspy/jquery-scrollspy.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>
+<script type="text/javascript" src="view/theme/frio/frameworks/autosize/autosize.min.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>
+<script type="text/javascript" src="view/theme/frio/frameworks/sticky-kit/jquery.sticky-kit.min.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>
 
 {{* own js files *}}
-<script type="text/javascript" src="view/theme/frio/js/theme.js"></script>
-<script type="text/javascript" src="view/theme/frio/js/modal.js"></script>
+<script type="text/javascript" src="view/theme/frio/js/theme.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>
+<script type="text/javascript" src="view/theme/frio/js/modal.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>
 {{if ! $block_public}}
-<script type="text/javascript" src="view/theme/frio/js/hovercard.js"></script>
+<script type="text/javascript" src="view/theme/frio/js/hovercard.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>
 {{/if}}
-<script type="text/javascript" src="view/theme/frio/js/textedit.js"></script>
+<script type="text/javascript" src="view/theme/frio/js/textedit.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>
 
 {{* Include the strings which are needed for some js functions (e.g. translation)
 They are loaded into the html <head> so that js functions can use them *}}

--- a/view/theme/frio/templates/jot-header.tpl
+++ b/view/theme/frio/templates/jot-header.tpl
@@ -1,7 +1,7 @@
 
-<script type="text/javascript" src="{{$baseurl}}/view/js/ajaxupload.js"></script>
-<script type="text/javascript" src="{{$baseurl}}/view/js/linkPreview.js"></script>
-<script type="text/javascript" src="{{$baseurl}}/view/theme/frio/js/jot.js"></script>
+<script type="text/javascript" src="{{$baseurl}}/view/js/ajaxupload.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>
+<script type="text/javascript" src="{{$baseurl}}/view/js/linkPreview.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>
+<script type="text/javascript" src="{{$baseurl}}/view/theme/frio/js/jot.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>
 
 <script type="text/javascript">
 	var editor = false;

--- a/view/theme/frio/templates/notifications/notifications.tpl
+++ b/view/theme/frio/templates/notifications/notifications.tpl
@@ -1,5 +1,5 @@
-<script type="text/javascript" src="../../frameworks/jquery-color/jquery.color.js"></script>
-<script type="text/javascript" src="../../js/mod_notifications.js"></script>
+<script type="text/javascript" src="../../frameworks/jquery-color/jquery.color.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>
+<script type="text/javascript" src="../../js/mod_notifications.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>
 
 <div class="generic-page-wrapper">
 	{{include file="section_title.tpl" title=$header}}

--- a/view/theme/frio/templates/photos_head.tpl
+++ b/view/theme/frio/templates/photos_head.tpl
@@ -1,5 +1,5 @@
 
-<script type="text/javascript" src="view/theme/frio/js/mod_photos.js"></script>
+<script type="text/javascript" src="view/theme/frio/js/mod_photos.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>
 <script type="text/javascript">
 	var ispublic = "{{$ispublic nofilter}}";
 </script>

--- a/view/theme/frio/templates/theme_settings.tpl
+++ b/view/theme/frio/templates/theme_settings.tpl
@@ -1,5 +1,5 @@
-<script src="{{$baseurl}}/view/theme/quattro/jquery.tools.min.js"></script>
-<script type="text/javascript" src="{{$baseurl}}/view/js/ajaxupload.js" ></script>
+<script src="{{$baseurl}}/view/theme/quattro/jquery.tools.min.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>
+<script type="text/javascript" src="{{$baseurl}}/view/js/ajaxupload.js?v={{$smarty.const.FRIENDICA_VERSION}}" ></script>
 
 {{include file="field_select.tpl" field=$scheme}}
 

--- a/view/theme/frio/templates/threaded_conversation.tpl
+++ b/view/theme/frio/templates/threaded_conversation.tpl
@@ -1,5 +1,5 @@
-<script type="text/javascript" src="view/theme/frio/frameworks/jquery-color/jquery.color.js"></script>
-{{if $mode == display}}<script type="text/javascript" src="view/theme/frio/js/mod_display.js"></script>{{/if}}
+<script type="text/javascript" src="view/theme/frio/frameworks/jquery-color/jquery.color.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>
+{{if $mode == display}}<script type="text/javascript" src="view/theme/frio/js/mod_display.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>{{/if}}
 
 {{$live_update nofilter}}
 

--- a/view/theme/quattro/templates/events_reminder.tpl
+++ b/view/theme/quattro/templates/events_reminder.tpl
@@ -1,8 +1,8 @@
 
-<link rel="stylesheet" type="text/css" href="{{$baseurl}}/view/asset/fullcalendar/dist/fullcalendar.min.css" />
-<link rel="stylesheet" type="text/css" href="{{$baseurl}}/view/asset/fullcalendar/dist/fullcalendar.print.min.css" />
-<script type="text/javascript" src="{{$baseurl}}/view/asset/moment/min/moment-with-locales.min.js"></script>
-<script type="text/javascript" src="{{$baseurl}}/view/asset/fullcalendar/dist/fullcalendar.min.js"></script>
+<link rel="stylesheet" type="text/css" href="{{$baseurl}}/view/asset/fullcalendar/dist/fullcalendar.min.css?v={{$smarty.const.FRIENDICA_VERSION}}" />
+<link rel="stylesheet" type="text/css" href="{{$baseurl}}/view/asset/fullcalendar/dist/fullcalendar.print.min.css?v={{$smarty.const.FRIENDICA_VERSION}}" />
+<script type="text/javascript" src="{{$baseurl}}/view/asset/moment/min/moment-with-locales.min.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>
+<script type="text/javascript" src="{{$baseurl}}/view/asset/fullcalendar/dist/fullcalendar.min.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>
 <script>
 	// start calendar from yesterday
 	var yesterday= new Date()

--- a/view/theme/quattro/templates/theme_settings.tpl
+++ b/view/theme/quattro/templates/theme_settings.tpl
@@ -1,4 +1,4 @@
- <script src="{{$baseurl}}/view/theme/quattro/jquery.tools.min.js"></script>
+ <script src="{{$baseurl}}/view/theme/quattro/jquery.tools.min.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>
  
 {{include file="field_select.tpl" field=$color}}
 

--- a/view/theme/smoothly/templates/bottom.tpl
+++ b/view/theme/smoothly/templates/bottom.tpl
@@ -1,5 +1,5 @@
 
-<script type="text/javascript" src="{{$baseurl}}/view/theme/smoothly/js/jquery.autogrow.textarea.js"></script>
+<script type="text/javascript" src="{{$baseurl}}/view/theme/smoothly/js/jquery.autogrow.textarea.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>
 <script type="text/javascript">
 function tautogrow(id) {
 	$("textarea#comment-edit-text-" + id).autogrow();

--- a/view/theme/smoothly/templates/jot-header.tpl
+++ b/view/theme/smoothly/templates/jot-header.tpl
@@ -48,7 +48,7 @@ function enableOnUser(){
 
 </script>
 
-<script type="text/javascript" src="view/js/ajaxupload.js" >
+<script type="text/javascript" src="view/js/ajaxupload.js?v={{$smarty.const.FRIENDICA_VERSION}}" >
 </script>
 
 <script>

--- a/view/theme/vier/templates/event_head.tpl
+++ b/view/theme/vier/templates/event_head.tpl
@@ -1,8 +1,8 @@
 
-<link rel="stylesheet" type="text/css" href="{{$baseurl}}/view/asset/fullcalendar/dist/fullcalendar.min.css" />
-<link rel="stylesheet" type="text/css" href="{{$baseurl}}/view/asset/fullcalendar/dist/fullcalendar.print.min.css" media="print" />
-<script type="text/javascript" src="{{$baseurl}}/view/asset/moment/min/moment-with-locales.min.js"></script>
-<script type="text/javascript" src="{{$baseurl}}/view/asset/fullcalendar/dist/fullcalendar.min.js"></script>
+<link rel="stylesheet" type="text/css" href="{{$baseurl}}/view/asset/fullcalendar/dist/fullcalendar.min.css?v={{$smarty.const.FRIENDICA_VERSION}}" />
+<link rel="stylesheet" type="text/css" href="{{$baseurl}}/view/asset/fullcalendar/dist/fullcalendar.print.min.css?v={{$smarty.const.FRIENDICA_VERSION}}" media="print" />
+<script type="text/javascript" src="{{$baseurl}}/view/asset/moment/min/moment-with-locales.min.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>
+<script type="text/javascript" src="{{$baseurl}}/view/asset/fullcalendar/dist/fullcalendar.min.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>
 
 <script>
 	function showEvent(eventid) {


### PR DESCRIPTION
This PR will prevent numerous support requests where people need to clear their cache after a release.

Effectively, it updates the path of all scripts and stylesheet when we change the Friendica version number, which happens only on release and when we branch the release candidate.

Additionally, it will enable new scripts and styles on devices where clearing the browser cache is  inconvenient (looking at you iOS Safari).