### PR TITLE
We now store tags in "tag"

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -178,29 +178,6 @@ define('NOTIFY_SHARE',       Notify\Type::SHARE);
 define('NOTIFY_SYSTEM',      Notify\Type::SYSTEM);
 /* @}*/
 
-
-/** @deprecated since 2019.03, use Term::UNKNOWN instead */
-define('TERM_UNKNOWN',   Term::UNKNOWN);
-/** @deprecated since 2019.03, use Term::HASHTAG instead */
-define('TERM_HASHTAG',   Term::HASHTAG);
-/** @deprecated since 2019.03, use Term::MENTION instead */
-define('TERM_MENTION',   Term::MENTION);
-/** @deprecated since 2019.03, use Term::CATEGORY instead */
-define('TERM_CATEGORY',  Term::CATEGORY);
-/** @deprecated since 2019.03, use Term::PCATEGORY instead */
-define('TERM_PCATEGORY', Term::PCATEGORY);
-/** @deprecated since 2019.03, use Term::FILE instead */
-define('TERM_FILE',      Term::FILE);
-/** @deprecated since 2019.03, use Term::SAVEDSEARCH instead */
-define('TERM_SAVEDSEARCH', Term::SAVEDSEARCH);
-/** @deprecated since 2019.03, use Term::CONVERSATION instead */
-define('TERM_CONVERSATION', Term::CONVERSATION);
-
-/** @deprecated since 2019.03, use Term::OBJECT_TYPE_POST instead */
-define('TERM_OBJ_POST',  Term::OBJECT_TYPE_POST);
-/** @deprecated since 2019.03, use Term::OBJECT_TYPE_PHOTO instead */
-define('TERM_OBJ_PHOTO', Term::OBJECT_TYPE_PHOTO);
-
 /**
  * @name Gravity
  *

--- a/include/api.php
+++ b/include/api.php
@@ -41,6 +41,7 @@ use Friendica\Model\Item;
 use Friendica\Model\Mail;
 use Friendica\Model\Notify;
 use Friendica\Model\Photo;
+use Friendica\Model\Term;
 use Friendica\Model\User;
 use Friendica\Model\UserItem;
 use Friendica\Network\FKOAuth1;
@@ -1541,7 +1542,7 @@ function api_search($type)
 		$condition = ["`oid` > ?
 			AND (`uid` = 0 OR (`uid` = ? AND NOT `global`)) 
 			AND `otype` = ? AND `type` = ? AND `term` = ?",
-			$since_id, local_user(), TERM_OBJ_POST, TERM_HASHTAG, $searchTerm];
+			$since_id, local_user(), Term::OBJECT_TYPE_POST, Term::HASHTAG, $searchTerm];
 		if ($max_id > 0) {
 			$condition[0] .= ' AND `oid` <= ?';
 			$condition[] = $max_id;

--- a/include/api.php
+++ b/include/api.php
@@ -2041,7 +2041,7 @@ function api_statuses_repeat($type)
 
 	Logger::log('API: api_statuses_repeat: '.$id);
 
-	$fields = ['body', 'title', 'attach', 'tag', 'author-name', 'author-link', 'author-avatar', 'guid', 'created', 'plink'];
+	$fields = ['uri-id', 'body', 'title', 'attach', 'tag', 'author-name', 'author-link', 'author-avatar', 'guid', 'created', 'plink'];
 	$item = Item::selectFirst($fields, ['id' => $id, 'private' => [Item::PUBLIC, Item::UNLISTED]]);
 
 	if (DBA::isResult($item) && $item['body'] != "") {
@@ -2069,6 +2069,8 @@ function api_statuses_repeat($type)
 		}
 
 		$item_id = item_post($a);
+
+		/// @todo Copy tags from the original post to the new one
 	} else {
 		throw new ForbiddenException();
 	}

--- a/include/items.php
+++ b/include/items.php
@@ -141,31 +141,44 @@ function query_page_info($url, $photo = "", $keywords = false, $keyword_blacklis
 	return $data;
 }
 
-function add_page_keywords($url, $photo = "", $keywords = false, $keyword_blacklist = "", $return_array = false)
+function add_page_keywords($url, $photo = "", $keywords = false, $keyword_blacklist = "")
 {
 	$data = query_page_info($url, $photo, $keywords, $keyword_blacklist);
+	if (empty($data['keywords']) || !is_array($data['keywords'])) {
+		return '';
+	}
 
 	$tags = "";
-	$taglist = [];
-	if (isset($data["keywords"]) && count($data["keywords"])) {
-		foreach ($data["keywords"] as $keyword) {
-			$hashtag = str_replace([" ", "+", "/", ".", "#", "'"],
-				["", "", "", "", "", ""], $keyword);
+	foreach ($data["keywords"] as $keyword) {
+		$hashtag = str_replace([" ", "+", "/", ".", "#", "'"],
+			["", "", "", "", "", ""], $keyword);
 
-			if ($tags != "") {
-				$tags .= ", ";
-			}
-
-			$tags .= "#[url=" . DI::baseUrl() . "/search?tag=" . $hashtag . "]" . $hashtag . "[/url]";
-			$taglist[] = $hashtag;
+		if ($tags != "") {
+			$tags .= ", ";
 		}
+
+		$tags .= "#[url=" . DI::baseUrl() . "/search?tag=" . $hashtag . "]" . $hashtag . "[/url]";
 	}
 
-	if ($return_array) {
-		return $taglist;
-	} else {
-		return $tags;
+	return $tags;
+}
+
+function get_page_keywords($url, $photo = "", $keywords = false, $keyword_blacklist = "")
+{
+	$data = query_page_info($url, $photo, $keywords, $keyword_blacklist);
+	if (empty($data['keywords']) || !is_array($data['keywords'])) {
+		return [];
 	}
+
+	$taglist = [];
+	foreach ($data['keywords'] as $keyword) {
+		$hashtag = str_replace([" ", "+", "/", ".", "#", "'"],
+			["", "", "", "", "", ""], $keyword);
+
+		$taglist[] = $hashtag;
+	}
+
+	return $taglist;
 }
 
 function add_page_info($url, $no_photos = false, $photo = "", $keywords = false, $keyword_blacklist = "")

--- a/include/items.php
+++ b/include/items.php
@@ -144,7 +144,7 @@ function query_page_info($url, $photo = "", $keywords = false, $keyword_blacklis
 function add_page_keywords($url, $photo = "", $keywords = false, $keyword_blacklist = "")
 {
 	$data = query_page_info($url, $photo, $keywords, $keyword_blacklist);
-	if (empty($data['keywords']) || !is_array($data['keywords'])) {
+	if (empty($data["keywords"]) || !is_array($data["keywords"])) {
 		return '';
 	}
 
@@ -166,7 +166,7 @@ function add_page_keywords($url, $photo = "", $keywords = false, $keyword_blackl
 function get_page_keywords($url, $photo = "", $keywords = false, $keyword_blacklist = "")
 {
 	$data = query_page_info($url, $photo, $keywords, $keyword_blacklist);
-	if (empty($data['keywords']) || !is_array($data['keywords'])) {
+	if (empty($data["keywords"]) || !is_array($data["keywords"])) {
 		return [];
 	}
 

--- a/include/items.php
+++ b/include/items.php
@@ -141,11 +141,12 @@ function query_page_info($url, $photo = "", $keywords = false, $keyword_blacklis
 	return $data;
 }
 
-function add_page_keywords($url, $photo = "", $keywords = false, $keyword_blacklist = "")
+function add_page_keywords($url, $photo = "", $keywords = false, $keyword_blacklist = "", $return_array = false)
 {
 	$data = query_page_info($url, $photo, $keywords, $keyword_blacklist);
 
 	$tags = "";
+	$taglist = [];
 	if (isset($data["keywords"]) && count($data["keywords"])) {
 		foreach ($data["keywords"] as $keyword) {
 			$hashtag = str_replace([" ", "+", "/", ".", "#", "'"],
@@ -156,10 +157,15 @@ function add_page_keywords($url, $photo = "", $keywords = false, $keyword_blackl
 			}
 
 			$tags .= "#[url=" . DI::baseUrl() . "/search?tag=" . $hashtag . "]" . $hashtag . "[/url]";
+			$taglist[] = $hashtag;
 		}
 	}
 
-	return $tags;
+	if ($return_array) {
+		return $taglist;
+	} else {
+		return $tags;
+	}
 }
 
 function add_page_info($url, $no_photos = false, $photo = "", $keywords = false, $keyword_blacklist = "")

--- a/mod/item.php
+++ b/mod/item.php
@@ -46,6 +46,7 @@ use Friendica\Model\FileTag;
 use Friendica\Model\Item;
 use Friendica\Model\Notify\Type;
 use Friendica\Model\Photo;
+use Friendica\Model\Tag;
 use Friendica\Model\Term;
 use Friendica\Network\HTTPException;
 use Friendica\Object\EMail\ItemCCEMail;
@@ -749,6 +750,8 @@ function item_post(App $a) {
 
 		throw new HTTPException\InternalServerErrorException(DI::l10n()->t('Item couldn\'t be fetched.'));
 	}
+
+	Tag::storeFromBody($datarray['uri-id'], $datarray['body']);
 
 	// update filetags in pconfig
 	FileTag::updatePconfig($uid, $categories_old, $categories_new, 'category');

--- a/mod/network.php
+++ b/mod/network.php
@@ -793,7 +793,7 @@ function networkThreadedView(App $a, $update, $parent)
 			STRAIGHT_JOIN `contact` AS `author` ON `author`.`id` = `item`.`author-id`
 			WHERE `item`.`uid` = 0 AND `item`.$ordering < ? AND `item`.$ordering > ? AND `item`.`gravity` = ?
 				AND NOT `author`.`hidden` AND NOT `author`.`blocked`" . $sql_tag_nets,
-			local_user(), TERM_OBJ_POST, TERM_HASHTAG,
+			local_user(), Term::OBJECT_TYPE_POST, Term::HASHTAG,
 			$top_limit, $bottom_limit, GRAVITY_PARENT);
 
 		$data = DBA::toArray($items);

--- a/mod/photos.php
+++ b/mod/photos.php
@@ -36,6 +36,7 @@ use Friendica\Model\Contact;
 use Friendica\Model\Item;
 use Friendica\Model\Photo;
 use Friendica\Model\Profile;
+use Friendica\Model\Tag;
 use Friendica\Model\User;
 use Friendica\Module\BaseProfile;
 use Friendica\Network\Probe;
@@ -421,7 +422,7 @@ function photos_post(App $a)
 		}
 
 		if ($item_id) {
-			$item = Item::selectFirst(['tag', 'inform'], ['id' => $item_id, 'uid' => $page_owner_uid]);
+			$item = Item::selectFirst(['tag', 'inform', 'uri-id'], ['id' => $item_id, 'uid' => $page_owner_uid]);
 
 			if (DBA::isResult($item)) {
 				$old_tag    = $item['tag'];
@@ -521,10 +522,17 @@ function photos_post(App $a)
 
 							$profile = str_replace(',', '%2c', $profile);
 							$str_tags .= '@[url=' . $profile . ']' . $newname . '[/url]';
+
+							if (!empty($item['uri-id'])) {
+								Tag::store($item['uri-id'], Tag::MENTION, $newname, $profile);
+							}	
 						}
 					} elseif (strpos($tag, '#') === 0) {
 						$tagname = substr($tag, 1);
 						$str_tags .= '#[url=' . DI::baseUrl() . "/search?tag=" . $tagname . ']' . $tagname . '[/url],';
+						if (!empty($item['uri-id'])) {
+							Tag::store($item['uri-id'], Tag::HASHTAG, $tagname);
+						}
 					}
 				}
 			}

--- a/mod/tagger.php
+++ b/mod/tagger.php
@@ -28,6 +28,7 @@ use Friendica\Core\Worker;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Item;
+use Friendica\Model\Term;
 use Friendica\Protocol\Activity;
 use Friendica\Util\Strings;
 use Friendica\Util\XML;
@@ -168,7 +169,7 @@ EOT;
 		Item::update(['visible' => true], ['id' => $item['id']]);
 	}
 
-	$term_objtype = ($item['resource-id'] ? TERM_OBJ_PHOTO : TERM_OBJ_POST);
+	$term_objtype = ($item['resource-id'] ? Term::OBJECT_TYPE_PHOTO : Term::OBJECT_TYPE_POST);
 
 	$t = q("SELECT count(tid) as tcount FROM term WHERE oid=%d AND term='%s'",
 		intval($item['id']),
@@ -179,7 +180,7 @@ EOT;
 		q("INSERT INTO term (oid, otype, type, term, url, uid) VALUE (%d, %d, %d, '%s', '%s', %d)",
 		   intval($item['id']),
 		   $term_objtype,
-		   TERM_HASHTAG,
+		   Term::HASHTAG,
 		   DBA::escape($term),
 		   '',
 		   intval($owner_uid)
@@ -201,7 +202,7 @@ EOT;
 			q("INSERT INTO term (`oid`, `otype`, `type`, `term`, `url`, `uid`) VALUE (%d, %d, %d, '%s', '%s', %d)",
 				intval($original_item['id']),
 				$term_objtype,
-				TERM_HASHTAG,
+				Term::HASHTAG,
 				DBA::escape($term),
 				'',
 				intval($owner_uid)

--- a/mod/tagger.php
+++ b/mod/tagger.php
@@ -28,6 +28,7 @@ use Friendica\Core\Worker;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Item;
+use Friendica\Model\Tag;
 use Friendica\Model\Term;
 use Friendica\Protocol\Activity;
 use Friendica\Util\Strings;
@@ -170,6 +171,8 @@ EOT;
 	}
 
 	$term_objtype = ($item['resource-id'] ? Term::OBJECT_TYPE_PHOTO : Term::OBJECT_TYPE_POST);
+
+	Tag::store($item['uri-id'], Tag::HASHTAG, $term);
 
 	$t = q("SELECT count(tid) as tcount FROM term WHERE oid=%d AND term='%s'",
 		intval($item['id']),

--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -2100,7 +2100,7 @@ class BBCode
 		$ret = [];
 
 		// Convert hashtag links to hashtags
-		$string = preg_replace('/#\[url\=([^\[\]]*)\](.*?)\[\/url\]/ism', '#$2', $string);
+		$string = preg_replace('/#\[url\=([^\[\]]*)\](.*?)\[\/url\]/ism', '#$2 ', $string);
 
 		// ignore anything in a code block
 		$string = preg_replace('/\[code.*?\].*?\[\/code\]/sm', '', $string);

--- a/src/Content/Widget/TagCloud.php
+++ b/src/Content/Widget/TagCloud.php
@@ -25,6 +25,7 @@ use Friendica\Core\Renderer;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Item;
+use Friendica\Model\Term;
 
 /**
  * TagCloud widget
@@ -45,7 +46,7 @@ class TagCloud
 	 * @return string       HTML formatted output.
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
-	public static function getHTML($uid, $count = 0, $owner_id = 0, $flags = '', $type = TERM_HASHTAG)
+	public static function getHTML($uid, $count = 0, $owner_id = 0, $flags = '', $type = Term::HASHTAG)
 	{
 		$o = '';
 		$r = self::tagadelic($uid, $count, $owner_id, $flags, $type);
@@ -84,7 +85,7 @@ class TagCloud
 	 * @return array        Alphabetical sorted array of used tags of an user.
 	 * @throws \Exception
 	 */
