### PR TITLE
AP: Always sign HTTP requests

### DIFF
--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -3705,8 +3705,10 @@ class Item
 	 */
 	public static function fetchByLink(string $uri, int $uid = 0)
 	{
+		Logger::info('Trying to fetch link', ['uid' => $uid, 'uri' => $uri]);
 		$item_id = self::searchByLink($uri, $uid);
 		if (!empty($item_id)) {
+			Logger::info('Link found', ['uid' => $uid, 'uri' => $uri, 'id' => $item_id]);
 			return $item_id;
 		}
 
@@ -3717,9 +3719,11 @@ class Item
 		}
 
 		if (!empty($item_id)) {
+			Logger::info('Link fetched', ['uid' => $uid, 'uri' => $uri, 'id' => $item_id]);
 			return $item_id;
 		}
 
+		Logger::info('Link not found', ['uid' => $uid, 'uri' => $uri]);
 		return 0;
 	}
 

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -193,17 +193,14 @@ class User
 	 */
 	public static function getFirstAdmin(array $fields = [])
 	{
-		$condition = [];
 		if (!empty(DI::config()->get('config', 'admin_nickname'))) {
-			$condition['nickname'] = DI::config()->get('config', 'admin_nickname');
-		}
-		if (!empty(DI::config()->get('config', 'admin_email'))) {
+			$administrator = self::getByNickname(DI::config()->get('config', 'admin_nickname'), $fields);
+		} elseif (!empty(DI::config()->get('config', 'admin_email'))) {
 			$adminList = explode(',', str_replace(' ', '', DI::config()->get('config', 'admin_email')));
-			$condition['email'] = $adminList[0];
 			$administrator = self::getByEmail($adminList[0], $fields);
-			if (!empty($administrator)) {
-				return $administrator;
-			}
+		}
+		if (!empty($administrator)) {
+			return $administrator;
 		}
 		return [];
 	}

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -186,6 +186,29 @@ class User
 	}
 
 	/**
+	 * Fetch the user array of the administrator. The first one if there are several.
+	 *
+	 * @param array $fields
+	 * @return array user
+	 */
+	public static function getFirstAdmin(array $fields = [])
+	{
+		$condition = [];
+		if (!empty(DI::config()->get('config', 'admin_nickname'))) {
+			$condition['nickname'] = DI::config()->get('config', 'admin_nickname');
+		}
+		if (!empty(DI::config()->get('config', 'admin_email'))) {
+			$adminList = explode(',', str_replace(' ', '', DI::config()->get('config', 'admin_email')));
+			$condition['email'] = $adminList[0];
+			$administrator = self::getByEmail($adminList[0], $fields);
+			if (!empty($administrator)) {
+				return $administrator;
+			}
+		}
+		return [];
+	}
+
+	/**
 	 * Get owner data by user id
 	 *
 	 * @param int $uid

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -194,15 +194,13 @@ class User
 	public static function getFirstAdmin(array $fields = [])
 	{
 		if (!empty(DI::config()->get('config', 'admin_nickname'))) {
-			$administrator = self::getByNickname(DI::config()->get('config', 'admin_nickname'), $fields);
+			return self::getByNickname(DI::config()->get('config', 'admin_nickname'), $fields);
 		} elseif (!empty(DI::config()->get('config', 'admin_email'))) {
 			$adminList = explode(',', str_replace(' ', '', DI::config()->get('config', 'admin_email')));
-			$administrator = self::getByEmail($adminList[0], $fields);
+			return self::getByEmail($adminList[0], $fields);
+		} else {
+			return [];
 		}
-		if (!empty($administrator)) {
-			return $administrator;
-		}
-		return [];
 	}
 
 	/**

--- a/src/Module/Friendica.php
+++ b/src/Module/Friendica.php
@@ -130,21 +130,13 @@ class Friendica extends BaseModule
 			$register_policy = $register_policies[$register_policy_int];
 		}
 
-		$condition = [];
-		$admin = false;
-		if (!empty($config->get('config', 'admin_nickname'))) {
-			$condition['nickname'] = $config->get('config', 'admin_nickname');
-		}
-		if (!empty($config->get('config', 'admin_email'))) {
-			$adminList = explode(',', str_replace(' ', '', $config->get('config', 'admin_email')));
-			$condition['email'] = $adminList[0];
-			$administrator = User::getByEmail($adminList[0], ['username', 'nickname']);
-			if (!empty($administrator)) {
-				$admin = [
-					'name'    => $administrator['username'],
-					'profile' => DI::baseUrl()->get() . '/profile/' . $administrator['nickname'],
-				];
-			}
+		$admin = [];
+		$administrator = User::getFirstAdmin(['username', 'nickname']);
+		if (!empty($administrator)) {
+			$admin = [
+				'name'    => $administrator['username'],
+				'profile' => DI::baseUrl()->get() . '/profile/' . $administrator['nickname'],
+			];
 		}
 
 		$visible_addons = Addon::getVisibleList();


### PR DESCRIPTION
See here: https://forum.friendi.ca/display/d8230ed6-515f-2083-ca77-075356461160

Mastodon can be configured to only accept signed HTTP requests - so we now sign them. SInce we don't always work in a user context we simply use the administrator or the first found user.