### PR TITLE
Avoid multiple database update mails, changed log level

### DIFF
--- a/src/Core/Update.php
+++ b/src/Core/Update.php
@@ -113,7 +113,7 @@ class Update
 
 				// Compare the current structure with the defined structure
 				// If the Lock is acquired, never release it automatically to avoid double updates
-				if (DI::lock()->acquire('dbupdate', 120, Cache\Duration::INFINITE)) {
+				if (DI::lock()->acquire('dbupdate', 0, Cache\Duration::INFINITE)) {
 
 					Logger::notice('Update starting.', ['from' => $stored, 'to' => $current]);
 

--- a/src/Core/Update.php
+++ b/src/Core/Update.php
@@ -154,8 +154,6 @@ class Update
 						DI::lock()->release('dbupdate');
 						return $retval;
 					} else {
-						DI::config()->set('database', 'last_successful_update', $current);
-						DI::config()->set('database', 'last_successful_update_time', time());
 						Logger::notice('Database structure update finished.', ['from' => $stored, 'to' => $current]);
 					}
 

--- a/src/Module/Admin/DBSync.php
+++ b/src/Module/Admin/DBSync.php
@@ -57,8 +57,6 @@ class DBSync extends BaseAdmin
 				$retval = DBStructure::update($a->getBasePath(), false, true);
 				if ($retval === '') {
 					$o = DI::l10n()->t("Database structure update %s was successfully applied.", DB_UPDATE_VERSION) . "<br />";
-					DI::config()->set('database', 'last_successful_update', DB_UPDATE_VERSION);
-					DI::config()->set('database', 'last_successful_update_time', time());
 				} else {
 					$o = DI::l10n()->t("Executing of database structure update %s failed with error: %s", DB_UPDATE_VERSION, $retval) . "<br />";
 				}


### PR DESCRIPTION
It has been reported for a long time that the mail for a successful database update had been sent multiple times. Also it seems as if the system not always had noted the correct database version so that it seemed as if the database update had failed.

The logging is improved to better detect problems, also the "build" config value is set at a different place. This should help.