### PR TITLE
Introduce Entities [WIP/ShowCase]

### DIFF
--- a/bin/dev/entities.php
+++ b/bin/dev/entities.php
@@ -1,0 +1,213 @@
+#!/usr/bin/env php
+<?php
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ *
+ */
+
+require dirname(__DIR__) . '/../vendor/autoload.php';
+
+/**
+ * Custom file printer with tab indention and one line between methods
+ */
+class FriendicaPhpPrinter extends \Nette\PhpGenerator\Printer
+{
+	protected $linesBetweenMethods = 1;
+}
+
+// replaces digits with their names
+function digitToText(string $name) {
+	$name = str_replace('0', 'zero_', $name);
+	$name = str_replace('1', 'one_', $name);
+	$name = str_replace('2', 'two_', $name);
+	$name = str_replace('3', 'three_', $name);
+	$name = str_replace('4', 'four_', $name);
+	$name = str_replace('5', 'five_', $name);
+	$name = str_replace('6', 'six_', $name);
+	$name = str_replace('7', 'seven_', $name);
+	$name = str_replace('8', 'eight_', $name);
+	$name = str_replace('9', 'nine_', $name);
+	return $name;
+}
+
+// Replaces underlines ("_") with camelCase notation (for variables)
+function camelCase($str) {
+	$i = array("-","_");
+	$str = digitToText($str);
+	$str = preg_replace('/([a-z])([A-Z])/', "\\1 \\2", $str);
+	$str = preg_replace('@[^a-zA-Z0-9\-_ ]+@', '', $str);
+	$str = str_replace($i, ' ', $str);
+	$str = str_replace(' ', '', ucwords(strtolower($str)));
+	$str = strtolower(substr($str,0,1)).substr($str,1);
+	return $str;
+}
+
+// Like camelcase, but with Uppercasing the first letter (for classes)
+function toClassName($str) {
+	$str = camelCase($str);
+	return ucfirst($str);
+}
+
+// Custom mapping of db-types to PHP types
+function getDbType(string $type) {
+	switch ($type) {
+		case 'int unsigned':
+		case 'longblob':
+		case 'mediumint unsigned':
+		case 'int':
+			return Nette\PhpGenerator\Type::INT;
+		case 'datetime':
+			// @todo Replace with "real" datetime
+			return Nette\PhpGenerator\Type::STRING;
+		case 'boolean':
+			return Nette\PhpGenerator\Type::BOOL;
+		default:
+			return Nette\PhpGenerator\Type::STRING;
+	}
+}
+
+// returns the class name based on a given table name
+function getClassName(string $str) {
+	$names = preg_split('/[-]+/', $str);
+	return toClassName($names[count($names) - 1]);
+}
+
+// returns a directory sequence based on a given table name
+function getDirs(string $str, string $del = '/') {
+	$names = preg_split('/[-]+/', $str);
+	$dirs = '';
+	for ($i = 0; $i < count($names) - 1; $i++) {
+		$dirs .= toClassName($names[$i]) . $del;
+	}
+	return substr($dirs, 0, (strlen($dirs) - strlen($del)));
+}
+
+$dbstructure = include __DIR__ . '/../../static/dbstructure.config.php';
+
+foreach ($dbstructure as $name => $table) {
+	$className = getClassName($name);
+	$dirPath = getDirs($name, '/');
+	$nsPath = getDirs($name, '\\');
+	$generator = new Nette\PhpGenerator\ClassType($className);
+	$generator->setExtends(\Friendica\BaseEntity::class);
+	$generator->addComment(sprintf('Entity class for table %s', $name))
+	          ->addComment('');
+
+	$returnArray = $generator->addMethod('toArray')
+	                         ->setPublic()
+	                         ->addComment('{@inheritDoc}')
+	                         ->addBody('return [');
+
+	$file = new Nette\PhpGenerator\PhpFile();
+	$file->addComment(<<<LIC
+@copyright Copyright (C) 2020, Friendica
+
+@license GNU APGL version 3 or any later version
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Used to check/generate entities for the Friendica codebase
+LIC
+	);
+	$file->setStrictTypes();
+
+	$namespace = $file->addNamespace('Friendica\Domain\Entity' . ($nsPath ? '\\' . $nsPath : ''));
+	$namespace->addUse(\Friendica\BaseEntity::class);
+
+	foreach ($table as $key => $value) {
+		switch ($key) {
+			case 'comment':
+				$generator->addComment($value);
+				break;
+			case 'fields':
+				foreach ($value as $field => $attributes) {
+					$property    = $generator->addProperty(camelCase($field))->setPrivate();
+					$getter      = $generator->addMethod(camelCase('get_' . $field))
+					                         ->setPublic()
+					                         ->addBody(sprintf('return $this->%s;', $property->getName()));
+					$setter      = $generator->addMethod(camelCase('set_' . $field))
+					                         ->setPublic()
+					                         ->addBody(sprintf('$this->%s = $%s;', $property->getName(), $property->getName()));
+					$setterParam = $setter->addParameter($property->getName());
+					$returnArray->addBody(sprintf("\t'%s' => \$this->%s,", $field, $property->getName()));
+					foreach ($attributes as $name => $attribute) {
+						switch ($name) {
+							case 'type':
+								$property->addComment(sprintf('@var %s', getDbType($attribute)));
+								$getter->addComment(sprintf('@return %s', getDbType($attribute)));
+								$setter->addComment(sprintf('@param %s $%s', getDbType($attribute), $property->getName()));
+								$setterParam->setType(getDbType($attribute));
+								break;
+							case 'comment':
+								$property->addComment($attribute);
+								$getter->addComment('Get ' . $attribute);
+								$setter->addComment('Set ' . $attribute);
+								break;
+							case 'primary':
+								if ($attribute) {
+									$generator->removeMethod($setter->getName());
+								}
+								break;
+							case 'relation':
+								foreach ($attribute as $relTable => $relField) {
+									$nsRel = getDirs($relTable, '\\');
+									$generator->addMethod(camelCase('get_' . $relTable))
+									          ->addComment(sprintf('Get %s', ($nsRel ? '\\' . $nsRel : '') . getClassName($relTable)))
+									          ->addComment('')
+									          ->addComment(sprintf('@return %s', ($nsRel ? '\\' . $nsRel : '') . getClassName($relTable)))
+									          ->addBody('//@todo use closure')
+									          ->addBody(sprintf('throw new NotImplementedException(\'lazy loading for %s is not implemented yet\');', camelCase($relField)));
+									$namespace->addUse(Friendica\Network\HTTPException\NotImplementedException::class);
+									if ($nsRel) {
+										$namespace->addUse('Friendica\Domain\Entity\\' . $nsRel );
+									}
+								}
+								break;
+							case 'default':
+								$property->setValue($attribute);
+						}
+					}
+				}
+				break;
+		}
+	}
+
+	$returnArray->addBody('];');
+
+	$class = $namespace->add($generator);
+
+	$dir = __DIR__ . '/../../src/Domain/Entity/' . $dirPath . '/';
+	if (!file_exists($dir)) {
+		mkdir($dir, 0777, true);
+	}
+
+	file_put_contents($dir . $generator->getName() . '.php', (new FriendicaPhpPrinter())->printFile($file), FILE_USE_INCLUDE_PATH);
+}

--- a/composer.json
+++ b/composer.json
@@ -121,7 +121,8 @@
 		"mikey179/vfsstream": "^1.6",
 		"mockery/mockery": "^1.2",
 		"johnkary/phpunit-speedtrap": "1.1",
-		"jakub-onderka/php-parallel-lint": "^1.0"
+		"jakub-onderka/php-parallel-lint": "^1.0",
+		"nette/php-generator": "^3.3"
 	},
 	"scripts": {
 		"test": "phpunit"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e1a839b13f7ba5892c8730d0da3ddf1c",
+    "content-hash": "9adec0be3564a47467caa4ebb2c50194",
     "packages": [
         {
             "name": "asika/simple-console",
@@ -3223,6 +3223,144 @@
                 "object graph"
             ],
             "time": "2017-10-19T19:58:43+00:00"
+        },
+        {
+            "name": "nette/php-generator",
+            "version": "v3.3.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/php-generator.git",
+                "reference": "8fe7e699dca7db186f56d75800cb1ec32e39c856"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/php-generator/zipball/8fe7e699dca7db186f56d75800cb1ec32e39c856",
+                "reference": "8fe7e699dca7db186f56d75800cb1ec32e39c856",
+                "shasum": ""
+            },
+            "require": {
+                "nette/utils": "^2.4.2 || ^3.0",
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "nette/tester": "^2.0",
+                "phpstan/phpstan": "^0.12",
+                "tracy/tracy": "^2.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.3-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0-only",
+                "GPL-3.0-only"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "https://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "https://nette.org/contributors"
+                }
+            ],
+            "description": "🐘 Nette PHP Generator: generates neat PHP code for you. Supports new PHP 7.4 features.",
+            "homepage": "https://nette.org",
+            "keywords": [
+                "code",
+                "nette",
+                "php",
+                "scaffolding"
+            ],
+            "time": "2020-02-09T14:39:09+00:00"
+        },
+        {
+            "name": "nette/utils",
+            "version": "v3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/utils.git",
+                "reference": "2c17d16d8887579ae1c0898ff94a3668997fd3eb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/utils/zipball/2c17d16d8887579ae1c0898ff94a3668997fd3eb",
+                "reference": "2c17d16d8887579ae1c0898ff94a3668997fd3eb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "nette/tester": "~2.0",
+                "phpstan/phpstan": "^0.12",
+                "tracy/tracy": "^2.3"
+            },
+            "suggest": {
+                "ext-gd": "to use Image",
+                "ext-iconv": "to use Strings::webalize() and toAscii()",
+                "ext-intl": "to use Strings::webalize(), toAscii(), normalize() and compare()",
+                "ext-json": "to use Nette\\Utils\\Json",
+                "ext-mbstring": "to use Strings::lower() etc...",
+                "ext-tokenizer": "to use Nette\\Utils\\Reflection::getUseStatements()",
+                "ext-xml": "to use Strings::length() etc. when mbstring is not available"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0-only",
+                "GPL-3.0-only"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "https://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "https://nette.org/contributors"
+                }
+            ],
+            "description": "🛠 Nette Utils: lightweight utilities for string & array manipulation, image handling, safe JSON encoding/decoding, validation, slug or strong password generating etc.",
+            "homepage": "https://nette.org",
+            "keywords": [
+                "array",
+                "core",
+                "datetime",
+                "images",
+                "json",
+                "nette",
+                "paginator",
+                "password",
+                "slugify",
+                "string",
+                "unicode",
+                "utf-8",
+                "utility",
+                "validation"
+            ],
+            "time": "2020-02-09T14:10:55+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",

--- a/src/Domain/Entity/Addon.php
+++ b/src/Domain/Entity/Addon.php
@@ -1,0 +1,210 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity;
+
+use Friendica\BaseEntity;
+
+/**
+ * Entity class for table addon
+ *
+ * registered addons
+ */
+class Addon extends BaseEntity
+{
+	/**
+	 * @var int
+	 */
+	private $id;
+
+	/**
+	 * @var string
+	 * addon base (file)name
+	 */
+	private $name = '';
+
+	/**
+	 * @var string
+	 * currently unused
+	 */
+	private $version = '';
+
+	/**
+	 * @var bool
+	 * currently always 1
+	 */
+	private $installed = '0';
+
+	/**
+	 * @var bool
+	 * currently unused
+	 */
+	private $hidden = '0';
+
+	/**
+	 * @var int
+	 * file timestamp to check for reloads
+	 */
+	private $timestamp = '0';
+
+	/**
+	 * @var bool
+	 * 1 = has admin config, 0 = has no admin config
+	 */
+	private $pluginAdmin = '0';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'id' => $this->id,
+			'name' => $this->name,
+			'version' => $this->version,
+			'installed' => $this->installed,
+			'hidden' => $this->hidden,
+			'timestamp' => $this->timestamp,
+			'plugin_admin' => $this->pluginAdmin,
+		];
+	}
+
+	/**
+	 * @return int
+	 * Get
+	 */
+	public function getId()
+	{
+		return $this->id;
+	}
+
+	/**
+	 * @return string
+	 * Get addon base (file)name
+	 */
+	public function getName()
+	{
+		return $this->name;
+	}
+
+	/**
+	 * @param string $name
+	 * Set addon base (file)name
+	 */
+	public function setName(string $name)
+	{
+		$this->name = $name;
+	}
+
+	/**
+	 * @return string
+	 * Get currently unused
+	 */
+	public function getVersion()
+	{
+		return $this->version;
+	}
+
+	/**
+	 * @param string $version
+	 * Set currently unused
+	 */
+	public function setVersion(string $version)
+	{
+		$this->version = $version;
+	}
+
+	/**
+	 * @return bool
+	 * Get currently always 1
+	 */
+	public function getInstalled()
+	{
+		return $this->installed;
+	}
+
+	/**
+	 * @param bool $installed
+	 * Set currently always 1
+	 */
+	public function setInstalled(bool $installed)
+	{
+		$this->installed = $installed;
+	}
+
+	/**
+	 * @return bool
+	 * Get currently unused
+	 */
+	public function getHidden()
+	{
+		return $this->hidden;
+	}
+
+	/**
+	 * @param bool $hidden
+	 * Set currently unused
+	 */
+	public function setHidden(bool $hidden)
+	{
+		$this->hidden = $hidden;
+	}
+
+	/**
+	 * @return int
+	 * Get file timestamp to check for reloads
+	 */
+	public function getTimestamp()
+	{
+		return $this->timestamp;
+	}
+
+	/**
+	 * @param int $timestamp
+	 * Set file timestamp to check for reloads
+	 */
+	public function setTimestamp(int $timestamp)
+	{
+		$this->timestamp = $timestamp;
+	}
+
+	/**
+	 * @return bool
+	 * Get 1 = has admin config, 0 = has no admin config
+	 */
+	public function getPluginAdmin()
+	{
+		return $this->pluginAdmin;
+	}
+
+	/**
+	 * @param bool $pluginAdmin
+	 * Set 1 = has admin config, 0 = has no admin config
+	 */
+	public function setPluginAdmin(bool $pluginAdmin)
+	{
+		$this->pluginAdmin = $pluginAdmin;
+	}
+}

--- a/src/Domain/Entity/Apcontact.php
+++ b/src/Domain/Entity/Apcontact.php
@@ -1,0 +1,570 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity;
+
+use Friendica\BaseEntity;
+
+/**
+ * Entity class for table apcontact
+ *
+ * ActivityPub compatible contacts - used in the ActivityPub implementation
+ */
+class Apcontact extends BaseEntity
+{
+	/**
+	 * @var string
+	 * URL of the contact
+	 */
+	private $url;
+
+	/**
+	 * @var string
+	 */
+	private $uuid;
+
+	/**
+	 * @var string
+	 */
+	private $type;
+
+	/**
+	 * @var string
+	 */
+	private $following;
+
+	/**
+	 * @var string
+	 */
+	private $followers;
+
+	/**
+	 * @var string
+	 */
+	private $inbox;
+
+	/**
+	 * @var string
+	 */
+	private $outbox;
+
+	/**
+	 * @var string
+	 */
+	private $sharedinbox;
+
+	/**
+	 * @var bool
+	 */
+	private $manuallyApprove;
+
+	/**
+	 * @var string
+	 */
+	private $nick = '';
+
+	/**
+	 * @var string
+	 */
+	private $name;
+
+	/**
+	 * @var string
+	 */
+	private $about;
+
+	/**
+	 * @var string
+	 */
+	private $photo;
+
+	/**
+	 * @var string
+	 */
+	private $addr;
+
+	/**
+	 * @var string
+	 */
+	private $alias;
+
+	/**
+	 * @var string
+	 */
+	private $pubkey;
+
+	/**
+	 * @var string
+	 * baseurl of the ap contact
+	 */
+	private $baseurl;
+
+	/**
+	 * @var string
+	 * Name of the contact's system
+	 */
+	private $generator;
+
+	/**
+	 * @var int
+	 * Number of following contacts
+	 */
+	private $followingCount = 0;
+
+	/**
+	 * @var int
+	 * Number of followers
+	 */
+	private $followersCount = 0;
+
+	/**
+	 * @var int
+	 * Number of posts
+	 */
+	private $statusesCount = 0;
+
+	/**
+	 * @var string
+	 */
+	private $updated = '0001-01-01 00:00:00';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'url' => $this->url,
+			'uuid' => $this->uuid,
+			'type' => $this->type,
+			'following' => $this->following,
+			'followers' => $this->followers,
+			'inbox' => $this->inbox,
+			'outbox' => $this->outbox,
+			'sharedinbox' => $this->sharedinbox,
+			'manually-approve' => $this->manuallyApprove,
+			'nick' => $this->nick,
+			'name' => $this->name,
+			'about' => $this->about,
+			'photo' => $this->photo,
+			'addr' => $this->addr,
+			'alias' => $this->alias,
+			'pubkey' => $this->pubkey,
+			'baseurl' => $this->baseurl,
+			'generator' => $this->generator,
+			'following_count' => $this->followingCount,
+			'followers_count' => $this->followersCount,
+			'statuses_count' => $this->statusesCount,
+			'updated' => $this->updated,
+		];
+	}
+
+	/**
+	 * @return string
+	 * Get URL of the contact
+	 */
+	public function getUrl()
+	{
+		return $this->url;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getUuid()
+	{
+		return $this->uuid;
+	}
+
+	/**
+	 * @param string $uuid
+	 * Set
+	 */
+	public function setUuid(string $uuid)
+	{
+		$this->uuid = $uuid;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getType()
+	{
+		return $this->type;
+	}
+
+	/**
+	 * @param string $type
+	 * Set
+	 */
+	public function setType(string $type)
+	{
+		$this->type = $type;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getFollowing()
+	{
+		return $this->following;
+	}
+
+	/**
+	 * @param string $following
+	 * Set
+	 */
+	public function setFollowing(string $following)
+	{
+		$this->following = $following;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getFollowers()
+	{
+		return $this->followers;
+	}
+
+	/**
+	 * @param string $followers
+	 * Set
+	 */
+	public function setFollowers(string $followers)
+	{
+		$this->followers = $followers;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getInbox()
+	{
+		return $this->inbox;
+	}
+
+	/**
+	 * @param string $inbox
+	 * Set
+	 */
+	public function setInbox(string $inbox)
+	{
+		$this->inbox = $inbox;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getOutbox()
+	{
+		return $this->outbox;
+	}
+
+	/**
+	 * @param string $outbox
+	 * Set
+	 */
+	public function setOutbox(string $outbox)
+	{
+		$this->outbox = $outbox;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getSharedinbox()
+	{
+		return $this->sharedinbox;
+	}
+
+	/**
+	 * @param string $sharedinbox
+	 * Set
+	 */
+	public function setSharedinbox(string $sharedinbox)
+	{
+		$this->sharedinbox = $sharedinbox;
+	}
+
+	/**
+	 * @return bool
+	 * Get
+	 */
+	public function getManuallyApprove()
+	{
+		return $this->manuallyApprove;
+	}
+
+	/**
+	 * @param bool $manuallyApprove
+	 * Set
+	 */
+	public function setManuallyApprove(bool $manuallyApprove)
+	{
+		$this->manuallyApprove = $manuallyApprove;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getNick()
+	{
+		return $this->nick;
+	}
+
+	/**
+	 * @param string $nick
+	 * Set
+	 */
+	public function setNick(string $nick)
+	{
+		$this->nick = $nick;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getName()
+	{
+		return $this->name;
+	}
+
+	/**
+	 * @param string $name
+	 * Set
+	 */
+	public function setName(string $name)
+	{
+		$this->name = $name;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getAbout()
+	{
+		return $this->about;
+	}
+
+	/**
+	 * @param string $about
+	 * Set
+	 */
+	public function setAbout(string $about)
+	{
+		$this->about = $about;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getPhoto()
+	{
+		return $this->photo;
+	}
+
+	/**
+	 * @param string $photo
+	 * Set
+	 */
+	public function setPhoto(string $photo)
+	{
+		$this->photo = $photo;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getAddr()
+	{
+		return $this->addr;
+	}
+
+	/**
+	 * @param string $addr
+	 * Set
+	 */
+	public function setAddr(string $addr)
+	{
+		$this->addr = $addr;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getAlias()
+	{
+		return $this->alias;
+	}
+
+	/**
+	 * @param string $alias
+	 * Set
+	 */
+	public function setAlias(string $alias)
+	{
+		$this->alias = $alias;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getPubkey()
+	{
+		return $this->pubkey;
+	}
+
+	/**
+	 * @param string $pubkey
+	 * Set
+	 */
+	public function setPubkey(string $pubkey)
+	{
+		$this->pubkey = $pubkey;
+	}
+
+	/**
+	 * @return string
+	 * Get baseurl of the ap contact
+	 */
+	public function getBaseurl()
+	{
+		return $this->baseurl;
+	}
+
+	/**
+	 * @param string $baseurl
+	 * Set baseurl of the ap contact
+	 */
+	public function setBaseurl(string $baseurl)
+	{
+		$this->baseurl = $baseurl;
+	}
+
+	/**
+	 * @return string
+	 * Get Name of the contact's system
+	 */
+	public function getGenerator()
+	{
+		return $this->generator;
+	}
+
+	/**
+	 * @param string $generator
+	 * Set Name of the contact's system
+	 */
+	public function setGenerator(string $generator)
+	{
+		$this->generator = $generator;
+	}
+
+	/**
+	 * @return int
+	 * Get Number of following contacts
+	 */
+	public function getFollowingCount()
+	{
+		return $this->followingCount;
+	}
+
+	/**
+	 * @param int $followingCount
+	 * Set Number of following contacts
+	 */
+	public function setFollowingCount(int $followingCount)
+	{
+		$this->followingCount = $followingCount;
+	}
+
+	/**
+	 * @return int
+	 * Get Number of followers
+	 */
+	public function getFollowersCount()
+	{
+		return $this->followersCount;
+	}
+
+	/**
+	 * @param int $followersCount
+	 * Set Number of followers
+	 */
+	public function setFollowersCount(int $followersCount)
+	{
+		$this->followersCount = $followersCount;
+	}
+
+	/**
+	 * @return int
+	 * Get Number of posts
+	 */
+	public function getStatusesCount()
+	{
+		return $this->statusesCount;
+	}
+
+	/**
+	 * @param int $statusesCount
+	 * Set Number of posts
+	 */
+	public function setStatusesCount(int $statusesCount)
+	{
+		$this->statusesCount = $statusesCount;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getUpdated()
+	{
+		return $this->updated;
+	}
+
+	/**
+	 * @param string $updated
+	 * Set
+	 */
+	public function setUpdated(string $updated)
+	{
+		$this->updated = $updated;
+	}
+}

--- a/src/Domain/Entity/Attach.php
+++ b/src/Domain/Entity/Attach.php
@@ -1,0 +1,423 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity;
+
+use Friendica\BaseEntity;
+use Friendica\Network\HTTPException\NotImplementedException;
+
+/**
+ * Entity class for table attach
+ *
+ * file attachments
+ */
+class Attach extends BaseEntity
+{
+	/**
+	 * @var int
+	 * generated index
+	 */
+	private $id;
+
+	/**
+	 * @var int
+	 * Owner User id
+	 */
+	private $uid = '0';
+
+	/**
+	 * @var string
+	 * hash
+	 */
+	private $hash = '';
+
+	/**
+	 * @var string
+	 * filename of original
+	 */
+	private $filename = '';
+
+	/**
+	 * @var string
+	 * mimetype
+	 */
+	private $filetype = '';
+
+	/**
+	 * @var int
+	 * size in bytes
+	 */
+	private $filesize = '0';
+
+	/**
+	 * @var int
+	 * file data
+	 */
+	private $data;
+
+	/**
+	 * @var string
+	 * creation time
+	 */
+	private $created = '0001-01-01 00:00:00';
+
+	/**
+	 * @var string
+	 * last edit time
+	 */
+	private $edited = '0001-01-01 00:00:00';
+
+	/**
+	 * @var string
+	 * Access Control - list of allowed contact.id '<19><78>
+	 */
+	private $allowCid;
+
+	/**
+	 * @var string
+	 * Access Control - list of allowed groups
+	 */
+	private $allowGid;
+
+	/**
+	 * @var string
+	 * Access Control - list of denied contact.id
+	 */
+	private $denyCid;
+
+	/**
+	 * @var string
+	 * Access Control - list of denied groups
+	 */
+	private $denyGid;
+
+	/**
+	 * @var string
+	 * Storage backend class
+	 */
+	private $backendClass;
+
+	/**
+	 * @var string
+	 * Storage backend data reference
+	 */
+	private $backendRef;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'id' => $this->id,
+			'uid' => $this->uid,
+			'hash' => $this->hash,
+			'filename' => $this->filename,
+			'filetype' => $this->filetype,
+			'filesize' => $this->filesize,
+			'data' => $this->data,
+			'created' => $this->created,
+			'edited' => $this->edited,
+			'allow_cid' => $this->allowCid,
+			'allow_gid' => $this->allowGid,
+			'deny_cid' => $this->denyCid,
+			'deny_gid' => $this->denyGid,
+			'backend-class' => $this->backendClass,
+			'backend-ref' => $this->backendRef,
+		];
+	}
+
+	/**
+	 * @return int
+	 * Get generated index
+	 */
+	public function getId()
+	{
+		return $this->id;
+	}
+
+	/**
+	 * @return int
+	 * Get Owner User id
+	 */
+	public function getUid()
+	{
+		return $this->uid;
+	}
+
+	/**
+	 * @param int $uid
+	 * Set Owner User id
+	 */
+	public function setUid(int $uid)
+	{
+		$this->uid = $uid;
+	}
+
+	/**
+	 * Get User
+	 *
+	 * @return User
+	 */
+	public function getUser()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for uid is not implemented yet');
+	}
+
+	/**
+	 * @return string
+	 * Get hash
+	 */
+	public function getHash()
+	{
+		return $this->hash;
+	}
+
+	/**
+	 * @param string $hash
+	 * Set hash
+	 */
+	public function setHash(string $hash)
+	{
+		$this->hash = $hash;
+	}
+
+	/**
+	 * @return string
+	 * Get filename of original
+	 */
+	public function getFilename()
+	{
+		return $this->filename;
+	}
+
+	/**
+	 * @param string $filename
+	 * Set filename of original
+	 */
+	public function setFilename(string $filename)
+	{
+		$this->filename = $filename;
+	}
+
+	/**
+	 * @return string
+	 * Get mimetype
+	 */
+	public function getFiletype()
+	{
+		return $this->filetype;
+	}
+
+	/**
+	 * @param string $filetype
+	 * Set mimetype
+	 */
+	public function setFiletype(string $filetype)
+	{
+		$this->filetype = $filetype;
+	}
+
+	/**
+	 * @return int
+	 * Get size in bytes
+	 */
+	public function getFilesize()
+	{
+		return $this->filesize;
+	}
+
+	/**
+	 * @param int $filesize
+	 * Set size in bytes
+	 */
+	public function setFilesize(int $filesize)
+	{
+		$this->filesize = $filesize;
+	}
+
+	/**
+	 * @return int
+	 * Get file data
+	 */
+	public function getData()
+	{
+		return $this->data;
+	}
+
+	/**
+	 * @param int $data
+	 * Set file data
+	 */
+	public function setData(int $data)
+	{
+		$this->data = $data;
+	}
+
+	/**
+	 * @return string
+	 * Get creation time
+	 */
+	public function getCreated()
+	{
+		return $this->created;
+	}
+
+	/**
+	 * @param string $created
+	 * Set creation time
+	 */
+	public function setCreated(string $created)
+	{
+		$this->created = $created;
+	}
+
+	/**
+	 * @return string
+	 * Get last edit time
+	 */
+	public function getEdited()
+	{
+		return $this->edited;
+	}
+
+	/**
+	 * @param string $edited
+	 * Set last edit time
+	 */
+	public function setEdited(string $edited)
+	{
+		$this->edited = $edited;
+	}
+
+	/**
+	 * @return string
+	 * Get Access Control - list of allowed contact.id '<19><78>
+	 */
+	public function getAllowCid()
+	{
+		return $this->allowCid;
+	}
+
+	/**
+	 * @param string $allowCid
+	 * Set Access Control - list of allowed contact.id '<19><78>
+	 */
+	public function setAllowCid(string $allowCid)
+	{
+		$this->allowCid = $allowCid;
+	}
+
+	/**
+	 * @return string
+	 * Get Access Control - list of allowed groups
+	 */
+	public function getAllowGid()
+	{
+		return $this->allowGid;
+	}
+
+	/**
+	 * @param string $allowGid
+	 * Set Access Control - list of allowed groups
+	 */
+	public function setAllowGid(string $allowGid)
+	{
+		$this->allowGid = $allowGid;
+	}
+
+	/**
+	 * @return string
+	 * Get Access Control - list of denied contact.id
+	 */
+	public function getDenyCid()
+	{
+		return $this->denyCid;
+	}
+
+	/**
+	 * @param string $denyCid
+	 * Set Access Control - list of denied contact.id
+	 */
+	public function setDenyCid(string $denyCid)
+	{
+		$this->denyCid = $denyCid;
+	}
+
+	/**
+	 * @return string
+	 * Get Access Control - list of denied groups
+	 */
+	public function getDenyGid()
+	{
+		return $this->denyGid;
+	}
+
+	/**
+	 * @param string $denyGid
+	 * Set Access Control - list of denied groups
+	 */
+	public function setDenyGid(string $denyGid)
+	{
+		$this->denyGid = $denyGid;
+	}
+
+	/**
+	 * @return string
+	 * Get Storage backend class
+	 */
+	public function getBackendClass()
+	{
+		return $this->backendClass;
+	}
+
+	/**
+	 * @param string $backendClass
+	 * Set Storage backend class
+	 */
+	public function setBackendClass(string $backendClass)
+	{
+		$this->backendClass = $backendClass;
+	}
+
+	/**
+	 * @return string
+	 * Get Storage backend data reference
+	 */
+	public function getBackendRef()
+	{
+		return $this->backendRef;
+	}
+
+	/**
+	 * @param string $backendRef
+	 * Set Storage backend data reference
+	 */
+	public function setBackendRef(string $backendRef)
+	{
+		$this->backendRef = $backendRef;
+	}
+}

--- a/src/Domain/Entity/AuthCodes.php
+++ b/src/Domain/Entity/AuthCodes.php
@@ -1,0 +1,168 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity;
+
+use Friendica\BaseEntity;
+use Friendica\Network\HTTPException\NotImplementedException;
+
+/**
+ * Entity class for table auth_codes
+ *
+ * OAuth usage
+ */
+class AuthCodes extends BaseEntity
+{
+	/**
+	 * @var string
+	 */
+	private $id;
+
+	/**
+	 * @var string
+	 */
+	private $clientId = '';
+
+	/**
+	 * @var string
+	 */
+	private $redirectUri = '';
+
+	/**
+	 * @var int
+	 */
+	private $expires = '0';
+
+	/**
+	 * @var string
+	 */
+	private $scope = '';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'id' => $this->id,
+			'client_id' => $this->clientId,
+			'redirect_uri' => $this->redirectUri,
+			'expires' => $this->expires,
+			'scope' => $this->scope,
+		];
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getId()
+	{
+		return $this->id;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getClientId()
+	{
+		return $this->clientId;
+	}
+
+	/**
+	 * @param string $clientId
+	 * Set
+	 */
+	public function setClientId(string $clientId)
+	{
+		$this->clientId = $clientId;
+	}
+
+	/**
+	 * Get Clients
+	 *
+	 * @return Clients
+	 */
+	public function getClients()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for clientId is not implemented yet');
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getRedirectUri()
+	{
+		return $this->redirectUri;
+	}
+
+	/**
+	 * @param string $redirectUri
+	 * Set
+	 */
+	public function setRedirectUri(string $redirectUri)
+	{
+		$this->redirectUri = $redirectUri;
+	}
+
+	/**
+	 * @return int
+	 * Get
+	 */
+	public function getExpires()
+	{
+		return $this->expires;
+	}
+
+	/**
+	 * @param int $expires
+	 * Set
+	 */
+	public function setExpires(int $expires)
+	{
+		$this->expires = $expires;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getScope()
+	{
+		return $this->scope;
+	}
+
+	/**
+	 * @param string $scope
+	 * Set
+	 */
+	public function setScope(string $scope)
+	{
+		$this->scope = $scope;
+	}
+}

--- a/src/Domain/Entity/Cache.php
+++ b/src/Domain/Entity/Cache.php
@@ -1,0 +1,136 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity;
+
+use Friendica\BaseEntity;
+
+/**
+ * Entity class for table cache
+ *
+ * Stores temporary data
+ */
+class Cache extends BaseEntity
+{
+	/**
+	 * @var string
+	 * cache key
+	 */
+	private $k;
+
+	/**
+	 * @var string
+	 * cached serialized value
+	 */
+	private $v;
+
+	/**
+	 * @var string
+	 * datetime of cache expiration
+	 */
+	private $expires = '0001-01-01 00:00:00';
+
+	/**
+	 * @var string
+	 * datetime of cache insertion
+	 */
+	private $updated = '0001-01-01 00:00:00';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'k' => $this->k,
+			'v' => $this->v,
+			'expires' => $this->expires,
+			'updated' => $this->updated,
+		];
+	}
+
+	/**
+	 * @return string
+	 * Get cache key
+	 */
+	public function getK()
+	{
+		return $this->k;
+	}
+
+	/**
+	 * @return string
+	 * Get cached serialized value
+	 */
+	public function getV()
+	{
+		return $this->v;
+	}
+
+	/**
+	 * @param string $v
+	 * Set cached serialized value
+	 */
+	public function setV(string $v)
+	{
+		$this->v = $v;
+	}
+
+	/**
+	 * @return string
+	 * Get datetime of cache expiration
+	 */
+	public function getExpires()
+	{
+		return $this->expires;
+	}
+
+	/**
+	 * @param string $expires
+	 * Set datetime of cache expiration
+	 */
+	public function setExpires(string $expires)
+	{
+		$this->expires = $expires;
+	}
+
+	/**
+	 * @return string
+	 * Get datetime of cache insertion
+	 */
+	public function getUpdated()
+	{
+		return $this->updated;
+	}
+
+	/**
+	 * @param string $updated
+	 * Set datetime of cache insertion
+	 */
+	public function setUpdated(string $updated)
+	{
+		$this->updated = $updated;
+	}
+}

--- a/src/Domain/Entity/Challenge.php
+++ b/src/Domain/Entity/Challenge.php
@@ -1,0 +1,179 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity;
+
+use Friendica\BaseEntity;
+
+/**
+ * Entity class for table challenge
+ */
+class Challenge extends BaseEntity
+{
+	/**
+	 * @var int
+	 * sequential ID
+	 */
+	private $id;
+
+	/**
+	 * @var string
+	 */
+	private $challenge = '';
+
+	/**
+	 * @var string
+	 */
+	private $dfrnId = '';
+
+	/**
+	 * @var int
+	 */
+	private $expire = '0';
+
+	/**
+	 * @var string
+	 */
+	private $type = '';
+
+	/**
+	 * @var string
+	 */
+	private $lastUpdate = '';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'id' => $this->id,
+			'challenge' => $this->challenge,
+			'dfrn-id' => $this->dfrnId,
+			'expire' => $this->expire,
+			'type' => $this->type,
+			'last_update' => $this->lastUpdate,
+		];
+	}
+
+	/**
+	 * @return int
+	 * Get sequential ID
+	 */
+	public function getId()
+	{
+		return $this->id;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getChallenge()
+	{
+		return $this->challenge;
+	}
+
+	/**
+	 * @param string $challenge
+	 * Set
+	 */
+	public function setChallenge(string $challenge)
+	{
+		$this->challenge = $challenge;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getDfrnId()
+	{
+		return $this->dfrnId;
+	}
+
+	/**
+	 * @param string $dfrnId
+	 * Set
+	 */
+	public function setDfrnId(string $dfrnId)
+	{
+		$this->dfrnId = $dfrnId;
+	}
+
+	/**
+	 * @return int
+	 * Get
+	 */
+	public function getExpire()
+	{
+		return $this->expire;
+	}
+
+	/**
+	 * @param int $expire
+	 * Set
+	 */
+	public function setExpire(int $expire)
+	{
+		$this->expire = $expire;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getType()
+	{
+		return $this->type;
+	}
+
+	/**
+	 * @param string $type
+	 * Set
+	 */
+	public function setType(string $type)
+	{
+		$this->type = $type;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getLastUpdate()
+	{
+		return $this->lastUpdate;
+	}
+
+	/**
+	 * @param string $lastUpdate
+	 * Set
+	 */
+	public function setLastUpdate(string $lastUpdate)
+	{
+		$this->lastUpdate = $lastUpdate;
+	}
+}

--- a/src/Domain/Entity/Clients.php
+++ b/src/Domain/Entity/Clients.php
@@ -1,0 +1,193 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity;
+
+use Friendica\BaseEntity;
+use Friendica\Network\HTTPException\NotImplementedException;
+
+/**
+ * Entity class for table clients
+ *
+ * OAuth usage
+ */
+class Clients extends BaseEntity
+{
+	/**
+	 * @var string
+	 */
+	private $clientId;
+
+	/**
+	 * @var string
+	 */
+	private $pw = '';
+
+	/**
+	 * @var string
+	 */
+	private $redirectUri = '';
+
+	/**
+	 * @var string
+	 */
+	private $name;
+
+	/**
+	 * @var string
+	 */
+	private $icon;
+
+	/**
+	 * @var int
+	 * User id
+	 */
+	private $uid = '0';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'client_id' => $this->clientId,
+			'pw' => $this->pw,
+			'redirect_uri' => $this->redirectUri,
+			'name' => $this->name,
+			'icon' => $this->icon,
+			'uid' => $this->uid,
+		];
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getClientId()
+	{
+		return $this->clientId;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getPw()
+	{
+		return $this->pw;
+	}
+
+	/**
+	 * @param string $pw
+	 * Set
+	 */
+	public function setPw(string $pw)
+	{
+		$this->pw = $pw;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getRedirectUri()
+	{
+		return $this->redirectUri;
+	}
+
+	/**
+	 * @param string $redirectUri
+	 * Set
+	 */
+	public function setRedirectUri(string $redirectUri)
+	{
+		$this->redirectUri = $redirectUri;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getName()
+	{
+		return $this->name;
+	}
+
+	/**
+	 * @param string $name
+	 * Set
+	 */
+	public function setName(string $name)
+	{
+		$this->name = $name;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getIcon()
+	{
+		return $this->icon;
+	}
+
+	/**
+	 * @param string $icon
+	 * Set
+	 */
+	public function setIcon(string $icon)
+	{
+		$this->icon = $icon;
+	}
+
+	/**
+	 * @return int
+	 * Get User id
+	 */
+	public function getUid()
+	{
+		return $this->uid;
+	}
+
+	/**
+	 * @param int $uid
+	 * Set User id
+	 */
+	public function setUid(int $uid)
+	{
+		$this->uid = $uid;
+	}
+
+	/**
+	 * Get User
+	 *
+	 * @return User
+	 */
+	public function getUser()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for uid is not implemented yet');
+	}
+}

--- a/src/Domain/Entity/Config.php
+++ b/src/Domain/Entity/Config.php
@@ -1,0 +1,132 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity;
+
+use Friendica\BaseEntity;
+
+/**
+ * Entity class for table config
+ *
+ * main configuration storage
+ */
+class Config extends BaseEntity
+{
+	/**
+	 * @var int
+	 */
+	private $id;
+
+	/**
+	 * @var string
+	 */
+	private $cat = '';
+
+	/**
+	 * @var string
+	 */
+	private $k = '';
+
+	/**
+	 * @var string
+	 */
+	private $v;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'id' => $this->id,
+			'cat' => $this->cat,
+			'k' => $this->k,
+			'v' => $this->v,
+		];
+	}
+
+	/**
+	 * @return int
+	 * Get
+	 */
+	public function getId()
+	{
+		return $this->id;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getCat()
+	{
+		return $this->cat;
+	}
+
+	/**
+	 * @param string $cat
+	 * Set
+	 */
+	public function setCat(string $cat)
+	{
+		$this->cat = $cat;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getK()
+	{
+		return $this->k;
+	}
+
+	/**
+	 * @param string $k
+	 * Set
+	 */
+	public function setK(string $k)
+	{
+		$this->k = $k;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getV()
+	{
+		return $this->v;
+	}
+
+	/**
+	 * @param string $v
+	 * Set
+	 */
+	public function setV(string $v)
+	{
+		$this->v = $v;
+	}
+}

--- a/src/Domain/Entity/Contact.php
+++ b/src/Domain/Entity/Contact.php
@@ -1,0 +1,1877 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity;
+
+use Friendica\BaseEntity;
+use Friendica\Network\HTTPException\NotImplementedException;
+
+/**
+ * Entity class for table contact
+ *
+ * contact table
+ */
+class Contact extends BaseEntity
+{
+	/**
+	 * @var int
+	 * sequential ID
+	 */
+	private $id;
+
+	/**
+	 * @var int
+	 * Owner User id
+	 */
+	private $uid = '0';
+
+	/**
+	 * @var string
+	 */
+	private $created = '0001-01-01 00:00:00';
+
+	/**
+	 * @var string
+	 * Date of last contact update
+	 */
+	private $updated = '0001-01-01 00:00:00';
+
+	/**
+	 * @var bool
+	 * 1 if the contact is the user him/her self
+	 */
+	private $self = '0';
+
+	/**
+	 * @var bool
+	 */
+	private $remoteSelf = '0';
+
+	/**
+	 * @var string
+	 * The kind of the relation between the user and the contact
+	 */
+	private $rel = '0';
+
+	/**
+	 * @var bool
+	 */
+	private $duplex = '0';
+
+	/**
+	 * @var string
+	 * Network of the contact
+	 */
+	private $network = '';
+
+	/**
+	 * @var string
+	 * Protocol of the contact
+	 */
+	private $protocol = '';
+
+	/**
+	 * @var string
+	 * Name that this contact is known by
+	 */
+	private $name = '';
+
+	/**
+	 * @var string
+	 * Nick- and user name of the contact
+	 */
+	private $nick = '';
+
+	/**
+	 * @var string
+	 */
+	private $location = '';
+
+	/**
+	 * @var string
+	 */
+	private $about;
+
+	/**
+	 * @var string
+	 * public keywords (interests) of the contact
+	 */
+	private $keywords;
+
+	/**
+	 * @var string
+	 */
+	private $gender = '';
+
+	/**
+	 * @var string
+	 */
+	private $xmpp = '';
+
+	/**
+	 * @var string
+	 */
+	private $attag = '';
+
+	/**
+	 * @var string
+	 */
+	private $avatar = '';
+
+	/**
+	 * @var string
+	 * Link to the profile photo of the contact
+	 */
+	private $photo = '';
+
+	/**
+	 * @var string
+	 * Link to the profile photo (thumb size)
+	 */
+	private $thumb = '';
+
+	/**
+	 * @var string
+	 * Link to the profile photo (micro size)
+	 */
+	private $micro = '';
+
+	/**
+	 * @var string
+	 */
+	private $sitePubkey;
+
+	/**
+	 * @var string
+	 */
+	private $issuedId = '';
+
+	/**
+	 * @var string
+	 */
+	private $dfrnId = '';
+
+	/**
+	 * @var string
+	 */
+	private $url = '';
+
+	/**
+	 * @var string
+	 */
+	private $nurl = '';
+
+	/**
+	 * @var string
+	 */
+	private $addr = '';
+
+	/**
+	 * @var string
+	 */
+	private $alias = '';
+
+	/**
+	 * @var string
+	 * RSA public key 4096 bit
+	 */
+	private $pubkey;
+
+	/**
+	 * @var string
+	 * RSA private key 4096 bit
+	 */
+	private $prvkey;
+
+	/**
+	 * @var string
+	 */
+	private $batch = '';
+
+	/**
+	 * @var string
+	 */
+	private $request;
+
+	/**
+	 * @var string
+	 */
+	private $notify;
+
+	/**
+	 * @var string
+	 */
+	private $poll;
+
+	/**
+	 * @var string
+	 */
+	private $confirm;
+
+	/**
+	 * @var string
+	 */
+	private $poco;
+
+	/**
+	 * @var bool
+	 */
+	private $aesAllow = '0';
+
+	/**
+	 * @var bool
+	 */
+	private $retAes = '0';
+
+	/**
+	 * @var bool
+	 */
+	private $usehub = '0';
+
+	/**
+	 * @var bool
+	 */
+	private $subhub = '0';
+
+	/**
+	 * @var string
+	 */
+	private $hubVerify = '';
+
+	/**
+	 * @var string
+	 * Date of the last try to update the contact info
+	 */
+	private $lastUpdate = '0001-01-01 00:00:00';
+
+	/**
+	 * @var string
+	 * Date of the last successful contact update
+	 */
+	private $successUpdate = '0001-01-01 00:00:00';
+
+	/**
+	 * @var string
+	 * Date of the last failed update
+	 */
+	private $failureUpdate = '0001-01-01 00:00:00';
+
+	/**
+	 * @var string
+	 */
+	private $nameDate = '0001-01-01 00:00:00';
+
+	/**
+	 * @var string
+	 */
+	private $uriDate = '0001-01-01 00:00:00';
+
+	/**
+	 * @var string
+	 */
+	private $avatarDate = '0001-01-01 00:00:00';
+
+	/**
+	 * @var string
+	 */
+	private $termDate = '0001-01-01 00:00:00';
+
+	/**
+	 * @var string
+	 * date of the last post
+	 */
+	private $lastItem = '0001-01-01 00:00:00';
+
+	/**
+	 * @var string
+	 */
+	private $priority = '0';
+
+	/**
+	 * @var bool
+	 * Node-wide block status
+	 */
+	private $blocked = '1';
+
+	/**
+	 * @var string
+	 * Node-wide block reason
+	 */
+	private $blockReason;
+
+	/**
+	 * @var bool
+	 * posts of the contact are readonly
+	 */
+	private $readonly = '0';
+
+	/**
+	 * @var bool
+	 */
+	private $writable = '0';
+
+	/**
+	 * @var bool
+	 * contact is a forum
+	 */
+	private $forum = '0';
+
+	/**
+	 * @var bool
+	 * contact is a private group
+	 */
+	private $prv = '0';
+
+	/**
+	 * @var string
+	 */
+	private $contactType = '0';
+
+	/**
+	 * @var bool
+	 */
+	private $hidden = '0';
+
+	/**
+	 * @var bool
+	 */
+	private $archive = '0';
+
+	/**
+	 * @var bool
+	 */
+	private $pending = '1';
+
+	/**
+	 * @var bool
+	 * Contact has been deleted
+	 */
+	private $deleted = '0';
+
+	/**
+	 * @var string
+	 */
+	private $rating = '0';
+
+	/**
+	 * @var bool
+	 * Contact prefers to not be searchable
+	 */
+	private $unsearchable = '0';
+
+	/**
+	 * @var bool
+	 * Contact posts sensitive content
+	 */
+	private $sensitive = '0';
+
+	/**
+	 * @var string
+	 * baseurl of the contact
+	 */
+	private $baseurl = '';
+
+	/**
+	 * @var string
+	 */
+	private $reason;
+
+	/**
+	 * @var string
+	 */
+	private $closeness = '99';
+
+	/**
+	 * @var string
+	 */
+	private $info;
+
+	/**
+	 * @var int
+	 * Deprecated
+	 */
+	private $profileId;
+
+	/**
+	 * @var string
+	 */
+	private $bdyear = '';
+
+	/**
+	 * @var string
+	 */
+	private $bd = '0001-01-01';
+
+	/**
+	 * @var bool
+	 */
+	private $notifyNewPosts = '0';
+
+	/**
+	 * @var string
+	 */
+	private $fetchFurtherInformation = '0';
+
+	/**
+	 * @var string
+	 */
+	private $ffiKeywordBlacklist;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'id' => $this->id,
+			'uid' => $this->uid,
+			'created' => $this->created,
+			'updated' => $this->updated,
+			'self' => $this->self,
+			'remote_self' => $this->remoteSelf,
+			'rel' => $this->rel,
+			'duplex' => $this->duplex,
+			'network' => $this->network,
+			'protocol' => $this->protocol,
+			'name' => $this->name,
+			'nick' => $this->nick,
+			'location' => $this->location,
+			'about' => $this->about,
+			'keywords' => $this->keywords,
+			'gender' => $this->gender,
+			'xmpp' => $this->xmpp,
+			'attag' => $this->attag,
+			'avatar' => $this->avatar,
+			'photo' => $this->photo,
+			'thumb' => $this->thumb,
+			'micro' => $this->micro,
+			'site-pubkey' => $this->sitePubkey,
+			'issued-id' => $this->issuedId,
+			'dfrn-id' => $this->dfrnId,
+			'url' => $this->url,
+			'nurl' => $this->nurl,
+			'addr' => $this->addr,
+			'alias' => $this->alias,
+			'pubkey' => $this->pubkey,
+			'prvkey' => $this->prvkey,
+			'batch' => $this->batch,
+			'request' => $this->request,
+			'notify' => $this->notify,
+			'poll' => $this->poll,
+			'confirm' => $this->confirm,
+			'poco' => $this->poco,
+			'aes_allow' => $this->aesAllow,
+			'ret-aes' => $this->retAes,
+			'usehub' => $this->usehub,
+			'subhub' => $this->subhub,
+			'hub-verify' => $this->hubVerify,
+			'last-update' => $this->lastUpdate,
+			'success_update' => $this->successUpdate,
+			'failure_update' => $this->failureUpdate,
+			'name-date' => $this->nameDate,
+			'uri-date' => $this->uriDate,
+			'avatar-date' => $this->avatarDate,
+			'term-date' => $this->termDate,
+			'last-item' => $this->lastItem,
+			'priority' => $this->priority,
+			'blocked' => $this->blocked,
+			'block_reason' => $this->blockReason,
+			'readonly' => $this->readonly,
+			'writable' => $this->writable,
+			'forum' => $this->forum,
+			'prv' => $this->prv,
+			'contact-type' => $this->contactType,
+			'hidden' => $this->hidden,
+			'archive' => $this->archive,
+			'pending' => $this->pending,
+			'deleted' => $this->deleted,
+			'rating' => $this->rating,
+			'unsearchable' => $this->unsearchable,
+			'sensitive' => $this->sensitive,
+			'baseurl' => $this->baseurl,
+			'reason' => $this->reason,
+			'closeness' => $this->closeness,
+			'info' => $this->info,
+			'profile-id' => $this->profileId,
+			'bdyear' => $this->bdyear,
+			'bd' => $this->bd,
+			'notify_new_posts' => $this->notifyNewPosts,
+			'fetch_further_information' => $this->fetchFurtherInformation,
+			'ffi_keyword_blacklist' => $this->ffiKeywordBlacklist,
+		];
+	}
+
+	/**
+	 * @return int
+	 * Get sequential ID
+	 */
+	public function getId()
+	{
+		return $this->id;
+	}
+
+	/**
+	 * @return int
+	 * Get Owner User id
+	 */
+	public function getUid()
+	{
+		return $this->uid;
+	}
+
+	/**
+	 * @param int $uid
+	 * Set Owner User id
+	 */
+	public function setUid(int $uid)
+	{
+		$this->uid = $uid;
+	}
+
+	/**
+	 * Get User
+	 *
+	 * @return User
+	 */
+	public function getUser()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for uid is not implemented yet');
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getCreated()
+	{
+		return $this->created;
+	}
+
+	/**
+	 * @param string $created
+	 * Set
+	 */
+	public function setCreated(string $created)
+	{
+		$this->created = $created;
+	}
+
+	/**
+	 * @return string
+	 * Get Date of last contact update
+	 */
+	public function getUpdated()
+	{
+		return $this->updated;
+	}
+
+	/**
+	 * @param string $updated
+	 * Set Date of last contact update
+	 */
+	public function setUpdated(string $updated)
+	{
+		$this->updated = $updated;
+	}
+
+	/**
+	 * @return bool
+	 * Get 1 if the contact is the user him/her self
+	 */
+	public function getSelf()
+	{
+		return $this->self;
+	}
+
+	/**
+	 * @param bool $self
+	 * Set 1 if the contact is the user him/her self
+	 */
+	public function setSelf(bool $self)
+	{
+		$this->self = $self;
+	}
+
+	/**
+	 * @return bool
+	 * Get
+	 */
+	public function getRemoteSelf()
+	{
+		return $this->remoteSelf;
+	}
+
+	/**
+	 * @param bool $remoteSelf
+	 * Set
+	 */
+	public function setRemoteSelf(bool $remoteSelf)
+	{
+		$this->remoteSelf = $remoteSelf;
+	}
+
+	/**
+	 * @return string
+	 * Get The kind of the relation between the user and the contact
+	 */
+	public function getRel()
+	{
+		return $this->rel;
+	}
+
+	/**
+	 * @param string $rel
+	 * Set The kind of the relation between the user and the contact
+	 */
+	public function setRel(string $rel)
+	{
+		$this->rel = $rel;
+	}
+
+	/**
+	 * @return bool
+	 * Get
+	 */
+	public function getDuplex()
+	{
+		return $this->duplex;
+	}
+
+	/**
+	 * @param bool $duplex
+	 * Set
+	 */
+	public function setDuplex(bool $duplex)
+	{
+		$this->duplex = $duplex;
+	}
+
+	/**
+	 * @return string
+	 * Get Network of the contact
+	 */
+	public function getNetwork()
+	{
+		return $this->network;
+	}
+
+	/**
+	 * @param string $network
+	 * Set Network of the contact
+	 */
+	public function setNetwork(string $network)
+	{
+		$this->network = $network;
+	}
+
+	/**
+	 * @return string
+	 * Get Protocol of the contact
+	 */
+	public function getProtocol()
+	{
+		return $this->protocol;
+	}
+
+	/**
+	 * @param string $protocol
+	 * Set Protocol of the contact
+	 */
+	public function setProtocol(string $protocol)
+	{
+		$this->protocol = $protocol;
+	}
+
+	/**
+	 * @return string
+	 * Get Name that this contact is known by
+	 */
+	public function getName()
+	{
+		return $this->name;
+	}
+
+	/**
+	 * @param string $name
+	 * Set Name that this contact is known by
+	 */
+	public function setName(string $name)
+	{
+		$this->name = $name;
+	}
+
+	/**
+	 * @return string
+	 * Get Nick- and user name of the contact
+	 */
+	public function getNick()
+	{
+		return $this->nick;
+	}
+
+	/**
+	 * @param string $nick
+	 * Set Nick- and user name of the contact
+	 */
+	public function setNick(string $nick)
+	{
+		$this->nick = $nick;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getLocation()
+	{
+		return $this->location;
+	}
+
+	/**
+	 * @param string $location
+	 * Set
+	 */
+	public function setLocation(string $location)
+	{
+		$this->location = $location;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getAbout()
+	{
+		return $this->about;
+	}
+
+	/**
+	 * @param string $about
+	 * Set
+	 */
+	public function setAbout(string $about)
+	{
+		$this->about = $about;
+	}
+
+	/**
+	 * @return string
+	 * Get public keywords (interests) of the contact
+	 */
+	public function getKeywords()
+	{
+		return $this->keywords;
+	}
+
+	/**
+	 * @param string $keywords
+	 * Set public keywords (interests) of the contact
+	 */
+	public function setKeywords(string $keywords)
+	{
+		$this->keywords = $keywords;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getGender()
+	{
+		return $this->gender;
+	}
+
+	/**
+	 * @param string $gender
+	 * Set
+	 */
+	public function setGender(string $gender)
+	{
+		$this->gender = $gender;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getXmpp()
+	{
+		return $this->xmpp;
+	}
+
+	/**
+	 * @param string $xmpp
+	 * Set
+	 */
+	public function setXmpp(string $xmpp)
+	{
+		$this->xmpp = $xmpp;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getAttag()
+	{
+		return $this->attag;
+	}
+
+	/**
+	 * @param string $attag
+	 * Set
+	 */
+	public function setAttag(string $attag)
+	{
+		$this->attag = $attag;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getAvatar()
+	{
+		return $this->avatar;
+	}
+
+	/**
+	 * @param string $avatar
+	 * Set
+	 */
+	public function setAvatar(string $avatar)
+	{
+		$this->avatar = $avatar;
+	}
+
+	/**
+	 * @return string
+	 * Get Link to the profile photo of the contact
+	 */
+	public function getPhoto()
+	{
+		return $this->photo;
+	}
+
+	/**
+	 * @param string $photo
+	 * Set Link to the profile photo of the contact
+	 */
+	public function setPhoto(string $photo)
+	{
+		$this->photo = $photo;
+	}
+
+	/**
+	 * @return string
+	 * Get Link to the profile photo (thumb size)
+	 */
+	public function getThumb()
+	{
+		return $this->thumb;
+	}
+
+	/**
+	 * @param string $thumb
+	 * Set Link to the profile photo (thumb size)
+	 */
+	public function setThumb(string $thumb)
+	{
+		$this->thumb = $thumb;
+	}
+
+	/**
+	 * @return string
+	 * Get Link to the profile photo (micro size)
+	 */
+	public function getMicro()
+	{
+		return $this->micro;
+	}
+
+	/**
+	 * @param string $micro
+	 * Set Link to the profile photo (micro size)
+	 */
+	public function setMicro(string $micro)
+	{
+		$this->micro = $micro;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getSitePubkey()
+	{
+		return $this->sitePubkey;
+	}
+
+	/**
+	 * @param string $sitePubkey
+	 * Set
+	 */
+	public function setSitePubkey(string $sitePubkey)
+	{
+		$this->sitePubkey = $sitePubkey;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getIssuedId()
+	{
+		return $this->issuedId;
+	}
+
+	/**
+	 * @param string $issuedId
+	 * Set
+	 */
+	public function setIssuedId(string $issuedId)
+	{
+		$this->issuedId = $issuedId;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getDfrnId()
+	{
+		return $this->dfrnId;
+	}
+
+	/**
+	 * @param string $dfrnId
+	 * Set
+	 */
+	public function setDfrnId(string $dfrnId)
+	{
+		$this->dfrnId = $dfrnId;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getUrl()
+	{
+		return $this->url;
+	}
+
+	/**
+	 * @param string $url
+	 * Set
+	 */
+	public function setUrl(string $url)
+	{
+		$this->url = $url;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getNurl()
+	{
+		return $this->nurl;
+	}
+
+	/**
+	 * @param string $nurl
+	 * Set
+	 */
+	public function setNurl(string $nurl)
+	{
+		$this->nurl = $nurl;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getAddr()
+	{
+		return $this->addr;
+	}
+
+	/**
+	 * @param string $addr
+	 * Set
+	 */
+	public function setAddr(string $addr)
+	{
+		$this->addr = $addr;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getAlias()
+	{
+		return $this->alias;
+	}
+
+	/**
+	 * @param string $alias
+	 * Set
+	 */
+	public function setAlias(string $alias)
+	{
+		$this->alias = $alias;
+	}
+
+	/**
+	 * @return string
+	 * Get RSA public key 4096 bit
+	 */
+	public function getPubkey()
+	{
+		return $this->pubkey;
+	}
+
+	/**
+	 * @param string $pubkey
+	 * Set RSA public key 4096 bit
+	 */
+	public function setPubkey(string $pubkey)
+	{
+		$this->pubkey = $pubkey;
+	}
+
+	/**
+	 * @return string
+	 * Get RSA private key 4096 bit
+	 */
+	public function getPrvkey()
+	{
+		return $this->prvkey;
+	}
+
+	/**
+	 * @param string $prvkey
+	 * Set RSA private key 4096 bit
+	 */
+	public function setPrvkey(string $prvkey)
+	{
+		$this->prvkey = $prvkey;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getBatch()
+	{
+		return $this->batch;
+	}
+
+	/**
+	 * @param string $batch
+	 * Set
+	 */
+	public function setBatch(string $batch)
+	{
+		$this->batch = $batch;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getRequest()
+	{
+		return $this->request;
+	}
+
+	/**
+	 * @param string $request
+	 * Set
+	 */
+	public function setRequest(string $request)
+	{
+		$this->request = $request;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getNotify()
+	{
+		return $this->notify;
+	}
+
+	/**
+	 * @param string $notify
+	 * Set
+	 */
+	public function setNotify(string $notify)
+	{
+		$this->notify = $notify;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getPoll()
+	{
+		return $this->poll;
+	}
+
+	/**
+	 * @param string $poll
+	 * Set
+	 */
+	public function setPoll(string $poll)
+	{
+		$this->poll = $poll;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getConfirm()
+	{
+		return $this->confirm;
+	}
+
+	/**
+	 * @param string $confirm
+	 * Set
+	 */
+	public function setConfirm(string $confirm)
+	{
+		$this->confirm = $confirm;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getPoco()
+	{
+		return $this->poco;
+	}
+
+	/**
+	 * @param string $poco
+	 * Set
+	 */
+	public function setPoco(string $poco)
+	{
+		$this->poco = $poco;
+	}
+
+	/**
+	 * @return bool
+	 * Get
+	 */
+	public function getAesAllow()
+	{
+		return $this->aesAllow;
+	}
+
+	/**
+	 * @param bool $aesAllow
+	 * Set
+	 */
+	public function setAesAllow(bool $aesAllow)
+	{
+		$this->aesAllow = $aesAllow;
+	}
+
+	/**
+	 * @return bool
+	 * Get
+	 */
+	public function getRetAes()
+	{
+		return $this->retAes;
+	}
+
+	/**
+	 * @param bool $retAes
+	 * Set
+	 */
+	public function setRetAes(bool $retAes)
+	{
+		$this->retAes = $retAes;
+	}
+
+	/**
+	 * @return bool
+	 * Get
+	 */
+	public function getUsehub()
+	{
+		return $this->usehub;
+	}
+
+	/**
+	 * @param bool $usehub
+	 * Set
+	 */
+	public function setUsehub(bool $usehub)
+	{
+		$this->usehub = $usehub;
+	}
+
+	/**
+	 * @return bool
+	 * Get
+	 */
+	public function getSubhub()
+	{
+		return $this->subhub;
+	}
+
+	/**
+	 * @param bool $subhub
+	 * Set
+	 */
+	public function setSubhub(bool $subhub)
+	{
+		$this->subhub = $subhub;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getHubVerify()
+	{
+		return $this->hubVerify;
+	}
+
+	/**
+	 * @param string $hubVerify
+	 * Set
+	 */
+	public function setHubVerify(string $hubVerify)
+	{
+		$this->hubVerify = $hubVerify;
+	}
+
+	/**
+	 * @return string
+	 * Get Date of the last try to update the contact info
+	 */
+	public function getLastUpdate()
+	{
+		return $this->lastUpdate;
+	}
+
+	/**
+	 * @param string $lastUpdate
+	 * Set Date of the last try to update the contact info
+	 */
+	public function setLastUpdate(string $lastUpdate)
+	{
+		$this->lastUpdate = $lastUpdate;
+	}
+
+	/**
+	 * @return string
+	 * Get Date of the last successful contact update
+	 */
+	public function getSuccessUpdate()
+	{
+		return $this->successUpdate;
+	}
+
+	/**
+	 * @param string $successUpdate
+	 * Set Date of the last successful contact update
+	 */
+	public function setSuccessUpdate(string $successUpdate)
+	{
+		$this->successUpdate = $successUpdate;
+	}
+
+	/**
+	 * @return string
+	 * Get Date of the last failed update
+	 */
+	public function getFailureUpdate()
+	{
+		return $this->failureUpdate;
+	}
+
+	/**
+	 * @param string $failureUpdate
+	 * Set Date of the last failed update
+	 */
+	public function setFailureUpdate(string $failureUpdate)
+	{
+		$this->failureUpdate = $failureUpdate;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getNameDate()
+	{
+		return $this->nameDate;
+	}
+
+	/**
+	 * @param string $nameDate
+	 * Set
+	 */
+	public function setNameDate(string $nameDate)
+	{
+		$this->nameDate = $nameDate;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getUriDate()
+	{
+		return $this->uriDate;
+	}
+
+	/**
+	 * @param string $uriDate
+	 * Set
+	 */
+	public function setUriDate(string $uriDate)
+	{
+		$this->uriDate = $uriDate;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getAvatarDate()
+	{
+		return $this->avatarDate;
+	}
+
+	/**
+	 * @param string $avatarDate
+	 * Set
+	 */
+	public function setAvatarDate(string $avatarDate)
+	{
+		$this->avatarDate = $avatarDate;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getTermDate()
+	{
+		return $this->termDate;
+	}
+
+	/**
+	 * @param string $termDate
+	 * Set
+	 */
+	public function setTermDate(string $termDate)
+	{
+		$this->termDate = $termDate;
+	}
+
+	/**
+	 * @return string
+	 * Get date of the last post
+	 */
+	public function getLastItem()
+	{
+		return $this->lastItem;
+	}
+
+	/**
+	 * @param string $lastItem
+	 * Set date of the last post
+	 */
+	public function setLastItem(string $lastItem)
+	{
+		$this->lastItem = $lastItem;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getPriority()
+	{
+		return $this->priority;
+	}
+
+	/**
+	 * @param string $priority
+	 * Set
+	 */
+	public function setPriority(string $priority)
+	{
+		$this->priority = $priority;
+	}
+
+	/**
+	 * @return bool
+	 * Get Node-wide block status
+	 */
+	public function getBlocked()
+	{
+		return $this->blocked;
+	}
+
+	/**
+	 * @param bool $blocked
+	 * Set Node-wide block status
+	 */
+	public function setBlocked(bool $blocked)
+	{
+		$this->blocked = $blocked;
+	}
+
+	/**
+	 * @return string
+	 * Get Node-wide block reason
+	 */
+	public function getBlockReason()
+	{
+		return $this->blockReason;
+	}
+
+	/**
+	 * @param string $blockReason
+	 * Set Node-wide block reason
+	 */
+	public function setBlockReason(string $blockReason)
+	{
+		$this->blockReason = $blockReason;
+	}
+
+	/**
+	 * @return bool
+	 * Get posts of the contact are readonly
+	 */
+	public function getReadonly()
+	{
+		return $this->readonly;
+	}
+
+	/**
+	 * @param bool $readonly
+	 * Set posts of the contact are readonly
+	 */
+	public function setReadonly(bool $readonly)
+	{
+		$this->readonly = $readonly;
+	}
+
+	/**
+	 * @return bool
+	 * Get
+	 */
+	public function getWritable()
+	{
+		return $this->writable;
+	}
+
+	/**
+	 * @param bool $writable
+	 * Set
+	 */
+	public function setWritable(bool $writable)
+	{
+		$this->writable = $writable;
+	}
+
+	/**
+	 * @return bool
+	 * Get contact is a forum
+	 */
+	public function getForum()
+	{
+		return $this->forum;
+	}
+
+	/**
+	 * @param bool $forum
+	 * Set contact is a forum
+	 */
+	public function setForum(bool $forum)
+	{
+		$this->forum = $forum;
+	}
+
+	/**
+	 * @return bool
+	 * Get contact is a private group
+	 */
+	public function getPrv()
+	{
+		return $this->prv;
+	}
+
+	/**
+	 * @param bool $prv
+	 * Set contact is a private group
+	 */
+	public function setPrv(bool $prv)
+	{
+		$this->prv = $prv;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getContactType()
+	{
+		return $this->contactType;
+	}
+
+	/**
+	 * @param string $contactType
+	 * Set
+	 */
+	public function setContactType(string $contactType)
+	{
+		$this->contactType = $contactType;
+	}
+
+	/**
+	 * @return bool
+	 * Get
+	 */
+	public function getHidden()
+	{
+		return $this->hidden;
+	}
+
+	/**
+	 * @param bool $hidden
+	 * Set
+	 */
+	public function setHidden(bool $hidden)
+	{
+		$this->hidden = $hidden;
+	}
+
+	/**
+	 * @return bool
+	 * Get
+	 */
+	public function getArchive()
+	{
+		return $this->archive;
+	}
+
+	/**
+	 * @param bool $archive
+	 * Set
+	 */
+	public function setArchive(bool $archive)
+	{
+		$this->archive = $archive;
+	}
+
+	/**
+	 * @return bool
+	 * Get
+	 */
+	public function getPending()
+	{
+		return $this->pending;
+	}
+
+	/**
+	 * @param bool $pending
+	 * Set
+	 */
+	public function setPending(bool $pending)
+	{
+		$this->pending = $pending;
+	}
+
+	/**
+	 * @return bool
+	 * Get Contact has been deleted
+	 */
+	public function getDeleted()
+	{
+		return $this->deleted;
+	}
+
+	/**
+	 * @param bool $deleted
+	 * Set Contact has been deleted
+	 */
+	public function setDeleted(bool $deleted)
+	{
+		$this->deleted = $deleted;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getRating()
+	{
+		return $this->rating;
+	}
+
+	/**
+	 * @param string $rating
+	 * Set
+	 */
+	public function setRating(string $rating)
+	{
+		$this->rating = $rating;
+	}
+
+	/**
+	 * @return bool
+	 * Get Contact prefers to not be searchable
+	 */
+	public function getUnsearchable()
+	{
+		return $this->unsearchable;
+	}
+
+	/**
+	 * @param bool $unsearchable
+	 * Set Contact prefers to not be searchable
+	 */
+	public function setUnsearchable(bool $unsearchable)
+	{
+		$this->unsearchable = $unsearchable;
+	}
+
+	/**
+	 * @return bool
+	 * Get Contact posts sensitive content
+	 */
+	public function getSensitive()
+	{
+		return $this->sensitive;
+	}
+
+	/**
+	 * @param bool $sensitive
+	 * Set Contact posts sensitive content
+	 */
+	public function setSensitive(bool $sensitive)
+	{
+		$this->sensitive = $sensitive;
+	}
+
+	/**
+	 * @return string
+	 * Get baseurl of the contact
+	 */
+	public function getBaseurl()
+	{
+		return $this->baseurl;
+	}
+
+	/**
+	 * @param string $baseurl
+	 * Set baseurl of the contact
+	 */
+	public function setBaseurl(string $baseurl)
+	{
+		$this->baseurl = $baseurl;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getReason()
+	{
+		return $this->reason;
+	}
+
+	/**
+	 * @param string $reason
+	 * Set
+	 */
+	public function setReason(string $reason)
+	{
+		$this->reason = $reason;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getCloseness()
+	{
+		return $this->closeness;
+	}
+
+	/**
+	 * @param string $closeness
+	 * Set
+	 */
+	public function setCloseness(string $closeness)
+	{
+		$this->closeness = $closeness;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getInfo()
+	{
+		return $this->info;
+	}
+
+	/**
+	 * @param string $info
+	 * Set
+	 */
+	public function setInfo(string $info)
+	{
+		$this->info = $info;
+	}
+
+	/**
+	 * @return int
+	 * Get Deprecated
+	 */
+	public function getProfileId()
+	{
+		return $this->profileId;
+	}
+
+	/**
+	 * @param int $profileId
+	 * Set Deprecated
+	 */
+	public function setProfileId(int $profileId)
+	{
+		$this->profileId = $profileId;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getBdyear()
+	{
+		return $this->bdyear;
+	}
+
+	/**
+	 * @param string $bdyear
+	 * Set
+	 */
+	public function setBdyear(string $bdyear)
+	{
+		$this->bdyear = $bdyear;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getBd()
+	{
+		return $this->bd;
+	}
+
+	/**
+	 * @param string $bd
+	 * Set
+	 */
+	public function setBd(string $bd)
+	{
+		$this->bd = $bd;
+	}
+
+	/**
+	 * @return bool
+	 * Get
+	 */
+	public function getNotifyNewPosts()
+	{
+		return $this->notifyNewPosts;
+	}
+
+	/**
+	 * @param bool $notifyNewPosts
+	 * Set
+	 */
+	public function setNotifyNewPosts(bool $notifyNewPosts)
+	{
+		$this->notifyNewPosts = $notifyNewPosts;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getFetchFurtherInformation()
+	{
+		return $this->fetchFurtherInformation;
+	}
+
+	/**
+	 * @param string $fetchFurtherInformation
+	 * Set
+	 */
+	public function setFetchFurtherInformation(string $fetchFurtherInformation)
+	{
+		$this->fetchFurtherInformation = $fetchFurtherInformation;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getFfiKeywordBlacklist()
+	{
+		return $this->ffiKeywordBlacklist;
+	}
+
+	/**
+	 * @param string $ffiKeywordBlacklist
+	 * Set
+	 */
+	public function setFfiKeywordBlacklist(string $ffiKeywordBlacklist)
+	{
+		$this->ffiKeywordBlacklist = $ffiKeywordBlacklist;
+	}
+}

--- a/src/Domain/Entity/Conv.php
+++ b/src/Domain/Entity/Conv.php
@@ -1,0 +1,248 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity;
+
+use Friendica\BaseEntity;
+use Friendica\Network\HTTPException\NotImplementedException;
+
+/**
+ * Entity class for table conv
+ *
+ * private messages
+ */
+class Conv extends BaseEntity
+{
+	/**
+	 * @var int
+	 * sequential ID
+	 */
+	private $id;
+
+	/**
+	 * @var string
+	 * A unique identifier for this conversation
+	 */
+	private $guid = '';
+
+	/**
+	 * @var string
+	 * sender_handle;recipient_handle
+	 */
+	private $recips;
+
+	/**
+	 * @var int
+	 * Owner User id
+	 */
+	private $uid = '0';
+
+	/**
+	 * @var string
+	 * handle of creator
+	 */
+	private $creator = '';
+
+	/**
+	 * @var string
+	 * creation timestamp
+	 */
+	private $created = '0001-01-01 00:00:00';
+
+	/**
+	 * @var string
+	 * edited timestamp
+	 */
+	private $updated = '0001-01-01 00:00:00';
+
+	/**
+	 * @var string
+	 * subject of initial message
+	 */
+	private $subject;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'id' => $this->id,
+			'guid' => $this->guid,
+			'recips' => $this->recips,
+			'uid' => $this->uid,
+			'creator' => $this->creator,
+			'created' => $this->created,
+			'updated' => $this->updated,
+			'subject' => $this->subject,
+		];
+	}
+
+	/**
+	 * @return int
+	 * Get sequential ID
+	 */
+	public function getId()
+	{
+		return $this->id;
+	}
+
+	/**
+	 * @return string
+	 * Get A unique identifier for this conversation
+	 */
+	public function getGuid()
+	{
+		return $this->guid;
+	}
+
+	/**
+	 * @param string $guid
+	 * Set A unique identifier for this conversation
+	 */
+	public function setGuid(string $guid)
+	{
+		$this->guid = $guid;
+	}
+
+	/**
+	 * @return string
+	 * Get sender_handle;recipient_handle
+	 */
+	public function getRecips()
+	{
+		return $this->recips;
+	}
+
+	/**
+	 * @param string $recips
+	 * Set sender_handle;recipient_handle
+	 */
+	public function setRecips(string $recips)
+	{
+		$this->recips = $recips;
+	}
+
+	/**
+	 * @return int
+	 * Get Owner User id
+	 */
+	public function getUid()
+	{
+		return $this->uid;
+	}
+
+	/**
+	 * @param int $uid
+	 * Set Owner User id
+	 */
+	public function setUid(int $uid)
+	{
+		$this->uid = $uid;
+	}
+
+	/**
+	 * Get User
+	 *
+	 * @return User
+	 */
+	public function getUser()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for uid is not implemented yet');
+	}
+
+	/**
+	 * @return string
+	 * Get handle of creator
+	 */
+	public function getCreator()
+	{
+		return $this->creator;
+	}
+
+	/**
+	 * @param string $creator
+	 * Set handle of creator
+	 */
+	public function setCreator(string $creator)
+	{
+		$this->creator = $creator;
+	}
+
+	/**
+	 * @return string
+	 * Get creation timestamp
+	 */
+	public function getCreated()
+	{
+		return $this->created;
+	}
+
+	/**
+	 * @param string $created
+	 * Set creation timestamp
+	 */
+	public function setCreated(string $created)
+	{
+		$this->created = $created;
+	}
+
+	/**
+	 * @return string
+	 * Get edited timestamp
+	 */
+	public function getUpdated()
+	{
+		return $this->updated;
+	}
+
+	/**
+	 * @param string $updated
+	 * Set edited timestamp
+	 */
+	public function setUpdated(string $updated)
+	{
+		$this->updated = $updated;
+	}
+
+	/**
+	 * @return string
+	 * Get subject of initial message
+	 */
+	public function getSubject()
+	{
+		return $this->subject;
+	}
+
+	/**
+	 * @param string $subject
+	 * Set subject of initial message
+	 */
+	public function setSubject(string $subject)
+	{
+		$this->subject = $subject;
+	}
+}

--- a/src/Domain/Entity/Conversation.php
+++ b/src/Domain/Entity/Conversation.php
@@ -1,0 +1,211 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity;
+
+use Friendica\BaseEntity;
+
+/**
+ * Entity class for table conversation
+ *
+ * Raw data and structure information for messages
+ */
+class Conversation extends BaseEntity
+{
+	/**
+	 * @var string
+	 * Original URI of the item - unrelated to the table with the same name
+	 */
+	private $itemUri;
+
+	/**
+	 * @var string
+	 * URI to which this item is a reply
+	 */
+	private $replyToUri = '';
+
+	/**
+	 * @var string
+	 * GNU Social conversation URI
+	 */
+	private $conversationUri = '';
+
+	/**
+	 * @var string
+	 * GNU Social conversation link
+	 */
+	private $conversationHref = '';
+
+	/**
+	 * @var string
+	 * The protocol of the item
+	 */
+	private $protocol = '255';
+
+	/**
+	 * @var string
+	 * Original source
+	 */
+	private $source;
+
+	/**
+	 * @var string
+	 * Receiving date
+	 */
+	private $received = '0001-01-01 00:00:00';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'item-uri' => $this->itemUri,
+			'reply-to-uri' => $this->replyToUri,
+			'conversation-uri' => $this->conversationUri,
+			'conversation-href' => $this->conversationHref,
+			'protocol' => $this->protocol,
+			'source' => $this->source,
+			'received' => $this->received,
+		];
+	}
+
+	/**
+	 * @return string
+	 * Get Original URI of the item - unrelated to the table with the same name
+	 */
+	public function getItemUri()
+	{
+		return $this->itemUri;
+	}
+
+	/**
+	 * @return string
+	 * Get URI to which this item is a reply
+	 */
+	public function getReplyToUri()
+	{
+		return $this->replyToUri;
+	}
+
+	/**
+	 * @param string $replyToUri
+	 * Set URI to which this item is a reply
+	 */
+	public function setReplyToUri(string $replyToUri)
+	{
+		$this->replyToUri = $replyToUri;
+	}
+
+	/**
+	 * @return string
+	 * Get GNU Social conversation URI
+	 */
+	public function getConversationUri()
+	{
+		return $this->conversationUri;
+	}
+
+	/**
+	 * @param string $conversationUri
+	 * Set GNU Social conversation URI
+	 */
+	public function setConversationUri(string $conversationUri)
+	{
+		$this->conversationUri = $conversationUri;
+	}
+
+	/**
+	 * @return string
+	 * Get GNU Social conversation link
+	 */
+	public function getConversationHref()
+	{
+		return $this->conversationHref;
+	}
+
+	/**
+	 * @param string $conversationHref
+	 * Set GNU Social conversation link
+	 */
+	public function setConversationHref(string $conversationHref)
+	{
+		$this->conversationHref = $conversationHref;
+	}
+
+	/**
+	 * @return string
+	 * Get The protocol of the item
+	 */
+	public function getProtocol()
+	{
+		return $this->protocol;
+	}
+
+	/**
+	 * @param string $protocol
+	 * Set The protocol of the item
+	 */
+	public function setProtocol(string $protocol)
+	{
+		$this->protocol = $protocol;
+	}
+
+	/**
+	 * @return string
+	 * Get Original source
+	 */
+	public function getSource()
+	{
+		return $this->source;
+	}
+
+	/**
+	 * @param string $source
+	 * Set Original source
+	 */
+	public function setSource(string $source)
+	{
+		$this->source = $source;
+	}
+
+	/**
+	 * @return string
+	 * Get Receiving date
+	 */
+	public function getReceived()
+	{
+		return $this->received;
+	}
+
+	/**
+	 * @param string $received
+	 * Set Receiving date
+	 */
+	public function setReceived(string $received)
+	{
+		$this->received = $received;
+	}
+}

--- a/src/Domain/Entity/Diaspora/Interaction.php
+++ b/src/Domain/Entity/Diaspora/Interaction.php
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity\Diaspora;
+
+use Friendica\BaseEntity;
+use Friendica\Domain\Entity\Item;
+use Friendica\Network\HTTPException\NotImplementedException;
+
+/**
+ * Entity class for table diaspora-interaction
+ *
+ * Signed Diaspora Interaction
+ */
+class Interaction extends BaseEntity
+{
+	/**
+	 * @var int
+	 * Id of the item-uri table entry that contains the item uri
+	 */
+	private $uriId;
+
+	/**
+	 * @var string
+	 * The Diaspora interaction
+	 */
+	private $interaction;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'uri-id' => $this->uriId,
+			'interaction' => $this->interaction,
+		];
+	}
+
+	/**
+	 * @return int
+	 * Get Id of the item-uri table entry that contains the item uri
+	 */
+	public function getUriId()
+	{
+		return $this->uriId;
+	}
+
+	/**
+	 * Get \ItemUri
+	 *
+	 * @return \ItemUri
+	 */
+	public function getItemUri()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for id is not implemented yet');
+	}
+
+	/**
+	 * @return string
+	 * Get The Diaspora interaction
+	 */
+	public function getInteraction()
+	{
+		return $this->interaction;
+	}
+
+	/**
+	 * @param string $interaction
+	 * Set The Diaspora interaction
+	 */
+	public function setInteraction(string $interaction)
+	{
+		$this->interaction = $interaction;
+	}
+}

--- a/src/Domain/Entity/Event.php
+++ b/src/Domain/Entity/Event.php
@@ -1,0 +1,557 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity;
+
+use Friendica\BaseEntity;
+use Friendica\Network\HTTPException\NotImplementedException;
+
+/**
+ * Entity class for table event
+ *
+ * Events
+ */
+class Event extends BaseEntity
+{
+	/**
+	 * @var int
+	 * sequential ID
+	 */
+	private $id;
+
+	/**
+	 * @var string
+	 */
+	private $guid = '';
+
+	/**
+	 * @var int
+	 * Owner User id
+	 */
+	private $uid = '0';
+
+	/**
+	 * @var int
+	 * contact_id (ID of the contact in contact table)
+	 */
+	private $cid = '0';
+
+	/**
+	 * @var string
+	 */
+	private $uri = '';
+
+	/**
+	 * @var string
+	 * creation time
+	 */
+	private $created = '0001-01-01 00:00:00';
+
+	/**
+	 * @var string
+	 * last edit time
+	 */
+	private $edited = '0001-01-01 00:00:00';
+
+	/**
+	 * @var string
+	 * event start time
+	 */
+	private $start = '0001-01-01 00:00:00';
+
+	/**
+	 * @var string
+	 * event end time
+	 */
+	private $finish = '0001-01-01 00:00:00';
+
+	/**
+	 * @var string
+	 * short description or title of the event
+	 */
+	private $summary;
+
+	/**
+	 * @var string
+	 * event description
+	 */
+	private $desc;
+
+	/**
+	 * @var string
+	 * event location
+	 */
+	private $location;
+
+	/**
+	 * @var string
+	 * event or birthday
+	 */
+	private $type = '';
+
+	/**
+	 * @var bool
+	 * if event does have no end this is 1
+	 */
+	private $nofinish = '0';
+
+	/**
+	 * @var bool
+	 * adjust to timezone of the recipient (0 or 1)
+	 */
+	private $adjust = '1';
+
+	/**
+	 * @var bool
+	 * 0 or 1
+	 */
+	private $ignore = '0';
+
+	/**
+	 * @var string
+	 * Access Control - list of allowed contact.id '<19><78>'
+	 */
+	private $allowCid;
+
+	/**
+	 * @var string
+	 * Access Control - list of allowed groups
+	 */
+	private $allowGid;
+
+	/**
+	 * @var string
+	 * Access Control - list of denied contact.id
+	 */
+	private $denyCid;
+
+	/**
+	 * @var string
+	 * Access Control - list of denied groups
+	 */
+	private $denyGid;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'id' => $this->id,
+			'guid' => $this->guid,
+			'uid' => $this->uid,
+			'cid' => $this->cid,
+			'uri' => $this->uri,
+			'created' => $this->created,
+			'edited' => $this->edited,
+			'start' => $this->start,
+			'finish' => $this->finish,
+			'summary' => $this->summary,
+			'desc' => $this->desc,
+			'location' => $this->location,
+			'type' => $this->type,
+			'nofinish' => $this->nofinish,
+			'adjust' => $this->adjust,
+			'ignore' => $this->ignore,
+			'allow_cid' => $this->allowCid,
+			'allow_gid' => $this->allowGid,
+			'deny_cid' => $this->denyCid,
+			'deny_gid' => $this->denyGid,
+		];
+	}
+
+	/**
+	 * @return int
+	 * Get sequential ID
+	 */
+	public function getId()
+	{
+		return $this->id;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getGuid()
+	{
+		return $this->guid;
+	}
+
+	/**
+	 * @param string $guid
+	 * Set
+	 */
+	public function setGuid(string $guid)
+	{
+		$this->guid = $guid;
+	}
+
+	/**
+	 * @return int
+	 * Get Owner User id
+	 */
+	public function getUid()
+	{
+		return $this->uid;
+	}
+
+	/**
+	 * @param int $uid
+	 * Set Owner User id
+	 */
+	public function setUid(int $uid)
+	{
+		$this->uid = $uid;
+	}
+
+	/**
+	 * Get User
+	 *
+	 * @return User
+	 */
+	public function getUser()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for uid is not implemented yet');
+	}
+
+	/**
+	 * @return int
+	 * Get contact_id (ID of the contact in contact table)
+	 */
+	public function getCid()
+	{
+		return $this->cid;
+	}
+
+	/**
+	 * @param int $cid
+	 * Set contact_id (ID of the contact in contact table)
+	 */
+	public function setCid(int $cid)
+	{
+		$this->cid = $cid;
+	}
+
+	/**
+	 * Get Contact
+	 *
+	 * @return Contact
+	 */
+	public function getContact()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for id is not implemented yet');
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getUri()
+	{
+		return $this->uri;
+	}
+
+	/**
+	 * @param string $uri
+	 * Set
+	 */
+	public function setUri(string $uri)
+	{
+		$this->uri = $uri;
+	}
+
+	/**
+	 * @return string
+	 * Get creation time
+	 */
+	public function getCreated()
+	{
+		return $this->created;
+	}
+
+	/**
+	 * @param string $created
+	 * Set creation time
+	 */
+	public function setCreated(string $created)
+	{
+		$this->created = $created;
+	}
+
+	/**
+	 * @return string
+	 * Get last edit time
+	 */
+	public function getEdited()
+	{
+		return $this->edited;
+	}
+
+	/**
+	 * @param string $edited
+	 * Set last edit time
+	 */
+	public function setEdited(string $edited)
+	{
+		$this->edited = $edited;
+	}
+
+	/**
+	 * @return string
+	 * Get event start time
+	 */
+	public function getStart()
+	{
+		return $this->start;
+	}
+
+	/**
+	 * @param string $start
+	 * Set event start time
+	 */
+	public function setStart(string $start)
+	{
+		$this->start = $start;
+	}
+
+	/**
+	 * @return string
+	 * Get event end time
+	 */
+	public function getFinish()
+	{
+		return $this->finish;
+	}
+
+	/**
+	 * @param string $finish
+	 * Set event end time
+	 */
+	public function setFinish(string $finish)
+	{
+		$this->finish = $finish;
+	}
+
+	/**
+	 * @return string
+	 * Get short description or title of the event
+	 */
+	public function getSummary()
+	{
+		return $this->summary;
+	}
+
+	/**
+	 * @param string $summary
+	 * Set short description or title of the event
+	 */
+	public function setSummary(string $summary)
+	{
+		$this->summary = $summary;
+	}
+
+	/**
+	 * @return string
+	 * Get event description
+	 */
+	public function getDesc()
+	{
+		return $this->desc;
+	}
+
+	/**
+	 * @param string $desc
+	 * Set event description
+	 */
+	public function setDesc(string $desc)
+	{
+		$this->desc = $desc;
+	}
+
+	/**
+	 * @return string
+	 * Get event location
+	 */
+	public function getLocation()
+	{
+		return $this->location;
+	}
+
+	/**
+	 * @param string $location
+	 * Set event location
+	 */
+	public function setLocation(string $location)
+	{
+		$this->location = $location;
+	}
+
+	/**
+	 * @return string
+	 * Get event or birthday
+	 */
+	public function getType()
+	{
+		return $this->type;
+	}
+
+	/**
+	 * @param string $type
+	 * Set event or birthday
+	 */
+	public function setType(string $type)
+	{
+		$this->type = $type;
+	}
+
+	/**
+	 * @return bool
+	 * Get if event does have no end this is 1
+	 */
+	public function getNofinish()
+	{
+		return $this->nofinish;
+	}
+
+	/**
+	 * @param bool $nofinish
+	 * Set if event does have no end this is 1
+	 */
+	public function setNofinish(bool $nofinish)
+	{
+		$this->nofinish = $nofinish;
+	}
+
+	/**
+	 * @return bool
+	 * Get adjust to timezone of the recipient (0 or 1)
+	 */
+	public function getAdjust()
+	{
+		return $this->adjust;
+	}
+
+	/**
+	 * @param bool $adjust
+	 * Set adjust to timezone of the recipient (0 or 1)
+	 */
+	public function setAdjust(bool $adjust)
+	{
+		$this->adjust = $adjust;
+	}
+
+	/**
+	 * @return bool
+	 * Get 0 or 1
+	 */
+	public function getIgnore()
+	{
+		return $this->ignore;
+	}
+
+	/**
+	 * @param bool $ignore
+	 * Set 0 or 1
+	 */
+	public function setIgnore(bool $ignore)
+	{
+		$this->ignore = $ignore;
+	}
+
+	/**
+	 * @return string
+	 * Get Access Control - list of allowed contact.id '<19><78>'
+	 */
+	public function getAllowCid()
+	{
+		return $this->allowCid;
+	}
+
+	/**
+	 * @param string $allowCid
+	 * Set Access Control - list of allowed contact.id '<19><78>'
+	 */
+	public function setAllowCid(string $allowCid)
+	{
+		$this->allowCid = $allowCid;
+	}
+
+	/**
+	 * @return string
+	 * Get Access Control - list of allowed groups
+	 */
+	public function getAllowGid()
+	{
+		return $this->allowGid;
+	}
+
+	/**
+	 * @param string $allowGid
+	 * Set Access Control - list of allowed groups
+	 */
+	public function setAllowGid(string $allowGid)
+	{
+		$this->allowGid = $allowGid;
+	}
+
+	/**
+	 * @return string
+	 * Get Access Control - list of denied contact.id
+	 */
+	public function getDenyCid()
+	{
+		return $this->denyCid;
+	}
+
+	/**
+	 * @param string $denyCid
+	 * Set Access Control - list of denied contact.id
+	 */
+	public function setDenyCid(string $denyCid)
+	{
+		$this->denyCid = $denyCid;
+	}
+
+	/**
+	 * @return string
+	 * Get Access Control - list of denied groups
+	 */
+	public function getDenyGid()
+	{
+		return $this->denyGid;
+	}
+
+	/**
+	 * @param string $denyGid
+	 * Set Access Control - list of denied groups
+	 */
+	public function setDenyGid(string $denyGid)
+	{
+		$this->denyGid = $denyGid;
+	}
+}

--- a/src/Domain/Entity/Fcontact.php
+++ b/src/Domain/Entity/Fcontact.php
@@ -1,0 +1,446 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity;
+
+use Friendica\BaseEntity;
+
+/**
+ * Entity class for table fcontact
+ *
+ * Diaspora compatible contacts - used in the Diaspora implementation
+ */
+class Fcontact extends BaseEntity
+{
+	/**
+	 * @var int
+	 * sequential ID
+	 */
+	private $id;
+
+	/**
+	 * @var string
+	 * unique id
+	 */
+	private $guid = '';
+
+	/**
+	 * @var string
+	 */
+	private $url = '';
+
+	/**
+	 * @var string
+	 */
+	private $name = '';
+
+	/**
+	 * @var string
+	 */
+	private $photo = '';
+
+	/**
+	 * @var string
+	 */
+	private $request = '';
+
+	/**
+	 * @var string
+	 */
+	private $nick = '';
+
+	/**
+	 * @var string
+	 */
+	private $addr = '';
+
+	/**
+	 * @var string
+	 */
+	private $batch = '';
+
+	/**
+	 * @var string
+	 */
+	private $notify = '';
+
+	/**
+	 * @var string
+	 */
+	private $poll = '';
+
+	/**
+	 * @var string
+	 */
+	private $confirm = '';
+
+	/**
+	 * @var string
+	 */
+	private $priority = '0';
+
+	/**
+	 * @var string
+	 */
+	private $network = '';
+
+	/**
+	 * @var string
+	 */
+	private $alias = '';
+
+	/**
+	 * @var string
+	 */
+	private $pubkey;
+
+	/**
+	 * @var string
+	 */
+	private $updated = '0001-01-01 00:00:00';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'id' => $this->id,
+			'guid' => $this->guid,
+			'url' => $this->url,
+			'name' => $this->name,
+			'photo' => $this->photo,
+			'request' => $this->request,
+			'nick' => $this->nick,
+			'addr' => $this->addr,
+			'batch' => $this->batch,
+			'notify' => $this->notify,
+			'poll' => $this->poll,
+			'confirm' => $this->confirm,
+			'priority' => $this->priority,
+			'network' => $this->network,
+			'alias' => $this->alias,
+			'pubkey' => $this->pubkey,
+			'updated' => $this->updated,
+		];
+	}
+
+	/**
+	 * @return int
+	 * Get sequential ID
+	 */
+	public function getId()
+	{
+		return $this->id;
+	}
+
+	/**
+	 * @return string
+	 * Get unique id
+	 */
+	public function getGuid()
+	{
+		return $this->guid;
+	}
+
+	/**
+	 * @param string $guid
+	 * Set unique id
+	 */
+	public function setGuid(string $guid)
+	{
+		$this->guid = $guid;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getUrl()
+	{
+		return $this->url;
+	}
+
+	/**
+	 * @param string $url
+	 * Set
+	 */
+	public function setUrl(string $url)
+	{
+		$this->url = $url;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getName()
+	{
+		return $this->name;
+	}
+
+	/**
+	 * @param string $name
+	 * Set
+	 */
+	public function setName(string $name)
+	{
+		$this->name = $name;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getPhoto()
+	{
+		return $this->photo;
+	}
+
+	/**
+	 * @param string $photo
+	 * Set
+	 */
+	public function setPhoto(string $photo)
+	{
+		$this->photo = $photo;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getRequest()
+	{
+		return $this->request;
+	}
+
+	/**
+	 * @param string $request
+	 * Set
+	 */
+	public function setRequest(string $request)
+	{
+		$this->request = $request;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getNick()
+	{
+		return $this->nick;
+	}
+
+	/**
+	 * @param string $nick
+	 * Set
+	 */
+	public function setNick(string $nick)
+	{
+		$this->nick = $nick;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getAddr()
+	{
+		return $this->addr;
+	}
+
+	/**
+	 * @param string $addr
+	 * Set
+	 */
+	public function setAddr(string $addr)
+	{
+		$this->addr = $addr;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getBatch()
+	{
+		return $this->batch;
+	}
+
+	/**
+	 * @param string $batch
+	 * Set
+	 */
+	public function setBatch(string $batch)
+	{
+		$this->batch = $batch;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getNotify()
+	{
+		return $this->notify;
+	}
+
+	/**
+	 * @param string $notify
+	 * Set
+	 */
+	public function setNotify(string $notify)
+	{
+		$this->notify = $notify;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getPoll()
+	{
+		return $this->poll;
+	}
+
+	/**
+	 * @param string $poll
+	 * Set
+	 */
+	public function setPoll(string $poll)
+	{
+		$this->poll = $poll;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getConfirm()
+	{
+		return $this->confirm;
+	}
+
+	/**
+	 * @param string $confirm
+	 * Set
+	 */
+	public function setConfirm(string $confirm)
+	{
+		$this->confirm = $confirm;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getPriority()
+	{
+		return $this->priority;
+	}
+
+	/**
+	 * @param string $priority
+	 * Set
+	 */
+	public function setPriority(string $priority)
+	{
+		$this->priority = $priority;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getNetwork()
+	{
+		return $this->network;
+	}
+
+	/**
+	 * @param string $network
+	 * Set
+	 */
+	public function setNetwork(string $network)
+	{
+		$this->network = $network;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getAlias()
+	{
+		return $this->alias;
+	}
+
+	/**
+	 * @param string $alias
+	 * Set
+	 */
+	public function setAlias(string $alias)
+	{
+		$this->alias = $alias;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getPubkey()
+	{
+		return $this->pubkey;
+	}
+
+	/**
+	 * @param string $pubkey
+	 * Set
+	 */
+	public function setPubkey(string $pubkey)
+	{
+		$this->pubkey = $pubkey;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getUpdated()
+	{
+		return $this->updated;
+	}
+
+	/**
+	 * @param string $updated
+	 * Set
+	 */
+	public function setUpdated(string $updated)
+	{
+		$this->updated = $updated;
+	}
+}

--- a/src/Domain/Entity/Fsuggest.php
+++ b/src/Domain/Entity/Fsuggest.php
@@ -1,0 +1,276 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity;
+
+use Friendica\BaseEntity;
+use Friendica\Network\HTTPException\NotImplementedException;
+
+/**
+ * Entity class for table fsuggest
+ *
+ * friend suggestion stuff
+ */
+class Fsuggest extends BaseEntity
+{
+	/**
+	 * @var int
+	 */
+	private $id;
+
+	/**
+	 * @var int
+	 * User id
+	 */
+	private $uid = '0';
+
+	/**
+	 * @var int
+	 */
+	private $cid = '0';
+
+	/**
+	 * @var string
+	 */
+	private $name = '';
+
+	/**
+	 * @var string
+	 */
+	private $url = '';
+
+	/**
+	 * @var string
+	 */
+	private $request = '';
+
+	/**
+	 * @var string
+	 */
+	private $photo = '';
+
+	/**
+	 * @var string
+	 */
+	private $note;
+
+	/**
+	 * @var string
+	 */
+	private $created = '0001-01-01 00:00:00';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'id' => $this->id,
+			'uid' => $this->uid,
+			'cid' => $this->cid,
+			'name' => $this->name,
+			'url' => $this->url,
+			'request' => $this->request,
+			'photo' => $this->photo,
+			'note' => $this->note,
+			'created' => $this->created,
+		];
+	}
+
+	/**
+	 * @return int
+	 * Get
+	 */
+	public function getId()
+	{
+		return $this->id;
+	}
+
+	/**
+	 * @return int
+	 * Get User id
+	 */
+	public function getUid()
+	{
+		return $this->uid;
+	}
+
+	/**
+	 * @param int $uid
+	 * Set User id
+	 */
+	public function setUid(int $uid)
+	{
+		$this->uid = $uid;
+	}
+
+	/**
+	 * Get User
+	 *
+	 * @return User
+	 */
+	public function getUser()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for uid is not implemented yet');
+	}
+
+	/**
+	 * @return int
+	 * Get
+	 */
+	public function getCid()
+	{
+		return $this->cid;
+	}
+
+	/**
+	 * @param int $cid
+	 * Set
+	 */
+	public function setCid(int $cid)
+	{
+		$this->cid = $cid;
+	}
+
+	/**
+	 * Get Contact
+	 *
+	 * @return Contact
+	 */
+	public function getContact()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for id is not implemented yet');
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getName()
+	{
+		return $this->name;
+	}
+
+	/**
+	 * @param string $name
+	 * Set
+	 */
+	public function setName(string $name)
+	{
+		$this->name = $name;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getUrl()
+	{
+		return $this->url;
+	}
+
+	/**
+	 * @param string $url
+	 * Set
+	 */
+	public function setUrl(string $url)
+	{
+		$this->url = $url;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getRequest()
+	{
+		return $this->request;
+	}
+
+	/**
+	 * @param string $request
+	 * Set
+	 */
+	public function setRequest(string $request)
+	{
+		$this->request = $request;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getPhoto()
+	{
+		return $this->photo;
+	}
+
+	/**
+	 * @param string $photo
+	 * Set
+	 */
+	public function setPhoto(string $photo)
+	{
+		$this->photo = $photo;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getNote()
+	{
+		return $this->note;
+	}
+
+	/**
+	 * @param string $note
+	 * Set
+	 */
+	public function setNote(string $note)
+	{
+		$this->note = $note;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getCreated()
+	{
+		return $this->created;
+	}
+
+	/**
+	 * @param string $created
+	 * Set
+	 */
+	public function setCreated(string $created)
+	{
+		$this->created = $created;
+	}
+}

--- a/src/Domain/Entity/Gcign.php
+++ b/src/Domain/Entity/Gcign.php
@@ -1,0 +1,134 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity;
+
+use Friendica\BaseEntity;
+use Friendica\Network\HTTPException\NotImplementedException;
+
+/**
+ * Entity class for table gcign
+ *
+ * contacts ignored by friend suggestions
+ */
+class Gcign extends BaseEntity
+{
+	/**
+	 * @var int
+	 * sequential ID
+	 */
+	private $id;
+
+	/**
+	 * @var int
+	 * Local User id
+	 */
+	private $uid = '0';
+
+	/**
+	 * @var int
+	 * gcontact.id of ignored contact
+	 */
+	private $gcid = '0';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'id' => $this->id,
+			'uid' => $this->uid,
+			'gcid' => $this->gcid,
+		];
+	}
+
+	/**
+	 * @return int
+	 * Get sequential ID
+	 */
+	public function getId()
+	{
+		return $this->id;
+	}
+
+	/**
+	 * @return int
+	 * Get Local User id
+	 */
+	public function getUid()
+	{
+		return $this->uid;
+	}
+
+	/**
+	 * @param int $uid
+	 * Set Local User id
+	 */
+	public function setUid(int $uid)
+	{
+		$this->uid = $uid;
+	}
+
+	/**
+	 * Get User
+	 *
+	 * @return User
+	 */
+	public function getUser()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for uid is not implemented yet');
+	}
+
+	/**
+	 * @return int
+	 * Get gcontact.id of ignored contact
+	 */
+	public function getGcid()
+	{
+		return $this->gcid;
+	}
+
+	/**
+	 * @param int $gcid
+	 * Set gcontact.id of ignored contact
+	 */
+	public function setGcid(int $gcid)
+	{
+		$this->gcid = $gcid;
+	}
+
+	/**
+	 * Get Gcontact
+	 *
+	 * @return Gcontact
+	 */
+	public function getGcontact()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for id is not implemented yet');
+	}
+}

--- a/src/Domain/Entity/Gcontact.php
+++ b/src/Domain/Entity/Gcontact.php
@@ -1,0 +1,719 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity;
+
+use Friendica\BaseEntity;
+
+/**
+ * Entity class for table gcontact
+ *
+ * global contacts
+ */
+class Gcontact extends BaseEntity
+{
+	/**
+	 * @var int
+	 * sequential ID
+	 */
+	private $id;
+
+	/**
+	 * @var string
+	 * Name that this contact is known by
+	 */
+	private $name = '';
+
+	/**
+	 * @var string
+	 * Nick- and user name of the contact
+	 */
+	private $nick = '';
+
+	/**
+	 * @var string
+	 * Link to the contacts profile page
+	 */
+	private $url = '';
+
+	/**
+	 * @var string
+	 */
+	private $nurl = '';
+
+	/**
+	 * @var string
+	 * Link to the profile photo
+	 */
+	private $photo = '';
+
+	/**
+	 * @var string
+	 */
+	private $connect = '';
+
+	/**
+	 * @var string
+	 */
+	private $created = '0001-01-01 00:00:00';
+
+	/**
+	 * @var string
+	 */
+	private $updated = '0001-01-01 00:00:00';
+
+	/**
+	 * @var string
+	 */
+	private $lastContact = '0001-01-01 00:00:00';
+
+	/**
+	 * @var string
+	 */
+	private $lastFailure = '0001-01-01 00:00:00';
+
+	/**
+	 * @var string
+	 */
+	private $archiveDate = '0001-01-01 00:00:00';
+
+	/**
+	 * @var bool
+	 */
+	private $archived = '0';
+
+	/**
+	 * @var string
+	 */
+	private $location = '';
+
+	/**
+	 * @var string
+	 */
+	private $about;
+
+	/**
+	 * @var string
+	 * puplic keywords (interests)
+	 */
+	private $keywords;
+
+	/**
+	 * @var string
+	 */
+	private $gender = '';
+
+	/**
+	 * @var string
+	 */
+	private $birthday = '0001-01-01';
+
+	/**
+	 * @var bool
+	 * 1 if contact is forum account
+	 */
+	private $community = '0';
+
+	/**
+	 * @var string
+	 */
+	private $contactType = '-1';
+
+	/**
+	 * @var bool
+	 * 1 = should be hidden from search
+	 */
+	private $hide = '0';
+
+	/**
+	 * @var bool
+	 * 1 = contact posts nsfw content
+	 */
+	private $nsfw = '0';
+
+	/**
+	 * @var string
+	 * social network protocol
+	 */
+	private $network = '';
+
+	/**
+	 * @var string
+	 */
+	private $addr = '';
+
+	/**
+	 * @var string
+	 */
+	private $notify;
+
+	/**
+	 * @var string
+	 */
+	private $alias = '';
+
+	/**
+	 * @var string
+	 */
+	private $generation = '0';
+
+	/**
+	 * @var string
+	 * baseurl of the contacts server
+	 */
+	private $serverUrl = '';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'id' => $this->id,
+			'name' => $this->name,
+			'nick' => $this->nick,
+			'url' => $this->url,
+			'nurl' => $this->nurl,
+			'photo' => $this->photo,
+			'connect' => $this->connect,
+			'created' => $this->created,
+			'updated' => $this->updated,
+			'last_contact' => $this->lastContact,
+			'last_failure' => $this->lastFailure,
+			'archive_date' => $this->archiveDate,
+			'archived' => $this->archived,
+			'location' => $this->location,
+			'about' => $this->about,
+			'keywords' => $this->keywords,
+			'gender' => $this->gender,
+			'birthday' => $this->birthday,
+			'community' => $this->community,
+			'contact-type' => $this->contactType,
+			'hide' => $this->hide,
+			'nsfw' => $this->nsfw,
+			'network' => $this->network,
+			'addr' => $this->addr,
+			'notify' => $this->notify,
+			'alias' => $this->alias,
+			'generation' => $this->generation,
+			'server_url' => $this->serverUrl,
+		];
+	}
+
+	/**
+	 * @return int
+	 * Get sequential ID
+	 */
+	public function getId()
+	{
+		return $this->id;
+	}
+
+	/**
+	 * @return string
+	 * Get Name that this contact is known by
+	 */
+	public function getName()
+	{
+		return $this->name;
+	}
+
+	/**
+	 * @param string $name
+	 * Set Name that this contact is known by
+	 */
+	public function setName(string $name)
+	{
+		$this->name = $name;
+	}
+
+	/**
+	 * @return string
+	 * Get Nick- and user name of the contact
+	 */
+	public function getNick()
+	{
+		return $this->nick;
+	}
+
+	/**
+	 * @param string $nick
+	 * Set Nick- and user name of the contact
+	 */
+	public function setNick(string $nick)
+	{
+		$this->nick = $nick;
+	}
+
+	/**
+	 * @return string
+	 * Get Link to the contacts profile page
+	 */
+	public function getUrl()
+	{
+		return $this->url;
+	}
+
+	/**
+	 * @param string $url
+	 * Set Link to the contacts profile page
+	 */
+	public function setUrl(string $url)
+	{
+		$this->url = $url;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getNurl()
+	{
+		return $this->nurl;
+	}
+
+	/**
+	 * @param string $nurl
+	 * Set
+	 */
+	public function setNurl(string $nurl)
+	{
+		$this->nurl = $nurl;
+	}
+
+	/**
+	 * @return string
+	 * Get Link to the profile photo
+	 */
+	public function getPhoto()
+	{
+		return $this->photo;
+	}
+
+	/**
+	 * @param string $photo
+	 * Set Link to the profile photo
+	 */
+	public function setPhoto(string $photo)
+	{
+		$this->photo = $photo;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getConnect()
+	{
+		return $this->connect;
+	}
+
+	/**
+	 * @param string $connect
+	 * Set
+	 */
+	public function setConnect(string $connect)
+	{
+		$this->connect = $connect;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getCreated()
+	{
+		return $this->created;
+	}
+
+	/**
+	 * @param string $created
+	 * Set
+	 */
+	public function setCreated(string $created)
+	{
+		$this->created = $created;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getUpdated()
+	{
+		return $this->updated;
+	}
+
+	/**
+	 * @param string $updated
+	 * Set
+	 */
+	public function setUpdated(string $updated)
+	{
+		$this->updated = $updated;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getLastContact()
+	{
+		return $this->lastContact;
+	}
+
+	/**
+	 * @param string $lastContact
+	 * Set
+	 */
+	public function setLastContact(string $lastContact)
+	{
+		$this->lastContact = $lastContact;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getLastFailure()
+	{
+		return $this->lastFailure;
+	}
+
+	/**
+	 * @param string $lastFailure
+	 * Set
+	 */
+	public function setLastFailure(string $lastFailure)
+	{
+		$this->lastFailure = $lastFailure;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getArchiveDate()
+	{
+		return $this->archiveDate;
+	}
+
+	/**
+	 * @param string $archiveDate
+	 * Set
+	 */
+	public function setArchiveDate(string $archiveDate)
+	{
+		$this->archiveDate = $archiveDate;
+	}
+
+	/**
+	 * @return bool
+	 * Get
+	 */
+	public function getArchived()
+	{
+		return $this->archived;
+	}
+
+	/**
+	 * @param bool $archived
+	 * Set
+	 */
+	public function setArchived(bool $archived)
+	{
+		$this->archived = $archived;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getLocation()
+	{
+		return $this->location;
+	}
+
+	/**
+	 * @param string $location
+	 * Set
+	 */
+	public function setLocation(string $location)
+	{
+		$this->location = $location;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getAbout()
+	{
+		return $this->about;
+	}
+
+	/**
+	 * @param string $about
+	 * Set
+	 */
+	public function setAbout(string $about)
+	{
+		$this->about = $about;
+	}
+
+	/**
+	 * @return string
+	 * Get puplic keywords (interests)
+	 */
+	public function getKeywords()
+	{
+		return $this->keywords;
+	}
+
+	/**
+	 * @param string $keywords
+	 * Set puplic keywords (interests)
+	 */
+	public function setKeywords(string $keywords)
+	{
+		$this->keywords = $keywords;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getGender()
+	{
+		return $this->gender;
+	}
+
+	/**
+	 * @param string $gender
+	 * Set
+	 */
+	public function setGender(string $gender)
+	{
+		$this->gender = $gender;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getBirthday()
+	{
+		return $this->birthday;
+	}
+
+	/**
+	 * @param string $birthday
+	 * Set
+	 */
+	public function setBirthday(string $birthday)
+	{
+		$this->birthday = $birthday;
+	}
+
+	/**
+	 * @return bool
+	 * Get 1 if contact is forum account
+	 */
+	public function getCommunity()
+	{
+		return $this->community;
+	}
+
+	/**
+	 * @param bool $community
+	 * Set 1 if contact is forum account
+	 */
+	public function setCommunity(bool $community)
+	{
+		$this->community = $community;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getContactType()
+	{
+		return $this->contactType;
+	}
+
+	/**
+	 * @param string $contactType
+	 * Set
+	 */
+	public function setContactType(string $contactType)
+	{
+		$this->contactType = $contactType;
+	}
+
+	/**
+	 * @return bool
+	 * Get 1 = should be hidden from search
+	 */
+	public function getHide()
+	{
+		return $this->hide;
+	}
+
+	/**
+	 * @param bool $hide
+	 * Set 1 = should be hidden from search
+	 */
+	public function setHide(bool $hide)
+	{
+		$this->hide = $hide;
+	}
+
+	/**
+	 * @return bool
+	 * Get 1 = contact posts nsfw content
+	 */
+	public function getNsfw()
+	{
+		return $this->nsfw;
+	}
+
+	/**
+	 * @param bool $nsfw
+	 * Set 1 = contact posts nsfw content
+	 */
+	public function setNsfw(bool $nsfw)
+	{
+		$this->nsfw = $nsfw;
+	}
+
+	/**
+	 * @return string
+	 * Get social network protocol
+	 */
+	public function getNetwork()
+	{
+		return $this->network;
+	}
+
+	/**
+	 * @param string $network
+	 * Set social network protocol
+	 */
+	public function setNetwork(string $network)
+	{
+		$this->network = $network;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getAddr()
+	{
+		return $this->addr;
+	}
+
+	/**
+	 * @param string $addr
+	 * Set
+	 */
+	public function setAddr(string $addr)
+	{
+		$this->addr = $addr;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getNotify()
+	{
+		return $this->notify;
+	}
+
+	/**
+	 * @param string $notify
+	 * Set
+	 */
+	public function setNotify(string $notify)
+	{
+		$this->notify = $notify;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getAlias()
+	{
+		return $this->alias;
+	}
+
+	/**
+	 * @param string $alias
+	 * Set
+	 */
+	public function setAlias(string $alias)
+	{
+		$this->alias = $alias;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getGeneration()
+	{
+		return $this->generation;
+	}
+
+	/**
+	 * @param string $generation
+	 * Set
+	 */
+	public function setGeneration(string $generation)
+	{
+		$this->generation = $generation;
+	}
+
+	/**
+	 * @return string
+	 * Get baseurl of the contacts server
+	 */
+	public function getServerUrl()
+	{
+		return $this->serverUrl;
+	}
+
+	/**
+	 * @param string $serverUrl
+	 * Set baseurl of the contacts server
+	 */
+	public function setServerUrl(string $serverUrl)
+	{
+		$this->serverUrl = $serverUrl;
+	}
+}

--- a/src/Domain/Entity/Glink.php
+++ b/src/Domain/Entity/Glink.php
@@ -1,0 +1,216 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity;
+
+use Friendica\BaseEntity;
+use Friendica\Network\HTTPException\NotImplementedException;
+
+/**
+ * Entity class for table glink
+ *
+ * 'friends of friends' linkages derived from poco
+ */
+class Glink extends BaseEntity
+{
+	/**
+	 * @var int
+	 * sequential ID
+	 */
+	private $id;
+
+	/**
+	 * @var int
+	 */
+	private $cid = '0';
+
+	/**
+	 * @var int
+	 * User id
+	 */
+	private $uid = '0';
+
+	/**
+	 * @var int
+	 */
+	private $gcid = '0';
+
+	/**
+	 * @var int
+	 */
+	private $zcid = '0';
+
+	/**
+	 * @var string
+	 */
+	private $updated = '0001-01-01 00:00:00';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'id' => $this->id,
+			'cid' => $this->cid,
+			'uid' => $this->uid,
+			'gcid' => $this->gcid,
+			'zcid' => $this->zcid,
+			'updated' => $this->updated,
+		];
+	}
+
+	/**
+	 * @return int
+	 * Get sequential ID
+	 */
+	public function getId()
+	{
+		return $this->id;
+	}
+
+	/**
+	 * @return int
+	 * Get
+	 */
+	public function getCid()
+	{
+		return $this->cid;
+	}
+
+	/**
+	 * @param int $cid
+	 * Set
+	 */
+	public function setCid(int $cid)
+	{
+		$this->cid = $cid;
+	}
+
+	/**
+	 * Get Contact
+	 *
+	 * @return Contact
+	 */
+	public function getContact()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for id is not implemented yet');
+	}
+
+	/**
+	 * @return int
+	 * Get User id
+	 */
+	public function getUid()
+	{
+		return $this->uid;
+	}
+
+	/**
+	 * @param int $uid
+	 * Set User id
+	 */
+	public function setUid(int $uid)
+	{
+		$this->uid = $uid;
+	}
+
+	/**
+	 * Get User
+	 *
+	 * @return User
+	 */
+	public function getUser()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for uid is not implemented yet');
+	}
+
+	/**
+	 * @return int
+	 * Get
+	 */
+	public function getGcid()
+	{
+		return $this->gcid;
+	}
+
+	/**
+	 * @param int $gcid
+	 * Set
+	 */
+	public function setGcid(int $gcid)
+	{
+		$this->gcid = $gcid;
+	}
+
+	/**
+	 * Get Gcontact
+	 *
+	 * @return Gcontact
+	 */
+	public function getGcontact()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for id is not implemented yet');
+	}
+
+	/**
+	 * @return int
+	 * Get
+	 */
+	public function getZcid()
+	{
+		return $this->zcid;
+	}
+
+	/**
+	 * @param int $zcid
+	 * Set
+	 */
+	public function setZcid(int $zcid)
+	{
+		$this->zcid = $zcid;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getUpdated()
+	{
+		return $this->updated;
+	}
+
+	/**
+	 * @param string $updated
+	 * Set
+	 */
+	public function setUpdated(string $updated)
+	{
+		$this->updated = $updated;
+	}
+}

--- a/src/Domain/Entity/Group.php
+++ b/src/Domain/Entity/Group.php
@@ -1,0 +1,173 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity;
+
+use Friendica\BaseEntity;
+use Friendica\Network\HTTPException\NotImplementedException;
+
+/**
+ * Entity class for table group
+ *
+ * privacy groups, group info
+ */
+class Group extends BaseEntity
+{
+	/**
+	 * @var int
+	 * sequential ID
+	 */
+	private $id;
+
+	/**
+	 * @var int
+	 * Owner User id
+	 */
+	private $uid = '0';
+
+	/**
+	 * @var bool
+	 * 1 indicates the member list is not private
+	 */
+	private $visible = '0';
+
+	/**
+	 * @var bool
+	 * 1 indicates the group has been deleted
+	 */
+	private $deleted = '0';
+
+	/**
+	 * @var string
+	 * human readable name of group
+	 */
+	private $name = '';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'id' => $this->id,
+			'uid' => $this->uid,
+			'visible' => $this->visible,
+			'deleted' => $this->deleted,
+			'name' => $this->name,
+		];
+	}
+
+	/**
+	 * @return int
+	 * Get sequential ID
+	 */
+	public function getId()
+	{
+		return $this->id;
+	}
+
+	/**
+	 * @return int
+	 * Get Owner User id
+	 */
+	public function getUid()
+	{
+		return $this->uid;
+	}
+
+	/**
+	 * @param int $uid
+	 * Set Owner User id
+	 */
+	public function setUid(int $uid)
+	{
+		$this->uid = $uid;
+	}
+
+	/**
+	 * Get User
+	 *
+	 * @return User
+	 */
+	public function getUser()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for uid is not implemented yet');
+	}
+
+	/**
+	 * @return bool
+	 * Get 1 indicates the member list is not private
+	 */
+	public function getVisible()
+	{
+		return $this->visible;
+	}
+
+	/**
+	 * @param bool $visible
+	 * Set 1 indicates the member list is not private
+	 */
+	public function setVisible(bool $visible)
+	{
+		$this->visible = $visible;
+	}
+
+	/**
+	 * @return bool
+	 * Get 1 indicates the group has been deleted
+	 */
+	public function getDeleted()
+	{
+		return $this->deleted;
+	}
+
+	/**
+	 * @param bool $deleted
+	 * Set 1 indicates the group has been deleted
+	 */
+	public function setDeleted(bool $deleted)
+	{
+		$this->deleted = $deleted;
+	}
+
+	/**
+	 * @return string
+	 * Get human readable name of group
+	 */
+	public function getName()
+	{
+		return $this->name;
+	}
+
+	/**
+	 * @param string $name
+	 * Set human readable name of group
+	 */
+	public function setName(string $name)
+	{
+		$this->name = $name;
+	}
+}

--- a/src/Domain/Entity/GroupMember.php
+++ b/src/Domain/Entity/GroupMember.php
@@ -1,0 +1,134 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity;
+
+use Friendica\BaseEntity;
+use Friendica\Network\HTTPException\NotImplementedException;
+
+/**
+ * Entity class for table group_member
+ *
+ * privacy groups, member info
+ */
+class GroupMember extends BaseEntity
+{
+	/**
+	 * @var int
+	 * sequential ID
+	 */
+	private $id;
+
+	/**
+	 * @var int
+	 * groups.id of the associated group
+	 */
+	private $gid = '0';
+
+	/**
+	 * @var int
+	 * contact.id of the member assigned to the associated group
+	 */
+	private $contactId = '0';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'id' => $this->id,
+			'gid' => $this->gid,
+			'contact-id' => $this->contactId,
+		];
+	}
+
+	/**
+	 * @return int
+	 * Get sequential ID
+	 */
+	public function getId()
+	{
+		return $this->id;
+	}
+
+	/**
+	 * @return int
+	 * Get groups.id of the associated group
+	 */
+	public function getGid()
+	{
+		return $this->gid;
+	}
+
+	/**
+	 * @param int $gid
+	 * Set groups.id of the associated group
+	 */
+	public function setGid(int $gid)
+	{
+		$this->gid = $gid;
+	}
+
+	/**
+	 * Get Group
+	 *
+	 * @return Group
+	 */
+	public function getGroup()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for id is not implemented yet');
+	}
+
+	/**
+	 * @return int
+	 * Get contact.id of the member assigned to the associated group
+	 */
+	public function getContactId()
+	{
+		return $this->contactId;
+	}
+
+	/**
+	 * @param int $contactId
+	 * Set contact.id of the member assigned to the associated group
+	 */
+	public function setContactId(int $contactId)
+	{
+		$this->contactId = $contactId;
+	}
+
+	/**
+	 * Get Contact
+	 *
+	 * @return Contact
+	 */
+	public function getContact()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for id is not implemented yet');
+	}
+}

--- a/src/Domain/Entity/Gserver.php
+++ b/src/Domain/Entity/Gserver.php
@@ -1,0 +1,497 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity;
+
+use Friendica\BaseEntity;
+
+/**
+ * Entity class for table gserver
+ *
+ * Global servers
+ */
+class Gserver extends BaseEntity
+{
+	/**
+	 * @var int
+	 * sequential ID
+	 */
+	private $id;
+
+	/**
+	 * @var string
+	 */
+	private $url = '';
+
+	/**
+	 * @var string
+	 */
+	private $nurl = '';
+
+	/**
+	 * @var string
+	 */
+	private $version = '';
+
+	/**
+	 * @var string
+	 */
+	private $siteName = '';
+
+	/**
+	 * @var string
+	 */
+	private $info;
+
+	/**
+	 * @var string
+	 */
+	private $registerPolicy = '0';
+
+	/**
+	 * @var int
+	 * Number of registered users
+	 */
+	private $registeredUsers = '0';
+
+	/**
+	 * @var string
+	 * Type of directory service (Poco, Mastodon)
+	 */
+	private $directoryType = '0';
+
+	/**
+	 * @var string
+	 */
+	private $poco = '';
+
+	/**
+	 * @var string
+	 */
+	private $noscrape = '';
+
+	/**
+	 * @var string
+	 */
+	private $network = '';
+
+	/**
+	 * @var string
+	 */
+	private $platform = '';
+
+	/**
+	 * @var bool
+	 * Has the server subscribed to the relay system
+	 */
+	private $relaySubscribe = '0';
+
+	/**
+	 * @var string
+	 * The scope of messages that the server wants to get
+	 */
+	private $relayScope = '';
+
+	/**
+	 * @var string
+	 */
+	private $created = '0001-01-01 00:00:00';
+
+	/**
+	 * @var string
+	 */
+	private $lastPocoQuery = '0001-01-01 00:00:00';
+
+	/**
+	 * @var string
+	 */
+	private $lastContact = '0001-01-01 00:00:00';
+
+	/**
+	 * @var string
+	 */
+	private $lastFailure = '0001-01-01 00:00:00';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'id' => $this->id,
+			'url' => $this->url,
+			'nurl' => $this->nurl,
+			'version' => $this->version,
+			'site_name' => $this->siteName,
+			'info' => $this->info,
+			'register_policy' => $this->registerPolicy,
+			'registered-users' => $this->registeredUsers,
+			'directory-type' => $this->directoryType,
+			'poco' => $this->poco,
+			'noscrape' => $this->noscrape,
+			'network' => $this->network,
+			'platform' => $this->platform,
+			'relay-subscribe' => $this->relaySubscribe,
+			'relay-scope' => $this->relayScope,
+			'created' => $this->created,
+			'last_poco_query' => $this->lastPocoQuery,
+			'last_contact' => $this->lastContact,
+			'last_failure' => $this->lastFailure,
+		];
+	}
+
+	/**
+	 * @return int
+	 * Get sequential ID
+	 */
+	public function getId()
+	{
+		return $this->id;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getUrl()
+	{
+		return $this->url;
+	}
+
+	/**
+	 * @param string $url
+	 * Set
+	 */
+	public function setUrl(string $url)
+	{
+		$this->url = $url;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getNurl()
+	{
+		return $this->nurl;
+	}
+
+	/**
+	 * @param string $nurl
+	 * Set
+	 */
+	public function setNurl(string $nurl)
+	{
+		$this->nurl = $nurl;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getVersion()
+	{
+		return $this->version;
+	}
+
+	/**
+	 * @param string $version
+	 * Set
+	 */
+	public function setVersion(string $version)
+	{
+		$this->version = $version;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getSiteName()
+	{
+		return $this->siteName;
+	}
+
+	/**
+	 * @param string $siteName
+	 * Set
+	 */
+	public function setSiteName(string $siteName)
+	{
+		$this->siteName = $siteName;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getInfo()
+	{
+		return $this->info;
+	}
+
+	/**
+	 * @param string $info
+	 * Set
+	 */
+	public function setInfo(string $info)
+	{
+		$this->info = $info;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getRegisterPolicy()
+	{
+		return $this->registerPolicy;
+	}
+
+	/**
+	 * @param string $registerPolicy
+	 * Set
+	 */
+	public function setRegisterPolicy(string $registerPolicy)
+	{
+		$this->registerPolicy = $registerPolicy;
+	}
+
+	/**
+	 * @return int
+	 * Get Number of registered users
+	 */
+	public function getRegisteredUsers()
+	{
+		return $this->registeredUsers;
+	}
+
+	/**
+	 * @param int $registeredUsers
+	 * Set Number of registered users
+	 */
+	public function setRegisteredUsers(int $registeredUsers)
+	{
+		$this->registeredUsers = $registeredUsers;
+	}
+
+	/**
+	 * @return string
+	 * Get Type of directory service (Poco, Mastodon)
+	 */
+	public function getDirectoryType()
+	{
+		return $this->directoryType;
+	}
+
+	/**
+	 * @param string $directoryType
+	 * Set Type of directory service (Poco, Mastodon)
+	 */
+	public function setDirectoryType(string $directoryType)
+	{
+		$this->directoryType = $directoryType;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getPoco()
+	{
+		return $this->poco;
+	}
+
+	/**
+	 * @param string $poco
+	 * Set
+	 */
+	public function setPoco(string $poco)
+	{
+		$this->poco = $poco;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getNoscrape()
+	{
+		return $this->noscrape;
+	}
+
+	/**
+	 * @param string $noscrape
+	 * Set
+	 */
+	public function setNoscrape(string $noscrape)
+	{
+		$this->noscrape = $noscrape;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getNetwork()
+	{
+		return $this->network;
+	}
+
+	/**
+	 * @param string $network
+	 * Set
+	 */
+	public function setNetwork(string $network)
+	{
+		$this->network = $network;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getPlatform()
+	{
+		return $this->platform;
+	}
+
+	/**
+	 * @param string $platform
+	 * Set
+	 */
+	public function setPlatform(string $platform)
+	{
+		$this->platform = $platform;
+	}
+
+	/**
+	 * @return bool
+	 * Get Has the server subscribed to the relay system
+	 */
+	public function getRelaySubscribe()
+	{
+		return $this->relaySubscribe;
+	}
+
+	/**
+	 * @param bool $relaySubscribe
+	 * Set Has the server subscribed to the relay system
+	 */
+	public function setRelaySubscribe(bool $relaySubscribe)
+	{
+		$this->relaySubscribe = $relaySubscribe;
+	}
+
+	/**
+	 * @return string
+	 * Get The scope of messages that the server wants to get
+	 */
+	public function getRelayScope()
+	{
+		return $this->relayScope;
+	}
+
+	/**
+	 * @param string $relayScope
+	 * Set The scope of messages that the server wants to get
+	 */
+	public function setRelayScope(string $relayScope)
+	{
+		$this->relayScope = $relayScope;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getCreated()
+	{
+		return $this->created;
+	}
+
+	/**
+	 * @param string $created
+	 * Set
+	 */
+	public function setCreated(string $created)
+	{
+		$this->created = $created;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getLastPocoQuery()
+	{
+		return $this->lastPocoQuery;
+	}
+
+	/**
+	 * @param string $lastPocoQuery
+	 * Set
+	 */
+	public function setLastPocoQuery(string $lastPocoQuery)
+	{
+		$this->lastPocoQuery = $lastPocoQuery;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getLastContact()
+	{
+		return $this->lastContact;
+	}
+
+	/**
+	 * @param string $lastContact
+	 * Set
+	 */
+	public function setLastContact(string $lastContact)
+	{
+		$this->lastContact = $lastContact;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getLastFailure()
+	{
+		return $this->lastFailure;
+	}
+
+	/**
+	 * @param string $lastFailure
+	 * Set
+	 */
+	public function setLastFailure(string $lastFailure)
+	{
+		$this->lastFailure = $lastFailure;
+	}
+}

--- a/src/Domain/Entity/Gserver/Tag.php
+++ b/src/Domain/Entity/Gserver/Tag.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity\Gserver;
+
+use Friendica\BaseEntity;
+use Friendica\Network\HTTPException\NotImplementedException;
+
+/**
+ * Entity class for table gserver-tag
+ *
+ * Tags that the server has subscribed
+ */
+class Tag extends BaseEntity
+{
+	/**
+	 * @var int
+	 * The id of the gserver
+	 */
+	private $gserverId = '0';
+
+	/**
+	 * @var string
+	 * Tag that the server has subscribed
+	 */
+	private $tag = '';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'gserver-id' => $this->gserverId,
+			'tag' => $this->tag,
+		];
+	}
+
+	/**
+	 * @return int
+	 * Get The id of the gserver
+	 */
+	public function getGserverId()
+	{
+		return $this->gserverId;
+	}
+
+	/**
+	 * Get Gserver
+	 *
+	 * @return Gserver
+	 */
+	public function getGserver()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for id is not implemented yet');
+	}
+
+	/**
+	 * @return string
+	 * Get Tag that the server has subscribed
+	 */
+	public function getTag()
+	{
+		return $this->tag;
+	}
+}

--- a/src/Domain/Entity/Hook.php
+++ b/src/Domain/Entity/Hook.php
@@ -1,0 +1,161 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity;
+
+use Friendica\BaseEntity;
+
+/**
+ * Entity class for table hook
+ *
+ * addon hook registry
+ */
+class Hook extends BaseEntity
+{
+	/**
+	 * @var int
+	 * sequential ID
+	 */
+	private $id;
+
+	/**
+	 * @var string
+	 * name of hook
+	 */
+	private $hook = '';
+
+	/**
+	 * @var string
+	 * relative filename of hook handler
+	 */
+	private $file = '';
+
+	/**
+	 * @var string
+	 * function name of hook handler
+	 */
+	private $function = '';
+
+	/**
+	 * @var string
+	 * not yet implemented - can be used to sort conflicts in hook handling by calling handlers in priority order
+	 */
+	private $priority = '0';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'id' => $this->id,
+			'hook' => $this->hook,
+			'file' => $this->file,
+			'function' => $this->function,
+			'priority' => $this->priority,
+		];
+	}
+
+	/**
+	 * @return int
+	 * Get sequential ID
+	 */
+	public function getId()
+	{
+		return $this->id;
+	}
+
+	/**
+	 * @return string
+	 * Get name of hook
+	 */
+	public function getHook()
+	{
+		return $this->hook;
+	}
+
+	/**
+	 * @param string $hook
+	 * Set name of hook
+	 */
+	public function setHook(string $hook)
+	{
+		$this->hook = $hook;
+	}
+
+	/**
+	 * @return string
+	 * Get relative filename of hook handler
+	 */
+	public function getFile()
+	{
+		return $this->file;
+	}
+
+	/**
+	 * @param string $file
+	 * Set relative filename of hook handler
+	 */
+	public function setFile(string $file)
+	{
+		$this->file = $file;
+	}
+
+	/**
+	 * @return string
+	 * Get function name of hook handler
+	 */
+	public function getFunction()
+	{
+		return $this->function;
+	}
+
+	/**
+	 * @param string $function
+	 * Set function name of hook handler
+	 */
+	public function setFunction(string $function)
+	{
+		$this->function = $function;
+	}
+
+	/**
+	 * @return string
+	 * Get not yet implemented - can be used to sort conflicts in hook handling by calling handlers in priority order
+	 */
+	public function getPriority()
+	{
+		return $this->priority;
+	}
+
+	/**
+	 * @param string $priority
+	 * Set not yet implemented - can be used to sort conflicts in hook handling by calling handlers in priority order
+	 */
+	public function setPriority(string $priority)
+	{
+		$this->priority = $priority;
+	}
+}

--- a/src/Domain/Entity/Inbox/Status.php
+++ b/src/Domain/Entity/Inbox/Status.php
@@ -1,0 +1,211 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity\Inbox;
+
+use Friendica\BaseEntity;
+
+/**
+ * Entity class for table inbox-status
+ *
+ * Status of ActivityPub inboxes
+ */
+class Status extends BaseEntity
+{
+	/**
+	 * @var string
+	 * URL of the inbox
+	 */
+	private $url;
+
+	/**
+	 * @var string
+	 * Creation date of this entry
+	 */
+	private $created = '0001-01-01 00:00:00';
+
+	/**
+	 * @var string
+	 * Date of the last successful delivery
+	 */
+	private $success = '0001-01-01 00:00:00';
+
+	/**
+	 * @var string
+	 * Date of the last failed delivery
+	 */
+	private $failure = '0001-01-01 00:00:00';
+
+	/**
+	 * @var string
+	 * Previous delivery date
+	 */
+	private $previous = '0001-01-01 00:00:00';
+
+	/**
+	 * @var bool
+	 * Is the inbox archived?
+	 */
+	private $archive = '0';
+
+	/**
+	 * @var bool
+	 * Is it a shared inbox?
+	 */
+	private $shared = '0';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'url' => $this->url,
+			'created' => $this->created,
+			'success' => $this->success,
+			'failure' => $this->failure,
+			'previous' => $this->previous,
+			'archive' => $this->archive,
+			'shared' => $this->shared,
+		];
+	}
+
+	/**
+	 * @return string
+	 * Get URL of the inbox
+	 */
+	public function getUrl()
+	{
+		return $this->url;
+	}
+
+	/**
+	 * @return string
+	 * Get Creation date of this entry
+	 */
+	public function getCreated()
+	{
+		return $this->created;
+	}
+
+	/**
+	 * @param string $created
+	 * Set Creation date of this entry
+	 */
+	public function setCreated(string $created)
+	{
+		$this->created = $created;
+	}
+
+	/**
+	 * @return string
+	 * Get Date of the last successful delivery
+	 */
+	public function getSuccess()
+	{
+		return $this->success;
+	}
+
+	/**
+	 * @param string $success
+	 * Set Date of the last successful delivery
+	 */
+	public function setSuccess(string $success)
+	{
+		$this->success = $success;
+	}
+
+	/**
+	 * @return string
+	 * Get Date of the last failed delivery
+	 */
+	public function getFailure()
+	{
+		return $this->failure;
+	}
+
+	/**
+	 * @param string $failure
+	 * Set Date of the last failed delivery
+	 */
+	public function setFailure(string $failure)
+	{
+		$this->failure = $failure;
+	}
+
+	/**
+	 * @return string
+	 * Get Previous delivery date
+	 */
+	public function getPrevious()
+	{
+		return $this->previous;
+	}
+
+	/**
+	 * @param string $previous
+	 * Set Previous delivery date
+	 */
+	public function setPrevious(string $previous)
+	{
+		$this->previous = $previous;
+	}
+
+	/**
+	 * @return bool
+	 * Get Is the inbox archived?
+	 */
+	public function getArchive()
+	{
+		return $this->archive;
+	}
+
+	/**
+	 * @param bool $archive
+	 * Set Is the inbox archived?
+	 */
+	public function setArchive(bool $archive)
+	{
+		$this->archive = $archive;
+	}
+
+	/**
+	 * @return bool
+	 * Get Is it a shared inbox?
+	 */
+	public function getShared()
+	{
+		return $this->shared;
+	}
+
+	/**
+	 * @param bool $shared
+	 * Set Is it a shared inbox?
+	 */
+	public function setShared(bool $shared)
+	{
+		$this->shared = $shared;
+	}
+}

--- a/src/Domain/Entity/Intro.php
+++ b/src/Domain/Entity/Intro.php
@@ -1,0 +1,334 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity;
+
+use Friendica\BaseEntity;
+use Friendica\Network\HTTPException\NotImplementedException;
+
+/**
+ * Entity class for table intro
+ */
+class Intro extends BaseEntity
+{
+	/**
+	 * @var int
+	 * sequential ID
+	 */
+	private $id;
+
+	/**
+	 * @var int
+	 * User id
+	 */
+	private $uid = '0';
+
+	/**
+	 * @var int
+	 */
+	private $fid = '0';
+
+	/**
+	 * @var int
+	 */
+	private $contactId = '0';
+
+	/**
+	 * @var bool
+	 */
+	private $knowyou = '0';
+
+	/**
+	 * @var bool
+	 */
+	private $duplex = '0';
+
+	/**
+	 * @var string
+	 */
+	private $note;
+
+	/**
+	 * @var string
+	 */
+	private $hash = '';
+
+	/**
+	 * @var string
+	 */
+	private $datetime = '0001-01-01 00:00:00';
+
+	/**
+	 * @var bool
+	 */
+	private $blocked = '1';
+
+	/**
+	 * @var bool
+	 */
+	private $ignore = '0';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'id' => $this->id,
+			'uid' => $this->uid,
+			'fid' => $this->fid,
+			'contact-id' => $this->contactId,
+			'knowyou' => $this->knowyou,
+			'duplex' => $this->duplex,
+			'note' => $this->note,
+			'hash' => $this->hash,
+			'datetime' => $this->datetime,
+			'blocked' => $this->blocked,
+			'ignore' => $this->ignore,
+		];
+	}
+
+	/**
+	 * @return int
+	 * Get sequential ID
+	 */
+	public function getId()
+	{
+		return $this->id;
+	}
+
+	/**
+	 * @return int
+	 * Get User id
+	 */
+	public function getUid()
+	{
+		return $this->uid;
+	}
+
+	/**
+	 * @param int $uid
+	 * Set User id
+	 */
+	public function setUid(int $uid)
+	{
+		$this->uid = $uid;
+	}
+
+	/**
+	 * Get User
+	 *
+	 * @return User
+	 */
+	public function getUser()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for uid is not implemented yet');
+	}
+
+	/**
+	 * @return int
+	 * Get
+	 */
+	public function getFid()
+	{
+		return $this->fid;
+	}
+
+	/**
+	 * @param int $fid
+	 * Set
+	 */
+	public function setFid(int $fid)
+	{
+		$this->fid = $fid;
+	}
+
+	/**
+	 * Get Fcontact
+	 *
+	 * @return Fcontact
+	 */
+	public function getFcontact()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for id is not implemented yet');
+	}
+
+	/**
+	 * @return int
+	 * Get
+	 */
+	public function getContactId()
+	{
+		return $this->contactId;
+	}
+
+	/**
+	 * @param int $contactId
+	 * Set
+	 */
+	public function setContactId(int $contactId)
+	{
+		$this->contactId = $contactId;
+	}
+
+	/**
+	 * Get Contact
+	 *
+	 * @return Contact
+	 */
+	public function getContact()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for id is not implemented yet');
+	}
+
+	/**
+	 * @return bool
+	 * Get
+	 */
+	public function getKnowyou()
+	{
+		return $this->knowyou;
+	}
+
+	/**
+	 * @param bool $knowyou
+	 * Set
+	 */
+	public function setKnowyou(bool $knowyou)
+	{
+		$this->knowyou = $knowyou;
+	}
+
+	/**
+	 * @return bool
+	 * Get
+	 */
+	public function getDuplex()
+	{
+		return $this->duplex;
+	}
+
+	/**
+	 * @param bool $duplex
+	 * Set
+	 */
+	public function setDuplex(bool $duplex)
+	{
+		$this->duplex = $duplex;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getNote()
+	{
+		return $this->note;
+	}
+
+	/**
+	 * @param string $note
+	 * Set
+	 */
+	public function setNote(string $note)
+	{
+		$this->note = $note;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getHash()
+	{
+		return $this->hash;
+	}
+
+	/**
+	 * @param string $hash
+	 * Set
+	 */
+	public function setHash(string $hash)
+	{
+		$this->hash = $hash;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getDatetime()
+	{
+		return $this->datetime;
+	}
+
+	/**
+	 * @param string $datetime
+	 * Set
+	 */
+	public function setDatetime(string $datetime)
+	{
+		$this->datetime = $datetime;
+	}
+
+	/**
+	 * @return bool
+	 * Get
+	 */
+	public function getBlocked()
+	{
+		return $this->blocked;
+	}
+
+	/**
+	 * @param bool $blocked
+	 * Set
+	 */
+	public function setBlocked(bool $blocked)
+	{
+		$this->blocked = $blocked;
+	}
+
+	/**
+	 * @return bool
+	 * Get
+	 */
+	public function getIgnore()
+	{
+		return $this->ignore;
+	}
+
+	/**
+	 * @param bool $ignore
+	 * Set
+	 */
+	public function setIgnore(bool $ignore)
+	{
+		$this->ignore = $ignore;
+	}
+}

--- a/src/Domain/Entity/Item.php
+++ b/src/Domain/Entity/Item.php
@@ -1,0 +1,1899 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity;
+
+use Friendica\BaseEntity;
+use Friendica\Network\HTTPException\NotImplementedException;
+
+/**
+ * Entity class for table item
+ *
+ * Structure for all posts
+ */
+class Item extends BaseEntity
+{
+	/** @var int */
+	private $id;
+
+	/**
+	 * @var string
+	 * A unique identifier for this item
+	 */
+	private $guid = '';
+
+	/**
+	 * @var string
+	 */
+	private $uri = '';
+
+	/**
+	 * @var int
+	 * Id of the item-uri table entry that contains the item uri
+	 */
+	private $uriId;
+
+	/**
+	 * @var string
+	 * RIPEMD-128 hash from uri
+	 */
+	private $uriHash = '';
+
+	/**
+	 * @var int
+	 * item.id of the parent to this item if it is a reply of some form; otherwise this must be set to the id of this item
+	 */
+	private $parent = '0';
+
+	/**
+	 * @var string
+	 * uri of the parent to this item
+	 */
+	private $parentUri = '';
+
+	/**
+	 * @var int
+	 * Id of the item-uri table that contains the parent uri
+	 */
+	private $parentUriId;
+
+	/**
+	 * @var string
+	 * If the parent of this item is not the top-level item in the conversation, the uri of the immediate parent; otherwise set to parent-uri
+	 */
+	private $thrParent = '';
+
+	/**
+	 * @var int
+	 * Id of the item-uri table that contains the thread parent uri
+	 */
+	private $thrParentId;
+
+	/**
+	 * @var string
+	 * Creation timestamp.
+	 */
+	private $created = '0001-01-01 00:00:00';
+
+	/**
+	 * @var string
+	 * Date of last edit (default is created)
+	 */
+	private $edited = '0001-01-01 00:00:00';
+
+	/**
+	 * @var string
+	 * Date of last comment/reply to this item
+	 */
+	private $commented = '0001-01-01 00:00:00';
+
+	/**
+	 * @var string
+	 * datetime
+	 */
+	private $received = '0001-01-01 00:00:00';
+
+	/**
+	 * @var string
+	 * Date that something in the conversation changed, indicating clients should fetch the conversation again
+	 */
+	private $changed = '0001-01-01 00:00:00';
+
+	/**
+	 * @var string
+	 */
+	private $gravity = '0';
+
+	/**
+	 * @var string
+	 * Network from where the item comes from
+	 */
+	private $network = '';
+
+	/**
+	 * @var int
+	 * Link to the contact table with uid=0 of the owner of this item
+	 */
+	private $ownerId = '0';
+
+	/**
+	 * @var int
+	 * Link to the contact table with uid=0 of the author of this item
+	 */
+	private $authorId = '0';
+
+	/**
+	 * @var int
+	 * Id of the item-content table entry that contains the whole item content
+	 */
+	private $icid;
+
+	/**
+	 * @var int
+	 * Id of the item-activity table entry that contains the activity data
+	 */
+	private $iaid;
+
+	/**
+	 * @var string
+	 */
+	private $extid = '';
+
+	/**
+	 * @var string
+	 * Post type (personal note, bookmark, ...)
+	 */
+	private $postType = '0';
+
+	/**
+	 * @var bool
+	 */
+	private $global = '0';
+
+	/**
+	 * @var bool
+	 * distribution is restricted
+	 */
+	private $private = '0';
+
+	/**
+	 * @var bool
+	 */
+	private $visible = '0';
+
+	/**
+	 * @var bool
+	 */
+	private $moderated = '0';
+
+	/**
+	 * @var bool
+	 * item has been deleted
+	 */
+	private $deleted = '0';
+
+	/**
+	 * @var int
+	 * Owner id which owns this copy of the item
+	 */
+	private $uid = '0';
+
+	/**
+	 * @var int
+	 * contact.id
+	 */
+	private $contactId = '0';
+
+	/**
+	 * @var bool
+	 * This item was posted to the wall of uid
+	 */
+	private $wall = '0';
+
+	/**
+	 * @var bool
+	 * item originated at this site
+	 */
+	private $origin = '0';
+
+	/**
+	 * @var bool
+	 */
+	private $pubmail = '0';
+
+	/**
+	 * @var bool
+	 * item has been favourited
+	 */
+	private $starred = '0';
+
+	/**
+	 * @var bool
+	 * item has not been seen
+	 */
+	private $unseen = '1';
+
+	/**
+	 * @var bool
+	 * The owner of this item was mentioned in it
+	 */
+	private $mention = '0';
+
+	/**
+	 * @var string
+	 */
+	private $forumMode = '0';
+
+	/**
+	 * @var int
+	 * ID of the permission set of this post
+	 */
+	private $psid;
+
+	/**
+	 * @var string
+	 * Used to link other tables to items, it identifies the linked resource (e.g. photo) and if set must also set resource_type
+	 */
+	private $resourceId = '';
+
+	/**
+	 * @var int
+	 * Used to link to the event.id
+	 */
+	private $eventId = '0';
+
+	/**
+	 * @var string
+	 * JSON structure representing attachments to this item
+	 */
+	private $attach;
+
+	/**
+	 * @var string
+	 * Deprecated
+	 */
+	private $allowCid;
+
+	/**
+	 * @var string
+	 * Deprecated
+	 */
+	private $allowGid;
+
+	/**
+	 * @var string
+	 * Deprecated
+	 */
+	private $denyCid;
+
+	/**
+	 * @var string
+	 * Deprecated
+	 */
+	private $denyGid;
+
+	/**
+	 * @var string
+	 * Deprecated
+	 */
+	private $postopts;
+
+	/**
+	 * @var string
+	 * Deprecated
+	 */
+	private $inform;
+
+	/**
+	 * @var string
+	 * Deprecated
+	 */
+	private $type;
+
+	/**
+	 * @var bool
+	 * Deprecated
+	 */
+	private $bookmark;
+
+	/**
+	 * @var string
+	 * Deprecated
+	 */
+	private $file;
+
+	/**
+	 * @var string
+	 * Deprecated
+	 */
+	private $location;
+
+	/**
+	 * @var string
+	 * Deprecated
+	 */
+	private $coord;
+
+	/**
+	 * @var string
+	 * Deprecated
+	 */
+	private $tag;
+
+	/**
+	 * @var string
+	 * Deprecated
+	 */
+	private $plink;
+
+	/**
+	 * @var string
+	 * Deprecated
+	 */
+	private $title;
+
+	/**
+	 * @var string
+	 * Deprecated
+	 */
+	private $contentWarning;
+
+	/**
+	 * @var string
+	 * Deprecated
+	 */
+	private $body;
+
+	/**
+	 * @var string
+	 * Deprecated
+	 */
+	private $app;
+
+	/**
+	 * @var string
+	 * Deprecated
+	 */
+	private $verb;
+
+	/**
+	 * @var string
+	 * Deprecated
+	 */
+	private $objectType;
+
+	/**
+	 * @var string
+	 * Deprecated
+	 */
+	private $object;
+
+	/**
+	 * @var string
+	 * Deprecated
+	 */
+	private $targetType;
+
+	/**
+	 * @var string
+	 * Deprecated
+	 */
+	private $target;
+
+	/**
+	 * @var string
+	 * Deprecated
+	 */
+	private $authorName;
+
+	/**
+	 * @var string
+	 * Deprecated
+	 */
+	private $authorLink;
+
+	/**
+	 * @var string
+	 * Deprecated
+	 */
+	private $authorAvatar;
+
+	/**
+	 * @var string
+	 * Deprecated
+	 */
+	private $ownerName;
+
+	/**
+	 * @var string
+	 * Deprecated
+	 */
+	private $ownerLink;
+
+	/**
+	 * @var string
+	 * Deprecated
+	 */
+	private $ownerAvatar;
+
+	/**
+	 * @var string
+	 * Deprecated
+	 */
+	private $renderedHash;
+
+	/**
+	 * @var string
+	 * Deprecated
+	 */
+	private $renderedHtml;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'id' => $this->id,
+			'guid' => $this->guid,
+			'uri' => $this->uri,
+			'uri-id' => $this->uriId,
+			'uri-hash' => $this->uriHash,
+			'parent' => $this->parent,
+			'parent-uri' => $this->parentUri,
+			'parent-uri-id' => $this->parentUriId,
+			'thr-parent' => $this->thrParent,
+			'thr-parent-id' => $this->thrParentId,
+			'created' => $this->created,
+			'edited' => $this->edited,
+			'commented' => $this->commented,
+			'received' => $this->received,
+			'changed' => $this->changed,
+			'gravity' => $this->gravity,
+			'network' => $this->network,
+			'owner-id' => $this->ownerId,
+			'author-id' => $this->authorId,
+			'icid' => $this->icid,
+			'iaid' => $this->iaid,
+			'extid' => $this->extid,
+			'post-type' => $this->postType,
+			'global' => $this->global,
+			'private' => $this->private,
+			'visible' => $this->visible,
+			'moderated' => $this->moderated,
+			'deleted' => $this->deleted,
+			'uid' => $this->uid,
+			'contact-id' => $this->contactId,
+			'wall' => $this->wall,
+			'origin' => $this->origin,
+			'pubmail' => $this->pubmail,
+			'starred' => $this->starred,
+			'unseen' => $this->unseen,
+			'mention' => $this->mention,
+			'forum_mode' => $this->forumMode,
+			'psid' => $this->psid,
+			'resource-id' => $this->resourceId,
+			'event-id' => $this->eventId,
+			'attach' => $this->attach,
+			'allow_cid' => $this->allowCid,
+			'allow_gid' => $this->allowGid,
+			'deny_cid' => $this->denyCid,
+			'deny_gid' => $this->denyGid,
+			'postopts' => $this->postopts,
+			'inform' => $this->inform,
+			'type' => $this->type,
+			'bookmark' => $this->bookmark,
+			'file' => $this->file,
+			'location' => $this->location,
+			'coord' => $this->coord,
+			'tag' => $this->tag,
+			'plink' => $this->plink,
+			'title' => $this->title,
+			'content-warning' => $this->contentWarning,
+			'body' => $this->body,
+			'app' => $this->app,
+			'verb' => $this->verb,
+			'object-type' => $this->objectType,
+			'object' => $this->object,
+			'target-type' => $this->targetType,
+			'target' => $this->target,
+			'author-name' => $this->authorName,
+			'author-link' => $this->authorLink,
+			'author-avatar' => $this->authorAvatar,
+			'owner-name' => $this->ownerName,
+			'owner-link' => $this->ownerLink,
+			'owner-avatar' => $this->ownerAvatar,
+			'rendered-hash' => $this->renderedHash,
+			'rendered-html' => $this->renderedHtml,
+		];
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getId()
+	{
+		return $this->id;
+	}
+
+	/**
+	 * Get Thread
+	 *
+	 * @return Thread
+	 */
+	public function getThread()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for iid is not implemented yet');
+	}
+
+	/**
+	 * @return string
+	 * Get A unique identifier for this item
+	 */
+	public function getGuid()
+	{
+		return $this->guid;
+	}
+
+	/**
+	 * @param string $guid
+	 * Set A unique identifier for this item
+	 */
+	public function setGuid(string $guid)
+	{
+		$this->guid = $guid;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getUri()
+	{
+		return $this->uri;
+	}
+
+	/**
+	 * @param string $uri
+	 * Set
+	 */
+	public function setUri(string $uri)
+	{
+		$this->uri = $uri;
+	}
+
+	/**
+	 * @return int
+	 * Get Id of the item-uri table entry that contains the item uri
+	 */
+	public function getUriId()
+	{
+		return $this->uriId;
+	}
+
+	/**
+	 * @param int $uriId
+	 * Set Id of the item-uri table entry that contains the item uri
+	 */
+	public function setUriId(int $uriId)
+	{
+		$this->uriId = $uriId;
+	}
+
+	/**
+	 * Get \ItemUri
+	 *
+	 * @return \ItemUri
+	 */
+	public function getItemUri()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for id is not implemented yet');
+	}
+
+	/**
+	 * @return string
+	 * Get RIPEMD-128 hash from uri
+	 */
+	public function getUriHash()
+	{
+		return $this->uriHash;
+	}
+
+	/**
+	 * @param string $uriHash
+	 * Set RIPEMD-128 hash from uri
+	 */
+	public function setUriHash(string $uriHash)
+	{
+		$this->uriHash = $uriHash;
+	}
+
+	/**
+	 * @return int
+	 * Get item.id of the parent to this item if it is a reply of some form; otherwise this must be set to the id of this item
+	 */
+	public function getParent()
+	{
+		return $this->parent;
+	}
+
+	/**
+	 * @param int $parent
+	 * Set item.id of the parent to this item if it is a reply of some form; otherwise this must be set to the id of this item
+	 */
+	public function setParent(int $parent)
+	{
+		$this->parent = $parent;
+	}
+
+	/**
+	 * Get Item
+	 *
+	 * @return Item
+	 */
+	public function getItem()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for id is not implemented yet');
+	}
+
+	/**
+	 * @return string
+	 * Get uri of the parent to this item
+	 */
+	public function getParentUri()
+	{
+		return $this->parentUri;
+	}
+
+	/**
+	 * @param string $parentUri
+	 * Set uri of the parent to this item
+	 */
+	public function setParentUri(string $parentUri)
+	{
+		$this->parentUri = $parentUri;
+	}
+
+	/**
+	 * @return int
+	 * Get Id of the item-uri table that contains the parent uri
+	 */
+	public function getParentUriId()
+	{
+		return $this->parentUriId;
+	}
+
+	/**
+	 * @param int $parentUriId
+	 * Set Id of the item-uri table that contains the parent uri
+	 */
+	public function setParentUriId(int $parentUriId)
+	{
+		$this->parentUriId = $parentUriId;
+	}
+
+	/**
+	 * @return string
+	 * Get If the parent of this item is not the top-level item in the conversation, the uri of the immediate parent; otherwise set to parent-uri
+	 */
+	public function getThrParent()
+	{
+		return $this->thrParent;
+	}
+
+	/**
+	 * @param string $thrParent
+	 * Set If the parent of this item is not the top-level item in the conversation, the uri of the immediate parent; otherwise set to parent-uri
+	 */
+	public function setThrParent(string $thrParent)
+	{
+		$this->thrParent = $thrParent;
+	}
+
+	/**
+	 * @return int
+	 * Get Id of the item-uri table that contains the thread parent uri
+	 */
+	public function getThrParentId()
+	{
+		return $this->thrParentId;
+	}
+
+	/**
+	 * @param int $thrParentId
+	 * Set Id of the item-uri table that contains the thread parent uri
+	 */
+	public function setThrParentId(int $thrParentId)
+	{
+		$this->thrParentId = $thrParentId;
+	}
+
+	/**
+	 * @return string
+	 * Get Creation timestamp.
+	 */
+	public function getCreated()
+	{
+		return $this->created;
+	}
+
+	/**
+	 * @param string $created
+	 * Set Creation timestamp.
+	 */
+	public function setCreated(string $created)
+	{
+		$this->created = $created;
+	}
+
+	/**
+	 * @return string
+	 * Get Date of last edit (default is created)
+	 */
+	public function getEdited()
+	{
+		return $this->edited;
+	}
+
+	/**
+	 * @param string $edited
+	 * Set Date of last edit (default is created)
+	 */
+	public function setEdited(string $edited)
+	{
+		$this->edited = $edited;
+	}
+
+	/**
+	 * @return string
+	 * Get Date of last comment/reply to this item
+	 */
+	public function getCommented()
+	{
+		return $this->commented;
+	}
+
+	/**
+	 * @param string $commented
+	 * Set Date of last comment/reply to this item
+	 */
+	public function setCommented(string $commented)
+	{
+		$this->commented = $commented;
+	}
+
+	/**
+	 * @return string
+	 * Get datetime
+	 */
+	public function getReceived()
+	{
+		return $this->received;
+	}
+
+	/**
+	 * @param string $received
+	 * Set datetime
+	 */
+	public function setReceived(string $received)
+	{
+		$this->received = $received;
+	}
+
+	/**
+	 * @return string
+	 * Get Date that something in the conversation changed, indicating clients should fetch the conversation again
+	 */
+	public function getChanged()
+	{
+		return $this->changed;
+	}
+
+	/**
+	 * @param string $changed
+	 * Set Date that something in the conversation changed, indicating clients should fetch the conversation again
+	 */
+	public function setChanged(string $changed)
+	{
+		$this->changed = $changed;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getGravity()
+	{
+		return $this->gravity;
+	}
+
+	/**
+	 * @param string $gravity
+	 * Set
+	 */
+	public function setGravity(string $gravity)
+	{
+		$this->gravity = $gravity;
+	}
+
+	/**
+	 * @return string
+	 * Get Network from where the item comes from
+	 */
+	public function getNetwork()
+	{
+		return $this->network;
+	}
+
+	/**
+	 * @param string $network
+	 * Set Network from where the item comes from
+	 */
+	public function setNetwork(string $network)
+	{
+		$this->network = $network;
+	}
+
+	/**
+	 * @return int
+	 * Get Link to the contact table with uid=0 of the owner of this item
+	 */
+	public function getOwnerId()
+	{
+		return $this->ownerId;
+	}
+
+	/**
+	 * @param int $ownerId
+	 * Set Link to the contact table with uid=0 of the owner of this item
+	 */
+	public function setOwnerId(int $ownerId)
+	{
+		$this->ownerId = $ownerId;
+	}
+
+	/**
+	 * Get Contact
+	 *
+	 * @return Contact
+	 */
+	public function getContact()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for id is not implemented yet');
+	}
+
+	/**
+	 * @return int
+	 * Get Link to the contact table with uid=0 of the author of this item
+	 */
+	public function getAuthorId()
+	{
+		return $this->authorId;
+	}
+
+	/**
+	 * @param int $authorId
+	 * Set Link to the contact table with uid=0 of the author of this item
+	 */
+	public function setAuthorId(int $authorId)
+	{
+		$this->authorId = $authorId;
+	}
+
+	/**
+	 * @return int
+	 * Get Id of the item-content table entry that contains the whole item content
+	 */
+	public function getIcid()
+	{
+		return $this->icid;
+	}
+
+	/**
+	 * @param int $icid
+	 * Set Id of the item-content table entry that contains the whole item content
+	 */
+	public function setIcid(int $icid)
+	{
+		$this->icid = $icid;
+	}
+
+	/**
+	 * Get \ItemContent
+	 *
+	 * @return \ItemContent
+	 */
+	public function getItemContent()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for id is not implemented yet');
+	}
+
+	/**
+	 * @return int
+	 * Get Id of the item-activity table entry that contains the activity data
+	 */
+	public function getIaid()
+	{
+		return $this->iaid;
+	}
+
+	/**
+	 * @param int $iaid
+	 * Set Id of the item-activity table entry that contains the activity data
+	 */
+	public function setIaid(int $iaid)
+	{
+		$this->iaid = $iaid;
+	}
+
+	/**
+	 * Get \ItemActivity
+	 *
+	 * @return \ItemActivity
+	 */
+	public function getItemActivity()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for id is not implemented yet');
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getExtid()
+	{
+		return $this->extid;
+	}
+
+	/**
+	 * @param string $extid
+	 * Set
+	 */
+	public function setExtid(string $extid)
+	{
+		$this->extid = $extid;
+	}
+
+	/**
+	 * @return string
+	 * Get Post type (personal note, bookmark, ...)
+	 */
+	public function getPostType()
+	{
+		return $this->postType;
+	}
+
+	/**
+	 * @param string $postType
+	 * Set Post type (personal note, bookmark, ...)
+	 */
+	public function setPostType(string $postType)
+	{
+		$this->postType = $postType;
+	}
+
+	/**
+	 * @return bool
+	 * Get
+	 */
+	public function getGlobal()
+	{
+		return $this->global;
+	}
+
+	/**
+	 * @param bool $global
+	 * Set
+	 */
+	public function setGlobal(bool $global)
+	{
+		$this->global = $global;
+	}
+
+	/**
+	 * @return bool
+	 * Get distribution is restricted
+	 */
+	public function getPrivate()
+	{
+		return $this->private;
+	}
+
+	/**
+	 * @param bool $private
+	 * Set distribution is restricted
+	 */
+	public function setPrivate(bool $private)
+	{
+		$this->private = $private;
+	}
+
+	/**
+	 * @return bool
+	 * Get
+	 */
+	public function getVisible()
+	{
+		return $this->visible;
+	}
+
+	/**
+	 * @param bool $visible
+	 * Set
+	 */
+	public function setVisible(bool $visible)
+	{
+		$this->visible = $visible;
+	}
+
+	/**
+	 * @return bool
+	 * Get
+	 */
+	public function getModerated()
+	{
+		return $this->moderated;
+	}
+
+	/**
+	 * @param bool $moderated
+	 * Set
+	 */
+	public function setModerated(bool $moderated)
+	{
+		$this->moderated = $moderated;
+	}
+
+	/**
+	 * @return bool
+	 * Get item has been deleted
+	 */
+	public function getDeleted()
+	{
+		return $this->deleted;
+	}
+
+	/**
+	 * @param bool $deleted
+	 * Set item has been deleted
+	 */
+	public function setDeleted(bool $deleted)
+	{
+		$this->deleted = $deleted;
+	}
+
+	/**
+	 * @return int
+	 * Get Owner id which owns this copy of the item
+	 */
+	public function getUid()
+	{
+		return $this->uid;
+	}
+
+	/**
+	 * @param int $uid
+	 * Set Owner id which owns this copy of the item
+	 */
+	public function setUid(int $uid)
+	{
+		$this->uid = $uid;
+	}
+
+	/**
+	 * Get User
+	 *
+	 * @return User
+	 */
+	public function getUser()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for uid is not implemented yet');
+	}
+
+	/**
+	 * @return int
+	 * Get contact.id
+	 */
+	public function getContactId()
+	{
+		return $this->contactId;
+	}
+
+	/**
+	 * @param int $contactId
+	 * Set contact.id
+	 */
+	public function setContactId(int $contactId)
+	{
+		$this->contactId = $contactId;
+	}
+
+	/**
+	 * @return bool
+	 * Get This item was posted to the wall of uid
+	 */
+	public function getWall()
+	{
+		return $this->wall;
+	}
+
+	/**
+	 * @param bool $wall
+	 * Set This item was posted to the wall of uid
+	 */
+	public function setWall(bool $wall)
+	{
+		$this->wall = $wall;
+	}
+
+	/**
+	 * @return bool
+	 * Get item originated at this site
+	 */
+	public function getOrigin()
+	{
+		return $this->origin;
+	}
+
+	/**
+	 * @param bool $origin
+	 * Set item originated at this site
+	 */
+	public function setOrigin(bool $origin)
+	{
+		$this->origin = $origin;
+	}
+
+	/**
+	 * @return bool
+	 * Get
+	 */
+	public function getPubmail()
+	{
+		return $this->pubmail;
+	}
+
+	/**
+	 * @param bool $pubmail
+	 * Set
+	 */
+	public function setPubmail(bool $pubmail)
+	{
+		$this->pubmail = $pubmail;
+	}
+
+	/**
+	 * @return bool
+	 * Get item has been favourited
+	 */
+	public function getStarred()
+	{
+		return $this->starred;
+	}
+
+	/**
+	 * @param bool $starred
+	 * Set item has been favourited
+	 */
+	public function setStarred(bool $starred)
+	{
+		$this->starred = $starred;
+	}
+
+	/**
+	 * @return bool
+	 * Get item has not been seen
+	 */
+	public function getUnseen()
+	{
+		return $this->unseen;
+	}
+
+	/**
+	 * @param bool $unseen
+	 * Set item has not been seen
+	 */
+	public function setUnseen(bool $unseen)
+	{
+		$this->unseen = $unseen;
+	}
+
+	/**
+	 * @return bool
+	 * Get The owner of this item was mentioned in it
+	 */
+	public function getMention()
+	{
+		return $this->mention;
+	}
+
+	/**
+	 * @param bool $mention
+	 * Set The owner of this item was mentioned in it
+	 */
+	public function setMention(bool $mention)
+	{
+		$this->mention = $mention;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getForumMode()
+	{
+		return $this->forumMode;
+	}
+
+	/**
+	 * @param string $forumMode
+	 * Set
+	 */
+	public function setForumMode(string $forumMode)
+	{
+		$this->forumMode = $forumMode;
+	}
+
+	/**
+	 * @return int
+	 * Get ID of the permission set of this post
+	 */
+	public function getPsid()
+	{
+		return $this->psid;
+	}
+
+	/**
+	 * @param int $psid
+	 * Set ID of the permission set of this post
+	 */
+	public function setPsid(int $psid)
+	{
+		$this->psid = $psid;
+	}
+
+	/**
+	 * Get Permissionset
+	 *
+	 * @return Permissionset
+	 */
+	public function getPermissionset()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for id is not implemented yet');
+	}
+
+	/**
+	 * @return string
+	 * Get Used to link other tables to items, it identifies the linked resource (e.g. photo) and if set must also set resource_type
+	 */
+	public function getResourceId()
+	{
+		return $this->resourceId;
+	}
+
+	/**
+	 * @param string $resourceId
+	 * Set Used to link other tables to items, it identifies the linked resource (e.g. photo) and if set must also set resource_type
+	 */
+	public function setResourceId(string $resourceId)
+	{
+		$this->resourceId = $resourceId;
+	}
+
+	/**
+	 * @return int
+	 * Get Used to link to the event.id
+	 */
+	public function getEventId()
+	{
+		return $this->eventId;
+	}
+
+	/**
+	 * @param int $eventId
+	 * Set Used to link to the event.id
+	 */
+	public function setEventId(int $eventId)
+	{
+		$this->eventId = $eventId;
+	}
+
+	/**
+	 * Get Event
+	 *
+	 * @return Event
+	 */
+	public function getEvent()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for id is not implemented yet');
+	}
+
+	/**
+	 * @return string
+	 * Get JSON structure representing attachments to this item
+	 */
+	public function getAttach()
+	{
+		return $this->attach;
+	}
+
+	/**
+	 * @param string $attach
+	 * Set JSON structure representing attachments to this item
+	 */
+	public function setAttach(string $attach)
+	{
+		$this->attach = $attach;
+	}
+
+	/**
+	 * @return string
+	 * Get Deprecated
+	 */
+	public function getAllowCid()
+	{
+		return $this->allowCid;
+	}
+
+	/**
+	 * @param string $allowCid
+	 * Set Deprecated
+	 */
+	public function setAllowCid(string $allowCid)
+	{
+		$this->allowCid = $allowCid;
+	}
+
+	/**
+	 * @return string
+	 * Get Deprecated
+	 */
+	public function getAllowGid()
+	{
+		return $this->allowGid;
+	}
+
+	/**
+	 * @param string $allowGid
+	 * Set Deprecated
+	 */
+	public function setAllowGid(string $allowGid)
+	{
+		$this->allowGid = $allowGid;
+	}
+
+	/**
+	 * @return string
+	 * Get Deprecated
+	 */
+	public function getDenyCid()
+	{
+		return $this->denyCid;
+	}
+
+	/**
+	 * @param string $denyCid
+	 * Set Deprecated
+	 */
+	public function setDenyCid(string $denyCid)
+	{
+		$this->denyCid = $denyCid;
+	}
+
+	/**
+	 * @return string
+	 * Get Deprecated
+	 */
+	public function getDenyGid()
+	{
+		return $this->denyGid;
+	}
+
+	/**
+	 * @param string $denyGid
+	 * Set Deprecated
+	 */
+	public function setDenyGid(string $denyGid)
+	{
+		$this->denyGid = $denyGid;
+	}
+
+	/**
+	 * @return string
+	 * Get Deprecated
+	 */
+	public function getPostopts()
+	{
+		return $this->postopts;
+	}
+
+	/**
+	 * @param string $postopts
+	 * Set Deprecated
+	 */
+	public function setPostopts(string $postopts)
+	{
+		$this->postopts = $postopts;
+	}
+
+	/**
+	 * @return string
+	 * Get Deprecated
+	 */
+	public function getInform()
+	{
+		return $this->inform;
+	}
+
+	/**
+	 * @param string $inform
+	 * Set Deprecated
+	 */
+	public function setInform(string $inform)
+	{
+		$this->inform = $inform;
+	}
+
+	/**
+	 * @return string
+	 * Get Deprecated
+	 */
+	public function getType()
+	{
+		return $this->type;
+	}
+
+	/**
+	 * @param string $type
+	 * Set Deprecated
+	 */
+	public function setType(string $type)
+	{
+		$this->type = $type;
+	}
+
+	/**
+	 * @return bool
+	 * Get Deprecated
+	 */
+	public function getBookmark()
+	{
+		return $this->bookmark;
+	}
+
+	/**
+	 * @param bool $bookmark
+	 * Set Deprecated
+	 */
+	public function setBookmark(bool $bookmark)
+	{
+		$this->bookmark = $bookmark;
+	}
+
+	/**
+	 * @return string
+	 * Get Deprecated
+	 */
+	public function getFile()
+	{
+		return $this->file;
+	}
+
+	/**
+	 * @param string $file
+	 * Set Deprecated
+	 */
+	public function setFile(string $file)
+	{
+		$this->file = $file;
+	}
+
+	/**
+	 * @return string
+	 * Get Deprecated
+	 */
+	public function getLocation()
+	{
+		return $this->location;
+	}
+
+	/**
+	 * @param string $location
+	 * Set Deprecated
+	 */
+	public function setLocation(string $location)
+	{
+		$this->location = $location;
+	}
+
+	/**
+	 * @return string
+	 * Get Deprecated
+	 */
+	public function getCoord()
+	{
+		return $this->coord;
+	}
+
+	/**
+	 * @param string $coord
+	 * Set Deprecated
+	 */
+	public function setCoord(string $coord)
+	{
+		$this->coord = $coord;
+	}
+
+	/**
+	 * @return string
+	 * Get Deprecated
+	 */
+	public function getTag()
+	{
+		return $this->tag;
+	}
+
+	/**
+	 * @param string $tag
+	 * Set Deprecated
+	 */
+	public function setTag(string $tag)
+	{
+		$this->tag = $tag;
+	}
+
+	/**
+	 * @return string
+	 * Get Deprecated
+	 */
+	public function getPlink()
+	{
+		return $this->plink;
+	}
+
+	/**
+	 * @param string $plink
+	 * Set Deprecated
+	 */
+	public function setPlink(string $plink)
+	{
+		$this->plink = $plink;
+	}
+
+	/**
+	 * @return string
+	 * Get Deprecated
+	 */
+	public function getTitle()
+	{
+		return $this->title;
+	}
+
+	/**
+	 * @param string $title
+	 * Set Deprecated
+	 */
+	public function setTitle(string $title)
+	{
+		$this->title = $title;
+	}
+
+	/**
+	 * @return string
+	 * Get Deprecated
+	 */
+	public function getContentWarning()
+	{
+		return $this->contentWarning;
+	}
+
+	/**
+	 * @param string $contentWarning
+	 * Set Deprecated
+	 */
+	public function setContentWarning(string $contentWarning)
+	{
+		$this->contentWarning = $contentWarning;
+	}
+
+	/**
+	 * @return string
+	 * Get Deprecated
+	 */
+	public function getBody()
+	{
+		return $this->body;
+	}
+
+	/**
+	 * @param string $body
+	 * Set Deprecated
+	 */
+	public function setBody(string $body)
+	{
+		$this->body = $body;
+	}
+
+	/**
+	 * @return string
+	 * Get Deprecated
+	 */
+	public function getApp()
+	{
+		return $this->app;
+	}
+
+	/**
+	 * @param string $app
+	 * Set Deprecated
+	 */
+	public function setApp(string $app)
+	{
+		$this->app = $app;
+	}
+
+	/**
+	 * @return string
+	 * Get Deprecated
+	 */
+	public function getVerb()
+	{
+		return $this->verb;
+	}
+
+	/**
+	 * @param string $verb
+	 * Set Deprecated
+	 */
+	public function setVerb(string $verb)
+	{
+		$this->verb = $verb;
+	}
+
+	/**
+	 * @return string
+	 * Get Deprecated
+	 */
+	public function getObjectType()
+	{
+		return $this->objectType;
+	}
+
+	/**
+	 * @param string $objectType
+	 * Set Deprecated
+	 */
+	public function setObjectType(string $objectType)
+	{
+		$this->objectType = $objectType;
+	}
+
+	/**
+	 * @return string
+	 * Get Deprecated
+	 */
+	public function getObject()
+	{
+		return $this->object;
+	}
+
+	/**
+	 * @param string $object
+	 * Set Deprecated
+	 */
+	public function setObject(string $object)
+	{
+		$this->object = $object;
+	}
+
+	/**
+	 * @return string
+	 * Get Deprecated
+	 */
+	public function getTargetType()
+	{
+		return $this->targetType;
+	}
+
+	/**
+	 * @param string $targetType
+	 * Set Deprecated
+	 */
+	public function setTargetType(string $targetType)
+	{
+		$this->targetType = $targetType;
+	}
+
+	/**
+	 * @return string
+	 * Get Deprecated
+	 */
+	public function getTarget()
+	{
+		return $this->target;
+	}
+
+	/**
+	 * @param string $target
+	 * Set Deprecated
+	 */
+	public function setTarget(string $target)
+	{
+		$this->target = $target;
+	}
+
+	/**
+	 * @return string
+	 * Get Deprecated
+	 */
+	public function getAuthorName()
+	{
+		return $this->authorName;
+	}
+
+	/**
+	 * @param string $authorName
+	 * Set Deprecated
+	 */
+	public function setAuthorName(string $authorName)
+	{
+		$this->authorName = $authorName;
+	}
+
+	/**
+	 * @return string
+	 * Get Deprecated
+	 */
+	public function getAuthorLink()
+	{
+		return $this->authorLink;
+	}
+
+	/**
+	 * @param string $authorLink
+	 * Set Deprecated
+	 */
+	public function setAuthorLink(string $authorLink)
+	{
+		$this->authorLink = $authorLink;
+	}
+
+	/**
+	 * @return string
+	 * Get Deprecated
+	 */
+	public function getAuthorAvatar()
+	{
+		return $this->authorAvatar;
+	}
+
+	/**
+	 * @param string $authorAvatar
+	 * Set Deprecated
+	 */
+	public function setAuthorAvatar(string $authorAvatar)
+	{
+		$this->authorAvatar = $authorAvatar;
+	}
+
+	/**
+	 * @return string
+	 * Get Deprecated
+	 */
+	public function getOwnerName()
+	{
+		return $this->ownerName;
+	}
+
+	/**
+	 * @param string $ownerName
+	 * Set Deprecated
+	 */
+	public function setOwnerName(string $ownerName)
+	{
+		$this->ownerName = $ownerName;
+	}
+
+	/**
+	 * @return string
+	 * Get Deprecated
+	 */
+	public function getOwnerLink()
+	{
+		return $this->ownerLink;
+	}
+
+	/**
+	 * @param string $ownerLink
+	 * Set Deprecated
+	 */
+	public function setOwnerLink(string $ownerLink)
+	{
+		$this->ownerLink = $ownerLink;
+	}
+
+	/**
+	 * @return string
+	 * Get Deprecated
+	 */
+	public function getOwnerAvatar()
+	{
+		return $this->ownerAvatar;
+	}
+
+	/**
+	 * @param string $ownerAvatar
+	 * Set Deprecated
+	 */
+	public function setOwnerAvatar(string $ownerAvatar)
+	{
+		$this->ownerAvatar = $ownerAvatar;
+	}
+
+	/**
+	 * @return string
+	 * Get Deprecated
+	 */
+	public function getRenderedHash()
+	{
+		return $this->renderedHash;
+	}
+
+	/**
+	 * @param string $renderedHash
+	 * Set Deprecated
+	 */
+	public function setRenderedHash(string $renderedHash)
+	{
+		$this->renderedHash = $renderedHash;
+	}
+
+	/**
+	 * @return string
+	 * Get Deprecated
+	 */
+	public function getRenderedHtml()
+	{
+		return $this->renderedHtml;
+	}
+
+	/**
+	 * @param string $renderedHtml
+	 * Set Deprecated
+	 */
+	public function setRenderedHtml(string $renderedHtml)
+	{
+		$this->renderedHtml = $renderedHtml;
+	}
+}

--- a/src/Domain/Entity/Item/Activity.php
+++ b/src/Domain/Entity/Item/Activity.php
@@ -1,0 +1,179 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity\Item;
+
+use Friendica\BaseEntity;
+use Friendica\Domain\Entity\Item;
+use Friendica\Network\HTTPException\NotImplementedException;
+
+/**
+ * Entity class for table item-activity
+ *
+ * Activities for items
+ */
+class Activity extends BaseEntity
+{
+	/** @var int */
+	private $id;
+
+	/**
+	 * @var string
+	 */
+	private $uri;
+
+	/**
+	 * @var int
+	 * Id of the item-uri table entry that contains the item uri
+	 */
+	private $uriId;
+
+	/**
+	 * @var string
+	 * RIPEMD-128 hash from uri
+	 */
+	private $uriHash = '';
+
+	/**
+	 * @var string
+	 */
+	private $activity = '0';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'id' => $this->id,
+			'uri' => $this->uri,
+			'uri-id' => $this->uriId,
+			'uri-hash' => $this->uriHash,
+			'activity' => $this->activity,
+		];
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getId()
+	{
+		return $this->id;
+	}
+
+	/**
+	 * Get Thread
+	 *
+	 * @return Thread
+	 */
+	public function getThread()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for iid is not implemented yet');
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getUri()
+	{
+		return $this->uri;
+	}
+
+	/**
+	 * @param string $uri
+	 * Set
+	 */
+	public function setUri(string $uri)
+	{
+		$this->uri = $uri;
+	}
+
+	/**
+	 * @return int
+	 * Get Id of the item-uri table entry that contains the item uri
+	 */
+	public function getUriId()
+	{
+		return $this->uriId;
+	}
+
+	/**
+	 * @param int $uriId
+	 * Set Id of the item-uri table entry that contains the item uri
+	 */
+	public function setUriId(int $uriId)
+	{
+		$this->uriId = $uriId;
+	}
+
+	/**
+	 * Get \ItemUri
+	 *
+	 * @return \ItemUri
+	 */
+	public function getItemUri()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for id is not implemented yet');
+	}
+
+	/**
+	 * @return string
+	 * Get RIPEMD-128 hash from uri
+	 */
+	public function getUriHash()
+	{
+		return $this->uriHash;
+	}
+
+	/**
+	 * @param string $uriHash
+	 * Set RIPEMD-128 hash from uri
+	 */
+	public function setUriHash(string $uriHash)
+	{
+		$this->uriHash = $uriHash;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getActivity()
+	{
+		return $this->activity;
+	}
+
+	/**
+	 * @param string $activity
+	 * Set
+	 */
+	public function setActivity(string $activity)
+	{
+		$this->activity = $activity;
+	}
+}

--- a/src/Domain/Entity/Item/Content.php
+++ b/src/Domain/Entity/Item/Content.php
@@ -1,0 +1,528 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity\Item;
+
+use Friendica\BaseEntity;
+use Friendica\Domain\Entity\Item;
+use Friendica\Network\HTTPException\NotImplementedException;
+
+/**
+ * Entity class for table item-content
+ *
+ * Content for all posts
+ */
+class Content extends BaseEntity
+{
+	/** @var int */
+	private $id;
+
+	/**
+	 * @var string
+	 */
+	private $uri;
+
+	/**
+	 * @var int
+	 * Id of the item-uri table entry that contains the item uri
+	 */
+	private $uriId;
+
+	/**
+	 * @var string
+	 * RIPEMD-128 hash from uri
+	 */
+	private $uriPlinkHash = '';
+
+	/**
+	 * @var string
+	 * item title
+	 */
+	private $title = '';
+
+	/**
+	 * @var string
+	 */
+	private $contentWarning = '';
+
+	/**
+	 * @var string
+	 * item body content
+	 */
+	private $body;
+
+	/**
+	 * @var string
+	 * text location where this item originated
+	 */
+	private $location = '';
+
+	/**
+	 * @var string
+	 * longitude/latitude pair representing location where this item originated
+	 */
+	private $coord = '';
+
+	/**
+	 * @var string
+	 * Language information about this post
+	 */
+	private $language;
+
+	/**
+	 * @var string
+	 * application which generated this item
+	 */
+	private $app = '';
+
+	/**
+	 * @var string
+	 */
+	private $renderedHash = '';
+
+	/**
+	 * @var string
+	 * item.body converted to html
+	 */
+	private $renderedHtml;
+
+	/**
+	 * @var string
+	 * ActivityStreams object type
+	 */
+	private $objectType = '';
+
+	/**
+	 * @var string
+	 * JSON encoded object structure unless it is an implied object (normal post)
+	 */
+	private $object;
+
+	/**
+	 * @var string
+	 * ActivityStreams target type if applicable (URI)
+	 */
+	private $targetType = '';
+
+	/**
+	 * @var string
+	 * JSON encoded target structure if used
+	 */
+	private $target;
+
+	/**
+	 * @var string
+	 * permalink or URL to a displayable copy of the message at its source
+	 */
+	private $plink = '';
+
+	/**
+	 * @var string
+	 * ActivityStreams verb
+	 */
+	private $verb = '';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'id' => $this->id,
+			'uri' => $this->uri,
+			'uri-id' => $this->uriId,
+			'uri-plink-hash' => $this->uriPlinkHash,
+			'title' => $this->title,
+			'content-warning' => $this->contentWarning,
+			'body' => $this->body,
+			'location' => $this->location,
+			'coord' => $this->coord,
+			'language' => $this->language,
+			'app' => $this->app,
+			'rendered-hash' => $this->renderedHash,
+			'rendered-html' => $this->renderedHtml,
+			'object-type' => $this->objectType,
+			'object' => $this->object,
+			'target-type' => $this->targetType,
+			'target' => $this->target,
+			'plink' => $this->plink,
+			'verb' => $this->verb,
+		];
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getId()
+	{
+		return $this->id;
+	}
+
+	/**
+	 * Get Thread
+	 *
+	 * @return Thread
+	 */
+	public function getThread()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for iid is not implemented yet');
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getUri()
+	{
+		return $this->uri;
+	}
+
+	/**
+	 * @param string $uri
+	 * Set
+	 */
+	public function setUri(string $uri)
+	{
+		$this->uri = $uri;
+	}
+
+	/**
+	 * @return int
+	 * Get Id of the item-uri table entry that contains the item uri
+	 */
+	public function getUriId()
+	{
+		return $this->uriId;
+	}
+
+	/**
+	 * @param int $uriId
+	 * Set Id of the item-uri table entry that contains the item uri
+	 */
+	public function setUriId(int $uriId)
+	{
+		$this->uriId = $uriId;
+	}
+
+	/**
+	 * Get \ItemUri
+	 *
+	 * @return \ItemUri
+	 */
+	public function getItemUri()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for id is not implemented yet');
+	}
+
+	/**
+	 * @return string
+	 * Get RIPEMD-128 hash from uri
+	 */
+	public function getUriPlinkHash()
+	{
+		return $this->uriPlinkHash;
+	}
+
+	/**
+	 * @param string $uriPlinkHash
+	 * Set RIPEMD-128 hash from uri
+	 */
+	public function setUriPlinkHash(string $uriPlinkHash)
+	{
+		$this->uriPlinkHash = $uriPlinkHash;
+	}
+
+	/**
+	 * @return string
+	 * Get item title
+	 */
+	public function getTitle()
+	{
+		return $this->title;
+	}
+
+	/**
+	 * @param string $title
+	 * Set item title
+	 */
+	public function setTitle(string $title)
+	{
+		$this->title = $title;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getContentWarning()
+	{
+		return $this->contentWarning;
+	}
+
+	/**
+	 * @param string $contentWarning
+	 * Set
+	 */
+	public function setContentWarning(string $contentWarning)
+	{
+		$this->contentWarning = $contentWarning;
+	}
+
+	/**
+	 * @return string
+	 * Get item body content
+	 */
+	public function getBody()
+	{
+		return $this->body;
+	}
+
+	/**
+	 * @param string $body
+	 * Set item body content
+	 */
+	public function setBody(string $body)
+	{
+		$this->body = $body;
+	}
+
+	/**
+	 * @return string
+	 * Get text location where this item originated
+	 */
+	public function getLocation()
+	{
+		return $this->location;
+	}
+
+	/**
+	 * @param string $location
+	 * Set text location where this item originated
+	 */
+	public function setLocation(string $location)
+	{
+		$this->location = $location;
+	}
+
+	/**
+	 * @return string
+	 * Get longitude/latitude pair representing location where this item originated
+	 */
+	public function getCoord()
+	{
+		return $this->coord;
+	}
+
+	/**
+	 * @param string $coord
+	 * Set longitude/latitude pair representing location where this item originated
+	 */
+	public function setCoord(string $coord)
+	{
+		$this->coord = $coord;
+	}
+
+	/**
+	 * @return string
+	 * Get Language information about this post
+	 */
+	public function getLanguage()
+	{
+		return $this->language;
+	}
+
+	/**
+	 * @param string $language
+	 * Set Language information about this post
+	 */
+	public function setLanguage(string $language)
+	{
+		$this->language = $language;
+	}
+
+	/**
+	 * @return string
+	 * Get application which generated this item
+	 */
+	public function getApp()
+	{
+		return $this->app;
+	}
+
+	/**
+	 * @param string $app
+	 * Set application which generated this item
+	 */
+	public function setApp(string $app)
+	{
+		$this->app = $app;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getRenderedHash()
+	{
+		return $this->renderedHash;
+	}
+
+	/**
+	 * @param string $renderedHash
+	 * Set
+	 */
+	public function setRenderedHash(string $renderedHash)
+	{
+		$this->renderedHash = $renderedHash;
+	}
+
+	/**
+	 * @return string
+	 * Get item.body converted to html
+	 */
+	public function getRenderedHtml()
+	{
+		return $this->renderedHtml;
+	}
+
+	/**
+	 * @param string $renderedHtml
+	 * Set item.body converted to html
+	 */
+	public function setRenderedHtml(string $renderedHtml)
+	{
+		$this->renderedHtml = $renderedHtml;
+	}
+
+	/**
+	 * @return string
+	 * Get ActivityStreams object type
+	 */
+	public function getObjectType()
+	{
+		return $this->objectType;
+	}
+
+	/**
+	 * @param string $objectType
+	 * Set ActivityStreams object type
+	 */
+	public function setObjectType(string $objectType)
+	{
+		$this->objectType = $objectType;
+	}
+
+	/**
+	 * @return string
+	 * Get JSON encoded object structure unless it is an implied object (normal post)
+	 */
+	public function getObject()
+	{
+		return $this->object;
+	}
+
+	/**
+	 * @param string $object
+	 * Set JSON encoded object structure unless it is an implied object (normal post)
+	 */
+	public function setObject(string $object)
+	{
+		$this->object = $object;
+	}
+
+	/**
+	 * @return string
+	 * Get ActivityStreams target type if applicable (URI)
+	 */
+	public function getTargetType()
+	{
+		return $this->targetType;
+	}
+
+	/**
+	 * @param string $targetType
+	 * Set ActivityStreams target type if applicable (URI)
+	 */
+	public function setTargetType(string $targetType)
+	{
+		$this->targetType = $targetType;
+	}
+
+	/**
+	 * @return string
+	 * Get JSON encoded target structure if used
+	 */
+	public function getTarget()
+	{
+		return $this->target;
+	}
+
+	/**
+	 * @param string $target
+	 * Set JSON encoded target structure if used
+	 */
+	public function setTarget(string $target)
+	{
+		$this->target = $target;
+	}
+
+	/**
+	 * @return string
+	 * Get permalink or URL to a displayable copy of the message at its source
+	 */
+	public function getPlink()
+	{
+		return $this->plink;
+	}
+
+	/**
+	 * @param string $plink
+	 * Set permalink or URL to a displayable copy of the message at its source
+	 */
+	public function setPlink(string $plink)
+	{
+		$this->plink = $plink;
+	}
+
+	/**
+	 * @return string
+	 * Get ActivityStreams verb
+	 */
+	public function getVerb()
+	{
+		return $this->verb;
+	}
+
+	/**
+	 * @param string $verb
+	 * Set ActivityStreams verb
+	 */
+	public function setVerb(string $verb)
+	{
+		$this->verb = $verb;
+	}
+}

--- a/src/Domain/Entity/Item/Delivery/Data.php
+++ b/src/Domain/Entity/Item/Delivery/Data.php
@@ -1,0 +1,323 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity\Item\Delivery;
+
+use Friendica\BaseEntity;
+use Friendica\Network\HTTPException\NotImplementedException;
+
+/**
+ * Entity class for table item-delivery-data
+ *
+ * Delivery data for items
+ */
+class Data extends BaseEntity
+{
+	/**
+	 * @var int
+	 * Item id
+	 */
+	private $iid;
+
+	/**
+	 * @var string
+	 * External post connectors add their network name to this comma-separated string to identify that they should be delivered to these networks during delivery
+	 */
+	private $postopts;
+
+	/**
+	 * @var string
+	 * Additional receivers of the linked item
+	 */
+	private $inform;
+
+	/**
+	 * @var string
+	 * Initial number of delivery recipients, used as item.delivery_queue_count
+	 */
+	private $queueCount = '0';
+
+	/**
+	 * @var string
+	 * Number of successful deliveries, used as item.delivery_queue_done
+	 */
+	private $queueDone = '0';
+
+	/**
+	 * @var string
+	 * Number of unsuccessful deliveries, used as item.delivery_queue_failed
+	 */
+	private $queueFailed = '0';
+
+	/**
+	 * @var string
+	 * Number of successful deliveries via ActivityPub
+	 */
+	private $activitypub = '0';
+
+	/**
+	 * @var string
+	 * Number of successful deliveries via DFRN
+	 */
+	private $dfrn = '0';
+
+	/**
+	 * @var string
+	 * Number of successful deliveries via legacy DFRN
+	 */
+	private $legacyDfrn = '0';
+
+	/**
+	 * @var string
+	 * Number of successful deliveries via Diaspora
+	 */
+	private $diaspora = '0';
+
+	/**
+	 * @var string
+	 * Number of successful deliveries via OStatus
+	 */
+	private $ostatus = '0';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'iid' => $this->iid,
+			'postopts' => $this->postopts,
+			'inform' => $this->inform,
+			'queue_count' => $this->queueCount,
+			'queue_done' => $this->queueDone,
+			'queue_failed' => $this->queueFailed,
+			'activitypub' => $this->activitypub,
+			'dfrn' => $this->dfrn,
+			'legacy_dfrn' => $this->legacyDfrn,
+			'diaspora' => $this->diaspora,
+			'ostatus' => $this->ostatus,
+		];
+	}
+
+	/**
+	 * @return int
+	 * Get Item id
+	 */
+	public function getIid()
+	{
+		return $this->iid;
+	}
+
+	/**
+	 * Get Item
+	 *
+	 * @return Item
+	 */
+	public function getItem()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for id is not implemented yet');
+	}
+
+	/**
+	 * @return string
+	 * Get External post connectors add their network name to this comma-separated string to identify that they should be delivered to these networks during delivery
+	 */
+	public function getPostopts()
+	{
+		return $this->postopts;
+	}
+
+	/**
+	 * @param string $postopts
+	 * Set External post connectors add their network name to this comma-separated string to identify that they should be delivered to these networks during delivery
+	 */
+	public function setPostopts(string $postopts)
+	{
+		$this->postopts = $postopts;
+	}
+
+	/**
+	 * @return string
+	 * Get Additional receivers of the linked item
+	 */
+	public function getInform()
+	{
+		return $this->inform;
+	}
+
+	/**
+	 * @param string $inform
+	 * Set Additional receivers of the linked item
+	 */
+	public function setInform(string $inform)
+	{
+		$this->inform = $inform;
+	}
+
+	/**
+	 * @return string
+	 * Get Initial number of delivery recipients, used as item.delivery_queue_count
+	 */
+	public function getQueueCount()
+	{
+		return $this->queueCount;
+	}
+
+	/**
+	 * @param string $queueCount
+	 * Set Initial number of delivery recipients, used as item.delivery_queue_count
+	 */
+	public function setQueueCount(string $queueCount)
+	{
+		$this->queueCount = $queueCount;
+	}
+
+	/**
+	 * @return string
+	 * Get Number of successful deliveries, used as item.delivery_queue_done
+	 */
+	public function getQueueDone()
+	{
+		return $this->queueDone;
+	}
+
+	/**
+	 * @param string $queueDone
+	 * Set Number of successful deliveries, used as item.delivery_queue_done
+	 */
+	public function setQueueDone(string $queueDone)
+	{
+		$this->queueDone = $queueDone;
+	}
+
+	/**
+	 * @return string
+	 * Get Number of unsuccessful deliveries, used as item.delivery_queue_failed
+	 */
+	public function getQueueFailed()
+	{
+		return $this->queueFailed;
+	}
+
+	/**
+	 * @param string $queueFailed
+	 * Set Number of unsuccessful deliveries, used as item.delivery_queue_failed
+	 */
+	public function setQueueFailed(string $queueFailed)
+	{
+		$this->queueFailed = $queueFailed;
+	}
+
+	/**
+	 * @return string
+	 * Get Number of successful deliveries via ActivityPub
+	 */
+	public function getActivitypub()
+	{
+		return $this->activitypub;
+	}
+
+	/**
+	 * @param string $activitypub
+	 * Set Number of successful deliveries via ActivityPub
+	 */
+	public function setActivitypub(string $activitypub)
+	{
+		$this->activitypub = $activitypub;
+	}
+
+	/**
+	 * @return string
+	 * Get Number of successful deliveries via DFRN
+	 */
+	public function getDfrn()
+	{
+		return $this->dfrn;
+	}
+
+	/**
+	 * @param string $dfrn
+	 * Set Number of successful deliveries via DFRN
+	 */
+	public function setDfrn(string $dfrn)
+	{
+		$this->dfrn = $dfrn;
+	}
+
+	/**
+	 * @return string
+	 * Get Number of successful deliveries via legacy DFRN
+	 */
+	public function getLegacyDfrn()
+	{
+		return $this->legacyDfrn;
+	}
+
+	/**
+	 * @param string $legacyDfrn
+	 * Set Number of successful deliveries via legacy DFRN
+	 */
+	public function setLegacyDfrn(string $legacyDfrn)
+	{
+		$this->legacyDfrn = $legacyDfrn;
+	}
+
+	/**
+	 * @return string
+	 * Get Number of successful deliveries via Diaspora
+	 */
+	public function getDiaspora()
+	{
+		return $this->diaspora;
+	}
+
+	/**
+	 * @param string $diaspora
+	 * Set Number of successful deliveries via Diaspora
+	 */
+	public function setDiaspora(string $diaspora)
+	{
+		$this->diaspora = $diaspora;
+	}
+
+	/**
+	 * @return string
+	 * Get Number of successful deliveries via OStatus
+	 */
+	public function getOstatus()
+	{
+		return $this->ostatus;
+	}
+
+	/**
+	 * @param string $ostatus
+	 * Set Number of successful deliveries via OStatus
+	 */
+	public function setOstatus(string $ostatus)
+	{
+		$this->ostatus = $ostatus;
+	}
+}

--- a/src/Domain/Entity/Item/Uri.php
+++ b/src/Domain/Entity/Item/Uri.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity\Item;
+
+use Friendica\BaseEntity;
+
+/**
+ * Entity class for table item-uri
+ *
+ * URI and GUID for items
+ */
+class Uri extends BaseEntity
+{
+	/** @var int */
+	private $id;
+
+	/**
+	 * @var string
+	 * URI of an item
+	 */
+	private $uri;
+
+	/**
+	 * @var string
+	 * A unique identifier for an item
+	 */
+	private $guid;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'id' => $this->id,
+			'uri' => $this->uri,
+			'guid' => $this->guid,
+		];
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getId()
+	{
+		return $this->id;
+	}
+
+	/**
+	 * @return string
+	 * Get URI of an item
+	 */
+	public function getUri()
+	{
+		return $this->uri;
+	}
+
+	/**
+	 * @param string $uri
+	 * Set URI of an item
+	 */
+	public function setUri(string $uri)
+	{
+		$this->uri = $uri;
+	}
+
+	/**
+	 * @return string
+	 * Get A unique identifier for an item
+	 */
+	public function getGuid()
+	{
+		return $this->guid;
+	}
+
+	/**
+	 * @param string $guid
+	 * Set A unique identifier for an item
+	 */
+	public function setGuid(string $guid)
+	{
+		$this->guid = $guid;
+	}
+}

--- a/src/Domain/Entity/Locks.php
+++ b/src/Domain/Entity/Locks.php
@@ -1,0 +1,157 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity;
+
+use Friendica\BaseEntity;
+
+/**
+ * Entity class for table locks
+ */
+class Locks extends BaseEntity
+{
+	/**
+	 * @var int
+	 * sequential ID
+	 */
+	private $id;
+
+	/**
+	 * @var string
+	 */
+	private $name = '';
+
+	/**
+	 * @var bool
+	 */
+	private $locked = '0';
+
+	/**
+	 * @var int
+	 * Process ID
+	 */
+	private $pid = '0';
+
+	/**
+	 * @var string
+	 * datetime of cache expiration
+	 */
+	private $expires = '0001-01-01 00:00:00';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'id' => $this->id,
+			'name' => $this->name,
+			'locked' => $this->locked,
+			'pid' => $this->pid,
+			'expires' => $this->expires,
+		];
+	}
+
+	/**
+	 * @return int
+	 * Get sequential ID
+	 */
+	public function getId()
+	{
+		return $this->id;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getName()
+	{
+		return $this->name;
+	}
+
+	/**
+	 * @param string $name
+	 * Set
+	 */
+	public function setName(string $name)
+	{
+		$this->name = $name;
+	}
+
+	/**
+	 * @return bool
+	 * Get
+	 */
+	public function getLocked()
+	{
+		return $this->locked;
+	}
+
+	/**
+	 * @param bool $locked
+	 * Set
+	 */
+	public function setLocked(bool $locked)
+	{
+		$this->locked = $locked;
+	}
+
+	/**
+	 * @return int
+	 * Get Process ID
+	 */
+	public function getPid()
+	{
+		return $this->pid;
+	}
+
+	/**
+	 * @param int $pid
+	 * Set Process ID
+	 */
+	public function setPid(int $pid)
+	{
+		$this->pid = $pid;
+	}
+
+	/**
+	 * @return string
+	 * Get datetime of cache expiration
+	 */
+	public function getExpires()
+	{
+		return $this->expires;
+	}
+
+	/**
+	 * @param string $expires
+	 * Set datetime of cache expiration
+	 */
+	public function setExpires(string $expires)
+	{
+		$this->expires = $expires;
+	}
+}

--- a/src/Domain/Entity/Mail.php
+++ b/src/Domain/Entity/Mail.php
@@ -1,0 +1,489 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity;
+
+use Friendica\BaseEntity;
+use Friendica\Network\HTTPException\NotImplementedException;
+
+/**
+ * Entity class for table mail
+ *
+ * private messages
+ */
+class Mail extends BaseEntity
+{
+	/**
+	 * @var int
+	 * sequential ID
+	 */
+	private $id;
+
+	/**
+	 * @var int
+	 * Owner User id
+	 */
+	private $uid = '0';
+
+	/**
+	 * @var string
+	 * A unique identifier for this private message
+	 */
+	private $guid = '';
+
+	/**
+	 * @var string
+	 * name of the sender
+	 */
+	private $fromName = '';
+
+	/**
+	 * @var string
+	 * contact photo link of the sender
+	 */
+	private $fromPhoto = '';
+
+	/**
+	 * @var string
+	 * profile linke of the sender
+	 */
+	private $fromUrl = '';
+
+	/**
+	 * @var string
+	 * contact.id
+	 */
+	private $contactId = '';
+
+	/**
+	 * @var int
+	 * conv.id
+	 */
+	private $convid = '0';
+
+	/**
+	 * @var string
+	 */
+	private $title = '';
+
+	/**
+	 * @var string
+	 */
+	private $body;
+
+	/**
+	 * @var bool
+	 * if message visited it is 1
+	 */
+	private $seen = '0';
+
+	/**
+	 * @var bool
+	 */
+	private $reply = '0';
+
+	/**
+	 * @var bool
+	 */
+	private $replied = '0';
+
+	/**
+	 * @var bool
+	 * if sender not in the contact table this is 1
+	 */
+	private $unknown = '0';
+
+	/**
+	 * @var string
+	 */
+	private $uri = '';
+
+	/**
+	 * @var string
+	 */
+	private $parentUri = '';
+
+	/**
+	 * @var string
+	 * creation time of the private message
+	 */
+	private $created = '0001-01-01 00:00:00';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'id' => $this->id,
+			'uid' => $this->uid,
+			'guid' => $this->guid,
+			'from-name' => $this->fromName,
+			'from-photo' => $this->fromPhoto,
+			'from-url' => $this->fromUrl,
+			'contact-id' => $this->contactId,
+			'convid' => $this->convid,
+			'title' => $this->title,
+			'body' => $this->body,
+			'seen' => $this->seen,
+			'reply' => $this->reply,
+			'replied' => $this->replied,
+			'unknown' => $this->unknown,
+			'uri' => $this->uri,
+			'parent-uri' => $this->parentUri,
+			'created' => $this->created,
+		];
+	}
+
+	/**
+	 * @return int
+	 * Get sequential ID
+	 */
+	public function getId()
+	{
+		return $this->id;
+	}
+
+	/**
+	 * @return int
+	 * Get Owner User id
+	 */
+	public function getUid()
+	{
+		return $this->uid;
+	}
+
+	/**
+	 * @param int $uid
+	 * Set Owner User id
+	 */
+	public function setUid(int $uid)
+	{
+		$this->uid = $uid;
+	}
+
+	/**
+	 * Get User
+	 *
+	 * @return User
+	 */
+	public function getUser()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for uid is not implemented yet');
+	}
+
+	/**
+	 * @return string
+	 * Get A unique identifier for this private message
+	 */
+	public function getGuid()
+	{
+		return $this->guid;
+	}
+
+	/**
+	 * @param string $guid
+	 * Set A unique identifier for this private message
+	 */
+	public function setGuid(string $guid)
+	{
+		$this->guid = $guid;
+	}
+
+	/**
+	 * @return string
+	 * Get name of the sender
+	 */
+	public function getFromName()
+	{
+		return $this->fromName;
+	}
+
+	/**
+	 * @param string $fromName
+	 * Set name of the sender
+	 */
+	public function setFromName(string $fromName)
+	{
+		$this->fromName = $fromName;
+	}
+
+	/**
+	 * @return string
+	 * Get contact photo link of the sender
+	 */
+	public function getFromPhoto()
+	{
+		return $this->fromPhoto;
+	}
+
+	/**
+	 * @param string $fromPhoto
+	 * Set contact photo link of the sender
+	 */
+	public function setFromPhoto(string $fromPhoto)
+	{
+		$this->fromPhoto = $fromPhoto;
+	}
+
+	/**
+	 * @return string
+	 * Get profile linke of the sender
+	 */
+	public function getFromUrl()
+	{
+		return $this->fromUrl;
+	}
+
+	/**
+	 * @param string $fromUrl
+	 * Set profile linke of the sender
+	 */
+	public function setFromUrl(string $fromUrl)
+	{
+		$this->fromUrl = $fromUrl;
+	}
+
+	/**
+	 * @return string
+	 * Get contact.id
+	 */
+	public function getContactId()
+	{
+		return $this->contactId;
+	}
+
+	/**
+	 * @param string $contactId
+	 * Set contact.id
+	 */
+	public function setContactId(string $contactId)
+	{
+		$this->contactId = $contactId;
+	}
+
+	/**
+	 * Get Contact
+	 *
+	 * @return Contact
+	 */
+	public function getContact()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for id is not implemented yet');
+	}
+
+	/**
+	 * @return int
+	 * Get conv.id
+	 */
+	public function getConvid()
+	{
+		return $this->convid;
+	}
+
+	/**
+	 * @param int $convid
+	 * Set conv.id
+	 */
+	public function setConvid(int $convid)
+	{
+		$this->convid = $convid;
+	}
+
+	/**
+	 * Get Conv
+	 *
+	 * @return Conv
+	 */
+	public function getConv()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for id is not implemented yet');
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getTitle()
+	{
+		return $this->title;
+	}
+
+	/**
+	 * @param string $title
+	 * Set
+	 */
+	public function setTitle(string $title)
+	{
+		$this->title = $title;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getBody()
+	{
+		return $this->body;
+	}
+
+	/**
+	 * @param string $body
+	 * Set
+	 */
+	public function setBody(string $body)
+	{
+		$this->body = $body;
+	}
+
+	/**
+	 * @return bool
+	 * Get if message visited it is 1
+	 */
+	public function getSeen()
+	{
+		return $this->seen;
+	}
+
+	/**
+	 * @param bool $seen
+	 * Set if message visited it is 1
+	 */
+	public function setSeen(bool $seen)
+	{
+		$this->seen = $seen;
+	}
+
+	/**
+	 * @return bool
+	 * Get
+	 */
+	public function getReply()
+	{
+		return $this->reply;
+	}
+
+	/**
+	 * @param bool $reply
+	 * Set
+	 */
+	public function setReply(bool $reply)
+	{
+		$this->reply = $reply;
+	}
+
+	/**
+	 * @return bool
+	 * Get
+	 */
+	public function getReplied()
+	{
+		return $this->replied;
+	}
+
+	/**
+	 * @param bool $replied
+	 * Set
+	 */
+	public function setReplied(bool $replied)
+	{
+		$this->replied = $replied;
+	}
+
+	/**
+	 * @return bool
+	 * Get if sender not in the contact table this is 1
+	 */
+	public function getUnknown()
+	{
+		return $this->unknown;
+	}
+
+	/**
+	 * @param bool $unknown
+	 * Set if sender not in the contact table this is 1
+	 */
+	public function setUnknown(bool $unknown)
+	{
+		$this->unknown = $unknown;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getUri()
+	{
+		return $this->uri;
+	}
+
+	/**
+	 * @param string $uri
+	 * Set
+	 */
+	public function setUri(string $uri)
+	{
+		$this->uri = $uri;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getParentUri()
+	{
+		return $this->parentUri;
+	}
+
+	/**
+	 * @param string $parentUri
+	 * Set
+	 */
+	public function setParentUri(string $parentUri)
+	{
+		$this->parentUri = $parentUri;
+	}
+
+	/**
+	 * @return string
+	 * Get creation time of the private message
+	 */
+	public function getCreated()
+	{
+		return $this->created;
+	}
+
+	/**
+	 * @param string $created
+	 * Set creation time of the private message
+	 */
+	public function setCreated(string $created)
+	{
+		$this->created = $created;
+	}
+}

--- a/src/Domain/Entity/Mailacct.php
+++ b/src/Domain/Entity/Mailacct.php
@@ -1,0 +1,351 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity;
+
+use Friendica\BaseEntity;
+use Friendica\Network\HTTPException\NotImplementedException;
+
+/**
+ * Entity class for table mailacct
+ *
+ * Mail account data for fetching mails
+ */
+class Mailacct extends BaseEntity
+{
+	/**
+	 * @var int
+	 * sequential ID
+	 */
+	private $id;
+
+	/**
+	 * @var int
+	 * User id
+	 */
+	private $uid = '0';
+
+	/**
+	 * @var string
+	 */
+	private $server = '';
+
+	/**
+	 * @var string
+	 */
+	private $port = '0';
+
+	/**
+	 * @var string
+	 */
+	private $ssltype = '';
+
+	/**
+	 * @var string
+	 */
+	private $mailbox = '';
+
+	/**
+	 * @var string
+	 */
+	private $user = '';
+
+	/**
+	 * @var string
+	 */
+	private $pass;
+
+	/**
+	 * @var string
+	 */
+	private $replyTo = '';
+
+	/**
+	 * @var string
+	 */
+	private $action = '0';
+
+	/**
+	 * @var string
+	 */
+	private $movetofolder = '';
+
+	/**
+	 * @var bool
+	 */
+	private $pubmail = '0';
+
+	/**
+	 * @var string
+	 */
+	private $lastCheck = '0001-01-01 00:00:00';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'id' => $this->id,
+			'uid' => $this->uid,
+			'server' => $this->server,
+			'port' => $this->port,
+			'ssltype' => $this->ssltype,
+			'mailbox' => $this->mailbox,
+			'user' => $this->user,
+			'pass' => $this->pass,
+			'reply_to' => $this->replyTo,
+			'action' => $this->action,
+			'movetofolder' => $this->movetofolder,
+			'pubmail' => $this->pubmail,
+			'last_check' => $this->lastCheck,
+		];
+	}
+
+	/**
+	 * @return int
+	 * Get sequential ID
+	 */
+	public function getId()
+	{
+		return $this->id;
+	}
+
+	/**
+	 * @return int
+	 * Get User id
+	 */
+	public function getUid()
+	{
+		return $this->uid;
+	}
+
+	/**
+	 * @param int $uid
+	 * Set User id
+	 */
+	public function setUid(int $uid)
+	{
+		$this->uid = $uid;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getUser()
+	{
+		return $this->user;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getServer()
+	{
+		return $this->server;
+	}
+
+	/**
+	 * @param string $server
+	 * Set
+	 */
+	public function setServer(string $server)
+	{
+		$this->server = $server;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getPort()
+	{
+		return $this->port;
+	}
+
+	/**
+	 * @param string $port
+	 * Set
+	 */
+	public function setPort(string $port)
+	{
+		$this->port = $port;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getSsltype()
+	{
+		return $this->ssltype;
+	}
+
+	/**
+	 * @param string $ssltype
+	 * Set
+	 */
+	public function setSsltype(string $ssltype)
+	{
+		$this->ssltype = $ssltype;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getMailbox()
+	{
+		return $this->mailbox;
+	}
+
+	/**
+	 * @param string $mailbox
+	 * Set
+	 */
+	public function setMailbox(string $mailbox)
+	{
+		$this->mailbox = $mailbox;
+	}
+
+	/**
+	 * @param string $user
+	 * Set
+	 */
+	public function setUser(string $user)
+	{
+		$this->user = $user;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getPass()
+	{
+		return $this->pass;
+	}
+
+	/**
+	 * @param string $pass
+	 * Set
+	 */
+	public function setPass(string $pass)
+	{
+		$this->pass = $pass;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getReplyTo()
+	{
+		return $this->replyTo;
+	}
+
+	/**
+	 * @param string $replyTo
+	 * Set
+	 */
+	public function setReplyTo(string $replyTo)
+	{
+		$this->replyTo = $replyTo;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getAction()
+	{
+		return $this->action;
+	}
+
+	/**
+	 * @param string $action
+	 * Set
+	 */
+	public function setAction(string $action)
+	{
+		$this->action = $action;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getMovetofolder()
+	{
+		return $this->movetofolder;
+	}
+
+	/**
+	 * @param string $movetofolder
+	 * Set
+	 */
+	public function setMovetofolder(string $movetofolder)
+	{
+		$this->movetofolder = $movetofolder;
+	}
+
+	/**
+	 * @return bool
+	 * Get
+	 */
+	public function getPubmail()
+	{
+		return $this->pubmail;
+	}
+
+	/**
+	 * @param bool $pubmail
+	 * Set
+	 */
+	public function setPubmail(bool $pubmail)
+	{
+		$this->pubmail = $pubmail;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getLastCheck()
+	{
+		return $this->lastCheck;
+	}
+
+	/**
+	 * @param string $lastCheck
+	 * Set
+	 */
+	public function setLastCheck(string $lastCheck)
+	{
+		$this->lastCheck = $lastCheck;
+	}
+}

--- a/src/Domain/Entity/Manage.php
+++ b/src/Domain/Entity/Manage.php
@@ -1,0 +1,123 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity;
+
+use Friendica\BaseEntity;
+use Friendica\Network\HTTPException\NotImplementedException;
+
+/**
+ * Entity class for table manage
+ *
+ * table of accounts that can manage each other
+ */
+class Manage extends BaseEntity
+{
+	/**
+	 * @var int
+	 * sequential ID
+	 */
+	private $id;
+
+	/**
+	 * @var int
+	 * User id
+	 */
+	private $uid = '0';
+
+	/**
+	 * @var int
+	 * User id
+	 */
+	private $mid = '0';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'id' => $this->id,
+			'uid' => $this->uid,
+			'mid' => $this->mid,
+		];
+	}
+
+	/**
+	 * @return int
+	 * Get sequential ID
+	 */
+	public function getId()
+	{
+		return $this->id;
+	}
+
+	/**
+	 * @return int
+	 * Get User id
+	 */
+	public function getUid()
+	{
+		return $this->uid;
+	}
+
+	/**
+	 * @param int $uid
+	 * Set User id
+	 */
+	public function setUid(int $uid)
+	{
+		$this->uid = $uid;
+	}
+
+	/**
+	 * Get User
+	 *
+	 * @return User
+	 */
+	public function getUser()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for uid is not implemented yet');
+	}
+
+	/**
+	 * @return int
+	 * Get User id
+	 */
+	public function getMid()
+	{
+		return $this->mid;
+	}
+
+	/**
+	 * @param int $mid
+	 * Set User id
+	 */
+	public function setMid(int $mid)
+	{
+		$this->mid = $mid;
+	}
+}

--- a/src/Domain/Entity/Notify.php
+++ b/src/Domain/Entity/Notify.php
@@ -1,0 +1,448 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity;
+
+use Friendica\BaseEntity;
+use Friendica\Network\HTTPException\NotImplementedException;
+
+/**
+ * Entity class for table notify
+ *
+ * notifications
+ */
+class Notify extends BaseEntity
+{
+	/**
+	 * @var int
+	 * sequential ID
+	 */
+	private $id;
+
+	/**
+	 * @var string
+	 */
+	private $type = '0';
+
+	/**
+	 * @var string
+	 */
+	private $name = '';
+
+	/**
+	 * @var string
+	 */
+	private $url = '';
+
+	/**
+	 * @var string
+	 */
+	private $photo = '';
+
+	/**
+	 * @var string
+	 */
+	private $date = '0001-01-01 00:00:00';
+
+	/**
+	 * @var string
+	 */
+	private $msg;
+
+	/**
+	 * @var int
+	 * Owner User id
+	 */
+	private $uid = '0';
+
+	/**
+	 * @var string
+	 */
+	private $link = '';
+
+	/**
+	 * @var int
+	 * item.id
+	 */
+	private $iid = '0';
+
+	/**
+	 * @var int
+	 */
+	private $parent = '0';
+
+	/**
+	 * @var bool
+	 */
+	private $seen = '0';
+
+	/**
+	 * @var string
+	 */
+	private $verb = '';
+
+	/**
+	 * @var string
+	 */
+	private $otype = '';
+
+	/**
+	 * @var string
+	 * Cached bbcode parsing of name
+	 */
+	private $nameCache;
+
+	/**
+	 * @var string
+	 * Cached bbcode parsing of msg
+	 */
+	private $msgCache;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'id' => $this->id,
+			'type' => $this->type,
+			'name' => $this->name,
+			'url' => $this->url,
+			'photo' => $this->photo,
+			'date' => $this->date,
+			'msg' => $this->msg,
+			'uid' => $this->uid,
+			'link' => $this->link,
+			'iid' => $this->iid,
+			'parent' => $this->parent,
+			'seen' => $this->seen,
+			'verb' => $this->verb,
+			'otype' => $this->otype,
+			'name_cache' => $this->nameCache,
+			'msg_cache' => $this->msgCache,
+		];
+	}
+
+	/**
+	 * @return int
+	 * Get sequential ID
+	 */
+	public function getId()
+	{
+		return $this->id;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getType()
+	{
+		return $this->type;
+	}
+
+	/**
+	 * @param string $type
+	 * Set
+	 */
+	public function setType(string $type)
+	{
+		$this->type = $type;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getName()
+	{
+		return $this->name;
+	}
+
+	/**
+	 * @param string $name
+	 * Set
+	 */
+	public function setName(string $name)
+	{
+		$this->name = $name;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getUrl()
+	{
+		return $this->url;
+	}
+
+	/**
+	 * @param string $url
+	 * Set
+	 */
+	public function setUrl(string $url)
+	{
+		$this->url = $url;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getPhoto()
+	{
+		return $this->photo;
+	}
+
+	/**
+	 * @param string $photo
+	 * Set
+	 */
+	public function setPhoto(string $photo)
+	{
+		$this->photo = $photo;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getDate()
+	{
+		return $this->date;
+	}
+
+	/**
+	 * @param string $date
+	 * Set
+	 */
+	public function setDate(string $date)
+	{
+		$this->date = $date;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getMsg()
+	{
+		return $this->msg;
+	}
+
+	/**
+	 * @param string $msg
+	 * Set
+	 */
+	public function setMsg(string $msg)
+	{
+		$this->msg = $msg;
+	}
+
+	/**
+	 * @return int
+	 * Get Owner User id
+	 */
+	public function getUid()
+	{
+		return $this->uid;
+	}
+
+	/**
+	 * @param int $uid
+	 * Set Owner User id
+	 */
+	public function setUid(int $uid)
+	{
+		$this->uid = $uid;
+	}
+
+	/**
+	 * Get User
+	 *
+	 * @return User
+	 */
+	public function getUser()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for uid is not implemented yet');
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getLink()
+	{
+		return $this->link;
+	}
+
+	/**
+	 * @param string $link
+	 * Set
+	 */
+	public function setLink(string $link)
+	{
+		$this->link = $link;
+	}
+
+	/**
+	 * @return int
+	 * Get item.id
+	 */
+	public function getIid()
+	{
+		return $this->iid;
+	}
+
+	/**
+	 * @param int $iid
+	 * Set item.id
+	 */
+	public function setIid(int $iid)
+	{
+		$this->iid = $iid;
+	}
+
+	/**
+	 * Get Item
+	 *
+	 * @return Item
+	 */
+	public function getItem()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for id is not implemented yet');
+	}
+
+	/**
+	 * @return int
+	 * Get
+	 */
+	public function getParent()
+	{
+		return $this->parent;
+	}
+
+	/**
+	 * @param int $parent
+	 * Set
+	 */
+	public function setParent(int $parent)
+	{
+		$this->parent = $parent;
+	}
+
+	/**
+	 * @return bool
+	 * Get
+	 */
+	public function getSeen()
+	{
+		return $this->seen;
+	}
+
+	/**
+	 * @param bool $seen
+	 * Set
+	 */
+	public function setSeen(bool $seen)
+	{
+		$this->seen = $seen;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getVerb()
+	{
+		return $this->verb;
+	}
+
+	/**
+	 * @param string $verb
+	 * Set
+	 */
+	public function setVerb(string $verb)
+	{
+		$this->verb = $verb;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getOtype()
+	{
+		return $this->otype;
+	}
+
+	/**
+	 * @param string $otype
+	 * Set
+	 */
+	public function setOtype(string $otype)
+	{
+		$this->otype = $otype;
+	}
+
+	/**
+	 * @return string
+	 * Get Cached bbcode parsing of name
+	 */
+	public function getNameCache()
+	{
+		return $this->nameCache;
+	}
+
+	/**
+	 * @param string $nameCache
+	 * Set Cached bbcode parsing of name
+	 */
+	public function setNameCache(string $nameCache)
+	{
+		$this->nameCache = $nameCache;
+	}
+
+	/**
+	 * @return string
+	 * Get Cached bbcode parsing of msg
+	 */
+	public function getMsgCache()
+	{
+		return $this->msgCache;
+	}
+
+	/**
+	 * @param string $msgCache
+	 * Set Cached bbcode parsing of msg
+	 */
+	public function setMsgCache(string $msgCache)
+	{
+		$this->msgCache = $msgCache;
+	}
+}

--- a/src/Domain/Entity/Notify/Threads.php
+++ b/src/Domain/Entity/Notify/Threads.php
@@ -1,0 +1,190 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity\Notify;
+
+use Friendica\BaseEntity;
+use Friendica\Network\HTTPException\NotImplementedException;
+
+/**
+ * Entity class for table notify-threads
+ */
+class Threads extends BaseEntity
+{
+	/**
+	 * @var int
+	 * sequential ID
+	 */
+	private $id;
+
+	/**
+	 * @var int
+	 */
+	private $notifyId = '0';
+
+	/**
+	 * @var int
+	 */
+	private $masterParentItem = '0';
+
+	/**
+	 * @var int
+	 */
+	private $parentItem = '0';
+
+	/**
+	 * @var int
+	 * User id
+	 */
+	private $receiverUid = '0';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'id' => $this->id,
+			'notify-id' => $this->notifyId,
+			'master-parent-item' => $this->masterParentItem,
+			'parent-item' => $this->parentItem,
+			'receiver-uid' => $this->receiverUid,
+		];
+	}
+
+	/**
+	 * @return int
+	 * Get sequential ID
+	 */
+	public function getId()
+	{
+		return $this->id;
+	}
+
+	/**
+	 * @return int
+	 * Get
+	 */
+	public function getNotifyId()
+	{
+		return $this->notifyId;
+	}
+
+	/**
+	 * @param int $notifyId
+	 * Set
+	 */
+	public function setNotifyId(int $notifyId)
+	{
+		$this->notifyId = $notifyId;
+	}
+
+	/**
+	 * Get Notify
+	 *
+	 * @return Notify
+	 */
+	public function getNotify()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for id is not implemented yet');
+	}
+
+	/**
+	 * @return int
+	 * Get
+	 */
+	public function getMasterParentItem()
+	{
+		return $this->masterParentItem;
+	}
+
+	/**
+	 * @param int $masterParentItem
+	 * Set
+	 */
+	public function setMasterParentItem(int $masterParentItem)
+	{
+		$this->masterParentItem = $masterParentItem;
+	}
+
+	/**
+	 * Get Item
+	 *
+	 * @return Item
+	 */
+	public function getItem()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for id is not implemented yet');
+	}
+
+	/**
+	 * @return int
+	 * Get
+	 */
+	public function getParentItem()
+	{
+		return $this->parentItem;
+	}
+
+	/**
+	 * @param int $parentItem
+	 * Set
+	 */
+	public function setParentItem(int $parentItem)
+	{
+		$this->parentItem = $parentItem;
+	}
+
+	/**
+	 * @return int
+	 * Get User id
+	 */
+	public function getReceiverUid()
+	{
+		return $this->receiverUid;
+	}
+
+	/**
+	 * @param int $receiverUid
+	 * Set User id
+	 */
+	public function setReceiverUid(int $receiverUid)
+	{
+		$this->receiverUid = $receiverUid;
+	}
+
+	/**
+	 * Get User
+	 *
+	 * @return User
+	 */
+	public function getUser()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for uid is not implemented yet');
+	}
+}

--- a/src/Domain/Entity/Oembed.php
+++ b/src/Domain/Entity/Oembed.php
@@ -1,0 +1,127 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity;
+
+use Friendica\BaseEntity;
+
+/**
+ * Entity class for table oembed
+ *
+ * cache for OEmbed queries
+ */
+class Oembed extends BaseEntity
+{
+	/**
+	 * @var string
+	 * page url
+	 */
+	private $url;
+
+	/**
+	 * @var int
+	 * Maximum width passed to Oembed
+	 */
+	private $maxwidth;
+
+	/**
+	 * @var string
+	 * OEmbed data of the page
+	 */
+	private $content;
+
+	/**
+	 * @var string
+	 * datetime of creation
+	 */
+	private $created = '0001-01-01 00:00:00';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'url' => $this->url,
+			'maxwidth' => $this->maxwidth,
+			'content' => $this->content,
+			'created' => $this->created,
+		];
+	}
+
+	/**
+	 * @return string
+	 * Get page url
+	 */
+	public function getUrl()
+	{
+		return $this->url;
+	}
+
+	/**
+	 * @return int
+	 * Get Maximum width passed to Oembed
+	 */
+	public function getMaxwidth()
+	{
+		return $this->maxwidth;
+	}
+
+	/**
+	 * @return string
+	 * Get OEmbed data of the page
+	 */
+	public function getContent()
+	{
+		return $this->content;
+	}
+
+	/**
+	 * @param string $content
+	 * Set OEmbed data of the page
+	 */
+	public function setContent(string $content)
+	{
+		$this->content = $content;
+	}
+
+	/**
+	 * @return string
+	 * Get datetime of creation
+	 */
+	public function getCreated()
+	{
+		return $this->created;
+	}
+
+	/**
+	 * @param string $created
+	 * Set datetime of creation
+	 */
+	public function setCreated(string $created)
+	{
+		$this->created = $created;
+	}
+}

--- a/src/Domain/Entity/Openwebauth/Token.php
+++ b/src/Domain/Entity/Openwebauth/Token.php
@@ -1,0 +1,197 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity\Openwebauth;
+
+use Friendica\BaseEntity;
+use Friendica\Network\HTTPException\NotImplementedException;
+
+/**
+ * Entity class for table openwebauth-token
+ *
+ * Store OpenWebAuth token to verify contacts
+ */
+class Token extends BaseEntity
+{
+	/**
+	 * @var int
+	 * sequential ID
+	 */
+	private $id;
+
+	/**
+	 * @var int
+	 * User id
+	 */
+	private $uid = '0';
+
+	/**
+	 * @var string
+	 * Verify type
+	 */
+	private $type = '';
+
+	/**
+	 * @var string
+	 * A generated token
+	 */
+	private $token = '';
+
+	/**
+	 * @var string
+	 */
+	private $meta = '';
+
+	/**
+	 * @var string
+	 * datetime of creation
+	 */
+	private $created = '0001-01-01 00:00:00';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'id' => $this->id,
+			'uid' => $this->uid,
+			'type' => $this->type,
+			'token' => $this->token,
+			'meta' => $this->meta,
+			'created' => $this->created,
+		];
+	}
+
+	/**
+	 * @return int
+	 * Get sequential ID
+	 */
+	public function getId()
+	{
+		return $this->id;
+	}
+
+	/**
+	 * @return int
+	 * Get User id
+	 */
+	public function getUid()
+	{
+		return $this->uid;
+	}
+
+	/**
+	 * @param int $uid
+	 * Set User id
+	 */
+	public function setUid(int $uid)
+	{
+		$this->uid = $uid;
+	}
+
+	/**
+	 * Get User
+	 *
+	 * @return User
+	 */
+	public function getUser()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for uid is not implemented yet');
+	}
+
+	/**
+	 * @return string
+	 * Get Verify type
+	 */
+	public function getType()
+	{
+		return $this->type;
+	}
+
+	/**
+	 * @param string $type
+	 * Set Verify type
+	 */
+	public function setType(string $type)
+	{
+		$this->type = $type;
+	}
+
+	/**
+	 * @return string
+	 * Get A generated token
+	 */
+	public function getToken()
+	{
+		return $this->token;
+	}
+
+	/**
+	 * @param string $token
+	 * Set A generated token
+	 */
+	public function setToken(string $token)
+	{
+		$this->token = $token;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getMeta()
+	{
+		return $this->meta;
+	}
+
+	/**
+	 * @param string $meta
+	 * Set
+	 */
+	public function setMeta(string $meta)
+	{
+		$this->meta = $meta;
+	}
+
+	/**
+	 * @return string
+	 * Get datetime of creation
+	 */
+	public function getCreated()
+	{
+		return $this->created;
+	}
+
+	/**
+	 * @param string $created
+	 * Set datetime of creation
+	 */
+	public function setCreated(string $created)
+	{
+		$this->created = $created;
+	}
+}

--- a/src/Domain/Entity/ParsedUrl.php
+++ b/src/Domain/Entity/ParsedUrl.php
@@ -1,0 +1,143 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity;
+
+use Friendica\BaseEntity;
+
+/**
+ * Entity class for table parsed_url
+ *
+ * cache for 'parse_url' queries
+ */
+class ParsedUrl extends BaseEntity
+{
+	/**
+	 * @var string
+	 * page url
+	 */
+	private $url;
+
+	/**
+	 * @var bool
+	 * is the 'guessing' mode active?
+	 */
+	private $guessing = '0';
+
+	/**
+	 * @var bool
+	 * is the data the result of oembed?
+	 */
+	private $oembed = '0';
+
+	/**
+	 * @var string
+	 * page data
+	 */
+	private $content;
+
+	/**
+	 * @var string
+	 * datetime of creation
+	 */
+	private $created = '0001-01-01 00:00:00';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'url' => $this->url,
+			'guessing' => $this->guessing,
+			'oembed' => $this->oembed,
+			'content' => $this->content,
+			'created' => $this->created,
+		];
+	}
+
+	/**
+	 * @return string
+	 * Get page url
+	 */
+	public function getUrl()
+	{
+		return $this->url;
+	}
+
+	/**
+	 * @return bool
+	 * Get is the 'guessing' mode active?
+	 */
+	public function getGuessing()
+	{
+		return $this->guessing;
+	}
+
+	/**
+	 * @return bool
+	 * Get is the data the result of oembed?
+	 */
+	public function getOembed()
+	{
+		return $this->oembed;
+	}
+
+	/**
+	 * @return string
+	 * Get page data
+	 */
+	public function getContent()
+	{
+		return $this->content;
+	}
+
+	/**
+	 * @param string $content
+	 * Set page data
+	 */
+	public function setContent(string $content)
+	{
+		$this->content = $content;
+	}
+
+	/**
+	 * @return string
+	 * Get datetime of creation
+	 */
+	public function getCreated()
+	{
+		return $this->created;
+	}
+
+	/**
+	 * @param string $created
+	 * Set datetime of creation
+	 */
+	public function setCreated(string $created)
+	{
+		$this->created = $created;
+	}
+}

--- a/src/Domain/Entity/Participation.php
+++ b/src/Domain/Entity/Participation.php
@@ -1,0 +1,157 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity;
+
+use Friendica\BaseEntity;
+use Friendica\Network\HTTPException\NotImplementedException;
+
+/**
+ * Entity class for table participation
+ *
+ * Storage for participation messages from Diaspora
+ */
+class Participation extends BaseEntity
+{
+	/**
+	 * @var int
+	 */
+	private $iid;
+
+	/**
+	 * @var string
+	 */
+	private $server;
+
+	/**
+	 * @var int
+	 */
+	private $cid;
+
+	/**
+	 * @var int
+	 */
+	private $fid;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'iid' => $this->iid,
+			'server' => $this->server,
+			'cid' => $this->cid,
+			'fid' => $this->fid,
+		];
+	}
+
+	/**
+	 * @return int
+	 * Get
+	 */
+	public function getIid()
+	{
+		return $this->iid;
+	}
+
+	/**
+	 * Get Item
+	 *
+	 * @return Item
+	 */
+	public function getItem()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for id is not implemented yet');
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getServer()
+	{
+		return $this->server;
+	}
+
+	/**
+	 * @return int
+	 * Get
+	 */
+	public function getCid()
+	{
+		return $this->cid;
+	}
+
+	/**
+	 * @param int $cid
+	 * Set
+	 */
+	public function setCid(int $cid)
+	{
+		$this->cid = $cid;
+	}
+
+	/**
+	 * Get Contact
+	 *
+	 * @return Contact
+	 */
+	public function getContact()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for id is not implemented yet');
+	}
+
+	/**
+	 * @return int
+	 * Get
+	 */
+	public function getFid()
+	{
+		return $this->fid;
+	}
+
+	/**
+	 * @param int $fid
+	 * Set
+	 */
+	public function setFid(int $fid)
+	{
+		$this->fid = $fid;
+	}
+
+	/**
+	 * Get Fcontact
+	 *
+	 * @return Fcontact
+	 */
+	public function getFcontact()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for id is not implemented yet');
+	}
+}

--- a/src/Domain/Entity/Pconfig.php
+++ b/src/Domain/Entity/Pconfig.php
@@ -1,0 +1,169 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity;
+
+use Friendica\BaseEntity;
+use Friendica\Network\HTTPException\NotImplementedException;
+
+/**
+ * Entity class for table pconfig
+ *
+ * personal (per user) configuration storage
+ */
+class Pconfig extends BaseEntity
+{
+	/**
+	 * @var int
+	 */
+	private $id;
+
+	/**
+	 * @var int
+	 * User id
+	 */
+	private $uid = '0';
+
+	/**
+	 * @var string
+	 */
+	private $cat = '';
+
+	/**
+	 * @var string
+	 */
+	private $k = '';
+
+	/**
+	 * @var string
+	 */
+	private $v;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'id' => $this->id,
+			'uid' => $this->uid,
+			'cat' => $this->cat,
+			'k' => $this->k,
+			'v' => $this->v,
+		];
+	}
+
+	/**
+	 * @return int
+	 * Get
+	 */
+	public function getId()
+	{
+		return $this->id;
+	}
+
+	/**
+	 * @return int
+	 * Get User id
+	 */
+	public function getUid()
+	{
+		return $this->uid;
+	}
+
+	/**
+	 * @param int $uid
+	 * Set User id
+	 */
+	public function setUid(int $uid)
+	{
+		$this->uid = $uid;
+	}
+
+	/**
+	 * Get User
+	 *
+	 * @return User
+	 */
+	public function getUser()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for uid is not implemented yet');
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getCat()
+	{
+		return $this->cat;
+	}
+
+	/**
+	 * @param string $cat
+	 * Set
+	 */
+	public function setCat(string $cat)
+	{
+		$this->cat = $cat;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getK()
+	{
+		return $this->k;
+	}
+
+	/**
+	 * @param string $k
+	 * Set
+	 */
+	public function setK(string $k)
+	{
+		$this->k = $k;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getV()
+	{
+		return $this->v;
+	}
+
+	/**
+	 * @param string $v
+	 * Set
+	 */
+	public function setV(string $v)
+	{
+		$this->v = $v;
+	}
+}

--- a/src/Domain/Entity/Permissionset.php
+++ b/src/Domain/Entity/Permissionset.php
@@ -1,0 +1,196 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity;
+
+use Friendica\BaseEntity;
+use Friendica\Network\HTTPException\NotImplementedException;
+
+/**
+ * Entity class for table permissionset
+ */
+class Permissionset extends BaseEntity
+{
+	/**
+	 * @var int
+	 * sequential ID
+	 */
+	private $id;
+
+	/**
+	 * @var int
+	 * Owner id of this permission set
+	 */
+	private $uid = '0';
+
+	/**
+	 * @var string
+	 * Access Control - list of allowed contact.id '<19><78>'
+	 */
+	private $allowCid;
+
+	/**
+	 * @var string
+	 * Access Control - list of allowed groups
+	 */
+	private $allowGid;
+
+	/**
+	 * @var string
+	 * Access Control - list of denied contact.id
+	 */
+	private $denyCid;
+
+	/**
+	 * @var string
+	 * Access Control - list of denied groups
+	 */
+	private $denyGid;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'id' => $this->id,
+			'uid' => $this->uid,
+			'allow_cid' => $this->allowCid,
+			'allow_gid' => $this->allowGid,
+			'deny_cid' => $this->denyCid,
+			'deny_gid' => $this->denyGid,
+		];
+	}
+
+	/**
+	 * @return int
+	 * Get sequential ID
+	 */
+	public function getId()
+	{
+		return $this->id;
+	}
+
+	/**
+	 * @return int
+	 * Get Owner id of this permission set
+	 */
+	public function getUid()
+	{
+		return $this->uid;
+	}
+
+	/**
+	 * @param int $uid
+	 * Set Owner id of this permission set
+	 */
+	public function setUid(int $uid)
+	{
+		$this->uid = $uid;
+	}
+
+	/**
+	 * Get User
+	 *
+	 * @return User
+	 */
+	public function getUser()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for uid is not implemented yet');
+	}
+
+	/**
+	 * @return string
+	 * Get Access Control - list of allowed contact.id '<19><78>'
+	 */
+	public function getAllowCid()
+	{
+		return $this->allowCid;
+	}
+
+	/**
+	 * @param string $allowCid
+	 * Set Access Control - list of allowed contact.id '<19><78>'
+	 */
+	public function setAllowCid(string $allowCid)
+	{
+		$this->allowCid = $allowCid;
+	}
+
+	/**
+	 * @return string
+	 * Get Access Control - list of allowed groups
+	 */
+	public function getAllowGid()
+	{
+		return $this->allowGid;
+	}
+
+	/**
+	 * @param string $allowGid
+	 * Set Access Control - list of allowed groups
+	 */
+	public function setAllowGid(string $allowGid)
+	{
+		$this->allowGid = $allowGid;
+	}
+
+	/**
+	 * @return string
+	 * Get Access Control - list of denied contact.id
+	 */
+	public function getDenyCid()
+	{
+		return $this->denyCid;
+	}
+
+	/**
+	 * @param string $denyCid
+	 * Set Access Control - list of denied contact.id
+	 */
+	public function setDenyCid(string $denyCid)
+	{
+		$this->denyCid = $denyCid;
+	}
+
+	/**
+	 * @return string
+	 * Get Access Control - list of denied groups
+	 */
+	public function getDenyGid()
+	{
+		return $this->denyGid;
+	}
+
+	/**
+	 * @param string $denyGid
+	 * Set Access Control - list of denied groups
+	 */
+	public function setDenyGid(string $denyGid)
+	{
+		$this->denyGid = $denyGid;
+	}
+}

--- a/src/Domain/Entity/Photo.php
+++ b/src/Domain/Entity/Photo.php
@@ -1,0 +1,668 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity;
+
+use Friendica\BaseEntity;
+use Friendica\Network\HTTPException\NotImplementedException;
+
+/**
+ * Entity class for table photo
+ *
+ * photo storage
+ */
+class Photo extends BaseEntity
+{
+	/**
+	 * @var int
+	 * sequential ID
+	 */
+	private $id;
+
+	/**
+	 * @var int
+	 * Owner User id
+	 */
+	private $uid = '0';
+
+	/**
+	 * @var int
+	 * contact.id
+	 */
+	private $contactId = '0';
+
+	/**
+	 * @var string
+	 * A unique identifier for this photo
+	 */
+	private $guid = '';
+
+	/**
+	 * @var string
+	 */
+	private $resourceId = '';
+
+	/**
+	 * @var string
+	 * creation date
+	 */
+	private $created = '0001-01-01 00:00:00';
+
+	/**
+	 * @var string
+	 * last edited date
+	 */
+	private $edited = '0001-01-01 00:00:00';
+
+	/**
+	 * @var string
+	 */
+	private $title = '';
+
+	/**
+	 * @var string
+	 */
+	private $desc;
+
+	/**
+	 * @var string
+	 * The name of the album to which the photo belongs
+	 */
+	private $album = '';
+
+	/**
+	 * @var string
+	 */
+	private $filename = '';
+
+	/** @var string */
+	private $type = 'image/jpeg';
+
+	/**
+	 * @var string
+	 */
+	private $height = '0';
+
+	/**
+	 * @var string
+	 */
+	private $width = '0';
+
+	/**
+	 * @var int
+	 */
+	private $datasize = '0';
+
+	/**
+	 * @var string
+	 */
+	private $data;
+
+	/**
+	 * @var string
+	 */
+	private $scale = '0';
+
+	/**
+	 * @var bool
+	 */
+	private $profile = '0';
+
+	/**
+	 * @var string
+	 * Access Control - list of allowed contact.id '<19><78>'
+	 */
+	private $allowCid;
+
+	/**
+	 * @var string
+	 * Access Control - list of allowed groups
+	 */
+	private $allowGid;
+
+	/**
+	 * @var string
+	 * Access Control - list of denied contact.id
+	 */
+	private $denyCid;
+
+	/**
+	 * @var string
+	 * Access Control - list of denied groups
+	 */
+	private $denyGid;
+
+	/**
+	 * @var string
+	 * Storage backend class
+	 */
+	private $backendClass;
+
+	/**
+	 * @var string
+	 * Storage backend data reference
+	 */
+	private $backendRef;
+
+	/**
+	 * @var string
+	 */
+	private $updated = '0001-01-01 00:00:00';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'id' => $this->id,
+			'uid' => $this->uid,
+			'contact-id' => $this->contactId,
+			'guid' => $this->guid,
+			'resource-id' => $this->resourceId,
+			'created' => $this->created,
+			'edited' => $this->edited,
+			'title' => $this->title,
+			'desc' => $this->desc,
+			'album' => $this->album,
+			'filename' => $this->filename,
+			'type' => $this->type,
+			'height' => $this->height,
+			'width' => $this->width,
+			'datasize' => $this->datasize,
+			'data' => $this->data,
+			'scale' => $this->scale,
+			'profile' => $this->profile,
+			'allow_cid' => $this->allowCid,
+			'allow_gid' => $this->allowGid,
+			'deny_cid' => $this->denyCid,
+			'deny_gid' => $this->denyGid,
+			'backend-class' => $this->backendClass,
+			'backend-ref' => $this->backendRef,
+			'updated' => $this->updated,
+		];
+	}
+
+	/**
+	 * @return int
+	 * Get sequential ID
+	 */
+	public function getId()
+	{
+		return $this->id;
+	}
+
+	/**
+	 * @return int
+	 * Get Owner User id
+	 */
+	public function getUid()
+	{
+		return $this->uid;
+	}
+
+	/**
+	 * @param int $uid
+	 * Set Owner User id
+	 */
+	public function setUid(int $uid)
+	{
+		$this->uid = $uid;
+	}
+
+	/**
+	 * Get User
+	 *
+	 * @return User
+	 */
+	public function getUser()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for uid is not implemented yet');
+	}
+
+	/**
+	 * @return int
+	 * Get contact.id
+	 */
+	public function getContactId()
+	{
+		return $this->contactId;
+	}
+
+	/**
+	 * @param int $contactId
+	 * Set contact.id
+	 */
+	public function setContactId(int $contactId)
+	{
+		$this->contactId = $contactId;
+	}
+
+	/**
+	 * Get Contact
+	 *
+	 * @return Contact
+	 */
+	public function getContact()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for id is not implemented yet');
+	}
+
+	/**
+	 * @return string
+	 * Get A unique identifier for this photo
+	 */
+	public function getGuid()
+	{
+		return $this->guid;
+	}
+
+	/**
+	 * @param string $guid
+	 * Set A unique identifier for this photo
+	 */
+	public function setGuid(string $guid)
+	{
+		$this->guid = $guid;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getResourceId()
+	{
+		return $this->resourceId;
+	}
+
+	/**
+	 * @param string $resourceId
+	 * Set
+	 */
+	public function setResourceId(string $resourceId)
+	{
+		$this->resourceId = $resourceId;
+	}
+
+	/**
+	 * @return string
+	 * Get creation date
+	 */
+	public function getCreated()
+	{
+		return $this->created;
+	}
+
+	/**
+	 * @param string $created
+	 * Set creation date
+	 */
+	public function setCreated(string $created)
+	{
+		$this->created = $created;
+	}
+
+	/**
+	 * @return string
+	 * Get last edited date
+	 */
+	public function getEdited()
+	{
+		return $this->edited;
+	}
+
+	/**
+	 * @param string $edited
+	 * Set last edited date
+	 */
+	public function setEdited(string $edited)
+	{
+		$this->edited = $edited;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getTitle()
+	{
+		return $this->title;
+	}
+
+	/**
+	 * @param string $title
+	 * Set
+	 */
+	public function setTitle(string $title)
+	{
+		$this->title = $title;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getDesc()
+	{
+		return $this->desc;
+	}
+
+	/**
+	 * @param string $desc
+	 * Set
+	 */
+	public function setDesc(string $desc)
+	{
+		$this->desc = $desc;
+	}
+
+	/**
+	 * @return string
+	 * Get The name of the album to which the photo belongs
+	 */
+	public function getAlbum()
+	{
+		return $this->album;
+	}
+
+	/**
+	 * @param string $album
+	 * Set The name of the album to which the photo belongs
+	 */
+	public function setAlbum(string $album)
+	{
+		$this->album = $album;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getFilename()
+	{
+		return $this->filename;
+	}
+
+	/**
+	 * @param string $filename
+	 * Set
+	 */
+	public function setFilename(string $filename)
+	{
+		$this->filename = $filename;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getType()
+	{
+		return $this->type;
+	}
+
+	/**
+	 * @param string $type
+	 */
+	public function setType(string $type)
+	{
+		$this->type = $type;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getHeight()
+	{
+		return $this->height;
+	}
+
+	/**
+	 * @param string $height
+	 * Set
+	 */
+	public function setHeight(string $height)
+	{
+		$this->height = $height;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getWidth()
+	{
+		return $this->width;
+	}
+
+	/**
+	 * @param string $width
+	 * Set
+	 */
+	public function setWidth(string $width)
+	{
+		$this->width = $width;
+	}
+
+	/**
+	 * @return int
+	 * Get
+	 */
+	public function getDatasize()
+	{
+		return $this->datasize;
+	}
+
+	/**
+	 * @param int $datasize
+	 * Set
+	 */
+	public function setDatasize(int $datasize)
+	{
+		$this->datasize = $datasize;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getData()
+	{
+		return $this->data;
+	}
+
+	/**
+	 * @param string $data
+	 * Set
+	 */
+	public function setData(string $data)
+	{
+		$this->data = $data;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getScale()
+	{
+		return $this->scale;
+	}
+
+	/**
+	 * @param string $scale
+	 * Set
+	 */
+	public function setScale(string $scale)
+	{
+		$this->scale = $scale;
+	}
+
+	/**
+	 * @return bool
+	 * Get
+	 */
+	public function getProfile()
+	{
+		return $this->profile;
+	}
+
+	/**
+	 * @param bool $profile
+	 * Set
+	 */
+	public function setProfile(bool $profile)
+	{
+		$this->profile = $profile;
+	}
+
+	/**
+	 * @return string
+	 * Get Access Control - list of allowed contact.id '<19><78>'
+	 */
+	public function getAllowCid()
+	{
+		return $this->allowCid;
+	}
+
+	/**
+	 * @param string $allowCid
+	 * Set Access Control - list of allowed contact.id '<19><78>'
+	 */
+	public function setAllowCid(string $allowCid)
+	{
+		$this->allowCid = $allowCid;
+	}
+
+	/**
+	 * @return string
+	 * Get Access Control - list of allowed groups
+	 */
+	public function getAllowGid()
+	{
+		return $this->allowGid;
+	}
+
+	/**
+	 * @param string $allowGid
+	 * Set Access Control - list of allowed groups
+	 */
+	public function setAllowGid(string $allowGid)
+	{
+		$this->allowGid = $allowGid;
+	}
+
+	/**
+	 * @return string
+	 * Get Access Control - list of denied contact.id
+	 */
+	public function getDenyCid()
+	{
+		return $this->denyCid;
+	}
+
+	/**
+	 * @param string $denyCid
+	 * Set Access Control - list of denied contact.id
+	 */
+	public function setDenyCid(string $denyCid)
+	{
+		$this->denyCid = $denyCid;
+	}
+
+	/**
+	 * @return string
+	 * Get Access Control - list of denied groups
+	 */
+	public function getDenyGid()
+	{
+		return $this->denyGid;
+	}
+
+	/**
+	 * @param string $denyGid
+	 * Set Access Control - list of denied groups
+	 */
+	public function setDenyGid(string $denyGid)
+	{
+		$this->denyGid = $denyGid;
+	}
+
+	/**
+	 * @return string
+	 * Get Storage backend class
+	 */
+	public function getBackendClass()
+	{
+		return $this->backendClass;
+	}
+
+	/**
+	 * @param string $backendClass
+	 * Set Storage backend class
+	 */
+	public function setBackendClass(string $backendClass)
+	{
+		$this->backendClass = $backendClass;
+	}
+
+	/**
+	 * @return string
+	 * Get Storage backend data reference
+	 */
+	public function getBackendRef()
+	{
+		return $this->backendRef;
+	}
+
+	/**
+	 * @param string $backendRef
+	 * Set Storage backend data reference
+	 */
+	public function setBackendRef(string $backendRef)
+	{
+		$this->backendRef = $backendRef;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getUpdated()
+	{
+		return $this->updated;
+	}
+
+	/**
+	 * @param string $updated
+	 * Set
+	 */
+	public function setUpdated(string $updated)
+	{
+		$this->updated = $updated;
+	}
+}

--- a/src/Domain/Entity/Poll.php
+++ b/src/Domain/Entity/Poll.php
@@ -1,0 +1,337 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity;
+
+use Friendica\BaseEntity;
+use Friendica\Network\HTTPException\NotImplementedException;
+
+/**
+ * Entity class for table poll
+ *
+ * Currently unused table for storing poll results
+ */
+class Poll extends BaseEntity
+{
+	/**
+	 * @var int
+	 */
+	private $id;
+
+	/**
+	 * @var int
+	 * User id
+	 */
+	private $uid = '0';
+
+	/**
+	 * @var string
+	 */
+	private $qzero;
+
+	/**
+	 * @var string
+	 */
+	private $qone;
+
+	/**
+	 * @var string
+	 */
+	private $qtwo;
+
+	/**
+	 * @var string
+	 */
+	private $qthree;
+
+	/**
+	 * @var string
+	 */
+	private $qfour;
+
+	/**
+	 * @var string
+	 */
+	private $qfive;
+
+	/**
+	 * @var string
+	 */
+	private $qsix;
+
+	/**
+	 * @var string
+	 */
+	private $qseven;
+
+	/**
+	 * @var string
+	 */
+	private $qeight;
+
+	/**
+	 * @var string
+	 */
+	private $qnine;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'id' => $this->id,
+			'uid' => $this->uid,
+			'q0' => $this->qzero,
+			'q1' => $this->qone,
+			'q2' => $this->qtwo,
+			'q3' => $this->qthree,
+			'q4' => $this->qfour,
+			'q5' => $this->qfive,
+			'q6' => $this->qsix,
+			'q7' => $this->qseven,
+			'q8' => $this->qeight,
+			'q9' => $this->qnine,
+		];
+	}
+
+	/**
+	 * @return int
+	 * Get
+	 */
+	public function getId()
+	{
+		return $this->id;
+	}
+
+	/**
+	 * @return int
+	 * Get User id
+	 */
+	public function getUid()
+	{
+		return $this->uid;
+	}
+
+	/**
+	 * @param int $uid
+	 * Set User id
+	 */
+	public function setUid(int $uid)
+	{
+		$this->uid = $uid;
+	}
+
+	/**
+	 * Get User
+	 *
+	 * @return User
+	 */
+	public function getUser()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for uid is not implemented yet');
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getQzero()
+	{
+		return $this->qzero;
+	}
+
+	/**
+	 * @param string $qzero
+	 * Set
+	 */
+	public function setQzero(string $qzero)
+	{
+		$this->qzero = $qzero;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getQone()
+	{
+		return $this->qone;
+	}
+
+	/**
+	 * @param string $qone
+	 * Set
+	 */
+	public function setQone(string $qone)
+	{
+		$this->qone = $qone;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getQtwo()
+	{
+		return $this->qtwo;
+	}
+
+	/**
+	 * @param string $qtwo
+	 * Set
+	 */
+	public function setQtwo(string $qtwo)
+	{
+		$this->qtwo = $qtwo;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getQthree()
+	{
+		return $this->qthree;
+	}
+
+	/**
+	 * @param string $qthree
+	 * Set
+	 */
+	public function setQthree(string $qthree)
+	{
+		$this->qthree = $qthree;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getQfour()
+	{
+		return $this->qfour;
+	}
+
+	/**
+	 * @param string $qfour
+	 * Set
+	 */
+	public function setQfour(string $qfour)
+	{
+		$this->qfour = $qfour;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getQfive()
+	{
+		return $this->qfive;
+	}
+
+	/**
+	 * @param string $qfive
+	 * Set
+	 */
+	public function setQfive(string $qfive)
+	{
+		$this->qfive = $qfive;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getQsix()
+	{
+		return $this->qsix;
+	}
+
+	/**
+	 * @param string $qsix
+	 * Set
+	 */
+	public function setQsix(string $qsix)
+	{
+		$this->qsix = $qsix;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getQseven()
+	{
+		return $this->qseven;
+	}
+
+	/**
+	 * @param string $qseven
+	 * Set
+	 */
+	public function setQseven(string $qseven)
+	{
+		$this->qseven = $qseven;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getQeight()
+	{
+		return $this->qeight;
+	}
+
+	/**
+	 * @param string $qeight
+	 * Set
+	 */
+	public function setQeight(string $qeight)
+	{
+		$this->qeight = $qeight;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getQnine()
+	{
+		return $this->qnine;
+	}
+
+	/**
+	 * @param string $qnine
+	 * Set
+	 */
+	public function setQnine(string $qnine)
+	{
+		$this->qnine = $qnine;
+	}
+}

--- a/src/Domain/Entity/PollResult.php
+++ b/src/Domain/Entity/PollResult.php
@@ -1,0 +1,117 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity;
+
+use Friendica\BaseEntity;
+use Friendica\Network\HTTPException\NotImplementedException;
+
+/**
+ * Entity class for table poll_result
+ *
+ * data for polls - currently unused
+ */
+class PollResult extends BaseEntity
+{
+	/**
+	 * @var int
+	 * sequential ID
+	 */
+	private $id;
+
+	/** @var int */
+	private $pollId = '0';
+
+	/**
+	 * @var string
+	 */
+	private $choice = '0';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'id' => $this->id,
+			'poll_id' => $this->pollId,
+			'choice' => $this->choice,
+		];
+	}
+
+	/**
+	 * @return int
+	 * Get sequential ID
+	 */
+	public function getId()
+	{
+		return $this->id;
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getPollId()
+	{
+		return $this->pollId;
+	}
+
+	/**
+	 * @param int $pollId
+	 */
+	public function setPollId(int $pollId)
+	{
+		$this->pollId = $pollId;
+	}
+
+	/**
+	 * Get Poll
+	 *
+	 * @return Poll
+	 */
+	public function getPoll()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for id is not implemented yet');
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getChoice()
+	{
+		return $this->choice;
+	}
+
+	/**
+	 * @param string $choice
+	 * Set
+	 */
+	public function setChoice(string $choice)
+	{
+		$this->choice = $choice;
+	}
+}

--- a/src/Domain/Entity/Process.php
+++ b/src/Domain/Entity/Process.php
@@ -1,0 +1,108 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity;
+
+use Friendica\BaseEntity;
+
+/**
+ * Entity class for table process
+ *
+ * Currently running system processes
+ */
+class Process extends BaseEntity
+{
+	/**
+	 * @var int
+	 */
+	private $pid;
+
+	/**
+	 * @var string
+	 */
+	private $command = '';
+
+	/**
+	 * @var string
+	 */
+	private $created = '0001-01-01 00:00:00';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'pid' => $this->pid,
+			'command' => $this->command,
+			'created' => $this->created,
+		];
+	}
+
+	/**
+	 * @return int
+	 * Get
+	 */
+	public function getPid()
+	{
+		return $this->pid;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getCommand()
+	{
+		return $this->command;
+	}
+
+	/**
+	 * @param string $command
+	 * Set
+	 */
+	public function setCommand(string $command)
+	{
+		$this->command = $command;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getCreated()
+	{
+		return $this->created;
+	}
+
+	/**
+	 * @param string $created
+	 * Set
+	 */
+	public function setCreated(string $created)
+	{
+		$this->created = $created;
+	}
+}

--- a/src/Domain/Entity/Profile.php
+++ b/src/Domain/Entity/Profile.php
@@ -1,0 +1,1086 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity;
+
+use Friendica\BaseEntity;
+use Friendica\Network\HTTPException\NotImplementedException;
+
+/**
+ * Entity class for table profile
+ *
+ * user profiles data
+ */
+class Profile extends BaseEntity
+{
+	/**
+	 * @var int
+	 * sequential ID
+	 */
+	private $id;
+
+	/**
+	 * @var int
+	 * Owner User id
+	 */
+	private $uid = '0';
+
+	/**
+	 * @var string
+	 * Deprecated
+	 */
+	private $profileName;
+
+	/**
+	 * @var bool
+	 * Deprecated
+	 */
+	private $isDefault;
+
+	/**
+	 * @var bool
+	 * Hide friend list from viewers of this profile
+	 */
+	private $hideFriends = '0';
+
+	/**
+	 * @var string
+	 */
+	private $name = '';
+
+	/**
+	 * @var string
+	 * Deprecated
+	 */
+	private $pdesc;
+
+	/**
+	 * @var string
+	 * Day of birth
+	 */
+	private $dob = '0000-00-00';
+
+	/**
+	 * @var string
+	 */
+	private $address = '';
+
+	/**
+	 * @var string
+	 */
+	private $locality = '';
+
+	/**
+	 * @var string
+	 */
+	private $region = '';
+
+	/**
+	 * @var string
+	 */
+	private $postalCode = '';
+
+	/**
+	 * @var string
+	 */
+	private $countryName = '';
+
+	/**
+	 * @var string
+	 * Deprecated
+	 */
+	private $hometown;
+
+	/**
+	 * @var string
+	 * Deprecated
+	 */
+	private $gender;
+
+	/**
+	 * @var string
+	 * Deprecated
+	 */
+	private $marital;
+
+	/**
+	 * @var string
+	 * Deprecated
+	 */
+	private $with;
+
+	/**
+	 * @var string
+	 * Deprecated
+	 */
+	private $howlong;
+
+	/**
+	 * @var string
+	 * Deprecated
+	 */
+	private $sexual;
+
+	/**
+	 * @var string
+	 * Deprecated
+	 */
+	private $politic;
+
+	/**
+	 * @var string
+	 * Deprecated
+	 */
+	private $religion;
+
+	/**
+	 * @var string
+	 */
+	private $pubKeywords;
+
+	/**
+	 * @var string
+	 */
+	private $prvKeywords;
+
+	/**
+	 * @var string
+	 * Deprecated
+	 */
+	private $likes;
+
+	/**
+	 * @var string
+	 * Deprecated
+	 */
+	private $dislikes;
+
+	/**
+	 * @var string
+	 * Profile description
+	 */
+	private $about;
+
+	/**
+	 * @var string
+	 * Deprecated
+	 */
+	private $summary;
+
+	/**
+	 * @var string
+	 * Deprecated
+	 */
+	private $music;
+
+	/**
+	 * @var string
+	 * Deprecated
+	 */
+	private $book;
+
+	/**
+	 * @var string
+	 * Deprecated
+	 */
+	private $tv;
+
+	/**
+	 * @var string
+	 * Deprecated
+	 */
+	private $film;
+
+	/**
+	 * @var string
+	 * Deprecated
+	 */
+	private $interest;
+
+	/**
+	 * @var string
+	 * Deprecated
+	 */
+	private $romance;
+
+	/**
+	 * @var string
+	 * Deprecated
+	 */
+	private $work;
+
+	/**
+	 * @var string
+	 * Deprecated
+	 */
+	private $education;
+
+	/**
+	 * @var string
+	 * Deprecated
+	 */
+	private $contact;
+
+	/**
+	 * @var string
+	 */
+	private $homepage = '';
+
+	/**
+	 * @var string
+	 */
+	private $xmpp = '';
+
+	/**
+	 * @var string
+	 */
+	private $photo = '';
+
+	/**
+	 * @var string
+	 */
+	private $thumb = '';
+
+	/**
+	 * @var bool
+	 * publish default profile in local directory
+	 */
+	private $publish = '0';
+
+	/**
+	 * @var bool
+	 * publish profile in global directory
+	 */
+	private $netPublish = '0';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'id' => $this->id,
+			'uid' => $this->uid,
+			'profile-name' => $this->profileName,
+			'is-default' => $this->isDefault,
+			'hide-friends' => $this->hideFriends,
+			'name' => $this->name,
+			'pdesc' => $this->pdesc,
+			'dob' => $this->dob,
+			'address' => $this->address,
+			'locality' => $this->locality,
+			'region' => $this->region,
+			'postal-code' => $this->postalCode,
+			'country-name' => $this->countryName,
+			'hometown' => $this->hometown,
+			'gender' => $this->gender,
+			'marital' => $this->marital,
+			'with' => $this->with,
+			'howlong' => $this->howlong,
+			'sexual' => $this->sexual,
+			'politic' => $this->politic,
+			'religion' => $this->religion,
+			'pub_keywords' => $this->pubKeywords,
+			'prv_keywords' => $this->prvKeywords,
+			'likes' => $this->likes,
+			'dislikes' => $this->dislikes,
+			'about' => $this->about,
+			'summary' => $this->summary,
+			'music' => $this->music,
+			'book' => $this->book,
+			'tv' => $this->tv,
+			'film' => $this->film,
+			'interest' => $this->interest,
+			'romance' => $this->romance,
+			'work' => $this->work,
+			'education' => $this->education,
+			'contact' => $this->contact,
+			'homepage' => $this->homepage,
+			'xmpp' => $this->xmpp,
+			'photo' => $this->photo,
+			'thumb' => $this->thumb,
+			'publish' => $this->publish,
+			'net-publish' => $this->netPublish,
+		];
+	}
+
+	/**
+	 * @return int
+	 * Get sequential ID
+	 */
+	public function getId()
+	{
+		return $this->id;
+	}
+
+	/**
+	 * @return int
+	 * Get Owner User id
+	 */
+	public function getUid()
+	{
+		return $this->uid;
+	}
+
+	/**
+	 * @param int $uid
+	 * Set Owner User id
+	 */
+	public function setUid(int $uid)
+	{
+		$this->uid = $uid;
+	}
+
+	/**
+	 * Get User
+	 *
+	 * @return User
+	 */
+	public function getUser()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for uid is not implemented yet');
+	}
+
+	/**
+	 * @return string
+	 * Get Deprecated
+	 */
+	public function getProfileName()
+	{
+		return $this->profileName;
+	}
+
+	/**
+	 * @param string $profileName
+	 * Set Deprecated
+	 */
+	public function setProfileName(string $profileName)
+	{
+		$this->profileName = $profileName;
+	}
+
+	/**
+	 * @return bool
+	 * Get Deprecated
+	 */
+	public function getIsDefault()
+	{
+		return $this->isDefault;
+	}
+
+	/**
+	 * @param bool $isDefault
+	 * Set Deprecated
+	 */
+	public function setIsDefault(bool $isDefault)
+	{
+		$this->isDefault = $isDefault;
+	}
+
+	/**
+	 * @return bool
+	 * Get Hide friend list from viewers of this profile
+	 */
+	public function getHideFriends()
+	{
+		return $this->hideFriends;
+	}
+
+	/**
+	 * @param bool $hideFriends
+	 * Set Hide friend list from viewers of this profile
+	 */
+	public function setHideFriends(bool $hideFriends)
+	{
+		$this->hideFriends = $hideFriends;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getName()
+	{
+		return $this->name;
+	}
+
+	/**
+	 * @param string $name
+	 * Set
+	 */
+	public function setName(string $name)
+	{
+		$this->name = $name;
+	}
+
+	/**
+	 * @return string
+	 * Get Deprecated
+	 */
+	public function getPdesc()
+	{
+		return $this->pdesc;
+	}
+
+	/**
+	 * @param string $pdesc
+	 * Set Deprecated
+	 */
+	public function setPdesc(string $pdesc)
+	{
+		$this->pdesc = $pdesc;
+	}
+
+	/**
+	 * @return string
+	 * Get Day of birth
+	 */
+	public function getDob()
+	{
+		return $this->dob;
+	}
+
+	/**
+	 * @param string $dob
+	 * Set Day of birth
+	 */
+	public function setDob(string $dob)
+	{
+		$this->dob = $dob;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getAddress()
+	{
+		return $this->address;
+	}
+
+	/**
+	 * @param string $address
+	 * Set
+	 */
+	public function setAddress(string $address)
+	{
+		$this->address = $address;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getLocality()
+	{
+		return $this->locality;
+	}
+
+	/**
+	 * @param string $locality
+	 * Set
+	 */
+	public function setLocality(string $locality)
+	{
+		$this->locality = $locality;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getRegion()
+	{
+		return $this->region;
+	}
+
+	/**
+	 * @param string $region
+	 * Set
+	 */
+	public function setRegion(string $region)
+	{
+		$this->region = $region;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getPostalCode()
+	{
+		return $this->postalCode;
+	}
+
+	/**
+	 * @param string $postalCode
+	 * Set
+	 */
+	public function setPostalCode(string $postalCode)
+	{
+		$this->postalCode = $postalCode;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getCountryName()
+	{
+		return $this->countryName;
+	}
+
+	/**
+	 * @param string $countryName
+	 * Set
+	 */
+	public function setCountryName(string $countryName)
+	{
+		$this->countryName = $countryName;
+	}
+
+	/**
+	 * @return string
+	 * Get Deprecated
+	 */
+	public function getHometown()
+	{
+		return $this->hometown;
+	}
+
+	/**
+	 * @param string $hometown
+	 * Set Deprecated
+	 */
+	public function setHometown(string $hometown)
+	{
+		$this->hometown = $hometown;
+	}
+
+	/**
+	 * @return string
+	 * Get Deprecated
+	 */
+	public function getGender()
+	{
+		return $this->gender;
+	}
+
+	/**
+	 * @param string $gender
+	 * Set Deprecated
+	 */
+	public function setGender(string $gender)
+	{
+		$this->gender = $gender;
+	}
+
+	/**
+	 * @return string
+	 * Get Deprecated
+	 */
+	public function getMarital()
+	{
+		return $this->marital;
+	}
+
+	/**
+	 * @param string $marital
+	 * Set Deprecated
+	 */
+	public function setMarital(string $marital)
+	{
+		$this->marital = $marital;
+	}
+
+	/**
+	 * @return string
+	 * Get Deprecated
+	 */
+	public function getWith()
+	{
+		return $this->with;
+	}
+
+	/**
+	 * @param string $with
+	 * Set Deprecated
+	 */
+	public function setWith(string $with)
+	{
+		$this->with = $with;
+	}
+
+	/**
+	 * @return string
+	 * Get Deprecated
+	 */
+	public function getHowlong()
+	{
+		return $this->howlong;
+	}
+
+	/**
+	 * @param string $howlong
+	 * Set Deprecated
+	 */
+	public function setHowlong(string $howlong)
+	{
+		$this->howlong = $howlong;
+	}
+
+	/**
+	 * @return string
+	 * Get Deprecated
+	 */
+	public function getSexual()
+	{
+		return $this->sexual;
+	}
+
+	/**
+	 * @param string $sexual
+	 * Set Deprecated
+	 */
+	public function setSexual(string $sexual)
+	{
+		$this->sexual = $sexual;
+	}
+
+	/**
+	 * @return string
+	 * Get Deprecated
+	 */
+	public function getPolitic()
+	{
+		return $this->politic;
+	}
+
+	/**
+	 * @param string $politic
+	 * Set Deprecated
+	 */
+	public function setPolitic(string $politic)
+	{
+		$this->politic = $politic;
+	}
+
+	/**
+	 * @return string
+	 * Get Deprecated
+	 */
+	public function getReligion()
+	{
+		return $this->religion;
+	}
+
+	/**
+	 * @param string $religion
+	 * Set Deprecated
+	 */
+	public function setReligion(string $religion)
+	{
+		$this->religion = $religion;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getPubKeywords()
+	{
+		return $this->pubKeywords;
+	}
+
+	/**
+	 * @param string $pubKeywords
+	 * Set
+	 */
+	public function setPubKeywords(string $pubKeywords)
+	{
+		$this->pubKeywords = $pubKeywords;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getPrvKeywords()
+	{
+		return $this->prvKeywords;
+	}
+
+	/**
+	 * @param string $prvKeywords
+	 * Set
+	 */
+	public function setPrvKeywords(string $prvKeywords)
+	{
+		$this->prvKeywords = $prvKeywords;
+	}
+
+	/**
+	 * @return string
+	 * Get Deprecated
+	 */
+	public function getLikes()
+	{
+		return $this->likes;
+	}
+
+	/**
+	 * @param string $likes
+	 * Set Deprecated
+	 */
+	public function setLikes(string $likes)
+	{
+		$this->likes = $likes;
+	}
+
+	/**
+	 * @return string
+	 * Get Deprecated
+	 */
+	public function getDislikes()
+	{
+		return $this->dislikes;
+	}
+
+	/**
+	 * @param string $dislikes
+	 * Set Deprecated
+	 */
+	public function setDislikes(string $dislikes)
+	{
+		$this->dislikes = $dislikes;
+	}
+
+	/**
+	 * @return string
+	 * Get Profile description
+	 */
+	public function getAbout()
+	{
+		return $this->about;
+	}
+
+	/**
+	 * @param string $about
+	 * Set Profile description
+	 */
+	public function setAbout(string $about)
+	{
+		$this->about = $about;
+	}
+
+	/**
+	 * @return string
+	 * Get Deprecated
+	 */
+	public function getSummary()
+	{
+		return $this->summary;
+	}
+
+	/**
+	 * @param string $summary
+	 * Set Deprecated
+	 */
+	public function setSummary(string $summary)
+	{
+		$this->summary = $summary;
+	}
+
+	/**
+	 * @return string
+	 * Get Deprecated
+	 */
+	public function getMusic()
+	{
+		return $this->music;
+	}
+
+	/**
+	 * @param string $music
+	 * Set Deprecated
+	 */
+	public function setMusic(string $music)
+	{
+		$this->music = $music;
+	}
+
+	/**
+	 * @return string
+	 * Get Deprecated
+	 */
+	public function getBook()
+	{
+		return $this->book;
+	}
+
+	/**
+	 * @param string $book
+	 * Set Deprecated
+	 */
+	public function setBook(string $book)
+	{
+		$this->book = $book;
+	}
+
+	/**
+	 * @return string
+	 * Get Deprecated
+	 */
+	public function getTv()
+	{
+		return $this->tv;
+	}
+
+	/**
+	 * @param string $tv
+	 * Set Deprecated
+	 */
+	public function setTv(string $tv)
+	{
+		$this->tv = $tv;
+	}
+
+	/**
+	 * @return string
+	 * Get Deprecated
+	 */
+	public function getFilm()
+	{
+		return $this->film;
+	}
+
+	/**
+	 * @param string $film
+	 * Set Deprecated
+	 */
+	public function setFilm(string $film)
+	{
+		$this->film = $film;
+	}
+
+	/**
+	 * @return string
+	 * Get Deprecated
+	 */
+	public function getInterest()
+	{
+		return $this->interest;
+	}
+
+	/**
+	 * @param string $interest
+	 * Set Deprecated
+	 */
+	public function setInterest(string $interest)
+	{
+		$this->interest = $interest;
+	}
+
+	/**
+	 * @return string
+	 * Get Deprecated
+	 */
+	public function getRomance()
+	{
+		return $this->romance;
+	}
+
+	/**
+	 * @param string $romance
+	 * Set Deprecated
+	 */
+	public function setRomance(string $romance)
+	{
+		$this->romance = $romance;
+	}
+
+	/**
+	 * @return string
+	 * Get Deprecated
+	 */
+	public function getWork()
+	{
+		return $this->work;
+	}
+
+	/**
+	 * @param string $work
+	 * Set Deprecated
+	 */
+	public function setWork(string $work)
+	{
+		$this->work = $work;
+	}
+
+	/**
+	 * @return string
+	 * Get Deprecated
+	 */
+	public function getEducation()
+	{
+		return $this->education;
+	}
+
+	/**
+	 * @param string $education
+	 * Set Deprecated
+	 */
+	public function setEducation(string $education)
+	{
+		$this->education = $education;
+	}
+
+	/**
+	 * @return string
+	 * Get Deprecated
+	 */
+	public function getContact()
+	{
+		return $this->contact;
+	}
+
+	/**
+	 * @param string $contact
+	 * Set Deprecated
+	 */
+	public function setContact(string $contact)
+	{
+		$this->contact = $contact;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getHomepage()
+	{
+		return $this->homepage;
+	}
+
+	/**
+	 * @param string $homepage
+	 * Set
+	 */
+	public function setHomepage(string $homepage)
+	{
+		$this->homepage = $homepage;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getXmpp()
+	{
+		return $this->xmpp;
+	}
+
+	/**
+	 * @param string $xmpp
+	 * Set
+	 */
+	public function setXmpp(string $xmpp)
+	{
+		$this->xmpp = $xmpp;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getPhoto()
+	{
+		return $this->photo;
+	}
+
+	/**
+	 * @param string $photo
+	 * Set
+	 */
+	public function setPhoto(string $photo)
+	{
+		$this->photo = $photo;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getThumb()
+	{
+		return $this->thumb;
+	}
+
+	/**
+	 * @param string $thumb
+	 * Set
+	 */
+	public function setThumb(string $thumb)
+	{
+		$this->thumb = $thumb;
+	}
+
+	/**
+	 * @return bool
+	 * Get publish default profile in local directory
+	 */
+	public function getPublish()
+	{
+		return $this->publish;
+	}
+
+	/**
+	 * @param bool $publish
+	 * Set publish default profile in local directory
+	 */
+	public function setPublish(bool $publish)
+	{
+		$this->publish = $publish;
+	}
+
+	/**
+	 * @return bool
+	 * Get publish profile in global directory
+	 */
+	public function getNetPublish()
+	{
+		return $this->netPublish;
+	}
+
+	/**
+	 * @param bool $netPublish
+	 * Set publish profile in global directory
+	 */
+	public function setNetPublish(bool $netPublish)
+	{
+		$this->netPublish = $netPublish;
+	}
+}

--- a/src/Domain/Entity/ProfileCheck.php
+++ b/src/Domain/Entity/ProfileCheck.php
@@ -1,0 +1,206 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity;
+
+use Friendica\BaseEntity;
+use Friendica\Network\HTTPException\NotImplementedException;
+
+/**
+ * Entity class for table profile_check
+ *
+ * DFRN remote auth use
+ */
+class ProfileCheck extends BaseEntity
+{
+	/**
+	 * @var int
+	 * sequential ID
+	 */
+	private $id;
+
+	/**
+	 * @var int
+	 * User id
+	 */
+	private $uid = '0';
+
+	/**
+	 * @var int
+	 * contact.id
+	 */
+	private $cid = '0';
+
+	/**
+	 * @var string
+	 */
+	private $dfrnId = '';
+
+	/**
+	 * @var string
+	 */
+	private $sec = '';
+
+	/**
+	 * @var int
+	 */
+	private $expire = '0';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'id' => $this->id,
+			'uid' => $this->uid,
+			'cid' => $this->cid,
+			'dfrn_id' => $this->dfrnId,
+			'sec' => $this->sec,
+			'expire' => $this->expire,
+		];
+	}
+
+	/**
+	 * @return int
+	 * Get sequential ID
+	 */
+	public function getId()
+	{
+		return $this->id;
+	}
+
+	/**
+	 * @return int
+	 * Get User id
+	 */
+	public function getUid()
+	{
+		return $this->uid;
+	}
+
+	/**
+	 * @param int $uid
+	 * Set User id
+	 */
+	public function setUid(int $uid)
+	{
+		$this->uid = $uid;
+	}
+
+	/**
+	 * Get User
+	 *
+	 * @return User
+	 */
+	public function getUser()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for uid is not implemented yet');
+	}
+
+	/**
+	 * @return int
+	 * Get contact.id
+	 */
+	public function getCid()
+	{
+		return $this->cid;
+	}
+
+	/**
+	 * @param int $cid
+	 * Set contact.id
+	 */
+	public function setCid(int $cid)
+	{
+		$this->cid = $cid;
+	}
+
+	/**
+	 * Get Contact
+	 *
+	 * @return Contact
+	 */
+	public function getContact()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for id is not implemented yet');
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getDfrnId()
+	{
+		return $this->dfrnId;
+	}
+
+	/**
+	 * @param string $dfrnId
+	 * Set
+	 */
+	public function setDfrnId(string $dfrnId)
+	{
+		$this->dfrnId = $dfrnId;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getSec()
+	{
+		return $this->sec;
+	}
+
+	/**
+	 * @param string $sec
+	 * Set
+	 */
+	public function setSec(string $sec)
+	{
+		$this->sec = $sec;
+	}
+
+	/**
+	 * @return int
+	 * Get
+	 */
+	public function getExpire()
+	{
+		return $this->expire;
+	}
+
+	/**
+	 * @param int $expire
+	 * Set
+	 */
+	public function setExpire(int $expire)
+	{
+		$this->expire = $expire;
+	}
+}

--- a/src/Domain/Entity/ProfileField.php
+++ b/src/Domain/Entity/ProfileField.php
@@ -1,0 +1,259 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity;
+
+use Friendica\BaseEntity;
+use Friendica\Network\HTTPException\NotImplementedException;
+
+/**
+ * Entity class for table profile_field
+ *
+ * Custom profile fields
+ */
+class ProfileField extends BaseEntity
+{
+	/**
+	 * @var int
+	 * sequential ID
+	 */
+	private $id;
+
+	/**
+	 * @var int
+	 * Owner user id
+	 */
+	private $uid = '0';
+
+	/**
+	 * @var int
+	 * Field ordering per user
+	 */
+	private $order = '1';
+
+	/**
+	 * @var int
+	 * ID of the permission set of this profile field - 0 = public
+	 */
+	private $psid;
+
+	/**
+	 * @var string
+	 * Label of the field
+	 */
+	private $label = '';
+
+	/**
+	 * @var string
+	 * Value of the field
+	 */
+	private $value;
+
+	/**
+	 * @var string
+	 * creation time
+	 */
+	private $created = '0001-01-01 00:00:00';
+
+	/**
+	 * @var string
+	 * last edit time
+	 */
+	private $edited = '0001-01-01 00:00:00';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'id' => $this->id,
+			'uid' => $this->uid,
+			'order' => $this->order,
+			'psid' => $this->psid,
+			'label' => $this->label,
+			'value' => $this->value,
+			'created' => $this->created,
+			'edited' => $this->edited,
+		];
+	}
+
+	/**
+	 * @return int
+	 * Get sequential ID
+	 */
+	public function getId()
+	{
+		return $this->id;
+	}
+
+	/**
+	 * @return int
+	 * Get Owner user id
+	 */
+	public function getUid()
+	{
+		return $this->uid;
+	}
+
+	/**
+	 * @param int $uid
+	 * Set Owner user id
+	 */
+	public function setUid(int $uid)
+	{
+		$this->uid = $uid;
+	}
+
+	/**
+	 * Get User
+	 *
+	 * @return User
+	 */
+	public function getUser()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for uid is not implemented yet');
+	}
+
+	/**
+	 * @return int
+	 * Get Field ordering per user
+	 */
+	public function getOrder()
+	{
+		return $this->order;
+	}
+
+	/**
+	 * @param int $order
+	 * Set Field ordering per user
+	 */
+	public function setOrder(int $order)
+	{
+		$this->order = $order;
+	}
+
+	/**
+	 * @return int
+	 * Get ID of the permission set of this profile field - 0 = public
+	 */
+	public function getPsid()
+	{
+		return $this->psid;
+	}
+
+	/**
+	 * @param int $psid
+	 * Set ID of the permission set of this profile field - 0 = public
+	 */
+	public function setPsid(int $psid)
+	{
+		$this->psid = $psid;
+	}
+
+	/**
+	 * Get Permissionset
+	 *
+	 * @return Permissionset
+	 */
+	public function getPermissionset()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for id is not implemented yet');
+	}
+
+	/**
+	 * @return string
+	 * Get Label of the field
+	 */
+	public function getLabel()
+	{
+		return $this->label;
+	}
+
+	/**
+	 * @param string $label
+	 * Set Label of the field
+	 */
+	public function setLabel(string $label)
+	{
+		$this->label = $label;
+	}
+
+	/**
+	 * @return string
+	 * Get Value of the field
+	 */
+	public function getValue()
+	{
+		return $this->value;
+	}
+
+	/**
+	 * @param string $value
+	 * Set Value of the field
+	 */
+	public function setValue(string $value)
+	{
+		$this->value = $value;
+	}
+
+	/**
+	 * @return string
+	 * Get creation time
+	 */
+	public function getCreated()
+	{
+		return $this->created;
+	}
+
+	/**
+	 * @param string $created
+	 * Set creation time
+	 */
+	public function setCreated(string $created)
+	{
+		$this->created = $created;
+	}
+
+	/**
+	 * @return string
+	 * Get last edit time
+	 */
+	public function getEdited()
+	{
+		return $this->edited;
+	}
+
+	/**
+	 * @param string $edited
+	 * Set last edit time
+	 */
+	public function setEdited(string $edited)
+	{
+		$this->edited = $edited;
+	}
+}

--- a/src/Domain/Entity/PushSubscriber.php
+++ b/src/Domain/Entity/PushSubscriber.php
@@ -1,0 +1,294 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity;
+
+use Friendica\BaseEntity;
+use Friendica\Network\HTTPException\NotImplementedException;
+
+/**
+ * Entity class for table push_subscriber
+ *
+ * Used for OStatus: Contains feed subscribers
+ */
+class PushSubscriber extends BaseEntity
+{
+	/**
+	 * @var int
+	 * sequential ID
+	 */
+	private $id;
+
+	/**
+	 * @var int
+	 * User id
+	 */
+	private $uid = '0';
+
+	/**
+	 * @var string
+	 */
+	private $callbackUrl = '';
+
+	/**
+	 * @var string
+	 */
+	private $topic = '';
+
+	/**
+	 * @var string
+	 */
+	private $nickname = '';
+
+	/**
+	 * @var string
+	 * Retrial counter
+	 */
+	private $push = '0';
+
+	/**
+	 * @var string
+	 * Date of last successful trial
+	 */
+	private $lastUpdate = '0001-01-01 00:00:00';
+
+	/**
+	 * @var string
+	 * Next retrial date
+	 */
+	private $nextTry = '0001-01-01 00:00:00';
+
+	/**
+	 * @var string
+	 * Date of last subscription renewal
+	 */
+	private $renewed = '0001-01-01 00:00:00';
+
+	/**
+	 * @var string
+	 */
+	private $secret = '';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'id' => $this->id,
+			'uid' => $this->uid,
+			'callback_url' => $this->callbackUrl,
+			'topic' => $this->topic,
+			'nickname' => $this->nickname,
+			'push' => $this->push,
+			'last_update' => $this->lastUpdate,
+			'next_try' => $this->nextTry,
+			'renewed' => $this->renewed,
+			'secret' => $this->secret,
+		];
+	}
+
+	/**
+	 * @return int
+	 * Get sequential ID
+	 */
+	public function getId()
+	{
+		return $this->id;
+	}
+
+	/**
+	 * @return int
+	 * Get User id
+	 */
+	public function getUid()
+	{
+		return $this->uid;
+	}
+
+	/**
+	 * @param int $uid
+	 * Set User id
+	 */
+	public function setUid(int $uid)
+	{
+		$this->uid = $uid;
+	}
+
+	/**
+	 * Get User
+	 *
+	 * @return User
+	 */
+	public function getUser()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for uid is not implemented yet');
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getCallbackUrl()
+	{
+		return $this->callbackUrl;
+	}
+
+	/**
+	 * @param string $callbackUrl
+	 * Set
+	 */
+	public function setCallbackUrl(string $callbackUrl)
+	{
+		$this->callbackUrl = $callbackUrl;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getTopic()
+	{
+		return $this->topic;
+	}
+
+	/**
+	 * @param string $topic
+	 * Set
+	 */
+	public function setTopic(string $topic)
+	{
+		$this->topic = $topic;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getNickname()
+	{
+		return $this->nickname;
+	}
+
+	/**
+	 * @param string $nickname
+	 * Set
+	 */
+	public function setNickname(string $nickname)
+	{
+		$this->nickname = $nickname;
+	}
+
+	/**
+	 * @return string
+	 * Get Retrial counter
+	 */
+	public function getPush()
+	{
+		return $this->push;
+	}
+
+	/**
+	 * @param string $push
+	 * Set Retrial counter
+	 */
+	public function setPush(string $push)
+	{
+		$this->push = $push;
+	}
+
+	/**
+	 * @return string
+	 * Get Date of last successful trial
+	 */
+	public function getLastUpdate()
+	{
+		return $this->lastUpdate;
+	}
+
+	/**
+	 * @param string $lastUpdate
+	 * Set Date of last successful trial
+	 */
+	public function setLastUpdate(string $lastUpdate)
+	{
+		$this->lastUpdate = $lastUpdate;
+	}
+
+	/**
+	 * @return string
+	 * Get Next retrial date
+	 */
+	public function getNextTry()
+	{
+		return $this->nextTry;
+	}
+
+	/**
+	 * @param string $nextTry
+	 * Set Next retrial date
+	 */
+	public function setNextTry(string $nextTry)
+	{
+		$this->nextTry = $nextTry;
+	}
+
+	/**
+	 * @return string
+	 * Get Date of last subscription renewal
+	 */
+	public function getRenewed()
+	{
+		return $this->renewed;
+	}
+
+	/**
+	 * @param string $renewed
+	 * Set Date of last subscription renewal
+	 */
+	public function setRenewed(string $renewed)
+	{
+		$this->renewed = $renewed;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getSecret()
+	{
+		return $this->secret;
+	}
+
+	/**
+	 * @param string $secret
+	 * Set
+	 */
+	public function setSecret(string $secret)
+	{
+		$this->secret = $secret;
+	}
+}

--- a/src/Domain/Entity/Register.php
+++ b/src/Domain/Entity/Register.php
@@ -1,0 +1,218 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity;
+
+use Friendica\BaseEntity;
+use Friendica\Network\HTTPException\NotImplementedException;
+
+/**
+ * Entity class for table register
+ *
+ * registrations requiring admin approval
+ */
+class Register extends BaseEntity
+{
+	/**
+	 * @var int
+	 * sequential ID
+	 */
+	private $id;
+
+	/**
+	 * @var string
+	 */
+	private $hash = '';
+
+	/**
+	 * @var string
+	 */
+	private $created = '0001-01-01 00:00:00';
+
+	/**
+	 * @var int
+	 * User id
+	 */
+	private $uid = '0';
+
+	/**
+	 * @var string
+	 */
+	private $password = '';
+
+	/**
+	 * @var string
+	 */
+	private $language = '';
+
+	/**
+	 * @var string
+	 */
+	private $note;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'id' => $this->id,
+			'hash' => $this->hash,
+			'created' => $this->created,
+			'uid' => $this->uid,
+			'password' => $this->password,
+			'language' => $this->language,
+			'note' => $this->note,
+		];
+	}
+
+	/**
+	 * @return int
+	 * Get sequential ID
+	 */
+	public function getId()
+	{
+		return $this->id;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getHash()
+	{
+		return $this->hash;
+	}
+
+	/**
+	 * @param string $hash
+	 * Set
+	 */
+	public function setHash(string $hash)
+	{
+		$this->hash = $hash;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getCreated()
+	{
+		return $this->created;
+	}
+
+	/**
+	 * @param string $created
+	 * Set
+	 */
+	public function setCreated(string $created)
+	{
+		$this->created = $created;
+	}
+
+	/**
+	 * @return int
+	 * Get User id
+	 */
+	public function getUid()
+	{
+		return $this->uid;
+	}
+
+	/**
+	 * @param int $uid
+	 * Set User id
+	 */
+	public function setUid(int $uid)
+	{
+		$this->uid = $uid;
+	}
+
+	/**
+	 * Get User
+	 *
+	 * @return User
+	 */
+	public function getUser()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for uid is not implemented yet');
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getPassword()
+	{
+		return $this->password;
+	}
+
+	/**
+	 * @param string $password
+	 * Set
+	 */
+	public function setPassword(string $password)
+	{
+		$this->password = $password;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getLanguage()
+	{
+		return $this->language;
+	}
+
+	/**
+	 * @param string $language
+	 * Set
+	 */
+	public function setLanguage(string $language)
+	{
+		$this->language = $language;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getNote()
+	{
+		return $this->note;
+	}
+
+	/**
+	 * @param string $note
+	 * Set
+	 */
+	public function setNote(string $note)
+	{
+		$this->note = $note;
+	}
+}

--- a/src/Domain/Entity/Search.php
+++ b/src/Domain/Entity/Search.php
@@ -1,0 +1,120 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity;
+
+use Friendica\BaseEntity;
+use Friendica\Network\HTTPException\NotImplementedException;
+
+/**
+ * Entity class for table search
+ */
+class Search extends BaseEntity
+{
+	/**
+	 * @var int
+	 * sequential ID
+	 */
+	private $id;
+
+	/**
+	 * @var int
+	 * User id
+	 */
+	private $uid = '0';
+
+	/**
+	 * @var string
+	 */
+	private $term = '';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'id' => $this->id,
+			'uid' => $this->uid,
+			'term' => $this->term,
+		];
+	}
+
+	/**
+	 * @return int
+	 * Get sequential ID
+	 */
+	public function getId()
+	{
+		return $this->id;
+	}
+
+	/**
+	 * @return int
+	 * Get User id
+	 */
+	public function getUid()
+	{
+		return $this->uid;
+	}
+
+	/**
+	 * @param int $uid
+	 * Set User id
+	 */
+	public function setUid(int $uid)
+	{
+		$this->uid = $uid;
+	}
+
+	/**
+	 * Get User
+	 *
+	 * @return User
+	 */
+	public function getUser()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for uid is not implemented yet');
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getTerm()
+	{
+		return $this->term;
+	}
+
+	/**
+	 * @param string $term
+	 * Set
+	 */
+	public function setTerm(string $term)
+	{
+		$this->term = $term;
+	}
+}

--- a/src/Domain/Entity/Session.php
+++ b/src/Domain/Entity/Session.php
@@ -1,0 +1,133 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity;
+
+use Friendica\BaseEntity;
+
+/**
+ * Entity class for table session
+ *
+ * web session storage
+ */
+class Session extends BaseEntity
+{
+	/**
+	 * @var string
+	 * sequential ID
+	 */
+	private $id;
+
+	/**
+	 * @var string
+	 */
+	private $sid = '';
+
+	/**
+	 * @var string
+	 */
+	private $data;
+
+	/**
+	 * @var int
+	 */
+	private $expire = '0';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'id' => $this->id,
+			'sid' => $this->sid,
+			'data' => $this->data,
+			'expire' => $this->expire,
+		];
+	}
+
+	/**
+	 * @return string
+	 * Get sequential ID
+	 */
+	public function getId()
+	{
+		return $this->id;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getSid()
+	{
+		return $this->sid;
+	}
+
+	/**
+	 * @param string $sid
+	 * Set
+	 */
+	public function setSid(string $sid)
+	{
+		$this->sid = $sid;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getData()
+	{
+		return $this->data;
+	}
+
+	/**
+	 * @param string $data
+	 * Set
+	 */
+	public function setData(string $data)
+	{
+		$this->data = $data;
+	}
+
+	/**
+	 * @return int
+	 * Get
+	 */
+	public function getExpire()
+	{
+		return $this->expire;
+	}
+
+	/**
+	 * @param int $expire
+	 * Set
+	 */
+	public function setExpire(int $expire)
+	{
+		$this->expire = $expire;
+	}
+}

--- a/src/Domain/Entity/Sign.php
+++ b/src/Domain/Entity/Sign.php
@@ -1,0 +1,170 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity;
+
+use Friendica\BaseEntity;
+use Friendica\Network\HTTPException\NotImplementedException;
+
+/**
+ * Entity class for table sign
+ *
+ * Diaspora signatures
+ */
+class Sign extends BaseEntity
+{
+	/**
+	 * @var int
+	 * sequential ID
+	 */
+	private $id;
+
+	/**
+	 * @var int
+	 * item.id
+	 */
+	private $iid = '0';
+
+	/**
+	 * @var string
+	 */
+	private $signedText;
+
+	/**
+	 * @var string
+	 */
+	private $signature;
+
+	/**
+	 * @var string
+	 */
+	private $signer = '';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'id' => $this->id,
+			'iid' => $this->iid,
+			'signed_text' => $this->signedText,
+			'signature' => $this->signature,
+			'signer' => $this->signer,
+		];
+	}
+
+	/**
+	 * @return int
+	 * Get sequential ID
+	 */
+	public function getId()
+	{
+		return $this->id;
+	}
+
+	/**
+	 * @return int
+	 * Get item.id
+	 */
+	public function getIid()
+	{
+		return $this->iid;
+	}
+
+	/**
+	 * @param int $iid
+	 * Set item.id
+	 */
+	public function setIid(int $iid)
+	{
+		$this->iid = $iid;
+	}
+
+	/**
+	 * Get Item
+	 *
+	 * @return Item
+	 */
+	public function getItem()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for id is not implemented yet');
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getSignedText()
+	{
+		return $this->signedText;
+	}
+
+	/**
+	 * @param string $signedText
+	 * Set
+	 */
+	public function setSignedText(string $signedText)
+	{
+		$this->signedText = $signedText;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getSignature()
+	{
+		return $this->signature;
+	}
+
+	/**
+	 * @param string $signature
+	 * Set
+	 */
+	public function setSignature(string $signature)
+	{
+		$this->signature = $signature;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getSigner()
+	{
+		return $this->signer;
+	}
+
+	/**
+	 * @param string $signer
+	 * Set
+	 */
+	public function setSigner(string $signer)
+	{
+		$this->signer = $signer;
+	}
+}

--- a/src/Domain/Entity/Storage.php
+++ b/src/Domain/Entity/Storage.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity;
+
+use Friendica\BaseEntity;
+
+/**
+ * Entity class for table storage
+ *
+ * Data stored by Database storage backend
+ */
+class Storage extends BaseEntity
+{
+	/**
+	 * @var int
+	 * Auto incremented image data id
+	 */
+	private $id;
+
+	/**
+	 * @var int
+	 * file data
+	 */
+	private $data;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'id' => $this->id,
+			'data' => $this->data,
+		];
+	}
+
+	/**
+	 * @return int
+	 * Get Auto incremented image data id
+	 */
+	public function getId()
+	{
+		return $this->id;
+	}
+
+	/**
+	 * @return int
+	 * Get file data
+	 */
+	public function getData()
+	{
+		return $this->data;
+	}
+
+	/**
+	 * @param int $data
+	 * Set file data
+	 */
+	public function setData(int $data)
+	{
+		$this->data = $data;
+	}
+}

--- a/src/Domain/Entity/Term.php
+++ b/src/Domain/Entity/Term.php
@@ -1,0 +1,324 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity;
+
+use Friendica\BaseEntity;
+use Friendica\Network\HTTPException\NotImplementedException;
+
+/**
+ * Entity class for table term
+ *
+ * item taxonomy (categories, tags, etc.) table
+ */
+class Term extends BaseEntity
+{
+	/**
+	 * @var int
+	 */
+	private $tid;
+
+	/**
+	 * @var int
+	 */
+	private $oid = '0';
+
+	/**
+	 * @var string
+	 */
+	private $otype = '0';
+
+	/**
+	 * @var string
+	 */
+	private $type = '0';
+
+	/**
+	 * @var string
+	 */
+	private $term = '';
+
+	/**
+	 * @var string
+	 */
+	private $url = '';
+
+	/**
+	 * @var string
+	 */
+	private $guid = '';
+
+	/**
+	 * @var string
+	 */
+	private $created = '0001-01-01 00:00:00';
+
+	/**
+	 * @var string
+	 */
+	private $received = '0001-01-01 00:00:00';
+
+	/**
+	 * @var bool
+	 */
+	private $global = '0';
+
+	/**
+	 * @var int
+	 * User id
+	 */
+	private $uid = '0';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'tid' => $this->tid,
+			'oid' => $this->oid,
+			'otype' => $this->otype,
+			'type' => $this->type,
+			'term' => $this->term,
+			'url' => $this->url,
+			'guid' => $this->guid,
+			'created' => $this->created,
+			'received' => $this->received,
+			'global' => $this->global,
+			'uid' => $this->uid,
+		];
+	}
+
+	/**
+	 * @return int
+	 * Get
+	 */
+	public function getTid()
+	{
+		return $this->tid;
+	}
+
+	/**
+	 * @return int
+	 * Get
+	 */
+	public function getOid()
+	{
+		return $this->oid;
+	}
+
+	/**
+	 * @param int $oid
+	 * Set
+	 */
+	public function setOid(int $oid)
+	{
+		$this->oid = $oid;
+	}
+
+	/**
+	 * Get Item
+	 *
+	 * @return Item
+	 */
+	public function getItem()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for id is not implemented yet');
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getOtype()
+	{
+		return $this->otype;
+	}
+
+	/**
+	 * @param string $otype
+	 * Set
+	 */
+	public function setOtype(string $otype)
+	{
+		$this->otype = $otype;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getType()
+	{
+		return $this->type;
+	}
+
+	/**
+	 * @param string $type
+	 * Set
+	 */
+	public function setType(string $type)
+	{
+		$this->type = $type;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getTerm()
+	{
+		return $this->term;
+	}
+
+	/**
+	 * @param string $term
+	 * Set
+	 */
+	public function setTerm(string $term)
+	{
+		$this->term = $term;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getUrl()
+	{
+		return $this->url;
+	}
+
+	/**
+	 * @param string $url
+	 * Set
+	 */
+	public function setUrl(string $url)
+	{
+		$this->url = $url;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getGuid()
+	{
+		return $this->guid;
+	}
+
+	/**
+	 * @param string $guid
+	 * Set
+	 */
+	public function setGuid(string $guid)
+	{
+		$this->guid = $guid;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getCreated()
+	{
+		return $this->created;
+	}
+
+	/**
+	 * @param string $created
+	 * Set
+	 */
+	public function setCreated(string $created)
+	{
+		$this->created = $created;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getReceived()
+	{
+		return $this->received;
+	}
+
+	/**
+	 * @param string $received
+	 * Set
+	 */
+	public function setReceived(string $received)
+	{
+		$this->received = $received;
+	}
+
+	/**
+	 * @return bool
+	 * Get
+	 */
+	public function getGlobal()
+	{
+		return $this->global;
+	}
+
+	/**
+	 * @param bool $global
+	 * Set
+	 */
+	public function setGlobal(bool $global)
+	{
+		$this->global = $global;
+	}
+
+	/**
+	 * @return int
+	 * Get User id
+	 */
+	public function getUid()
+	{
+		return $this->uid;
+	}
+
+	/**
+	 * @param int $uid
+	 * Set User id
+	 */
+	public function setUid(int $uid)
+	{
+		$this->uid = $uid;
+	}
+
+	/**
+	 * Get User
+	 *
+	 * @return User
+	 */
+	public function getUser()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for uid is not implemented yet');
+	}
+}

--- a/src/Domain/Entity/Thread.php
+++ b/src/Domain/Entity/Thread.php
@@ -1,0 +1,675 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity;
+
+use Friendica\BaseEntity;
+use Friendica\Network\HTTPException\NotImplementedException;
+
+/**
+ * Entity class for table thread
+ *
+ * Thread related data
+ */
+class Thread extends BaseEntity
+{
+	/**
+	 * @var int
+	 * sequential ID
+	 */
+	private $iid = '0';
+
+	/**
+	 * @var int
+	 * User id
+	 */
+	private $uid = '0';
+
+	/**
+	 * @var int
+	 */
+	private $contactId = '0';
+
+	/**
+	 * @var int
+	 * Item owner
+	 */
+	private $ownerId = '0';
+
+	/**
+	 * @var int
+	 * Item author
+	 */
+	private $authorId = '0';
+
+	/**
+	 * @var string
+	 */
+	private $created = '0001-01-01 00:00:00';
+
+	/**
+	 * @var string
+	 */
+	private $edited = '0001-01-01 00:00:00';
+
+	/**
+	 * @var string
+	 */
+	private $commented = '0001-01-01 00:00:00';
+
+	/**
+	 * @var string
+	 */
+	private $received = '0001-01-01 00:00:00';
+
+	/**
+	 * @var string
+	 */
+	private $changed = '0001-01-01 00:00:00';
+
+	/**
+	 * @var bool
+	 */
+	private $wall = '0';
+
+	/**
+	 * @var bool
+	 */
+	private $private = '0';
+
+	/**
+	 * @var bool
+	 */
+	private $pubmail = '0';
+
+	/**
+	 * @var bool
+	 */
+	private $moderated = '0';
+
+	/**
+	 * @var bool
+	 */
+	private $visible = '0';
+
+	/**
+	 * @var bool
+	 */
+	private $starred = '0';
+
+	/**
+	 * @var bool
+	 */
+	private $ignored = '0';
+
+	/**
+	 * @var string
+	 * Post type (personal note, bookmark, ...)
+	 */
+	private $postType = '0';
+
+	/**
+	 * @var bool
+	 */
+	private $unseen = '1';
+
+	/**
+	 * @var bool
+	 */
+	private $deleted = '0';
+
+	/**
+	 * @var bool
+	 */
+	private $origin = '0';
+
+	/**
+	 * @var string
+	 */
+	private $forumMode = '0';
+
+	/**
+	 * @var bool
+	 */
+	private $mention = '0';
+
+	/**
+	 * @var string
+	 */
+	private $network = '';
+
+	/**
+	 * @var bool
+	 */
+	private $bookmark;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'iid' => $this->iid,
+			'uid' => $this->uid,
+			'contact-id' => $this->contactId,
+			'owner-id' => $this->ownerId,
+			'author-id' => $this->authorId,
+			'created' => $this->created,
+			'edited' => $this->edited,
+			'commented' => $this->commented,
+			'received' => $this->received,
+			'changed' => $this->changed,
+			'wall' => $this->wall,
+			'private' => $this->private,
+			'pubmail' => $this->pubmail,
+			'moderated' => $this->moderated,
+			'visible' => $this->visible,
+			'starred' => $this->starred,
+			'ignored' => $this->ignored,
+			'post-type' => $this->postType,
+			'unseen' => $this->unseen,
+			'deleted' => $this->deleted,
+			'origin' => $this->origin,
+			'forum_mode' => $this->forumMode,
+			'mention' => $this->mention,
+			'network' => $this->network,
+			'bookmark' => $this->bookmark,
+		];
+	}
+
+	/**
+	 * @return int
+	 * Get sequential ID
+	 */
+	public function getIid()
+	{
+		return $this->iid;
+	}
+
+	/**
+	 * Get Item
+	 *
+	 * @return Item
+	 */
+	public function getItem()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for id is not implemented yet');
+	}
+
+	/**
+	 * @return int
+	 * Get User id
+	 */
+	public function getUid()
+	{
+		return $this->uid;
+	}
+
+	/**
+	 * @param int $uid
+	 * Set User id
+	 */
+	public function setUid(int $uid)
+	{
+		$this->uid = $uid;
+	}
+
+	/**
+	 * Get User
+	 *
+	 * @return User
+	 */
+	public function getUser()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for uid is not implemented yet');
+	}
+
+	/**
+	 * @return int
+	 * Get
+	 */
+	public function getContactId()
+	{
+		return $this->contactId;
+	}
+
+	/**
+	 * @param int $contactId
+	 * Set
+	 */
+	public function setContactId(int $contactId)
+	{
+		$this->contactId = $contactId;
+	}
+
+	/**
+	 * Get Contact
+	 *
+	 * @return Contact
+	 */
+	public function getContact()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for id is not implemented yet');
+	}
+
+	/**
+	 * @return int
+	 * Get Item owner
+	 */
+	public function getOwnerId()
+	{
+		return $this->ownerId;
+	}
+
+	/**
+	 * @param int $ownerId
+	 * Set Item owner
+	 */
+	public function setOwnerId(int $ownerId)
+	{
+		$this->ownerId = $ownerId;
+	}
+
+	/**
+	 * @return int
+	 * Get Item author
+	 */
+	public function getAuthorId()
+	{
+		return $this->authorId;
+	}
+
+	/**
+	 * @param int $authorId
+	 * Set Item author
+	 */
+	public function setAuthorId(int $authorId)
+	{
+		$this->authorId = $authorId;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getCreated()
+	{
+		return $this->created;
+	}
+
+	/**
+	 * @param string $created
+	 * Set
+	 */
+	public function setCreated(string $created)
+	{
+		$this->created = $created;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getEdited()
+	{
+		return $this->edited;
+	}
+
+	/**
+	 * @param string $edited
+	 * Set
+	 */
+	public function setEdited(string $edited)
+	{
+		$this->edited = $edited;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getCommented()
+	{
+		return $this->commented;
+	}
+
+	/**
+	 * @param string $commented
+	 * Set
+	 */
+	public function setCommented(string $commented)
+	{
+		$this->commented = $commented;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getReceived()
+	{
+		return $this->received;
+	}
+
+	/**
+	 * @param string $received
+	 * Set
+	 */
+	public function setReceived(string $received)
+	{
+		$this->received = $received;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getChanged()
+	{
+		return $this->changed;
+	}
+
+	/**
+	 * @param string $changed
+	 * Set
+	 */
+	public function setChanged(string $changed)
+	{
+		$this->changed = $changed;
+	}
+
+	/**
+	 * @return bool
+	 * Get
+	 */
+	public function getWall()
+	{
+		return $this->wall;
+	}
+
+	/**
+	 * @param bool $wall
+	 * Set
+	 */
+	public function setWall(bool $wall)
+	{
+		$this->wall = $wall;
+	}
+
+	/**
+	 * @return bool
+	 * Get
+	 */
+	public function getPrivate()
+	{
+		return $this->private;
+	}
+
+	/**
+	 * @param bool $private
+	 * Set
+	 */
+	public function setPrivate(bool $private)
+	{
+		$this->private = $private;
+	}
+
+	/**
+	 * @return bool
+	 * Get
+	 */
+	public function getPubmail()
+	{
+		return $this->pubmail;
+	}
+
+	/**
+	 * @param bool $pubmail
+	 * Set
+	 */
+	public function setPubmail(bool $pubmail)
+	{
+		$this->pubmail = $pubmail;
+	}
+
+	/**
+	 * @return bool
+	 * Get
+	 */
+	public function getModerated()
+	{
+		return $this->moderated;
+	}
+
+	/**
+	 * @param bool $moderated
+	 * Set
+	 */
+	public function setModerated(bool $moderated)
+	{
+		$this->moderated = $moderated;
+	}
+
+	/**
+	 * @return bool
+	 * Get
+	 */
+	public function getVisible()
+	{
+		return $this->visible;
+	}
+
+	/**
+	 * @param bool $visible
+	 * Set
+	 */
+	public function setVisible(bool $visible)
+	{
+		$this->visible = $visible;
+	}
+
+	/**
+	 * @return bool
+	 * Get
+	 */
+	public function getStarred()
+	{
+		return $this->starred;
+	}
+
+	/**
+	 * @param bool $starred
+	 * Set
+	 */
+	public function setStarred(bool $starred)
+	{
+		$this->starred = $starred;
+	}
+
+	/**
+	 * @return bool
+	 * Get
+	 */
+	public function getIgnored()
+	{
+		return $this->ignored;
+	}
+
+	/**
+	 * @param bool $ignored
+	 * Set
+	 */
+	public function setIgnored(bool $ignored)
+	{
+		$this->ignored = $ignored;
+	}
+
+	/**
+	 * @return string
+	 * Get Post type (personal note, bookmark, ...)
+	 */
+	public function getPostType()
+	{
+		return $this->postType;
+	}
+
+	/**
+	 * @param string $postType
+	 * Set Post type (personal note, bookmark, ...)
+	 */
+	public function setPostType(string $postType)
+	{
+		$this->postType = $postType;
+	}
+
+	/**
+	 * @return bool
+	 * Get
+	 */
+	public function getUnseen()
+	{
+		return $this->unseen;
+	}
+
+	/**
+	 * @param bool $unseen
+	 * Set
+	 */
+	public function setUnseen(bool $unseen)
+	{
+		$this->unseen = $unseen;
+	}
+
+	/**
+	 * @return bool
+	 * Get
+	 */
+	public function getDeleted()
+	{
+		return $this->deleted;
+	}
+
+	/**
+	 * @param bool $deleted
+	 * Set
+	 */
+	public function setDeleted(bool $deleted)
+	{
+		$this->deleted = $deleted;
+	}
+
+	/**
+	 * @return bool
+	 * Get
+	 */
+	public function getOrigin()
+	{
+		return $this->origin;
+	}
+
+	/**
+	 * @param bool $origin
+	 * Set
+	 */
+	public function setOrigin(bool $origin)
+	{
+		$this->origin = $origin;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getForumMode()
+	{
+		return $this->forumMode;
+	}
+
+	/**
+	 * @param string $forumMode
+	 * Set
+	 */
+	public function setForumMode(string $forumMode)
+	{
+		$this->forumMode = $forumMode;
+	}
+
+	/**
+	 * @return bool
+	 * Get
+	 */
+	public function getMention()
+	{
+		return $this->mention;
+	}
+
+	/**
+	 * @param bool $mention
+	 * Set
+	 */
+	public function setMention(bool $mention)
+	{
+		$this->mention = $mention;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getNetwork()
+	{
+		return $this->network;
+	}
+
+	/**
+	 * @param string $network
+	 * Set
+	 */
+	public function setNetwork(string $network)
+	{
+		$this->network = $network;
+	}
+
+	/**
+	 * @return bool
+	 * Get
+	 */
+	public function getBookmark()
+	{
+		return $this->bookmark;
+	}
+
+	/**
+	 * @param bool $bookmark
+	 * Set
+	 */
+	public function setBookmark(bool $bookmark)
+	{
+		$this->bookmark = $bookmark;
+	}
+}

--- a/src/Domain/Entity/Tokens.php
+++ b/src/Domain/Entity/Tokens.php
@@ -1,0 +1,200 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity;
+
+use Friendica\BaseEntity;
+use Friendica\Network\HTTPException\NotImplementedException;
+
+/**
+ * Entity class for table tokens
+ *
+ * OAuth usage
+ */
+class Tokens extends BaseEntity
+{
+	/**
+	 * @var string
+	 */
+	private $id;
+
+	/**
+	 * @var string
+	 */
+	private $secret;
+
+	/** @var string */
+	private $clientId = '';
+
+	/**
+	 * @var int
+	 */
+	private $expires = '0';
+
+	/**
+	 * @var string
+	 */
+	private $scope = '';
+
+	/**
+	 * @var int
+	 * User id
+	 */
+	private $uid = '0';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'id' => $this->id,
+			'secret' => $this->secret,
+			'client_id' => $this->clientId,
+			'expires' => $this->expires,
+			'scope' => $this->scope,
+			'uid' => $this->uid,
+		];
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getId()
+	{
+		return $this->id;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getSecret()
+	{
+		return $this->secret;
+	}
+
+	/**
+	 * @param string $secret
+	 * Set
+	 */
+	public function setSecret(string $secret)
+	{
+		$this->secret = $secret;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getClientId()
+	{
+		return $this->clientId;
+	}
+
+	/**
+	 * @param string $clientId
+	 */
+	public function setClientId(string $clientId)
+	{
+		$this->clientId = $clientId;
+	}
+
+	/**
+	 * Get Clients
+	 *
+	 * @return Clients
+	 */
+	public function getClients()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for clientId is not implemented yet');
+	}
+
+	/**
+	 * @return int
+	 * Get
+	 */
+	public function getExpires()
+	{
+		return $this->expires;
+	}
+
+	/**
+	 * @param int $expires
+	 * Set
+	 */
+	public function setExpires(int $expires)
+	{
+		$this->expires = $expires;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getScope()
+	{
+		return $this->scope;
+	}
+
+	/**
+	 * @param string $scope
+	 * Set
+	 */
+	public function setScope(string $scope)
+	{
+		$this->scope = $scope;
+	}
+
+	/**
+	 * @return int
+	 * Get User id
+	 */
+	public function getUid()
+	{
+		return $this->uid;
+	}
+
+	/**
+	 * @param int $uid
+	 * Set User id
+	 */
+	public function setUid(int $uid)
+	{
+		$this->uid = $uid;
+	}
+
+	/**
+	 * Get User
+	 *
+	 * @return User
+	 */
+	public function getUser()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for uid is not implemented yet');
+	}
+}

--- a/src/Domain/Entity/TwoFaAppSpecificPassword.php
+++ b/src/Domain/Entity/TwoFaAppSpecificPassword.php
@@ -1,0 +1,198 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity;
+
+use Friendica\BaseEntity;
+use Friendica\Network\HTTPException\NotImplementedException;
+
+/**
+ * Entity class for table 2fa_app_specific_password
+ *
+ * Two-factor app-specific _password
+ */
+class TwoFaAppSpecificPassword extends BaseEntity
+{
+	/**
+	 * @var int
+	 * Password ID for revocation
+	 */
+	private $id;
+
+	/**
+	 * @var int
+	 * User ID
+	 */
+	private $uid;
+
+	/**
+	 * @var string
+	 * Description of the usage of the password
+	 */
+	private $description;
+
+	/**
+	 * @var string
+	 * Hashed password
+	 */
+	private $hashedPassword;
+
+	/**
+	 * @var string
+	 * Datetime the password was generated
+	 */
+	private $generated;
+
+	/**
+	 * @var string
+	 * Datetime the password was last used
+	 */
+	private $lastUsed;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'id' => $this->id,
+			'uid' => $this->uid,
+			'description' => $this->description,
+			'hashed_password' => $this->hashedPassword,
+			'generated' => $this->generated,
+			'last_used' => $this->lastUsed,
+		];
+	}
+
+	/**
+	 * @return int
+	 * Get Password ID for revocation
+	 */
+	public function getId()
+	{
+		return $this->id;
+	}
+
+	/**
+	 * @return int
+	 * Get User ID
+	 */
+	public function getUid()
+	{
+		return $this->uid;
+	}
+
+	/**
+	 * @param int $uid
+	 * Set User ID
+	 */
+	public function setUid(int $uid)
+	{
+		$this->uid = $uid;
+	}
+
+	/**
+	 * Get User
+	 *
+	 * @return User
+	 */
+	public function getUser()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for uid is not implemented yet');
+	}
+
+	/**
+	 * @return string
+	 * Get Description of the usage of the password
+	 */
+	public function getDescription()
+	{
+		return $this->description;
+	}
+
+	/**
+	 * @param string $description
+	 * Set Description of the usage of the password
+	 */
+	public function setDescription(string $description)
+	{
+		$this->description = $description;
+	}
+
+	/**
+	 * @return string
+	 * Get Hashed password
+	 */
+	public function getHashedPassword()
+	{
+		return $this->hashedPassword;
+	}
+
+	/**
+	 * @param string $hashedPassword
+	 * Set Hashed password
+	 */
+	public function setHashedPassword(string $hashedPassword)
+	{
+		$this->hashedPassword = $hashedPassword;
+	}
+
+	/**
+	 * @return string
+	 * Get Datetime the password was generated
+	 */
+	public function getGenerated()
+	{
+		return $this->generated;
+	}
+
+	/**
+	 * @param string $generated
+	 * Set Datetime the password was generated
+	 */
+	public function setGenerated(string $generated)
+	{
+		$this->generated = $generated;
+	}
+
+	/**
+	 * @return string
+	 * Get Datetime the password was last used
+	 */
+	public function getLastUsed()
+	{
+		return $this->lastUsed;
+	}
+
+	/**
+	 * @param string $lastUsed
+	 * Set Datetime the password was last used
+	 */
+	public function setLastUsed(string $lastUsed)
+	{
+		$this->lastUsed = $lastUsed;
+	}
+}

--- a/src/Domain/Entity/TwoFaRecoveryCodes.php
+++ b/src/Domain/Entity/TwoFaRecoveryCodes.php
@@ -1,0 +1,139 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity;
+
+use Friendica\BaseEntity;
+use Friendica\Network\HTTPException\NotImplementedException;
+
+/**
+ * Entity class for table 2fa_recovery_codes
+ *
+ * Two-factor authentication recovery codes
+ */
+class TwoFaRecoveryCodes extends BaseEntity
+{
+	/**
+	 * @var int
+	 * User ID
+	 */
+	private $uid;
+
+	/**
+	 * @var string
+	 * Recovery code string
+	 */
+	private $code;
+
+	/**
+	 * @var string
+	 * Datetime the code was generated
+	 */
+	private $generated;
+
+	/**
+	 * @var string
+	 * Datetime the code was used
+	 */
+	private $used;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'uid' => $this->uid,
+			'code' => $this->code,
+			'generated' => $this->generated,
+			'used' => $this->used,
+		];
+	}
+
+	/**
+	 * @return int
+	 * Get User ID
+	 */
+	public function getUid()
+	{
+		return $this->uid;
+	}
+
+	/**
+	 * Get User
+	 *
+	 * @return User
+	 */
+	public function getUser()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for uid is not implemented yet');
+	}
+
+	/**
+	 * @return string
+	 * Get Recovery code string
+	 */
+	public function getCode()
+	{
+		return $this->code;
+	}
+
+	/**
+	 * @return string
+	 * Get Datetime the code was generated
+	 */
+	public function getGenerated()
+	{
+		return $this->generated;
+	}
+
+	/**
+	 * @param string $generated
+	 * Set Datetime the code was generated
+	 */
+	public function setGenerated(string $generated)
+	{
+		$this->generated = $generated;
+	}
+
+	/**
+	 * @return string
+	 * Get Datetime the code was used
+	 */
+	public function getUsed()
+	{
+		return $this->used;
+	}
+
+	/**
+	 * @param string $used
+	 * Set Datetime the code was used
+	 */
+	public function setUsed(string $used)
+	{
+		$this->used = $used;
+	}
+}

--- a/src/Domain/Entity/User.php
+++ b/src/Domain/Entity/User.php
@@ -1,0 +1,1162 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity;
+
+use Friendica\BaseEntity;
+use Friendica\Network\HTTPException\NotImplementedException;
+
+/**
+ * Entity class for table user
+ *
+ * The local users
+ */
+class User extends BaseEntity
+{
+	/**
+	 * @var int
+	 * sequential ID
+	 */
+	private $uid;
+
+	/**
+	 * @var int
+	 * The parent user that has full control about this user
+	 */
+	private $parentUid = '0';
+
+	/**
+	 * @var string
+	 * A unique identifier for this user
+	 */
+	private $guid = '';
+
+	/**
+	 * @var string
+	 * Name that this user is known by
+	 */
+	private $username = '';
+
+	/**
+	 * @var string
+	 * encrypted password
+	 */
+	private $password = '';
+
+	/**
+	 * @var bool
+	 * Is the password hash double-hashed?
+	 */
+	private $legacyPassword = '0';
+
+	/**
+	 * @var string
+	 * nick- and user name
+	 */
+	private $nickname = '';
+
+	/**
+	 * @var string
+	 * the users email address
+	 */
+	private $email = '';
+
+	/**
+	 * @var string
+	 */
+	private $openid = '';
+
+	/**
+	 * @var string
+	 * PHP-legal timezone
+	 */
+	private $timezone = '';
+
+	/**
+	 * @var string
+	 * default language
+	 */
+	private $language = 'en';
+
+	/**
+	 * @var string
+	 * timestamp of registration
+	 */
+	private $registerDate = '0001-01-01 00:00:00';
+
+	/**
+	 * @var string
+	 * timestamp of last login
+	 */
+	private $loginDate = '0001-01-01 00:00:00';
+
+	/**
+	 * @var string
+	 * Default for item.location
+	 */
+	private $defaultLocation = '';
+
+	/**
+	 * @var bool
+	 * 1 allows to display the location
+	 */
+	private $allowLocation = '0';
+
+	/**
+	 * @var string
+	 * user theme preference
+	 */
+	private $theme = '';
+
+	/**
+	 * @var string
+	 * RSA public key 4096 bit
+	 */
+	private $pubkey;
+
+	/**
+	 * @var string
+	 * RSA private key 4096 bit
+	 */
+	private $prvkey;
+
+	/**
+	 * @var string
+	 */
+	private $spubkey;
+
+	/**
+	 * @var string
+	 */
+	private $sprvkey;
+
+	/**
+	 * @var bool
+	 * user is verified through email
+	 */
+	private $verified = '0';
+
+	/**
+	 * @var bool
+	 * 1 for user is blocked
+	 */
+	private $blocked = '0';
+
+	/**
+	 * @var bool
+	 * Prohibit contacts to post to the profile page of the user
+	 */
+	private $blockwall = '0';
+
+	/**
+	 * @var bool
+	 * Hide profile details from unkown viewers
+	 */
+	private $hidewall = '0';
+
+	/**
+	 * @var bool
+	 * Prohibit contacts to tag the post of this user
+	 */
+	private $blocktags = '0';
+
+	/**
+	 * @var bool
+	 * Permit unknown people to send private mails to this user
+	 */
+	private $unkmail = '0';
+
+	/**
+	 * @var int
+	 */
+	private $cntunkmail = '10';
+
+	/**
+	 * @var string
+	 * email notification options
+	 */
+	private $notifyFlags = '65535';
+
+	/**
+	 * @var string
+	 * page/profile type
+	 */
+	private $pageFlags = '0';
+
+	/**
+	 * @var string
+	 */
+	private $accountType = '0';
+
+	/**
+	 * @var bool
+	 */
+	private $prvnets = '0';
+
+	/**
+	 * @var string
+	 * Password reset request token
+	 */
+	private $pwdreset;
+
+	/**
+	 * @var string
+	 * Timestamp of the last password reset request
+	 */
+	private $pwdresetTime;
+
+	/**
+	 * @var int
+	 */
+	private $maxreq = '10';
+
+	/**
+	 * @var int
+	 */
+	private $expire = '0';
+
+	/**
+	 * @var bool
+	 * if 1 the account is removed
+	 */
+	private $accountRemoved = '0';
+
+	/**
+	 * @var bool
+	 */
+	private $accountExpired = '0';
+
+	/**
+	 * @var string
+	 * timestamp when account expires and will be deleted
+	 */
+	private $accountExpiresOn = '0001-01-01 00:00:00';
+
+	/**
+	 * @var string
+	 * timestamp of last warning of account expiration
+	 */
+	private $expireNotificationSent = '0001-01-01 00:00:00';
+
+	/**
+	 * @var int
+	 */
+	private $defGid = '0';
+
+	/**
+	 * @var string
+	 * default permission for this user
+	 */
+	private $allowCid;
+
+	/**
+	 * @var string
+	 * default permission for this user
+	 */
+	private $allowGid;
+
+	/**
+	 * @var string
+	 * default permission for this user
+	 */
+	private $denyCid;
+
+	/**
+	 * @var string
+	 * default permission for this user
+	 */
+	private $denyGid;
+
+	/**
+	 * @var string
+	 */
+	private $openidserver;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'uid' => $this->uid,
+			'parent-uid' => $this->parentUid,
+			'guid' => $this->guid,
+			'username' => $this->username,
+			'password' => $this->password,
+			'legacy_password' => $this->legacyPassword,
+			'nickname' => $this->nickname,
+			'email' => $this->email,
+			'openid' => $this->openid,
+			'timezone' => $this->timezone,
+			'language' => $this->language,
+			'register_date' => $this->registerDate,
+			'login_date' => $this->loginDate,
+			'default-location' => $this->defaultLocation,
+			'allow_location' => $this->allowLocation,
+			'theme' => $this->theme,
+			'pubkey' => $this->pubkey,
+			'prvkey' => $this->prvkey,
+			'spubkey' => $this->spubkey,
+			'sprvkey' => $this->sprvkey,
+			'verified' => $this->verified,
+			'blocked' => $this->blocked,
+			'blockwall' => $this->blockwall,
+			'hidewall' => $this->hidewall,
+			'blocktags' => $this->blocktags,
+			'unkmail' => $this->unkmail,
+			'cntunkmail' => $this->cntunkmail,
+			'notify-flags' => $this->notifyFlags,
+			'page-flags' => $this->pageFlags,
+			'account-type' => $this->accountType,
+			'prvnets' => $this->prvnets,
+			'pwdreset' => $this->pwdreset,
+			'pwdreset_time' => $this->pwdresetTime,
+			'maxreq' => $this->maxreq,
+			'expire' => $this->expire,
+			'account_removed' => $this->accountRemoved,
+			'account_expired' => $this->accountExpired,
+			'account_expires_on' => $this->accountExpiresOn,
+			'expire_notification_sent' => $this->expireNotificationSent,
+			'def_gid' => $this->defGid,
+			'allow_cid' => $this->allowCid,
+			'allow_gid' => $this->allowGid,
+			'deny_cid' => $this->denyCid,
+			'deny_gid' => $this->denyGid,
+			'openidserver' => $this->openidserver,
+		];
+	}
+
+	/**
+	 * @return int
+	 * Get sequential ID
+	 */
+	public function getUid()
+	{
+		return $this->uid;
+	}
+
+	/**
+	 * @return int
+	 * Get The parent user that has full control about this user
+	 */
+	public function getParentUid()
+	{
+		return $this->parentUid;
+	}
+
+	/**
+	 * @param int $parentUid
+	 * Set The parent user that has full control about this user
+	 */
+	public function setParentUid(int $parentUid)
+	{
+		$this->parentUid = $parentUid;
+	}
+
+	/**
+	 * Get User
+	 *
+	 * @return User
+	 */
+	public function getUser()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for uid is not implemented yet');
+	}
+
+	/**
+	 * @return string
+	 * Get A unique identifier for this user
+	 */
+	public function getGuid()
+	{
+		return $this->guid;
+	}
+
+	/**
+	 * @param string $guid
+	 * Set A unique identifier for this user
+	 */
+	public function setGuid(string $guid)
+	{
+		$this->guid = $guid;
+	}
+
+	/**
+	 * @return string
+	 * Get Name that this user is known by
+	 */
+	public function getUsername()
+	{
+		return $this->username;
+	}
+
+	/**
+	 * @param string $username
+	 * Set Name that this user is known by
+	 */
+	public function setUsername(string $username)
+	{
+		$this->username = $username;
+	}
+
+	/**
+	 * @return string
+	 * Get encrypted password
+	 */
+	public function getPassword()
+	{
+		return $this->password;
+	}
+
+	/**
+	 * @param string $password
+	 * Set encrypted password
+	 */
+	public function setPassword(string $password)
+	{
+		$this->password = $password;
+	}
+
+	/**
+	 * @return bool
+	 * Get Is the password hash double-hashed?
+	 */
+	public function getLegacyPassword()
+	{
+		return $this->legacyPassword;
+	}
+
+	/**
+	 * @param bool $legacyPassword
+	 * Set Is the password hash double-hashed?
+	 */
+	public function setLegacyPassword(bool $legacyPassword)
+	{
+		$this->legacyPassword = $legacyPassword;
+	}
+
+	/**
+	 * @return string
+	 * Get nick- and user name
+	 */
+	public function getNickname()
+	{
+		return $this->nickname;
+	}
+
+	/**
+	 * @param string $nickname
+	 * Set nick- and user name
+	 */
+	public function setNickname(string $nickname)
+	{
+		$this->nickname = $nickname;
+	}
+
+	/**
+	 * @return string
+	 * Get the users email address
+	 */
+	public function getEmail()
+	{
+		return $this->email;
+	}
+
+	/**
+	 * @param string $email
+	 * Set the users email address
+	 */
+	public function setEmail(string $email)
+	{
+		$this->email = $email;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getOpenid()
+	{
+		return $this->openid;
+	}
+
+	/**
+	 * @param string $openid
+	 * Set
+	 */
+	public function setOpenid(string $openid)
+	{
+		$this->openid = $openid;
+	}
+
+	/**
+	 * @return string
+	 * Get PHP-legal timezone
+	 */
+	public function getTimezone()
+	{
+		return $this->timezone;
+	}
+
+	/**
+	 * @param string $timezone
+	 * Set PHP-legal timezone
+	 */
+	public function setTimezone(string $timezone)
+	{
+		$this->timezone = $timezone;
+	}
+
+	/**
+	 * @return string
+	 * Get default language
+	 */
+	public function getLanguage()
+	{
+		return $this->language;
+	}
+
+	/**
+	 * @param string $language
+	 * Set default language
+	 */
+	public function setLanguage(string $language)
+	{
+		$this->language = $language;
+	}
+
+	/**
+	 * @return string
+	 * Get timestamp of registration
+	 */
+	public function getRegisterDate()
+	{
+		return $this->registerDate;
+	}
+
+	/**
+	 * @param string $registerDate
+	 * Set timestamp of registration
+	 */
+	public function setRegisterDate(string $registerDate)
+	{
+		$this->registerDate = $registerDate;
+	}
+
+	/**
+	 * @return string
+	 * Get timestamp of last login
+	 */
+	public function getLoginDate()
+	{
+		return $this->loginDate;
+	}
+
+	/**
+	 * @param string $loginDate
+	 * Set timestamp of last login
+	 */
+	public function setLoginDate(string $loginDate)
+	{
+		$this->loginDate = $loginDate;
+	}
+
+	/**
+	 * @return string
+	 * Get Default for item.location
+	 */
+	public function getDefaultLocation()
+	{
+		return $this->defaultLocation;
+	}
+
+	/**
+	 * @param string $defaultLocation
+	 * Set Default for item.location
+	 */
+	public function setDefaultLocation(string $defaultLocation)
+	{
+		$this->defaultLocation = $defaultLocation;
+	}
+
+	/**
+	 * @return bool
+	 * Get 1 allows to display the location
+	 */
+	public function getAllowLocation()
+	{
+		return $this->allowLocation;
+	}
+
+	/**
+	 * @param bool $allowLocation
+	 * Set 1 allows to display the location
+	 */
+	public function setAllowLocation(bool $allowLocation)
+	{
+		$this->allowLocation = $allowLocation;
+	}
+
+	/**
+	 * @return string
+	 * Get user theme preference
+	 */
+	public function getTheme()
+	{
+		return $this->theme;
+	}
+
+	/**
+	 * @param string $theme
+	 * Set user theme preference
+	 */
+	public function setTheme(string $theme)
+	{
+		$this->theme = $theme;
+	}
+
+	/**
+	 * @return string
+	 * Get RSA public key 4096 bit
+	 */
+	public function getPubkey()
+	{
+		return $this->pubkey;
+	}
+
+	/**
+	 * @param string $pubkey
+	 * Set RSA public key 4096 bit
+	 */
+	public function setPubkey(string $pubkey)
+	{
+		$this->pubkey = $pubkey;
+	}
+
+	/**
+	 * @return string
+	 * Get RSA private key 4096 bit
+	 */
+	public function getPrvkey()
+	{
+		return $this->prvkey;
+	}
+
+	/**
+	 * @param string $prvkey
+	 * Set RSA private key 4096 bit
+	 */
+	public function setPrvkey(string $prvkey)
+	{
+		$this->prvkey = $prvkey;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getSpubkey()
+	{
+		return $this->spubkey;
+	}
+
+	/**
+	 * @param string $spubkey
+	 * Set
+	 */
+	public function setSpubkey(string $spubkey)
+	{
+		$this->spubkey = $spubkey;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getSprvkey()
+	{
+		return $this->sprvkey;
+	}
+
+	/**
+	 * @param string $sprvkey
+	 * Set
+	 */
+	public function setSprvkey(string $sprvkey)
+	{
+		$this->sprvkey = $sprvkey;
+	}
+
+	/**
+	 * @return bool
+	 * Get user is verified through email
+	 */
+	public function getVerified()
+	{
+		return $this->verified;
+	}
+
+	/**
+	 * @param bool $verified
+	 * Set user is verified through email
+	 */
+	public function setVerified(bool $verified)
+	{
+		$this->verified = $verified;
+	}
+
+	/**
+	 * @return bool
+	 * Get 1 for user is blocked
+	 */
+	public function getBlocked()
+	{
+		return $this->blocked;
+	}
+
+	/**
+	 * @param bool $blocked
+	 * Set 1 for user is blocked
+	 */
+	public function setBlocked(bool $blocked)
+	{
+		$this->blocked = $blocked;
+	}
+
+	/**
+	 * @return bool
+	 * Get Prohibit contacts to post to the profile page of the user
+	 */
+	public function getBlockwall()
+	{
+		return $this->blockwall;
+	}
+
+	/**
+	 * @param bool $blockwall
+	 * Set Prohibit contacts to post to the profile page of the user
+	 */
+	public function setBlockwall(bool $blockwall)
+	{
+		$this->blockwall = $blockwall;
+	}
+
+	/**
+	 * @return bool
+	 * Get Hide profile details from unkown viewers
+	 */
+	public function getHidewall()
+	{
+		return $this->hidewall;
+	}
+
+	/**
+	 * @param bool $hidewall
+	 * Set Hide profile details from unkown viewers
+	 */
+	public function setHidewall(bool $hidewall)
+	{
+		$this->hidewall = $hidewall;
+	}
+
+	/**
+	 * @return bool
+	 * Get Prohibit contacts to tag the post of this user
+	 */
+	public function getBlocktags()
+	{
+		return $this->blocktags;
+	}
+
+	/**
+	 * @param bool $blocktags
+	 * Set Prohibit contacts to tag the post of this user
+	 */
+	public function setBlocktags(bool $blocktags)
+	{
+		$this->blocktags = $blocktags;
+	}
+
+	/**
+	 * @return bool
+	 * Get Permit unknown people to send private mails to this user
+	 */
+	public function getUnkmail()
+	{
+		return $this->unkmail;
+	}
+
+	/**
+	 * @param bool $unkmail
+	 * Set Permit unknown people to send private mails to this user
+	 */
+	public function setUnkmail(bool $unkmail)
+	{
+		$this->unkmail = $unkmail;
+	}
+
+	/**
+	 * @return int
+	 * Get
+	 */
+	public function getCntunkmail()
+	{
+		return $this->cntunkmail;
+	}
+
+	/**
+	 * @param int $cntunkmail
+	 * Set
+	 */
+	public function setCntunkmail(int $cntunkmail)
+	{
+		$this->cntunkmail = $cntunkmail;
+	}
+
+	/**
+	 * @return string
+	 * Get email notification options
+	 */
+	public function getNotifyFlags()
+	{
+		return $this->notifyFlags;
+	}
+
+	/**
+	 * @param string $notifyFlags
+	 * Set email notification options
+	 */
+	public function setNotifyFlags(string $notifyFlags)
+	{
+		$this->notifyFlags = $notifyFlags;
+	}
+
+	/**
+	 * @return string
+	 * Get page/profile type
+	 */
+	public function getPageFlags()
+	{
+		return $this->pageFlags;
+	}
+
+	/**
+	 * @param string $pageFlags
+	 * Set page/profile type
+	 */
+	public function setPageFlags(string $pageFlags)
+	{
+		$this->pageFlags = $pageFlags;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getAccountType()
+	{
+		return $this->accountType;
+	}
+
+	/**
+	 * @param string $accountType
+	 * Set
+	 */
+	public function setAccountType(string $accountType)
+	{
+		$this->accountType = $accountType;
+	}
+
+	/**
+	 * @return bool
+	 * Get
+	 */
+	public function getPrvnets()
+	{
+		return $this->prvnets;
+	}
+
+	/**
+	 * @param bool $prvnets
+	 * Set
+	 */
+	public function setPrvnets(bool $prvnets)
+	{
+		$this->prvnets = $prvnets;
+	}
+
+	/**
+	 * @return string
+	 * Get Password reset request token
+	 */
+	public function getPwdreset()
+	{
+		return $this->pwdreset;
+	}
+
+	/**
+	 * @param string $pwdreset
+	 * Set Password reset request token
+	 */
+	public function setPwdreset(string $pwdreset)
+	{
+		$this->pwdreset = $pwdreset;
+	}
+
+	/**
+	 * @return string
+	 * Get Timestamp of the last password reset request
+	 */
+	public function getPwdresetTime()
+	{
+		return $this->pwdresetTime;
+	}
+
+	/**
+	 * @param string $pwdresetTime
+	 * Set Timestamp of the last password reset request
+	 */
+	public function setPwdresetTime(string $pwdresetTime)
+	{
+		$this->pwdresetTime = $pwdresetTime;
+	}
+
+	/**
+	 * @return int
+	 * Get
+	 */
+	public function getMaxreq()
+	{
+		return $this->maxreq;
+	}
+
+	/**
+	 * @param int $maxreq
+	 * Set
+	 */
+	public function setMaxreq(int $maxreq)
+	{
+		$this->maxreq = $maxreq;
+	}
+
+	/**
+	 * @return int
+	 * Get
+	 */
+	public function getExpire()
+	{
+		return $this->expire;
+	}
+
+	/**
+	 * @param int $expire
+	 * Set
+	 */
+	public function setExpire(int $expire)
+	{
+		$this->expire = $expire;
+	}
+
+	/**
+	 * @return bool
+	 * Get if 1 the account is removed
+	 */
+	public function getAccountRemoved()
+	{
+		return $this->accountRemoved;
+	}
+
+	/**
+	 * @param bool $accountRemoved
+	 * Set if 1 the account is removed
+	 */
+	public function setAccountRemoved(bool $accountRemoved)
+	{
+		$this->accountRemoved = $accountRemoved;
+	}
+
+	/**
+	 * @return bool
+	 * Get
+	 */
+	public function getAccountExpired()
+	{
+		return $this->accountExpired;
+	}
+
+	/**
+	 * @param bool $accountExpired
+	 * Set
+	 */
+	public function setAccountExpired(bool $accountExpired)
+	{
+		$this->accountExpired = $accountExpired;
+	}
+
+	/**
+	 * @return string
+	 * Get timestamp when account expires and will be deleted
+	 */
+	public function getAccountExpiresOn()
+	{
+		return $this->accountExpiresOn;
+	}
+
+	/**
+	 * @param string $accountExpiresOn
+	 * Set timestamp when account expires and will be deleted
+	 */
+	public function setAccountExpiresOn(string $accountExpiresOn)
+	{
+		$this->accountExpiresOn = $accountExpiresOn;
+	}
+
+	/**
+	 * @return string
+	 * Get timestamp of last warning of account expiration
+	 */
+	public function getExpireNotificationSent()
+	{
+		return $this->expireNotificationSent;
+	}
+
+	/**
+	 * @param string $expireNotificationSent
+	 * Set timestamp of last warning of account expiration
+	 */
+	public function setExpireNotificationSent(string $expireNotificationSent)
+	{
+		$this->expireNotificationSent = $expireNotificationSent;
+	}
+
+	/**
+	 * @return int
+	 * Get
+	 */
+	public function getDefGid()
+	{
+		return $this->defGid;
+	}
+
+	/**
+	 * @param int $defGid
+	 * Set
+	 */
+	public function setDefGid(int $defGid)
+	{
+		$this->defGid = $defGid;
+	}
+
+	/**
+	 * @return string
+	 * Get default permission for this user
+	 */
+	public function getAllowCid()
+	{
+		return $this->allowCid;
+	}
+
+	/**
+	 * @param string $allowCid
+	 * Set default permission for this user
+	 */
+	public function setAllowCid(string $allowCid)
+	{
+		$this->allowCid = $allowCid;
+	}
+
+	/**
+	 * @return string
+	 * Get default permission for this user
+	 */
+	public function getAllowGid()
+	{
+		return $this->allowGid;
+	}
+
+	/**
+	 * @param string $allowGid
+	 * Set default permission for this user
+	 */
+	public function setAllowGid(string $allowGid)
+	{
+		$this->allowGid = $allowGid;
+	}
+
+	/**
+	 * @return string
+	 * Get default permission for this user
+	 */
+	public function getDenyCid()
+	{
+		return $this->denyCid;
+	}
+
+	/**
+	 * @param string $denyCid
+	 * Set default permission for this user
+	 */
+	public function setDenyCid(string $denyCid)
+	{
+		$this->denyCid = $denyCid;
+	}
+
+	/**
+	 * @return string
+	 * Get default permission for this user
+	 */
+	public function getDenyGid()
+	{
+		return $this->denyGid;
+	}
+
+	/**
+	 * @param string $denyGid
+	 * Set default permission for this user
+	 */
+	public function setDenyGid(string $denyGid)
+	{
+		$this->denyGid = $denyGid;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getOpenidserver()
+	{
+		return $this->openidserver;
+	}
+
+	/**
+	 * @param string $openidserver
+	 * Set
+	 */
+	public function setOpenidserver(string $openidserver)
+	{
+		$this->openidserver = $openidserver;
+	}
+}

--- a/src/Domain/Entity/User/Contact.php
+++ b/src/Domain/Entity/User/Contact.php
@@ -1,0 +1,175 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity\User;
+
+use Friendica\BaseEntity;
+use Friendica\Network\HTTPException\NotImplementedException;
+
+/**
+ * Entity class for table user-contact
+ *
+ * User specific public contact data
+ */
+class Contact extends BaseEntity
+{
+	/**
+	 * @var int
+	 * Contact id of the linked public contact
+	 */
+	private $cid = '0';
+
+	/**
+	 * @var int
+	 * User id
+	 */
+	private $uid = '0';
+
+	/**
+	 * @var bool
+	 * Contact is completely blocked for this user
+	 */
+	private $blocked;
+
+	/**
+	 * @var bool
+	 * Posts from this contact are ignored
+	 */
+	private $ignored;
+
+	/**
+	 * @var bool
+	 * Posts from this contact are collapsed
+	 */
+	private $collapsed;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'cid' => $this->cid,
+			'uid' => $this->uid,
+			'blocked' => $this->blocked,
+			'ignored' => $this->ignored,
+			'collapsed' => $this->collapsed,
+		];
+	}
+
+	/**
+	 * @return int
+	 * Get Contact id of the linked public contact
+	 */
+	public function getCid()
+	{
+		return $this->cid;
+	}
+
+	/**
+	 * Get Contact
+	 *
+	 * @return Contact
+	 */
+	public function getContact()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for id is not implemented yet');
+	}
+
+	/**
+	 * @return int
+	 * Get User id
+	 */
+	public function getUid()
+	{
+		return $this->uid;
+	}
+
+	/**
+	 * Get User
+	 *
+	 * @return User
+	 */
+	public function getUser()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for uid is not implemented yet');
+	}
+
+	/**
+	 * @return bool
+	 * Get Contact is completely blocked for this user
+	 */
+	public function getBlocked()
+	{
+		return $this->blocked;
+	}
+
+	/**
+	 * @param bool $blocked
+	 * Set Contact is completely blocked for this user
+	 */
+	public function setBlocked(bool $blocked)
+	{
+		$this->blocked = $blocked;
+	}
+
+	/**
+	 * @return bool
+	 * Get Posts from this contact are ignored
+	 */
+	public function getIgnored()
+	{
+		return $this->ignored;
+	}
+
+	/**
+	 * @param bool $ignored
+	 * Set Posts from this contact are ignored
+	 */
+	public function setIgnored(bool $ignored)
+	{
+		$this->ignored = $ignored;
+	}
+
+	/**
+	 * @return bool
+	 * Get Posts from this contact are collapsed
+	 */
+	public function getCollapsed()
+	{
+		return $this->collapsed;
+	}
+
+	/**
+	 * @param bool $collapsed
+	 * Set Posts from this contact are collapsed
+	 */
+	public function setCollapsed(bool $collapsed)
+	{
+		$this->collapsed = $collapsed;
+	}
+}

--- a/src/Domain/Entity/User/Item.php
+++ b/src/Domain/Entity/User/Item.php
@@ -1,0 +1,199 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity\User;
+
+use Friendica\BaseEntity;
+use Friendica\Network\HTTPException\NotImplementedException;
+
+/**
+ * Entity class for table user-item
+ *
+ * User specific item data
+ */
+class Item extends BaseEntity
+{
+	/**
+	 * @var int
+	 * Item id
+	 */
+	private $iid = '0';
+
+	/**
+	 * @var int
+	 * User id
+	 */
+	private $uid = '0';
+
+	/**
+	 * @var bool
+	 * Marker to hide an item from the user
+	 */
+	private $hidden = '0';
+
+	/**
+	 * @var bool
+	 * Ignore this thread if set
+	 */
+	private $ignored;
+
+	/**
+	 * @var bool
+	 * The item is pinned on the profile page
+	 */
+	private $pinned;
+
+	/**
+	 * @var string
+	 */
+	private $notificationType = '0';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'iid' => $this->iid,
+			'uid' => $this->uid,
+			'hidden' => $this->hidden,
+			'ignored' => $this->ignored,
+			'pinned' => $this->pinned,
+			'notification-type' => $this->notificationType,
+		];
+	}
+
+	/**
+	 * @return int
+	 * Get Item id
+	 */
+	public function getIid()
+	{
+		return $this->iid;
+	}
+
+	/**
+	 * Get Item
+	 *
+	 * @return Item
+	 */
+	public function getItem()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for id is not implemented yet');
+	}
+
+	/**
+	 * @return int
+	 * Get User id
+	 */
+	public function getUid()
+	{
+		return $this->uid;
+	}
+
+	/**
+	 * Get User
+	 *
+	 * @return User
+	 */
+	public function getUser()
+	{
+		//@todo use closure
+		throw new NotImplementedException('lazy loading for uid is not implemented yet');
+	}
+
+	/**
+	 * @return bool
+	 * Get Marker to hide an item from the user
+	 */
+	public function getHidden()
+	{
+		return $this->hidden;
+	}
+
+	/**
+	 * @param bool $hidden
+	 * Set Marker to hide an item from the user
+	 */
+	public function setHidden(bool $hidden)
+	{
+		$this->hidden = $hidden;
+	}
+
+	/**
+	 * @return bool
+	 * Get Ignore this thread if set
+	 */
+	public function getIgnored()
+	{
+		return $this->ignored;
+	}
+
+	/**
+	 * @param bool $ignored
+	 * Set Ignore this thread if set
+	 */
+	public function setIgnored(bool $ignored)
+	{
+		$this->ignored = $ignored;
+	}
+
+	/**
+	 * @return bool
+	 * Get The item is pinned on the profile page
+	 */
+	public function getPinned()
+	{
+		return $this->pinned;
+	}
+
+	/**
+	 * @param bool $pinned
+	 * Set The item is pinned on the profile page
+	 */
+	public function setPinned(bool $pinned)
+	{
+		$this->pinned = $pinned;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getNotificationType()
+	{
+		return $this->notificationType;
+	}
+
+	/**
+	 * @param string $notificationType
+	 * Set
+	 */
+	public function setNotificationType(string $notificationType)
+	{
+		$this->notificationType = $notificationType;
+	}
+}

--- a/src/Domain/Entity/Userd.php
+++ b/src/Domain/Entity/Userd.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity;
+
+use Friendica\BaseEntity;
+
+/**
+ * Entity class for table userd
+ *
+ * Deleted usernames
+ */
+class Userd extends BaseEntity
+{
+	/**
+	 * @var int
+	 * sequential ID
+	 */
+	private $id;
+
+	/**
+	 * @var string
+	 */
+	private $username;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'id' => $this->id,
+			'username' => $this->username,
+		];
+	}
+
+	/**
+	 * @return int
+	 * Get sequential ID
+	 */
+	public function getId()
+	{
+		return $this->id;
+	}
+
+	/**
+	 * @return string
+	 * Get
+	 */
+	public function getUsername()
+	{
+		return $this->username;
+	}
+
+	/**
+	 * @param string $username
+	 * Set
+	 */
+	public function setUsername(string $username)
+	{
+		$this->username = $username;
+	}
+}

--- a/src/Domain/Entity/Worker/Ipc.php
+++ b/src/Domain/Entity/Worker/Ipc.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity\Worker;
+
+use Friendica\BaseEntity;
+
+/**
+ * Entity class for table worker-ipc
+ *
+ * Inter process communication between the frontend and the worker
+ */
+class Ipc extends BaseEntity
+{
+	/**
+	 * @var int
+	 */
+	private $key;
+
+	/**
+	 * @var bool
+	 * Flag for outstanding jobs
+	 */
+	private $jobs;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'key' => $this->key,
+			'jobs' => $this->jobs,
+		];
+	}
+
+	/**
+	 * @return int
+	 * Get
+	 */
+	public function getKey()
+	{
+		return $this->key;
+	}
+
+	/**
+	 * @return bool
+	 * Get Flag for outstanding jobs
+	 */
+	public function getJobs()
+	{
+		return $this->jobs;
+	}
+
+	/**
+	 * @param bool $jobs
+	 * Set Flag for outstanding jobs
+	 */
+	public function setJobs(bool $jobs)
+	{
+		$this->jobs = $jobs;
+	}
+}

--- a/src/Domain/Entity/Workerqueue.php
+++ b/src/Domain/Entity/Workerqueue.php
@@ -1,0 +1,261 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU APGL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Used to check/generate entities for the Friendica codebase
+ */
+
+declare(strict_types=1);
+
+namespace Friendica\Domain\Entity;
+
+use Friendica\BaseEntity;
+
+/**
+ * Entity class for table workerqueue
+ *
+ * Background tasks queue entries
+ */
+class Workerqueue extends BaseEntity
+{
+	/**
+	 * @var int
+	 * Auto incremented worker task id
+	 */
+	private $id;
+
+	/**
+	 * @var string
+	 * Task command
+	 */
+	private $parameter;
+
+	/**
+	 * @var string
+	 * Task priority
+	 */
+	private $priority = '0';
+
+	/**
+	 * @var string
+	 * Creation date
+	 */
+	private $created = '0001-01-01 00:00:00';
+
+	/**
+	 * @var int
+	 * Process id of the worker
+	 */
+	private $pid = '0';
+
+	/**
+	 * @var string
+	 * Execution date
+	 */
+	private $executed = '0001-01-01 00:00:00';
+
+	/**
+	 * @var string
+	 * Next retrial date
+	 */
+	private $nextTry = '0001-01-01 00:00:00';
+
+	/**
+	 * @var string
+	 * Retrial counter
+	 */
+	private $retrial = '0';
+
+	/**
+	 * @var bool
+	 * Marked 1 when the task was done - will be deleted later
+	 */
+	private $done = '0';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray()
+	{
+		return [
+			'id' => $this->id,
+			'parameter' => $this->parameter,
+			'priority' => $this->priority,
+			'created' => $this->created,
+			'pid' => $this->pid,
+			'executed' => $this->executed,
+			'next_try' => $this->nextTry,
+			'retrial' => $this->retrial,
+			'done' => $this->done,
+		];
+	}
+
+	/**
+	 * @return int
+	 * Get Auto incremented worker task id
+	 */
+	public function getId()
+	{
+		return $this->id;
+	}
+
+	/**
+	 * @return string
+	 * Get Task command
+	 */
+	public function getParameter()
+	{
+		return $this->parameter;
+	}
+
+	/**
+	 * @param string $parameter
+	 * Set Task command
+	 */
+	public function setParameter(string $parameter)
+	{
+		$this->parameter = $parameter;
+	}
+
+	/**
+	 * @return string
+	 * Get Task priority
+	 */
+	public function getPriority()
+	{
+		return $this->priority;
+	}
+
+	/**
+	 * @param string $priority
+	 * Set Task priority
+	 */
+	public function setPriority(string $priority)
+	{
+		$this->priority = $priority;
+	}
+
+	/**
+	 * @return string
+	 * Get Creation date
+	 */
+	public function getCreated()
+	{
+		return $this->created;
+	}
+
+	/**
+	 * @param string $created
+	 * Set Creation date
+	 */
+	public function setCreated(string $created)
+	{
+		$this->created = $created;
+	}
+
+	/**
+	 * @return int
+	 * Get Process id of the worker
+	 */
+	public function getPid()
+	{
+		return $this->pid;
+	}
+
+	/**
+	 * @param int $pid
+	 * Set Process id of the worker
+	 */
+	public function setPid(int $pid)
+	{
+		$this->pid = $pid;
+	}
+
+	/**
+	 * @return string
+	 * Get Execution date
+	 */
+	public function getExecuted()
+	{
+		return $this->executed;
+	}
+
+	/**
+	 * @param string $executed
+	 * Set Execution date
+	 */
+	public function setExecuted(string $executed)
+	{
+		$this->executed = $executed;
+	}
+
+	/**
+	 * @return string
+	 * Get Next retrial date
+	 */
+	public function getNextTry()
+	{
+		return $this->nextTry;
+	}
+
+	/**
+	 * @param string $nextTry
+	 * Set Next retrial date
+	 */
+	public function setNextTry(string $nextTry)
+	{
+		$this->nextTry = $nextTry;
+	}
+
+	/**
+	 * @return string
+	 * Get Retrial counter
+	 */
+	public function getRetrial()
+	{
+		return $this->retrial;
+	}
+
+	/**
+	 * @param string $retrial
+	 * Set Retrial counter
+	 */
+	public function setRetrial(string $retrial)
+	{
+		$this->retrial = $retrial;
+	}
+
+	/**
+	 * @return bool
+	 * Get Marked 1 when the task was done - will be deleted later
+	 */
+	public function getDone()
+	{
+		return $this->done;
+	}
+
+	/**
+	 * @param bool $done
+	 * Set Marked 1 when the task was done - will be deleted later
+	 */
+	public function setDone(bool $done)
+	{
+		$this->done = $done;
+	}
+}


### PR DESCRIPTION
- New script `bin/entities.php` for automatic entity generation
- Add all entities based on the table structure
- Add dev composer dependency "nette/php-generator"

ToDos:
- [ ] Automatic Repository generation
- [ ] Automatic lazy loader generation
- [ ] Automatic unit test generation
- [ ] Automatic check of changed dbstructure and impacts on the code

This is a show case how I know entities from the OOP world. It depends on the wish of @annando  that every table should be a 1:1 model without too much abstraction and the wish of @MrPetovan and I to have a usable OOP pattern.

In a "last" stage, we could automatically re-create the whole entity world based on the dbstructure file, so we won't have to type any code in case of table-structure adaption (and it will throw an error in case a field is deleted, but there's a dependency in the codebase.
=> In JAVA, there's an annotation `@Column(item.uid)` to have this check at compile time, the current script would check it at least during the Travis-CI check for example :)

As said it's just a show case and far from finished yet!