### PR TITLE
[frio] Restore jot modal panel overflow value

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -1179,6 +1179,7 @@ section #jotOpen {
 #jot-modal #item-Q0,
 #jot-modal #profile-jot-acl-wrapper,
 #jot-modal #acl-wrapper {
+    overflow: hidden;
     display: flex;
     flex: auto;
     flex-direction: column;
@@ -1202,7 +1203,6 @@ section #jotOpen {
 }
 #jot-text-wrap textarea {
     min-height: 100px;
-	max-height: 440px;
     overflow-y: auto !important;
     overflow-y: overlay !important;
 }


### PR DESCRIPTION
Fixes #9090
Follow-up to #9191
Reverts 1c37f4aa88a13cf5a37b2b6c6ee05b9069830b02
Reverts part of 43df577209d532b820eb5aaf4e1fb8d9c128f4d6

It was causing jot panel content to overflow the modal window. I must have had a good reason to remove it, so please keep your eyes peeled after this is pulled.

