### PR TITLE
Issue 8610: Implicit mentions work again

### DIFF
--- a/mod/item.php
+++ b/mod/item.php
@@ -100,13 +100,8 @@ function item_post(App $a) {
 	$toplevel_item_id = intval($_REQUEST['parent'] ?? 0);
 	$thr_parent_uri = trim($_REQUEST['parent_uri'] ?? '');
 
-	$thread_parent_uriid = 0;
-	$thread_parent_contact = null;
-
 	$toplevel_item = null;
 	$parent_user = null;
-
-	$parent_contact = null;
 
 	$objecttype = null;
 	$profile_uid = ($_REQUEST['profile_uid'] ?? 0) ?: local_user();
@@ -122,9 +117,7 @@ function item_post(App $a) {
 		// if this isn't the top-level parent of the conversation, find it
 		if (DBA::isResult($toplevel_item)) {
 			// The URI and the contact is taken from the direct parent which needn't to be the top parent
-			$thread_parent_uriid = $toplevel_item['uri-id'];
 			$thr_parent_uri = $toplevel_item['uri'];
-			$thread_parent_contact = Contact::getDetailsByURL($toplevel_item["author-link"]);
 
 			if ($toplevel_item['id'] != $toplevel_item['parent']) {
 				$toplevel_item = Item::selectFirst([], ['id' => $toplevel_item['parent']]);

--- a/mod/item.php
+++ b/mod/item.php
@@ -737,7 +737,7 @@ function item_post(App $a) {
 
 	Tag::storeFromBody($datarray['uri-id'], $datarray['body']);
 
-	if (!\Friendica\Content\Feature::isEnabled($uid, 'explicit_mentions')) {
+	if (!\Friendica\Content\Feature::isEnabled($uid, 'explicit_mentions') && ($datarray['gravity'] == GRAVITY_COMMENT)) {
 		Tag::createImplicitMentions($datarray['uri-id'], $datarray['thr-parent-id']);
 	}
 

--- a/src/Model/Tag.php
+++ b/src/Model/Tag.php
@@ -326,6 +326,27 @@ class Tag
 	}
 
 	/**
+	 * Create implicit mentions for a given post
+	 *
+	 * @param integer $uri_id
+	 * @param integer $parent_uri_id
+	 */
+	public static function createImplicitMentions(int $uri_id, int $parent_uri_id)
+	{
+		if (DI::config()->get('system', 'disable_implicit_mentions')) {
+			return;
+		}
+
+		$tags = DBA::select('tag-view', ['name', 'url'], ['uri-id' => $parent_uri_id]);
+		while ($tag = DBA::fetch($tags)) {
+			self::store($uri_id, self::IMPLICIT_MENTION, $tag['name'], $tag['url']);
+		}
+
+		$parent = Item::selectFirst(['author-link', 'author-name'], ['uri-id' => $parent_uri_id]);
+		self::store($uri_id, self::IMPLICIT_MENTION, $parent['author-name'], $parent['author-link']);
+	}
+
+	/**
 	 * Retrieves the terms from the provided type(s) associated with the provided item ID.
 	 *
 	 * @param int       $item_id

--- a/src/Model/Tag.php
+++ b/src/Model/Tag.php
@@ -333,6 +333,10 @@ class Tag
 	 */
 	public static function createImplicitMentions(int $uri_id, int $parent_uri_id)
 	{
+		// Always mention the direct parent author
+		$parent = Item::selectFirst(['author-link', 'author-name'], ['uri-id' => $parent_uri_id]);
+		self::store($uri_id, self::IMPLICIT_MENTION, $parent['author-name'], $parent['author-link']);
+
 		if (DI::config()->get('system', 'disable_implicit_mentions')) {
 			return;
 		}
@@ -341,9 +345,6 @@ class Tag
 		while ($tag = DBA::fetch($tags)) {
 			self::store($uri_id, self::IMPLICIT_MENTION, $tag['name'], $tag['url']);
 		}
-
-		$parent = Item::selectFirst(['author-link', 'author-name'], ['uri-id' => $parent_uri_id]);
-		self::store($uri_id, self::IMPLICIT_MENTION, $parent['author-name'], $parent['author-link']);
 	}
 
 	/**

--- a/src/Model/Tag.php
+++ b/src/Model/Tag.php
@@ -333,10 +333,6 @@ class Tag
 	 */
 	public static function createImplicitMentions(int $uri_id, int $parent_uri_id)
 	{
-		if ($uri_id == $parent_uri_id) {
-			return;
-		}
-
 		// Always mention the direct parent author
 		$parent = Item::selectFirst(['author-link', 'author-name'], ['uri-id' => $parent_uri_id]);
 		self::store($uri_id, self::IMPLICIT_MENTION, $parent['author-name'], $parent['author-link']);

--- a/src/Model/Tag.php
+++ b/src/Model/Tag.php
@@ -349,6 +349,7 @@ class Tag
 		while ($tag = DBA::fetch($tags)) {
 			self::store($uri_id, self::IMPLICIT_MENTION, $tag['name'], $tag['url']);
 		}
+		DBA::close($tags);
 	}
 
 	/**

--- a/src/Model/Tag.php
+++ b/src/Model/Tag.php
@@ -333,6 +333,10 @@ class Tag
 	 */
 	public static function createImplicitMentions(int $uri_id, int $parent_uri_id)
 	{
+		if ($uri_id == $parent_uri_id) {
+			return;
+		}
+
 		// Always mention the direct parent author
 		$parent = Item::selectFirst(['author-link', 'author-name'], ['uri-id' => $parent_uri_id]);
 		self::store($uri_id, self::IMPLICIT_MENTION, $parent['author-name'], $parent['author-link']);

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -359,9 +359,7 @@ class Processor
 					return false;
 				}
 
-				$potential_implicit_mentions = self::getImplicitMentionList($parent);
-				$content = self::removeImplicitMentionsFromBody($content, $potential_implicit_mentions);
-				$activity['tags'] = self::convertImplicitMentionsInTags($activity['tags'], $potential_implicit_mentions);
+				$content = self::removeImplicitMentionsFromBody($content, self::getImplicitMentionList($parent));
 			}
 			$item['content-warning'] = HTML::toBBCode($activity['summary']);
 			$item['body'] = $content;
@@ -1032,25 +1030,5 @@ class Processor
 		$kept_mentions[] = $body;
 
 		return implode('', $kept_mentions);
-	}
-
-	private static function convertImplicitMentionsInTags($activity_tags, array $potential_mentions)
-	{
-		if (DI::config()->get('system', 'disable_implicit_mentions')) {
-			return $activity_tags;
-		}
-
-		foreach ($activity_tags as $index => $tag) {
-			if (in_array($tag['href'], $potential_mentions)) {
-				$activity_tags[$index]['name'] = preg_replace(
-					'/' . preg_quote(Tag::TAG_CHARACTER[Tag::MENTION], '/') . '/',
-					Tag::TAG_CHARACTER[Tag::IMPLICIT_MENTION],
-					$activity_tags[$index]['name'],
-					1
-				);
-			}
-		}
-
-		return $activity_tags;
 	}
 }

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -359,7 +359,7 @@ class Processor
 					return false;
 				}
 
-				$content = self::removeImplicitMentionsFromBody($content, self::getImplicitMentionList($parent));
+				$content = self::removeImplicitMentionsFromBody($content, $parent);
 			}
 			$item['content-warning'] = HTML::toBBCode($activity['summary']);
 			$item['body'] = $content;
