### PR TITLE
Synchronize contacts with the directory server

### DIFF
--- a/src/Module/Admin/Site.php
+++ b/src/Module/Admin/Site.php
@@ -179,6 +179,7 @@ class Site extends BaseAdmin
 		$optimize_max_tablesize = (!empty($_POST['optimize_max_tablesize']) ? intval(trim($_POST['optimize_max_tablesize'])) : 100);
 		$optimize_fragmentation = (!empty($_POST['optimize_fragmentation']) ? intval(trim($_POST['optimize_fragmentation'])) : 30);
 		$contact_discovery      = (!empty($_POST['contact_discovery'])      ? intval(trim($_POST['contact_discovery']))      : ContactRelation::DISCOVERY_NONE);
+		$synchronize_directory  = (!empty($_POST['synchronize_directory'])  ? intval(trim($_POST['synchronize_directory']))  : false);
 		$poco_completion        = (!empty($_POST['poco_completion'])        ? intval(trim($_POST['poco_completion']))        : false);
 		$poco_requery_days      = (!empty($_POST['poco_requery_days'])      ? intval(trim($_POST['poco_requery_days']))      : 7);
 		$poco_discovery         = (!empty($_POST['poco_discovery'])         ? intval(trim($_POST['poco_discovery']))         : PortableContact::DISABLED);
@@ -309,6 +310,7 @@ class Site extends BaseAdmin
 		DI::config()->set('system', 'optimize_fragmentation', $optimize_fragmentation);
 		DI::config()->set('system', 'poco_completion'       , $poco_completion);
 		DI::config()->set('system', 'contact_discovery'     , $contact_discovery);
+		DI::config()->set('system', 'synchronize_directory' , $synchronize_directory);
 		DI::config()->set('system', 'poco_requery_days'     , $poco_requery_days);
 		DI::config()->set('system', 'poco_discovery'        , $poco_discovery);
 		DI::config()->set('system', 'poco_discovery_since'  , $poco_discovery_since);
@@ -684,6 +686,7 @@ class Site extends BaseAdmin
 				'<li>' . DI::l10n()->t('Local contacts - contacts of our local contacts are discovered for their followers/followings.') . '</li>' .
 				'<li>' . DI::l10n()->t('Interactors - contacts of our local contacts and contacts who interacted on locally visible postings are discovered for their followers/followings.') . '</li></ul>',
 				$discovery_choices],
+			'$synchronize_directory'  => ['synchronize_directory', DI::l10n()->t('Synchronize the contacts with the directory server'), DI::config()->get('system', 'synchronize_directory'), DI::l10n()->t('if enabled, the system will check periodically for new contacts on the defined directory server.')],
 
 			'$poco_completion'        => ['poco_completion', DI::l10n()->t('Periodical check of global contacts'), DI::config()->get('system', 'poco_completion'), DI::l10n()->t('If enabled, the global contacts are checked periodically for missing or outdated data and the vitality of the contacts and servers.')],
 			'$poco_requery_days'      => ['poco_requery_days', DI::l10n()->t('Days between requery'), DI::config()->get('system', 'poco_requery_days'), DI::l10n()->t('Number of days after which a server is requeried for his contacts.')],

--- a/src/Worker/AddContact.php
+++ b/src/Worker/AddContact.php
@@ -34,6 +34,13 @@ class AddContact
 	 */
 	public static function execute(int $uid, string $url)
 	{
+		if ($uid == 0) {
+			// Adding public contact
+			$result = Contact::getIdForURL($url);
+			Logger::info('Added public contact', ['url' => $url, 'result' => $result]);
+			return;
+		}
+
 		$user = User::getById($uid);
 		if (empty($user)) {
 			return;

--- a/src/Worker/Cron.php
+++ b/src/Worker/Cron.php
@@ -105,6 +105,11 @@ class Cron
 		// Hourly cron calls
 		if (DI::config()->get('system', 'last_cron_hourly', 0) + 3600 < time()) {
 
+			// Search for new contacts in the directory
+			if (DI::config()->get('system', 'synchronize_directory')) {
+				Worker::add(PRIORITY_LOW, 'PullDirectory');
+			}
+
 			// Delete all done workerqueue entries
 			DBA::delete('workerqueue', ['`done` AND `executed` < UTC_TIMESTAMP() - INTERVAL 1 HOUR']);
 

--- a/view/templates/admin/site.tpl
+++ b/view/templates/admin/site.tpl
@@ -98,6 +98,7 @@
 
 		<h2>{{$portable_contacts}}</h2>
 		{{include file="field_select.tpl" field=$contact_discovery}}
+		{{include file="field_checkbox.tpl" field=$synchronize_directory}}
 		{{include file="field_checkbox.tpl" field=$poco_completion}}
 		{{include file="field_input.tpl" field=$poco_requery_days}}
 		{{include file="field_select.tpl" field=$poco_discovery}}

--- a/view/theme/frio/templates/admin/site.tpl
+++ b/view/theme/frio/templates/admin/site.tpl
@@ -219,6 +219,7 @@
 				<div id="admin-settings-contacts-collapse" class="panel-collapse collapse" role="tabpanel" aria-labelledby="admin-settings-cocontactsrporate">
 					<div class="panel-body">
 						{{include file="field_select.tpl" field=$contact_discovery}}
+						{{include file="field_checkbox.tpl" field=$synchronize_directory}}
 						{{include file="field_checkbox.tpl" field=$poco_completion}}
 						{{include file="field_input.tpl" field=$poco_requery_days}}
 						{{include file="field_select.tpl" field=$poco_discovery}}


### PR DESCRIPTION
There is now a new option to fetch new contacts from a directory server. This is another step towards removing the "Poco"-functionality.