### PR TITLE
Useless info messages removed

### DIFF
--- a/mod/api.php
+++ b/mod/api.php
@@ -47,12 +47,12 @@ function oauth_get_client(OAuthRequest $request)
 function api_post(App $a)
 {
 	if (!local_user()) {
-		notice(DI::l10n()->t('Permission denied.') . EOL);
+		notice(DI::l10n()->t('Permission denied.'));
 		return;
 	}
 
 	if (count($a->user) && !empty($a->user['uid']) && $a->user['uid'] != local_user()) {
-		notice(DI::l10n()->t('Permission denied.') . EOL);
+		notice(DI::l10n()->t('Permission denied.'));
 		return;
 	}
 }
@@ -107,7 +107,7 @@ function api_content(App $a)
 
 		if (!local_user()) {
 			/// @TODO We need login form to redirect to this page
-			notice(DI::l10n()->t('Please login to continue.') . EOL);
+			notice(DI::l10n()->t('Please login to continue.'));
 			return Login::form(DI::args()->getQueryString(), false, $request->get_parameters());
 		}
 		//FKOAuth1::loginUser(4);

--- a/mod/cal.php
+++ b/mod/cal.php
@@ -134,7 +134,7 @@ function cal_content(App $a)
 	$is_owner = local_user() == $a->profile['uid'];
 
 	if ($a->profile['hidewall'] && !$is_owner && !$remote_contact) {
-		notice(DI::l10n()->t('Access to this profile has been restricted.') . EOL);
+		notice(DI::l10n()->t('Access to this profile has been restricted.'));
 		return;
 	}
 

--- a/mod/common.php
+++ b/mod/common.php
@@ -40,7 +40,7 @@ function common_content(App $a)
 	$zcid = 0;
 
 	if (!local_user()) {
-		notice(DI::l10n()->t('Permission denied.') . EOL);
+		notice(DI::l10n()->t('Permission denied.'));
 		return;
 	}
 
@@ -103,7 +103,7 @@ function common_content(App $a)
 	}
 
 	if ($total < 1) {
-		notice(DI::l10n()->t('No contacts in common.') . EOL);
+		notice(DI::l10n()->t('No contacts in common.'));
 		return $o;
 	}
 

--- a/mod/dfrn_confirm.php
+++ b/mod/dfrn_confirm.php
@@ -76,13 +76,13 @@ function dfrn_confirm_post(App $a, $handsfree = null)
 	if (empty($_POST['source_url'])) {
 		$uid = ($handsfree['uid'] ?? 0) ?: local_user();
 		if (!$uid) {
-			notice(DI::l10n()->t('Permission denied.') . EOL);
+			notice(DI::l10n()->t('Permission denied.'));
 			return;
 		}
 
 		$user = DBA::selectFirst('user', [], ['uid' => $uid]);
 		if (!DBA::isResult($user)) {
-			notice(DI::l10n()->t('Profile not found.') . EOL);
+			notice(DI::l10n()->t('Profile not found.'));
 			return;
 		}
 
@@ -137,8 +137,8 @@ function dfrn_confirm_post(App $a, $handsfree = null)
 		);
 		if (!DBA::isResult($r)) {
 			Logger::log('Contact not found in DB.');
-			notice(DI::l10n()->t('Contact not found.') . EOL);
-			notice(DI::l10n()->t('This may occasionally happen if contact was requested by both persons and it has already been approved.') . EOL);
+			notice(DI::l10n()->t('Contact not found.'));
+			notice(DI::l10n()->t('This may occasionally happen if contact was requested by both persons and it has already been approved.'));
 			return;
 		}
 
@@ -239,20 +239,20 @@ function dfrn_confirm_post(App $a, $handsfree = null)
 			// We shouldn't proceed, because the xml parser might choke,
 			// and $status is going to be zero, which indicates success.
 			// We can hardly call this a success.
-			notice(DI::l10n()->t('Response from remote site was not understood.') . EOL);
+			notice(DI::l10n()->t('Response from remote site was not understood.'));
 			return;
 		}
 
 		if (strlen($leading_junk) && DI::config()->get('system', 'debugging')) {
 			// This might be more common. Mixed error text and some XML.
 			// If we're configured for debugging, show the text. Proceed in either case.
-			notice(DI::l10n()->t('Unexpected response from remote site: ') . EOL . $leading_junk . EOL);
+			notice(DI::l10n()->t('Unexpected response from remote site: ') . $leading_junk);
 		}
 
 		if (stristr($res, "<status") === false) {
 			// wrong xml! stop here!
 			Logger::log('Unexpected response posting to ' . $dfrn_confirm);
-			notice(DI::l10n()->t('Unexpected response from remote site: ') . EOL . htmlspecialchars($res) . EOL);
+			notice(DI::l10n()->t('Unexpected response from remote site: ') . EOL . htmlspecialchars($res));
 			return;
 		}
 
@@ -261,7 +261,7 @@ function dfrn_confirm_post(App $a, $handsfree = null)
 		$message = XML::unescape($xml->message);   // human readable text of what may have gone wrong.
 		switch ($status) {
 			case 0:
-				info(DI::l10n()->t("Confirmation completed successfully.") . EOL);
+				info(DI::l10n()->t("Confirmation completed successfully."));
 				break;
 			case 1:
 				// birthday paradox - generate new dfrn-id and fall through.
@@ -273,15 +273,15 @@ function dfrn_confirm_post(App $a, $handsfree = null)
 				);
 
 			case 2:
-				notice(DI::l10n()->t("Temporary failure. Please wait and try again.") . EOL);
+				notice(DI::l10n()->t("Temporary failure. Please wait and try again."));
 				break;
 			case 3:
-				notice(DI::l10n()->t("Introduction failed or was revoked.") . EOL);
+				notice(DI::l10n()->t("Introduction failed or was revoked."));
 				break;
 		}
 
 		if (strlen($message)) {
-			notice(DI::l10n()->t('Remote site reported: ') . $message . EOL);
+			notice(DI::l10n()->t('Remote site reported: ') . $message);
 		}
 
 		if (($status == 0) && $intro_id) {

--- a/mod/dfrn_poll.php
+++ b/mod/dfrn_poll.php
@@ -133,7 +133,7 @@ function dfrn_poll_init(App $a)
 					Session::setVisitorsContacts();
 
 					if (!$quiet) {
-						info(DI::l10n()->t('%1$s welcomes %2$s', $r[0]['username'], $r[0]['name']) . EOL);
+						info(DI::l10n()->t('%1$s welcomes %2$s', $r[0]['username'], $r[0]['name']));
 					}
 
 					// Visitors get 1 day session.
@@ -536,7 +536,7 @@ function dfrn_poll_content(App $a)
 					Session::setVisitorsContacts();
 
 					if (!$quiet) {
-						info(DI::l10n()->t('%1$s welcomes %2$s', $r[0]['username'], $r[0]['name']) . EOL);
+						info(DI::l10n()->t('%1$s welcomes %2$s', $r[0]['username'], $r[0]['name']));
 					}
 
 					// Visitors get 1 day session.

--- a/mod/dfrn_request.php
+++ b/mod/dfrn_request.php
@@ -110,7 +110,7 @@ function dfrn_request_post(App $a)
 				if (DBA::isResult($r)) {
 					if (strlen($r[0]['dfrn-id'])) {
 						// We don't need to be here. It has already happened.
-						notice(DI::l10n()->t("This introduction has already been accepted.") . EOL);
+						notice(DI::l10n()->t("This introduction has already been accepted."));
 						return;
 					} else {
 						$contact_record = $r[0];
@@ -128,18 +128,18 @@ function dfrn_request_post(App $a)
 					$parms = Probe::profile($dfrn_url);
 
 					if (!count($parms)) {
-						notice(DI::l10n()->t('Profile location is not valid or does not contain profile information.') . EOL);
+						notice(DI::l10n()->t('Profile location is not valid or does not contain profile information.'));
 						return;
 					} else {
 						if (empty($parms['fn'])) {
-							notice(DI::l10n()->t('Warning: profile location has no identifiable owner name.') . EOL);
+							notice(DI::l10n()->t('Warning: profile location has no identifiable owner name.'));
 						}
 						if (empty($parms['photo'])) {
-							notice(DI::l10n()->t('Warning: profile location has no profile photo.') . EOL);
+							notice(DI::l10n()->t('Warning: profile location has no profile photo.'));
 						}
 						$invalid = Probe::validDfrn($parms);
 						if ($invalid) {
-							notice(DI::l10n()->tt("%d required parameter was not found at the given location", "%d required parameters were not found at the given location", $invalid) . EOL);
+							notice(DI::l10n()->tt("%d required parameter was not found at the given location", "%d required parameters were not found at the given location", $invalid));
 							return;
 						}
 					}
@@ -177,7 +177,7 @@ function dfrn_request_post(App $a)
 				}
 
 				if ($r) {
-					info(DI::l10n()->t("Introduction complete.") . EOL);
+					info(DI::l10n()->t("Introduction complete."));
 				}
 
 				$r = q("SELECT `id`, `network` FROM `contact` WHERE `uid` = %d AND `url` = '%s' AND `site-pubkey` = '%s' LIMIT 1",
@@ -213,7 +213,7 @@ function dfrn_request_post(App $a)
 		}
 
 		// invalid/bogus request
-		notice(DI::l10n()->t('Unrecoverable protocol error.') . EOL);
+		notice(DI::l10n()->t('Unrecoverable protocol error.'));
 		DI::baseUrl()->redirect();
 		return; // NOTREACHED
 	}
@@ -240,7 +240,7 @@ function dfrn_request_post(App $a)
 	 *
 	 */
 	if (empty($a->profile['uid'])) {
-		notice(DI::l10n()->t('Profile unavailable.') . EOL);
+		notice(DI::l10n()->t('Profile unavailable.'));
 		return;
 	}
 
@@ -261,9 +261,9 @@ function dfrn_request_post(App $a)
 				intval($uid)
 			);
 			if (DBA::isResult($r) && count($r) > $maxreq) {
-				notice(DI::l10n()->t('%s has received too many connection requests today.', $a->profile['name']) . EOL);
-				notice(DI::l10n()->t('Spam protection measures have been invoked.') . EOL);
-				notice(DI::l10n()->t('Friends are advised to please try again in 24 hours.') . EOL);
+				notice(DI::l10n()->t('%s has received too many connection requests today.', $a->profile['name']));
+				notice(DI::l10n()->t('Spam protection measures have been invoked.'));
+				notice(DI::l10n()->t('Friends are advised to please try again in 24 hours.'));
 				return;
 			}
 		}
