### PR TITLE
Use the proper way to display milliseconds

### DIFF
--- a/src/Object/Api/Mastodon/Account.php
+++ b/src/Object/Api/Mastodon/Account.php
@@ -108,7 +108,7 @@ class Account extends BaseDataTransferObject
 		$userContactCreated = $userContact['created'] ?? DBA::NULL_DATETIME;
 
 		$created = $userContactCreated < $publicContactCreated && ($userContactCreated != DBA::NULL_DATETIME) ? $userContactCreated : $publicContactCreated;
-		$this->created_at      = DateTimeFormat::utc($created, DateTimeFormat::API);
+		$this->created_at      = DateTimeFormat::utc($created, DateTimeFormat::JSON);
 
 		$this->note            = BBCode::convert($publicContact['about'], false);
 		$this->url             = $publicContact['url'];

--- a/src/Object/Api/Mastodon/Notification.php
+++ b/src/Object/Api/Mastodon/Notification.php
@@ -52,7 +52,7 @@ class Notification extends BaseDataTransferObject
 	{
 		$this->id         = (string)$id;
 		$this->type       = $type;
-		$this->created_at = DateTimeFormat::utc($created_at, DateTimeFormat::API);
+		$this->created_at = DateTimeFormat::utc($created_at, DateTimeFormat::JSON);
 		$this->account    = $account->toArray();
 
 		if (!empty($status)) {

--- a/src/Object/Api/Mastodon/Status.php
+++ b/src/Object/Api/Mastodon/Status.php
@@ -100,7 +100,7 @@ class Status extends BaseDataTransferObject
 	public function __construct(array $item, Account $account, Counts $counts, UserAttributes $userAttributes, bool $sensitive, Application $application, array $mentions, array $tags, Card $card, array $attachments, array $reblog)
 	{
 		$this->id         = (string)$item['uri-id'];
-		$this->created_at = DateTimeFormat::utc($item['created'], DateTimeFormat::API);
+		$this->created_at = DateTimeFormat::utc($item['created'], DateTimeFormat::JSON);
 
 		if ($item['gravity'] == GRAVITY_COMMENT) {
 			$this->in_reply_to_id         = (string)$item['thr-parent-id'];

--- a/src/Object/Api/Mastodon/Token.php
+++ b/src/Object/Api/Mastodon/Token.php
@@ -53,6 +53,6 @@ class Token extends BaseDataTransferObject
 		$this->access_token = $access_token;
 		$this->token_type   = $token_type;
 		$this->scope        = $scope;
-		$this->created_at   = DateTimeFormat::utc($created_at, DateTimeFormat::API);
+		$this->created_at   = DateTimeFormat::utc($created_at, DateTimeFormat::JSON);
 	}
 }

--- a/src/Util/DateTimeFormat.php
+++ b/src/Util/DateTimeFormat.php
@@ -34,7 +34,7 @@ class DateTimeFormat
 	const ATOM  = 'Y-m-d\TH:i:s\Z';
 	const MYSQL = 'Y-m-d H:i:s';
 	const HTTP  = 'D, d M Y H:i:s \G\M\T';
-	const API   = 'Y-m-d\TH:i:s.000\Z';
+	const API   = 'Y-m-d\TH:i:s.v\Z';
 
 	/**
 	 * convert() shorthand for UTC.

--- a/src/Util/DateTimeFormat.php
+++ b/src/Util/DateTimeFormat.php
@@ -34,7 +34,7 @@ class DateTimeFormat
 	const ATOM  = 'Y-m-d\TH:i:s\Z';
 	const MYSQL = 'Y-m-d H:i:s';
 	const HTTP  = 'D, d M Y H:i:s \G\M\T';
-	const API   = 'Y-m-d\TH:i:s.v\Z';
+	const JSON  = 'Y-m-d\TH:i:s.v\Z';
 
 	/**
 	 * convert() shorthand for UTC.


### PR DESCRIPTION
This is a small change that will not make any differenc for the API calls since the database doesn't store milliseconds. But since PHP 7, the date format is able of returning the miliseconds, so we should support it.

Also the format string is renamed to "JSON", since this seems to be the more or less agreed time format for JSON documents: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toJSON