### PR TITLE
Fix PHPUnit 8 warnings

### DIFF
--- a/tests/legacy/ApiTest.php
+++ b/tests/legacy/ApiTest.php
@@ -189,7 +189,7 @@ class ApiTest extends FixtureTest
 	private function assertXml($result = '', $root_element = '')
 	{
 		self::assertStringStartsWith('<?xml version="1.0"?>', $result);
-		self::assertContains('<' . $root_element, $result);
+		self::assertStringContainsString('<' . $root_element, $result);
 		// We could probably do more checks here.
 	}
 
@@ -1505,7 +1505,7 @@ class ApiTest extends FixtureTest
 		$result             = api_search('json');
 		foreach ($result['status'] as $status) {
 			self::assertStatus($status);
-			self::assertContains('reply', $status['text'], '', true);
+			self::assertStringContainsStringIgnoringCase('reply', $status['text'], '', true);
 		}
 	}
 
@@ -1521,7 +1521,7 @@ class ApiTest extends FixtureTest
 		$result            = api_search('json');
 		foreach ($result['status'] as $status) {
 			self::assertStatus($status);
-			self::assertContains('reply', $status['text'], '', true);
+			self::assertStringContainsStringIgnoringCase('reply', $status['text'], '', true);
 		}
 	}
 
@@ -1537,7 +1537,7 @@ class ApiTest extends FixtureTest
 		$result          = api_search('json');
 		foreach ($result['status'] as $status) {
 			self::assertStatus($status);
-			self::assertContains('reply', $status['text'], '', true);
+			self::assertStringContainsStringIgnoringCase('reply', $status['text'], '', true);
 		}
 	}
 
@@ -1551,7 +1551,7 @@ class ApiTest extends FixtureTest
 		$result        = api_search('json');
 		foreach ($result['status'] as $status) {
 			self::assertStatus($status);
-			self::assertContains('#friendica', $status['text'], '', true);
+			self::assertStringContainsStringIgnoringCase('#friendica', $status['text'], '', true);
 		}
 	}
 
@@ -2874,7 +2874,7 @@ class ApiTest extends FixtureTest
 		$_POST['text']        = 'message_text';
 		$_POST['screen_name'] = $this->friendUser['nick'];
 		$result               = api_direct_messages_new('json');
-		self::assertContains('message_text', $result['direct_message']['text']);
+		self::assertStringContainsString('message_text', $result['direct_message']['text']);
 		self::assertEquals('selfcontact', $result['direct_message']['sender_screen_name']);
 		self::assertEquals(1, $result['direct_message']['friendica_seen']);
 	}
@@ -2891,8 +2891,8 @@ class ApiTest extends FixtureTest
 		$_POST['screen_name'] = $this->friendUser['nick'];
 		$_REQUEST['title']    = 'message_title';
 		$result               = api_direct_messages_new('json');
-		self::assertContains('message_text', $result['direct_message']['text']);
-		self::assertContains('message_title', $result['direct_message']['text']);
+		self::assertStringContainsString('message_text', $result['direct_message']['text']);
+		self::assertStringContainsString('message_title', $result['direct_message']['text']);
 		self::assertEquals('selfcontact', $result['direct_message']['sender_screen_name']);
 		self::assertEquals(1, $result['direct_message']['friendica_seen']);
 	}

