### PR TITLE
Clarify the effect of "net-publish"

### DIFF
--- a/mod/settings.php
+++ b/mod/settings.php
@@ -1098,17 +1098,19 @@ function settings_content(App $a)
 		$profile_in_dir = '<input type="hidden" name="profile_in_directory" value="1" />';
 	} else {
 		$profile_in_dir = Renderer::replaceMacros($opt_tpl, [
-			'$field' => ['profile_in_directory', DI::l10n()->t('Publish your default profile in your local site directory?'), $profile['publish'], DI::l10n()->t('Your profile will be published in this node\'s <a href="%s">local directory</a>. Your profile details may be publicly visible depending on the system settings.', DI::baseUrl().'/directory')]
+			'$field' => ['profile_in_directory', DI::l10n()->t('Publish your profile in your local site directory?'), $profile['publish'], DI::l10n()->t('Your profile will be published in this node\'s <a href="%s">local directory</a>. Your profile details may be publicly visible depending on the system settings.', DI::baseUrl().'/directory')]
 		]);
 	}
 
 	if (strlen(DI::config()->get('system', 'directory'))) {
-		$profile_in_net_dir = Renderer::replaceMacros($opt_tpl, [
-			'$field' => ['profile_in_netdirectory', DI::l10n()->t('Publish your default profile in the global social directory?'), $profile['net-publish'], DI::l10n()->t('Your profile will be published in the global friendica directories (e.g. <a href="%s">%s</a>). Your profile will be visible in public.', DI::config()->get('system', 'directory'), DI::config()->get('system', 'directory'))	. " " . DI::l10n()->t("This setting also determines whether Friendica will inform search engines that your profile should be indexed or not. Third-party search engines may or may not respect this setting.")]
-		]);
+		$net_pub_desc = ' ' . DI::l10n()->t('Your profile will also be published in the global friendica directories (e.g. <a href="%s">%s</a>).', DI::config()->get('system', 'directory'), DI::config()->get('system', 'directory'));
 	} else {
-		$profile_in_net_dir = '';
+		$net_pub_desc = '';
 	}
