### PR TITLE
Add security.txt file

### DIFF
--- a/security.txt
+++ b/security.txt
@@ -1,0 +1,9 @@
+Contact: mailto:info@friendi.ca
+
+Expires: Wed, 30 Jun 2021 23:59 +0000
+
+Preferred-Languages: en
+
+Canonical: https://git.friendi.ca/friendica/friendica/raw/branch/stable/security.txt
+
+Policy: https://friendi.ca/security-policy/

--- a/src/Module/WellKnown/SecurityTxt.php
+++ b/src/Module/WellKnown/SecurityTxt.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * @copyright Copyright (C) 2020, Friendica
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Friendica\Module\WellKnown;
+
+use Friendica\BaseModule;
+
+/**
+ * Standardized way of exposing metadata about the project security policy
+ * @see https://securitytxt.org
+ */
+class SecurityTxt extends BaseModule
+{
+	public static function rawContent(array $parameters = [])
+	{
+		$name = 'security.txt';
+		$fp = fopen($name, 'rt');
+
+		header('Content-type: text/plain; charset=utf-8');
+		header("Content-Length: " . filesize($name));
+
+		fpassthru($fp);
+		exit;
+	}
+}

--- a/static/routes.config.php
+++ b/static/routes.config.php
@@ -44,6 +44,7 @@ return [
 	'/.well-known' => [
 		'/host-meta'      => [Module\WellKnown\HostMeta::class,     [R::GET]],
 		'/nodeinfo'       => [Module\WellKnown\NodeInfo::class,     [R::GET]],
+		'/security.txt'   => [Module\WellKnown\SecurityTxt::class,  [R::GET]],
 		'/webfinger'      => [Module\Xrd::class,                    [R::GET]],
 		'/x-nodeinfo2'    => [Module\NodeInfo210::class,            [R::GET]],
 		'/x-social-relay' => [Module\WellKnown\XSocialRelay::class, [R::GET]],


### PR DESCRIPTION
See suggestion here: https://mordor.social/display/027b03f7-1860-46c1-88c0-d4f673509058

This PR adds both the `security.txt` file to the project repository and the `/.well-known/security.txt` route on all the Friendica nodes.

Nothing fancy, no PGP key, and a reference to a new page on the Friendi.ca website: https://friendi.ca/security-policy/