### PR TITLE
Remove unneeded configutation

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -64,7 +64,6 @@ class Database
 	/** @var PDO|mysqli */
 	protected $connection;
 	protected $driver;
-	protected $emulate_prepares = false;
 	protected $pdo_emulate_prepares = false;
 	private $error          = false;
 	private $errorno        = 0;
@@ -122,7 +121,6 @@ class Database
 
 		$persistent = (bool)$this->configCache->get('database', 'persistent');
 
-		$this->emulate_prepares = (bool)$this->configCache->get('database', 'emulate_prepares');
 		$this->pdo_emulate_prepares = (bool)$this->configCache->get('database', 'pdo_emulate_prepares');
 
 		if (!$this->configCache->get('database', 'disable_pdo') && class_exists('\PDO') && in_array('mysql', PDO::getAvailableDrivers())) {
@@ -527,7 +525,7 @@ class Database
 		switch ($this->driver) {
 			case self::PDO:
 				// If there are no arguments we use "query"
-				if ($this->emulate_prepares || count($args) == 0) {
+				if (count($args) == 0) {
 					if (!$retval = $this->connection->query($this->replaceParameters($sql, $args))) {
 						$errorInfo     = $this->connection->errorInfo();
 						$this->error   = $errorInfo[2];
@@ -577,7 +575,7 @@ class Database
 				$can_be_prepared = in_array($command, ['select', 'update', 'insert', 'delete']);
 
 				// The fallback routine is called as well when there are no arguments
-				if ($this->emulate_prepares || !$can_be_prepared || (count($args) == 0)) {
+				if (!$can_be_prepared || (count($args) == 0)) {
 					$retval = $this->connection->query($this->replaceParameters($sql, $args));
 					if ($this->connection->errno) {
 						$this->error   = $this->connection->error;

--- a/static/defaults.config.php
+++ b/static/defaults.config.php
@@ -55,8 +55,7 @@ return [
 
 		// pdo_emulate_prepares (Boolean)
 		// If enabled, the builtin emulation for prepared statements is used.
-		// When enabled, a workaround is used to ensure that the returned field types are correct,
-		// since by standard all returned values are casted as strings.
+		// This can be used as a workaround for the database error "Prepared statement needs to be re-prepared".
 		'pdo_emulate_prepares' => false,
 
 		// disable_pdo (Boolean)

--- a/static/defaults.config.php
+++ b/static/defaults.config.php
@@ -53,15 +53,10 @@ return [
 		// Database connection charset. Changing this value will likely corrupt special characters.
 		'charset' => 'utf8mb4',
 
-		// emulate_prepares (Boolean) (Experimental)
-		// If enabled, prepared statements will be emulated.
-		// In combination with MySQLi this will cast all return values to strings.
-		'emulate_prepares' => false,
-
-		// pdo_emulate_prepares (Boolean) (Experimental)
+		// pdo_emulate_prepares (Boolean)
 		// If enabled, the builtin emulation for prepared statements is used.
-		// Due to limitations of that emulation (all return values are casted as strings)
-		// this will most likely cause issues and should not be used on production systems.
+		// When enabled, a workaround is used to ensure that the returned field types are correct,
+		// since by standard all returned values are casted as strings.
 		'pdo_emulate_prepares' => false,
 
 		// disable_pdo (Boolean)


### PR DESCRIPTION
The configuration parameter `emulate_prepares` had been introduced to track down (and solve) problems - but it hadn't fulfilled it's job. So we remove it now.

Also the description of `pdo_emulate_prepares` had been changed to reflect that this option should be production ready.