### PR TITLE
Remove $binary flag for HTTPRequest

### DIFF
--- a/mod/parse_url.php
+++ b/mod/parse_url.php
@@ -85,7 +85,7 @@ function parse_url_content(App $a)
 	// Check if the URL is an image, video or audio file. If so format
 	// the URL with the corresponding BBCode media tag
 	// Fetch the header of the URL
-	$curlResponse = DI::httpRequest()->get($url, false, ['novalidate' => true, 'nobody' => true]);
+	$curlResponse = DI::httpRequest()->get($url, ['novalidate' => true, 'nobody' => true]);
 
 	if ($curlResponse->isSuccess()) {
 		// Convert the header fields into an array

--- a/src/Content/OEmbed.php
+++ b/src/Content/OEmbed.php
@@ -95,7 +95,7 @@ class OEmbed
 
 			if (!in_array($ext, $noexts)) {
 				// try oembed autodiscovery
-				$html_text = DI::httpRequest()->fetch($embedurl, false, 15, 'text/*');
+				$html_text = DI::httpRequest()->fetch($embedurl, 15, 'text/*');
 				if ($html_text) {
 					$dom = @DOMDocument::loadHTML($html_text);
 					if ($dom) {

--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -485,7 +485,7 @@ class BBCode
 					continue;
 				}
 
-				$curlResult = DI::httpRequest()->get($mtch[1], true);
+				$curlResult = DI::httpRequest()->get($mtch[1]);
 				if (!$curlResult->isSuccess()) {
 					continue;
 				}

--- a/src/Core/Search.php
+++ b/src/Core/Search.php
@@ -122,7 +122,7 @@ class Search
 			$searchUrl .= '&page=' . $page;
 		}
 
-		$resultJson = DI::httpRequest()->fetch($searchUrl, false, 0, 'application/json');
+		$resultJson = DI::httpRequest()->fetch($searchUrl, 0, 'application/json');
 
 		$results = json_decode($resultJson, true);
 
@@ -264,7 +264,7 @@ class Search
 			$return = Contact::searchByName($search, $mode);
 		} else {
 			$p = $page > 1 ? 'p=' . $page : '';
-			$curlResult = DI::httpRequest()->get(self::getGlobalDirectory() . '/search/people?' . $p . '&q=' . urlencode($search), false, ['accept_content' => 'application/json']);
+			$curlResult = DI::httpRequest()->get(self::getGlobalDirectory() . '/search/people?' . $p . '&q=' . urlencode($search), ['accept_content' => 'application/json']);
 			if ($curlResult->isSuccess()) {
 				$searchResult = json_decode($curlResult->getBody(), true);
 				if (!empty($searchResult['profiles'])) {

--- a/src/Core/Worker.php
+++ b/src/Core/Worker.php
@@ -1064,7 +1064,7 @@ class Worker
 		}
 
 		$url = DI::baseUrl() . '/worker';
-		DI::httpRequest()->fetch($url, false, 1);
+		DI::httpRequest()->fetch($url, 1);
 	}
 
 	/**

--- a/src/Model/GServer.php
+++ b/src/Model/GServer.php
@@ -311,7 +311,7 @@ class GServer
 
 		// When a nodeinfo is present, we don't need to dig further
 		$xrd_timeout = DI::config()->get('system', 'xrd_timeout');
-		$curlResult = DI::httpRequest()->get($url . '/.well-known/nodeinfo', false, ['timeout' => $xrd_timeout]);
+		$curlResult = DI::httpRequest()->get($url . '/.well-known/nodeinfo', ['timeout' => $xrd_timeout]);
 		if ($curlResult->isTimeout()) {
 			self::setFailure($url);
 			return false;
@@ -344,7 +344,7 @@ class GServer
 					$basedata = ['detection-method' => self::DETECT_MANUAL];
 				}
 
-				$curlResult = DI::httpRequest()->get($baseurl, false, ['timeout' => $xrd_timeout]);
+				$curlResult = DI::httpRequest()->get($baseurl, ['timeout' => $xrd_timeout]);
 				if ($curlResult->isSuccess()) {
 					$basedata = self::analyseRootHeader($curlResult, $basedata);
 					$basedata = self::analyseRootBody($curlResult, $basedata, $baseurl);
@@ -361,7 +361,7 @@ class GServer
 					// When the base path doesn't seem to contain a social network we try the complete path.
 					// Most detectable system have to be installed in the root directory.
 					// We checked the base to avoid false positives.
-					$curlResult = DI::httpRequest()->get($url, false, ['timeout' => $xrd_timeout]);
+					$curlResult = DI::httpRequest()->get($url, ['timeout' => $xrd_timeout]);
 					if ($curlResult->isSuccess()) {
 						$urldata = self::analyseRootHeader($curlResult, $serverdata);
 						$urldata = self::analyseRootBody($curlResult, $urldata, $url);
@@ -913,7 +913,7 @@ class GServer
 	private static function validHostMeta(string $url)
 	{
 		$xrd_timeout = DI::config()->get('system', 'xrd_timeout');
-		$curlResult = DI::httpRequest()->get($url . '/.well-known/host-meta', false, ['timeout' => $xrd_timeout]);
+		$curlResult = DI::httpRequest()->get($url . '/.well-known/host-meta', ['timeout' => $xrd_timeout]);
 		if (!$curlResult->isSuccess()) {
 			return false;
 		}
@@ -1639,7 +1639,7 @@ class GServer
 		if (!empty($accesstoken)) {
 			$api = 'https://instances.social/api/1.0/instances/list?count=0';
 			$header = ['Authorization: Bearer '.$accesstoken];
-			$curlResult = DI::httpRequest()->get($api, false, ['headers' => $header]);
+			$curlResult = DI::httpRequest()->get($api, ['headers' => $header]);
 
 			if ($curlResult->isSuccess()) {
 				$servers = json_decode($curlResult->getBody(), true);

--- a/src/Model/Photo.php
+++ b/src/Model/Photo.php
@@ -422,7 +422,7 @@ class Photo
 
 		$filename = basename($image_url);
 		if (!empty($image_url)) {
-			$ret = DI::httpRequest()->get($image_url, true);
+			$ret = DI::httpRequest()->get($image_url);
 			$img_str = $ret->getBody();
 			$type = $ret->getContentType();
 		} else {

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -1002,7 +1002,7 @@ class User
 			$photo_failure = false;
 
 			$filename = basename($photo);
-			$curlResult = DI::httpRequest()->get($photo, true);
+			$curlResult = DI::httpRequest()->get($photo);
 			if ($curlResult->isSuccess()) {
 				$img_str = $curlResult->getBody();
 				$type = $curlResult->getContentType();

--- a/src/Module/Magic.php
+++ b/src/Module/Magic.php
@@ -100,7 +100,7 @@ class Magic extends BaseModule
 				);
 
 				// Try to get an authentication token from the other instance.
-				$curlResult = DI::httpRequest()->get($basepath . '/owa', false, ['headers' => $headers]);
+				$curlResult = DI::httpRequest()->get($basepath . '/owa', ['headers' => $headers]);
 
 				if ($curlResult->isSuccess()) {
 					$j = json_decode($curlResult->getBody(), true);

--- a/src/Network/IHTTPRequest.php
+++ b/src/Network/IHTTPRequest.php
@@ -34,7 +34,6 @@ interface IHTTPRequest
 	 * to preserve cookies from one request to the next.
 	 *
 	 * @param string $url             URL to fetch
-	 * @param bool   $binary          default false
 	 *                                TRUE if asked to return binary results (file download)
 	 * @param int    $timeout         Timeout in seconds, default system config value or 60 seconds
 	 * @param string $accept_content  supply Accept: header with 'accept_content' as the value
@@ -42,7 +41,7 @@ interface IHTTPRequest
 	 *
 	 * @return string The fetched content
 	 */
-	public function fetch(string $url, bool $binary = false, int $timeout = 0, string $accept_content = '', string $cookiejar = '');
+	public function fetch(string $url, int $timeout = 0, string $accept_content = '', string $cookiejar = '');
 
 	/**
 	 * Fetches the whole response of an URL.
@@ -51,7 +50,6 @@ interface IHTTPRequest
 	 * all the information collected during the fetch.
 	 *
 	 * @param string $url             URL to fetch
-	 * @param bool   $binary          default false
 	 *                                TRUE if asked to return binary results (file download)
 	 * @param int    $timeout         Timeout in seconds, default system config value or 60 seconds
 	 * @param string $accept_content  supply Accept: header with 'accept_content' as the value
@@ -59,13 +57,12 @@ interface IHTTPRequest
 	 *
 	 * @return CurlResult With all relevant information, 'body' contains the actual fetched content.
 	 */
-	public function fetchFull(string $url, bool $binary = false, int $timeout = 0, string $accept_content = '', string $cookiejar = '');
+	public function fetchFull(string $url, int $timeout = 0, string $accept_content = '', string $cookiejar = '');
 
 	/**
 	 * Send a GET to an URL.
 	 *
 	 * @param string $url        URL to fetch
-	 * @param bool   $binary     default false
 	 *                           TRUE if asked to return binary results (file download)
 	 * @param array  $opts       (optional parameters) assoziative array with:
 	 *                           'accept_content' => supply Accept: header with 'accept_content' as the value
@@ -78,7 +75,7 @@ interface IHTTPRequest
 	 *
 	 * @return CurlResult
 	 */
-	public function get(string $url, bool $binary = false, array $opts = []);
+	public function get(string $url, array $opts = []);
 
 	/**
 	 * Send POST request to an URL

--- a/src/Network/Probe.php
+++ b/src/Network/Probe.php
@@ -169,7 +169,7 @@ class Probe
 		Logger::info('Probing', ['host' => $host, 'ssl_url' => $ssl_url, 'url' => $url, 'callstack' => System::callstack(20)]);
 		$xrd = null;
 
-		$curlResult = DI::httpRequest()->get($ssl_url, false, ['timeout' => $xrd_timeout, 'accept_content' => 'application/xrd+xml']);
+		$curlResult = DI::httpRequest()->get($ssl_url, ['timeout' => $xrd_timeout, 'accept_content' => 'application/xrd+xml']);
 		$ssl_connection_error = ($curlResult->getErrorNumber() == CURLE_COULDNT_CONNECT) || ($curlResult->getReturnCode() == 0);
 		if ($curlResult->isSuccess()) {
 			$xml = $curlResult->getBody();
@@ -186,7 +186,7 @@ class Probe
 		}
 
 		if (!is_object($xrd) && !empty($url)) {
-			$curlResult = DI::httpRequest()->get($url, false, ['timeout' => $xrd_timeout, 'accept_content' => 'application/xrd+xml']);
+			$curlResult = DI::httpRequest()->get($url, ['timeout' => $xrd_timeout, 'accept_content' => 'application/xrd+xml']);
 			$connection_error = ($curlResult->getErrorNumber() == CURLE_COULDNT_CONNECT) || ($curlResult->getReturnCode() == 0);
 			if ($curlResult->isTimeout()) {
 				Logger::info('Probing timeout', ['url' => $url]);
@@ -941,7 +941,7 @@ class Probe
 	{
 		$xrd_timeout = DI::config()->get('system', 'xrd_timeout', 20);
 
-		$curlResult = DI::httpRequest()->get($url, false, ['timeout' => $xrd_timeout, 'accept_content' => $type]);
+		$curlResult = DI::httpRequest()->get($url, ['timeout' => $xrd_timeout, 'accept_content' => $type]);
 		if ($curlResult->isTimeout()) {
 			self::$istimeout = true;
 			return [];

--- a/src/Protocol/OStatus.php
+++ b/src/Protocol/OStatus.php
@@ -738,7 +738,7 @@ class OStatus
 
 		self::$conv_list[$conversation] = true;
 
-		$curlResult = DI::httpRequest()->get($conversation, false, ['accept_content' => 'application/atom+xml, text/html']);
+		$curlResult = DI::httpRequest()->get($conversation, ['accept_content' => 'application/atom+xml, text/html']);
 
 		if (!$curlResult->isSuccess()) {
 			return;
@@ -931,7 +931,7 @@ class OStatus
 		}
 
 		$stored = false;
-		$curlResult = DI::httpRequest()->get($related, false, ['accept_content' => 'application/atom+xml, text/html']);
+		$curlResult = DI::httpRequest()->get($related, ['accept_content' => 'application/atom+xml, text/html']);
 
 		if (!$curlResult->isSuccess()) {
 			return;

--- a/src/Util/HTTPSignature.php
+++ b/src/Util/HTTPSignature.php
@@ -449,7 +449,7 @@ class HTTPSignature
 		$curl_opts = $opts;
 		$curl_opts['header'] = $headers;
 
-		$curlResult = DI::httpRequest()->get($request, false, $curl_opts);
+		$curlResult = DI::httpRequest()->get($request, $curl_opts);
 		$return_code = $curlResult->getReturnCode();
 
 		Logger::log('Fetched for user ' . $uid . ' from ' . $request . ' returned ' . $return_code, Logger::DEBUG);

--- a/src/Util/Images.php
+++ b/src/Util/Images.php
@@ -184,7 +184,7 @@ class Images
 			return $data;
 		}
 
-		$img_str = DI::httpRequest()->fetch($url, true, 4);
+		$img_str = DI::httpRequest()->fetch($url, 4);
 
 		if (!$img_str) {
 			return [];

--- a/src/Worker/OnePoll.php
+++ b/src/Worker/OnePoll.php
@@ -444,7 +444,7 @@ class OnePoll
 		}
 
 		$cookiejar = tempnam(get_temppath(), 'cookiejar-onepoll-');
-		$curlResult = DI::httpRequest()->get($contact['poll'], false, ['cookiejar' => $cookiejar]);
+		$curlResult = DI::httpRequest()->get($contact['poll'], ['cookiejar' => $cookiejar]);
 		unlink($cookiejar);
 
 		if ($curlResult->isTimeout()) {


### PR DESCRIPTION
Removed the `$binary` flag for
- `IHTTPRequest::get()`
- `IHTTPRequest::fetch()`
- `IHTTPRequest::fetchAll()`

It's a little bit of cleanup because of PSR-7 (see #9400 )

Reason (https://www.php.net/manual/en/function.curl-setopt.php - `CURLOPT_BINARYTRANSFER`)
> From PHP 5.1.3, this option has no effect: the raw output will always be returned when CURLOPT_RETURNTRANSFER is used.

And we're using `CURLOPT_RETURNTRANSFER` for every get call:
https://github.com/friendica/friendica/blob/6f175177f2bb7dd1b301d8bf3fe4ba6c42f81960/src/Network/HTTPRequest.php#L118

ToDo:
- [ ] Testing the branch on https://friendica.philipp.info for 24hours

Needs https://github.com/friendica/friendica-addons/pull/1032 as well