### PR TITLE
Quickfix for current Json-LD problems

### DIFF
--- a/src/Util/JsonLD.php
+++ b/src/Util/JsonLD.php
@@ -152,7 +152,7 @@ class JsonLD
 		jsonld_set_document_loader('Friendica\Util\JsonLD::documentLoader');
 
 		$context = (object)['as' => 'https://www.w3.org/ns/activitystreams#',
-			'w3id' => 'https://w3id.org/security#',
+			'w3id' => (object)['@id' => 'https://w3id.org/security#', '@type' => '@id'],
 			'ldp' => (object)['@id' => 'http://www.w3.org/ns/ldp#', '@type' => '@id'],
 			'vcard' => (object)['@id' => 'http://www.w3.org/2006/vcard/ns#', '@type' => '@id'],
 			'dfrn' => (object)['@id' => 'http://purl.org/macgirvin/dfrn/1.0/', '@type' => '@id'],


### PR DESCRIPTION
This is a quickfix for the currently existing problem that due to the (currently) non working URL `https://w3id.org/security/v1` that is used in the context of every ActivityPub header.

Since we are normalizing and compacting the Json-LD messages (the first for the signature check, the second for easier parsing), the URLs in the context need to be resolvable.

This fix here is ugly and highly untested. Side effect can occur.