### PR TITLE
Use a constant for the contact photos / don't cache them

### DIFF
--- a/mod/fbrowser.php
+++ b/mod/fbrowser.php
@@ -9,6 +9,7 @@ use Friendica\App;
 use Friendica\Core\Renderer;
 use Friendica\Database\DBA;
 use Friendica\DI;
+use Friendica\Model\Photo;
 use Friendica\Util\Images;
 use Friendica\Util\Strings;
 
@@ -47,8 +48,8 @@ function fbrowser_content(App $a)
 			if ($a->argc==2) {
 				$photos = q("SELECT distinct(`album`) AS `album` FROM `photo` WHERE `uid` = %d AND `album` != '%s' AND `album` != '%s' ",
 					intval(local_user()),
-					DBA::escape('Contact Photos'),
-					DBA::escape(DI::l10n()->t('Contact Photos'))
+					DBA::escape(Photo::CONTACT_PHOTOS),
+					DBA::escape(DI::l10n()->t(Photo::CONTACT_PHOTOS))
 				);
 
 				$albums = array_column($photos, 'album');
@@ -66,8 +67,8 @@ function fbrowser_content(App $a)
 					FROM `photo` WHERE `uid` = %d $sql_extra AND `album` != '%s' AND `album` != '%s'
 					GROUP BY `resource-id` $sql_extra2",
 				intval(local_user()),
-				DBA::escape('Contact Photos'),
-				DBA::escape(DI::l10n()->t('Contact Photos'))
+				DBA::escape(Photo::CONTACT_PHOTOS),
+				DBA::escape(DI::l10n()->t(Photo::CONTACT_PHOTOS))
 			);
 
 			function _map_files1($rr)

--- a/mod/photos.php
+++ b/mod/photos.php
@@ -193,7 +193,7 @@ function photos_post(App $a)
 		}
 		$album = hex2bin($a->argv[3]);
 
