### PR TITLE
Use post-type for the item container

### DIFF
--- a/mod/photos.php
+++ b/mod/photos.php
@@ -784,7 +784,7 @@ function photos_post(App $a)
 	$arr['guid']          = System::createUUID();
 	$arr['uid']           = $page_owner_uid;
 	$arr['uri']           = $uri;
-	$arr['type']          = 'photo';
+	$arr['post-type']     = Item::PT_IMAGE;
 	$arr['wall']          = 1;
 	$arr['resource-id']   = $resource_id;
 	$arr['contact-id']    = $owner_record['id'];

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -2157,7 +2157,7 @@ class Item
 
 			// Only expire posts, not photos and photo comments
 
-			if (!$expire_photos && strlen($item['resource-id'])) {
+			if (!$expire_photos && (!empty($item['resource-id']) || ($item['post-type'] == self::PT_IMAGE))) {
 				continue;
 			} elseif (!$expire_starred && intval($item['starred'])) {
 				continue;

--- a/src/Worker/ExpirePosts.php
+++ b/src/Worker/ExpirePosts.php
@@ -224,10 +224,10 @@ class ExpirePosts
 					AND NOT `uri-id` IN (SELECT `parent-uri-id` FROM `post-user` INNER JOIN `contact` ON `contact`.`id` = `contact-id` AND `notify_new_posts`
 						WHERE `parent-uri-id` = `post-thread`.`uri-id`)
 					AND NOT `uri-id` IN (SELECT `parent-uri-id` FROM `post-user`
-						WHERE (`origin` OR `event-id` != 0 OR `post-type` = ?) AND `parent-uri-id` = `post-thread`.`uri-id`)
+						WHERE (`origin` OR `event-id` != 0 OR `post-type` IN (?, ?)) AND `parent-uri-id` = `post-thread`.`uri-id`)
 					AND NOT `uri-id` IN (SELECT `uri-id` FROM `post-content`
 						WHERE `resource-id` != 0 AND `uri-id` = `post-thread`.`uri-id`))",
-				$expire_days, Item::PT_PERSONAL_NOTE]);
+				$expire_days, Item::PT_PERSONAL_NOTE, Item::PT_IMAGE]);
 
 			Logger::notice('Start deleting expired threads');
 			$affected_count = 0;

--- a/src/Worker/RemoveUnusedContacts.php
+++ b/src/Worker/RemoveUnusedContacts.php
@@ -34,14 +34,14 @@ class RemoveUnusedContacts
 {
 	public static function execute()
 	{
-		$condition = ["`uid` = ? AND NOT `self` AND NOT `nurl` IN (SELECT `nurl` FROM `contact` WHERE `uid` != ?)
+		$condition = ["`id` != ? AND `uid` = ? AND NOT `self` AND NOT `nurl` IN (SELECT `nurl` FROM `contact` WHERE `uid` != ?)
 			AND (NOT `network` IN (?, ?, ?, ?, ?, ?) OR (`archive` AND `success_update` < UTC_TIMESTAMP() - INTERVAL ? DAY))
 			AND NOT `id` IN (SELECT `author-id` FROM `post-user`) AND NOT `id` IN (SELECT `owner-id` FROM `post-user`)
 			AND NOT `id` IN (SELECT `causer-id` FROM `post-user`) AND NOT `id` IN (SELECT `cid` FROM `post-tag`)
 			AND NOT `id` IN (SELECT `contact-id` FROM `post-user`) AND NOT `id` IN (SELECT `cid` FROM `user-contact`)
 			AND NOT `id` IN (SELECT `cid` FROM `event`) AND NOT `id` IN (SELECT `contact-id` FROM `group_member`)
 			AND `created` < UTC_TIMESTAMP() - INTERVAL ? DAY",
-			0, 0, Protocol::DFRN, Protocol::DIASPORA, Protocol::OSTATUS, Protocol::FEED, Protocol::MAIL, Protocol::ACTIVITYPUB, 365, 30];
+			0, 0, 0, Protocol::DFRN, Protocol::DIASPORA, Protocol::OSTATUS, Protocol::FEED, Protocol::MAIL, Protocol::ACTIVITYPUB, 365, 30];
 
 		$total = DBA::count('contact', $condition);
 		Logger::notice('Starting removal', ['total' => $total]);


### PR DESCRIPTION
For every `photo` a post is created as some kind of container. At one place in the code we already had set the `post-type` to `PT_IMAGE` for these container entries. We now do this at the other place as well. We also look for this entry when expiring items.