### PR TITLE
Rename notify classes according the feature name, not the table name

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -32,7 +32,7 @@ use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Contact;
-use Friendica\Model\Notify;
+use Friendica\Model\Notification;
 use Friendica\Util\BasePath;
 use Friendica\Util\DateTimeFormat;
 
@@ -145,36 +145,36 @@ $netgroup_ids = [
 define('MAX_LIKERS',    75);
 
 /**
- * @name Notify
+ * @name Notification
  *
  * Email notification options
  * @{
  */
-/** @deprecated since 2020.03, use Notify\Type::INTRO instead */
-define('NOTIFY_INTRO',        Notify\Type::INTRO);
-/** @deprecated since 2020.03, use Notify\Type::CONFIRM instead */
-define('NOTIFY_CONFIRM',      Notify\Type::CONFIRM);
-/** @deprecated since 2020.03, use Notify\Type::WALL instead */
-define('NOTIFY_WALL',         Notify\Type::WALL);
-/** @deprecated since 2020.03, use Notify\Type::COMMENT instead */
-define('NOTIFY_COMMENT',      Notify\Type::COMMENT);
-/** @deprecated since 2020.03, use Notify\Type::MAIL instead */
-define('NOTIFY_MAIL',        Notify\Type::MAIL);
-/** @deprecated since 2020.03, use Notify\Type::SUGGEST instead */
-define('NOTIFY_SUGGEST',     Notify\Type::SUGGEST);
-/** @deprecated since 2020.03, use Notify\Type::PROFILE instead */
-define('NOTIFY_PROFILE',     Notify\Type::PROFILE);
-/** @deprecated since 2020.03, use Notify\Type::TAG_SELF instead */
-define('NOTIFY_TAGSELF',     Notify\Type::TAG_SELF);
-/** @deprecated since 2020.03, use Notify\Type::TAG_SHARE instead */
-define('NOTIFY_TAGSHARE',    Notify\Type::TAG_SHARE);
-/** @deprecated since 2020.03, use Notify\Type::POKE instead */
-define('NOTIFY_POKE',        Notify\Type::POKE);
-/** @deprecated since 2020.03, use Notify\Type::SHARE instead */
-define('NOTIFY_SHARE',       Notify\Type::SHARE);
+/** @deprecated since 2020.03, use Notification\Type::INTRO instead */
+define('NOTIFY_INTRO',        Notification\Type::INTRO);
+/** @deprecated since 2020.03, use Notification\Type::CONFIRM instead */
+define('NOTIFY_CONFIRM',      Notification\Type::CONFIRM);
+/** @deprecated since 2020.03, use Notification\Type::WALL instead */
+define('NOTIFY_WALL',         Notification\Type::WALL);
+/** @deprecated since 2020.03, use Notification\Type::COMMENT instead */
+define('NOTIFY_COMMENT',      Notification\Type::COMMENT);
+/** @deprecated since 2020.03, use Notification\Type::MAIL instead */
+define('NOTIFY_MAIL',        Notification\Type::MAIL);
+/** @deprecated since 2020.03, use Notification\Type::SUGGEST instead */
+define('NOTIFY_SUGGEST',     Notification\Type::SUGGEST);
+/** @deprecated since 2020.03, use Notification\Type::PROFILE instead */
+define('NOTIFY_PROFILE',     Notification\Type::PROFILE);
+/** @deprecated since 2020.03, use Notification\Type::TAG_SELF instead */
+define('NOTIFY_TAGSELF',     Notification\Type::TAG_SELF);
+/** @deprecated since 2020.03, use Notification\Type::TAG_SHARE instead */
+define('NOTIFY_TAGSHARE',    Notification\Type::TAG_SHARE);
+/** @deprecated since 2020.03, use Notification\Type::POKE instead */
+define('NOTIFY_POKE',        Notification\Type::POKE);
+/** @deprecated since 2020.03, use Notification\Type::SHARE instead */
+define('NOTIFY_SHARE',       Notification\Type::SHARE);
 
-/** @deprecated since 2020.12, use Notify\Type::SYSTEM instead */
-define('NOTIFY_SYSTEM',      Notify\Type::SYSTEM);
+/** @deprecated since 2020.12, use Notification\Type::SYSTEM instead */
+define('NOTIFY_SYSTEM',      Notification\Type::SYSTEM);
 /* @}*/
 
 /**

--- a/include/api.php
+++ b/include/api.php
@@ -39,13 +39,12 @@ use Friendica\Model\Contact;
 use Friendica\Model\Group;
 use Friendica\Model\Item;
 use Friendica\Model\Mail;
-use Friendica\Model\Notify;
+use Friendica\Model\Notification;
 use Friendica\Model\Photo;
 use Friendica\Model\Post;
 use Friendica\Model\User;
 use Friendica\Model\UserItem;
 use Friendica\Model\Verb;
-use Friendica\Security\FKOAuth1;
 use Friendica\Network\HTTPException;
 use Friendica\Network\HTTPException\BadRequestException;
 use Friendica\Network\HTTPException\ExpectationFailedException;
@@ -53,12 +52,12 @@ use Friendica\Network\HTTPException\ForbiddenException;
 use Friendica\Network\HTTPException\InternalServerErrorException;
 use Friendica\Network\HTTPException\MethodNotAllowedException;
 use Friendica\Network\HTTPException\NotFoundException;
-use Friendica\Network\HTTPException\NotImplementedException;
 use Friendica\Network\HTTPException\TooManyRequestsException;
 use Friendica\Network\HTTPException\UnauthorizedException;
 use Friendica\Object\Image;
 use Friendica\Protocol\Activity;
 use Friendica\Protocol\Diaspora;
+use Friendica\Security\FKOAuth1;
 use Friendica\Security\OAuth1\OAuthRequest;
 use Friendica\Security\OAuth1\OAuthUtil;
 use Friendica\Util\DateTimeFormat;
@@ -5809,7 +5808,7 @@ function api_friendica_notification_seen($type)
 		$notify = DI::notify()->getByID($id, api_user());
 		DI::notify()->setSeen(true, $notify);
 
-		if ($notify->otype === Notify\ObjectType::ITEM) {
+		if ($notify->otype === Notification\ObjectType::ITEM) {
 			$item = Post::selectFirstForUser(api_user(), [], ['id' => $notify->iid, 'uid' => api_user()]);
 			if (DBA::isResult($item)) {
 				// we found the item, return it to the user

--- a/include/enotify.php
+++ b/include/enotify.php
@@ -29,7 +29,7 @@ use Friendica\DI;
 use Friendica\Model\Contact;
 use Friendica\Model\Item;
 use Friendica\Model\ItemContent;
-use Friendica\Model\Notify;
+use Friendica\Model\Notification;
 use Friendica\Model\Post;
 use Friendica\Model\User;
 use Friendica\Model\UserItem;
@@ -132,7 +132,7 @@ function notification($params)
 	$hsitelink = '';
 	$itemlink  = '';
 
-	if ($params['type'] == Notify\Type::MAIL) {
+	if ($params['type'] == Notification\Type::MAIL) {
 		$itemlink = $params['link'];
 
 		$subject = $l10n->t('%s New mail received at %s', $subjectPrefix, $sitename);
@@ -148,7 +148,7 @@ function notification($params)
 		$show_in_notification_page = false;
 	}
 
-	if ($params['type'] == Notify\Type::COMMENT || $params['type'] == Notify\Type::TAG_SELF) {
+	if ($params['type'] == Notification\Type::COMMENT || $params['type'] == Notification\Type::TAG_SELF) {
 		$thread = Post::selectFirstThreadForUser($params['uid'], ['ignored'], ['iid' => $parent_id, 'deleted' => false]);
 		if (DBA::isResult($thread) && $thread['ignored']) {
 			Logger::log('Thread ' . $parent_id . ' will be ignored', Logger::DEBUG);
@@ -158,7 +158,7 @@ function notification($params)
 		// Check to see if there was already a tag notify or comment notify for this post.
 		// If so don't create a second notification
 		/// @todo In the future we should store the notification with the highest "value" and replace notifications
-		$condition = ['type' => [Notify\Type::TAG_SELF, Notify\Type::COMMENT, Notify\Type::SHARE],
+		$condition = ['type' => [Notification\Type::TAG_SELF, Notification\Type::COMMENT, Notification\Type::SHARE],
 			'link' => $params['link'], 'uid' => $params['uid']];
 		if (DBA::exists('notify', $condition)) {
 			return false;
@@ -166,7 +166,7 @@ function notification($params)
 
 		// if it's a post figure out who's post it is.
 		$item = null;
-		if ($params['otype'] === Notify\ObjectType::ITEM && $parent_id) {
+		if ($params['otype'] === Notification\ObjectType::ITEM && $parent_id) {
 			$item = Post::selectFirstForUser($params['uid'], Item::ITEM_FIELDLIST, ['id' => $parent_id, 'deleted' => false]);
 		}
 
@@ -244,7 +244,7 @@ function notification($params)
 		$itemlink =  $params['link'];
 	}
 
-	if ($params['type'] == Notify\Type::WALL) {
+	if ($params['type'] == Notification\Type::WALL) {
 		$subject = $l10n->t('%s %s posted to your profile wall', $subjectPrefix, $params['source_name']);
 
 		$preamble = $l10n->t('%1$s posted to your profile wall at %2$s', $params['source_name'], $sitename);
@@ -259,7 +259,7 @@ function notification($params)
 		$itemlink =  $params['link'];
 	}
 
-	if ($params['type'] == Notify\Type::SHARE) {
+	if ($params['type'] == Notification\Type::SHARE) {
 		if ($params['origin_link'] == $params['source_link']) {
 			$subject = $l10n->t('%s %s shared a new post', $subjectPrefix, $params['source_name']);
 
@@ -284,7 +284,7 @@ function notification($params)
 		$itemlink =  $params['link'];
 	}
 
-	if ($params['type'] == Notify\Type::POKE) {
+	if ($params['type'] == Notification\Type::POKE) {
 		$subject = $l10n->t('%1$s %2$s poked you', $subjectPrefix, $params['source_name']);
 
 		$preamble = $l10n->t('%1$s poked you at %2$s', $params['source_name'], $sitename);
@@ -303,7 +303,7 @@ function notification($params)
 		$itemlink =  $params['link'];
 	}
 
-	if ($params['type'] == Notify\Type::TAG_SHARE) {
+	if ($params['type'] == Notification\Type::TAG_SHARE) {
 		$itemlink =  $params['link'];
 		$subject = $l10n->t('%s %s tagged your post', $subjectPrefix, $params['source_name']);
 
@@ -318,7 +318,7 @@ function notification($params)
 		$hsitelink = sprintf($sitelink, '<a href="'.$siteurl.'">'.$sitename.'</a>');
 	}
 
-	if ($params['type'] == Notify\Type::INTRO) {
+	if ($params['type'] == Notification\Type::INTRO) {
 		$itemlink = $params['link'];
 		$subject = $l10n->t('%s Introduction received', $subjectPrefix);
 
@@ -361,7 +361,7 @@ function notification($params)
 		}
 	}
 
-	if ($params['type'] == Notify\Type::SUGGEST) {
+	if ($params['type'] == Notification\Type::SUGGEST) {
 		$itemlink =  $params['link'];
 		$subject = $l10n->t('%s Friend suggestion received', $subjectPrefix);
 
@@ -381,7 +381,7 @@ function notification($params)
 		$hsitelink = sprintf($sitelink, '<a href="'.$siteurl.'">'.$sitename.'</a>');
 	}
 
-	if ($params['type'] == Notify\Type::CONFIRM) {
+	if ($params['type'] == Notification\Type::CONFIRM) {
 		if ($params['verb'] == Activity::FRIEND) { // mutual connection
 			$itemlink =  $params['link'];
 			$subject = $l10n->t('%s Connection accepted', $subjectPrefix);
@@ -417,7 +417,7 @@ function notification($params)
 		}
 	}
 
-	if ($params['type'] == Notify\Type::SYSTEM) {
+	if ($params['type'] == Notification\Type::SYSTEM) {
 		switch($params['event']) {
 			case "SYSTEM_REGISTER_REQUEST":
 				$itemlink =  $params['link'];
@@ -514,7 +514,7 @@ function notification($params)
 
 	// send email notification if notification preferences permit
 	if ((intval($params['notify_flags']) & intval($params['type']))
-		|| $params['type'] == Notify\Type::SYSTEM) {
+		|| $params['type'] == Notification\Type::SYSTEM) {
 
 		Logger::log('sending notification email');
 
@@ -631,7 +631,7 @@ function check_item_notification($itemid, $uid, $notification_type) {
 
 	// Generate the notification array
 	$params = [];
-	$params['otype'] = Notify\ObjectType::ITEM;
+	$params['otype'] = Notification\ObjectType::ITEM;
 	$params['uid'] = $uid;
 	$params['origin_cid'] = $params['cid'] = $item['author-id'];
 	$params['item'] = $item;
@@ -651,7 +651,7 @@ function check_item_notification($itemid, $uid, $notification_type) {
 	}
 
 	if ($notification_type & UserItem::NOTIF_SHARED) {
-		$params['type'] = Notify\Type::SHARE;
+		$params['type'] = Notification\Type::SHARE;
 		$params['verb'] = Activity::POST;
 
 		// Special treatment for posts that had been shared via "announce"
@@ -668,22 +668,22 @@ function check_item_notification($itemid, $uid, $notification_type) {
 			}
 		}
 	} elseif ($notification_type & UserItem::NOTIF_EXPLICIT_TAGGED) {
-		$params['type'] = Notify\Type::TAG_SELF;
+		$params['type'] = Notification\Type::TAG_SELF;
 		$params['verb'] = Activity::TAG;
 	} elseif ($notification_type & UserItem::NOTIF_IMPLICIT_TAGGED) {
-		$params['type'] = Notify\Type::COMMENT;
+		$params['type'] = Notification\Type::COMMENT;
 		$params['verb'] = Activity::POST;
 	} elseif ($notification_type & UserItem::NOTIF_THREAD_COMMENT) {
-		$params['type'] = Notify\Type::COMMENT;
+		$params['type'] = Notification\Type::COMMENT;
 		$params['verb'] = Activity::POST;
 	} elseif ($notification_type & UserItem::NOTIF_DIRECT_COMMENT) {
-		$params['type'] = Notify\Type::COMMENT;
+		$params['type'] = Notification\Type::COMMENT;
 		$params['verb'] = Activity::POST;
 	} elseif ($notification_type & UserItem::NOTIF_COMMENT_PARTICIPATION) {
-		$params['type'] = Notify\Type::COMMENT;
+		$params['type'] = Notification\Type::COMMENT;
 		$params['verb'] = Activity::POST;
 	} elseif ($notification_type & UserItem::NOTIF_ACTIVITY_PARTICIPATION) {
-		$params['type'] = Notify\Type::COMMENT;
+		$params['type'] = Notification\Type::COMMENT;
 		$params['verb'] = Activity::POST;
 	} else {
 		return false;

--- a/mod/dfrn_confirm.php
+++ b/mod/dfrn_confirm.php
@@ -40,8 +40,7 @@ use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Contact;
 use Friendica\Model\Group;
-use Friendica\Model\Notify;
-use Friendica\Model\Notify\Type;
+use Friendica\Model\Notification;
 use Friendica\Model\User;
 use Friendica\Protocol\Activity;
 use Friendica\Util\Crypto;
@@ -540,11 +539,11 @@ function dfrn_confirm_post(App $a, $handsfree = null)
 		if (DBA::isResult($r)) {
 			$combined = $r[0];
 
-			if ($combined['notify-flags'] & Type::CONFIRM) {
+			if ($combined['notify-flags'] & Notification\Type::CONFIRM) {
 				$mutual = ($new_relation == Contact::FRIEND);
 				notification([
-					'type'  => Type::CONFIRM,
-					'otype' => Notify\ObjectType::INTRO,
+					'type'  => Notification\Type::CONFIRM,
+					'otype' => Notification\ObjectType::INTRO,
 					'verb'  => ($mutual ? Activity::FRIEND : Activity::FOLLOW),
 					'uid'   => $combined['uid'],
 					'cid'   => $combined['id'],

--- a/mod/dfrn_request.php
+++ b/mod/dfrn_request.php
@@ -35,8 +35,7 @@ use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Contact;
 use Friendica\Model\Group;
-use Friendica\Model\Notify;
-use Friendica\Model\Notify\Type;
+use Friendica\Model\Notification;
 use Friendica\Model\Profile;
 use Friendica\Model\User;
 use Friendica\Module\Security\Login;
@@ -560,8 +559,8 @@ function dfrn_request_content(App $a)
 
 				if (!$auto_confirm) {
 					notification([
-						'type'  => Type::INTRO,
-						'otype' => Notify\ObjectType::INTRO,
+						'type'  => Notification\Type::INTRO,
+						'otype' => Notification\ObjectType::INTRO,
 						'verb'  => Activity::REQ_FRIEND,
 						'uid'   => $r[0]['uid'],
 						'cid'   => $r[0]['id'],

--- a/mod/item.php
+++ b/mod/item.php
@@ -45,8 +45,7 @@ use Friendica\Model\Contact;
 use Friendica\Model\Conversation;
 use Friendica\Model\FileTag;
 use Friendica\Model\Item;
-use Friendica\Model\Notify;
-use Friendica\Model\Notify\Type;
+use Friendica\Model\Notification;
 use Friendica\Model\Photo;
 use Friendica\Model\Post;
 use Friendica\Model\Tag;
@@ -55,8 +54,8 @@ use Friendica\Network\HTTPException;
 use Friendica\Object\EMail\ItemCCEMail;
 use Friendica\Protocol\Activity;
 use Friendica\Protocol\Diaspora;
-use Friendica\Util\DateTimeFormat;
 use Friendica\Security\Security;
+use Friendica\Util\DateTimeFormat;
 use Friendica\Worker\Delivery;
 
 function item_post(App $a) {
@@ -743,8 +742,8 @@ function item_post(App $a) {
 	if ($contact_record != $author) {
 		if ($toplevel_item_id) {
 			notification([
-				'type'  => Type::COMMENT,
-				'otype' => Notify\ObjectType::ITEM,
+				'type'  => Notification\Type::COMMENT,
+				'otype' => Notification\ObjectType::ITEM,
 				'verb'  => Activity::POST,
 				'uid'   => $profile_uid,
 				'cid'   => $datarray['author-id'],
@@ -753,8 +752,8 @@ function item_post(App $a) {
 			]);
 		} elseif (empty($forum_contact)) {
 			notification([
-				'type'  => Type::WALL,
-				'otype' => Notify\ObjectType::ITEM,
+				'type'  => Notification\Type::WALL,
+				'otype' => Notification\ObjectType::ITEM,
 				'verb'  => Activity::POST,
 				'uid'   => $profile_uid,
 				'cid'   => $datarray['author-id'],

--- a/mod/message.php
+++ b/mod/message.php
@@ -29,7 +29,6 @@ use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Contact;
 use Friendica\Model\Mail;
-use Friendica\Model\Notify\Type;
 use Friendica\Module\Security\Login;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Strings;

--- a/mod/ping.php
+++ b/mod/ping.php
@@ -28,7 +28,7 @@ use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Contact;
 use Friendica\Model\Group;
-use Friendica\Model\Notify\Type;
+use Friendica\Model\Notification;
 use Friendica\Model\Post;
 use Friendica\Model\Verb;
 use Friendica\Protocol\Activity;
@@ -418,8 +418,8 @@ function ping_get_notifications($uid)
 			AND NOT (`notify`.`type` IN (%d, %d))
 			AND $seensql `notify`.`seen` ORDER BY `notify`.`date` $order LIMIT %d, 50",
 			intval($uid),
-			intval(Type::INTRO),
-			intval(Type::MAIL),
+			intval(Notification\Type::INTRO),
+			intval(Notification\Type::MAIL),
 			intval($offset)
 		);
 
@@ -448,7 +448,7 @@ function ping_get_notifications($uid)
 				$notification["message"] = $notification["msg_cache"];
 			} else {
 				$notification["name"] = strip_tags(BBCode::convert($notification["name"]));
-				$notification["message"] = Friendica\Model\Notify::formatMessage($notification["name"], strip_tags(BBCode::convert($notification["msg"])));
+				$notification["message"] = Notification::formatMessage($notification["name"], strip_tags(BBCode::convert($notification["msg"])));
 
 				q(
 					"UPDATE `notify` SET `name_cache` = '%s', `msg_cache` = '%s' WHERE `id` = %d",

--- a/mod/settings.php
+++ b/mod/settings.php
@@ -32,7 +32,7 @@ use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Contact;
 use Friendica\Model\Group;
-use Friendica\Model\Notify\Type;
+use Friendica\Model\Notification;
 use Friendica\Model\User;
 use Friendica\Module\BaseSettings;
 use Friendica\Module\Security\Login;
@@ -895,14 +895,14 @@ function settings_content(App $a)
 
 		'$h_not' 	=> DI::l10n()->t('Notification Settings'),
 		'$lbl_not' 	=> DI::l10n()->t('Send a notification email when:'),
-		'$notify1'	=> ['notify1', DI::l10n()->t('You receive an introduction'), ($notify & Type::INTRO), Type::INTRO, ''],
-		'$notify2'	=> ['notify2', DI::l10n()->t('Your introductions are confirmed'), ($notify & Type::CONFIRM), Type::CONFIRM, ''],
-		'$notify3'	=> ['notify3', DI::l10n()->t('Someone writes on your profile wall'), ($notify & Type::WALL), Type::WALL, ''],
-		'$notify4'	=> ['notify4', DI::l10n()->t('Someone writes a followup comment'), ($notify & Type::COMMENT), Type::COMMENT, ''],
-		'$notify5'	=> ['notify5', DI::l10n()->t('You receive a private message'), ($notify & Type::MAIL), Type::MAIL, ''],
-		'$notify6'  => ['notify6', DI::l10n()->t('You receive a friend suggestion'), ($notify & Type::SUGGEST), Type::SUGGEST, ''],
-		'$notify7'  => ['notify7', DI::l10n()->t('You are tagged in a post'), ($notify & Type::TAG_SELF), Type::TAG_SELF, ''],
-		'$notify8'  => ['notify8', DI::l10n()->t('You are poked/prodded/etc. in a post'), ($notify & Type::POKE), Type::POKE, ''],
+		'$notify1'	=> ['notify1', DI::l10n()->t('You receive an introduction'), ($notify & Notification\Type::INTRO), Notification\Type::INTRO, ''],
+		'$notify2'	=> ['notify2', DI::l10n()->t('Your introductions are confirmed'), ($notify & Notification\Type::CONFIRM), Notification\Type::CONFIRM, ''],
+		'$notify3'	=> ['notify3', DI::l10n()->t('Someone writes on your profile wall'), ($notify & Notification\Type::WALL), Notification\Type::WALL, ''],
+		'$notify4'	=> ['notify4', DI::l10n()->t('Someone writes a followup comment'), ($notify & Notification\Type::COMMENT), Notification\Type::COMMENT, ''],
+		'$notify5'	=> ['notify5', DI::l10n()->t('You receive a private message'), ($notify & Notification\Type::MAIL), Notification\Type::MAIL, ''],
+		'$notify6'  => ['notify6', DI::l10n()->t('You receive a friend suggestion'), ($notify & Notification\Type::SUGGEST), Notification\Type::SUGGEST, ''],
+		'$notify7'  => ['notify7', DI::l10n()->t('You are tagged in a post'), ($notify & Notification\Type::TAG_SELF), Notification\Type::TAG_SELF, ''],
+		'$notify8'  => ['notify8', DI::l10n()->t('You are poked/prodded/etc. in a post'), ($notify & Notification\Type::POKE), Notification\Type::POKE, ''],
 
 		'$desktop_notifications' => ['desktop_notifications', DI::l10n()->t('Activate desktop notifications') , false, DI::l10n()->t('Show desktop popup on new notifications')],
 

--- a/src/Collection/Notifications.php
+++ b/src/Collection/Notifications.php
@@ -19,15 +19,18 @@
  *
  */
 
-namespace Friendica\Model\Notify;
+namespace Friendica\Collection;
 
-/**
- * Enum for different otypes of the Notify
- */
-class ObjectType
+use Friendica\BaseCollection;
+use Friendica\Model;
+
+class Notifications extends BaseCollection
 {
-	const PERSON = 'person';
-	const MAIL   = 'mail';
-	const ITEM   = 'item';
-	const INTRO  = 'intro';
+	/**
+	 * @return Model\Notification
+	 */
+	public function current()
+	{
+		return parent::current();
+	}
 }

--- a/src/DI.php
+++ b/src/DI.php
@@ -411,11 +411,11 @@ abstract class DI
 	}
 
 	/**
-	 * @return Repository\Notify
+	 * @return Repository\Notification
 	 */
 	public static function notify()
 	{
-		return self::$dice->create(Repository\Notify::class);
+		return self::$dice->create(Repository\Notification::class);
 	}
 
 	//

