### PR TITLE
API: Not implemented stuff should return 404

### DIFF
--- a/include/api.php
+++ b/include/api.php
@@ -386,7 +386,7 @@ function api_call(App $a, App\Arguments $args = null)
 		}
 
 		Logger::warning(API_LOG_PREFIX . 'not implemented', ['module' => 'api', 'action' => 'call', 'query' => DI::args()->getQueryString()]);
-		throw new NotImplementedException();
+		throw new NotFoundException();
 	} catch (HTTPException $e) {
 		header("HTTP/1.1 {$e->getCode()} {$e->httpdesc}");
 		return api_error($type, $e, $args);

--- a/tests/legacy/ApiTest.php
+++ b/tests/legacy/ApiTest.php
@@ -500,7 +500,7 @@ class ApiTest extends FixtureTest
 	public function testApiCallWithUninplementedApi()
 	{
 		self::assertEquals(
-			'{"status":{"error":"Not Implemented","code":"501 Not Implemented","request":""}}',
+			'{"status":{"error":"Not Found","code":"404 Not Found","request":""}}',
 			api_call($this->app)
 		);
 	}


### PR DESCRIPTION
This makes our API more compatible. At most we should return `NotImplementedException` only for known endpoints that aren't implemented.