### PR TITLE
Add support for Unicode in Model\Tag::store

### DIFF
--- a/src/Model/Tag.php
+++ b/src/Model/Tag.php
@@ -70,8 +70,8 @@ class Tag
 	public static function store(int $uriid, int $type, string $name, string $url = '', $probing = true)
 	{
 		if ($type == self::HASHTAG) {
-			// Remove some common "garbarge" from tags
-			$name = trim($name, "\x00..\x20\xFF#!@,;.:'/?!^°$%".'"');
+			// Trim Unicode non-word characters
+			$name = preg_replace('/(^\W+)|(\W+$)/us', '', $name);
 
 			$tags = explode(self::TAG_CHARACTER[self::HASHTAG], $name);
 			if (count($tags) > 1) {


### PR DESCRIPTION
Fixes #8896 

I started to implement a multi-byte `trim()`, but using the same character classes as the original `trim()` call tripped the regular expression engine (like the NULL character `\0`).

In the end, I went for the flamethrower and now we aren't just trimming, we're purifying the tag name through the regular expression class `\W` which means that all non-word Unicode characters are removed from the tag name, even if they aren't at the extremities, because we have no good reason to keep them inside the string as well.

This will turn hashtag phrases into unreadable one-word sentences, but it's easier this way.