### PR TITLE
Probe for the date of the last item

### DIFF
--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -1218,11 +1218,11 @@ class Contact
 		}
 
 		// Take the default values when probing failed
-		if (!empty($default) && !in_array($data["network"], array_merge(Protocol::NATIVE_SUPPORT, [Protocol::PUMPIO]))) {
+		if (!empty($default) && (empty($data['network']) || !in_array($data["network"], array_merge(Protocol::NATIVE_SUPPORT, [Protocol::PUMPIO])))) {
 			$data = array_merge($data, $default);
 		}
 
-		if (empty($data) || ($data['network'] == Protocol::PHANTOM)) {
+		if (empty($data['network']) || ($data['network'] == Protocol::PHANTOM)) {
 			Logger::info('No valid network found', ['url' => $url, 'data' => $data, 'callstack' => System::callstack(20)]);
 			return 0;
 		}
@@ -1267,7 +1267,7 @@ class Contact
 				'poco'      => $data['poco'] ?? '',
 				'baseurl'   => $data['baseurl'] ?? '',
 				'gsid'      => $data['gsid'] ?? null,
-				'last-item' => $data['last-item'],
+				'last-item' => $data['last-item'] ?: DBA::NULL_DATETIME,
 				'name-date' => DateTimeFormat::utcNow(),
 				'uri-date'  => DateTimeFormat::utcNow(),
 				'avatar-date' => DateTimeFormat::utcNow(),

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -1235,8 +1235,10 @@ class Contact
 			$data['gsid'] = GServer::getID($data['baseurl']);
 		}
 
-		$data['last-item'] = Probe::getLastUpdate($data);
-		Logger::info('Fetched last item', ['url' => $data['url'], 'last-item' => $data['last-item']]);
+		if ($uid == 0) {
+			$data['last-item'] = Probe::getLastUpdate($data);
+			Logger::info('Fetched last item', ['url' => $data['url'], 'last-item' => $data['last-item']]);
+		}
 
 		if (!$contact_id && !empty($data['alias']) && ($data['alias'] != $data['url']) && !$in_loop) {
 			$contact_id = self::getIdForURL($data["alias"], $uid, false, $default, true);
@@ -1267,7 +1269,6 @@ class Contact
 				'poco'      => $data['poco'] ?? '',
 				'baseurl'   => $data['baseurl'] ?? '',
 				'gsid'      => $data['gsid'] ?? null,
-				'last-item' => $data['last-item'] ?: DBA::NULL_DATETIME,
 				'name-date' => DateTimeFormat::utcNow(),
 				'uri-date'  => DateTimeFormat::utcNow(),
 				'avatar-date' => DateTimeFormat::utcNow(),
@@ -1275,6 +1276,10 @@ class Contact
 				'blocked'   => 0,
 				'readonly'  => 0,
 				'pending'   => 0];
+
+			if (!empty($data['last-item'])) {
+				$fields['last-item'] = $data['last-item'];
+			}
 
 			$condition = ['nurl' => Strings::normaliseLink($data["url"]), 'uid' => $uid, 'deleted' => false];
 
@@ -1333,7 +1338,7 @@ class Contact
 				$updated[$field] = ($data[$field] ?? '') ?: $contact[$field];
 			}
 
-			if ($contact['last-item'] < $data['last-item']) {
+			if (!empty($data['last-item']) && ($contact['last-item'] < $data['last-item'])) {
 				$updated['last-item'] = $data['last-item'];
 			}
 

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -1238,6 +1238,16 @@ class Contact
 			$contact = self::getByURL($data['alias'], false, ['id']);
 			if (!empty($contact['id'])) {
 				$contact_id = $contact['id'];
+				Logger::info('Fetched id by alias', ['cid' => $contact_id, 'url' => $url, 'probed_url' => $data['url'], 'alias' => $data['alias']]);
+			}
+		}
+
+		// Possibly there is a contact entry with the probed URL
+		if (!$contact_id  && ($url != $data['url']) && ($url != $data['alias'])) {
+			$contact = self::getByURL($data['url'], false, ['id']);
+			if (!empty($contact['id'])) {
+				$contact_id = $contact['id'];
+				Logger::info('Fetched id by url', ['cid' => $contact_id, 'url' => $url, 'probed_url' => $data['url'], 'alias' => $data['alias']]);
 			}
 		}
 

