### PR TITLE
"uri-id" instead of "uri" or "id"

### DIFF
--- a/include/conversation.php
+++ b/include/conversation.php
@@ -838,8 +838,8 @@ function conversation_add_children(array $parents, $block_authors, $order, $uid)
 				}
 			}
 		} else {
-			$condition = ["`parent-uri` = ? AND `uid` IN (0, ?) AND (`vid` != ? OR `vid` IS NULL)",
-				$parent['uri'], $uid, Verb::getID(Activity::FOLLOW)];
+			$condition = ["`parent-uri-id` = ? AND `uid` IN (0, ?) AND (`vid` != ? OR `vid` IS NULL)",
+				$parent['uri-id'], $uid, Verb::getID(Activity::FOLLOW)];
 			$activity = [];
 		}
 		$items = conversation_fetch_items($parent, $items, $condition, $block_authors, $params, $activity);
@@ -1037,31 +1037,31 @@ function builtin_activity_puller(array $activity, array &$conv_responses)
 
 			$link = '<a href="' . $url . '"' . $sparkle . '>' . htmlentities($activity['author-name']) . '</a>';
 
-			if (empty($activity['thr-parent'])) {
-				$activity['thr-parent'] = $activity['parent-uri'];
+			if (empty($activity['thr-parent-id'])) {
+				$activity['thr-parent-id'] = $activity['parent-uri-id'];
 			}
 
 			// Skip when the causer of the parent is the same than the author of the announce
-			if (($verb == Activity::ANNOUNCE) && Post::exists(['uri' => $activity['thr-parent'],
+			if (($verb == Activity::ANNOUNCE) && Post::exists(['uri-id' => $activity['thr-parent-id'],
 				'uid' => $activity['uid'], 'causer-id' => $activity['author-id'], 'gravity' => GRAVITY_PARENT])) {
 				continue;
 			}
 
-			if (!isset($conv_responses[$mode][$activity['thr-parent']])) {
-				$conv_responses[$mode][$activity['thr-parent']] = [
+			if (!isset($conv_responses[$mode][$activity['thr-parent-id']])) {
+				$conv_responses[$mode][$activity['thr-parent-id']] = [
 					'links' => [],
 					'self' => 0,
 				];
-			} elseif (in_array($link, $conv_responses[$mode][$activity['thr-parent']]['links'])) {
+			} elseif (in_array($link, $conv_responses[$mode][$activity['thr-parent-id']]['links'])) {
 				// only list each unique author once
 				continue;
 			}
 
 			if (public_contact() == $activity['author-id']) {
-				$conv_responses[$mode][$activity['thr-parent']]['self'] = 1;
+				$conv_responses[$mode][$activity['thr-parent-id']]['self'] = 1;
 			}
 
-			$conv_responses[$mode][$activity['thr-parent']]['links'][] = $link;
+			$conv_responses[$mode][$activity['thr-parent-id']]['links'][] = $link;
 
 			// there can only be one activity verb per item so if we found anything, we can stop looking
 			return;
@@ -1268,17 +1268,17 @@ function get_item_children(array &$item_list, array $parent, $recursive = true)
 		if ($item['gravity'] != GRAVITY_PARENT) {
 			if ($recursive) {
 				// Fallback to parent-uri if thr-parent is not set
-				$thr_parent = $item['thr-parent'];
+				$thr_parent = $item['thr-parent-id'];
 				if ($thr_parent == '') {
-					$thr_parent = $item['parent-uri'];
+					$thr_parent = $item['parent-uri-id'];
 				}
 
-				if ($thr_parent == $parent['uri']) {
+				if ($thr_parent == $parent['uri-id']) {
 					$item['children'] = get_item_children($item_list, $item);
 					$children[] = $item;
 					unset($item_list[$i]);
 				}
-			} elseif ($item['parent'] == $parent['id']) {
+			} elseif ($item['parent-uri-id'] == $parent['uri-id']) {
 				$children[] = $item;
 				unset($item_list[$i]);
 			}
@@ -1408,7 +1408,7 @@ function conv_sort(array $item_list, $order)
 			continue;
 		}
 
-		$item_array[$item['uri']] = $item;
+		$item_array[$item['uri-id']] = $item;
 	}
 
 	// Extract the top level items

--- a/mod/notes.php
+++ b/mod/notes.php
@@ -82,7 +82,7 @@ function notes_content(App $a, $update = false)
 
 	$params = ['order' => ['created' => true],
 		'limit' => [$pager->getStart(), $pager->getItemsPerPage()]];
-	$r = Post::selectThreadForUser(local_user(), ['uri'], $condition, $params);
+	$r = Post::selectThreadForUser(local_user(), ['uri-id'], $condition, $params);
 
 	$count = 0;
 

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -1339,7 +1339,7 @@ class Contact
 		}
 
 		if ($thread_mode) {		
-			$items = Post::toArray(Post::selectForUser(local_user(), ['uri', 'gravity', 'parent-uri', 'thr-parent-id', 'author-id'], $condition, $params));
+			$items = Post::toArray(Post::selectForUser(local_user(), ['uri-id', 'gravity', 'parent-uri-id', 'thr-parent-id', 'author-id'], $condition, $params));
 
 			$o .= conversation($a, $items, 'contacts', $update, false, 'commented', local_user());
 		} else {

--- a/src/Module/Conversation/Community.php
+++ b/src/Module/Conversation/Community.php
@@ -356,7 +356,7 @@ class Community extends BaseModule
 			}
 		}
 
-		$r = Post::selectThreadForUser(0, ['uri', 'commented', 'author-link'], $condition, $params);
+		$r = Post::selectThreadForUser(0, ['uri-id', 'commented', 'author-link'], $condition, $params);
 
 		$items = Post::toArray($r);
 

--- a/src/Module/Profile/Status.php
+++ b/src/Module/Profile/Status.php
@@ -194,7 +194,7 @@ class Status extends BaseProfile
 		$pager = new Pager(DI::l10n(), $args->getQueryString(), $itemspage_network);
 		$params = ['limit' => [$pager->getStart(), $pager->getItemsPerPage()], 'order' => ['received' => true]];
 
-		$items_stmt = Post::select(['uri', 'thr-parent-id', 'gravity', 'author-id', 'received'], $condition, $params);
+		$items_stmt = Post::select(['uri-id', 'thr-parent-id', 'gravity', 'author-id', 'received'], $condition, $params);
 
 		// Set a time stamp for this page. We will make use of it when we
 		// search for new items (update routine)
@@ -228,7 +228,7 @@ class Status extends BaseProfile
 				$condition = [];
 			}
 	
-			$pinned_items = Post::selectPinned($a->profile['uid'], ['uri', 'pinned'], $condition);
+			$pinned_items = Post::selectPinned($a->profile['uid'], ['uri-id', 'pinned'], $condition);
 			$pinned = Post::toArray($pinned_items);
 			$items = array_merge($items, $pinned);
 		}

--- a/src/Module/Update/Network.php
+++ b/src/Module/Update/Network.php
@@ -4,7 +4,6 @@ namespace Friendica\Module\Update;
 
 use Friendica\Core\System;
 use Friendica\DI;
-use Friendica\Model\Item;
 use Friendica\Model\Post;
 use Friendica\Module\Conversation\Network as NetworkModule;
 

--- a/src/Module/Update/Profile.php
+++ b/src/Module/Update/Profile.php
@@ -78,7 +78,7 @@ class Profile extends BaseModule
 		}
 
 		$items_stmt = DBA::p(
-			"SELECT DISTINCT(`parent-uri`) AS `uri`, `created` FROM `post-view`
+			"SELECT DISTINCT(`parent-uri-id`) AS `uri-id`, `created` FROM `post-view`
 				WHERE `uid` = ? AND NOT `contact-blocked` AND NOT `contact-pending`
 				AND `visible` AND (NOT `deleted` OR `gravity` = ?)
 				AND NOT `moderated` AND `wall` $sql_extra4 $sql_extra

--- a/src/Object/Post.php
+++ b/src/Object/Post.php
@@ -287,8 +287,8 @@ class Post
 		$responses = [];
 		foreach ($response_verbs as $value => $verb) {
 			$responses[$verb] = [
-				'self'   => $conv_responses[$verb][$item['uri']]['self'] ?? 0,
-				'output' => !empty($conv_responses[$verb][$item['uri']]) ? format_activity($conv_responses[$verb][$item['uri']]['links'], $verb, $item['uri']) : '',
+				'self'   => $conv_responses[$verb][$item['uri-id']]['self'] ?? 0,
+				'output' => !empty($conv_responses[$verb][$item['uri-id']]) ? format_activity($conv_responses[$verb][$item['uri-id']]['links'], $verb, $item['uri-id']) : '',
 			];
 		}
 

--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -310,22 +310,25 @@ class DFRN
 	}
 
 	/**
-	 * Generate an atom entry for a given item id
+	 * Generate an atom entry for a given uri id and user
 	 *
-	 * @param int     $item_id      The item id
+	 * @param int     $uri_id       The uri id
+	 * @param int     $uid          The user id
 	 * @param boolean $conversation Show the conversation. If false show the single post.
 	 *
 	 * @return string DFRN feed entry
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 * @throws \ImagickException
 	 */
-	public static function itemFeed($item_id, $conversation = false)
+	public static function itemFeed(int $uri_id, int $uid, bool $conversation = false)
 	{
 		if ($conversation) {
-			$condition = ['parent' => $item_id];
+			$condition = ['parent-uri-id' => $uri_id];
 		} else {
-			$condition = ['id' => $item_id];
+			$condition = ['uri-id' => $uri_id];
 		}
+
+		$condition['uid'] = $uid;
 
 		$items = Post::selectToArray(Item::DELIVER_FIELDLIST, $condition);
 		if (!DBA::isResult($items)) {


### PR DESCRIPTION
In the future "post" table the fields "uri", "parent-uri" and "thr-parent" won't be stored directly in this table. Only the fields "uri-id", "parent-uri-id" and "thr-parent-id" will. Also the "post" table won't contain the "id" field anymore. So we now get rid of them.

This code had been running on my system for the last few days without problems.