### PR TITLE
Fix unneeded database functions in the callstack

### DIFF
--- a/src/Core/System.php
+++ b/src/Core/System.php
@@ -45,20 +45,22 @@ class System
 		array_shift($trace);
 
 		$callstack = [];
-		$previous = ['class' => '', 'function' => ''];
+		$previous = ['class' => '', 'function' => '', 'database' => false];
 
 		// The ignore list contains all functions that are only wrapper functions
 		$ignore = ['fetchUrl', 'call_user_func_array'];
 
 		while ($func = array_pop($trace)) {
 			if (!empty($func['class'])) {
-				// Don't show multiple calls from the "dba" class to show the essential parts of the callstack
-				if ((($previous['class'] != $func['class']) || ($func['class'] != 'Friendica\Database\DBA')) && ($previous['function'] != 'q')) {
+				// Don't show multiple calls from the Database classes to show the essential parts of the callstack
+				$func['database'] = in_array($func['class'], ['Friendica\Database\DBA', 'Friendica\Database\Database']);
+				if (!$previous['database'] || !$func['database']) {	
 					$classparts = explode("\\", $func['class']);
 					$callstack[] = array_pop($classparts).'::'.$func['function'];
 					$previous = $func;
 				}
 			} elseif (!in_array($func['function'], $ignore)) {
+				$func['database'] = ($func['function'] == 'q');
 				$callstack[] = $func['function'];
 				$func['class'] = '';
 				$previous = $func;


### PR DESCRIPTION
This fixes the problem that the displayed callstack contained unneeded stuff that made debugging harder, since the real origin wasn't displayed in the callstack (by default we only display the last 4 items of the callstack).