### PR TITLE
Worker: Fetch jobs for multiple workers

### DIFF
--- a/src/Core/Worker.php
+++ b/src/Core/Worker.php
@@ -96,7 +96,8 @@ class Worker
 
 		// We fetch the next queue entry that is about to be executed
 		while ($r = self::workerProcess()) {
-			$refetched = false;
+			// Don't refetch when a worker fetches tasks for multiple workers
+			$refetched = DI::config()->get('system', 'worker_multiple_fetch');
 			foreach ($r as $entry) {
 				// Assure that the priority is an integer value
 				$entry['priority'] = (int)$entry['priority'];
@@ -143,6 +144,7 @@ class Worker
 			// Quit the worker once every cron interval
 			if (time() > ($starttime + (DI::config()->get('system', 'cron_interval') * 60))) {
 				Logger::info('Process lifetime reached, respawning.');
+				self::unclaimProcess();
 				self::spawnWorker();
 				return;
 			}

--- a/static/defaults.config.php
+++ b/static/defaults.config.php
@@ -499,6 +499,11 @@ return [
 		// Setting 0 would allow maximum worker queues at all times, which is not recommended.
 		'worker_load_exponent' => 3,
 
+		// worker_multiple_fetch (Boolean)
+		// When activated, the worker fetches jobs for multiple workers (not only for itself).
+		// This is an experimental setting without knowing the performance impact.
+		'worker_multiple_fetch' => false,
+		
 		// worker_defer_limit (Integer)
 		// Per default the systems tries delivering for 15 times before dropping it.
 		'worker_defer_limit' => 15,


### PR DESCRIPTION
This PR contains an experimental new way to assign tasks to workers. By now every worker fetches it's own tasks. But I want to check if it is an advantage if the scheduling is done via a single worker for multiple workers. Means: The current worker is checking for the currently active workers and is assigning tasks to all of them.

In theory this should increase speed because the process of fetching tasks is done less often.

I'm sure that it will have side effects, that's why it is hidden behind a configuration. When not enabled, the system should behave like before.

I'm sure that other PRs will follow that will extend this functionality somewhere in the future.