### PR TITLE
Perform a reload after following a thread

### DIFF
--- a/view/js/main.js
+++ b/view/js/main.js
@@ -680,6 +680,8 @@ function doFollowThread(ident) {
 	$('#like-rotator-' + ident.toString()).show();
 	$.post('item/' + ident.toString() + '/follow', NavUpdate);
 	liking = 1;
+	force_update = true;
+	update_item = ident.toString();
 }
 
 function doStar(ident) {


### PR DESCRIPTION
When following a thread there had been the bug that the spinner ran endlessly. This is now fixed.