### PR TITLE
Support for real reshares

### DIFF
--- a/include/conversation.php
+++ b/include/conversation.php
@@ -562,9 +562,10 @@ function conversation(App $a, array $items, $mode, $update, $preview = false, $o
 				];
 
 				$likebuttons = [
-					'like'    => null,
-					'dislike' => null,
-					'share'   => null,
+					'like'     => null,
+					'dislike'  => null,
+					'share'    => null,
+					'announce' => null,
 				];
 
 				if (DI::pConfig()->get(local_user(), 'system', 'hide_dislike')) {

--- a/src/Object/Post.php
+++ b/src/Object/Post.php
@@ -151,9 +151,10 @@ class Post
 		}
 		$sparkle = '';
 		$buttons = [
-			'like'    => null,
-			'dislike' => null,
-			'share'   => null,
+			'like'     => null,
+			'dislike'  => null,
+			'share'    => null,
+			'announce' => null,
 		];
 		$dropping = false;
 		$pinned = '';
@@ -175,6 +176,7 @@ class Post
 			: false);
 
 		$shareable = in_array($conv->getProfileOwner(), [0, local_user()]) && $item['private'] != Item::PRIVATE;
+		$announceable = $shareable && in_array($item['network'], [Protocol::ACTIVITYPUB, Protocol::DFRN]);
 
 		$edpost = false;
 
@@ -344,7 +346,10 @@ class Post
 			$buttons['like']    = [DI::l10n()->t("I like this \x28toggle\x29")      , DI::l10n()->t("like")];
 			$buttons['dislike'] = [DI::l10n()->t("I don't like this \x28toggle\x29"), DI::l10n()->t("dislike")];
 			if ($shareable) {
-				$buttons['share'] = [DI::l10n()->t('Share this'), DI::l10n()->t('share')];
+				$buttons['share'] = [DI::l10n()->t('Share this'), DI::l10n()->t('Share')];
+			}
+			if ($announceable) {
+				$buttons['announce'] = [DI::l10n()->t('Announce this'), DI::l10n()->t('Announce')];
 			}
 		}
 

--- a/view/templates/wall_thread.tpl
+++ b/view/templates/wall_thread.tpl
@@ -82,7 +82,8 @@
 			<div class="wall-item-like-buttons" id="wall-item-like-buttons-{{$item.id}}">
 				<a href="#" class="icon like{{if $item.responses.like.self}} active{{/if}}" title="{{$item.vote.like.0}}" onclick="dolike({{$item.id}}, 'like'{{if $item.responses.like.self}}, true{{/if}}); return false"></a>
 				{{if $item.vote.dislike}}<a href="#" class="icon dislike{{if $item.responses.dislike.self}} active{{/if}}" title="{{$item.vote.dislike.0}}" onclick="dolike({{$item.id}},'dislike'{{if $item.responses.dislike.self}}, true{{/if}}); return false"></a>{{/if}}
-				{{if $item.vote.share}}<a href="#" class="icon recycle wall-item-share-buttons" title="{{$item.vote.share.0}}" onclick="jotShare({{$item.id}}); return false"></a>{{/if}}
+				{{if $item.vote.announce}}<a href="#" class="icon recycle{{if $item.responses.announce.self}} active{{/if}}" title="{{$item.vote.announce.0}}" onclick="dolike({{$item.id}},'announce'{{if $item.responses.announce.self}}, true{{/if}}); return false"></a>{{/if}}
+				{{if $item.vote.share}}<a href="#" class="icon share wall-item-share-buttons" title="{{$item.vote.share.0}}" onclick="jotShare({{$item.id}}); return false"></a>{{/if}}
 				<img id="like-rotator-{{$item.id}}" class="like-rotator" src="images/rotator.gif" alt="{{$item.wait}}" title="{{$item.wait}}" style="display: none;" />
 			</div>
 			{{/if}}

--- a/view/theme/frio/templates/wall_thread.tpl
+++ b/view/theme/frio/templates/wall_thread.tpl
@@ -311,11 +311,17 @@ as the value of $top_child_total (this is done at the end of this file)
 
 			{{* Button for sharing the item *}}
 			{{if $item.vote}}