@@ -287,7 +287,7 @@ function dfrn_request_post(App $a)
 
 		$url = trim($_POST['dfrn_url']);
 		if (!strlen($url)) {
-			notice(DI::l10n()->t("Invalid locator") . EOL);
+			notice(DI::l10n()->t("Invalid locator"));
 			return;
 		}
 
@@ -323,10 +323,10 @@ function dfrn_request_post(App $a)
 
 			if (DBA::isResult($ret)) {
 				if (strlen($ret[0]['issued-id'])) {
-					notice(DI::l10n()->t('You have already introduced yourself here.') . EOL);
+					notice(DI::l10n()->t('You have already introduced yourself here.'));
 					return;
 				} elseif ($ret[0]['rel'] == Contact::FRIEND) {
-					notice(DI::l10n()->t('Apparently you are already friends with %s.', $a->profile['name']) . EOL);
+					notice(DI::l10n()->t('Apparently you are already friends with %s.', $a->profile['name']));
 					return;
 				} else {
 					$contact_record = $ret[0];
@@ -346,19 +346,19 @@ function dfrn_request_post(App $a)
 			} else {
 				$url = Network::isUrlValid($url);
 				if (!$url) {
-					notice(DI::l10n()->t('Invalid profile URL.') . EOL);
+					notice(DI::l10n()->t('Invalid profile URL.'));
 					DI::baseUrl()->redirect(DI::args()->getCommand());
 					return; // NOTREACHED
 				}
 
 				if (!Network::isUrlAllowed($url)) {
-					notice(DI::l10n()->t('Disallowed profile URL.') . EOL);
+					notice(DI::l10n()->t('Disallowed profile URL.'));
 					DI::baseUrl()->redirect(DI::args()->getCommand());
 					return; // NOTREACHED
 				}
 
 				if (Network::isUrlBlocked($url)) {
-					notice(DI::l10n()->t('Blocked domain') . EOL);
+					notice(DI::l10n()->t('Blocked domain'));
 					DI::baseUrl()->redirect(DI::args()->getCommand());
 					return; // NOTREACHED
 				}
@@ -366,18 +366,18 @@ function dfrn_request_post(App $a)
 				$parms = Probe::profile(($hcard) ? $hcard : $url);
 
 				if (!count($parms)) {
-					notice(DI::l10n()->t('Profile location is not valid or does not contain profile information.') . EOL);
+					notice(DI::l10n()->t('Profile location is not valid or does not contain profile information.'));
 					DI::baseUrl()->redirect(DI::args()->getCommand());
 				} else {
 					if (empty($parms['fn'])) {
-						notice(DI::l10n()->t('Warning: profile location has no identifiable owner name.') . EOL);
+						notice(DI::l10n()->t('Warning: profile location has no identifiable owner name.'));
 					}
 					if (empty($parms['photo'])) {
-						notice(DI::l10n()->t('Warning: profile location has no profile photo.') . EOL);
+						notice(DI::l10n()->t('Warning: profile location has no profile photo.'));
 					}
 					$invalid = Probe::validDfrn($parms);
 					if ($invalid) {
-						notice(DI::l10n()->tt("%d required parameter was not found at the given location", "%d required parameters were not found at the given location", $invalid) . EOL);
+						notice(DI::l10n()->tt("%d required parameter was not found at the given location", "%d required parameters were not found at the given location", $invalid));
 
 						return;
 					}
@@ -425,7 +425,7 @@ function dfrn_request_post(App $a)
 				}
 			}
 			if ($r === false) {
-				notice(DI::l10n()->t('Failed to update contact record.') . EOL);
+				notice(DI::l10n()->t('Failed to update contact record.'));
 				return;
 			}
 
@@ -445,7 +445,7 @@ function dfrn_request_post(App $a)
 
 			// This notice will only be seen by the requestor if the requestor and requestee are on the same server.
 			if (!$failed) {
-				info(DI::l10n()->t('Your introduction has been sent.') . EOL);
+				info(DI::l10n()->t('Your introduction has been sent.'));
 			}
 
 			// "Homecoming" - send the requestor back to their site to record the introduction.
@@ -477,7 +477,7 @@ function dfrn_request_post(App $a)
 			// NOTREACHED
 			// END $network != Protocol::PHANTOM
 		} else {
-			notice(DI::l10n()->t("Remote subscription can't be done for your network. Please subscribe directly on your system.") . EOL);
+			notice(DI::l10n()->t("Remote subscription can't be done for your network. Please subscribe directly on your system."));
 			return;
 		}
 	} return;
