### PR TITLE
Avoid duplicated links in shared posts

### DIFF
--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -61,7 +61,8 @@ class BBCode
 	const BACKLINK = 8;
 	const ACTIVITYPUB = 9;
 
-	const ANCHOR = '<br class="anchor">';
+	const TOP_ANCHOR = '<br class="top-anchor">';
+	const BOTTOM_ANCHOR = '<br class="button-anchor">';
 	/**
 	 * Fetches attachment data that were generated the old way
 	 *
@@ -1089,7 +1090,7 @@ class BBCode
 					'$guid'         => $attributes['guid'],
 					'$network_name' => ContactSelector::networkToName($network, $attributes['profile']),
 					'$network_icon' => ContactSelector::networkToIcon($network, $attributes['profile']),
-					'$content'      => self::setMentions(trim($content), 0, $network) . self::ANCHOR,
+					'$content'      => self::TOP_ANCHOR . self::setMentions(trim($content), 0, $network) . self::BOTTOM_ANCHOR,
 				]);
 				break;
 		}

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -2799,13 +2799,18 @@ class Item
 						'attachment'   => $attachment,
 					],
 				]);
-				$trailing .= $media;
+				// On Diaspora posts the attached pictures are leading
+				if ($item['network'] == Protocol::DIASPORA) {
+					$leading .= $media;
+				} else {
+					$trailing .= $media;
+				}
 			}
 		}
 
 		if ($shared) {
-			$content = str_replace(BBCode::ANCHOR, '<div class="body-attach">' . $leading . '<div class="clear"></div></div>' . BBCode::ANCHOR, $content);
-			$content = str_replace(BBCode::ANCHOR, BBCode::ANCHOR . '<div class="body-attach">' . $trailing . '<div class="clear"></div></div>', $content);
+			$content = str_replace(BBCode::TOP_ANCHOR, '<div class="body-attach">' . $leading . '<div class="clear"></div></div>' . BBCode::TOP_ANCHOR, $content);
+			$content = str_replace(BBCode::BOTTOM_ANCHOR, '<div class="body-attach">' . $trailing . '<div class="clear"></div></div>' . BBCode::BOTTOM_ANCHOR, $content);
 		} else {
 			if ($leading != '') {
 				$content = '<div class="body-attach">' . $leading . '<div class="clear"></div></div>' . $content;
@@ -2881,7 +2886,7 @@ class Item
 			// @todo Use a template
 			$rendered = BBCode::convertAttachment('', BBCode::INTERNAL, false, $data);
 			if ($shared) {
-				return str_replace(BBCode::ANCHOR, BBCode::ANCHOR . $rendered, $content);
+				return str_replace(BBCode::BOTTOM_ANCHOR, BBCode::BOTTOM_ANCHOR . $rendered, $content);
 			} else {
 				return $content . $rendered;
 			}

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -2838,7 +2838,13 @@ class Item
 
 		if (!empty($attachments['link'])) {
 			foreach ($attachments['link'] as $link) {
-				if (!in_array(strtolower($link['url']), $ignore_links)) {
+				$found = false;
+				foreach ($ignore_links as $ignore_link) {
+					if (Strings::compareLink($link['url'], $ignore_link)) {
+						$found = true;
+					}
+				}
+				if (!$found) {
 					$attachment = $link;
 				}
 			}

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -2640,7 +2640,7 @@ class Item
 			unset($hook_data);
 		}
 
-		$body = $item['body'];
+		$body = $item['body'] ?? '';
 		$item['body'] = preg_replace("/\s*\[attachment .*?\].*?\[\/attachment\]\s*/ism", '', $item['body']);
 		self::putInCache($item);
 		$item['body'] = $body;

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -184,7 +184,7 @@ class Item
 				$content_fields = ['raw-body' => trim($fields['raw-body'] ?? $fields['body'])];
 
 				// Remove all media attachments from the body and store them in the post-media table
-				// @todo On shared postings (Diaspora style and commented reshare) don't fetch content from rhe shared part
+				// @todo On shared postings (Diaspora style and commented reshare) don't fetch content from the shared part
 				$content_fields['raw-body'] = Post\Media::insertFromBody($item['uri-id'], $content_fields['raw-body']);
 				$content_fields['raw-body'] = self::setHashtags($content_fields['raw-body']);
 			}
