### PR TITLE
Only set file permissions when configured

### DIFF
--- a/src/Module/Proxy.php
+++ b/src/Module/Proxy.php
@@ -127,13 +127,16 @@ class Proxy extends BaseModule
 		}
 
 		$basepath = $a->getBasePath();
+		$filepermission = DI::config()->get('system', 'proxy_file_chmod');
 
 		// Store original image
 		if ($direct_cache) {
 			// direct cache , store under ./proxy/
 			$filename = $basepath . '/proxy/' . ProxyUtils::proxifyUrl($request['url'], true);
 			file_put_contents($filename, $image->asString());
-			chmod($filename, DI::config()->get('system', 'proxy_file_chmod'));
+			if (!empty($filepermission)) {
+				chmod($filename, $filepermission);
+			}
 		} elseif($cachefile !== '') {
 			// cache file
 			file_put_contents($cachefile, $image->asString());
@@ -153,7 +156,9 @@ class Proxy extends BaseModule
 		if ($direct_cache && $request['sizetype'] != '') {
 			$filename = $basepath . '/proxy/' . ProxyUtils::proxifyUrl($request['url'], true) . $request['sizetype'];
 			file_put_contents($filename, $image->asString());
-			chmod($filename, DI::config()->get('system', 'proxy_file_chmod'));
+			if (!empty($filepermission)) {
+				chmod($filename, $filepermission);
+			}
 		}
 
 		self::responseImageHttpCache($image);

--- a/static/defaults.config.php
+++ b/static/defaults.config.php
@@ -571,8 +571,8 @@ return [
 		// Timeout in seconds for fetching the XRD links.
 		'xrd_timeout' => 20,
 
-		// proxy_file_chmod (Octal Integer)
-		// Access rights for downloaded files in /proxy/ directory like 0640
+		// proxy_file_chmod (Octal Integer like 0640)
+		// If set, defines the files permissions for downloaded files in the /proxy/ directory, default is system-dependent
 		'proxy_file_chmod' => 0,
 	],
 	'experimental' => [

--- a/static/defaults.config.php
+++ b/static/defaults.config.php
@@ -571,9 +571,9 @@ return [
 		// Timeout in seconds for fetching the XRD links.
 		'xrd_timeout' => 20,
 
-		// proxy_file_chmod (Integer)
-		// Access rights for downloaded files in /proxy/ directory
-		'proxy_file_chmod' => 0640,
+		// proxy_file_chmod (Octal Integer)
+		// Access rights for downloaded files in /proxy/ directory like 0640
+		'proxy_file_chmod' => 0,
 	],
 	'experimental' => [
 		// exp_themes (Boolean)


### PR DESCRIPTION
Fixes https://forum.friendi.ca/display/b8bb205c-9960-4ca2-47bb-6d1906311534

Follow up to PR #10022

Now the permissions are only set when explicitely configured.
