### PR TITLE
Improvements for delivering forum posts

### DIFF
--- a/include/api.php
+++ b/include/api.php
@@ -5710,7 +5710,7 @@ function api_friendica_activity($type)
 
 	$id = $_REQUEST['id'] ?? 0;
 
-	$res = Item::performActivity($id, $verb);
+	$res = Item::performActivity($id, $verb, api_user());
 
 	if ($res) {
 		if ($type == "xml") {

--- a/mod/subthread.php
+++ b/mod/subthread.php
@@ -34,7 +34,7 @@ function subthread_content(App $a)
 
 	$item_id = (($a->argc > 1) ? Strings::escapeTags(trim($a->argv[1])) : 0);
 
-	if (!Item::performActivity($item_id, 'follow')) {
+	if (!Item::performActivity($item_id, 'follow', local_user())) {
 		Logger::info('Following item failed', ['item' => $item_id]);
 		throw new HTTPException\BadRequestException();
 	}

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -2010,8 +2010,12 @@ class Item
 
 		$contact = Contact::selectFirst(['id'], ['nurl' => $pcontact['nurl'], 'uid' => $item['uid']]);
 		if (!empty($contact['id'])) {
-			Item::update(['owner-id' => $item['author-id'], 'contact-id' => $contact['id']],
-				['uri-id' => $item['parent-uri-id'], 'uid' => $item['uid']]);
+			$condition = ['uri-id' => $item['parent-uri-id'], 'uid' => $item['uid']];
+			Item::update(['owner-id' => $item['author-id'], 'contact-id' => $contact['id']], $condition);
+			$forum_item = Item::selectFirst(['id'], $condition);
+			if (!empty($forum_item['id'])) {
+				UserItem::setNotification($forum_item['id']);
+			}
 			LOgger::info('Convert message into a forum message', ['uri-id' => $item['uri-id'], 'parent-uri-id' => $item['parent-uri-id'], 'uid' => $item['uid'], 'owner-id' => $item['author-id'], 'contact-id' => $contact['id']]);
 		}
 	}

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -2022,6 +2022,8 @@ class Item
 			if (!empty($forum_item['id'])) {
 				// This will trigger notifications like "X shared a new post"
 				UserItem::setNotification($forum_item['id']);
+
+				check_user_notification($forum_item['id']);
 			}
 			LOgger::info('Convert message into a forum message', ['uri-id' => $item['uri-id'], 'parent-uri-id' => $item['parent-uri-id'], 'uid' => $item['uid'], 'owner-id' => $item['author-id'], 'contact-id' => $contact['id']]);
 		}

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -2701,7 +2701,9 @@ class Item
 
 		Worker::add(['priority' => PRIORITY_HIGH, 'dont_fork' => true], 'Notifier', Delivery::POST, $item_id);
 
-		Item::performActivity($item_id, 'announce', $uid);
+		/// @todo This code should be activated by the end of the year 2020
+		// See also "createActivityFromItem"
+		//Item::performActivity($item_id, 'announce', $uid);
 
 		return false;
 	}

--- a/src/Module/Like.php
+++ b/src/Module/Like.php
@@ -51,7 +51,7 @@ class Like extends BaseModule
 		// @TODO: Replace with parameter from router
 		$itemId = (($app->argc > 1) ? Strings::escapeTags(trim($app->argv[1])) : 0);
 
