### PR TITLE
issue 9996: "bd" cannot be ""

### DIFF
--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -2579,13 +2579,14 @@ class Contact
 	public static function updateBirthdays()
 	{
 		$condition = [
-			'`bd` > "0001-01-01"
+			'`bd` > ?
 			AND (`contact`.`rel` = ? OR `contact`.`rel` = ?)
 			AND NOT `contact`.`pending`
 			AND NOT `contact`.`hidden`
 			AND NOT `contact`.`blocked`
 			AND NOT `contact`.`archive`
 			AND NOT `contact`.`deleted`',
+			DBA::NULL_DATE,
 			self::SHARING,
 			self::FRIEND
 		];

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -2579,9 +2579,7 @@ class Contact
 	public static function updateBirthdays()
 	{
 		$condition = [
-			'`bd` != ""
-			AND `bd` > "0001-01-01"
-			AND SUBSTRING(`bd`, 1, 4) != `bdyear`
+			'`bd` > "0001-01-01"
 			AND (`contact`.`rel` = ? OR `contact`.`rel` = ?)
 			AND NOT `contact`.`pending`
 			AND NOT `contact`.`hidden`


### PR DESCRIPTION
Fixes #9996

The field "bd" is a date field. MySQL is right about complaining that "" is no valid value.