-				{{if $item.vote.share}}
+				{{if $item.vote.share OR $item.vote.announce}}
 					{{if $item.vote.like OR $item.vote.dislike OR $item.comment_html}}
 				<span role="presentation" class="separator"></span>
 					{{/if}}
-				<button type="button" class="btn-link button-votes" id="share-{{$item.id}}" title="{{$item.vote.share.0}}" onclick="jotShare({{$item.id}});"><i class="fa fa-retweet" aria-hidden="true"></i>&nbsp;{{$item.vote.share.1}}</button>
+				{{/if}}
+				{{if $item.vote.announce}}
+				<button type="button" class="btn-link button-announces{{if $item.responses.announce.self}} active" aria-pressed="true{{/if}}" id="announce-{{$item.id}}" title="{{$item.vote.announce.0}}" onclick="doLikeAction({{$item.id}}, 'announce'{{if $item.responses.announce.self}}, true{{/if}});" data-toggle="button"><i class="fa fa-retweet" aria-hidden="true"></i>&nbsp;{{$item.vote.announce.1}}</button>
+				<span role="presentation" class="separator"></span>
+				{{/if}}
+				{{if $item.vote.share}}
+				<button type="button" class="btn-link button-votes" id="share-{{$item.id}}" title="{{$item.vote.share.0}}" onclick="jotShare({{$item.id}});"><i class="fa fa-share" aria-hidden="true"></i>&nbsp;{{$item.vote.share.1}}</button>
 				{{/if}}
 			{{/if}}
 
@@ -434,10 +440,18 @@ as the value of $top_child_total (this is done at the end of this file)
 				</div>
 			{{/if}}
 
+			{{* Button for announcing the item *}}
+			{{if $item.vote.announce}}
+<!--				<div class="btn-group" role="group">
+					<button type="button" class="btn btn-sm button-announces{{if $item.responses.announce.self}} active" aria-pressed="true{{/if}}" id="announce-{{$item.id}}" title="{{$item.vote.announce.0}}" onclick="doLikeAction({{$item.id}}, 'announce'{{if $item.responses.announce.self}}, true{{/if}});" data-toggle="button"><i class="fa fa-retweet-up" aria-hidden="true"></i></button>
+				</div>
+				-->
+			{{/if}}
+
 			{{* Button for sharing the item *}}
 			{{if $item.vote.share}}
 				<div class="btn-group" role="group">
-					<button type="button" class="btn btn-sm button-votes" id="share-{{$item.id}}" title="{{$item.vote.share.0}}" onclick="jotShare({{$item.id}});"><i class="fa fa-retweet" aria-hidden="true"></i></button>
+					<button type="button" class="btn btn-sm button-votes" id="share-{{$item.id}}" title="{{$item.vote.share.0}}" onclick="jotShare({{$item.id}});"><i class="fa fa-share" aria-hidden="true"></i></button>
 				</div>
 			{{/if}}
 

--- a/view/theme/quattro/templates/wall_thread.tpl
+++ b/view/theme/quattro/templates/wall_thread.tpl
@@ -122,6 +122,9 @@
 				{{if $item.vote.dislike}}
 				<a href="#" id="dislike-{{$item.id}}"{{if $item.responses.dislike.self}} class="active{{/if}}" title="{{$item.vote.dislike.0}}" onclick="dolike({{$item.id}}, 'dislike'{{if $item.responses.dislike.self}}, true{{/if}}); return false">{{$item.vote.dislike.1}}</a>
 				{{/if}}
+				{{if $item.vote.announce}}
+				<a href="#" id="announce-{{$item.id}}"{{if $item.responses.announce.self}} class="active{{/if}}" title="{{$item.vote.announce.0}}" onclick="dolike({{$item.id}}, 'announce'{{if $item.responses.announce.self}}, true{{/if}}); return false">{{$item.vote.announce.1}}</a>
+				{{/if}}
 			    {{if $item.vote.share}}
 				    <a href="#" id="share-{{$item.id}}" title="{{$item.vote.share.0}}" onclick="jotShare({{$item.id}}); return false">{{$item.vote.share.1}}</a>
 			    {{/if}}

