### PR TITLE
Add support for "hs2019" algorithm value in Util\HTTPSignature

### DIFF
--- a/src/Util/HTTPSignature.php
+++ b/src/Util/HTTPSignature.php
@@ -534,6 +534,14 @@ class HTTPSignature
 
 		$algorithm = null;
 
+		// Wildcard value where signing algorithm should be derived from keyId
+		// @see https://tools.ietf.org/html/draft-ietf-httpbis-message-signatures-00#section-4.1
+		// Defaulting to SHA256 as it seems to be the prevalent implementation
+		// @see https://arewehs2019yet.vpzom.click
+		if ($sig_block['algorithm'] === 'hs2019') {
+			$algorithm = 'sha256';
+		}
+
 		if ($sig_block['algorithm'] === 'rsa-sha256') {
 			$algorithm = 'sha256';
 		}


### PR DESCRIPTION
May close #8839

This looks right to me from the available information but I'm no cryptography expert. It doesn't accept any more algorithms than before but it does add support for the `hs2019` value by defaulting to `SHA-256` like other Fediverse implementations seem to be doing.