### PR TITLE
[frio] Align brand name color on nav icon

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -391,6 +391,7 @@ header #banner #logo-img,
 }
 #navbrand-container #navbar-brand-text {
     padding-left: 5px;
+	color: $nav_icon_color;
 }
 
 /* NavBar */


### PR DESCRIPTION
After one of the last CSS refactoring I did for frio, I reset the brand name color to the link color which usually doesn't work as well against the nav background. This micro-PR restores the intended color.