### PR TITLE
Remove dependency to App in Contact::createFromProbe

### DIFF
--- a/mod/follow.php
+++ b/mod/follow.php
@@ -40,7 +40,6 @@ function follow_post(App $a)
 		DI::baseUrl()->redirect('contact');
 	}
 
-	$uid = local_user();
 	$url = Probe::cleanURI($_REQUEST['url']);
 	$return_path = 'follow?url=' . urlencode($url);
 
@@ -48,7 +47,7 @@ function follow_post(App $a)
 	// This is just a precaution if maybe this page is called somewhere directly via POST
 	$_SESSION['fastlane'] = $url;
 
-	$result = Contact::createFromProbe($uid, $url, true);
+	$result = Contact::createFromProbe($a->user, $url, true);
 
 	if ($result['success'] == false) {
 		// Possibly it is a remote item and not an account

--- a/mod/ostatus_subscribe.php
+++ b/mod/ostatus_subscribe.php
@@ -91,7 +91,7 @@ function ostatus_subscribe_content(App $a)
 
 	$probed = Probe::uri($url);
 	if ($probed['network'] == Protocol::OSTATUS) {
-		$result = Contact::createFromProbe($uid, $url, true, Protocol::OSTATUS);
+		$result = Contact::createFromProbe($a->user, $url, true, Protocol::OSTATUS);
 		if ($result['success']) {
 			$o .= ' - ' . DI::l10n()->t('success');
 		} else {

--- a/mod/repair_ostatus.php
+++ b/mod/repair_ostatus.php
@@ -70,7 +70,7 @@ function repair_ostatus_content(App $a) {
 
 	$o .= "<p>".DI::l10n()->t("Keep this window open until done.")."</p>";
 
-	Contact::createFromProbe($uid, $r[0]["url"], true);
+	Contact::createFromProbe($a->user, $r[0]["url"], true);
 
 	DI::page()['htmlhead'] = '<meta http-equiv="refresh" content="1; URL=' . DI::baseUrl() . '/repair_ostatus?counter='.$counter.'">';
 

--- a/src/Module/Contact.php
+++ b/src/Module/Contact.php
@@ -167,10 +167,9 @@ class Contact extends BaseModule
 			return;
 		}
 
-		$uid = $contact['uid'];
-
 		if ($contact['network'] == Protocol::OSTATUS) {
-			$result = Model\Contact::createFromProbe($uid, $contact['url'], false, $contact['network']);
+			$user = Model\User::getById($contact['uid']);
+			$result = Model\Contact::createFromProbe($user, $contact['url'], false, $contact['network']);
 
 			if ($result['success']) {
 				DBA::update('contact', ['subhub' => 1], ['id' => $contact_id]);

--- a/src/Worker/AddContact.php
+++ b/src/Worker/AddContact.php
@@ -23,6 +23,7 @@ namespace Friendica\Worker;
 
 use Friendica\Core\Logger;
 use Friendica\Model\Contact;
+use Friendica\Model\User;
 
 class AddContact
 {
@@ -33,7 +34,11 @@ class AddContact
 	 */
 	public static function execute(int $uid, string $url)
 	{
-		$result = Contact::createFromProbe($uid, $url, '', false);
+		$user = User::getById($uid);
+		if (empty($user)) {
+			return;
+		}
+		$result = Contact::createFromProbe($user, $url, '', false);
 		Logger::info('Added contact', ['uid' => $uid, 'url' => $url, 'result' => $result]);
 	}
 }


### PR DESCRIPTION
- Address https://github.com/friendica/friendica/issues/8473#issuecomment-641259906

The `$a->user` array `Contact::createFromProbe` used is only populated when a user is authenticated, which means that it was absent in the worker context. The method now takes an explicit user array as first parameter and doesn't require authentication to work with Diaspora contacts.

Interestingly, the OStatus/DFRN case nearby had already been fixed but Diaspora was still using the faulty App member.