### PR TITLE
Don't create the parent during a deletion

### DIFF
--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -2705,8 +2705,12 @@ class DFRN
 		}
 
 		$deletions = $xpath->query("/atom:feed/at:deleted-entry");
-		foreach ($deletions as $deletion) {
-			self::processDeletion($xpath, $deletion, $importer);
+		if (!empty($deletions)) {
+			foreach ($deletions as $deletion) {
+				self::processDeletion($xpath, $deletion, $importer);
+			}
+			Logger::notice('Deletions had been processed');
+			return 200;
 		}
 
 		if (!$sort_by_date) {

--- a/src/Worker/Delivery.php
+++ b/src/Worker/Delivery.php
@@ -296,13 +296,17 @@ class Delivery
 			$msgitems = [$target_item];
 			$atom = DFRN::entries($msgitems, $owner);
 		} else {
-			$msgitems = [];
-			foreach ($items as $item) {
-				// Only add the parent when we don't delete other items.
-				if (($target_item['id'] == $item['id']) || ($cmd != self::DELETION)) {
-					$item["entry:comment-allow"] = true;
-					$item["entry:cid"] = ($top_level ? $contact['id'] : 0);
-					$msgitems[] = $item;
+			if ($target_item['deleted']) {
+				$msgitems = [$target_item];
+			} else {
+				$msgitems = [];
+				foreach ($items as $item) {
+					// Only add the parent when we don't delete other items.
+					if (($target_item['id'] == $item['id']) || ($cmd != self::DELETION)) {
+						$item["entry:comment-allow"] = true;
+						$item["entry:cid"] = ($top_level ? $contact['id'] : 0);
+						$msgitems[] = $item;
+					}
 				}
 			}
 			$atom = DFRN::entries($msgitems, $owner);


### PR DESCRIPTION
This should fix the long time problem that old posts had been recreated and that they appeared as new posts. The origin lies in the DFRN protocol that not only transmits the post but it's parent as well. This also happened with deletion messages. To make it more subtle, the problem (AFAIK) only occurred with relayed deletions.

We now cover this situation on both sides. Means: When transmitting deletion messages we only transmit this single message. And when receiving such a message we just quit after performing the deletion. This means that the parent post won't be created.