### PR TITLE
Fix sharing detection on reshares

### DIFF
--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -2026,13 +2026,13 @@ class Item
 			return;
 		}
 
-		if (Contact::getIdForURL($parent['author-link'], $item['uid'])) {
+		if (($author['contact-type'] != Contact::TYPE_COMMUNITY) && Contact::isSharing($parent['author-link'], $item['uid'])) {
 			logger::info('The parent author is a user contact: quit', ['author' => $parent['author-link'], 'uid' => $item['uid']]);
 			return;
 		}
 
 		$cid = Contact::getIdForURL($author['url'], $item['uid']);
-		if (empty($cid)) {
+		if (empty($cid) || !Contact::isSharing($cid, $item['uid'])) {
 			logger::info('The resharer is not a user contact: quit', ['resharer' => $author['url'], 'uid' => $item['uid']]);
 			return;
 		}


### PR DESCRIPTION
When rewriting the owner of an announces (reshared) post, we mustn't quit when the resharer is a forum. Also we have to check if the contact is sharing with the user - the check for a user contact is not sufficient.