### PR TITLE
Frio: mobile: secondnav arrow

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -2189,6 +2189,12 @@ ul.tabs li:hover,
 ul.tabs li.active {
 	border-bottom-width: 4px;
 }
+.tabbar.visible-xs .tabs-extended {
+	padding-top: 0;
+}
+#dropdownMenuTools-xs {
+	padding: 9px 10px;
+}
 ul.tabbar ul.tabs-extended:hover li.dropdown {
 	border-bottom: 0;
 }

--- a/view/theme/frio/templates/common_tabs.tpl
+++ b/view/theme/frio/templates/common_tabs.tpl
@@ -5,9 +5,12 @@
 		<li>
 			<ul class="tabs flex-nav" role="menu">
 				{{foreach $tabs as $tab}}
-					<li id="{{$tab.id}}" role="presentation" {{if $tab.sel}} class="{{$tab.sel}}" {{/if}}><a role="menuitem"
-							href="{{$tab.url}}" {{if $tab.accesskey}}accesskey="{{$tab.accesskey}}" {{/if}}
-							{{if $tab.title}} title="{{$tab.title}}" {{/if}}>{{$tab.label}}</a></li>
+					<li id="{{$tab.id}}" role="presentation" {{if $tab.sel}} class="{{$tab.sel}}" {{/if}}>
+						<a role="menuitem" href="{{$tab.url}}" {{if $tab.accesskey}}accesskey="{{$tab.accesskey}}" {{/if}}
+							{{if $tab.title}} title="{{$tab.title}}" {{/if}}>
+							{{$tab.label}}
+						</a>
+					</li>
 				{{/foreach}}
 			</ul>
 		</li>
@@ -33,9 +36,11 @@
 			<ul class="tabs" role="menu">
 				{{foreach $tabs as $tab}}
 					{{if $tab.sel}}
-						<li id="{{$tab.id}}-xs" role="presentation" {{if $tab.sel}} class="{{$tab.sel}}" {{/if}}><a
-								role="menuitem" href="{{$tab.url}}" {{if $tab.title}} title="{{$tab.title}}"
-								{{/if}}>{{$tab.label}}</a></li>
+						<li id="{{$tab.id}}-xs" role="presentation" {{if $tab.sel}} class="{{$tab.sel}}" {{/if}}>
+							<a role="menuitem" href="{{$tab.url}}" {{if $tab.title}} title="{{$tab.title}}" {{/if}}>
+								{{$tab.label}}
+							</a>
+						</li>
 					{{else}}
 						{{$exttabs[]=$tab}}
 					{{/if}}
@@ -53,9 +58,11 @@
 					</button>
 					<ul class="dropdown-menu" role="menu" aria-labelledby="dropdownMenuTools">
 						{{foreach $exttabs as $tab}}
-							<li id="{{$tab.id}}-xs" role="presentation" {{if $tab.sel}} class="{{$tab.sel}}" {{/if}}><a
-									role="menuitem" href="{{$tab.url}}" {{if $tab.title}} title="{{$tab.title}}"
-									{{/if}}>{{$tab.label}}</a></li>
+							<li id="{{$tab.id}}-xs" role="presentation" {{if $tab.sel}} class="{{$tab.sel}}" {{/if}}>
+								<a role="menuitem" href="{{$tab.url}}" {{if $tab.title}} title="{{$tab.title}}" {{/if}}>
+									{{$tab.label}}
+								</a>
+							</li>
 						{{/foreach}}
 					</ul>
 				</li>

--- a/view/theme/frio/templates/common_tabs.tpl
+++ b/view/theme/frio/templates/common_tabs.tpl
@@ -1,13 +1,14 @@
-
 <div class="tabbar-wrapper">
 	{{* Tab navigation bar for tablets and computer *}}
 	<ul role="menubar" class="tabbar list-inline visible-lg visible-md visible-sm hidden-xs">
 		{{* The normal tabbar *}}
 		<li>
-			<ul class="tabs flex-nav" role="menu" >
-			{{foreach $tabs as $tab}}
-				<li id="{{$tab.id}}" role="presentation" {{if $tab.sel}} class="{{$tab.sel}}" {{/if}}><a role="menuitem" href="{{$tab.url}}" {{if $tab.accesskey}}accesskey="{{$tab.accesskey}}"{{/if}} {{if $tab.title}} title="{{$tab.title}}"{{/if}}>{{$tab.label}}</a></li>
-			{{/foreach}}
+			<ul class="tabs flex-nav" role="menu">
+				{{foreach $tabs as $tab}}
+					<li id="{{$tab.id}}" role="presentation" {{if $tab.sel}} class="{{$tab.sel}}" {{/if}}><a role="menuitem"
+							href="{{$tab.url}}" {{if $tab.accesskey}}accesskey="{{$tab.accesskey}}" {{/if}}
+							{{if $tab.title}} title="{{$tab.title}}" {{/if}}>{{$tab.label}}</a></li>
+				{{/foreach}}
 			</ul>
 		</li>
 
