### PR TITLE
Add type hint to Database::insert

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -979,7 +979,7 @@ class Database
 	 * @return boolean was the insert successful?
 	 * @throws \Exception
 	 */
-	public function insert($table, $param, $on_duplicate_update = false)
+	public function insert($table, array $param, bool $on_duplicate_update = false)
 	{
 		if (empty($table) || empty($param)) {
 			$this->logger->info('Table and fields have to be set');


### PR DESCRIPTION
- Will escalate warning to fatal error in https://github.com/friendica/friendica/issues/8474#issuecomment-646802016

@AlfredSK Please monitor your PHP log once you pull this one because of an expected fatal error when the `$param` parameter is the wrong type.