### PR TITLE
Improve AP support for forums

### DIFF
--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -2716,9 +2716,7 @@ class Item
 
 		Worker::add(['priority' => PRIORITY_HIGH, 'dont_fork' => true], 'Notifier', Delivery::POST, $item_id);
 
-		/// @todo This code should be activated by the end of the year 2020
-		// See also "createActivityFromItem"
-		//Item::performActivity($item_id, 'announce', $uid);
+		Item::performActivity($item_id, 'announce', $uid);
 
 		return false;
 	}

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -914,21 +914,6 @@ class Transmitter
 			return false;
 		}
 
-		/// @todo This code should be removed by the end of the year 2020
-		if ($item['wall'] && ($item['uri'] == $item['parent-uri'])) {
-			$owner = User::getOwnerDataById($item['uid']);
-			if (($owner['account-type'] == User::ACCOUNT_TYPE_COMMUNITY) && ($item['author-link'] != $owner['url'])) {
-				$type = 'Announce';
-
-				// Disguise forum posts as reshares. Will later be converted to a real announce
-				$item['body'] = BBCode::getShareOpeningTag($item['author-name'], $item['author-link'], $item['author-avatar'],
-					$item['plink'], $item['created'], $item['guid']) . $item['body'] . '[/share]';
-			}
-		}
-
-		/*
-		/// @todo This code should be activated by the end of the year 2020		
-		// See also "tagDeliver";
 		// In case of a forum post ensure to return the original post if author and forum are on the same machine
 		if (!empty($item['forum_mode'])) {
 			$author = Contact::getById($item['author-id'], ['nurl']);
@@ -939,7 +924,6 @@ class Transmitter
 				}
 			}
 		}
-		*/
 
 		if (empty($type)) {
 			$condition = ['item-uri' => $item['uri'], 'protocol' => Conversation::PARCEL_ACTIVITYPUB];


### PR DESCRIPTION
Some PR ago there had been massive improvements for the forum support via ActivityPub. Some changes had been hold back, since there possibly had been the problem that it it could make things worse for older systems.

Some days ago I realized that the prognosed problems already occur. Also I looked at the code again and came to the conclusion that this change here is enough to serve as a safety net for older versions:
https://github.com/friendica/friendica/blob/develop/src/Worker/Notifier.php#L688-L692

So with this PR the forum support for systems like Pleroma and Mastodon should improve a lot and Friendica systems shouldn't feel a difference.