### PR TITLE
Move "remote self" to the contact settings

### DIFF
--- a/doc/Settings.md
+++ b/doc/Settings.md
@@ -182,7 +182,7 @@ By default, any (valid) email address is allowed in registrations.
 
 #### Allow Users to set remote_self
 
-If you enable the `Allow Users to set remote_self` users can select Atom feeds from their contact list being their *remote self* in the advanced contact settings.
+If you enable the `Allow Users to set remote_self` users can select Atom feeds from their contact list being their *remote self* in the contact settings.
 Which means that postings by the remote self are automatically reposted by Friendica in their names.
 
 This feature can be used to let the user mirror e.g. blog postings into their Friendica postings.

--- a/doc/de/Settings.md
+++ b/doc/de/Settings.md
@@ -172,7 +172,7 @@ Wildcards werden akzeptiert Standardmäßig sind alle gültigen Email-Adressen e
 
 #### Nutzern erlauben das remote_self Flag zu setzen
 
-Webb du die Option `Nutzern erlauben das remote_self Flag zu setzen` aktivierst, können alle Nutzer Atom Feeds in den erweiterten Einstellungen des Kontakts als "Entferntes Konto" markieren.
+Webb du die Option `Nutzern erlauben das remote_self Flag zu setzen` aktivierst, können alle Nutzer Atom Feeds in den Kontakteinstellungen als "Entferntes Konto" markieren.
 Dadurch werden automatisch alle Beiträge dieser Feeds für diesen Nutzer gespiegelt und an die Kontakte bei Friendica verteilt.
 
 Dieses Feature kann z.B. dafür genutzt werden Blogbeiträge zu spiegeln.

--- a/src/Module/Contact.php
+++ b/src/Module/Contact.php
@@ -21,7 +21,6 @@
 
 namespace Friendica\Module;
 
-use Friendica\App;
 use Friendica\BaseModule;
 use Friendica\Content\ContactSelector;
 use Friendica\Content\Nav;
@@ -132,6 +131,8 @@ class Contact extends BaseModule
 
 		$fetch_further_information = intval($_POST['fetch_further_information'] ?? 0);
 
+		$remote_self = $_POST['remote_self'] ?? false;
+
 		$ffi_keyword_denylist = Strings::escapeHtml(trim($_POST['ffi_keyword_denylist'] ?? ''));
 
 		$priority = intval($_POST['poll'] ?? 0);
@@ -147,6 +148,7 @@ class Contact extends BaseModule
 			'hidden'     => $hidden,
 			'notify_new_posts' => $notify,
 			'fetch_further_information' => $fetch_further_information,
+			'remote_self' => $remote_self,
 			'ffi_keyword_denylist'     => $ffi_keyword_denylist],
 			['id' => $contact_id, 'uid' => local_user()]
 		);
@@ -555,6 +557,18 @@ class Contact extends BaseModule
 				];
 			}
 
+			// Disable remote self for everything except feeds.
+			// There is an issue when you repeat an item from maybe twitter and you got comments from friendica and twitter
+			// Problem is, you couldn't reply to both networks.
+			$allow_remote_self = in_array($contact['network'], [Protocol::FEED, Protocol::DFRN, Protocol::DIASPORA, Protocol::TWITTER])
+				&& DI::config()->get('system', 'allow_users_remote_self');
+
+			if ($contact['network'] == Protocol::FEED) {
+				$remote_self_options = ['0' => DI::l10n()->t('No mirroring'), '1' => DI::l10n()->t('Mirror as forwarded posting'), '2' => DI::l10n()->t('Mirror as my own posting')];
+			} else {
+				$remote_self_options = ['0' => DI::l10n()->t('No mirroring'), '2' => DI::l10n()->t('Mirror as my own posting')];
+			}
+
 			$poll_interval = null;
 			if ((($contact['network'] == Protocol::FEED) && !DI::config()->get('system', 'adjust_poll_frequency')) || ($contact['network']== Protocol::MAIL)) {
 				$poll_interval = ContactSelector::pollInterval($contact['priority'], !$poll_enabled);
@@ -629,6 +643,13 @@ class Contact extends BaseModule
 				'$contact_status' => DI::l10n()->t('Status'),
 				'$contact_settings_label' => $contact_settings_label,
 				'$contact_profile_label' => DI::l10n()->t('Profile'),
+				'$allow_remote_self' => $allow_remote_self,
+				'$remote_self'       => ['remote_self',
+					DI::l10n()->t('Mirror postings from this contact'),
+					$contact['remote_self'],
+					DI::l10n()->t('Mark this contact as remote_self, this will cause friendica to repost new entries from this contact.'),
+					$remote_self_options
+				],	
 			]);
 
 			$arr = ['contact' => $contact, 'output' => $o];
