### PR TITLE
Fix console user config set command

### DIFF
--- a/src/Console/User.php
+++ b/src/Console/User.php
@@ -26,7 +26,6 @@ use Friendica\App;
 use Friendica\Content\Pager;
 use Friendica\Core\L10n;
 use Friendica\Core\PConfig\IPConfig;
-use Friendica\Database\Database;
 use Friendica\Model\Register;
 use Friendica\Model\User as UserModel;
 use Friendica\Util\Temporal;
@@ -89,7 +88,7 @@ HELP;
 		return $help;
 	}
 
-	public function __construct(App\Mode $appMode, L10n $l10n, Database $dba, IPConfig $pConfig, array $argv = null)
+	public function __construct(App\Mode $appMode, L10n $l10n, IPConfig $pConfig, array $argv = null)
 	{
 		parent::__construct($argv);
 

--- a/src/Console/User.php
+++ b/src/Console/User.php
@@ -178,7 +178,7 @@ HELP;
 		$nick = $this->getNick($arg_index);
 
 		$user = UserModel::getByNickname($nick, ['uid']);
-		if (!$user) {
+		if (empty($user)) {
 			throw new RuntimeException($this->l10n->t('User not found'));
 		}
 
@@ -206,7 +206,7 @@ HELP;
 		try {
 			$result = UserModel::updatePassword($user['uid'], $password);
 
-			if (!$result) {
+			if (empty($result)) {
 				throw new \Exception($this->l10n->t('Password update failed. Please try again.'));
 			}
 
@@ -425,7 +425,7 @@ HELP;
 				return false;
 		}
 
-		if ($user) {
+		if (!empty($user)) {
 			$table->addRow($user);
 		}
 		$this->out($table->getTable());


### PR DESCRIPTION
In change d1d5cb2857 @nupplaphil updated the "user config" command I added to avoid using DI:: directly, instead using the dependency injected $pConfig.  But looks like he missed a couple of places.  So I've updated those too.

I also removed the last references to the dba member variable.  Instead it now goes through Model\User, which I think is probably the structure you're going for here, right?  According to the comments, the calls to isResult are kinda pointless, since they're only checking if a boolean is false.  Although I admit I didn't dive too deeply into the code to verify if the comments are correct.

I guess this file is now in a state where it should have a unit test, right?

I also added a return value check, to avoid an irritating PHP warning during "user search nick \<invalid nick\>".