### PR TITLE
Issue 9264: post types should now work

### DIFF
--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -1712,8 +1712,7 @@ class Item
 		$item['owner-id'] = ($item['owner-id'] ?? 0) ?: Contact::getIdForURL($item['owner-link'], 0, null, $default);
 
 		$actor = ($item['gravity'] == GRAVITY_PARENT) ? $item['owner-id'] : $item['author-id'];
-		if (in_array($item['post-type'], [self::PT_ARTICLE, self::PT_COMMENT, self::PT_RELAY, self::PT_GLOBAL])
-			&& !$item['origin'] && ($item['uid'] != 0) && Contact::isSharing($actor, $item['uid'])) {
+		if (!$item['origin'] && ($item['uid'] != 0) && Contact::isSharing($actor, $item['uid'])) {
 			$item['post-type'] = self::PT_FOLLOWER;
 		}
 
@@ -2038,8 +2037,7 @@ class Item
 		}
 
 		if ($author['contact-type'] != Contact::TYPE_COMMUNITY) {
-			if (!in_array($parent['post-type'], [self::PT_ARTICLE, self::PT_COMMENT, self::PT_STORED, self::PT_GLOBAL, self::PT_RELAY, self::PT_FETCHED])
-				|| Contact::isSharing($parent['owner-id'], $item['uid'])) {
+			if (Contact::isSharing($parent['owner-id'], $item['uid'])) {
 				Logger::info('The resharer is no forum: quit', ['resharer' => $item['author-id'], 'owner' => $parent['owner-id'], 'author' => $parent['author-id'], 'uid' => $item['uid']]);
 				return;
 			}
@@ -2382,6 +2380,7 @@ class Item
 			unset($item['starred']);
 			unset($item['postopts']);
 			unset($item['inform']);
+			unset($item['post-type']);
 			if ($item['uri'] == $item['parent-uri']) {
 				$item['contact-id'] = $item['owner-id'];
 			} else {
@@ -2444,6 +2443,7 @@ class Item
 		unset($item['starred']);
 		unset($item['postopts']);
 		unset($item['inform']);
+		unset($item['post-type']);
 		$item['contact-id'] = Contact::getIdForURL($item['author-link']);
 
 		$public_shadow = self::insert($item, false, true);

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -488,6 +488,7 @@ class Processor
 		}
 
 		$stored = false;
+		ksort($activity['receiver']);
 
 		foreach ($activity['receiver'] as $receiver) {
 			if ($receiver == -1) {
@@ -523,12 +524,10 @@ class Processor
 					$item['post-type'] = Item::PT_ARTICLE;
 			}
 
-			if (in_array($item['post-type'], [Item::PT_COMMENT, Item::PT_GLOBAL, Item::PT_ARTICLE])) {
-				if (!empty($activity['from-relay'])) {
-					$item['post-type'] = Item::PT_RELAY;
-				} elseif (!empty($activity['thread-completion'])) {
-					$item['post-type'] = Item::PT_FETCHED;
-				}
+			if (!empty($activity['from-relay'])) {
+				$item['post-type'] = Item::PT_RELAY;
+			} elseif (!empty($activity['thread-completion'])) {
+				$item['post-type'] = Item::PT_FETCHED;
 			}
 
 			if (!empty($activity['from-relay'])) {


### PR DESCRIPTION
This now really should fix #9264

There had been a bug with the reception types - since it is an array with numeric keys, one mustn't use `array_merge` here. Fixing this reveals some more bugs, where posts that had been fetched via "completion" had falsely been assigned to the follower.

This now does seem to work. It would be great if this would be merged in advance of the hackathon, so that there is a clean base to start from.