### PR TITLE
Update vagrant devbox provisioning

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -34,10 +34,14 @@ Vagrant.configure(2) do |config|
   #
   #   # Customize the amount of memory on the VM:
     vb.memory = server_memory
+
+    unless Vagrant.has_plugin?("vagrant-vbguest")
+      raise 'vagrant-vbguest plugin is not installed! Install with "vagrant plugin install vagrant-vbguest"'
+    end
   end
 
   # Enable provisioning with a shell script.
-  config.vm.provision "shell", path: "./bin/dev/vagrant_provision.sh"
+  config.vm.provision "shell", path: "./bin/dev/vagrant_provision.sh", privileged: true
     # run: "always"
     # run: "once"
 end

--- a/bin/dev/vagrant_provision.sh
+++ b/bin/dev/vagrant_provision.sh
@@ -1,13 +1,23 @@
 #!/bin/bash
-#Script to setup the vagrant instance for running friendica
+# Script to setup the vagrant instance for running friendica
 #
-#DO NOT RUN on your physical machine as this won't be of any use
-#and f.e. deletes your /var/www/ folder!
-echo "Friendica configuration settings"
-sudo apt-get update
+# DO NOT RUN on your physical machine as this won't be of any use
+# and f.e. deletes your /var/www/ folder!
+#
+# Run as root by vagrant
+#
+##
 
-# Install virtualbox guest additions
-sudo apt-get install virtualbox-guest-x11
+ADMIN_NICK="admin"
+ADMIN_PASSW="admin"
+
+USER_NICK="user"
+USER_PASSW="user"
+
+##
+
+echo "Friendica configuration settings"
+apt-get update
 
 #Selfsigned cert
 echo ">>> Installing *.xip.io self-signed SSL"
@@ -23,32 +33,32 @@ localityName=New Haven/
 commonName=$DOMAIN/
 subjectAltName=DNS:$EXTRADOMAIN
 "
-sudo mkdir -p "$SSL_DIR"
-sudo openssl genrsa -out "$SSL_DIR/xip.io.key" 4096
-sudo openssl req -new -subj "$(echo -n "$SUBJ" | tr "\n" "/")" -key "$SSL_DIR/xip.io.key" -out "$SSL_DIR/xip.io.csr" -passin pass:$PASSPHRASE
-sudo openssl x509 -req -days 365 -in "$SSL_DIR/xip.io.csr" -signkey "$SSL_DIR/xip.io.key" -out "$SSL_DIR/xip.io.crt"
+mkdir -p "$SSL_DIR"
+openssl genrsa -out "$SSL_DIR/xip.io.key" 4096
+openssl req -new -subj "$(echo -n "$SUBJ" | tr "\n" "/")" -key "$SSL_DIR/xip.io.key" -out "$SSL_DIR/xip.io.csr" -passin pass:$PASSPHRASE
+openssl x509 -req -days 365 -in "$SSL_DIR/xip.io.csr" -signkey "$SSL_DIR/xip.io.key" -out "$SSL_DIR/xip.io.crt"
 
 
 #Install apache2
 echo ">>> Installing Apache2 webserver"
-sudo apt-get install -y apache2
-sudo a2enmod rewrite actions ssl
-sudo cp /vagrant/bin/dev/vagrant_vhost.sh /usr/local/bin/vhost
-sudo chmod guo+x /usr/local/bin/vhost
-sudo vhost -s 192.168.22.10.xip.io -d /var/www -p /etc/ssl/xip.io -c xip.io -a friendica.local
-sudo a2dissite 000-default
-sudo service apache2 restart
+apt-get install -qq apache2
+a2enmod rewrite actions ssl
+cp /vagrant/bin/dev/vagrant_vhost.sh /usr/local/bin/vhost
+chmod guo+x /usr/local/bin/vhost
+vhost -s 192.168.22.10.xip.io -d /var/www -p /etc/ssl/xip.io -c xip.io -a friendica.local
+a2dissite 000-default
+service apache2 restart
 
 #Install php
 echo ">>> Installing PHP7"
-sudo apt-get install -y php libapache2-mod-php php-cli php-mysql php-curl php-gd php-mbstring php-xml imagemagick php-imagick php-zip
-sudo systemctl restart apache2
+apt-get install -qq php libapache2-mod-php php-cli php-mysql php-curl php-gd php-mbstring php-xml imagemagick php-imagick php-zip
+systemctl restart apache2
 
 #Install mysql
 echo ">>> Installing Mysql"
-sudo debconf-set-selections <<< "mariadb-server mariadb-server/root_password password root"
-sudo debconf-set-selections <<< "mariadb-server mariadb-server/root_password_again password root"
-sudo apt-get install -qq mariadb-server
+debconf-set-selections <<< "mariadb-server mariadb-server/root_password password root"
+debconf-set-selections <<< "mariadb-server mariadb-server/root_password_again password root"
+apt-get install -qq mariadb-server
 # enable remote access
 # setting the mysql bind-address to allow connections from everywhere
 sed -i "s/bind-address.*/bind-address = 0.0.0.0/" /etc/mysql/my.cnf
