### PR TITLE
Delete sleeping database processes

### DIFF
--- a/src/Worker/Cron.php
+++ b/src/Worker/Cron.php
@@ -154,7 +154,7 @@ class Cron
 		
 		$processes = DBA::p("SHOW FULL PROCESSLIST");
 		while ($process = DBA::fetch($processes)) {
-			if (($process['Command'] != 'Sleep') || ($process['Time'] < 60) || ($process['db'] != DBA::databaseName())) {
+			if (($process['Command'] != 'Sleep') || ($process['Time'] < 300) || ($process['db'] != DBA::databaseName())) {
 				continue;
 			}
 

--- a/src/Worker/Cron.php
+++ b/src/Worker/Cron.php
@@ -154,7 +154,6 @@ class Cron
 		
 		$processes = DBA::p("SHOW FULL PROCESSLIST");
 		while ($process = DBA::fetch($processes)) {
-			// To-Do: Auf Datenbank abgrenzen
 			if (($process['Command'] != 'Sleep') || ($process['Time'] < 60) || ($process['db'] != DBA::databaseName())) {
 				continue;
 			}

--- a/static/defaults.config.php
+++ b/static/defaults.config.php
@@ -194,6 +194,10 @@ return [
 		// If it is not running and hadn't been terminated normally, it will be started automatically.
 		'daemon_watchdog' => false,
 
+		// delete_sleeping_processes (Boolean)
+		// Periodically delete waiting database processes.
+		'delete_sleeping_processes' => false,
+
 		// diaspora_test (Boolean)
 		// For development only. Disables the message transfer.
 		'diaspora_test' => false,


### PR DESCRIPTION
Sometimes database connections are kept open and are just sleeping. There is now an option to kill them.