### PR TITLE
Append to session remotes instead of replacing

### DIFF
--- a/src/Core/Session.php
+++ b/src/Core/Session.php
@@ -124,7 +124,7 @@ class Session
 			}
 
 			/* get+set to append */
-			$remote_value = $session->get('remote', null);
+			$remote_value = $session->get('remote', []);
 			$remote_value[$contact['uid']] = $contact['id'];
 			$session->set('remote', $remote_value);
 		}

--- a/src/Core/Session.php
+++ b/src/Core/Session.php
@@ -123,7 +123,10 @@ class Session
 				continue;
 			}
 
-			$session->set('remote', [$contact['uid'] => $contact['id']]);
+			/* get+set to append */
+			$remote_value = $session->get('remote', null);
+			$remote_value[$contact['uid']] = $contact['id'];
+			$session->set('remote', $remote_value);
 		}
 		DBA::close($remote_contacts);
 	}


### PR DESCRIPTION
This change is necessary for my (mostly private) site to work correctly.  In this context it is very common to have several contacts on the same node.  Let me know if I should retarget to develop if it is too close to release.

The session remotes array stores the contacts that a current user is authenticated as, which may correspond to multiple local users.  The list is constructed correctly but each consecutive entry is saved to the session by overwriting the whole remotes array with a single element list rather than appending to it.  This change now reads the current list, adds an element appropriately, and saves it back to the session.

One comment on the idiosyncrasy:  I'm not sure why the array isn't constructed wholesale and then saved to the session.  The existing code saves an empty list to the session as the first step and then seems to try to save each addition to the session individually as well.  So I followed that pattern.  I'm not sure if there is some session coherence maintained by doing it this way or not.