### PR TITLE
Restore Mastodon emoji span classes

### DIFF
--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -50,7 +50,7 @@ use Friendica\Util\XML;
 class BBCode
 {
 	// Update this value to the current date whenever changes are made to BBCode::convert
-	const VERSION = '2020-12-06';
+	const VERSION = '2020-12-18-small-emojis';
 
 	const INTERNAL = 0;
 	const API = 2;
@@ -1467,7 +1467,7 @@ class BBCode
 				$text = preg_replace("(\[style=(.*?)\](.*?)\[\/style\])ism", '<span style="$1">$2</span>', $text);
 
 				// Check for CSS classes
-				$text = preg_replace("(\[class=(.*?)\](.*?)\[\/class\])ism", '<span style="$1">$2</span>', $text);
+				$text = preg_replace("(\[class=(.*?)\](.*?)\[\/class\])ism", '<span class="$1">$2</span>', $text);
 
 				// handle nested lists
 				$endlessloop = 0;

--- a/tests/src/Content/Text/BBCodeTest.php
+++ b/tests/src/Content/Text/BBCodeTest.php
@@ -277,6 +277,10 @@ class BBCodeTest extends MockedTest
 				'expectedHTML' => '<span style="color:#FFFFFF;">dare to move your mouse here</span>',
 				'text' => '[color=FFFFFF]dare to move your mouse here[/color]'
 			],
+			'bug-9639-span-classes' => [
+				'expectedHTML' => '<span class="arbitrary classes">Test</span>',
+				'text' => '[class=arbitrary classes]Test[/class]',
+			],
 		];
 	}
 


### PR DESCRIPTION
Fixes #9639 

- Fix typo in replacement of [class] tag
- Add support for allowlisted classes

This was another side-effect of the new HTML Purify usage during BBCode conversion to HTML.