### PR TITLE
Issue 8675: reduce requests of foreign pages

### DIFF
--- a/src/Model/APContact.php
+++ b/src/Model/APContact.php
@@ -276,15 +276,17 @@ class APContact
 			}
 		}
 
-		$parts = parse_url($apcontact['url']);
-		unset($parts['path']);
-		$baseurl = Network::unparseURL($parts);
+		if (empty($fetched_contact['baseurl']) || $update) {
+			$parts = parse_url($apcontact['url']);
+			unset($parts['path']);
+			$baseurl = Network::unparseURL($parts);
 
-		// Check if the address is resolvable or the profile url is identical with the base url of the system
-		if (self::addrToUrl($apcontact['addr'], $apcontact['url']) || Strings::compareLink($apcontact['url'], $baseurl)) {
-			$apcontact['baseurl'] = $baseurl;
-		} else {
-			$apcontact['addr'] = null;
+			// Check if the address is resolvable or the profile url is identical with the base url of the system
+			if (self::addrToUrl($apcontact['addr'], $apcontact['url']) || Strings::compareLink($apcontact['url'], $baseurl)) {
+				$apcontact['baseurl'] = $baseurl;
+			} else {
+				$apcontact['addr'] = null;
+			}
 		}
 
 		if (empty($apcontact['baseurl'])) {
@@ -312,7 +314,7 @@ class APContact
 			DBA::delete('apcontact', ['url' => $url]);
 		}
 
-		Logger::log('Updated profile for ' . $url, Logger::DEBUG);
+		Logger::info('Updated profile', ['url' => $url]);
 
 		return $apcontact;
 	}

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -2085,7 +2085,7 @@ class Contact
 		// These fields aren't updated by this routine:
 		// 'xmpp', 'sensitive'
 
-		$fields = ['uid', 'avatar', 'name', 'nick', 'location', 'keywords', 'about',
+		$fields = ['uid', 'avatar', 'name', 'nick', 'location', 'keywords', 'about', 'subscribe',
 			'unsearchable', 'url', 'addr', 'batch', 'notify', 'poll', 'request', 'confirm', 'poco',
 			'network', 'alias', 'baseurl', 'gsid', 'forum', 'prv', 'contact-type', 'pubkey'];
 		$contact = DBA::selectFirst('contact', $fields, ['id' => $id]);

--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -27,7 +27,6 @@ use Friendica\Content\Widget\ContactBlock;
 use Friendica\Core\Cache\Duration;
 use Friendica\Core\Hook;
 use Friendica\Core\Logger;
-use Friendica\Network\Probe;
 use Friendica\Core\Protocol;
 use Friendica\Core\Renderer;
 use Friendica\Core\Session;
@@ -772,7 +771,7 @@ class Profile
 		$_SESSION['visitor_handle'] = $visitor['addr'];
 		$_SESSION['visitor_home'] = $visitor['url'];
 		$_SESSION['my_url'] = $visitor['url'];
-		$_SESSION['remote_comment'] = Probe::getRemoteFollowLink($visitor['url']);
+		$_SESSION['remote_comment'] = $visitor['subscribe'];
 
 		Session::setVisitorsContacts();
 

--- a/src/Module/RemoteFollow.php
+++ b/src/Module/RemoteFollow.php
@@ -67,17 +67,14 @@ class RemoteFollow extends BaseModule
 			return;
 		}
 
-		// Fetch link for the "remote follow" functionality of the given profile
-		$follow_link_template = Probe::getRemoteFollowLink($url);
-
-		if (empty($follow_link_template)) {
+		if (empty($data['subscribe'])) {
 			notice(DI::l10n()->t("Remote subscription can't be done for your network. Please subscribe directly on your system."));
 			return;
 		}
 
-		Logger::notice('Remote request', ['url' => $url, 'follow' => $a->profile['url'], 'remote' => $follow_link_template]);
+		Logger::notice('Remote request', ['url' => $url, 'follow' => $a->profile['url'], 'remote' => $data['subscribe']]);
 		
-		// Substitute our user's feed URL into $follow_link_template
+		// Substitute our user's feed URL into $data['subscribe']
 		// Send the subscriber home to subscribe
 		// Diaspora needs the uri in the format user@domain.tld
 		if ($data['network'] == Protocol::DIASPORA) {
@@ -86,7 +83,7 @@ class RemoteFollow extends BaseModule
 			$uri = urlencode($a->profile['url']);
 		}
 	
-		$follow_link = str_replace('{uri}', $uri, $follow_link_template);
+		$follow_link = str_replace('{uri}', $uri, $data['subscribe']);
 		System::externalRedirect($follow_link);
 	}
 

--- a/src/Network/CurlResult.php
+++ b/src/Network/CurlResult.php
@@ -22,6 +22,7 @@
 namespace Friendica\Network;
 
 use Friendica\Core\Logger;
+use Friendica\Core\System;
 use Friendica\Network\HTTPException\InternalServerErrorException;
 use Friendica\Util\Network;
 
@@ -166,7 +167,7 @@ class CurlResult
 		}
 
 		if (!$this->isSuccess) {
-			Logger::log('error: ' . $this->url . ': ' . $this->returnCode . ' - ' . $this->error, Logger::INFO);
+			Logger::error('error', ['url' => $this->url, 'code' => $this->returnCode, 'error'  => $this->error, 'callstack' => System::callstack(20)]);
 			Logger::log('debug: ' . print_r($this->info, true), Logger::DATA);
 		}
 

--- a/src/Network/CurlResult.php
+++ b/src/Network/CurlResult.php
@@ -168,7 +168,7 @@ class CurlResult
 
 		if (!$this->isSuccess) {
 			Logger::error('error', ['url' => $this->url, 'code' => $this->returnCode, 'error'  => $this->error, 'callstack' => System::callstack(20)]);
-			Logger::log('debug: ' . print_r($this->info, true), Logger::DATA);
+			Logger::debug('debug', ['info' => $this->info]);
 		}
 
 		if (!$this->isSuccess && $this->errorNumber == CURLE_OPERATION_TIMEDOUT) {

--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -54,7 +54,7 @@
 use Friendica\Database\DBA;
 
 if (!defined('DB_UPDATE_VERSION')) {
-	define('DB_UPDATE_VERSION', 1351);
+	define('DB_UPDATE_VERSION', 1352);
 }
 
 return [
@@ -141,6 +141,7 @@ return [
 			"notify" => ["type" => "varchar(255)", "comment" => ""],
 			"poll" => ["type" => "varchar(255)", "comment" => ""],
 			"confirm" => ["type" => "varchar(255)", "comment" => ""],
+			"subscribe" => ["type" => "varchar(255)", "comment" => ""],
 			"poco" => ["type" => "varchar(255)", "comment" => ""],
 			"aes_allow" => ["type" => "boolean", "not null" => "1", "default" => "0", "comment" => ""],
 			"ret-aes" => ["type" => "boolean", "not null" => "1", "default" => "0", "comment" => ""],


### PR DESCRIPTION
This fixes https://github.com/friendica/friendica/issues/8675

We had fetched the remote side every time for their "subscribe" link instead of storing it at the time we probed that contact.

We now store this value.

Somewhere in the future we should get rid of the `Probe::lrdd` function completely and should store everything in the contact table