### PR TITLE
Don't show failed contacts

### DIFF
--- a/src/Content/Widget/ContactBlock.php
+++ b/src/Content/Widget/ContactBlock.php
@@ -66,6 +66,7 @@ class ContactBlock
 			'pending' => false,
 			'hidden' => false,
 			'archive' => false,
+			'failed' => false,
 			'network' => [Protocol::DFRN, Protocol::ACTIVITYPUB, Protocol::OSTATUS, Protocol::DIASPORA, Protocol::FEED],
 		]);
 

--- a/src/Model/Contact/Group.php
+++ b/src/Model/Contact/Group.php
@@ -82,6 +82,7 @@ class Group
 			   AND NOT `deleted`
 			   AND NOT `blocked`
 			   AND NOT `pending`
+			   AND NOT `failed`
 			   AND `id` NOT IN (
 			   	SELECT DISTINCT(`contact-id`)
 			   	FROM `group_member`

--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -406,6 +406,7 @@ class Profile
 					'pending' => false,
 					'hidden' => false,
 					'archive' => false,
+					'failed' => false,
 					'network' => Protocol::FEDERATED,
 				]);
 			}

--- a/src/Module/Contact.php
+++ b/src/Module/Contact.php
@@ -652,15 +652,15 @@ class Contact extends BaseModule
 				array_unshift($sql_values, 0);
 				break;
 			case 'archived':
-				$sql_extra = " AND `archive` AND NOT `blocked` AND NOT `pending`";
+				$sql_extra = " AND (`archive` OR `failed`) AND NOT `blocked` AND NOT `pending`";
 				break;
 			case 'pending':
-				$sql_extra = " AND `pending` AND NOT `archive` AND ((`rel` = ?)
+				$sql_extra = " AND `pending` AND NOT `archive` AND NOT `failed` AND ((`rel` = ?)
 					OR EXISTS (SELECT `id` FROM `intro` WHERE `contact-id` = `contact`.`id` AND NOT `ignore`))";
 				$sql_values[] = Model\Contact::SHARING;
 				break;
 			default:
-				$sql_extra = " AND NOT `archive` AND NOT `blocked` AND NOT `pending`";
+				$sql_extra = " AND NOT `archive` AND NOT `blocked` AND NOT `pending` AND NOT `failed`";
 				break;
 		}
 

--- a/src/Module/Contact/Contacts.php
+++ b/src/Module/Contact/Contacts.php
@@ -41,6 +41,7 @@ class Contacts extends BaseModule
 			'blocked' => false,
 			'self' => false,
 			'hidden' => false,
+			'failed' => false,
 		];
 
 		$noresult_label = DI::l10n()->t('No known contacts.');

--- a/src/Module/Group.php
+++ b/src/Module/Group.php
@@ -319,7 +319,7 @@ class Group extends BaseModule
 			$contacts = Model\Contact\Group::listUngrouped(local_user());
 		} else {
 			$contacts_stmt = DBA::select('contact', [],
-				['uid' => local_user(), 'pending' => false, 'blocked' => false, 'self' => false],
+				['uid' => local_user(), 'pending' => false, 'blocked' => false, 'failed' => false, 'self' => false],
 				['order' => ['name']]
 			);
 			$contacts = DBA::toArray($contacts_stmt);

--- a/src/Module/Profile/Contacts.php
+++ b/src/Module/Profile/Contacts.php
@@ -69,6 +69,7 @@ class Contacts extends Module\BaseProfile
 			'pending' => false,
 			'hidden'  => false,
 			'archive' => false,
+			'failed'  => false,
 			'self'    => false,
 			'network' => [Protocol::ACTIVITYPUB, Protocol::DFRN, Protocol::DIASPORA, Protocol::OSTATUS, Protocol::FEED]
 		];


### PR DESCRIPTION
Contacts marked as "failed" are contacts that failed the last probing. We shouldn't display them.