### PR TITLE
Issue 8371: Improvements for picture permissions

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -1,6 +1,6 @@
 -- ------------------------------------------
 -- Friendica 2020.03-dev (Dalmatian Bellflower)
--- DB_UPDATE_VERSION 1336
+-- DB_UPDATE_VERSION 1337
 -- ------------------------------------------
 
 
@@ -948,6 +948,7 @@ CREATE TABLE IF NOT EXISTS `photo` (
 	`allow_gid` mediumtext COMMENT 'Access Control - list of allowed groups',
 	`deny_cid` mediumtext COMMENT 'Access Control - list of denied contact.id',
 	`deny_gid` mediumtext COMMENT 'Access Control - list of denied groups',
+	`accessible` boolean NOT NULL DEFAULT '0' COMMENT 'Make photo publicly accessible, ignoring permissions',
 	`backend-class` tinytext COMMENT 'Storage backend class',
 	`backend-ref` text COMMENT 'Storage backend data reference',
 	`updated` datetime NOT NULL DEFAULT '0001-01-01 00:00:00' COMMENT '',

--- a/mod/settings.php
+++ b/mod/settings.php
@@ -319,6 +319,7 @@ function settings_post(App $a)
 	$hide_friends     = (($_POST['hide-friends'] == 1) ? 1: 0);
 	$hidewall         = (($_POST['hidewall'] == 1) ? 1: 0);
 	$unlisted         = (($_POST['unlisted'] == 1) ? 1: 0);
+	$accessiblephotos = (($_POST['accessible-photos'] == 1) ? 1: 0);
 
 	$email_textonly   = (($_POST['email_textonly'] == 1) ? 1 : 0);
 	$detailed_notif   = (($_POST['detailed_notif'] == 1) ? 1 : 0);
@@ -417,6 +418,7 @@ function settings_post(App $a)
 	DI::pConfig()->set(local_user(), 'system', 'email_textonly', $email_textonly);
 	DI::pConfig()->set(local_user(), 'system', 'detailed_notif', $detailed_notif);
 	DI::pConfig()->set(local_user(), 'system', 'unlisted', $unlisted);
+	DI::pConfig()->set(local_user(), 'system', 'accessible-photos', $accessiblephotos);
 
 	if ($page_flags == User::PAGE_FLAGS_PRVGROUP) {
 		$hidewall = 1;
@@ -843,6 +845,10 @@ function settings_content(App $a)
 		'$field' => ['unlisted', DI::l10n()->t('Make public posts unlisted'), DI::pConfig()->get(local_user(), 'system', 'unlisted'), DI::l10n()->t('Your public posts will not appear on the community pages or in search results, nor be sent to relay servers. However they can still appear on public feeds on remote servers.')],
 	]);
 
+	$accessiblephotos = Renderer::replaceMacros($opt_tpl, [
+		'$field' => ['accessible-photos', DI::l10n()->t('Make all posted pictures accessible'), DI::pConfig()->get(local_user(), 'system', 'accessible-photos'), DI::l10n()->t("This option makes every posted picture accessible via the direct link. This is a workaround for the problem that most other networks can't handle permissions on pictures. Non public pictures still won't be visible for the public on your photo albums though.")],
+	]);
+
 	$blockwall = Renderer::replaceMacros($opt_tpl, [
 		'$field' => ['blockwall', DI::l10n()->t('Allow friends to post to your profile page?'), (intval($a->user['blockwall']) ? '0' : '1'), DI::l10n()->t('Your contacts may write posts on your profile wall. These posts will be distributed to your contacts')],
 	]);
@@ -957,6 +963,7 @@ function settings_content(App $a)
 		'$hide_friends' => $hide_friends,
 		'$hide_wall' => $hide_wall,
 		'$unlisted' => $unlisted,
+		'$accessiblephotos' => $accessiblephotos,
 		'$unkmail' => $unkmail,
 		'$cntunkmail' 	=> ['cntunkmail', DI::l10n()->t('Maximum private messages per day from unknown people:'), $cntunkmail , DI::l10n()->t("\x28to prevent spam abuse\x29")],
 

--- a/src/Module/Photo.php
+++ b/src/Module/Photo.php
@@ -84,13 +84,13 @@ class Photo extends BaseModule
 				}
 				$photo = MPhoto::getPhoto($photoid, $scale);
 				if ($photo === false) {
-					$photo = MPhoto::createPhotoForSystemResource("images/nosign.jpg");
+					throw new \Friendica\Network\HTTPException\NotFoundException(DI::l10n()->t('The Photo with id %s is not available.', $photoid));
 				}
 				break;
 		}
 
 		if ($photo === false) {
-			System::httpExit('404', 'Not Found');
+			throw new \Friendica\Network\HTTPException\NotFoundException();
 		}
 
 		$cacheable = ($photo["allow_cid"] . $photo["allow_gid"] . $photo["deny_cid"] . $photo["deny_gid"] === "") && (isset($photo["cacheable"]) ? $photo["cacheable"] : true);

--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -51,7 +51,7 @@
 use Friendica\Database\DBA;
 
 if (!defined('DB_UPDATE_VERSION')) {
-	define('DB_UPDATE_VERSION', 1336);
+	define('DB_UPDATE_VERSION', 1337);
 }
 
 return [
@@ -1051,6 +1051,7 @@ return [
 			"allow_gid" => ["type" => "mediumtext", "comment" => "Access Control - list of allowed groups"],
 			"deny_cid" => ["type" => "mediumtext", "comment" => "Access Control - list of denied contact.id"],
 			"deny_gid" => ["type" => "mediumtext", "comment" => "Access Control - list of denied groups"],
+			"accessible" => ["type" => "boolean", "not null" => "1", "default" => "0", "comment" => "Make photo publicly accessible, ignoring permissions"],
 			"backend-class" => ["type" => "tinytext", "comment" => "Storage backend class"],
 			"backend-ref" => ["type" => "text", "comment" => "Storage backend data reference"],
 			"updated" => ["type" => "datetime", "not null" => "1", "default" => DBA::NULL_DATETIME, "comment" => ""]

--- a/view/templates/settings/settings.tpl
+++ b/view/templates/settings/settings.tpl
@@ -55,6 +55,8 @@
 
 {{$unlisted nofilter}}
 
+{{$accessiblephotos nofilter}}
+
 {{$blockwall nofilter}}
 
 {{$blocktags nofilter}}

--- a/view/theme/frio/templates/settings/settings.tpl
+++ b/view/theme/frio/templates/settings/settings.tpl
@@ -91,6 +91,8 @@
 
 						{{$unlisted nofilter}}
 
+						{{$accessiblephotos nofilter}}
+
 						{{$blockwall nofilter}}
 
 						{{$blocktags nofilter}}


### PR DESCRIPTION
This should fix issue https://github.com/friendica/friendica/issues/8371 and creates a workaround for the "red circle" problems.

According to issue #8371 the permission fields in photos are sometimes set to `null` - which then causes the permission function not to alter permissions. This is now changed so that permissions are also altered on photos with the permissions set to `null`.

This PR also addresses the main issue with the red circles: Most systems like Mastodon or Diaspora can't handle non public photos. They fetch the photos without authentication. We cannot change the other systems. And stating "yeah, the others are to blame when they cannot see your pictures" don't help the users who just want to post their pictures to a non public audience. So we introduce a new option. (Yeah, I'm feeling guilty about adding new options, but this one is needed, I think)

The option allows pictures to be fetched without  authentication, but still they can't be seen in the photo albums if you don't have the permission. It's up to the user to decide if this is enough protection.