### PR TITLE
No implicit mention for top level Diaspora comments

### DIFF
--- a/src/Object/Post.php
+++ b/src/Object/Post.php
@@ -881,13 +881,13 @@ class Post
 			return '';
 		}
 
-		$item = PostModel::selectFirst(['author-addr', 'uri-id'], ['id' => $this->getId()]);
+		$item = PostModel::selectFirst(['author-addr', 'uri-id', 'network', 'gravity'], ['id' => $this->getId()]);
 		if (!DBA::isResult($item) || empty($item['author-addr'])) {
 			// Should not happen
 			return '';
 		}
 
-		if ($item['author-addr'] != $owner['addr']) {
+		if (($item['author-addr'] != $owner['addr']) && (($item['gravity'] != GRAVITY_PARENT) || !in_array($item['network'], [Protocol::DIASPORA]))) {
 			$text = '@' . $item['author-addr'] . ' ';
 		} else {
 			$text = '';

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -3599,7 +3599,7 @@ class Diaspora
 			return $result;
 		}
 
-		$toplevel_item = Post::selectFirst(['guid', 'author-id', 'author-link'], ['id' => $item['parent'], 'parent' => $item['parent']]);
+		$toplevel_item = Post::selectFirst(['guid', 'author-id', 'author-link', 'gravity'], ['id' => $item['parent'], 'parent' => $item['parent']]);
 		if (!DBA::isResult($toplevel_item)) {
 			Logger::error('Missing parent conversation item', ['parent' => $item['parent']]);
 			return false;
@@ -3607,7 +3607,7 @@ class Diaspora
 
 		$thread_parent_item = $toplevel_item;
 		if ($item['thr-parent'] != $item['parent-uri']) {
-			$thread_parent_item = Post::selectFirst(['guid', 'author-id', 'author-link'], ['uri' => $item['thr-parent'], 'uid' => $item['uid']]);
+			$thread_parent_item = Post::selectFirst(['guid', 'author-id', 'author-link', 'gravity'], ['uri' => $item['thr-parent'], 'uid' => $item['uid']]);
 		}
 
 		$body = $item["body"];
@@ -3618,6 +3618,7 @@ class Diaspora
 		// - Implicit mentions are enabled
 		if (
 			$item['author-id'] != $thread_parent_item['author-id']
+			&& ($thread_parent_item['gravity'] != GRAVITY_PARENT)
 			&& (empty($item['uid']) || !Feature::isEnabled($item['uid'], 'explicit_mentions'))
 			&& !DI::config()->get('system', 'disable_implicit_mentions')
 		) {


### PR DESCRIPTION
Implicit mentions on Diaspora posts can be annoying for the thread owner because on top level comments the thread owner is automatically mentioned. Now this only happens on comments on comments.