### PR TITLE
Remove unused contacts

### DIFF
--- a/src/Worker/Cron.php
+++ b/src/Worker/Cron.php
@@ -117,6 +117,8 @@ class Cron
 
 			Worker::add(PRIORITY_LOW, 'CleanItemUri');
 
+			Worker::add(PRIORITY_LOW, 'RemoveUnusedContacts');
+
 			// check upstream version?
 			Worker::add(PRIORITY_LOW, 'CheckVersion');
 

--- a/src/Worker/RemoveUnusedContacts.php
+++ b/src/Worker/RemoveUnusedContacts.php
@@ -29,8 +29,10 @@ use Friendica\Model\Photo;
 /**
  * Removes public contacts that aren't in use
  */
-class RemoveUnusedContacts {
-	public static function execute() {
+class RemoveUnusedContacts
+{
+	public static function execute()
+	{
 		$condition = ["`uid` = ? AND NOT `self` AND NOT `nurl` IN (SELECT `nurl` FROM `contact` WHERE `uid` != ?)
 			AND (NOT `network` IN (?, ?, ?, ?, ?, ?) OR (`archive` AND `success_update` < UTC_TIMESTAMP() - INTERVAL ? DAY))
 			AND NOT `id` IN (SELECT `author-id` FROM `item`) AND NOT `id` IN (SELECT `owner-id` FROM `item`)

--- a/src/Worker/RemoveUnusedContacts.php
+++ b/src/Worker/RemoveUnusedContacts.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Friendica\Worker;
+
+use Friendica\Core\Logger;
+use Friendica\Core\Protocol;
+use Friendica\Database\DBA;
+use Friendica\Model\Photo;
+
+/**
+ * Removes public contacts that aren't in use
+ */
+class RemoveUnusedContacts {
+	public static function execute() {
+		$condition = ["`uid` = ? AND NOT `self` AND NOT `nurl` IN (SELECT `nurl` FROM `contact` WHERE `uid` != ?)
+			AND (NOT `network` IN (?, ?, ?, ?, ?, ?) OR (`archive` AND `success_update` < UTC_TIMESTAMP() - INTERVAL ? DAY))
+			AND NOT `id` IN (SELECT `author-id` FROM `item`) AND NOT `id` IN (SELECT `owner-id` FROM `item`)
+			AND NOT `id` IN (SELECT `causer-id` FROM `item`) AND NOT `id` IN (SELECT `cid` FROM `post-tag`)
+			AND NOT `id` IN (SELECT `contact-id` FROM `item`) AND NOT `id` IN (SELECT `author-id` FROM `thread`)
+			AND NOT `id` IN (SELECT `owner-id` FROM `thread`) AND NOT `id` IN (SELECT `contact-id` FROM `thread`)
+			AND NOT `id` IN (SELECT `contact-id` FROM `post-user`) AND NOT `id` IN (SELECT `cid` FROM `user-contact`) 
+			AND NOT `id` IN (SELECT `cid` FROM `event`) AND NOT `id` IN (SELECT `contact-id` FROM `group_member`)",
+			0, 0, Protocol::DFRN, Protocol::DIASPORA, Protocol::OSTATUS, Protocol::FEED, Protocol::MAIL, Protocol::ACTIVITYPUB, 365];
+
+		$total = DBA::count('contact', $condition);
+		Logger::notice('Starting removal', ['total' => $total]);
+		$count = 0;
+		$contacts = DBA::select('contact', ['id', 'uid'], $condition);
+		while ($contact = DBA::fetch($contacts)) {
+			if (Photo::delete(['uid' => $contact['uid'], 'contact-id' => $contact['id']])) {
+				DBA::delete('contact', ['id' => $contact['id']]);
+				if ((++$count % 1000) == 0) {
+					Logger::notice('In removal', ['count' => $count, 'total' => $total]);
+				}
+			}
+		}
+		DBA::close($contacts);
+		Logger::notice('Removal done', ['count' => $count, 'total' => $total]);
+	}
+}

--- a/src/Worker/UpdateContacts.php
+++ b/src/Worker/UpdateContacts.php
@@ -74,8 +74,9 @@ class UpdateContacts
 
 		$count = 0;
 		foreach ($ids as $id) {
-			Worker::add(PRIORITY_LOW, "UpdateContact", $id);
-			++$count;
+			if (Worker::add(PRIORITY_LOW, "UpdateContact", $id)) {
+				++$count;
+			}
 		}
 
 		Logger::info('Initiated update for federated contacts', ['count' => $count]);

--- a/src/Worker/UpdateGServers.php
+++ b/src/Worker/UpdateGServers.php
@@ -62,12 +62,15 @@ class UpdateGServers
 			// There are duplicated "url" but not "nurl". So we check both addresses instead of just overwriting them,
 			// since that would mean loosing data.
 			if (!empty($gserver['url'])) {
-				Worker::add(PRIORITY_LOW, 'UpdateGServer', $gserver['url']);
+				if (Worker::add(PRIORITY_LOW, 'UpdateGServer', $gserver['url'])) {
+					$count++;
+				}
 			}
 			if (!empty($gserver['nurl']) && ($gserver['nurl'] != Strings::normaliseLink($gserver['url']))) {
-				Worker::add(PRIORITY_LOW, 'UpdateGServer', $gserver['nurl']);
+				if (Worker::add(PRIORITY_LOW, 'UpdateGServer', $gserver['nurl'])) {
+					$count++;
+				}
 			}
-			$count++;
 		}
 		DBA::close($gservers);
 		Logger::info('Updated servers', ['count' => $count]);


### PR DESCRIPTION
This helps with the problem of the huge storage space needed for the photos. The main contributor for this are the cached avatar pictures. So now we remove all public contacts (and their avatars) when first: either they are archived and hadn't been reachable for at least a year or are contacts from any non federated networks. And second: There are no items (and other stuff) belonging to this contact.

This reduced the number of contacts on my system from 900,000 to 600,000.

Some future PR could remove the cached pictures of unused - but unarchived - fediverse contacts.