### PR TITLE
Fix external link inconsistency part 1: Remove insecure target="_blank" attributes

### DIFF
--- a/doc/BBCode.md
+++ b/doc/BBCode.md
@@ -113,17 +113,17 @@ table.bbcodes > * > tr > th {
 <tr>
   <td>[bookmark]http://friendi.ca[/bookmark]<br><br>
 #^[url]http://friendi.ca[/url]</td>
-  <td><span class="oembed link"><h4>Friendica: <a href="http://friendi.ca" rel="oembed"></a><a href="http://friendi.ca" target="_blank">http://friendi.ca</a></h4></span></td>
+  <td><span class="oembed link"><h4>Friendica: <a href="http://friendi.ca" rel="oembed"></a><a href="http://friendi.ca">http://friendi.ca</a></h4></span></td>
 </tr>
 <tr>
   <td>[bookmark=http://friendi.ca]Bookmark[/bookmark]<br><br>
 #^[url=http://friendi.ca]Bookmark[/url]<br><br>
 #[url=http://friendi.ca]^[/url][url=http://friendi.ca]Bookmark[/url]</td>
-  <td><span class="oembed link"><h4>Friendica: <a href="http://friendi.ca" rel="oembed"></a><a href="http://friendi.ca" target="_blank">Bookmark</a></h4></span></td>
+  <td><span class="oembed link"><h4>Friendica: <a href="http://friendi.ca" rel="oembed"></a><a href="http://friendi.ca">Bookmark</a></h4></span></td>
 </tr>
 <tr>
   <td>[url=/posts/f16d77b0630f0134740c0cc47a0ea02a]Diaspora post with GUID[/url]</td>
-  <td><a href="/display/f16d77b0630f0134740c0cc47a0ea02a" target="_blank">Diaspora post with GUID</a></td>
+  <td><a href="/display/f16d77b0630f0134740c0cc47a0ea02a">Diaspora post with GUID</a></td>
 </tr>
 <tr>
   <td>#Friendica</td>

--- a/doc/de/BBCode.md
+++ b/doc/de/BBCode.md
@@ -113,17 +113,17 @@ table.bbcodes > * > tr > th {
 <tr>
   <td>[bookmark]http://friendi.ca[/bookmark]<br><br>
 #^[url]http://friendi.ca[/url]</td>
-  <td><span class="oembed link"><h4>Friendica: <a href="http://friendi.ca" rel="oembed"></a><a href="http://friendi.ca" target="_blank">http://friendi.ca</a></h4></span></td>
+  <td><span class="oembed link"><h4>Friendica: <a href="http://friendi.ca" rel="oembed"></a><a href="http://friendi.ca">http://friendi.ca</a></h4></span></td>
 </tr>
 <tr>
   <td>[bookmark=http://friendi.ca]Lesezeichen[/bookmark]<br><br>
 #^[url=http://friendi.ca]Lesezeichen[/url]<br><br>
 #[url=http://friendi.ca]^[/url][url=http://friendi.ca]Lesezeichen[/url]</td>
-  <td><span class="oembed link"><h4>Friendica: <a href="http://friendi.ca" rel="oembed"></a><a href="http://friendi.ca" target="_blank">Lesezeichen</a></h4></span></td>
+  <td><span class="oembed link"><h4>Friendica: <a href="http://friendi.ca" rel="oembed"></a><a href="http://friendi.ca">Lesezeichen</a></h4></span></td>
 </tr>
 <tr>
   <td>[url=/posts/f16d77b0630f0134740c0cc47a0ea02a]Diaspora Beitrag mit GUID[/url]</td>
-  <td><a href="/display/f16d77b0630f0134740c0cc47a0ea02a" target="_blank">Diaspora Beitrag mit GUID</a></td>
+  <td><a href="/display/f16d77b0630f0134740c0cc47a0ea02a">Diaspora Beitrag mit GUID</a></td>
 </tr>
 <tr>
   <td>#Friendica</td>

--- a/doc/de/Chats.md
+++ b/doc/de/Chats.md
@@ -25,13 +25,13 @@ In den ersten Zeilen wird Dir Dein Name und Deine aktuelle IP-Adresse angezeigt.
 Rechts im Fenster siehst Du alle Teilnehmer des Chats.
 Unten hast Du ein Eingabefeld, um Beiträge zu schreiben.
 
-Weiter Informationen zu IRC findest Du zum Beispiel auf <a href="http://wiki.ubuntuusers.de/IRC" target="_blank">ubuntuusers.de</a>, in <a href="https://de.wikipedia.org/wiki/Internet_Relay_Chat" target="_blank">Wikipedia</a> oder bei <a href="http://www.irchelp.org/" target="_blank">icrhelp.org</a> (in Englisch).
+Weiter Informationen zu IRC findest Du zum Beispiel auf <a href="http://wiki.ubuntuusers.de/IRC">ubuntuusers.de</a>, in <a href="https://de.wikipedia.org/wiki/Internet_Relay_Chat">Wikipedia</a> oder bei <a href="http://www.irchelp.org/">icrhelp.org</a> (in Englisch).
 
 ## Jappix Mini
 
 Das Jappix Mini Addon erlaubt das Erstellen einer Chatbox für Jabber/XMPP-Kontakte.
 Ein Jabber/XMPP Account sollte vor der Installation bereits vorhanden sein.
-Die ausführliche Anleitung dazu und eine Kontrolle, ob Du nicht sogar schon über Deinen E-Mail Anbieter einen Jabber-Account hast, findest Du unter <a href="http://einfachjabber.de" target="_blank">einfachjabber.de</a>.
+Die ausführliche Anleitung dazu und eine Kontrolle, ob Du nicht sogar schon über Deinen E-Mail Anbieter einen Jabber-Account hast, findest Du unter <a href="http://einfachjabber.de">einfachjabber.de</a>.
 
 Einige Server zum Anmelden eines neuen Accounts:
 

--- a/doc/de/Developers.md
+++ b/doc/de/Developers.md
@@ -26,4 +26,4 @@ Dies gilt vor allem für Übersetzungen, da wir hier möglicherweise nicht alle 
 Außerdem: **teste Deine Änderungen!** Vergiss nicht, dass eine simple Fehlerlösung einen anderen Fehler auslösen kann.
 Lass Deine Änderungen von einem erfahrenen Friendica-Entwickler gegenprüfen.
 
-Eine ausführliche Anleitung zu Git findest Du unter <a href="https://git-scm.com/book/de/v1" target="_blank">https://git-scm.com/book/de/v1</a>.
+Eine ausführliche Anleitung zu Git findest Du unter <a href="https://git-scm.com/book/de/v1">https://git-scm.com/book/de/v1</a>.

--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -634,12 +634,12 @@ class BBCode
 
 			if (!empty($data['title']) && !empty($data['url'])) {
 				if (!empty($data['image']) && empty($data['text']) && ($data['type'] == 'photo')) {
-					$return .= sprintf('<a href="%s" target="_blank"><img src="%s" alt="" title="%s" class="attachment-image" /></a>', $data['url'], self::proxyUrl($data['image'], $simplehtml), $data['title']);
+					$return .= sprintf('<a href="%s"><img src="%s" alt="" title="%s" class="attachment-image" /></a>', $data['url'], self::proxyUrl($data['image'], $simplehtml), $data['title']);
 				} else {
 					if (!empty($data['image'])) {
-						$return .= sprintf('<a href="%s" target="_blank"><img src="%s" alt="" title="%s" class="attachment-image" /></a><br />', $data['url'], self::proxyUrl($data['image'], $simplehtml), $data['title']);
+						$return .= sprintf('<a href="%s"><img src="%s" alt="" title="%s" class="attachment-image" /></a><br />', $data['url'], self::proxyUrl($data['image'], $simplehtml), $data['title']);
 					} elseif (!empty($data['preview'])) {
-						$return .= sprintf('<a href="%s" target="_blank"><img src="%s" alt="" title="%s" class="attachment-preview" /></a><br />', $data['url'], self::proxyUrl($data['preview'], $simplehtml), $data['title']);
+						$return .= sprintf('<a href="%s"><img src="%s" alt="" title="%s" class="attachment-preview" /></a><br />', $data['url'], self::proxyUrl($data['preview'], $simplehtml), $data['title']);
 					}
 					$return .= sprintf('<h4><a href="%s">%s</a></h4>', $data['url'], $data['title']);
 				}
@@ -732,7 +732,7 @@ class BBCode
 	 */
 	private static function convertUrlForActivityPub($url)
 	{
-		$html = '<a href="%s" target="_blank">%s</a>';
+		$html = '<a href="%s">%s</a>';
 		return sprintf($html, $url, self::getStyledURL($url));
 	}
 
@@ -1038,7 +1038,7 @@ class BBCode
 				break;
 			case 4:
 				$headline = '<p><b>' . html_entity_decode('&#x2672; ', ENT_QUOTES, 'UTF-8');
-				$headline .= DI::l10n()->t('<a href="%1$s" target="_blank">%2$s</a> %3$s', $attributes['link'], $mention, $attributes['posted']);
+				$headline .= DI::l10n()->t('<a href="%1$s">%2$s</a> %3$s', $attributes['link'], $mention, $attributes['posted']);
 				$headline .= ':</b></p>' . "\n";
 
 				$text = ($is_quote_share? '<hr />' : '') . $headline . '<blockquote class="shared_content">' . trim($content) . '</blockquote>' . "\n";
@@ -1636,9 +1636,9 @@ class BBCode
 			$text = preg_replace_callback("/\[audio\](.*?)\[\/audio\]/ism", $try_oembed_callback, $text);
 		} else {
 			$text = preg_replace("/\[video\](.*?)\[\/video\]/ism",
-				'<a href="$1" target="_blank">$1</a>', $text);
+				'<a href="$1">$1</a>', $text);
 			$text = preg_replace("/\[audio\](.*?)\[\/audio\]/ism",
-				'<a href="$1" target="_blank">$1</a>', $text);
+				'<a href="$1">$1</a>', $text);
 		}
 
 		// html5 video and audio
@@ -1665,7 +1665,7 @@ class BBCode
 			$text = preg_replace("/\[youtube\]([A-Za-z0-9\-_=]+)(.*?)\[\/youtube\]/ism", '<iframe width="' . $a->videowidth . '" height="' . $a->videoheight . '" src="https://www.youtube.com/embed/$1" frameborder="0" ></iframe>', $text);
 		} else {
 			$text = preg_replace("/\[youtube\]([A-Za-z0-9\-_=]+)(.*?)\[\/youtube\]/ism",
-				'<a href="https://www.youtube.com/watch?v=$1" target="_blank">https://www.youtube.com/watch?v=$1</a>', $text);
+				'<a href="https://www.youtube.com/watch?v=$1">https://www.youtube.com/watch?v=$1</a>', $text);
 		}
 
 		if ($try_oembed) {
@@ -1680,7 +1680,7 @@ class BBCode
 			$text = preg_replace("/\[vimeo\]([0-9]+)(.*?)\[\/vimeo\]/ism", '<iframe width="' . $a->videowidth . '" height="' . $a->videoheight . '" src="https://player.vimeo.com/video/$1" frameborder="0" ></iframe>', $text);
 		} else {
 			$text = preg_replace("/\[vimeo\]([0-9]+)(.*?)\[\/vimeo\]/ism",
-				'<a href="https://vimeo.com/$1" target="_blank">https://vimeo.com/$1</a>', $text);
+				'<a href="https://vimeo.com/$1">https://vimeo.com/$1</a>', $text);
 		}
 
 		// oembed tag
