### PR TITLE
Store server protocol

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -1,6 +1,6 @@
 -- ------------------------------------------
--- Friendica 2020.12-rc (Red Hot Poker)
--- DB_UPDATE_VERSION 1384
+-- Friendica 2021.03-dev (Red Hot Poker)
+-- DB_UPDATE_VERSION 1385
 -- ------------------------------------------
 
 
@@ -20,6 +20,7 @@ CREATE TABLE IF NOT EXISTS `gserver` (
 	`poco` varchar(255) NOT NULL DEFAULT '' COMMENT '',
 	`noscrape` varchar(255) NOT NULL DEFAULT '' COMMENT '',
 	`network` char(4) NOT NULL DEFAULT '' COMMENT '',
+	`protocol` tinyint unsigned COMMENT 'The protocol of the server',
 	`platform` varchar(255) NOT NULL DEFAULT '' COMMENT '',
 	`relay-subscribe` boolean NOT NULL DEFAULT '0' COMMENT 'Has the server subscribed to the relay system',
 	`relay-scope` varchar(10) NOT NULL DEFAULT '' COMMENT 'The scope of messages that the server wants to get',

--- a/src/Model/GServer.php
+++ b/src/Model/GServer.php
@@ -1744,7 +1744,7 @@ class GServer
 	 * @return void 
 	 * @throws Exception 
 	 */
-	static function setProtocol(int $gsid, int $protocol)
+	public static function setProtocol(int $gsid, int $protocol)
 	{
 		if (empty($gsid)) {
 			return;
@@ -1795,5 +1795,26 @@ class GServer
 
 		Logger::info('Protocol for server', ['protocol' => $protocol, 'old' => $old, 'id' => $gsid, 'url' => $gserver['url']]);
 		DBA::update('gserver', ['protocol' => $protocol], ['id' => $gsid]);
+	}
+
+	/**
+	 * Fetch the protocol of the given server
+	 *
+	 * @param int $gsid Server id
+	 * @return int 
+	 * @throws Exception 
+	 */
+	public static function getProtocol(int $gsid)
+	{
+		if (empty($gsid)) {
+			return null;
+		}
+
+		$gserver = DBA::selectFirst('gserver', ['protocol'], ['id' => $gsid]);
+		if (DBA::isResult($gserver)) {
+			return $gserver['protocol'];
+		}
+
+		return null;
 	}
 }

--- a/src/Model/PushSubscriber.php
+++ b/src/Model/PushSubscriber.php
@@ -25,6 +25,7 @@ use Friendica\Core\Logger;
 use Friendica\Core\Worker;
 use Friendica\Database\DBA;
 use Friendica\Util\DateTimeFormat;
+use Friendica\Util\Network;
 
 class PushSubscriber
 {
@@ -170,5 +171,13 @@ class PushSubscriber
 		$fields = ['push' => 0, 'next_try' => DBA::NULL_DATETIME, 'last_update' => $last_update];
 		DBA::update('push_subscriber', $fields, ['id' => $id]);
 		Logger::log('Subscriber ' . $subscriber['callback_url'] . ' for ' . $subscriber['nickname'] . ' is marked as vital', Logger::DEBUG);
+
+		$parts = parse_url($subscriber['callback_url']);
+		unset($parts['path']);
+		$server_url = Network::unparseURL($parts);
+		$gsid = GServer::getID($server_url, true);
+		if (!empty($gsid)) {
+			GServer::setProtocol($gsid, Post\DeliveryData::OSTATUS);
+		}
 	}
 }

--- a/src/Worker/Delivery.php
+++ b/src/Worker/Delivery.php
@@ -202,7 +202,7 @@ class Delivery
 			return;
 		}
 
-		$protocol = Model\GServer::getProtocol($contact['gsid']);
+		$protocol = Model\GServer::getProtocol($contact['gsid'] ?? 0);
 
 		// Transmit via Diaspora if the thread had started as Diaspora post.
 		// Also transmit via Diaspora if this is a direct answer to a Diaspora comment.
@@ -364,7 +364,7 @@ class Delivery
 					if (($deliver_status >= 200) && ($deliver_status <= 299)) {
 						Model\Post\DeliveryData::incrementQueueDone($target_item['uri-id'], $protocol);
 
-						Model\GServer::setProtocol($contact['gsid'], $protocol);
+						Model\GServer::setProtocol($contact['gsid'] ?? 0, $protocol);
 					} else {
 						Model\Post\DeliveryData::incrementQueueFailed($target_item['uri-id']);
 					}
