### PR TITLE
[frio] Vary Back to Top element depending on the theme accent/colors

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -119,7 +119,7 @@ blockquote {
 #back-to-top {
     display: none;
     cursor: pointer;
-    color: white;
+    color: $nav_icon_color;
     position: fixed;
     z-index: 49;
     right: 20px;
@@ -128,7 +128,7 @@ blockquote {
     font-size: 2.9em;
     padding: 0 12px 0 12px;
     border-radius: 10px;
-    background-color: #aaa;
+    background-color: $nav_bg;
     line-height: 1.5;
 }
 

--- a/view/theme/frio/php/default.php
+++ b/view/theme/frio/php/default.php
@@ -149,7 +149,7 @@ $is_singleuser_class = $is_singleuser ? "is-singleuser" : "is-not-singleuser";
 				</div><!--row-->
 			</div><!-- container -->
 
-			<div id="back-to-top" title="back to top">&#8679;</div>
+			<div id="back-to-top" title="back to top">⇪</div>
 		</main>
 
 		<footer>

--- a/view/theme/frio/php/standard.php
+++ b/view/theme/frio/php/standard.php
@@ -70,7 +70,7 @@
 			</div><!--row-->
 		</div><!-- container -->
 
-		<div id="back-to-top" title="back to top">&#8679;</div>
+		<div id="back-to-top" title="back to top">⇪</div>
 	</main>
 
 <footer>

--- a/view/theme/frio/scheme/black.css
+++ b/view/theme/frio/scheme/black.css
@@ -347,11 +347,17 @@ section > .generic-page-wrapper,
 .fsuggest-content-wrapper,
 .panel,
 aside .widget,
-.nav-container .widget{
+.nav-container .widget,
+#back-to-top
+{
 	box-shadow: 0 0 3px $link_color;
 	-webkit-box-shadow: 0 0 3px $link_color;
 }
 
 input[type=text].tt-input {
 	box-shadow: none;
+}
+
+#back-to-top {
+	color: $link_color;
 }

--- a/view/theme/frio/scheme/dark.css
+++ b/view/theme/frio/scheme/dark.css
@@ -327,3 +327,7 @@ legend {
 input[type=text].tt-input {
 	box-shadow: none;
 }
+
+#back-to-top {
+	border: 1px solid $nav_icon_color;
+}


### PR DESCRIPTION
Supersedes #9403
Fixes #9249 

- Add specific support for dark/black schemes

Unfortunately #9403 cannot be accepted because it uses the `mask` CSS property that has a spotty support among browsers. Here's my more modest approach to move the needle of #9249 forward thanks to @foss- prodding.

I replaced the existing Unicode arrow because this one was more visible and convey better the idea of back to top among the available ones : `⇑⇧⇪⇮⇭⇫⇬⇯`

Here are the results:

Light scheme
![friendica-frio-back-to-top-light](https://user-images.githubusercontent.com/925415/103394199-00745900-4af5-11eb-8a54-0258b14ded5d.png)

Dark scheme
![friendica-frio-back-to-top-dark](https://user-images.githubusercontent.com/925415/103394198-00745900-4af5-11eb-84a3-032a3b247ce5.png)

Black scheme
![friendica-frio-back-to-top-black](https://user-images.githubusercontent.com/925415/103394194-ffdbc280-4af4-11eb-848b-1830fb9c379c.png)
