### PR TITLE
Don't count and fetch "follow" activities

### DIFF
--- a/mod/ping.php
+++ b/mod/ping.php
@@ -30,6 +30,7 @@ use Friendica\Model\Contact;
 use Friendica\Model\Group;
 use Friendica\Model\Item;
 use Friendica\Model\Notify\Type;
+use Friendica\Protocol\Activity;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Temporal;
 use Friendica\Util\Proxy as ProxyUtils;
@@ -134,9 +135,10 @@ function ping_init(App $a)
 
 		$notifs = ping_get_notifications(local_user());
 
-		$condition = ["`unseen` AND `uid` = ? AND `contact-id` != ?", local_user(), local_user()];
+		$condition = ["`unseen` AND `uid` = ? AND `contact-id` != ? AND (`activity` != ? OR `activity` IS NULL)",
+			local_user(), local_user(), Item::activityToIndex(Activity::FOLLOW)];
 		$fields = ['id', 'parent', 'verb', 'author-name', 'unseen', 'author-link', 'author-avatar', 'contact-avatar',
-			'network', 'created', 'object', 'parent-author-name', 'parent-author-link', 'parent-guid', 'wall'];
+			'network', 'created', 'object', 'parent-author-name', 'parent-author-link', 'parent-guid', 'wall', 'activity'];
 		$params = ['order' => ['received' => true]];
 		$items = Item::selectForUser(local_user(), $fields, $condition, $params);
 

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -74,7 +74,7 @@ class Item
 		'event-id', 'event-created', 'event-edited', 'event-start', 'event-finish',
 		'event-summary', 'event-desc', 'event-location', 'event-type',
 		'event-nofinish', 'event-adjust', 'event-ignore', 'event-id',
-		'delivery_queue_count', 'delivery_queue_done', 'delivery_queue_failed'
+		'delivery_queue_count', 'delivery_queue_done', 'delivery_queue_failed', 'activity'
 	];
 
 	// Field list that is used to deliver items via the protocols
@@ -1672,7 +1672,13 @@ class Item
 				$allow_gid      = $parent['allow_gid'];
 				$deny_cid       = $parent['deny_cid'];
 				$deny_gid       = $parent['deny_gid'];
-				$item['wall']   = $parent['wall'];
+
+				// Don't federate received participation messages
+				if ($item['verb'] != Activity::FOLLOW) {
+					$item['wall'] = $parent['wall'];
+				} else {
+					$item['wall'] = false;
+				}
 
 				/*
 				 * If the parent is private, force privacy for the entire conversation


### PR DESCRIPTION
Caused by the new "follow" (participation) messages the counter for new messages had been irritatingly high. This is fixed now.