### PR TITLE
AP comments from GNU Social are now working

### DIFF
--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -3745,6 +3745,36 @@ class Item
 	}
 
 	/**
+	 * Return the URI for a link to the post 
+	 * 
+	 * @param string $uri URI or link to post
+	 *
+	 * @return string URI
+	 */
+	public static function getURIByLink(string $uri)
+	{
+		$ssl_uri = str_replace('http://', 'https://', $uri);
+		$uris = [$uri, $ssl_uri, Strings::normaliseLink($uri)];
+
+		$item = DBA::selectFirst('item', ['uri'], ['uri' => $uris]);
+		if (DBA::isResult($item)) {
+			return $item['uri'];
+		}
+
+		$itemcontent = DBA::selectFirst('item-content', ['uri-id'], ['plink' => $uris]);
+		if (!DBA::isResult($itemcontent)) {
+			return '';
+		}
+
+		$itemuri = DBA::selectFirst('item-uri', ['uri'], ['id' => $itemcontent['uri-id']]);
+		if (DBA::isResult($itemuri)) {
+			return $itemuri['uri'];
+		}
+
+		return '';
+	}
+
+	/**
 	 * Fetches item for given URI or plink
 	 *
 	 * @param string $uri

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -181,7 +181,7 @@ class Processor
 		}
 
 		if (empty($activity['directmessage']) && ($activity['id'] != $activity['reply-to-id']) && !Item::exists(['uri' => $activity['reply-to-id']])) {
-			Logger::log('Parent ' . $activity['reply-to-id'] . ' not found. Try to refetch it.');
+			Logger::notice('Parent not found. Try to refetch it.', ['parent' => $activity['reply-to-id']]);
 			self::fetchMissingActivity($activity['reply-to-id'], $activity);
 		}
 


### PR DESCRIPTION
GNU Social don't uses the "id" field but the "url" field from the post as a reference for their comments. This is a bug, but since you should be liberal in what you accept, we now have a special treatment for this.