### PR TITLE
Various performance improvements

### DIFF
--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -1098,7 +1098,7 @@ class BBCode
 			@curl_exec($ch);
 			$curl_info = @curl_getinfo($ch);
 
-			DI::profiler()->saveTimestamp($stamp1, "network", System::callstack());
+			DI::profiler()->saveTimestamp($stamp1, "network");
 
 			if (substr($curl_info['content_type'], 0, 6) == 'image/') {
 				$text = "[url=" . $match[1] . ']' . $match[1] . "[/url]";
@@ -1172,7 +1172,7 @@ class BBCode
 		@curl_exec($ch);
 		$curl_info = @curl_getinfo($ch);
 
-		DI::profiler()->saveTimestamp($stamp1, "network", System::callstack());
+		DI::profiler()->saveTimestamp($stamp1, "network");
 
 		// if its a link to a picture then embed this picture
 		if (substr($curl_info['content_type'], 0, 6) == 'image/') {
@@ -2045,7 +2045,7 @@ class BBCode
 		// Now convert HTML to Markdown
 		$text = HTML::toMarkdown($text);
 
-		DI::profiler()->saveTimestamp($stamp1, "parser", System::callstack());
+		DI::profiler()->saveTimestamp($stamp1, "parser");
 
 		// Libertree has a problem with escaped hashtags.
 		$text = str_replace(['\#'], ['#'], $text);

--- a/src/Content/Text/Markdown.php
+++ b/src/Content/Text/Markdown.php
@@ -57,7 +57,7 @@ class Markdown
 
 		$html = $MarkdownParser->transform($text);
 
-		DI::profiler()->saveTimestamp($stamp1, "parser", System::callstack());
+		DI::profiler()->saveTimestamp($stamp1, "parser");
 
 		return $html;
 	}

--- a/src/Core/Addon.php
+++ b/src/Core/Addon.php
@@ -256,7 +256,7 @@ class Addon
 
 		$stamp1 = microtime(true);
 		$f = file_get_contents("addon/$addon/$addon.php");
-		DI::profiler()->saveTimestamp($stamp1, "file", System::callstack());
+		DI::profiler()->saveTimestamp($stamp1, "file");
 
 		$r = preg_match("|/\*.*\*/|msU", $f, $m);
 

--- a/src/Core/Addon.php
+++ b/src/Core/Addon.php
@@ -136,7 +136,7 @@ class Addon
 			$func();
 		}
 
-		DBA::delete('hook', ['file' => 'addon/' . $addon . '/' . $addon . '.php']);
+		Hook::delete(['file' => 'addon/' . $addon . '/' . $addon . '.php']);
 
 		unset(self::$addons[array_search($addon, self::$addons)]);
 	}
@@ -204,17 +204,9 @@ class Addon
 			}
 
 			Logger::notice("Addon {addon}: {action}", ['action' => 'reload', 'addon' => $addon['name']]);
-			@include_once($fname);
 
-			if (function_exists($addonname . '_uninstall')) {
-				$func = $addonname . '_uninstall';
-				$func(DI::app());
-			}
-			if (function_exists($addonname . '_install')) {
-				$func = $addonname . '_install';
-				$func(DI::app());
-			}
-			DBA::update('addon', ['timestamp' => $t], ['id' => $addon['id']]);
+			self::uninstall($fname);
+			self::install($fname);
 		}
 	}
 

--- a/src/Core/Cache/ProfilerCache.php
+++ b/src/Core/Cache/ProfilerCache.php
@@ -56,7 +56,7 @@ class ProfilerCache implements ICache, IMemoryCache
 
 		$return = $this->cache->getAllKeys($prefix);
 
-		$this->profiler->saveTimestamp($time, 'cache', System::callstack());
+		$this->profiler->saveTimestamp($time, 'cache');
 
 		return $return;
 	}
@@ -70,7 +70,7 @@ class ProfilerCache implements ICache, IMemoryCache
 
 		$return = $this->cache->get($key);
 
-		$this->profiler->saveTimestamp($time, 'cache', System::callstack());
+		$this->profiler->saveTimestamp($time, 'cache');
 
 		return $return;
 	}
