### PR TITLE
Critical: Avoid dropping of incoming DFRN messages

### DIFF
--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -2709,8 +2709,10 @@ class DFRN
 			foreach ($deletions as $deletion) {
 				self::processDeletion($xpath, $deletion, $importer);
 			}
-			Logger::notice('Deletions had been processed');
-			return 200;
+			if (count($deletions) > 0) {
+				Logger::notice('Deletions had been processed');
+				return 200;
+			}
 		}
 
 		if (!$sort_by_date) {


### PR DESCRIPTION
This is a critical PR. It seems as if we dropped most or all of the incoming posts via DFRN in the last few days. This should help and should be merged soon. At a later time we have to have a deep look into the whole message transfer.