### PR TITLE
Make the tests work again with PHP 7.2

### DIFF
--- a/tests/functional/DependencyCheckTest.php
+++ b/tests/functional/DependencyCheckTest.php
@@ -136,6 +136,9 @@ class DependencyCheckTest extends TestCase
 
 	public function testAppMode()
 	{
+		$configCache = $this->dice->create(Cache::class);
+		$configCache->set('database', 'disable_pdo', true);
+
 		/** @var App\Mode $mode */
 		$mode = $this->dice->create(App\Mode::class);
 

--- a/tests/functional/DependencyCheckTest.php
+++ b/tests/functional/DependencyCheckTest.php
@@ -79,6 +79,7 @@ class DependencyCheckTest extends TestCase
 		self::assertInstanceOf(ConfigFileLoader::class, $configFileLoader);
 
 		$configCache = new Cache();
+		$configCache->set('database', 'disable_pdo', true);
 		$configFileLoader->setupCache($configCache);
 
 		self::assertNotEmpty($configCache->getAll());
@@ -123,8 +124,8 @@ class DependencyCheckTest extends TestCase
 		self::assertNotNull($database->getConnection(), 'There is no database connection');
 
 		$result = $database->p("SELECT 1");
-		self::assertEquals($database->errorMessage(), '', 'There had been a database error message');
-		self::assertEquals($database->errorNo(), 0, 'There had been a database error number');
+		self::assertEquals('', $database->errorMessage(), 'There had been a database error message');
+		self::assertEquals(0, $database->errorNo(), 'There had been a database error number');
 
 		self::assertTrue($database->connected(), 'The database is not connected');
 	}

--- a/tests/functional/DependencyCheckTest.php
+++ b/tests/functional/DependencyCheckTest.php
@@ -79,7 +79,6 @@ class DependencyCheckTest extends TestCase
 		self::assertInstanceOf(ConfigFileLoader::class, $configFileLoader);
 
 		$configCache = new Cache();
-		$configCache->set('database', 'disable_pdo', true);
 		$configFileLoader->setupCache($configCache);
 
 		self::assertNotEmpty($configCache->getAll());
@@ -116,11 +115,16 @@ class DependencyCheckTest extends TestCase
 
 	public function testDatabase()
 	{
+		$configCache = $this->dice->create(Cache::class);
+		$configCache->set('database', 'disable_pdo', true);
+
 		/** @var Database $database */
 		$database = $this->dice->create(Database::class);
 
+		$database->setTestmode(true);
+
 		self::assertInstanceOf(Database::class, $database);
-		self::assertContains($database->getDriver(), [Database::PDO, Database::MYSQLI], 'The driver returns an unexpected value');
+		self::assertContains($database->getDriver(), [Database::MYSQLI], 'The driver returns an unexpected value');
 		self::assertNotNull($database->getConnection(), 'There is no database connection');
 
 		$result = $database->p("SELECT 1");


### PR DESCRIPTION
This PR includes stuff to make the tests running again with PHP 7.2 by deactivating PDO.