### PR TITLE
Store avatar cache fields only when needed

### DIFF
--- a/mod/dfrn_confirm.php
+++ b/mod/dfrn_confirm.php
@@ -304,7 +304,7 @@ function dfrn_confirm_post(App $a, $handsfree = null)
 		 *
 		 * We will also update the contact record with the nature and scope of the relationship.
 		 */
-		Contact::updateAvatar($contact['photo'], $uid, $contact_id);
+		Contact::updateAvatar($contact_id, $contact['photo']);
 
 		Logger::log('dfrn_confirm: confirm - imported photos');
 
@@ -484,7 +484,7 @@ function dfrn_confirm_post(App $a, $handsfree = null)
 			$photo = DI::baseUrl() . '/images/person-300.jpg';
 		}
 
-		Contact::updateAvatar($photo, $local_uid, $dfrn_record);
+		Contact::updateAvatar($dfrn_record, $photo);
 
 		Logger::log('dfrn_confirm: request - photos imported');
 

--- a/mod/dfrn_request.php
+++ b/mod/dfrn_request.php
@@ -189,7 +189,7 @@ function dfrn_request_post(App $a)
 					Group::addMember(User::getDefaultGroup(local_user(), $r[0]["network"]), $r[0]['id']);
 
 					if (isset($photo)) {
-						Contact::updateAvatar($photo, local_user(), $r[0]["id"], true);
+						Contact::updateAvatar($r[0]["id"], $photo, true);
 					}
 
 					$forward_path = "contact/" . $r[0]['id'];
@@ -420,7 +420,7 @@ function dfrn_request_post(App $a)
 					);
 					if (DBA::isResult($r)) {
 						$contact_record = $r[0];
-						Contact::updateAvatar($photo, $uid, $contact_record["id"], true);
+						Contact::updateAvatar($contact_record["id"], $photo, true);
 					}
 				}
 			}

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -1703,6 +1703,10 @@ class Item
 			'photo' => $item['owner-avatar'], 'network' => $item['network']];
 		$item['owner-id'] = ($item['owner-id'] ?? 0) ?: Contact::getIdForURL($item['owner-link'], 0, null, $default);
 
+		// Ensure that there is an avatar cache
+		Contact::checkAvatarCache($item['author-id']);
+		Contact::checkAvatarCache($item['owner-id']);
+
 		// The contact-id should be set before "self::insert" was called - but there seems to be issues sometimes
 		$item["contact-id"] = self::contactId($item);
 

--- a/src/Module/Contact/Advanced.php
+++ b/src/Module/Contact/Advanced.php
@@ -87,7 +87,7 @@ class Advanced extends BaseModule
 		if ($photo) {
 			DI::logger()->notice('Updating photo.', ['photo' => $photo]);
 
-			Model\Contact::updateAvatar($photo, local_user(), $contact['id'], true);
+			Model\Contact::updateAvatar($contact['id'], $photo, true);
 		}
 
 		if (!$r) {

--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -1680,11 +1680,11 @@ class DFRN
 			$condition = ['uid' => 0, 'nurl' => Strings::normaliseLink($contact_old['url'])];
 			DBA::update('contact', $fields, $condition, true);
 
-			Contact::updateAvatar($author['avatar'], $importer['importer_uid'], $contact['id']);
+			Contact::updateAvatar($contact['id'], $author['avatar']);
 
 			$pcid = Contact::getIdForURL($contact_old['url']);
 			if (!empty($pcid)) {
-				Contact::updateAvatar($author['avatar'], 0, $pcid);
+				Contact::updateAvatar($pcid, $author['avatar']);
 			}
 
 			/*
@@ -1962,7 +1962,7 @@ class DFRN
 
 		DBA::update('contact', $fields, $condition);
 
-		Contact::updateAvatar($relocate["avatar"], $importer["importer_uid"], $importer["id"], true);
+		Contact::updateAvatar($importer["id"], $relocate["avatar"], true);
 
 		Logger::log('Contacts are updated.');
 

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -2410,7 +2410,7 @@ class Diaspora
 			$image_url = "http://".$handle_parts[1].$image_url;
 		}
 
-		Contact::updateAvatar($image_url, $importer["uid"], $contact["id"]);
+		Contact::updateAvatar($contact["id"], $image_url);
 
 		// Generic birthday. We don't know the timezone. The year is irrelevant.
 

--- a/src/Protocol/OStatus.php
+++ b/src/Protocol/OStatus.php
@@ -216,7 +216,7 @@ class OStatus
 
 			if (!empty($author["author-avatar"]) && ($author["author-avatar"] != $current['avatar'])) {
 				Logger::log("Update profile picture for contact ".$contact["id"], Logger::DEBUG);
-				Contact::updateAvatar($author["author-avatar"], $importer["uid"], $contact["id"]);
+				Contact::updateAvatar($contact["id"], $author["author-avatar"]);
 			}
 
 			// Ensure that we are having this contact (with uid=0)
@@ -237,7 +237,7 @@ class OStatus
 
 				// Update the avatar
 				if (!empty($author["author-avatar"])) {
-					Contact::updateAvatar($author["author-avatar"], 0, $cid);
+					Contact::updateAvatar($cid, $author["author-avatar"]);
 				}
 			}
 


### PR DESCRIPTION
To be able to remove the `gcontact` table, we have to ensure to not waste too much disc space with avatar pictures that aren't displayed at all. So for public contacts we now only store these values when the contacts are used for stored items.

Most likely we will discover some more places where the cache has to be activated as well - but this will be done when needed.

Attention: The corresponding PR https://github.com/friendica/friendica-addons/pull/1008 for the addons has to merged at the same time since the parameter order of a function had been changed.