### PR TITLE
ActivityPub: Add support for multiple Link as urls of Images attachments

### DIFF
--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -115,10 +115,22 @@ class Processor
 							continue 2;
 						}
 
+						$item['body'] .= "\n";
+
+						// image is the preview/thumbnail URL
+						if (!empty($attach['image'])) {
+							$item['body'] .= '[url=' . $attach['url'] . ']';
+							$attach['url'] = $attach['image'];
+						}
+
 						if (empty($attach['name'])) {
-							$item['body'] .= "\n[img]" . $attach['url'] . '[/img]';
+							$item['body'] .= '[img]' . $attach['url'] . '[/img]';
 						} else {
-							$item['body'] .= "\n[img=" . $attach['url'] . ']' . $attach['name'] . '[/img]';
+							$item['body'] .= '[img=' . $attach['url'] . ']' . $attach['name'] . '[/img]';
+						}
+
+						if (!empty($attach['image'])) {
+							$item['body'] .= '[/url]';
 						}
 					} elseif ($filetype == 'audio') {
 						if (!empty($activity['source']) && strpos($activity['source'], $attach['url'])) {


### PR DESCRIPTION
Address https://github.com/friendica/friendica/issues/8676#issuecomment-650554955

This PR also adds support for preview images for image attachments since we can now discriminate between different image sizes if they are provided.