### PR TITLE
Use profile.about for profile description

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -1,6 +1,6 @@
 -- ------------------------------------------
 -- Friendica 2020.03-dev (Dalmatian Bellflower)
--- DB_UPDATE_VERSION 1332
+-- DB_UPDATE_VERSION 1333
 -- ------------------------------------------
 
 
@@ -999,7 +999,7 @@ CREATE TABLE IF NOT EXISTS `profile` (
 	`is-default` boolean COMMENT 'Deprecated',
 	`hide-friends` boolean NOT NULL DEFAULT '0' COMMENT 'Hide friend list from viewers of this profile',
 	`name` varchar(255) NOT NULL DEFAULT '' COMMENT '',
-	`pdesc` varchar(255) NOT NULL DEFAULT '' COMMENT 'Title or description',
+	`pdesc` varchar(255) COMMENT 'Deprecated',
 	`dob` varchar(32) NOT NULL DEFAULT '0000-00-00' COMMENT 'Day of birth',
 	`address` varchar(255) NOT NULL DEFAULT '' COMMENT '',
 	`locality` varchar(255) NOT NULL DEFAULT '' COMMENT '',
@@ -1018,7 +1018,7 @@ CREATE TABLE IF NOT EXISTS `profile` (
 	`prv_keywords` text COMMENT '',
 	`likes` text COMMENT 'Deprecated',
 	`dislikes` text COMMENT 'Deprecated',
-	`about` text COMMENT 'Deprecated',
+	`about` text COMMENT 'Profile description',
 	`summary` varchar(255) COMMENT 'Deprecated',
 	`music` text COMMENT 'Deprecated',
 	`book` text COMMENT 'Deprecated',

--- a/doc/database/db_profile.md
+++ b/doc/database/db_profile.md
@@ -9,7 +9,7 @@ Table profile
 | is-default   | Mark this profile as default profile          | tinyint(1)   | NO   |     | 0                   |                |
 | hide-friends | Hide friend list from viewers of this profile | tinyint(1)   | NO   |     | 0                   |                |
 | name         |                                               | varchar(255) | NO   |     |                     |                |
-| pdesc        | Title or description                          | varchar(255) | NO   |     |                     |                |
+| pdesc        | Deprecated                                    | varchar(255) | NO   |     |                     |                |
 | dob          | Day of birth                                  | varchar(32)  | NO   |     | 0001-01-01          |                |
 | address      |                                               | varchar(255) | NO   |     |                     |                |
 | locality     |                                               | varchar(255) | NO   |     |                     |                |
@@ -28,7 +28,7 @@ Table profile
 | prv_keywords |                                               | text         | NO   |     | NULL                |                |
 | likes        | Deprecated                                    | text         | NO   |     | NULL                |                |
 | dislikes     | Deprecated                                    | text         | NO   |     | NULL                |                |
-| about        | Deprecated                                    | text         | NO   |     | NULL                |                |
+| about        | Profile description                           | text         | NO   |     |                     |                |
 | summary      | Deprecated                                    | varchar(255) | NO   |     |                     |                |
 | music        | Deprecated                                    | text         | NO   |     | NULL                |                |
 | book         | Deprecated                                    | text         | NO   |     | NULL                |                |

--- a/mod/cal.php
+++ b/mod/cal.php
@@ -59,9 +59,9 @@ function cal_init(App $a)
 	$vcard_widget = Renderer::replaceMacros($tpl, [
 		'$name' => $profile['name'],
 		'$photo' => $profile['photo'],
-		'$addr' => (($profile['addr'] != "") ? $profile['addr'] : ""),
+		'$addr' => $profile['addr'] ?: '',
 		'$account_type' => $account_type,
-		'$pdesc' => (($profile['pdesc'] != "") ? $profile['pdesc'] : ""),
+		'$about' => $profile['about'] ?: '',
 	]);
 
 	$cal_widget = Widget\CalendarExport::getHTML();

--- a/mod/photos.php
+++ b/mod/photos.php
@@ -65,7 +65,7 @@ function photos_init(App $a) {
 			'$photo' => $profile['photo'],
 			'$addr' => $profile['addr'] ?? '',
 			'$account_type' => $account_type,
-			'$pdesc' => $profile['pdesc'] ?? '',
+			'$about' => $profile['about'] ?? '',
 		]);
 
 		$albums = Photo::getAlbums($a->data['user']['uid']);

--- a/mod/videos.php
+++ b/mod/videos.php
@@ -50,7 +50,7 @@ function videos_init(App $a)
 			'$photo' => $profile['photo'],
 			'$addr' => $profile['addr'] ?? '',
 			'$account_type' => $account_type,
-			'$pdesc' => $profile['pdesc'] ?? '',
+			'$about' => $profile['about'] ?? '',
 		]);
 
 		// If not there, create 'aside' empty

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -722,7 +722,7 @@ class Contact
 			return;
 		}
 
