### PR TITLE
Support cid URLs as used in mailstream plugin

### DIFF
--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -28,6 +28,7 @@ use Friendica\Content\ContactSelector;
 use Friendica\Content\Item;
 use Friendica\Content\OEmbed;
 use Friendica\Content\Smilies;
+use Friendica\Content\Text\HTMLPurifier_URIScheme_cid;
 use Friendica\Core\Hook;
 use Friendica\Core\Logger;
 use Friendica\Core\Protocol;
@@ -1873,6 +1874,8 @@ class BBCode
 			},
 			$text
 		);
+
+		\HTMLPurifier_URISchemeRegistry::instance()->register('cid', new HTMLPurifier_URIScheme_cid());
 
 		$config = \HTMLPurifier_HTML5Config::createDefault();
 		$config->set('HTML.Doctype', 'HTML5');

--- a/src/Content/Text/HTMLPurifier_URIScheme_cid.php
+++ b/src/Content/Text/HTMLPurifier_URIScheme_cid.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Friendica\Content\Text;
+
+use \HTMLPurifier_URIScheme;
+
+/**
+ * Validates content-id ("cid") as used in multi-part MIME messages, as defined by RFC 2392
+ */
+class HTMLPurifier_URIScheme_cid extends HTMLPurifier_URIScheme
+{
+	/**
+	 * @type bool
+	 */
+	public $browsable = true;
+
+	/**
+	 * @type bool
+	 */
+	public $may_omit_host = true;
+
+	/**
+	 * @param HTMLPurifier_URI $uri
+	 * @param HTMLPurifier_Config $config
+	 * @param HTMLPurifier_Context $context
+	 * @return bool
+	 */
+	public function doValidate(&$uri, $config, $context)
+	{
+		$uri->userinfo = null;
+		$uri->host = null;
+		$uri->port = null;
+		$uri->query = null;
+		// typecode check needed on path
+		return true;
+	}
+}


### PR DESCRIPTION
The mailstream plugin sends items as emails, which is (still) the easiest way to cache and read content offline.  It attaches embedded images to the emails so that they will be available offline.  To insert the images in the correct place, it refers to them with cid URLs.

With [this PR](https://github.com/friendica/friendica/commit/a0f6d678c4450b559c0be87533def7357f06665f) Friendica switched to HTMLPurifier.  This does not allow cid URLs by default, so inline images in mailstream emails have not been visible since that change.

This PR enables cid URLs again.  HTMLPurifier requires a URIScheme class for each scheme, and doesn't include a pre-written one for cid.  So I've had to write one.  It was mostly copied from the news scheme.

Technically cids must not include special characters defined by RFC 822.  But to keep things simple I haven't added any checks for that.