### PR TITLE
Prevent endless loops and long running feed processing

### DIFF
--- a/src/Model/GContact.php
+++ b/src/Model/GContact.php
@@ -884,11 +884,11 @@ class GContact
 			$items = $outbox['orderedItems'];
 		} elseif (!empty($outbox['first']['orderedItems'])) {
 			$items = $outbox['first']['orderedItems'];
-		} elseif (!empty($outbox['first']['href'])) {
+		} elseif (!empty($outbox['first']['href']) && ($outbox['first']['href'] != $feed)) {
 			self::updateFromOutbox($outbox['first']['href'], $data);
 			return;
 		} elseif (!empty($outbox['first'])) {
-			if (is_string($outbox['first'])) {
+			if (is_string($outbox['first']) && ($outbox['first'] != $feed)) {
 				self::updateFromOutbox($outbox['first'], $data);
 			} else {
 				Logger::warning('Unexpected data', ['outbox' => $outbox]);

--- a/src/Protocol/ActivityPub.php
+++ b/src/Protocol/ActivityPub.php
@@ -231,7 +231,7 @@ class ActivityPub
 			$items = $data['orderedItems'];
 		} elseif (!empty($data['first']['orderedItems'])) {
 			$items = $data['first']['orderedItems'];
-		} elseif (!empty($data['first']) && is_string($data['first'])) {
+		} elseif (!empty($data['first']) && is_string($data['first']) && ($data['first'] != $url)) {
 			return self::fetchItems($data['first'], $uid);
 		} else {
 			$items = [];

--- a/src/Protocol/Feed.php
+++ b/src/Protocol/Feed.php
@@ -232,8 +232,16 @@ class Feed {
 		}
 
 		$items = [];
+
+		// Limit the number of items that are about to be fetched
+		$total_items = ($entries->length - 1);
+		$max_items = DI::config()->get('system', 'max_feed_items');
+		if (($max_items > 0) && ($total_items > $max_items)) {
+			$total_items = $max_items;
+		}
+
 		// Importing older entries first
-		for ($i = $entries->length - 1; $i >= 0; --$i) {
+		for ($i = $total_items; $i >= 0; --$i) {
 			$entry = $entries->item($i);
 
 			$item = array_merge($header, $author);

--- a/src/Worker/Cron.php
+++ b/src/Worker/Cron.php
@@ -69,9 +69,6 @@ class Cron
 		// Clear cache entries
 		Worker::add(PRIORITY_LOW, "CronJobs", "clear_cache");
 
-		// Repair missing Diaspora values in contacts
-		Worker::add(PRIORITY_LOW, "CronJobs", "repair_diaspora");
-
 		// Repair entries in the database
 		Worker::add(PRIORITY_LOW, "CronJobs", "repair_database");
 

--- a/static/defaults.config.php
+++ b/static/defaults.config.php
@@ -273,6 +273,10 @@ return [
 		// Maximum number of queue items for a single contact before subsequent messages are discarded.
 		'max_contact_queue' => 500,
 
+		// max_feed_items (Integer)
+		// Maximum number of feed items that are fetched and processed. For unlimited items set to 0.
+		'max_feed_items' => 10,
+
 		// max_image_length (Integer)
 		// An alternate way of limiting picture upload sizes.
 		// Specify the maximum pixel  length that pictures are allowed to be (for non-square pictures, it will apply to the longest side).

--- a/static/defaults.config.php
+++ b/static/defaults.config.php
@@ -275,7 +275,7 @@ return [
 
 		// max_feed_items (Integer)
 		// Maximum number of feed items that are fetched and processed. For unlimited items set to 0.
-		'max_feed_items' => 10,
+		'max_feed_items' => 20,
 
 		// max_image_length (Integer)
 		// An alternate way of limiting picture upload sizes.


### PR DESCRIPTION
I had a look at my workers today. There had been some really long running processes that blocked the whole system. It was caused by an endless loop while fetching AP items and some feeds with very much items.