### PR TITLE
OStatus: Avoid a notice

### DIFF
--- a/src/Protocol/OStatus.php
+++ b/src/Protocol/OStatus.php
@@ -247,7 +247,7 @@ class OStatus
 			$gcid = GContact::update($contact);
 
 			GContact::link($gcid, $contact["uid"], $contact["id"]);
-		} elseif ($contact["network"] != Protocol::DFRN) {
+		} elseif (empty($contact["network"]) || ($contact["network"] != Protocol::DFRN)) {
 			$contact = [];
 		}
 


### PR DESCRIPTION
This happens when the `$contact` variable doesn't contain that index.