--- a/src/Factory/Notification/Notification.php
+++ b/src/Factory/Notification/Notification.php
@@ -56,7 +56,7 @@ class Notification extends BaseFactory
 {
 	/** @var Database */
 	private $dba;
-	/** @var Repository\Notify */
+	/** @var Repository\Notification */
 	private $notification;
 	/** @var BaseURL */
 	private $baseUrl;
@@ -65,7 +65,7 @@ class Notification extends BaseFactory
 	/** @var string */
 	private $nurl;
 
-	public function __construct(LoggerInterface $logger, Database $dba, Repository\Notify $notification, BaseURL $baseUrl, L10n $l10n, App $app, IPConfig $pConfig, ISession $session)
+	public function __construct(LoggerInterface $logger, Database $dba, Repository\Notification $notification, BaseURL $baseUrl, L10n $l10n, App $app, IPConfig $pConfig, ISession $session)
 	{
 		parent::__construct($logger);
 

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -34,7 +34,6 @@ use Friendica\Core\Worker;
 use Friendica\Database\Database;
 use Friendica\Database\DBA;
 use Friendica\DI;
-use Friendica\Model\Notify\Type;
 use Friendica\Network\HTTPException;
 use Friendica\Network\Probe;
 use Friendica\Protocol\Activity;
@@ -2499,12 +2498,12 @@ class Contact
 
 				Group::addMember(User::getDefaultGroup($importer['uid'], $contact_record["network"]), $contact_record['id']);
 
-				if (($user['notify-flags'] & Type::INTRO) &&
+				if (($user['notify-flags'] & Notification\Type::INTRO) &&
 					in_array($user['page-flags'], [User::PAGE_FLAGS_NORMAL])) {
 
 					notification([
-						'type'  => Type::INTRO,
-						'otype' => Notify\ObjectType::INTRO,
+						'type'  => Notification\Type::INTRO,
+						'otype' => Notification\ObjectType::INTRO,
 						'verb'  => ($sharing ? Activity::FRIEND : Activity::FOLLOW),
 						'uid'   => $user['uid'],
 						'cid'   => $contact_record['id'],

--- a/src/Model/FContact.php
+++ b/src/Model/FContact.php
@@ -25,7 +25,6 @@ use Friendica\Core\Logger;
 use Friendica\Core\Protocol;
 use Friendica\Database\DBA;
 use Friendica\DI;
-use Friendica\Model\Notify\Type;
 use Friendica\Network\Probe;
 use Friendica\Protocol\Activity;
 use Friendica\Util\DateTimeFormat;
@@ -181,8 +180,8 @@ class FContact
 		DBA::insert('intro', $fields);
 
 		notification([
-			'type'  => Type::SUGGEST,
-			'otype' => Notify\ObjectType::INTRO,
+			'type'  => Notification\Type::SUGGEST,
+			'otype' => Notification\ObjectType::INTRO,
 			'verb'  => Activity::REQ_FRIEND,
 			'uid'   => $owner['uid'],
 			'cid'   => $from_contact['uid'],

--- a/src/Model/Mail.php
+++ b/src/Model/Mail.php
@@ -24,9 +24,8 @@ namespace Friendica\Model;
 use Friendica\Core\Logger;
 use Friendica\Core\System;
 use Friendica\Core\Worker;
-use Friendica\DI;
 use Friendica\Database\DBA;
-use Friendica\Model\Notify\Type;
+use Friendica\DI;
 use Friendica\Protocol\Activity;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Worker\Delivery;
@@ -84,8 +83,8 @@ class Mail
 
 		// send notifications.
 		$notif_params = [
-			'type'  => Type::MAIL,
-			'otype' => Notify\ObjectType::MAIL,
+			'type'  => Notification\Type::MAIL,
+			'otype' => Notification\ObjectType::MAIL,
 			'verb'  => Activity::POST,
 			'uid'   => $user['uid'],
 			'cid'   => $msg['contact-id'],

--- a/src/Model/Notification.php
+++ b/src/Model/Notification.php
@@ -48,13 +48,12 @@ use Psr\Log\LoggerInterface;
  * @property-read string name_cache Full name of the contact subject
  * @property-read string msg_cache  Plaintext version of the notification text with a placeholder (`{0}`) for the subject contact's name.
  */
-class Notify extends BaseModel
+class Notification extends BaseModel
 {
-
-	/** @var \Friendica\Repository\Notify */
+	/** @var \Friendica\Repository\Notification */
 	private $repo;
 
-	public function __construct(Database $dba, LoggerInterface $logger, \Friendica\Repository\Notify $repo, array $data = [])
+	public function __construct(Database $dba, LoggerInterface $logger, \Friendica\Repository\Notification $repo, array $data = [])
 	{
 		parent::__construct($dba, $logger, $data);
 

--- a/src/Model/Notification/ObjectType.php
+++ b/src/Model/Notification/ObjectType.php
@@ -19,18 +19,15 @@
  *
  */
 
-namespace Friendica\Collection;
+namespace Friendica\Model\Notification;
 
-use Friendica\BaseCollection;
-use Friendica\Model;
-
-class Notifies extends BaseCollection
+/**
+ * Enum for different otypes of the Notify
+ */
+class ObjectType
 {
-	/**
-	 * @return Model\Notify
-	 */
-	public function current()
-	{
-		return parent::current();
-	}
+	const PERSON = 'person';
+	const MAIL   = 'mail';
+	const ITEM   = 'item';
+	const INTRO  = 'intro';
 }

--- a/src/Model/Notification/Type.php
+++ b/src/Model/Notification/Type.php
@@ -19,7 +19,7 @@
  *
  */
 
-namespace Friendica\Model\Notify;
+namespace Friendica\Model\Notification;
 
 /**
  * Enum for different types of the Notify

--- a/src/Module/Delegation.php
+++ b/src/Module/Delegation.php
@@ -28,7 +28,7 @@ use Friendica\Core\Session;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Contact;
-use Friendica\Model\Notify\Type;
+use Friendica\Model\Notification;
 use Friendica\Model\User;
 use Friendica\Network\HTTPException\ForbiddenException;
 
@@ -131,7 +131,7 @@ class Delegation extends BaseModule
 
 			$identities[$key]['selected'] = ($identity['nickname'] === DI::app()->user['nickname']);
 
-			$condition = ["`uid` = ? AND `msg` != '' AND NOT (`type` IN (?, ?)) AND NOT `seen`", $identity['uid'], Type::INTRO, Type::MAIL];
+			$condition = ["`uid` = ? AND `msg` != '' AND NOT (`type` IN (?, ?)) AND NOT `seen`", $identity['uid'], Notification\Type::INTRO, Notification\Type::MAIL];
 			$params = ['distinct' => true, 'expression' => 'parent'];
 			$notifications = DBA::count('notify', $condition, $params);
 

--- a/src/Module/Register.php
+++ b/src/Module/Register.php
@@ -365,7 +365,7 @@ class Register extends BaseModule
 			// send notification to admins
 			while ($admin = DBA::fetch($admins_stmt)) {
 				\notification([
-					'type'         => Model\Notify\Type::SYSTEM,
+					'type'         => Model\Notification\Type::SYSTEM,
 					'event'        => 'SYSTEM_REGISTER_REQUEST',
 					'uid'          => $admin['uid'],
 					'link'         => $base_url . '/admin/users/',

--- a/src/Object/Api/Friendica/Notification.php
+++ b/src/Object/Api/Friendica/Notification.php
@@ -24,7 +24,7 @@ namespace Friendica\Object\Api\Friendica;
 use Friendica\BaseEntity;
 use Friendica\Content\Text\BBCode;
 use Friendica\Content\Text\HTML;
-use Friendica\Model\Notify;
+use Friendica\Model\Notification as NotificationModel;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Temporal;
 
@@ -78,7 +78,7 @@ class Notification extends BaseEntity
 	/** @var string Message (Plaintext) */
 	protected $msg_plain;
 
-	public function __construct(Notify $notify)
+	public function __construct(NotificationModel $notify)
 	{
 		// map each notify attribute to the entity
 		foreach ($notify->toArray() as $key => $value) {

--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -37,8 +37,7 @@ use Friendica\Model\FContact;
 use Friendica\Model\Item;
 use Friendica\Model\ItemURI;
 use Friendica\Model\Mail;
-use Friendica\Model\Notify;
-use Friendica\Model\Notify\Type;
+use Friendica\Model\Notification;
 use Friendica\Model\PermissionSet;
 use Friendica\Model\Post;
 use Friendica\Model\Post\Category;
@@ -1963,8 +1962,8 @@ class DFRN
 				// send a notification
 				notification(
 					[
-					"type"     => Type::POKE,
-					"otype"    => Notify\ObjectType::PERSON,
+					"type"     => Notification\Type::POKE,
+					"otype"    => Notification\ObjectType::PERSON,
 					"activity" => $verb,
 					"verb"     => $item["verb"],
 					"uid"      => $importer["importer_uid"],

--- a/src/Repository/Notification.php
+++ b/src/Repository/Notification.php
@@ -30,28 +30,28 @@ use Friendica\Network\HTTPException\InternalServerErrorException;
 use Friendica\Network\HTTPException\NotFoundException;
 use Friendica\Util\DateTimeFormat;
 
-class Notify extends BaseRepository
+class Notification extends BaseRepository
 {
 	protected static $table_name = 'notify';
 
-	protected static $model_class = Model\Notify::class;
+	protected static $model_class = Model\Notification::class;
 
-	protected static $collection_class = Collection\Notifies::class;
+	protected static $collection_class = Collection\Notifications::class;
 
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @return Model\Notify
+	 * @return Model\Notification
 	 */
 	protected function create(array $data)
 	{
-		return new Model\Notify($this->dba, $this->logger, $this, $data);
+		return new Model\Notification($this->dba, $this->logger, $this, $data);
 	}
 
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @return Collection\Notifies
+	 * @return Collection\Notifications
 	 */
 	public function select(array $condition = [], array $params = [])
 	{
@@ -66,7 +66,7 @@ class Notify extends BaseRepository
 	 * @param int $id The ID of the notify instance
 	 * @param int $uid The user ID, bound to this notify instance (= security check)
 	 *
-	 * @return Model\Notify
+	 * @return Model\Notification
 	 * @throws NotFoundException
 	 */
 	public function getByID(int $id, int $uid)
@@ -77,14 +77,14 @@ class Notify extends BaseRepository
 	/**
 	 * Set seen state of notifications of the local_user()
 	 *
-	 * @param bool         $seen   optional true or false. default true
-	 * @param Model\Notify $notify optional a notify, which should be set seen (including his parents)
+	 * @param bool               $seen   optional true or false. default true
+	 * @param Model\Notification $notify optional a notify, which should be set seen (including his parents)
 	 *
 	 * @return bool true on success, false on error
 	 *
 	 * @throws Exception
 	 */
-	public function setSeen(bool $seen = true, Model\Notify $notify = null)
+	public function setSeen(bool $seen = true, Model\Notification $notify = null)
 	{
 		if (empty($notify)) {
 			$conditions = ['uid' => local_user()];
@@ -102,7 +102,7 @@ class Notify extends BaseRepository
 	/**
 	 * @param array $fields
 	 *
-	 * @return Model\Notify|false
+	 * @return Model\Notification|false
 	 *
 	 * @throws InternalServerErrorException
 	 * @throws Exception

--- a/tests/datasets/api.fixture.php
+++ b/tests/datasets/api.fixture.php
@@ -19,7 +19,7 @@
  *
  */
 
-use Friendica\Model\Notify;
+use Friendica\Model\Notification;
 
 return [
 	// Empty these tables
@@ -375,7 +375,7 @@ return [
 			'iid' => 4,
 			'seen' => 0,
 			'verb' => '',
-			'otype' => Notify\ObjectType::ITEM,
+			'otype' => Notification\ObjectType::ITEM,
 			'name_cache' => 'Reply to',
 			'msg_cache' => 'A test reply from an item',
 		],

--- a/update.php
+++ b/update.php
@@ -40,7 +40,6 @@
  * If you need to run a script before the database update, name the function "pre_update_4712()"
  */
 
-use Friendica\Core\Addon;
 use Friendica\Core\Logger;
 use Friendica\Core\Update;
 use Friendica\Core\Worker;
@@ -50,7 +49,7 @@ use Friendica\Database\DBStructure;
 use Friendica\DI;
 use Friendica\Model\Contact;
 use Friendica\Model\Item;
-use Friendica\Model\Notify;
+use Friendica\Model\Notification;
 use Friendica\Model\Photo;
 use Friendica\Model\Post;
 use Friendica\Model\Storage;
@@ -655,12 +654,12 @@ function pre_update_1377()
 function update_1380()
 {
 	if (!DBA::e("UPDATE `notify` INNER JOIN `item` ON `item`.`id` = `notify`.`iid` SET `notify`.`uri-id` = `item`.`uri-id` WHERE `notify`.`uri-id` IS NULL AND `notify`.`otype` IN (?, ?)",
-		Notify\ObjectType::ITEM, Notify\ObjectType::PERSON)) {
+		Notification\ObjectType::ITEM, Notification\ObjectType::PERSON)) {
 		return Update::FAILED;
 	}
 
 	if (!DBA::e("UPDATE `notify` INNER JOIN `item` ON `item`.`id` = `notify`.`parent` SET `notify`.`parent-uri-id` = `item`.`uri-id` WHERE `notify`.`parent-uri-id` IS NULL AND `notify`.`otype` IN (?, ?)",
-		Notify\ObjectType::ITEM, Notify\ObjectType::PERSON)) {
+		Notification\ObjectType::ITEM, Notification\ObjectType::PERSON)) {
 		return Update::FAILED;
 	}
 


### PR DESCRIPTION
Remainder of https://github.com/friendica/friendica/pull/9853 after https://github.com/friendica/friendica/pull/9858
Addon counter part: https://github.com/friendica/friendica-addons/pull/1070

This PR contains a pretty significant renaming commit because I got irritated that I didn't get all the notification-related classes when I looked for "Notification" in the project file names. The problem is that most the classes were named after the notification table name which is what it is but cannot be easily changed. Classes name can, so here we are.