### PR TITLE
Use "pdo_emulate_prepares" by default

### DIFF
--- a/static/defaults.config.php
+++ b/static/defaults.config.php
@@ -56,7 +56,7 @@ return [
 		// pdo_emulate_prepares (Boolean)
 		// If enabled, the builtin emulation for prepared statements is used.
 		// This can be used as a workaround for the database error "Prepared statement needs to be re-prepared".
-		'pdo_emulate_prepares' => false,
+		'pdo_emulate_prepares' => true,
 
 		// disable_pdo (Boolean)
 		// PDO is used by default (if available). Otherwise MySQLi will be used.


### PR DESCRIPTION
There had been several reports in the past that people had problems with their database servers because of the views, see #8550

This setting now is activated by default. I haven't had experienced performance impacts for the one or the other setting.