### PR TITLE
Ensure to add the cron forkhood worker task with medium priority

### DIFF
--- a/src/Worker/Cron.php
+++ b/src/Worker/Cron.php
@@ -55,13 +55,13 @@ class Cron
 		}
 
 		// Fork the cron jobs in separate parts to avoid problems when one of them is crashing
-		Hook::fork($a->queue['priority'], 'cron');
+		Hook::fork(PRIORITY_MEDIUM, 'cron');
 
 		// Poll contacts
 		Worker::add(PRIORITY_MEDIUM, 'PollContacts');
 
 		// Update contact information
-		Worker::add(PRIORITY_LOW, 'UpdatePublicContacts');		
+		Worker::add(PRIORITY_LOW, 'UpdatePublicContacts');
 
 		// run the process to update server directories in the background
 		Worker::add(PRIORITY_LOW, 'UpdateServerDirectories');


### PR DESCRIPTION
The cronhooks had been created with the same priority like the cron task. This leads to situations where the cronhook had been created with lower priorities which delayed their execution. So now we use a static value.