### PR TITLE
Don't show "delete contact" when there is a follow or unfollow option

### DIFF
--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -1278,6 +1278,10 @@ class Contact
 			}
 		}
 
+		if (!empty($follow_link) || !empty($unfollow_link)) {
+			$contact_drop_link = '';
+		}
+
 		/**
 		 * Menu array:
 		 * "name" => [ "Label", "link", (bool)Should the link opened in a new tab? ]

--- a/view/theme/frio/templates/contact_template.tpl
+++ b/view/theme/frio/templates/contact_template.tpl
@@ -73,6 +73,11 @@
 					<i class="fa fa-user-plus" aria-hidden="true"></i>
 				</a>
 				{{/if}}
+				{{if $contact.photo_menu.unfollow}}
+				<a class="contact-action-link btn-link" href="{{$contact.photo_menu.unfollow.1}}" data-toggle="tooltip" title="{{$contact.photo_menu.unfollow.0}}">
+					<i class="fa fa-user-times" aria-hidden="true"></i>
+				</a>
+				{{/if}}
 				{{if $contact.photo_menu.hide}}
 				<a class="contact-action-link btn-link" href="{{$contact.photo_menu.hide.1}}" data-toggle="tooltip" title="{{$contact.photo_menu.hide.0}}">
 					<i class="fa fa-times" aria-hidden="true"></i>


### PR DESCRIPTION
This PR spung out of a discussion in the support forum about the alleged inability of Friendica to change the relation status of contacts and that you should delete a contact to unfollow the person.

Fact is: Friendica does know the "unfollow" (without loosing the relation) now for several years. But I guess it is to hidden. So in the contact lists we now don't show the "delete" option when there is a "follow" or "unfollow" option and we display the "unfollow" option in the Frio theme (this wasn't the case until now).

You still are able to delete contacts, it just went one level deeper. Hopefully this make things easier to use.