### PR TITLE
Store the raw data in a different way

### DIFF
--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -448,6 +448,10 @@ class Processor
 		$item['owner-link'] = $activity['actor'];
 		$item['owner-id'] = Contact::getIdForURL($activity['actor'], 0, true);
 
+		if (!empty($activity['raw'])) {
+			$item['source'] = $activity['raw'];
+		}
+
 		$isForum = false;
 
 		if (!empty($activity['thread-completion'])) {

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -448,8 +448,9 @@ class Processor
 		$item['owner-link'] = $activity['actor'];
 		$item['owner-id'] = Contact::getIdForURL($activity['actor'], 0, true);
 
-		if (!empty($activity['raw'])) {
+		if (!empty($activity['raw']) && isset($activity['protocol'])) {
 			$item['source'] = $activity['raw'];
+			$item['protocol'] = $activity['protocol'];
 		}
 
 		$isForum = false;

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -451,6 +451,8 @@ class Processor
 		if (!empty($activity['raw']) && isset($activity['protocol'])) {
 			$item['source'] = $activity['raw'];
 			$item['protocol'] = $activity['protocol'];
+			$item['conversation-href'] = $activity['context'] ?? '';
+			$item['conversation-uri'] = $activity['conversation'] ?? '';
 		}
 
 		$isForum = false;

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -29,6 +29,7 @@ use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\APContact;
 use Friendica\Model\Contact;
+use Friendica\Model\Conversation;
 use Friendica\Model\Event;
 use Friendica\Model\Item;
 use Friendica\Model\Mail;
@@ -448,9 +449,9 @@ class Processor
 		$item['owner-link'] = $activity['actor'];
 		$item['owner-id'] = Contact::getIdForURL($activity['actor'], 0, true);
 
-		if (!empty($activity['raw']) && isset($activity['protocol'])) {
+		if (!empty($activity['raw'])) {
 			$item['source'] = $activity['raw'];
-			$item['protocol'] = $activity['protocol'];
+			$item['protocol'] = Conversation::PARCEL_ACTIVITYPUB;
 			$item['conversation-href'] = $activity['context'] ?? '';
 			$item['conversation-uri'] = $activity['conversation'] ?? '';
 		}

--- a/src/Protocol/ActivityPub/Receiver.php
+++ b/src/Protocol/ActivityPub/Receiver.php
@@ -28,7 +28,6 @@ use Friendica\Core\Logger;
 use Friendica\Core\Protocol;
 use Friendica\Model\Contact;
 use Friendica\Model\APContact;
-use Friendica\Model\Conversation;
 use Friendica\Model\Item;
 use Friendica\Model\User;
 use Friendica\Protocol\Activity;
@@ -355,7 +354,6 @@ class Receiver
 
 		if (!empty($body)) {
 			$object_data['raw'] = $body;
-			$object_data['protocol'] = Conversation::PARCEL_ACTIVITYPUB;
 		}
 
 		// Internal flag for thread completion. See Processor.php


### PR DESCRIPTION
Storing the raw conversation data in the item class helps with storing activities like reshares that we couldn't store by now.