### PR TITLE
Fix fatal error 

### DIFF
--- a/src/Protocol/Feed.php
+++ b/src/Protocol/Feed.php
@@ -437,14 +437,14 @@ class Feed
 			$enclosures = $xpath->query("enclosure|atom:link[@rel='enclosure']", $entry);
 			foreach ($enclosures AS $enclosure) {
 				$href = "";
-				$length = "";
+				$length = 0;
 				$type = "";
 
 				foreach ($enclosure->attributes AS $attribute) {
 					if (in_array($attribute->name, ["url", "href"])) {
 						$href = $attribute->textContent;
 					} elseif ($attribute->name == "length") {
-						$length = $attribute->textContent;
+						$length = (int)$attribute->textContent;
 					} elseif ($attribute->name == "type") {
 						$type = $attribute->textContent;
 					}


### PR DESCRIPTION
This fixes `Argument 2 passed to Friendica\Model\Post\Media::getAttachElement() must be of the type int, string given`
See https://github.com/friendica/friendica/issues/9250#issuecomment-720547558