### PR TITLE
[frio] More accessible contact request buttons in mobile

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -702,6 +702,17 @@ nav.navbar .nav > li > button:focus
     max-height: 400px;
     overflow: auto
 }
+.intro-actions {
+	font-size: 2em;
+	padding: 1em;
+}
+.intro-wrapper button.intro-action-link {
+	padding-left: 10px;
+	padding-right: 10px;
+}
+ul li .intro-wrapper button.intro-action-link {
+	opacity:0.7;
+}
 @media screen and (max-width: 768px) {
     #topbar-second #space-menu-dropdown .media-list,
     #topbar-second #search-menu-dropdown .media-list {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/74432/95259573-a7fc2b00-0827-11eb-89b1-ad1b80c63e32.png)

- scaled up the icons
- removed the dysfunctional hover effect
- added more padding inbetween the icons

Fixes #8533 