### PR TITLE
File extension to Mimetype matching fix for filenames with extra periods in them

### DIFF
--- a/src/Util/Mimetype.php
+++ b/src/Util/Mimetype.php
@@ -1088,7 +1088,7 @@ class Mimetype
 			'zsh' => 'text/x-script.zsh'
 		];
 	
-		$dot = strpos($filename, '.');
+		$dot = strrpos($filename, '.');
 		if ($dot !== false) {
 			$ext = strtolower(substr($filename, $dot + 1));
 			if (array_key_exists($ext, $mime_types)) {


### PR DESCRIPTION
When `Mimetype::getContentType($filename)` matches a file name to a mime type, it used to use `strpos()` which ultimately breaks the extension off of the filename at the first period it encounters. I changed it to `strrpos()` so that it breaks the extension off of the filename at the last period it encounters. This fixes a bug where a file named `trim.xxxyyyzzzz.MOV`, uploaded from an iPhone has its mime type set to `application/octet-stream` and thus does not get embedded in a post as a video.