### PR TITLE
Add additional direction types

### DIFF
--- a/include/conversation.php
+++ b/include/conversation.php
@@ -741,32 +741,39 @@ function conversation_fetch_comments($thread_items, $pinned) {
 			$direction = ['direction' => 5, 'title' => DI::l10n()->t('%s commented on this.', $row['author-name'])];
 		}
 
-		if (($row['gravity'] == GRAVITY_PARENT) && !$row['origin'] && ($row['author-id'] == $row['owner-id'])) {
-			if (Contact::isSharing($row['author-id'], $row['uid'])) {
+		switch ($row['post-type']) {
+			case Item::PT_TO:
+				$row['direction'] = ['direction' => 7, 'title' => DI::l10n()->t('You had been addressed (%s).', 'to')];
+				break;
+			case Item::PT_CC:
+				$row['direction'] = ['direction' => 7, 'title' => DI::l10n()->t('You had been addressed (%s).', 'cc')];
+				break;
+			case Item::PT_BTO:
+				$row['direction'] = ['direction' => 7, 'title' => DI::l10n()->t('You had been addressed (%s).', 'bto')];
+				break;
+			case Item::PT_BCC:
+				$row['direction'] = ['direction' => 7, 'title' => DI::l10n()->t('You had been addressed (%s).', 'bcc')];
+				break;
+			case Item::PT_FOLLOWER:
 				$row['direction'] = ['direction' => 6, 'title' => DI::l10n()->t('You are following %s.', $row['author-name'])];
-			} else {
-				if ($row['post-type'] == Item::PT_TAG) {
-					$row['direction'] = ['direction' => 4, 'title' => DI::l10n()->t('Tagged')];
-				}
-				$parentlines[] = $lineno;
-			}
+				break;
+			case Item::PT_TAG:
+				$row['direction'] = ['direction' => 4, 'title' => DI::l10n()->t('Tagged')];
+				break;
+			case Item::PT_ANNOUNCEMENT:
+				$row['direction'] = ['direction' => 3, 'title' => DI::l10n()->t('Reshared')];
+				break;
+			case Item::PT_COMMENT:
+				$row['direction'] = ['direction' => 5, 'title' => DI::l10n()->t('%s is participating in this thread.', $row['author-name'])];
+				break;
+			case Item::PT_STORED:
+				$row['direction'] = ['direction' => 8, 'title' => DI::l10n()->t('Stored')];
+				break;
+		}
 
-			switch ($row['post-type']) {
-				case Item::PT_TO:
-					$row['direction'] = ['direction' => 7, 'title' => DI::l10n()->t('You had been addressed (%s).', 'to')];
-					break;
-				case Item::PT_CC:
-					$row['direction'] = ['direction' => 7, 'title' => DI::l10n()->t('You had been addressed (%s).', 'cc')];
-					break;
-				case Item::PT_BTO:
-					$row['direction'] = ['direction' => 7, 'title' => DI::l10n()->t('You had been addressed (%s).', 'bto')];
-					break;
-				case Item::PT_BCC:
-					$row['direction'] = ['direction' => 7, 'title' => DI::l10n()->t('You had been addressed (%s).', 'bcc')];
-					break;
-				case Item::PT_FOLLOWER:
-					$row['direction'] = ['direction' => 6, 'title' => DI::l10n()->t('You are following %s.', $row['author-name'])];
-			}
+		if (($row['gravity'] == GRAVITY_PARENT) && !$row['origin'] && ($row['author-id'] == $row['owner-id']) &&
+			!Contact::isSharing($row['author-id'], $row['uid'])) {
+			$parentlines[] = $lineno;
 		}
 
 		if ($row['gravity'] == GRAVITY_PARENT) {

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -62,6 +62,9 @@ class Item
 	const PT_BTO = 67;
 	const PT_BCC = 68;
 	const PT_FOLLOWER = 69;
+	const PT_ANNOUNCEMENT = 70;
+	const PT_COMMENT = 71;
+	const PT_STORED = 72;
 	const PT_PERSONAL_NOTE = 128;
 
 	// Field list that is used to display the items
@@ -1696,6 +1699,11 @@ class Item
 			'photo' => $item['owner-avatar'], 'network' => $item['network']];
 		$item['owner-id'] = ($item['owner-id'] ?? 0) ?: Contact::getIdForURL($item['owner-link'], 0, null, $default);
 
+		$actor = ($item['gravity'] == GRAVITY_PARENT) ? $item['owner-id'] : $item['author-id'];
+		if (!$item['origin'] && in_array($item['post-type'], [self::PT_ARTICLE, self::PT_COMMENT]) && Contact::isSharing($actor, $item['uid'])) {
+			$item['post-type'] = self::PT_FOLLOWER;
+		}
+
 		// Ensure that there is an avatar cache
 		Contact::checkAvatarCache($item['author-id']);
 		Contact::checkAvatarCache($item['owner-id']);
@@ -1998,10 +2006,10 @@ class Item
 	 */
 	private static function setOwnerforResharedItem(array $item)
 	{
-		$parent = self::selectFirst(['id', 'owner-id', 'author-id', 'author-link', 'origin'],
-			['uri-id' => $item['parent-uri-id'], 'uid' => $item['uid']]);
+		$parent = self::selectFirst(['id', 'owner-id', 'author-id', 'author-link', 'origin', 'post-type'],
+			['uri-id' => $item['thr-parent-id'], 'uid' => $item['uid']]);
 		if (!DBA::isResult($parent)) {
-			Logger::error('Parent not found', ['uri-id' => $item['parent-uri-id'], 'uid' => $item['uid']]);
+			Logger::error('Parent not found', ['uri-id' => $item['thr-parent-id'], 'uid' => $item['uid']]);
 			return;
 		}
 
@@ -2011,19 +2019,24 @@ class Item
 			return;
 		}
 
-		if ($author['contact-type'] != Contact::TYPE_COMMUNITY) {
-			logger::info('The resharer is no forum: quit', ['resharer' => $item['author-id'], 'owner' => $parent['owner-id'], 'author' => $parent['author-id'], 'uid' => $item['uid']]);
-			return;
-		}
-
 		$cid = Contact::getIdForURL($author['url'], $item['uid']);
 		if (empty($cid) || !Contact::isSharing($cid, $item['uid'])) {
 			logger::info('The resharer is not a following contact: quit', ['resharer' => $author['url'], 'uid' => $item['uid']]);
 			return;
 		}
 
-		Item::update(['owner-id' => $item['author-id'], 'contact-id' => $cid], ['id' => $parent['id']]);
-		Logger::info('Change owner of the parent', ['uri-id' => $item['uri-id'], 'parent-uri-id' => $item['parent-uri-id'], 'uid' => $item['uid'], 'owner-id' => $item['author-id'], 'contact-id' => $cid]);
+		if ($author['contact-type'] != Contact::TYPE_COMMUNITY) {
+			if (!in_array($parent['post-type'], [self::PT_ARTICLE, self::PT_COMMENT]) || Contact::isSharing($parent['owner-id'], $item['uid'])) {
+				logger::info('The resharer is no forum: quit', ['resharer' => $item['author-id'], 'owner' => $parent['owner-id'], 'author' => $parent['author-id'], 'uid' => $item['uid']]);
+				return;
+			}
+			self::update(['post-type' => self::PT_ANNOUNCEMENT], ['id' => $parent['id']]);
+			Logger::info('Set announcement post-type', ['uri-id' => $item['uri-id'], 'thr-parent-id' => $item['thr-parent-id'], 'uid' => $item['uid']]);
+			return;
+		}
+
+		self::update(['owner-id' => $item['author-id'], 'contact-id' => $cid], ['id' => $parent['id']]);
+		Logger::info('Change owner of the parent', ['uri-id' => $item['uri-id'], 'thr-parent-id' => $item['thr-parent-id'], 'uid' => $item['uid'], 'owner-id' => $item['author-id'], 'contact-id' => $cid]);
 	}
 
 	/**
@@ -2228,6 +2241,8 @@ class Item
 			Logger::notice('Item is private or not from a federated network. It will not be stored for the user.', ['uri-id' => $uri_id, 'uid' => $uid, 'private' => $item['private'], 'network' => $item['network']]);
 			return 0;
 		}
+
+		$item['post-type'] = self::PT_STORED;
 
 		$item = array_merge($item, $fields);
 

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -2021,13 +2021,13 @@ class Item
 
 		$cid = Contact::getIdForURL($author['url'], $item['uid']);
 		if (empty($cid) || !Contact::isSharing($cid, $item['uid'])) {
-			logger::info('The resharer is not a following contact: quit', ['resharer' => $author['url'], 'uid' => $item['uid']]);
+			Logger::info('The resharer is not a following contact: quit', ['resharer' => $author['url'], 'uid' => $item['uid']]);
 			return;
 		}
 
 		if ($author['contact-type'] != Contact::TYPE_COMMUNITY) {
 			if (!in_array($parent['post-type'], [self::PT_ARTICLE, self::PT_COMMENT]) || Contact::isSharing($parent['owner-id'], $item['uid'])) {
-				logger::info('The resharer is no forum: quit', ['resharer' => $item['author-id'], 'owner' => $parent['owner-id'], 'author' => $parent['author-id'], 'uid' => $item['uid']]);
+				Logger::info('The resharer is no forum: quit', ['resharer' => $item['author-id'], 'owner' => $parent['owner-id'], 'author' => $parent['author-id'], 'uid' => $item['uid']]);
 				return;
 			}
 			self::update(['post-type' => self::PT_ANNOUNCEMENT], ['id' => $parent['id']]);

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -26,6 +26,7 @@ use Friendica\Content\Text\BBCode;
 use Friendica\Content\Text\HTML;
 use Friendica\Core\Logger;
 use Friendica\Core\Protocol;
+use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\APContact;
@@ -353,7 +354,7 @@ class Processor
 		DBA::close($items);
 
 		if (count($original) != count($receivers)) {
-			Logger::info('Improved data', ['id' => $activity['id'], 'object' => $activity['object_id'], 'original' => $original, 'improved' => $receivers]);
+			Logger::info('Improved data', ['id' => $activity['id'], 'object' => $activity['object_id'], 'original' => $original, 'improved' => $receivers, 'callstack' => System::callstack()]);
 		}
 
 		return $receivers;
@@ -543,6 +544,9 @@ class Processor
 					break;
 				case Receiver::TARGET_FOLLOWER:
 					$item['post-type'] = Item::PT_FOLLOWER;
+					break;
+				case Receiver::TARGET_ANSWER:
+					$item['post-type'] = Item::PT_COMMENT;
 					break;
 				default:
 					$item['post-type'] = Item::PT_ARTICLE;

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -1735,6 +1735,9 @@ class Diaspora
 		$datarray["owner-link"] = $contact["url"];
 		$datarray["owner-id"] = Contact::getIdForURL($contact["url"], 0);
 
+		// Will be overwritten for sharing accounts in Item::insert
+		$datarray['post-type'] = Item::PT_COMMENT;
+
 		$datarray["guid"] = $guid;
 		$datarray["uri"] = self::getUriFromGuid($author, $guid);
 		$datarray['uri-id'] = ItemURI::insert(['uri' => $datarray['uri'], 'guid' => $datarray['guid']]);

--- a/view/theme/frio/templates/sub/direction.tpl
+++ b/view/theme/frio/templates/sub/direction.tpl
@@ -15,6 +15,8 @@
 		<i class="fa fa-user" aria-hidden="true" title="{{$direction.title}}"></i>
 	{{elseif $direction.direction == 7}}
 		<i class="fa fa-at" aria-hidden="true" title="{{$direction.title}}"></i>
+	{{elseif $direction.direction == 8}}
+		<i class="fa fa-share" aria-hidden="true" title="{{$direction.title}}"></i>
 	{{/if}}
 </span>
 {{/if}}

--- a/view/theme/vier/templates/sub/direction.tpl
+++ b/view/theme/vier/templates/sub/direction.tpl
@@ -15,6 +15,8 @@
 		<i class="icon-ok-sign" aria-hidden="true" title="{{$direction.title}}"></i>
 	{{elseif $direction.direction == 7}}
 		<i class="icon-forward" aria-hidden="true" title="{{$direction.title}}"></i>
+	{{elseif $direction.direction == 8}}
+		<i class="icon-share" aria-hidden="true" title="{{$direction.title}}"></i>
 	{{/if}}
 </span>
 {{/if}}


### PR DESCRIPTION
We now also display if a post had been directed to you via "to", "cc" or "bcc". So you can better detect why you received that post. Also the values are now displayed at every post, also the comments.

And most likely the bug was fixed that caused to sometimes receive posts via DFRN from non followers.