### PR TITLE
Avoid notice "Undefined index: author-name" in Diaspora delivery

### DIFF
--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -94,9 +94,9 @@ class Item
 			'private', 'title', 'body', 'raw-body', 'location', 'coord', 'app',
 			'inform', 'deleted', 'extid', 'post-type', 'gravity',
 			'allow_cid', 'allow_gid', 'deny_cid', 'deny_gid',
-			'author-id', 'author-link', 'owner-id', 'owner-link', 'contact-uid',
+			'author-id', 'author-link', 'author-name', 'author-avatar', 'owner-id', 'owner-link', 'contact-uid',
 			'signed_text', 'network', 'wall', 'contact-id', 'plink', 'forum_mode', 'origin',
-			'thr-parent-id', 'parent-uri-id', 'postopts', 'pubmail', 
+			'thr-parent-id', 'parent-uri-id', 'postopts', 'pubmail',
 			'event-created', 'event-edited', 'event-start', 'event-finish',
 			'event-summary', 'event-desc', 'event-location', 'event-type',
 			'event-nofinish', 'event-adjust', 'event-ignore', 'event-id'];


### PR DESCRIPTION
This avoids two notices and a fatal error:
```
PHP Fatal error:  Uncaught TypeError: Argument 1 passed to Friendica\Content\Text\BBCode::getShareOpeningTag() must be of the type string, null given, called in /src/Protocol/Diaspora.php on line 3401 and defined in /src/Content/Text/BBCode.php:2201
Mar  6 13:29:36 pro-ite php: PHP Notice:  Undefined index: author-name in /src/Protocol/Diaspora.php on line 3400
Mar  6 13:29:36 pro-ite php: PHP Notice:  Undefined index: author-avatar in /src/Protocol/Diaspora.php on line 3400
```