### PR TITLE
Improve handling of the visibility parameter of the new ACL

### DIFF
--- a/include/api.php
+++ b/include/api.php
@@ -4219,7 +4219,7 @@ function api_fr_photo_create_update($type)
 	$deny_cid  = $_REQUEST['deny_cid' ] ?? null;
 	$allow_gid = $_REQUEST['allow_gid'] ?? null;
 	$deny_gid  = $_REQUEST['deny_gid' ] ?? null;
-	$visibility = !empty($_REQUEST['visibility']) && $_REQUEST['visibility'] !== "false";
+	$visibility = !$allow_cid && !$deny_cid && !$allow_gid && !$deny_gid;
 
 	// do several checks on input parameters
 	// we do not allow calls without album string

--- a/mod/events.php
+++ b/mod/events.php
@@ -163,27 +163,26 @@ function events_post(App $a)
 
 
 	if ($share) {
-		$str_contact_allow = '';
-		$str_group_allow   = '';
-		$str_contact_deny  = '';
-		$str_group_deny    = '';
+		$user = User::getById($uid, ['allow_cid', 'allow_gid', 'deny_cid', 'deny_gid']);
+		if (!DBA::isResult($user)) {
+			return;
+		}
 
-		if (($_REQUEST['visibility'] ?? '') !== 'public') {
-			$user = User::getById($uid, ['allow_cid', 'allow_gid', 'deny_cid', 'deny_gid']);
-			if (!DBA::isResult($user)) {
-				return;
-			}
+		$aclFormatter = DI::aclFormatter();
+		$str_contact_allow = isset($_REQUEST['contact_allow']) ? $aclFormatter->toString($_REQUEST['contact_allow']) : $user['allow_cid'] ?? '';
+		$str_group_allow   = isset($_REQUEST['group_allow'])   ? $aclFormatter->toString($_REQUEST['group_allow'])   : $user['allow_gid'] ?? '';
+		$str_contact_deny  = isset($_REQUEST['contact_deny'])  ? $aclFormatter->toString($_REQUEST['contact_deny'])  : $user['deny_cid']  ?? '';
+		$str_group_deny    = isset($_REQUEST['group_deny'])    ? $aclFormatter->toString($_REQUEST['group_deny'])    : $user['deny_gid']  ?? '';
 
-			$aclFormatter = DI::aclFormatter();
-			$str_contact_allow = isset($_REQUEST['contact_allow']) ? $aclFormatter->toString($_REQUEST['contact_allow']) : $user['allow_cid'] ?? '';
-			$str_group_allow   = isset($_REQUEST['group_allow'])   ? $aclFormatter->toString($_REQUEST['group_allow'])   : $user['allow_gid'] ?? '';
-			$str_contact_deny  = isset($_REQUEST['contact_deny'])  ? $aclFormatter->toString($_REQUEST['contact_deny'])  : $user['deny_cid']  ?? '';
-			$str_group_deny    = isset($_REQUEST['group_deny'])    ? $aclFormatter->toString($_REQUEST['group_deny'])    : $user['deny_gid']  ?? '';
-
-			// Since we know from the visibility parameter it should be private, we have to prevent the empty ACL case
-			// that would make the item public. So we always append the author's contact id to the allowed contacts.
+		$visibility = $_REQUEST['visibility'] ?? '';
+		if ($visibility === 'public') {
+			// The ACL selector introduced in version 2019.12 sends ACL input data even when the Public visibility is selected
+			$str_contact_allow = $str_group_allow = $str_contact_deny = $str_group_deny = '';
+		} else if ($visibility === 'custom') {
+			// Since we know from the visibility parameter the item should be private, we have to prevent the empty ACL
+			// case that would make it public. So we always append the author's contact id to the allowed contacts.
 			// See https://github.com/friendica/friendica/issues/9672
-			$str_contact_allow .= $aclFormatter->toString(\Friendica\Model\Contact::getPublicIdByUserId($uid));
+			$str_contact_allow .= $aclFormatter->toString(Contact::getPublicIdByUserId($uid));
 		}
 	} else {
 		$str_contact_allow = '<' . $self . '>';

--- a/mod/item.php
+++ b/mod/item.php
@@ -261,20 +261,19 @@ function item_post(App $a) {
 		$guid              = $orig_post['guid'];
 		$extid             = $orig_post['extid'];
 	} else {
-		$str_contact_allow = '';
-		$str_group_allow   = '';
-		$str_contact_deny  = '';
-		$str_group_deny    = '';
+		$aclFormatter = DI::aclFormatter();
+		$str_contact_allow = isset($_REQUEST['contact_allow']) ? $aclFormatter->toString($_REQUEST['contact_allow']) : $user['allow_cid'] ?? '';
+		$str_group_allow   = isset($_REQUEST['group_allow'])   ? $aclFormatter->toString($_REQUEST['group_allow'])   : $user['allow_gid'] ?? '';
+		$str_contact_deny  = isset($_REQUEST['contact_deny'])  ? $aclFormatter->toString($_REQUEST['contact_deny'])  : $user['deny_cid']  ?? '';
+		$str_group_deny    = isset($_REQUEST['group_deny'])    ? $aclFormatter->toString($_REQUEST['group_deny'])    : $user['deny_gid']  ?? '';
 
-		if (($_REQUEST['visibility'] ?? '') !== 'public') {
-			$aclFormatter = DI::aclFormatter();
-			$str_contact_allow = isset($_REQUEST['contact_allow']) ? $aclFormatter->toString($_REQUEST['contact_allow']) : $user['allow_cid'] ?? '';
-			$str_group_allow   = isset($_REQUEST['group_allow'])   ? $aclFormatter->toString($_REQUEST['group_allow'])   : $user['allow_gid'] ?? '';
-			$str_contact_deny  = isset($_REQUEST['contact_deny'])  ? $aclFormatter->toString($_REQUEST['contact_deny'])  : $user['deny_cid']  ?? '';
-			$str_group_deny    = isset($_REQUEST['group_deny'])    ? $aclFormatter->toString($_REQUEST['group_deny'])    : $user['deny_gid']  ?? '';
-
-			// Since we know from the visibility parameter it should be private, we have to prevent the empty ACL case
-			// that would make the item public. So we always append the author's contact id to the allowed contacts.
+		$visibility = $_REQUEST['visibility'] ?? '';
+		if ($visibility === 'public') {
+			// The ACL selector introduced in version 2019.12 sends ACL input data even when the Public visibility is selected
+			$str_contact_allow = $str_group_allow = $str_contact_deny = $str_group_deny = '';
+		} else if ($visibility === 'custom') {
+			// Since we know from the visibility parameter the item should be private, we have to prevent the empty ACL
+			// case that would make it public. So we always append the author's contact id to the allowed contacts.
 			// See https://github.com/friendica/friendica/issues/9672
 			$str_contact_allow .= $aclFormatter->toString(Contact::getPublicIdByUserId($uid));
 		}


### PR DESCRIPTION
Follow-up to #9690

I finally found out why the tests were failing. With the new way to handle permissions in #9690, if the `visibility` parameter was missing from the request, we assumed it is a private post. Since the failing API test call didn't set it, it triggered the path for private posts even though it wasn't accounted for in the test setup.

This PR introduces backward compatibility with the old way to handle permission by making the `visibility` parameter optional.