### PR TITLE
Fixes several database errors, removes "relation" handling

### DIFF
--- a/src/Core/Hook.php
+++ b/src/Core/Hook.php
@@ -218,7 +218,7 @@ class Hook
 		} else {
 			// remove orphan hooks
 			$condition = ['hook' => $name, 'file' => $hook[0], 'function' => $hook[1]];
-			self::delete($condition, ['cascade' => false]);
+			self::delete($condition);
 		}
 	}
 
@@ -250,13 +250,12 @@ class Hook
 	 * We have to clear the cached routerDispatchData because addons can provide routes
 	 *
 	 * @param array $condition
-	 * @param array $options
 	 * @return bool
 	 * @throws \Exception
 	 */
-	public static function delete(array $condition, array $options = [])
+	public static function delete(array $condition)
 	{
-		$result = DBA::delete('hook', $condition, $options);
+		$result = DBA::delete('hook', $condition);
 
 		if ($result) {
 			DI::cache()->delete('routerDispatchData');

--- a/src/Database/DBA.php
+++ b/src/Database/DBA.php
@@ -388,9 +388,6 @@ class DBA
 	 *
 	 * @param string|array $table      Table name
 	 * @param array        $conditions Field condition(s)
-	 * @param array        $options
-	 *                           - cascade: If true we delete records in other tables that depend on the one we're deleting through
-	 *                           relations (default: true)
 	 *
 	 * @return boolean was the delete successful?
 	 * @throws \Exception

--- a/src/Model/Contact/Relation.php
+++ b/src/Model/Contact/Relation.php
@@ -137,16 +137,14 @@ class Relation
 			$actor = Contact::getIdForURL($contact);
 			if (!empty($actor)) {
 				if (in_array($contact, $followers)) {
-					$condition = ['cid' => $target, 'relation-cid' => $actor];
-					DBA::insert('contact-relation', $condition, Database::INSERT_IGNORE);
-					DBA::update('contact-relation', ['follows' => true, 'follow-updated' => DateTimeFormat::utcNow()], $condition);
+					$fields = ['cid' => $target, 'relation-cid' => $actor, 'follows' => true, 'follow-updated' => DateTimeFormat::utcNow()];
+					DBA::insert('contact-relation', $fields, Database::INSERT_UPDATE);
 					$follower_counter++;
 				}
 
 				if (in_array($contact, $followings)) {
-					$condition = ['cid' => $actor, 'relation-cid' => $target];
-					DBA::insert('contact-relation', $condition, Database::INSERT_IGNORE);
-					DBA::update('contact-relation', ['follows' => true, 'follow-updated' => DateTimeFormat::utcNow()], $condition);
+					$fields = ['cid' => $actor, 'relation-cid' => $target, 'follows' => true, 'follow-updated' => DateTimeFormat::utcNow()];
+					DBA::insert('contact-relation', $fields, Database::INSERT_UPDATE);
 					$following_counter++;
 				}
 			}

--- a/src/Model/Contact/Relation.php
+++ b/src/Model/Contact/Relation.php
@@ -137,14 +137,16 @@ class Relation
 			$actor = Contact::getIdForURL($contact);
 			if (!empty($actor)) {
 				if (in_array($contact, $followers)) {
-					$fields = ['cid' => $target, 'relation-cid' => $actor, 'follows' => true, 'follow-updated' => DateTimeFormat::utcNow()];
-					DBA::insert('contact-relation', $fields, Database::INSERT_UPDATE);
+					$condition = ['cid' => $target, 'relation-cid' => $actor];
+					DBA::insert('contact-relation', $condition, Database::INSERT_IGNORE);
+					DBA::update('contact-relation', ['follows' => true, 'follow-updated' => DateTimeFormat::utcNow()], $condition);
 					$follower_counter++;
 				}
 
 				if (in_array($contact, $followings)) {
-					$fields = ['cid' => $actor, 'relation-cid' => $target, 'follows' => true, 'follow-updated' => DateTimeFormat::utcNow()];
-					DBA::insert('contact-relation', $fields, Database::INSERT_UPDATE);
+					$condition = ['cid' => $actor, 'relation-cid' => $target];
+					DBA::insert('contact-relation', $condition, Database::INSERT_IGNORE);
+					DBA::update('contact-relation', ['follows' => true, 'follow-updated' => DateTimeFormat::utcNow()], $condition);
 					$following_counter++;
 				}
 			}

--- a/src/Model/Event.php
+++ b/src/Model/Event.php
@@ -242,7 +242,7 @@ class Event
 			return;
 		}
 
-		DBA::delete('event', ['id' => $event_id], ['cascade' => false]);
+		DBA::delete('event', ['id' => $event_id]);
 		Logger::log("Deleted event ".$event_id, Logger::DEBUG);
 	}
 

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -318,14 +318,6 @@ class Item
 
 		Post\DeliveryData::delete($item['uri-id']);
 
