### PR TITLE
Remove probe caching, locking cleanup

### DIFF
--- a/src/Module/Debug/Probe.php
+++ b/src/Module/Debug/Probe.php
@@ -44,7 +44,7 @@ class Probe extends BaseModule
 		$res  = '';
 
 		if (!empty($addr)) {
-			$res = NetworkProbe::uri($addr, '', 0, false);
+			$res = NetworkProbe::uri($addr, '', 0);
 			$res = print_r($res, true);
 		}
 

--- a/src/Network/Probe.php
+++ b/src/Network/Probe.php
@@ -328,16 +328,8 @@ class Probe
 	 * @throws HTTPException\InternalServerErrorException
 	 * @throws \ImagickException
 	 */
-	public static function uri($uri, $network = '', $uid = -1, $cache = true)
+	public static function uri($uri, $network = '', $uid = -1)
 	{
-		$cachekey = 'Probe::uri:' . $network . ':' . $uri;
-		if ($cache) {
-			$result = DI::cache()->get($cachekey);
-			if (!is_null($result)) {
-				return $result;
-			}
-		}
-
 		if ($uid == -1) {
 			$uid = local_user();
 		}
@@ -408,14 +400,7 @@ class Probe
 			$data['hide'] = self::getHideStatus($data['url']);
 		}
 
-		$data = self::rearrangeData($data);
-
-		// Only store into the cache if the value seems to be valid
-		if (!in_array($data['network'], [Protocol::PHANTOM, Protocol::MAIL])) {
-			DI::cache()->set($cachekey, $data, Duration::DAY);
-		}
-
-		return $data;
+		return self::rearrangeData($data);
 	}
 
 

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -822,7 +822,7 @@ class Processor
 		}
 
 		Logger::info('Updating profile', ['object' => $activity['object_id']]);
-		Contact::updateFromProbeByURL($activity['object_id'], true);
+		Contact::updateFromProbeByURL($activity['object_id']);
 	}
 
 	/**

--- a/src/Protocol/ActivityPub/Receiver.php
+++ b/src/Protocol/ActivityPub/Receiver.php
@@ -679,7 +679,7 @@ class Receiver
 			return;
 		}
 
-		if (Contact::updateFromProbe($cid, '', true)) {
+		if (Contact::updateFromProbe($cid)) {
 			Logger::info('Update was successful', ['id' => $cid, 'uid' => $uid, 'url' => $url]);
 		}
 

--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -2878,14 +2878,13 @@ class DFRN
 	 * Checks if the given contact url does support DFRN
 	 *
 	 * @param string  $url    profile url
-	 * @param boolean $update Update the profile
 	 * @return boolean
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 * @throws \ImagickException
 	 */
-	public static function isSupportedByContactUrl($url, $update = false)
+	public static function isSupportedByContactUrl($url)
 	{
-		$probe = Probe::uri($url, Protocol::DFRN, 0, !$update);
+		$probe = Probe::uri($url, Protocol::DFRN);
 		return $probe['network'] == Protocol::DFRN;
 	}
 }

--- a/src/Protocol/OStatus.php
+++ b/src/Protocol/OStatus.php
@@ -544,15 +544,8 @@ class OStatus
 						} elseif ($item['contact-id'] < 0) {
 							Logger::log("Item with uri ".$item["uri"]." is from a blocked contact.", Logger::DEBUG);
 						} else {
-							// We are having duplicated entries. Hopefully this solves it.
-							if (DI::lock()->acquire('ostatus_process_item_insert')) {
-								$ret = Item::insert($item);
-								DI::lock()->release('ostatus_process_item_insert');
-								Logger::log("Item with uri ".$item["uri"]." for user ".$importer["uid"].' stored. Return value: '.$ret);
-							} else {
-								$ret = Item::insert($item);
-								Logger::log("We couldn't lock - but tried to store the item anyway. Return value is ".$ret);
-							}
+							$ret = Item::insert($item);
+							Logger::log("Item with uri ".$item["uri"]." for user ".$importer["uid"].' stored. Return value: '.$ret);
 						}
 					}
 				}
@@ -2218,14 +2211,13 @@ class OStatus
 	 * Checks if the given contact url does support OStatus
 	 *
 	 * @param string  $url    profile url
-	 * @param boolean $update Update the profile
 	 * @return boolean
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 * @throws \ImagickException
 	 */
-	public static function isSupportedByContactUrl($url, $update = false)
+	public static function isSupportedByContactUrl($url)
 	{
-		$probe = Probe::uri($url, Protocol::OSTATUS, 0, !$update);
+		$probe = Probe::uri($url, Protocol::OSTATUS);
 		return $probe['network'] == Protocol::OSTATUS;
 	}
 }

--- a/src/Worker/Cron.php
+++ b/src/Worker/Cron.php
@@ -168,7 +168,7 @@ class Cron
 				$oldest_id = $contact['id'];
 				$oldest_date = $contact['last-update'];
 			}
-			Worker::add(PRIORITY_LOW, "UpdateContact", $contact['id'], 'force');
+			Worker::add(PRIORITY_LOW, "UpdateContact", $contact['id']);
 			++$count;
 		}
 		Logger::info('Initiated update for public contacts', ['interval' => $count, 'id' => $oldest_id, 'oldest' => $oldest_date]);

--- a/src/Worker/OnePoll.php
+++ b/src/Worker/OnePoll.php
@@ -61,12 +61,12 @@ class OnePoll
 		}
 
 		if (($contact['network'] != Protocol::MAIL) || $force) {
-			Contact::updateFromProbe($contact_id, '', $force);
+			Contact::updateFromProbe($contact_id);
 		}
 
 		// Special treatment for wrongly detected local contacts
 		if (!$force && ($contact['network'] != Protocol::DFRN) && Contact::isLocalById($contact_id)) {
-			Contact::updateFromProbe($contact_id, Protocol::DFRN, true);
+			Contact::updateFromProbe($contact_id, Protocol::DFRN);
 			$contact = DBA::selectFirst('contact', [], ['id' => $contact_id]);
 		}
 

--- a/src/Worker/UpdateContact.php
+++ b/src/Worker/UpdateContact.php
@@ -29,14 +29,11 @@ class UpdateContact
 	/**
 	 * Update contact data via probe
 	 * @param int    $contact_id Contact ID
-	 * @param string $command
 	 */
-	public static function execute($contact_id, $command = '')
+	public static function execute($contact_id)
 	{
-		$force = ($command == "force");
+		$success = Contact::updateFromProbe($contact_id);
 
-		$success = Contact::updateFromProbe($contact_id, '', $force);
-
-		Logger::info('Updated from probe', ['id' => $contact_id, 'force' => $force, 'success' => $success]);
+		Logger::info('Updated from probe', ['id' => $contact_id, 'success' => $success]);
 	}
 }


### PR DESCRIPTION
This is a cleanup PR. The probing is now done only at places where we don't need to cache the requests. So we are able to remove some code that handles with this.

Also some locking had been removed (at OStatus) since it isn't needed there. Also the locking at the worker got constants since this is nicer.