### PR TITLE
The "sign" table had been removed

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -1,5 +1,5 @@
 -- ------------------------------------------
--- Friendica 2020.03-rc (Dalmatian Bellflower)
+-- Friendica 2020.06-dev (Red Hot Poker)
 -- DB_UPDATE_VERSION 1338
 -- ------------------------------------------
 
@@ -1151,19 +1151,6 @@ CREATE TABLE IF NOT EXISTS `session` (
 	 INDEX `sid` (`sid`(64)),
 	 INDEX `expire` (`expire`)
 ) DEFAULT COLLATE utf8mb4_general_ci COMMENT='web session storage';
-
---
--- TABLE sign
---
-CREATE TABLE IF NOT EXISTS `sign` (
-	`id` int unsigned NOT NULL auto_increment COMMENT 'sequential ID',
-	`iid` int unsigned NOT NULL DEFAULT 0 COMMENT 'item.id',
-	`signed_text` mediumtext COMMENT '',
-	`signature` text COMMENT '',
-	`signer` varchar(255) NOT NULL DEFAULT '' COMMENT '',
-	 PRIMARY KEY(`id`),
-	 UNIQUE INDEX `iid` (`iid`)
-) DEFAULT COLLATE utf8mb4_general_ci COMMENT='Diaspora signatures';
 
 --
 -- TABLE term

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -714,8 +714,6 @@ class Item
 			'nofinish' => 'event-nofinish','adjust' => 'event-adjust',
 			'ignore' => 'event-ignore', 'id' => 'event-id'];
 
-		$fields['sign'] = ['signed_text', 'signature', 'signer'];
-
 		$fields['diaspora-interaction'] = ['interaction'];
 
 		return $fields;
@@ -799,10 +797,6 @@ class Item
 
 		if (strpos($sql_commands, "`event`.") !== false) {
 			$joins .= " LEFT JOIN `event` ON `event-id` = `event`.`id`";
-		}
-
-		if (strpos($sql_commands, "`sign`.") !== false) {
-			$joins .= " LEFT JOIN `sign` ON `sign`.`iid` = `item`.`id`";
 		}
 
 		if (strpos($sql_commands, "`diaspora-interaction`.") !== false) {
@@ -2000,10 +1994,6 @@ class Item
 
 			if (!empty($dsprsig->signed_text) && empty($dsprsig->signature) && empty($dsprsig->signer)) {
 				DBA::insert('diaspora-interaction', ['uri-id' => $item['uri-id'], 'interaction' => $dsprsig->signed_text], true);
-			} else {
-				// The other fields are used by very old Friendica servers, so we currently store them differently
-				DBA::insert('sign', ['iid' => $current_post, 'signed_text' => $dsprsig->signed_text,
-					'signature' => $dsprsig->signature, 'signer' => $dsprsig->signer]);
 			}
 		}
 

--- a/src/Worker/DBClean.php
+++ b/src/Worker/DBClean.php
@@ -71,7 +71,7 @@ class DBClean {
 	 *  3:    Orphaned data from thread table.
 	 *  4:    Orphaned data from notify table.
 	 *  5:    Orphaned data from notify-threads table.
-	 *  6:    Orphaned data from sign table.
+	 *  6:    Legacy functionality (removed)
 	 *  7:    Orphaned data from term table.
 	 *  8:    Expired threads.
 	 *  9:    Old global item entries from expired threads.
@@ -224,31 +224,8 @@ class DBClean {
 				DI::config()->set('system', 'finished-dbclean-5', true);
 			}
 		} elseif ($stage == 6) {
-			$last_id = DI::config()->get('system', 'dbclean-last-id-6', 0);
-
-			Logger::log("Deleting orphaned data from sign table. Last ID: ".$last_id);
-			$r = DBA::p("SELECT `iid`, `id` FROM `sign`
-					WHERE NOT EXISTS (SELECT `id` FROM `item` WHERE `item`.`id` = `sign`.`iid`) AND `id` >= ?
-					ORDER BY `id` LIMIT ?", $last_id, $limit);
-			$count = DBA::numRows($r);
-			if ($count > 0) {
-				Logger::log("found sign orphans: ".$count);
-				while ($orphan = DBA::fetch($r)) {
-					$last_id = $orphan["id"];
-					DBA::delete('sign', ['iid' => $orphan["iid"]]);
-				}
-				Worker::add(PRIORITY_MEDIUM, 'DBClean', 6, $last_id);
-			} else {
-				Logger::log("No sign orphans found");
-			}
-			DBA::close($r);
-			Logger::log("Done deleting ".$count." orphaned data from sign table. Last ID: ".$last_id);
-
-			DI::config()->set('system', 'dbclean-last-id-6', $last_id);
-
-			if ($count < $limit) {
-				DI::config()->set('system', 'finished-dbclean-6', true);
-			}
+			// The legacy functionality had been removed
+			DI::config()->set('system', 'finished-dbclean-6', true);
 		} elseif ($stage == 7) {
 			$last_id = DI::config()->get('system', 'dbclean-last-id-7', 0);
 

--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -1268,20 +1268,6 @@ return [
 			"expire" => ["expire"],
 		]
 	],
-	"sign" => [
-		"comment" => "Diaspora signatures",
-		"fields" => [
-			"id" => ["type" => "int unsigned", "not null" => "1", "extra" => "auto_increment", "primary" => "1", "comment" => "sequential ID"],
-			"iid" => ["type" => "int unsigned", "not null" => "1", "default" => "0", "relation" => ["item" => "id"], "comment" => "item.id"],
-			"signed_text" => ["type" => "mediumtext", "comment" => ""],
-			"signature" => ["type" => "text", "comment" => ""],
-			"signer" => ["type" => "varchar(255)", "not null" => "1", "default" => "", "comment" => ""],
-		],
-		"indexes" => [
-			"PRIMARY" => ["id"],
-			"iid" => ["UNIQUE", "iid"],
-		]
-	],
 	"term" => [
 		"comment" => "item taxonomy (categories, tags, etc.) table",
 		"fields" => [


### PR DESCRIPTION
The `sign` had long been replaced by the `diaspora-interaction` table (which luckily is connected via the `uri-id` field). On my both systems the newest entry had been from October 2018. So I think we are on the safe side to remove it.

This is a (very small) preparation for the item structure rearrangement.