@@ -84,7 +84,7 @@ class ProfilerCache implements ICache, IMemoryCache
 
 		$return = $this->cache->set($key, $value, $ttl);
 
-		$this->profiler->saveTimestamp($time, 'cache', System::callstack());
+		$this->profiler->saveTimestamp($time, 'cache');
 
 		return $return;
 	}
@@ -98,7 +98,7 @@ class ProfilerCache implements ICache, IMemoryCache
 
 		$return = $this->cache->delete($key);
 
-		$this->profiler->saveTimestamp($time, 'cache', System::callstack());
+		$this->profiler->saveTimestamp($time, 'cache');
 
 		return $return;
 	}
@@ -112,7 +112,7 @@ class ProfilerCache implements ICache, IMemoryCache
 
 		$return = $this->cache->clear($outdated);
 
-		$this->profiler->saveTimestamp($time, 'cache', System::callstack());
+		$this->profiler->saveTimestamp($time, 'cache');
 
 		return $return;
 	}
@@ -127,7 +127,7 @@ class ProfilerCache implements ICache, IMemoryCache
 
 			$return = $this->cache->add($key, $value, $ttl);
 
-			$this->profiler->saveTimestamp($time, 'cache', System::callstack());
+			$this->profiler->saveTimestamp($time, 'cache');
 
 			return $return;
 		} else {
@@ -145,7 +145,7 @@ class ProfilerCache implements ICache, IMemoryCache
 
 			$return = $this->cache->compareSet($key, $oldValue, $newValue, $ttl);
 
-			$this->profiler->saveTimestamp($time, 'cache', System::callstack());
+			$this->profiler->saveTimestamp($time, 'cache');
 
 			return $return;
 		} else {
@@ -163,7 +163,7 @@ class ProfilerCache implements ICache, IMemoryCache
 
 			$return = $this->cache->compareDelete($key, $value);
 
-			$this->profiler->saveTimestamp($time, 'cache', System::callstack());
+			$this->profiler->saveTimestamp($time, 'cache');
 
 			return $return;
 		} else {

--- a/src/Core/Hook.php
+++ b/src/Core/Hook.php
@@ -247,6 +247,8 @@ class Hook
 	/**
 	 * Deletes one or more hook records
 	 *
+	 * We have to clear the cached routerDispatchData because addons can provide routes
+	 *
 	 * @param array $condition
 	 * @param array $options
 	 * @return bool
@@ -256,11 +258,17 @@ class Hook
 	{
 		$result = DBA::delete('hook', $condition, $options);
 
+		if ($result) {
+			DI::cache()->delete('routerDispatchData');
+		}
+
 		return $result;
 	}
 
 	/**
 	 * Inserts a hook record
+	 *
+	 * We have to clear the cached routerDispatchData because addons can provide routes
 	 *
 	 * @param array $condition
 	 * @return bool
@@ -269,6 +277,10 @@ class Hook
 	private static function insert(array $condition)
 	{
 		$result = DBA::insert('hook', $condition);
+
+		if ($result) {
+			DI::cache()->delete('routerDispatchData');
+		}
 
 		return $result;
 	}

--- a/src/Core/Hook.php
+++ b/src/Core/Hook.php
@@ -99,9 +99,7 @@ class Hook
 			return true;
 		}
 
-		$result = DBA::insert('hook', ['hook' => $hook, 'file' => $file, 'function' => $function, 'priority' => $priority]);
-
-		return $result;
+		return self::insert(['hook' => $hook, 'file' => $file, 'function' => $function, 'priority' => $priority]);
 	}
 
 	/**
@@ -119,10 +117,10 @@ class Hook
 
 		// This here is only needed for fixing a problem that existed on the develop branch
 		$condition = ['hook' => $hook, 'file' => $file, 'function' => $function];
-		DBA::delete('hook', $condition);
+		self::delete($condition);
 
 		$condition = ['hook' => $hook, 'file' => $relative_file, 'function' => $function];
-		$result = DBA::delete('hook', $condition);
+		$result = self::delete($condition);
 		return $result;
 	}
 
@@ -220,7 +218,7 @@ class Hook
 		} else {
 			// remove orphan hooks
 			$condition = ['hook' => $name, 'file' => $hook[0], 'function' => $hook[1]];
-			DBA::delete('hook', $condition, ['cascade' => false]);
+			self::delete($condition, ['cascade' => false]);
 		}
 	}
 
@@ -244,5 +242,34 @@ class Hook
 		}
 
 		return false;
+	}
+
+	/**
+	 * Deletes one or more hook records
+	 *
+	 * @param array $condition
+	 * @param array $options
+	 * @return bool
+	 * @throws \Exception
+	 */
+	public static function delete(array $condition, array $options = [])
+	{
+		$result = DBA::delete('hook', $condition, $options);
+
+		return $result;
+	}
+
+	/**
+	 * Inserts a hook record
+	 *
+	 * @param array $condition
+	 * @return bool
+	 * @throws \Exception
+	 */
+	private static function insert(array $condition)
+	{
+		$result = DBA::insert('hook', $condition);
+
+		return $result;
 	}
 }

