### PR TITLE
Make Model\User::getAuthenticationInfo accessible to addons

### DIFF
--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -559,7 +559,7 @@ class User
 	 * @return array
 	 * @throws HTTPException\NotFoundException
 	 */
-	private static function getAuthenticationInfo($user_info)
+	public static function getAuthenticationInfo($user_info)
 	{
 		$user = null;
 


### PR DESCRIPTION
Related to https://github.com/friendica/friendica/issues/4140

- It contains the centralized authentication requirements for user records

Necessary for https://github.com/friendica/friendica-addons/pull/1043