### PR TITLE
Re-activate API tests

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -8,7 +8,7 @@ coverage:
   round: down
   range: "70...100"
   status:
-    project: off
-    patch: off
+    project: false
+    patch: false
 
-comment: off
+comment: false

--- a/.drone.yml
+++ b/.drone.yml
@@ -67,6 +67,11 @@ type: docker
 name: php7.3-mariadb
 
 steps:
+  - name: Composer install
+    image: friendicaci/php7.4:php7.4.18
+    commands:
+      - composer validate
+      - composer install --prefer-dist
   - name: Test Friendica
     image: friendicaci/php7.3:php7.3.28
     environment:
@@ -79,8 +84,6 @@ steps:
       MEMCACHED_HOST: "memcached"
       MEMCACHE_HOST: "memcached"
     commands:
-      - composer validate
-      - composer install --prefer-dist
       - cp config/local-sample.config.php config/local.config.php
       - if ! bin/wait-for-connection $MYSQL_HOST $MYSQL_PORT 300; then echo "[ERROR] Waited 300 seconds, no response" >&2; exit 1; fi
       - mysql -h$MYSQL_HOST -P$MYSQL_PORT -p$MYSQL_PASSWORD -u$MYSQL_USER $MYSQL_DATABASE < database.sql
@@ -108,6 +111,11 @@ type: docker
 name: php7.4-mariadb
 
 steps:
+  - name: Composer install
+    image: friendicaci/php7.4:php7.4.18
+    commands:
+      - composer validate
+      - composer install --prefer-dist
   - name: Test Friendica
     image: friendicaci/php7.4:php7.4.18
     environment:
@@ -122,8 +130,6 @@ steps:
       XDEBUG_MODE: "coverage"
     commands:
       - phpenmod xdebug
-      - composer validate
-      - composer install --prefer-dist
       - cp config/local-sample.config.php config/local.config.php
       - if ! bin/wait-for-connection $MYSQL_HOST $MYSQL_PORT 300; then echo "[ERROR] Waited 300 seconds, no response" >&2; exit 1; fi
       - mysql -h$MYSQL_HOST -P$MYSQL_PORT -p$MYSQL_PASSWORD -u$MYSQL_USER $MYSQL_DATABASE < database.sql
@@ -161,6 +167,11 @@ type: docker
 name: php8.0-mariadb
 
 steps:
+  - name: Composer install
+    image: friendicaci/php7.4:php7.4.18
+    commands:
+      - composer validate
+      - composer install --prefer-dist
   - name: Test Friendica
     image: friendicaci/php8.0:php8.0.5
     environment:
@@ -173,8 +184,6 @@ steps:
       MEMCACHED_HOST: "memcached"
       MEMCACHE_HOST: "memcached"
     commands:
-      - composer validate
-      - composer install --prefer-dist
       - cp config/local-sample.config.php config/local.config.php
       - if ! bin/wait-for-connection $MYSQL_HOST $MYSQL_PORT 300; then echo "[ERROR] Waited 300 seconds, no response" >&2; exit 1; fi
       - mysql -h$MYSQL_HOST -P$MYSQL_PORT -p$MYSQL_PASSWORD -u$MYSQL_USER $MYSQL_DATABASE < database.sql

--- a/tests/DatabaseTestTrait.php
+++ b/tests/DatabaseTestTrait.php
@@ -34,6 +34,8 @@ trait DatabaseTestTrait
 		StaticDatabase::statConnect($_SERVER);
 		// Rollbacks every DB usage (in case the test couldn't call tearDown)
 		StaticDatabase::statRollback();
+		// Rollback the first, outer transaction just 2 be sure
+		StaticDatabase::getGlobConnection()->rollBack();
 		// Start the first, outer transaction
 		StaticDatabase::getGlobConnection()->beginTransaction();
 	}

