### PR TITLE
Only display redundant preview data with preview picture

### DIFF
--- a/src/Content/PageInfo.php
+++ b/src/Content/PageInfo.php
@@ -134,14 +134,6 @@ class PageInfo
 
 		$text = "[attachment type='" . $data['type'] . "'";
 
-		if (empty($data['text'])) {
-			$data['text'] = $data['title'];
-		}
-
-		if (empty($data['text'])) {
-			$data['text'] = $data['url'];
-		}
-
 		if (!empty($data['url'])) {
 			$text .= " url='" . $data['url'] . "'";
 		}
@@ -160,6 +152,14 @@ class PageInfo
 				$text .= " image='" . $preview . "'";
 			} else {
 				$text .= " preview='" . $preview . "'";
+
+				if (empty($data['text'])) {
+					$data['text'] = $data['title'];
+				}
+		
+				if (empty($data['text'])) {
+					$data['text'] = $data['url'];
+				}
 			}
 		}
 


### PR DESCRIPTION
When displaying previews for links until now we displayed the title as text when there had been no text. This is useless. We now only do this with small preview pictures for optical purposes.