### PR TITLE
Give checkboxes better background colors

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -2044,7 +2044,7 @@ p.wall-item-announce,
 
 .radio label::before,
 .checkbox label::before {
-	background-color: $background_color;
+	background-color: $nav_bg;
 }
 .radio label::after {
 	background-color: $link_color;

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -2044,7 +2044,7 @@ p.wall-item-announce,
 
 .radio label::before,
 .checkbox label::before {
-	background-color: $nav_bg;
+	background-color: rgba(255,255,255,$contentbg_transp);
 }
 .radio label::after {
 	background-color: $link_color;

--- a/view/theme/frio/scheme/black.css
+++ b/view/theme/frio/scheme/black.css
@@ -82,6 +82,11 @@ input[type=range] {
 	color: $font_color_darker;
 }
 
+.radio label::before,
+.checkbox label::before {
+	background-color: $background_color;
+}
+
 .nav-tabs>li.active>a,
 .nav-tabs>li.active>a:focus,
 .nav-tabs>li.active>a:hover,

--- a/view/theme/frio/scheme/dark.css
+++ b/view/theme/frio/scheme/dark.css
@@ -83,6 +83,11 @@ input[type=range] {
 	color: $font_color_darker;
 }
 
+.radio label::before,
+.checkbox label::before {
+	background-color: $background_color;
+}
+
 .nav-tabs>li.active>a,
 .nav-tabs>li.active>a:focus,
 .nav-tabs>li.active>a:hover,


### PR DESCRIPTION
Following the discussion in #9042 I moved the checkbox settings to each accented scheme. To avoid side effect I replaced the used variable in the light (and therefore the custom) scheme to the color set for the main content.

**Results**

Custom scheme:
![image](https://user-images.githubusercontent.com/74432/95791921-b42e2f80-0ce2-11eb-8a7e-19523945cbf9.png)

Light scheme:
![image](https://user-images.githubusercontent.com/74432/95791958-c6a86900-0ce2-11eb-9457-8feba86ba608.png)

Dark scheme (red accented):
![image](https://user-images.githubusercontent.com/74432/95792005-de7fed00-0ce2-11eb-9d9f-f1d681b3f843.png)

Black scheme (purple accented):
![image](https://user-images.githubusercontent.com/74432/95792049-f5264400-0ce2-11eb-8962-aab89885b4d5.png)

Fixes #9042.