### PR TITLE
Fix notice "Undefined index: network" and warning "strpos(): Empty needle"

### DIFF
--- a/src/Content/PageInfo.php
+++ b/src/Content/PageInfo.php
@@ -292,7 +292,7 @@ class PageInfo
 			$quotedUrl
 		)$#isx", function ($match) use ($url) {
 			// Stripping URLs with no label
-			if (!isset($match[1])) {
+			if (empty($match[1])) {
 				return '';
 			}
 

--- a/src/Module/Contact.php
+++ b/src/Module/Contact.php
@@ -937,7 +937,7 @@ class Contact extends BaseModule
 			],
 		];
 
-		if (in_array($contact['network'], [Protocol::FEED, Protocol::MAIL]) && ($cid != $pcid)) {
+		if (!empty($contact['network']) && in_array($contact['network'], [Protocol::FEED, Protocol::MAIL]) && ($cid != $pcid)) {
 			$tabs[] = ['label' => DI::l10n()->t('Advanced'),
 				'url'   => 'contact/' . $cid . '/advanced/',
 				'sel'   => (($active_tab == self::TAB_ADVANCED) ? 'active' : ''),


### PR DESCRIPTION
This warning is fixed: `strpos(): Empty needle in /src/Content/PageInfo.php on line 300`

Ths notice is fixed: `Undefined index: network in /src/Module/Contact.php on line 940`