### PR TITLE
Avoid duplicates in post-view

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -1,6 +1,6 @@
 -- ------------------------------------------
 -- Friendica 2021.03-dev (Red Hot Poker)
--- DB_UPDATE_VERSION 1390
+-- DB_UPDATE_VERSION 1391
 -- ------------------------------------------
 
 
@@ -1577,7 +1577,6 @@ CREATE VIEW `post-view` AS SELECT
 	`contact`.`avatar-date` AS `avatar-date`,
 	`contact`.`thumb` AS `thumb`,
 	`contact`.`dfrn-id` AS `dfrn-id`,
-	`group_member`.`gid` AS `group-id`,
 	`item`.`author-id` AS `author-id`,
 	`author`.`url` AS `author-link`,
 	`author`.`addr` AS `author-addr`,
@@ -1639,7 +1638,6 @@ CREATE VIEW `post-view` AS SELECT
 			STRAIGHT_JOIN `contact` AS `author` ON `author`.`id` = `item`.`author-id`
 			STRAIGHT_JOIN `contact` AS `owner` ON `owner`.`id` = `item`.`owner-id`
 			STRAIGHT_JOIN `contact` AS `causer` ON `causer`.`id` = `item`.`causer-id`
-			LEFT JOIN `group_member` ON `group_member`.`contact-id` = `item`.`contact-id`
 			LEFT JOIN `verb` ON `verb`.`id` = `item`.`vid`
 			LEFT JOIN `event` ON `event`.`id` = `item`.`event-id`
 			LEFT JOIN `diaspora-interaction` ON `diaspora-interaction`.`uri-id` = `item`.`uri-id`
@@ -1740,7 +1738,6 @@ CREATE VIEW `post-thread-view` AS SELECT
 	`contact`.`avatar-date` AS `avatar-date`,
 	`contact`.`thumb` AS `thumb`,
 	`contact`.`dfrn-id` AS `dfrn-id`,
-	`group_member`.`gid` AS `group-id`,
 	`thread`.`author-id` AS `author-id`,
 	`author`.`url` AS `author-link`,
 	`author`.`addr` AS `author-addr`,
@@ -1803,7 +1800,6 @@ CREATE VIEW `post-thread-view` AS SELECT
 			STRAIGHT_JOIN `contact` AS `author` ON `author`.`id` = `thread`.`author-id`
 			STRAIGHT_JOIN `contact` AS `owner` ON `owner`.`id` = `thread`.`owner-id`
 			STRAIGHT_JOIN `contact` AS `causer` ON `causer`.`id` = `item`.`causer-id`
-			LEFT JOIN `group_member` ON `group_member`.`contact-id` = `thread`.`contact-id`
 			LEFT JOIN `verb` ON `verb`.`id` = `item`.`vid`
 			LEFT JOIN `event` ON `event`.`id` = `item`.`event-id`
 			LEFT JOIN `diaspora-interaction` ON `diaspora-interaction`.`uri-id` = `thread`.`uri-id`

--- a/include/api.php
+++ b/include/api.php
@@ -3297,8 +3297,10 @@ function api_lists_statuses($type)
 
 	$start = max(0, ($page - 1) * $count);
 
-	$condition = ["`uid` = ? AND `gravity` IN (?, ?) AND `id` > ? AND `group-id` = ?",
-		api_user(), GRAVITY_PARENT, GRAVITY_COMMENT, $since_id, $_REQUEST['list_id']];
+	$groups = DBA::selectToArray('group_member', ['contact-id'], ['gid' => 1]);
+	$gids = array_column($groups, 'contact-id');
+	$condition = ['uid' => api_user(), 'gravity' => [GRAVITY_PARENT, GRAVITY_COMMENT], 'group-id' => $gids];
+	$condition = DBA::mergeConditions($condition, ["`id` > ?", $since_id]);
 
 	if ($max_id > 0) {
 		$condition[0] .= " AND `id` <= ?";

--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -55,7 +55,7 @@
 use Friendica\Database\DBA;
 
 if (!defined('DB_UPDATE_VERSION')) {
-	define('DB_UPDATE_VERSION', 1390);
+	define('DB_UPDATE_VERSION', 1391);
 }
 
 return [

--- a/static/dbview.config.php
+++ b/static/dbview.config.php
@@ -123,7 +123,6 @@
 			"avatar-date" => ["contact", "avatar-date"],
 			"thumb" => ["contact", "thumb"],
 			"dfrn-id" => ["contact", "dfrn-id"],
-			"group-id" => ["group_member", "gid"],
 			"author-id" => ["item", "author-id"],
 			"author-link" => ["author", "url"],
 			"author-addr" => ["author", "addr"],
@@ -186,7 +185,6 @@
 			STRAIGHT_JOIN `contact` AS `author` ON `author`.`id` = `item`.`author-id`
 			STRAIGHT_JOIN `contact` AS `owner` ON `owner`.`id` = `item`.`owner-id`
 			STRAIGHT_JOIN `contact` AS `causer` ON `causer`.`id` = `item`.`causer-id`
-			LEFT JOIN `group_member` ON `group_member`.`contact-id` = `item`.`contact-id`
 			LEFT JOIN `verb` ON `verb`.`id` = `item`.`vid`
 			LEFT JOIN `event` ON `event`.`id` = `item`.`event-id`
 			LEFT JOIN `diaspora-interaction` ON `diaspora-interaction`.`uri-id` = `item`.`uri-id`
@@ -285,7 +283,6 @@
 			"avatar-date" => ["contact", "avatar-date"],
 			"thumb" => ["contact", "thumb"],
 			"dfrn-id" => ["contact", "dfrn-id"],
-			"group-id" => ["group_member", "gid"],
 			"author-id" => ["thread", "author-id"],
 			"author-link" => ["author", "url"],
 			"author-addr" => ["author", "addr"],
@@ -349,7 +346,6 @@
 			STRAIGHT_JOIN `contact` AS `author` ON `author`.`id` = `thread`.`author-id`
 			STRAIGHT_JOIN `contact` AS `owner` ON `owner`.`id` = `thread`.`owner-id`
 			STRAIGHT_JOIN `contact` AS `causer` ON `causer`.`id` = `item`.`causer-id`
-			LEFT JOIN `group_member` ON `group_member`.`contact-id` = `thread`.`contact-id`
 			LEFT JOIN `verb` ON `verb`.`id` = `item`.`vid`
 			LEFT JOIN `event` ON `event`.`id` = `item`.`event-id`
 			LEFT JOIN `diaspora-interaction` ON `diaspora-interaction`.`uri-id` = `thread`.`uri-id`


### PR DESCRIPTION
Including the `group_member` table in the view wasn't that great of an idea :-)

Since it is only used on a single occasion, we can workaround it.