@@ -916,7 +937,7 @@ class Contact extends BaseModule
 			],
 		];
 
-		if ($cid != $pcid) {
+		if (in_array($contact['network'], [Protocol::FEED, Protocol::MAIL]) && ($cid != $pcid)) {
 			$tabs[] = ['label' => DI::l10n()->t('Advanced'),
 				'url'   => 'contact/' . $cid . '/advanced/',
 				'sel'   => (($active_tab == self::TAB_ADVANCED) ? 'active' : ''),

--- a/src/Module/Contact/Advanced.php
+++ b/src/Module/Contact/Advanced.php
@@ -63,7 +63,6 @@ class Advanced extends BaseModule
 		$poll        = $_POST['poll'] ?? '';
 		$attag       = $_POST['attag'] ?? '';
 		$photo       = $_POST['photo'] ?? '';
-		$remote_self = $_POST['remote_self'] ?? false;
 		$nurl        = Strings::normaliseLink($url);
 
 		$r = DI::dba()->update(
@@ -79,7 +78,6 @@ class Advanced extends BaseModule
 				'notify'      => $notify,
 				'poll'        => $poll,
 				'attag'       => $attag,
-				'remote_self' => $remote_self,
 			],
 			['id' => $contact['id'], 'uid' => local_user()]
 		);
@@ -113,18 +111,6 @@ class Advanced extends BaseModule
 
 		$returnaddr = "contact/$cid";
 
-		// Disable remote self for everything except feeds.
-		// There is an issue when you repeat an item from maybe twitter and you got comments from friendica and twitter
-		// Problem is, you couldn't reply to both networks.
-		$allow_remote_self = in_array($contact['network'], [Protocol::FEED, Protocol::DFRN, Protocol::DIASPORA, Protocol::TWITTER])
-		                     && DI::config()->get('system', 'allow_users_remote_self');
-
-		if ($contact['network'] == Protocol::FEED) {
-			$remote_self_options = ['0' => DI::l10n()->t('No mirroring'), '1' => DI::l10n()->t('Mirror as forwarded posting'), '2' => DI::l10n()->t('Mirror as my own posting')];
-		} else {
-			$remote_self_options = ['0' => DI::l10n()->t('No mirroring'), '2' => DI::l10n()->t('Mirror as my own posting')];
-		}
-
 		// This data is fetched automatically for most networks.
 		// Editing does only makes sense for mail and feed contacts.
 		if (!in_array($contact['network'], [Protocol::FEED, Protocol::MAIL])) {
@@ -146,14 +132,6 @@ class Advanced extends BaseModule
 			'$udprofilenow'      => DI::l10n()->t('Refetch contact data'),
 			'$contact_id'        => $contact['id'],
 			'$lbl_submit'        => DI::l10n()->t('Submit'),
-			'$label_remote_self' => DI::l10n()->t('Remote Self'),
-			'$allow_remote_self' => $allow_remote_self,
-			'$remote_self'       => ['remote_self',
-				DI::l10n()->t('Mirror postings from this contact'),
-				$contact['remote_self'],
-				DI::l10n()->t('Mark this contact as remote_self, this will cause friendica to repost new entries from this contact.'),
-				$remote_self_options
-			],
 
 			'$name'    => ['name', DI::l10n()->t('Name'), $contact['name'], '', '', $readonly],
 			'$nick'    => ['nick', DI::l10n()->t('Account Nickname'), $contact['nick'], '', '', $readonly],

--- a/view/templates/contact/advanced.tpl
+++ b/view/templates/contact/advanced.tpl
@@ -39,12 +39,6 @@
 
 	{{include file="field_input.tpl" field=$photo}}
 
-
-	{{if $allow_remote_self eq 1}}
-	<h4>{{$label_remote_self}}</h4>
-	{{include file="field_select.tpl" field=$remote_self}}
-	{{/if}}
-
 	<input type="submit" name="submit" value="{{$lbl_submit}}" />
 
 </form>

--- a/view/templates/contact_edit.tpl
+++ b/view/templates/contact_edit.tpl
@@ -69,6 +69,10 @@
 						{{include file="field_select.tpl" field=$fetch_further_information}}
 						{{if $fetch_further_information.2 == 2 || $fetch_further_information.2 == 3}} {{include file="field_textarea.tpl" field=$ffi_keyword_denylist}} {{/if}}
 					{{/if}}
+					{{if $allow_remote_self}}
+						{{include file="field_select.tpl" field=$remote_self}}
+					{{/if}}
+
 					{{include file="field_checkbox.tpl" field=$hidden}}
 
 				<div id="contact-edit-info-wrapper">

--- a/view/theme/frio/templates/contact/advanced.tpl
+++ b/view/theme/frio/templates/contact/advanced.tpl
@@ -41,12 +41,6 @@
 
 		{{include file="field_input.tpl" field=$photo}}
 
-
-		{{if $allow_remote_self eq 1}}
-		<h4>{{$label_remote_self}}</h4>
-		{{include file="field_select.tpl" field=$remote_self}}
-		{{/if}}
-
 		<div class="pull-right settings-submit-wrapper" >
 			<button type="submit" name="submit" class="btn btn-primary" value="{{$lbl_submit}}">{{$lbl_submit}}</button>
 		</div>

--- a/view/theme/frio/templates/contact_edit.tpl
+++ b/view/theme/frio/templates/contact_edit.tpl
@@ -135,6 +135,10 @@
 									{{include file="field_select.tpl" field=$fetch_further_information}}
 									{{if $fetch_further_information.2 == 2 || $fetch_further_information.2 == 3}} {{include file="field_textarea.tpl" field=$ffi_keyword_denylist}} {{/if}}
 								{{/if}}
+								{{if $allow_remote_self}}
+									{{include file="field_select.tpl" field=$remote_self}}
+								{{/if}}
+
 								{{include file="field_checkbox.tpl" field=$hidden}}
 
 								<div class="pull-right settings-submit-wrapper" >

--- a/view/theme/vier/templates/contact_edit.tpl
+++ b/view/theme/vier/templates/contact_edit.tpl
@@ -70,6 +70,10 @@
 						{{include file="field_select.tpl" field=$fetch_further_information}}
 						{{if $fetch_further_information.2 == 2 || $fetch_further_information.2 == 3}} {{include file="field_textarea.tpl" field=$ffi_keyword_denylist}} {{/if}}
 					{{/if}}
+					{{if $allow_remote_self}}
+						{{include file="field_select.tpl" field=$remote_self}}
+					{{/if}}
+
 					{{include file="field_checkbox.tpl" field=$hidden}}
 
 				<div id="contact-edit-info-wrapper">


### PR DESCRIPTION
Currently the "remote self" settings are under the "advanced" tab. It now moved to the "contact settings" page. It does make more sense to group all settings at a single place.