### PR TITLE
Fix warning "supplied key param cannot be coerced into a public key"

### DIFF
--- a/src/Util/HTTPSignature.php
+++ b/src/Util/HTTPSignature.php
@@ -544,7 +544,7 @@ class HTTPSignature
 
 		$key = self::fetchKey($sig_block['keyId'], $actor);
 
-		if (empty($key)) {
+		if (empty($key) || empty($key['pubkey'])) {
 			return false;
 		}
 


### PR DESCRIPTION
Fixes `PHP Warning:  openssl_verify(): supplied key param cannot be coerced into a public key in /htdocs/src/Util/Crypto.php on line 64`

This PR also adds the functionality that "Tombstone" accounts (removed accounts) are deleted upon arrival. When a remote account is deleted on AP then systems like Mastodon are transmitting a last message in their name. The message can't be validated anymore since the account can't be retrieved anymore. So in the past we just dropped these messages.

We still drop these messages but we delete the removed account on our side. So the effect is the same.