### PR TITLE
API: Limit the elements for the context

### DIFF
--- a/src/Module/Api/Mastodon/Statuses/Context.php
+++ b/src/Module/Api/Mastodon/Statuses/Context.php
@@ -44,6 +44,10 @@ class Context extends BaseApi
 			DI::mstdnError()->UnprocessableEntity();
 		}
 
+		$request = self::getRequest([
+			'limit'    => 40, // Maximum number of results to return. Defaults to 40.
+		]);
+
 		$id = $parameters['id'];
 
 		$parent = Post::selectFirst(['parent-uri-id'], ['uri-id' => $id]);
@@ -70,22 +74,22 @@ class Context extends BaseApi
 
 		$ancestors = [];
 		foreach (self::getParents($id, $parents) as $ancestor) {
-			$ancestors[$ancestor] = DI::mstdnStatus()->createFromUriId($ancestor, $uid);
+			$ancestors[] = $ancestor;
 		}
 
-		ksort($ancestors);
-		foreach ($ancestors as $ancestor) {
-			$statuses['ancestors'][] = $ancestor;
+		asort($ancestors);
+		foreach (array_slice($ancestors, 0, $request['limit']) as $ancestor) {
+			$statuses['ancestors'][] = DI::mstdnStatus()->createFromUriId($ancestor, $uid);;
 		}
 
 		$descendants = [];
 		foreach (self::getChildren($id, $children) as $descendant) {
-			$descendants[] = DI::mstdnStatus()->createFromUriId($descendant, $uid);
+			$descendants[] = $descendant; 
 		}
 
-		ksort($descendants);
-		foreach ($descendants as $descendant) {
-			$statuses['descendants'][] = $descendant;
+		asort($descendants);
+		foreach (array_slice($descendants, 0, $request['limit']) as $descendant) {
+			$statuses['descendants'][] = DI::mstdnStatus()->createFromUriId($descendant, $uid);
 		}
 
 		System::jsonExit($statuses);


### PR DESCRIPTION
The `context` API command lists all ancestors and descendants of a post. In rare cases this can be huge numbers. So we now limit the amount of posts that we return.