### PR TITLE
Fix refresh after comment/like for other themes like Frio

### DIFF
--- a/mod/update_contact.php
+++ b/mod/update_contact.php
@@ -24,12 +24,19 @@
 use Friendica\App;
 use Friendica\Core\System;
 use Friendica\DI;
+use Friendica\Model\Item;
 use Friendica\Module\Contact;
 
 function update_contact_content(App $a)
 {
 	if (!empty($a->argv[1]) && (!empty($_GET['force']) || !DI::pConfig()->get(local_user(), 'system', 'no_auto_update'))) {
-		$text = Contact::getConversationsHMTL($a, $a->argv[1], true, ($_GET['item'] ?? 0));
+		if (!empty($_GET['item'])) {
+			$item = Item::selectFirst(['parent'], ['id' => $_GET['item']]);
+			$parentid = $item['parent'] ?? 0;
+		} else {
+			$parentid = 0;
+		}
+		$text = Contact::getConversationsHMTL($a, $a->argv[1], true, $parentid);
 	} else {
 		$text = '';
 	}

--- a/mod/update_network.php
+++ b/mod/update_network.php
@@ -23,6 +23,7 @@
 use Friendica\App;
 use Friendica\Core\System;
 use Friendica\DI;
+use Friendica\Model\Item;
 
 require_once "mod/network.php";
 
@@ -33,10 +34,15 @@ function update_network_content(App $a)
 	}
 
 	$profile_uid = intval($_GET['p']);
-	$parent = intval($_GET['item']);
 
 	if (!DI::pConfig()->get($profile_uid, "system", "no_auto_update") || ($_GET["force"] == 1)) {
-		$text = network_content($a, $profile_uid, $parent);
+		if (!empty($_GET['item'])) {
+			$item = Item::selectFirst(['parent'], ['id' => $_GET['item']]);
+			$parentid = $item['parent'] ?? 0;
+		} else {
+			$parentid = 0;
+		}
+		$text = network_content($a, $profile_uid, $parentid);
 	} else {
 		$text = "";
 	}

--- a/src/Module/Conversation/Community.php
+++ b/src/Module/Conversation/Community.php
@@ -256,10 +256,16 @@ class Community extends BaseModule
 			self::$itemsPerPage = DI::app()->force_max_items;
 		}
 
+		if (!empty($_GET['item'])) {
+			$item = Item::selectFirst(['parent'], ['id' => $_GET['item']]);
+			self::$item_id = $item['parent'] ?? 0;
+		} else {
+			self::$item_id = 0;
+		}
+
 		self::$since_id = $_GET['since_id'] ?? null;
 		self::$max_id   = $_GET['max_id']   ?? null;
 		self::$max_id   = $_GET['last_commented'] ?? self::$max_id;
-		self::$item_id  = $_GET['item'] ?? null;
 	}
 
 	/**
@@ -344,7 +350,7 @@ class Community extends BaseModule
 			return [];
 		}
 
-		if (isset($item_id)) {
+		if (!empty($item_id)) {
 			$condition[0] .= " AND `iid` = ?";
 			$condition[] = $item_id;
 		} else {


### PR DESCRIPTION
I realized that on different themes like Frio the provided item id for the update process hadn't always been the parent. This means that on other themes the automated refresh hadn't worked for nested comments/likes.