--- a/src/Core/Renderer.php
+++ b/src/Core/Renderer.php
@@ -92,7 +92,7 @@ class Renderer
 			throw new InternalServerErrorException($message);
 		}
 
-		DI::profiler()->saveTimestamp($stamp1, "rendering", System::callstack());
+		DI::profiler()->saveTimestamp($stamp1, "rendering");
 
 		return $output;
 	}
@@ -121,7 +121,7 @@ class Renderer
 			throw new InternalServerErrorException($message);
 		}
 
-		DI::profiler()->saveTimestamp($stamp1, "file", System::callstack());
+		DI::profiler()->saveTimestamp($stamp1, "file");
 
 		return $template;
 	}

--- a/src/Core/System.php
+++ b/src/Core/System.php
@@ -33,16 +33,17 @@ class System
 	/**
 	 * Returns a string with a callstack. Can be used for logging.
 	 *
-	 * @param integer $depth optional, default 4
+	 * @param integer $depth  How many calls to include in the stacks after filtering
+	 * @param int     $offset How many calls to shave off the top of the stack, for example if
+	 *                        this is called from a centralized method that isn't relevant to the callstack
 	 * @return string
 	 */
-	public static function callstack($depth = 4)
+	public static function callstack(int $depth = 4, int $offset = 0)
 	{
 		$trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
 
-		// We remove the first two items from the list since they contain data that we don't need.
-		array_shift($trace);
-		array_shift($trace);
+		// We remove at least the first two items from the list since they contain data that we don't need.
+		$trace = array_slice($trace, 2 + $offset);
 
 		$callstack = [];
 		$previous = ['class' => '', 'function' => '', 'database' => false];

--- a/src/Core/Theme.php
+++ b/src/Core/Theme.php
@@ -158,6 +158,8 @@ class Theme
 			if (function_exists($func)) {
 				$func();
 			}
+
+			Hook::delete(['file' => "view/theme/$theme/theme.php"]);
 		}
 
 		$allowed_themes = Theme::getAllowedList();

--- a/src/Core/Theme.php
+++ b/src/Core/Theme.php
@@ -90,7 +90,7 @@ class Theme
 
 		$stamp1 = microtime(true);
 		$theme_file = file_get_contents("view/theme/$theme/theme.php");
-		DI::profiler()->saveTimestamp($stamp1, "file", System::callstack());
+		DI::profiler()->saveTimestamp($stamp1, "file");
 
 		$result = preg_match("|/\*.*\*/|msU", $theme_file, $matches);
 

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -699,7 +699,7 @@ class Database
 			$this->errorno = $errorno;
 		}
 
-		$this->profiler->saveTimestamp($stamp1, 'database', System::callstack());
+		$this->profiler->saveTimestamp($stamp1, 'database');
 
 		if ($this->configCache->get('system', 'db_log')) {
 			$stamp2   = microtime(true);
@@ -783,7 +783,7 @@ class Database
 			$this->errorno = $errorno;
 		}
 
