### PR TITLE
Remove unused conversation response code

### DIFF
--- a/include/conversation.php
+++ b/include/conversation.php
@@ -579,12 +579,11 @@ function conversation(App $a, array $items, $mode, $update, $preview = false, $o
 	$items = $cb['items'];
 
 	$conv_responses = [
-		'like' => ['title' => DI::l10n()->t('Likes','title')],
-		'dislike' => ['title' => DI::l10n()->t('Dislikes','title')],
-		'attendyes' => ['title' => DI::l10n()->t('Attending','title')],
-		'attendno' => ['title' => DI::l10n()->t('Not attending','title')],
-		'attendmaybe' => ['title' => DI::l10n()->t('Might attend','title')],
-		'announce' => ['title' => DI::l10n()->t('Reshares','title')]
+		'like'        => [],
+		'dislike'     => [],
+		'attendyes'   => [],
+		'attendno'    => [],
+		'attendmaybe' => []
 	];
 
 	if (DI::pConfig()->get(local_user(), 'system', 'hide_dislike')) {
@@ -1571,57 +1570,4 @@ function render_location_dummy(array $item) {
 	if (!empty($item['coord']) && !empty($item['coord'])) {
 		return $item['coord'];
 	}
-}
-
-function get_responses(array $conv_responses, array $response_verbs, array $item, Post $ob = null) {
-	$ret = [];
-	foreach ($response_verbs as $v) {
-		$ret[$v] = [];
-		$ret[$v]['count'] = $conv_responses[$v][$item['uri']] ?? 0;
-		$ret[$v]['list']  = $conv_responses[$v][$item['uri'] . '-l'] ?? [];
-		$ret[$v]['self']  = $conv_responses[$v][$item['uri'] . '-self'] ?? '0';
-		if (count($ret[$v]['list']) > MAX_LIKERS) {
-			$ret[$v]['list_part'] = array_slice($ret[$v]['list'], 0, MAX_LIKERS);
-			array_push($ret[$v]['list_part'], '<a href="#" data-toggle="modal" data-target="#' . $v . 'Modal-'
-				. (($ob) ? $ob->getId() : $item['id']) . '"><b>' . DI::l10n()->t('View all') . '</b></a>');
-		} else {
-			$ret[$v]['list_part'] = '';
-		}
-		$ret[$v]['button'] = get_response_button_text($v, $ret[$v]['count']);
-		$ret[$v]['title'] = $conv_responses[$v]['title'];
-	}
-
-	$count = 0;
-	foreach ($ret as $key) {
-		if ($key['count'] == true) {
-			$count++;
-		}
-	}
-	$ret['count'] = $count;
-
-	return $ret;
-}
-
-function get_response_button_text($v, $count)
-{
-	$return = '';
-	switch ($v) {
-		case 'like':
-			$return = DI::l10n()->tt('Like', 'Likes', $count);
-			break;
-		case 'dislike':
-			$return = DI::l10n()->tt('Dislike', 'Dislikes', $count);
-			break;
-		case 'attendyes':
-			$return = DI::l10n()->tt('Attending', 'Attending', $count);
-			break;
-		case 'attendno':
-			$return = DI::l10n()->tt('Not Attending', 'Not Attending', $count);
-			break;
-		case 'attendmaybe':
-			$return = DI::l10n()->tt('Undecided', 'Undecided', $count);
-			break;
-	}
-
-	return $return;
 }

--- a/mod/photos.php
+++ b/mod/photos.php
@@ -1412,11 +1412,11 @@ function photos_content(App $a)
 			}
 
 			$conv_responses = [
-				'like'        => ['title' => DI::l10n()->t('Likes','title')],
-				'dislike'     => ['title' => DI::l10n()->t('Dislikes','title')],
-				'attendyes'   => ['title' => DI::l10n()->t('Attending','title')],
-				'attendno'    => ['title' => DI::l10n()->t('Not attending','title')],
-				'attendmaybe' => ['title' => DI::l10n()->t('Might attend','title')]
+				'like'        => [],
+				'dislike'     => [],
+				'attendyes'   => [],
+				'attendno'    => [],
+				'attendmaybe' => []
 			];
 
 			if (DI::pConfig()->get(local_user(), 'system', 'hide_dislike')) {

--- a/mod/photos.php
+++ b/mod/photos.php
@@ -1372,7 +1372,6 @@ function photos_content(App $a)
 		$likebuttons = '';
 		$comments = '';
 		$paginate = '';
-		$responses = '';
 
 		if (!empty($link_item['id']) && !empty($link_item['uri'])) {
 			$cmnt_tpl = Renderer::getMarkupTemplate('comment_item.tpl');
@@ -1460,7 +1459,6 @@ function photos_content(App $a)
 				foreach ($items as $item) {
 					$comment = '';
 					$template = $tpl;
-					$sparkle = '';
 
 					$activity = DI::activity();
 
@@ -1523,8 +1521,6 @@ function photos_content(App $a)
 				}
 			}
 
-			$responses = get_responses($conv_responses, ['like', 'dislike'], $link_item);
-
 			$paginate = $pager->renderFull($total);
 		}
 
@@ -1544,7 +1540,6 @@ function photos_content(App $a)
 			'$likebuttons' => $likebuttons,
 			'$like' => $like,
 			'$dislike' => $dislike,
-			'responses' => $responses,
 			'$comments' => $comments,
 			'$paginate' => $paginate,
 		]);

--- a/src/Content/BoundariesPager.php
+++ b/src/Content/BoundariesPager.php
@@ -57,7 +57,7 @@ class BoundariesPager extends Pager
 		$this->last_item_id = $last_item_id;
 
 		$parsed = parse_url($this->getBaseQueryString());
-		if ($parsed) {
+		if (!empty($parsed['query'])) {
 			parse_str($parsed['query'], $queryParameters);
 
 			$this->first_page = !($queryParameters['since_id'] ?? null) && !($queryParameters['max_id'] ?? null);

--- a/src/Object/Post.php
+++ b/src/Object/Post.php
@@ -272,10 +272,12 @@ class Post
 			}
 		}
 
-		$responses = get_responses($conv_responses, $response_verbs, $item, $this);
-
-		foreach ($response_verbs as $value => $verbs) {
-			$responses[$verbs]['output'] = !empty($conv_responses[$verbs][$item['uri']]) ? format_like($conv_responses[$verbs][$item['uri']], $conv_responses[$verbs][$item['uri'] . '-l'], $verbs, $item['uri']) : '';
+		$responses = [];
+		foreach ($response_verbs as $value => $verb) {
+			$responses[$verb] = [
+				'self'   => $conv_responses[$verb][$item['uri'] . '-self'] ?? 0,
+				'output' => !empty($conv_responses[$verb][$item['uri']]) ? format_like($conv_responses[$verb][$item['uri']], $conv_responses[$verb][$item['uri'] . '-l'], $verb, $item['uri']) : '',
+			];
 		}
 
 		/*

--- a/src/Object/Thread.php
+++ b/src/Object/Thread.php
@@ -34,6 +34,7 @@ use Friendica\Util\Security;
  */
 class Thread
 {
+	/** @var Post[] */
 	private $parents = [];
 	private $mode = null;
 	private $writable = false;


### PR DESCRIPTION
Address https://github.com/friendica/friendica/issues/8000#issuecomment-587138376
Address https://github.com/friendica/friendica/issues/8000#issuecomment-589263329

This PR touches a part of Friendica I've always wanted to redo because it's hard to understand but it was working so I didn't: the conversation responses. Until today, when this notice has been the perfect pretext to cull it to its bare use. It still is unsatisfactory, but it is less of a code wart now.