### PR TITLE
Make birthday time comparison 32-bit safe in Protocol\DFRN

### DIFF
--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -1441,19 +1441,19 @@ class DFRN
 	/**
 	 * Fetch the author data from head or entry items
 	 *
-	 * @param object $xpath     XPath object
-	 * @param object $context   In which context should the data be searched
-	 * @param array  $importer  Record of the importer user mixed with contact of the content
-	 * @param string $element   Element name from which the data is fetched
-	 * @param bool   $onlyfetch Should the data only be fetched or should it update the contact record as well
-	 * @param string $xml       optional, default empty
+	 * @param \DOMXPath $xpath     XPath object
+	 * @param \DOMNode  $context   In which context should the data be searched
+	 * @param array     $importer  Record of the importer user mixed with contact of the content
+	 * @param string    $element   Element name from which the data is fetched
+	 * @param bool      $onlyfetch Should the data only be fetched or should it update the contact record as well
+	 * @param string    $xml       optional, default empty
 	 *
 	 * @return array Relevant data of the author
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 * @throws \ImagickException
 	 * @todo  Find good type-hints for all parameter
 	 */
-	private static function fetchauthor($xpath, $context, $importer, $element, $onlyfetch, $xml = "")
+	private static function fetchauthor(\DOMXPath $xpath, \DOMNode $context, $importer, $element, $onlyfetch, $xml = "")
 	{
 		$author = [];
 		$author["name"] = XML::getFirstNodeValue($xpath, $element."/atom:name/text()", $context);
@@ -1609,12 +1609,14 @@ class DFRN
 			}
 
 			// "dfrn:birthday" contains the birthday converted to UTC
-			$birthday = XML::getFirstNodeValue($xpath, $element . "/poco:birthday/text()", $context);
-
-			if (strtotime($birthday) > time()) {
-				$bd_timestamp = strtotime($birthday);
-
-				$poco["bdyear"] = date("Y", $bd_timestamp);
+			$birthday = XML::getFirstNodeValue($xpath, $element . "/dfrn:birthday/text()", $context);
+			try {
+				$birthday_date = new \DateTime($birthday);
+				if ($birthday_date > new \DateTime()) {
+					$poco["bdyear"] = $birthday_date->format("Y");
+				}
+			} catch (\Exception $e) {
+				// Invalid birthday
 			}
 
 			// "poco:birthday" is the birthday in the format "yyyy-mm-dd"


### PR DESCRIPTION
- Address https://github.com/friendica/friendica/issues/10168#issuecomment-838221234

I also changed the XML field name to what I believe is expected. `poco:birthday` was checked twice while `dfrn:birthday` wasn't used in the `fetchauthor()` method.