### PR TITLE
Remove album name bin2hex conversion in file browser

### DIFF
--- a/mod/fbrowser.php
+++ b/mod/fbrowser.php
@@ -39,31 +39,26 @@ function fbrowser_content(App $a)
 
 	switch ($a->argv[1]) {
 		case "image":
-			$path = [["", DI::l10n()->t("Photos")]];
+			$path = ['' => DI::l10n()->t('Photos')];
 			$albums = false;
 			$sql_extra = "";
 			$sql_extra2 = " ORDER BY created DESC LIMIT 0, 10";
 
 			if ($a->argc==2) {
-				$albums = q("SELECT distinct(`album`) AS `album` FROM `photo` WHERE `uid` = %d AND `album` != '%s' AND `album` != '%s' ",
+				$photos = q("SELECT distinct(`album`) AS `album` FROM `photo` WHERE `uid` = %d AND `album` != '%s' AND `album` != '%s' ",
 					intval(local_user()),
 					DBA::escape('Contact Photos'),
 					DBA::escape(DI::l10n()->t('Contact Photos'))
 				);
 
-				function _map_folder1($el)
-				{
-					return [bin2hex($el['album']),$el['album']];
-				};
-
-				$albums = array_map("_map_folder1", $albums);
+				$albums = array_column($photos, 'album');
 			}
 
 			if ($a->argc == 3) {
-				$album = hex2bin($a->argv[2]);
+				$album = $a->argv[2];
 				$sql_extra = sprintf("AND `album` = '%s' ", DBA::escape($album));
 				$sql_extra2 = "";
-				$path[] = [$a->argv[2], $album];
+				$path[$album] = $album;
 			}
 
 			$r = q("SELECT `resource-id`, ANY_VALUE(`id`) AS `id`, ANY_VALUE(`filename`) AS `filename`, ANY_VALUE(`type`) AS `type`,

--- a/mod/photos.php
+++ b/mod/photos.php
@@ -309,7 +309,7 @@ function photos_post(App $a)
 		$desc        = !empty($_POST['desc'])      ? Strings::escapeTags(trim($_POST['desc']))      : '';
 		$rawtags     = !empty($_POST['newtag'])    ? Strings::escapeTags(trim($_POST['newtag']))    : '';
 		$item_id     = !empty($_POST['item_id'])   ? intval($_POST['item_id'])                      : 0;
-		$albname     = !empty($_POST['albname'])   ? Strings::escapeTags(trim($_POST['albname']))   : '';
+		$albname     = !empty($_POST['albname'])   ? trim($_POST['albname'])                        : '';
 		$origaname   = !empty($_POST['origaname']) ? Strings::escapeTags(trim($_POST['origaname'])) : '';
 
 		$aclFormatter = DI::aclFormatter();
@@ -615,10 +615,10 @@ function photos_post(App $a)
 	Hook::callAll('photo_post_init', $_POST);
 
 	// Determine the album to use
-	$album    = !empty($_REQUEST['album'])    ? Strings::escapeTags(trim($_REQUEST['album']))    : '';
-	$newalbum = !empty($_REQUEST['newalbum']) ? Strings::escapeTags(trim($_REQUEST['newalbum'])) : '';
+	$album    = trim($_REQUEST['album'] ?? '');
+	$newalbum = trim($_REQUEST['newalbum'] ?? '');
 
-	Logger::log('mod/photos.php: photos_post(): album= ' . $album . ' newalbum= ' . $newalbum , Logger::DEBUG);
+	Logger::info('album= ' . $album . ' newalbum= ' . $newalbum);
 
 	if (!strlen($album)) {
 		if (strlen($newalbum)) {

--- a/mod/wall_upload.php
+++ b/mod/wall_upload.php
@@ -41,7 +41,7 @@ function wall_upload_post(App $a, $desktopmode = true)
 	Logger::log("wall upload: starting new upload", Logger::DEBUG);
 
 	$r_json = (!empty($_GET['response']) && $_GET['response'] == 'json');
-	$album = (!empty($_GET['album']) ? Strings::escapeTags(trim($_GET['album'])) : '');
+	$album = trim($_GET['album'] ?? '');
 
 	if ($a->argc > 1) {
 		if (empty($_FILES['media'])) {

--- a/view/js/filebrowser.js
+++ b/view/js/filebrowser.js
@@ -77,8 +77,7 @@ var FileBrowser = {
 
 		$(".folders a, .path a").on("click", function(e){
 			e.preventDefault();
-			var url = baseurl + "/fbrowser/" + FileBrowser.type + "/" + this.dataset.folder + "?mode=minimal" + location['hash'];
-			location.href = url;
+			location.href = baseurl + "/fbrowser/" + FileBrowser.type + "/" + encodeURIComponent(this.dataset.folder) + "?mode=minimal" + location['hash'];
 		});
 
 		$(".photo-album-photo-link").on('click', function(e){

--- a/view/templates/filebrowser.tpl
+++ b/view/templates/filebrowser.tpl
@@ -14,13 +14,17 @@
 	</div>
 
 	<div class="path">
-		{{foreach $path as $p}}<a href="#" data-folder="{{$p.0}}">{{$p.1}}</a>{{/foreach}}
+		{{foreach $path as $folder => $name}}
+			<a href="#" data-folder="{{$folder}}">{{$name}}</a>
+		{{/foreach}}
 	</div>
 
 	{{if $folders }}
 	<div class="folders">
 		<ul>
-			{{foreach $folders as $f}}<li><a href="#" data-folder="{{$f.0}}">{{$f.1}}</a></li>{{/foreach}}
+		{{foreach $folders as $folder}}
+			<li><a href="#" data-folder="{{$folder}}">{{$folder}}</a></li>
+		{{/foreach}}
 		</ul>
 	</div>
 	{{/if}}

--- a/view/theme/frio/js/filebrowser.js
+++ b/view/theme/frio/js/filebrowser.js
@@ -99,7 +99,7 @@ var FileBrowser = {
 		// Click on album link
 		$(".fbrowser").on("click", ".folders a, .path a", function(e) {
 			e.preventDefault();
-			var url = baseurl + "/fbrowser/" + FileBrowser.type + "/" + this.dataset.folder + "?mode=none&theme=frio";
+			var url = baseurl + "/fbrowser/" + FileBrowser.type + "/" + encodeURIComponent(this.dataset.folder) + "?mode=none&theme=frio";
 			FileBrowser.folder = this.dataset.folder;
 
 			FileBrowser.loadContent(url);
@@ -161,12 +161,11 @@ var FileBrowser = {
 	// Initialize the AjaxUpload for the upload buttons
 	uploadButtons: function() {
 		if ($("#upload-image").length) {
-			// To get the albumname we need to convert it from hex
-			var albumname = hex2bin(FileBrowser.folder);
 			//AjaxUpload for images
 			var image_uploader = new window.AjaxUpload(
 				'upload-image',
-				{	action: 'wall_upload/' + FileBrowser.nickname + '?response=json&album=' + albumname,
+				{
+					action: 'wall_upload/' + FileBrowser.nickname + '?response=json&album=' + encodeURIComponent(FileBrowser.folder),
 					name: 'userfile',
 					responseType: 'json',
 					onSubmit: function(file, ext) {
@@ -183,9 +182,8 @@ var FileBrowser = {
 							return;
 						}
 
-						var url = baseurl + "/fbrowser/" + FileBrowser.type + "/" + FileBrowser.folder + "?mode=none&theme=frio";
 						// load new content to fbrowser window
-						FileBrowser.loadContent(url);
+						FileBrowser.loadContent(baseurl + '/fbrowser/' + FileBrowser.type + '/' + encodeURIComponent(FileBrowser.folder) + '?mode=none&theme=frio');
 					}
 				}
 			);

--- a/view/theme/frio/templates/filebrowser.tpl
+++ b/view/theme/frio/templates/filebrowser.tpl
@@ -9,7 +9,9 @@
 
 		{{* The breadcrumb navigation *}}
 		<ol class="path breadcrumb" aria-label="Breadcrumb" role="navigation">
-			{{foreach $path as $p}}<li role="presentation"><a href="#" data-folder="{{$p.0}}">{{$p.1}}</a></li>{{/foreach}}
+		{{foreach $path as $folder => $name}}
+			<li role="presentation"><a href="#" data-folder="{{$folder}}">{{$name}}</a></li>
+		{{/foreach}}
 
 			{{* Switch between image and file mode *}}
 			<div class="fbswitcher btn-group btn-group-xs pull-right" aria-label="Switch between image and file mode">
@@ -24,9 +26,9 @@
 			{{if $folders }}
 			<div class="folders media-left" role="navigation" aria-label="Album Navigation">
 				<ul role="menu">
-					{{foreach $folders as $f}}
+					{{foreach $folders as $folder}}
 					<li role="presentation">
-						<a href="#" data-folder="{{$f.0}}" role="menuitem">{{$f.1}}</a>
+						<a href="#" data-folder="{{$folder}}" role="menuitem">{{$folder}}</a>
 					</li>
 					{{/foreach}}
 				</ul>


### PR DESCRIPTION
Fixes #8534

- Avoids Javascript hex2bin() limitation to Latin-1 string encoding

Started removing some calls to `Strings::escapeTags`. With the Smarty default escaping, these probably aren't needed anymore. No sweeping changes just yet, I was able to verify there was no glaring XSS hole left after the album name call removal, but they probably all are obsolete.