### PR TITLE
Normalize return value in Database->fetch

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -910,13 +910,12 @@ class Database
 	/**
 	 * Fetch a single row
 	 *
-	 * @param mixed $stmt statement object
+	 * @param PDOStatement|mysqli_stmt $stmt statement object
 	 *
-	 * @return array current row
+	 * @return array|false current row
 	 */
 	public function fetch($stmt)
 	{
-
 		$stamp1 = microtime(true);
 
 		$columns = [];
@@ -934,7 +933,7 @@ class Database
 				break;
 			case self::MYSQLI:
 				if (get_class($stmt) == 'mysqli_result') {
-					$columns = $stmt->fetch_assoc();
+					$columns = $stmt->fetch_assoc() ?? false;
 					break;
 				}
 

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -223,13 +223,14 @@ class Item
 	 * Fetch a single item row
 	 *
 	 * @param mixed $stmt statement object
-	 * @return array current row
+	 * @return array|false current row or false
+	 * @throws \Exception
 	 */
 	public static function fetch($stmt)
 	{
 		$row = DBA::fetch($stmt);
 
-		if (is_bool($row)) {
+		if (!is_array($row)) {
 			return $row;
 		}
 


### PR DESCRIPTION
- Address https://github.com/friendica/friendica/issues/9250#issuecomment-741857058

Database->fetch could return `null` with `mysqli` at the end of the result set instead of the expected `false`.