### PR TITLE
Replace "gcontact" with "contact" - improved suggestions

### DIFF
--- a/mod/suggest.php
+++ b/mod/suggest.php
@@ -26,7 +26,6 @@ use Friendica\Core\Renderer;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Contact;
-use Friendica\Model\GContact;
 
 function suggest_init(App $a)
 {

--- a/mod/suggest.php
+++ b/mod/suggest.php
@@ -60,9 +60,8 @@ function suggest_content(App $a)
 	DI::page()['aside'] .= Widget::follow();
 
 
-	$r = GContact::suggestionQuery(local_user());
-
-	if (! DBA::isResult($r)) {
+	$contacts = Contact::getSuggestions(local_user());
+	if (!DBA::isResult($contacts)) {
 		$o .= DI::l10n()->t('No suggestions available. If this is a new site, please try again in 24 hours.');
 		return $o;
 	}
@@ -94,35 +93,20 @@ function suggest_content(App $a)
 	$id = 0;
 	$entries = [];
 
-	foreach ($r as $rr) {
-		$connlnk = DI::baseUrl() . '/follow/?url=' . (($rr['connect']) ? $rr['connect'] : $rr['url']);
-		$ignlnk = DI::baseUrl() . '/suggest?ignore=' . $rr['id'];
-		$photo_menu = [
-			'profile' => [DI::l10n()->t("View Profile"), Contact::magicLink($rr["url"])],
-			'follow' => [DI::l10n()->t("Connect/Follow"), $connlnk],
-			'hide' => [DI::l10n()->t('Ignore/Hide'), $ignlnk]
-		];
-
-		$contact_details = Contact::getByURLForUser($rr["url"], local_user()) ?: $rr;
-
+	foreach ($contacts as $contact) {
 		$entry = [
-			'url' => Contact::magicLink($rr['url']),
-			'itemurl' => (($contact_details['addr'] != "") ? $contact_details['addr'] : $rr['url']),
-			'img_hover' => $rr['url'],
-			'name' => $contact_details['name'],
-			'thumb' => Contact::getThumb($contact_details),
-			'details'       => $contact_details['location'],
-			'tags'          => $contact_details['keywords'],
-			'about'         => $contact_details['about'],
-			'account_type'  => Contact::getAccountType($contact_details),
-			'ignlnk' => $ignlnk,
-			'ignid' => $rr['id'],
-			'conntxt' => DI::l10n()->t('Connect'),
-			'connlnk' => $connlnk,
-			'photo_menu' => $photo_menu,
-			'ignore' => DI::l10n()->t('Ignore/Hide'),
-			'network' => ContactSelector::networkToName($rr['network'], $rr['url']),
-			'id' => ++$id,
+			'url'          => Contact::magicLink($contact['url']),
+			'itemurl'      => $contact['addr'] ?: $contact['url'],
+			'name'         => $contact['name'],
+			'thumb'        => Contact::getThumb($contact),
+			'img_hover'    => $contact['url'],
+			'details'      => $contact['location'],
+			'tags'         => $contact['keywords'],
+			'about'        => $contact['about'],
+			'account_type' => Contact::getAccountType($contact),
+			'network'      => ContactSelector::networkToName($contact['network'], $contact['url']),
+			'photo_menu'   => Contact::photoMenu($contact),
+			'id'           => ++$id,
 		];
 		$entries[] = $entry;
 	}

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -2982,7 +2982,7 @@ class Contact
 		$diaspora = DI::config()->get('system', 'diaspora_enabled') ? Protocol::DIASPORA : Protocol::ACTIVITYPUB;
 		$ostatus = !DI::config()->get('system', 'ostatus_disabled') ? Protocol::OSTATUS : Protocol::ACTIVITYPUB;
 
-		// The query returns contacts where contacts interacted with who the given user follows.
+		// The query returns contacts where contacts interacted with whom the given user follows.
 		// Contacts who already are in the user's contact table are ignored.
 		$results = DBA::select('contact', [],
 			["`id` IN (SELECT `cid` FROM `contact-relation` WHERE `relation-cid` IN

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -2987,8 +2987,8 @@ class Contact
 		$results = DBA::select('contact', [],
 			["`id` IN (SELECT `cid` FROM `contact-relation` WHERE `relation-cid` IN
 				(SELECT `cid` FROM `contact-relation` WHERE `relation-cid` = ?)
-				AND NOT `cid` IN (SELECT `id` FROM `contact` WHERE `uid` = ? AND `nurl` IN
-					(SELECT `nurl` FROM `contact` WHERE `uid` = ? AND `rel` IN (?, ?))))
+					AND NOT `cid` IN (SELECT `id` FROM `contact` WHERE `uid` = ? AND `nurl` IN
+						(SELECT `nurl` FROM `contact` WHERE `uid` = ? AND `rel` IN (?, ?))))
 			AND NOT `hidden` AND `network` IN (?, ?, ?, ?)",
 			$cid, 0, $uid, Contact::FRIEND, Contact::SHARING,
 			Protocol::ACTIVITYPUB, Protocol::DFRN, $diaspora, $ostatus],
@@ -3011,8 +3011,8 @@ class Contact
 		$results = DBA::select('contact', [],
 			["`id` IN (SELECT `cid` FROM `contact-relation` WHERE `relation-cid` IN
 				(SELECT `relation-cid` FROM `contact-relation` WHERE `cid` = ?)
-				AND NOT `cid` IN (SELECT `id` FROM `contact` WHERE `uid` = ? AND `nurl` IN
-					(SELECT `nurl` FROM `contact` WHERE `uid` = ? AND `rel` IN (?, ?))))
+					AND NOT `cid` IN (SELECT `id` FROM `contact` WHERE `uid` = ? AND `nurl` IN
+						(SELECT `nurl` FROM `contact` WHERE `uid` = ? AND `rel` IN (?, ?))))
 			AND NOT `hidden` AND `network` IN (?, ?, ?, ?)",
 			$cid, 0, $uid, Contact::FRIEND, Contact::SHARING,
 			Protocol::ACTIVITYPUB, Protocol::DFRN, $diaspora, $ostatus],

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -3006,7 +3006,7 @@ class Contact
 			return array_slice($contacts, $start, $limit);
 		}
 
-		// The query returns contacts where contacts interacted with who also interacted with the given user.
+		// The query returns contacts where contacts interacted with whom also interacted with the given user.
 		// Contacts who already are in the user's contact table are ignored.
 		$results = DBA::select('contact', [],
 			["`id` IN (SELECT `cid` FROM `contact-relation` WHERE `relation-cid` IN

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -2915,4 +2915,157 @@ class Contact
 
 		return in_array($protocol, [Protocol::DFRN, Protocol::DIASPORA, Protocol::ACTIVITYPUB]) && !$self;
 	}
+
+	/**
+	 * Search contact table by nick or name
+	 *
+	 * @param string $search Name or nick
+	 * @param string $mode   Search mode (e.g. "community")
+	 *
+	 * @return array with search results
+	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
+	 */
+	public static function searchByName($search, $mode = '')
+	{
+		if (empty($search)) {
+			return [];
+		}
+
+		// check supported networks
+		if (DI::config()->get('system', 'diaspora_enabled')) {
+			$diaspora = Protocol::DIASPORA;
+		} else {
+			$diaspora = Protocol::DFRN;
+		}
+
+		if (!DI::config()->get('system', 'ostatus_disabled')) {
+			$ostatus = Protocol::OSTATUS;
+		} else {
+			$ostatus = Protocol::DFRN;
+		}
+
+		// check if we search only communities or every contact
+		if ($mode === 'community') {
+			$extra_sql = sprintf(' AND `contact-type` = %d', Contact::TYPE_COMMUNITY);
+		} else {
+			$extra_sql = '';
+		}
+
+		$search .= '%';
+
+		$results = DBA::p("SELECT * FROM `contact`
+			WHERE NOT `unsearchable` AND `network` IN (?, ?, ?, ?) AND
+				NOT `failed` AND `uid` = ? AND
+				(`addr` LIKE ? OR `name` LIKE ? OR `nick` LIKE ?) $extra_sql
+				ORDER BY `nurl` DESC LIMIT 1000",
+			Protocol::DFRN, Protocol::ACTIVITYPUB, $ostatus, $diaspora, 0, $search, $search, $search
+		);
+
+		$contacts = DBA::toArray($results);
+		return $contacts;
+	}
+
+	/**
+	 * @param int $uid   user
+	 * @param int $start optional, default 0
+	 * @param int $limit optional, default 80
+	 * @return array
+	 */
+	static public function getSuggestions(int $uid, int $start = 0, int $limit = 80)
+	{
+		$cid = self::getPublicIdByUserId($uid);
+		$totallimit = $start + $limit;
+		$contacts = [];
+
+		Logger::info('Collecting suggestions', ['uid' => $uid, 'cid' => $cid, 'start' => $start, 'limit' => $limit]);
+
+		$diaspora = DI::config()->get('system', 'diaspora_enabled') ? Protocol::DIASPORA : Protocol::ACTIVITYPUB;
+		$ostatus = !DI::config()->get('system', 'ostatus_disabled') ? Protocol::OSTATUS : Protocol::ACTIVITYPUB;
+
+		// The query returns contacts where contacts interacted with who the given user follows.
+		// Contacts who already are in the user's contact table are ignored.
+		$results = DBA::select('contact', [],
+			["`id` IN (SELECT `cid` FROM `contact-relation` WHERE `relation-cid` IN
+				(SELECT `cid` FROM `contact-relation` WHERE `relation-cid` = ?)
+				AND NOT `cid` IN (SELECT `id` FROM `contact` WHERE `uid` = ? AND `nurl` IN
+					(SELECT `nurl` FROM `contact` WHERE `uid` = ? AND `rel` IN (?, ?))))
+			AND NOT `hidden` AND `network` IN (?, ?, ?, ?)",
+			$cid, 0, $uid, Contact::FRIEND, Contact::SHARING,
+			Protocol::ACTIVITYPUB, Protocol::DFRN, $diaspora, $ostatus],
+			['order' => ['last-item' => true], 'limit' => $totallimit]
+		);
+
+		while ($contact = DBA::fetch($results)) {
+			$contacts[$contact['id']] = $contact;
+		}
+		DBA::close($results);
+
+		Logger::info('Contacts of contacts who are followed by the given user', ['uid' => $uid, 'cid' => $cid, 'count' => count($contacts)]);
+
+		if (count($contacts) >= $totallimit) {
+			return array_slice($contacts, $start, $limit);
+		}
+
+		// The query returns contacts where contacts interacted with who also interacted with the given user.
+		// Contacts who already are in the user's contact table are ignored.
+		$results = DBA::select('contact', [],
+			["`id` IN (SELECT `cid` FROM `contact-relation` WHERE `relation-cid` IN
+				(SELECT `relation-cid` FROM `contact-relation` WHERE `cid` = ?)
+				AND NOT `cid` IN (SELECT `id` FROM `contact` WHERE `uid` = ? AND `nurl` IN
+					(SELECT `nurl` FROM `contact` WHERE `uid` = ? AND `rel` IN (?, ?))))
+			AND NOT `hidden` AND `network` IN (?, ?, ?, ?)",
+			$cid, 0, $uid, Contact::FRIEND, Contact::SHARING,
+			Protocol::ACTIVITYPUB, Protocol::DFRN, $diaspora, $ostatus],
+			['order' => ['last-item' => true], 'limit' => $totallimit]
+		);
+
+		while ($contact = DBA::fetch($results)) {
+			$contacts[$contact['id']] = $contact;
+		}
+		DBA::close($results);
+
+		Logger::info('Contacts of contacts who are following the given user', ['uid' => $uid, 'cid' => $cid, 'count' => count($contacts)]);
+
+		if (count($contacts) >= $totallimit) {
+			return array_slice($contacts, $start, $limit);
+		}
+
+		// The query returns contacts that follow the given user but aren't followed by that user.
+		$results = DBA::select('contact', [],
+			["`nurl` IN (SELECT `nurl` FROM `contact` WHERE `uid` = ? AND `rel` = ?)
+			AND NOT `hidden` AND `uid` = ? AND `network` IN (?, ?, ?, ?)",
+			$uid, Contact::FOLLOWER, 0, 
+			Protocol::ACTIVITYPUB, Protocol::DFRN, $diaspora, $ostatus],
+			['order' => ['last-item' => true], 'limit' => $totallimit]
+		);
+
+		while ($contact = DBA::fetch($results)) {
+			$contacts[$contact['id']] = $contact;
+		}
+		DBA::close($results);
+
+		Logger::info('Followers that are not followed by the given user', ['uid' => $uid, 'cid' => $cid, 'count' => count($contacts)]);
+
+		if (count($contacts) >= $totallimit) {
+			return array_slice($contacts, $start, $limit);
+		}
+
+		// The query returns any contact that isn't followed by that user.
+		$results = DBA::select('contact', [],
+			["NOT `nurl` IN (SELECT `nurl` FROM `contact` WHERE `uid` = ? AND `rel` IN (?, ?))
+			AND NOT `hidden` AND `uid` = ? AND `network` IN (?, ?, ?, ?)",
+			$uid, Contact::FRIEND, Contact::SHARING, 0, 
+			Protocol::ACTIVITYPUB, Protocol::DFRN, $diaspora, $ostatus],
+			['order' => ['last-item' => true], 'limit' => $totallimit]
+		);
+
+		while ($contact = DBA::fetch($results)) {
+			$contacts[$contact['id']] = $contact;
+		}
+		DBA::close($results);
+
+		Logger::info('Any contact', ['uid' => $uid, 'cid' => $cid, 'count' => count($contacts)]);
+
+		return array_slice($contacts, $start, $limit);
+	}
 }

