### PR TITLE
Issue 10306: Improve local delivery

### DIFF
--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -1941,7 +1941,7 @@ class Contact
 			return false;
 		}
 
-		if (Contact::isLocal($ret['url'])) {
+		if (self::isLocal($ret['url'])) {
 			Logger::info('Local contacts are not updated here.');
 			return true;
 		}

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -1355,7 +1355,7 @@ class Item
 	public static function storeForUserByUriId(int $uri_id, int $uid, array $fields = [], int $source_uid = 0)
 	{
 		if ($uid == $source_uid) {
-			Logger::warning('target UID must be be equal to the source UID', ['uri-id' => $uri_id, 'uid' => $uid]);
+			Logger::warning('target UID must not be be equal to the source UID', ['uri-id' => $uri_id, 'uid' => $uid]);
 			return 0;
 		}
 

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -1386,8 +1386,9 @@ class Item
 
 		if ((($item['gravity'] == GRAVITY_COMMENT) || $is_reshare) && !Post::exists(['uri-id' => $item['thr-parent-id'], 'uid' => $uid])) {
 			// Only do an auto complete with the source uid "0" to prevent privavy problems
-			$result = self::storeForUserByUriId($item['thr-parent-id'], $uid);
-			Logger::info('Fetched thread parent', ['uri-id' => $item['thr-parent-id'], 'uid' => $uid, 'result' => $result]);
+			$causer = $item['causer-id'] ?: $item['author-id'];
+			$result = self::storeForUserByUriId($item['thr-parent-id'], $uid, ['causer-id' => $causer, 'post-reason' => self::PR_FETCHED]);
+			Logger::info('Fetched thread parent', ['uri-id' => $item['thr-parent-id'], 'uid' => $uid, 'causer' => $causer, 'result' => $result]);
 		}
 
 		$stored = self::storeForUser($item, $uid);
@@ -1420,12 +1421,9 @@ class Item
 		unset($item['pubmail']);
 		unset($item['forum_mode']);
 
-		//unset($item['post-reason']);
-		//unset($item['protocol']);
 		unset($item['event-id']);
 		unset($item['hidden']);
 		unset($item['notification-type']);
-		//unset($item['resource-id']);
 
 		$item['uid'] = $uid;
 		$item['origin'] = 0;

--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -164,15 +164,16 @@ class Post
 	 * @param array $fields
 	 * @param array $condition
 	 * @param array $params
+	 * @param bool  $user_mode true = post-user-view, false = post-view
 	 * @return bool|array
 	 * @throws \Exception
 	 * @see   DBA::select
 	 */
-	public static function selectFirst(array $fields = [], array $condition = [], $params = [])
+	public static function selectFirst(array $fields = [], array $condition = [], $params = [], bool $user_mode = true)
 	{
 		$params['limit'] = 1;
 
-		$result = self::select($fields, $condition, $params);
+		$result = self::select($fields, $condition, $params, $user_mode);
 
 		if (is_bool($result)) {
 			return $result;

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -312,7 +312,7 @@ class User
 	 */
 	public static function getIdForURL(string $url)
 	{
-		// Avoid any database requests when the hostname isn't even part of the url.
+		// Avoid database queries when the local node hostname isn't even part of the url.
 		if (!Contact::isLocal($url)) {
 			return 0;
 		}

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -313,7 +313,7 @@ class User
 	public static function getIdForURL(string $url)
 	{
 		// Avoid any database requests when the hostname isn't even part of the url.
-		if (!strpos($url, DI::baseUrl()->getHostname())) {
+		if (!Contact::isLocal($url)) {
 			return 0;
 		}
 

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -748,10 +748,6 @@ class Transmitter
 
 		$contacts = DBA::select('contact', ['id', 'url', 'network', 'protocol', 'gsid'], $condition);
 		while ($contact = DBA::fetch($contacts)) {
-			if (Contact::isLocal($contact['url'])) {
-				continue;
-			}
-
 			if (!self::isAPContact($contact, $networks)) {
 				continue;
 			}
@@ -766,7 +762,7 @@ class Transmitter
 
 			$profile = APContact::getByURL($contact['url'], false);
 			if (!empty($profile)) {
-				if (empty($profile['sharedinbox']) || $personal) {
+				if (empty($profile['sharedinbox']) || $personal || Contact::isLocal($contact['url'])) {
 					$target = $profile['inbox'];
 				} else {
 					$target = $profile['sharedinbox'];
@@ -829,15 +825,11 @@ class Transmitter
 				if ($item_profile && ($receiver == $item_profile['followers']) && ($uid == $profile_uid)) {
 					$inboxes = array_merge($inboxes, self::fetchTargetInboxesforUser($uid, $personal, self::isAPPost($last_id)));
 				} else {
-					if (Contact::isLocal($receiver)) {
-						continue;
-					}
-
 					$profile = APContact::getByURL($receiver, false);
 					if (!empty($profile)) {
 						$contact = Contact::getByURLForUser($receiver, $uid, false, ['id']);
 
-						if (empty($profile['sharedinbox']) || $personal || $blindcopy) {
+						if (empty($profile['sharedinbox']) || $personal || $blindcopy || Contact::isLocal($receiver)) {
 							$target = $profile['inbox'];
 						} else {
 							$target = $profile['sharedinbox'];

--- a/src/Util/Network.php
+++ b/src/Util/Network.php
@@ -548,4 +548,15 @@ class Network
 			exit;
 		}
 	}
+
+	/**
+	 * Check if the given URL is a local link
+	 *
+	 * @param string $url 
+	 * @return bool 
+	 */
+	public static function isLocalLink(string $url)
+	{
+		return (strpos(Strings::normaliseLink($url), Strings::normaliseLink(DI::baseUrl())) !== false);
+	}
 }

--- a/src/Worker/Notifier.php
+++ b/src/Worker/Notifier.php
@@ -782,7 +782,7 @@ class Notifier
 			if ((count($receivers) == 1) && Network::isLocalLink($inbox)) {
 				$contact = Contact::getById($receivers[0], ['url']);
 				if ($target_uid = User::getIdForURL($contact['url'])) {
-					$fields = ['protocol' => Conversation::PARCEL_LOCAL_DFRN, 'direction' => Conversation::PUSH];
+					$fields = ['protocol' => Conversation::PARCEL_LOCAL_DFRN, 'direction' => Conversation::PUSH, 'post-reason' => Item::PR_BCC];
 					Item::storeForUserByUriId($target_item['uri-id'], $target_uid, $fields, $target_item['uid']);
 					Logger::info('Delivered locally', ['cmd' => $cmd, 'id' => $target_item['id'], 'inbox' => $inbox]);
 					continue;


### PR DESCRIPTION
This fixes #10306

We had several issues with the delivery of activities on the same machine. This is now completely reworked so that the behaviour should be idential to a communication between two Friendica servers (using AP).

Some tests are still open, for example with local forums. But I guess this can be done until the release is done.