### PR TITLE
Handle fatal error when attachment url is null

### DIFF
--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -189,7 +189,7 @@ class Processor
 						}
 
 						$item['body'] .= "\n[video]" . $attach['url'] . '[/video]';
-					} else {
+					} elseif (!empty($attach['url'])) {
 						if (!empty($item['attach'])) {
 							$item['attach'] .= ',';
 						} else {
@@ -202,6 +202,8 @@ class Processor
 							$attach['mediaType'] ?? '',
 							$attach['name'] ?? ''
 						);
+					} else {
+						Logger::notice('Unknown attachment', ['attach' => $attach]);
 					}
 			}
 		}


### PR DESCRIPTION
This fixes this problem:
`PHP Fatal error:  Uncaught TypeError: Argument 1 passed to Friendica\Model\Post\Media::getAttachElement() must be of the type string, null given`