### PR TITLE
Frio: Improve readability and navigation, first pass

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -1442,20 +1442,6 @@ aside .panel-body {
 }
 
 /* Thread hover effects */
-/* .desktop-view .panel.tread-wrapper {
-    -webkit-transition: box-shadow 0.25s ease-in-out;
-    -moz-transition: box-shadow 0.25s ease-in-out;
-    -o-transition: box-shadow 0.25s ease-in-out;
-    -ms-transition: box-shadow 0.25s ease-in-out;
-    transition: box-shadow 0.25s ease-in-out;
-} */
-/* .desktop-view .panel.tread-wrapper:hover {
-    box-shadow: 0 0 3px #dadada;
-    -webkit-box-shadow: 0 0 3px #dadada;
-    -moz-box-shadow: 0 0 3px #dadada;
-
-} */
-
 .desktop-view .wall-item-container .wall-item-content a,
 .desktop-view .wall-item-name,
 .desktop-view .wall-item-container .fakelink,

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -419,7 +419,7 @@ nav.navbar {
 }
 #topbar-first .navbar-toggle {
     margin-top: 5px;
-    margin-bottom: 0; /* adding a bottom margin is useless */
+    margin-bottom: 0;
 }
 #topbar-first .nav > li > a,
 #topbar-first .nav > li > button,

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -417,6 +417,10 @@ nav.navbar {
     z-index: 1030;
     color: $nav_icon_color;
 }
+#topbar-first .navbar-toggle {
+    margin-top: 5px;
+    margin-bottom: 0; /* adding a bottom margin is useless */
+}
 #topbar-first .nav > li > a,
 #topbar-first .nav > li > button,
 nav.navbar .nav > li > a,
@@ -656,6 +660,22 @@ nav.navbar .nav > li > button:focus
 #topbar-first #search-box .navbar-form {
     margin: 0px;
     padding: 12px 12px;
+}
+#search-mobile {
+    position: fixed;
+    top: 90px;
+    left: 0;
+    right: 0;
+    z-index: 2;
+
+    background-color: $background_color;
+
+    /* fix bootstrap well not playing well with data-target slide animation */
+    margin: 0;
+    padding: 0;
+    min-height: 0;
+    border-radius: 0;
+
 }
 #search-mobile .navbar-form {
     margin: 0;
