### PR TITLE
Add error message when setting config to existing value

### DIFF
--- a/src/Console/Config.php
+++ b/src/Console/Config.php
@@ -128,6 +128,10 @@ HELP;
 				throw new RuntimeException("$cat.$key is an array and can't be set using this command.");
 			}
 
+			if ($this->config->get($cat, $key) == $value) {
+				throw new RuntimeException("$cat.$key already set to $value.");
+			}
+
 			$result = $this->config->set($cat, $key, $value);
 			if ($result) {
 				$this->out("{$cat}.{$key} <= " .

--- a/src/Console/Config.php
+++ b/src/Console/Config.php
@@ -128,7 +128,7 @@ HELP;
 				throw new RuntimeException("$cat.$key is an array and can't be set using this command.");
 			}
 
-			if ($this->config->get($cat, $key) == $value) {
+			if ($this->config->get($cat, $key) === $value) {
 				throw new RuntimeException("$cat.$key already set to $value.");
 			}
 

--- a/tests/src/Console/ConfigConsoleTest.php
+++ b/tests/src/Console/ConfigConsoleTest.php
@@ -65,8 +65,13 @@ class ConfigConsoleTest extends ConsoleTest
 		$this->configMock
 			->shouldReceive('get')
 			->with('config', 'test')
-			->andReturn('now')
+			->andReturn('old')
 			->twice();
+		$this->configMock
+			->shouldReceive('get')
+			->with('config', 'test')
+			->andReturn('now')
+			->once();
 
 		$console = new Config($this->appMode, $this->configMock, $this->consoleArgv);
 		$console->setArgument(0, 'config');
@@ -116,6 +121,23 @@ class ConfigConsoleTest extends ConsoleTest
 		$txt = $this->dumpExecute($console);
 
 		self::assertEquals("[Error] config.test is an array and can't be set using this command.\n", $txt);
+	}
+
+	public function testSetExistingValue()
+	{
+		$this->configMock
+			->shouldReceive('get')
+			->with('config', 'test')
+			->andReturn('now')
+			->twice();
+
+		$console = new Config($this->appMode, $this->configMock, $this->consoleArgv);
+		$console->setArgument(0, 'config');
+		$console->setArgument(1, 'test');
+		$console->setArgument(2, 'now');
+		$txt = $this->dumpExecute($console);
+
+		self::assertEquals("[Error] config.test already set to now.\n", $txt);
 	}
 
 	public function testTooManyArguments()
@@ -171,7 +193,7 @@ CONF;
 			->shouldReceive('get')
 			->with('test', 'it')
 			->andReturn(null)
-			->once();
+			->twice();
 		$console = new Config($this->appMode, $this->configMock, [$this->consoleArgv]);
 		$console->setArgument(0, 'test');
 		$console->setArgument(1, 'it');


### PR DESCRIPTION
This is related to using ansible to set up a friendica instance.  Ansible wants feedback on whether something changed for reporting purposes.  The simplest way to do this with the console config command is to make it an error when the user tries to set the value to its existing value.  And perhaps that's useful feedback for a command-line user anyway.