-		$this->profiler->saveTimestamp($stamp, "database_write", System::callstack());
+		$this->profiler->saveTimestamp($stamp, "database_write");
 
 		return $retval;
 	}
@@ -964,7 +964,7 @@ class Database
 				}
 		}
 
-		$this->profiler->saveTimestamp($stamp1, 'database', System::callstack());
+		$this->profiler->saveTimestamp($stamp1, 'database');
 
 		return $columns;
 	}
@@ -1644,7 +1644,7 @@ class Database
 				break;
 		}
 
-		$this->profiler->saveTimestamp($stamp1, 'database', System::callstack());
+		$this->profiler->saveTimestamp($stamp1, 'database');
 
 		return $ret;
 	}

--- a/src/Factory/SessionFactory.php
+++ b/src/Factory/SessionFactory.php
@@ -85,7 +85,7 @@ class SessionFactory
 				$session = new Session\Native($baseURL, $handler);
 			}
 		} finally {
-			$profiler->saveTimestamp($stamp1, 'parser', System::callstack());
+			$profiler->saveTimestamp($stamp1, 'parser');
 			return $session;
 		}
 	}

--- a/src/Network/HTTPRequest.php
+++ b/src/Network/HTTPRequest.php
@@ -199,7 +199,7 @@ class HTTPRequest implements IHTTPRequest
 
 		@curl_close($ch);
 
-		$this->profiler->saveTimestamp($stamp1, 'network', System::callstack());
+		$this->profiler->saveTimestamp($stamp1, 'network');
 
 		return $curlResponse;
 	}
@@ -285,7 +285,7 @@ class HTTPRequest implements IHTTPRequest
 
 		curl_close($ch);
 