--- a/src/Module/Search/Acl.php
+++ b/src/Module/Search/Acl.php
@@ -74,22 +74,17 @@ class Acl extends BaseModule
 		$mode = $_REQUEST['smode'];
 		$page = $_REQUEST['page'] ?? 1;
 
-		$r = Search::searchGlobalContact($search, $mode, $page);
+		$result = Search::searchContact($search, $mode, $page);
 
 		$contacts = [];
-		foreach ($r as $g) {
-			if (empty($g['name'])) {
-				DI::logger()->warning('Wrong result item from Search::searchGlobalContact', ['$g' => $g, '$search' => $search, '$mode' => $mode, '$page' => $page]);
-				continue;
-			}
-			$contact = Contact::getByURL($g['url']);
+		foreach ($result as $contact) {
 			$contacts[] = [
-				'photo'   => Contact::getMicro($contact, $g['photo']),
-				'name'    => htmlspecialchars($contact['name'] ?? $g['name']),
-				'nick'    => $contact['nick'] ?? ($g['addr'] ?: $g['url']),
-				'network' => $contact['network'] ?? $g['network'],
-				'link'    => $g['url'],
-				'forum'   => !empty($g['community']),
+				'photo'   => Contact::getMicro($contact),
+				'name'    => htmlspecialchars($contact['name']),
+				'nick'    => $contact['nick'],
+				'network' => $contact['network'],
+				'link'    => $contact['url'],
+				'forum'   => $contact['contact-type'] == Contact::TYPE_COMMUNITY,
 			];
 		}
 

--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -202,6 +202,7 @@ return [
 			"dfrn-id" => ["dfrn-id(64)"],
 			"issued-id" => ["issued-id(64)"],
 			"network_uid_lastupdate" => ["network", "uid", "last-update"],
+			"uid_lastitem" => ["uid", "last-item"],			
 			"gsid" => ["gsid"]
 		]
 	],

