### PR TITLE
Network: Fix continuous load issues

### DIFF
--- a/src/Module/Conversation/Network.php
+++ b/src/Module/Conversation/Network.php
@@ -332,13 +332,13 @@ class Network extends BaseModule
 				self::$max_id = $get['last_received'] ?? self::$max_id;
 				break;
 			case 'commented':
-				self::$max_id = $_GET['last_commented'] ?? self::$max_id;
+				self::$max_id = $get['last_commented'] ?? self::$max_id;
 				break;
 			case 'created':
-				self::$max_id = $_GET['last_created'] ?? self::$max_id;
+				self::$max_id = $get['last_created'] ?? self::$max_id;
 				break;
 			case 'uriid':
-				self::$max_id = $_GET['last_uriid'] ?? self::$max_id;
+				self::$max_id = $get['last_uriid'] ?? self::$max_id;
 				break;
 		}
 	}

--- a/src/Module/Conversation/Network.php
+++ b/src/Module/Conversation/Network.php
@@ -11,6 +11,7 @@ use Friendica\Content\Text\HTML;
 use Friendica\Core\ACL;
 use Friendica\Core\Hook;
 use Friendica\Core\Renderer;
+use Friendica\Core\Session;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Contact;
@@ -282,7 +283,7 @@ class Network extends BaseModule
 
 		self::$forumContactId = $parameters['contact_id'] ?? 0;
 
-		self::$selectedTab = '';
+		self::$selectedTab = Session::get('network-tab', '');
 
 		if (!empty($get['star'])) {
 			self::$selectedTab = 'star';
@@ -296,9 +297,16 @@ class Network extends BaseModule
 			self::$selectedTab = $get['order'];
 		}
 
+		Session::set('network-tab', self::$selectedTab);
+
 		self::$star    = intval($get['star'] ?? 0);
 		self::$mention = intval($_GET['mention'] ?? 0);
-		self::$order   = $get['order'] ?? 'commented';
+		self::$order   = $get['order'] ?? Session::get('network-order', 'commented');
+
+		self::$selectedTab = self::$selectedTab ?? self::$order;
+
+		Session::set('network-tab', self::$selectedTab);
+		Session::set('network-order', self::$order);
 
 		self::$accountTypeString = $_GET['accounttype'] ?? $parameters['accounttype'] ?? '';
 		self::$accountType = User::getAccountTypeByString(self::$accountTypeString);

--- a/src/Module/Conversation/Network.php
+++ b/src/Module/Conversation/Network.php
@@ -300,7 +300,7 @@ class Network extends BaseModule
 		Session::set('network-tab', self::$selectedTab);
 
 		self::$star    = intval($get['star'] ?? 0);
-		self::$mention = intval($_GET['mention'] ?? 0);
+		self::$mention = intval($get['mention'] ?? 0);
 		self::$order   = $get['order'] ?? Session::get('network-order', 'commented');
 
 		self::$selectedTab = self::$selectedTab ?? self::$order;
@@ -308,7 +308,7 @@ class Network extends BaseModule
 		Session::set('network-tab', self::$selectedTab);
 		Session::set('network-order', self::$order);
 
-		self::$accountTypeString = $_GET['accounttype'] ?? $parameters['accounttype'] ?? '';
+		self::$accountTypeString = $get['accounttype'] ?? $parameters['accounttype'] ?? '';
 		self::$accountType = User::getAccountTypeByString(self::$accountTypeString);
 
 		self::$network = $get['nets'] ?? '';
@@ -324,12 +324,12 @@ class Network extends BaseModule
 				DI::config()->get('system', 'itemspage_network'));
 		}
 
-		self::$min_id = $_GET['min_id'] ?? null;
-		self::$max_id = $_GET['max_id'] ?? null;
+		self::$min_id = $get['min_id'] ?? null;
+		self::$max_id = $get['max_id'] ?? null;
 
 		switch (self::$order) {
 			case 'received':
-				self::$max_id = $_GET['last_received'] ?? self::$max_id;
+				self::$max_id = $get['last_received'] ?? self::$max_id;
 				break;
 			case 'commented':
 				self::$max_id = $_GET['last_commented'] ?? self::$max_id;


### PR DESCRIPTION
The continuous load hadn't always worked like expected. There had been situations when the same content had been loaded again and again.