### PR TITLE
Prevent alt text of emoji image tags to be converted to smilies in BBCode::convert

### DIFF
--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -1393,6 +1393,16 @@ class BBCode
 					$text = self::convertAttachment($text, $simple_html, $try_oembed);
 				}
 
+				$nosmile = strpos($text, '[nosmile]') !== false;
+				$text = str_replace('[nosmile]', '', $text);
+
+				// Replace non graphical smilies for external posts
+				if (!$nosmile && !$for_plaintext) {
+					$text = self::performWithEscapedTags($text, ['img'], function ($text) {
+						return Smilies::replace($text);
+					});
+				}
+
 				// leave open the posibility of [map=something]
 				// this is replaced in Item::prepareBody() which has knowledge of the item location
 				if (strpos($text, '[/map]') !== false) {
@@ -1505,11 +1515,6 @@ class BBCode
 						return preg_replace(Strings::autoLinkRegEx(), '[url]$1[/url]', $text);
 					});
 				}
-
-				// This is actually executed in Item::prepareBody()
-
-				$nosmile = strpos($text, '[nosmile]') !== false;
-				$text = str_replace('[nosmile]', '', $text);
 
 				// Check for font change text
 				$text = preg_replace("/\[font=(.*?)\](.*?)\[\/font\]/sm", "<span style=\"font-family: $1;\">$2</span>", $text);
@@ -1681,13 +1686,6 @@ class BBCode
 					$text = preg_replace("/\[event\-location\](.*?)\[\/event\-location\]/ism", '', $text);
 					$text = preg_replace("/\[event\-adjust\](.*?)\[\/event\-adjust\]/ism", '', $text);
 					$text = preg_replace("/\[event\-id\](.*?)\[\/event\-id\]/ism", '', $text);
-				}
-
-				// Replace non graphical smilies for external posts
-				if (!$nosmile && !$for_plaintext) {
-					$text = self::performWithEscapedTags($text, ['img'], function ($text) {
-						return Smilies::replace($text);
-					});
 				}
 
 				if (!$for_plaintext && DI::config()->get('system', 'big_emojis') && ($simple_html != self::DIASPORA)) {


### PR DESCRIPTION
This time, for real.

Follow-up to #9534

I realized that while escaping the `img` BBCode tag was the correct idea introduced in #9534, unfortunately it was useless at the position it was in `BBCode::convert` since it occurred after `img` BBCode tags were transformed into `img` HTML tags which are unaffected by the tag escape block.