-		$this->profiler->saveTimestamp($stamp1, 'network', System::callstack());
+		$this->profiler->saveTimestamp($stamp1, 'network');
 
 		// Very old versions of Lighttpd don't like the "Expect" header, so we remove it when needed
 		if ($curlResponse->getReturnCode() == 417) {
@@ -335,7 +335,7 @@ class HTTPRequest implements IHTTPRequest
 		$http_code = $curl_info['http_code'];
 		curl_close($ch);
 
-		$this->profiler->saveTimestamp($stamp1, "network", System::callstack());
+		$this->profiler->saveTimestamp($stamp1, "network");
 
 		if ($http_code == 0) {
 			return $url;
@@ -377,7 +377,7 @@ class HTTPRequest implements IHTTPRequest
 		$body = curl_exec($ch);
 		curl_close($ch);
 
-		$this->profiler->saveTimestamp($stamp1, "network", System::callstack());
+		$this->profiler->saveTimestamp($stamp1, "network");
 
 		if (trim($body) == "") {
 			return $url;

--- a/src/Object/Image.php
+++ b/src/Object/Image.php
@@ -625,7 +625,7 @@ class Image
 
 		$stamp1 = microtime(true);
 		file_put_contents($path, $string);
-		DI::profiler()->saveTimestamp($stamp1, "file", System::callstack());
+		DI::profiler()->saveTimestamp($stamp1, "file");
 	}
 
 	/**

--- a/src/Util/Images.php
+++ b/src/Util/Images.php
@@ -200,7 +200,7 @@ class Images
 
 				$stamp1 = microtime(true);
 				file_put_contents($tempfile, $img_str);
-				DI::profiler()->saveTimestamp($stamp1, "file", System::callstack());
+				DI::profiler()->saveTimestamp($stamp1, "file");
 
 				$data = getimagesize($tempfile);
 				unlink($tempfile);

--- a/src/Util/Logger/ProfilerLogger.php
+++ b/src/Util/Logger/ProfilerLogger.php
@@ -61,7 +61,7 @@ class ProfilerLogger implements LoggerInterface
 	{
 		$stamp1 = microtime(true);
 		$this->logger->emergency($message, $context);
-		$this->profiler->saveTimestamp($stamp1, 'file', System::callstack());
+		$this->profiler->saveTimestamp($stamp1, 'file');
 	}
 
 	/**
@@ -71,7 +71,7 @@ class ProfilerLogger implements LoggerInterface
 	{
 		$stamp1 = microtime(true);
 		$this->logger->alert($message, $context);
-		$this->profiler->saveTimestamp($stamp1, 'file', System::callstack());
+		$this->profiler->saveTimestamp($stamp1, 'file');
 	}
 
 	/**
@@ -81,7 +81,7 @@ class ProfilerLogger implements LoggerInterface
 	{
 		$stamp1 = microtime(true);
 		$this->logger->critical($message, $context);
-		$this->profiler->saveTimestamp($stamp1, 'file', System::callstack());
+		$this->profiler->saveTimestamp($stamp1, 'file');
 	}
 
 	/**
@@ -91,7 +91,7 @@ class ProfilerLogger implements LoggerInterface
 	{
 		$stamp1 = microtime(true);
 		$this->logger->error($message, $context);
-		$this->profiler->saveTimestamp($stamp1, 'file', System::callstack());
+		$this->profiler->saveTimestamp($stamp1, 'file');
 	}
 
 	/**
@@ -101,7 +101,7 @@ class ProfilerLogger implements LoggerInterface
 	{
 		$stamp1 = microtime(true);
 		$this->logger->warning($message, $context);
-		$this->profiler->saveTimestamp($stamp1, 'file', System::callstack());
+		$this->profiler->saveTimestamp($stamp1, 'file');
 	}
 
 	/**
@@ -111,7 +111,7 @@ class ProfilerLogger implements LoggerInterface
 	{
 		$stamp1 = microtime(true);
 		$this->logger->notice($message, $context);
-		$this->profiler->saveTimestamp($stamp1, 'file', System::callstack());
+		$this->profiler->saveTimestamp($stamp1, 'file');
 	}
 
 	/**
@@ -121,7 +121,7 @@ class ProfilerLogger implements LoggerInterface
 	{
 		$stamp1 = microtime(true);
 		$this->logger->info($message, $context);
-		$this->profiler->saveTimestamp($stamp1, 'file', System::callstack());
+		$this->profiler->saveTimestamp($stamp1, 'file');
 	}
 
 	/**
@@ -131,7 +131,7 @@ class ProfilerLogger implements LoggerInterface
 	{
 		$stamp1 = microtime(true);
 		$this->logger->debug($message, $context);
-		$this->profiler->saveTimestamp($stamp1, 'file', System::callstack());
+		$this->profiler->saveTimestamp($stamp1, 'file');
 	}
 
 	/**
@@ -141,6 +141,6 @@ class ProfilerLogger implements LoggerInterface
 	{
 		$stamp1 = microtime(true);
 		$this->logger->log($level, $message, $context);
-		$this->profiler->saveTimestamp($stamp1, 'file', System::callstack());
+		$this->profiler->saveTimestamp($stamp1, 'file');
 	}
 }

--- a/src/Util/Profiler.php
+++ b/src/Util/Profiler.php
@@ -23,6 +23,7 @@ namespace Friendica\Util;
 
 use Friendica\Core\Config\Cache;
 use Friendica\Core\Config\IConfig;
+use Friendica\Core\System;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
@@ -88,15 +89,17 @@ class Profiler implements ContainerInterface
 	 * Saves a timestamp for a value - f.e. a call
 	 * Necessary for profiling Friendica
 	 *
-	 * @param int $timestamp the Timestamp
-	 * @param string $value A value to profile
-	 * @param string $callstack The callstack of the current profiling data
+	 * @param int    $timestamp the Timestamp
+	 * @param string $value     A value to profile
+	 * @param string $callstack A callstack string, generated if absent
 	 */
 	public function saveTimestamp($timestamp, $value, $callstack = '')
 	{
 		if (!$this->enabled) {
 			return;
 		}
+
+		$callstack = $callstack ?: System::callstack(4, 1);
 
 		$duration = floatval(microtime(true) - $timestamp);
 

--- a/static/dependencies.config.php
+++ b/static/dependencies.config.php
@@ -191,10 +191,9 @@ return [
 	],
 	App\Router::class => [
 		'constructParams' => [
-			$_SERVER, null
-		],
-		'call' => [
-			['loadRoutes', [include __DIR__ . '/routes.config.php'], Dice::CHAIN_CALL],
+			$_SERVER,
+			__DIR__ . '/routes.config.php',
+			null
 		],
 	],
 	L10n::class => [

--- a/tests/src/App/ModuleTest.php
+++ b/tests/src/App/ModuleTest.php
@@ -22,6 +22,7 @@
 namespace Friendica\Test\src\App;
 
 use Friendica\App;
+use Friendica\Core\Cache\ICache;
 use Friendica\Core\Config\IConfig;
 use Friendica\Core\L10n;
 use Friendica\LegacyModule;
@@ -175,7 +176,11 @@ class ModuleTest extends DatabaseTest
 		$l10n = \Mockery::mock(L10n::class);
 		$l10n->shouldReceive('t')->andReturnUsing(function ($args) { return $args; });
 
-		$router = (new App\Router([], $l10n))->loadRoutes(include __DIR__ . '/../../../static/routes.config.php');
+		$cache = \Mockery::mock(ICache::class);
+		$cache->shouldReceive('get')->with('routerDispatchData')->andReturn('')->atMost()->once();
+		$cache->shouldReceive('set')->withAnyArgs()->andReturn(false)->atMost()->once();
+
+		$router = (new App\Router([], __DIR__ . '/../../../static/routes.config.php', $l10n, $cache));
 
 		$module = (new App\Module($name))->determineClass(new App\Arguments('', $command), $router, $config);
 

--- a/tests/src/Util/Logger/ProfilerLoggerTest.php
+++ b/tests/src/Util/Logger/ProfilerLoggerTest.php
@@ -58,7 +58,7 @@ class ProfilerLoggerTest extends MockedTest
 		$logger = new ProfilerLogger($this->logger, $this->profiler);
 
 		$this->logger->shouldReceive($function)->with($message, $context)->once();
-		$this->profiler->shouldReceive('saveTimestamp')->with(\Mockery::any(), 'file', \Mockery::any())->once();
+		$this->profiler->shouldReceive('saveTimestamp')->with(\Mockery::any(), 'file')->once();
 		$logger->$function($message, $context);
 	}
 
@@ -70,7 +70,7 @@ class ProfilerLoggerTest extends MockedTest
 		$logger = new ProfilerLogger($this->logger, $this->profiler);
 
 		$this->logger->shouldReceive('log')->with(LogLevel::WARNING, 'test', ['a' => 'context'])->once();
-		$this->profiler->shouldReceive('saveTimestamp')->with(\Mockery::any(), 'file', \Mockery::any())->once();
+		$this->profiler->shouldReceive('saveTimestamp')->with(\Mockery::any(), 'file')->once();
 
 		$logger->log(LogLevel::WARNING, 'test', ['a' => 'context']);
 	}

--- a/view/theme/frio/theme.php
+++ b/view/theme/frio/theme.php
@@ -54,18 +54,6 @@ function frio_install()
 	Logger::log('installed theme frio');
 }
 
-function frio_uninstall()
-{
-	Hook::unregister('prepare_body_final', 'view/theme/frio/theme.php', 'frio_item_photo_links');
-	Hook::unregister('item_photo_menu', 'view/theme/frio/theme.php', 'frio_item_photo_menu');
-	Hook::unregister('contact_photo_menu', 'view/theme/frio/theme.php', 'frio_contact_photo_menu');
-	Hook::unregister('nav_info', 'view/theme/frio/theme.php', 'frio_remote_nav');
-	Hook::unregister('acl_lookup_end', 'view/theme/frio/theme.php', 'frio_acl_lookup');
-	Hook::unregister('display_item', 'view/theme/frio/theme.php', 'frio_display_item');
-
-	Logger::log('uninstalled theme frio');
-}
-
 /**
  * Replace friendica photo links hook
  *


### PR DESCRIPTION
Closes #8929 

Two-parter:
- `System::callstack` is now called only when the profiler is enabled: saves ~850ms per request
- The router dispatch data is now cached: saves ~850ms per request

Friendica should feel slightly snappier now.