@@ -493,7 +493,7 @@ function dfrn_request_content(App $a)
 	// to send us to the post section to record the introduction.
 	if (!empty($_GET['dfrn_url'])) {
 		if (!local_user()) {
-			info(DI::l10n()->t("Please login to confirm introduction.") . EOL);
+			info(DI::l10n()->t("Please login to confirm introduction."));
 			/* setup the return URL to come back to this page if they use openid */
 			return Login::form();
 		}
@@ -501,7 +501,7 @@ function dfrn_request_content(App $a)
 		// Edge case, but can easily happen in the wild. This person is authenticated,
 		// but not as the person who needs to deal with this request.
 		if ($a->user['nickname'] != $a->argv[1]) {
-			notice(DI::l10n()->t("Incorrect identity currently logged in. Please login to <strong>this</strong> profile.") . EOL);
+			notice(DI::l10n()->t("Incorrect identity currently logged in. Please login to <strong>this</strong> profile."));
 			return Login::form();
 		}
 
@@ -603,7 +603,7 @@ function dfrn_request_content(App $a)
 		// Normal web request. Display our user's introduction form.
 		if (DI::config()->get('system', 'block_public') && !Session::isAuthenticated()) {
 			if (!DI::config()->get('system', 'local_block')) {
-				notice(DI::l10n()->t('Public access denied.') . EOL);
+				notice(DI::l10n()->t('Public access denied.'));
 				return;
 			}
 		}

--- a/mod/editpost.php
+++ b/mod/editpost.php
@@ -35,14 +35,14 @@ function editpost_content(App $a)
 	$o = '';
 
 	if (!local_user()) {
-		notice(DI::l10n()->t('Permission denied.') . EOL);
+		notice(DI::l10n()->t('Permission denied.'));
 		return;
 	}
 
 	$post_id = (($a->argc > 1) ? intval($a->argv[1]) : 0);
 
 	if (!$post_id) {
-		notice(DI::l10n()->t('Item not found') . EOL);
+		notice(DI::l10n()->t('Item not found'));
 		return;
 	}
 
@@ -52,7 +52,7 @@ function editpost_content(App $a)
 	$item = Item::selectFirstForUser(local_user(), $fields, ['id' => $post_id, 'uid' => local_user()]);
 
 	if (!DBA::isResult($item)) {
-		notice(DI::l10n()->t('Item not found') . EOL);
+		notice(DI::l10n()->t('Item not found'));
 		return;
 	}
 

--- a/mod/events.php
+++ b/mod/events.php
@@ -584,8 +584,6 @@ function events_content(App $a)
 
 		if (Item::exists(['id' => $ev[0]['itemid']])) {
 			notice(DI::l10n()->t('Failed to remove event') . EOL);
-		} else {
-			info(DI::l10n()->t('Event removed') . EOL);
 		}
 
 		DI::baseUrl()->redirect('events');

--- a/mod/events.php
+++ b/mod/events.php
@@ -132,7 +132,7 @@ function events_post(App $a)
 	$onerror_path = 'events/' . $action . '?' . http_build_query($params, null, null, PHP_QUERY_RFC3986);
 
 	if (strcmp($finish, $start) < 0 && !$nofinish) {
-		notice(DI::l10n()->t('Event can not end before it has started.') . EOL);
+		notice(DI::l10n()->t('Event can not end before it has started.'));
 		if (intval($_REQUEST['preview'])) {
 			echo DI::l10n()->t('Event can not end before it has started.');
 			exit();
@@ -141,7 +141,7 @@ function events_post(App $a)
 	}
 
 	if (!$summary || ($start === DBA::NULL_DATETIME)) {
-		notice(DI::l10n()->t('Event title and start time are required.') . EOL);
+		notice(DI::l10n()->t('Event title and start time are required.'));
 		if (intval($_REQUEST['preview'])) {
 			echo DI::l10n()->t('Event title and start time are required.');
 			exit();
@@ -225,7 +225,7 @@ function events_post(App $a)
 function events_content(App $a)
 {
 	if (!local_user()) {
-		notice(DI::l10n()->t('Permission denied.') . EOL);
+		notice(DI::l10n()->t('Permission denied.'));
 		return Login::form();
 	}
 
@@ -583,7 +583,7 @@ function events_content(App $a)
 		}
 
 		if (Item::exists(['id' => $ev[0]['itemid']])) {
-			notice(DI::l10n()->t('Failed to remove event') . EOL);
+			notice(DI::l10n()->t('Failed to remove event'));
 		}
 
 		DI::baseUrl()->redirect('events');

--- a/mod/follow.php
+++ b/mod/follow.php
@@ -62,7 +62,7 @@ function follow_post(App $a)
 		DI::baseUrl()->redirect('contact/' . $result['cid']);
 	}
 
-	info(DI::l10n()->t('The contact could not be added.'));
+	notice(DI::l10n()->t('The contact could not be added.'));
 
 	DI::baseUrl()->redirect($return_path);
 	// NOTREACHED

--- a/mod/item.php
+++ b/mod/item.php
@@ -333,7 +333,7 @@ function item_post(App $a) {
 				System::jsonExit(['preview' => '']);
 			}
 
-			info(DI::l10n()->t('Empty post discarded.'));
+			notice(DI::l10n()->t('Empty post discarded.'));
 			if ($return_path) {
 				DI::baseUrl()->redirect($return_path);
 			}
@@ -703,7 +703,6 @@ function item_post(App $a) {
 		// update filetags in pconfig
 		FileTag::updatePconfig($uid, $categories_old, $categories_new, 'category');
 
-		info(DI::l10n()->t('Post updated.'));
 		if ($return_path) {
 			DI::baseUrl()->redirect($return_path);
 		}
@@ -725,7 +724,7 @@ function item_post(App $a) {
 	$post_id = Item::insert($datarray);
 
 	if (!$post_id) {
-		info(DI::l10n()->t('Item wasn\'t stored.'));
+		notice(DI::l10n()->t('Item wasn\'t stored.'));
 		if ($return_path) {
 			DI::baseUrl()->redirect($return_path);
 		}
@@ -826,7 +825,6 @@ function item_post(App $a) {
 		return $post_id;
 	}
 
-	info(DI::l10n()->t('Post published.'));
 	item_post_return(DI::baseUrl(), $api_source, $return_path);
 	// NOTREACHED
 }

--- a/mod/item.php
+++ b/mod/item.php
@@ -888,7 +888,7 @@ function drop_item(int $id, string $return = '')
 	$item = Item::selectFirstForUser(local_user(), $fields, ['id' => $id]);
 
 	if (!DBA::isResult($item)) {
-		notice(DI::l10n()->t('Item not found.') . EOL);
+		notice(DI::l10n()->t('Item not found.'));
 		DI::baseUrl()->redirect('network');
 	}
 

--- a/mod/lostpass.php
+++ b/mod/lostpass.php
@@ -37,7 +37,7 @@ function lostpass_post(App $a)
 	$condition = ['(`email` = ? OR `nickname` = ?) AND `verified` = 1 AND `blocked` = 0', $loginame, $loginame];
 	$user = DBA::selectFirst('user', ['uid', 'username', 'nickname', 'email', 'language'], $condition);
 	if (!DBA::isResult($user)) {
-		notice(DI::l10n()->t('No valid account found.') . EOL);
+		notice(DI::l10n()->t('No valid account found.'));
 		DI::baseUrl()->redirect();
 	}
 
@@ -49,7 +49,7 @@ function lostpass_post(App $a)
 	];
 	$result = DBA::update('user', $fields, ['uid' => $user['uid']]);
 	if ($result) {
-		info(DI::l10n()->t('Password reset request issued. Check your email.') . EOL);
+		info(DI::l10n()->t('Password reset request issued. Check your email.'));
 	}
 
 	$sitename = DI::config()->get('config', 'sitename');
@@ -152,7 +152,7 @@ function lostpass_generate_password($user)
 			'$newpass' => $new_password,
 		]);
 
-		info("Your password has been reset." . EOL);
+		info("Your password has been reset.");
 
 		$sitename = DI::config()->get('config', 'sitename');
 		$preamble = Strings::deindent(DI::l10n()->t('

--- a/mod/lostpass.php
+++ b/mod/lostpass.php
@@ -152,7 +152,7 @@ function lostpass_generate_password($user)
 			'$newpass' => $new_password,
 		]);
 
-		info("Your password has been reset.");
+		info(DI::l10n()->t("Your password has been reset."));
 
 		$sitename = DI::config()->get('config', 'sitename');
 		$preamble = Strings::deindent(DI::l10n()->t('

--- a/mod/match.php
+++ b/mod/match.php
@@ -60,7 +60,7 @@ function match_content(App $a)
 		return '';
 	}
 	if (!$profile['pub_keywords'] && (!$profile['prv_keywords'])) {
-		notice(DI::l10n()->t('No keywords to match. Please add keywords to your profile.') . EOL);
+		notice(DI::l10n()->t('No keywords to match. Please add keywords to your profile.'));
 		return '';
 	}
 
@@ -141,7 +141,7 @@ function match_content(App $a)
 	}
 
 	if (empty($entries)) {
-		info(DI::l10n()->t('No matches') . EOL);
+		info(DI::l10n()->t('No matches'));
 	}
 
 	$tpl = Renderer::getMarkupTemplate('viewcontact_template.tpl');

--- a/mod/message.php
+++ b/mod/message.php
@@ -68,7 +68,7 @@ function message_init(App $a)
 function message_post(App $a)
 {
 	if (!local_user()) {
-		notice(DI::l10n()->t('Permission denied.') . EOL);
+		notice(DI::l10n()->t('Permission denied.'));
 		return;
 	}
 
@@ -82,17 +82,17 @@ function message_post(App $a)
 
 	switch ($ret) {
 		case -1:
-			notice(DI::l10n()->t('No recipient selected.') . EOL);
+			notice(DI::l10n()->t('No recipient selected.'));
 			$norecip = true;
 			break;
 		case -2:
-			notice(DI::l10n()->t('Unable to locate contact information.') . EOL);
+			notice(DI::l10n()->t('Unable to locate contact information.'));
 			break;
 		case -3:
-			notice(DI::l10n()->t('Message could not be sent.') . EOL);
+			notice(DI::l10n()->t('Message could not be sent.'));
 			break;
 		case -4:
-			notice(DI::l10n()->t('Message collection failure.') . EOL);
+			notice(DI::l10n()->t('Message collection failure.'));
 			break;
 	}
 
@@ -111,7 +111,7 @@ function message_content(App $a)
 	Nav::setSelected('messages');
 
 	if (!local_user()) {
-		notice(DI::l10n()->t('Permission denied.') . EOL);
+		notice(DI::l10n()->t('Permission denied.'));
 		return Login::form();
 	}
 
@@ -176,12 +176,12 @@ function message_content(App $a)
 		if ($cmd === 'drop') {
 			$message = DBA::selectFirst('mail', ['convid'], ['id' => $a->argv[2], 'uid' => local_user()]);
 			if(!DBA::isResult($message)){
-				notice(DI::l10n()->t('Conversation not found.') . EOL);
+				notice(DI::l10n()->t('Conversation not found.'));
 				DI::baseUrl()->redirect('message');
 			}
 
 			if (!DBA::delete('mail', ['id' => $a->argv[2], 'uid' => local_user()])) {
-				notice(DI::l10n()->t('Message was not deleted.') . EOL);
+				notice(DI::l10n()->t('Message was not deleted.'));
 			}
 
 			$conversation = DBA::selectFirst('mail', ['id'], ['convid' => $message['convid'], 'uid' => local_user()]);
@@ -199,7 +199,7 @@ function message_content(App $a)
 				$parent = $r[0]['parent-uri'];
 
 				if (!DBA::delete('mail', ['parent-uri' => $parent, 'uid' => local_user()])) {
-					notice(DI::l10n()->t('Conversation was not removed.') . EOL);
+					notice(DI::l10n()->t('Conversation was not removed.'));
 				}
 			}
 			DI::baseUrl()->redirect('message');
@@ -298,7 +298,7 @@ function message_content(App $a)
 		$r = get_messages(local_user(), $pager->getStart(), $pager->getItemsPerPage());
 
 		if (!DBA::isResult($r)) {
-			notice(DI::l10n()->t('No messages.') . EOL);
+			notice(DI::l10n()->t('No messages.'));
 			return $o;
 		}
 
@@ -355,7 +355,7 @@ function message_content(App $a)
 		}
 
 		if (!DBA::isResult($messages)) {
-			notice(DI::l10n()->t('Message not available.') . EOL);
+			notice(DI::l10n()->t('Message not available.'));
 			return $o;
 		}
 

--- a/mod/message.php
+++ b/mod/message.php
@@ -94,8 +94,6 @@ function message_post(App $a)
 		case -4:
 			notice(DI::l10n()->t('Message collection failure.') . EOL);
 			break;
-		default:
-			info(DI::l10n()->t('Message sent.') . EOL);
 	}
 
 	// fake it to go back to the input form if no recipient listed
@@ -178,17 +176,16 @@ function message_content(App $a)
 		if ($cmd === 'drop') {
 			$message = DBA::selectFirst('mail', ['convid'], ['id' => $a->argv[2], 'uid' => local_user()]);
 			if(!DBA::isResult($message)){
-				info(DI::l10n()->t('Conversation not found.') . EOL);
+				notice(DI::l10n()->t('Conversation not found.') . EOL);
 				DI::baseUrl()->redirect('message');
 			}
 
-			if (DBA::delete('mail', ['id' => $a->argv[2], 'uid' => local_user()])) {
-				info(DI::l10n()->t('Message deleted.') . EOL);
+			if (!DBA::delete('mail', ['id' => $a->argv[2], 'uid' => local_user()])) {
+				notice(DI::l10n()->t('Message was not deleted.') . EOL);
 			}
 
 			$conversation = DBA::selectFirst('mail', ['id'], ['convid' => $message['convid'], 'uid' => local_user()]);
 			if(!DBA::isResult($conversation)){
-				info(DI::l10n()->t('Conversation removed.') . EOL);
 				DI::baseUrl()->redirect('message');
 			}
 
@@ -201,8 +198,8 @@ function message_content(App $a)
 			if (DBA::isResult($r)) {
 				$parent = $r[0]['parent-uri'];
 
-				if (DBA::delete('mail', ['parent-uri' => $parent, 'uid' => local_user()])) {
-					info(DI::l10n()->t('Conversation removed.') . EOL);
+				if (!DBA::delete('mail', ['parent-uri' => $parent, 'uid' => local_user()])) {
+					notice(DI::l10n()->t('Conversation was not removed.') . EOL);
 				}
 			}
 			DI::baseUrl()->redirect('message');
@@ -301,7 +298,7 @@ function message_content(App $a)
 		$r = get_messages(local_user(), $pager->getStart(), $pager->getItemsPerPage());
 
 		if (!DBA::isResult($r)) {
-			info(DI::l10n()->t('No messages.') . EOL);
+			notice(DI::l10n()->t('No messages.') . EOL);
 			return $o;
 		}
 

--- a/mod/network.php
+++ b/mod/network.php
@@ -305,7 +305,7 @@ function network_content(App $a, $update = 0, $parent = 0)
 	}
 
 	if ($o === '') {
-		notice("No items found");
+		notice(DI::l10n()->t("No items found"));
 	}
 
 	return $o;

--- a/mod/network.php
+++ b/mod/network.php
@@ -305,7 +305,7 @@ function network_content(App $a, $update = 0, $parent = 0)
 	}
 
 	if ($o === '') {
-		info("No items found");
+		notice("No items found");
 	}
 
 	return $o;
@@ -569,7 +569,7 @@ function networkThreadedView(App $a, $update, $parent)
 			$sql_extra3 .= " OR (`thread`.`contact-id` = '$contact_str_self' AND `temp1`.`allow_gid` LIKE '" . Strings::protectSprintf('%<' . intval($gid) . '>%') . "' AND `temp1`.`private`))";
 		} else {
 			$sql_extra3 .= " AND false ";
-			info(DI::l10n()->t('Group is empty'));
+			notice(DI::l10n()->t('Group is empty'));
 		}
 
 		$o = Renderer::replaceMacros(Renderer::getMarkupTemplate('section_title.tpl'), [

--- a/mod/network.php
+++ b/mod/network.php
@@ -47,7 +47,7 @@ use Friendica\Util\Strings;
 function network_init(App $a)
 {
 	if (!local_user()) {
-		notice(DI::l10n()->t('Permission denied.') . EOL);
+		notice(DI::l10n()->t('Permission denied.'));
 		return;
 	}
 
@@ -548,7 +548,7 @@ function networkThreadedView(App $a, $update, $parent)
 			if ($update) {
 				exit();
 			}
-			notice(DI::l10n()->t('No such group') . EOL);
+			notice(DI::l10n()->t('No such group'));
 			DI::baseUrl()->redirect('network/0');
 			// NOTREACHED
 		}
@@ -598,7 +598,7 @@ function networkThreadedView(App $a, $update, $parent)
 				'id' => 'network',
 			]) . $o;
 		} else {
-			notice(DI::l10n()->t('Invalid contact.') . EOL);
+			notice(DI::l10n()->t('Invalid contact.'));
 			DI::baseUrl()->redirect('network');
 			// NOTREACHED
 		}

