### PR TITLE
Remotely load posts to comment on them on the own page

### DIFF
--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -786,7 +786,7 @@ class Profile
 		$_SESSION['visitor_handle'] = $visitor['addr'];
 		$_SESSION['visitor_home'] = $visitor['url'];
 		$_SESSION['my_url'] = $visitor['url'];
-		$_SESSION['remote_follow'] = Probe::getRemoteFollowLink($visitor['url']);
+		$_SESSION['remote_comment'] = Probe::getRemoteFollowLink($visitor['url']);
 
 		Session::setVisitorsContacts();
 

--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -27,6 +27,7 @@ use Friendica\Content\Widget\ContactBlock;
 use Friendica\Core\Cache\Duration;
 use Friendica\Core\Hook;
 use Friendica\Core\Logger;
+use Friendica\Network\Probe;
 use Friendica\Core\Protocol;
 use Friendica\Core\Renderer;
 use Friendica\Core\Session;
@@ -785,6 +786,7 @@ class Profile
 		$_SESSION['visitor_handle'] = $visitor['addr'];
 		$_SESSION['visitor_home'] = $visitor['url'];
 		$_SESSION['my_url'] = $visitor['url'];
+		$_SESSION['remote_follow'] = Probe::getRemoteFollowLink($visitor['url']);
 
 		Session::setVisitorsContacts();
 

--- a/src/Object/Post.php
+++ b/src/Object/Post.php
@@ -392,6 +392,14 @@ class Post
 			$ago = DI::l10n()->t('%s (Received %s)', $ago, $ago_received);
 		}
 
+		// Fetching of Diaspora posts doesn't always work. There are issues with reshares and possibly comments
+		if (($item['network'] != Protocol::DIASPORA) && empty($comment) && !empty(Session::get('remote_follow'))) {
+			$remote_comment = [DI::l10n()->t('Comment this item on your system'), DI::l10n()->t('remote comment'),
+				str_replace('{uri}', urlencode($item['uri']), Session::get('remote_follow'))];
+		} else {
+			$remote_comment = '';
+		}
+
 		$tmp_item = [
 			'template'        => $this->getTemplate(),
 			'type'            => implode("", array_slice(explode("/", $item['verb']), -1)),
@@ -455,6 +463,7 @@ class Post
 			'switchcomment'   => DI::l10n()->t('Comment'),
 			'reply_label'     => DI::l10n()->t('Reply to %s', $name_e),
 			'comment'         => $comment,
+			'remote_comment'  => $remote_comment,
 			'menu'            => DI::l10n()->t('More'),
 			'previewing'      => $conv->isPreview() ? ' preview ' : '',
 			'wait'            => DI::l10n()->t('Please wait'),

--- a/src/Object/Post.php
+++ b/src/Object/Post.php
@@ -393,9 +393,9 @@ class Post
 		}
 
 		// Fetching of Diaspora posts doesn't always work. There are issues with reshares and possibly comments
-		if (($item['network'] != Protocol::DIASPORA) && empty($comment) && !empty(Session::get('remote_follow'))) {
+		if (($item['network'] != Protocol::DIASPORA) && empty($comment) && !empty(Session::get('remote_comment'))) {
 			$remote_comment = [DI::l10n()->t('Comment this item on your system'), DI::l10n()->t('remote comment'),
-				str_replace('{uri}', urlencode($item['uri']), Session::get('remote_follow'))];
+				str_replace('{uri}', urlencode($item['uri']), Session::get('remote_comment'))];
 		} else {
 			$remote_comment = '';
 		}

--- a/view/templates/wall_thread.tpl
+++ b/view/templates/wall_thread.tpl
@@ -83,6 +83,9 @@
 				<img id="like-rotator-{{$item.id}}" class="like-rotator" src="images/rotator.gif" alt="{{$item.wait}}" title="{{$item.wait}}" style="display: none;" />
 			</div>
 			{{/if}}
