### PR TITLE
Restore auto-complete feature in comments forms

### DIFF
--- a/view/js/main.js
+++ b/view/js/main.js
@@ -175,6 +175,17 @@ $(function() {
 		$(textarea).trigger('change');
 	});
 
+	$(".comment-edit-wrapper textarea, .wall-item-comment-wrapper textarea")
+		.editor_autocomplete(baseurl + '/search/acl')
+		.bbco_autocomplete('bbcode');
+
+	// Ensures asynchronously-added comment forms recognize mentions, tags and BBCodes as well
+	document.addEventListener("postprocess_liveupdate", function() {
+		$(".comment-edit-wrapper textarea, .wall-item-comment-wrapper textarea")
+			.editor_autocomplete(baseurl + '/search/acl')
+			.bbco_autocomplete('bbcode');
+	});
+
 	/* popup menus */
 	function close_last_popup_menu() {
 		if (last_popup_menu) {
@@ -568,10 +579,6 @@ function updateConvItems(data) {
 		commentBusy = false;
 		$('body').css('cursor', 'auto');
 	}
-	/* autocomplete @nicknames */
-	$(".comment-edit-form  textarea").editor_autocomplete(baseurl + '/search/acl');
-	/* autocomplete bbcode */
-	$(".comment-edit-form  textarea").bbco_autocomplete('bbcode');
 }
 
 function liveUpdate(src) {

--- a/view/templates/display-head.tpl
+++ b/view/templates/display-head.tpl
@@ -1,13 +1,6 @@
 {{if $alternate}}
-<link href='{{$alternate}}' rel='alternate' type='application/atom+xml'>
+<link href="{{$alternate}}" rel="alternate" type="application/atom+xml">
 {{/if}}
 {{if $conversation}}
-<link href='{{$conversation}}' rel='conversation' type='application/atom+xml'>
+<link href="{{$conversation}}" rel="conversation" type="application/atom+xml">
 {{/if}}
-<script>
-$(document).ready(function() {
-	$(".comment-edit-wrapper textarea").editor_autocomplete(baseurl + '/search/acl');
-	// make auto-complete work in more places
-	$(".wall-item-comment-wrapper textarea").editor_autocomplete(baseurl + '/search/acl');
-});
-</script>


### PR DESCRIPTION
Fixes #9622 

- New catch-all feature supports network/display pages, infinite scroll and live updated conversations