### PR TITLE
Issue 8943: Only check for too old postings for feeds

### DIFF
--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -1431,7 +1431,7 @@ class Item
 	 * @param array $item
 	 * @return boolean item is too old
 	 */
-	public static function tooOld(array $item)
+	public static function isTooOld(array $item)
 	{
 		// check for create date and expire time
 		$expire_interval = DI::config()->get('system', 'dbclean-expire-days', 0);

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -1382,27 +1382,6 @@ class Item
 			return false;
 		}
 
-		// check for create date and expire time
-		$expire_interval = DI::config()->get('system', 'dbclean-expire-days', 0);
-
-		$user = DBA::selectFirst('user', ['expire'], ['uid' => $item['uid']]);
-		if (DBA::isResult($user) && ($user['expire'] > 0) && (($user['expire'] < $expire_interval) || ($expire_interval == 0))) {
-			$expire_interval = $user['expire'];
-		}
-
-		if (($expire_interval > 0) && !empty($item['created'])) {
-			$expire_date = time() - ($expire_interval * 86400);
-			$created_date = strtotime($item['created']);
-			if ($created_date < $expire_date) {
-				Logger::notice('Item created before expiration interval.', [
-					'created' => date('c', $created_date),
-					'expired' => date('c', $expire_date),
-					'$item' => $item
-				]);
-				return false;
-			}
-		}
-
 		if (!empty($item['author-id']) && Contact::isBlocked($item['author-id'])) {
 			Logger::notice('Author is blocked node-wide', ['author-link' => $item['author-link'], 'item-uri' => $item['uri']]);
 			return false;
@@ -1444,6 +1423,38 @@ class Item
 		}
 
 		return true;
+	}
+
+	/**
+	 * Check if the item array is too old
+	 *
+	 * @param array $item
+	 * @return boolean item is too old
+	 */
+	public static function tooOld(array $item)
+	{
+		// check for create date and expire time
+		$expire_interval = DI::config()->get('system', 'dbclean-expire-days', 0);
+
+		$user = DBA::selectFirst('user', ['expire'], ['uid' => $item['uid']]);
+		if (DBA::isResult($user) && ($user['expire'] > 0) && (($user['expire'] < $expire_interval) || ($expire_interval == 0))) {
+			$expire_interval = $user['expire'];
+		}
+
+		if (($expire_interval > 0) && !empty($item['created'])) {
+			$expire_date = time() - ($expire_interval * 86400);
+			$created_date = strtotime($item['created']);
+			if ($created_date < $expire_date) {
+				Logger::notice('Item created before expiration interval.', [
+					'created' => date('c', $created_date),
+					'expired' => date('c', $expire_date),
+					'$item' => $item
+				]);
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/src/Protocol/Feed.php
+++ b/src/Protocol/Feed.php
@@ -503,7 +503,10 @@ class Feed
 				$items[] = $item;
 				break;
 			} elseif (!Item::isValid($item)) {
-				Logger::info('Feed is invalid', ['created' => $item['created'], 'uid' => $item['uid'], 'uri' => $item['uri']]);
+				Logger::info('Feed item is invalid', ['created' => $item['created'], 'uid' => $item['uid'], 'uri' => $item['uri']]);
+				continue;
+			} elseif (Item::tooOld($item)) {
+				Logger::info('Feed is too old', ['created' => $item['created'], 'uid' => $item['uid'], 'uri' => $item['uri']]);
 				continue;
 			}
 

--- a/src/Protocol/Feed.php
+++ b/src/Protocol/Feed.php
@@ -505,7 +505,7 @@ class Feed
 			} elseif (!Item::isValid($item)) {
 				Logger::info('Feed item is invalid', ['created' => $item['created'], 'uid' => $item['uid'], 'uri' => $item['uri']]);
 				continue;
-			} elseif (Item::tooOld($item)) {
+			} elseif (Item::isTooOld($item)) {
 				Logger::info('Feed is too old', ['created' => $item['created'], 'uid' => $item['uid'], 'uri' => $item['uri']]);
 				continue;
 			}


### PR DESCRIPTION
This fixes https://github.com/friendica/friendica/issues/8943

I just checked the code. We expire based on the date the message arrived at the system. So no situation should occur when an item would be fetched and directly being expired.

This check does make sense for feeds, so it is now only used there.