### PR TITLE
API: The instance record had got a malformatted value

### DIFF
--- a/src/Object/Api/Mastodon/Instance.php
+++ b/src/Object/Api/Mastodon/Instance.php
@@ -80,7 +80,7 @@ class Instance extends BaseDataTransferObject
 		$instance->description = DI::config()->get('config', 'info');
 		$instance->email = DI::config()->get('config', 'admin_email');
 		$instance->version = FRIENDICA_VERSION;
-		$instance->urls = []; // Not supported
+		$instance->urls = null; // Not supported
 		$instance->stats = Stats::get();
 		$instance->thumbnail = $baseUrl->get() . (DI::config()->get('system', 'shortcut_icon') ?? 'images/friendica-32.png');
 		$instance->languages = [DI::config()->get('system', 'language')];


### PR DESCRIPTION
The `urls` value musn't be an array but an object. This prevented the app "Mammut" from registering. (it still doesn't work with that application - but this is a different story)