### PR TITLE
Update wrong assertion regarding a profile being local user's self in Model\Profile

### DIFF
--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -304,7 +304,7 @@ class Profile
 
 		$profile_is_dfrn = $profile['network'] == Protocol::DFRN;
 		$profile_is_native = in_array($profile['network'], Protocol::NATIVE_SUPPORT);
-		$local_user_is_self = $profile['self'] ?? false;
+		$local_user_is_self = self::getMyURL() && ($profile['url'] == self::getMyURL());
 		$visitor_is_authenticated = (bool)self::getMyURL();
 		$visitor_is_following =
 			in_array($visitor_contact['rel'] ?? 0, [Contact::FOLLOWER, Contact::FRIEND])


### PR DESCRIPTION
- It was hiding follow links for profiles on the same node

Fixes #9315 
Supersedes #9353

Since the `owner-view` view was created, all the rows returned from it have `self = 1` by definition. The vcard selects from this view for local node users and we used to assume in the vcard that if it was set, it meant the profile was the local user.

The condition for `$local_user_is_self` has been updated to reflect this change and the vcard follow link behaves as expected again.