@@ -396,7 +396,7 @@ class Delivery
 			// We successfully delivered a message, the contact is alive
 			Model\Contact::unmarkForArchival($contact);
 
-			Model\GServer::setProtocol($contact['gsid'], $protocol);
+			Model\GServer::setProtocol($contact['gsid'] ?? 0, $protocol);
 
 			if (in_array($cmd, [Delivery::POST, Delivery::POKE])) {
 				Model\Post\DeliveryData::incrementQueueDone($target_item['uri-id'], $protocol);
@@ -483,7 +483,7 @@ class Delivery
 			// We successfully delivered a message, the contact is alive
 			Model\Contact::unmarkForArchival($contact);
 
-			Model\GServer::setProtocol($contact['gsid'], Model\Post\DeliveryData::DIASPORA);
+			Model\GServer::setProtocol($contact['gsid'] ?? 0, Model\Post\DeliveryData::DIASPORA);
 
 			if (in_array($cmd, [Delivery::POST, Delivery::POKE])) {
 				Model\Post\DeliveryData::incrementQueueDone($target_item['uri-id'], Model\Post\DeliveryData::DIASPORA);

--- a/src/Worker/Delivery.php
+++ b/src/Worker/Delivery.php
@@ -360,6 +360,8 @@ class Delivery
 				if (in_array($cmd, [Delivery::POST, Delivery::POKE])) {
 					if (($deliver_status >= 200) && ($deliver_status <= 299)) {
 						Model\Post\DeliveryData::incrementQueueDone($target_item['uri-id'], $protocol);
+
+						Model\GServer::setProtocol($contact['gsid'], $protocol);
 					} else {
 						Model\Post\DeliveryData::incrementQueueFailed($target_item['uri-id']);
 					}
@@ -390,6 +392,8 @@ class Delivery
 		if (($deliver_status >= 200) && ($deliver_status <= 299)) {
 			// We successfully delivered a message, the contact is alive
 			Model\Contact::unmarkForArchival($contact);
+
+			Model\GServer::setProtocol($contact['gsid'], $protocol);
 
 			if (in_array($cmd, [Delivery::POST, Delivery::POKE])) {
 				Model\Post\DeliveryData::incrementQueueDone($target_item['uri-id'], $protocol);
@@ -475,6 +479,8 @@ class Delivery
 		if (($deliver_status >= 200) && ($deliver_status <= 299)) {
 			// We successfully delivered a message, the contact is alive
 			Model\Contact::unmarkForArchival($contact);
+
+			Model\GServer::setProtocol($contact['gsid'], Model\Post\DeliveryData::DIASPORA);
 
 			if (in_array($cmd, [Delivery::POST, Delivery::POKE])) {
 				Model\Post\DeliveryData::incrementQueueDone($target_item['uri-id'], Model\Post\DeliveryData::DIASPORA);

--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -55,7 +55,7 @@
 use Friendica\Database\DBA;
 
 if (!defined('DB_UPDATE_VERSION')) {
-	define('DB_UPDATE_VERSION', 1384);
+	define('DB_UPDATE_VERSION', 1385);
 }
 
 return [
@@ -75,6 +75,7 @@ return [
 			"poco" => ["type" => "varchar(255)", "not null" => "1", "default" => "", "comment" => ""],
 			"noscrape" => ["type" => "varchar(255)", "not null" => "1", "default" => "", "comment" => ""],
 			"network" => ["type" => "char(4)", "not null" => "1", "default" => "", "comment" => ""],
+			"protocol" => ["type" => "tinyint unsigned", "comment" => "The protocol of the server"],
 			"platform" => ["type" => "varchar(255)", "not null" => "1", "default" => "", "comment" => ""],
 			"relay-subscribe" => ["type" => "boolean", "not null" => "1", "default" => "0", "comment" => "Has the server subscribed to the relay system"],
 			"relay-scope" => ["type" => "varchar(10)", "not null" => "1", "default" => "", "comment" => "The scope of messages that the server wants to get"],


### PR DESCRIPTION
This PR includes the commits from PR https://github.com/friendica/friendica/pull/9766 - so it should be reviewed after the merge of the other PR.

We now store the transport protocol that had been used to delivered message to the given server. This can be used to use the best protocol to deliver content to a Friendica server.