### PR TITLE
Don't transmit to archived inboxes

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -1,6 +1,6 @@
 -- ------------------------------------------
 -- Friendica 2020.12-dev (Red Hot Poker)
--- DB_UPDATE_VERSION 1378
+-- DB_UPDATE_VERSION 1379
 -- ------------------------------------------
 
 
@@ -332,6 +332,7 @@ CREATE TABLE IF NOT EXISTS `apcontact` (
 	 INDEX `alias` (`alias`(190)),
 	 INDEX `followers` (`followers`(190)),
 	 INDEX `baseurl` (`baseurl`(190)),
+	 INDEX `sharedinbox` (`sharedinbox`(190)),
 	 INDEX `gsid` (`gsid`),
 	FOREIGN KEY (`gsid`) REFERENCES `gserver` (`id`) ON UPDATE RESTRICT ON DELETE RESTRICT
 ) DEFAULT COLLATE utf8mb4_general_ci COMMENT='ActivityPub compatible contacts - used in the ActivityPub implementation';
@@ -1057,7 +1058,7 @@ CREATE TABLE IF NOT EXISTS `photo` (
 	 INDEX `uid_album_scale_created` (`uid`,`album`(32),`scale`,`created`),
 	 INDEX `uid_album_resource-id_created` (`uid`,`album`(32),`resource-id`,`created`),
 	 INDEX `resource-id` (`resource-id`),
-	FOREIGN KEY (`uid`) REFERENCES `user` (`uid`) ON UPDATE RESTRICT ON DELETE CASCADE,
+	FOREIGN KEY (`uid`) REFERENCES `user` (`uid`) ON UPDATE RESTRICT ON DELETE RESTRICT,
 	FOREIGN KEY (`contact-id`) REFERENCES `contact` (`id`) ON UPDATE RESTRICT ON DELETE RESTRICT
 ) DEFAULT COLLATE utf8mb4_general_ci COMMENT='photo storage';
 

--- a/src/Model/APContact.php
+++ b/src/Model/APContact.php
@@ -366,10 +366,10 @@ class APContact
 		}
 
 		if (!empty($apcontact['sharedinbox'])) {
-			// Check if there are any vital inboxes
-			$vital = DBA::exists('apcontact', ["`sharedinbox` = ? AnD `inbox` IN (SELECT `url` FROM `inbox-status` WHERE `success` > `failure`)",
+			// Check if there are any available inboxes
+			$available = DBA::exists('apcontact', ["`sharedinbox` = ? AnD `inbox` IN (SELECT `url` FROM `inbox-status` WHERE `success` > `failure`)",
 				$apcontact['sharedinbox']]);
-			if (!$vital) {
+			if (!$available) {
 				// If all known personal inboxes are failing then set their shared inbox to failure as well
 				Logger::info('Set shared inbox status to failure', ['sharedinbox' => $apcontact['sharedinbox']]);
 				HTTPSignature::setInboxStatus($apcontact['sharedinbox'], false, true);

--- a/src/Protocol/ActivityPub/Receiver.php
+++ b/src/Protocol/ActivityPub/Receiver.php
@@ -104,6 +104,8 @@ class Receiver
 			return;
 		}
 
+		APContact::unMarkForArchival($apcontact);
+
 		$http_signer = HTTPSignature::getSigner($body, $header);
 		if (empty($http_signer)) {
 			Logger::warning('Invalid HTTP signature, message will be discarded.');
@@ -233,6 +235,7 @@ class Receiver
 
 		$profile = APContact::getByURL($object_id);
 		if (!empty($profile['type'])) {
+			APContact::unMarkForArchival($profile);
 			return 'as:' . $profile['type'];
 		}
 

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -670,7 +670,7 @@ class Transmitter
 	 *
 	 * @return boolean "true" if inbox is archived
 	 */
-	private static function archivedInbox($url)
+	public static function archivedInbox($url)
 	{
 		return DBA::exists('inbox-status', ['url' => $url, 'archive' => true]);
 	}

--- a/src/Util/HTTPSignature.php
+++ b/src/Util/HTTPSignature.php
@@ -314,14 +314,15 @@ class HTTPSignature
 	 *
 	 * @param string  $url     The URL of the inbox
 	 * @param boolean $success Transmission status
+	 * @param boolean $shared  The inbox is a shared inbox
 	 */
-	static private function setInboxStatus($url, $success)
+	static public function setInboxStatus($url, $success, $shared = false)
 	{
 		$now = DateTimeFormat::utcNow();
 
 		$status = DBA::selectFirst('inbox-status', [], ['url' => $url]);
 		if (!DBA::isResult($status)) {
-			DBA::insert('inbox-status', ['url' => $url, 'created' => $now]);
+			DBA::insert('inbox-status', ['url' => $url, 'created' => $now, 'shared' => $shared]);
 			$status = DBA::selectFirst('inbox-status', [], ['url' => $url]);
 		}
 

--- a/src/Worker/Delivery.php
+++ b/src/Worker/Delivery.php
@@ -193,9 +193,9 @@ class Delivery
 			return;
 		}
 
-		// We don't deliver our items to blocked or pending contacts, and not to ourselves either
+		// We don't deliver our items to blocked, archived or pending contacts, and not to ourselves either
 		$contact = DBA::selectFirst('contact', [],
-			['id' => $contact_id, 'blocked' => false, 'pending' => false, 'self' => false]
+			['id' => $contact_id, 'archive' => false, 'blocked' => false, 'pending' => false, 'self' => false]
 		);
 		if (!DBA::isResult($contact)) {
 			self::setFailedQueue($cmd, $target_item);

--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -55,7 +55,7 @@
 use Friendica\Database\DBA;
 
 if (!defined('DB_UPDATE_VERSION')) {
-	define('DB_UPDATE_VERSION', 1378);
+	define('DB_UPDATE_VERSION', 1379);
 }
 
 return [
@@ -395,6 +395,7 @@ return [
 			"alias" => ["alias(190)"],
 			"followers" => ["followers(190)"],
 			"baseurl" => ["baseurl(190)"],
+			"sharedinbox" => ["sharedinbox(190)"],
 			"gsid" => ["gsid"]
 		]
 	],
@@ -1081,7 +1082,7 @@ return [
 		"comment" => "photo storage",
 		"fields" => [
 			"id" => ["type" => "int unsigned", "not null" => "1", "extra" => "auto_increment", "primary" => "1", "comment" => "sequential ID"],
-			"uid" => ["type" => "mediumint unsigned", "not null" => "1", "default" => "0", "foreign" => ["user" => "uid"], "comment" => "Owner User id"],
+			"uid" => ["type" => "mediumint unsigned", "not null" => "1", "default" => "0", "foreign" => ["user" => "uid", "on delete" => "restrict"], "comment" => "Owner User id"],
 			"contact-id" => ["type" => "int unsigned", "not null" => "1", "default" => "0", "foreign" => ["contact" => "id", "on delete" => "restrict"], "comment" => "contact.id"],
 			"guid" => ["type" => "char(16)", "not null" => "1", "default" => "", "comment" => "A unique identifier for this photo"],
 			"resource-id" => ["type" => "char(32)", "not null" => "1", "default" => "", "comment" => ""],


### PR DESCRIPTION
Message delivery to archived contacts/inboxes only decreases the server performance. So we now check before transmitting if the contact or inbox is archived. We already check during the creation of the delivery queue entry. But when a delivery fails the system tries for several days. So it can (and will) happen that an account is archived in the meantime.

Also we now check and set the inbox status at more places to improve the quality of the data.