### PR TITLE
Avoid duplicated attachments / unwanted attachments

### DIFF
--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -1893,7 +1893,7 @@ class BBCode
 
 		$text = HTML::purify($text, $allowedIframeDomains);
 
-		return $text;
+		return trim($text);
 	}
 
 	/**

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -2871,7 +2871,8 @@ class Item
 						$found = true;
 					}
 				}
-				if (!$found) {
+				// @todo Judge between the links to use the one with most information
+				if (!$found && (empty($attachment) || empty($attachment['name']) || empty($attachment['description']))) {
 					$attachment = $link;
 				}
 			}


### PR DESCRIPTION
This fixes the problem that unknown attachments (type "Unknown") causes display problems for example at Mastodon. Also the problem is solved that under certain circumstances attachments are transmitted multiple times for the same URL.