### PR TITLE
Forbid non-CLI access to command-line scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,8 +71,8 @@ venv/
 /addons
 /addon
 
-#ignore .htaccess
-.htaccess
+#ignore base .htaccess
+/.htaccess
 
 #ignore filesystem storage default path
 /storage

--- a/.htaccess-dist
+++ b/.htaccess-dist
@@ -1,3 +1,6 @@
+# This file is meant to be copied to ".htaccess" on Apache-powered web servers.
+# The created .htaccess file can be edited manually and will not be overwritten by Friendica updates.
+
 Options -Indexes
 AddType application/x-java-archive .jar
 AddType audio/ogg .oga

--- a/bin/.htaccess
+++ b/bin/.htaccess
@@ -1,0 +1,10 @@
+# This file prevents browser access to Friendica command-line scripts on Apache-powered web servers.
+# It isn't meant to be edited manually, please check the base Friendica folder for the .htaccess-dist file instead.
+
+<IfModule authz_host_module>
+    Require all denied
+</IfModule>
+<IfModule !authz_host_module>
+    Order Allow,Deny
+    Deny from all
+</IfModule>

--- a/bin/auth_ejabberd.php
+++ b/bin/auth_ejabberd.php
@@ -51,6 +51,11 @@
  *
  */
 
+if (php_sapi_name() !== 'cli') {
+	header($_SERVER["SERVER_PROTOCOL"] . ' 403 Forbidden');
+	exit();
+}
+
 use Dice\Dice;
 use Friendica\App\Mode;
 use Friendica\Util\ExAuth;

--- a/bin/console.php
+++ b/bin/console.php
@@ -20,6 +20,11 @@
  *
  */
 
+if (php_sapi_name() !== 'cli') {
+	header($_SERVER["SERVER_PROTOCOL"] . ' 403 Forbidden');
+	exit();
+}
+
 use Dice\Dice;
 use Psr\Log\LoggerInterface;
 

--- a/bin/daemon.php
+++ b/bin/daemon.php
@@ -23,6 +23,11 @@
  * This script was taken from http://php.net/manual/en/function.pcntl-fork.php
  */
 
+if (php_sapi_name() !== 'cli') {
+	header($_SERVER["SERVER_PROTOCOL"] . ' 403 Forbidden');
+	exit();
+}
+
 use Dice\Dice;
 use Friendica\Core\Logger;
 use Friendica\Core\Worker;

--- a/bin/testargs.php
+++ b/bin/testargs.php
@@ -26,6 +26,10 @@
  *
  */
 
+if (php_sapi_name() !== 'cli') {
+	header($_SERVER["SERVER_PROTOCOL"] . ' 403 Forbidden');
+	exit();
+}
 
 if (($_SERVER["argc"] > 1) && isset($_SERVER["argv"][1])) {
 	echo $_SERVER["argv"][1];

--- a/bin/wait-for-connection
+++ b/bin/wait-for-connection
@@ -24,6 +24,11 @@
  * Usage: php bin/wait-for-connection {HOST} {PORT} [{TIMEOUT}]
  */
 
+if (php_sapi_name() !== 'cli') {
+	header($_SERVER["SERVER_PROTOCOL"] . ' 403 Forbidden');
+	exit();
+}
+
 $timeout = 60;
 switch ($argc) {
 	case 4:

--- a/bin/worker.php
+++ b/bin/worker.php
@@ -21,6 +21,11 @@
  * Starts the background processing
  */
 
+if (php_sapi_name() !== 'cli') {
+	header($_SERVER["SERVER_PROTOCOL"] . ' 403 Forbidden');
+	exit();
+}
+
 use Dice\Dice;
 use Friendica\App;
 use Friendica\Core\Update;

--- a/mods/sample-nginx.config
+++ b/mods/sample-nginx.config
@@ -141,4 +141,9 @@ server {
   location ~ /\. {
     deny all;
   }
+
+  # deny access to the CLI scripts
+  location ^~ /bin {
+    deny all;
+  }
 }


### PR DESCRIPTION
Fixes #9154 

Ideally, the Friendica web endpoint should be in a subfolder of the project (say, `view`) and the web server root folder should be pointed to it. This would prevent us from having to do this kind of manual prevention, but it would mean that Friendica can't work directly out of the box when the complete archive is unpacked in an existing web directory.

I'm increasingly convinced it isn't a big deal as setting up a Friendica node now requires command-line access, which in my opinion is more technically advanced than pointing a web server to a specific directory. I believe GUI shared hosting offers this feature more often than cron jobs, which are required by Friendica to work.