### PR TITLE
Fix object handling inside log arrays

### DIFF
--- a/src/Util/Logger/AbstractLogger.php
+++ b/src/Util/Logger/AbstractLogger.php
@@ -104,6 +104,28 @@ abstract class AbstractLogger implements LoggerInterface
 	}
 
 	/**
+	 * JSON Encodes an complete array including objects with "__toString()" methods
+	 *
+	 * @param array $input an Input Array to encode
+	 *
+	 * @return false|string The json encoded output of the array
+	 */
+	protected function jsonEncodeArray(array $input)
+	{
+		$output = [];
+
+		foreach ($input as $key => $value) {
+			if (method_exists($value, '__toString')) {
+				$output[$key] = $value->__toString();
+			} else {
+				$output[$key] = $value;
+			}
+		}
+
+		return @json_encode($output);
+	}
+
+	/**
 	 * {@inheritdoc}
 	 */
 	public function emergency($message, array $context = array())

--- a/src/Util/Logger/StreamLogger.php
+++ b/src/Util/Logger/StreamLogger.php
@@ -161,8 +161,8 @@ class StreamLogger extends AbstractLogger
 		$logMessage .= $this->channel . ' ';
 		$logMessage .= '[' . strtoupper($level) . ']: ';
 		$logMessage .= $this->psrInterpolate($message, $context) . ' ';
-		$logMessage .= @json_encode($context) . ' - ';
-		$logMessage .= @json_encode($record);
+		$logMessage .= $this->jsonEncodeArray($context) . ' - ';
+		$logMessage .= $this->jsonEncodeArray($record);
 		$logMessage .= PHP_EOL;
 
 		return $logMessage;

--- a/src/Util/Logger/SyslogLogger.php
+++ b/src/Util/Logger/SyslogLogger.php
@@ -195,8 +195,8 @@ class SyslogLogger extends AbstractLogger
 		$logMessage .= $this->channel . ' ';
 		$logMessage .= '[' . $this->logToString[$level] . ']: ';
 		$logMessage .= $this->psrInterpolate($message, $context) . ' ';
-		$logMessage .= @json_encode($context) . ' - ';
-		$logMessage .= @json_encode($record);
+		$logMessage .= $this->jsonEncodeArray($context) . ' - ';
+		$logMessage .= $this->jsonEncodeArray($record);
 
 		return $logMessage;
 	}

--- a/tests/src/Util/Logger/AbstractLoggerTest.php
+++ b/tests/src/Util/Logger/AbstractLoggerTest.php
@@ -159,4 +159,23 @@ abstract class AbstractLoggerTest extends MockedTest
 
 		self::assertContains(@json_encode($context), $text);
 	}
+
+	/**
+	 * Test a message with an exception
+	 */
+	public function testExceptionHandling()
+	{
+		$e = new \Exception("Test String", 123);
+		$eFollowUp = new \Exception("FollowUp", 456, $e);
+
+		$assertion = $eFollowUp->__toString();
+
+		$logger = $this->getInstance();
+		$logger->alert('test', ['e' => $eFollowUp]);
+		$text = $this->getContent();
+
+		self::assertLogline($text);
+
+		self::assertContains(@json_encode($assertion), $this->getContent());
+	}
 }


### PR DESCRIPTION
Alternative way of #10085 

@fabrixxm - I thought explaining the whole way would be complicated, I just created this PR. Please have a look if you feel comfortable with this fix. The `psrInterpolate()` method has a different scope, so it wouldn't be applicable as you already said.

I added a specific test for it as well