### PR TITLE
Restore removed announce key in conv_response array in include/conversation

### DIFF
--- a/include/conversation.php
+++ b/include/conversation.php
@@ -583,7 +583,8 @@ function conversation(App $a, array $items, $mode, $update, $preview = false, $o
 		'dislike'     => [],
 		'attendyes'   => [],
 		'attendno'    => [],
-		'attendmaybe' => []
+		'attendmaybe' => [],
+		'announce'    => [],	
 	];
 
 	if (DI::pConfig()->get(local_user(), 'system', 'hide_dislike')) {


### PR DESCRIPTION
- Follow-up to #8329

See https://github.com/friendica/friendica/pull/8329#discussion_r384751431

Thanks to @AlfredSK for his vigilance.