### PR TITLE
allow forum delivery using attached mention tags

### DIFF
--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -2673,7 +2673,7 @@ class Item
 
 		if (!$mention) {
 			$tags = Tag::getByURIId($item_id, [Tag::MENTION, Tag::EXCLUSIVE_MENTION]);
-			$foreach ($tags as $tag) {
+			foreach ($tags as $tag) {
 				if (Strings::compareLink($link, $tag['url']) || Strings::compareLink($dlink, $tag['url'])) {
 					$mention = true;
 					Logger::log('mention found in tag: ' . $tag['url']);

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -2672,7 +2672,7 @@ class Item
 		}
 
 		if (!$mention) {
-			$tags = Tag::getByURIId($item_id, [Tag::MENTION, Tag::EXCLUSIVE_MENTION]);
+			$tags = Tag::getByURIId($item['uri-id'], [Tag::MENTION, Tag::EXCLUSIVE_MENTION]);
 			foreach ($tags as $tag) {
 				if (Strings::compareLink($link, $tag['url']) || Strings::compareLink($dlink, $tag['url'])) {
 					$mention = true;

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -29,7 +29,7 @@ use Friendica\Core\Protocol;
 use Friendica\Core\Renderer;
 use Friendica\Core\Session;
 use Friendica\Core\System;
-use Friendica\Core\Tag;
+use Friendica\Model\Tag;
 use Friendica\Core\Worker;
 use Friendica\Database\DBA;
 use Friendica\Database\DBStructure;

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -2676,7 +2676,7 @@ class Item
 			foreach ($tags as $tag) {
 				if (Strings::compareLink($link, $tag['url']) || Strings::compareLink($dlink, $tag['url'])) {
 					$mention = true;
-					Logger::log('mention found in tag: ' . $tag['url']);
+					DI::logger()->info('mention found in tag.', ['url' => $tag['url']]);
 				}
 			}
 		}

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -29,6 +29,7 @@ use Friendica\Core\Protocol;
 use Friendica\Core\Renderer;
 use Friendica\Core\Session;
 use Friendica\Core\System;
+use Friendica\Core\Tag;
 use Friendica\Core\Worker;
 use Friendica\Database\DBA;
 use Friendica\Database\DBStructure;
@@ -2670,6 +2671,16 @@ class Item
 			}
 		}
 
+		if (!$mention) {
+			$tags = Tag::getByURIId($item_id, [Tag::MENTION, Tag::EXCLUSIVE_MENTION]);
+			$foreach ($tags as $tag) {
+				if (Strings::compareLink($link, $tag['url']) || Strings::compareLink($dlink, $tag['url'])) {
+					$mention = true;
+					Logger::log('mention found in tag: ' . $tag['url']);
+				}
+			}
+		}
+		
 		if (!$mention) {
 			if (($community_page || $prvgroup) &&
 				  !$item['wall'] && !$item['origin'] && ($item['gravity'] == GRAVITY_PARENT)) {


### PR DESCRIPTION
Compatibility: This is completely untested as I do not have an installed friendica site to test against; but should allow forum deliveries if mention is contained in attached tags besides only pattern matching in the message body. 