### PR TITLE
Clear all previous template variables before replacing Macros

### DIFF
--- a/src/Render/FriendicaSmartyEngine.php
+++ b/src/Render/FriendicaSmartyEngine.php
@@ -83,6 +83,8 @@ final class FriendicaSmartyEngine extends TemplateEngine
 		Hook::callAll('template_vars', $arr);
 		$vars = $arr['vars'];
 
+		$this->smarty->clearAllAssign();
+
 		foreach ($vars as $key => $value) {
 			if ($key[0] === '$') {
 				$key = substr($key, 1);

--- a/view/theme/frio/php/minimal.php
+++ b/view/theme/frio/php/minimal.php
@@ -6,7 +6,10 @@
 	<?php if(!empty($page['htmlhead'])) echo $page['htmlhead'] ?>
 </head>
 <body class="minimal">
-	<section><?php if(!empty($page['content'])) echo $page['content']; ?>
+	<section>
+		<div  class="generic-page-wrapper">
+			<?php if(!empty($page['content'])) echo $page['content']; ?>
+		</div>
 		<div id="page-footer"></div>
 	</section>
 	<!-- Modal  -->

--- a/view/theme/frio/templates/auto_request.tpl
+++ b/view/theme/frio/templates/auto_request.tpl
@@ -1,45 +1,43 @@
-<div class="generic-page-wrapper">
-	<h1>{{$header}}</h1>
+<h1>{{$header}}</h1>
 
 {{if !$myaddr}}
-	<p id="dfrn-request-intro">
-		{{$page_desc nofilter}}
-	</p>
-	<p>
-		{{$invite_desc nofilter}}
-	</p>
+<p id="dfrn-request-intro">
+	{{$page_desc nofilter}}
+</p>
+<p>
+	{{$invite_desc nofilter}}
+</p>
 {{/if}}
 
-	<form action="{{$request}}" method="post">
+<form action="{{$request}}" method="post">
 {{if $url}}
-		<dl>
-			<dt>{{$url_label}}</dt>
-			<dd><a target="blank" href="{{$zrl}}">{{$url}}</a></dd>
-		</dl>
+	<dl>
+		<dt>{{$url_label}}</dt>
+		<dd><a target="blank" href="{{$zrl}}">{{$url}}</a></dd>
+	</dl>
 {{/if}}
 {{if $keywords}}
-		<dl>
-			<dt>{{$keywords_label}}</dt>
-			<dd>{{$keywords}}</dd>
-		</dl>
+	<dl>
+		<dt>{{$keywords_label}}</dt>
+		<dd>{{$keywords}}</dd>
+	</dl>
 {{/if}}
-		<div id="dfrn-request-url-wrapper">
-			<label id="dfrn-url-label" for="dfrn-url">{{$your_address}}</label>
-			{{if $myaddr}}
-				{{$myaddr}}
-				<input type="hidden" name="dfrn_url" id="dfrn-url" value="{{$myaddr}}" />
-			{{else}}
-				<input type="text" name="dfrn_url" id="dfrn-url" size="32" value="{{$myaddr}}">
-			{{/if}}
-			<input type="hidden" name="url" id="url" value="{{$url}}">
-			<div id="dfrn-request-url-end"></div>
-		</div>
+	<div id="dfrn-request-url-wrapper">
+		<label id="dfrn-url-label" for="dfrn-url">{{$your_address}}</label>
+		{{if $myaddr}}
+			{{$myaddr}}
+			<input type="hidden" name="dfrn_url" id="dfrn-url" value="{{$myaddr}}" />
+		{{else}}
+			<input type="text" name="dfrn_url" id="dfrn-url" size="32" value="{{$myaddr}}">
+		{{/if}}
+		<input type="hidden" name="url" id="url" value="{{$url}}">
+		<div id="dfrn-request-url-end"></div>
+	</div>
 
-		<div id="dfrn-request-submit-wrapper">
+	<div id="dfrn-request-submit-wrapper">
 {{if $submit}}
-			<input class="btn btn-primary" type="submit" name="submit" id="dfrn-request-submit-button" value="{{$submit}}">
+		<input class="btn btn-primary" type="submit" name="submit" id="dfrn-request-submit-button" value="{{$submit}}">
 {{/if}}
-			<input class="btn btn-default" type="submit" name="cancel" id="dfrn-request-cancel-button" value="{{$cancel}}">
-		</div>
-	</form>
-</div>
+		<input class="btn btn-default" type="submit" name="cancel" id="dfrn-request-cancel-button" value="{{$cancel}}">
+	</div>
+</form>


### PR DESCRIPTION
Fix #8746 

The problem was that we use a single Smarty object to process all the templates in a single page. And since we didn't clear the list of assigned variable, a stray variable from a previous template processing ended up in this particular template.

Why this one? Because it's been reworked recently, and it has multiple uses, which means that one of the variables may or may not be set. This is accounted for in the template that checks whether the variable exists or not, but it was definitely not expecting this variable to have been set for a previous template processing.

The variable in question was ubiquitously named `$url` and was set to be used in `micropro.tpl`, a template used when showing the contacts of the target account in the left column of the `/dfrn_request` page.

So the URL shown would always be the profile URL of the last contact shown in the left column. And it could change depending on the displayed contact list.

However, it wouldn't have changed anything to the following, and the correct account would have been followed anyway.