### PR TITLE
Don't check the date on regular feeds

### DIFF
--- a/src/Protocol/OStatus.php
+++ b/src/Protocol/OStatus.php
@@ -2200,7 +2200,7 @@ class OStatus
 			$last_update = 'now -30 days';
 		}
 
-		$check_date = DateTimeFormat::utc($last_update);
+		$check_date = $feed_mode ? '' : DateTimeFormat::utc($last_update);
 		$authorid = Contact::getIdForURL($owner["url"], 0, true);
 
 		$condition = ["`uid` = ? AND `received` > ? AND NOT `deleted`


### PR DESCRIPTION
A user just contacted me because his feed had been empty. I saw that we do have a date limit there. But this only does make sense on technical feeds for conversation stuff, not for feeds.