### PR TITLE
Trending tags are now sort by different users

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -1,6 +1,6 @@
 -- ------------------------------------------
 -- Friendica 2021.03-rc (Red Hot Poker)
--- DB_UPDATE_VERSION 1411
+-- DB_UPDATE_VERSION 1412
 -- ------------------------------------------
 
 
@@ -2231,6 +2231,7 @@ CREATE VIEW `tag-search-view` AS SELECT
 	`post-user`.`gravity` AS `gravity`,
 	`post-user`.`received` AS `received`,
 	`post-user`.`network` AS `network`,
+	`post-user`.`author-id` AS `author-id`,
 	`tag`.`name` AS `name`
 	FROM `post-tag`
 			INNER JOIN `tag` ON `tag`.`id` = `post-tag`.`tid`

--- a/src/Model/Tag.php
+++ b/src/Model/Tag.php
@@ -547,10 +547,10 @@ class Tag
 	{
 		$block_sql = self::getBlockedSQL();
 
-		$tagsStmt = DBA::p("SELECT `name` AS `term`, COUNT(*) AS `score`
+		$tagsStmt = DBA::p("SELECT `name` AS `term`, COUNT(*) AS `score`, COUNT(DISTINCT(`author-id`)) as `authors`
 			FROM `tag-search-view`
 			WHERE `private` = ? AND `uid` = ? AND `received` > DATE_SUB(NOW(), INTERVAL ? HOUR) $block_sql
-			GROUP BY `term` ORDER BY `score` DESC LIMIT ?",
+			GROUP BY `term` ORDER BY `authors` DESC, `score` DESC LIMIT ?",
 			Item::PUBLIC, 0, $period, $limit);
 
 		if (DBA::isResult($tagsStmt)) {
@@ -592,10 +592,10 @@ class Tag
 	{
 		$block_sql = self::getBlockedSQL();
 
-		$tagsStmt = DBA::p("SELECT `name` AS `term`, COUNT(*) AS `score`
+		$tagsStmt = DBA::p("SELECT `name` AS `term`, COUNT(*) AS `score`, COUNT(DISTINCT(`author-id`)) as `authors`
 			FROM `tag-search-view`
 			WHERE `private` = ? AND `wall` AND `origin` AND `received` > DATE_SUB(NOW(), INTERVAL ? HOUR) $block_sql
-			GROUP BY `term` ORDER BY `score` DESC LIMIT ?",
+			GROUP BY `term` ORDER BY `authors` DESC, `score` DESC LIMIT ?",
 			Item::PUBLIC, $period, $limit);
 
 		if (DBA::isResult($tagsStmt)) {

--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -55,7 +55,7 @@
 use Friendica\Database\DBA;
 
 if (!defined('DB_UPDATE_VERSION')) {
-	define('DB_UPDATE_VERSION', 1411);
+	define('DB_UPDATE_VERSION', 1412);
 }
 
 return [

--- a/static/dbview.config.php
+++ b/static/dbview.config.php
@@ -783,6 +783,7 @@
 			"gravity" => ["post-user", "gravity"],
 			"received" => ["post-user", "received"],
 			"network" => ["post-user", "network"],
+			"author-id" => ["post-user", "author-id"],
 			"name" => ["tag", "name"],
 		],
 		"query" => "FROM `post-tag`


### PR DESCRIPTION
The calculation for trending tags formerly simply was based on the numbers a tag had been used. This preferred bots that post a lot of posts with the same tags.

We now sort by the number of different users who used that tag. And only after this we sort by the number that tag is used.