### PR TITLE
Configuration for the priority of the notification for expired messages

### DIFF
--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -1186,7 +1186,9 @@ class Item
 			self::markForDeletion(['uri' => $item['uri'], 'deleted' => false], $priority);
 
 			// send the notification upstream/downstream
-			Worker::add(['priority' => $priority, 'dont_fork' => true], "Notifier", Delivery::DELETION, intval($item['id']));
+			if ($priority) {
+				Worker::add(['priority' => $priority, 'dont_fork' => true], "Notifier", Delivery::DELETION, intval($item['id']));
+			}
 		} elseif ($item['uid'] != 0) {
 			Post\User::update($item['uri-id'], $item['uid'], ['hidden' => true]);
 
@@ -3111,6 +3113,8 @@ class Item
 
 		$expired = 0;
 
+		$priority = DI::config()->get('system', 'expire-notify-priority');
+
 		while ($item = Item::fetch($items)) {
 			// don't expire filed items
 
@@ -3130,7 +3134,7 @@ class Item
 				continue;
 			}
 
-			self::markForDeletionById($item['id'], PRIORITY_LOW);
+			self::markForDeletionById($item['id'], $priority);
 
 			++$expired;
 		}

--- a/static/defaults.config.php
+++ b/static/defaults.config.php
@@ -237,6 +237,10 @@ return [
 		// restricts develop log writes to requests originating from this IP address.
 		'dlogip' => '',
 
+		// expire-notify-priority (integer)
+		// Priority for the expirary notification 
+		'expire-notify-priority' => PRIORITY_LOW,
+
 		// free_crawls (Integer)
 		// Number of "free" searches when system => permit_crawling is enabled.
 		'free_crawls' => 10,


### PR DESCRIPTION
Formerly the priority for the task to notify remote systems of expired posts had been fix. We can now configure it. And when we set that value to `0` we can even (temporarily) deactivate the notification. This can be used when a system is too slow to keep up with the deletions.