### PR TITLE
Issue 8586: Reduce the amount of item receivers

### DIFF
--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -265,8 +265,7 @@ class Diaspora
 		}
 
 		$items = Item::select(['author-id', 'author-link', 'parent-author-link'],
-			['parent' => $item['parent'], 'gravity' => [GRAVITY_COMMENT, GRAVITY_ACTIVITY]],
-			['group_by' => ['author-id']]);
+			['parent' => $item['parent'], 'gravity' => [GRAVITY_COMMENT, GRAVITY_ACTIVITY]]);
 		while ($item = DBA::fetch($items)) {
 			$contact = DBA::selectFirst('contact', ['id', 'url', 'name', 'protocol', 'batch', 'network'],
 				['id' => $item['author-id']]);

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -264,7 +264,7 @@ class Diaspora
 			return $contacts;
 		}
 
-		$items = Item::select(['author-id', 'author-link', 'parent-author-link'],
+		$items = Item::select(['author-id', 'author-link', 'parent-author-link', 'parent-guid'],
 			['parent' => $item['parent'], 'gravity' => [GRAVITY_COMMENT, GRAVITY_ACTIVITY]]);
 		while ($item = DBA::fetch($items)) {
 			$contact = DBA::selectFirst('contact', ['id', 'url', 'name', 'protocol', 'batch', 'network'],

--- a/src/Worker/Notifier.php
+++ b/src/Worker/Notifier.php
@@ -437,7 +437,7 @@ class Notifier
 
 				// Fetch the participation list
 				// The function will ensure that there are no duplicates
-				$relay_list = Diaspora::participantsForThread($parent, $relay_list);
+				$relay_list = Diaspora::participantsForThread($target_item, $relay_list);
 
 				// Add the relay to the list, avoid duplicates.
 				// Don't send community posts to the relay. Forum posts via the Diaspora protocol are looking ugly.


### PR DESCRIPTION
This should/could help with issue #8586

Possibly a change in the way participiant for Diaspora posts are generated is causing an "explosion" of item receivers.

This change limits the receivers to Diaspora contacts and will not come to effect for the participation message itself. (Possibly this both caused the issue)

Additionally there had been an issue that the participation hadn't really worked. So a higher number of receivers is expected - but not *that* much.