### PR TITLE
Introduce possibility for mapping $_SERVER variables to config-cache values

### DIFF
--- a/src/Core/Config/Cache.php
+++ b/src/Core/Config/Cache.php
@@ -36,6 +36,8 @@ class Cache
 	const SOURCE_DB = 1;
 	/** @var int Indicates that the cache entry is set by a server environment variable - High Priority */
 	const SOURCE_ENV = 3;
+	/** @var int Indicates that the cache entry is fixed and must not be changed */
+	const SOURCE_FIX = 4;
 
 	/** @var int Default value for a config source */
 	const SOURCE_DEFAULT = self::SOURCE_FILE;

--- a/src/Core/Config/JitConfig.php
+++ b/src/Core/Config/JitConfig.php
@@ -70,7 +70,7 @@ class JitConfig extends BaseConfig
 		}
 
 		// load the whole category out of the DB into the cache
-		$this->configCache->load($config, true);
+		$this->configCache->load($config, Cache::SOURCE_DB);
 	}
 
 	/**

--- a/src/Core/Config/PreloadConfig.php
+++ b/src/Core/Config/PreloadConfig.php
@@ -69,7 +69,7 @@ class PreloadConfig extends BaseConfig
 		$this->config_loaded = true;
 
 		// load the whole category out of the DB into the cache
-		$this->configCache->load($config, true);
+		$this->configCache->load($config, Cache::SOURCE_DB);
 	}
 
 	/**

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -21,10 +21,8 @@
 
 namespace Friendica\Database;
 
-use Exception;
 use Friendica\Core\Config\Cache;
 use Friendica\Core\System;
-use Friendica\DI;
 use Friendica\Network\HTTPException\InternalServerErrorException;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Profiler;
@@ -75,36 +73,11 @@ class Database
 		$this->profiler      = $profiler;
 		$this->logger        = $logger;
 
-		$this->readServerVariables($server);
 		$this->connect();
 
 		if ($this->isConnected()) {
 			// Loads DB_UPDATE_VERSION constant
 			DBStructure::definition($configCache->get('system', 'basepath'), false);
-		}
-	}
-
-	private function readServerVariables(array $server)
-	{
-		// Use environment variables for mysql if they are set beforehand
-		if (!empty($server['MYSQL_HOST'])
-		    && (!empty($server['MYSQL_USERNAME']) || !empty($server['MYSQL_USER']))
-		    && $server['MYSQL_PASSWORD'] !== false
-		    && !empty($server['MYSQL_DATABASE']))
-		{
-			$db_host = $server['MYSQL_HOST'];
-			if (!empty($server['MYSQL_PORT'])) {
-				$db_host .= ':' . $server['MYSQL_PORT'];
-			}
-			$this->configCache->set('database', 'hostname', $db_host);
-			unset($db_host);
-			if (!empty($server['MYSQL_USERNAME'])) {
-				$this->configCache->set('database', 'username', $server['MYSQL_USERNAME']);
-			} else {
-				$this->configCache->set('database', 'username', $server['MYSQL_USER']);
-			}
-			$this->configCache->set('database', 'password', (string) $server['MYSQL_PASSWORD']);
-			$this->configCache->set('database', 'database', $server['MYSQL_DATABASE']);
 		}
 	}
 
@@ -124,6 +97,11 @@ class Database
 		if (count($serverdata) > 1) {
 			$port = trim($serverdata[1]);
 		}
+
+		if (!empty(trim($this->configCache->get('database', 'port')))) {
+			$port = trim(trim($this->configCache->get('database', 'port')));
+		}
+
 		$server  = trim($server);
 		$user    = trim($this->configCache->get('database', 'username'));
 		$pass    = trim($this->configCache->get('database', 'password'));
@@ -658,7 +636,7 @@ class Database
 			$errorno = $this->errorno;
 
 			if ($this->testmode) {
-				throw new Exception(DI::l10n()->t('Database error %d "%s" at "%s"', $errorno, $error, $this->replaceParameters($sql, $args)));
+				throw new DatabaseException($error, $errorno, $this->replaceParameters($sql, $args));
 			}
 
 			$this->logger->error('DB Error', [
@@ -761,7 +739,7 @@ class Database
 			$errorno = $this->errorno;
 
 			if ($this->testmode) {
-				throw new Exception(DI::l10n()->t('Database error %d "%s" at "%s"', $errorno, $error, $this->replaceParameters($sql, $params)));
+				throw new DatabaseException($error, $errorno, $this->replaceParameters($sql, $params));
 			}
 
 			$this->logger->error('DB Error', [

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -99,7 +99,7 @@ class Database
 		}
 
 		if (!empty(trim($this->configCache->get('database', 'port')))) {
-			$port = trim(trim($this->configCache->get('database', 'port')));
+			$port = trim($this->configCache->get('database', 'port'));
 		}
 
 		$server  = trim($server);

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -66,7 +66,7 @@ class Database
 	protected $testmode       = false;
 	private $relation       = [];
 
-	public function __construct(Cache $configCache, Profiler $profiler, LoggerInterface $logger, array $server = [])
+	public function __construct(Cache $configCache, Profiler $profiler, LoggerInterface $logger)
 	{
 		// We are storing these values for being able to perform a reconnect
 		$this->configCache   = $configCache;

--- a/src/Database/DatabaseException.php
+++ b/src/Database/DatabaseException.php
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types=1);
+
+namespace Friendica\Database;
+
+use Exception;
+use Throwable;
+
+/**
+ * A database fatal exception, which shouldn't occur
+ */
+class DatabaseException extends Exception
+{
+	protected $query;
+
+	/**
+	 * Construct the exception. Note: The message is NOT binary safe.
+	 *
+	 * @link https://php.net/manual/en/exception.construct.php
+	 *
+	 * @param string    $message  The Database error message.
+	 * @param int       $code     The Database error code.
+	 * @param string    $query    The Database error query.
+	 * @param Throwable $previous [optional] The previous throwable used for the exception chaining.
+	 */
+	public function __construct(string $message, int $code, string $query, Throwable $previous = null)
+	{
+		parent::__construct($message, $code, $previous);
+		$this->query = $query;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function __toString()
+	{
+		return sprintf('Database error %d "%s" at "%s"', $this->message, $this->code, $this->query);
+	}
+}

--- a/src/Factory/ConfigFactory.php
+++ b/src/Factory/ConfigFactory.php
@@ -37,10 +37,10 @@ class ConfigFactory
 	 *
 	 * @throws Exception
 	 */
-	public function createCache(ConfigFileLoader $loader)
+	public function createCache(ConfigFileLoader $loader, array $server = [])
 	{
 		$configCache = new Cache();
-		$loader->setupCache($configCache);
+		$loader->setupCache($configCache, $server);
 
 		return $configCache;
 	}

--- a/src/Util/ConfigFileLoader.php
+++ b/src/Util/ConfigFileLoader.php
@@ -97,11 +97,12 @@ class ConfigFileLoader
 	 * expected local.config.php
 	 *
 	 * @param Cache $config The config cache to load to
+	 * @param array $server The $_SERVER array
 	 * @param bool  $raw    Setup the raw config format
 	 *
 	 * @throws Exception
 	 */
-	public function setupCache(Cache $config, $raw = false)
+	public function setupCache(Cache $config, array $server = [], $raw = false)
 	{
 		// Load static config files first, the order is important
 		$config->load($this->loadStaticConfig('defaults'), Cache::SOURCE_FILE);
@@ -114,10 +115,12 @@ class ConfigFileLoader
 		// Now load every other config you find inside the 'config/' directory
 		$this->loadCoreConfig($config);
 
+		$config->load($this->loadEnvConfig($server), Cache::SOURCE_ENV);
+
 		// In case of install mode, add the found basepath (because there isn't a basepath set yet
 		if (!$raw && empty($config->get('system', 'basepath'))) {
 			// Setting at least the basepath we know
-			$config->set('system', 'basepath', $this->baseDir);
+			$config->set('system', 'basepath', $this->baseDir, Cache::SOURCE_FILE);
 		}
 	}
 
@@ -190,6 +193,38 @@ class ConfigFileLoader
 		} else {
 			return [];
 		}
