### PR TITLE
Don't create a user-item entry on default

### DIFF
--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -321,7 +321,9 @@ class Item
 
 		$items = Post::select(['id', 'uid', 'uri-id'], $condition);
 		while ($item = Post::fetch($items)) {
-			Post\User::update($item['uri-id'], $item['uid'], ['hidden' => true]);
+			if (in_array($item['uid'], [$uid, 0])) {
+				Post\User::update($item['uri-id'], $uid, ['hidden' => true], true);
+			}
 
 			// "Deleting" global items just means hiding them
 			if ($item['uid'] == 0) {

--- a/src/Model/Post/User.php
+++ b/src/Model/Post/User.php
@@ -66,11 +66,12 @@ class User
 	 *
 	 * @param integer $uri_id
 	 * @param integer $uid
-	 * @param array   $fields
+	 * @param array   $data
+	 * @param bool    $insert_if_missing
 	 * @return bool
 	 * @throws \Exception
 	 */
-	public static function update(int $uri_id, int $uid, array $data = [])
+	public static function update(int $uri_id, int $uid, array $data = [], bool $insert_if_missing = false)
 	{
 		if (empty($uri_id)) {
 			throw new BadMethodCallException('Empty URI_id');
@@ -86,6 +87,6 @@ class User
 			return true;
 		}
 
-		return DBA::update('post-user', $fields, ['uri-id' => $uri_id, 'uid' => $uid], true);
+		return DBA::update('post-user', $fields, ['uri-id' => $uri_id, 'uid' => $uid], $insert_if_missing ? true : []);
 	}
 }


### PR DESCRIPTION
Until now we always created a `user-item` entry when we called the update function and this entry hadn't existed. This does make sense for rare occasions - but not by default. In fact this could have prevented users from receiving some posts at all.

One can test how much items hadn't been delivered successfully on the own machine by executing this query:
```
SELECT COUNT(*) FROM `post-user` WHERE `contact-id` = 0 AND `notification-type` != 0;
```
There is currently no repair functionality for this issue. Possibly this is done at a later time when the impact is more severe than expected.