### PR TITLE
Add probe_detect hook

### DIFF
--- a/doc/Addons.md
+++ b/doc/Addons.md
@@ -466,6 +466,19 @@ Hook data is a `\FastRoute\RouterCollector` object that should be used to add ad
 
 **Notice**: The class whose name is provided in the route handler must be reachable via auto-loader.
 
+### probe_detect
+
+Called before trying to detect the target network of a URL.
+If any registered hook function sets the `result` key of the hook data array, it will be returned immediately.
+Hook functions should also return immediately if the hook data contains an existing result. 
+
+Hook data:
+
+- **uri** (input): the profile URI.
+- **network** (input): the target network (can be empty for auto-detection).
+- **uid** (input): the user to return the contact data for (can be empty for public contacts).
+- **result** (output): Set by the hook function to indicate a successful detection.
+
 ## Complete list of hook callbacks
 
 Here is a complete list of all hook callbacks with file locations (as of 24-Sep-2018). Please see the source for details of any hooks not documented above.

--- a/src/Network/Probe.php
+++ b/src/Network/Probe.php
@@ -1745,39 +1745,6 @@ class Probe
 		$data['network'] = Protocol::TWITTER;
 		$data['baseurl'] = 'https://twitter.com';
 
-		$curlResult = Network::curl($data['url'], false);
-		if (!$curlResult->isSuccess()) {
-			return [];
-		}
-
-		$body = $curlResult->getBody();
-		$doc = new DOMDocument();
-		@$doc->loadHTML($body);
-		$xpath = new DOMXPath($doc);
-
-		$list = $xpath->query('//img[@class]');
-		foreach ($list as $node) {
-			$img_attr = [];
-			if ($node->attributes->length) {
-				foreach ($node->attributes as $attribute) {
-					$img_attr[$attribute->name] = $attribute->value;
-				}
-			}
-
-			if (empty($img_attr['class'])) {
-				continue;
-			}
-
-			if (strpos($img_attr['class'], 'ProfileAvatar-image') !== false) {
-				if (!empty($img_attr['src'])) {
-					$data['photo'] = $img_attr['src'];
-				}
-				if (!empty($img_attr['alt'])) {
-					$data['name'] = $img_attr['alt'];
-				}
-			}
-		}
-
 		return $data;
 	}
 

--- a/src/Network/Probe.php
+++ b/src/Network/Probe.php
@@ -24,6 +24,7 @@ namespace Friendica\Network;
 use DOMDocument;
 use DomXPath;
 use Friendica\Core\Cache\Duration;
+use Friendica\Core\Hook;
 use Friendica\Core\Logger;
 use Friendica\Core\Protocol;
 use Friendica\Core\System;
@@ -616,6 +617,19 @@ class Probe
 	private static function detect($uri, $network, $uid)
 	{
 		$parts = parse_url($uri);
+
+		$hookData = [
+			'uri'     => $uri,
+			'network' => $network,
+			'uid'     => $uid,
+			'result'  => [],
+		];
+
+		Hook::callAll('probe_detect', $hookData);
+
+		if ($hookData['result']) {
+			return $hookData['result'];
+		}
 
 		if (!empty($parts["scheme"]) && !empty($parts["host"])) {
 			$host = $parts["host"];


### PR DESCRIPTION
While [improving the share blocks display](https://github.com/friendica/friendica/pull/8740), I found out that the way we probed Twitter profile URL has been rendered obsolete by the React Native frontend Twitter uses, leaving no usable informations in the HTML page we retrieve with curl.

So I set out to fix this by adding a hook that the Twitter addon can use to perform a profile lookup through the API.