+	}
+
+	/**
+	 * Tries to load environment specific variables, based on the `env.config.php` mapping table
+	 *
+	 * @param array $server The $_SERVER variable
+	 *
+	 * @return array The config array (empty if no config was found)
+	 *
+	 * @throws Exception if the configuration file isn't readable
+	 */
+	public function loadEnvConfig(array $server)
+	{
+		$filepath = $this->baseDir . DIRECTORY_SEPARATOR .   // /var/www/html/
+					self::STATIC_DIR . DIRECTORY_SEPARATOR . // static/
+					"env.config.php";                        // env.config.php
+
+		if (!file_exists($filepath)) {
+			return [];
+		}
+
+		$envConfig = $this->loadConfigFile($filepath);
+
+		$return = [];
+
+		foreach ($envConfig as $envKey => $configStructure) {
+			if (isset($server[$envKey])) {
+				$return[$configStructure[0]][$configStructure[1]] = $server[$envKey];
+			}
+		}
+
+		return $return;
 	}
 
 	/**

--- a/src/Util/ConfigFileLoader.php
+++ b/src/Util/ConfigFileLoader.php
@@ -104,12 +104,12 @@ class ConfigFileLoader
 	public function setupCache(Cache $config, $raw = false)
 	{
 		// Load static config files first, the order is important
-		$config->load($this->loadStaticConfig('defaults'));
-		$config->load($this->loadStaticConfig('settings'));
+		$config->load($this->loadStaticConfig('defaults'), Cache::SOURCE_FILE);
+		$config->load($this->loadStaticConfig('settings'), Cache::SOURCE_FILE);
 
 		// try to load the legacy config first
-		$config->load($this->loadLegacyConfig('htpreconfig'), true);
-		$config->load($this->loadLegacyConfig('htconfig'), true);
+		$config->load($this->loadLegacyConfig('htpreconfig'), Cache::SOURCE_FILE);
+		$config->load($this->loadLegacyConfig('htconfig'), Cache::SOURCE_FILE);
 
 		// Now load every other config you find inside the 'config/' directory
 		$this->loadCoreConfig($config);
@@ -157,12 +157,12 @@ class ConfigFileLoader
 	{
 		// try to load legacy ini-files first
 		foreach ($this->getConfigFiles(true) as $configFile) {
-			$config->load($this->loadINIConfigFile($configFile), true);
+			$config->load($this->loadINIConfigFile($configFile), Cache::SOURCE_FILE);
 		}
 
 		// try to load supported config at last to overwrite it
 		foreach ($this->getConfigFiles() as $configFile) {
-			$config->load($this->loadConfigFile($configFile), true);
+			$config->load($this->loadConfigFile($configFile), Cache::SOURCE_FILE);
 		}
 
 		return [];

--- a/static/defaults.config.php
+++ b/static/defaults.config.php
@@ -32,6 +32,11 @@ return [
 		// Can contain the port number with the syntax "hostname:port".
 		'hostname' => '',
 
+		// port (Integer)
+		// Port of the database server.
+		// Can be used instead of adding a port number to the hostname
+		'port' => null,
+
 		// user (String)
 		// Database user name. Please don't use "root".
 		'username' => '',

--- a/static/dependencies.config.php
+++ b/static/dependencies.config.php
@@ -75,13 +75,13 @@ return [
 	Util\ConfigFileLoader::class => [
 		'shared'          => true,
 		'constructParams' => [
-			[Dice::INSTANCE => '$basepath'],
+			[Dice::INSTANCE => '$basepath']
 		],
 	],
 	Config\Cache::class          => [
 		'instanceOf' => Factory\ConfigFactory::class,
 		'call'       => [
-			['createCache', [], Dice::CHAIN_CALL],
+			['createCache', [$_SERVER], Dice::CHAIN_CALL],
 		],
 	],
 	App\Mode::class              => [
@@ -105,7 +105,6 @@ return [
 	Database::class                         => [
 		'constructParams' => [
 			[Dice::INSTANCE => \Psr\Log\NullLogger::class],
-			$_SERVER,
 		],
 	],
 	/**

--- a/static/dependencies.config.php
+++ b/static/dependencies.config.php
@@ -75,7 +75,7 @@ return [
 	Util\ConfigFileLoader::class => [
 		'shared'          => true,
 		'constructParams' => [
-			[Dice::INSTANCE => '$basepath']
+			[Dice::INSTANCE => '$basepath'],
 		],
 	],
 	Config\Cache::class          => [

--- a/static/env.config.php
+++ b/static/env.config.php
@@ -17,7 +17,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * Main mapping table of environment variables to correct config values
+ * Main mapping table of environment variables to namespaced config values
  *
  */
 

