### PR TITLE
Remove strictly numeric tags exception

### DIFF
--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -2104,11 +2104,6 @@ class BBCode
 						continue;
 					}
 
-					// ignore strictly numeric tags like #1
-					if ((strpos($match, '#') === 0) && ctype_digit(substr($match, 1))) {
-						continue;
-					}
-
 					// try not to catch url fragments
 					if (strpos($string, $match) && preg_match('/[a-zA-z0-9\/]/', substr($string, strpos($string, $match) - 1, 1))) {
 						continue;


### PR DESCRIPTION
Fixes #9733 
- It prevented to use year number hashtags for no clear benefit

It wasn't a bug, it was a questionable feature.