### PR TITLE
New field "manually-approve" for contact table

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -1,6 +1,6 @@
 -- ------------------------------------------
 -- Friendica 2020.09-dev (Red Hot Poker)
--- DB_UPDATE_VERSION 1365
+-- DB_UPDATE_VERSION 1366
 -- ------------------------------------------
 
 
@@ -98,6 +98,7 @@ CREATE TABLE IF NOT EXISTS `contact` (
 	`forum` boolean NOT NULL DEFAULT '0' COMMENT 'contact is a forum',
 	`prv` boolean NOT NULL DEFAULT '0' COMMENT 'contact is a private group',
 	`contact-type` tinyint NOT NULL DEFAULT 0 COMMENT '',
+	`manually-approve` boolean COMMENT '',
 	`hidden` boolean NOT NULL DEFAULT '0' COMMENT '',
 	`archive` boolean NOT NULL DEFAULT '0' COMMENT '',
 	`pending` boolean NOT NULL DEFAULT '1' COMMENT '',

--- a/database.sql
+++ b/database.sql
@@ -1541,6 +1541,7 @@ CREATE VIEW `owner-view` AS SELECT
 	`contact`.`forum` AS `forum`,
 	`contact`.`prv` AS `prv`,
 	`contact`.`contact-type` AS `contact-type`,
+	`contact`.`manually-approve` AS `manually-approve`,
 	`contact`.`hidden` AS `hidden`,
 	`contact`.`archive` AS `archive`,
 	`contact`.`pending` AS `pending`,

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -1802,7 +1802,7 @@ class Contact
 		// These fields aren't updated by this routine:
 		// 'xmpp', 'sensitive'
 
-		$fields = ['uid', 'avatar', 'name', 'nick', 'location', 'keywords', 'about', 'subscribe',
+		$fields = ['uid', 'avatar', 'name', 'nick', 'location', 'keywords', 'about', 'subscribe', 'manually-approve',
 			'unsearchable', 'url', 'addr', 'batch', 'notify', 'poll', 'request', 'confirm', 'poco',
 			'network', 'alias', 'baseurl', 'gsid', 'forum', 'prv', 'contact-type', 'pubkey', 'last-item'];
 		$contact = DBA::selectFirst('contact', $fields, ['id' => $id]);
@@ -1851,9 +1851,8 @@ class Contact
 			$ret['prv'] = false;
 			$ret['contact-type'] = $ret['account-type'];
 			if ($ret['contact-type'] == User::ACCOUNT_TYPE_COMMUNITY) {
-				$apcontact = APContact::getByURL($ret['url'], false);
-				if (isset($apcontact['manually-approve'])) {
-					$ret['forum'] = (bool)!$apcontact['manually-approve'];
+				if (isset($ret['manually-approve'])) {
+					$ret['forum'] = (bool)!$ret['manually-approve'];
 					$ret['prv'] = (bool)!$ret['forum'];
 				}
 			}

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -1850,11 +1850,9 @@ class Contact
 			$ret['forum'] = false;
 			$ret['prv'] = false;
 			$ret['contact-type'] = $ret['account-type'];
-			if ($ret['contact-type'] == User::ACCOUNT_TYPE_COMMUNITY) {
-				if (isset($ret['manually-approve'])) {
-					$ret['forum'] = (bool)!$ret['manually-approve'];
-					$ret['prv'] = (bool)!$ret['forum'];
-				}
+			if (($ret['contact-type'] == User::ACCOUNT_TYPE_COMMUNITY) && isset($ret['manually-approve'])) {
+				$ret['forum'] = (bool)!$ret['manually-approve'];
+				$ret['prv'] = (bool)!$ret['forum'];
 			}
 		}
 
@@ -2121,10 +2119,8 @@ class Contact
 		$hidden = (($protocol === Protocol::MAIL) ? 1 : 0);
 
 		$pending = false;
-		if ($protocol == Protocol::ACTIVITYPUB) {
-			if (isset($ret['manually-approve'])) {
-				$pending = (bool)$ret['manually-approve'];
-			}
+		if (($protocol == Protocol::ACTIVITYPUB) && isset($ret['manually-approve'])) {
+			$pending = (bool)$ret['manually-approve'];
 		}
 
 		if (in_array($protocol, [Protocol::MAIL, Protocol::DIASPORA, Protocol::ACTIVITYPUB])) {

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -2122,9 +2122,8 @@ class Contact
 
 		$pending = false;
 		if ($protocol == Protocol::ACTIVITYPUB) {
-			$apcontact = APContact::getByURL($ret['url'], false);
-			if (isset($apcontact['manually-approve'])) {
-				$pending = (bool)$apcontact['manually-approve'];
+			if (isset($ret['manually-approve'])) {
+				$pending = (bool)$ret['manually-approve'];
 			}
 		}
 

--- a/src/Network/Probe.php
+++ b/src/Network/Probe.php
@@ -91,12 +91,12 @@ class Probe
 				"community", "keywords", "location", "about", "hide",
 				"batch", "notify", "poll", "request", "confirm", "subscribe", "poco",
 				"following", "followers", "inbox", "outbox", "sharedinbox",
-				"priority", "network", "pubkey", "baseurl", "gsid"];
+				"priority", "network", "pubkey", "manually-approve", "baseurl", "gsid"];
 
 		$newdata = [];
 		foreach ($fields as $field) {
 			if (isset($data[$field])) {
-				if (in_array($field, ["gsid", "hide", "account-type"])) {
+				if (in_array($field, ["gsid", "hide", "account-type", "manually-approve"])) {
 					$newdata[$field] = (int)$data[$field];
 				} else {	
 					$newdata[$field] = $data[$field];
@@ -1454,6 +1454,7 @@ class Probe
 			&& !empty($hcard_url)
 		) {
 			$data["network"] = Protocol::DIASPORA;
+			$data["manually-approve"] = false;
 
 			// The Diaspora handle must always be lowercase
 			if (!empty($data["addr"])) {
@@ -1544,6 +1545,7 @@ class Probe
 			&& isset($data["url"])
 		) {
 			$data["network"] = Protocol::OSTATUS;
+			$data["manually-approve"] = false;
 		} else {
 			return $short ? false : [];
 		}
@@ -2218,7 +2220,8 @@ class Probe
 			'following' => $approfile['following'], 'followers' => $approfile['followers'],
 			'inbox' => $approfile['inbox'], 'outbox' => $approfile['outbox'],
 			'sharedinbox' => $approfile['endpoints']['sharedInbox'], 'network' => Protocol::DFRN, 
-			'pubkey' => $profile['upubkey'], 'baseurl' => $approfile['generator']['url'], 'gsid' => $profile['gsid']];
+			'pubkey' => $profile['upubkey'], 'baseurl' => $approfile['generator']['url'], 'gsid' => $profile['gsid'],
+			'manually-approve' => in_array($profile['page-flags'], [User::PAGE_FLAGS_NORMAL, User::PAGE_FLAGS_PRVGROUP])];
 		return self::rearrangeData($data);		
 	}
 }

--- a/src/Object/Api/Mastodon/Account.php
+++ b/src/Object/Api/Mastodon/Account.php
@@ -103,7 +103,13 @@ class Account extends BaseEntity
 		$this->bot             = ($publicContact['contact-type'] == Contact::TYPE_NEWS);
 		$this->discoverable    = !$publicContact['unsearchable'];
 		$this->group           = ($publicContact['contact-type'] == Contact::TYPE_COMMUNITY);
-		$this->created_at      = DateTimeFormat::utc($publicContact['created'], DateTimeFormat::ATOM);
+
+		$publicContactCreated = $publicContact['created'] ?: DBA::NULL_DATETIME;
+		$userContactCreated = $userContact['created'] ?? DBA::NULL_DATETIME;
+
+		$created = $userContactCreated < $publicContactCreated && ($userContactCreated != DBA::NULL_DATETIME) ? $userContactCreated : $publicContactCreated;
+		$this->created_at      = DateTimeFormat::utc($created, DateTimeFormat::ATOM);
+
 		$this->note            = BBCode::convert($publicContact['about'], false);
 		$this->url             = $publicContact['url'];
 		$this->avatar          = $userContact['avatar'] ?? $publicContact['avatar'];

--- a/src/Object/Api/Mastodon/Account.php
+++ b/src/Object/Api/Mastodon/Account.php
@@ -99,7 +99,7 @@ class Account extends BaseEntity
 				$publicContact['nick'] :
 				$publicContact['addr'];
 		$this->display_name    = $publicContact['name'];
-		$this->locked          = !empty($apcontact['manually-approve']);
+		$this->locked          = $publicContact['manually-approve'] ?? !empty($apcontact['manually-approve']);
 		$this->bot             = ($publicContact['contact-type'] == Contact::TYPE_NEWS);
 		$this->discoverable    = !$publicContact['unsearchable'];
 		$this->group           = ($publicContact['contact-type'] == Contact::TYPE_COMMUNITY);

--- a/src/Protocol/ActivityPub.php
+++ b/src/Protocol/ActivityPub.php
@@ -157,6 +157,7 @@ class ActivityPub
 		$profile['poll'] = $apcontact['outbox'];
 		$profile['pubkey'] = $apcontact['pubkey'];
 		$profile['subscribe'] = $apcontact['subscribe'];
+		$profile['manually-approve'] = $apcontact['manually-approve'];
 		$profile['baseurl'] = $apcontact['baseurl'];
 		$profile['gsid'] = $apcontact['gsid'];
 

--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -54,7 +54,7 @@
 use Friendica\Database\DBA;
 
 if (!defined('DB_UPDATE_VERSION')) {
-	define('DB_UPDATE_VERSION', 1365);
+	define('DB_UPDATE_VERSION', 1366);
 }
 
 return [
@@ -153,6 +153,7 @@ return [
 			"forum" => ["type" => "boolean", "not null" => "1", "default" => "0", "comment" => "contact is a forum"],
 			"prv" => ["type" => "boolean", "not null" => "1", "default" => "0", "comment" => "contact is a private group"],
 			"contact-type" => ["type" => "tinyint", "not null" => "1", "default" => "0", "comment" => ""],
+			"manually-approve" => ["type" => "boolean", "comment" => ""],
 			"hidden" => ["type" => "boolean", "not null" => "1", "default" => "0", "comment" => ""],
 			"archive" => ["type" => "boolean", "not null" => "1", "default" => "0", "comment" => ""],
 			"pending" => ["type" => "boolean", "not null" => "1", "default" => "1", "comment" => ""],

--- a/static/dbview.config.php
+++ b/static/dbview.config.php
@@ -184,6 +184,7 @@ return [
 			"forum" => ["contact", "forum"],
 			"prv" => ["contact", "prv"],
 			"contact-type" => ["contact", "contact-type"],
+			"manually-approve" => ["contact", "manually-approve"],
 			"hidden" => ["contact", "hidden"],
 			"archive" => ["contact", "archive"],
 			"pending" => ["contact", "pending"],


### PR DESCRIPTION
We had some places in the code where we used that field already but had to fetch it via the APContact table.