### PR TITLE
Fix uninstall of installed addons

### DIFF
--- a/src/Core/Addon.php
+++ b/src/Core/Addon.php
@@ -112,37 +112,14 @@ class Addon
 	 */
 	public static function loadAddons()
 	{
-		$installed_addons = [];
+		$installed_addons = DBA::selectToArray('addon', ['name'], ['installed' => true]);
 
-		$r = DBA::select('addon', [], ['installed' => 1]);
-		if (DBA::isResult($r)) {
-			$installed_addons = DBA::toArray($r);
-		}
-
-		$addons = DI::config()->get('system', 'addon');
 		$addons_arr = [];
-
-		if ($addons) {
-			$addons_arr = explode(',', str_replace(' ', '', $addons));
+		foreach ($installed_addons as $addon) {
+			$addons_arr[] = $addon['name'];
 		}
 
 		self::$addons = $addons_arr;
-
-		$installed_arr = [];
-
-		foreach ($installed_addons as $addon) {
-			if (!self::isEnabled($addon['name'])) {
-				self::uninstall($addon['name']);
-			} else {
-				$installed_arr[] = $addon['name'];
-			}
-		}
-
-		foreach (self::$addons as $p) {
-			if (!in_array($p, $installed_arr)) {
-				self::install($p);
-			}
-		}
 	}
 
 	/**
@@ -168,8 +145,6 @@ class Addon
 		DBA::delete('hook', ['file' => 'addon/' . $addon . '/' . $addon . '.php']);
 
 		unset(self::$addons[array_search($addon, self::$addons)]);
-
-		Addon::saveEnabledList();
 	}
 
 	/**
@@ -212,8 +187,6 @@ class Addon
 				self::$addons[] = $addon;
 			}
 
-			Addon::saveEnabledList();
-
 			return true;
 		} else {
 			Logger::error("Addon {addon}: {action} failed", ['action' => 'install', 'addon' => $addon]);
@@ -226,38 +199,33 @@ class Addon
 	 */
 	public static function reload()
 	{
-		$addons = DI::config()->get('system', 'addon');
-		if (strlen($addons)) {
-			$r = DBA::select('addon', [], ['installed' => 1]);
-			if (DBA::isResult($r)) {
-				$installed = DBA::toArray($r);
-			} else {
-				$installed = [];
-			}
+		$installed = DBA::selectToArray('addon', [], ['installed' => 1]);
 
-			$addon_list = explode(',', $addons);
+		$addon_list = [];
+		foreach ($installed as $addon) {
+			$addon_list[] = $addon['name'];
+		}
 
-			foreach ($addon_list as $addon) {
-				$addon = Strings::sanitizeFilePathItem(trim($addon));
-				$fname = 'addon/' . $addon . '/' . $addon . '.php';
-				if (file_exists($fname)) {
-					$t = @filemtime($fname);
-					foreach ($installed as $i) {
-						if (($i['name'] == $addon) && ($i['timestamp'] != $t)) {
+		foreach ($addon_list as $addon) {
+			$addon = Strings::sanitizeFilePathItem(trim($addon));
+			$fname = 'addon/' . $addon . '/' . $addon . '.php';
+			if (file_exists($fname)) {
+				$t = @filemtime($fname);
+				foreach ($installed as $i) {
+					if (($i['name'] == $addon) && ($i['timestamp'] != $t)) {
 
-							Logger::notice("Addon {addon}: {action}", ['action' => 'reload', 'addon' => $i['name']]);
-							@include_once($fname);
+						Logger::notice("Addon {addon}: {action}", ['action' => 'reload', 'addon' => $i['name']]);
+						@include_once($fname);
 
-							if (function_exists($addon . '_uninstall')) {
-								$func = $addon . '_uninstall';
-								$func(DI::app());
-							}
-							if (function_exists($addon . '_install')) {
-								$func = $addon . '_install';
-								$func(DI::app());
-							}
-							DBA::update('addon', ['timestamp' => $t], ['id' => $i['id']]);
+						if (function_exists($addon . '_uninstall')) {
+							$func = $addon . '_uninstall';
+							$func(DI::app());
 						}
+						if (function_exists($addon . '_install')) {
+							$func = $addon . '_install';
+							$func(DI::app());
+						}
+						DBA::update('addon', ['timestamp' => $t], ['id' => $i['id']]);
 					}
 				}
 			}
@@ -355,16 +323,6 @@ class Addon
 	public static function getEnabledList()
 	{
 		return self::$addons;
-	}
-
-	/**
-	 * Saves the current enabled addon list in the system.addon config key
-	 *
-	 * @return boolean
-	 */
-	public static function saveEnabledList()
-	{
-		return DI::config()->set('system', 'addon', implode(',', self::$addons));
 	}
 
 	/**

--- a/src/Model/Nodeinfo.php
+++ b/src/Model/Nodeinfo.php
@@ -43,20 +43,7 @@ class Nodeinfo
 		// If the addon 'statistics_json' is enabled then disable it and activate nodeinfo.
 		if (Addon::isEnabled('statistics_json')) {
 			$config->set('system', 'nodeinfo', true);
-
-			$addon = 'statistics_json';
-			$addons = $config->get('system', 'addon');
-
-			if ($addons) {
-				$addons_arr = explode(',', str_replace(' ', '', $addons));
-
-				$idx = array_search($addon, $addons_arr);
-				if ($idx !== false) {
-					unset($addons_arr[$idx]);
-					Addon::uninstall($addon);
-					$config->set('system', 'addon', implode(', ', $addons_arr));
-				}
-			}
+			Addon::uninstall('statistics_json');
 		}
 
 		if (empty($config->get('system', 'nodeinfo'))) {

--- a/src/Module/Admin/Addons/Details.php
+++ b/src/Module/Admin/Addons/Details.php
@@ -84,8 +84,6 @@ class Details extends BaseAdmin
 					info(DI::l10n()->t('Addon %s enabled.', $addon));
 				}
 
-				Addon::saveEnabledList();
-
 				DI::baseUrl()->redirect('admin/addons/' . $addon);
 			}
 

--- a/update.php
+++ b/update.php
@@ -92,10 +92,7 @@ function update_1191()
 	DI::config()->set('system', 'maintenance', 1);
 
 	if (Addon::isEnabled('forumlist')) {
-		//delete forumlist manually from addon and hook table
-		// since Addon::uninstall() don't work here
-		DBA::delete('addon', ['name' => 'forumlist']);
-		DBA::delete('hook', ['file' => 'addon/forumlist/forumlist.php']);
+		Addon::uninstall('forumlist');
 	}
 
 	// select old formlist addon entries

--- a/update.php
+++ b/update.php
@@ -92,23 +92,10 @@ function update_1191()
 	DI::config()->set('system', 'maintenance', 1);
 
 	if (Addon::isEnabled('forumlist')) {
-		$addon = 'forumlist';
-		$addons = DI::config()->get('system', 'addon');
-		$addons_arr = [];
-
-		if ($addons) {
-			$addons_arr = explode(",", str_replace(" ", "", $addons));
-
-			$idx = array_search($addon, $addons_arr);
-			if ($idx !== false) {
-				unset($addons_arr[$idx]);
-				//delete forumlist manually from addon and hook table
-				// since Addon::uninstall() don't work here
-				q("DELETE FROM `addon` WHERE `name` = 'forumlist' ");
-				q("DELETE FROM `hook` WHERE `file` = 'addon/forumlist/forumlist.php' ");
-				DI::config()->set('system', 'addon', implode(", ", $addons_arr));
-			}
-		}
+		//delete forumlist manually from addon and hook table
+		// since Addon::uninstall() don't work here
+		DBA::delete('addon', ['name' => 'forumlist']);
+		DBA::delete('hook', ['file' => 'addon/forumlist/forumlist.php']);
 	}
 
 	// select old formlist addon entries


### PR DESCRIPTION
On one of my servers I had an interesting problem: Just installed addons got uninstalled directly after being installed.

After some tests I realized that the problem was caused due to some concurrent behaviour. The enabled addons are stored both in a config variable and the `addon` table. When we activate (or deactivate) and addon then we perform the appropriate changes in the `addon` table and we write it down in the config variable. But nearly at the same time - during the startup - the config variable is compared with the installed addons. And if that mismatches, the addons are activated or deactivated.

On my system the page load (with reading of the config variable) seem to be faster than storing the value in the config variable. So the just installed addon got uninstalled instantaneously. Since we don't need that config variable (it is some leftover from ancient times), it is now removed.