### PR TITLE
Avoid fatal error on the community page

### DIFF
--- a/src/Content/PageInfo.php
+++ b/src/Content/PageInfo.php
@@ -142,6 +142,10 @@ class PageInfo
 			$text .= " title='" . $data['title'] . "'";
 		}
 
+		if (empty($data['text'])) {
+			$data['text'] = '';
+		}
+
 		// Only embedd a picture link when it seems to be a valid picture ("width" is set)
 		if (!empty($data['images']) && !empty($data['images'][0]['width'])) {
 			$preview = str_replace(['[', ']'], ['&#91;', '&#93;'], htmlentities($data['images'][0]['src'], ENT_QUOTES, 'UTF-8', false));
@@ -163,7 +167,7 @@ class PageInfo
 			}
 		}
 
-		$text .= ']' . $data['text'] ?? '' . '[/attachment]';
+		$text .= ']' . $data['text'] . '[/attachment]';
 
 		$hashtags = '';
 		if (!empty($data['keywords'])) {

--- a/src/Object/Post.php
+++ b/src/Object/Post.php
@@ -977,7 +977,7 @@ class Post
 
 		if ($this->isToplevel()) {
 			if ($conv->getMode() !== 'profile') {
-				if ($this->getDataValue('wall') && !$this->getDataValue('self')) {
+				if ($this->getDataValue('wall') && !$this->getDataValue('self') && !empty($a->page_contact)) {
 					// On the network page, I am the owner. On the display page it will be the profile owner.
 					// This will have been stored in $a->page_contact by our calling page.
 					// Put this person as the wall owner of the wall-to-wall notice.


### PR DESCRIPTION
This should fix this fatal error:
```
[Sun Sep 20 19:23:19.574692 2020] [php7:error] [pid 25996] [client 192.168.102.50:52726] PHP Fatal error:  
Uncaught TypeError: Argument 1 passed to Friendica\\Model\\Contact::getByURL() must be of the type string, null given, called in /var/www/html/src/Model/Contact.php on line 2518 and defined in /var/www/html/src/Model/Contact.php:207
Stack trace:
#0 /var/www/html/src/Model/Contact.php(2518): Friendica\\Model\\Contact::getByURL(NULL, false)
#1 /var/www/html/src/Object/Post.php(985): Friendica\\Model\\Contact::magicLink(NULL)
#2 /var/www/html/src/Object/Post.php(286): Friendica\\Object\\Post->checkWallToWall()
#3 /var/www/html/src/Object/Thread.php(207): Friendica\\Object\\Post->getTemplateData(Array)
#4 /var/www/html/include/conversation.php(679): Friendica\\Object\\Thread->getTemplateData(Array)
#5 /var/www/html/src/Module/Conversation/Community.php(104): conversation(Object(Friendica\\App), Array, 'community', false, false, 'commented', 1)
#6 [internal function]: Friendica\\Module\\Conversation\\Community::content(Array)
#7 /var/www/html/src/App/Page.php(331): call_user_func(Array, Array)
#8 /var/www/html/src/App/Page.php(38 in /var/www/html/src/Model/Contact.php on line 207, referer: https://f.nospy.net/display/ec054ce7-845f-6780-1213-61e875841323
```
See here: https://forum.friendi.ca/73b2629d-695f-6790-afd6-62c731724465