### PR TITLE
Add expected support for sort strings in select() parameters

### DIFF
--- a/src/Database/DBA.php
+++ b/src/Database/DBA.php
@@ -648,6 +648,20 @@ class DBA
 	/**
 	 * Returns the SQL parameter string built from the provided parameter array
 	 *
+	 * Expected format for each key:
+	 *
+	 * group_by:
+	 *  - list of column names
+	 *
+	 * order:
+	 *  - numeric keyed column name => ASC
+	 *  - associative element with boolean value => DESC (true), ASC (false)
+	 *  - associative element with string value => 'ASC' or 'DESC' literally
+	 *
+	 * limit:
+	 *  - single numeric value => count
+	 *  - list with two numeric values => offset, count
+	 *
 	 * @param array $params
 	 * @return string
 	 */
@@ -665,7 +679,11 @@ class DBA
 				if ($order === 'RAND()') {
 					$order_string .= "RAND(), ";
 				} elseif (!is_int($fields)) {
-					$order_string .= self::quoteIdentifier($fields) . " " . ($order ? "DESC" : "ASC") . ", ";
+					if ($order !== 'DESC' && $order !== 'ASC') {
+						$order = $order ? 'DESC' : 'ASC';
+					}
+
+					$order_string .= self::quoteIdentifier($fields) . " " . $order . ", ";
 				} else {
 					$order_string .= self::quoteIdentifier($order) . ", ";
 				}

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -1467,24 +1467,30 @@ class Database
 	/**
 	 * Select rows from a table
 	 *
+	 *
+	 * Example:
+	 * $table = 'item';
+	 * or:
+	 * $table = ['schema' => 'table'];
+	 * @see DBA::buildTableString()
+	 *
+	 * $fields = ['id', 'uri', 'uid', 'network'];
+	 *
+	 * $condition = ['uid' => 1, 'network' => 'dspr', 'blocked' => true];
+	 * or:
+	 * $condition = ['`uid` = ? AND `network` IN (?, ?)', 1, 'dfrn', 'dspr'];
+	 * @see DBA::buildCondition()
+	 *
+	 * $params = ['order' => ['id', 'received' => true, 'created' => 'ASC'), 'limit' => 10];
+	 * @see DBA::buildParameter()
+	 *
+	 * $data = DBA::select($table, $fields, $condition, $params);
+	 *
 	 * @param string|array $table     Table name or array [schema => table]
 	 * @param array        $fields    Array of selected fields, empty for all
 	 * @param array        $condition Array of fields for condition
 	 * @param array        $params    Array of several parameters
-	 *
 	 * @return boolean|object
-	 *
-	 * Example:
-	 * $table = "item";
-	 * $fields = array("id", "uri", "uid", "network");
-	 *
-	 * $condition = array("uid" => 1, "network" => 'dspr');
-	 * or:
-	 * $condition = array("`uid` = ? AND `network` IN (?, ?)", 1, 'dfrn', 'dspr');
-	 *
-	 * $params = array("order" => array("id", "received" => true), "limit" => 10);
-	 *
-	 * $data = DBA::select($table, $fields, $condition, $params);
 	 * @throws \Exception
 	 */
 	public function select($table, array $fields = [], array $condition = [], array $params = [])


### PR DESCRIPTION
- Fix unexpected behaviors with calls already using the sort strings

Fixes #8829 

Well, this one was fun. I expected to have to fix legacy API stuff, but instead I discovered that @nupplaphil used sort string `ASC` and `DESC` in the `order` parameter of `Database->select` for fetching notifications even though we didn't have any support for them until now. This produced the intended result when using `DESC` but the opposite for `ASC` as truthy values were unilaterally converted to `DESC`.