@@ -1398,9 +1418,9 @@ textarea.comment-edit-text:focus + .comment-edit-form .preview {
 .panel {
     border: none;
     background-color: rgba(255,255,255,$contentbg_transp);
-    box-shadow: 0 0 3px #dadada;
-    -webkit-box-shadow: 0 0 3px #dadada;
-    -moz-box-shadow: 0 0 3px #dadada;
+    box-shadow: 0 0 2px #dadada;
+    -webkit-box-shadow: 0 0 2px #dadada;
+    -moz-box-shadow: 0 0 2px #dadada;
     border-radius: 4px;
     position: relative;
 }
@@ -1422,6 +1442,20 @@ aside .panel-body {
 }
 
 /* Thread hover effects */
+/* .desktop-view .panel.tread-wrapper {
+    -webkit-transition: box-shadow 0.25s ease-in-out;
+    -moz-transition: box-shadow 0.25s ease-in-out;
+    -o-transition: box-shadow 0.25s ease-in-out;
+    -ms-transition: box-shadow 0.25s ease-in-out;
+    transition: box-shadow 0.25s ease-in-out;
+} */
+/* .desktop-view .panel.tread-wrapper:hover {
+    box-shadow: 0 0 3px #dadada;
+    -webkit-box-shadow: 0 0 3px #dadada;
+    -moz-box-shadow: 0 0 3px #dadada;
+
+} */
+
 .desktop-view .wall-item-container .wall-item-content a,
 .desktop-view .wall-item-name,
 .desktop-view .wall-item-container .fakelink,
@@ -1458,6 +1492,14 @@ aside .panel-body {
 .wall-item-container.panel-body {
     padding: 0;
     border-top: none;
+}
+
+.comment-edit-preview .wall-item-container.panel-body.preview {
+    margin-top: 4px;
+
+}
+.comment-edit-preview .panel {
+    margin-bottom: 0;
 }
 
 .wall-item-container .media {
@@ -1847,6 +1889,7 @@ wall-item-comment-wrapper.well {
     background-color: rgba(237, 237, 237, $contentbg_transp);
     background-image: none;
     margin-bottom: 1px;
+    background-color: red;
 }
 wall-item-comment-wrapper.well-small {
     padding: 10px;
@@ -1908,6 +1951,7 @@ wall-item-comment-wrapper.well hr {
 
 .comment-edit-submit-wrapper {
     text-align: right;
+    /* margin-bottom: 0; */
 }
 
 .comment-icon-list {

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -1937,7 +1937,7 @@ wall-item-comment-wrapper.well hr {
 
 .comment-edit-submit-wrapper {
     text-align: right;
-    /* margin-bottom: 0; */
+    margin-bottom: 0;
 }
 
 .comment-icon-list {

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -670,12 +670,11 @@ nav.navbar .nav > li > button:focus
 
     background-color: $background_color;
 
-    /* fix bootstrap well not playing well with data-target slide animation */
+    /* fix bootstrap .well class not playing well with data-target slide animation */
     margin: 0;
     padding: 0;
     min-height: 0;
     border-radius: 0;
-
 }
 #search-mobile .navbar-form {
     margin: 0;
@@ -1482,7 +1481,6 @@ aside .panel-body {
 
 .comment-edit-preview .wall-item-container.panel-body.preview {
     margin-top: 4px;
-
 }
 .comment-edit-preview .panel {
     margin-bottom: 0;
@@ -3450,7 +3448,6 @@ section .profile-match-wrapper {
         left: 10%;
         z-index: -1;
     }
-
 }
 
 /* Mobile display */

--- a/view/theme/frio/scheme/dark.php
+++ b/view/theme/frio/scheme/dark.php
@@ -22,7 +22,6 @@ $nav_icon_hover_color = '#' . $accentColor->darken(20);
 switch ($scheme_accent) {
 	case FRIO_SCHEME_ACCENT_GREEN:
 	case FRIO_SCHEME_ACCENT_RED:
-
 		$nav_bg = '#' . $accentColor->darken(27);
 		$background_color = '#' . $accentColor->darken(29);
 		break;

--- a/view/theme/frio/scheme/dark.php
+++ b/view/theme/frio/scheme/dark.php
@@ -16,13 +16,15 @@ switch ($scheme_accent) {
 	default:
 		$link_color = '#' . $accentColor->lighten(25);
 }
-$nav_icon_color = $scheme_accent;
+$nav_icon_color = '#' . $accentColor->lighten(40);
 $nav_icon_hover_color = '#' . $accentColor->darken(20);
+
 switch ($scheme_accent) {
 	case FRIO_SCHEME_ACCENT_GREEN:
 	case FRIO_SCHEME_ACCENT_RED:
-		$nav_bg = '#' . $accentColor->darken(25);
-		$background_color = '#' . $accentColor->darken(27);
+
+		$nav_bg = '#' . $accentColor->darken(27);
+		$background_color = '#' . $accentColor->darken(29);
 		break;
 	default:
 		$nav_bg = '#' . $accentColor->darken(30);

--- a/view/theme/frio/style.php
+++ b/view/theme/frio/style.php
@@ -188,8 +188,8 @@ $options = [
 	'$background_repeat'           => $background_repeat,
 	'$login_bg_image'              => $login_bg_image,
 	'$login_bg_color'              => $login_bg_color,
-	'$font_color_darker'           => $font_color_darker ?? '#555',
-	'$font_color'                  => $font_color ?? '#777',
+	'$font_color_darker'           => $font_color_darker ?? '#222',
+	'$font_color'                  => $font_color ?? '#444',
 ];
 
 $css_tpl = file_get_contents('view/theme/frio/css/style.css');

--- a/view/theme/frio/templates/nav.tpl
+++ b/view/theme/frio/templates/nav.tpl
@@ -25,51 +25,51 @@
 				{{* Buttons for the mobile view *}}
 				<button type="button" class="navbar-toggle collapsed pull-right" data-toggle="offcanvas" data-target="#myNavmenu" aria-controls="myNavmenu" aria-haspopup="true">
 					<span class="sr-only">Toggle navigation</span>
-					<i class="fa fa-ellipsis-v" aria-hidden="true"></i>
+					<i class="fa fa-ellipsis-v fa-fw fa-lg" aria-hidden="true"></i>
 				</button>
 				<button type="button" class="navbar-toggle collapsed pull-right" data-toggle="collapse" data-target="#search-mobile" aria-expanded="false" aria-controls="search-mobile">
 					<span class="sr-only">Toggle Search</span>
-					<i class="fa fa-search" aria-hidden="true" style="color:#FFF;"></i>
+					<i class="fa fa-search fa-fw fa-lg" aria-hidden="true" style="color:#FFF;"></i>
 				</button>
 				<button type="button" class="navbar-toggle collapsed pull-left visible-sm visible-xs" data-toggle="offcanvas" data-target="aside" aria-haspopup="true">
 					<span class="sr-only">Toggle navigation</span>
-					<i class="fa fa-ellipsis-v" aria-hidden="true"></i>
+					<i class="fa fa-ellipsis-v fa-fw fa-lg" aria-hidden="true"></i>
 				</button>
 
 				{{* Left section of the NavBar with navigation shortcuts/icons *}}
 				<ul class="nav navbar-left" role="menubar">
 					{{if $nav.network}}
 					<li class="nav-segment">
-						<a accesskey="n" class="nav-menu {{$sel.network}}" href="{{$nav.network.0}}" data-toggle="tooltip" aria-label="{{$nav.network.3}}" title="{{$nav.network.3}}"><i class="fa fa-lg fa-th" aria-hidden="true"></i><span id="net-update" class="nav-network-badge badge nav-notification"></span></a>
+						<a accesskey="n" class="nav-menu {{$sel.network}}" href="{{$nav.network.0}}" data-toggle="tooltip" aria-label="{{$nav.network.3}}" title="{{$nav.network.3}}"><i class="fa fa-lg fa-th fa-fw" aria-hidden="true"></i><span id="net-update" class="nav-network-badge badge nav-notification"></span></a>
 					</li>
 					{{/if}}
 					{{if $nav.home}}
 					<li class="nav-segment">
-						<a accesskey="p" class="nav-menu {{$sel.home}}" href="{{$nav.home.0}}" data-toggle="tooltip" aria-label="{{$nav.home.3}}" title="{{$nav.home.3}}"><i class="fa fa-lg fa-home" aria-hidden="true"></i><span id="home-update" class="nav-home-badge badge nav-notification"></span></a>
+						<a accesskey="p" class="nav-menu {{$sel.home}}" href="{{$nav.home.0}}" data-toggle="tooltip" aria-label="{{$nav.home.3}}" title="{{$nav.home.3}}"><i class="fa fa-lg fa-home fa-fw" aria-hidden="true"></i><span id="home-update" class="nav-home-badge badge nav-notification"></span></a>
 					</li>
 					{{/if}}
 
 					{{if $nav.community}}
 					<li class="nav-segment">
-						<a accesskey="c" class="nav-menu {{$sel.community}}" href="{{$nav.community.0}}" data-toggle="tooltip" aria-label="{{$nav.community.3}}" title="{{$nav.community.3}}"><i class="fa fa-lg fa-bullseye" aria-hidden="true"></i></a>
+						<a accesskey="c" class="nav-menu {{$sel.community}}" href="{{$nav.community.0}}" data-toggle="tooltip" aria-label="{{$nav.community.3}}" title="{{$nav.community.3}}"><i class="fa fa-lg fa-bullseye fa-fw" aria-hidden="true"></i></a>
 					</li>
 					{{/if}}
 
 					{{if $nav.messages}}
 					<li class="nav-segment hidden-xs">
-						<a accesskey="m" id="nav-messages-link" href="{{$nav.messages.0}}" data-toggle="tooltip" aria-label="{{$nav.messages.1}}" title="{{$nav.messages.1}}" class="nav-menu {{$sel.messages}}"><i class="fa fa-envelope fa-lg" aria-hidden="true"></i><span id="mail-update" class="nav-mail-badge badge nav-notification"></span></a>
+						<a accesskey="m" id="nav-messages-link" href="{{$nav.messages.0}}" data-toggle="tooltip" aria-label="{{$nav.messages.1}}" title="{{$nav.messages.1}}" class="nav-menu {{$sel.messages}}"><i class="fa fa-envelope fa-lg fa-fw" aria-hidden="true"></i><span id="mail-update" class="nav-mail-badge badge nav-notification"></span></a>
 					</li>
 					{{/if}}
 
 					{{if $nav.events}}
 					<li class="nav-segment hidden-xs">
-						<a accesskey="e" id="nav-events-link" href="{{$nav.events.0}}" data-toggle="tooltip" aria-label="{{$nav.events.1}}" title="{{$nav.events.1}}" class="nav-menu"><i class="fa fa-lg fa-calendar"></i></a>
+						<a accesskey="e" id="nav-events-link" href="{{$nav.events.0}}" data-toggle="tooltip" aria-label="{{$nav.events.1}}" title="{{$nav.events.1}}" class="nav-menu"><i class="fa fa-lg fa-calendar fa-fw"></i></a>
 					</li>
 					{{/if}}
 
 					{{if $nav.contacts}}
 					<li class="nav-segment hidden-xs">
-						<a accesskey="k" id="nav-contacts-link" href="{{$nav.contacts.0}}" data-toggle="tooltip" aria-label="{{$nav.contacts.1}}" title="{{$nav.contacts.1}}"class="nav-menu {{$sel.contacts}} {{$nav.contacts.2}}"><i class="fa fa-users fa-lg"></i></a>
+						<a accesskey="k" id="nav-contacts-link" href="{{$nav.contacts.0}}" data-toggle="tooltip" aria-label="{{$nav.contacts.1}}" title="{{$nav.contacts.1}}"class="nav-menu {{$sel.contacts}} {{$nav.contacts.2}}"><i class="fa fa-users fa-lg fa-fw"></i></a>
 					</li>
 					{{/if}}
 
@@ -264,14 +264,16 @@
 {{/if}}
 
 {{* provide a a search input for mobile view, which expands by pressing the search icon *}}
-<div id="search-mobile" class="hidden-lg hidden-md collapse">
-	<form class="navbar-form" role="search" method="get" action="{{$nav.search.0}}">
-		<!-- <img class="hidden-xs" src="{{$nav.userinfo.icon}}" alt="{{$nav.userinfo.name}}" style="max-width:33px; max-height:33px; min-width:33px; min-height:33px; width:33px; height:33px;"> -->
-		<div class="form-group form-group-search">
-			<input id="nav-search-input-field-mobile" class="form-control form-search" type="text" name="q" data-toggle="tooltip" title="{{$search_hint}}" placeholder="{{$nav.search.1}}">
-			<button class="btn btn-default btn-sm form-button-search" type="submit">{{$nav.search.1}}</button>
-		</div>
-	</form>
+<div id="search-mobile" class="hidden-lg hidden-md hidden-sm collapse row well">
+	<div class="col-xs-12">
+		<form class="navbar-form" role="search" method="get" action="{{$nav.search.0}}">
+			<!-- <img class="hidden-xs" src="{{$nav.userinfo.icon}}" alt="{{$nav.userinfo.name}}" style="max-width:33px; max-height:33px; min-width:33px; min-height:33px; width:33px; height:33px;"> -->
+			<div class="form-group form-group-search">
+				<input id="nav-search-input-field-mobile" class="form-control form-search" type="text" name="q" data-toggle="tooltip" title="{{$search_hint}}" placeholder="{{$nav.search.1}}">
+				<button class="btn btn-default btn-sm form-button-search" type="submit">{{$nav.search.1}}</button>
+			</div>
+		</form>
+	</div>
 </div>
 
 {{* The second navbar which contains nav points of the actual page - (nav points are actual handled by this theme throug js *}}


### PR DESCRIPTION
Removed margin between buttons and the panel bottom on each post:
![frio - useless margin](https://user-images.githubusercontent.com/11581433/104823962-1c2d6e00-581c-11eb-9edb-ec650cd9bf0a.png)

Navigation icons fixed. They are now aligned and the 3 dots and search icon the same size: 
![image](https://user-images.githubusercontent.com/11581433/104824008-73334300-581c-11eb-9314-187ccccdd5d9.png)

I also made the search bar to float so you don't need to scroll to the top to search for something. The text input now takes the whole width on mobile (xs). (#9767)

Color contrast before:
![Frio Dark - test - options](https://user-images.githubusercontent.com/11581433/104823947-01f39000-581c-11eb-8ee8-7016aa65ba0b.png)
![frio light - test - posts](https://user-images.githubusercontent.com/11581433/104823949-0324bd00-581c-11eb-936f-e19adb21ebee.png)

On accents, main colors is a little lighter to improve contrast. I might play with brightness too.

**Now:**
Light:
Main text a little darker here to improve contrast (yes, again, contrast!)
![image](https://user-images.githubusercontent.com/11581433/104824224-fc974500-581d-11eb-9667-cff2a52b80ab.png)

I still need to play a little here it doesn't look quite like it would need to be for the dark accent colors.

Dark - Blue accent:
![image](https://user-images.githubusercontent.com/11581433/104824140-6ebb5a00-581d-11eb-9e87-5b88efc86ba7.png)

Dark - Red accent:
![image](https://user-images.githubusercontent.com/11581433/104824155-8d215580-581d-11eb-9d64-7c7cb3a0432e.png)


The box-shadow was reduced from 3px to 2px so there is a better separation between each posts. Again, need a little more work to beautify the thing. This is mostly visible on the dark theme. I could probably put a black box-shadow on the dark theme :thinking: 

Could be a starter to fix: #9769 
Does fix: #9761 #9767 