@@ -1801,17 +1801,17 @@ class BBCode
 				. '</a>';
 		}, $text);
 
-		// We need no target="_blank" for local links
-		// convert links start with DI::baseUrl() as local link without the target="_blank" attribute
+		// We need no for local links
+		// convert links start with DI::baseUrl() as local link without the attribute
 		$escapedBaseUrl = preg_quote(DI::baseUrl(), '/');
 		$text = preg_replace("/\[url\](".$escapedBaseUrl.".*?)\[\/url\]/ism", '<a href="$1">$1</a>', $text);
 		$text = preg_replace("/\[url\=(".$escapedBaseUrl.".*?)\](.*?)\[\/url\]/ism", '<a href="$1">$2</a>', $text);
 
-		$text = preg_replace("/\[url\](.*?)\[\/url\]/ism", '<a href="$1" target="_blank">$1</a>', $text);
-		$text = preg_replace("/\[url\=(.*?)\](.*?)\[\/url\]/ism", '<a href="$1" target="_blank">$2</a>', $text);
+		$text = preg_replace("/\[url\](.*?)\[\/url\]/ism", '<a href="$1">$1</a>', $text);
+		$text = preg_replace("/\[url\=(.*?)\](.*?)\[\/url\]/ism", '<a href="$1">$2</a>', $text);
 
 		// Red compatibility, though the link can't be authenticated on Friendica
