### PR TITLE
Issue 9633: Avoid contact lookup in conversation to avoid long loading times

### DIFF
--- a/include/conversation.php
+++ b/include/conversation.php
@@ -324,8 +324,7 @@ function conv_get_blocklist()
 	$blocklist = [];
 
 	foreach (explode(',', $str_blocked) as $entry) {
-		// The 4th parameter guarantees that there always will be a public contact entry
-		$cid = Contact::getIdForURL(trim($entry), 0, false, ['url' => trim($entry)]);
+		$cid = Contact::getIdForURL(trim($entry), 0, false);
 		if (!empty($cid)) {
 			$blocklist[] = $cid;
 		}


### PR DESCRIPTION
This fixes https://github.com/friendica/friendica/issues/9633

The legacy blocking method fetches the contact id value with every loading of the page. It should be done without any probing but due to changes in the used function the probing had been performed - which lead to huge problems.