### PR TITLE
The table "item-delivery-data" does not exist on newer systems

### DIFF
--- a/src/Database/PostUpdate.php
+++ b/src/Database/PostUpdate.php
@@ -456,6 +456,11 @@ class PostUpdate
 			return true;
 		}
 
+		if (!DBStructure::existsTable('item-delivery-data')) {
+			DI::config()->set('system', 'post_update_version', 1297);
+			return true;
+		}
+
 		$max_item_delivery_data = DBA::selectFirst('item-delivery-data', ['iid'], ['queue_count > 0 OR queue_done > 0'], ['order' => ['iid']]);
 		$max_iid = $max_item_delivery_data['iid'];
 
@@ -697,6 +702,11 @@ class PostUpdate
 	{
 		// Was the script completed?
 		if (DI::config()->get('system', 'post_update_version') >= 1345) {
+			return true;
+		}
+
+		if (!DBStructure::existsTable('item-delivery-data')) {
+			DI::config()->set('system', 'post_update_version', 1345);
 			return true;
 		}
 

--- a/update.php
+++ b/update.php
@@ -348,7 +348,9 @@ function update_1309()
 
 function update_1315()
 {
-	DBA::delete('item-delivery-data', ['postopts' => '', 'inform' => '', 'queue_count' => 0, 'queue_done' => 0]);
+	if (DBStructure::existsTable('item-delivery-data')) {
+		DBA::delete('item-delivery-data', ['postopts' => '', 'inform' => '', 'queue_count' => 0, 'queue_done' => 0]);
+	}
 	return Update::SUCCESS;
 }
 


### PR DESCRIPTION
See here: https://forum.friendi.ca/display/c443a55c-145f-4042-adb3-33f956743600

The table had been replaced by another table. 
