### PR TITLE
Reduce page size in contacts pages

### DIFF
--- a/src/Module/Contact/Contacts.php
+++ b/src/Module/Contact/Contacts.php
@@ -67,7 +67,7 @@ class Contacts extends BaseModule
 				$total = Model\Contact\Relation::countAll($cid, $condition);
 		}
 
-		$pager = new Pager(DI::l10n(), DI::args()->getQueryString());
+		$pager = new Pager(DI::l10n(), DI::args()->getQueryString(), 30);
 		$desc = '';
 
 		switch ($type) {

--- a/src/Module/Profile/Common.php
+++ b/src/Module/Profile/Common.php
@@ -78,7 +78,7 @@ class Common extends BaseProfile
 
 		$total = Contact\Relation::countCommon($sourceId, $targetId, $condition);
 
-		$pager = new Pager(DI::l10n(), DI::args()->getQueryString());
+		$pager = new Pager(DI::l10n(), DI::args()->getQueryString(), 30);
 
 		$commonFollows = Contact\Relation::listCommon($sourceId, $targetId, $condition, $pager->getItemsPerPage(), $pager->getStart());
 

--- a/src/Module/Profile/Contacts.php
+++ b/src/Module/Profile/Contacts.php
@@ -81,7 +81,7 @@ class Contacts extends Module\BaseProfile
 
 		$total = DBA::count('contact', $condition);
 
-		$pager = new Pager(DI::l10n(), DI::args()->getQueryString());
+		$pager = new Pager(DI::l10n(), DI::args()->getQueryString(), 30);
 
 		$params = ['order' => ['name' => false], 'limit' => [$pager->getStart(), $pager->getItemsPerPage()]];
 


### PR DESCRIPTION
I realized after pulling that the default page limit of 50 is too much for contact lists.