### PR TITLE
Fix link preview with videos

### DIFF
--- a/src/Module/ParseUrl.php
+++ b/src/Module/ParseUrl.php
@@ -96,7 +96,8 @@ class ParseUrl extends BaseModule
 		if ($format == 'json') {
 			$siteinfo = Util\ParseUrl::getSiteinfoCached($url);
 
-			if (in_array($siteinfo['type'], ['image', 'video', 'audio'])) {
+			if (empty($siteinfo['title']) && empty($siteinfo['text']) && empty($siteinfo['image'])
+				&& in_array($siteinfo['type'], ['image', 'video', 'audio'])) {
 				switch ($siteinfo['type']) {
 					case 'video':
 						$content_type = 'video';


### PR DESCRIPTION
When creating a post and you enter a link then a preview should appear. This hadn't worked anymore for videos. Now we only treat content as "image", "video" or "audio" when they don't appear to be a link to some page with link, title or preview image.