### PR TITLE
Remove unused cached avatar photo entries

### DIFF
--- a/src/Worker/Cron.php
+++ b/src/Worker/Cron.php
@@ -119,6 +119,8 @@ class Cron
 
 			Worker::add(PRIORITY_LOW, 'RemoveUnusedContacts');
 
+			Worker::add(PRIORITY_LOW, 'RemoveUnusedAvatars');
+
 			// check upstream version?
 			Worker::add(PRIORITY_LOW, 'CheckVersion');
 

--- a/src/Worker/RemoveUnusedAvatars.php
+++ b/src/Worker/RemoveUnusedAvatars.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Friendica\Worker;
+
+use Friendica\Core\Logger;
+use Friendica\Core\Protocol;
+use Friendica\Core\Worker;
+use Friendica\Database\DBA;
+use Friendica\Model\Photo;
+
+/**
+ * Removes cached avatars from public contacts that aren't in use
+ */
+class RemoveUnusedAvatars
+{
+	public static function execute()
+	{
+		$condition = ["`uid` = ? AND NOT `self` AND NOT `nurl` IN (SELECT `nurl` FROM `contact` WHERE `uid` != ?)
+			AND `id` IN (SELECT `contact-id` FROM `photo`) AND NOT `id` IN (SELECT `author-id` FROM `item`)
+			AND NOT `id` IN (SELECT `owner-id` FROM `item`) AND NOT `id` IN (SELECT `causer-id` FROM `item`)
+			AND NOT `id` IN (SELECT `cid` FROM `post-tag`) AND NOT `id` IN (SELECT `contact-id` FROM `item`)", 0, 0];
+
+		$total = DBA::count('contact', $condition);
+		Logger::notice('Starting removal', ['total' => $total]);
+		$count = 0;
+		$contacts = DBA::select('contact', ['id'], $condition);
+		while ($contact = DBA::fetch($contacts)) {
+			DBA::update('contact', ['photo' => '', 'thumb' => '', 'micro' => ''], ['id' => $contact['id']]);
+			Photo::delete(['contact-id' => $contact['id'], 'album' => Photo::CONTACT_PHOTOS]);
+			if ((++$count % 1000) == 0) {
+				if (!Worker::isInMaintenanceWindow()) {
+					Logger::notice('We are outside of the maintenance window, quitting');
+					return;
+				}
+				Logger::notice('In removal', ['count' => $count, 'total' => $total]);
+			}
+		}
+		DBA::close($contacts);
+		Logger::notice('Removal done', ['count' => $count, 'total' => $total]);
+	}
+}


### PR DESCRIPTION
We now remove avatar photo entries when they aren't used in items. This and some previous PR that removed unused contacts from non federated networks helped to shrink the size of the storage table on one of my systems from 46 GB to 7.7 GB. (After optimizing the table)