### PR TITLE
Force avatar update for Contact Advanced page

### DIFF
--- a/src/Module/Contact/Advanced.php
+++ b/src/Module/Contact/Advanced.php
@@ -68,7 +68,7 @@ class Advanced extends BaseModule
 		if ($photo) {
 			DI::logger()->notice('Updating photo.', ['photo' => $photo]);
 
-			Model\Contact::updateAvatar($photo, local_user(), $contact['id']);
+			Model\Contact::updateAvatar($photo, local_user(), $contact['id'], true);
 		}
 
 		if ($r) {


### PR DESCRIPTION
Now a new avatar photo REALLY gets overwritten in the contact advanced page