### PR TITLE
Update avatar after user creation

### DIFF
--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -1123,6 +1123,8 @@ class User
 					Photo::update(['profile' => 1], ['resource-id' => $resource_id]);
 				}
 			}
+
+			Contact::updateSelfFromUserID($uid, true);
 		}
 
 		Hook::callAll('register_account', $uid);


### PR DESCRIPTION
Closes #10342 

The `avatar` field stayed empty after calling `User::create()`, so the catavatar is stored as a profile photo (so for example you can see your tiny avatar at the profile-drop down), but loading it per `avatar` field returned an empty value, so the Profile editor didn't show anything