### PR TITLE
Issue 9457: Fix network order for starred and mention

### DIFF
--- a/src/Module/Conversation/Network.php
+++ b/src/Module/Conversation/Network.php
@@ -285,21 +285,25 @@ class Network extends BaseModule
 
 		self::$selectedTab = Session::get('network-tab', DI::pConfig()->get(local_user(), 'network.view', 'selected_tab', ''));
 
+		self::$order = 'commented';
+
 		if (!empty($get['star'])) {
 			self::$selectedTab = 'star';
+			self::$order = 'received';
 		}
 
 		if (!empty($get['mention'])) {
 			self::$selectedTab = 'mention';
+			self::$order = 'received';
 		}
 
 		if (!empty($get['order'])) {
 			self::$selectedTab = $get['order'];
+			self::$order = $get['order'];
 		}
 
 		self::$star    = intval($get['star'] ?? 0);
 		self::$mention = intval($get['mention'] ?? 0);
-		self::$order   = $get['order'] ?? Session::get('network-order', 'commented');
 
 		self::$selectedTab = self::$selectedTab ?? self::$order;
 
@@ -339,8 +343,6 @@ class Network extends BaseModule
 				self::$order = 'commented';
 				self::$max_id = $get['last_commented'] ?? self::$max_id;
 		}
-
-		Session::set('network-order', self::$order);
 	}
 
 	protected static function getItems(string $table, array $params, array $conditionFields = [])


### PR DESCRIPTION
Fixes https://github.com/friendica/friendica/issues/9457

The problem had been that the previously used order had been used as well when showing the starred posts or the mentions. This is now always a fixed order.