### PR TITLE
The account fields are rearrange to match Mastodon

### DIFF
--- a/src/Object/Api/Mastodon/Account.php
+++ b/src/Object/Api/Mastodon/Account.php
@@ -46,14 +46,14 @@ class Account extends BaseEntity
 	protected $display_name;
 	/** @var bool */
 	protected $locked;
-	/** @var string (Datetime) */
+	/** @var bool|null */
+	protected $bot = null;
+	/** @var bool */
+	protected $discoverable;
+	/** @var bool */
+	protected $group;
+	/** @var string|null (Datetime) */
 	protected $created_at;
-	/** @var int */
-	protected $followers_count;
-	/** @var int */
-	protected $following_count;
-	/** @var int */
-	protected $statuses_count;
 	/** @var string */
 	protected $note;
 	/** @var string (URL)*/
@@ -66,20 +66,20 @@ class Account extends BaseEntity
 	protected $header;
 	/** @var string (URL) */
 	protected $header_static;
+	/** @var int */
+	protected $followers_count;
+	/** @var int */
+	protected $following_count;
+	/** @var int */
+	protected $statuses_count;
+	/** @var string|null (Datetime) */
+	protected $last_status_at = null;
 	/** @var Emoji[] */
 	protected $emojis;
 	/** @var Account|null */
 	protected $moved = null;
 	/** @var Field[]|null */
 	protected $fields = null;
-	/** @var bool|null */
-	protected $bot = null;
-	/** @var bool */
-	protected $group;
-	/** @var bool */
-	protected $discoverable;
-	/** @var string|null (Datetime) */
-	protected $last_status_at = null;
 
 	/**
 	 * Creates an account record from a public contact record. Expects all contact table fields to be set.
@@ -92,7 +92,7 @@ class Account extends BaseEntity
 	 */
 	public function __construct(BaseURL $baseUrl, array $publicContact, Fields $fields, array $apcontact = [], array $userContact = [])
 	{
-		$this->id              = $publicContact['id'];
+		$this->id              = (string)$publicContact['id'];
 		$this->username        = $publicContact['nick'];
 		$this->acct            =
 			strpos($publicContact['url'], $baseUrl->get() . '/') === 0 ?
@@ -100,10 +100,10 @@ class Account extends BaseEntity
 				$publicContact['addr'];
 		$this->display_name    = $publicContact['name'];
 		$this->locked          = !empty($apcontact['manually-approve']);
+		$this->bot             = ($publicContact['contact-type'] == Contact::TYPE_NEWS);
+		$this->discoverable    = !$publicContact['unsearchable'];
+		$this->group           = ($publicContact['contact-type'] == Contact::TYPE_COMMUNITY);
 		$this->created_at      = DateTimeFormat::utc($publicContact['created'], DateTimeFormat::ATOM);
-		$this->followers_count = $apcontact['followers_count'] ?? 0;
-		$this->following_count = $apcontact['following_count'] ?? 0;
-		$this->statuses_count  = $apcontact['statuses_count'] ?? 0;
 		$this->note            = BBCode::convert($publicContact['about'], false);
 		$this->url             = $publicContact['url'];
 		$this->avatar          = $userContact['avatar'] ?? $publicContact['avatar'];
@@ -111,18 +111,20 @@ class Account extends BaseEntity
 		// No header picture in Friendica
 		$this->header          = '';
 		$this->header_static   = '';
-		// No custom emojis per account in Friendica
-		$this->emojis          = [];
-		// No metadata fields in Friendica
-		$this->fields          = $fields->getArrayCopy();
-		$this->bot             = ($publicContact['contact-type'] == Contact::TYPE_NEWS);
-		$this->group           = ($publicContact['contact-type'] == Contact::TYPE_COMMUNITY);
-		$this->discoverable    = !$publicContact['unsearchable'];
+		$this->followers_count = $apcontact['followers_count'] ?? 0;
+		$this->following_count = $apcontact['following_count'] ?? 0;
+		$this->statuses_count  = $apcontact['statuses_count'] ?? 0;
 
 		$publicContactLastItem = $publicContact['last-item'] ?: DBA::NULL_DATETIME;
 		$userContactLastItem = $userContact['last-item'] ?? DBA::NULL_DATETIME;
 
 		$lastItem = $userContactLastItem > $publicContactLastItem ? $userContactLastItem : $publicContactLastItem;
-		$this->last_status_at  = $lastItem != DBA::NULL_DATETIME ? DateTimeFormat::utc($lastItem, DateTimeFormat::ATOM) : null;
+		$this->last_status_at  = $lastItem != DBA::NULL_DATETIME ? DateTimeFormat::utc($lastItem, 'Y-m-d') : null;
+
+		// No custom emojis per account in Friendica
+		$this->emojis          = [];
+		// No metadata fields in Friendica
+		$this->fields          = $fields->getArrayCopy();
+
 	}
 }

--- a/src/Object/Api/Mastodon/Account.php
+++ b/src/Object/Api/Mastodon/Account.php
@@ -123,7 +123,6 @@ class Account extends BaseEntity
 
 		// No custom emojis per account in Friendica
 		$this->emojis          = [];
-		// No metadata fields in Friendica
 		$this->fields          = $fields->getArrayCopy();
 
 	}


### PR DESCRIPTION
I had a look at how Mastodon returns the account fields. The order is changed. Also the `id` field is string and not integer. Also I saw that the `last_status_at` field now returns only the date, but not the time. Since this is more privacy orientated, I applied this change as well.

You can compare https://mastodon.social/api/v1/directory?limit=1&local=true with https://pirati.ca/api/v1/directory?limit=1&local=true to see the similarity.