### PR TITLE
Add HTML Purify to BBCode::convert

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
 		"league/html-to-markdown": "^4.8",
 		"level-2/dice": "^4",
 		"lightopenid/lightopenid": "dev-master",
+		"matriphe/iso-639": "^1.2",
 		"michelf/php-markdown": "^1.7",
 		"mobiledetect/mobiledetectlib": "^2.8",
 		"monolog/monolog": "^1.25",
@@ -47,6 +48,7 @@
 		"psr/container": "^1.0",
 		"seld/cli-prompt": "^1.0",
 		"smarty/smarty": "^3.1",
+		"xemlock/htmlpurifier-html5": "^0.1.11",
 		"fxp/composer-asset-plugin": "^1.4",
 		"bower-asset/base64": "^1.0",
 		"bower-asset/chart-js": "^2.8",
@@ -64,8 +66,7 @@
 		"npm-asset/moment": "^2.24",
 		"npm-asset/perfect-scrollbar": "0.6.16",
 		"npm-asset/textcomplete": "^0.18.2",
-		"npm-asset/typeahead.js": "^0.11.1",
-		"matriphe/iso-639": "^1.2"
+		"npm-asset/typeahead.js": "^0.11.1"
 	},
 	"repositories": [
 		{

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fd22bd8c29dcea3d6b6eeb117d79af52",
+    "content-hash": "7d8031c9b95fd94d8872804759a26509",
     "packages": [
         {
             "name": "asika/simple-console",
@@ -3431,6 +3431,57 @@
                 "shim"
             ],
             "time": "2020-05-12T16:14:59+00:00"
+        },
+        {
+            "name": "xemlock/htmlpurifier-html5",
+            "version": "v0.1.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/xemlock/htmlpurifier-html5.git",
+                "reference": "f0d563f9fd4a82a3d759043483f9a94c0d8c2255"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/xemlock/htmlpurifier-html5/zipball/f0d563f9fd4a82a3d759043483f9a94c0d8c2255",
+                "reference": "f0d563f9fd4a82a3d759043483f9a94c0d8c2255",
+                "shasum": ""
+            },
+            "require": {
+                "ezyang/htmlpurifier": "^4.8",
+                "php": ">=5.2"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^1.1|^2.1",
+                "phpunit/phpunit": ">=4.7 <8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "library/HTMLPurifier/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "xemlock",
+                    "email": "xemlock@gmail.com"
+                }
+            ],
+            "description": "HTML5 element definitions for HTML Purifier",
+            "keywords": [
+                "HTML5",
+                "Purifier",
+                "html",
+                "htmlpurifier",
+                "security",
+                "tidy",
+                "validator",
+                "xss"
+            ],
+            "time": "2019-08-07T17:19:21+00:00"
         }
     ],
     "packages-dev": [

--- a/src/Content/PageInfo.php
+++ b/src/Content/PageInfo.php
@@ -265,7 +265,7 @@ class PageInfo
 		}
 
 		if (!$matches && $searchNakedUrls) {
-			preg_match('~(?<=\W|^)(?<![=\]])(https?://.+)$~is', $body, $matches);
+			preg_match(Strings::autoLinkRegEx(), $body, $matches);
 			if ($matches && !Strings::endsWith($body, $matches[1])) {
 				unset($matches);
 			}

--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -49,6 +49,9 @@ use Friendica\Util\XML;
 
 class BBCode
 {
+	// Update this value to the current date whenever changes are made to BBCode::convert
+	const VERSION = '2020-12-03';
+
 	const INTERNAL = 0;
 	const API = 2;
 	const DIASPORA = 3;

--- a/src/Content/Text/HTML.php
+++ b/src/Content/Text/HTML.php
@@ -36,27 +36,6 @@ use League\HTMLToMarkdown\HtmlConverter;
 
 class HTML
 {
-	public static function sanitizeCSS($input)
-	{
-		$cleaned = "";
-
-		$input = strtolower($input);
-
-		for ($i = 0; $i < strlen($input); $i++) {
-			$char = substr($input, $i, 1);
-
-			if (($char >= "a") && ($char <= "z")) {
-				$cleaned .= $char;
-			}
-
-			if (!(strpos(" #;:0123456789-_.%", $char) === false)) {
-				$cleaned .= $char;
-			}
-		}
-
-		return $cleaned;
-	}
-
 	/**
 	 * Search all instances of a specific HTML tag node in the provided DOM document and replaces them with BBCode text nodes.
 	 *

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -3537,18 +3537,18 @@ class Item
 
 		if ($rendered_hash == ''
 			|| $rendered_html == ''
-			|| $rendered_hash != BBCode::VERSION . '::' . hash('md5', $body)
+			|| $rendered_hash != hash('md5', BBCode::VERSION . '::' . $body)
 			|| DI::config()->get('system', 'ignore_cache')
 		) {
 			self::addRedirToImageTags($item);
 
 			$item['rendered-html'] = BBCode::convert($item['body']);
-			$item['rendered-hash'] = hash('md5', $body);
+			$item['rendered-hash'] = hash('md5', BBCode::VERSION . '::' . $body);
 
 			$hook_data = ['item' => $item, 'rendered-html' => $item['rendered-html'], 'rendered-hash' => $item['rendered-hash']];
 			Hook::callAll('put_item_in_cache', $hook_data);
 			$item['rendered-html'] = $hook_data['rendered-html'];
-			$item['rendered-hash'] = BBCode::VERSION . '::' . $hook_data['rendered-hash'];
+			$item['rendered-hash'] = $hook_data['rendered-hash'];
 			unset($hook_data);
 
 			// Force an update if the generated values differ from the existing ones

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -3529,49 +3529,50 @@ class Item
 	 */
 	public static function putInCache(&$item, $update = false)
 	{
-		$body = $item["body"];
+		// Save original body to prevent addons to modify it
+		$body = $item['body'];
 
 		$rendered_hash = $item['rendered-hash'] ?? '';
 		$rendered_html = $item['rendered-html'] ?? '';
 
 		if ($rendered_hash == ''
-			|| $rendered_html == ""
-			|| $rendered_hash != hash("md5", $item["body"])
-			|| DI::config()->get("system", "ignore_cache")
+			|| $rendered_html == ''
+			|| $rendered_hash != BBCode::VERSION . '::' . hash('md5', $body)
+			|| DI::config()->get('system', 'ignore_cache')
 		) {
 			self::addRedirToImageTags($item);
 
-			$item["rendered-html"] = BBCode::convert($item["body"]);
-			$item["rendered-hash"] = hash("md5", $item["body"]);
+			$item['rendered-html'] = BBCode::convert($item['body']);
+			$item['rendered-hash'] = hash('md5', $body);
 
 			$hook_data = ['item' => $item, 'rendered-html' => $item['rendered-html'], 'rendered-hash' => $item['rendered-hash']];
 			Hook::callAll('put_item_in_cache', $hook_data);
 			$item['rendered-html'] = $hook_data['rendered-html'];
-			$item['rendered-hash'] = $hook_data['rendered-hash'];
+			$item['rendered-hash'] = BBCode::VERSION . '::' . $hook_data['rendered-hash'];
 			unset($hook_data);
 
 			// Force an update if the generated values differ from the existing ones
-			if ($rendered_hash != $item["rendered-hash"]) {
+			if ($rendered_hash != $item['rendered-hash']) {
 				$update = true;
 			}
 
 			// Only compare the HTML when we forcefully ignore the cache
-			if (DI::config()->get("system", "ignore_cache") && ($rendered_html != $item["rendered-html"])) {
+			if (DI::config()->get('system', 'ignore_cache') && ($rendered_html != $item['rendered-html'])) {
 				$update = true;
 			}
 
-			if ($update && !empty($item["id"])) {
+			if ($update && !empty($item['id'])) {
 				self::update(
 					[
-						'rendered-html' => $item["rendered-html"],
-						'rendered-hash' => $item["rendered-hash"]
+						'rendered-html' => $item['rendered-html'],
+						'rendered-hash' => $item['rendered-hash']
 					],
-					['id' => $item["id"]]
+					['id' => $item['id']]
 				);
 			}
 		}
 
-		$item["body"] = $body;
+		$item['body'] = $body;
 	}
 
 	/**

--- a/src/Module/Debug/Babel.php
+++ b/src/Module/Debug/Babel.php
@@ -49,7 +49,7 @@ class Babel extends BaseModule
 		if (!empty($_REQUEST['text'])) {
 			switch (($_REQUEST['type'] ?? '') ?: 'bbcode') {
 				case 'bbcode':
-					$bbcode = trim($_REQUEST['text']);
+					$bbcode = $_REQUEST['text'];
 					$results[] = [
 						'title'   => DI::l10n()->t('Source input'),
 						'content' => visible_whitespace($bbcode)
@@ -65,6 +65,11 @@ class Babel extends BaseModule
 					$results[] = [
 						'title'   => DI::l10n()->t('BBCode::convert (raw HTML)'),
 						'content' => visible_whitespace($html)
+					];
+
+					$results[] = [
+						'title'   => DI::l10n()->t('BBCode::convert (hex)'),
+						'content' => visible_whitespace(bin2hex($html)),
 					];
 
 					$results[] = [
@@ -176,6 +181,25 @@ class Babel extends BaseModule
 					$results[] = [
 						'title'   => DI::l10n()->t('HTML Input'),
 						'content' => $html
+					];
+
+					$config = \HTMLPurifier_Config::createDefault();
+					$HTMLPurifier = new \HTMLPurifier($config);
+					$purified = $HTMLPurifier->purify($html);
+
+					$results[] = [
+						'title'   => DI::l10n()->t('HTML Purified (raw)'),
+						'content' => visible_whitespace($purified),
+					];
+
+					$results[] = [
+						'title'   => DI::l10n()->t('HTML Purified (hex)'),
+						'content' => visible_whitespace(bin2hex($purified)),
+					];
+
+					$results[] = [
+						'title'   => DI::l10n()->t('HTML Purified'),
+						'content' => $purified,
 					];
 
 					$bbcode = Text\HTML::toBBCode($html);

--- a/view/templates/babel.tpl
+++ b/view/templates/babel.tpl
@@ -24,9 +24,7 @@
 		<div class="panel-heading">
 			<h3 class="panel-title">{{$result.title}}</h3>
 		</div>
-		<div class="panel-body">
-			{{$result.content nofilter}}
-		</div>
+		<div class="panel-body">{{$result.content nofilter}}</div>
 	</div>
 	{{/foreach}}
 </div>


### PR DESCRIPTION
Fix #9611 

This was a long time coming, and since we don't have 100% coverage of `BBCode::convert`, we may have to tweak HTML Purify's configuration some more over the RC period because of regressions in post's HTML display, but it's a promising start.

Beyond the case that @palant found and graciously reported, it was also trivially simple to display arbitrary HTML using the `[noparse]` and `[nobb]` tags, and this opportunity has now been closed as well.

I also added BBCode versioning and the version number is used when checking a post's render hash. Any discrepancy between the stored hash (including the version number) and the computed hash + updated version number will trigger a re-conversion even if the body didn't change. This will allow us to fix additional security issues related to BBCode but also to retroactively update the display of posts whose HTML render has been cached after we change the `BBCode::convert` for any reason.