### PR TITLE
Fix view profile link

### DIFF
--- a/src/Module/Settings/Profile/Index.php
+++ b/src/Module/Settings/Profile/Index.php
@@ -243,7 +243,7 @@ class Index extends BaseSettings
 			'$submit' => DI::l10n()->t('Submit'),
 			'$profpic' => DI::l10n()->t('Change Profile Photo'),
 			'$profpiclink' => '/photos/' . $a->user['nickname'],
-			'$viewprof' => DI::l10n()->t('View this profile'),
+			'$viewprof' => DI::l10n()->t('View Profile'),
 
 			'$lbl_personal_section' => DI::l10n()->t('Personal'),
 			'$lbl_picture_section' => DI::l10n()->t('Profile picture'),

--- a/view/templates/settings/profile/index.tpl
+++ b/view/templates/settings/profile/index.tpl
@@ -5,7 +5,7 @@
 <div id="profile-edit-links">
 	<ul>
 		<li><a href="settings/profile/photo" id="profile-photo_upload-link" title="{{$profpic}}">{{$profpic}}</a></li>
-		<li><a href="profile/{{$nickname}}" id="profile-edit-view-link" title="{{$viewprof}}">{{$viewprof}}</a></li>
+		<li><a href="profile/{{$nickname}}/profile" id="profile-edit-view-link" title="{{$viewprof}}">{{$viewprof}}</a></li>
 	</ul>
 </div>
 

--- a/view/theme/frio/templates/settings/profile/index.tpl
+++ b/view/theme/frio/templates/settings/profile/index.tpl
@@ -12,7 +12,7 @@
 					<li role="presentation"><a role="menuitem" href="{{$profpiclink}}" id="profile-photo_upload-link" title="{{$profpic}}"><i class="fa fa-user" aria-hidden="true"></i>&nbsp;{{$profpic}}</a></li>
 					<li role="presentation"><button role="menuitem" type="button" class="btn-link" id="profile-photo_upload-link-new" title="{{$lbl_profile_photo}}" onclick="openClose('profile-photo-upload-section');"><i class="fa fa-user" aria-hidden="true"></i>&nbsp;{{$lbl_profile_photo}}</button></li>
 					<li role="presentation" class="divider"></li>
-					<li role="presentation"><a role="menuitem" href="profile/{{$nickname}}" id="profile-edit-view-link" title="{{$viewprof}}">{{$viewprof}}</a></li>
+					<li role="presentation"><a role="menuitem" href="profile/{{$nickname}}/profile" id="profile-edit-view-link" title="{{$viewprof}}">{{$viewprof}}</a></li>
 				</ul>
 			</li>
 		</ul>

--- a/view/theme/vier/templates/settings/profile/index.tpl
+++ b/view/theme/vier/templates/settings/profile/index.tpl
@@ -12,7 +12,7 @@
 
 <div id="profile-edit-links">
 	<ul>
-		<li><a class="btn" href="profile/{{$nickname}}" id="profile-edit-view-link" title="{{$viewprof}}">{{$viewprof}}</a></li>
+		<li><a class="btn" href="profile/{{$nickname}}/profile" id="profile-edit-view-link" title="{{$viewprof}}">{{$viewprof}}</a></li>
 	</ul>
 </div>
 <div id="profile-edit-links-end"></div>


### PR DESCRIPTION
The 'view this profile' links on 'settings -> profile -> edit' redirected the user to the status/wall page. This is now fixed. The user will be redirected to their profile instead.

Fixes #8303 

Question is - since we have only one profile now - should we also change the wording from "View this profile" to something like "View profile" or "View your profile"? Or is it ok to leave it like it is? Suggestions?