### PR TITLE
Tags: Use the parameters for the cache key

### DIFF
--- a/src/Model/Tag.php
+++ b/src/Model/Tag.php
@@ -537,7 +537,7 @@ class Tag
 	 */
 	public static function getLocalTrendingHashtags(int $period, $limit = 10)
 	{
-		$tags = DI::cache()->get('local_trending_tags');
+		$tags = DI::cache()->get('local_trending_tags-' . $period . '-' . $limit);
 		if (!empty($tags)) {
 			return $tags;
 		} else {
@@ -563,7 +563,7 @@ class Tag
 
 		if (DBA::isResult($tagsStmt)) {
 			$tags = DBA::toArray($tagsStmt);
-			DI::cache()->set('local_trending_tags', $tags, Duration::HOUR);
+			DI::cache()->set('local_trending_tags-' . $period . '-' . $limit, $tags, Duration::HOUR);
 			return $tags;
 		}
 


### PR DESCRIPTION
We do so for the global trending tags, we should do so for the local ones as well.