### PR TITLE
Cache clearing rearrangements

### DIFF
--- a/src/Worker/ClearCache.php
+++ b/src/Worker/ClearCache.php
@@ -37,7 +37,7 @@ class ClearCache
 
 		// clear old cache
 		DI::cache()->clear();
-		if (!DI::config()->get('system', 'optimize_tables')) {
+		if (DI::config()->get('system', 'optimize_tables')) {
 			DBA::e("OPTIMIZE TABLE `cache`");
 		}
 
@@ -66,13 +66,13 @@ class ClearCache
 
 		// Delete the cached OEmbed entries that are older than three month
 		DBA::delete('oembed', ["`created` < NOW() - INTERVAL 3 MONTH"]);
-		if (!DI::config()->get('system', 'optimize_tables')) {
+		if (DI::config()->get('system', 'optimize_tables')) {
 			DBA::e("OPTIMIZE TABLE `oembed`");
 		}
 
 		// Delete the cached "parse_url" entries that are older than three month
 		DBA::delete('parsed_url', ["`created` < NOW() - INTERVAL 3 MONTH"]);
-		if (!DI::config()->get('system', 'optimize_tables')) {
+		if (DI::config()->get('system', 'optimize_tables')) {
 			DBA::e("OPTIMIZE TABLE `parsed_url`");
 		}
 	}

--- a/src/Worker/ClearCache.php
+++ b/src/Worker/ClearCache.php
@@ -21,7 +21,6 @@
 
 namespace Friendica\Worker;
 
-use Friendica\Core\Logger;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Photo;
@@ -35,21 +34,12 @@ class ClearCache
 	public static function execute()
 	{
 		$a = DI::app();
-		$last = DI::config()->get('system', 'cache_last_cleared');
-
-		if ($last) {
-			$next = $last + (3600); // Once per hour
-			$clear_cache = ($next <= time());
-		} else {
-			$clear_cache = true;
-		}
-
-		if (!$clear_cache) {
-			return;
-		}
 
 		// clear old cache
 		DI::cache()->clear();
+		if (!DI::config()->get('system', 'optimize_tables')) {
+			DBA::e("OPTIMIZE TABLE `cache`");
+		}
 
 		// clear old item cache files
 		clear_cache();
@@ -76,25 +66,14 @@ class ClearCache
 
 		// Delete the cached OEmbed entries that are older than three month
 		DBA::delete('oembed', ["`created` < NOW() - INTERVAL 3 MONTH"]);
+		if (!DI::config()->get('system', 'optimize_tables')) {
+			DBA::e("OPTIMIZE TABLE `oembed`");
+		}
 
 		// Delete the cached "parse_url" entries that are older than three month
 		DBA::delete('parsed_url', ["`created` < NOW() - INTERVAL 3 MONTH"]);
-
-		if (DI::config()->get('system', 'optimize_tables')) {
-			Logger::info('Optimize start');
-			DBA::e("OPTIMIZE TABLE `auth_codes`");
-			DBA::e("OPTIMIZE TABLE `cache`");
-			DBA::e("OPTIMIZE TABLE `challenge`");
-			DBA::e("OPTIMIZE TABLE `locks`");
-			DBA::e("OPTIMIZE TABLE `oembed`");
+		if (!DI::config()->get('system', 'optimize_tables')) {
 			DBA::e("OPTIMIZE TABLE `parsed_url`");
-			DBA::e("OPTIMIZE TABLE `profile_check`");
-			DBA::e("OPTIMIZE TABLE `session`");
-			DBA::e("OPTIMIZE TABLE `tokens`");
-			DBA::e("OPTIMIZE TABLE `process`");
-			Logger::info('Optimize finished');
 		}
-
-		DI::config()->set('system', 'cache_last_cleared', time());
 	}
 }

--- a/src/Worker/Cron.php
+++ b/src/Worker/Cron.php
@@ -63,9 +63,6 @@ class Cron
 		// Call possible post update functions
 		Worker::add(PRIORITY_LOW, 'PostUpdate');
 
-		// Clear cache entries
-		Worker::add(PRIORITY_LOW, 'ClearCache');
-
 		// Repair entries in the database
 		Worker::add(PRIORITY_LOW, 'RepairDatabase');
 
@@ -94,6 +91,10 @@ class Cron
 
 			self::checkdeletedContacts();
 
+			if (!DI::config()->get('system', 'optimize_tables')) {
+				self::optimizeTables();
+			}
+	
 			DI::config()->set('system', 'last_expire_day', $d2);
 		}
 
@@ -110,8 +111,19 @@ class Cron
 
 			// Optimizing this table only last seconds
 			if (DI::config()->get('system', 'optimize_tables')) {
-				DBA::e("OPTIMIZE TABLE `workerqueue`");
+				// We are acquiring the two locks from the worker to avoid locking problems
+				if (DI::lock()->acquire(Worker::LOCK_PROCESS, 10)) {
+					if (DI::lock()->acquire(Worker::LOCK_WORKER, 10)) {
+						DBA::e("OPTIMIZE TABLE `workerqueue`");
+						DBA::e("OPTIMIZE TABLE `process`");			
+						DI::lock()->release(Worker::LOCK_WORKER);
+					}
+					DI::lock()->release(Worker::LOCK_PROCESS);
+				}
 			}
+
+			// Clear cache entries
+			Worker::add(PRIORITY_LOW, 'ClearCache');
 
 			DI::config()->set('system', 'last_cron_hourly', time());
 		}
@@ -134,6 +146,25 @@ class Cron
 		DI::config()->set('system', 'last_cron', time());
 
 		return;
+	}
+
+	/**
+	 * Optimize tables that are known to grow and shrink all the time
+	 *
+	 * @return void
+	 */
+	private static function optimizeTables()
+	{
+		Logger::info('Optimize start');
+
+		DBA::e("OPTIMIZE TABLE `auth_codes`");
+		DBA::e("OPTIMIZE TABLE `challenge`");
+		DBA::e("OPTIMIZE TABLE `locks`");
+		DBA::e("OPTIMIZE TABLE `profile_check`");
+		DBA::e("OPTIMIZE TABLE `session`");
+		DBA::e("OPTIMIZE TABLE `tokens`");
+
+		DI::lock()->release('optimize_tables');
 	}
 
 	/**

--- a/src/Worker/Cron.php
+++ b/src/Worker/Cron.php
@@ -91,7 +91,7 @@ class Cron
 
 			self::checkdeletedContacts();
 
-			if (!DI::config()->get('system', 'optimize_tables')) {
+			if (DI::config()->get('system', 'optimize_tables')) {
 				self::optimizeTables();
 			}
 	


### PR DESCRIPTION
On one of my servers I watched some weird table locking problems when optimizing the tables. I split these calls now and I'm calling them at different places and times. The "clear cache" functionality is now called in a section of the cron where it is called only once an hour - instead of calling it all the time and then checking if an hour had passed.