### PR TITLE
Issue 8961: Rearranged config defaults

### DIFF
--- a/static/defaults.config.php
+++ b/static/defaults.config.php
@@ -210,6 +210,10 @@ return [
 		// Disable the polling of DFRN and OStatus contacts through onepoll.php.
 		'disable_polling' => false,
 
+		// display_resharer (Boolean)
+		// Display the first resharer as icon and text on a reshared item.
+		'display_resharer' => false,
+
 		// dlogfile (Path)
 		// location of the developer log file.
 		'dlogfile' => '',
@@ -303,6 +307,12 @@ return [
 		// Maximum number of queue items for a single contact before subsequent messages are discarded.
 		'max_contact_queue' => 500,
 
+		// max_csv_file_size (Integer)
+		// When uploading a CSV with account addresses to follow
+		// in the user settings, this controls the maximum file
+		// size of the upload file.
+		'max_csv_file_size' => 30720,
+
 		// max_feed_items (Integer)
 		// Maximum number of feed items that are fetched and processed. For unlimited items set to 0.
 		'max_feed_items' => 20,
@@ -394,10 +404,6 @@ return [
 		// - 1 = every hour
 		// - 0 = every minute
 		'pushpoll_frequency' => 3,
-
-		// queue_no_dead_check (Boolean)
-		// Ignore if the target contact or server seems to be dead during queue delivery.
-		'queue_no_dead_check' => false,
 
 		// redis_host (String)
 		// Host name of the redis daemon.

--- a/static/settings.config.php
+++ b/static/settings.config.php
@@ -141,19 +141,9 @@ return [
 		// Used by the worker in a non-HTTP execution environment.
 		'url' => '',
 
-		// max_csv_file_size (Integer)
-		// When uploading a CSV with account addresses to follow
-		// in the user settings, this controls the maximum file
-		// size of the upload file.
-		'max_csv_file_size' => 30720,
-
 		// optimize_tables (Boolean)
 		// Periodically (once an hour) run an "optimize table" command for cache tables
 		'optimize_tables' => false,
-
-		// display_resharer (Boolean)
-		// Display the first resharer as icon and text on a reshared item.
-		'display_resharer' => false,
 	],
 
 	// Used in the admin settings to lock certain features


### PR DESCRIPTION
Part of https://github.com/friendica/friendica/issues/8961

AFAIK `defaults.config.php` should contain all settings without a frontend config dialog, `settings.config.php` is meant for all stuff that is also configurable via frontend. So some settings had been moved.