### PR TITLE
Don't check for table_open_cache when pdo_emulate_prepares is activated

### DIFF
--- a/src/Module/Admin/Summary.php
+++ b/src/Module/Admin/Summary.php
@@ -63,12 +63,14 @@ class Summary extends BaseAdmin
 		}
 
 		// Avoid the database error 1615 "Prepared statement needs to be re-prepared", see https://github.com/friendica/friendica/issues/8550
-		$table_definition_cache = DBA::getVariable('table_definition_cache');
-		$table_open_cache = DBA::getVariable('table_open_cache');
-		if (!empty($table_definition_cache) && !empty($table_open_cache)) {
-			$suggested_definition_cache = min(400 + round($table_open_cache / 2, 1), 2000);
-			if ($suggested_definition_cache > $table_definition_cache) {
-				$warningtext[] = DI::l10n()->t('Your table_definition_cache is too low (%d). This can lead to the database error "Prepared statement needs to be re-prepared". Please set it at least to %d (or -1 for autosizing). See <a href="%s">here</a> for more information.<br />', $table_definition_cache, $suggested_definition_cache, 'https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_table_definition_cache');
+		if (!DI::config()->get('database', 'pdo_emulate_prepares')) {
+			$table_definition_cache = DBA::getVariable('table_definition_cache');
+			$table_open_cache = DBA::getVariable('table_open_cache');
+			if (!empty($table_definition_cache) && !empty($table_open_cache)) {
+				$suggested_definition_cache = min(400 + round($table_open_cache / 2, 1), 2000);
+				if ($suggested_definition_cache > $table_definition_cache) {
+					$warningtext[] = DI::l10n()->t('Your table_definition_cache is too low (%d). This can lead to the database error "Prepared statement needs to be re-prepared". Please set it at least to %d. See <a href="%s">here</a> for more information.<br />', $table_definition_cache, $suggested_definition_cache, 'https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_table_definition_cache');
+				}
 			}
 		}
 


### PR DESCRIPTION
The problem with the "table_open_cache" only exists when "pdo_emulate_prepares" isn't activated, so we don't need to check it when it is activated.