### PR TITLE
Don't display a resharer that was the causer of the post

### DIFF
--- a/include/conversation.php
+++ b/include/conversation.php
@@ -1005,6 +1005,14 @@ function builtin_activity_puller($item, &$conv_responses) {
 				continue;
 			}
 
+			// Skip when the causer of the parent is the same than the author of the announce
+			if ($verb == Activity::ANNOUNCE) {
+				$parent = Item::selectFirst(['causer-id', 'gravity'], ['uri' => $item['thr-parent']]);
+				if (($parent['causer-id'] == $item['author-id']) && ($parent['gravity'] == GRAVITY_PARENT)) {
+					continue;
+				}
+			}
+
 			if (!isset($conv_responses[$mode][$item['thr-parent']])) {
 				$conv_responses[$mode][$item['thr-parent']] = 1;
 			} else {


### PR DESCRIPTION
We now only display resharers in the bottom of a message when they hadn't been the causer.