### PR TITLE
Ignore list for redirects

### DIFF
--- a/src/Network/HTTPRequest.php
+++ b/src/Network/HTTPRequest.php
@@ -475,14 +475,4 @@ class HTTPRequest implements IHTTPRequest
 			DB_UPDATE_VERSION . '; ' .
 			$this->baseUrl;
 	}
-
-	private function redirectBlocked(string $url = null)
-	{
-		$hosts = $this->config->get('system', 'no_redirect_hosts');
-		if (empty($hosts)) {
-			return false;
-		}
-
-		$hostlist = explode(',', $hosts);
-	}
 }

--- a/src/Protocol/Feed.php
+++ b/src/Protocol/Feed.php
@@ -351,6 +351,8 @@ class Feed
 
 			$orig_plink = $item["plink"];
 
+			$item["plink"] = DI::httpRequest()->finalUrl($item["plink"]);
+
 			$item["parent-uri"] = $item["uri"];
 
 			$item["title"] = XML::getFirstNodeValue($xpath, 'atom:title/text()', $entry);

--- a/src/Protocol/Feed.php
+++ b/src/Protocol/Feed.php
@@ -351,8 +351,6 @@ class Feed
 
 			$orig_plink = $item["plink"];
 
-			$item["plink"] = DI::httpRequest()->finalUrl($item["plink"]);
-
 			$item["parent-uri"] = $item["uri"];
 
 			$item["title"] = XML::getFirstNodeValue($xpath, 'atom:title/text()', $entry);

--- a/src/Util/Network.php
+++ b/src/Util/Network.php
@@ -178,6 +178,35 @@ class Network
 	}
 
 	/**
+	 * Checks if the provided url is on the list of domains where redirects are blocked.
+	 * Returns true if it is or malformed URL, false if not.
+	 *
+	 * @param string $url The url to check the domain from
+	 *
+	 * @return boolean
+	 */
+	public static function isRedirectBlocked(string $url)
+	{
+		$host = @parse_url($url, PHP_URL_HOST);
+		if (!$host) {
+			return false;
+		}
+
+		$no_redirect_list = DI::config()->get('system', 'no_redirect_list', []);
+		if (!$no_redirect_list) {
+			return false;
+		}
+
+		foreach ($no_redirect_list as $no_redirect) {
+			if (fnmatch(strtolower($no_redirect), strtolower($host))) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
 	 * Check if email address is allowed to register here.
 	 *
 	 * Compare against our list (wildcards allowed).

--- a/static/defaults.config.php
+++ b/static/defaults.config.php
@@ -362,6 +362,10 @@ return [
 		// Don't use OEmbed to fetch more information about a link.
 		'no_oembed' => false,
 
+		// no_redirect_list (Array)
+		// List of domains where HTTP redirects should be ignored. 
+		'no_redirect_list' => [],
+
 		// no_smilies (Boolean)
 		// Don't show smilies.
 		'no_smilies' => false,


### PR DESCRIPTION
The function `finalUrl` is meant to resolve link shorteners. This is nice, but can also create problems when the remote system has redirectors when cookies are not enabled or when the content is not allowed from the server's coordinates, but from the viewers. (Can happen with news pages in the US who don't want to adhere the GDPR standards from the EU)

We now have a configurable list for ignored redirects.

This PR fixes a problem on one of my servers that mirrors a lot of news pages. One of the news outlets began to introduce a redirect for subscribers and non subscribers some days ago.