-	private static function tagadelic($uid, $count = 0, $owner_id = 0, $flags = '', $type = TERM_HASHTAG)
+	private static function tagadelic($uid, $count = 0, $owner_id = 0, $flags = '', $type = Term::HASHTAG)
 	{
 		$sql_options = Item::getPermissionsSQLByUserId($uid);
 		$limit = $count ? sprintf('LIMIT %d', intval($count)) : '';
@@ -109,7 +110,7 @@ class TagCloud
 			GROUP BY `term` ORDER BY `total` DESC $limit",
 			$uid,
 			$type,
-			TERM_OBJ_POST
+			Term::OBJECT_TYPE_POST
 		);
 		if (!DBA::isResult($tag_stmt)) {
 			return [];

--- a/src/Model/FileTag.php
+++ b/src/Model/FileTag.php
@@ -23,6 +23,7 @@ namespace Friendica\Model;
 
 use Friendica\Database\DBA;
 use Friendica\DI;
+use Friendica\Model\Term;
 
 /**
  * This class handles FileTag related functions
@@ -195,11 +196,11 @@ class FileTag
 			if ($type == 'file') {
 				$lbracket = '[';
 				$rbracket = ']';
-				$termtype = TERM_FILE;
+				$termtype = Term::FILE;
 			} else {
 				$lbracket = '<';
 				$rbracket = '>';
-				$termtype = TERM_CATEGORY;
+				$termtype = Term::CATEGORY;
 			}
 
 			$filetags_updated = $saved;

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -2611,7 +2611,7 @@ class Item
 		// This sorting is important when there are hashtags that are part of other hashtags
 		// Otherwise there could be problems with hashtags like #test and #test2
 		// Because of this we are sorting from the longest to the shortest tag.
-		usort($rawtags, function($a, $b) {
+		usort($tags, function($a, $b) {
 			return strlen($b) <=> strlen($a);
 		});
 

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -94,7 +94,8 @@ class Item
 	const CONTENT_FIELDLIST = ['language'];
 
 	// All fields in the item table
-	const ITEM_FIELDLIST = ['id', 'uid', 'parent', 'uri', 'parent-uri', 'thr-parent', 'guid',
+	const ITEM_FIELDLIST = ['id', 'uid', 'parent', 'uri', 'parent-uri', 'thr-parent',
+			'guid', 'uri-id', 'parent-uri-id', 'thr-parent-id',
 			'contact-id', 'type', 'wall', 'gravity', 'extid', 'icid', 'iaid', 'psid',
 			'created', 'edited', 'commented', 'received', 'changed', 'verb',
 			'postopts', 'plink', 'resource-id', 'event-id', 'tag', 'attach', 'inform',

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -342,7 +342,7 @@ class Item
 			}
 		}
 
-		if (array_key_exists('signed_text', $row) && array_key_exists('interaction', $row) && !is_null($row['interaction'])) {
+		if (array_key_exists('interaction', $row)) {
 			$row['signed_text'] = $row['interaction'];
 		}
 
@@ -672,7 +672,8 @@ class Item
 	{
 		$fields = [];
 
-		$fields['item'] = ['id', 'uid', 'parent', 'uri', 'parent-uri', 'thr-parent', 'guid',
+		$fields['item'] = ['id', 'uid', 'parent', 'uri', 'parent-uri', 'thr-parent',
+			'guid', 'uri-id', 'parent-uri-id', 'thr-parent-id',
 			'contact-id', 'owner-id', 'author-id', 'type', 'wall', 'gravity', 'extid',
 			'created', 'edited', 'commented', 'received', 'changed', 'psid',
 			'resource-id', 'event-id', 'tag', 'attach', 'post-type', 'file',

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -2610,7 +2610,10 @@ class Item
 
 		// This sorting is important when there are hashtags that are part of other hashtags
 		// Otherwise there could be problems with hashtags like #test and #test2
-		rsort($tags);
+		// Because of this we are sorting from the longest to the shortest tag.
+		usort($rawtags, function($a, $b) {
+			return strlen($b) <=> strlen($a);
+		});
 
 		$URLSearchString = "^\[\]";
 

--- a/src/Model/ItemURI.php
+++ b/src/Model/ItemURI.php
@@ -42,11 +42,15 @@ class ItemURI
 			DBA::insert('item-uri', $fields, true);
 		}
 
-		$itemuri = DBA::selectFirst('item-uri', ['id'], ['uri' => $uri]);
+		$itemuri = DBA::selectFirst('item-uri', ['id', 'guid'], ['uri' => $uri]);
 
 		if (!DBA::isResult($itemuri)) {
 			// This shouldn't happen
 			return null;
+		}
+
+		if (empty($itemuri['guid']) && !empty($fields['guid'])) {
+			DBA::update('item-uri', ['guid' => $fields['guid']], ['id' => $itemuri['id']]);
 		}
 
 		return $itemuri['id'];

--- a/src/Model/Tag.php
+++ b/src/Model/Tag.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Friendica\Model;
+
+use Friendica\Core\Logger;
+use Friendica\Database\DBA;
+use Friendica\Content\Text\BBCode;
+
+/**
+ * Class Tag
+ *
+ * This Model class handles tag table interactions.
+ * This tables stores relevant tags related to posts, like hashtags and mentions.
+ */
+class Tag
+{
+    const UNKNOWN           = 0;
+    const HASHTAG           = 1;
+    const MENTION           = 2;
+    const CATEGORY          = 3;
+    const FILE              = 5;
+	/**
+	 * An implicit mention is a mention in a comment body that is redundant with the threading information.
+	 */
+    const IMPLICIT_MENTION  = 8;
+	/**
+	 * An exclusive mention transfers the ownership of the post to the target account, usually a forum.
+	 */
+    const EXCLUSIVE_MENTION = 9;
+
+    const TAG_CHARACTER = [
+    	self::HASHTAG           => '#',
+    	self::MENTION           => '@',
+    	self::IMPLICIT_MENTION  => '%',
+    	self::EXCLUSIVE_MENTION => '!',
+    ];
+
+	/**
+	 * Store tags from the body
+	 *
+	 * @param integer $uriid
+	 * @param string $body
+	 */
+	public static function storeFromBody(int $uriid, string $body)
+	{
+		$tags = BBCode::getTags($body);
+		if (empty($tags)) {
+			return;
+		}
+
+		foreach ($tags as $tag) {
+			if ((substr($tag, 0, 1) != Term::TAG_CHARACTER[Term::HASHTAG]) || (strlen($tag) <= 1)) {
+				Logger::info('Skip tag', ['uriid' => $uriid, 'tag' => $tag]);
+				continue;
+			}
+
+			$fields = ['uri-id' => $uriid, 'name' => substr($tag, 1, 64), 'type' => Term::HASHTAG];
+			DBA::insert('tag', $fields, true);
+			Logger::info('Stored tag', ['uriid' => $uriid, 'tag' => $tag, 'fields' => $fields]);
+		}
+	}
+}

--- a/src/Model/Tag.php
+++ b/src/Model/Tag.php
@@ -54,6 +54,14 @@ class Tag
 		self::EXCLUSIVE_MENTION => '!',
 	];
 
