### PR TITLE
Funkwhale support added, Peertube support improved

### DIFF
--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -133,6 +133,18 @@ class Processor
 				} else {
 					$item['body'] .= "\n[img=" . $attach['url'] . ']' . $attach['name'] . '[/img]';
 				}
+			} elseif ($filetype == 'audio') {
+				if (!empty($activity['source']) && strpos($activity['source'], $attach['url'])) {
+					continue;
+				}
+
+				$item['body'] .= "\n[audio]" . $attach['url'] . '[/audio]';
+			} elseif ($filetype == 'video') {
+				if (!empty($activity['source']) && strpos($activity['source'], $attach['url'])) {
+					continue;
+				}
+
+				$item['body'] .= "\n[video]" . $attach['url'] . '[/video]';
 			} else {
 				if (!empty($item["attach"])) {
 					$item["attach"] .= ',';
@@ -387,10 +399,6 @@ class Processor
 			}
 			$item['content-warning'] = HTML::toBBCode($activity['summary']);
 			$item['body'] = $content;
-
-			if (($activity['object_type'] == 'as:Video') && !empty($activity['alternate-url'])) {
-				$item['body'] .= "\n[video]" . $activity['alternate-url'] . '[/video]';
-			}
 		}
 
 		$item['tag'] = self::constructTagString($activity['tags'], $activity['sensitive']);


### PR DESCRIPTION
This adds the missing support for audio types in PR, see issue #7771. It also fixes the Peertube support. Previously `alternate-url` pointed to the video data instead to the Peertube page with the video.