### PR TITLE
Mode switch for insert

### DIFF
--- a/src/Content/OEmbed.php
+++ b/src/Content/OEmbed.php
@@ -29,6 +29,7 @@ use Exception;
 use Friendica\Core\Cache\Duration;
 use Friendica\Core\Hook;
 use Friendica\Core\Renderer;
+use Friendica\Database\Database;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Util\DateTimeFormat;
@@ -131,7 +132,7 @@ class OEmbed
 					'maxwidth' => $a->videowidth,
 					'content' => $json_string,
 					'created' => DateTimeFormat::utcNow()
-				], true);
+				], Database::INSERT_UPDATE);
 				$cache_ttl = Duration::DAY;
 			} else {
 				$cache_ttl = Duration::FIVE_MINUTES;

--- a/src/Database/DBA.php
+++ b/src/Database/DBA.php
@@ -290,16 +290,16 @@ class DBA
 	/**
 	 * Insert a row into a table
 	 *
-	 * @param string|array $table               Table name or array [schema => table]
-	 * @param array        $param               parameter array
-	 * @param bool         $on_duplicate_update Do an update on a duplicate entry
+	 * @param string|array $table          Table name or array [schema => table]
+	 * @param array        $param          parameter array
+	 * @param int          $duplicate_mode What to do on a duplicated entry
 	 *
 	 * @return boolean was the insert successful?
 	 * @throws \Exception
 	 */
-	public static function insert($table, $param, $on_duplicate_update = false)
+	public static function insert($table, array $param, int $duplicate_mode = Database::INSERT_DEFAULT)
 	{
-		return DI::dba()->insert($table, $param, $on_duplicate_update);
+		return DI::dba()->insert($table, $param, $duplicate_mode);
 	}
 
 	/**

--- a/src/Database/DBStructure.php
+++ b/src/Database/DBStructure.php
@@ -1050,7 +1050,7 @@ class DBStructure
 	{
 		if (self::existsTable('verb') && !DBA::exists('verb', ['id' => 1])) {
 			foreach (Item::ACTIVITIES as $index => $activity) {
-				DBA::insert('verb', ['id' => $index + 1, 'name' => $activity], true);
+				DBA::insert('verb', ['id' => $index + 1, 'name' => $activity], Database::INSERT_IGNORE);
 			}
 		}
 

--- a/src/Database/PostUpdate.php
+++ b/src/Database/PostUpdate.php
@@ -736,7 +736,7 @@ class PostUpdate
 		while ($delivery = DBA::fetch($deliveries)) {
 			$id = $delivery['iid'];
 			unset($delivery['iid']);
-			DBA::insert('post-delivery-data', $delivery, true);
+			DBA::insert('post-delivery-data', $delivery, Database::INSERT_UPDATE);
 			++$rows;
 		}
 		DBA::close($deliveries);

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -31,6 +31,7 @@ use Friendica\Core\Renderer;
 use Friendica\Core\Session;
 use Friendica\Core\System;
 use Friendica\Core\Worker;
+use Friendica\Database\Database;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Notify\Type;
@@ -168,13 +169,13 @@ class Contact
 	 * Insert a row into the contact table
 	 * Important: You can't use DBA::lastInsertId() after this call since it will be set to 0.
 	 *
-	 * @param array        $fields              field array
-	 * @param bool         $on_duplicate_update Do an update on a duplicate entry
+	 * @param array $fields         field array
+	 * @param int   $duplicate_mode Do an update on a duplicate entry
 	 *
 	 * @return boolean was the insert successful?
 	 * @throws \Exception
 	 */
-	public static function insert(array $fields, bool $on_duplicate_update = false)
+	public static function insert(array $fields, int $duplicate_mode = Database::INSERT_DEFAULT)
 	{
 		if (!empty($fields['baseurl']) && empty($fields['gsid'])) {
 			$fields['gsid'] = GServer::getID($fields['baseurl'], true);
@@ -184,7 +185,7 @@ class Contact
 			$fields['created'] = DateTimeFormat::utcNow();
 		}
 
-		$ret = DBA::insert('contact', $fields, $on_duplicate_update);
+		$ret = DBA::insert('contact', $fields, $duplicate_mode);
 		$contact = DBA::selectFirst('contact', ['nurl', 'uid'], ['id' => DBA::lastInsertId()]);
 		if (!DBA::isResult($contact)) {
 			// Shouldn't happen

--- a/src/Model/Conversation.php
+++ b/src/Model/Conversation.php
@@ -23,6 +23,7 @@ namespace Friendica\Model;
 
 use Friendica\Core\Logger;
 use Friendica\Core\Protocol;
+use Friendica\Database\Database;
 use Friendica\Database\DBA;
 use Friendica\Util\DateTimeFormat;
 
@@ -124,7 +125,7 @@ class Conversation
 						Logger::DEBUG);
 				}
 			} else {
-				if (!DBA::insert('conversation', $conversation, true)) {
+				if (!DBA::insert('conversation', $conversation, Database::INSERT_UPDATE)) {
 					Logger::log('Conversation: insert for ' . $conversation['item-uri'] . ' (protocol ' . $conversation['protocol'] . ') failed',
 						Logger::DEBUG);
 				}

--- a/src/Model/GServer.php
+++ b/src/Model/GServer.php
@@ -27,6 +27,7 @@ use Friendica\Core\Logger;
 use Friendica\Core\Protocol;
 use Friendica\Core\System;
 use Friendica\Core\Worker;
+use Friendica\Database\Database;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Module\Register;
@@ -541,7 +542,7 @@ class GServer
 			}
 
 			foreach ($tags as $tag) {
-				DBA::insert('gserver-tag', ['gserver-id' => $gserver['id'], 'tag' => $tag], true);
+				DBA::insert('gserver-tag', ['gserver-id' => $gserver['id'], 'tag' => $tag], Database::INSERT_IGNORE);
 			}
 		}
 