--- a/tests/src/Model/Storage/FilesystemStorageTest.php
+++ b/tests/src/Model/Storage/FilesystemStorageTest.php
@@ -81,7 +81,7 @@ class FilesystemStorageTest extends StorageTest
 	public function testMissingDirPermissions()
 	{
 		$this->expectException(StorageException::class);
-		$this->expectExceptionMessageRegExp("/Filesystem storage failed to create \".*\". Check you write permissions./");
+		$this->expectExceptionMessageMatches("/Filesystem storage failed to create \".*\". Check you write permissions./");
 		$this->root->getChild('storage')->chmod(000);
 
 		$instance = $this->getInstance();
@@ -97,7 +97,7 @@ class FilesystemStorageTest extends StorageTest
 		static::markTestIncomplete("Cannot catch file_put_content() error due vfsStream failure");
 
 		$this->expectException(StorageException::class);
-		$this->expectExceptionMessageRegExp("/Filesystem storage failed to save data to \".*\". Check your write permissions/");
+		$this->expectExceptionMessageMatches("/Filesystem storage failed to save data to \".*\". Check your write permissions/");
 
 		vfsStream::create(['storage' => ['f0' => ['c0' => ['k0i0' => '']]]], $this->root);
 

--- a/tests/src/Util/BasePathTest.php
+++ b/tests/src/Util/BasePathTest.php
@@ -68,7 +68,7 @@ class BasePathTest extends MockedTest
 	public function testFailedBasePath()
 	{
 		$this->expectException(\Exception::class);
-		$this->expectExceptionMessageRegExp("/(.*) is not a valid basepath/");
+		$this->expectExceptionMessageMatches("/(.*) is not a valid basepath/");
 		
 		$basepath = new BasePath('/now23452sgfgas', []);
 		$basepath->getPath();

--- a/tests/src/Util/Config/ConfigFileLoaderTest.php
+++ b/tests/src/Util/Config/ConfigFileLoaderTest.php
@@ -59,7 +59,7 @@ class ConfigFileLoaderTest extends MockedTest
 	 */
 	public function testLoadConfigWrong()
 	{
-		$this->expectExceptionMessageRegExp("/Error loading config file \w+/");
+		$this->expectExceptionMessageMatches("/Error loading config file \w+/");
 		$this->expectException(\Exception::class);
 		$this->delConfigFile('local.config.php');
 

--- a/tests/src/Util/EMailerTest.php
+++ b/tests/src/Util/EMailerTest.php
@@ -78,16 +78,16 @@ class EMailerTest extends MockedTest
 
 		self::assertTrue($emailer->send($testEmail));
 
-		self::assertContains("X-Friendica-Host: friendica.local", EmailerSpy::$MAIL_DATA['headers']);
-		self::assertContains("X-Friendica-Platform: Friendica", EmailerSpy::$MAIL_DATA['headers']);
-		self::assertContains("List-ID: <notification.friendica.local>", EmailerSpy::$MAIL_DATA['headers']);
-		self::assertContains("List-Archive: <http://friendica.local/notifications/system>", EmailerSpy::$MAIL_DATA['headers']);
-		self::assertContains("Reply-To: Sender <sender@friendica.local>", EmailerSpy::$MAIL_DATA['headers']);
-		self::assertContains("MIME-Version: 1.0", EmailerSpy::$MAIL_DATA['headers']);
+		self::assertStringContainsString("X-Friendica-Host: friendica.local", EmailerSpy::$MAIL_DATA['headers']);
+		self::assertStringContainsString("X-Friendica-Platform: Friendica", EmailerSpy::$MAIL_DATA['headers']);
+		self::assertStringContainsString("List-ID: <notification.friendica.local>", EmailerSpy::$MAIL_DATA['headers']);
+		self::assertStringContainsString("List-Archive: <http://friendica.local/notifications/system>", EmailerSpy::$MAIL_DATA['headers']);
+		self::assertStringContainsString("Reply-To: Sender <sender@friendica.local>", EmailerSpy::$MAIL_DATA['headers']);
+		self::assertStringContainsString("MIME-Version: 1.0", EmailerSpy::$MAIL_DATA['headers']);
 		// Base64 "Test Text"
-		self::assertContains(chunk_split(base64_encode('Test Text')), EmailerSpy::$MAIL_DATA['body']);
+		self::assertStringContainsString(chunk_split(base64_encode('Test Text')), EmailerSpy::$MAIL_DATA['body']);
 		// Base64 "Test Message<b>Bold</b>"
-		self::assertContains(chunk_split(base64_encode("Test Message<b>Bold</b>")), EmailerSpy::$MAIL_DATA['body']);
+		self::assertStringContainsString(chunk_split(base64_encode("Test Message<b>Bold</b>")), EmailerSpy::$MAIL_DATA['body']);
 		self::assertEquals("Test Subject", EmailerSpy::$MAIL_DATA['subject']);
 		self::assertEquals("recipient@friendica.local", EmailerSpy::$MAIL_DATA['to']);
 		self::assertEquals("-f sender@friendica.local", EmailerSpy::$MAIL_DATA['parameters']);

--- a/tests/src/Util/Logger/AbstractLoggerTest.php
+++ b/tests/src/Util/Logger/AbstractLoggerTest.php
@@ -106,8 +106,8 @@ abstract class AbstractLoggerTest extends MockedTest
 		$logger->emergency('A {psr} test', ['psr' => 'working']);
 		$logger->alert('An {array} test', ['array' => ['it', 'is', 'working']]);
 		$text = $this->getContent();
-		self::assertContains('A working test', $text);
-		self::assertContains('An ["it","is","working"] test', $text);
+		self::assertStringContainsString('A working test', $text);
+		self::assertStringContainsString('An ["it","is","working"] test', $text);
 	}
 
 	/**
@@ -119,9 +119,9 @@ abstract class AbstractLoggerTest extends MockedTest
 		$logger->emergency('A test');
 
 		$text = $this->getContent();
-		self::assertContains('"file":"' . self::FILE . '"', $text);
-		self::assertContains('"line":' . self::LINE, $text);
-		self::assertContains('"function":"' . self::FUNC . '"', $text);
+		self::assertStringContainsString('"file":"' . self::FILE . '"', $text);
+		self::assertStringContainsString('"line":' . self::LINE, $text);
+		self::assertStringContainsString('"function":"' . self::FUNC . '"', $text);
 	}
 
 	/**
@@ -157,7 +157,7 @@ abstract class AbstractLoggerTest extends MockedTest
 
 		self::assertLogline($text);
 
-		self::assertContains(@json_encode($context), $text);
+		self::assertStringContainsString(@json_encode($context), $text);
 	}
 
 	/**
@@ -176,7 +176,7 @@ abstract class AbstractLoggerTest extends MockedTest
 
 		self::assertLogline($text);
 
-		self::assertContains(@json_encode($assertion), $this->getContent());
+		self::assertStringContainsString(@json_encode($assertion), $this->getContent());
 	}
 
 	public function testNoObjectHandling()
@@ -187,6 +187,6 @@ abstract class AbstractLoggerTest extends MockedTest
 
 		self::assertLogline($text);
 
-		self::assertContains('test', $this->getContent());
+		self::assertStringContainsString('test', $this->getContent());
 	}
 }

--- a/tests/src/Util/Logger/StreamLoggerTest.php
+++ b/tests/src/Util/Logger/StreamLoggerTest.php
@@ -128,7 +128,7 @@ class StreamLoggerTest extends AbstractLoggerTest
 	public function testWrongUrl()
 	{
 		$this->expectException(\UnexpectedValueException::class);
-		$this->expectExceptionMessageRegExp("/The stream or file .* could not be opened: .* /");
+		$this->expectExceptionMessageMatches("/The stream or file .* could not be opened: .* /");
 
 		$logfile = vfsStream::newFile('friendica.log')
 			->at($this->root)->chmod(0);
@@ -144,7 +144,7 @@ class StreamLoggerTest extends AbstractLoggerTest
 	public function testWrongDir()
 	{
 		$this->expectException(\UnexpectedValueException::class);
-		$this->expectExceptionMessageRegExp("/Directory .* cannot get created: .* /");
+		$this->expectExceptionMessageMatches("/Directory .* cannot get created: .* /");
 
 		static::markTestIncomplete('We need a platform independent way to set directory to readonly');
 
@@ -159,7 +159,7 @@ class StreamLoggerTest extends AbstractLoggerTest
 	public function testWrongMinimumLevel()
 	{
 		$this->expectException(\InvalidArgumentException::class);
-		$this->expectExceptionMessageRegExp("/The level \".*\" is not valid./");
+		$this->expectExceptionMessageMatches("/The level \".*\" is not valid./");
 
 		$logger = new StreamLogger('test', 'file.text', $this->introspection, $this->fileSystem, 'NOPE');
 	}
@@ -170,7 +170,7 @@ class StreamLoggerTest extends AbstractLoggerTest
 	public function testWrongLogLevel()
 	{
 		$this->expectException(\InvalidArgumentException::class);
-		$this->expectExceptionMessageRegExp("/The level \".*\" is not valid./");
+		$this->expectExceptionMessageMatches("/The level \".*\" is not valid./");
 
 		$logfile = vfsStream::newFile('friendica.log')
 			->at($this->root);

--- a/tests/src/Util/Logger/SyslogLoggerTest.php
+++ b/tests/src/Util/Logger/SyslogLoggerTest.php
@@ -63,7 +63,7 @@ class SyslogLoggerTest extends AbstractLoggerTest
 	public function testWrongMinimumLevel()
 	{
 		$this->expectException(\InvalidArgumentException::class);
-		$this->expectExceptionMessageRegExp("/The level \".*\" is not valid./");
+		$this->expectExceptionMessageMatches("/The level \".*\" is not valid./");
 		
 		$logger = new SyslogLoggerWrapper('test', $this->introspection, 'NOPE');
 	}
@@ -74,7 +74,7 @@ class SyslogLoggerTest extends AbstractLoggerTest
 	public function testWrongLogLevel()
 	{
 		$this->expectException(\InvalidArgumentException::class);
-		$this->expectExceptionMessageRegExp("/The level \".*\" is not valid./");
+		$this->expectExceptionMessageMatches("/The level \".*\" is not valid./");
 
 		$logger = new SyslogLoggerWrapper('test', $this->introspection);
 
@@ -88,7 +88,7 @@ class SyslogLoggerTest extends AbstractLoggerTest
 	{
 		if (PHP_MAJOR_VERSION < 8) {
 			$this->expectException(\UnexpectedValueException::class);
-			$this->expectExceptionMessageRegExp("/Can\'t open syslog for ident \".*\" and facility \".*\": .* /");
+			$this->expectExceptionMessageMatches("/Can\'t open syslog for ident \".*\" and facility \".*\": .* /");
 		} else {
 			$this->expectException(\TypeError::class);
 			$this->expectExceptionMessage("openlog(): Argument #3 (\$facility) must be of type int, string given");


### PR DESCRIPTION
- Replace `expectExceptionMessageRegExp()`  with `expectExceptionMessageMatches()`
- Replace `assertContains()` for string assertions

But this leads to another problem :-)

PHPUnit 8.0 isn't possible with PHP 7.0, so everyone, who installs PHPUnit per `composer` will get PHPUnit 6. And PHPUnit 6 doesn't have both methods yet ...