### PR TITLE
Selective probing for AP

### DIFF
--- a/src/Model/ContactRelation.php
+++ b/src/Model/ContactRelation.php
@@ -101,7 +101,7 @@ class ContactRelation
 			return;
 		}
 
-		if (in_array($contact['network'], [Protocol::ACTIVITYPUB, Protocol::DFRN])) {
+		if (in_array($contact['network'], [Protocol::ACTIVITYPUB, Protocol::DFRN, Protocol::OSTATUS])) {
 			// The contact is (most likely) speaking AP, so updating is allowed
 			$apcontact = APContact::getByURL($url);
 		} else {

--- a/src/Model/ContactRelation.php
+++ b/src/Model/ContactRelation.php
@@ -22,6 +22,7 @@
 namespace Friendica\Model;
 
 use Friendica\Core\Logger;
+use Friendica\Core\Protocol;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Protocol\ActivityPub;
@@ -100,7 +101,13 @@ class ContactRelation
 			return;
 		}
 
-		$apcontact = APContact::getByURL($url);
+		if (in_array($contact['network'], [Protocol::ACTIVITYPUB, Protocol::DFRN])) {
+			// The contact is (most likely) speaking AP, so updating is allowed
+			$apcontact = APContact::getByURL($url);
+		} else {
+			// The contact isn't obviously speaking AP, so we don't allow updating
+			$apcontact = APContact::getByURL($url, false);
+		}
 
 		if (!empty($apcontact['followers']) && is_string($apcontact['followers'])) {
 			$followers = ActivityPub::fetchItems($apcontact['followers']);


### PR DESCRIPTION
We only should probe contacts for their AP data when we expect it. For the other protocols we only look but don't probe. (Hubzilla or Socialhome can both do AP and Diaspora)