### PR TITLE
Move the menu down hard

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -631,6 +631,9 @@ nav.navbar .nav > li > button:focus
 #myNavmenu li.nav-sitename {
     font-weight: bold;
 }
+#myNavmenu {
+    top: 50px;
+}
 #topbar-first .dropdown.account li#nav-sitename {
     padding-left: 15px;
     padding-right: 15px;


### PR DESCRIPTION
In mobile Frio view move the right off-canvas menu down hard to not cover the hamburger menu button.
Fixes #8485 