### PR TITLE
Issue 8844: Fix probing of unknown AP contacts

### DIFF
--- a/src/Network/Probe.php
+++ b/src/Network/Probe.php
@@ -342,7 +342,7 @@ class Probe
 		}
 
 		if (empty($network) || ($network == Protocol::ACTIVITYPUB)) {
-			$ap_profile = ActivityPub::probeProfile($uri, !$cache);
+			$ap_profile = ActivityPub::probeProfile($uri);
 		} else {
 			$ap_profile = [];
 		}


### PR DESCRIPTION
This really fixes https://github.com/friendica/friendica/issues/8844

The problem had been that the second parameter of `ActivityPub::probeProfile` controls whether the system should perform an update or if the values should be taken from the `apcontact` table without any probing.

This contradicts the meaning of the `$cache` parameter which only says: "Fetch the data from the cache if present. If not present then perform a probe".

This is a bug that we had from the beginning of the AP integration. It is funny that it took so long to find it.