--- a/src/Model/ItemURI.php
+++ b/src/Model/ItemURI.php
@@ -21,6 +21,7 @@
 
 namespace Friendica\Model;
 
+use Friendica\Database\Database;
 use Friendica\Database\DBA;
 
 class ItemURI
@@ -39,7 +40,7 @@ class ItemURI
 		$uri = substr($fields['uri'], 0, 255);
 
 		if (!DBA::exists('item-uri', ['uri' => $uri])) {
-			DBA::insert('item-uri', $fields, true);
+			DBA::insert('item-uri', $fields, Database::INSERT_UPDATE);
 		}
 
 		$itemuri = DBA::selectFirst('item-uri', ['id', 'guid'], ['uri' => $uri]);

--- a/src/Model/Post/Media.php
+++ b/src/Model/Post/Media.php
@@ -23,6 +23,7 @@ namespace Friendica\Model\Post;
 
 use Friendica\Core\Logger;
 use Friendica\Core\System;
+use Friendica\Database\Database;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Util\Images;
@@ -72,14 +73,14 @@ class Media
 
 		// We are storing as fast as possible to avoid duplicated network requests
 		// when fetching additional information for pictures and other content.
-		$result = DBA::insert('post-media', $media, true);
+		$result = DBA::insert('post-media', $media, Database::INSERT_UPDATE);
 		Logger::info('Stored media', ['result' => $result, 'media' => $media, 'callstack' => System::callstack()]);
 		$stored = $media;
 
 		$media = self::fetchAdditionalData($media);
 
 		if (array_diff_assoc($media, $stored)) {
-			$result = DBA::insert('post-media', $media, true);
+			$result = DBA::insert('post-media', $media, Database::INSERT_UPDATE);
 			Logger::info('Updated media', ['result' => $result, 'media' => $media]);
 		} else {
 			Logger::info('Nothing to update', ['media' => $media]);

--- a/src/Model/Post/User.php
+++ b/src/Model/Post/User.php
@@ -23,7 +23,7 @@ namespace Friendica\Model\Post;
 
 use Friendica\Database\DBA;
 use \BadMethodCallException;
-use Friendica\Core\Logger;
+use Friendica\Database\Database;
 use Friendica\Database\DBStructure;
 
 class User
@@ -58,7 +58,7 @@ class User
 			$fields['unseen'] = false;
 		}
 
