### PR TITLE
Prevent image descriptions from being replaced by local smilies

### DIFF
--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -1699,7 +1699,9 @@ class BBCode
 
 				// Replace non graphical smilies for external posts
 				if (!$nosmile && !$for_plaintext) {
-					$text = Smilies::replace($text);
+					$text = self::performWithEscapedTags($text, ['img'], function ($text) {
+						return Smilies::replace($text);
+					});
 				}
 
 				if (!$for_plaintext && DI::config()->get('system', 'big_emojis') && ($simple_html != self::DIASPORA)) {


### PR DESCRIPTION
- AP-received emojis have their code in the image description