### PR TITLE
Issue 10105: Use legacy photo data field if used

### DIFF
--- a/src/Model/Attach.php
+++ b/src/Model/Attach.php
@@ -159,8 +159,12 @@ class Attach
 	 */
 	public static function getData($item)
 	{
+		if (!empty($item['data'])) {
+			return $item['data'];
+		}
+
 		$backendClass = DI::storageManager()->getByName($item['backend-class'] ?? '');
-		if ($backendClass === null) {
+		if (empty($backendClass)) {
 			// legacy data storage in 'data' column
 			$i = self::selectFirst(['data'], ['id' => $item['id']]);
 			if ($i === false) {
@@ -275,7 +279,7 @@ class Attach
 
 			foreach($items as $item) {
 				$backend_class = DI::storageManager()->getByName($item['backend-class'] ?? '');
-				if ($backend_class !== null) {
+				if (!empty($backend_class)) {
 					$fields['backend-ref'] = $backend_class->put($img->asString(), $item['backend-ref'] ?? '');
 				} else {
 					$fields['data'] = $img->asString();
@@ -307,7 +311,7 @@ class Attach
 
 		foreach($items as $item) {
 			$backend_class = DI::storageManager()->getByName($item['backend-class'] ?? '');
-			if ($backend_class !== null) {
+			if (!empty($backend_class)) {
 				$backend_class->delete($item['backend-ref'] ?? '');
 			}
 		}

--- a/src/Model/Photo.php
+++ b/src/Model/Photo.php
@@ -188,8 +188,12 @@ class Photo
 	 */
 	public static function getImageDataForPhoto(array $photo)
 	{
+		if (!empty($photo['data'])) {
+			return $photo['data'];
+		}
+
 		$backendClass = DI::storageManager()->getByName($photo['backend-class'] ?? '');
-		if ($backendClass === null) {
+		if (empty($backendClass)) {
 			// legacy data storage in "data" column
 			$i = self::selectFirst(['data'], ['id' => $photo['id']]);
 			if ($i === false) {
@@ -308,7 +312,7 @@ class Photo
 			$storage = DI::storage();
 		}
 
-		if ($storage === null) {
+		if (empty($storage)) {
 			$data = $Image->asString();
 		} else {
 			$backend_ref = $storage->put($Image->asString(), $backend_ref);
@@ -368,7 +372,7 @@ class Photo
 
 		while ($photo = DBA::fetch($photos)) {
 			$backend_class = DI::storageManager()->getByName($photo['backend-class'] ?? '');
-			if ($backend_class !== null) {
+			if (!empty($backend_class)) {
 				if ($backend_class->delete($photo["backend-ref"] ?? '')) {
 					// Delete the photos after they had been deleted successfully
 					DBA::delete("photo", ['id' => $photo['id']]);
@@ -402,7 +406,7 @@ class Photo
 
 			foreach($photos as $photo) {
 				$backend_class = DI::storageManager()->getByName($photo['backend-class'] ?? '');
-				if ($backend_class !== null) {
+				if (!empty($backend_class)) {
 					$fields["backend-ref"] = $backend_class->put($img->asString(), $photo['backend-ref']);
 				} else {
 					$fields["data"] = $img->asString();


### PR DESCRIPTION
This handles #10105 and possibly fixes it.

In this issue it seems as if the `data` field in the `photo` table is srill filled but not used when fetching the photo.