### PR TITLE
Fix Password Reset Token Security

### DIFF
--- a/mod/lostpass.php
+++ b/mod/lostpass.php
@@ -44,7 +44,7 @@ function lostpass_post(App $a)
 	$pwdreset_token = Strings::getRandomHex(32);
 
 	$fields = [
-		'pwdreset' => $pwdreset_token,
+		'pwdreset' => hash('sha256', $pwdreset_token),
 		'pwdreset_time' => DateTimeFormat::utcNow()
 	];
 	$result = DBA::update('user', $fields, ['uid' => $user['uid']]);
@@ -95,7 +95,7 @@ function lostpass_content(App $a)
 	if ($a->argc > 1) {
 		$pwdreset_token = $a->argv[1];
 
-		$user = DBA::selectFirst('user', ['uid', 'username', 'nickname', 'email', 'pwdreset_time', 'language'], ['pwdreset' => $pwdreset_token]);
+		$user = DBA::selectFirst('user', ['uid', 'username', 'nickname', 'email', 'pwdreset_time', 'language'], ['pwdreset' => hash('sha256', $pwdreset_token)]);
 		if (!DBA::isResult($user)) {
 			notice(DI::l10n()->t("Request could not be verified. \x28You may have previously submitted it.\x29 Password reset failed."));
 

--- a/mod/lostpass.php
+++ b/mod/lostpass.php
@@ -41,7 +41,7 @@ function lostpass_post(App $a)
 		DI::baseUrl()->redirect();
 	}
 
-	$pwdreset_token = Strings::getRandomName(12) . random_int(1000, 9999);
+	$pwdreset_token = Strings::getRandomHex(32);
 
 	$fields = [
 		'pwdreset' => $pwdreset_token,


### PR DESCRIPTION
Currently password reset tokens are not nearly as safe as they should be:
1. The random name is predictable.
2. The last 4-digits are brute forcible but not predictable.
3. Easily available for nefarious purposes if an adversary has read access to the DB, or they are leaked through SQL injection.

I fixed all of these issues in this PR.

The password reset tokens are now generated with a CSPRNG, specifically 16 bytes in length (32 ASCII hexadecimal encoded output).

The password reset tokens are stored in a hashed form, which means adversaries can't use them when obtained through read access via SQL injection, or read access to DB. And the received password reset token is hashed before the look up to make timing attacks impractical. Although this isn't the ideal solution since it's being indexed by a secret value, it is a bandaid that works.