### PR TITLE
Remove extraneous relation on item-activity.id

### DIFF
--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -759,7 +759,7 @@ return [
 	"item-activity" => [
 		"comment" => "Activities for items",
 		"fields" => [
-			"id" => ["type" => "int unsigned", "not null" => "1", "extra" => "auto_increment", "primary" => "1", "relation" => ["thread" => "iid"]],
+			"id" => ["type" => "int unsigned", "not null" => "1", "extra" => "auto_increment", "primary" => "1"],
 			"uri" => ["type" => "varchar(255)", "comment" => ""],
 			"uri-id" => ["type" => "int unsigned", "relation" => ["item-uri" => "id"], "comment" => "Id of the item-uri table entry that contains the item uri"],
 			"uri-hash" => ["type" => "varchar(80)", "not null" => "1", "default" => "", "comment" => "RIPEMD-128 hash from uri"],

--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -775,7 +775,7 @@ return [
 	"item-content" => [
 		"comment" => "Content for all posts",
 		"fields" => [
-			"id" => ["type" => "int unsigned", "not null" => "1", "extra" => "auto_increment", "primary" => "1", "relation" => ["thread" => "iid"]],
+			"id" => ["type" => "int unsigned", "not null" => "1", "extra" => "auto_increment", "primary" => "1"],
 			"uri" => ["type" => "varchar(255)", "comment" => ""],
 			"uri-id" => ["type" => "int unsigned", "relation" => ["item-uri" => "id"], "comment" => "Id of the item-uri table entry that contains the item uri"],
 			"uri-plink-hash" => ["type" => "varchar(80)", "not null" => "1", "default" => "", "comment" => "RIPEMD-128 hash from uri"],


### PR DESCRIPTION
Should fix #7134

Since it's a change in the relations, I don't believe there will be any database structure change and as such doesn't require a bum in the schema version number.

Thanks a ton to @SpcCw who single-handedly spearheaded the debugging effort for this hard to track issue.