### PR TITLE
Issue 10050: Ensure to not create contacts for expired users

### DIFF
--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -571,7 +571,8 @@ class Contact
 			return true;
 		}
 
-		$user = DBA::selectFirst('user', ['uid', 'username', 'nickname', 'pubkey', 'prvkey'], ['uid' => $uid]);
+		$user = DBA::selectFirst('user', ['uid', 'username', 'nickname', 'pubkey', 'prvkey'],
+			['uid' => $uid, 'account_expired' => false]);
 		if (!DBA::isResult($user)) {
 			return false;
 		}
@@ -624,7 +625,7 @@ class Contact
 		}
 
 		$fields = ['nickname', 'page-flags', 'account-type', 'prvkey', 'pubkey'];
-		$user = DBA::selectFirst('user', $fields, ['uid' => $uid]);
+		$user = DBA::selectFirst('user', $fields, ['uid' => $uid, 'account_expired' => false]);
 		if (!DBA::isResult($user)) {
 			return;
 		}

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -399,7 +399,7 @@ class User
 			return false;
 		}
 
-		if (!$repairMissing) {
+		if (!$repairMissing || $owner['account_expired']) {
 			return $owner;
 		}
 
@@ -1366,6 +1366,9 @@ class User
 		// save username (actually the nickname as it is guaranteed
 		// unique), so it cannot be re-registered in the future.
 		DBA::insert('userd', ['username' => $user['nickname']]);
+
+		// Remove all personal settings, especially connector settings
+		DBA::delete('pconfig', ['uid' => $uid]);
 
 		// The user and related data will be deleted in Friendica\Worker\ExpireAndRemoveUsers
 		DBA::update('user', ['account_removed' => true, 'account_expires_on' => DateTimeFormat::utc('now + 7 day')], ['uid' => $uid]);


### PR DESCRIPTION
This - again - tries to handle issue #10050. Possibly new contacts are added in the background during the deletion of the user in connectors like the Twitter connector or because of functions that are designed to heal missing data for users like a missing self contact.