### PR TITLE
We now set the protocol in "gserver" on receiving as well

### DIFF
--- a/mod/pubsub.php
+++ b/mod/pubsub.php
@@ -25,11 +25,11 @@ use Friendica\Core\Protocol;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Contact;
-use Friendica\Protocol\Feed;
 use Friendica\Protocol\OStatus;
 use Friendica\Util\Strings;
 use Friendica\Util\Network;
-use Friendica\Core\System;
+use Friendica\Model\GServer;
+use Friendica\Model\Post;
 
 function hub_return($valid, $body)
 {
@@ -132,6 +132,10 @@ function pubsub_post(App $a)
 			Logger::log('Contact ' . $author["author-link"] . ' (' . $contact_id . ') for user ' . $nick . " wasn't found - ignored. XML: " . $xml);
 			hub_post_return();
 		}
+	}
+
+	if (!empty($contact['gsid'])) {
+		GServer::setProtocol($contact['gsid'], Post\DeliveryData::OSTATUS);
 	}
 
 	if (!in_array($contact['rel'], [Contact::SHARING, Contact::FRIEND]) && ($contact['network'] != Protocol::FEED)) {

--- a/mod/salmon.php
+++ b/mod/salmon.php
@@ -25,6 +25,8 @@ use Friendica\Core\Protocol;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Contact;
+use Friendica\Model\GServer;
+use Friendica\Model\Post;
 use Friendica\Protocol\ActivityNamespace;
 use Friendica\Protocol\OStatus;
 use Friendica\Protocol\Salmon;
@@ -183,6 +185,10 @@ function salmon_post(App $a, $xml = '') {
 				);
 			}
 		}
+	}
+
+	if (!empty($r[0]['gsid'])) {
+		GServer::setProtocol($r[0]['gsid'], Post\DeliveryData::OSTATUS);
 	}
 
 	// Have we ignored the person?

--- a/src/Model/GServer.php
+++ b/src/Model/GServer.php
@@ -1793,7 +1793,7 @@ class GServer
 			}
 		}
 
-		Logger::info('Protocol for server', ['protocol' => $protocol, 'old' => $old, 'id' => $gsid, 'url' => $gserver['url']]);
+		Logger::info('Protocol for server', ['protocol' => $protocol, 'old' => $old, 'id' => $gsid, 'url' => $gserver['url'], 'callstack' => System::callstack(20)]);
 		DBA::update('gserver', ['protocol' => $protocol], ['id' => $gsid]);
 	}
 

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -33,6 +33,7 @@ use Friendica\Model\APContact;
 use Friendica\Model\Contact;
 use Friendica\Model\Conversation;
 use Friendica\Model\Event;
+use Friendica\Model\GServer;
 use Friendica\Model\Item;
 use Friendica\Model\ItemURI;
 use Friendica\Model\Mail;
@@ -366,6 +367,19 @@ class Processor
 		$item['plink'] = $activity['alternate-url'] ?? $item['uri'];
 
 		$item = self::constructAttachList($activity, $item);
+
+		// We received the post via AP, so we set the protocol of the server to AP
+		$contact = Contact::getById($item['author-id'], ['gsid']);
+		if (!empty($contact['gsid'])) {
+			GServer::setProtocol($contact['gsid'], Post\DeliveryData::ACTIVITYPUB);
+		}
+
+		if ($item['author-id'] != $item['owner-id']) {
+			$contact = Contact::getById($item['owner-id'], ['gsid']);
+			if (!empty($contact['gsid'])) {
+				GServer::setProtocol($contact['gsid'], Post\DeliveryData::ACTIVITYPUB);
+			}
+		}
 
 		return $item;
 	}

--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -34,6 +34,7 @@ use Friendica\Model\Contact;
 use Friendica\Model\Conversation;
 use Friendica\Model\Event;
 use Friendica\Model\FContact;
+use Friendica\Model\GServer;
 use Friendica\Model\Item;
 use Friendica\Model\ItemURI;
 use Friendica\Model\Mail;
