### PR TITLE
Prevent another endless loop while fetching AP items

### DIFF
--- a/src/Protocol/ActivityPub.php
+++ b/src/Protocol/ActivityPub.php
@@ -234,7 +234,7 @@ class ActivityPub
 		} elseif (!empty($data['first']) && is_string($data['first']) && ($data['first'] != $url)) {
 			return self::fetchItems($data['first'], $uid);
 		} else {
-			$items = [];
+			return [];
 		}
 
 		if (!empty($data['next']) && is_string($data['next'])) {


### PR DESCRIPTION
Some AP endpoints always provide a "next" field although there is no content anymore.