### PR TITLE
Issue 9705: Perform an age check when the post isn't fetched

### DIFF
--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -1698,6 +1698,12 @@ class Item
 		// The contact-id should be set before "self::insert" was called - but there seems to be issues sometimes
 		$item["contact-id"] = self::contactId($item);
 
+		if (!empty($item['direction']) && in_array($item['direction'], [Conversation::PUSH, Conversation::RELAY]) &&
+			self::isTooOld($item)) {
+			Logger::info('Item is too old', ['item' => $item]);
+			return 0;
+		}
+
 		if (!self::isValid($item)) {
 			return 0;
 		}


### PR DESCRIPTION
Fixes https://github.com/friendica/friendica/issues/9705

Since we now can distinguish reliably between posts that had been fetched and those that arrives via relay or other servers, we can now reject old posts without loosing the ability to fetch really old posts.