### PR TITLE
Avoid an empty basepath

### DIFF
--- a/src/Database/DBStructure.php
+++ b/src/Database/DBStructure.php
@@ -192,6 +192,9 @@ class DBStructure
 	public static function definition($basePath, $with_addons_structure = true)
 	{
 		if (!self::$definition) {
+			if (empty($basePath)) {
+				$basePath = DI::app()->getBasePath();
+			}
 
 			$filename = $basePath . '/static/dbstructure.config.php';
 


### PR DESCRIPTION
This could fix the problem described here: https://forum.friendi.ca/display/0b6b25a8-8760-76e9-2317-301122817982

where the error `[Error] Missing database structure config file static/dbstructure.config.php` had been reported.