### PR TITLE
Issue 4755: Use the system mail address as sender

### DIFF
--- a/src/Module/Invite.php
+++ b/src/Module/Invite.php
@@ -95,8 +95,7 @@ class Invite extends BaseModule
 				$nmessage = $message;
 			}
 
-			$additional_headers = 'From: ' . $app->user['email'] . "\n"
-				. 'Sender: ' . DI::emailer()->getSiteEmailAddress() . "\n"
+			$additional_headers = 'From: "' . $app->user['email'] . '" <' . DI::emailer()->getSiteEmailAddress() . ">\n"
 				. 'Content-type: text/plain; charset=UTF-8' . "\n"
 				. 'Content-transfer-encoding: 8bit';
 


### PR DESCRIPTION
Possibly fixes #4755

The problem is that most mail servers now reject mails when the sending mail server isn't in the list of allowed mail servers for the "from" mail address.

So we now use the system mail address that hopefully will be accepted.