### PR TITLE
Fix commenting on mobile to Diaspora

### DIFF
--- a/mod/item.php
+++ b/mod/item.php
@@ -713,13 +713,6 @@ function item_post(App $a) {
 	unset($datarray['self']);
 	unset($datarray['api_source']);
 
-	if ($origin) {
-		$signed = Diaspora::createCommentSignature($uid, $datarray);
-		if (!empty($signed)) {
-			$datarray['diaspora_signed_text'] = json_encode($signed);
-		}
-	}
-
 	$post_id = Item::insert($datarray);
 
 	if (!$post_id) {

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -1060,7 +1060,14 @@ class Item
 			Post\Content::insert($item['uri-id'], $item);
 		}
 
-		// Diaspora signature
+		// Create Diaspora signature
+		if ($item['origin'] && empty($item['diaspora_signed_text'])) {
+			$signed = Diaspora::createCommentSignature($uid, $item);
+			if (!empty($signed)) {
+				$item['diaspora_signed_text'] = json_encode($signed);
+			}
+		}
+
 		if (!empty($item['diaspora_signed_text'])) {
 			DBA::replace('diaspora-interaction', ['uri-id' => $item['uri-id'], 'interaction' => $item['diaspora_signed_text']]);
 		}

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -4049,6 +4049,11 @@ class Diaspora
 			return false;
 		}
 
+		// This is only needed for the automated tests
+		if (empty($owner['uprvkey'])) {
+			return false;
+		}
+
 		$message = self::constructComment($item, $owner);
 		if ($message === false) {
 			return false;

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -4049,13 +4049,6 @@ class Diaspora
 			return false;
 		}
 
-		$parent = Post::selectFirst(['parent-uri'], ['uri' => $item['thr-parent']]);
-		if (!DBA::isResult($parent)) {
-			return;
-		}
-
-		$item['parent-uri'] = $parent['parent-uri'];
-
 		$message = self::constructComment($item, $owner);
 		if ($message === false) {
 			return false;


### PR DESCRIPTION
See the German discussion here: https://forum.friendi.ca/display/adf174d5-1560-b4de-0df2-f65625635172

When a comment had been created via API, no Diaspora signature had been created, thus the comments couldn't be sended.