+
+	$profile_in_net_dir = Renderer::replaceMacros($opt_tpl, [
+		'$field' => ['profile_in_netdirectory', DI::l10n()->t('Allow your profile to be searchable globally?'), $profile['net-publish'], DI::l10n()->t("Activate this setting if you want others to easily find and follow you. Your profile will be searchable on remote systems. This setting also determines whether Friendica will inform search engines that your profile should be indexed or not.") . $net_pub_desc]
+	]);
 
 	$hide_friends = Renderer::replaceMacros($opt_tpl, [
 		'$field' => ['hide-friends', DI::l10n()->t('Hide your contact/friend list from viewers of your default profile?'), $profile['hide-friends'], DI::l10n()->t('Your contact list won\'t be shown in your default profile page. You can decide to show your contact list separately for each additional profile you create')],
@@ -1133,10 +1135,6 @@ function settings_content(App $a)
 	$unkmail = Renderer::replaceMacros($opt_tpl, [
 		'$field' => ['unkmail', DI::l10n()->t('Permit unknown people to send you private mail?'), $unkmail, DI::l10n()->t('Friendica network users may send you private messages even if they are not in your contact list.')],
 	]);
-
-	if (!$profile['publish'] && !$profile['net-publish']) {
-		info(DI::l10n()->t('Profile is <strong>not published</strong>.') . EOL);
-	}
 
 	$tpl_addr = Renderer::getMarkupTemplate('settings/nick_set.tpl');
 

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -785,7 +785,7 @@ class Contact
 		$fields['avatar'] = DI::baseUrl() . '/photo/profile/' .$uid . '.' . $file_suffix;
 		$fields['forum'] = $user['page-flags'] == User::PAGE_FLAGS_COMMUNITY;
 		$fields['prv'] = $user['page-flags'] == User::PAGE_FLAGS_PRVGROUP;
-		$fields['unsearchable'] = $user['hidewall'] || !$profile['net-publish'];
+		$fields['unsearchable'] = !$profile['net-publish'];
 
 		// it seems as if ported accounts can have wrong values, so we make sure that now everything is fine.
 		$fields['url'] = DI::baseUrl() . '/profile/' . $user['nickname'];

--- a/src/Model/GContact.php
+++ b/src/Model/GContact.php
@@ -1136,7 +1136,7 @@ class GContact
 				'keywords' => $userdata['pub_keywords'],
 				'birthday' => $userdata['dob'], 'photo' => $userdata['photo'],
 				"notify" => $userdata['notify'], 'url' => $userdata['url'],
-				"hide" => ($userdata['hidewall'] || !$userdata['net-publish']),
+				"hide" => !$userdata['net-publish'],
 				'nick' => $userdata['nickname'], 'addr' => $userdata['addr'],
 				"connect" => $userdata['addr'], "server_url" => DI::baseUrl(),
 				"generation" => 1, 'network' => Protocol::DFRN];

--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -392,7 +392,7 @@ class Profile
 			$diaspora = [
 				'guid' => $profile['guid'],
 				'podloc' => DI::baseUrl(),
-				'searchable' => (($profile['publish'] && $profile['net-publish']) ? 'true' : 'false'),
+				'searchable' => ($profile['net-publish'] ? 'true' : 'false'),
 				'nickname' => $profile['nickname'],
 				'fullname' => $profile['name'],
 				'firstname' => $firstname,

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -616,8 +616,7 @@ class User
 		$verified   = !empty($data['verified']);
 		$language   = !empty($data['language'])   ? Strings::escapeTags(trim($data['language']))   : 'en';
 
-		$publish = !empty($data['profile_publish_reg']);
-		$netpublish = $publish && DI::config()->get('system', 'directory');
+		$netpublish = $publish = !empty($data['profile_publish_reg']);
 
 		if ($password1 != $confirm) {
 			throw new Exception(DI::l10n()->t('Passwords do not match. Password unchanged.'));

--- a/src/Module/HoverCard.php
+++ b/src/Module/HoverCard.php
@@ -75,7 +75,7 @@ class HoverCard extends BaseModule
 
 		$uri = urlencode('acct:' . $a->profile['nickname'] . '@' . $baseUrl->getHostname() . ($baseUrl->getUrlPath() ? '/' . $baseUrl->getUrlPath() : ''));
 
-		$page['htmlhead'] .= '<meta name="dfrn-global-visibility" content="' . (($a->profile['net-publish']) ? 'true' : 'false') . '" />' . "\r\n";
+		$page['htmlhead'] .= '<meta name="dfrn-global-visibility" content="' . ($a->profile['net-publish'] ? 'true' : 'false') . '" />' . "\r\n";
 		$page['htmlhead'] .= '<link rel="alternate" type="application/atom+xml" href="' . $baseUrl->get() . '/dfrn_poll/' . $nickname . '" />' . "\r\n";
 		$page['htmlhead'] .= '<link rel="lrdd" type="application/xrd+xml" href="' . $baseUrl->get() . '/xrd/?uri=' . $uri . '" />' . "\r\n";
 		header('Link: <' . $baseUrl->get() . '/xrd/?uri=' . $uri . '>; rel="lrdd"; type="application/xrd+xml"', false);

--- a/src/Module/NoScrape.php
+++ b/src/Module/NoScrape.php
@@ -69,7 +69,7 @@ class NoScrape extends BaseModule
 			$json_info["dfrn-{$dfrn}"] = DI::baseUrl() . "/dfrn_{$dfrn}/{$which}";
 		}
 
-		if (!$a->profile['net-publish'] || $a->profile['hidewall']) {
+		if (!$a->profile['net-publish']) {
 			$json_info['hide'] = true;
 			System::jsonExit($json_info);
 		}

--- a/src/Module/Profile/Profile.php
+++ b/src/Module/Profile/Profile.php
@@ -293,7 +293,7 @@ class Profile extends BaseProfile
 
 		$htmlhead .= '<meta name="dfrn-global-visibility" content="' . ($profile['net-publish'] ? 'true' : 'false') . '" />' . "\n";
 
-		if (!$profile['net-publish'] || $profile['hidewall']) {
+		if (!$profile['net-publish']) {
 			$htmlhead .= '<meta content="noindex, noarchive" name="robots" />' . "\n";
 		}
 

--- a/src/Module/Profile/Status.php
+++ b/src/Module/Profile/Status.php
@@ -48,7 +48,7 @@ class Status extends BaseProfile
 
 		ProfileModel::load($a, $parameters['nickname']);
 
-		if (!$a->profile['net-publish'] || $a->profile['hidewall']) {
+		if (!$a->profile['net-publish']) {
 			DI::page()['htmlhead'] .= '<meta content="noindex, noarchive" name="robots" />' . "\n";
 		}
 

--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -640,7 +640,7 @@ class DFRN
 	private static function addAuthor(DOMDocument $doc, array $owner, $authorelement, $public)
 	{
 		// Should the profile be "unsearchable" in the net? Then add the "hide" element
-		$hide = DBA::exists('profile', ['uid' => $owner['uid'], 'net-publish' = false]);
+		$hide = DBA::exists('profile', ['uid' => $owner['uid'], 'net-publish' => false]);
 
 		$author = $doc->createElement($authorelement);
 

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -4118,7 +4118,7 @@ class Diaspora
 		$large = DI::baseUrl().'/photo/custom/300/'.$profile['uid'].'.jpg';
 		$medium = DI::baseUrl().'/photo/custom/100/'.$profile['uid'].'.jpg';
 		$small = DI::baseUrl().'/photo/custom/50/'  .$profile['uid'].'.jpg';
-		$searchable = (($profile['publish'] && $profile['net-publish']) ? 'true' : 'false');
+		$searchable = ($profile['net-publish'] ? 'true' : 'false');
 
 		$dob = null;
 		$about = null;


### PR DESCRIPTION
For a long time, the profile setting "net-publish" had not only controlled if a profile should be published to the global directory. It also controls whether other remote systems like Diaspora could search the user or if search engines should find this user.

This is now explained more clearly. Also this setting is now solely responsible for not being searchable. This helps in avoiding side effects.