### PR TITLE
Fix Object parsing for Logging

### DIFF
--- a/src/Util/Logger/AbstractLogger.php
+++ b/src/Util/Logger/AbstractLogger.php
@@ -115,7 +115,7 @@ abstract class AbstractLogger implements LoggerInterface
 		$output = [];
 
 		foreach ($input as $key => $value) {
-			if (method_exists($value, '__toString')) {
+			if (is_object($value) && method_exists($value, '__toString')) {
 				$output[$key] = $value->__toString();
 			} else {
 				$output[$key] = $value;

--- a/tests/src/Util/Logger/AbstractLoggerTest.php
+++ b/tests/src/Util/Logger/AbstractLoggerTest.php
@@ -178,4 +178,15 @@ abstract class AbstractLoggerTest extends MockedTest
 
 		self::assertContains(@json_encode($assertion), $this->getContent());
 	}
+
+	public function testNoObjectHandling()
+	{
+		$logger = $this->getInstance();
+		$logger->alert('test', ['e' => ['test' => 'test']]);
+		$text = $this->getContent();
+
+		self::assertLogline($text);
+
+		self::assertContains('test', $this->getContent());
+	}
 }


### PR DESCRIPTION
Closes #10107 

Added a test for it (it would break with PHP8 -> temporary tested it with PHP8)

(.. I think we should upgrade to a phpunit version, which is compatible with PHP8 and add it to the test-framework ..)