### PR TITLE
The highest post update version number is 1384

### DIFF
--- a/src/Database/PostUpdate.php
+++ b/src/Database/PostUpdate.php
@@ -46,7 +46,7 @@ class PostUpdate
 {
 	// Needed for the helper function to read from the legacy term table
 	const OBJECT_TYPE_POST  = 1;
-	const VERSION = 1383;
+	const VERSION = 1384;
 
 	/**
 	 * Calls the post update functions


### PR DESCRIPTION
This fixes the wrong display on the `/friendica` page.