### PR TITLE
Cast field data when ATTR_EMULATE_PREPARES is enabled

### DIFF
--- a/include/api.php
+++ b/include/api.php
@@ -2164,10 +2164,10 @@ function api_statuses_mentions($type)
 	// get last network messages
 
 	// params
-	$since_id = $_REQUEST['since_id'] ?? 0;
-	$max_id   = $_REQUEST['max_id']   ?? 0;
-	$count    = $_REQUEST['count']    ?? 20;
-	$page     = $_REQUEST['page']     ?? 1;
+	$since_id = intval($_REQUEST['since_id'] ?? 0);
+	$max_id   = intval($_REQUEST['max_id']   ?? 0);
+	$count    = intval($_REQUEST['count']    ?? 20);
+	$page     = intval($_REQUEST['page']     ?? 1);
 
 	$start = max(0, ($page - 1) * $count);
 

--- a/mod/message.php
+++ b/mod/message.php
@@ -385,7 +385,7 @@ function message_content(App $a)
  * @param int $limit
  * @return array
  */
-function get_messages($uid, $start, $limit)
+function get_messages(int $uid, int $start, int $limit)
 {
 	return DBA::toArray(DBA::p('SELECT
 			m.`id`,

--- a/src/Database/DBA.php
+++ b/src/Database/DBA.php
@@ -777,6 +777,18 @@ class DBA
 	}
 
 	/**
+	 * Cast field types according to the table definition
+	 *
+	 * @param string $table
+	 * @param array  $fields
+	 * @return array casted fields
+	 */
+	public static function castFields(string $table, array $fields)
+	{
+		return DI::dba()->castFields($table, $fields);
+	}
+
+	/**
 	 * Returns the error number of the last query
 	 *
 	 * @return string Error number (0 if no error)

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -233,6 +233,8 @@ class Item
 			return $row;
 		}
 
+		$row = DBA::castFields('item', $row);
+
 		// ---------------------- Transform item structure data ----------------------
 
 		// We prefer the data from the user's contact over the public one
@@ -3024,7 +3026,7 @@ class Item
 		return $recipients;
 	}
 
-	public static function expire($uid, $days, $network = "", $force = false)
+	public static function expire(int $uid, int $days, string $network = "", bool $force = false)
 	{
 		if (!$uid || ($days < 1)) {
 			return;

--- a/src/Model/Tag.php
+++ b/src/Model/Tag.php
@@ -517,7 +517,7 @@ class Tag
 	 * @return array
 	 * @throws \Exception
 	 */
-	public static function setGlobalTrendingHashtags(int $period, $limit = 10)
+	public static function setGlobalTrendingHashtags(int $period, int $limit = 10)
 	{
 		$tagsStmt = DBA::p("SELECT `name` AS `term`, COUNT(*) AS `score`
 			FROM `tag-search-view`
@@ -560,7 +560,7 @@ class Tag
 	 * @return array
 	 * @throws \Exception
 	 */
-	public static function setLocalTrendingHashtags(int $period, $limit = 10)
+	public static function setLocalTrendingHashtags(int $period, int $limit = 10)
 	{
 		$tagsStmt = DBA::p("SELECT `name` AS `term`, COUNT(*) AS `score`
 			FROM `tag-search-view`


### PR DESCRIPTION
Due to the usage of views in the recent versions, MySQL possibly needs some tweaking. Otherwise the system fails with "Prepared statement needs to be re-prepared".

This had been covered in the issues https://github.com/friendica/friendica/issues/8550, https://github.com/friendica/friendica/issues/9069 and https://github.com/friendica/friendica/issues/8949

Sometimes users can't change the needed settings. 

To cope with this, we introduced a setting for the `local.config.php` some time ago:

```
	'database' => [
		'hostname' => 'hostname',
...
		'pdo_emulate_prepares' => true,
	],
```

This hadn't really worked well, since this mode has an ugly side effect: fields are always casted as strings.. Now there are some workarounds.