### PR TITLE
Remove extraneous HTML decode in Markdown::toBBCode

### DIFF
--- a/src/Content/Text/Markdown.php
+++ b/src/Content/Text/Markdown.php
@@ -109,8 +109,6 @@ class Markdown
 	 */
 	public static function toBBCode($s)
 	{
-		$s = html_entity_decode($s, ENT_COMPAT, 'UTF-8');
-
 		// The parser cannot handle paragraphs correctly
 		$s = str_replace(['</p>', '<p>', '<p dir="ltr">'], ['<br>', '<br>', '<br>'], $s);
 

--- a/tests/src/Content/Text/MarkdownTest.php
+++ b/tests/src/Content/Text/MarkdownTest.php
@@ -21,6 +21,7 @@
 
 namespace Friendica\Test\src\Content\Text;
 
+use Friendica\Content\Text\HTML;
 use Friendica\Content\Text\Markdown;
 use Friendica\Test\MockedTest;
 use Friendica\Test\Util\AppMockTrait;
@@ -67,5 +68,31 @@ class MarkdownTest extends MockedTest
 		$output = Markdown::convert($input);
 
 		$this->assertEquals($expected, $output);
+	}
+
+	public function dataMarkdownText()
+	{
+		return [
+			'bug-8358-double-decode' => [
+				'expectedBBCode' => 'with the <sup> and </sup> tag',
+				'markdown' => 'with the &lt;sup&gt; and &lt;/sup&gt; tag',
+			],
+		];
+	}
+
+	/**
+	 * Test convert Markdown to BBCode
+	 *
+	 * @dataProvider dataMarkdownText
+	 *
+	 * @param string $expectedBBCode Expected BBCode output
+	 * @param string $html           Markdown text
+	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
+	 */
+	public function testToBBCode($expectedBBCode, $html)
+	{
+		$actual = Markdown::toBBCode($html);
+
+		$this->assertEquals($expectedBBCode, $actual);
 	}
 }

--- a/view/templates/babel.tpl
+++ b/view/templates/babel.tpl
@@ -6,6 +6,7 @@
 		</div>
 		<div class="form-group">
 			{{include file="field_radio.tpl" field=$type_bbcode}}
+			{{include file="field_radio.tpl" field=$type_diaspora}}
 			{{include file="field_radio.tpl" field=$type_markdown}}
 			{{include file="field_radio.tpl" field=$type_html}}
 		</div>


### PR DESCRIPTION
Fixes #8358 

I checked, everywhere we use `Markdown::toBBCode` in the Diaspora protocol, we already ran `XML::unescape` on the input text, which made the decode at the start of the function redundant and harmful in this particular case.

Also, test!