### PR TITLE
Issue 9268: Don't show posts from followers on community page

### DIFF
--- a/src/Module/Conversation/Community.php
+++ b/src/Module/Conversation/Community.php
@@ -295,6 +295,11 @@ class Community extends BaseModule
 			return [];
 		}
 
+		if (local_user() && DI::config()->get('system', 'community_no_followers')) {
+			$condition[0] .= " AND NOT EXISTS (SELECT `uri-id` FROM `thread` AS t1 WHERE `t1`.`uri-id` = `thread`.`uri-id` AND `t1`.`uid` = ?)";
+			$condition[] = local_user();
+		}
+
 		if (isset($max_id)) {
 			$condition[0] .= " AND `commented` < ?";
 			$condition[] = $max_id;

--- a/static/defaults.config.php
+++ b/static/defaults.config.php
@@ -122,6 +122,10 @@ return [
 		// Deny public access to the local user directory.
 		'block_local_dir' => false,
 
+		// community_no_followers (Boolean)
+		// Don't display followers on the global community
+		'community_no_followers' => false,
+
 		// cron_interval (Integer)
 		// Minimal period in minutes between two calls of the "Cron" worker job.
 		'cron_interval' => 5,


### PR DESCRIPTION
This is the first implementation for #9268

We can now display only posts from accounts that we don't follow. In the future we should control this with an widget, but for testing purposes it is now a server setting.