### PR TITLE
Issue 8493: Avoid fatal error when fetching items via API

### DIFF
--- a/include/conversation.php
+++ b/include/conversation.php
@@ -149,11 +149,11 @@ function localize_item(&$item)
 		$activity = DI::activity();
 
 		if (stristr($item['verb'], Activity::POKE)) {
-			$verb = urldecode(substr($item['verb'],strpos($item['verb'],'#')+1));
+			$verb = urldecode(substr($item['verb'], strpos($item['verb'],'#') + 1));
 			if (!$verb) {
 				return;
 			}
-			if ($item['object-type']=="" || $item['object-type']!== Activity\ObjectType::PERSON) {
+			if ($item['object-type'] == "" || $item['object-type'] !== Activity\ObjectType::PERSON) {
 				return;
 			}
 
@@ -162,7 +162,7 @@ function localize_item(&$item)
 
 			$xmlhead = "<" . "?xml version='1.0' encoding='UTF-8' ?" . ">";
 
-			$obj = XML::parseString($xmlhead.$item['object']);
+			$obj = XML::parseString($xmlhead . $item['object']);
 
 			$Bname = $obj->title;
 			$Blink = $obj->id;
@@ -198,7 +198,7 @@ function localize_item(&$item)
 
 		}
 
-		if ($activity->match($item['verb'],  Activity::TAG)) {
+		if ($activity->match($item['verb'], Activity::TAG)) {
 			$fields = ['author-id', 'author-link', 'author-name', 'author-network',
 				'verb', 'object-type', 'resource-id', 'body', 'plink'];
 			$obj = Item::selectFirst($fields, ['uri' => $item['parent-uri']]);

--- a/include/conversation.php
+++ b/include/conversation.php
@@ -189,12 +189,12 @@ function localize_item(&$item)
 			$txt = DI::l10n()->t('%1$s poked %2$s');
 
 			// now translate the verb
-			$poked_t = trim(sprintf($txt, "", ""));
+			$poked_t = trim(sprintf($txt, '', ''));
 			$txt = str_replace($poked_t, DI::l10n()->t($verb), $txt);
 
 			// then do the sprintf on the translation string
 
-			$item['body'] = sprintf($txt, $A, $B). "\n\n\n" . $Bphoto;
+			$item['body'] = sprintf($txt, $A, $B) . "\n\n\n" . $Bphoto;
 
 		}
 


### PR DESCRIPTION
This should fix https://github.com/friendica/friendica/issues/8493

In that function there had been a lot of useless code. It had been reduced to the needed amount. Also a check for the "verb" field had been added (that solves the issue). The removal just had been the icing of the cake.

Only the stuff for "poke" and the remotely tagging had been left, since they are displayed as message with an body. The removed parts are for generating messages in the body for liking, disliking, attending and this whole other stuff that never had been displayed anywhere.