### PR TITLE
Avoid "Duplicate entry"

### DIFF
--- a/src/Util/HTTPSignature.php
+++ b/src/Util/HTTPSignature.php
@@ -22,6 +22,7 @@
 namespace Friendica\Util;
 
 use Friendica\Core\Logger;
+use Friendica\Database\Database;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\APContact;
@@ -323,7 +324,7 @@ class HTTPSignature
 
 		$status = DBA::selectFirst('inbox-status', [], ['url' => $url]);
 		if (!DBA::isResult($status)) {
-			DBA::insert('inbox-status', ['url' => $url, 'created' => $now, 'shared' => $shared]);
+			DBA::insert('inbox-status', ['url' => $url, 'created' => $now, 'shared' => $shared], Database::INSERT_IGNORE);
 			$status = DBA::selectFirst('inbox-status', [], ['url' => $url]);
 		}
 


### PR DESCRIPTION
Avoid `DB Error {"code":1062,"error":"Duplicate entry 'https:\/\/host/users\/user\/inbox' for key 'PRIMARY'","callstack":"DBA::insert, HTTPSignature::setInboxStatus, APContact::unarchiveInbox, APContact::getByURL, ActivityPub::probeProfile, Probe::uri, Contact::getIdForURL, Processor::acceptIncomingMessage","params":"INSERT INTO `inbox-status` (`url`, `created`, `shared`) VALUES ('https:\/\/host\/users\/user\/inbox', '2020-12-17 17:44:59', 0)"}`