### PR TITLE
Add Login form in case of notification links

### DIFF
--- a/include/api.php
+++ b/include/api.php
@@ -25,7 +25,6 @@
 
 use Friendica\App;
 use Friendica\Content\ContactSelector;
-use Friendica\Content\Feature;
 use Friendica\Content\Text\BBCode;
 use Friendica\Content\Text\HTML;
 use Friendica\Core\Hook;
@@ -42,7 +41,6 @@ use Friendica\Model\Item;
 use Friendica\Model\Mail;
 use Friendica\Model\Notify;
 use Friendica\Model\Photo;
-use Friendica\Model\Profile;
 use Friendica\Model\User;
 use Friendica\Model\UserItem;
 use Friendica\Network\FKOAuth1;
@@ -5920,7 +5918,7 @@ function api_friendica_notification_seen($type)
 	$id = (!empty($_REQUEST['id']) ? intval($_REQUEST['id']) : 0);
 
 	try {
-		$notify = DI::notify()->getByID($id);
+		$notify = DI::notify()->getByID($id, api_user());
 		DI::notify()->setSeen(true, $notify);
 
 		if ($notify->otype === Notify\ObjectType::ITEM) {

--- a/src/Module/Notifications/Notification.php
+++ b/src/Module/Notifications/Notification.php
@@ -100,7 +100,7 @@ class Notification extends BaseModule
 	public static function content(array $parameters = [])
 	{
 		if (!local_user()) {
-			notice(DI::l10n()->t('Permission denied.'));
+			notice(DI::l10n()->t('You must be logged in to show this page.'));
 			return Login::form();
 		}
 

--- a/src/Module/Notifications/Notification.php
+++ b/src/Module/Notifications/Notification.php
@@ -24,6 +24,7 @@ namespace Friendica\Module\Notifications;
 use Friendica\BaseModule;
 use Friendica\Core\System;
 use Friendica\DI;
+use Friendica\Module\Security\Login;
 use Friendica\Network\HTTPException;
 
 /**
@@ -31,15 +32,21 @@ use Friendica\Network\HTTPException;
  */
 class Notification extends BaseModule
 {
-	public static function init(array $parameters = [])
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @throws HTTPException\InternalServerErrorException
+	 * @throws HTTPException\NotFoundException
+	 * @throws HTTPException\UnauthorizedException
+	 * @throws \ImagickException
+	 * @throws \Exception
+	 */
+	public static function post(array $parameters = [])
 	{
 		if (!local_user()) {
 			throw new HTTPException\UnauthorizedException(DI::l10n()->t('Permission denied.'));
 		}
-	}
 
-	public static function post(array $parameters = [])
-	{
 		$request_id = $parameters['id'] ?? false;
 
 		if ($request_id) {
@@ -58,9 +65,17 @@ class Notification extends BaseModule
 		}
 	}
 
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @throws HTTPException\UnauthorizedException
+	 */
 	public static function rawContent(array $parameters = [])
 	{
-		// @TODO: Replace with parameter from router
+		if (!local_user()) {
+			throw new HTTPException\UnauthorizedException(DI::l10n()->t('Permission denied.'));
+		}
+
 		if (DI::args()->get(1) === 'mark' && DI::args()->get(2) === 'all') {
 			try {
 				$success = DI::notify()->setSeen();
@@ -74,31 +89,36 @@ class Notification extends BaseModule
 	}
 
 	/**
+	 * {@inheritDoc}
+	 *
 	 * Redirect to the notifications main page or to the url for the chosen notifications
 	 *
-	 * @return string|void
+	 * @throws HTTPException\NotFoundException In case the notification is either not existing or is not for this user
 	 * @throws HTTPException\InternalServerErrorException
+	 * @throws \Exception
 	 */
 	public static function content(array $parameters = [])
 	{
+		if (!local_user()) {
+			notice(DI::l10n()->t('Permission denied.'));
+			return Login::form();
+		}
+
 		$request_id = $parameters['id'] ?? false;
 
 		if ($request_id) {
-			try {
-				$notify = DI::notify()->getByID($request_id);
-				DI::notify()->setSeen(true, $notify);
+			$notify = DI::notify()->getByID($request_id);
+			DI::notify()->setSeen(true, $notify);
 
-				if (!empty($notify->link)) {
-					System::externalRedirect($notify->link);
-				}
-
-			} catch (HTTPException\NotFoundException $e) {
-				info(DI::l10n()->t('Invalid notification.'));
+			if (!empty($notify->link)) {
+				System::externalRedirect($notify->link);
 			}
 
 			DI::baseUrl()->redirect();
 		}
 
 		DI::baseUrl()->redirect('notifications/system');
+
+		throw new HTTPException\InternalServerErrorException('Invalid situation.');
 	}
 }

--- a/src/Module/Notifications/Notification.php
+++ b/src/Module/Notifications/Notification.php
@@ -107,7 +107,7 @@ class Notification extends BaseModule
 		$request_id = $parameters['id'] ?? false;
 
 		if ($request_id) {
-			$notify = DI::notify()->getByID($request_id);
+			$notify = DI::notify()->getByID($request_id, local_user());
 			DI::notify()->setSeen(true, $notify);
 
 			if (!empty($notify->link)) {

--- a/src/Repository/Notify.php
+++ b/src/Repository/Notify.php
@@ -23,9 +23,9 @@ namespace Friendica\Repository;
 
 use Exception;
 use Friendica\BaseRepository;
+use Friendica\Collection;
 use Friendica\Core\Hook;
 use Friendica\Model;
-use Friendica\Collection;
 use Friendica\Network\HTTPException\InternalServerErrorException;
 use Friendica\Network\HTTPException\NotFoundException;
 use Friendica\Util\DateTimeFormat;
@@ -61,14 +61,17 @@ class Notify extends BaseRepository
 	}
 
 	/**
-	 * {@inheritDoc}
+	 * Return one notify instance based on ID / UID
+	 *
+	 * @param int $id The ID of the notify instance
+	 * @param int $uid The user ID, bound to this notify instance (= security check)
 	 *
 	 * @return Model\Notify
 	 * @throws NotFoundException
 	 */
-	public function getByID(int $id)
+	public function getByID(int $id, int $uid)
 	{
-		return $this->selectFirst(['id' => $id, 'uid' => local_user()]);
+		return $this->selectFirst(['id' => $id, 'uid' => $uid]);
 	}
 
 	/**


### PR DESCRIPTION
Closes #8342 
The UnauthorizedException is now just thrown in case a login should be prohibited (like for POST-action or raw-outputs)