### PR TITLE
API: Bookmarked posts are starred, not pinned

### DIFF
--- a/src/Module/Api/Mastodon/Bookmarks.php
+++ b/src/Module/Api/Mastodon/Bookmarks.php
@@ -52,7 +52,7 @@ class Bookmarks extends BaseApi
 
 		$params = ['order' => ['uri-id' => true], 'limit' => $request['limit']];
 
-		$condition = ['pinned' => true, 'uid' => $uid];
+		$condition = ['starred' => true, 'uid' => $uid];
 
 		if (!empty($request['max_id'])) {
 			$condition = DBA::mergeConditions($condition, ["`uri-id` < ?", $request['max_id']]);


### PR DESCRIPTION
This is a small fix in the API. Now bookmarked posts really show posts that are bookmarked.