### PR TITLE
Combine network information with link to original post

### DIFF
--- a/view/theme/frio/templates/wall_thread.tpl
+++ b/view/theme/frio/templates/wall_thread.tpl
@@ -209,17 +209,10 @@ as the value of $top_child_total (this is done at the end of this file)
 		{{/if}}
 
 		<div class="preferences">
-		{{if $item.network_icon != ""}}
-			<span class="wall-item-network"><i class="fa fa-{{$item.network_icon}}" title="{{$item.network_name}}" aria-hidden="true"></i></span>
-		{{else}}
-			<span class="wall-item-network" title="{{$item.app}}">{{$item.network_name}}</span>
-		{{/if}}
-		{{if $item.plink}}	{{*link to the original source of the item *}}
-			&nbsp;
-			<a href="{{$item.plink.href}}" class="plink u-url" aria-label="{{$item.plink.title}}" title="{{$item.plink.title}}">
-				<i class="fa fa-external-link"></i>
+			{{*link to the original source of the item *}}
+			<a href="{{$item.plink.href}}" class="plink u-url" aria-label="{{$item.plink.title}}">
+				<span class="wall-item-network"><i class="fa fa-{{$item.network_icon}}" title="{{$item.network_name}}" aria-hidden="true"></i></span>
 			</a>
-		{{/if}}
 		</div>
 
 		<div class="clearfix"></div>


### PR DESCRIPTION
Instead of:
![grafik](https://user-images.githubusercontent.com/844208/74772638-ae399900-5290-11ea-8964-e209ac6dbb8e.png)

we now display this:
![grafik](https://user-images.githubusercontent.com/844208/74772545-80545480-5290-11ea-8155-72baec6adfe8.png)

And the icon is clickable.