### PR TITLE
Force exception conversion to string when logging

### DIFF
--- a/src/Factory/LockFactory.php
+++ b/src/Factory/LockFactory.php
@@ -100,7 +100,7 @@ class LockFactory
 					return self::useAutoDriver();
 			}
 		} catch (\Exception $exception) {
-			$this->logger->alert('Driver \'' . $lock_type . '\' failed - Fallback to \'useAutoDriver()\'', ['exception' => $exception]);
+			$this->logger->alert('Driver \'' . $lock_type . '\' failed - Fallback to \'useAutoDriver()\'', ['exception' => $exception->__toString()]);
 			return self::useAutoDriver();
 		}
 	}
@@ -122,7 +122,7 @@ class LockFactory
 			try {
 				return new Lock\SemaphoreLock();
 			} catch (\Exception $exception) {
-				$this->logger->warning('Using Semaphore driver for locking failed.', ['exception' => $exception]);
+				$this->logger->warning('Using Semaphore driver for locking failed.', ['exception' => $exception->__toString()]);
 			}
 		}
 
@@ -135,7 +135,7 @@ class LockFactory
 					return new Lock\CacheLock($cache);
 				}
 			} catch (\Exception $exception) {
-				$this->logger->warning('Using Cache driver for locking failed.', ['exception' => $exception]);
+				$this->logger->warning('Using Cache driver for locking failed.', ['exception' => $exception->__toString()]);
 			}
 		}
 

--- a/src/Factory/Notification/Introduction.php
+++ b/src/Factory/Notification/Introduction.php
@@ -180,7 +180,7 @@ class Introduction extends BaseFactory
 				}
 			}
 		} catch (Exception $e) {
-			$this->logger->warning('Select failed.', ['uid' => $_SESSION['uid'], 'exception' => $e]);
+			$this->logger->warning('Select failed.', ['uid' => $_SESSION['uid'], 'exception' => $e->__toString()]);
 		}
 
 		return $formattedNotifications;

--- a/src/Factory/Notification/Notification.php
+++ b/src/Factory/Notification/Notification.php
@@ -247,7 +247,7 @@ class Notification extends BaseFactory
 					'seen'  => $notification->seen]);
 			}
 		} catch (Exception $e) {
-			$this->logger->warning('Select failed.', ['conditions' => $conditions, 'exception' => $e]);
+			$this->logger->warning('Select failed.', ['conditions' => $conditions, 'exception' => $e->__toString()]);
 		}
 
 		return $formattedNotifications;
@@ -284,7 +284,7 @@ class Notification extends BaseFactory
 				$formattedNotifications[] = $this->createFromItem($item);
 			}
 		} catch (Exception $e) {
-			$this->logger->warning('Select failed.', ['conditions' => $conditions, 'exception' => $e]);
+			$this->logger->warning('Select failed.', ['conditions' => $conditions, 'exception' => $e->__toString()]);
 		}
 
 		return $formattedNotifications;
@@ -321,7 +321,7 @@ class Notification extends BaseFactory
 				$formattedNotifications[] = $this->createFromItem($item);
 			}
 		} catch (Exception $e) {
-			$this->logger->warning('Select failed.', ['conditions' => $condition, 'exception' => $e]);
+			$this->logger->warning('Select failed.', ['conditions' => $condition, 'exception' => $e->__toString()]);
 		}
 
 		return $formattedNotifications;
@@ -364,7 +364,7 @@ class Notification extends BaseFactory
 				$formattedNotifications[] = $this->createFromItem($item);
 			}
 		} catch (Exception $e) {
-			$this->logger->warning('Select failed.', ['conditions' => $condition, 'exception' => $e]);
+			$this->logger->warning('Select failed.', ['conditions' => $condition, 'exception' => $e->__toString()]);
 		}
 
 		return $formattedNotifications;

--- a/src/Module/Notifications/Notification.php
+++ b/src/Module/Notifications/Notification.php
@@ -80,7 +80,7 @@ class Notification extends BaseModule
 			try {
 				$success = DI::notify()->setSeen();
 			} catch (\Exception $e) {
-				DI::logger()->warning('set all seen failed.', ['exception' => $e]);
+				DI::logger()->warning('set all seen failed.', ['exception' => $e->__toString()]);
 				$success = false;
 			}
 

--- a/src/Util/EMailer/MailBuilder.php
+++ b/src/Util/EMailer/MailBuilder.php
@@ -121,7 +121,7 @@ abstract class MailBuilder
 		try {
 			$this->l10n = $user['language'] ? $this->l10n->withLang($user['language']) : $this->l10n;
 		} catch (Exception $e) {
-			$this->logger->warning('cannot use language.', ['user' => $user, 'exception' => $e]);
+			$this->logger->warning('cannot use language.', ['user' => $user, 'exception' => $e->__toString()]);
 		}
 
 		return $this;


### PR DESCRIPTION
When exception is passed to logger data is not serialized by which I think is `json_encode`, resulting in a series of useless log like 

    [...]'exception': {}

this patch force conversion to string on every exception which is passed to logging functions.
(a similar PR for addons will follow)