### PR TITLE
Exclude [img] tags from tag replacement

### DIFF
--- a/mod/item.php
+++ b/mod/item.php
@@ -375,7 +375,7 @@ function item_post(App $a) {
 	$only_to_forum = false;
 	$forum_contact = [];
 
-	$body = BBCode::performWithEscapedTags($body, ['noparse', 'pre', 'code'], function ($body) use ($profile_uid, $network, $str_contact_allow, &$inform, &$private_forum, &$private_id, &$only_to_forum, &$forum_contact) {
+	$body = BBCode::performWithEscapedTags($body, ['noparse', 'pre', 'code', 'img'], function ($body) use ($profile_uid, $network, $str_contact_allow, &$inform, &$private_forum, &$private_id, &$only_to_forum, &$forum_contact) {
 		$tags = BBCode::getTags($body);
 
 		$tagged = [];

--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -2188,7 +2188,7 @@ class BBCode
 	 */
 	public static function setMentions($body, $profile_uid = 0, $network = '')
 	{
-		BBCode::performWithEscapedTags($body, ['noparse', 'pre', 'code'], function ($body) use ($profile_uid, $network) {
+		BBCode::performWithEscapedTags($body, ['noparse', 'pre', 'code', 'img'], function ($body) use ($profile_uid, $network) {
 			$tags = BBCode::getTags($body);
 
 			$tagged = [];
@@ -2211,7 +2211,7 @@ class BBCode
 					}
 				}
 
-			$success = Item::replaceTag($body, $inform, $profile_uid, $tag, $network);
+				$success = Item::replaceTag($body, $inform, $profile_uid, $tag, $network);
 
 				if ($success['replaced']) {
 					$tagged[] = $tag;


### PR DESCRIPTION
Fixes #8488

I chose to exclude `[img]` from tag replacement instead of tag search, because I believe posts can still be tagged from the caption of an image. It just won't be replaced with a link in the image caption.

Also I didn't expect my tag exclusion feature to be used again so soon, I guess it's time for a self-patting on the back.