### PR TITLE
Fix fatal errors, warnings and notices

### DIFF
--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -855,6 +855,9 @@ class Transmitter
 	public static function createActivityFromMail($mail_id, $object_mode = false)
 	{
 		$mail = self::ItemArrayFromMail($mail_id);
+		if (empty($mail)) {
+			return [];
+		}
 		$object = self::createNote($mail);
 
 		if (!$object_mode) {

--- a/src/Protocol/Feed.php
+++ b/src/Protocol/Feed.php
@@ -563,7 +563,7 @@ class Feed
 				$data_text = strip_tags(trim($data['text'] ?? ''));
 				$item_body = strip_tags(trim($item['body'] ?? ''));
 
-				if (($data_text == $item_body) || strstr($item_body, $data_text)) {
+				if (!empty($data_text) && (($data_text == $item_body) || strstr($item_body, $data_text))) {
 					$data['text'] = '';
 				}
 

--- a/src/Util/ExAuth.php
+++ b/src/Util/ExAuth.php
@@ -39,6 +39,7 @@ use Friendica\App;
 use Friendica\Core\Config\IConfig;
 use Friendica\Core\PConfig\IPConfig;
 use Friendica\Database\Database;
+use Friendica\DI;
 use Friendica\Model\User;
 use Friendica\Network\HTTPException;
 


### PR DESCRIPTION
This fixes:
* ` PHP Fatal error:  Uncaught Error: Class 'Friendica\Util\DI' not found in /src/Util/ExAuth.php:223`
* `PHP Fatal error:  Uncaught TypeError: Argument 1 passed to Friendica\Model\Tag::getByURIId() must be of the type int, null given, called in /src/Protocol/ActivityPub/Transmitter.php on line 493 and defined in /src/Model/Tag.php:363`
* `PHP Notice:  Undefined index: uri in /src/Protocol/ActivityPub/Transmitter.php on line 866`
* `PHP Warning:  strstr(): Empty needle in /src/Protocol/Feed.php on line 568`