### PR TITLE
[frio] Darken unseen notification text on accent dark scheme

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -591,6 +591,9 @@ nav.navbar .nav > li > button:focus
     border-left: 3px solid #e3eff3;
     background-color: #e3eff3;
 }
+#topbar-first #nav-notifications-menu li.notification-unseen a {
+    color: $nav_icon_color;
+}
 #topbar-first #nav-notifications-menu li.notif-entry:hover {
     background-color: #f7f7f7;
     border-left: 3px solid $link_color;
@@ -603,6 +606,9 @@ nav.navbar .nav > li > button:focus
 }
 #topbar-first #nav-notifications-menu .media .media-body .label {
     padding: .1em .5em
+}
+#topbar-first #nav-notifications-menu li.notification-unseen .media .time {
+    color: $nav_icon_color;
 }
 #topbar-first #nav-notifications-menu li.notif-entry .media-object a img {
     height: 32px;

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -592,7 +592,7 @@ nav.navbar .nav > li > button:focus
     background-color: #e3eff3;
 }
 #topbar-first #nav-notifications-menu li.notification-unseen a {
-    color: $nav_icon_color;
+    color: $nav_icon_hover_color;
 }
 #topbar-first #nav-notifications-menu li.notif-entry:hover {
     background-color: #f7f7f7;
@@ -608,7 +608,7 @@ nav.navbar .nav > li > button:focus
     padding: .1em .5em
 }
 #topbar-first #nav-notifications-menu li.notification-unseen .media .time {
-    color: $nav_icon_color;
+    color: $nav_icon_hover_color;
 }
 #topbar-first #nav-notifications-menu li.notif-entry .media-object a img {
     height: 32px;


### PR DESCRIPTION
To darken unseen notifications text on Frio (accent dark) I added new class definitions. These overwrite colors with already existing ones from the topbar:

Default:

![image](https://user-images.githubusercontent.com/74432/95248235-4af87900-0817-11eb-81f3-5187005bb208.png)

Hover:

![image](https://user-images.githubusercontent.com/74432/95248294-619ed000-0817-11eb-87cf-8ba050a3eaa8.png)

Mobile:

![image](https://user-images.githubusercontent.com/74432/95248693-f6a1c900-0817-11eb-8070-2f16b310e318.png)

This should fix #9236 