### PR TITLE
Implement correct behavior for since_id/min_id in boundary pagination

### DIFF
--- a/src/BaseRepository.php
+++ b/src/BaseRepository.php
@@ -97,33 +97,52 @@ abstract class BaseRepository extends BaseFactory
 	 * Populates the collection according to the condition. Retrieves a limited subset of models depending on the boundaries
 	 * and the limit. The total count of rows matching the condition is stored in the collection.
 	 *
+	 * max_id and min_id are susceptible to the query order:
+	 * - min_id alone only reliably works with ASC order
+	 * - max_id alone only reliably works with DESC order
+	 * If the wrong order is detected in either case, we inverse the query order and we reverse the model array after the query
+	 *
 	 * Chainable.
 	 *
 	 * @param array $condition
 	 * @param array $params
-	 * @param int?  $max_id
-	 * @param int?  $since_id
+	 * @param int?  $min_id Retrieve models with an id no fewer than this, as close to it as possible
+	 * @param int?  $max_id Retrieve models with an id no greater than this, as close to it as possible
 	 * @param int   $limit
 	 * @return BaseCollection
 	 * @throws \Exception
 	 */
-	public function selectByBoundaries(array $condition = [], array $params = [], int $max_id = null, int $since_id = null, int $limit = self::LIMIT)
+	public function selectByBoundaries(array $condition = [], array $params = [], int $min_id = null, int $max_id = null, int $limit = self::LIMIT)
 	{
 		$totalCount = DBA::count(static::$table_name, $condition);
 
 		$boundCondition = $condition;
 
-		if (isset($max_id)) {
-			$boundCondition = DBA::mergeConditions($boundCondition, ['`id` < ?', $max_id]);
+		$reverseModels = false;
+
+		if (isset($min_id)) {
+			$boundCondition = DBA::mergeConditions($boundCondition, ['`id` > ?', $min_id]);
+			if (!isset($max_id) && isset($params['order']['id']) && ($params['order']['id'] === true || $params['order']['id'] === 'DESC')) {
+				$reverseModels = true;
+				$params['order']['id'] = 'ASC';
+			}
 		}
 
-		if (isset($since_id)) {
-			$boundCondition = DBA::mergeConditions($boundCondition, ['`id` > ?', $since_id]);
+		if (isset($max_id)) {
+			$boundCondition = DBA::mergeConditions($boundCondition, ['`id` < ?', $max_id]);
+			if (!isset($min_id) && (!isset($params['order']['id']) || $params['order']['id'] === false || $params['order']['id'] === 'ASC')) {
+				$reverseModels = true;
+				$params['order']['id'] = 'DESC';
+			}
 		}
 
 		$params['limit'] = $limit;
 
 		$models = $this->selectModels($boundCondition, $params);
+
+		if ($reverseModels) {
+			$models = array_reverse($models);
+		}
 
 		return new static::$collection_class($models, $totalCount);
 	}
@@ -216,6 +235,8 @@ abstract class BaseRepository extends BaseFactory
 				$models[] = static::$model_class::createFromPrototype($prototype, $record);
 			}
 		}
+
+		$this->dba->close($result);
 
 		return $models;
 	}

