### PR TITLE
Move share content conversion before link handling in Text\BBCode::convert

### DIFF
--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -1765,6 +1765,15 @@ class BBCode
 				$text);
 		}
 
+		// Shared content conversion
+		// Notice: may create [bookmark] tags so this must be ran before the link handling
+		$text = self::convertShare(
+			$text,
+			function (array $attributes, array $author_contact, $content, $is_quote_share) use ($simple_html) {
+				return self::convertShareCallback($attributes, $author_contact, $content, $is_quote_share, $simple_html);
+			}
+		);
+
 		// Bookmarks in red - will be converted to bookmarks in friendica
 		$text = preg_replace("/#\^\[url\](.*?)\[\/url\]/ism", '[bookmark=$1]$1[/bookmark]', $text);
 		$text = preg_replace("/#\^\[url\=(.*?)\](.*?)\[\/url\]/ism", '[bookmark=$1]$2[/bookmark]', $text);
@@ -1882,14 +1891,6 @@ class BBCode
 
 		$regex = '#<([^>]*?)(href)="(?!' . implode('|', $allowed_link_protocols) . ')(.*?)"(.*?)>#ism';
 		$text = preg_replace($regex, '<$1$2="javascript:void(0)"$4 data-original-href="$3" class="invalid-href" title="' . DI::l10n()->t('Invalid link protocol') . '">', $text);
-
-		// Shared content
-		$text = self::convertShare(
-			$text,
-			function (array $attributes, array $author_contact, $content, $is_quote_share) use ($simple_html) {
-				return self::convertShareCallback($attributes, $author_contact, $content, $is_quote_share, $simple_html);
-			}
-		);
 
 		if ($saved_image) {
 			$text = self::interpolateSavedImagesIntoItemBody($text, $saved_image);

--- a/tests/src/Content/Text/BBCodeTest.php
+++ b/tests/src/Content/Text/BBCodeTest.php
@@ -236,7 +236,7 @@ class BBCodeTest extends MockedTest
 			'bug-7808-code-amp' => [
 				'expectedHtml' => '<code>&amp;</code>',
 				'text' => '[code]&[/code]',
-			]
+			],
 		];
 	}
 


### PR DESCRIPTION
Should fix #8722, didn't test on a production environment yet, but the `[bookmark]` tag were correctly processed after these changes.