### PR TITLE
Storage: small fixes to 'storage move'

### DIFF
--- a/src/Console/Storage.php
+++ b/src/Console/Storage.php
@@ -23,6 +23,7 @@ namespace Friendica\Console;
 
 use Asika\SimpleConsole\CommandArgsException;
 use Friendica\Core\StorageManager;
+use Friendica\Model\Storage\StorageException;
 
 /**
  * tool to manage storage backend and stored data from CLI
@@ -164,6 +165,10 @@ HELP;
 
 		$current = $this->storageManager->getBackend();
 		$total = 0;
+
+		if (is_null($current)) {
+			throw new StorageException(sprintf("Cannot move to legacy storage. Please select a storage backend."));
+		}
 
 		do {
 			$moved = $this->storageManager->move($current, $tables, $this->getOption('n', 5000));

--- a/src/Core/StorageManager.php
+++ b/src/Core/StorageManager.php
@@ -305,7 +305,7 @@ class StorageManager
 					$data = $source->get($sourceRef);
 				}
 
-				$this->logger->info('Save data to new backend.', ['newBackend' => $destination]);
+				$this->logger->info('Save data to new backend.', ['newBackend' => $destination::getName()]);
 				$destinationRef = $destination->put($data);
 				$this->logger->info('Saved data.', ['newReference' => $destinationRef]);
 


### PR DESCRIPTION
- stop command if current storage backend is still "legacy"
  show a nice message instead an exception about a null value passed to a function expecting IStorage)

- write destination backend name in log
  write `Save data to new backend. {"newBackend":"Database"}` instead of `Save data to new backend. {"newBackend":{}}` 