### PR TITLE
Support for unprepared delayed posts

### DIFF
--- a/include/api.php
+++ b/include/api.php
@@ -67,7 +67,6 @@ use Friendica\Util\Proxy as ProxyUtils;
 use Friendica\Util\Strings;
 use Friendica\Util\XML;
 
-require_once __DIR__ . '/../mod/share.php';
 require_once __DIR__ . '/../mod/item.php';
 require_once __DIR__ . '/../mod/wall_upload.php';
 

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -2910,8 +2910,8 @@ class Item
 		$datarray['api_source'] = true;
 
 		// We have to tell the hooks who we are - this really should be improved
-		$_SESSION["authenticated"] = true;
-		$_SESSION["uid"] = $contact['uid'];
+		$_SESSION['authenticated'] = true;
+		$_SESSION['uid'] = $contact['uid'];
 
 		return (bool)$result;
 	}

--- a/src/Model/Post/Delayed.php
+++ b/src/Model/Post/Delayed.php
@@ -127,7 +127,7 @@ class Delayed
 			$id = item_post(DI::app());
 
 			Logger::notice('Unprepared post stored', ['id' => $id, 'uid' => $item['uid'], 'extid' => $item['extid']]);
-			return;
+			return $id;
 		}
 		$id = Item::insert($item, $notify);
 

--- a/src/Model/Post/Delayed.php
+++ b/src/Model/Post/Delayed.php
@@ -47,6 +47,7 @@ class Delayed
 	public static function add(string $uri, array $item, int $notify = 0, bool $unprepared = false, string $delayed = '', array $taglist = [], array $attachments = [])
 	{
 		if (empty($item['uid']) || self::exists($uri, $item['uid'])) {
+			Logger::notice('No uid or already found');
 			return false;
 		}
 

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -51,9 +51,6 @@ use Friendica\Util\Map;
 use Friendica\Util\Network;
 use Friendica\Util\XML;
 
-require_once 'include/api.php';
-require_once 'mod/share.php';
-
 /**
  * ActivityPub Transmitter Protocol class
  *

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -3382,7 +3382,6 @@ class Diaspora
 			}
 
 			if ($item['author-link'] != $item['owner-link']) {
-				require_once 'mod/share.php';
 				$body = BBCode::getShareOpeningTag($item['author-name'], $item['author-link'], $item['author-avatar'],
 					$item['plink'], $item['created']) . $body . '[/share]';
 			}

--- a/src/Protocol/Feed.php
+++ b/src/Protocol/Feed.php
@@ -656,8 +656,7 @@ class Feed
 				}
 				$publish_at = date(DateTimeFormat::MYSQL, $publish_time);
 
-				Post\Delayed::add($publish_at, $posting['item'], $posting['notify'], $posting['taglist'], $posting['attachments']);
-				DI::pConfig()->set($item['uid'], 'system', 'last_publish', $next_publish);
+				Post\Delayed::add($posting['item']['uri'], $posting['item'], $posting['notify'], false, $publish_at, $posting['taglist'], $posting['attachments']);
 			}
 		}
 

--- a/src/Protocol/OStatus.php
+++ b/src/Protocol/OStatus.php
@@ -46,9 +46,6 @@ use Friendica\Util\Proxy as ProxyUtils;
 use Friendica\Util\Strings;
 use Friendica\Util\XML;
 
-require_once 'mod/share.php';
-require_once 'include/api.php';
-
 /**
  * This class contain functions for the OStatus protocol
  */

--- a/src/Worker/DelayedPublish.php
+++ b/src/Worker/DelayedPublish.php
@@ -33,11 +33,12 @@ class DelayedPublish
 	  * @param integer $notify
 	  * @param array $taglist
 	  * @param array $attachments
+	  * @param bool  $unprepared
 	  * @return void
 	  */
-	public static function execute(array $item, int $notify = 0, array $taglist = [], array $attachments = [])
+	public static function execute(array $item, int $notify = 0, array $taglist = [], array $attachments = [], bool $unprepared = false)
 	{
-		$id = Post\Delayed::publish($item, $notify, $taglist, $attachments);
-		Logger::notice('Post published', ['id' => $id, 'uid' => $item['uid'], 'cid' => $item['contact-id'], 'notify' => $notify]);
+		$id = Post\Delayed::publish($item, $notify, $taglist, $attachments, $unprepared);
+		Logger::notice('Post published', ['id' => $id, 'uid' => $item['uid'], 'cid' => $item['contact-id'], 'notify' => $notify, 'unprepared' => $unprepared]);
 	}
 }

--- a/src/Worker/DelayedPublish.php
+++ b/src/Worker/DelayedPublish.php
@@ -34,11 +34,12 @@ class DelayedPublish
 	  * @param array $taglist
 	  * @param array $attachments
 	  * @param bool  $unprepared
+	  * @param string $uri
 	  * @return void
 	  */
-	public static function execute(array $item, int $notify = 0, array $taglist = [], array $attachments = [], bool $unprepared = false)
+	public static function execute(array $item, int $notify = 0, array $taglist = [], array $attachments = [], bool $unprepared = false, string $uri = '')
 	{
-		$id = Post\Delayed::publish($item, $notify, $taglist, $attachments, $unprepared);
+		$id = Post\Delayed::publish($item, $notify, $taglist, $attachments, $unprepared, $uri);
 		Logger::notice('Post published', ['id' => $id, 'uid' => $item['uid'], 'cid' => $item['contact-id'], 'notify' => $notify, 'unprepared' => $unprepared]);
 	}
 }


### PR DESCRIPTION
Some time ago we introduced delayed posts with a minimal posting interval to avoid creating a bunch of multiple posts in a few seconds (which mostly is understood as annoying).

This had worked with mirrored feeds but not with tweets or posts from the IFTTT addon due to the nature of how their posts are generated.

This is now possible. The PR for the addons will follow.