### PR TITLE
[frio] Add share dropdown to mobile post view

### DIFF
--- a/src/Object/Post.php
+++ b/src/Object/Post.php
@@ -351,10 +351,11 @@ class Post
 			$buttons['like']    = [DI::l10n()->t("I like this \x28toggle\x29")      , DI::l10n()->t("like")];
 			$buttons['dislike'] = [DI::l10n()->t("I don't like this \x28toggle\x29"), DI::l10n()->t("dislike")];
 			if ($shareable) {
-				$buttons['share'] = [DI::l10n()->t('Quote and share this'), DI::l10n()->t('Quote Share')];
+				$buttons['share'] = [DI::l10n()->t('Quote share this'), DI::l10n()->t('Quote Share')];
 			}
 			if ($announceable) {
-				$buttons['announce'] = [DI::l10n()->t('Share this'), DI::l10n()->t('Share')];
+				$buttons['announce'] = [DI::l10n()->t('Reshare this'), DI::l10n()->t('Reshare')];
+				$buttons['unannounce'] = [DI::l10n()->t('Cancel your Reshare'), DI::l10n()->t('Unshare')];
 			}
 		}
 

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -1,14 +1,14 @@
 # FRIENDICA Distributed Social Network
-# Copyright (C) 2010-2020 the Friendica Project
+# Copyright (C) 2010-2021 the Friendica Project
 # This file is distributed under the same license as the Friendica package.
 # Mike Macgirvin, 2010
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: 2020.12-rc\n"
+"Project-Id-Version: 2021.03-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-12-27 12:02+0000\n"
+"POT-Creation-Date: 2021-01-07 10:15-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,448 +18,35 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 
-#: view/theme/duepuntozero/config.php:52
-msgid "default"
-msgstr ""
-
-#: view/theme/duepuntozero/config.php:53
-msgid "greenzero"
-msgstr ""
-
-#: view/theme/duepuntozero/config.php:54
-msgid "purplezero"
-msgstr ""
-
-#: view/theme/duepuntozero/config.php:55
-msgid "easterbunny"
-msgstr ""
-
-#: view/theme/duepuntozero/config.php:56
-msgid "darkzero"
-msgstr ""
-
-#: view/theme/duepuntozero/config.php:57
-msgid "comix"
-msgstr ""
-
-#: view/theme/duepuntozero/config.php:58
-msgid "slackr"
-msgstr ""
-
-#: view/theme/duepuntozero/config.php:69 view/theme/quattro/config.php:71
-#: view/theme/vier/config.php:119 view/theme/frio/config.php:160
-#: mod/message.php:206 mod/message.php:374 mod/events.php:579
-#: mod/photos.php:950 mod/photos.php:1053 mod/photos.php:1339
-#: mod/photos.php:1380 mod/photos.php:1437 mod/photos.php:1510
-#: src/Object/Post.php:953 src/Module/Debug/Localtime.php:64
-#: src/Module/Profile/Profile.php:242 src/Module/FriendSuggest.php:129
-#: src/Module/Install.php:234 src/Module/Install.php:276
-#: src/Module/Install.php:313 src/Module/Delegation.php:152
-#: src/Module/Contact.php:604 src/Module/Invite.php:175
-#: src/Module/Item/Compose.php:144 src/Module/Contact/Poke.php:155
-#: src/Module/Contact/Advanced.php:132
-#: src/Module/Settings/Profile/Index.php:237
-msgid "Submit"
-msgstr ""
-
-#: view/theme/duepuntozero/config.php:70 view/theme/quattro/config.php:72
-#: view/theme/vier/config.php:120 view/theme/frio/config.php:161
-#: src/Module/Settings/Display.php:193
-msgid "Theme settings"
-msgstr ""
-
-#: view/theme/duepuntozero/config.php:71
-msgid "Variations"
-msgstr ""
-
-#: view/theme/quattro/config.php:73
-msgid "Alignment"
-msgstr ""
-
-#: view/theme/quattro/config.php:73
-msgid "Left"
-msgstr ""
-
-#: view/theme/quattro/config.php:73
-msgid "Center"
-msgstr ""
-
-#: view/theme/quattro/config.php:74
-msgid "Color scheme"
-msgstr ""
-
-#: view/theme/quattro/config.php:75
-msgid "Posts font size"
-msgstr ""
-
-#: view/theme/quattro/config.php:76
-msgid "Textareas font size"
-msgstr ""
-
-#: view/theme/vier/config.php:75
-msgid "Comma separated list of helper forums"
-msgstr ""
-
-#: view/theme/vier/config.php:115
-msgid "don't show"
-msgstr ""
-
-#: view/theme/vier/config.php:115
-msgid "show"
-msgstr ""
-
-#: view/theme/vier/config.php:121
-msgid "Set style"
-msgstr ""
-
-#: view/theme/vier/config.php:122
-msgid "Community Pages"
-msgstr ""
-
-#: view/theme/vier/config.php:123 view/theme/vier/theme.php:125
-msgid "Community Profiles"
-msgstr ""
-
-#: view/theme/vier/config.php:124
-msgid "Help or @NewHere ?"
-msgstr ""
-
-#: view/theme/vier/config.php:125 view/theme/vier/theme.php:296
-msgid "Connect Services"
-msgstr ""
-
-#: view/theme/vier/config.php:126
-msgid "Find Friends"
-msgstr ""
-
-#: view/theme/vier/config.php:127 view/theme/vier/theme.php:152
-msgid "Last users"
-msgstr ""
-
-#: view/theme/vier/theme.php:170 src/Content/Widget.php:73
-msgid "Find People"
-msgstr ""
-
-#: view/theme/vier/theme.php:171 src/Content/Widget.php:74
-msgid "Enter name or interest"
-msgstr ""
-
-#: view/theme/vier/theme.php:172 include/conversation.php:962
-#: mod/follow.php:145 src/Model/Contact.php:979 src/Model/Contact.php:992
-#: src/Content/Widget.php:75
-msgid "Connect/Follow"
-msgstr ""
-
-#: view/theme/vier/theme.php:173 src/Content/Widget.php:76
-msgid "Examples: Robert Morgenstein, Fishing"
-msgstr ""
-
-#: view/theme/vier/theme.php:174 src/Module/Contact.php:876
-#: src/Module/Directory.php:105 src/Content/Widget.php:77
-msgid "Find"
-msgstr ""
-
-#: view/theme/vier/theme.php:175 mod/suggest.php:55 src/Content/Widget.php:78
-msgid "Friend Suggestions"
-msgstr ""
-
-#: view/theme/vier/theme.php:176 src/Content/Widget.php:79
-msgid "Similar Interests"
-msgstr ""
-
-#: view/theme/vier/theme.php:177 src/Content/Widget.php:80
-msgid "Random Profile"
-msgstr ""
-
-#: view/theme/vier/theme.php:178 src/Content/Widget.php:81
-msgid "Invite Friends"
-msgstr ""
-
-#: view/theme/vier/theme.php:179 src/Module/Directory.php:97
-#: src/Content/Widget.php:82
-msgid "Global Directory"
-msgstr ""
-
-#: view/theme/vier/theme.php:181 src/Content/Widget.php:84
-msgid "Local Directory"
-msgstr ""
-
-#: view/theme/vier/theme.php:211
-msgid "Quick Start"
-msgstr ""
-
-#: view/theme/vier/theme.php:217 src/Module/Help.php:69
-#: src/Module/Settings/TwoFactor/Index.php:106
-#: src/Module/Settings/TwoFactor/Verify.php:132
-#: src/Module/Settings/TwoFactor/Recovery.php:93
-#: src/Module/Settings/TwoFactor/AppSpecific.php:115 src/Content/Nav.php:212
-msgid "Help"
-msgstr ""
-
-#: view/theme/frio/config.php:142
-msgid "Light (Accented)"
-msgstr ""
-
-#: view/theme/frio/config.php:143
-msgid "Dark (Accented)"
-msgstr ""
-
-#: view/theme/frio/config.php:144
-msgid "Black (Accented)"
-msgstr ""
-
-#: view/theme/frio/config.php:156
-msgid "Note"
-msgstr ""
-
-#: view/theme/frio/config.php:156
-msgid "Check image permissions if all users are allowed to see the image"
-msgstr ""
-
-#: view/theme/frio/config.php:162
-msgid "Custom"
-msgstr ""
-
-#: view/theme/frio/config.php:163
-msgid "Legacy"
-msgstr ""
-
-#: view/theme/frio/config.php:164
-msgid "Accented"
-msgstr ""
-
-#: view/theme/frio/config.php:165
-msgid "Select color scheme"
-msgstr ""
-
-#: view/theme/frio/config.php:166
-msgid "Select scheme accent"
-msgstr ""
-
-#: view/theme/frio/config.php:166
-msgid "Blue"
-msgstr ""
-
-#: view/theme/frio/config.php:166
-msgid "Red"
-msgstr ""
-
-#: view/theme/frio/config.php:166
-msgid "Purple"
-msgstr ""
-
-#: view/theme/frio/config.php:166
-msgid "Green"
-msgstr ""
-
-#: view/theme/frio/config.php:166
-msgid "Pink"
-msgstr ""
-
-#: view/theme/frio/config.php:167
-msgid "Copy or paste schemestring"
-msgstr ""
-
-#: view/theme/frio/config.php:167
-msgid ""
-"You can copy this string to share your theme with others. Pasting here "
-"applies the schemestring"
-msgstr ""
-
-#: view/theme/frio/config.php:168
-msgid "Navigation bar background color"
-msgstr ""
-
-#: view/theme/frio/config.php:169
-msgid "Navigation bar icon color "
-msgstr ""
-
-#: view/theme/frio/config.php:170
-msgid "Link color"
-msgstr ""
-
-#: view/theme/frio/config.php:171
-msgid "Set the background color"
-msgstr ""
-
-#: view/theme/frio/config.php:172
-msgid "Content background opacity"
-msgstr ""
-
-#: view/theme/frio/config.php:173
-msgid "Set the background image"
-msgstr ""
-
-#: view/theme/frio/config.php:174
-msgid "Background image style"
-msgstr ""
-
-#: view/theme/frio/config.php:179
-msgid "Login page background image"
-msgstr ""
-
-#: view/theme/frio/config.php:183
-msgid "Login page background color"
-msgstr ""
-
-#: view/theme/frio/config.php:183
-msgid "Leave background image and color empty for theme defaults"
-msgstr ""
-
-#: view/theme/frio/theme.php:207
-msgid "Guest"
-msgstr ""
-
-#: view/theme/frio/theme.php:210
-msgid "Visitor"
-msgstr ""
-
-#: view/theme/frio/theme.php:225 src/Module/Contact.php:655
-#: src/Module/Contact.php:920 src/Module/BaseProfile.php:60
-#: src/Module/Settings/TwoFactor/Index.php:107 src/Content/Nav.php:177
-msgid "Status"
-msgstr ""
-
-#: view/theme/frio/theme.php:225 src/Content/Nav.php:177
-#: src/Content/Nav.php:263
-msgid "Your posts and conversations"
-msgstr ""
-
-#: view/theme/frio/theme.php:226 src/Module/Profile/Profile.php:236
-#: src/Module/Welcome.php:57 src/Module/Contact.php:657
-#: src/Module/Contact.php:936 src/Module/BaseProfile.php:52
-#: src/Module/BaseSettings.php:57 src/Content/Nav.php:178
-msgid "Profile"
-msgstr ""
-
-#: view/theme/frio/theme.php:226 src/Content/Nav.php:178
-msgid "Your profile page"
-msgstr ""
-
-#: view/theme/frio/theme.php:227 mod/fbrowser.php:43
-#: src/Module/BaseProfile.php:68 src/Content/Nav.php:179
-msgid "Photos"
-msgstr ""
-
-#: view/theme/frio/theme.php:227 src/Content/Nav.php:179
-msgid "Your photos"
-msgstr ""
-
-#: view/theme/frio/theme.php:228 src/Module/BaseProfile.php:76
-#: src/Module/BaseProfile.php:79 src/Content/Nav.php:180
-msgid "Videos"
-msgstr ""
-
-#: view/theme/frio/theme.php:228 src/Content/Nav.php:180
-msgid "Your videos"
-msgstr ""
-
-#: view/theme/frio/theme.php:229 view/theme/frio/theme.php:233 mod/cal.php:273
-#: mod/events.php:421 src/Module/BaseProfile.php:88
-#: src/Module/BaseProfile.php:99 src/Content/Nav.php:181
-#: src/Content/Nav.php:248
-msgid "Events"
-msgstr ""
-
-#: view/theme/frio/theme.php:229 src/Content/Nav.php:181
-msgid "Your events"
-msgstr ""
-
-#: view/theme/frio/theme.php:232 src/Content/Nav.php:261
-msgid "Network"
-msgstr ""
-
-#: view/theme/frio/theme.php:232 src/Content/Nav.php:261
-msgid "Conversations from your friends"
-msgstr ""
-
-#: view/theme/frio/theme.php:233 src/Module/BaseProfile.php:91
-#: src/Module/BaseProfile.php:102 src/Content/Nav.php:248
-msgid "Events and Calendar"
-msgstr ""
-
-#: view/theme/frio/theme.php:234 mod/message.php:135 src/Content/Nav.php:273
-msgid "Messages"
-msgstr ""
-
-#: view/theme/frio/theme.php:234 src/Content/Nav.php:273
-msgid "Private mail"
-msgstr ""
-
-#: view/theme/frio/theme.php:235 src/Module/Welcome.php:52
-#: src/Module/Admin/Themes/Details.php:93
-#: src/Module/Admin/Addons/Details.php:114 src/Module/BaseSettings.php:124
-#: src/Content/Nav.php:282
-msgid "Settings"
-msgstr ""
-
-#: view/theme/frio/theme.php:235 src/Content/Nav.php:282
-msgid "Account settings"
-msgstr ""
-
-#: view/theme/frio/theme.php:236 src/Module/Contact.php:855
-#: src/Module/Contact.php:943 src/Module/BaseProfile.php:121
-#: src/Module/BaseProfile.php:124 src/Content/Nav.php:225
-#: src/Content/Nav.php:284 src/Content/Text/HTML.php:898
-msgid "Contacts"
-msgstr ""
-
-#: view/theme/frio/theme.php:236 src/Content/Nav.php:284
-msgid "Manage/edit friends and contacts"
-msgstr ""
-
-#: view/theme/frio/theme.php:321 include/conversation.php:941
-msgid "Follow Thread"
-msgstr ""
-
-#: view/theme/frio/php/standard.php:38 view/theme/frio/php/default.php:81
-msgid "Skip to main content"
-msgstr ""
-
-#: view/theme/frio/php/Image.php:40
-msgid "Top Banner"
-msgstr ""
-
-#: view/theme/frio/php/Image.php:40
-msgid ""
-"Resize image to the width of the screen and show background color below on "
-"long pages."
-msgstr ""
-
-#: view/theme/frio/php/Image.php:41
-msgid "Full screen"
-msgstr ""
-
-#: view/theme/frio/php/Image.php:41
-msgid ""
-"Resize image to fill entire screen, clipping either the right or the bottom."
-msgstr ""
-
-#: view/theme/frio/php/Image.php:42
-msgid "Single row mosaic"
-msgstr ""
-
-#: view/theme/frio/php/Image.php:42
-msgid ""
-"Resize image to repeat it on a single row, either vertical or horizontal."
-msgstr ""
-
-#: view/theme/frio/php/Image.php:43
-msgid "Mosaic"
-msgstr ""
-
-#: view/theme/frio/php/Image.php:43
-msgid "Repeat image to fill the screen."
-msgstr ""
-
-#: update.php:198
+#: include/api.php:1128
 #, php-format
-msgid "%s: Updating author-id and owner-id in item and thread table. "
+msgid "Daily posting limit of %d post reached. The post was rejected."
+msgid_plural "Daily posting limit of %d posts reached. The post was rejected."
+msgstr[0] ""
+msgstr[1] ""
+
+#: include/api.php:1142
+#, php-format
+msgid "Weekly posting limit of %d post reached. The post was rejected."
+msgid_plural "Weekly posting limit of %d posts reached. The post was rejected."
+msgstr[0] ""
+msgstr[1] ""
+
+#: include/api.php:1156
+#, php-format
+msgid "Monthly posting limit of %d post reached. The post was rejected."
 msgstr ""
 
-#: update.php:253
-#, php-format
-msgid "%s: Updating post-type."
+#: include/api.php:4458 mod/photos.php:106 mod/photos.php:210
+#: mod/photos.php:638 mod/photos.php:1042 mod/photos.php:1059
+#: mod/photos.php:1607 src/Model/User.php:1045 src/Model/User.php:1053
+#: src/Model/User.php:1061 src/Module/Settings/Profile/Photo/Crop.php:97
+#: src/Module/Settings/Profile/Photo/Crop.php:113
+#: src/Module/Settings/Profile/Photo/Crop.php:129
+#: src/Module/Settings/Profile/Photo/Crop.php:178
+#: src/Module/Settings/Profile/Photo/Index.php:96
+#: src/Module/Settings/Profile/Photo/Index.php:102
+msgid "Profile Photos"
 msgstr ""
 
 #: include/conversation.php:189
@@ -488,27 +75,27 @@ msgstr ""
 msgid "Select"
 msgstr ""
 
-#: include/conversation.php:560 mod/settings.php:564 mod/settings.php:706
-#: mod/photos.php:1469 src/Module/Contact.php:886 src/Module/Contact.php:1190
-#: src/Module/Admin/Users/Index.php:153 src/Module/Admin/Users/Active.php:139
-#: src/Module/Admin/Users/Blocked.php:140
+#: include/conversation.php:560 mod/photos.php:1469 mod/settings.php:564
+#: mod/settings.php:706 src/Module/Admin/Users/Active.php:139
+#: src/Module/Admin/Users/Blocked.php:140 src/Module/Admin/Users/Index.php:153
+#: src/Module/Contact.php:886 src/Module/Contact.php:1190
 msgid "Delete"
 msgstr ""
 
-#: include/conversation.php:595 src/Object/Post.php:449 src/Object/Post.php:450
+#: include/conversation.php:595 src/Object/Post.php:450 src/Object/Post.php:451
 #, php-format
 msgid "View %s's profile @ %s"
 msgstr ""
 
-#: include/conversation.php:608 src/Object/Post.php:437
+#: include/conversation.php:608 src/Object/Post.php:438
 msgid "Categories:"
 msgstr ""
 
-#: include/conversation.php:609 src/Object/Post.php:438
+#: include/conversation.php:609 src/Object/Post.php:439
 msgid "Filed under:"
 msgstr ""
 
-#: include/conversation.php:616 src/Object/Post.php:463
+#: include/conversation.php:616 src/Object/Post.php:464
 #, php-format
 msgid "%s from %s"
 msgstr ""
@@ -518,9 +105,9 @@ msgid "View in context"
 msgstr ""
 
 #: include/conversation.php:633 include/conversation.php:1215
-#: mod/wallmessage.php:155 mod/message.php:205 mod/message.php:375
-#: mod/editpost.php:105 mod/photos.php:1534 src/Object/Post.php:496
-#: src/Module/Item/Compose.php:159
+#: mod/editpost.php:105 mod/message.php:205 mod/message.php:375
+#: mod/photos.php:1534 mod/wallmessage.php:155 src/Module/Item/Compose.php:159
+#: src/Object/Post.php:497
 msgid "Please wait"
 msgstr ""
 
@@ -593,14 +180,18 @@ msgstr ""
 msgid "Fetched because of %s"
 msgstr ""
 
+#: include/conversation.php:941 view/theme/frio/theme.php:321
+msgid "Follow Thread"
+msgstr ""
+
 #: include/conversation.php:942 src/Model/Contact.php:984
 msgid "View Status"
 msgstr ""
 
 #: include/conversation.php:943 include/conversation.php:965
-#: src/Module/Directory.php:166 src/Module/Settings/Profile/Index.php:240
 #: src/Model/Contact.php:910 src/Model/Contact.php:976
-#: src/Model/Contact.php:985
+#: src/Model/Contact.php:985 src/Module/Directory.php:166
+#: src/Module/Settings/Profile/Index.php:240
 msgid "View Profile"
 msgstr ""
 
@@ -622,26 +213,33 @@ msgstr ""
 msgid "Send PM"
 msgstr ""
 
-#: include/conversation.php:948 src/Module/Contact.php:625
-#: src/Module/Contact.php:883 src/Module/Contact.php:1165
-#: src/Module/Admin/Users/Index.php:154 src/Module/Admin/Users/Active.php:140
-#: src/Module/Admin/Blocklist/Contact.php:84
+#: include/conversation.php:948 src/Module/Admin/Blocklist/Contact.php:84
+#: src/Module/Admin/Users/Active.php:140 src/Module/Admin/Users/Index.php:154
+#: src/Module/Contact.php:625 src/Module/Contact.php:883
+#: src/Module/Contact.php:1165
 msgid "Block"
 msgstr ""
 
-#: include/conversation.php:949 src/Module/Notifications/Notification.php:59
-#: src/Module/Notifications/Introductions.php:113
-#: src/Module/Notifications/Introductions.php:191 src/Module/Contact.php:626
+#: include/conversation.php:949 src/Module/Contact.php:626
 #: src/Module/Contact.php:884 src/Module/Contact.php:1173
+#: src/Module/Notifications/Introductions.php:113
+#: src/Module/Notifications/Introductions.php:191
+#: src/Module/Notifications/Notification.php:59
 msgid "Ignore"
 msgstr ""
 
-#: include/conversation.php:953 src/Object/Post.php:426
+#: include/conversation.php:953 src/Object/Post.php:427
 msgid "Languages"
 msgstr ""
 
 #: include/conversation.php:957 src/Model/Contact.php:991
 msgid "Poke"
+msgstr ""
+
+#: include/conversation.php:962 mod/follow.php:145 src/Content/Widget.php:75
+#: src/Model/Contact.php:979 src/Model/Contact.php:992
+#: view/theme/vier/theme.php:172
+msgid "Connect/Follow"
 msgstr ""
 
 #: include/conversation.php:1093
@@ -737,8 +335,8 @@ msgstr ""
 msgid "Visible to <strong>everybody</strong>"
 msgstr ""
 
-#: include/conversation.php:1176 src/Object/Post.php:963
-#: src/Module/Item/Compose.php:153
+#: include/conversation.php:1176 src/Module/Item/Compose.php:153
+#: src/Object/Post.php:964
 msgid "Please enter a image/video/audio/webpage URL:"
 msgstr ""
 
@@ -762,17 +360,17 @@ msgstr ""
 msgid "New Post"
 msgstr ""
 
-#: include/conversation.php:1193 src/Object/Post.php:357
+#: include/conversation.php:1193
 msgid "Share"
 msgstr ""
 
 #: include/conversation.php:1194 mod/editpost.php:90 mod/photos.php:1382
-#: src/Object/Post.php:954 src/Module/Contact/Poke.php:154
+#: src/Module/Contact/Poke.php:154 src/Object/Post.php:955
 msgid "Loading..."
 msgstr ""
 
-#: include/conversation.php:1195 mod/wallmessage.php:153 mod/message.php:203
-#: mod/message.php:372 mod/editpost.php:91
+#: include/conversation.php:1195 mod/editpost.php:91 mod/message.php:203
+#: mod/message.php:372 mod/wallmessage.php:153
 msgid "Upload photo"
 msgstr ""
 
@@ -788,43 +386,43 @@ msgstr ""
 msgid "attach file"
 msgstr ""
 
-#: include/conversation.php:1199 src/Object/Post.php:955
-#: src/Module/Item/Compose.php:145
+#: include/conversation.php:1199 src/Module/Item/Compose.php:145
+#: src/Object/Post.php:956
 msgid "Bold"
 msgstr ""
 
-#: include/conversation.php:1200 src/Object/Post.php:956
-#: src/Module/Item/Compose.php:146
+#: include/conversation.php:1200 src/Module/Item/Compose.php:146
+#: src/Object/Post.php:957
 msgid "Italic"
 msgstr ""
 
-#: include/conversation.php:1201 src/Object/Post.php:957
-#: src/Module/Item/Compose.php:147
+#: include/conversation.php:1201 src/Module/Item/Compose.php:147
+#: src/Object/Post.php:958
 msgid "Underline"
 msgstr ""
 
-#: include/conversation.php:1202 src/Object/Post.php:958
-#: src/Module/Item/Compose.php:148
+#: include/conversation.php:1202 src/Module/Item/Compose.php:148
+#: src/Object/Post.php:959
 msgid "Quote"
 msgstr ""
 
-#: include/conversation.php:1203 src/Object/Post.php:959
-#: src/Module/Item/Compose.php:149
+#: include/conversation.php:1203 src/Module/Item/Compose.php:149
+#: src/Object/Post.php:960
 msgid "Code"
 msgstr ""
 
-#: include/conversation.php:1204 src/Object/Post.php:960
-#: src/Module/Item/Compose.php:150
+#: include/conversation.php:1204 src/Module/Item/Compose.php:150
+#: src/Object/Post.php:961
 msgid "Image"
 msgstr ""
 
-#: include/conversation.php:1205 src/Object/Post.php:961
-#: src/Module/Item/Compose.php:151
+#: include/conversation.php:1205 src/Module/Item/Compose.php:151
+#: src/Object/Post.php:962
 msgid "Link"
 msgstr ""
 
-#: include/conversation.php:1206 src/Object/Post.php:962
-#: src/Module/Item/Compose.php:152
+#: include/conversation.php:1206 src/Module/Item/Compose.php:152
+#: src/Object/Post.php:963
 msgid "Link or Media"
 msgstr ""
 
@@ -859,7 +457,7 @@ msgstr ""
 msgid "Permission settings"
 msgstr ""
 
-#: include/conversation.php:1217 mod/editpost.php:135 mod/events.php:582
+#: include/conversation.php:1217 mod/editpost.php:135 mod/events.php:573
 #: mod/photos.php:968 mod/photos.php:1335
 msgid "Permissions"
 msgstr ""
@@ -868,23 +466,22 @@ msgstr ""
 msgid "Public post"
 msgstr ""
 
-#: include/conversation.php:1230 mod/editpost.php:126 mod/events.php:577
+#: include/conversation.php:1230 mod/editpost.php:126 mod/events.php:568
 #: mod/photos.php:1381 mod/photos.php:1438 mod/photos.php:1511
-#: src/Object/Post.php:964 src/Module/Item/Compose.php:154
+#: src/Module/Item/Compose.php:154 src/Object/Post.php:965
 msgid "Preview"
 msgstr ""
 
-#: include/conversation.php:1234 mod/settings.php:504 mod/settings.php:530
-#: mod/unfollow.php:100 mod/tagrm.php:36 mod/tagrm.php:126
-#: mod/dfrn_request.php:643 mod/editpost.php:129 mod/follow.php:151
-#: mod/fbrowser.php:105 mod/fbrowser.php:134 mod/photos.php:1036
-#: mod/photos.php:1142 src/Module/Contact.php:459
-#: src/Module/RemoteFollow.php:110
+#: include/conversation.php:1234 mod/dfrn_request.php:643 mod/editpost.php:129
+#: mod/fbrowser.php:105 mod/fbrowser.php:134 mod/follow.php:151
+#: mod/photos.php:1036 mod/photos.php:1142 mod/settings.php:504
+#: mod/settings.php:530 mod/tagrm.php:36 mod/tagrm.php:126 mod/unfollow.php:100
+#: src/Module/Contact.php:459 src/Module/RemoteFollow.php:110
 msgid "Cancel"
 msgstr ""
 
-#: include/conversation.php:1241 mod/editpost.php:133
-#: src/Module/Contact.php:344 src/Model/Profile.php:445
+#: include/conversation.php:1241 mod/editpost.php:133 src/Model/Profile.php:445
+#: src/Module/Contact.php:344
 msgid "Message"
 msgstr ""
 
@@ -1221,144 +818,153 @@ msgstr ""
 msgid "Please visit %s to approve or reject the request."
 msgstr ""
 
-#: include/api.php:1128
-#, php-format
-msgid "Daily posting limit of %d post reached. The post was rejected."
-msgid_plural "Daily posting limit of %d posts reached. The post was rejected."
-msgstr[0] ""
-msgstr[1] ""
-
-#: include/api.php:1142
-#, php-format
-msgid "Weekly posting limit of %d post reached. The post was rejected."
-msgid_plural "Weekly posting limit of %d posts reached. The post was rejected."
-msgstr[0] ""
-msgstr[1] ""
-
-#: include/api.php:1156
-#, php-format
-msgid "Monthly posting limit of %d post reached. The post was rejected."
-msgstr ""
-
-#: include/api.php:4458 mod/photos.php:106 mod/photos.php:210
-#: mod/photos.php:638 mod/photos.php:1042 mod/photos.php:1059
-#: mod/photos.php:1607 src/Module/Settings/Profile/Photo/Crop.php:97
-#: src/Module/Settings/Profile/Photo/Crop.php:113
-#: src/Module/Settings/Profile/Photo/Crop.php:129
-#: src/Module/Settings/Profile/Photo/Crop.php:178
-#: src/Module/Settings/Profile/Photo/Index.php:96
-#: src/Module/Settings/Profile/Photo/Index.php:102 src/Model/User.php:1045
-#: src/Model/User.php:1053 src/Model/User.php:1061
-msgid "Profile Photos"
-msgstr ""
-
-#: mod/redir.php:34 mod/redir.php:203 mod/cal.php:47 mod/cal.php:51
-#: mod/follow.php:37 src/Module/Debug/ItemBody.php:37
-#: src/Module/Conversation/Community.php:193 src/Module/Item/Ignore.php:41
-#: src/Module/Diaspora/Receive.php:51
-msgid "Access denied."
-msgstr ""
-
-#: mod/redir.php:50 mod/redir.php:130
-msgid "Bad Request."
-msgstr ""
-
-#: mod/redir.php:56 mod/redir.php:157 mod/dfrn_confirm.php:140
-#: src/Module/FriendSuggest.php:54 src/Module/FriendSuggest.php:93
-#: src/Module/Group.php:105 src/Module/Contact/Advanced.php:53
-#: src/Module/Contact/Advanced.php:104 src/Module/Contact/Contacts.php:36
-msgid "Contact not found."
-msgstr ""
-
-#: mod/wallmessage.php:35 mod/wallmessage.php:59 mod/wallmessage.php:96
-#: mod/wallmessage.php:120 mod/dfrn_confirm.php:79 mod/settings.php:47
-#: mod/settings.php:65 mod/settings.php:493 mod/repair_ostatus.php:31
-#: mod/unfollow.php:35 mod/unfollow.php:50 mod/unfollow.php:82
-#: mod/message.php:70 mod/message.php:113 mod/ostatus_subscribe.php:30
-#: mod/suggest.php:34 mod/wall_upload.php:99 mod/wall_upload.php:102
-#: mod/api.php:52 mod/api.php:57 mod/wall_attach.php:78 mod/wall_attach.php:81
-#: mod/item.php:183 mod/item.php:188 mod/item.php:916 mod/uimport.php:32
-#: mod/editpost.php:38 mod/events.php:235 mod/follow.php:54 mod/follow.php:134
-#: mod/notes.php:43 mod/photos.php:175 mod/photos.php:921
-#: src/Module/Notifications/Notification.php:47
+#: mod/api.php:52 mod/api.php:57 mod/dfrn_confirm.php:79 mod/editpost.php:38
+#: mod/events.php:226 mod/follow.php:54 mod/follow.php:134 mod/item.php:183
+#: mod/item.php:188 mod/item.php:916 mod/message.php:70 mod/message.php:113
+#: mod/notes.php:43 mod/ostatus_subscribe.php:30 mod/photos.php:175
+#: mod/photos.php:921 mod/repair_ostatus.php:31 mod/settings.php:47
+#: mod/settings.php:65 mod/settings.php:493 mod/suggest.php:34
+#: mod/uimport.php:32 mod/unfollow.php:35 mod/unfollow.php:50
+#: mod/unfollow.php:82 mod/wallmessage.php:35 mod/wallmessage.php:59
+#: mod/wallmessage.php:96 mod/wallmessage.php:120 mod/wall_attach.php:78
+#: mod/wall_attach.php:81 mod/wall_upload.php:99 mod/wall_upload.php:102
+#: src/Module/Attach.php:56 src/Module/BaseApi.php:59 src/Module/BaseApi.php:65
+#: src/Module/BaseNotifications.php:88 src/Module/Contact/Advanced.php:43
+#: src/Module/Contact.php:385 src/Module/Delegation.php:118
+#: src/Module/FollowConfirm.php:16 src/Module/FriendSuggest.php:44
+#: src/Module/Group.php:45 src/Module/Group.php:90 src/Module/Invite.php:40
+#: src/Module/Invite.php:128 src/Module/Notifications/Notification.php:47
 #: src/Module/Notifications/Notification.php:76
 #: src/Module/Profile/Common.php:57 src/Module/Profile/Contacts.php:57
-#: src/Module/BaseNotifications.php:88 src/Module/Register.php:62
-#: src/Module/Register.php:75 src/Module/Register.php:193
-#: src/Module/Register.php:232 src/Module/FriendSuggest.php:44
-#: src/Module/BaseApi.php:59 src/Module/BaseApi.php:65
-#: src/Module/Delegation.php:118 src/Module/Contact.php:385
-#: src/Module/FollowConfirm.php:16 src/Module/Invite.php:40
-#: src/Module/Invite.php:128 src/Module/Attach.php:56 src/Module/Group.php:45
-#: src/Module/Group.php:90 src/Module/Search/Directory.php:38
-#: src/Module/Contact/Advanced.php:43
+#: src/Module/Register.php:62 src/Module/Register.php:75
+#: src/Module/Register.php:193 src/Module/Register.php:232
+#: src/Module/Search/Directory.php:38 src/Module/Settings/Delegation.php:42
+#: src/Module/Settings/Delegation.php:70 src/Module/Settings/Display.php:42
+#: src/Module/Settings/Display.php:118
 #: src/Module/Settings/Profile/Photo/Crop.php:157
 #: src/Module/Settings/Profile/Photo/Index.php:113
-#: src/Module/Settings/Delegation.php:42 src/Module/Settings/Delegation.php:70
-#: src/Module/Settings/Display.php:42 src/Module/Settings/Display.php:118
 msgid "Permission denied."
 msgstr ""
 
-#: mod/wallmessage.php:68 mod/wallmessage.php:129
-#, php-format
-msgid "Number of daily wall messages for %s exceeded. Message failed."
+#: mod/api.php:102 mod/api.php:124
+msgid "Authorize application connection"
 msgstr ""
 
-#: mod/wallmessage.php:76 mod/message.php:84
-msgid "No recipient selected."
+#: mod/api.php:103
+msgid "Return to your app and insert this Securty Code:"
 msgstr ""
 
-#: mod/wallmessage.php:79
-msgid "Unable to check your home location."
+#: mod/api.php:112 src/Module/BaseAdmin.php:54 src/Module/BaseAdmin.php:58
+msgid "Please login to continue."
 msgstr ""
 
-#: mod/wallmessage.php:82 mod/message.php:91
-msgid "Message could not be sent."
-msgstr ""
-
-#: mod/wallmessage.php:85 mod/message.php:94
-msgid "Message collection failure."
-msgstr ""
-
-#: mod/wallmessage.php:103 mod/wallmessage.php:112
-msgid "No recipient."
-msgstr ""
-
-#: mod/wallmessage.php:137 mod/message.php:185 mod/message.php:298
-msgid "Please enter a link URL:"
-msgstr ""
-
-#: mod/wallmessage.php:142 mod/message.php:194
-msgid "Send Private Message"
-msgstr ""
-
-#: mod/wallmessage.php:143
-#, php-format
+#: mod/api.php:126
 msgid ""
-"If you wish for %s to respond, please check that the privacy settings on "
-"your site allow private mail from unknown senders."
+"Do you want to authorize this application to access your posts and contacts, "
+"and/or create new posts for you?"
 msgstr ""
 
-#: mod/wallmessage.php:144 mod/message.php:195 mod/message.php:364
-msgid "To:"
+#: mod/api.php:127 src/Module/Contact.php:456
+#: src/Module/Notifications/Introductions.php:123 src/Module/Register.php:115
+msgid "Yes"
 msgstr ""
 
-#: mod/wallmessage.php:145 mod/message.php:196 mod/message.php:365
-msgid "Subject:"
+#: mod/api.php:128 src/Module/Notifications/Introductions.php:123
+#: src/Module/Register.php:116
+msgid "No"
 msgstr ""
 
-#: mod/wallmessage.php:151 mod/message.php:200 mod/message.php:368
-#: src/Module/Invite.php:168
-msgid "Your message:"
+#: mod/cal.php:46 mod/cal.php:50 mod/follow.php:37 mod/redir.php:34
+#: mod/redir.php:203 src/Module/Conversation/Community.php:193
+#: src/Module/Debug/ItemBody.php:37 src/Module/Diaspora/Receive.php:51
+#: src/Module/Item/Ignore.php:41
+msgid "Access denied."
 msgstr ""
 
-#: mod/wallmessage.php:154 mod/message.php:204 mod/message.php:373
-#: mod/editpost.php:95
-msgid "Insert web link"
+#: mod/cal.php:72 mod/cal.php:133 src/Module/HoverCard.php:53
+#: src/Module/Profile/Common.php:41 src/Module/Profile/Common.php:53
+#: src/Module/Profile/Contacts.php:40 src/Module/Profile/Contacts.php:51
+#: src/Module/Profile/Status.php:57 src/Module/Register.php:258
+msgid "User not found."
+msgstr ""
+
+#: mod/cal.php:143 mod/display.php:286 src/Module/Profile/Profile.php:94
+#: src/Module/Profile/Profile.php:109 src/Module/Profile/Status.php:108
+#: src/Module/Update/Profile.php:55
+msgid "Access to this profile has been restricted."
+msgstr ""
+
+#: mod/cal.php:274 mod/events.php:412 src/Content/Nav.php:181
+#: src/Content/Nav.php:248 src/Module/BaseProfile.php:88
+#: src/Module/BaseProfile.php:99 view/theme/frio/theme.php:229
+#: view/theme/frio/theme.php:233
+msgid "Events"
+msgstr ""
+
+#: mod/cal.php:275 mod/events.php:413
+msgid "View"
+msgstr ""
+
+#: mod/cal.php:276 mod/events.php:415
+msgid "Previous"
+msgstr ""
+
+#: mod/cal.php:277 mod/events.php:416 src/Module/Install.php:196
+msgid "Next"
+msgstr ""
+
+#: mod/cal.php:280 mod/events.php:421 src/Model/Event.php:447
+msgid "today"
+msgstr ""
+
+#: mod/cal.php:281 mod/events.php:422 src/Model/Event.php:448
+#: src/Util/Temporal.php:330
+msgid "month"
+msgstr ""
+
+#: mod/cal.php:282 mod/events.php:423 src/Model/Event.php:449
+#: src/Util/Temporal.php:331
+msgid "week"
+msgstr ""
+
+#: mod/cal.php:283 mod/events.php:424 src/Model/Event.php:450
+#: src/Util/Temporal.php:332
+msgid "day"
+msgstr ""
+
+#: mod/cal.php:284 mod/events.php:425
+msgid "list"
+msgstr ""
+
+#: mod/cal.php:297 src/Console/User.php:152 src/Console/User.php:250
+#: src/Console/User.php:283 src/Console/User.php:309 src/Model/User.php:607
+#: src/Module/Admin/Users/Active.php:73 src/Module/Admin/Users/Blocked.php:74
+#: src/Module/Admin/Users/Index.php:80 src/Module/Admin/Users/Pending.php:71
+#: src/Module/Api/Twitter/ContactEndpoint.php:73
+msgid "User not found"
+msgstr ""
+
+#: mod/cal.php:306
+msgid "This calendar format is not supported"
+msgstr ""
+
+#: mod/cal.php:308
+msgid "No exportable data found"
+msgstr ""
+
+#: mod/cal.php:325
+msgid "calendar"
 msgstr ""
 
 #: mod/dfrn_confirm.php:85 src/Module/Profile/Profile.php:82
 msgid "Profile not found."
+msgstr ""
+
+#: mod/dfrn_confirm.php:140 mod/redir.php:56 mod/redir.php:157
+#: src/Module/Contact/Advanced.php:53 src/Module/Contact/Advanced.php:104
+#: src/Module/Contact/Contacts.php:36 src/Module/FriendSuggest.php:54
+#: src/Module/FriendSuggest.php:93 src/Module/Group.php:105
+msgid "Contact not found."
 msgstr ""
 
 #: mod/dfrn_confirm.php:141
@@ -1427,36 +1033,551 @@ msgstr ""
 msgid "Unable to update your contact profile details on our system"
 msgstr ""
 
-#: mod/videos.php:129 mod/display.php:179 mod/dfrn_request.php:601
-#: mod/photos.php:835 src/Module/Debug/WebFinger.php:38
-#: src/Module/Debug/Probe.php:39 src/Module/Conversation/Community.php:187
+#: mod/dfrn_poll.php:135 mod/dfrn_poll.php:506
+#, php-format
+msgid "%1$s welcomes %2$s"
+msgstr ""
+
+#: mod/dfrn_request.php:114
+msgid "This introduction has already been accepted."
+msgstr ""
+
+#: mod/dfrn_request.php:132 mod/dfrn_request.php:370
+msgid "Profile location is not valid or does not contain profile information."
+msgstr ""
+
+#: mod/dfrn_request.php:136 mod/dfrn_request.php:374
+msgid "Warning: profile location has no identifiable owner name."
+msgstr ""
+
+#: mod/dfrn_request.php:139 mod/dfrn_request.php:377
+msgid "Warning: profile location has no profile photo."
+msgstr ""
+
+#: mod/dfrn_request.php:143 mod/dfrn_request.php:381
+#, php-format
+msgid "%d required parameter was not found at the given location"
+msgid_plural "%d required parameters were not found at the given location"
+msgstr[0] ""
+msgstr[1] ""
+
+#: mod/dfrn_request.php:181
+msgid "Introduction complete."
+msgstr ""
+
+#: mod/dfrn_request.php:217
+msgid "Unrecoverable protocol error."
+msgstr ""
+
+#: mod/dfrn_request.php:244 src/Module/RemoteFollow.php:54
+msgid "Profile unavailable."
+msgstr ""
+
+#: mod/dfrn_request.php:265
+#, php-format
+msgid "%s has received too many connection requests today."
+msgstr ""
+
+#: mod/dfrn_request.php:266
+msgid "Spam protection measures have been invoked."
+msgstr ""
+
+#: mod/dfrn_request.php:267
+msgid "Friends are advised to please try again in 24 hours."
+msgstr ""
+
+#: mod/dfrn_request.php:291 src/Module/RemoteFollow.php:60
+msgid "Invalid locator"
+msgstr ""
+
+#: mod/dfrn_request.php:327
+msgid "You have already introduced yourself here."
+msgstr ""
+
+#: mod/dfrn_request.php:330
+#, php-format
+msgid "Apparently you are already friends with %s."
+msgstr ""
+
+#: mod/dfrn_request.php:350
+msgid "Invalid profile URL."
+msgstr ""
+
+#: mod/dfrn_request.php:356 src/Model/Contact.php:2143
+msgid "Disallowed profile URL."
+msgstr ""
+
+#: mod/dfrn_request.php:362 src/Model/Contact.php:2148
+#: src/Module/Friendica.php:80
+msgid "Blocked domain"
+msgstr ""
+
+#: mod/dfrn_request.php:429 src/Module/Contact.php:157
+msgid "Failed to update contact record."
+msgstr ""
+
+#: mod/dfrn_request.php:449
+msgid "Your introduction has been sent."
+msgstr ""
+
+#: mod/dfrn_request.php:481 src/Module/RemoteFollow.php:72
+msgid ""
+"Remote subscription can't be done for your network. Please subscribe "
+"directly on your system."
+msgstr ""
+
+#: mod/dfrn_request.php:497
+msgid "Please login to confirm introduction."
+msgstr ""
+
+#: mod/dfrn_request.php:505
+msgid ""
+"Incorrect identity currently logged in. Please login to <strong>this</"
+"strong> profile."
+msgstr ""
+
+#: mod/dfrn_request.php:519 mod/dfrn_request.php:534
+msgid "Confirm"
+msgstr ""
+
+#: mod/dfrn_request.php:530
+msgid "Hide this contact"
+msgstr ""
+
+#: mod/dfrn_request.php:532
+#, php-format
+msgid "Welcome home %s."
+msgstr ""
+
+#: mod/dfrn_request.php:533
+#, php-format
+msgid "Please confirm your introduction/connection request to %s."
+msgstr ""
+
+#: mod/dfrn_request.php:601 mod/display.php:179 mod/photos.php:835
+#: mod/videos.php:129 src/Module/Conversation/Community.php:187
+#: src/Module/Debug/Probe.php:39 src/Module/Debug/WebFinger.php:38
 #: src/Module/Directory.php:49 src/Module/Search/Index.php:50
 #: src/Module/Search/Index.php:55
 msgid "Public access denied."
 msgstr ""
 
-#: mod/videos.php:134
-msgid "No videos selected"
+#: mod/dfrn_request.php:637 src/Module/RemoteFollow.php:104
+msgid "Friend/Connection Request"
 msgstr ""
 
-#: mod/videos.php:182 mod/photos.php:906
-msgid "Access to this item is restricted."
+#: mod/dfrn_request.php:638
+#, php-format
+msgid ""
+"Enter your Webfinger address (user@domain.tld) or profile URL here. If this "
+"isn't supported by your system (for example it doesn't work with Diaspora), "
+"you have to subscribe to <strong>%s</strong> directly on your system"
 msgstr ""
 
-#: mod/videos.php:252 src/Model/Item.php:3710
-msgid "View Video"
+#: mod/dfrn_request.php:639 src/Module/RemoteFollow.php:106
+#, php-format
+msgid ""
+"If you are not yet a member of the free social web, <a href=\"%s\">follow "
+"this link to find a public Friendica node and join us today</a>."
 msgstr ""
 
-#: mod/videos.php:259 mod/photos.php:1627
-msgid "View Album"
+#: mod/dfrn_request.php:640 src/Module/RemoteFollow.php:107
+msgid "Your Webfinger address or profile URL:"
 msgstr ""
 
-#: mod/videos.php:267
-msgid "Recent Videos"
+#: mod/dfrn_request.php:641 mod/follow.php:146 src/Module/RemoteFollow.php:108
+msgid "Please answer the following:"
 msgstr ""
 
-#: mod/videos.php:269
-msgid "Upload New Videos"
+#: mod/dfrn_request.php:642 mod/follow.php:73 mod/unfollow.php:99
+#: src/Module/RemoteFollow.php:109
+msgid "Submit Request"
+msgstr ""
+
+#: mod/dfrn_request.php:649 mod/follow.php:160
+#, php-format
+msgid "%s knows you"
+msgstr ""
+
+#: mod/dfrn_request.php:650 mod/follow.php:161
+msgid "Add a personal note:"
+msgstr ""
+
+#: mod/display.php:238 mod/display.php:322
+msgid "The requested item doesn't exist or has been deleted."
+msgstr ""
+
+#: mod/display.php:402
+msgid "The feed for this item is unavailable."
+msgstr ""
+
+#: mod/editpost.php:45 mod/editpost.php:55
+msgid "Item not found"
+msgstr ""
+
+#: mod/editpost.php:62
+msgid "Edit post"
+msgstr ""
+
+#: mod/editpost.php:89 mod/notes.php:62 src/Content/Text/HTML.php:881
+#: src/Module/Filer/SaveTag.php:66
+msgid "Save"
+msgstr ""
+
+#: mod/editpost.php:95 mod/message.php:204 mod/message.php:373
+#: mod/wallmessage.php:154
+msgid "Insert web link"
+msgstr ""
+
+#: mod/editpost.php:96
+msgid "web link"
+msgstr ""
+
+#: mod/editpost.php:97
+msgid "Insert video link"
+msgstr ""
+
+#: mod/editpost.php:98
+msgid "video link"
+msgstr ""
+
+#: mod/editpost.php:99
+msgid "Insert audio link"
+msgstr ""
+
+#: mod/editpost.php:100
+msgid "audio link"
+msgstr ""
+
+#: mod/editpost.php:114 src/Core/ACL.php:312
+msgid "CC: email addresses"
+msgstr ""
+
+#: mod/editpost.php:121 src/Core/ACL.php:313
+msgid "Example: bob@example.com, mary@example.com"
+msgstr ""
+
+#: mod/events.php:136 mod/events.php:138
+msgid "Event can not end before it has started."
+msgstr ""
+
+#: mod/events.php:145 mod/events.php:147
+msgid "Event title and start time are required."
+msgstr ""
+
+#: mod/events.php:414
+msgid "Create New Event"
+msgstr ""
+
+#: mod/events.php:526
+msgid "Event details"
+msgstr ""
+
+#: mod/events.php:527
+msgid "Starting date and Title are required."
+msgstr ""
+
+#: mod/events.php:528 mod/events.php:533
+msgid "Event Starts:"
+msgstr ""
+
+#: mod/events.php:528 mod/events.php:560
+#: src/Module/Admin/Blocklist/Server.php:79
+#: src/Module/Admin/Blocklist/Server.php:80
+#: src/Module/Admin/Blocklist/Server.php:99
+#: src/Module/Admin/Blocklist/Server.php:100
+#: src/Module/Admin/Item/Delete.php:70 src/Module/Debug/Probe.php:57
+#: src/Module/Install.php:189 src/Module/Install.php:222
+#: src/Module/Install.php:227 src/Module/Install.php:246
+#: src/Module/Install.php:257 src/Module/Install.php:262
+#: src/Module/Install.php:268 src/Module/Install.php:273
+#: src/Module/Install.php:287 src/Module/Install.php:302
+#: src/Module/Install.php:329 src/Module/Register.php:135
+#: src/Module/Security/TwoFactor/Verify.php:85
+#: src/Module/Settings/TwoFactor/Index.php:128
+#: src/Module/Settings/TwoFactor/Verify.php:141
+msgid "Required"
+msgstr ""
+
+#: mod/events.php:541 mod/events.php:566
+msgid "Finish date/time is not known or not relevant"
+msgstr ""
+
+#: mod/events.php:543 mod/events.php:548
+msgid "Event Finishes:"
+msgstr ""
+
+#: mod/events.php:554 mod/events.php:567
+msgid "Adjust for viewer timezone"
+msgstr ""
+
+#: mod/events.php:556 src/Module/Profile/Profile.php:172
+#: src/Module/Settings/Profile/Index.php:253
+msgid "Description:"
+msgstr ""
+
+#: mod/events.php:558 src/Model/Event.php:84 src/Model/Event.php:111
+#: src/Model/Event.php:456 src/Model/Event.php:950 src/Model/Profile.php:358
+#: src/Module/Contact.php:646 src/Module/Directory.php:156
+#: src/Module/Notifications/Introductions.php:172
+#: src/Module/Profile/Profile.php:190
+msgid "Location:"
+msgstr ""
+
+#: mod/events.php:560 mod/events.php:562
+msgid "Title:"
+msgstr ""
+
+#: mod/events.php:563 mod/events.php:564
+msgid "Share this event"
+msgstr ""
+
+#: mod/events.php:570 mod/message.php:206 mod/message.php:374
+#: mod/photos.php:950 mod/photos.php:1053 mod/photos.php:1339
+#: mod/photos.php:1380 mod/photos.php:1437 mod/photos.php:1510
+#: src/Module/Contact/Advanced.php:132 src/Module/Contact/Poke.php:155
+#: src/Module/Contact.php:604 src/Module/Debug/Localtime.php:64
+#: src/Module/Delegation.php:152 src/Module/FriendSuggest.php:129
+#: src/Module/Install.php:234 src/Module/Install.php:276
+#: src/Module/Install.php:313 src/Module/Invite.php:175
+#: src/Module/Item/Compose.php:144 src/Module/Profile/Profile.php:242
+#: src/Module/Settings/Profile/Index.php:237 src/Object/Post.php:954
+#: view/theme/duepuntozero/config.php:69 view/theme/frio/config.php:160
+#: view/theme/quattro/config.php:71 view/theme/vier/config.php:119
+msgid "Submit"
+msgstr ""
+
+#: mod/events.php:571 src/Module/Profile/Profile.php:243
+msgid "Basic"
+msgstr ""
+
+#: mod/events.php:572 src/Module/Admin/Site.php:587 src/Module/Contact.php:953
+#: src/Module/Profile/Profile.php:244
+msgid "Advanced"
+msgstr ""
+
+#: mod/events.php:589
+msgid "Failed to remove event"
+msgstr ""
+
+#: mod/fbrowser.php:43 src/Content/Nav.php:179 src/Module/BaseProfile.php:68
+#: view/theme/frio/theme.php:227
+msgid "Photos"
+msgstr ""
+
+#: mod/fbrowser.php:107 mod/fbrowser.php:136
+#: src/Module/Settings/Profile/Photo/Index.php:130
+msgid "Upload"
+msgstr ""
+
+#: mod/fbrowser.php:131
+msgid "Files"
+msgstr ""
+
+#: mod/follow.php:83
+msgid "You already added this contact."
+msgstr ""
+
+#: mod/follow.php:99
+msgid "The network type couldn't be detected. Contact can't be added."
+msgstr ""
+
+#: mod/follow.php:107
+msgid "Diaspora support isn't enabled. Contact can't be added."
+msgstr ""
+
+#: mod/follow.php:112
+msgid "OStatus support is disabled. Contact can't be added."
+msgstr ""
+
+#: mod/follow.php:147 mod/unfollow.php:97
+msgid "Your Identity Address:"
+msgstr ""
+
+#: mod/follow.php:148 mod/unfollow.php:103
+#: src/Module/Admin/Blocklist/Contact.php:100 src/Module/Contact.php:642
+#: src/Module/Notifications/Introductions.php:108
+#: src/Module/Notifications/Introductions.php:183
+msgid "Profile URL"
+msgstr ""
+
+#: mod/follow.php:149 src/Module/Contact.php:652
+#: src/Module/Notifications/Introductions.php:176
+#: src/Module/Profile/Profile.php:202
+msgid "Tags:"
+msgstr ""
+
+#: mod/follow.php:170 mod/unfollow.php:113 src/Module/BaseProfile.php:63
+#: src/Module/Contact.php:931
+msgid "Status Messages and Posts"
+msgstr ""
+
+#: mod/follow.php:202
+msgid "The contact could not be added."
+msgstr ""
+
+#: mod/item.php:134 mod/item.php:138
+msgid "Unable to locate original post."
+msgstr ""
+
+#: mod/item.php:333 mod/item.php:338
+msgid "Empty post discarded."
+msgstr ""
+
+#: mod/item.php:705
+msgid "Post updated."
+msgstr ""
+
+#: mod/item.php:722 mod/item.php:727
+msgid "Item wasn't stored."
+msgstr ""
+
+#: mod/item.php:738
+msgid "Item couldn't be fetched."
+msgstr ""
+
+#: mod/item.php:866 src/Module/Admin/Themes/Details.php:39
+#: src/Module/Admin/Themes/Index.php:59 src/Module/Debug/ItemBody.php:46
+#: src/Module/Debug/ItemBody.php:59
+msgid "Item not found."
+msgstr ""
+
+#: mod/lostpass.php:40
+msgid "No valid account found."
+msgstr ""
+
+#: mod/lostpass.php:52
+msgid "Password reset request issued. Check your email."
+msgstr ""
+
+#: mod/lostpass.php:58
+#, php-format
+msgid ""
+"\n"
+"\t\tDear %1$s,\n"
+"\t\t\tA request was recently received at \"%2$s\" to reset your account\n"
+"\t\tpassword. In order to confirm this request, please select the "
+"verification link\n"
+"\t\tbelow or paste it into your web browser address bar.\n"
+"\n"
+"\t\tIf you did NOT request this change, please DO NOT follow the link\n"
+"\t\tprovided and ignore and/or delete this email, the request will expire "
+"shortly.\n"
+"\n"
+"\t\tYour password will not be changed unless we can verify that you\n"
+"\t\tissued this request."
+msgstr ""
+
+#: mod/lostpass.php:69
+#, php-format
+msgid ""
+"\n"
+"\t\tFollow this link soon to verify your identity:\n"
+"\n"
+"\t\t%1$s\n"
+"\n"
+"\t\tYou will then receive a follow-up message containing the new password.\n"
+"\t\tYou may change that password from your account settings page after "
+"logging in.\n"
+"\n"
+"\t\tThe login details are as follows:\n"
+"\n"
+"\t\tSite Location:\t%2$s\n"
+"\t\tLogin Name:\t%3$s"
+msgstr ""
+
+#: mod/lostpass.php:84
+#, php-format
+msgid "Password reset requested at %s"
+msgstr ""
+
+#: mod/lostpass.php:100
+msgid ""
+"Request could not be verified. (You may have previously submitted it.) "
+"Password reset failed."
+msgstr ""
+
+#: mod/lostpass.php:113
+msgid "Request has expired, please make a new one."
+msgstr ""
+
+#: mod/lostpass.php:128
+msgid "Forgot your Password?"
+msgstr ""
+
+#: mod/lostpass.php:129
+msgid ""
+"Enter your email address and submit to have your password reset. Then check "
+"your email for further instructions."
+msgstr ""
+
+#: mod/lostpass.php:130 src/Module/Security/Login.php:144
+msgid "Nickname or Email: "
+msgstr ""
+
+#: mod/lostpass.php:131
+msgid "Reset"
+msgstr ""
+
+#: mod/lostpass.php:146 src/Module/Security/Login.php:156
+msgid "Password Reset"
+msgstr ""
+
+#: mod/lostpass.php:147
+msgid "Your password has been reset as requested."
+msgstr ""
+
+#: mod/lostpass.php:148
+msgid "Your new password is"
+msgstr ""
+
+#: mod/lostpass.php:149
+msgid "Save or copy your new password - and then"
+msgstr ""
+
+#: mod/lostpass.php:150
+msgid "click here to login"
+msgstr ""
+
+#: mod/lostpass.php:151
+msgid ""
+"Your password may be changed from the <em>Settings</em> page after "
+"successful login."
+msgstr ""
+
+#: mod/lostpass.php:155
+msgid "Your password has been reset."
+msgstr ""
+
+#: mod/lostpass.php:158
+#, php-format
+msgid ""
+"\n"
+"\t\t\tDear %1$s,\n"
+"\t\t\t\tYour password has been changed as requested. Please retain this\n"
+"\t\t\tinformation for your records (or change your password immediately to\n"
+"\t\t\tsomething that you will remember).\n"
+"\t\t"
+msgstr ""
+
+#: mod/lostpass.php:164
+#, php-format
+msgid ""
+"\n"
+"\t\t\tYour login details are as follows:\n"
+"\n"
+"\t\t\tSite Location:\t%1$s\n"
+"\t\t\tLogin Name:\t%2$s\n"
+"\t\t\tPassword:\t%3$s\n"
+"\n"
+"\t\t\tYou may change that password from your account settings page after "
+"logging in.\n"
+"\t\t"
+msgstr ""
+
+#: mod/lostpass.php:176
+#, php-format
+msgid "Your password has been changed at %s"
 msgstr ""
 
 #: mod/match.php:62
@@ -1478,6 +1599,464 @@ msgstr ""
 #: mod/match.php:125
 msgid "Profile Match"
 msgstr ""
+
+#: mod/message.php:47 mod/message.php:128 src/Content/Nav.php:276
+msgid "New Message"
+msgstr ""
+
+#: mod/message.php:84 mod/wallmessage.php:76
+msgid "No recipient selected."
+msgstr ""
+
+#: mod/message.php:88
+msgid "Unable to locate contact information."
+msgstr ""
+
+#: mod/message.php:91 mod/wallmessage.php:82
+msgid "Message could not be sent."
+msgstr ""
+
+#: mod/message.php:94 mod/wallmessage.php:85
+msgid "Message collection failure."
+msgstr ""
+
+#: mod/message.php:122 src/Module/Notifications/Introductions.php:114
+#: src/Module/Notifications/Introductions.php:155
+#: src/Module/Notifications/Notification.php:56
+msgid "Discard"
+msgstr ""
+
+#: mod/message.php:135 src/Content/Nav.php:273 view/theme/frio/theme.php:234
+msgid "Messages"
+msgstr ""
+
+#: mod/message.php:148
+msgid "Conversation not found."
+msgstr ""
+
+#: mod/message.php:153
+msgid "Message was not deleted."
+msgstr ""
+
+#: mod/message.php:171
+msgid "Conversation was not removed."
+msgstr ""
+
+#: mod/message.php:185 mod/message.php:298 mod/wallmessage.php:137
+msgid "Please enter a link URL:"
+msgstr ""
+
+#: mod/message.php:194 mod/wallmessage.php:142
+msgid "Send Private Message"
+msgstr ""
+
+#: mod/message.php:195 mod/message.php:364 mod/wallmessage.php:144
+msgid "To:"
+msgstr ""
+
+#: mod/message.php:196 mod/message.php:365 mod/wallmessage.php:145
+msgid "Subject:"
+msgstr ""
+
+#: mod/message.php:200 mod/message.php:368 mod/wallmessage.php:151
+#: src/Module/Invite.php:168
+msgid "Your message:"
+msgstr ""
+
+#: mod/message.php:234
+msgid "No messages."
+msgstr ""
+
+#: mod/message.php:290
+msgid "Message not available."
+msgstr ""
+
+#: mod/message.php:340
+msgid "Delete message"
+msgstr ""
+
+#: mod/message.php:342 mod/message.php:469
+msgid "D, d M Y - g:i A"
+msgstr ""
+
+#: mod/message.php:357 mod/message.php:466
+msgid "Delete conversation"
+msgstr ""
+
+#: mod/message.php:359
+msgid ""
+"No secure communications available. You <strong>may</strong> be able to "
+"respond from the sender's profile page."
+msgstr ""
+
+#: mod/message.php:363
+msgid "Send Reply"
+msgstr ""
+
+#: mod/message.php:445
+#, php-format
+msgid "Unknown sender - %s"
+msgstr ""
+
+#: mod/message.php:447
+#, php-format
+msgid "You and %s"
+msgstr ""
+
+#: mod/message.php:449
+#, php-format
+msgid "%s and You"
+msgstr ""
+
+#: mod/message.php:472
+#, php-format
+msgid "%d message"
+msgid_plural "%d messages"
+msgstr[0] ""
+msgstr[1] ""
+
+#: mod/notes.php:50 src/Module/BaseProfile.php:110
+msgid "Personal Notes"
+msgstr ""
+
+#: mod/notes.php:58
+msgid "Personal notes are visible only by yourself."
+msgstr ""
+
+#: mod/ostatus_subscribe.php:35
+msgid "Subscribing to OStatus contacts"
+msgstr ""
+
+#: mod/ostatus_subscribe.php:45
+msgid "No contact provided."
+msgstr ""
+
+#: mod/ostatus_subscribe.php:51
+msgid "Couldn't fetch information for contact."
+msgstr ""
+
+#: mod/ostatus_subscribe.php:61
+msgid "Couldn't fetch friends for contact."
+msgstr ""
+
+#: mod/ostatus_subscribe.php:79 mod/repair_ostatus.php:65
+msgid "Done"
+msgstr ""
+
+#: mod/ostatus_subscribe.php:93
+msgid "success"
+msgstr ""
+
+#: mod/ostatus_subscribe.php:95
+msgid "failed"
+msgstr ""
+
+#: mod/ostatus_subscribe.php:98 src/Object/Post.php:311
+msgid "ignored"
+msgstr ""
+
+#: mod/ostatus_subscribe.php:103 mod/repair_ostatus.php:71
+msgid "Keep this window open until done."
+msgstr ""
+
+#: mod/photos.php:128 src/Module/BaseProfile.php:71
+msgid "Photo Albums"
+msgstr ""
+
+#: mod/photos.php:129 mod/photos.php:1636
+msgid "Recent Photos"
+msgstr ""
+
+#: mod/photos.php:131 mod/photos.php:1104 mod/photos.php:1638
+msgid "Upload New Photos"
+msgstr ""
+
+#: mod/photos.php:149 src/Module/BaseSettings.php:37
+msgid "everybody"
+msgstr ""
+
+#: mod/photos.php:182
+msgid "Contact information unavailable"
+msgstr ""
+
+#: mod/photos.php:221
+msgid "Album not found."
+msgstr ""
+
+#: mod/photos.php:279
+msgid "Album successfully deleted"
+msgstr ""
+
+#: mod/photos.php:281
+msgid "Album was empty."
+msgstr ""
+
+#: mod/photos.php:313
+msgid "Failed to delete the photo."
+msgstr ""
+
+#: mod/photos.php:588
+msgid "a photo"
+msgstr ""
+
+#: mod/photos.php:588
+#, php-format
+msgid "%1$s was tagged in %2$s by %3$s"
+msgstr ""
+
+#: mod/photos.php:671 mod/photos.php:674 mod/photos.php:701
+#: mod/wall_upload.php:174 src/Module/Settings/Profile/Photo/Index.php:61
+#, php-format
+msgid "Image exceeds size limit of %s"
+msgstr ""
+
+#: mod/photos.php:677
+msgid "Image upload didn't complete, please try again"
+msgstr ""
+
+#: mod/photos.php:680
+msgid "Image file is missing"
+msgstr ""
+
+#: mod/photos.php:685
+msgid ""
+"Server can't accept new file upload at this time, please contact your "
+"administrator"
+msgstr ""
+
+#: mod/photos.php:709
+msgid "Image file is empty."
+msgstr ""
+
+#: mod/photos.php:724 mod/wall_upload.php:188
+#: src/Module/Settings/Profile/Photo/Index.php:70
+msgid "Unable to process image."
+msgstr ""
+
+#: mod/photos.php:753 mod/wall_upload.php:227
+#: src/Module/Settings/Profile/Photo/Index.php:97
+msgid "Image upload failed."
+msgstr ""
+
+#: mod/photos.php:840
+msgid "No photos selected"
+msgstr ""
+
+#: mod/photos.php:906 mod/videos.php:182
+msgid "Access to this item is restricted."
+msgstr ""
+
+#: mod/photos.php:960
+msgid "Upload Photos"
+msgstr ""
+
+#: mod/photos.php:964 mod/photos.php:1049
+msgid "New album name: "
+msgstr ""
+
+#: mod/photos.php:965
+msgid "or select existing album:"
+msgstr ""
+
+#: mod/photos.php:966
+msgid "Do not show a status post for this upload"
+msgstr ""
+
+#: mod/photos.php:1032
+msgid "Do you really want to delete this photo album and all its photos?"
+msgstr ""
+
+#: mod/photos.php:1033 mod/photos.php:1054
+msgid "Delete Album"
+msgstr ""
+
+#: mod/photos.php:1060
+msgid "Edit Album"
+msgstr ""
+
+#: mod/photos.php:1061
+msgid "Drop Album"
+msgstr ""
+
+#: mod/photos.php:1066
+msgid "Show Newest First"
+msgstr ""
+
+#: mod/photos.php:1068
+msgid "Show Oldest First"
+msgstr ""
+
+#: mod/photos.php:1089 mod/photos.php:1621
+msgid "View Photo"
+msgstr ""
+
+#: mod/photos.php:1126
+msgid "Permission denied. Access to this item may be restricted."
+msgstr ""
+
+#: mod/photos.php:1128
+msgid "Photo not available"
+msgstr ""
+
+#: mod/photos.php:1138
+msgid "Do you really want to delete this photo?"
+msgstr ""
+
+#: mod/photos.php:1139 mod/photos.php:1340
+msgid "Delete Photo"
+msgstr ""
+
+#: mod/photos.php:1230
+msgid "View photo"
+msgstr ""
+
+#: mod/photos.php:1232
+msgid "Edit photo"
+msgstr ""
+
+#: mod/photos.php:1233
+msgid "Delete photo"
+msgstr ""
+
+#: mod/photos.php:1234
+msgid "Use as profile photo"
+msgstr ""
+
+#: mod/photos.php:1241
+msgid "Private Photo"
+msgstr ""
+
+#: mod/photos.php:1247
+msgid "View Full Size"
+msgstr ""
+
+#: mod/photos.php:1308
+msgid "Tags: "
+msgstr ""
+
+#: mod/photos.php:1311
+msgid "[Select tags to remove]"
+msgstr ""
+
+#: mod/photos.php:1326
+msgid "New album name"
+msgstr ""
+
+#: mod/photos.php:1327
+msgid "Caption"
+msgstr ""
+
+#: mod/photos.php:1328
+msgid "Add a Tag"
+msgstr ""
+
+#: mod/photos.php:1328
+msgid "Example: @bob, @Barbara_Jensen, @jim@example.com, #California, #camping"
+msgstr ""
+
+#: mod/photos.php:1329
+msgid "Do not rotate"
+msgstr ""
+
+#: mod/photos.php:1330
+msgid "Rotate CW (right)"
+msgstr ""
+
+#: mod/photos.php:1331
+msgid "Rotate CCW (left)"
+msgstr ""
+
+#: mod/photos.php:1377 mod/photos.php:1434 mod/photos.php:1507
+#: src/Module/Contact.php:1096 src/Module/Item/Compose.php:142
+#: src/Object/Post.php:951
+msgid "This is you"
+msgstr ""
+
+#: mod/photos.php:1379 mod/photos.php:1436 mod/photos.php:1509
+#: src/Object/Post.php:491 src/Object/Post.php:953
+msgid "Comment"
+msgstr ""
+
+#: mod/photos.php:1531
+msgid "Like"
+msgstr ""
+
+#: mod/photos.php:1532 src/Object/Post.php:351
+msgid "I like this (toggle)"
+msgstr ""
+
+#: mod/photos.php:1533
+msgid "Dislike"
+msgstr ""
+
+#: mod/photos.php:1535 src/Object/Post.php:352
+msgid "I don't like this (toggle)"
+msgstr ""
+
+#: mod/photos.php:1557
+msgid "Map"
+msgstr ""
+
+#: mod/photos.php:1627 mod/videos.php:259
+msgid "View Album"
+msgstr ""
+
+#: mod/ping.php:285
+msgid "{0} wants to be your friend"
+msgstr ""
+
+#: mod/ping.php:302
+msgid "{0} requested registration"
+msgstr ""
+
+#: mod/ping.php:315
+#, php-format
+msgid "{0} and %d others requested registration"
+msgstr ""
+
+#: mod/redir.php:50 mod/redir.php:130
+msgid "Bad Request."
+msgstr ""
+
+#: mod/removeme.php:63
+msgid "User deleted their account"
+msgstr ""
+
+#: mod/removeme.php:64
+msgid ""
+"On your Friendica node an user deleted their account. Please ensure that "
+"their data is removed from the backups."
+msgstr ""
+
+#: mod/removeme.php:65
+#, php-format
+msgid "The user id is %d"
+msgstr ""
+
+#: mod/removeme.php:99 mod/removeme.php:102
+msgid "Remove My Account"
+msgstr ""
+
+#: mod/removeme.php:100
+msgid ""
+"This will completely remove your account. Once this has been done it is not "
+"recoverable."
+msgstr ""
+
+#: mod/removeme.php:101
+msgid "Please enter your password for verification:"
+msgstr ""
+
+#: mod/repair_ostatus.php:36
+msgid "Resubscribing to OStatus contacts"
+msgstr ""
+
+#: mod/repair_ostatus.php:50 src/Module/Debug/ActivityPubConversion.php:130
+#: src/Module/Debug/Babel.php:293 src/Module/Security/TwoFactor/Verify.php:82
+msgid "Error"
+msgid_plural "Errors"
+msgstr[0] ""
+msgstr[1] ""
 
 #: mod/settings.php:90
 msgid "Missing some important data!"
@@ -1556,21 +2135,20 @@ msgid "Add application"
 msgstr ""
 
 #: mod/settings.php:503 mod/settings.php:610 mod/settings.php:708
-#: mod/settings.php:843 src/Module/Admin/Themes/Index.php:113
+#: mod/settings.php:843 src/Module/Admin/Addons/Index.php:69
 #: src/Module/Admin/Features.php:87 src/Module/Admin/Logs/Settings.php:82
-#: src/Module/Admin/Site.php:598 src/Module/Admin/Tos.php:66
-#: src/Module/Admin/Addons/Index.php:69 src/Module/Settings/Delegation.php:170
+#: src/Module/Admin/Site.php:582 src/Module/Admin/Themes/Index.php:113
+#: src/Module/Admin/Tos.php:66 src/Module/Settings/Delegation.php:170
 #: src/Module/Settings/Display.php:189
 msgid "Save Settings"
 msgstr ""
 
 #: mod/settings.php:505 mod/settings.php:531
-#: src/Module/Admin/Users/Create.php:71 src/Module/Admin/Users/Pending.php:104
-#: src/Module/Admin/Users/Index.php:142 src/Module/Admin/Users/Index.php:162
-#: src/Module/Admin/Users/Active.php:129 src/Module/Admin/Users/Blocked.php:130
-#: src/Module/Admin/Users/Deleted.php:88
 #: src/Module/Admin/Blocklist/Contact.php:90
-#: src/Module/Contact/Advanced.php:134
+#: src/Module/Admin/Users/Active.php:129 src/Module/Admin/Users/Blocked.php:130
+#: src/Module/Admin/Users/Create.php:71 src/Module/Admin/Users/Deleted.php:88
+#: src/Module/Admin/Users/Index.php:142 src/Module/Admin/Users/Index.php:162
+#: src/Module/Admin/Users/Pending.php:104 src/Module/Contact/Advanced.php:134
 msgid "Name"
 msgstr ""
 
@@ -2271,210 +2849,14 @@ msgstr ""
 msgid "Resend relocate message to contacts"
 msgstr ""
 
-#: mod/ping.php:285
-msgid "{0} wants to be your friend"
-msgstr ""
-
-#: mod/ping.php:302
-msgid "{0} requested registration"
-msgstr ""
-
-#: mod/ping.php:315
-#, php-format
-msgid "{0} and %d others requested registration"
-msgstr ""
-
-#: mod/repair_ostatus.php:36
-msgid "Resubscribing to OStatus contacts"
-msgstr ""
-
-#: mod/repair_ostatus.php:50 src/Module/Security/TwoFactor/Verify.php:82
-#: src/Module/Debug/Babel.php:293
-#: src/Module/Debug/ActivityPubConversion.php:130
-msgid "Error"
-msgid_plural "Errors"
-msgstr[0] ""
-msgstr[1] ""
-
-#: mod/repair_ostatus.php:65 mod/ostatus_subscribe.php:79
-msgid "Done"
-msgstr ""
-
-#: mod/repair_ostatus.php:71 mod/ostatus_subscribe.php:103
-msgid "Keep this window open until done."
-msgstr ""
-
-#: mod/unfollow.php:65 mod/unfollow.php:133
-msgid "You aren't following this contact."
-msgstr ""
-
-#: mod/unfollow.php:71 mod/unfollow.php:139
-msgid "Unfollowing is currently not supported by your network."
-msgstr ""
-
-#: mod/unfollow.php:95
-msgid "Disconnect/Unfollow"
-msgstr ""
-
-#: mod/unfollow.php:97 mod/follow.php:147
-msgid "Your Identity Address:"
-msgstr ""
-
-#: mod/unfollow.php:99 mod/dfrn_request.php:642 mod/follow.php:73
-#: src/Module/RemoteFollow.php:109
-msgid "Submit Request"
-msgstr ""
-
-#: mod/unfollow.php:103 mod/follow.php:148
-#: src/Module/Notifications/Introductions.php:108
-#: src/Module/Notifications/Introductions.php:183 src/Module/Contact.php:642
-#: src/Module/Admin/Blocklist/Contact.php:100
-msgid "Profile URL"
-msgstr ""
-
-#: mod/unfollow.php:113 mod/follow.php:170 src/Module/Contact.php:931
-#: src/Module/BaseProfile.php:63
-msgid "Status Messages and Posts"
-msgstr ""
-
-#: mod/message.php:47 mod/message.php:128 src/Content/Nav.php:276
-msgid "New Message"
-msgstr ""
-
-#: mod/message.php:88
-msgid "Unable to locate contact information."
-msgstr ""
-
-#: mod/message.php:122 src/Module/Notifications/Notification.php:56
-#: src/Module/Notifications/Introductions.php:114
-#: src/Module/Notifications/Introductions.php:155
-msgid "Discard"
-msgstr ""
-
-#: mod/message.php:148
-msgid "Conversation not found."
-msgstr ""
-
-#: mod/message.php:153
-msgid "Message was not deleted."
-msgstr ""
-
-#: mod/message.php:171
-msgid "Conversation was not removed."
-msgstr ""
-
-#: mod/message.php:234
-msgid "No messages."
-msgstr ""
-
-#: mod/message.php:290
-msgid "Message not available."
-msgstr ""
-
-#: mod/message.php:340
-msgid "Delete message"
-msgstr ""
-
-#: mod/message.php:342 mod/message.php:469
-msgid "D, d M Y - g:i A"
-msgstr ""
-
-#: mod/message.php:357 mod/message.php:466
-msgid "Delete conversation"
-msgstr ""
-
-#: mod/message.php:359
+#: mod/suggest.php:44
 msgid ""
-"No secure communications available. You <strong>may</strong> be able to "
-"respond from the sender's profile page."
+"No suggestions available. If this is a new site, please try again in 24 "
+"hours."
 msgstr ""
 
-#: mod/message.php:363
-msgid "Send Reply"
-msgstr ""
-
-#: mod/message.php:445
-#, php-format
-msgid "Unknown sender - %s"
-msgstr ""
-
-#: mod/message.php:447
-#, php-format
-msgid "You and %s"
-msgstr ""
-
-#: mod/message.php:449
-#, php-format
-msgid "%s and You"
-msgstr ""
-
-#: mod/message.php:472
-#, php-format
-msgid "%d message"
-msgid_plural "%d messages"
-msgstr[0] ""
-msgstr[1] ""
-
-#: mod/ostatus_subscribe.php:35
-msgid "Subscribing to OStatus contacts"
-msgstr ""
-
-#: mod/ostatus_subscribe.php:45
-msgid "No contact provided."
-msgstr ""
-
-#: mod/ostatus_subscribe.php:51
-msgid "Couldn't fetch information for contact."
-msgstr ""
-
-#: mod/ostatus_subscribe.php:61
-msgid "Couldn't fetch friends for contact."
-msgstr ""
-
-#: mod/ostatus_subscribe.php:93
-msgid "success"
-msgstr ""
-
-#: mod/ostatus_subscribe.php:95
-msgid "failed"
-msgstr ""
-
-#: mod/ostatus_subscribe.php:98 src/Object/Post.php:311
-msgid "ignored"
-msgstr ""
-
-#: mod/dfrn_poll.php:135 mod/dfrn_poll.php:506
-#, php-format
-msgid "%1$s welcomes %2$s"
-msgstr ""
-
-#: mod/removeme.php:63
-msgid "User deleted their account"
-msgstr ""
-
-#: mod/removeme.php:64
-msgid ""
-"On your Friendica node an user deleted their account. Please ensure that "
-"their data is removed from the backups."
-msgstr ""
-
-#: mod/removeme.php:65
-#, php-format
-msgid "The user id is %d"
-msgstr ""
-
-#: mod/removeme.php:99 mod/removeme.php:102
-msgid "Remove My Account"
-msgstr ""
-
-#: mod/removeme.php:100
-msgid ""
-"This will completely remove your account. Once this has been done it is not "
-"recoverable."
-msgstr ""
-
-#: mod/removeme.php:101
-msgid "Please enter your password for verification:"
+#: mod/suggest.php:55 src/Content/Widget.php:78 view/theme/vier/theme.php:175
+msgid "Friend Suggestions"
 msgstr ""
 
 #: mod/tagrm.php:112
@@ -2487,413 +2869,6 @@ msgstr ""
 
 #: mod/tagrm.php:125 src/Module/Settings/Delegation.php:179
 msgid "Remove"
-msgstr ""
-
-#: mod/suggest.php:44
-msgid ""
-"No suggestions available. If this is a new site, please try again in 24 "
-"hours."
-msgstr ""
-
-#: mod/display.php:238 mod/display.php:322
-msgid "The requested item doesn't exist or has been deleted."
-msgstr ""
-
-#: mod/display.php:286 mod/cal.php:142 src/Module/Profile/Status.php:108
-#: src/Module/Profile/Profile.php:94 src/Module/Profile/Profile.php:109
-#: src/Module/Update/Profile.php:55
-msgid "Access to this profile has been restricted."
-msgstr ""
-
-#: mod/display.php:402
-msgid "The feed for this item is unavailable."
-msgstr ""
-
-#: mod/wall_upload.php:52 mod/wall_upload.php:63 mod/wall_upload.php:108
-#: mod/wall_upload.php:159 mod/wall_upload.php:162 mod/wall_attach.php:42
-#: mod/wall_attach.php:49 mod/wall_attach.php:87
-msgid "Invalid request."
-msgstr ""
-
-#: mod/wall_upload.php:174 mod/photos.php:671 mod/photos.php:674
-#: mod/photos.php:701 src/Module/Settings/Profile/Photo/Index.php:61
-#, php-format
-msgid "Image exceeds size limit of %s"
-msgstr ""
-
-#: mod/wall_upload.php:188 mod/photos.php:724
-#: src/Module/Settings/Profile/Photo/Index.php:70
-msgid "Unable to process image."
-msgstr ""
-
-#: mod/wall_upload.php:219
-msgid "Wall Photos"
-msgstr ""
-
-#: mod/wall_upload.php:227 mod/photos.php:753
-#: src/Module/Settings/Profile/Photo/Index.php:97
-msgid "Image upload failed."
-msgstr ""
-
-#: mod/lostpass.php:40
-msgid "No valid account found."
-msgstr ""
-
-#: mod/lostpass.php:52
-msgid "Password reset request issued. Check your email."
-msgstr ""
-
-#: mod/lostpass.php:58
-#, php-format
-msgid ""
-"\n"
-"\t\tDear %1$s,\n"
-"\t\t\tA request was recently received at \"%2$s\" to reset your account\n"
-"\t\tpassword. In order to confirm this request, please select the "
-"verification link\n"
-"\t\tbelow or paste it into your web browser address bar.\n"
-"\n"
-"\t\tIf you did NOT request this change, please DO NOT follow the link\n"
-"\t\tprovided and ignore and/or delete this email, the request will expire "
-"shortly.\n"
-"\n"
-"\t\tYour password will not be changed unless we can verify that you\n"
-"\t\tissued this request."
-msgstr ""
-
-#: mod/lostpass.php:69
-#, php-format
-msgid ""
-"\n"
-"\t\tFollow this link soon to verify your identity:\n"
-"\n"
-"\t\t%1$s\n"
-"\n"
-"\t\tYou will then receive a follow-up message containing the new password.\n"
-"\t\tYou may change that password from your account settings page after "
-"logging in.\n"
-"\n"
-"\t\tThe login details are as follows:\n"
-"\n"
-"\t\tSite Location:\t%2$s\n"
-"\t\tLogin Name:\t%3$s"
-msgstr ""
-
-#: mod/lostpass.php:84
-#, php-format
-msgid "Password reset requested at %s"
-msgstr ""
-
-#: mod/lostpass.php:100
-msgid ""
-"Request could not be verified. (You may have previously submitted it.) "
-"Password reset failed."
-msgstr ""
-
-#: mod/lostpass.php:113
-msgid "Request has expired, please make a new one."
-msgstr ""
-
-#: mod/lostpass.php:128
-msgid "Forgot your Password?"
-msgstr ""
-
-#: mod/lostpass.php:129
-msgid ""
-"Enter your email address and submit to have your password reset. Then check "
-"your email for further instructions."
-msgstr ""
-
-#: mod/lostpass.php:130 src/Module/Security/Login.php:144
-msgid "Nickname or Email: "
-msgstr ""
-
-#: mod/lostpass.php:131
-msgid "Reset"
-msgstr ""
-
-#: mod/lostpass.php:146 src/Module/Security/Login.php:156
-msgid "Password Reset"
-msgstr ""
-
-#: mod/lostpass.php:147
-msgid "Your password has been reset as requested."
-msgstr ""
-
-#: mod/lostpass.php:148
-msgid "Your new password is"
-msgstr ""
-
-#: mod/lostpass.php:149
-msgid "Save or copy your new password - and then"
-msgstr ""
-
-#: mod/lostpass.php:150
-msgid "click here to login"
-msgstr ""
-
-#: mod/lostpass.php:151
-msgid ""
-"Your password may be changed from the <em>Settings</em> page after "
-"successful login."
-msgstr ""
-
-#: mod/lostpass.php:155
-msgid "Your password has been reset."
-msgstr ""
-
-#: mod/lostpass.php:158
-#, php-format
-msgid ""
-"\n"
-"\t\t\tDear %1$s,\n"
-"\t\t\t\tYour password has been changed as requested. Please retain this\n"
-"\t\t\tinformation for your records (or change your password immediately to\n"
-"\t\t\tsomething that you will remember).\n"
-"\t\t"
-msgstr ""
-
-#: mod/lostpass.php:164
-#, php-format
-msgid ""
-"\n"
-"\t\t\tYour login details are as follows:\n"
-"\n"
-"\t\t\tSite Location:\t%1$s\n"
-"\t\t\tLogin Name:\t%2$s\n"
-"\t\t\tPassword:\t%3$s\n"
-"\n"
-"\t\t\tYou may change that password from your account settings page after "
-"logging in.\n"
-"\t\t"
-msgstr ""
-
-#: mod/lostpass.php:176
-#, php-format
-msgid "Your password has been changed at %s"
-msgstr ""
-
-#: mod/dfrn_request.php:114
-msgid "This introduction has already been accepted."
-msgstr ""
-
-#: mod/dfrn_request.php:132 mod/dfrn_request.php:370
-msgid "Profile location is not valid or does not contain profile information."
-msgstr ""
-
-#: mod/dfrn_request.php:136 mod/dfrn_request.php:374
-msgid "Warning: profile location has no identifiable owner name."
-msgstr ""
-
-#: mod/dfrn_request.php:139 mod/dfrn_request.php:377
-msgid "Warning: profile location has no profile photo."
-msgstr ""
-
-#: mod/dfrn_request.php:143 mod/dfrn_request.php:381
-#, php-format
-msgid "%d required parameter was not found at the given location"
-msgid_plural "%d required parameters were not found at the given location"
-msgstr[0] ""
-msgstr[1] ""
-
-#: mod/dfrn_request.php:181
-msgid "Introduction complete."
-msgstr ""
-
-#: mod/dfrn_request.php:217
-msgid "Unrecoverable protocol error."
-msgstr ""
-
-#: mod/dfrn_request.php:244 src/Module/RemoteFollow.php:54
-msgid "Profile unavailable."
-msgstr ""
-
-#: mod/dfrn_request.php:265
-#, php-format
-msgid "%s has received too many connection requests today."
-msgstr ""
-
-#: mod/dfrn_request.php:266
-msgid "Spam protection measures have been invoked."
-msgstr ""
-
-#: mod/dfrn_request.php:267
-msgid "Friends are advised to please try again in 24 hours."
-msgstr ""
-
-#: mod/dfrn_request.php:291 src/Module/RemoteFollow.php:60
-msgid "Invalid locator"
-msgstr ""
-
-#: mod/dfrn_request.php:327
-msgid "You have already introduced yourself here."
-msgstr ""
-
-#: mod/dfrn_request.php:330
-#, php-format
-msgid "Apparently you are already friends with %s."
-msgstr ""
-
-#: mod/dfrn_request.php:350
-msgid "Invalid profile URL."
-msgstr ""
-
-#: mod/dfrn_request.php:356 src/Model/Contact.php:2143
-msgid "Disallowed profile URL."
-msgstr ""
-
-#: mod/dfrn_request.php:362 src/Module/Friendica.php:80
-#: src/Model/Contact.php:2148
-msgid "Blocked domain"
-msgstr ""
-
-#: mod/dfrn_request.php:429 src/Module/Contact.php:157
-msgid "Failed to update contact record."
-msgstr ""
-
-#: mod/dfrn_request.php:449
-msgid "Your introduction has been sent."
-msgstr ""
-
-#: mod/dfrn_request.php:481 src/Module/RemoteFollow.php:72
-msgid ""
-"Remote subscription can't be done for your network. Please subscribe "
-"directly on your system."
-msgstr ""
-
-#: mod/dfrn_request.php:497
-msgid "Please login to confirm introduction."
-msgstr ""
-
-#: mod/dfrn_request.php:505
-msgid ""
-"Incorrect identity currently logged in. Please login to <strong>this</"
-"strong> profile."
-msgstr ""
-
-#: mod/dfrn_request.php:519 mod/dfrn_request.php:534
-msgid "Confirm"
-msgstr ""
-
-#: mod/dfrn_request.php:530
-msgid "Hide this contact"
-msgstr ""
-
-#: mod/dfrn_request.php:532
-#, php-format
-msgid "Welcome home %s."
-msgstr ""
-
-#: mod/dfrn_request.php:533
-#, php-format
-msgid "Please confirm your introduction/connection request to %s."
-msgstr ""
-
-#: mod/dfrn_request.php:637 src/Module/RemoteFollow.php:104
-msgid "Friend/Connection Request"
-msgstr ""
-
-#: mod/dfrn_request.php:638
-#, php-format
-msgid ""
-"Enter your Webfinger address (user@domain.tld) or profile URL here. If this "
-"isn't supported by your system (for example it doesn't work with Diaspora), "
-"you have to subscribe to <strong>%s</strong> directly on your system"
-msgstr ""
-
-#: mod/dfrn_request.php:639 src/Module/RemoteFollow.php:106
-#, php-format
-msgid ""
-"If you are not yet a member of the free social web, <a href=\"%s\">follow "
-"this link to find a public Friendica node and join us today</a>."
-msgstr ""
-
-#: mod/dfrn_request.php:640 src/Module/RemoteFollow.php:107
-msgid "Your Webfinger address or profile URL:"
-msgstr ""
-
-#: mod/dfrn_request.php:641 mod/follow.php:146 src/Module/RemoteFollow.php:108
-msgid "Please answer the following:"
-msgstr ""
-
-#: mod/dfrn_request.php:649 mod/follow.php:160
-#, php-format
-msgid "%s knows you"
-msgstr ""
-
-#: mod/dfrn_request.php:650 mod/follow.php:161
-msgid "Add a personal note:"
-msgstr ""
-
-#: mod/api.php:102 mod/api.php:124
-msgid "Authorize application connection"
-msgstr ""
-
-#: mod/api.php:103
-msgid "Return to your app and insert this Securty Code:"
-msgstr ""
-
-#: mod/api.php:112 src/Module/BaseAdmin.php:54 src/Module/BaseAdmin.php:58
-msgid "Please login to continue."
-msgstr ""
-
-#: mod/api.php:126
-msgid ""
-"Do you want to authorize this application to access your posts and contacts, "
-"and/or create new posts for you?"
-msgstr ""
-
-#: mod/api.php:127 src/Module/Notifications/Introductions.php:123
-#: src/Module/Register.php:115 src/Module/Contact.php:456
-msgid "Yes"
-msgstr ""
-
-#: mod/api.php:128 src/Module/Notifications/Introductions.php:123
-#: src/Module/Register.php:116
-msgid "No"
-msgstr ""
-
-#: mod/wall_attach.php:105
-msgid "Sorry, maybe your upload is bigger than the PHP configuration allows"
-msgstr ""
-
-#: mod/wall_attach.php:105
-msgid "Or - did you try to upload an empty file?"
-msgstr ""
-
-#: mod/wall_attach.php:116
-#, php-format
-msgid "File exceeds size limit of %s"
-msgstr ""
-
-#: mod/wall_attach.php:131
-msgid "File upload failed."
-msgstr ""
-
-#: mod/item.php:134 mod/item.php:138
-msgid "Unable to locate original post."
-msgstr ""
-
-#: mod/item.php:333 mod/item.php:338
-msgid "Empty post discarded."
-msgstr ""
-
-#: mod/item.php:705
-msgid "Post updated."
-msgstr ""
-
-#: mod/item.php:722 mod/item.php:727
-msgid "Item wasn't stored."
-msgstr ""
-
-#: mod/item.php:738
-msgid "Item couldn't be fetched."
-msgstr ""
-
-#: mod/item.php:866 src/Module/Debug/ItemBody.php:46
-#: src/Module/Debug/ItemBody.php:59 src/Module/Admin/Themes/Details.php:39
-#: src/Module/Admin/Themes/Index.php:59
-msgid "Item not found."
 msgstr ""
 
 #: mod/uimport.php:45
@@ -2941,455 +2916,79 @@ msgid ""
 "select \"Export account\""
 msgstr ""
 
-#: mod/cal.php:74 src/Module/Profile/Common.php:41
-#: src/Module/Profile/Common.php:53 src/Module/Profile/Status.php:57
-#: src/Module/Profile/Contacts.php:40 src/Module/Profile/Contacts.php:51
-#: src/Module/Register.php:258 src/Module/HoverCard.php:53
-msgid "User not found."
+#: mod/unfollow.php:65 mod/unfollow.php:133
+msgid "You aren't following this contact."
 msgstr ""
 
-#: mod/cal.php:274 mod/events.php:422
-msgid "View"
+#: mod/unfollow.php:71 mod/unfollow.php:139
+msgid "Unfollowing is currently not supported by your network."
 msgstr ""
 
-#: mod/cal.php:275 mod/events.php:424
-msgid "Previous"
+#: mod/unfollow.php:95
+msgid "Disconnect/Unfollow"
 msgstr ""
 
-#: mod/cal.php:276 mod/events.php:425 src/Module/Install.php:196
-msgid "Next"
+#: mod/videos.php:134
+msgid "No videos selected"
 msgstr ""
 
-#: mod/cal.php:279 mod/events.php:430 src/Model/Event.php:444
-msgid "today"
+#: mod/videos.php:252 src/Model/Item.php:3710
+msgid "View Video"
 msgstr ""
 
-#: mod/cal.php:280 mod/events.php:431 src/Util/Temporal.php:330
-#: src/Model/Event.php:445
-msgid "month"
+#: mod/videos.php:267
+msgid "Recent Videos"
 msgstr ""
 
-#: mod/cal.php:281 mod/events.php:432 src/Util/Temporal.php:331
-#: src/Model/Event.php:446
-msgid "week"
+#: mod/videos.php:269
+msgid "Upload New Videos"
 msgstr ""
 
-#: mod/cal.php:282 mod/events.php:433 src/Util/Temporal.php:332
-#: src/Model/Event.php:447
-msgid "day"
-msgstr ""
-
-#: mod/cal.php:283 mod/events.php:434
-msgid "list"
-msgstr ""
-
-#: mod/cal.php:296 src/Console/User.php:152 src/Console/User.php:250
-#: src/Console/User.php:283 src/Console/User.php:309
-#: src/Module/Api/Twitter/ContactEndpoint.php:73
-#: src/Module/Admin/Users/Pending.php:71 src/Module/Admin/Users/Index.php:80
-#: src/Module/Admin/Users/Active.php:73 src/Module/Admin/Users/Blocked.php:74
-#: src/Model/User.php:607
-msgid "User not found"
-msgstr ""
-
-#: mod/cal.php:305
-msgid "This calendar format is not supported"
-msgstr ""
-
-#: mod/cal.php:307
-msgid "No exportable data found"
-msgstr ""
-
-#: mod/cal.php:324
-msgid "calendar"
-msgstr ""
-
-#: mod/editpost.php:45 mod/editpost.php:55
-msgid "Item not found"
-msgstr ""
-
-#: mod/editpost.php:62
-msgid "Edit post"
-msgstr ""
-
-#: mod/editpost.php:89 mod/notes.php:62 src/Module/Filer/SaveTag.php:66
-#: src/Content/Text/HTML.php:881
-msgid "Save"
-msgstr ""
-
-#: mod/editpost.php:96
-msgid "web link"
-msgstr ""
-
-#: mod/editpost.php:97
-msgid "Insert video link"
-msgstr ""
-
-#: mod/editpost.php:98
-msgid "video link"
-msgstr ""
-
-#: mod/editpost.php:99
-msgid "Insert audio link"
-msgstr ""
-
-#: mod/editpost.php:100
-msgid "audio link"
-msgstr ""
-
-#: mod/editpost.php:114 src/Core/ACL.php:312
-msgid "CC: email addresses"
-msgstr ""
-
-#: mod/editpost.php:121 src/Core/ACL.php:313
-msgid "Example: bob@example.com, mary@example.com"
-msgstr ""
-
-#: mod/events.php:135 mod/events.php:137
-msgid "Event can not end before it has started."
-msgstr ""
-
-#: mod/events.php:144 mod/events.php:146
-msgid "Event title and start time are required."
-msgstr ""
-
-#: mod/events.php:423
-msgid "Create New Event"
-msgstr ""
-
-#: mod/events.php:535
-msgid "Event details"
-msgstr ""
-
-#: mod/events.php:536
-msgid "Starting date and Title are required."
-msgstr ""
-
-#: mod/events.php:537 mod/events.php:542
-msgid "Event Starts:"
-msgstr ""
-
-#: mod/events.php:537 mod/events.php:569
-#: src/Module/Security/TwoFactor/Verify.php:85 src/Module/Debug/Probe.php:57
-#: src/Module/Register.php:135 src/Module/Install.php:189
-#: src/Module/Install.php:222 src/Module/Install.php:227
-#: src/Module/Install.php:246 src/Module/Install.php:257
-#: src/Module/Install.php:262 src/Module/Install.php:268
-#: src/Module/Install.php:273 src/Module/Install.php:287
-#: src/Module/Install.php:302 src/Module/Install.php:329
-#: src/Module/Admin/Blocklist/Server.php:79
-#: src/Module/Admin/Blocklist/Server.php:80
-#: src/Module/Admin/Blocklist/Server.php:99
-#: src/Module/Admin/Blocklist/Server.php:100
-#: src/Module/Admin/Item/Delete.php:70
-#: src/Module/Settings/TwoFactor/Index.php:128
-#: src/Module/Settings/TwoFactor/Verify.php:141
-msgid "Required"
-msgstr ""
-
-#: mod/events.php:550 mod/events.php:575
-msgid "Finish date/time is not known or not relevant"
-msgstr ""
-
-#: mod/events.php:552 mod/events.php:557
-msgid "Event Finishes:"
-msgstr ""
-
-#: mod/events.php:563 mod/events.php:576
-msgid "Adjust for viewer timezone"
-msgstr ""
-
-#: mod/events.php:565 src/Module/Profile/Profile.php:172
-#: src/Module/Settings/Profile/Index.php:253
-msgid "Description:"
-msgstr ""
-
-#: mod/events.php:567 src/Module/Notifications/Introductions.php:172
-#: src/Module/Profile/Profile.php:190 src/Module/Contact.php:646
-#: src/Module/Directory.php:156 src/Model/Event.php:84 src/Model/Event.php:111
-#: src/Model/Event.php:453 src/Model/Event.php:947 src/Model/Profile.php:358
-msgid "Location:"
-msgstr ""
-
-#: mod/events.php:569 mod/events.php:571
-msgid "Title:"
-msgstr ""
-
-#: mod/events.php:572 mod/events.php:573
-msgid "Share this event"
-msgstr ""
-
-#: mod/events.php:580 src/Module/Profile/Profile.php:243
-msgid "Basic"
-msgstr ""
-
-#: mod/events.php:581 src/Module/Profile/Profile.php:244
-#: src/Module/Contact.php:953 src/Module/Admin/Site.php:603
-msgid "Advanced"
-msgstr ""
-
-#: mod/events.php:598
-msgid "Failed to remove event"
-msgstr ""
-
-#: mod/follow.php:83
-msgid "You already added this contact."
-msgstr ""
-
-#: mod/follow.php:99
-msgid "The network type couldn't be detected. Contact can't be added."
-msgstr ""
-
-#: mod/follow.php:107
-msgid "Diaspora support isn't enabled. Contact can't be added."
-msgstr ""
-
-#: mod/follow.php:112
-msgid "OStatus support is disabled. Contact can't be added."
-msgstr ""
-
-#: mod/follow.php:149 src/Module/Notifications/Introductions.php:176
-#: src/Module/Profile/Profile.php:202 src/Module/Contact.php:652
-msgid "Tags:"
-msgstr ""
-
-#: mod/follow.php:202
-msgid "The contact could not be added."
-msgstr ""
-
-#: mod/fbrowser.php:107 mod/fbrowser.php:136
-#: src/Module/Settings/Profile/Photo/Index.php:130
-msgid "Upload"
-msgstr ""
-
-#: mod/fbrowser.php:131
-msgid "Files"
-msgstr ""
-
-#: mod/notes.php:50 src/Module/BaseProfile.php:110
-msgid "Personal Notes"
-msgstr ""
-
-#: mod/notes.php:58
-msgid "Personal notes are visible only by yourself."
-msgstr ""
-
-#: mod/photos.php:128 src/Module/BaseProfile.php:71
-msgid "Photo Albums"
-msgstr ""
-
-#: mod/photos.php:129 mod/photos.php:1636
-msgid "Recent Photos"
-msgstr ""
-
-#: mod/photos.php:131 mod/photos.php:1104 mod/photos.php:1638
-msgid "Upload New Photos"
-msgstr ""
-
-#: mod/photos.php:149 src/Module/BaseSettings.php:37
-msgid "everybody"
-msgstr ""
-
-#: mod/photos.php:182
-msgid "Contact information unavailable"
-msgstr ""
-
-#: mod/photos.php:221
-msgid "Album not found."
-msgstr ""
-
-#: mod/photos.php:279
-msgid "Album successfully deleted"
-msgstr ""
-
-#: mod/photos.php:281
-msgid "Album was empty."
-msgstr ""
-
-#: mod/photos.php:313
-msgid "Failed to delete the photo."
-msgstr ""
-
-#: mod/photos.php:588
-msgid "a photo"
-msgstr ""
-
-#: mod/photos.php:588
+#: mod/wallmessage.php:68 mod/wallmessage.php:129
 #, php-format
-msgid "%1$s was tagged in %2$s by %3$s"
+msgid "Number of daily wall messages for %s exceeded. Message failed."
 msgstr ""
 
-#: mod/photos.php:677
-msgid "Image upload didn't complete, please try again"
+#: mod/wallmessage.php:79
+msgid "Unable to check your home location."
 msgstr ""
 
-#: mod/photos.php:680
-msgid "Image file is missing"
+#: mod/wallmessage.php:103 mod/wallmessage.php:112
+msgid "No recipient."
 msgstr ""
 
-#: mod/photos.php:685
+#: mod/wallmessage.php:143
+#, php-format
 msgid ""
-"Server can't accept new file upload at this time, please contact your "
-"administrator"
+"If you wish for %s to respond, please check that the privacy settings on "
+"your site allow private mail from unknown senders."
 msgstr ""
 
-#: mod/photos.php:709
-msgid "Image file is empty."
+#: mod/wall_attach.php:42 mod/wall_attach.php:49 mod/wall_attach.php:87
+#: mod/wall_upload.php:52 mod/wall_upload.php:63 mod/wall_upload.php:108
+#: mod/wall_upload.php:159 mod/wall_upload.php:162
+msgid "Invalid request."
 msgstr ""
 
-#: mod/photos.php:840
-msgid "No photos selected"
+#: mod/wall_attach.php:105
+msgid "Sorry, maybe your upload is bigger than the PHP configuration allows"
 msgstr ""
 
-#: mod/photos.php:960
-msgid "Upload Photos"
+#: mod/wall_attach.php:105
+msgid "Or - did you try to upload an empty file?"
 msgstr ""
 
-#: mod/photos.php:964 mod/photos.php:1049
-msgid "New album name: "
+#: mod/wall_attach.php:116
+#, php-format
+msgid "File exceeds size limit of %s"
 msgstr ""
 
-#: mod/photos.php:965
-msgid "or select existing album:"
+#: mod/wall_attach.php:131
+msgid "File upload failed."
 msgstr ""
 
-#: mod/photos.php:966
-msgid "Do not show a status post for this upload"
-msgstr ""
-
-#: mod/photos.php:1032
-msgid "Do you really want to delete this photo album and all its photos?"
-msgstr ""
-
-#: mod/photos.php:1033 mod/photos.php:1054
-msgid "Delete Album"
-msgstr ""
-
-#: mod/photos.php:1060
-msgid "Edit Album"
-msgstr ""
-
-#: mod/photos.php:1061
-msgid "Drop Album"
-msgstr ""
-
-#: mod/photos.php:1066
-msgid "Show Newest First"
-msgstr ""
-
-#: mod/photos.php:1068
-msgid "Show Oldest First"
-msgstr ""
-
-#: mod/photos.php:1089 mod/photos.php:1621
-msgid "View Photo"
-msgstr ""
-
-#: mod/photos.php:1126
-msgid "Permission denied. Access to this item may be restricted."
-msgstr ""
-
-#: mod/photos.php:1128
-msgid "Photo not available"
-msgstr ""
-
-#: mod/photos.php:1138
-msgid "Do you really want to delete this photo?"
-msgstr ""
-
-#: mod/photos.php:1139 mod/photos.php:1340
-msgid "Delete Photo"
-msgstr ""
-
-#: mod/photos.php:1230
-msgid "View photo"
-msgstr ""
-
-#: mod/photos.php:1232
-msgid "Edit photo"
-msgstr ""
-
-#: mod/photos.php:1233
-msgid "Delete photo"
-msgstr ""
-
-#: mod/photos.php:1234
-msgid "Use as profile photo"
-msgstr ""
-
-#: mod/photos.php:1241
-msgid "Private Photo"
-msgstr ""
-
-#: mod/photos.php:1247
-msgid "View Full Size"
-msgstr ""
-
-#: mod/photos.php:1308
-msgid "Tags: "
-msgstr ""
-
-#: mod/photos.php:1311
-msgid "[Select tags to remove]"
-msgstr ""
-
-#: mod/photos.php:1326
-msgid "New album name"
-msgstr ""
-
-#: mod/photos.php:1327
-msgid "Caption"
-msgstr ""
-
-#: mod/photos.php:1328
-msgid "Add a Tag"
-msgstr ""
-
-#: mod/photos.php:1328
-msgid "Example: @bob, @Barbara_Jensen, @jim@example.com, #California, #camping"
-msgstr ""
-
-#: mod/photos.php:1329
-msgid "Do not rotate"
-msgstr ""
-
-#: mod/photos.php:1330
-msgid "Rotate CW (right)"
-msgstr ""
-
-#: mod/photos.php:1331
-msgid "Rotate CCW (left)"
-msgstr ""
-
-#: mod/photos.php:1377 mod/photos.php:1434 mod/photos.php:1507
-#: src/Object/Post.php:950 src/Module/Contact.php:1096
-#: src/Module/Item/Compose.php:142
-msgid "This is you"
-msgstr ""
-
-#: mod/photos.php:1379 mod/photos.php:1436 mod/photos.php:1509
-#: src/Object/Post.php:490 src/Object/Post.php:952
-msgid "Comment"
-msgstr ""
-
-#: mod/photos.php:1531
-msgid "Like"
-msgstr ""
-
-#: mod/photos.php:1532 src/Object/Post.php:351
-msgid "I like this (toggle)"
-msgstr ""
-
-#: mod/photos.php:1533
-msgid "Dislike"
-msgstr ""
-
-#: mod/photos.php:1535 src/Object/Post.php:352
-msgid "I don't like this (toggle)"
-msgstr ""
-
-#: mod/photos.php:1557
-msgid "Map"
+#: mod/wall_upload.php:219
+msgid "Wall Photos"
 msgstr ""
 
 #: src/App/Module.php:241
@@ -3413,134 +3012,829 @@ msgstr ""
 msgid "Page not found."
 msgstr ""
 
-#: src/Security/Authentication.php:210 src/Security/Authentication.php:262
-msgid "Login failed."
+#: src/App.php:309
+msgid "No system theme config value set."
 msgstr ""
 
-#: src/Security/Authentication.php:224 src/Model/User.php:843
+#: src/BaseModule.php:150
 msgid ""
-"We encountered a problem while logging in with the OpenID you provided. "
-"Please check the correct spelling of the ID."
+"The form security token was not correct. This probably happened because the "
+"form has been opened for too long (>3 hours) before submitting it."
 msgstr ""
 
-#: src/Security/Authentication.php:224 src/Model/User.php:843
-msgid "The error message was:"
+#: src/BaseModule.php:179
+msgid "All contacts"
 msgstr ""
 
-#: src/Security/Authentication.php:273
-msgid "Login failed. Please check your credentials."
+#: src/BaseModule.php:184 src/Content/Widget.php:237 src/Core/ACL.php:182
+#: src/Module/Contact.php:852 src/Module/PermissionTooltip.php:76
+#: src/Module/PermissionTooltip.php:98
+msgid "Followers"
 msgstr ""
 
-#: src/Security/Authentication.php:389
+#: src/BaseModule.php:189 src/Content/Widget.php:238 src/Module/Contact.php:853
+msgid "Following"
+msgstr ""
+
+#: src/BaseModule.php:194 src/Content/Widget.php:239 src/Module/Contact.php:854
+msgid "Mutual friends"
+msgstr ""
+
+#: src/BaseModule.php:202
+msgid "Common"
+msgstr ""
+
+#: src/Console/ArchiveContact.php:105
 #, php-format
-msgid "Welcome %s"
+msgid "Could not find any unarchived contact entry for this URL (%s)"
 msgstr ""
 
-#: src/Security/Authentication.php:390
-msgid "Please upload a profile photo."
+#: src/Console/ArchiveContact.php:108
+msgid "The contact entries have been archived"
 msgstr ""
 
-#: src/Database/DBStructure.php:64
+#: src/Console/GlobalCommunityBlock.php:96
+#: src/Module/Admin/Blocklist/Contact.php:49
 #, php-format
-msgid "The database version had been set to %s."
+msgid "Could not find any contact entry for this URL (%s)"
 msgstr ""
 
-#: src/Database/DBStructure.php:82
-msgid "No unused tables found."
+#: src/Console/GlobalCommunityBlock.php:101
+#: src/Module/Admin/Blocklist/Contact.php:47
+msgid "The contact has been blocked from the node"
 msgstr ""
 
-#: src/Database/DBStructure.php:87
+#: src/Console/PostUpdate.php:87
+#, php-format
+msgid "Post update version number has been set to %s."
+msgstr ""
+
+#: src/Console/PostUpdate.php:95
+msgid "Check for pending update actions."
+msgstr ""
+
+#: src/Console/PostUpdate.php:97
+msgid "Done."
+msgstr ""
+
+#: src/Console/PostUpdate.php:99
+msgid "Execute pending post updates."
+msgstr ""
+
+#: src/Console/PostUpdate.php:105
+msgid "All pending post updates are done."
+msgstr ""
+
+#: src/Console/User.php:158
+msgid "Enter new password: "
+msgstr ""
+
+#: src/Console/User.php:193
+msgid "Enter user name: "
+msgstr ""
+
+#: src/Console/User.php:201 src/Console/User.php:241 src/Console/User.php:274
+#: src/Console/User.php:300
+msgid "Enter user nickname: "
+msgstr ""
+
+#: src/Console/User.php:209
+msgid "Enter user email address: "
+msgstr ""
+
+#: src/Console/User.php:217
+msgid "Enter a language (optional): "
+msgstr ""
+
+#: src/Console/User.php:255
+msgid "User is not pending."
+msgstr ""
+
+#: src/Console/User.php:313
+msgid "User has already been marked for deletion."
+msgstr ""
+
+#: src/Console/User.php:318
+#, php-format
+msgid "Type \"yes\" to delete %s"
+msgstr ""
+
+#: src/Console/User.php:320
+msgid "Deletion aborted."
+msgstr ""
+
+#: src/Content/BoundariesPager.php:116 src/Content/Pager.php:171
+msgid "newer"
+msgstr ""
+
+#: src/Content/BoundariesPager.php:124 src/Content/Pager.php:176
+msgid "older"
+msgstr ""
+
+#: src/Content/ContactSelector.php:48
+msgid "Frequently"
+msgstr ""
+
+#: src/Content/ContactSelector.php:49
+msgid "Hourly"
+msgstr ""
+
+#: src/Content/ContactSelector.php:50
+msgid "Twice daily"
+msgstr ""
+
+#: src/Content/ContactSelector.php:51
+msgid "Daily"
+msgstr ""
+
+#: src/Content/ContactSelector.php:52
+msgid "Weekly"
+msgstr ""
+
+#: src/Content/ContactSelector.php:53
+msgid "Monthly"
+msgstr ""
+
+#: src/Content/ContactSelector.php:99
+msgid "DFRN"
+msgstr ""
+
+#: src/Content/ContactSelector.php:100
+msgid "OStatus"
+msgstr ""
+
+#: src/Content/ContactSelector.php:101
+msgid "RSS/Atom"
+msgstr ""
+
+#: src/Content/ContactSelector.php:102 src/Module/Admin/Users/Active.php:129
+#: src/Module/Admin/Users/Blocked.php:130 src/Module/Admin/Users/Create.php:73
+#: src/Module/Admin/Users/Deleted.php:88 src/Module/Admin/Users/Index.php:142
+#: src/Module/Admin/Users/Index.php:162 src/Module/Admin/Users/Pending.php:104
+msgid "Email"
+msgstr ""
+
+#: src/Content/ContactSelector.php:103 src/Module/Debug/Babel.php:306
+msgid "Diaspora"
+msgstr ""
+
+#: src/Content/ContactSelector.php:104
+msgid "Zot!"
+msgstr ""
+
+#: src/Content/ContactSelector.php:105
+msgid "LinkedIn"
+msgstr ""
+
+#: src/Content/ContactSelector.php:106
+msgid "XMPP/IM"
+msgstr ""
+
+#: src/Content/ContactSelector.php:107
+msgid "MySpace"
+msgstr ""
+
+#: src/Content/ContactSelector.php:108
+msgid "Google+"
+msgstr ""
+
+#: src/Content/ContactSelector.php:109
+msgid "pump.io"
+msgstr ""
+
+#: src/Content/ContactSelector.php:110
+msgid "Twitter"
+msgstr ""
+
+#: src/Content/ContactSelector.php:111
+msgid "Discourse"
+msgstr ""
+
+#: src/Content/ContactSelector.php:112
+msgid "Diaspora Connector"
+msgstr ""
+
+#: src/Content/ContactSelector.php:113
+msgid "GNU Social Connector"
+msgstr ""
+
+#: src/Content/ContactSelector.php:114
+msgid "ActivityPub"
+msgstr ""
+
+#: src/Content/ContactSelector.php:115
+msgid "pnut"
+msgstr ""
+
+#: src/Content/ContactSelector.php:149
+#, php-format
+msgid "%s (via %s)"
+msgstr ""
+
+#: src/Content/Feature.php:96
+msgid "General Features"
+msgstr ""
+
+#: src/Content/Feature.php:98
+msgid "Photo Location"
+msgstr ""
+
+#: src/Content/Feature.php:98
 msgid ""
-"These tables are not used for friendica and will be deleted when you execute "
-"\"dbstructure drop -e\":"
+"Photo metadata is normally stripped. This extracts the location (if present) "
+"prior to stripping metadata and links it to a map."
 msgstr ""
 
-#: src/Database/DBStructure.php:125
-msgid "There are no tables on MyISAM or InnoDB with the Antelope file format."
+#: src/Content/Feature.php:99
+msgid "Trending Tags"
 msgstr ""
 
-#: src/Database/DBStructure.php:149
+#: src/Content/Feature.php:99
+msgid ""
+"Show a community page widget with a list of the most popular tags in recent "
+"public posts."
+msgstr ""
+
+#: src/Content/Feature.php:104
+msgid "Post Composition Features"
+msgstr ""
+
+#: src/Content/Feature.php:105
+msgid "Auto-mention Forums"
+msgstr ""
+
+#: src/Content/Feature.php:105
+msgid ""
+"Add/remove mention when a forum page is selected/deselected in ACL window."
+msgstr ""
+
+#: src/Content/Feature.php:106
+msgid "Explicit Mentions"
+msgstr ""
+
+#: src/Content/Feature.php:106
+msgid ""
+"Add explicit mentions to comment box for manual control over who gets "
+"mentioned in replies."
+msgstr ""
+
+#: src/Content/Feature.php:111
+msgid "Post/Comment Tools"
+msgstr ""
+
+#: src/Content/Feature.php:112
+msgid "Post Categories"
+msgstr ""
+
+#: src/Content/Feature.php:112
+msgid "Add categories to your posts"
+msgstr ""
+
+#: src/Content/Feature.php:117
+msgid "Advanced Profile Settings"
+msgstr ""
+
+#: src/Content/Feature.php:118
+msgid "List Forums"
+msgstr ""
+
+#: src/Content/Feature.php:118
+msgid "Show visitors public community forums at the Advanced Profile Page"
+msgstr ""
+
+#: src/Content/Feature.php:119
+msgid "Tag Cloud"
+msgstr ""
+
+#: src/Content/Feature.php:119
+msgid "Provide a personal tag cloud on your profile page"
+msgstr ""
+
+#: src/Content/Feature.php:120
+msgid "Display Membership Date"
+msgstr ""
+
+#: src/Content/Feature.php:120
+msgid "Display membership date in profile"
+msgstr ""
+
+#: src/Content/ForumManager.php:145 src/Content/Nav.php:229
+#: src/Content/Text/HTML.php:902 src/Content/Widget.php:540
+msgid "Forums"
+msgstr ""
+
+#: src/Content/ForumManager.php:147
+msgid "External link to forum"
+msgstr ""
+
+#: src/Content/ForumManager.php:150 src/Content/Widget.php:519
+msgid "show less"
+msgstr ""
+
+#: src/Content/ForumManager.php:151 src/Content/Widget.php:424
+#: src/Content/Widget.php:520
+msgid "show more"
+msgstr ""
+
+#: src/Content/Nav.php:90
+msgid "Nothing new here"
+msgstr ""
+
+#: src/Content/Nav.php:94 src/Module/Special/HTTPException.php:75
+msgid "Go back"
+msgstr ""
+
+#: src/Content/Nav.php:95
+msgid "Clear notifications"
+msgstr ""
+
+#: src/Content/Nav.php:96 src/Content/Text/HTML.php:889
+msgid "@name, !forum, #tags, content"
+msgstr ""
+
+#: src/Content/Nav.php:169 src/Module/Security/Login.php:141
+msgid "Logout"
+msgstr ""
+
+#: src/Content/Nav.php:169
+msgid "End this session"
+msgstr ""
+
+#: src/Content/Nav.php:171 src/Module/Bookmarklet.php:46
+#: src/Module/Security/Login.php:142
+msgid "Login"
+msgstr ""
+
+#: src/Content/Nav.php:171
+msgid "Sign in"
+msgstr ""
+
+#: src/Content/Nav.php:177 src/Module/BaseProfile.php:60
+#: src/Module/Contact.php:655 src/Module/Contact.php:920
+#: src/Module/Settings/TwoFactor/Index.php:107 view/theme/frio/theme.php:225
+msgid "Status"
+msgstr ""
+
+#: src/Content/Nav.php:177 src/Content/Nav.php:263
+#: view/theme/frio/theme.php:225
+msgid "Your posts and conversations"
+msgstr ""
+
+#: src/Content/Nav.php:178 src/Module/BaseProfile.php:52
+#: src/Module/BaseSettings.php:57 src/Module/Contact.php:657
+#: src/Module/Contact.php:936 src/Module/Profile/Profile.php:236
+#: src/Module/Welcome.php:57 view/theme/frio/theme.php:226
+msgid "Profile"
+msgstr ""
+
+#: src/Content/Nav.php:178 view/theme/frio/theme.php:226
+msgid "Your profile page"
+msgstr ""
+
+#: src/Content/Nav.php:179 view/theme/frio/theme.php:227
+msgid "Your photos"
+msgstr ""
+
+#: src/Content/Nav.php:180 src/Module/BaseProfile.php:76
+#: src/Module/BaseProfile.php:79 view/theme/frio/theme.php:228
+msgid "Videos"
+msgstr ""
+
+#: src/Content/Nav.php:180 view/theme/frio/theme.php:228
+msgid "Your videos"
+msgstr ""
+
+#: src/Content/Nav.php:181 view/theme/frio/theme.php:229
+msgid "Your events"
+msgstr ""
+
+#: src/Content/Nav.php:182
+msgid "Personal notes"
+msgstr ""
+
+#: src/Content/Nav.php:182
+msgid "Your personal notes"
+msgstr ""
+
+#: src/Content/Nav.php:202 src/Content/Nav.php:263
+msgid "Home"
+msgstr ""
+
+#: src/Content/Nav.php:202
+msgid "Home Page"
+msgstr ""
+
+#: src/Content/Nav.php:206 src/Module/Register.php:155
+#: src/Module/Security/Login.php:102
+msgid "Register"
+msgstr ""
+
+#: src/Content/Nav.php:206
+msgid "Create an account"
+msgstr ""
+
+#: src/Content/Nav.php:212 src/Module/Help.php:69
+#: src/Module/Settings/TwoFactor/AppSpecific.php:115
+#: src/Module/Settings/TwoFactor/Index.php:106
+#: src/Module/Settings/TwoFactor/Recovery.php:93
+#: src/Module/Settings/TwoFactor/Verify.php:132 view/theme/vier/theme.php:217
+msgid "Help"
+msgstr ""
+
+#: src/Content/Nav.php:212
+msgid "Help and documentation"
+msgstr ""
+
+#: src/Content/Nav.php:216
+msgid "Apps"
+msgstr ""
+
+#: src/Content/Nav.php:216
+msgid "Addon applications, utilities, games"
+msgstr ""
+
+#: src/Content/Nav.php:220 src/Content/Text/HTML.php:887
+#: src/Module/Search/Index.php:99
+msgid "Search"
+msgstr ""
+
+#: src/Content/Nav.php:220
+msgid "Search site content"
+msgstr ""
+
+#: src/Content/Nav.php:223 src/Content/Text/HTML.php:896
+msgid "Full Text"
+msgstr ""
+
+#: src/Content/Nav.php:224 src/Content/Text/HTML.php:897
+#: src/Content/Widget/TagCloud.php:68
+msgid "Tags"
+msgstr ""
+
+#: src/Content/Nav.php:225 src/Content/Nav.php:284
+#: src/Content/Text/HTML.php:898 src/Module/BaseProfile.php:121
+#: src/Module/BaseProfile.php:124 src/Module/Contact.php:855
+#: src/Module/Contact.php:943 view/theme/frio/theme.php:236
+msgid "Contacts"
+msgstr ""
+
+#: src/Content/Nav.php:244
+msgid "Community"
+msgstr ""
+
+#: src/Content/Nav.php:244
+msgid "Conversations on this and other servers"
+msgstr ""
+
+#: src/Content/Nav.php:248 src/Module/BaseProfile.php:91
+#: src/Module/BaseProfile.php:102 view/theme/frio/theme.php:233
+msgid "Events and Calendar"
+msgstr ""
+
+#: src/Content/Nav.php:251
+msgid "Directory"
+msgstr ""
+
+#: src/Content/Nav.php:251
+msgid "People directory"
+msgstr ""
+
+#: src/Content/Nav.php:253 src/Module/BaseAdmin.php:85
+msgid "Information"
+msgstr ""
+
+#: src/Content/Nav.php:253
+msgid "Information about this friendica instance"
+msgstr ""
+
+#: src/Content/Nav.php:256 src/Module/Admin/Tos.php:59
+#: src/Module/BaseAdmin.php:95 src/Module/Register.php:163
+#: src/Module/Tos.php:84
+msgid "Terms of Service"
+msgstr ""
+
+#: src/Content/Nav.php:256
+msgid "Terms of Service of this Friendica instance"
+msgstr ""
+
+#: src/Content/Nav.php:261 view/theme/frio/theme.php:232
+msgid "Network"
+msgstr ""
+
+#: src/Content/Nav.php:261 view/theme/frio/theme.php:232
+msgid "Conversations from your friends"
+msgstr ""
+
+#: src/Content/Nav.php:267
+msgid "Introductions"
+msgstr ""
+
+#: src/Content/Nav.php:267
+msgid "Friend Requests"
+msgstr ""
+
+#: src/Content/Nav.php:268 src/Module/BaseNotifications.php:139
+#: src/Module/Notifications/Introductions.php:54
+msgid "Notifications"
+msgstr ""
+
+#: src/Content/Nav.php:269
+msgid "See all notifications"
+msgstr ""
+
+#: src/Content/Nav.php:270
+msgid "Mark all system notifications seen"
+msgstr ""
+
+#: src/Content/Nav.php:273 view/theme/frio/theme.php:234
+msgid "Private mail"
+msgstr ""
+
+#: src/Content/Nav.php:274
+msgid "Inbox"
+msgstr ""
+
+#: src/Content/Nav.php:275
+msgid "Outbox"
+msgstr ""
+
+#: src/Content/Nav.php:279
+msgid "Accounts"
+msgstr ""
+
+#: src/Content/Nav.php:279
+msgid "Manage other pages"
+msgstr ""
+
+#: src/Content/Nav.php:282 src/Module/Admin/Addons/Details.php:114
+#: src/Module/Admin/Themes/Details.php:93 src/Module/BaseSettings.php:124
+#: src/Module/Welcome.php:52 view/theme/frio/theme.php:235
+msgid "Settings"
+msgstr ""
+
+#: src/Content/Nav.php:282 view/theme/frio/theme.php:235
+msgid "Account settings"
+msgstr ""
+
+#: src/Content/Nav.php:284 view/theme/frio/theme.php:236
+msgid "Manage/edit friends and contacts"
+msgstr ""
+
+#: src/Content/Nav.php:289 src/Module/BaseAdmin.php:125
+msgid "Admin"
+msgstr ""
+
+#: src/Content/Nav.php:289
+msgid "Site setup and configuration"
+msgstr ""
+
+#: src/Content/Nav.php:292
+msgid "Navigation"
+msgstr ""
+
+#: src/Content/Nav.php:292
+msgid "Site map"
+msgstr ""
+
+#: src/Content/OEmbed.php:267
+msgid "Embedding disabled"
+msgstr ""
+
+#: src/Content/OEmbed.php:389
+msgid "Embedded content"
+msgstr ""
+
+#: src/Content/Pager.php:221
+msgid "prev"
+msgstr ""
+
+#: src/Content/Pager.php:281
+msgid "last"
+msgstr ""
+
+#: src/Content/Text/BBCode.php:961 src/Content/Text/BBCode.php:1605
+#: src/Content/Text/BBCode.php:1606
+msgid "Image/photo"
+msgstr ""
+
+#: src/Content/Text/BBCode.php:1063
 #, php-format
 msgid ""
-"\n"
-"Error %d occurred during database update:\n"
-"%s\n"
+"<a href=\"%1$s\" target=\"_blank\" rel=\"noopener noreferrer\">%2$s</a> %3$s"
 msgstr ""
 
-#: src/Database/DBStructure.php:152
-msgid "Errors encountered performing database changes: "
+#: src/Content/Text/BBCode.php:1088 src/Model/Item.php:3778
+#: src/Model/Item.php:3784
+msgid "link to source"
 msgstr ""
 
-#: src/Database/DBStructure.php:380
-msgid "Another database update is currently running."
+#: src/Content/Text/BBCode.php:1523 src/Content/Text/HTML.php:939
+msgid "Click to open/close"
 msgstr ""
 
-#: src/Database/DBStructure.php:384
+#: src/Content/Text/BBCode.php:1554
+msgid "$1 wrote:"
+msgstr ""
+
+#: src/Content/Text/BBCode.php:1608 src/Content/Text/BBCode.php:1609
+msgid "Encrypted content"
+msgstr ""
+
+#: src/Content/Text/BBCode.php:1821
+msgid "Invalid source protocol"
+msgstr ""
+
+#: src/Content/Text/BBCode.php:1836
+msgid "Invalid link protocol"
+msgstr ""
+
+#: src/Content/Text/HTML.php:787
+msgid "Loading more entries..."
+msgstr ""
+
+#: src/Content/Text/HTML.php:788
+msgid "The end"
+msgstr ""
+
+#: src/Content/Text/HTML.php:881 src/Model/Profile.php:439
+#: src/Module/Contact.php:340
+msgid "Follow"
+msgstr ""
+
+#: src/Content/Widget/CalendarExport.php:63
+msgid "Export"
+msgstr ""
+
+#: src/Content/Widget/CalendarExport.php:64
+msgid "Export calendar as ical"
+msgstr ""
+
+#: src/Content/Widget/CalendarExport.php:65
+msgid "Export calendar as csv"
+msgstr ""
+
+#: src/Content/Widget/ContactBlock.php:73
+msgid "No contacts"
+msgstr ""
+
+#: src/Content/Widget/ContactBlock.php:105
 #, php-format
-msgid "%s: Database update"
+msgid "%d Contact"
+msgid_plural "%d Contacts"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/Content/Widget/ContactBlock.php:124
+msgid "View Contacts"
 msgstr ""
 
-#: src/Database/DBStructure.php:684
+#: src/Content/Widget/SavedSearches.php:47
+msgid "Remove term"
+msgstr ""
+
+#: src/Content/Widget/SavedSearches.php:60
+msgid "Saved Searches"
+msgstr ""
+
+#: src/Content/Widget/TrendingTags.php:51
 #, php-format
-msgid "%s: updating %s table."
+msgid "Trending Tags (last %d hour)"
+msgid_plural "Trending Tags (last %d hours)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/Content/Widget/TrendingTags.php:52
+msgid "More Trending Tags"
 msgstr ""
 
-#: src/Core/Renderer.php:90 src/Core/Renderer.php:119 src/Core/Renderer.php:146
-#: src/Core/Renderer.php:180 src/Render/FriendicaSmartyEngine.php:56
-msgid ""
-"Friendica can't display this page at the moment, please contact the "
-"administrator."
+#: src/Content/Widget.php:48
+msgid "Add New Contact"
 msgstr ""
 
-#: src/Core/Renderer.php:142
-msgid "template engine cannot be registered without a name."
+#: src/Content/Widget.php:49
+msgid "Enter address or web location"
 msgstr ""
 
-#: src/Core/Renderer.php:176
-msgid "template engine is not registered!"
+#: src/Content/Widget.php:50
+msgid "Example: bob@example.com, http://example.com/barbara"
 msgstr ""
 
-#: src/Core/Update.php:226
+#: src/Content/Widget.php:52
+msgid "Connect"
+msgstr ""
+
+#: src/Content/Widget.php:67
 #, php-format
-msgid "Update %s failed. See error logs."
+msgid "%d invitation available"
+msgid_plural "%d invitations available"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/Content/Widget.php:73 view/theme/vier/theme.php:170
+msgid "Find People"
 msgstr ""
 
-#: src/Core/Update.php:279
+#: src/Content/Widget.php:74 view/theme/vier/theme.php:171
+msgid "Enter name or interest"
+msgstr ""
+
+#: src/Content/Widget.php:76 view/theme/vier/theme.php:173
+msgid "Examples: Robert Morgenstein, Fishing"
+msgstr ""
+
+#: src/Content/Widget.php:77 src/Module/Contact.php:876
+#: src/Module/Directory.php:105 view/theme/vier/theme.php:174
+msgid "Find"
+msgstr ""
+
+#: src/Content/Widget.php:79 view/theme/vier/theme.php:176
+msgid "Similar Interests"
+msgstr ""
+
+#: src/Content/Widget.php:80 view/theme/vier/theme.php:177
+msgid "Random Profile"
+msgstr ""
+
+#: src/Content/Widget.php:81 view/theme/vier/theme.php:178
+msgid "Invite Friends"
+msgstr ""
+
+#: src/Content/Widget.php:82 src/Module/Directory.php:97
+#: view/theme/vier/theme.php:179
+msgid "Global Directory"
+msgstr ""
+
+#: src/Content/Widget.php:84 view/theme/vier/theme.php:181
+msgid "Local Directory"
+msgstr ""
+
+#: src/Content/Widget.php:213 src/Model/Group.php:535
+#: src/Module/Contact.php:839 src/Module/Welcome.php:76
+msgid "Groups"
+msgstr ""
+
+#: src/Content/Widget.php:215
+msgid "Everyone"
+msgstr ""
+
+#: src/Content/Widget.php:244
+msgid "Relationships"
+msgstr ""
+
+#: src/Content/Widget.php:246 src/Module/Contact.php:791
+#: src/Module/Group.php:292
+msgid "All Contacts"
+msgstr ""
+
+#: src/Content/Widget.php:285
+msgid "Protocols"
+msgstr ""
+
+#: src/Content/Widget.php:287
+msgid "All Protocols"
+msgstr ""
+
+#: src/Content/Widget.php:324
+msgid "Saved Folders"
+msgstr ""
+
+#: src/Content/Widget.php:326 src/Content/Widget.php:365
+msgid "Everything"
+msgstr ""
+
+#: src/Content/Widget.php:363
+msgid "Categories"
+msgstr ""
+
+#: src/Content/Widget.php:420
 #, php-format
-msgid ""
-"\n"
-"\t\t\t\tThe friendica developers released update %s recently,\n"
-"\t\t\t\tbut when I tried to install it, something went terribly wrong.\n"
-"\t\t\t\tThis needs to be fixed soon and I can't do it alone. Please contact "
-"a\n"
-"\t\t\t\tfriendica developer if you can not help me on your own. My database "
-"might be invalid."
+msgid "%d contact in common"
+msgid_plural "%d contacts in common"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/Content/Widget.php:513
+msgid "Archives"
 msgstr ""
 
-#: src/Core/Update.php:285
-#, php-format
-msgid "The error message is\\n[pre]%s[/pre]"
+#: src/Content/Widget.php:537
+msgid "Persons"
 msgstr ""
 
-#: src/Core/Update.php:289 src/Core/Update.php:331
-msgid "[Friendica Notify] Database update"
+#: src/Content/Widget.php:538
+msgid "Organisations"
 msgstr ""
 
-#: src/Core/Update.php:325
-#, php-format
-msgid ""
-"\n"
-"\t\t\t\t\tThe friendica database was successfully updated from %s to %s."
+#: src/Content/Widget.php:539 src/Model/Contact.php:1409
+msgid "News"
+msgstr ""
+
+#: src/Content/Widget.php:544 src/Module/Admin/BaseUsers.php:50
+msgid "All"
 msgstr ""
 
 #: src/Core/ACL.php:153 src/Module/Profile/Profile.php:237
 msgid "Yourself"
-msgstr ""
-
-#: src/Core/ACL.php:182 src/Module/PermissionTooltip.php:76
-#: src/Module/PermissionTooltip.php:98 src/Module/Contact.php:852
-#: src/Content/Widget.php:237 src/BaseModule.php:184
-msgid "Followers"
 msgstr ""
 
 #: src/Core/ACL.php:189 src/Module/PermissionTooltip.php:82
@@ -3749,243 +4043,251 @@ msgid "Error: POSIX PHP module required but not installed."
 msgstr ""
 
 #: src/Core/Installer.php:467
-msgid "JSON PHP module"
+msgid "Program execution functions"
 msgstr ""
 
 #: src/Core/Installer.php:468
-msgid "Error: JSON PHP module required but not installed."
+msgid "Error: Program execution functions required but not enabled."
 msgstr ""
 
 #: src/Core/Installer.php:474
-msgid "File Information PHP module"
+msgid "JSON PHP module"
 msgstr ""
 
 #: src/Core/Installer.php:475
+msgid "Error: JSON PHP module required but not installed."
+msgstr ""
+
+#: src/Core/Installer.php:481
+msgid "File Information PHP module"
+msgstr ""
+
+#: src/Core/Installer.php:482
 msgid "Error: File Information PHP module required but not installed."
 msgstr ""
 
-#: src/Core/Installer.php:498
+#: src/Core/Installer.php:505
 msgid ""
 "The web installer needs to be able to create a file called \"local.config.php"
 "\" in the \"config\" folder of your web server and it is unable to do so."
 msgstr ""
 
-#: src/Core/Installer.php:499
+#: src/Core/Installer.php:506
 msgid ""
 "This is most often a permission setting, as the web server may not be able "
 "to write files in your folder - even if you can."
 msgstr ""
 
-#: src/Core/Installer.php:500
+#: src/Core/Installer.php:507
 msgid ""
 "At the end of this procedure, we will give you a text to save in a file "
 "named local.config.php in your Friendica \"config\" folder."
 msgstr ""
 
-#: src/Core/Installer.php:501
+#: src/Core/Installer.php:508
 msgid ""
 "You can alternatively skip this procedure and perform a manual installation. "
 "Please see the file \"INSTALL.txt\" for instructions."
 msgstr ""
 
-#: src/Core/Installer.php:504
+#: src/Core/Installer.php:511
 msgid "config/local.config.php is writable"
 msgstr ""
 
-#: src/Core/Installer.php:524
+#: src/Core/Installer.php:531
 msgid ""
 "Friendica uses the Smarty3 template engine to render its web views. Smarty3 "
 "compiles templates to PHP to speed up rendering."
 msgstr ""
 
-#: src/Core/Installer.php:525
+#: src/Core/Installer.php:532
 msgid ""
 "In order to store these compiled templates, the web server needs to have "
 "write access to the directory view/smarty3/ under the Friendica top level "
 "folder."
 msgstr ""
 
-#: src/Core/Installer.php:526
+#: src/Core/Installer.php:533
 msgid ""
 "Please ensure that the user that your web server runs as (e.g. www-data) has "
 "write access to this folder."
 msgstr ""
 
-#: src/Core/Installer.php:527
+#: src/Core/Installer.php:534
 msgid ""
 "Note: as a security measure, you should give the web server write access to "
 "view/smarty3/ only--not the template files (.tpl) that it contains."
 msgstr ""
 
-#: src/Core/Installer.php:530
+#: src/Core/Installer.php:537
 msgid "view/smarty3 is writable"
 msgstr ""
 
-#: src/Core/Installer.php:559
+#: src/Core/Installer.php:566
 msgid ""
 "Url rewrite in .htaccess is not working. Make sure you copied .htaccess-dist "
 "to .htaccess."
 msgstr ""
 
-#: src/Core/Installer.php:561
+#: src/Core/Installer.php:568
 msgid "Error message from Curl when fetching"
 msgstr ""
 
-#: src/Core/Installer.php:566
+#: src/Core/Installer.php:573
 msgid "Url rewrite is working"
 msgstr ""
 
-#: src/Core/Installer.php:595
+#: src/Core/Installer.php:602
 msgid "ImageMagick PHP extension is not installed"
 msgstr ""
 
-#: src/Core/Installer.php:597
+#: src/Core/Installer.php:604
 msgid "ImageMagick PHP extension is installed"
 msgstr ""
 
-#: src/Core/Installer.php:599
+#: src/Core/Installer.php:606
 msgid "ImageMagick supports GIF"
 msgstr ""
 
-#: src/Core/Installer.php:621
+#: src/Core/Installer.php:628
 msgid "Database already in use."
 msgstr ""
 
-#: src/Core/Installer.php:626
+#: src/Core/Installer.php:633
 msgid "Could not connect to database."
 msgstr ""
 
-#: src/Core/L10n.php:371 src/Module/Settings/Display.php:178
-#: src/Model/Event.php:412
+#: src/Core/L10n.php:371 src/Model/Event.php:415
+#: src/Module/Settings/Display.php:178
 msgid "Monday"
 msgstr ""
 
-#: src/Core/L10n.php:371 src/Model/Event.php:413
+#: src/Core/L10n.php:371 src/Model/Event.php:416
 msgid "Tuesday"
 msgstr ""
 
-#: src/Core/L10n.php:371 src/Model/Event.php:414
+#: src/Core/L10n.php:371 src/Model/Event.php:417
 msgid "Wednesday"
 msgstr ""
 
-#: src/Core/L10n.php:371 src/Model/Event.php:415
+#: src/Core/L10n.php:371 src/Model/Event.php:418
 msgid "Thursday"
 msgstr ""
 
-#: src/Core/L10n.php:371 src/Model/Event.php:416
+#: src/Core/L10n.php:371 src/Model/Event.php:419
 msgid "Friday"
 msgstr ""
 
-#: src/Core/L10n.php:371 src/Model/Event.php:417
+#: src/Core/L10n.php:371 src/Model/Event.php:420
 msgid "Saturday"
 msgstr ""
 
-#: src/Core/L10n.php:371 src/Module/Settings/Display.php:178
-#: src/Model/Event.php:411
+#: src/Core/L10n.php:371 src/Model/Event.php:414
+#: src/Module/Settings/Display.php:178
 msgid "Sunday"
 msgstr ""
 
-#: src/Core/L10n.php:375 src/Model/Event.php:432
+#: src/Core/L10n.php:375 src/Model/Event.php:435
 msgid "January"
 msgstr ""
 
-#: src/Core/L10n.php:375 src/Model/Event.php:433
+#: src/Core/L10n.php:375 src/Model/Event.php:436
 msgid "February"
 msgstr ""
 
-#: src/Core/L10n.php:375 src/Model/Event.php:434
+#: src/Core/L10n.php:375 src/Model/Event.php:437
 msgid "March"
 msgstr ""
 
-#: src/Core/L10n.php:375 src/Model/Event.php:435
+#: src/Core/L10n.php:375 src/Model/Event.php:438
 msgid "April"
 msgstr ""
 
-#: src/Core/L10n.php:375 src/Core/L10n.php:395 src/Model/Event.php:423
+#: src/Core/L10n.php:375 src/Core/L10n.php:395 src/Model/Event.php:426
 msgid "May"
 msgstr ""
 
-#: src/Core/L10n.php:375 src/Model/Event.php:436
+#: src/Core/L10n.php:375 src/Model/Event.php:439
 msgid "June"
 msgstr ""
 
-#: src/Core/L10n.php:375 src/Model/Event.php:437
+#: src/Core/L10n.php:375 src/Model/Event.php:440
 msgid "July"
 msgstr ""
 
-#: src/Core/L10n.php:375 src/Model/Event.php:438
+#: src/Core/L10n.php:375 src/Model/Event.php:441
 msgid "August"
 msgstr ""
 
-#: src/Core/L10n.php:375 src/Model/Event.php:439
+#: src/Core/L10n.php:375 src/Model/Event.php:442
 msgid "September"
 msgstr ""
 
-#: src/Core/L10n.php:375 src/Model/Event.php:440
+#: src/Core/L10n.php:375 src/Model/Event.php:443
 msgid "October"
 msgstr ""
 
-#: src/Core/L10n.php:375 src/Model/Event.php:441
+#: src/Core/L10n.php:375 src/Model/Event.php:444
 msgid "November"
 msgstr ""
 
-#: src/Core/L10n.php:375 src/Model/Event.php:442
+#: src/Core/L10n.php:375 src/Model/Event.php:445
 msgid "December"
 msgstr ""
 
-#: src/Core/L10n.php:391 src/Model/Event.php:404
+#: src/Core/L10n.php:391 src/Model/Event.php:407
 msgid "Mon"
 msgstr ""
 
-#: src/Core/L10n.php:391 src/Model/Event.php:405
+#: src/Core/L10n.php:391 src/Model/Event.php:408
 msgid "Tue"
 msgstr ""
 
-#: src/Core/L10n.php:391 src/Model/Event.php:406
+#: src/Core/L10n.php:391 src/Model/Event.php:409
 msgid "Wed"
 msgstr ""
 
-#: src/Core/L10n.php:391 src/Model/Event.php:407
+#: src/Core/L10n.php:391 src/Model/Event.php:410
 msgid "Thu"
 msgstr ""
 
-#: src/Core/L10n.php:391 src/Model/Event.php:408
+#: src/Core/L10n.php:391 src/Model/Event.php:411
 msgid "Fri"
 msgstr ""
 
-#: src/Core/L10n.php:391 src/Model/Event.php:409
+#: src/Core/L10n.php:391 src/Model/Event.php:412
 msgid "Sat"
 msgstr ""
 
-#: src/Core/L10n.php:391 src/Model/Event.php:403
+#: src/Core/L10n.php:391 src/Model/Event.php:406
 msgid "Sun"
 msgstr ""
 
-#: src/Core/L10n.php:395 src/Model/Event.php:419
+#: src/Core/L10n.php:395 src/Model/Event.php:422
 msgid "Jan"
 msgstr ""
 
-#: src/Core/L10n.php:395 src/Model/Event.php:420
+#: src/Core/L10n.php:395 src/Model/Event.php:423
 msgid "Feb"
 msgstr ""
 
-#: src/Core/L10n.php:395 src/Model/Event.php:421
+#: src/Core/L10n.php:395 src/Model/Event.php:424
 msgid "Mar"
 msgstr ""
 
-#: src/Core/L10n.php:395 src/Model/Event.php:422
+#: src/Core/L10n.php:395 src/Model/Event.php:425
 msgid "Apr"
 msgstr ""
 
-#: src/Core/L10n.php:395 src/Model/Event.php:424
+#: src/Core/L10n.php:395 src/Model/Event.php:427
 msgid "Jun"
 msgstr ""
 
-#: src/Core/L10n.php:395 src/Model/Event.php:425
+#: src/Core/L10n.php:395 src/Model/Event.php:428
 msgid "Jul"
 msgstr ""
 
-#: src/Core/L10n.php:395 src/Model/Event.php:426
+#: src/Core/L10n.php:395 src/Model/Event.php:429
 msgid "Aug"
 msgstr ""
 
@@ -3993,15 +4295,15 @@ msgstr ""
 msgid "Sep"
 msgstr ""
 
-#: src/Core/L10n.php:395 src/Model/Event.php:428
+#: src/Core/L10n.php:395 src/Model/Event.php:431
 msgid "Oct"
 msgstr ""
 
-#: src/Core/L10n.php:395 src/Model/Event.php:429
+#: src/Core/L10n.php:395 src/Model/Event.php:432
 msgid "Nov"
 msgstr ""
 
-#: src/Core/L10n.php:395 src/Model/Event.php:430
+#: src/Core/L10n.php:395 src/Model/Event.php:433
 msgid "Dec"
 msgstr ""
 
@@ -4053,6 +4355,54 @@ msgstr ""
 msgid "rebuffed"
 msgstr ""
 
+#: src/Core/Renderer.php:90 src/Core/Renderer.php:119 src/Core/Renderer.php:146
+#: src/Core/Renderer.php:180 src/Render/FriendicaSmartyEngine.php:56
+msgid ""
+"Friendica can't display this page at the moment, please contact the "
+"administrator."
+msgstr ""
+
+#: src/Core/Renderer.php:142
+msgid "template engine cannot be registered without a name."
+msgstr ""
+
+#: src/Core/Renderer.php:176
+msgid "template engine is not registered!"
+msgstr ""
+
+#: src/Core/Update.php:226
+#, php-format
+msgid "Update %s failed. See error logs."
+msgstr ""
+
+#: src/Core/Update.php:279
+#, php-format
+msgid ""
+"\n"
+"\t\t\t\tThe friendica developers released update %s recently,\n"
+"\t\t\t\tbut when I tried to install it, something went terribly wrong.\n"
+"\t\t\t\tThis needs to be fixed soon and I can't do it alone. Please contact "
+"a\n"
+"\t\t\t\tfriendica developer if you can not help me on your own. My database "
+"might be invalid."
+msgstr ""
+
+#: src/Core/Update.php:285
+#, php-format
+msgid "The error message is\\n[pre]%s[/pre]"
+msgstr ""
+
+#: src/Core/Update.php:289 src/Core/Update.php:331
+msgid "[Friendica Notify] Database update"
+msgstr ""
+
+#: src/Core/Update.php:325
+#, php-format
+msgid ""
+"\n"
+"\t\t\t\t\tThe friendica database was successfully updated from %s to %s."
+msgstr ""
+
 #: src/Core/UserImport.php:126
 msgid "Error decoding account file"
 msgstr ""
@@ -4085,397 +4435,49 @@ msgstr ""
 msgid "Done. You can now login with your username and password"
 msgstr ""
 
-#: src/LegacyModule.php:49
+#: src/Database/DBStructure.php:64
 #, php-format
-msgid "Legacy module file not found: %s"
+msgid "The database version had been set to %s."
 msgstr ""
 
-#: src/Worker/Delivery.php:557
-msgid "(no subject)"
+#: src/Database/DBStructure.php:82
+msgid "No unused tables found."
 msgstr ""
 
-#: src/Object/EMail/ItemCCEMail.php:39
+#: src/Database/DBStructure.php:87
+msgid ""
+"These tables are not used for friendica and will be deleted when you execute "
+"\"dbstructure drop -e\":"
+msgstr ""
+
+#: src/Database/DBStructure.php:125
+msgid "There are no tables on MyISAM or InnoDB with the Antelope file format."
+msgstr ""
+
+#: src/Database/DBStructure.php:149
 #, php-format
 msgid ""
-"This message was sent to you by %s, a member of the Friendica social network."
+"\n"
+"Error %d occurred during database update:\n"
+"%s\n"
 msgstr ""
 
-#: src/Object/EMail/ItemCCEMail.php:41
+#: src/Database/DBStructure.php:152
+msgid "Errors encountered performing database changes: "
+msgstr ""
+
+#: src/Database/DBStructure.php:380
+msgid "Another database update is currently running."
+msgstr ""
+
+#: src/Database/DBStructure.php:384
 #, php-format
-msgid "You may visit them online at %s"
+msgid "%s: Database update"
 msgstr ""
 
-#: src/Object/EMail/ItemCCEMail.php:42
-msgid ""
-"Please contact the sender by replying to this post if you do not wish to "
-"receive these messages."
-msgstr ""
-
-#: src/Object/EMail/ItemCCEMail.php:46
+#: src/Database/DBStructure.php:684
 #, php-format
-msgid "%s posted an update."
-msgstr ""
-
-#: src/Object/Post.php:147
-msgid "This entry was edited"
-msgstr ""
-
-#: src/Object/Post.php:175
-msgid "Private Message"
-msgstr ""
-
-#: src/Object/Post.php:220
-msgid "pinned item"
-msgstr ""
-
-#: src/Object/Post.php:225
-msgid "Delete locally"
-msgstr ""
-
-#: src/Object/Post.php:228
-msgid "Delete globally"
-msgstr ""
-
-#: src/Object/Post.php:228
-msgid "Remove locally"
-msgstr ""
-
-#: src/Object/Post.php:241
-msgid "save to folder"
-msgstr ""
-
-#: src/Object/Post.php:276
-msgid "I will attend"
-msgstr ""
-
-#: src/Object/Post.php:276
-msgid "I will not attend"
-msgstr ""
-
-#: src/Object/Post.php:276
-msgid "I might attend"
-msgstr ""
-
-#: src/Object/Post.php:306
-msgid "ignore thread"
-msgstr ""
-
-#: src/Object/Post.php:307
-msgid "unignore thread"
-msgstr ""
-
-#: src/Object/Post.php:308
-msgid "toggle ignore status"
-msgstr ""
-
-#: src/Object/Post.php:320
-msgid "pin"
-msgstr ""
-
-#: src/Object/Post.php:321
-msgid "unpin"
-msgstr ""
-
-#: src/Object/Post.php:322
-msgid "toggle pin status"
-msgstr ""
-
-#: src/Object/Post.php:325
-msgid "pinned"
-msgstr ""
-
-#: src/Object/Post.php:332
-msgid "add star"
-msgstr ""
-
-#: src/Object/Post.php:333
-msgid "remove star"
-msgstr ""
-
-#: src/Object/Post.php:334
-msgid "toggle star status"
-msgstr ""
-
-#: src/Object/Post.php:337
-msgid "starred"
-msgstr ""
-
-#: src/Object/Post.php:341
-msgid "add tag"
-msgstr ""
-
-#: src/Object/Post.php:351
-msgid "like"
-msgstr ""
-
-#: src/Object/Post.php:352
-msgid "dislike"
-msgstr ""
-
-#: src/Object/Post.php:354
-msgid "Quote and share this"
-msgstr ""
-
-#: src/Object/Post.php:354
-msgid "Quote Share"
-msgstr ""
-
-#: src/Object/Post.php:357
-msgid "Share this"
-msgstr ""
-
-#: src/Object/Post.php:402
-#, php-format
-msgid "%s (Received %s)"
-msgstr ""
-
-#: src/Object/Post.php:407
-msgid "Comment this item on your system"
-msgstr ""
-
-#: src/Object/Post.php:407
-msgid "remote comment"
-msgstr ""
-
-#: src/Object/Post.php:419
-msgid "Pushed"
-msgstr ""
-
-#: src/Object/Post.php:419
-msgid "Pulled"
-msgstr ""
-
-#: src/Object/Post.php:451
-msgid "to"
-msgstr ""
-
-#: src/Object/Post.php:452
-msgid "via"
-msgstr ""
-
-#: src/Object/Post.php:453
-msgid "Wall-to-Wall"
-msgstr ""
-
-#: src/Object/Post.php:454
-msgid "via Wall-To-Wall:"
-msgstr ""
-
-#: src/Object/Post.php:491
-#, php-format
-msgid "Reply to %s"
-msgstr ""
-
-#: src/Object/Post.php:494
-msgid "More"
-msgstr ""
-
-#: src/Object/Post.php:512
-msgid "Notifier task is pending"
-msgstr ""
-
-#: src/Object/Post.php:513
-msgid "Delivery to remote servers is pending"
-msgstr ""
-
-#: src/Object/Post.php:514
-msgid "Delivery to remote servers is underway"
-msgstr ""
-
-#: src/Object/Post.php:515
-msgid "Delivery to remote servers is mostly done"
-msgstr ""
-
-#: src/Object/Post.php:516
-msgid "Delivery to remote servers is done"
-msgstr ""
-
-#: src/Object/Post.php:536
-#, php-format
-msgid "%d comment"
-msgid_plural "%d comments"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/Object/Post.php:537
-msgid "Show more"
-msgstr ""
-
-#: src/Object/Post.php:538
-msgid "Show fewer"
-msgstr ""
-
-#: src/Object/Post.php:549 src/Model/Item.php:3527
-msgid "comment"
-msgid_plural "comments"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/Console/ArchiveContact.php:105
-#, php-format
-msgid "Could not find any unarchived contact entry for this URL (%s)"
-msgstr ""
-
-#: src/Console/ArchiveContact.php:108
-msgid "The contact entries have been archived"
-msgstr ""
-
-#: src/Console/GlobalCommunityBlock.php:96
-#: src/Module/Admin/Blocklist/Contact.php:49
-#, php-format
-msgid "Could not find any contact entry for this URL (%s)"
-msgstr ""
-
-#: src/Console/GlobalCommunityBlock.php:101
-#: src/Module/Admin/Blocklist/Contact.php:47
-msgid "The contact has been blocked from the node"
-msgstr ""
-
-#: src/Console/User.php:158
-msgid "Enter new password: "
-msgstr ""
-
-#: src/Console/User.php:193
-msgid "Enter user name: "
-msgstr ""
-
-#: src/Console/User.php:201 src/Console/User.php:241 src/Console/User.php:274
-#: src/Console/User.php:300
-msgid "Enter user nickname: "
-msgstr ""
-
-#: src/Console/User.php:209
-msgid "Enter user email address: "
-msgstr ""
-
-#: src/Console/User.php:217
-msgid "Enter a language (optional): "
-msgstr ""
-
-#: src/Console/User.php:255
-msgid "User is not pending."
-msgstr ""
-
-#: src/Console/User.php:313
-msgid "User has already been marked for deletion."
-msgstr ""
-
-#: src/Console/User.php:318
-#, php-format
-msgid "Type \"yes\" to delete %s"
-msgstr ""
-
-#: src/Console/User.php:320
-msgid "Deletion aborted."
-msgstr ""
-
-#: src/Console/PostUpdate.php:87
-#, php-format
-msgid "Post update version number has been set to %s."
-msgstr ""
-
-#: src/Console/PostUpdate.php:95
-msgid "Check for pending update actions."
-msgstr ""
-
-#: src/Console/PostUpdate.php:97
-msgid "Done."
-msgstr ""
-
-#: src/Console/PostUpdate.php:99
-msgid "Execute pending post updates."
-msgstr ""
-
-#: src/Console/PostUpdate.php:105
-msgid "All pending post updates are done."
-msgstr ""
-
-#: src/Render/FriendicaSmartyEngine.php:52
-msgid "The folder view/smarty3/ must be writable by webserver."
-msgstr ""
-
-#: src/Repository/ProfileField.php:275
-msgid "Hometown:"
-msgstr ""
-
-#: src/Repository/ProfileField.php:276
-msgid "Marital Status:"
-msgstr ""
-
-#: src/Repository/ProfileField.php:277
-msgid "With:"
-msgstr ""
-
-#: src/Repository/ProfileField.php:278
-msgid "Since:"
-msgstr ""
-
-#: src/Repository/ProfileField.php:279
-msgid "Sexual Preference:"
-msgstr ""
-
-#: src/Repository/ProfileField.php:280
-msgid "Political Views:"
-msgstr ""
-
-#: src/Repository/ProfileField.php:281
-msgid "Religious Views:"
-msgstr ""
-
-#: src/Repository/ProfileField.php:282
-msgid "Likes:"
-msgstr ""
-
-#: src/Repository/ProfileField.php:283
-msgid "Dislikes:"
-msgstr ""
-
-#: src/Repository/ProfileField.php:284
-msgid "Title/Description:"
-msgstr ""
-
-#: src/Repository/ProfileField.php:285 src/Module/Admin/Summary.php:231
-msgid "Summary"
-msgstr ""
-
-#: src/Repository/ProfileField.php:286
-msgid "Musical interests"
-msgstr ""
-
-#: src/Repository/ProfileField.php:287
-msgid "Books, literature"
-msgstr ""
-
-#: src/Repository/ProfileField.php:288
-msgid "Television"
-msgstr ""
-
-#: src/Repository/ProfileField.php:289
-msgid "Film/dance/culture/entertainment"
-msgstr ""
-
-#: src/Repository/ProfileField.php:290
-msgid "Hobbies/Interests"
-msgstr ""
-
-#: src/Repository/ProfileField.php:291
-msgid "Love/romance"
-msgstr ""
-
-#: src/Repository/ProfileField.php:292
-msgid "Work/employment"
-msgstr ""
-
-#: src/Repository/ProfileField.php:293
-msgid "School/education"
-msgstr ""
-
-#: src/Repository/ProfileField.php:294
-msgid "Contact information and Social Networks"
-msgstr ""
-
-#: src/App.php:309
-msgid "No system theme config value set."
+msgid "%s: updating %s table."
 msgstr ""
 
 #: src/Factory/Api/Mastodon/Error.php:32
@@ -4535,288 +4537,3350 @@ msgstr ""
 msgid "%s is now friends with %s"
 msgstr ""
 
-#: src/Module/Notifications/Notifications.php:50
-msgid "Network Notifications"
-msgstr ""
-
-#: src/Module/Notifications/Notifications.php:58
-msgid "System Notifications"
-msgstr ""
-
-#: src/Module/Notifications/Notifications.php:66
-msgid "Personal Notifications"
-msgstr ""
-
-#: src/Module/Notifications/Notifications.php:74
-msgid "Home Notifications"
-msgstr ""
-
-#: src/Module/Notifications/Notifications.php:133
-#: src/Module/Notifications/Introductions.php:202
+#: src/LegacyModule.php:49
 #, php-format
-msgid "No more %s notifications."
+msgid "Legacy module file not found: %s"
 msgstr ""
 
-#: src/Module/Notifications/Notifications.php:138
-msgid "Show unread"
+#: src/Model/Contact.php:980 src/Model/Contact.php:993
+msgid "UnFollow"
 msgstr ""
 
-#: src/Module/Notifications/Notifications.php:138
-msgid "Show all"
+#: src/Model/Contact.php:989
+msgid "Drop Contact"
 msgstr ""
 
-#: src/Module/Notifications/Notification.php:103
-msgid "You must be logged in to show this page."
-msgstr ""
-
-#: src/Module/Notifications/Introductions.php:54
-#: src/Module/BaseNotifications.php:139 src/Content/Nav.php:268
-msgid "Notifications"
-msgstr ""
-
-#: src/Module/Notifications/Introductions.php:78
-msgid "Show Ignored Requests"
-msgstr ""
-
-#: src/Module/Notifications/Introductions.php:78
-msgid "Hide Ignored Requests"
-msgstr ""
-
-#: src/Module/Notifications/Introductions.php:94
-#: src/Module/Notifications/Introductions.php:163
-msgid "Notification type:"
-msgstr ""
-
-#: src/Module/Notifications/Introductions.php:97
-msgid "Suggested by:"
-msgstr ""
-
+#: src/Model/Contact.php:999 src/Module/Admin/Users/Pending.php:107
 #: src/Module/Notifications/Introductions.php:111
 #: src/Module/Notifications/Introductions.php:189
-#: src/Module/Admin/Users/Pending.php:107 src/Model/Contact.php:999
 msgid "Approve"
 msgstr ""
 
-#: src/Module/Notifications/Introductions.php:122
-msgid "Claims to be known to you: "
+#: src/Model/Contact.php:1405
+msgid "Organisation"
 msgstr ""
 
-#: src/Module/Notifications/Introductions.php:131
-msgid "Shall your connection be bidirectional or not?"
+#: src/Model/Contact.php:1413
+msgid "Forum"
 msgstr ""
 
-#: src/Module/Notifications/Introductions.php:132
-#, php-format
+#: src/Model/Contact.php:2153
+msgid "Connect URL missing."
+msgstr ""
+
+#: src/Model/Contact.php:2162
 msgid ""
-"Accepting %s as a friend allows %s to subscribe to your posts, and you will "
-"also receive updates from them in your news feed."
+"The contact could not be added. Please check the relevant network "
+"credentials in your Settings -> Social Networks page."
 msgstr ""
 
-#: src/Module/Notifications/Introductions.php:133
-#, php-format
+#: src/Model/Contact.php:2203
 msgid ""
-"Accepting %s as a subscriber allows them to subscribe to your posts, but you "
-"will not receive updates from them in your news feed."
+"This site is not configured to allow communications with other networks."
 msgstr ""
 
-#: src/Module/Notifications/Introductions.php:135
-msgid "Friend"
+#: src/Model/Contact.php:2204 src/Model/Contact.php:2217
+msgid "No compatible communication protocols or feeds were discovered."
 msgstr ""
 
-#: src/Module/Notifications/Introductions.php:136
-msgid "Subscriber"
+#: src/Model/Contact.php:2215
+msgid "The profile address specified does not provide adequate information."
 msgstr ""
 
-#: src/Module/Notifications/Introductions.php:174 src/Module/Contact.php:650
-#: src/Model/Profile.php:362
+#: src/Model/Contact.php:2220
+msgid "An author or name was not found."
+msgstr ""
+
+#: src/Model/Contact.php:2223
+msgid "No browser URL could be matched to this address."
+msgstr ""
+
+#: src/Model/Contact.php:2226
+msgid ""
+"Unable to match @-style Identity Address with a known protocol or email "
+"contact."
+msgstr ""
+
+#: src/Model/Contact.php:2227
+msgid "Use mailto: in front of address to force email check."
+msgstr ""
+
+#: src/Model/Contact.php:2233
+msgid ""
+"The profile address specified belongs to a network which has been disabled "
+"on this site."
+msgstr ""
+
+#: src/Model/Contact.php:2238
+msgid ""
+"Limited profile. This person will be unable to receive direct/personal "
+"notifications from you."
+msgstr ""
+
+#: src/Model/Contact.php:2297
+msgid "Unable to retrieve contact information."
+msgstr ""
+
+#: src/Model/Event.php:50 src/Model/Event.php:864
+#: src/Module/Debug/Localtime.php:36
+msgid "l F d, Y \\@ g:i A"
+msgstr ""
+
+#: src/Model/Event.php:77 src/Model/Event.php:94 src/Model/Event.php:454
+#: src/Model/Event.php:932
+msgid "Starts:"
+msgstr ""
+
+#: src/Model/Event.php:80 src/Model/Event.php:100 src/Model/Event.php:455
+#: src/Model/Event.php:936
+msgid "Finishes:"
+msgstr ""
+
+#: src/Model/Event.php:404
+msgid "all-day"
+msgstr ""
+
+#: src/Model/Event.php:430
+msgid "Sept"
+msgstr ""
+
+#: src/Model/Event.php:452
+msgid "No events to display"
+msgstr ""
+
+#: src/Model/Event.php:580
+msgid "l, F j"
+msgstr ""
+
+#: src/Model/Event.php:611
+msgid "Edit event"
+msgstr ""
+
+#: src/Model/Event.php:612
+msgid "Duplicate event"
+msgstr ""
+
+#: src/Model/Event.php:613
+msgid "Delete event"
+msgstr ""
+
+#: src/Model/Event.php:865
+msgid "D g:i A"
+msgstr ""
+
+#: src/Model/Event.php:866
+msgid "g:i A"
+msgstr ""
+
+#: src/Model/Event.php:951 src/Model/Event.php:953
+msgid "Show map"
+msgstr ""
+
+#: src/Model/Event.php:952
+msgid "Hide map"
+msgstr ""
+
+#: src/Model/Event.php:1044
+#, php-format
+msgid "%s's birthday"
+msgstr ""
+
+#: src/Model/Event.php:1045
+#, php-format
+msgid "Happy Birthday %s"
+msgstr ""
+
+#: src/Model/Group.php:92
+msgid ""
+"A deleted group with this name was revived. Existing item permissions "
+"<strong>may</strong> apply to this group and any future members. If this is "
+"not what you intended, please create another group with a different name."
+msgstr ""
+
+#: src/Model/Group.php:451
+msgid "Default privacy group for new contacts"
+msgstr ""
+
+#: src/Model/Group.php:483
+msgid "Everybody"
+msgstr ""
+
+#: src/Model/Group.php:502
+msgid "edit"
+msgstr ""
+
+#: src/Model/Group.php:534
+msgid "add"
+msgstr ""
+
+#: src/Model/Group.php:539
+msgid "Edit group"
+msgstr ""
+
+#: src/Model/Group.php:540 src/Module/Group.php:193
+msgid "Contacts not in any group"
+msgstr ""
+
+#: src/Model/Group.php:542
+msgid "Create a new group"
+msgstr ""
+
+#: src/Model/Group.php:543 src/Module/Group.php:178 src/Module/Group.php:201
+#: src/Module/Group.php:276
+msgid "Group Name: "
+msgstr ""
+
+#: src/Model/Group.php:544
+msgid "Edit groups"
+msgstr ""
+
+#: src/Model/Item.php:2530
+#, php-format
+msgid "Detected languages in this post:\\n%s"
+msgstr ""
+
+#: src/Model/Item.php:3525
+msgid "activity"
+msgstr ""
+
+#: src/Model/Item.php:3527 src/Object/Post.php:550
+msgid "comment"
+msgid_plural "comments"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/Model/Item.php:3530
+msgid "post"
+msgstr ""
+
+#: src/Model/Item.php:3654
+#, php-format
+msgid "Content warning: %s"
+msgstr ""
+
+#: src/Model/Item.php:3727
+msgid "bytes"
+msgstr ""
+
+#: src/Model/Item.php:3772
+msgid "View on separate page"
+msgstr ""
+
+#: src/Model/Item.php:3773
+msgid "view on separate page"
+msgstr ""
+
+#: src/Model/Mail.php:121 src/Model/Mail.php:259
+msgid "[no subject]"
+msgstr ""
+
+#: src/Model/Profile.php:346 src/Module/Profile/Profile.php:251
+#: src/Module/Profile/Profile.php:253
+msgid "Edit profile"
+msgstr ""
+
+#: src/Model/Profile.php:348
+msgid "Change profile photo"
+msgstr ""
+
+#: src/Model/Profile.php:361 src/Module/Directory.php:161
+#: src/Module/Profile/Profile.php:180
+msgid "Homepage:"
+msgstr ""
+
+#: src/Model/Profile.php:362 src/Module/Contact.php:650
+#: src/Module/Notifications/Introductions.php:174
 msgid "About:"
 msgstr ""
 
-#: src/Module/Notifications/Introductions.php:177 src/Module/Contact.php:634
-msgid "Hide this contact from others"
+#: src/Model/Profile.php:363 src/Module/Contact.php:648
+#: src/Module/Profile/Profile.php:176
+msgid "XMPP:"
 msgstr ""
 
-#: src/Module/Notifications/Introductions.php:186 src/Module/Contact.php:338
-#: src/Model/Profile.php:451
+#: src/Model/Profile.php:441 src/Module/Contact.php:342
+msgid "Unfollow"
+msgstr ""
+
+#: src/Model/Profile.php:443
+msgid "Atom feed"
+msgstr ""
+
+#: src/Model/Profile.php:451 src/Module/Contact.php:338
+#: src/Module/Notifications/Introductions.php:186
 msgid "Network:"
 msgstr ""
 
-#: src/Module/Notifications/Introductions.php:201
-msgid "No introductions."
+#: src/Model/Profile.php:481 src/Model/Profile.php:578
+msgid "g A l F d"
 msgstr ""
 
-#: src/Module/Manifest.php:42
-msgid "A Decentralized Social Network"
+#: src/Model/Profile.php:482
+msgid "F d"
 msgstr ""
 
-#: src/Module/Security/Logout.php:53
-msgid "Logged out."
+#: src/Model/Profile.php:544 src/Model/Profile.php:629
+msgid "[today]"
 msgstr ""
 
-#: src/Module/Security/TwoFactor/Verify.php:61
-#: src/Module/Security/TwoFactor/Recovery.php:64
-#: src/Module/Settings/TwoFactor/Verify.php:82
-msgid "Invalid code, please retry."
+#: src/Model/Profile.php:554
+msgid "Birthday Reminders"
 msgstr ""
 
-#: src/Module/Security/TwoFactor/Verify.php:80 src/Module/BaseSettings.php:50
+#: src/Model/Profile.php:555
+msgid "Birthdays this week:"
+msgstr ""
+
+#: src/Model/Profile.php:616
+msgid "[No description]"
+msgstr ""
+
+#: src/Model/Profile.php:642
+msgid "Event Reminders"
+msgstr ""
+
+#: src/Model/Profile.php:643
+msgid "Upcoming events the next 7 days:"
+msgstr ""
+
+#: src/Model/Profile.php:818
+#, php-format
+msgid "OpenWebAuth: %1$s welcomes %2$s"
+msgstr ""
+
+#: src/Model/Storage/Database.php:74
+#, php-format
+msgid "Database storage failed to update %s"
+msgstr ""
+
+#: src/Model/Storage/Database.php:82
+msgid "Database storage failed to insert data"
+msgstr ""
+
+#: src/Model/Storage/Filesystem.php:100
+#, php-format
+msgid ""
+"Filesystem storage failed to create \"%s\". Check you write permissions."
+msgstr ""
+
+#: src/Model/Storage/Filesystem.php:148
+#, php-format
+msgid ""
+"Filesystem storage failed to save data to \"%s\". Check your write "
+"permissions"
+msgstr ""
+
+#: src/Model/Storage/Filesystem.php:176
+msgid "Storage base path"
+msgstr ""
+
+#: src/Model/Storage/Filesystem.php:178
+msgid ""
+"Folder where uploaded files are saved. For maximum security, This should be "
+"a path outside web server folder tree"
+msgstr ""
+
+#: src/Model/Storage/Filesystem.php:191
+msgid "Enter a valid existing folder"
+msgstr ""
+
+#: src/Model/User.php:186 src/Model/User.php:931
+msgid "SERIOUS ERROR: Generation of security keys failed."
+msgstr ""
+
+#: src/Model/User.php:549
+msgid "Login failed"
+msgstr ""
+
+#: src/Model/User.php:581
+msgid "Not enough information to authenticate"
+msgstr ""
+
+#: src/Model/User.php:676
+msgid "Password can't be empty"
+msgstr ""
+
+#: src/Model/User.php:695
+msgid "Empty passwords are not allowed."
+msgstr ""
+
+#: src/Model/User.php:699
+msgid ""
+"The new password has been exposed in a public data dump, please choose "
+"another."
+msgstr ""
+
+#: src/Model/User.php:705
+msgid ""
+"The password can't contain accentuated letters, white spaces or colons (:)"
+msgstr ""
+
+#: src/Model/User.php:811
+msgid "Passwords do not match. Password unchanged."
+msgstr ""
+
+#: src/Model/User.php:818
+msgid "An invitation is required."
+msgstr ""
+
+#: src/Model/User.php:822
+msgid "Invitation could not be verified."
+msgstr ""
+
+#: src/Model/User.php:830
+msgid "Invalid OpenID url"
+msgstr ""
+
+#: src/Model/User.php:843 src/Security/Authentication.php:224
+msgid ""
+"We encountered a problem while logging in with the OpenID you provided. "
+"Please check the correct spelling of the ID."
+msgstr ""
+
+#: src/Model/User.php:843 src/Security/Authentication.php:224
+msgid "The error message was:"
+msgstr ""
+
+#: src/Model/User.php:849
+msgid "Please enter the required information."
+msgstr ""
+
+#: src/Model/User.php:863
+#, php-format
+msgid ""
+"system.username_min_length (%s) and system.username_max_length (%s) are "
+"excluding each other, swapping values."
+msgstr ""
+
+#: src/Model/User.php:870
+#, php-format
+msgid "Username should be at least %s character."
+msgid_plural "Username should be at least %s characters."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/Model/User.php:874
+#, php-format
+msgid "Username should be at most %s character."
+msgid_plural "Username should be at most %s characters."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/Model/User.php:882
+msgid "That doesn't appear to be your full (First Last) name."
+msgstr ""
+
+#: src/Model/User.php:887
+msgid "Your email domain is not among those allowed on this site."
+msgstr ""
+
+#: src/Model/User.php:891
+msgid "Not a valid email address."
+msgstr ""
+
+#: src/Model/User.php:894
+msgid "The nickname was blocked from registration by the nodes admin."
+msgstr ""
+
+#: src/Model/User.php:898 src/Model/User.php:906
+msgid "Cannot use that email."
+msgstr ""
+
+#: src/Model/User.php:913
+msgid "Your nickname can only contain a-z, 0-9 and _."
+msgstr ""
+
+#: src/Model/User.php:921 src/Model/User.php:978
+msgid "Nickname is already registered. Please choose another."
+msgstr ""
+
+#: src/Model/User.php:965 src/Model/User.php:969
+msgid "An error occurred during registration. Please try again."
+msgstr ""
+
+#: src/Model/User.php:992
+msgid "An error occurred creating your default profile. Please try again."
+msgstr ""
+
+#: src/Model/User.php:999
+msgid "An error occurred creating your self contact. Please try again."
+msgstr ""
+
+#: src/Model/User.php:1004
+msgid "Friends"
+msgstr ""
+
+#: src/Model/User.php:1008
+msgid ""
+"An error occurred creating your default contact group. Please try again."
+msgstr ""
+
+#: src/Model/User.php:1199
+#, php-format
+msgid ""
+"\n"
+"\t\tDear %1$s,\n"
+"\t\t\tthe administrator of %2$s has set up an account for you."
+msgstr ""
+
+#: src/Model/User.php:1202
+#, php-format
+msgid ""
+"\n"
+"\t\tThe login details are as follows:\n"
+"\n"
+"\t\tSite Location:\t%1$s\n"
+"\t\tLogin Name:\t\t%2$s\n"
+"\t\tPassword:\t\t%3$s\n"
+"\n"
+"\t\tYou may change your password from your account \"Settings\" page after "
+"logging\n"
+"\t\tin.\n"
+"\n"
+"\t\tPlease take a few moments to review the other account settings on that "
+"page.\n"
+"\n"
+"\t\tYou may also wish to add some basic information to your default profile\n"
+"\t\t(on the \"Profiles\" page) so that other people can easily find you.\n"
+"\n"
+"\t\tWe recommend setting your full name, adding a profile photo,\n"
+"\t\tadding some profile \"keywords\" (very useful in making new friends) - "
+"and\n"
+"\t\tperhaps what country you live in; if you do not wish to be more "
+"specific\n"
+"\t\tthan that.\n"
+"\n"
+"\t\tWe fully respect your right to privacy, and none of these items are "
+"necessary.\n"
+"\t\tIf you are new and do not know anybody here, they may help\n"
+"\t\tyou to make some new and interesting friends.\n"
+"\n"
+"\t\tIf you ever want to delete your account, you can do so at %1$s/removeme\n"
+"\n"
+"\t\tThank you and welcome to %4$s."
+msgstr ""
+
+#: src/Model/User.php:1235 src/Model/User.php:1342
+#, php-format
+msgid "Registration details for %s"
+msgstr ""
+
+#: src/Model/User.php:1255
+#, php-format
+msgid ""
+"\n"
+"\t\t\tDear %1$s,\n"
+"\t\t\t\tThank you for registering at %2$s. Your account is pending for "
+"approval by the administrator.\n"
+"\n"
+"\t\t\tYour login details are as follows:\n"
+"\n"
+"\t\t\tSite Location:\t%3$s\n"
+"\t\t\tLogin Name:\t\t%4$s\n"
+"\t\t\tPassword:\t\t%5$s\n"
+"\t\t"
+msgstr ""
+
+#: src/Model/User.php:1274
+#, php-format
+msgid "Registration at %s"
+msgstr ""
+
+#: src/Model/User.php:1298
+#, php-format
+msgid ""
+"\n"
+"\t\t\t\tDear %1$s,\n"
+"\t\t\t\tThank you for registering at %2$s. Your account has been created.\n"
+"\t\t\t"
+msgstr ""
+
+#: src/Model/User.php:1306
+#, php-format
+msgid ""
+"\n"
+"\t\t\tThe login details are as follows:\n"
+"\n"
+"\t\t\tSite Location:\t%3$s\n"
+"\t\t\tLogin Name:\t\t%1$s\n"
+"\t\t\tPassword:\t\t%5$s\n"
+"\n"
+"\t\t\tYou may change your password from your account \"Settings\" page after "
+"logging\n"
+"\t\t\tin.\n"
+"\n"
+"\t\t\tPlease take a few moments to review the other account settings on that "
+"page.\n"
+"\n"
+"\t\t\tYou may also wish to add some basic information to your default "
+"profile\n"
+"\t\t\t(on the \"Profiles\" page) so that other people can easily find you.\n"
+"\n"
+"\t\t\tWe recommend setting your full name, adding a profile photo,\n"
+"\t\t\tadding some profile \"keywords\" (very useful in making new friends) - "
+"and\n"
+"\t\t\tperhaps what country you live in; if you do not wish to be more "
+"specific\n"
+"\t\t\tthan that.\n"
+"\n"
+"\t\t\tWe fully respect your right to privacy, and none of these items are "
+"necessary.\n"
+"\t\t\tIf you are new and do not know anybody here, they may help\n"
+"\t\t\tyou to make some new and interesting friends.\n"
+"\n"
+"\t\t\tIf you ever want to delete your account, you can do so at %3$s/"
+"removeme\n"
+"\n"
+"\t\t\tThank you and welcome to %2$s."
+msgstr ""
+
+#: src/Module/Admin/Addons/Details.php:65
+msgid "Addon not found."
+msgstr ""
+
+#: src/Module/Admin/Addons/Details.php:76 src/Module/Admin/Addons/Index.php:49
+#, php-format
+msgid "Addon %s disabled."
+msgstr ""
+
+#: src/Module/Admin/Addons/Details.php:79 src/Module/Admin/Addons/Index.php:51
+#, php-format
+msgid "Addon %s enabled."
+msgstr ""
+
+#: src/Module/Admin/Addons/Details.php:88
+#: src/Module/Admin/Themes/Details.php:46
+msgid "Disable"
+msgstr ""
+
+#: src/Module/Admin/Addons/Details.php:91
+#: src/Module/Admin/Themes/Details.php:49
+msgid "Enable"
+msgstr ""
+
+#: src/Module/Admin/Addons/Details.php:111 src/Module/Admin/Addons/Index.php:67
+#: src/Module/Admin/Blocklist/Contact.php:78
+#: src/Module/Admin/Blocklist/Server.php:88 src/Module/Admin/Federation.php:140
+#: src/Module/Admin/Item/Delete.php:65 src/Module/Admin/Logs/Settings.php:80
+#: src/Module/Admin/Logs/View.php:64 src/Module/Admin/Queue.php:72
+#: src/Module/Admin/Site.php:579 src/Module/Admin/Summary.php:230
+#: src/Module/Admin/Themes/Details.php:90 src/Module/Admin/Themes/Index.php:111
+#: src/Module/Admin/Tos.php:58 src/Module/Admin/Users/Active.php:136
+#: src/Module/Admin/Users/Blocked.php:137 src/Module/Admin/Users/Create.php:61
+#: src/Module/Admin/Users/Deleted.php:85 src/Module/Admin/Users/Index.php:149
+#: src/Module/Admin/Users/Pending.php:101
+msgid "Administration"
+msgstr ""
+
+#: src/Module/Admin/Addons/Details.php:112 src/Module/Admin/Addons/Index.php:68
+#: src/Module/BaseAdmin.php:92 src/Module/BaseSettings.php:87
+msgid "Addons"
+msgstr ""
+
+#: src/Module/Admin/Addons/Details.php:113
+#: src/Module/Admin/Themes/Details.php:92
+msgid "Toggle"
+msgstr ""
+
+#: src/Module/Admin/Addons/Details.php:121
+#: src/Module/Admin/Themes/Details.php:101
+msgid "Author: "
+msgstr ""
+
+#: src/Module/Admin/Addons/Details.php:122
+#: src/Module/Admin/Themes/Details.php:102
+msgid "Maintainer: "
+msgstr ""
+
+#: src/Module/Admin/Addons/Index.php:42
+msgid "Addons reloaded"
+msgstr ""
+
+#: src/Module/Admin/Addons/Index.php:53
+#, php-format
+msgid "Addon %s failed to install."
+msgstr ""
+
+#: src/Module/Admin/Addons/Index.php:70
+msgid "Reload active addons"
+msgstr ""
+
+#: src/Module/Admin/Addons/Index.php:75
+#, php-format
+msgid ""
+"There are currently no addons available on your node. You can find the "
+"official addon repository at %1$s and might find other interesting addons in "
+"the open addon registry at %2$s"
+msgstr ""
+
+#: src/Module/Admin/BaseUsers.php:53
+msgid "List of all users"
+msgstr ""
+
+#: src/Module/Admin/BaseUsers.php:58
+msgid "Active"
+msgstr ""
+
+#: src/Module/Admin/BaseUsers.php:61
+msgid "List of active accounts"
+msgstr ""
+
+#: src/Module/Admin/BaseUsers.php:66 src/Module/Contact.php:799
+#: src/Module/Contact.php:859
+msgid "Pending"
+msgstr ""
+
+#: src/Module/Admin/BaseUsers.php:69
+msgid "List of pending registrations"
+msgstr ""
+
+#: src/Module/Admin/BaseUsers.php:74 src/Module/Contact.php:807
+#: src/Module/Contact.php:860
+msgid "Blocked"
+msgstr ""
+
+#: src/Module/Admin/BaseUsers.php:77
+msgid "List of blocked users"
+msgstr ""
+
+#: src/Module/Admin/BaseUsers.php:82
+msgid "Deleted"
+msgstr ""
+
+#: src/Module/Admin/BaseUsers.php:85
+msgid "List of pending user deletions"
+msgstr ""
+
+#: src/Module/Admin/BaseUsers.php:103
+msgid "Private Forum"
+msgstr ""
+
+#: src/Module/Admin/BaseUsers.php:110
+msgid "Relay"
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Contact.php:57
+#, php-format
+msgid "%s contact unblocked"
+msgid_plural "%s contacts unblocked"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/Module/Admin/Blocklist/Contact.php:79
+msgid "Remote Contact Blocklist"
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Contact.php:80
+msgid ""
+"This page allows you to prevent any message from a remote contact to reach "
+"your node."
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Contact.php:81
+msgid "Block Remote Contact"
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Contact.php:82
+#: src/Module/Admin/Users/Active.php:138 src/Module/Admin/Users/Blocked.php:139
+#: src/Module/Admin/Users/Index.php:151 src/Module/Admin/Users/Pending.php:103
+msgid "select all"
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Contact.php:83
+msgid "select none"
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Contact.php:85
+#: src/Module/Admin/Users/Blocked.php:142 src/Module/Admin/Users/Index.php:156
+#: src/Module/Contact.php:625 src/Module/Contact.php:883
+#: src/Module/Contact.php:1165
+msgid "Unblock"
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Contact.php:86
+msgid "No remote contact is blocked from this node."
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Contact.php:88
+msgid "Blocked Remote Contacts"
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Contact.php:89
+msgid "Block New Remote Contact"
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Contact.php:90
+msgid "Photo"
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Contact.php:90
+msgid "Reason"
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Contact.php:98
+#, php-format
+msgid "%s total blocked contact"
+msgid_plural "%s total blocked contacts"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/Module/Admin/Blocklist/Contact.php:100
+msgid "URL of the remote contact to block."
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Contact.php:101
+msgid "Block Reason"
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Server.php:49
+msgid "Server domain pattern added to blocklist."
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Server.php:79
+#: src/Module/Admin/Blocklist/Server.php:104
+msgid "Blocked server domain pattern"
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Server.php:80
+#: src/Module/Admin/Blocklist/Server.php:105 src/Module/Friendica.php:81
+msgid "Reason for the block"
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Server.php:81
+msgid "Delete server domain pattern"
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Server.php:81
+msgid "Check to delete this entry from the blocklist"
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Server.php:89
+msgid "Server Domain Pattern Blocklist"
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Server.php:90
+msgid ""
+"This page can be used to define a blocklist of server domain patterns from "
+"the federated network that are not allowed to interact with your node. For "
+"each domain pattern you should also provide the reason why you block it."
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Server.php:91
+msgid ""
+"The list of blocked server domain patterns will be made publically available "
+"on the <a href=\"/friendica\">/friendica</a> page so that your users and "
+"people investigating communication problems can find the reason easily."
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Server.php:92
+msgid ""
+"<p>The server domain pattern syntax is case-insensitive shell wildcard, "
+"comprising the following special characters:</p>\n"
+"<ul>\n"
+"\t<li><code>*</code>: Any number of characters</li>\n"
+"\t<li><code>?</code>: Any single character</li>\n"
+"\t<li><code>[&lt;char1&gt;&lt;char2&gt;...]</code>: char1 or char2</li>\n"
+"</ul>"
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Server.php:98
+msgid "Add new entry to block list"
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Server.php:99
+msgid "Server Domain Pattern"
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Server.php:99
+msgid ""
+"The domain pattern of the new server to add to the block list. Do not "
+"include the protocol."
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Server.php:100
+msgid "Block reason"
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Server.php:100
+msgid "The reason why you blocked this server domain pattern."
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Server.php:101
+msgid "Add Entry"
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Server.php:102
+msgid "Save changes to the blocklist"
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Server.php:103
+msgid "Current Entries in the Blocklist"
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Server.php:106
+msgid "Delete entry from blocklist"
+msgstr ""
+
+#: src/Module/Admin/Blocklist/Server.php:109
+msgid "Delete entry from blocklist?"
+msgstr ""
+
+#: src/Module/Admin/DBSync.php:51
+msgid "Update has been marked successful"
+msgstr ""
+
+#: src/Module/Admin/DBSync.php:59
+#, php-format
+msgid "Database structure update %s was successfully applied."
+msgstr ""
+
+#: src/Module/Admin/DBSync.php:61
+#, php-format
+msgid "Executing of database structure update %s failed with error: %s"
+msgstr ""
+
+#: src/Module/Admin/DBSync.php:76
+#, php-format
+msgid "Executing %s failed with error: %s"
+msgstr ""
+
+#: src/Module/Admin/DBSync.php:78
+#, php-format
+msgid "Update %s was successfully applied."
+msgstr ""
+
+#: src/Module/Admin/DBSync.php:81
+#, php-format
+msgid "Update %s did not return a status. Unknown if it succeeded."
+msgstr ""
+
+#: src/Module/Admin/DBSync.php:84
+#, php-format
+msgid "There was no additional update function %s that needed to be called."
+msgstr ""
+
+#: src/Module/Admin/DBSync.php:106
+msgid "No failed updates."
+msgstr ""
+
+#: src/Module/Admin/DBSync.php:107
+msgid "Check database structure"
+msgstr ""
+
+#: src/Module/Admin/DBSync.php:112
+msgid "Failed Updates"
+msgstr ""
+
+#: src/Module/Admin/DBSync.php:113
+msgid ""
+"This does not include updates prior to 1139, which did not return a status."
+msgstr ""
+
+#: src/Module/Admin/DBSync.php:114
+msgid "Mark success (if update was manually applied)"
+msgstr ""
+
+#: src/Module/Admin/DBSync.php:115
+msgid "Attempt to execute this update step automatically"
+msgstr ""
+
+#: src/Module/Admin/Features.php:76
+#, php-format
+msgid "Lock feature %s"
+msgstr ""
+
+#: src/Module/Admin/Features.php:85
+msgid "Manage Additional Features"
+msgstr ""
+
+#: src/Module/Admin/Federation.php:53
+msgid "Other"
+msgstr ""
+
+#: src/Module/Admin/Federation.php:107 src/Module/Admin/Federation.php:267
+msgid "unknown"
+msgstr ""
+
+#: src/Module/Admin/Federation.php:135
+msgid ""
+"This page offers you some numbers to the known part of the federated social "
+"network your Friendica node is part of. These numbers are not complete but "
+"only reflect the part of the network your node is aware of."
+msgstr ""
+
+#: src/Module/Admin/Federation.php:141 src/Module/BaseAdmin.php:87
+msgid "Federation Statistics"
+msgstr ""
+
+#: src/Module/Admin/Federation.php:145
+#, php-format
+msgid ""
+"Currently this node is aware of %d nodes with %d registered users from the "
+"following platforms:"
+msgstr ""
+
+#: src/Module/Admin/Item/Delete.php:54
+msgid "Item marked for deletion."
+msgstr ""
+
+#: src/Module/Admin/Item/Delete.php:66 src/Module/BaseAdmin.php:105
+msgid "Delete Item"
+msgstr ""
+
+#: src/Module/Admin/Item/Delete.php:67
+msgid "Delete this Item"
+msgstr ""
+
+#: src/Module/Admin/Item/Delete.php:68
+msgid ""
+"On this page you can delete an item from your node. If the item is a top "
+"level posting, the entire thread will be deleted."
+msgstr ""
+
+#: src/Module/Admin/Item/Delete.php:69
+msgid ""
+"You need to know the GUID of the item. You can find it e.g. by looking at "
+"the display URL. The last part of http://example.com/display/123456 is the "
+"GUID, here 123456."
+msgstr ""
+
+#: src/Module/Admin/Item/Delete.php:70
+msgid "GUID"
+msgstr ""
+
+#: src/Module/Admin/Item/Delete.php:70
+msgid "The GUID of the item you want to delete."
+msgstr ""
+
+#: src/Module/Admin/Item/Source.php:57
+msgid "Item Guid"
+msgstr ""
+
+#: src/Module/Admin/Logs/Settings.php:48
+#, php-format
+msgid "The logfile '%s' is not writable. No logging possible"
+msgstr ""
+
+#: src/Module/Admin/Logs/Settings.php:72
+msgid "PHP log currently enabled."
+msgstr ""
+
+#: src/Module/Admin/Logs/Settings.php:74
+msgid "PHP log currently disabled."
+msgstr ""
+
+#: src/Module/Admin/Logs/Settings.php:81 src/Module/BaseAdmin.php:107
+#: src/Module/BaseAdmin.php:108
+msgid "Logs"
+msgstr ""
+
+#: src/Module/Admin/Logs/Settings.php:83
+msgid "Clear"
+msgstr ""
+
+#: src/Module/Admin/Logs/Settings.php:87
+msgid "Enable Debugging"
+msgstr ""
+
+#: src/Module/Admin/Logs/Settings.php:88
+msgid "Log file"
+msgstr ""
+
+#: src/Module/Admin/Logs/Settings.php:88
+msgid ""
+"Must be writable by web server. Relative to your Friendica top-level "
+"directory."
+msgstr ""
+
+#: src/Module/Admin/Logs/Settings.php:89
+msgid "Log level"
+msgstr ""
+
+#: src/Module/Admin/Logs/Settings.php:91
+msgid "PHP logging"
+msgstr ""
+
+#: src/Module/Admin/Logs/Settings.php:92
+msgid ""
+"To temporarily enable logging of PHP errors and warnings you can prepend the "
+"following to the index.php file of your installation. The filename set in "
+"the 'error_log' line is relative to the friendica top-level directory and "
+"must be writeable by the web server. The option '1' for 'log_errors' and "
+"'display_errors' is to enable these options, set to '0' to disable them."
+msgstr ""
+
+#: src/Module/Admin/Logs/View.php:40
+#, php-format
+msgid ""
+"Error trying to open <strong>%1$s</strong> log file.\\r\\n<br/>Check to see "
+"if file %1$s exist and is readable."
+msgstr ""
+
+#: src/Module/Admin/Logs/View.php:44
+#, php-format
+msgid ""
+"Couldn't open <strong>%1$s</strong> log file.\\r\\n<br/>Check to see if file "
+"%1$s is readable."
+msgstr ""
+
+#: src/Module/Admin/Logs/View.php:65 src/Module/BaseAdmin.php:109
+msgid "View Logs"
+msgstr ""
+
+#: src/Module/Admin/Queue.php:50
+msgid "Inspect Deferred Worker Queue"
+msgstr ""
+
+#: src/Module/Admin/Queue.php:51
+msgid ""
+"This page lists the deferred worker jobs. This are jobs that couldn't be "
+"executed at the first time."
+msgstr ""
+
+#: src/Module/Admin/Queue.php:54
+msgid "Inspect Worker Queue"
+msgstr ""
+
+#: src/Module/Admin/Queue.php:55
+msgid ""
+"This page lists the currently queued worker jobs. These jobs are handled by "
+"the worker cronjob you've set up during install."
+msgstr ""
+
+#: src/Module/Admin/Queue.php:75
+msgid "ID"
+msgstr ""
+
+#: src/Module/Admin/Queue.php:76
+msgid "Job Parameters"
+msgstr ""
+
+#: src/Module/Admin/Queue.php:77
+msgid "Created"
+msgstr ""
+
+#: src/Module/Admin/Queue.php:78
+msgid "Priority"
+msgstr ""
+
+#: src/Module/Admin/Site.php:69
+msgid "Can not parse base url. Must have at least <scheme>://<domain>"
+msgstr ""
+
+#: src/Module/Admin/Site.php:123
+msgid "Relocation started. Could take a while to complete."
+msgstr ""
+
+#: src/Module/Admin/Site.php:249
+msgid "Invalid storage backend setting value."
+msgstr ""
+
+#: src/Module/Admin/Site.php:449 src/Module/Settings/Display.php:134
+msgid "No special theme for mobile devices"
+msgstr ""
+
+#: src/Module/Admin/Site.php:466 src/Module/Settings/Display.php:144
+#, php-format
+msgid "%s - (Experimental)"
+msgstr ""
+
+#: src/Module/Admin/Site.php:478
+msgid "No community page for local users"
+msgstr ""
+
+#: src/Module/Admin/Site.php:479
+msgid "No community page"
+msgstr ""
+
+#: src/Module/Admin/Site.php:480
+msgid "Public postings from users of this site"
+msgstr ""
+
+#: src/Module/Admin/Site.php:481
+msgid "Public postings from the federated network"
+msgstr ""
+
+#: src/Module/Admin/Site.php:482
+msgid "Public postings from local users and the federated network"
+msgstr ""
+
+#: src/Module/Admin/Site.php:488
+msgid "Multi user instance"
+msgstr ""
+
+#: src/Module/Admin/Site.php:516
+msgid "Closed"
+msgstr ""
+
+#: src/Module/Admin/Site.php:517
+msgid "Requires approval"
+msgstr ""
+
+#: src/Module/Admin/Site.php:518
+msgid "Open"
+msgstr ""
+
+#: src/Module/Admin/Site.php:522 src/Module/Install.php:204
+msgid "No SSL policy, links will track page SSL state"
+msgstr ""
+
+#: src/Module/Admin/Site.php:523 src/Module/Install.php:205
+msgid "Force all links to use SSL"
+msgstr ""
+
+#: src/Module/Admin/Site.php:524 src/Module/Install.php:206
+msgid "Self-signed certificate, use SSL for local links only (discouraged)"
+msgstr ""
+
+#: src/Module/Admin/Site.php:528
+msgid "Don't check"
+msgstr ""
+
+#: src/Module/Admin/Site.php:529
+msgid "check the stable version"
+msgstr ""
+
+#: src/Module/Admin/Site.php:530
+msgid "check the development version"
+msgstr ""
+
+#: src/Module/Admin/Site.php:534
+msgid "none"
+msgstr ""
+
+#: src/Module/Admin/Site.php:535
+msgid "Local contacts"
+msgstr ""
+
+#: src/Module/Admin/Site.php:536
+msgid "Interactors"
+msgstr ""
+
+#: src/Module/Admin/Site.php:549
+msgid "Database (legacy)"
+msgstr ""
+
+#: src/Module/Admin/Site.php:580 src/Module/BaseAdmin.php:90
+msgid "Site"
+msgstr ""
+
+#: src/Module/Admin/Site.php:581
+msgid "General Information"
+msgstr ""
+
+#: src/Module/Admin/Site.php:583
+msgid "Republish users to directory"
+msgstr ""
+
+#: src/Module/Admin/Site.php:584 src/Module/Register.php:139
+msgid "Registration"
+msgstr ""
+
+#: src/Module/Admin/Site.php:585
+msgid "File upload"
+msgstr ""
+
+#: src/Module/Admin/Site.php:586
+msgid "Policies"
+msgstr ""
+
+#: src/Module/Admin/Site.php:588
+msgid "Auto Discovered Contact Directory"
+msgstr ""
+
+#: src/Module/Admin/Site.php:589
+msgid "Performance"
+msgstr ""
+
+#: src/Module/Admin/Site.php:590
+msgid "Worker"
+msgstr ""
+
+#: src/Module/Admin/Site.php:591
+msgid "Message Relay"
+msgstr ""
+
+#: src/Module/Admin/Site.php:592
+msgid "Relocate Instance"
+msgstr ""
+
+#: src/Module/Admin/Site.php:593
+msgid ""
+"<strong>Warning!</strong> Advanced function. Could make this server "
+"unreachable."
+msgstr ""
+
+#: src/Module/Admin/Site.php:597
+msgid "Site name"
+msgstr ""
+
+#: src/Module/Admin/Site.php:598
+msgid "Sender Email"
+msgstr ""
+
+#: src/Module/Admin/Site.php:598
+msgid ""
+"The email address your server shall use to send notification emails from."
+msgstr ""
+
+#: src/Module/Admin/Site.php:599
+msgid "Name of the system actor"
+msgstr ""
+
+#: src/Module/Admin/Site.php:599
+msgid ""
+"Name of the internal system account that is used to perform ActivityPub "
+"requests. This must be an unused username. If set, this can't be changed "
+"again."
+msgstr ""
+
+#: src/Module/Admin/Site.php:600
+msgid "Banner/Logo"
+msgstr ""
+
+#: src/Module/Admin/Site.php:601
+msgid "Email Banner/Logo"
+msgstr ""
+
+#: src/Module/Admin/Site.php:602
+msgid "Shortcut icon"
+msgstr ""
+
+#: src/Module/Admin/Site.php:602
+msgid "Link to an icon that will be used for browsers."
+msgstr ""
+
+#: src/Module/Admin/Site.php:603
+msgid "Touch icon"
+msgstr ""
+
+#: src/Module/Admin/Site.php:603
+msgid "Link to an icon that will be used for tablets and mobiles."
+msgstr ""
+
+#: src/Module/Admin/Site.php:604
+msgid "Additional Info"
+msgstr ""
+
+#: src/Module/Admin/Site.php:604
+#, php-format
+msgid ""
+"For public servers: you can add additional information here that will be "
+"listed at %s/servers."
+msgstr ""
+
+#: src/Module/Admin/Site.php:605
+msgid "System language"
+msgstr ""
+
+#: src/Module/Admin/Site.php:606
+msgid "System theme"
+msgstr ""
+
+#: src/Module/Admin/Site.php:606
+msgid ""
+"Default system theme - may be over-ridden by user profiles - <a href=\"/"
+"admin/themes\" id=\"cnftheme\">Change default theme settings</a>"
+msgstr ""
+
+#: src/Module/Admin/Site.php:607
+msgid "Mobile system theme"
+msgstr ""
+
+#: src/Module/Admin/Site.php:607
+msgid "Theme for mobile devices"
+msgstr ""
+
+#: src/Module/Admin/Site.php:608 src/Module/Install.php:214
+msgid "SSL link policy"
+msgstr ""
+
+#: src/Module/Admin/Site.php:608 src/Module/Install.php:216
+msgid "Determines whether generated links should be forced to use SSL"
+msgstr ""
+
+#: src/Module/Admin/Site.php:609
+msgid "Force SSL"
+msgstr ""
+
+#: src/Module/Admin/Site.php:609
+msgid ""
+"Force all Non-SSL requests to SSL - Attention: on some systems it could lead "
+"to endless loops."
+msgstr ""
+
+#: src/Module/Admin/Site.php:610
+msgid "Hide help entry from navigation menu"
+msgstr ""
+
+#: src/Module/Admin/Site.php:610
+msgid ""
+"Hides the menu entry for the Help pages from the navigation menu. You can "
+"still access it calling /help directly."
+msgstr ""
+
+#: src/Module/Admin/Site.php:611
+msgid "Single user instance"
+msgstr ""
+
+#: src/Module/Admin/Site.php:611
+msgid "Make this instance multi-user or single-user for the named user"
+msgstr ""
+
+#: src/Module/Admin/Site.php:613
+msgid "File storage backend"
+msgstr ""
+
+#: src/Module/Admin/Site.php:613
+msgid ""
+"The backend used to store uploaded data. If you change the storage backend, "
+"you can manually move the existing files. If you do not do so, the files "
+"uploaded before the change will still be available at the old backend. "
+"Please see <a href=\"/help/Settings#1_2_3_1\">the settings documentation</a> "
+"for more information about the choices and the moving procedure."
+msgstr ""
+
+#: src/Module/Admin/Site.php:615
+msgid "Maximum image size"
+msgstr ""
+
+#: src/Module/Admin/Site.php:615
+msgid ""
+"Maximum size in bytes of uploaded images. Default is 0, which means no "
+"limits."
+msgstr ""
+
+#: src/Module/Admin/Site.php:616
+msgid "Maximum image length"
+msgstr ""
+
+#: src/Module/Admin/Site.php:616
+msgid ""
+"Maximum length in pixels of the longest side of uploaded images. Default is "
+"-1, which means no limits."
+msgstr ""
+
+#: src/Module/Admin/Site.php:617
+msgid "JPEG image quality"
+msgstr ""
+
+#: src/Module/Admin/Site.php:617
+msgid ""
+"Uploaded JPEGS will be saved at this quality setting [0-100]. Default is "
+"100, which is full quality."
+msgstr ""
+
+#: src/Module/Admin/Site.php:619
+msgid "Register policy"
+msgstr ""
+
+#: src/Module/Admin/Site.php:620
+msgid "Maximum Daily Registrations"
+msgstr ""
+
+#: src/Module/Admin/Site.php:620
+msgid ""
+"If registration is permitted above, this sets the maximum number of new user "
+"registrations to accept per day.  If register is set to closed, this setting "
+"has no effect."
+msgstr ""
+
+#: src/Module/Admin/Site.php:621
+msgid "Register text"
+msgstr ""
+
+#: src/Module/Admin/Site.php:621
+msgid ""
+"Will be displayed prominently on the registration page. You can use BBCode "
+"here."
+msgstr ""
+
+#: src/Module/Admin/Site.php:622
+msgid "Forbidden Nicknames"
+msgstr ""
+
+#: src/Module/Admin/Site.php:622
+msgid ""
+"Comma separated list of nicknames that are forbidden from registration. "
+"Preset is a list of role names according RFC 2142."
+msgstr ""
+
+#: src/Module/Admin/Site.php:623
+msgid "Accounts abandoned after x days"
+msgstr ""
+
+#: src/Module/Admin/Site.php:623
+msgid ""
+"Will not waste system resources polling external sites for abandonded "
+"accounts. Enter 0 for no time limit."
+msgstr ""
+
+#: src/Module/Admin/Site.php:624
+msgid "Allowed friend domains"
+msgstr ""
+
+#: src/Module/Admin/Site.php:624
+msgid ""
+"Comma separated list of domains which are allowed to establish friendships "
+"with this site. Wildcards are accepted. Empty to allow any domains"
+msgstr ""
+
+#: src/Module/Admin/Site.php:625
+msgid "Allowed email domains"
+msgstr ""
+
+#: src/Module/Admin/Site.php:625
+msgid ""
+"Comma separated list of domains which are allowed in email addresses for "
+"registrations to this site. Wildcards are accepted. Empty to allow any "
+"domains"
+msgstr ""
+
+#: src/Module/Admin/Site.php:626
+msgid "No OEmbed rich content"
+msgstr ""
+
+#: src/Module/Admin/Site.php:626
+msgid ""
+"Don't show the rich content (e.g. embedded PDF), except from the domains "
+"listed below."
+msgstr ""
+
+#: src/Module/Admin/Site.php:627
+msgid "Allowed OEmbed domains"
+msgstr ""
+
+#: src/Module/Admin/Site.php:627
+msgid ""
+"Comma separated list of domains which oembed content is allowed to be "
+"displayed. Wildcards are accepted."
+msgstr ""
+
+#: src/Module/Admin/Site.php:628
+msgid "Block public"
+msgstr ""
+
+#: src/Module/Admin/Site.php:628
+msgid ""
+"Check to block public access to all otherwise public personal pages on this "
+"site unless you are currently logged in."
+msgstr ""
+
+#: src/Module/Admin/Site.php:629
+msgid "Force publish"
+msgstr ""
+
+#: src/Module/Admin/Site.php:629
+msgid ""
+"Check to force all profiles on this site to be listed in the site directory."
+msgstr ""
+
+#: src/Module/Admin/Site.php:629
+msgid "Enabling this may violate privacy laws like the GDPR"
+msgstr ""
+
+#: src/Module/Admin/Site.php:630
+msgid "Global directory URL"
+msgstr ""
+
+#: src/Module/Admin/Site.php:630
+msgid ""
+"URL to the global directory. If this is not set, the global directory is "
+"completely unavailable to the application."
+msgstr ""
+
+#: src/Module/Admin/Site.php:631
+msgid "Private posts by default for new users"
+msgstr ""
+
+#: src/Module/Admin/Site.php:631
+msgid ""
+"Set default post permissions for all new members to the default privacy "
+"group rather than public."
+msgstr ""
+
+#: src/Module/Admin/Site.php:632
+msgid "Don't include post content in email notifications"
+msgstr ""
+
+#: src/Module/Admin/Site.php:632
+msgid ""
+"Don't include the content of a post/comment/private message/etc. in the "
+"email notifications that are sent out from this site, as a privacy measure."
+msgstr ""
+
+#: src/Module/Admin/Site.php:633
+msgid "Disallow public access to addons listed in the apps menu."
+msgstr ""
+
+#: src/Module/Admin/Site.php:633
+msgid ""
+"Checking this box will restrict addons listed in the apps menu to members "
+"only."
+msgstr ""
+
+#: src/Module/Admin/Site.php:634
+msgid "Don't embed private images in posts"
+msgstr ""
+
+#: src/Module/Admin/Site.php:634
+msgid ""
+"Don't replace locally-hosted private photos in posts with an embedded copy "
+"of the image. This means that contacts who receive posts containing private "
+"photos will have to authenticate and load each image, which may take a while."
+msgstr ""
+
+#: src/Module/Admin/Site.php:635
+msgid "Explicit Content"
+msgstr ""
+
+#: src/Module/Admin/Site.php:635
+msgid ""
+"Set this to announce that your node is used mostly for explicit content that "
+"might not be suited for minors. This information will be published in the "
+"node information and might be used, e.g. by the global directory, to filter "
+"your node from listings of nodes to join. Additionally a note about this "
+"will be shown at the user registration page."
+msgstr ""
+
+#: src/Module/Admin/Site.php:636
+msgid "Allow Users to set remote_self"
+msgstr ""
+
+#: src/Module/Admin/Site.php:636
+msgid ""
+"With checking this, every user is allowed to mark every contact as a "
+"remote_self in the repair contact dialog. Setting this flag on a contact "
+"causes mirroring every posting of that contact in the users stream."
+msgstr ""
+
+#: src/Module/Admin/Site.php:637
+msgid "Block multiple registrations"
+msgstr ""
+
+#: src/Module/Admin/Site.php:637
+msgid "Disallow users to register additional accounts for use as pages."
+msgstr ""
+
+#: src/Module/Admin/Site.php:638
+msgid "Disable OpenID"
+msgstr ""
+
+#: src/Module/Admin/Site.php:638
+msgid "Disable OpenID support for registration and logins."
+msgstr ""
+
+#: src/Module/Admin/Site.php:639
+msgid "No Fullname check"
+msgstr ""
+
+#: src/Module/Admin/Site.php:639
+msgid ""
+"Allow users to register without a space between the first name and the last "
+"name in their full name."
+msgstr ""
+
+#: src/Module/Admin/Site.php:640
+msgid "Community pages for visitors"
+msgstr ""
+
+#: src/Module/Admin/Site.php:640
+msgid ""
+"Which community pages should be available for visitors. Local users always "
+"see both pages."
+msgstr ""
+
+#: src/Module/Admin/Site.php:641
+msgid "Posts per user on community page"
+msgstr ""
+
+#: src/Module/Admin/Site.php:641
+msgid ""
+"The maximum number of posts per user on the community page. (Not valid for "
+"\"Global Community\")"
+msgstr ""
+
+#: src/Module/Admin/Site.php:642
+msgid "Disable OStatus support"
+msgstr ""
+
+#: src/Module/Admin/Site.php:642
+msgid ""
+"Disable built-in OStatus (StatusNet, GNU Social etc.) compatibility. All "
+"communications in OStatus are public, so privacy warnings will be "
+"occasionally displayed."
+msgstr ""
+
+#: src/Module/Admin/Site.php:643
+msgid "OStatus support can only be enabled if threading is enabled."
+msgstr ""
+
+#: src/Module/Admin/Site.php:645
+msgid ""
+"Diaspora support can't be enabled because Friendica was installed into a sub "
+"directory."
+msgstr ""
+
+#: src/Module/Admin/Site.php:646
+msgid "Enable Diaspora support"
+msgstr ""
+
+#: src/Module/Admin/Site.php:646
+msgid "Provide built-in Diaspora network compatibility."
+msgstr ""
+
+#: src/Module/Admin/Site.php:647
+msgid "Only allow Friendica contacts"
+msgstr ""
+
+#: src/Module/Admin/Site.php:647
+msgid ""
+"All contacts must use Friendica protocols. All other built-in communication "
+"protocols disabled."
+msgstr ""
+
+#: src/Module/Admin/Site.php:648
+msgid "Verify SSL"
+msgstr ""
+
+#: src/Module/Admin/Site.php:648
+msgid ""
+"If you wish, you can turn on strict certificate checking. This will mean you "
+"cannot connect (at all) to self-signed SSL sites."
+msgstr ""
+
+#: src/Module/Admin/Site.php:649
+msgid "Proxy user"
+msgstr ""
+
+#: src/Module/Admin/Site.php:650
+msgid "Proxy URL"
+msgstr ""
+
+#: src/Module/Admin/Site.php:651
+msgid "Network timeout"
+msgstr ""
+
+#: src/Module/Admin/Site.php:651
+msgid "Value is in seconds. Set to 0 for unlimited (not recommended)."
+msgstr ""
+
+#: src/Module/Admin/Site.php:652
+msgid "Maximum Load Average"
+msgstr ""
+
+#: src/Module/Admin/Site.php:652
+#, php-format
+msgid ""
+"Maximum system load before delivery and poll processes are deferred - "
+"default %d."
+msgstr ""
+
+#: src/Module/Admin/Site.php:653
+msgid "Maximum Load Average (Frontend)"
+msgstr ""
+
+#: src/Module/Admin/Site.php:653
+msgid "Maximum system load before the frontend quits service - default 50."
+msgstr ""
+
+#: src/Module/Admin/Site.php:654
+msgid "Minimal Memory"
+msgstr ""
+
+#: src/Module/Admin/Site.php:654
+msgid ""
+"Minimal free memory in MB for the worker. Needs access to /proc/meminfo - "
+"default 0 (deactivated)."
+msgstr ""
+
+#: src/Module/Admin/Site.php:655
+msgid "Periodically optimize tables"
+msgstr ""
+
+#: src/Module/Admin/Site.php:655
+msgid "Periodically optimize tables like the cache and the workerqueue"
+msgstr ""
+
+#: src/Module/Admin/Site.php:657
+msgid "Discover followers/followings from contacts"
+msgstr ""
+
+#: src/Module/Admin/Site.php:657
+msgid ""
+"If enabled, contacts are checked for their followers and following contacts."
+msgstr ""
+
+#: src/Module/Admin/Site.php:658
+msgid "None - deactivated"
+msgstr ""
+
+#: src/Module/Admin/Site.php:659
+msgid ""
+"Local contacts - contacts of our local contacts are discovered for their "
+"followers/followings."
+msgstr ""
+
+#: src/Module/Admin/Site.php:660
+msgid ""
+"Interactors - contacts of our local contacts and contacts who interacted on "
+"locally visible postings are discovered for their followers/followings."
+msgstr ""
+
+#: src/Module/Admin/Site.php:662
+msgid "Synchronize the contacts with the directory server"
+msgstr ""
+
+#: src/Module/Admin/Site.php:662
+msgid ""
+"if enabled, the system will check periodically for new contacts on the "
+"defined directory server."
+msgstr ""
+
+#: src/Module/Admin/Site.php:664
+msgid "Days between requery"
+msgstr ""
+
+#: src/Module/Admin/Site.php:664
+msgid "Number of days after which a server is requeried for his contacts."
+msgstr ""
+
+#: src/Module/Admin/Site.php:665
+msgid "Discover contacts from other servers"
+msgstr ""
+
+#: src/Module/Admin/Site.php:665
+msgid ""
+"Periodically query other servers for contacts. The system queries Friendica, "
+"Mastodon and Hubzilla servers."
+msgstr ""
+
+#: src/Module/Admin/Site.php:666
+msgid "Search the local directory"
+msgstr ""
+
+#: src/Module/Admin/Site.php:666
+msgid ""
+"Search the local directory instead of the global directory. When searching "
+"locally, every search will be executed on the global directory in the "
+"background. This improves the search results when the search is repeated."
+msgstr ""
+
+#: src/Module/Admin/Site.php:668
+msgid "Publish server information"
+msgstr ""
+
+#: src/Module/Admin/Site.php:668
+msgid ""
+"If enabled, general server and usage data will be published. The data "
+"contains the name and version of the server, number of users with public "
+"profiles, number of posts and the activated protocols and connectors. See <a "
+"href=\"http://the-federation.info/\">the-federation.info</a> for details."
+msgstr ""
+
+#: src/Module/Admin/Site.php:670
+msgid "Check upstream version"
+msgstr ""
+
+#: src/Module/Admin/Site.php:670
+msgid ""
+"Enables checking for new Friendica versions at github. If there is a new "
+"version, you will be informed in the admin panel overview."
+msgstr ""
+
+#: src/Module/Admin/Site.php:671
+msgid "Suppress Tags"
+msgstr ""
+
+#: src/Module/Admin/Site.php:671
+msgid "Suppress showing a list of hashtags at the end of the posting."
+msgstr ""
+
+#: src/Module/Admin/Site.php:672
+msgid "Clean database"
+msgstr ""
+
+#: src/Module/Admin/Site.php:672
+msgid ""
+"Remove old remote items, orphaned database records and old content from some "
+"other helper tables."
+msgstr ""
+
+#: src/Module/Admin/Site.php:673
+msgid "Lifespan of remote items"
+msgstr ""
+
+#: src/Module/Admin/Site.php:673
+msgid ""
+"When the database cleanup is enabled, this defines the days after which "
+"remote items will be deleted. Own items, and marked or filed items are "
+"always kept. 0 disables this behaviour."
+msgstr ""
+
+#: src/Module/Admin/Site.php:674
+msgid "Lifespan of unclaimed items"
+msgstr ""
+
+#: src/Module/Admin/Site.php:674
+msgid ""
+"When the database cleanup is enabled, this defines the days after which "
+"unclaimed remote items (mostly content from the relay) will be deleted. "
+"Default value is 90 days. Defaults to the general lifespan value of remote "
+"items if set to 0."
+msgstr ""
+
+#: src/Module/Admin/Site.php:675
+msgid "Lifespan of raw conversation data"
+msgstr ""
+
+#: src/Module/Admin/Site.php:675
+msgid ""
+"The conversation data is used for ActivityPub and OStatus, as well as for "
+"debug purposes. It should be safe to remove it after 14 days, default is 90 "
+"days."
+msgstr ""
+
+#: src/Module/Admin/Site.php:676
+msgid "Path to item cache"
+msgstr ""
+
+#: src/Module/Admin/Site.php:676
+msgid "The item caches buffers generated bbcode and external images."
+msgstr ""
+
+#: src/Module/Admin/Site.php:677
+msgid "Cache duration in seconds"
+msgstr ""
+
+#: src/Module/Admin/Site.php:677
+msgid ""
+"How long should the cache files be hold? Default value is 86400 seconds (One "
+"day). To disable the item cache, set the value to -1."
+msgstr ""
+
+#: src/Module/Admin/Site.php:678
+msgid "Maximum numbers of comments per post"
+msgstr ""
+
+#: src/Module/Admin/Site.php:678
+msgid "How much comments should be shown for each post? Default value is 100."
+msgstr ""
+
+#: src/Module/Admin/Site.php:679
+msgid "Maximum numbers of comments per post on the display page"
+msgstr ""
+
+#: src/Module/Admin/Site.php:679
+msgid ""
+"How many comments should be shown on the single view for each post? Default "
+"value is 1000."
+msgstr ""
+
+#: src/Module/Admin/Site.php:680
+msgid "Temp path"
+msgstr ""
+
+#: src/Module/Admin/Site.php:680
+msgid ""
+"If you have a restricted system where the webserver can't access the system "
+"temp path, enter another path here."
+msgstr ""
+
+#: src/Module/Admin/Site.php:681
+msgid "Disable picture proxy"
+msgstr ""
+
+#: src/Module/Admin/Site.php:681
+msgid ""
+"The picture proxy increases performance and privacy. It shouldn't be used on "
+"systems with very low bandwidth."
+msgstr ""
+
+#: src/Module/Admin/Site.php:682
+msgid "Only search in tags"
+msgstr ""
+
+#: src/Module/Admin/Site.php:682
+msgid "On large systems the text search can slow down the system extremely."
+msgstr ""
+
+#: src/Module/Admin/Site.php:684
+msgid "New base url"
+msgstr ""
+
+#: src/Module/Admin/Site.php:684
+msgid ""
+"Change base url for this server. Sends relocate message to all Friendica and "
+"Diaspora* contacts of all users."
+msgstr ""
+
+#: src/Module/Admin/Site.php:686
+msgid "RINO Encryption"
+msgstr ""
+
+#: src/Module/Admin/Site.php:686
+msgid "Encryption layer between nodes."
+msgstr ""
+
+#: src/Module/Admin/Site.php:686 src/Module/Admin/Site.php:694
+#: src/Module/Contact.php:554 src/Module/Settings/TwoFactor/Index.php:113
+msgid "Disabled"
+msgstr ""
+
+#: src/Module/Admin/Site.php:686
+msgid "Enabled"
+msgstr ""
+
+#: src/Module/Admin/Site.php:688
+msgid "Maximum number of parallel workers"
+msgstr ""
+
+#: src/Module/Admin/Site.php:688
+#, php-format
+msgid ""
+"On shared hosters set this to %d. On larger systems, values of %d are great. "
+"Default value is %d."
+msgstr ""
+
+#: src/Module/Admin/Site.php:689
+msgid "Enable fastlane"
+msgstr ""
+
+#: src/Module/Admin/Site.php:689
+msgid ""
+"When enabed, the fastlane mechanism starts an additional worker if processes "
+"with higher priority are blocked by processes of lower priority."
+msgstr ""
+
+#: src/Module/Admin/Site.php:691
+msgid "Use relay servers"
+msgstr ""
+
+#: src/Module/Admin/Site.php:691
+msgid ""
+"Enables the receiving of public posts from relay servers. They will be "
+"included in the search, subscribed tags and on the global community page."
+msgstr ""
+
+#: src/Module/Admin/Site.php:692
+msgid "\"Social Relay\" server"
+msgstr ""
+
+#: src/Module/Admin/Site.php:692
+#, php-format
+msgid ""
+"Address of the \"Social Relay\" server where public posts should be send to. "
+"For example %s. ActivityRelay servers are administrated via the \"console "
+"relay\" command line command."
+msgstr ""
+
+#: src/Module/Admin/Site.php:693
+msgid "Direct relay transfer"
+msgstr ""
+
+#: src/Module/Admin/Site.php:693
+msgid ""
+"Enables the direct transfer to other servers without using the relay servers"
+msgstr ""
+
+#: src/Module/Admin/Site.php:694
+msgid "Relay scope"
+msgstr ""
+
+#: src/Module/Admin/Site.php:694
+msgid ""
+"Can be \"all\" or \"tags\". \"all\" means that every public post should be "
+"received. \"tags\" means that only posts with selected tags should be "
+"received."
+msgstr ""
+
+#: src/Module/Admin/Site.php:694
+msgid "all"
+msgstr ""
+
+#: src/Module/Admin/Site.php:694
+msgid "tags"
+msgstr ""
+
+#: src/Module/Admin/Site.php:695
+msgid "Server tags"
+msgstr ""
+
+#: src/Module/Admin/Site.php:695
+msgid "Comma separated list of tags for the \"tags\" subscription."
+msgstr ""
+
+#: src/Module/Admin/Site.php:696
+msgid "Deny Server tags"
+msgstr ""
+
+#: src/Module/Admin/Site.php:696
+msgid "Comma separated list of tags that are rejected."
+msgstr ""
+
+#: src/Module/Admin/Site.php:697
+msgid "Allow user tags"
+msgstr ""
+
+#: src/Module/Admin/Site.php:697
+msgid ""
+"If enabled, the tags from the saved searches will used for the \"tags\" "
+"subscription in addition to the \"relay_server_tags\"."
+msgstr ""
+
+#: src/Module/Admin/Site.php:700
+msgid "Start Relocation"
+msgstr ""
+
+#: src/Module/Admin/Summary.php:53
+#, php-format
+msgid "Template engine (%s) error: %s"
+msgstr ""
+
+#: src/Module/Admin/Summary.php:57
+#, php-format
+msgid ""
+"Your DB still runs with MyISAM tables. You should change the engine type to "
+"InnoDB. As Friendica will use InnoDB only features in the future, you should "
+"change this! See <a href=\"%s\">here</a> for a guide that may be helpful "
+"converting the table engines. You may also use the command <tt>php bin/"
+"console.php dbstructure toinnodb</tt> of your Friendica installation for an "
+"automatic conversion.<br />"
+msgstr ""
+
+#: src/Module/Admin/Summary.php:62
+#, php-format
+msgid ""
+"Your DB still runs with InnoDB tables in the Antelope file format. You "
+"should change the file format to Barracuda. Friendica is using features that "
+"are not provided by the Antelope format. See <a href=\"%s\">here</a> for a "
+"guide that may be helpful converting the table engines. You may also use the "
+"command <tt>php bin/console.php dbstructure toinnodb</tt> of your Friendica "
+"installation for an automatic conversion.<br />"
+msgstr ""
+
+#: src/Module/Admin/Summary.php:71
+#, php-format
+msgid ""
+"Your table_definition_cache is too low (%d). This can lead to the database "
+"error \"Prepared statement needs to be re-prepared\". Please set it at least "
+"to %d (or -1 for autosizing). See <a href=\"%s\">here</a> for more "
+"information.<br />"
+msgstr ""
+
+#: src/Module/Admin/Summary.php:80
+#, php-format
+msgid ""
+"There is a new version of Friendica available for download. Your current "
+"version is %1$s, upstream version is %2$s"
+msgstr ""
+
+#: src/Module/Admin/Summary.php:89
+msgid ""
+"The database update failed. Please run \"php bin/console.php dbstructure "
+"update\" from the command line and have a look at the errors that might "
+"appear."
+msgstr ""
+
+#: src/Module/Admin/Summary.php:93
+msgid ""
+"The last update failed. Please run \"php bin/console.php dbstructure update"
+"\" from the command line and have a look at the errors that might appear. "
+"(Some of the errors are possibly inside the logfile.)"
+msgstr ""
+
+#: src/Module/Admin/Summary.php:98
+msgid "The worker was never executed. Please check your database structure!"
+msgstr ""
+
+#: src/Module/Admin/Summary.php:100
+#, php-format
+msgid ""
+"The last worker execution was on %s UTC. This is older than one hour. Please "
+"check your crontab settings."
+msgstr ""
+
+#: src/Module/Admin/Summary.php:105
+#, php-format
+msgid ""
+"Friendica's configuration now is stored in config/local.config.php, please "
+"copy config/local-sample.config.php and move your config from <code>."
+"htconfig.php</code>. See <a href=\"%s\">the Config help page</a> for help "
+"with the transition."
+msgstr ""
+
+#: src/Module/Admin/Summary.php:109
+#, php-format
+msgid ""
+"Friendica's configuration now is stored in config/local.config.php, please "
+"copy config/local-sample.config.php and move your config from <code>config/"
+"local.ini.php</code>. See <a href=\"%s\">the Config help page</a> for help "
+"with the transition."
+msgstr ""
+
+#: src/Module/Admin/Summary.php:115
+#, php-format
+msgid ""
+"<a href=\"%s\">%s</a> is not reachable on your system. This is a severe "
+"configuration issue that prevents server to server communication. See <a "
+"href=\"%s\">the installation page</a> for help."
+msgstr ""
+
+#: src/Module/Admin/Summary.php:133
+#, php-format
+msgid "The logfile '%s' is not usable. No logging possible (error: '%s')"
+msgstr ""
+
+#: src/Module/Admin/Summary.php:147
+#, php-format
+msgid "The debug logfile '%s' is not usable. No logging possible (error: '%s')"
+msgstr ""
+
+#: src/Module/Admin/Summary.php:163
+#, php-format
+msgid ""
+"Friendica's system.basepath was updated from '%s' to '%s'. Please remove the "
+"system.basepath from your db to avoid differences."
+msgstr ""
+
+#: src/Module/Admin/Summary.php:171
+#, php-format
+msgid ""
+"Friendica's current system.basepath '%s' is wrong and the config file '%s' "
+"isn't used."
+msgstr ""
+
+#: src/Module/Admin/Summary.php:179
+#, php-format
+msgid ""
+"Friendica's current system.basepath '%s' is not equal to the config file "
+"'%s'. Please fix your configuration."
+msgstr ""
+
+#: src/Module/Admin/Summary.php:186
+msgid "Normal Account"
+msgstr ""
+
+#: src/Module/Admin/Summary.php:187
+msgid "Automatic Follower Account"
+msgstr ""
+
+#: src/Module/Admin/Summary.php:188
+msgid "Public Forum Account"
+msgstr ""
+
+#: src/Module/Admin/Summary.php:189
+msgid "Automatic Friend Account"
+msgstr ""
+
+#: src/Module/Admin/Summary.php:190
+msgid "Blog Account"
+msgstr ""
+
+#: src/Module/Admin/Summary.php:191
+msgid "Private Forum Account"
+msgstr ""
+
+#: src/Module/Admin/Summary.php:211
+msgid "Message queues"
+msgstr ""
+
+#: src/Module/Admin/Summary.php:217
+msgid "Server Settings"
+msgstr ""
+
+#: src/Module/Admin/Summary.php:231 src/Repository/ProfileField.php:285
+msgid "Summary"
+msgstr ""
+
+#: src/Module/Admin/Summary.php:233
+msgid "Registered users"
+msgstr ""
+
+#: src/Module/Admin/Summary.php:235
+msgid "Pending registrations"
+msgstr ""
+
+#: src/Module/Admin/Summary.php:236
+msgid "Version"
+msgstr ""
+
+#: src/Module/Admin/Summary.php:240
+msgid "Active addons"
+msgstr ""
+
+#: src/Module/Admin/Themes/Details.php:57 src/Module/Admin/Themes/Index.php:65
+#, php-format
+msgid "Theme %s disabled."
+msgstr ""
+
+#: src/Module/Admin/Themes/Details.php:59 src/Module/Admin/Themes/Index.php:67
+#, php-format
+msgid "Theme %s successfully enabled."
+msgstr ""
+
+#: src/Module/Admin/Themes/Details.php:61 src/Module/Admin/Themes/Index.php:69
+#, php-format
+msgid "Theme %s failed to install."
+msgstr ""
+
+#: src/Module/Admin/Themes/Details.php:83
+msgid "Screenshot"
+msgstr ""
+
+#: src/Module/Admin/Themes/Details.php:91 src/Module/Admin/Themes/Index.php:112
+#: src/Module/BaseAdmin.php:93
+msgid "Themes"
+msgstr ""
+
+#: src/Module/Admin/Themes/Embed.php:65
+msgid "Unknown theme."
+msgstr ""
+
+#: src/Module/Admin/Themes/Index.php:51
+msgid "Themes reloaded"
+msgstr ""
+
+#: src/Module/Admin/Themes/Index.php:114
+msgid "Reload active themes"
+msgstr ""
+
+#: src/Module/Admin/Themes/Index.php:119
+#, php-format
+msgid "No themes found on the system. They should be placed in %1$s"
+msgstr ""
+
+#: src/Module/Admin/Themes/Index.php:120
+msgid "[Experimental]"
+msgstr ""
+
+#: src/Module/Admin/Themes/Index.php:121
+msgid "[Unsupported]"
+msgstr ""
+
+#: src/Module/Admin/Tos.php:60
+msgid "Display Terms of Service"
+msgstr ""
+
+#: src/Module/Admin/Tos.php:60
+msgid ""
+"Enable the Terms of Service page. If this is enabled a link to the terms "
+"will be added to the registration form and the general information page."
+msgstr ""
+
+#: src/Module/Admin/Tos.php:61
+msgid "Display Privacy Statement"
+msgstr ""
+
+#: src/Module/Admin/Tos.php:61
+#, php-format
+msgid ""
+"Show some informations regarding the needed information to operate the node "
+"according e.g. to <a href=\"%s\" target=\"_blank\" rel=\"noopener noreferrer"
+"\">EU-GDPR</a>."
+msgstr ""
+
+#: src/Module/Admin/Tos.php:62
+msgid "Privacy Statement Preview"
+msgstr ""
+
+#: src/Module/Admin/Tos.php:64
+msgid "The Terms of Service"
+msgstr ""
+
+#: src/Module/Admin/Tos.php:64
+msgid ""
+"Enter the Terms of Service for your node here. You can use BBCode. Headers "
+"of sections should be [h2] and below."
+msgstr ""
+
+#: src/Module/Admin/Users/Active.php:45 src/Module/Admin/Users/Index.php:45
+#, php-format
+msgid "%s user blocked"
+msgid_plural "%s users blocked"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/Module/Admin/Users/Active.php:53 src/Module/Admin/Users/Active.php:88
+#: src/Module/Admin/Users/Blocked.php:54 src/Module/Admin/Users/Blocked.php:89
+#: src/Module/Admin/Users/Index.php:60 src/Module/Admin/Users/Index.php:95
+msgid "You can't remove yourself"
+msgstr ""
+
+#: src/Module/Admin/Users/Active.php:57 src/Module/Admin/Users/Blocked.php:58
+#: src/Module/Admin/Users/Index.php:64
+#, php-format
+msgid "%s user deleted"
+msgid_plural "%s users deleted"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/Module/Admin/Users/Active.php:86 src/Module/Admin/Users/Blocked.php:87
+#: src/Module/Admin/Users/Index.php:93
+#, php-format
+msgid "User \"%s\" deleted"
+msgstr ""
+
+#: src/Module/Admin/Users/Active.php:96 src/Module/Admin/Users/Index.php:103
+#, php-format
+msgid "User \"%s\" blocked"
+msgstr ""
+
+#: src/Module/Admin/Users/Active.php:129 src/Module/Admin/Users/Blocked.php:130
+#: src/Module/Admin/Users/Deleted.php:88 src/Module/Admin/Users/Index.php:142
+#: src/Module/Admin/Users/Index.php:162
+msgid "Register date"
+msgstr ""
+
+#: src/Module/Admin/Users/Active.php:129 src/Module/Admin/Users/Blocked.php:130
+#: src/Module/Admin/Users/Deleted.php:88 src/Module/Admin/Users/Index.php:142
+#: src/Module/Admin/Users/Index.php:162
+msgid "Last login"
+msgstr ""
+
+#: src/Module/Admin/Users/Active.php:129 src/Module/Admin/Users/Blocked.php:130
+#: src/Module/Admin/Users/Deleted.php:88 src/Module/Admin/Users/Index.php:142
+#: src/Module/Admin/Users/Index.php:162
+msgid "Last public item"
+msgstr ""
+
+#: src/Module/Admin/Users/Active.php:129 src/Module/Admin/Users/Blocked.php:130
+#: src/Module/Admin/Users/Index.php:142
+msgid "Type"
+msgstr ""
+
+#: src/Module/Admin/Users/Active.php:137
+msgid "Active Accounts"
+msgstr ""
+
+#: src/Module/Admin/Users/Active.php:141 src/Module/Admin/Users/Blocked.php:141
+#: src/Module/Admin/Users/Index.php:155
+msgid "User blocked"
+msgstr ""
+
+#: src/Module/Admin/Users/Active.php:142 src/Module/Admin/Users/Blocked.php:143
+#: src/Module/Admin/Users/Index.php:157
+msgid "Site admin"
+msgstr ""
+
+#: src/Module/Admin/Users/Active.php:143 src/Module/Admin/Users/Blocked.php:144
+#: src/Module/Admin/Users/Index.php:158
+msgid "Account expired"
+msgstr ""
+
+#: src/Module/Admin/Users/Active.php:144 src/Module/Admin/Users/Index.php:161
+msgid "Create a new user"
+msgstr ""
+
+#: src/Module/Admin/Users/Active.php:150 src/Module/Admin/Users/Blocked.php:150
+#: src/Module/Admin/Users/Index.php:167
+msgid ""
+"Selected users will be deleted!\\n\\nEverything these users had posted on "
+"this site will be permanently deleted!\\n\\nAre you sure?"
+msgstr ""
+
+#: src/Module/Admin/Users/Active.php:151 src/Module/Admin/Users/Blocked.php:151
+#: src/Module/Admin/Users/Index.php:168
+msgid ""
+"The user {0} will be deleted!\\n\\nEverything this user has posted on this "
+"site will be permanently deleted!\\n\\nAre you sure?"
+msgstr ""
+
+#: src/Module/Admin/Users/Blocked.php:46 src/Module/Admin/Users/Index.php:52
+#, php-format
+msgid "%s user unblocked"
+msgid_plural "%s users unblocked"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/Module/Admin/Users/Blocked.php:96 src/Module/Admin/Users/Index.php:109
+#, php-format
+msgid "User \"%s\" unblocked"
+msgstr ""
+
+#: src/Module/Admin/Users/Blocked.php:138
+msgid "Blocked Users"
+msgstr ""
+
+#: src/Module/Admin/Users/Create.php:62
+msgid "New User"
+msgstr ""
+
+#: src/Module/Admin/Users/Create.php:63
+msgid "Add User"
+msgstr ""
+
+#: src/Module/Admin/Users/Create.php:71
+msgid "Name of the new user."
+msgstr ""
+
+#: src/Module/Admin/Users/Create.php:72
+msgid "Nickname"
+msgstr ""
+
+#: src/Module/Admin/Users/Create.php:72
+msgid "Nickname of the new user."
+msgstr ""
+
+#: src/Module/Admin/Users/Create.php:73
+msgid "Email address of the new user."
+msgstr ""
+
+#: src/Module/Admin/Users/Deleted.php:86
+msgid "Users awaiting permanent deletion"
+msgstr ""
+
+#: src/Module/Admin/Users/Deleted.php:88 src/Module/Admin/Users/Index.php:162
+msgid "Permanent deletion"
+msgstr ""
+
+#: src/Module/Admin/Users/Index.php:150 src/Module/Admin/Users/Index.php:160
+#: src/Module/BaseAdmin.php:91
+msgid "Users"
+msgstr ""
+
+#: src/Module/Admin/Users/Index.php:152
+msgid "User waiting for permanent deletion"
+msgstr ""
+
+#: src/Module/Admin/Users/Pending.php:48
+#, php-format
+msgid "%s user approved"
+msgid_plural "%s users approved"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/Module/Admin/Users/Pending.php:55
+#, php-format
+msgid "%s registration revoked"
+msgid_plural "%s registrations revoked"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/Module/Admin/Users/Pending.php:81
+msgid "Account approved."
+msgstr ""
+
+#: src/Module/Admin/Users/Pending.php:87
+msgid "Registration revoked"
+msgstr ""
+
+#: src/Module/Admin/Users/Pending.php:102
+msgid "User registrations awaiting review"
+msgstr ""
+
+#: src/Module/Admin/Users/Pending.php:104
+msgid "Request date"
+msgstr ""
+
+#: src/Module/Admin/Users/Pending.php:105
+msgid "No registrations."
+msgstr ""
+
+#: src/Module/Admin/Users/Pending.php:106
+msgid "Note from the user"
+msgstr ""
+
+#: src/Module/Admin/Users/Pending.php:108
+msgid "Deny"
+msgstr ""
+
+#: src/Module/Api/Mastodon/Unimplemented.php:42
+#, php-format
+msgid "API endpoint \"%s\" is not implemented"
+msgstr ""
+
+#: src/Module/Api/Mastodon/Unimplemented.php:43
+msgid ""
+"The API endpoint is currently not implemented but might be in the future."
+msgstr ""
+
+#: src/Module/Api/Twitter/ContactEndpoint.php:65 src/Module/Contact.php:400
+msgid "Contact not found"
+msgstr ""
+
+#: src/Module/Api/Twitter/ContactEndpoint.php:135
+msgid "Profile not found"
+msgstr ""
+
+#: src/Module/Apps.php:47
+msgid "No installed applications."
+msgstr ""
+
+#: src/Module/Apps.php:52
+msgid "Applications"
+msgstr ""
+
+#: src/Module/Attach.php:50 src/Module/Attach.php:62
+msgid "Item was not found."
+msgstr ""
+
+#: src/Module/BaseAdmin.php:63
+msgid "You don't have access to administration pages."
+msgstr ""
+
+#: src/Module/BaseAdmin.php:67
+msgid ""
+"Submanaged account can't access the administration pages. Please log back in "
+"as the main account."
+msgstr ""
+
+#: src/Module/BaseAdmin.php:86
+msgid "Overview"
+msgstr ""
+
+#: src/Module/BaseAdmin.php:89
+msgid "Configuration"
+msgstr ""
+
+#: src/Module/BaseAdmin.php:94 src/Module/BaseSettings.php:65
+msgid "Additional features"
+msgstr ""
+
+#: src/Module/BaseAdmin.php:97
+msgid "Database"
+msgstr ""
+
+#: src/Module/BaseAdmin.php:98
+msgid "DB updates"
+msgstr ""
+
+#: src/Module/BaseAdmin.php:99
+msgid "Inspect Deferred Workers"
+msgstr ""
+
+#: src/Module/BaseAdmin.php:100
+msgid "Inspect worker Queue"
+msgstr ""
+
+#: src/Module/BaseAdmin.php:102
+msgid "Tools"
+msgstr ""
+
+#: src/Module/BaseAdmin.php:103
+msgid "Contact Blocklist"
+msgstr ""
+
+#: src/Module/BaseAdmin.php:104
+msgid "Server Blocklist"
+msgstr ""
+
+#: src/Module/BaseAdmin.php:111
+msgid "Diagnostics"
+msgstr ""
+
+#: src/Module/BaseAdmin.php:112
+msgid "PHP Info"
+msgstr ""
+
+#: src/Module/BaseAdmin.php:113
+msgid "probe address"
+msgstr ""
+
+#: src/Module/BaseAdmin.php:114
+msgid "check webfinger"
+msgstr ""
+
+#: src/Module/BaseAdmin.php:115
+msgid "Item Source"
+msgstr ""
+
+#: src/Module/BaseAdmin.php:116
+msgid "Babel"
+msgstr ""
+
+#: src/Module/BaseAdmin.php:117
+msgid "ActivityPub Conversion"
+msgstr ""
+
+#: src/Module/BaseAdmin.php:126
+msgid "Addon Features"
+msgstr ""
+
+#: src/Module/BaseAdmin.php:127
+msgid "User registrations waiting for confirmation"
+msgstr ""
+
+#: src/Module/BaseProfile.php:55 src/Module/Contact.php:939
+msgid "Profile Details"
+msgstr ""
+
+#: src/Module/BaseProfile.php:113
+msgid "Only You Can See This"
+msgstr ""
+
+#: src/Module/BaseProfile.php:132 src/Module/BaseProfile.php:135
+msgid "Tips for New Members"
+msgstr ""
+
+#: src/Module/BaseSearch.php:69
+#, php-format
+msgid "People Search - %s"
+msgstr ""
+
+#: src/Module/BaseSearch.php:79
+#, php-format
+msgid "Forum Search - %s"
+msgstr ""
+
+#: src/Module/BaseSettings.php:43
+msgid "Account"
+msgstr ""
+
+#: src/Module/BaseSettings.php:50 src/Module/Security/TwoFactor/Verify.php:80
 #: src/Module/Settings/TwoFactor/Index.php:105
 msgid "Two-factor authentication"
 msgstr ""
 
-#: src/Module/Security/TwoFactor/Verify.php:81
-msgid ""
-"<p>Open the two-factor authentication app on your device to get an "
-"authentication code and verify your identity.</p>"
+#: src/Module/BaseSettings.php:73
+msgid "Display"
 msgstr ""
 
-#: src/Module/Security/TwoFactor/Verify.php:84
-#: src/Module/Security/TwoFactor/Recovery.php:85
+#: src/Module/BaseSettings.php:94 src/Module/Settings/Delegation.php:171
+msgid "Manage Accounts"
+msgstr ""
+
+#: src/Module/BaseSettings.php:101
+msgid "Connected apps"
+msgstr ""
+
+#: src/Module/BaseSettings.php:108 src/Module/Settings/UserExport.php:66
+msgid "Export personal data"
+msgstr ""
+
+#: src/Module/BaseSettings.php:115
+msgid "Remove account"
+msgstr ""
+
+#: src/Module/Bookmarklet.php:56
+msgid "This page is missing a url parameter."
+msgstr ""
+
+#: src/Module/Bookmarklet.php:78
+msgid "The post was created"
+msgstr ""
+
+#: src/Module/Contact/Advanced.php:92
+msgid "Contact update failed."
+msgstr ""
+
+#: src/Module/Contact/Advanced.php:109
+msgid ""
+"<strong>WARNING: This is highly advanced</strong> and if you enter incorrect "
+"information your communications with this contact may stop working."
+msgstr ""
+
+#: src/Module/Contact/Advanced.php:110
+msgid ""
+"Please use your browser 'Back' button <strong>now</strong> if you are "
+"uncertain what to do on this page."
+msgstr ""
+
+#: src/Module/Contact/Advanced.php:130
+msgid "Return to contact editor"
+msgstr ""
+
+#: src/Module/Contact/Advanced.php:135
+msgid "Account Nickname"
+msgstr ""
+
+#: src/Module/Contact/Advanced.php:136
+msgid "@Tagname - overrides Name/Nickname"
+msgstr ""
+
+#: src/Module/Contact/Advanced.php:137
+msgid "Account URL"
+msgstr ""
+
+#: src/Module/Contact/Advanced.php:138
+msgid "Account URL Alias"
+msgstr ""
+
+#: src/Module/Contact/Advanced.php:139
+msgid "Friend Request URL"
+msgstr ""
+
+#: src/Module/Contact/Advanced.php:140
+msgid "Friend Confirm URL"
+msgstr ""
+
+#: src/Module/Contact/Advanced.php:141
+msgid "Notification Endpoint URL"
+msgstr ""
+
+#: src/Module/Contact/Advanced.php:142
+msgid "Poll/Feed URL"
+msgstr ""
+
+#: src/Module/Contact/Advanced.php:143
+msgid "New photo from this URL"
+msgstr ""
+
+#: src/Module/Contact/Contacts.php:31 src/Module/Conversation/Network.php:174
+msgid "Invalid contact."
+msgstr ""
+
+#: src/Module/Contact/Contacts.php:54
+msgid "No known contacts."
+msgstr ""
+
+#: src/Module/Contact/Contacts.php:68 src/Module/Profile/Common.php:99
+msgid "No common contacts."
+msgstr ""
+
+#: src/Module/Contact/Contacts.php:80 src/Module/Profile/Contacts.php:97
+#, php-format
+msgid "Follower (%s)"
+msgid_plural "Followers (%s)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/Module/Contact/Contacts.php:84 src/Module/Profile/Contacts.php:100
+#, php-format
+msgid "Following (%s)"
+msgid_plural "Following (%s)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/Module/Contact/Contacts.php:88 src/Module/Profile/Contacts.php:103
+#, php-format
+msgid "Mutual friend (%s)"
+msgid_plural "Mutual friends (%s)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/Module/Contact/Contacts.php:90 src/Module/Profile/Contacts.php:105
+#, php-format
+msgid "These contacts both follow and are followed by <strong>%s</strong>."
+msgstr ""
+
+#: src/Module/Contact/Contacts.php:96 src/Module/Profile/Common.php:87
+#, php-format
+msgid "Common contact (%s)"
+msgid_plural "Common contacts (%s)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/Module/Contact/Contacts.php:98 src/Module/Profile/Common.php:89
 #, php-format
 msgid ""
-"Don’t have your phone? <a href=\"%s\">Enter a two-factor recovery code</a>"
+"Both <strong>%s</strong> and yourself have publicly interacted with these "
+"contacts (follow, comment or likes on public posts)."
 msgstr ""
 
-#: src/Module/Security/TwoFactor/Verify.php:85
-#: src/Module/Settings/TwoFactor/Verify.php:141
-msgid "Please enter a code from your authentication app"
-msgstr ""
-
-#: src/Module/Security/TwoFactor/Verify.php:86
-msgid "Verify code and complete login"
-msgstr ""
-
-#: src/Module/Security/TwoFactor/Recovery.php:60
+#: src/Module/Contact/Contacts.php:104 src/Module/Profile/Contacts.php:111
 #, php-format
-msgid "Remaining recovery codes: %d"
+msgid "Contact (%s)"
+msgid_plural "Contacts (%s)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/Module/Contact/Poke.php:113
+msgid "Error while sending poke, please retry."
 msgstr ""
 
-#: src/Module/Security/TwoFactor/Recovery.php:83
-msgid "Two-factor recovery"
+#: src/Module/Contact/Poke.php:126 src/Module/Search/Acl.php:55
+msgid "You must be logged in to use this module."
 msgstr ""
 
-#: src/Module/Security/TwoFactor/Recovery.php:84
-msgid ""
-"<p>You can enter one of your one-time recovery codes in case you lost access "
-"to your mobile device.</p>"
+#: src/Module/Contact/Poke.php:149
+msgid "Poke/Prod"
 msgstr ""
 
-#: src/Module/Security/TwoFactor/Recovery.php:86
-msgid "Please enter a recovery code"
+#: src/Module/Contact/Poke.php:150
+msgid "poke, prod or do other things to somebody"
 msgstr ""
 
-#: src/Module/Security/TwoFactor/Recovery.php:87
-msgid "Submit recovery code and complete login"
+#: src/Module/Contact/Poke.php:152
+msgid "Choose what you wish to do to recipient"
 msgstr ""
 
-#: src/Module/Security/Login.php:101
-msgid "Create a New Account"
+#: src/Module/Contact/Poke.php:153
+msgid "Make this post private"
 msgstr ""
 
-#: src/Module/Security/Login.php:102 src/Module/Register.php:155
-#: src/Content/Nav.php:206
-msgid "Register"
-msgstr ""
-
-#: src/Module/Security/Login.php:126
-msgid "Your OpenID: "
-msgstr ""
-
-#: src/Module/Security/Login.php:129
-msgid ""
-"Please enter your username and password to add the OpenID to your existing "
-"account."
-msgstr ""
-
-#: src/Module/Security/Login.php:131
-msgid "Or login using OpenID: "
-msgstr ""
-
-#: src/Module/Security/Login.php:141 src/Content/Nav.php:169
-msgid "Logout"
-msgstr ""
-
-#: src/Module/Security/Login.php:142 src/Module/Bookmarklet.php:46
-#: src/Content/Nav.php:171
-msgid "Login"
-msgstr ""
-
-#: src/Module/Security/Login.php:145
-msgid "Password: "
-msgstr ""
-
-#: src/Module/Security/Login.php:146
-msgid "Remember me"
-msgstr ""
-
-#: src/Module/Security/Login.php:155
-msgid "Forgot your password?"
-msgstr ""
-
-#: src/Module/Security/Login.php:158
-msgid "Website Terms of Service"
-msgstr ""
-
-#: src/Module/Security/Login.php:159
-msgid "terms of service"
-msgstr ""
-
-#: src/Module/Security/Login.php:161
-msgid "Website Privacy Policy"
-msgstr ""
-
-#: src/Module/Security/Login.php:162
-msgid "privacy policy"
-msgstr ""
-
-#: src/Module/Security/OpenID.php:54
-msgid "OpenID protocol error. No ID returned"
-msgstr ""
-
-#: src/Module/Security/OpenID.php:92
-msgid ""
-"Account not found. Please login to your existing account to add the OpenID "
-"to it."
-msgstr ""
-
-#: src/Module/Security/OpenID.php:94
-msgid ""
-"Account not found. Please register a new account or login to your existing "
-"account to add the OpenID to it."
-msgstr ""
-
-#: src/Module/Debug/Localtime.php:36 src/Model/Event.php:50
-#: src/Model/Event.php:861
-msgid "l F d, Y \\@ g:i A"
-msgstr ""
-
-#: src/Module/Debug/Localtime.php:49
-msgid "Time Conversion"
-msgstr ""
-
-#: src/Module/Debug/Localtime.php:50
-msgid ""
-"Friendica provides this service for sharing events with other networks and "
-"friends in unknown timezones."
-msgstr ""
-
-#: src/Module/Debug/Localtime.php:51
+#: src/Module/Contact.php:94
 #, php-format
-msgid "UTC time: %s"
+msgid "%d contact edited."
+msgid_plural "%d contacts edited."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/Module/Contact.php:121
+msgid "Could not access contact record."
 msgstr ""
 
-#: src/Module/Debug/Localtime.php:54
+#: src/Module/Contact.php:419
+msgid "Contact has been blocked"
+msgstr ""
+
+#: src/Module/Contact.php:419
+msgid "Contact has been unblocked"
+msgstr ""
+
+#: src/Module/Contact.php:429
+msgid "Contact has been ignored"
+msgstr ""
+
+#: src/Module/Contact.php:429
+msgid "Contact has been unignored"
+msgstr ""
+
+#: src/Module/Contact.php:439
+msgid "Contact has been archived"
+msgstr ""
+
+#: src/Module/Contact.php:439
+msgid "Contact has been unarchived"
+msgstr ""
+
+#: src/Module/Contact.php:452
+msgid "Drop contact"
+msgstr ""
+
+#: src/Module/Contact.php:455 src/Module/Contact.php:879
+msgid "Do you really want to delete this contact?"
+msgstr ""
+
+#: src/Module/Contact.php:468
+msgid "Contact has been removed."
+msgstr ""
+
+#: src/Module/Contact.php:496
 #, php-format
-msgid "Current timezone: %s"
+msgid "You are mutual friends with %s"
 msgstr ""
 
-#: src/Module/Debug/Localtime.php:58
+#: src/Module/Contact.php:500
 #, php-format
-msgid "Converted localtime: %s"
+msgid "You are sharing with %s"
 msgstr ""
 
-#: src/Module/Debug/Localtime.php:62
-msgid "Please select your timezone:"
+#: src/Module/Contact.php:504
+#, php-format
+msgid "%s is sharing with you"
+msgstr ""
+
+#: src/Module/Contact.php:528
+msgid "Private communications are not available for this contact."
+msgstr ""
+
+#: src/Module/Contact.php:530
+msgid "Never"
+msgstr ""
+
+#: src/Module/Contact.php:533
+msgid "(Update was not successful)"
+msgstr ""
+
+#: src/Module/Contact.php:533
+msgid "(Update was successful)"
+msgstr ""
+
+#: src/Module/Contact.php:535 src/Module/Contact.php:1136
+msgid "Suggest friends"
+msgstr ""
+
+#: src/Module/Contact.php:539
+#, php-format
+msgid "Network type: %s"
+msgstr ""
+
+#: src/Module/Contact.php:544
+msgid "Communications lost with this contact!"
+msgstr ""
+
+#: src/Module/Contact.php:550
+msgid "Fetch further information for feeds"
+msgstr ""
+
+#: src/Module/Contact.php:552
+msgid ""
+"Fetch information like preview pictures, title and teaser from the feed "
+"item. You can activate this if the feed doesn't contain much text. Keywords "
+"are taken from the meta header in the feed item and are posted as hash tags."
+msgstr ""
+
+#: src/Module/Contact.php:555
+msgid "Fetch information"
+msgstr ""
+
+#: src/Module/Contact.php:556
+msgid "Fetch keywords"
+msgstr ""
+
+#: src/Module/Contact.php:557
+msgid "Fetch information and keywords"
+msgstr ""
+
+#: src/Module/Contact.php:569 src/Module/Contact.php:573
+#: src/Module/Contact.php:576 src/Module/Contact.php:580
+msgid "No mirroring"
+msgstr ""
+
+#: src/Module/Contact.php:570
+msgid "Mirror as forwarded posting"
+msgstr ""
+
+#: src/Module/Contact.php:571 src/Module/Contact.php:577
+#: src/Module/Contact.php:581
+msgid "Mirror as my own posting"
+msgstr ""
+
+#: src/Module/Contact.php:574 src/Module/Contact.php:578
+msgid "Native reshare"
+msgstr ""
+
+#: src/Module/Contact.php:593
+msgid "Contact Information / Notes"
+msgstr ""
+
+#: src/Module/Contact.php:594
+msgid "Contact Settings"
+msgstr ""
+
+#: src/Module/Contact.php:602
+msgid "Contact"
+msgstr ""
+
+#: src/Module/Contact.php:606
+msgid "Their personal note"
+msgstr ""
+
+#: src/Module/Contact.php:608
+msgid "Edit contact notes"
+msgstr ""
+
+#: src/Module/Contact.php:611 src/Module/Contact.php:1104
+#, php-format
+msgid "Visit %s's profile [%s]"
+msgstr ""
+
+#: src/Module/Contact.php:612
+msgid "Block/Unblock contact"
+msgstr ""
+
+#: src/Module/Contact.php:613
+msgid "Ignore contact"
+msgstr ""
+
+#: src/Module/Contact.php:614
+msgid "View conversations"
+msgstr ""
+
+#: src/Module/Contact.php:619
+msgid "Last update:"
+msgstr ""
+
+#: src/Module/Contact.php:621
+msgid "Update public posts"
+msgstr ""
+
+#: src/Module/Contact.php:623 src/Module/Contact.php:1146
+msgid "Update now"
+msgstr ""
+
+#: src/Module/Contact.php:626 src/Module/Contact.php:884
+#: src/Module/Contact.php:1173
+msgid "Unignore"
+msgstr ""
+
+#: src/Module/Contact.php:630
+msgid "Currently blocked"
+msgstr ""
+
+#: src/Module/Contact.php:631
+msgid "Currently ignored"
+msgstr ""
+
+#: src/Module/Contact.php:632
+msgid "Currently archived"
+msgstr ""
+
+#: src/Module/Contact.php:633
+msgid "Awaiting connection acknowledge"
+msgstr ""
+
+#: src/Module/Contact.php:634 src/Module/Notifications/Introductions.php:177
+msgid "Hide this contact from others"
+msgstr ""
+
+#: src/Module/Contact.php:634
+msgid ""
+"Replies/likes to your public posts <strong>may</strong> still be visible"
+msgstr ""
+
+#: src/Module/Contact.php:635
+msgid "Notification for new posts"
+msgstr ""
+
+#: src/Module/Contact.php:635
+msgid "Send a notification of every new post of this contact"
+msgstr ""
+
+#: src/Module/Contact.php:637
+msgid "Keyword Deny List"
+msgstr ""
+
+#: src/Module/Contact.php:637
+msgid ""
+"Comma separated list of keywords that should not be converted to hashtags, "
+"when \"Fetch information and keywords\" is selected"
+msgstr ""
+
+#: src/Module/Contact.php:653 src/Module/Settings/TwoFactor/Index.php:127
+msgid "Actions"
+msgstr ""
+
+#: src/Module/Contact.php:660
+msgid "Mirror postings from this contact"
+msgstr ""
+
+#: src/Module/Contact.php:662
+msgid ""
+"Mark this contact as remote_self, this will cause friendica to repost new "
+"entries from this contact."
+msgstr ""
+
+#: src/Module/Contact.php:794
+msgid "Show all contacts"
+msgstr ""
+
+#: src/Module/Contact.php:802
+msgid "Only show pending contacts"
+msgstr ""
+
+#: src/Module/Contact.php:810
+msgid "Only show blocked contacts"
+msgstr ""
+
+#: src/Module/Contact.php:815 src/Module/Contact.php:862
+msgid "Ignored"
+msgstr ""
+
+#: src/Module/Contact.php:818
+msgid "Only show ignored contacts"
+msgstr ""
+
+#: src/Module/Contact.php:823 src/Module/Contact.php:863
+msgid "Archived"
+msgstr ""
+
+#: src/Module/Contact.php:826
+msgid "Only show archived contacts"
+msgstr ""
+
+#: src/Module/Contact.php:831 src/Module/Contact.php:861
+msgid "Hidden"
+msgstr ""
+
+#: src/Module/Contact.php:834
+msgid "Only show hidden contacts"
+msgstr ""
+
+#: src/Module/Contact.php:842
+msgid "Organize your contact groups"
+msgstr ""
+
+#: src/Module/Contact.php:874
+msgid "Search your contacts"
+msgstr ""
+
+#: src/Module/Contact.php:875 src/Module/Search/Index.php:192
+#, php-format
+msgid "Results for: %s"
+msgstr ""
+
+#: src/Module/Contact.php:885 src/Module/Contact.php:1182
+msgid "Archive"
+msgstr ""
+
+#: src/Module/Contact.php:885 src/Module/Contact.php:1182
+msgid "Unarchive"
+msgstr ""
+
+#: src/Module/Contact.php:888
+msgid "Batch Actions"
+msgstr ""
+
+#: src/Module/Contact.php:923
+msgid "Conversations started by this contact"
+msgstr ""
+
+#: src/Module/Contact.php:928
+msgid "Posts and Comments"
+msgstr ""
+
+#: src/Module/Contact.php:946
+msgid "View all known contacts"
+msgstr ""
+
+#: src/Module/Contact.php:956
+msgid "Advanced Contact Settings"
+msgstr ""
+
+#: src/Module/Contact.php:1063
+msgid "Mutual Friendship"
+msgstr ""
+
+#: src/Module/Contact.php:1067
+msgid "is a fan of yours"
+msgstr ""
+
+#: src/Module/Contact.php:1071
+msgid "you are a fan of"
+msgstr ""
+
+#: src/Module/Contact.php:1089
+msgid "Pending outgoing contact request"
+msgstr ""
+
+#: src/Module/Contact.php:1091
+msgid "Pending incoming contact request"
+msgstr ""
+
+#: src/Module/Contact.php:1156
+msgid "Refetch contact data"
+msgstr ""
+
+#: src/Module/Contact.php:1167
+msgid "Toggle Blocked status"
+msgstr ""
+
+#: src/Module/Contact.php:1175
+msgid "Toggle Ignored status"
+msgstr ""
+
+#: src/Module/Contact.php:1184
+msgid "Toggle Archive status"
+msgstr ""
+
+#: src/Module/Contact.php:1192
+msgid "Delete contact"
+msgstr ""
+
+#: src/Module/Conversation/Community.php:68
+msgid "Local Community"
+msgstr ""
+
+#: src/Module/Conversation/Community.php:71
+msgid "Posts from local users on this server"
+msgstr ""
+
+#: src/Module/Conversation/Community.php:79
+msgid "Global Community"
+msgstr ""
+
+#: src/Module/Conversation/Community.php:82
+msgid "Posts from users of the whole federated network"
+msgstr ""
+
+#: src/Module/Conversation/Community.php:115
+msgid "Own Contacts"
+msgstr ""
+
+#: src/Module/Conversation/Community.php:119
+msgid "Include"
+msgstr ""
+
+#: src/Module/Conversation/Community.php:120
+msgid "Hide"
+msgstr ""
+
+#: src/Module/Conversation/Community.php:148 src/Module/Search/Index.php:139
+#: src/Module/Search/Index.php:179
+msgid "No results."
+msgstr ""
+
+#: src/Module/Conversation/Community.php:173
+msgid ""
+"This community stream shows all public posts received by this node. They may "
+"not reflect the opinions of this node’s users."
+msgstr ""
+
+#: src/Module/Conversation/Community.php:211
+msgid "Community option not available."
+msgstr ""
+
+#: src/Module/Conversation/Community.php:227
+msgid "Not available."
+msgstr ""
+
+#: src/Module/Conversation/Network.php:160
+msgid "No such group"
+msgstr ""
+
+#: src/Module/Conversation/Network.php:164
+#, php-format
+msgid "Group: %s"
+msgstr ""
+
+#: src/Module/Conversation/Network.php:240
+msgid "Latest Activity"
+msgstr ""
+
+#: src/Module/Conversation/Network.php:243
+msgid "Sort by latest activity"
+msgstr ""
+
+#: src/Module/Conversation/Network.php:248
+msgid "Latest Posts"
+msgstr ""
+
+#: src/Module/Conversation/Network.php:251
+msgid "Sort by post received date"
+msgstr ""
+
+#: src/Module/Conversation/Network.php:256
+#: src/Module/Settings/Profile/Index.php:242
+msgid "Personal"
+msgstr ""
+
+#: src/Module/Conversation/Network.php:259
+msgid "Posts that mention or involve you"
+msgstr ""
+
+#: src/Module/Conversation/Network.php:264
+msgid "Starred"
+msgstr ""
+
+#: src/Module/Conversation/Network.php:267
+msgid "Favourite Posts"
+msgstr ""
+
+#: src/Module/Credits.php:44
+msgid "Credits"
+msgstr ""
+
+#: src/Module/Credits.php:45
+msgid ""
+"Friendica is a community project, that would not be possible without the "
+"help of many people. Here is a list of those who have contributed to the "
+"code or the translation of Friendica. Thank you all!"
+msgstr ""
+
+#: src/Module/Debug/ActivityPubConversion.php:58
+msgid "Formatted"
+msgstr ""
+
+#: src/Module/Debug/ActivityPubConversion.php:62
+msgid "Source"
+msgstr ""
+
+#: src/Module/Debug/ActivityPubConversion.php:70
+msgid "Activity"
+msgstr ""
+
+#: src/Module/Debug/ActivityPubConversion.php:118
+msgid "Object data"
+msgstr ""
+
+#: src/Module/Debug/ActivityPubConversion.php:125
+msgid "Result Item"
+msgstr ""
+
+#: src/Module/Debug/ActivityPubConversion.php:138
+msgid "Source activity"
 msgstr ""
 
 #: src/Module/Debug/Babel.php:54
@@ -4979,10 +8043,6 @@ msgstr ""
 msgid "BBCode"
 msgstr ""
 
-#: src/Module/Debug/Babel.php:306 src/Content/ContactSelector.php:103
-msgid "Diaspora"
-msgstr ""
-
 #: src/Module/Debug/Babel.php:307
 msgid "Markdown"
 msgstr ""
@@ -4995,34 +8055,6 @@ msgstr ""
 msgid "Twitter Source"
 msgstr ""
 
-#: src/Module/Debug/WebFinger.php:37 src/Module/Debug/Probe.php:38
-msgid "Only logged in users are permitted to perform a probing."
-msgstr ""
-
-#: src/Module/Debug/ActivityPubConversion.php:58
-msgid "Formatted"
-msgstr ""
-
-#: src/Module/Debug/ActivityPubConversion.php:62
-msgid "Source"
-msgstr ""
-
-#: src/Module/Debug/ActivityPubConversion.php:70
-msgid "Activity"
-msgstr ""
-
-#: src/Module/Debug/ActivityPubConversion.php:118
-msgid "Object data"
-msgstr ""
-
-#: src/Module/Debug/ActivityPubConversion.php:125
-msgid "Result Item"
-msgstr ""
-
-#: src/Module/Debug/ActivityPubConversion.php:138
-msgid "Source activity"
-msgstr ""
-
 #: src/Module/Debug/Feed.php:38 src/Module/Filer/SaveTag.php:38
 #: src/Module/Settings/Profile/Index.php:158
 msgid "You must be logged in to use this module"
@@ -5032,354 +8064,130 @@ msgstr ""
 msgid "Source URL"
 msgstr ""
 
+#: src/Module/Debug/Localtime.php:49
+msgid "Time Conversion"
+msgstr ""
+
+#: src/Module/Debug/Localtime.php:50
+msgid ""
+"Friendica provides this service for sharing events with other networks and "
+"friends in unknown timezones."
+msgstr ""
+
+#: src/Module/Debug/Localtime.php:51
+#, php-format
+msgid "UTC time: %s"
+msgstr ""
+
+#: src/Module/Debug/Localtime.php:54
+#, php-format
+msgid "Current timezone: %s"
+msgstr ""
+
+#: src/Module/Debug/Localtime.php:58
+#, php-format
+msgid "Converted localtime: %s"
+msgstr ""
+
+#: src/Module/Debug/Localtime.php:62
+msgid "Please select your timezone:"
+msgstr ""
+
+#: src/Module/Debug/Probe.php:38 src/Module/Debug/WebFinger.php:37
+msgid "Only logged in users are permitted to perform a probing."
+msgstr ""
+
 #: src/Module/Debug/Probe.php:54
 msgid "Lookup address"
 msgstr ""
 
-#: src/Module/Profile/Common.php:87 src/Module/Contact/Contacts.php:96
-#, php-format
-msgid "Common contact (%s)"
-msgid_plural "Common contacts (%s)"
-msgstr[0] ""
-msgstr[1] ""
+#: src/Module/Delegation.php:147
+msgid "Switch between your accounts"
+msgstr ""
 
-#: src/Module/Profile/Common.php:89 src/Module/Contact/Contacts.php:98
+#: src/Module/Delegation.php:148
+msgid "Manage your accounts"
+msgstr ""
+
+#: src/Module/Delegation.php:149
+msgid ""
+"Toggle between different identities or community/group pages which share "
+"your account details or which you have been granted \"manage\" permissions"
+msgstr ""
+
+#: src/Module/Delegation.php:150
+msgid "Select an identity to manage: "
+msgstr ""
+
+#: src/Module/Directory.php:77
+msgid "No entries (some entries may be hidden)."
+msgstr ""
+
+#: src/Module/Directory.php:99
+msgid "Find on this site"
+msgstr ""
+
+#: src/Module/Directory.php:101
+msgid "Results for:"
+msgstr ""
+
+#: src/Module/Directory.php:103
+msgid "Site Directory"
+msgstr ""
+
+#: src/Module/Filer/RemoveTag.php:63
+msgid "Item was not removed"
+msgstr ""
+
+#: src/Module/Filer/RemoveTag.php:66
+msgid "Item was not deleted"
+msgstr ""
+
+#: src/Module/Filer/SaveTag.php:65
+msgid "- select -"
+msgstr ""
+
+#: src/Module/Friendica.php:61
+msgid "Installed addons/apps:"
+msgstr ""
+
+#: src/Module/Friendica.php:66
+msgid "No installed addons/apps"
+msgstr ""
+
+#: src/Module/Friendica.php:71
+#, php-format
+msgid "Read about the <a href=\"%1$s/tos\">Terms of Service</a> of this node."
+msgstr ""
+
+#: src/Module/Friendica.php:78
+msgid "On this server the following remote servers are blocked."
+msgstr ""
+
+#: src/Module/Friendica.php:96
 #, php-format
 msgid ""
-"Both <strong>%s</strong> and yourself have publicly interacted with these "
-"contacts (follow, comment or likes on public posts)."
+"This is Friendica, version %s that is running at the web location %s. The "
+"database version is %s, the post update version is %s."
 msgstr ""
 
-#: src/Module/Profile/Common.php:99 src/Module/Contact/Contacts.php:68
-msgid "No common contacts."
-msgstr ""
-
-#: src/Module/Profile/Status.php:64 src/Module/Profile/Status.php:67
-#: src/Module/Profile/Profile.php:321 src/Module/Profile/Profile.php:324
-#: src/Protocol/OStatus.php:1261 src/Protocol/Feed.php:999
-#, php-format
-msgid "%s's timeline"
-msgstr ""
-
-#: src/Module/Profile/Status.php:65 src/Module/Profile/Profile.php:322
-#: src/Protocol/OStatus.php:1265 src/Protocol/Feed.php:1003
-#, php-format
-msgid "%s's posts"
-msgstr ""
-
-#: src/Module/Profile/Status.php:66 src/Module/Profile/Profile.php:323
-#: src/Protocol/OStatus.php:1268 src/Protocol/Feed.php:1006
-#, php-format
-msgid "%s's comments"
-msgstr ""
-
-#: src/Module/Profile/Contacts.php:97 src/Module/Contact/Contacts.php:80
-#, php-format
-msgid "Follower (%s)"
-msgid_plural "Followers (%s)"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/Module/Profile/Contacts.php:100 src/Module/Contact/Contacts.php:84
-#, php-format
-msgid "Following (%s)"
-msgid_plural "Following (%s)"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/Module/Profile/Contacts.php:103 src/Module/Contact/Contacts.php:88
-#, php-format
-msgid "Mutual friend (%s)"
-msgid_plural "Mutual friends (%s)"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/Module/Profile/Contacts.php:105 src/Module/Contact/Contacts.php:90
-#, php-format
-msgid "These contacts both follow and are followed by <strong>%s</strong>."
-msgstr ""
-
-#: src/Module/Profile/Contacts.php:111 src/Module/Contact/Contacts.php:104
-#, php-format
-msgid "Contact (%s)"
-msgid_plural "Contacts (%s)"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/Module/Profile/Contacts.php:121
-msgid "No contacts."
-msgstr ""
-
-#: src/Module/Profile/Profile.php:135
-#, php-format
+#: src/Module/Friendica.php:101
 msgid ""
-"You're currently viewing your profile as <b>%s</b> <a href=\"%s\" class="
-"\"btn btn-sm pull-right\">Cancel</a>"
+"Please visit <a href=\"https://friendi.ca\">Friendi.ca</a> to learn more "
+"about the Friendica project."
 msgstr ""
 
-#: src/Module/Profile/Profile.php:149
-msgid "Member since:"
+#: src/Module/Friendica.php:102
+msgid "Bug reports and issues: please visit"
 msgstr ""
 
-#: src/Module/Profile/Profile.php:155
-msgid "j F, Y"
+#: src/Module/Friendica.php:102
+msgid "the bugtracker at github"
 msgstr ""
 
-#: src/Module/Profile/Profile.php:156
-msgid "j F"
-msgstr ""
-
-#: src/Module/Profile/Profile.php:164 src/Util/Temporal.php:163
-msgid "Birthday:"
-msgstr ""
-
-#: src/Module/Profile/Profile.php:167 src/Module/Settings/Profile/Index.php:260
-#: src/Util/Temporal.php:165
-msgid "Age: "
-msgstr ""
-
-#: src/Module/Profile/Profile.php:167 src/Module/Settings/Profile/Index.php:260
-#: src/Util/Temporal.php:165
-#, php-format
-msgid "%d year old"
-msgid_plural "%d years old"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/Module/Profile/Profile.php:176 src/Module/Contact.php:648
-#: src/Model/Profile.php:363
-msgid "XMPP:"
-msgstr ""
-
-#: src/Module/Profile/Profile.php:180 src/Module/Directory.php:161
-#: src/Model/Profile.php:361
-msgid "Homepage:"
-msgstr ""
-
-#: src/Module/Profile/Profile.php:229
-msgid "Forums:"
-msgstr ""
-
-#: src/Module/Profile/Profile.php:241
-msgid "View profile as:"
-msgstr ""
-
-#: src/Module/Profile/Profile.php:251 src/Module/Profile/Profile.php:253
-#: src/Model/Profile.php:346
-msgid "Edit profile"
-msgstr ""
-
-#: src/Module/Profile/Profile.php:258
-msgid "View as"
-msgstr ""
-
-#: src/Module/Register.php:69
-msgid "Only parent users can create additional accounts."
-msgstr ""
-
-#: src/Module/Register.php:101
+#: src/Module/Friendica.php:103
 msgid ""
-"You may (optionally) fill in this form via OpenID by supplying your OpenID "
-"and clicking \"Register\"."
-msgstr ""
-
-#: src/Module/Register.php:102
-msgid ""
-"If you are not familiar with OpenID, please leave that field blank and fill "
-"in the rest of the items."
-msgstr ""
-
-#: src/Module/Register.php:103
-msgid "Your OpenID (optional): "
-msgstr ""
-
-#: src/Module/Register.php:112
-msgid "Include your profile in member directory?"
-msgstr ""
-
-#: src/Module/Register.php:135
-msgid "Note for the admin"
-msgstr ""
-
-#: src/Module/Register.php:135
-msgid "Leave a message for the admin, why you want to join this node"
-msgstr ""
-
-#: src/Module/Register.php:136
-msgid "Membership on this site is by invitation only."
-msgstr ""
-
-#: src/Module/Register.php:137
-msgid "Your invitation code: "
-msgstr ""
-
-#: src/Module/Register.php:139 src/Module/Admin/Site.php:600
-msgid "Registration"
-msgstr ""
-
-#: src/Module/Register.php:145
-msgid "Your Full Name (e.g. Joe Smith, real or real-looking): "
-msgstr ""
-
-#: src/Module/Register.php:146
-msgid ""
-"Your Email Address: (Initial information will be send there, so this has to "
-"be an existing address.)"
-msgstr ""
-
-#: src/Module/Register.php:147
-msgid "Please repeat your e-mail address:"
-msgstr ""
-
-#: src/Module/Register.php:149
-msgid "Leave empty for an auto generated password."
-msgstr ""
-
-#: src/Module/Register.php:151
-#, php-format
-msgid ""
-"Choose a profile nickname. This must begin with a text character. Your "
-"profile address on this site will then be \"<strong>nickname@%s</strong>\"."
-msgstr ""
-
-#: src/Module/Register.php:152
-msgid "Choose a nickname: "
-msgstr ""
-
-#: src/Module/Register.php:161
-msgid "Import your profile to this friendica instance"
-msgstr ""
-
-#: src/Module/Register.php:163 src/Module/BaseAdmin.php:95
-#: src/Module/Tos.php:84 src/Module/Admin/Tos.php:59 src/Content/Nav.php:256
-msgid "Terms of Service"
-msgstr ""
-
-#: src/Module/Register.php:168
-msgid "Note: This node explicitly contains adult content"
-msgstr ""
-
-#: src/Module/Register.php:170 src/Module/Settings/Delegation.php:155
-msgid "Parent Password:"
-msgstr ""
-
-#: src/Module/Register.php:170 src/Module/Settings/Delegation.php:155
-msgid ""
-"Please enter the password of the parent account to legitimize your request."
-msgstr ""
-
-#: src/Module/Register.php:199
-msgid "Password doesn't match."
-msgstr ""
-
-#: src/Module/Register.php:205
-msgid "Please enter your password."
-msgstr ""
-
-#: src/Module/Register.php:247
-msgid "You have entered too much information."
-msgstr ""
-
-#: src/Module/Register.php:271
-msgid "Please enter the identical mail address in the second field."
-msgstr ""
-
-#: src/Module/Register.php:298
-msgid "The additional account was created."
-msgstr ""
-
-#: src/Module/Register.php:323
-msgid ""
-"Registration successful. Please check your email for further instructions."
-msgstr ""
-
-#: src/Module/Register.php:327
-#, php-format
-msgid ""
-"Failed to send email message. Here your accout details:<br> login: %s<br> "
-"password: %s<br><br>You can change your password after login."
-msgstr ""
-
-#: src/Module/Register.php:333
-msgid "Registration successful."
-msgstr ""
-
-#: src/Module/Register.php:338 src/Module/Register.php:345
-msgid "Your registration can not be processed."
-msgstr ""
-
-#: src/Module/Register.php:344
-msgid "You have to leave a request note for the admin."
-msgstr ""
-
-#: src/Module/Register.php:390
-msgid "Your registration is pending approval by the site owner."
-msgstr ""
-
-#: src/Module/Special/HTTPException.php:49
-msgid "Bad Request"
-msgstr ""
-
-#: src/Module/Special/HTTPException.php:50
-msgid "Unauthorized"
-msgstr ""
-
-#: src/Module/Special/HTTPException.php:51
-msgid "Forbidden"
-msgstr ""
-
-#: src/Module/Special/HTTPException.php:52
-msgid "Not Found"
-msgstr ""
-
-#: src/Module/Special/HTTPException.php:53
-msgid "Internal Server Error"
-msgstr ""
-
-#: src/Module/Special/HTTPException.php:54
-msgid "Service Unavailable"
-msgstr ""
-
-#: src/Module/Special/HTTPException.php:61
-msgid ""
-"The server cannot or will not process the request due to an apparent client "
-"error."
-msgstr ""
-
-#: src/Module/Special/HTTPException.php:62
-msgid "Authentication is required and has failed or has not yet been provided."
-msgstr ""
-
-#: src/Module/Special/HTTPException.php:63
-msgid ""
-"The request was valid, but the server is refusing action. The user might not "
-"have the necessary permissions for a resource, or may need an account."
-msgstr ""
-
-#: src/Module/Special/HTTPException.php:64
-msgid ""
-"The requested resource could not be found but may be available in the future."
-msgstr ""
-
-#: src/Module/Special/HTTPException.php:65
-msgid ""
-"An unexpected condition was encountered and no more specific message is "
-"suitable."
-msgstr ""
-
-#: src/Module/Special/HTTPException.php:66
-msgid ""
-"The server is currently unavailable (because it is overloaded or down for "
-"maintenance). Please try again later."
-msgstr ""
-
-#: src/Module/Special/HTTPException.php:72 src/Content/Nav.php:94
-msgid "Go back"
-msgstr ""
-
-#: src/Module/Home.php:54
-#, php-format
-msgid "Welcome to %s"
+"Suggestions, praise, etc. - please email \"info\" at \"friendi - dot - ca"
 msgstr ""
 
 #: src/Module/FriendSuggest.php:65
@@ -5399,15 +8207,109 @@ msgstr ""
 msgid "Suggest a friend for %s"
 msgstr ""
 
-#: src/Module/Credits.php:44
-msgid "Credits"
+#: src/Module/Group.php:61
+msgid "Could not create group."
 msgstr ""
 
-#: src/Module/Credits.php:45
-msgid ""
-"Friendica is a community project, that would not be possible without the "
-"help of many people. Here is a list of those who have contributed to the "
-"code or the translation of Friendica. Thank you all!"
+#: src/Module/Group.php:72 src/Module/Group.php:214 src/Module/Group.php:238
+msgid "Group not found."
+msgstr ""
+
+#: src/Module/Group.php:78
+msgid "Group name was not changed."
+msgstr ""
+
+#: src/Module/Group.php:100
+msgid "Unknown group."
+msgstr ""
+
+#: src/Module/Group.php:109
+msgid "Contact is deleted."
+msgstr ""
+
+#: src/Module/Group.php:115
+msgid "Unable to add the contact to the group."
+msgstr ""
+
+#: src/Module/Group.php:118
+msgid "Contact successfully added to group."
+msgstr ""
+
+#: src/Module/Group.php:122
+msgid "Unable to remove the contact from the group."
+msgstr ""
+
+#: src/Module/Group.php:125
+msgid "Contact successfully removed from group."
+msgstr ""
+
+#: src/Module/Group.php:128
+msgid "Unknown group command."
+msgstr ""
+
+#: src/Module/Group.php:131
+msgid "Bad request."
+msgstr ""
+
+#: src/Module/Group.php:170
+msgid "Save Group"
+msgstr ""
+
+#: src/Module/Group.php:171
+msgid "Filter"
+msgstr ""
+
+#: src/Module/Group.php:177
+msgid "Create a group of contacts/friends."
+msgstr ""
+
+#: src/Module/Group.php:219
+msgid "Unable to remove group."
+msgstr ""
+
+#: src/Module/Group.php:270
+msgid "Delete Group"
+msgstr ""
+
+#: src/Module/Group.php:280
+msgid "Edit Group Name"
+msgstr ""
+
+#: src/Module/Group.php:290
+msgid "Members"
+msgstr ""
+
+#: src/Module/Group.php:293
+msgid "Group is empty"
+msgstr ""
+
+#: src/Module/Group.php:306
+msgid "Remove contact from group"
+msgstr ""
+
+#: src/Module/Group.php:326
+msgid "Click on a contact to add or remove."
+msgstr ""
+
+#: src/Module/Group.php:340
+msgid "Add contact to group"
+msgstr ""
+
+#: src/Module/Help.php:62
+msgid "Help:"
+msgstr ""
+
+#: src/Module/Home.php:54
+#, php-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: src/Module/HoverCard.php:47
+msgid "No profile"
+msgstr ""
+
+#: src/Module/HTTPException/MethodNotAllowed.php:32
+msgid "Method Not Allowed."
 msgstr ""
 
 #: src/Module/Install.php:177
@@ -5435,28 +8337,8 @@ msgstr ""
 msgid "Check again"
 msgstr ""
 
-#: src/Module/Install.php:204 src/Module/Admin/Site.php:530
-msgid "No SSL policy, links will track page SSL state"
-msgstr ""
-
-#: src/Module/Install.php:205 src/Module/Admin/Site.php:531
-msgid "Force all links to use SSL"
-msgstr ""
-
-#: src/Module/Install.php:206 src/Module/Admin/Site.php:532
-msgid "Self-signed certificate, use SSL for local links only (discouraged)"
-msgstr ""
-
 #: src/Module/Install.php:212
 msgid "Base settings"
-msgstr ""
-
-#: src/Module/Install.php:214 src/Module/Admin/Site.php:624
-msgid "SSL link policy"
-msgstr ""
-
-#: src/Module/Install.php:216 src/Module/Admin/Site.php:624
-msgid "Determines whether generated links should be forced to use SSL"
 msgstr ""
 
 #: src/Module/Install.php:219
@@ -5590,922 +8472,6 @@ msgid ""
 "administrator email. This will allow you to enter the site admin panel."
 msgstr ""
 
-#: src/Module/Filer/SaveTag.php:65
-msgid "- select -"
-msgstr ""
-
-#: src/Module/Filer/RemoveTag.php:63
-msgid "Item was not removed"
-msgstr ""
-
-#: src/Module/Filer/RemoveTag.php:66
-msgid "Item was not deleted"
-msgstr ""
-
-#: src/Module/PermissionTooltip.php:24
-#, php-format
-msgid "Wrong type \"%s\", expected one of: %s"
-msgstr ""
-
-#: src/Module/PermissionTooltip.php:37
-msgid "Model not found"
-msgstr ""
-
-#: src/Module/PermissionTooltip.php:59
-msgid "Remote privacy information not available."
-msgstr ""
-
-#: src/Module/PermissionTooltip.php:70
-msgid "Visible to:"
-msgstr ""
-
-#: src/Module/Delegation.php:147
-msgid "Switch between your accounts"
-msgstr ""
-
-#: src/Module/Delegation.php:148
-msgid "Manage your accounts"
-msgstr ""
-
-#: src/Module/Delegation.php:149
-msgid ""
-"Toggle between different identities or community/group pages which share "
-"your account details or which you have been granted \"manage\" permissions"
-msgstr ""
-
-#: src/Module/Delegation.php:150
-msgid "Select an identity to manage: "
-msgstr ""
-
-#: src/Module/Conversation/Community.php:68
-msgid "Local Community"
-msgstr ""
-
-#: src/Module/Conversation/Community.php:71
-msgid "Posts from local users on this server"
-msgstr ""
-
-#: src/Module/Conversation/Community.php:79
-msgid "Global Community"
-msgstr ""
-
-#: src/Module/Conversation/Community.php:82
-msgid "Posts from users of the whole federated network"
-msgstr ""
-
-#: src/Module/Conversation/Community.php:115
-msgid "Own Contacts"
-msgstr ""
-
-#: src/Module/Conversation/Community.php:119
-msgid "Include"
-msgstr ""
-
-#: src/Module/Conversation/Community.php:120
-msgid "Hide"
-msgstr ""
-
-#: src/Module/Conversation/Community.php:148 src/Module/Search/Index.php:139
-#: src/Module/Search/Index.php:179
-msgid "No results."
-msgstr ""
-
-#: src/Module/Conversation/Community.php:173
-msgid ""
-"This community stream shows all public posts received by this node. They may "
-"not reflect the opinions of this node’s users."
-msgstr ""
-
-#: src/Module/Conversation/Community.php:211
-msgid "Community option not available."
-msgstr ""
-
-#: src/Module/Conversation/Community.php:227
-msgid "Not available."
-msgstr ""
-
-#: src/Module/Conversation/Network.php:160
-msgid "No such group"
-msgstr ""
-
-#: src/Module/Conversation/Network.php:164
-#, php-format
-msgid "Group: %s"
-msgstr ""
-
-#: src/Module/Conversation/Network.php:174 src/Module/Contact/Contacts.php:31
-msgid "Invalid contact."
-msgstr ""
-
-#: src/Module/Conversation/Network.php:240
-msgid "Latest Activity"
-msgstr ""
-
-#: src/Module/Conversation/Network.php:243
-msgid "Sort by latest activity"
-msgstr ""
-
-#: src/Module/Conversation/Network.php:248
-msgid "Latest Posts"
-msgstr ""
-
-#: src/Module/Conversation/Network.php:251
-msgid "Sort by post received date"
-msgstr ""
-
-#: src/Module/Conversation/Network.php:256
-#: src/Module/Settings/Profile/Index.php:242
-msgid "Personal"
-msgstr ""
-
-#: src/Module/Conversation/Network.php:259
-msgid "Posts that mention or involve you"
-msgstr ""
-
-#: src/Module/Conversation/Network.php:264
-msgid "Starred"
-msgstr ""
-
-#: src/Module/Conversation/Network.php:267
-msgid "Favourite Posts"
-msgstr ""
-
-#: src/Module/Welcome.php:44
-msgid "Welcome to Friendica"
-msgstr ""
-
-#: src/Module/Welcome.php:45
-msgid "New Member Checklist"
-msgstr ""
-
-#: src/Module/Welcome.php:46
-msgid ""
-"We would like to offer some tips and links to help make your experience "
-"enjoyable. Click any item to visit the relevant page. A link to this page "
-"will be visible from your home page for two weeks after your initial "
-"registration and then will quietly disappear."
-msgstr ""
-
-#: src/Module/Welcome.php:48
-msgid "Getting Started"
-msgstr ""
-
-#: src/Module/Welcome.php:49
-msgid "Friendica Walk-Through"
-msgstr ""
-
-#: src/Module/Welcome.php:50
-msgid ""
-"On your <em>Quick Start</em> page - find a brief introduction to your "
-"profile and network tabs, make some new connections, and find some groups to "
-"join."
-msgstr ""
-
-#: src/Module/Welcome.php:53
-msgid "Go to Your Settings"
-msgstr ""
-
-#: src/Module/Welcome.php:54
-msgid ""
-"On your <em>Settings</em> page -  change your initial password. Also make a "
-"note of your Identity Address. This looks just like an email address - and "
-"will be useful in making friends on the free social web."
-msgstr ""
-
-#: src/Module/Welcome.php:55
-msgid ""
-"Review the other settings, particularly the privacy settings. An unpublished "
-"directory listing is like having an unlisted phone number. In general, you "
-"should probably publish your listing - unless all of your friends and "
-"potential friends know exactly how to find you."
-msgstr ""
-
-#: src/Module/Welcome.php:58 src/Module/Settings/Profile/Index.php:248
-msgid "Upload Profile Photo"
-msgstr ""
-
-#: src/Module/Welcome.php:59
-msgid ""
-"Upload a profile photo if you have not done so already. Studies have shown "
-"that people with real photos of themselves are ten times more likely to make "
-"friends than people who do not."
-msgstr ""
-
-#: src/Module/Welcome.php:60
-msgid "Edit Your Profile"
-msgstr ""
-
-#: src/Module/Welcome.php:61
-msgid ""
-"Edit your <strong>default</strong> profile to your liking. Review the "
-"settings for hiding your list of friends and hiding the profile from unknown "
-"visitors."
-msgstr ""
-
-#: src/Module/Welcome.php:62
-msgid "Profile Keywords"
-msgstr ""
-
-#: src/Module/Welcome.php:63
-msgid ""
-"Set some public keywords for your profile which describe your interests. We "
-"may be able to find other people with similar interests and suggest "
-"friendships."
-msgstr ""
-
-#: src/Module/Welcome.php:65
-msgid "Connecting"
-msgstr ""
-
-#: src/Module/Welcome.php:67
-msgid "Importing Emails"
-msgstr ""
-
-#: src/Module/Welcome.php:68
-msgid ""
-"Enter your email access information on your Connector Settings page if you "
-"wish to import and interact with friends or mailing lists from your email "
-"INBOX"
-msgstr ""
-
-#: src/Module/Welcome.php:69
-msgid "Go to Your Contacts Page"
-msgstr ""
-
-#: src/Module/Welcome.php:70
-msgid ""
-"Your Contacts page is your gateway to managing friendships and connecting "
-"with friends on other networks. Typically you enter their address or site "
-"URL in the <em>Add New Contact</em> dialog."
-msgstr ""
-
-#: src/Module/Welcome.php:71
-msgid "Go to Your Site's Directory"
-msgstr ""
-
-#: src/Module/Welcome.php:72
-msgid ""
-"The Directory page lets you find other people in this network or other "
-"federated sites. Look for a <em>Connect</em> or <em>Follow</em> link on "
-"their profile page. Provide your own Identity Address if requested."
-msgstr ""
-
-#: src/Module/Welcome.php:73
-msgid "Finding New People"
-msgstr ""
-
-#: src/Module/Welcome.php:74
-msgid ""
-"On the side panel of the Contacts page are several tools to find new "
-"friends. We can match people by interest, look up people by name or "
-"interest, and provide suggestions based on network relationships. On a brand "
-"new site, friend suggestions will usually begin to be populated within 24 "
-"hours."
-msgstr ""
-
-#: src/Module/Welcome.php:76 src/Module/Contact.php:839 src/Model/Group.php:535
-#: src/Content/Widget.php:213
-msgid "Groups"
-msgstr ""
-
-#: src/Module/Welcome.php:77
-msgid "Group Your Contacts"
-msgstr ""
-
-#: src/Module/Welcome.php:78
-msgid ""
-"Once you have made some friends, organize them into private conversation "
-"groups from the sidebar of your Contacts page and then you can interact with "
-"each group privately on your Network page."
-msgstr ""
-
-#: src/Module/Welcome.php:80
-msgid "Why Aren't My Posts Public?"
-msgstr ""
-
-#: src/Module/Welcome.php:81
-msgid ""
-"Friendica respects your privacy. By default, your posts will only show up to "
-"people you've added as friends. For more information, see the help section "
-"from the link above."
-msgstr ""
-
-#: src/Module/Welcome.php:83
-msgid "Getting Help"
-msgstr ""
-
-#: src/Module/Welcome.php:84
-msgid "Go to the Help Section"
-msgstr ""
-
-#: src/Module/Welcome.php:85
-msgid ""
-"Our <strong>help</strong> pages may be consulted for detail on other program "
-"features and resources."
-msgstr ""
-
-#: src/Module/Bookmarklet.php:56
-msgid "This page is missing a url parameter."
-msgstr ""
-
-#: src/Module/Bookmarklet.php:78
-msgid "The post was created"
-msgstr ""
-
-#: src/Module/BaseAdmin.php:63
-msgid "You don't have access to administration pages."
-msgstr ""
-
-#: src/Module/BaseAdmin.php:67
-msgid ""
-"Submanaged account can't access the administration pages. Please log back in "
-"as the main account."
-msgstr ""
-
-#: src/Module/BaseAdmin.php:85 src/Content/Nav.php:253
-msgid "Information"
-msgstr ""
-
-#: src/Module/BaseAdmin.php:86
-msgid "Overview"
-msgstr ""
-
-#: src/Module/BaseAdmin.php:87 src/Module/Admin/Federation.php:141
-msgid "Federation Statistics"
-msgstr ""
-
-#: src/Module/BaseAdmin.php:89
-msgid "Configuration"
-msgstr ""
-
-#: src/Module/BaseAdmin.php:90 src/Module/Admin/Site.php:596
-msgid "Site"
-msgstr ""
-
-#: src/Module/BaseAdmin.php:91 src/Module/Admin/Users/Index.php:150
-#: src/Module/Admin/Users/Index.php:160
-msgid "Users"
-msgstr ""
-
-#: src/Module/BaseAdmin.php:92 src/Module/Admin/Addons/Details.php:112
-#: src/Module/Admin/Addons/Index.php:68 src/Module/BaseSettings.php:87
-msgid "Addons"
-msgstr ""
-
-#: src/Module/BaseAdmin.php:93 src/Module/Admin/Themes/Details.php:91
-#: src/Module/Admin/Themes/Index.php:112
-msgid "Themes"
-msgstr ""
-
-#: src/Module/BaseAdmin.php:94 src/Module/BaseSettings.php:65
-msgid "Additional features"
-msgstr ""
-
-#: src/Module/BaseAdmin.php:97
-msgid "Database"
-msgstr ""
-
-#: src/Module/BaseAdmin.php:98
-msgid "DB updates"
-msgstr ""
-
-#: src/Module/BaseAdmin.php:99
-msgid "Inspect Deferred Workers"
-msgstr ""
-
-#: src/Module/BaseAdmin.php:100
-msgid "Inspect worker Queue"
-msgstr ""
-
-#: src/Module/BaseAdmin.php:102
-msgid "Tools"
-msgstr ""
-
-#: src/Module/BaseAdmin.php:103
-msgid "Contact Blocklist"
-msgstr ""
-
-#: src/Module/BaseAdmin.php:104
-msgid "Server Blocklist"
-msgstr ""
-
-#: src/Module/BaseAdmin.php:105 src/Module/Admin/Item/Delete.php:66
-msgid "Delete Item"
-msgstr ""
-
-#: src/Module/BaseAdmin.php:107 src/Module/BaseAdmin.php:108
-#: src/Module/Admin/Logs/Settings.php:81
-msgid "Logs"
-msgstr ""
-
-#: src/Module/BaseAdmin.php:109 src/Module/Admin/Logs/View.php:65
-msgid "View Logs"
-msgstr ""
-
-#: src/Module/BaseAdmin.php:111
-msgid "Diagnostics"
-msgstr ""
-
-#: src/Module/BaseAdmin.php:112
-msgid "PHP Info"
-msgstr ""
-
-#: src/Module/BaseAdmin.php:113
-msgid "probe address"
-msgstr ""
-
-#: src/Module/BaseAdmin.php:114
-msgid "check webfinger"
-msgstr ""
-
-#: src/Module/BaseAdmin.php:115
-msgid "Item Source"
-msgstr ""
-
-#: src/Module/BaseAdmin.php:116
-msgid "Babel"
-msgstr ""
-
-#: src/Module/BaseAdmin.php:117
-msgid "ActivityPub Conversion"
-msgstr ""
-
-#: src/Module/BaseAdmin.php:125 src/Content/Nav.php:289
-msgid "Admin"
-msgstr ""
-
-#: src/Module/BaseAdmin.php:126
-msgid "Addon Features"
-msgstr ""
-
-#: src/Module/BaseAdmin.php:127
-msgid "User registrations waiting for confirmation"
-msgstr ""
-
-#: src/Module/Contact.php:94
-#, php-format
-msgid "%d contact edited."
-msgid_plural "%d contacts edited."
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/Module/Contact.php:121
-msgid "Could not access contact record."
-msgstr ""
-
-#: src/Module/Contact.php:340 src/Model/Profile.php:439
-#: src/Content/Text/HTML.php:881
-msgid "Follow"
-msgstr ""
-
-#: src/Module/Contact.php:342 src/Model/Profile.php:441
-msgid "Unfollow"
-msgstr ""
-
-#: src/Module/Contact.php:400 src/Module/Api/Twitter/ContactEndpoint.php:65
-msgid "Contact not found"
-msgstr ""
-
-#: src/Module/Contact.php:419
-msgid "Contact has been blocked"
-msgstr ""
-
-#: src/Module/Contact.php:419
-msgid "Contact has been unblocked"
-msgstr ""
-
-#: src/Module/Contact.php:429
-msgid "Contact has been ignored"
-msgstr ""
-
-#: src/Module/Contact.php:429
-msgid "Contact has been unignored"
-msgstr ""
-
-#: src/Module/Contact.php:439
-msgid "Contact has been archived"
-msgstr ""
-
-#: src/Module/Contact.php:439
-msgid "Contact has been unarchived"
-msgstr ""
-
-#: src/Module/Contact.php:452
-msgid "Drop contact"
-msgstr ""
-
-#: src/Module/Contact.php:455 src/Module/Contact.php:879
-msgid "Do you really want to delete this contact?"
-msgstr ""
-
-#: src/Module/Contact.php:468
-msgid "Contact has been removed."
-msgstr ""
-
-#: src/Module/Contact.php:496
-#, php-format
-msgid "You are mutual friends with %s"
-msgstr ""
-
-#: src/Module/Contact.php:500
-#, php-format
-msgid "You are sharing with %s"
-msgstr ""
-
-#: src/Module/Contact.php:504
-#, php-format
-msgid "%s is sharing with you"
-msgstr ""
-
-#: src/Module/Contact.php:528
-msgid "Private communications are not available for this contact."
-msgstr ""
-
-#: src/Module/Contact.php:530
-msgid "Never"
-msgstr ""
-
-#: src/Module/Contact.php:533
-msgid "(Update was not successful)"
-msgstr ""
-
-#: src/Module/Contact.php:533
-msgid "(Update was successful)"
-msgstr ""
-
-#: src/Module/Contact.php:535 src/Module/Contact.php:1136
-msgid "Suggest friends"
-msgstr ""
-
-#: src/Module/Contact.php:539
-#, php-format
-msgid "Network type: %s"
-msgstr ""
-
-#: src/Module/Contact.php:544
-msgid "Communications lost with this contact!"
-msgstr ""
-
-#: src/Module/Contact.php:550
-msgid "Fetch further information for feeds"
-msgstr ""
-
-#: src/Module/Contact.php:552
-msgid ""
-"Fetch information like preview pictures, title and teaser from the feed "
-"item. You can activate this if the feed doesn't contain much text. Keywords "
-"are taken from the meta header in the feed item and are posted as hash tags."
-msgstr ""
-
-#: src/Module/Contact.php:554 src/Module/Admin/Site.php:702
-#: src/Module/Admin/Site.php:712 src/Module/Settings/TwoFactor/Index.php:113
-msgid "Disabled"
-msgstr ""
-
-#: src/Module/Contact.php:555
-msgid "Fetch information"
-msgstr ""
-
-#: src/Module/Contact.php:556
-msgid "Fetch keywords"
-msgstr ""
-
-#: src/Module/Contact.php:557
-msgid "Fetch information and keywords"
-msgstr ""
-
-#: src/Module/Contact.php:569 src/Module/Contact.php:573
-#: src/Module/Contact.php:576 src/Module/Contact.php:580
-msgid "No mirroring"
-msgstr ""
-
-#: src/Module/Contact.php:570
-msgid "Mirror as forwarded posting"
-msgstr ""
-
-#: src/Module/Contact.php:571 src/Module/Contact.php:577
-#: src/Module/Contact.php:581
-msgid "Mirror as my own posting"
-msgstr ""
-
-#: src/Module/Contact.php:574 src/Module/Contact.php:578
-msgid "Native reshare"
-msgstr ""
-
-#: src/Module/Contact.php:593
-msgid "Contact Information / Notes"
-msgstr ""
-
-#: src/Module/Contact.php:594
-msgid "Contact Settings"
-msgstr ""
-
-#: src/Module/Contact.php:602
-msgid "Contact"
-msgstr ""
-
-#: src/Module/Contact.php:606
-msgid "Their personal note"
-msgstr ""
-
-#: src/Module/Contact.php:608
-msgid "Edit contact notes"
-msgstr ""
-
-#: src/Module/Contact.php:611 src/Module/Contact.php:1104
-#, php-format
-msgid "Visit %s's profile [%s]"
-msgstr ""
-
-#: src/Module/Contact.php:612
-msgid "Block/Unblock contact"
-msgstr ""
-
-#: src/Module/Contact.php:613
-msgid "Ignore contact"
-msgstr ""
-
-#: src/Module/Contact.php:614
-msgid "View conversations"
-msgstr ""
-
-#: src/Module/Contact.php:619
-msgid "Last update:"
-msgstr ""
-
-#: src/Module/Contact.php:621
-msgid "Update public posts"
-msgstr ""
-
-#: src/Module/Contact.php:623 src/Module/Contact.php:1146
-msgid "Update now"
-msgstr ""
-
-#: src/Module/Contact.php:625 src/Module/Contact.php:883
-#: src/Module/Contact.php:1165 src/Module/Admin/Users/Index.php:156
-#: src/Module/Admin/Users/Blocked.php:142
-#: src/Module/Admin/Blocklist/Contact.php:85
-msgid "Unblock"
-msgstr ""
-
-#: src/Module/Contact.php:626 src/Module/Contact.php:884
-#: src/Module/Contact.php:1173
-msgid "Unignore"
-msgstr ""
-
-#: src/Module/Contact.php:630
-msgid "Currently blocked"
-msgstr ""
-
-#: src/Module/Contact.php:631
-msgid "Currently ignored"
-msgstr ""
-
-#: src/Module/Contact.php:632
-msgid "Currently archived"
-msgstr ""
-
-#: src/Module/Contact.php:633
-msgid "Awaiting connection acknowledge"
-msgstr ""
-
-#: src/Module/Contact.php:634
-msgid ""
-"Replies/likes to your public posts <strong>may</strong> still be visible"
-msgstr ""
-
-#: src/Module/Contact.php:635
-msgid "Notification for new posts"
-msgstr ""
-
-#: src/Module/Contact.php:635
-msgid "Send a notification of every new post of this contact"
-msgstr ""
-
-#: src/Module/Contact.php:637
-msgid "Keyword Deny List"
-msgstr ""
-
-#: src/Module/Contact.php:637
-msgid ""
-"Comma separated list of keywords that should not be converted to hashtags, "
-"when \"Fetch information and keywords\" is selected"
-msgstr ""
-
-#: src/Module/Contact.php:653 src/Module/Settings/TwoFactor/Index.php:127
-msgid "Actions"
-msgstr ""
-
-#: src/Module/Contact.php:660
-msgid "Mirror postings from this contact"
-msgstr ""
-
-#: src/Module/Contact.php:662
-msgid ""
-"Mark this contact as remote_self, this will cause friendica to repost new "
-"entries from this contact."
-msgstr ""
-
-#: src/Module/Contact.php:791 src/Module/Group.php:292
-#: src/Content/Widget.php:246
-msgid "All Contacts"
-msgstr ""
-
-#: src/Module/Contact.php:794
-msgid "Show all contacts"
-msgstr ""
-
-#: src/Module/Contact.php:799 src/Module/Contact.php:859
-#: src/Module/Admin/BaseUsers.php:66
-msgid "Pending"
-msgstr ""
-
-#: src/Module/Contact.php:802
-msgid "Only show pending contacts"
-msgstr ""
-
-#: src/Module/Contact.php:807 src/Module/Contact.php:860
-#: src/Module/Admin/BaseUsers.php:74
-msgid "Blocked"
-msgstr ""
-
-#: src/Module/Contact.php:810
-msgid "Only show blocked contacts"
-msgstr ""
-
-#: src/Module/Contact.php:815 src/Module/Contact.php:862
-msgid "Ignored"
-msgstr ""
-
-#: src/Module/Contact.php:818
-msgid "Only show ignored contacts"
-msgstr ""
-
-#: src/Module/Contact.php:823 src/Module/Contact.php:863
-msgid "Archived"
-msgstr ""
-
-#: src/Module/Contact.php:826
-msgid "Only show archived contacts"
-msgstr ""
-
-#: src/Module/Contact.php:831 src/Module/Contact.php:861
-msgid "Hidden"
-msgstr ""
-
-#: src/Module/Contact.php:834
-msgid "Only show hidden contacts"
-msgstr ""
-
-#: src/Module/Contact.php:842
-msgid "Organize your contact groups"
-msgstr ""
-
-#: src/Module/Contact.php:853 src/Content/Widget.php:238 src/BaseModule.php:189
-msgid "Following"
-msgstr ""
-
-#: src/Module/Contact.php:854 src/Content/Widget.php:239 src/BaseModule.php:194
-msgid "Mutual friends"
-msgstr ""
-
-#: src/Module/Contact.php:874
-msgid "Search your contacts"
-msgstr ""
-
-#: src/Module/Contact.php:875 src/Module/Search/Index.php:192
-#, php-format
-msgid "Results for: %s"
-msgstr ""
-
-#: src/Module/Contact.php:885 src/Module/Contact.php:1182
-msgid "Archive"
-msgstr ""
-
-#: src/Module/Contact.php:885 src/Module/Contact.php:1182
-msgid "Unarchive"
-msgstr ""
-
-#: src/Module/Contact.php:888
-msgid "Batch Actions"
-msgstr ""
-
-#: src/Module/Contact.php:923
-msgid "Conversations started by this contact"
-msgstr ""
-
-#: src/Module/Contact.php:928
-msgid "Posts and Comments"
-msgstr ""
-
-#: src/Module/Contact.php:939 src/Module/BaseProfile.php:55
-msgid "Profile Details"
-msgstr ""
-
-#: src/Module/Contact.php:946
-msgid "View all known contacts"
-msgstr ""
-
-#: src/Module/Contact.php:956
-msgid "Advanced Contact Settings"
-msgstr ""
-
-#: src/Module/Contact.php:1063
-msgid "Mutual Friendship"
-msgstr ""
-
-#: src/Module/Contact.php:1067
-msgid "is a fan of yours"
-msgstr ""
-
-#: src/Module/Contact.php:1071
-msgid "you are a fan of"
-msgstr ""
-
-#: src/Module/Contact.php:1089
-msgid "Pending outgoing contact request"
-msgstr ""
-
-#: src/Module/Contact.php:1091
-msgid "Pending incoming contact request"
-msgstr ""
-
-#: src/Module/Contact.php:1156
-msgid "Refetch contact data"
-msgstr ""
-
-#: src/Module/Contact.php:1167
-msgid "Toggle Blocked status"
-msgstr ""
-
-#: src/Module/Contact.php:1175
-msgid "Toggle Ignored status"
-msgstr ""
-
-#: src/Module/Contact.php:1184
-msgid "Toggle Archive status"
-msgstr ""
-
-#: src/Module/Contact.php:1192
-msgid "Delete contact"
-msgstr ""
-
-#: src/Module/Tos.php:46 src/Module/Tos.php:88
-msgid ""
-"At the time of registration, and for providing communications between the "
-"user account and their contacts, the user has to provide a display name (pen "
-"name), an username (nickname) and a working email address. The names will be "
-"accessible on the profile page of the account by any visitor of the page, "
-"even if other profile details are not displayed. The email address will only "
-"be used to send the user notifications about interactions, but wont be "
-"visibly displayed. The listing of an account in the node's user directory or "
-"the global user directory is optional and can be controlled in the user "
-"settings, it is not necessary for communication."
-msgstr ""
-
-#: src/Module/Tos.php:47 src/Module/Tos.php:89
-msgid ""
-"This data is required for communication and is passed on to the nodes of the "
-"communication partners and is stored there. Users can enter additional "
-"private data that may be transmitted to the communication partners accounts."
-msgstr ""
-
-#: src/Module/Tos.php:48 src/Module/Tos.php:90
-#, php-format
-msgid ""
-"At any point in time a logged in user can export their account data from the "
-"<a href=\"%1$s/settings/userexport\">account settings</a>. If the user wants "
-"to delete their account they can do so at <a href=\"%1$s/removeme\">%1$s/"
-"removeme</a>. The deletion of the account will be permanent. Deletion of the "
-"data will also be requested from the nodes of the communication partners."
-msgstr ""
-
-#: src/Module/Tos.php:51 src/Module/Tos.php:87
-msgid "Privacy Statement"
-msgstr ""
-
-#: src/Module/Help.php:62
-msgid "Help:"
-msgstr ""
-
-#: src/Module/HTTPException/MethodNotAllowed.php:32
-msgid "Method Not Allowed."
-msgstr ""
-
-#: src/Module/Api/Twitter/ContactEndpoint.php:135
-msgid "Profile not found"
-msgstr ""
-
-#: src/Module/Api/Mastodon/Unimplemented.php:42
-#, php-format
-msgid "API endpoint \"%s\" is not implemented"
-msgstr ""
-
-#: src/Module/Api/Mastodon/Unimplemented.php:43
-msgid ""
-"The API endpoint is currently not implemented but might be in the future."
-msgstr ""
-
 #: src/Module/Invite.php:55
 msgid "Total invitation limit exceeded."
 msgstr ""
@@ -6610,1937 +8576,6 @@ msgid ""
 "important, please visit http://friendi.ca"
 msgstr ""
 
-#: src/Module/BaseSearch.php:69
-#, php-format
-msgid "People Search - %s"
-msgstr ""
-
-#: src/Module/BaseSearch.php:79
-#, php-format
-msgid "Forum Search - %s"
-msgstr ""
-
-#: src/Module/Admin/Themes/Details.php:46
-#: src/Module/Admin/Addons/Details.php:88
-msgid "Disable"
-msgstr ""
-
-#: src/Module/Admin/Themes/Details.php:49
-#: src/Module/Admin/Addons/Details.php:91
-msgid "Enable"
-msgstr ""
-
-#: src/Module/Admin/Themes/Details.php:57 src/Module/Admin/Themes/Index.php:65
-#, php-format
-msgid "Theme %s disabled."
-msgstr ""
-
-#: src/Module/Admin/Themes/Details.php:59 src/Module/Admin/Themes/Index.php:67
-#, php-format
-msgid "Theme %s successfully enabled."
-msgstr ""
-
-#: src/Module/Admin/Themes/Details.php:61 src/Module/Admin/Themes/Index.php:69
-#, php-format
-msgid "Theme %s failed to install."
-msgstr ""
-
-#: src/Module/Admin/Themes/Details.php:83
-msgid "Screenshot"
-msgstr ""
-
-#: src/Module/Admin/Themes/Details.php:90 src/Module/Admin/Themes/Index.php:111
-#: src/Module/Admin/Queue.php:72 src/Module/Admin/Federation.php:140
-#: src/Module/Admin/Logs/View.php:64 src/Module/Admin/Logs/Settings.php:80
-#: src/Module/Admin/Site.php:595 src/Module/Admin/Summary.php:230
-#: src/Module/Admin/Users/Create.php:61 src/Module/Admin/Users/Pending.php:101
-#: src/Module/Admin/Users/Index.php:149 src/Module/Admin/Users/Active.php:136
-#: src/Module/Admin/Users/Blocked.php:137 src/Module/Admin/Users/Deleted.php:85
-#: src/Module/Admin/Tos.php:58 src/Module/Admin/Blocklist/Server.php:88
-#: src/Module/Admin/Blocklist/Contact.php:78
-#: src/Module/Admin/Item/Delete.php:65 src/Module/Admin/Addons/Details.php:111
-#: src/Module/Admin/Addons/Index.php:67
-msgid "Administration"
-msgstr ""
-
-#: src/Module/Admin/Themes/Details.php:92
-#: src/Module/Admin/Addons/Details.php:113
-msgid "Toggle"
-msgstr ""
-
-#: src/Module/Admin/Themes/Details.php:101
-#: src/Module/Admin/Addons/Details.php:121
-msgid "Author: "
-msgstr ""
-
-#: src/Module/Admin/Themes/Details.php:102
-#: src/Module/Admin/Addons/Details.php:122
-msgid "Maintainer: "
-msgstr ""
-
-#: src/Module/Admin/Themes/Embed.php:65
-msgid "Unknown theme."
-msgstr ""
-
-#: src/Module/Admin/Themes/Index.php:51
-msgid "Themes reloaded"
-msgstr ""
-
-#: src/Module/Admin/Themes/Index.php:114
-msgid "Reload active themes"
-msgstr ""
-
-#: src/Module/Admin/Themes/Index.php:119
-#, php-format
-msgid "No themes found on the system. They should be placed in %1$s"
-msgstr ""
-
-#: src/Module/Admin/Themes/Index.php:120
-msgid "[Experimental]"
-msgstr ""
-
-#: src/Module/Admin/Themes/Index.php:121
-msgid "[Unsupported]"
-msgstr ""
-
-#: src/Module/Admin/Features.php:76
-#, php-format
-msgid "Lock feature %s"
-msgstr ""
-
-#: src/Module/Admin/Features.php:85
-msgid "Manage Additional Features"
-msgstr ""
-
-#: src/Module/Admin/Queue.php:50
-msgid "Inspect Deferred Worker Queue"
-msgstr ""
-
-#: src/Module/Admin/Queue.php:51
-msgid ""
-"This page lists the deferred worker jobs. This are jobs that couldn't be "
-"executed at the first time."
-msgstr ""
-
-#: src/Module/Admin/Queue.php:54
-msgid "Inspect Worker Queue"
-msgstr ""
-
-#: src/Module/Admin/Queue.php:55
-msgid ""
-"This page lists the currently queued worker jobs. These jobs are handled by "
-"the worker cronjob you've set up during install."
-msgstr ""
-
-#: src/Module/Admin/Queue.php:75
-msgid "ID"
-msgstr ""
-
-#: src/Module/Admin/Queue.php:76
-msgid "Job Parameters"
-msgstr ""
-
-#: src/Module/Admin/Queue.php:77
-msgid "Created"
-msgstr ""
-
-#: src/Module/Admin/Queue.php:78
-msgid "Priority"
-msgstr ""
-
-#: src/Module/Admin/BaseUsers.php:50 src/Content/Widget.php:544
-msgid "All"
-msgstr ""
-
-#: src/Module/Admin/BaseUsers.php:53
-msgid "List of all users"
-msgstr ""
-
-#: src/Module/Admin/BaseUsers.php:58
-msgid "Active"
-msgstr ""
-
-#: src/Module/Admin/BaseUsers.php:61
-msgid "List of active accounts"
-msgstr ""
-
-#: src/Module/Admin/BaseUsers.php:69
-msgid "List of pending registrations"
-msgstr ""
-
-#: src/Module/Admin/BaseUsers.php:77
-msgid "List of blocked users"
-msgstr ""
-
-#: src/Module/Admin/BaseUsers.php:82
-msgid "Deleted"
-msgstr ""
-
-#: src/Module/Admin/BaseUsers.php:85
-msgid "List of pending user deletions"
-msgstr ""
-
-#: src/Module/Admin/BaseUsers.php:103
-msgid "Private Forum"
-msgstr ""
-
-#: src/Module/Admin/BaseUsers.php:110
-msgid "Relay"
-msgstr ""
-
-#: src/Module/Admin/DBSync.php:51
-msgid "Update has been marked successful"
-msgstr ""
-
-#: src/Module/Admin/DBSync.php:59
-#, php-format
-msgid "Database structure update %s was successfully applied."
-msgstr ""
-
-#: src/Module/Admin/DBSync.php:61
-#, php-format
-msgid "Executing of database structure update %s failed with error: %s"
-msgstr ""
-
-#: src/Module/Admin/DBSync.php:76
-#, php-format
-msgid "Executing %s failed with error: %s"
-msgstr ""
-
-#: src/Module/Admin/DBSync.php:78
-#, php-format
-msgid "Update %s was successfully applied."
-msgstr ""
-
-#: src/Module/Admin/DBSync.php:81
-#, php-format
-msgid "Update %s did not return a status. Unknown if it succeeded."
-msgstr ""
-
-#: src/Module/Admin/DBSync.php:84
-#, php-format
-msgid "There was no additional update function %s that needed to be called."
-msgstr ""
-
-#: src/Module/Admin/DBSync.php:106
-msgid "No failed updates."
-msgstr ""
-
-#: src/Module/Admin/DBSync.php:107
-msgid "Check database structure"
-msgstr ""
-
-#: src/Module/Admin/DBSync.php:112
-msgid "Failed Updates"
-msgstr ""
-
-#: src/Module/Admin/DBSync.php:113
-msgid ""
-"This does not include updates prior to 1139, which did not return a status."
-msgstr ""
-
-#: src/Module/Admin/DBSync.php:114
-msgid "Mark success (if update was manually applied)"
-msgstr ""
-
-#: src/Module/Admin/DBSync.php:115
-msgid "Attempt to execute this update step automatically"
-msgstr ""
-
-#: src/Module/Admin/Federation.php:53
-msgid "Other"
-msgstr ""
-
-#: src/Module/Admin/Federation.php:107 src/Module/Admin/Federation.php:267
-msgid "unknown"
-msgstr ""
-
-#: src/Module/Admin/Federation.php:135
-msgid ""
-"This page offers you some numbers to the known part of the federated social "
-"network your Friendica node is part of. These numbers are not complete but "
-"only reflect the part of the network your node is aware of."
-msgstr ""
-
-#: src/Module/Admin/Federation.php:145
-#, php-format
-msgid ""
-"Currently this node is aware of %d nodes with %d registered users from the "
-"following platforms:"
-msgstr ""
-
-#: src/Module/Admin/Logs/View.php:40
-#, php-format
-msgid ""
-"Error trying to open <strong>%1$s</strong> log file.\\r\\n<br/>Check to see "
-"if file %1$s exist and is readable."
-msgstr ""
-
-#: src/Module/Admin/Logs/View.php:44
-#, php-format
-msgid ""
-"Couldn't open <strong>%1$s</strong> log file.\\r\\n<br/>Check to see if file "
-"%1$s is readable."
-msgstr ""
-
-#: src/Module/Admin/Logs/Settings.php:48
-#, php-format
-msgid "The logfile '%s' is not writable. No logging possible"
-msgstr ""
-
-#: src/Module/Admin/Logs/Settings.php:72
-msgid "PHP log currently enabled."
-msgstr ""
-
-#: src/Module/Admin/Logs/Settings.php:74
-msgid "PHP log currently disabled."
-msgstr ""
-
-#: src/Module/Admin/Logs/Settings.php:83
-msgid "Clear"
-msgstr ""
-
-#: src/Module/Admin/Logs/Settings.php:87
-msgid "Enable Debugging"
-msgstr ""
-
-#: src/Module/Admin/Logs/Settings.php:88
-msgid "Log file"
-msgstr ""
-
-#: src/Module/Admin/Logs/Settings.php:88
-msgid ""
-"Must be writable by web server. Relative to your Friendica top-level "
-"directory."
-msgstr ""
-
-#: src/Module/Admin/Logs/Settings.php:89
-msgid "Log level"
-msgstr ""
-
-#: src/Module/Admin/Logs/Settings.php:91
-msgid "PHP logging"
-msgstr ""
-
-#: src/Module/Admin/Logs/Settings.php:92
-msgid ""
-"To temporarily enable logging of PHP errors and warnings you can prepend the "
-"following to the index.php file of your installation. The filename set in "
-"the 'error_log' line is relative to the friendica top-level directory and "
-"must be writeable by the web server. The option '1' for 'log_errors' and "
-"'display_errors' is to enable these options, set to '0' to disable them."
-msgstr ""
-
-#: src/Module/Admin/Site.php:69
-msgid "Can not parse base url. Must have at least <scheme>://<domain>"
-msgstr ""
-
-#: src/Module/Admin/Site.php:123
-msgid "Relocation started. Could take a while to complete."
-msgstr ""
-
-#: src/Module/Admin/Site.php:251
-msgid "Invalid storage backend setting value."
-msgstr ""
-
-#: src/Module/Admin/Site.php:457 src/Module/Settings/Display.php:134
-msgid "No special theme for mobile devices"
-msgstr ""
-
-#: src/Module/Admin/Site.php:474 src/Module/Settings/Display.php:144
-#, php-format
-msgid "%s - (Experimental)"
-msgstr ""
-
-#: src/Module/Admin/Site.php:486
-msgid "No community page for local users"
-msgstr ""
-
-#: src/Module/Admin/Site.php:487
-msgid "No community page"
-msgstr ""
-
-#: src/Module/Admin/Site.php:488
-msgid "Public postings from users of this site"
-msgstr ""
-
-#: src/Module/Admin/Site.php:489
-msgid "Public postings from the federated network"
-msgstr ""
-
-#: src/Module/Admin/Site.php:490
-msgid "Public postings from local users and the federated network"
-msgstr ""
-
-#: src/Module/Admin/Site.php:496
-msgid "Multi user instance"
-msgstr ""
-
-#: src/Module/Admin/Site.php:524
-msgid "Closed"
-msgstr ""
-
-#: src/Module/Admin/Site.php:525
-msgid "Requires approval"
-msgstr ""
-
-#: src/Module/Admin/Site.php:526
-msgid "Open"
-msgstr ""
-
-#: src/Module/Admin/Site.php:536
-msgid "Don't check"
-msgstr ""
-
-#: src/Module/Admin/Site.php:537
-msgid "check the stable version"
-msgstr ""
-
-#: src/Module/Admin/Site.php:538
-msgid "check the development version"
-msgstr ""
-
-#: src/Module/Admin/Site.php:542
-msgid "none"
-msgstr ""
-
-#: src/Module/Admin/Site.php:543
-msgid "Local contacts"
-msgstr ""
-
-#: src/Module/Admin/Site.php:544
-msgid "Interactors"
-msgstr ""
-
-#: src/Module/Admin/Site.php:557
-msgid "Database (legacy)"
-msgstr ""
-
-#: src/Module/Admin/Site.php:597
-msgid "General Information"
-msgstr ""
-
-#: src/Module/Admin/Site.php:599
-msgid "Republish users to directory"
-msgstr ""
-
-#: src/Module/Admin/Site.php:601
-msgid "File upload"
-msgstr ""
-
-#: src/Module/Admin/Site.php:602
-msgid "Policies"
-msgstr ""
-
-#: src/Module/Admin/Site.php:604
-msgid "Auto Discovered Contact Directory"
-msgstr ""
-
-#: src/Module/Admin/Site.php:605
-msgid "Performance"
-msgstr ""
-
-#: src/Module/Admin/Site.php:606
-msgid "Worker"
-msgstr ""
-
-#: src/Module/Admin/Site.php:607
-msgid "Message Relay"
-msgstr ""
-
-#: src/Module/Admin/Site.php:608
-msgid "Relocate Instance"
-msgstr ""
-
-#: src/Module/Admin/Site.php:609
-msgid ""
-"<strong>Warning!</strong> Advanced function. Could make this server "
-"unreachable."
-msgstr ""
-
-#: src/Module/Admin/Site.php:613
-msgid "Site name"
-msgstr ""
-
-#: src/Module/Admin/Site.php:614
-msgid "Sender Email"
-msgstr ""
-
-#: src/Module/Admin/Site.php:614
-msgid ""
-"The email address your server shall use to send notification emails from."
-msgstr ""
-
-#: src/Module/Admin/Site.php:615
-msgid "Name of the system actor"
-msgstr ""
-
-#: src/Module/Admin/Site.php:615
-msgid ""
-"Name of the internal system account that is used to perform ActivityPub "
-"requests. This must be an unused username. If set, this can't be changed "
-"again."
-msgstr ""
-
-#: src/Module/Admin/Site.php:616
-msgid "Banner/Logo"
-msgstr ""
-
-#: src/Module/Admin/Site.php:617
-msgid "Email Banner/Logo"
-msgstr ""
-
-#: src/Module/Admin/Site.php:618
-msgid "Shortcut icon"
-msgstr ""
-
-#: src/Module/Admin/Site.php:618
-msgid "Link to an icon that will be used for browsers."
-msgstr ""
-
-#: src/Module/Admin/Site.php:619
-msgid "Touch icon"
-msgstr ""
-
-#: src/Module/Admin/Site.php:619
-msgid "Link to an icon that will be used for tablets and mobiles."
-msgstr ""
-
-#: src/Module/Admin/Site.php:620
-msgid "Additional Info"
-msgstr ""
-
-#: src/Module/Admin/Site.php:620
-#, php-format
-msgid ""
-"For public servers: you can add additional information here that will be "
-"listed at %s/servers."
-msgstr ""
-
-#: src/Module/Admin/Site.php:621
-msgid "System language"
-msgstr ""
-
-#: src/Module/Admin/Site.php:622
-msgid "System theme"
-msgstr ""
-
-#: src/Module/Admin/Site.php:622
-msgid ""
-"Default system theme - may be over-ridden by user profiles - <a href=\"/"
-"admin/themes\" id=\"cnftheme\">Change default theme settings</a>"
-msgstr ""
-
-#: src/Module/Admin/Site.php:623
-msgid "Mobile system theme"
-msgstr ""
-
-#: src/Module/Admin/Site.php:623
-msgid "Theme for mobile devices"
-msgstr ""
-
-#: src/Module/Admin/Site.php:625
-msgid "Force SSL"
-msgstr ""
-
-#: src/Module/Admin/Site.php:625
-msgid ""
-"Force all Non-SSL requests to SSL - Attention: on some systems it could lead "
-"to endless loops."
-msgstr ""
-
-#: src/Module/Admin/Site.php:626
-msgid "Hide help entry from navigation menu"
-msgstr ""
-
-#: src/Module/Admin/Site.php:626
-msgid ""
-"Hides the menu entry for the Help pages from the navigation menu. You can "
-"still access it calling /help directly."
-msgstr ""
-
-#: src/Module/Admin/Site.php:627
-msgid "Single user instance"
-msgstr ""
-
-#: src/Module/Admin/Site.php:627
-msgid "Make this instance multi-user or single-user for the named user"
-msgstr ""
-
-#: src/Module/Admin/Site.php:629
-msgid "File storage backend"
-msgstr ""
-
-#: src/Module/Admin/Site.php:629
-msgid ""
-"The backend used to store uploaded data. If you change the storage backend, "
-"you can manually move the existing files. If you do not do so, the files "
-"uploaded before the change will still be available at the old backend. "
-"Please see <a href=\"/help/Settings#1_2_3_1\">the settings documentation</a> "
-"for more information about the choices and the moving procedure."
-msgstr ""
-
-#: src/Module/Admin/Site.php:631
-msgid "Maximum image size"
-msgstr ""
-
-#: src/Module/Admin/Site.php:631
-msgid ""
-"Maximum size in bytes of uploaded images. Default is 0, which means no "
-"limits."
-msgstr ""
-
-#: src/Module/Admin/Site.php:632
-msgid "Maximum image length"
-msgstr ""
-
-#: src/Module/Admin/Site.php:632
-msgid ""
-"Maximum length in pixels of the longest side of uploaded images. Default is "
-"-1, which means no limits."
-msgstr ""
-
-#: src/Module/Admin/Site.php:633
-msgid "JPEG image quality"
-msgstr ""
-
-#: src/Module/Admin/Site.php:633
-msgid ""
-"Uploaded JPEGS will be saved at this quality setting [0-100]. Default is "
-"100, which is full quality."
-msgstr ""
-
-#: src/Module/Admin/Site.php:635
-msgid "Register policy"
-msgstr ""
-
-#: src/Module/Admin/Site.php:636
-msgid "Maximum Daily Registrations"
-msgstr ""
-
-#: src/Module/Admin/Site.php:636
-msgid ""
-"If registration is permitted above, this sets the maximum number of new user "
-"registrations to accept per day.  If register is set to closed, this setting "
-"has no effect."
-msgstr ""
-
-#: src/Module/Admin/Site.php:637
-msgid "Register text"
-msgstr ""
-
-#: src/Module/Admin/Site.php:637
-msgid ""
-"Will be displayed prominently on the registration page. You can use BBCode "
-"here."
-msgstr ""
-
-#: src/Module/Admin/Site.php:638
-msgid "Forbidden Nicknames"
-msgstr ""
-
-#: src/Module/Admin/Site.php:638
-msgid ""
-"Comma separated list of nicknames that are forbidden from registration. "
-"Preset is a list of role names according RFC 2142."
-msgstr ""
-
-#: src/Module/Admin/Site.php:639
-msgid "Accounts abandoned after x days"
-msgstr ""
-
-#: src/Module/Admin/Site.php:639
-msgid ""
-"Will not waste system resources polling external sites for abandonded "
-"accounts. Enter 0 for no time limit."
-msgstr ""
-
-#: src/Module/Admin/Site.php:640
-msgid "Allowed friend domains"
-msgstr ""
-
-#: src/Module/Admin/Site.php:640
-msgid ""
-"Comma separated list of domains which are allowed to establish friendships "
-"with this site. Wildcards are accepted. Empty to allow any domains"
-msgstr ""
-
-#: src/Module/Admin/Site.php:641
-msgid "Allowed email domains"
-msgstr ""
-
-#: src/Module/Admin/Site.php:641
-msgid ""
-"Comma separated list of domains which are allowed in email addresses for "
-"registrations to this site. Wildcards are accepted. Empty to allow any "
-"domains"
-msgstr ""
-
-#: src/Module/Admin/Site.php:642
-msgid "No OEmbed rich content"
-msgstr ""
-
-#: src/Module/Admin/Site.php:642
-msgid ""
-"Don't show the rich content (e.g. embedded PDF), except from the domains "
-"listed below."
-msgstr ""
-
-#: src/Module/Admin/Site.php:643
-msgid "Allowed OEmbed domains"
-msgstr ""
-
-#: src/Module/Admin/Site.php:643
-msgid ""
-"Comma separated list of domains which oembed content is allowed to be "
-"displayed. Wildcards are accepted."
-msgstr ""
-
-#: src/Module/Admin/Site.php:644
-msgid "Block public"
-msgstr ""
-
-#: src/Module/Admin/Site.php:644
-msgid ""
-"Check to block public access to all otherwise public personal pages on this "
-"site unless you are currently logged in."
-msgstr ""
-
-#: src/Module/Admin/Site.php:645
-msgid "Force publish"
-msgstr ""
-
-#: src/Module/Admin/Site.php:645
-msgid ""
-"Check to force all profiles on this site to be listed in the site directory."
-msgstr ""
-
-#: src/Module/Admin/Site.php:645
-msgid "Enabling this may violate privacy laws like the GDPR"
-msgstr ""
-
-#: src/Module/Admin/Site.php:646
-msgid "Global directory URL"
-msgstr ""
-
-#: src/Module/Admin/Site.php:646
-msgid ""
-"URL to the global directory. If this is not set, the global directory is "
-"completely unavailable to the application."
-msgstr ""
-
-#: src/Module/Admin/Site.php:647
-msgid "Private posts by default for new users"
-msgstr ""
-
-#: src/Module/Admin/Site.php:647
-msgid ""
-"Set default post permissions for all new members to the default privacy "
-"group rather than public."
-msgstr ""
-
-#: src/Module/Admin/Site.php:648
-msgid "Don't include post content in email notifications"
-msgstr ""
-
-#: src/Module/Admin/Site.php:648
-msgid ""
-"Don't include the content of a post/comment/private message/etc. in the "
-"email notifications that are sent out from this site, as a privacy measure."
-msgstr ""
-
-#: src/Module/Admin/Site.php:649
-msgid "Disallow public access to addons listed in the apps menu."
-msgstr ""
-
-#: src/Module/Admin/Site.php:649
-msgid ""
-"Checking this box will restrict addons listed in the apps menu to members "
-"only."
-msgstr ""
-
-#: src/Module/Admin/Site.php:650
-msgid "Don't embed private images in posts"
-msgstr ""
-
-#: src/Module/Admin/Site.php:650
-msgid ""
-"Don't replace locally-hosted private photos in posts with an embedded copy "
-"of the image. This means that contacts who receive posts containing private "
-"photos will have to authenticate and load each image, which may take a while."
-msgstr ""
-
-#: src/Module/Admin/Site.php:651
-msgid "Explicit Content"
-msgstr ""
-
-#: src/Module/Admin/Site.php:651
-msgid ""
-"Set this to announce that your node is used mostly for explicit content that "
-"might not be suited for minors. This information will be published in the "
-"node information and might be used, e.g. by the global directory, to filter "
-"your node from listings of nodes to join. Additionally a note about this "
-"will be shown at the user registration page."
-msgstr ""
-
-#: src/Module/Admin/Site.php:652
-msgid "Allow Users to set remote_self"
-msgstr ""
-
-#: src/Module/Admin/Site.php:652
-msgid ""
-"With checking this, every user is allowed to mark every contact as a "
-"remote_self in the repair contact dialog. Setting this flag on a contact "
-"causes mirroring every posting of that contact in the users stream."
-msgstr ""
-
-#: src/Module/Admin/Site.php:653
-msgid "Block multiple registrations"
-msgstr ""
-
-#: src/Module/Admin/Site.php:653
-msgid "Disallow users to register additional accounts for use as pages."
-msgstr ""
-
-#: src/Module/Admin/Site.php:654
-msgid "Disable OpenID"
-msgstr ""
-
-#: src/Module/Admin/Site.php:654
-msgid "Disable OpenID support for registration and logins."
-msgstr ""
-
-#: src/Module/Admin/Site.php:655
-msgid "No Fullname check"
-msgstr ""
-
-#: src/Module/Admin/Site.php:655
-msgid ""
-"Allow users to register without a space between the first name and the last "
-"name in their full name."
-msgstr ""
-
-#: src/Module/Admin/Site.php:656
-msgid "Community pages for visitors"
-msgstr ""
-
-#: src/Module/Admin/Site.php:656
-msgid ""
-"Which community pages should be available for visitors. Local users always "
-"see both pages."
-msgstr ""
-
-#: src/Module/Admin/Site.php:657
-msgid "Posts per user on community page"
-msgstr ""
-
-#: src/Module/Admin/Site.php:657
-msgid ""
-"The maximum number of posts per user on the community page. (Not valid for "
-"\"Global Community\")"
-msgstr ""
-
-#: src/Module/Admin/Site.php:658
-msgid "Disable OStatus support"
-msgstr ""
-
-#: src/Module/Admin/Site.php:658
-msgid ""
-"Disable built-in OStatus (StatusNet, GNU Social etc.) compatibility. All "
-"communications in OStatus are public, so privacy warnings will be "
-"occasionally displayed."
-msgstr ""
-
-#: src/Module/Admin/Site.php:659
-msgid "OStatus support can only be enabled if threading is enabled."
-msgstr ""
-
-#: src/Module/Admin/Site.php:661
-msgid ""
-"Diaspora support can't be enabled because Friendica was installed into a sub "
-"directory."
-msgstr ""
-
-#: src/Module/Admin/Site.php:662
-msgid "Enable Diaspora support"
-msgstr ""
-
-#: src/Module/Admin/Site.php:662
-msgid "Provide built-in Diaspora network compatibility."
-msgstr ""
-
-#: src/Module/Admin/Site.php:663
-msgid "Only allow Friendica contacts"
-msgstr ""
-
-#: src/Module/Admin/Site.php:663
-msgid ""
-"All contacts must use Friendica protocols. All other built-in communication "
-"protocols disabled."
-msgstr ""
-
-#: src/Module/Admin/Site.php:664
-msgid "Verify SSL"
-msgstr ""
-
-#: src/Module/Admin/Site.php:664
-msgid ""
-"If you wish, you can turn on strict certificate checking. This will mean you "
-"cannot connect (at all) to self-signed SSL sites."
-msgstr ""
-
-#: src/Module/Admin/Site.php:665
-msgid "Proxy user"
-msgstr ""
-
-#: src/Module/Admin/Site.php:666
-msgid "Proxy URL"
-msgstr ""
-
-#: src/Module/Admin/Site.php:667
-msgid "Network timeout"
-msgstr ""
-
-#: src/Module/Admin/Site.php:667
-msgid "Value is in seconds. Set to 0 for unlimited (not recommended)."
-msgstr ""
-
-#: src/Module/Admin/Site.php:668
-msgid "Maximum Load Average"
-msgstr ""
-
-#: src/Module/Admin/Site.php:668
-#, php-format
-msgid ""
-"Maximum system load before delivery and poll processes are deferred - "
-"default %d."
-msgstr ""
-
-#: src/Module/Admin/Site.php:669
-msgid "Maximum Load Average (Frontend)"
-msgstr ""
-
-#: src/Module/Admin/Site.php:669
-msgid "Maximum system load before the frontend quits service - default 50."
-msgstr ""
-
-#: src/Module/Admin/Site.php:670
-msgid "Minimal Memory"
-msgstr ""
-
-#: src/Module/Admin/Site.php:670
-msgid ""
-"Minimal free memory in MB for the worker. Needs access to /proc/meminfo - "
-"default 0 (deactivated)."
-msgstr ""
-
-#: src/Module/Admin/Site.php:671
-msgid "Periodically optimize tables"
-msgstr ""
-
-#: src/Module/Admin/Site.php:671
-msgid "Periodically optimize tables like the cache and the workerqueue"
-msgstr ""
-
-#: src/Module/Admin/Site.php:673
-msgid "Discover followers/followings from contacts"
-msgstr ""
-
-#: src/Module/Admin/Site.php:673
-msgid ""
-"If enabled, contacts are checked for their followers and following contacts."
-msgstr ""
-
-#: src/Module/Admin/Site.php:674
-msgid "None - deactivated"
-msgstr ""
-
-#: src/Module/Admin/Site.php:675
-msgid ""
-"Local contacts - contacts of our local contacts are discovered for their "
-"followers/followings."
-msgstr ""
-
-#: src/Module/Admin/Site.php:676
-msgid ""
-"Interactors - contacts of our local contacts and contacts who interacted on "
-"locally visible postings are discovered for their followers/followings."
-msgstr ""
-
-#: src/Module/Admin/Site.php:678
-msgid "Synchronize the contacts with the directory server"
-msgstr ""
-
-#: src/Module/Admin/Site.php:678
-msgid ""
-"if enabled, the system will check periodically for new contacts on the "
-"defined directory server."
-msgstr ""
-
-#: src/Module/Admin/Site.php:680
-msgid "Days between requery"
-msgstr ""
-
-#: src/Module/Admin/Site.php:680
-msgid "Number of days after which a server is requeried for his contacts."
-msgstr ""
-
-#: src/Module/Admin/Site.php:681
-msgid "Discover contacts from other servers"
-msgstr ""
-
-#: src/Module/Admin/Site.php:681
-msgid ""
-"Periodically query other servers for contacts. The system queries Friendica, "
-"Mastodon and Hubzilla servers."
-msgstr ""
-
-#: src/Module/Admin/Site.php:682
-msgid "Search the local directory"
-msgstr ""
-
-#: src/Module/Admin/Site.php:682
-msgid ""
-"Search the local directory instead of the global directory. When searching "
-"locally, every search will be executed on the global directory in the "
-"background. This improves the search results when the search is repeated."
-msgstr ""
-
-#: src/Module/Admin/Site.php:684
-msgid "Publish server information"
-msgstr ""
-
-#: src/Module/Admin/Site.php:684
-msgid ""
-"If enabled, general server and usage data will be published. The data "
-"contains the name and version of the server, number of users with public "
-"profiles, number of posts and the activated protocols and connectors. See <a "
-"href=\"http://the-federation.info/\">the-federation.info</a> for details."
-msgstr ""
-
-#: src/Module/Admin/Site.php:686
-msgid "Check upstream version"
-msgstr ""
-
-#: src/Module/Admin/Site.php:686
-msgid ""
-"Enables checking for new Friendica versions at github. If there is a new "
-"version, you will be informed in the admin panel overview."
-msgstr ""
-
-#: src/Module/Admin/Site.php:687
-msgid "Suppress Tags"
-msgstr ""
-
-#: src/Module/Admin/Site.php:687
-msgid "Suppress showing a list of hashtags at the end of the posting."
-msgstr ""
-
-#: src/Module/Admin/Site.php:688
-msgid "Clean database"
-msgstr ""
-
-#: src/Module/Admin/Site.php:688
-msgid ""
-"Remove old remote items, orphaned database records and old content from some "
-"other helper tables."
-msgstr ""
-
-#: src/Module/Admin/Site.php:689
-msgid "Lifespan of remote items"
-msgstr ""
-
-#: src/Module/Admin/Site.php:689
-msgid ""
-"When the database cleanup is enabled, this defines the days after which "
-"remote items will be deleted. Own items, and marked or filed items are "
-"always kept. 0 disables this behaviour."
-msgstr ""
-
-#: src/Module/Admin/Site.php:690
-msgid "Lifespan of unclaimed items"
-msgstr ""
-
-#: src/Module/Admin/Site.php:690
-msgid ""
-"When the database cleanup is enabled, this defines the days after which "
-"unclaimed remote items (mostly content from the relay) will be deleted. "
-"Default value is 90 days. Defaults to the general lifespan value of remote "
-"items if set to 0."
-msgstr ""
-
-#: src/Module/Admin/Site.php:691
-msgid "Lifespan of raw conversation data"
-msgstr ""
-
-#: src/Module/Admin/Site.php:691
-msgid ""
-"The conversation data is used for ActivityPub and OStatus, as well as for "
-"debug purposes. It should be safe to remove it after 14 days, default is 90 "
-"days."
-msgstr ""
-
-#: src/Module/Admin/Site.php:692
-msgid "Path to item cache"
-msgstr ""
-
-#: src/Module/Admin/Site.php:692
-msgid "The item caches buffers generated bbcode and external images."
-msgstr ""
-
-#: src/Module/Admin/Site.php:693
-msgid "Cache duration in seconds"
-msgstr ""
-
-#: src/Module/Admin/Site.php:693
-msgid ""
-"How long should the cache files be hold? Default value is 86400 seconds (One "
-"day). To disable the item cache, set the value to -1."
-msgstr ""
-
-#: src/Module/Admin/Site.php:694
-msgid "Maximum numbers of comments per post"
-msgstr ""
-
-#: src/Module/Admin/Site.php:694
-msgid "How much comments should be shown for each post? Default value is 100."
-msgstr ""
-
-#: src/Module/Admin/Site.php:695
-msgid "Maximum numbers of comments per post on the display page"
-msgstr ""
-
-#: src/Module/Admin/Site.php:695
-msgid ""
-"How many comments should be shown on the single view for each post? Default "
-"value is 1000."
-msgstr ""
-
-#: src/Module/Admin/Site.php:696
-msgid "Temp path"
-msgstr ""
-
-#: src/Module/Admin/Site.php:696
-msgid ""
-"If you have a restricted system where the webserver can't access the system "
-"temp path, enter another path here."
-msgstr ""
-
-#: src/Module/Admin/Site.php:697
-msgid "Disable picture proxy"
-msgstr ""
-
-#: src/Module/Admin/Site.php:697
-msgid ""
-"The picture proxy increases performance and privacy. It shouldn't be used on "
-"systems with very low bandwidth."
-msgstr ""
-
-#: src/Module/Admin/Site.php:698
-msgid "Only search in tags"
-msgstr ""
-
-#: src/Module/Admin/Site.php:698
-msgid "On large systems the text search can slow down the system extremely."
-msgstr ""
-
-#: src/Module/Admin/Site.php:700
-msgid "New base url"
-msgstr ""
-
-#: src/Module/Admin/Site.php:700
-msgid ""
-"Change base url for this server. Sends relocate message to all Friendica and "
-"Diaspora* contacts of all users."
-msgstr ""
-
-#: src/Module/Admin/Site.php:702
-msgid "RINO Encryption"
-msgstr ""
-
-#: src/Module/Admin/Site.php:702
-msgid "Encryption layer between nodes."
-msgstr ""
-
-#: src/Module/Admin/Site.php:702
-msgid "Enabled"
-msgstr ""
-
-#: src/Module/Admin/Site.php:704
-msgid "Maximum number of parallel workers"
-msgstr ""
-
-#: src/Module/Admin/Site.php:704
-#, php-format
-msgid ""
-"On shared hosters set this to %d. On larger systems, values of %d are great. "
-"Default value is %d."
-msgstr ""
-
-#: src/Module/Admin/Site.php:705
-msgid "Don't use \"proc_open\" with the worker"
-msgstr ""
-
-#: src/Module/Admin/Site.php:705
-msgid ""
-"Enable this if your system doesn't allow the use of \"proc_open\". This can "
-"happen on shared hosters. If this is enabled you should increase the "
-"frequency of worker calls in your crontab."
-msgstr ""
-
-#: src/Module/Admin/Site.php:706
-msgid "Enable fastlane"
-msgstr ""
-
-#: src/Module/Admin/Site.php:706
-msgid ""
-"When enabed, the fastlane mechanism starts an additional worker if processes "
-"with higher priority are blocked by processes of lower priority."
-msgstr ""
-
-#: src/Module/Admin/Site.php:707
-msgid "Enable frontend worker"
-msgstr ""
-
-#: src/Module/Admin/Site.php:707
-#, php-format
-msgid ""
-"When enabled the Worker process is triggered when backend access is "
-"performed (e.g. messages being delivered). On smaller sites you might want "
-"to call %s/worker on a regular basis via an external cron job. You should "
-"only enable this option if you cannot utilize cron/scheduled jobs on your "
-"server."
-msgstr ""
-
-#: src/Module/Admin/Site.php:709
-msgid "Use relay servers"
-msgstr ""
-
-#: src/Module/Admin/Site.php:709
-msgid ""
-"Enables the receiving of public posts from relay servers. They will be "
-"included in the search, subscribed tags and on the global community page."
-msgstr ""
-
-#: src/Module/Admin/Site.php:710
-msgid "\"Social Relay\" server"
-msgstr ""
-
-#: src/Module/Admin/Site.php:710
-#, php-format
-msgid ""
-"Address of the \"Social Relay\" server where public posts should be send to. "
-"For example %s. ActivityRelay servers are administrated via the \"console "
-"relay\" command line command."
-msgstr ""
-
-#: src/Module/Admin/Site.php:711
-msgid "Direct relay transfer"
-msgstr ""
-
-#: src/Module/Admin/Site.php:711
-msgid ""
-"Enables the direct transfer to other servers without using the relay servers"
-msgstr ""
-
-#: src/Module/Admin/Site.php:712
-msgid "Relay scope"
-msgstr ""
-
-#: src/Module/Admin/Site.php:712
-msgid ""
-"Can be \"all\" or \"tags\". \"all\" means that every public post should be "
-"received. \"tags\" means that only posts with selected tags should be "
-"received."
-msgstr ""
-
-#: src/Module/Admin/Site.php:712
-msgid "all"
-msgstr ""
-
-#: src/Module/Admin/Site.php:712
-msgid "tags"
-msgstr ""
-
-#: src/Module/Admin/Site.php:713
-msgid "Server tags"
-msgstr ""
-
-#: src/Module/Admin/Site.php:713
-msgid "Comma separated list of tags for the \"tags\" subscription."
-msgstr ""
-
-#: src/Module/Admin/Site.php:714
-msgid "Deny Server tags"
-msgstr ""
-
-#: src/Module/Admin/Site.php:714
-msgid "Comma separated list of tags that are rejected."
-msgstr ""
-
-#: src/Module/Admin/Site.php:715
-msgid "Allow user tags"
-msgstr ""
-
-#: src/Module/Admin/Site.php:715
-msgid ""
-"If enabled, the tags from the saved searches will used for the \"tags\" "
-"subscription in addition to the \"relay_server_tags\"."
-msgstr ""
-
-#: src/Module/Admin/Site.php:718
-msgid "Start Relocation"
-msgstr ""
-
-#: src/Module/Admin/Summary.php:53
-#, php-format
-msgid "Template engine (%s) error: %s"
-msgstr ""
-
-#: src/Module/Admin/Summary.php:57
-#, php-format
-msgid ""
-"Your DB still runs with MyISAM tables. You should change the engine type to "
-"InnoDB. As Friendica will use InnoDB only features in the future, you should "
-"change this! See <a href=\"%s\">here</a> for a guide that may be helpful "
-"converting the table engines. You may also use the command <tt>php bin/"
-"console.php dbstructure toinnodb</tt> of your Friendica installation for an "
-"automatic conversion.<br />"
-msgstr ""
-
-#: src/Module/Admin/Summary.php:62
-#, php-format
-msgid ""
-"Your DB still runs with InnoDB tables in the Antelope file format. You "
-"should change the file format to Barracuda. Friendica is using features that "
-"are not provided by the Antelope format. See <a href=\"%s\">here</a> for a "
-"guide that may be helpful converting the table engines. You may also use the "
-"command <tt>php bin/console.php dbstructure toinnodb</tt> of your Friendica "
-"installation for an automatic conversion.<br />"
-msgstr ""
-
-#: src/Module/Admin/Summary.php:71
-#, php-format
-msgid ""
-"Your table_definition_cache is too low (%d). This can lead to the database "
-"error \"Prepared statement needs to be re-prepared\". Please set it at least "
-"to %d (or -1 for autosizing). See <a href=\"%s\">here</a> for more "
-"information.<br />"
-msgstr ""
-
-#: src/Module/Admin/Summary.php:80
-#, php-format
-msgid ""
-"There is a new version of Friendica available for download. Your current "
-"version is %1$s, upstream version is %2$s"
-msgstr ""
-
-#: src/Module/Admin/Summary.php:89
-msgid ""
-"The database update failed. Please run \"php bin/console.php dbstructure "
-"update\" from the command line and have a look at the errors that might "
-"appear."
-msgstr ""
-
-#: src/Module/Admin/Summary.php:93
-msgid ""
-"The last update failed. Please run \"php bin/console.php dbstructure update"
-"\" from the command line and have a look at the errors that might appear. "
-"(Some of the errors are possibly inside the logfile.)"
-msgstr ""
-
-#: src/Module/Admin/Summary.php:98
-msgid "The worker was never executed. Please check your database structure!"
-msgstr ""
-
-#: src/Module/Admin/Summary.php:100
-#, php-format
-msgid ""
-"The last worker execution was on %s UTC. This is older than one hour. Please "
-"check your crontab settings."
-msgstr ""
-
-#: src/Module/Admin/Summary.php:105
-#, php-format
-msgid ""
-"Friendica's configuration now is stored in config/local.config.php, please "
-"copy config/local-sample.config.php and move your config from <code>."
-"htconfig.php</code>. See <a href=\"%s\">the Config help page</a> for help "
-"with the transition."
-msgstr ""
-
-#: src/Module/Admin/Summary.php:109
-#, php-format
-msgid ""
-"Friendica's configuration now is stored in config/local.config.php, please "
-"copy config/local-sample.config.php and move your config from <code>config/"
-"local.ini.php</code>. See <a href=\"%s\">the Config help page</a> for help "
-"with the transition."
-msgstr ""
-
-#: src/Module/Admin/Summary.php:115
-#, php-format
-msgid ""
-"<a href=\"%s\">%s</a> is not reachable on your system. This is a severe "
-"configuration issue that prevents server to server communication. See <a "
-"href=\"%s\">the installation page</a> for help."
-msgstr ""
-
-#: src/Module/Admin/Summary.php:133
-#, php-format
-msgid "The logfile '%s' is not usable. No logging possible (error: '%s')"
-msgstr ""
-
-#: src/Module/Admin/Summary.php:147
-#, php-format
-msgid "The debug logfile '%s' is not usable. No logging possible (error: '%s')"
-msgstr ""
-
-#: src/Module/Admin/Summary.php:163
-#, php-format
-msgid ""
-"Friendica's system.basepath was updated from '%s' to '%s'. Please remove the "
-"system.basepath from your db to avoid differences."
-msgstr ""
-
-#: src/Module/Admin/Summary.php:171
-#, php-format
-msgid ""
-"Friendica's current system.basepath '%s' is wrong and the config file '%s' "
-"isn't used."
-msgstr ""
-
-#: src/Module/Admin/Summary.php:179
-#, php-format
-msgid ""
-"Friendica's current system.basepath '%s' is not equal to the config file "
-"'%s'. Please fix your configuration."
-msgstr ""
-
-#: src/Module/Admin/Summary.php:186
-msgid "Normal Account"
-msgstr ""
-
-#: src/Module/Admin/Summary.php:187
-msgid "Automatic Follower Account"
-msgstr ""
-
-#: src/Module/Admin/Summary.php:188
-msgid "Public Forum Account"
-msgstr ""
-
-#: src/Module/Admin/Summary.php:189
-msgid "Automatic Friend Account"
-msgstr ""
-
-#: src/Module/Admin/Summary.php:190
-msgid "Blog Account"
-msgstr ""
-
-#: src/Module/Admin/Summary.php:191
-msgid "Private Forum Account"
-msgstr ""
-
-#: src/Module/Admin/Summary.php:211
-msgid "Message queues"
-msgstr ""
-
-#: src/Module/Admin/Summary.php:217
-msgid "Server Settings"
-msgstr ""
-
-#: src/Module/Admin/Summary.php:233
-msgid "Registered users"
-msgstr ""
-
-#: src/Module/Admin/Summary.php:235
-msgid "Pending registrations"
-msgstr ""
-
-#: src/Module/Admin/Summary.php:236
-msgid "Version"
-msgstr ""
-
-#: src/Module/Admin/Summary.php:240
-msgid "Active addons"
-msgstr ""
-
-#: src/Module/Admin/Users/Create.php:62
-msgid "New User"
-msgstr ""
-
-#: src/Module/Admin/Users/Create.php:63
-msgid "Add User"
-msgstr ""
-
-#: src/Module/Admin/Users/Create.php:71
-msgid "Name of the new user."
-msgstr ""
-
-#: src/Module/Admin/Users/Create.php:72
-msgid "Nickname"
-msgstr ""
-
-#: src/Module/Admin/Users/Create.php:72
-msgid "Nickname of the new user."
-msgstr ""
-
-#: src/Module/Admin/Users/Create.php:73 src/Module/Admin/Users/Pending.php:104
-#: src/Module/Admin/Users/Index.php:142 src/Module/Admin/Users/Index.php:162
-#: src/Module/Admin/Users/Active.php:129 src/Module/Admin/Users/Blocked.php:130
-#: src/Module/Admin/Users/Deleted.php:88 src/Content/ContactSelector.php:102
-msgid "Email"
-msgstr ""
-
-#: src/Module/Admin/Users/Create.php:73
-msgid "Email address of the new user."
-msgstr ""
-
-#: src/Module/Admin/Users/Pending.php:48
-#, php-format
-msgid "%s user approved"
-msgid_plural "%s users approved"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/Module/Admin/Users/Pending.php:55
-#, php-format
-msgid "%s registration revoked"
-msgid_plural "%s registrations revoked"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/Module/Admin/Users/Pending.php:81
-msgid "Account approved."
-msgstr ""
-
-#: src/Module/Admin/Users/Pending.php:87
-msgid "Registration revoked"
-msgstr ""
-
-#: src/Module/Admin/Users/Pending.php:102
-msgid "User registrations awaiting review"
-msgstr ""
-
-#: src/Module/Admin/Users/Pending.php:103 src/Module/Admin/Users/Index.php:151
-#: src/Module/Admin/Users/Active.php:138 src/Module/Admin/Users/Blocked.php:139
-#: src/Module/Admin/Blocklist/Contact.php:82
-msgid "select all"
-msgstr ""
-
-#: src/Module/Admin/Users/Pending.php:104
-msgid "Request date"
-msgstr ""
-
-#: src/Module/Admin/Users/Pending.php:105
-msgid "No registrations."
-msgstr ""
-
-#: src/Module/Admin/Users/Pending.php:106
-msgid "Note from the user"
-msgstr ""
-
-#: src/Module/Admin/Users/Pending.php:108
-msgid "Deny"
-msgstr ""
-
-#: src/Module/Admin/Users/Index.php:45 src/Module/Admin/Users/Active.php:45
-#, php-format
-msgid "%s user blocked"
-msgid_plural "%s users blocked"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/Module/Admin/Users/Index.php:52 src/Module/Admin/Users/Blocked.php:46
-#, php-format
-msgid "%s user unblocked"
-msgid_plural "%s users unblocked"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/Module/Admin/Users/Index.php:60 src/Module/Admin/Users/Index.php:95
-#: src/Module/Admin/Users/Active.php:53 src/Module/Admin/Users/Active.php:88
-#: src/Module/Admin/Users/Blocked.php:54 src/Module/Admin/Users/Blocked.php:89
-msgid "You can't remove yourself"
-msgstr ""
-
-#: src/Module/Admin/Users/Index.php:64 src/Module/Admin/Users/Active.php:57
-#: src/Module/Admin/Users/Blocked.php:58
-#, php-format
-msgid "%s user deleted"
-msgid_plural "%s users deleted"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/Module/Admin/Users/Index.php:93 src/Module/Admin/Users/Active.php:86
-#: src/Module/Admin/Users/Blocked.php:87
-#, php-format
-msgid "User \"%s\" deleted"
-msgstr ""
-
-#: src/Module/Admin/Users/Index.php:103 src/Module/Admin/Users/Active.php:96
-#, php-format
-msgid "User \"%s\" blocked"
-msgstr ""
-
-#: src/Module/Admin/Users/Index.php:109 src/Module/Admin/Users/Blocked.php:96
-#, php-format
-msgid "User \"%s\" unblocked"
-msgstr ""
-
-#: src/Module/Admin/Users/Index.php:142 src/Module/Admin/Users/Index.php:162
-#: src/Module/Admin/Users/Active.php:129 src/Module/Admin/Users/Blocked.php:130
-#: src/Module/Admin/Users/Deleted.php:88
-msgid "Register date"
-msgstr ""
-
-#: src/Module/Admin/Users/Index.php:142 src/Module/Admin/Users/Index.php:162
-#: src/Module/Admin/Users/Active.php:129 src/Module/Admin/Users/Blocked.php:130
-#: src/Module/Admin/Users/Deleted.php:88
-msgid "Last login"
-msgstr ""
-
-#: src/Module/Admin/Users/Index.php:142 src/Module/Admin/Users/Index.php:162
-#: src/Module/Admin/Users/Active.php:129 src/Module/Admin/Users/Blocked.php:130
-#: src/Module/Admin/Users/Deleted.php:88
-msgid "Last public item"
-msgstr ""
-
-#: src/Module/Admin/Users/Index.php:142 src/Module/Admin/Users/Active.php:129
-#: src/Module/Admin/Users/Blocked.php:130
-msgid "Type"
-msgstr ""
-
-#: src/Module/Admin/Users/Index.php:152
-msgid "User waiting for permanent deletion"
-msgstr ""
-
-#: src/Module/Admin/Users/Index.php:155 src/Module/Admin/Users/Active.php:141
-#: src/Module/Admin/Users/Blocked.php:141
-msgid "User blocked"
-msgstr ""
-
-#: src/Module/Admin/Users/Index.php:157 src/Module/Admin/Users/Active.php:142
-#: src/Module/Admin/Users/Blocked.php:143
-msgid "Site admin"
-msgstr ""
-
-#: src/Module/Admin/Users/Index.php:158 src/Module/Admin/Users/Active.php:143
-#: src/Module/Admin/Users/Blocked.php:144
-msgid "Account expired"
-msgstr ""
-
-#: src/Module/Admin/Users/Index.php:161 src/Module/Admin/Users/Active.php:144
-msgid "Create a new user"
-msgstr ""
-
-#: src/Module/Admin/Users/Index.php:162 src/Module/Admin/Users/Deleted.php:88
-msgid "Permanent deletion"
-msgstr ""
-
-#: src/Module/Admin/Users/Index.php:167 src/Module/Admin/Users/Active.php:150
-#: src/Module/Admin/Users/Blocked.php:150
-msgid ""
-"Selected users will be deleted!\\n\\nEverything these users had posted on "
-"this site will be permanently deleted!\\n\\nAre you sure?"
-msgstr ""
-
-#: src/Module/Admin/Users/Index.php:168 src/Module/Admin/Users/Active.php:151
-#: src/Module/Admin/Users/Blocked.php:151
-msgid ""
-"The user {0} will be deleted!\\n\\nEverything this user has posted on this "
-"site will be permanently deleted!\\n\\nAre you sure?"
-msgstr ""
-
-#: src/Module/Admin/Users/Active.php:137
-msgid "Active Accounts"
-msgstr ""
-
-#: src/Module/Admin/Users/Blocked.php:138
-msgid "Blocked Users"
-msgstr ""
-
-#: src/Module/Admin/Users/Deleted.php:86
-msgid "Users awaiting permanent deletion"
-msgstr ""
-
-#: src/Module/Admin/Tos.php:60
-msgid "Display Terms of Service"
-msgstr ""
-
-#: src/Module/Admin/Tos.php:60
-msgid ""
-"Enable the Terms of Service page. If this is enabled a link to the terms "
-"will be added to the registration form and the general information page."
-msgstr ""
-
-#: src/Module/Admin/Tos.php:61
-msgid "Display Privacy Statement"
-msgstr ""
-
-#: src/Module/Admin/Tos.php:61
-#, php-format
-msgid ""
-"Show some informations regarding the needed information to operate the node "
-"according e.g. to <a href=\"%s\" target=\"_blank\" rel=\"noopener noreferrer"
-"\">EU-GDPR</a>."
-msgstr ""
-
-#: src/Module/Admin/Tos.php:62
-msgid "Privacy Statement Preview"
-msgstr ""
-
-#: src/Module/Admin/Tos.php:64
-msgid "The Terms of Service"
-msgstr ""
-
-#: src/Module/Admin/Tos.php:64
-msgid ""
-"Enter the Terms of Service for your node here. You can use BBCode. Headers "
-"of sections should be [h2] and below."
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Server.php:49
-msgid "Server domain pattern added to blocklist."
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Server.php:79
-#: src/Module/Admin/Blocklist/Server.php:104
-msgid "Blocked server domain pattern"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Server.php:80
-#: src/Module/Admin/Blocklist/Server.php:105 src/Module/Friendica.php:81
-msgid "Reason for the block"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Server.php:81
-msgid "Delete server domain pattern"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Server.php:81
-msgid "Check to delete this entry from the blocklist"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Server.php:89
-msgid "Server Domain Pattern Blocklist"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Server.php:90
-msgid ""
-"This page can be used to define a blocklist of server domain patterns from "
-"the federated network that are not allowed to interact with your node. For "
-"each domain pattern you should also provide the reason why you block it."
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Server.php:91
-msgid ""
-"The list of blocked server domain patterns will be made publically available "
-"on the <a href=\"/friendica\">/friendica</a> page so that your users and "
-"people investigating communication problems can find the reason easily."
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Server.php:92
-msgid ""
-"<p>The server domain pattern syntax is case-insensitive shell wildcard, "
-"comprising the following special characters:</p>\n"
-"<ul>\n"
-"\t<li><code>*</code>: Any number of characters</li>\n"
-"\t<li><code>?</code>: Any single character</li>\n"
-"\t<li><code>[&lt;char1&gt;&lt;char2&gt;...]</code>: char1 or char2</li>\n"
-"</ul>"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Server.php:98
-msgid "Add new entry to block list"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Server.php:99
-msgid "Server Domain Pattern"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Server.php:99
-msgid ""
-"The domain pattern of the new server to add to the block list. Do not "
-"include the protocol."
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Server.php:100
-msgid "Block reason"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Server.php:100
-msgid "The reason why you blocked this server domain pattern."
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Server.php:101
-msgid "Add Entry"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Server.php:102
-msgid "Save changes to the blocklist"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Server.php:103
-msgid "Current Entries in the Blocklist"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Server.php:106
-msgid "Delete entry from blocklist"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Server.php:109
-msgid "Delete entry from blocklist?"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Contact.php:57
-#, php-format
-msgid "%s contact unblocked"
-msgid_plural "%s contacts unblocked"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/Module/Admin/Blocklist/Contact.php:79
-msgid "Remote Contact Blocklist"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Contact.php:80
-msgid ""
-"This page allows you to prevent any message from a remote contact to reach "
-"your node."
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Contact.php:81
-msgid "Block Remote Contact"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Contact.php:83
-msgid "select none"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Contact.php:86
-msgid "No remote contact is blocked from this node."
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Contact.php:88
-msgid "Blocked Remote Contacts"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Contact.php:89
-msgid "Block New Remote Contact"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Contact.php:90
-msgid "Photo"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Contact.php:90
-msgid "Reason"
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Contact.php:98
-#, php-format
-msgid "%s total blocked contact"
-msgid_plural "%s total blocked contacts"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/Module/Admin/Blocklist/Contact.php:100
-msgid "URL of the remote contact to block."
-msgstr ""
-
-#: src/Module/Admin/Blocklist/Contact.php:101
-msgid "Block Reason"
-msgstr ""
-
-#: src/Module/Admin/Item/Source.php:57
-msgid "Item Guid"
-msgstr ""
-
-#: src/Module/Admin/Item/Delete.php:54
-msgid "Item marked for deletion."
-msgstr ""
-
-#: src/Module/Admin/Item/Delete.php:67
-msgid "Delete this Item"
-msgstr ""
-
-#: src/Module/Admin/Item/Delete.php:68
-msgid ""
-"On this page you can delete an item from your node. If the item is a top "
-"level posting, the entire thread will be deleted."
-msgstr ""
-
-#: src/Module/Admin/Item/Delete.php:69
-msgid ""
-"You need to know the GUID of the item. You can find it e.g. by looking at "
-"the display URL. The last part of http://example.com/display/123456 is the "
-"GUID, here 123456."
-msgstr ""
-
-#: src/Module/Admin/Item/Delete.php:70
-msgid "GUID"
-msgstr ""
-
-#: src/Module/Admin/Item/Delete.php:70
-msgid "The GUID of the item you want to delete."
-msgstr ""
-
-#: src/Module/Admin/Addons/Details.php:65
-msgid "Addon not found."
-msgstr ""
-
-#: src/Module/Admin/Addons/Details.php:76 src/Module/Admin/Addons/Index.php:49
-#, php-format
-msgid "Addon %s disabled."
-msgstr ""
-
-#: src/Module/Admin/Addons/Details.php:79 src/Module/Admin/Addons/Index.php:51
-#, php-format
-msgid "Addon %s enabled."
-msgstr ""
-
-#: src/Module/Admin/Addons/Index.php:42
-msgid "Addons reloaded"
-msgstr ""
-
-#: src/Module/Admin/Addons/Index.php:53
-#, php-format
-msgid "Addon %s failed to install."
-msgstr ""
-
-#: src/Module/Admin/Addons/Index.php:70
-msgid "Reload active addons"
-msgstr ""
-
-#: src/Module/Admin/Addons/Index.php:75
-#, php-format
-msgid ""
-"There are currently no addons available on your node. You can find the "
-"official addon repository at %1$s and might find other interesting addons in "
-"the open addon registry at %2$s"
-msgstr ""
-
-#: src/Module/Directory.php:77
-msgid "No entries (some entries may be hidden)."
-msgstr ""
-
-#: src/Module/Directory.php:99
-msgid "Find on this site"
-msgstr ""
-
-#: src/Module/Directory.php:101
-msgid "Results for:"
-msgstr ""
-
-#: src/Module/Directory.php:103
-msgid "Site Directory"
-msgstr ""
-
-#: src/Module/Attach.php:50 src/Module/Attach.php:62
-msgid "Item was not found."
-msgstr ""
-
 #: src/Module/Item/Compose.php:46
 msgid "Please enter a post body."
 msgstr ""
@@ -8575,55 +8610,114 @@ msgid ""
 "your device"
 msgstr ""
 
-#: src/Module/Friendica.php:61
-msgid "Installed addons/apps:"
+#: src/Module/Maintenance.php:46
+msgid "System down for maintenance"
 msgstr ""
 
-#: src/Module/Friendica.php:66
-msgid "No installed addons/apps"
+#: src/Module/Manifest.php:42
+msgid "A Decentralized Social Network"
 msgstr ""
 
-#: src/Module/Friendica.php:71
+#: src/Module/Notifications/Introductions.php:78
+msgid "Show Ignored Requests"
+msgstr ""
+
+#: src/Module/Notifications/Introductions.php:78
+msgid "Hide Ignored Requests"
+msgstr ""
+
+#: src/Module/Notifications/Introductions.php:94
+#: src/Module/Notifications/Introductions.php:163
+msgid "Notification type:"
+msgstr ""
+
+#: src/Module/Notifications/Introductions.php:97
+msgid "Suggested by:"
+msgstr ""
+
+#: src/Module/Notifications/Introductions.php:122
+msgid "Claims to be known to you: "
+msgstr ""
+
+#: src/Module/Notifications/Introductions.php:131
+msgid "Shall your connection be bidirectional or not?"
+msgstr ""
+
+#: src/Module/Notifications/Introductions.php:132
 #, php-format
-msgid "Read about the <a href=\"%1$s/tos\">Terms of Service</a> of this node."
+msgid ""
+"Accepting %s as a friend allows %s to subscribe to your posts, and you will "
+"also receive updates from them in your news feed."
 msgstr ""
 
-#: src/Module/Friendica.php:78
-msgid "On this server the following remote servers are blocked."
-msgstr ""
-
-#: src/Module/Friendica.php:96
+#: src/Module/Notifications/Introductions.php:133
 #, php-format
 msgid ""
-"This is Friendica, version %s that is running at the web location %s. The "
-"database version is %s, the post update version is %s."
+"Accepting %s as a subscriber allows them to subscribe to your posts, but you "
+"will not receive updates from them in your news feed."
 msgstr ""
 
-#: src/Module/Friendica.php:101
-msgid ""
-"Please visit <a href=\"https://friendi.ca\">Friendi.ca</a> to learn more "
-"about the Friendica project."
+#: src/Module/Notifications/Introductions.php:135
+msgid "Friend"
 msgstr ""
 
-#: src/Module/Friendica.php:102
-msgid "Bug reports and issues: please visit"
+#: src/Module/Notifications/Introductions.php:136
+msgid "Subscriber"
 msgstr ""
 
-#: src/Module/Friendica.php:102
-msgid "the bugtracker at github"
+#: src/Module/Notifications/Introductions.php:201
+msgid "No introductions."
 msgstr ""
 
-#: src/Module/Friendica.php:103
-msgid ""
-"Suggestions, praise, etc. - please email \"info\" at \"friendi - dot - ca"
+#: src/Module/Notifications/Introductions.php:202
+#: src/Module/Notifications/Notifications.php:133
+#, php-format
+msgid "No more %s notifications."
 msgstr ""
 
-#: src/Module/BaseProfile.php:113
-msgid "Only You Can See This"
+#: src/Module/Notifications/Notification.php:103
+msgid "You must be logged in to show this page."
 msgstr ""
 
-#: src/Module/BaseProfile.php:132 src/Module/BaseProfile.php:135
-msgid "Tips for New Members"
+#: src/Module/Notifications/Notifications.php:50
+msgid "Network Notifications"
+msgstr ""
+
+#: src/Module/Notifications/Notifications.php:58
+msgid "System Notifications"
+msgstr ""
+
+#: src/Module/Notifications/Notifications.php:66
+msgid "Personal Notifications"
+msgstr ""
+
+#: src/Module/Notifications/Notifications.php:74
+msgid "Home Notifications"
+msgstr ""
+
+#: src/Module/Notifications/Notifications.php:138
+msgid "Show unread"
+msgstr ""
+
+#: src/Module/Notifications/Notifications.php:138
+msgid "Show all"
+msgstr ""
+
+#: src/Module/PermissionTooltip.php:24
+#, php-format
+msgid "Wrong type \"%s\", expected one of: %s"
+msgstr ""
+
+#: src/Module/PermissionTooltip.php:37
+msgid "Model not found"
+msgstr ""
+
+#: src/Module/PermissionTooltip.php:59
+msgid "Remote privacy information not available."
+msgstr ""
+
+#: src/Module/PermissionTooltip.php:70
+msgid "Visible to:"
 msgstr ""
 
 #: src/Module/Photo.php:93
@@ -8634,6 +8728,211 @@ msgstr ""
 #: src/Module/Photo.php:111
 #, php-format
 msgid "Invalid photo with id %s."
+msgstr ""
+
+#: src/Module/Profile/Contacts.php:121
+msgid "No contacts."
+msgstr ""
+
+#: src/Module/Profile/Profile.php:135
+#, php-format
+msgid ""
+"You're currently viewing your profile as <b>%s</b> <a href=\"%s\" class="
+"\"btn btn-sm pull-right\">Cancel</a>"
+msgstr ""
+
+#: src/Module/Profile/Profile.php:149
+msgid "Member since:"
+msgstr ""
+
+#: src/Module/Profile/Profile.php:155
+msgid "j F, Y"
+msgstr ""
+
+#: src/Module/Profile/Profile.php:156
+msgid "j F"
+msgstr ""
+
+#: src/Module/Profile/Profile.php:164 src/Util/Temporal.php:163
+msgid "Birthday:"
+msgstr ""
+
+#: src/Module/Profile/Profile.php:167 src/Module/Settings/Profile/Index.php:260
+#: src/Util/Temporal.php:165
+msgid "Age: "
+msgstr ""
+
+#: src/Module/Profile/Profile.php:167 src/Module/Settings/Profile/Index.php:260
+#: src/Util/Temporal.php:165
+#, php-format
+msgid "%d year old"
+msgid_plural "%d years old"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/Module/Profile/Profile.php:229
+msgid "Forums:"
+msgstr ""
+
+#: src/Module/Profile/Profile.php:241
+msgid "View profile as:"
+msgstr ""
+
+#: src/Module/Profile/Profile.php:258
+msgid "View as"
+msgstr ""
+
+#: src/Module/Profile/Profile.php:321 src/Module/Profile/Profile.php:324
+#: src/Module/Profile/Status.php:64 src/Module/Profile/Status.php:67
+#: src/Protocol/Feed.php:999 src/Protocol/OStatus.php:1261
+#, php-format
+msgid "%s's timeline"
+msgstr ""
+
+#: src/Module/Profile/Profile.php:322 src/Module/Profile/Status.php:65
+#: src/Protocol/Feed.php:1003 src/Protocol/OStatus.php:1265
+#, php-format
+msgid "%s's posts"
+msgstr ""
+
+#: src/Module/Profile/Profile.php:323 src/Module/Profile/Status.php:66
+#: src/Protocol/Feed.php:1006 src/Protocol/OStatus.php:1268
+#, php-format
+msgid "%s's comments"
+msgstr ""
+
+#: src/Module/Register.php:69
+msgid "Only parent users can create additional accounts."
+msgstr ""
+
+#: src/Module/Register.php:101
+msgid ""
+"You may (optionally) fill in this form via OpenID by supplying your OpenID "
+"and clicking \"Register\"."
+msgstr ""
+
+#: src/Module/Register.php:102
+msgid ""
+"If you are not familiar with OpenID, please leave that field blank and fill "
+"in the rest of the items."
+msgstr ""
+
+#: src/Module/Register.php:103
+msgid "Your OpenID (optional): "
+msgstr ""
+
+#: src/Module/Register.php:112
+msgid "Include your profile in member directory?"
+msgstr ""
+
+#: src/Module/Register.php:135
+msgid "Note for the admin"
+msgstr ""
+
+#: src/Module/Register.php:135
+msgid "Leave a message for the admin, why you want to join this node"
+msgstr ""
+
+#: src/Module/Register.php:136
+msgid "Membership on this site is by invitation only."
+msgstr ""
+
+#: src/Module/Register.php:137
+msgid "Your invitation code: "
+msgstr ""
+
+#: src/Module/Register.php:145
+msgid "Your Full Name (e.g. Joe Smith, real or real-looking): "
+msgstr ""
+
+#: src/Module/Register.php:146
+msgid ""
+"Your Email Address: (Initial information will be send there, so this has to "
+"be an existing address.)"
+msgstr ""
+
+#: src/Module/Register.php:147
+msgid "Please repeat your e-mail address:"
+msgstr ""
+
+#: src/Module/Register.php:149
+msgid "Leave empty for an auto generated password."
+msgstr ""
+
+#: src/Module/Register.php:151
+#, php-format
+msgid ""
+"Choose a profile nickname. This must begin with a text character. Your "
+"profile address on this site will then be \"<strong>nickname@%s</strong>\"."
+msgstr ""
+
+#: src/Module/Register.php:152
+msgid "Choose a nickname: "
+msgstr ""
+
+#: src/Module/Register.php:161
+msgid "Import your profile to this friendica instance"
+msgstr ""
+
+#: src/Module/Register.php:168
+msgid "Note: This node explicitly contains adult content"
+msgstr ""
+
+#: src/Module/Register.php:170 src/Module/Settings/Delegation.php:155
+msgid "Parent Password:"
+msgstr ""
+
+#: src/Module/Register.php:170 src/Module/Settings/Delegation.php:155
+msgid ""
+"Please enter the password of the parent account to legitimize your request."
+msgstr ""
+
+#: src/Module/Register.php:199
+msgid "Password doesn't match."
+msgstr ""
+
+#: src/Module/Register.php:205
+msgid "Please enter your password."
+msgstr ""
+
+#: src/Module/Register.php:247
+msgid "You have entered too much information."
+msgstr ""
+
+#: src/Module/Register.php:271
+msgid "Please enter the identical mail address in the second field."
+msgstr ""
+
+#: src/Module/Register.php:298
+msgid "The additional account was created."
+msgstr ""
+
+#: src/Module/Register.php:323
+msgid ""
+"Registration successful. Please check your email for further instructions."
+msgstr ""
+
+#: src/Module/Register.php:327
+#, php-format
+msgid ""
+"Failed to send email message. Here your accout details:<br> login: %s<br> "
+"password: %s<br><br>You can change your password after login."
+msgstr ""
+
+#: src/Module/Register.php:333
+msgid "Registration successful."
+msgstr ""
+
+#: src/Module/Register.php:338 src/Module/Register.php:345
+msgid "Your registration can not be processed."
+msgstr ""
+
+#: src/Module/Register.php:344
+msgid "You have to leave a request note for the admin."
+msgstr ""
+
+#: src/Module/Register.php:390
+msgid "Your registration is pending approval by the site owner."
 msgstr ""
 
 #: src/Module/RemoteFollow.php:67
@@ -8648,127 +8947,6 @@ msgid ""
 "or <strong>%s</strong> directly on your system."
 msgstr ""
 
-#: src/Module/BaseSettings.php:43
-msgid "Account"
-msgstr ""
-
-#: src/Module/BaseSettings.php:73
-msgid "Display"
-msgstr ""
-
-#: src/Module/BaseSettings.php:94 src/Module/Settings/Delegation.php:171
-msgid "Manage Accounts"
-msgstr ""
-
-#: src/Module/BaseSettings.php:101
-msgid "Connected apps"
-msgstr ""
-
-#: src/Module/BaseSettings.php:108 src/Module/Settings/UserExport.php:66
-msgid "Export personal data"
-msgstr ""
-
-#: src/Module/BaseSettings.php:115
-msgid "Remove account"
-msgstr ""
-
-#: src/Module/Group.php:61
-msgid "Could not create group."
-msgstr ""
-
-#: src/Module/Group.php:72 src/Module/Group.php:214 src/Module/Group.php:238
-msgid "Group not found."
-msgstr ""
-
-#: src/Module/Group.php:78
-msgid "Group name was not changed."
-msgstr ""
-
-#: src/Module/Group.php:100
-msgid "Unknown group."
-msgstr ""
-
-#: src/Module/Group.php:109
-msgid "Contact is deleted."
-msgstr ""
-
-#: src/Module/Group.php:115
-msgid "Unable to add the contact to the group."
-msgstr ""
-
-#: src/Module/Group.php:118
-msgid "Contact successfully added to group."
-msgstr ""
-
-#: src/Module/Group.php:122
-msgid "Unable to remove the contact from the group."
-msgstr ""
-
-#: src/Module/Group.php:125
-msgid "Contact successfully removed from group."
-msgstr ""
-
-#: src/Module/Group.php:128
-msgid "Unknown group command."
-msgstr ""
-
-#: src/Module/Group.php:131
-msgid "Bad request."
-msgstr ""
-
-#: src/Module/Group.php:170
-msgid "Save Group"
-msgstr ""
-
-#: src/Module/Group.php:171
-msgid "Filter"
-msgstr ""
-
-#: src/Module/Group.php:177
-msgid "Create a group of contacts/friends."
-msgstr ""
-
-#: src/Module/Group.php:178 src/Module/Group.php:201 src/Module/Group.php:276
-#: src/Model/Group.php:543
-msgid "Group Name: "
-msgstr ""
-
-#: src/Module/Group.php:193 src/Model/Group.php:540
-msgid "Contacts not in any group"
-msgstr ""
-
-#: src/Module/Group.php:219
-msgid "Unable to remove group."
-msgstr ""
-
-#: src/Module/Group.php:270
-msgid "Delete Group"
-msgstr ""
-
-#: src/Module/Group.php:280
-msgid "Edit Group Name"
-msgstr ""
-
-#: src/Module/Group.php:290
-msgid "Members"
-msgstr ""
-
-#: src/Module/Group.php:293
-msgid "Group is empty"
-msgstr ""
-
-#: src/Module/Group.php:306
-msgid "Remove contact from group"
-msgstr ""
-
-#: src/Module/Group.php:326
-msgid "Click on a contact to add or remove."
-msgstr ""
-
-#: src/Module/Group.php:340
-msgid "Add contact to group"
-msgstr ""
-
 #: src/Module/Search/Index.php:54
 msgid "Only logged in users are permitted to perform a search."
 msgstr ""
@@ -8777,18 +8955,9 @@ msgstr ""
 msgid "Only one search per minute is permitted for not logged in users."
 msgstr ""
 
-#: src/Module/Search/Index.php:99 src/Content/Nav.php:220
-#: src/Content/Text/HTML.php:887
-msgid "Search"
-msgstr ""
-
 #: src/Module/Search/Index.php:190
 #, php-format
 msgid "Items tagged with: %s"
-msgstr ""
-
-#: src/Module/Search/Acl.php:55 src/Module/Contact/Poke.php:126
-msgid "You must be logged in to use this module."
 msgstr ""
 
 #: src/Module/Search/Saved.php:45
@@ -8803,96 +8972,326 @@ msgstr ""
 msgid "Search term was not removed."
 msgstr ""
 
-#: src/Module/HoverCard.php:47
-msgid "No profile"
+#: src/Module/Security/Login.php:101
+msgid "Create a New Account"
 msgstr ""
 
-#: src/Module/Contact/Poke.php:113
-msgid "Error while sending poke, please retry."
+#: src/Module/Security/Login.php:126
+msgid "Your OpenID: "
 msgstr ""
 
-#: src/Module/Contact/Poke.php:149
-msgid "Poke/Prod"
-msgstr ""
-
-#: src/Module/Contact/Poke.php:150
-msgid "poke, prod or do other things to somebody"
-msgstr ""
-
-#: src/Module/Contact/Poke.php:152
-msgid "Choose what you wish to do to recipient"
-msgstr ""
-
-#: src/Module/Contact/Poke.php:153
-msgid "Make this post private"
-msgstr ""
-
-#: src/Module/Contact/Advanced.php:92
-msgid "Contact update failed."
-msgstr ""
-
-#: src/Module/Contact/Advanced.php:109
+#: src/Module/Security/Login.php:129
 msgid ""
-"<strong>WARNING: This is highly advanced</strong> and if you enter incorrect "
-"information your communications with this contact may stop working."
+"Please enter your username and password to add the OpenID to your existing "
+"account."
 msgstr ""
 
-#: src/Module/Contact/Advanced.php:110
+#: src/Module/Security/Login.php:131
+msgid "Or login using OpenID: "
+msgstr ""
+
+#: src/Module/Security/Login.php:145
+msgid "Password: "
+msgstr ""
+
+#: src/Module/Security/Login.php:146
+msgid "Remember me"
+msgstr ""
+
+#: src/Module/Security/Login.php:155
+msgid "Forgot your password?"
+msgstr ""
+
+#: src/Module/Security/Login.php:158
+msgid "Website Terms of Service"
+msgstr ""
+
+#: src/Module/Security/Login.php:159
+msgid "terms of service"
+msgstr ""
+
+#: src/Module/Security/Login.php:161
+msgid "Website Privacy Policy"
+msgstr ""
+
+#: src/Module/Security/Login.php:162
+msgid "privacy policy"
+msgstr ""
+
+#: src/Module/Security/Logout.php:53
+msgid "Logged out."
+msgstr ""
+
+#: src/Module/Security/OpenID.php:54
+msgid "OpenID protocol error. No ID returned"
+msgstr ""
+
+#: src/Module/Security/OpenID.php:92
 msgid ""
-"Please use your browser 'Back' button <strong>now</strong> if you are "
-"uncertain what to do on this page."
+"Account not found. Please login to your existing account to add the OpenID "
+"to it."
 msgstr ""
 
-#: src/Module/Contact/Advanced.php:130
-msgid "Return to contact editor"
+#: src/Module/Security/OpenID.php:94
+msgid ""
+"Account not found. Please register a new account or login to your existing "
+"account to add the OpenID to it."
 msgstr ""
 
-#: src/Module/Contact/Advanced.php:135
-msgid "Account Nickname"
+#: src/Module/Security/TwoFactor/Recovery.php:60
+#, php-format
+msgid "Remaining recovery codes: %d"
 msgstr ""
 
-#: src/Module/Contact/Advanced.php:136
-msgid "@Tagname - overrides Name/Nickname"
+#: src/Module/Security/TwoFactor/Recovery.php:64
+#: src/Module/Security/TwoFactor/Verify.php:61
+#: src/Module/Settings/TwoFactor/Verify.php:82
+msgid "Invalid code, please retry."
 msgstr ""
 
-#: src/Module/Contact/Advanced.php:137
-msgid "Account URL"
+#: src/Module/Security/TwoFactor/Recovery.php:83
+msgid "Two-factor recovery"
 msgstr ""
 
-#: src/Module/Contact/Advanced.php:138
-msgid "Account URL Alias"
+#: src/Module/Security/TwoFactor/Recovery.php:84
+msgid ""
+"<p>You can enter one of your one-time recovery codes in case you lost access "
+"to your mobile device.</p>"
 msgstr ""
 
-#: src/Module/Contact/Advanced.php:139
-msgid "Friend Request URL"
+#: src/Module/Security/TwoFactor/Recovery.php:85
+#: src/Module/Security/TwoFactor/Verify.php:84
+#, php-format
+msgid ""
+"Don’t have your phone? <a href=\"%s\">Enter a two-factor recovery code</a>"
 msgstr ""
 
-#: src/Module/Contact/Advanced.php:140
-msgid "Friend Confirm URL"
+#: src/Module/Security/TwoFactor/Recovery.php:86
+msgid "Please enter a recovery code"
 msgstr ""
 
-#: src/Module/Contact/Advanced.php:141
-msgid "Notification Endpoint URL"
+#: src/Module/Security/TwoFactor/Recovery.php:87
+msgid "Submit recovery code and complete login"
 msgstr ""
 
-#: src/Module/Contact/Advanced.php:142
-msgid "Poll/Feed URL"
+#: src/Module/Security/TwoFactor/Verify.php:81
+msgid ""
+"<p>Open the two-factor authentication app on your device to get an "
+"authentication code and verify your identity.</p>"
 msgstr ""
 
-#: src/Module/Contact/Advanced.php:143
-msgid "New photo from this URL"
+#: src/Module/Security/TwoFactor/Verify.php:85
+#: src/Module/Settings/TwoFactor/Verify.php:141
+msgid "Please enter a code from your authentication app"
 msgstr ""
 
-#: src/Module/Contact/Contacts.php:54
-msgid "No known contacts."
+#: src/Module/Security/TwoFactor/Verify.php:86
+msgid "Verify code and complete login"
 msgstr ""
 
-#: src/Module/Apps.php:47
-msgid "No installed applications."
+#: src/Module/Settings/Delegation.php:53
+msgid "Delegation successfully granted."
 msgstr ""
 
-#: src/Module/Apps.php:52
-msgid "Applications"
+#: src/Module/Settings/Delegation.php:55
+msgid "Parent user not found, unavailable or password doesn't match."
+msgstr ""
+
+#: src/Module/Settings/Delegation.php:59
+msgid "Delegation successfully revoked."
+msgstr ""
+
+#: src/Module/Settings/Delegation.php:81 src/Module/Settings/Delegation.php:103
+msgid ""
+"Delegated administrators can view but not change delegation permissions."
+msgstr ""
+
+#: src/Module/Settings/Delegation.php:95
+msgid "Delegate user not found."
+msgstr ""
+
+#: src/Module/Settings/Delegation.php:143
+msgid "No parent user"
+msgstr ""
+
+#: src/Module/Settings/Delegation.php:154
+#: src/Module/Settings/Delegation.php:165
+msgid "Parent User"
+msgstr ""
+
+#: src/Module/Settings/Delegation.php:162
+msgid "Additional Accounts"
+msgstr ""
+
+#: src/Module/Settings/Delegation.php:163
+msgid ""
+"Register additional accounts that are automatically connected to your "
+"existing account so you can manage them from this account."
+msgstr ""
+
+#: src/Module/Settings/Delegation.php:164
+msgid "Register an additional account"
+msgstr ""
+
+#: src/Module/Settings/Delegation.php:168
+msgid ""
+"Parent users have total control about this account, including the account "
+"settings. Please double check whom you give this access."
+msgstr ""
+
+#: src/Module/Settings/Delegation.php:172
+msgid "Delegates"
+msgstr ""
+
+#: src/Module/Settings/Delegation.php:174
+msgid ""
+"Delegates are able to manage all aspects of this account/page except for "
+"basic account settings. Please do not delegate your personal account to "
+"anybody that you do not trust completely."
+msgstr ""
+
+#: src/Module/Settings/Delegation.php:175
+msgid "Existing Page Delegates"
+msgstr ""
+
+#: src/Module/Settings/Delegation.php:177
+msgid "Potential Delegates"
+msgstr ""
+
+#: src/Module/Settings/Delegation.php:180
+msgid "Add"
+msgstr ""
+
+#: src/Module/Settings/Delegation.php:181
+msgid "No entries."
+msgstr ""
+
+#: src/Module/Settings/Display.php:105
+msgid "The theme you chose isn't available."
+msgstr ""
+
+#: src/Module/Settings/Display.php:142
+#, php-format
+msgid "%s - (Unsupported)"
+msgstr ""
+
+#: src/Module/Settings/Display.php:188
+msgid "Display Settings"
+msgstr ""
+
+#: src/Module/Settings/Display.php:190
+msgid "General Theme Settings"
+msgstr ""
+
+#: src/Module/Settings/Display.php:191
+msgid "Custom Theme Settings"
+msgstr ""
+
+#: src/Module/Settings/Display.php:192
+msgid "Content Settings"
+msgstr ""
+
+#: src/Module/Settings/Display.php:193 view/theme/duepuntozero/config.php:70
+#: view/theme/frio/config.php:161 view/theme/quattro/config.php:72
+#: view/theme/vier/config.php:120
+msgid "Theme settings"
+msgstr ""
+
+#: src/Module/Settings/Display.php:194
+msgid "Calendar"
+msgstr ""
+
+#: src/Module/Settings/Display.php:200
+msgid "Display Theme:"
+msgstr ""
+
+#: src/Module/Settings/Display.php:201
+msgid "Mobile Theme:"
+msgstr ""
+
+#: src/Module/Settings/Display.php:204
+msgid "Number of items to display per page:"
+msgstr ""
+
+#: src/Module/Settings/Display.php:204 src/Module/Settings/Display.php:205
+msgid "Maximum of 100 items"
+msgstr ""
+
+#: src/Module/Settings/Display.php:205
+msgid "Number of items to display per page when viewed from mobile device:"
+msgstr ""
+
+#: src/Module/Settings/Display.php:206
+msgid "Update browser every xx seconds"
+msgstr ""
+
+#: src/Module/Settings/Display.php:206
+msgid "Minimum of 10 seconds. Enter -1 to disable it."
+msgstr ""
+
+#: src/Module/Settings/Display.php:207
+msgid "Automatic updates only at the top of the post stream pages"
+msgstr ""
+
+#: src/Module/Settings/Display.php:207
+msgid ""
+"Auto update may add new posts at the top of the post stream pages, which can "
+"affect the scroll position and perturb normal reading if it happens anywhere "
+"else the top of the page."
+msgstr ""
+
+#: src/Module/Settings/Display.php:208
+msgid "Don't show emoticons"
+msgstr ""
+
+#: src/Module/Settings/Display.php:208
+msgid ""
+"Normally emoticons are replaced with matching symbols. This setting disables "
+"this behaviour."
+msgstr ""
+
+#: src/Module/Settings/Display.php:209
+msgid "Infinite scroll"
+msgstr ""
+
+#: src/Module/Settings/Display.php:209
+msgid "Automatic fetch new items when reaching the page end."
+msgstr ""
+
+#: src/Module/Settings/Display.php:210
+msgid "Disable Smart Threading"
+msgstr ""
+
+#: src/Module/Settings/Display.php:210
+msgid "Disable the automatic suppression of extraneous thread indentation."
+msgstr ""
+
+#: src/Module/Settings/Display.php:211
+msgid "Hide the Dislike feature"
+msgstr ""
+
+#: src/Module/Settings/Display.php:211
+msgid "Hides the Dislike button and dislike reactions on posts and comments."
+msgstr ""
+
+#: src/Module/Settings/Display.php:212
+msgid "Display the resharer"
+msgstr ""
+
+#: src/Module/Settings/Display.php:212
+msgid "Display the first resharer as icon and text on a reshared item."
+msgstr ""
+
+#: src/Module/Settings/Display.php:213
+msgid "Stay local"
+msgstr ""
+
+#: src/Module/Settings/Display.php:213
+msgid "Don't go to a remote system when following a contact link."
+msgstr ""
+
+#: src/Module/Settings/Display.php:215
+msgid "Beginning of week:"
 msgstr ""
 
 #: src/Module/Settings/Profile/Index.php:85
@@ -8954,6 +9353,10 @@ msgstr ""
 
 #: src/Module/Settings/Profile/Index.php:246
 msgid "Custom Profile Fields"
+msgstr ""
+
+#: src/Module/Settings/Profile/Index.php:248 src/Module/Welcome.php:58
+msgid "Upload Profile Photo"
 msgstr ""
 
 #: src/Module/Settings/Profile/Index.php:252
@@ -9092,81 +9495,82 @@ msgstr ""
 msgid "select a photo from your photo albums"
 msgstr ""
 
-#: src/Module/Settings/Delegation.php:53
-msgid "Delegation successfully granted."
+#: src/Module/Settings/TwoFactor/AppSpecific.php:52
+#: src/Module/Settings/TwoFactor/Recovery.php:50
+#: src/Module/Settings/TwoFactor/Verify.php:56
+msgid "Please enter your password to access this page."
 msgstr ""
 
-#: src/Module/Settings/Delegation.php:55
-msgid "Parent user not found, unavailable or password doesn't match."
+#: src/Module/Settings/TwoFactor/AppSpecific.php:70
+msgid "App-specific password generation failed: The description is empty."
 msgstr ""
 
-#: src/Module/Settings/Delegation.php:59
-msgid "Delegation successfully revoked."
-msgstr ""
-
-#: src/Module/Settings/Delegation.php:81 src/Module/Settings/Delegation.php:103
+#: src/Module/Settings/TwoFactor/AppSpecific.php:73
 msgid ""
-"Delegated administrators can view but not change delegation permissions."
+"App-specific password generation failed: This description already exists."
 msgstr ""
 
-#: src/Module/Settings/Delegation.php:95
-msgid "Delegate user not found."
+#: src/Module/Settings/TwoFactor/AppSpecific.php:77
+msgid "New app-specific password generated."
 msgstr ""
 
-#: src/Module/Settings/Delegation.php:143
-msgid "No parent user"
+#: src/Module/Settings/TwoFactor/AppSpecific.php:83
+msgid "App-specific passwords successfully revoked."
 msgstr ""
 
-#: src/Module/Settings/Delegation.php:154
-#: src/Module/Settings/Delegation.php:165
-msgid "Parent User"
+#: src/Module/Settings/TwoFactor/AppSpecific.php:93
+msgid "App-specific password successfully revoked."
 msgstr ""
 
-#: src/Module/Settings/Delegation.php:162
-msgid "Additional Accounts"
+#: src/Module/Settings/TwoFactor/AppSpecific.php:114
+msgid "Two-factor app-specific passwords"
 msgstr ""
 
-#: src/Module/Settings/Delegation.php:163
+#: src/Module/Settings/TwoFactor/AppSpecific.php:116
 msgid ""
-"Register additional accounts that are automatically connected to your "
-"existing account so you can manage them from this account."
+"<p>App-specific passwords are randomly generated passwords used instead your "
+"regular password to authenticate your account on third-party applications "
+"that don't support two-factor authentication.</p>"
 msgstr ""
 
-#: src/Module/Settings/Delegation.php:164
-msgid "Register an additional account"
-msgstr ""
-
-#: src/Module/Settings/Delegation.php:168
+#: src/Module/Settings/TwoFactor/AppSpecific.php:117
 msgid ""
-"Parent users have total control about this account, including the account "
-"settings. Please double check whom you give this access."
+"Make sure to copy your new app-specific password now. You won’t be able to "
+"see it again!"
 msgstr ""
 
-#: src/Module/Settings/Delegation.php:172
-msgid "Delegates"
+#: src/Module/Settings/TwoFactor/AppSpecific.php:120
+msgid "Description"
 msgstr ""
 
-#: src/Module/Settings/Delegation.php:174
+#: src/Module/Settings/TwoFactor/AppSpecific.php:121
+msgid "Last Used"
+msgstr ""
+
+#: src/Module/Settings/TwoFactor/AppSpecific.php:122
+msgid "Revoke"
+msgstr ""
+
+#: src/Module/Settings/TwoFactor/AppSpecific.php:123
+msgid "Revoke All"
+msgstr ""
+
+#: src/Module/Settings/TwoFactor/AppSpecific.php:126
 msgid ""
-"Delegates are able to manage all aspects of this account/page except for "
-"basic account settings. Please do not delegate your personal account to "
-"anybody that you do not trust completely."
+"When you generate a new app-specific password, you must use it right away, "
+"it will be shown to you once after you generate it."
 msgstr ""
 
-#: src/Module/Settings/Delegation.php:175
-msgid "Existing Page Delegates"
+#: src/Module/Settings/TwoFactor/AppSpecific.php:127
+msgid "Generate new app-specific password"
 msgstr ""
 
-#: src/Module/Settings/Delegation.php:177
-msgid "Potential Delegates"
+#: src/Module/Settings/TwoFactor/AppSpecific.php:128
+msgid "Friendiqa on my Fairphone 2..."
 msgstr ""
 
-#: src/Module/Settings/Delegation.php:180
-msgid "Add"
-msgstr ""
-
-#: src/Module/Settings/Delegation.php:181
-msgid "No entries."
+#: src/Module/Settings/TwoFactor/AppSpecific.php:129
+msgid "Generate"
 msgstr ""
 
 #: src/Module/Settings/TwoFactor/Index.php:67
@@ -9261,10 +9665,34 @@ msgstr ""
 msgid "Finish app configuration"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Verify.php:56
-#: src/Module/Settings/TwoFactor/Recovery.php:50
-#: src/Module/Settings/TwoFactor/AppSpecific.php:52
-msgid "Please enter your password to access this page."
+#: src/Module/Settings/TwoFactor/Recovery.php:66
+msgid "New recovery codes successfully generated."
+msgstr ""
+
+#: src/Module/Settings/TwoFactor/Recovery.php:92
+msgid "Two-factor recovery codes"
+msgstr ""
+
+#: src/Module/Settings/TwoFactor/Recovery.php:94
+msgid ""
+"<p>Recovery codes can be used to access your account in the event you lose "
+"access to your device and cannot receive two-factor authentication codes.</"
+"p><p><strong>Put these in a safe spot!</strong> If you lose your device and "
+"don’t have the recovery codes you will lose access to your account.</p>"
+msgstr ""
+
+#: src/Module/Settings/TwoFactor/Recovery.php:96
+msgid ""
+"When you generate new recovery codes, you must copy the new codes. Your old "
+"codes won’t work anymore."
+msgstr ""
+
+#: src/Module/Settings/TwoFactor/Recovery.php:97
+msgid "Generate new recovery codes"
+msgstr ""
+
+#: src/Module/Settings/TwoFactor/Recovery.php:99
+msgid "Next: Verification"
 msgstr ""
 
 #: src/Module/Settings/TwoFactor/Verify.php:78
@@ -9312,230 +9740,6 @@ msgstr ""
 msgid "Verify code and enable two-factor authentication"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Recovery.php:66
-msgid "New recovery codes successfully generated."
-msgstr ""
-
-#: src/Module/Settings/TwoFactor/Recovery.php:92
-msgid "Two-factor recovery codes"
-msgstr ""
-
-#: src/Module/Settings/TwoFactor/Recovery.php:94
-msgid ""
-"<p>Recovery codes can be used to access your account in the event you lose "
-"access to your device and cannot receive two-factor authentication codes.</"
-"p><p><strong>Put these in a safe spot!</strong> If you lose your device and "
-"don’t have the recovery codes you will lose access to your account.</p>"
-msgstr ""
-
-#: src/Module/Settings/TwoFactor/Recovery.php:96
-msgid ""
-"When you generate new recovery codes, you must copy the new codes. Your old "
-"codes won’t work anymore."
-msgstr ""
-
-#: src/Module/Settings/TwoFactor/Recovery.php:97
-msgid "Generate new recovery codes"
-msgstr ""
-
-#: src/Module/Settings/TwoFactor/Recovery.php:99
-msgid "Next: Verification"
-msgstr ""
-
-#: src/Module/Settings/TwoFactor/AppSpecific.php:70
-msgid "App-specific password generation failed: The description is empty."
-msgstr ""
-
-#: src/Module/Settings/TwoFactor/AppSpecific.php:73
-msgid ""
-"App-specific password generation failed: This description already exists."
-msgstr ""
-
-#: src/Module/Settings/TwoFactor/AppSpecific.php:77
-msgid "New app-specific password generated."
-msgstr ""
-
-#: src/Module/Settings/TwoFactor/AppSpecific.php:83
-msgid "App-specific passwords successfully revoked."
-msgstr ""
-
-#: src/Module/Settings/TwoFactor/AppSpecific.php:93
-msgid "App-specific password successfully revoked."
-msgstr ""
-
-#: src/Module/Settings/TwoFactor/AppSpecific.php:114
-msgid "Two-factor app-specific passwords"
-msgstr ""
-
-#: src/Module/Settings/TwoFactor/AppSpecific.php:116
-msgid ""
-"<p>App-specific passwords are randomly generated passwords used instead your "
-"regular password to authenticate your account on third-party applications "
-"that don't support two-factor authentication.</p>"
-msgstr ""
-
-#: src/Module/Settings/TwoFactor/AppSpecific.php:117
-msgid ""
-"Make sure to copy your new app-specific password now. You won’t be able to "
-"see it again!"
-msgstr ""
-
-#: src/Module/Settings/TwoFactor/AppSpecific.php:120
-msgid "Description"
-msgstr ""
-
-#: src/Module/Settings/TwoFactor/AppSpecific.php:121
-msgid "Last Used"
-msgstr ""
-
-#: src/Module/Settings/TwoFactor/AppSpecific.php:122
-msgid "Revoke"
-msgstr ""
-
-#: src/Module/Settings/TwoFactor/AppSpecific.php:123
-msgid "Revoke All"
-msgstr ""
-
-#: src/Module/Settings/TwoFactor/AppSpecific.php:126
-msgid ""
-"When you generate a new app-specific password, you must use it right away, "
-"it will be shown to you once after you generate it."
-msgstr ""
-
-#: src/Module/Settings/TwoFactor/AppSpecific.php:127
-msgid "Generate new app-specific password"
-msgstr ""
-
-#: src/Module/Settings/TwoFactor/AppSpecific.php:128
-msgid "Friendiqa on my Fairphone 2..."
-msgstr ""
-
-#: src/Module/Settings/TwoFactor/AppSpecific.php:129
-msgid "Generate"
-msgstr ""
-
-#: src/Module/Settings/Display.php:105
-msgid "The theme you chose isn't available."
-msgstr ""
-
-#: src/Module/Settings/Display.php:142
-#, php-format
-msgid "%s - (Unsupported)"
-msgstr ""
-
-#: src/Module/Settings/Display.php:188
-msgid "Display Settings"
-msgstr ""
-
-#: src/Module/Settings/Display.php:190
-msgid "General Theme Settings"
-msgstr ""
-
-#: src/Module/Settings/Display.php:191
-msgid "Custom Theme Settings"
-msgstr ""
-
-#: src/Module/Settings/Display.php:192
-msgid "Content Settings"
-msgstr ""
-
-#: src/Module/Settings/Display.php:194
-msgid "Calendar"
-msgstr ""
-
-#: src/Module/Settings/Display.php:200
-msgid "Display Theme:"
-msgstr ""
-
-#: src/Module/Settings/Display.php:201
-msgid "Mobile Theme:"
-msgstr ""
-
-#: src/Module/Settings/Display.php:204
-msgid "Number of items to display per page:"
-msgstr ""
-
-#: src/Module/Settings/Display.php:204 src/Module/Settings/Display.php:205
-msgid "Maximum of 100 items"
-msgstr ""
-
-#: src/Module/Settings/Display.php:205
-msgid "Number of items to display per page when viewed from mobile device:"
-msgstr ""
-
-#: src/Module/Settings/Display.php:206
-msgid "Update browser every xx seconds"
-msgstr ""
-
-#: src/Module/Settings/Display.php:206
-msgid "Minimum of 10 seconds. Enter -1 to disable it."
-msgstr ""
-
-#: src/Module/Settings/Display.php:207
-msgid "Automatic updates only at the top of the post stream pages"
-msgstr ""
-
-#: src/Module/Settings/Display.php:207
-msgid ""
-"Auto update may add new posts at the top of the post stream pages, which can "
-"affect the scroll position and perturb normal reading if it happens anywhere "
-"else the top of the page."
-msgstr ""
-
-#: src/Module/Settings/Display.php:208
-msgid "Don't show emoticons"
-msgstr ""
-
-#: src/Module/Settings/Display.php:208
-msgid ""
-"Normally emoticons are replaced with matching symbols. This setting disables "
-"this behaviour."
-msgstr ""
-
-#: src/Module/Settings/Display.php:209
-msgid "Infinite scroll"
-msgstr ""
-
-#: src/Module/Settings/Display.php:209
-msgid "Automatic fetch new items when reaching the page end."
-msgstr ""
-
-#: src/Module/Settings/Display.php:210
-msgid "Disable Smart Threading"
-msgstr ""
-
-#: src/Module/Settings/Display.php:210
-msgid "Disable the automatic suppression of extraneous thread indentation."
-msgstr ""
-
-#: src/Module/Settings/Display.php:211
-msgid "Hide the Dislike feature"
-msgstr ""
-
-#: src/Module/Settings/Display.php:211
-msgid "Hides the Dislike button and dislike reactions on posts and comments."
-msgstr ""
-
-#: src/Module/Settings/Display.php:212
-msgid "Display the resharer"
-msgstr ""
-
-#: src/Module/Settings/Display.php:212
-msgid "Display the first resharer as icon and text on a reshared item."
-msgstr ""
-
-#: src/Module/Settings/Display.php:213
-msgid "Stay local"
-msgstr ""
-
-#: src/Module/Settings/Display.php:213
-msgid "Don't go to a remote system when following a contact link."
-msgstr ""
-
-#: src/Module/Settings/Display.php:215
-msgid "Beginning of week:"
-msgstr ""
-
 #: src/Module/Settings/UserExport.php:58
 msgid "Export account"
 msgstr ""
@@ -9567,8 +9771,496 @@ msgid ""
 "e.g. Mastodon."
 msgstr ""
 
-#: src/Module/Maintenance.php:46
-msgid "System down for maintenance"
+#: src/Module/Special/HTTPException.php:49
+msgid "Bad Request"
+msgstr ""
+
+#: src/Module/Special/HTTPException.php:50
+msgid "Unauthorized"
+msgstr ""
+
+#: src/Module/Special/HTTPException.php:51
+msgid "Forbidden"
+msgstr ""
+
+#: src/Module/Special/HTTPException.php:52
+msgid "Not Found"
+msgstr ""
+
+#: src/Module/Special/HTTPException.php:53
+msgid "Internal Server Error"
+msgstr ""
+
+#: src/Module/Special/HTTPException.php:54
+msgid "Service Unavailable"
+msgstr ""
+
+#: src/Module/Special/HTTPException.php:61
+msgid ""
+"The server cannot or will not process the request due to an apparent client "
+"error."
+msgstr ""
+
+#: src/Module/Special/HTTPException.php:62
+msgid "Authentication is required and has failed or has not yet been provided."
+msgstr ""
+
+#: src/Module/Special/HTTPException.php:63
+msgid ""
+"The request was valid, but the server is refusing action. The user might not "
+"have the necessary permissions for a resource, or may need an account."
+msgstr ""
+
+#: src/Module/Special/HTTPException.php:64
+msgid ""
+"The requested resource could not be found but may be available in the future."
+msgstr ""
+
+#: src/Module/Special/HTTPException.php:65
+msgid ""
+"An unexpected condition was encountered and no more specific message is "
+"suitable."
+msgstr ""
+
+#: src/Module/Special/HTTPException.php:66
+msgid ""
+"The server is currently unavailable (because it is overloaded or down for "
+"maintenance). Please try again later."
+msgstr ""
+
+#: src/Module/Special/HTTPException.php:76
+msgid "Stack trace:"
+msgstr ""
+
+#: src/Module/Special/HTTPException.php:80
+#, php-format
+msgid "Exception thrown in %s:%d"
+msgstr ""
+
+#: src/Module/Tos.php:46 src/Module/Tos.php:88
+msgid ""
+"At the time of registration, and for providing communications between the "
+"user account and their contacts, the user has to provide a display name (pen "
+"name), an username (nickname) and a working email address. The names will be "
+"accessible on the profile page of the account by any visitor of the page, "
+"even if other profile details are not displayed. The email address will only "
+"be used to send the user notifications about interactions, but wont be "
+"visibly displayed. The listing of an account in the node's user directory or "
+"the global user directory is optional and can be controlled in the user "
+"settings, it is not necessary for communication."
+msgstr ""
+
+#: src/Module/Tos.php:47 src/Module/Tos.php:89
+msgid ""
+"This data is required for communication and is passed on to the nodes of the "
+"communication partners and is stored there. Users can enter additional "
+"private data that may be transmitted to the communication partners accounts."
+msgstr ""
+
+#: src/Module/Tos.php:48 src/Module/Tos.php:90
+#, php-format
+msgid ""
+"At any point in time a logged in user can export their account data from the "
+"<a href=\"%1$s/settings/userexport\">account settings</a>. If the user wants "
+"to delete their account they can do so at <a href=\"%1$s/removeme\">%1$s/"
+"removeme</a>. The deletion of the account will be permanent. Deletion of the "
+"data will also be requested from the nodes of the communication partners."
+msgstr ""
+
+#: src/Module/Tos.php:51 src/Module/Tos.php:87
+msgid "Privacy Statement"
+msgstr ""
+
+#: src/Module/Welcome.php:44
+msgid "Welcome to Friendica"
+msgstr ""
+
+#: src/Module/Welcome.php:45
+msgid "New Member Checklist"
+msgstr ""
+
+#: src/Module/Welcome.php:46
+msgid ""
+"We would like to offer some tips and links to help make your experience "
+"enjoyable. Click any item to visit the relevant page. A link to this page "
+"will be visible from your home page for two weeks after your initial "
+"registration and then will quietly disappear."
+msgstr ""
+
+#: src/Module/Welcome.php:48
+msgid "Getting Started"
+msgstr ""
+
+#: src/Module/Welcome.php:49
+msgid "Friendica Walk-Through"
+msgstr ""
+
+#: src/Module/Welcome.php:50
+msgid ""
+"On your <em>Quick Start</em> page - find a brief introduction to your "
+"profile and network tabs, make some new connections, and find some groups to "
+"join."
+msgstr ""
+
+#: src/Module/Welcome.php:53
+msgid "Go to Your Settings"
+msgstr ""
+
+#: src/Module/Welcome.php:54
+msgid ""
+"On your <em>Settings</em> page -  change your initial password. Also make a "
+"note of your Identity Address. This looks just like an email address - and "
+"will be useful in making friends on the free social web."
+msgstr ""
+
+#: src/Module/Welcome.php:55
+msgid ""
+"Review the other settings, particularly the privacy settings. An unpublished "
+"directory listing is like having an unlisted phone number. In general, you "
+"should probably publish your listing - unless all of your friends and "
+"potential friends know exactly how to find you."
+msgstr ""
+
+#: src/Module/Welcome.php:59
+msgid ""
+"Upload a profile photo if you have not done so already. Studies have shown "
+"that people with real photos of themselves are ten times more likely to make "
+"friends than people who do not."
+msgstr ""
+
+#: src/Module/Welcome.php:60
+msgid "Edit Your Profile"
+msgstr ""
+
+#: src/Module/Welcome.php:61
+msgid ""
+"Edit your <strong>default</strong> profile to your liking. Review the "
+"settings for hiding your list of friends and hiding the profile from unknown "
+"visitors."
+msgstr ""
+
+#: src/Module/Welcome.php:62
+msgid "Profile Keywords"
+msgstr ""
+
+#: src/Module/Welcome.php:63
+msgid ""
+"Set some public keywords for your profile which describe your interests. We "
+"may be able to find other people with similar interests and suggest "
+"friendships."
+msgstr ""
+
+#: src/Module/Welcome.php:65
+msgid "Connecting"
+msgstr ""
+
+#: src/Module/Welcome.php:67
+msgid "Importing Emails"
+msgstr ""
+
+#: src/Module/Welcome.php:68
+msgid ""
+"Enter your email access information on your Connector Settings page if you "
+"wish to import and interact with friends or mailing lists from your email "
+"INBOX"
+msgstr ""
+
+#: src/Module/Welcome.php:69
+msgid "Go to Your Contacts Page"
+msgstr ""
+
+#: src/Module/Welcome.php:70
+msgid ""
+"Your Contacts page is your gateway to managing friendships and connecting "
+"with friends on other networks. Typically you enter their address or site "
+"URL in the <em>Add New Contact</em> dialog."
+msgstr ""
+
+#: src/Module/Welcome.php:71
+msgid "Go to Your Site's Directory"
+msgstr ""
+
+#: src/Module/Welcome.php:72
+msgid ""
+"The Directory page lets you find other people in this network or other "
+"federated sites. Look for a <em>Connect</em> or <em>Follow</em> link on "
+"their profile page. Provide your own Identity Address if requested."
+msgstr ""
+
+#: src/Module/Welcome.php:73
+msgid "Finding New People"
+msgstr ""
+
+#: src/Module/Welcome.php:74
+msgid ""
+"On the side panel of the Contacts page are several tools to find new "
+"friends. We can match people by interest, look up people by name or "
+"interest, and provide suggestions based on network relationships. On a brand "
+"new site, friend suggestions will usually begin to be populated within 24 "
+"hours."
+msgstr ""
+
+#: src/Module/Welcome.php:77
+msgid "Group Your Contacts"
+msgstr ""
+
+#: src/Module/Welcome.php:78
+msgid ""
+"Once you have made some friends, organize them into private conversation "
+"groups from the sidebar of your Contacts page and then you can interact with "
+"each group privately on your Network page."
+msgstr ""
+
+#: src/Module/Welcome.php:80
+msgid "Why Aren't My Posts Public?"
+msgstr ""
+
+#: src/Module/Welcome.php:81
+msgid ""
+"Friendica respects your privacy. By default, your posts will only show up to "
+"people you've added as friends. For more information, see the help section "
+"from the link above."
+msgstr ""
+
+#: src/Module/Welcome.php:83
+msgid "Getting Help"
+msgstr ""
+
+#: src/Module/Welcome.php:84
+msgid "Go to the Help Section"
+msgstr ""
+
+#: src/Module/Welcome.php:85
+msgid ""
+"Our <strong>help</strong> pages may be consulted for detail on other program "
+"features and resources."
+msgstr ""
+
+#: src/Object/EMail/ItemCCEMail.php:39
+#, php-format
+msgid ""
+"This message was sent to you by %s, a member of the Friendica social network."
+msgstr ""
+
+#: src/Object/EMail/ItemCCEMail.php:41
+#, php-format
+msgid "You may visit them online at %s"
+msgstr ""
+
+#: src/Object/EMail/ItemCCEMail.php:42
+msgid ""
+"Please contact the sender by replying to this post if you do not wish to "
+"receive these messages."
+msgstr ""
+
+#: src/Object/EMail/ItemCCEMail.php:46
+#, php-format
+msgid "%s posted an update."
+msgstr ""
+
+#: src/Object/Post.php:147
+msgid "This entry was edited"
+msgstr ""
+
+#: src/Object/Post.php:175
+msgid "Private Message"
+msgstr ""
+
+#: src/Object/Post.php:220
+msgid "pinned item"
+msgstr ""
+
+#: src/Object/Post.php:225
+msgid "Delete locally"
+msgstr ""
+
+#: src/Object/Post.php:228
+msgid "Delete globally"
+msgstr ""
+
+#: src/Object/Post.php:228
+msgid "Remove locally"
+msgstr ""
+
+#: src/Object/Post.php:241
+msgid "save to folder"
+msgstr ""
+
+#: src/Object/Post.php:276
+msgid "I will attend"
+msgstr ""
+
+#: src/Object/Post.php:276
+msgid "I will not attend"
+msgstr ""
+
+#: src/Object/Post.php:276
+msgid "I might attend"
+msgstr ""
+
+#: src/Object/Post.php:306
+msgid "ignore thread"
+msgstr ""
+
+#: src/Object/Post.php:307
+msgid "unignore thread"
+msgstr ""
+
+#: src/Object/Post.php:308
+msgid "toggle ignore status"
+msgstr ""
+
+#: src/Object/Post.php:320
+msgid "pin"
+msgstr ""
+
+#: src/Object/Post.php:321
+msgid "unpin"
+msgstr ""
+
+#: src/Object/Post.php:322
+msgid "toggle pin status"
+msgstr ""
+
+#: src/Object/Post.php:325
+msgid "pinned"
+msgstr ""
+
+#: src/Object/Post.php:332
+msgid "add star"
+msgstr ""
+
+#: src/Object/Post.php:333
+msgid "remove star"
+msgstr ""
+
+#: src/Object/Post.php:334
+msgid "toggle star status"
+msgstr ""
+
+#: src/Object/Post.php:337
+msgid "starred"
+msgstr ""
+
+#: src/Object/Post.php:341
+msgid "add tag"
+msgstr ""
+
+#: src/Object/Post.php:351
+msgid "like"
+msgstr ""
+
+#: src/Object/Post.php:352
+msgid "dislike"
+msgstr ""
+
+#: src/Object/Post.php:354
+msgid "Quote share this"
+msgstr ""
+
+#: src/Object/Post.php:354
+msgid "Quote Share"
+msgstr ""
+
+#: src/Object/Post.php:357
+msgid "Reshare this"
+msgstr ""
+
+#: src/Object/Post.php:357
+msgid "Reshare"
+msgstr ""
+
+#: src/Object/Post.php:358
+msgid "Cancel your Reshare"
+msgstr ""
+
+#: src/Object/Post.php:358
+msgid "Unshare"
+msgstr ""
+
+#: src/Object/Post.php:403
+#, php-format
+msgid "%s (Received %s)"
+msgstr ""
+
+#: src/Object/Post.php:408
+msgid "Comment this item on your system"
+msgstr ""
+
+#: src/Object/Post.php:408
+msgid "remote comment"
+msgstr ""
+
+#: src/Object/Post.php:420
+msgid "Pushed"
+msgstr ""
+
+#: src/Object/Post.php:420
+msgid "Pulled"
+msgstr ""
+
+#: src/Object/Post.php:452
+msgid "to"
+msgstr ""
+
+#: src/Object/Post.php:453
+msgid "via"
+msgstr ""
+
+#: src/Object/Post.php:454
+msgid "Wall-to-Wall"
+msgstr ""
+
+#: src/Object/Post.php:455
+msgid "via Wall-To-Wall:"
+msgstr ""
+
+#: src/Object/Post.php:492
+#, php-format
+msgid "Reply to %s"
+msgstr ""
+
+#: src/Object/Post.php:495
+msgid "More"
+msgstr ""
+
+#: src/Object/Post.php:513
+msgid "Notifier task is pending"
+msgstr ""
+
+#: src/Object/Post.php:514
+msgid "Delivery to remote servers is pending"
+msgstr ""
+
+#: src/Object/Post.php:515
+msgid "Delivery to remote servers is underway"
+msgstr ""
+
+#: src/Object/Post.php:516
+msgid "Delivery to remote servers is mostly done"
+msgstr ""
+
+#: src/Object/Post.php:517
+msgid "Delivery to remote servers is done"
+msgstr ""
+
+#: src/Object/Post.php:537
+#, php-format
+msgid "%d comment"
+msgid_plural "%d comments"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/Object/Post.php:538
+msgid "Show more"
+msgstr ""
+
+#: src/Object/Post.php:539
+msgid "Show fewer"
+msgstr ""
+
+#: src/Protocol/Diaspora.php:3431
+msgid "Attachments:"
 msgstr ""
 
 #: src/Protocol/OStatus.php:1763
@@ -9589,8 +10281,105 @@ msgstr ""
 msgid "stopped following"
 msgstr ""
 
-#: src/Protocol/Diaspora.php:3431
-msgid "Attachments:"
+#: src/Render/FriendicaSmartyEngine.php:52
+msgid "The folder view/smarty3/ must be writable by webserver."
+msgstr ""
+
+#: src/Repository/ProfileField.php:275
+msgid "Hometown:"
+msgstr ""
+
+#: src/Repository/ProfileField.php:276
+msgid "Marital Status:"
+msgstr ""
+
+#: src/Repository/ProfileField.php:277
+msgid "With:"
+msgstr ""
+
+#: src/Repository/ProfileField.php:278
+msgid "Since:"
+msgstr ""
+
+#: src/Repository/ProfileField.php:279
+msgid "Sexual Preference:"
+msgstr ""
+
+#: src/Repository/ProfileField.php:280
+msgid "Political Views:"
+msgstr ""
+
+#: src/Repository/ProfileField.php:281
+msgid "Religious Views:"
+msgstr ""
+
+#: src/Repository/ProfileField.php:282
+msgid "Likes:"
+msgstr ""
+
+#: src/Repository/ProfileField.php:283
+msgid "Dislikes:"
+msgstr ""
+
+#: src/Repository/ProfileField.php:284
+msgid "Title/Description:"
+msgstr ""
+
+#: src/Repository/ProfileField.php:286
+msgid "Musical interests"
+msgstr ""
+
+#: src/Repository/ProfileField.php:287
+msgid "Books, literature"
+msgstr ""
+
+#: src/Repository/ProfileField.php:288
+msgid "Television"
+msgstr ""
+
+#: src/Repository/ProfileField.php:289
+msgid "Film/dance/culture/entertainment"
+msgstr ""
+
+#: src/Repository/ProfileField.php:290
+msgid "Hobbies/Interests"
+msgstr ""
+
+#: src/Repository/ProfileField.php:291
+msgid "Love/romance"
+msgstr ""
+
+#: src/Repository/ProfileField.php:292
+msgid "Work/employment"
+msgstr ""
+
+#: src/Repository/ProfileField.php:293
+msgid "School/education"
+msgstr ""
+
+#: src/Repository/ProfileField.php:294
+msgid "Contact information and Social Networks"
+msgstr ""
+
+#: src/Security/Authentication.php:210 src/Security/Authentication.php:262
+msgid "Login failed."
+msgstr ""
+
+#: src/Security/Authentication.php:273
+msgid "Login failed. Please check your credentials."
+msgstr ""
+
+#: src/Security/Authentication.php:389
+#, php-format
+msgid "Welcome %s"
+msgstr ""
+
+#: src/Security/Authentication.php:390
+msgid "Please upload a profile photo."
+msgstr ""
+
+#: src/Util/EMailer/MailBuilder.php:259
+msgid "Friendica Notification"
 msgstr ""
 
 #: src/Util/EMailer/NotifyMailBuilder.php:78
@@ -9610,10 +10399,6 @@ msgstr ""
 #: src/Util/EMailer/SystemMailBuilder.php:101
 #: src/Util/EMailer/SystemMailBuilder.php:118
 msgid "thanks"
-msgstr ""
-
-#: src/Util/EMailer/MailBuilder.php:259
-msgid "Friendica Notification"
 msgstr ""
 
 #: src/Util/Temporal.php:167
@@ -9682,1058 +10467,274 @@ msgstr ""
 msgid "%1$d %2$s ago"
 msgstr ""
 
-#: src/Model/Storage/Database.php:74
+#: src/Worker/Delivery.php:557
+msgid "(no subject)"
+msgstr ""
+
+#: update.php:198
 #, php-format
-msgid "Database storage failed to update %s"
+msgid "%s: Updating author-id and owner-id in item and thread table. "
 msgstr ""
 
-#: src/Model/Storage/Database.php:82
-msgid "Database storage failed to insert data"
-msgstr ""
-
-#: src/Model/Storage/Filesystem.php:100
+#: update.php:253
 #, php-format
+msgid "%s: Updating post-type."
+msgstr ""
+
+#: view/theme/duepuntozero/config.php:52
+msgid "default"
+msgstr ""
+
+#: view/theme/duepuntozero/config.php:53
+msgid "greenzero"
+msgstr ""
+
+#: view/theme/duepuntozero/config.php:54
+msgid "purplezero"
+msgstr ""
+
+#: view/theme/duepuntozero/config.php:55
+msgid "easterbunny"
+msgstr ""
+
+#: view/theme/duepuntozero/config.php:56
+msgid "darkzero"
+msgstr ""
+
+#: view/theme/duepuntozero/config.php:57
+msgid "comix"
+msgstr ""
+
+#: view/theme/duepuntozero/config.php:58
+msgid "slackr"
+msgstr ""
+
+#: view/theme/duepuntozero/config.php:71
+msgid "Variations"
+msgstr ""
+
+#: view/theme/frio/config.php:142
+msgid "Light (Accented)"
+msgstr ""
+
+#: view/theme/frio/config.php:143
+msgid "Dark (Accented)"
+msgstr ""
+
+#: view/theme/frio/config.php:144
+msgid "Black (Accented)"
+msgstr ""
+
+#: view/theme/frio/config.php:156
+msgid "Note"
+msgstr ""
+
+#: view/theme/frio/config.php:156
+msgid "Check image permissions if all users are allowed to see the image"
+msgstr ""
+
+#: view/theme/frio/config.php:162
+msgid "Custom"
+msgstr ""
+
+#: view/theme/frio/config.php:163
+msgid "Legacy"
+msgstr ""
+
+#: view/theme/frio/config.php:164
+msgid "Accented"
+msgstr ""
+
+#: view/theme/frio/config.php:165
+msgid "Select color scheme"
+msgstr ""
+
+#: view/theme/frio/config.php:166
+msgid "Select scheme accent"
+msgstr ""
+
+#: view/theme/frio/config.php:166
+msgid "Blue"
+msgstr ""
+
+#: view/theme/frio/config.php:166
+msgid "Red"
+msgstr ""
+
+#: view/theme/frio/config.php:166
+msgid "Purple"
+msgstr ""
+
+#: view/theme/frio/config.php:166
+msgid "Green"
+msgstr ""
+
+#: view/theme/frio/config.php:166
+msgid "Pink"
+msgstr ""
+
+#: view/theme/frio/config.php:167
+msgid "Copy or paste schemestring"
+msgstr ""
+
+#: view/theme/frio/config.php:167
 msgid ""
-"Filesystem storage failed to create \"%s\". Check you write permissions."
+"You can copy this string to share your theme with others. Pasting here "
+"applies the schemestring"
 msgstr ""
 
-#: src/Model/Storage/Filesystem.php:148
-#, php-format
+#: view/theme/frio/config.php:168
+msgid "Navigation bar background color"
+msgstr ""
+
+#: view/theme/frio/config.php:169
+msgid "Navigation bar icon color "
+msgstr ""
+
+#: view/theme/frio/config.php:170
+msgid "Link color"
+msgstr ""
+
+#: view/theme/frio/config.php:171
+msgid "Set the background color"
+msgstr ""
+
+#: view/theme/frio/config.php:172
+msgid "Content background opacity"
+msgstr ""
+
+#: view/theme/frio/config.php:173
+msgid "Set the background image"
+msgstr ""
+
+#: view/theme/frio/config.php:174
+msgid "Background image style"
+msgstr ""
+
+#: view/theme/frio/config.php:179
+msgid "Login page background image"
+msgstr ""
+
+#: view/theme/frio/config.php:183
+msgid "Login page background color"
+msgstr ""
+
+#: view/theme/frio/config.php:183
+msgid "Leave background image and color empty for theme defaults"
+msgstr ""
+
+#: view/theme/frio/php/default.php:81 view/theme/frio/php/standard.php:38
+msgid "Skip to main content"
+msgstr ""
+
+#: view/theme/frio/php/Image.php:40
+msgid "Top Banner"
+msgstr ""
+
+#: view/theme/frio/php/Image.php:40
 msgid ""
-"Filesystem storage failed to save data to \"%s\". Check your write "
-"permissions"
+"Resize image to the width of the screen and show background color below on "
+"long pages."
 msgstr ""
 
-#: src/Model/Storage/Filesystem.php:176
-msgid "Storage base path"
+#: view/theme/frio/php/Image.php:41
+msgid "Full screen"
 msgstr ""
 
-#: src/Model/Storage/Filesystem.php:178
+#: view/theme/frio/php/Image.php:41
 msgid ""
-"Folder where uploaded files are saved. For maximum security, This should be "
-"a path outside web server folder tree"
+"Resize image to fill entire screen, clipping either the right or the bottom."
 msgstr ""
 
-#: src/Model/Storage/Filesystem.php:191
-msgid "Enter a valid existing folder"
+#: view/theme/frio/php/Image.php:42
+msgid "Single row mosaic"
 msgstr ""
 
-#: src/Model/Item.php:2530
-#, php-format
-msgid "Detected languages in this post:\\n%s"
-msgstr ""
-
-#: src/Model/Item.php:3525
-msgid "activity"
-msgstr ""
-
-#: src/Model/Item.php:3530
-msgid "post"
-msgstr ""
-
-#: src/Model/Item.php:3654
-#, php-format
-msgid "Content warning: %s"
-msgstr ""
-
-#: src/Model/Item.php:3727
-msgid "bytes"
-msgstr ""
-
-#: src/Model/Item.php:3772
-msgid "View on separate page"
-msgstr ""
-
-#: src/Model/Item.php:3773
-msgid "view on separate page"
-msgstr ""
-
-#: src/Model/Item.php:3778 src/Model/Item.php:3784
-#: src/Content/Text/BBCode.php:1088
-msgid "link to source"
-msgstr ""
-
-#: src/Model/Mail.php:121 src/Model/Mail.php:259
-msgid "[no subject]"
-msgstr ""
-
-#: src/Model/Contact.php:980 src/Model/Contact.php:993
-msgid "UnFollow"
-msgstr ""
-
-#: src/Model/Contact.php:989
-msgid "Drop Contact"
-msgstr ""
-
-#: src/Model/Contact.php:1405
-msgid "Organisation"
-msgstr ""
-
-#: src/Model/Contact.php:1409 src/Content/Widget.php:539
-msgid "News"
-msgstr ""
-
-#: src/Model/Contact.php:1413
-msgid "Forum"
-msgstr ""
-
-#: src/Model/Contact.php:2153
-msgid "Connect URL missing."
-msgstr ""
-
-#: src/Model/Contact.php:2162
+#: view/theme/frio/php/Image.php:42
 msgid ""
-"The contact could not be added. Please check the relevant network "
-"credentials in your Settings -> Social Networks page."
+"Resize image to repeat it on a single row, either vertical or horizontal."
 msgstr ""
 
-#: src/Model/Contact.php:2203
-msgid ""
-"This site is not configured to allow communications with other networks."
+#: view/theme/frio/php/Image.php:43
+msgid "Mosaic"
 msgstr ""
 
-#: src/Model/Contact.php:2204 src/Model/Contact.php:2217
-msgid "No compatible communication protocols or feeds were discovered."
+#: view/theme/frio/php/Image.php:43
+msgid "Repeat image to fill the screen."
 msgstr ""
 
-#: src/Model/Contact.php:2215
-msgid "The profile address specified does not provide adequate information."
+#: view/theme/frio/theme.php:207
+msgid "Guest"
 msgstr ""
 
-#: src/Model/Contact.php:2220
-msgid "An author or name was not found."
+#: view/theme/frio/theme.php:210
+msgid "Visitor"
 msgstr ""
 
-#: src/Model/Contact.php:2223
-msgid "No browser URL could be matched to this address."
+#: view/theme/quattro/config.php:73
+msgid "Alignment"
 msgstr ""
 
-#: src/Model/Contact.php:2226
-msgid ""
-"Unable to match @-style Identity Address with a known protocol or email "
-"contact."
+#: view/theme/quattro/config.php:73
+msgid "Left"
 msgstr ""
 
-#: src/Model/Contact.php:2227
-msgid "Use mailto: in front of address to force email check."
+#: view/theme/quattro/config.php:73
+msgid "Center"
 msgstr ""
 
-#: src/Model/Contact.php:2233
-msgid ""
-"The profile address specified belongs to a network which has been disabled "
-"on this site."
+#: view/theme/quattro/config.php:74
+msgid "Color scheme"
 msgstr ""
 
-#: src/Model/Contact.php:2238
-msgid ""
-"Limited profile. This person will be unable to receive direct/personal "
-"notifications from you."
+#: view/theme/quattro/config.php:75
+msgid "Posts font size"
 msgstr ""
 
-#: src/Model/Contact.php:2297
-msgid "Unable to retrieve contact information."
+#: view/theme/quattro/config.php:76
+msgid "Textareas font size"
 msgstr ""
 
-#: src/Model/Event.php:77 src/Model/Event.php:94 src/Model/Event.php:451
-#: src/Model/Event.php:929
-msgid "Starts:"
+#: view/theme/vier/config.php:75
+msgid "Comma separated list of helper forums"
 msgstr ""
 
-#: src/Model/Event.php:80 src/Model/Event.php:100 src/Model/Event.php:452
-#: src/Model/Event.php:933
-msgid "Finishes:"
+#: view/theme/vier/config.php:115
+msgid "don't show"
 msgstr ""
 
-#: src/Model/Event.php:401
-msgid "all-day"
+#: view/theme/vier/config.php:115
+msgid "show"
 msgstr ""
 
-#: src/Model/Event.php:427
-msgid "Sept"
+#: view/theme/vier/config.php:121
+msgid "Set style"
 msgstr ""
 
-#: src/Model/Event.php:449
-msgid "No events to display"
+#: view/theme/vier/config.php:122
+msgid "Community Pages"
 msgstr ""
 
-#: src/Model/Event.php:577
-msgid "l, F j"
+#: view/theme/vier/config.php:123 view/theme/vier/theme.php:125
+msgid "Community Profiles"
 msgstr ""
 
-#: src/Model/Event.php:608
-msgid "Edit event"
+#: view/theme/vier/config.php:124
+msgid "Help or @NewHere ?"
 msgstr ""
 
-#: src/Model/Event.php:609
-msgid "Duplicate event"
+#: view/theme/vier/config.php:125 view/theme/vier/theme.php:296
+msgid "Connect Services"
 msgstr ""
 
-#: src/Model/Event.php:610
-msgid "Delete event"
+#: view/theme/vier/config.php:126
+msgid "Find Friends"
 msgstr ""
 
-#: src/Model/Event.php:862
-msgid "D g:i A"
+#: view/theme/vier/config.php:127 view/theme/vier/theme.php:152
+msgid "Last users"
 msgstr ""
 
-#: src/Model/Event.php:863
-msgid "g:i A"
-msgstr ""
-
-#: src/Model/Event.php:948 src/Model/Event.php:950
-msgid "Show map"
-msgstr ""
-
-#: src/Model/Event.php:949
-msgid "Hide map"
-msgstr ""
-
-#: src/Model/Event.php:1041
-#, php-format
-msgid "%s's birthday"
-msgstr ""
-
-#: src/Model/Event.php:1042
-#, php-format
-msgid "Happy Birthday %s"
-msgstr ""
-
-#: src/Model/User.php:186 src/Model/User.php:931
-msgid "SERIOUS ERROR: Generation of security keys failed."
-msgstr ""
-
-#: src/Model/User.php:549
-msgid "Login failed"
-msgstr ""
-
-#: src/Model/User.php:581
-msgid "Not enough information to authenticate"
-msgstr ""
-
-#: src/Model/User.php:676
-msgid "Password can't be empty"
-msgstr ""
-
-#: src/Model/User.php:695
-msgid "Empty passwords are not allowed."
-msgstr ""
-
-#: src/Model/User.php:699
-msgid ""
-"The new password has been exposed in a public data dump, please choose "
-"another."
-msgstr ""
-
-#: src/Model/User.php:705
-msgid ""
-"The password can't contain accentuated letters, white spaces or colons (:)"
-msgstr ""
-
-#: src/Model/User.php:811
-msgid "Passwords do not match. Password unchanged."
-msgstr ""
-
-#: src/Model/User.php:818
-msgid "An invitation is required."
-msgstr ""
-
-#: src/Model/User.php:822
-msgid "Invitation could not be verified."
-msgstr ""
-
-#: src/Model/User.php:830
-msgid "Invalid OpenID url"
-msgstr ""
-
-#: src/Model/User.php:849
-msgid "Please enter the required information."
-msgstr ""
-
-#: src/Model/User.php:863
-#, php-format
-msgid ""
-"system.username_min_length (%s) and system.username_max_length (%s) are "
-"excluding each other, swapping values."
-msgstr ""
-
-#: src/Model/User.php:870
-#, php-format
-msgid "Username should be at least %s character."
-msgid_plural "Username should be at least %s characters."
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/Model/User.php:874
-#, php-format
-msgid "Username should be at most %s character."
-msgid_plural "Username should be at most %s characters."
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/Model/User.php:882
-msgid "That doesn't appear to be your full (First Last) name."
-msgstr ""
-
-#: src/Model/User.php:887
-msgid "Your email domain is not among those allowed on this site."
-msgstr ""
-
-#: src/Model/User.php:891
-msgid "Not a valid email address."
-msgstr ""
-
-#: src/Model/User.php:894
-msgid "The nickname was blocked from registration by the nodes admin."
-msgstr ""
-
-#: src/Model/User.php:898 src/Model/User.php:906
-msgid "Cannot use that email."
-msgstr ""
-
-#: src/Model/User.php:913
-msgid "Your nickname can only contain a-z, 0-9 and _."
-msgstr ""
-
-#: src/Model/User.php:921 src/Model/User.php:978
-msgid "Nickname is already registered. Please choose another."
-msgstr ""
-
-#: src/Model/User.php:965 src/Model/User.php:969
-msgid "An error occurred during registration. Please try again."
-msgstr ""
-
-#: src/Model/User.php:992
-msgid "An error occurred creating your default profile. Please try again."
-msgstr ""
-
-#: src/Model/User.php:999
-msgid "An error occurred creating your self contact. Please try again."
-msgstr ""
-
-#: src/Model/User.php:1004
-msgid "Friends"
-msgstr ""
-
-#: src/Model/User.php:1008
-msgid ""
-"An error occurred creating your default contact group. Please try again."
-msgstr ""
-
-#: src/Model/User.php:1196
-#, php-format
-msgid ""
-"\n"
-"\t\tDear %1$s,\n"
-"\t\t\tthe administrator of %2$s has set up an account for you."
-msgstr ""
-
-#: src/Model/User.php:1199
-#, php-format
-msgid ""
-"\n"
-"\t\tThe login details are as follows:\n"
-"\n"
-"\t\tSite Location:\t%1$s\n"
-"\t\tLogin Name:\t\t%2$s\n"
-"\t\tPassword:\t\t%3$s\n"
-"\n"
-"\t\tYou may change your password from your account \"Settings\" page after "
-"logging\n"
-"\t\tin.\n"
-"\n"
-"\t\tPlease take a few moments to review the other account settings on that "
-"page.\n"
-"\n"
-"\t\tYou may also wish to add some basic information to your default profile\n"
-"\t\t(on the \"Profiles\" page) so that other people can easily find you.\n"
-"\n"
-"\t\tWe recommend setting your full name, adding a profile photo,\n"
-"\t\tadding some profile \"keywords\" (very useful in making new friends) - "
-"and\n"
-"\t\tperhaps what country you live in; if you do not wish to be more "
-"specific\n"
-"\t\tthan that.\n"
-"\n"
-"\t\tWe fully respect your right to privacy, and none of these items are "
-"necessary.\n"
-"\t\tIf you are new and do not know anybody here, they may help\n"
-"\t\tyou to make some new and interesting friends.\n"
-"\n"
-"\t\tIf you ever want to delete your account, you can do so at %1$s/removeme\n"
-"\n"
-"\t\tThank you and welcome to %4$s."
-msgstr ""
-
-#: src/Model/User.php:1232 src/Model/User.php:1339
-#, php-format
-msgid "Registration details for %s"
-msgstr ""
-
-#: src/Model/User.php:1252
-#, php-format
-msgid ""
-"\n"
-"\t\t\tDear %1$s,\n"
-"\t\t\t\tThank you for registering at %2$s. Your account is pending for "
-"approval by the administrator.\n"
-"\n"
-"\t\t\tYour login details are as follows:\n"
-"\n"
-"\t\t\tSite Location:\t%3$s\n"
-"\t\t\tLogin Name:\t\t%4$s\n"
-"\t\t\tPassword:\t\t%5$s\n"
-"\t\t"
-msgstr ""
-
-#: src/Model/User.php:1271
-#, php-format
-msgid "Registration at %s"
-msgstr ""
-
-#: src/Model/User.php:1295
-#, php-format
-msgid ""
-"\n"
-"\t\t\t\tDear %1$s,\n"
-"\t\t\t\tThank you for registering at %2$s. Your account has been created.\n"
-"\t\t\t"
-msgstr ""
-
-#: src/Model/User.php:1303
-#, php-format
-msgid ""
-"\n"
-"\t\t\tThe login details are as follows:\n"
-"\n"
-"\t\t\tSite Location:\t%3$s\n"
-"\t\t\tLogin Name:\t\t%1$s\n"
-"\t\t\tPassword:\t\t%5$s\n"
-"\n"
-"\t\t\tYou may change your password from your account \"Settings\" page after "
-"logging\n"
-"\t\t\tin.\n"
-"\n"
-"\t\t\tPlease take a few moments to review the other account settings on that "
-"page.\n"
-"\n"
-"\t\t\tYou may also wish to add some basic information to your default "
-"profile\n"
-"\t\t\t(on the \"Profiles\" page) so that other people can easily find you.\n"
-"\n"
-"\t\t\tWe recommend setting your full name, adding a profile photo,\n"
-"\t\t\tadding some profile \"keywords\" (very useful in making new friends) - "
-"and\n"
-"\t\t\tperhaps what country you live in; if you do not wish to be more "
-"specific\n"
-"\t\t\tthan that.\n"
-"\n"
-"\t\t\tWe fully respect your right to privacy, and none of these items are "
-"necessary.\n"
-"\t\t\tIf you are new and do not know anybody here, they may help\n"
-"\t\t\tyou to make some new and interesting friends.\n"
-"\n"
-"\t\t\tIf you ever want to delete your account, you can do so at %3$s/"
-"removeme\n"
-"\n"
-"\t\t\tThank you and welcome to %2$s."
-msgstr ""
-
-#: src/Model/Group.php:92
-msgid ""
-"A deleted group with this name was revived. Existing item permissions "
-"<strong>may</strong> apply to this group and any future members. If this is "
-"not what you intended, please create another group with a different name."
-msgstr ""
-
-#: src/Model/Group.php:451
-msgid "Default privacy group for new contacts"
-msgstr ""
-
-#: src/Model/Group.php:483
-msgid "Everybody"
-msgstr ""
-
-#: src/Model/Group.php:502
-msgid "edit"
-msgstr ""
-
-#: src/Model/Group.php:534
-msgid "add"
-msgstr ""
-
-#: src/Model/Group.php:539
-msgid "Edit group"
-msgstr ""
-
-#: src/Model/Group.php:542
-msgid "Create a new group"
-msgstr ""
-
-#: src/Model/Group.php:544
-msgid "Edit groups"
-msgstr ""
-
-#: src/Model/Profile.php:348
-msgid "Change profile photo"
-msgstr ""
-
-#: src/Model/Profile.php:443
-msgid "Atom feed"
-msgstr ""
-
-#: src/Model/Profile.php:481 src/Model/Profile.php:578
-msgid "g A l F d"
-msgstr ""
-
-#: src/Model/Profile.php:482
-msgid "F d"
-msgstr ""
-
-#: src/Model/Profile.php:544 src/Model/Profile.php:629
-msgid "[today]"
-msgstr ""
-
-#: src/Model/Profile.php:554
-msgid "Birthday Reminders"
-msgstr ""
-
-#: src/Model/Profile.php:555
-msgid "Birthdays this week:"
-msgstr ""
-
-#: src/Model/Profile.php:616
-msgid "[No description]"
-msgstr ""
-
-#: src/Model/Profile.php:642
-msgid "Event Reminders"
-msgstr ""
-
-#: src/Model/Profile.php:643
-msgid "Upcoming events the next 7 days:"
-msgstr ""
-
-#: src/Model/Profile.php:818
-#, php-format
-msgid "OpenWebAuth: %1$s welcomes %2$s"
-msgstr ""
-
-#: src/Content/Widget.php:48
-msgid "Add New Contact"
-msgstr ""
-
-#: src/Content/Widget.php:49
-msgid "Enter address or web location"
-msgstr ""
-
-#: src/Content/Widget.php:50
-msgid "Example: bob@example.com, http://example.com/barbara"
-msgstr ""
-
-#: src/Content/Widget.php:52
-msgid "Connect"
-msgstr ""
-
-#: src/Content/Widget.php:67
-#, php-format
-msgid "%d invitation available"
-msgid_plural "%d invitations available"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/Content/Widget.php:215
-msgid "Everyone"
-msgstr ""
-
-#: src/Content/Widget.php:244
-msgid "Relationships"
-msgstr ""
-
-#: src/Content/Widget.php:285
-msgid "Protocols"
-msgstr ""
-
-#: src/Content/Widget.php:287
-msgid "All Protocols"
-msgstr ""
-
-#: src/Content/Widget.php:324
-msgid "Saved Folders"
-msgstr ""
-
-#: src/Content/Widget.php:326 src/Content/Widget.php:365
-msgid "Everything"
-msgstr ""
-
-#: src/Content/Widget.php:363
-msgid "Categories"
-msgstr ""
-
-#: src/Content/Widget.php:420
-#, php-format
-msgid "%d contact in common"
-msgid_plural "%d contacts in common"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/Content/Widget.php:424 src/Content/Widget.php:520
-#: src/Content/ForumManager.php:151
-msgid "show more"
-msgstr ""
-
-#: src/Content/Widget.php:513
-msgid "Archives"
-msgstr ""
-
-#: src/Content/Widget.php:519 src/Content/ForumManager.php:150
-msgid "show less"
-msgstr ""
-
-#: src/Content/Widget.php:537
-msgid "Persons"
-msgstr ""
-
-#: src/Content/Widget.php:538
-msgid "Organisations"
-msgstr ""
-
-#: src/Content/Widget.php:540 src/Content/Nav.php:229
-#: src/Content/ForumManager.php:145 src/Content/Text/HTML.php:902
-msgid "Forums"
-msgstr ""
-
-#: src/Content/ContactSelector.php:48
-msgid "Frequently"
-msgstr ""
-
-#: src/Content/ContactSelector.php:49
-msgid "Hourly"
-msgstr ""
-
-#: src/Content/ContactSelector.php:50
-msgid "Twice daily"
-msgstr ""
-
-#: src/Content/ContactSelector.php:51
-msgid "Daily"
-msgstr ""
-
-#: src/Content/ContactSelector.php:52
-msgid "Weekly"
-msgstr ""
-
-#: src/Content/ContactSelector.php:53
-msgid "Monthly"
-msgstr ""
-
-#: src/Content/ContactSelector.php:99
-msgid "DFRN"
-msgstr ""
-
-#: src/Content/ContactSelector.php:100
-msgid "OStatus"
-msgstr ""
-
-#: src/Content/ContactSelector.php:101
-msgid "RSS/Atom"
-msgstr ""
-
-#: src/Content/ContactSelector.php:104
-msgid "Zot!"
-msgstr ""
-
-#: src/Content/ContactSelector.php:105
-msgid "LinkedIn"
-msgstr ""
-
-#: src/Content/ContactSelector.php:106
-msgid "XMPP/IM"
-msgstr ""
-
-#: src/Content/ContactSelector.php:107
-msgid "MySpace"
-msgstr ""
-
-#: src/Content/ContactSelector.php:108
-msgid "Google+"
-msgstr ""
-
-#: src/Content/ContactSelector.php:109
-msgid "pump.io"
-msgstr ""
-
-#: src/Content/ContactSelector.php:110
-msgid "Twitter"
-msgstr ""
-
-#: src/Content/ContactSelector.php:111
-msgid "Discourse"
-msgstr ""
-
-#: src/Content/ContactSelector.php:112
-msgid "Diaspora Connector"
-msgstr ""
-
-#: src/Content/ContactSelector.php:113
-msgid "GNU Social Connector"
-msgstr ""
-
-#: src/Content/ContactSelector.php:114
-msgid "ActivityPub"
-msgstr ""
-
-#: src/Content/ContactSelector.php:115
-msgid "pnut"
-msgstr ""
-
-#: src/Content/ContactSelector.php:149
-#, php-format
-msgid "%s (via %s)"
-msgstr ""
-
-#: src/Content/Feature.php:96
-msgid "General Features"
-msgstr ""
-
-#: src/Content/Feature.php:98
-msgid "Photo Location"
-msgstr ""
-
-#: src/Content/Feature.php:98
-msgid ""
-"Photo metadata is normally stripped. This extracts the location (if present) "
-"prior to stripping metadata and links it to a map."
-msgstr ""
-
-#: src/Content/Feature.php:99
-msgid "Trending Tags"
-msgstr ""
-
-#: src/Content/Feature.php:99
-msgid ""
-"Show a community page widget with a list of the most popular tags in recent "
-"public posts."
-msgstr ""
-
-#: src/Content/Feature.php:104
-msgid "Post Composition Features"
-msgstr ""
-
-#: src/Content/Feature.php:105
-msgid "Auto-mention Forums"
-msgstr ""
-
-#: src/Content/Feature.php:105
-msgid ""
-"Add/remove mention when a forum page is selected/deselected in ACL window."
-msgstr ""
-
-#: src/Content/Feature.php:106
-msgid "Explicit Mentions"
-msgstr ""
-
-#: src/Content/Feature.php:106
-msgid ""
-"Add explicit mentions to comment box for manual control over who gets "
-"mentioned in replies."
-msgstr ""
-
-#: src/Content/Feature.php:111
-msgid "Post/Comment Tools"
-msgstr ""
-
-#: src/Content/Feature.php:112
-msgid "Post Categories"
-msgstr ""
-
-#: src/Content/Feature.php:112
-msgid "Add categories to your posts"
-msgstr ""
-
-#: src/Content/Feature.php:117
-msgid "Advanced Profile Settings"
-msgstr ""
-
-#: src/Content/Feature.php:118
-msgid "List Forums"
-msgstr ""
-
-#: src/Content/Feature.php:118
-msgid "Show visitors public community forums at the Advanced Profile Page"
-msgstr ""
-
-#: src/Content/Feature.php:119
-msgid "Tag Cloud"
-msgstr ""
-
-#: src/Content/Feature.php:119
-msgid "Provide a personal tag cloud on your profile page"
-msgstr ""
-
-#: src/Content/Feature.php:120
-msgid "Display Membership Date"
-msgstr ""
-
-#: src/Content/Feature.php:120
-msgid "Display membership date in profile"
-msgstr ""
-
-#: src/Content/Nav.php:90
-msgid "Nothing new here"
-msgstr ""
-
-#: src/Content/Nav.php:95
-msgid "Clear notifications"
-msgstr ""
-
-#: src/Content/Nav.php:96 src/Content/Text/HTML.php:889
-msgid "@name, !forum, #tags, content"
-msgstr ""
-
-#: src/Content/Nav.php:169
-msgid "End this session"
-msgstr ""
-
-#: src/Content/Nav.php:171
-msgid "Sign in"
-msgstr ""
-
-#: src/Content/Nav.php:182
-msgid "Personal notes"
-msgstr ""
-
-#: src/Content/Nav.php:182
-msgid "Your personal notes"
-msgstr ""
-
-#: src/Content/Nav.php:202 src/Content/Nav.php:263
-msgid "Home"
-msgstr ""
-
-#: src/Content/Nav.php:202
-msgid "Home Page"
-msgstr ""
-
-#: src/Content/Nav.php:206
-msgid "Create an account"
-msgstr ""
-
-#: src/Content/Nav.php:212
-msgid "Help and documentation"
-msgstr ""
-
-#: src/Content/Nav.php:216
-msgid "Apps"
-msgstr ""
-
-#: src/Content/Nav.php:216
-msgid "Addon applications, utilities, games"
-msgstr ""
-
-#: src/Content/Nav.php:220
-msgid "Search site content"
-msgstr ""
-
-#: src/Content/Nav.php:223 src/Content/Text/HTML.php:896
-msgid "Full Text"
-msgstr ""
-
-#: src/Content/Nav.php:224 src/Content/Widget/TagCloud.php:68
-#: src/Content/Text/HTML.php:897
-msgid "Tags"
-msgstr ""
-
-#: src/Content/Nav.php:244
-msgid "Community"
-msgstr ""
-
-#: src/Content/Nav.php:244
-msgid "Conversations on this and other servers"
-msgstr ""
-
-#: src/Content/Nav.php:251
-msgid "Directory"
-msgstr ""
-
-#: src/Content/Nav.php:251
-msgid "People directory"
-msgstr ""
-
-#: src/Content/Nav.php:253
-msgid "Information about this friendica instance"
-msgstr ""
-
-#: src/Content/Nav.php:256
-msgid "Terms of Service of this Friendica instance"
-msgstr ""
-
-#: src/Content/Nav.php:267
-msgid "Introductions"
-msgstr ""
-
-#: src/Content/Nav.php:267
-msgid "Friend Requests"
-msgstr ""
-
-#: src/Content/Nav.php:269
-msgid "See all notifications"
-msgstr ""
-
-#: src/Content/Nav.php:270
-msgid "Mark all system notifications seen"
-msgstr ""
-
-#: src/Content/Nav.php:274
-msgid "Inbox"
-msgstr ""
-
-#: src/Content/Nav.php:275
-msgid "Outbox"
-msgstr ""
-
-#: src/Content/Nav.php:279
-msgid "Accounts"
-msgstr ""
-
-#: src/Content/Nav.php:279
-msgid "Manage other pages"
-msgstr ""
-
-#: src/Content/Nav.php:289
-msgid "Site setup and configuration"
-msgstr ""
-
-#: src/Content/Nav.php:292
-msgid "Navigation"
-msgstr ""
-
-#: src/Content/Nav.php:292
-msgid "Site map"
-msgstr ""
-
-#: src/Content/Widget/SavedSearches.php:47
-msgid "Remove term"
-msgstr ""
-
-#: src/Content/Widget/SavedSearches.php:60
-msgid "Saved Searches"
-msgstr ""
-
-#: src/Content/Widget/CalendarExport.php:63
-msgid "Export"
-msgstr ""
-
-#: src/Content/Widget/CalendarExport.php:64
-msgid "Export calendar as ical"
-msgstr ""
-
-#: src/Content/Widget/CalendarExport.php:65
-msgid "Export calendar as csv"
-msgstr ""
-
-#: src/Content/Widget/TrendingTags.php:51
-#, php-format
-msgid "Trending Tags (last %d hour)"
-msgid_plural "Trending Tags (last %d hours)"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/Content/Widget/TrendingTags.php:52
-msgid "More Trending Tags"
-msgstr ""
-
-#: src/Content/Widget/ContactBlock.php:73
-msgid "No contacts"
-msgstr ""
-
-#: src/Content/Widget/ContactBlock.php:105
-#, php-format
-msgid "%d Contact"
-msgid_plural "%d Contacts"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/Content/Widget/ContactBlock.php:124
-msgid "View Contacts"
-msgstr ""
-
-#: src/Content/BoundariesPager.php:116 src/Content/Pager.php:171
-msgid "newer"
-msgstr ""
-
-#: src/Content/BoundariesPager.php:124 src/Content/Pager.php:176
-msgid "older"
-msgstr ""
-
-#: src/Content/OEmbed.php:267
-msgid "Embedding disabled"
-msgstr ""
-
-#: src/Content/OEmbed.php:389
-msgid "Embedded content"
-msgstr ""
-
-#: src/Content/Pager.php:221
-msgid "prev"
-msgstr ""
-
-#: src/Content/Pager.php:281
-msgid "last"
-msgstr ""
-
-#: src/Content/ForumManager.php:147
-msgid "External link to forum"
-msgstr ""
-
-#: src/Content/Text/HTML.php:787
-msgid "Loading more entries..."
-msgstr ""
-
-#: src/Content/Text/HTML.php:788
-msgid "The end"
-msgstr ""
-
-#: src/Content/Text/HTML.php:939 src/Content/Text/BBCode.php:1518
-msgid "Click to open/close"
-msgstr ""
-
-#: src/Content/Text/BBCode.php:961 src/Content/Text/BBCode.php:1600
-#: src/Content/Text/BBCode.php:1601
-msgid "Image/photo"
-msgstr ""
-
-#: src/Content/Text/BBCode.php:1063
-#, php-format
-msgid ""
-"<a href=\"%1$s\" target=\"_blank\" rel=\"noopener noreferrer\">%2$s</a> %3$s"
-msgstr ""
-
-#: src/Content/Text/BBCode.php:1549
-msgid "$1 wrote:"
-msgstr ""
-
-#: src/Content/Text/BBCode.php:1603 src/Content/Text/BBCode.php:1604
-msgid "Encrypted content"
-msgstr ""
-
-#: src/Content/Text/BBCode.php:1823
-msgid "Invalid source protocol"
-msgstr ""
-
-#: src/Content/Text/BBCode.php:1838
-msgid "Invalid link protocol"
-msgstr ""
-
-#: src/BaseModule.php:150
-msgid ""
-"The form security token was not correct. This probably happened because the "
-"form has been opened for too long (>3 hours) before submitting it."
-msgstr ""
-
-#: src/BaseModule.php:179
-msgid "All contacts"
-msgstr ""
-
-#: src/BaseModule.php:202
-msgid "Common"
+#: view/theme/vier/theme.php:211
+msgid "Quick Start"
 msgstr ""

--- a/view/theme/frio/templates/wall_thread.tpl
+++ b/view/theme/frio/templates/wall_thread.tpl
@@ -440,17 +440,33 @@ as the value of $top_child_total (this is done at the end of this file)
 				</div>
 			{{/if}}
 
-			{{* Button for announcing the item *}}
-			{{if $item.vote.announce}}
-				<div class="btn-group" role="group">
-					<button type="button" class="btn btn-sm button-votes{{if $item.responses.announce.self}} active" aria-pressed="true{{/if}}" id="announce-{{$item.id}}" title="{{$item.vote.announce.0}}" onclick="doLikeAction({{$item.id}}, 'announce'{{if $item.responses.announce.self}}, true{{/if}});" data-toggle="button"><i class="fa fa-retweet" aria-hidden="true"></i></button>
-				</div>
-			{{/if}}
-
-			{{* Button for sharing the item *}}
-			{{if $item.vote.share}}
-				<div class="btn-group" role="group">
-					<button type="button" class="btn btn-sm button-votes" id="share-{{$item.id}}" title="{{$item.vote.share.0}}" onclick="jotShare({{$item.id}});"><i class="fa fa-share" aria-hidden="true"></i></button>
+			{{if $item.vote.announce OR $item.vote.share}}
+				<div class="share-links btn-group{{if $item.thread_level > 1}} dropup{{/if}}">
+					<button type="button" class="btn btn-sm dropdown-toggle{{if $item.responses.announce.self}} active{{/if}}" data-toggle="dropdown" id="shareMenuOptions-{{$item.id}}" aria-haspopup="true" aria-expanded="false" title="{{$item.menu}}">
+						<i class="fa fa-share" aria-hidden="true"></i>
+					</button>
+					<ul class="dropdown-menu dropdown-menu-left" role="menu" aria-labelledby="shareMenuOptions-{{$item.id}}">
+						{{if $item.vote.announce}} {{* edit the posting *}}
+						<li role="menuitem">
+							{{if $item.responses.announce.self}}
+							<a class="btn-link" id="announce-{{$item.id}}" href="javascript:doLikeAction({{$item.id}}, 'announce', true);" title="{{$item.vote.unannounce.0}}">
+								<i class="fa fa-ban" aria-hidden="true"></i> {{$item.vote.unannounce.1}}
+							</a>
+							{{else}}
+							<a class="btn-link" id="announce-{{$item.id}}" href="javascript:doLikeAction({{$item.id}}, 'announce');" title="{{$item.vote.announce.0}}">
+								<i class="fa fa-retweet" aria-hidden="true"></i> {{$item.vote.announce.1}}
+							</a>
+							{{/if}}
+						</li>
+						{{/if}}
+						{{if $item.vote.share}}
+						<li role="menuitem">
+							<a class="btn-link" id="share-{{$item.id}}" href="javascript:jotShare({{$item.id}});" title="{{$item.vote.share.0}}">
+								<i class="fa fa-share" aria-hidden="true"></i> {{$item.vote.share.1}}
+							</a>
+						</li>
+						{{/if}}
+					</ul>
 				</div>
 			{{/if}}
 


### PR DESCRIPTION
Addresses #9698

This isn't the requested undo feature, but it is a way to prevent involuntary sharing while swiping on mobile devices. Both share actions have been gathered in a dropdown menu, this means that native reshare now requires two actions instead of one precedently.