--- a/view/theme/vier/theme.php
+++ b/view/theme/vier/theme.php
@@ -118,20 +118,19 @@ function vier_community_info()
 
 	// comunity_profiles
 	if ($show_profiles) {
-		$r = GContact::suggestionQuery(local_user(), 0, 9);
+		$contacts = Contact::getSuggestions(local_user(), 0, 9);
 
 		$tpl = Renderer::getMarkupTemplate('ch_directory_item.tpl');
-		if (DBA::isResult($r)) {
+		if (DBA::isResult($contacts)) {
 			$aside['$comunity_profiles_title'] = DI::l10n()->t('Community Profiles');
 			$aside['$comunity_profiles_items'] = [];
 
-			foreach ($r as $rr) {
-				$contact = Contact::getByURL($rr['url']);
+			foreach ($contacts as $contact) {
 				$entry = Renderer::replaceMacros($tpl, [
-					'$id' => $rr['id'],
-					'$profile_link' => 'follow/?url='.urlencode($rr['url']),
-					'$photo' => Contact::getMicro($contact, $rr['photo']),
-					'$alt_text' => $contact['name'] ?? $rr['name'],
+					'$id' => $contact['id'],
+					'$profile_link' => 'follow/?url='.urlencode($contact['url']),
+					'$photo' => Contact::getMicro($contact),
+					'$alt_text' => $contact['name'],
 				]);
 				$aside['$comunity_profiles_items'][] = $entry;
 			}


### PR DESCRIPTION
In this release we will replace the "gcontact" table with the "contact" table. This is one of the steps towards this goal. The suggestions now work based on the "contact" table. Also the suggestion mechanism has completely changed. It should now work in most situations mostly reliable.