### PR TITLE
Catch template engine errors

### DIFF
--- a/src/Core/Renderer.php
+++ b/src/Core/Renderer.php
@@ -23,6 +23,7 @@ namespace Friendica\Core;
 
 use Exception;
 use Friendica\DI;
+use Friendica\Network\HTTPException\InternalServerErrorException;
 use Friendica\Render\TemplateEngine;
 
 /**
@@ -70,6 +71,7 @@ class Renderer
 	 * @param string $template
 	 * @param array  $vars
 	 * @return string
+	 * @throws InternalServerErrorException
 	 */
 	public static function replaceMacros(string $template, array $vars)
 	{
@@ -83,8 +85,8 @@ class Renderer
 		try {
 			$output = $t->replaceMacros($template, $vars);
 		} catch (Exception $e) {
-			echo "<pre><b>" . __FUNCTION__ . "</b>: " . $e->getMessage() . "</pre>";
-			exit();
+			DI::logger()->critical($e->getMessage(), ['template' => $template, 'vars' => $vars]);
+			throw new InternalServerErrorException(DI::l10n()->t('Friendica can\'t display this page at the moment, please contact the administrator or check the Friendica log for errors.'));
 		}
 
 		DI::profiler()->saveTimestamp($stamp1, "rendering", System::callstack());
@@ -99,7 +101,7 @@ class Renderer
 	 * @param string $subDir Subdirectory (Optional)
 	 *
 	 * @return string template.
-	 * @throws Exception
+	 * @throws InternalServerErrorException
 	 */
 	public static function getMarkupTemplate($file, $subDir = '')
 	{
@@ -109,8 +111,8 @@ class Renderer
 		try {
 			$template = $t->getTemplateFile($file, $subDir);
 		} catch (Exception $e) {
-			echo "<pre><b>" . __FUNCTION__ . "</b>: " . $e->getMessage() . "</pre>";
-			exit();
+			DI::logger()->critical($e->getMessage(), ['file' => $file, 'subDir' => $subDir]);
+			throw new InternalServerErrorException(DI::l10n()->t('Friendica can\'t display this page at the moment, please contact the administrator or check the Friendica log for errors.'));
 		}
 
 		DI::profiler()->saveTimestamp($stamp1, "file", System::callstack());
@@ -122,6 +124,7 @@ class Renderer
 	 * Register template engine class
 	 *
 	 * @param string $class
+	 * @throws InternalServerErrorException
 	 */
 	public static function registerTemplateEngine($class)
 	{
@@ -131,8 +134,8 @@ class Renderer
 			$name = $v['name'];
 			self::$template_engines[$name] = $class;
 		} else {
-			echo "template engine <tt>$class</tt> cannot be registered without a name.\n";
-			die();
+			DI::logger()->critical(DI::l10n()->t('template engine cannot be registered without a name.'), ['class' => $class]);
+			throw new InternalServerErrorException(DI::l10n()->t('Friendica can\'t display this page at the moment, please contact the administrator or check the Friendica log for errors.'));
 		}
 	}
 
@@ -143,6 +146,7 @@ class Renderer
 	 * or default
 	 *
 	 * @return TemplateEngine Template Engine instance
+	 * @throws InternalServerErrorException
 	 */
 	public static function getTemplateEngine()
 	{
@@ -160,8 +164,8 @@ class Renderer
 			}
 		}
 
-		echo "template engine <tt>$template_engine</tt> is not registered!\n";
-		exit();
+		DI::logger()->critical(DI::l10n()->t('template engine is not registered!'), ['template_engine' => $template_engine]);
+		throw new InternalServerErrorException(DI::l10n()->t('Friendica can\'t display this page at the moment, please contact the administrator or check the Friendica log for errors.'));
 	}
 
 	/**

--- a/src/Core/Renderer.php
+++ b/src/Core/Renderer.php
@@ -73,7 +73,7 @@ class Renderer
 	 * @return string
 	 * @throws InternalServerErrorException
 	 */
-	public static function replaceMacros(string $template, array $vars)
+	public static function replaceMacros(string $template, array $vars = [])
 	{
 		$stamp1 = microtime(true);
 

--- a/src/Core/Renderer.php
+++ b/src/Core/Renderer.php
@@ -86,7 +86,10 @@ class Renderer
 			$output = $t->replaceMacros($template, $vars);
 		} catch (Exception $e) {
 			DI::logger()->critical($e->getMessage(), ['template' => $template, 'vars' => $vars]);
-			throw new InternalServerErrorException(DI::l10n()->t('Friendica can\'t display this page at the moment, please contact the administrator or check the Friendica log for errors.'));
+			$message = is_site_admin() ?
+				$e->getMessage() :
+				DI::l10n()->t('Friendica can\'t display this page at the moment, please contact the administrator.');
+			throw new InternalServerErrorException($message);
 		}
 
 		DI::profiler()->saveTimestamp($stamp1, "rendering", System::callstack());
