### PR TITLE
Add support for token strings in HTTPSignature::parseSigheader

### DIFF
--- a/src/Util/Crypto.php
+++ b/src/Util/Crypto.php
@@ -461,11 +461,12 @@ class Crypto
 			return;
 		}
 
-		$alg = ((array_key_exists('alg', $data)) ? $data['alg'] : 'aes256cbc');
+		$alg = $data['alg'] ?? 'aes256cbc';
 		if ($alg === 'aes256cbc') {
-			return self::encapsulateAes($data['data'], $prvkey);
+			return self::unencapsulateAes($data['data'], $prvkey);
 		}
-		return self::encapsulateOther($data['data'], $prvkey, $alg);
+
+		return self::unencapsulateOther($data, $prvkey, $alg);
 	}
 
 	/**

--- a/src/Util/HTTPSignature.php
+++ b/src/Util/HTTPSignature.php
@@ -191,8 +191,10 @@ class HTTPSignature
 
 	/**
 	 * @param string $header
-	 * @return array associate array with
+	 * @return array associative array with
 	 *   - \e string \b keyID
+	 *   - \e string \b created
+	 *   - \e string \b expires
 	 *   - \e string \b algorithm
 	 *   - \e array  \b headers
 	 *   - \e string \b signature
@@ -200,78 +202,55 @@ class HTTPSignature
 	 */
 	public static function parseSigheader($header)
 	{
-		$ret = [];
+		// Remove obsolete folds
+		$header = preg_replace('/\n\s+/', ' ', $header);
+
+		$token = "[!#$%&'*+.^_`|~0-9A-Za-z-]";
+
+		$quotedString = '"(?:\\\\.|[^"\\\\])*"';
+
+		$regex = "/($token+)=($quotedString|$token+)/ism";
+
 		$matches = [];
+		preg_match_all($regex, $header, $matches, PREG_SET_ORDER);
+
+		$headers = [];
+		foreach ($matches as $match) {
+			$headers[$match[1]] = trim($match[2] ?: $match[3], '"');
+		}
 
 		// if the header is encrypted, decrypt with (default) site private key and continue
-		if (preg_match('/iv="(.*?)"/ism', $header, $matches)) {
-			$header = self::decryptSigheader($header);
+		if (!empty($headers['iv'])) {
+			$header = self::decryptSigheader($headers, DI::config()->get('system', 'prvkey'));
+			return self::parseSigheader($header);
 		}
 
-		if (preg_match('/keyId="(.*?)"/ism', $header, $matches)) {
-			$ret['keyId'] = $matches[1];
+		$return = [
+			'keyId'     => $headers['keyId'] ?? '',
+			'algorithm' => $headers['algorithm'] ?? 'rsa-sha256',
+			'created'   => $headers['created'] ?? null,
+			'expires'   => $headers['expires'] ?? null,
+			'headers'   => explode(' ', $headers['headers'] ?? ''),
+			'signature' => base64_decode(preg_replace('/\s+/', '', $headers['signature'] ?? '')),
+		];
+
+		if (!empty($return['signature']) && !empty($return['algorithm']) && empty($return['headers'])) {
+			$return['headers'] = ['date'];
 		}
 
-		if (preg_match('/algorithm="(.*?)"/ism', $header, $matches)) {
-			$ret['algorithm'] = $matches[1];
-		} else {
-			$ret['algorithm'] = 'rsa-sha256';
-		}
-
-		if (preg_match('/headers="(.*?)"/ism', $header, $matches)) {
-			$ret['headers'] = explode(' ', $matches[1]);
-		}
-
-		if (preg_match('/signature="(.*?)"/ism', $header, $matches)) {
-			$ret['signature'] = base64_decode(preg_replace('/\s+/', '', $matches[1]));
-		}
-
-		if (!empty($ret['signature']) && !empty($ret['algorithm']) && empty($ret['headers'])) {
-			$ret['headers'] = ['date'];
-		}
-
-		return $ret;
+		return $return;
 	}
 
 	/**
-	 * @param string $header
-	 * @param string $prvkey (optional), if not set use site private key
-	 *
-	 * @return array|string associative array, empty string if failue
-	 *   - \e string \b iv
-	 *   - \e string \b key
-	 *   - \e string \b alg
-	 *   - \e string \b data
+	 * @param array  $headers Signature headers
+	 * @param string $prvkey  The site private key
+	 * @return string Decrypted signature string
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
-	private static function decryptSigheader($header, $prvkey = null)
+	private static function decryptSigheader(array $headers, string $prvkey)
 	{
-		$iv = $key = $alg = $data = null;
-
-		if (!$prvkey) {
-			$prvkey = DI::config()->get('system', 'prvkey');
-		}
-
-		$matches = [];
-
-		if (preg_match('/iv="(.*?)"/ism', $header, $matches)) {
-			$iv = $matches[1];
-		}
-
-		if (preg_match('/key="(.*?)"/ism', $header, $matches)) {
-			$key = $matches[1];
-		}
-
-		if (preg_match('/alg="(.*?)"/ism', $header, $matches)) {
-			$alg = $matches[1];
-		}
-
-		if (preg_match('/data="(.*?)"/ism', $header, $matches)) {
-			$data = $matches[1];
-		}
-
-		if ($iv && $key && $alg && $data) {
-			return Crypto::unencapsulate(['iv' => $iv, 'key' => $key, 'alg' => $alg, 'data' => $data], $prvkey);
+		if (!empty($headers['iv']) && !empty($headers['key']) && !empty($headers['data'])) {
+			return Crypto::unencapsulate($headers, $prvkey);
 		}
 
 		return '';

--- a/tests/src/Util/HTTPSignatureTest.php
+++ b/tests/src/Util/HTTPSignatureTest.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Friendica\Test\src\Util;
+
+use Friendica\Util\HTTPSignature;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * HTTP Signature utility test class
+ */
+class HTTPSignatureTest extends TestCase
+{
+	public function testParseSigheader()
+	{
+		$header = 'keyId="test-key-a", algorithm="hs2019",
+       created=1402170695,
+       headers="(request-target) (created) host date content-type digest
+           content-length",
+       signature="KXUj1H3ZOhv3Nk4xlRLTn4bOMlMOmFiud3VXrMa9MaLCxnVmrqOX5B
+           ulRvB65YW/wQp0oT/nNQpXgOYeY8ovmHlpkRyz5buNDqoOpRsCpLGxsIJ9cX8
+           XVsM9jy+Q1+RIlD9wfWoPHhqhoXt35ZkasuIDPF/AETuObs9QydlsqONwbK+T
+           dQguDK/8Va1Pocl6wK1uLwqcXlxhPEb55EmdYB9pddDyHTADING7K4qMwof2m
+           C3t8Pb0yoLZoZX5a4Or4FrCCKK/9BHAhq/RsVk0dTENMbTB4i7cHvKQu+o9xu
+           YWuxyvBa0Z6NdOb0di70cdrSDEsL5Gz7LBY5J2N9KdGg=="';
+
+		$headers = HTTPSignature::parseSigheader($header);
+		$this->assertSame([
+			'keyId'     => 'test-key-a',
+			'algorithm' => 'hs2019',
+			'created'   => '1402170695',
+			'expires'   => null,
+			'headers'   => ['(request-target)', '(created)', 'host', 'date', 'content-type', 'digest', 'content-length'],
+			'signature' => base64_decode('KXUj1H3ZOhv3Nk4xlRLTn4bOMlMOmFiud3VXrMa9MaLCxnVmrqOX5BulRvB65YW/wQp0oT/nNQpXgOYeY8ovmHlpkRyz5buNDqoOpRsCpLGxsIJ9cX8XVsM9jy+Q1+RIlD9wfWoPHhqhoXt35ZkasuIDPF/AETuObs9QydlsqONwbK+TdQguDK/8Va1Pocl6wK1uLwqcXlxhPEb55EmdYB9pddDyHTADING7K4qMwof2mC3t8Pb0yoLZoZX5a4Or4FrCCKK/9BHAhq/RsVk0dTENMbTB4i7cHvKQu+o9xuYWuxyvBa0Z6NdOb0di70cdrSDEsL5Gz7LBY5J2N9KdGg=='),
+		], $headers);
+	}
+}


### PR DESCRIPTION
Closes #8847

This enhancement led me to find that `Crypto::unencapsulate` could never have worked since it's been ported from Hubzilla.

I do not believe it has ever been used either.