### PR TITLE
Enable inbox for the system account

### DIFF
--- a/static/routes.config.php
+++ b/static/routes.config.php
@@ -162,6 +162,7 @@ return [
 	'/followers/{owner}' => [Module\Followers::class,       [R::GET]],
 	'/following/{owner}' => [Module\Following::class,       [R::GET]],
 	'/friendica[/json]'  => [Module\Friendica::class,       [R::GET]],
+	'/friendica/inbox'   => [Module\Inbox::class,           [R::GET, R::POST]],
 
 	'/fsuggest/{contact:\d+}' => [Module\FriendSuggest::class,  [R::GET, R::POST]],
 


### PR DESCRIPTION
In https://github.com/friendica/friendica/pull/9050 the system user had been introduced. It is propagating an "inbox" endpoint that is enabled with this PR.

This is a preparation for being able to use the ActivityPub relays.