### PR TITLE
The post-media table now works with the "attach" field as well

### DIFF
--- a/mod/item.php
+++ b/mod/item.php
@@ -35,7 +35,6 @@ use Friendica\Content\Text\BBCode;
 use Friendica\Core\Hook;
 use Friendica\Core\Logger;
 use Friendica\Core\Protocol;
-use Friendica\Core\Renderer;
 use Friendica\Core\Session;
 use Friendica\Core\System;
 use Friendica\Core\Worker;
@@ -48,6 +47,7 @@ use Friendica\Model\FileTag;
 use Friendica\Model\Item;
 use Friendica\Model\Notify\Type;
 use Friendica\Model\Photo;
+use Friendica\Model\Post;
 use Friendica\Model\Tag;
 use Friendica\Network\HTTPException;
 use Friendica\Object\EMail\ItemCCEMail;
@@ -55,7 +55,6 @@ use Friendica\Protocol\Activity;
 use Friendica\Protocol\Diaspora;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Security\Security;
-use Friendica\Util\Strings;
 use Friendica\Worker\Delivery;
 
 function item_post(App $a) {
@@ -532,9 +531,8 @@ function item_post(App $a) {
 				if (strlen($attachments)) {
 					$attachments .= ',';
 				}
-				$attachments .= '[attach]href="' . DI::baseUrl() . '/attach/' . $attachment['id'] .
-						'" length="' . $attachment['filesize'] . '" type="' . $attachment['filetype'] .
-						'" title="' . ($attachment['filename'] ? $attachment['filename'] : '') . '"[/attach]';
+				$attachments .= Post\Media::getAttachElement(DI::baseUrl() . '/attach/' . $attachment['id'],
+					$attachment['filesize'], $attachment['filetype'], $attachment['filename'] ?? '');
 			}
 			$body = str_replace($match[1],'',$body);
 		}

--- a/src/DI.php
+++ b/src/DI.php
@@ -240,6 +240,14 @@ abstract class DI
 	}
 
 	/**
+	 * @return Factory\Api\Mastodon\Attachment
+	 */
+	public static function mstdnAttachment()
+	{
+		return self::$dice->create(Factory\Api\Mastodon\Attachment::class);
+	}
+
+	/**
 	 * @return Factory\Api\Mastodon\Emoji
 	 */
 	public static function mstdnEmoji()

--- a/src/Factory/Api/Mastodon/Attachment.php
+++ b/src/Factory/Api/Mastodon/Attachment.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Friendica\Factory\Api\Mastodon;
+
+use Friendica\App\BaseURL;
+use Friendica\BaseFactory;
+use Friendica\Network\HTTPException;
+use Friendica\Model\Post;
+use Friendica\Repository\ProfileField;
+use Friendica\Util\Proxy;
+use Psr\Log\LoggerInterface;
+
+class Attachment extends BaseFactory
+{
+	/** @var BaseURL */
+	protected $baseUrl;
+	/** @var ProfileField */
+	protected $profileField;
+	/** @var Field */
+	protected $mstdnField;
+
+	public function __construct(LoggerInterface $logger, BaseURL $baseURL, ProfileField $profileField, Field $mstdnField)
+	{
+		parent::__construct($logger);
+
+		$this->baseUrl = $baseURL;
+		$this->profileField = $profileField;
+		$this->mstdnField = $mstdnField;
+	}
+
+	/**
+	 * @param int $uriId Uri-ID of the attachments
+	 * @return array
+	 * @throws HTTPException\InternalServerErrorException
+	 * @throws \ImagickException
+	 */
+	public function createFromUriId(int $uriId)
+	{
+		$attachments = [];
+		foreach (Post\Media::getByURIId($uriId) as $attachment) {
+
+			$filetype = !empty($attachment['mimetype']) ? strtolower(substr($attachment['mimetype'], 0, strpos($attachment['mimetype'], '/'))) : '';
+
+			if (($filetype == 'audio') || ($attachment['type'] == Post\Media::AUDIO)) {
+				$type = 'audio';
+			} elseif (($filetype == 'video') || ($attachment['type'] == Post\Media::VIDEO)) {
+				$type = 'video';
+			} elseif ($attachment['mimetype'] == 'image/gif') {
+				$type = 'gifv';
+			} elseif (($filetype == 'image') || ($attachment['type'] == Post\Media::IMAGE)) {
+				$type = 'image';
+			} else {
+				$type = 'unknown';
+			}
+
+			$remote = $attachment['url'];
+			if ($type == 'image') {
+				if (Proxy::isLocalImage($attachment['url'])) {
+					$url = $attachment['url'];
+					$preview = $attachment['preview'] ?? $url;
+					$remote = '';
+				} else {
+					$url = Proxy::proxifyUrl($attachment['url']);
+					$preview = Proxy::proxifyUrl($attachment['url'], false, Proxy::SIZE_SMALL);
+				}
+			} else {
+				$url = '';
+				$preview = '';
+			}
+
+			$object = new \Friendica\Object\Api\Mastodon\Attachment($attachment, $type, $url, $preview, $remote);
+			$attachments[] = $object->toArray();
+		}
+
+		return $attachments;
+	}
+}

