### PR TITLE
Add eslint, prettier config files to Frio folder

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,3 +8,7 @@ charset = utf-8
 end_of_line = lf
 trim_trailing_whitespaces = true
 indent_style = tab
+quote_type = single
+
+[*.js]
+quote_type = double

--- a/view/theme/frio/.eslintrc.json
+++ b/view/theme/frio/.eslintrc.json
@@ -1,0 +1,8 @@
+{
+	"rules": {
+		"no-unused-vars": ["warn", { "args": "none", "argsIgnorePattern": "req|res|next|val" }],
+		"quotes": ["error", "double"],
+		"indent": ["error", "tab"],
+		"prettier/prettier": ["error"]
+	}
+}

--- a/view/theme/frio/.prettierrc
+++ b/view/theme/frio/.prettierrc
@@ -1,0 +1,12 @@
+{
+	"printWidth": 120,
+	"tabWidth": 4,
+	"useTabs": true,
+	"semi": true,
+	"singleQuote": false,
+	"quoteProps": "as-needed",
+	"trailingComma": "all",
+	"bracketSpacing": true,
+	"arrowParens": "always",
+	"endOfLine": "lf"
+}


### PR DESCRIPTION
Add a .js file exception to use double-quotes in `.editorconfig`
Add eslint and prettier config file to frio theme folder. This makes it easier for VS Code (and probably other editors) that have those plugins installed to follow coding guidelines.

I set it up to use double-quotes as it was what was mostly used already. I can switch it to use single quotes if the maintainers prefer it that way.

If this is merged I'll make a PR with all files with fixed formatting for the frio theme files. This will make future PRs easier to read and avoid the #9844 mess I made (I hate VSCode)