### PR TITLE
Contacts can now be updated from every theme

### DIFF
--- a/src/Module/Contact.php
+++ b/src/Module/Contact.php
@@ -1139,7 +1139,7 @@ class Contact extends BaseModule
 			];
 		}
 
-		if (in_array($contact['network'], Protocol::FEDERATED)) {
+		if (in_array($contact['network'], Protocol::NATIVE_SUPPORT)) {
 			$contact_actions['updateprofile'] = [
 				'label' => DI::l10n()->t('Refetch contact data'),
 				'url'   => 'contact/' . $contact['id'] . '/updateprofile',

--- a/src/Module/Contact/Advanced.php
+++ b/src/Module/Contact/Advanced.php
@@ -128,8 +128,6 @@ class Advanced extends BaseModule
 			'$info'              => $info,
 			'$returnaddr'        => $returnaddr,
 			'$return'            => DI::l10n()->t('Return to contact editor'),
-			'$update_profile'    => in_array($contact['network'], Protocol::FEDERATED),
-			'$udprofilenow'      => DI::l10n()->t('Refetch contact data'),
 			'$contact_id'        => $contact['id'],
 			'$lbl_submit'        => DI::l10n()->t('Submit'),
 

--- a/view/templates/contact/advanced.tpl
+++ b/view/templates/contact/advanced.tpl
@@ -13,12 +13,6 @@
 
 	<!-- <h4>{{$contact_name}}</h4> -->
 
-	<div id="contact-update-profile-wrapper">
-	{{if $update_profile}}
-		<span id="contact-update-profile-now" class="button"><a href="contact/{{$contact_id}}/updateprofile" >{{$udprofilenow}}</a></span>
-	{{/if}}
-	</div>
-
 	{{include file="field_input.tpl" field=$name}}
 
 	{{include file="field_input.tpl" field=$nick}}

--- a/view/templates/contact_edit.tpl
+++ b/view/templates/contact_edit.tpl
@@ -17,6 +17,7 @@
 						<ul role="menu" aria-haspopup="true" id="contact-actions-menu" class="menu-popup" >
 							{{if $lblsuggest}}<li role="menuitem"><a  href="#" title="{{$contact_actions.suggest.title}}" onclick="window.location.href='{{$contact_actions.suggest.url}}'; return false;">{{$contact_actions.suggest.label}}</a></li>{{/if}}
 							{{if $poll_enabled}}<li role="menuitem"><a  href="#" title="{{$contact_actions.update.title}}" onclick="window.location.href='{{$contact_actions.update.url}}'; return false;">{{$contact_actions.update.label}}</a></li>{{/if}}
+							{{if $contact_actions.updateprofile}}<li role="menuitem"><a href="{{$contact_actions.updateprofile.url}}" title="{{$contact_actions.updateprofile.title}}">{{$contact_actions.updateprofile.label}}</a></li>{{/if}}
 							<li class="divider"></li>
 							<li role="menuitem"><a  href="#" title="{{$contact_actions.block.title}}" onclick="window.location.href='{{$contact_actions.block.url}}'; return false;">{{$contact_actions.block.label}}</a></li>
 							<li role="menuitem"><a  href="#" title="{{$contact_actions.ignore.title}}" onclick="window.location.href='{{$contact_actions.ignore.url}}'; return false;">{{$contact_actions.ignore.label}}</a></li>

--- a/view/theme/frio/templates/contact/advanced.tpl
+++ b/view/theme/frio/templates/contact/advanced.tpl
@@ -15,12 +15,6 @@
 
 		<!-- <h4>{{$contact_name}}</h4> -->
 
-		<div id="contact-update-profile-wrapper">
-		{{if $update_profile}}
-			<span id="contact-update-profile-now" class="button"><a href="contact/{{$contact_id}}/updateprofile" >{{$udprofilenow}}</a></span>
-		{{/if}}
-		</div>
-
 		{{include file="field_input.tpl" field=$name}}
 
 		{{include file="field_input.tpl" field=$nick}}

--- a/view/theme/vier/templates/contact_edit.tpl
+++ b/view/theme/vier/templates/contact_edit.tpl
@@ -18,6 +18,7 @@
 						<ul role="menu" aria-haspopup="true" id="contact-actions-menu" class="menu-popup" >
 							{{if $lblsuggest}}<li role="menuitem"><a  href="#" title="{{$contact_actions.suggest.title}}" onclick="window.location.href='{{$contact_actions.suggest.url}}'; return false;">{{$contact_actions.suggest.label}}</a></li>{{/if}}
 							{{if $poll_enabled}}<li role="menuitem"><a  href="#" title="{{$contact_actions.update.title}}" onclick="window.location.href='{{$contact_actions.update.url}}'; return false;">{{$contact_actions.update.label}}</a></li>{{/if}}
+							{{if $contact_actions.updateprofile}}<li role="menuitem"><a href="{{$contact_actions.updateprofile.url}}" title="{{$contact_actions.updateprofile.title}}">{{$contact_actions.updateprofile.label}}</a></li>{{/if}}
 							<li class="divider"></li>
 							<li role="menuitem"><a  href="#" title="{{$contact_actions.block.title}}" onclick="window.location.href='{{$contact_actions.block.url}}'; return false;">{{$contact_actions.block.label}}</a></li>
 							<li role="menuitem"><a  href="#" title="{{$contact_actions.ignore.title}}" onclick="window.location.href='{{$contact_actions.ignore.url}}'; return false;">{{$contact_actions.ignore.label}}</a></li>


### PR DESCRIPTION
Some time ago the functionality to update contacts had been introduced on the contact page (it previously was available on the "advanced" page). Then the "advanced" page had been made accessible only for feed and mail contacts.

But: It had been forgotten to do so for other themes than Frio. This is now fixed.