### PR TITLE
post/thread views are renamed, search bugs fixed

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -1462,10 +1462,10 @@ CREATE TABLE IF NOT EXISTS `workerqueue` (
 ) DEFAULT COLLATE utf8mb4_general_ci COMMENT='Background tasks queue entries';
 
 --
--- VIEW post-view
+-- VIEW post-user-view
 --
-DROP VIEW IF EXISTS `post-view`;
-CREATE VIEW `post-view` AS SELECT 
+DROP VIEW IF EXISTS `post-user-view`;
+CREATE VIEW `post-user-view` AS SELECT 
 	`post-user`.`id` AS `id`,
 	`post-user`.`id` AS `post-user-id`,
 	`post-user`.`uid` AS `uid`,
@@ -1620,10 +1620,10 @@ CREATE VIEW `post-view` AS SELECT
 			LEFT JOIN `contact` AS `parent-post-author` ON `parent-post-author`.`id` = `parent-post`.`author-id`;
 
 --
--- VIEW post-thread-view
+-- VIEW post-thread-user-view
 --
-DROP VIEW IF EXISTS `post-thread-view`;
-CREATE VIEW `post-thread-view` AS SELECT 
+DROP VIEW IF EXISTS `post-thread-user-view`;
+CREATE VIEW `post-thread-user-view` AS SELECT 
 	`post-user`.`id` AS `id`,
 	`post-user`.`id` AS `post-user-id`,
 	`post-thread-user`.`uid` AS `uid`,
@@ -2034,8 +2034,10 @@ CREATE VIEW `tag-search-view` AS SELECT
 	`post-user`.`private` AS `private`,
 	`post-user`.`wall` AS `wall`,
 	`post-user`.`origin` AS `origin`,
+	`post-user`.`global` AS `global`,
 	`post-user`.`gravity` AS `gravity`,
 	`post-user`.`received` AS `received`,
+	`post-user`.`network` AS `network`,
 	`tag`.`name` AS `name`
 	FROM `post-tag`
 			INNER JOIN `tag` ON `tag`.`id` = `post-tag`.`tid`

--- a/include/api.php
+++ b/include/api.php
@@ -6007,7 +6007,7 @@ function bindComments(&$data)
 	}
 
 	$idStr = DBA::escape(implode(', ', $ids));
-	$sql = "SELECT `parent`, COUNT(*) as comments FROM `post-view` WHERE `parent` IN ($idStr) AND `deleted` = ? AND `gravity`= ? GROUP BY `parent`";
+	$sql = "SELECT `parent`, COUNT(*) as comments FROM `post-user-view` WHERE `parent` IN ($idStr) AND `deleted` = ? AND `gravity`= ? GROUP BY `parent`";
 	$items = DBA::p($sql, 0, GRAVITY_COMMENT);
 	$itemsData = DBA::toArray($items);
 

--- a/mod/photos.php
+++ b/mod/photos.php
@@ -1266,7 +1266,7 @@ function photos_content(App $a)
 		// as a "post" but displaying instead the photo it is linked to
 
 		/// @todo Rewrite this query. To do so, $sql_extra must be changed
