### PR TITLE
[frio] Limit jot textarea height

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -1202,6 +1202,7 @@ section #jotOpen {
 }
 #jot-text-wrap textarea {
     min-height: 100px;
+	max-height: 440px;
     overflow-y: auto !important;
     overflow-y: overlay !important;
 }


### PR DESCRIPTION
Doesn't help with #9090 after all

This PR limits the modal jot text area height to 440px, which equates 15 lines of text on mobile display, the maximum before overflowing.