### PR TITLE
Avoid duplicate item entries

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -1030,7 +1030,7 @@ class Database
 				$id = $this->connection->insert_id;
 				break;
 		}
-		return $id;
+		return (int)$id;
 	}
 
 	/**

--- a/src/Model/Post/Category.php
+++ b/src/Model/Post/Category.php
@@ -89,7 +89,7 @@ class Category
 					continue;
 				}
 
-				DBA::insert('post-category', [
+				DBA::replace('post-category', [
 					'uri-id' => $uri_id,
 					'uid' => $uid,
 					'type' => self::FILE,
@@ -105,7 +105,7 @@ class Category
 					continue;
 				}
 
-				DBA::insert('post-category', [
+				DBA::replace('post-category', [
 					'uri-id' => $uri_id,
 					'uid' => $uid,
 					'type' => self::CATEGORY,


### PR DESCRIPTION
Our item table is missing a good unique key. So duplicated postings can happen - and they happen very often when several relay servers had been added. We now use a different approach: We lock the item table, check for an existing post, if not adding it, then unlocking the table. This worked now for several hours on my machine without any problem.