### PR TITLE
Show if a post arrived via relay

### DIFF
--- a/include/conversation.php
+++ b/include/conversation.php
@@ -764,10 +764,9 @@ function conversation_fetch_comments($thread_items, $pinned) {
 			case Item::PT_GLOBAL:
 				$row['direction'] = ['direction' => 9, 'title' => DI::l10n()->t('Global')];
 				break;
-			default:
-				if ($row['uid'] == 0) {
-					$row['direction'] = ['direction' => 9, 'title' => DI::l10n()->t('Global')];
-				}
+			case Item::PT_RELAY:
+				$row['direction'] = ['direction' => 10, 'title' => DI::l10n()->t('Relay')];
+				break;
 		}
 
 		if (($row['gravity'] == GRAVITY_PARENT) && !$row['origin'] && ($row['author-id'] == $row['owner-id']) &&

--- a/include/conversation.php
+++ b/include/conversation.php
@@ -767,7 +767,10 @@ function conversation_fetch_comments($thread_items, $pinned) {
 			case Item::PT_RELAY:
 				$row['direction'] = ['direction' => 10, 'title' => DI::l10n()->t('Relay')];
 				break;
-		}
+			case Item::PT_FETCHED:
+				$row['direction'] = ['direction' => 2, 'title' => DI::l10n()->t('Fetched')];
+				break;
+			}
 
 		if (($row['gravity'] == GRAVITY_PARENT) && !$row['origin'] && ($row['author-id'] == $row['owner-id']) &&
 			!Contact::isSharing($row['author-id'], $row['uid'])) {

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -67,6 +67,7 @@ class Item
 	const PT_COMMENT = 71;
 	const PT_STORED = 72;
 	const PT_GLOBAL = 73;
+	const PT_RELAY = 74;
 	const PT_PERSONAL_NOTE = 128;
 
 	// Field list that is used to display the items

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -68,6 +68,7 @@ class Item
 	const PT_STORED = 72;
 	const PT_GLOBAL = 73;
 	const PT_RELAY = 74;
+	const PT_FETCHED = 75;
 	const PT_PERSONAL_NOTE = 128;
 
 	// Field list that is used to display the items

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -521,8 +521,12 @@ class Processor
 					$item['post-type'] = Item::PT_ARTICLE;
 			}
 
-			if (in_array($item['post-type'], [Item::PT_GLOBAL, Item::PT_ARTICLE]) && !empty($activity['from-relay'])) {
-				$item['post-type'] = Item::PT_RELAY;
+			if (in_array($item['post-type'], [Item::PT_COMMENT, Item::PT_GLOBAL, Item::PT_ARTICLE])) {
+				if (!empty($activity['from-relay'])) {
+					$item['post-type'] = Item::PT_RELAY;
+				} elseif (!empty($activity['thread-completion'])) {
+					$item['post-type'] = Item::PT_FETCHED;
+				}
 			}
 
 			if ($item['isForum'] ?? false) {
@@ -692,13 +696,13 @@ class Processor
 	/**
 	 * Fetches missing posts
 	 *
-	 * @param string $url       message URL
-	 * @param array  $child     activity array with the child of this message
-	 * @param bool   $relaymode Posts arrived via relay
+	 * @param string $url   message URL
+	 * @param array  $child activity array with the child of this message
+	 * @param string $actor Relay actor
 	 * @return string fetched message URL
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
-	public static function fetchMissingActivity(string $url, array $child = [], bool $relaymode = false)
+	public static function fetchMissingActivity(string $url, array $child = [], string $actor = '')
 	{
 		if (!empty($child['receiver'])) {
 			$uid = ActivityPub\Receiver::getFirstUserFromReceivers($child['receiver']);
@@ -757,7 +761,7 @@ class Processor
 		$ldactivity = JsonLD::compact($activity);
 
 		$ldactivity['thread-completion'] = true;
-		$ldactivity['from-relay'] = $relaymode;
+		$ldactivity['from-relay'] = !empty($actor);
 
 		ActivityPub\Receiver::processActivity($ldactivity, json_encode($activity), $uid, true, false, $signer);
 

--- a/src/Protocol/ActivityPub/Receiver.php
+++ b/src/Protocol/ActivityPub/Receiver.php
@@ -180,7 +180,7 @@ class Receiver
 			return;
 		}
 
-		Processor::fetchMissingActivity($object_id);
+		Processor::fetchMissingActivity($object_id, [], true);
 
 		$item_id = Item::searchByLink($object_id);
 		if ($item_id) {
@@ -468,6 +468,11 @@ class Receiver
 			$object_data['thread-completion'] = $activity['thread-completion'];
 		}
 
+		// Internal flag for posts that arrived via relay
+		if (!empty($activity['from-relay'])) {
+			$object_data['from-relay'] = $activity['from-relay'];
+		}
+		
 		switch ($type) {
 			case 'as:Create':
 				if (in_array($object_data['object_type'], self::CONTENT_TYPES)) {

--- a/src/Protocol/ActivityPub/Receiver.php
+++ b/src/Protocol/ActivityPub/Receiver.php
@@ -100,7 +100,7 @@ class Receiver
 
 		$apcontact = APContact::getByURL($actor);
 		if (!empty($apcontact) && ($apcontact['type'] == 'Application') && ($apcontact['nick'] == 'relay')) {
-			self::processRelayPost($ldactivity);
+			self::processRelayPost($ldactivity, $actor);
 			return;
 		}
 
@@ -150,10 +150,11 @@ class Receiver
 	/**
 	 * Process incoming posts from relays
 	 *
-	 * @param array $activity
+	 * @param array  $activity
+	 * @param string $actor
 	 * @return void
 	 */
-	private static function processRelayPost(array $activity)
+	private static function processRelayPost(array $activity, string $actor)
 	{
 		$type = JsonLD::fetchElement($activity, '@type');
 		if (!$type) {
@@ -180,7 +181,7 @@ class Receiver
 			return;
 		}
 
-		Processor::fetchMissingActivity($object_id, [], true);
+		Processor::fetchMissingActivity($object_id, [], $actor);
 
 		$item_id = Item::searchByLink($object_id);
 		if ($item_id) {

--- a/view/theme/frio/templates/sub/direction.tpl
+++ b/view/theme/frio/templates/sub/direction.tpl
@@ -19,6 +19,8 @@
 		<i class="fa fa-share" aria-hidden="true" title="{{$direction.title}}"></i>
 	{{elseif $direction.direction == 9}}
 		<i class="fa fa-globe" aria-hidden="true" title="{{$direction.title}}"></i>
+	{{elseif $direction.direction == 10}}
+		<i class="fa fa-inbox" aria-hidden="true" title="{{$direction.title}}"></i>
 	{{/if}}
 </span>
 {{/if}}

--- a/view/theme/vier/templates/sub/direction.tpl
+++ b/view/theme/vier/templates/sub/direction.tpl
@@ -19,6 +19,8 @@
 		<i class="icon-share" aria-hidden="true" title="{{$direction.title}}"></i>
 	{{elseif $direction.direction == 9}}
 		<i class="icon-globe" aria-hidden="true" title="{{$direction.title}}"></i>
+	{{elseif $direction.direction == 10}}
+		<i class="icon-inbox" aria-hidden="true" title="{{$direction.title}}"></i>
 	{{/if}}
 </span>
 {{/if}}


### PR DESCRIPTION
There is now a new direction for relay posts. This is also a preparation for hashtag filtering of these relay posts.

Also we don't assume "global" anymore by default. This should help to debug this situation: https://github.com/friendica/friendica/issues/9167#issuecomment-696062134