### PR TITLE
Try OEmbed first for [audio] and [video] tags

### DIFF
--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -1616,12 +1616,13 @@ class BBCode
 					// html5 video and audio
 					$text = preg_replace("/\[video\](.*?\.(ogg|ogv|oga|ogm|webm|mp4).*?)\[\/video\]/ism",
 						'<video src="$1" controls width="' . $a->videowidth . '" height="' . $a->videoheight . '" loop="true"><a href="$1">$1</a></video>', $text);
-					$text = preg_replace("/\[video\](.*?)\[\/video\]/ism",
-						'<a href="$1" target="_blank" rel="noopener noreferrer">$1</a>', $text);
-					$text = preg_replace("/\[audio\](.*?)\[\/audio\]/ism", '<audio src="$1" controls><a href="$1">$1</a></audio>', $text);
 
 					$text = preg_replace_callback("/\[video\](.*?)\[\/video\]/ism", $try_oembed_callback, $text);
 					$text = preg_replace_callback("/\[audio\](.*?)\[\/audio\]/ism", $try_oembed_callback, $text);
+
+					$text = preg_replace("/\[video\](.*?)\[\/video\]/ism",
+						'<a href="$1" target="_blank" rel="noopener noreferrer">$1</a>', $text);
+					$text = preg_replace("/\[audio\](.*?)\[\/audio\]/ism", '<audio src="$1" controls><a href="$1">$1</a></audio>', $text);
 				} else {
 					$text = preg_replace("/\[video\](.*?)\[\/video\]/ism",
 						'<a href="$1" target="_blank" rel="noopener noreferrer">$1</a>', $text);


### PR DESCRIPTION
Fixes #9666 
Depends on #9915

Even after having introduced this fix, I couldn't get the nice embed for Youtube, and then I realized that it also depends on #9915 that has a specific OEmbed provision for Youtube. Successfully tested both fixes simultaneously.