### PR TITLE
Issue 9968: Avoid blocking update calls

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -1,6 +1,6 @@
 -- ------------------------------------------
 -- Friendica 2021.03-rc (Red Hot Poker)
--- DB_UPDATE_VERSION 1408
+-- DB_UPDATE_VERSION 1409
 -- ------------------------------------------
 
 
@@ -186,6 +186,7 @@ CREATE TABLE IF NOT EXISTS `contact` (
 	 INDEX `blocked_uid` (`blocked`,`uid`),
 	 INDEX `uid_rel_network_poll` (`uid`,`rel`,`network`,`poll`(64),`archive`),
 	 INDEX `uid_network_batch` (`uid`,`network`,`batch`(64)),
+	 INDEX `batch_contact-type` (`batch`(64),`contact-type`),
 	 INDEX `addr_uid` (`addr`(128),`uid`),
 	 INDEX `nurl_uid` (`nurl`(128),`uid`),
 	 INDEX `nick_uid` (`nick`(128),`uid`),

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -855,7 +855,9 @@ class Contact
 		if (!empty($contact['batch']) && !empty($contact['term-date']) && ($contact['term-date'] > DBA::NULL_DATETIME)) {
 			$fields = ['failed' => false, 'term-date' => DBA::NULL_DATETIME, 'archive' => false];
 			$condition = ['uid' => 0, 'network' => Protocol::FEDERATED, 'batch' => $contact['batch'], 'contact-type' => self::TYPE_RELAY];
-			DBA::update('contact', $fields, $condition);
+			if (!DBA::exists('contact', array_merge($condition, $fields))) {
+				DBA::update('contact', $fields, $condition);
+			}
 		}
 
 		$condition = ['`id` = ? AND (`term-date` > ? OR `archive`)', $contact['id'], DBA::NULL_DATETIME];

--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -55,7 +55,7 @@
 use Friendica\Database\DBA;
 
 if (!defined('DB_UPDATE_VERSION')) {
-	define('DB_UPDATE_VERSION', 1408);
+	define('DB_UPDATE_VERSION', 1409);
 }
 
 return [
@@ -245,6 +245,7 @@ return [
 			"blocked_uid" => ["blocked", "uid"],
 			"uid_rel_network_poll" => ["uid", "rel", "network", "poll(64)", "archive"],
 			"uid_network_batch" => ["uid", "network", "batch(64)"],
+			"batch_contact-type" => ["batch(64)", "contact-type"],
 			"addr_uid" => ["addr(128)", "uid"],
 			"nurl_uid" => ["nurl(128)", "uid"],
 			"nick_uid" => ["nick(128)", "uid"],


### PR DESCRIPTION
Fixes #9968 with the help of a new index and checking before updating, so that it reduces the times the contact table is locked at all.