--- a/src/Factory/Api/Mastodon/Status.php
+++ b/src/Factory/Api/Mastodon/Status.php
@@ -82,9 +82,11 @@ class Status extends BaseFactory
 		$mentions = DI::mstdnMention()->createFromUriId($uriId);
 		$tags = DI::mstdnTag()->createFromUriId($uriId);
 
-		$attachment = BBCode::getAttachmentData($item['body']);
-		$card = new \Friendica\Object\Api\Mastodon\Card($attachment);
+		$data = BBCode::getAttachmentData($item['body']);
+		$card = new \Friendica\Object\Api\Mastodon\Card($data);
 
-		return new \Friendica\Object\Api\Mastodon\Status($item, $account, $counts, $userAttributes, $sensitive, $application, $mentions, $tags, $card);
+		$attachments = DI::mstdnAttachment()->createFromUriId($uriId);
+
+		return new \Friendica\Object\Api\Mastodon\Status($item, $account, $counts, $userAttributes, $sensitive, $application, $mentions, $tags, $card, $attachments);
 	}
 }

--- a/src/Model/Post/Media.php
+++ b/src/Model/Post/Media.php
@@ -82,7 +82,7 @@ class Media
 			$result = DBA::insert('post-media', $media, true);
 			Logger::info('Updated media', ['result' => $result, 'media' => $media]);
 		} else {
-			Logger::info('Norhing to update', ['media' => $media]);
+			Logger::info('Nothing to update', ['media' => $media]);
 		}
 	}
 

--- a/src/Model/Post/Media.php
+++ b/src/Model/Post/Media.php
@@ -258,4 +258,16 @@ class Media
 			self::insert($media);
 		}
 	}
+
+	/**
+	 * Retrieves the media attachments associated with the provided item ID.
+	 *
+	 * @param int $uri_id
+	 * @return array
+	 * @throws \Exception
+	 */
+	public static function getByURIId(int $uri_id)
+	{
+		return DBA::selectToArray('post-media', [], ['uri-id' => $uri_id]);
+	}
 }

--- a/src/Object/Api/Mastodon/Attachment.php
+++ b/src/Object/Api/Mastodon/Attachment.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Friendica\Object\Api\Mastodon;
+
+use Friendica\BaseEntity;
+
+/**
+ * Class Attachment
+ *
+ * @see https://docs.joinmastodon.org/entities/attachment
+ */
+class Attachment extends BaseEntity
+{
+	/** @var string */
+	protected $id;
+	/** @var string */
+	protected $type;
+	/** @var string */
+	protected $url;
+	/** @var string */
+	protected $preview_url;
+	/** @var string */
+	protected $remote_url;
+	/** @var string */
+	protected $text_url;
+	/** @var string */
+	protected $description;
+
+	/**
+	 * Creates an attachment
+	 *
+	 * @param array $attachment
+	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
+	 */
+	public function __construct(array $attachment, string $type, string $url, string $preview, string $remote)
+	{
+		$this->id = (string)$attachment['id'];
+		$this->type = $type;
+		$this->url = $url;
+		$this->preview_url = $preview;
+		$this->remote_url = $remote;
+		$this->text_url = $this->remote_url ?? $this->url;
+		$this->description = $attachment['description'];
+	}
+
+	/**
+	 * Returns the current entity as an array
+	 *
+	 * @return array
+	 */
+	public function toArray()
+	{
+		$attachment = parent::toArray();
+
+		if (empty($attachment['remote_url'])) {
+			$attachment['remote_url'] = null;
+		}
+
+		return $attachment;
+	}
+}

