### PR TITLE
Avoid foreign key violations

### DIFF
--- a/src/Worker/MergeContact.php
+++ b/src/Worker/MergeContact.php
@@ -24,7 +24,6 @@ namespace Friendica\Worker;
 use Friendica\Core\Logger;
 use Friendica\Database\DBA;
 use Friendica\Database\DBStructure;
-use Friendica\Model\Post;
 
 class MergeContact
 {
@@ -44,29 +43,25 @@ class MergeContact
 
 		Logger::info('Handling duplicate', ['search' => $old_cid, 'replace' => $new_cid]);
 
-		// Search and replace
-		Post::update(['contact-id' => $new_cid], ['contact-id' => $old_cid]);
+		foreach (['item', 'thread', 'post-user', 'post-thread-user'] as $table) {
+			if (DBStructure::existsTable($table)) {
+				DBA::update($table, ['contact-id' => $new_cid], ['contact-id' => $old_cid]);
+			}
+		}
 		DBA::update('mail', ['contact-id' => $new_cid], ['contact-id' => $old_cid]);
 		DBA::update('photo', ['contact-id' => $new_cid], ['contact-id' => $old_cid]);
 		DBA::update('event', ['cid' => $new_cid], ['cid' => $old_cid]);
-		if (DBStructure::existsTable('item')) {
-			DBA::update('item', ['contact-id' => $new_cid], ['contact-id' => $old_cid]);
-		}
-		if (DBStructure::existsTable('thread')) {
-			DBA::update('thread', ['contact-id' => $new_cid], ['contact-id' => $old_cid]);
-		}
 
 		// These fields only contain public contact entries (uid = 0)
 		if ($uid == 0) {
 			DBA::update('post-tag', ['cid' => $new_cid], ['cid' => $old_cid]);
 			DBA::delete('post-tag', ['cid' => $old_cid]);
-			Post::update(['author-id' => $new_cid], ['author-id' => $old_cid]);
-			Post::update(['owner-id' => $new_cid], ['owner-id' => $old_cid]);
-			Post::update(['causer-id' => $new_cid], ['causer-id' => $old_cid]);
-			if (DBStructure::existsTable('item')) {
-				DBA::update('item', ['author-id' => $new_cid], ['author-id' => $old_cid]);
-				DBA::update('item', ['owner-id' => $new_cid], ['owner-id' => $old_cid]);
-				DBA::update('item', ['causer-id' => $new_cid], ['causer-id' => $old_cid]);
+			foreach (['item', 'post', 'post-thread', 'post-user', 'post-thread-user'] as $table) {
+				if (DBStructure::existsTable($table)) {
+					DBA::update($table, ['author-id' => $new_cid], ['author-id' => $old_cid]);
+					DBA::update($table, ['owner-id' => $new_cid], ['owner-id' => $old_cid]);
+					DBA::update($table, ['causer-id' => $new_cid], ['causer-id' => $old_cid]);
+				}
 			}
 			if (DBStructure::existsTable('thread')) {
 				DBA::update('thread', ['author-id' => $new_cid], ['author-id' => $old_cid]);


### PR DESCRIPTION
Avoid errors like 

```
DB Error {"code":1451,"error":"Cannot delete or update a parent row: a foreign key constraint fails (`piratica`.`post`, CONSTRAINT `post_ibfk_4` FOREIGN KEY (`owner-id`) REFERENCES `contact` (`id`))"
```