### PR TITLE
Changed statistics query for nodeinfo

### DIFF
--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -1111,16 +1111,13 @@ class User
 
 		$userStmt = DBA::p("SELECT `user`.`uid`, `user`.`login_date`, `contact`.`last-item`
 			FROM `user`
-			INNER JOIN `profile` ON `profile`.`uid` = `user`.`uid`
 			INNER JOIN `contact` ON `contact`.`uid` = `user`.`uid` AND `contact`.`self`
 			WHERE `user`.`verified`
 				AND `user`.`login_date` > ?
-				AND `user`.`account-type` != ?
 				AND NOT `user`.`blocked`
 				AND NOT `user`.`account_removed`
 				AND NOT `user`.`account_expired`",
-				DBA::NULL_DATETIME,
-				self::ACCOUNT_TYPE_COMMUNITY
+				DBA::NULL_DATETIME
 		);
 
 		if (!DBA::isResult($userStmt)) {

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -1113,9 +1113,15 @@ class User
 			FROM `user`
 			INNER JOIN `profile` ON `profile`.`uid` = `user`.`uid`
 			INNER JOIN `contact` ON `contact`.`uid` = `user`.`uid` AND `contact`.`self`
-			WHERE `user`.`verified` AND `user`.`login_date` > '0001-01-01' AND NOT `user`.`account-type` = 3
-				AND NOT `user`.`blocked` AND NOT `user`.`account_removed`
-				AND NOT `user`.`account_expired`");
+			WHERE `user`.`verified`
+				AND `user`.`login_date` > ?
+				AND `user`.`account-type` != ?
+				AND NOT `user`.`blocked`
+				AND NOT `user`.`account_removed`
+				AND NOT `user`.`account_expired`",
+				DBA::NULL_DATETIME,
+				self::ACCOUNT_TYPE_COMMUNITY
+		);
 
 		if (!DBA::isResult($userStmt)) {
 			return $statistics;

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -1113,7 +1113,7 @@ class User
 			FROM `user`
 			INNER JOIN `profile` ON `profile`.`uid` = `user`.`uid`
 			INNER JOIN `contact` ON `contact`.`uid` = `user`.`uid` AND `contact`.`self`
-			WHERE (`profile`.`publish` OR `profile`.`net-publish`) AND `user`.`verified`
+			WHERE `user`.`verified` AND `user`.`login_date` > '0001-01-01' AND NOT `user`.`account-type` = 3
 				AND NOT `user`.`blocked` AND NOT `user`.`account_removed`
 				AND NOT `user`.`account_expired`");
 


### PR DESCRIPTION
There it is. :-)
I removed the 'published to directories' condition and added a check for 'user has logged in at least once'. This is done by a 'greater than 0001-01-01' comparison. It works but maybe there is a more elegant way.
~~I also excluded community accounts (forums) from the user count.~~ I am very sure someone suggested this but I cannot find it anymore. I know this is debatable. Please comment.

So, with that change we count all valid users accounts that have at least logged in once ~~but are no forums~~.

Please comment, like and share. ;-)

Fixes #8202