### PR TITLE
Fixed: Module\Contact is sometimes used, sometimes only Contact.

### DIFF
--- a/src/Module/Directory.php
+++ b/src/Module/Directory.php
@@ -85,7 +85,7 @@ class Directory extends BaseModule
 			foreach ($profiles['entries'] as $entry) {
 				$contact = Model\Contact::getByURLForUser($entry['url'], local_user());
 				if (!empty($contact)) {
-					$entries[] = Contact::getContactTemplateVars($contact);
+					$entries[] = Model\Contact::getContactTemplateVars($contact);
 				}
 			}
 		}


### PR DESCRIPTION
Module\Contact is sometimes used, sometimes only Contact. This needs to be more consitent over the whole code base.