### PR TITLE
[frio] Add narrow screen short item action button row

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -56,11 +56,10 @@ body a[name]:not([href]) {
     visibility: hidden;
 }
 
-body a:hover, .btn-link:hover,
-body a:focus, .btn-link:focus,
-body a:active, .btn-link:active,
-body a.active, .btn-link.active {
-    /*color: #59d6e4;*/
+body a:hover, .btn-link:hover, .btn:hover,
+body a:focus, .btn-link:focus, .btn:focus,
+body a:active, .btn-link:active, .btn:active,
+body a.active, .btn-link.active, .btn.active {
     color: $link_hover_color;
     text-decoration: none;
     outline: none;
@@ -1890,10 +1889,6 @@ code > .hl-main {
     margin: 0;
     margin-left: 20px;
 }
-.wall-item-actions .button-event {
-    padding-left: 5px;
-    padding-right: 5px;
-}
 .wall-item-actions .button-comments,
 .wall-item-actions .button-votes,
 .wall-item-actions .button-likes {
@@ -1906,37 +1901,37 @@ code > .hl-main {
 .wall-item-actions .separator {
     margin: 0 .3em;
 }
-.wall-item-actions .more-links {
-    vertical-align: baseline;
-}
 
 .wall-item-responses > div > p {
     margin: 0;
 }
 
 /* wall item hover effects */
-.wall-item-container .wall-item-links,
-.wall-item-container .wall-item-actions button,
-.wall-item-container .body-attach > a {
-    opacity: 0.3;
-    -webkit-transition: all 0.25s ease-in-out;
-    -moz-transition: all 0.25s ease-in-out;
-    -o-transition: all 0.25s ease-in-out;
-    -ms-transition: all 0.25s ease-in-out;
-    transition: all 0.25s ease-in-out;
-}
-.wall-item-container:hover .wall-item-links,
-.wall-item-container:hover .wall-item-actions button,
-.wall-item-container:hover .body-attach > a {
-    opacity: 1;
-    -webkit-transition: all 0.25s ease-in-out;
-    -moz-transition: all 0.25s ease-in-out;
-    -o-transition: all 0.25s ease-in-out;
-    -ms-transition: all 0.25s ease-in-out;
-    transition: all 0.25s ease-in-out;
-}
-.wall-item-container .wall-item-body .body-attach > a:hover {
-    opacity: 1;
+
+@media (min-width: 768px) {
+	.wall-item-container .wall-item-links,
+	.wall-item-container .wall-item-actions button,
+	.wall-item-container .body-attach > a {
+		opacity: 0.3;
+		-webkit-transition: all 0.25s ease-in-out;
+		-moz-transition: all 0.25s ease-in-out;
+		-o-transition: all 0.25s ease-in-out;
+		-ms-transition: all 0.25s ease-in-out;
+		transition: all 0.25s ease-in-out;
+	}
+	.wall-item-container:hover .wall-item-links,
+	.wall-item-container:hover .wall-item-actions button,
+	.wall-item-container:hover .body-attach > a {
+		opacity: 1;
+		-webkit-transition: all 0.25s ease-in-out;
+		-moz-transition: all 0.25s ease-in-out;
+		-o-transition: all 0.25s ease-in-out;
+		-ms-transition: all 0.25s ease-in-out;
+		transition: all 0.25s ease-in-out;
+	}
+	.wall-item-container .wall-item-body .body-attach > a:hover {
+		opacity: 1;
+	}
 }
 
 /*

--- a/view/theme/frio/templates/wall_thread.tpl
+++ b/view/theme/frio/templates/wall_thread.tpl
@@ -268,7 +268,7 @@ as the value of $top_child_total (this is done at the end of this file)
 		<!-- <hr /> -->
 		<div class="wall-item-actions">
 			{{* Action buttons to interact with the item (like: like, dislike, share and so on *}}
-			<span class="wall-item-actions-left">
+			<span class="wall-item-actions-left hidden-xs">
 
 			{{* Buttons for like and dislike *}}
 			{{if $item.vote}}
@@ -373,7 +373,7 @@ as the value of $top_child_total (this is done at the end of this file)
 
 			</span>
 
-			<span class="wall-item-actions-right">
+			<span class="wall-item-actions-right hidden-xs">
 				{{* Event attendance buttons *}}
 			{{if $item.isevent}}
 				<span class="vote-event">
@@ -390,6 +390,121 @@ as the value of $top_child_total (this is done at the end of this file)
 			{{/if}}
 				</span>
 			</span>
+
+			<div class="btn-toolbar visible-xs" role="toolbar">
+			{{* Buttons for like and dislike *}}
+			{{if $item.vote}}
+				<div class="btn-group" role="group">
+				{{if $item.vote.like}}
+					<button type="button" class="btn btn-sm button-likes{{if $item.responses.like.self}} active" aria-pressed="true{{/if}}" id="like-{{$item.id}}" title="{{$item.vote.like.0}}" onclick="doLikeAction({{$item.id}},'like');" data-toggle="button""><i class="fa fa-thumbs-up" aria-hidden="true"></i></button>
+				{{/if}}
+				{{if $item.vote.dislike}}
+					<button type="button" class="btn btn-sm button-likes{{if $item.responses.dislike.self}} active" aria-pressed="true{{/if}}" id="dislike-{{$item.id}}" title="{{$item.vote.dislike.0}}" onclick="doLikeAction({{$item.id}},'dislike');" data-toggle="button"><i class="fa fa-thumbs-down" aria-hidden="true"></i></button>
+				{{/if}}
+				</div>
+			{{/if}}
+
+			{{* Button to open the comment text field *}}
+			{{if $item.comment}}
+				<div class="btn-group" role="group">
+					<button type="button" class="btn btn-sm button-comments" id="comment-{{$item.id}}" title="{{$item.switchcomment}}" {{if $item.thread_level != 1}}onclick="openClose('item-comments-{{$item.id}}'); commentExpand({{$item.id}});" {{else}} onclick="openClose('item-comments-{{$item.id}}'); commentExpand({{$item.id}});"{{/if}}><i class="fa fa-commenting" aria-hidden="true"></i></button>
+				</div>
+			{{/if}}
+
+			{{* Button for sharing the item *}}
+			{{if $item.vote.share}}
+				<div class="btn-group" role="group">
+					<button type="button" class="btn btn-sm button-votes" id="share-{{$item.id}}" title="{{$item.vote.share.0}}" onclick="jotShare({{$item.id}});"><i class="fa fa-retweet" aria-hidden="true"></i></button>
+				</div>
+			{{/if}}
+
+			{{* Put additional actions in a dropdown menu *}}
+				<div class="btn-group" role="group">
+					<img id="like-rotator-{{$item.id}}" class="like-rotator" src="images/rotator.gif" alt="{{$item.wait}}" title="{{$item.wait}}" style="display: none;" />
+				</div>
+			</div>
+
+			<div class="wall-item-actions-right visible-xs">
+				{{* Event attendance buttons *}}
+			{{if $item.isevent}}
+				<div class="btn-group" role="group">
+					<button type="button" class="btn btn-sm btn-default button-event{{if $item.responses.attendyes.self}} active" aria-pressed="true{{/if}}" id="attendyes-{{$item.id}}" title="{{$item.attend.0}}" onclick="doLikeAction({{$item.id}},'attendyes');"><i class="fa fa-check" aria-hidden="true"><span class="sr-only">{{$item.attend.0}}</span></i></button>
+					<button type="button" class="btn btn-sm btn-default button-event{{if $item.responses.attendno.self}} active" aria-pressed="true{{/if}}" id="attendno-{{$item.id}}" title="{{$item.attend.1}}" onclick="doLikeAction({{$item.id}},'attendno');"><i class="fa fa-times" aria-hidden="true"><span class="sr-only">{{$item.attend.1}}</span></i></button>
+					<button type="button" class="btn btn-sm btn-default button-event{{if $item.responses.attendmaybe.self}} active" aria-pressed="true{{/if}}" id="attendmaybe-{{$item.id}}" title="{{$item.attend.2}}" onclick="doLikeAction({{$item.id}},'attendmaybe');"><i class="fa fa-question" aria-hidden="true"><span class="sr-only">{{$item.attend.2}}</span></i></button>
+				</div>
+			{{/if}}
+
+			{{if $item.edpost || $item.tagger || $item.filer || $item.pin || $item.star || $item.subthread || $item.ignore || $item.drop.dropping}}
+				<div class="more-links btn-group{{if $item.thread_level > 1}} dropup{{/if}}">
+					<button type="button" class="btn btn-sm dropdown-toggle" data-toggle="dropdown" id="dropdownMenuOptions-{{$item.id}}" aria-haspopup="true" aria-expanded="false" title="{{$item.menu}}"><i class="fa fa-ellipsis-h" aria-hidden="true"></i></button>
+					<ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="dropdownMenuOptions-{{$item.id}}">
+					{{if $item.edpost}} {{* edit the posting *}}
+						<li role="menuitem">
+							<a href="javascript:editpost('{{$item.edpost.0}}?mode=none');" title="{{$item.edpost.1}}" class="btn-link navicon pencil"><i class="fa fa-pencil" aria-hidden="true"></i> {{$item.edpost.1}}</a>
+						</li>
+					{{/if}}
+
+						{{if $item.tagger}} {{* tag the post *}}
+							<li role="menuitem">
+							<a id="tagger-{{$item.id}}" href="javascript:itemTag({{$item.id}});" class="btn-link {{$item.tagger.class}}" title="{{$item.tagger.add}}"><i class="fa fa-tag" aria-hidden="true"></i> {{$item.tagger.add}}</a>
+						</li>
+						{{/if}}
+
+						{{if $item.filer}}
+							<li role="menuitem">
+							<a id="filer-{{$item.id}}" href="javascript:itemFiler({{$item.id}});" class="btn-link filer-item filer-icon" title="{{$item.filer}}"><i class="fa fa-folder" aria-hidden="true"></i>&nbsp;{{$item.filer}}</a>
+						</li>
+						{{/if}}
+
+						{{if $item.pin}}
+							<li role="menuitem">
+							<a id="pin-{{$item.id}}" href="javascript:dopin({{$item.id}});" class="btn-link {{$item.pin.classdo}}" title="{{$item.pin.do}}"><i class="fa fa-circle-o" aria-hidden="true"></i>&nbsp;{{$item.pin.do}}</a>
+							<a id="unpin-{{$item.id}}" href="javascript:dopin({{$item.id}});" class="btn-link {{$item.pin.classundo}}" title="{{$item.pin.undo}}"><i class="fa fa-dot-circle-o" aria-hidden="true"></i>&nbsp;{{$item.pin.undo}}</a>
+						</li>
+						{{/if}}
+
+						{{if $item.star}}
+							<li role="menuitem">
+							<a id="star-{{$item.id}}" href="javascript:dostar({{$item.id}});" class="btn-link {{$item.star.classdo}}" title="{{$item.star.do}}"><i class="fa fa-star-o" aria-hidden="true"></i>&nbsp;{{$item.star.do}}</a>
+							<a id="unstar-{{$item.id}}" href="javascript:dostar({{$item.id}});" class="btn-link {{$item.star.classundo}}" title="{{$item.star.undo}}"><i class="fa fa-star" aria-hidden="true"></i>&nbsp;{{$item.star.undo}}</a>
+						</li>
+						{{/if}}
+
+						{{if $item.subthread}}
+							<li role="menuitem">
+							<a id="subthread-{{$item.id}}" href="javascript:{{$item.subthread.action}}" class="btn-link" title="{{$item.subthread.title}}"><i class="fa fa-plus" aria-hidden="true"></i>&nbsp;{{$item.subthread.title}}</a>
+						</li>
+						{{/if}}
+
+						{{if $item.ignore || $item.drop.dropping}}
+							<li role="separator" class="divider"></li>
+						{{/if}}
+
+						{{if $item.ignore}}
+							<li role="menuitem">
+							<a id="ignore-{{$item.id}}" href="javascript:doignore({{$item.id}});" class="btn-link {{$item.ignore.classdo}}" title="{{$item.ignore.do}}"><i class="fa fa-eye-slash" aria-hidden="true"></i> {{$item.ignore.do}}</a>
+						</li>
+							<li role="menuitem">
+							<a id="unignore-{{$item.id}}" href="javascript:doignore({{$item.id}});" class="btn-link {{$item.ignore.classundo}}"  title="{{$item.ignore.undo}}"><i class="fa fa-eye" aria-hidden="true"></i> {{$item.ignore.undo}}</a>
+						</li>
+						{{/if}}
+
+						{{if $item.drop.dropping}}
+							<li role="menuitem">
+							<a class="btn-link navicon delete" href="javascript:dropItem('item/drop/{{$item.id}}/{{$item.return}}', 'item-{{$item.guid}}');" title="{{$item.drop.delete}}"><i class="fa fa-trash" aria-hidden="true"></i> {{$item.drop.delete}}</a>
+						</li>
+						{{/if}}
+					</ul>
+					<img id="like-rotator-{{$item.id}}" class="like-rotator" src="images/rotator.gif" alt="{{$item.wait}}" title="{{$item.wait}}" style="display: none;" />
+				</div>
+			{{/if}}
+				<span class="pull-right checkbox">
+			{{if $item.drop.pagedrop}}
+					<input type="checkbox" title="{{$item.drop.select}}" name="itemselected[]" id="checkbox-{{$item.id}}" class="item-select" value="{{$item.id}}" />
+					<label for="checkbox-{{$item.id}}"></label>
+			{{/if}}
+				</span>
+			</div>
 		</div><!--./wall-item-actions-->
 
 		<div class="wall-item-links"></div>


### PR DESCRIPTION
Addresses https://forum.friendi.ca/display/0b6b25a8-155e-428d-790d-5d1061064747

This PR add a narrow screen specific display for the item action buttons. Labels are hidden to ensure a single line of buttons and the more menu is anchored on the right to avoid clipping outside of the screen.

![friendica-mobile-reaction-buttons](https://user-images.githubusercontent.com/925415/74396212-4f32da80-4ddf-11ea-82d6-6dd5241756f2.png)