+	/**
+	 * Store tag/mention elements
+	 *
+	 * @param integer $uriid
+	 * @param integer $type
+	 * @param string $name
+	 * @param string $url
+	 */
 	public static function store(int $uriid, int $type, string $name, string $url = '')
 	{
 		$name = trim($name, "\x00..\x20\xFF#!@");
@@ -85,6 +93,14 @@ class Tag
 		Logger::info('Stored tag/mention', ['uri-id' => $uriid, 'tag-id' => $tagid, 'tag' => $fields]);
 	}
 
+	/**
+	 * Store tag/mention elements
+	 *
+	 * @param integer $uriid
+	 * @param string $hash
+	 * @param string $name
+	 * @param string $url
+	 */
 	public static function storeByHash(int $uriid, string $hash, string $name, string $url = '')
 	{
 		if ($hash == self::TAG_CHARACTER[self::MENTION]) {

--- a/src/Model/Tag.php
+++ b/src/Model/Tag.php
@@ -127,7 +127,7 @@ class Tag
 	 */
 	public static function storeFromBody(int $uriid, string $body, string $tags = '#@!')
 	{
-		if (!preg_match_all("/([" . $tags . "])\[url\=(.*?)\](.*?)\[\/url\]/ism", $body, $result, PREG_SET_ORDER)) {
+		if (!preg_match_all("/([" . $tags . "])\[url\=([^\[\]]*)\](.*?)\[\/url\]/ism", $body, $result, PREG_SET_ORDER)) {
 			return;
 		}
 

--- a/src/Model/Tag.php
+++ b/src/Model/Tag.php
@@ -68,12 +68,12 @@ class Tag
 		}
 
 		foreach ($tags as $tag) {
-			if ((substr($tag, 0, 1) != Term::TAG_CHARACTER[Term::HASHTAG]) || (strlen($tag) <= 1)) {
+			if ((substr($tag, 0, 1) != self::TAG_CHARACTER[self::HASHTAG]) || (strlen($tag) <= 1)) {
 				Logger::info('Skip tag', ['uriid' => $uriid, 'tag' => $tag]);
 				continue;
 			}
 
-			$fields = ['uri-id' => $uriid, 'name' => substr($tag, 1, 64), 'type' => Term::HASHTAG];
+			$fields = ['uri-id' => $uriid, 'name' => substr($tag, 1, 64), 'type' => self::HASHTAG];
 			DBA::insert('tag', $fields, true);
 			Logger::info('Stored tag', ['uriid' => $uriid, 'tag' => $tag, 'fields' => $fields]);
 		}

--- a/src/Model/Tag.php
+++ b/src/Model/Tag.php
@@ -69,7 +69,7 @@ class Tag
 			return;
 		}
 
-		$fields = ['name' => substr($name, 0, 64), 'type' => $type];
+		$fields = ['name' => substr($name, 0, 96), 'type' => $type];
 
 		if (!empty($url) && ($url != $name)) {
 			$fields['url'] = strtolower($url);
@@ -119,25 +119,20 @@ class Tag
 	}
 
 	/**
-	 * Store tags from the body
-	 *
-	 * @param integer $uriid
-	 * @param string $body
+	 * Store tags and mentions from the body
+	 * 
+	 * @param integer $uriid URI-Id
+	 * @param string  $body   Body of the post
+	 * @param string  $tags   Accepted tags
 	 */
-	public static function storeFromBody(int $uriid, string $body)
+	public static function storeFromBody(int $uriid, string $body, string $tags = '#@!')
 	{
-		$tags = BBCode::getTags($body);
-		if (empty($tags)) {
+		if (!preg_match_all("/([" . $tags . "])\[url\=(.*?)\](.*?)\[\/url\]/ism", $body, $result, PREG_SET_ORDER)) {
 			return;
 		}
 
-		foreach ($tags as $tag) {
-			if ((substr($tag, 0, 1) != self::TAG_CHARACTER[self::HASHTAG]) || (strlen($tag) <= 1)) {
-				Logger::info('Skip tag', ['uriid' => $uriid, 'tag' => $tag]);
-				continue;
-			}
-
-			self::storeByHash($uriid, '#', $tag);
+		foreach ($result as $tag) {
+			self::storeByHash($uriid, $tag[1], $tag[3], $tag[2]);
 		}
 	}
 }

--- a/src/Model/Tag.php
+++ b/src/Model/Tag.php
@@ -117,7 +117,7 @@ class Tag
 
 		DBA::insert('post-tag', ['uri-id' => $uriid, 'type' => $type, 'tid' => $tagid, 'cid' => $cid], true);
 
-		Logger::info('Stored tag/mention', ['uri-id' => $uriid, 'tag-id' => $tagid, 'contact-id' => $cid]);
+		Logger::info('Stored tag/mention', ['uri-id' => $uriid, 'tag-id' => $tagid, 'contact-id' => $cid, 'callstack' => System::callstack(8)]);
 	}
 
 	/**
@@ -206,7 +206,7 @@ class Tag
 		if (!DBA::isResult($tag)) {
 			return;
 		}
-		Logger::info('Removing tag/mention', ['uri-id' => $uriid, 'tid' => $tag['id'], 'name' => $name, 'url' => $url]);
+		Logger::info('Removing tag/mention', ['uri-id' => $uriid, 'tid' => $tag['id'], 'name' => $name, 'url' => $url, 'callstack' => System::callstack(8)]);
 		DBA::delete('post-tag', ['uri-id' => $uriid, 'tid' => $tag['id']]);
 	}
 

--- a/src/Model/Tag.php
+++ b/src/Model/Tag.php
@@ -33,26 +33,26 @@ use Friendica\Content\Text\BBCode;
  */
 class Tag
 {
-    const UNKNOWN           = 0;
-    const HASHTAG           = 1;
-    const MENTION           = 2;
-    const CATEGORY          = 3;
-    const FILE              = 5;
+	const UNKNOWN  = 0;
+	const HASHTAG  = 1;
+	const MENTION  = 2;
+	const CATEGORY = 3;
+	const FILE     = 5;
 	/**
 	 * An implicit mention is a mention in a comment body that is redundant with the threading information.
 	 */
-    const IMPLICIT_MENTION  = 8;
+	const IMPLICIT_MENTION  = 8;
 	/**
 	 * An exclusive mention transfers the ownership of the post to the target account, usually a forum.
 	 */
-    const EXCLUSIVE_MENTION = 9;
+	const EXCLUSIVE_MENTION = 9;
 
-    const TAG_CHARACTER = [
-    	self::HASHTAG           => '#',
-    	self::MENTION           => '@',
-    	self::IMPLICIT_MENTION  => '%',
-    	self::EXCLUSIVE_MENTION => '!',
-    ];
+	const TAG_CHARACTER = [
+		self::HASHTAG           => '#',
+		self::MENTION           => '@',
+		self::IMPLICIT_MENTION  => '%',
+		self::EXCLUSIVE_MENTION => '!',
+	];
 
 	/**
 	 * Store tags from the body

--- a/src/Model/Tag.php
+++ b/src/Model/Tag.php
@@ -149,8 +149,12 @@ class Tag
 	 * @param string  $body   Body of the post
 	 * @param string  $tags   Accepted tags
 	 */
-	public static function storeFromBody(int $uriid, string $body, string $tags = '#@!')
+	public static function storeFromBody(int $uriid, string $body, string $tags = null)
 	{
+		if (is_null($tags)) {
+			$tags =  self::TAG_CHARACTER[self::HASHTAG] . self::TAG_CHARACTER[self::MENTION] . self::TAG_CHARACTER[self::EXCLUSIVE_MENTION];
+		}
+
 		if (!preg_match_all("/([" . $tags . "])\[url\=([^\[\]]*)\]([^\[\]]*)\[\/url\]/ism", $body, $result, PREG_SET_ORDER)) {
 			return;
 		}

--- a/src/Model/Tag.php
+++ b/src/Model/Tag.php
@@ -127,15 +127,8 @@ class Tag
 	 */
 	public static function storeByHash(int $uriid, string $hash, string $name, string $url = '')
 	{
-		if ($hash == self::TAG_CHARACTER[self::MENTION]) {
-			$type = self::MENTION;
-		} elseif ($hash == self::TAG_CHARACTER[self::EXCLUSIVE_MENTION]) {
-			$type = self::EXCLUSIVE_MENTION;
-		} elseif ($hash == self::TAG_CHARACTER[self::IMPLICIT_MENTION]) {
-			$type = self::IMPLICIT_MENTION;
-		} elseif ($hash == self::TAG_CHARACTER[self::HASHTAG]) {
-			$type = self::HASHTAG;
-		} else {
+		$type = self::getTypeForHash($hash);
+		if ($type == self::UNKNOWN) {
 			return;
 		}
 
@@ -193,18 +186,33 @@ class Tag
 	 */
 	public static function removeByHash(int $uriid, string $hash, string $name, string $url = '')
 	{
-		if ($hash == self::TAG_CHARACTER[self::MENTION]) {
-			$type = self::MENTION;
-		} elseif ($hash == self::TAG_CHARACTER[self::EXCLUSIVE_MENTION]) {
-			$type = self::EXCLUSIVE_MENTION;
-		} elseif ($hash == self::TAG_CHARACTER[self::IMPLICIT_MENTION]) {
-			$type = self::IMPLICIT_MENTION;
-		} elseif ($hash == self::TAG_CHARACTER[self::HASHTAG]) {
-			$type = self::HASHTAG;
-		} else {
+		$type = self::getTypeForHash($hash);
+		if ($type == self::UNKNOWN) {
 			return;
 		}
 
 		self::remove($uriid, $type, $name, $url);
+	}
+
+	/**
+	 * Get the type for the given hash
+	 *
+	 * @param string $hash
+	 * @return integer type
+	 */
+	private static function getTypeForHash(string $hash)
+	{
+		if ($hash == self::TAG_CHARACTER[self::MENTION]) {
+			return self::MENTION;
+		} elseif ($hash == self::TAG_CHARACTER[self::EXCLUSIVE_MENTION]) {
+			return self::EXCLUSIVE_MENTION;
+		} elseif ($hash == self::TAG_CHARACTER[self::IMPLICIT_MENTION]) {
+			return self::IMPLICIT_MENTION;
+		} elseif ($hash == self::TAG_CHARACTER[self::HASHTAG]) {
+			return self::HASHTAG;
+		} else {
+			return self::UNKNOWN;
+		}
+
 	}
 }

--- a/src/Model/Tag.php
+++ b/src/Model/Tag.php
@@ -94,7 +94,7 @@ class Tag
 		if (empty($cid)) {
 			$fields = ['name' => substr($name, 0, 96), 'url' => ''];
 
-			if (!empty($url) && ($url != $name)) {
+			if (($type != Tag::HASHTAG) && !empty($url) && ($url != $name)) {
 				$fields['url'] = strtolower($url);
 			}
 	

--- a/src/Model/Tag.php
+++ b/src/Model/Tag.php
@@ -115,7 +115,18 @@ class Tag
 			}
 		}
 
-		DBA::insert('post-tag', ['uri-id' => $uriid, 'type' => $type, 'tid' => $tagid, 'cid' => $cid], true);
+		$fields = ['uri-id' => $uriid, 'type' => $type, 'tid' => $tagid, 'cid' => $cid];
+
+		if (in_array($type, [Tag::MENTION, Tag::EXCLUSIVE_MENTION, Tag::IMPLICIT_MENTION])) {
+			$condition = $fields;
+			$condition['type'] = [Tag::MENTION, Tag::EXCLUSIVE_MENTION, Tag::IMPLICIT_MENTION];
+			if (DBA::exists('post-tag', $condition)) {
+				Logger::info('Tag already exists', $fields);
+				return;
+			}
+		}
+
+		DBA::insert('post-tag', $fields, true);
 
 		Logger::info('Stored tag/mention', ['uri-id' => $uriid, 'tag-id' => $tagid, 'contact-id' => $cid, 'callstack' => System::callstack(8)]);
 	}

--- a/src/Model/Term.php
+++ b/src/Model/Term.php
@@ -40,10 +40,7 @@ class Term
     const HASHTAG           = 1;
     const MENTION           = 2;
     const CATEGORY          = 3;
-    const PCATEGORY         = 4;
     const FILE              = 5;
-    const SAVEDSEARCH       = 6;
-    const CONVERSATION      = 7;
 	/**
 	 * An implicit mention is a mention in a comment body that is redundant with the threading information.
 	 */

--- a/src/Model/Term.php
+++ b/src/Model/Term.php
@@ -330,6 +330,10 @@ class Term
 				continue;
 			}
 
+			if (empty($term)) {
+				continue;
+			}
+
 			if ($item['uid'] == 0) {
 				$global = true;
 				DBA::update('term', ['global' => true], ['otype' => self::OBJECT_TYPE_POST, 'guid' => $item['guid']]);

--- a/src/Model/UserItem.php
+++ b/src/Model/UserItem.php
@@ -26,6 +26,7 @@ use Friendica\Core\Hook;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Util\Strings;
+use Friendica\Model\Term;
 
 class UserItem
 {
@@ -206,7 +207,7 @@ class UserItem
 		}
 
 		// Or the contact is a mentioned forum
-		$tags = DBA::select('term', ['url'], ['otype' => TERM_OBJ_POST, 'oid' => $item['id'], 'type' => TERM_MENTION, 'uid' => $uid]);
+		$tags = DBA::select('term', ['url'], ['otype' => term::OBJECT_TYPE_POST, 'oid' => $item['id'], 'type' => Term::MENTION, 'uid' => $uid]);
 		while ($tag = DBA::fetch($tags)) {
 			$condition = ['nurl' => Strings::normaliseLink($tag['url']), 'uid' => $uid, 'notify_new_posts' => true, 'contact-type' => Contact::TYPE_COMMUNITY];
 			if (DBA::exists('contact', $condition)) {

--- a/src/Model/UserItem.php
+++ b/src/Model/UserItem.php
@@ -207,7 +207,7 @@ class UserItem
 		}
 
 		// Or the contact is a mentioned forum
-		$tags = DBA::select('term', ['url'], ['otype' => term::OBJECT_TYPE_POST, 'oid' => $item['id'], 'type' => Term::MENTION, 'uid' => $uid]);
+		$tags = DBA::select('term', ['url'], ['otype' => Term::OBJECT_TYPE_POST, 'oid' => $item['id'], 'type' => Term::MENTION, 'uid' => $uid]);
 		while ($tag = DBA::fetch($tags)) {
 			$condition = ['nurl' => Strings::normaliseLink($tag['url']), 'uid' => $uid, 'notify_new_posts' => true, 'contact-type' => Contact::TYPE_COMMUNITY];
 			if (DBA::exists('contact', $condition)) {

--- a/src/Module/Hashtag.php
+++ b/src/Module/Hashtag.php
@@ -25,6 +25,7 @@ use Friendica\BaseModule;
 use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\Util\Strings;
+use Friendica\Model\Term;
 
 /**
  * Hashtag module.
@@ -43,7 +44,7 @@ class Hashtag extends BaseModule
 
 		$taglist = DBA::p("SELECT DISTINCT(`term`) FROM `term` WHERE `term` LIKE ? AND `type` = ? ORDER BY `term`",
 			$t . '%',
-			intval(TERM_HASHTAG)
+			intval(Term::HASHTAG)
 		);
 		while ($tag = DBA::fetch($taglist)) {
 			$result[] = ['text' => $tag['term']];

--- a/src/Module/Profile/Status.php
+++ b/src/Module/Profile/Status.php
@@ -31,6 +31,7 @@ use Friendica\DI;
 use Friendica\Model\Item;
 use Friendica\Model\Profile as ProfileModel;
 use Friendica\Model\User;
+use Friendica\Model\Term;
 use Friendica\Module\BaseProfile;
 use Friendica\Module\Security\Login;
 use Friendica\Util\DateTimeFormat;
@@ -142,12 +143,12 @@ class Status extends BaseProfile
 
 		if (!empty($category)) {
 			$sql_post_table = sprintf("INNER JOIN (SELECT `oid` FROM `term` WHERE `term` = '%s' AND `otype` = %d AND `type` = %d AND `uid` = %d ORDER BY `tid` DESC) AS `term` ON `item`.`id` = `term`.`oid` ",
-				DBA::escape(Strings::protectSprintf($category)), intval(TERM_OBJ_POST), intval(TERM_CATEGORY), intval($a->profile['uid']));
+				DBA::escape(Strings::protectSprintf($category)), intval(Term::OBJECT_TYPE_POST), intval(Term::CATEGORY), intval($a->profile['uid']));
 		}
 
 		if (!empty($hashtags)) {
 			$sql_post_table .= sprintf("INNER JOIN (SELECT `oid` FROM `term` WHERE `term` = '%s' AND `otype` = %d AND `type` = %d AND `uid` = %d ORDER BY `tid` DESC) AS `term` ON `item`.`id` = `term`.`oid` ",
-				DBA::escape(Strings::protectSprintf($hashtags)), intval(TERM_OBJ_POST), intval(TERM_HASHTAG), intval($a->profile['uid']));
+				DBA::escape(Strings::protectSprintf($hashtags)), intval(Term::OBJECT_TYPE_POST), intval(Term::HASHTAG), intval($a->profile['uid']));
 		}
 
 		if (!empty($datequery)) {

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -170,14 +170,10 @@ class Processor
 	 */
 	public static function updateItem($activity)
 	{
-		$item = Item::selectFirst(['uri', 'uri-id', 'guid', 'thr-parent', 'gravity'], ['uri' => $activity['id']]);
+		$item = Item::selectFirst(['uri', 'uri-id', 'thr-parent', 'gravity'], ['uri' => $activity['id']]);
 		if (!DBA::isResult($item)) {
 			Logger::warning('Unknown item', ['uri' => $activity['id']]);
 			return;
-		}
-
-		if (empty($item['uri-id'])) {
-			$item['uri-id'] = ItemURI::insert(['uri' => $item['uri'], 'guid' => $item['guid']]);
 		}
 
 		$item['changed'] = DateTimeFormat::utcNow();

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -600,6 +600,12 @@ class Processor
 					$fields['type'] = Term::IMPLICIT_MENTION;
 					$fields['name'] = substr($fields['name'], 1);
 				}
+				if (!empty($tag['href'])) {
+					$apcontact = APContact::getByURL($tag['href']);
+					if (!empty($apcontact['name'])) {
+						$fields['name'] = $apcontact['name'];
+					}
+				}
 			} elseif ($tag['type'] == 'Hashtag') {
 				$fields['type'] = Term::HASHTAG;
 				if (substr($fields['name'], 0, 1) == Term::TAG_CHARACTER[Term::HASHTAG]) {

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -576,6 +576,12 @@ class Processor
 		}
 	}
 
+	/**
+	 * Store tags and mentions into the tag table
+	 *
+	 * @param integer $uriid
+	 * @param array $tags
+	 */
 	private static function storeTags(int $uriid, array $tags = null)
 	{
 		// Make sure to delete all existing tags (can happen when called via the update functionality)

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -609,6 +609,8 @@ class Processor
 
 			if (empty($fields['name'])) {
 				continue;
+			} else {
+				$fields['name'] = substr($fields['name'], 0, 64);
 			}
 			
 			if (!empty($tag['href'] && ($tag['href'] != $tag['name']))) {

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -407,6 +407,7 @@ class Processor
 
 		$item['tag'] = self::constructTagString($activity['tags'], $activity['sensitive']);
 
+		Tag::storeFromBody($item['uri-id'], $item['body'], '@!');
 		self::storeTags($item['uri-id'], $activity['tags']);
 
 		$item['location'] = $activity['location'];
@@ -602,9 +603,8 @@ class Processor
 					Tag::TAG_CHARACTER[Tag::EXCLUSIVE_MENTION],
 					Tag::TAG_CHARACTER[Tag::IMPLICIT_MENTION]])) {
 					$tag['name'] = substr($tag['name'], 1);
-				} else {
-					$hash = '#';
 				}
+				$type = Tag::IMPLICIT_MENTION;
 
 				if (!empty($tag['href'])) {
 					$apcontact = APContact::getByURL($tag['href']);
@@ -613,18 +613,17 @@ class Processor
 					}
 				}
 			} elseif ($tag['type'] == 'Hashtag') {
-				if (substr($tag['name'], 0, 1) == Term::TAG_CHARACTER[Term::HASHTAG]) {
+				if ($hash == Tag::TAG_CHARACTER[Tag::HASHTAG]) {
 					$tag['name'] = substr($tag['name'], 1);
-				} else {
-					$hash = '@';
 				}
+				$type = Tag::HASHTAG;
 			}
 
 			if (empty($tag['name'])) {
 				continue;
 			}
 			
-			Tag::storeByHash($uriid, $hash, $tag['name'], $tag['href']);
+			Tag::store($uriid, $type, $tag['name'], $tag['href']);
 		}
 	}
 

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -602,8 +602,8 @@ class Processor
 				}
 				if (!empty($tag['href'])) {
 					$apcontact = APContact::getByURL($tag['href']);
-					if (!empty($apcontact['name'])) {
-						$fields['name'] = $apcontact['name'];
+					if (!empty($apcontact['name']) || !empty($apcontact['nick'])) {
+						$fields['name'] = $apcontact['name'] ?: $apcontact['nick'];
 					}
 				}
 			} elseif ($tag['type'] == 'Hashtag') {

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -407,7 +407,7 @@ class Processor
 
 		$item['tag'] = self::constructTagString($activity['tags'], $activity['sensitive']);
 
-		Tag::storeFromBody($item['uri-id'], $item['body'], '@!');
+		self::storeFromBody($item);
 		self::storeTags($item['uri-id'], $activity['tags']);
 
 		$item['location'] = $activity['location'];
@@ -419,6 +419,14 @@ class Processor
 		$item['app'] = $activity['generator'];
 
 		return $item;
+	}
+
+	private static function storeFromBody($item)
+	{
+		// Make sure to delete all existing tags (can happen when called via the update functionality)
+		DBA::delete('post-tag', ['uri-id' => $uriid]);
+
+		Tag::storeFromBody($item['uri-id'], $item['body'], '@!');
 	}
 
 	/**
@@ -588,9 +596,6 @@ class Processor
 	 */
 	private static function storeTags(int $uriid, array $tags = null)
 	{
-		// Make sure to delete all existing tags (can happen when called via the update functionality)
-		DBA::delete('post-tag', ['uri-id' => $uriid]);
-
 		foreach ($tags as $tag) {
 			if (empty($tag['name']) || empty($tag['type']) || !in_array($tag['type'], ['Mention', 'Hashtag'])) {
 				continue;
@@ -622,7 +627,7 @@ class Processor
 			if (empty($tag['name'])) {
 				continue;
 			}
-			
+
 			Tag::store($uriid, $type, $tag['name'], $tag['href']);
 		}
 	}

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -619,7 +619,7 @@ class Processor
 
 			DBA::insert('tag', $fields, true);
 
-			Logger::info('Got Tag', ['uriid' => $uriid, 'tag' => $tag, 'sensitive' => $sensitive, 'fields' => $fields]);
+			Logger::info('Stored tag/mention', ['uriid' => $uriid, 'tag' => $tag, 'sensitive' => $sensitive, 'fields' => $fields]);
 		}
 	}
 

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -251,7 +251,7 @@ class Processor
 		}
 
 		foreach ($activity['receiver'] as $receiver) {
-			$item = Item::selectFirst(['id', 'tag', 'origin', 'author-link'], ['uri' => $activity['target_id'], 'uid' => $receiver]);
+			$item = Item::selectFirst(['id', 'uri-id', 'tag', 'origin', 'author-link'], ['uri' => $activity['target_id'], 'uid' => $receiver]);
 			if (!DBA::isResult($item)) {
 				// We don't fetch missing content for this purpose
 				continue;
@@ -261,6 +261,8 @@ class Processor
 				Logger::info('Not origin, not from the author, skipping update', ['id' => $item['id'], 'author' => $item['author-link'], 'actor' => $activity['actor']]);
 				continue;
 			}
+
+			Tag::store($item['uri-id'], Tag::HASHTAG, $activity['object_content'], $activity['object_id']);
 
 			// To-Do:
 			// - Check if "blocktag" is set

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -421,10 +421,15 @@ class Processor
 		return $item;
 	}
 
-	private static function storeFromBody($item)
+	/**
+	 * Store hashtags and mentions
+	 *
+	 * @param array $item
+	 */
+	private static function storeFromBody(array $item)
 	{
 		// Make sure to delete all existing tags (can happen when called via the update functionality)
-		DBA::delete('post-tag', ['uri-id' => $uriid]);
+		DBA::delete('post-tag', ['uri-id' => $item['uri-id']]);
 
 		Tag::storeFromBody($item['uri-id'], $item['body'], '@!');
 	}

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -1218,7 +1218,7 @@ class Transmitter
 	 */
 	private static function isSensitive($item_id)
 	{
-		$condition = ['otype' => TERM_OBJ_POST, 'oid' => $item_id, 'type' => TERM_HASHTAG, 'term' => 'nsfw'];
+		$condition = ['otype' => Term::OBJECT_TYPE_POST, 'oid' => $item_id, 'type' => Term::HASHTAG, 'term' => 'nsfw'];
 		return DBA::exists('term', $condition);
 	}
 

--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -2465,13 +2465,13 @@ class DFRN
 						$fields = ['uri-id' => $item['uri-id'], 'name' => substr($term, 0, 64)];
 
 						if ($termhash == Term::TAG_CHARACTER[Term::MENTION]) {
-							$fields['type'] = Term::EXCLUSIVE_MENTION;
+							$fields['type'] = Term::MENTION;
 						} elseif ($termhash == Term::TAG_CHARACTER[Term::EXCLUSIVE_MENTION]) {
 							$fields['type'] = Term::EXCLUSIVE_MENTION;
 						} elseif ($termhash == Term::TAG_CHARACTER[Term::IMPLICIT_MENTION]) {
 							$fields['type'] = Term::IMPLICIT_MENTION;
 						} elseif ($termhash == Term::TAG_CHARACTER[Term::HASHTAG]) {
-							$fields['type'] = Term::IMPLICIT_MENTION;
+							$fields['type'] = Term::HASHTAG;
 						}
 
 						if (!empty($termurl)) {

--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -2464,26 +2464,7 @@ class DFRN
 
 						$item["tag"] .= $termhash . "[url=" . $termurl . "]" . $term . "[/url]";
 
-						// Store the hashtag/mention
-						$fields = ['uri-id' => $item['uri-id'], 'name' => substr($term, 0, 64)];
-
-						if ($termhash == Term::TAG_CHARACTER[Term::MENTION]) {
-							$fields['type'] = Term::MENTION;
-						} elseif ($termhash == Term::TAG_CHARACTER[Term::EXCLUSIVE_MENTION]) {
-							$fields['type'] = Term::EXCLUSIVE_MENTION;
-						} elseif ($termhash == Term::TAG_CHARACTER[Term::IMPLICIT_MENTION]) {
-							$fields['type'] = Term::IMPLICIT_MENTION;
-						} elseif ($termhash == Term::TAG_CHARACTER[Term::HASHTAG]) {
-							$fields['type'] = Term::HASHTAG;
-						}
-
-						if (!empty($termurl)) {
-							$fields['url'] = $termurl;
-						}
-
-						DBA::insert('tag', $fields, true);
-
-						Logger::info('Stored tag/mention', ['uri-id' => $item['uri-id'], 'tag' => $term, 'url' => $termurl, 'hash' => $termhash, 'fields' => $fields]);
+						Tag::storeByHash($item['uri-id'], $termhash, $term, $termurl);
 					}
 				}
 			}

