### PR TITLE
Update the "commented" field only on several verbs

### DIFF
--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -1840,6 +1840,7 @@ class Item
 		}
 
 		$body = $item['body'];
+		$verb = $item['verb'];
 
 		// We just remove everything that is content
 		foreach (array_merge(self::CONTENT_FIELDLIST, self::MIXED_CONTENT_FIELDLIST) as $field) {
@@ -1943,7 +1944,7 @@ class Item
 			$update_commented = in_array($item['gravity'], [GRAVITY_PARENT, GRAVITY_COMMENT]);
 		} else {
 			// Update when it isn't a follow or tag verb
-			$update_commented = !in_array($item['verb'], [Activity::FOLLOW, Activity::TAG]);
+			$update_commented = !in_array($verb, [Activity::FOLLOW, Activity::TAG]);
 		}
 
 		if ($update_commented) {

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -1828,8 +1828,6 @@ class Item
 			$notify_type = Delivery::POST;
 		}
 
-		$like_no_comment = DI::config()->get('system', 'like_no_comment');
-
 		DBA::transaction();
 
 		if (!in_array($item['verb'], self::ACTIVITIES)) {
@@ -1940,8 +1938,15 @@ class Item
 		$item['parent'] = $parent_id;
 
 		// update the commented timestamp on the parent
-		// Only update "commented" if it is really a comment
-		if (($item['gravity'] != GRAVITY_ACTIVITY) || !$like_no_comment) {
+		if (DI::config()->get('system', 'like_no_comment')) {
+			// Update when it is a comment
+			$update_commented = in_array($item['gravity'], [GRAVITY_PARENT, GRAVITY_COMMENT]);
+		} else {
+			// Update when it isn't a follow or tag verb
+			$update_commented = !in_array($item['verb'], [Activity::FOLLOW, Activity::TAG]);
+		}
+
+		if ($update_commented) {
 			DBA::update('item', ['commented' => DateTimeFormat::utcNow(), 'changed' => DateTimeFormat::utcNow()], ['id' => $parent_id]);
 		} else {
 			DBA::update('item', ['changed' => DateTimeFormat::utcNow()], ['id' => $parent_id]);


### PR DESCRIPTION
Should fix https://forum.friendi.ca/display/0b6b25a8-155f-5fa1-b469-24d392137485

Posts in "activity" order are sorted after the "commented" field. There are technical activities like the "follow" activity that shouldn't change the "commented" field.