### PR TITLE
Prevent delivering AP comments to Diaspora

### DIFF
--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -672,7 +672,8 @@ class Item
 
 		$fields['parent-item'] = ['guid' => 'parent-guid', 'network' => 'parent-network'];
 
-		$fields['parent-item-author'] = ['url' => 'parent-author-link', 'name' => 'parent-author-name'];
+		$fields['parent-item-author'] = ['url' => 'parent-author-link', 'name' => 'parent-author-name',
+			'network' => 'parent-author-network'];
 
 		$fields['event'] = ['created' => 'event-created', 'edited' => 'event-edited',
 			'start' => 'event-start','finish' => 'event-finish',


### PR DESCRIPTION
There had been situations where comments to comments from ActivityPub had been sent to Diaspora. This is irritating for Diaspora users since they cannot see the comment that this comment is reacting to.

This solution is not perfect though. It will not catch a situation where somewhere in the comment thread a person from Friendica is commenting and then others from Friendica are commenting on that specific comment. But this check is better than nothing.