### PR TITLE
Allow support for allowlisted iframe sources in Content\text\BBCode::convert

### DIFF
--- a/doc/BBCode.md
+++ b/doc/BBCode.md
@@ -503,10 +503,6 @@ You can embed video, audio and more in a message.
   <td>Embed OEmbed rich content.</td>
 </tr>
 <tr>
-  <td>[iframe]URL[/iframe]</td>
-  <td>General embed, iframe size is limited by the theme size for video players.</td>
-</tr>
-<tr>
   <td>[url]*url*[/url]</td>
   <td>If *url* supports oembed or opengraph specifications the embedded object will be shown (eg, documents from scribd).
 Page title with a link to *url* will be shown.</td>

--- a/doc/de/BBCode.md
+++ b/doc/de/BBCode.md
@@ -483,10 +483,6 @@ Du kannst Videos, Musikdateien und weitere Dinge in Beitr&auml;gen einbinden.
   <td>OEmbed rich content einbetten.</td>
 </tr>
 <tr>
-  <td>[iframe]URL[/iframe]</td>
-  <td>General embed, iframe size is limited by the theme size for video players.</td>
-</tr>
-<tr>
   <td>[url]*url*[/url]</td>
   <td>Wenn *url* die OEmbed- oder Opengraph-Spezifikationen unterst&uuml;tzt, wird das Objekt eingebettet (z.B. Dokumente von scribd).
   Ansonsten wird der Titel der Seite mit der URL verlinkt.</td>

--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -1876,6 +1876,14 @@ class BBCode
 
 		$config = \HTMLPurifier_HTML5Config::createDefault();
 		$config->set('HTML.Doctype', 'HTML5');
+		$config->set('HTML.SafeIframe', true);
+		$config->set('URI.SafeIframeRegexp', '%^(?:
+			https://www.youtube.com/embed/
+			|
+			https://player.vimeo.com/video/
+			|
+			' . DI::baseUrl() . '/oembed/ # Has to change with the source in Content\Oembed::iframe
+		)%xi');
 		$config->set('Attr.AllowedRel', [
 			'noreferrer' => true,
 			'noopener' => true,

--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -1622,11 +1622,8 @@ class BBCode
 						'<a href="$1" target="_blank" rel="noopener noreferrer">$1</a>', $text);
 				}
 
-				if ($try_oembed) {
-					$text = preg_replace("/\[iframe\](.*?)\[\/iframe\]/ism", '<iframe src="$1" width="' . $a->videowidth . '" height="' . $a->videoheight . '"><a href="$1">$1</a></iframe>', $text);
-				} else {
-					$text = preg_replace("/\[iframe\](.*?)\[\/iframe\]/ism", '<a href="$1">$1</a>', $text);
-				}
+				// Backward compatibility, [iframe] support has been removed in version 2020.12
+				$text = preg_replace("/\[iframe\](.*?)\[\/iframe\]/ism", '<a href="$1">$1</a>', $text);
 
 				// Youtube extensions
 				if ($try_oembed) {

--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -50,7 +50,7 @@ use Friendica\Util\XML;
 class BBCode
 {
 	// Update this value to the current date whenever changes are made to BBCode::convert
-	const VERSION = '2020-12-06';
+	const VERSION = '2020-12-18';
 
 	const INTERNAL = 0;
 	const API = 2;

--- a/src/Content/Text/HTML.php
+++ b/src/Content/Text/HTML.php
@@ -290,7 +290,8 @@ class HTML
 
 			self::tagToBBCode($doc, 'video', ['src' => '/(.+)/'], '[video]$1', '[/video]', true);
 			self::tagToBBCode($doc, 'audio', ['src' => '/(.+)/'], '[audio]$1', '[/audio]', true);
-			self::tagToBBCode($doc, 'iframe', ['src' => '/(.+)/'], '[iframe]$1', '[/iframe]', true);
+			// Backward compatibility, [iframe] support has been removed in version 2020.12
+			self::tagToBBCode($doc, 'iframe', ['src' => '/(.+)/'], '[url]$1', '[/url]', true);
 
 			self::tagToBBCode($doc, 'key', [], '[code]', '[/code]');
 			self::tagToBBCode($doc, 'code', [], '[code]', '[/code]');
@@ -630,6 +631,7 @@ class HTML
 			self::tagToBBCode($doc, 'img', ['src' => '/(.+)/'], ' ', ' ');
 		}
 
+		// Backward compatibility, [iframe] support has been removed in version 2020.12
 		self::tagToBBCode($doc, 'iframe', ['src' => '/(.+)/'], ' $1 ', '');
 
 		$message = $doc->saveHTML();


### PR DESCRIPTION
Fixes #9656 

Will retroactively fix the display of all the posts with missing Youtube/Vimeo embeds.