### PR TITLE
Harden OEmbed link discovery

### DIFF
--- a/src/Content/OEmbed.php
+++ b/src/Content/OEmbed.php
@@ -106,6 +106,10 @@ class OEmbed
 							as $link)
 						{
 							$href = $link->getAttributeNode('href')->nodeValue;
+							// Both Youtube and Vimeo output OEmbed endpoint URL with HTTP
+							// but their OEmbed endpoint is only accessible by HTTPS ¯\_(ツ)_/¯
+							$href = str_replace(['http://www.youtube.com/', 'http://player.vimeo.com/'],
+								['https://www.youtube.com/', 'https://player.vimeo.com/'], $href);
 							$result = DI::httpRequest()->fetchFull($href . '&maxwidth=' . $a->videowidth);
 							if ($result->getReturnCode() === 200) {
 								$json_string = $result->getBody();
@@ -335,10 +339,6 @@ class OEmbed
 
 	public static function getHTML($url, $title = null)
 	{
-		// Always embed the SSL version
-		$url = str_replace(["http://www.youtube.com/", "http://player.vimeo.com/"],
-					["https://www.youtube.com/", "https://player.vimeo.com/"], $url);
-
 		$o = self::fetchURL($url, !self::isAllowedURL($url));
 
 		if (!is_object($o) || property_exists($o, 'type') && $o->type == 'error') {


### PR DESCRIPTION
Part of #9895 
Part of #9666
Related to #1191
Related to https://github.com/friendica/friendica-addons/pull/1079

This PR ensures that the OEmbed result for an arbitrary URL has been obtained from a successful request. OEmbed success response is standardized, but error responses are not.

Additionally, it adds back an OEmbed exception for Youtube dating back to 2015: #1247