### PR TITLE
Fix Message button.

### DIFF
--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -145,7 +145,7 @@ class Profile
 	 */
 	public static function load(App $a, $nickname, array $profiledata = [], $show_connect = true)
 	{
-		$user = DBA::selectFirst('user', [], ['nickname' => $nickname, 'account_removed' => false]);
+		$user = User::getByNickname($nickname);
 
 		if (!DBA::isResult($user) && empty($profiledata)) {
 			Logger::log('profile error: ' . DI::args()->getQueryString(), Logger::DEBUG);

--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -169,12 +169,13 @@ class Profile
 		if (empty($user['uid'])) {
 			$profile = [];
 		} else {
+			$contact_id = Contact::getIdForURL(Strings::normaliseLink(DI::baseurl() . '/profile/' . $nickname), local_user());
 			$profile = array_merge(
 				$user,
+				Contact::getById($contact_id),
 				Profile::getByUID($user['uid']),
-				Contact::getById(Contact::getIdForURL(Strings::normaliseLink(DI::baseurl() . '/profile/' . $nickname), local_user()))
 			);
-			$profile['cid'] = $profile['id'];
+			$profile['cid'] = $contact_id;
 		}
 
 		if (empty($profile) && empty($profiledata)) {

--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -145,7 +145,7 @@ class Profile
 	 */
 	public static function load(App $a, $nickname, array $profiledata = [], $show_connect = true)
 	{
-		$user = DBA::selectFirst('user', ['uid'], ['nickname' => $nickname, 'account_removed' => false]);
+		$user = DBA::selectFirst('user', [], ['nickname' => $nickname, 'account_removed' => false]);
 
 		if (!DBA::isResult($user) && empty($profiledata)) {
 			Logger::log('profile error: ' . DI::args()->getQueryString(), Logger::DEBUG);
@@ -166,7 +166,16 @@ class Profile
 			}
 		}
 
-		$profile = !empty($user['uid']) ? User::getOwnerDataById($user['uid'], false) : [];
+		if (empty($user['uid'])) {
+			$profile = [];
+		} else {
+			$profile = array_merge(
+				$user,
+				Profile::getByUID($user['uid']),
+				Contact::getById(Contact::getIdForURL(Strings::normaliseLink(DI::baseurl() . '/profile/' . $nickname), local_user()))
+			);
+			$profile['cid'] = $profile['id'];
+		}
 
 		if (empty($profile) && empty($profiledata)) {
 			Logger::log('profile error: ' . DI::args()->getQueryString(), Logger::DEBUG);
@@ -334,7 +343,7 @@ class Profile
 
 			if (Contact::canReceivePrivateMessages($profile)) {
 				if ($visitor_is_followed || $visitor_is_following) {
-					$wallmessage_link = $visitor_base_path . '/message/new/' . base64_encode($profile['addr'] ?? '');
+					$wallmessage_link = $visitor_base_path . '/message/new/' . $profile['cid'];
 				} elseif ($visitor_is_authenticated && !empty($profile['unkmail'])) {
 					$wallmessage_link = 'wallmessage/' . $profile['nickname'];
 				}


### PR DESCRIPTION
Really, actually fixed this time.

I'm not sure the way I've done this is the best way (could've done it in one query instead of two with raw SQL), but it works. getOwnerDataById returns the contact record where 'self' is true (i.e., the contact record owned by the user represented by the contact record), when what you actually want is the contact record for the profile being viewed owned by the logged-in user (i.e., where contact.uid is local_user()).

Also, looks like maybe message links used base64 encodings of the user's fediverse address at one point, but the page definitely expects the bare contact ID now, so I had to change that as well.