### PR TITLE
Rename -q option to -y for user delete console command

### DIFF
--- a/src/Console/User.php
+++ b/src/Console/User.php
@@ -59,7 +59,7 @@ console user - Modify user settings per console commands.
 Usage
 	bin/console user password <nickname> [<password>] [-h|--help|-?] [-v]
 	bin/console user add [<name> [<nickname> [<email> [<language>]]]] [-h|--help|-?] [-v]
-	bin/console user delete [<nickname>] [-q] [-h|--help|-?] [-v]
+	bin/console user delete [<nickname>] [-y] [-h|--help|-?] [-v]
 	bin/console user allow [<nickname>] [-h|--help|-?] [-v]
 	bin/console user deny [<nickname>] [-h|--help|-?] [-v]
 	bin/console user block [<nickname>] [-h|--help|-?] [-v]
@@ -78,8 +78,8 @@ Description
 
 Options
     -h|--help|-? Show help information
-    -v           Show more debug information.
-    -q           Quiet mode (don't ask for a command).
+    -v           Show more debug information
+    -y           Non-interactive mode, assume "yes" as answer to the user deletion prompt
 HELP;
 		return $help;
 	}
@@ -314,7 +314,7 @@ HELP;
 			return true;
 		}
 
-		if (!$this->getOption('q')) {
+		if (!$this->getOption('y')) {
 			$this->out($this->l10n->t('Type "yes" to delete %s', $nick));
 			if (CliPrompt::prompt() !== 'yes') {
 				throw new RuntimeException($this->l10n->t('Deletion aborted.'));

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -1321,6 +1321,7 @@ class User
 		$condition = [];
 		switch ($type) {
 			case 'active':
+				$condition['account_removed'] = false;
 				$condition['blocked'] = false;
 				break;
 			case 'blocked':


### PR DESCRIPTION
Closes #8846

This is a backward breaking change, however it is a restrictive one: user accounts previously quietly deleted won't be anymore without a script change. No user account will be deleted when they weren't meant to be.