### PR TITLE
Restore autolink in share block content in BBCode::convertShare

### DIFF
--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -1008,7 +1008,9 @@ class BBCode
 					$attributes['avatar'] = ProxyUtils::proxifyUrl($attributes['avatar'], false, ProxyUtils::SIZE_THUMB);
 				}
 
-				return $match[1] . $callback($attributes, $author_contact, $match[3], trim($match[1]) != '');
+				$content = preg_replace(Strings::autoLinkRegEx(), '<a href="$1">$1</a>', $match[3]);
+
+				return $match[1] . $callback($attributes, $author_contact, $content, trim($match[1]) != '');
 			},
 			$text
 		);


### PR DESCRIPTION
Fixes #9291
Blocked by #9694 for test fix