### PR TITLE
Support signed outbox requests

### DIFF
--- a/src/Module/Outbox.php
+++ b/src/Module/Outbox.php
@@ -22,10 +22,10 @@
 namespace Friendica\Module;
 
 use Friendica\BaseModule;
-use Friendica\Core\System;
 use Friendica\DI;
 use Friendica\Model\User;
 use Friendica\Protocol\ActivityPub;
+use Friendica\Util\HTTPSignature;
 
 /**
  * ActivityPub Outbox
@@ -48,11 +48,8 @@ class Outbox extends BaseModule
 
 		$page = $_REQUEST['page'] ?? null;
 
-		/// @todo Add Authentication to enable fetching of non public content
-		// $requester = HTTPSignature::getSigner('', $_SERVER);
-
-		$outbox = ActivityPub\Transmitter::getOutbox($owner, $page);
-
+		$requester = HTTPSignature::getSigner('', $_SERVER);
+		$outbox = ActivityPub\Transmitter::getOutbox($owner, $page, $requester);
 		header('Content-Type: application/activity+json');
 		echo json_encode($outbox);
 		exit();

--- a/src/Util/HTTPSignature.php
+++ b/src/Util/HTTPSignature.php
@@ -484,7 +484,7 @@ class HTTPSignature
 		}
 
 		$headers = [];
-		$headers['(request-target)'] = strtolower($http_headers['REQUEST_METHOD']) . ' ' . $http_headers['REQUEST_URI'];
+		$headers['(request-target)'] = strtolower($http_headers['REQUEST_METHOD']) . ' ' . parse_url($http_headers['REQUEST_URI'], PHP_URL_PATH);
 
 		// First take every header
 		foreach ($http_headers as $k => $v) {


### PR DESCRIPTION
We now are supporting that private items can be fetched via signed HTTP requests. We support fetching these items in the outbox and directly.

This also fixes a bug when checking for signatures of incoming requests.