### PR TITLE
Some more unneeded settings removed

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -340,10 +340,6 @@ function info($s)
 {
 	$a = DI::app();
 
-	if (local_user() && DI::pConfig()->get(local_user(), 'system', 'ignore_info')) {
-		return;
-	}
-
 	if (empty($_SESSION['sysmsg_info'])) {
 		$_SESSION['sysmsg_info'] = [];
 	}

--- a/mod/network.php
+++ b/mod/network.php
@@ -501,13 +501,6 @@ function networkThreadedView(App $a, $update, $parent)
 		$tabs = network_tabs($a);
 		$o .= $tabs;
 
-		if ($gid && ($t = Contact::getOStatusCountByGroupId($gid)) && !DI::pConfig()->get(local_user(), 'system', 'nowarn_insecure')) {
-			notice(DI::l10n()->tt("Warning: This group contains %s member from a network that doesn't allow non public messages.",
-				"Warning: This group contains %s members from a network that doesn't allow non public messages.",
-				$t) . EOL);
-			notice(DI::l10n()->t("Messages in this group won't be send to these receivers.").EOL);
-		}
-
 		Nav::setSelected('network');
 
 		$content = '';
@@ -621,10 +614,6 @@ function networkThreadedView(App $a, $update, $parent)
 				'contacts' => $entries,
 				'id' => 'network',
 			]) . $o;
