### PR TITLE
Publish the provider fields in the API

### DIFF
--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -146,13 +146,15 @@ class BBCode
 	public static function getAttachmentData($body)
 	{
 		$data = [
-			'type'        => '',
-			'text'        => '',
-			'after'       => '',
-			'image'       => null,
-			'url'         => '',
-			'title'       => '',
-			'description' => '',
+			'type'          => '',
+			'text'          => '',
+			'after'         => '',
+			'image'         => null,
+			'url'           => '',
+			'provider_name' => '',
+			'provider_url'  => '',
+			'title'         => '',
+			'description'   => '',
 		];
 
 		if (!preg_match("/(.*)\[attachment(.*?)\](.*?)\[\/attachment\](.*)/ism", $body, $match)) {
@@ -252,6 +254,16 @@ class BBCode
 		$data['description'] = trim($match[3]);
 
 		$data['after'] = trim($match[4]);
+
+		$parts = parse_url($data['url']);
+		if (!empty($parts['scheme']) && !empty($parts['host'])) {
+			$data['provider_name'] = $parts['host'];
+			$data['provider_url'] = $parts['scheme'] . '://' . $parts['host'];
+
+			if (!empty($parts['port'])) {
+				$data['provider_url'] .= ':' . $parts['port'];
+			}
+		}
 
 		return $data;
 	}

--- a/src/Factory/Api/Mastodon/Status.php
+++ b/src/Factory/Api/Mastodon/Status.php
@@ -78,7 +78,7 @@ class Status extends BaseFactory
 		);
 
 		$sensitive = DBA::exists('tag-view', ['uri-id' => $uriId, 'name' => 'nsfw']);
-		$application = new \Friendica\Object\Api\Mastodon\Application($item['app']);
+		$application = new \Friendica\Object\Api\Mastodon\Application($item['app'] ?? '');
 		$mentions = DI::mstdnMention()->createFromUriId($uriId);
 		$tags = DI::mstdnTag()->createFromUriId($uriId);
 

--- a/src/Object/Api/Mastodon/Card.php
+++ b/src/Object/Api/Mastodon/Card.php
@@ -22,10 +22,6 @@
 namespace Friendica\Object\Api\Mastodon;
 
 use Friendica\BaseEntity;
-use Friendica\Content\Text\BBCode;
-use Friendica\Object\Api\Mastodon\Status\Counts;
-use Friendica\Object\Api\Mastodon\Status\UserAttributes;
-use Friendica\Util\DateTimeFormat;
 
 /**
  * Class Card
@@ -43,21 +39,27 @@ class Card extends BaseEntity
 	/** @var string */
 	protected $type;
 	/** @var string */
+	protected $provider_name;
+	/** @var string */
+	protected $provider_url;
+	/** @var string */
 	protected $image;
 
 	/**
-	 * Creates a status record from an item record.
+	 * Creates a card record from an attachment array.
 	 *
 	 * @param array   $attachment Attachment record
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
 	public function __construct(array $attachment)
 	{
-		$this->url         = $attachment['url'] ?? '';
-		$this->title       = $attachment['title'] ?? '';
-		$this->description = $attachment['description'] ?? '';
-		$this->type        = $attachment['type'] ?? '';
-		$this->image       = $attachment['image'] ?? '';
+		$this->url           = $attachment['url'] ?? '';
+		$this->title         = $attachment['title'] ?? '';
+		$this->description   = $attachment['description'] ?? '';
+		$this->type          = $attachment['type'] ?? '';
+		$this->image         = $attachment['image'] ?? '';
+		$this->provider_name = $attachment['provider_name'] ?? '';
+		$this->provider_url  = $attachment['provider_url'] ?? '';
 	}
 
 	/**


### PR DESCRIPTION
Two more fields are filled in the card object of the Mastodon API. Also a bug is fixed when the "app" field is "null".