### PR TITLE
Add support for mobile profile URL to core twitter probing

### DIFF
--- a/mod/dfrn_request.php
+++ b/mod/dfrn_request.php
@@ -297,8 +297,8 @@ function dfrn_request_post(App $a)
 		$data = Probe::uri($url);
 		$network = $data["network"];
 
-		// Canonicalise email-style profile locator
-		$url = Probe::webfingerDfrn($url, $hcard);
+		// Canonicalize email-style profile locator
+		$url = Probe::webfingerDfrn($data['url'], $hcard);
 
 		if (substr($url, 0, 5) === 'stat:') {
 			// Every time we detect the remote subscription we define this as OStatus.

--- a/mod/follow.php
+++ b/mod/follow.php
@@ -129,7 +129,7 @@ function follow_content(App $a)
 
 	if ($protocol == Protocol::PHANTOM) {
 		// Possibly it is a remote item and not an account
-		follow_remote_item($url);
+		follow_remote_item($ret['url']);
 
 		notice(DI::l10n()->t("The network type couldn't be detected. Contact can't be added."));
 		$submit = '';

--- a/mod/ostatus_subscribe.php
+++ b/mod/ostatus_subscribe.php
@@ -48,7 +48,6 @@ function ostatus_subscribe_content(App $a)
 		}
 
 		$contact = Probe::uri($_REQUEST['url']);
-
 		if (!$contact) {
 			DI::pConfig()->delete($uid, 'ostatus', 'legacy_contact');
 			return $o . DI::l10n()->t('Couldn\'t fetch information for contact.');
@@ -91,7 +90,7 @@ function ostatus_subscribe_content(App $a)
 
 	$probed = Probe::uri($url);
 	if ($probed['network'] == Protocol::OSTATUS) {
-		$result = Contact::createFromProbe($a->user, $url, true, Protocol::OSTATUS);
+		$result = Contact::createFromProbe($a->user, $probed['url'], true, Protocol::OSTATUS);
 		if ($result['success']) {
 			$o .= ' - ' . DI::l10n()->t('success');
 		} else {

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -1572,7 +1572,7 @@ class Contact
 			$data['gsid'] = GServer::getID($data['baseurl']);
 		}
 
-		if (!$contact_id && !empty($data['alias']) && ($data['alias'] != $url) && !$in_loop) {
+		if (!$contact_id && !empty($data['alias']) && ($data['alias'] != $data['url']) && !$in_loop) {
 			$contact_id = self::getIdForURL($data["alias"], $uid, true, $default, true);
 		}
 
@@ -2353,11 +2353,11 @@ class Contact
 		$condition = ['uid' => $user['uid'], 'poll' => [$ret['poll'], Strings::normaliseLink($ret['poll'])], 'network' => $ret['network'], 'pending' => false];
 		$contact = DBA::selectFirst('contact', ['id', 'rel'], $condition);
 		if (!DBA::isResult($contact)) {
-			$condition = ['uid' => $user['uid'], 'nurl' => Strings::normaliseLink($url), 'network' => $ret['network'], 'pending' => false];
+			$condition = ['uid' => $user['uid'], 'nurl' => Strings::normaliseLink($ret['url']), 'network' => $ret['network'], 'pending' => false];
 			$contact = DBA::selectFirst('contact', ['id', 'rel'], $condition);
 		}
 
-		$protocol = self::getProtocol($url, $ret['network']);
+		$protocol = self::getProtocol($ret['url'], $ret['network']);
 
 		if (($protocol === Protocol::DFRN) && !DBA::isResult($contact)) {
 			if ($interactive) {
@@ -2394,7 +2394,7 @@ class Contact
 			if (empty($ret['url'])) {
 				$result['message'] .= DI::l10n()->t('No browser URL could be matched to this address.') . EOL;
 			}
-			if (strpos($url, '@') !== false) {
+			if (strpos($ret['url'], '@') !== false) {
 				$result['message'] .= DI::l10n()->t('Unable to match @-style Identity Address with a known protocol or email contact.') . EOL;
 				$result['message'] .= DI::l10n()->t('Use mailto: in front of address to force email check.') . EOL;
 			}
@@ -2418,7 +2418,7 @@ class Contact
 
 		$pending = false;
 		if ($protocol == Protocol::ACTIVITYPUB) {
-			$apcontact = APContact::getByURL($url, false);
+			$apcontact = APContact::getByURL($ret['url'], false);
 			if (isset($apcontact['manually-approve'])) {
 				$pending = (bool)$apcontact['manually-approve'];
 			}

--- a/src/Model/GContact.php
+++ b/src/Model/GContact.php
@@ -230,8 +230,6 @@ class GContact
 				throw new Exception('Probing for URL ' . $gcontact['url'] . ' failed');
 			}
 
-			$orig_profile = $gcontact['url'];
-
 			$gcontact['server_url'] = $data['baseurl'];
 
 			$gcontact = array_merge($gcontact, $data);

--- a/src/Model/Mail.php
+++ b/src/Model/Mail.php
@@ -276,10 +276,7 @@ class Mail
 
 		$recip_handle = $recipient['nickname'] . '@' . substr(DI::baseUrl(), strpos(DI::baseUrl(), '://') + 3);
 
-		$sender_nick = basename($me['url']);
-		$sender_host = substr($me['url'], strpos($me['url'], '://') + 3);
-		$sender_host = substr($sender_host, 0, strpos($sender_host, '/'));
-		$sender_handle = $sender_nick . '@' . $sender_host;
+		$sender_handle = $me['addr'];
 
 		$handles = $recip_handle . ';' . $sender_handle;
 

--- a/src/Model/Mail.php
+++ b/src/Model/Mail.php
@@ -268,7 +268,6 @@ class Mail
 		$uri = Item::newURI(local_user(), $guid);
 
 		$me = Probe::uri($replyto);
-
 		if (!$me['name']) {
 			return -2;
 		}
@@ -277,8 +276,8 @@ class Mail
 
 		$recip_handle = $recipient['nickname'] . '@' . substr(DI::baseUrl(), strpos(DI::baseUrl(), '://') + 3);
 
-		$sender_nick = basename($replyto);
-		$sender_host = substr($replyto, strpos($replyto, '://') + 3);
+		$sender_nick = basename($me['url']);
+		$sender_host = substr($me['url'], strpos($me['url'], '://') + 3);
 		$sender_host = substr($sender_host, 0, strpos($sender_host, '/'));
 		$sender_handle = $sender_nick . '@' . $sender_host;
 
@@ -313,7 +312,7 @@ class Mail
 				'reply' => 0,
 				'replied' => 0,
 				'uri' => $uri,
-				'parent-uri' => $replyto,
+				'parent-uri' => $me['url'],
 				'created' => DateTimeFormat::utcNow(),
 				'unknown' => 1
 			]

--- a/src/Module/Acctlink.php
+++ b/src/Module/Acctlink.php
@@ -36,7 +36,6 @@ class Acctlink extends BaseModule
 
 		if ($addr) {
 			$url = Probe::uri($addr)['url'] ?? '';
-
 			if ($url) {
 				System::externalRedirect($url);
 				exit();

--- a/src/Network/Probe.php
+++ b/src/Network/Probe.php
@@ -692,7 +692,7 @@ class Probe
 		$parts = parse_url($uri);
 
 		if (!empty($parts['scheme']) && !empty($parts['host'])) {
-			if ($parts['host'] == 'twitter.com') {
+			if (in_array($parts['host'], ['twitter.com', 'mobile.twitter.com'])) {
 				return self::twitter($uri);
 			}
 		} elseif (strstr($uri, '@')) {
@@ -706,7 +706,9 @@ class Probe
 				return self::mail($uri, $uid);
 			}
 
-			if (strpos($uri, '@twitter.com')) {
+			if (Strings::endsWith($uri, '@twitter.com')
+				|| Strings::endsWith($uri, '@mobile.twitter.com')
+			) {
 				return self::twitter($uri);
 			}
 		} else {
@@ -1720,9 +1722,9 @@ class Probe
 	 */
 	private static function twitter($uri)
 	{
-		if (preg_match('=(.*)@twitter.com=i', $uri, $matches)) {
+		if (preg_match('=([^@]+)@(?:mobile\.)?twitter\.com$=i', $uri, $matches)) {
 			$nick = $matches[1];
-		} elseif (preg_match('=https?://twitter.com/(.*)=i', $uri, $matches)) {
+		} elseif (preg_match('=^https?://(?:mobile\.)?twitter\.com/(.+)=i', $uri, $matches)) {
 			$nick = $matches[1];
 		} else {
 			return [];

--- a/src/Protocol/OStatus.php
+++ b/src/Protocol/OStatus.php
@@ -1829,11 +1829,12 @@ class OStatus
 		$item["private"] = Item::PRIVATE;
 
 		$contact = Probe::uri($item['follow']);
+		$item['follow'] = $contact['url'];
 
-		if ($contact['alias'] == '') {
-			$contact['alias'] = $contact["url"];
-		} else {
+		if ($contact['alias']) {
 			$item['follow'] = $contact['alias'];
+		} else {
+			$contact['alias'] = $contact['url'];
 		}
 
 		$condition = ['uid' => $owner['uid'], 'nurl' => Strings::normaliseLink($contact["url"])];


### PR DESCRIPTION
Fixes #8517
Replaces #8518 and #8773

Additionally, it ensures the `url` property in the result of `Probe::uri` is used authoritatively. It will not change the behavior of probing when the result URL is the same as the provided URL.

I tried to minimize the footprint in `Probe::uri` as I felt it wasn't the right place to handle this.