### PR TITLE
Avoid duplicate postings

### DIFF
--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -1834,6 +1834,11 @@ class Item
 
 		if (!in_array($item['verb'], self::ACTIVITIES)) {
 			$item['icid'] = self::insertContent($item);
+			if (empty($item['icid'])) {
+				// This most likely happens when identical posts arrives from different sources at the same time
+				Logger::warning('No content stored, quitting', ['guid' => $item['guid'], 'uri-id' => $item['uri-id'], 'causer-id' => ($item['causer-id'] ?? 0), 'post-type' => $item['post-type'], 'network' => $item['network']]);
+				return 0;
+			}
 		}
 
 		$body = $item['body'];


### PR DESCRIPTION
Because of the relay servers, we now receive the same item multiple times. This can happen at nearly the same time which can cause timing issues so that the duplicate check doesn't work reliable. These conditions also lead to not being able adding the item content. So that is an indicator for duplicated posts.

In the future we have to add a unique key for the item table - but we cannot introduce this easily without cleaning the data before.