### PR TITLE
The old tag handling is removed

### DIFF
--- a/include/api.php
+++ b/include/api.php
@@ -2033,7 +2033,7 @@ function api_statuses_repeat($type)
 
 	Logger::log('API: api_statuses_repeat: '.$id);
 
-	$fields = ['uri-id', 'body', 'title', 'attach', 'tag', 'author-name', 'author-link', 'author-avatar', 'guid', 'created', 'plink'];
+	$fields = ['uri-id', 'body', 'title', 'attach', 'author-name', 'author-link', 'author-avatar', 'guid', 'created', 'plink'];
 	$item = Item::selectFirst($fields, ['id' => $id, 'private' => [Item::PUBLIC, Item::UNLISTED]]);
 
 	if (DBA::isResult($item) && $item['body'] != "") {
@@ -2051,7 +2051,6 @@ function api_statuses_repeat($type)
 			$post .= "[/share]";
 		}
 		$_REQUEST['body'] = $post;
-		$_REQUEST['tag'] = $item['tag'];
 		$_REQUEST['attach'] = $item['attach'];
 		$_REQUEST['profile_uid'] = api_user();
 		$_REQUEST['api_source'] = true;

--- a/include/enotify.php
+++ b/include/enotify.php
@@ -574,7 +574,7 @@ function check_user_notification($itemid) {
  * @throws \Friendica\Network\HTTPException\InternalServerErrorException
  */
 function check_item_notification($itemid, $uid, $notification_type) {
-	$fields = ['id', 'mention', 'tag', 'parent', 'title', 'body',
+	$fields = ['id', 'mention', 'parent', 'title', 'body',
 		'author-link', 'author-name', 'author-avatar', 'author-id',
 		'guid', 'parent-uri', 'uri', 'contact-id', 'network'];
 	$condition = ['id' => $itemid, 'gravity' => [GRAVITY_PARENT, GRAVITY_COMMENT], 'deleted' => false];

--- a/include/items.php
+++ b/include/items.php
@@ -141,28 +141,6 @@ function query_page_info($url, $photo = "", $keywords = false, $keyword_blacklis
 	return $data;
 }
 
-function add_page_keywords($url, $photo = "", $keywords = false, $keyword_blacklist = "")
-{
-	$data = query_page_info($url, $photo, $keywords, $keyword_blacklist);
-	if (empty($data["keywords"]) || !is_array($data["keywords"])) {
-		return '';
-	}
-
-	$tags = "";
-	foreach ($data["keywords"] as $keyword) {
-		$hashtag = str_replace([" ", "+", "/", ".", "#", "'"],
-			["", "", "", "", "", ""], $keyword);
-
-		if ($tags != "") {
-			$tags .= ", ";
-		}
-
-		$tags .= "#[url=" . DI::baseUrl() . "/search?tag=" . $hashtag . "]" . $hashtag . "[/url]";
-	}
-
-	return $tags;
-}
-
 function get_page_keywords($url, $photo = "", $keywords = false, $keyword_blacklist = "")
 {
 	$data = query_page_info($url, $photo, $keywords, $keyword_blacklist);

--- a/mod/tagger.php
+++ b/mod/tagger.php
@@ -29,7 +29,6 @@ use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Item;
 use Friendica\Model\Tag;
-use Friendica\Model\Term;
 use Friendica\Protocol\Activity;
 use Friendica\Util\Strings;
 use Friendica\Util\XML;
@@ -170,49 +169,7 @@ EOT;
 		Item::update(['visible' => true], ['id' => $item['id']]);
 	}
 
-	$term_objtype = ($item['resource-id'] ? Term::OBJECT_TYPE_PHOTO : Term::OBJECT_TYPE_POST);
-
 	Tag::store($item['uri-id'], Tag::HASHTAG, $term);
-
-	$t = q("SELECT count(tid) as tcount FROM term WHERE oid=%d AND term='%s'",
-		intval($item['id']),
-		DBA::escape($term)
-	);
-
-	if (!$blocktags && $t[0]['tcount'] == 0) {
-		q("INSERT INTO term (oid, otype, type, term, url, uid) VALUE (%d, %d, %d, '%s', '%s', %d)",
-		   intval($item['id']),
-		   $term_objtype,
-		   Tag::HASHTAG,
-		   DBA::escape($term),
-		   '',
-		   intval($owner_uid)
-		);
-	}
-
-	// if the original post is on this site, update it.
-	$original_item = Item::selectFirst(['tag', 'id', 'uid'], ['origin' => true, 'uri' => $item['uri']]);
-	if (DBA::isResult($original_item)) {
-		$x = q("SELECT `blocktags` FROM `user` WHERE `uid`=%d LIMIT 1",
-			intval($original_item['uid'])
-		);
-		$t = q("SELECT COUNT(`tid`) AS `tcount` FROM `term` WHERE `oid`=%d AND `term`='%s'",
-			intval($original_item['id']),
-			DBA::escape($term)
-		);
-
-		if (DBA::isResult($x) && !$x[0]['blocktags'] && $t[0]['tcount'] == 0){
-			q("INSERT INTO term (`oid`, `otype`, `type`, `term`, `url`, `uid`) VALUE (%d, %d, %d, '%s', '%s', %d)",
-				intval($original_item['id']),
-				$term_objtype,
-				Tag::HASHTAG,
-				DBA::escape($term),
-				'',
-				intval($owner_uid)
-			);
-		}
-	}
-
 
 	$arr['id'] = $post_id;
 

--- a/mod/tagrm.php
+++ b/mod/tagrm.php
@@ -25,7 +25,6 @@ use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Item;
 use Friendica\Model\Tag;
-use Friendica\Model\Term;
 use Friendica\Util\Strings;
 
 function tagrm_post(App $a)
@@ -58,17 +57,16 @@ function tagrm_post(App $a)
  * @param $tags array
  * @throws Exception
  */
-function update_tags($item_id, $tags){
-	if (empty($item_id) || empty($tags)){
+function update_tags($item_id, $tags)
+{
+	if (empty($item_id) || empty($tags)) {
 		return;
 	}
 
-	$item = Item::selectFirst(['tag', 'uri-id'], ['id' => $item_id, 'uid' => local_user()]);
+	$item = Item::selectFirst(['uri-id'], ['id' => $item_id, 'uid' => local_user()]);
 	if (!DBA::isResult($item)) {
 		return;
 	}
-
-	$old_tags = explode(',', $item['tag']);
 
 	foreach ($tags as $new_tag) {
 		if (preg_match_all('/([#@!])\[url\=([^\[\]]*)\]([^\[\]]*)\[\/url\]/ism', $new_tag, $results, PREG_SET_ORDER)) {
@@ -76,17 +74,7 @@ function update_tags($item_id, $tags){
 				Tag::removeByHash($item['uri-id'], $tag[1], $tag[3], $tag[2]);
 			}
 		}
-	
-		foreach ($old_tags as $index => $old_tag) {
-			if (strcmp($old_tag, $new_tag) == 0) {
-				unset($old_tags[$index]);
-				break;
-			}
-		}
 	}
-
-	$tag_str = implode(',', $old_tags);
-	Term::insertFromTagFieldByItemId($item_id, $tag_str);
 }
 
 function tagrm_content(App $a)

--- a/src/Model/Tag.php
+++ b/src/Model/Tag.php
@@ -40,8 +40,6 @@ class Tag
 	const UNKNOWN  = 0;
 	const HASHTAG  = 1;
 	const MENTION  = 2;
-	const CATEGORY = 3;
-	const FILE     = 5;
 	/**
 	 * An implicit mention is a mention in a comment body that is redundant with the threading information.
 	 */

--- a/src/Model/UserItem.php
+++ b/src/Model/UserItem.php
@@ -227,9 +227,10 @@ class UserItem
 	 */
 	private static function checkImplicitMention(array $item, array $profiles)
 	{
-		foreach ($profiles AS $profile) {
-			if (strpos($item['tag'], '=' . $profile.']') || strpos($item['body'], '=' . $profile . ']')) {
-				if (strpos($item['body'], $profile) === false) {
+		$mentions = Tag::getByURIId($item['uri-id'], [Tag::IMPLICIT_MENTION]);
+		foreach ($mentions as $mention) {
+			foreach ($profiles as $profile) {
+				if (Strings::compareLink($profile, $mention['url'])) {
 					return true;
 				}
 			}
@@ -246,9 +247,10 @@ class UserItem
 	 */
 	private static function checkExplicitMention(array $item, array $profiles)
 	{
-		foreach ($profiles AS $profile) {
-			if (strpos($item['tag'], '=' . $profile.']') || strpos($item['body'], '=' . $profile . ']')) {
-				if (!(strpos($item['body'], $profile) === false)) {
+		$mentions = Tag::getByURIId($item['uri-id'], [Tag::MENTION, Tag::EXCLUSIVE_MENTION]);
+		foreach ($mentions as $mention) {
+			foreach ($profiles as $profile) {
+				if (Strings::compareLink($profile, $mention['url'])) {
 					return true;
 				}
 			}

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -2582,7 +2582,7 @@ class Diaspora
 		}
 
 		// Do we already have this item?
-		$fields = ['body', 'title', 'attach', 'tag', 'app', 'created', 'object-type', 'uri', 'guid',
+		$fields = ['body', 'title', 'attach', 'app', 'created', 'object-type', 'uri', 'guid',
 			'author-name', 'author-link', 'author-avatar'];
 		$condition = ['guid' => $guid, 'visible' => true, 'deleted' => false, 'private' => [Item::PUBLIC, Item::UNLISTED]];
 		$item = Item::selectFirst($fields, $condition);
@@ -2626,7 +2626,7 @@ class Diaspora
 			}
 
 			if ($stored) {
-				$fields = ['body', 'title', 'attach', 'tag', 'app', 'created', 'object-type', 'uri', 'guid',
+				$fields = ['body', 'title', 'attach', 'app', 'created', 'object-type', 'uri', 'guid',
 					'author-name', 'author-link', 'author-avatar'];
 				$condition = ['guid' => $guid, 'visible' => true, 'deleted' => false, 'private' => [Item::PUBLIC, Item::UNLISTED]];
 				$item = Item::selectFirst($fields, $condition);
@@ -2772,7 +2772,6 @@ class Diaspora
 
 		Tag::storeFromBody($datarray['uri-id'], $datarray["body"]);
 
-		$datarray["tag"] = $original_item["tag"];
 		$datarray["attach"] = $original_item["attach"];
 		$datarray["app"]  = $original_item["app"];
 

--- a/src/Protocol/Feed.php
+++ b/src/Protocol/Feed.php
@@ -481,7 +481,7 @@ class Feed {
 					if (empty($taglist)) {
 						$taglist = get_page_keywords($item["plink"], $preview, true, $contact["ffi_keyword_blacklist"]);
 					}
-					/// @todo $item["body"] .= "\n" . $tags;
+					$item["body"] .= "\n" . self::tagToString($taglist);
 				} else {
 					$taglist = [];
 				}
@@ -525,6 +525,27 @@ class Feed {
 		}
 
 		return ["header" => $author, "items" => $items];
+	}
+
+	/**
+	 * Convert a tag array to a tag string
+	 *
+	 * @param array $tags
+	 * @return string tag string
+	 */
+	private static function tagToString(array $tags)
+	{
+		$tagstr = '';
+
+		foreach ($tags as $tag) {
+			if ($tagstr != "") {
+				$tagstr .= ", ";
+			}
+	
+			$tagstr .= "#[url=" . DI::baseUrl() . "/search?tag=" . urlencode($tag) . "]" . $tag . "[/url]";
+		}
+
+		return $tagstr;
 	}
 
 	private static function titleIsBody($title, $body)

--- a/src/Protocol/Feed.php
+++ b/src/Protocol/Feed.php
@@ -385,18 +385,10 @@ class Feed {
 				$item["attach"] .= '[attach]href="' . $href . '" length="' . $length . '" type="' . $type . '"[/attach]';
 			}
 
-			$tags = '';
 			$taglist = [];
 			$categories = $xpath->query("category", $entry);
 			foreach ($categories AS $category) {
-				$hashtag = $category->nodeValue;
-				if ($tags != '') {
-					$tags .= ', ';
-				}
-
-				$taglink = "#[url=" . DI::baseUrl() . "/search?tag=" . $hashtag . "]" . $hashtag . "[/url]";
-				$tags .= $taglink;
-				$taglist[] = $hashtag;
+				$taglist[] = $category->nodeValue;
 			}
 
 			$body = trim(XML::getFirstNodeValue($xpath, 'atom:content/text()', $entry));
@@ -477,7 +469,6 @@ class Feed {
 				// We always strip the title since it will be added in the page information
 				$item["title"] = "";
 				$item["body"] = $item["body"] . add_page_info($item["plink"], false, $preview, ($contact["fetch_further_information"] == 2), $contact["ffi_keyword_blacklist"]);
-				$item["tag"] = add_page_keywords($item["plink"], $preview, ($contact["fetch_further_information"] == 2), $contact["ffi_keyword_blacklist"]);
 				$taglist = get_page_keywords($item["plink"], $preview, ($contact["fetch_further_information"] == 2), $contact["ffi_keyword_blacklist"]);
 				$item["object-type"] = Activity\ObjectType::BOOKMARK;
 				unset($item["attach"]);
@@ -487,14 +478,10 @@ class Feed {
 				}
 
 				if (!empty($contact["fetch_further_information"]) && ($contact["fetch_further_information"] == 3)) {
-					if (!empty($tags)) {
-						$item["tag"] = $tags;
-					} else {
-						// @todo $preview is never set in this case, is it intended? - @MrPetovan 2018-02-13
-						$item["tag"] = add_page_keywords($item["plink"], $preview, true, $contact["ffi_keyword_blacklist"]);
+					if (empty($taglist)) {
 						$taglist = get_page_keywords($item["plink"], $preview, true, $contact["ffi_keyword_blacklist"]);
 					}
-					$item["body"] .= "\n" . $item['tag'];
+					/// @todo $item["body"] .= "\n" . $tags;
 				} else {
 					$taglist = [];
 				}

--- a/src/Protocol/OStatus.php
+++ b/src/Protocol/OStatus.php
@@ -2081,13 +2081,10 @@ class OStatus
 			XML::addElement($doc, $entry, "ostatus:conversation", $conversation_uri, $attributes);
 		}
 
-		$tags = item::getFeedTags($item);
-
+		$tags = Tag::getByURIId($item['uri-id']);
 		if (count($tags)) {
-			foreach ($tags as $t) {
-				if ($t[0] == "@") {
-					$mentioned[$t[1]] = $t[1];
-				}
+			foreach ($tags as $tag) {
+				$mentioned[$tag['url']] = $tag['url'];
 			}
 		}
 
@@ -2138,9 +2135,9 @@ class OStatus
 		}
 
 		if (count($tags)) {
-			foreach ($tags as $t) {
-				if ($t[0] != "@") {
-					XML::addElement($doc, $entry, "category", "", ["term" => $t[2]]);
+			foreach ($tags as $tag) {
+				if ($tag['type'] == Tag::HASHTAG) {
+					XML::addElement($doc, $entry, "category", "", ["term" => $tag['name']]);
 				}
 			}
 		}


### PR DESCRIPTION
This is a follow up to PR https://github.com/friendica/friendica/pull/8566

We now don't use the "tag" field anymore and we don't write into the "term" table for tags anymore. That table is still used for categories and folders. Replacing that will be part of a different PR.