@@ -112,7 +115,10 @@ class Renderer
 			$template = $t->getTemplateFile($file, $subDir);
 		} catch (Exception $e) {
 			DI::logger()->critical($e->getMessage(), ['file' => $file, 'subDir' => $subDir]);
-			throw new InternalServerErrorException(DI::l10n()->t('Friendica can\'t display this page at the moment, please contact the administrator or check the Friendica log for errors.'));
+			$message = is_site_admin() ?
+				$e->getMessage() :
+				DI::l10n()->t('Friendica can\'t display this page at the moment, please contact the administrator.');
+			throw new InternalServerErrorException($message);
 		}
 
 		DI::profiler()->saveTimestamp($stamp1, "file", System::callstack());
@@ -134,8 +140,12 @@ class Renderer
 			$name = $v['name'];
 			self::$template_engines[$name] = $class;
 		} else {
-			DI::logger()->critical(DI::l10n()->t('template engine cannot be registered without a name.'), ['class' => $class]);
-			throw new InternalServerErrorException(DI::l10n()->t('Friendica can\'t display this page at the moment, please contact the administrator or check the Friendica log for errors.'));
+			$admin_message = DI::l10n()->t('template engine cannot be registered without a name.');
+			DI::logger()->critical($admin_message, ['class' => $class]);
+			$message = is_site_admin() ?
+				$admin_message :
+				DI::l10n()->t('Friendica can\'t display this page at the moment, please contact the administrator.');
+			throw new InternalServerErrorException($message);
 		}
 	}
 
@@ -164,8 +174,12 @@ class Renderer
 			}
 		}
 
