### PR TITLE
[frio] Replace additional sort buttons by anchor links in users admin

### DIFF
--- a/view/theme/frio/templates/admin/users/active.tpl
+++ b/view/theme/frio/templates/admin/users/active.tpl
@@ -100,29 +100,29 @@
 					<td colspan="4">
 					{{if $order_users != $th_users.2.1}}
 						<p>
-							<button type="button" data-order-url="{{$baseurl}}/admin/users/active?o={{if $order_direction_users == "+"}}-{{/if}}{{$th_users.2.1}}" class="btn-link table-order">
-							&#8597; {{$th_users.2.0}}</button> : {{$u.register_date}}
+							<a href="{{$baseurl}}/admin/users/active?o={{if $order_direction_users == "+"}}-{{/if}}{{$th_users.2.1}}" class="btn-link table-order">
+							&#8597; {{$th_users.2.0}}</a> : {{$u.register_date}}
 						</p>
 					{{/if}}
 
 					{{if $order_users != $th_users.3.1}}
 						<p>
-							<button type="button" data-order-url="{{$baseurl}}/admin/users/active?o={{if $order_direction_users == "+"}}-{{/if}}{{$th_users.3.1}}" class="btn-link table-order">
-								&#8597; {{$th_users.3.0}}</button> : {{$u.login_date}}
+							<a href="{{$baseurl}}/admin/users/active?o={{if $order_direction_users == "+"}}-{{/if}}{{$th_users.3.1}}" class="btn-link table-order">
+								&#8597; {{$th_users.3.0}}</a> : {{$u.login_date}}
 						</p>
 					{{/if}}
 
 					{{if $order_users != $th_users.4.1}}
 						<p>
-							<button type="button" data-order-url="{{$baseurl}}/admin/users/active?o={{if $order_direction_users == "+"}}-{{/if}}{{$th_users.4.1}}" class="btn-link table-order">
-								&#8597; {{$th_users.4.0}}</button> : {{$u.lastitem_date}}
+							<a href="{{$baseurl}}/admin/users/active?o={{if $order_direction_users == "+"}}-{{/if}}{{$th_users.4.1}}" class="btn-link table-order">
+								&#8597; {{$th_users.4.0}}</a> : {{$u.lastitem_date}}
 						</p>
 					{{/if}}
 
 					{{if in_array($order_users,[$th_users.2.1, $th_users.3.1, $th_users.4.1]) }}
 						<p>
-							<button type="button" data-order-url="{{$baseurl}}/admin/users/active?o={{if $order_direction_users == "+"}}-{{/if}}{{$th_users.5.1}}" class="btn-link table-order">
-								&#8597; {{$th_users.5.0}}</button> : {{$u.page_flags}}{{if $u.page_flags_raw==0 && $u.account_type_raw > 0}}, {{$u.account_type}}{{/if}} {{if $u.is_admin}}({{$siteadmin}}){{/if}} {{if $u.account_expired}}({{$accountexpired}}){{/if}}
+							<a href="{{$baseurl}}/admin/users/active?o={{if $order_direction_users == "+"}}-{{/if}}{{$th_users.5.1}}" class="btn-link table-order">
+								&#8597; {{$th_users.5.0}}</a> : {{$u.page_flags}}{{if $u.page_flags_raw==0 && $u.account_type_raw > 0}}, {{$u.account_type}}{{/if}} {{if $u.is_admin}}({{$siteadmin}}){{/if}} {{if $u.account_expired}}({{$accountexpired}}){{/if}}
 						</p>
 					{{/if}}
 

--- a/view/theme/frio/templates/admin/users/blocked.tpl
+++ b/view/theme/frio/templates/admin/users/blocked.tpl
@@ -100,29 +100,29 @@
 					<td colspan="4">
 					{{if $order_users != $th_users.2.1}}
 						<p>
-							<button type="button" data-order-url="{{$baseurl}}/admin/users/blocked?o={{if $order_direction_users == "+"}}-{{/if}}{{$th_users.2.1}}" class="btn-link table-order">
-							&#8597; {{$th_users.2.0}}</button> : {{$u.register_date}}
+							<a href="{{$baseurl}}/admin/users/blocked?o={{if $order_direction_users == "+"}}-{{/if}}{{$th_users.2.1}}" class="btn-link table-order">
+							&#8597; {{$th_users.2.0}}</a> : {{$u.register_date}}
 						</p>
 					{{/if}}
 
 					{{if $order_users != $th_users.3.1}}
 						<p>
-							<button type="button" data-order-url="{{$baseurl}}/admin/users/blocked?o={{if $order_direction_users == "+"}}-{{/if}}{{$th_users.3.1}}" class="btn-link table-order">
-								&#8597; {{$th_users.3.0}}</button> : {{$u.login_date}}
+							<a href="{{$baseurl}}/admin/users/blocked?o={{if $order_direction_users == "+"}}-{{/if}}{{$th_users.3.1}}" class="btn-link table-order">
+								&#8597; {{$th_users.3.0}}</a> : {{$u.login_date}}
 						</p>
 					{{/if}}
 
 					{{if $order_users != $th_users.4.1}}
 						<p>
