### PR TITLE
Fix wrong variable name in Model\Attach

### DIFF
--- a/src/Model/Attach.php
+++ b/src/Model/Attach.php
@@ -159,7 +159,7 @@ class Attach
 	 */
 	public static function getData($item)
 	{
-		$backendClass = DI::storageManager()->getByName($photo['backend-class'] ?? '');
+		$backendClass = DI::storageManager()->getByName($item['backend-class'] ?? '');
 		if ($backendClass === null) {
 			// legacy data storage in 'data' column
 			$i = self::selectFirst(['data'], ['id' => $item['id']]);


### PR DESCRIPTION
Fixes #8626 

- Prevented attachment data from being retrieved from storage