### PR TITLE
Use constants for the BBCode modes

### DIFF
--- a/include/api.php
+++ b/include/api.php
@@ -2491,10 +2491,10 @@ function api_format_messages($item, $recipient, $sender)
 		if ($_GET['getText'] == 'html') {
 			$ret['text'] = BBCode::convert($item['body'], false);
 		} elseif ($_GET['getText'] == 'plain') {
-			$ret['text'] = trim(HTML::toPlaintext(BBCode::convert(api_clean_plain_items($item['body']), false, 2, true), 0));
+			$ret['text'] = trim(HTML::toPlaintext(BBCode::convert(api_clean_plain_items($item['body']), false, BBCode::API, true), 0));
 		}
 	} else {
-		$ret['text'] = $item['title'] . "\n" . HTML::toPlaintext(BBCode::convert(api_clean_plain_items($item['body']), false, 2, true), 0);
+		$ret['text'] = $item['title'] . "\n" . HTML::toPlaintext(BBCode::convert(api_clean_plain_items($item['body']), false, BBCode::API, true), 0);
 	}
 	if (!empty($_GET['getUserObjects']) && $_GET['getUserObjects'] == 'false') {
 		unset($ret['sender']);
@@ -2520,7 +2520,7 @@ function api_convert_item($item)
 	$attachments = api_get_attachments($body);
 
 	// Workaround for ostatus messages where the title is identically to the body
-	$html = BBCode::convert(api_clean_plain_items($body), false, 2, true);
+	$html = BBCode::convert(api_clean_plain_items($body), false, BBCode::API, true);
 	$statusbody = trim(HTML::toPlaintext($html, 0));
 
 	// handle data: images

--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -2035,7 +2035,7 @@ class BBCode
 
 		// Convert it to HTML - don't try oembed
 		if ($for_diaspora) {
-			$text = self::convert($text, false, 3);
+			$text = self::convert($text, false, self::DIASPORA);
 
 			// Add all tags that maybe were removed
 			if (preg_match_all("/#\[url\=([$url_search_string]*)\](.*?)\[\/url\]/ism", $original_text, $tags)) {
@@ -2049,7 +2049,7 @@ class BBCode
 				$text = $text . " " . $tagline;
 			}
 		} else {
-			$text = self::convert($text, false, 4);
+			$text = self::convert($text, false, self::CONNECTORS);
 		}
 
 		// If a link is followed by a quote then there should be a newline before it

--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -443,15 +443,15 @@ class BBCode
 	 */
 	public static function toPlaintext($text, $keep_urls = true)
 	{
-		$naked_text = HTML::toPlaintext(BBCode::convert($text, false, 0, true), 0, !$keep_urls);
+		$naked_text = HTML::toPlaintext(self::convert($text, false, 0, true), 0, !$keep_urls);
 
 		return $naked_text;
 	}
 
-	private static function proxyUrl($image, $simplehtml = BBCode::INTERNAL)
+	private static function proxyUrl($image, $simplehtml = self::INTERNAL)
 	{
 		// Only send proxied pictures to API and for internal display
-		if (in_array($simplehtml, [BBCode::INTERNAL, BBCode::API])) {
+		if (in_array($simplehtml, [self::INTERNAL, self::API])) {
 			return ProxyUtils::proxifyUrl($image);
 		} else {
 			return $image;
@@ -620,7 +620,7 @@ class BBCode
 	 * @return string
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
-	private static function convertAttachment($text, $simplehtml = BBCode::INTERNAL, $tryoembed = true)
+	private static function convertAttachment($text, $simplehtml = self::INTERNAL, $tryoembed = true)
 	{
 		$data = self::getAttachmentData($text);
 		if (empty($data) || empty($data['url'])) {
@@ -649,7 +649,7 @@ class BBCode
 		} catch (Exception $e) {
 			$data['title'] = ($data['title'] ?? '') ?: $data['url'];
 
-			if ($simplehtml != BBCode::CONNECTORS) {
+			if ($simplehtml != self::CONNECTORS) {
 				$return = sprintf('<div class="type-%s">', $data['type']);
 			}
 
@@ -676,7 +676,7 @@ class BBCode
 				$return .= sprintf('<sup><a href="%s">%s</a></sup>', $data['url'], parse_url($data['url'], PHP_URL_HOST));
 			}
 
-			if ($simplehtml != BBCode::CONNECTORS) {
+			if ($simplehtml != self::CONNECTORS) {
 				$return .= '</div>';
 			}
 		}
@@ -1261,7 +1261,7 @@ class BBCode
 	 * @return string
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
-	public static function convert($text, $try_oembed = true, $simple_html = BBCode::INTERNAL, $for_plaintext = false)
+	public static function convert($text, $try_oembed = true, $simple_html = self::INTERNAL, $for_plaintext = false)
 	{
 		$a = DI::app();
 
@@ -1389,9 +1389,9 @@ class BBCode
 
 		/// @todo Have a closer look at the different html modes
 		// Handle attached links or videos
-		if ($simple_html == BBCode::ACTIVITYPUB) {
+		if ($simple_html == self::ACTIVITYPUB) {
 			$text = self::removeAttachment($text);
-		} elseif (!in_array($simple_html, [BBCode::INTERNAL, BBCode::CONNECTORS])) {
+		} elseif (!in_array($simple_html, [self::INTERNAL, self::CONNECTORS])) {
 			$text = self::removeAttachment($text, true);
 		} else {
 			$text = self::convertAttachment($text, $simple_html, $try_oembed);
@@ -1454,7 +1454,7 @@ class BBCode
 
 		// Check for sized text
 		// [size=50] --> font-size: 50px (with the unit).
-		if ($simple_html != BBCode::DIASPORA) {
+		if ($simple_html != self::DIASPORA) {
 			$text = preg_replace("(\[size=(\d*?)\](.*?)\[\/size\])ism", "<span style=\"font-size: $1px; line-height: initial;\">$2</span>", $text);
 			$text = preg_replace("(\[size=(.*?)\](.*?)\[\/size\])ism", "<span style=\"font-size: $1; line-height: initial;\">$2</span>", $text);
 		} else {
@@ -1728,7 +1728,7 @@ class BBCode
 		}
 
 		if (!$for_plaintext) {
-			if (in_array($simple_html, [BBCode::OSTATUS, BBCode::ACTIVITYPUB])) {
+			if (in_array($simple_html, [self::OSTATUS, self::ACTIVITYPUB])) {
 				$text = preg_replace_callback("/\[url\](.*?)\[\/url\]/ism", 'self::convertUrlForActivityPubCallback', $text);
 				$text = preg_replace_callback("/\[url\=(.*?)\](.*?)\[\/url\]/ism", 'self::convertUrlForActivityPubCallback', $text);
 			}
@@ -1740,14 +1740,14 @@ class BBCode
 		$text = str_replace(["\r","\n"], ['<br />', '<br />'], $text);
 
 		// Remove all hashtag addresses
-		if ($simple_html && !in_array($simple_html, [BBCode::DIASPORA, BBCode::OSTATUS, BBCode::ACTIVITYPUB])) {
+		if ($simple_html && !in_array($simple_html, [self::DIASPORA, self::OSTATUS, self::ACTIVITYPUB])) {
 			$text = preg_replace("/([#@!])\[url\=(.*?)\](.*?)\[\/url\]/ism", '$1$3', $text);
-		} elseif ($simple_html == BBCode::DIASPORA) {
+		} elseif ($simple_html == self::DIASPORA) {
 			// The ! is converted to @ since Diaspora only understands the @
 			$text = preg_replace("/([@!])\[url\=(.*?)\](.*?)\[\/url\]/ism",
 				'@<a href="$2">$3</a>',
 				$text);
-		} elseif (in_array($simple_html, [BBCode::OSTATUS, BBCode::ACTIVITYPUB])) {
+		} elseif (in_array($simple_html, [self::OSTATUS, self::ACTIVITYPUB])) {
 			$text = preg_replace("/([@!])\[url\=(.*?)\](.*?)\[\/url\]/ism",
 				'$1<span class="vcard"><a href="$2" class="url u-url mention" title="$3"><span class="fn nickname mention">$3</span></a></span>',
 				$text);
@@ -1763,7 +1763,7 @@ class BBCode
 		$text = preg_replace("/#\[url\=.*?\]\^\[\/url\]\[url\=(.*?)\](.*?)\[\/url\]/i",
 					"[bookmark=$1]$2[/bookmark]", $text);
 
-		if (in_array($simple_html, [BBCode::API, BBCode::OSTATUS, BBCode::TWITTER])) {
+		if (in_array($simple_html, [self::API, self::OSTATUS, self::TWITTER])) {
 			$text = preg_replace_callback("/([^#@!])\[url\=([^\]]*)\](.*?)\[\/url\]/ism", "self::expandLinksCallback", $text);
 			//$Text = preg_replace("/[^#@!]\[url\=([^\]]*)\](.*?)\[\/url\]/ism", ' $2 [url]$1[/url]', $Text);
 			$text = preg_replace("/\[bookmark\=([^\]]*)\](.*?)\[\/bookmark\]/ism", ' $2 [url]$1[/url]',$text);

--- a/src/Factory/Api/Mastodon/Field.php
+++ b/src/Factory/Api/Mastodon/Field.php
@@ -37,7 +37,7 @@ class Field extends BaseFactory
 	 */
 	public function createFromProfileField(ProfileField $profileField)
 	{
-		return new \Friendica\Api\Entity\Mastodon\Field($profileField->label, BBCode::convert($profileField->value, false, 9));
+		return new \Friendica\Api\Entity\Mastodon\Field($profileField->label, BBCode::convert($profileField->value, false, BBCode::ACTIVITYPUB));
 	}
 
 	/**

--- a/src/Model/Event.php
+++ b/src/Model/Event.php
@@ -611,7 +611,7 @@ class Event
 
 			$title = BBCode::convert(Strings::escapeHtml($event['summary']));
 			if (!$title) {
-				list($title, $_trash) = explode("<br", BBCode::convert(Strings::escapeHtml($event['desc'])), 2);
+				list($title, $_trash) = explode("<br", BBCode::convert(Strings::escapeHtml($event['desc'])), BBCode::API);
 			}
 
 			$author_link = $event['author-link'];

--- a/src/Model/ItemContent.php
+++ b/src/Model/ItemContent.php
@@ -22,6 +22,7 @@
 namespace Friendica\Model;
 
 use Friendica\Content\Text;
+use Friendica\Content\Text\BBCode;
 use Friendica\Core\Protocol;
 use Friendica\DI;
 
@@ -41,7 +42,7 @@ class ItemContent
 	 * @see   \Friendica\Content\Text\BBCode::getAttachedData
 	 *
 	 */
-	public static function getPlaintextPost($item, $limit = 0, $includedlinks = false, $htmlmode = 2, $target_network = '')
+	public static function getPlaintextPost($item, $limit = 0, $includedlinks = false, $htmlmode = BBCode::API, $target_network = '')
 	{
 		// Remove hashtags
 		$URLSearchString = '^\[\]';
@@ -79,11 +80,11 @@ class ItemContent
 			}
 		} else {// Try to guess the correct target network
 			switch ($htmlmode) {
-				case 8:
+				case BBCode::TWITTER:
 					$abstract = Text\BBCode::getAbstract($item['body'], Protocol::TWITTER);
 					break;
 
-				case 7:
+				case BBCode::OSTATUS:
 					$abstract = Text\BBCode::getAbstract($item['body'], Protocol::STATUSNET);
 					break;
 
@@ -139,8 +140,8 @@ class ItemContent
 					$msg = trim(str_replace($link, '', $msg));
 				} elseif (($limit == 0) || ($pos < $limit)) {
 					// The limit has to be increased since it will be shortened - but not now
-					// Only do it with Twitter (htmlmode = 8)
-					if (($limit > 0) && (strlen($link) > 23) && ($htmlmode == 8)) {
+					// Only do it with Twitter
+					if (($limit > 0) && (strlen($link) > 23) && ($htmlmode == BBCode::TWITTER)) {
 						$limit = $limit - 23 + strlen($link);
 					}
 

--- a/src/Module/Api/Friendica/Profile/Show.php
+++ b/src/Module/Api/Friendica/Profile/Show.php
@@ -83,7 +83,7 @@ class Show extends BaseApi
 		foreach ($profileFields as $profileField) {
 			$custom_fields[] = [
 				'label' => $profileField->label,
-				'value' => BBCode::convert($profileField->value, false, 2),
+				'value' => BBCode::convert($profileField->value, false, BBCode::API),
 			];
 		}
 

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -644,7 +644,7 @@ class Processor
 					$title = $matches[3];
 				}
 
-				$title = trim(HTML::toPlaintext(BBCode::convert($title, false, 2, true), 0));
+				$title = trim(HTML::toPlaintext(BBCode::convert($title, false, BBCode::API, true), 0));
 
 				if (strlen($title) > 20) {
 					$title = substr($title, 0, 20) . '...';

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -1215,7 +1215,7 @@ class Transmitter
 	{
 		$event = [];
 		$event['name'] = $item['event-summary'];
-		$event['content'] = BBCode::convert($item['event-desc'], false, 9);
+		$event['content'] = BBCode::convert($item['event-desc'], false, BBCode::ACTIVITYPUB);
 		$event['startTime'] = DateTimeFormat::utc($item['event-start'] . '+00:00', DateTimeFormat::ATOM);
 
 		if (!$item['event-nofinish']) {
@@ -1309,7 +1309,7 @@ class Transmitter
 			$regexp = "/[@!]\[url\=([^\[\]]*)\].*?\[\/url\]/ism";
 			$body = preg_replace_callback($regexp, ['self', 'mentionCallback'], $body);
 
-			$data['content'] = BBCode::convert($body, false, 9);
+			$data['content'] = BBCode::convert($body, false, BBCode::ACTIVITYPUB);
 		}
 
 		// The regular "content" field does contain a minimized HTML. This is done since systems like

--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -951,7 +951,7 @@ class DFRN
 				$htmlbody = "[b]" . $item['title'] . "[/b]\n\n" . $htmlbody;
 			}
 
-			$htmlbody = BBCode::convert($htmlbody, false, 7);
+			$htmlbody = BBCode::convert($htmlbody, false, BBCode::OSTATUS);
 		}
 
 		$author = self::addEntryAuthor($doc, "author", $item["author-link"], $item);
@@ -2428,7 +2428,8 @@ class DFRN
 				if (($term != "") && ($scheme != "")) {
 					$parts = explode(":", $scheme);
 					if ((count($parts) >= 4) && (array_shift($parts) == "X-DFRN")) {
-						$termurl = implode(":", $parts);
+						$termurl = array_pop($parts);
+						$termurl = array_pop($parts) . $termurl;
 						Tag::store($item['uri-id'], Tag::IMPLICIT_MENTION, $term, $termurl);
 					}
 				}

--- a/src/Protocol/OStatus.php
+++ b/src/Protocol/OStatus.php
@@ -1456,7 +1456,7 @@ class OStatus
 		XML::addElement($doc, $author, "name", $owner["nick"]);
 		XML::addElement($doc, $author, "email", $owner["addr"]);
 		if ($show_profile) {
-			XML::addElement($doc, $author, "summary", BBCode::convert($owner["about"], false, 7));
+			XML::addElement($doc, $author, "summary", BBCode::convert($owner["about"], false, BBCode::OSTATUS));
 		}
 
 		$attributes = ["rel" => "alternate", "type" => "text/html", "href" => $owner["url"]];
@@ -1483,7 +1483,7 @@ class OStatus
 		XML::addElement($doc, $author, "poco:preferredUsername", $owner["nick"]);
 		XML::addElement($doc, $author, "poco:displayName", $owner["name"]);
 		if ($show_profile) {
-			XML::addElement($doc, $author, "poco:note", BBCode::convert($owner["about"], false, 7));
+			XML::addElement($doc, $author, "poco:note", BBCode::convert($owner["about"], false, BBCode::OSTATUS));
 
 			if (trim($owner["location"]) != "") {
 				$element = $doc->createElement("poco:address");
@@ -1895,7 +1895,7 @@ class OStatus
 
 		if (!$toplevel) {
 			if (!empty($item['title'])) {
-				$title = BBCode::convert($item['title'], false, 7);
+				$title = BBCode::convert($item['title'], false, BBCode::OSTATUS);
 			} else {
 				$title = sprintf("New note by %s", $owner["nick"]);
 			}
@@ -1984,7 +1984,7 @@ class OStatus
 			$body = "[b]".$item['title']."[/b]\n\n".$body;
 		}
 
-		$body = BBCode::convert($body, false, 7);
+		$body = BBCode::convert($body, false, BBCode::OSTATUS);
 
 		XML::addElement($doc, $entry, "content", $body, ["type" => "html"]);
 


### PR DESCRIPTION
I just realized that we still are using numeric values for the BBCode modes instead of using constants. Now we use constants.