### PR TITLE
Drop unused friendica tables

### DIFF
--- a/src/Console/DatabaseStructure.php
+++ b/src/Console/DatabaseStructure.php
@@ -48,11 +48,12 @@ class DatabaseStructure extends \Asika\SimpleConsole\Console
 		$help = <<<HELP
 console dbstructure - Performs database updates
 Usage
-	bin/console dbstructure <command> [-h|--help|-?] |-f|--force] [-v]
+	bin/console dbstructure <command> [-h|--help|-?] [-e|--execute] |-f|--force] [-o|--override] [-v]
 
 Commands
 	dryrun   Show database update schema queries without running them
 	update   Update database schema
+	drop     Drop tables that aren't in use anymore
 	dumpsql  Dump database schema
 	toinnodb Convert all tables from MyISAM or InnoDB in the Antelope file format to InnoDB in the Barracuda file format
 	initial  Set needed initial values in the tables
@@ -61,8 +62,9 @@ Commands
 Options
     -h|--help|-?       Show help information
     -v                 Show more debug information.
+	-e|--execute       Execute the dropping.
     -f|--force         Force the update command (Even if the database structure matches)
-    -o|--override      Override running or stalling updates
+	-o|--override      Override running or stalling updates
 HELP;
 		return $help;
 	}
@@ -109,6 +111,12 @@ HELP;
 				$override = $this->getOption(['o', 'override'], false);
 				$output = Update::run($basePath, $force, $override,true, false);
 				break;
+			case "drop":
+				$execute = $this->getOption(['e', 'execute'], false);
+				ob_start();
+				DBStructure::dropTables($execute);
+				$output = ob_get_clean();
+				break;
 			case "dumpsql":
 				ob_start();
 				DBStructure::printStructure($basePath);
@@ -133,7 +141,7 @@ HELP;
 				$output = 'Unknown command: ' . $this->getArgument(0);
 		}
 
-		$this->out($output);
+		$this->out(trim($output));
 
 		return 0;
 	}

--- a/src/Console/DatabaseStructure.php
+++ b/src/Console/DatabaseStructure.php
@@ -48,23 +48,25 @@ class DatabaseStructure extends \Asika\SimpleConsole\Console
 		$help = <<<HELP
 console dbstructure - Performs database updates
 Usage
-	bin/console dbstructure <command> [-h|--help|-?] [-e|--execute] |-f|--force] [-o|--override] [-v]
+	bin/console dbstructure <command> [options]
 
 Commands
-	dryrun   Show database update schema queries without running them
-	update   Update database schema
-	drop     Drop tables that aren't in use anymore
-	dumpsql  Dump database schema
-	toinnodb Convert all tables from MyISAM or InnoDB in the Antelope file format to InnoDB in the Barracuda file format
-	initial  Set needed initial values in the tables
-	version  Set the database to a given number
+    drop     Show tables that aren't in use by Friendica anymore and can be dropped
+       -e|--execute    Execute the dropping
 
-Options
+    update   Update database schema
+       -f|--force      Force the update command (Even if the database structure matches)
+       -o|--override   Override running or stalling updates
+
+    dryrun   Show database update schema queries without running them
+    dumpsql  Dump database schema
+    toinnodb Convert all tables from MyISAM or InnoDB in the Antelope file format to InnoDB in the Barracuda file format
+    initial  Set needed initial values in the tables
+    version  Set the database to a given number
+
+General Options
     -h|--help|-?       Show help information
     -v                 Show more debug information.
-    -e|--execute       Execute the dropping.
-    -f|--force         Force the update command (Even if the database structure matches)
-    -o|--override      Override running or stalling updates
 HELP;
 		return $help;
 	}

--- a/src/Console/DatabaseStructure.php
+++ b/src/Console/DatabaseStructure.php
@@ -62,9 +62,9 @@ Commands
 Options
     -h|--help|-?       Show help information
     -v                 Show more debug information.
-	-e|--execute       Execute the dropping.
+    -e|--execute       Execute the dropping.
     -f|--force         Force the update command (Even if the database structure matches)
-	-o|--override      Override running or stalling updates
+    -o|--override      Override running or stalling updates
 HELP;
 		return $help;
 	}

--- a/src/Database/DBStructure.php
+++ b/src/Database/DBStructure.php
@@ -65,6 +65,46 @@ class DBStructure
 	}
 
 	/**
+	 * Drop unused tables
+	 *
+	 * @param boolean $execute
+	 * @return void
+	 */
+	public static function dropTables(bool $execute)
+	{
+		$old_tables = ['fserver', 'gcign', 'gcontact', 'gcontact-relation', 'gfollower' ,'glink', 'item-delivery-data',
+		'item_id', 'poll', 'poll_result', 'queue', 'retriever_rule', 'sign', 'spam', 'term'];
+
+		$tables = DBA::selectToArray(['INFORMATION_SCHEMA' => 'TABLES'], ['TABLE_NAME'],
+			['TABLE_SCHEMA' => DBA::databaseName(), 'TABLE_TYPE' => 'BASE TABLE']);
+
+		if (empty($tables)) {
+			echo DI::l10n()->t('No unused tables found.');
+			return;
+		}
+
+		if (!$execute) {
+			echo DI::l10n()->t('These tables are not used for friendica and will be deleted when you execute "dbstructure drop -e":') . "\n\n";
+		}
+
+		foreach ($tables as $table) {
+			if (in_array($table['TABLE_NAME'], $old_tables)) {
+				if ($execute) {
+					$sql = 'DROP TABLE ' . DBA::quoteIdentifier($table['TABLE_NAME']) . ';';
+					echo $sql . "\n";
+
+					$result = DBA::e($sql);
+					if (!DBA::isResult($result)) {
+						self::printUpdateError($sql);
+					}
+				} else {
+					echo $table['TABLE_NAME'] . "\n";
+				}
+			}
+		}
+	}
+
+	/**
 	 * Converts all tables from MyISAM/InnoDB Antelope to InnoDB Barracuda
 	 */
 	public static function convertToInnoDB()

--- a/src/Database/View.php
+++ b/src/Database/View.php
@@ -158,7 +158,7 @@ class View
 	}
 
 	/**
-	 * Check if the given table/view is a view
+	 * Check if the given table/view is a table
 	 *
 	 * @param string $table
 	 * @return boolean "true" if it's a table


### PR DESCRIPTION
During the times we abandoned tables and replaced them with new ones in a better structure. But we always kept the old tables.

We now have got an option to remove these tables. This is not done by the update process to make sure that no data is deleted unintentionally.