### PR TITLE
Delete removed contacts

### DIFF
--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -97,6 +97,7 @@ class User
 	const ACCOUNT_TYPE_NEWS =         2;
 	const ACCOUNT_TYPE_COMMUNITY =    3;
 	const ACCOUNT_TYPE_RELAY =        4;
+	const ACCOUNT_TYPE_DELETED =    127;
 	/**
 	 * @}
 	 */

--- a/src/Module/Proxy.php
+++ b/src/Module/Proxy.php
@@ -104,7 +104,7 @@ class Proxy extends BaseModule
 
 		// It shouldn't happen but it does - spaces in URL
 		$request['url'] = str_replace(' ', '+', $request['url']);
-		$fetchResult = HTTPSignature::fetchRaw($request['url'], local_user(), true, ['timeout' => 10]);
+		$fetchResult = HTTPSignature::fetchRaw($request['url'], local_user(), ['timeout' => 10]);
 		$img_str = $fetchResult->getBody();
 
 		// If there is an error then return a blank image

--- a/src/Protocol/ActivityPub.php
+++ b/src/Protocol/ActivityPub.php
@@ -68,7 +68,7 @@ class ActivityPub
 		'manuallyApprovesFollowers' => 'as:manuallyApprovesFollowers',
 		'sensitive' => 'as:sensitive', 'Hashtag' => 'as:Hashtag',
 		'directMessage' => 'litepub:directMessage']];
-	const ACCOUNT_TYPES = ['Person', 'Organization', 'Service', 'Group', 'Application'];
+	const ACCOUNT_TYPES = ['Person', 'Organization', 'Service', 'Group', 'Application', 'Tombstone'];
 	/**
 	 * Checks if the web request is done for the AP protocol
 	 *
@@ -113,7 +113,10 @@ class ActivityPub
 			case 'Application':
 				$accounttype = User::ACCOUNT_TYPE_RELAY;
 				break;
-		}
+			case 'Tombstone':
+				$accounttype = User::ACCOUNT_TYPE_DELETED;
+				break;
+			}
 
 		return $accounttype;
 	}

--- a/src/Protocol/ActivityPub.php
+++ b/src/Protocol/ActivityPub.php
@@ -116,7 +116,7 @@ class ActivityPub
 			case 'Tombstone':
 				$accounttype = User::ACCOUNT_TYPE_DELETED;
 				break;
-			}
+		}
 
 		return $accounttype;
 	}

--- a/src/Util/HTTPSignature.php
+++ b/src/Util/HTTPSignature.php
@@ -376,8 +376,7 @@ class HTTPSignature
 	 */
 	public static function fetch($request, $uid)
 	{
-		$opts = ['accept_content' => 'application/activity+json, application/ld+json'];
-		$curlResult = self::fetchRaw($request, $uid, false, $opts);
+		$curlResult = self::fetchRaw($request, $uid);
 
 		if (empty($curlResult)) {
 			return false;
@@ -410,7 +409,7 @@ class HTTPSignature
 	 * @return object CurlResult
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
-	public static function fetchRaw($request, $uid = 0, $binary = false, $opts = [])
+	public static function fetchRaw($request, $uid = 0, $opts = ['accept_content' => 'application/activity+json, application/ld+json'])
 	{
 		$header = [];
 

--- a/src/Worker/RemoveContact.php
+++ b/src/Worker/RemoveContact.php
@@ -31,15 +31,21 @@ use Friendica\Model\Photo;
  */
 class RemoveContact {
 	public static function execute($id) {
-
 		// Only delete if the contact is to be deleted
 		$contact = DBA::selectFirst('contact', ['uid'], ['deleted' => true, 'id' => $id]);
 		if (!DBA::isResult($contact)) {
 			return;
 		}
 
+		Logger::info('Start deleting contact', ['id' => $id]);
 		// Now we delete the contact and all depending tables
-		$condition = ['uid' => $contact['uid'], 'contact-id' => $id];
+		if ($contact['uid'] == 0) {
+			DBA::delete('post-tag', ['cid' => $id]);
+			$condition = ["`author-id` = ? OR `owner-id` = ? OR `causer-id` = ? OR `contact-id` = ?",
+				$id, $id, $id, $id];
+		} else {
+			$condition = ['uid' => $contact['uid'], 'contact-id' => $id];
+		}
 		do {
 			$items = Item::select(['id', 'guid'], $condition, ['limit' => 100]);
 			while ($item = Item::fetch($items)) {
@@ -49,7 +55,8 @@ class RemoveContact {
 			DBA::close($items);
 		} while (Item::exists($condition));
 
-		Photo::delete(['uid' => $contact['uid'], 'contact-id' => $id]);
-		DBA::delete('contact', ['id' => $id]);
+		Photo::delete(['contact-id' => $id]);
+		$ret = DBA::delete('contact', ['id' => $id]);
+		Logger::info('Deleted contact', ['id' => $id, 'result' => $ret]);
 	}
 }


### PR DESCRIPTION
We hadn't handled it very well when a user on a remote site decided to delete their profile. We not only detected it in the most cases, but we hadn't even detected it when probing the contact - and even if that had worked, the deletion most likely would had failed.

This fixes this all.