### PR TITLE
Re-allow anonymous use of CSRF tokens

### DIFF
--- a/src/BaseModule.php
+++ b/src/BaseModule.php
@@ -140,11 +140,7 @@ abstract class BaseModule
 			return false;
 		}
 
-		if (empty($a->user)) {
-			return false;
-		}
-
-		$sec_hash = hash('whirlpool', $a->user['guid'] . $a->user['prvkey'] . session_id() . $x[0] . $typename);
+		$sec_hash = hash('whirlpool', ($a->user['guid'] ?? '') . ($a->user['prvkey'] ?? '') . session_id() . $x[0] . $typename);
 
 		return ($sec_hash == $x[1]);
 	}


### PR DESCRIPTION
Follow-up to #9041
Fixes #9065 

The last batch of notice fixes was overzealous, it included forbidding unauthenticated users to user CSRF forms, disabling registering completely.