### PR TITLE
Fixes PHP Warning: " array_unshift() expects parameter 1 to be array, int given"

### DIFF
--- a/src/Core/Worker.php
+++ b/src/Core/Worker.php
@@ -311,6 +311,10 @@ class Worker
 		}
 
 		$argv = json_decode($queue['parameter'], true);
+		if (!is_array($argv)) {
+			$argv = [];
+		}
+
 		if (!empty($queue['command'])) {
 			array_unshift($argv, $queue['command']);
 		}


### PR DESCRIPTION
Fixes `PHP Warning:  array_unshift() expects parameter 1 to be array, int given in /src/Core/Worker.php on line 315`