### PR TITLE
Fix: Posts sent to forums had been rejected

### DIFF
--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -462,14 +462,12 @@ class Transmitter
 		}
 
 		$always_bcc = false;
-		$isforum = false;
 
 		// Check if we should always deliver our stuff via BCC
 		if (!empty($item['uid'])) {
 			$profile = User::getOwnerDataById($item['uid']);
 			if (!empty($profile)) {
 				$always_bcc = $profile['hide-friends'];
-				$isforum = $profile['account-type'] == User::ACCOUNT_TYPE_COMMUNITY;
 			}
 		}
 
@@ -477,7 +475,7 @@ class Transmitter
 			$always_bcc = true;
 		}
 
-		if ((self::isAnnounce($item) && !$isforum) || DI::config()->get('debug', 'total_ap_delivery')) {
+		if (self::isAnnounce($item) || DI::config()->get('debug', 'total_ap_delivery')) {
 			// Will be activated in a later step
 			$networks = Protocol::FEDERATED;
 		} else {
@@ -531,10 +529,6 @@ class Transmitter
 						continue;
 					}
 
-					if ($isforum && DBA::isResult($contact) && ($contact['dfrn'] == Protocol::DFRN)) {
-						continue;
-					}
-
 					if (!empty($profile = APContact::getByURL($contact['url'], false))) {
 						$data['to'][] = $profile['url'];
 					}
@@ -544,10 +538,6 @@ class Transmitter
 			foreach ($receiver_list as $receiver) {
 				$contact = DBA::selectFirst('contact', ['url', 'hidden', 'network', 'protocol'], ['id' => $receiver]);
 				if (!DBA::isResult($contact) || (!in_array($contact['network'], $networks) && ($contact['protocol'] != Protocol::ACTIVITYPUB))) {
-					continue;
-				}
-
-				if ($isforum && DBA::isResult($contact) && ($contact['dfrn'] == Protocol::DFRN)) {
 					continue;
 				}
 

--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -1500,15 +1500,20 @@ class DFRN
 
 		$fields = ['id', 'uid', 'url', 'network', 'avatar-date', 'avatar', 'name-date', 'uri-date', 'addr',
 			'name', 'nick', 'about', 'location', 'keywords', 'xmpp', 'bdyear', 'bd', 'hidden', 'contact-type'];
-		$condition = ["`uid` = ? AND `nurl` = ? AND `network` != ? AND NOT `pending` AND NOT `blocked` AND `rel` IN (?, ?)",
-			$importer["importer_uid"], Strings::normaliseLink($author["link"]), Protocol::STATUSNET,
-			Contact::SHARING, Contact::FRIEND];
+		$condition = ["`uid` = ? AND `nurl` = ? AND `network` != ? AND NOT `pending` AND NOT `blocked`",
+			$importer["importer_uid"], Strings::normaliseLink($author["link"]), Protocol::STATUSNET];
+
+		if ($importer['account-type'] != User::ACCOUNT_TYPE_COMMUNITY) {
+			$condition = DBA::mergeConditions($condition, ['rel' => [Contact::SHARING, Contact::FRIEND]]);
+		}
+
 		$contact_old = DBA::selectFirst('contact', $fields, $condition);
 
 		if (DBA::isResult($contact_old)) {
 			$author["contact-id"] = $contact_old["id"];
 			$author["network"] = $contact_old["network"];
 		} else {
+			Logger::info('Blubb', ['condition' => $condition]);
 			if (!$onlyfetch) {
 				Logger::debug("Contact ".$author["link"]." wasn't found for user ".$importer["importer_uid"]." XML: ".$xml);
 			}

--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -1513,10 +1513,7 @@ class DFRN
 			$author["contact-id"] = $contact_old["id"];
 			$author["network"] = $contact_old["network"];
 		} else {
-			Logger::info('Blubb', ['condition' => $condition]);
-			if (!$onlyfetch) {
-				Logger::debug("Contact ".$author["link"]." wasn't found for user ".$importer["importer_uid"]." XML: ".$xml);
-			}
+			Logger::info('Contact not found', ['condition' => $condition]);
 
 			$author["contact-unknown"] = true;
 			$contact = Contact::getByURL($author["link"], null, ["id", "network"]);


### PR DESCRIPTION
This fixes a problem when posts that had been sent to a forum hadn't been redistributed. This - for example - touches the problem for local forums that hadn't really worked for local users.

Also this enables the forums to use AP to send posts to Friendica users.