### PR TITLE
Prevent false "photo" page detection

### DIFF
--- a/src/Content/OEmbed.php
+++ b/src/Content/OEmbed.php
@@ -33,7 +33,6 @@ use Friendica\Database\Database;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Util\DateTimeFormat;
-use Friendica\Util\Images;
 use Friendica\Util\Network;
 use Friendica\Util\ParseUrl;
 use Friendica\Util\Proxy as ProxyUtils;

--- a/src/Content/OEmbed.php
+++ b/src/Content/OEmbed.php
@@ -33,6 +33,7 @@ use Friendica\Database\Database;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Util\DateTimeFormat;
+use Friendica\Util\Images;
 use Friendica\Util\Network;
 use Friendica\Util\ParseUrl;
 use Friendica\Util\Proxy as ProxyUtils;
@@ -162,7 +163,13 @@ class OEmbed
 				$oembed->type = $data['type'];
 
 				if ($oembed->type == 'photo') {
-					$oembed->url = $data['url'];
+					if (!empty($data['images'])) {
+						$oembed->url = $data['images'][0]['src'];
+						$oembed->width = $data['images'][0]['width'];
+						$oembed->height = $data['images'][0]['height'];
+					} else {
+						$oembed->type = 'link';
+					}
 				}
 			}
 
@@ -190,7 +197,7 @@ class OEmbed
 				$oembed->author_url = $data['author_url'];
 			}
 
-			if (!empty($data['images'])) {
+			if (!empty($data['images']) && ($oembed->type != 'photo')) {
 				$oembed->thumbnail_url = $data['images'][0]['src'];
 				$oembed->thumbnail_width = $data['images'][0]['width'];
 				$oembed->thumbnail_height = $data['images'][0]['height'];

--- a/src/Util/ParseUrl.php
+++ b/src/Util/ParseUrl.php
@@ -349,6 +349,9 @@ class ParseUrl
 			$siteinfo['title'] = trim($list->item(0)->nodeValue);
 		}
 
+		$twitter_card = false;
+		$twitter_image = false;
+
 		$list = $xpath->query('//meta[@name]');
 		foreach ($list as $node) {
 			$meta_tag = [];
@@ -376,6 +379,7 @@ class ParseUrl
 					break;
 				case 'twitter:image':
 					$siteinfo['image'] = $meta_tag['content'];
+					$twitter_image = true;
 					break;
 				case 'twitter:image:src':
 					$siteinfo['image'] = $meta_tag['content'];
@@ -383,7 +387,7 @@ class ParseUrl
 				case 'twitter:card':
 					// Detect photo pages
 					if ($meta_tag['content'] == 'summary_large_image') {
-						$siteinfo['type'] = 'photo';
+						$twitter_card = true;
 					}
 					break;
 				case 'twitter:description':
@@ -458,6 +462,7 @@ class ParseUrl
 						break;
 					case 'twitter:image':
 						$siteinfo['image'] = $meta_tag['content'];
+						$twitter_image = true;
 						break;
 				}
 			}
@@ -473,8 +478,8 @@ class ParseUrl
 		}
 
 		// Prevent to have a photo type without an image
-		if ((empty($siteinfo['image']) || !empty($siteinfo['text'])) && ($siteinfo['type'] == 'photo')) {
-			$siteinfo['type'] = 'link';
+		if ($twitter_card && $twitter_image && !empty($siteinfo['image'])) {
+			$siteinfo['type'] = 'photo';
 		}
 
 		if (!empty($siteinfo['image'])) {


### PR DESCRIPTION
There had been problems with the Twitter addon detecting regular pages as "photo" pages. I'm sure that there is an issue at the Twitter addon with this as well, but at this late stage I only want to make a really small change.

This "photo" type for webpages is more or less some ugly workaround for our own photo pages, I think. So this should be changed as well - in the future.

But for now this will fix the problem as well.