--- a/mod/notes.php
+++ b/mod/notes.php
@@ -40,7 +40,7 @@ function notes_init(App $a)
 function notes_content(App $a, $update = false)
 {
 	if (!local_user()) {
-		notice(DI::l10n()->t('Permission denied.') . EOL);
+		notice(DI::l10n()->t('Permission denied.'));
 		return;
 	}
 

--- a/mod/oexchange.php
+++ b/mod/oexchange.php
@@ -45,7 +45,6 @@ function oexchange_content(App $a) {
 	}
 
 	if (($a->argc > 1) && $a->argv[1] === 'done') {
-		info(DI::l10n()->t('Post successful.') . EOL);
 		return;
 	}
 

--- a/mod/ostatus_subscribe.php
+++ b/mod/ostatus_subscribe.php
@@ -28,7 +28,7 @@ use Friendica\Util\Network;
 function ostatus_subscribe_content(App $a)
 {
 	if (!local_user()) {
-		notice(DI::l10n()->t('Permission denied.') . EOL);
+		notice(DI::l10n()->t('Permission denied.'));
 		DI::baseUrl()->redirect('ostatus_subscribe');
 		// NOTREACHED
 	}

--- a/mod/photos.php
+++ b/mod/photos.php
@@ -295,7 +295,6 @@ function photos_post(App $a)
 
 				// Update the photo albums cache
 				Photo::clearAlbumCache($page_owner_uid);
-				notice('Successfully deleted the photo.');
 			} else {
 				notice('Failed to delete the photo.');
 				DI::baseUrl()->redirect('photos/' . $a->argv[1] . '/image/' . $a->argv[3]);

--- a/mod/photos.php
+++ b/mod/photos.php
@@ -175,14 +175,14 @@ function photos_post(App $a)
 	}
 
 	if (!$can_post) {
-		notice(DI::l10n()->t('Permission denied.') . EOL);
+		notice(DI::l10n()->t('Permission denied.'));
 		exit();
 	}
 
 	$owner_record = User::getOwnerDataById($page_owner_uid);
 
 	if (!$owner_record) {
-		notice(DI::l10n()->t('Contact information unavailable') . EOL);
+		notice(DI::l10n()->t('Contact information unavailable'));
 		Logger::log('photos_post: unable to locate contact record for page owner. uid=' . $page_owner_uid);
 		exit();
 	}
@@ -204,7 +204,7 @@ function photos_post(App $a)
 		);
 
 		if (!DBA::isResult($r)) {
-			notice(DI::l10n()->t('Album not found.') . EOL);
+			notice(DI::l10n()->t('Album not found.'));
 			DI::baseUrl()->redirect('photos/' . $a->data['user']['nickname'] . '/album');
 			return; // NOTREACHED
 		}
@@ -296,7 +296,7 @@ function photos_post(App $a)
 				// Update the photo albums cache
 				Photo::clearAlbumCache($page_owner_uid);
 			} else {
-				notice('Failed to delete the photo.');
+				notice(DI::l10n()->t('Failed to delete the photo.'));
 				DI::baseUrl()->redirect('photos/' . $a->argv[1] . '/image/' . $a->argv[3]);
 			}
 
@@ -675,21 +675,21 @@ function photos_post(App $a)
 	if ($error !== UPLOAD_ERR_OK) {
 		switch ($error) {
 			case UPLOAD_ERR_INI_SIZE:
-				notice(DI::l10n()->t('Image exceeds size limit of %s', ini_get('upload_max_filesize')) . EOL);
+				notice(DI::l10n()->t('Image exceeds size limit of %s', ini_get('upload_max_filesize')));
 				break;
 			case UPLOAD_ERR_FORM_SIZE:
-				notice(DI::l10n()->t('Image exceeds size limit of %s', Strings::formatBytes($_REQUEST['MAX_FILE_SIZE'] ?? 0)) . EOL);
+				notice(DI::l10n()->t('Image exceeds size limit of %s', Strings::formatBytes($_REQUEST['MAX_FILE_SIZE'] ?? 0)));
 				break;
 			case UPLOAD_ERR_PARTIAL:
-				notice(DI::l10n()->t('Image upload didn\'t complete, please try again') . EOL);
+				notice(DI::l10n()->t('Image upload didn\'t complete, please try again'));
 				break;
 			case UPLOAD_ERR_NO_FILE:
-				notice(DI::l10n()->t('Image file is missing') . EOL);
+				notice(DI::l10n()->t('Image file is missing'));
 				break;
 			case UPLOAD_ERR_NO_TMP_DIR:
 			case UPLOAD_ERR_CANT_WRITE:
 			case UPLOAD_ERR_EXTENSION:
-				notice(DI::l10n()->t('Server can\'t accept new file upload at this time, please contact your administrator') . EOL);
+				notice(DI::l10n()->t('Server can\'t accept new file upload at this time, please contact your administrator'));
 				break;
 		}
 		@unlink($src);
@@ -705,7 +705,7 @@ function photos_post(App $a)
 	$maximagesize = DI::config()->get('system', 'maximagesize');
 
 	if ($maximagesize && ($filesize > $maximagesize)) {
-		notice(DI::l10n()->t('Image exceeds size limit of %s', Strings::formatBytes($maximagesize)) . EOL);
+		notice(DI::l10n()->t('Image exceeds size limit of %s', Strings::formatBytes($maximagesize)));
 		@unlink($src);
 		$foo = 0;
 		Hook::callAll('photo_post_end', $foo);
@@ -713,7 +713,7 @@ function photos_post(App $a)
 	}
 
 	if (!$filesize) {
-		notice(DI::l10n()->t('Image file is empty.') . EOL);
+		notice(DI::l10n()->t('Image file is empty.'));
 		@unlink($src);
 		$foo = 0;
 		Hook::callAll('photo_post_end', $foo);
@@ -728,7 +728,7 @@ function photos_post(App $a)
 
 	if (!$image->isValid()) {
 		Logger::log('mod/photos.php: photos_post(): unable to process image' , Logger::DEBUG);
-		notice(DI::l10n()->t('Unable to process image.') . EOL);
+		notice(DI::l10n()->t('Unable to process image.'));
 		@unlink($src);
 		$foo = 0;
 		Hook::callAll('photo_post_end',$foo);
@@ -757,7 +757,7 @@ function photos_post(App $a)
 
 	if (!$r) {
 		Logger::log('mod/photos.php: photos_post(): image store failed', Logger::DEBUG);
-		notice(DI::l10n()->t('Image upload failed.') . EOL);
+		notice(DI::l10n()->t('Image upload failed.'));
 		return;
 	}
 
@@ -840,12 +840,12 @@ function photos_content(App $a)
 	// photos/name/image/xxxxx/drop
 
 	if (DI::config()->get('system', 'block_public') && !Session::isAuthenticated()) {
-		notice(DI::l10n()->t('Public access denied.') . EOL);
+		notice(DI::l10n()->t('Public access denied.'));
 		return;
 	}
 
 	if (empty($a->data['user'])) {
-		notice(DI::l10n()->t('No photos selected') . EOL);
+		notice(DI::l10n()->t('No photos selected'));
 		return;
 	}
 
@@ -911,7 +911,7 @@ function photos_content(App $a)
 	}
 
 	if ($a->data['user']['hidewall'] && (local_user() != $owner_uid) && !$remote_contact) {
-		notice(DI::l10n()->t('Access to this item is restricted.') . EOL);
+		notice(DI::l10n()->t('Access to this item is restricted.'));
 		return;
 	}
 
@@ -1136,7 +1136,7 @@ function photos_content(App $a)
 			if (DBA::exists('photo', ['resource-id' => $datum, 'uid' => $owner_uid])) {
 				notice(DI::l10n()->t('Permission denied. Access to this item may be restricted.'));
 			} else {
-				notice(DI::l10n()->t('Photo not available') . EOL);
+				notice(DI::l10n()->t('Photo not available'));
 			}
 			return;
 		}

--- a/mod/repair_ostatus.php
+++ b/mod/repair_ostatus.php
@@ -28,7 +28,7 @@ use Friendica\Model\Contact;
 function repair_ostatus_content(App $a) {
 
 	if (! local_user()) {
-		notice(DI::l10n()->t('Permission denied.') . EOL);
+		notice(DI::l10n()->t('Permission denied.'));
 		DI::baseUrl()->redirect('ostatus_repair');
 		// NOTREACHED
 	}

--- a/mod/settings.php
+++ b/mod/settings.php
@@ -202,9 +202,6 @@ function settings_post(App $a)
 						}
 					}
 				}
-				if (!$failed) {
-					info(DI::l10n()->t('Email settings updated.') . EOL);
-				}
 			}
 		}
 
@@ -219,7 +216,6 @@ function settings_post(App $a)
 				DI::pConfig()->set(local_user(), 'feature', substr($k, 8), ((intval($v)) ? 1 : 0));
 			}
 		}
