### PR TITLE
Disable drone.io integration

### DIFF
--- a/mods/.drone.yml
+++ b/mods/.drone.yml
@@ -1,3 +1,5 @@
+# Drone.io test YML-File, currently disabled
+# See https://github.com/friendica/friendica/pull/7643 for further infos
 kind: pipeline
 name: mysql8.0-php7.1
 


### PR DESCRIPTION
FollowUp #7643

Since it isn't working as expected and we need a some fixings/followups at the server-config (@ben-utzer and I will have to setup the environment for it), I disable the drone support for now. It frustrates me at every PR when I see the "orange" signal isn't finishing ... ^^ 

It's possible to re-enable it at any time with moving the `.drone.yml` file in the root again :-)