### PR TITLE
Add setting for proxy file chmod value

### DIFF
--- a/src/Module/Proxy.php
+++ b/src/Module/Proxy.php
@@ -131,7 +131,9 @@ class Proxy extends BaseModule
 		// Store original image
 		if ($direct_cache) {
 			// direct cache , store under ./proxy/
-			file_put_contents($basepath . '/proxy/' . ProxyUtils::proxifyUrl($request['url'], true), $image->asString());
+			$filename = $basepath . '/proxy/' . ProxyUtils::proxifyUrl($request['url'], true)
+			file_put_contents($filename, $image->asString());
+			chmod($filename, DI::config()->get('system', 'proxy_file_chmod', 0640));
 		} elseif($cachefile !== '') {
 			// cache file
 			file_put_contents($cachefile, $image->asString());
@@ -149,7 +151,9 @@ class Proxy extends BaseModule
 
 		// Store scaled image
 		if ($direct_cache && $request['sizetype'] != '') {
-			file_put_contents($basepath . '/proxy/' . ProxyUtils::proxifyUrl($request['url'], true) . $request['sizetype'], $image->asString());
+			$filename = $basepath . '/proxy/' . ProxyUtils::proxifyUrl($request['url'], true) . $request['sizetype'];
+			file_put_contents($filename, $image->asString());
+			chmod($filename, DI::config()->get('system', 'proxy_file_chmod', 0640));
 		}
 
 		self::responseImageHttpCache($image);

--- a/src/Module/Proxy.php
+++ b/src/Module/Proxy.php
@@ -133,7 +133,7 @@ class Proxy extends BaseModule
 			// direct cache , store under ./proxy/
 			$filename = $basepath . '/proxy/' . ProxyUtils::proxifyUrl($request['url'], true);
 			file_put_contents($filename, $image->asString());
-			chmod($filename, DI::config()->get('system', 'proxy_file_chmod', 0640));
+			chmod($filename, DI::config()->get('system', 'proxy_file_chmod'));
 		} elseif($cachefile !== '') {
 			// cache file
 			file_put_contents($cachefile, $image->asString());
@@ -153,7 +153,7 @@ class Proxy extends BaseModule
 		if ($direct_cache && $request['sizetype'] != '') {
 			$filename = $basepath . '/proxy/' . ProxyUtils::proxifyUrl($request['url'], true) . $request['sizetype'];
 			file_put_contents($filename, $image->asString());
-			chmod($filename, DI::config()->get('system', 'proxy_file_chmod', 0640));
+			chmod($filename, DI::config()->get('system', 'proxy_file_chmod'));
 		}
 
 		self::responseImageHttpCache($image);

--- a/src/Module/Proxy.php
+++ b/src/Module/Proxy.php
@@ -131,7 +131,7 @@ class Proxy extends BaseModule
 		// Store original image
 		if ($direct_cache) {
 			// direct cache , store under ./proxy/
-			$filename = $basepath . '/proxy/' . ProxyUtils::proxifyUrl($request['url'], true)
+			$filename = $basepath . '/proxy/' . ProxyUtils::proxifyUrl($request['url'], true);
 			file_put_contents($filename, $image->asString());
 			chmod($filename, DI::config()->get('system', 'proxy_file_chmod', 0640));
 		} elseif($cachefile !== '') {

--- a/static/defaults.config.php
+++ b/static/defaults.config.php
@@ -570,6 +570,10 @@ return [
 		// xrd_timeout (Integer)
 		// Timeout in seconds for fetching the XRD links.
 		'xrd_timeout' => 20,
+
+		// proxy_file_chmod (Integer)
+		// Access rights for downloaded files in /proxy/ directory
+		'proxy_file_chmod' => 0640,
 	],
 	'experimental' => [
 		// exp_themes (Boolean)


### PR DESCRIPTION
Closes #10020

Added ability to set chmod (default: 0640) for "proxified" files (downloaded to `/proxy/` directory). This allows customization, e.g. if people want 0600 instead without changing the code.