### PR TITLE
Remove orphaned checkbox for compose page

### DIFF
--- a/view/theme/frio/templates/theme_settings.tpl
+++ b/view/theme/frio/templates/theme_settings.tpl
@@ -183,10 +183,6 @@
 	});
 </script>
 
-<div class="form-group">
-    {{include file="field_checkbox.tpl" field=$enable_compose}}
-</div>
-
 <div class="settings-submit-wrapper form-group pull-right">
 	<button type="submit" value="{{$submit}}" class="settings-submit btn btn-primary" name="frio-settings-submit">{{$submit}}</button>
 </div>


### PR DESCRIPTION
There was still a checkbox for the removed 'enable compose page' option.
This is removed now.

https://forum.friendi.ca/display/adf174d5-185e-661a-75da-867175572699