--- a/view/theme/smoothly/templates/wall_thread.tpl
+++ b/view/theme/smoothly/templates/wall_thread.tpl
@@ -95,8 +95,11 @@
 				{{if $item.vote.dislike}}
 				<a href="#" class="icon dislike{{if $item.responses.dislike.self}} self{{/if}}" title="{{$item.vote.dislike.0}}" onclick="dolike({{$item.id}}, 'dislike'{{if $item.responses.dislike.self}}, true{{/if}}); return false"></a>
 				{{/if}}
+				{{if $item.vote.announce}}
+				<a href="#" class="icon recycle{{if $item.responses.announce.self}} self{{/if}}" title="{{$item.vote.announce.0}}" onclick="dolike({{$item.id}}, 'announce'{{if $item.responses.announce.self}}, true{{/if}}); return false"></a>
+				{{/if}}
 				{{if $item.vote.share}}
-				<a href="#" class="icon recycle wall-item-share-buttons" title="{{$item.vote.share.0}}" onclick="jotShare({{$item.id}}); return false"></a>				{{/if}}
+				<a href="#" class="icon share wall-item-share-buttons" title="{{$item.vote.share.0}}" onclick="jotShare({{$item.id}}); return false"></a>				{{/if}}
 				<img id="like-rotator-{{$item.id}}" class="like-rotator" src="images/rotator.gif" alt="{{$item.wait}}" title="{{$item.wait}}" style="display: none;" />
 			</div>
 			{{/if}}

--- a/view/theme/vier/templates/wall_thread.tpl
+++ b/view/theme/vier/templates/wall_thread.tpl
@@ -124,9 +124,11 @@
 				<a role="button" id="like-{{$item.id}}"{{if $item.responses.like.self}} class="active"{{/if}} title="{{$item.vote.like.0}}" onclick="dolike({{$item.id}}, 'like'{{if $item.responses.like.self}}, true{{/if}}); return false"><i class="icon-thumbs-up icon-large"><span class="sr-only">{{$item.vote.like.0}}</span></i></a>
 				{{/if}}{{if $item.vote.dislike}}
 				<a role="button" id="dislike-{{$item.id}}"{{if $item.responses.dislike.self}} class="active"{{/if}} title="{{$item.vote.dislike.0}}" onclick="dolike({{$item.id}}, 'dislike'{{if $item.responses.dislike.self}}, true{{/if}}); return false"><i class="icon-thumbs-down icon-large"><span class="sr-only">{{$item.vote.dislike.0}}</span></i></a>
+				{{/if}}{{if $item.vote.announce}}
+				<a role="button" id="announce-{{$item.id}}"{{if $item.responses.announce.self}} class="active"{{/if}} title="{{$item.vote.announce.0}}" onclick="dolike({{$item.id}}, 'announce'{{if $item.responses.announce.self}}, true{{/if}}); return false"><i class="icon-retweet icon-large"><span class="sr-only">{{$item.vote.dislike.0}}</span></i></a>
 				{{/if}}
 			    {{if $item.vote.share}}
-				    <a role="button" id="share-{{$item.id}}" title="{{$item.vote.share.0}}" onclick="jotShare({{$item.id}}); return false"><i class="icon-retweet icon-large"><span class="sr-only">{{$item.vote.share.0}}</span></i></a>
+				    <a role="button" id="share-{{$item.id}}" title="{{$item.vote.share.0}}" onclick="jotShare({{$item.id}}); return false"><i class="icon-share icon-large"><span class="sr-only">{{$item.vote.share.0}}</span></i></a>
 			    {{/if}}
 			{{/if}}
 


### PR DESCRIPTION
By now we had a somewhat weird (unintuitive) support for resharing posts. When pressing "share", the editor window opens, the user has to keep the content unchanged and then has to deselect all connectors, since - for example - a reshared Friendica post really looks ugly on Twitter.

Now the user simply has to press a button, that's all. The post is then distributed in the own network. This is working for posts from ActivityPub/Friendica. Twitter will be possible in the future as well. Diaspora could be possible as well.