### PR TITLE
Fix GuzzleHttpClient - Use PHP temp stream

### DIFF
--- a/src/Network/HTTPRequest.php
+++ b/src/Network/HTTPRequest.php
@@ -205,7 +205,7 @@ class HTTPRequest implements IHTTPRequest
 				'referer' => true,
 			],
 			'on_headers' => $onHeaders,
-			'sink' => tempnam(get_temppath(), 'guzzle'),
+			'sink' => fopen('php://temp', 'w+'),
 			'curl' => $curlOptions
 		]);
 


### PR DESCRIPTION
FollowUp #9414 , #9400 
Use php-temp stream for guzzle sink

Strange enough that directly using the php stream works, but with the fallback of Guzzle itself it doesn't ..