-		DI::logger()->critical(DI::l10n()->t('template engine is not registered!'), ['template_engine' => $template_engine]);
-		throw new InternalServerErrorException(DI::l10n()->t('Friendica can\'t display this page at the moment, please contact the administrator or check the Friendica log for errors.'));
+		$admin_message = DI::l10n()->t('template engine is not registered!');
+		DI::logger()->critical($admin_message, ['template_engine' => $template_engine]);
+		$message = is_site_admin() ?
+			$admin_message :
+			DI::l10n()->t('Friendica can\'t display this page at the moment, please contact the administrator.');
+		throw new InternalServerErrorException($message);
 	}
 
 	/**

--- a/src/Model/Tag.php
+++ b/src/Model/Tag.php
@@ -535,6 +535,6 @@ class Tag
 			}
 		}
 
-		return Strings::startsWith($tag, $tag_chars);
+		return Strings::startsWithChars($tag, $tag_chars);
 	}	
 }

--- a/src/Module/Admin/Summary.php
+++ b/src/Module/Admin/Summary.php
@@ -31,7 +31,9 @@ use Friendica\Database\DBStructure;
 use Friendica\DI;
 use Friendica\Model\Register;
 use Friendica\Module\BaseAdmin;
+use Friendica\Module\Update\Profile;
 use Friendica\Network\HTTPException\InternalServerErrorException;
+use Friendica\Render\FriendicaSmarty;
 use Friendica\Util\ConfigFileLoader;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Network;
@@ -46,6 +48,14 @@ class Summary extends BaseAdmin
 
 		// are there MyISAM tables in the DB? If so, trigger a warning message
 		$warningtext = [];
+
+		$templateEngine = Renderer::getTemplateEngine();
+		$errors = [];
+		$templateEngine->testInstall($errors);
+		foreach ($errors as $error) {
+			$warningtext[] = DI::l10n()->t('Template engine (%s) error: %s', $templateEngine::$name, $error);
+		}
+
 		if (DBA::count(['information_schema' => 'tables'], ['engine' => 'myisam', 'table_schema' => DBA::databaseName()])) {
 			$warningtext[] = DI::l10n()->t('Your DB still runs with MyISAM tables. You should change the engine type to InnoDB. As Friendica will use InnoDB only features in the future, you should change this! See <a href="%s">here</a> for a guide that may be helpful converting the table engines. You may also use the command <tt>php bin/console.php dbstructure toinnodb</tt> of your Friendica installation for an automatic conversion.<br />', 'https://dev.mysql.com/doc/refman/5.7/en/converting-tables-to-innodb.html');
 		}
@@ -136,7 +146,6 @@ class Summary extends BaseAdmin
 						throw new InternalServerErrorException('Stream is null.');
 					}
 				}
-
 			} catch (\Throwable $exception) {
 				$warningtext[] = DI::l10n()->t('The debug logfile \'%s\' is not usable. No logging possible (error: \'%s\')', $file, $exception->getMessage());
 			}

--- a/src/Render/FriendicaSmarty.php
+++ b/src/Render/FriendicaSmarty.php
@@ -21,7 +21,6 @@
 
 namespace Friendica\Render;
 
-use Friendica\DI;
 use Smarty;
 use Friendica\Core\Renderer;
 
@@ -34,26 +33,23 @@ class FriendicaSmarty extends Smarty
 
 	public $filename;
 
-	function __construct()
+	function __construct(string $theme, array $theme_info)
 	{
 		parent::__construct();
-
-		$a = DI::app();
-		$theme = $a->getCurrentTheme();
 
 		// setTemplateDir can be set to an array, which Smarty will parse in order.
 		// The order is thus very important here
 		$template_dirs = ['theme' => "view/theme/$theme/" . self::SMARTY3_TEMPLATE_FOLDER . "/"];
-		if (!empty($a->theme_info['extends'])) {
-			$template_dirs = $template_dirs + ['extends' => "view/theme/" . $a->theme_info["extends"] . "/" . self::SMARTY3_TEMPLATE_FOLDER . "/"];
+		if (!empty($theme_info['extends'])) {
+			$template_dirs = $template_dirs + ['extends' => "view/theme/" . $theme_info["extends"] . "/" . self::SMARTY3_TEMPLATE_FOLDER . "/"];
 		}
 
 		$template_dirs = $template_dirs + ['base' => "view/" . self::SMARTY3_TEMPLATE_FOLDER . "/"];
 		$this->setTemplateDir($template_dirs);
 
 		$this->setCompileDir('view/smarty3/compiled/');
-		$this->setConfigDir('view/smarty3/config/');
-		$this->setCacheDir('view/smarty3/cache/');
+		$this->setConfigDir('view/smarty3/');
+		$this->setCacheDir('view/smarty3/');
 
 		$this->left_delimiter = Renderer::getTemplateLeftDelimiter('smarty3');
 		$this->right_delimiter = Renderer::getTemplateRightDelimiter('smarty3');
@@ -63,13 +59,4 @@ class FriendicaSmarty extends Smarty
 		// Don't report errors so verbosely
 		$this->error_reporting = E_ALL & ~E_NOTICE;
 	}
-
-	function parsed($template = '')
-	{
-		if ($template) {
-			return $this->fetch('string:' . $template);
-		}
-		return $this->fetch('file:' . $this->filename);
-	}
-
 }

--- a/src/Render/FriendicaSmartyEngine.php
+++ b/src/Render/FriendicaSmartyEngine.php
@@ -49,8 +49,12 @@ final class FriendicaSmartyEngine extends TemplateEngine
 		$this->smarty = new FriendicaSmarty($this->theme, $this->theme_info);
 
 		if (!is_writable(DI::basePath() . '/view/smarty3')) {
-			DI::logger()->critical(DI::l10n()->t('The folder view/smarty3/ must be writable by webserver.'));
-			throw new InternalServerErrorException(DI::l10n()->t('Friendica can\'t display this page at the moment, please contact the administrator or check the Friendica log for errors.'));
+			$admin_message = DI::l10n()->t('The folder view/smarty3/ must be writable by webserver.');
+			DI::logger()->critical($admin_message);
+			$message = is_site_admin() ?
+				$admin_message :
+				DI::l10n()->t('Friendica can\'t display this page at the moment, please contact the administrator.');
+			throw new InternalServerErrorException($message);
 		}
 	}
 

--- a/src/Render/FriendicaSmartyEngine.php
+++ b/src/Render/FriendicaSmartyEngine.php
@@ -23,56 +23,69 @@ namespace Friendica\Render;
 
 use Friendica\Core\Hook;
 use Friendica\DI;
+use Friendica\Util\Strings;
 
 /**
- * Smarty implementation of the Friendica template engine interface
+ * Smarty implementation of the Friendica template abstraction
  */
