### PR TITLE
Watchdog mode to check if the daemon is running

### DIFF
--- a/static/defaults.config.php
+++ b/static/defaults.config.php
@@ -191,6 +191,11 @@ return [
 		// A value of 0 disables the deletion process.
 		'dbclean-expire-limit' => 1000,
 
+		// daemon_watchdog (Boolean)
+		// Enable regular checking if the daemon is running.
+		// If it is not running and hadn't been terminated normally, it will be started automatically.
+		'daemon_watchdog' => false,
+
 		// diaspora_test (Boolean)
 		// For development only. Disables the message transfer.
 		'diaspora_test' => false,


### PR DESCRIPTION
When the daemon mode is activated and the watchdog enabled, then it will be automatically restarted when it ended unexpected.