@@ -969,10 +969,6 @@ class Processor
 	 */
 	private static function getImplicitMentionList(array $parent)
 	{
-		if (DI::config()->get('system', 'disable_implicit_mentions')) {
-			return [];
-		}
-
 		$parent_terms = Tag::getByURIId($parent['uri-id'], [Tag::MENTION, Tag::IMPLICIT_MENTION, Tag::EXCLUSIVE_MENTION]);
 
 		$parent_author = Contact::getDetailsByURL($parent['author-link'], 0);
@@ -1006,14 +1002,16 @@ class Processor
 	 * Strips from the body prepended implicit mentions
 	 *
 	 * @param string $body
-	 * @param array $potential_mentions
+	 * @param array $parent
 	 * @return string
 	 */
-	private static function removeImplicitMentionsFromBody($body, array $potential_mentions)
+	private static function removeImplicitMentionsFromBody(string $body, array $parent)
 	{
 		if (DI::config()->get('system', 'disable_implicit_mentions')) {
 			return $body;
 		}
+
+		$potential_mentions = self::getImplicitMentionList($parent);
 
 		$kept_mentions = [];
 

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -1845,10 +1845,6 @@ class Transmitter
 
 	private static function prependMentions($body, int $uriid)
 	{
-		if (DI::config()->get('system', 'disable_implicit_mentions')) {
-			return $body;
-		}
-
 		$mentions = [];
 
 		foreach (Tag::getByURIId($uriid, [Tag::IMPLICIT_MENTION]) as $tag) {

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -1294,7 +1294,7 @@ class Transmitter
 		$body = $item['body'];
 
 		if (empty($item['uid']) || !Feature::isEnabled($item['uid'], 'explicit_mentions')) {
-			$body = self::prependMentions($body, $permission_block);
+			$body = self::prependMentions($body, $item['uri-id']);
 		}
 
 		if ($type == 'Note') {
@@ -1843,7 +1843,7 @@ class Transmitter
 		HTTPSignature::transmit($signed, $profile['inbox'], $uid);
 	}
 
-	private static function prependMentions($body, array $permission_block)
+	private static function prependMentions($body, int $uriid)
 	{
 		if (DI::config()->get('system', 'disable_implicit_mentions')) {
 			return $body;
@@ -1851,14 +1851,14 @@ class Transmitter
 
 		$mentions = [];
 
-		foreach ($permission_block['to'] as $profile_url) {
-			$profile = Contact::getDetailsByURL($profile_url);
+		foreach (Tag::getByURIId($uriid, [Tag::IMPLICIT_MENTION]) as $tag) {
+			$profile = Contact::getDetailsByURL($tag['url']);
 			if (!empty($profile['addr'])
 				&& $profile['contact-type'] != Contact::TYPE_COMMUNITY
 				&& !strstr($body, $profile['addr'])
-				&& !strstr($body, $profile_url)
+				&& !strstr($body, $tag['url'])
 			) {
-				$mentions[] = '@[url=' . $profile_url . ']' . $profile['nick'] . '[/url]';
+				$mentions[] = '@[url=' . $tag['url'] . ']' . $profile['nick'] . '[/url]';
 			}
 		}
 


### PR DESCRIPTION
Fixes #8610

Due to the modifications in the tag system, the implicit mentions hadn't worked anymore. This fixes it by doing it differently.

The functionality is now completely based upon the "tag" table entries. When creating a new post, the system looks for the implicit mentions (all mentions from the post we are commenting on and additionally the author of the previous post) and adds them as implicit (means invisible) mentions to the post. When the post is then send out to AP, we are taking these implicit mentions and add them to the body and additionally use them to create the tags as well. (The last part is a change that I introduced)

Another change is the behaviour when this functionality is deactivated. Then the author of the previous post is automatically mentioned. This is more or less the identical behaviour from before, but it is now implemented in a much cleaner way, I think.