### PR TITLE
avoid notice in probe.php

### DIFF
--- a/src/Network/Probe.php
+++ b/src/Network/Probe.php
@@ -370,7 +370,7 @@ class Probe
 			$data[] = ["@attributes" => $link];
 		}
 
-		if (is_array($webfinger["aliases"])) {
+		if (!empty($webfinger["aliases"]) && is_array($webfinger["aliases"])) {
 			foreach ($webfinger["aliases"] as $alias) {
 				$data[] = ["@attributes" =>
 							["rel" => "alias",


### PR DESCRIPTION
Hi,
I've set up a local git repo for development and learned about how to create branches, create commits and how to push that stuff to GitHub. It's rocket science. :-)

I tried to fix a notice https://github.com/friendica/friendica/issues/8475#issuecomment-612831549.

Please review with care. I just copied the first part of the changed line from another line in that file and it seems to fix that notice.

PS: That file has a wild mixture of single and double quotes. If you want me to fix that too please tell me to do so.

adresses: 
https://github.com/friendica/friendica/issues/8475#issuecomment-612831549
https://github.com/friendica/friendica/issues/8475#issuecomment-616816770 (partly)
https://github.com/friendica/friendica/issues/8475#issuecomment-625635222
