### PR TITLE
Fix & align HTML mail text

### DIFF
--- a/view/templates/email/html.tpl
+++ b/view/templates/email/html.tpl
@@ -14,10 +14,12 @@
 				<div style="clear: both;"></div>
 			</td>
 		</tr>
+		<tr>
+			<td>
+				{{$htmlversion nofilter}}
+			</td>
+		</tr>
 	</tbody>
 	</table>
-	<p>
-	{{$htmlversion nofilter}}
-	</p>
 </body>
 </html>

--- a/view/templates/email/notify/html.tpl
+++ b/view/templates/email/notify/html.tpl
@@ -35,11 +35,13 @@
 			</td>
 		</tr>
 		<tr>
+			<td></td>
 			<td>
 				{{$thanks}}
 			</td>
 		</tr>
 		<tr>
+			<td></td>
 			<td>
 				{{$site_admin}}
 			</td>

--- a/view/templates/email/notify/html.tpl
+++ b/view/templates/email/notify/html.tpl
@@ -1,20 +1,48 @@
 <table>
-<tbody>
-	<tr><td colspan="2" style="padding-top:22px;">{{$preamble nofilter}}</td></tr>
-
+	<thead>
+		<tr>
+			<td colspan="2" style="padding-top:22px;">
+				{{$preamble nofilter}}
+			</td>
+		</tr>
+	</thead>
 {{if $content_allowed}}
+	<tbody>
 	{{if $source_photo}}
-	<tr>
-		<td style="padding-left:22px;padding-top:22px;width:60px;" valign="top" rowspan=3><a href="{{$source_link}}"><img style="border:0px;width:48px;height:48px;" src="{{$source_photo}}"></a></td>
-		<td style="padding-top:22px;"><a href="{{$source_link}}">{{$source_name}}</a></td>
-	</tr>
+		<tr>
+			<td style="padding-left:22px;padding-top:22px;width:60px;" valign="top" rowspan=3><a href="{{$source_link}}"><img style="border:0px;width:48px;height:48px;" src="{{$source_photo}}"></a></td>
+			<td style="padding-top:22px;"><a href="{{$source_link}}">{{$source_name}}</a></td>
+		</tr>
 	{{/if}}
-	<tr><td style="font-weight:bold;padding-bottom:5px;">{{$title}}</td></tr>
-	<tr><td style="padding-right:22px;">{{$htmlversion nofilter}}</td></tr>
+		<tr>
+			<td style="font-weight:bold;padding-bottom:5px;">{{$title}}</td>
+		</tr>
+		<tr>
+			<td style="padding-right:22px;">{{$htmlversion nofilter}}
+		</td>
+		</tr>
 {{/if}}
-	<tr><td colspan="2" style="padding-top:11px;">{{$hsitelink nofilter}}</td></tr>
-	<tr><td colspan="2" style="padding-bottom:11px;">{{$hitemlink nofilter}}</td></tr>
-	<tr><td></td><td>{{$thanks}}</td></tr>
-	<tr><td></td><td>{{$site_admin}}</td></tr>
-</tbody>
+	</tbody>
+	<tfoot>
+		<tr>
+			<td colspan="2" style="padding-top:11px;">
+				{{$hsitelink nofilter}}
+			</td>
+		</tr>
+		<tr>
+			<td colspan="2" style="padding-bottom:11px;">
+				{{$hitemlink nofilter}}
+			</td>
+		</tr>
+		<tr>
+			<td>
+				{{$thanks}}
+			</td>
+		</tr>
+		<tr>
+			<td>
+				{{$site_admin}}
+			</td>
+		</tr>
+	</tfoot>
 </table>

--- a/view/templates/email/system/html.tpl
+++ b/view/templates/email/system/html.tpl
@@ -1,5 +1,28 @@
 <table>
-<tr><td style="padding-right:22px;">{{$htmlversion nofilter}}</td></tr>
-<tr><td>{{$thanks}}</td></tr>
-<tr><td>{{$site_admin}}</td></tr>
+	<thead>
+	<tr>
+		<td>
+			{{$preamble nofilter}}
+		</td>
+	</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td style="padding-right:22px;">
+				{{$htmlversion nofilter}}
+			</td>
+		</tr>
+	</tbody>
+	<tfoot>
+		<tr>
+			<td>
+				{{$thanks}}
+			</td>
+	</tr>
+	<tr>
+		<td>
+			{{$site_admin}}
+		</td>
+	</tr>
+	</tfoot>
 </table>

--- a/view/templates/email/system/html.tpl
+++ b/view/templates/email/system/html.tpl
@@ -18,7 +18,7 @@
 			<td>
 				{{$thanks}}
 			</td>
-	</tr>
+		</tr>
 	<tr>
 		<td>
 			{{$site_admin}}


### PR DESCRIPTION
Now the preamble is added again in the HTML template of system emails ..

Fixes https://github.com/friendica/friendica/pull/8365#issuecomment-596089067

And I cleaned up the HTML message again since it really looked ugly! I sent a notification to myself and it seems now nicer