### PR TITLE
change the console search subcommand so that it fits the documentation

### DIFF
--- a/src/Console/User.php
+++ b/src/Console/User.php
@@ -409,7 +409,7 @@ HELP;
 			case 'guid':
 				$user = UserModel::getByGuid($param, $fields);
 				break;
-			case 'email':
+			case 'mail':
 				$user = UserModel::getByEmail($param, $fields);
 				break;
 			case 'nick':


### PR DESCRIPTION
The documentation of the console command to search a user by mail was documented to use "mail" as subcommand. The code falsly expected "email". This PR changes the subcommand so that it fits the documentation.