### PR TITLE
AP: Limited comment distribution

### DIFF
--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -478,7 +478,7 @@ class Transmitter
 								$data['to'][] = $profile['url'];
 							} else {
 								$data['cc'][] = $profile['url'];
-								if (($item['private'] != Item::PRIVATE) && $item['private'] && !empty($actor_profile['followers'])) {
+								if (($item['private'] != Item::PRIVATE) && !empty($actor_profile['followers'])) {
 									$data['cc'][] = $actor_profile['followers'];
 								}
 							}


### PR DESCRIPTION
There had been a bug that limited the amount of receivers of a comment that had been distributed via AP. The most important persons (means: all persons already involved in that thread) always received the comment. But on AP also all your followers are receiving every comment. That hadn't been the case here.