-		$fields = ['name', 'photo', 'thumb', 'pdesc' => 'about', 'address', 'locality', 'region',
+		$fields = ['name', 'photo', 'thumb', 'about', 'address', 'locality', 'region',
 			'country-name', 'pub_keywords', 'xmpp', 'net-publish'];
 		$profile = DBA::selectFirst('profile', $fields, ['uid' => $uid]);
 		if (!DBA::isResult($profile)) {

--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -899,7 +899,7 @@ class Profile
 				WHERE $publish AND NOT `user`.`blocked` AND NOT `user`.`account_removed`
 				AND ((`profile`.`name` LIKE ?) OR
 				(`user`.`nickname` LIKE ?) OR
-				(`profile`.`pdesc` LIKE ?) OR
+				(`profile`.`about` LIKE ?) OR
 				(`profile`.`locality` LIKE ?) OR
 				(`profile`.`region` LIKE ?) OR
 				(`profile`.`country-name` LIKE ?) OR
@@ -934,7 +934,7 @@ class Profile
 			WHERE $publish AND NOT `user`.`blocked` AND NOT `user`.`account_removed` AND `contact`.`self`
 			AND ((`profile`.`name` LIKE ?) OR
 				(`user`.`nickname` LIKE ?) OR
-				(`profile`.`pdesc` LIKE ?) OR
+				(`profile`.`about` LIKE ?) OR
 				(`profile`.`locality` LIKE ?) OR
 				(`profile`.`region` LIKE ?) OR
 				(`profile`.`country-name` LIKE ?) OR

--- a/src/Module/Api/Friendica/Profile/Show.php
+++ b/src/Module/Api/Friendica/Profile/Show.php
@@ -77,7 +77,7 @@ class Show extends BaseApi
 			'profile_thumb'    => $profile_row['thumb'],
 			'publish'          => $profile_row['publish'] ? true : false,
 			'net_publish'      => $profile_row['net-publish'] ? true : false,
-			'description'      => $profile_row['pdesc'],
+			'description'      => $profile_row['about'],
 			'date_of_birth'    => $profile_row['dob'],
 			'address'          => $profile_row['address'],
 			'city'             => $profile_row['locality'],

--- a/src/Module/Directory.php
+++ b/src/Module/Directory.php
@@ -105,7 +105,7 @@ class Directory extends BaseModule
 
 		$profile_link = $contact['profile_url'];
 
-		$pdesc = (($contact['pdesc']) ? $contact['pdesc'] . '<br />' : '');
+		$about = (($contact['about']) ? $contact['about'] . '<br />' : '');
 
 		$details = '';
 		if (strlen($contact['locality'])) {
@@ -157,7 +157,7 @@ class Directory extends BaseModule
 			'profile'      => $profile,
 			'location'     => $location_e,
 			'tags'         => $contact['pub_keywords'],
-			'pdesc'        => $pdesc,
+			'about'        => $about,
 			'homepage'     => $homepage,
 			'photo_menu'   => $photo_menu,
 

--- a/src/Module/NoScrape.php
+++ b/src/Module/NoScrape.php
@@ -112,7 +112,7 @@ class NoScrape extends BaseModule
 		$json_info['last-activity'] = date('o-W', $last_active);
 
 		//These are optional fields.
-		$profile_fields = ['pdesc', 'locality', 'region', 'postal-code', 'country-name'];
+		$profile_fields = ['about', 'locality', 'region', 'postal-code', 'country-name'];
 		foreach ($profile_fields as $field) {
 			if (!empty($a->profile[$field])) {
 				$json_info["$field"] = $a->profile[$field];

--- a/src/Module/Profile/Profile.php
+++ b/src/Module/Profile/Profile.php
@@ -136,8 +136,8 @@ class Profile extends BaseProfile
 			}
 		}
 
-		if ($a->profile['pdesc']) {
-			$basic_fields += self::buildField('pdesc', DI::l10n()->t('Description:'), HTML::toLink($a->profile['pdesc']));
+		if ($a->profile['about']) {
+			$basic_fields += self::buildField('about', DI::l10n()->t('Description:'), BBCode::convert($a->profile['about']));
 		}
 
 		if ($a->profile['xmpp']) {

--- a/src/Module/Settings/Profile/Index.php
+++ b/src/Module/Settings/Profile/Index.php
@@ -70,7 +70,7 @@ class Index extends BaseSettings
 
 		$namechanged = $profile['name'] != $name;
 
-		$pdesc = Strings::escapeTags(trim($_POST['pdesc']));
+		$about = Strings::escapeTags(trim($_POST['about']));
 		$address = Strings::escapeTags(trim($_POST['address']));
 		$locality = Strings::escapeTags(trim($_POST['locality']));
 		$region = Strings::escapeTags(trim($_POST['region']));
@@ -102,7 +102,7 @@ class Index extends BaseSettings
 			'profile',
 			[
 				'name'         => $name,
-				'pdesc'        => $pdesc,
+				'about'        => $about,
 				'dob'          => $dob,
 				'address'      => $address,
 				'locality'     => $locality,
@@ -254,7 +254,7 @@ class Index extends BaseSettings
 			'$baseurl' => DI::baseUrl()->get(true),
 			'$nickname' => $a->user['nickname'],
 			'$name' => ['name', DI::l10n()->t('Display name:'), $profile['name']],
-			'$pdesc' => ['pdesc', DI::l10n()->t('Title/Description:'), $profile['pdesc']],
+			'$about' => ['about', DI::l10n()->t('Description:'), $profile['about']],
 			'$dob' => Temporal::getDateofBirthField($profile['dob'], $a->user['timezone']),
 			'$hide_friends' => $hide_friends,
 			'$address' => ['address', DI::l10n()->t('Street Address:'), $profile['address']],

--- a/src/Repository/ProfileField.php
+++ b/src/Repository/ProfileField.php
@@ -263,7 +263,7 @@ class ProfileField extends BaseRepository
 			'religion'  => $this->l10n->t('Religious Views:'),
 			'likes'     => $this->l10n->t('Likes:'),
 			'dislikes'  => $this->l10n->t('Dislikes:'),
-			'about'     => $this->l10n->t('About:'),
+			'pdesc'     => $this->l10n->t('Title/Description:'),
 			'summary'   => $this->l10n->t('Summary'),
 			'music'     => $this->l10n->t('Musical interests'),
 			'book'      => $this->l10n->t('Books, literature'),

--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -34,7 +34,7 @@
 use Friendica\Database\DBA;
 
 if (!defined('DB_UPDATE_VERSION')) {
-	define('DB_UPDATE_VERSION', 1332);
+	define('DB_UPDATE_VERSION', 1333);
 }
 
 return [
@@ -1088,7 +1088,7 @@ return [
 			"is-default" => ["type" => "boolean", "comment" => "Deprecated"],
 			"hide-friends" => ["type" => "boolean", "not null" => "1", "default" => "0", "comment" => "Hide friend list from viewers of this profile"],
 			"name" => ["type" => "varchar(255)", "not null" => "1", "default" => "", "comment" => ""],
-			"pdesc" => ["type" => "varchar(255)", "not null" => "1", "default" => "", "comment" => "Title or description"],
+			"pdesc" => ["type" => "varchar(255)", "comment" => "Deprecated"],
 			"dob" => ["type" => "varchar(32)", "not null" => "1", "default" => "0000-00-00", "comment" => "Day of birth"],
 			"address" => ["type" => "varchar(255)", "not null" => "1", "default" => "", "comment" => ""],
 			"locality" => ["type" => "varchar(255)", "not null" => "1", "default" => "", "comment" => ""],
@@ -1107,7 +1107,7 @@ return [
 			"prv_keywords" => ["type" => "text", "comment" => ""],
 			"likes" => ["type" => "text", "comment" => "Deprecated"],
 			"dislikes" => ["type" => "text", "comment" => "Deprecated"],
-			"about" => ["type" => "text", "comment" => "Deprecated"],
+			"about" => ["type" => "text", "comment" => "Profile description"],
 			"summary" => ["type" => "varchar(255)", "comment" => "Deprecated"],
 			"music" => ["type" => "text", "comment" => "Deprecated"],
 			"book" => ["type" => "text", "comment" => "Deprecated"],

--- a/view/templates/profile/vcard.tpl
+++ b/view/templates/profile/vcard.tpl
@@ -5,7 +5,7 @@
 	
 	{{if $profile.addr}}<div class="p-addr">{{$profile.addr}}</div>{{/if}}
 	
-	{{if $profile.pdesc}}<div class="title">{{$profile.pdesc}}</div>{{/if}}
+	{{if $profile.about}}<div class="title">{{$profile.about}}</div>{{/if}}
 
 	{{if $profile.picdate}}
 		<div id="profile-photo-wrapper"><a href="{{$profile.url}}"><img class="photo u-photo" width="175" height="175" src="{{$profile.photo}}?rev={{$profile.picdate}}" alt="{{$profile.name}}"></a></div>

--- a/view/templates/settings/profile/index.tpl
+++ b/view/templates/settings/profile/index.tpl
@@ -20,11 +20,11 @@
 			<input type="text" size="32" name="name" id="profile-edit-name" value="{{$name.2}}"/>
 		</div>
 		<div id="profile-edit-name-end"></div>
-		<div id="profile-edit-pdesc-wrapper">
-			<label id="profile-edit-pdesc-label" for="profile-edit-pdesc">{{$pdesc.1}} </label>
-			<input type="text" size="32" name="pdesc" id="profile-edit-pdesc" value="{{$pdesc.1}}"/>
+		<div id="profile-edit-about-wrapper">
+			<label id="profile-edit-about-label" for="profile-edit-about">{{$about.1}} </label>
+			<input type="text" size="32" name="about" id="profile-edit-about" value="{{$about.1}}"/>
 		</div>
-		<div id="profile-edit-pdesc-end"></div>
+		<div id="profile-edit-about-end"></div>
 		<div id="profile-edit-dob-wrapper">
 			{{$dob nofilter}}
 		</div>

--- a/view/templates/widget/vcard.tpl
+++ b/view/templates/widget/vcard.tpl
@@ -2,7 +2,7 @@
 <div class="vcard h-card">
 	<div class="fn p-name">{{$name}}</div>
 	{{if $addr}}<div class="p-addr">{{$addr}}</div>{{/if}}
-	{{if $pdesc}}<div class="title p-job-title">{{$pdesc}}</div>{{/if}}
+	{{if $about}}<div class="title p-job-title">{{$about}}</div>{{/if}}
 	{{if $url}}
 	<div id="profile-photo-wrapper"><a href="{{$url}}"><img class="vcard-photo photo u-photo" style="width: 175px; height: 175px;" src="{{$photo}}" alt="{{$name}}" /></a></div>
 	{{else}}

--- a/view/theme/duepuntozero/style.css
+++ b/view/theme/duepuntozero/style.css
@@ -732,7 +732,7 @@ input#dfrn-url {
 
 #profile-edit-profile-name-label,
 #profile-edit-name-label,
-#profile-edit-pdesc-label,
+#profile-edit-about-label,
 #profile-edit-dob-label,
 #profile-edit-address-label,
 #profile-edit-locality-label,
@@ -748,7 +748,7 @@ input#dfrn-url {
 
 #profile-edit-profile-name,
 #profile-edit-name,
-#profile-edit-pdesc,
+#profile-edit-about,
 #profile-edit-dob,
 #profile-edit-address,
 #profile-edit-locality,
@@ -823,7 +823,7 @@ input#dfrn-url {
 }
 
 
-#profile-edit-pdesc-desc,
+#profile-edit-about-desc,
 #profile-edit-pubkeywords-desc,
 #profile-edit-prvkeywords-desc {
 	float: left;
@@ -855,7 +855,7 @@ input#dfrn-url {
 }
 
 #profile-edit-name-end,
-#profile-edit-pdesc-end,
+#profile-edit-about-end,
 #profile-edit-dob-end,
 #profile-edit-address-end,
 #profile-edit-locality-end,

--- a/view/theme/duepuntozero/templates/profile/vcard.tpl
+++ b/view/theme/duepuntozero/templates/profile/vcard.tpl
@@ -5,7 +5,7 @@
 	
 	{{if $profile.addr}}<div class="p-addr">{{$profile.addr}}</div>{{/if}}
 	
-	{{if $profile.pdesc}}<div class="title">{{$profile.pdesc}}</div>{{/if}}
+	{{if $profile.about}}<div class="title">{{$profile.about}}</div>{{/if}}
 	<div id="profile-photo-wrapper"><img class="photo u-photo" width="175" height="175" src="{{$profile.photo}}?rev={{$profile.picdate}}" alt="{{$profile.name}}"></div>
 
 	{{if $account_type}}<div class="account-type">{{$account_type}}</div>{{/if}}

--- a/view/theme/frio/templates/profile/vcard.tpl
+++ b/view/theme/frio/templates/profile/vcard.tpl
@@ -41,7 +41,7 @@
 
 			{{if $profile.addr}}<div class="p-addr">{{include file="sub/punct_wrap.tpl" text=$profile.addr}}</div>{{/if}}
 
-			{{if $profile.pdesc}}<div class="title">{{$profile.pdesc}}</div>{{/if}}
+			{{if $profile.about}}<div class="title">{{$profile.about}}</div>{{/if}}
 
 			{{if $account_type}}<div class="account-type">({{$account_type}})</div>{{/if}}
 		</div>

--- a/view/theme/frio/templates/settings/profile/index.tpl
+++ b/view/theme/frio/templates/settings/profile/index.tpl
@@ -62,7 +62,7 @@
 					<div class="section-content-tools-wrapper">
 						{{include file="field_input.tpl" field=$name}}
 
-						{{include file="field_input.tpl" field=$pdesc}}
+						{{include file="field_textarea.tpl" field=$about}}
 
 						{{$dob nofilter}}
 

--- a/view/theme/frio/templates/widget/vcard.tpl
+++ b/view/theme/frio/templates/widget/vcard.tpl
@@ -30,7 +30,7 @@
 
 			{{if $account_type}}<div class="account-type">({{$account_type}})</div>{{/if}}
 
-			{{if $pdesc}}<div class="title">{{$pdesc}}</div>{{/if}}
+			{{if $about}}<div class="title">{{$about}}</div>{{/if}}
 
 			{{if $network_link}}<dl class="network"><dt class="network-label">{{$network}}</dt><dd class="x-network">{{$network_link nofilter}}</dd></dl>{{/if}}
 		</div>

--- a/view/theme/quattro/dark/style.css
+++ b/view/theme/quattro/dark/style.css
@@ -1945,7 +1945,7 @@ ul.tabs li .active {
   padding: 7px;
 }
 #profile-edit-name-label,
-#profile-edit-pdesc-label,
+#profile-edit-about-label,
 #profile-edit-dob-label,
 #profile-edit-address-label,
 #profile-edit-locality-label,
@@ -1960,7 +1960,7 @@ ul.tabs li .active {
   padding-top: 7px;
 }
 #profile-edit-name,
-#profile-edit-pdesc,
+#profile-edit-about,
 #profile-edit-dob,
 #profile-edit-address,
 #profile-edit-locality,

--- a/view/theme/quattro/green/style.css
+++ b/view/theme/quattro/green/style.css
@@ -1945,7 +1945,7 @@ ul.tabs li .active {
   padding: 7px;
 }
 #profile-edit-name-label,
-#profile-edit-pdesc-label,
+#profile-edit-about-label,
 #profile-edit-dob-label,
 #profile-edit-address-label,
 #profile-edit-locality-label,
@@ -1960,7 +1960,7 @@ ul.tabs li .active {
   padding-top: 7px;
 }
 #profile-edit-name,
-#profile-edit-pdesc,
+#profile-edit-about,
 #profile-edit-dob,
 #profile-edit-address,
 #profile-edit-locality,

--- a/view/theme/quattro/lilac/style.css
+++ b/view/theme/quattro/lilac/style.css
@@ -1945,7 +1945,7 @@ ul.tabs li .active {
   padding: 7px;
 }
 #profile-edit-name-label,
-#profile-edit-pdesc-label,
+#profile-edit-about-label,
 #profile-edit-dob-label,
 #profile-edit-address-label,
 #profile-edit-locality-label,
@@ -1960,7 +1960,7 @@ ul.tabs li .active {
   padding-top: 7px;
 }
 #profile-edit-name,
-#profile-edit-pdesc,
+#profile-edit-about,
 #profile-edit-dob,
 #profile-edit-address,
 #profile-edit-locality,

--- a/view/theme/quattro/quattro.less
+++ b/view/theme/quattro/quattro.less
@@ -1238,7 +1238,7 @@ ul.tabs {
 	padding: 7px;
 }
 #profile-edit-name-label,
-#profile-edit-pdesc-label,
+#profile-edit-about-label,
 #profile-edit-dob-label,
 #profile-edit-address-label,
 #profile-edit-locality-label,
@@ -1253,7 +1253,7 @@ ul.tabs {
         padding-top: 7px;
 }
 #profile-edit-name,
-#profile-edit-pdesc,
+#profile-edit-about,
 #profile-edit-dob,
 #profile-edit-address,
 #profile-edit-locality,

--- a/view/theme/quattro/templates/profile/vcard.tpl
+++ b/view/theme/quattro/templates/profile/vcard.tpl
@@ -17,7 +17,7 @@
 
 	{{if $profile.addr}}<div class="p-addr">{{$profile.addr}}</div>{{/if}}
 
-	{{if $pdesc}}<div class="title">{{$profile.pdesc}}</div>{{/if}}
+	{{if $about}}<div class="title">{{$profile.about}}</div>{{/if}}
 	<div id="profile-photo-wrapper"><img class="photo u-photo" width="175" height="175" src="{{$profile.photo}}?rev={{$profile.picdate}}" alt="{{$profile.name}}" /></div>
 
 	{{if $account_type}}<div class="account-type">{{$account_type}}</div>{{/if}}

--- a/view/theme/vier/templates/profile/vcard.tpl
+++ b/view/theme/vier/templates/profile/vcard.tpl
@@ -11,7 +11,7 @@
 
 	{{if $profile.addr}}<div class="p-addr">{{$profile.addr}}</div>{{/if}}
 
-	{{if $profile.pdesc}}<div class="title">{{$profile.pdesc}}</div>{{/if}}
+	{{if $profile.about}}<div class="title">{{$profile.about}}</div>{{/if}}
 
 	{{if $profile.picdate}}
 		<div id="profile-photo-wrapper"><a href="{{$profile.url}}"><img class="photo u-photo" src="{{$profile.photo}}?rev={{$profile.picdate}}" alt="{{$profile.name}}"></a></div>

--- a/view/theme/vier/templates/settings/profile/index.tpl
+++ b/view/theme/vier/templates/settings/profile/index.tpl
@@ -54,11 +54,11 @@
 				</div>
 				<div id="profile-edit-name-end"></div>
 
-				<div id="profile-edit-pdesc-wrapper">
-					<label id="profile-edit-pdesc-label" for="profile-edit-pdesc">{{$pdesc.1}} </label>
-					<input type="text" size="32" name="pdesc" id="profile-edit-pdesc" value="{{$pdesc.2}}"/>
+				<div id="profile-edit-about-wrapper">
+					<label id="profile-edit-about-label" for="profile-edit-about">{{$about.1}} </label>
+					<input type="text" size="32" name="about" id="profile-edit-about" value="{{$about.2}}"/>
 				</div>
-				<div id="profile-edit-pdesc-end"></div>
+				<div id="profile-edit-about-end"></div>
 
 				<div id="profile-edit-xmpp-wrapper">
 					<label id="profile-edit-xmpp-label" for="profile-edit-xmpp">{{$xmpp.1}} </label>


### PR DESCRIPTION
Closes #8251 
Follow-up to #8156
Part of #7817

This PR is particular because it requires an update for users on develop nodes, but it won't be needed for users on stable nodes.

Meaning that stable users will have their profiles migrated normally, but without an additional update routine, the develop users will lose the content of their `profile.pdesc` field in the database limbo, never to be accessed again.

And this additional work will be absolutely useless for people upgrading from stable to stable version.

Should we just do an announcement on the forums or should we add a piece of code that will only be relevant for node that have been running the develop branch between January 24th and the moment this PR will be merged?