### PR TITLE
Fix: mobile: Frio dark , +change side bar padding

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -95,8 +95,8 @@ blockquote {
         padding-top: 100px;
         z-index: 10;
         overflow: auto;
-        padding-left: 2px!important;
-        padding-right: 2px!important;
+        padding-left: 6px!important;
+        padding-right: 6px!important;
     }
     aside::before {
         content: " ";

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -88,13 +88,15 @@ blockquote {
     aside{
         position: fixed!important;
         top: 0!important;
-        background-color: #fff;
+        background-color: $background_color;
         width: 100%;
         max-width: 300px;
         height: 100%;
         padding-top: 100px;
         z-index: 10;
         overflow: auto;
+        padding-left: 2px!important;
+        padding-right: 2px!important;
     }
     aside::before {
         content: " ";


### PR DESCRIPTION
Fix #9764

Also the padding was getting on my nerves on mobile:

Before:
![image](https://user-images.githubusercontent.com/11581433/104663538-37bd3b00-569b-11eb-8db3-fc4306c0316b.png)

After (6px):
![image](https://user-images.githubusercontent.com/11581433/104663863-ec575c80-569b-11eb-8a4d-54fc5e3e3ded.png)