-		return DBA::insert('post-user', $fields);
+		return DBA::insert('post-user', $fields, Database::INSERT_IGNORE);
 	}
 
 	/**

--- a/src/Model/Tag.php
+++ b/src/Model/Tag.php
@@ -25,6 +25,7 @@ use Friendica\Content\Text\BBCode;
 use Friendica\Core\Cache\Duration;
 use Friendica\Core\Logger;
 use Friendica\Core\System;
+use Friendica\Database\Database;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Util\Strings;
@@ -151,7 +152,7 @@ class Tag
 			}
 		}
 
-		DBA::insert('post-tag', $fields, true);
+		DBA::insert('post-tag', $fields, Database::INSERT_IGNORE);
 
 		Logger::info('Stored tag/mention', ['uri-id' => $uriid, 'tag-id' => $tagid, 'contact-id' => $cid, 'name' => $name, 'type' => $type, 'callstack' => System::callstack(8)]);
 	}
@@ -172,7 +173,7 @@ class Tag
 			return $tag['id'];
 		}
 
-		DBA::insert('tag', $fields, true);
+		DBA::insert('tag', $fields, Database::INSERT_IGNORE);
 		$tid = DBA::lastInsertId();
 		if (!empty($tid)) {
 			return $tid;

--- a/src/Model/Verb.php
+++ b/src/Model/Verb.php
@@ -21,6 +21,7 @@
 
 namespace Friendica\Model;
 
+use Friendica\Database\Database;
 use Friendica\Database\DBA;
 
 class Verb
@@ -44,7 +45,7 @@ class Verb
 			return $verb_record['id'];
 		}
 
-		DBA::insert('verb', ['name' => $verb], true);
+		DBA::insert('verb', ['name' => $verb], Database::INSERT_IGNORE);
 
 		return DBA::lastInsertId();
 	}

--- a/src/Util/ParseUrl.php
+++ b/src/Util/ParseUrl.php
@@ -26,6 +26,7 @@ use DOMXPath;
 use Friendica\Content\OEmbed;
 use Friendica\Core\Hook;
 use Friendica\Core\Logger;
+use Friendica\Database\Database;
 use Friendica\Database\DBA;
 use Friendica\DI;
 
@@ -91,7 +92,7 @@ class ParseUrl
 				'oembed' => $do_oembed, 'content' => serialize($data),
 				'created' => DateTimeFormat::utcNow()
 			],
-			true
+			Database::INSERT_UPDATE
 		);
 
 		return $data;

--- a/update.php
+++ b/update.php
@@ -44,6 +44,7 @@ use Friendica\Core\Addon;
 use Friendica\Core\Logger;
 use Friendica\Core\Update;
 use Friendica\Core\Worker;
+use Friendica\Database\Database;
 use Friendica\Database\DBA;
 use Friendica\Database\DBStructure;
 use Friendica\DI;
@@ -429,7 +430,7 @@ function update_1332()
 function update_1347()
 {
 	foreach (Item::ACTIVITIES as $index => $activity) {
-		DBA::insert('verb', ['id' => $index + 1, 'name' => $activity], true);
+		DBA::insert('verb', ['id' => $index + 1, 'name' => $activity], Database::INSERT_IGNORE);
 	}
 
 	return Update::SUCCESS;


### PR DESCRIPTION
Formerly the `insert` command had a boolean switch to toggle between regular insert and "update on duplicate". The boolean switch is now changed into an integer field and also does now a third option: "Ignore".

"ignore" just fails silently, but the return value tells us if a row had been inserted or not.