### PR TITLE
Account selector for the community page

### DIFF
--- a/src/Module/Conversation/Community.php
+++ b/src/Module/Conversation/Community.php
@@ -114,18 +114,14 @@ class Community extends BaseModule
 		$o .= $pager->renderMinimal(count($items));
 
 		DI::page()['aside'] .= Renderer::replaceMacros(Renderer::getMarkupTemplate('widget/community_accounts.tpl'), [
-			'$content'               => self::$content,
-			'$title'                 => DI::l10n()->t('Accounts'),
-			'$all'                   => DI::l10n()->t('All Accounts'),
-			'$all_selected'          => ($parameters['accounttype'] == '') ? 'selected' : '',
-			'$person'                => DI::l10n()->t('Personal Accounts'),
-			'$person_selected'       => ($parameters['accounttype'] == 'person') ? 'selected' : '',
-			'$organisation'          => DI::l10n()->t('Organisation Accounts'),
-			'$organisation_selected' => ($parameters['accounttype'] == 'organisation') ? 'selected' : '',
-			'$news'                  => DI::l10n()->t('News Accounts'),
-			'$news_selected'         => ($parameters['accounttype'] == 'news') ? 'selected' : '',
-			'$community'             => DI::l10n()->t('Communities'),
-			'$community_selected'    => ($parameters['accounttype'] == 'community') ? 'selected' : '',
+			'$title'        => DI::l10n()->t('Accounts'),
+			'$content'      => self::$content,
+			'$accounttype'  => $parameters['accounttype'],
+			'$all'          => DI::l10n()->t('All Accounts'),
+			'$person'       => DI::l10n()->t('Personal Accounts'),
+			'$organisation' => DI::l10n()->t('Organisation Accounts'),
+			'$news'         => DI::l10n()->t('News Accounts'),
+			'$community'    => DI::l10n()->t('Communities'),
 		]);
 
 		if (Feature::isEnabled(local_user(), 'trending_tags')) {

--- a/src/Module/Conversation/Community.php
+++ b/src/Module/Conversation/Community.php
@@ -113,6 +113,21 @@ class Community extends BaseModule
 
 		$o .= $pager->renderMinimal(count($items));
 
+		DI::page()['aside'] .= Renderer::replaceMacros(Renderer::getMarkupTemplate('widget/community_accounts.tpl'), [
+			'$content'               => self::$content,
+			'$title'                 => DI::l10n()->t('Accounts'),
+			'$all'                   => DI::l10n()->t('All Accounts'),
+			'$all_selected'          => ($parameters['accounttype'] == '') ? 'selected' : '',
+			'$person'                => DI::l10n()->t('Personal Accounts'),
+			'$person_selected'       => ($parameters['accounttype'] == 'person') ? 'selected' : '',
+			'$organisation'          => DI::l10n()->t('Organisation Accounts'),
+			'$organisation_selected' => ($parameters['accounttype'] == 'organisation') ? 'selected' : '',
+			'$news'                  => DI::l10n()->t('News Accounts'),
+			'$news_selected'         => ($parameters['accounttype'] == 'news') ? 'selected' : '',
+			'$community'             => DI::l10n()->t('Communities'),
+			'$community_selected'    => ($parameters['accounttype'] == 'community') ? 'selected' : '',
+		]);
+
 		if (Feature::isEnabled(local_user(), 'trending_tags')) {
 			DI::page()['aside'] .= TrendingTags::getHTML(self::$content);
 		}

--- a/view/templates/widget/community_accounts.tpl
+++ b/view/templates/widget/community_accounts.tpl
@@ -3,9 +3,9 @@
 
 	<ul class="sidebar-community-accounts-ul">
 		<li role="menuitem" class="sidebar-community-accounts-li{{if !$accounttype}} selected{{/if}}"><a href="community/{{$content}}">{{$all}}</a></li>
-		<li role="menuitem" class="sidebar-community-accounts-li{{if $accounttype eq 'person'}} selected{{/if}}"><a href="community/{{$content}}/person">{{$person}}</a></li>
-		<li role="menuitem" class="sidebar-community-accounts-li{{if $accounttype eq 'organisation'}} selected{{/if}}"><a href="community/{{$content}}/organisation">{{$organisation}}</a></li>
-		<li role="menuitem" class="sidebar-community-accounts-li{{if $accounttype eq 'news'}} selected{{/if}}"><a href="community/{{$content}}/news">{{$news}}</a></li>
-		<li role="menuitem" class="sidebar-community-accounts-li{{if $accounttype eq 'community'}} selected{{/if}}"><a href="community/{{$content}}/community">{{$community}}</a></li>
+		<li role="menuitem" class="sidebar-community-accounts-li{{if $accounttype == 'person'}} selected{{/if}}"><a href="community/{{$content}}/person">{{$person}}</a></li>
+		<li role="menuitem" class="sidebar-community-accounts-li{{if $accounttype == 'organisation'}} selected{{/if}}"><a href="community/{{$content}}/organisation">{{$organisation}}</a></li>
+		<li role="menuitem" class="sidebar-community-accounts-li{{if $accounttype == 'news'}} selected{{/if}}"><a href="community/{{$content}}/news">{{$news}}</a></li>
+		<li role="menuitem" class="sidebar-community-accounts-li{{if $accounttype == 'community'}} selected{{/if}}"><a href="community/{{$content}}/community">{{$community}}</a></li>
 	</ul>
 </div>

--- a/view/templates/widget/community_accounts.tpl
+++ b/view/templates/widget/community_accounts.tpl
@@ -1,0 +1,11 @@
+<div id="sidebar-community-accounts" class="widget">
+	<h3>{{$title}}</h3>
+
+	<ul class="sidebar-community-accounts-ul">
+		<li role="menuitem" class="sidebar-community-accounts-li {{$all_selected}}"><a href="community/{{$content}}">{{$all}}</a></li>
+		<li role="menuitem" class="sidebar-community-accounts-li {{$person_selected}}"><a href="community/{{$content}}/person">{{$person}}</a></li>
+		<li role="menuitem" class="sidebar-community-accounts-li {{$organisation_selected}}"><a href="community/{{$content}}/organisation">{{$organisation}}</a></li>
+		<li role="menuitem" class="sidebar-community-accounts-li {{$news_selected}}"><a href="community/{{$content}}/news">{{$news}}</a></li>
+		<li role="menuitem" class="sidebar-community-accounts-li {{$community_selected}}"><a href="community/{{$content}}/community">{{$community}}</a></li>
+	</ul>
+</div>

--- a/view/templates/widget/community_accounts.tpl
+++ b/view/templates/widget/community_accounts.tpl
@@ -2,10 +2,10 @@
 	<h3>{{$title}}</h3>
 
 	<ul class="sidebar-community-accounts-ul">
-		<li role="menuitem" class="sidebar-community-accounts-li {{$all_selected}}"><a href="community/{{$content}}">{{$all}}</a></li>
-		<li role="menuitem" class="sidebar-community-accounts-li {{$person_selected}}"><a href="community/{{$content}}/person">{{$person}}</a></li>
-		<li role="menuitem" class="sidebar-community-accounts-li {{$organisation_selected}}"><a href="community/{{$content}}/organisation">{{$organisation}}</a></li>
-		<li role="menuitem" class="sidebar-community-accounts-li {{$news_selected}}"><a href="community/{{$content}}/news">{{$news}}</a></li>
-		<li role="menuitem" class="sidebar-community-accounts-li {{$community_selected}}"><a href="community/{{$content}}/community">{{$community}}</a></li>
+		<li role="menuitem" class="sidebar-community-accounts-li{{if !$accounttype}} selected{{/if}}"><a href="community/{{$content}}">{{$all}}</a></li>
+		<li role="menuitem" class="sidebar-community-accounts-li{{if $accounttype eq 'person'}} selected{{/if}}"><a href="community/{{$content}}/person">{{$person}}</a></li>
+		<li role="menuitem" class="sidebar-community-accounts-li{{if $accounttype eq 'organisation'}} selected{{/if}}"><a href="community/{{$content}}/organisation">{{$organisation}}</a></li>
+		<li role="menuitem" class="sidebar-community-accounts-li{{if $accounttype eq 'news'}} selected{{/if}}"><a href="community/{{$content}}/news">{{$news}}</a></li>
+		<li role="menuitem" class="sidebar-community-accounts-li{{if $accounttype eq 'community'}} selected{{/if}}"><a href="community/{{$content}}/community">{{$community}}</a></li>
 	</ul>
 </div>


### PR DESCRIPTION
For a longer time we had been able to select the account types that we want to see on the community page - but there hadn't been no frontend. Now we have got a frontend for that.