--- a/src/Network/Probe.php
+++ b/src/Network/Probe.php
@@ -2044,9 +2044,13 @@ class Probe
 	 */
 	private static function updateFromNoScrape(array $data)
 	{
+		if (empty($data['baseurl'])) {
+			return '';
+		}
+
 		// Check the 'noscrape' endpoint when it is a Friendica server
 		$gserver = DBA::selectFirst('gserver', ['noscrape'], ["`nurl` = ? AND `noscrape` != ''",
-		Strings::normaliseLink($data['baseurl'])]);
+			Strings::normaliseLink($data['baseurl'])]);
 		if (!DBA::isResult($gserver)) {
 			return '';
 		}

--- a/src/Network/Probe.php
+++ b/src/Network/Probe.php
@@ -38,6 +38,7 @@ use Friendica\Protocol\ActivityPub;
 use Friendica\Protocol\Email;
 use Friendica\Protocol\Feed;
 use Friendica\Util\Crypto;
+use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Network;
 use Friendica\Util\Strings;
 use Friendica\Util\XML;
@@ -2008,5 +2009,162 @@ class Probe
 		Logger::debug('Avatar fixed', ['base' => $base, 'avatar' => $avatar, 'fixed' => $fixed]);
 
 		return $fixed;
+	}
+
+	/**
+	 * Fetch the last date that the contact had posted something (publically)
+	 *
+	 * @param string $data  probing result
+	 * @return string last activity
+	 */
+	public static function getLastUpdate(array $data)
+	{
+		if ($lastUpdate = self::updateFromNoScrape($data)) {
+			return $lastUpdate;
+		}
+
+		if (!empty($data['outbox'])) {
+			return self::updateFromOutbox($data['outbox'], $data);
+		} elseif (!empty($data['poll']) && ($data['network'] == Protocol::ACTIVITYPUB)) {
+			return self::updateFromOutbox($data['poll'], $data);
+		} elseif (!empty($data['poll'])) {
+			return self::updateFromFeed($data);
+		}
+
+		return '';
+	}
+
+	/**
+	 * Fetch the last activity date from the "noscrape" endpoint
+	 *
+	 * @param array $data Probing result
+	 * @return string last activity
+	 *
+	 * @return bool 'true' if update was successful or the server was unreachable
+	 */
+	private static function updateFromNoScrape(array $data)
+	{
+		// Check the 'noscrape' endpoint when it is a Friendica server
+		$gserver = DBA::selectFirst('gserver', ['noscrape'], ["`nurl` = ? AND `noscrape` != ''",
+		Strings::normaliseLink($data['baseurl'])]);
+		if (!DBA::isResult($gserver)) {
+			return '';
+		}
+
+		$curlResult = DI::httpRequest()->get($gserver['noscrape'] . '/' . $data['nick']);
+
+		if ($curlResult->isSuccess() && !empty($curlResult->getBody())) {
+			$noscrape = json_decode($curlResult->getBody(), true);
+			if (!empty($noscrape) && !empty($noscrape['updated'])) {
+				return DateTimeFormat::utc($noscrape['updated'], DateTimeFormat::MYSQL);
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Fetch the last activity date from an ActivityPub Outbox
+	 *
+	 * @param string $feed
+	 * @param array  $data Probing result
+	 * @return string last activity
+	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
+	 */
+	private static function updateFromOutbox(string $feed, array $data)
+	{
+		$outbox = ActivityPub::fetchContent($feed);
+		if (empty($outbox)) {
+			return '';
+		}
+
+		if (!empty($outbox['orderedItems'])) {
+			$items = $outbox['orderedItems'];
+		} elseif (!empty($outbox['first']['orderedItems'])) {
+			$items = $outbox['first']['orderedItems'];
+		} elseif (!empty($outbox['first']['href']) && ($outbox['first']['href'] != $feed)) {
+			return self::updateFromOutbox($outbox['first']['href'], $data);
+		} elseif (!empty($outbox['first'])) {
+			if (is_string($outbox['first']) && ($outbox['first'] != $feed)) {
+				return self::updateFromOutbox($outbox['first'], $data);
+			} else {
+				Logger::warning('Unexpected data', ['outbox' => $outbox]);
+			}
+			return '';
+		} else {
+			$items = [];
+		}
+
+		$last_updated = '';
+		foreach ($items as $activity) {
+			if (!empty($activity['published'])) {
+				$published =  DateTimeFormat::utc($activity['published']);
+			} elseif (!empty($activity['object']['published'])) {
+				$published =  DateTimeFormat::utc($activity['object']['published']);
+			} else {
+				continue;
+			}
+
+			if ($last_updated < $published) {
+				$last_updated = $published;
+			}
+		}
+
+		if (!empty($last_updated)) {
+			return $last_updated;
+		}
+
+		return '';
+	}
+
+	/**
+	 * Fetch the last activity date from an XML feed
+	 *
+	 * @param array $data Probing result
+	 * @return string last activity
+	 */
+	private static function updateFromFeed(array $data)
+	{
+		// Search for the newest entry in the feed
+		$curlResult = DI::httpRequest()->get($data['poll']);
+		if (!$curlResult->isSuccess()) {
+			return '';
+		}
+
+		$doc = new DOMDocument();
+		@$doc->loadXML($curlResult->getBody());
+
+		$xpath = new DOMXPath($doc);
+		$xpath->registerNamespace('atom', 'http://www.w3.org/2005/Atom');
+
+		$entries = $xpath->query('/atom:feed/atom:entry');
+
+		$last_updated = '';
+
+		foreach ($entries as $entry) {
+			$published_item = $xpath->query('atom:published/text()', $entry)->item(0);
+			$updated_item   = $xpath->query('atom:updated/text()'  , $entry)->item(0);
+			$published      = !empty($published_item->nodeValue) ? DateTimeFormat::utc($published_item->nodeValue) : null;
+			$updated        = !empty($updated_item->nodeValue) ? DateTimeFormat::utc($updated_item->nodeValue) : null;
+
+			if (empty($published) || empty($updated)) {
+				Logger::notice('Invalid entry for XPath.', ['entry' => $entry, 'url' => $data['url']]);
+				continue;
+			}
+
+			if ($last_updated < $published) {
+				$last_updated = $published;
+			}
+
+			if ($last_updated < $updated) {
+				$last_updated = $updated;
+			}
+		}
+
+		if (!empty($last_updated)) {
+			return $last_updated;
+		}
+
+		return '';
 	}
 }

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -1106,20 +1106,7 @@ class Diaspora
 	 */
 	private static function contactByHandle($uid, $handle)
 	{
-		$cid = Contact::getIdForURL($handle, $uid);
-		if (!$cid) {
-			Logger::log("Haven't found a contact for user " . $uid . " and handle " . $handle, Logger::DEBUG);
-			return false;
-		}
-
-		$contact = DBA::selectFirst('contact', [], ['id' => $cid]);
-		if (!DBA::isResult($contact)) {
-			// This here shouldn't happen at all
-			Logger::log("Haven't found a contact for user " . $uid . " and handle " . $handle, Logger::DEBUG);
-			return false;
-		}
-
-		return $contact;
+		return Contact::getByURL($handle, null, [], $uid);
 	}
 
 	/**

--- a/src/Protocol/OStatus.php
+++ b/src/Protocol/OStatus.php
@@ -2017,7 +2017,7 @@ class OStatus
 		$mentioned = $newmentions;
 
 		foreach ($mentioned as $mention) {
-			$contact = Contact::getByURL($mention, ['contact-type']);
+			$contact = Contact::getByURL($mention, false, ['contact-type']);
 			if (!empty($contact) && ($contact['contact-type'] == Contact::TYPE_COMMUNITY)) {
 				XML::addElement($doc, $entry, "link", "",
 					[

--- a/view/theme/frio/theme.php
+++ b/view/theme/frio/theme.php
@@ -201,7 +201,7 @@ function frio_remote_nav($a, &$nav)
 		$remoteUser = Contact::getById(remote_user(), $fields);
 		$nav['remote'] = DI::l10n()->t('Guest');
 	} elseif (Model\Profile::getMyURL()) {
-		$remoteUser = Contact::getByURL($homelink, $fields);
+		$remoteUser = Contact::getByURL($homelink, null, $fields);
 		$nav['remote'] = DI::l10n()->t('Visitor');
 	} else {
 		$remoteUser = null;


### PR DESCRIPTION
This functionality had been part of the `GContact` class. The `last-item` can be used to check how vital a contact is. We fill it for every item that arrives at out system. And now we fetch it during discovery as well. This is needed since now the `Contact` class does all what the `GContact` class did before. So we store contacts now that hadn't had any posts at all on the system.