### PR TITLE
Offer "follow thread" only when you don't already follow

### DIFF
--- a/include/conversation.php
+++ b/include/conversation.php
@@ -899,7 +899,7 @@ function item_photo_menu($item) {
 	$block_link = '';
 	$ignore_link = '';
 
-	if (local_user() && local_user() == $item['uid'] && $item['gravity'] == GRAVITY_PARENT && !$item['self']) {
+	if (local_user() && local_user() == $item['uid'] && $item['gravity'] == GRAVITY_PARENT && !$item['self'] && !$item['mention']) {
 		$sub_link = 'javascript:doFollowThread(' . $item['id'] . '); return false;';
 	}
 

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -76,7 +76,7 @@ class Item
 		'commented', 'created', 'edited', 'received', 'verb', 'object-type', 'postopts', 'plink',
 		'wall', 'private', 'starred', 'origin', 'parent-origin', 'title', 'body', 'language',
 		'content-warning', 'location', 'coord', 'app', 'rendered-hash', 'rendered-html', 'object',
-		'allow_cid', 'allow_gid', 'deny_cid', 'deny_gid',
+		'allow_cid', 'allow_gid', 'deny_cid', 'deny_gid', 'mention',
 		'author-id', 'author-link', 'author-name', 'author-avatar', 'author-network',
 		'owner-id', 'owner-link', 'owner-name', 'owner-avatar', 'owner-network', 'owner-contact-type',
 		'causer-id', 'causer-link', 'causer-name', 'causer-avatar', 'causer-contact-type', 'causer-network',

--- a/src/Object/Post.php
+++ b/src/Object/Post.php
@@ -300,14 +300,16 @@ class Post
 		if ($this->isToplevel()) {
 			if(local_user()) {
 				$ignored = PostModel\ThreadUser::getIgnored($item['uri-id'], local_user());
-				$ignore = [
-					'do'        => DI::l10n()->t("ignore thread"),
-					'undo'      => DI::l10n()->t("unignore thread"),
-					'toggle'    => DI::l10n()->t("toggle ignore status"),
-					'classdo'   => $ignored ? "hidden" : "",
-					'classundo' => $ignored ? "" : "hidden",
-					'ignored'   => DI::l10n()->t('ignored'),
-				];
+				if ($item['mention'] || $ignored) {
+					$ignore = [
+						'do'        => DI::l10n()->t("ignore thread"),
+						'undo'      => DI::l10n()->t("unignore thread"),
+						'toggle'    => DI::l10n()->t("toggle ignore status"),
+						'classdo'   => $ignored ? "hidden" : "",
+						'classundo' => $ignored ? "" : "hidden",
+						'ignored'   => DI::l10n()->t('ignored'),
+					];
+				}
 
 				if ($conv->getProfileOwner() == local_user() && ($item['uid'] != 0)) {
 					if ($origin) {

--- a/view/theme/frio/theme.php
+++ b/view/theme/frio/theme.php
@@ -314,7 +314,7 @@ function frio_display_item(App $a, &$arr)
 		local_user()
 		&& local_user() == $arr['item']['uid']
 		&& $arr['item']['gravity'] == GRAVITY_PARENT
-		&& !$arr['item']['self'])
+		&& !$arr['item']['self'] && !$arr['item']['mention'])
 	{
 		$followThread = [
 			'menu'   => 'follow_thread',

--- a/view/theme/frio/theme.php
+++ b/view/theme/frio/theme.php
@@ -314,8 +314,9 @@ function frio_display_item(App $a, &$arr)
 		local_user()
 		&& local_user() == $arr['item']['uid']
 		&& $arr['item']['gravity'] == GRAVITY_PARENT
-		&& !$arr['item']['self'] && !$arr['item']['mention'])
-	{
+		&& !$arr['item']['self']
+		&& !$arr['item']['mention']
+	) {
 		$followThread = [
 			'menu'   => 'follow_thread',
 			'title'  => DI::l10n()->t('Follow Thread'),


### PR DESCRIPTION
"Follow thread" enables you to receive notifications for a thread without visibly participating. For technical reasons it is not possible to unfollow. So to avoid confusion, the "follow thread" menu item now isn't displayed when you already are participating in the thread.