### PR TITLE
added CSV import/export of server blocklist

### DIFF
--- a/src/Console/ServerBlock.php
+++ b/src/Console/ServerBlock.php
@@ -144,12 +144,12 @@ HELP;
 				];
 				if (!in_array($data, $newBlockList)) {
 					$newBlockList[] = $data;
-                }
+				}
 			}
 			foreach ($currBlockList as $blocked) {
 				if (!in_array($blocked, $newBlockList)) {
 					$newBlockList[] = $blocked;
-                }
+				}
 			}
 			if ($config->set('system', 'blocklist', $newBlockList)) {
 				$this->out(sprintf("Entries from %s that were not blocked before are now blocked", $filename));

--- a/src/Console/ServerBlock.php
+++ b/src/Console/ServerBlock.php
@@ -68,7 +68,6 @@ Description
 Options
     -h|--help|-? Show help information
     -v           Show more debug information.
-
 HELP;
 		return $help;
 	}

--- a/src/Console/ServerBlock.php
+++ b/src/Console/ServerBlock.php
@@ -112,6 +112,9 @@ HELP;
 		$filename = $this->getArgument(1);
 		$blocklist = $config->get('system', 'blocklist', []);
 		$fp = fopen($filename, 'w');
+		if (!$fp) {
+			throw new Exception(sprintf('The file "%s" could not be created.', $filename));
+		}
 		foreach ($blocklist as $domain) {
 			fputcsv($fp, $domain);
 		}
@@ -156,6 +159,8 @@ HELP;
 				return 1;
 			}
 
+		} else {
+			throw new Exception(sprintf('The file "%s" could not be opened for importing', $filename));
 		}
 	}
 

--- a/src/Console/ServerBlock.php
+++ b/src/Console/ServerBlock.php
@@ -67,7 +67,7 @@ Description
 
 Options
 	-h|--help|-? Show help information
-	-v		   Show more debug information.
+	-v           Show more debug information.
 HELP;
 		return $help;
 	}

--- a/src/Console/ServerBlock.php
+++ b/src/Console/ServerBlock.php
@@ -48,26 +48,27 @@ class ServerBlock extends Console
 		$help = <<<HELP
 console serverblock - Manage blocked server domain patterns
 Usage
-	bin/console serverblock [-h|--help|-?] [-v]
-	bin/console serverblock add <pattern> <reason> [-h|--help|-?] [-v]
-	bin/console serverblock remove <pattern> [-h|--help|-?] [-v]
-	bin/console serverblock export <filename>
-	bin/console serverblock import <filename>
+    bin/console serverblock [-h|--help|-?] [-v]
+    bin/console serverblock add <pattern> <reason> [-h|--help|-?] [-v]
+    bin/console serverblock remove <pattern> [-h|--help|-?] [-v]
+    bin/console serverblock export <filename>
+    bin/console serverblock import <filename>
 
 Description
-	With this tool, you can list the current blocked server domain patterns
-	or you can add / remove a blocked server domain pattern from the list.
-	Using the export and import options you can share your server blocklist
-	with other node admins by CSV files.
-	
-	Patterns are case-insensitive shell wildcard comprising the following special characters:
-	- * : Any number of characters
-	- ? : Any single character
-	- [<char1><char2>...] : char1 or char2 or...
+    With this tool, you can list the current blocked server domain patterns
+    or you can add / remove a blocked server domain pattern from the list.
+    Using the export and import options you can share your server blocklist
+    with other node admins by CSV files.
+
+    Patterns are case-insensitive shell wildcard comprising the following special characters:
+    - * : Any number of characters
+    - ? : Any single character
+    - [<char1><char2>...] : char1 or char2 or...
 
 Options
-	-h|--help|-? Show help information
-	-v           Show more debug information.
+    -h|--help|-? Show help information
+    -v           Show more debug information.
+
 HELP;
 		return $help;
 	}

--- a/src/Console/ServerBlock.php
+++ b/src/Console/ServerBlock.php
@@ -127,10 +127,10 @@ HELP;
 		$filename = $this->getArgument(1);
 		$currBlockList = $config->get('system', 'blocklist', []);
 		$newBlockList = [];
-		if (($fp = fopen($filename, 'r')) !== FALSE) {
-			while (($data = fgetcsv($fp, 1000, ',')) !== FALSE) {
+		if (($fp = fopen($filename, 'r')) !== false) {
+			while (($data = fgetcsv($fp, 1000, ',')) !== false) {
 				$domain = $data[0];
-				if (count($data)  == 0) {
+				if (count($data) == 0) {
 					$reason = self::DEFAULT_REASON;
 				} else {
 					$reason = $data[1];
@@ -139,12 +139,14 @@ HELP;
 					'domain' => $domain,
 					'reason' => $reason
 				];
-				if (!in_array($data, $newBlockList))
+				if (!in_array($data, $newBlockList)) {
 					$newBlockList[] = $data;
+                }
 			}
 			foreach ($currBlockList as $blocked) {
-				if (!in_array($blocked, $newBlockList))
+				if (!in_array($blocked, $newBlockList)) {
 					$newBlockList[] = $blocked;
+                }
 			}
 			if ($config->set('system', 'blocklist', $newBlockList)) {
 				$this->out(sprintf("Entries from %s that were not blocked before are now blocked", $filename));

--- a/tests/src/Console/ServerBlockConsoleTest.php
+++ b/tests/src/Console/ServerBlockConsoleTest.php
@@ -334,14 +334,18 @@ CONS;
 		$help = <<<HELP
 console serverblock - Manage blocked server domain patterns
 Usage
-	bin/console serverblock [-h|--help|-?] [-v]
-	bin/console serverblock add <pattern> <reason> [-h|--help|-?] [-v]
-	bin/console serverblock remove <pattern> [-h|--help|-?] [-v]
+    bin/console serverblock [-h|--help|-?] [-v]
+    bin/console serverblock add <pattern> <reason> [-h|--help|-?] [-v]
+    bin/console serverblock remove <pattern> [-h|--help|-?] [-v]
+    bin/console serverblock export <filename>
+    bin/console serverblock import <filename>
 
 Description
-	With this tool, you can list the current blocked server domain patterns
+    With this tool, you can list the current blocked server domain patterns
     or you can add / remove a blocked server domain pattern from the list.
-    
+    Using the export and import options you can share your server blocklist
+    with other node admins by CSV files.
+
     Patterns are case-insensitive shell wildcard comprising the following special characters:
     - * : Any number of characters
     - ? : Any single character


### PR DESCRIPTION
This PR adds two new subcommands to the console command `serverblock` that can be used by the node admin to import and export the nodes server blocklist from/to a CSV file.

```
bin/console serverblock import test.csv
bin/console serverblock export test.csv
```

Part of #8881