--- a/src/Object/Api/Mastodon/Status.php
+++ b/src/Object/Api/Mastodon/Status.php
@@ -97,7 +97,7 @@ class Status extends BaseEntity
 	 * @param array   $item
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
-	public function __construct(array $item, Account $account, Counts $counts, UserAttributes $userAttributes, bool $sensitive, Application $application, array $mentions, array $tags, Card $card)
+	public function __construct(array $item, Account $account, Counts $counts, UserAttributes $userAttributes, bool $sensitive, Application $application, array $mentions, array $tags, Card $card, array $attachments)
 	{
 		$this->id         = (string)$item['uri-id'];
 		$this->created_at = DateTimeFormat::utc($item['created'], DateTimeFormat::ATOM);
@@ -130,7 +130,7 @@ class Status extends BaseEntity
 		$this->reblog = null; /// @todo
 		$this->application = $application->toArray();
 		$this->account = $account->toArray();
-		$this->media_attachments = []; /// @todo
+		$this->media_attachments = $attachments;
 		$this->mentions = $mentions;
 		$this->tags = $tags;
 		$this->emojis = [];

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -196,7 +196,8 @@ class Processor
 							$item['attach'] = '';
 						}
 
-						$item['attach'] .= '[attach]href="' . $attach['url'] . '" length="' . ($attach['length'] ?? '0') . '" type="' . $attach['mediaType'] . '" title="' . ($attach['name'] ?? '') . '"[/attach]';
+						$item['attach'] .= Post\Media::getAttachElement($attach['url'],
+							$attach['length'] ?? 0, $attach['mediaType'], $attach['name'] ?? '');
 					}
 			}
 		}

--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -39,6 +39,7 @@ use Friendica\Model\ItemURI;
 use Friendica\Model\Mail;
 use Friendica\Model\Notify\Type;
 use Friendica\Model\PermissionSet;
+use Friendica\Model\Post;
 use Friendica\Model\Post\Category;
 use Friendica\Model\Profile;
 use Friendica\Model\Tag;
@@ -2176,7 +2177,7 @@ class DFRN
 							$item["attach"] = "";
 						}
 
-						$item["attach"] .= '[attach]href="' . $href . '" length="' . $length . '" type="' . $type . '" title="' . $title . '"[/attach]';
+						$item["attach"] .= Post\Media::getAttachElement($href, $length, $type, $title);
 						break;
 				}
 			}

--- a/src/Protocol/Feed.php
+++ b/src/Protocol/Feed.php
@@ -33,6 +33,7 @@ use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Contact;
 use Friendica\Model\Item;
+use Friendica\Model\Post;
 use Friendica\Model\Tag;
 use Friendica\Model\User;
 use Friendica\Util\DateTimeFormat;
@@ -457,7 +458,7 @@ class Feed
 
 				$attachments[] = ["link" => $href, "type" => $type, "length" => $length];
 
-				$item["attach"] .= '[attach]href="' . $href . '" length="' . $length . '" type="' . $type . '"[/attach]';
+				$item["attach"] .= Post\Media::getAttachElement($href, $length, $type);
 			}
 
 			$taglist = [];

--- a/src/Protocol/OStatus.php
+++ b/src/Protocol/OStatus.php
@@ -36,6 +36,7 @@ use Friendica\Model\Contact;
 use Friendica\Model\Conversation;
 use Friendica\Model\Item;
 use Friendica\Model\ItemURI;
+use Friendica\Model\Post;
 use Friendica\Model\Tag;
 use Friendica\Model\User;
 use Friendica\Network\Probe;
@@ -1126,7 +1127,8 @@ class OStatus
 							if (!isset($attribute['length'])) {
 								$attribute['length'] = "0";
 							}
-							$item["attach"] .= '[attach]href="'.$attribute['href'].'" length="'.$attribute['length'].'" type="'.$attribute['type'].'" title="'.($attribute['title'] ?? '') .'"[/attach]';
+							$item["attach"] .= Post\Media::getAttachElement($attribute['href'],
+								$attribute['length'], $attribute['type'], $attribute['title'] ?? '');
 						}
 						break;
 					case "related":


### PR DESCRIPTION
We now store the content of the `attach` field in the `post-media` table as well.