### PR TITLE
ParseUrl: Remove image when it doesn't fit the requirements

### DIFF
--- a/src/Util/ParseUrl.php
+++ b/src/Util/ParseUrl.php
@@ -524,7 +524,11 @@ class ParseUrl
 						$image['contenttype'] = $photodata['mime'];
 						unset($image['url']);
 						ksort($image);
+					} else {
+						$image = [];
 					}
+				} else {
+					$image = [];
 				}
 			});
 


### PR DESCRIPTION
We don't want to keep a photo when it is too small or invalid.