### PR TITLE
New "remote self" option: Native Reshare

### DIFF
--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -139,7 +139,12 @@ class Contact
 	 * @}
 	 */
 
-	/**
+	 const MIRROR_DEACTIVATED = 0;
+	 const MIRROR_FORWARDED = 1;
+	 const MIRROR_OWN_POST = 2;
+	 const MIRROR_NATIVE_RESHARE = 3;
+
+	 /**
 	 * @param array $fields    Array of selected fields, empty for all
 	 * @param array $condition Array of fields for condition
 	 * @param array $params    Array of several parameters

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -2802,6 +2802,10 @@ class Item
 			return;
 		}
 
+		if (!in_array($item['network'], [Protocol::ACTIVITYPUB, Protocol::DFRN])) {
+			return;
+		}
+
 		Logger::info('Automatically reshare item', ['uid' => $item['uid'], 'id' => $item['id'], 'guid' => $item['guid'], 'uri-id' => $item['uri-id']]);
 
 		Item::performActivity($item['id'], 'announce', $item['uid']);

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -1181,7 +1181,7 @@ class Item
 		}
 
 		// Is it our comment and/or our thread?
-		if ($item['origin'] || $parent['origin']) {
+		if (($item['origin'] || $parent['origin']) && ($item['uid'] != 0)) {
 			// When we delete the original post we will delete all existing copies on the server as well
 			self::markForDeletion(['uri' => $item['uri'], 'deleted' => false], $priority);
 
@@ -1978,6 +1978,9 @@ class Item
 
 		// Distribute items to users who subscribed to their tags
 		self::distributeByTags($item);
+
+		// Automatically reshare the item if the "remote_self" option is selected
+		self::autoReshare($item);
 
 		$transmit = $notify || ($item['visible'] && ($parent_origin || $item['origin']));
 
@@ -2783,6 +2786,27 @@ class Item
 		return false;
 	}
 
+	/**
+	 * Automatically reshare the item if the "remote_self" option is selected
+	 *
+	 * @param array $item
+	 * @return void
+	 */
+	private static function autoReshare(array $item)
+	{
+		if ($item['gravity'] != GRAVITY_PARENT) {
+			return;
+		}
+
+		if (!DBA::exists('contact', ['id' => $item['contact-id'], 'remote_self' => Contact::MIRROR_NATIVE_RESHARE])) {
+			return;
+		}
+
+		Logger::info('Automatically reshare item', ['uid' => $item['uid'], 'id' => $item['id'], 'guid' => $item['guid'], 'uri-id' => $item['uri-id']]);
+
+		Item::performActivity($item['id'], 'announce', $item['uid']);
+	}
+
 	public static function isRemoteSelf($contact, &$datarray)
 	{
 		if (!$contact['remote_self']) {
@@ -2814,7 +2838,7 @@ class Item
 
 		$datarray2 = $datarray;
 		Logger::info('remote-self start', ['contact' => $contact['url'], 'remote_self'=> $contact['remote_self'], 'item' => $datarray]);
-		if ($contact['remote_self'] == 2) {
+		if ($contact['remote_self'] == Contact::MIRROR_OWN_POST) {
 			$self = DBA::selectFirst('contact', ['id', 'name', 'url', 'thumb'],
 					['uid' => $contact['uid'], 'self' => true]);
 			if (DBA::isResult($self)) {

--- a/src/Module/Contact.php
+++ b/src/Module/Contact.php
@@ -560,13 +560,23 @@ class Contact extends BaseModule
 			// Disable remote self for everything except feeds.
 			// There is an issue when you repeat an item from maybe twitter and you got comments from friendica and twitter
 			// Problem is, you couldn't reply to both networks.
-			$allow_remote_self = in_array($contact['network'], [Protocol::FEED, Protocol::DFRN, Protocol::DIASPORA, Protocol::TWITTER])
+			$allow_remote_self = in_array($contact['network'], [Protocol::ACTIVITYPUB, Protocol::FEED, Protocol::DFRN, Protocol::DIASPORA, Protocol::TWITTER])
 				&& DI::config()->get('system', 'allow_users_remote_self');
 
 			if ($contact['network'] == Protocol::FEED) {
-				$remote_self_options = ['0' => DI::l10n()->t('No mirroring'), '1' => DI::l10n()->t('Mirror as forwarded posting'), '2' => DI::l10n()->t('Mirror as my own posting')];
+				$remote_self_options = [Model\Contact::MIRROR_DEACTIVATED => DI::l10n()->t('No mirroring'),
+					Model\Contact::MIRROR_FORWARDED => DI::l10n()->t('Mirror as forwarded posting'),
+					Model\Contact::MIRROR_OWN_POST => DI::l10n()->t('Mirror as my own posting')];
+			} elseif (in_array($contact['network'], [Protocol::ACTIVITYPUB])) {
+				$remote_self_options = [Model\Contact::MIRROR_DEACTIVATED => DI::l10n()->t('No mirroring'), 
+				Model\Contact::MIRROR_NATIVE_RESHARE => DI::l10n()->t('Native reshare')];
+			} elseif (in_array($contact['network'], [Protocol::DFRN])) {
+				$remote_self_options = [Model\Contact::MIRROR_DEACTIVATED => DI::l10n()->t('No mirroring'), 
+				Model\Contact::MIRROR_OWN_POST => DI::l10n()->t('Mirror as my own posting'),
+				Model\Contact::MIRROR_NATIVE_RESHARE => DI::l10n()->t('Native reshare')];
 			} else {
-				$remote_self_options = ['0' => DI::l10n()->t('No mirroring'), '2' => DI::l10n()->t('Mirror as my own posting')];
+				$remote_self_options = [Model\Contact::MIRROR_DEACTIVATED => DI::l10n()->t('No mirroring'), 
+					Model\Contact::MIRROR_OWN_POST => DI::l10n()->t('Mirror as my own posting')];
 			}
 
 			$poll_interval = null;


### PR DESCRIPTION
On ActivityPub and DFRN contacts we can now set the option to reshare their posts via an native AP "announce" activity.

See https://github.com/friendica/friendica/issues/9592