### PR TITLE
Should fix the unknown "internal-psid" field

### DIFF
--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -846,7 +846,9 @@ class Item
 	 */
 	private static function constructSelectFields(array $fields, array $selected)
 	{
-		$selected = array_merge($selected, ['internal-iid', 'internal-psid', 'internal-iaid', 'internal-network']);
+		if (!empty($selected)) {
+			$selected = array_merge($selected, ['internal-iid', 'internal-psid', 'internal-iaid', 'internal-network']);
+		}
 
 		if (in_array('verb', $selected)) {
 			$selected[] = 'internal-activity';

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -177,7 +177,7 @@ class Item
 		}
 
 		$pinned = [];
-		while ($useritem = self::fetch($useritems)) {
+		while ($useritem = DBA::fetch($useritems)) {
 			$pinned[] = $useritem['iid'];
 		}
 		DBA::close($useritems);


### PR DESCRIPTION
The `fetch` function from the item class must only be called for a dataset that had been created by the item functions. This should fix the problem with the unknown "internal-psid" field.