### PR TITLE
Don't delete local tombstone contacts

### DIFF
--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -1941,6 +1941,11 @@ class Contact
 			return false;
 		}
 
+		if (Contact::isLocal($ret['url'])) {
+			Logger::info('Local contacts are not updated here.');
+			return true;
+		}
+
 		if (!empty($ret['account-type']) && $ret['account-type'] == User::ACCOUNT_TYPE_DELETED) {
 			Logger::info('Deleted account', ['id' => $id, 'url' => $ret['url'], 'ret' => $ret]);
 			self::remove($id);

--- a/src/Util/HTTPSignature.php
+++ b/src/Util/HTTPSignature.php
@@ -558,8 +558,10 @@ class HTTPSignature
 		if (!empty($key['url']) && !empty($key['type']) && ($key['type'] == 'Tombstone')) {
 			Logger::info('Actor is a tombstone', ['key' => $key]);
 
-			// We now delete everything that we possibly knew from this actor
-			Contact::deleteContactByUrl($key['url']);
+			if (!Contact::isLocal($key['url'])) {
+				// We now delete everything that we possibly knew from this actor
+				Contact::deleteContactByUrl($key['url']);
+			}
 			return null;
 		}
 


### PR DESCRIPTION
See https://forum.friendi.ca/display/e18176ef-2060-a823-5c21-37b659713767

It seems as if it can happen that local contacts are treated like remote contacts concerning the handling of tombstones (means deleted accounts). Of course this should not be done.