-		info(DI::l10n()->t('Features updated') . EOL);
 		return;
 	}
 
@@ -231,7 +227,7 @@ function settings_post(App $a)
 			// was there an error
 			if ($_FILES['importcontact-filename']['error'] > 0) {
 				Logger::notice('Contact CSV file upload error');
-				info(DI::l10n()->t('Contact CSV file upload error'));
+				notice(DI::l10n()->t('Contact CSV file upload error'));
 			} else {
 				$csvArray = array_map('str_getcsv', file($_FILES['importcontact-filename']['tmp_name']));
 				// import contacts
@@ -443,8 +439,8 @@ function settings_post(App $a)
 		$fields['openidserver'] = '';
 	}
 
-	if (DBA::update('user', $fields, ['uid' => local_user()])) {
-		info(DI::l10n()->t('Settings updated.') . EOL);
+	if (!DBA::update('user', $fields, ['uid' => local_user()])) {
+		notice(DI::l10n()->t('Settings were not updated.') . EOL);
 	}
 
 	// clear session language

--- a/mod/settings.php
+++ b/mod/settings.php
@@ -63,7 +63,7 @@ function settings_post(App $a)
 	}
 
 	if (count($a->user) && !empty($a->user['uid']) && $a->user['uid'] != local_user()) {
-		notice(DI::l10n()->t('Permission denied.') . EOL);
+		notice(DI::l10n()->t('Permission denied.'));
 		return;
 	}
 
@@ -198,7 +198,7 @@ function settings_post(App $a)
 						unset($dcrpass);
 						if (!$mbox) {
 							$failed = true;
-							notice(DI::l10n()->t('Failed to connect with email account using the settings provided.') . EOL);
+							notice(DI::l10n()->t('Failed to connect with email account using the settings provided.'));
 						}
 					}
 				}
@@ -420,10 +420,10 @@ function settings_post(App $a)
 		$hidewall = 1;
 		if (!$str_contact_allow && !$str_group_allow && !$str_contact_deny && !$str_group_deny) {
 			if ($def_gid) {
-				info(DI::l10n()->t('Private forum has no privacy permissions. Using default privacy group.'). EOL);
+				info(DI::l10n()->t('Private forum has no privacy permissions. Using default privacy group.'));
 				$str_group_allow = '<' . $def_gid . '>';
 			} else {
-				notice(DI::l10n()->t('Private forum has no privacy permissions and no default privacy group.') . EOL);
+				notice(DI::l10n()->t('Private forum has no privacy permissions and no default privacy group.'));
 			}
 		}
 	}
@@ -440,7 +440,7 @@ function settings_post(App $a)
 	}
 
 	if (!DBA::update('user', $fields, ['uid' => local_user()])) {
-		notice(DI::l10n()->t('Settings were not updated.') . EOL);
+		notice(DI::l10n()->t('Settings were not updated.'));
 	}
 
 	// clear session language
@@ -485,12 +485,12 @@ function settings_content(App $a)
 	Nav::setSelected('settings');
 
 	if (!local_user()) {
-		//notice(DI::l10n()->t('Permission denied.') . EOL);
+		//notice(DI::l10n()->t('Permission denied.'));
 		return Login::form();
 	}
 
 	if (!empty($_SESSION['submanage'])) {
-		notice(DI::l10n()->t('Permission denied.') . EOL);
+		notice(DI::l10n()->t('Permission denied.'));
 		return;
 	}
 
@@ -718,7 +718,7 @@ function settings_content(App $a)
 
 	$profile = DBA::selectFirst('profile', [], ['uid' => local_user()]);
 	if (!DBA::isResult($profile)) {
-		notice(DI::l10n()->t('Unable to find your profile. Please contact your admin.') . EOL);
+		notice(DI::l10n()->t('Unable to find your profile. Please contact your admin.'));
 		return;
 	}
 

--- a/mod/suggest.php
+++ b/mod/suggest.php
@@ -51,7 +51,7 @@ function suggest_content(App $a)
 	$o = '';
 
 	if (! local_user()) {
-		notice(DI::l10n()->t('Permission denied.') . EOL);
+		notice(DI::l10n()->t('Permission denied.'));
 		return;
 	}
 

--- a/mod/tagrm.php
+++ b/mod/tagrm.php
@@ -44,7 +44,6 @@ function tagrm_post(App $a)
 
 	$item_id = $_POST['item'] ?? 0;
 	update_tags($item_id, $tags);
-	info(DI::l10n()->t('Tag(s) removed') . EOL);
 
 	DI::baseUrl()->redirect($_SESSION['photo_return']);
 	// NOTREACHED

--- a/mod/uimport.php
+++ b/mod/uimport.php
@@ -29,7 +29,7 @@ use Friendica\DI;
 function uimport_post(App $a)
 {
 	if ((DI::config()->get('config', 'register_policy') != \Friendica\Module\Register::OPEN) && !is_site_admin()) {
-		notice(DI::l10n()->t('Permission denied.') . EOL);
+		notice(DI::l10n()->t('Permission denied.'));
 		return;
 	}
 
@@ -42,7 +42,7 @@ function uimport_post(App $a)
 function uimport_content(App $a)
 {
 	if ((DI::config()->get('config', 'register_policy') != \Friendica\Module\Register::OPEN) && !is_site_admin()) {
-		notice(DI::l10n()->t('User imports on closed servers can only be done by an administrator.') . EOL);
+		notice(DI::l10n()->t('User imports on closed servers can only be done by an administrator.'));
 		return;
 	}
 
@@ -51,7 +51,7 @@ function uimport_content(App $a)
 		$r = q("select count(*) as total from user where register_date > UTC_TIMESTAMP - INTERVAL 1 day");
 		if ($r && $r[0]['total'] >= $max_dailies) {
 			Logger::log('max daily registrations exceeded.');
-			notice(DI::l10n()->t('This site has exceeded the number of allowed daily account registrations. Please try again tomorrow.') . EOL);
+			notice(DI::l10n()->t('This site has exceeded the number of allowed daily account registrations. Please try again tomorrow.'));
 			return;
 		}
 	}

--- a/mod/unfollow.php
+++ b/mod/unfollow.php
@@ -79,7 +79,6 @@ function unfollow_post(App $a)
 		$return_path = $base_return_path . '/' . $contact['id'];
 	}
 
-	info(DI::l10n()->t('Contact unfollowed'));
 	DI::baseUrl()->redirect($return_path);
 	// NOTREACHED
 }

--- a/mod/videos.php
+++ b/mod/videos.php
@@ -126,7 +126,7 @@ function videos_content(App $a)
 
 
 	if (DI::config()->get('system', 'block_public') && !Session::isAuthenticated()) {
-		notice(DI::l10n()->t('Public access denied.') . EOL);
+		notice(DI::l10n()->t('Public access denied.'));
 		return;
 	}
 
@@ -179,7 +179,7 @@ function videos_content(App $a)
 	}
 
 	if ($a->data['user']['hidewall'] && (local_user() != $owner_uid) && !$remote_contact) {
-		notice(DI::l10n()->t('Access to this item is restricted.') . EOL);
+		notice(DI::l10n()->t('Access to this item is restricted.'));
 		return;
 	}
 

--- a/mod/wall_attach.php
+++ b/mod/wall_attach.php
@@ -106,7 +106,7 @@ function wall_attach_post(App $a) {
 		if ($r_json) {
 			echo json_encode(['error' => $msg]);
 		} else {
-			notice($msg . EOL);
+			notice($msg);
 		}
 		@unlink($src);
 		exit();

--- a/mod/wall_upload.php
+++ b/mod/wall_upload.php
@@ -99,7 +99,7 @@ function wall_upload_post(App $a, $desktopmode = true)
 			echo json_encode(['error' => DI::l10n()->t('Permission denied.')]);
 			exit();
 		}
-		notice(DI::l10n()->t('Permission denied.') . EOL);
+		notice(DI::l10n()->t('Permission denied.'));
 		exit();
 	}
 
@@ -159,7 +159,7 @@ function wall_upload_post(App $a, $desktopmode = true)
 			echo json_encode(['error' => DI::l10n()->t('Invalid request.')]);
 			exit();
 		}
-		notice(DI::l10n()->t('Invalid request.').EOL);
+		notice(DI::l10n()->t('Invalid request.'));
 		exit();
 	}
 