+			{{if $item.remote_comment}}
+				<div class="wall-item-links-wrapper"><a href="{{$item.remote_comment.2}}" title="{{$item.remote_comment.0}}" target="_blank" class="icon remote-link{{$item.sparkle}} u-url"></a></div>
+			{{/if}}
 			{{if $item.plink}}
 				<div class="wall-item-links-wrapper"><a href="{{$item.plink.href}}" title="{{$item.plink.title}}" target="_blank" class="icon remote-link{{$item.sparkle}} u-url"></a></div>
 			{{/if}}

--- a/view/theme/frio/templates/wall_thread.tpl
+++ b/view/theme/frio/templates/wall_thread.tpl
@@ -287,6 +287,10 @@ as the value of $top_child_total (this is done at the end of this file)
 				{{/if}}
 			{{/if}}
 
+			{{if $item.remote_comment}}
+				<a href="{{$item.remote_comment.2}}" class="btn-link button-comments" title="{{$item.remote_comment.0}}"><i class="fa fa-commenting" aria-hidden="true"></i>&nbsp;{{$item.remote_comment.1}}</a>
+			{{/if}}
+
 			{{* Button to open the comment text field *}}
 			{{if $item.comment}}
 				<button type="button" class="btn-link button-comments" id="comment-{{$item.id}}" title="{{$item.switchcomment}}" {{if $item.thread_level != 1}}onclick="openClose('item-comments-{{$item.id}}'); commentExpand({{$item.id}});" {{else}} onclick="openClose('item-comments-{{$item.id}}'); commentExpand({{$item.id}});"{{/if}}><i class="fa fa-commenting" aria-hidden="true"></i>&nbsp;{{$item.switchcomment}}</button>

--- a/view/theme/quattro/templates/wall_thread.tpl
+++ b/view/theme/quattro/templates/wall_thread.tpl
@@ -113,6 +113,10 @@
                                 <a href="#" id="filer-{{$item.id}}" onclick="itemFiler({{$item.id}}); return false;" class="filer-item filer-icon" title="{{$item.filer}}">{{$item.filer}}</a>
 			{{/if}}
 
+			{{if $item.remote_comment}}
+				<a title="{{$item.remote_comment.0}}" href="{{$item.remote_comment.2}}">{{$item.remote_comment.1}}</a>
+			{{/if}}
+
 			{{if $item.vote}}
 				<a href="#" id="like-{{$item.id}}"{{if $item.responses.like.self}} class="active{{/if}}" title="{{$item.vote.like.0}}" onclick="dolike({{$item.id}},'like'); return false">{{$item.vote.like.1}}</a>
 				{{if $item.vote.dislike}}

--- a/view/theme/vier/templates/wall_thread.tpl
+++ b/view/theme/vier/templates/wall_thread.tpl
@@ -102,6 +102,10 @@
 			<div class="wall-item-actions-social">
 			{{if $item.threaded}}
 			{{/if}}
+			{{if $item.remote_comment}}
+				<a role="button" title="{{$item.remote_comment.0}}" href="{{$item.remote_comment.2}}"><i class="icon-commenting"><span class="sr-only">{{$item.remote_comment.1}}</span></i></a>
+			{{/if}}
+
 			{{if $item.comment}}
 				<a role="button" id="comment-{{$item.id}}" class="fakelink togglecomment" onclick="openClose('item-comments-{{$item.id}}'); commentExpand({{$item.id}});" title="{{$item.switchcomment}}"><i class="icon-commenting"><span class="sr-only">{{$item.switchcomment}}</span></i></a>
 			{{/if}}


### PR DESCRIPTION
When authenticated, we now display a link for each post to load it on the visitor's system. So people can easily comment even on posts that aren't currently available on the system.

Since there are issues with Diaspora, this is currently not activated for this protocol. Also this only works if the visitor's system is on the develop branch.