### PR TITLE
Configuration if the database is opened with persistent connections

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -134,6 +134,8 @@ class Database
 			return false;
 		}
 
+		$persistent = (bool)$this->configCache->get('database', 'persistent');
+
 		$this->emulate_prepares = (bool)$this->configCache->get('database', 'emulate_prepares');
 		$this->pdo_emulate_prepares = (bool)$this->configCache->get('database', 'pdo_emulate_prepares');
 
@@ -150,7 +152,7 @@ class Database
 			}
 
 			try {
-				$this->connection = @new PDO($connect, $user, $pass);
+				$this->connection = @new PDO($connect, $user, $pass, [PDO::ATTR_PERSISTENT => $persistent]);
 				$this->connection->setAttribute(PDO::ATTR_EMULATE_PREPARES, $this->pdo_emulate_prepares);
 				$this->connected = true;
 			} catch (PDOException $e) {

--- a/static/defaults.config.php
+++ b/static/defaults.config.php
@@ -62,6 +62,13 @@ return [
 		// disable_pdo (Boolean)
 		// PDO is used by default (if available). Otherwise MySQLi will be used.
 		'disable_pdo' => false,
+
+		// persistent (Boolean)
+		// This controls if the system should use persistent connections or not.
+		// Persistent connections increase the performance.
+		// On the other hand the number of open connections are higher,
+		// this will most likely increase the system load.
+		'persistent' => false,
 	],
 	'config' => [
 		// admin_email (Comma-separated list)


### PR DESCRIPTION
Until now we hadn't configured if persistent connections are used or not. I'm unsure what is used in that case. Now we can configure the behaviour and per standard they are not used.

On squeet.me this seems to have lead to a drop in the load from around 5-7 to 0.x to 2.x.