### PR TITLE
[dbstructure 1373] Replace contact.blocked with user.blocked in owner-view

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -1574,7 +1574,7 @@ CREATE VIEW `owner-view` AS SELECT
 	`contact`.`term-date` AS `term-date`,
 	`contact`.`last-item` AS `last-item`,
 	`contact`.`priority` AS `priority`,
-	`contact`.`blocked` AS `blocked`,
+	`user`.`blocked` AS `blocked`,
 	`contact`.`block_reason` AS `block_reason`,
 	`contact`.`readonly` AS `readonly`,
 	`contact`.`writable` AS `writable`,

--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -54,7 +54,7 @@
 use Friendica\Database\DBA;
 
 if (!defined('DB_UPDATE_VERSION')) {
-	define('DB_UPDATE_VERSION', 1372);
+	define('DB_UPDATE_VERSION', 1373);
 }
 
 return [

--- a/static/dbview.config.php
+++ b/static/dbview.config.php
@@ -181,7 +181,7 @@ return [
 			"term-date" => ["contact", "term-date"],
 			"last-item" => ["contact", "last-item"],
 			"priority" => ["contact", "priority"],
-			"blocked" => ["contact", "blocked"], /// @todo Check if "blocked" from contact or from the users table
+			"blocked" => ["user", "blocked"],
 			"block_reason" => ["contact", "block_reason"],
 			"readonly" => ["contact", "readonly"],
 			"writable" => ["contact", "writable"],


### PR DESCRIPTION
Fixes #9326 

- It was falsely reporting blocked users as unblocked since we don't block the public self contact

Fortunately, the `owner-view` view isn't used much through the modules yet so the privacy impact has been low.