--- a/mod/wallmessage.php
+++ b/mod/wallmessage.php
@@ -32,7 +32,7 @@ function wallmessage_post(App $a) {
 
 	$replyto = Profile::getMyURL();
 	if (!$replyto) {
-		notice(DI::l10n()->t('Permission denied.') . EOL);
+		notice(DI::l10n()->t('Permission denied.'));
 		return;
 	}
 
@@ -56,7 +56,7 @@ function wallmessage_post(App $a) {
 	$user = $r[0];
 
 	if (! intval($user['unkmail'])) {
-		notice(DI::l10n()->t('Permission denied.') . EOL);
+		notice(DI::l10n()->t('Permission denied.'));
 		return;
 	}
 
@@ -73,16 +73,16 @@ function wallmessage_post(App $a) {
 
 	switch ($ret) {
 		case -1:
-			notice(DI::l10n()->t('No recipient selected.') . EOL);
+			notice(DI::l10n()->t('No recipient selected.'));
 			break;
 		case -2:
-			notice(DI::l10n()->t('Unable to check your home location.') . EOL);
+			notice(DI::l10n()->t('Unable to check your home location.'));
 			break;
 		case -3:
-			notice(DI::l10n()->t('Message could not be sent.') . EOL);
+			notice(DI::l10n()->t('Message could not be sent.'));
 			break;
 		case -4:
-			notice(DI::l10n()->t('Message collection failure.') . EOL);
+			notice(DI::l10n()->t('Message collection failure.'));
 			break;
 	}
 
@@ -93,14 +93,14 @@ function wallmessage_post(App $a) {
 function wallmessage_content(App $a) {
 
 	if (!Profile::getMyURL()) {
-		notice(DI::l10n()->t('Permission denied.') . EOL);
+		notice(DI::l10n()->t('Permission denied.'));
 		return;
 	}
 
 	$recipient = (($a->argc > 1) ? $a->argv[1] : '');
 
 	if (!$recipient) {
-		notice(DI::l10n()->t('No recipient.') . EOL);
+		notice(DI::l10n()->t('No recipient.'));
 		return;
 	}
 
@@ -109,7 +109,7 @@ function wallmessage_content(App $a) {
 	);
 
 	if (! DBA::isResult($r)) {
-		notice(DI::l10n()->t('No recipient.') . EOL);
+		notice(DI::l10n()->t('No recipient.'));
 		Logger::log('wallmessage: no recipient');
 		return;
 	}
@@ -117,7 +117,7 @@ function wallmessage_content(App $a) {
 	$user = $r[0];
 
 	if (!intval($user['unkmail'])) {
-		notice(DI::l10n()->t('Permission denied.') . EOL);
+		notice(DI::l10n()->t('Permission denied.'));
 		return;
 	}
 

--- a/mod/wallmessage.php
+++ b/mod/wallmessage.php
@@ -84,8 +84,6 @@ function wallmessage_post(App $a) {
 		case -4:
 			notice(DI::l10n()->t('Message collection failure.') . EOL);
 			break;
-		default:
-			info(DI::l10n()->t('Message sent.') . EOL);
 	}
 
 	DI::baseUrl()->redirect('profile/'.$user['nickname']);

--- a/src/App/Authentication.php
+++ b/src/App/Authentication.php
@@ -270,7 +270,7 @@ class Authentication
 			}
 		} catch (Exception $e) {
 			$this->logger->warning('authenticate: failed login attempt', ['action' => 'login', 'username' => Strings::escapeTags($username), 'ip' => $_SERVER['REMOTE_ADDR']]);
-			info($this->l10n->t('Login failed. Please check your credentials.' . EOL));
+			notice($this->l10n->t('Login failed. Please check your credentials.' . EOL));
 			$this->baseUrl->redirect();
 		}
 
@@ -389,8 +389,6 @@ class Authentication
 				info($this->l10n->t('Welcome %s', $user_record['username']));
 				info($this->l10n->t('Please upload a profile photo.'));
 				$this->baseUrl->redirect('settings/profile/photo/new');
-			} else {
-				info($this->l10n->t("Welcome back %s", $user_record['username']));
 			}
 		}
 

--- a/src/App/Authentication.php
+++ b/src/App/Authentication.php
@@ -207,7 +207,7 @@ class Authentication
 
 		// if it's an email address or doesn't resolve to a URL, fail.
 		if ($noid || strpos($openid_url, '@') || !Network::isUrlValid($openid_url)) {
-			notice($this->l10n->t('Login failed.') . EOL);
+			notice($this->l10n->t('Login failed.'));
 			$this->baseUrl->redirect();
 		}
 
@@ -270,7 +270,7 @@ class Authentication
 			}
 		} catch (Exception $e) {
 			$this->logger->warning('authenticate: failed login attempt', ['action' => 'login', 'username' => Strings::escapeTags($username), 'ip' => $_SERVER['REMOTE_ADDR']]);
-			notice($this->l10n->t('Login failed. Please check your credentials.' . EOL));
+			notice($this->l10n->t('Login failed. Please check your credentials.'));
 			$this->baseUrl->redirect();
 		}
 

