### PR TITLE
Added support for the "replace" database command

### DIFF
--- a/src/Database/DBA.php
+++ b/src/Database/DBA.php
@@ -293,6 +293,20 @@ class DBA
 	}
 
 	/**
+	 * Replace a row of a table
+	 *
+	 * @param string|array $table Table name or array [schema => table]
+	 * @param array        $param parameter array
+	 *
+	 * @return boolean was the insert successful?
+	 * @throws \Exception
+	 */
+	public static function replace($table, $param)
+	{
+		return DI::dba()->replace($table, $param);
+	}
+
+	/**
 	 * Fetch the id of the last insert command
 	 *
 	 * @return integer Last inserted id

--- a/src/Database/DBA.php
+++ b/src/Database/DBA.php
@@ -293,7 +293,8 @@ class DBA
 	}
 
 	/**
-	 * Replace a row of a table
+	 * Inserts a row with the provided data in the provided table.
+	 * If the data corresponds to an existing row through a UNIQUE or PRIMARY index constraints, it updates the row instead.
 	 *
 	 * @param string|array $table Table name or array [schema => table]
 	 * @param array        $param parameter array

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -1007,6 +1007,33 @@ class Database
 	}
 
 	/**
+	 * Replace a row of a table
+	 *
+	 * @param string|array $table Table name or array [schema => table]
+	 * @param array        $param parameter array
+	 *
+	 * @return boolean was the insert successful?
+	 * @throws \Exception
+	 */
+	public function replace($table, array $param)
+	{
+		if (empty($table) || empty($param)) {
+			$this->logger->info('Table and fields have to be set');
+			return false;
+		}
+
+		$table_string = DBA::buildTableString($table);
+
+		$fields_string = implode(', ', array_map([DBA::class, 'quoteIdentifier'], array_keys($param)));
+
+		$values_string = substr(str_repeat("?, ", count($param)), 0, -2);
+
+		$sql = "REPLACE " . $table_string . " (" . $fields_string . ") VALUES (" . $values_string . ")";
+
+		return $this->e($sql, $param);
+	}
+
+	/**
 	 * Fetch the id of the last insert command
 	 *
 	 * @return integer Last inserted id

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -1007,7 +1007,8 @@ class Database
 	}
 
 	/**
-	 * Replace a row of a table
+	 * Inserts a row with the provided data in the provided table.
+	 * If the data corresponds to an existing row through a UNIQUE or PRIMARY index constraints, it updates the row instead.
 	 *
 	 * @param string|array $table Table name or array [schema => table]
 	 * @param array        $param parameter array


### PR DESCRIPTION
`replace` is a standardized way of inserting and handle key duplicates. It isn't used at the moment. In the future it should be used whenever tables values are inserted and there is an unique key.