### PR TITLE
Issue 9736: Fix for undroppable registrations

### DIFF
--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -1159,6 +1159,9 @@ class User
 			return false;
 		}
 
+		// Delete the avatar
+		Photo::delete(['uid' => $register['uid']]);
+
 		return DBA::delete('user', ['uid' => $register['uid']]) &&
 		       Register::deleteByHash($register['hash']);
 	}


### PR DESCRIPTION
This fixes https://github.com/friendica/friendica/issues/9736

Due to the foreign keys we can only delete users if there is no photo entry for them.