-		$text = preg_replace("/\[zrl\=(.*?)\](.*?)\[\/zrl\]/ism", '<a href="$1" target="_blank">$2</a>', $text);
+		$text = preg_replace("/\[zrl\=(.*?)\](.*?)\[\/zrl\]/ism", '<a href="$1">$2</a>', $text);
 
 
 		// we may need to restrict this further if it picks up too many strays

--- a/src/Content/Text/HTML.php
+++ b/src/Content/Text/HTML.php
@@ -943,7 +943,7 @@ class HTML
 	 */
 	public static function toLink($s)
 	{
-		$s = preg_replace("/(https?\:\/\/[a-zA-Z0-9\:\/\-\?\&\;\.\=\_\~\#\'\%\$\!\+]*)/", ' <a href="$1" target="_blank">$1</a>', $s);
+		$s = preg_replace("/(https?\:\/\/[a-zA-Z0-9\:\/\-\?\&\;\.\=\_\~\#\'\%\$\!\+]*)/", ' <a href="$1">$1</a>', $s);
 		$s = preg_replace("/\<(.*?)(src|href)=(.*?)\&amp\;(.*?)\>/ism", '<$1$2=$3&$4>', $s);
 		return $s;
 	}

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -3630,7 +3630,7 @@ class Item
 			$title .= ' ' . $mtch[2] . ' ' . DI::l10n()->t('bytes');
 
 			$icon = '<div class="attachtype icon s22 type-' . $filetype . ' subtype-' . $filesubtype . '"></div>';
