### PR TITLE
Fix warnings ("Division by zero" and "key parameter is not a valid public key")

### DIFF
--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -1727,10 +1727,10 @@ class BBCode
 			$text = Smilies::replace($text);			
 		}
 
-		if (DI::config()->get('system', 'big_emojis') && ($simple_html != self::DIASPORA)) {
+		if (!$for_plaintext && DI::config()->get('system', 'big_emojis') && ($simple_html != self::DIASPORA)) {
 			$conv = html_entity_decode(str_replace([' ', "\n", "\r"], '', $text));
 			// Emojis are always 4 byte Unicode characters
-			if (strlen($conv) / mb_strlen($conv) == 4) {
+			if (!empty($conv) && (strlen($conv) / mb_strlen($conv) == 4)) {
 				$text = '<span style="font-size: xx-large; line-height: initial;">' . $text . '</span>';
 			}
 		}

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -3139,7 +3139,9 @@ class Diaspora
 		$json = json_encode(["iv" => $b_iv, "key" => $b_aes_key]);
 
 		$encrypted_key_bundle = "";
-		openssl_public_encrypt($json, $encrypted_key_bundle, $pubkey);
+		if (!@openssl_public_encrypt($json, $encrypted_key_bundle, $pubkey)) {
+			return false;
+		}
 
 		$json_object = json_encode(
 			["aes_key" => base64_encode($encrypted_key_bundle),


### PR DESCRIPTION
This fixes two warnings:
* `PHP Warning:  openssl_public_encrypt(): key parameter is not a valid public key in src/Protocol/Diaspora.php on line 3142`
* `PHP Warning:  Division by zero in src/Content/Text/BBCode.php on line 1733`