### PR TITLE
Skip Contact::getDetailsByURL when url is empty in GContact::searchByName

### DIFF
--- a/src/Model/GContact.php
+++ b/src/Model/GContact.php
@@ -107,7 +107,7 @@ class GContact
 
 			// Ignore results that look strange.
 			// For historic reasons the gcontact table does contain some garbage.
-			if (!empty($urlparts['query']) || !empty($urlparts['fragment'])) {
+			if (empty($result['nurl']) || !empty($urlparts['query']) || !empty($urlparts['fragment'])) {
 				continue;
 			}
 


### PR DESCRIPTION
- Address https://github.com/friendica/friendica/issues/8000#issuecomment-602169147