### PR TITLE
Mat/user config console command

### DIFF
--- a/src/Console/Config.php
+++ b/src/Console/Config.php
@@ -128,6 +128,10 @@ HELP;
 				throw new RuntimeException("$cat.$key is an array and can't be set using this command.");
 			}
 
+			if ($this->config->get($cat, $key) == $value) {
+				throw new RuntimeException("$cat.$key already set to $value.");
+			}
+
 			$result = $this->config->set($cat, $key, $value);
 			if ($result) {
 				$this->out("{$cat}.{$key} <= " .

--- a/src/Core/PConfig/JitPConfig.php
+++ b/src/Core/PConfig/JitPConfig.php
@@ -69,6 +69,8 @@ class JitPConfig extends BasePConfig
 
 		// load the whole category out of the DB into the cache
 		$this->configCache->load($uid, $config);
+
+		return $config;
 	}
 
 	/**

--- a/tests/src/Console/ConfigConsoleTest.php
+++ b/tests/src/Console/ConfigConsoleTest.php
@@ -171,7 +171,7 @@ CONF;
 			->shouldReceive('get')
 			->with('test', 'it')
 			->andReturn(null)
-			->once();
+			->exactly(2);
 		$console = new Config($this->appMode, $this->configMock, [$this->consoleArgv]);
 		$console->setArgument(0, 'test');
 		$console->setArgument(1, 'it');


### PR DESCRIPTION
As with my previous change to allow enabling and disabling plugins, the motivation for this change is so I can use ansible to set up test friendica instances.  This provides four new commands for controlling user-specific configuration from the command line.

In ansible commands should be idempotent, the system expects commands to at least report if no change occurred.  Therefore I also added an error message to the config command when setting a value has no effect.