### PR TITLE
Reduced network request when probing

### DIFF
--- a/src/Protocol/ActivityPub.php
+++ b/src/Protocol/ActivityPub.php
@@ -145,7 +145,7 @@ class ActivityPub
 	{
 		$apcontact = APContact::getByURL($url, $update);
 		if (empty($apcontact)) {
-			return false;
+			return [];
 		}
 
 		$profile = ['network' => Protocol::ACTIVITYPUB];


### PR DESCRIPTION
When probing accounts we always had queried `.well-known/host-meta` first to obtain the path to the `webfinger` URL. This call isn't needed if the `webfinger` URL follows the RFC recommendations, see here: https://tools.ietf.org/html/rfc7033#section-10.1

If this isn't the case (AFAIK this is only the case with old Friendica versions like 3.x and lower) then we query `.well-known/host-meta` to fetch the `webfinger` URL.