@@ -2603,6 +2604,14 @@ class DFRN
 		}
 
 		Logger::log("Import DFRN message for user " . $importer["importer_uid"] . " from contact " . $importer["id"], Logger::DEBUG);
+
+		if (!empty($importer['gsid'])) {
+			if ($protocol == Conversation::PARCEL_DIASPORA_DFRN) {
+				GServer::setProtocol($importer['gsid'], Post\DeliveryData::DFRN);
+			} elseif ($protocol == Conversation::PARCEL_LEGACY_DFRN) {
+				GServer::setProtocol($importer['gsid'], Post\DeliveryData::LEGACY_DFRN);
+			}
+		}
 
 		// is it a public forum? Private forums aren't exposed with this method
 		$forum = intval(XML::getFirstNodeValue($xpath, "/atom:feed/dfrn:community/text()"));

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -35,6 +35,7 @@ use Friendica\DI;
 use Friendica\Model\Contact;
 use Friendica\Model\Conversation;
 use Friendica\Model\FContact;
+use Friendica\Model\GServer;
 use Friendica\Model\Item;
 use Friendica\Model\ItemURI;
 use Friendica\Model\Mail;
@@ -1498,6 +1499,10 @@ class Diaspora
 			return false;
 		}
 
+		if (!empty($contact['gsid'])) {
+			GServer::setProtocol($contact['gsid'], Post\DeliveryData::DIASPORA);
+		}
+
 		$message_id = self::messageExists($importer["uid"], $guid);
 		if ($message_id) {
 			return true;
@@ -1682,6 +1687,10 @@ class Diaspora
 			return false;
 		}
 
+		if (!empty($contact['gsid'])) {
+			GServer::setProtocol($contact['gsid'], Post\DeliveryData::DIASPORA);
+		}
+
 		$conversation = DBA::selectFirst('conv', [], ['uid' => $importer["uid"], 'guid' => $guid]);
 		if (!DBA::isResult($conversation)) {
 			$r = q(
@@ -1739,6 +1748,10 @@ class Diaspora
 		$contact = self::allowedContactByHandle($importer, $sender, true);
 		if (!$contact) {
 			return false;
+		}
+
+		if (!empty($contact['gsid'])) {
+			GServer::setProtocol($contact['gsid'], Post\DeliveryData::DIASPORA);
 		}
 
 		$message_id = self::messageExists($importer["uid"], $guid);
@@ -1851,6 +1864,10 @@ class Diaspora
 			return false;
 		}
 
+		if (!empty($contact['gsid'])) {
+			GServer::setProtocol($contact['gsid'], Post\DeliveryData::DIASPORA);
+		}
+
 		$conversation = null;
 
 		$condition = ['uid' => $importer["uid"], 'guid' => $conversation_guid];
@@ -1909,6 +1926,10 @@ class Diaspora
 		$contact = self::allowedContactByHandle($importer, $author, true);
 		if (!$contact) {
 			return false;
+		}
+
+		if (!empty($contact['gsid'])) {
+			GServer::setProtocol($contact['gsid'], Post\DeliveryData::DIASPORA);
 		}
 
 		if (self::messageExists($importer["uid"], $guid)) {
@@ -2407,6 +2428,10 @@ class Diaspora
 			return false;
 		}
 
+		if (!empty($contact['gsid'])) {
+			GServer::setProtocol($contact['gsid'], Post\DeliveryData::DIASPORA);
+		}
+
 		$message_id = self::messageExists($importer["uid"], $guid);
 		if ($message_id) {
 			return true;
@@ -2677,6 +2702,10 @@ class Diaspora
 		$contact = self::allowedContactByHandle($importer, $author, false);
 		if (!$contact) {
 			return false;
+		}
+
+		if (!empty($contact['gsid'])) {
+			GServer::setProtocol($contact['gsid'], Post\DeliveryData::DIASPORA);
 		}
 
 		$message_id = self::messageExists($importer["uid"], $guid);


### PR DESCRIPTION
The "protocol" field in the "gserver" table is used to determine the best protocol to deliver content. Currently we only set this field when we delivered content.

We now set this value also when we receive content