### PR TITLE
Centralized fetching of the default avatar

### DIFF
--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -1678,7 +1678,7 @@ class Contact
 			}
 		}
 
-		$default_avatar = empty($avatar) || ($avatar == DI::baseUrl() . self::DEFAULT_AVATAR_PHOTO);
+		$default_avatar = empty($avatar) || strpos($avatar, self::DEFAULT_AVATAR_PHOTO);
 
 		if ($default_avatar) {
 			$avatar = self::getDefaultAvatar($contact, Proxy::SIZE_SMALL);

--- a/src/Model/Photo.php
+++ b/src/Model/Photo.php
@@ -32,6 +32,7 @@ use Friendica\Object\Image;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Images;
 use Friendica\Security\Security;
+use Friendica\Util\Proxy;
 use Friendica\Util\Strings;
 
 require_once "include/dba.php";
@@ -494,9 +495,10 @@ class Photo
 		}
 
 		if ($photo_failure) {
-			$image_url = DI::baseUrl() . Contact::DEFAULT_AVATAR_PHOTO;
-			$thumb = DI::baseUrl() . Contact::DEFAULT_AVATAR_THUMB;
-			$micro = DI::baseUrl() . Contact::DEFAULT_AVATAR_MICRO;
+			$contact = Contact::getById($cid) ?: [];
+			$image_url = Contact::getDefaultAvatar($contact, Proxy::SIZE_SMALL);
+			$thumb = Contact::getDefaultAvatar($contact, Proxy::SIZE_THUMB);
+			$micro = Contact::getDefaultAvatar($contact, Proxy::SIZE_MICRO);
 		}
 
 		return [$image_url, $thumb, $micro];

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -41,6 +41,7 @@ use Friendica\Util\Crypto;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Images;
 use Friendica\Util\Network;
+use Friendica\Util\Proxy;
 use Friendica\Util\Strings;
 use Friendica\Worker\Delivery;
 use ImagickException;
@@ -192,11 +193,12 @@ class User
 		$system['name'] = 'System Account';
 		$system['addr'] = $system_actor_name . '@' . DI::baseUrl()->getHostname();
 		$system['nick'] = $system_actor_name;
-		$system['avatar'] = DI::baseUrl() . Contact::DEFAULT_AVATAR_PHOTO;
-		$system['photo'] = DI::baseUrl() . Contact::DEFAULT_AVATAR_PHOTO;
-		$system['thumb'] = DI::baseUrl() . Contact::DEFAULT_AVATAR_THUMB;
-		$system['micro'] = DI::baseUrl() . Contact::DEFAULT_AVATAR_MICRO;
 		$system['url'] = DI::baseUrl() . '/friendica';
+
+		$system['avatar'] = $system['photo'] = Contact::getDefaultAvatar($system, Proxy::SIZE_SMALL);
+		$system['thumb'] = Contact::getDefaultAvatar($system, Proxy::SIZE_THUMB);
+		$system['micro'] = Contact::getDefaultAvatar($system, Proxy::SIZE_MICRO);
+
 		$system['nurl'] = Strings::normaliseLink($system['url']);
 		$system['pubkey'] = $keys['pubkey'];
 		$system['prvkey'] = $keys['prvkey'];

--- a/static/defaults.config.php
+++ b/static/defaults.config.php
@@ -470,6 +470,10 @@ return [
 		// Whether to use Cache to store session data or to use PHP native session storage.
 		'session_handler' => 'database',
 
+		// remote_avatar_lookup (Boolean)
+		// Perform an avatar lookup via the activated services for remote contacts
+		'remote_avatar_lookup' => false,
+
 		// remove_multiplicated_lines (Boolean)
 		// If enabled, multiple linefeeds in items are stripped to a single one.
 		'remove_multiplicated_lines' => false,


### PR DESCRIPTION
In the past we had set the default avatar at various places. We now use a centralized function. This also allows us to replace these avatars with automatically generated avatars from various services.

The fetching of automatically generated avatars is disabled by default.