### PR TITLE
Fix the display of mentions on Pleroma

### DIFF
--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -1330,7 +1330,7 @@ class Transmitter
 			return $match[0];
 		}
 
-		return '[url=' . ($data['alias'] ?: $data['url']) . ']@' . $data['nick'] . '[/url]';
+		return '[url=' . $data['url'] . ']@' . $data['nick'] . '[/url]';
 	}
 
 	/**


### PR DESCRIPTION
On Pleroma the links are followed by a text showing the hostname of that link. This happened for mentions as well - which shouldn't be the case.
![Bildschirmfoto vom 2021-03-27 23-57-41](https://user-images.githubusercontent.com/844208/112737126-663b7a00-8f58-11eb-9a08-e669ef1b2139.png)

It happened because we used the content of the "alias" field of the contact if that was filled. But this link differed from the profile link, so it seems that this triggered the displaying of the hostname.

Now it looks okay:
![Bildschirmfoto vom 2021-03-27 23-58-05](https://user-images.githubusercontent.com/844208/112737135-73586900-8f58-11eb-9d13-d99e65df15be.png)
