### PR TITLE
Fiy fatal error

### DIFF
--- a/src/Worker/UpdateServerDirectory.php
+++ b/src/Worker/UpdateServerDirectory.php
@@ -60,8 +60,8 @@ class UpdateServerDirectory
 		Logger::info('PoCo discovery started', ['poco' => $gserver['poco']]);
 
 		$urls = [];
-		foreach (array_column($contacts['entry'], 'urls') as $urls) {
-			foreach ($urls as $url_entry) {
+		foreach (array_column($contacts['entry'], 'urls') as $url_entries) {
+			foreach ($url_entries as $url_entry) {
 				if (empty($url_entry['type']) || empty($url_entry['value'])) {
 					continue;
 				}


### PR DESCRIPTION
Fixes:

```
Aug  4 03:12:16 manitu php[10127]: PHP Fatal error:  Uncaught TypeError: Argument 1 passed to Friendica\Model\Contact::getByURL() must be of the type string, array given, called in /src/Model/Contact.php on line 3072 and defined in /src/Model/Contact.php:205
Aug  4 03:12:16 manitu php[10127]: Stack trace:
Aug  4 03:12:16 manitu php[10127]: #0 /src/Model/Contact.php(3072): Friendica\Model\Contact::getByURL(Array, false, Array)
Aug  4 03:12:16 manitu php[10127]: #1 /src/Worker/UpdateServerDirectory.php(74): Friendica\Model\Contact::addByUrls(Array)
Aug  4 03:12:16 manitu php[10127]: #2 /src/Worker/UpdateServerDirectory.php(42): Friendica\Worker\UpdateServerDirectory::discoverPoCo(Array)
Aug  4 03:12:16 manitu php[10127]: #3 [internal function]: Friendica\Worker\UpdateServerDirectory::execute(Array)
Aug  4 03:12:16 manitu php[10127]: #4 /src/Core/Worker.php(408): call_user_func_array('Friendica\\Worke...', Array)
Aug  4 03:12:16 manitu php[10127]: #5 /src/Core/Worker.php(309): Friendica\Core\W/
```