### PR TITLE
API: New function to fetch current user id

### DIFF
--- a/src/Module/BaseApi.php
+++ b/src/Module/BaseApi.php
@@ -92,6 +92,22 @@ class BaseApi extends BaseModule
 	}
 
 	/**
+	 * Get current user id, returns 0 if not logged in
+	 *
+	 * @return int User ID
+	 */
+	protected static function getCurrentUserID()
+	{
+		if (is_null(self::$current_user_id)) {
+			api_login(DI::app(), false);
+
+			self::$current_user_id = api_user();
+		}
+
+		return (int)self::$current_user_id;
+	}
+
+	/**
 	 * Get user info array.
 	 *
 	 * @param int|string $contact_id Contact ID or URL


### PR DESCRIPTION
This PR introduces a new function to the API classes. We can now fetch the current user id.

When no user is logged in, the function will not fail, but simply return 0. This behaviour is needed for some API endpoints that can both be called anonymously and logged in.