### PR TITLE
Postupdate: Check for existence of the "term" table

### DIFF
--- a/src/Database/PostUpdate.php
+++ b/src/Database/PostUpdate.php
@@ -634,6 +634,11 @@ class PostUpdate
 			return true;
 		}
 
+		if (!DBStructure::existsTable('term')) {
+			DI::config()->set('system', 'post_update_version', 1342);
+			return true;
+		}
+
 		$id = DI::config()->get('system', 'post_update_version_1342_id', 0);
 
 		Logger::info('Start', ['item' => $id]);
@@ -785,6 +790,11 @@ class PostUpdate
 	{
 		// Was the script completed?
 		if (DI::config()->get('system', 'post_update_version') >= 1346) {
+			return true;
+		}
+
+		if (!DBStructure::existsTable('term')) {
+			DI::config()->set('system', 'post_update_version', 1346);
 			return true;
 		}
 


### PR DESCRIPTION
See here: https://forum.friendi.ca/display/c443a55c-105f-7a02-57aa-ec6762643638

The postupdate process had problems on really new systems without the "term" table.