### PR TITLE
Fix: Feeds and mail accounts hadn't been fetched reliably

### DIFF
--- a/src/Worker/OnePoll.php
+++ b/src/Worker/OnePoll.php
@@ -111,7 +111,7 @@ class OnePoll
 			DBA::update('contact', ['last-update' => $updated], ['id' => $contact['id']]);
 			return;
 		}		
-		
+
 		// We don't poll AP contacts by now
 		if ($protocol === Protocol::ACTIVITYPUB) {
 			Logger::log("Don't poll AP contact");
@@ -707,6 +707,9 @@ class OnePoll
 		} else {
 			Logger::log("Mail: no mails for ".$mailconf['user']);
 		}
+
+		self::updateContact($contact, ['failed' => false, 'last-update' => $updated, 'success_update' => $updated]);
+		Contact::unmarkForArchival($contact);
 
 		Logger::log("Mail: closing connection for ".$mailconf['user']);
 		imap_close($mbox);


### PR DESCRIPTION
Feeds hadn't been fetched at the right times. The condition for the check contained a `>` - but `<` had been correct. Also on mal accounts the "last-update" and "next-update" hadn't been set.