### PR TITLE
Check for empty body to prevent a fatal error

### DIFF
--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -2479,12 +2479,15 @@ class Item
 	 */
 	private static function getLanguage(array $item)
 	{
-		if (!in_array($item['gravity'], [GRAVITY_PARENT, GRAVITY_COMMENT])) {
+		if (!in_array($item['gravity'], [GRAVITY_PARENT, GRAVITY_COMMENT]) || empty($item['body'])) {
 			return '';
 		}
 
 		// Convert attachments to links
 		$naked_body = BBCode::removeAttachment($item['body']);
+		if (empty($naked_body)) {
+			return '';
+		}
 
 		// Remove links and pictures
 		$naked_body = BBCode::removeLinks($naked_body);


### PR DESCRIPTION
This fixes:
`
HP Fatal error:  Uncaught TypeError: Argument 1 passed to Friendica\Content\Text\BBCode::removeLinks() must be of the type string, null given, called in /src/Model/Item.php on line 2490 and defined in /src/Content/Text/BBCode.php:1235
`