### PR TITLE
Support newline as block contact separator

### DIFF
--- a/include/conversation.php
+++ b/include/conversation.php
@@ -316,7 +316,7 @@ function conv_get_blocklist()
 		return [];
 	}
 
-	$str_blocked = DI::pConfig()->get(local_user(), 'system', 'blocked');
+	$str_blocked = str_replace(["\n", "\r"], ",", DI::pConfig()->get(local_user(), 'system', 'blocked'));
 	if (empty($str_blocked)) {
 		return [];
 	}


### PR DESCRIPTION
Contacts for the block list should be separated with a comma. But people could possibly had used a linefeed as well. (like happened on my server).