@@ -2833,7 +2833,7 @@ class Item
 	 * @param string $body
 	 * @param string $content
 	 * @param bool   $shared
-	 * @param array $ignore_links
+	 * @param array  $ignore_links A list of URLs to ignore
 	 * @return string modified content
 	 */
 	private static function addLinkAttachment(array $attachments, string $body, string $content, bool $shared, array $ignore_links)
@@ -2883,7 +2883,7 @@ class Item
 		}
 		DI::profiler()->saveTimestamp($stamp1, 'rendering');
 
-		if (!empty($data) && !in_array($data['url'], $ignore_links)) {
+		if (isset($data['url']) && !in_array($data['url'], $ignore_links)) {
 			// @todo Use a template
 			$rendered = BBCode::convertAttachment('', BBCode::INTERNAL, false, $data);
 			if ($shared) {

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -2743,6 +2743,7 @@ class Item
 		$leading = '';
 		$trailing = '';
 
+		// @todo In the future we should make a single for the template engine with all media in it. This allows more flexibilty.
 		foreach ($attachments['visual'] as $attachment) {
 			if (self::containsLink($item['body'], $attachment['url'])) {
 				continue;

--- a/src/Model/Post/Media.php
+++ b/src/Model/Post/Media.php
@@ -30,6 +30,7 @@ use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Util\Images;
 use Friendica\Util\ParseUrl;
+use Friendica\Util\Strings;
 
 /**
  * Class Media
@@ -465,9 +466,10 @@ class Media
 		$selected = '';
 
 		foreach ($media as $medium) {
-			$medium['url'] = strtolower($medium['url']);
-			if (in_array($medium['url'], $links)) {
-				continue;
+			foreach ($links as $link) {
+				if (Strings::compareLink($link, $medium['url'])) {
+					continue 2;
+				}
 			}
 
 			$type = explode('/', current(explode(';', $medium['mimetype'])));

--- a/src/Model/Post/Media.php
+++ b/src/Model/Post/Media.php
@@ -447,11 +447,12 @@ class Media
 	/**
 	 * Split the attachment media in the three segments "visual", "link" and "additional"
 	 * 
-	 * @param int $uri_id 
+	 * @param int    $uri_id 
 	 * @param string $guid
+	 * @param array  $links ist of links that shouldn't be added 
 	 * @return array attachments
 	 */
-	public static function splitAttachments(int $uri_id, string $guid = '')
+	public static function splitAttachments(int $uri_id, string $guid = '', array $links = [])
 	{
 		$attachments = ['visual' => [], 'link' => [], 'additional' => []];
 
@@ -464,6 +465,11 @@ class Media
 		$selected = '';
 
 		foreach ($media as $medium) {
+			$medium['url'] = strtolower($medium['url']);
+			if (in_array($medium['url'], $links)) {
+				continue;
+			}
+
 			$type = explode('/', current(explode(';', $medium['mimetype'])));
 			if (count($type) < 2) {
 				Logger::info('Unknown MimeType', ['type' => $type, 'media' => $medium]);

--- a/src/Model/Post/Media.php
+++ b/src/Model/Post/Media.php
@@ -526,15 +526,19 @@ class Media
 	 * Add media attachments to the body
 	 *
 	 * @param int $uriid
+	 * @param string $body
 	 * @return string body
 	 */
-	public static function addAttachmentsToBody(int $uriid)
+	public static function addAttachmentsToBody(int $uriid, string $body = '')
 	{
-		$item = Post::selectFirst(['body'], ['uri-id' => $uriid]);
-		if (!DBA::isResult($item)) {
-			return '';
+		if (empty($body)) {
+			$item = Post::selectFirst(['body'], ['uri-id' => $uriid]);
+			if (!DBA::isResult($item)) {
+				return '';
+			}
+			$body = $item['body'];
 		}
-		$body = preg_replace("/\s*\[attachment .*?\].*?\[\/attachment\]\s*/ism", '', $item['body']);
+		$body = preg_replace("/\s*\[attachment .*?\].*?\[\/attachment\]\s*/ism", '', $body);
 
 		foreach (self::getByURIId($uriid, [self::IMAGE, self::AUDIO, self::VIDEO]) as $media) {
 			if (Item::containsLink($body, $media['url'])) {

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -1291,22 +1291,35 @@ class Transmitter
 			$attachments[] = $attachment;
 		}
 		*/
-		foreach (Post\Media::getByURIId($item['uri-id'], [Post\Media::DOCUMENT, Post\Media::TORRENT, Post\Media::UNKNOWN]) as $attachment) {
-			$attachments[] = ['type' => 'Document',
-				'mediaType' => $attachment['mimetype'],
-				'url' => $attachment['url'],
-				'name' => $attachment['description']];
+		$uriids = [$item['uri-id']];
+		$shared = BBCode::fetchShareAttributes($item['body']);
+		if (!empty($shared['guid'])) {
+			$shared_item = Post::selectFirst(['uri-id'], ['guid' => $shared['guid']]);
+			if (!empty($shared_item['uri-id'])) {
+				$uriids[] = $shared_item['uri-id'];
+			}
+		}
+
+		foreach ($uriids as $uriid) {
+			foreach (Post\Media::getByURIId($uriid, [Post\Media::DOCUMENT, Post\Media::TORRENT, Post\Media::UNKNOWN]) as $attachment) {
+				$attachments[] = ['type' => 'Document',
+					'mediaType' => $attachment['mimetype'],
+					'url' => $attachment['url'],
+					'name' => $attachment['description']];
+			}
 		}
 
 		if ($type != 'Note') {
 			return $attachments;
 		}
 
-		foreach (Post\Media::getByURIId($item['uri-id'], [Post\Media::AUDIO, Post\Media::IMAGE, Post\Media::VIDEO]) as $attachment) {
-			$attachments[] = ['type' => 'Document',
-				'mediaType' => $attachment['mimetype'],
-				'url' => $attachment['url'],
-				'name' => $attachment['description']];
+		foreach ($uriids as $uriid) {
+			foreach (Post\Media::getByURIId($uriid, [Post\Media::AUDIO, Post\Media::IMAGE, Post\Media::VIDEO]) as $attachment) {
+				$attachments[] = ['type' => 'Document',
+					'mediaType' => $attachment['mimetype'],
+					'url' => $attachment['url'],
+					'name' => $attachment['description']];
+			}
 		}
 
 		return $attachments;

--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -899,10 +899,10 @@ class DFRN
 			$entry->setAttribute("xmlns:statusnet", ActivityNamespace::STATUSNET);
 		}
 
+		$body = Post\Media::addAttachmentsToBody($item['uri-id']);
+
 		if ($item['private'] == Item::PRIVATE) {
-			$body = Item::fixPrivatePhotos($item['body'], $owner['uid'], $item, $cid);
-		} else {
-			$body = $item['body'];
+			$body = Item::fixPrivatePhotos($body, $owner['uid'], $item, $cid);
 		}
 
 		// Remove the abstract element. It is only locally important.

--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -899,7 +899,7 @@ class DFRN
 			$entry->setAttribute("xmlns:statusnet", ActivityNamespace::STATUSNET);
 		}
 
-		$body = Post\Media::addAttachmentsToBody($item['uri-id']);
+		$body = Post\Media::addAttachmentsToBody($item['uri-id'], $item['body']);
 
 		if ($item['private'] == Item::PRIVATE) {
 			$body = Item::fixPrivatePhotos($body, $owner['uid'], $item, $cid);

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -3367,36 +3367,6 @@ class Diaspora
 	}
 
 	/**
-	 * Add media attachments to the body
-	 *
-	 * @param array $item
-	 * @return string body
-	 */
-	private static function addAttachments(array $item)
-	{
-		$body = $item['body'];
-
-		foreach (Post\Media::getByURIId($item['uri-id'], [Post\Media::IMAGE, Post\Media::AUDIO, Post\Media::VIDEO]) as $media) {
-			if (Item::containsLink($item['body'], $media['url'])) {
-				continue;
-			}
-
-			if ($media['type'] == Post\Media::IMAGE) {
-				if (!empty($media['description'])) {
-					$body .= "\n[img=" . $media['url'] . ']' . $media['description'] .'[/img]';
-				} else {
-					$body .= "\n[img]" . $media['url'] .'[/img]';
-				}
-			} elseif ($media['type'] == Post\Media::AUDIO) {
-				$body .= "\n[audio]" . $media['url'] . "[/audio]\n";
-			} elseif ($media['type'] == Post\Media::VIDEO) {
-				$body .= "\n[video]" . $media['url'] . "[/video]\n";
-			}
-		}
-		return $body;
-	}
-
-	/**
 	 * Create a post (status message or reshare)
 	 *
 	 * @param array $item  The item that will be exported
@@ -3436,7 +3406,7 @@ class Diaspora
 			$type = "reshare";
 		} else {
 			$title = $item["title"];
-			$body = self::addAttachments($item);
+			$body = Post\Media::addAttachmentsToBody($item['uri-id']);
 
 			// Fetch the title from an attached link - if there is one
 			if (empty($item["title"]) && DI::pConfig()->get($owner['uid'], 'system', 'attach_link_title')) {
@@ -3650,7 +3620,7 @@ class Diaspora
 			$thread_parent_item = Post::selectFirst(['guid', 'author-id', 'author-link', 'gravity'], ['uri' => $item['thr-parent'], 'uid' => $item['uid']]);
 		}
 
-		$body = self::addAttachments($item);
+		$body = Post\Media::addAttachmentsToBody($item['uri-id']);
 
 		// The replied to autor mention is prepended for clarity if:
 		// - Item replied isn't yours

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -3406,7 +3406,7 @@ class Diaspora
 			$type = "reshare";
 		} else {
 			$title = $item["title"];
-			$body = Post\Media::addAttachmentsToBody($item['uri-id']);
+			$body = Post\Media::addAttachmentsToBody($item['uri-id'], $item['body']);
 
 			// Fetch the title from an attached link - if there is one
 			if (empty($item["title"]) && DI::pConfig()->get($owner['uid'], 'system', 'attach_link_title')) {
@@ -3620,7 +3620,7 @@ class Diaspora
 			$thread_parent_item = Post::selectFirst(['guid', 'author-id', 'author-link', 'gravity'], ['uri' => $item['thr-parent'], 'uid' => $item['uid']]);
 		}
 
-		$body = Post\Media::addAttachmentsToBody($item['uri-id']);
+		$body = Post\Media::addAttachmentsToBody($item['uri-id'], $item['body']);
 
 		// The replied to autor mention is prepended for clarity if:
 		// - Item replied isn't yours

--- a/src/Protocol/OStatus.php
+++ b/src/Protocol/OStatus.php
@@ -1885,7 +1885,8 @@ class OStatus
 		XML::addElement($doc, $entry, "id", $item["uri"]);
 		XML::addElement($doc, $entry, "title", html_entity_decode($title, ENT_QUOTES, 'UTF-8'));
 
-		$body = self::formatPicturePost($item['body']);
+		$body = Post\Media::addAttachmentsToBody($item['uri-id']);
+		$body = self::formatPicturePost($body);
 
 		if (!empty($item['title'])) {
 			$body = "[b]".$item['title']."[/b]\n\n".$body;

--- a/src/Protocol/OStatus.php
+++ b/src/Protocol/OStatus.php
@@ -1885,7 +1885,7 @@ class OStatus
 		XML::addElement($doc, $entry, "id", $item["uri"]);
 		XML::addElement($doc, $entry, "title", html_entity_decode($title, ENT_QUOTES, 'UTF-8'));
 
-		$body = Post\Media::addAttachmentsToBody($item['uri-id']);
+		$body = Post\Media::addAttachmentsToBody($item['uri-id'], $item['body']);
 		$body = self::formatPicturePost($body);
 
 		if (!empty($item['title'])) {


### PR DESCRIPTION
When a shared post does contains an attachment then we shouldn't use it in the sharer as well.