### PR TITLE
AP: Interpret "update" as "create" when item isn't found

### DIFF
--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -173,7 +173,8 @@ class Processor
 	{
 		$item = Item::selectFirst(['uri', 'uri-id', 'thr-parent', 'gravity'], ['uri' => $activity['id']]);
 		if (!DBA::isResult($item)) {
-			Logger::warning('Unknown item', ['uri' => $activity['id']]);
+			Logger::warning('No existing item, item will be created', ['uri' => $activity['id']]);
+			self::createItem($activity);
 			return;
 		}
 


### PR DESCRIPTION
It helps with this: https://github.com/friendica/friendica/issues/8538#issuecomment-618589764

Interestingly this situation hadn't occurred a second time, so it isn't a fix for this issue (which seem to have fixed it on itself), but something that I realized while testing.