--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -2410,7 +2410,7 @@ class DFRN
 
 		$item['uri-id'] = ItemURI::insert(['uri' => $item['uri'], 'guid' => $item['guid']]);
 
-		Tag::storeFromBody($item['uri-id'], $item["body"]);
+		Tag::storeFromBody($item['uri-id'], $item["body"], '#');
 
 		// We store the data from "dfrn:diaspora_signature" in a different table, this is done in "Item::insert"
 		$dsprsig = XML::unescape(XML::getFirstNodeValue($xpath, "dfrn:diaspora_signature/text()", $entry));

--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -2243,7 +2243,7 @@ class DFRN
 				$xt = XML::parseString($item["target"], false);
 
 				if ($xt->type == Activity\ObjectType::NOTE) {
-					$item_tag = Item::selectFirst(['id', 'tag'], ['uri' => $xt->id, 'uid' => $importer["importer_uid"]]);
+					$item_tag = Item::selectFirst(['id', 'uri-id', 'tag'], ['uri' => $xt->id, 'uid' => $importer["importer_uid"]]);
 
 					if (!DBA::isResult($item_tag)) {
 						Logger::log("Query failed to execute, no result returned in " . __FUNCTION__);
@@ -2252,6 +2252,8 @@ class DFRN
 
 					// extract tag, if not duplicate, add to parent item
 					if ($xo->content) {
+						Tag::store($item_tag['uri-id'], Tag::HASHTAG, $xo->content);
+
 						if (!stristr($item_tag["tag"], trim($xo->content))) {
 							$tag = $item_tag["tag"] . (strlen($item_tag["tag"]) ? ',' : '') . '#[url=' . $xo->id . ']'. $xo->content . '[/url]';
 							Item::update(['tag' => $tag], ['id' => $item_tag["id"]]);

--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -2410,7 +2410,7 @@ class DFRN
 
 		$item['uri-id'] = ItemURI::insert(['uri' => $item['uri'], 'guid' => $item['guid']]);
 
-		Tag::storeFromBody($item['uri-id'], $item["body"], '#');
+		Tag::storeFromBody($item['uri-id'], $item["body"]);
 
 		// We store the data from "dfrn:diaspora_signature" in a different table, this is done in "Item::insert"
 		$dsprsig = XML::unescape(XML::getFirstNodeValue($xpath, "dfrn:diaspora_signature/text()", $entry));
@@ -2466,7 +2466,7 @@ class DFRN
 
 						$item["tag"] .= $termhash . "[url=" . $termurl . "]" . $term . "[/url]";
 
-						Tag::storeByHash($item['uri-id'], $termhash, $term, $termurl);
+						Tag::store($item['uri-id'], Tag::IMPLICIT_MENTION, $term, $termurl);
 					}
 				}
 			}

--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -40,6 +40,7 @@ use Friendica\Model\Mail;
 use Friendica\Model\Notify\Type;
 use Friendica\Model\PermissionSet;
 use Friendica\Model\Profile;
+use Friendica\Model\Tag;
 use Friendica\Model\Term;
 use Friendica\Model\User;
 use Friendica\Network\Probe;
@@ -2406,6 +2407,8 @@ class DFRN
 		$item["guid"] = XML::getFirstNodeValue($xpath, "dfrn:diaspora_guid/text()", $entry);
 
 		$item['uri-id'] = ItemURI::insert(['uri' => $item['uri'], 'guid' => $item['guid']]);
+
+		Tag::storeFromBody($item['uri-id'], $item["body"]);
 
 		// We store the data from "dfrn:diaspora_signature" in a different table, this is done in "Item::insert"
 		$dsprsig = XML::unescape(XML::getFirstNodeValue($xpath, "dfrn:diaspora_signature/text()", $entry));

--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -24,9 +24,7 @@ namespace Friendica\Protocol;
 use DOMDocument;
 use DOMXPath;
 use Friendica\App\BaseURL;
-use Friendica\Content\OEmbed;
 use Friendica\Content\Text\BBCode;
-use Friendica\Content\Text\HTML;
 use Friendica\Core\Hook;
 use Friendica\Core\Logger;
 use Friendica\Core\Protocol;
@@ -41,6 +39,7 @@ use Friendica\Model\Mail;
 use Friendica\Model\Notify\Type;
 use Friendica\Model\PermissionSet;
 use Friendica\Model\Profile;
+use Friendica\Model\Term;
 use Friendica\Model\User;
 use Friendica\Network\Probe;
 use Friendica\Util\Crypto;
@@ -49,8 +48,6 @@ use Friendica\Util\Images;
 use Friendica\Util\Network;
 use Friendica\Util\Strings;
 use Friendica\Util\XML;
-use HTMLPurifier;
-use HTMLPurifier_Config;
 
 /**
  * This class contain functions to create and send DFRN XML files
@@ -252,8 +249,8 @@ class DFRN
 			$sql_post_table = sprintf(
 				"INNER JOIN (SELECT `oid` FROM `term` WHERE `term` = '%s' AND `otype` = %d AND `type` = %d AND `uid` = %d ORDER BY `tid` DESC) AS `term` ON `item`.`id` = `term`.`oid` ",
 				DBA::escape(Strings::protectSprintf($category)),
-				intval(TERM_OBJ_POST),
-				intval(TERM_CATEGORY),
+				intval(Term::OBJECT_TYPE_POST),
+				intval(Term::CATEGORY),
 				intval($owner_id)
 			);
 		}

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -39,6 +39,7 @@ use Friendica\Model\ItemURI;
 use Friendica\Model\ItemDeliveryData;
 use Friendica\Model\Mail;
 use Friendica\Model\Profile;
+use Friendica\Model\Tag;
 use Friendica\Model\Term;
 use Friendica\Model\User;
 use Friendica\Network\Probe;
@@ -1850,25 +1851,6 @@ class Diaspora
 		}
 	}
 
-	private static function storeTags(int $uriid, string $body)
-	{
-		$tags = BBCode::getTags($body);
-		if (empty($tags)) {
-			return;
-		}
-
-		foreach ($tags as $tag) {
-			if ((substr($tag, 0, 1) != Term::TAG_CHARACTER[Term::HASHTAG]) || (strlen($tag) <= 1)) {
-				Logger::info('Skip tag', ['uriid' => $uriid, 'tag' => $tag]);
-				continue;
-			}
-
-			$fields = ['uri-id' => $uriid, 'name' => substr($tag, 1, 64), 'type' => Term::HASHTAG];
-			DBA::insert('tag', $fields, true);
-			Logger::info('Stored tag', ['uriid' => $uriid, 'tag' => $tag, 'fields' => $fields]);
-		}
-	}
-
 	/**
 	 * Processes an incoming comment
 	 *
@@ -1963,7 +1945,7 @@ class Diaspora
 		$datarray["body"] = self::replacePeopleGuid($body, $person["url"]);
 
 		self::storeMentions($datarray['uri-id'], $text);
-		self::storeTags($datarray['uri-id'], $datarray["body"]);
+		Tag::storeFromBody($datarray['uri-id'], $datarray["body"]);
 
 		self::fetchGuid($datarray);
 

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -1810,6 +1810,12 @@ class Diaspora
 		return false;
 	}
 
+	/**
+	 * Store the mentions in the tag table
+	 *
+	 * @param integer $uriid
+	 * @param string $text
+	 */
 	private static function storeMentions(int $uriid, string $text)
 	{
 		preg_match_all('/([@!]){(?:([^}]+?); ?)?([^} ]+)}/', $text, $matches, PREG_SET_ORDER);

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -3020,7 +3020,7 @@ class Diaspora
 		$datarray["body"] = self::replacePeopleGuid($body, $contact["url"]);
 
 		self::storeMentions($datarray['uri-id'], $text);
-		self::storeTags($datarray['uri-id'], $datarray["body"]);
+		Tag::storeFromBody($datarray['uri-id'], $datarray["body"]);
 
 		if ($provider_display_name != "") {
 			$datarray["app"] = $provider_display_name;

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -1938,7 +1938,7 @@ class Diaspora
 		$datarray["body"] = self::replacePeopleGuid($body, $person["url"]);
 
 		self::storeMentions($datarray['uri-id'], $text);
-		Tag::storeFromBody($datarray['uri-id'], $datarray["body"], '#');
+		Tag::storeRawTagsFromBody($datarray['uri-id'], $datarray["body"]);
 
 		self::fetchGuid($datarray);
 
@@ -3015,7 +3015,7 @@ class Diaspora
 		$datarray["body"] = self::replacePeopleGuid($body, $contact["url"]);
 
 		self::storeMentions($datarray['uri-id'], $text);
-		Tag::storeFromBody($datarray['uri-id'], $datarray["body"], '#');
+		Tag::storeRawTagsFromBody($datarray['uri-id'], $datarray["body"]);
 
 		if ($provider_display_name != "") {
 			$datarray["app"] = $provider_display_name;

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -1840,20 +1840,7 @@ class Diaspora
 				continue;
 			}
 
-			$fields = ['uri-id' => $uriid, 'name' => substr($person['name'] ?: $person['nick'], 0, 64), 'url' => $person['url']];
-
-			if ($match[1] == Term::TAG_CHARACTER[Term::MENTION]) {
-				$fields['type'] = Term::MENTION;
-			} elseif ($match[1] == Term::TAG_CHARACTER[Term::EXCLUSIVE_MENTION]) {
-				$fields['type'] = Term::EXCLUSIVE_MENTION;
-			} elseif ($match[1] == Term::TAG_CHARACTER[Term::IMPLICIT_MENTION]) {
-				$fields['type'] = Term::IMPLICIT_MENTION;
-			} else {
-				continue;
-			}
-
-			DBA::insert('tag', $fields, true);
-			Logger::info('Stored mention', ['uriid' => $uriid, 'match' => $match, 'fields' => $fields]);
+			Tag::storeByHash($uriid, $match[1], $person['name'] ?: $person['nick'], $person['url']);
 		}
 	}
 

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -2781,6 +2781,8 @@ class Diaspora
 
 		$datarray["body"] = $prefix.$original_item["body"]."[/share]";
 
+		Tag::storeFromBody($datarray['uri-id'], $datarray["body"]);
+
 		$datarray["tag"] = $original_item["tag"];
 		$datarray["attach"] = $original_item["attach"];
 		$datarray["app"]  = $original_item["app"];

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -1938,7 +1938,7 @@ class Diaspora
 		$datarray["body"] = self::replacePeopleGuid($body, $person["url"]);
 
 		self::storeMentions($datarray['uri-id'], $text);
-		Tag::storeFromBody($datarray['uri-id'], $datarray["body"]);
+		Tag::storeFromBody($datarray['uri-id'], $datarray["body"], '#');
 
 		self::fetchGuid($datarray);
 
@@ -3013,7 +3013,7 @@ class Diaspora
 		$datarray["body"] = self::replacePeopleGuid($body, $contact["url"]);
 
 		self::storeMentions($datarray['uri-id'], $text);
-		Tag::storeFromBody($datarray['uri-id'], $datarray["body"]);
+		Tag::storeFromBody($datarray['uri-id'], $datarray["body"], '#');
 
 		if ($provider_display_name != "") {
 			$datarray["app"] = $provider_display_name;

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -38,6 +38,7 @@ use Friendica\Model\Item;
 use Friendica\Model\ItemDeliveryData;
 use Friendica\Model\Mail;
 use Friendica\Model\Profile;
+use Friendica\Model\Term;
 use Friendica\Model\User;
 use Friendica\Network\Probe;
 use Friendica\Util\Crypto;
@@ -123,7 +124,7 @@ class Diaspora
 			}
 
 			// All tags of the current post
-			$condition = ['otype' => TERM_OBJ_POST, 'type' => TERM_HASHTAG, 'oid' => $parent['parent']];
+			$condition = ['otype' => Term::OBJECT_TYPE_POST, 'type' => Term::HASHTAG, 'oid' => $parent['parent']];
 			$tags = DBA::select('term', ['term'], $condition);
 			$taglist = [];
 			while ($tag = DBA::fetch($tags)) {

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -1834,7 +1834,7 @@ class Diaspora
 				continue;
 			}
 
-			$fields = ['uri-id' => $uriid, 'name' => substr($person['addr'], 0, 64), 'url' => $person['url']];
+			$fields = ['uri-id' => $uriid, 'name' => substr($person['name'] ?: $person['nick'], 0, 64), 'url' => $person['url']];
 
 			if ($match[1] == Term::TAG_CHARACTER[Term::MENTION]) {
 				$fields['type'] = Term::MENTION;

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -1958,7 +1958,6 @@ class Diaspora
 		$datarray["changed"] = $datarray["created"] = $datarray["edited"] = $created_at;
 
 		$datarray["plink"] = self::plink($author, $guid, $parent_item['guid']);
-	
 		$body = Markdown::toBBCode($text);
 
 		$datarray["body"] = self::replacePeopleGuid($body, $person["url"]);
@@ -2708,7 +2707,6 @@ class Diaspora
 
 		$datarray['guid'] = $parent['guid'] . '-' . $guid;
 		$datarray['uri'] = self::getUriFromGuid($author, $datarray['guid']);
-
 		$datarray['parent-uri'] = $parent['uri'];
 
 		$datarray['verb'] = $datarray['body'] = Activity::ANNOUNCE;

--- a/src/Protocol/Feed.php
+++ b/src/Protocol/Feed.php
@@ -523,7 +523,7 @@ class Feed {
 					// Set the delivery priority for "remote self" to "medium"
 					$notify = PRIORITY_MEDIUM;
 				}
-	
+
 				$id = Item::insert($item, false, $notify);
 
 				Logger::info("Feed for contact " . $contact["url"] . " stored under id " . $id);

--- a/src/Protocol/Feed.php
+++ b/src/Protocol/Feed.php
@@ -29,7 +29,7 @@ use Friendica\Core\Protocol;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Item;
-use Friendica\Model\Term;
+use Friendica\Model\Tag;
 use Friendica\Util\Network;
 use Friendica\Util\ParseUrl;
 use Friendica\Util\XML;
@@ -478,7 +478,7 @@ class Feed {
 				$item["title"] = "";
 				$item["body"] = $item["body"] . add_page_info($item["plink"], false, $preview, ($contact["fetch_further_information"] == 2), $contact["ffi_keyword_blacklist"]);
 				$item["tag"] = add_page_keywords($item["plink"], $preview, ($contact["fetch_further_information"] == 2), $contact["ffi_keyword_blacklist"]);
-				$taglist = add_page_keywords($item["plink"], $preview, ($contact["fetch_further_information"] == 2), $contact["ffi_keyword_blacklist"], true);
+				$taglist = get_page_keywords($item["plink"], $preview, ($contact["fetch_further_information"] == 2), $contact["ffi_keyword_blacklist"]);
 				$item["object-type"] = Activity\ObjectType::BOOKMARK;
 				unset($item["attach"]);
 			} else {
@@ -492,7 +492,7 @@ class Feed {
 					} else {
 						// @todo $preview is never set in this case, is it intended? - @MrPetovan 2018-02-13
 						$item["tag"] = add_page_keywords($item["plink"], $preview, true, $contact["ffi_keyword_blacklist"]);
-						$taglist = add_page_keywords($item["plink"], $preview, true, $contact["ffi_keyword_blacklist"], true);
+						$taglist = get_page_keywords($item["plink"], $preview, true, $contact["ffi_keyword_blacklist"]);
 					}
 					$item["body"] .= "\n" . $item['tag'];
 				} else {
@@ -531,10 +531,7 @@ class Feed {
 				if (!empty($id) && !empty($taglist)) {
 					$feeditem = Item::selectFirst(['uri-id'], ['id' => $id]);
 					foreach ($taglist as $tag) {
-						$fields = ['uri-id' => $feeditem['uri-id'], 'name' => substr($tag, 0, 64), 'type' => Term::HASHTAG];
-						DBA::insert('tag', $fields, true);
-		
-						Logger::info('Stored tag', ['uri-id' => $feeditem['uri-id'], 'tag' => $tag, 'fields' => $fields]);
+						Tag::storeByHash($feeditem['uri-id'], '#', $tag);
 					}					
 				}
 			}

--- a/src/Protocol/Feed.php
+++ b/src/Protocol/Feed.php
@@ -29,6 +29,7 @@ use Friendica\Core\Protocol;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Item;
+use Friendica\Model\Term;
 use Friendica\Util\Network;
 use Friendica\Util\ParseUrl;
 use Friendica\Util\XML;
@@ -385,6 +386,7 @@ class Feed {
 			}
 
 			$tags = '';
+			$taglist = [];
 			$categories = $xpath->query("category", $entry);
 			foreach ($categories AS $category) {
 				$hashtag = $category->nodeValue;
@@ -394,6 +396,7 @@ class Feed {
 
 				$taglink = "#[url=" . DI::baseUrl() . "/search?tag=" . $hashtag . "]" . $hashtag . "[/url]";
 				$tags .= $taglink;
+				$taglist[] = $hashtag;
 			}
 
 			$body = trim(XML::getFirstNodeValue($xpath, 'atom:content/text()', $entry));
@@ -475,6 +478,7 @@ class Feed {
 				$item["title"] = "";
 				$item["body"] = $item["body"] . add_page_info($item["plink"], false, $preview, ($contact["fetch_further_information"] == 2), $contact["ffi_keyword_blacklist"]);
 				$item["tag"] = add_page_keywords($item["plink"], $preview, ($contact["fetch_further_information"] == 2), $contact["ffi_keyword_blacklist"]);
+				$taglist = add_page_keywords($item["plink"], $preview, ($contact["fetch_further_information"] == 2), $contact["ffi_keyword_blacklist"], true);
 				$item["object-type"] = Activity\ObjectType::BOOKMARK;
 				unset($item["attach"]);
 			} else {
@@ -488,8 +492,11 @@ class Feed {
 					} else {
 						// @todo $preview is never set in this case, is it intended? - @MrPetovan 2018-02-13
 						$item["tag"] = add_page_keywords($item["plink"], $preview, true, $contact["ffi_keyword_blacklist"]);
+						$taglist = add_page_keywords($item["plink"], $preview, true, $contact["ffi_keyword_blacklist"], true);
 					}
 					$item["body"] .= "\n" . $item['tag'];
+				} else {
+					$taglist = [];
 				}
 
 				// Add the link to the original feed entry if not present in feed
@@ -516,10 +523,20 @@ class Feed {
 					// Set the delivery priority for "remote self" to "medium"
 					$notify = PRIORITY_MEDIUM;
 				}
-
+	
 				$id = Item::insert($item, false, $notify);
 
 				Logger::info("Feed for contact " . $contact["url"] . " stored under id " . $id);
+
+				if (!empty($id) && !empty($taglist)) {
+					$feeditem = Item::selectFirst(['uri-id'], ['id' => $id]);
+					foreach ($taglist as $tag) {
+						$fields = ['uri-id' => $feeditem['uri-id'], 'name' => substr($tag, 0, 64), 'type' => Term::HASHTAG];
+						DBA::insert('tag', $fields, true);
+		
+						Logger::info('Stored tag', ['uri-id' => $feeditem['uri-id'], 'tag' => $tag, 'fields' => $fields]);
+					}					
+				}
 			}
 		}
 

--- a/src/Protocol/Feed.php
+++ b/src/Protocol/Feed.php
@@ -531,7 +531,7 @@ class Feed {
 				if (!empty($id) && !empty($taglist)) {
 					$feeditem = Item::selectFirst(['uri-id'], ['id' => $id]);
 					foreach ($taglist as $tag) {
-						Tag::storeByHash($feeditem['uri-id'], '#', $tag);
+						Tag::store($feeditem['uri-id'], Tag::HASHTAG, $tag);
 					}					
 				}
 			}

--- a/src/Protocol/OStatus.php
+++ b/src/Protocol/OStatus.php
@@ -35,6 +35,8 @@ use Friendica\Model\Contact;
 use Friendica\Model\Conversation;
 use Friendica\Model\GContact;
 use Friendica\Model\Item;
+use Friendica\Model\ItemURI;
+use Friendica\Model\Term;
 use Friendica\Model\User;
 use Friendica\Network\Probe;
 use Friendica\Util\DateTimeFormat;
@@ -437,6 +439,7 @@ class OStatus
 			$item = array_merge($header, $author);
 
 			$item["uri"] = XML::getFirstNodeValue($xpath, 'atom:id/text()', $entry);
+			$item['uri-id'] = ItemURI::insert(['uri' => $item['uri']]);
 
 			$item["verb"] = XML::getFirstNodeValue($xpath, 'activity:verb/text()', $entry);
 
@@ -660,6 +663,12 @@ class OStatus
 						}
 
 						$item['tag'] .= '#[url=' . DI::baseUrl() . '/search?tag=' . $term . ']' . $term . '[/url]';
+
+						// Store the hashtag
+						$fields = ['uri-id' => $item['uri-id'], 'name' => substr($term, 0, 64), 'type' => Term::HASHTAG];
+						DBA::insert('tag', $fields, true);
+
+						Logger::info('Stored tag', ['uri-id' => $item['uri-id'], 'tag' => $term, 'fields' => $fields]);
 					}
 				}
 			}

