### PR TITLE
Issue 10264: Remote comments for visitors

### DIFF
--- a/mod/dfrn_poll.php
+++ b/mod/dfrn_poll.php
@@ -128,6 +128,7 @@ function dfrn_poll_init(App $a)
 					$_SESSION['visitor_handle'] = $r[0]['addr'];
 					$_SESSION['visitor_visiting'] = $r[0]['uid'];
 					$_SESSION['my_url'] = $r[0]['url'];
+					$_SESSION['remote_comment'] = $r[0]['subscribe'];
 
 					Session::setVisitorsContacts();
 
@@ -497,8 +498,10 @@ function dfrn_poll_content(App $a)
 					$_SESSION['authenticated'] = 1;
 					$_SESSION['visitor_id'] = $r[0]['id'];
 					$_SESSION['visitor_home'] = $r[0]['url'];
+					$_SESSION['visitor_handle'] = $r[0]['addr'];
 					$_SESSION['visitor_visiting'] = $r[0]['uid'];
 					$_SESSION['my_url'] = $r[0]['url'];
+					$_SESSION['remote_comment'] = $r[0]['subscribe'];
 
 					Session::setVisitorsContacts();
 

--- a/src/App.php
+++ b/src/App.php
@@ -34,6 +34,7 @@ use Friendica\Core\L10n;
 use Friendica\Core\System;
 use Friendica\Core\Theme;
 use Friendica\Database\Database;
+use Friendica\Model\Contact;
 use Friendica\Model\Profile;
 use Friendica\Module\Special\HTTPException as ModuleHTTPException;
 use Friendica\Network\HTTPException;
@@ -464,6 +465,11 @@ class App
 						if (Core\Session::get('visitor_home') != $_GET["zrl"]) {
 							Core\Session::set('my_url', $_GET['zrl']);
 							Core\Session::set('authenticated', 0);
+
+							$remote_contact = Contact::getByURL($_GET['zrl'], false, ['subscribe']);
+							if (!empty($remote_contact['subscribe'])) {
+								$_SESSION['remote_comment'] = $remote_contact['subscribe'];
+							}
 						}
 
 						Model\Profile::zrlInit($this);

--- a/src/Object/Post.php
+++ b/src/Object/Post.php
@@ -401,9 +401,13 @@ class Post
 		}
 
 		// Fetching of Diaspora posts doesn't always work. There are issues with reshares and possibly comments
-		if (($item['network'] != Protocol::DIASPORA) && empty($comment) && !empty(Session::get('remote_comment'))) {
+		if (!local_user() && ($item['network'] != Protocol::DIASPORA) && !empty(Session::get('remote_comment'))) {
 			$remote_comment = [DI::l10n()->t('Comment this item on your system'), DI::l10n()->t('Remote comment'),
 				str_replace('{uri}', urlencode($item['uri']), Session::get('remote_comment'))];
+
+			// Ensure to either display the remote comment or the local activities
+			$buttons = [];
+			$comment_html = '';
 		} else {
 			$remote_comment = '';
 		}


### PR DESCRIPTION
Hopefully fixes #10264

Either we should display the "remote comment" options or the regular local activities.

Also now the system should always fetch the remote url of a contact to offer the remote comment possibility.