### PR TITLE
Replace mention to $_SERVER with parameter in Content\Markdown::convert

### DIFF
--- a/src/Content/Text/Markdown.php
+++ b/src/Content/Text/Markdown.php
@@ -35,20 +35,20 @@ class Markdown
 	 * compatibility with Diaspora in spite of the Markdown standard.
 	 *
 	 * @param string $text
-	 * @param bool   $hardwrap
+	 * @param bool   $hardwrap Enables line breaks on \n without two trailing spaces
+	 * @param string $baseuri  Optional. Prepend anchor links with this URL
 	 * @return string
-	 * @throws \Exception
 	 */
-	public static function convert($text, $hardwrap = true) {
+	public static function convert($text, $hardwrap = true, $baseuri = null) {
 		$stamp1 = microtime(true);
 
 		$MarkdownParser = new MarkdownParser();
 		$MarkdownParser->code_class_prefix  = 'language-';
 		$MarkdownParser->hard_wrap          = $hardwrap;
 		$MarkdownParser->hashtag_protection = true;
-		$MarkdownParser->url_filter_func    = function ($url) {
-			if (strpos($url, '#') === 0) {
-				$url = ltrim($_SERVER['REQUEST_URI'], '/') . $url;
+		$MarkdownParser->url_filter_func    = function ($url) use ($baseuri) {
+			if (!empty($baseuri) && strpos($url, '#') === 0) {
+				$url = ltrim($baseuri, '/') . $url;
 			}
 			return  $url;
 		};


### PR DESCRIPTION
Address https://github.com/friendica/friendica/issues/8475#issuecomment-642073809
Follow-up to https://github.com/friendica/friendica/pull/6845
Part of https://github.com/friendica/friendica/issues/6633

- $_SERVER key isn't always available, no idea what it was used for exactly

The anchor URL replacement was introduced in #6845 but I'm not sure why since it doesn't change anything to the output of the provided text in #6633