### PR TITLE
Add "user config" console command

### DIFF
--- a/src/Core/PConfig/JitPConfig.php
+++ b/src/Core/PConfig/JitPConfig.php
@@ -69,6 +69,8 @@ class JitPConfig extends BasePConfig
 
 		// load the whole category out of the DB into the cache
 		$this->configCache->load($uid, $config);
+
+		return $config;
 	}
 
 	/**


### PR DESCRIPTION
As with my previous change to allow enabling and disabling plugins, the motivation for this change is so I can use ansible to set up test friendica instances. This provides four new commands for controlling user-specific configuration from the command line.