### PR TITLE
HOTFIX to make all themes (but frio) working again

### DIFF
--- a/src/Module/Theme.php
+++ b/src/Module/Theme.php
@@ -41,6 +41,7 @@ class Theme extends BaseModule
 		}
 
 		// set the path for later use in the theme styles
+		$THEMEPATH = "view/theme/$theme";
 		if (file_exists("view/theme/$theme/style.php")) {
 			require_once "view/theme/$theme/style.php";
 		}


### PR DESCRIPTION
PR #9039 removed the THEMEPATH variable from Module/Theme.php and thus broke all themes except for frio which the PR aimed to improve.

This PR is a hotfix to make the other themes usabke again, by re-introducing that variable. A later PR shall fix the problem by adopting the other themes to the new way frio is doing stuff.