### PR TITLE
[pre] blocks now preserve spaces

### DIFF
--- a/doc/BBCode.md
+++ b/doc/BBCode.md
@@ -634,6 +634,14 @@ On Mastodon this field is used for the content warning.
   <td>@user@domain.tld #hashtag</td>
 </tr>
 <tr>
+  <td>Additionally, [pre] blocks preserve spaces:
+    <ul>
+      <li>[pre]&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Spaces[/pre]</li>
+    </ul>
+  </td>
+  <td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Spaces</td>
+</tr>
+<tr>
   <td>[nosmile] is used to disable smilies on a post by post basis<br>
     <br>
     [nosmile] ;-) :-O

--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -1299,9 +1299,9 @@ class BBCode
 				// Remove the abstract element. It is a non visible element.
 				$text = self::stripAbstract($text);
 
-				// Move all spaces out of the tags
-				$text = preg_replace("/\[(\w*)\](\s*)/ism", '$2[$1]', $text);
-				$text = preg_replace("/(\s*)\[\/(\w*)\]/ism", '[/$2]$1', $text);
+				// Move new lines outside of tags
+				$text = preg_replace("#\[(\w*)](\n*)#ism", '$2[$1]', $text);
+				$text = preg_replace("#(\n*)\[/(\w*)]#ism", '[/$2]$1', $text);
 
 				// Extract the private images which use data urls since preg has issues with
 				// large data sizes. Stash them away while we do bbcode conversion, and then put them back

--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -1878,7 +1878,11 @@ class BBCode
 			// Remove escaping tags
 			$text = preg_replace("/\[noparse\](.*?)\[\/noparse\]/ism", '\1', $text);
 			$text = preg_replace("/\[nobb\](.*?)\[\/nobb\]/ism", '\1', $text);
-			$text = preg_replace("/\[pre\](.*?)\[\/pre\]/ism", '\1', $text);
+
+			// Additionally, [pre] tags preserve spaces
+			$text = preg_replace_callback("/\[pre\](.*?)\[\/pre\]/ism", function ($match) {
+				return str_replace(' ', '&nbsp;', $match[1]);
+			}, $text);
 
 			return $text;
 		}); // Escaped code

--- a/tests/src/Content/Text/BBCodeTest.php
+++ b/tests/src/Content/Text/BBCodeTest.php
@@ -236,7 +236,11 @@ class BBCodeTest extends MockedTest
 			'bug-7808-code-amp' => [
 				'expectedHtml' => '<code>&amp;</code>',
 				'text' => '[code]&[/code]',
-			]
+			],
+			'task-8800-pre-spaces-notag' => [
+				'expectedHtml' => '[test] Space',
+				'text' => '[test] Space',
+			],
 		];
 	}
 

--- a/tests/src/Content/Text/BBCodeTest.php
+++ b/tests/src/Content/Text/BBCodeTest.php
@@ -241,6 +241,10 @@ class BBCodeTest extends MockedTest
 				'expectedHtml' => '[test] Space',
 				'text' => '[test] Space',
 			],
+			'task-8800-pre-spaces' => [
+				'expectedHtml' => '&nbsp;&nbsp;&nbsp;&nbsp;Spaces',
+				'text' => '[pre]    Spaces[/pre]',
+			],
 		];
 	}
 


### PR DESCRIPTION
Fixes #8800 

Additionally, it fixes a long-standing issue where spaces after non-tags would be stripped as well.