### PR TITLE
Use the AP adress for probing webfinger

### DIFF
--- a/src/Network/Probe.php
+++ b/src/Network/Probe.php
@@ -712,7 +712,14 @@ class Probe
 
 		Logger::info('Probing start', ['uri' => $uri]);
 
-		$data = self::getWebfingerArray($uri);
+		if (!empty($ap_profile['addr']) && ($ap_profile['addr'] != $uri)) {
+			$data = self::getWebfingerArray($ap_profile['addr']);
+		}
+
+		if (empty($data)) {
+			$data = self::getWebfingerArray($uri);
+		}
+
 		if (empty($data)) {
 			if (!empty($parts['scheme'])) {
 				return self::feed($uri);


### PR DESCRIPTION
The `addr` in the webfinger array is the result of a webfinger probe. So this should be used when the other checks are done.

The background is the preparation of enabling ActivityPub relays.