### PR TITLE
Replaced "getDetailsByURL" with "getByURL/getByURLForUser"

### DIFF
--- a/mod/common.php
+++ b/mod/common.php
@@ -57,7 +57,7 @@ function common_content(App $a)
 
 		if (DBA::isResult($contact)) {
 			DI::page()['aside'] = "";
-			Model\Profile::load($a, "", Model\Contact::getDetailsByURL($contact["url"]));
+			Model\Profile::load($a, "", Model\Contact::getByURLForUser($contact["url"], 0, [], false));
 		}
 	} else {
 		$contact = DBA::selectFirst('contact', ['name', 'url', 'photo', 'uid', 'id'], ['self' => true, 'uid' => $uid]);
@@ -124,7 +124,7 @@ function common_content(App $a)
 	$entries = [];
 	foreach ($common_friends as $common_friend) {
 		//get further details of the contact
-		$contact_details = Model\Contact::getDetailsByURL($common_friend['url'], $uid);
+		$contact_details = Model\Contact::getByURLForUser($common_friend['url'], $uid, [], false);
 
 		// $rr['id'] is needed to use contact_photo_menu()
 		/// @TODO Adding '/" here avoids E_NOTICE on missing constants

--- a/mod/common.php
+++ b/mod/common.php
@@ -57,7 +57,7 @@ function common_content(App $a)
 
 		if (DBA::isResult($contact)) {
 			DI::page()['aside'] = "";
-			Model\Profile::load($a, "", Model\Contact::getByURLForUser($contact["url"], 0, [], false));
+			Model\Profile::load($a, "", Model\Contact::getByURL($contact["url"], false));
 		}
 	} else {
 		$contact = DBA::selectFirst('contact', ['name', 'url', 'photo', 'uid', 'id'], ['self' => true, 'uid' => $uid]);
@@ -124,7 +124,7 @@ function common_content(App $a)
 	$entries = [];
 	foreach ($common_friends as $common_friend) {
 		//get further details of the contact
-		$contact_details = Model\Contact::getByURLForUser($common_friend['url'], $uid, [], false);
+		$contact_details = Model\Contact::getByURLForUser($common_friend['url'], $uid, false);
 
 		// $rr['id'] is needed to use contact_photo_menu()
 		/// @TODO Adding '/" here avoids E_NOTICE on missing constants

--- a/mod/common.php
+++ b/mod/common.php
@@ -124,7 +124,7 @@ function common_content(App $a)
 	$entries = [];
 	foreach ($common_friends as $common_friend) {
 		//get further details of the contact
-		$contact_details = Model\Contact::getByURLForUser($common_friend['url'], $uid, false);
+		$contact_details = Model\Contact::getByURLForUser($common_friend['url'], $uid);
 
 		// $rr['id'] is needed to use contact_photo_menu()
 		/// @TODO Adding '/" here avoids E_NOTICE on missing constants

--- a/mod/display.php
+++ b/mod/display.php
@@ -164,7 +164,7 @@ function display_fetchauthor($a, $item)
 		$profiledata["about"] = "";
 	}
 
-	$profiledata = array_merge($profiledata, Contact::getByURLForUser($profiledata["url"], local_user(), [], false));
+	$profiledata = array_merge($profiledata, Contact::getByURLForUser($profiledata["url"], local_user(), false));
 
 	if (!empty($profiledata["photo"])) {
 		$profiledata["photo"] = DI::baseUrl()->remove($profiledata["photo"]);

--- a/mod/display.php
+++ b/mod/display.php
@@ -164,7 +164,7 @@ function display_fetchauthor($a, $item)
 		$profiledata["about"] = "";
 	}
 
-	$profiledata = array_merge($profiledata, Contact::getByURLForUser($profiledata["url"], local_user(), false));
+	$profiledata = array_merge($profiledata, Contact::getByURLForUser($profiledata["url"], local_user()));
 
 	if (!empty($profiledata["photo"])) {
 		$profiledata["photo"] = DI::baseUrl()->remove($profiledata["photo"]);

--- a/mod/display.php
+++ b/mod/display.php
@@ -164,7 +164,7 @@ function display_fetchauthor($a, $item)
 		$profiledata["about"] = "";
 	}
 
-	$profiledata = Contact::getDetailsByURL($profiledata["url"], local_user(), $profiledata);
+	$profiledata = array_merge($profiledata, Contact::getByURLForUser($profiledata["url"], local_user(), [], false));
 
 	if (!empty($profiledata["photo"])) {
 		$profiledata["photo"] = DI::baseUrl()->remove($profiledata["photo"]);

--- a/mod/editpost.php
+++ b/mod/editpost.php
@@ -145,7 +145,7 @@ function undo_post_tagging($s) {
 	if ($cnt) {
 		foreach ($matches as $mtch) {
 			if (in_array($mtch[1], ['!', '@'])) {
-				$contact = Contact::getDetailsByURL($mtch[2]);
+				$contact = Contact::getByURL($mtch[2], 0, ['addr'], false);
 				$mtch[3] = empty($contact['addr']) ? $mtch[2] : $contact['addr'];
 			}
 			$s = str_replace($mtch[0], $mtch[1] . $mtch[3],$s);

--- a/mod/editpost.php
+++ b/mod/editpost.php
@@ -145,7 +145,7 @@ function undo_post_tagging($s) {
 	if ($cnt) {
 		foreach ($matches as $mtch) {
 			if (in_array($mtch[1], ['!', '@'])) {
-				$contact = Contact::getByURL($mtch[2], 0, ['addr'], false);
+				$contact = Contact::getByURL($mtch[2], false, ['addr']);
 				$mtch[3] = empty($contact['addr']) ? $mtch[2] : $contact['addr'];
 			}
 			$s = str_replace($mtch[0], $mtch[1] . $mtch[3],$s);

--- a/mod/follow.php
+++ b/mod/follow.php
@@ -107,7 +107,7 @@ function follow_content(App $a)
 		}
 	}
 
-	$contact = Contact::getByURL($url, 0, [], true);
+	$contact = Contact::getByURL($url, true);
 	if (empty($contact)) {
 		// Possibly it is a remote item and not an account
 		follow_remote_item($url);

--- a/mod/match.php
+++ b/mod/match.php
@@ -102,7 +102,7 @@ function match_content(App $a)
 				'follow' => [DI::l10n()->t("Connect/Follow"), $connlnk]
 			];
 
-			$contact_details = Contact::getByURL($profile->url, 0, [], false);
+			$contact_details = Contact::getByURL($profile->url, false);
 
 			$entry = [
 				'url'          => Contact::magicLink($profile->url),

--- a/mod/match.php
+++ b/mod/match.php
@@ -102,7 +102,7 @@ function match_content(App $a)
 				'follow' => [DI::l10n()->t("Connect/Follow"), $connlnk]
 			];
 
-			$contact_details = Contact::getDetailsByURL($profile->url, 0);
+			$contact_details = Contact::getByURL($profile->url, 0, [], false);
 
 			$entry = [
 				'url'          => Contact::magicLink($profile->url),

--- a/mod/message.php
+++ b/mod/message.php
@@ -396,7 +396,7 @@ function message_content(App $a)
 			$body_e = BBCode::convert($message['body']);
 			$to_name_e = $message['name'];
 
-			$contact = Contact::getDetailsByURL($message['from-url']);
+			$contact = Contact::getByURL($message['from-url'], 0, ['thumb', 'addr'], false);
 			if (isset($contact["thumb"])) {
 				$from_photo = $contact["thumb"];
 			} else {
@@ -528,7 +528,7 @@ function render_messages(array $msg, $t)
 		$body_e = $rr['body'];
 		$to_name_e = $rr['name'];
 
-		$contact = Contact::getDetailsByURL($rr['url']);
+		$contact = Contact::getByURL($rr['url'], 0, ['thumb', 'addr'], false);
 		if (isset($contact["thumb"])) {
 			$from_photo = $contact["thumb"];
 		} else {

--- a/mod/message.php
+++ b/mod/message.php
@@ -396,7 +396,7 @@ function message_content(App $a)
 			$body_e = BBCode::convert($message['body']);
 			$to_name_e = $message['name'];
 
-			$contact = Contact::getByURL($message['from-url'], 0, ['thumb', 'addr'], false);
+			$contact = Contact::getByURL($message['from-url'], false, ['thumb', 'addr']);
 			if (isset($contact["thumb"])) {
 				$from_photo = $contact["thumb"];
 			} else {
@@ -528,7 +528,7 @@ function render_messages(array $msg, $t)
 		$body_e = $rr['body'];
 		$to_name_e = $rr['name'];
 
-		$contact = Contact::getByURL($rr['url'], 0, ['thumb', 'addr'], false);
+		$contact = Contact::getByURL($rr['url'], false, ['thumb', 'addr']);
 		if (isset($contact["thumb"])) {
 			$from_photo = $contact["thumb"];
 		} else {

--- a/mod/ping.php
+++ b/mod/ping.php
@@ -331,7 +331,7 @@ function ping_init(App $a)
 
 		if (DBA::isResult($notifs)) {
 			foreach ($notifs as $notif) {
-				$contact = Contact::getByURL($notif['url'], 0, ['micro'], false);
+				$contact = Contact::getByURL($notif['url'], false, ['micro']);
 				if (isset($contact['micro'])) {
 					$notif['photo'] = ProxyUtils::proxifyUrl($contact['micro'], false, ProxyUtils::SIZE_MICRO);
 				} else {

--- a/mod/ping.php
+++ b/mod/ping.php
@@ -331,7 +331,7 @@ function ping_init(App $a)
 
 		if (DBA::isResult($notifs)) {
 			foreach ($notifs as $notif) {
-				$contact = Contact::getDetailsByURL($notif['url']);
+				$contact = Contact::getByURL($notif['url'], 0, ['micro'], false);
 				if (isset($contact['micro'])) {
 					$notif['photo'] = ProxyUtils::proxifyUrl($contact['micro'], false, ProxyUtils::SIZE_MICRO);
 				} else {

--- a/mod/suggest.php
+++ b/mod/suggest.php
@@ -104,7 +104,7 @@ function suggest_content(App $a)
 			'hide' => [DI::l10n()->t('Ignore/Hide'), $ignlnk]
 		];
 
-		$contact_details = Contact::getDetailsByURL($rr["url"], local_user(), $rr);
+		$contact_details = array_merge($rr, Contact::getByURLForUser($rr["url"], local_user(), [], false));
 
 		$entry = [
 			'url' => Contact::magicLink($rr['url']),

--- a/mod/suggest.php
+++ b/mod/suggest.php
@@ -104,7 +104,7 @@ function suggest_content(App $a)
 			'hide' => [DI::l10n()->t('Ignore/Hide'), $ignlnk]
 		];
 
-		$contact_details = array_merge($rr, Contact::getByURLForUser($rr["url"], local_user(), false));
+		$contact_details = array_merge($rr, Contact::getByURLForUser($rr["url"], local_user()));
 
 		$entry = [
 			'url' => Contact::magicLink($rr['url']),

--- a/mod/suggest.php
+++ b/mod/suggest.php
@@ -104,7 +104,7 @@ function suggest_content(App $a)
 			'hide' => [DI::l10n()->t('Ignore/Hide'), $ignlnk]
 		];
 
-		$contact_details = array_merge($rr, Contact::getByURLForUser($rr["url"], local_user(), [], false));
+		$contact_details = array_merge($rr, Contact::getByURLForUser($rr["url"], local_user(), false));
 
 		$entry = [
 			'url' => Contact::magicLink($rr['url']),

--- a/mod/unfollow.php
+++ b/mod/unfollow.php
@@ -146,7 +146,7 @@ function unfollow_content(App $a)
 	]);
 
 	DI::page()['aside'] = '';
-	Profile::load($a, '', Contact::getByURL($contact['url'], 0, [], false));
+	Profile::load($a, '', Contact::getByURL($contact['url'], false));
 
 	$o .= Renderer::replaceMacros(Renderer::getMarkupTemplate('section_title.tpl'), ['$title' => DI::l10n()->t('Status Messages and Posts')]);
 

--- a/mod/unfollow.php
+++ b/mod/unfollow.php
@@ -146,7 +146,7 @@ function unfollow_content(App $a)
 	]);
 
 	DI::page()['aside'] = '';
-	Profile::load($a, '', Contact::getDetailsByURL($contact['url']));
+	Profile::load($a, '', Contact::getByURL($contact['url'], 0, [], false));
 
 	$o .= Renderer::replaceMacros(Renderer::getMarkupTemplate('section_title.tpl'), ['$title' => DI::l10n()->t('Status Messages and Posts')]);
 

--- a/src/Content/Item.php
+++ b/src/Content/Item.php
@@ -130,7 +130,7 @@ class Item
 				// Checking for the alias that is used for OStatus
 				$pattern = '/[@!]\[url\=(.*?)\](.*?)\[\/url\]/ism';
 				if (preg_match($pattern, $tag, $matches)) {
-					$data = Contact::getDetailsByURL($matches[1]);
+					$data = Contact::getByURL($matches[1], 0, ['alias', 'nick'], false);
 
 					if ($data['alias'] != '') {
 						$newtag = '@[url=' . $data['alias'] . ']' . $data['nick'] . '[/url]';
@@ -149,15 +149,8 @@ class Item
 			$name = $nameparts[0];
 
 			// Try to detect the contact in various ways
-			if (strpos($name, 'http://')) {
-				// At first we have to ensure that the contact exists
-				Contact::getIdForURL($name);
-
-				// Now we should have something
-				$contact = Contact::getDetailsByURL($name, $profile_uid);
-			} elseif (strpos($name, '@')) {
-				// This function automatically probes when no entry was found
-				$contact = Contact::getDetailsByAddr($name, $profile_uid);
+			if (strpos($name, 'http://') || strpos($name, '@')) {
+				$contact = Contact::getByURLForUser($name, $profile_uid, []);
 			} else {
 				$contact = false;
 				$fields = ['id', 'url', 'nick', 'name', 'alias', 'network', 'forum', 'prv'];

--- a/src/Content/Item.php
+++ b/src/Content/Item.php
@@ -130,7 +130,7 @@ class Item
 				// Checking for the alias that is used for OStatus
 				$pattern = '/[@!]\[url\=(.*?)\](.*?)\[\/url\]/ism';
 				if (preg_match($pattern, $tag, $matches)) {
-					$data = Contact::getByURL($matches[1], 0, ['alias', 'nick'], false);
+					$data = Contact::getByURL($matches[1], false, ['alias', 'nick']);
 
 					if ($data['alias'] != '') {
 						$newtag = '@[url=' . $data['alias'] . ']' . $data['nick'] . '[/url]';

--- a/src/Content/Item.php
+++ b/src/Content/Item.php
@@ -150,7 +150,7 @@ class Item
 
 			// Try to detect the contact in various ways
 			if (strpos($name, 'http://') || strpos($name, '@')) {
-				$contact = Contact::getByURLForUser($name, $profile_uid, []);
+				$contact = Contact::getByURLForUser($name, $profile_uid);
 			} else {
 				$contact = false;
 				$fields = ['id', 'url', 'nick', 'name', 'alias', 'network', 'forum', 'prv'];

--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -1975,11 +1975,7 @@ class BBCode
 	 */
 	private static function bbCodeMention2DiasporaCallback($match)
 	{
-		$contact = Contact::getDetailsByURL($match[3]);
-
-		if (empty($contact['addr'])) {
-			$contact = Probe::uri($match[3]);
-		}
+		$contact = Contact::getByURL($match[3], 0, ['addr']);
 
 		if (empty($contact['addr'])) {
 			return $match[0];

--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -983,7 +983,7 @@ class BBCode
 					$attributes[$field] = html_entity_decode($matches[2] ?? '', ENT_QUOTES, 'UTF-8');
 				}
 
-				$author_contact = Contact::getByURL($attributes['profile'], 0, ['url', 'addr', 'name', 'micro'], false);
+				$author_contact = Contact::getByURL($attributes['profile'], false, ['url', 'addr', 'name', 'micro']);
 				$author_contact['url'] = ($author_contact['url'] ?? $attributes['profile']);
 				$author_contact['addr'] = ($author_contact['addr'] ?? '') ?: Protocol::getAddrFromProfileUrl($attributes['profile']);
 
@@ -1061,7 +1061,7 @@ class BBCode
 			default:
 				$text = ($is_quote_share? "\n" : '');
 
-				$contact = Contact::getByURL($attributes['profile'], 0, ['network'], false);
+				$contact = Contact::getByURL($attributes['profile'], false, ['network']);
 				$network = $contact['network'] ?? Protocol::PHANTOM;
 
 				$tpl = Renderer::getMarkupTemplate('shared_content.tpl');
@@ -1975,7 +1975,7 @@ class BBCode
 	 */
 	private static function bbCodeMention2DiasporaCallback($match)
 	{
-		$contact = Contact::getByURL($match[3], 0, ['addr']);
+		$contact = Contact::getByURL($match[3], null, ['addr']);
 
 		if (empty($contact['addr'])) {
 			return $match[0];

--- a/src/Content/Text/Markdown.php
+++ b/src/Content/Text/Markdown.php
@@ -83,7 +83,7 @@ class Markdown
 					return '';
 				}
 
-				$data = Contact::getDetailsByAddr($matches[3]);
+				$data = Contact::getByURL($matches[3]);
 
 				if (empty($data)) {
 					return '';

--- a/src/Core/Search.php
+++ b/src/Core/Search.php
@@ -77,7 +77,7 @@ class Search
 			// Ensure that we do have a contact entry
 			Contact::getIdForURL($user_data['url'] ?? '');
 
-			$contactDetails = Contact::getDetailsByURL($user_data['url'] ?? '', local_user());
+			$contactDetails = Contact::getByURLForUser($user_data['url'] ?? '', local_user(), [], false);
 
 			$result = new ContactResult(
 				$user_data['name'] ?? '',
@@ -143,7 +143,7 @@ class Search
 
 		foreach ($profiles as $profile) {
 			$profile_url = $profile['url'] ?? '';
-			$contactDetails = Contact::getDetailsByURL($profile_url, local_user());
+			$contactDetails = Contact::getByURLForUser($profile_url, local_user(), [], false);
 
 			$result = new ContactResult(
 				$profile['name'] ?? '',
@@ -232,7 +232,7 @@ class Search
 				continue;
 			}
 
-			$contact = Contact::getDetailsByURL($row["nurl"], local_user());
+			$contact = Contact::getByURLForUser($row["nurl"], local_user(), [], false);
 
 			if ($contact["name"] == "") {
 				$contact["name"] = end(explode("/", $urlParts["path"]));

--- a/src/Core/Search.php
+++ b/src/Core/Search.php
@@ -77,7 +77,7 @@ class Search
 			// Ensure that we do have a contact entry
 			Contact::getIdForURL($user_data['url'] ?? '');
 
-			$contactDetails = Contact::getByURLForUser($user_data['url'] ?? '', local_user(), false);
+			$contactDetails = Contact::getByURLForUser($user_data['url'] ?? '', local_user());
 
 			$result = new ContactResult(
 				$user_data['name'] ?? '',
@@ -143,7 +143,7 @@ class Search
 
 		foreach ($profiles as $profile) {
 			$profile_url = $profile['url'] ?? '';
-			$contactDetails = Contact::getByURLForUser($profile_url, local_user(), false);
+			$contactDetails = Contact::getByURLForUser($profile_url, local_user());
 
 			$result = new ContactResult(
 				$profile['name'] ?? '',
@@ -232,7 +232,7 @@ class Search
 				continue;
 			}
 
-			$contact = Contact::getByURLForUser($row["nurl"], local_user(), false);
+			$contact = Contact::getByURLForUser($row["nurl"], local_user());
 
 			if ($contact["name"] == "") {
 				$contact["name"] = end(explode("/", $urlParts["path"]));

--- a/src/Core/Search.php
+++ b/src/Core/Search.php
@@ -77,7 +77,7 @@ class Search
 			// Ensure that we do have a contact entry
 			Contact::getIdForURL($user_data['url'] ?? '');
 
-			$contactDetails = Contact::getByURLForUser($user_data['url'] ?? '', local_user(), [], false);
+			$contactDetails = Contact::getByURLForUser($user_data['url'] ?? '', local_user(), false);
 
 			$result = new ContactResult(
 				$user_data['name'] ?? '',
@@ -143,7 +143,7 @@ class Search
 
 		foreach ($profiles as $profile) {
 			$profile_url = $profile['url'] ?? '';
-			$contactDetails = Contact::getByURLForUser($profile_url, local_user(), [], false);
+			$contactDetails = Contact::getByURLForUser($profile_url, local_user(), false);
 
 			$result = new ContactResult(
 				$profile['name'] ?? '',
@@ -232,7 +232,7 @@ class Search
 				continue;
 			}
 
-			$contact = Contact::getByURLForUser($row["nurl"], local_user(), [], false);
+			$contact = Contact::getByURLForUser($row["nurl"], local_user(), false);
 
 			if ($contact["name"] == "") {
 				$contact["name"] = end(explode("/", $urlParts["path"]));

--- a/src/Factory/Notification/Introduction.php
+++ b/src/Factory/Notification/Introduction.php
@@ -99,7 +99,7 @@ class Introduction extends BaseFactory
 		$formattedNotifications = [];
 
 		try {
-			/// @todo Fetch contact details by "Contact::getDetailsByUrl" instead of queries to contact, fcontact and gcontact
+			/// @todo Fetch contact details by "Contact::getByUrl" instead of queries to contact, fcontact and gcontact
 			$stmtNotifications = $this->dba->p(
 				"SELECT `intro`.`id` AS `intro_id`, `intro`.*, `contact`.*,
 				`fcontact`.`name` AS `fname`, `fcontact`.`url` AS `furl`, `fcontact`.`addr` AS `faddr`,
@@ -213,7 +213,7 @@ class Introduction extends BaseFactory
 		// If the network and addr is still not available
 		// get the missing data data from other sources
 		if (empty($intro['gnetwork']) || empty($intro['gaddr'])) {
-			$ret = Contact::getDetailsByURL($intro['url']);
+			$ret = Contact::getByURL($intro['url'], 0, ['network', 'addr'], false);
 
 			if (empty($intro['gnetwork']) && !empty($ret['network'])) {
 				$intro['gnetwork'] = $ret['network'];

--- a/src/Factory/Notification/Introduction.php
+++ b/src/Factory/Notification/Introduction.php
@@ -213,7 +213,7 @@ class Introduction extends BaseFactory
 		// If the network and addr is still not available
 		// get the missing data data from other sources
 		if (empty($intro['gnetwork']) || empty($intro['gaddr'])) {
-			$ret = Contact::getByURL($intro['url'], 0, ['network', 'addr'], false);
+			$ret = Contact::getByURL($intro['url'], false, ['network', 'addr']);
 
 			if (empty($intro['gnetwork']) && !empty($ret['network'])) {
 				$intro['gnetwork'] = $ret['network'];

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -238,7 +238,7 @@ class Contact
 	 * @param boolean $update true = always update, false = never update, null = update when not found or outdated
 	 * @return array contact array
 	 */
-	public static function getByURLForUser(string $url, int $uid = 0, $update = null, array $fields = [])
+	public static function getByURLForUser(string $url, int $uid = 0, $update = false, array $fields = [])
 	{
 		if ($uid != 0) {
 			$contact = self::getByURL($url, $update, $fields, $uid);

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -199,7 +199,7 @@ class Contact
 	 * @param boolean $update true = always update, false = never update, null = update when not found or outdated
 	 * @return array contact array
 	 */
-	public static function getByURL(string $url, int $uid = 0, array $fields = [], $update = null)
+	public static function getByURL(string $url, $update = null, array $fields = [], int $uid = 0)
 	{
 		if ($update || is_null($update)) {
 			$cid = self::getIdForURL($url, $uid, !($update ?? false));
@@ -241,7 +241,7 @@ class Contact
 	public static function getByURLForUser(string $url, int $uid = 0, array $fields = [], $update = null)
 	{
 		if ($uid != 0) {
-			$contact = self::getByURL($url, $uid, $fields, $update);
+			$contact = self::getByURL($url, $update, $fields, $uid);
 			if (!empty($contact)) {
 				if (!empty($contact['id'])) {
 					$contact['cid'] = $contact['id'];
@@ -251,7 +251,7 @@ class Contact
 			}
 		}
 
-		$contact = self::getByURL($url, 0, $fields, $update);
+		$contact = self::getByURL($url, $update, $fields);
 		if (!empty($contact['id'])) {		
 			$contact['cid'] = 0;
 			$contact['zid'] = $contact['id'];
@@ -1318,7 +1318,7 @@ class Contact
 			return 0;
 		}
 
-		$contact = self::getByURL($url, $uid, ['id', 'avatar', 'updated', 'network'], false);
+		$contact = self::getByURL($url, false, ['id', 'avatar', 'updated', 'network'], $uid);
 
 		if (!empty($contact)) {
 			$contact_id = $contact["id"];

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -229,6 +229,37 @@ class Contact
 	}
 
 	/**
+	 * Fetches a contact for a given user by a given url.
+	 * In difference to "getByURL" the function will fetch a public contact when no user contact had been found.
+	 *
+	 * @param string  $url    profile url
+	 * @param integer $uid    User ID of the contact
+	 * @param array   $fields Field list
+	 * @param boolean $update true = always update, false = never update, null = update when not found or outdated
+	 * @return array contact array
+	 */
+	public static function getByURLForUser(string $url, int $uid = 0, array $fields = [], $update = null)
+	{
+		if ($uid != 0) {
+			$contact = self::getByURL($url, $uid, $fields, $update);
+			if (!empty($contact)) {
+				if (!empty($contact['id'])) {
+					$contact['cid'] = $contact['id'];
+					$contact['zid'] = 0;
+				}
+				return $contact;
+			}
+		}
+
+		$contact = self::getByURL($url, 0, $fields, $update);
+		if (!empty($contact['id'])) {		
+			$contact['cid'] = 0;
+			$contact['zid'] = $contact['id'];
+		}
+		return $contact;
+	}
+
+	/**
 	 * Tests if the given contact is a follower
 	 *
 	 * @param int $cid Either public contact id or user's contact id
@@ -1003,218 +1034,6 @@ class Contact
 		DBA::update('contact', $fields, ['id' => $contact['id']]);
 		DBA::update('contact', $fields, ['nurl' => Strings::normaliseLink($contact['url']), 'self' => false]);
 		GContact::updateFromPublicContactURL($contact['url']);
-	}
-
-	/**
-	 * Get contact data for a given profile link
-	 *
-	 * The function looks at several places (contact table and gcontact table) for the contact
-	 * It caches its result for the same script execution to prevent duplicate calls
-	 *
-	 * @param string $url     The profile link
-	 * @param int    $uid     User id
-	 * @param array  $default If not data was found take this data as default value
-	 *
-	 * @return array Contact data
-	 * @throws HTTPException\InternalServerErrorException
-	 */
-	public static function getDetailsByURL($url, $uid = -1, array $default = [])
-	{
-		static $cache = [];
-
-		if ($url == '') {
-			return $default;
-		}
-
-		if ($uid == -1) {
-			$uid = local_user();
-		}
-
-		if (isset($cache[$url][$uid])) {
-			return $cache[$url][$uid];
-		}
-
-		$ssl_url = str_replace('http://', 'https://', $url);
-
-		$nurl = Strings::normaliseLink($url);
-
-		// Fetch contact data from the contact table for the given user
-		$s = DBA::p("SELECT `id`, `id` AS `cid`, 0 AS `gid`, 0 AS `zid`, `uid`, `url`, `nurl`, `alias`, `network`, `name`, `nick`, `addr`, `location`, `about`, `xmpp`,
-			`keywords`, `photo`, `thumb`, `micro`, `forum`, `prv`, (`forum` | `prv`) AS `community`, `contact-type`, `bd` AS `birthday`, `self`, `rel`, `pending`
-		FROM `contact` WHERE `nurl` = ? AND `uid` = ?", $nurl, $uid);
-		$r = DBA::toArray($s);
-
-		// Fetch contact data from the contact table for the given user, checking with the alias
-		if (!DBA::isResult($r)) {
-			$s = DBA::p("SELECT `id`, `id` AS `cid`, 0 AS `gid`, 0 AS `zid`, `uid`, `url`, `nurl`, `alias`, `network`, `name`, `nick`, `addr`, `location`, `about`, `xmpp`,
-				`keywords`, `photo`, `thumb`, `micro`, `forum`, `prv`, (`forum` | `prv`) AS `community`, `contact-type`, `bd` AS `birthday`, `self`, `rel`, `pending`
-			FROM `contact` WHERE `alias` IN (?, ?, ?) AND `uid` = ?", $nurl, $url, $ssl_url, $uid);
-			$r = DBA::toArray($s);
-		}
-
-		// Fetch the data from the contact table with "uid=0" (which is filled automatically)
-		if (!DBA::isResult($r)) {
-			$s = DBA::p("SELECT `id`, 0 AS `cid`, `id` AS `zid`, 0 AS `gid`, `uid`, `url`, `nurl`, `alias`, `network`, `name`, `nick`, `addr`, `location`, `about`, `xmpp`,
-			`keywords`, `photo`, `thumb`, `micro`, `forum`, `prv`, (`forum` | `prv`) AS `community`, `contact-type`, `bd` AS `birthday`, 0 AS `self`, `rel`, `pending`
-			FROM `contact` WHERE `nurl` = ? AND `uid` = 0", $nurl);
-			$r = DBA::toArray($s);
-		}
-
-		// Fetch the data from the contact table with "uid=0" (which is filled automatically) - checked with the alias
-		if (!DBA::isResult($r)) {
-			$s = DBA::p("SELECT `id`, 0 AS `cid`, `id` AS `zid`, 0 AS `gid`, `uid`, `url`, `nurl`, `alias`, `network`, `name`, `nick`, `addr`, `location`, `about`, `xmpp`,
-			`keywords`, `photo`, `thumb`, `micro`, `forum`, `prv`, (`forum` | `prv`) AS `community`, `contact-type`, `bd` AS `birthday`, 0 AS `self`, `rel`, `pending`
-			FROM `contact` WHERE `alias` IN (?, ?, ?) AND `uid` = 0", $nurl, $url, $ssl_url);
-			$r = DBA::toArray($s);
-		}
-
-		// Fetch the data from the gcontact table
-		if (!DBA::isResult($r)) {
-			$s = DBA::p("SELECT 0 AS `id`, 0 AS `cid`, `id` AS `gid`, 0 AS `zid`, 0 AS `uid`, `url`, `nurl`, `alias`, `network`, `name`, `nick`, `addr`, `location`, `about`, '' AS `xmpp`,
-			`keywords`, `photo`, `photo` AS `thumb`, `photo` AS `micro`, 0 AS `forum`, 0 AS `prv`, `community`, `contact-type`, `birthday`, 0 AS `self`, 2 AS `rel`, 0 AS `pending`
-			FROM `gcontact` WHERE `nurl` = ?", $nurl);
-			$r = DBA::toArray($s);
-		}
-
-		if (DBA::isResult($r)) {
-			// If there is more than one entry we filter out the connector networks
-			if (count($r) > 1) {
-				foreach ($r as $id => $result) {
-					if (!in_array($result["network"], Protocol::NATIVE_SUPPORT)) {
-						unset($r[$id]);
-					}
-				}
-			}
-
-			$profile = array_shift($r);
-		}
-
-		if (!empty($profile)) {
-			$authoritativeResult = true;
-			// "bd" always contains the upcoming birthday of a contact.
-			// "birthday" might contain the birthday including the year of birth.
-			if ($profile["birthday"] > DBA::NULL_DATE) {
-				$bd_timestamp = strtotime($profile["birthday"]);
-				$month = date("m", $bd_timestamp);
-				$day = date("d", $bd_timestamp);
-
-				$current_timestamp = time();
-				$current_year = date("Y", $current_timestamp);
-				$current_month = date("m", $current_timestamp);
-				$current_day = date("d", $current_timestamp);
-
-				$profile["bd"] = $current_year . "-" . $month . "-" . $day;
-				$current = $current_year . "-" . $current_month . "-" . $current_day;
-
-				if ($profile["bd"] < $current) {
-					$profile["bd"] = ( ++$current_year) . "-" . $month . "-" . $day;
-				}
-			} else {
-				$profile["bd"] = DBA::NULL_DATE;
-			}
-		} else {
-			$authoritativeResult = false;
-			$profile = $default;
-		}
-
-		if (empty($profile["photo"]) && isset($default["photo"])) {
-			$profile["photo"] = $default["photo"];
-		}
-
-		if (empty($profile["name"]) && isset($default["name"])) {
-			$profile["name"] = $default["name"];
-		}
-
-		if (empty($profile["network"]) && isset($default["network"])) {
-			$profile["network"] = $default["network"];
-		}
-
-		if (empty($profile["thumb"]) && isset($profile["photo"])) {
-			$profile["thumb"] = $profile["photo"];
-		}
-
-		if (empty($profile["micro"]) && isset($profile["thumb"])) {
-			$profile["micro"] = $profile["thumb"];
-		}
-
-		if ((empty($profile["addr"]) || empty($profile["name"])) && !empty($profile["gid"])
-			&& in_array($profile["network"], Protocol::FEDERATED)
-		) {
-			Worker::add(PRIORITY_LOW, "UpdateGContact", $url);
-		}
-
-		// Show contact details of Diaspora contacts only if connected
-		if (empty($profile["cid"]) && ($profile["network"] ?? "") == Protocol::DIASPORA) {
-			$profile["location"] = "";
-			$profile["about"] = "";
-			$profile["birthday"] = DBA::NULL_DATE;
-		}
-
-		// Only cache the result if it came from the DB since this method is used in widely different contexts
-		// @see display_fetch_author for an example of $default parameter diverging from the DB result
-		if ($authoritativeResult) {
-			$cache[$url][$uid] = $profile;
-		}
-
-		return $profile;
-	}
-
-	/**
-	 * Get contact data for a given address
-	 *
-	 * The function looks at several places (contact table and gcontact table) for the contact
-	 *
-	 * @param string $addr The profile link
-	 * @param int    $uid  User id
-	 *
-	 * @return array Contact data
-	 * @throws HTTPException\InternalServerErrorException
-	 * @throws \ImagickException
-	 */
-	public static function getDetailsByAddr($addr, $uid = -1)
-	{
-		if ($addr == '') {
-			return [];
-		}
-
-		if ($uid == -1) {
-			$uid = local_user();
-		}
-
-		// Fetch contact data from the contact table for the given user
-		$r = q("SELECT `id`, `id` AS `cid`, 0 AS `gid`, 0 AS `zid`, `uid`, `url`, `nurl`, `alias`, `network`, `name`, `nick`, `addr`, `location`, `about`, `xmpp`,
-			`keywords`, `photo`, `thumb`, `micro`, `forum`, `prv`, (`forum` | `prv`) AS `community`, `contact-type`, `bd` AS `birthday`, `self`, `rel`, `pending`,`baseurl`
-			FROM `contact` WHERE `addr` = '%s' AND `uid` = %d AND NOT `deleted`",
-			DBA::escape($addr),
-			intval($uid)
-		);
-		// Fetch the data from the contact table with "uid=0" (which is filled automatically)
-		if (!DBA::isResult($r)) {
-			$r = q("SELECT `id`, 0 AS `cid`, `id` AS `zid`, 0 AS `gid`, `uid`, `url`, `nurl`, `alias`, `network`, `name`, `nick`, `addr`, `location`, `about`, `xmpp`,
-				`keywords`, `photo`, `thumb`, `micro`, `forum`, `prv`, (`forum` | `prv`) AS `community`, `contact-type`, `bd` AS `birthday`, 0 AS `self`, `rel`, `pending`, `baseurl`
-				FROM `contact` WHERE `addr` = '%s' AND `uid` = 0 AND NOT `deleted`",
-				DBA::escape($addr)
-			);
-		}
-
-		// Fetch the data from the gcontact table
-		if (!DBA::isResult($r)) {
-			$r = q("SELECT 0 AS `id`, 0 AS `cid`, `id` AS `gid`, 0 AS `zid`, 0 AS `uid`, `url`, `nurl`, `alias`, `network`, `name`, `nick`, `addr`, `location`, `about`, '' AS `xmpp`,
-				`keywords`, `photo`, `photo` AS `thumb`, `photo` AS `micro`, `community` AS `forum`, 0 AS `prv`, `community`, `contact-type`, `birthday`, 0 AS `self`, 2 AS `rel`, 0 AS `pending`, `server_url` AS `baseurl`
-				FROM `gcontact` WHERE `addr` = '%s'",
-				DBA::escape($addr)
-			);
-		}
-
-		if (!DBA::isResult($r)) {
-			$data = Probe::uri($addr);
-
-			$profile = self::getDetailsByURL($data['url'], $uid, $data);
-		} else {
-			$profile = $r[0];
-		}
-
-		return $profile;
 	}
 
 	/**

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -238,7 +238,7 @@ class Contact
 	 * @param boolean $update true = always update, false = never update, null = update when not found or outdated
 	 * @return array contact array
 	 */
-	public static function getByURLForUser(string $url, int $uid = 0, array $fields = [], $update = null)
+	public static function getByURLForUser(string $url, int $uid = 0, $update = null, array $fields = [])
 	{
 		if ($uid != 0) {
 			$contact = self::getByURL($url, $update, $fields, $uid);

--- a/src/Model/GContact.php
+++ b/src/Model/GContact.php
@@ -111,7 +111,7 @@ class GContact
 				continue;
 			}
 
-			$gcontacts[] = Contact::getDetailsByURL($result['nurl'], local_user());
+			$gcontacts[] = Contact::getByURLForUser($result['nurl'], local_user(), [], false);
 		}
 		DBA::close($results);
 		return $gcontacts;

--- a/src/Model/GContact.php
+++ b/src/Model/GContact.php
@@ -111,7 +111,7 @@ class GContact
 				continue;
 			}
 
-			$gcontacts[] = Contact::getByURLForUser($result['nurl'], local_user(), false);
+			$gcontacts[] = Contact::getByURLForUser($result['nurl'], local_user());
 		}
 		DBA::close($results);
 		return $gcontacts;

--- a/src/Model/GContact.php
+++ b/src/Model/GContact.php
@@ -111,7 +111,7 @@ class GContact
 				continue;
 			}
 
-			$gcontacts[] = Contact::getByURLForUser($result['nurl'], local_user(), [], false);
+			$gcontacts[] = Contact::getByURLForUser($result['nurl'], local_user(), false);
 		}
 		DBA::close($results);
 		return $gcontacts;

--- a/src/Module/AllFriends.php
+++ b/src/Module/AllFriends.php
@@ -63,7 +63,7 @@ class AllFriends extends BaseModule
 		}
 
 		DI::page()['aside'] = "";
-		Model\Profile::load($app, "", Model\Contact::getDetailsByURL($contact["url"]));
+		Model\Profile::load($app, "", Model\Contact::getByURL($contact["url"], 0, [], false));
 
 		$total = Model\GContact::countAllFriends(local_user(), $cid);
 
@@ -79,7 +79,7 @@ class AllFriends extends BaseModule
 		$entries = [];
 		foreach ($friends as $friend) {
 			//get further details of the contact
-			$contactDetails = Model\Contact::getDetailsByURL($friend['url'], $uid, $friend);
+			$contactDetails = array_merge($friend, Model\Contact::getByURLForUser($friend['url'], $uid, [], false));
 
 			$connlnk = '';
 			// $friend[cid] is only available for common contacts. So if the contact is a common one, use contact_photo_menu to generate the photoMenu

--- a/src/Module/AllFriends.php
+++ b/src/Module/AllFriends.php
@@ -79,7 +79,7 @@ class AllFriends extends BaseModule
 		$entries = [];
 		foreach ($friends as $friend) {
 			//get further details of the contact
-			$contactDetails = array_merge($friend, Model\Contact::getByURLForUser($friend['url'], $uid, false));
+			$contactDetails = array_merge($friend, Model\Contact::getByURLForUser($friend['url'], $uid));
 
 			$connlnk = '';
 			// $friend[cid] is only available for common contacts. So if the contact is a common one, use contact_photo_menu to generate the photoMenu

--- a/src/Module/AllFriends.php
+++ b/src/Module/AllFriends.php
@@ -79,7 +79,7 @@ class AllFriends extends BaseModule
 		$entries = [];
 		foreach ($friends as $friend) {
 			//get further details of the contact
-			$contactDetails = array_merge($friend, Model\Contact::getByURLForUser($friend['url'], $uid, [], false));
+			$contactDetails = array_merge($friend, Model\Contact::getByURLForUser($friend['url'], $uid, false));
 
 			$connlnk = '';
 			// $friend[cid] is only available for common contacts. So if the contact is a common one, use contact_photo_menu to generate the photoMenu

--- a/src/Module/AllFriends.php
+++ b/src/Module/AllFriends.php
@@ -63,7 +63,7 @@ class AllFriends extends BaseModule
 		}
 
 		DI::page()['aside'] = "";
-		Model\Profile::load($app, "", Model\Contact::getByURL($contact["url"], 0, [], false));
+		Model\Profile::load($app, "", Model\Contact::getByURL($contact["url"], false));
 
 		$total = Model\GContact::countAllFriends(local_user(), $cid);
 

--- a/src/Module/Contact.php
+++ b/src/Module/Contact.php
@@ -971,7 +971,7 @@ class Contact extends BaseModule
 		if (DBA::isResult($contact)) {
 			DI::page()['aside'] = '';
 
-			$profiledata = Model\Contact::getByURL($contact['url'], 0, [], false);
+			$profiledata = Model\Contact::getByURL($contact['url'], false);
 
 			Model\Profile::load($a, '', $profiledata, true);
 
@@ -994,7 +994,7 @@ class Contact extends BaseModule
 		if (DBA::isResult($contact)) {
 			DI::page()['aside'] = '';
 
-			$profiledata = Model\Contact::getByURL($contact['url'], 0, [], false);
+			$profiledata = Model\Contact::getByURL($contact['url'], false);
 
 			if (local_user() && in_array($profiledata['network'], Protocol::FEDERATED)) {
 				$profiledata['remoteconnect'] = DI::baseUrl() . '/follow?url=' . urlencode($profiledata['url']);

--- a/src/Module/Contact.php
+++ b/src/Module/Contact.php
@@ -971,7 +971,7 @@ class Contact extends BaseModule
 		if (DBA::isResult($contact)) {
 			DI::page()['aside'] = '';
 
-			$profiledata = Model\Contact::getDetailsByURL($contact['url']);
+			$profiledata = Model\Contact::getByURL($contact['url'], 0, [], false);
 
 			Model\Profile::load($a, '', $profiledata, true);
 
@@ -994,7 +994,7 @@ class Contact extends BaseModule
 		if (DBA::isResult($contact)) {
 			DI::page()['aside'] = '';
 
-			$profiledata = Model\Contact::getDetailsByURL($contact['url']);
+			$profiledata = Model\Contact::getByURL($contact['url'], 0, [], false);
 
 			if (local_user() && in_array($profiledata['network'], Protocol::FEDERATED)) {
 				$profiledata['remoteconnect'] = DI::baseUrl() . '/follow?url=' . urlencode($profiledata['url']);

--- a/src/Module/Contact/Advanced.php
+++ b/src/Module/Contact/Advanced.php
@@ -108,7 +108,7 @@ class Advanced extends BaseModule
 			throw new BadRequestException(DI::l10n()->t('Contact not found.'));
 		}
 
-		Model\Profile::load(DI::app(), "", Model\Contact::getByURL($contact["url"], 0, [], false));
+		Model\Profile::load(DI::app(), "", Model\Contact::getByURL($contact["url"], false));
 
 		$warning = DI::l10n()->t('<strong>WARNING: This is highly advanced</strong> and if you enter incorrect information your communications with this contact may stop working.');
 		$info    = DI::l10n()->t('Please use your browser \'Back\' button <strong>now</strong> if you are uncertain what to do on this page.');

--- a/src/Module/Contact/Advanced.php
+++ b/src/Module/Contact/Advanced.php
@@ -108,7 +108,7 @@ class Advanced extends BaseModule
 			throw new BadRequestException(DI::l10n()->t('Contact not found.'));
 		}
 
-		Model\Profile::load(DI::app(), "", Model\Contact::getDetailsByURL($contact["url"]));
+		Model\Profile::load(DI::app(), "", Model\Contact::getByURL($contact["url"], 0, [], false));
 
 		$warning = DI::l10n()->t('<strong>WARNING: This is highly advanced</strong> and if you enter incorrect information your communications with this contact may stop working.');
 		$info    = DI::l10n()->t('Please use your browser \'Back\' button <strong>now</strong> if you are uncertain what to do on this page.');

--- a/src/Module/Contact/Hovercard.php
+++ b/src/Module/Contact/Hovercard.php
@@ -65,7 +65,7 @@ class Hovercard extends BaseModule
 		// Search for contact data
 		// Look if the local user has got the contact
 		if (Session::isAuthenticated()) {
-			$contact = Contact::getByURLForUser($contact_url, local_user(), false);
+			$contact = Contact::getByURLForUser($contact_url, local_user());
 		} else {
 			$contact = Contact::getByURL($contact_url, false);
 		}

--- a/src/Module/Contact/Hovercard.php
+++ b/src/Module/Contact/Hovercard.php
@@ -67,7 +67,7 @@ class Hovercard extends BaseModule
 		if (Session::isAuthenticated()) {
 			$contact = Contact::getByURLForUser($contact_url, local_user(), [], false);
 		} else {
-			$contact = Contact::getByURL($contact_url, 0, [], false);
+			$contact = Contact::getByURL($contact_url, false);
 		}
 
 		if (!count($contact)) {

--- a/src/Module/Contact/Hovercard.php
+++ b/src/Module/Contact/Hovercard.php
@@ -65,7 +65,7 @@ class Hovercard extends BaseModule
 		// Search for contact data
 		// Look if the local user has got the contact
 		if (Session::isAuthenticated()) {
-			$contact = Contact::getByURLForUser($contact_url, local_user(), [], false);
+			$contact = Contact::getByURLForUser($contact_url, local_user(), false);
 		} else {
 			$contact = Contact::getByURL($contact_url, false);
 		}

--- a/src/Module/Contact/Hovercard.php
+++ b/src/Module/Contact/Hovercard.php
@@ -58,31 +58,16 @@ class Hovercard extends BaseModule
 		$contact = [];
 
 		// if it's the url containing https it should be converted to http
-		$contact_nurl = Strings::normaliseLink(GContact::cleanContactUrl($contact_url));
-		if (!$contact_nurl) {
+		if (!$contact_url) {
 			throw new HTTPException\BadRequestException();
 		}
 
 		// Search for contact data
 		// Look if the local user has got the contact
 		if (Session::isAuthenticated()) {
-			$contact = Contact::getDetailsByURL($contact_nurl, local_user());
-		}
-
-		// If not then check the global user
-		if (!count($contact)) {
-			$contact = Contact::getDetailsByURL($contact_nurl);
-		}
-
-		// Feeds url could have been destroyed through "cleanContactUrl", so we now use the original url
-		if (!count($contact) && Session::isAuthenticated()) {
-			$contact_nurl = Strings::normaliseLink($contact_url);
-			$contact = Contact::getDetailsByURL($contact_nurl, local_user());
-		}
-
-		if (!count($contact)) {
-			$contact_nurl = Strings::normaliseLink($contact_url);
-			$contact = Contact::getDetailsByURL($contact_nurl);
+			$contact = Contact::getByURLForUser($contact_url, local_user(), [], false);
+		} else {
+			$contact = Contact::getByURL($contact_url, 0, [], false);
 		}
 
 		if (!count($contact)) {
@@ -110,7 +95,7 @@ class Hovercard extends BaseModule
 				'about'        => $contact['about'],
 				'network_link' => Strings::formatNetworkName($contact['network'], $contact['url']),
 				'tags'         => $contact['keywords'],
-				'bd'           => $contact['birthday'] <= DBA::NULL_DATE ? '' : $contact['birthday'],
+				'bd'           => $contact['bd'] <= DBA::NULL_DATE ? '' : $contact['bd'],
 				'account_type' => Contact::getAccountType($contact),
 				'actions'      => $actions,
 			],

--- a/src/Module/Contact/Poke.php
+++ b/src/Module/Contact/Poke.php
@@ -138,7 +138,7 @@ class Poke extends BaseModule
 			throw new HTTPException\NotFoundException();
 		}
 
-		Model\Profile::load(DI::app(), '', Model\Contact::getDetailsByURL($contact["url"]));
+		Model\Profile::load(DI::app(), '', Model\Contact::getByURL($contact["url"], 0, [], false));
 
 		$verbs = [];
 		foreach (DI::l10n()->getPokeVerbs() as $verb => $translations) {

--- a/src/Module/Contact/Poke.php
+++ b/src/Module/Contact/Poke.php
@@ -138,7 +138,7 @@ class Poke extends BaseModule
 			throw new HTTPException\NotFoundException();
 		}
 
-		Model\Profile::load(DI::app(), '', Model\Contact::getByURL($contact["url"], 0, [], false));
+		Model\Profile::load(DI::app(), '', Model\Contact::getByURL($contact["url"], false));
 
 		$verbs = [];
 		foreach (DI::l10n()->getPokeVerbs() as $verb => $translations) {

--- a/src/Module/Profile/Contacts.php
+++ b/src/Module/Profile/Contacts.php
@@ -103,7 +103,7 @@ class Contacts extends BaseProfile
 				continue;
 			}
 
-			$contact_details = array_merge($contact, Contact::getByURLForUser($contact['url'], $a->profile['uid'], [], false));
+			$contact_details = array_merge($contact, Contact::getByURLForUser($contact['url'], $a->profile['uid'], false));
 
 			$contacts[] = [
 				'id'           => $contact['id'],

--- a/src/Module/Profile/Contacts.php
+++ b/src/Module/Profile/Contacts.php
@@ -103,7 +103,7 @@ class Contacts extends BaseProfile
 				continue;
 			}
 
-			$contact_details = array_merge($contact, Contact::getByURLForUser($contact['url'], $a->profile['uid'], false));
+			$contact_details = array_merge($contact, Contact::getByURLForUser($contact['url'], $a->profile['uid']));
 
 			$contacts[] = [
 				'id'           => $contact['id'],

--- a/src/Module/Profile/Contacts.php
+++ b/src/Module/Profile/Contacts.php
@@ -103,7 +103,7 @@ class Contacts extends BaseProfile
 				continue;
 			}
 
-			$contact_details = Contact::getDetailsByURL($contact['url'], $a->profile['uid'], $contact);
+			$contact_details = array_merge($contact, Contact::getByURLForUser($contact['url'], $a->profile['uid'], [], false));
 
 			$contacts[] = [
 				'id'           => $contact['id'],

--- a/src/Module/Search/Acl.php
+++ b/src/Module/Search/Acl.php
@@ -350,7 +350,7 @@ class Acl extends BaseModule
 					continue;
 				}
 
-				$contact = Contact::getByURL($author, 0, ['micro', 'name', 'id', 'network', 'nick', 'addr', 'url', 'forum'], false);
+				$contact = Contact::getByURL($author, false, ['micro', 'name', 'id', 'network', 'nick', 'addr', 'url', 'forum']);
 
 				if (count($contact) > 0) {
 					$unknown_contacts[] = [

--- a/src/Module/Search/Acl.php
+++ b/src/Module/Search/Acl.php
@@ -350,7 +350,7 @@ class Acl extends BaseModule
 					continue;
 				}
 
-				$contact = Contact::getDetailsByURL($author);
+				$contact = Contact::getByURL($author, 0, ['micro', 'name', 'id', 'network', 'nick', 'addr', 'url', 'forum'], false);
 
 				if (count($contact) > 0) {
 					$unknown_contacts[] = [

--- a/src/Module/Search/Index.php
+++ b/src/Module/Search/Index.php
@@ -237,13 +237,13 @@ class Index extends BaseSearch
 		} else {
 			// Cheaper local lookup for anonymous users, no probe
 			if ($isAddr) {
-				$contact = Contact::selectFirst(['id' => 'cid'], ['addr' => $search, 'uid' => 0]);
+				$contact = Contact::selectFirst(['id'], ['addr' => $search, 'uid' => 0]);
 			} else {
-				$contact = Contact::getDetailsByURL($search, 0, ['cid' => 0]);
+				$contact = array_merge(['id' => 0], Contact::getByURL($search, 0, ['id']));
 			}
 
 			if (DBA::isResult($contact)) {
-				$contact_id = $contact['cid'];
+				$contact_id = $contact['id'];
 			}
 		}
 

--- a/src/Module/Search/Index.php
+++ b/src/Module/Search/Index.php
@@ -239,7 +239,7 @@ class Index extends BaseSearch
 			if ($isAddr) {
 				$contact = Contact::selectFirst(['id'], ['addr' => $search, 'uid' => 0]);
 			} else {
-				$contact = array_merge(['id' => 0], Contact::getByURL($search, 0, ['id']));
+				$contact = array_merge(['id' => 0], Contact::getByURL($search, null, ['id']));
 			}
 
 			if (DBA::isResult($contact)) {

--- a/src/Object/Post.php
+++ b/src/Object/Post.php
@@ -877,7 +877,7 @@ class Post
 
 		$terms = Tag::getByURIId($item['uri-id'], [Tag::MENTION, Tag::IMPLICIT_MENTION, Tag::EXCLUSIVE_MENTION]);
 		foreach ($terms as $term) {
-			$profile = Contact::getByURL($term['url'], 0, ['addr', 'contact-type'], false);
+			$profile = Contact::getByURL($term['url'], false, ['addr', 'contact-type']);
 			if (!empty($profile['addr']) && ((($profile['contact-type'] ?? '') ?: Contact::TYPE_UNKNOWN) != Contact::TYPE_COMMUNITY) &&
 				($profile['addr'] != $owner['addr']) && !strstr($text, $profile['addr'])) {
 				$text .= '@' . $profile['addr'] . ' ';

--- a/src/Object/Post.php
+++ b/src/Object/Post.php
@@ -877,7 +877,7 @@ class Post
 
 		$terms = Tag::getByURIId($item['uri-id'], [Tag::MENTION, Tag::IMPLICIT_MENTION, Tag::EXCLUSIVE_MENTION]);
 		foreach ($terms as $term) {
-			$profile = Contact::getDetailsByURL($term['url']);
+			$profile = Contact::getByURL($term['url'], 0, ['addr', 'contact-type'], false);
 			if (!empty($profile['addr']) && ((($profile['contact-type'] ?? '') ?: Contact::TYPE_UNKNOWN) != Contact::TYPE_COMMUNITY) &&
 				($profile['addr'] != $owner['addr']) && !strstr($text, $profile['addr'])) {
 				$text .= '@' . $profile['addr'] . ' ';

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -987,7 +987,7 @@ class Processor
 	{
 		$parent_terms = Tag::getByURIId($parent['uri-id'], [Tag::MENTION, Tag::IMPLICIT_MENTION, Tag::EXCLUSIVE_MENTION]);
 
-		$parent_author = Contact::getDetailsByURL($parent['author-link'], 0);
+		$parent_author = Contact::getByURL($parent['author-link'], 0, ['url', 'nurl', 'alias'], false);
 
 		$implicit_mentions = [];
 		if (empty($parent_author['url'])) {
@@ -1003,7 +1003,7 @@ class Processor
 		}
 
 		foreach ($parent_terms as $term) {
-			$contact = Contact::getDetailsByURL($term['url'], 0);
+			$contact = Contact::getByURL($term['url'], 0, ['url', 'nurl', 'alias'], false);
 			if (!empty($contact['url'])) {
 				$implicit_mentions[] = $contact['url'];
 				$implicit_mentions[] = $contact['nurl'];

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -987,7 +987,7 @@ class Processor
 	{
 		$parent_terms = Tag::getByURIId($parent['uri-id'], [Tag::MENTION, Tag::IMPLICIT_MENTION, Tag::EXCLUSIVE_MENTION]);
 
-		$parent_author = Contact::getByURL($parent['author-link'], 0, ['url', 'nurl', 'alias'], false);
+		$parent_author = Contact::getByURL($parent['author-link'], false, ['url', 'nurl', 'alias']);
 
 		$implicit_mentions = [];
 		if (empty($parent_author['url'])) {
@@ -1003,7 +1003,7 @@ class Processor
 		}
 
 		foreach ($parent_terms as $term) {
-			$contact = Contact::getByURL($term['url'], 0, ['url', 'nurl', 'alias'], false);
+			$contact = Contact::getByURL($term['url'], false, ['url', 'nurl', 'alias']);
 			if (!empty($contact['url'])) {
 				$implicit_mentions[] = $contact['url'];
 				$implicit_mentions[] = $contact['nurl'];

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -1008,7 +1008,7 @@ class Transmitter
 				$url = DI::baseUrl() . '/search?tag=' . urlencode($term['name']);
 				$tags[] = ['type' => 'Hashtag', 'href' => $url, 'name' => '#' . $term['name']];
 			} else {
-				$contact = Contact::getByURL($term['url'], 0, ['addr'], false);
+				$contact = Contact::getByURL($term['url'], false, ['addr']);
 				if (!empty($contact['addr'])) {
 					$mention = '@' . $contact['addr'];
 				} else {
@@ -1141,7 +1141,7 @@ class Transmitter
 			return '';
 		}
 
-		$data = Contact::getByURL($match[1], 0, ['url', 'nick'], false);
+		$data = Contact::getByURL($match[1], false, ['url', 'nick']);
 		if (empty($data['nick'])) {
 			return $match[0];
 		}
@@ -1861,7 +1861,7 @@ class Transmitter
 		$mentions = [];
 
 		foreach (Tag::getByURIId($uriid, [Tag::IMPLICIT_MENTION]) as $tag) {
-			$profile = Contact::getByURL($tag['url'], 0, ['addr', 'contact-type', 'nick'], false);
+			$profile = Contact::getByURL($tag['url'], false, ['addr', 'contact-type', 'nick']);
 			if (!empty($profile['addr'])
 				&& $profile['contact-type'] != Contact::TYPE_COMMUNITY
 				&& !strstr($body, $profile['addr'])

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -1008,7 +1008,7 @@ class Transmitter
 				$url = DI::baseUrl() . '/search?tag=' . urlencode($term['name']);
 				$tags[] = ['type' => 'Hashtag', 'href' => $url, 'name' => '#' . $term['name']];
 			} else {
-				$contact = Contact::getDetailsByURL($term['url']);
+				$contact = Contact::getByURL($term['url'], 0, ['addr'], false);
 				if (!empty($contact['addr'])) {
 					$mention = '@' . $contact['addr'];
 				} else {
@@ -1141,7 +1141,7 @@ class Transmitter
 			return '';
 		}
 
-		$data = Contact::getDetailsByURL($match[1]);
+		$data = Contact::getByURL($match[1], 0, ['url', 'nick'], false);
 		if (empty($data['nick'])) {
 			return $match[0];
 		}
@@ -1861,7 +1861,7 @@ class Transmitter
 		$mentions = [];
 
 		foreach (Tag::getByURIId($uriid, [Tag::IMPLICIT_MENTION]) as $tag) {
-			$profile = Contact::getDetailsByURL($tag['url']);
+			$profile = Contact::getByURL($tag['url'], 0, ['addr', 'contact-type', 'nick'], false);
 			if (!empty($profile['addr'])
 				&& $profile['contact-type'] != Contact::TYPE_COMMUNITY
 				&& !strstr($body, $profile['addr'])

--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -755,7 +755,7 @@ class DFRN
 	{
 		$author = $doc->createElement($element);
 
-		$contact = Contact::getByURLForUser($contact_url, $item["uid"], ['url', 'name', 'addr', 'photo']);
+		$contact = Contact::getByURLForUser($contact_url, $item["uid"], null, ['url', 'name', 'addr', 'photo']);
 		if (!empty($contact)) {
 			XML::addElement($doc, $author, "name", $contact["name"]);
 			XML::addElement($doc, $author, "uri", $contact["url"]);

--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -755,7 +755,7 @@ class DFRN
 	{
 		$author = $doc->createElement($element);
 
-		$contact = Contact::getByURLForUser($contact_url, $item["uid"], null, ['url', 'name', 'addr', 'photo']);
+		$contact = Contact::getByURLForUser($contact_url, $item["uid"], false, ['url', 'name', 'addr', 'photo']);
 		if (!empty($contact)) {
 			XML::addElement($doc, $author, "name", $contact["name"]);
 			XML::addElement($doc, $author, "uri", $contact["url"]);

--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -755,7 +755,7 @@ class DFRN
 	{
 		$author = $doc->createElement($element);
 
-		$contact = Contact::getDetailsByURL($contact_url, $item["uid"]);
+		$contact = Contact::getByURLForUser($contact_url, $item["uid"], ['url', 'name', 'addr', 'photo']);
 		if (!empty($contact)) {
 			XML::addElement($doc, $author, "name", $contact["name"]);
 			XML::addElement($doc, $author, "uri", $contact["url"]);

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -1568,7 +1568,7 @@ class Diaspora
 	 */
 	private static function plink($addr, $guid, $parent_guid = '')
 	{
-		$contact = Contact::getDetailsByAddr($addr);
+		$contact = Contact::getByURL($addr);
 		if (empty($contact)) {
 			Logger::info('No contact data for address', ['addr' => $addr]);
 			return '';
@@ -3729,7 +3729,7 @@ class Diaspora
 
 	private static function prependParentAuthorMention($body, $profile_url)
 	{
-		$profile = Contact::getDetailsByURL($profile_url);
+		$profile = Contact::getByURL($profile_url, 0, ['addr', 'name', 'contact-type'], false);
 		if (!empty($profile['addr'])
 			&& $profile['contact-type'] != Contact::TYPE_COMMUNITY
 			&& !strstr($body, $profile['addr'])

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -3729,7 +3729,7 @@ class Diaspora
 
 	private static function prependParentAuthorMention($body, $profile_url)
 	{
-		$profile = Contact::getByURL($profile_url, 0, ['addr', 'name', 'contact-type'], false);
+		$profile = Contact::getByURL($profile_url, false, ['addr', 'name', 'contact-type']);
 		if (!empty($profile['addr'])
 			&& $profile['contact-type'] != Contact::TYPE_COMMUNITY
 			&& !strstr($body, $profile['addr'])

--- a/src/Protocol/OStatus.php
+++ b/src/Protocol/OStatus.php
@@ -2105,7 +2105,7 @@ class OStatus
 			$mentioned = $newmentions;
 
 			foreach ($mentioned as $mention) {
-				$contact = Contact::getByURL($mention, 0, ['contact-type']);
+				$contact = Contact::getByURL($mention, ['contact-type']);
 				if (!empty($contact) && ($contact['contact-type'] == Contact::TYPE_COMMUNITY)) {
 					XML::addElement($doc, $entry, "link", "",
 						[

--- a/src/Util/Profiler.php
+++ b/src/Util/Profiler.php
@@ -177,7 +177,7 @@ class Profiler implements ContainerInterface
 			$output .= "\nDatabase Read:\n";
 			foreach ($this->callstack["database"] as $func => $time) {
 				$time = round($time, 3);
-				if ($time > 0) {
+				if ($time > 0.001) {
 					$output .= $func . ": " . $time . "\n";
 				}
 			}


### PR DESCRIPTION
The functions `getDetailsByAddr` and `getDetailsByURL` are now replaced by the functions `getByURL` and `getByURLForUser`. These are more leaner functions that are based on the function `getIdForURL`.

The difference between `getByURL` and `getByURLForUser` is that `getByURLForUser` will try to fetch the public contact when no contact had been found for the given user, while `getByURL` will return an empty array if no contact had been found for a user.