### PR TITLE
Frio: unseen notifications background adjustment

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -632,8 +632,8 @@ nav.navbar .nav > li > button:focus
 }
 
 #topbar-first #nav-notifications-menu li.notification-unseen {
-    border-left: 3px solid #f3fcfd;
-    background-color: #f3fcfd;
+    border-left: 3px solid #e3eff3;
+    background-color: #e3eff3;
 }
 #topbar-first #nav-notifications-menu li.notif-entry:hover {
     background-color: #f7f7f7;
@@ -2980,7 +2980,7 @@ ul.notif-network-list > li:hover .intro-action-buttons {
 
 /* Notifications Page */
 ul.notif-network-list li.unseen {
-    background-color: #f3fcfd;
+    background-color: #e3eff3;
 }
 .notif-item img.notif-image {
     height: 48px;

--- a/view/theme/frio/scheme/plusminus.css
+++ b/view/theme/frio/scheme/plusminus.css
@@ -26,7 +26,7 @@ aside .widget, .form-control, .panel, .nav-container, .wall-item-content, .e-con
 }
 
 #topbar-first #nav-notifications-menu li.notification-unseen {
-    border-left: 3px solid #f3fcfd;
+    border-left: 3px solid #e3eff3;
     background-color: antiquewhite;
 }
 


### PR DESCRIPTION
Background color for unseen notifications slightly changed for better visibility.

Old color: `#f3fcfd`
New color: `#e3eff3`

I changed the color value everywhere. It was only used for the notifications background. So it should do no harm. :-)

@hoergen Can you please check if this change somehow breaks the plusminus scheme? I don't think so but maybe you know better.

Fixes #8281 