--- a/static/env.config.php
+++ b/static/env.config.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Main mapping table of environment variables to correct config values
+ *
+ */
+
+return [
+	'MYSQL_HOST' => ['database', 'hostname'],
+	'MYSQL_USERNAME' => ['database', 'username'],
+	'MYSQL_USER' => ['database', 'username'],
+	'MYSQL_PORT' => ['database', 'port'],
+	'MYSQL_PASSWORD' => ['database', 'password'],
+	'MYSQL_DATABASE' => ['database', 'database'],
+];

--- a/tests/src/Core/Config/CacheTest.php
+++ b/tests/src/Core/Config/CacheTest.php
@@ -83,13 +83,14 @@ class CacheTest extends MockedTest
 		];
 
 		$configCache = new Cache();
-		$configCache->load($data);
-		$configCache->load($override);
+		$configCache->load($data, Cache::SOURCE_DB);
+		// doesn't override - Low Priority due Config file
+		$configCache->load($override, Cache::SOURCE_FILE);
 
 		$this->assertConfigValues($data, $configCache);
 
-		// override the value
-		$configCache->load($override, true);
+		// override the value - High Prio due Server Env
+		$configCache->load($override, Cache::SOURCE_ENV);
 
 		$this->assertEquals($override['system']['test'], $configCache->get('system', 'test'));
 		$this->assertEquals($override['system']['boolTrue'], $configCache->get('system', 'boolTrue'));

