### PR TITLE
Don't create automated summaries

### DIFF
--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -1525,11 +1525,20 @@ class Transmitter
 
 		if ($type == 'Note') {
 			$body = $item['raw-body'] ?? self::removePictures($body);
-		} elseif (($type == 'Article') && empty($data['summary'])) {
-			$regexp = "/[@!]\[url\=([^\[\]]*)\].*?\[\/url\]/ism";
-			$summary = preg_replace_callback($regexp, ['self', 'mentionAddrCallback'], $body);
-			$data['summary'] = BBCode::toPlaintext(Plaintext::shorten(self::removePictures($summary), 1000));
 		}
+
+		/**
+		 * @todo Improve the automated summary
+		 * This part is currently deactivated. The automated summary seems to be more
+		 * confusing than helping. But possibly we will find a better way.
+		 * So the code is left here for now as a reminder
+		 * 
+		 * } elseif (($type == 'Article') && empty($data['summary'])) {
+		 * 		$regexp = "/[@!]\[url\=([^\[\]]*)\].*?\[\/url\]/ism";
+		 * 		$summary = preg_replace_callback($regexp, ['self', 'mentionAddrCallback'], $body);
+		 * 		$data['summary'] = BBCode::toPlaintext(Plaintext::shorten(self::removePictures($summary), 1000));
+		 * }
+		 */
 
 		if (empty($item['uid']) || !Feature::isEnabled($item['uid'], 'explicit_mentions')) {
 			$body = self::prependMentions($body, $item['uri-id'], $item['author-link']);


### PR DESCRIPTION
See the (German) discussion here: https://loma.ml/display/373ebf56-4960-a91d-e5c2-350749317327

Posts that are transmitted as articles aren't fully displayed on Mastodon. Only the title, the post link and optionally a summary is transmitted. This summary had been created automatically. But this seems to had been more confusing than helping. So for now this is deacticated.