-		if ($album === DI::l10n()->t('Profile Photos') || $album === 'Contact Photos' || $album === DI::l10n()->t('Contact Photos')) {
+		if ($album === DI::l10n()->t('Profile Photos') || $album === Photo::CONTACT_PHOTOS || $album === DI::l10n()->t(Photo::CONTACT_PHOTOS)) {
 			DI::baseUrl()->redirect($_SESSION['photo_return']);
 			return; // NOTREACHED
 		}
@@ -937,7 +937,7 @@ function photos_content(App $a)
 		$albumselect .= '<option value="" ' . (!$selname ? ' selected="selected" ' : '') . '>&lt;current year&gt;</option>';
 		if (!empty($a->data['albums'])) {
 			foreach ($a->data['albums'] as $album) {
-				if (($album['album'] === '') || ($album['album'] === 'Contact Photos') || ($album['album'] === DI::l10n()->t('Contact Photos'))) {
+				if (($album['album'] === '') || ($album['album'] === Photo::CONTACT_PHOTOS) || ($album['album'] === DI::l10n()->t(Photo::CONTACT_PHOTOS))) {
 					continue;
 				}
 				$selected = (($selname === $album['album']) ? ' selected="selected" ' : '');
@@ -1050,7 +1050,7 @@ function photos_content(App $a)
 
 		// edit album name
 		if ($cmd === 'edit') {
-			if (($album !== DI::l10n()->t('Profile Photos')) && ($album !== 'Contact Photos') && ($album !== DI::l10n()->t('Contact Photos'))) {
+			if (($album !== DI::l10n()->t('Profile Photos')) && ($album !== Photo::CONTACT_PHOTOS) && ($album !== DI::l10n()->t(Photo::CONTACT_PHOTOS))) {
 				if ($can_post) {
 					$edit_tpl = Renderer::getMarkupTemplate('album_edit.tpl');
 
@@ -1067,7 +1067,7 @@ function photos_content(App $a)
 				}
 			}
 		} else {
-			if (($album !== DI::l10n()->t('Profile Photos')) && ($album !== 'Contact Photos') && ($album !== DI::l10n()->t('Contact Photos')) && $can_post) {
+			if (($album !== DI::l10n()->t('Profile Photos')) && ($album !== Photo::CONTACT_PHOTOS) && ($album !== DI::l10n()->t(Photo::CONTACT_PHOTOS)) && $can_post) {
 				$edit = [DI::l10n()->t('Edit Album'), 'photos/' . $a->data['user']['nickname'] . '/album/' . bin2hex($album) . '/edit'];
 				$drop = [DI::l10n()->t('Drop Album'), 'photos/' . $a->data['user']['nickname'] . '/album/' . bin2hex($album) . '/drop'];
 			}
@@ -1550,8 +1550,8 @@ function photos_content(App $a)
 	$r = q("SELECT `resource-id`, max(`scale`) AS `scale` FROM `photo` WHERE `uid` = %d AND `album` != '%s' AND `album` != '%s'
 		$sql_extra GROUP BY `resource-id`",
 		intval($a->data['user']['uid']),
-		DBA::escape('Contact Photos'),
-		DBA::escape(DI::l10n()->t('Contact Photos'))
+		DBA::escape(Photo::CONTACT_PHOTOS),
+		DBA::escape(DI::l10n()->t(Photo::CONTACT_PHOTOS))
 	);
 	if (DBA::isResult($r)) {
 		$total = count($r);
@@ -1565,8 +1565,8 @@ function photos_content(App $a)
 		WHERE `uid` = %d AND `album` != '%s' AND `album` != '%s'
 		$sql_extra GROUP BY `resource-id` ORDER BY `created` DESC LIMIT %d , %d",
 		intval($a->data['user']['uid']),
-		DBA::escape('Contact Photos'),
-		DBA::escape(DI::l10n()->t('Contact Photos')),
+		DBA::escape(Photo::CONTACT_PHOTOS),
+		DBA::escape(DI::l10n()->t(Photo::CONTACT_PHOTOS)),
 		$pager->getStart(),
 		$pager->getItemsPerPage()
 	);

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -1584,6 +1584,16 @@ class Contact
 
 		$update = ($contact['avatar'] != $avatar) || $force;
 
+		if (strpos($avatar, self::DEFAULT_AVATAR_PHOTO)) {
+			$fields = ['avatar' => $avatar, 'avatar-date' => DateTimeFormat::utcNow(),
+				'photo' => DI::baseUrl() . self::DEFAULT_AVATAR_PHOTO,
+				'thumb' => DI::baseUrl() . self::DEFAULT_AVATAR_THUMB,
+				'micro' => DI::baseUrl() . self::DEFAULT_AVATAR_MICRO];
+			DBA::update('contact', $fields, ['id' => $cid]);
+			Photo::delete(['uid' => $uid, 'contact-id' => $cid, 'album' => Photo::CONTACT_PHOTOS]);
+			return;
+		}
+
 		if (!$update) {
 			foreach ($data as $image_uri) {
 				$image_rid = Photo::ridFromURI($image_uri);

--- a/src/Model/Photo.php
+++ b/src/Model/Photo.php
@@ -41,6 +41,8 @@ require_once "include/dba.php";
  */
 class Photo
 {
+	const CONTACT_PHOTOS = 'Contact Photos';
+
 	/**
 	 * Select rows from the photo table and returns them as array
 	 *
@@ -408,7 +410,7 @@ class Photo
 		$micro = "";
 
 		$photo = DBA::selectFirst(
-			"photo", ["resource-id"], ["uid" => $uid, "contact-id" => $cid, "scale" => 4, "album" => "Contact Photos"]
+			"photo", ["resource-id"], ["uid" => $uid, "contact-id" => $cid, "scale" => 4, "album" => self::CONTACT_PHOTOS]
 		);
 		if (!empty($photo['resource-id'])) {
 			$resource_id = $photo["resource-id"];
@@ -437,7 +439,7 @@ class Photo
 		if ($Image->isValid()) {
 			$Image->scaleToSquare(300);
 
-			$r = self::store($Image, $uid, $cid, $resource_id, $filename, "Contact Photos", 4);
+			$r = self::store($Image, $uid, $cid, $resource_id, $filename, self::CONTACT_PHOTOS, 4);
 
 			if ($r === false) {
 				$photo_failure = true;
@@ -445,7 +447,7 @@ class Photo
 
 			$Image->scaleDown(80);
 
-			$r = self::store($Image, $uid, $cid, $resource_id, $filename, "Contact Photos", 5);
+			$r = self::store($Image, $uid, $cid, $resource_id, $filename, self::CONTACT_PHOTOS, 5);
 
 			if ($r === false) {
 				$photo_failure = true;
@@ -453,7 +455,7 @@ class Photo
 
 			$Image->scaleDown(48);
 
-			$r = self::store($Image, $uid, $cid, $resource_id, $filename, "Contact Photos", 6);
+			$r = self::store($Image, $uid, $cid, $resource_id, $filename, self::CONTACT_PHOTOS, 6);
 
 			if ($r === false) {
 				$photo_failure = true;
@@ -561,8 +563,8 @@ class Photo
 					WHERE `uid` = %d  AND `album` != '%s' AND `album` != '%s' $sql_extra
 					GROUP BY `album` ORDER BY `created` DESC",
 					intval($uid),
-					DBA::escape("Contact Photos"),
-					DBA::escape(DI::l10n()->t("Contact Photos"))
+					DBA::escape(self::CONTACT_PHOTOS),
+					DBA::escape(DI::l10n()->t(self::CONTACT_PHOTOS))
 				);
 			} else {
 				// This query doesn't do the count and is much faster
@@ -570,8 +572,8 @@ class Photo
 					FROM `photo` USE INDEX (`uid_album_scale_created`)
 					WHERE `uid` = %d  AND `album` != '%s' AND `album` != '%s' $sql_extra",
 					intval($uid),
-					DBA::escape("Contact Photos"),
-					DBA::escape(DI::l10n()->t("Contact Photos"))
+					DBA::escape(self::CONTACT_PHOTOS),
+					DBA::escape(DI::l10n()->t(self::CONTACT_PHOTOS))
 				);
 			}
 			DI::cache()->set($key, $albums, Duration::DAY);


### PR DESCRIPTION
We now are using a constant for the album name of the contact avatars.

Also we don't create a cached version of the default avatar. This doesn't make sense and just is a waste of space.