### PR TITLE
Fix notifications for wrong users

### DIFF
--- a/src/Model/UserItem.php
+++ b/src/Model/UserItem.php
@@ -63,8 +63,15 @@ class UserItem
 			return;
 		}
 
-		// fetch all users in the thread
-		$uids = [];
+		if ($item['uid'] == 0) {
+			$uids = [];
+		} else {
+			// Always include the item user
+			$uids = [$item['uid']];
+		}
+
+		// Add every user who participated so far in this thread
+		// This can only happen with participations on global items. (means: uid = 0) 
 		$users = DBA::p("SELECT DISTINCT(`contact`.`uid`) FROM `item`
 			INNER JOIN `contact` ON `contact`.`id` = `item`.`contact-id` AND `contact`.`uid` != 0
 			WHERE `parent` IN (SELECT `parent` FROM `item` WHERE `id`=?)", $iid);
@@ -72,24 +79,6 @@ class UserItem
 			$uids[] = $user['uid'];
 		}
 		DBA::close($users);
-
-		// Add item users
-		$users = Item::select(['uid'], ["`parent-uri-id` = ? AND `uid` != ?", $item['parent-uri-id'], 0], ['group_by' => ['uid']]);
-		while ($user = DBA::fetch($users)) {
-			$uids[] = $user['uid'];
-		}
-		DBA::close($users);
-
-		// Check for mentions to local users
-		if (in_array($item['private'], [Item::PUBLIC, Item::UNLISTED])) {
-			$mentions = Tag::getByURIId($item['uri-id'], [Tag::MENTION, Tag::IMPLICIT_MENTION, Tag::EXCLUSIVE_MENTION]);
-			foreach ($mentions as $mention) {
-				$uid = User::getIdForURL($mention['url']);
-				if (!empty($uid)) {
-					$uids[] = $uid;
-				}
-			}
-		}
 
 		foreach (array_unique($uids) as $uid) {
 			self::setNotificationForUser($item, $uid);


### PR DESCRIPTION
This is a fix for PR #9149. That PR created the problem that users got notified about share notifications from other users.