### PR TITLE
Issue 9276: Cache the trending hashtags in the background

### DIFF
--- a/src/Model/Tag.php
+++ b/src/Model/Tag.php
@@ -494,7 +494,7 @@ class Tag
 	 */
 	public static function getGlobalTrendingHashtags(int $period, $limit = 10)
 	{
-		$tags = DI::cache()->get('global_trending_tags');
+		$tags = DI::cache()->get('global_trending_tags-' . $period . '-' . $limit);
 		if (!empty($tags)) {
 			return $tags;
 		} else {
@@ -520,7 +520,7 @@ class Tag
 
 		if (DBA::isResult($tagsStmt)) {
 			$tags = DBA::toArray($tagsStmt);
-			DI::cache()->set('global_trending_tags', $tags, Duration::HOUR);
+			DI::cache()->set('global_trending_tags-' . $period . '-' . $limit, $tags, Duration::HOUR);
 			return $tags;
 		}
 

--- a/src/Model/Tag.php
+++ b/src/Model/Tag.php
@@ -488,54 +488,86 @@ class Tag
 	 * Returns a list of the most frequent global hashtags over the given period
 	 *
 	 * @param int $period Period in hours to consider posts
+	 * @param int $limit  Number of returned tags
 	 * @return array
 	 * @throws \Exception
 	 */
 	public static function getGlobalTrendingHashtags(int $period, $limit = 10)
 	{
 		$tags = DI::cache()->get('global_trending_tags');
+		if (!empty($tags)) {
+			return $tags;
+		} else {
+			return self::setGlobalTrendingHashtags($period, $limit);
+		}
+	}
 
-		if (empty($tags)) {
-			$tagsStmt = DBA::p("SELECT `name` AS `term`, COUNT(*) AS `score`
-				FROM `tag-search-view`
-				WHERE `private` = ? AND `received` > DATE_SUB(NOW(), INTERVAL ? HOUR)
-				GROUP BY `term` ORDER BY `score` DESC LIMIT ?",
-				Item::PUBLIC, $period, $limit);
+	/**
+	 * Creates a list of the most frequent global hashtags over the given period
+	 *
+	 * @param int $period Period in hours to consider posts
+	 * @param int $limit  Number of returned tags
+	 * @return array
+	 * @throws \Exception
+	 */
+	public static function setGlobalTrendingHashtags(int $period, $limit = 10)
+	{
+		$tagsStmt = DBA::p("SELECT `name` AS `term`, COUNT(*) AS `score`
+			FROM `tag-search-view`
+			WHERE `private` = ? AND `received` > DATE_SUB(NOW(), INTERVAL ? HOUR)
+			GROUP BY `term` ORDER BY `score` DESC LIMIT ?",
+			Item::PUBLIC, $period, $limit);
 
-			if (DBA::isResult($tagsStmt)) {
-				$tags = DBA::toArray($tagsStmt);
-				DI::cache()->set('global_trending_tags', $tags, Duration::HOUR);
-			}
+		if (DBA::isResult($tagsStmt)) {
+			$tags = DBA::toArray($tagsStmt);
+			DI::cache()->set('global_trending_tags', $tags, Duration::HOUR);
+			return $tags;
 		}
 
-		return $tags ?: [];
+		return [];
 	}
 
 	/**
 	 * Returns a list of the most frequent local hashtags over the given period
 	 *
 	 * @param int $period Period in hours to consider posts
+	 * @param int $limit  Number of returned tags
 	 * @return array
 	 * @throws \Exception
 	 */
 	public static function getLocalTrendingHashtags(int $period, $limit = 10)
 	{
 		$tags = DI::cache()->get('local_trending_tags');
+		if (!empty($tags)) {
+			return $tags;
+		} else {
+			return self::setLocalTrendingHashtags($period, $limit);
+		}
+	}
 
-		if (empty($tags)) {
-			$tagsStmt = DBA::p("SELECT `name` AS `term`, COUNT(*) AS `score`
-				FROM `tag-search-view`
-				WHERE `private` = ? AND `wall` AND `origin` AND `received` > DATE_SUB(NOW(), INTERVAL ? HOUR)
-				GROUP BY `term` ORDER BY `score` DESC LIMIT ?",
-				Item::PUBLIC, $period, $limit);
+	/**
+	 * Returns a list of the most frequent local hashtags over the given period
+	 *
+	 * @param int $period Period in hours to consider posts
+	 * @param int $limit  Number of returned tags
+	 * @return array
+	 * @throws \Exception
+	 */
+	public static function setLocalTrendingHashtags(int $period, $limit = 10)
+	{
+		$tagsStmt = DBA::p("SELECT `name` AS `term`, COUNT(*) AS `score`
+			FROM `tag-search-view`
+			WHERE `private` = ? AND `wall` AND `origin` AND `received` > DATE_SUB(NOW(), INTERVAL ? HOUR)
+			GROUP BY `term` ORDER BY `score` DESC LIMIT ?",
+			Item::PUBLIC, $period, $limit);
 
-			if (DBA::isResult($tagsStmt)) {
-				$tags = DBA::toArray($tagsStmt);
-				DI::cache()->set('local_trending_tags', $tags, Duration::HOUR);
-			}
+		if (DBA::isResult($tagsStmt)) {
+			$tags = DBA::toArray($tagsStmt);
+			DI::cache()->set('local_trending_tags', $tags, Duration::HOUR);
+			return $tags;
 		}
 
-		return $tags ?: [];
+		return [];
 	}
 
 	/**

--- a/src/Worker/Cron.php
+++ b/src/Worker/Cron.php
@@ -25,6 +25,7 @@ use Friendica\Core\Hook;
 use Friendica\Core\Logger;
 use Friendica\Core\Worker;
 use Friendica\DI;
+use Friendica\Model\Tag;
 
 class Cron
 {
@@ -73,6 +74,10 @@ class Cron
 
 		// Repair entries in the database
 		Worker::add(PRIORITY_LOW, 'RepairDatabase');
+
+		// Update trending tags cache for the community page
+		Tag::setLocalTrendingHashtags(24, 20);
+		Tag::setGlobalTrendingHashtags(24, 20);
 
 		// Hourly cron calls
 		if (DI::config()->get('system', 'last_cron_hourly', 0) + 3600 < time()) {


### PR DESCRIPTION
This fixes https://github.com/friendica/friendica/issues/9276

We now create the cache for the trending tags in the background.