### PR TITLE
Limit the size of contact avatars

### DIFF
--- a/src/Model/Photo.php
+++ b/src/Model/Photo.php
@@ -464,7 +464,7 @@ class Photo
 			$maximagesize = DI::config()->get('system', 'maximagesize');
 			if (!empty($maximagesize) && ($filesize > $maximagesize)) {
 				Logger::info('Avatar exceeds image limit', ['uid' => $uid, 'cid' => $cid, 'maximagesize' => $maximagesize, 'size' => $filesize, 'type' => $Image->getType()]);
-				if (($Image->getType() == 'image/gif')) {
+				if ($Image->getType() == 'image/gif') {
 					$Image->toStatic();
 					$Image = new Image($Image->asString(), 'image/png');
 

--- a/src/Object/Image.php
+++ b/src/Object/Image.php
@@ -576,6 +576,21 @@ class Image
 	}
 
 	/**
+	 * Convert a GIF to a PNG to make it static
+	 */
+	public function toStatic()
+	{
+		if ($this->type != 'image/gif') {
+			return;
+		}
+
+		if ($this->isImagick()) {
+			$this->type == 'image/png';
+			$this->image->setFormat('png');
+		}
+	}
+
+	/**
 	 * @param integer $max maximum
 	 * @param integer $x   x coordinate
 	 * @param integer $y   y coordinate


### PR DESCRIPTION
Some people seem to tend to put whole movies in their avatars. This can exceed the packet size of the database connection and is just a waste of space.

So we now handle this situation by converting it to a PNG or by resizing it.