### PR TITLE
Discover contacts: Prevent putting much stress on remote systems

### DIFF
--- a/src/Model/GContact.php
+++ b/src/Model/GContact.php
@@ -1359,7 +1359,7 @@ class GContact
 
 				if (!Network::isUrlBlocked($contact)) {
 					Logger::info('Discover new AP contact', ['url' => $contact]);
-					Worker::add(PRIORITY_LOW, 'UpdateGContact', $contact);
+					Worker::add(PRIORITY_LOW, 'UpdateGContact', $contact, 'nodiscover');
 				} else {
 					Logger::info('No discovery, the URL is blocked.', ['url' => $contact]);
 				}
@@ -1399,7 +1399,7 @@ class GContact
 						}
 						if (!Network::isUrlBlocked($entry['value'])) {
 							Logger::info('Discover new PoCo contact', ['url' => $entry['value']]);
-							Worker::add(PRIORITY_LOW, 'UpdateGContact', $entry['value']);
+							Worker::add(PRIORITY_LOW, 'UpdateGContact', $entry['value'], 'nodiscover');
 						} else {
 							Logger::info('No discovery, the URL is blocked.', ['url' => $entry['value']]);
 						}

--- a/src/Worker/UpdateGContact.php
+++ b/src/Worker/UpdateGContact.php
@@ -35,12 +35,13 @@ class UpdateGContact
 	public static function execute(string $url, string $command = '')
 	{
 		$force = ($command == "force");
+		$nodiscover = ($command == "nodiscover");
 
 		$success = GContact::updateFromProbe($url, $force);
 
 		Logger::info('Updated from probe', ['url' => $url, 'force' => $force, 'success' => $success]);
 
-		if ($success && (DI::config()->get('system', 'gcontact_discovery') == GContact::DISCOVERY_RECURSIVE)) {
+		if ($success && !$nodiscover && (DI::config()->get('system', 'gcontact_discovery') == GContact::DISCOVERY_RECURSIVE)) {
 			GContact::discoverFollowers($url);
 		}
 	}


### PR DESCRIPTION
The polling of remote followers/followings can put much stress on remote systems if done in the recursive mode. This should reduce the stress a lot.