-
-			if ($contact['network'] === Protocol::OSTATUS && $contact['writable'] && !DI::pConfig()->get(local_user(),'system','nowarn_insecure')) {
-				notice(DI::l10n()->t('Private messages to this person are at risk of public disclosure.') . EOL);
-			}
 		} else {
 			notice(DI::l10n()->t('Invalid contact.') . EOL);
 			DI::baseUrl()->redirect('network');

--- a/mod/settings.php
+++ b/mod/settings.php
@@ -342,12 +342,9 @@ function settings_post(App $a)
 		$mobile_theme       = !empty($_POST['mobile_theme'])       ? Strings::escapeTags(trim($_POST['mobile_theme'])) : '';
 		$nosmile            = !empty($_POST['nosmile'])            ? intval($_POST['nosmile'])            : 0;
 		$first_day_of_week  = !empty($_POST['first_day_of_week'])  ? intval($_POST['first_day_of_week'])  : 0;
-		$noinfo             = !empty($_POST['noinfo'])             ? intval($_POST['noinfo'])             : 0;
 		$infinite_scroll    = !empty($_POST['infinite_scroll'])    ? intval($_POST['infinite_scroll'])    : 0;
 		$no_auto_update     = !empty($_POST['no_auto_update'])     ? intval($_POST['no_auto_update'])     : 0;
-		$bandwidth_saver    = !empty($_POST['bandwidth_saver'])    ? intval($_POST['bandwidth_saver'])    : 0;
 		$no_smart_threading = !empty($_POST['no_smart_threading']) ? intval($_POST['no_smart_threading']) : 0;
-		$nowarn_insecure    = !empty($_POST['nowarn_insecure'])    ? intval($_POST['nowarn_insecure'])    : 0;
 		$browser_update     = !empty($_POST['browser_update'])     ? intval($_POST['browser_update'])     : 0;
 		if ($browser_update != -1) {
 			$browser_update = $browser_update * 1000;
@@ -373,16 +370,13 @@ function settings_post(App $a)
 			DI::pConfig()->set(local_user(), 'system', 'mobile_theme', $mobile_theme);
 		}
 
-		DI::pConfig()->set(local_user(), 'system', 'nowarn_insecure'         , $nowarn_insecure);
 		DI::pConfig()->set(local_user(), 'system', 'update_interval'         , $browser_update);
 		DI::pConfig()->set(local_user(), 'system', 'itemspage_network'       , $itemspage_network);
 		DI::pConfig()->set(local_user(), 'system', 'itemspage_mobile_network', $itemspage_mobile_network);
 		DI::pConfig()->set(local_user(), 'system', 'no_smilies'              , $nosmile);
 		DI::pConfig()->set(local_user(), 'system', 'first_day_of_week'       , $first_day_of_week);
-		DI::pConfig()->set(local_user(), 'system', 'ignore_info'             , $noinfo);
 		DI::pConfig()->set(local_user(), 'system', 'infinite_scroll'         , $infinite_scroll);
 		DI::pConfig()->set(local_user(), 'system', 'no_auto_update'          , $no_auto_update);
-		DI::pConfig()->set(local_user(), 'system', 'bandwidth_saver'         , $bandwidth_saver);
 		DI::pConfig()->set(local_user(), 'system', 'no_smart_threading'      , $no_smart_threading);
 
 		if (in_array($theme, Theme::getAllowedList())) {
@@ -931,8 +925,6 @@ function settings_content(App $a)
 		$theme_selected        = $a->user['theme'] ?: $default_theme;
 		$mobile_theme_selected = Session::get('mobile-theme', $default_mobile_theme);
 
-		$nowarn_insecure = intval(DI::pConfig()->get(local_user(), 'system', 'nowarn_insecure'));
-
 		$browser_update = intval(DI::pConfig()->get(local_user(), 'system', 'update_interval'));
 		if (intval($browser_update) != -1) {
 			$browser_update = (($browser_update == 0) ? 40 : $browser_update / 1000); // default if not set: 40 seconds
@@ -947,10 +939,8 @@ function settings_content(App $a)
 		$first_day_of_week = DI::pConfig()->get(local_user(), 'system', 'first_day_of_week', 0);
 		$weekdays = [0 => DI::l10n()->t("Sunday"), 1 => DI::l10n()->t("Monday")];
 
-		$noinfo = DI::pConfig()->get(local_user(), 'system', 'ignore_info', 0);
 		$infinite_scroll = DI::pConfig()->get(local_user(), 'system', 'infinite_scroll', 0);
 		$no_auto_update = DI::pConfig()->get(local_user(), 'system', 'no_auto_update', 0);
-		$bandwidth_saver = DI::pConfig()->get(local_user(), 'system', 'bandwidth_saver', 0);
 		$no_smart_threading = DI::pConfig()->get(local_user(), 'system', 'no_smart_threading', 0);
 
 		$theme_config = "";
@@ -969,17 +959,14 @@ function settings_content(App $a)
 
 			'$theme'	=> ['theme', DI::l10n()->t('Display Theme:'), $theme_selected, '', $themes, true],
 			'$mobile_theme'	=> ['mobile_theme', DI::l10n()->t('Mobile Theme:'), $mobile_theme_selected, '', $mobile_themes, false],
-			'$nowarn_insecure' => ['nowarn_insecure',  DI::l10n()->t('Suppress warning of insecure networks'), $nowarn_insecure, DI::l10n()->t("Should the system suppress the warning that the current group contains members of networks that can't receive non public postings.")],
 			'$ajaxint'   => ['browser_update',  DI::l10n()->t("Update browser every xx seconds"), $browser_update, DI::l10n()->t('Minimum of 10 seconds. Enter -1 to disable it.')],
 			'$itemspage_network'   => ['itemspage_network',  DI::l10n()->t("Number of items to display per page:"), $itemspage_network, DI::l10n()->t('Maximum of 100 items')],
 			'$itemspage_mobile_network'   => ['itemspage_mobile_network',  DI::l10n()->t("Number of items to display per page when viewed from mobile device:"), $itemspage_mobile_network, DI::l10n()->t('Maximum of 100 items')],
-			'$nosmile'	=> ['nosmile', DI::l10n()->t("Don't show emoticons"), $nosmile, ''],
+			'$nosmile'	=> ['nosmile', DI::l10n()->t("Don't show emoticons"), $nosmile, DI::l10n()->t('Normally emoticons are replaced with matching symbols. This setting disables this behaviour.')],
 			'$calendar_title' => DI::l10n()->t('Calendar'),
 			'$first_day_of_week'	=> ['first_day_of_week', DI::l10n()->t('Beginning of week:'), $first_day_of_week, '', $weekdays, false],
-			'$noinfo'	=> ['noinfo', DI::l10n()->t("Don't show notices"), $noinfo, ''],
-			'$infinite_scroll'	=> ['infinite_scroll', DI::l10n()->t("Infinite scroll"), $infinite_scroll, ''],
+			'$infinite_scroll'	=> ['infinite_scroll', DI::l10n()->t("Infinite scroll"), $infinite_scroll, DI::l10n()->t('Automatic add new items when reaching the page end.')],
 			'$no_auto_update'	=> ['no_auto_update', DI::l10n()->t("Automatic updates only at the top of the network page"), $no_auto_update, DI::l10n()->t('When disabled, the network page is updated all the time, which could be confusing while reading.')],
-			'$bandwidth_saver' => ['bandwidth_saver', DI::l10n()->t('Bandwidth Saver Mode'), $bandwidth_saver, DI::l10n()->t('When enabled, embedded content is not displayed on automatic updates, they only show on page reload.')],
 			'$no_smart_threading' => ['no_smart_threading', DI::l10n()->t('Disable Smart Threading'), $no_smart_threading, DI::l10n()->t('Disable the automatic suppression of extraneous thread indentation.')],
 
 			'$d_tset' => DI::l10n()->t('General Theme Settings'),
@@ -1021,8 +1008,6 @@ function settings_content(App $a)
 	$expire_starred = DI::pConfig()->get(local_user(), 'expire', 'starred', true);
 	$expire_photos = DI::pConfig()->get(local_user(), 'expire', 'photos', false);
 	$expire_network_only = DI::pConfig()->get(local_user(), 'expire', 'network_only', false);
-
-	// nowarn_insecure
 
 	if (!strlen($a->user['timezone'])) {
 		$timezone = date_default_timezone_get();

--- a/mod/settings.php
+++ b/mod/settings.php
@@ -965,7 +965,7 @@ function settings_content(App $a)
 			'$nosmile'	=> ['nosmile', DI::l10n()->t("Don't show emoticons"), $nosmile, DI::l10n()->t('Normally emoticons are replaced with matching symbols. This setting disables this behaviour.')],
 			'$calendar_title' => DI::l10n()->t('Calendar'),
 			'$first_day_of_week'	=> ['first_day_of_week', DI::l10n()->t('Beginning of week:'), $first_day_of_week, '', $weekdays, false],
-			'$infinite_scroll'	=> ['infinite_scroll', DI::l10n()->t("Infinite scroll"), $infinite_scroll, DI::l10n()->t('Automatic add new items when reaching the page end.')],
+			'$infinite_scroll'	=> ['infinite_scroll', DI::l10n()->t("Infinite scroll"), $infinite_scroll, DI::l10n()->t('Automatic fetch new items when reaching the page end.')],
 			'$no_auto_update'	=> ['no_auto_update', DI::l10n()->t("Automatic updates only at the top of the network page"), $no_auto_update, DI::l10n()->t('When disabled, the network page is updated all the time, which could be confusing while reading.')],
 			'$no_smart_threading' => ['no_smart_threading', DI::l10n()->t('Disable Smart Threading'), $no_smart_threading, DI::l10n()->t('Disable the automatic suppression of extraneous thread indentation.')],
 

--- a/src/Core/System.php
+++ b/src/Core/System.php
@@ -299,18 +299,6 @@ class System
 	 */
 	public static function htmlUpdateExit($o)
 	{
-		if (DI::pConfig()->get(local_user(), "system", "bandwidth_saver")) {
-			$replace = "<br />".DI::l10n()->t("[Embedded content - reload page to view]")."<br />";
-			$pattern = "/<\s*audio[^>]*>(.*?)<\s*\/\s*audio>/i";
-			$o = preg_replace($pattern, $replace, $o);
-			$pattern = "/<\s*video[^>]*>(.*?)<\s*\/\s*video>/i";
-			$o = preg_replace($pattern, $replace, $o);
-			$pattern = "/<\s*embed[^>]*>(.*?)<\s*\/\s*embed>/i";
-			$o = preg_replace($pattern, $replace, $o);
-			$pattern = "/<\s*iframe[^>]*>(.*?)<\s*\/\s*iframe>/i";
-			$o = preg_replace($pattern, $replace, $o);
-		}
-
 		header("Content-type: text/html");
 		echo "<!DOCTYPE html><html><body>\r\n";
 		// We can remove this hack once Internet Explorer recognises HTML5 natively

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -641,35 +641,6 @@ class Contact
 	}
 
 	/**
-	 * Returns the count of OStatus contacts in a group
-	 *
-	 * @param int $gid
-	 * @return int
-	 * @throws \Exception
-	 */
-	public static function getOStatusCountByGroupId($gid)
-	{
-		$return = 0;
-		if (intval($gid)) {
-			$contacts = DBA::fetchFirst('SELECT COUNT(*) AS `count`
-				FROM `contact`
-				INNER JOIN `group_member`
-					ON `contact`.`id` = `group_member`.`contact-id`
-				WHERE `gid` = ?
-				AND `contact`.`uid` = ?
-				AND `contact`.`network` = ?
-				AND `contact`.`notify` != ""',
-				$gid,
-				local_user(),
-				Protocol::OSTATUS
-			);
-			$return = $contacts['count'];
-		}
-
-		return $return;
-	}
-
-	/**
 	 * Creates the self-contact for the provided user id
 	 *
 	 * @param int $uid

--- a/view/templates/settings/display.tpl
+++ b/view/templates/settings/display.tpl
@@ -14,12 +14,9 @@
 
 {{include file="field_input.tpl" field=$itemspage_mobile_network}}
 {{include file="field_input.tpl" field=$ajaxint}}
-{{include file="field_checkbox.tpl" field=$nowarn_insecure}}
 {{include file="field_checkbox.tpl" field=$no_auto_update}}
 {{include file="field_checkbox.tpl" field=$nosmile}}
-{{include file="field_checkbox.tpl" field=$noinfo}}
 {{include file="field_checkbox.tpl" field=$infinite_scroll}}
-{{include file="field_checkbox.tpl" field=$bandwidth_saver}}
 {{include file="field_checkbox.tpl" field=$no_smart_threading}}
 <h2>{{$calendar_title}}</h2>
 {{include file="field_select.tpl" field=$first_day_of_week}}

--- a/view/theme/frio/templates/settings/display.tpl
+++ b/view/theme/frio/templates/settings/display.tpl
@@ -69,12 +69,9 @@
 						{{include file="field_input.tpl" field=$itemspage_network}}
 						{{include file="field_input.tpl" field=$itemspage_mobile_network}}
 						{{include file="field_input.tpl" field=$ajaxint}}
-						{{include file="field_checkbox.tpl" field=$nowarn_insecure}}
 						{{include file="field_checkbox.tpl" field=$no_auto_update}}
 						{{include file="field_checkbox.tpl" field=$nosmile}}
-						{{include file="field_checkbox.tpl" field=$noinfo}}
 						{{include file="field_checkbox.tpl" field=$infinite_scroll}}
-						{{include file="field_checkbox.tpl" field=$bandwidth_saver}}
 						{{include file="field_checkbox.tpl" field=$no_smart_threading}}
 
 						<div class="form-group pull-right settings-submit-wrapper" >


### PR DESCRIPTION
This PR removes three different "display" settings:

1. The "bandwidth saver" doesn't make no sense, since it forces the user to reload the content - which increases the bandwith usage.
2. The warning for insecure networks contained some check for OStatus contacts and didn't make that much sense, since there never had been the danger to disclose private content to OStatus contacts.
3. The option to ignore "info" messages is removed as well, since it was most likely a reaction to being flooded with messages all the time (like the one above)

See discussion here: https://forum.friendi.ca/display/ec054ce7-365e-4d36-5c14-0a0309965951