@@ -66,41 +76,60 @@ $MYSQL -uroot -proot -e "FLUSH PRIVILEGES"
 systemctl restart mysql
 
 
-
 #configure rudimentary mail server (local delivery only)
 #add Friendica accounts for local user accounts, use email address like vagrant@friendica.local, read the email with 'mail'.
+echo ">>> Installing 'Local Only' postfix"
 debconf-set-selections <<< "postfix postfix/mailname string friendica.local"
 debconf-set-selections <<< "postfix postfix/main_mailer_type string 'Local Only'"
-sudo apt-get install -y postfix mailutils libmailutils-dev
-sudo echo -e "friendica1:	vagrant\nfriendica2:	vagrant\nfriendica3:	vagrant\nfriendica4:	vagrant\nfriendica5:	vagrant" >> /etc/aliases && sudo newaliases
+apt-get install -qq postfix mailutils libmailutils-dev
+echo -e "friendica1:	vagrant\nfriendica2:	vagrant\nfriendica3:	vagrant\nfriendica4:	vagrant\nfriendica5:	vagrant" >> /etc/aliases && newaliases
 
 # Friendica needs git for fetching some dependencies
-sudo apt-get install -y git
+echo ">>> Installing git"
+apt-get install -qq git
 
 #make the vagrant directory the docroot
-sudo rm -rf /var/www/
-sudo ln -fs /vagrant /var/www
+echo ">>> Symlink /var/www to /vagrant"
+rm -rf /var/www/
+ln -fs /vagrant /var/www
 
 # install deps with composer
-sudo apt install unzip
+echo ">>> Installing php requirements"
+apt install unzip
 cd /var/www
-sudo -u www-data php bin/composer.phar install
+php bin/composer.phar install
 
-# initial config file for friendica in vagrant
-cp /vagrant/mods/local.config.vagrant.php /vagrant/config/local.config.php
+
+echo ">>> Setup Friendica"
 
 # copy the .htaccess-dist file to .htaccess so that rewrite rules work
 cp /vagrant/.htaccess-dist /vagrant/.htaccess
 
 # create the friendica database
 echo "create database friendica DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci" | $MYSQL -u root -proot
-# import test database
-$MYSQL -uroot -proot friendica < /vagrant/friendica_test_data.sql
+# import test database (disabled because too old)
+#$MYSQL -uroot -proot friendica < /vagrant/friendica_test_data.sql
+
+# install friendica
+bin/console autoinstall -f /vagrant/mods/local.config.vagrant.php
+
+# add users
+# (disable a bunch of validation because this is a dev install, deh, it needs invalid emails and stupid passwords)
+bin/console config system disable_email_validation 1
+bin/console config system disable_password_exposed 1
+bin/console user add "$ADMIN_NICK" "$ADMIN_NICK" "$ADMIN_NICK@friendica.local" en
+bin/console user password "$ADMIN_NICK" "$ADMIN_PASSW"
+bin/console user add "$USER_NICK" "$USER_NICK" "$USER_NICK@friendica.local" en
+bin/console user password "$USER_NICK" "$USER_PASSW"
+
+# set the admin
+bin/console config config admin_email ""$ADMIN_NICK@friendica.local""
+
 
 # create cronjob - activate if you have enough memory in you dev VM
-echo "*/10 * * * * cd /vagrant; /usr/bin/php bin/worker.php" >> friendicacron
-sudo crontab friendicacron
-sudo rm friendicacron
+# cronjob runs as www-data user
+echo ">>> Installing cronjob"
+echo "*/10 * * * *    www-data    cd /vagrant; /usr/bin/php bin/worker.php" >> /etc/cron.d/friendica
 
 # friendica needs write access to /tmp
-sudo chmod 777 /tmp
+chmod 777 /tmp

--- a/mods/local.config.vagrant.php
+++ b/mods/local.config.vagrant.php
@@ -29,6 +29,7 @@ return [
 	// ****************************************************************
 
 	'config' => [
+		'hostname' => 'friendica.local',
 		'admin_email' => 'admin@friendica.local',
 		'sitename' => 'Friendica Social Network',
 		'register_policy' => \Friendica\Module\Register::OPEN,
@@ -38,5 +39,6 @@ return [
 		'default_timezone' => 'UTC',
 		'language' => 'en',
 		'basepath' => '/vagrant',
+		'ssl_policy' => \Friendica\App\BaseURL::SSL_POLICY_SELFSIGN,
 	],
 ];


### PR DESCRIPTION
- run provisioning script as root
- don't load friendica_test_data.sql which is outdated
- install friendica and create users via console commands
- install cronjob in `/etc/cron.d/friendica` and run as `www-data` user
- force to have "vagrant-vbguest" insstalled. We need updated vbguest
  addins to correctly mount local folder
- add "config.hostname" and "system.ssl_policy" values in
  `local.config.vagrant.php`