--- a/src/Protocol/OStatus.php
+++ b/src/Protocol/OStatus.php
@@ -36,7 +36,7 @@ use Friendica\Model\Conversation;
 use Friendica\Model\GContact;
 use Friendica\Model\Item;
 use Friendica\Model\ItemURI;
-use Friendica\Model\Term;
+use Friendica\Model\Tag;
 use Friendica\Model\User;
 use Friendica\Network\Probe;
 use Friendica\Util\DateTimeFormat;
@@ -665,10 +665,7 @@ class OStatus
 						$item['tag'] .= '#[url=' . DI::baseUrl() . '/search?tag=' . $term . ']' . $term . '[/url]';
 
 						// Store the hashtag
-						$fields = ['uri-id' => $item['uri-id'], 'name' => substr($term, 0, 64), 'type' => Term::HASHTAG];
-						DBA::insert('tag', $fields, true);
-
-						Logger::info('Stored tag', ['uri-id' => $item['uri-id'], 'tag' => $term, 'fields' => $fields]);
+						Tag::storeByHash($item['uri-id'], '#', $term);
 					}
 				}
 			}

--- a/src/Protocol/OStatus.php
+++ b/src/Protocol/OStatus.php
@@ -709,6 +709,8 @@ class OStatus
 			$item["body"] = add_page_info_to_body($item["body"]);
 		}
 
