### PR TITLE
Remove tracking pixels when importing feeds

### DIFF
--- a/src/Protocol/Feed.php
+++ b/src/Protocol/Feed.php
@@ -494,6 +494,9 @@ class Feed
 			}
 			$item["body"] = HTML::toBBCode($body, $basepath);
 
+			// Remove tracking pixels
+			$item["body"] = preg_replace("/\[img=1x1\]([^\[\]]*)\[\/img\]/Usi", '', $item["body"]);
+
 			if (($item["body"] == '') && ($item["title"] != '')) {
 				$item["body"] = $item["title"];
 				$item["title"] = '';


### PR DESCRIPTION
I discovered that one of the feeds that I'm mirroring on one of my systems does contain some tracking pixel. So now pixels width the width and height of eine pixel will be removed.