### PR TITLE
Fix fatal error in storage list console when default backend is used

### DIFF
--- a/src/Console/Storage.php
+++ b/src/Console/Storage.php
@@ -106,7 +106,7 @@ HELP;
 		$isregisterd = false;
 		foreach ($this->storageManager->listBackends() as $name => $class) {
 			$issel = ' ';
-			if ($current::getName() == $name) {
+			if ($current && $current::getName() == $name) {
 				$issel = '*';
 				$isregisterd = true;
 			};


### PR DESCRIPTION
Fixes the followint Fatal Error:
```
$ php bin/console.php storage list -v
...
[Error] Class name must be a valid object or a string
[Backtrace]:
#0 src/Console/Storage.php(86): Friendica\Console\Storage->doList()
#1 vendor/asika/simple-console/src/Console.php(108): Friendica\Console\Storage->doExecute()
#2 src/Core/Console.php(148): Asika\SimpleConsole\Console->execute()
#3 vendor/asika/simple-console/src/Console.php(108): Friendica\Core\Console->doExecute()
#4 bin/console.php(31): Asika\SimpleConsole\Console->execute()
#5 {main}
```