### PR TITLE
API: Support for private mails

### DIFF
--- a/doc/API-Mastodon.md
+++ b/doc/API-Mastodon.md
@@ -51,6 +51,9 @@ These endpoints use the [Mastodon API entities](https://docs.joinmastodon.org/en
 - [`GET /api/v1/apps/verify_credentials`](https://docs.joinmastodon.org/methods/apps/)
 - [`GET /api/v1/blocks`](https://docs.joinmastodon.org/methods/accounts/blocks/)
 - [`GET /api/v1/bookmarks`](https://docs.joinmastodon.org/methods/accounts/bookmarks/)
+- [`GET /api/v1/conversations`](https://docs.joinmastodon.org/methods/timelines/conversations/)
+- [`DELETE /api/v1/conversations/:id`](https://docs.joinmastodon.org/methods/timelines/conversations/)
+- [`POST /api/v1/conversations/:id/read`](https://docs.joinmastodon.org/methods/timelines/conversations/)
 - [`GET /api/v1/custom_emojis`](https://docs.joinmastodon.org/methods/instance/custom_emojis/)
     - Doesn't return unicode emojis since they aren't using an image URL
 
@@ -118,9 +121,6 @@ These endpoints use the [Mastodon API entities](https://docs.joinmastodon.org/en
 These emdpoints are planned to be implemented
 
 - [`PATCH /api/v1/accounts/update_credentials`](https://docs.joinmastodon.org/methods/accounts/)
-- [`GET /api/v1/conversations`](https://docs.joinmastodon.org/methods/timelines/conversations/)
-- [`DELETE /api/v1/conversations/:id`](https://docs.joinmastodon.org/methods/timelines/conversations/)
-- [`POST /api/v1/conversations/:id/read`](https://docs.joinmastodon.org/methods/timelines/conversations/)
 - [`GET /api/v1/instance/activity`](https://docs.joinmastodon.org/methods/instance#weekly-activity)
 - [`GET /api/v1/timelines/direct`](https://docs.joinmastodon.org/methods/timelines/)
 

--- a/doc/API-Mastodon.md
+++ b/doc/API-Mastodon.md
@@ -108,6 +108,7 @@ These endpoints use the [Mastodon API entities](https://docs.joinmastodon.org/en
 - [`POST /api/v1/statuses/:id/pin`](https://docs.joinmastodon.org/methods/statuses/)
 - [`POST /api/v1/statuses/:id/unpin`](https://docs.joinmastodon.org/methods/statuses/)
 - [`GET /api/v1/suggestions`](https://docs.joinmastodon.org/methods/accounts/suggestions/)
+- [`GET /api/v1/timelines/direct`](https://docs.joinmastodon.org/methods/timelines/)
 - [`GET /api/v1/timelines/home`](https://docs.joinmastodon.org/methods/timelines/)
 - [`GET /api/v1/timelines/list/:id`](https://docs.joinmastodon.org/methods/timelines/)
 - [`GET /api/v1/timelines/public`](https://docs.joinmastodon.org/methods/timelines/)
@@ -122,7 +123,6 @@ These emdpoints are planned to be implemented
 
 - [`PATCH /api/v1/accounts/update_credentials`](https://docs.joinmastodon.org/methods/accounts/)
 - [`GET /api/v1/instance/activity`](https://docs.joinmastodon.org/methods/instance#weekly-activity)
-- [`GET /api/v1/timelines/direct`](https://docs.joinmastodon.org/methods/timelines/)
 
 ## Non supportable endpoints
 

--- a/src/DI.php
+++ b/src/DI.php
@@ -264,6 +264,14 @@ abstract class DI
 	}
 
 	/**
+	 * @return Factory\Api\Mastodon\Conversation
+	 */
+	public static function mstdnConversation()
+	{
+		return self::$dice->create(Factory\Api\Mastodon\Conversation::class);
+	}
+
+	/**
 	 * @return Factory\Api\Mastodon\Emoji
 	 */
 	public static function mstdnEmoji()

--- a/src/Factory/Api/Mastodon/Conversation.php
+++ b/src/Factory/Api/Mastodon/Conversation.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * @copyright Copyright (C) 2010-2021, the Friendica project
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Friendica\Factory\Api\Mastodon;
+
+use Friendica\BaseFactory;
+use Friendica\Database\DBA;
+use Friendica\DI;
+use Friendica\Model\Contact;
+
+class Conversation extends BaseFactory
+{
+	public function CreateFromConvId(int $id)
+	{
+		$accounts    = [];
+		$unread      = false;
+		$last_status = null;
+
+		$ids = [];
+		$mails = DBA::select('mail', ['id', 'from-url', 'uid', 'seen'], ['convid' => $id], ['order' => ['id' => true]]);
+		while ($mail = DBA::fetch($mails)) {
+			if (!$mail['seen']) {
+				$unread = true;
+			}
+
+			$id = Contact::getIdForURL($mail['from-url'], 0, false);
+			if (in_array($id, $ids)) {
+				continue;
+			}
+
+			$ids[] = $id;
+
+			if (empty($last_status)) {
+				$last_status = DI::mstdnStatus()->createFromMailId($mail['id'], $mail['uid']);
+			}
+
+			$accounts[] = DI::mstdnAccount()->createFromContactId($id, $mail['uid']);
+		}
+
+		return new \Friendica\Object\Api\Mastodon\Conversation($id, $accounts, $unread, $last_status);
+	}
+}

--- a/src/Factory/Api/Mastodon/Conversation.php
+++ b/src/Factory/Api/Mastodon/Conversation.php
@@ -35,6 +35,7 @@ class Conversation extends BaseFactory
 		$last_status = null;
 
 		$ids = [];
+
 		$mails = DBA::select('mail', ['id', 'from-url', 'uid', 'seen'], ['convid' => $id], ['order' => ['id' => true]]);
 		while ($mail = DBA::fetch($mails)) {
 			if (!$mail['seen']) {

--- a/src/Factory/Api/Mastodon/Conversation.php
+++ b/src/Factory/Api/Mastodon/Conversation.php
@@ -50,10 +50,10 @@ class Conversation extends BaseFactory
 			$ids[] = $id;
 
 			if (empty($last_status)) {
-				$last_status = DI::mstdnStatus()->createFromMailId($mail['id'], $mail['uid']);
+				$last_status = DI::mstdnStatus()->createFromMailId($mail['id']);
 			}
 
-			$accounts[] = DI::mstdnAccount()->createFromContactId($id, $mail['uid']);
+			$accounts[] = DI::mstdnAccount()->createFromContactId($id, 0);
 		}
 
 		return new \Friendica\Object\Api\Mastodon\Conversation($id, $accounts, $unread, $last_status);

--- a/src/Factory/Api/Mastodon/Status.php
+++ b/src/Factory/Api/Mastodon/Status.php
@@ -155,16 +155,16 @@ class Status extends BaseFactory
 		$reshare     = [];
 
 		$item = [
-			'uri-id' => $mail['id'],
-			'created' => $mail['created'],
-			'thr-parent-id' => 0,
+			'uri-id'           => $mail['id'],
+			'created'          => $mail['created'],
+			'thr-parent-id'    => 0,
 			'parent-author-id' => 0,
-			'title' => $conv['subject'],
-			'private' => Item::PRIVATE,
-			'language' => '',
-			'uri' => $mail['uri'],
-			'plink' => '',
-			'body' => BBCode::convert($mail['body'], false, BBCode::API)
+			'title'            => $conv['subject'],
+			'private'          => Item::PRIVATE,
+			'language'         => '',
+			'uri'              => $mail['uri'],
+			'plink'            => '',
+			'body'             => BBCode::convert($mail['body'], false, BBCode::API)
 		];
 
 		return new \Friendica\Object\Api\Mastodon\Status($item, $account, $counts, $userAttributes, $sensitive, $application, $mentions, $tags, $card, $attachments, $reshare);

--- a/src/Factory/Api/Mastodon/Status.php
+++ b/src/Factory/Api/Mastodon/Status.php
@@ -123,12 +123,11 @@ class Status extends BaseFactory
 
 	/**
 	 * @param int $uriId id of the mail
-	 * @param int $uid   mail user
 	 * @return \Friendica\Object\Api\Mastodon\Status
 	 * @throws HTTPException\InternalServerErrorException
 	 * @throws \ImagickException
 	 */
-	public function createFromMailId(int $id, $uid)
+	public function createFromMailId(int $id)
 	{
 		$item = ActivityPub\Transmitter::ItemArrayFromMail($id, true);
 		if (empty($item)) {

--- a/src/Module/Api/Mastodon/Conversation.php
+++ b/src/Module/Api/Mastodon/Conversation.php
@@ -39,7 +39,7 @@ class Conversation extends BaseApi
 		if (!empty($parameters['id'])) {
 			DI::mstdnError()->UnprocessableEntity();
 		}
-		
+
 		DBA::delete('conv', ['id' => $parameters['id'], 'uid' => $uid]);
 		DBA::delete('mail', ['convid' => $parameters['id'], 'uid' => $uid]);
 
@@ -65,6 +65,7 @@ class Conversation extends BaseApi
 		$params = ['order' => ['id' => true], 'limit' => $request['limit']];
 
 		$convs = DBA::select('conv', ['id'], ['uid' => $uid], $params);
+
 		$conversations = [];
 
 		foreach ($convs as $conv) {

--- a/src/Module/Api/Mastodon/Conversation.php
+++ b/src/Module/Api/Mastodon/Conversation.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * @copyright Copyright (C) 2010-2021, the Friendica project
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Friendica\Module\Api\Mastodon;
+
+use Friendica\Core\System;
+use Friendica\Database\DBA;
+use Friendica\DI;
+use Friendica\Module\BaseApi;
+
+/**
+ * @see https://docs.joinmastodon.org/methods/timelines/conversations/
+ */
+class Conversation extends BaseApi
+{
+	public static function delete(array $parameters = [])
+	{
+		self::login(self::SCOPE_WRITE);
+		$uid = self::getCurrentUserID();
+
+		if (!empty($parameters['id'])) {
+			DI::mstdnError()->UnprocessableEntity();
+		}
+		
+		DBA::delete('conv', ['id' => $parameters['id'], 'uid' => $uid]);
+		DBA::delete('mail', ['convid' => $parameters['id'], 'uid' => $uid]);
+
+		System::jsonExit([]);
+	}
+
+	/**
+	 * @param array $parameters
+	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
+	 */
+	public static function rawContent(array $parameters = [])
+	{
+		self::login(self::SCOPE_READ);
+		$uid = self::getCurrentUserID();
+
+		$request = self::getRequest([
+			'limit'    => 20, // Maximum number of results. Defaults to 20. Max 40.
+			'max_id'   => 0,  // Return results older than this ID. Use HTTP Link header to paginate.
+			'since_id' => 0,  // Return results newer than this ID. Use HTTP Link header to paginate.
+			'min_id'   => 0,  // Return results immediately newer than this ID. Use HTTP Link header to paginate.
+		]);
+
+		$params = ['order' => ['id' => true], 'limit' => $request['limit']];
+
+		$convs = DBA::select('conv', ['id'], ['uid' => $uid], $params);
+		$conversations = [];
+
+		foreach ($convs as $conv) {
+			$conversations[] = DI::mstdnConversation()->CreateFromConvId($conv['id']);
+		}
+
+		System::jsonExit($conversations);
+	}
+}

--- a/src/Module/Api/Mastodon/Conversation.php
+++ b/src/Module/Api/Mastodon/Conversation.php
@@ -76,6 +76,7 @@ class Conversation extends BaseApi
 
 		if (!empty($request['min_id'])) {
 			$condition = DBA::mergeConditions($condition, ["`id` > ?", $request['min_id']]);
+
 			$params['order'] = ['id'];
 		}
 

--- a/src/Module/Api/Mastodon/Conversations/Read.php
+++ b/src/Module/Api/Mastodon/Conversations/Read.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * @copyright Copyright (C) 2010-2021, the Friendica project
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Friendica\Module\Api\Mastodon\Conversation;
+
+use Friendica\Core\System;
+use Friendica\Database\DBA;
+use Friendica\DI;
+use Friendica\Module\BaseApi;
+
+/**
+ * @see https://docs.joinmastodon.org/methods/timelines/conversations/
+ */
+class Read extends BaseApi
+{
+	public static function post(array $parameters = [])
+	{
+		self::login(self::SCOPE_WRITE);
+		$uid = self::getCurrentUserID();
+
+		if (!empty($parameters['id'])) {
+			DI::mstdnError()->UnprocessableEntity();
+		}
+		
+		DBA::update('mail', ['seen' => true], ['convid' => $parameters['id'], 'uid' => $uid]);
+
+		System::jsonExit(DI::mstdnConversation()->CreateFromConvId($parameters['id'])->toArray());
+	}
+}

--- a/src/Module/Api/Mastodon/Conversations/Read.php
+++ b/src/Module/Api/Mastodon/Conversations/Read.php
@@ -39,7 +39,7 @@ class Read extends BaseApi
 		if (!empty($parameters['id'])) {
 			DI::mstdnError()->UnprocessableEntity();
 		}
-		
+
 		DBA::update('mail', ['seen' => true], ['convid' => $parameters['id'], 'uid' => $uid]);
 
 		System::jsonExit(DI::mstdnConversation()->CreateFromConvId($parameters['id'])->toArray());

--- a/src/Module/Api/Mastodon/Timelines/Direct.php
+++ b/src/Module/Api/Mastodon/Timelines/Direct.php
@@ -24,7 +24,6 @@ namespace Friendica\Module\Api\Mastodon\Timelines;
 use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\DI;
-use Friendica\Model\Post;
 use Friendica\Module\BaseApi;
 use Friendica\Network\HTTPException;
 
@@ -43,10 +42,10 @@ class Direct extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		$request = self::getRequest([
-			'max_id'          => 0,     // Return results older than id
-			'since_id'        => 0,     // Return results newer than id
-			'min_id'          => 0,     // Return results immediately newer than id
-			'limit'           => 20,    // Maximum number of results to return. Defaults to 20.
+			'max_id'   => 0,  // Return results older than id
+			'since_id' => 0,  // Return results newer than id
+			'min_id'   => 0,  // Return results immediately newer than id
+			'limit'    => 20, // Maximum number of results to return. Defaults to 20.
 		]);
 
 		$params = ['order' => ['id' => true], 'limit' => $request['limit']];

--- a/src/Module/Api/Mastodon/Timelines/Direct.php
+++ b/src/Module/Api/Mastodon/Timelines/Direct.php
@@ -67,12 +67,12 @@ class Direct extends BaseApi
 			$params['order'] = ['id'];
 		}
 
-		$mails = DBA::select('mail', ['id', 'uid'], $condition, $params);
+		$mails = DBA::select('mail', ['id'], $condition, $params);
 
 		$statuses = [];
 
 		while ($mail = DBA::fetch($mails)) {
-			$statuses[] = DI::mstdnStatus()->createFromMailId($mail['id'], $mail['uid']);
+			$statuses[] = DI::mstdnStatus()->createFromMailId($mail['id']);
 		}
 
 		if (!empty($request['min_id'])) {

--- a/src/Object/Api/Mastodon/Conversation.php
+++ b/src/Object/Api/Mastodon/Conversation.php
@@ -46,9 +46,9 @@ class Conversation extends BaseDataTransferObject
 
 	public function __construct(string $id, array $accounts, bool $unread, \Friendica\Object\Api\Mastodon\Status $last_status)
 	{
-		$this->id = $id;
-		$this->accounts = $accounts;
-		$this->unread = $unread;
+		$this->id          = $id;
+		$this->accounts    = $accounts;
+		$this->unread      = $unread;
 		$this->last_status = $last_status;
 	}
 }

--- a/src/Object/Api/Mastodon/Conversation.php
+++ b/src/Object/Api/Mastodon/Conversation.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * @copyright Copyright (C) 2010-2021, the Friendica project
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Friendica\Object\Api\Mastodon;
+
+use Friendica\BaseDataTransferObject;
+
+/**
+ * Class Conversation
+ *
+ * @see https://docs.joinmastodon.org/entities/conversation/
+ */
+class Conversation extends BaseDataTransferObject
+{
+	//Required attributes
+	/** @var string */
+	protected $id;
+	/** @var array */
+	protected $accounts;
+	/** @var bool */
+	protected $unread;
+
+	// Optional attributes
+	/**
+	 * @var Status
+	 */
+	protected $last_status = true;
+
+	public function __construct(string $id, array $accounts, bool $unread, \Friendica\Object\Api\Mastodon\Status $last_status)
+	{
+		$this->id = $id;
+		$this->accounts = $accounts;
+		$this->unread = $unread;
+		$this->last_status = $last_status;
+	}
+}

--- a/static/routes.config.php
+++ b/static/routes.config.php
@@ -142,7 +142,7 @@ return [
 			'/statuses/{id:\d+}/unpin'           => [Module\Api\Mastodon\Statuses\Unpin::class,           [        R::POST]],
 			'/suggestions'                       => [Module\Api\Mastodon\Suggestions::class,              [R::GET         ]],
 			'/suggestions/{id:\d+}'              => [Module\Api\Mastodon\Unimplemented::class,            [R::DELETE      ]], // not implemented
-			'/timelines/direct'                  => [Module\Api\Mastodon\Unimplemented::class,            [R::GET         ]], // @todo
+			'/timelines/direct'                  => [Module\Api\Mastodon\Timelines\Direct::class,         [R::GET         ]],
 			'/timelines/home'                    => [Module\Api\Mastodon\Timelines\Home::class,           [R::GET         ]],
 			'/timelines/list/{id:\d+}'           => [Module\Api\Mastodon\Timelines\ListTimeline::class,   [R::GET         ]],
 			'/timelines/public'                  => [Module\Api\Mastodon\Timelines\PublicTimeline::class, [R::GET         ]],

--- a/static/routes.config.php
+++ b/static/routes.config.php
@@ -90,9 +90,9 @@ return [
 			'/apps/verify_credentials'           => [Module\Api\Mastodon\Apps\VerifyCredentials::class,   [R::GET         ]],
 			'/blocks'                            => [Module\Api\Mastodon\Blocks::class,                   [R::GET         ]],
 			'/bookmarks'                         => [Module\Api\Mastodon\Bookmarks::class,                [R::GET         ]],
-			'/conversations'                     => [Module\Api\Mastodon\Unimplemented::class,            [R::GET         ]], // @todo
-			'/conversations/{id:\d+}'            => [Module\Api\Mastodon\Unimplemented::class,            [R::DELETE      ]], // @todo
-			'/conversations/{id:\d+}/read'       => [Module\Api\Mastodon\Unimplemented::class,            [R::POST        ]], // @todo
+			'/conversations'                     => [Module\Api\Mastodon\Conversation::class,             [R::GET         ]],
+			'/conversations/{id:\d+}'            => [Module\Api\Mastodon\Conversation::class,             [R::DELETE      ]],
+			'/conversations/{id:\d+}/read'       => [Module\Api\Mastodon\Conversation\Read::class,        [R::POST        ]],
 			'/custom_emojis'                     => [Module\Api\Mastodon\CustomEmojis::class,             [R::GET         ]],
 			'/domain_blocks'                     => [Module\Api\Mastodon\Unimplemented::class,            [R::GET, R::POST, R::DELETE]], // not supported
 			'/directory'                         => [Module\Api\Mastodon\Directory::class,                [R::GET         ]],


### PR DESCRIPTION
We now support some of the API endpoints that are used for private conversations. Direct mails aren't working at the moment with the clients that I tested, although the tests looked fine.

Checking this will be part of a later PR.