-							<button type="button" data-order-url="{{$baseurl}}/admin/users/blocked?o={{if $order_direction_users == "+"}}-{{/if}}{{$th_users.4.1}}" class="btn-link table-order">
-								&#8597; {{$th_users.4.0}}</button> : {{$u.lastitem_date}}
+							<a href="{{$baseurl}}/admin/users/blocked?o={{if $order_direction_users == "+"}}-{{/if}}{{$th_users.4.1}}" class="btn-link table-order">
+								&#8597; {{$th_users.4.0}}</a> : {{$u.lastitem_date}}
 						</p>
 					{{/if}}
 
 					{{if in_array($order_users,[$th_users.2.1, $th_users.3.1, $th_users.4.1]) }}
 						<p>
-							<button type="button" data-order-url="{{$baseurl}}/admin/users/blocked?o={{if $order_direction_users == "+"}}-{{/if}}{{$th_users.5.1}}" class="btn-link table-order">
-								&#8597; {{$th_users.5.0}}</button> : {{$u.page_flags}}{{if $u.page_flags_raw==0 && $u.account_type_raw > 0}}, {{$u.account_type}}{{/if}} {{if $u.is_admin}}({{$siteadmin}}){{/if}} {{if $u.account_expired}}({{$accountexpired}}){{/if}}
+							<a href="{{$baseurl}}/admin/users/blocked?o={{if $order_direction_users == "+"}}-{{/if}}{{$th_users.5.1}}" class="btn-link table-order">
+								&#8597; {{$th_users.5.0}}</a> : {{$u.page_flags}}{{if $u.page_flags_raw==0 && $u.account_type_raw > 0}}, {{$u.account_type}}{{/if}} {{if $u.is_admin}}({{$siteadmin}}){{/if}} {{if $u.account_expired}}({{$accountexpired}}){{/if}}
 						</p>
 					{{/if}}
 

--- a/view/theme/frio/templates/admin/users/index.tpl
+++ b/view/theme/frio/templates/admin/users/index.tpl
@@ -102,29 +102,29 @@
 					<td colspan="4">
 					{{if $order_users != $th_users.2.1}}
 						<p>
-							<button type="button" data-order-url="{{$baseurl}}/admin/users/?o={{if $order_direction_users == "+"}}-{{/if}}{{$th_users.2.1}}" class="btn-link table-order">
-							&#8597; {{$th_users.2.0}}</button> : {{$u.register_date}}
+							<a href="{{$baseurl}}/admin/users/?o={{if $order_direction_users == "+"}}-{{/if}}{{$th_users.2.1}}" class="btn-link table-order">
+							&#8597; {{$th_users.2.0}}</a> : {{$u.register_date}}
 						</p>
 					{{/if}}
 
 					{{if $order_users != $th_users.3.1}}
 						<p>
-							<button type="button" data-order-url="{{$baseurl}}/admin/users/?o={{if $order_direction_users == "+"}}-{{/if}}{{$th_users.3.1}}" class="btn-link table-order">
-								&#8597; {{$th_users.3.0}}</button> : {{$u.login_date}}
+							<a href="{{$baseurl}}/admin/users/?o={{if $order_direction_users == "+"}}-{{/if}}{{$th_users.3.1}}" class="btn-link table-order">
+								&#8597; {{$th_users.3.0}}</a> : {{$u.login_date}}
 						</p>
 					{{/if}}
 
 					{{if $order_users != $th_users.4.1}}
 						<p>
-							<button type="button" data-order-url="{{$baseurl}}/admin/users/?o={{if $order_direction_users == "+"}}-{{/if}}{{$th_users.4.1}}" class="btn-link table-order">
-								&#8597; {{$th_users.4.0}}</button> : {{$u.lastitem_date}}
+							<a href="{{$baseurl}}/admin/users/?o={{if $order_direction_users == "+"}}-{{/if}}{{$th_users.4.1}}" class="btn-link table-order">
+								&#8597; {{$th_users.4.0}}</a> : {{$u.lastitem_date}}
 						</p>
 					{{/if}}
 
 					{{if in_array($order_users,[$th_users.2.1, $th_users.3.1, $th_users.4.1]) }}
 						<p>
-							<button type="button" data-order-url="{{$baseurl}}/admin/users/?o={{if $order_direction_users == "+"}}-{{/if}}{{$th_users.5.1}}" class="btn-link table-order">
-								&#8597; {{$th_users.5.0}}</button> : {{$u.page_flags}}{{if $u.page_flags_raw==0 && $u.account_type_raw > 0}}, {{$u.account_type}}{{/if}} {{if $u.is_admin}}({{$siteadmin}}){{/if}} {{if $u.account_expired}}({{$accountexpired}}){{/if}}
+							<a href="{{$baseurl}}/admin/users/?o={{if $order_direction_users == "+"}}-{{/if}}{{$th_users.5.1}}" class="btn-link table-order">
+								&#8597; {{$th_users.5.0}}</a> : {{$u.page_flags}}{{if $u.page_flags_raw==0 && $u.account_type_raw > 0}}, {{$u.account_type}}{{/if}} {{if $u.is_admin}}({{$siteadmin}}){{/if}} {{if $u.account_expired}}({{$accountexpired}}){{/if}}
 						</p>
 					{{/if}}
 


### PR DESCRIPTION
Follow-up to #9501
Fixes #9518

- Buttons were used in a previous version where sorting was done using Javascript