### PR TITLE
Enable Drone Caching

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -67,11 +67,36 @@ type: docker
 name: php7.3-mariadb
 
 steps:
+  - name: Restore cache
+    image: meltwater/drone-cache:dev
+    settings:
+      backend: "filesystem"
+      restore: true
+      cache_key: '{{ .Repo.Name }}_php73_{{ arch }}_{{ os }}'
+      archive_format: "gzip"
+      mount:
+        - '.composer'
+    volumes:
+      - name: cache
+        path: /tmp/cache
   - name: Composer install
-    image: friendicaci/php7.4:php7.4.18
+    image: friendicaci/php7.3:php7.3.28
     commands:
-      - composer validate
-      - composer install --prefer-dist
+      - export COMPOSER_HOME=.composer
+      - ./bin/composer.phar validate
+      - ./bin/composer.phar install --prefer-dist
+  - name: Rebuild cache
+    image: meltwater/drone-cache:dev
+    settings:
+      backend: "filesystem"
+      rebuild: true
+      cache_key: '{{ .Repo.Name }}_php73_{{ arch }}_{{ os }}'
+      archive_format: "gzip"
+      mount:
+        - '.composer'
+    volumes:
+      - name: cache
+        path: /tmp/cache
   - name: Test Friendica
     image: friendicaci/php7.3:php7.3.28
     environment:
@@ -105,6 +130,11 @@ services:
 
   - name: redis
     image: redis
+
+volumes:
+  - name: cache
+    host:
+      path: /tmp/drone-cache
 ---
 kind: pipeline
 type: docker

--- a/.drone.yml
+++ b/.drone.yml
@@ -222,11 +222,36 @@ type: docker
 name: php8.0-mariadb
 
 steps:
+  - name: Restore cache
+    image: meltwater/drone-cache:dev
+    settings:
+      backend: "filesystem"
+      restore: true
+      cache_key: '{{ .Repo.Name }}_php80_{{ arch }}_{{ os }}'
+      archive_format: "gzip"
+      mount:
+        - '.composer'
+    volumes:
+      - name: cache
+        path: /tmp/cache
   - name: Composer install
-    image: friendicaci/php7.4:php7.4.18
+    image: friendicaci/php8.0:php8.0.5
     commands:
-      - composer validate
-      - composer install --prefer-dist
+      - export COMPOSER_HOME=.composer
+      - ./bin/composer.phar validate
+      - ./bin/composer.phar install --prefer-dist
+  - name: Rebuild cache
+    image: meltwater/drone-cache:dev
+    settings:
+      backend: "filesystem"
+      rebuild: true
+      cache_key: '{{ .Repo.Name }}_php80_{{ arch }}_{{ os }}'
+      archive_format: "gzip"
+      mount:
+        - '.composer'
+    volumes:
+      - name: cache
+        path: /tmp/cache
   - name: Test Friendica
     image: friendicaci/php8.0:php8.0.5
     environment:

--- a/.drone.yml
+++ b/.drone.yml
@@ -52,15 +52,45 @@ trigger:
     - pull_request
 
 steps:
+  - name: Restore cache
+    image: meltwater/drone-cache:dev
+    settings:
+      backend: "filesystem"
+      restore: true
+      cache_key: '{{ .Repo.Name }}_phpcs_{{ arch }}_{{ os }}'
+      archive_format: "gzip"
+      mount:
+        - '.composer'
+    volumes:
+      - name: cache
+        path: /tmp/cache
   - name: Install dependencies
     image: composer
     commands:
+      - export COMPOSER_HOME=.composer
       - ./bin/composer.phar run cs:install
+  - name: Rebuild cache
+    image: meltwater/drone-cache:dev
+    settings:
+      backend: "filesystem"
+      rebuild: true
+      cache_key: '{{ .Repo.Name }}_phpcs_{{ arch }}_{{ os }}'
+      archive_format: "gzip"
+      mount:
+        - '.composer'
+    volumes:
+      - name: cache
+        path: /tmp/cache
   - name: Run coding standards check
     image: friendicaci/php-cs
     commands:
       - export CHANGED_FILES="$(git diff --name-status ${DRONE_COMMIT_BEFORE}..${DRONE_COMMIT_AFTER} | grep ^A | cut -f2)"
       - /check-php-cs.sh
+
+volumes:
+  - name: cache
+    host:
+      path: /tmp/drone-cache
 ---
 kind: pipeline
 type: docker
@@ -216,6 +246,11 @@ services:
 
   - name: redis
     image: redis
+
+volumes:
+  - name: cache
+    host:
+      path: /tmp/drone-cache
 ---
 kind: pipeline
 type: docker
@@ -285,3 +320,8 @@ services:
 
   - name: redis
     image: redis
+
+volumes:
+  - name: cache
+    host:
+      path: /tmp/drone-cache

--- a/.drone.yml
+++ b/.drone.yml
@@ -141,11 +141,36 @@ type: docker
 name: php7.4-mariadb
 
 steps:
+  - name: Restore cache
+    image: meltwater/drone-cache:dev
+    settings:
+      backend: "filesystem"
+      restore: true
+      cache_key: '{{ .Repo.Name }}_php74_{{ arch }}_{{ os }}'
+      archive_format: "gzip"
+      mount:
+        - '.composer'
+    volumes:
+      - name: cache
+        path: /tmp/cache
   - name: Composer install
     image: friendicaci/php7.4:php7.4.18
     commands:
-      - composer validate
-      - composer install --prefer-dist
+      - export COMPOSER_HOME=.composer
+      - ./bin/composer.phar validate
+      - ./bin/composer.phar install --prefer-dist
+  - name: Rebuild cache
+    image: meltwater/drone-cache:dev
+    settings:
+      backend: "filesystem"
+      rebuild: true
+      cache_key: '{{ .Repo.Name }}_php74_{{ arch }}_{{ os }}'
+      archive_format: "gzip"
+      mount:
+        - '.composer'
+    volumes:
+      - name: cache
+        path: /tmp/cache
   - name: Test Friendica
     image: friendicaci/php7.4:php7.4.18
     environment:


### PR DESCRIPTION
Enable Drone caching for dependencies (saves around ~15-20 seconds each for install command if the cache is used)

here for example: https://drone.friendi.ca/friendica/friendica/1374/7/6