### PR TITLE
Reduce the amount of contact updates

### DIFF
--- a/src/Module/Search/Index.php
+++ b/src/Module/Search/Index.php
@@ -156,7 +156,7 @@ class Index extends BaseSearch
 		}
 
 		$last_uriid = isset($_GET['last_uriid']) ? intval($_GET['last_uriid']) : 0;
-Logger::info('Blubb', ['uri' => $last_uriid]);
+
 		$pager = new Pager(DI::l10n(), DI::args()->getQueryString(), $itemsPerPage);
 
 		if ($tag) {

--- a/src/Worker/PullDirectory.php
+++ b/src/Worker/PullDirectory.php
@@ -22,7 +22,6 @@
 namespace Friendica\Worker;
 
 use Friendica\Core\Logger;
-use Friendica\Core\Worker;
 use Friendica\DI;
 use Friendica\Model\Contact;
 
@@ -65,6 +64,6 @@ class PullDirectory
 		$now = $contacts['now'] ?? 0;
 		DI::config()->set('system', 'last-directory-sync', $now);
 
-		Logger::info('Synchronization ended', ['now' => $now, 'count' => $result['count'], 'added' => $result['added'], 'updated' => $result['updated'], 'directory' => $directory]);
+		Logger::info('Synchronization ended', ['now' => $now, 'count' => $result['count'], 'added' => $result['added'], 'updated' => $result['updated'], 'unchanged' => $result['unchanged'], 'directory' => $directory]);
 	}
 }

--- a/src/Worker/UpdateServerDirectory.php
+++ b/src/Worker/UpdateServerDirectory.php
@@ -73,7 +73,7 @@ class UpdateServerDirectory
 
 		$result = Contact::addByUrls($urls);
 
-		Logger::info('PoCo discovery ended', ['count' => $result['count'], 'added' => $result['added'], 'updated' => $result['updated'], 'poco' => $gserver['poco']]);
+		Logger::info('PoCo discovery ended', ['count' => $result['count'], 'added' => $result['added'], 'updated' => $result['updated'], 'unchanged' => $result['unchanged'], 'poco' => $gserver['poco']]);
 	}
 
 	private static function discoverMastodonDirectory(array $gserver)
@@ -101,6 +101,6 @@ class UpdateServerDirectory
 
 		$result = Contact::addByUrls($urls);
 
-		Logger::info('Account discovery ended', ['count' => $result['count'], 'added' => $result['added'], 'updated' => $result['updated'], 'url' => $gserver['url']]);
+		Logger::info('Account discovery ended', ['count' => $result['count'], 'added' => $result['added'], 'updated' => $result['updated'], 'unchanged' => $result['unchanged'], 'url' => $gserver['url']]);
 	}
 }


### PR DESCRIPTION
While searching for the reason of increased requests I saw that there had been situations where the same contact had been probed in a short period of a few minutes.

I hopefully have tracked down most the reasons. We had to also check for the creation date to not automatically recheck a just created contact. Also we had some timing problem, so that on newly created contacts the contact had been updated during the process that was updating the contact for the first time.

Also the update mechanism for global contacts has changed. Failed contacts are now only checked every 6 months. Contacts that are engaged in conversations are checked every week (like before) and the rest is checked every month. This should reduce the load on both sides as well.

And last but not least some debugging message had been removed.