### PR TITLE
Avoid loop situations and connection timeouts

### DIFF
--- a/src/Model/Contact/Relation.php
+++ b/src/Model/Contact/Relation.php
@@ -166,7 +166,7 @@ class Relation
 		}
 
 		if (empty($contact)) {
-			$contact = Contact::getByURL($url);
+			$contact = Contact::getByURL($url, false);
 		}
 
 		if (empty($contact)) {

--- a/src/Network/HTTPRequest.php
+++ b/src/Network/HTTPRequest.php
@@ -137,6 +137,8 @@ class HTTPRequest implements IHTTPRequest
 			@curl_setopt($ch, CURLOPT_NOBODY, $opts['nobody']);
 		}
 
+		@curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
+
 		if (!empty($opts['timeout'])) {
 			@curl_setopt($ch, CURLOPT_TIMEOUT, $opts['timeout']);
 		} else {
@@ -238,6 +240,8 @@ class HTTPRequest implements IHTTPRequest
 			curl_setopt($ch, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
 		}
 
+		@curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
+
 		if (intval($timeout)) {
 			curl_setopt($ch, CURLOPT_TIMEOUT, $timeout);
 		} else {
@@ -331,6 +335,7 @@ class HTTPRequest implements IHTTPRequest
 		curl_setopt($ch, CURLOPT_URL, $url);
 		curl_setopt($ch, CURLOPT_HEADER, 1);
 		curl_setopt($ch, CURLOPT_NOBODY, 1);
+		curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
 		curl_setopt($ch, CURLOPT_TIMEOUT, 10);
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 		curl_setopt($ch, CURLOPT_USERAGENT, $this->getUserAgent());
@@ -375,6 +380,7 @@ class HTTPRequest implements IHTTPRequest
 		curl_setopt($ch, CURLOPT_URL, $url);
 		curl_setopt($ch, CURLOPT_HEADER, 0);
 		curl_setopt($ch, CURLOPT_NOBODY, 0);
+		curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
 		curl_setopt($ch, CURLOPT_TIMEOUT, 10);
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 		curl_setopt($ch, CURLOPT_USERAGENT, $this->getUserAgent());


### PR DESCRIPTION
There had been two different issues that lead to endless running of `getIdForURL`. At first we hadn't handled a connection timeout. So on some (broken) systems we waited for a connection for ever.

Additionally there had been the issue where - while adding a contact - the contact discovery lead to an endless loop.