### PR TITLE
Issue 7771: Funkwhale support

### DIFF
--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -1631,7 +1631,7 @@ class BBCode
 		// Try to Oembed
 		if ($try_oembed) {
 			$text = preg_replace("/\[video\](.*?\.(ogg|ogv|oga|ogm|webm|mp4).*?)\[\/video\]/ism", '<video src="$1" controls="controls" width="' . $a->videowidth . '" height="' . $a->videoheight . '" loop="true"><a href="$1">$1</a></video>', $text);
-			$text = preg_replace("/\[audio\](.*?\.(ogg|ogv|oga|ogm|webm|mp4|mp3).*?)\[\/audio\]/ism", '<audio src="$1" controls="controls"><a href="$1">$1</a></audio>', $text);
+			$text = preg_replace("/\[audio\](.*?)\[\/audio\]/ism", '<audio src="$1" controls="controls"><a href="$1">$1</a></audio>', $text);
 
 			$text = preg_replace_callback("/\[video\](.*?)\[\/video\]/ism", $try_oembed_callback, $text);
 			$text = preg_replace_callback("/\[audio\](.*?)\[\/audio\]/ism", $try_oembed_callback, $text);

--- a/src/Model/APContact.php
+++ b/src/Model/APContact.php
@@ -26,6 +26,7 @@ use Friendica\Core\Logger;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Protocol\ActivityPub;
+use Friendica\Util\Crypto;
 use Friendica\Util\Network;
 use Friendica\Util\JsonLD;
 use Friendica\Util\DateTimeFormat;
@@ -209,6 +210,9 @@ class APContact
 		$apcontact['pubkey'] = null;
 		if (!empty($compacted['w3id:publicKey'])) {
 			$apcontact['pubkey'] = trim(JsonLD::fetchElement($compacted['w3id:publicKey'], 'w3id:publicKeyPem', '@value'));
+			if (strstr($apcontact['pubkey'], 'RSA ')) {
+				$apcontact['pubkey'] = Crypto::rsaToPem($apcontact['pubkey']);
+			}
 		}
 
 		$apcontact['manually-approve'] = (int)JsonLD::fetchElement($compacted, 'as:manuallyApprovesFollowers');

--- a/src/Protocol/ActivityPub/Receiver.php
+++ b/src/Protocol/ActivityPub/Receiver.php
@@ -841,6 +841,10 @@ class Receiver
 				continue;
 			}
 
+			if (empty($element['href'])) {
+				$element['href'] = $element['name'];
+			}
+
 			$taglist[] = $element;
 		}
 		return $taglist;


### PR DESCRIPTION
Fixes https://github.com/friendica/friendica/issues/7771

We now do support Funkwhale. To make this happen, we needed some tweaks to the core:
- the `[audio]` needed to work without an explicit fileending
- RSA keys have to work as well (newer version of Funkwhale won't use them anymore)
- Hashtags need to have an unique URL to be displayed correctly