### PR TITLE
Template Engine with Subdirectory

### DIFF
--- a/src/Core/Renderer.php
+++ b/src/Core/Renderer.php
@@ -99,19 +99,18 @@ class Renderer
 	 * Load a given template $s
 	 *
 	 * @param string $s    Template to load.
-	 * @param string $root Optional.
+	 * @param string $subDir Subdirectory (Optional)
 	 *
 	 * @return string template.
 	 * @throws Exception
 	 */
-	public static function getMarkupTemplate($s, $root = '')
+	public static function getMarkupTemplate($s, $subDir = '')
 	{
 		$stamp1 = microtime(true);
-		$a = DI::app();
 		$t = self::getTemplateEngine();
 
 		try {
-			$template = $t->getTemplateFile($s, $root);
+			$template = $t->getTemplateFile($s, $subDir);
 		} catch (Exception $e) {
 			echo "<pre><b>" . __FUNCTION__ . "</b>: " . $e->getMessage() . "</pre>";
 			exit();

--- a/src/DI.php
+++ b/src/DI.php
@@ -384,6 +384,14 @@ abstract class DI
 	}
 
 	/**
+	 * @return string
+	 */
+	public static function basePath()
+	{
+		return self::$dice->create('$basepath');
+	}
+
+	/**
 	 * @return Util\DateTimeFormat
 	 */
 	public static function dtFormat()

--- a/src/Render/FriendicaSmartyEngine.php
+++ b/src/Render/FriendicaSmartyEngine.php
@@ -68,15 +68,17 @@ class FriendicaSmartyEngine implements ITemplateEngine
 		return $s->parsed($template);
 	}
 
-	public function getTemplateFile($file, $root = '')
+	public function getTemplateFile($file, $subDir = '')
 	{
 		$a = DI::app();
 		$template = new FriendicaSmarty();
 
 		// Make sure $root ends with a slash /
-		if ($root !== '' && substr($root, -1, 1) !== '/') {
-			$root = $root . '/';
+		if ($subDir !== '' && substr($subDir, -1, 1) !== '/') {
+			$subDir = $subDir . '/';
 		}
+
+		$root = DI::basePath() . '/' . $subDir;
 
 		$theme = $a->getCurrentTheme();
 		$filename = $template::SMARTY3_TEMPLATE_FOLDER . '/' . $file;

--- a/src/Render/ITemplateEngine.php
+++ b/src/Render/ITemplateEngine.php
@@ -27,5 +27,5 @@ namespace Friendica\Render;
 interface ITemplateEngine
 {
 	public function replaceMacros($s, $v);
-	public function getTemplateFile($file, $root = '');
+	public function getTemplateFile($file, $subDir = '');
 }


### PR DESCRIPTION
- Use explicit root path for template engine
- Replace `__DIR__` paramters in addons with subdirectories
- Fixes local tests, where call is made out of '/' and not '/vagrant/'

Needs https://github.com/friendica/friendica-addons/pull/977 as well