### PR TITLE
Fix malformatted tag scheme

### DIFF
--- a/src/Model/Tag.php
+++ b/src/Model/Tag.php
@@ -93,6 +93,10 @@ class Tag
 				return;
 			}
 
+			if ((substr($url, 0, 7) == 'https//') || (substr($url, 0, 6) == 'http//')) {
+				Logger::notice('Wrong scheme in url', ['url' => $url, 'callstack' => System::callstack(20)]);
+			}
+
 			if (!$probing) {
 				$condition = ['nurl' => Strings::normaliseLink($url), 'uid' => 0, 'deleted' => false];
 				$contact = DBA::selectFirst('contact', ['id'], $condition, ['order' => ['id']]);

--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -2408,7 +2408,7 @@ class DFRN
 					$parts = explode(":", $scheme);
 					if ((count($parts) >= 4) && (array_shift($parts) == "X-DFRN")) {
 						$termurl = array_pop($parts);
-						$termurl = array_pop($parts) . $termurl;
+						$termurl = array_pop($parts) . ':' . $termurl;
 						Tag::store($item['uri-id'], Tag::IMPLICIT_MENTION, $term, $termurl);
 					}
 				}


### PR DESCRIPTION
Incoming mentions from DFRN had falsely been stored without the `:`, means in the format `https//server.tld/...`.