### PR TITLE
Improve "direction" icons on "vier", new direction "global"

### DIFF
--- a/include/conversation.php
+++ b/include/conversation.php
@@ -769,6 +769,10 @@ function conversation_fetch_comments($thread_items, $pinned) {
 			case Item::PT_STORED:
 				$row['direction'] = ['direction' => 8, 'title' => DI::l10n()->t('Stored')];
 				break;
+			default:
+				if ($row['uid'] == 0) {
+					$row['direction'] = ['direction' => 9, 'title' => DI::l10n()->t('Global')];
+				}
 		}
 
 		if (($row['gravity'] == GRAVITY_PARENT) && !$row['origin'] && ($row['author-id'] == $row['owner-id']) &&

--- a/view/theme/frio/templates/sub/direction.tpl
+++ b/view/theme/frio/templates/sub/direction.tpl
@@ -17,6 +17,8 @@
 		<i class="fa fa-at" aria-hidden="true" title="{{$direction.title}}"></i>
 	{{elseif $direction.direction == 8}}
 		<i class="fa fa-share" aria-hidden="true" title="{{$direction.title}}"></i>
+	{{elseif $direction.direction == 9}}
+		<i class="fa fa-globe" aria-hidden="true" title="{{$direction.title}}"></i>
 	{{/if}}
 </span>
 {{/if}}

--- a/view/theme/vier/templates/sub/direction.tpl
+++ b/view/theme/vier/templates/sub/direction.tpl
@@ -6,17 +6,19 @@
 	{{elseif $direction.direction == 2}}
 		<i class="icon-download" aria-hidden="true" title="{{$direction.title}}"></i>
 	{{elseif $direction.direction == 3}}
-		<i class="icon-share" aria-hidden="true" title="{{$direction.title}}"></i>
+		<i class="icon-retweet" aria-hidden="true" title="{{$direction.title}}"></i>
 	{{elseif $direction.direction == 4}}
 		<i class="icon-tag" aria-hidden="true" title="{{$direction.title}}"></i>
 	{{elseif $direction.direction == 5}}
 		<i class="icon-commenting" aria-hidden="true" title="{{$direction.title}}"></i>
 	{{elseif $direction.direction == 6}}
-		<i class="icon-ok-sign" aria-hidden="true" title="{{$direction.title}}"></i>
+		<i class="icon-user" aria-hidden="true" title="{{$direction.title}}"></i>
 	{{elseif $direction.direction == 7}}
 		<i class="icon-forward" aria-hidden="true" title="{{$direction.title}}"></i>
 	{{elseif $direction.direction == 8}}
 		<i class="icon-share" aria-hidden="true" title="{{$direction.title}}"></i>
+	{{elseif $direction.direction == 9}}
+		<i class="icon-globe" aria-hidden="true" title="{{$direction.title}}"></i>
 	{{/if}}
 </span>
 {{/if}}


### PR DESCRIPTION
The direction icons on "vier" should look better now. Also there is a new icon indicating that it is a global item. These are items that appear on the "community" page. They only allow limited interactions by now. (Because there is no item record for the given user, only for "uid=0".