### PR TITLE
[frio] Divert unseen notification background colors into schemes

### DIFF
--- a/view/theme/frio/scheme/black.css
+++ b/view/theme/frio/scheme/black.css
@@ -17,6 +17,9 @@
 	background-color: $nav_bg;
 }
 
+#topbar-first #nav-notifications-menu li.notification-unseen {
+        background-color: $nav_icon_hover_color;
+}
 
 #topbar-second {
 	background-color: $nav_bg;

--- a/view/theme/frio/scheme/dark.css
+++ b/view/theme/frio/scheme/dark.css
@@ -17,6 +17,9 @@
 	background-color: $nav_bg;
 }
 
+#topbar-first #nav-notifications-menu li.notification-unseen {
+        background-color: $nav_icon_hover_color;
+}
 
 #topbar-second {
 	background-color: $nav_bg;


### PR DESCRIPTION
To avoid side effects for other themes the background colors are set in schemes now.

Dark:

![image](https://user-images.githubusercontent.com/74432/95379214-5f0aac00-08e5-11eb-8529-9c437816599c.png)

Black:

![image](https://user-images.githubusercontent.com/74432/95379236-67fb7d80-08e5-11eb-97ac-388d51b13418.png)

Fixing #9236 