### PR TITLE
Revert "application/xrd+xml" backend content type

### DIFF
--- a/src/App/Mode.php
+++ b/src/App/Mode.php
@@ -38,7 +38,7 @@ class Mode
 	const DBCONFIGAVAILABLE   = 4;
 	const MAINTENANCEDISABLED = 8;
 
-	const BACKEND_CONTENT_TYPES = ['application/jrd+json', 'application/xrd+xml', 'text/xml',
+	const BACKEND_CONTENT_TYPES = ['application/jrd+json', 'text/xml',
 		'application/rss+xml', 'application/atom+xml', 'application/activity+json'];
 
 	/***


### PR DESCRIPTION
Reverts the content type `application/xrd+xml`, introduced with #9336 .

The 2Factor Authentication method sends `application/xrd+xml` messages. After entering the right code, I see the following `HTTP_ACCEPT` header value: `text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8, application/xrd+xml`.

I don't find any manual overrides where we'd set this header in this case, so I thought it's maybe part of the 2factor process based on the Google lib. What do you say @MrPetovan  ?

The problem is that without this PR, the 2Factor doesn't work because the verification is determined as "backend mode", so the session isn't working right.