### PR TITLE
Allow null values in photo table permission fields

### DIFF
--- a/mod/item.php
+++ b/mod/item.php
@@ -244,10 +244,10 @@ function item_post(App $a) {
 	$body = preg_replace('#\[url=([^\]]*?)\]\[/url\]#ism', '[url]$1[/url]', $body);
 
 	if (!empty($orig_post)) {
-		$str_group_allow   = $orig_post['allow_gid'] ?? '';
-		$str_contact_allow = $orig_post['allow_cid'] ?? '';
-		$str_group_deny    = $orig_post['deny_gid']  ?? '';
-		$str_contact_deny  = $orig_post['deny_cid']  ?? '';
+		$str_group_allow   = $orig_post['allow_gid'];
+		$str_contact_allow = $orig_post['allow_cid'];
+		$str_group_deny    = $orig_post['deny_gid'];
+		$str_contact_deny  = $orig_post['deny_cid'];
 		$location          = $orig_post['location'];
 		$coord             = $orig_post['coord'];
 		$verb              = $orig_post['verb'];
@@ -264,10 +264,10 @@ function item_post(App $a) {
 	} else {
 		$aclFormatter = DI::aclFormatter();
 
-		$str_group_allow   = isset($_REQUEST['group_allow'])   ? $aclFormatter->toString($_REQUEST['group_allow'])    : $user['allow_gid'] ?? '';
-		$str_contact_allow = isset($_REQUEST['contact_allow']) ? $aclFormatter->toString($_REQUEST['contact__allow']) : $user['allow_cid'] ?? '';
-		$str_group_deny    = isset($_REQUEST['group_deny'])    ? $aclFormatter->toString($_REQUEST['group_deny'])     : $user['deny_gid']  ?? '';
-		$str_contact_deny  = isset($_REQUEST['contact_deny'])  ? $aclFormatter->toString($_REQUEST['contact_deny'])   : $user['deny_cid']  ?? '';
+		$str_group_allow   = isset($_REQUEST['group_allow'])   ? $aclFormatter->toString($_REQUEST['group_allow'])    : $user['allow_gid'];
+		$str_contact_allow = isset($_REQUEST['contact_allow']) ? $aclFormatter->toString($_REQUEST['contact__allow']) : $user['allow_cid'];
+		$str_group_deny    = isset($_REQUEST['group_deny'])    ? $aclFormatter->toString($_REQUEST['group_deny'])     : $user['deny_gid'];
+		$str_contact_deny  = isset($_REQUEST['contact_deny'])  ? $aclFormatter->toString($_REQUEST['contact_deny'])   : $user['deny_cid'];
 
 		$title             = Strings::escapeTags(trim($_REQUEST['title']    ?? ''));
 		$location          = Strings::escapeTags(trim($_REQUEST['location'] ?? ''));
@@ -298,10 +298,10 @@ function item_post(App $a) {
 				$network = $toplevel_item['network'];
 			}
 
-			$str_contact_allow = $toplevel_item['allow_cid'] ?? '';
-			$str_group_allow   = $toplevel_item['allow_gid'] ?? '';
-			$str_contact_deny  = $toplevel_item['deny_cid'] ?? '';
-			$str_group_deny    = $toplevel_item['deny_gid'] ?? '';
+			$str_contact_allow = $toplevel_item['allow_cid'];
+			$str_group_allow   = $toplevel_item['allow_gid'];
+			$str_contact_deny  = $toplevel_item['deny_cid'];
+			$str_group_deny    = $toplevel_item['deny_gid'];
 			$private           = $toplevel_item['private'];
 
 			$wall              = $toplevel_item['wall'];

--- a/src/Model/Photo.php
+++ b/src/Model/Photo.php
@@ -298,14 +298,6 @@ class Photo
 			$backend_ref = $storage->put($Image->asString(), $backend_ref);
 		}
 
-		// Prevent "null" permissions
-		if (!empty($uid)) {
-			$allow_cid = $allow_cid ?? '<' . $uid . '>';
-			$allow_gid = $allow_gid ?? '';
-			$deny_cid = $deny_cid ?? '';
-			$deny_gid = $deny_gid ?? '';
-		}
-
 		$fields = [
 			"uid" => $uid,
 			"contact-id" => $cid,

--- a/src/Module/Photo.php
+++ b/src/Module/Photo.php
@@ -93,7 +93,12 @@ class Photo extends BaseModule
 			throw new \Friendica\Network\HTTPException\NotFoundException();
 		}
 
-		$cacheable = ($photo["allow_cid"] . $photo["allow_gid"] . $photo["deny_cid"] . $photo["deny_gid"] === "") && (isset($photo["cacheable"]) ? $photo["cacheable"] : true);
+		$cacheable =
+			empty($photo['allow_cid']) &&
+			empty($photo['allow_gid']) &&
+			empty($photo['deny_cid']) &&
+			empty($photo['deny_gid']) &&
+			($photo['cacheable'] ?? true);
 
 		$img = MPhoto::getImageForPhoto($photo);
 


### PR DESCRIPTION
Replaces #8430
Fixes #8371 

This is what should have been done from the start. There's no actual reason to triple-check (`===`) specifically for empty string since we don't differentiate between `null` values and empty string anyway.

I didn't revert all the previous PR because they introduce a potentially useful setting for making picture accessible in private posts to non-Friendica users, instead I went over each of them and removed what is unnecessary or harmful.

I'm sorry I didn't look into this earlier, I thought Michael had this and I had my hands kind of full otherwise, but it would have saved everyone a bunch of time.

This PR will also retroactively enable all the photos with NULL permissions to be displayed again.