### PR TITLE
Accept "application/json" as application type for ActivityPub

### DIFF
--- a/src/Protocol/ActivityPub.php
+++ b/src/Protocol/ActivityPub.php
@@ -77,6 +77,7 @@ class ActivityPub
 	public static function isRequest()
 	{
 		return stristr($_SERVER['HTTP_ACCEPT'] ?? '', 'application/activity+json') ||
+			stristr($_SERVER['HTTP_ACCEPT'] ?? '', 'application/json') ||
 			stristr($_SERVER['HTTP_ACCEPT'] ?? '', 'application/ld+json');
 	}
 


### PR DESCRIPTION
Requests via "application/json" are now treated as AP requests.