-			$as .= '<a href="' . strip_tags($the_url) . '" title="' . $title . '" class="attachlink" target="_blank" >' . $icon . '</a>';
+			$as .= '<a href="' . strip_tags($the_url) . '" title="' . $title . '" class="attachlink">' . $icon . '</a>';
 		}
 
 		if ($as != '') {

--- a/src/Model/Term.php
+++ b/src/Model/Term.php
@@ -462,13 +462,13 @@ class Term
 						$item['body'] = str_replace($orig_tag, $tag['url'], $item['body']);
 					}
 
-					$return['hashtags'][] = $prefix . '<a href="' . $tag['url'] . '" target="_blank">' . htmlspecialchars($tag['term']) . '</a>';
-					$return['tags'][] = $prefix . '<a href="' . $tag['url'] . '" target="_blank">' . htmlspecialchars($tag['term']) . '</a>';
+					$return['hashtags'][] = $prefix . '<a href="' . $tag['url'] . '">' . htmlspecialchars($tag['term']) . '</a>';
+					$return['tags'][] = $prefix . '<a href="' . $tag['url'] . '">' . htmlspecialchars($tag['term']) . '</a>';
 					break;
 				case self::MENTION:
 					$tag['url'] = Contact::magicLink($tag['url']);
-					$return['mentions'][] = $prefix . '<a href="' . $tag['url'] . '" target="_blank">' . htmlspecialchars($tag['term']) . '</a>';
-					$return['tags'][] = $prefix . '<a href="' . $tag['url'] . '" target="_blank">' . htmlspecialchars($tag['term']) . '</a>';
+					$return['mentions'][] = $prefix . '<a href="' . $tag['url'] . '">' . htmlspecialchars($tag['term']) . '</a>';
+					$return['tags'][] = $prefix . '<a href="' . $tag['url'] . '">' . htmlspecialchars($tag['term']) . '</a>';
 					break;
 				case self::IMPLICIT_MENTION:
 					$return['implicit_mentions'][] = $prefix . $tag['term'];

--- a/src/Module/Admin/Tos.php
+++ b/src/Module/Admin/Tos.php
@@ -60,7 +60,7 @@ class Tos extends BaseAdmin
 			'$title' => DI::l10n()->t('Administration'),
 			'$page' => DI::l10n()->t('Terms of Service'),
 			'$displaytos' => ['displaytos', DI::l10n()->t('Display Terms of Service'), DI::config()->get('system', 'tosdisplay'), DI::l10n()->t('Enable the Terms of Service page. If this is enabled a link to the terms will be added to the registration form and the general information page.')],
-			'$displayprivstatement' => ['displayprivstatement', DI::l10n()->t('Display Privacy Statement'), DI::config()->get('system', 'tosprivstatement'), DI::l10n()->t('Show some informations regarding the needed information to operate the node according e.g. to <a href="%s" target="_blank">EU-GDPR</a>.', 'https://en.wikipedia.org/wiki/General_Data_Protection_Regulation')],
+			'$displayprivstatement' => ['displayprivstatement', DI::l10n()->t('Display Privacy Statement'), DI::config()->get('system', 'tosprivstatement'), DI::l10n()->t('Show some informations regarding the needed information to operate the node according e.g. to <a href="%s">EU-GDPR</a>.', 'https://en.wikipedia.org/wiki/General_Data_Protection_Regulation')],
 			'$preview' => DI::l10n()->t('Privacy Statement Preview'),
 			'$privtext' => $tos->privacy_complete,
 			'$tostext' => ['tostext', DI::l10n()->t('The Terms of Service'), DI::config()->get('system', 'tostext'), DI::l10n()->t('Enter the Terms of Service for your node here. You can use BBCode. Headers of sections should be [h2] and below.')],