-		// When the permission set will be used in photo and events as well,
-		// this query here needs to be extended.
-		// @todo Currently deactivated. We need the permission set in the deletion process.
-		// This is a reminder to add the removal somewhere else.
-		//if (!empty($item['psid']) && !self::exists(['psid' => $item['psid'], 'deleted' => false])) {
-		//	DBA::delete('permissionset', ['id' => $item['psid']], ['cascade' => false]);
-		//}
-
 		// If it's the parent of a comment thread, kill all the kids
 		if ($item['gravity'] == GRAVITY_PARENT) {
 			self::markForDeletion(['parent' => $item['parent'], 'deleted' => false], $priority);

--- a/src/Module/Conversation/Community.php
+++ b/src/Module/Conversation/Community.php
@@ -332,7 +332,7 @@ class Community extends BaseModule
 		$params = ['order' => ['commented' => true], 'limit' => $itemspage];
 
 		if (!empty($item_id)) {
-			$condition[0] .= " AND `iid` = ?";
+			$condition[0] .= " AND `id` = ?";
 			$condition[] = $item_id;
 		} else {
 			if (local_user() && !empty($_REQUEST['no_sharer'])) {

--- a/src/Worker/Delivery.php
+++ b/src/Worker/Delivery.php
@@ -183,7 +183,7 @@ class Delivery
 		}
 
 		if (empty($items)) {
-			Logger::log('No delivery data for  ' . $cmd . ' - Item ID: ' .$target_id . ' - Contact ID: ' . $contact_id);
+			Logger::notice('No delivery data', ['command' => $cmd, 'uri-id' => $post_uriid, 'cid' => $contact_id]);
 		}
 
 		$owner = Model\User::getOwnerDataById($uid);
@@ -221,7 +221,7 @@ class Delivery
 			$contact['network'] = Protocol::DFRN;
 		}
 
-		Logger::notice('Delivering', ['cmd' => $cmd, 'target' => $target_id, 'followup' => $followup, 'network' => $contact['network']]);
+		Logger::notice('Delivering', ['cmd' => $cmd, 'uri-id' => $post_uriid, 'followup' => $followup, 'network' => $contact['network']]);
 
 		switch ($contact['network']) {
 			case Protocol::DFRN:

--- a/src/Worker/MergeContact.php
+++ b/src/Worker/MergeContact.php
@@ -23,6 +23,7 @@ namespace Friendica\Worker;
 
 use Friendica\Core\Logger;
 use Friendica\Database\DBA;
+use Friendica\Database\DBStructure;
 use Friendica\Model\Post;
 
 class MergeContact
@@ -48,6 +49,12 @@ class MergeContact
 		DBA::update('mail', ['contact-id' => $new_cid], ['contact-id' => $old_cid]);
 		DBA::update('photo', ['contact-id' => $new_cid], ['contact-id' => $old_cid]);
 		DBA::update('event', ['cid' => $new_cid], ['cid' => $old_cid]);
+		if (DBStructure::existsTable('item')) {
+			DBA::update('item', ['contact-id' => $new_cid], ['contact-id' => $old_cid]);
+		}
+		if (DBStructure::existsTable('thread')) {
+			DBA::update('thread', ['contact-id' => $new_cid], ['contact-id' => $old_cid]);
+		}
 
 		// These fields only contain public contact entries (uid = 0)
 		if ($uid == 0) {
@@ -56,6 +63,16 @@ class MergeContact
 			Post::update(['author-id' => $new_cid], ['author-id' => $old_cid]);
 			Post::update(['owner-id' => $new_cid], ['owner-id' => $old_cid]);
 			Post::update(['causer-id' => $new_cid], ['causer-id' => $old_cid]);
+			if (DBStructure::existsTable('item')) {
+				DBA::update('item', ['author-id' => $new_cid], ['author-id' => $old_cid]);
+				DBA::update('item', ['owner-id' => $new_cid], ['owner-id' => $old_cid]);
+				DBA::update('item', ['causer-id' => $new_cid], ['causer-id' => $old_cid]);
+			}
+			if (DBStructure::existsTable('thread')) {
+				DBA::update('thread', ['author-id' => $new_cid], ['author-id' => $old_cid]);
+				DBA::update('thread', ['owner-id' => $new_cid], ['owner-id' => $old_cid]);
+				DBA::update('thread', ['causer-id' => $new_cid], ['causer-id' => $old_cid]);
+			}
 		} else {
 			/// @todo Check if some other data needs to be adjusted as well, possibly the "rel" status?
 		}

--- a/src/Worker/RemoveContact.php
+++ b/src/Worker/RemoveContact.php
@@ -54,6 +54,8 @@ class RemoveContact {
 			DBA::delete('item', ['contact-id' => $id]);
 		}
 
+		DBA::delete('mail', ['contact-id' => $id]);
+
 		Post\ThreadUser::delete(['author-id' => $id]);
 		Post\ThreadUser::delete(['owner-id' => $id]);
 		Post\ThreadUser::delete(['causer-id' => $id]);

--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -46,7 +46,7 @@
  * ],
  *
  * Whenever possible prefer "foreign" before "relation" with the foreign keys.
- * "foreign" adds true foreign keys on the database level, while "relation" simulates this behaviour.
+ * "foreign" adds true foreign keys on the database level, while "relation" is just an indicator of a table relation without any consequences
  *
  * If you need to make any change, make sure to increment the DB_UPDATE_VERSION constant value below.
  *


### PR DESCRIPTION
This PR removes the "relation" handling which we used prior to the foreign keys to handle table relations. Since it isn't used anymore, it created unneeded complexity to the "delete" handling (that also created a problem when the delete condition parameter contained an array)

Also it fixes a database error where we used some field that isn't anymore.