+		Tag::storeFromBody($item['uri-id'], $item['body']);
+
 		// Mastodon Content Warning
 		if (($item["verb"] == Activity::POST) && $xpath->evaluate('boolean(atom:summary)', $entry)) {
 			$clear_text = XML::getFirstNodeValue($xpath, 'atom:summary/text()', $entry);

--- a/src/Protocol/OStatus.php
+++ b/src/Protocol/OStatus.php
@@ -665,7 +665,7 @@ class OStatus
 						$item['tag'] .= '#[url=' . DI::baseUrl() . '/search?tag=' . $term . ']' . $term . '[/url]';
 
 						// Store the hashtag
-						Tag::storeByHash($item['uri-id'], '#', $term);
+						Tag::store($item['uri-id'], Tag::HASHTAG, $term);
 					}
 				}
 			}

--- a/src/Worker/TagUpdate.php
+++ b/src/Worker/TagUpdate.php
@@ -23,6 +23,7 @@ namespace Friendica\Worker;
 
 use Friendica\Core\Logger;
 use Friendica\Database\DBA;
+use Friendica\Model\Term;
 
 class TagUpdate
 {
@@ -35,14 +36,14 @@ class TagUpdate
 			if ($message['uid'] == 0) {
 				$global = true;
 
-				DBA::update('term', ['global' => true], ['otype' => TERM_OBJ_POST, 'guid' => $message['guid']]);
+				DBA::update('term', ['global' => true], ['otype' => Term::OBJECT_TYPE_POST, 'guid' => $message['guid']]);
 			} else {
-				$global = (DBA::count('term', ['uid' => 0, 'otype' => TERM_OBJ_POST, 'guid' => $message['guid']]) > 0);
+				$global = (DBA::count('term', ['uid' => 0, 'otype' => Term::OBJECT_TYPE_POST, 'guid' => $message['guid']]) > 0);
 			}
 
 			$fields = ['guid' => $message['guid'], 'created' => $message['created'],
 				'received' => $message['received'], 'global' => $global];
-			DBA::update('term', $fields, ['otype' => TERM_OBJ_POST, 'oid' => $message['oid']]);
+			DBA::update('term', $fields, ['otype' => Term::OBJECT_TYPE_POST, 'oid' => $message['oid']]);
 		}
 
 		DBA::close($messages);

