### PR TITLE
Asynchronous contact relation check

### DIFF
--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -2075,7 +2075,7 @@ class Contact
 	 * @throws HTTPException\InternalServerErrorException
 	 * @throws \ImagickException
 	 */
-	public static function updateFromProbe($id, $network = '', $force = false)
+	public static function updateFromProbe(int $id, string $network = '', bool $force = false)
 	{
 		/*
 		  Warning: Never ever fetch the public key via Probe::uri and write it into the contacts.
@@ -2123,6 +2123,10 @@ class Contact
 			return false;
 		}
 
+		if (ContactRelation::isDiscoverable($ret['url'])) {
+			Worker::add(PRIORITY_LOW, 'ContactDiscovery', $ret['url']);
+		}
+
 		if (isset($ret['hide']) && is_bool($ret['hide'])) {
 			$ret['unsearchable'] = $ret['hide'];
 		}
@@ -2146,8 +2150,6 @@ class Contact
 		if ($uid == 0) {
 			GContact::updateFromPublicContactID($id);
 		}
-
-		ContactRelation::discoverByUrl($ret['url']);
 
 		$update = false;
 

--- a/src/Worker/ContactDiscovery.php
+++ b/src/Worker/ContactDiscovery.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Friendica\Worker;
+
+use Friendica\Model\ContactRelation;
+
+class ContactDiscovery
+{
+	/**
+	 * Discover contact relations
+	 * @param string $url
+	 */
+	public static function execute(string $url)
+	{
+		ContactRelation::discoverByUrl($url);
+	}
+}


### PR DESCRIPTION
Due to perframce reasons the contact relation check is now done as a worker process. And before invoking the worker, the system checks if the worker needs to be called at all.