--- a/src/App/Module.php
+++ b/src/App/Module.php
@@ -237,7 +237,7 @@ class Module
 	public function run(Core\L10n $l10n, App\BaseURL $baseUrl, LoggerInterface $logger, array $server, array $post)
 	{
 		if ($this->printNotAllowedAddon) {
-			info($l10n->t("You must be logged in to use addons. "));
+			notice($l10n->t("You must be logged in to use addons. "));
 		}
 
 		/* The URL provided does not resolve to a valid module.

--- a/src/Core/UserImport.php
+++ b/src/Core/UserImport.php
@@ -271,7 +271,7 @@ class UserImport
 
 				if ($r === false) {
 					Logger::log("uimport:insert profile: ERROR : " . DBA::errorMessage(), Logger::INFO);
-					info(DI::l10n()->t("User profile creation error"));
+					notice(DI::l10n()->t("User profile creation error"));
 					DBA::delete('user', ['uid' => $newuid]);
 					DBA::delete('profile_field', ['uid' => $newuid]);
 					return;

--- a/src/Model/FileTag.php
+++ b/src/Model/FileTag.php
@@ -271,8 +271,6 @@ class FileTag
 			if (!strlen($saved) || !stristr($saved, '[' . self::encode($file) . ']')) {
 				DI::pConfig()->set($uid, 'system', 'filetags', $saved . '[' . self::encode($file) . ']');
 			}
-
-			info(DI::l10n()->t('Item filed'));
 		}
 
 		return true;

--- a/src/Model/Group.php
+++ b/src/Model/Group.php
@@ -89,7 +89,7 @@ class Group
 				$group = DBA::selectFirst('group', ['deleted'], ['id' => $gid]);
 				if (DBA::isResult($group) && $group['deleted']) {
 					DBA::update('group', ['deleted' => 0], ['id' => $gid]);
-					notice(DI::l10n()->t('A deleted group with this name was revived. Existing item permissions <strong>may</strong> apply to this group and any future members. If this is not what you intended, please create another group with a different name.') . EOL);
+					notice(DI::l10n()->t('A deleted group with this name was revived. Existing item permissions <strong>may</strong> apply to this group and any future members. If this is not what you intended, please create another group with a different name.'));
 				}
 				return true;
 			}

--- a/src/Module/Admin/Addons/Index.php
+++ b/src/Module/Admin/Addons/Index.php
@@ -50,7 +50,7 @@ class Index extends BaseAdmin
 					} elseif (Addon::install($addon)) {
 						info(DI::l10n()->t('Addon %s enabled.', $addon));
 					} else {
-						info(DI::l10n()->t('Addon %s failed to install.', $addon));
+						notice(DI::l10n()->t('Addon %s failed to install.', $addon));
 					}
 
 					break;

--- a/src/Module/Admin/Addons/Index.php
+++ b/src/Module/Admin/Addons/Index.php
@@ -39,7 +39,7 @@ class Index extends BaseAdmin
 			switch ($_GET['action']) {
 				case 'reload':
 					Addon::reload();
-					info('Addons reloaded');
+					info(DI::l10n()->t('Addons reloaded'));
 					break;
 
 				case 'toggle' :

--- a/src/Module/Admin/Blocklist/Server.php
+++ b/src/Module/Admin/Blocklist/Server.php
@@ -46,7 +46,7 @@ class Server extends BaseAdmin
 				'reason' => Strings::escapeTags(trim($_POST['newentry_reason']))
 			];
 			DI::config()->set('system', 'blocklist', $blocklist);
-			info(DI::l10n()->t('Server domain pattern added to blocklist.') . EOL);
+			info(DI::l10n()->t('Server domain pattern added to blocklist.'));
 		} else {
 			// Edit the entries from blocklist
 			$blocklist = [];

--- a/src/Module/Admin/Blocklist/Server.php
+++ b/src/Module/Admin/Blocklist/Server.php
@@ -62,7 +62,6 @@ class Server extends BaseAdmin
 				}
 			}
 			DI::config()->set('system', 'blocklist', $blocklist);
-			info(DI::l10n()->t('Site blocklist updated.') . EOL);
 		}
 
 		DI::baseUrl()->redirect('admin/blocklist/server');

--- a/src/Module/Admin/DBSync.php
+++ b/src/Module/Admin/DBSync.php
@@ -47,7 +47,7 @@ class DBSync extends BaseAdmin
 				if (intval($curr) == $update) {
 					DI::config()->set('system', 'build', intval($curr) + 1);
 				}
-				info(DI::l10n()->t('Update has been marked successful') . EOL);
+				info(DI::l10n()->t('Update has been marked successful'));
 			}
 			DI::baseUrl()->redirect('admin/dbsync');
 		}

--- a/src/Module/Admin/Item/Delete.php
+++ b/src/Module/Admin/Item/Delete.php
@@ -51,7 +51,7 @@ class Delete extends BaseAdmin
 			Item::markForDeletion(['guid' => $guid]);
 		}
 
-		info(DI::l10n()->t('Item marked for deletion.') . EOL);
+		info(DI::l10n()->t('Item marked for deletion.'));
 		DI::baseUrl()->redirect('admin/item/delete');
 	}
 

--- a/src/Module/Admin/Logs/Settings.php
+++ b/src/Module/Admin/Logs/Settings.php
@@ -51,7 +51,6 @@ class Settings extends BaseAdmin
 			DI::config()->set('system', 'loglevel', $loglevel);
 		}
 
-		info(DI::l10n()->t("Log settings updated."));
 		DI::baseUrl()->redirect('admin/logs');
 	}
 

--- a/src/Module/Admin/Site.php
+++ b/src/Module/Admin/Site.php
@@ -122,7 +122,7 @@ class Site extends BaseAdmin
 			}
 			DBA::close($usersStmt);
 
-			info("Relocation started. Could take a while to complete.");
+			info(DI::l10n()->t("Relocation started. Could take a while to complete."));
 
 			DI::baseUrl()->redirect('admin/site');
 		}

--- a/src/Module/Admin/Site.php
+++ b/src/Module/Admin/Site.php
@@ -250,7 +250,7 @@ class Site extends BaseAdmin
 				DI::baseUrl()->redirect('admin/site' . $active_panel);
 			}
 		} else {
-			info(DI::l10n()->t('Invalid storage backend setting value.'));
+			notice(DI::l10n()->t('Invalid storage backend setting value.'));
 		}
 
 		// Has the directory url changed? If yes, then resubmit the existing profiles there
@@ -432,8 +432,6 @@ class Site extends BaseAdmin
 		DI::config()->set('system', 'relay_user_tags'  , $relay_user_tags);
 
 		DI::config()->set('system', 'rino_encrypt'     , $rino);
-
-		info(DI::l10n()->t('Site settings updated.') . EOL);
 
 		DI::baseUrl()->redirect('admin/site' . $active_panel);
 	}

--- a/src/Module/Admin/Themes/Details.php
+++ b/src/Module/Admin/Themes/Details.php
@@ -48,8 +48,6 @@ class Details extends BaseAdmin
 				}
 			}
 
-			info(DI::l10n()->t('Theme settings updated.'));
-
 			if (DI::mode()->isAjax()) {
 				return;
 			}
@@ -91,7 +89,7 @@ class Details extends BaseAdmin
 				} elseif (Theme::install($theme)) {
 					info(DI::l10n()->t('Theme %s successfully enabled.', $theme));
 				} else {
-					info(DI::l10n()->t('Theme %s failed to install.', $theme));
+					notice(DI::l10n()->t('Theme %s failed to install.', $theme));
 				}
 
 				DI::baseUrl()->redirect('admin/themes/' . $theme);

--- a/src/Module/Admin/Themes/Embed.php
+++ b/src/Module/Admin/Themes/Embed.php
@@ -62,8 +62,6 @@ class Embed extends BaseAdmin
 				}
 			}
 
-			info(DI::l10n()->t('Theme settings updated.'));
-
 			if (DI::mode()->isAjax()) {
 				return;
 			}

--- a/src/Module/Admin/Themes/Index.php
+++ b/src/Module/Admin/Themes/Index.php
@@ -48,7 +48,7 @@ class Index extends BaseAdmin
 					}
 					Theme::setAllowedList($allowed_themes);
 
-					info('Themes reloaded');
+					info(DI::l10n()->t('Themes reloaded'));
 					break;
 
 				case 'toggle' :

--- a/src/Module/Admin/Themes/Index.php
+++ b/src/Module/Admin/Themes/Index.php
@@ -66,7 +66,7 @@ class Index extends BaseAdmin
 						} elseif (Theme::install($theme)) {
 							info(DI::l10n()->t('Theme %s successfully enabled.', $theme));
 						} else {
-							info(DI::l10n()->t('Theme %s failed to install.', $theme));
+							notice(DI::l10n()->t('Theme %s failed to install.', $theme));
 						}
 					}
 

--- a/src/Module/Admin/Tos.php
+++ b/src/Module/Admin/Tos.php
@@ -45,8 +45,6 @@ class Tos extends BaseAdmin
 		DI::config()->set('system', 'tosprivstatement', $displayprivstatement);
 		DI::config()->set('system', 'tostext', $tostext);
 
-		info(DI::l10n()->t('The Terms of Service settings have been updated.'));
-
 		DI::baseUrl()->redirect('admin/tos');
 	}
 

--- a/src/Module/Admin/Users.php
+++ b/src/Module/Admin/Users.php
@@ -109,7 +109,7 @@ class Users extends BaseAdmin
 			$uid = $a->argv[3];
 			$user = User::getById($uid, ['username', 'blocked']);
 			if (!DBA::isResult($user)) {
-				notice('User not found' . EOL);
+				notice(DI::l10n()->t('User not found'));
 				DI::baseUrl()->redirect('admin/users');
 				return ''; // NOTREACHED
 			}

--- a/src/Module/Apps.php
+++ b/src/Module/Apps.php
@@ -44,7 +44,7 @@ class Apps extends BaseModule
 		$apps = Nav::getAppMenu();
 
 		if (count($apps) == 0) {
-			notice(DI::l10n()->t('No installed applications.') . EOL);
+			notice(DI::l10n()->t('No installed applications.'));
 		}
 
 		$tpl = Renderer::getMarkupTemplate('apps.tpl');

--- a/src/Module/BaseSearch.php
+++ b/src/Module/BaseSearch.php
@@ -116,7 +116,7 @@ class BaseSearch extends BaseModule
 	protected static function printResult(ResultList $results, Pager $pager, $header = '')
 	{
 		if ($results->getTotal() == 0) {
-			info(DI::l10n()->t('No matches'));
+			notice(DI::l10n()->t('No matches'));
 			return '';
 		}
 

--- a/src/Module/Contact.php
+++ b/src/Module/Contact.php
@@ -144,9 +144,7 @@ class Contact extends BaseModule
 			['id' => $contact_id, 'uid' => local_user()]
 		);
 
-		if (DBA::isResult($r)) {
-			info(DI::l10n()->t('Contact updated.') . EOL);
-		} else {
+		if (!DBA::isResult($r)) {
 			notice(DI::l10n()->t('Failed to update contact record.') . EOL);
 		}
 

--- a/src/Module/Contact.php
+++ b/src/Module/Contact.php
@@ -112,7 +112,7 @@ class Contact extends BaseModule
 		}
 
 		if (!DBA::exists('contact', ['id' => $contact_id, 'uid' => local_user(), 'deleted' => false])) {
-			notice(DI::l10n()->t('Could not access contact record.') . EOL);
+			notice(DI::l10n()->t('Could not access contact record.'));
 			DI::baseUrl()->redirect('contact');
 			return; // NOTREACHED
 		}
@@ -145,7 +145,7 @@ class Contact extends BaseModule
 		);
 
 		if (!DBA::isResult($r)) {
-			notice(DI::l10n()->t('Failed to update contact record.') . EOL);
+			notice(DI::l10n()->t('Failed to update contact record.'));
 		}
 
 		$contact = DBA::selectFirst('contact', [], ['id' => $contact_id, 'uid' => local_user(), 'deleted' => false]);
@@ -364,7 +364,7 @@ class Contact extends BaseModule
 		Nav::setSelected('contact');
 
 		if (!local_user()) {
-			notice(DI::l10n()->t('Permission denied.') . EOL);
+			notice(DI::l10n()->t('Permission denied.'));
 			return Login::form();
 		}
 
@@ -398,7 +398,7 @@ class Contact extends BaseModule
 				self::blockContact($contact_id);
 
 				$blocked = Model\Contact::isBlockedByUser($contact_id, local_user());
-				info(($blocked ? DI::l10n()->t('Contact has been blocked') : DI::l10n()->t('Contact has been unblocked')) . EOL);
+				info(($blocked ? DI::l10n()->t('Contact has been blocked') : DI::l10n()->t('Contact has been unblocked')));
 
 				DI::baseUrl()->redirect('contact/' . $contact_id);
 				// NOTREACHED
@@ -408,7 +408,7 @@ class Contact extends BaseModule
 				self::ignoreContact($contact_id);
 
 				$ignored = Model\Contact::isIgnoredByUser($contact_id, local_user());
-				info(($ignored ? DI::l10n()->t('Contact has been ignored') : DI::l10n()->t('Contact has been unignored')) . EOL);
+				info(($ignored ? DI::l10n()->t('Contact has been ignored') : DI::l10n()->t('Contact has been unignored')));
 
 				DI::baseUrl()->redirect('contact/' . $contact_id);
 				// NOTREACHED
@@ -418,7 +418,7 @@ class Contact extends BaseModule
 				$r = self::archiveContact($contact_id, $orig_record);
 				if ($r) {
 					$archived = (($orig_record['archive']) ? 0 : 1);
-					info((($archived) ? DI::l10n()->t('Contact has been archived') : DI::l10n()->t('Contact has been unarchived')) . EOL);
+					info((($archived) ? DI::l10n()->t('Contact has been archived') : DI::l10n()->t('Contact has been unarchived')));
 				}
 
 				DI::baseUrl()->redirect('contact/' . $contact_id);
@@ -459,7 +459,7 @@ class Contact extends BaseModule
 				}
 
 				self::dropContact($orig_record);
-				info(DI::l10n()->t('Contact has been removed.') . EOL);
+				info(DI::l10n()->t('Contact has been removed.'));
 
 				DI::baseUrl()->redirect('contact');
 				// NOTREACHED

--- a/src/Module/Contact/Advanced.php
+++ b/src/Module/Contact/Advanced.php
@@ -91,7 +91,7 @@ class Advanced extends BaseModule
 		}
 
 		if (!$r) {
-			notice(DI::l10n()->t('Contact update failed.') . EOL);
+			notice(DI::l10n()->t('Contact update failed.'));
 		}
 
 		return;

--- a/src/Module/Contact/Advanced.php
+++ b/src/Module/Contact/Advanced.php
@@ -90,9 +90,7 @@ class Advanced extends BaseModule
 			Model\Contact::updateAvatar($photo, local_user(), $contact['id'], true);
 		}
 
-		if ($r) {
-			info(DI::l10n()->t('Contact settings applied.') . EOL);
-		} else {
+		if (!$r) {
 			notice(DI::l10n()->t('Contact update failed.') . EOL);
 		}
 

--- a/src/Module/Contact/Poke.php
+++ b/src/Module/Contact/Poke.php
@@ -110,9 +110,7 @@ class Poke extends BaseModule
 	 */
 	private static function postReturn(bool $success)
 	{
-		if ($success) {
-			info(DI::l10n()->t('Poke successfully sent.'));
-		} else {
+		if (!$success) {
 			notice(DI::l10n()->t('Error while sending poke, please retry.'));
 		}
 

--- a/src/Module/Conversation/Community.php
+++ b/src/Module/Conversation/Community.php
@@ -81,7 +81,7 @@ class Community extends BaseModule
 		$items = self::getItems();
 
 		if (!DBA::isResult($items)) {
-			info(DI::l10n()->t('No results.'));
+			notice(DI::l10n()->t('No results.'));
 			return $o;
 		}
 

--- a/src/Module/Debug/Feed.php
+++ b/src/Module/Debug/Feed.php
@@ -36,7 +36,7 @@ class Feed extends BaseModule
 	public static function init(array $parameters = [])
 	{
 		if (!local_user()) {
-			info(DI::l10n()->t('You must be logged in to use this module'));
+			notice(DI::l10n()->t('You must be logged in to use this module'));
 			DI::baseUrl()->redirect();
 		}
 	}

--- a/src/Module/Directory.php
+++ b/src/Module/Directory.php
@@ -75,7 +75,7 @@ class Directory extends BaseModule
 		$profiles = Profile::searchProfiles($pager->getStart(), $pager->getItemsPerPage(), $search);
 
 		if ($profiles['total'] === 0) {
-			notice(DI::l10n()->t('No entries (some entries may be hidden).') . EOL);
+			notice(DI::l10n()->t('No entries (some entries may be hidden).'));
 		} else {
 			if (in_array('small', $app->argv)) {
 				$photo = 'thumb';

--- a/src/Module/Directory.php
+++ b/src/Module/Directory.php
@@ -75,7 +75,7 @@ class Directory extends BaseModule
 		$profiles = Profile::searchProfiles($pager->getStart(), $pager->getItemsPerPage(), $search);
 
 		if ($profiles['total'] === 0) {
-			info(DI::l10n()->t('No entries (some entries may be hidden).') . EOL);
+			notice(DI::l10n()->t('No entries (some entries may be hidden).') . EOL);
 		} else {
 			if (in_array('small', $app->argv)) {
 				$photo = 'thumb';

--- a/src/Module/Filer/RemoveTag.php
+++ b/src/Module/Filer/RemoveTag.php
@@ -59,11 +59,11 @@ class RemoveTag extends BaseModule
 		]);
 
 		if ($item_id && strlen($term)) {
-			if (FileTag::unsaveFile(local_user(), $item_id, $term, $category)) {
-				info('Item removed');
+			if (!FileTag::unsaveFile(local_user(), $item_id, $term, $category)) {
+				notice(DI::l10n()->t('Item was not removed'));
 			}
 		} else {
-			info('Item was not deleted');
+			notice(DI::l10n()->t('Item was not deleted'));
 		}
 
 		DI::baseUrl()->redirect('network?file=' . rawurlencode($term));

--- a/src/Module/Filer/SaveTag.php
+++ b/src/Module/Filer/SaveTag.php
@@ -35,7 +35,7 @@ class SaveTag extends BaseModule
 	public static function init(array $parameters = [])
 	{
 		if (!local_user()) {
-			info(DI::l10n()->t('You must be logged in to use this module'));
+			notice(DI::l10n()->t('You must be logged in to use this module'));
 			DI::baseUrl()->redirect();
 		}
 	}
@@ -54,7 +54,6 @@ class SaveTag extends BaseModule
 		if ($item_id && strlen($term)) {
 			// file item
 			Model\FileTag::saveFile(local_user(), $item_id, $term);
-			info(DI::l10n()->t('Filetag %s saved to item', $term));
 		}
 
 		// return filer dialog

--- a/src/Module/FollowConfirm.php
+++ b/src/Module/FollowConfirm.php
@@ -13,7 +13,7 @@ class FollowConfirm extends BaseModule
 	{
 		$uid = local_user();
 		if (!$uid) {
-			notice(DI::l10n()->t('Permission denied.') . EOL);
+			notice(DI::l10n()->t('Permission denied.'));
 			return;
 		}
 

--- a/src/Module/Group.php
+++ b/src/Module/Group.php
@@ -53,7 +53,6 @@ class Group extends BaseModule
 			$name = Strings::escapeTags(trim($_POST['groupname']));
 			$r = Model\Group::create(local_user(), $name);
 			if ($r) {
-				info(DI::l10n()->t('Group created.'));
 				$r = Model\Group::getIdByName(local_user(), $name);
 				if ($r) {
 					DI::baseUrl()->redirect('group/' . $r);
@@ -75,8 +74,8 @@ class Group extends BaseModule
 			}
 			$groupname = Strings::escapeTags(trim($_POST['groupname']));
 			if (strlen($groupname) && ($groupname != $group['name'])) {
-				if (Model\Group::update($group['id'], $groupname)) {
-					info(DI::l10n()->t('Group name changed.'));
+				if (!Model\Group::update($group['id'], $groupname)) {
+					notice(DI::l10n()->t('Group name was not changed.'));
 				}
 			}
 		}
@@ -216,9 +215,7 @@ class Group extends BaseModule
 					DI::baseUrl()->redirect('contact');
 				}
 
-				if (Model\Group::remove($a->argv[2])) {
-					info(DI::l10n()->t('Group removed.'));
-				} else {
+				if (!Model\Group::remove($a->argv[2])) {
 					notice(DI::l10n()->t('Unable to remove group.'));
 				}
 			}

--- a/src/Module/Invite.php
+++ b/src/Module/Invite.php
@@ -75,7 +75,7 @@ class Invite extends BaseModule
 			$recipient = trim($recipient);
 
 			if (!filter_var($recipient, FILTER_VALIDATE_EMAIL)) {
-				notice(DI::l10n()->t('%s : Not a valid email address.', $recipient) . EOL);
+				notice(DI::l10n()->t('%s : Not a valid email address.', $recipient));
 				continue;
 			}
 
@@ -111,15 +111,15 @@ class Invite extends BaseModule
 				$current_invites++;
 				DI::pConfig()->set(local_user(), 'system', 'sent_invites', $current_invites);
 				if ($current_invites > $max_invites) {
-					notice(DI::l10n()->t('Invitation limit exceeded. Please contact your site administrator.') . EOL);
+					notice(DI::l10n()->t('Invitation limit exceeded. Please contact your site administrator.'));
 					return;
 				}
 			} else {
-				notice(DI::l10n()->t('%s : Message delivery failed.', $recipient) . EOL);
+				notice(DI::l10n()->t('%s : Message delivery failed.', $recipient));
 			}
 
 		}
-		notice(DI::l10n()->tt('%d message sent.', '%d messages sent.', $total) . EOL);
+		notice(DI::l10n()->tt('%d message sent.', '%d messages sent.', $total));
 	}
 
 	public static function content(array $parameters = [])

--- a/src/Module/Notifications/Introductions.php
+++ b/src/Module/Notifications/Introductions.php
@@ -191,7 +191,7 @@ class Introductions extends BaseNotifications
 		}
 
 		if (count($notifications['notifications']) == 0) {
-			notice(DI::l10n()->t('No introductions.') . EOL);
+			notice(DI::l10n()->t('No introductions.'));
 			$notificationNoContent = DI::l10n()->t('No more %s notifications.', $notifications['ident']);
 		}
 

--- a/src/Module/Notifications/Introductions.php
+++ b/src/Module/Notifications/Introductions.php
@@ -191,7 +191,7 @@ class Introductions extends BaseNotifications
 		}
 
 		if (count($notifications['notifications']) == 0) {
-			info(DI::l10n()->t('No introductions.') . EOL);
+			notice(DI::l10n()->t('No introductions.') . EOL);
 			$notificationNoContent = DI::l10n()->t('No more %s notifications.', $notifications['ident']);
 		}
 

--- a/src/Module/Profile/Contacts.php
+++ b/src/Module/Profile/Contacts.php
@@ -64,7 +64,7 @@ class Contacts extends BaseProfile
 		$o = self::getTabsHTML($a, 'contacts', $is_owner, $nickname);
 
 		if (!count($a->profile) || $a->profile['hide-friends']) {
-			notice(DI::l10n()->t('Permission denied.') . EOL);
+			notice(DI::l10n()->t('Permission denied.'));
 			return $o;
 		}
 
@@ -92,7 +92,7 @@ class Contacts extends BaseProfile
 		$contacts_stmt = DBA::select('contact', [], $condition, $params);
 
 		if (!DBA::isResult($contacts_stmt)) {
-			notice(DI::l10n()->t('No contacts.') . EOL);
+			notice(DI::l10n()->t('No contacts.'));
 			return $o;
 		}
 

--- a/src/Module/Profile/Contacts.php
+++ b/src/Module/Profile/Contacts.php
@@ -92,7 +92,7 @@ class Contacts extends BaseProfile
 		$contacts_stmt = DBA::select('contact', [], $condition, $params);
 
 		if (!DBA::isResult($contacts_stmt)) {
-			info(DI::l10n()->t('No contacts.') . EOL);
+			notice(DI::l10n()->t('No contacts.') . EOL);
 			return $o;
 		}
 

--- a/src/Module/Profile/Status.php
+++ b/src/Module/Profile/Status.php
@@ -102,7 +102,7 @@ class Status extends BaseProfile
 		$last_updated_key = "profile:" . $a->profile['uid'] . ":" . local_user() . ":" . $remote_contact;
 
 		if (!empty($a->profile['hidewall']) && !$is_owner && !$remote_contact) {
-			notice(DI::l10n()->t('Access to this profile has been restricted.') . EOL);
+			notice(DI::l10n()->t('Access to this profile has been restricted.'));
 			return '';
 		}
 

--- a/src/Module/Search/Index.php
+++ b/src/Module/Search/Index.php
@@ -176,7 +176,7 @@ class Index extends BaseSearch
 		}
 
 		if (!DBA::isResult($r)) {
-			info(DI::l10n()->t('No results.'));
+			notice(DI::l10n()->t('No results.'));
 			return $o;
 		}
 

--- a/src/Module/Search/Saved.php
+++ b/src/Module/Search/Saved.php
@@ -41,16 +41,18 @@ class Saved extends BaseModule
 				case 'add':
 					$fields = ['uid' => local_user(), 'term' => $search];
 					if (!DBA::exists('search', $fields)) {
-						DBA::insert('search', $fields);
-						info(DI::l10n()->t('Search term successfully saved.'));
+						if (!DBA::insert('search', $fields)) {
+							notice(DI::l10n()->t('Search term was not saved.'));
+						}
 					} else {
-						info(DI::l10n()->t('Search term already saved.'));
+						notice(DI::l10n()->t('Search term already saved.'));
 					}
 					break;
 
 				case 'remove':
-					DBA::delete('search', ['uid' => local_user(), 'term' => $search]);
-					info(DI::l10n()->t('Search term successfully removed.'));
+					if (!DBA::delete('search', ['uid' => local_user(), 'term' => $search])) {
+						notice(DI::l10n()->t('Search term was not removed.'));
+					}
 					break;
 			}
 		}

