### PR TITLE
Fix message "empty network" in gcontact::getid

### DIFF
--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -1560,7 +1560,7 @@ class DFRN
 		if (DBA::isResult($contact_old) && !$onlyfetch) {
 			Logger::log("Check if contact details for contact " . $contact_old["id"] . " (" . $contact_old["nick"] . ") have to be updated.", Logger::DEBUG);
 
-			$poco = ["url" => $contact_old["url"]];
+			$poco = ["url" => $contact_old["url"], "network" => $contact_old["network"]];
 
 			// When was the last change to name or uri?
 			$name_element = $xpath->query($element . "/atom:name", $context)->item(0);


### PR DESCRIPTION
While having a look at the performance, I see lots of log entries with "empty network" in it. They occurred due to a missing network parameter.

Also the `getId` function now doesn't use a lock anymore. It is now working similar to `getIdForURL` which seems to work fine. In fact the locking really created significant performance issues.