### PR TITLE
Fixes empty feed preview data

### DIFF
--- a/src/Protocol/Feed.php
+++ b/src/Protocol/Feed.php
@@ -563,7 +563,7 @@ class Feed
 				$data_text = strip_tags(trim($data['text'] ?? ''));
 				$item_body = strip_tags(trim($item['body'] ?? ''));
 
-				if (!empty($data['text']) && (($data_text == $item_body) || strstr($item_body, $data_text))) {
+				if (($data_text == $item_body) || strstr($item_body, $data_text)) {
 					$data['text'] = '';
 				}
 

--- a/src/Protocol/Feed.php
+++ b/src/Protocol/Feed.php
@@ -554,7 +554,7 @@ class Feed
 
 				$data = PageInfo::queryUrl($item["plink"], false, $preview, ($contact["fetch_further_information"] == 2), $contact["ffi_keyword_denylist"] ?? '');
 
-				// Take the data that was provided by the feed if the query wasn't empty
+				// Take the data that was provided by the feed if the query is empty
 				if (($data['type'] == 'link') && empty($data['title']) && empty($data['text'])) {
 					$data['title'] = $saved_title;
 					$item["body"] = $saved_body;

--- a/src/Protocol/Feed.php
+++ b/src/Protocol/Feed.php
@@ -533,6 +533,9 @@ class Feed
 					$replace = true;
 				}
 
+				$saved_body = $item["body"];
+				$saved_title = $item["title"];
+
 				if ($replace) {
 					$item["body"] = trim($item["title"]);
 				}
@@ -549,9 +552,17 @@ class Feed
 					}
 				}
 
+				$data = PageInfo::queryUrl($item["plink"], false, $preview, ($contact["fetch_further_information"] == 2), $contact["ffi_keyword_denylist"] ?? '');
+
+				// Take the data that was provided by the feed if the query wasn't empty
+				if (($data['type'] == 'link') && empty($data['title']) && empty($data['text'])) {
+					$data['title'] = $saved_title;
+					$item["body"] = $saved_body;
+				}
+
 				// We always strip the title since it will be added in the page information
 				$item["title"] = "";
-				$item["body"] = $item["body"] . "\n" . PageInfo::getFooterFromUrl($item["plink"], false, $preview, ($contact["fetch_further_information"] == 2), $contact["ffi_keyword_denylist"] ?? '');
+				$item["body"] = $item["body"] . "\n" . PageInfo::getFooterFromData($data, false);
 				$taglist = $contact["fetch_further_information"] == 2 ? PageInfo::getTagsFromUrl($item["plink"], $preview, $contact["ffi_keyword_denylist"] ?? '') : [];
 				$item["object-type"] = Activity\ObjectType::BOOKMARK;
 				unset($item["attach"]);

--- a/src/Protocol/Feed.php
+++ b/src/Protocol/Feed.php
@@ -560,6 +560,13 @@ class Feed
 					$item["body"] = $saved_body;
 				}
 
+				$data_text = strip_tags(trim($data['text'] ?? ''));
+				$item_body = strip_tags(trim($item['body'] ?? ''));
+
+				if (!empty($data['text']) && (($data_text == $item_body) || strstr($item_body, $data_text))) {
+					$data['text'] = '';
+				}
+
 				// We always strip the title since it will be added in the page information
 				$item["title"] = "";
 				$item["body"] = $item["body"] . "\n" . PageInfo::getFooterFromData($data, false);


### PR DESCRIPTION
When fetching feeds, there is the option to replace the feed content with content that had been fetched from the feed entry. There can be situations, when we cannot fetch this data. This is for example the case when the link is an unwanted redirect - see PR https://github.com/friendica/friendica/pull/9212

In this case we will now replace the empty data with the data from the feed.