### PR TITLE
Show the relations of Twitter contacts

### DIFF
--- a/src/Module/Contact.php
+++ b/src/Module/Contact.php
@@ -513,7 +513,7 @@ class Contact extends BaseModule
 				$relation_text = '';
 			}
 
-			if (!in_array($contact['network'], Protocol::FEDERATED)) {
+			if (!in_array($contact['network'], array_merge(Protocol::FEDERATED, [Protocol::TWITTER]))) {
 				$relation_text = '';
 			}
 


### PR DESCRIPTION
Since we now fetch the real contact relations of Twitter contacts, we now can display them on the contacts page like we do with the federated networks.