### PR TITLE
Remove empty lines around the horizontal ruler, no maximum height

### DIFF
--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -50,7 +50,7 @@ use Friendica\Util\XML;
 class BBCode
 {
 	// Update this value to the current date whenever changes are made to BBCode::convert
-	const VERSION = '2021-04-05';
+	const VERSION = '2021-04-07';
 
 	const INTERNAL = 0;
 	const API = 2;
@@ -1404,10 +1404,14 @@ class BBCode
 				$search = ["\n[th]", "[th]\n", " [th]", "\n[/th]", "[/th]\n", "[/th] ",
 					"\n[td]", "[td]\n", " [td]", "\n[/td]", "[/td]\n", "[/td] ",
 					"\n[tr]", "[tr]\n", " [tr]", "[tr] ", "\n[/tr]", "[/tr]\n", " [/tr]", "[/tr] ",
+					"\n[hr]", "[hr]\n", " [hr]", "[hr] ",
+					"\n[attachment ", " [attachment ", "\n[/attachment]", "[/attachment]\n", " [/attachment]", "[/attachment] ",
 					"[table]\n", "[table] ", " [table]", "\n[/table]", " [/table]", "[/table] "];
 				$replace = ["[th]", "[th]", "[th]", "[/th]", "[/th]", "[/th]",
 					"[td]", "[td]", "[td]", "[/td]", "[/td]", "[/td]",
 					"[tr]", "[tr]", "[tr]", "[tr]", "[/tr]", "[/tr]", "[/tr]", "[/tr]",
+					"[hr]", "[hr]", "[hr]", "[hr]",
+					"[attachment ", "[attachment ", "[/attachment]", "[/attachment]", "[/attachment]", "[/attachment]",
 					"[table]", "[table]", "[table]", "[/table]", "[/table]", "[/table]"];
 				do {
 					$oldtext = $text;

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -1801,7 +1801,6 @@ aside .panel-body {
 	word-break: break-word;
 }
 .wall-item-content img {
-	max-height: 480px;
 	object-fit: contain;
 }
 .wall-item-body > img,


### PR DESCRIPTION
Empty lines before and after the horizontal ruler and the attachment element have to be removed. Also the maximum height had been removed, since this cooperates fine with the dynamic "show more" addon.