### PR TITLE
Fallback to database lock if locking fails

### DIFF
--- a/src/Factory/LockFactory.php
+++ b/src/Factory/LockFactory.php
@@ -122,7 +122,7 @@ class LockFactory
 			try {
 				return new Lock\SemaphoreLock();
 			} catch (\Exception $exception) {
-				$this->logger->debug('Using Semaphore driver for locking failed.', ['exception' => $exception]);
+				$this->logger->warning('Using Semaphore driver for locking failed.', ['exception' => $exception]);
 			}
 		}
 
@@ -135,7 +135,7 @@ class LockFactory
 					return new Lock\CacheLock($cache);
 				}
 			} catch (\Exception $exception) {
-				$this->logger->debug('Using Cache driver for locking failed.', ['exception' => $exception]);
+				$this->logger->warning('Using Cache driver for locking failed.', ['exception' => $exception]);
 			}
 		}
 


### PR DESCRIPTION
Sometimes there seems to be temporary issues with the locking class. This happens on squeet.me, but seems to happen to other systems as well, see this (German) thread: https://forum.friendi.ca/display/0b6b25a8-185f-b2b5-8930-c63756698055

So now we will perform a regular table lock as fallback.