### PR TITLE
Frio - Dim tags and mention

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -1788,10 +1788,34 @@ code > .hl-main {
 /* wall item hover effects */
 
 @media (min-width: 768px) {
+    /* Tags and mentions */
+    .wall-item-container .wall-item-bottom .wall-item-tags span.label {
+        filter:grayscale(0.5);
+        opacity: 0.8;
+
+        -webkit-transition: all 0.25s ease-in-out;
+		-moz-transition: all 0.25s ease-in-out;
+		-o-transition: all 0.25s ease-in-out;
+		-ms-transition: all 0.25s ease-in-out;
+		transition: all 0.25s ease-in-out;
+    }
+
+    .wall-item-container:hover .wall-item-bottom .wall-item-tags span.label {
+        filter:grayscale(0);
+        opacity: 1;
+
+        -webkit-transition: all 0.25s ease-in-out;
+		-moz-transition: all 0.25s ease-in-out;
+		-o-transition: all 0.25s ease-in-out;
+		-ms-transition: all 0.25s ease-in-out;
+		transition: all 0.25s ease-in-out;
+    }
+    /* Like/Comment/etc buttons */
 	.wall-item-container .wall-item-links,
 	.wall-item-container .wall-item-actions button,
 	.wall-item-container .body-attach > a {
-		opacity: 0.3;
+        opacity: 0.4;
+        
 		-webkit-transition: all 0.25s ease-in-out;
 		-moz-transition: all 0.25s ease-in-out;
 		-o-transition: all 0.25s ease-in-out;
@@ -1801,7 +1825,8 @@ code > .hl-main {
 	.wall-item-container:hover .wall-item-links,
 	.wall-item-container:hover .wall-item-actions button,
 	.wall-item-container:hover .body-attach > a {
-		opacity: 1;
+        opacity: 1;
+        
 		-webkit-transition: all 0.25s ease-in-out;
 		-moz-transition: all 0.25s ease-in-out;
 		-o-transition: all 0.25s ease-in-out;

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -1788,34 +1788,34 @@ code > .hl-main {
 /* wall item hover effects */
 
 @media (min-width: 768px) {
-    /* Tags and mentions */
-    .wall-item-container .wall-item-bottom .wall-item-tags span.label {
-        filter:grayscale(0.5);
-        opacity: 0.8;
+	/* Tags and mentions */
+	.wall-item-container .wall-item-bottom .wall-item-tags span.label {
+		filter:grayscale(0.5);
+		opacity: 0.8;
 
-        -webkit-transition: all 0.25s ease-in-out;
+		-webkit-transition: all 0.25s ease-in-out;
 		-moz-transition: all 0.25s ease-in-out;
 		-o-transition: all 0.25s ease-in-out;
 		-ms-transition: all 0.25s ease-in-out;
 		transition: all 0.25s ease-in-out;
-    }
+	}
 
-    .wall-item-container:hover .wall-item-bottom .wall-item-tags span.label {
-        filter:grayscale(0);
-        opacity: 1;
+	.wall-item-container:hover .wall-item-bottom .wall-item-tags span.label {
+		filter:grayscale(0);
+		opacity: 1;
 
-        -webkit-transition: all 0.25s ease-in-out;
+		-webkit-transition: all 0.25s ease-in-out;
 		-moz-transition: all 0.25s ease-in-out;
 		-o-transition: all 0.25s ease-in-out;
 		-ms-transition: all 0.25s ease-in-out;
 		transition: all 0.25s ease-in-out;
-    }
-    /* Like/Comment/etc buttons */
+	}
+	/* Like/Comment/etc buttons */
 	.wall-item-container .wall-item-links,
 	.wall-item-container .wall-item-actions button,
 	.wall-item-container .body-attach > a {
-        opacity: 0.4;
-        
+		opacity: 0.4;
+		
 		-webkit-transition: all 0.25s ease-in-out;
 		-moz-transition: all 0.25s ease-in-out;
 		-o-transition: all 0.25s ease-in-out;
@@ -1825,8 +1825,8 @@ code > .hl-main {
 	.wall-item-container:hover .wall-item-links,
 	.wall-item-container:hover .wall-item-actions button,
 	.wall-item-container:hover .body-attach > a {
-        opacity: 1;
-        
+		opacity: 1;
+		
 		-webkit-transition: all 0.25s ease-in-out;
 		-moz-transition: all 0.25s ease-in-out;
 		-o-transition: all 0.25s ease-in-out;


### PR DESCRIPTION
Fix #7557

I set the values to what was middle ground from the feedbacks. We can always tweak further later once people have tried it.

Slight increase in opacity to post actions (from 30% to 40%) - All screenshots in #7557 are with that value and nobody complained ;) (I also said that [in this reply](https://github.com/friendica/friendica/issues/7557#issuecomment-761021521))

Result:
![image](https://user-images.githubusercontent.com/11581433/104783725-aad6b800-5754-11eb-8336-c24f2d69eb3d.png)

Edit: The overall dim and contrast might be re-explored when I tackle #9769