--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -1293,16 +1293,27 @@ return [
 		]
 	],
 	"tag" => [
-		"comment" => "item tags and mentions",
+		"comment" => "tags and mentions",
 		"fields" => [
-			"uri-id" => ["type" => "int unsigned", "not null" => "1", "primary" => "1", "relation" => ["item-uri" => "id"], "comment" => "Id of the item-uri table entry that contains the item uri"],
-			"type" => ["type" => "tinyint unsigned", "not null" => "1", "default" => "0", "primary" => "1", "comment" => ""],
-			"name" => ["type" => "varchar(64)", "not null" => "1", "default" => "", "primary" => "1", "comment" => ""],
-			"url" => ["type" => "varchar(255)", "not null" => "1", "default" => "", "comment" => ""]
+			"id" => ["type" => "int unsigned", "not null" => "1", "extra" => "auto_increment", "primary" => "1", "comment" => ""],
+			"type" => ["type" => "tinyint unsigned", "not null" => "1", "default" => "0", "comment" => ""],
+			"name" => ["type" => "varchar(64)", "not null" => "1", "default" => "", "comment" => ""],
+			"url" => ["type" => "varbinary(255)", "not null" => "1", "default" => "", "comment" => ""]
 		],
 		"indexes" => [
-			"PRIMARY" => ["uri-id", "type", "name"],
-			"type_name" => ["type", "name"]
+			"PRIMARY" => ["id"],			
+			"type_name_url" => ["UNIQUE", "type", "name", "url"]
+		]
+	],
+	"post-tag" => [
+		"comment" => "post relation to tags",
+		"fields" => [
+			"tid" => ["type" => "int unsigned", "not null" => "1", "relation" => ["tag" => "id"], "primary" => "1", "comment" => ""],
+			"uri-id" => ["type" => "int unsigned", "not null" => "1", "primary" => "1", "relation" => ["item-uri" => "id"], "comment" => "Id of the item-uri table entry that contains the item uri"],
+		],
+		"indexes" => [
+			"PRIMARY" => ["tid", "uri-id"],
+			"uri-id" => ["uri-id"]
 		]
 	],
 	"thread" => [

--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -1310,7 +1310,7 @@ return [
 		"fields" => [
 			"uri-id" => ["type" => "int unsigned", "not null" => "1", "primary" => "1", "relation" => ["item-uri" => "id"], "comment" => "Id of the item-uri table entry that contains the item uri"],
 			"type" => ["type" => "tinyint unsigned", "not null" => "1", "default" => "0", "primary" => "1", "comment" => ""],
-			"tid" => ["type" => "int unsigned", "not null" => "1", "relation" => ["tag" => "id"], "primary" => "1", "comment" => ""],
+			"tid" => ["type" => "int unsigned", "not null" => "1", "default" => "0", "primary" => "1", "relation" => ["tag" => "id"], "comment" => ""],
 			"cid" => ["type" => "int unsigned", "not null" => "1", "default" => "0", "primary" => "1", "relation" => ["contact" => "id"], "comment" => "Contact id of the mentioned public contact"],
 		],
 		"indexes" => [

--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -1297,7 +1297,7 @@ return [
 		"fields" => [
 			"id" => ["type" => "int unsigned", "not null" => "1", "extra" => "auto_increment", "primary" => "1", "comment" => ""],
 			"type" => ["type" => "tinyint unsigned", "not null" => "1", "default" => "0", "comment" => ""],
-			"name" => ["type" => "varchar(64)", "not null" => "1", "default" => "", "comment" => ""],
+			"name" => ["type" => "varchar(96)", "not null" => "1", "default" => "", "comment" => ""],
 			"url" => ["type" => "varbinary(255)", "not null" => "1", "default" => "", "comment" => ""]
 		],
 		"indexes" => [

--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -1301,7 +1301,8 @@ return [
 		],
 		"indexes" => [
 			"PRIMARY" => ["id"],
-			"type_name_url" => ["UNIQUE", "name", "url"]
+			"type_name_url" => ["UNIQUE", "name", "url"],
+			"url" => ["url"]
 		]
 	],
 	"post-tag" => [

--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -51,7 +51,7 @@
 use Friendica\Database\DBA;
 
 if (!defined('DB_UPDATE_VERSION')) {
-	define('DB_UPDATE_VERSION', 1338);
+	define('DB_UPDATE_VERSION', 1339);
 }
 
 return [
@@ -1290,6 +1290,19 @@ return [
 			"uid_otype_type_term_global_created" => ["uid", "otype", "type", "term(32)", "global", "created"],
 			"uid_otype_type_url" => ["uid", "otype", "type", "url(64)"],
 			"guid" => ["guid(64)"],
+		]
+	],
+	"tag" => [
+		"comment" => "item tags and mentions",
+		"fields" => [
+			"uri-id" => ["type" => "int unsigned", "not null" => "1", "primary" => "1", "relation" => ["item-uri" => "id"], "comment" => "Id of the item-uri table entry that contains the item uri"],
+			"type" => ["type" => "tinyint unsigned", "not null" => "1", "default" => "0", "primary" => "1", "comment" => ""],
+			"name" => ["type" => "varchar(64)", "not null" => "1", "default" => "", "primary" => "1", "comment" => ""],
+			"url" => ["type" => "varchar(255)", "not null" => "1", "default" => "", "comment" => ""]
+		],
+		"indexes" => [
+			"PRIMARY" => ["uri-id", "type", "name"],
+			"type_name" => ["type", "name"]
 		]
 	],
 	"thread" => [

--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -1296,24 +1296,26 @@ return [
 		"comment" => "tags and mentions",
 		"fields" => [
 			"id" => ["type" => "int unsigned", "not null" => "1", "extra" => "auto_increment", "primary" => "1", "comment" => ""],
-			"type" => ["type" => "tinyint unsigned", "not null" => "1", "default" => "0", "comment" => ""],
 			"name" => ["type" => "varchar(96)", "not null" => "1", "default" => "", "comment" => ""],
 			"url" => ["type" => "varbinary(255)", "not null" => "1", "default" => "", "comment" => ""]
 		],
 		"indexes" => [
-			"PRIMARY" => ["id"],			
-			"type_name_url" => ["UNIQUE", "type", "name", "url"]
+			"PRIMARY" => ["id"],
+			"type_name_url" => ["UNIQUE", "name", "url"]
 		]
 	],
 	"post-tag" => [
 		"comment" => "post relation to tags",
 		"fields" => [
-			"tid" => ["type" => "int unsigned", "not null" => "1", "relation" => ["tag" => "id"], "primary" => "1", "comment" => ""],
 			"uri-id" => ["type" => "int unsigned", "not null" => "1", "primary" => "1", "relation" => ["item-uri" => "id"], "comment" => "Id of the item-uri table entry that contains the item uri"],
+			"type" => ["type" => "tinyint unsigned", "not null" => "1", "default" => "0", "primary" => "1", "comment" => ""],
+			"tid" => ["type" => "int unsigned", "not null" => "1", "relation" => ["tag" => "id"], "primary" => "1", "comment" => ""],
+			"cid" => ["type" => "int unsigned", "not null" => "1", "default" => "0", "primary" => "1", "relation" => ["contact" => "id"], "comment" => "Contact id of the mentioned public contact"],
 		],
 		"indexes" => [
-			"PRIMARY" => ["tid", "uri-id"],
-			"uri-id" => ["uri-id"]
+			"PRIMARY" => ["uri-id", "type", "tid", "cid"],
+			"uri-id" => ["tid"],
+			"cid" => ["tid"]
 		]
 	],
 	"thread" => [


### PR DESCRIPTION
This is some work in progress. We now do store the hashtags and mentions in the new table "tag" as well. Currently we don't read from this table and there is no process to convert the data from "term". This will be done in a future PR. I just want to avoid that this PR gets too large.