### PR TITLE
Add HTML escaping to field_input value

### DIFF
--- a/view/templates/field_input.tpl
+++ b/view/templates/field_input.tpl
@@ -1,7 +1,7 @@
 	
 	<div class="field input" id="wrapper_{{$field.0}}">
 		<label for="id_{{$field.0}}">{{$field.1}}</label>
-		<input{{if $field.6}} type="{{$field.6}}"{{else}} type="text"{{/if}} name="{{$field.0}}" id="id_{{$field.0}}" value="{{$field.2 nofilter}}"{{if $field.4 eq 'required'}} required{{/if}}{{if $field.5 eq "autofocus"}} autofocus{{elseif $field.5}} {{$field.5 nofilter}}{{/if}} aria-describedby="{{$field.0}}_tip">
+		<input{{if $field.6}} type="{{$field.6}}"{{else}} type="text"{{/if}} name="{{$field.0}}" id="id_{{$field.0}}" value="{{$field.2}}"{{if $field.4 eq 'required'}} required{{/if}}{{if $field.5 eq "autofocus"}} autofocus{{elseif $field.5}} {{$field.5 nofilter}}{{/if}} aria-describedby="{{$field.0}}_tip">
 	{{if $field.3}}
 		<span class="field_help" role="tooltip" id="{{$field.0}}_tip">{{$field.3 nofilter}}</span>
 	{{/if}}

--- a/view/theme/frio/templates/field_input.tpl
+++ b/view/theme/frio/templates/field_input.tpl
@@ -3,7 +3,7 @@
 	{{if !isset($label) || $label != false }}
 		<label for="id_{{$field.0}}" id="label_{{$field.0}}">{{$field.1 nofilter}}{{if $field.4}}<span class="required"> {{$field.4}}</span>{{/if}}</label>
 	{{/if}}
-		<input class="form-control" name="{{$field.0}}" id="id_{{$field.0}}"{{if $field.6}} type="{{$field.6}}"{{else}} type="text"{{/if}} value="{{$field.2 nofilter}}"{{if $field.4 eq "required"}} required{{/if}}{{if $field.5 eq "autofocus"}} autofocus{{elseif $field.5}} {{$field.5 nofilter}}{{/if}} aria-describedby="{{$field.0}}_tip">
+		<input class="form-control" name="{{$field.0}}" id="id_{{$field.0}}"{{if $field.6}} type="{{$field.6}}"{{else}} type="text"{{/if}} value="{{$field.2}}"{{if $field.4 eq "required"}} required{{/if}}{{if $field.5 eq "autofocus"}} autofocus{{elseif $field.5}} {{$field.5 nofilter}}{{/if}} aria-describedby="{{$field.0}}_tip">
 	{{if $field.3}}
 		<span class="help-block" id="{{$field.0}}_tip" role="tooltip">{{$field.3 nofilter}}</span>
 	{{/if}}


### PR DESCRIPTION
Fixes #9138 

- Quotes weren't rendering in pre-populated fields

Please note: this is sweeping change in a generic template, there may be side-effects although there are no reasons unescaped HTML should be interpolated as is in the value attribute of an input field.