### PR TITLE
New setting that controls notifications for ignored contacts

### DIFF
--- a/include/enotify.php
+++ b/include/enotify.php
@@ -624,6 +624,11 @@ function check_item_notification($itemid, $uid, $notification_type) {
 		return false;
 	}
 
+	if (DI::pConfig()->get(local_user(), 'system', 'notify_ignored', true) && Contact\User::isIgnored($item['author-id'], $uid)) {
+		Logger::info('Author is ignored, dropping notification', ['cid' => $item['author-id'], 'uid' =>  $uid]);
+		return false;
+	}
+
 	// Generate the notification array
 	$params = [];
 	$params['otype'] = Notify\ObjectType::ITEM;

--- a/include/enotify.php
+++ b/include/enotify.php
@@ -624,7 +624,7 @@ function check_item_notification($itemid, $uid, $notification_type) {
 		return false;
 	}
 
-	if (DI::pConfig()->get(local_user(), 'system', 'notify_ignored', true) && Contact\User::isIgnored($item['author-id'], $uid)) {
+	if (!DI::pConfig()->get(local_user(), 'system', 'notify_ignored', true) && Contact\User::isIgnored($item['author-id'], $uid)) {
 		Logger::info('Author is ignored, dropping notification', ['cid' => $item['author-id'], 'uid' =>  $uid]);
 		return false;
 	}

--- a/mod/settings.php
+++ b/mod/settings.php
@@ -323,6 +323,8 @@ function settings_post(App $a)
 	$email_textonly   = (($_POST['email_textonly'] == 1) ? 1 : 0);
 	$detailed_notif   = (($_POST['detailed_notif'] == 1) ? 1 : 0);
 
+	$notify_ignored   = (($_POST['notify_ignored'] == 1) ? 1 : 0);
+	
 	$notify = 0;
 
 	if (!empty($_POST['notify1'])) {
@@ -416,6 +418,7 @@ function settings_post(App $a)
 
 	DI::pConfig()->set(local_user(), 'system', 'email_textonly', $email_textonly);
 	DI::pConfig()->set(local_user(), 'system', 'detailed_notif', $detailed_notif);
+	DI::pConfig()->set(local_user(), 'system', 'notify_ignored', $notify_ignored);
 	DI::pConfig()->set(local_user(), 'system', 'unlisted', $unlisted);
 	DI::pConfig()->set(local_user(), 'system', 'accessible-photos', $accessiblephotos);
 
@@ -911,7 +914,11 @@ function settings_content(App $a)
 									DI::pConfig()->get(local_user(), 'system', 'detailed_notif'),
 									DI::l10n()->t('Per default, notifications are condensed to a single notification per item. When enabled every notification is displayed.')],
 
-		'$h_advn' => DI::l10n()->t('Advanced Account/Page Type Settings'),
+		'$notify_ignored' => ['notify_ignored', DI::l10n()->t('Show notifications of ignored contacts') ,
+									DI::pConfig()->get(local_user(), 'system', 'notify_ignored', true),
+									DI::l10n()->t("You don't see posts from ignored contacts. But you still see their comments. This setting controls if you want to still receive regular notifications that are caused by ignored contacts or not.")],
+
+									'$h_advn' => DI::l10n()->t('Advanced Account/Page Type Settings'),
 		'$h_descadvn' => DI::l10n()->t('Change the behaviour of this account for special situations'),
 		'$pagetype' => $pagetype,
 

--- a/view/templates/settings/settings.tpl
+++ b/view/templates/settings/settings.tpl
@@ -101,6 +101,8 @@
 			{{include file="field_checkbox.tpl" field=$email_textonly}}
 			{{include file="field_checkbox.tpl" field=$detailed_notif}}
 
+			{{include file="field_checkbox.tpl" field=$notify_ignored}}
+
 			{{include file="field_checkbox.tpl" field=$desktop_notifications}}
 			<script>
 				(function () {

--- a/view/theme/frio/templates/settings/settings.tpl
+++ b/view/theme/frio/templates/settings/settings.tpl
@@ -150,6 +150,8 @@
 						{{include file="field_checkbox.tpl" field=$email_textonly}}
 						{{include file="field_checkbox.tpl" field=$detailed_notif}}
 
+						{{include file="field_checkbox.tpl" field=$notify_ignored}}
+
 						{{* commented out because it was commented out in the original template
 						<div class="field">
 						 <button type="button" onclick="javascript:Notification.requestPermission(function(perm){if(perm === 'granted')alert('{{$desktop_notifications_success_message}}');});">{{$desktop_notifications}}</button>


### PR DESCRIPTION
This is an alternate solution to PR https://github.com/friendica/friendica/pull/9853

The check for ignored contacts is done at a central place and also it is configurable.