### PR TITLE
Use the "post-user" table instead of the "post" table for deletion checks

### DIFF
--- a/src/Worker/ExpirePosts.php
+++ b/src/Worker/ExpirePosts.php
@@ -178,10 +178,10 @@ class ExpirePosts
 		}
 		Logger::notice('Start collecting orphaned URI-ID', ['last-id' => $item['uri-id']]);
 		$uris = DBA::select('item-uri', ['id'], ["`id` < ?
-			AND NOT EXISTS(SELECT `uri-id` FROM `post` WHERE `uri-id` = `item-uri`.`id`)
-			AND NOT EXISTS(SELECT `parent-uri-id` FROM `post` WHERE `parent-uri-id` = `item-uri`.`id`)
-			AND NOT EXISTS(SELECT `thr-parent-id` FROM `post` WHERE `thr-parent-id` = `item-uri`.`id`)
-			AND NOT EXISTS(SELECT `external-id` FROM `post` WHERE `external-id` = `item-uri`.`id`)", $item['uri-id']]);
+			AND NOT EXISTS(SELECT `uri-id` FROM `post-user` WHERE `uri-id` = `item-uri`.`id`)
+			AND NOT EXISTS(SELECT `parent-uri-id` FROM `post-user` WHERE `parent-uri-id` = `item-uri`.`id`)
+			AND NOT EXISTS(SELECT `thr-parent-id` FROM `post-user` WHERE `thr-parent-id` = `item-uri`.`id`)
+			AND NOT EXISTS(SELECT `external-id` FROM `post-user` WHERE `external-id` = `item-uri`.`id`)", $item['uri-id']]);
 
 		Logger::notice('Start deleting orphaned URI-ID', ['last-id' => $item['uri-id']]);
 		$affected_count = 0;


### PR DESCRIPTION
Until now we used the "post" table for checks if "item-uri" entries can be deleted. Normally this shouldn't be a problem since for every entry in the "post" table there should be some in the "post-user" table as well. But when there had been technical issues (like discussed in the thread https://opensocial.at/display/59c238fc-6160-5d19-fd02-bee363705966) this can could delete your "post-user" entries.