### PR TITLE
Let "subscribe" be filled at every time to avoid a notice

### DIFF
--- a/src/Network/Probe.php
+++ b/src/Network/Probe.php
@@ -389,11 +389,7 @@ class Probe
 
 		self::$istimeout = false;
 
-		if ($network != Protocol::ACTIVITYPUB) {
-			$data = self::detect($uri, $network, $uid);
-		} else {
-			$data = null;
-		}
+		$data = self::detect($uri, $network, $uid);
 
 		// When the previous detection process had got a time out
 		// we could falsely detect a Friendica profile as AP profile.


### PR DESCRIPTION
See https://github.com/friendica/friendica/issues/8475#issuecomment-637669645

We have to ensure that the "subscribe" field is filled at any time.