@@ -16,11 +17,12 @@
 		<li class="pull-right">
 			<ul class="tabs tabs-extended" role="menu">
 				<li role="presentation" class="dropdown flex-target">
-					<button type="button" class="btn-link dropdown-toggle" id="dropdownMenuTools" data-toggle="dropdown" aria-expanded="false">
+					<button type="button" class="btn-link dropdown-toggle" id="dropdownMenuTools" data-toggle="dropdown"
+						aria-expanded="false">
 						<i class="fa fa-chevron-down" aria-hidden="true"></i>
 					</button>
 				</li>
-			 </ul>
+			</ul>
 		</li>
 	</ul>
 
@@ -31,9 +33,11 @@
 			<ul class="tabs" role="menu">
 				{{foreach $tabs as $tab}}
 					{{if $tab.sel}}
-					<li id="{{$tab.id}}-xs" role="presentation" {{if $tab.sel}} class="{{$tab.sel}}" {{/if}}><a role="menuitem" href="{{$tab.url}}" {{if $tab.title}} title="{{$tab.title}}"{{/if}}>{{$tab.label}}</a></li>
+						<li id="{{$tab.id}}-xs" role="presentation" {{if $tab.sel}} class="{{$tab.sel}}" {{/if}}><a
+								role="menuitem" href="{{$tab.url}}" {{if $tab.title}} title="{{$tab.title}}"
+								{{/if}}>{{$tab.label}}</a></li>
 					{{else}}
-					{{$exttabs[]=$tab}}
+						{{$exttabs[]=$tab}}
 					{{/if}}
 				{{/foreach}}
 			</ul>
@@ -43,12 +47,15 @@
 		<li class="pull-right">
 			<ul class="tabs tabs-extended">
 				<li class="dropdown">
-					<button type="button" class="btn-link dropdown-toggle" id="dropdownMenuTools-xs" data-toggle="dropdown" aria-expanded="false">
+					<button type="button" class="btn-link dropdown-toggle" id="dropdownMenuTools-xs"
+						data-toggle="dropdown" aria-expanded="false">
 						<i class="fa fa-chevron-down" aria-hidden="true"></i>
 					</button>
 					<ul class="dropdown-menu pull-right" role="menu" aria-labelledby="dropdownMenuTools">
 						{{foreach $exttabs as $tab}}
-						<li id="{{$tab.id}}-xs" role="presentation" {{if $tab.sel}} class="{{$tab.sel}}" {{/if}}><a role="menuitem" href="{{$tab.url}}" {{if $tab.title}} title="{{$tab.title}}"{{/if}}>{{$tab.label}}</a></li>
+							<li id="{{$tab.id}}-xs" role="presentation" {{if $tab.sel}} class="{{$tab.sel}}" {{/if}}><a
+									role="menuitem" href="{{$tab.url}}" {{if $tab.title}} title="{{$tab.title}}"
+									{{/if}}>{{$tab.label}}</a></li>
 						{{/foreach}}
 					</ul>
 				</li>

--- a/view/theme/frio/templates/common_tabs.tpl
+++ b/view/theme/frio/templates/common_tabs.tpl
@@ -44,14 +44,14 @@
 		</li>
 
 		{{* All others are moved to this dropdown menu *}}
-		<li class="pull-right">
+		<li>
 			<ul class="tabs tabs-extended">
 				<li class="dropdown">
 					<button type="button" class="btn-link dropdown-toggle" id="dropdownMenuTools-xs"
 						data-toggle="dropdown" aria-expanded="false">
 						<i class="fa fa-chevron-down" aria-hidden="true"></i>
 					</button>
-					<ul class="dropdown-menu pull-right" role="menu" aria-labelledby="dropdownMenuTools">
+					<ul class="dropdown-menu" role="menu" aria-labelledby="dropdownMenuTools">
 						{{foreach $exttabs as $tab}}
 							<li id="{{$tab.id}}-xs" role="presentation" {{if $tab.sel}} class="{{$tab.sel}}" {{/if}}><a
 									role="menuitem" href="{{$tab.url}}" {{if $tab.title}} title="{{$tab.title}}"


### PR DESCRIPTION

**Before:**
The arrow was on the right. You had to precisely click on the arrow to open the dropdown menu.

**Now:**
![image](https://user-images.githubusercontent.com/11581433/105643814-2248cd80-5e60-11eb-9c13-a917795bce54.png)
Moved the arrow closer to the tab.
I added a padding to the button so the clickable area is larger.

Fix #9856

First commit was for formatting. To [compare diff see here](https://github.com/friendica/friendica/pull/9861/commits/e09bc681ffe9ab7f79e4eb84e3738dca456f7925).