### PR TITLE
Various post display improvements

### DIFF
--- a/include/conversation.php
+++ b/include/conversation.php
@@ -725,7 +725,7 @@ function conversation_fetch_comments($thread_items, $pinned) {
 
 		if (!empty($parentlines) && empty($direction) && ($row['gravity'] == GRAVITY_COMMENT)
 			&& Contact::isSharing($row['author-id'], $row['uid'])) {
-			$direction = ['direction' => 2, 'title' => DI::l10n()->t('%s commented this.', $row['author-name'])];
+			$direction = ['direction' => 5, 'title' => DI::l10n()->t('%s commented on this.', $row['author-name'])];
 		}
 
 		if (($row['gravity'] == GRAVITY_PARENT) && !$row['origin'] && ($row['author-id'] == $row['owner-id'])

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2020.09-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-08-31 18:51+0000\n"
+"POT-Creation-Date: 2020-09-03 10:50-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,462 +18,35 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 
-#: view/theme/duepuntozero/config.php:52
-msgid "default"
-msgstr ""
-
-#: view/theme/duepuntozero/config.php:53
-msgid "greenzero"
-msgstr ""
-
-#: view/theme/duepuntozero/config.php:54
-msgid "purplezero"
-msgstr ""
-
-#: view/theme/duepuntozero/config.php:55
-msgid "easterbunny"
-msgstr ""
-
-#: view/theme/duepuntozero/config.php:56
-msgid "darkzero"
-msgstr ""
-
-#: view/theme/duepuntozero/config.php:57
-msgid "comix"
-msgstr ""
-
-#: view/theme/duepuntozero/config.php:58
-msgid "slackr"
-msgstr ""
-
-#: view/theme/duepuntozero/config.php:69 view/theme/quattro/config.php:71
-#: view/theme/vier/config.php:119 view/theme/frio/config.php:160
-#: mod/message.php:272 mod/message.php:442 mod/events.php:572
-#: mod/photos.php:958 mod/photos.php:1064 mod/photos.php:1351
-#: mod/photos.php:1395 mod/photos.php:1442 mod/photos.php:1505
-#: src/Object/Post.php:949 src/Module/Debug/Localtime.php:64
-#: src/Module/Profile/Profile.php:241 src/Module/FriendSuggest.php:129
-#: src/Module/Install.php:230 src/Module/Install.php:270
-#: src/Module/Install.php:306 src/Module/Delegation.php:151
-#: src/Module/Contact.php:580 src/Module/Invite.php:175
-#: src/Module/Item/Compose.php:144 src/Module/Contact/Poke.php:156
-#: src/Module/Contact/Advanced.php:140
-#: src/Module/Settings/Profile/Index.php:237
-msgid "Submit"
-msgstr ""
-
-#: view/theme/duepuntozero/config.php:70 view/theme/quattro/config.php:72
-#: view/theme/vier/config.php:120 view/theme/frio/config.php:161
-#: src/Module/Settings/Display.php:189
-msgid "Theme settings"
-msgstr ""
-
-#: view/theme/duepuntozero/config.php:71
-msgid "Variations"
-msgstr ""
-
-#: view/theme/quattro/config.php:73
-msgid "Alignment"
-msgstr ""
-
-#: view/theme/quattro/config.php:73
-msgid "Left"
-msgstr ""
-
-#: view/theme/quattro/config.php:73
-msgid "Center"
-msgstr ""
-
-#: view/theme/quattro/config.php:74
-msgid "Color scheme"
-msgstr ""
-
-#: view/theme/quattro/config.php:75
-msgid "Posts font size"
-msgstr ""
-
-#: view/theme/quattro/config.php:76
-msgid "Textareas font size"
-msgstr ""
-
-#: view/theme/vier/config.php:75
-msgid "Comma separated list of helper forums"
-msgstr ""
-
-#: view/theme/vier/config.php:115
-msgid "don't show"
-msgstr ""
-
-#: view/theme/vier/config.php:115
-msgid "show"
-msgstr ""
-
-#: view/theme/vier/config.php:121
-msgid "Set style"
-msgstr ""
-
-#: view/theme/vier/config.php:122
-msgid "Community Pages"
-msgstr ""
-
-#: view/theme/vier/config.php:123 view/theme/vier/theme.php:124
-msgid "Community Profiles"
-msgstr ""
-
-#: view/theme/vier/config.php:124
-msgid "Help or @NewHere ?"
-msgstr ""
-
-#: view/theme/vier/config.php:125 view/theme/vier/theme.php:337
-msgid "Connect Services"
-msgstr ""
-
-#: view/theme/vier/config.php:126
-msgid "Find Friends"
-msgstr ""
-
-#: view/theme/vier/config.php:127 view/theme/vier/theme.php:151
-msgid "Last users"
-msgstr ""
-
-#: view/theme/vier/theme.php:169 src/Content/Widget.php:77
-msgid "Find People"
-msgstr ""
-
-#: view/theme/vier/theme.php:170 src/Content/Widget.php:78
-msgid "Enter name or interest"
-msgstr ""
-
-#: view/theme/vier/theme.php:171 include/conversation.php:908
-#: mod/follow.php:163 src/Model/Contact.php:960 src/Model/Contact.php:973
-#: src/Content/Widget.php:79
-msgid "Connect/Follow"
-msgstr ""
-
-#: view/theme/vier/theme.php:172 src/Content/Widget.php:80
-msgid "Examples: Robert Morgenstein, Fishing"
-msgstr ""
-
-#: view/theme/vier/theme.php:173 src/Module/Contact.php:840
-#: src/Module/Directory.php:105 src/Content/Widget.php:81
-msgid "Find"
-msgstr ""
-
-#: view/theme/vier/theme.php:174 mod/suggest.php:55 src/Content/Widget.php:82
-msgid "Friend Suggestions"
-msgstr ""
-
-#: view/theme/vier/theme.php:175 src/Content/Widget.php:83
-msgid "Similar Interests"
-msgstr ""
-
-#: view/theme/vier/theme.php:176 src/Content/Widget.php:84
-msgid "Random Profile"
-msgstr ""
-
-#: view/theme/vier/theme.php:177 src/Content/Widget.php:85
-msgid "Invite Friends"
-msgstr ""
-
-#: view/theme/vier/theme.php:178 src/Module/Directory.php:97
-#: src/Content/Widget.php:86
-msgid "Global Directory"
-msgstr ""
-
-#: view/theme/vier/theme.php:180 src/Content/Widget.php:88
-msgid "Local Directory"
-msgstr ""
-
-#: view/theme/vier/theme.php:220 src/Content/Nav.php:229
-#: src/Content/ForumManager.php:144 src/Content/Text/HTML.php:917
-msgid "Forums"
-msgstr ""
-
-#: view/theme/vier/theme.php:222 src/Content/ForumManager.php:146
-msgid "External link to forum"
-msgstr ""
-
-#: view/theme/vier/theme.php:225 src/Content/Widget.php:428
-#: src/Content/Widget.php:523 src/Content/ForumManager.php:149
-msgid "show more"
-msgstr ""
-
-#: view/theme/vier/theme.php:252
-msgid "Quick Start"
-msgstr ""
-
-#: view/theme/vier/theme.php:258 src/Module/Help.php:69
-#: src/Module/Settings/TwoFactor/Index.php:106
-#: src/Module/Settings/TwoFactor/Verify.php:132
-#: src/Module/Settings/TwoFactor/Recovery.php:93
-#: src/Module/Settings/TwoFactor/AppSpecific.php:115 src/Content/Nav.php:212
-msgid "Help"
-msgstr ""
-
-#: view/theme/frio/config.php:142
-msgid "Light (Accented)"
-msgstr ""
-
-#: view/theme/frio/config.php:143
-msgid "Dark (Accented)"
-msgstr ""
-
-#: view/theme/frio/config.php:144
-msgid "Black (Accented)"
-msgstr ""
-
-#: view/theme/frio/config.php:156
-msgid "Note"
-msgstr ""
-
-#: view/theme/frio/config.php:156
-msgid "Check image permissions if all users are allowed to see the image"
-msgstr ""
-
-#: view/theme/frio/config.php:162
-msgid "Custom"
-msgstr ""
-
-#: view/theme/frio/config.php:163
-msgid "Legacy"
-msgstr ""
-
-#: view/theme/frio/config.php:164
-msgid "Accented"
-msgstr ""
-
-#: view/theme/frio/config.php:165
-msgid "Select color scheme"
-msgstr ""
-
-#: view/theme/frio/config.php:166
-msgid "Select scheme accent"
-msgstr ""
-
-#: view/theme/frio/config.php:166
-msgid "Blue"
-msgstr ""
-
-#: view/theme/frio/config.php:166
-msgid "Red"
-msgstr ""
-
-#: view/theme/frio/config.php:166
-msgid "Purple"
-msgstr ""
-
-#: view/theme/frio/config.php:166
-msgid "Green"
-msgstr ""
-
-#: view/theme/frio/config.php:166
-msgid "Pink"
-msgstr ""
-
-#: view/theme/frio/config.php:167
-msgid "Copy or paste schemestring"
-msgstr ""
-
-#: view/theme/frio/config.php:167
-msgid ""
-"You can copy this string to share your theme with others. Pasting here "
-"applies the schemestring"
-msgstr ""
-
-#: view/theme/frio/config.php:168
-msgid "Navigation bar background color"
-msgstr ""
-
-#: view/theme/frio/config.php:169
-msgid "Navigation bar icon color "
-msgstr ""
-
-#: view/theme/frio/config.php:170
-msgid "Link color"
-msgstr ""
-
-#: view/theme/frio/config.php:171
-msgid "Set the background color"
-msgstr ""
-
-#: view/theme/frio/config.php:172
-msgid "Content background opacity"
-msgstr ""
-
-#: view/theme/frio/config.php:173
-msgid "Set the background image"
-msgstr ""
-
-#: view/theme/frio/config.php:174
-msgid "Background image style"
-msgstr ""
-
-#: view/theme/frio/config.php:179
-msgid "Login page background image"
-msgstr ""
-
-#: view/theme/frio/config.php:183
-msgid "Login page background color"
-msgstr ""
-
-#: view/theme/frio/config.php:183
-msgid "Leave background image and color empty for theme defaults"
-msgstr ""
-
-#: view/theme/frio/theme.php:207
-msgid "Guest"
-msgstr ""
-
-#: view/theme/frio/theme.php:210
-msgid "Visitor"
-msgstr ""
-
-#: view/theme/frio/theme.php:225 src/Module/Contact.php:631
-#: src/Module/Contact.php:884 src/Module/BaseProfile.php:60
-#: src/Module/Settings/TwoFactor/Index.php:107 src/Content/Nav.php:177
-msgid "Status"
-msgstr ""
-
-#: view/theme/frio/theme.php:225 src/Content/Nav.php:177
-#: src/Content/Nav.php:263
-msgid "Your posts and conversations"
-msgstr ""
-
-#: view/theme/frio/theme.php:226 src/Module/Profile/Profile.php:236
-#: src/Module/Welcome.php:57 src/Module/Contact.php:633
-#: src/Module/Contact.php:900 src/Module/BaseProfile.php:52
-#: src/Module/BaseSettings.php:57 src/Content/Nav.php:178
-msgid "Profile"
-msgstr ""
-
-#: view/theme/frio/theme.php:226 src/Content/Nav.php:178
-msgid "Your profile page"
-msgstr ""
-
-#: view/theme/frio/theme.php:227 mod/fbrowser.php:43
-#: src/Module/BaseProfile.php:68 src/Content/Nav.php:179
-msgid "Photos"
-msgstr ""
-
-#: view/theme/frio/theme.php:227 src/Content/Nav.php:179
-msgid "Your photos"
-msgstr ""
-
-#: view/theme/frio/theme.php:228 src/Module/BaseProfile.php:76
-#: src/Module/BaseProfile.php:79 src/Content/Nav.php:180
-msgid "Videos"
-msgstr ""
-
-#: view/theme/frio/theme.php:228 src/Content/Nav.php:180
-msgid "Your videos"
-msgstr ""
-
-#: view/theme/frio/theme.php:229 view/theme/frio/theme.php:233 mod/cal.php:273
-#: mod/events.php:414 src/Module/BaseProfile.php:88
-#: src/Module/BaseProfile.php:99 src/Content/Nav.php:181
-#: src/Content/Nav.php:248
-msgid "Events"
-msgstr ""
-
-#: view/theme/frio/theme.php:229 src/Content/Nav.php:181
-msgid "Your events"
-msgstr ""
-
-#: view/theme/frio/theme.php:232 src/Content/Nav.php:261
-msgid "Network"
-msgstr ""
-
-#: view/theme/frio/theme.php:232 src/Content/Nav.php:261
-msgid "Conversations from your friends"
-msgstr ""
-
-#: view/theme/frio/theme.php:233 src/Module/BaseProfile.php:91
-#: src/Module/BaseProfile.php:102 src/Content/Nav.php:248
-msgid "Events and Calendar"
-msgstr ""
-
-#: view/theme/frio/theme.php:234 mod/message.php:135 src/Content/Nav.php:273
-msgid "Messages"
-msgstr ""
-
-#: view/theme/frio/theme.php:234 src/Content/Nav.php:273
-msgid "Private mail"
-msgstr ""
-
-#: view/theme/frio/theme.php:235 src/Module/Welcome.php:52
-#: src/Module/Admin/Themes/Details.php:124
-#: src/Module/Admin/Addons/Details.php:119 src/Module/BaseSettings.php:124
-#: src/Content/Nav.php:282
-msgid "Settings"
-msgstr ""
-
-#: view/theme/frio/theme.php:235 src/Content/Nav.php:282
-msgid "Account settings"
-msgstr ""
-
-#: view/theme/frio/theme.php:236 src/Module/Contact.php:819
-#: src/Module/Contact.php:907 src/Module/BaseProfile.php:121
-#: src/Module/BaseProfile.php:124 src/Content/Nav.php:225
-#: src/Content/Nav.php:284 src/Content/Text/HTML.php:913
-msgid "Contacts"
-msgstr ""
-
-#: view/theme/frio/theme.php:236 src/Content/Nav.php:284
-msgid "Manage/edit friends and contacts"
-msgstr ""
-
-#: view/theme/frio/theme.php:321 include/conversation.php:891
-msgid "Follow Thread"
-msgstr ""
-
-#: view/theme/frio/php/standard.php:38 view/theme/frio/php/default.php:81
-msgid "Skip to main content"
-msgstr ""
-
-#: view/theme/frio/php/Image.php:40
-msgid "Top Banner"
-msgstr ""
-
-#: view/theme/frio/php/Image.php:40
-msgid ""
-"Resize image to the width of the screen and show background color below on "
-"long pages."
-msgstr ""
-
-#: view/theme/frio/php/Image.php:41
-msgid "Full screen"
-msgstr ""
-
-#: view/theme/frio/php/Image.php:41
-msgid ""
-"Resize image to fill entire screen, clipping either the right or the bottom."
-msgstr ""
-
-#: view/theme/frio/php/Image.php:42
-msgid "Single row mosaic"
-msgstr ""
-
-#: view/theme/frio/php/Image.php:42
-msgid ""
-"Resize image to repeat it on a single row, either vertical or horizontal."
-msgstr ""
-
-#: view/theme/frio/php/Image.php:43
-msgid "Mosaic"
-msgstr ""
-
-#: view/theme/frio/php/Image.php:43
-msgid "Repeat image to fill the screen."
-msgstr ""
-
-#: update.php:196
+#: include/api.php:1127
 #, php-format
-msgid "%s: Updating author-id and owner-id in item and thread table. "
+msgid "Daily posting limit of %d post reached. The post was rejected."
+msgid_plural "Daily posting limit of %d posts reached. The post was rejected."
+msgstr[0] ""
+msgstr[1] ""
+
+#: include/api.php:1141
+#, php-format
+msgid "Weekly posting limit of %d post reached. The post was rejected."
+msgid_plural "Weekly posting limit of %d posts reached. The post was rejected."
+msgstr[0] ""
+msgstr[1] ""
+
+#: include/api.php:1155
+#, php-format
+msgid "Monthly posting limit of %d post reached. The post was rejected."
 msgstr ""
 
-#: update.php:251
-#, php-format
-msgid "%s: Updating post-type."
+#: include/api.php:4452 mod/photos.php:105 mod/photos.php:196
+#: mod/photos.php:633 mod/photos.php:1053 mod/photos.php:1070
+#: mod/photos.php:1580 src/Model/User.php:999 src/Model/User.php:1007
+#: src/Model/User.php:1015 src/Module/Settings/Profile/Photo/Crop.php:97
+#: src/Module/Settings/Profile/Photo/Crop.php:113
+#: src/Module/Settings/Profile/Photo/Crop.php:129
+#: src/Module/Settings/Profile/Photo/Crop.php:178
+#: src/Module/Settings/Profile/Photo/Index.php:96
+#: src/Module/Settings/Profile/Photo/Index.php:102
+msgid "Profile Photos"
 msgstr ""
 
 #: include/conversation.php:188
@@ -502,9 +75,9 @@ msgstr ""
 msgid "Select"
 msgstr ""
 
-#: include/conversation.php:555 mod/settings.php:560 mod/settings.php:702
-#: mod/photos.php:1474 src/Module/Contact.php:850 src/Module/Contact.php:1153
-#: src/Module/Admin/Users.php:253
+#: include/conversation.php:555 mod/photos.php:1474 mod/settings.php:560
+#: mod/settings.php:702 src/Module/Admin/Users.php:253
+#: src/Module/Contact.php:850 src/Module/Contact.php:1153
 msgid "Delete"
 msgstr ""
 
@@ -531,9 +104,9 @@ msgid "View in context"
 msgstr ""
 
 #: include/conversation.php:627 include/conversation.php:1183
-#: mod/wallmessage.php:155 mod/message.php:271 mod/message.php:443
-#: mod/editpost.php:104 mod/photos.php:1378 src/Object/Post.php:488
-#: src/Module/Item/Compose.php:159
+#: mod/editpost.php:104 mod/message.php:271 mod/message.php:443
+#: mod/photos.php:1378 mod/wallmessage.php:155 src/Module/Item/Compose.php:159
+#: src/Object/Post.php:488
 msgid "Please wait"
 msgstr ""
 
@@ -553,11 +126,15 @@ msgstr ""
 
 #: include/conversation.php:728
 #, php-format
-msgid "%s commented this."
+msgid "%s commented on this."
 msgstr ""
 
 #: include/conversation.php:734
 msgid "Tagged"
+msgstr ""
+
+#: include/conversation.php:891 view/theme/frio/theme.php:321
+msgid "Follow Thread"
 msgstr ""
 
 #: include/conversation.php:892 src/Model/Contact.php:965
@@ -565,9 +142,9 @@ msgid "View Status"
 msgstr ""
 
 #: include/conversation.php:893 include/conversation.php:911
-#: src/Module/Directory.php:166 src/Module/Settings/Profile/Index.php:240
 #: src/Model/Contact.php:891 src/Model/Contact.php:957
-#: src/Model/Contact.php:966
+#: src/Model/Contact.php:966 src/Module/Directory.php:166
+#: src/Module/Settings/Profile/Index.php:240
 msgid "View Profile"
 msgstr ""
 
@@ -589,21 +166,28 @@ msgstr ""
 msgid "Send PM"
 msgstr ""
 
-#: include/conversation.php:898 src/Module/Contact.php:601
+#: include/conversation.php:898 src/Module/Admin/Blocklist/Contact.php:84
+#: src/Module/Admin/Users.php:254 src/Module/Contact.php:601
 #: src/Module/Contact.php:847 src/Module/Contact.php:1128
-#: src/Module/Admin/Users.php:254 src/Module/Admin/Blocklist/Contact.php:84
 msgid "Block"
 msgstr ""
 
-#: include/conversation.php:899 src/Module/Notifications/Notification.php:59
-#: src/Module/Notifications/Introductions.php:110
-#: src/Module/Notifications/Introductions.php:185 src/Module/Contact.php:602
+#: include/conversation.php:899 src/Module/Contact.php:602
 #: src/Module/Contact.php:848 src/Module/Contact.php:1136
+#: src/Module/Notifications/Introductions.php:110
+#: src/Module/Notifications/Introductions.php:185
+#: src/Module/Notifications/Notification.php:59
 msgid "Ignore"
 msgstr ""
 
 #: include/conversation.php:903 src/Model/Contact.php:972
 msgid "Poke"
+msgstr ""
+
+#: include/conversation.php:908 mod/follow.php:163 src/Content/Widget.php:79
+#: src/Model/Contact.php:960 src/Model/Contact.php:973
+#: view/theme/vier/theme.php:171
+msgid "Connect/Follow"
 msgstr ""
 
 #: include/conversation.php:1034
@@ -699,8 +283,8 @@ msgstr ""
 msgid "Visible to <strong>everybody</strong>"
 msgstr ""
 
-#: include/conversation.php:1122 src/Object/Post.php:959
-#: src/Module/Item/Compose.php:153
+#: include/conversation.php:1122 src/Module/Item/Compose.php:153
+#: src/Object/Post.php:959
 msgid "Please enter a image/video/audio/webpage URL:"
 msgstr ""
 
@@ -729,12 +313,12 @@ msgid "Share"
 msgstr ""
 
 #: include/conversation.php:1162 mod/editpost.php:89 mod/photos.php:1397
-#: src/Object/Post.php:950 src/Module/Contact/Poke.php:155
+#: src/Module/Contact/Poke.php:155 src/Object/Post.php:950
 msgid "Loading..."
 msgstr ""
 
-#: include/conversation.php:1163 mod/wallmessage.php:153 mod/message.php:269
-#: mod/message.php:440 mod/editpost.php:90
+#: include/conversation.php:1163 mod/editpost.php:90 mod/message.php:269
+#: mod/message.php:440 mod/wallmessage.php:153
 msgid "Upload photo"
 msgstr ""
 
@@ -750,43 +334,43 @@ msgstr ""
 msgid "attach file"
 msgstr ""
 
-#: include/conversation.php:1167 src/Object/Post.php:951
-#: src/Module/Item/Compose.php:145
+#: include/conversation.php:1167 src/Module/Item/Compose.php:145
+#: src/Object/Post.php:951
 msgid "Bold"
 msgstr ""
 
-#: include/conversation.php:1168 src/Object/Post.php:952
-#: src/Module/Item/Compose.php:146
+#: include/conversation.php:1168 src/Module/Item/Compose.php:146
+#: src/Object/Post.php:952
 msgid "Italic"
 msgstr ""
 
-#: include/conversation.php:1169 src/Object/Post.php:953
-#: src/Module/Item/Compose.php:147
+#: include/conversation.php:1169 src/Module/Item/Compose.php:147
+#: src/Object/Post.php:953
 msgid "Underline"
 msgstr ""
 
-#: include/conversation.php:1170 src/Object/Post.php:954
-#: src/Module/Item/Compose.php:148
+#: include/conversation.php:1170 src/Module/Item/Compose.php:148
+#: src/Object/Post.php:954
 msgid "Quote"
 msgstr ""
 
-#: include/conversation.php:1171 src/Object/Post.php:955
-#: src/Module/Item/Compose.php:149
+#: include/conversation.php:1171 src/Module/Item/Compose.php:149
+#: src/Object/Post.php:955
 msgid "Code"
 msgstr ""
 
-#: include/conversation.php:1172 src/Object/Post.php:956
-#: src/Module/Item/Compose.php:150
+#: include/conversation.php:1172 src/Module/Item/Compose.php:150
+#: src/Object/Post.php:956
 msgid "Image"
 msgstr ""
 
-#: include/conversation.php:1173 src/Object/Post.php:957
-#: src/Module/Item/Compose.php:151
+#: include/conversation.php:1173 src/Module/Item/Compose.php:151
+#: src/Object/Post.php:957
 msgid "Link"
 msgstr ""
 
-#: include/conversation.php:1174 src/Object/Post.php:958
-#: src/Module/Item/Compose.php:152
+#: include/conversation.php:1174 src/Module/Item/Compose.php:152
+#: src/Object/Post.php:958
 msgid "Link or Media"
 msgstr ""
 
@@ -831,15 +415,15 @@ msgstr ""
 
 #: include/conversation.php:1198 mod/editpost.php:125 mod/events.php:570
 #: mod/photos.php:1396 mod/photos.php:1443 mod/photos.php:1506
-#: src/Object/Post.php:960 src/Module/Item/Compose.php:154
+#: src/Module/Item/Compose.php:154 src/Object/Post.php:960
 msgid "Preview"
 msgstr ""
 
-#: include/conversation.php:1202 mod/settings.php:500 mod/settings.php:526
-#: mod/unfollow.php:137 mod/message.php:165 mod/tagrm.php:36 mod/tagrm.php:126
-#: mod/dfrn_request.php:648 mod/item.php:928 mod/editpost.php:128
-#: mod/follow.php:169 mod/fbrowser.php:105 mod/fbrowser.php:134
-#: mod/photos.php:1047 mod/photos.php:1154 src/Module/Contact.php:457
+#: include/conversation.php:1202 mod/dfrn_request.php:648 mod/editpost.php:128
+#: mod/fbrowser.php:105 mod/fbrowser.php:134 mod/follow.php:169
+#: mod/item.php:928 mod/message.php:165 mod/photos.php:1047 mod/photos.php:1154
+#: mod/settings.php:500 mod/settings.php:526 mod/tagrm.php:36 mod/tagrm.php:126
+#: mod/unfollow.php:137 src/Module/Contact.php:457
 #: src/Module/RemoteFollow.php:110
 msgid "Cancel"
 msgstr ""
@@ -856,8 +440,8 @@ msgstr ""
 msgid "Private post"
 msgstr ""
 
-#: include/conversation.php:1214 mod/editpost.php:132
-#: src/Module/Contact.php:332 src/Model/Profile.php:454
+#: include/conversation.php:1214 mod/editpost.php:132 src/Model/Profile.php:454
+#: src/Module/Contact.php:332
 msgid "Message"
 msgstr ""
 
@@ -1194,144 +778,153 @@ msgstr ""
 msgid "Please visit %s to approve or reject the request."
 msgstr ""
 
-#: include/api.php:1127
-#, php-format
-msgid "Daily posting limit of %d post reached. The post was rejected."
-msgid_plural "Daily posting limit of %d posts reached. The post was rejected."
-msgstr[0] ""
-msgstr[1] ""
-
-#: include/api.php:1141
-#, php-format
-msgid "Weekly posting limit of %d post reached. The post was rejected."
-msgid_plural "Weekly posting limit of %d posts reached. The post was rejected."
-msgstr[0] ""
-msgstr[1] ""
-
-#: include/api.php:1155
-#, php-format
-msgid "Monthly posting limit of %d post reached. The post was rejected."
-msgstr ""
-
-#: include/api.php:4452 mod/photos.php:105 mod/photos.php:196
-#: mod/photos.php:633 mod/photos.php:1053 mod/photos.php:1070
-#: mod/photos.php:1580 src/Module/Settings/Profile/Photo/Crop.php:97
-#: src/Module/Settings/Profile/Photo/Crop.php:113
-#: src/Module/Settings/Profile/Photo/Crop.php:129
-#: src/Module/Settings/Profile/Photo/Crop.php:178
-#: src/Module/Settings/Profile/Photo/Index.php:96
-#: src/Module/Settings/Profile/Photo/Index.php:102 src/Model/User.php:999
-#: src/Model/User.php:1007 src/Model/User.php:1015
-msgid "Profile Photos"
-msgstr ""
-
-#: mod/redir.php:34 mod/redir.php:203 mod/cal.php:47 mod/cal.php:51
-#: mod/follow.php:37 src/Module/Debug/ItemBody.php:37
-#: src/Module/Conversation/Community.php:145 src/Module/Item/Ignore.php:41
-#: src/Module/Diaspora/Receive.php:51
-msgid "Access denied."
-msgstr ""
-
-#: mod/redir.php:50 mod/redir.php:130
-msgid "Bad Request."
-msgstr ""
-
-#: mod/redir.php:56 mod/redir.php:157 mod/dfrn_confirm.php:139
-#: src/Module/FriendSuggest.php:54 src/Module/FriendSuggest.php:93
-#: src/Module/Group.php:105 src/Module/Contact/Advanced.php:53
-#: src/Module/Contact/Advanced.php:106 src/Module/Contact/Contacts.php:33
-msgid "Contact not found."
-msgstr ""
-
-#: mod/wallmessage.php:35 mod/wallmessage.php:59 mod/wallmessage.php:96
-#: mod/wallmessage.php:120 mod/dfrn_confirm.php:78 mod/settings.php:47
-#: mod/settings.php:65 mod/settings.php:489 mod/network.php:47
-#: mod/repair_ostatus.php:31 mod/unfollow.php:37 mod/unfollow.php:91
-#: mod/unfollow.php:123 mod/message.php:70 mod/message.php:113
-#: mod/ostatus_subscribe.php:30 mod/suggest.php:34 mod/wall_upload.php:99
-#: mod/wall_upload.php:102 mod/api.php:50 mod/api.php:55 mod/wall_attach.php:78
-#: mod/wall_attach.php:81 mod/item.php:189 mod/item.php:194 mod/item.php:973
-#: mod/uimport.php:32 mod/editpost.php:38 mod/events.php:228 mod/follow.php:76
-#: mod/follow.php:152 mod/notes.php:43 mod/photos.php:178 mod/photos.php:929
+#: mod/api.php:50 mod/api.php:55 mod/dfrn_confirm.php:78 mod/editpost.php:38
+#: mod/events.php:228 mod/follow.php:76 mod/follow.php:152 mod/item.php:189
+#: mod/item.php:194 mod/item.php:973 mod/message.php:70 mod/message.php:113
+#: mod/network.php:47 mod/notes.php:43 mod/ostatus_subscribe.php:30
+#: mod/photos.php:178 mod/photos.php:929 mod/repair_ostatus.php:31
+#: mod/settings.php:47 mod/settings.php:65 mod/settings.php:489
+#: mod/suggest.php:34 mod/uimport.php:32 mod/unfollow.php:37
+#: mod/unfollow.php:91 mod/unfollow.php:123 mod/wallmessage.php:35
+#: mod/wallmessage.php:59 mod/wallmessage.php:96 mod/wallmessage.php:120
+#: mod/wall_attach.php:78 mod/wall_attach.php:81 mod/wall_upload.php:99
+#: mod/wall_upload.php:102 src/Module/Attach.php:56 src/Module/BaseApi.php:59
+#: src/Module/BaseApi.php:65 src/Module/BaseNotifications.php:88
+#: src/Module/Contact/Advanced.php:43 src/Module/Contact.php:371
+#: src/Module/Delegation.php:118 src/Module/FollowConfirm.php:16
+#: src/Module/FriendSuggest.php:44 src/Module/Group.php:45
+#: src/Module/Group.php:90 src/Module/Invite.php:40 src/Module/Invite.php:128
 #: src/Module/Notifications/Notification.php:47
 #: src/Module/Notifications/Notification.php:76
 #: src/Module/Profile/Common.php:57 src/Module/Profile/Contacts.php:57
-#: src/Module/BaseNotifications.php:88 src/Module/Register.php:62
-#: src/Module/Register.php:75 src/Module/Register.php:195
-#: src/Module/Register.php:234 src/Module/FriendSuggest.php:44
-#: src/Module/BaseApi.php:59 src/Module/BaseApi.php:65
-#: src/Module/Delegation.php:118 src/Module/Contact.php:371
-#: src/Module/FollowConfirm.php:16 src/Module/Invite.php:40
-#: src/Module/Invite.php:128 src/Module/Attach.php:56 src/Module/Group.php:45
-#: src/Module/Group.php:90 src/Module/Search/Directory.php:38
-#: src/Module/Contact/Advanced.php:43
+#: src/Module/Register.php:62 src/Module/Register.php:75
+#: src/Module/Register.php:195 src/Module/Register.php:234
+#: src/Module/Search/Directory.php:38 src/Module/Settings/Delegation.php:42
+#: src/Module/Settings/Delegation.php:70 src/Module/Settings/Display.php:42
+#: src/Module/Settings/Display.php:116
 #: src/Module/Settings/Profile/Photo/Crop.php:157
 #: src/Module/Settings/Profile/Photo/Index.php:113
-#: src/Module/Settings/Delegation.php:42 src/Module/Settings/Delegation.php:70
-#: src/Module/Settings/Display.php:42 src/Module/Settings/Display.php:116
 msgid "Permission denied."
 msgstr ""
 
-#: mod/wallmessage.php:68 mod/wallmessage.php:129
-#, php-format
-msgid "Number of daily wall messages for %s exceeded. Message failed."
+#: mod/api.php:100 mod/api.php:122
+msgid "Authorize application connection"
 msgstr ""
 
-#: mod/wallmessage.php:76 mod/message.php:84
-msgid "No recipient selected."
+#: mod/api.php:101
+msgid "Return to your app and insert this Securty Code:"
 msgstr ""
 
-#: mod/wallmessage.php:79
-msgid "Unable to check your home location."
+#: mod/api.php:110 src/Module/BaseAdmin.php:73
+msgid "Please login to continue."
 msgstr ""
 
-#: mod/wallmessage.php:82 mod/message.php:91
-msgid "Message could not be sent."
-msgstr ""
-
-#: mod/wallmessage.php:85 mod/message.php:94
-msgid "Message collection failure."
-msgstr ""
-
-#: mod/wallmessage.php:103 mod/wallmessage.php:112
-msgid "No recipient."
-msgstr ""
-
-#: mod/wallmessage.php:137 mod/message.php:215 mod/message.php:365
-msgid "Please enter a link URL:"
-msgstr ""
-
-#: mod/wallmessage.php:142 mod/message.php:257
-msgid "Send Private Message"
-msgstr ""
-
-#: mod/wallmessage.php:143
-#, php-format
+#: mod/api.php:124
 msgid ""
-"If you wish for %s to respond, please check that the privacy settings on "
-"your site allow private mail from unknown senders."
+"Do you want to authorize this application to access your posts and contacts, "
+"and/or create new posts for you?"
 msgstr ""
 
-#: mod/wallmessage.php:144 mod/message.php:258 mod/message.php:431
-msgid "To:"
+#: mod/api.php:125 mod/item.php:925 mod/message.php:162
+#: src/Module/Contact.php:454 src/Module/Notifications/Introductions.php:119
+#: src/Module/Register.php:115
+msgid "Yes"
 msgstr ""
 
-#: mod/wallmessage.php:145 mod/message.php:262 mod/message.php:433
-msgid "Subject:"
+#: mod/api.php:126 src/Module/Notifications/Introductions.php:119
+#: src/Module/Register.php:116
+msgid "No"
 msgstr ""
 
-#: mod/wallmessage.php:151 mod/message.php:266 mod/message.php:436
-#: src/Module/Invite.php:168
-msgid "Your message:"
+#: mod/cal.php:47 mod/cal.php:51 mod/follow.php:37 mod/redir.php:34
+#: mod/redir.php:203 src/Module/Conversation/Community.php:145
+#: src/Module/Debug/ItemBody.php:37 src/Module/Diaspora/Receive.php:51
+#: src/Module/Item/Ignore.php:41
+msgid "Access denied."
 msgstr ""
 
-#: mod/wallmessage.php:154 mod/message.php:270 mod/message.php:441
-#: mod/editpost.php:94
-msgid "Insert web link"
+#: mod/cal.php:74 src/Module/HoverCard.php:53 src/Module/Profile/Common.php:41
+#: src/Module/Profile/Common.php:53 src/Module/Profile/Contacts.php:40
+#: src/Module/Profile/Contacts.php:51 src/Module/Profile/Status.php:54
+#: src/Module/Register.php:260
+msgid "User not found."
+msgstr ""
+
+#: mod/cal.php:142 mod/display.php:282 src/Module/Profile/Profile.php:94
+#: src/Module/Profile/Profile.php:109 src/Module/Profile/Status.php:105
+#: src/Module/Update/Profile.php:55
+msgid "Access to this profile has been restricted."
+msgstr ""
+
+#: mod/cal.php:273 mod/events.php:414 src/Content/Nav.php:181
+#: src/Content/Nav.php:248 src/Module/BaseProfile.php:88
+#: src/Module/BaseProfile.php:99 view/theme/frio/theme.php:229
+#: view/theme/frio/theme.php:233
+msgid "Events"
+msgstr ""
+
+#: mod/cal.php:274 mod/events.php:415
+msgid "View"
+msgstr ""
+
+#: mod/cal.php:275 mod/events.php:417
+msgid "Previous"
+msgstr ""
+
+#: mod/cal.php:276 mod/events.php:418 src/Module/Install.php:192
+msgid "Next"
+msgstr ""
+
+#: mod/cal.php:279 mod/events.php:423 src/Model/Event.php:445
+msgid "today"
+msgstr ""
+
+#: mod/cal.php:280 mod/events.php:424 src/Model/Event.php:446
+#: src/Util/Temporal.php:330
+msgid "month"
+msgstr ""
+
+#: mod/cal.php:281 mod/events.php:425 src/Model/Event.php:447
+#: src/Util/Temporal.php:331
+msgid "week"
+msgstr ""
+
+#: mod/cal.php:282 mod/events.php:426 src/Model/Event.php:448
+#: src/Util/Temporal.php:332
+msgid "day"
+msgstr ""
+
+#: mod/cal.php:283 mod/events.php:427
+msgid "list"
+msgstr ""
+
+#: mod/cal.php:296 src/Console/User.php:152 src/Console/User.php:250
+#: src/Console/User.php:283 src/Console/User.php:309 src/Model/User.php:561
+#: src/Module/Admin/Users.php:112 src/Module/Api/Twitter/ContactEndpoint.php:73
+msgid "User not found"
+msgstr ""
+
+#: mod/cal.php:305
+msgid "This calendar format is not supported"
+msgstr ""
+
+#: mod/cal.php:307
+msgid "No exportable data found"
+msgstr ""
+
+#: mod/cal.php:324
+msgid "calendar"
 msgstr ""
 
 #: mod/dfrn_confirm.php:84 src/Module/Profile/Profile.php:82
 msgid "Profile not found."
+msgstr ""
+
+#: mod/dfrn_confirm.php:139 mod/redir.php:56 mod/redir.php:157
+#: src/Module/Contact/Advanced.php:53 src/Module/Contact/Advanced.php:106
+#: src/Module/Contact/Contacts.php:33 src/Module/FriendSuggest.php:54
+#: src/Module/FriendSuggest.php:93 src/Module/Group.php:105
+msgid "Contact not found."
 msgstr ""
 
 #: mod/dfrn_confirm.php:140
@@ -1400,40 +993,549 @@ msgstr ""
 msgid "Unable to update your contact profile details on our system"
 msgstr ""
 
-#: mod/dfrn_confirm.php:552 mod/dfrn_request.php:569 src/Model/Contact.php:2398
+#: mod/dfrn_confirm.php:552 mod/dfrn_request.php:569 src/Model/Contact.php:2392
 msgid "[Name Withheld]"
 msgstr ""
 
-#: mod/videos.php:129 mod/display.php:179 mod/dfrn_request.php:606
-#: mod/photos.php:843 src/Module/Debug/WebFinger.php:38
-#: src/Module/Debug/Probe.php:39 src/Module/Conversation/Community.php:139
+#: mod/dfrn_poll.php:135 mod/dfrn_poll.php:506
+#, php-format
+msgid "%1$s welcomes %2$s"
+msgstr ""
+
+#: mod/dfrn_request.php:113
+msgid "This introduction has already been accepted."
+msgstr ""
+
+#: mod/dfrn_request.php:131 mod/dfrn_request.php:369
+msgid "Profile location is not valid or does not contain profile information."
+msgstr ""
+
+#: mod/dfrn_request.php:135 mod/dfrn_request.php:373
+msgid "Warning: profile location has no identifiable owner name."
+msgstr ""
+
+#: mod/dfrn_request.php:138 mod/dfrn_request.php:376
+msgid "Warning: profile location has no profile photo."
+msgstr ""
+
+#: mod/dfrn_request.php:142 mod/dfrn_request.php:380
+#, php-format
+msgid "%d required parameter was not found at the given location"
+msgid_plural "%d required parameters were not found at the given location"
+msgstr[0] ""
+msgstr[1] ""
+
+#: mod/dfrn_request.php:180
+msgid "Introduction complete."
+msgstr ""
+
+#: mod/dfrn_request.php:216
+msgid "Unrecoverable protocol error."
+msgstr ""
+
+#: mod/dfrn_request.php:243 src/Module/RemoteFollow.php:54
+msgid "Profile unavailable."
+msgstr ""
+
+#: mod/dfrn_request.php:264
+#, php-format
+msgid "%s has received too many connection requests today."
+msgstr ""
+
+#: mod/dfrn_request.php:265
+msgid "Spam protection measures have been invoked."
+msgstr ""
+
+#: mod/dfrn_request.php:266
+msgid "Friends are advised to please try again in 24 hours."
+msgstr ""
+
+#: mod/dfrn_request.php:290 src/Module/RemoteFollow.php:60
+msgid "Invalid locator"
+msgstr ""
+
+#: mod/dfrn_request.php:326
+msgid "You have already introduced yourself here."
+msgstr ""
+
+#: mod/dfrn_request.php:329
+#, php-format
+msgid "Apparently you are already friends with %s."
+msgstr ""
+
+#: mod/dfrn_request.php:349
+msgid "Invalid profile URL."
+msgstr ""
+
+#: mod/dfrn_request.php:355 src/Model/Contact.php:2017
+msgid "Disallowed profile URL."
+msgstr ""
+
+#: mod/dfrn_request.php:361 src/Model/Contact.php:2022
+#: src/Module/Friendica.php:79
+msgid "Blocked domain"
+msgstr ""
+
+#: mod/dfrn_request.php:428 src/Module/Contact.php:153
+msgid "Failed to update contact record."
+msgstr ""
+
+#: mod/dfrn_request.php:448
+msgid "Your introduction has been sent."
+msgstr ""
+
+#: mod/dfrn_request.php:480 src/Module/RemoteFollow.php:72
+msgid ""
+"Remote subscription can't be done for your network. Please subscribe "
+"directly on your system."
+msgstr ""
+
+#: mod/dfrn_request.php:496
+msgid "Please login to confirm introduction."
+msgstr ""
+
+#: mod/dfrn_request.php:504
+msgid ""
+"Incorrect identity currently logged in. Please login to <strong>this</"
+"strong> profile."
+msgstr ""
+
+#: mod/dfrn_request.php:518 mod/dfrn_request.php:533
+msgid "Confirm"
+msgstr ""
+
+#: mod/dfrn_request.php:529
+msgid "Hide this contact"
+msgstr ""
+
+#: mod/dfrn_request.php:531
+#, php-format
+msgid "Welcome home %s."
+msgstr ""
+
+#: mod/dfrn_request.php:532
+#, php-format
+msgid "Please confirm your introduction/connection request to %s."
+msgstr ""
+
+#: mod/dfrn_request.php:606 mod/display.php:179 mod/photos.php:843
+#: mod/videos.php:129 src/Module/Conversation/Community.php:139
+#: src/Module/Debug/Probe.php:39 src/Module/Debug/WebFinger.php:38
 #: src/Module/Directory.php:49 src/Module/Search/Index.php:49
 #: src/Module/Search/Index.php:54
 msgid "Public access denied."
 msgstr ""
 
-#: mod/videos.php:134
-msgid "No videos selected"
+#: mod/dfrn_request.php:642 src/Module/RemoteFollow.php:104
+msgid "Friend/Connection Request"
 msgstr ""
 
-#: mod/videos.php:182 mod/photos.php:914
-msgid "Access to this item is restricted."
+#: mod/dfrn_request.php:643
+#, php-format
+msgid ""
+"Enter your Webfinger address (user@domain.tld) or profile URL here. If this "
+"isn't supported by your system (for example it doesn't work with Diaspora), "
+"you have to subscribe to <strong>%s</strong> directly on your system"
 msgstr ""
 
-#: mod/videos.php:252 src/Model/Item.php:3567
-msgid "View Video"
+#: mod/dfrn_request.php:644 src/Module/RemoteFollow.php:106
+#, php-format
+msgid ""
+"If you are not yet a member of the free social web, <a href=\"%s\">follow "
+"this link to find a public Friendica node and join us today</a>."
 msgstr ""
 
-#: mod/videos.php:259 mod/photos.php:1600
-msgid "View Album"
+#: mod/dfrn_request.php:645 src/Module/RemoteFollow.php:107
+msgid "Your Webfinger address or profile URL:"
 msgstr ""
 
-#: mod/videos.php:267
-msgid "Recent Videos"
+#: mod/dfrn_request.php:646 mod/follow.php:164 src/Module/RemoteFollow.php:108
+msgid "Please answer the following:"
 msgstr ""
 
-#: mod/videos.php:269
-msgid "Upload New Videos"
+#: mod/dfrn_request.php:647 mod/follow.php:95 mod/unfollow.php:136
+#: src/Module/RemoteFollow.php:109
+msgid "Submit Request"
+msgstr ""
+
+#: mod/dfrn_request.php:654 mod/follow.php:178
+#, php-format
+msgid "%s knows you"
+msgstr ""
+
+#: mod/dfrn_request.php:655 mod/follow.php:179
+msgid "Add a personal note:"
+msgstr ""
+
+#: mod/display.php:238 mod/display.php:318
+msgid "The requested item doesn't exist or has been deleted."
+msgstr ""
+
+#: mod/display.php:398
+msgid "The feed for this item is unavailable."
+msgstr ""
+
+#: mod/editpost.php:45 mod/editpost.php:55
+msgid "Item not found"
+msgstr ""
+
+#: mod/editpost.php:62
+msgid "Edit post"
+msgstr ""
+
+#: mod/editpost.php:88 mod/notes.php:62 src/Content/Text/HTML.php:896
+#: src/Module/Filer/SaveTag.php:66
+msgid "Save"
+msgstr ""
+
+#: mod/editpost.php:94 mod/message.php:270 mod/message.php:441
+#: mod/wallmessage.php:154
+msgid "Insert web link"
+msgstr ""
+
+#: mod/editpost.php:95
+msgid "web link"
+msgstr ""
+
+#: mod/editpost.php:96
+msgid "Insert video link"
+msgstr ""
+
+#: mod/editpost.php:97
+msgid "video link"
+msgstr ""
+
+#: mod/editpost.php:98
+msgid "Insert audio link"
+msgstr ""
+
+#: mod/editpost.php:99
+msgid "audio link"
+msgstr ""
+
+#: mod/editpost.php:113 src/Core/ACL.php:314
+msgid "CC: email addresses"
+msgstr ""
+
+#: mod/editpost.php:120 src/Core/ACL.php:315
+msgid "Example: bob@example.com, mary@example.com"
+msgstr ""
+
+#: mod/events.php:135 mod/events.php:137
+msgid "Event can not end before it has started."
+msgstr ""
+
+#: mod/events.php:144 mod/events.php:146
+msgid "Event title and start time are required."
+msgstr ""
+
+#: mod/events.php:416
+msgid "Create New Event"
+msgstr ""
+
+#: mod/events.php:528
+msgid "Event details"
+msgstr ""
+
+#: mod/events.php:529
+msgid "Starting date and Title are required."
+msgstr ""
+
+#: mod/events.php:530 mod/events.php:535
+msgid "Event Starts:"
+msgstr ""
+
+#: mod/events.php:530 mod/events.php:562
+msgid "Required"
+msgstr ""
+
+#: mod/events.php:543 mod/events.php:568
+msgid "Finish date/time is not known or not relevant"
+msgstr ""
+
+#: mod/events.php:545 mod/events.php:550
+msgid "Event Finishes:"
+msgstr ""
+
+#: mod/events.php:556 mod/events.php:569
+msgid "Adjust for viewer timezone"
+msgstr ""
+
+#: mod/events.php:558 src/Module/Profile/Profile.php:172
+#: src/Module/Settings/Profile/Index.php:253
+msgid "Description:"
+msgstr ""
+
+#: mod/events.php:560 src/Model/Event.php:84 src/Model/Event.php:111
+#: src/Model/Event.php:454 src/Model/Event.php:948 src/Model/Profile.php:364
+#: src/Module/Contact.php:622 src/Module/Directory.php:156
+#: src/Module/Notifications/Introductions.php:166
+#: src/Module/Profile/Profile.php:190
+msgid "Location:"
+msgstr ""
+
+#: mod/events.php:562 mod/events.php:564
+msgid "Title:"
+msgstr ""
+
+#: mod/events.php:565 mod/events.php:566
+msgid "Share this event"
+msgstr ""
+
+#: mod/events.php:572 mod/message.php:272 mod/message.php:442
+#: mod/photos.php:958 mod/photos.php:1064 mod/photos.php:1351
+#: mod/photos.php:1395 mod/photos.php:1442 mod/photos.php:1505
+#: src/Module/Contact/Advanced.php:140 src/Module/Contact/Poke.php:156
+#: src/Module/Contact.php:580 src/Module/Debug/Localtime.php:64
+#: src/Module/Delegation.php:151 src/Module/FriendSuggest.php:129
+#: src/Module/Install.php:230 src/Module/Install.php:270
+#: src/Module/Install.php:306 src/Module/Invite.php:175
+#: src/Module/Item/Compose.php:144 src/Module/Profile/Profile.php:241
+#: src/Module/Settings/Profile/Index.php:237 src/Object/Post.php:949
+#: view/theme/duepuntozero/config.php:69 view/theme/frio/config.php:160
+#: view/theme/quattro/config.php:71 view/theme/vier/config.php:119
+msgid "Submit"
+msgstr ""
+
+#: mod/events.php:573 src/Module/Profile/Profile.php:242
+msgid "Basic"
+msgstr ""
+
+#: mod/events.php:574 src/Module/Admin/Site.php:594 src/Module/Contact.php:917
+#: src/Module/Profile/Profile.php:243
+msgid "Advanced"
+msgstr ""
+
+#: mod/events.php:575 mod/photos.php:976 mod/photos.php:1347
+msgid "Permissions"
+msgstr ""
+
+#: mod/events.php:591
+msgid "Failed to remove event"
+msgstr ""
+
+#: mod/fbrowser.php:43 src/Content/Nav.php:179 src/Module/BaseProfile.php:68
+#: view/theme/frio/theme.php:227
+msgid "Photos"
+msgstr ""
+
+#: mod/fbrowser.php:107 mod/fbrowser.php:136
+#: src/Module/Settings/Profile/Photo/Index.php:130
+msgid "Upload"
+msgstr ""
+
+#: mod/fbrowser.php:131
+msgid "Files"
+msgstr ""
+
+#: mod/follow.php:65
+msgid "The contact could not be added."
+msgstr ""
+
+#: mod/follow.php:105
+msgid "You already added this contact."
+msgstr ""
+
+#: mod/follow.php:121
+msgid "The network type couldn't be detected. Contact can't be added."
+msgstr ""
+
+#: mod/follow.php:129
+msgid "Diaspora support isn't enabled. Contact can't be added."
+msgstr ""
+
+#: mod/follow.php:134
+msgid "OStatus support is disabled. Contact can't be added."
+msgstr ""
+
+#: mod/follow.php:165 mod/unfollow.php:134
+msgid "Your Identity Address:"
+msgstr ""
+
+#: mod/follow.php:166 mod/unfollow.php:140
+#: src/Module/Admin/Blocklist/Contact.php:100 src/Module/Contact.php:618
+#: src/Module/Notifications/Introductions.php:103
+#: src/Module/Notifications/Introductions.php:177
+msgid "Profile URL"
+msgstr ""
+
+#: mod/follow.php:167 src/Module/Contact.php:628
+#: src/Module/Notifications/Introductions.php:170
+#: src/Module/Profile/Profile.php:202
+msgid "Tags:"
+msgstr ""
+
+#: mod/follow.php:188 mod/unfollow.php:150 src/Module/BaseProfile.php:63
+#: src/Module/Contact.php:895
+msgid "Status Messages and Posts"
+msgstr ""
+
+#: mod/item.php:132 mod/item.php:136
+msgid "Unable to locate original post."
+msgstr ""
+
+#: mod/item.php:336 mod/item.php:341
+msgid "Empty post discarded."
+msgstr ""
+
+#: mod/item.php:710
+msgid "Post updated."
+msgstr ""
+
+#: mod/item.php:727 mod/item.php:732
+msgid "Item wasn't stored."
+msgstr ""
+
+#: mod/item.php:743
+msgid "Item couldn't be fetched."
+msgstr ""
+
+#: mod/item.php:891 src/Module/Admin/Themes/Details.php:70
+#: src/Module/Admin/Themes/Index.php:59 src/Module/Debug/ItemBody.php:46
+#: src/Module/Debug/ItemBody.php:59
+msgid "Item not found."
+msgstr ""
+
+#: mod/item.php:923
+msgid "Do you really want to delete this item?"
+msgstr ""
+
+#: mod/lostpass.php:40
+msgid "No valid account found."
+msgstr ""
+
+#: mod/lostpass.php:52
+msgid "Password reset request issued. Check your email."
+msgstr ""
+
+#: mod/lostpass.php:58
+#, php-format
+msgid ""
+"\n"
+"\t\tDear %1$s,\n"
+"\t\t\tA request was recently received at \"%2$s\" to reset your account\n"
+"\t\tpassword. In order to confirm this request, please select the "
+"verification link\n"
+"\t\tbelow or paste it into your web browser address bar.\n"
+"\n"
+"\t\tIf you did NOT request this change, please DO NOT follow the link\n"
+"\t\tprovided and ignore and/or delete this email, the request will expire "
+"shortly.\n"
+"\n"
+"\t\tYour password will not be changed unless we can verify that you\n"
+"\t\tissued this request."
+msgstr ""
+
+#: mod/lostpass.php:69
+#, php-format
+msgid ""
+"\n"
+"\t\tFollow this link soon to verify your identity:\n"
+"\n"
+"\t\t%1$s\n"
+"\n"
+"\t\tYou will then receive a follow-up message containing the new password.\n"
+"\t\tYou may change that password from your account settings page after "
+"logging in.\n"
+"\n"
+"\t\tThe login details are as follows:\n"
+"\n"
+"\t\tSite Location:\t%2$s\n"
+"\t\tLogin Name:\t%3$s"
+msgstr ""
+
+#: mod/lostpass.php:84
+#, php-format
+msgid "Password reset requested at %s"
+msgstr ""
+
+#: mod/lostpass.php:100
+msgid ""
+"Request could not be verified. (You may have previously submitted it.) "
+"Password reset failed."
+msgstr ""
+
+#: mod/lostpass.php:113
+msgid "Request has expired, please make a new one."
+msgstr ""
+
+#: mod/lostpass.php:128
+msgid "Forgot your Password?"
+msgstr ""
+
+#: mod/lostpass.php:129
+msgid ""
+"Enter your email address and submit to have your password reset. Then check "
+"your email for further instructions."
+msgstr ""
+
+#: mod/lostpass.php:130 src/Module/Security/Login.php:144
+msgid "Nickname or Email: "
+msgstr ""
+
+#: mod/lostpass.php:131
+msgid "Reset"
+msgstr ""
+
+#: mod/lostpass.php:146 src/Module/Security/Login.php:156
+msgid "Password Reset"
+msgstr ""
+
+#: mod/lostpass.php:147
+msgid "Your password has been reset as requested."
+msgstr ""
+
+#: mod/lostpass.php:148
+msgid "Your new password is"
+msgstr ""
+
+#: mod/lostpass.php:149
+msgid "Save or copy your new password - and then"
+msgstr ""
+
+#: mod/lostpass.php:150
+msgid "click here to login"
+msgstr ""
+
+#: mod/lostpass.php:151
+msgid ""
+"Your password may be changed from the <em>Settings</em> page after "
+"successful login."
+msgstr ""
+
+#: mod/lostpass.php:155
+msgid "Your password has been reset."
+msgstr ""
+
+#: mod/lostpass.php:158
+#, php-format
+msgid ""
+"\n"
+"\t\t\tDear %1$s,\n"
+"\t\t\t\tYour password has been changed as requested. Please retain this\n"
+"\t\t\tinformation for your records (or change your password immediately to\n"
+"\t\t\tsomething that you will remember).\n"
+"\t\t"
+msgstr ""
+
+#: mod/lostpass.php:164
+#, php-format
+msgid ""
+"\n"
+"\t\t\tYour login details are as follows:\n"
+"\n"
+"\t\t\tSite Location:\t%1$s\n"
+"\t\t\tLogin Name:\t%2$s\n"
+"\t\t\tPassword:\t%3$s\n"
+"\n"
+"\t\t\tYou may change that password from your account settings page after "
+"logging in.\n"
+"\t\t"
+msgstr ""
+
+#: mod/lostpass.php:176
+#, php-format
+msgid "Your password has been changed at %s"
 msgstr ""
 
 #: mod/match.php:62
@@ -1455,6 +1557,508 @@ msgstr ""
 #: mod/match.php:125
 msgid "Profile Match"
 msgstr ""
+
+#: mod/message.php:47 mod/message.php:128 src/Content/Nav.php:276
+msgid "New Message"
+msgstr ""
+
+#: mod/message.php:84 mod/wallmessage.php:76
+msgid "No recipient selected."
+msgstr ""
+
+#: mod/message.php:88
+msgid "Unable to locate contact information."
+msgstr ""
+
+#: mod/message.php:91 mod/wallmessage.php:82
+msgid "Message could not be sent."
+msgstr ""
+
+#: mod/message.php:94 mod/wallmessage.php:85
+msgid "Message collection failure."
+msgstr ""
+
+#: mod/message.php:122 src/Module/Notifications/Introductions.php:111
+#: src/Module/Notifications/Introductions.php:149
+#: src/Module/Notifications/Notification.php:56
+msgid "Discard"
+msgstr ""
+
+#: mod/message.php:135 src/Content/Nav.php:273 view/theme/frio/theme.php:234
+msgid "Messages"
+msgstr ""
+
+#: mod/message.php:160
+msgid "Do you really want to delete this message?"
+msgstr ""
+
+#: mod/message.php:178
+msgid "Conversation not found."
+msgstr ""
+
+#: mod/message.php:183
+msgid "Message was not deleted."
+msgstr ""
+
+#: mod/message.php:201
+msgid "Conversation was not removed."
+msgstr ""
+
+#: mod/message.php:215 mod/message.php:365 mod/wallmessage.php:137
+msgid "Please enter a link URL:"
+msgstr ""
+
+#: mod/message.php:257 mod/wallmessage.php:142
+msgid "Send Private Message"
+msgstr ""
+
+#: mod/message.php:258 mod/message.php:431 mod/wallmessage.php:144
+msgid "To:"
+msgstr ""
+
+#: mod/message.php:262 mod/message.php:433 mod/wallmessage.php:145
+msgid "Subject:"
+msgstr ""
+
+#: mod/message.php:266 mod/message.php:436 mod/wallmessage.php:151
+#: src/Module/Invite.php:168
+msgid "Your message:"
+msgstr ""
+
+#: mod/message.php:300
+msgid "No messages."
+msgstr ""
+
+#: mod/message.php:357
+msgid "Message not available."
+msgstr ""
+
+#: mod/message.php:407
+msgid "Delete message"
+msgstr ""
+
+#: mod/message.php:409 mod/message.php:537
+msgid "D, d M Y - g:i A"
+msgstr ""
+
+#: mod/message.php:424 mod/message.php:534
+msgid "Delete conversation"
+msgstr ""
+
+#: mod/message.php:426
+msgid ""
+"No secure communications available. You <strong>may</strong> be able to "
+"respond from the sender's profile page."
+msgstr ""
+
+#: mod/message.php:430
+msgid "Send Reply"
+msgstr ""
+
+#: mod/message.php:513
+#, php-format
+msgid "Unknown sender - %s"
+msgstr ""
+
+#: mod/message.php:515
+#, php-format
+msgid "You and %s"
+msgstr ""
+
+#: mod/message.php:517
+#, php-format
+msgid "%s and You"
+msgstr ""
+
+#: mod/message.php:540
+#, php-format
+msgid "%d message"
+msgid_plural "%d messages"
+msgstr[0] ""
+msgstr[1] ""
+
+#: mod/network.php:297
+msgid "No items found"
+msgstr ""
+
+#: mod/network.php:528
+msgid "No such group"
+msgstr ""
+
+#: mod/network.php:536
+#, php-format
+msgid "Group: %s"
+msgstr ""
+
+#: mod/network.php:548 src/Module/Contact/Contacts.php:28
+msgid "Invalid contact."
+msgstr ""
+
+#: mod/network.php:686
+msgid "Latest Activity"
+msgstr ""
+
+#: mod/network.php:689
+msgid "Sort by latest activity"
+msgstr ""
+
+#: mod/network.php:694
+msgid "Latest Posts"
+msgstr ""
+
+#: mod/network.php:697
+msgid "Sort by post received date"
+msgstr ""
+
+#: mod/network.php:704 src/Module/Settings/Profile/Index.php:242
+msgid "Personal"
+msgstr ""
+
+#: mod/network.php:707
+msgid "Posts that mention or involve you"
+msgstr ""
+
+#: mod/network.php:713
+msgid "Starred"
+msgstr ""
+
+#: mod/network.php:716
+msgid "Favourite Posts"
+msgstr ""
+
+#: mod/notes.php:50 src/Module/BaseProfile.php:110
+msgid "Personal Notes"
+msgstr ""
+
+#: mod/ostatus_subscribe.php:35
+msgid "Subscribing to OStatus contacts"
+msgstr ""
+
+#: mod/ostatus_subscribe.php:45
+msgid "No contact provided."
+msgstr ""
+
+#: mod/ostatus_subscribe.php:51
+msgid "Couldn't fetch information for contact."
+msgstr ""
+
+#: mod/ostatus_subscribe.php:61
+msgid "Couldn't fetch friends for contact."
+msgstr ""
+
+#: mod/ostatus_subscribe.php:79 mod/repair_ostatus.php:65
+msgid "Done"
+msgstr ""
+
+#: mod/ostatus_subscribe.php:93
+msgid "success"
+msgstr ""
+
+#: mod/ostatus_subscribe.php:95
+msgid "failed"
+msgstr ""
+
+#: mod/ostatus_subscribe.php:98 src/Object/Post.php:305
+msgid "ignored"
+msgstr ""
+
+#: mod/ostatus_subscribe.php:103 mod/repair_ostatus.php:71
+msgid "Keep this window open until done."
+msgstr ""
+
+#: mod/photos.php:127 src/Module/BaseProfile.php:71
+msgid "Photo Albums"
+msgstr ""
+
+#: mod/photos.php:128 mod/photos.php:1609
+msgid "Recent Photos"
+msgstr ""
+
+#: mod/photos.php:130 mod/photos.php:1115 mod/photos.php:1611
+msgid "Upload New Photos"
+msgstr ""
+
+#: mod/photos.php:148 src/Module/BaseSettings.php:37
+msgid "everybody"
+msgstr ""
+
+#: mod/photos.php:185
+msgid "Contact information unavailable"
+msgstr ""
+
+#: mod/photos.php:207
+msgid "Album not found."
+msgstr ""
+
+#: mod/photos.php:265
+msgid "Album successfully deleted"
+msgstr ""
+
+#: mod/photos.php:267
+msgid "Album was empty."
+msgstr ""
+
+#: mod/photos.php:299
+msgid "Failed to delete the photo."
+msgstr ""
+
+#: mod/photos.php:583
+msgid "a photo"
+msgstr ""
+
+#: mod/photos.php:583
+#, php-format
+msgid "%1$s was tagged in %2$s by %3$s"
+msgstr ""
+
+#: mod/photos.php:678 mod/photos.php:681 mod/photos.php:708
+#: mod/wall_upload.php:174 src/Module/Settings/Profile/Photo/Index.php:61
+#, php-format
+msgid "Image exceeds size limit of %s"
+msgstr ""
+
+#: mod/photos.php:684
+msgid "Image upload didn't complete, please try again"
+msgstr ""
+
+#: mod/photos.php:687
+msgid "Image file is missing"
+msgstr ""
+
+#: mod/photos.php:692
+msgid ""
+"Server can't accept new file upload at this time, please contact your "
+"administrator"
+msgstr ""
+
+#: mod/photos.php:716
+msgid "Image file is empty."
+msgstr ""
+
+#: mod/photos.php:731 mod/wall_upload.php:188
+#: src/Module/Settings/Profile/Photo/Index.php:70
+msgid "Unable to process image."
+msgstr ""
+
+#: mod/photos.php:760 mod/wall_upload.php:227
+#: src/Module/Settings/Profile/Photo/Index.php:97
+msgid "Image upload failed."
+msgstr ""
+
+#: mod/photos.php:848
+msgid "No photos selected"
+msgstr ""
+
+#: mod/photos.php:914 mod/videos.php:182
+msgid "Access to this item is restricted."
+msgstr ""
+
+#: mod/photos.php:968
+msgid "Upload Photos"
+msgstr ""
+
+#: mod/photos.php:972 mod/photos.php:1060
+msgid "New album name: "
+msgstr ""
+
+#: mod/photos.php:973
+msgid "or select existing album:"
+msgstr ""
+
+#: mod/photos.php:974
+msgid "Do not show a status post for this upload"
+msgstr ""
+
+#: mod/photos.php:990 mod/photos.php:1355
+msgid "Show to Groups"
+msgstr ""
+
+#: mod/photos.php:991 mod/photos.php:1356
+msgid "Show to Contacts"
+msgstr ""
+
+#: mod/photos.php:1042
+msgid "Do you really want to delete this photo album and all its photos?"
+msgstr ""
+
+#: mod/photos.php:1044 mod/photos.php:1065
+msgid "Delete Album"
+msgstr ""
+
+#: mod/photos.php:1071
+msgid "Edit Album"
+msgstr ""
+
+#: mod/photos.php:1072
+msgid "Drop Album"
+msgstr ""
+
+#: mod/photos.php:1077
+msgid "Show Newest First"
+msgstr ""
+
+#: mod/photos.php:1079
+msgid "Show Oldest First"
+msgstr ""
+
+#: mod/photos.php:1100 mod/photos.php:1594
+msgid "View Photo"
+msgstr ""
+
+#: mod/photos.php:1137
+msgid "Permission denied. Access to this item may be restricted."
+msgstr ""
+
+#: mod/photos.php:1139
+msgid "Photo not available"
+msgstr ""
+
+#: mod/photos.php:1149
+msgid "Do you really want to delete this photo?"
+msgstr ""
+
+#: mod/photos.php:1151 mod/photos.php:1352
+msgid "Delete Photo"
+msgstr ""
+
+#: mod/photos.php:1242
+msgid "View photo"
+msgstr ""
+
+#: mod/photos.php:1244
+msgid "Edit photo"
+msgstr ""
+
+#: mod/photos.php:1245
+msgid "Delete photo"
+msgstr ""
+
+#: mod/photos.php:1246
+msgid "Use as profile photo"
+msgstr ""
+
+#: mod/photos.php:1253
+msgid "Private Photo"
+msgstr ""
+
+#: mod/photos.php:1259
+msgid "View Full Size"
+msgstr ""
+
+#: mod/photos.php:1320
+msgid "Tags: "
+msgstr ""
+
+#: mod/photos.php:1323
+msgid "[Select tags to remove]"
+msgstr ""
+
+#: mod/photos.php:1338
+msgid "New album name"
+msgstr ""
+
+#: mod/photos.php:1339
+msgid "Caption"
+msgstr ""
+
+#: mod/photos.php:1340
+msgid "Add a Tag"
+msgstr ""
+
+#: mod/photos.php:1340
+msgid "Example: @bob, @Barbara_Jensen, @jim@example.com, #California, #camping"
+msgstr ""
+
+#: mod/photos.php:1341
+msgid "Do not rotate"
+msgstr ""
+
+#: mod/photos.php:1342
+msgid "Rotate CW (right)"
+msgstr ""
+
+#: mod/photos.php:1343
+msgid "Rotate CCW (left)"
+msgstr ""
+
+#: mod/photos.php:1376 src/Object/Post.php:345
+msgid "I like this (toggle)"
+msgstr ""
+
+#: mod/photos.php:1377 src/Object/Post.php:346
+msgid "I don't like this (toggle)"
+msgstr ""
+
+#: mod/photos.php:1392 mod/photos.php:1439 mod/photos.php:1502
+#: src/Module/Contact.php:1059 src/Module/Item/Compose.php:142
+#: src/Object/Post.php:946
+msgid "This is you"
+msgstr ""
+
+#: mod/photos.php:1394 mod/photos.php:1441 mod/photos.php:1504
+#: src/Object/Post.php:482 src/Object/Post.php:948
+msgid "Comment"
+msgstr ""
+
+#: mod/photos.php:1530
+msgid "Map"
+msgstr ""
+
+#: mod/photos.php:1600 mod/videos.php:259
+msgid "View Album"
+msgstr ""
+
+#: mod/ping.php:285
+msgid "{0} wants to be your friend"
+msgstr ""
+
+#: mod/ping.php:301
+msgid "{0} requested registration"
+msgstr ""
+
+#: mod/redir.php:50 mod/redir.php:130
+msgid "Bad Request."
+msgstr ""
+
+#: mod/removeme.php:63
+msgid "User deleted their account"
+msgstr ""
+
+#: mod/removeme.php:64
+msgid ""
+"On your Friendica node an user deleted their account. Please ensure that "
+"their data is removed from the backups."
+msgstr ""
+
+#: mod/removeme.php:65
+#, php-format
+msgid "The user id is %d"
+msgstr ""
+
+#: mod/removeme.php:99 mod/removeme.php:102
+msgid "Remove My Account"
+msgstr ""
+
+#: mod/removeme.php:100
+msgid ""
+"This will completely remove your account. Once this has been done it is not "
+"recoverable."
+msgstr ""
+
+#: mod/removeme.php:101
+msgid "Please enter your password for verification:"
+msgstr ""
+
+#: mod/repair_ostatus.php:36
+msgid "Resubscribing to OStatus contacts"
+msgstr ""
+
+#: mod/repair_ostatus.php:50 src/Module/Debug/ActivityPubConversion.php:130
+#: src/Module/Debug/Babel.php:269 src/Module/Security/TwoFactor/Verify.php:82
+msgid "Error"
+msgid_plural "Errors"
+msgstr[0] ""
+msgstr[1] ""
 
 #: mod/settings.php:90
 msgid "Missing some important data!"
@@ -1533,18 +2137,18 @@ msgid "Add application"
 msgstr ""
 
 #: mod/settings.php:499 mod/settings.php:606 mod/settings.php:704
-#: mod/settings.php:859 src/Module/Admin/Themes/Index.php:113
+#: mod/settings.php:859 src/Module/Admin/Addons/Index.php:69
 #: src/Module/Admin/Features.php:87 src/Module/Admin/Logs/Settings.php:80
-#: src/Module/Admin/Site.php:589 src/Module/Admin/Tos.php:66
-#: src/Module/Admin/Addons/Index.php:69 src/Module/Settings/Delegation.php:170
+#: src/Module/Admin/Site.php:589 src/Module/Admin/Themes/Index.php:113
+#: src/Module/Admin/Tos.php:66 src/Module/Settings/Delegation.php:170
 #: src/Module/Settings/Display.php:185
 msgid "Save Settings"
 msgstr ""
 
-#: mod/settings.php:501 mod/settings.php:527 src/Module/Admin/Users.php:237
+#: mod/settings.php:501 mod/settings.php:527
+#: src/Module/Admin/Blocklist/Contact.php:90 src/Module/Admin/Users.php:237
 #: src/Module/Admin/Users.php:248 src/Module/Admin/Users.php:262
-#: src/Module/Admin/Users.php:278 src/Module/Admin/Blocklist/Contact.php:90
-#: src/Module/Contact/Advanced.php:150
+#: src/Module/Admin/Users.php:278 src/Module/Contact/Advanced.php:150
 msgid "Name"
 msgstr ""
 
@@ -2245,264 +2849,14 @@ msgstr ""
 msgid "Resend relocate message to contacts"
 msgstr ""
 
-#: mod/ping.php:285
-msgid "{0} wants to be your friend"
-msgstr ""
-
-#: mod/ping.php:301
-msgid "{0} requested registration"
-msgstr ""
-
-#: mod/network.php:297
-msgid "No items found"
-msgstr ""
-
-#: mod/network.php:528
-msgid "No such group"
-msgstr ""
-
-#: mod/network.php:536
-#, php-format
-msgid "Group: %s"
-msgstr ""
-
-#: mod/network.php:548 src/Module/Contact/Contacts.php:28
-msgid "Invalid contact."
-msgstr ""
-
-#: mod/network.php:686
-msgid "Latest Activity"
-msgstr ""
-
-#: mod/network.php:689
-msgid "Sort by latest activity"
-msgstr ""
-
-#: mod/network.php:694
-msgid "Latest Posts"
-msgstr ""
-
-#: mod/network.php:697
-msgid "Sort by post received date"
-msgstr ""
-
-#: mod/network.php:704 src/Module/Settings/Profile/Index.php:242
-msgid "Personal"
-msgstr ""
-
-#: mod/network.php:707
-msgid "Posts that mention or involve you"
-msgstr ""
-
-#: mod/network.php:713
-msgid "Starred"
-msgstr ""
-
-#: mod/network.php:716
-msgid "Favourite Posts"
-msgstr ""
-
-#: mod/repair_ostatus.php:36
-msgid "Resubscribing to OStatus contacts"
-msgstr ""
-
-#: mod/repair_ostatus.php:50 src/Module/Security/TwoFactor/Verify.php:82
-#: src/Module/Debug/Babel.php:269
-#: src/Module/Debug/ActivityPubConversion.php:130
-msgid "Error"
-msgid_plural "Errors"
-msgstr[0] ""
-msgstr[1] ""
-
-#: mod/repair_ostatus.php:65 mod/ostatus_subscribe.php:79
-msgid "Done"
-msgstr ""
-
-#: mod/repair_ostatus.php:71 mod/ostatus_subscribe.php:103
-msgid "Keep this window open until done."
-msgstr ""
-
-#: mod/unfollow.php:51 mod/unfollow.php:106
-msgid "You aren't following this contact."
-msgstr ""
-
-#: mod/unfollow.php:61 mod/unfollow.php:112
-msgid "Unfollowing is currently not supported by your network."
-msgstr ""
-
-#: mod/unfollow.php:132
-msgid "Disconnect/Unfollow"
-msgstr ""
-
-#: mod/unfollow.php:134 mod/follow.php:165
-msgid "Your Identity Address:"
-msgstr ""
-
-#: mod/unfollow.php:136 mod/dfrn_request.php:647 mod/follow.php:95
-#: src/Module/RemoteFollow.php:109
-msgid "Submit Request"
-msgstr ""
-
-#: mod/unfollow.php:140 mod/follow.php:166
-#: src/Module/Notifications/Introductions.php:103
-#: src/Module/Notifications/Introductions.php:177 src/Module/Contact.php:618
-#: src/Module/Admin/Blocklist/Contact.php:100
-msgid "Profile URL"
-msgstr ""
-
-#: mod/unfollow.php:150 mod/follow.php:188 src/Module/Contact.php:895
-#: src/Module/BaseProfile.php:63
-msgid "Status Messages and Posts"
-msgstr ""
-
-#: mod/message.php:47 mod/message.php:128 src/Content/Nav.php:276
-msgid "New Message"
-msgstr ""
-
-#: mod/message.php:88
-msgid "Unable to locate contact information."
-msgstr ""
-
-#: mod/message.php:122 src/Module/Notifications/Notification.php:56
-#: src/Module/Notifications/Introductions.php:111
-#: src/Module/Notifications/Introductions.php:149
-msgid "Discard"
-msgstr ""
-
-#: mod/message.php:160
-msgid "Do you really want to delete this message?"
-msgstr ""
-
-#: mod/message.php:162 mod/api.php:125 mod/item.php:925
-#: src/Module/Notifications/Introductions.php:119 src/Module/Register.php:115
-#: src/Module/Contact.php:454
-msgid "Yes"
-msgstr ""
-
-#: mod/message.php:178
-msgid "Conversation not found."
-msgstr ""
-
-#: mod/message.php:183
-msgid "Message was not deleted."
-msgstr ""
-
-#: mod/message.php:201
-msgid "Conversation was not removed."
-msgstr ""
-
-#: mod/message.php:300
-msgid "No messages."
-msgstr ""
-
-#: mod/message.php:357
-msgid "Message not available."
-msgstr ""
-
-#: mod/message.php:407
-msgid "Delete message"
-msgstr ""
-
-#: mod/message.php:409 mod/message.php:537
-msgid "D, d M Y - g:i A"
-msgstr ""
-
-#: mod/message.php:424 mod/message.php:534
-msgid "Delete conversation"
-msgstr ""
-
-#: mod/message.php:426
+#: mod/suggest.php:44
 msgid ""
-"No secure communications available. You <strong>may</strong> be able to "
-"respond from the sender's profile page."
+"No suggestions available. If this is a new site, please try again in 24 "
+"hours."
 msgstr ""
 
-#: mod/message.php:430
-msgid "Send Reply"
-msgstr ""
-
-#: mod/message.php:513
-#, php-format
-msgid "Unknown sender - %s"
-msgstr ""
-
-#: mod/message.php:515
-#, php-format
-msgid "You and %s"
-msgstr ""
-
-#: mod/message.php:517
-#, php-format
-msgid "%s and You"
-msgstr ""
-
-#: mod/message.php:540
-#, php-format
-msgid "%d message"
-msgid_plural "%d messages"
-msgstr[0] ""
-msgstr[1] ""
-
-#: mod/ostatus_subscribe.php:35
-msgid "Subscribing to OStatus contacts"
-msgstr ""
-
-#: mod/ostatus_subscribe.php:45
-msgid "No contact provided."
-msgstr ""
-
-#: mod/ostatus_subscribe.php:51
-msgid "Couldn't fetch information for contact."
-msgstr ""
-
-#: mod/ostatus_subscribe.php:61
-msgid "Couldn't fetch friends for contact."
-msgstr ""
-
-#: mod/ostatus_subscribe.php:93
-msgid "success"
-msgstr ""
-
-#: mod/ostatus_subscribe.php:95
-msgid "failed"
-msgstr ""
-
-#: mod/ostatus_subscribe.php:98 src/Object/Post.php:305
-msgid "ignored"
-msgstr ""
-
-#: mod/dfrn_poll.php:135 mod/dfrn_poll.php:506
-#, php-format
-msgid "%1$s welcomes %2$s"
-msgstr ""
-
-#: mod/removeme.php:63
-msgid "User deleted their account"
-msgstr ""
-
-#: mod/removeme.php:64
-msgid ""
-"On your Friendica node an user deleted their account. Please ensure that "
-"their data is removed from the backups."
-msgstr ""
-
-#: mod/removeme.php:65
-#, php-format
-msgid "The user id is %d"
-msgstr ""
-
-#: mod/removeme.php:99 mod/removeme.php:102
-msgid "Remove My Account"
-msgstr ""
-
-#: mod/removeme.php:100
-msgid ""
-"This will completely remove your account. Once this has been done it is not "
-"recoverable."
-msgstr ""
-
-#: mod/removeme.php:101
-msgid "Please enter your password for verification:"
+#: mod/suggest.php:55 src/Content/Widget.php:82 view/theme/vier/theme.php:174
+msgid "Friend Suggestions"
 msgstr ""
 
 #: mod/tagrm.php:112
@@ -2515,412 +2869,6 @@ msgstr ""
 
 #: mod/tagrm.php:125 src/Module/Settings/Delegation.php:179
 msgid "Remove"
-msgstr ""
-
-#: mod/suggest.php:44
-msgid ""
-"No suggestions available. If this is a new site, please try again in 24 "
-"hours."
-msgstr ""
-
-#: mod/display.php:238 mod/display.php:318
-msgid "The requested item doesn't exist or has been deleted."
-msgstr ""
-
-#: mod/display.php:282 mod/cal.php:142 src/Module/Profile/Status.php:105
-#: src/Module/Profile/Profile.php:94 src/Module/Profile/Profile.php:109
-#: src/Module/Update/Profile.php:55
-msgid "Access to this profile has been restricted."
-msgstr ""
-
-#: mod/display.php:398
-msgid "The feed for this item is unavailable."
-msgstr ""
-
-#: mod/wall_upload.php:52 mod/wall_upload.php:63 mod/wall_upload.php:108
-#: mod/wall_upload.php:159 mod/wall_upload.php:162 mod/wall_attach.php:42
-#: mod/wall_attach.php:49 mod/wall_attach.php:87
-msgid "Invalid request."
-msgstr ""
-
-#: mod/wall_upload.php:174 mod/photos.php:678 mod/photos.php:681
-#: mod/photos.php:708 src/Module/Settings/Profile/Photo/Index.php:61
-#, php-format
-msgid "Image exceeds size limit of %s"
-msgstr ""
-
-#: mod/wall_upload.php:188 mod/photos.php:731
-#: src/Module/Settings/Profile/Photo/Index.php:70
-msgid "Unable to process image."
-msgstr ""
-
-#: mod/wall_upload.php:219
-msgid "Wall Photos"
-msgstr ""
-
-#: mod/wall_upload.php:227 mod/photos.php:760
-#: src/Module/Settings/Profile/Photo/Index.php:97
-msgid "Image upload failed."
-msgstr ""
-
-#: mod/lostpass.php:40
-msgid "No valid account found."
-msgstr ""
-
-#: mod/lostpass.php:52
-msgid "Password reset request issued. Check your email."
-msgstr ""
-
-#: mod/lostpass.php:58
-#, php-format
-msgid ""
-"\n"
-"\t\tDear %1$s,\n"
-"\t\t\tA request was recently received at \"%2$s\" to reset your account\n"
-"\t\tpassword. In order to confirm this request, please select the "
-"verification link\n"
-"\t\tbelow or paste it into your web browser address bar.\n"
-"\n"
-"\t\tIf you did NOT request this change, please DO NOT follow the link\n"
-"\t\tprovided and ignore and/or delete this email, the request will expire "
-"shortly.\n"
-"\n"
-"\t\tYour password will not be changed unless we can verify that you\n"
-"\t\tissued this request."
-msgstr ""
-
-#: mod/lostpass.php:69
-#, php-format
-msgid ""
-"\n"
-"\t\tFollow this link soon to verify your identity:\n"
-"\n"
-"\t\t%1$s\n"
-"\n"
-"\t\tYou will then receive a follow-up message containing the new password.\n"
-"\t\tYou may change that password from your account settings page after "
-"logging in.\n"
-"\n"
-"\t\tThe login details are as follows:\n"
-"\n"
-"\t\tSite Location:\t%2$s\n"
-"\t\tLogin Name:\t%3$s"
-msgstr ""
-
-#: mod/lostpass.php:84
-#, php-format
-msgid "Password reset requested at %s"
-msgstr ""
-
-#: mod/lostpass.php:100
-msgid ""
-"Request could not be verified. (You may have previously submitted it.) "
-"Password reset failed."
-msgstr ""
-
-#: mod/lostpass.php:113
-msgid "Request has expired, please make a new one."
-msgstr ""
-
-#: mod/lostpass.php:128
-msgid "Forgot your Password?"
-msgstr ""
-
-#: mod/lostpass.php:129
-msgid ""
-"Enter your email address and submit to have your password reset. Then check "
-"your email for further instructions."
-msgstr ""
-
-#: mod/lostpass.php:130 src/Module/Security/Login.php:144
-msgid "Nickname or Email: "
-msgstr ""
-
-#: mod/lostpass.php:131
-msgid "Reset"
-msgstr ""
-
-#: mod/lostpass.php:146 src/Module/Security/Login.php:156
-msgid "Password Reset"
-msgstr ""
-
-#: mod/lostpass.php:147
-msgid "Your password has been reset as requested."
-msgstr ""
-
-#: mod/lostpass.php:148
-msgid "Your new password is"
-msgstr ""
-
-#: mod/lostpass.php:149
-msgid "Save or copy your new password - and then"
-msgstr ""
-
-#: mod/lostpass.php:150
-msgid "click here to login"
-msgstr ""
-
-#: mod/lostpass.php:151
-msgid ""
-"Your password may be changed from the <em>Settings</em> page after "
-"successful login."
-msgstr ""
-
-#: mod/lostpass.php:155
-msgid "Your password has been reset."
-msgstr ""
-
-#: mod/lostpass.php:158
-#, php-format
-msgid ""
-"\n"
-"\t\t\tDear %1$s,\n"
-"\t\t\t\tYour password has been changed as requested. Please retain this\n"
-"\t\t\tinformation for your records (or change your password immediately to\n"
-"\t\t\tsomething that you will remember).\n"
-"\t\t"
-msgstr ""
-
-#: mod/lostpass.php:164
-#, php-format
-msgid ""
-"\n"
-"\t\t\tYour login details are as follows:\n"
-"\n"
-"\t\t\tSite Location:\t%1$s\n"
-"\t\t\tLogin Name:\t%2$s\n"
-"\t\t\tPassword:\t%3$s\n"
-"\n"
-"\t\t\tYou may change that password from your account settings page after "
-"logging in.\n"
-"\t\t"
-msgstr ""
-
-#: mod/lostpass.php:176
-#, php-format
-msgid "Your password has been changed at %s"
-msgstr ""
-
-#: mod/dfrn_request.php:113
-msgid "This introduction has already been accepted."
-msgstr ""
-
-#: mod/dfrn_request.php:131 mod/dfrn_request.php:369
-msgid "Profile location is not valid or does not contain profile information."
-msgstr ""
-
-#: mod/dfrn_request.php:135 mod/dfrn_request.php:373
-msgid "Warning: profile location has no identifiable owner name."
-msgstr ""
-
-#: mod/dfrn_request.php:138 mod/dfrn_request.php:376
-msgid "Warning: profile location has no profile photo."
-msgstr ""
-
-#: mod/dfrn_request.php:142 mod/dfrn_request.php:380
-#, php-format
-msgid "%d required parameter was not found at the given location"
-msgid_plural "%d required parameters were not found at the given location"
-msgstr[0] ""
-msgstr[1] ""
-
-#: mod/dfrn_request.php:180
-msgid "Introduction complete."
-msgstr ""
-
-#: mod/dfrn_request.php:216
-msgid "Unrecoverable protocol error."
-msgstr ""
-
-#: mod/dfrn_request.php:243 src/Module/RemoteFollow.php:54
-msgid "Profile unavailable."
-msgstr ""
-
-#: mod/dfrn_request.php:264
-#, php-format
-msgid "%s has received too many connection requests today."
-msgstr ""
-
-#: mod/dfrn_request.php:265
-msgid "Spam protection measures have been invoked."
-msgstr ""
-
-#: mod/dfrn_request.php:266
-msgid "Friends are advised to please try again in 24 hours."
-msgstr ""
-
-#: mod/dfrn_request.php:290 src/Module/RemoteFollow.php:60
-msgid "Invalid locator"
-msgstr ""
-
-#: mod/dfrn_request.php:326
-msgid "You have already introduced yourself here."
-msgstr ""
-
-#: mod/dfrn_request.php:329
-#, php-format
-msgid "Apparently you are already friends with %s."
-msgstr ""
-
-#: mod/dfrn_request.php:349
-msgid "Invalid profile URL."
-msgstr ""
-
-#: mod/dfrn_request.php:355 src/Model/Contact.php:2020
-msgid "Disallowed profile URL."
-msgstr ""
-
-#: mod/dfrn_request.php:361 src/Module/Friendica.php:79
-#: src/Model/Contact.php:2025
-msgid "Blocked domain"
-msgstr ""
-
-#: mod/dfrn_request.php:428 src/Module/Contact.php:153
-msgid "Failed to update contact record."
-msgstr ""
-
-#: mod/dfrn_request.php:448
-msgid "Your introduction has been sent."
-msgstr ""
-
-#: mod/dfrn_request.php:480 src/Module/RemoteFollow.php:72
-msgid ""
-"Remote subscription can't be done for your network. Please subscribe "
-"directly on your system."
-msgstr ""
-
-#: mod/dfrn_request.php:496
-msgid "Please login to confirm introduction."
-msgstr ""
-
-#: mod/dfrn_request.php:504
-msgid ""
-"Incorrect identity currently logged in. Please login to <strong>this</"
-"strong> profile."
-msgstr ""
-
-#: mod/dfrn_request.php:518 mod/dfrn_request.php:533
-msgid "Confirm"
-msgstr ""
-
-#: mod/dfrn_request.php:529
-msgid "Hide this contact"
-msgstr ""
-
-#: mod/dfrn_request.php:531
-#, php-format
-msgid "Welcome home %s."
-msgstr ""
-
-#: mod/dfrn_request.php:532
-#, php-format
-msgid "Please confirm your introduction/connection request to %s."
-msgstr ""
-
-#: mod/dfrn_request.php:642 src/Module/RemoteFollow.php:104
-msgid "Friend/Connection Request"
-msgstr ""
-
-#: mod/dfrn_request.php:643
-#, php-format
-msgid ""
-"Enter your Webfinger address (user@domain.tld) or profile URL here. If this "
-"isn't supported by your system (for example it doesn't work with Diaspora), "
-"you have to subscribe to <strong>%s</strong> directly on your system"
-msgstr ""
-
-#: mod/dfrn_request.php:644 src/Module/RemoteFollow.php:106
-#, php-format
-msgid ""
-"If you are not yet a member of the free social web, <a href=\"%s\">follow "
-"this link to find a public Friendica node and join us today</a>."
-msgstr ""
-
-#: mod/dfrn_request.php:645 src/Module/RemoteFollow.php:107
-msgid "Your Webfinger address or profile URL:"
-msgstr ""
-
-#: mod/dfrn_request.php:646 mod/follow.php:164 src/Module/RemoteFollow.php:108
-msgid "Please answer the following:"
-msgstr ""
-
-#: mod/dfrn_request.php:654 mod/follow.php:178
-#, php-format
-msgid "%s knows you"
-msgstr ""
-
-#: mod/dfrn_request.php:655 mod/follow.php:179
-msgid "Add a personal note:"
-msgstr ""
-
-#: mod/api.php:100 mod/api.php:122
-msgid "Authorize application connection"
-msgstr ""
-
-#: mod/api.php:101
-msgid "Return to your app and insert this Securty Code:"
-msgstr ""
-
-#: mod/api.php:110 src/Module/BaseAdmin.php:73
-msgid "Please login to continue."
-msgstr ""
-
-#: mod/api.php:124
-msgid ""
-"Do you want to authorize this application to access your posts and contacts, "
-"and/or create new posts for you?"
-msgstr ""
-
-#: mod/api.php:126 src/Module/Notifications/Introductions.php:119
-#: src/Module/Register.php:116
-msgid "No"
-msgstr ""
-
-#: mod/wall_attach.php:105
-msgid "Sorry, maybe your upload is bigger than the PHP configuration allows"
-msgstr ""
-
-#: mod/wall_attach.php:105
-msgid "Or - did you try to upload an empty file?"
-msgstr ""
-
-#: mod/wall_attach.php:116
-#, php-format
-msgid "File exceeds size limit of %s"
-msgstr ""
-
-#: mod/wall_attach.php:131
-msgid "File upload failed."
-msgstr ""
-
-#: mod/item.php:132 mod/item.php:136
-msgid "Unable to locate original post."
-msgstr ""
-
-#: mod/item.php:336 mod/item.php:341
-msgid "Empty post discarded."
-msgstr ""
-
-#: mod/item.php:710
-msgid "Post updated."
-msgstr ""
-
-#: mod/item.php:727 mod/item.php:732
-msgid "Item wasn't stored."
-msgstr ""
-
-#: mod/item.php:743
-msgid "Item couldn't be fetched."
-msgstr ""
-
-#: mod/item.php:891 src/Module/Debug/ItemBody.php:46
-#: src/Module/Debug/ItemBody.php:59 src/Module/Admin/Themes/Details.php:70
-#: src/Module/Admin/Themes/Index.php:59
-msgid "Item not found."
-msgstr ""
-
-#: mod/item.php:923
-msgid "Do you really want to delete this item?"
 msgstr ""
 
 #: mod/uimport.php:45
@@ -2968,451 +2916,79 @@ msgid ""
 "select \"Export account\""
 msgstr ""
 
-#: mod/cal.php:74 src/Module/Profile/Common.php:41
-#: src/Module/Profile/Common.php:53 src/Module/Profile/Status.php:54
-#: src/Module/Profile/Contacts.php:40 src/Module/Profile/Contacts.php:51
-#: src/Module/Register.php:260 src/Module/HoverCard.php:53
-msgid "User not found."
+#: mod/unfollow.php:51 mod/unfollow.php:106
+msgid "You aren't following this contact."
 msgstr ""
 
-#: mod/cal.php:274 mod/events.php:415
-msgid "View"
+#: mod/unfollow.php:61 mod/unfollow.php:112
+msgid "Unfollowing is currently not supported by your network."
 msgstr ""
 
-#: mod/cal.php:275 mod/events.php:417
-msgid "Previous"
+#: mod/unfollow.php:132
+msgid "Disconnect/Unfollow"
 msgstr ""
 
-#: mod/cal.php:276 mod/events.php:418 src/Module/Install.php:192
-msgid "Next"
+#: mod/videos.php:134
+msgid "No videos selected"
 msgstr ""
 
-#: mod/cal.php:279 mod/events.php:423 src/Model/Event.php:445
-msgid "today"
+#: mod/videos.php:252 src/Model/Item.php:3567
+msgid "View Video"
 msgstr ""
 
-#: mod/cal.php:280 mod/events.php:424 src/Util/Temporal.php:330
-#: src/Model/Event.php:446
-msgid "month"
+#: mod/videos.php:267
+msgid "Recent Videos"
 msgstr ""
 
-#: mod/cal.php:281 mod/events.php:425 src/Util/Temporal.php:331
-#: src/Model/Event.php:447
-msgid "week"
+#: mod/videos.php:269
+msgid "Upload New Videos"
 msgstr ""
 
-#: mod/cal.php:282 mod/events.php:426 src/Util/Temporal.php:332
-#: src/Model/Event.php:448
-msgid "day"
-msgstr ""
-
-#: mod/cal.php:283 mod/events.php:427
-msgid "list"
-msgstr ""
-
-#: mod/cal.php:296 src/Console/User.php:152 src/Console/User.php:250
-#: src/Console/User.php:283 src/Console/User.php:309
-#: src/Module/Api/Twitter/ContactEndpoint.php:73 src/Module/Admin/Users.php:112
-#: src/Model/User.php:561
-msgid "User not found"
-msgstr ""
-
-#: mod/cal.php:305
-msgid "This calendar format is not supported"
-msgstr ""
-
-#: mod/cal.php:307
-msgid "No exportable data found"
-msgstr ""
-
-#: mod/cal.php:324
-msgid "calendar"
-msgstr ""
-
-#: mod/editpost.php:45 mod/editpost.php:55
-msgid "Item not found"
-msgstr ""
-
-#: mod/editpost.php:62
-msgid "Edit post"
-msgstr ""
-
-#: mod/editpost.php:88 mod/notes.php:62 src/Module/Filer/SaveTag.php:66
-#: src/Content/Text/HTML.php:896
-msgid "Save"
-msgstr ""
-
-#: mod/editpost.php:95
-msgid "web link"
-msgstr ""
-
-#: mod/editpost.php:96
-msgid "Insert video link"
-msgstr ""
-
-#: mod/editpost.php:97
-msgid "video link"
-msgstr ""
-
-#: mod/editpost.php:98
-msgid "Insert audio link"
-msgstr ""
-
-#: mod/editpost.php:99
-msgid "audio link"
-msgstr ""
-
-#: mod/editpost.php:113 src/Core/ACL.php:314
-msgid "CC: email addresses"
-msgstr ""
-
-#: mod/editpost.php:120 src/Core/ACL.php:315
-msgid "Example: bob@example.com, mary@example.com"
-msgstr ""
-
-#: mod/events.php:135 mod/events.php:137
-msgid "Event can not end before it has started."
-msgstr ""
-
-#: mod/events.php:144 mod/events.php:146
-msgid "Event title and start time are required."
-msgstr ""
-
-#: mod/events.php:416
-msgid "Create New Event"
-msgstr ""
-
-#: mod/events.php:528
-msgid "Event details"
-msgstr ""
-
-#: mod/events.php:529
-msgid "Starting date and Title are required."
-msgstr ""
-
-#: mod/events.php:530 mod/events.php:535
-msgid "Event Starts:"
-msgstr ""
-
-#: mod/events.php:530 mod/events.php:562
-msgid "Required"
-msgstr ""
-
-#: mod/events.php:543 mod/events.php:568
-msgid "Finish date/time is not known or not relevant"
-msgstr ""
-
-#: mod/events.php:545 mod/events.php:550
-msgid "Event Finishes:"
-msgstr ""
-
-#: mod/events.php:556 mod/events.php:569
-msgid "Adjust for viewer timezone"
-msgstr ""
-
-#: mod/events.php:558 src/Module/Profile/Profile.php:172
-#: src/Module/Settings/Profile/Index.php:253
-msgid "Description:"
-msgstr ""
-
-#: mod/events.php:560 src/Module/Notifications/Introductions.php:166
-#: src/Module/Profile/Profile.php:190 src/Module/Contact.php:622
-#: src/Module/Directory.php:156 src/Model/Event.php:84 src/Model/Event.php:111
-#: src/Model/Event.php:454 src/Model/Event.php:948 src/Model/Profile.php:364
-msgid "Location:"
-msgstr ""
-
-#: mod/events.php:562 mod/events.php:564
-msgid "Title:"
-msgstr ""
-
-#: mod/events.php:565 mod/events.php:566
-msgid "Share this event"
-msgstr ""
-
-#: mod/events.php:573 src/Module/Profile/Profile.php:242
-msgid "Basic"
-msgstr ""
-
-#: mod/events.php:574 src/Module/Profile/Profile.php:243
-#: src/Module/Contact.php:917 src/Module/Admin/Site.php:594
-msgid "Advanced"
-msgstr ""
-
-#: mod/events.php:575 mod/photos.php:976 mod/photos.php:1347
-msgid "Permissions"
-msgstr ""
-
-#: mod/events.php:591
-msgid "Failed to remove event"
-msgstr ""
-
-#: mod/follow.php:65
-msgid "The contact could not be added."
-msgstr ""
-
-#: mod/follow.php:105
-msgid "You already added this contact."
-msgstr ""
-
-#: mod/follow.php:121
-msgid "The network type couldn't be detected. Contact can't be added."
-msgstr ""
-
-#: mod/follow.php:129
-msgid "Diaspora support isn't enabled. Contact can't be added."
-msgstr ""
-
-#: mod/follow.php:134
-msgid "OStatus support is disabled. Contact can't be added."
-msgstr ""
-
-#: mod/follow.php:167 src/Module/Notifications/Introductions.php:170
-#: src/Module/Profile/Profile.php:202 src/Module/Contact.php:628
-msgid "Tags:"
-msgstr ""
-
-#: mod/fbrowser.php:107 mod/fbrowser.php:136
-#: src/Module/Settings/Profile/Photo/Index.php:130
-msgid "Upload"
-msgstr ""
-
-#: mod/fbrowser.php:131
-msgid "Files"
-msgstr ""
-
-#: mod/notes.php:50 src/Module/BaseProfile.php:110
-msgid "Personal Notes"
-msgstr ""
-
-#: mod/photos.php:127 src/Module/BaseProfile.php:71
-msgid "Photo Albums"
-msgstr ""
-
-#: mod/photos.php:128 mod/photos.php:1609
-msgid "Recent Photos"
-msgstr ""
-
-#: mod/photos.php:130 mod/photos.php:1115 mod/photos.php:1611
-msgid "Upload New Photos"
-msgstr ""
-
-#: mod/photos.php:148 src/Module/BaseSettings.php:37
-msgid "everybody"
-msgstr ""
-
-#: mod/photos.php:185
-msgid "Contact information unavailable"
-msgstr ""
-
-#: mod/photos.php:207
-msgid "Album not found."
-msgstr ""
-
-#: mod/photos.php:265
-msgid "Album successfully deleted"
-msgstr ""
-
-#: mod/photos.php:267
-msgid "Album was empty."
-msgstr ""
-
-#: mod/photos.php:299
-msgid "Failed to delete the photo."
-msgstr ""
-
-#: mod/photos.php:583
-msgid "a photo"
-msgstr ""
-
-#: mod/photos.php:583
+#: mod/wallmessage.php:68 mod/wallmessage.php:129
 #, php-format
-msgid "%1$s was tagged in %2$s by %3$s"
+msgid "Number of daily wall messages for %s exceeded. Message failed."
 msgstr ""
 
-#: mod/photos.php:684
-msgid "Image upload didn't complete, please try again"
+#: mod/wallmessage.php:79
+msgid "Unable to check your home location."
 msgstr ""
 
-#: mod/photos.php:687
-msgid "Image file is missing"
+#: mod/wallmessage.php:103 mod/wallmessage.php:112
+msgid "No recipient."
 msgstr ""
 
-#: mod/photos.php:692
+#: mod/wallmessage.php:143
+#, php-format
 msgid ""
-"Server can't accept new file upload at this time, please contact your "
-"administrator"
+"If you wish for %s to respond, please check that the privacy settings on "
+"your site allow private mail from unknown senders."
 msgstr ""
 
-#: mod/photos.php:716
-msgid "Image file is empty."
+#: mod/wall_attach.php:42 mod/wall_attach.php:49 mod/wall_attach.php:87
+#: mod/wall_upload.php:52 mod/wall_upload.php:63 mod/wall_upload.php:108
+#: mod/wall_upload.php:159 mod/wall_upload.php:162
+msgid "Invalid request."
 msgstr ""
 
-#: mod/photos.php:848
-msgid "No photos selected"
+#: mod/wall_attach.php:105
+msgid "Sorry, maybe your upload is bigger than the PHP configuration allows"
 msgstr ""
 
-#: mod/photos.php:968
-msgid "Upload Photos"
+#: mod/wall_attach.php:105
+msgid "Or - did you try to upload an empty file?"
 msgstr ""
 
-#: mod/photos.php:972 mod/photos.php:1060
-msgid "New album name: "
+#: mod/wall_attach.php:116
+#, php-format
+msgid "File exceeds size limit of %s"
 msgstr ""
 
-#: mod/photos.php:973
-msgid "or select existing album:"
+#: mod/wall_attach.php:131
+msgid "File upload failed."
 msgstr ""
 
-#: mod/photos.php:974
-msgid "Do not show a status post for this upload"
-msgstr ""
-
-#: mod/photos.php:990 mod/photos.php:1355
-msgid "Show to Groups"
-msgstr ""
-
-#: mod/photos.php:991 mod/photos.php:1356
-msgid "Show to Contacts"
-msgstr ""
-
-#: mod/photos.php:1042
-msgid "Do you really want to delete this photo album and all its photos?"
-msgstr ""
-
-#: mod/photos.php:1044 mod/photos.php:1065
-msgid "Delete Album"
-msgstr ""
-
-#: mod/photos.php:1071
-msgid "Edit Album"
-msgstr ""
-
-#: mod/photos.php:1072
-msgid "Drop Album"
-msgstr ""
-
-#: mod/photos.php:1077
-msgid "Show Newest First"
-msgstr ""
-
-#: mod/photos.php:1079
-msgid "Show Oldest First"
-msgstr ""
-
-#: mod/photos.php:1100 mod/photos.php:1594
-msgid "View Photo"
-msgstr ""
-
-#: mod/photos.php:1137
-msgid "Permission denied. Access to this item may be restricted."
-msgstr ""
-
-#: mod/photos.php:1139
-msgid "Photo not available"
-msgstr ""
-
-#: mod/photos.php:1149
-msgid "Do you really want to delete this photo?"
-msgstr ""
-
-#: mod/photos.php:1151 mod/photos.php:1352
-msgid "Delete Photo"
-msgstr ""
-
-#: mod/photos.php:1242
-msgid "View photo"
-msgstr ""
-
-#: mod/photos.php:1244
-msgid "Edit photo"
-msgstr ""
-
-#: mod/photos.php:1245
-msgid "Delete photo"
-msgstr ""
-
-#: mod/photos.php:1246
-msgid "Use as profile photo"
-msgstr ""
-
-#: mod/photos.php:1253
-msgid "Private Photo"
-msgstr ""
-
-#: mod/photos.php:1259
-msgid "View Full Size"
-msgstr ""
-
-#: mod/photos.php:1320
-msgid "Tags: "
-msgstr ""
-
-#: mod/photos.php:1323
-msgid "[Select tags to remove]"
-msgstr ""
-
-#: mod/photos.php:1338
-msgid "New album name"
-msgstr ""
-
-#: mod/photos.php:1339
-msgid "Caption"
-msgstr ""
-
-#: mod/photos.php:1340
-msgid "Add a Tag"
-msgstr ""
-
-#: mod/photos.php:1340
-msgid "Example: @bob, @Barbara_Jensen, @jim@example.com, #California, #camping"
-msgstr ""
-
-#: mod/photos.php:1341
-msgid "Do not rotate"
-msgstr ""
-
-#: mod/photos.php:1342
-msgid "Rotate CW (right)"
-msgstr ""
-
-#: mod/photos.php:1343
-msgid "Rotate CCW (left)"
-msgstr ""
-
-#: mod/photos.php:1376 src/Object/Post.php:345
-msgid "I like this (toggle)"
-msgstr ""
-
-#: mod/photos.php:1377 src/Object/Post.php:346
-msgid "I don't like this (toggle)"
-msgstr ""
-
-#: mod/photos.php:1392 mod/photos.php:1439 mod/photos.php:1502
-#: src/Object/Post.php:946 src/Module/Contact.php:1059
-#: src/Module/Item/Compose.php:142
-msgid "This is you"
-msgstr ""
-
-#: mod/photos.php:1394 mod/photos.php:1441 mod/photos.php:1504
-#: src/Object/Post.php:482 src/Object/Post.php:948
-msgid "Comment"
-msgstr ""
-
-#: mod/photos.php:1530
-msgid "Map"
-msgstr ""
-
-#: src/App/Module.php:240
-msgid "You must be logged in to use addons. "
-msgstr ""
-
-#: src/App/Page.php:249
-msgid "Delete this item?"
-msgstr ""
-
-#: src/App/Page.php:297
-msgid "toggle mobile"
+#: mod/wall_upload.php:219
+msgid "Wall Photos"
 msgstr ""
 
 #: src/App/Authentication.php:210 src/App/Authentication.php:262
@@ -3442,6 +3018,18 @@ msgstr ""
 msgid "Please upload a profile photo."
 msgstr ""
 
+#: src/App/Module.php:240
+msgid "You must be logged in to use addons. "
+msgstr ""
+
+#: src/App/Page.php:249
+msgid "Delete this item?"
+msgstr ""
+
+#: src/App/Page.php:297
+msgid "toggle mobile"
+msgstr ""
+
 #: src/App/Router.php:224
 #, php-format
 msgid "Method not allowed for this module. Allowed method(s): %s"
@@ -3451,99 +3039,808 @@ msgstr ""
 msgid "Page not found."
 msgstr ""
 
-#: src/Database/DBStructure.php:69
-msgid "There are no tables on MyISAM or InnoDB with the Antelope file format."
+#: src/App.php:310
+msgid "No system theme config value set."
 msgstr ""
 
-#: src/Database/DBStructure.php:93
+#: src/BaseModule.php:150
+msgid ""
+"The form security token was not correct. This probably happened because the "
+"form has been opened for too long (>3 hours) before submitting it."
+msgstr ""
+
+#: src/BaseModule.php:179
+msgid "All contacts"
+msgstr ""
+
+#: src/BaseModule.php:184 src/Content/Widget.php:241 src/Core/ACL.php:184
+#: src/Module/Contact.php:816 src/Module/PermissionTooltip.php:76
+#: src/Module/PermissionTooltip.php:98
+msgid "Followers"
+msgstr ""
+
+#: src/BaseModule.php:189 src/Content/Widget.php:242 src/Module/Contact.php:817
+msgid "Following"
+msgstr ""
+
+#: src/BaseModule.php:194 src/Content/Widget.php:243 src/Module/Contact.php:818
+msgid "Mutual friends"
+msgstr ""
+
+#: src/BaseModule.php:202
+msgid "Common"
+msgstr ""
+
+#: src/Console/ArchiveContact.php:105
+#, php-format
+msgid "Could not find any unarchived contact entry for this URL (%s)"
+msgstr ""
+
+#: src/Console/ArchiveContact.php:108
+msgid "The contact entries have been archived"
+msgstr ""
+
+#: src/Console/GlobalCommunityBlock.php:96
+#: src/Module/Admin/Blocklist/Contact.php:49
+#, php-format
+msgid "Could not find any contact entry for this URL (%s)"
+msgstr ""
+
+#: src/Console/GlobalCommunityBlock.php:101
+#: src/Module/Admin/Blocklist/Contact.php:47
+msgid "The contact has been blocked from the node"
+msgstr ""
+
+#: src/Console/PostUpdate.php:87
+#, php-format
+msgid "Post update version number has been set to %s."
+msgstr ""
+
+#: src/Console/PostUpdate.php:95
+msgid "Check for pending update actions."
+msgstr ""
+
+#: src/Console/PostUpdate.php:97
+msgid "Done."
+msgstr ""
+
+#: src/Console/PostUpdate.php:99
+msgid "Execute pending post updates."
+msgstr ""
+
+#: src/Console/PostUpdate.php:105
+msgid "All pending post updates are done."
+msgstr ""
+
+#: src/Console/User.php:158
+msgid "Enter new password: "
+msgstr ""
+
+#: src/Console/User.php:193
+msgid "Enter user name: "
+msgstr ""
+
+#: src/Console/User.php:201 src/Console/User.php:241 src/Console/User.php:274
+#: src/Console/User.php:300
+msgid "Enter user nickname: "
+msgstr ""
+
+#: src/Console/User.php:209
+msgid "Enter user email address: "
+msgstr ""
+
+#: src/Console/User.php:217
+msgid "Enter a language (optional): "
+msgstr ""
+
+#: src/Console/User.php:255
+msgid "User is not pending."
+msgstr ""
+
+#: src/Console/User.php:313
+msgid "User has already been marked for deletion."
+msgstr ""
+
+#: src/Console/User.php:318
+#, php-format
+msgid "Type \"yes\" to delete %s"
+msgstr ""
+
+#: src/Console/User.php:320
+msgid "Deletion aborted."
+msgstr ""
+
+#: src/Content/BoundariesPager.php:116 src/Content/Pager.php:171
+msgid "newer"
+msgstr ""
+
+#: src/Content/BoundariesPager.php:124 src/Content/Pager.php:176
+msgid "older"
+msgstr ""
+
+#: src/Content/ContactSelector.php:48
+msgid "Frequently"
+msgstr ""
+
+#: src/Content/ContactSelector.php:49
+msgid "Hourly"
+msgstr ""
+
+#: src/Content/ContactSelector.php:50
+msgid "Twice daily"
+msgstr ""
+
+#: src/Content/ContactSelector.php:51
+msgid "Daily"
+msgstr ""
+
+#: src/Content/ContactSelector.php:52
+msgid "Weekly"
+msgstr ""
+
+#: src/Content/ContactSelector.php:53
+msgid "Monthly"
+msgstr ""
+
+#: src/Content/ContactSelector.php:99
+msgid "DFRN"
+msgstr ""
+
+#: src/Content/ContactSelector.php:100
+msgid "OStatus"
+msgstr ""
+
+#: src/Content/ContactSelector.php:101
+msgid "RSS/Atom"
+msgstr ""
+
+#: src/Content/ContactSelector.php:102 src/Module/Admin/Users.php:237
+#: src/Module/Admin/Users.php:248 src/Module/Admin/Users.php:262
+#: src/Module/Admin/Users.php:280
+msgid "Email"
+msgstr ""
+
+#: src/Content/ContactSelector.php:103 src/Module/Debug/Babel.php:282
+msgid "Diaspora"
+msgstr ""
+
+#: src/Content/ContactSelector.php:104
+msgid "Zot!"
+msgstr ""
+
+#: src/Content/ContactSelector.php:105
+msgid "LinkedIn"
+msgstr ""
+
+#: src/Content/ContactSelector.php:106
+msgid "XMPP/IM"
+msgstr ""
+
+#: src/Content/ContactSelector.php:107
+msgid "MySpace"
+msgstr ""
+
+#: src/Content/ContactSelector.php:108
+msgid "Google+"
+msgstr ""
+
+#: src/Content/ContactSelector.php:109
+msgid "pump.io"
+msgstr ""
+
+#: src/Content/ContactSelector.php:110
+msgid "Twitter"
+msgstr ""
+
+#: src/Content/ContactSelector.php:111
+msgid "Discourse"
+msgstr ""
+
+#: src/Content/ContactSelector.php:112
+msgid "Diaspora Connector"
+msgstr ""
+
+#: src/Content/ContactSelector.php:113
+msgid "GNU Social Connector"
+msgstr ""
+
+#: src/Content/ContactSelector.php:114
+msgid "ActivityPub"
+msgstr ""
+
+#: src/Content/ContactSelector.php:115
+msgid "pnut"
+msgstr ""
+
+#: src/Content/ContactSelector.php:149
+#, php-format
+msgid "%s (via %s)"
+msgstr ""
+
+#: src/Content/Feature.php:96
+msgid "General Features"
+msgstr ""
+
+#: src/Content/Feature.php:98
+msgid "Photo Location"
+msgstr ""
+
+#: src/Content/Feature.php:98
+msgid ""
+"Photo metadata is normally stripped. This extracts the location (if present) "
+"prior to stripping metadata and links it to a map."
+msgstr ""
+
+#: src/Content/Feature.php:99
+msgid "Trending Tags"
+msgstr ""
+
+#: src/Content/Feature.php:99
+msgid ""
+"Show a community page widget with a list of the most popular tags in recent "
+"public posts."
+msgstr ""
+
+#: src/Content/Feature.php:104
+msgid "Post Composition Features"
+msgstr ""
+
+#: src/Content/Feature.php:105
+msgid "Auto-mention Forums"
+msgstr ""
+
+#: src/Content/Feature.php:105
+msgid ""
+"Add/remove mention when a forum page is selected/deselected in ACL window."
+msgstr ""
+
+#: src/Content/Feature.php:106
+msgid "Explicit Mentions"
+msgstr ""
+
+#: src/Content/Feature.php:106
+msgid ""
+"Add explicit mentions to comment box for manual control over who gets "
+"mentioned in replies."
+msgstr ""
+
+#: src/Content/Feature.php:111
+msgid "Post/Comment Tools"
+msgstr ""
+
+#: src/Content/Feature.php:112
+msgid "Post Categories"
+msgstr ""
+
+#: src/Content/Feature.php:112
+msgid "Add categories to your posts"
+msgstr ""
+
+#: src/Content/Feature.php:117
+msgid "Advanced Profile Settings"
+msgstr ""
+
+#: src/Content/Feature.php:118
+msgid "List Forums"
+msgstr ""
+
+#: src/Content/Feature.php:118
+msgid "Show visitors public community forums at the Advanced Profile Page"
+msgstr ""
+
+#: src/Content/Feature.php:119
+msgid "Tag Cloud"
+msgstr ""
+
+#: src/Content/Feature.php:119
+msgid "Provide a personal tag cloud on your profile page"
+msgstr ""
+
+#: src/Content/Feature.php:120
+msgid "Display Membership Date"
+msgstr ""
+
+#: src/Content/Feature.php:120
+msgid "Display membership date in profile"
+msgstr ""
+
+#: src/Content/ForumManager.php:144 src/Content/Nav.php:229
+#: src/Content/Text/HTML.php:917 view/theme/vier/theme.php:220
+msgid "Forums"
+msgstr ""
+
+#: src/Content/ForumManager.php:146 view/theme/vier/theme.php:222
+msgid "External link to forum"
+msgstr ""
+
+#: src/Content/ForumManager.php:149 src/Content/Widget.php:428
+#: src/Content/Widget.php:523 view/theme/vier/theme.php:225
+msgid "show more"
+msgstr ""
+
+#: src/Content/Nav.php:90
+msgid "Nothing new here"
+msgstr ""
+
+#: src/Content/Nav.php:94 src/Module/Special/HTTPException.php:72
+msgid "Go back"
+msgstr ""
+
+#: src/Content/Nav.php:95
+msgid "Clear notifications"
+msgstr ""
+
+#: src/Content/Nav.php:96 src/Content/Text/HTML.php:904
+msgid "@name, !forum, #tags, content"
+msgstr ""
+
+#: src/Content/Nav.php:169 src/Module/Security/Login.php:141
+msgid "Logout"
+msgstr ""
+
+#: src/Content/Nav.php:169
+msgid "End this session"
+msgstr ""
+
+#: src/Content/Nav.php:171 src/Module/Bookmarklet.php:46
+#: src/Module/Security/Login.php:142
+msgid "Login"
+msgstr ""
+
+#: src/Content/Nav.php:171
+msgid "Sign in"
+msgstr ""
+
+#: src/Content/Nav.php:177 src/Module/BaseProfile.php:60
+#: src/Module/Contact.php:631 src/Module/Contact.php:884
+#: src/Module/Settings/TwoFactor/Index.php:107 view/theme/frio/theme.php:225
+msgid "Status"
+msgstr ""
+
+#: src/Content/Nav.php:177 src/Content/Nav.php:263
+#: view/theme/frio/theme.php:225
+msgid "Your posts and conversations"
+msgstr ""
+
+#: src/Content/Nav.php:178 src/Module/BaseProfile.php:52
+#: src/Module/BaseSettings.php:57 src/Module/Contact.php:633
+#: src/Module/Contact.php:900 src/Module/Profile/Profile.php:236
+#: src/Module/Welcome.php:57 view/theme/frio/theme.php:226
+msgid "Profile"
+msgstr ""
+
+#: src/Content/Nav.php:178 view/theme/frio/theme.php:226
+msgid "Your profile page"
+msgstr ""
+
+#: src/Content/Nav.php:179 view/theme/frio/theme.php:227
+msgid "Your photos"
+msgstr ""
+
+#: src/Content/Nav.php:180 src/Module/BaseProfile.php:76
+#: src/Module/BaseProfile.php:79 view/theme/frio/theme.php:228
+msgid "Videos"
+msgstr ""
+
+#: src/Content/Nav.php:180 view/theme/frio/theme.php:228
+msgid "Your videos"
+msgstr ""
+
+#: src/Content/Nav.php:181 view/theme/frio/theme.php:229
+msgid "Your events"
+msgstr ""
+
+#: src/Content/Nav.php:182
+msgid "Personal notes"
+msgstr ""
+
+#: src/Content/Nav.php:182
+msgid "Your personal notes"
+msgstr ""
+
+#: src/Content/Nav.php:202 src/Content/Nav.php:263
+msgid "Home"
+msgstr ""
+
+#: src/Content/Nav.php:202
+msgid "Home Page"
+msgstr ""
+
+#: src/Content/Nav.php:206 src/Module/Register.php:155
+#: src/Module/Security/Login.php:102
+msgid "Register"
+msgstr ""
+
+#: src/Content/Nav.php:206
+msgid "Create an account"
+msgstr ""
+
+#: src/Content/Nav.php:212 src/Module/Help.php:69
+#: src/Module/Settings/TwoFactor/AppSpecific.php:115
+#: src/Module/Settings/TwoFactor/Index.php:106
+#: src/Module/Settings/TwoFactor/Recovery.php:93
+#: src/Module/Settings/TwoFactor/Verify.php:132 view/theme/vier/theme.php:258
+msgid "Help"
+msgstr ""
+
+#: src/Content/Nav.php:212
+msgid "Help and documentation"
+msgstr ""
+
+#: src/Content/Nav.php:216
+msgid "Apps"
+msgstr ""
+
+#: src/Content/Nav.php:216
+msgid "Addon applications, utilities, games"
+msgstr ""
+
+#: src/Content/Nav.php:220 src/Content/Text/HTML.php:902
+#: src/Module/Search/Index.php:98
+msgid "Search"
+msgstr ""
+
+#: src/Content/Nav.php:220
+msgid "Search site content"
+msgstr ""
+
+#: src/Content/Nav.php:223 src/Content/Text/HTML.php:911
+msgid "Full Text"
+msgstr ""
+
+#: src/Content/Nav.php:224 src/Content/Text/HTML.php:912
+#: src/Content/Widget/TagCloud.php:68
+msgid "Tags"
+msgstr ""
+
+#: src/Content/Nav.php:225 src/Content/Nav.php:284
+#: src/Content/Text/HTML.php:913 src/Module/BaseProfile.php:121
+#: src/Module/BaseProfile.php:124 src/Module/Contact.php:819
+#: src/Module/Contact.php:907 view/theme/frio/theme.php:236
+msgid "Contacts"
+msgstr ""
+
+#: src/Content/Nav.php:244
+msgid "Community"
+msgstr ""
+
+#: src/Content/Nav.php:244
+msgid "Conversations on this and other servers"
+msgstr ""
+
+#: src/Content/Nav.php:248 src/Module/BaseProfile.php:91
+#: src/Module/BaseProfile.php:102 view/theme/frio/theme.php:233
+msgid "Events and Calendar"
+msgstr ""
+
+#: src/Content/Nav.php:251
+msgid "Directory"
+msgstr ""
+
+#: src/Content/Nav.php:251
+msgid "People directory"
+msgstr ""
+
+#: src/Content/Nav.php:253 src/Module/BaseAdmin.php:92
+msgid "Information"
+msgstr ""
+
+#: src/Content/Nav.php:253
+msgid "Information about this friendica instance"
+msgstr ""
+
+#: src/Content/Nav.php:256 src/Module/Admin/Tos.php:59
+#: src/Module/BaseAdmin.php:102 src/Module/Register.php:163
+#: src/Module/Tos.php:84
+msgid "Terms of Service"
+msgstr ""
+
+#: src/Content/Nav.php:256
+msgid "Terms of Service of this Friendica instance"
+msgstr ""
+
+#: src/Content/Nav.php:261 view/theme/frio/theme.php:232
+msgid "Network"
+msgstr ""
+
+#: src/Content/Nav.php:261 view/theme/frio/theme.php:232
+msgid "Conversations from your friends"
+msgstr ""
+
+#: src/Content/Nav.php:267
+msgid "Introductions"
+msgstr ""
+
+#: src/Content/Nav.php:267
+msgid "Friend Requests"
+msgstr ""
+
+#: src/Content/Nav.php:268 src/Module/BaseNotifications.php:139
+#: src/Module/Notifications/Introductions.php:52
+msgid "Notifications"
+msgstr ""
+
+#: src/Content/Nav.php:269
+msgid "See all notifications"
+msgstr ""
+
+#: src/Content/Nav.php:270
+msgid "Mark all system notifications seen"
+msgstr ""
+
+#: src/Content/Nav.php:273 view/theme/frio/theme.php:234
+msgid "Private mail"
+msgstr ""
+
+#: src/Content/Nav.php:274
+msgid "Inbox"
+msgstr ""
+
+#: src/Content/Nav.php:275
+msgid "Outbox"
+msgstr ""
+
+#: src/Content/Nav.php:279
+msgid "Accounts"
+msgstr ""
+
+#: src/Content/Nav.php:279
+msgid "Manage other pages"
+msgstr ""
+
+#: src/Content/Nav.php:282 src/Module/Admin/Addons/Details.php:119
+#: src/Module/Admin/Themes/Details.php:124 src/Module/BaseSettings.php:124
+#: src/Module/Welcome.php:52 view/theme/frio/theme.php:235
+msgid "Settings"
+msgstr ""
+
+#: src/Content/Nav.php:282 view/theme/frio/theme.php:235
+msgid "Account settings"
+msgstr ""
+
+#: src/Content/Nav.php:284 view/theme/frio/theme.php:236
+msgid "Manage/edit friends and contacts"
+msgstr ""
+
+#: src/Content/Nav.php:289 src/Module/BaseAdmin.php:132
+msgid "Admin"
+msgstr ""
+
+#: src/Content/Nav.php:289
+msgid "Site setup and configuration"
+msgstr ""
+
+#: src/Content/Nav.php:292
+msgid "Navigation"
+msgstr ""
+
+#: src/Content/Nav.php:292
+msgid "Site map"
+msgstr ""
+
+#: src/Content/OEmbed.php:266
+msgid "Embedding disabled"
+msgstr ""
+
+#: src/Content/OEmbed.php:388
+msgid "Embedded content"
+msgstr ""
+
+#: src/Content/Pager.php:221
+msgid "prev"
+msgstr ""
+
+#: src/Content/Pager.php:281
+msgid "last"
+msgstr ""
+
+#: src/Content/Text/BBCode.php:946 src/Content/Text/BBCode.php:1605
+#: src/Content/Text/BBCode.php:1606
+msgid "Image/photo"
+msgstr ""
+
+#: src/Content/Text/BBCode.php:1046
 #, php-format
 msgid ""
-"\n"
-"Error %d occurred during database update:\n"
-"%s\n"
+"<a href=\"%1$s\" target=\"_blank\" rel=\"noopener noreferrer\">%2$s</a> %3$s"
 msgstr ""
 
-#: src/Database/DBStructure.php:96
-msgid "Errors encountered performing database changes: "
+#: src/Content/Text/BBCode.php:1071 src/Model/Item.php:3635
+#: src/Model/Item.php:3641
+msgid "link to source"
 msgstr ""
 
-#: src/Database/DBStructure.php:296
-msgid "Another database update is currently running."
+#: src/Content/Text/BBCode.php:1523 src/Content/Text/HTML.php:954
+msgid "Click to open/close"
 msgstr ""
 
-#: src/Database/DBStructure.php:300
+#: src/Content/Text/BBCode.php:1554
+msgid "$1 wrote:"
+msgstr ""
+
+#: src/Content/Text/BBCode.php:1608 src/Content/Text/BBCode.php:1609
+msgid "Encrypted content"
+msgstr ""
+
+#: src/Content/Text/BBCode.php:1831
+msgid "Invalid source protocol"
+msgstr ""
+
+#: src/Content/Text/BBCode.php:1846
+msgid "Invalid link protocol"
+msgstr ""
+
+#: src/Content/Text/HTML.php:802
+msgid "Loading more entries..."
+msgstr ""
+
+#: src/Content/Text/HTML.php:803
+msgid "The end"
+msgstr ""
+
+#: src/Content/Text/HTML.php:896 src/Model/Profile.php:448
+#: src/Module/Contact.php:328
+msgid "Follow"
+msgstr ""
+
+#: src/Content/Widget/CalendarExport.php:63
+msgid "Export"
+msgstr ""
+
+#: src/Content/Widget/CalendarExport.php:64
+msgid "Export calendar as ical"
+msgstr ""
+
+#: src/Content/Widget/CalendarExport.php:65
+msgid "Export calendar as csv"
+msgstr ""
+
+#: src/Content/Widget/ContactBlock.php:72
+msgid "No contacts"
+msgstr ""
+
+#: src/Content/Widget/ContactBlock.php:104
 #, php-format
-msgid "%s: Database update"
+msgid "%d Contact"
+msgid_plural "%d Contacts"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/Content/Widget/ContactBlock.php:123
+msgid "View Contacts"
 msgstr ""
 
-#: src/Database/DBStructure.php:600
+#: src/Content/Widget/SavedSearches.php:47
+msgid "Remove term"
+msgstr ""
+
+#: src/Content/Widget/SavedSearches.php:60
+msgid "Saved Searches"
+msgstr ""
+
+#: src/Content/Widget/TrendingTags.php:51
 #, php-format
-msgid "%s: updating %s table."
+msgid "Trending Tags (last %d hour)"
+msgid_plural "Trending Tags (last %d hours)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/Content/Widget/TrendingTags.php:52
+msgid "More Trending Tags"
 msgstr ""
 
-#: src/Database/Database.php:661 src/Database/Database.php:764
+#: src/Content/Widget.php:52
+msgid "Add New Contact"
+msgstr ""
+
+#: src/Content/Widget.php:53
+msgid "Enter address or web location"
+msgstr ""
+
+#: src/Content/Widget.php:54
+msgid "Example: bob@example.com, http://example.com/barbara"
+msgstr ""
+
+#: src/Content/Widget.php:56
+msgid "Connect"
+msgstr ""
+
+#: src/Content/Widget.php:71
 #, php-format
-msgid "Database error %d \"%s\" at \"%s\""
+msgid "%d invitation available"
+msgid_plural "%d invitations available"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/Content/Widget.php:77 view/theme/vier/theme.php:169
+msgid "Find People"
 msgstr ""
 
-#: src/Core/Renderer.php:91 src/Core/Renderer.php:120 src/Core/Renderer.php:147
-#: src/Core/Renderer.php:181 src/Render/FriendicaSmartyEngine.php:56
-msgid ""
-"Friendica can't display this page at the moment, please contact the "
-"administrator."
+#: src/Content/Widget.php:78 view/theme/vier/theme.php:170
+msgid "Enter name or interest"
 msgstr ""
 
-#: src/Core/Renderer.php:143
-msgid "template engine cannot be registered without a name."
+#: src/Content/Widget.php:80 view/theme/vier/theme.php:172
+msgid "Examples: Robert Morgenstein, Fishing"
 msgstr ""
 
-#: src/Core/Renderer.php:177
-msgid "template engine is not registered!"
+#: src/Content/Widget.php:81 src/Module/Contact.php:840
+#: src/Module/Directory.php:105 view/theme/vier/theme.php:173
+msgid "Find"
 msgstr ""
 
-#: src/Core/Update.php:219
+#: src/Content/Widget.php:83 view/theme/vier/theme.php:175
+msgid "Similar Interests"
+msgstr ""
+
+#: src/Content/Widget.php:84 view/theme/vier/theme.php:176
+msgid "Random Profile"
+msgstr ""
+
+#: src/Content/Widget.php:85 view/theme/vier/theme.php:177
+msgid "Invite Friends"
+msgstr ""
+
+#: src/Content/Widget.php:86 src/Module/Directory.php:97
+#: view/theme/vier/theme.php:178
+msgid "Global Directory"
+msgstr ""
+
+#: src/Content/Widget.php:88 view/theme/vier/theme.php:180
+msgid "Local Directory"
+msgstr ""
+
+#: src/Content/Widget.php:217 src/Model/Group.php:528
+#: src/Module/Contact.php:803 src/Module/Welcome.php:76
+msgid "Groups"
+msgstr ""
+
+#: src/Content/Widget.php:219
+msgid "Everyone"
+msgstr ""
+
+#: src/Content/Widget.php:248
+msgid "Relationships"
+msgstr ""
+
+#: src/Content/Widget.php:250 src/Module/Contact.php:755
+#: src/Module/Group.php:292
+msgid "All Contacts"
+msgstr ""
+
+#: src/Content/Widget.php:289
+msgid "Protocols"
+msgstr ""
+
+#: src/Content/Widget.php:291
+msgid "All Protocols"
+msgstr ""
+
+#: src/Content/Widget.php:328
+msgid "Saved Folders"
+msgstr ""
+
+#: src/Content/Widget.php:330 src/Content/Widget.php:369
+msgid "Everything"
+msgstr ""
+
+#: src/Content/Widget.php:367
+msgid "Categories"
+msgstr ""
+
+#: src/Content/Widget.php:424
 #, php-format
-msgid "Update %s failed. See error logs."
-msgstr ""
+msgid "%d contact in common"
+msgid_plural "%d contacts in common"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/Core/Update.php:286
-#, php-format
-msgid ""
-"\n"
-"\t\t\t\tThe friendica developers released update %s recently,\n"
-"\t\t\t\tbut when I tried to install it, something went terribly wrong.\n"
-"\t\t\t\tThis needs to be fixed soon and I can't do it alone. Please contact "
-"a\n"
-"\t\t\t\tfriendica developer if you can not help me on your own. My database "
-"might be invalid."
-msgstr ""
-
-#: src/Core/Update.php:292
-#, php-format
-msgid ""
-"The error message is\n"
-"[pre]%s[/pre]"
-msgstr ""
-
-#: src/Core/Update.php:296 src/Core/Update.php:332
-msgid "[Friendica Notify] Database update"
-msgstr ""
-
-#: src/Core/Update.php:326
-#, php-format
-msgid ""
-"\n"
-"\t\t\t\t\tThe friendica database was successfully updated from %s to %s."
+#: src/Content/Widget.php:517
+msgid "Archives"
 msgstr ""
 
 #: src/Core/ACL.php:155
 msgid "Yourself"
-msgstr ""
-
-#: src/Core/ACL.php:184 src/Module/PermissionTooltip.php:76
-#: src/Module/PermissionTooltip.php:98 src/Module/Contact.php:816
-#: src/Content/Widget.php:241 src/BaseModule.php:184
-msgid "Followers"
 msgstr ""
 
 #: src/Core/ACL.php:191 src/Module/PermissionTooltip.php:82
@@ -3858,8 +4155,8 @@ msgstr ""
 msgid "Could not connect to database."
 msgstr ""
 
-#: src/Core/L10n.php:371 src/Module/Settings/Display.php:174
-#: src/Model/Event.php:413
+#: src/Core/L10n.php:371 src/Model/Event.php:413
+#: src/Module/Settings/Display.php:174
 msgid "Monday"
 msgstr ""
 
@@ -3883,8 +4180,8 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
-#: src/Core/L10n.php:371 src/Module/Settings/Display.php:174
-#: src/Model/Event.php:412
+#: src/Core/L10n.php:371 src/Model/Event.php:412
+#: src/Module/Settings/Display.php:174
 msgid "Sunday"
 msgstr ""
 
@@ -4056,6 +4353,56 @@ msgstr ""
 msgid "rebuffed"
 msgstr ""
 
+#: src/Core/Renderer.php:91 src/Core/Renderer.php:120 src/Core/Renderer.php:147
+#: src/Core/Renderer.php:181 src/Render/FriendicaSmartyEngine.php:56
+msgid ""
+"Friendica can't display this page at the moment, please contact the "
+"administrator."
+msgstr ""
+
+#: src/Core/Renderer.php:143
+msgid "template engine cannot be registered without a name."
+msgstr ""
+
+#: src/Core/Renderer.php:177
+msgid "template engine is not registered!"
+msgstr ""
+
+#: src/Core/Update.php:219
+#, php-format
+msgid "Update %s failed. See error logs."
+msgstr ""
+
+#: src/Core/Update.php:286
+#, php-format
+msgid ""
+"\n"
+"\t\t\t\tThe friendica developers released update %s recently,\n"
+"\t\t\t\tbut when I tried to install it, something went terribly wrong.\n"
+"\t\t\t\tThis needs to be fixed soon and I can't do it alone. Please contact "
+"a\n"
+"\t\t\t\tfriendica developer if you can not help me on your own. My database "
+"might be invalid."
+msgstr ""
+
+#: src/Core/Update.php:292
+#, php-format
+msgid ""
+"The error message is\n"
+"[pre]%s[/pre]"
+msgstr ""
+
+#: src/Core/Update.php:296 src/Core/Update.php:332
+msgid "[Friendica Notify] Database update"
+msgstr ""
+
+#: src/Core/Update.php:326
+#, php-format
+msgid ""
+"\n"
+"\t\t\t\t\tThe friendica database was successfully updated from %s to %s."
+msgstr ""
+
 #: src/Core/UserImport.php:126
 msgid "Error decoding account file"
 msgstr ""
@@ -4088,393 +4435,39 @@ msgstr ""
 msgid "Done. You can now login with your username and password"
 msgstr ""
 
-#: src/LegacyModule.php:49
+#: src/Database/Database.php:661 src/Database/Database.php:764
 #, php-format
-msgid "Legacy module file not found: %s"
+msgid "Database error %d \"%s\" at \"%s\""
 msgstr ""
 
-#: src/Worker/Delivery.php:556
-msgid "(no subject)"
+#: src/Database/DBStructure.php:69
+msgid "There are no tables on MyISAM or InnoDB with the Antelope file format."
 msgstr ""
 
-#: src/Object/EMail/ItemCCEMail.php:39
+#: src/Database/DBStructure.php:93
 #, php-format
 msgid ""
-"This message was sent to you by %s, a member of the Friendica social network."
+"\n"
+"Error %d occurred during database update:\n"
+"%s\n"
 msgstr ""
 
-#: src/Object/EMail/ItemCCEMail.php:41
+#: src/Database/DBStructure.php:96
+msgid "Errors encountered performing database changes: "
+msgstr ""
+
+#: src/Database/DBStructure.php:296
+msgid "Another database update is currently running."
+msgstr ""
+
+#: src/Database/DBStructure.php:300
 #, php-format
-msgid "You may visit them online at %s"
+msgid "%s: Database update"
 msgstr ""
 
-#: src/Object/EMail/ItemCCEMail.php:42
-msgid ""
-"Please contact the sender by replying to this post if you do not wish to "
-"receive these messages."
-msgstr ""
-
-#: src/Object/EMail/ItemCCEMail.php:46
+#: src/Database/DBStructure.php:600
 #, php-format
-msgid "%s posted an update."
-msgstr ""
-
-#: src/Object/Post.php:147
-msgid "This entry was edited"
-msgstr ""
-
-#: src/Object/Post.php:174
-msgid "Private Message"
-msgstr ""
-
-#: src/Object/Post.php:213
-msgid "pinned item"
-msgstr ""
-
-#: src/Object/Post.php:218
-msgid "Delete locally"
-msgstr ""
-
-#: src/Object/Post.php:221
-msgid "Delete globally"
-msgstr ""
-
-#: src/Object/Post.php:221
-msgid "Remove locally"
-msgstr ""
-
-#: src/Object/Post.php:235
-msgid "save to folder"
-msgstr ""
-
-#: src/Object/Post.php:270
-msgid "I will attend"
-msgstr ""
-
-#: src/Object/Post.php:270
-msgid "I will not attend"
-msgstr ""
-
-#: src/Object/Post.php:270
-msgid "I might attend"
-msgstr ""
-
-#: src/Object/Post.php:300
-msgid "ignore thread"
-msgstr ""
-
-#: src/Object/Post.php:301
-msgid "unignore thread"
-msgstr ""
-
-#: src/Object/Post.php:302
-msgid "toggle ignore status"
-msgstr ""
-
-#: src/Object/Post.php:314
-msgid "pin"
-msgstr ""
-
-#: src/Object/Post.php:315
-msgid "unpin"
-msgstr ""
-
-#: src/Object/Post.php:316
-msgid "toggle pin status"
-msgstr ""
-
-#: src/Object/Post.php:319
-msgid "pinned"
-msgstr ""
-
-#: src/Object/Post.php:326
-msgid "add star"
-msgstr ""
-
-#: src/Object/Post.php:327
-msgid "remove star"
-msgstr ""
-
-#: src/Object/Post.php:328
-msgid "toggle star status"
-msgstr ""
-
-#: src/Object/Post.php:331
-msgid "starred"
-msgstr ""
-
-#: src/Object/Post.php:335
-msgid "add tag"
-msgstr ""
-
-#: src/Object/Post.php:345
-msgid "like"
-msgstr ""
-
-#: src/Object/Post.php:346
-msgid "dislike"
-msgstr ""
-
-#: src/Object/Post.php:348
-msgid "Share this"
-msgstr ""
-
-#: src/Object/Post.php:348
-msgid "share"
-msgstr ""
-
-#: src/Object/Post.php:400
-#, php-format
-msgid "%s (Received %s)"
-msgstr ""
-
-#: src/Object/Post.php:405
-msgid "Comment this item on your system"
-msgstr ""
-
-#: src/Object/Post.php:405
-msgid "remote comment"
-msgstr ""
-
-#: src/Object/Post.php:417
-msgid "Pushed"
-msgstr ""
-
-#: src/Object/Post.php:417
-msgid "Pulled"
-msgstr ""
-
-#: src/Object/Post.php:444
-msgid "to"
-msgstr ""
-
-#: src/Object/Post.php:445
-msgid "via"
-msgstr ""
-
-#: src/Object/Post.php:446
-msgid "Wall-to-Wall"
-msgstr ""
-
-#: src/Object/Post.php:447
-msgid "via Wall-To-Wall:"
-msgstr ""
-
-#: src/Object/Post.php:483
-#, php-format
-msgid "Reply to %s"
-msgstr ""
-
-#: src/Object/Post.php:486
-msgid "More"
-msgstr ""
-
-#: src/Object/Post.php:503
-msgid "Notifier task is pending"
-msgstr ""
-
-#: src/Object/Post.php:504
-msgid "Delivery to remote servers is pending"
-msgstr ""
-
-#: src/Object/Post.php:505
-msgid "Delivery to remote servers is underway"
-msgstr ""
-
-#: src/Object/Post.php:506
-msgid "Delivery to remote servers is mostly done"
-msgstr ""
-
-#: src/Object/Post.php:507
-msgid "Delivery to remote servers is done"
-msgstr ""
-
-#: src/Object/Post.php:527
-#, php-format
-msgid "%d comment"
-msgid_plural "%d comments"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/Object/Post.php:528
-msgid "Show more"
-msgstr ""
-
-#: src/Object/Post.php:529
-msgid "Show fewer"
-msgstr ""
-
-#: src/Object/Post.php:540 src/Model/Item.php:3381
-msgid "comment"
-msgid_plural "comments"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/Console/ArchiveContact.php:105
-#, php-format
-msgid "Could not find any unarchived contact entry for this URL (%s)"
-msgstr ""
-
-#: src/Console/ArchiveContact.php:108
-msgid "The contact entries have been archived"
-msgstr ""
-
-#: src/Console/GlobalCommunityBlock.php:96
-#: src/Module/Admin/Blocklist/Contact.php:49
-#, php-format
-msgid "Could not find any contact entry for this URL (%s)"
-msgstr ""
-
-#: src/Console/GlobalCommunityBlock.php:101
-#: src/Module/Admin/Blocklist/Contact.php:47
-msgid "The contact has been blocked from the node"
-msgstr ""
-
-#: src/Console/User.php:158
-msgid "Enter new password: "
-msgstr ""
-
-#: src/Console/User.php:193
-msgid "Enter user name: "
-msgstr ""
-
-#: src/Console/User.php:201 src/Console/User.php:241 src/Console/User.php:274
-#: src/Console/User.php:300
-msgid "Enter user nickname: "
-msgstr ""
-
-#: src/Console/User.php:209
-msgid "Enter user email address: "
-msgstr ""
-
-#: src/Console/User.php:217
-msgid "Enter a language (optional): "
-msgstr ""
-
-#: src/Console/User.php:255
-msgid "User is not pending."
-msgstr ""
-
-#: src/Console/User.php:313
-msgid "User has already been marked for deletion."
-msgstr ""
-
-#: src/Console/User.php:318
-#, php-format
-msgid "Type \"yes\" to delete %s"
-msgstr ""
-
-#: src/Console/User.php:320
-msgid "Deletion aborted."
-msgstr ""
-
-#: src/Console/PostUpdate.php:87
-#, php-format
-msgid "Post update version number has been set to %s."
-msgstr ""
-
-#: src/Console/PostUpdate.php:95
-msgid "Check for pending update actions."
-msgstr ""
-
-#: src/Console/PostUpdate.php:97
-msgid "Done."
-msgstr ""
-
-#: src/Console/PostUpdate.php:99
-msgid "Execute pending post updates."
-msgstr ""
-
-#: src/Console/PostUpdate.php:105
-msgid "All pending post updates are done."
-msgstr ""
-
-#: src/Render/FriendicaSmartyEngine.php:52
-msgid "The folder view/smarty3/ must be writable by webserver."
-msgstr ""
-
-#: src/Repository/ProfileField.php:275
-msgid "Hometown:"
-msgstr ""
-
-#: src/Repository/ProfileField.php:276
-msgid "Marital Status:"
-msgstr ""
-
-#: src/Repository/ProfileField.php:277
-msgid "With:"
-msgstr ""
-
-#: src/Repository/ProfileField.php:278
-msgid "Since:"
-msgstr ""
-
-#: src/Repository/ProfileField.php:279
-msgid "Sexual Preference:"
-msgstr ""
-
-#: src/Repository/ProfileField.php:280
-msgid "Political Views:"
-msgstr ""
-
-#: src/Repository/ProfileField.php:281
-msgid "Religious Views:"
-msgstr ""
-
-#: src/Repository/ProfileField.php:282
-msgid "Likes:"
-msgstr ""
-
-#: src/Repository/ProfileField.php:283
-msgid "Dislikes:"
-msgstr ""
-
-#: src/Repository/ProfileField.php:284
-msgid "Title/Description:"
-msgstr ""
-
-#: src/Repository/ProfileField.php:285 src/Module/Admin/Summary.php:231
-msgid "Summary"
-msgstr ""
-
-#: src/Repository/ProfileField.php:286
-msgid "Musical interests"
-msgstr ""
-
-#: src/Repository/ProfileField.php:287
-msgid "Books, literature"
-msgstr ""
-
-#: src/Repository/ProfileField.php:288
-msgid "Television"
-msgstr ""
-
-#: src/Repository/ProfileField.php:289
-msgid "Film/dance/culture/entertainment"
-msgstr ""
-
-#: src/Repository/ProfileField.php:290
-msgid "Hobbies/Interests"
-msgstr ""
-
-#: src/Repository/ProfileField.php:291
-msgid "Love/romance"
-msgstr ""
-
-#: src/Repository/ProfileField.php:292
-msgid "Work/employment"
-msgstr ""
-
-#: src/Repository/ProfileField.php:293
-msgid "School/education"
-msgstr ""
-
-#: src/Repository/ProfileField.php:294
-msgid "Contact information and Social Networks"
-msgstr ""
-
-#: src/App.php:310
-msgid "No system theme config value set."
+msgid "%s: updating %s table."
 msgstr ""
 
 #: src/Factory/Notification/Introduction.php:128
@@ -4530,2251 +4523,830 @@ msgstr ""
 msgid "%s is now friends with %s"
 msgstr ""
 
-#: src/Module/Notifications/Notifications.php:50
-msgid "Network Notifications"
-msgstr ""
-
-#: src/Module/Notifications/Notifications.php:58
-msgid "System Notifications"
-msgstr ""
-
-#: src/Module/Notifications/Notifications.php:66
-msgid "Personal Notifications"
-msgstr ""
-
-#: src/Module/Notifications/Notifications.php:74
-msgid "Home Notifications"
-msgstr ""
-
-#: src/Module/Notifications/Notifications.php:133
-#: src/Module/Notifications/Introductions.php:195
+#: src/LegacyModule.php:49
 #, php-format
-msgid "No more %s notifications."
+msgid "Legacy module file not found: %s"
 msgstr ""
 
-#: src/Module/Notifications/Notifications.php:138
-msgid "Show unread"
+#: src/Model/Contact.php:961 src/Model/Contact.php:974
+msgid "UnFollow"
 msgstr ""
 
-#: src/Module/Notifications/Notifications.php:138
-msgid "Show all"
+#: src/Model/Contact.php:970
+msgid "Drop Contact"
 msgstr ""
 
-#: src/Module/Notifications/Notification.php:103
-msgid "You must be logged in to show this page."
-msgstr ""
-
-#: src/Module/Notifications/Introductions.php:52
-#: src/Module/BaseNotifications.php:139 src/Content/Nav.php:268
-msgid "Notifications"
-msgstr ""
-
-#: src/Module/Notifications/Introductions.php:76
-msgid "Show Ignored Requests"
-msgstr ""
-
-#: src/Module/Notifications/Introductions.php:76
-msgid "Hide Ignored Requests"
-msgstr ""
-
-#: src/Module/Notifications/Introductions.php:90
-#: src/Module/Notifications/Introductions.php:157
-msgid "Notification type:"
-msgstr ""
-
-#: src/Module/Notifications/Introductions.php:93
-msgid "Suggested by:"
-msgstr ""
-
-#: src/Module/Notifications/Introductions.php:105
-#: src/Module/Notifications/Introductions.php:171 src/Module/Contact.php:610
-msgid "Hide this contact from others"
-msgstr ""
-
+#: src/Model/Contact.php:980 src/Module/Admin/Users.php:251
 #: src/Module/Notifications/Introductions.php:107
 #: src/Module/Notifications/Introductions.php:183
-#: src/Module/Admin/Users.php:251 src/Model/Contact.php:980
 msgid "Approve"
 msgstr ""
 
-#: src/Module/Notifications/Introductions.php:118
-msgid "Claims to be known to you: "
+#: src/Model/Contact.php:1367
+msgid "Organisation"
 msgstr ""
 
-#: src/Module/Notifications/Introductions.php:125
-msgid "Shall your connection be bidirectional or not?"
+#: src/Model/Contact.php:1371
+msgid "News"
 msgstr ""
 
-#: src/Module/Notifications/Introductions.php:126
-#, php-format
+#: src/Model/Contact.php:1375
+msgid "Forum"
+msgstr ""
+
+#: src/Model/Contact.php:2027
+msgid "Connect URL missing."
+msgstr ""
+
+#: src/Model/Contact.php:2036
 msgid ""
-"Accepting %s as a friend allows %s to subscribe to your posts, and you will "
-"also receive updates from them in your news feed."
+"The contact could not be added. Please check the relevant network "
+"credentials in your Settings -> Social Networks page."
 msgstr ""
 
-#: src/Module/Notifications/Introductions.php:127
-#, php-format
+#: src/Model/Contact.php:2077
 msgid ""
-"Accepting %s as a subscriber allows them to subscribe to your posts, but you "
-"will not receive updates from them in your news feed."
+"This site is not configured to allow communications with other networks."
 msgstr ""
 
-#: src/Module/Notifications/Introductions.php:129
-msgid "Friend"
+#: src/Model/Contact.php:2078 src/Model/Contact.php:2091
+msgid "No compatible communication protocols or feeds were discovered."
 msgstr ""
 
-#: src/Module/Notifications/Introductions.php:130
-msgid "Subscriber"
+#: src/Model/Contact.php:2089
+msgid "The profile address specified does not provide adequate information."
 msgstr ""
 
-#: src/Module/Notifications/Introductions.php:168 src/Module/Contact.php:626
-#: src/Model/Profile.php:368
-msgid "About:"
+#: src/Model/Contact.php:2094
+msgid "An author or name was not found."
 msgstr ""
 
-#: src/Module/Notifications/Introductions.php:180 src/Module/Contact.php:326
-#: src/Model/Profile.php:460
-msgid "Network:"
+#: src/Model/Contact.php:2097
+msgid "No browser URL could be matched to this address."
 msgstr ""
 
-#: src/Module/Notifications/Introductions.php:194
-msgid "No introductions."
-msgstr ""
-
-#: src/Module/Manifest.php:42
-msgid "A Decentralized Social Network"
-msgstr ""
-
-#: src/Module/Security/Logout.php:53
-msgid "Logged out."
-msgstr ""
-
-#: src/Module/Security/TwoFactor/Verify.php:61
-#: src/Module/Security/TwoFactor/Recovery.php:64
-#: src/Module/Settings/TwoFactor/Verify.php:82
-msgid "Invalid code, please retry."
-msgstr ""
-
-#: src/Module/Security/TwoFactor/Verify.php:80 src/Module/BaseSettings.php:50
-#: src/Module/Settings/TwoFactor/Index.php:105
-msgid "Two-factor authentication"
-msgstr ""
-
-#: src/Module/Security/TwoFactor/Verify.php:81
+#: src/Model/Contact.php:2100
 msgid ""
-"<p>Open the two-factor authentication app on your device to get an "
-"authentication code and verify your identity.</p>"
+"Unable to match @-style Identity Address with a known protocol or email "
+"contact."
 msgstr ""
 
-#: src/Module/Security/TwoFactor/Verify.php:84
-#: src/Module/Security/TwoFactor/Recovery.php:85
-#, php-format
+#: src/Model/Contact.php:2101
+msgid "Use mailto: in front of address to force email check."
+msgstr ""
+
+#: src/Model/Contact.php:2107
 msgid ""
-"Don’t have your phone? <a href=\"%s\">Enter a two-factor recovery code</a>"
+"The profile address specified belongs to a network which has been disabled "
+"on this site."
 msgstr ""
 
-#: src/Module/Security/TwoFactor/Verify.php:85
-#: src/Module/Settings/TwoFactor/Verify.php:141
-msgid "Please enter a code from your authentication app"
-msgstr ""
-
-#: src/Module/Security/TwoFactor/Verify.php:86
-msgid "Verify code and complete login"
-msgstr ""
-
-#: src/Module/Security/TwoFactor/Recovery.php:60
-#, php-format
-msgid "Remaining recovery codes: %d"
-msgstr ""
-
-#: src/Module/Security/TwoFactor/Recovery.php:83
-msgid "Two-factor recovery"
-msgstr ""
-
-#: src/Module/Security/TwoFactor/Recovery.php:84
+#: src/Model/Contact.php:2112
 msgid ""
-"<p>You can enter one of your one-time recovery codes in case you lost access "
-"to your mobile device.</p>"
+"Limited profile. This person will be unable to receive direct/personal "
+"notifications from you."
 msgstr ""
 
-#: src/Module/Security/TwoFactor/Recovery.php:86
-msgid "Please enter a recovery code"
+#: src/Model/Contact.php:2171
+msgid "Unable to retrieve contact information."
 msgstr ""
 
-#: src/Module/Security/TwoFactor/Recovery.php:87
-msgid "Submit recovery code and complete login"
-msgstr ""
-
-#: src/Module/Security/Login.php:101
-msgid "Create a New Account"
-msgstr ""
-
-#: src/Module/Security/Login.php:102 src/Module/Register.php:155
-#: src/Content/Nav.php:206
-msgid "Register"
-msgstr ""
-
-#: src/Module/Security/Login.php:126
-msgid "Your OpenID: "
-msgstr ""
-
-#: src/Module/Security/Login.php:129
-msgid ""
-"Please enter your username and password to add the OpenID to your existing "
-"account."
-msgstr ""
-
-#: src/Module/Security/Login.php:131
-msgid "Or login using OpenID: "
-msgstr ""
-
-#: src/Module/Security/Login.php:141 src/Content/Nav.php:169
-msgid "Logout"
-msgstr ""
-
-#: src/Module/Security/Login.php:142 src/Module/Bookmarklet.php:46
-#: src/Content/Nav.php:171
-msgid "Login"
-msgstr ""
-
-#: src/Module/Security/Login.php:145
-msgid "Password: "
-msgstr ""
-
-#: src/Module/Security/Login.php:146
-msgid "Remember me"
-msgstr ""
-
-#: src/Module/Security/Login.php:155
-msgid "Forgot your password?"
-msgstr ""
-
-#: src/Module/Security/Login.php:158
-msgid "Website Terms of Service"
-msgstr ""
-
-#: src/Module/Security/Login.php:159
-msgid "terms of service"
-msgstr ""
-
-#: src/Module/Security/Login.php:161
-msgid "Website Privacy Policy"
-msgstr ""
-
-#: src/Module/Security/Login.php:162
-msgid "privacy policy"
-msgstr ""
-
-#: src/Module/Security/OpenID.php:54
-msgid "OpenID protocol error. No ID returned"
-msgstr ""
-
-#: src/Module/Security/OpenID.php:92
-msgid ""
-"Account not found. Please login to your existing account to add the OpenID "
-"to it."
-msgstr ""
-
-#: src/Module/Security/OpenID.php:94
-msgid ""
-"Account not found. Please register a new account or login to your existing "
-"account to add the OpenID to it."
-msgstr ""
-
-#: src/Module/Debug/Localtime.php:36 src/Model/Event.php:50
-#: src/Model/Event.php:862
+#: src/Model/Event.php:50 src/Model/Event.php:862
+#: src/Module/Debug/Localtime.php:36
 msgid "l F d, Y \\@ g:i A"
 msgstr ""
 
-#: src/Module/Debug/Localtime.php:49
-msgid "Time Conversion"
+#: src/Model/Event.php:77 src/Model/Event.php:94 src/Model/Event.php:452
+#: src/Model/Event.php:930
+msgid "Starts:"
 msgstr ""
 
-#: src/Module/Debug/Localtime.php:50
+#: src/Model/Event.php:80 src/Model/Event.php:100 src/Model/Event.php:453
+#: src/Model/Event.php:934
+msgid "Finishes:"
+msgstr ""
+
+#: src/Model/Event.php:402
+msgid "all-day"
+msgstr ""
+
+#: src/Model/Event.php:428
+msgid "Sept"
+msgstr ""
+
+#: src/Model/Event.php:450
+msgid "No events to display"
+msgstr ""
+
+#: src/Model/Event.php:578
+msgid "l, F j"
+msgstr ""
+
+#: src/Model/Event.php:609
+msgid "Edit event"
+msgstr ""
+
+#: src/Model/Event.php:610
+msgid "Duplicate event"
+msgstr ""
+
+#: src/Model/Event.php:611
+msgid "Delete event"
+msgstr ""
+
+#: src/Model/Event.php:863
+msgid "D g:i A"
+msgstr ""
+
+#: src/Model/Event.php:864
+msgid "g:i A"
+msgstr ""
+
+#: src/Model/Event.php:949 src/Model/Event.php:951
+msgid "Show map"
+msgstr ""
+
+#: src/Model/Event.php:950
+msgid "Hide map"
+msgstr ""
+
+#: src/Model/Event.php:1042
+#, php-format
+msgid "%s's birthday"
+msgstr ""
+
+#: src/Model/Event.php:1043
+#, php-format
+msgid "Happy Birthday %s"
+msgstr ""
+
+#: src/Model/Group.php:92
 msgid ""
-"Friendica provides this service for sharing events with other networks and "
-"friends in unknown timezones."
+"A deleted group with this name was revived. Existing item permissions "
+"<strong>may</strong> apply to this group and any future members. If this is "
+"not what you intended, please create another group with a different name."
 msgstr ""
 
-#: src/Module/Debug/Localtime.php:51
-#, php-format
-msgid "UTC time: %s"
+#: src/Model/Group.php:451
+msgid "Default privacy group for new contacts"
 msgstr ""
 
-#: src/Module/Debug/Localtime.php:54
-#, php-format
-msgid "Current timezone: %s"
+#: src/Model/Group.php:483
+msgid "Everybody"
 msgstr ""
 
-#: src/Module/Debug/Localtime.php:58
-#, php-format
-msgid "Converted localtime: %s"
+#: src/Model/Group.php:502
+msgid "edit"
 msgstr ""
 
-#: src/Module/Debug/Localtime.php:62
-msgid "Please select your timezone:"
+#: src/Model/Group.php:527
+msgid "add"
 msgstr ""
 
-#: src/Module/Debug/Babel.php:54
-msgid "Source input"
+#: src/Model/Group.php:532
+msgid "Edit group"
 msgstr ""
 
-#: src/Module/Debug/Babel.php:60
-msgid "BBCode::toPlaintext"
+#: src/Model/Group.php:533 src/Module/Group.php:193
+msgid "Contacts not in any group"
 msgstr ""
 
-#: src/Module/Debug/Babel.php:66
-msgid "BBCode::convert (raw HTML)"
+#: src/Model/Group.php:535
+msgid "Create a new group"
 msgstr ""
 
-#: src/Module/Debug/Babel.php:71
-msgid "BBCode::convert"
+#: src/Model/Group.php:536 src/Module/Group.php:178 src/Module/Group.php:201
+#: src/Module/Group.php:276
+msgid "Group Name: "
 msgstr ""
 
-#: src/Module/Debug/Babel.php:77
-msgid "BBCode::convert => HTML::toBBCode"
+#: src/Model/Group.php:537
+msgid "Edit groups"
 msgstr ""
 
-#: src/Module/Debug/Babel.php:83
-msgid "BBCode::toMarkdown"
+#: src/Model/Item.php:3379
+msgid "activity"
 msgstr ""
 
-#: src/Module/Debug/Babel.php:89
-msgid "BBCode::toMarkdown => Markdown::convert (raw HTML)"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:93
-msgid "BBCode::toMarkdown => Markdown::convert"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:99
-msgid "BBCode::toMarkdown => Markdown::toBBCode"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:105
-msgid "BBCode::toMarkdown =>  Markdown::convert => HTML::toBBCode"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:113
-msgid "Item Body"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:117
-msgid "Item Tags"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:123
-msgid "PageInfo::appendToBody"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:128
-msgid "PageInfo::appendToBody => BBCode::convert (raw HTML)"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:132
-msgid "PageInfo::appendToBody => BBCode::convert"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:139
-msgid "Source input (Diaspora format)"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:148
-msgid "Source input (Markdown)"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:154
-msgid "Markdown::convert (raw HTML)"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:159
-msgid "Markdown::convert"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:165
-msgid "Markdown::toBBCode"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:172
-msgid "Raw HTML input"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:177
-msgid "HTML Input"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:183
-msgid "HTML::toBBCode"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:189
-msgid "HTML::toBBCode => BBCode::convert"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:194
-msgid "HTML::toBBCode => BBCode::convert (raw HTML)"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:200
-msgid "HTML::toBBCode => BBCode::toPlaintext"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:206
-msgid "HTML::toMarkdown"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:212
-msgid "HTML::toPlaintext"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:218
-msgid "HTML::toPlaintext (compact)"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:228
-msgid "Decoded post"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:252
-msgid "Post array before expand entities"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:259
-msgid "Post converted"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:264
-msgid "Converted body"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:270
-msgid "Twitter addon is absent from the addon/ folder."
-msgstr ""
-
-#: src/Module/Debug/Babel.php:280
-msgid "Source text"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:281
-msgid "BBCode"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:282 src/Content/ContactSelector.php:103
-msgid "Diaspora"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:283
-msgid "Markdown"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:284
-msgid "HTML"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:286
-msgid "Twitter Source"
-msgstr ""
-
-#: src/Module/Debug/WebFinger.php:37 src/Module/Debug/Probe.php:38
-msgid "Only logged in users are permitted to perform a probing."
-msgstr ""
-
-#: src/Module/Debug/ActivityPubConversion.php:58
-msgid "Formatted"
-msgstr ""
-
-#: src/Module/Debug/ActivityPubConversion.php:62
-msgid "Source"
-msgstr ""
-
-#: src/Module/Debug/ActivityPubConversion.php:70
-msgid "Activity"
-msgstr ""
-
-#: src/Module/Debug/ActivityPubConversion.php:118
-msgid "Object data"
-msgstr ""
-
-#: src/Module/Debug/ActivityPubConversion.php:125
-msgid "Result Item"
-msgstr ""
-
-#: src/Module/Debug/ActivityPubConversion.php:138
-msgid "Source activity"
-msgstr ""
-
-#: src/Module/Debug/Feed.php:38 src/Module/Filer/SaveTag.php:38
-#: src/Module/Settings/Profile/Index.php:158
-msgid "You must be logged in to use this module"
-msgstr ""
-
-#: src/Module/Debug/Feed.php:63
-msgid "Source URL"
-msgstr ""
-
-#: src/Module/Debug/Probe.php:54
-msgid "Lookup address"
-msgstr ""
-
-#: src/Module/Profile/Common.php:87 src/Module/Contact/Contacts.php:92
-#, php-format
-msgid "Common contact (%s)"
-msgid_plural "Common contacts (%s)"
+#: src/Model/Item.php:3381 src/Object/Post.php:540
+msgid "comment"
+msgid_plural "comments"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Module/Profile/Common.php:89 src/Module/Contact/Contacts.php:94
+#: src/Model/Item.php:3384
+msgid "post"
+msgstr ""
+
+#: src/Model/Item.php:3507
 #, php-format
-msgid ""
-"Both <strong>%s</strong> and yourself have publicly interacted with these "
-"contacts (follow, comment or likes on public posts)."
+msgid "Content warning: %s"
 msgstr ""
 
-#: src/Module/Profile/Common.php:99 src/Module/Contact/Contacts.php:64
-msgid "No common contacts."
+#: src/Model/Item.php:3584
+msgid "bytes"
 msgstr ""
 
-#: src/Module/Profile/Status.php:61 src/Module/Profile/Status.php:64
-#: src/Module/Profile/Profile.php:320 src/Module/Profile/Profile.php:323
-#: src/Protocol/OStatus.php:1269 src/Protocol/Feed.php:892
-#, php-format
-msgid "%s's timeline"
+#: src/Model/Item.php:3629
+msgid "View on separate page"
 msgstr ""
 
-#: src/Module/Profile/Status.php:62 src/Module/Profile/Profile.php:321
-#: src/Protocol/OStatus.php:1273 src/Protocol/Feed.php:896
-#, php-format
-msgid "%s's posts"
+#: src/Model/Item.php:3630
+msgid "view on separate page"
 msgstr ""
 
-#: src/Module/Profile/Status.php:63 src/Module/Profile/Profile.php:322
-#: src/Protocol/OStatus.php:1276 src/Protocol/Feed.php:899
-#, php-format
-msgid "%s's comments"
+#: src/Model/Mail.php:128 src/Model/Mail.php:263
+msgid "[no subject]"
 msgstr ""
 
-#: src/Module/Profile/Contacts.php:96 src/Module/Contact/Contacts.php:76
-#, php-format
-msgid "Follower (%s)"
-msgid_plural "Followers (%s)"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/Module/Profile/Contacts.php:99 src/Module/Contact/Contacts.php:80
-#, php-format
-msgid "Following (%s)"
-msgid_plural "Following (%s)"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/Module/Profile/Contacts.php:102 src/Module/Contact/Contacts.php:84
-#, php-format
-msgid "Mutual friend (%s)"
-msgid_plural "Mutual friends (%s)"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/Module/Profile/Contacts.php:104 src/Module/Contact/Contacts.php:86
-#, php-format
-msgid "These contacts both follow and are followed by <strong>%s</strong>."
-msgstr ""
-
-#: src/Module/Profile/Contacts.php:110 src/Module/Contact/Contacts.php:100
-#, php-format
-msgid "Contact (%s)"
-msgid_plural "Contacts (%s)"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/Module/Profile/Contacts.php:120
-msgid "No contacts."
-msgstr ""
-
-#: src/Module/Profile/Profile.php:135
-#, php-format
-msgid ""
-"You're currently viewing your profile as <b>%s</b> <a href=\"%s\" class="
-"\"btn btn-sm pull-right\">Cancel</a>"
-msgstr ""
-
-#: src/Module/Profile/Profile.php:149
-msgid "Member since:"
-msgstr ""
-
-#: src/Module/Profile/Profile.php:155
-msgid "j F, Y"
-msgstr ""
-
-#: src/Module/Profile/Profile.php:156
-msgid "j F"
-msgstr ""
-
-#: src/Module/Profile/Profile.php:164 src/Util/Temporal.php:163
-msgid "Birthday:"
-msgstr ""
-
-#: src/Module/Profile/Profile.php:167 src/Module/Settings/Profile/Index.php:260
-#: src/Util/Temporal.php:165
-msgid "Age: "
-msgstr ""
-
-#: src/Module/Profile/Profile.php:167 src/Module/Settings/Profile/Index.php:260
-#: src/Util/Temporal.php:165
-#, php-format
-msgid "%d year old"
-msgid_plural "%d years old"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/Module/Profile/Profile.php:176 src/Module/Contact.php:624
-#: src/Model/Profile.php:369
-msgid "XMPP:"
-msgstr ""
-
-#: src/Module/Profile/Profile.php:180 src/Module/Directory.php:161
-#: src/Model/Profile.php:367
-msgid "Homepage:"
-msgstr ""
-
-#: src/Module/Profile/Profile.php:229
-msgid "Forums:"
-msgstr ""
-
-#: src/Module/Profile/Profile.php:240
-msgid "View profile as:"
-msgstr ""
-
-#: src/Module/Profile/Profile.php:250 src/Module/Profile/Profile.php:252
-#: src/Model/Profile.php:346
+#: src/Model/Profile.php:346 src/Module/Profile/Profile.php:250
+#: src/Module/Profile/Profile.php:252
 msgid "Edit profile"
 msgstr ""
 
-#: src/Module/Profile/Profile.php:257
-msgid "View as"
+#: src/Model/Profile.php:348
+msgid "Change profile photo"
 msgstr ""
 
-#: src/Module/Register.php:69
-msgid "Only parent users can create additional accounts."
+#: src/Model/Profile.php:367 src/Module/Directory.php:161
+#: src/Module/Profile/Profile.php:180
+msgid "Homepage:"
 msgstr ""
 
-#: src/Module/Register.php:101
-msgid ""
-"You may (optionally) fill in this form via OpenID by supplying your OpenID "
-"and clicking \"Register\"."
+#: src/Model/Profile.php:368 src/Module/Contact.php:626
+#: src/Module/Notifications/Introductions.php:168
+msgid "About:"
 msgstr ""
 
-#: src/Module/Register.php:102
-msgid ""
-"If you are not familiar with OpenID, please leave that field blank and fill "
-"in the rest of the items."
+#: src/Model/Profile.php:369 src/Module/Contact.php:624
+#: src/Module/Profile/Profile.php:176
+msgid "XMPP:"
 msgstr ""
 
-#: src/Module/Register.php:103
-msgid "Your OpenID (optional): "
-msgstr ""
-
-#: src/Module/Register.php:112
-msgid "Include your profile in member directory?"
-msgstr ""
-
-#: src/Module/Register.php:135
-msgid "Note for the admin"
-msgstr ""
-
-#: src/Module/Register.php:135
-msgid "Leave a message for the admin, why you want to join this node"
-msgstr ""
-
-#: src/Module/Register.php:136
-msgid "Membership on this site is by invitation only."
-msgstr ""
-
-#: src/Module/Register.php:137
-msgid "Your invitation code: "
-msgstr ""
-
-#: src/Module/Register.php:139 src/Module/Admin/Site.php:591
-msgid "Registration"
-msgstr ""
-
-#: src/Module/Register.php:145
-msgid "Your Full Name (e.g. Joe Smith, real or real-looking): "
-msgstr ""
-
-#: src/Module/Register.php:146
-msgid ""
-"Your Email Address: (Initial information will be send there, so this has to "
-"be an existing address.)"
-msgstr ""
-
-#: src/Module/Register.php:147
-msgid "Please repeat your e-mail address:"
-msgstr ""
-
-#: src/Module/Register.php:149
-msgid "Leave empty for an auto generated password."
-msgstr ""
-
-#: src/Module/Register.php:151
-#, php-format
-msgid ""
-"Choose a profile nickname. This must begin with a text character. Your "
-"profile address on this site will then be \"<strong>nickname@%s</strong>\"."
-msgstr ""
-
-#: src/Module/Register.php:152
-msgid "Choose a nickname: "
-msgstr ""
-
-#: src/Module/Register.php:161
-msgid "Import your profile to this friendica instance"
-msgstr ""
-
-#: src/Module/Register.php:163 src/Module/BaseAdmin.php:102
-#: src/Module/Tos.php:84 src/Module/Admin/Tos.php:59 src/Content/Nav.php:256
-msgid "Terms of Service"
-msgstr ""
-
-#: src/Module/Register.php:168
-msgid "Note: This node explicitly contains adult content"
-msgstr ""
-
-#: src/Module/Register.php:170 src/Module/Settings/Delegation.php:155
-msgid "Parent Password:"
-msgstr ""
-
-#: src/Module/Register.php:170 src/Module/Settings/Delegation.php:155
-msgid ""
-"Please enter the password of the parent account to legitimize your request."
-msgstr ""
-
-#: src/Module/Register.php:201
-msgid "Password doesn't match."
-msgstr ""
-
-#: src/Module/Register.php:207
-msgid "Please enter your password."
-msgstr ""
-
-#: src/Module/Register.php:249
-msgid "You have entered too much information."
-msgstr ""
-
-#: src/Module/Register.php:273
-msgid "Please enter the identical mail address in the second field."
-msgstr ""
-
-#: src/Module/Register.php:300
-msgid "The additional account was created."
-msgstr ""
-
-#: src/Module/Register.php:325
-msgid ""
-"Registration successful. Please check your email for further instructions."
-msgstr ""
-
-#: src/Module/Register.php:329
-#, php-format
-msgid ""
-"Failed to send email message. Here your accout details:<br> login: %s<br> "
-"password: %s<br><br>You can change your password after login."
-msgstr ""
-
-#: src/Module/Register.php:335
-msgid "Registration successful."
-msgstr ""
-
-#: src/Module/Register.php:340 src/Module/Register.php:347
-msgid "Your registration can not be processed."
-msgstr ""
-
-#: src/Module/Register.php:346
-msgid "You have to leave a request note for the admin."
-msgstr ""
-
-#: src/Module/Register.php:394
-msgid "Your registration is pending approval by the site owner."
-msgstr ""
-
-#: src/Module/Special/HTTPException.php:49
-msgid "Bad Request"
-msgstr ""
-
-#: src/Module/Special/HTTPException.php:50
-msgid "Unauthorized"
-msgstr ""
-
-#: src/Module/Special/HTTPException.php:51
-msgid "Forbidden"
-msgstr ""
-
-#: src/Module/Special/HTTPException.php:52
-msgid "Not Found"
-msgstr ""
-
-#: src/Module/Special/HTTPException.php:53
-msgid "Internal Server Error"
-msgstr ""
-
-#: src/Module/Special/HTTPException.php:54
-msgid "Service Unavailable"
-msgstr ""
-
-#: src/Module/Special/HTTPException.php:61
-msgid ""
-"The server cannot or will not process the request due to an apparent client "
-"error."
-msgstr ""
-
-#: src/Module/Special/HTTPException.php:62
-msgid "Authentication is required and has failed or has not yet been provided."
-msgstr ""
-
-#: src/Module/Special/HTTPException.php:63
-msgid ""
-"The request was valid, but the server is refusing action. The user might not "
-"have the necessary permissions for a resource, or may need an account."
-msgstr ""
-
-#: src/Module/Special/HTTPException.php:64
-msgid ""
-"The requested resource could not be found but may be available in the future."
-msgstr ""
-
-#: src/Module/Special/HTTPException.php:65
-msgid ""
-"An unexpected condition was encountered and no more specific message is "
-"suitable."
-msgstr ""
-
-#: src/Module/Special/HTTPException.php:66
-msgid ""
-"The server is currently unavailable (because it is overloaded or down for "
-"maintenance). Please try again later."
-msgstr ""
-
-#: src/Module/Special/HTTPException.php:72 src/Content/Nav.php:94
-msgid "Go back"
-msgstr ""
-
-#: src/Module/Home.php:54
-#, php-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: src/Module/FriendSuggest.php:65
-msgid "Suggested contact not found."
-msgstr ""
-
-#: src/Module/FriendSuggest.php:84
-msgid "Friend suggestion sent."
-msgstr ""
-
-#: src/Module/FriendSuggest.php:121
-msgid "Suggest Friends"
-msgstr ""
-
-#: src/Module/FriendSuggest.php:124
-#, php-format
-msgid "Suggest a friend for %s"
-msgstr ""
-
-#: src/Module/Credits.php:44
-msgid "Credits"
-msgstr ""
-
-#: src/Module/Credits.php:45
-msgid ""
-"Friendica is a community project, that would not be possible without the "
-"help of many people. Here is a list of those who have contributed to the "
-"code or the translation of Friendica. Thank you all!"
-msgstr ""
-
-#: src/Module/Install.php:177
-msgid "Friendica Communications Server - Setup"
-msgstr ""
-
-#: src/Module/Install.php:188
-msgid "System check"
-msgstr ""
-
-#: src/Module/Install.php:193
-msgid "Check again"
-msgstr ""
-
-#: src/Module/Install.php:200 src/Module/Admin/Site.php:524
-msgid "No SSL policy, links will track page SSL state"
-msgstr ""
-
-#: src/Module/Install.php:201 src/Module/Admin/Site.php:525
-msgid "Force all links to use SSL"
-msgstr ""
-
-#: src/Module/Install.php:202 src/Module/Admin/Site.php:526
-msgid "Self-signed certificate, use SSL for local links only (discouraged)"
-msgstr ""
-
-#: src/Module/Install.php:208
-msgid "Base settings"
-msgstr ""
-
-#: src/Module/Install.php:210 src/Module/Admin/Site.php:615
-msgid "SSL link policy"
-msgstr ""
-
-#: src/Module/Install.php:212 src/Module/Admin/Site.php:615
-msgid "Determines whether generated links should be forced to use SSL"
-msgstr ""
-
-#: src/Module/Install.php:215
-msgid "Host name"
-msgstr ""
-
-#: src/Module/Install.php:217
-msgid ""
-"Overwrite this field in case the determinated hostname isn't right, "
-"otherweise leave it as is."
-msgstr ""
-
-#: src/Module/Install.php:220
-msgid "Base path to installation"
-msgstr ""
-
-#: src/Module/Install.php:222
-msgid ""
-"If the system cannot detect the correct path to your installation, enter the "
-"correct path here. This setting should only be set if you are using a "
-"restricted system and symbolic links to your webroot."
-msgstr ""
-
-#: src/Module/Install.php:225
-msgid "Sub path of the URL"
-msgstr ""
-
-#: src/Module/Install.php:227
-msgid ""
-"Overwrite this field in case the sub path determination isn't right, "
-"otherwise leave it as is. Leaving this field blank means the installation is "
-"at the base URL without sub path."
-msgstr ""
-
-#: src/Module/Install.php:238
-msgid "Database connection"
-msgstr ""
-
-#: src/Module/Install.php:239
-msgid ""
-"In order to install Friendica we need to know how to connect to your "
-"database."
-msgstr ""
-
-#: src/Module/Install.php:240
-msgid ""
-"Please contact your hosting provider or site administrator if you have "
-"questions about these settings."
-msgstr ""
-
-#: src/Module/Install.php:241
-msgid ""
-"The database you specify below should already exist. If it does not, please "
-"create it before continuing."
-msgstr ""
-
-#: src/Module/Install.php:248
-msgid "Database Server Name"
-msgstr ""
-
-#: src/Module/Install.php:253
-msgid "Database Login Name"
-msgstr ""
-
-#: src/Module/Install.php:259
-msgid "Database Login Password"
-msgstr ""
-
-#: src/Module/Install.php:261
-msgid "For security reasons the password must not be empty"
-msgstr ""
-
-#: src/Module/Install.php:264
-msgid "Database Name"
-msgstr ""
-
-#: src/Module/Install.php:268 src/Module/Install.php:297
-msgid "Please select a default timezone for your website"
-msgstr ""
-
-#: src/Module/Install.php:282
-msgid "Site settings"
-msgstr ""
-
-#: src/Module/Install.php:292
-msgid "Site administrator email address"
-msgstr ""
-
-#: src/Module/Install.php:294
-msgid ""
-"Your account email address must match this in order to use the web admin "
-"panel."
-msgstr ""
-
-#: src/Module/Install.php:301
-msgid "System Language:"
-msgstr ""
-
-#: src/Module/Install.php:303
-msgid ""
-"Set the default language for your Friendica installation interface and to "
-"send emails."
-msgstr ""
-
-#: src/Module/Install.php:315
-msgid "Your Friendica site database has been installed."
-msgstr ""
-
-#: src/Module/Install.php:323
-msgid "Installation finished"
-msgstr ""
-
-#: src/Module/Install.php:343
-msgid "<h1>What next</h1>"
-msgstr ""
-
-#: src/Module/Install.php:344
-msgid ""
-"IMPORTANT: You will need to [manually] setup a scheduled task for the worker."
-msgstr ""
-
-#: src/Module/Install.php:345
-msgid "Please see the file \"INSTALL.txt\"."
-msgstr ""
-
-#: src/Module/Install.php:347
-#, php-format
-msgid ""
-"Go to your new Friendica node <a href=\"%s/register\">registration page</a> "
-"and register as new user. Remember to use the same email you have entered as "
-"administrator email. This will allow you to enter the site admin panel."
-msgstr ""
-
-#: src/Module/Filer/SaveTag.php:65
-msgid "- select -"
-msgstr ""
-
-#: src/Module/Filer/RemoveTag.php:63
-msgid "Item was not removed"
-msgstr ""
-
-#: src/Module/Filer/RemoveTag.php:66
-msgid "Item was not deleted"
-msgstr ""
-
-#: src/Module/PermissionTooltip.php:24
-#, php-format
-msgid "Wrong type \"%s\", expected one of: %s"
-msgstr ""
-
-#: src/Module/PermissionTooltip.php:37
-msgid "Model not found"
-msgstr ""
-
-#: src/Module/PermissionTooltip.php:59
-msgid "Remote privacy information not available."
-msgstr ""
-
-#: src/Module/PermissionTooltip.php:70
-msgid "Visible to:"
-msgstr ""
-
-#: src/Module/Delegation.php:147
-msgid "Manage Identities and/or Pages"
-msgstr ""
-
-#: src/Module/Delegation.php:148
-msgid ""
-"Toggle between different identities or community/group pages which share "
-"your account details or which you have been granted \"manage\" permissions"
-msgstr ""
-
-#: src/Module/Delegation.php:149
-msgid "Select an identity to manage: "
-msgstr ""
-
-#: src/Module/Conversation/Community.php:56
-msgid "Local Community"
-msgstr ""
-
-#: src/Module/Conversation/Community.php:59
-msgid "Posts from local users on this server"
-msgstr ""
-
-#: src/Module/Conversation/Community.php:67
-msgid "Global Community"
-msgstr ""
-
-#: src/Module/Conversation/Community.php:70
-msgid "Posts from users of the whole federated network"
-msgstr ""
-
-#: src/Module/Conversation/Community.php:84 src/Module/Search/Index.php:179
-msgid "No results."
-msgstr ""
-
-#: src/Module/Conversation/Community.php:125
-msgid ""
-"This community stream shows all public posts received by this node. They may "
-"not reflect the opinions of this node’s users."
-msgstr ""
-
-#: src/Module/Conversation/Community.php:178
-msgid "Community option not available."
-msgstr ""
-
-#: src/Module/Conversation/Community.php:194
-msgid "Not available."
-msgstr ""
-
-#: src/Module/Welcome.php:44
-msgid "Welcome to Friendica"
-msgstr ""
-
-#: src/Module/Welcome.php:45
-msgid "New Member Checklist"
-msgstr ""
-
-#: src/Module/Welcome.php:46
-msgid ""
-"We would like to offer some tips and links to help make your experience "
-"enjoyable. Click any item to visit the relevant page. A link to this page "
-"will be visible from your home page for two weeks after your initial "
-"registration and then will quietly disappear."
-msgstr ""
-
-#: src/Module/Welcome.php:48
-msgid "Getting Started"
-msgstr ""
-
-#: src/Module/Welcome.php:49
-msgid "Friendica Walk-Through"
-msgstr ""
-
-#: src/Module/Welcome.php:50
-msgid ""
-"On your <em>Quick Start</em> page - find a brief introduction to your "
-"profile and network tabs, make some new connections, and find some groups to "
-"join."
-msgstr ""
-
-#: src/Module/Welcome.php:53
-msgid "Go to Your Settings"
-msgstr ""
-
-#: src/Module/Welcome.php:54
-msgid ""
-"On your <em>Settings</em> page -  change your initial password. Also make a "
-"note of your Identity Address. This looks just like an email address - and "
-"will be useful in making friends on the free social web."
-msgstr ""
-
-#: src/Module/Welcome.php:55
-msgid ""
-"Review the other settings, particularly the privacy settings. An unpublished "
-"directory listing is like having an unlisted phone number. In general, you "
-"should probably publish your listing - unless all of your friends and "
-"potential friends know exactly how to find you."
-msgstr ""
-
-#: src/Module/Welcome.php:58 src/Module/Settings/Profile/Index.php:248
-msgid "Upload Profile Photo"
-msgstr ""
-
-#: src/Module/Welcome.php:59
-msgid ""
-"Upload a profile photo if you have not done so already. Studies have shown "
-"that people with real photos of themselves are ten times more likely to make "
-"friends than people who do not."
-msgstr ""
-
-#: src/Module/Welcome.php:60
-msgid "Edit Your Profile"
-msgstr ""
-
-#: src/Module/Welcome.php:61
-msgid ""
-"Edit your <strong>default</strong> profile to your liking. Review the "
-"settings for hiding your list of friends and hiding the profile from unknown "
-"visitors."
-msgstr ""
-
-#: src/Module/Welcome.php:62
-msgid "Profile Keywords"
-msgstr ""
-
-#: src/Module/Welcome.php:63
-msgid ""
-"Set some public keywords for your profile which describe your interests. We "
-"may be able to find other people with similar interests and suggest "
-"friendships."
-msgstr ""
-
-#: src/Module/Welcome.php:65
-msgid "Connecting"
-msgstr ""
-
-#: src/Module/Welcome.php:67
-msgid "Importing Emails"
-msgstr ""
-
-#: src/Module/Welcome.php:68
-msgid ""
-"Enter your email access information on your Connector Settings page if you "
-"wish to import and interact with friends or mailing lists from your email "
-"INBOX"
-msgstr ""
-
-#: src/Module/Welcome.php:69
-msgid "Go to Your Contacts Page"
-msgstr ""
-
-#: src/Module/Welcome.php:70
-msgid ""
-"Your Contacts page is your gateway to managing friendships and connecting "
-"with friends on other networks. Typically you enter their address or site "
-"URL in the <em>Add New Contact</em> dialog."
-msgstr ""
-
-#: src/Module/Welcome.php:71
-msgid "Go to Your Site's Directory"
-msgstr ""
-
-#: src/Module/Welcome.php:72
-msgid ""
-"The Directory page lets you find other people in this network or other "
-"federated sites. Look for a <em>Connect</em> or <em>Follow</em> link on "
-"their profile page. Provide your own Identity Address if requested."
-msgstr ""
-
-#: src/Module/Welcome.php:73
-msgid "Finding New People"
-msgstr ""
-
-#: src/Module/Welcome.php:74
-msgid ""
-"On the side panel of the Contacts page are several tools to find new "
-"friends. We can match people by interest, look up people by name or "
-"interest, and provide suggestions based on network relationships. On a brand "
-"new site, friend suggestions will usually begin to be populated within 24 "
-"hours."
-msgstr ""
-
-#: src/Module/Welcome.php:76 src/Module/Contact.php:803 src/Model/Group.php:528
-#: src/Content/Widget.php:217
-msgid "Groups"
-msgstr ""
-
-#: src/Module/Welcome.php:77
-msgid "Group Your Contacts"
-msgstr ""
-
-#: src/Module/Welcome.php:78
-msgid ""
-"Once you have made some friends, organize them into private conversation "
-"groups from the sidebar of your Contacts page and then you can interact with "
-"each group privately on your Network page."
-msgstr ""
-
-#: src/Module/Welcome.php:80
-msgid "Why Aren't My Posts Public?"
-msgstr ""
-
-#: src/Module/Welcome.php:81
-msgid ""
-"Friendica respects your privacy. By default, your posts will only show up to "
-"people you've added as friends. For more information, see the help section "
-"from the link above."
-msgstr ""
-
-#: src/Module/Welcome.php:83
-msgid "Getting Help"
-msgstr ""
-
-#: src/Module/Welcome.php:84
-msgid "Go to the Help Section"
-msgstr ""
-
-#: src/Module/Welcome.php:85
-msgid ""
-"Our <strong>help</strong> pages may be consulted for detail on other program "
-"features and resources."
-msgstr ""
-
-#: src/Module/Bookmarklet.php:56
-msgid "This page is missing a url parameter."
-msgstr ""
-
-#: src/Module/Bookmarklet.php:78
-msgid "The post was created"
-msgstr ""
-
-#: src/Module/BaseAdmin.php:79
-msgid ""
-"Submanaged account can't access the administation pages. Please log back in "
-"as the main account."
-msgstr ""
-
-#: src/Module/BaseAdmin.php:92 src/Content/Nav.php:253
-msgid "Information"
-msgstr ""
-
-#: src/Module/BaseAdmin.php:93
-msgid "Overview"
-msgstr ""
-
-#: src/Module/BaseAdmin.php:94 src/Module/Admin/Federation.php:141
-msgid "Federation Statistics"
-msgstr ""
-
-#: src/Module/BaseAdmin.php:96
-msgid "Configuration"
-msgstr ""
-
-#: src/Module/BaseAdmin.php:97 src/Module/Admin/Site.php:588
-msgid "Site"
-msgstr ""
-
-#: src/Module/BaseAdmin.php:98 src/Module/Admin/Users.php:243
-#: src/Module/Admin/Users.php:260
-msgid "Users"
-msgstr ""
-
-#: src/Module/BaseAdmin.php:99 src/Module/Admin/Addons/Details.php:117
-#: src/Module/Admin/Addons/Index.php:68 src/Module/BaseSettings.php:87
-msgid "Addons"
-msgstr ""
-
-#: src/Module/BaseAdmin.php:100 src/Module/Admin/Themes/Details.php:122
-#: src/Module/Admin/Themes/Index.php:112
-msgid "Themes"
-msgstr ""
-
-#: src/Module/BaseAdmin.php:101 src/Module/BaseSettings.php:65
-msgid "Additional features"
-msgstr ""
-
-#: src/Module/BaseAdmin.php:104
-msgid "Database"
-msgstr ""
-
-#: src/Module/BaseAdmin.php:105
-msgid "DB updates"
-msgstr ""
-
-#: src/Module/BaseAdmin.php:106
-msgid "Inspect Deferred Workers"
-msgstr ""
-
-#: src/Module/BaseAdmin.php:107
-msgid "Inspect worker Queue"
-msgstr ""
-
-#: src/Module/BaseAdmin.php:109
-msgid "Tools"
-msgstr ""
-
-#: src/Module/BaseAdmin.php:110
-msgid "Contact Blocklist"
-msgstr ""
-
-#: src/Module/BaseAdmin.php:111
-msgid "Server Blocklist"
-msgstr ""
-
-#: src/Module/BaseAdmin.php:112 src/Module/Admin/Item/Delete.php:66
-msgid "Delete Item"
-msgstr ""
-
-#: src/Module/BaseAdmin.php:114 src/Module/BaseAdmin.php:115
-#: src/Module/Admin/Logs/Settings.php:79
-msgid "Logs"
-msgstr ""
-
-#: src/Module/BaseAdmin.php:116 src/Module/Admin/Logs/View.php:65
-msgid "View Logs"
-msgstr ""
-
-#: src/Module/BaseAdmin.php:118
-msgid "Diagnostics"
-msgstr ""
-
-#: src/Module/BaseAdmin.php:119
-msgid "PHP Info"
-msgstr ""
-
-#: src/Module/BaseAdmin.php:120
-msgid "probe address"
-msgstr ""
-
-#: src/Module/BaseAdmin.php:121
-msgid "check webfinger"
-msgstr ""
-
-#: src/Module/BaseAdmin.php:122
-msgid "Item Source"
-msgstr ""
-
-#: src/Module/BaseAdmin.php:123
-msgid "Babel"
-msgstr ""
-
-#: src/Module/BaseAdmin.php:124
-msgid "ActivityPub Conversion"
-msgstr ""
-
-#: src/Module/BaseAdmin.php:132 src/Content/Nav.php:289
-msgid "Admin"
-msgstr ""
-
-#: src/Module/BaseAdmin.php:133
-msgid "Addon Features"
-msgstr ""
-
-#: src/Module/BaseAdmin.php:134
-msgid "User registrations waiting for confirmation"
-msgstr ""
-
-#: src/Module/Contact.php:93
-#, php-format
-msgid "%d contact edited."
-msgid_plural "%d contacts edited."
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/Module/Contact.php:120
-msgid "Could not access contact record."
-msgstr ""
-
-#: src/Module/Contact.php:328 src/Model/Profile.php:448
-#: src/Content/Text/HTML.php:896
-msgid "Follow"
-msgstr ""
-
-#: src/Module/Contact.php:330 src/Model/Profile.php:450
+#: src/Model/Profile.php:450 src/Module/Contact.php:330
 msgid "Unfollow"
 msgstr ""
 
-#: src/Module/Contact.php:386 src/Module/Api/Twitter/ContactEndpoint.php:65
-msgid "Contact not found"
+#: src/Model/Profile.php:452
+msgid "Atom feed"
 msgstr ""
 
-#: src/Module/Contact.php:405
-msgid "Contact has been blocked"
+#: src/Model/Profile.php:460 src/Module/Contact.php:326
+#: src/Module/Notifications/Introductions.php:180
+msgid "Network:"
 msgstr ""
 
-#: src/Module/Contact.php:405
-msgid "Contact has been unblocked"
+#: src/Model/Profile.php:490 src/Model/Profile.php:587
+msgid "g A l F d"
 msgstr ""
 
-#: src/Module/Contact.php:415
-msgid "Contact has been ignored"
+#: src/Model/Profile.php:491
+msgid "F d"
 msgstr ""
 
-#: src/Module/Contact.php:415
-msgid "Contact has been unignored"
+#: src/Model/Profile.php:553 src/Model/Profile.php:638
+msgid "[today]"
 msgstr ""
 
-#: src/Module/Contact.php:425
-msgid "Contact has been archived"
+#: src/Model/Profile.php:563
+msgid "Birthday Reminders"
 msgstr ""
 
-#: src/Module/Contact.php:425
-msgid "Contact has been unarchived"
+#: src/Model/Profile.php:564
+msgid "Birthdays this week:"
 msgstr ""
 
-#: src/Module/Contact.php:449
-msgid "Drop contact"
+#: src/Model/Profile.php:625
+msgid "[No description]"
 msgstr ""
 
-#: src/Module/Contact.php:452 src/Module/Contact.php:843
-msgid "Do you really want to delete this contact?"
+#: src/Model/Profile.php:651
+msgid "Event Reminders"
 msgstr ""
 
-#: src/Module/Contact.php:466
-msgid "Contact has been removed."
+#: src/Model/Profile.php:652
+msgid "Upcoming events the next 7 days:"
 msgstr ""
 
-#: src/Module/Contact.php:494
+#: src/Model/Profile.php:827
 #, php-format
-msgid "You are mutual friends with %s"
+msgid "OpenWebAuth: %1$s welcomes %2$s"
 msgstr ""
 
-#: src/Module/Contact.php:498
+#: src/Model/Storage/Database.php:74
 #, php-format
-msgid "You are sharing with %s"
+msgid "Database storage failed to update %s"
 msgstr ""
 
-#: src/Module/Contact.php:502
-#, php-format
-msgid "%s is sharing with you"
+#: src/Model/Storage/Database.php:82
+msgid "Database storage failed to insert data"
 msgstr ""
 
-#: src/Module/Contact.php:526
-msgid "Private communications are not available for this contact."
-msgstr ""
-
-#: src/Module/Contact.php:528
-msgid "Never"
-msgstr ""
-
-#: src/Module/Contact.php:531
-msgid "(Update was successful)"
-msgstr ""
-
-#: src/Module/Contact.php:531
-msgid "(Update was not successful)"
-msgstr ""
-
-#: src/Module/Contact.php:533 src/Module/Contact.php:1099
-msgid "Suggest friends"
-msgstr ""
-
-#: src/Module/Contact.php:537
-#, php-format
-msgid "Network type: %s"
-msgstr ""
-
-#: src/Module/Contact.php:542
-msgid "Communications lost with this contact!"
-msgstr ""
-
-#: src/Module/Contact.php:548
-msgid "Fetch further information for feeds"
-msgstr ""
-
-#: src/Module/Contact.php:550
-msgid ""
-"Fetch information like preview pictures, title and teaser from the feed "
-"item. You can activate this if the feed doesn't contain much text. Keywords "
-"are taken from the meta header in the feed item and are posted as hash tags."
-msgstr ""
-
-#: src/Module/Contact.php:552 src/Module/Admin/Site.php:693
-#: src/Module/Admin/Site.php:703 src/Module/Settings/TwoFactor/Index.php:113
-msgid "Disabled"
-msgstr ""
-
-#: src/Module/Contact.php:553
-msgid "Fetch information"
-msgstr ""
-
-#: src/Module/Contact.php:554
-msgid "Fetch keywords"
-msgstr ""
-
-#: src/Module/Contact.php:555
-msgid "Fetch information and keywords"
-msgstr ""
-
-#: src/Module/Contact.php:569
-msgid "Contact Information / Notes"
-msgstr ""
-
-#: src/Module/Contact.php:570
-msgid "Contact Settings"
-msgstr ""
-
-#: src/Module/Contact.php:578
-msgid "Contact"
-msgstr ""
-
-#: src/Module/Contact.php:582
-msgid "Their personal note"
-msgstr ""
-
-#: src/Module/Contact.php:584
-msgid "Edit contact notes"
-msgstr ""
-
-#: src/Module/Contact.php:587 src/Module/Contact.php:1067
-#, php-format
-msgid "Visit %s's profile [%s]"
-msgstr ""
-
-#: src/Module/Contact.php:588
-msgid "Block/Unblock contact"
-msgstr ""
-
-#: src/Module/Contact.php:589
-msgid "Ignore contact"
-msgstr ""
-
-#: src/Module/Contact.php:590
-msgid "View conversations"
-msgstr ""
-
-#: src/Module/Contact.php:595
-msgid "Last update:"
-msgstr ""
-
-#: src/Module/Contact.php:597
-msgid "Update public posts"
-msgstr ""
-
-#: src/Module/Contact.php:599 src/Module/Contact.php:1109
-msgid "Update now"
-msgstr ""
-
-#: src/Module/Contact.php:601 src/Module/Contact.php:847
-#: src/Module/Contact.php:1128 src/Module/Admin/Users.php:256
-#: src/Module/Admin/Blocklist/Contact.php:85
-msgid "Unblock"
-msgstr ""
-
-#: src/Module/Contact.php:602 src/Module/Contact.php:848
-#: src/Module/Contact.php:1136
-msgid "Unignore"
-msgstr ""
-
-#: src/Module/Contact.php:606
-msgid "Currently blocked"
-msgstr ""
-
-#: src/Module/Contact.php:607
-msgid "Currently ignored"
-msgstr ""
-
-#: src/Module/Contact.php:608
-msgid "Currently archived"
-msgstr ""
-
-#: src/Module/Contact.php:609
-msgid "Awaiting connection acknowledge"
-msgstr ""
-
-#: src/Module/Contact.php:610
-msgid ""
-"Replies/likes to your public posts <strong>may</strong> still be visible"
-msgstr ""
-
-#: src/Module/Contact.php:611
-msgid "Notification for new posts"
-msgstr ""
-
-#: src/Module/Contact.php:611
-msgid "Send a notification of every new post of this contact"
-msgstr ""
-
-#: src/Module/Contact.php:613
-msgid "Keyword Deny List"
-msgstr ""
-
-#: src/Module/Contact.php:613
-msgid ""
-"Comma separated list of keywords that should not be converted to hashtags, "
-"when \"Fetch information and keywords\" is selected"
-msgstr ""
-
-#: src/Module/Contact.php:629 src/Module/Settings/TwoFactor/Index.php:127
-msgid "Actions"
-msgstr ""
-
-#: src/Module/Contact.php:755 src/Module/Group.php:292
-#: src/Content/Widget.php:250
-msgid "All Contacts"
-msgstr ""
-
-#: src/Module/Contact.php:758
-msgid "Show all contacts"
-msgstr ""
-
-#: src/Module/Contact.php:763 src/Module/Contact.php:823
-msgid "Pending"
-msgstr ""
-
-#: src/Module/Contact.php:766
-msgid "Only show pending contacts"
-msgstr ""
-
-#: src/Module/Contact.php:771 src/Module/Contact.php:824
-msgid "Blocked"
-msgstr ""
-
-#: src/Module/Contact.php:774
-msgid "Only show blocked contacts"
-msgstr ""
-
-#: src/Module/Contact.php:779 src/Module/Contact.php:826
-msgid "Ignored"
-msgstr ""
-
-#: src/Module/Contact.php:782
-msgid "Only show ignored contacts"
-msgstr ""
-
-#: src/Module/Contact.php:787 src/Module/Contact.php:827
-msgid "Archived"
-msgstr ""
-
-#: src/Module/Contact.php:790
-msgid "Only show archived contacts"
-msgstr ""
-
-#: src/Module/Contact.php:795 src/Module/Contact.php:825
-msgid "Hidden"
-msgstr ""
-
-#: src/Module/Contact.php:798
-msgid "Only show hidden contacts"
-msgstr ""
-
-#: src/Module/Contact.php:806
-msgid "Organize your contact groups"
-msgstr ""
-
-#: src/Module/Contact.php:817 src/Content/Widget.php:242 src/BaseModule.php:189
-msgid "Following"
-msgstr ""
-
-#: src/Module/Contact.php:818 src/Content/Widget.php:243 src/BaseModule.php:194
-msgid "Mutual friends"
-msgstr ""
-
-#: src/Module/Contact.php:838
-msgid "Search your contacts"
-msgstr ""
-
-#: src/Module/Contact.php:839 src/Module/Search/Index.php:186
-#, php-format
-msgid "Results for: %s"
-msgstr ""
-
-#: src/Module/Contact.php:849 src/Module/Contact.php:1145
-msgid "Archive"
-msgstr ""
-
-#: src/Module/Contact.php:849 src/Module/Contact.php:1145
-msgid "Unarchive"
-msgstr ""
-
-#: src/Module/Contact.php:852
-msgid "Batch Actions"
-msgstr ""
-
-#: src/Module/Contact.php:887
-msgid "Conversations started by this contact"
-msgstr ""
-
-#: src/Module/Contact.php:892
-msgid "Posts and Comments"
-msgstr ""
-
-#: src/Module/Contact.php:903 src/Module/BaseProfile.php:55
-msgid "Profile Details"
-msgstr ""
-
-#: src/Module/Contact.php:910
-msgid "View all known contacts"
-msgstr ""
-
-#: src/Module/Contact.php:920
-msgid "Advanced Contact Settings"
-msgstr ""
-
-#: src/Module/Contact.php:1026
-msgid "Mutual Friendship"
-msgstr ""
-
-#: src/Module/Contact.php:1030
-msgid "is a fan of yours"
-msgstr ""
-
-#: src/Module/Contact.php:1034
-msgid "you are a fan of"
-msgstr ""
-
-#: src/Module/Contact.php:1052
-msgid "Pending outgoing contact request"
-msgstr ""
-
-#: src/Module/Contact.php:1054
-msgid "Pending incoming contact request"
-msgstr ""
-
-#: src/Module/Contact.php:1119 src/Module/Contact/Advanced.php:138
-msgid "Refetch contact data"
-msgstr ""
-
-#: src/Module/Contact.php:1130
-msgid "Toggle Blocked status"
-msgstr ""
-
-#: src/Module/Contact.php:1138
-msgid "Toggle Ignored status"
-msgstr ""
-
-#: src/Module/Contact.php:1147
-msgid "Toggle Archive status"
-msgstr ""
-
-#: src/Module/Contact.php:1155
-msgid "Delete contact"
-msgstr ""
-
-#: src/Module/Tos.php:46 src/Module/Tos.php:88
-msgid ""
-"At the time of registration, and for providing communications between the "
-"user account and their contacts, the user has to provide a display name (pen "
-"name), an username (nickname) and a working email address. The names will be "
-"accessible on the profile page of the account by any visitor of the page, "
-"even if other profile details are not displayed. The email address will only "
-"be used to send the user notifications about interactions, but wont be "
-"visibly displayed. The listing of an account in the node's user directory or "
-"the global user directory is optional and can be controlled in the user "
-"settings, it is not necessary for communication."
-msgstr ""
-
-#: src/Module/Tos.php:47 src/Module/Tos.php:89
-msgid ""
-"This data is required for communication and is passed on to the nodes of the "
-"communication partners and is stored there. Users can enter additional "
-"private data that may be transmitted to the communication partners accounts."
-msgstr ""
-
-#: src/Module/Tos.php:48 src/Module/Tos.php:90
+#: src/Model/Storage/Filesystem.php:100
 #, php-format
 msgid ""
-"At any point in time a logged in user can export their account data from the "
-"<a href=\"%1$s/settings/userexport\">account settings</a>. If the user wants "
-"to delete their account they can do so at <a href=\"%1$s/removeme\">%1$s/"
-"removeme</a>. The deletion of the account will be permanent. Deletion of the "
-"data will also be requested from the nodes of the communication partners."
+"Filesystem storage failed to create \"%s\". Check you write permissions."
 msgstr ""
 
-#: src/Module/Tos.php:51 src/Module/Tos.php:87
-msgid "Privacy Statement"
-msgstr ""
-
-#: src/Module/Help.php:62
-msgid "Help:"
-msgstr ""
-
-#: src/Module/HTTPException/MethodNotAllowed.php:32
-msgid "Method Not Allowed."
-msgstr ""
-
-#: src/Module/Api/Twitter/ContactEndpoint.php:135
-msgid "Profile not found"
-msgstr ""
-
-#: src/Module/Invite.php:55
-msgid "Total invitation limit exceeded."
-msgstr ""
-
-#: src/Module/Invite.php:78
+#: src/Model/Storage/Filesystem.php:148
 #, php-format
-msgid "%s : Not a valid email address."
+msgid ""
+"Filesystem storage failed to save data to \"%s\". Check your write "
+"permissions"
 msgstr ""
 
-#: src/Module/Invite.php:105
-msgid "Please join us on Friendica"
+#: src/Model/Storage/Filesystem.php:176
+msgid "Storage base path"
 msgstr ""
 
-#: src/Module/Invite.php:114
-msgid "Invitation limit exceeded. Please contact your site administrator."
+#: src/Model/Storage/Filesystem.php:178
+msgid ""
+"Folder where uploaded files are saved. For maximum security, This should be "
+"a path outside web server folder tree"
 msgstr ""
 
-#: src/Module/Invite.php:118
+#: src/Model/Storage/Filesystem.php:191
+msgid "Enter a valid existing folder"
+msgstr ""
+
+#: src/Model/User.php:141 src/Model/User.php:885
+msgid "SERIOUS ERROR: Generation of security keys failed."
+msgstr ""
+
+#: src/Model/User.php:503
+msgid "Login failed"
+msgstr ""
+
+#: src/Model/User.php:535
+msgid "Not enough information to authenticate"
+msgstr ""
+
+#: src/Model/User.php:630
+msgid "Password can't be empty"
+msgstr ""
+
+#: src/Model/User.php:649
+msgid "Empty passwords are not allowed."
+msgstr ""
+
+#: src/Model/User.php:653
+msgid ""
+"The new password has been exposed in a public data dump, please choose "
+"another."
+msgstr ""
+
+#: src/Model/User.php:659
+msgid ""
+"The password can't contain accentuated letters, white spaces or colons (:)"
+msgstr ""
+
+#: src/Model/User.php:765
+msgid "Passwords do not match. Password unchanged."
+msgstr ""
+
+#: src/Model/User.php:772
+msgid "An invitation is required."
+msgstr ""
+
+#: src/Model/User.php:776
+msgid "Invitation could not be verified."
+msgstr ""
+
+#: src/Model/User.php:784
+msgid "Invalid OpenID url"
+msgstr ""
+
+#: src/Model/User.php:803
+msgid "Please enter the required information."
+msgstr ""
+
+#: src/Model/User.php:817
 #, php-format
-msgid "%s : Message delivery failed."
+msgid ""
+"system.username_min_length (%s) and system.username_max_length (%s) are "
+"excluding each other, swapping values."
 msgstr ""
 
-#: src/Module/Invite.php:122
+#: src/Model/User.php:824
 #, php-format
-msgid "%d message sent."
-msgid_plural "%d messages sent."
+msgid "Username should be at least %s character."
+msgid_plural "Username should be at least %s characters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Module/Invite.php:140
-msgid "You have no more invitations available"
+#: src/Model/User.php:828
+#, php-format
+msgid "Username should be at most %s character."
+msgid_plural "Username should be at most %s characters."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/Model/User.php:836
+msgid "That doesn't appear to be your full (First Last) name."
 msgstr ""
 
-#: src/Module/Invite.php:147
+#: src/Model/User.php:841
+msgid "Your email domain is not among those allowed on this site."
+msgstr ""
+
+#: src/Model/User.php:845
+msgid "Not a valid email address."
+msgstr ""
+
+#: src/Model/User.php:848
+msgid "The nickname was blocked from registration by the nodes admin."
+msgstr ""
+
+#: src/Model/User.php:852 src/Model/User.php:860
+msgid "Cannot use that email."
+msgstr ""
+
+#: src/Model/User.php:867
+msgid "Your nickname can only contain a-z, 0-9 and _."
+msgstr ""
+
+#: src/Model/User.php:875 src/Model/User.php:932
+msgid "Nickname is already registered. Please choose another."
+msgstr ""
+
+#: src/Model/User.php:919 src/Model/User.php:923
+msgid "An error occurred during registration. Please try again."
+msgstr ""
+
+#: src/Model/User.php:946
+msgid "An error occurred creating your default profile. Please try again."
+msgstr ""
+
+#: src/Model/User.php:953
+msgid "An error occurred creating your self contact. Please try again."
+msgstr ""
+
+#: src/Model/User.php:958
+msgid "Friends"
+msgstr ""
+
+#: src/Model/User.php:962
+msgid ""
+"An error occurred creating your default contact group. Please try again."
+msgstr ""
+
+#: src/Model/User.php:1150
 #, php-format
 msgid ""
-"Visit %s for a list of public sites that you can join. Friendica members on "
-"other sites can all connect with each other, as well as with members of many "
-"other social networks."
+"\n"
+"\t\tDear %1$s,\n"
+"\t\t\tthe administrator of %2$s has set up an account for you."
 msgstr ""
 
-#: src/Module/Invite.php:149
+#: src/Model/User.php:1153
 #, php-format
 msgid ""
-"To accept this invitation, please visit and register at %s or any other "
-"public Friendica website."
+"\n"
+"\t\tThe login details are as follows:\n"
+"\n"
+"\t\tSite Location:\t%1$s\n"
+"\t\tLogin Name:\t\t%2$s\n"
+"\t\tPassword:\t\t%3$s\n"
+"\n"
+"\t\tYou may change your password from your account \"Settings\" page after "
+"logging\n"
+"\t\tin.\n"
+"\n"
+"\t\tPlease take a few moments to review the other account settings on that "
+"page.\n"
+"\n"
+"\t\tYou may also wish to add some basic information to your default profile\n"
+"\t\t(on the \"Profiles\" page) so that other people can easily find you.\n"
+"\n"
+"\t\tWe recommend setting your full name, adding a profile photo,\n"
+"\t\tadding some profile \"keywords\" (very useful in making new friends) - "
+"and\n"
+"\t\tperhaps what country you live in; if you do not wish to be more "
+"specific\n"
+"\t\tthan that.\n"
+"\n"
+"\t\tWe fully respect your right to privacy, and none of these items are "
+"necessary.\n"
+"\t\tIf you are new and do not know anybody here, they may help\n"
+"\t\tyou to make some new and interesting friends.\n"
+"\n"
+"\t\tIf you ever want to delete your account, you can do so at %1$s/removeme\n"
+"\n"
+"\t\tThank you and welcome to %4$s."
 msgstr ""
 
-#: src/Module/Invite.php:150
+#: src/Model/User.php:1186 src/Model/User.php:1293
+#, php-format
+msgid "Registration details for %s"
+msgstr ""
+
+#: src/Model/User.php:1206
 #, php-format
 msgid ""
-"Friendica sites all inter-connect to create a huge privacy-enhanced social "
-"web that is owned and controlled by its members. They can also connect with "
-"many traditional social networks. See %s for a list of alternate Friendica "
-"sites you can join."
+"\n"
+"\t\t\tDear %1$s,\n"
+"\t\t\t\tThank you for registering at %2$s. Your account is pending for "
+"approval by the administrator.\n"
+"\n"
+"\t\t\tYour login details are as follows:\n"
+"\n"
+"\t\t\tSite Location:\t%3$s\n"
+"\t\t\tLogin Name:\t\t%4$s\n"
+"\t\t\tPassword:\t\t%5$s\n"
+"\t\t"
 msgstr ""
 
-#: src/Module/Invite.php:154
-msgid ""
-"Our apologies. This system is not currently configured to connect with other "
-"public sites or invite members."
-msgstr ""
-
-#: src/Module/Invite.php:157
-msgid ""
-"Friendica sites all inter-connect to create a huge privacy-enhanced social "
-"web that is owned and controlled by its members. They can also connect with "
-"many traditional social networks."
-msgstr ""
-
-#: src/Module/Invite.php:156
+#: src/Model/User.php:1225
 #, php-format
-msgid "To accept this invitation, please visit and register at %s."
+msgid "Registration at %s"
 msgstr ""
 
-#: src/Module/Invite.php:164
-msgid "Send invitations"
-msgstr ""
-
-#: src/Module/Invite.php:165
-msgid "Enter email addresses, one per line:"
-msgstr ""
-
-#: src/Module/Invite.php:169
-msgid ""
-"You are cordially invited to join me and other close friends on Friendica - "
-"and help us to create a better social web."
-msgstr ""
-
-#: src/Module/Invite.php:171
-msgid "You will need to supply this invitation code: $invite_code"
-msgstr ""
-
-#: src/Module/Invite.php:171
-msgid ""
-"Once you have registered, please connect with me via my profile page at:"
-msgstr ""
-
-#: src/Module/Invite.php:173
-msgid ""
-"For more information about the Friendica project and why we feel it is "
-"important, please visit http://friendi.ca"
-msgstr ""
-
-#: src/Module/BaseSearch.php:69
+#: src/Model/User.php:1249
 #, php-format
-msgid "People Search - %s"
+msgid ""
+"\n"
+"\t\t\t\tDear %1$s,\n"
+"\t\t\t\tThank you for registering at %2$s. Your account has been created.\n"
+"\t\t\t"
 msgstr ""
 
-#: src/Module/BaseSearch.php:79
+#: src/Model/User.php:1257
 #, php-format
-msgid "Forum Search - %s"
+msgid ""
+"\n"
+"\t\t\tThe login details are as follows:\n"
+"\n"
+"\t\t\tSite Location:\t%3$s\n"
+"\t\t\tLogin Name:\t\t%1$s\n"
+"\t\t\tPassword:\t\t%5$s\n"
+"\n"
+"\t\t\tYou may change your password from your account \"Settings\" page after "
+"logging\n"
+"\t\t\tin.\n"
+"\n"
+"\t\t\tPlease take a few moments to review the other account settings on that "
+"page.\n"
+"\n"
+"\t\t\tYou may also wish to add some basic information to your default "
+"profile\n"
+"\t\t\t(on the \"Profiles\" page) so that other people can easily find you.\n"
+"\n"
+"\t\t\tWe recommend setting your full name, adding a profile photo,\n"
+"\t\t\tadding some profile \"keywords\" (very useful in making new friends) - "
+"and\n"
+"\t\t\tperhaps what country you live in; if you do not wish to be more "
+"specific\n"
+"\t\t\tthan that.\n"
+"\n"
+"\t\t\tWe fully respect your right to privacy, and none of these items are "
+"necessary.\n"
+"\t\t\tIf you are new and do not know anybody here, they may help\n"
+"\t\t\tyou to make some new and interesting friends.\n"
+"\n"
+"\t\t\tIf you ever want to delete your account, you can do so at %3$s/"
+"removeme\n"
+"\n"
+"\t\t\tThank you and welcome to %2$s."
 msgstr ""
 
-#: src/Module/Admin/Themes/Details.php:77
+#: src/Module/Admin/Addons/Details.php:70
+msgid "Addon not found."
+msgstr ""
+
+#: src/Module/Admin/Addons/Details.php:81 src/Module/Admin/Addons/Index.php:49
+#, php-format
+msgid "Addon %s disabled."
+msgstr ""
+
+#: src/Module/Admin/Addons/Details.php:84 src/Module/Admin/Addons/Index.php:51
+#, php-format
+msgid "Addon %s enabled."
+msgstr ""
+
 #: src/Module/Admin/Addons/Details.php:93
+#: src/Module/Admin/Themes/Details.php:77
 msgid "Disable"
 msgstr ""
 
-#: src/Module/Admin/Themes/Details.php:80
 #: src/Module/Admin/Addons/Details.php:96
+#: src/Module/Admin/Themes/Details.php:80
 msgid "Enable"
 msgstr ""
 
-#: src/Module/Admin/Themes/Details.php:88 src/Module/Admin/Themes/Index.php:65
-#, php-format
-msgid "Theme %s disabled."
-msgstr ""
-
-#: src/Module/Admin/Themes/Details.php:90 src/Module/Admin/Themes/Index.php:67
-#, php-format
-msgid "Theme %s successfully enabled."
-msgstr ""
-
-#: src/Module/Admin/Themes/Details.php:92 src/Module/Admin/Themes/Index.php:69
-#, php-format
-msgid "Theme %s failed to install."
-msgstr ""
-
-#: src/Module/Admin/Themes/Details.php:114
-msgid "Screenshot"
-msgstr ""
-
-#: src/Module/Admin/Themes/Details.php:121
-#: src/Module/Admin/Themes/Index.php:111 src/Module/Admin/Users.php:242
-#: src/Module/Admin/Queue.php:75 src/Module/Admin/Federation.php:140
-#: src/Module/Admin/Logs/View.php:64 src/Module/Admin/Logs/Settings.php:78
-#: src/Module/Admin/Site.php:587 src/Module/Admin/Summary.php:230
-#: src/Module/Admin/Tos.php:58 src/Module/Admin/Blocklist/Server.php:88
+#: src/Module/Admin/Addons/Details.php:116 src/Module/Admin/Addons/Index.php:67
 #: src/Module/Admin/Blocklist/Contact.php:78
-#: src/Module/Admin/Item/Delete.php:65 src/Module/Admin/Addons/Details.php:116
-#: src/Module/Admin/Addons/Index.php:67
+#: src/Module/Admin/Blocklist/Server.php:88 src/Module/Admin/Federation.php:140
+#: src/Module/Admin/Item/Delete.php:65 src/Module/Admin/Logs/Settings.php:78
+#: src/Module/Admin/Logs/View.php:64 src/Module/Admin/Queue.php:75
+#: src/Module/Admin/Site.php:587 src/Module/Admin/Summary.php:230
+#: src/Module/Admin/Themes/Details.php:121
+#: src/Module/Admin/Themes/Index.php:111 src/Module/Admin/Tos.php:58
+#: src/Module/Admin/Users.php:242
 msgid "Administration"
 msgstr ""
 
-#: src/Module/Admin/Themes/Details.php:123
+#: src/Module/Admin/Addons/Details.php:117 src/Module/Admin/Addons/Index.php:68
+#: src/Module/BaseAdmin.php:99 src/Module/BaseSettings.php:87
+msgid "Addons"
+msgstr ""
+
 #: src/Module/Admin/Addons/Details.php:118
+#: src/Module/Admin/Themes/Details.php:123
 msgid "Toggle"
 msgstr ""
 
-#: src/Module/Admin/Themes/Details.php:132
 #: src/Module/Admin/Addons/Details.php:126
+#: src/Module/Admin/Themes/Details.php:132
 msgid "Author: "
 msgstr ""
 
-#: src/Module/Admin/Themes/Details.php:133
 #: src/Module/Admin/Addons/Details.php:127
+#: src/Module/Admin/Themes/Details.php:133
 msgid "Maintainer: "
 msgstr ""
 
-#: src/Module/Admin/Themes/Embed.php:84
-msgid "Unknown theme."
+#: src/Module/Admin/Addons/Index.php:42
+msgid "Addons reloaded"
 msgstr ""
 
-#: src/Module/Admin/Themes/Index.php:51
-msgid "Themes reloaded"
-msgstr ""
-
-#: src/Module/Admin/Themes/Index.php:114
-msgid "Reload active themes"
-msgstr ""
-
-#: src/Module/Admin/Themes/Index.php:119
+#: src/Module/Admin/Addons/Index.php:53
 #, php-format
-msgid "No themes found on the system. They should be placed in %1$s"
+msgid "Addon %s failed to install."
 msgstr ""
 
-#: src/Module/Admin/Themes/Index.php:120
-msgid "[Experimental]"
+#: src/Module/Admin/Addons/Index.php:70
+msgid "Reload active addons"
 msgstr ""
 
-#: src/Module/Admin/Themes/Index.php:121
-msgid "[Unsupported]"
-msgstr ""
-
-#: src/Module/Admin/Features.php:76
+#: src/Module/Admin/Addons/Index.php:75
 #, php-format
-msgid "Lock feature %s"
+msgid ""
+"There are currently no addons available on your node. You can find the "
+"official addon repository at %1$s and might find other interesting addons in "
+"the open addon registry at %2$s"
 msgstr ""
 
-#: src/Module/Admin/Features.php:85
-msgid "Manage Additional Features"
-msgstr ""
-
-#: src/Module/Admin/Users.php:61
+#: src/Module/Admin/Blocklist/Contact.php:57
 #, php-format
-msgid "%s user blocked"
-msgid_plural "%s users blocked"
+msgid "%s contact unblocked"
+msgid_plural "%s contacts unblocked"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Module/Admin/Users.php:68
-#, php-format
-msgid "%s user unblocked"
-msgid_plural "%s users unblocked"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/Module/Admin/Users.php:76 src/Module/Admin/Users.php:126
-msgid "You can't remove yourself"
+#: src/Module/Admin/Blocklist/Contact.php:79
+msgid "Remote Contact Blocklist"
 msgstr ""
 
-#: src/Module/Admin/Users.php:80
-#, php-format
-msgid "%s user deleted"
-msgid_plural "%s users deleted"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/Module/Admin/Users.php:87
-#, php-format
-msgid "%s user approved"
-msgid_plural "%s users approved"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/Module/Admin/Users.php:94
-#, php-format
-msgid "%s registration revoked"
-msgid_plural "%s registrations revoked"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/Module/Admin/Users.php:124
-#, php-format
-msgid "User \"%s\" deleted"
+#: src/Module/Admin/Blocklist/Contact.php:80
+msgid ""
+"This page allows you to prevent any message from a remote contact to reach "
+"your node."
 msgstr ""
 
-#: src/Module/Admin/Users.php:132
-#, php-format
-msgid "User \"%s\" blocked"
+#: src/Module/Admin/Blocklist/Contact.php:81
+msgid "Block Remote Contact"
 msgstr ""
 
-#: src/Module/Admin/Users.php:137
-#, php-format
-msgid "User \"%s\" unblocked"
-msgstr ""
-
-#: src/Module/Admin/Users.php:142
-msgid "Account approved."
-msgstr ""
-
-#: src/Module/Admin/Users.php:147
-msgid "Registration revoked"
-msgstr ""
-
-#: src/Module/Admin/Users.php:191
-msgid "Private Forum"
-msgstr ""
-
-#: src/Module/Admin/Users.php:198
-msgid "Relay"
-msgstr ""
-
-#: src/Module/Admin/Users.php:237 src/Module/Admin/Users.php:248
-#: src/Module/Admin/Users.php:262 src/Module/Admin/Users.php:280
-#: src/Content/ContactSelector.php:102
-msgid "Email"
-msgstr ""
-
-#: src/Module/Admin/Users.php:237 src/Module/Admin/Users.php:262
-msgid "Register date"
-msgstr ""
-
-#: src/Module/Admin/Users.php:237 src/Module/Admin/Users.php:262
-msgid "Last login"
-msgstr ""
-
-#: src/Module/Admin/Users.php:237 src/Module/Admin/Users.php:262
-msgid "Last public item"
-msgstr ""
-
-#: src/Module/Admin/Users.php:237
-msgid "Type"
-msgstr ""
-
-#: src/Module/Admin/Users.php:244
-msgid "Add User"
-msgstr ""
-
-#: src/Module/Admin/Users.php:245 src/Module/Admin/Blocklist/Contact.php:82
+#: src/Module/Admin/Blocklist/Contact.php:82 src/Module/Admin/Users.php:245
 msgid "select all"
 msgstr ""
 
-#: src/Module/Admin/Users.php:246
-msgid "User registrations waiting for confirm"
+#: src/Module/Admin/Blocklist/Contact.php:83
+msgid "select none"
 msgstr ""
 
-#: src/Module/Admin/Users.php:247
-msgid "User waiting for permanent deletion"
+#: src/Module/Admin/Blocklist/Contact.php:85 src/Module/Admin/Users.php:256
+#: src/Module/Contact.php:601 src/Module/Contact.php:847
+#: src/Module/Contact.php:1128
+msgid "Unblock"
 msgstr ""
 
-#: src/Module/Admin/Users.php:248
-msgid "Request date"
+#: src/Module/Admin/Blocklist/Contact.php:86
+msgid "No remote contact is blocked from this node."
 msgstr ""
 
-#: src/Module/Admin/Users.php:249
-msgid "No registrations."
+#: src/Module/Admin/Blocklist/Contact.php:88
+msgid "Blocked Remote Contacts"
 msgstr ""
 
-#: src/Module/Admin/Users.php:250
-msgid "Note from the user"
+#: src/Module/Admin/Blocklist/Contact.php:89
+msgid "Block New Remote Contact"
 msgstr ""
 
-#: src/Module/Admin/Users.php:252
-msgid "Deny"
+#: src/Module/Admin/Blocklist/Contact.php:90
+msgid "Photo"
 msgstr ""
 
-#: src/Module/Admin/Users.php:255
-msgid "User blocked"
+#: src/Module/Admin/Blocklist/Contact.php:90
+msgid "Reason"
 msgstr ""
 
-#: src/Module/Admin/Users.php:257
-msgid "Site admin"
+#: src/Module/Admin/Blocklist/Contact.php:98
+#, php-format
+msgid "%s total blocked contact"
+msgid_plural "%s total blocked contacts"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/Module/Admin/Blocklist/Contact.php:100
+msgid "URL of the remote contact to block."
 msgstr ""
 
-#: src/Module/Admin/Users.php:258
-msgid "Account expired"
+#: src/Module/Admin/Blocklist/Contact.php:101
+msgid "Block Reason"
 msgstr ""
 
-#: src/Module/Admin/Users.php:261
-msgid "New User"
+#: src/Module/Admin/Blocklist/Server.php:49
+msgid "Server domain pattern added to blocklist."
 msgstr ""
 
-#: src/Module/Admin/Users.php:262
-msgid "Permanent deletion"
+#: src/Module/Admin/Blocklist/Server.php:79
+#: src/Module/Admin/Blocklist/Server.php:104
+msgid "Blocked server domain pattern"
 msgstr ""
 
-#: src/Module/Admin/Users.php:267
+#: src/Module/Admin/Blocklist/Server.php:80
+#: src/Module/Admin/Blocklist/Server.php:105 src/Module/Friendica.php:80
+msgid "Reason for the block"
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Server.php:81
+msgid "Delete server domain pattern"
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Server.php:81
+msgid "Check to delete this entry from the blocklist"
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Server.php:89
+msgid "Server Domain Pattern Blocklist"
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Server.php:90
 msgid ""
-"Selected users will be deleted!\\n\\nEverything these users had posted on "
-"this site will be permanently deleted!\\n\\nAre you sure?"
+"This page can be used to define a blocklist of server domain patterns from "
+"the federated network that are not allowed to interact with your node. For "
+"each domain pattern you should also provide the reason why you block it."
 msgstr ""
 
-#: src/Module/Admin/Users.php:268
+#: src/Module/Admin/Blocklist/Server.php:91
 msgid ""
-"The user {0} will be deleted!\\n\\nEverything this user has posted on this "
-"site will be permanently deleted!\\n\\nAre you sure?"
+"The list of blocked server domain patterns will be made publically available "
+"on the <a href=\"/friendica\">/friendica</a> page so that your users and "
+"people investigating communication problems can find the reason easily."
 msgstr ""
 
-#: src/Module/Admin/Users.php:278
-msgid "Name of the new user."
-msgstr ""
-
-#: src/Module/Admin/Users.php:279
-msgid "Nickname"
-msgstr ""
-
-#: src/Module/Admin/Users.php:279
-msgid "Nickname of the new user."
-msgstr ""
-
-#: src/Module/Admin/Users.php:280
-msgid "Email address of the new user."
-msgstr ""
-
-#: src/Module/Admin/Queue.php:53
-msgid "Inspect Deferred Worker Queue"
-msgstr ""
-
-#: src/Module/Admin/Queue.php:54
+#: src/Module/Admin/Blocklist/Server.php:92
 msgid ""
-"This page lists the deferred worker jobs. This are jobs that couldn't be "
-"executed at the first time."
+"<p>The server domain pattern syntax is case-insensitive shell wildcard, "
+"comprising the following special characters:</p>\n"
+"<ul>\n"
+"\t<li><code>*</code>: Any number of characters</li>\n"
+"\t<li><code>?</code>: Any single character</li>\n"
+"\t<li><code>[&lt;char1&gt;&lt;char2&gt;...]</code>: char1 or char2</li>\n"
+"</ul>"
 msgstr ""
 
-#: src/Module/Admin/Queue.php:57
-msgid "Inspect Worker Queue"
+#: src/Module/Admin/Blocklist/Server.php:98
+msgid "Add new entry to block list"
 msgstr ""
 
-#: src/Module/Admin/Queue.php:58
+#: src/Module/Admin/Blocklist/Server.php:99
+msgid "Server Domain Pattern"
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Server.php:99
 msgid ""
-"This page lists the currently queued worker jobs. These jobs are handled by "
-"the worker cronjob you've set up during install."
+"The domain pattern of the new server to add to the block list. Do not "
+"include the protocol."
 msgstr ""
 
-#: src/Module/Admin/Queue.php:78
-msgid "ID"
+#: src/Module/Admin/Blocklist/Server.php:100
+msgid "Block reason"
 msgstr ""
 
-#: src/Module/Admin/Queue.php:79
-msgid "Job Parameters"
+#: src/Module/Admin/Blocklist/Server.php:100
+msgid "The reason why you blocked this server domain pattern."
 msgstr ""
 
-#: src/Module/Admin/Queue.php:80
-msgid "Created"
+#: src/Module/Admin/Blocklist/Server.php:101
+msgid "Add Entry"
 msgstr ""
 
-#: src/Module/Admin/Queue.php:81
-msgid "Priority"
+#: src/Module/Admin/Blocklist/Server.php:102
+msgid "Save changes to the blocklist"
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Server.php:103
+msgid "Current Entries in the Blocklist"
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Server.php:106
+msgid "Delete entry from blocklist"
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Server.php:109
+msgid "Delete entry from blocklist?"
 msgstr ""
 
 #: src/Module/Admin/DBSync.php:50
@@ -6836,6 +5408,15 @@ msgstr ""
 msgid "Attempt to execute this update step automatically"
 msgstr ""
 
+#: src/Module/Admin/Features.php:76
+#, php-format
+msgid "Lock feature %s"
+msgstr ""
+
+#: src/Module/Admin/Features.php:85
+msgid "Manage Additional Features"
+msgstr ""
+
 #: src/Module/Admin/Federation.php:53
 msgid "Other"
 msgstr ""
@@ -6851,6 +5432,10 @@ msgid ""
 "only reflect the part of the network your node is aware of."
 msgstr ""
 
+#: src/Module/Admin/Federation.php:141 src/Module/BaseAdmin.php:94
+msgid "Federation Statistics"
+msgstr ""
+
 #: src/Module/Admin/Federation.php:145
 #, php-format
 msgid ""
@@ -6858,18 +5443,41 @@ msgid ""
 "following platforms:"
 msgstr ""
 
-#: src/Module/Admin/Logs/View.php:40
-#, php-format
-msgid ""
-"Error trying to open <strong>%1$s</strong> log file.\\r\\n<br/>Check to see "
-"if file %1$s exist and is readable."
+#: src/Module/Admin/Item/Delete.php:54
+msgid "Item marked for deletion."
 msgstr ""
 
-#: src/Module/Admin/Logs/View.php:44
-#, php-format
+#: src/Module/Admin/Item/Delete.php:66 src/Module/BaseAdmin.php:112
+msgid "Delete Item"
+msgstr ""
+
+#: src/Module/Admin/Item/Delete.php:67
+msgid "Delete this Item"
+msgstr ""
+
+#: src/Module/Admin/Item/Delete.php:68
 msgid ""
-"Couldn't open <strong>%1$s</strong> log file.\\r\\n<br/>Check to see if file "
-"%1$s is readable."
+"On this page you can delete an item from your node. If the item is a top "
+"level posting, the entire thread will be deleted."
+msgstr ""
+
+#: src/Module/Admin/Item/Delete.php:69
+msgid ""
+"You need to know the GUID of the item. You can find it e.g. by looking at "
+"the display URL. The last part of http://example.com/display/123456 is the "
+"GUID, here 123456."
+msgstr ""
+
+#: src/Module/Admin/Item/Delete.php:70
+msgid "GUID"
+msgstr ""
+
+#: src/Module/Admin/Item/Delete.php:70
+msgid "The GUID of the item you want to delete."
+msgstr ""
+
+#: src/Module/Admin/Item/Source.php:57
+msgid "Item Guid"
 msgstr ""
 
 #: src/Module/Admin/Logs/Settings.php:45
@@ -6883,6 +5491,11 @@ msgstr ""
 
 #: src/Module/Admin/Logs/Settings.php:72
 msgid "PHP log currently disabled."
+msgstr ""
+
+#: src/Module/Admin/Logs/Settings.php:79 src/Module/BaseAdmin.php:114
+#: src/Module/BaseAdmin.php:115
+msgid "Logs"
 msgstr ""
 
 #: src/Module/Admin/Logs/Settings.php:81
@@ -6918,6 +5531,60 @@ msgid ""
 "the 'error_log' line is relative to the friendica top-level directory and "
 "must be writeable by the web server. The option '1' for 'log_errors' and "
 "'display_errors' is to enable these options, set to '0' to disable them."
+msgstr ""
+
+#: src/Module/Admin/Logs/View.php:40
+#, php-format
+msgid ""
+"Error trying to open <strong>%1$s</strong> log file.\\r\\n<br/>Check to see "
+"if file %1$s exist and is readable."
+msgstr ""
+
+#: src/Module/Admin/Logs/View.php:44
+#, php-format
+msgid ""
+"Couldn't open <strong>%1$s</strong> log file.\\r\\n<br/>Check to see if file "
+"%1$s is readable."
+msgstr ""
+
+#: src/Module/Admin/Logs/View.php:65 src/Module/BaseAdmin.php:116
+msgid "View Logs"
+msgstr ""
+
+#: src/Module/Admin/Queue.php:53
+msgid "Inspect Deferred Worker Queue"
+msgstr ""
+
+#: src/Module/Admin/Queue.php:54
+msgid ""
+"This page lists the deferred worker jobs. This are jobs that couldn't be "
+"executed at the first time."
+msgstr ""
+
+#: src/Module/Admin/Queue.php:57
+msgid "Inspect Worker Queue"
+msgstr ""
+
+#: src/Module/Admin/Queue.php:58
+msgid ""
+"This page lists the currently queued worker jobs. These jobs are handled by "
+"the worker cronjob you've set up during install."
+msgstr ""
+
+#: src/Module/Admin/Queue.php:78
+msgid "ID"
+msgstr ""
+
+#: src/Module/Admin/Queue.php:79
+msgid "Job Parameters"
+msgstr ""
+
+#: src/Module/Admin/Queue.php:80
+msgid "Created"
+msgstr ""
+
+#: src/Module/Admin/Queue.php:81
+msgid "Priority"
 msgstr ""
 
 #: src/Module/Admin/Site.php:69
@@ -6977,6 +5644,18 @@ msgstr ""
 msgid "Open"
 msgstr ""
 
+#: src/Module/Admin/Site.php:524 src/Module/Install.php:200
+msgid "No SSL policy, links will track page SSL state"
+msgstr ""
+
+#: src/Module/Admin/Site.php:525 src/Module/Install.php:201
+msgid "Force all links to use SSL"
+msgstr ""
+
+#: src/Module/Admin/Site.php:526 src/Module/Install.php:202
+msgid "Self-signed certificate, use SSL for local links only (discouraged)"
+msgstr ""
+
 #: src/Module/Admin/Site.php:530
 msgid "Don't check"
 msgstr ""
@@ -7005,8 +5684,16 @@ msgstr ""
 msgid "Database (legacy)"
 msgstr ""
 
+#: src/Module/Admin/Site.php:588 src/Module/BaseAdmin.php:97
+msgid "Site"
+msgstr ""
+
 #: src/Module/Admin/Site.php:590
 msgid "Republish users to directory"
+msgstr ""
+
+#: src/Module/Admin/Site.php:591 src/Module/Register.php:139
+msgid "Registration"
 msgstr ""
 
 #: src/Module/Admin/Site.php:592
@@ -7122,6 +5809,14 @@ msgstr ""
 
 #: src/Module/Admin/Site.php:614
 msgid "Theme for mobile devices"
+msgstr ""
+
+#: src/Module/Admin/Site.php:615 src/Module/Install.php:210
+msgid "SSL link policy"
+msgstr ""
+
+#: src/Module/Admin/Site.php:615 src/Module/Install.php:212
+msgid "Determines whether generated links should be forced to use SSL"
 msgstr ""
 
 #: src/Module/Admin/Site.php:616
@@ -7747,6 +6442,11 @@ msgstr ""
 msgid "Encryption layer between nodes."
 msgstr ""
 
+#: src/Module/Admin/Site.php:693 src/Module/Admin/Site.php:703
+#: src/Module/Contact.php:552 src/Module/Settings/TwoFactor/Index.php:113
+msgid "Disabled"
+msgstr ""
+
 #: src/Module/Admin/Site.php:693
 msgid "Enabled"
 msgstr ""
@@ -8024,6 +6724,10 @@ msgstr ""
 msgid "Server Settings"
 msgstr ""
 
+#: src/Module/Admin/Summary.php:231 src/Repository/ProfileField.php:285
+msgid "Summary"
+msgstr ""
+
 #: src/Module/Admin/Summary.php:233
 msgid "Registered users"
 msgstr ""
@@ -8038,6 +6742,55 @@ msgstr ""
 
 #: src/Module/Admin/Summary.php:240
 msgid "Active addons"
+msgstr ""
+
+#: src/Module/Admin/Themes/Details.php:88 src/Module/Admin/Themes/Index.php:65
+#, php-format
+msgid "Theme %s disabled."
+msgstr ""
+
+#: src/Module/Admin/Themes/Details.php:90 src/Module/Admin/Themes/Index.php:67
+#, php-format
+msgid "Theme %s successfully enabled."
+msgstr ""
+
+#: src/Module/Admin/Themes/Details.php:92 src/Module/Admin/Themes/Index.php:69
+#, php-format
+msgid "Theme %s failed to install."
+msgstr ""
+
+#: src/Module/Admin/Themes/Details.php:114
+msgid "Screenshot"
+msgstr ""
+
+#: src/Module/Admin/Themes/Details.php:122
+#: src/Module/Admin/Themes/Index.php:112 src/Module/BaseAdmin.php:100
+msgid "Themes"
+msgstr ""
+
+#: src/Module/Admin/Themes/Embed.php:84
+msgid "Unknown theme."
+msgstr ""
+
+#: src/Module/Admin/Themes/Index.php:51
+msgid "Themes reloaded"
+msgstr ""
+
+#: src/Module/Admin/Themes/Index.php:114
+msgid "Reload active themes"
+msgstr ""
+
+#: src/Module/Admin/Themes/Index.php:119
+#, php-format
+msgid "No themes found on the system. They should be placed in %1$s"
+msgstr ""
+
+#: src/Module/Admin/Themes/Index.php:120
+msgid "[Experimental]"
+msgstr ""
+
+#: src/Module/Admin/Themes/Index.php:121
+msgid "[Unsupported]"
 msgstr ""
 
 #: src/Module/Admin/Tos.php:60
@@ -8076,225 +6829,1119 @@ msgid ""
 "of sections should be [h2] and below."
 msgstr ""
 
-#: src/Module/Admin/Blocklist/Server.php:49
-msgid "Server domain pattern added to blocklist."
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Server.php:79
-#: src/Module/Admin/Blocklist/Server.php:104
-msgid "Blocked server domain pattern"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Server.php:80
-#: src/Module/Admin/Blocklist/Server.php:105 src/Module/Friendica.php:80
-msgid "Reason for the block"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Server.php:81
-msgid "Delete server domain pattern"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Server.php:81
-msgid "Check to delete this entry from the blocklist"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Server.php:89
-msgid "Server Domain Pattern Blocklist"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Server.php:90
-msgid ""
-"This page can be used to define a blocklist of server domain patterns from "
-"the federated network that are not allowed to interact with your node. For "
-"each domain pattern you should also provide the reason why you block it."
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Server.php:91
-msgid ""
-"The list of blocked server domain patterns will be made publically available "
-"on the <a href=\"/friendica\">/friendica</a> page so that your users and "
-"people investigating communication problems can find the reason easily."
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Server.php:92
-msgid ""
-"<p>The server domain pattern syntax is case-insensitive shell wildcard, "
-"comprising the following special characters:</p>\n"
-"<ul>\n"
-"\t<li><code>*</code>: Any number of characters</li>\n"
-"\t<li><code>?</code>: Any single character</li>\n"
-"\t<li><code>[&lt;char1&gt;&lt;char2&gt;...]</code>: char1 or char2</li>\n"
-"</ul>"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Server.php:98
-msgid "Add new entry to block list"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Server.php:99
-msgid "Server Domain Pattern"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Server.php:99
-msgid ""
-"The domain pattern of the new server to add to the block list. Do not "
-"include the protocol."
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Server.php:100
-msgid "Block reason"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Server.php:100
-msgid "The reason why you blocked this server domain pattern."
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Server.php:101
-msgid "Add Entry"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Server.php:102
-msgid "Save changes to the blocklist"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Server.php:103
-msgid "Current Entries in the Blocklist"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Server.php:106
-msgid "Delete entry from blocklist"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Server.php:109
-msgid "Delete entry from blocklist?"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Contact.php:57
+#: src/Module/Admin/Users.php:61
 #, php-format
-msgid "%s contact unblocked"
-msgid_plural "%s contacts unblocked"
+msgid "%s user blocked"
+msgid_plural "%s users blocked"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Module/Admin/Blocklist/Contact.php:79
-msgid "Remote Contact Blocklist"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Contact.php:80
-msgid ""
-"This page allows you to prevent any message from a remote contact to reach "
-"your node."
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Contact.php:81
-msgid "Block Remote Contact"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Contact.php:83
-msgid "select none"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Contact.php:86
-msgid "No remote contact is blocked from this node."
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Contact.php:88
-msgid "Blocked Remote Contacts"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Contact.php:89
-msgid "Block New Remote Contact"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Contact.php:90
-msgid "Photo"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Contact.php:90
-msgid "Reason"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Contact.php:98
+#: src/Module/Admin/Users.php:68
 #, php-format
-msgid "%s total blocked contact"
-msgid_plural "%s total blocked contacts"
+msgid "%s user unblocked"
+msgid_plural "%s users unblocked"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Module/Admin/Blocklist/Contact.php:100
-msgid "URL of the remote contact to block."
+#: src/Module/Admin/Users.php:76 src/Module/Admin/Users.php:126
+msgid "You can't remove yourself"
 msgstr ""
 
-#: src/Module/Admin/Blocklist/Contact.php:101
-msgid "Block Reason"
+#: src/Module/Admin/Users.php:80
+#, php-format
+msgid "%s user deleted"
+msgid_plural "%s users deleted"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/Module/Admin/Users.php:87
+#, php-format
+msgid "%s user approved"
+msgid_plural "%s users approved"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/Module/Admin/Users.php:94
+#, php-format
+msgid "%s registration revoked"
+msgid_plural "%s registrations revoked"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/Module/Admin/Users.php:124
+#, php-format
+msgid "User \"%s\" deleted"
 msgstr ""
 
-#: src/Module/Admin/Item/Source.php:57
-msgid "Item Guid"
+#: src/Module/Admin/Users.php:132
+#, php-format
+msgid "User \"%s\" blocked"
 msgstr ""
 
-#: src/Module/Admin/Item/Delete.php:54
-msgid "Item marked for deletion."
+#: src/Module/Admin/Users.php:137
+#, php-format
+msgid "User \"%s\" unblocked"
 msgstr ""
 
-#: src/Module/Admin/Item/Delete.php:67
-msgid "Delete this Item"
+#: src/Module/Admin/Users.php:142
+msgid "Account approved."
 msgstr ""
 
-#: src/Module/Admin/Item/Delete.php:68
+#: src/Module/Admin/Users.php:147
+msgid "Registration revoked"
+msgstr ""
+
+#: src/Module/Admin/Users.php:191
+msgid "Private Forum"
+msgstr ""
+
+#: src/Module/Admin/Users.php:198
+msgid "Relay"
+msgstr ""
+
+#: src/Module/Admin/Users.php:237 src/Module/Admin/Users.php:262
+msgid "Register date"
+msgstr ""
+
+#: src/Module/Admin/Users.php:237 src/Module/Admin/Users.php:262
+msgid "Last login"
+msgstr ""
+
+#: src/Module/Admin/Users.php:237 src/Module/Admin/Users.php:262
+msgid "Last public item"
+msgstr ""
+
+#: src/Module/Admin/Users.php:237
+msgid "Type"
+msgstr ""
+
+#: src/Module/Admin/Users.php:243 src/Module/Admin/Users.php:260
+#: src/Module/BaseAdmin.php:98
+msgid "Users"
+msgstr ""
+
+#: src/Module/Admin/Users.php:244
+msgid "Add User"
+msgstr ""
+
+#: src/Module/Admin/Users.php:246
+msgid "User registrations waiting for confirm"
+msgstr ""
+
+#: src/Module/Admin/Users.php:247
+msgid "User waiting for permanent deletion"
+msgstr ""
+
+#: src/Module/Admin/Users.php:248
+msgid "Request date"
+msgstr ""
+
+#: src/Module/Admin/Users.php:249
+msgid "No registrations."
+msgstr ""
+
+#: src/Module/Admin/Users.php:250
+msgid "Note from the user"
+msgstr ""
+
+#: src/Module/Admin/Users.php:252
+msgid "Deny"
+msgstr ""
+
+#: src/Module/Admin/Users.php:255
+msgid "User blocked"
+msgstr ""
+
+#: src/Module/Admin/Users.php:257
+msgid "Site admin"
+msgstr ""
+
+#: src/Module/Admin/Users.php:258
+msgid "Account expired"
+msgstr ""
+
+#: src/Module/Admin/Users.php:261
+msgid "New User"
+msgstr ""
+
+#: src/Module/Admin/Users.php:262
+msgid "Permanent deletion"
+msgstr ""
+
+#: src/Module/Admin/Users.php:267
 msgid ""
-"On this page you can delete an item from your node. If the item is a top "
-"level posting, the entire thread will be deleted."
+"Selected users will be deleted!\\n\\nEverything these users had posted on "
+"this site will be permanently deleted!\\n\\nAre you sure?"
 msgstr ""
 
-#: src/Module/Admin/Item/Delete.php:69
+#: src/Module/Admin/Users.php:268
 msgid ""
-"You need to know the GUID of the item. You can find it e.g. by looking at "
-"the display URL. The last part of http://example.com/display/123456 is the "
-"GUID, here 123456."
+"The user {0} will be deleted!\\n\\nEverything this user has posted on this "
+"site will be permanently deleted!\\n\\nAre you sure?"
 msgstr ""
 
-#: src/Module/Admin/Item/Delete.php:70
-msgid "GUID"
+#: src/Module/Admin/Users.php:278
+msgid "Name of the new user."
 msgstr ""
 
-#: src/Module/Admin/Item/Delete.php:70
-msgid "The GUID of the item you want to delete."
+#: src/Module/Admin/Users.php:279
+msgid "Nickname"
 msgstr ""
 
-#: src/Module/Admin/Addons/Details.php:70
-msgid "Addon not found."
+#: src/Module/Admin/Users.php:279
+msgid "Nickname of the new user."
 msgstr ""
 
-#: src/Module/Admin/Addons/Details.php:81 src/Module/Admin/Addons/Index.php:49
+#: src/Module/Admin/Users.php:280
+msgid "Email address of the new user."
+msgstr ""
+
+#: src/Module/Api/Twitter/ContactEndpoint.php:65 src/Module/Contact.php:386
+msgid "Contact not found"
+msgstr ""
+
+#: src/Module/Api/Twitter/ContactEndpoint.php:135
+msgid "Profile not found"
+msgstr ""
+
+#: src/Module/Apps.php:47
+msgid "No installed applications."
+msgstr ""
+
+#: src/Module/Apps.php:52
+msgid "Applications"
+msgstr ""
+
+#: src/Module/Attach.php:50 src/Module/Attach.php:62
+msgid "Item was not found."
+msgstr ""
+
+#: src/Module/BaseAdmin.php:79
+msgid ""
+"Submanaged account can't access the administation pages. Please log back in "
+"as the main account."
+msgstr ""
+
+#: src/Module/BaseAdmin.php:93
+msgid "Overview"
+msgstr ""
+
+#: src/Module/BaseAdmin.php:96
+msgid "Configuration"
+msgstr ""
+
+#: src/Module/BaseAdmin.php:101 src/Module/BaseSettings.php:65
+msgid "Additional features"
+msgstr ""
+
+#: src/Module/BaseAdmin.php:104
+msgid "Database"
+msgstr ""
+
+#: src/Module/BaseAdmin.php:105
+msgid "DB updates"
+msgstr ""
+
+#: src/Module/BaseAdmin.php:106
+msgid "Inspect Deferred Workers"
+msgstr ""
+
+#: src/Module/BaseAdmin.php:107
+msgid "Inspect worker Queue"
+msgstr ""
+
+#: src/Module/BaseAdmin.php:109
+msgid "Tools"
+msgstr ""
+
+#: src/Module/BaseAdmin.php:110
+msgid "Contact Blocklist"
+msgstr ""
+
+#: src/Module/BaseAdmin.php:111
+msgid "Server Blocklist"
+msgstr ""
+
+#: src/Module/BaseAdmin.php:118
+msgid "Diagnostics"
+msgstr ""
+
+#: src/Module/BaseAdmin.php:119
+msgid "PHP Info"
+msgstr ""
+
+#: src/Module/BaseAdmin.php:120
+msgid "probe address"
+msgstr ""
+
+#: src/Module/BaseAdmin.php:121
+msgid "check webfinger"
+msgstr ""
+
+#: src/Module/BaseAdmin.php:122
+msgid "Item Source"
+msgstr ""
+
+#: src/Module/BaseAdmin.php:123
+msgid "Babel"
+msgstr ""
+
+#: src/Module/BaseAdmin.php:124
+msgid "ActivityPub Conversion"
+msgstr ""
+
+#: src/Module/BaseAdmin.php:133
+msgid "Addon Features"
+msgstr ""
+
+#: src/Module/BaseAdmin.php:134
+msgid "User registrations waiting for confirmation"
+msgstr ""
+
+#: src/Module/BaseProfile.php:55 src/Module/Contact.php:903
+msgid "Profile Details"
+msgstr ""
+
+#: src/Module/BaseProfile.php:113
+msgid "Only You Can See This"
+msgstr ""
+
+#: src/Module/BaseProfile.php:132 src/Module/BaseProfile.php:135
+msgid "Tips for New Members"
+msgstr ""
+
+#: src/Module/BaseSearch.php:69
 #, php-format
-msgid "Addon %s disabled."
+msgid "People Search - %s"
 msgstr ""
 
-#: src/Module/Admin/Addons/Details.php:84 src/Module/Admin/Addons/Index.php:51
+#: src/Module/BaseSearch.php:79
 #, php-format
-msgid "Addon %s enabled."
+msgid "Forum Search - %s"
 msgstr ""
 
-#: src/Module/Admin/Addons/Index.php:42
-msgid "Addons reloaded"
+#: src/Module/BaseSettings.php:43
+msgid "Account"
 msgstr ""
 
-#: src/Module/Admin/Addons/Index.php:53
+#: src/Module/BaseSettings.php:50 src/Module/Security/TwoFactor/Verify.php:80
+#: src/Module/Settings/TwoFactor/Index.php:105
+msgid "Two-factor authentication"
+msgstr ""
+
+#: src/Module/BaseSettings.php:73
+msgid "Display"
+msgstr ""
+
+#: src/Module/BaseSettings.php:94 src/Module/Settings/Delegation.php:171
+msgid "Manage Accounts"
+msgstr ""
+
+#: src/Module/BaseSettings.php:101
+msgid "Connected apps"
+msgstr ""
+
+#: src/Module/BaseSettings.php:108 src/Module/Settings/UserExport.php:65
+msgid "Export personal data"
+msgstr ""
+
+#: src/Module/BaseSettings.php:115
+msgid "Remove account"
+msgstr ""
+
+#: src/Module/Bookmarklet.php:56
+msgid "This page is missing a url parameter."
+msgstr ""
+
+#: src/Module/Bookmarklet.php:78
+msgid "The post was created"
+msgstr ""
+
+#: src/Module/Contact/Advanced.php:94
+msgid "Contact update failed."
+msgstr ""
+
+#: src/Module/Contact/Advanced.php:111
+msgid ""
+"<strong>WARNING: This is highly advanced</strong> and if you enter incorrect "
+"information your communications with this contact may stop working."
+msgstr ""
+
+#: src/Module/Contact/Advanced.php:112
+msgid ""
+"Please use your browser 'Back' button <strong>now</strong> if you are "
+"uncertain what to do on this page."
+msgstr ""
+
+#: src/Module/Contact/Advanced.php:123 src/Module/Contact/Advanced.php:125
+msgid "No mirroring"
+msgstr ""
+
+#: src/Module/Contact/Advanced.php:123
+msgid "Mirror as forwarded posting"
+msgstr ""
+
+#: src/Module/Contact/Advanced.php:123 src/Module/Contact/Advanced.php:125
+msgid "Mirror as my own posting"
+msgstr ""
+
+#: src/Module/Contact/Advanced.php:136
+msgid "Return to contact editor"
+msgstr ""
+
+#: src/Module/Contact/Advanced.php:138 src/Module/Contact.php:1119
+msgid "Refetch contact data"
+msgstr ""
+
+#: src/Module/Contact/Advanced.php:141
+msgid "Remote Self"
+msgstr ""
+
+#: src/Module/Contact/Advanced.php:144
+msgid "Mirror postings from this contact"
+msgstr ""
+
+#: src/Module/Contact/Advanced.php:146
+msgid ""
+"Mark this contact as remote_self, this will cause friendica to repost new "
+"entries from this contact."
+msgstr ""
+
+#: src/Module/Contact/Advanced.php:151
+msgid "Account Nickname"
+msgstr ""
+
+#: src/Module/Contact/Advanced.php:152
+msgid "@Tagname - overrides Name/Nickname"
+msgstr ""
+
+#: src/Module/Contact/Advanced.php:153
+msgid "Account URL"
+msgstr ""
+
+#: src/Module/Contact/Advanced.php:154
+msgid "Account URL Alias"
+msgstr ""
+
+#: src/Module/Contact/Advanced.php:155
+msgid "Friend Request URL"
+msgstr ""
+
+#: src/Module/Contact/Advanced.php:156
+msgid "Friend Confirm URL"
+msgstr ""
+
+#: src/Module/Contact/Advanced.php:157
+msgid "Notification Endpoint URL"
+msgstr ""
+
+#: src/Module/Contact/Advanced.php:158
+msgid "Poll/Feed URL"
+msgstr ""
+
+#: src/Module/Contact/Advanced.php:159
+msgid "New photo from this URL"
+msgstr ""
+
+#: src/Module/Contact/Contacts.php:46
+msgid "No known contacts."
+msgstr ""
+
+#: src/Module/Contact/Contacts.php:64 src/Module/Profile/Common.php:99
+msgid "No common contacts."
+msgstr ""
+
+#: src/Module/Contact/Contacts.php:76 src/Module/Profile/Contacts.php:96
 #, php-format
-msgid "Addon %s failed to install."
+msgid "Follower (%s)"
+msgid_plural "Followers (%s)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/Module/Contact/Contacts.php:80 src/Module/Profile/Contacts.php:99
+#, php-format
+msgid "Following (%s)"
+msgid_plural "Following (%s)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/Module/Contact/Contacts.php:84 src/Module/Profile/Contacts.php:102
+#, php-format
+msgid "Mutual friend (%s)"
+msgid_plural "Mutual friends (%s)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/Module/Contact/Contacts.php:86 src/Module/Profile/Contacts.php:104
+#, php-format
+msgid "These contacts both follow and are followed by <strong>%s</strong>."
 msgstr ""
 
-#: src/Module/Admin/Addons/Index.php:70
-msgid "Reload active addons"
-msgstr ""
+#: src/Module/Contact/Contacts.php:92 src/Module/Profile/Common.php:87
+#, php-format
+msgid "Common contact (%s)"
+msgid_plural "Common contacts (%s)"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/Module/Admin/Addons/Index.php:75
+#: src/Module/Contact/Contacts.php:94 src/Module/Profile/Common.php:89
 #, php-format
 msgid ""
-"There are currently no addons available on your node. You can find the "
-"official addon repository at %1$s and might find other interesting addons in "
-"the open addon registry at %2$s"
+"Both <strong>%s</strong> and yourself have publicly interacted with these "
+"contacts (follow, comment or likes on public posts)."
+msgstr ""
+
+#: src/Module/Contact/Contacts.php:100 src/Module/Profile/Contacts.php:110
+#, php-format
+msgid "Contact (%s)"
+msgid_plural "Contacts (%s)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/Module/Contact/Poke.php:114
+msgid "Error while sending poke, please retry."
+msgstr ""
+
+#: src/Module/Contact/Poke.php:127 src/Module/Search/Acl.php:55
+msgid "You must be logged in to use this module."
+msgstr ""
+
+#: src/Module/Contact/Poke.php:150
+msgid "Poke/Prod"
+msgstr ""
+
+#: src/Module/Contact/Poke.php:151
+msgid "poke, prod or do other things to somebody"
+msgstr ""
+
+#: src/Module/Contact/Poke.php:153
+msgid "Choose what you wish to do to recipient"
+msgstr ""
+
+#: src/Module/Contact/Poke.php:154
+msgid "Make this post private"
+msgstr ""
+
+#: src/Module/Contact.php:93
+#, php-format
+msgid "%d contact edited."
+msgid_plural "%d contacts edited."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/Module/Contact.php:120
+msgid "Could not access contact record."
+msgstr ""
+
+#: src/Module/Contact.php:405
+msgid "Contact has been blocked"
+msgstr ""
+
+#: src/Module/Contact.php:405
+msgid "Contact has been unblocked"
+msgstr ""
+
+#: src/Module/Contact.php:415
+msgid "Contact has been ignored"
+msgstr ""
+
+#: src/Module/Contact.php:415
+msgid "Contact has been unignored"
+msgstr ""
+
+#: src/Module/Contact.php:425
+msgid "Contact has been archived"
+msgstr ""
+
+#: src/Module/Contact.php:425
+msgid "Contact has been unarchived"
+msgstr ""
+
+#: src/Module/Contact.php:449
+msgid "Drop contact"
+msgstr ""
+
+#: src/Module/Contact.php:452 src/Module/Contact.php:843
+msgid "Do you really want to delete this contact?"
+msgstr ""
+
+#: src/Module/Contact.php:466
+msgid "Contact has been removed."
+msgstr ""
+
+#: src/Module/Contact.php:494
+#, php-format
+msgid "You are mutual friends with %s"
+msgstr ""
+
+#: src/Module/Contact.php:498
+#, php-format
+msgid "You are sharing with %s"
+msgstr ""
+
+#: src/Module/Contact.php:502
+#, php-format
+msgid "%s is sharing with you"
+msgstr ""
+
+#: src/Module/Contact.php:526
+msgid "Private communications are not available for this contact."
+msgstr ""
+
+#: src/Module/Contact.php:528
+msgid "Never"
+msgstr ""
+
+#: src/Module/Contact.php:531
+msgid "(Update was successful)"
+msgstr ""
+
+#: src/Module/Contact.php:531
+msgid "(Update was not successful)"
+msgstr ""
+
+#: src/Module/Contact.php:533 src/Module/Contact.php:1099
+msgid "Suggest friends"
+msgstr ""
+
+#: src/Module/Contact.php:537
+#, php-format
+msgid "Network type: %s"
+msgstr ""
+
+#: src/Module/Contact.php:542
+msgid "Communications lost with this contact!"
+msgstr ""
+
+#: src/Module/Contact.php:548
+msgid "Fetch further information for feeds"
+msgstr ""
+
+#: src/Module/Contact.php:550
+msgid ""
+"Fetch information like preview pictures, title and teaser from the feed "
+"item. You can activate this if the feed doesn't contain much text. Keywords "
+"are taken from the meta header in the feed item and are posted as hash tags."
+msgstr ""
+
+#: src/Module/Contact.php:553
+msgid "Fetch information"
+msgstr ""
+
+#: src/Module/Contact.php:554
+msgid "Fetch keywords"
+msgstr ""
+
+#: src/Module/Contact.php:555
+msgid "Fetch information and keywords"
+msgstr ""
+
+#: src/Module/Contact.php:569
+msgid "Contact Information / Notes"
+msgstr ""
+
+#: src/Module/Contact.php:570
+msgid "Contact Settings"
+msgstr ""
+
+#: src/Module/Contact.php:578
+msgid "Contact"
+msgstr ""
+
+#: src/Module/Contact.php:582
+msgid "Their personal note"
+msgstr ""
+
+#: src/Module/Contact.php:584
+msgid "Edit contact notes"
+msgstr ""
+
+#: src/Module/Contact.php:587 src/Module/Contact.php:1067
+#, php-format
+msgid "Visit %s's profile [%s]"
+msgstr ""
+
+#: src/Module/Contact.php:588
+msgid "Block/Unblock contact"
+msgstr ""
+
+#: src/Module/Contact.php:589
+msgid "Ignore contact"
+msgstr ""
+
+#: src/Module/Contact.php:590
+msgid "View conversations"
+msgstr ""
+
+#: src/Module/Contact.php:595
+msgid "Last update:"
+msgstr ""
+
+#: src/Module/Contact.php:597
+msgid "Update public posts"
+msgstr ""
+
+#: src/Module/Contact.php:599 src/Module/Contact.php:1109
+msgid "Update now"
+msgstr ""
+
+#: src/Module/Contact.php:602 src/Module/Contact.php:848
+#: src/Module/Contact.php:1136
+msgid "Unignore"
+msgstr ""
+
+#: src/Module/Contact.php:606
+msgid "Currently blocked"
+msgstr ""
+
+#: src/Module/Contact.php:607
+msgid "Currently ignored"
+msgstr ""
+
+#: src/Module/Contact.php:608
+msgid "Currently archived"
+msgstr ""
+
+#: src/Module/Contact.php:609
+msgid "Awaiting connection acknowledge"
+msgstr ""
+
+#: src/Module/Contact.php:610 src/Module/Notifications/Introductions.php:105
+#: src/Module/Notifications/Introductions.php:171
+msgid "Hide this contact from others"
+msgstr ""
+
+#: src/Module/Contact.php:610
+msgid ""
+"Replies/likes to your public posts <strong>may</strong> still be visible"
+msgstr ""
+
+#: src/Module/Contact.php:611
+msgid "Notification for new posts"
+msgstr ""
+
+#: src/Module/Contact.php:611
+msgid "Send a notification of every new post of this contact"
+msgstr ""
+
+#: src/Module/Contact.php:613
+msgid "Keyword Deny List"
+msgstr ""
+
+#: src/Module/Contact.php:613
+msgid ""
+"Comma separated list of keywords that should not be converted to hashtags, "
+"when \"Fetch information and keywords\" is selected"
+msgstr ""
+
+#: src/Module/Contact.php:629 src/Module/Settings/TwoFactor/Index.php:127
+msgid "Actions"
+msgstr ""
+
+#: src/Module/Contact.php:758
+msgid "Show all contacts"
+msgstr ""
+
+#: src/Module/Contact.php:763 src/Module/Contact.php:823
+msgid "Pending"
+msgstr ""
+
+#: src/Module/Contact.php:766
+msgid "Only show pending contacts"
+msgstr ""
+
+#: src/Module/Contact.php:771 src/Module/Contact.php:824
+msgid "Blocked"
+msgstr ""
+
+#: src/Module/Contact.php:774
+msgid "Only show blocked contacts"
+msgstr ""
+
+#: src/Module/Contact.php:779 src/Module/Contact.php:826
+msgid "Ignored"
+msgstr ""
+
+#: src/Module/Contact.php:782
+msgid "Only show ignored contacts"
+msgstr ""
+
+#: src/Module/Contact.php:787 src/Module/Contact.php:827
+msgid "Archived"
+msgstr ""
+
+#: src/Module/Contact.php:790
+msgid "Only show archived contacts"
+msgstr ""
+
+#: src/Module/Contact.php:795 src/Module/Contact.php:825
+msgid "Hidden"
+msgstr ""
+
+#: src/Module/Contact.php:798
+msgid "Only show hidden contacts"
+msgstr ""
+
+#: src/Module/Contact.php:806
+msgid "Organize your contact groups"
+msgstr ""
+
+#: src/Module/Contact.php:838
+msgid "Search your contacts"
+msgstr ""
+
+#: src/Module/Contact.php:839 src/Module/Search/Index.php:186
+#, php-format
+msgid "Results for: %s"
+msgstr ""
+
+#: src/Module/Contact.php:849 src/Module/Contact.php:1145
+msgid "Archive"
+msgstr ""
+
+#: src/Module/Contact.php:849 src/Module/Contact.php:1145
+msgid "Unarchive"
+msgstr ""
+
+#: src/Module/Contact.php:852
+msgid "Batch Actions"
+msgstr ""
+
+#: src/Module/Contact.php:887
+msgid "Conversations started by this contact"
+msgstr ""
+
+#: src/Module/Contact.php:892
+msgid "Posts and Comments"
+msgstr ""
+
+#: src/Module/Contact.php:910
+msgid "View all known contacts"
+msgstr ""
+
+#: src/Module/Contact.php:920
+msgid "Advanced Contact Settings"
+msgstr ""
+
+#: src/Module/Contact.php:1026
+msgid "Mutual Friendship"
+msgstr ""
+
+#: src/Module/Contact.php:1030
+msgid "is a fan of yours"
+msgstr ""
+
+#: src/Module/Contact.php:1034
+msgid "you are a fan of"
+msgstr ""
+
+#: src/Module/Contact.php:1052
+msgid "Pending outgoing contact request"
+msgstr ""
+
+#: src/Module/Contact.php:1054
+msgid "Pending incoming contact request"
+msgstr ""
+
+#: src/Module/Contact.php:1130
+msgid "Toggle Blocked status"
+msgstr ""
+
+#: src/Module/Contact.php:1138
+msgid "Toggle Ignored status"
+msgstr ""
+
+#: src/Module/Contact.php:1147
+msgid "Toggle Archive status"
+msgstr ""
+
+#: src/Module/Contact.php:1155
+msgid "Delete contact"
+msgstr ""
+
+#: src/Module/Conversation/Community.php:56
+msgid "Local Community"
+msgstr ""
+
+#: src/Module/Conversation/Community.php:59
+msgid "Posts from local users on this server"
+msgstr ""
+
+#: src/Module/Conversation/Community.php:67
+msgid "Global Community"
+msgstr ""
+
+#: src/Module/Conversation/Community.php:70
+msgid "Posts from users of the whole federated network"
+msgstr ""
+
+#: src/Module/Conversation/Community.php:84 src/Module/Search/Index.php:179
+msgid "No results."
+msgstr ""
+
+#: src/Module/Conversation/Community.php:125
+msgid ""
+"This community stream shows all public posts received by this node. They may "
+"not reflect the opinions of this node’s users."
+msgstr ""
+
+#: src/Module/Conversation/Community.php:178
+msgid "Community option not available."
+msgstr ""
+
+#: src/Module/Conversation/Community.php:194
+msgid "Not available."
+msgstr ""
+
+#: src/Module/Credits.php:44
+msgid "Credits"
+msgstr ""
+
+#: src/Module/Credits.php:45
+msgid ""
+"Friendica is a community project, that would not be possible without the "
+"help of many people. Here is a list of those who have contributed to the "
+"code or the translation of Friendica. Thank you all!"
+msgstr ""
+
+#: src/Module/Debug/ActivityPubConversion.php:58
+msgid "Formatted"
+msgstr ""
+
+#: src/Module/Debug/ActivityPubConversion.php:62
+msgid "Source"
+msgstr ""
+
+#: src/Module/Debug/ActivityPubConversion.php:70
+msgid "Activity"
+msgstr ""
+
+#: src/Module/Debug/ActivityPubConversion.php:118
+msgid "Object data"
+msgstr ""
+
+#: src/Module/Debug/ActivityPubConversion.php:125
+msgid "Result Item"
+msgstr ""
+
+#: src/Module/Debug/ActivityPubConversion.php:138
+msgid "Source activity"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:54
+msgid "Source input"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:60
+msgid "BBCode::toPlaintext"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:66
+msgid "BBCode::convert (raw HTML)"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:71
+msgid "BBCode::convert"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:77
+msgid "BBCode::convert => HTML::toBBCode"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:83
+msgid "BBCode::toMarkdown"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:89
+msgid "BBCode::toMarkdown => Markdown::convert (raw HTML)"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:93
+msgid "BBCode::toMarkdown => Markdown::convert"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:99
+msgid "BBCode::toMarkdown => Markdown::toBBCode"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:105
+msgid "BBCode::toMarkdown =>  Markdown::convert => HTML::toBBCode"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:113
+msgid "Item Body"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:117
+msgid "Item Tags"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:123
+msgid "PageInfo::appendToBody"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:128
+msgid "PageInfo::appendToBody => BBCode::convert (raw HTML)"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:132
+msgid "PageInfo::appendToBody => BBCode::convert"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:139
+msgid "Source input (Diaspora format)"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:148
+msgid "Source input (Markdown)"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:154
+msgid "Markdown::convert (raw HTML)"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:159
+msgid "Markdown::convert"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:165
+msgid "Markdown::toBBCode"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:172
+msgid "Raw HTML input"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:177
+msgid "HTML Input"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:183
+msgid "HTML::toBBCode"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:189
+msgid "HTML::toBBCode => BBCode::convert"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:194
+msgid "HTML::toBBCode => BBCode::convert (raw HTML)"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:200
+msgid "HTML::toBBCode => BBCode::toPlaintext"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:206
+msgid "HTML::toMarkdown"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:212
+msgid "HTML::toPlaintext"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:218
+msgid "HTML::toPlaintext (compact)"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:228
+msgid "Decoded post"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:252
+msgid "Post array before expand entities"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:259
+msgid "Post converted"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:264
+msgid "Converted body"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:270
+msgid "Twitter addon is absent from the addon/ folder."
+msgstr ""
+
+#: src/Module/Debug/Babel.php:280
+msgid "Source text"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:281
+msgid "BBCode"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:283
+msgid "Markdown"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:284
+msgid "HTML"
+msgstr ""
+
+#: src/Module/Debug/Babel.php:286
+msgid "Twitter Source"
+msgstr ""
+
+#: src/Module/Debug/Feed.php:38 src/Module/Filer/SaveTag.php:38
+#: src/Module/Settings/Profile/Index.php:158
+msgid "You must be logged in to use this module"
+msgstr ""
+
+#: src/Module/Debug/Feed.php:63
+msgid "Source URL"
+msgstr ""
+
+#: src/Module/Debug/Localtime.php:49
+msgid "Time Conversion"
+msgstr ""
+
+#: src/Module/Debug/Localtime.php:50
+msgid ""
+"Friendica provides this service for sharing events with other networks and "
+"friends in unknown timezones."
+msgstr ""
+
+#: src/Module/Debug/Localtime.php:51
+#, php-format
+msgid "UTC time: %s"
+msgstr ""
+
+#: src/Module/Debug/Localtime.php:54
+#, php-format
+msgid "Current timezone: %s"
+msgstr ""
+
+#: src/Module/Debug/Localtime.php:58
+#, php-format
+msgid "Converted localtime: %s"
+msgstr ""
+
+#: src/Module/Debug/Localtime.php:62
+msgid "Please select your timezone:"
+msgstr ""
+
+#: src/Module/Debug/Probe.php:38 src/Module/Debug/WebFinger.php:37
+msgid "Only logged in users are permitted to perform a probing."
+msgstr ""
+
+#: src/Module/Debug/Probe.php:54
+msgid "Lookup address"
+msgstr ""
+
+#: src/Module/Delegation.php:147
+msgid "Manage Identities and/or Pages"
+msgstr ""
+
+#: src/Module/Delegation.php:148
+msgid ""
+"Toggle between different identities or community/group pages which share "
+"your account details or which you have been granted \"manage\" permissions"
+msgstr ""
+
+#: src/Module/Delegation.php:149
+msgid "Select an identity to manage: "
 msgstr ""
 
 #: src/Module/Directory.php:77
@@ -8313,42 +7960,16 @@ msgstr ""
 msgid "Site Directory"
 msgstr ""
 
-#: src/Module/Attach.php:50 src/Module/Attach.php:62
-msgid "Item was not found."
+#: src/Module/Filer/RemoveTag.php:63
+msgid "Item was not removed"
 msgstr ""
 
-#: src/Module/Item/Compose.php:46
-msgid "Please enter a post body."
+#: src/Module/Filer/RemoveTag.php:66
+msgid "Item was not deleted"
 msgstr ""
 
-#: src/Module/Item/Compose.php:59
-msgid "This feature is only available with the frio theme."
-msgstr ""
-
-#: src/Module/Item/Compose.php:86
-msgid "Compose new personal note"
-msgstr ""
-
-#: src/Module/Item/Compose.php:95
-msgid "Compose new post"
-msgstr ""
-
-#: src/Module/Item/Compose.php:135
-msgid "Visibility"
-msgstr ""
-
-#: src/Module/Item/Compose.php:156
-msgid "Clear the location"
-msgstr ""
-
-#: src/Module/Item/Compose.php:157
-msgid "Location services are unavailable on your device"
-msgstr ""
-
-#: src/Module/Item/Compose.php:158
-msgid ""
-"Location services are disabled. Please check the website's permissions on "
-"your device"
+#: src/Module/Filer/SaveTag.php:65
+msgid "- select -"
 msgstr ""
 
 #: src/Module/Friendica.php:60
@@ -8394,58 +8015,21 @@ msgid ""
 "Suggestions, praise, etc. - please email \"info\" at \"friendi - dot - ca"
 msgstr ""
 
-#: src/Module/BaseProfile.php:113
-msgid "Only You Can See This"
+#: src/Module/FriendSuggest.php:65
+msgid "Suggested contact not found."
 msgstr ""
 
-#: src/Module/BaseProfile.php:132 src/Module/BaseProfile.php:135
-msgid "Tips for New Members"
+#: src/Module/FriendSuggest.php:84
+msgid "Friend suggestion sent."
 msgstr ""
 
-#: src/Module/Photo.php:87
+#: src/Module/FriendSuggest.php:121
+msgid "Suggest Friends"
+msgstr ""
+
+#: src/Module/FriendSuggest.php:124
 #, php-format
-msgid "The Photo with id %s is not available."
-msgstr ""
-
-#: src/Module/Photo.php:102
-#, php-format
-msgid "Invalid photo with id %s."
-msgstr ""
-
-#: src/Module/RemoteFollow.php:67
-msgid "The provided profile link doesn't seem to be valid"
-msgstr ""
-
-#: src/Module/RemoteFollow.php:105
-#, php-format
-msgid ""
-"Enter your Webfinger address (user@domain.tld) or profile URL here. If this "
-"isn't supported by your system, you have to subscribe to <strong>%s</strong> "
-"or <strong>%s</strong> directly on your system."
-msgstr ""
-
-#: src/Module/BaseSettings.php:43
-msgid "Account"
-msgstr ""
-
-#: src/Module/BaseSettings.php:73
-msgid "Display"
-msgstr ""
-
-#: src/Module/BaseSettings.php:94 src/Module/Settings/Delegation.php:171
-msgid "Manage Accounts"
-msgstr ""
-
-#: src/Module/BaseSettings.php:101
-msgid "Connected apps"
-msgstr ""
-
-#: src/Module/BaseSettings.php:108 src/Module/Settings/UserExport.php:65
-msgid "Export personal data"
-msgstr ""
-
-#: src/Module/BaseSettings.php:115
-msgid "Remove account"
+msgid "Suggest a friend for %s"
 msgstr ""
 
 #: src/Module/Group.php:61
@@ -8504,15 +8088,6 @@ msgstr ""
 msgid "Create a group of contacts/friends."
 msgstr ""
 
-#: src/Module/Group.php:178 src/Module/Group.php:201 src/Module/Group.php:276
-#: src/Model/Group.php:536
-msgid "Group Name: "
-msgstr ""
-
-#: src/Module/Group.php:193 src/Model/Group.php:533
-msgid "Contacts not in any group"
-msgstr ""
-
 #: src/Module/Group.php:219
 msgid "Unable to remove group."
 msgstr ""
@@ -8545,6 +8120,645 @@ msgstr ""
 msgid "Add contact to group"
 msgstr ""
 
+#: src/Module/Help.php:62
+msgid "Help:"
+msgstr ""
+
+#: src/Module/Home.php:54
+#, php-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: src/Module/HoverCard.php:47
+msgid "No profile"
+msgstr ""
+
+#: src/Module/HTTPException/MethodNotAllowed.php:32
+msgid "Method Not Allowed."
+msgstr ""
+
+#: src/Module/Install.php:177
+msgid "Friendica Communications Server - Setup"
+msgstr ""
+
+#: src/Module/Install.php:188
+msgid "System check"
+msgstr ""
+
+#: src/Module/Install.php:193
+msgid "Check again"
+msgstr ""
+
+#: src/Module/Install.php:208
+msgid "Base settings"
+msgstr ""
+
+#: src/Module/Install.php:215
+msgid "Host name"
+msgstr ""
+
+#: src/Module/Install.php:217
+msgid ""
+"Overwrite this field in case the determinated hostname isn't right, "
+"otherweise leave it as is."
+msgstr ""
+
+#: src/Module/Install.php:220
+msgid "Base path to installation"
+msgstr ""
+
+#: src/Module/Install.php:222
+msgid ""
+"If the system cannot detect the correct path to your installation, enter the "
+"correct path here. This setting should only be set if you are using a "
+"restricted system and symbolic links to your webroot."
+msgstr ""
+
+#: src/Module/Install.php:225
+msgid "Sub path of the URL"
+msgstr ""
+
+#: src/Module/Install.php:227
+msgid ""
+"Overwrite this field in case the sub path determination isn't right, "
+"otherwise leave it as is. Leaving this field blank means the installation is "
+"at the base URL without sub path."
+msgstr ""
+
+#: src/Module/Install.php:238
+msgid "Database connection"
+msgstr ""
+
+#: src/Module/Install.php:239
+msgid ""
+"In order to install Friendica we need to know how to connect to your "
+"database."
+msgstr ""
+
+#: src/Module/Install.php:240
+msgid ""
+"Please contact your hosting provider or site administrator if you have "
+"questions about these settings."
+msgstr ""
+
+#: src/Module/Install.php:241
+msgid ""
+"The database you specify below should already exist. If it does not, please "
+"create it before continuing."
+msgstr ""
+
+#: src/Module/Install.php:248
+msgid "Database Server Name"
+msgstr ""
+
+#: src/Module/Install.php:253
+msgid "Database Login Name"
+msgstr ""
+
+#: src/Module/Install.php:259
+msgid "Database Login Password"
+msgstr ""
+
+#: src/Module/Install.php:261
+msgid "For security reasons the password must not be empty"
+msgstr ""
+
+#: src/Module/Install.php:264
+msgid "Database Name"
+msgstr ""
+
+#: src/Module/Install.php:268 src/Module/Install.php:297
+msgid "Please select a default timezone for your website"
+msgstr ""
+
+#: src/Module/Install.php:282
+msgid "Site settings"
+msgstr ""
+
+#: src/Module/Install.php:292
+msgid "Site administrator email address"
+msgstr ""
+
+#: src/Module/Install.php:294
+msgid ""
+"Your account email address must match this in order to use the web admin "
+"panel."
+msgstr ""
+
+#: src/Module/Install.php:301
+msgid "System Language:"
+msgstr ""
+
+#: src/Module/Install.php:303
+msgid ""
+"Set the default language for your Friendica installation interface and to "
+"send emails."
+msgstr ""
+
+#: src/Module/Install.php:315
+msgid "Your Friendica site database has been installed."
+msgstr ""
+
+#: src/Module/Install.php:323
+msgid "Installation finished"
+msgstr ""
+
+#: src/Module/Install.php:343
+msgid "<h1>What next</h1>"
+msgstr ""
+
+#: src/Module/Install.php:344
+msgid ""
+"IMPORTANT: You will need to [manually] setup a scheduled task for the worker."
+msgstr ""
+
+#: src/Module/Install.php:345
+msgid "Please see the file \"INSTALL.txt\"."
+msgstr ""
+
+#: src/Module/Install.php:347
+#, php-format
+msgid ""
+"Go to your new Friendica node <a href=\"%s/register\">registration page</a> "
+"and register as new user. Remember to use the same email you have entered as "
+"administrator email. This will allow you to enter the site admin panel."
+msgstr ""
+
+#: src/Module/Invite.php:55
+msgid "Total invitation limit exceeded."
+msgstr ""
+
+#: src/Module/Invite.php:78
+#, php-format
+msgid "%s : Not a valid email address."
+msgstr ""
+
+#: src/Module/Invite.php:105
+msgid "Please join us on Friendica"
+msgstr ""
+
+#: src/Module/Invite.php:114
+msgid "Invitation limit exceeded. Please contact your site administrator."
+msgstr ""
+
+#: src/Module/Invite.php:118
+#, php-format
+msgid "%s : Message delivery failed."
+msgstr ""
+
+#: src/Module/Invite.php:122
+#, php-format
+msgid "%d message sent."
+msgid_plural "%d messages sent."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/Module/Invite.php:140
+msgid "You have no more invitations available"
+msgstr ""
+
+#: src/Module/Invite.php:147
+#, php-format
+msgid ""
+"Visit %s for a list of public sites that you can join. Friendica members on "
+"other sites can all connect with each other, as well as with members of many "
+"other social networks."
+msgstr ""
+
+#: src/Module/Invite.php:149
+#, php-format
+msgid ""
+"To accept this invitation, please visit and register at %s or any other "
+"public Friendica website."
+msgstr ""
+
+#: src/Module/Invite.php:150
+#, php-format
+msgid ""
+"Friendica sites all inter-connect to create a huge privacy-enhanced social "
+"web that is owned and controlled by its members. They can also connect with "
+"many traditional social networks. See %s for a list of alternate Friendica "
+"sites you can join."
+msgstr ""
+
+#: src/Module/Invite.php:154
+msgid ""
+"Our apologies. This system is not currently configured to connect with other "
+"public sites or invite members."
+msgstr ""
+
+#: src/Module/Invite.php:157
+msgid ""
+"Friendica sites all inter-connect to create a huge privacy-enhanced social "
+"web that is owned and controlled by its members. They can also connect with "
+"many traditional social networks."
+msgstr ""
+
+#: src/Module/Invite.php:156
+#, php-format
+msgid "To accept this invitation, please visit and register at %s."
+msgstr ""
+
+#: src/Module/Invite.php:164
+msgid "Send invitations"
+msgstr ""
+
+#: src/Module/Invite.php:165
+msgid "Enter email addresses, one per line:"
+msgstr ""
+
+#: src/Module/Invite.php:169
+msgid ""
+"You are cordially invited to join me and other close friends on Friendica - "
+"and help us to create a better social web."
+msgstr ""
+
+#: src/Module/Invite.php:171
+msgid "You will need to supply this invitation code: $invite_code"
+msgstr ""
+
+#: src/Module/Invite.php:171
+msgid ""
+"Once you have registered, please connect with me via my profile page at:"
+msgstr ""
+
+#: src/Module/Invite.php:173
+msgid ""
+"For more information about the Friendica project and why we feel it is "
+"important, please visit http://friendi.ca"
+msgstr ""
+
+#: src/Module/Item/Compose.php:46
+msgid "Please enter a post body."
+msgstr ""
+
+#: src/Module/Item/Compose.php:59
+msgid "This feature is only available with the frio theme."
+msgstr ""
+
+#: src/Module/Item/Compose.php:86
+msgid "Compose new personal note"
+msgstr ""
+
+#: src/Module/Item/Compose.php:95
+msgid "Compose new post"
+msgstr ""
+
+#: src/Module/Item/Compose.php:135
+msgid "Visibility"
+msgstr ""
+
+#: src/Module/Item/Compose.php:156
+msgid "Clear the location"
+msgstr ""
+
+#: src/Module/Item/Compose.php:157
+msgid "Location services are unavailable on your device"
+msgstr ""
+
+#: src/Module/Item/Compose.php:158
+msgid ""
+"Location services are disabled. Please check the website's permissions on "
+"your device"
+msgstr ""
+
+#: src/Module/Maintenance.php:46
+msgid "System down for maintenance"
+msgstr ""
+
+#: src/Module/Manifest.php:42
+msgid "A Decentralized Social Network"
+msgstr ""
+
+#: src/Module/Notifications/Introductions.php:76
+msgid "Show Ignored Requests"
+msgstr ""
+
+#: src/Module/Notifications/Introductions.php:76
+msgid "Hide Ignored Requests"
+msgstr ""
+
+#: src/Module/Notifications/Introductions.php:90
+#: src/Module/Notifications/Introductions.php:157
+msgid "Notification type:"
+msgstr ""
+
+#: src/Module/Notifications/Introductions.php:93
+msgid "Suggested by:"
+msgstr ""
+
+#: src/Module/Notifications/Introductions.php:118
+msgid "Claims to be known to you: "
+msgstr ""
+
+#: src/Module/Notifications/Introductions.php:125
+msgid "Shall your connection be bidirectional or not?"
+msgstr ""
+
+#: src/Module/Notifications/Introductions.php:126
+#, php-format
+msgid ""
+"Accepting %s as a friend allows %s to subscribe to your posts, and you will "
+"also receive updates from them in your news feed."
+msgstr ""
+
+#: src/Module/Notifications/Introductions.php:127
+#, php-format
+msgid ""
+"Accepting %s as a subscriber allows them to subscribe to your posts, but you "
+"will not receive updates from them in your news feed."
+msgstr ""
+
+#: src/Module/Notifications/Introductions.php:129
+msgid "Friend"
+msgstr ""
+
+#: src/Module/Notifications/Introductions.php:130
+msgid "Subscriber"
+msgstr ""
+
+#: src/Module/Notifications/Introductions.php:194
+msgid "No introductions."
+msgstr ""
+
+#: src/Module/Notifications/Introductions.php:195
+#: src/Module/Notifications/Notifications.php:133
+#, php-format
+msgid "No more %s notifications."
+msgstr ""
+
+#: src/Module/Notifications/Notification.php:103
+msgid "You must be logged in to show this page."
+msgstr ""
+
+#: src/Module/Notifications/Notifications.php:50
+msgid "Network Notifications"
+msgstr ""
+
+#: src/Module/Notifications/Notifications.php:58
+msgid "System Notifications"
+msgstr ""
+
+#: src/Module/Notifications/Notifications.php:66
+msgid "Personal Notifications"
+msgstr ""
+
+#: src/Module/Notifications/Notifications.php:74
+msgid "Home Notifications"
+msgstr ""
+
+#: src/Module/Notifications/Notifications.php:138
+msgid "Show unread"
+msgstr ""
+
+#: src/Module/Notifications/Notifications.php:138
+msgid "Show all"
+msgstr ""
+
+#: src/Module/PermissionTooltip.php:24
+#, php-format
+msgid "Wrong type \"%s\", expected one of: %s"
+msgstr ""
+
+#: src/Module/PermissionTooltip.php:37
+msgid "Model not found"
+msgstr ""
+
+#: src/Module/PermissionTooltip.php:59
+msgid "Remote privacy information not available."
+msgstr ""
+
+#: src/Module/PermissionTooltip.php:70
+msgid "Visible to:"
+msgstr ""
+
+#: src/Module/Photo.php:87
+#, php-format
+msgid "The Photo with id %s is not available."
+msgstr ""
+
+#: src/Module/Photo.php:102
+#, php-format
+msgid "Invalid photo with id %s."
+msgstr ""
+
+#: src/Module/Profile/Contacts.php:120
+msgid "No contacts."
+msgstr ""
+
+#: src/Module/Profile/Profile.php:135
+#, php-format
+msgid ""
+"You're currently viewing your profile as <b>%s</b> <a href=\"%s\" class="
+"\"btn btn-sm pull-right\">Cancel</a>"
+msgstr ""
+
+#: src/Module/Profile/Profile.php:149
+msgid "Member since:"
+msgstr ""
+
+#: src/Module/Profile/Profile.php:155
+msgid "j F, Y"
+msgstr ""
+
+#: src/Module/Profile/Profile.php:156
+msgid "j F"
+msgstr ""
+
+#: src/Module/Profile/Profile.php:164 src/Util/Temporal.php:163
+msgid "Birthday:"
+msgstr ""
+
+#: src/Module/Profile/Profile.php:167 src/Module/Settings/Profile/Index.php:260
+#: src/Util/Temporal.php:165
+msgid "Age: "
+msgstr ""
+
+#: src/Module/Profile/Profile.php:167 src/Module/Settings/Profile/Index.php:260
+#: src/Util/Temporal.php:165
+#, php-format
+msgid "%d year old"
+msgid_plural "%d years old"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/Module/Profile/Profile.php:229
+msgid "Forums:"
+msgstr ""
+
+#: src/Module/Profile/Profile.php:240
+msgid "View profile as:"
+msgstr ""
+
+#: src/Module/Profile/Profile.php:257
+msgid "View as"
+msgstr ""
+
+#: src/Module/Profile/Profile.php:320 src/Module/Profile/Profile.php:323
+#: src/Module/Profile/Status.php:61 src/Module/Profile/Status.php:64
+#: src/Protocol/Feed.php:892 src/Protocol/OStatus.php:1269
+#, php-format
+msgid "%s's timeline"
+msgstr ""
+
+#: src/Module/Profile/Profile.php:321 src/Module/Profile/Status.php:62
+#: src/Protocol/Feed.php:896 src/Protocol/OStatus.php:1273
+#, php-format
+msgid "%s's posts"
+msgstr ""
+
+#: src/Module/Profile/Profile.php:322 src/Module/Profile/Status.php:63
+#: src/Protocol/Feed.php:899 src/Protocol/OStatus.php:1276
+#, php-format
+msgid "%s's comments"
+msgstr ""
+
+#: src/Module/Register.php:69
+msgid "Only parent users can create additional accounts."
+msgstr ""
+
+#: src/Module/Register.php:101
+msgid ""
+"You may (optionally) fill in this form via OpenID by supplying your OpenID "
+"and clicking \"Register\"."
+msgstr ""
+
+#: src/Module/Register.php:102
+msgid ""
+"If you are not familiar with OpenID, please leave that field blank and fill "
+"in the rest of the items."
+msgstr ""
+
+#: src/Module/Register.php:103
+msgid "Your OpenID (optional): "
+msgstr ""
+
+#: src/Module/Register.php:112
+msgid "Include your profile in member directory?"
+msgstr ""
+
+#: src/Module/Register.php:135
+msgid "Note for the admin"
+msgstr ""
+
+#: src/Module/Register.php:135
+msgid "Leave a message for the admin, why you want to join this node"
+msgstr ""
+
+#: src/Module/Register.php:136
+msgid "Membership on this site is by invitation only."
+msgstr ""
+
+#: src/Module/Register.php:137
+msgid "Your invitation code: "
+msgstr ""
+
+#: src/Module/Register.php:145
+msgid "Your Full Name (e.g. Joe Smith, real or real-looking): "
+msgstr ""
+
+#: src/Module/Register.php:146
+msgid ""
+"Your Email Address: (Initial information will be send there, so this has to "
+"be an existing address.)"
+msgstr ""
+
+#: src/Module/Register.php:147
+msgid "Please repeat your e-mail address:"
+msgstr ""
+
+#: src/Module/Register.php:149
+msgid "Leave empty for an auto generated password."
+msgstr ""
+
+#: src/Module/Register.php:151
+#, php-format
+msgid ""
+"Choose a profile nickname. This must begin with a text character. Your "
+"profile address on this site will then be \"<strong>nickname@%s</strong>\"."
+msgstr ""
+
+#: src/Module/Register.php:152
+msgid "Choose a nickname: "
+msgstr ""
+
+#: src/Module/Register.php:161
+msgid "Import your profile to this friendica instance"
+msgstr ""
+
+#: src/Module/Register.php:168
+msgid "Note: This node explicitly contains adult content"
+msgstr ""
+
+#: src/Module/Register.php:170 src/Module/Settings/Delegation.php:155
+msgid "Parent Password:"
+msgstr ""
+
+#: src/Module/Register.php:170 src/Module/Settings/Delegation.php:155
+msgid ""
+"Please enter the password of the parent account to legitimize your request."
+msgstr ""
+
+#: src/Module/Register.php:201
+msgid "Password doesn't match."
+msgstr ""
+
+#: src/Module/Register.php:207
+msgid "Please enter your password."
+msgstr ""
+
+#: src/Module/Register.php:249
+msgid "You have entered too much information."
+msgstr ""
+
+#: src/Module/Register.php:273
+msgid "Please enter the identical mail address in the second field."
+msgstr ""
+
+#: src/Module/Register.php:300
+msgid "The additional account was created."
+msgstr ""
+
+#: src/Module/Register.php:325
+msgid ""
+"Registration successful. Please check your email for further instructions."
+msgstr ""
+
+#: src/Module/Register.php:329
+#, php-format
+msgid ""
+"Failed to send email message. Here your accout details:<br> login: %s<br> "
+"password: %s<br><br>You can change your password after login."
+msgstr ""
+
+#: src/Module/Register.php:335
+msgid "Registration successful."
+msgstr ""
+
+#: src/Module/Register.php:340 src/Module/Register.php:347
+msgid "Your registration can not be processed."
+msgstr ""
+
+#: src/Module/Register.php:346
+msgid "You have to leave a request note for the admin."
+msgstr ""
+
+#: src/Module/Register.php:394
+msgid "Your registration is pending approval by the site owner."
+msgstr ""
+
+#: src/Module/RemoteFollow.php:67
+msgid "The provided profile link doesn't seem to be valid"
+msgstr ""
+
+#: src/Module/RemoteFollow.php:105
+#, php-format
+msgid ""
+"Enter your Webfinger address (user@domain.tld) or profile URL here. If this "
+"isn't supported by your system, you have to subscribe to <strong>%s</strong> "
+"or <strong>%s</strong> directly on your system."
+msgstr ""
+
 #: src/Module/Search/Index.php:53
 msgid "Only logged in users are permitted to perform a search."
 msgstr ""
@@ -8553,18 +8767,9 @@ msgstr ""
 msgid "Only one search per minute is permitted for not logged in users."
 msgstr ""
 
-#: src/Module/Search/Index.php:98 src/Content/Nav.php:220
-#: src/Content/Text/HTML.php:902
-msgid "Search"
-msgstr ""
-
 #: src/Module/Search/Index.php:184
 #, php-format
 msgid "Items tagged with: %s"
-msgstr ""
-
-#: src/Module/Search/Acl.php:55 src/Module/Contact/Poke.php:127
-msgid "You must be logged in to use this module."
 msgstr ""
 
 #: src/Module/Search/Saved.php:45
@@ -8579,122 +8784,318 @@ msgstr ""
 msgid "Search term was not removed."
 msgstr ""
 
-#: src/Module/HoverCard.php:47
-msgid "No profile"
+#: src/Module/Security/Login.php:101
+msgid "Create a New Account"
 msgstr ""
 
-#: src/Module/Contact/Poke.php:114
-msgid "Error while sending poke, please retry."
+#: src/Module/Security/Login.php:126
+msgid "Your OpenID: "
 msgstr ""
 
-#: src/Module/Contact/Poke.php:150
-msgid "Poke/Prod"
-msgstr ""
-
-#: src/Module/Contact/Poke.php:151
-msgid "poke, prod or do other things to somebody"
-msgstr ""
-
-#: src/Module/Contact/Poke.php:153
-msgid "Choose what you wish to do to recipient"
-msgstr ""
-
-#: src/Module/Contact/Poke.php:154
-msgid "Make this post private"
-msgstr ""
-
-#: src/Module/Contact/Advanced.php:94
-msgid "Contact update failed."
-msgstr ""
-
-#: src/Module/Contact/Advanced.php:111
+#: src/Module/Security/Login.php:129
 msgid ""
-"<strong>WARNING: This is highly advanced</strong> and if you enter incorrect "
-"information your communications with this contact may stop working."
+"Please enter your username and password to add the OpenID to your existing "
+"account."
 msgstr ""
 
-#: src/Module/Contact/Advanced.php:112
+#: src/Module/Security/Login.php:131
+msgid "Or login using OpenID: "
+msgstr ""
+
+#: src/Module/Security/Login.php:145
+msgid "Password: "
+msgstr ""
+
+#: src/Module/Security/Login.php:146
+msgid "Remember me"
+msgstr ""
+
+#: src/Module/Security/Login.php:155
+msgid "Forgot your password?"
+msgstr ""
+
+#: src/Module/Security/Login.php:158
+msgid "Website Terms of Service"
+msgstr ""
+
+#: src/Module/Security/Login.php:159
+msgid "terms of service"
+msgstr ""
+
+#: src/Module/Security/Login.php:161
+msgid "Website Privacy Policy"
+msgstr ""
+
+#: src/Module/Security/Login.php:162
+msgid "privacy policy"
+msgstr ""
+
+#: src/Module/Security/Logout.php:53
+msgid "Logged out."
+msgstr ""
+
+#: src/Module/Security/OpenID.php:54
+msgid "OpenID protocol error. No ID returned"
+msgstr ""
+
+#: src/Module/Security/OpenID.php:92
 msgid ""
-"Please use your browser 'Back' button <strong>now</strong> if you are "
-"uncertain what to do on this page."
+"Account not found. Please login to your existing account to add the OpenID "
+"to it."
 msgstr ""
 
-#: src/Module/Contact/Advanced.php:123 src/Module/Contact/Advanced.php:125
-msgid "No mirroring"
-msgstr ""
-
-#: src/Module/Contact/Advanced.php:123
-msgid "Mirror as forwarded posting"
-msgstr ""
-
-#: src/Module/Contact/Advanced.php:123 src/Module/Contact/Advanced.php:125
-msgid "Mirror as my own posting"
-msgstr ""
-
-#: src/Module/Contact/Advanced.php:136
-msgid "Return to contact editor"
-msgstr ""
-
-#: src/Module/Contact/Advanced.php:141
-msgid "Remote Self"
-msgstr ""
-
-#: src/Module/Contact/Advanced.php:144
-msgid "Mirror postings from this contact"
-msgstr ""
-
-#: src/Module/Contact/Advanced.php:146
+#: src/Module/Security/OpenID.php:94
 msgid ""
-"Mark this contact as remote_self, this will cause friendica to repost new "
-"entries from this contact."
+"Account not found. Please register a new account or login to your existing "
+"account to add the OpenID to it."
 msgstr ""
 
-#: src/Module/Contact/Advanced.php:151
-msgid "Account Nickname"
+#: src/Module/Security/TwoFactor/Recovery.php:60
+#, php-format
+msgid "Remaining recovery codes: %d"
 msgstr ""
 
-#: src/Module/Contact/Advanced.php:152
-msgid "@Tagname - overrides Name/Nickname"
+#: src/Module/Security/TwoFactor/Recovery.php:64
+#: src/Module/Security/TwoFactor/Verify.php:61
+#: src/Module/Settings/TwoFactor/Verify.php:82
+msgid "Invalid code, please retry."
 msgstr ""
 
-#: src/Module/Contact/Advanced.php:153
-msgid "Account URL"
+#: src/Module/Security/TwoFactor/Recovery.php:83
+msgid "Two-factor recovery"
 msgstr ""
 
-#: src/Module/Contact/Advanced.php:154
-msgid "Account URL Alias"
+#: src/Module/Security/TwoFactor/Recovery.php:84
+msgid ""
+"<p>You can enter one of your one-time recovery codes in case you lost access "
+"to your mobile device.</p>"
 msgstr ""
 
-#: src/Module/Contact/Advanced.php:155
-msgid "Friend Request URL"
+#: src/Module/Security/TwoFactor/Recovery.php:85
+#: src/Module/Security/TwoFactor/Verify.php:84
+#, php-format
+msgid ""
+"Don’t have your phone? <a href=\"%s\">Enter a two-factor recovery code</a>"
 msgstr ""
 
-#: src/Module/Contact/Advanced.php:156
-msgid "Friend Confirm URL"
+#: src/Module/Security/TwoFactor/Recovery.php:86
+msgid "Please enter a recovery code"
 msgstr ""
 
-#: src/Module/Contact/Advanced.php:157
-msgid "Notification Endpoint URL"
+#: src/Module/Security/TwoFactor/Recovery.php:87
+msgid "Submit recovery code and complete login"
 msgstr ""
 
-#: src/Module/Contact/Advanced.php:158
-msgid "Poll/Feed URL"
+#: src/Module/Security/TwoFactor/Verify.php:81
+msgid ""
+"<p>Open the two-factor authentication app on your device to get an "
+"authentication code and verify your identity.</p>"
 msgstr ""
 
-#: src/Module/Contact/Advanced.php:159
-msgid "New photo from this URL"
+#: src/Module/Security/TwoFactor/Verify.php:85
+#: src/Module/Settings/TwoFactor/Verify.php:141
+msgid "Please enter a code from your authentication app"
 msgstr ""
 
-#: src/Module/Contact/Contacts.php:46
-msgid "No known contacts."
+#: src/Module/Security/TwoFactor/Verify.php:86
+msgid "Verify code and complete login"
 msgstr ""
 
-#: src/Module/Apps.php:47
-msgid "No installed applications."
+#: src/Module/Settings/Delegation.php:53
+msgid "Delegation successfully granted."
 msgstr ""
 
-#: src/Module/Apps.php:52
-msgid "Applications"
+#: src/Module/Settings/Delegation.php:55
+msgid "Parent user not found, unavailable or password doesn't match."
+msgstr ""
+
+#: src/Module/Settings/Delegation.php:59
+msgid "Delegation successfully revoked."
+msgstr ""
+
+#: src/Module/Settings/Delegation.php:81 src/Module/Settings/Delegation.php:103
+msgid ""
+"Delegated administrators can view but not change delegation permissions."
+msgstr ""
+
+#: src/Module/Settings/Delegation.php:95
+msgid "Delegate user not found."
+msgstr ""
+
+#: src/Module/Settings/Delegation.php:143
+msgid "No parent user"
+msgstr ""
+
+#: src/Module/Settings/Delegation.php:154
+#: src/Module/Settings/Delegation.php:165
+msgid "Parent User"
+msgstr ""
+
+#: src/Module/Settings/Delegation.php:162
+msgid "Additional Accounts"
+msgstr ""
+
+#: src/Module/Settings/Delegation.php:163
+msgid ""
+"Register additional accounts that are automatically connected to your "
+"existing account so you can manage them from this account."
+msgstr ""
+
+#: src/Module/Settings/Delegation.php:164
+msgid "Register an additional account"
+msgstr ""
+
+#: src/Module/Settings/Delegation.php:168
+msgid ""
+"Parent users have total control about this account, including the account "
+"settings. Please double check whom you give this access."
+msgstr ""
+
+#: src/Module/Settings/Delegation.php:172
+msgid "Delegates"
+msgstr ""
+
+#: src/Module/Settings/Delegation.php:174
+msgid ""
+"Delegates are able to manage all aspects of this account/page except for "
+"basic account settings. Please do not delegate your personal account to "
+"anybody that you do not trust completely."
+msgstr ""
+
+#: src/Module/Settings/Delegation.php:175
+msgid "Existing Page Delegates"
+msgstr ""
+
+#: src/Module/Settings/Delegation.php:177
+msgid "Potential Delegates"
+msgstr ""
+
+#: src/Module/Settings/Delegation.php:180
+msgid "Add"
+msgstr ""
+
+#: src/Module/Settings/Delegation.php:181
+msgid "No entries."
+msgstr ""
+
+#: src/Module/Settings/Display.php:103
+msgid "The theme you chose isn't available."
+msgstr ""
+
+#: src/Module/Settings/Display.php:140
+#, php-format
+msgid "%s - (Unsupported)"
+msgstr ""
+
+#: src/Module/Settings/Display.php:184
+msgid "Display Settings"
+msgstr ""
+
+#: src/Module/Settings/Display.php:186
+msgid "General Theme Settings"
+msgstr ""
+
+#: src/Module/Settings/Display.php:187
+msgid "Custom Theme Settings"
+msgstr ""
+
+#: src/Module/Settings/Display.php:188
+msgid "Content Settings"
+msgstr ""
+
+#: src/Module/Settings/Display.php:189 view/theme/duepuntozero/config.php:70
+#: view/theme/frio/config.php:161 view/theme/quattro/config.php:72
+#: view/theme/vier/config.php:120
+msgid "Theme settings"
+msgstr ""
+
+#: src/Module/Settings/Display.php:190
+msgid "Calendar"
+msgstr ""
+
+#: src/Module/Settings/Display.php:196
+msgid "Display Theme:"
+msgstr ""
+
+#: src/Module/Settings/Display.php:197
+msgid "Mobile Theme:"
+msgstr ""
+
+#: src/Module/Settings/Display.php:200
+msgid "Number of items to display per page:"
+msgstr ""
+
+#: src/Module/Settings/Display.php:200 src/Module/Settings/Display.php:201
+msgid "Maximum of 100 items"
+msgstr ""
+
+#: src/Module/Settings/Display.php:201
+msgid "Number of items to display per page when viewed from mobile device:"
+msgstr ""
+
+#: src/Module/Settings/Display.php:202
+msgid "Update browser every xx seconds"
+msgstr ""
+
+#: src/Module/Settings/Display.php:202
+msgid "Minimum of 10 seconds. Enter -1 to disable it."
+msgstr ""
+
+#: src/Module/Settings/Display.php:203
+msgid "Automatic updates only at the top of the post stream pages"
+msgstr ""
+
+#: src/Module/Settings/Display.php:203
+msgid ""
+"Auto update may add new posts at the top of the post stream pages, which can "
+"affect the scroll position and perturb normal reading if it happens anywhere "
+"else the top of the page."
+msgstr ""
+
+#: src/Module/Settings/Display.php:204
+msgid "Don't show emoticons"
+msgstr ""
+
+#: src/Module/Settings/Display.php:204
+msgid ""
+"Normally emoticons are replaced with matching symbols. This setting disables "
+"this behaviour."
+msgstr ""
+
+#: src/Module/Settings/Display.php:205
+msgid "Infinite scroll"
+msgstr ""
+
+#: src/Module/Settings/Display.php:205
+msgid "Automatic fetch new items when reaching the page end."
+msgstr ""
+
+#: src/Module/Settings/Display.php:206
+msgid "Disable Smart Threading"
+msgstr ""
+
+#: src/Module/Settings/Display.php:206
+msgid "Disable the automatic suppression of extraneous thread indentation."
+msgstr ""
+
+#: src/Module/Settings/Display.php:207
+msgid "Hide the Dislike feature"
+msgstr ""
+
+#: src/Module/Settings/Display.php:207
+msgid "Hides the Dislike button and dislike reactions on posts and comments."
+msgstr ""
+
+#: src/Module/Settings/Display.php:208
+msgid "Display the resharer"
+msgstr ""
+
+#: src/Module/Settings/Display.php:208
+msgid "Display the first resharer as icon and text on a reshared item."
+msgstr ""
+
+#: src/Module/Settings/Display.php:210
+msgid "Beginning of week:"
 msgstr ""
 
 #: src/Module/Settings/Profile/Index.php:85
@@ -8756,6 +9157,10 @@ msgstr ""
 
 #: src/Module/Settings/Profile/Index.php:246
 msgid "Custom Profile Fields"
+msgstr ""
+
+#: src/Module/Settings/Profile/Index.php:248 src/Module/Welcome.php:58
+msgid "Upload Profile Photo"
 msgstr ""
 
 #: src/Module/Settings/Profile/Index.php:252
@@ -8894,81 +9299,82 @@ msgstr ""
 msgid "select a photo from your photo albums"
 msgstr ""
 
-#: src/Module/Settings/Delegation.php:53
-msgid "Delegation successfully granted."
+#: src/Module/Settings/TwoFactor/AppSpecific.php:52
+#: src/Module/Settings/TwoFactor/Recovery.php:50
+#: src/Module/Settings/TwoFactor/Verify.php:56
+msgid "Please enter your password to access this page."
 msgstr ""
 
-#: src/Module/Settings/Delegation.php:55
-msgid "Parent user not found, unavailable or password doesn't match."
+#: src/Module/Settings/TwoFactor/AppSpecific.php:70
+msgid "App-specific password generation failed: The description is empty."
 msgstr ""
 
-#: src/Module/Settings/Delegation.php:59
-msgid "Delegation successfully revoked."
-msgstr ""
-
-#: src/Module/Settings/Delegation.php:81 src/Module/Settings/Delegation.php:103
+#: src/Module/Settings/TwoFactor/AppSpecific.php:73
 msgid ""
-"Delegated administrators can view but not change delegation permissions."
+"App-specific password generation failed: This description already exists."
 msgstr ""
 
-#: src/Module/Settings/Delegation.php:95
-msgid "Delegate user not found."
+#: src/Module/Settings/TwoFactor/AppSpecific.php:77
+msgid "New app-specific password generated."
 msgstr ""
 
-#: src/Module/Settings/Delegation.php:143
-msgid "No parent user"
+#: src/Module/Settings/TwoFactor/AppSpecific.php:83
+msgid "App-specific passwords successfully revoked."
 msgstr ""
 
-#: src/Module/Settings/Delegation.php:154
-#: src/Module/Settings/Delegation.php:165
-msgid "Parent User"
+#: src/Module/Settings/TwoFactor/AppSpecific.php:93
+msgid "App-specific password successfully revoked."
 msgstr ""
 
-#: src/Module/Settings/Delegation.php:162
-msgid "Additional Accounts"
+#: src/Module/Settings/TwoFactor/AppSpecific.php:114
+msgid "Two-factor app-specific passwords"
 msgstr ""
 
-#: src/Module/Settings/Delegation.php:163
+#: src/Module/Settings/TwoFactor/AppSpecific.php:116
 msgid ""
-"Register additional accounts that are automatically connected to your "
-"existing account so you can manage them from this account."
+"<p>App-specific passwords are randomly generated passwords used instead your "
+"regular password to authenticate your account on third-party applications "
+"that don't support two-factor authentication.</p>"
 msgstr ""
 
-#: src/Module/Settings/Delegation.php:164
-msgid "Register an additional account"
-msgstr ""
-
-#: src/Module/Settings/Delegation.php:168
+#: src/Module/Settings/TwoFactor/AppSpecific.php:117
 msgid ""
-"Parent users have total control about this account, including the account "
-"settings. Please double check whom you give this access."
+"Make sure to copy your new app-specific password now. You won’t be able to "
+"see it again!"
 msgstr ""
 
-#: src/Module/Settings/Delegation.php:172
-msgid "Delegates"
+#: src/Module/Settings/TwoFactor/AppSpecific.php:120
+msgid "Description"
 msgstr ""
 
-#: src/Module/Settings/Delegation.php:174
+#: src/Module/Settings/TwoFactor/AppSpecific.php:121
+msgid "Last Used"
+msgstr ""
+
+#: src/Module/Settings/TwoFactor/AppSpecific.php:122
+msgid "Revoke"
+msgstr ""
+
+#: src/Module/Settings/TwoFactor/AppSpecific.php:123
+msgid "Revoke All"
+msgstr ""
+
+#: src/Module/Settings/TwoFactor/AppSpecific.php:126
 msgid ""
-"Delegates are able to manage all aspects of this account/page except for "
-"basic account settings. Please do not delegate your personal account to "
-"anybody that you do not trust completely."
+"When you generate a new app-specific password, you must use it right away, "
+"it will be shown to you once after you generate it."
 msgstr ""
 
-#: src/Module/Settings/Delegation.php:175
-msgid "Existing Page Delegates"
+#: src/Module/Settings/TwoFactor/AppSpecific.php:127
+msgid "Generate new app-specific password"
 msgstr ""
 
-#: src/Module/Settings/Delegation.php:177
-msgid "Potential Delegates"
+#: src/Module/Settings/TwoFactor/AppSpecific.php:128
+msgid "Friendiqa on my Fairphone 2..."
 msgstr ""
 
-#: src/Module/Settings/Delegation.php:180
-msgid "Add"
-msgstr ""
-
-#: src/Module/Settings/Delegation.php:181
-msgid "No entries."
+#: src/Module/Settings/TwoFactor/AppSpecific.php:129
+msgid "Generate"
 msgstr ""
 
 #: src/Module/Settings/TwoFactor/Index.php:67
@@ -9063,10 +9469,34 @@ msgstr ""
 msgid "Finish app configuration"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Verify.php:56
-#: src/Module/Settings/TwoFactor/Recovery.php:50
-#: src/Module/Settings/TwoFactor/AppSpecific.php:52
-msgid "Please enter your password to access this page."
+#: src/Module/Settings/TwoFactor/Recovery.php:66
+msgid "New recovery codes successfully generated."
+msgstr ""
+
+#: src/Module/Settings/TwoFactor/Recovery.php:92
+msgid "Two-factor recovery codes"
+msgstr ""
+
+#: src/Module/Settings/TwoFactor/Recovery.php:94
+msgid ""
+"<p>Recovery codes can be used to access your account in the event you lose "
+"access to your device and cannot receive two-factor authentication codes.</"
+"p><p><strong>Put these in a safe spot!</strong> If you lose your device and "
+"don’t have the recovery codes you will lose access to your account.</p>"
+msgstr ""
+
+#: src/Module/Settings/TwoFactor/Recovery.php:96
+msgid ""
+"When you generate new recovery codes, you must copy the new codes. Your old "
+"codes won’t work anymore."
+msgstr ""
+
+#: src/Module/Settings/TwoFactor/Recovery.php:97
+msgid "Generate new recovery codes"
+msgstr ""
+
+#: src/Module/Settings/TwoFactor/Recovery.php:99
+msgid "Next: Verification"
 msgstr ""
 
 #: src/Module/Settings/TwoFactor/Verify.php:78
@@ -9114,222 +9544,6 @@ msgstr ""
 msgid "Verify code and enable two-factor authentication"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Recovery.php:66
-msgid "New recovery codes successfully generated."
-msgstr ""
-
-#: src/Module/Settings/TwoFactor/Recovery.php:92
-msgid "Two-factor recovery codes"
-msgstr ""
-
-#: src/Module/Settings/TwoFactor/Recovery.php:94
-msgid ""
-"<p>Recovery codes can be used to access your account in the event you lose "
-"access to your device and cannot receive two-factor authentication codes.</"
-"p><p><strong>Put these in a safe spot!</strong> If you lose your device and "
-"don’t have the recovery codes you will lose access to your account.</p>"
-msgstr ""
-
-#: src/Module/Settings/TwoFactor/Recovery.php:96
-msgid ""
-"When you generate new recovery codes, you must copy the new codes. Your old "
-"codes won’t work anymore."
-msgstr ""
-
-#: src/Module/Settings/TwoFactor/Recovery.php:97
-msgid "Generate new recovery codes"
-msgstr ""
-
-#: src/Module/Settings/TwoFactor/Recovery.php:99
-msgid "Next: Verification"
-msgstr ""
-
-#: src/Module/Settings/TwoFactor/AppSpecific.php:70
-msgid "App-specific password generation failed: The description is empty."
-msgstr ""
-
-#: src/Module/Settings/TwoFactor/AppSpecific.php:73
-msgid ""
-"App-specific password generation failed: This description already exists."
-msgstr ""
-
-#: src/Module/Settings/TwoFactor/AppSpecific.php:77
-msgid "New app-specific password generated."
-msgstr ""
-
-#: src/Module/Settings/TwoFactor/AppSpecific.php:83
-msgid "App-specific passwords successfully revoked."
-msgstr ""
-
-#: src/Module/Settings/TwoFactor/AppSpecific.php:93
-msgid "App-specific password successfully revoked."
-msgstr ""
-
-#: src/Module/Settings/TwoFactor/AppSpecific.php:114
-msgid "Two-factor app-specific passwords"
-msgstr ""
-
-#: src/Module/Settings/TwoFactor/AppSpecific.php:116
-msgid ""
-"<p>App-specific passwords are randomly generated passwords used instead your "
-"regular password to authenticate your account on third-party applications "
-"that don't support two-factor authentication.</p>"
-msgstr ""
-
-#: src/Module/Settings/TwoFactor/AppSpecific.php:117
-msgid ""
-"Make sure to copy your new app-specific password now. You won’t be able to "
-"see it again!"
-msgstr ""
-
-#: src/Module/Settings/TwoFactor/AppSpecific.php:120
-msgid "Description"
-msgstr ""
-
-#: src/Module/Settings/TwoFactor/AppSpecific.php:121
-msgid "Last Used"
-msgstr ""
-
-#: src/Module/Settings/TwoFactor/AppSpecific.php:122
-msgid "Revoke"
-msgstr ""
-
-#: src/Module/Settings/TwoFactor/AppSpecific.php:123
-msgid "Revoke All"
-msgstr ""
-
-#: src/Module/Settings/TwoFactor/AppSpecific.php:126
-msgid ""
-"When you generate a new app-specific password, you must use it right away, "
-"it will be shown to you once after you generate it."
-msgstr ""
-
-#: src/Module/Settings/TwoFactor/AppSpecific.php:127
-msgid "Generate new app-specific password"
-msgstr ""
-
-#: src/Module/Settings/TwoFactor/AppSpecific.php:128
-msgid "Friendiqa on my Fairphone 2..."
-msgstr ""
-
-#: src/Module/Settings/TwoFactor/AppSpecific.php:129
-msgid "Generate"
-msgstr ""
-
-#: src/Module/Settings/Display.php:103
-msgid "The theme you chose isn't available."
-msgstr ""
-
-#: src/Module/Settings/Display.php:140
-#, php-format
-msgid "%s - (Unsupported)"
-msgstr ""
-
-#: src/Module/Settings/Display.php:184
-msgid "Display Settings"
-msgstr ""
-
-#: src/Module/Settings/Display.php:186
-msgid "General Theme Settings"
-msgstr ""
-
-#: src/Module/Settings/Display.php:187
-msgid "Custom Theme Settings"
-msgstr ""
-
-#: src/Module/Settings/Display.php:188
-msgid "Content Settings"
-msgstr ""
-
-#: src/Module/Settings/Display.php:190
-msgid "Calendar"
-msgstr ""
-
-#: src/Module/Settings/Display.php:196
-msgid "Display Theme:"
-msgstr ""
-
-#: src/Module/Settings/Display.php:197
-msgid "Mobile Theme:"
-msgstr ""
-
-#: src/Module/Settings/Display.php:200
-msgid "Number of items to display per page:"
-msgstr ""
-
-#: src/Module/Settings/Display.php:200 src/Module/Settings/Display.php:201
-msgid "Maximum of 100 items"
-msgstr ""
-
-#: src/Module/Settings/Display.php:201
-msgid "Number of items to display per page when viewed from mobile device:"
-msgstr ""
-
-#: src/Module/Settings/Display.php:202
-msgid "Update browser every xx seconds"
-msgstr ""
-
-#: src/Module/Settings/Display.php:202
-msgid "Minimum of 10 seconds. Enter -1 to disable it."
-msgstr ""
-
-#: src/Module/Settings/Display.php:203
-msgid "Automatic updates only at the top of the post stream pages"
-msgstr ""
-
-#: src/Module/Settings/Display.php:203
-msgid ""
-"Auto update may add new posts at the top of the post stream pages, which can "
-"affect the scroll position and perturb normal reading if it happens anywhere "
-"else the top of the page."
-msgstr ""
-
-#: src/Module/Settings/Display.php:204
-msgid "Don't show emoticons"
-msgstr ""
-
-#: src/Module/Settings/Display.php:204
-msgid ""
-"Normally emoticons are replaced with matching symbols. This setting disables "
-"this behaviour."
-msgstr ""
-
-#: src/Module/Settings/Display.php:205
-msgid "Infinite scroll"
-msgstr ""
-
-#: src/Module/Settings/Display.php:205
-msgid "Automatic fetch new items when reaching the page end."
-msgstr ""
-
-#: src/Module/Settings/Display.php:206
-msgid "Disable Smart Threading"
-msgstr ""
-
-#: src/Module/Settings/Display.php:206
-msgid "Disable the automatic suppression of extraneous thread indentation."
-msgstr ""
-
-#: src/Module/Settings/Display.php:207
-msgid "Hide the Dislike feature"
-msgstr ""
-
-#: src/Module/Settings/Display.php:207
-msgid "Hides the Dislike button and dislike reactions on posts and comments."
-msgstr ""
-
-#: src/Module/Settings/Display.php:208
-msgid "Display the resharer"
-msgstr ""
-
-#: src/Module/Settings/Display.php:208
-msgid "Display the first resharer as icon and text on a reshared item."
-msgstr ""
-
-#: src/Module/Settings/Display.php:210
-msgid "Beginning of week:"
-msgstr ""
-
 #: src/Module/Settings/UserExport.php:57
 msgid "Export account"
 msgstr ""
@@ -9361,8 +9575,471 @@ msgid ""
 "e.g. Mastodon."
 msgstr ""
 
-#: src/Module/Maintenance.php:46
-msgid "System down for maintenance"
+#: src/Module/Special/HTTPException.php:49
+msgid "Bad Request"
+msgstr ""
+
+#: src/Module/Special/HTTPException.php:50
+msgid "Unauthorized"
+msgstr ""
+
+#: src/Module/Special/HTTPException.php:51
+msgid "Forbidden"
+msgstr ""
+
+#: src/Module/Special/HTTPException.php:52
+msgid "Not Found"
+msgstr ""
+
+#: src/Module/Special/HTTPException.php:53
+msgid "Internal Server Error"
+msgstr ""
+
+#: src/Module/Special/HTTPException.php:54
+msgid "Service Unavailable"
+msgstr ""
+
+#: src/Module/Special/HTTPException.php:61
+msgid ""
+"The server cannot or will not process the request due to an apparent client "
+"error."
+msgstr ""
+
+#: src/Module/Special/HTTPException.php:62
+msgid "Authentication is required and has failed or has not yet been provided."
+msgstr ""
+
+#: src/Module/Special/HTTPException.php:63
+msgid ""
+"The request was valid, but the server is refusing action. The user might not "
+"have the necessary permissions for a resource, or may need an account."
+msgstr ""
+
+#: src/Module/Special/HTTPException.php:64
+msgid ""
+"The requested resource could not be found but may be available in the future."
+msgstr ""
+
+#: src/Module/Special/HTTPException.php:65
+msgid ""
+"An unexpected condition was encountered and no more specific message is "
+"suitable."
+msgstr ""
+
+#: src/Module/Special/HTTPException.php:66
+msgid ""
+"The server is currently unavailable (because it is overloaded or down for "
+"maintenance). Please try again later."
+msgstr ""
+
+#: src/Module/Tos.php:46 src/Module/Tos.php:88
+msgid ""
+"At the time of registration, and for providing communications between the "
+"user account and their contacts, the user has to provide a display name (pen "
+"name), an username (nickname) and a working email address. The names will be "
+"accessible on the profile page of the account by any visitor of the page, "
+"even if other profile details are not displayed. The email address will only "
+"be used to send the user notifications about interactions, but wont be "
+"visibly displayed. The listing of an account in the node's user directory or "
+"the global user directory is optional and can be controlled in the user "
+"settings, it is not necessary for communication."
+msgstr ""
+
+#: src/Module/Tos.php:47 src/Module/Tos.php:89
+msgid ""
+"This data is required for communication and is passed on to the nodes of the "
+"communication partners and is stored there. Users can enter additional "
+"private data that may be transmitted to the communication partners accounts."
+msgstr ""
+
+#: src/Module/Tos.php:48 src/Module/Tos.php:90
+#, php-format
+msgid ""
+"At any point in time a logged in user can export their account data from the "
+"<a href=\"%1$s/settings/userexport\">account settings</a>. If the user wants "
+"to delete their account they can do so at <a href=\"%1$s/removeme\">%1$s/"
+"removeme</a>. The deletion of the account will be permanent. Deletion of the "
+"data will also be requested from the nodes of the communication partners."
+msgstr ""
+
+#: src/Module/Tos.php:51 src/Module/Tos.php:87
+msgid "Privacy Statement"
+msgstr ""
+
+#: src/Module/Welcome.php:44
+msgid "Welcome to Friendica"
+msgstr ""
+
+#: src/Module/Welcome.php:45
+msgid "New Member Checklist"
+msgstr ""
+
+#: src/Module/Welcome.php:46
+msgid ""
+"We would like to offer some tips and links to help make your experience "
+"enjoyable. Click any item to visit the relevant page. A link to this page "
+"will be visible from your home page for two weeks after your initial "
+"registration and then will quietly disappear."
+msgstr ""
+
+#: src/Module/Welcome.php:48
+msgid "Getting Started"
+msgstr ""
+
+#: src/Module/Welcome.php:49
+msgid "Friendica Walk-Through"
+msgstr ""
+
+#: src/Module/Welcome.php:50
+msgid ""
+"On your <em>Quick Start</em> page - find a brief introduction to your "
+"profile and network tabs, make some new connections, and find some groups to "
+"join."
+msgstr ""
+
+#: src/Module/Welcome.php:53
+msgid "Go to Your Settings"
+msgstr ""
+
+#: src/Module/Welcome.php:54
+msgid ""
+"On your <em>Settings</em> page -  change your initial password. Also make a "
+"note of your Identity Address. This looks just like an email address - and "
+"will be useful in making friends on the free social web."
+msgstr ""
+
+#: src/Module/Welcome.php:55
+msgid ""
+"Review the other settings, particularly the privacy settings. An unpublished "
+"directory listing is like having an unlisted phone number. In general, you "
+"should probably publish your listing - unless all of your friends and "
+"potential friends know exactly how to find you."
+msgstr ""
+
+#: src/Module/Welcome.php:59
+msgid ""
+"Upload a profile photo if you have not done so already. Studies have shown "
+"that people with real photos of themselves are ten times more likely to make "
+"friends than people who do not."
+msgstr ""
+
+#: src/Module/Welcome.php:60
+msgid "Edit Your Profile"
+msgstr ""
+
+#: src/Module/Welcome.php:61
+msgid ""
+"Edit your <strong>default</strong> profile to your liking. Review the "
+"settings for hiding your list of friends and hiding the profile from unknown "
+"visitors."
+msgstr ""
+
+#: src/Module/Welcome.php:62
+msgid "Profile Keywords"
+msgstr ""
+
+#: src/Module/Welcome.php:63
+msgid ""
+"Set some public keywords for your profile which describe your interests. We "
+"may be able to find other people with similar interests and suggest "
+"friendships."
+msgstr ""
+
+#: src/Module/Welcome.php:65
+msgid "Connecting"
+msgstr ""
+
+#: src/Module/Welcome.php:67
+msgid "Importing Emails"
+msgstr ""
+
+#: src/Module/Welcome.php:68
+msgid ""
+"Enter your email access information on your Connector Settings page if you "
+"wish to import and interact with friends or mailing lists from your email "
+"INBOX"
+msgstr ""
+
+#: src/Module/Welcome.php:69
+msgid "Go to Your Contacts Page"
+msgstr ""
+
+#: src/Module/Welcome.php:70
+msgid ""
+"Your Contacts page is your gateway to managing friendships and connecting "
+"with friends on other networks. Typically you enter their address or site "
+"URL in the <em>Add New Contact</em> dialog."
+msgstr ""
+
+#: src/Module/Welcome.php:71
+msgid "Go to Your Site's Directory"
+msgstr ""
+
+#: src/Module/Welcome.php:72
+msgid ""
+"The Directory page lets you find other people in this network or other "
+"federated sites. Look for a <em>Connect</em> or <em>Follow</em> link on "
+"their profile page. Provide your own Identity Address if requested."
+msgstr ""
+
+#: src/Module/Welcome.php:73
+msgid "Finding New People"
+msgstr ""
+
+#: src/Module/Welcome.php:74
+msgid ""
+"On the side panel of the Contacts page are several tools to find new "
+"friends. We can match people by interest, look up people by name or "
+"interest, and provide suggestions based on network relationships. On a brand "
+"new site, friend suggestions will usually begin to be populated within 24 "
+"hours."
+msgstr ""
+
+#: src/Module/Welcome.php:77
+msgid "Group Your Contacts"
+msgstr ""
+
+#: src/Module/Welcome.php:78
+msgid ""
+"Once you have made some friends, organize them into private conversation "
+"groups from the sidebar of your Contacts page and then you can interact with "
+"each group privately on your Network page."
+msgstr ""
+
+#: src/Module/Welcome.php:80
+msgid "Why Aren't My Posts Public?"
+msgstr ""
+
+#: src/Module/Welcome.php:81
+msgid ""
+"Friendica respects your privacy. By default, your posts will only show up to "
+"people you've added as friends. For more information, see the help section "
+"from the link above."
+msgstr ""
+
+#: src/Module/Welcome.php:83
+msgid "Getting Help"
+msgstr ""
+
+#: src/Module/Welcome.php:84
+msgid "Go to the Help Section"
+msgstr ""
+
+#: src/Module/Welcome.php:85
+msgid ""
+"Our <strong>help</strong> pages may be consulted for detail on other program "
+"features and resources."
+msgstr ""
+
+#: src/Object/EMail/ItemCCEMail.php:39
+#, php-format
+msgid ""
+"This message was sent to you by %s, a member of the Friendica social network."
+msgstr ""
+
+#: src/Object/EMail/ItemCCEMail.php:41
+#, php-format
+msgid "You may visit them online at %s"
+msgstr ""
+
+#: src/Object/EMail/ItemCCEMail.php:42
+msgid ""
+"Please contact the sender by replying to this post if you do not wish to "
+"receive these messages."
+msgstr ""
+
+#: src/Object/EMail/ItemCCEMail.php:46
+#, php-format
+msgid "%s posted an update."
+msgstr ""
+
+#: src/Object/Post.php:147
+msgid "This entry was edited"
+msgstr ""
+
+#: src/Object/Post.php:174
+msgid "Private Message"
+msgstr ""
+
+#: src/Object/Post.php:213
+msgid "pinned item"
+msgstr ""
+
+#: src/Object/Post.php:218
+msgid "Delete locally"
+msgstr ""
+
+#: src/Object/Post.php:221
+msgid "Delete globally"
+msgstr ""
+
+#: src/Object/Post.php:221
+msgid "Remove locally"
+msgstr ""
+
+#: src/Object/Post.php:235
+msgid "save to folder"
+msgstr ""
+
+#: src/Object/Post.php:270
+msgid "I will attend"
+msgstr ""
+
+#: src/Object/Post.php:270
+msgid "I will not attend"
+msgstr ""
+
+#: src/Object/Post.php:270
+msgid "I might attend"
+msgstr ""
+
+#: src/Object/Post.php:300
+msgid "ignore thread"
+msgstr ""
+
+#: src/Object/Post.php:301
+msgid "unignore thread"
+msgstr ""
+
+#: src/Object/Post.php:302
+msgid "toggle ignore status"
+msgstr ""
+
+#: src/Object/Post.php:314
+msgid "pin"
+msgstr ""
+
+#: src/Object/Post.php:315
+msgid "unpin"
+msgstr ""
+
+#: src/Object/Post.php:316
+msgid "toggle pin status"
+msgstr ""
+
+#: src/Object/Post.php:319
+msgid "pinned"
+msgstr ""
+
+#: src/Object/Post.php:326
+msgid "add star"
+msgstr ""
+
+#: src/Object/Post.php:327
+msgid "remove star"
+msgstr ""
+
+#: src/Object/Post.php:328
+msgid "toggle star status"
+msgstr ""
+
+#: src/Object/Post.php:331
+msgid "starred"
+msgstr ""
+
+#: src/Object/Post.php:335
+msgid "add tag"
+msgstr ""
+
+#: src/Object/Post.php:345
+msgid "like"
+msgstr ""
+
+#: src/Object/Post.php:346
+msgid "dislike"
+msgstr ""
+
+#: src/Object/Post.php:348
+msgid "Share this"
+msgstr ""
+
+#: src/Object/Post.php:348
+msgid "share"
+msgstr ""
+
+#: src/Object/Post.php:400
+#, php-format
+msgid "%s (Received %s)"
+msgstr ""
+
+#: src/Object/Post.php:405
+msgid "Comment this item on your system"
+msgstr ""
+
+#: src/Object/Post.php:405
+msgid "remote comment"
+msgstr ""
+
+#: src/Object/Post.php:417
+msgid "Pushed"
+msgstr ""
+
+#: src/Object/Post.php:417
+msgid "Pulled"
+msgstr ""
+
+#: src/Object/Post.php:444
+msgid "to"
+msgstr ""
+
+#: src/Object/Post.php:445
+msgid "via"
+msgstr ""
+
+#: src/Object/Post.php:446
+msgid "Wall-to-Wall"
+msgstr ""
+
+#: src/Object/Post.php:447
+msgid "via Wall-To-Wall:"
+msgstr ""
+
+#: src/Object/Post.php:483
+#, php-format
+msgid "Reply to %s"
+msgstr ""
+
+#: src/Object/Post.php:486
+msgid "More"
+msgstr ""
+
+#: src/Object/Post.php:503
+msgid "Notifier task is pending"
+msgstr ""
+
+#: src/Object/Post.php:504
+msgid "Delivery to remote servers is pending"
+msgstr ""
+
+#: src/Object/Post.php:505
+msgid "Delivery to remote servers is underway"
+msgstr ""
+
+#: src/Object/Post.php:506
+msgid "Delivery to remote servers is mostly done"
+msgstr ""
+
+#: src/Object/Post.php:507
+msgid "Delivery to remote servers is done"
+msgstr ""
+
+#: src/Object/Post.php:527
+#, php-format
+msgid "%d comment"
+msgid_plural "%d comments"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/Object/Post.php:528
+msgid "Show more"
+msgstr ""
+
+#: src/Object/Post.php:529
+msgid "Show fewer"
+msgstr ""
+
+#: src/Protocol/Diaspora.php:3516
+msgid "Attachments:"
 msgstr ""
 
 #: src/Protocol/OStatus.php:1777
@@ -9383,8 +10060,88 @@ msgstr ""
 msgid "stopped following"
 msgstr ""
 
-#: src/Protocol/Diaspora.php:3516
-msgid "Attachments:"
+#: src/Render/FriendicaSmartyEngine.php:52
+msgid "The folder view/smarty3/ must be writable by webserver."
+msgstr ""
+
+#: src/Repository/ProfileField.php:275
+msgid "Hometown:"
+msgstr ""
+
+#: src/Repository/ProfileField.php:276
+msgid "Marital Status:"
+msgstr ""
+
+#: src/Repository/ProfileField.php:277
+msgid "With:"
+msgstr ""
+
+#: src/Repository/ProfileField.php:278
+msgid "Since:"
+msgstr ""
+
+#: src/Repository/ProfileField.php:279
+msgid "Sexual Preference:"
+msgstr ""
+
+#: src/Repository/ProfileField.php:280
+msgid "Political Views:"
+msgstr ""
+
+#: src/Repository/ProfileField.php:281
+msgid "Religious Views:"
+msgstr ""
+
+#: src/Repository/ProfileField.php:282
+msgid "Likes:"
+msgstr ""
+
+#: src/Repository/ProfileField.php:283
+msgid "Dislikes:"
+msgstr ""
+
+#: src/Repository/ProfileField.php:284
+msgid "Title/Description:"
+msgstr ""
+
+#: src/Repository/ProfileField.php:286
+msgid "Musical interests"
+msgstr ""
+
+#: src/Repository/ProfileField.php:287
+msgid "Books, literature"
+msgstr ""
+
+#: src/Repository/ProfileField.php:288
+msgid "Television"
+msgstr ""
+
+#: src/Repository/ProfileField.php:289
+msgid "Film/dance/culture/entertainment"
+msgstr ""
+
+#: src/Repository/ProfileField.php:290
+msgid "Hobbies/Interests"
+msgstr ""
+
+#: src/Repository/ProfileField.php:291
+msgid "Love/romance"
+msgstr ""
+
+#: src/Repository/ProfileField.php:292
+msgid "Work/employment"
+msgstr ""
+
+#: src/Repository/ProfileField.php:293
+msgid "School/education"
+msgstr ""
+
+#: src/Repository/ProfileField.php:294
+msgid "Contact information and Social Networks"
+msgstr ""
+
+#: src/Util/EMailer/MailBuilder.php:212
+msgid "Friendica Notification"
 msgstr ""
 
 #: src/Util/EMailer/NotifyMailBuilder.php:78
@@ -9404,10 +10161,6 @@ msgstr ""
 #: src/Util/EMailer/SystemMailBuilder.php:101
 #: src/Util/EMailer/SystemMailBuilder.php:118
 msgid "thanks"
-msgstr ""
-
-#: src/Util/EMailer/MailBuilder.php:212
-msgid "Friendica Notification"
 msgstr ""
 
 #: src/Util/Temporal.php:167
@@ -9476,1027 +10229,274 @@ msgstr ""
 msgid "%1$d %2$s ago"
 msgstr ""
 
-#: src/Model/Storage/Database.php:74
+#: src/Worker/Delivery.php:556
+msgid "(no subject)"
+msgstr ""
+
+#: update.php:196
 #, php-format
-msgid "Database storage failed to update %s"
+msgid "%s: Updating author-id and owner-id in item and thread table. "
 msgstr ""
 
-#: src/Model/Storage/Database.php:82
-msgid "Database storage failed to insert data"
-msgstr ""
-
-#: src/Model/Storage/Filesystem.php:100
+#: update.php:251
 #, php-format
+msgid "%s: Updating post-type."
+msgstr ""
+
+#: view/theme/duepuntozero/config.php:52
+msgid "default"
+msgstr ""
+
+#: view/theme/duepuntozero/config.php:53
+msgid "greenzero"
+msgstr ""
+
+#: view/theme/duepuntozero/config.php:54
+msgid "purplezero"
+msgstr ""
+
+#: view/theme/duepuntozero/config.php:55
+msgid "easterbunny"
+msgstr ""
+
+#: view/theme/duepuntozero/config.php:56
+msgid "darkzero"
+msgstr ""
+
+#: view/theme/duepuntozero/config.php:57
+msgid "comix"
+msgstr ""
+
+#: view/theme/duepuntozero/config.php:58
+msgid "slackr"
+msgstr ""
+
+#: view/theme/duepuntozero/config.php:71
+msgid "Variations"
+msgstr ""
+
+#: view/theme/frio/config.php:142
+msgid "Light (Accented)"
+msgstr ""
+
+#: view/theme/frio/config.php:143
+msgid "Dark (Accented)"
+msgstr ""
+
+#: view/theme/frio/config.php:144
+msgid "Black (Accented)"
+msgstr ""
+
+#: view/theme/frio/config.php:156
+msgid "Note"
+msgstr ""
+
+#: view/theme/frio/config.php:156
+msgid "Check image permissions if all users are allowed to see the image"
+msgstr ""
+
+#: view/theme/frio/config.php:162
+msgid "Custom"
+msgstr ""
+
+#: view/theme/frio/config.php:163
+msgid "Legacy"
+msgstr ""
+
+#: view/theme/frio/config.php:164
+msgid "Accented"
+msgstr ""
+
+#: view/theme/frio/config.php:165
+msgid "Select color scheme"
+msgstr ""
+
+#: view/theme/frio/config.php:166
+msgid "Select scheme accent"
+msgstr ""
+
+#: view/theme/frio/config.php:166
+msgid "Blue"
+msgstr ""
+
+#: view/theme/frio/config.php:166
+msgid "Red"
+msgstr ""
+
+#: view/theme/frio/config.php:166
+msgid "Purple"
+msgstr ""
+
+#: view/theme/frio/config.php:166
+msgid "Green"
+msgstr ""
+
+#: view/theme/frio/config.php:166
+msgid "Pink"
+msgstr ""
+
+#: view/theme/frio/config.php:167
+msgid "Copy or paste schemestring"
+msgstr ""
+
+#: view/theme/frio/config.php:167
 msgid ""
-"Filesystem storage failed to create \"%s\". Check you write permissions."
+"You can copy this string to share your theme with others. Pasting here "
+"applies the schemestring"
 msgstr ""
 
-#: src/Model/Storage/Filesystem.php:148
-#, php-format
+#: view/theme/frio/config.php:168
+msgid "Navigation bar background color"
+msgstr ""
+
+#: view/theme/frio/config.php:169
+msgid "Navigation bar icon color "
+msgstr ""
+
+#: view/theme/frio/config.php:170
+msgid "Link color"
+msgstr ""
+
+#: view/theme/frio/config.php:171
+msgid "Set the background color"
+msgstr ""
+
+#: view/theme/frio/config.php:172
+msgid "Content background opacity"
+msgstr ""
+
+#: view/theme/frio/config.php:173
+msgid "Set the background image"
+msgstr ""
+
+#: view/theme/frio/config.php:174
+msgid "Background image style"
+msgstr ""
+
+#: view/theme/frio/config.php:179
+msgid "Login page background image"
+msgstr ""
+
+#: view/theme/frio/config.php:183
+msgid "Login page background color"
+msgstr ""
+
+#: view/theme/frio/config.php:183
+msgid "Leave background image and color empty for theme defaults"
+msgstr ""
+
+#: view/theme/frio/php/default.php:81 view/theme/frio/php/standard.php:38
+msgid "Skip to main content"
+msgstr ""
+
+#: view/theme/frio/php/Image.php:40
+msgid "Top Banner"
+msgstr ""
+
+#: view/theme/frio/php/Image.php:40
 msgid ""
-"Filesystem storage failed to save data to \"%s\". Check your write "
-"permissions"
+"Resize image to the width of the screen and show background color below on "
+"long pages."
 msgstr ""
 
-#: src/Model/Storage/Filesystem.php:176
-msgid "Storage base path"
+#: view/theme/frio/php/Image.php:41
+msgid "Full screen"
 msgstr ""
 
-#: src/Model/Storage/Filesystem.php:178
+#: view/theme/frio/php/Image.php:41
 msgid ""
-"Folder where uploaded files are saved. For maximum security, This should be "
-"a path outside web server folder tree"
+"Resize image to fill entire screen, clipping either the right or the bottom."
 msgstr ""
 
-#: src/Model/Storage/Filesystem.php:191
-msgid "Enter a valid existing folder"
+#: view/theme/frio/php/Image.php:42
+msgid "Single row mosaic"
 msgstr ""
 
-#: src/Model/Item.php:3379
-msgid "activity"
-msgstr ""
-
-#: src/Model/Item.php:3384
-msgid "post"
-msgstr ""
-
-#: src/Model/Item.php:3507
-#, php-format
-msgid "Content warning: %s"
-msgstr ""
-
-#: src/Model/Item.php:3584
-msgid "bytes"
-msgstr ""
-
-#: src/Model/Item.php:3629
-msgid "View on separate page"
-msgstr ""
-
-#: src/Model/Item.php:3630
-msgid "view on separate page"
-msgstr ""
-
-#: src/Model/Item.php:3635 src/Model/Item.php:3641
-#: src/Content/Text/BBCode.php:1071
-msgid "link to source"
-msgstr ""
-
-#: src/Model/Mail.php:128 src/Model/Mail.php:263
-msgid "[no subject]"
-msgstr ""
-
-#: src/Model/Contact.php:961 src/Model/Contact.php:974
-msgid "UnFollow"
-msgstr ""
-
-#: src/Model/Contact.php:970
-msgid "Drop Contact"
-msgstr ""
-
-#: src/Model/Contact.php:1367
-msgid "Organisation"
-msgstr ""
-
-#: src/Model/Contact.php:1371
-msgid "News"
-msgstr ""
-
-#: src/Model/Contact.php:1375
-msgid "Forum"
-msgstr ""
-
-#: src/Model/Contact.php:2030
-msgid "Connect URL missing."
-msgstr ""
-
-#: src/Model/Contact.php:2039
+#: view/theme/frio/php/Image.php:42
 msgid ""
-"The contact could not be added. Please check the relevant network "
-"credentials in your Settings -> Social Networks page."
+"Resize image to repeat it on a single row, either vertical or horizontal."
 msgstr ""
 
-#: src/Model/Contact.php:2080
-msgid ""
-"This site is not configured to allow communications with other networks."
+#: view/theme/frio/php/Image.php:43
+msgid "Mosaic"
 msgstr ""
 
-#: src/Model/Contact.php:2081 src/Model/Contact.php:2094
-msgid "No compatible communication protocols or feeds were discovered."
+#: view/theme/frio/php/Image.php:43
+msgid "Repeat image to fill the screen."
 msgstr ""
 
-#: src/Model/Contact.php:2092
-msgid "The profile address specified does not provide adequate information."
+#: view/theme/frio/theme.php:207
+msgid "Guest"
 msgstr ""
 
-#: src/Model/Contact.php:2097
-msgid "An author or name was not found."
+#: view/theme/frio/theme.php:210
+msgid "Visitor"
 msgstr ""
 
-#: src/Model/Contact.php:2100
-msgid "No browser URL could be matched to this address."
+#: view/theme/quattro/config.php:73
+msgid "Alignment"
 msgstr ""
 
-#: src/Model/Contact.php:2103
-msgid ""
-"Unable to match @-style Identity Address with a known protocol or email "
-"contact."
+#: view/theme/quattro/config.php:73
+msgid "Left"
 msgstr ""
 
-#: src/Model/Contact.php:2104
-msgid "Use mailto: in front of address to force email check."
+#: view/theme/quattro/config.php:73
+msgid "Center"
 msgstr ""
 
-#: src/Model/Contact.php:2110
-msgid ""
-"The profile address specified belongs to a network which has been disabled "
-"on this site."
+#: view/theme/quattro/config.php:74
+msgid "Color scheme"
 msgstr ""
 
-#: src/Model/Contact.php:2115
-msgid ""
-"Limited profile. This person will be unable to receive direct/personal "
-"notifications from you."
+#: view/theme/quattro/config.php:75
+msgid "Posts font size"
 msgstr ""
 
-#: src/Model/Contact.php:2177
-msgid "Unable to retrieve contact information."
+#: view/theme/quattro/config.php:76
+msgid "Textareas font size"
 msgstr ""
 
-#: src/Model/Event.php:77 src/Model/Event.php:94 src/Model/Event.php:452
-#: src/Model/Event.php:930
-msgid "Starts:"
+#: view/theme/vier/config.php:75
+msgid "Comma separated list of helper forums"
 msgstr ""
 
-#: src/Model/Event.php:80 src/Model/Event.php:100 src/Model/Event.php:453
-#: src/Model/Event.php:934
-msgid "Finishes:"
+#: view/theme/vier/config.php:115
+msgid "don't show"
 msgstr ""
 
-#: src/Model/Event.php:402
-msgid "all-day"
+#: view/theme/vier/config.php:115
+msgid "show"
 msgstr ""
 
-#: src/Model/Event.php:428
-msgid "Sept"
+#: view/theme/vier/config.php:121
+msgid "Set style"
 msgstr ""
 
-#: src/Model/Event.php:450
-msgid "No events to display"
+#: view/theme/vier/config.php:122
+msgid "Community Pages"
 msgstr ""
 
-#: src/Model/Event.php:578
-msgid "l, F j"
+#: view/theme/vier/config.php:123 view/theme/vier/theme.php:124
+msgid "Community Profiles"
 msgstr ""
 
-#: src/Model/Event.php:609
-msgid "Edit event"
+#: view/theme/vier/config.php:124
+msgid "Help or @NewHere ?"
 msgstr ""
 
-#: src/Model/Event.php:610
-msgid "Duplicate event"
+#: view/theme/vier/config.php:125 view/theme/vier/theme.php:337
+msgid "Connect Services"
 msgstr ""
 
-#: src/Model/Event.php:611
-msgid "Delete event"
+#: view/theme/vier/config.php:126
+msgid "Find Friends"
 msgstr ""
 
-#: src/Model/Event.php:863
-msgid "D g:i A"
+#: view/theme/vier/config.php:127 view/theme/vier/theme.php:151
+msgid "Last users"
 msgstr ""
 
-#: src/Model/Event.php:864
-msgid "g:i A"
-msgstr ""
-
-#: src/Model/Event.php:949 src/Model/Event.php:951
-msgid "Show map"
-msgstr ""
-
-#: src/Model/Event.php:950
-msgid "Hide map"
-msgstr ""
-
-#: src/Model/Event.php:1042
-#, php-format
-msgid "%s's birthday"
-msgstr ""
-
-#: src/Model/Event.php:1043
-#, php-format
-msgid "Happy Birthday %s"
-msgstr ""
-
-#: src/Model/User.php:141 src/Model/User.php:885
-msgid "SERIOUS ERROR: Generation of security keys failed."
-msgstr ""
-
-#: src/Model/User.php:503
-msgid "Login failed"
-msgstr ""
-
-#: src/Model/User.php:535
-msgid "Not enough information to authenticate"
-msgstr ""
-
-#: src/Model/User.php:630
-msgid "Password can't be empty"
-msgstr ""
-
-#: src/Model/User.php:649
-msgid "Empty passwords are not allowed."
-msgstr ""
-
-#: src/Model/User.php:653
-msgid ""
-"The new password has been exposed in a public data dump, please choose "
-"another."
-msgstr ""
-
-#: src/Model/User.php:659
-msgid ""
-"The password can't contain accentuated letters, white spaces or colons (:)"
-msgstr ""
-
-#: src/Model/User.php:765
-msgid "Passwords do not match. Password unchanged."
-msgstr ""
-
-#: src/Model/User.php:772
-msgid "An invitation is required."
-msgstr ""
-
-#: src/Model/User.php:776
-msgid "Invitation could not be verified."
-msgstr ""
-
-#: src/Model/User.php:784
-msgid "Invalid OpenID url"
-msgstr ""
-
-#: src/Model/User.php:803
-msgid "Please enter the required information."
-msgstr ""
-
-#: src/Model/User.php:817
-#, php-format
-msgid ""
-"system.username_min_length (%s) and system.username_max_length (%s) are "
-"excluding each other, swapping values."
-msgstr ""
-
-#: src/Model/User.php:824
-#, php-format
-msgid "Username should be at least %s character."
-msgid_plural "Username should be at least %s characters."
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/Model/User.php:828
-#, php-format
-msgid "Username should be at most %s character."
-msgid_plural "Username should be at most %s characters."
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/Model/User.php:836
-msgid "That doesn't appear to be your full (First Last) name."
-msgstr ""
-
-#: src/Model/User.php:841
-msgid "Your email domain is not among those allowed on this site."
-msgstr ""
-
-#: src/Model/User.php:845
-msgid "Not a valid email address."
-msgstr ""
-
-#: src/Model/User.php:848
-msgid "The nickname was blocked from registration by the nodes admin."
-msgstr ""
-
-#: src/Model/User.php:852 src/Model/User.php:860
-msgid "Cannot use that email."
-msgstr ""
-
-#: src/Model/User.php:867
-msgid "Your nickname can only contain a-z, 0-9 and _."
-msgstr ""
-
-#: src/Model/User.php:875 src/Model/User.php:932
-msgid "Nickname is already registered. Please choose another."
-msgstr ""
-
-#: src/Model/User.php:919 src/Model/User.php:923
-msgid "An error occurred during registration. Please try again."
-msgstr ""
-
-#: src/Model/User.php:946
-msgid "An error occurred creating your default profile. Please try again."
-msgstr ""
-
-#: src/Model/User.php:953
-msgid "An error occurred creating your self contact. Please try again."
-msgstr ""
-
-#: src/Model/User.php:958
-msgid "Friends"
-msgstr ""
-
-#: src/Model/User.php:962
-msgid ""
-"An error occurred creating your default contact group. Please try again."
-msgstr ""
-
-#: src/Model/User.php:1150
-#, php-format
-msgid ""
-"\n"
-"\t\tDear %1$s,\n"
-"\t\t\tthe administrator of %2$s has set up an account for you."
-msgstr ""
-
-#: src/Model/User.php:1153
-#, php-format
-msgid ""
-"\n"
-"\t\tThe login details are as follows:\n"
-"\n"
-"\t\tSite Location:\t%1$s\n"
-"\t\tLogin Name:\t\t%2$s\n"
-"\t\tPassword:\t\t%3$s\n"
-"\n"
-"\t\tYou may change your password from your account \"Settings\" page after "
-"logging\n"
-"\t\tin.\n"
-"\n"
-"\t\tPlease take a few moments to review the other account settings on that "
-"page.\n"
-"\n"
-"\t\tYou may also wish to add some basic information to your default profile\n"
-"\t\t(on the \"Profiles\" page) so that other people can easily find you.\n"
-"\n"
-"\t\tWe recommend setting your full name, adding a profile photo,\n"
-"\t\tadding some profile \"keywords\" (very useful in making new friends) - "
-"and\n"
-"\t\tperhaps what country you live in; if you do not wish to be more "
-"specific\n"
-"\t\tthan that.\n"
-"\n"
-"\t\tWe fully respect your right to privacy, and none of these items are "
-"necessary.\n"
-"\t\tIf you are new and do not know anybody here, they may help\n"
-"\t\tyou to make some new and interesting friends.\n"
-"\n"
-"\t\tIf you ever want to delete your account, you can do so at %1$s/removeme\n"
-"\n"
-"\t\tThank you and welcome to %4$s."
-msgstr ""
-
-#: src/Model/User.php:1186 src/Model/User.php:1293
-#, php-format
-msgid "Registration details for %s"
-msgstr ""
-
-#: src/Model/User.php:1206
-#, php-format
-msgid ""
-"\n"
-"\t\t\tDear %1$s,\n"
-"\t\t\t\tThank you for registering at %2$s. Your account is pending for "
-"approval by the administrator.\n"
-"\n"
-"\t\t\tYour login details are as follows:\n"
-"\n"
-"\t\t\tSite Location:\t%3$s\n"
-"\t\t\tLogin Name:\t\t%4$s\n"
-"\t\t\tPassword:\t\t%5$s\n"
-"\t\t"
-msgstr ""
-
-#: src/Model/User.php:1225
-#, php-format
-msgid "Registration at %s"
-msgstr ""
-
-#: src/Model/User.php:1249
-#, php-format
-msgid ""
-"\n"
-"\t\t\t\tDear %1$s,\n"
-"\t\t\t\tThank you for registering at %2$s. Your account has been created.\n"
-"\t\t\t"
-msgstr ""
-
-#: src/Model/User.php:1257
-#, php-format
-msgid ""
-"\n"
-"\t\t\tThe login details are as follows:\n"
-"\n"
-"\t\t\tSite Location:\t%3$s\n"
-"\t\t\tLogin Name:\t\t%1$s\n"
-"\t\t\tPassword:\t\t%5$s\n"
-"\n"
-"\t\t\tYou may change your password from your account \"Settings\" page after "
-"logging\n"
-"\t\t\tin.\n"
-"\n"
-"\t\t\tPlease take a few moments to review the other account settings on that "
-"page.\n"
-"\n"
-"\t\t\tYou may also wish to add some basic information to your default "
-"profile\n"
-"\t\t\t(on the \"Profiles\" page) so that other people can easily find you.\n"
-"\n"
-"\t\t\tWe recommend setting your full name, adding a profile photo,\n"
-"\t\t\tadding some profile \"keywords\" (very useful in making new friends) - "
-"and\n"
-"\t\t\tperhaps what country you live in; if you do not wish to be more "
-"specific\n"
-"\t\t\tthan that.\n"
-"\n"
-"\t\t\tWe fully respect your right to privacy, and none of these items are "
-"necessary.\n"
-"\t\t\tIf you are new and do not know anybody here, they may help\n"
-"\t\t\tyou to make some new and interesting friends.\n"
-"\n"
-"\t\t\tIf you ever want to delete your account, you can do so at %3$s/"
-"removeme\n"
-"\n"
-"\t\t\tThank you and welcome to %2$s."
-msgstr ""
-
-#: src/Model/Group.php:92
-msgid ""
-"A deleted group with this name was revived. Existing item permissions "
-"<strong>may</strong> apply to this group and any future members. If this is "
-"not what you intended, please create another group with a different name."
-msgstr ""
-
-#: src/Model/Group.php:451
-msgid "Default privacy group for new contacts"
-msgstr ""
-
-#: src/Model/Group.php:483
-msgid "Everybody"
-msgstr ""
-
-#: src/Model/Group.php:502
-msgid "edit"
-msgstr ""
-
-#: src/Model/Group.php:527
-msgid "add"
-msgstr ""
-
-#: src/Model/Group.php:532
-msgid "Edit group"
-msgstr ""
-
-#: src/Model/Group.php:535
-msgid "Create a new group"
-msgstr ""
-
-#: src/Model/Group.php:537
-msgid "Edit groups"
-msgstr ""
-
-#: src/Model/Profile.php:348
-msgid "Change profile photo"
-msgstr ""
-
-#: src/Model/Profile.php:452
-msgid "Atom feed"
-msgstr ""
-
-#: src/Model/Profile.php:490 src/Model/Profile.php:587
-msgid "g A l F d"
-msgstr ""
-
-#: src/Model/Profile.php:491
-msgid "F d"
-msgstr ""
-
-#: src/Model/Profile.php:553 src/Model/Profile.php:638
-msgid "[today]"
-msgstr ""
-
-#: src/Model/Profile.php:563
-msgid "Birthday Reminders"
-msgstr ""
-
-#: src/Model/Profile.php:564
-msgid "Birthdays this week:"
-msgstr ""
-
-#: src/Model/Profile.php:625
-msgid "[No description]"
-msgstr ""
-
-#: src/Model/Profile.php:651
-msgid "Event Reminders"
-msgstr ""
-
-#: src/Model/Profile.php:652
-msgid "Upcoming events the next 7 days:"
-msgstr ""
-
-#: src/Model/Profile.php:827
-#, php-format
-msgid "OpenWebAuth: %1$s welcomes %2$s"
-msgstr ""
-
-#: src/Content/Widget.php:52
-msgid "Add New Contact"
-msgstr ""
-
-#: src/Content/Widget.php:53
-msgid "Enter address or web location"
-msgstr ""
-
-#: src/Content/Widget.php:54
-msgid "Example: bob@example.com, http://example.com/barbara"
-msgstr ""
-
-#: src/Content/Widget.php:56
-msgid "Connect"
-msgstr ""
-
-#: src/Content/Widget.php:71
-#, php-format
-msgid "%d invitation available"
-msgid_plural "%d invitations available"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/Content/Widget.php:219
-msgid "Everyone"
-msgstr ""
-
-#: src/Content/Widget.php:248
-msgid "Relationships"
-msgstr ""
-
-#: src/Content/Widget.php:289
-msgid "Protocols"
-msgstr ""
-
-#: src/Content/Widget.php:291
-msgid "All Protocols"
-msgstr ""
-
-#: src/Content/Widget.php:328
-msgid "Saved Folders"
-msgstr ""
-
-#: src/Content/Widget.php:330 src/Content/Widget.php:369
-msgid "Everything"
-msgstr ""
-
-#: src/Content/Widget.php:367
-msgid "Categories"
-msgstr ""
-
-#: src/Content/Widget.php:424
-#, php-format
-msgid "%d contact in common"
-msgid_plural "%d contacts in common"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/Content/Widget.php:517
-msgid "Archives"
-msgstr ""
-
-#: src/Content/ContactSelector.php:48
-msgid "Frequently"
-msgstr ""
-
-#: src/Content/ContactSelector.php:49
-msgid "Hourly"
-msgstr ""
-
-#: src/Content/ContactSelector.php:50
-msgid "Twice daily"
-msgstr ""
-
-#: src/Content/ContactSelector.php:51
-msgid "Daily"
-msgstr ""
-
-#: src/Content/ContactSelector.php:52
-msgid "Weekly"
-msgstr ""
-
-#: src/Content/ContactSelector.php:53
-msgid "Monthly"
-msgstr ""
-
-#: src/Content/ContactSelector.php:99
-msgid "DFRN"
-msgstr ""
-
-#: src/Content/ContactSelector.php:100
-msgid "OStatus"
-msgstr ""
-
-#: src/Content/ContactSelector.php:101
-msgid "RSS/Atom"
-msgstr ""
-
-#: src/Content/ContactSelector.php:104
-msgid "Zot!"
-msgstr ""
-
-#: src/Content/ContactSelector.php:105
-msgid "LinkedIn"
-msgstr ""
-
-#: src/Content/ContactSelector.php:106
-msgid "XMPP/IM"
-msgstr ""
-
-#: src/Content/ContactSelector.php:107
-msgid "MySpace"
-msgstr ""
-
-#: src/Content/ContactSelector.php:108
-msgid "Google+"
-msgstr ""
-
-#: src/Content/ContactSelector.php:109
-msgid "pump.io"
-msgstr ""
-
-#: src/Content/ContactSelector.php:110
-msgid "Twitter"
-msgstr ""
-
-#: src/Content/ContactSelector.php:111
-msgid "Discourse"
-msgstr ""
-
-#: src/Content/ContactSelector.php:112
-msgid "Diaspora Connector"
-msgstr ""
-
-#: src/Content/ContactSelector.php:113
-msgid "GNU Social Connector"
-msgstr ""
-
-#: src/Content/ContactSelector.php:114
-msgid "ActivityPub"
-msgstr ""
-
-#: src/Content/ContactSelector.php:115
-msgid "pnut"
-msgstr ""
-
-#: src/Content/ContactSelector.php:149
-#, php-format
-msgid "%s (via %s)"
-msgstr ""
-
-#: src/Content/Feature.php:96
-msgid "General Features"
-msgstr ""
-
-#: src/Content/Feature.php:98
-msgid "Photo Location"
-msgstr ""
-
-#: src/Content/Feature.php:98
-msgid ""
-"Photo metadata is normally stripped. This extracts the location (if present) "
-"prior to stripping metadata and links it to a map."
-msgstr ""
-
-#: src/Content/Feature.php:99
-msgid "Trending Tags"
-msgstr ""
-
-#: src/Content/Feature.php:99
-msgid ""
-"Show a community page widget with a list of the most popular tags in recent "
-"public posts."
-msgstr ""
-
-#: src/Content/Feature.php:104
-msgid "Post Composition Features"
-msgstr ""
-
-#: src/Content/Feature.php:105
-msgid "Auto-mention Forums"
-msgstr ""
-
-#: src/Content/Feature.php:105
-msgid ""
-"Add/remove mention when a forum page is selected/deselected in ACL window."
-msgstr ""
-
-#: src/Content/Feature.php:106
-msgid "Explicit Mentions"
-msgstr ""
-
-#: src/Content/Feature.php:106
-msgid ""
-"Add explicit mentions to comment box for manual control over who gets "
-"mentioned in replies."
-msgstr ""
-
-#: src/Content/Feature.php:111
-msgid "Post/Comment Tools"
-msgstr ""
-
-#: src/Content/Feature.php:112
-msgid "Post Categories"
-msgstr ""
-
-#: src/Content/Feature.php:112
-msgid "Add categories to your posts"
-msgstr ""
-
-#: src/Content/Feature.php:117
-msgid "Advanced Profile Settings"
-msgstr ""
-
-#: src/Content/Feature.php:118
-msgid "List Forums"
-msgstr ""
-
-#: src/Content/Feature.php:118
-msgid "Show visitors public community forums at the Advanced Profile Page"
-msgstr ""
-
-#: src/Content/Feature.php:119
-msgid "Tag Cloud"
-msgstr ""
-
-#: src/Content/Feature.php:119
-msgid "Provide a personal tag cloud on your profile page"
-msgstr ""
-
-#: src/Content/Feature.php:120
-msgid "Display Membership Date"
-msgstr ""
-
-#: src/Content/Feature.php:120
-msgid "Display membership date in profile"
-msgstr ""
-
-#: src/Content/Nav.php:90
-msgid "Nothing new here"
-msgstr ""
-
-#: src/Content/Nav.php:95
-msgid "Clear notifications"
-msgstr ""
-
-#: src/Content/Nav.php:96 src/Content/Text/HTML.php:904
-msgid "@name, !forum, #tags, content"
-msgstr ""
-
-#: src/Content/Nav.php:169
-msgid "End this session"
-msgstr ""
-
-#: src/Content/Nav.php:171
-msgid "Sign in"
-msgstr ""
-
-#: src/Content/Nav.php:182
-msgid "Personal notes"
-msgstr ""
-
-#: src/Content/Nav.php:182
-msgid "Your personal notes"
-msgstr ""
-
-#: src/Content/Nav.php:202 src/Content/Nav.php:263
-msgid "Home"
-msgstr ""
-
-#: src/Content/Nav.php:202
-msgid "Home Page"
-msgstr ""
-
-#: src/Content/Nav.php:206
-msgid "Create an account"
-msgstr ""
-
-#: src/Content/Nav.php:212
-msgid "Help and documentation"
-msgstr ""
-
-#: src/Content/Nav.php:216
-msgid "Apps"
-msgstr ""
-
-#: src/Content/Nav.php:216
-msgid "Addon applications, utilities, games"
-msgstr ""
-
-#: src/Content/Nav.php:220
-msgid "Search site content"
-msgstr ""
-
-#: src/Content/Nav.php:223 src/Content/Text/HTML.php:911
-msgid "Full Text"
-msgstr ""
-
-#: src/Content/Nav.php:224 src/Content/Widget/TagCloud.php:68
-#: src/Content/Text/HTML.php:912
-msgid "Tags"
-msgstr ""
-
-#: src/Content/Nav.php:244
-msgid "Community"
-msgstr ""
-
-#: src/Content/Nav.php:244
-msgid "Conversations on this and other servers"
-msgstr ""
-
-#: src/Content/Nav.php:251
-msgid "Directory"
-msgstr ""
-
-#: src/Content/Nav.php:251
-msgid "People directory"
-msgstr ""
-
-#: src/Content/Nav.php:253
-msgid "Information about this friendica instance"
-msgstr ""
-
-#: src/Content/Nav.php:256
-msgid "Terms of Service of this Friendica instance"
-msgstr ""
-
-#: src/Content/Nav.php:267
-msgid "Introductions"
-msgstr ""
-
-#: src/Content/Nav.php:267
-msgid "Friend Requests"
-msgstr ""
-
-#: src/Content/Nav.php:269
-msgid "See all notifications"
-msgstr ""
-
-#: src/Content/Nav.php:270
-msgid "Mark all system notifications seen"
-msgstr ""
-
-#: src/Content/Nav.php:274
-msgid "Inbox"
-msgstr ""
-
-#: src/Content/Nav.php:275
-msgid "Outbox"
-msgstr ""
-
-#: src/Content/Nav.php:279
-msgid "Accounts"
-msgstr ""
-
-#: src/Content/Nav.php:279
-msgid "Manage other pages"
-msgstr ""
-
-#: src/Content/Nav.php:289
-msgid "Site setup and configuration"
-msgstr ""
-
-#: src/Content/Nav.php:292
-msgid "Navigation"
-msgstr ""
-
-#: src/Content/Nav.php:292
-msgid "Site map"
-msgstr ""
-
-#: src/Content/Widget/SavedSearches.php:47
-msgid "Remove term"
-msgstr ""
-
-#: src/Content/Widget/SavedSearches.php:60
-msgid "Saved Searches"
-msgstr ""
-
-#: src/Content/Widget/CalendarExport.php:63
-msgid "Export"
-msgstr ""
-
-#: src/Content/Widget/CalendarExport.php:64
-msgid "Export calendar as ical"
-msgstr ""
-
-#: src/Content/Widget/CalendarExport.php:65
-msgid "Export calendar as csv"
-msgstr ""
-
-#: src/Content/Widget/TrendingTags.php:51
-#, php-format
-msgid "Trending Tags (last %d hour)"
-msgid_plural "Trending Tags (last %d hours)"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/Content/Widget/TrendingTags.php:52
-msgid "More Trending Tags"
-msgstr ""
-
-#: src/Content/Widget/ContactBlock.php:72
-msgid "No contacts"
-msgstr ""
-
-#: src/Content/Widget/ContactBlock.php:104
-#, php-format
-msgid "%d Contact"
-msgid_plural "%d Contacts"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/Content/Widget/ContactBlock.php:123
-msgid "View Contacts"
-msgstr ""
-
-#: src/Content/BoundariesPager.php:116 src/Content/Pager.php:171
-msgid "newer"
-msgstr ""
-
-#: src/Content/BoundariesPager.php:124 src/Content/Pager.php:176
-msgid "older"
-msgstr ""
-
-#: src/Content/OEmbed.php:266
-msgid "Embedding disabled"
-msgstr ""
-
-#: src/Content/OEmbed.php:388
-msgid "Embedded content"
-msgstr ""
-
-#: src/Content/Pager.php:221
-msgid "prev"
-msgstr ""
-
-#: src/Content/Pager.php:281
-msgid "last"
-msgstr ""
-
-#: src/Content/Text/HTML.php:802
-msgid "Loading more entries..."
-msgstr ""
-
-#: src/Content/Text/HTML.php:803
-msgid "The end"
-msgstr ""
-
-#: src/Content/Text/HTML.php:954 src/Content/Text/BBCode.php:1523
-msgid "Click to open/close"
-msgstr ""
-
-#: src/Content/Text/BBCode.php:946 src/Content/Text/BBCode.php:1605
-#: src/Content/Text/BBCode.php:1606
-msgid "Image/photo"
-msgstr ""
-
-#: src/Content/Text/BBCode.php:1046
-#, php-format
-msgid ""
-"<a href=\"%1$s\" target=\"_blank\" rel=\"noopener noreferrer\">%2$s</a> %3$s"
-msgstr ""
-
-#: src/Content/Text/BBCode.php:1554
-msgid "$1 wrote:"
-msgstr ""
-
-#: src/Content/Text/BBCode.php:1608 src/Content/Text/BBCode.php:1609
-msgid "Encrypted content"
-msgstr ""
-
-#: src/Content/Text/BBCode.php:1831
-msgid "Invalid source protocol"
-msgstr ""
-
-#: src/Content/Text/BBCode.php:1846
-msgid "Invalid link protocol"
-msgstr ""
-
-#: src/BaseModule.php:150
-msgid ""
-"The form security token was not correct. This probably happened because the "
-"form has been opened for too long (>3 hours) before submitting it."
-msgstr ""
-
-#: src/BaseModule.php:179
-msgid "All contacts"
-msgstr ""
-
-#: src/BaseModule.php:202
-msgid "Common"
+#: view/theme/vier/theme.php:252
+msgid "Quick Start"
 msgstr ""

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -1499,14 +1499,14 @@ aside .panel-body {
 }
 
 /* wall items action dropdown menu */
+.media [role=heading] {
+	position: relative;
+}
+
 .preferences {
     position: absolute;
-    right: 15px;
-    top: 10px;
-}
-.comment .preferences {
-    right: 10px;
-    top: 5px;
+    right: 0;
+    top: 0;
 }
 .wall-item-network {
     font-size: 13px;
@@ -3411,10 +3411,6 @@ section .profile-match-wrapper {
 
 	.media {
 		margin-top: 0;
-	}
-
-	.preferences {
-		right: 10px;
 	}
 
 	.generic-page-wrapper, .videos-content-wrapper, .suggest-content-wrapper, .help-content-wrapper, .match-content-wrapper, .dirfind-content-wrapper, .directory-content-wrapper, .delegation-content-wrapper, .notes-content-wrapper, .message-content-wrapper, .apps-content-wrapper, #adminpage, .delegate-content-wrapper, .uexport-content-wrapper, .dfrn_request-content-wrapper, .friendica-content-wrapper, .credits-content-wrapper, .nogroup-content-wrapper, .profperm-content-wrapper, .invite-content-wrapper, .tos-content-wrapper, .fsuggest-content-wrapper {

--- a/view/theme/frio/templates/sub/direction.tpl
+++ b/view/theme/frio/templates/sub/direction.tpl
@@ -9,6 +9,8 @@
 		<i class="fa fa-share-alt" aria-hidden="true" title="{{$direction.title}}"></i>
 	{{elseif $direction.direction == 4}}
 		<i class="fa fa-hashtag" aria-hidden="true" title="{{$direction.title}}"></i>
+	{{elseif $direction.direction == 5}}
+		<i class="fa fa-comment-o" aria-hidden="true" title="{{$direction.title}}"></i>
 	{{/if}}
 </span>
 {{/if}}

--- a/view/theme/frio/templates/wall_thread.tpl
+++ b/view/theme/frio/templates/wall_thread.tpl
@@ -81,6 +81,9 @@ as the value of $top_child_total (this is done at the end of this file)
 <span class="uriid" style="display: none;">{{$item.uriid}}</span>
 {{/if}}
 	<div class="media {{$item.shiny}}">
+	{{if $item.responses.announce && $mode != 'display'}}
+		<div class="wall-item-ammounce wall-item-responses" id="wall-item-ammounce-{{$item.id}}">{{$item.responses.announce.output nofilter}}</div>
+	{{/if}}
 		{{* The avatar picture and the photo-menu *}}
 		<div class="dropdown pull-left"><!-- Dropdown -->
 			{{if $item.thread_level==1}}
@@ -123,112 +126,113 @@ as the value of $top_child_total (this is done at the end of this file)
 		</div><!-- ./Dropdown -->
 
 
+	{{if $item.thread_level!=1}}
+		<div class="media-body">{{*this is the media body for comments - this div must be closed at the end of the file *}}
+	{{/if}}
 
-		{{* contact info header*}}
-		{{if $item.thread_level==1}}
-		<div role="heading " aria-level="{{$item.thread_level}}" class="contact-info hidden-sm hidden-xs media-body"><!-- <= For computer -->
-			<h4 class="media-heading">
-				<a href="{{$item.profile_url}}" title="{{$item.linktitle}}" class="wall-item-name-link userinfo hover-card">
-					<span class="wall-item-name {{$item.sparkle}}">{{$item.name}}</span>
-				</a>
-			{{if $item.owner_url}}
-				{{$item.via}}
-				<a href="{{$item.owner_url}}" target="redir" title="{{$item.olinktitle}}" class="wall-item-name-link userinfo hover-card">
-					<span class="wall-item-name {{$item.osparkle}}" id="wall-item-ownername-{{$item.id}}">{{$item.owner_name}}</span>
-				</a>
-			{{/if}}
-			{{if $item.lock}}
-				<span class="navicon lock fakelink" onClick="lockview(event, 'item', {{$item.id}});" title="{{$item.lock}}" data-toggle="tooltip">
-					&nbsp;<small><i class="fa fa-lock" aria-hidden="true"></i></small>
-				</span>
-			{{/if}}
-			</h4>
-
-			<div class="additional-info text-muted">
-				<div id="wall-item-ago-{{$item.id}}" class="wall-item-ago">
-					<small>
-						<a href="{{$item.plink.orig}}">
-							<span class="time" title="{{$item.localtime}}" data-toggle="tooltip">
-								<time class="dt-published" datetime="{{$item.localtime}}">{{$item.ago}}</time>
-							</span>
-						</a>
-						{{if $item.owner_self}}
-							{{include file="sub/delivery_count.tpl" delivery=$item.delivery}}
-						{{/if}}
-						{{if $item.direction}}
-							{{include file="sub/direction.tpl" direction=$item.direction}}
-						{{/if}}
-						{{if $item.pinned}}
-							&bull; <i class="fa fa-thumb-tack" aria-hidden="true" title="{{$item.pinned}}"></i>
-							<span class="sr-only">{{$item.pinned}}</span>
-						{{/if}}
-
-					</small>
-				</div>
-
-				{{if $item.location}}
-				<div id="wall-item-location-{{$item.id}}" class="wall-item-location">
-					<small><span class="location">({{$item.location nofilter}})</span></small>
-				</div>
+			{{* contact info header*}}
+		<div role="heading" aria-level="{{$item.thread_level}}">
+			<div class="preferences">
+				{{if $item.network_icon != ""}}
+					<span class="wall-item-network"><i class="fa fa-{{$item.network_icon}}" title="{{$item.network_name}}" aria-hidden="true"></i></span>
+				{{else}}
+					<span class="wall-item-network" title="{{$item.app}}">{{$item.network_name}}</span>
+				{{/if}}
+				{{if $item.plink}}	{{*link to the original source of the item *}}
+					&nbsp;
+					<a href="{{$item.plink.href}}" class="plink u-url" aria-label="{{$item.plink.title}}" title="{{$item.plink.title}}">
+						<i class="fa fa-external-link"></i>
+					</a>
 				{{/if}}
 			</div>
-			{{* @todo $item.created have to be inserted *}}
-		</div>
+		{{if $item.thread_level==1}}
+			<div class="contact-info hidden-sm hidden-xs media-body"><!-- <= For computer -->
+				<h4 class="media-heading">
+					<a href="{{$item.profile_url}}" title="{{$item.linktitle}}" class="wall-item-name-link userinfo hover-card">
+						<span class="wall-item-name {{$item.sparkle}}">{{$item.name}}</span>
+					</a>
+				{{if $item.owner_url}}
+					{{$item.via}}
+					<a href="{{$item.owner_url}}" target="redir" title="{{$item.olinktitle}}" class="wall-item-name-link userinfo hover-card">
+						<span class="wall-item-name {{$item.osparkle}}" id="wall-item-ownername-{{$item.id}}">{{$item.owner_name}}</span>
+					</a>
+				{{/if}}
+				{{if $item.lock}}
+					<span class="navicon lock fakelink" onClick="lockview(event, 'item', {{$item.id}});" title="{{$item.lock}}" data-toggle="tooltip">
+						&nbsp;<small><i class="fa fa-lock" aria-hidden="true"></i></small>
+					</span>
+				{{/if}}
+				</h4>
 
-		{{* contact info header for smartphones *}}
-		<div role="heading " aria-level="{{$item.thread_level}}" class="contact-info-xs hidden-lg hidden-md"><!-- <= For smartphone (responsive) -->
-			<h5 class="media-heading">
-				<a href="{{$item.profile_url}}" title="{{$item.linktitle}}" class="wall-item-name-link userinfo hover-card"><span>{{$item.name}}</span></a>
-				<p class="text-muted">
-					<small>
-						<a class="time" href="{{$item.plink.orig}}"><span class="wall-item-ago">{{$item.ago}}</span></a>
-						{{if $item.location}}&nbsp;&mdash;&nbsp;({{$item.location nofilter}}){{/if}}
-						{{if $item.owner_self}}
-							{{include file="sub/delivery_count.tpl" delivery=$item.delivery}}
-						{{/if}}
-						{{if $item.direction}}
-							{{include file="sub/direction.tpl" direction=$item.direction}}
-						{{/if}}
-					</small>
-				</p>
-			</h5>
-		</div>
-		{{/if}} {{* End of if $item.thread_level==1 *}}
+				<div class="additional-info text-muted">
+					<div id="wall-item-ago-{{$item.id}}" class="wall-item-ago">
+						<small>
+							<a href="{{$item.plink.orig}}">
+								<span class="time" title="{{$item.localtime}}" data-toggle="tooltip">
+									<time class="dt-published" datetime="{{$item.localtime}}">{{$item.ago}}</time>
+								</span>
+							</a>
+							{{if $item.owner_self}}
+								{{include file="sub/delivery_count.tpl" delivery=$item.delivery}}
+							{{/if}}
+							{{if $item.direction}}
+								{{include file="sub/direction.tpl" direction=$item.direction}}
+							{{/if}}
+							{{if $item.pinned}}
+								&bull; <i class="fa fa-thumb-tack" aria-hidden="true" title="{{$item.pinned}}"></i>
+								<span class="sr-only">{{$item.pinned}}</span>
+							{{/if}}
 
-		{{* contact info header for comments *}}
-		{{if $item.thread_level!=1}}
-		<div class="media-body">{{*this is the media body for comments - this div must be closed at the end of the file *}}
-		<div role="heading " aria-level="{{$item.thread_level}}" class="contact-info-comment">
-			<h5 class="media-heading">
-				<a href="{{$item.profile_url}}" title="{{$item.linktitle}}" class="wall-item-name-link userinfo hover-card"><span class="fakelink">{{$item.name}}</span></a>
-				<span class="text-muted">
-					<small>
-						<a class="time" href="{{$item.plink.orig}}" title="{{$item.localtime}}" data-toggle="tooltip">{{$item.ago}}</a>
-						{{if $item.location}}&nbsp;&mdash;&nbsp;({{$item.location nofilter}}){{/if}}
-						{{if $item.owner_self}}
-							{{include file="sub/delivery_count.tpl" delivery=$item.delivery}}
-						{{/if}}
-						{{if $item.direction}}
-							{{include file="sub/direction.tpl" direction=$item.direction}}
-						{{/if}}
-					</small>
-				</span>
-			</h5>
-		</div>
-		{{/if}}
+						</small>
+					</div>
 
-		<div class="preferences">
-		{{if $item.network_icon != ""}}
-			<span class="wall-item-network"><i class="fa fa-{{$item.network_icon}}" title="{{$item.network_name}}" aria-hidden="true"></i></span>
-		{{else}}
-			<span class="wall-item-network" title="{{$item.app}}">{{$item.network_name}}</span>
-		{{/if}}
-		{{if $item.plink}}	{{*link to the original source of the item *}}
-			&nbsp;
-			<a href="{{$item.plink.href}}" class="plink u-url" aria-label="{{$item.plink.title}}" title="{{$item.plink.title}}">
-				<i class="fa fa-external-link"></i>
-			</a>
-		{{/if}}
+					{{if $item.location}}
+					<div id="wall-item-location-{{$item.id}}" class="wall-item-location">
+						<small><span class="location">({{$item.location nofilter}})</span></small>
+					</div>
+					{{/if}}
+				</div>
+				{{* @todo $item.created have to be inserted *}}
+			</div>
+
+			{{* contact info header for smartphones *}}
+			<div class="contact-info-xs hidden-lg hidden-md"><!-- <= For smartphone (responsive) -->
+				<h5 class="media-heading">
+					<a href="{{$item.profile_url}}" title="{{$item.linktitle}}" class="wall-item-name-link userinfo hover-card"><span>{{$item.name}}</span></a>
+					<p class="text-muted">
+						<small>
+							<a class="time" href="{{$item.plink.orig}}"><span class="wall-item-ago">{{$item.ago}}</span></a>
+							{{if $item.location}}&nbsp;&mdash;&nbsp;({{$item.location nofilter}}){{/if}}
+							{{if $item.owner_self}}
+								{{include file="sub/delivery_count.tpl" delivery=$item.delivery}}
+							{{/if}}
+							{{if $item.direction}}
+								{{include file="sub/direction.tpl" direction=$item.direction}}
+							{{/if}}
+						</small>
+					</p>
+				</h5>
+			</div>
+		{{else}} {{* End of if $item.thread_level == 1 *}}
+			{{* contact info header for comments *}}
+			<div class="contact-info-comment">
+				<h5 class="media-heading">
+					<a href="{{$item.profile_url}}" title="{{$item.linktitle}}" class="wall-item-name-link userinfo hover-card"><span class="fakelink">{{$item.name}}</span></a>
+					<span class="text-muted">
+				<small>
+					<a class="time" href="{{$item.plink.orig}}" title="{{$item.localtime}}" data-toggle="tooltip">{{$item.ago}}</a>
+					{{if $item.location}}&nbsp;&mdash;&nbsp;({{$item.location nofilter}}){{/if}}
+					{{if $item.owner_self}}
+						{{include file="sub/delivery_count.tpl" delivery=$item.delivery}}
+					{{/if}}
+					{{if $item.direction}}
+						{{include file="sub/direction.tpl" direction=$item.direction}}
+					{{/if}}
+				</small>
+			</span>
+				</h5>
+			</div>
+		{{/if}} {{* End of if $item.thread_level != 1 *}}
 		</div>
 
 		<div class="clearfix"></div>
@@ -523,13 +527,15 @@ as the value of $top_child_total (this is done at the end of this file)
 		<div class="wall-item-links"></div>
 
 		{{* Display likes, dislike and attendance stats *}}
-		{{if $item.responses}}
-			<div class="wall-item-responses">
-				{{foreach $item.responses as $verb=>$response}}
-				<div class="wall-item-{{$verb}}" id="wall-item-{{$verb}}-{{$item.id}}">{{$response.output nofilter}}</div>
-				{{/foreach}}
-			</div>
-		{{/if}}
+	{{if $item.responses}}
+		<div class="wall-item-responses">
+			{{foreach $item.responses as $verb=>$response}}
+				{{if $verb != 'announce' || $mode == 'display'}}
+			<div class="wall-item-{{$verb}}" id="wall-item-{{$verb}}-{{$item.id}}">{{$response.output nofilter}}</div>
+				{{/if}}
+			{{/foreach}}
+		</div>
+	{{/if}}
 
 		{{* Insert comment box of threaded children *}}
 		{{if $item.threaded && $item.comment && $item.indent==comment}}

--- a/view/theme/vier/templates/sub/direction.tpl
+++ b/view/theme/vier/templates/sub/direction.tpl
@@ -9,6 +9,8 @@
 		<i class="icon-share" aria-hidden="true" title="{{$direction.title}}"></i>
 	{{elseif $direction.direction == 4}}
 		<i class="icon-tag" aria-hidden="true" title="{{$direction.title}}"></i>
+	{{elseif $direction.direction == 5}}
+		<i class="icon-commenting" aria-hidden="true" title="{{$direction.title}}"></i>
 	{{/if}}
 </span>
 {{/if}}


### PR DESCRIPTION
This PR includes two distinct post display improvements:
1. Post direction icon change to reflect comment better, with an additional base English language change
2. For frio only, the reshare information is now shown at the top of posts in the network page. This increases consistency with other popular social media platforms such as Mastodon and Twitter that both show the resharer on top of the reshared posts.