### PR TITLE
Move mod/common.php to src/ Part 2: Add Module\Profile\Common class

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -266,7 +266,7 @@ function public_contact()
 }
 
 /**
- * Returns contact id of authenticated site visitor or false
+ * Returns public contact id of authenticated site visitor or false
  *
  * @return int|bool visitor_id or false
  */

--- a/src/Core/Session.php
+++ b/src/Core/Session.php
@@ -65,10 +65,10 @@ class Session
 	}
 
 	/**
-	 * Returns contact ID for given user ID
+	 * Return the user contact ID of a visitor for the given user ID they are visiting
 	 *
 	 * @param integer $uid User ID
-	 * @return integer Contact ID of visitor for given user ID
+	 * @return integer
 	 */
 	public static function getRemoteContactID($uid)
 	{

--- a/src/Model/Contact/Relation.php
+++ b/src/Model/Contact/Relation.php
@@ -431,7 +431,7 @@ class Relation
 	 * @return array
 	 * @throws Exception
 	 */
-	public static function listCommon(int $sourceId, int $targetId, array $fields = [], array $condition = [], int $count = 30, int $offset = 0, bool $shuffle = false)
+	public static function listCommon(int $sourceId, int $targetId, array $condition = [], int $count = 30, int $offset = 0, bool $shuffle = false)
 	{
 		$condition = DBA::mergeConditions($condition,
 			["`id` IN (SELECT `relation-cid` FROM `contact-relation` WHERE `cid` = ? AND `follows`) 
@@ -439,7 +439,7 @@ class Relation
 			$sourceId, $targetId]
 		);
 
-		return DI::dba()->selectToArray('contact', $fields, $condition,
+		return DI::dba()->selectToArray('contact', [], $condition,
 			['limit' => [$offset, $count], 'order' => [$shuffle ? 'name' : 'RAND()']]
 		);
 	}
@@ -470,7 +470,6 @@ class Relation
 	 *
 	 * @param int   $sourceId  Public contact id
 	 * @param int   $targetId  Public contact id
-	 * @param array $field     Field list
 	 * @param array $condition Additional condition array on the contact table
 	 * @param int   $count
 	 * @param int   $offset
@@ -478,7 +477,7 @@ class Relation
 	 * @return array
 	 * @throws Exception
 	 */
-	public static function listCommonFollows(int $sourceId, int $targetId, array $fields = [], array $condition = [], int $count = 30, int $offset = 0, bool $shuffle = false)
+	public static function listCommonFollows(int $sourceId, int $targetId, array $condition = [], int $count = 30, int $offset = 0, bool $shuffle = false)
 	{
 		$condition = DBA::mergeConditions($condition,
 			["`id` IN (SELECT `relation-cid` FROM `contact-relation` WHERE `cid` = ? AND `follows`) 
@@ -486,7 +485,7 @@ class Relation
 			$sourceId, $targetId]
 		);
 
-		return DI::dba()->selectToArray('contact', $fields, $condition,
+		return DI::dba()->selectToArray('contact', [], $condition,
 			['limit' => [$offset, $count], 'order' => [$shuffle ? 'name' : 'RAND()']]
 		);
 	}
@@ -516,7 +515,6 @@ class Relation
 	 *
 	 * @param int   $sourceId  Public contact id
 	 * @param int   $targetId  Public contact id
-	 * @param array $field     Field list
 	 * @param array $condition Additional condition on the contact table
 	 * @param int   $count
 	 * @param int   $offset
@@ -524,7 +522,7 @@ class Relation
 	 * @return array
 	 * @throws Exception
 	 */
-	public static function listCommonFollowers(int $sourceId, int $targetId, array $fields = [], array $condition = [], int $count = 30, int $offset = 0, bool $shuffle = false)
+	public static function listCommonFollowers(int $sourceId, int $targetId, array $condition = [], int $count = 30, int $offset = 0, bool $shuffle = false)
 	{
 		$condition = DBA::mergeConditions($condition,
 			["`id` IN (SELECT `cid` FROM `contact-relation` WHERE `relation-cid` = ? AND `follows`) 
@@ -532,7 +530,7 @@ class Relation
 			$sourceId, $targetId]
 		);
 
-		return DI::dba()->selectToArray('contact', $fields, $condition,
+		return DI::dba()->selectToArray('contact', [], $condition,
 			['limit' => [$offset, $count], 	'order' => [$shuffle ? 'name' : 'RAND()']]
 		);
 	}

--- a/src/Model/GContact.php
+++ b/src/Model/GContact.php
@@ -46,7 +46,7 @@ class GContact
 			$sourceId,
 		];
 
-		return Contact\Relation::countCommonFollows($sourceId, $targetIds['public'] ?? 0, [], $condition);
+		return Contact\Relation::countCommonFollows($sourceId, $targetIds['public'] ?? 0, $condition);
 	}
 
 	/**
@@ -74,7 +74,7 @@ LIMIT 1",
 			$sourceId,
 		];
 
-		return Contact\Relation::countCommonFollowers($sourceId, $targetPublicContact['id'] ?? 0, [], $condition);
+		return Contact\Relation::countCommonFollowers($sourceId, $targetPublicContact['id'] ?? 0, $condition);
 	}
 
 	/**
@@ -100,7 +100,7 @@ LIMIT 1",
 			$sourceId,
 		];
 
-		return Contact\Relation::listCommonFollows($sourceId, $targetIds['public'] ?? 0, [], $condition, $limit, $start, $shuffle);
+		return Contact\Relation::listCommonFollows($sourceId, $targetIds['public'] ?? 0, $condition, $limit, $start, $shuffle);
 	}
 
 	/**
@@ -134,6 +134,6 @@ LIMIT 1",
 			$sourceId,
 		];
 
-		return Contact\Relation::listCommonFollows($sourceId, $targetPublicContact['id'] ?? 0, [], $condition, $limit, $start, $shuffle);
+		return Contact\Relation::listCommonFollows($sourceId, $targetPublicContact['id'] ?? 0, $condition, $limit, $start, $shuffle);
 	}
 }

--- a/src/Module/Contact.php
+++ b/src/Module/Contact.php
@@ -1030,7 +1030,7 @@ class Contact extends BaseModule
 			}
 		}
 
-		if (!empty($contact['uid']) && !empty($contact['rel'])) {
+		if (!empty($contact['uid']) && !empty($contact['rel']) && local_user() == $contact['uid']) {
 			switch ($contact['rel']) {
 				case Model\Contact::FRIEND:
 					$alt_text = DI::l10n()->t('Mutual Friendship');

--- a/src/Module/Profile/Status.php
+++ b/src/Module/Profile/Status.php
@@ -108,7 +108,7 @@ class Status extends BaseProfile
 
 		$o .= self::getTabsHTML($a, 'status', $is_owner, $a->profile['nickname']);
 
-		$o .= Widget::commonFriendsVisitor($a->profile['uid']);
+		$o .= Widget::commonFriendsVisitor($a->profile['uid'], $a->profile['nickname']);
 
 		$commpage = $a->profile['page-flags'] == User::PAGE_FLAGS_COMMUNITY;
 		$commvisitor = $commpage && $remote_contact;

--- a/static/routes.config.php
+++ b/static/routes.config.php
@@ -252,6 +252,7 @@ return [
 	'/profile' => [
 		'/{nickname}'                                         => [Module\Profile\Index::class,    [R::GET]],
 		'/{nickname}/profile'                                 => [Module\Profile\Profile::class,  [R::GET]],
+		'/{nickname}/contacts/common'                         => [Module\Profile\Common::class,   [R::GET]],
 		'/{nickname}/contacts[/{type}]'                       => [Module\Profile\Contacts::class, [R::GET]],
 		'/{nickname}/status[/{category}[/{date1}[/{date2}]]]' => [Module\Profile\Status::class,   [R::GET]],
 	],

--- a/view/templates/profile/contacts.tpl
+++ b/view/templates/profile/contacts.tpl
@@ -10,6 +10,9 @@
 		<li role="menuitem"><a href="profile/{{$nickname}}/contacts/followers" class="tab button{{if $type == 'followers'}} active{{/if}}">{{$followers_label}}</a></li>
 		<li role="menuitem"><a href="profile/{{$nickname}}/contacts/following" class="tab button{{if $type == 'following'}} active{{/if}}">{{$following_label}}</a></li>
 		<li role="menuitem"><a href="profile/{{$nickname}}/contacts/mutuals" class="tab button{{if $type == 'mutuals'}} active{{/if}}">{{$mutuals_label}}</a></li>
+	{{if $displayCommonTab}}
+		<li role="menuitem"><a href="profile/{{$nickname}}/contacts/common" class="tab button{{if $type == 'common'}} active{{/if}}{{if !$common_count}} disabled{{/if}}">{{$common_label}}</a></li>
+	{{/if}}
 	</ul>
 {{if $contacts}}
 	<div id="viewcontact_wrapper-{{$id}}">

--- a/view/templates/profile/contacts.tpl
+++ b/view/templates/profile/contacts.tpl
@@ -1,18 +1,26 @@
 <div class="generic-page-wrapper">
 	{{include file="section_title.tpl"}}
 
+{{if $desc}}
+	<p>{{$desc nofilter}}</p>
+{{/if}}
+
 	<ul role="menubar" class="tabs">
 		<li role="menuitem"><a href="profile/{{$nickname}}/contacts" class="tab button{{if !$type || $type == 'all'}} active{{/if}}">{{$all_label}}</a></li>
 		<li role="menuitem"><a href="profile/{{$nickname}}/contacts/followers" class="tab button{{if $type == 'followers'}} active{{/if}}">{{$followers_label}}</a></li>
 		<li role="menuitem"><a href="profile/{{$nickname}}/contacts/following" class="tab button{{if $type == 'following'}} active{{/if}}">{{$following_label}}</a></li>
 		<li role="menuitem"><a href="profile/{{$nickname}}/contacts/mutuals" class="tab button{{if $type == 'mutuals'}} active{{/if}}">{{$mutuals_label}}</a></li>
 	</ul>
-
+{{if $contacts}}
 	<div id="viewcontact_wrapper-{{$id}}">
-{{foreach $contacts as $contact}}
+	{{foreach $contacts as $contact}}
 		{{include file="contact_template.tpl"}}
-{{/foreach}}
+	{{/foreach}}
 	</div>
+{{else}}
+	<div class="alert alert-info" role="alert">{{$noresult_label}}</div>
+{{/if}}
+
 	<div class="clear"></div>
 	<div id="view-contact-end"></div>
 

--- a/view/templates/widget/remote_friends_common.tpl
+++ b/view/templates/widget/remote_friends_common.tpl
@@ -1,22 +1,18 @@
-
 <div id="remote-friends-in-common" class="bigwidget">
-	<div id="rfic-desc">{{$desc nofilter}} &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;{{if $linkmore}}<a href="{{$base}}/common/rem/{{$uid}}/{{$cid}}">{{$more}}</a>{{/if}}</div>
-	{{if $items}}
-	{{foreach $items as $item}}
+	<div id="rfic-desc">{{$desc nofilter}} &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;{{if $linkmore}}<a href="profile/{{$nickname}}/contacts/common">{{$more}}</a>{{/if}}</div>
+	{{foreach $contacts as $contact}}
 	<div class="profile-match-wrapper">
 		<div class="profile-match-photo">
-			<a href="{{$item.url}}">
-				<img src="{{$item.photo}}" width="80" height="80" alt="{{$item.name}}" title="{{$item.name}}" />
+			<a href="{{$contact.url}}">
+				<img src="{{$contact.photo}}" width="80" height="80" alt="{{$contact.name}}" title="{{$contact.name}}" />
 			</a>
 		</div>
 		<div class="profile-match-break"></div>
 		<div class="profile-match-name">
-			<a href="{{$item.url}}" title="{{$item.name}}">{{$item.name}}</a>
+			<a href="{{$contact.url}}" title="{{$contact.name}}">{{$contact.name}}</a>
 		</div>
 		<div class="profile-match-end"></div>
 	</div>
 	{{/foreach}}
-	{{/if}}
 	<div id="rfic-end" class="clear"></div>
 </div>
-

--- a/view/theme/frio/templates/contact_template.tpl
+++ b/view/theme/frio/templates/contact_template.tpl
@@ -6,7 +6,9 @@
 			<div class="contact-entry-photo mframe" id="contact-entry-photo-{{$contact.id}}">
 
 				<div class="contact-photo-image-wrapper hidden-xs">
-					<img class="contact-photo media-object xl" src="{{$contact.thumb}}" {{$contact.sparkle}} alt="{{$contact.name}}" />
+					<a href="{{$contact.url}}">
+						<img class="contact-photo media-object xl" src="{{$contact.thumb}}" {{$contact.sparkle}} alt="{{$contact.name}}" />
+					</a>
 				</div>
 
 				{{* For very small displays we use a dropdown menu for contact relating actions *}}

--- a/view/theme/frio/templates/profile/contacts.tpl
+++ b/view/theme/frio/templates/profile/contacts.tpl
@@ -1,18 +1,33 @@
 <div class="generic-page-wrapper">
 	{{include file="section_title.tpl"}}
 
-	<ul class="nav nav-tabs">
-		<li role="presentation"{{if !$type || $type == 'all'}} class="active"{{/if}}><a href="profile/{{$nickname}}/contacts">{{$all_label}}</a></li>
-		<li role="presentation"{{if $type == 'followers'}} class="active"{{/if}}><a href="profile/{{$nickname}}/contacts/followers">{{$followers_label}}</a></li>
-		<li role="presentation"{{if $type == 'following'}} class="active"{{/if}}><a href="profile/{{$nickname}}/contacts/following">{{$following_label}}</a></li>
-		<li role="presentation"{{if $type == 'mutuals'}} class="active"{{/if}}><a href="profile/{{$nickname}}/contacts/mutuals">{{$mutuals_label}}</a></li>
-	</ul>
+{{if $desc}}
+	<p>{{$desc nofilter}}</p>
+{{/if}}
 
-	<ul id="viewcontact_wrapper{{if $id}}-{{$id}}{{/if}}" class="viewcontact_wrapper media-list">
-{{foreach $contacts as $contact}}
-		<li>{{include file="contact_template.tpl"}}</li>
-{{/foreach}}
+	<ul class="nav nav-tabs">
+		<li role="presentation"{{if !$type || $type == 'all'}} class="active"{{/if}}>
+			<a href="profile/{{$nickname}}/contacts">{{$all_label}}</a>
+		</li>
+		<li role="presentation"{{if $type == 'followers'}} class="active"{{/if}}>
+			<a href="profile/{{$nickname}}/contacts/followers">{{$followers_label}}</a>
+		</li>
+		<li role="presentation"{{if $type == 'following'}} class="active"{{/if}}>
+			<a href="profile/{{$nickname}}/contacts/following">{{$following_label}}</a>
+		</li>
+		<li role="presentation"{{if $type == 'mutuals'}} class="active"{{/if}}>
+			<a href="profile/{{$nickname}}/contacts/mutuals">{{$mutuals_label}}</a>
+		</li>
 	</ul>
+{{if $contacts}}
+	<ul id="viewcontact_wrapper{{if $id}}-{{$id}}{{/if}}" class="viewcontact_wrapper media-list">
+	{{foreach $contacts as $contact}}
+		<li>{{include file="contact_template.tpl"}}</li>
+	{{/foreach}}
+	</ul>
+{{else}}
+	<div class="alert alert-info" role="alert">{{$noresult_label}}</div>
+{{/if}}
 	<div class="clear"></div>
 	<div id="view-contact-end"></div>
 

--- a/view/theme/frio/templates/profile/contacts.tpl
+++ b/view/theme/frio/templates/profile/contacts.tpl
@@ -18,6 +18,11 @@
 		<li role="presentation"{{if $type == 'mutuals'}} class="active"{{/if}}>
 			<a href="profile/{{$nickname}}/contacts/mutuals">{{$mutuals_label}}</a>
 		</li>
+	{{if $displayCommonTab}}
+		<li role="presentation"{{if $type == 'common'}} class="active"{{/if}}>
+			<a href="profile/{{$nickname}}/contacts/common" class="tab button">{{$common_label}}</a>
+		</li>
+	{{/if}}
 	</ul>
 {{if $contacts}}
 	<ul id="viewcontact_wrapper{{if $id}}-{{$id}}{{/if}}" class="viewcontact_wrapper media-list">


### PR DESCRIPTION
Part of #8918 
Follow-up to #8963

This is the first part of the replacement for `/common`: finding the common contacts between a user local to the node and a visiting user, who may be from the same node or another one. It replaces the `/common/rem/{uid}/{cid}` route that was used in the common contacts widgets.

Unfortunately I couldn't test this in a real situation with two users having actual common contacts, so I'm putting this out there for valiant develop node admins to test.

It adds a new tab in the contact types in the `/profile/{nickname}/contacts` page, and should be linked to in the common contacts widget that exclusively appears on the `/profile/{nickname}` (or  `/profile/{nickname}/status`) page.

If it is successful I'll carry on with the ~~second~~ third part which replaces the `/common/loc/{uid}/{cid}` route in a similar fashion.

I may even obsolete the `/allfriends` module altogether.