### PR TITLE
Added missing "use" line for DBStructure class

### DIFF
--- a/update.php
+++ b/update.php
@@ -45,6 +45,7 @@ use Friendica\Core\Logger;
 use Friendica\Core\Update;
 use Friendica\Core\Worker;
 use Friendica\Database\Database;
+use Friendica\Database\DBStructure;
 use Friendica\Database\DBA;
 use Friendica\Database\DBStructure;
 use Friendica\DI;


### PR DESCRIPTION
This adds a missing `use` statement, during `./bin/console dbstructure update` I got a "class not found" error and was able to trace it back to `update.php`.