### PR TITLE
Don't automatically post hashtags when sharing links

### DIFF
--- a/mod/item.php
+++ b/mod/item.php
@@ -221,6 +221,7 @@ function item_post(App $a) {
 
 		// Fetch the basic attachment data
 		$attachment = ParseUrl::getSiteinfoCached($attachment_url);
+		unset($attachment['keywords']);
 
 		// Overwrite the basic data with possible changes from the frontend
 		$attachment['type'] = $attachment_type;


### PR DESCRIPTION
We now fetch all data from a link when sharing it - but we shouldn't share the hashtags.