### PR TITLE
intensify notification bubble color

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -479,7 +479,7 @@ nav.navbar .nav > li > button:focus
     position: absolute;
     top: 4px;
     right: -2px;
-    background-color: #ff8989;
+    background-color: #ff3535;
 }
 #topbar-first #intro-update{
     cursor: pointer;


### PR DESCRIPTION
This commit makes the red color slightly more intense and give the bubbly more contrast.

Dark:

![image](https://user-images.githubusercontent.com/74432/95501341-6e9ef900-09a8-11eb-922d-5be2272a1064.png)

Black:

![image](https://user-images.githubusercontent.com/74432/95501365-79f22480-09a8-11eb-94de-6e82c03895fc.png)

Light:

![image](https://user-images.githubusercontent.com/74432/95501386-837b8c80-09a8-11eb-8741-d9d16d36fe6f.png)

On Traditional Red it's well distinguishable:

![image](https://user-images.githubusercontent.com/74432/95505524-c0e31880-09ae-11eb-8e4b-7632479ff58f.png)

Fixes #9238  