-class FriendicaSmartyEngine implements ITemplateEngine
+final class FriendicaSmartyEngine extends TemplateEngine
 {
 	static $name = "smarty3";
 
-	public function __construct()
+	const FILE_PREFIX = 'file:';
+	const STRING_PREFIX = 'string:';
+
+	/** @var FriendicaSmarty */
+	private $smarty;
+
+	/**
+	 * @inheritDoc
+	 */
+	public function __construct(string $theme, array $theme_info)
 	{
-		if (!is_writable(__DIR__ . '/../../view/smarty3/')) {
+		$this->theme = $theme;
+		$this->theme_info = $theme_info;
+		$this->smarty = new FriendicaSmarty($this->theme, $this->theme_info);
+
+		if (!is_writable(DI::basePath() . '/view/smarty3')) {
 			echo "<b>ERROR:</b> folder <tt>view/smarty3/</tt> must be writable by webserver.";
 			exit();
 		}
 	}
 
-	// ITemplateEngine interface
-	public function replaceMacros($s, $r)
+	/**
+	 * @inheritDoc
+	 */
+	public function replaceMacros(string $template, array $vars)
 	{
-		$template = '';
-		if (gettype($s) === 'string') {
-			$template = $s;
-			$s = new FriendicaSmarty();
+		if (!Strings::startsWith($template, self::FILE_PREFIX)) {
+			$template = self::STRING_PREFIX . $template;
 		}
-
-		$r['$APP'] = DI::app();
 
 		// "middleware": inject variables into templates
 		$arr = [
-			"template" => basename($s->filename),
-			"vars" => $r
+			'template' => basename($this->smarty->filename),
+			'vars' => $vars
 		];
-		Hook::callAll("template_vars", $arr);
-		$r = $arr['vars'];
+		Hook::callAll('template_vars', $arr);
+		$vars = $arr['vars'];
 
-		foreach ($r as $key => $value) {
+		foreach ($vars as $key => $value) {
 			if ($key[0] === '$') {
 				$key = substr($key, 1);
 			}
 
-			$s->assign($key, $value);
+			$this->smarty->assign($key, $value);
 		}
-		return $s->parsed($template);
+
+		return $this->smarty->fetch($template);
 	}
 
-	public function getTemplateFile($file, $subDir = '')
+	/**
+	 * @inheritDoc
+	 */
+	public function getTemplateFile(string $file, string $subDir = '')
 	{
-		$a = DI::app();
-		$template = new FriendicaSmarty();
-
 		// Make sure $root ends with a slash /
 		if ($subDir !== '' && substr($subDir, -1, 1) !== '/') {
 			$subDir = $subDir . '/';
@@ -80,21 +93,20 @@ class FriendicaSmartyEngine implements ITemplateEngine
 
 		$root = DI::basePath() . '/' . $subDir;
 
-		$theme = $a->getCurrentTheme();
-		$filename = $template::SMARTY3_TEMPLATE_FOLDER . '/' . $file;
+		$filename = $this->smarty::SMARTY3_TEMPLATE_FOLDER . '/' . $file;
 
-		if (file_exists("{$root}view/theme/$theme/$filename")) {
-			$template_file = "{$root}view/theme/$theme/$filename";
-		} elseif (!empty($a->theme_info['extends']) && file_exists(sprintf('%sview/theme/%s}/%s', $root, $a->theme_info['extends'], $filename))) {
-			$template_file = sprintf('%sview/theme/%s}/%s', $root, $a->theme_info['extends'], $filename);
+		if (file_exists("{$root}view/theme/$this->theme/$filename")) {
+			$template_file = "{$root}view/theme/$this->theme/$filename";
+		} elseif (!empty($this->theme_info['extends']) && file_exists(sprintf('%sview/theme/%s}/%s', $root, $this->theme_info['extends'], $filename))) {
+			$template_file = sprintf('%sview/theme/%s}/%s', $root, $this->theme_info['extends'], $filename);
 		} elseif (file_exists("{$root}/$filename")) {
 			$template_file = "{$root}/$filename";
 		} else {
 			$template_file = "{$root}view/$filename";
 		}
 
-		$template->filename = $template_file;
+		$this->smarty->filename = $template_file;
 
-		return $template;
+		return self::FILE_PREFIX . $template_file;
 	}
 }

--- a/src/Render/FriendicaSmartyEngine.php
+++ b/src/Render/FriendicaSmartyEngine.php
@@ -56,6 +56,14 @@ final class FriendicaSmartyEngine extends TemplateEngine
 	/**
 	 * @inheritDoc
 	 */
+	public function testInstall(array &$errors = null)
+	{
+		$this->smarty->testInstall($errors);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
 	public function replaceMacros(string $template, array $vars)
 	{
 		if (!Strings::startsWith($template, self::FILE_PREFIX)) {

--- a/src/Render/FriendicaSmartyEngine.php
+++ b/src/Render/FriendicaSmartyEngine.php
@@ -23,6 +23,7 @@ namespace Friendica\Render;
 
 use Friendica\Core\Hook;
 use Friendica\DI;
+use Friendica\Network\HTTPException\InternalServerErrorException;
 use Friendica\Util\Strings;
 
 /**
@@ -48,8 +49,8 @@ final class FriendicaSmartyEngine extends TemplateEngine
 		$this->smarty = new FriendicaSmarty($this->theme, $this->theme_info);
 
 		if (!is_writable(DI::basePath() . '/view/smarty3')) {
-			echo "<b>ERROR:</b> folder <tt>view/smarty3/</tt> must be writable by webserver.";
-			exit();
+			DI::logger()->critical(DI::l10n()->t('The folder view/smarty3/ must be writable by webserver.'));
+			throw new InternalServerErrorException(DI::l10n()->t('Friendica can\'t display this page at the moment, please contact the administrator or check the Friendica log for errors.'));
 		}
 	}
 

--- a/src/Render/TemplateEngine.php
+++ b/src/Render/TemplateEngine.php
@@ -24,8 +24,37 @@ namespace Friendica\Render;
 /**
  * Interface for template engines
  */
-interface ITemplateEngine
+abstract class TemplateEngine
 {
-	public function replaceMacros($s, $v);
-	public function getTemplateFile($file, $subDir = '');
+	/** @var string */
+	static $name;
+
+	/** @var string */
+	protected $theme;
+	/** @var array */
+	protected $theme_info;
+
+	/**
+	 * @param string $theme      The current theme name
+	 * @param array  $theme_info The current theme info array
+	 */
+	abstract public function __construct(string $theme, array $theme_info);
+
+	/**
+	 * Returns the rendered template output from the template string and variables
+	 *
+	 * @param string $template
+	 * @param array  $vars
+	 * @return string
+	 */
+	abstract public function replaceMacros(string $template, array $vars);
+
+	/**
+	 * Returns the template string from a file path and an optional sub-directory from the project root
+	 *
+	 * @param string $file
+	 * @param string $subDir
+	 * @return mixed
+	 */
+	abstract public function getTemplateFile(string $file, string $subDir = '');
 }

--- a/src/Render/TemplateEngine.php
+++ b/src/Render/TemplateEngine.php
@@ -41,6 +41,14 @@ abstract class TemplateEngine
 	abstract public function __construct(string $theme, array $theme_info);
 
 	/**
+	 * Checks the template engine is correctly installed and configured and reports error messages in the provided
+	 * parameter or displays them directly if it's null.
+	 *
+	 * @param array|null $errors
+	 */
+	abstract public function testInstall(array &$errors = null);
+
+	/**
 	 * Returns the rendered template output from the template string and variables
 	 *
 	 * @param string $template

--- a/src/Util/Strings.php
+++ b/src/Util/Strings.php
@@ -369,9 +369,23 @@ class Strings
 	 * @param array	 $chars
 	 * @return bool
 	 */
-	public static function startsWith($string, array $chars)
+	public static function startsWithChars($string, array $chars)
 	{
 		$return = in_array(substr(trim($string), 0, 1), $chars);
+
+		return $return;
+	}
+
+	/**
+	 * Check if the first string starts with the second
+	 *
+	 * @param string $string
+	 * @param string $start
+	 * @return bool
+	 */
+	public static function startsWith(string $string, string $start)
+	{
+		$return = substr_compare($string, $start, 0, strlen($start)) === 0;
 
 		return $return;
 	}

--- a/tests/Util/AppMockTrait.php
+++ b/tests/Util/AppMockTrait.php
@@ -108,7 +108,7 @@ trait AppMockTrait
 			->andReturn($this->configMock);
 		$this->app
 			->shouldReceive('getTemplateEngine')
-			->andReturn(new FriendicaSmartyEngine());
+			->andReturn(new FriendicaSmartyEngine('frio', []));
 		$this->app
 			->shouldReceive('getCurrentTheme')
 			->andReturn('Smarty3');


### PR DESCRIPTION
Part of #8653

Template engine exceptions are now properly handled. I couldn't help but refactor the whole template engine situation. Renderer methods now have simpler return/parameter types.