-		$linked_items = q("SELECT `id` FROM `post-view` WHERE `resource-id` = '%s' $sql_extra LIMIT 1",
+		$linked_items = q("SELECT `id` FROM `post-user-view` WHERE `resource-id` = '%s' $sql_extra LIMIT 1",
 			DBA::escape($datum)
 		);
 		if (DBA::isResult($linked_items)) {

--- a/mod/ping.php
+++ b/mod/ping.php
@@ -412,8 +412,8 @@ function ping_get_notifications($uid)
 
 	do {
 		$r = q(
-			"SELECT `notify`.*, `post-view`.`visible`, `post-view`.`deleted`
-			FROM `notify` LEFT JOIN `post-view` ON `post-view`.`id` = `notify`.`iid`
+			"SELECT `notify`.*, `post`.`visible`, `post`.`deleted`
+			FROM `notify` LEFT JOIN `post` ON `post`.`uri-id` = `notify`.`uri-id`
 			WHERE `notify`.`uid` = %d AND `notify`.`msg` != ''
 			AND NOT (`notify`.`type` IN (%d, %d))
 			AND $seensql `notify`.`seen` ORDER BY `notify`.`date` $order LIMIT %d, 50",

--- a/src/Content/ForumManager.php
+++ b/src/Content/ForumManager.php
@@ -209,9 +209,9 @@ class ForumManager
 	public static function countUnseenItems()
 	{
 		$stmtContacts = DBA::p(
-			"SELECT `contact`.`id`, `contact`.`name`, COUNT(*) AS `count` FROM `post-view`
-				INNER JOIN `contact` ON `post-view`.`contact-id` = `contact`.`id`
-				WHERE `post-view`.`uid` = ? AND `post-view`.`visible` AND NOT `post-view`.`deleted` AND `post-view`.`unseen`
+			"SELECT `contact`.`id`, `contact`.`name`, COUNT(*) AS `count` FROM `post-user-view`
+				INNER JOIN `contact` ON `post-user-view`.`contact-id` = `contact`.`id`
+				WHERE `post-user-view`.`uid` = ? AND `post-user-view`.`visible` AND NOT `post-user-view`.`deleted` AND `post-user-view`.`unseen`
 				AND `contact`.`network` IN (?, ?) AND `contact`.`contact-type` = ?
 				AND NOT `contact`.`blocked` AND NOT `contact`.`hidden`
 				AND NOT `contact`.`pending` AND NOT `contact`.`archive`

--- a/src/Content/OEmbed.php
+++ b/src/Content/OEmbed.php
@@ -99,7 +99,7 @@ class OEmbed
 				$html_text = DI::httpRequest()->fetch($embedurl, 15, 'text/*');
 				if ($html_text) {
 					$dom = new DOMDocument();
-					if ($dom->loadHTML($html_text)) {
+					if (@$dom->loadHTML($html_text)) {
 						$xpath = new DOMXPath($dom);
 						foreach (
 							$xpath->query("//link[@type='application/json+oembed'] | //link[@type='text/json+oembed']")

--- a/src/Content/Widget/TagCloud.php
+++ b/src/Content/Widget/TagCloud.php
@@ -87,24 +87,24 @@ class TagCloud
 	 */
 	private static function tagadelic($uid, $count = 0, $owner_id = 0, $flags = '', $type = Tag::HASHTAG)
 	{
-		$sql_options = Item::getPermissionsSQLByUserId($uid, 'post-view');
+		$sql_options = Item::getPermissionsSQLByUserId($uid, 'post-user-view');
 		$limit = $count ? sprintf('LIMIT %d', intval($count)) : '';
 
 		if ($flags) {
 			if ($flags === 'wall') {
-				$sql_options .= ' AND `post-view`.`wall` ';
+				$sql_options .= ' AND `post-user-view`.`wall` ';
 			}
 		}
 
 		if ($owner_id) {
-			$sql_options .= ' AND `post-view`.`owner-id` = ' . intval($owner_id) . ' ';
+			$sql_options .= ' AND `post-user-view`.`owner-id` = ' . intval($owner_id) . ' ';
 		}
 
 		// Fetch tags
 		$tag_stmt = DBA::p("SELECT `name`, COUNT(`name`) AS `total` FROM `tag-search-view`
-			LEFT JOIN `post-view` ON `tag-search-view`.`uri-id` = `post-view`.`uri-id`
+			LEFT JOIN `post-user-view` ON `tag-search-view`.`uri-id` = `post-user-view`.`uri-id` AND `tag-search-view`.`uid` = `post-user-view`.`uid`
 			WHERE `tag-search-view`.`uid` = ?
-			AND `post-view`.`visible` AND NOT `post-view`.`deleted`
+			AND `post-user-view`.`visible` AND NOT `post-user-view`.`deleted`
 			$sql_options
 			GROUP BY `name` ORDER BY `total` DESC $limit",
 			$uid

--- a/src/Model/Event.php
+++ b/src/Model/Event.php
@@ -516,8 +516,8 @@ class Event
 		}
 
 		// Query for the event by event id
-		$events = DBA::toArray(DBA::p("SELECT `event`.*, `post-view`.`id` AS `itemid` FROM `event`
-			LEFT JOIN `post-view` ON `post-view`.`event-id` = `event`.`id` AND `post-view`.`uid` = `event`.`uid`
+		$events = DBA::toArray(DBA::p("SELECT `event`.*, `post-user-view`.`id` AS `itemid` FROM `event`
+			LEFT JOIN `post-user-view` ON `post-user-view`.`event-id` = `event`.`id` AND `post-user-view`.`uid` = `event`.`uid`
 			WHERE `event`.`uid` = %d AND `event`.`id` = %d $sql_extra",
 			$owner_uid, $event_id));
 
@@ -555,8 +555,8 @@ class Event
 
 		// Query for the event by date.
 		// @todo Slow query (518 seconds to run), to be optimzed
-		$events = DBA::toArray(DBA::p("SELECT `event`.*, `post-view`.`id` AS `itemid` FROM `event`
-				LEFT JOIN `post-view` ON `post-view`.`event-id` = `event`.`id` AND `post-view`.`uid` = `event`.`uid`
+		$events = DBA::toArray(DBA::p("SELECT `event`.*, `post-user-view`.`id` AS `itemid` FROM `event`
+				LEFT JOIN `post-user-view` ON `post-user-view`.`event-id` = `event`.`id` AND `post-user-view`.`uid` = `event`.`uid`
 				WHERE `event`.`uid` = ? AND `event`.`ignore` = ?
 				AND ((NOT `adjust` AND (`finish` >= ? OR (`nofinish` AND `start` >= ?)) AND `start` <= ?)
 				OR  (`adjust` AND (`finish` >= ? OR (`nofinish` AND `start` >= ?)) AND `start` <= ?))" . $sql_extra,

--- a/src/Model/Group.php
+++ b/src/Model/Group.php
@@ -160,7 +160,7 @@ class Group
 	public static function countUnseen()
 	{
 		$stmt = DBA::p("SELECT `group`.`id`, `group`.`name`,
-				(SELECT COUNT(*) FROM `post-view`
+				(SELECT COUNT(*) FROM `post-user-view`
 					WHERE `uid` = ?
 					AND `unseen`
 					AND `contact-id` IN

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -1190,7 +1190,7 @@ class Item
 	 */
 	public static function distribute($itemid, $signed_text = '')
 	{
-		$condition = ["`id` IN (SELECT `parent` FROM `post-view` WHERE `id` = ?)", $itemid];
+		$condition = ["`id` IN (SELECT `parent` FROM `post-user-view` WHERE `id` = ?)", $itemid];
 		$parent = Post::selectFirst(['owner-id'], $condition);
 		if (!DBA::isResult($parent)) {
 			Logger::warning('Item not found', ['condition' => $condition]);

--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -132,7 +132,7 @@ class Post
 	 * @throws \Exception
 	 */
 	public static function exists($condition) {
-		return DBA::exists('post-view', $condition);
+		return DBA::exists('post-user-view', $condition);
 	}
 
 	/**
@@ -153,7 +153,7 @@ class Post
 	 */
 	public static function count(array $condition = [], array $params = [])
 	{
-		return DBA::count('post-view', $condition, $params);
+		return DBA::count('post-user-view', $condition, $params);
 	}
 
 	/**
@@ -211,7 +211,7 @@ class Post
 	/**
 	 * Select rows from the given view
 	 *
-	 * @param string $view      View (post-view or post-thread-view)
+	 * @param string $view      View (post-user-view or post-thread-user-view)
 	 * @param array  $selected  Array of selected fields, empty for all
 	 * @param array  $condition Array of fields for condition
 	 * @param array  $params    Array of several parameters
@@ -224,7 +224,7 @@ class Post
 		if (empty($selected)) {
 			$selected = array_merge(Item::DISPLAY_FIELDLIST, Item::ITEM_FIELDLIST);
 
-			if ($view == 'post-thread-view') {
+			if ($view == 'post-thread-user-view') {
 				$selected = array_merge($selected, ['ignored']);
 			}
 		}
@@ -246,7 +246,7 @@ class Post
 	 */
 	public static function select(array $selected = [], array $condition = [], $params = [])
 	{
-		return self::selectView('post-view', $selected, $condition, $params);
+		return self::selectView('post-user-view', $selected, $condition, $params);
 	}
 
 	/**
@@ -261,13 +261,13 @@ class Post
 	 */
 	public static function selectThread(array $selected = [], array $condition = [], $params = [])
 	{
-		return self::selectView('post-thread-view', $selected, $condition, $params);
+		return self::selectView('post-thread-user-view', $selected, $condition, $params);
 	}
 
 	/**
 	 * Select rows from the given view for a given user
 	 *
-	 * @param string  $view      View (post-view or post-thread-view)
+	 * @param string  $view      View (post-user-view or post-thread-user-view)
 	 * @param integer $uid       User ID
 	 * @param array   $selected  Array of selected fields, empty for all
 	 * @param array   $condition Array of fields for condition
@@ -329,7 +329,7 @@ class Post
 	 */
 	public static function selectForUser($uid, array $selected = [], array $condition = [], $params = [])
 	{
-		return self::selectViewForUser('post-view', $uid, $selected, $condition, $params);
+		return self::selectViewForUser('post-user-view', $uid, $selected, $condition, $params);
 	}
 
 		/**
@@ -345,7 +345,7 @@ class Post
 	 */
 	public static function selectThreadForUser($uid, array $selected = [], array $condition = [], $params = [])
 	{
-		return self::selectViewForUser('post-thread-view', $uid, $selected, $condition, $params);
+		return self::selectViewForUser('post-thread-user-view', $uid, $selected, $condition, $params);
 	}
 
 	/**
@@ -443,7 +443,7 @@ class Post
 		$update_fields = DBStructure::getFieldsForTable('post-user', $fields);
 		if (!empty($update_fields)) {
 			$affected_count = 0;
-			$posts = DBA::select('post-view', ['post-user-id'], $condition);
+			$posts = DBA::select('post-user-view', ['post-user-id'], $condition);
 			while ($rows = DBA::toArray($posts, false, 100)) {
 				$puids = array_column($rows, 'post-user-id');
 				if (!DBA::update('post-user', $update_fields, ['id' => $puids])) {
@@ -460,7 +460,7 @@ class Post
 		$update_fields = DBStructure::getFieldsForTable('post-content', $fields);
 		if (!empty($update_fields)) {
 			$affected_count = 0;
-			$posts = DBA::select('post-view', ['uri-id'], $condition, ['group_by' => ['uri-id']]);
+			$posts = DBA::select('post-user-view', ['uri-id'], $condition, ['group_by' => ['uri-id']]);
 			while ($rows = DBA::toArray($posts, false, 100)) {
 				$uriids = array_column($rows, 'uri-id');
 				if (!DBA::update('post-content', $update_fields, ['uri-id' => $uriids])) {
@@ -477,7 +477,7 @@ class Post
 		$update_fields = DBStructure::getFieldsForTable('post', $fields);
 		if (!empty($update_fields)) {
 			$affected_count = 0;
-			$posts = DBA::select('post-view', ['uri-id'], $condition, ['group_by' => ['uri-id']]);
+			$posts = DBA::select('post-user-view', ['uri-id'], $condition, ['group_by' => ['uri-id']]);
 			while ($rows = DBA::toArray($posts, false, 100)) {
 				$uriids = array_column($rows, 'uri-id');
 				if (!DBA::update('post', $update_fields, ['uri-id' => $uriids])) {
@@ -494,7 +494,7 @@ class Post
 		$update_fields = Post\DeliveryData::extractFields($fields);
 		if (!empty($update_fields)) {
 			$affected_count = 0;
-			$posts = DBA::select('post-view', ['uri-id'], $condition, ['group_by' => ['uri-id']]);
+			$posts = DBA::select('post-user-view', ['uri-id'], $condition, ['group_by' => ['uri-id']]);
 			while ($rows = DBA::toArray($posts, false, 100)) {
 				$uriids = array_column($rows, 'uri-id');
 				if (!DBA::update('post-delivery-data', $update_fields, ['uri-id' => $uriids])) {
@@ -511,7 +511,7 @@ class Post
 		$update_fields = DBStructure::getFieldsForTable('post-thread', $fields);
 		if (!empty($update_fields)) {
 			$affected_count = 0;
-			$posts = DBA::select('post-view', ['uri-id'], $thread_condition, ['group_by' => ['uri-id']]);
+			$posts = DBA::select('post-user-view', ['uri-id'], $thread_condition, ['group_by' => ['uri-id']]);
 			while ($rows = DBA::toArray($posts, false, 100)) {
 				$uriids = array_column($rows, 'uri-id');
 				if (!DBA::update('post-thread', $update_fields, ['uri-id' => $uriids])) {
@@ -528,7 +528,7 @@ class Post
 		$update_fields = DBStructure::getFieldsForTable('post-thread-user', $fields);
 		if (!empty($update_fields)) {
 			$affected_count = 0;
-			$posts = DBA::select('post-view', ['post-user-id'], $thread_condition);
+			$posts = DBA::select('post-user-view', ['post-user-id'], $thread_condition);
 			while ($rows = DBA::toArray($posts, false, 100)) {
 				$thread_puids = array_column($rows, 'post-user-id');
 				if (!DBA::update('post-thread-user', $update_fields, ['post-user-id' => $thread_puids])) {

--- a/src/Model/Post/Content.php
+++ b/src/Model/Post/Content.php
@@ -109,8 +109,8 @@ class Content
 	public static function getURIIdListBySearch(string $search, int $uid = 0, int $start = 0, int $limit = 100, int $last_uriid = 0)
 	{
 		$condition = ["`uri-id` IN (SELECT `uri-id` FROM `post-content` WHERE MATCH (`title`, `content-warning`, `body`) AGAINST (? IN BOOLEAN MODE))
-			AND (NOT `private` OR (`private` AND `uid` = ?)) AND (`network` IN (?, ?, ?, ?) OR (`uid` = ? AND `uid` != ?))",
-			$search, $uid, Protocol::ACTIVITYPUB, Protocol::DFRN, Protocol::DIASPORA, Protocol::OSTATUS, $uid, 0];
+			AND (`uid` = ? OR (`uid` = ? AND NOT `global`)) AND (`network` IN (?, ?, ?, ?) OR (`uid` = ? AND `uid` != ?))",
+			$search, 0, $uid, Protocol::ACTIVITYPUB, Protocol::DFRN, Protocol::DIASPORA, Protocol::OSTATUS, $uid, 0];
 
 		if (!empty($last_uriid)) {
 			$condition = DBA::mergeConditions($condition, ["`uri-id` < ?", $last_uriid]);
@@ -118,7 +118,6 @@ class Content
 
 		$params = [
 			'order' => ['uri-id' => true],
-			'group_by' => ['uri-id'],
 			'limit' => [$start, $limit]
 		];
 
@@ -136,8 +135,8 @@ class Content
 	public static function countBySearch(string $search, int $uid = 0)
 	{
 		$condition = ["`uri-id` IN (SELECT `uri-id` FROM `post-content` WHERE MATCH (`title`, `content-warning`, `body`) AGAINST (? IN BOOLEAN MODE))
-			AND (NOT `private` OR (`private` AND `uid` = ?)) AND (`network` IN (?, ?, ?, ?) OR (`uid` = ? AND `uid` != ?))",
-			$search, $uid, Protocol::ACTIVITYPUB, Protocol::DFRN, Protocol::DIASPORA, Protocol::OSTATUS, $uid, 0];
+			AND (`uid` = ? OR (`uid` = ? AND NOT `global`)) AND (`network` IN (?, ?, ?, ?) OR (`uid` = ? AND `uid` != ?))",
+			$search, 0, $uid, Protocol::ACTIVITYPUB, Protocol::DFRN, Protocol::DIASPORA, Protocol::OSTATUS, $uid, 0];
 		return Post::count($condition);
 	}
 }

--- a/src/Model/Post/UserNotification.php
+++ b/src/Model/Post/UserNotification.php
@@ -149,7 +149,7 @@ class UserNotification
 
 		// Add every user who participated so far in this thread
 		// This can only happen with participations on global items. (means: uid = 0) 
-		$users = DBA::p("SELECT DISTINCT(`contact-uid`) AS `uid` FROM `post-view`
+		$users = DBA::p("SELECT DISTINCT(`contact-uid`) AS `uid` FROM `post-user-view`
 			WHERE `contact-uid` != 0 AND `parent-uri-id` = ? AND `uid` = ?", $item['parent-uri-id'], $uid);
 		while ($user = DBA::fetch($users)) {
 			$uids[] = $user['uid'];

--- a/src/Model/Tag.php
+++ b/src/Model/Tag.php
@@ -455,12 +455,11 @@ class Tag
 	 */
 	public static function countByTag(string $search, int $uid = 0)
 	{
-		$condition = ["`name` = ? AND (NOT `private` OR (`private` AND `uid` = ?))
-			AND `uri-id` IN (SELECT `uri-id` FROM `post-view` WHERE `network` IN (?, ?, ?, ?))",
-			$search, $uid, Protocol::ACTIVITYPUB, Protocol::DFRN, Protocol::DIASPORA, Protocol::OSTATUS];
-		$params = ['group_by' => ['uri-id']];
+		$condition = ["`name` = ? AND (`uid` = ? OR (`uid` = ? AND NOT `global`))
+			AND (`network` IN (?, ?, ?, ?) OR (`uid` = ? AND `uid` != ?))",
+			$search, 0, $uid, Protocol::ACTIVITYPUB, Protocol::DFRN, Protocol::DIASPORA, Protocol::OSTATUS, $uid, 0];
 
-		return DBA::count('tag-search-view', $condition, $params);
+		return DBA::count('tag-search-view', $condition);
 	}
 
 	/**
@@ -475,9 +474,9 @@ class Tag
 	 */
 	public static function getURIIdListByTag(string $search, int $uid = 0, int $start = 0, int $limit = 100, int $last_uriid = 0)
 	{
-		$condition = ["`name` = ? AND (NOT `private` OR (`private` AND `uid` = ?))
-			AND `uri-id` IN (SELECT `uri-id` FROM `post-view` WHERE `network` IN (?, ?, ?, ?))",
-			$search, $uid, Protocol::ACTIVITYPUB, Protocol::DFRN, Protocol::DIASPORA, Protocol::OSTATUS];
+		$condition = ["`name` = ? AND (`uid` = ? OR (`uid` = ? AND NOT `global`))
+			AND (`network` IN (?, ?, ?, ?) OR (`uid` = ? AND `uid` != ?))",
+			$search, 0, $uid, Protocol::ACTIVITYPUB, Protocol::DFRN, Protocol::DIASPORA, Protocol::OSTATUS, $uid, 0];
 
 		if (!empty($last_uriid)) {
 			$condition = DBA::mergeConditions($condition, ["`uri-id` < ?", $last_uriid]);
@@ -485,7 +484,6 @@ class Tag
 
 		$params = [
 			'order' => ['uri-id' => true],
-			'group_by' => ['uri-id'],
 			'limit' => [$start, $limit]
 		];
 

--- a/src/Module/Api/Mastodon/Timelines/PublicTimeline.php
+++ b/src/Module/Api/Mastodon/Timelines/PublicTimeline.php
@@ -62,11 +62,11 @@ class PublicTimeline extends BaseApi
 			'uid' => 0, 'network' => Protocol::FEDERATED];
 
 		if ($local) {
-			$condition = DBA::mergeConditions($condition, ["`uri-id` IN (SELECT `uri-id` FROM `post-view` WHERE `origin`)"]);
+			$condition = DBA::mergeConditions($condition, ["`uri-id` IN (SELECT `uri-id` FROM `post-user` WHERE `origin`)"]);
 		}
 
 		if ($remote) {
-			$condition = DBA::mergeConditions($condition, ["NOT `uri-id` IN (SELECT `uri-id` FROM `post-view` WHERE `origin`)"]);
+			$condition = DBA::mergeConditions($condition, ["NOT `uri-id` IN (SELECT `uri-id` FROM `post-user` WHERE `origin`)"]);
 		}
 
 		if (!empty($max_id)) {

--- a/src/Module/Conversation/Community.php
+++ b/src/Module/Conversation/Community.php
@@ -336,7 +336,7 @@ class Community extends BaseModule
 			$condition[] = $item_id;
 		} else {
 			if (local_user() && !empty($_REQUEST['no_sharer'])) {
-				$condition[0] .= " AND NOT EXISTS (SELECT `uri-id` FROM `post-user` WHERE `post-user`.`uri-id` = `post-thread-view`.`uri-id` AND `post-user`.`uid` = ?)";
+				$condition[0] .= " AND NOT EXISTS (SELECT `uri-id` FROM `post-user` WHERE `post-user`.`uri-id` = `post-thread-user-view`.`uri-id` AND `post-user`.`uid` = ?)";
 				$condition[] = local_user();
 			}
 	

--- a/src/Module/Profile/Status.php
+++ b/src/Module/Profile/Status.php
@@ -180,13 +180,11 @@ class Status extends BaseProfile
 		}
 
 		$condition = DBA::mergeConditions($condition, ["((`gravity` = ? AND `wall`) OR
-			(`gravity` = ? AND `vid` = ? AND `origin` AND `thr-parent-id` IN
-				(SELECT `uri-id` FROM `post-view`
-					WHERE `gravity` = ? AND `network` IN (?, ?, ?, ?) AND `uid` IN (?, ?)
-						AND `uri-id` = `thr-parent-id`)))",
+			(`gravity` = ? AND `vid` = ? AND `origin`
+			AND EXISTS(SELECT `uri-id` FROM `post` WHERE `gravity` = ? AND `network` IN (?, ?, ?, ?)
+				AND `uri-id` = `post-user-view`.`thr-parent-id`)))",
 			GRAVITY_PARENT, GRAVITY_ACTIVITY, Verb::getID(Activity::ANNOUNCE), GRAVITY_PARENT,
-			Protocol::DFRN, Protocol::ACTIVITYPUB, Protocol::DIASPORA, Protocol::OSTATUS,
-			0, $a->profile['uid']]);
+			Protocol::DFRN, Protocol::ACTIVITYPUB, Protocol::DIASPORA, Protocol::OSTATUS]);
 
 		$condition = DBA::mergeConditions($condition, ['uid' => $a->profile['uid'], 'network' => Protocol::FEDERATED,
 			'visible' => true, 'deleted' => false]);

--- a/src/Module/Update/Profile.php
+++ b/src/Module/Update/Profile.php
@@ -81,7 +81,7 @@ class Profile extends BaseModule
 		}
 
 		$items_stmt = DBA::p(
-			"SELECT DISTINCT(`parent-uri-id`) AS `uri-id`, MAX(`created`), MAX(`received`) FROM `post-view`
+			"SELECT DISTINCT(`parent-uri-id`) AS `uri-id`, MAX(`created`), MAX(`received`) FROM `post-user-view`
 				WHERE `uid` = ? AND NOT `contact-blocked` AND NOT `contact-pending`
 				AND `visible` AND (NOT `deleted` OR `gravity` = ?)
 				AND `wall` $sql_extra4 $sql_extra

--- a/static/dbview.config.php
+++ b/static/dbview.config.php
@@ -37,7 +37,7 @@
  */
 
  return [
-	"post-view" => [
+	"post-user-view" => [
 		"fields" => [
 			"id" => ["post-user", "id"],
 			"post-user-id" => ["post-user", "id"],
@@ -193,7 +193,7 @@
 			LEFT JOIN `post-user` AS `parent-post` ON `parent-post`.`uri-id` = `post-user`.`parent-uri-id` AND `parent-post`.`uid` = `post-user`.`uid`
 			LEFT JOIN `contact` AS `parent-post-author` ON `parent-post-author`.`id` = `parent-post`.`author-id`"
 	],
-	"post-thread-view" => [
+	"post-thread-user-view" => [
 		"fields" => [
 			"id" => ["post-user", "id"],
 			"post-user-id" => ["post-user", "id"],
@@ -591,8 +591,10 @@
 			"private" => ["post-user", "private"],
 			"wall" => ["post-user", "wall"],
 			"origin" => ["post-user", "origin"],
+			"global" => ["post-user", "global"],
 			"gravity" => ["post-user", "gravity"],
 			"received" => ["post-user", "received"],
+			"network" => ["post-user", "network"],
 			"name" => ["tag", "name"],
 		],
 		"query" => "FROM `post-tag`


### PR DESCRIPTION
Because the leading tables of views for the posts and the thread-posts are the "post--user" and "post-thread-user" tables, I think it is better to rename these views.

This also happens because we possibly will have a "post-view" and "post-thread-view" view in the future that will then be based on "post" and "post-thread".

While renaming the places, I fixed some small bugs. The bug #9923 should be fixed by this.

Also in the "expire" functionality we now clean up all post related tables and we are deleting only full threads.

The query for displaying profiles had been simplified and should be now faster.

The tag search now contains posts from all networks, also it should be faster.