### PR TITLE
Setting "maintenance" for pre and post updates

### DIFF
--- a/src/Console/DatabaseStructure.php
+++ b/src/Console/DatabaseStructure.php
@@ -106,7 +106,7 @@ HELP;
 
 		switch ($this->getArgument(0)) {
 			case "dryrun":
-				$output = DBStructure::update($basePath, true, false);
+				$output = DBStructure::dryRun();
 				break;
 			case "update":
 				$force    = $this->getOption(['f', 'force'], false);

--- a/src/Core/Installer.php
+++ b/src/Core/Installer.php
@@ -192,7 +192,7 @@ class Installer
 	 */
 	public function installDatabase($basePath)
 	{
-		$result = DBStructure::update($basePath, false, true, true);
+		$result = DBStructure::install($basePath);
 
 		if ($result) {
 			$txt = DI::l10n()->t('You may need to import the file "database.sql" manually using phpmyadmin or mysql.') . EOL;

--- a/src/Core/Update.php
+++ b/src/Core/Update.php
@@ -166,7 +166,7 @@ class Update
 
 					// update the structure in one call
 					Logger::notice('Execute structure update');
-					$retval = DBStructure::update($basePath, $verbose, true);
+					$retval = DBStructure::performUpdate(false, $verbose);
 					if (!empty($retval)) {
 						if ($sendMail) {
 							self::updateFailed(

--- a/src/Core/Update.php
+++ b/src/Core/Update.php
@@ -27,6 +27,7 @@ use Friendica\Database\DBA;
 use Friendica\Database\DBStructure;
 use Friendica\DI;
 use Friendica\Network\HTTPException\InternalServerErrorException;
+use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Strings;
 
 class Update
@@ -143,14 +144,20 @@ class Update
 						return '';
 					}
 
+					DI::config()->set('system', 'maintenance', 1);
+		
 					// run the pre_update_nnnn functions in update.php
 					for ($version = $stored + 1; $version <= $current; $version++) {
 						Logger::notice('Execute pre update.', ['version' => $version]);
+						DI::config()->set('system', 'maintenance_reason', DI::l10n()->t('%s: executing pre update %d',
+							DateTimeFormat::utcNow() . ' ' . date('e'), $version));
 						$r = self::runUpdateFunction($version, 'pre_update', $sendMail);
 						if (!$r) {
 							Logger::warning('Pre update failed', ['version' => $version]);
 							DI::config()->set('system', 'update', Update::FAILED);
 							DI::lock()->release('dbupdate');
+							DI::config()->set('system', 'maintenance', 0);
+							DI::config()->set('system', 'maintenance_reason', '');
 							return $r;
 						} else {
 							Logger::notice('Pre update executed.', ['version' => $version]);
@@ -170,6 +177,8 @@ class Update
 						Logger::error('Update ERROR.', ['from' => $stored, 'to' => $current, 'retval' => $retval]);
 						DI::config()->set('system', 'update', Update::FAILED);
 						DI::lock()->release('dbupdate');
+						DI::config()->set('system', 'maintenance', 0);
+						DI::config()->set('system', 'maintenance_reason', '');
 						return $retval;
 					} else {
 						Logger::notice('Database structure update finished.', ['from' => $stored, 'to' => $current]);
@@ -178,11 +187,15 @@ class Update
 					// run the update_nnnn functions in update.php
 					for ($version = $stored + 1; $version <= $current; $version++) {
 						Logger::notice('Execute post update.', ['version' => $version]);
+						DI::config()->set('system', 'maintenance_reason', DI::l10n()->t('%s: executing post update %d',
+							DateTimeFormat::utcNow() . ' ' . date('e'), $version));
 						$r = self::runUpdateFunction($version, 'update', $sendMail);
 						if (!$r) {
 							Logger::warning('Post update failed', ['version' => $version]);
 							DI::config()->set('system', 'update', Update::FAILED);
 							DI::lock()->release('dbupdate');
+							DI::config()->set('system', 'maintenance', 0);
+							DI::config()->set('system', 'maintenance_reason', '');
 							return $r;
 						} else {
 							DI::config()->set('system', 'build', $version);
@@ -193,6 +206,8 @@ class Update
 					DI::config()->set('system', 'build', $current);
 					DI::config()->set('system', 'update', Update::SUCCESS);
 					DI::lock()->release('dbupdate');
+					DI::config()->set('system', 'maintenance', 0);
+					DI::config()->set('system', 'maintenance_reason', '');
 
 					Logger::notice('Update success.', ['from' => $stored, 'to' => $current]);
 					if ($sendMail) {

--- a/src/Database/DBStructure.php
+++ b/src/Database/DBStructure.php
@@ -375,6 +375,8 @@ class DBStructure
 	 */
 	public static function update($basePath, $verbose, $action, $install = false, array $tables = null, array $definition = null)
 	{
+		$in_maintenance = DI::config()->get('system', 'maintenance');
+
 		if ($action && !$install) {
 			if (self::isUpdating()) {
 				return DI::l10n()->t('Another database update is currently running.');
@@ -737,8 +739,10 @@ class DBStructure
 		self::checkInitialValues();
 
 		if ($action && !$install) {
-			DI::config()->set('system', 'maintenance', 0);
-			DI::config()->set('system', 'maintenance_reason', '');
+			if (!$in_maintenance) {
+				DI::config()->set('system', 'maintenance', 0);
+				DI::config()->set('system', 'maintenance_reason', '');
+			}
 
 			if ($errors) {
 				DI::config()->set('system', 'dbupdate', self::UPDATE_FAILED);

--- a/src/Module/Admin/DBSync.php
+++ b/src/Module/Admin/DBSync.php
@@ -54,7 +54,7 @@ class DBSync extends BaseAdmin
 				break;
 			case 'check':
 				// @TODO Seems like a similar logic like Update::check()
-				$retval = DBStructure::update($a->getBasePath(), false, true);
+				$retval = DBStructure::performUpdate();
 				if ($retval === '') {
 					$o = DI::l10n()->t("Database structure update %s was successfully applied.", DB_UPDATE_VERSION) . "<br />";
 				} else {

--- a/src/Module/Admin/Summary.php
+++ b/src/Module/Admin/Summary.php
@@ -82,7 +82,7 @@ class Summary extends BaseAdmin
 		}
 
 		if (DI::config()->get('system', 'dbupdate', DBStructure::UPDATE_NOT_CHECKED) == DBStructure::UPDATE_NOT_CHECKED) {
-			DBStructure::update($a->getBasePath(), false, true);
+			DBStructure::performUpdate();
 		}
 
 		if (DI::config()->get('system', 'dbupdate') == DBStructure::UPDATE_FAILED) {


### PR DESCRIPTION
The maintenance mode is now automatically set during the pre and post update routines as well. This hadn't been done in the past ans thus created some problems because of concurring calls and blocking database accesses.

PR https://github.com/friendica/friendica-addons/pull/1073 needs to be accepted at the same time.