### PR TITLE
Lint & CI: Replace 3rd party library with native PHP linting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,20 @@
+name: Lint
+on: pull_request
+
+jobs:
+  php-linters:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-versions: ['7.3', '7.4', '8.0']
+    name: php${{ matrix.php-versions }} lint
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+      - name: Set up php${{ matrix.php-versions }}
+        uses: shivammathur/setup-php@master
+        with:
+          php-version: ${{ matrix.php-versions }}
+          coverage: none
+      - name: Lint
+        run: bin/composer.phar run lint

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -82,9 +82,6 @@ jobs:
         run: |
           mysql -h"127.0.0.1" -P"$PORT" -utest -ptest test < database.sql
 
-      - name: Test with Parallel-lint
-        run: vendor/bin/parallel-lint --exclude vendor/ --exclude view/asset/ .
-
       - name: Test with phpunit
         run: $(git rev-parse --show-toplevel)/bin/phpunit --configuration tests/phpunit.xml --coverage-clover clover.xml
         env:

--- a/composer.json
+++ b/composer.json
@@ -128,6 +128,7 @@
 		"mikey179/vfsstream": "^1.6"
 	},
 	"scripts": {
-		"test": "phpunit"
+		"test": "phpunit",
+		"lint": "find . -name \\*.php -not -path './vendor/*' -not -path './view/asset/*' -print0 | xargs -0 -n1 php -l"
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -124,7 +124,6 @@
 		]
 	},
 	"require-dev": {
-		"php-parallel-lint/php-parallel-lint": "^1.2",
 		"mockery/mockery": "^1.3",
 		"mikey179/vfsstream": "^1.6"
 	},

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "355e17099c031793ea039e702acbb0d7",
+    "content-hash": "5cf680863afa011d3c2c9f4e0b817690",
     "packages": [
         {
             "name": "asika/simple-console",
@@ -3978,59 +3978,6 @@
                 "testing"
             ],
             "time": "2021-02-24T09:51:00+00:00"
-        },
-        {
-            "name": "php-parallel-lint/php-parallel-lint",
-            "version": "v1.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-parallel-lint/PHP-Parallel-Lint.git",
-                "reference": "474f18bc6cc6aca61ca40bfab55139de614e51ca"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-parallel-lint/PHP-Parallel-Lint/zipball/474f18bc6cc6aca61ca40bfab55139de614e51ca",
-                "reference": "474f18bc6cc6aca61ca40bfab55139de614e51ca",
-                "shasum": ""
-            },
-            "require": {
-                "ext-json": "*",
-                "php": ">=5.4.0"
-            },
-            "replace": {
-                "grogy/php-parallel-lint": "*",
-                "jakub-onderka/php-parallel-lint": "*"
-            },
-            "require-dev": {
-                "nette/tester": "^1.3 || ^2.0",
-                "php-parallel-lint/php-console-highlighter": "~0.3",
-                "squizlabs/php_codesniffer": "~3.0"
-            },
-            "suggest": {
-                "php-parallel-lint/php-console-highlighter": "Highlight syntax in code snippet"
-            },
-            "bin": [
-                "parallel-lint"
-            ],
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "./"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-2-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Jakub Onderka",
-                    "email": "ahoj@jakubonderka.cz"
-                }
-            ],
-            "description": "This tool check syntax of PHP files about 20x faster than serial check.",
-            "homepage": "https://github.com/php-parallel-lint/PHP-Parallel-Lint",
-            "time": "2020-04-04T12:18:32+00:00"
         }
     ],
     "aliases": [],


### PR DESCRIPTION
Reduce 3rd party dependencies & use PHP native functions for linting.
AND it's a own check during the CI