### PR TITLE
[frio] Remove textcomplete hidden input box shadows in dark/black schemes

### DIFF
--- a/view/theme/frio/js/theme.js
+++ b/view/theme/frio/js/theme.js
@@ -2,6 +2,9 @@
 var jotcache = ''; //The jot cache. We use it as cache to restore old/original jot content
 
 $(document).ready(function(){
+	// Destroy unused perfect scrollbar in aside element
+	$('aside').perfectScrollbar('destroy');
+
 	//fade in/out based on scrollTop value
 	var scrollStart;
 

--- a/view/theme/frio/scheme/black.css
+++ b/view/theme/frio/scheme/black.css
@@ -345,3 +345,7 @@ aside .widget,
 	box-shadow: 0 0 3px $link_color;
 	-webkit-box-shadow: 0 0 3px $link_color;
 }
+
+input[type=text].tt-input {
+	box-shadow: none;
+}

--- a/view/theme/frio/scheme/dark.css
+++ b/view/theme/frio/scheme/dark.css
@@ -318,3 +318,7 @@ legend {
 .adminpage .table-hover > tbody > tr:hover + tr.details {
 	background-color: $nav_bg;
 }
+
+input[type=text].tt-input {
+	box-shadow: none;
+}


### PR DESCRIPTION
Fixes #9193 and another display bug that @foss- didn't report here.