### PR TITLE
Avoid warning "array_merge(): Expected parameter 2 to be an array, null given"

### DIFF
--- a/src/Module/Api/Mastodon/Apps.php
+++ b/src/Module/Api/Mastodon/Apps.php
@@ -50,7 +50,7 @@ class Apps extends BaseApi
 		if (!empty($postdata)) {
 			$postrequest = json_decode($postdata, true);
 			if (!empty($postrequest) && is_array($postrequest)) {
-				$request = array_merge($request, $$postrequest);
+				$request = array_merge($request, $postrequest);
 			}
 		}
 			


### PR DESCRIPTION
See here: https://github.com/friendica/friendica/issues/10168#issuecomment-850903411