### PR TITLE
Fix wrong variable name in ping_init

### DIFF
--- a/mod/ping.php
+++ b/mod/ping.php
@@ -301,7 +301,7 @@ function ping_init(App $a)
 						'seen'    => false,
 						'message' => DI::l10n()->t('{0} requested registration'),
 					];
-					$notifs[] = $notif;
+					$notifications[] = $notif;
 				}
 			} else {
 				$notif = [


### PR DESCRIPTION
Follow-up to #9540
Fixes #9564 

We really don't need bugs of our own making 😓