--- a/src/Content/BoundariesPager.php
+++ b/src/Content/BoundariesPager.php
@@ -27,7 +27,7 @@ use Friendica\Util\Network;
 use Friendica\Util\Strings;
 
 /**
- * This pager should be used by lists using the since_id†/max_id† parameters
+ * This pager should be used by lists using the min_id†/max_id† parameters
  *
  * This pager automatically identifies if the sorting is done increasingly or decreasingly if the first item id†
  * and last item id† are different. Otherwise it defaults to decreasingly like reverse chronological lists.
@@ -60,9 +60,9 @@ class BoundariesPager extends Pager
 		if (!empty($parsed['query'])) {
 			parse_str($parsed['query'], $queryParameters);
 
-			$this->first_page = !($queryParameters['since_id'] ?? null) && !($queryParameters['max_id'] ?? null);
+			$this->first_page = !($queryParameters['min_id'] ?? null) && !($queryParameters['max_id'] ?? null);
 
-			unset($queryParameters['since_id']);
+			unset($queryParameters['min_id']);
 			unset($queryParameters['max_id']);
 
 			$parsed['query'] = http_build_query($queryParameters);
@@ -111,7 +111,7 @@ class BoundariesPager extends Pager
 			'prev'  => [
 				'url'   => Strings::ensureQueryParameter($this->baseQueryString .
 					($this->first_item_id >= $this->last_item_id ?
-						'&since_id=' . $this->first_item_id : '&max_id=' . $this->first_item_id)
+						'&min_id=' . $this->first_item_id : '&max_id=' . $this->first_item_id)
 				),
 				'text'  => $this->l10n->t('newer'),
 				'class' => 'previous' . ($this->first_page ? ' disabled' : '')
@@ -119,7 +119,7 @@ class BoundariesPager extends Pager
 			'next'  => [
 				'url'   => Strings::ensureQueryParameter($this->baseQueryString .
 					($this->first_item_id >= $this->last_item_id ?
-					'&max_id=' . $this->last_item_id : '&since_id=' . $this->last_item_id)
+					'&max_id=' . $this->last_item_id : '&min_id=' . $this->last_item_id)
 				),
 				'text'  => $this->l10n->t('older'),
 				'class' =>  'next' . ($displayedItemCount < $this->getItemsPerPage() ? ' disabled' : '')

--- a/src/Module/Api/Mastodon/FollowRequests.php
+++ b/src/Module/Api/Mastodon/FollowRequests.php
@@ -91,7 +91,7 @@ class FollowRequests extends BaseApi
 	 */
 	public static function rawContent(array $parameters = [])
 	{
-		$since_id = $_GET['since_id'] ?? null;
+		$min_id = $_GET['min_id'] ?? null;
 		$max_id = $_GET['max_id'] ?? null;
 		$limit = intval($_GET['limit'] ?? 40);
 
@@ -100,7 +100,7 @@ class FollowRequests extends BaseApi
 		$introductions = DI::intro()->selectByBoundaries(
 			['`uid` = ? AND NOT `ignore`', self::$current_user_id],
 			['order' => ['id' => 'DESC']],
-			$since_id,
+			$min_id,
 			$max_id,
 			$limit
 		);
@@ -127,7 +127,7 @@ class FollowRequests extends BaseApi
 		}
 
 		if (count($introductions)) {
-			$links[] = '<' . $baseUrl->get() . '/api/v1/follow_requests?' . http_build_query($base_query + ['since_id' => $introductions[0]->id]) . '>; rel="prev"';
+			$links[] = '<' . $baseUrl->get() . '/api/v1/follow_requests?' . http_build_query($base_query + ['min_id' => $introductions[0]->id]) . '>; rel="prev"';
 		}
 
 		header('Link: ' . implode(', ', $links));

--- a/src/Repository/FSuggest.php
+++ b/src/Repository/FSuggest.php
@@ -78,16 +78,16 @@ class FSuggest extends BaseRepository
 	}
 
 	/**
-	 * @param array $condition
-	 * @param array $params
+	 * @param array    $condition
+	 * @param array    $params
+	 * @param int|null $min_id
 	 * @param int|null $max_id
-	 * @param int|null $since_id
-	 * @param int $limit
+	 * @param int      $limit
 	 * @return Collection\FSuggests
 	 * @throws \Exception
 	 */
-	public function selectByBoundaries(array $condition = [], array $params = [], int $max_id = null, int $since_id = null, int $limit = self::LIMIT)
+	public function selectByBoundaries(array $condition = [], array $params = [], int $min_id = null, int $max_id = null, int $limit = self::LIMIT)
 	{
-		return parent::selectByBoundaries($condition, $params, $max_id, $since_id, $limit);
+		return parent::selectByBoundaries($condition, $params, $min_id, $max_id, $limit);
 	}
 }

--- a/src/Repository/Introduction.php
+++ b/src/Repository/Introduction.php
@@ -64,16 +64,16 @@ class Introduction extends BaseRepository
 	}
 
 	/**
-	 * @param array $condition
-	 * @param array $params
+	 * @param array    $condition
+	 * @param array    $params
+	 * @param int|null $min_id
 	 * @param int|null $max_id
-	 * @param int|null $since_id
-	 * @param int $limit
+	 * @param int      $limit
 	 * @return Collection\Introductions
 	 * @throws \Exception
 	 */
