### PR TITLE
Use webfinger in apcontact fetch

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -1,6 +1,6 @@
 -- ------------------------------------------
 -- Friendica 2020.06-dev (Red Hot Poker)
--- DB_UPDATE_VERSION 1351
+-- DB_UPDATE_VERSION 1353
 -- ------------------------------------------
 
 
@@ -85,6 +85,7 @@ CREATE TABLE IF NOT EXISTS `contact` (
 	`notify` varchar(255) COMMENT '',
 	`poll` varchar(255) COMMENT '',
 	`confirm` varchar(255) COMMENT '',
+	`subscribe` varchar(255) COMMENT '',
 	`poco` varchar(255) COMMENT '',
 	`aes_allow` boolean NOT NULL DEFAULT '0' COMMENT '',
 	`ret-aes` boolean NOT NULL DEFAULT '0' COMMENT '',
@@ -240,6 +241,7 @@ CREATE TABLE IF NOT EXISTS `apcontact` (
 	`addr` varchar(255) COMMENT '',
 	`alias` varchar(255) COMMENT '',
 	`pubkey` text COMMENT '',
+	`subscribe` varchar(255) COMMENT '',
 	`baseurl` varchar(255) COMMENT 'baseurl of the ap contact',
 	`gsid` int unsigned COMMENT 'Global Server ID',
 	`generator` varchar(255) COMMENT 'Name of the contact\'s system',

--- a/src/Model/APContact.php
+++ b/src/Model/APContact.php
@@ -295,6 +295,8 @@ class APContact
 				if (!empty($data['subscribe'])) {
 					$apcontact['subscribe'] = $data['subscribe'];
 				}
+			} else {
+				$apcontact['addr'] = null;
 			}
 		}
 

--- a/src/Network/Probe.php
+++ b/src/Network/Probe.php
@@ -389,7 +389,11 @@ class Probe
 
 		self::$istimeout = false;
 
-		$data = self::detect($uri, $network, $uid);
+		if ($network != Protocol::ACTIVITYPUB) {
+			$data = self::detect($uri, $network, $uid);
+		} else {
+			$data = null;
+		}
 
 		// When the previous detection process had got a time out
 		// we could falsely detect a Friendica profile as AP profile.
@@ -397,9 +401,7 @@ class Probe
 			$ap_profile = ActivityPub::probeProfile($uri);
 
 			if (empty($data) || (!empty($ap_profile) && empty($network) && (($data['network'] ?? '') != Protocol::DFRN))) {
-				$subscribe = $data['subscribe'] ?? '';
 				$data = $ap_profile;
-				$data['subscribe'] = $subscribe;
 			} elseif (!empty($ap_profile)) {
 				$ap_profile['batch'] = '';
 				$data = array_merge($ap_profile, $data);
@@ -921,7 +923,7 @@ class Probe
 	 * @return array webfinger data
 	 * @throws HTTPException\InternalServerErrorException
 	 */
-	private static function webfinger($url, $type)
+	public static function webfinger($url, $type)
 	{
 		$xrd_timeout = DI::config()->get('system', 'xrd_timeout', 20);
 

--- a/src/Protocol/ActivityPub.php
+++ b/src/Protocol/ActivityPub.php
@@ -170,6 +170,7 @@ class ActivityPub
 		$profile['notify'] = $apcontact['inbox'];
 		$profile['poll'] = $apcontact['outbox'];
 		$profile['pubkey'] = $apcontact['pubkey'];
+		$profile['subscribe'] = $apcontact['subscribe'];
 		$profile['baseurl'] = $apcontact['baseurl'];
 		$profile['gsid'] = $apcontact['gsid'];
 

--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -54,7 +54,7 @@
 use Friendica\Database\DBA;
 
 if (!defined('DB_UPDATE_VERSION')) {
-	define('DB_UPDATE_VERSION', 1352);
+	define('DB_UPDATE_VERSION', 1353);
 }
 
 return [
@@ -304,6 +304,7 @@ return [
 			"addr" => ["type" => "varchar(255)", "comment" => ""],
 			"alias" => ["type" => "varchar(255)", "comment" => ""],
 			"pubkey" => ["type" => "text", "comment" => ""],
+			"subscribe" => ["type" => "varchar(255)", "comment" => ""],
 			"baseurl" => ["type" => "varchar(255)", "comment" => "baseurl of the ap contact"],
 			"gsid" => ["type" => "int unsigned", "foreign" => ["gserver" => "id", "on delete" => "restrict"], "comment" => "Global Server ID"],
 			"generator" => ["type" => "varchar(255)", "comment" => "Name of the contact's system"],


### PR DESCRIPTION
There is some data that can be fetched via webfinger. We already worked with webfinger there, but we now fetch some more data.

Additionally this restores the functionality to not do intensive probing when the probing is done only for ActivityPub.