### PR TITLE
Use PageInfo::appendDataToBody in ActivityPub\Processor::constructAttachList

### DIFF
--- a/src/Content/PageInfo.php
+++ b/src/Content/PageInfo.php
@@ -49,14 +49,34 @@ class PageInfo
 			return $body;
 		}
 
-		$footer = self::getFooterFromUrl($url, $no_photos);
-		if (!$footer) {
+		$data = self::queryUrl($url);
+		if (!$data) {
 			return $body;
 		}
 
-		$body = self::stripTrailingUrlFromBody($body, $url);
+		return self::appendDataToBody($body, $data, $no_photos);
+	}
 
-		$body .= "\n" . $footer;
+	/**
+	 * @param string $body
+	 * @param array  $data
+	 * @param bool   $no_photos
+	 * @return string
+	 * @throws HTTPException\InternalServerErrorException
+	 */
+	public static function appendDataToBody(string $body, array $data, bool $no_photos = false)
+	{
+		// Only one [attachment] tag per body is allowed
+		$existingAttachmentPos = strpos($body, '[attachment');
+		if ($existingAttachmentPos !== false) {
+			$linkTitle = $data['title'] ?: $data['url'];
+			// Additional link attachments are prepended before the existing [attachment] tag
+			$body = substr_replace($body, "\n[bookmark=" . $data['url'] . ']' . $linkTitle . "[/bookmark]\n", $existingAttachmentPos, 0);
+		} else {
+			$footer = PageInfo::getFooterFromData($data, $no_photos);
+			$body = self::stripTrailingUrlFromBody($body, $data['url']);
+			$body .= "\n" . $footer;
+		}
 
 		return $body;
 	}

--- a/src/Content/PageInfo.php
+++ b/src/Content/PageInfo.php
@@ -40,7 +40,7 @@ class PageInfo
 	 * @return string
 	 * @throws HTTPException\InternalServerErrorException
 	 */
-	public static function appendToBody(string $body, bool $searchNakedUrls = false, bool $no_photos = false)
+	public static function searchAndAppendToBody(string $body, bool $searchNakedUrls = false, bool $no_photos = false)
 	{
 		Logger::info('add_page_info_to_body: fetch page info for body', ['body' => $body]);
 

--- a/src/Module/Debug/Babel.php
+++ b/src/Module/Debug/Babel.php
@@ -115,7 +115,7 @@ class Babel extends BaseModule
 						'content' => visible_whitespace(var_export($tags, true)),
 					];
 
-					$body2 = PageInfo::appendToBody($bbcode, true);
+					$body2 = PageInfo::searchAndAppendToBody($bbcode, true);
 					$results[] = [
 						'title'   => DI::l10n()->t('PageInfo::appendToBody'),
 						'content' => visible_whitespace($body2)

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -2622,7 +2622,7 @@ class Diaspora
 				$item["body"] = self::replacePeopleGuid($item["body"], $item["author-link"]);
 
 				// Add OEmbed and other information to the body
-				$item["body"] = PageInfo::appendToBody($item["body"], false, true);
+				$item["body"] = PageInfo::searchAndAppendToBody($item["body"], false, true);
 
 				return $item;
 			} else {
@@ -2986,7 +2986,7 @@ class Diaspora
 
 			// Add OEmbed and other information to the body
 			if (!self::isHubzilla($contact["url"])) {
-				$body = PageInfo::appendToBody($body, false, true);
+				$body = PageInfo::searchAndAppendToBody($body, false, true);
 			}
 		}
 

--- a/src/Protocol/OStatus.php
+++ b/src/Protocol/OStatus.php
@@ -698,7 +698,7 @@ class OStatus
 
 		// Only add additional data when there is no picture in the post
 		if (!strstr($item["body"], '[/img]')) {
-			$item["body"] = PageInfo::appendToBody($item["body"]);
+			$item["body"] = PageInfo::searchAndAppendToBody($item["body"]);
 		}
 
 		Tag::storeFromBody($item['uri-id'], $item['body']);

--- a/src/Util/ParseUrl.php
+++ b/src/Util/ParseUrl.php
@@ -55,14 +55,13 @@ class ParseUrl
 	 *                            to avoid endless loops
 	 *
 	 * @return array which contains needed data for embedding
-	 *    string 'url' => The url of the parsed page
-	 *    string 'type' => Content type
-	 *    string 'title' => The title of the content
-	 *    string 'text' => The description for the content
-	 *    string 'image' => A preview image of the content (only available
-	 *                if $no_geuessing = false
-	 *    array'images' = Array of preview pictures
-	 *    string 'keywords' => The tags which belong to the content
+	 *    string 'url'      => The url of the parsed page
+	 *    string 'type'     => Content type
+	 *    string 'title'    => (optional) The title of the content
+	 *    string 'text'     => (optional) The description for the content
+	 *    string 'image'    => (optional) A preview image of the content (only available if $no_geuessing = false)
+	 *    array  'images'   => (optional) Array of preview pictures
+	 *    string 'keywords' => (optional) The tags which belong to the content
 	 *
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 * @see   ParseUrl::getSiteinfo() for more information about scraping
@@ -115,14 +114,13 @@ class ParseUrl
 	 * @param int    $count       Internal counter to avoid endless loops
 	 *
 	 * @return array which contains needed data for embedding
-	 *    string 'url' => The url of the parsed page
-	 *    string 'type' => Content type
-	 *    string 'title' => The title of the content
-	 *    string 'text' => The description for the content
-	 *    string 'image' => A preview image of the content (only available
-	 *                if $no_geuessing = false
-	 *    array'images' = Array of preview pictures
-	 *    string 'keywords' => The tags which belong to the content
+	 *    string 'url'      => The url of the parsed page
+	 *    string 'type'     => Content type
+	 *    string 'title'    => (optional) The title of the content
+	 *    string 'text'     => (optional) The description for the content
+	 *    string 'image'    => (optional) A preview image of the content (only available if $no_guessing = false)
+	 *    array  'images'   => (optional) Array of preview pictures
+	 *    string 'keywords' => (optional) The tags which belong to the content
 	 *
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 * @todo  https://developers.google.com/+/plugins/snippet/
@@ -140,27 +138,26 @@ class ParseUrl
 	 */
 	public static function getSiteinfo($url, $no_guessing = false, $do_oembed = true, $count = 1)
 	{
-		$siteinfo = [];
-
 		// Check if the URL does contain a scheme
 		$scheme = parse_url($url, PHP_URL_SCHEME);
 
 		if ($scheme == '') {
-			$url = 'http://' . trim($url, '/');
+			$url = 'http://' . ltrim($url, '/');
 		}
+
+		$url = trim($url, "'\"");
+
+		$url = Network::stripTrackingQueryParams($url);
+
+		$siteinfo = [
+			'url' => $url,
+			'type' => 'link',
+		];
 
 		if ($count > 10) {
 			Logger::log('Endless loop detected for ' . $url, Logger::DEBUG);
 			return $siteinfo;
 		}
-
-		$url = trim($url, "'");
-		$url = trim($url, '"');
-
-		$url = Network::stripTrackingQueryParams($url);
-
-		$siteinfo['url'] = $url;
-		$siteinfo['type'] = 'link';
 
 		$curlResult = Network::curl($url);
 		if (!$curlResult->isSuccess()) {


### PR DESCRIPTION
Closes #8788 
Part of #8797 

This PR unifies the way we handle attached PageInfo to item body by using the same process for ActivityPub than for other protocols.