-	public function selectByBoundaries(array $condition = [], array $params = [], int $max_id = null, int $since_id = null, int $limit = self::LIMIT)
+	public function selectByBoundaries(array $condition = [], array $params = [], int $min_id = null, int $max_id = null, int $limit = self::LIMIT)
 	{
-		return parent::selectByBoundaries($condition, $params, $max_id, $since_id, $limit);
+		return parent::selectByBoundaries($condition, $params, $min_id, $max_id, $limit);
 	}
 }

--- a/src/Repository/PermissionSet.php
+++ b/src/Repository/PermissionSet.php
@@ -93,17 +93,17 @@ class PermissionSet extends BaseRepository
 	}
 
 	/**
-	 * @param array $condition
-	 * @param array $params
+	 * @param array    $condition
+	 * @param array    $params
+	 * @param int|null $min_id
 	 * @param int|null $max_id
-	 * @param int|null $since_id
-	 * @param int $limit
+	 * @param int      $limit
 	 * @return Collection\PermissionSets
 	 * @throws \Exception
 	 */
-	public function selectByBoundaries(array $condition = [], array $params = [], int $max_id = null, int $since_id = null, int $limit = self::LIMIT)
+	public function selectByBoundaries(array $condition = [], array $params = [], int $min_id = null, int $max_id = null, int $limit = self::LIMIT)
 	{
-		return parent::selectByBoundaries($condition, $params, $max_id, $since_id, $limit);
+		return parent::selectByBoundaries($condition, $params, $min_id, $max_id, $limit);
 	}
 
 	/**

--- a/src/Repository/ProfileField.php
+++ b/src/Repository/ProfileField.php
@@ -87,17 +87,17 @@ class ProfileField extends BaseRepository
 	}
 
 	/**
-	 * @param array $condition
-	 * @param array $params
+	 * @param array    $condition
+	 * @param array    $params
+	 * @param int|null $min_id
 	 * @param int|null $max_id
-	 * @param int|null $since_id
-	 * @param int $limit
+	 * @param int      $limit
 	 * @return Collection\ProfileFields
 	 * @throws \Exception
 	 */
-	public function selectByBoundaries(array $condition = [], array $params = [], int $max_id = null, int $since_id = null, int $limit = self::LIMIT)
+	public function selectByBoundaries(array $condition = [], array $params = [], int $min_id = null, int $max_id = null, int $limit = self::LIMIT)
 	{
-		return parent::selectByBoundaries($condition, $params, $max_id, $since_id, $limit);
+		return parent::selectByBoundaries($condition, $params, $min_id, $max_id, $limit);
 	}
 
 	/**

--- a/view/js/main.js
+++ b/view/js/main.js
@@ -536,7 +536,7 @@ function updateConvItems(data) {
 		if ($('#' + ident).length === 0
 			&& (!getUrlParameter('page')
 				&& !getUrlParameter('max_id')
-				&& !getUrlParameter('since_id')
+				&& !getUrlParameter('min_id')
 				|| getUrlParameter('page') === '1'
 			)
 		) {
@@ -609,8 +609,8 @@ function liveUpdate(src) {
 	if (getUrlParameter('page')) {
 		update_url += '&page=' + getUrlParameter('page');
 	}
-	if (getUrlParameter('since_id')) {
-		update_url += '&since_id=' + getUrlParameter('since_id');
+	if (getUrlParameter('min_id')) {
+		update_url += '&min_id=' + getUrlParameter('min_id');
 	}
 	if (getUrlParameter('max_id')) {
 		update_url += '&max_id=' + getUrlParameter('max_id');


### PR DESCRIPTION
Part of #9127

The previous behavior of `since_id` systematically showed the most recent results. This affected only previous pages when used with the boundaries pager or in certain API calls. I actually snooped at how Mastodon handles the `since_id` parameter, and I found out that they introduced a `min_id` parameter that does what I wanted to do with `since_id`, and they do have to reverse the items as well, see https://github.com/tootsuite/mastodon/blob/fa0c71f0d92ed5587859710dde3b076ec64b1498/app/models/concerns/paginable.rb

Consequently, I've renamed the `since_id` parameter to `min_id` where relevant. There are a bunch of legacy API calls that make use of `since_id` and they should be ported to `min_id` when we move them to `src/`.