### PR TITLE
Deletions are now done via DFRN as well

### DIFF
--- a/src/Worker/Notifier.php
+++ b/src/Worker/Notifier.php
@@ -519,7 +519,9 @@ class Notifier
 				$contact['network'] = Protocol::DFRN;
 			}
 
-			if (in_array($contact['id'], $ap_contacts)) {
+			// Deletions are always sent via DFRN as well.
+			// This is done until we can perform deletions of foreign comments on our own threads via AP.
+			if (($cmd != Delivery::DELETION) && in_array($contact['id'], $ap_contacts)) {
 				Logger::info('Contact is already delivered via AP, so skip delivery via legacy DFRN/Diaspora', ['target' => $post_uriid, 'uid' => $sender_uid, 'contact' => $contact['url']]);
 				continue;
 			}


### PR DESCRIPTION
On AP we currently can only delete our own posts/comments but not other comments on our own threads.

So for this task we will still use DFRN as well.