### PR TITLE
Fix: Fetching content via the "objects" endpoint behaved wrong

### DIFF
--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -193,6 +193,8 @@ class Transmitter
 			$items = Item::select(['id'], $condition, ['limit' => [($page - 1) * 20, 20], 'order' => ['created' => true]]);
 			while ($item = Item::fetch($items)) {
 				$activity = self::createActivityFromItem($item['id'], true);
+		                $activity['type'] = $activity['type'] == 'Update' ? 'Create' : $activity['type'];
+
 				// Only list "Create" activity objects here, no reshares
 				if (is_array($activity['object']) && ($activity['type'] == 'Create')) {
 					$list[] = $activity['object'];


### PR DESCRIPTION
While analyzing #8341 I discovered some bad behaviour by our "objects" endpoint. This fixes it.