### PR TITLE
Avoid unneeded database calls when showing posts of contacts

### DIFF
--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -1761,7 +1761,6 @@ class Contact
 	 * Returns posts from a given contact url
 	 *
 	 * @param string $contact_url Contact URL
-	 *
 	 * @param bool   $thread_mode
 	 * @param int    $update
 	 * @return string posts in HTML
@@ -1769,9 +1768,21 @@ class Contact
 	 */
 	public static function getPostsFromUrl($contact_url, $thread_mode = false, $update = 0)
 	{
-		$a = DI::app();
+		return self::getPostsFromId(self::getIdForURL($contact_url), $thread_mode, $update);
+	}
 
-		$cid = self::getIdForURL($contact_url);
+	/**
+	 * Returns posts from a given contact id
+	 *
+	 * @param integer $cid
+	 * @param bool    $thread_mode
+	 * @param integer $update
+	 * @return string posts in HTML
+	 * @throws \Exception
+	 */
+	public static function getPostsFromId($cid, $thread_mode = false, $update = 0)
+	{
+		$a = DI::app();
 
 		$contact = DBA::selectFirst('contact', ['contact-type', 'network'], ['id' => $cid]);
 		if (!DBA::isResult($contact)) {

--- a/src/Module/Contact.php
+++ b/src/Module/Contact.php
@@ -976,7 +976,12 @@ class Contact extends BaseModule
 			$profiledata = Model\Contact::getDetailsByURL($contact['url']);
 
 			Model\Profile::load($a, '', $profiledata, true);
-			$o .= Model\Contact::getPostsFromUrl($contact['url'], true, $update);
+
+			if ($contact['uid'] == 0) {
+				$o .= Model\Contact::getPostsFromId($contact['id'], true, $update);
+			} else {
+				$o .= Model\Contact::getPostsFromUrl($contact['url'], true, $update);
+			}
 		}
 
 		return $o;
@@ -998,7 +1003,12 @@ class Contact extends BaseModule
 			}
 
 			Model\Profile::load($a, '', $profiledata, true);
-			$o .= Model\Contact::getPostsFromUrl($contact['url']);
+
+			if ($contact['uid'] == 0) {
+				$o .= Model\Contact::getPostsFromId($contact['id']);
+			} else {
+				$o .= Model\Contact::getPostsFromUrl($contact['url']);
+			}
 		}
 
 		return $o;


### PR DESCRIPTION
It doesn't make sense to fetch the URL of a contact that we know the id of, to pass that URL and to fetch the id from it.

So we now use the id if possible.