### PR TITLE
Issue 9402: Avoid message "invalid storage backend settings" on empty value

### DIFF
--- a/src/Module/Admin/Site.php
+++ b/src/Module/Admin/Site.php
@@ -247,7 +247,7 @@ class Site extends BaseAdmin
 				}
 				DI::baseUrl()->redirect('admin/site' . $active_panel);
 			}
-		} else {
+		} elseif (!empty($storagebackend)) {
 			notice(DI::l10n()->t('Invalid storage backend setting value.'));
 		}
 


### PR DESCRIPTION
Fixes https://github.com/friendica/friendica/issues/9402