### PR TITLE
[frio] Fix more action button position on Firefox

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -1593,7 +1593,6 @@ aside .panel-body {
 .wall-item-container.panel-body {
     padding: 0;
     border-top: none;
-    overflow: hidden;
 }
 
 .wall-item-container .media {
@@ -1908,7 +1907,7 @@ code > .hl-main {
     margin: 0 .3em;
 }
 .wall-item-actions .more-links {
-    position: absolute;
+    vertical-align: baseline;
 }
 
 .wall-item-responses > div > p {


### PR DESCRIPTION
Follow-up to #8269
Closes #8255

I didn't see any specific reason to keep the `overflow: hidden` at this level, I may have to add it back to the post body block if there are visual regressions with wide embeds.