### PR TITLE
[ActivityPub] Add support for more attachments structures

### DIFF
--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -96,7 +96,15 @@ class Processor
 		foreach ($activity['attachments'] as $attach) {
 			switch ($attach['type']) {
 				case 'link':
-					$item['body'] .= "\n[attachment type='link' url='" . $attach['url'] . "' title='" . ($attach['title'] ?? '') . "' image='" . ($attach['image'] ?? '') . "']" . ($attach['desc'] ?? '') . '[/attachment]';
+					// Only one [attachment] tag is allowed
+					$existingAttachmentPos = strpos($item['body'], '[attachment');
+					if ($existingAttachmentPos !== false) {
+						$linkTitle = $attach['title'] ?: $attach['url'];
+						// Additional link attachments are prepended before the existing [attachment] tag
+						$item['body'] = substr_replace($item['body'], "\n[bookmark=" . $attach['url'] . ']' . $linkTitle . "[/bookmark]\n", $existingAttachmentPos, 0);
+					} else {
+						$item['body'] .= "\n[attachment type='link' url='" . $attach['url'] . "' title='" . ($attach['title'] ?? '') . "' image='" . ($attach['image'] ?? '') . "']" . ($attach['desc'] ?? '') . '[/attachment]';
+					}
 					break;
 				default:
 					$filetype = strtolower(substr($attach['mediaType'], 0, strpos($attach['mediaType'], '/')));

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -94,39 +94,43 @@ class Processor
 		}
 
 		foreach ($activity['attachments'] as $attach) {
-			$filetype = strtolower(substr($attach['mediaType'], 0, strpos($attach['mediaType'], '/')));
-			if ($filetype == 'image') {
-				if (!empty($activity['source']) && strpos($activity['source'], $attach['url'])) {
-					continue;
-				}
+			switch ($attach['type']) {
+				case 'link':
+					$item['body'] .= "\n[attachment type='link' url='" . $attach['url'] . "' title='" . ($attach['title'] ?? '') . "' image='" . ($attach['image'] ?? '') . "']" . ($attach['desc'] ?? '') . '[/attachment]';
+					break;
+				default:
+					$filetype = strtolower(substr($attach['mediaType'], 0, strpos($attach['mediaType'], '/')));
+					if ($filetype == 'image') {
+						if (!empty($activity['source']) && strpos($activity['source'], $attach['url'])) {
+							continue;
+						}
 
-				if (empty($attach['name'])) {
-					$item['body'] .= "\n[img]" . $attach['url'] . '[/img]';
-				} else {
-					$item['body'] .= "\n[img=" . $attach['url'] . ']' . $attach['name'] . '[/img]';
-				}
-			} elseif ($filetype == 'audio') {
-				if (!empty($activity['source']) && strpos($activity['source'], $attach['url'])) {
-					continue;
-				}
+						if (empty($attach['name'])) {
+							$item['body'] .= "\n[img]" . $attach['url'] . '[/img]';
+						} else {
+							$item['body'] .= "\n[img=" . $attach['url'] . ']' . $attach['name'] . '[/img]';
+						}
+					} elseif ($filetype == 'audio') {
+						if (!empty($activity['source']) && strpos($activity['source'], $attach['url'])) {
+							continue;
+						}
 
-				$item['body'] .= "\n[audio]" . $attach['url'] . '[/audio]';
-			} elseif ($filetype == 'video') {
-				if (!empty($activity['source']) && strpos($activity['source'], $attach['url'])) {
-					continue;
-				}
+						$item['body'] .= "\n[audio]" . $attach['url'] . '[/audio]';
+					} elseif ($filetype == 'video') {
+						if (!empty($activity['source']) && strpos($activity['source'], $attach['url'])) {
+							continue;
+						}
 
-				$item['body'] .= "\n[video]" . $attach['url'] . '[/video]';
-			} else {
-				if (!empty($item["attach"])) {
-					$item["attach"] .= ',';
-				} else {
-					$item["attach"] = '';
-				}
-				if (!isset($attach['length'])) {
-					$attach['length'] = "0";
-				}
-				$item["attach"] .= '[attach]href="'.$attach['url'].'" length="'.$attach['length'].'" type="'.$attach['mediaType'].'" title="'.($attach['name'] ?? '') .'"[/attach]';
+						$item['body'] .= "\n[video]" . $attach['url'] . '[/video]';
+					} else {
+						if (!empty($item["attach"])) {
+							$item["attach"] .= ',';
+						} else {
+							$item["attach"] = '';
+						}
+
+						$item["attach"] .= '[attach]href="' . $attach['url'] . '" length="' . ($attach['length'] ?? '0') . '" type="' . $attach['mediaType'] . '" title="' . ($attach['name'] ?? '') . '"[/attach]';
+					}
 			}
 		}
 

--- a/src/Protocol/ActivityPub/Receiver.php
+++ b/src/Protocol/ActivityPub/Receiver.php
@@ -821,13 +821,9 @@ class Receiver
 	 *
 	 * @return array with tags in a simplified format
 	 */
-	private static function processTags($tags)
+	private static function processTags(array $tags)
 	{
 		$taglist = [];
-
-		if (empty($tags)) {
-			return [];
-		}
 
 		foreach ($tags as $tag) {
 			if (empty($tag)) {
@@ -854,16 +850,12 @@ class Receiver
 	/**
 	 * Convert emojis from JSON-LD format into a simplified format
 	 *
-	 * @param $emojis
+	 * @param array $emojis
 	 * @return array with emojis in a simplified format
 	 */
-	private static function processEmojis($emojis)
+	private static function processEmojis(array $emojis)
 	{
 		$emojilist = [];
-
-		if (empty($emojis)) {
-			return [];
-		}
 
 		foreach ($emojis as $emoji) {
 			if (empty($emoji) || (JsonLD::fetchElement($emoji, '@type') != 'toot:Emoji') || empty($emoji['as:icon'])) {
@@ -876,6 +868,7 @@ class Receiver
 
 			$emojilist[] = $element;
 		}
+
 		return $emojilist;
 	}
 
@@ -886,24 +879,62 @@ class Receiver
 	 *
 	 * @return array with attachmants in a simplified format
 	 */
-	private static function processAttachments($attachments)
+	private static function processAttachments(array $attachments)
 	{
 		$attachlist = [];
 
-		if (empty($attachments)) {
-			return [];
-		}
+		// Removes empty values
+		$attachments = array_filter($attachments);
 
 		foreach ($attachments as $attachment) {
-			if (empty($attachment)) {
-				continue;
-			}
+			switch (JsonLD::fetchElement($attachment, '@type')) {
+				case 'as:Page':
+					$pageUrl = null;
+					$pageImage = null;
 
-			$attachlist[] = ['type' => str_replace('as:', '', JsonLD::fetchElement($attachment, '@type')),
-				'mediaType' => JsonLD::fetchElement($attachment, 'as:mediaType', '@value'),
-				'name' => JsonLD::fetchElement($attachment, 'as:name', '@value'),
-				'url' => JsonLD::fetchElement($attachment, 'as:url', '@id')];
+					$urls = JsonLD::fetchElementArray($attachment, 'as:url');
+					foreach ($urls as $url) {
+						// Single scalar URL case
+						if (is_string($url)) {
+							$pageUrl = $url;
+							continue;
+						}
+
+						$href = JsonLD::fetchElement($url, 'as:href', '@id');
+						$mediaType = JsonLD::fetchElement($url, 'as:mediaType', '@value');
+						if (Strings::startsWith($mediaType, 'image')) {
+							$pageImage = $href;
+						} else {
+							$pageUrl = $href;
+						}
+					}
+
+					$attachlist[] = [
+						'type'  => 'link',
+						'title' => JsonLD::fetchElement($attachment, 'as:name', '@value'),
+						'desc'  => JsonLD::fetchElement($attachment, 'as:summary', '@value'),
+						'url'   => $pageUrl,
+						'image' => $pageImage,
+					];
+					break;
+				case 'as:Link':
+					$attachlist[] = [
+						'type' => str_replace('as:', '', JsonLD::fetchElement($attachment, '@type')),
+						'mediaType' => JsonLD::fetchElement($attachment, 'as:mediaType', '@value'),
+						'name' => JsonLD::fetchElement($attachment, 'as:name', '@value'),
+						'url' => JsonLD::fetchElement($attachment, 'as:href', '@id')
+					];
+					break;
+				default:
+					$attachlist[] = [
+						'type' => str_replace('as:', '', JsonLD::fetchElement($attachment, '@type')),
+						'mediaType' => JsonLD::fetchElement($attachment, 'as:mediaType', '@value'),
+						'name' => JsonLD::fetchElement($attachment, 'as:name', '@value'),
+						'url' => JsonLD::fetchElement($attachment, 'as:url', '@id')
+					];
+			}
 		}
+
 		return $attachlist;
 	}
 
@@ -1086,9 +1117,9 @@ class Receiver
 		$object_data['latitude'] = JsonLD::fetchElement($object_data, 'latitude', '@value');
 		$object_data['longitude'] = JsonLD::fetchElement($object, 'as:location', 'as:longitude', '@type', 'as:Place');
 		$object_data['longitude'] = JsonLD::fetchElement($object_data, 'longitude', '@value');
-		$object_data['attachments'] = self::processAttachments(JsonLD::fetchElementArray($object, 'as:attachment'));
-		$object_data['tags'] = self::processTags(JsonLD::fetchElementArray($object, 'as:tag'));
-		$object_data['emojis'] = self::processEmojis(JsonLD::fetchElementArray($object, 'as:tag', 'toot:Emoji'));
+		$object_data['attachments'] = self::processAttachments(JsonLD::fetchElementArray($object, 'as:attachment') ?? []);
+		$object_data['tags'] = self::processTags(JsonLD::fetchElementArray($object, 'as:tag') ?? []);
+		$object_data['emojis'] = self::processEmojis(JsonLD::fetchElementArray($object, 'as:tag', 'toot:Emoji') ?? []);
 		$object_data['generator'] = JsonLD::fetchElement($object, 'as:generator', 'as:name', '@type', 'as:Application');
 		$object_data['generator'] = JsonLD::fetchElement($object_data, 'generator', '@value');
 		$object_data['alternate-url'] = JsonLD::fetchElement($object, 'as:url', '@id');

--- a/src/Util/JsonLD.php
+++ b/src/Util/JsonLD.php
@@ -175,10 +175,6 @@ class JsonLD
 	 */
 	public static function fetchElementArray($array, $element, $key = null)
 	{
-		if (empty($array)) {
-			return null;
-		}
-
 		if (!isset($array[$element])) {
 			return null;
 		}


### PR DESCRIPTION
Part of #8676 

The only risky change I kept for my development is the change to the default value of the `$key` parameter of `JsonLD::getElementArray` but I've checked all the references to it and either they were setting the parameter or they should benefit from the change.

The problem was that it would only retrieve the `id` value of the searched elements by default, while the functions the result was fed to were expecting full structures.

Otherwise it just adds more mapping from AP attachments to local attachments syntax.