--- a/tests/legacy/ApiTest.php
+++ b/tests/legacy/ApiTest.php
@@ -2266,6 +2266,7 @@ class ApiTest extends FixtureTest
 			[
 				'network' => 'feed',
 				'title'   => 'item_title',
+				'uri-id'  => 1,
 				// We need a long string to test that it is correctly cut
 				'body'    => 'perspiciatis impedit voluptatem quis molestiae ea qui ' .
 				             'reiciendis dolorum aut ducimus sunt consequatur inventore dolor ' .
@@ -2308,12 +2309,13 @@ class ApiTest extends FixtureTest
 			[
 				'network' => 'feed',
 				'title'   => 'item_title',
+				'uri-id'  => 1,
 				'body'    => '',
 				'plink'   => 'item_plink'
 			]
 		);
-		self::assertEquals('item_title', $result['text']);
-		self::assertEquals('<h4>item_title</h4><br>item_plink', $result['html']);
+		self::assertEquals("item_title\n\nParent status", $result['text']);
+		self::assertEquals('<h4>item_title</h4><br>Parent statusitem_plink', $result['html']);
 	}
 
 	/**
@@ -2325,8 +2327,9 @@ class ApiTest extends FixtureTest
 	{
 		$result = api_convert_item(
 			[
-				'title' => 'item_title',
-				'body'  => 'item_title item_body'
+				'title'  => 'item_title',
+				'body'   => 'item_title item_body',
+				'uri-id' => 1,
 			]
 		);
 		self::assertEquals('item_title item_body', $result['text']);

--- a/tests/legacy/ApiTest.php
+++ b/tests/legacy/ApiTest.php
@@ -2309,13 +2309,13 @@ class ApiTest extends FixtureTest
 			[
 				'network' => 'feed',
 				'title'   => 'item_title',
-				'uri-id'  => 1,
+				'uri-id'  => -1,
 				'body'    => '',
 				'plink'   => 'item_plink'
 			]
 		);
-		self::assertEquals("item_title\n\nParent status", $result['text']);
-		self::assertEquals('<h4>item_title</h4><br>Parent statusitem_plink', $result['html']);
+		self::assertEquals("item_title", $result['text']);
+		self::assertEquals('<h4>item_title</h4><br>item_plink', $result['html']);
 	}
 
 	/**

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -8,7 +8,7 @@
 		timeoutForLargeTests="900">
 	<testsuite name='friendica'>
 		<directory suffix='.php'>functional/</directory>
-		<directory suffix='.php'>include/</directory>
+		<directory suffix='.php'>legacy/</directory>
 		<directory suffix='.php'>src/</directory>
 	</testsuite>
 	<!-- Filters for Code Coverage -->
@@ -16,14 +16,14 @@
 		<whitelist>
 			<directory suffix=".php">..</directory>
 			<exclude>
-				<directory suffix=".php">config/</directory>
-				<directory suffix=".php">doc/</directory>
-				<directory suffix=".php">images/</directory>
-				<directory suffix=".php">library/</directory>
-				<directory suffix=".php">spec/</directory>
-				<directory suffix=".php">tests/</directory>
-				<directory suffix=".php">view/</directory>
-				<directory suffix=".php">vendor/</directory>
+				<directory suffix=".php">../config/</directory>
+				<directory suffix=".php">../doc/</directory>
+				<directory suffix=".php">../images/</directory>
+				<directory suffix=".php">../library/</directory>
+				<directory suffix=".php">../spec/</directory>
+				<directory suffix=".php">../tests/</directory>
+				<directory suffix=".php">../view/</directory>
+				<directory suffix=".php">../vendor/</directory>
 			</exclude>
 		</whitelist>
 	</filter>


### PR DESCRIPTION
FollowUp #10112

.. Oups .. I accidentally disabled the API tests

And when re-enabling them, I found some really ugly bugs as well ..

Like accidentally commiting transactions because of the `autocommit` flag inside the `DBA::lock()` methods. Because this setting overrules the transaction hierarchy for tests and commits the current test-content straight forward into the DB ...

Sadly calculating the codecov-reporting xml now takes a lot longer than before, so we're back at ~4 minutes test-duration :-/