--- a/tests/src/Core/Config/CacheTest.php
+++ b/tests/src/Core/Config/CacheTest.php
@@ -94,6 +94,19 @@ class CacheTest extends MockedTest
 
 		$this->assertEquals($override['system']['test'], $configCache->get('system', 'test'));
 		$this->assertEquals($override['system']['boolTrue'], $configCache->get('system', 'boolTrue'));
+
+		// Don't overwrite server ENV variables - even in load mode
+		$configCache->load($data, Cache::SOURCE_DB);
+
+		$this->assertEquals($override['system']['test'], $configCache->get('system', 'test'));
+		$this->assertEquals($override['system']['boolTrue'], $configCache->get('system', 'boolTrue'));
+
+		// Overwrite ENV variables with ENV variables
+		$configCache->load($data, Cache::SOURCE_ENV);
+
+		$this->assertConfigValues($data, $configCache);
+		$this->assertNotEquals($override['system']['test'], $configCache->get('system', 'test'));
+		$this->assertNotEquals($override['system']['boolTrue'], $configCache->get('system', 'boolTrue'));
 	}
 
 	/**

--- a/tests/src/Core/Config/ConfigTest.php
+++ b/tests/src/Core/Config/ConfigTest.php
@@ -350,7 +350,7 @@ abstract class ConfigTest extends MockedTest
 	 */
 	public function testGetWithRefresh($data)
 	{
-		$this->configCache->load(['test' => ['it' => 'now']]);
+		$this->configCache->load(['test' => ['it' => 'now']], Cache::SOURCE_FILE);
 
 		$this->testedConfig = $this->getInstance();
 		$this->assertInstanceOf(Cache::class, $this->testedConfig->getCache());
@@ -375,7 +375,7 @@ abstract class ConfigTest extends MockedTest
 	 */
 	public function testDeleteWithoutDB($data)
 	{
-		$this->configCache->load(['test' => ['it' => $data]]);
+		$this->configCache->load(['test' => ['it' => $data]], Cache::SOURCE_FILE);
 
 		$this->testedConfig = $this->getInstance();
 		$this->assertInstanceOf(Cache::class, $this->testedConfig->getCache());
@@ -395,7 +395,7 @@ abstract class ConfigTest extends MockedTest
 	 */
 	public function testDeleteWithDB()
 	{
-		$this->configCache->load(['test' => ['it' => 'now', 'quarter' => 'true']]);
+		$this->configCache->load(['test' => ['it' => 'now', 'quarter' => 'true']], Cache::SOURCE_FILE);
 
 		$this->configModel->shouldReceive('delete')
 		                  ->with('test', 'it')


### PR DESCRIPTION
This PR introduces the possibility to have three different sources of config entries:
- A config file
- A db entry
- A $_SERVER env variable

Due the problem that db values may override env variables again (like when manually using `$config->load()`), I prioritize the sources
Low prio - config file
Middle prio - db entry
High prio - $_SERVER var

So in the end, even the config tries to load db variables again, the $_SERVER variable based config entries remain.

There's a new mapping table to map $_SERVER env variables onto the config:
`static/env.config.php`

After this PR, I think I do want to add some of the docker specific env variables into this config and add a "doc" in this repo for it. So other deployment types (or other container/virtualization possibilities) can reuse the $_SERVER config variables.

[edit] it currently works on my friendica.philipp.info node