### PR TITLE
Issue 9303: Detect AP accesses as backend, prevent ping pong

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -448,7 +448,7 @@ class App
 				Core\Worker::executeIfIdle();
 			}
 
-			if ($this->mode->isNormal()) {
+			if ($this->mode->isNormal() && !$this->mode->isBackend()) {
 				$requester = HTTPSignature::getSigner('', $_SERVER);
 				if (!empty($requester)) {
 					Profile::addVisitorCookieForHandle($requester);
@@ -456,7 +456,7 @@ class App
 			}
 
 			// ZRL
-			if (!empty($_GET['zrl']) && $this->mode->isNormal()) {
+			if (!empty($_GET['zrl']) && $this->mode->isNormal() && !$this->mode->isBackend()) {
 				if (!local_user()) {
 					// Only continue when the given profile link seems valid
 					// Valid profile links contain a path with "/profile/" and no query parameters

--- a/src/App/Mode.php
+++ b/src/App/Mode.php
@@ -134,8 +134,15 @@ class Mode
 	 */
 	public function determineRunMode(bool $isBackend, Module $module, array $server, MobileDetect $mobileDetect)
 	{
-		$isBackend = $isBackend ||
-		             $module->isBackend();
+		$contenttypes = ['application/jrd+json', 'application/xrd+xml', 'text/xml',
+			'application/rss+xml', 'application/atom+xml', 'application/activity+json'];
+		foreach ($contenttypes as $type) {
+			if (strpos(strtolower($server['HTTP_ACCEPT'] ?? ''), $type) !== false) {
+				$isBackend = true;
+			}
+		}
+
+		$isBackend = $isBackend || $module->isBackend();
 		$isMobile  = $mobileDetect->isMobile();
 		$isTablet  = $mobileDetect->isTablet();
 		$isAjax    = strtolower($server['HTTP_X_REQUESTED_WITH'] ?? '') == 'xmlhttprequest';

--- a/src/App/Mode.php
+++ b/src/App/Mode.php
@@ -38,6 +38,9 @@ class Mode
 	const DBCONFIGAVAILABLE   = 4;
 	const MAINTENANCEDISABLED = 8;
 
+	const BACKEND_CONTENT_TYPES = ['application/jrd+json', 'application/xrd+xml', 'text/xml',
+		'application/rss+xml', 'application/atom+xml', 'application/activity+json'];
+
 	/***
 	 * @var int The mode of this Application
 	 *
@@ -134,9 +137,7 @@ class Mode
 	 */
 	public function determineRunMode(bool $isBackend, Module $module, array $server, MobileDetect $mobileDetect)
 	{
-		$contenttypes = ['application/jrd+json', 'application/xrd+xml', 'text/xml',
-			'application/rss+xml', 'application/atom+xml', 'application/activity+json'];
-		foreach ($contenttypes as $type) {
+		foreach (self::BACKEND_CONTENT_TYPES as $type) {
 			if (strpos(strtolower($server['HTTP_ACCEPT'] ?? ''), $type) !== false) {
 				$isBackend = true;
 			}


### PR DESCRIPTION
This hopefully helps with issue https://github.com/friendica/friendica/issues/9303

We now prevent that AP processes are detected as frontend processes. For frontend processes we always check for the signed requests and add some session information. But when the other contact is new then we have to request their profile data - which then can lead to the other system detecting our access, wanting to add some session data and requesting some data from us as well - which leads into some ping pong actions.

We have to check if this really had been the origin of the problem.