--- a/tests/src/Content/Text/BBCodeTest.php
+++ b/tests/src/Content/Text/BBCodeTest.php
@@ -164,7 +164,7 @@ class BBCodeTest extends MockedTest
 	public function testAutoLinking($data, $assertHTML)
 	{
 		$output = BBCode::convert($data);
-		$assert = '<a href="' . $data . '" target="_blank">' . $data . '</a>';
+		$assert = '<a href="' . $data . '">' . $data . '</a>';
 		if ($assertHTML) {
 			$this->assertEquals($assert, $output);
 		} else {
@@ -176,21 +176,21 @@ class BBCodeTest extends MockedTest
 	{
 		return [
 			'bug-7271-condensed-space' => [
-				'expectedHtml' => '<ul class="listdecimal" style="list-style-type: decimal;"><li> <a href="http://example.com/" target="_blank">http://example.com/</a></li></ul>',
+				'expectedHtml' => '<ul class="listdecimal" style="list-style-type: decimal;"><li> <a href="http://example.com/">http://example.com/</a></li></ul>',
 				'text' => '[ol][*] http://example.com/[/ol]',
 			],
 			'bug-7271-condensed-nospace' => [
-				'expectedHtml' => '<ul class="listdecimal" style="list-style-type: decimal;"><li><a href="http://example.com/" target="_blank">http://example.com/</a></li></ul>',
+				'expectedHtml' => '<ul class="listdecimal" style="list-style-type: decimal;"><li><a href="http://example.com/">http://example.com/</a></li></ul>',
 				'text' => '[ol][*]http://example.com/[/ol]',
 			],
 			'bug-7271-indented-space' => [
-				'expectedHtml' => '<ul class="listbullet" style="list-style-type: circle;"><li> <a href="http://example.com/" target="_blank">http://example.com/</a></li></ul>',
+				'expectedHtml' => '<ul class="listbullet" style="list-style-type: circle;"><li> <a href="http://example.com/">http://example.com/</a></li></ul>',
 				'text' => '[ul]
 [*] http://example.com/
 [/ul]',
 			],
 			'bug-7271-indented-nospace' => [
-				'expectedHtml' => '<ul class="listbullet" style="list-style-type: circle;"><li><a href="http://example.com/" target="_blank">http://example.com/</a></li></ul>',
+				'expectedHtml' => '<ul class="listbullet" style="list-style-type: circle;"><li><a href="http://example.com/">http://example.com/</a></li></ul>',
 				'text' => '[ul]
 [*]http://example.com/
 [/ul]',

--- a/view/templates/event.tpl
+++ b/view/templates/event.tpl
@@ -4,7 +4,7 @@
 	
 	{{if $event.item.author_name}}<a href="{{$event.item.author_link}}" ><img src="{{$event.item.author_avatar}}" height="32" width="32" />{{$event.item.author_name}}</a>{{/if}}
 	{{$event.html nofilter}}
-	{{if $event.item.plink}}<a href="{{$event.plink.0}}" title="{{$event.plink.1}}" target="_blank" class="plink-event-link icon s22 remote-link"></a>{{/if}}
+	{{if $event.item.plink}}<a href="{{$event.plink.0}}" title="{{$event.plink.1}}" class="plink-event-link icon s22 remote-link"></a>{{/if}}
 	{{if $event.edit}}<a href="{{$event.edit.0}}" title="{{$event.edit.1}}" class="edit-event-link icon s22 pencil"></a>{{/if}}
 	{{if $event.copy}}<a href="{{$event.copy.0}}" title="{{$event.copy.1}}" class="copy-event-link icon s22 copy"></a>{{/if}}
 	{{if $event.drop}}<a href="{{$event.drop.0}}" onclick="return confirmDelete();" title="{{$event.drop.1}}" class="drop-event-link icon s22 delete"></a>{{/if}}

--- a/view/templates/events.tpl
+++ b/view/templates/events.tpl
@@ -17,7 +17,7 @@
 	{{if $event.is_first}}<hr /><a name="link-{{$event.j}}" ><div class="event-list-date">{{$event.d}}</div></a>{{/if}}
 	{{if $event.item.author_name}}<a href="{{$event.item.author_link}}" ><img src="{{$event.item.author_avatar}}" height="32" width="32" />{{$event.item.author_name}}</a>{{/if}}
 	{{$event.html nofilter}}
-	{{if $event.item.plink}}<a href="{{$event.plink.0}}" title="{{$event.plink.1}}" target="_blank" class="plink-event-link icon s22 remote-link"></a>{{/if}}
+	{{if $event.item.plink}}<a href="{{$event.plink.0}}" title="{{$event.plink.1}}" class="plink-event-link icon s22 remote-link"></a>{{/if}}
 	{{if $event.edit}}<a href="{{$event.edit.0}}" title="{{$event.edit.1}}" class="edit-event-link icon s22 pencil"></a>{{/if}}
 	</div>
 	<div class="clear"></div>

--- a/view/templates/profile/vcard.tpl
+++ b/view/templates/profile/vcard.tpl
@@ -41,7 +41,7 @@
 
 	{{if $updated}}<div class="updated" style="display:none;">{{$updated}}</div>{{/if}}
 
-	{{if $homepage}}<dl class="homepage"><dt class="homepage-label">{{$homepage}}</dt><dd class="homepage-url u-url"><a href="{{$profile.homepage}}" rel="me" target="_blank">{{$profile.homepage}}</a></dd></dl>{{/if}}
+	{{if $homepage}}<dl class="homepage"><dt class="homepage-label">{{$homepage}}</dt><dd class="homepage-url u-url"><a href="{{$profile.homepage}}" rel="me">{{$profile.homepage}}</a></dd></dl>{{/if}}
 
 	{{if $about}}<dl class="about"><dt class="about-label">{{$about}}</dt><dd class="x-network">{{$profile.about nofilter}}</dd></dl>{{/if}}
 

--- a/view/templates/shared_content.tpl
+++ b/view/templates/shared_content.tpl
@@ -1,12 +1,12 @@
 <div class="shared-wrapper">
 	<div class="shared_header">
 		{{if $avatar}}
-			<a href="{{$profile}}" target="_blank" class="shared-userinfo">
+			<a href="{{$profile}}" class="shared-userinfo">
 			<img src="{{$avatar}}" height="32" width="32">
 			</a>
 		{{/if}}
-		<div><a href="{{$profile}}" target="_blank" class="shared-wall-item-name"><span class="shared-author">{{$author}}</span></a></div>
-		<div class="shared-wall-item-ago"><small><a href="{{$link}}" target="_blank"><span class="shared-time">{{$posted}}</a></a></small></div>
+		<div><a href="{{$profile}}" class="shared-wall-item-name"><span class="shared-author">{{$author}}</span></a></div>
+		<div class="shared-wall-item-ago"><small><a href="{{$link}}"><span class="shared-time">{{$posted}}</a></a></small></div>
 	</div>
 	<blockquote class="shared_content">{{$content nofilter}}</blockquote>
 </div>

--- a/view/templates/wall_thread.tpl
+++ b/view/templates/wall_thread.tpl
@@ -84,10 +84,10 @@
 			</div>
 			{{/if}}
 			{{if $item.remote_comment}}
-				<div class="wall-item-links-wrapper"><a href="{{$item.remote_comment.2}}" title="{{$item.remote_comment.0}}" target="_blank" class="icon remote-link{{$item.sparkle}} u-url"></a></div>
+				<div class="wall-item-links-wrapper"><a href="{{$item.remote_comment.2}}" title="{{$item.remote_comment.0}}" class="icon remote-link{{$item.sparkle}} u-url"></a></div>
 			{{/if}}
 			{{if $item.plink}}
-				<div class="wall-item-links-wrapper"><a href="{{$item.plink.href}}" title="{{$item.plink.title}}" target="_blank" class="icon remote-link{{$item.sparkle}} u-url"></a></div>
+				<div class="wall-item-links-wrapper"><a href="{{$item.plink.href}}" title="{{$item.plink.title}}" class="icon remote-link{{$item.sparkle}} u-url"></a></div>
 			{{/if}}
 			{{if $item.edpost}}
 				<a class="editpost icon pencil" href="{{$item.edpost.0}}" title="{{$item.edpost.1}}"></a>

--- a/view/templates/widget_forumlist.tpl
+++ b/view/templates/widget_forumlist.tpl
@@ -24,7 +24,7 @@ function showHideForumlist() {
 		{{if $forum.id <= $visible_forums}}
 		<li class="forum-widget-entry forum-{{$forum.cid}}" id="forum-widget-entry-{{$forum.id}}" role="menuitem">
 			<span class="notify badge pull-right"></span>
-			<a href="{{$forum.external_url}}" title="{{$forum.link_desc}}" class="label sparkle" target="_blank">
+			<a href="{{$forum.external_url}}" title="{{$forum.link_desc}}" class="label sparkle">
 				<img class="forumlist-img" src="{{$forum.micro}}" alt="{{$forum.link_desc}}" />
 			</a>
 			<a class="forum-widget-link {{if $forum.selected}}forum-selected{{/if}}" id="forum-widget-link-{{$forum.id}}" href="{{$forum.url}}" >{{$forum.name}}</a>
@@ -34,7 +34,7 @@ function showHideForumlist() {
 		{{if $forum.id > $visible_forums}}
 		<li class="forum-widget-entry forum-{{$forum.cid}}" id="forum-widget-entry-extended-{{$forum.id}}" role="menuitem" style="display: none;">
 			<span class="notify badge pull-right"></span>
-			<a href="{{$forum.external_url}}" title="{{$forum.link_desc}}" class="label sparkle" target="_blank">
+			<a href="{{$forum.external_url}}" title="{{$forum.link_desc}}" class="label sparkle">
 				<img class="forumlist-img" src="{{$forum.micro}}" alt="{{$forum.link_desc}}" />
 			</a>
 			<a class="forum-widget-link {{if $forum.selected}}forum-selected{{/if}}" id="forum-widget-link-{{$forum.id}}" href="{{$forum.url}}" >{{$forum.name}}</a>

--- a/view/theme/frio/templates/profile/vcard.tpl
+++ b/view/theme/frio/templates/profile/vcard.tpl
@@ -94,7 +94,7 @@
 		{{if $profile.xmpp}}
 		<div class="xmpp">
 			<span class="xmpp-label icon"><i class="fa fa-comments"></i></span>
-			<span class="xmpp-data"><a href="xmpp:{{$profile.xmpp}}" rel="me" target="_blank">{{include file="sub/punct_wrap.tpl" text=$profile.xmpp}}</a></span>
+			<span class="xmpp-data"><a href="xmpp:{{$profile.xmpp}}" rel="me">{{include file="sub/punct_wrap.tpl" text=$profile.xmpp}}</a></span>
 		</div>
 		{{/if}}
 
@@ -107,7 +107,7 @@
 		{{if $homepage}}
 		<div class="homepage detail">
 			<span class="homepage-label icon"><i class="fa fa-external-link-square"></i></span>
-			<span class="homepage-url u-url"><a href="{{$profile.homepage}}" rel="me" target="_blank">{{include file="sub/punct_wrap.tpl" text=$profile.homepage}}</a></span>
+			<span class="homepage-url u-url"><a href="{{$profile.homepage}}" rel="me">{{include file="sub/punct_wrap.tpl" text=$profile.homepage}}</a></span>
 		</div>
 		{{/if}}
 

--- a/view/theme/quattro/templates/events.tpl
+++ b/view/theme/quattro/templates/events.tpl
@@ -13,7 +13,7 @@
 	{{if $event.is_first}}<hr /><a name="link-{{$event.j}}" ><div class="event-list-date">{{$event.d}}</div></a>{{/if}}
 	{{if $event.item.author_name}}<a href="{{$event.item.author_link}}" ><img src="{{$event.item.author_avatar}}" height="32" width="32" />{{$event.item.author_name}}</a>{{/if}}
 	{{$event.html nofilter}}
-	{{if $event.item.plink}}<a href="{{$event.plink.0}}" title="{{$event.plink.1}}" target="_blank" class="plink-event-link icon s22 remote-link"></a>{{/if}}
+	{{if $event.item.plink}}<a href="{{$event.plink.0}}" title="{{$event.plink.1}}" class="plink-event-link icon s22 remote-link"></a>{{/if}}
 	{{if $event.edit}}<a href="{{$event.edit.0}}" title="{{$event.edit.1}}" class="edit-event-link icon s22 pencil"></a>{{/if}}
 	</div>
 	<div class="clear"></div>

--- a/view/theme/quattro/templates/widget_forumlist.tpl
+++ b/view/theme/quattro/templates/widget_forumlist.tpl
@@ -21,7 +21,7 @@ function showHideForumlist() {
 		{{if $forum.id <= $visible_forums}}
 		<li class="forum-widget-entry forum-{{$forum.cid}} tool {{if $forum.selected}}selected{{/if}}" id="forum-widget-entry-{{$forum.id}}" role="menuitem">
 			<span class="notify badge pull-right"></span>
-			<a href="{{$forum.external_url}}" title="{{$forum.link_desc}}" class="label sparkle" target="_blank">
+			<a href="{{$forum.external_url}}" title="{{$forum.link_desc}}" class="label sparkle">
 				<img class="forumlist-img" src="{{$forum.micro}}" alt="{{$forum.link_desc}}" />
 			</a>
 			<a class="forum-widget-link" id="forum-widget-link-{{$forum.id}}" href="{{$forum.url}}" >{{$forum.name}}</a>
@@ -31,7 +31,7 @@ function showHideForumlist() {
 		{{if $forum.id > $visible_forums}}
 		<li class="forum-widget-entry forum-{{$forum.cid}} tool {{if $forum.selected}}selected{{/if}}" id="forum-widget-entry-extended-{{$forum.id}}" role="menuitem" style="display: none;">
 			<span class="notify badge pull-right"></span>
-			<a href="{{$forum.external_url}}" title="{{$forum.link_desc}}" class="label sparkle" target="_blank">
+			<a href="{{$forum.external_url}}" title="{{$forum.link_desc}}" class="label sparkle">
 				<img class="forumlist-img" src="{{$forum.micro}}" alt="{{$forum.link_desc}}" />
 			</a>
 			<a class="forum-widget-link" id="forum-widget-link-{{$forum.id}}" href="{{$forum.url}}" >{{$forum.name}}</a>

--- a/view/theme/vier/templates/profile/vcard.tpl
+++ b/view/theme/vier/templates/profile/vcard.tpl
@@ -48,7 +48,7 @@
 
 	{{if $updated}}<div class="updated" style="display:none;">{{$updated}}</div>{{/if}}
 
-	{{if $homepage}}<dl class="homepage"><dt class="homepage-label">{{$homepage}}</dt><dd class="homepage-url"><a href="{{$profile.homepage}}" class="u-url" rel="me" target="_blank">{{$profile.homepage}}</a></dd></dl>{{/if}}
+	{{if $homepage}}<dl class="homepage"><dt class="homepage-label">{{$homepage}}</dt><dd class="homepage-url"><a href="{{$profile.homepage}}" class="u-url" rel="me">{{$profile.homepage}}</a></dd></dl>{{/if}}
 
 	{{if $about}}<dl class="about"><dt class="about-label">{{$about}}</dt><dd class="x-network">{{$profile.about nofilter}}</dd></dl>{{/if}}
 

--- a/view/theme/vier/templates/widget_forumlist_right.tpl
+++ b/view/theme/vier/templates/widget_forumlist_right.tpl
@@ -21,7 +21,7 @@ function showHideForumlist() {
 		{{if $forum.id <= $visible_forums}}
 		<li class="forum-widget-entry forum-{{$forum.cid}}" id="forum-widget-entry-{{$forum.id}}" role="menuitem">
 			<span class="notify badge pull-right"></span>
-			<a href="{{$forum.external_url}}" title="{{$forum.link_desc}}" class="label sparkle" target="_blank">
+			<a href="{{$forum.external_url}}" title="{{$forum.link_desc}}" class="label sparkle">
 				<img class="forumlist-img" src="{{$forum.micro}}" alt="{{$forum.link_desc}}" />
 			</a>
 			<a class="forum-widget-link {{if $forum.selected}}forum-selected{{/if}}" id="forum-widget-link-{{$forum.id}}" href="{{$forum.url}}" >{{$forum.name}}</a>
@@ -31,7 +31,7 @@ function showHideForumlist() {
 		{{if $forum.id > $visible_forums}}
 		<li class="forum-widget-entry forum-{{$forum.cid}}" id="forum-widget-entry-extended-{{$forum.id}}" role="menuitem" style="display: none;">
 			<span class="notify badge pull-right"></span>
-			<a href="{{$forum.external_url}}" title="{{$forum.link_desc}}" class="label sparkle" target="_blank">
+			<a href="{{$forum.external_url}}" title="{{$forum.link_desc}}" class="label sparkle">
 				<img class="forumlist-img" src="{{$forum.micro}}" alt="{{$forum.link_desc}}" />
 			</a>
 			<a class="forum-widget-link {{if $forum.selected}}forum-selected{{/if}}" id="forum-widget-link-{{$forum.id}}" href="{{$forum.url}}" >{{$forum.name}}</a>


### PR DESCRIPTION
Part of #8323

This PR removes all `target="_blank"` from the project. It is a security and a usability feature. Like I said in the corresponding issue thread, since we currently don't have a good definition of what constitutes an external link or not, leading to an inconsistent behavior, I'd rather remove the security risk and revert to a sane default behavior first before anyone takes a stab at a centralized link function.