-		if (!Item::performActivity($itemId, $verb)) {
+		if (!Item::performActivity($itemId, $verb, local_user())) {
 			throw new HTTPException\BadRequestException();
 		}
 

--- a/src/Protocol/ActivityPub/Receiver.php
+++ b/src/Protocol/ActivityPub/Receiver.php
@@ -387,29 +387,23 @@ class Receiver
 
 			case 'as:Announce':
 				if (in_array($object_data['object_type'], self::CONTENT_TYPES)) {
-					$profile = APContact::getByURL($object_data['actor']);
-					// Reshared posts from persons appear as summary at the bottom
-					// If this isn't set, then a single reshare appears on top. This is used for groups.
-					$object_data['thread-completion'] = ($profile['type'] != 'Group');
+					$object_data['thread-completion'] = true;
 
 					$item = ActivityPub\Processor::createItem($object_data);
 					ActivityPub\Processor::postItem($object_data, $item);
 
-					// Add the bottom reshare information only for persons
-					if ($profile['type'] != 'Group') {
-						$announce_object_data = self::processObject($activity);
-						$announce_object_data['name'] = $type;
-						$announce_object_data['author'] = JsonLD::fetchElement($activity, 'as:actor', '@id');
-						$announce_object_data['object_id'] = $object_data['object_id'];
-						$announce_object_data['object_type'] = $object_data['object_type'];
-						$announce_object_data['push'] = $push;
+					$announce_object_data = self::processObject($activity);
+					$announce_object_data['name'] = $type;
+					$announce_object_data['author'] = JsonLD::fetchElement($activity, 'as:actor', '@id');
+					$announce_object_data['object_id'] = $object_data['object_id'];
+					$announce_object_data['object_type'] = $object_data['object_type'];
+					$announce_object_data['push'] = $push;
 
-						if (!empty($body)) {
-							$announce_object_data['raw'] = $body;
-						}
-
-						ActivityPub\Processor::createActivity($announce_object_data, Activity::ANNOUNCE);
+					if (!empty($body)) {
+						$announce_object_data['raw'] = $body;
 					}
+
+					ActivityPub\Processor::createActivity($announce_object_data, Activity::ANNOUNCE);
 				}
 				break;
 

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -863,6 +863,21 @@ class Transmitter
 			return false;
 		}
 
+		/// @todo This code should be removed by the end of the year 2020
+		if ($item['wall'] && ($item['uri'] == $item['parent-uri'])) {
+			$owner = User::getOwnerDataById($item['uid']);
+			if (($owner['account-type'] == User::ACCOUNT_TYPE_COMMUNITY) && ($item['author-link'] != $owner['url'])) {
+				$type = 'Announce';
+
+				// Disguise forum posts as reshares. Will later be converted to a real announce
+				$item['body'] = BBCode::getShareOpeningTag($item['author-name'], $item['author-link'], $item['author-avatar'],
+					$item['plink'], $item['created'], $item['guid']) . $item['body'] . '[/share]';
+			}
+		}
+
+		/*
+		/// @todo This code should be activated by the end of the year 2020		
+		// See also "tagDeliver";
 		// In case of a forum post ensure to return the original post if author and forum are on the same machine
 		if (!empty($item['forum_mode'])) {
 			$author = Contact::getById($item['author-id'], ['nurl']);
@@ -873,6 +888,7 @@ class Transmitter
 				}
 			}
 		}
+		*/
 
 		if (empty($type)) {
 			$condition = ['item-uri' => $item['uri'], 'protocol' => Conversation::PARCEL_ACTIVITYPUB];

--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -2162,6 +2162,7 @@ class DFRN
 				|| ($item["verb"] == Activity::ATTEND)
 				|| ($item["verb"] == Activity::ATTENDNO)
 				|| ($item["verb"] == Activity::ATTENDMAYBE)
+				|| ($item["verb"] == Activity::ANNOUNCE)
 			) {
 				$is_like = true;
 				$item["gravity"] = GRAVITY_ACTIVITY;

--- a/src/Worker/Notifier.php
+++ b/src/Worker/Notifier.php
@@ -475,7 +475,7 @@ class Notifier
 						continue;
 					}
 
-					if (self::skipDFRN($rr, $target_item, $parent, $thr_parent, $cmd)) {
+					if (self::skipDFRN($rr, $target_item, $parent, $thr_parent, $owner, $cmd)) {
 						Logger::info('Contact can be delivered via AP, so skip delivery via legacy DFRN/Diaspora', ['id' => $target_id, 'url' => $rr['url']]);
 						continue;
 					}
@@ -530,7 +530,7 @@ class Notifier
 				continue;
 			}
 
-			if (self::skipDFRN($contact, $target_item, $parent, $thr_parent, $cmd)) {
+			if (self::skipDFRN($contact, $target_item, $parent, $thr_parent, $owner, $cmd)) {
 				Logger::info('Contact can be delivered via AP, so skip delivery via legacy DFRN/Diaspora', ['target' => $target_id, 'url' => $contact['url']]);
 				continue;
 			}
@@ -648,12 +648,13 @@ class Notifier
 	 * @param array  $item       The post
 	 * @param array  $parent     The parent
 	 * @param array  $thr_parent The thread parent
+	 * @param array  $owner      Owner array
 	 * @param string $cmd        Notifier command
 	 * @return bool
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 * @throws \ImagickException
 	 */
-	private static function skipDFRN($contact, $item, $parent, $thr_parent, $cmd)
+	private static function skipDFRN($contact, $item, $parent, $thr_parent, $owner, $cmd)
 	{
 		if (empty($parent['network'])) {
 			return false;
@@ -681,6 +682,12 @@ class Notifier
 
 		// Don't skip DFRN delivery for these commands
 		if (in_array($cmd, [Delivery::SUGGESTION, Delivery::REMOVAL, Delivery::RELOCATION, Delivery::POKE])) {
+			return false;
+		}
+
+		// For the time being we always deliver forum post via DFRN if possible
+		// This can be removed possible at the end of 2020 when hopefully most system can process AP forum posts
+		if ($owner['account-type'] == User::ACCOUNT_TYPE_COMMUNITY) {
 			return false;
 		}
 


### PR DESCRIPTION
This was intended as improvement for the message delivery process for forums via ActivityPub, inspirated by PR https://github.com/friendica/friendica/pull/8962. During the tests many problems had been found and fixed, especially with forums on the same server as the user account.

It then worked very well, completely reliable between AP and Friendica - but with problems between new Friendica systems and older ones.

So this PR now contains many fixes, but not the fix that improves AP compatibility. This should be activated at the end of the year, when most system should have updated.