--- a/src/Module/Settings/Profile/Index.php
+++ b/src/Module/Settings/Profile/Index.php
@@ -134,9 +134,7 @@ class Index extends BaseSettings
 			['uid' => local_user()]
 		);
 
-		if ($result) {
-			info(DI::l10n()->t('Profile updated.'));
-		} else {
+		if (!$result) {
 			notice(DI::l10n()->t('Profile couldn\'t be updated.'));
 			return;
 		}

--- a/src/Module/Settings/Profile/Photo/Index.php
+++ b/src/Module/Settings/Profile/Photo/Index.php
@@ -93,9 +93,7 @@ class Index extends BaseSettings
 
 		$filename = '';
 
-		if (Photo::store($Image, local_user(), 0, $resource_id, $filename, DI::l10n()->t('Profile Photos'), 0)) {
-			info(DI::l10n()->t('Image uploaded successfully.'));
-		} else {
+		if (!Photo::store($Image, local_user(), 0, $resource_id, $filename, DI::l10n()->t('Profile Photos'), 0)) {
 			notice(DI::l10n()->t('Image upload failed.'));
 		}
 


### PR DESCRIPTION
Also the EOL had been removed.

When there are places where we disagree whether the message does make sense there, we could add something similar to the loglevel there. Means: We could define a message level so that users could decide on their own, if they want to get all, some or none.