### PR TITLE
Add routes file recompute on last modification time change

### DIFF
--- a/src/App/Router.php
+++ b/src/App/Router.php
@@ -93,6 +93,10 @@ class Router
 		$this->routeCollector = isset($routeCollector) ?
 			$routeCollector :
 			new RouteCollector(new Std(), new GroupCountBased());
+
+		if ($this->baseRoutesFilepath && !file_exists($this->baseRoutesFilepath)) {
+			throw new HTTPException\InternalServerErrorException('Routes file path does\'n exist.');
+		}
 	}
 
 	/**
@@ -249,7 +253,7 @@ class Router
 	{
 		$dispatchData = [];
 
-		if ($this->baseRoutesFilepath && file_exists($this->baseRoutesFilepath)) {
+		if ($this->baseRoutesFilepath) {
 			$dispatchData = require $this->baseRoutesFilepath;
 			if (!is_array($dispatchData)) {
 				throw new HTTPException\InternalServerErrorException('Invalid base routes file');
@@ -280,7 +284,7 @@ class Router
 		$lastRoutesFileModifiedTime = $this->cache->get('lastRoutesFileModifiedTime');
 		$forceRecompute = false;
 
-		if ($this->baseRoutesFilepath && file_exists($this->baseRoutesFilepath)) {
+		if ($this->baseRoutesFilepath) {
 			$routesFileModifiedTime = filemtime($this->baseRoutesFilepath);
 			$forceRecompute = $lastRoutesFileModifiedTime != $routesFileModifiedTime;
 		}

--- a/tests/src/App/ModuleTest.php
+++ b/tests/src/App/ModuleTest.php
@@ -178,7 +178,8 @@ class ModuleTest extends DatabaseTest
 
 		$cache = \Mockery::mock(ICache::class);
 		$cache->shouldReceive('get')->with('routerDispatchData')->andReturn('')->atMost()->once();
-		$cache->shouldReceive('set')->withAnyArgs()->andReturn(false)->atMost()->once();
+		$cache->shouldReceive('get')->with('lastRoutesFileModifiedTime')->andReturn('')->atMost()->once();
+		$cache->shouldReceive('set')->withAnyArgs()->andReturn(false)->atMost()->twice();
 
 		$router = (new App\Router([], __DIR__ . '/../../../static/routes.config.php', $l10n, $cache));
 

--- a/tests/src/App/RouterTest.php
+++ b/tests/src/App/RouterTest.php
@@ -185,7 +185,7 @@ class RouterTest extends TestCase
 						],
 					],
 					'/post' => [
-						'/it' => [Module\NodeInfo::class, [Router::POST]],
+						'/it' => [Module\WellKnown\NodeInfo::class, [Router::POST]],
 					],
 					'/double' => [Module\Profile\Index::class, [Router::GET, Router::POST]]
 				],
@@ -221,7 +221,7 @@ class RouterTest extends TestCase
 		], '', $this->l10n, $this->cache))->loadRoutes($routes);
 
 		// Don't find GET
-		$this->assertEquals(Module\NodeInfo::class, $router->getModuleClass('/post/it'));
+		$this->assertEquals(Module\WellKnown\NodeInfo::class, $router->getModuleClass('/post/it'));
 		$this->assertEquals(Module\Profile\Index::class, $router->getModuleClass('/double'));
 	}
 }


### PR DESCRIPTION
Related to #9423

I'm not happy about the hoops we have to jump through regarding the value of `Router->baseRoutesFilepath`. I feel like the file existence should be tested in the constructor if the path is provided, which would then ensure that if the variable is set, the file exists.

What do you think @nupplaphil ?