### PR TITLE
Ensure Tag::getByURIId parameter value in OStatus::entryFooter

### DIFF
--- a/src/Protocol/OStatus.php
+++ b/src/Protocol/OStatus.php
@@ -2081,11 +2081,9 @@ class OStatus
 			XML::addElement($doc, $entry, "ostatus:conversation", $conversation_uri, $attributes);
 		}
 
-		$tags = Tag::getByURIId($item['uri-id']);
-		if (count($tags)) {
-			foreach ($tags as $tag) {
-				$mentioned[$tag['url']] = $tag['url'];
-			}
+		// uri-id isn't present for follow entry pseudo-items
+		foreach (Tag::getByURIId($item['uri-id'] ?? 0) as $tag) {
+			$mentioned[$tag['url']] = $tag['url'];
 		}
 
 		// Make sure that mentions are accepted (GNU Social has problems with mixing HTTP and HTTPS)


### PR DESCRIPTION
- Address https://github.com/friendica/friendica/issues/8473#issuecomment-623701081
- $item['uri-id'] isn't present for follow entry pseudo-items