### PR TITLE
Create plink if missing

### DIFF
--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -1265,7 +1265,7 @@ class Diaspora
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 * @throws \ImagickException
 	 */
-	private static function plink($addr, $guid, $parent_guid = '')
+	private static function plink(string $addr, string $guid, string $parent_guid = '')
 	{
 		$contact = Contact::getByURL($addr);
 		if (empty($contact)) {
@@ -2434,6 +2434,10 @@ class Diaspora
 		$original_item = self::originalItem($root_guid, $root_author);
 		if (!$original_item) {
 			return false;
+		}
+
+		if (empty($original_item['plink'])) {
+			$original_item['plink'] = self::plink($root_author, $root_guid);
 		}
 
 		$datarray = [];


### PR DESCRIPTION
Alternate solution to PR https://github.com/friendica/friendica/pull/9775

The `plink` shouldn't be missing. On Diaspora we generate the value by our own (since the protocol doesn't provide it), so it's no problem to generate it on our own.