### PR TITLE
Iissue 8560: Wrong value for parent in mail notification

### DIFF
--- a/mod/message.php
+++ b/mod/message.php
@@ -352,13 +352,7 @@ function message_content(App $a)
 			$messages = DBA::toArray($messages_stmt);
 
 			DBA::update('mail', ['seen' => 1], ['parent-uri' => $message['parent-uri'], 'uid' => local_user()]);
-
-			if ($message['convid']) {
-				// Clear Diaspora private message notifications
-				DBA::update('notify', ['seen' => 1], ['type' => Type::MAIL, 'parent' => $message['convid'], 'uid' => local_user()]);
-			}
-			// Clear DFRN private message notifications
-			DBA::update('notify', ['seen' => 1], ['type' => Type::MAIL, 'parent' => $message['parent-uri'], 'uid' => local_user()]);
+			DBA::update('notify', ['seen' => 1], ['type' => Type::MAIL, 'parent' => $message['id'], 'uid' => local_user()]);
 		} else {
 			$messages = false;
 		}

--- a/src/Model/Mail.php
+++ b/src/Model/Mail.php
@@ -92,7 +92,7 @@ class Mail
 			'to_email' => $user['email'],
 			'uid' => $user['uid'],
 			'item' => $msg,
-			'parent' => 0,
+			'parent' => $msg['id'],
 			'source_name' => $msg['from-name'],
 			'source_link' => $msg['from-url'],
 			'source_photo' => $msg['from-photo'],


### PR DESCRIPTION
Fixes #8560
We never filled the "parent" field but searched for it. This is now changed.