### PR TITLE
Remove whitespace before ":" of mail headers

### DIFF
--- a/src/Object/Email.php
+++ b/src/Object/Email.php
@@ -137,10 +137,10 @@ class Email implements IEmail
 		foreach ($this->additionalMailHeader as $name => $values) {
 			if (is_array($values)) {
 				foreach ($values as $value) {
-					$headerString .= "$name : $value\n";
+					$headerString .= "$name: $value\n";
 				}
 			} else {
-				$headerString .= "$name : $values\n";
+				$headerString .= "$name: $values\n";
 			}
 		}
 		return $headerString;

--- a/tests/src/Util/EMailerTest.php
+++ b/tests/src/Util/EMailerTest.php
@@ -83,10 +83,10 @@ class EMailerTest extends MockedTest
 
 		$this->assertTrue($emailer->send($testEmail));
 
-		$this->assertContains("X-Friendica-Host : friendica.local", EmailerSpy::$MAIL_DATA['headers']);
-		$this->assertContains("X-Friendica-Platform : Friendica", EmailerSpy::$MAIL_DATA['headers']);
-		$this->assertContains("List-ID : <notification.friendica.local>", EmailerSpy::$MAIL_DATA['headers']);
-		$this->assertContains("List-Archive : <http://friendica.local/notifications/system>", EmailerSpy::$MAIL_DATA['headers']);
+		$this->assertContains("X-Friendica-Host: friendica.local", EmailerSpy::$MAIL_DATA['headers']);
+		$this->assertContains("X-Friendica-Platform: Friendica", EmailerSpy::$MAIL_DATA['headers']);
+		$this->assertContains("List-ID: <notification.friendica.local>", EmailerSpy::$MAIL_DATA['headers']);
+		$this->assertContains("List-Archive: <http://friendica.local/notifications/system>", EmailerSpy::$MAIL_DATA['headers']);
 		$this->assertContains("Reply-To: Sender <sender@friendica.local>", EmailerSpy::$MAIL_DATA['headers']);
 		$this->assertContains("MIME-Version: 1.0", EmailerSpy::$MAIL_DATA['headers']);
 		// Base64 "Test Text"


### PR DESCRIPTION
Fixes #9282 