### PR TITLE
PWA: Improve manifest file

### DIFF
--- a/src/Module/Manifest.php
+++ b/src/Module/Manifest.php
@@ -36,15 +36,15 @@ class Manifest extends BaseModule
 		$theme = DI::config()->get('system', 'theme');
 
 		$manifest = [
-			'name'			=> $config->get('config', 'sitename', 'Friendica'),
-			'start_url'		=> DI::baseUrl()->get(),
-			'display'		=> 'standalone',
-			'description'	=> $config->get('config', 'info', DI::l10n()->t('A Decentralized Social Network')),
-			'short_name'	=> 'Friendica',
-			'lang'			=> $config->get('system', 'language'),
-			'dir'			=> 'auto',
-			'categories'	=> ['social network', 'internet'],
-			'icons'			=> [
+			'name'          => $config->get('config', 'sitename', 'Friendica'),
+			'start_url'     => DI::baseUrl()->get(),
+			'display'       => 'standalone',
+			'description'   => $config->get('config', 'info', DI::l10n()->t('A Decentralized Social Network')),
+			'short_name'    => 'Friendica',
+			'lang'          => $config->get('system', 'language'),
+			'dir'           => 'auto',
+			'categories'    => ['social network', 'internet'],
+			'icons'         => [
 				[
 					'src'   => DI::baseUrl()->get() . '/' . $touch_icon,
 					'sizes' => '192x192',
@@ -56,26 +56,26 @@ class Manifest extends BaseModule
 					'type'  => 'image/png',
 				],
 			],
-			'shortcuts'		=> [
+			'shortcuts'     => [
 				[
-					'name'	=> 'Latest posts',
-					'url'	=> '/network'
+					'name'  => 'Latest posts',
+					'url'   => '/network'
 				],
 				[
-					'name'	=> 'Messages',
-					'url'	=> '/message'
+					'name'  => 'Messages',
+					'url'   => '/message'
 				],
 				[
-					'name'	=> 'Notifications',
-					'url'	=> '/notifications/system'
+					'name'  => 'Notifications',
+					'url'   => '/notifications/system'
 				],
 				[
-					'name'	=> 'Contacts',
-					'url'	=> '/contact'
+					'name'  => 'Contacts',
+					'url'   => '/contact'
 				],
 				[
-					'name'	=> 'Events',
-					'url'	=> '/events'
+					'name'  => 'Events',
+					'url'   => '/events'
 				]
 			]
 		];

--- a/src/Module/Manifest.php
+++ b/src/Module/Manifest.php
@@ -36,12 +36,15 @@ class Manifest extends BaseModule
 		$theme = DI::config()->get('system', 'theme');
 
 		$manifest = [
-			'name'        => $config->get('config', 'sitename', 'Friendica'),
-			'start_url'   => DI::baseUrl()->get(),
-			'display'     => 'standalone',
-			'description' => $config->get('config', 'info', DI::l10n()->t('A Decentralized Social Network')),
-			'short_name'  => 'Friendica',
-			'icons'       => [
+			'name'			=> $config->get('config', 'sitename', 'Friendica'),
+			'start_url'		=> DI::baseUrl()->get(),
+			'display'		=> 'standalone',
+			'description'	=> $config->get('config', 'info', DI::l10n()->t('A Decentralized Social Network')),
+			'short_name'	=> 'Friendica',
+			'lang'			=> $config->get('system', 'language'),
+			'dir'			=> 'auto',
+			'categories'	=> ['social network', 'internet'],
+			'icons'			=> [
 				[
 					'src'   => DI::baseUrl()->get() . '/' . $touch_icon,
 					'sizes' => '192x192',
@@ -53,6 +56,28 @@ class Manifest extends BaseModule
 					'type'  => 'image/png',
 				],
 			],
+			'shortcuts'		=> [
+				[
+					'name'	=> 'Latest posts',
+					'url'	=> '/network'
+				],
+				[
+					'name'	=> 'Messages',
+					'url'	=> '/message'
+				],
+				[
+					'name'	=> 'Notifications',
+					'url'	=> '/notifications/system'
+				],
+				[
+					'name'	=> 'Contacts',
+					'url'	=> '/contact'
+				],
+				[
+					'name'	=> 'Events',
+					'url'	=> '/events'
+				]
+			]
 		];
 
 		if ($background_color = Core\Theme::getBackgroundColor($theme)) {


### PR DESCRIPTION
- I've added the language of the PWA app by getting the language setting of the instance.
- Set text direction to auto, the browser should pick up the right direction for the user (according to specs)
- Add categories.
- Add shortcut icons. iOS and some android version support those. Clicking on the PWA app icon should open a menu with those quick links.

Since this is the main manifest file, all themes will work with this.

Generated manifest file:
![image](https://user-images.githubusercontent.com/11581433/105737184-a0aa7b80-5f03-11eb-9b57-6351be17596d.png)

Might try to add some icons to the links eventually. Chrome-based browser and safari I believe need a web worker for PWA to work at all. Firefox have no problem with a "fully online" PWA and doesn't require a web worker.