### PR TITLE
Fix providing the public key

### DIFF
--- a/view/templates/profile/vcard.tpl
+++ b/view/templates/profile/vcard.tpl
@@ -33,7 +33,7 @@
 		</dl>
 	{{/if}}
 
-	{{if $profile.pubkey}}<div class="key u-key" style="display:none;">{{$profile.pubkey}}</div>{{/if}}
+	{{if $profile.upubkey}}<div class="key u-key" style="display:none;">{{$profile.upubkey}}</div>{{/if}}
 
 	{{if $contacts}}<div class="contacts" style="display:none;">{{$contacts}}</div>{{/if}}
 

--- a/view/theme/duepuntozero/templates/profile/vcard.tpl
+++ b/view/theme/duepuntozero/templates/profile/vcard.tpl
@@ -27,7 +27,7 @@
 
 	{{if $profile.about}}<div class="title">{{$profile.about nofilter}}</div>{{/if}}
 
-	{{if $profile.pubkey}}<div class="key" style="display:none;">{{$profile.pubkey}}</div>{{/if}}
+	{{if $profile.upubkey}}<div class="key" style="display:none;">{{$profile.upubkey}}</div>{{/if}}
 
 	{{if $homepage}}<dl class="homepage"><dt class="homepage-label">{{$homepage}}</dt><dd class="homepage-url"><a href="{{$profile.homepage}}" class="u-url" rel="me" target="external-link">{{$profile.homepage}}</a></dd></dl>{{/if}}
 

--- a/view/theme/frio/templates/profile/vcard.tpl
+++ b/view/theme/frio/templates/profile/vcard.tpl
@@ -98,7 +98,7 @@
 		</div>
 		{{/if}}
 
-		{{if $profile.pubkey}}<div class="key u-key" style="display:none;">{{$profile.pubkey}}</div>{{/if}}
+		{{if $profile.upubkey}}<div class="key u-key" style="display:none;">{{$profile.upubkey}}</div>{{/if}}
 
 		{{if $contacts}}<div class="contacts" style="display:none;">{{$contacts}}</div>{{/if}}
 

--- a/view/theme/quattro/templates/profile/vcard.tpl
+++ b/view/theme/quattro/templates/profile/vcard.tpl
@@ -46,7 +46,7 @@
                 </dl>
         {{/if}}
 
-	{{if $profile.pubkey}}<div class="key" style="display:none;">{{$profile.pubkey}}</div>{{/if}}
+	{{if $profile.upubkey}}<div class="key" style="display:none;">{{$profile.upubkey}}</div>{{/if}}
 
 	{{if $homepage}}
 	<dl class="homepage"><dt class="homepage-label">{{$homepage}}</dt>

--- a/view/theme/vier/templates/profile/vcard.tpl
+++ b/view/theme/vier/templates/profile/vcard.tpl
@@ -40,7 +40,7 @@
 		</dl>
 	{{/if}}
 
-	{{if $profile.pubkey}}<div class="key u-key" style="display:none;">{{$profile.pubkey}}</div>{{/if}}
+	{{if $profile.upubkey}}<div class="key u-key" style="display:none;">{{$profile.upubkey}}</div>{{/if}}
 
 	{{if $contacts}}<div class="contacts" style="display:none;">{{$contacts}}</div>{{/if}}
 


### PR DESCRIPTION
We hadn't provided the public key anymore in the hcard due to removing duplicated fields.

This could possibly caused problems with Diaspora contact requests when your account was new.