### PR TITLE
API: some more endpoints added

### DIFF
--- a/doc/API-Mastodon.md
+++ b/doc/API-Mastodon.md
@@ -73,6 +73,7 @@ These endpoints use the [Mastodon API entities](https://docs.joinmastodon.org/en
 
 
 - [`GET /api/v1/instance`](https://docs.joinmastodon.org/methods/instance#fetch-instance)
+- GET /api/v1/instance/rules Undocumented, returns Terms of Service
 - [`GET /api/v1/instance/peers`](https://docs.joinmastodon.org/methods/instance#list-of-connected-domains)
 - [`GET /api/v1/lists`](https://docs.joinmastodon.org/methods/timelines/lists/)
 - [`POST /api/v1/lists`](https://docs.joinmastodon.org/methods/timelines/lists/)
@@ -140,7 +141,9 @@ They refer to features that don't exist in Friendica yet.
 These endpoints won't be implemented at the moment.
 They refer to features or data that don't exist in Friendica yet.
 
+- POST /api/meta Misskey API endpoint.
 - [`POST /api/v1/accounts`](https://docs.joinmastodon.org/methods/accounts/)
+- [`GET /api/v1/accounts/:id/featured_tags`](https://docs.joinmastodon.org/methods/accounts/)
 - [`POST /api/v1/accounts/:id/pin`](https://docs.joinmastodon.org/methods/accounts/)
 - [`POST /api/v1/accounts/:id/unpin`](https://docs.joinmastodon.org/methods/accounts/)
 - [`GET /api/v1/admin/accounts`](https://docs.joinmastodon.org/methods/admin/)
@@ -167,8 +170,13 @@ They refer to features or data that don't exist in Friendica yet.
 - [`POST /api/v1/markers`](https://docs.joinmastodon.org/methods/timelines/markers/)
 - [`GET /api/v1/polls/:id`](https://docs.joinmastodon.org/methods/statuses/polls/)
 - [`POST /api/v1/polls/:id/votes`](https://docs.joinmastodon.org/methods/statuses/polls/)
+- [`DELETE /api/v1/push/subscription`](https://docs.joinmastodon.org/methods/notifications/push/)
+- [`GET /api/v1/push/subscription`](https://docs.joinmastodon.org/methods/notifications/push/)
+- [`PUSH /api/v1/push/subscription`](https://docs.joinmastodon.org/methods/notifications/push/)
+- [`PUT /api/v1/push/subscription`](https://docs.joinmastodon.org/methods/notifications/push/)
 - [`POST /api/v1/reports`](https://docs.joinmastodon.org/methods/accounts/reports/)
 - [`GET /api/v1/scheduled_statuses/:id`](https://docs.joinmastodon.org/methods/statuses/scheduled_statuses/)
 - [`PUT /api/v1/scheduled_statuses/:id`](https://docs.joinmastodon.org/methods/statuses/scheduled_statuses/)
 - [`DELETE /api/v1/scheduled_statuses/:id`](https://docs.joinmastodon.org/methods/statuses/scheduled_statuses/)
+- [`GET /api/v1/streaming`](https://docs.joinmastodon.org/methods/timelines/streaming/)
 - [`DELETE /api/v1/suggestions/:id`](https://docs.joinmastodon.org/methods/accounts/suggestions/)

--- a/src/Module/Api/Mastodon/Instance/Rules.php
+++ b/src/Module/Api/Mastodon/Instance/Rules.php
@@ -40,10 +40,11 @@ class Rules extends BaseApi
 	public static function rawContent(array $parameters = [])
 	{
 		$rules = [];
-		$id = 0;
+		$id    = 0;
 
 		if (DI::config()->get('system', 'tosdisplay')) {
 			$html = BBCode::convert(DI::config()->get('system', 'tostext'), false, BBCode::EXTERNAL);
+
 			$msg = HTML::toPlaintext($html, 0, true);
 			foreach (explode("\n", $msg) as $line) {
 				$line = trim($line);

--- a/src/Module/Api/Mastodon/Instance/Rules.php
+++ b/src/Module/Api/Mastodon/Instance/Rules.php
@@ -19,31 +19,40 @@
  *
  */
 
-namespace Friendica\Module\Api\Mastodon;
+namespace Friendica\Module\Api\Mastodon\Instance;
 
+use Friendica\Content\Text\BBCode;
+use Friendica\Content\Text\HTML;
 use Friendica\Core\System;
+use Friendica\DI;
 use Friendica\Module\BaseApi;
+use Friendica\Network\HTTPException;
 
 /**
- * @see https://docs.joinmastodon.org/methods/accounts/filters/
+ * Undocumented API endpoint
  */
-class Filters extends BaseApi
+class Rules extends BaseApi
 {
-	public static function post(array $parameters = [])
-	{
-		self::login(self::SCOPE_WRITE);
-
-		self::unsupported('post');
-	}
-
 	/**
 	 * @param array $parameters
-	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
+	 * @throws HTTPException\InternalServerErrorException
 	 */
 	public static function rawContent(array $parameters = [])
 	{
-		self::login(self::SCOPE_READ);
+		$rules = [];
+		$id = 0;
 
-		System::jsonExit([]);
+		if (DI::config()->get('system', 'tosdisplay')) {
+			$html = BBCode::convert(DI::config()->get('system', 'tostext'), false, BBCode::EXTERNAL);
+			$msg = HTML::toPlaintext($html, 0, true);
+			foreach (explode("\n", $msg) as $line) {
+				$line = trim($line);
+				if ($line) {
+					$rules[] = ['id' => (string)++$id, 'text' => $line];
+				}
+			}
+		}
+
+		System::jsonExit($rules);
 	}
 }

--- a/static/routes.config.php
+++ b/static/routes.config.php
@@ -60,6 +60,7 @@ return [
 			'/accounts'                          => [Module\Api\Mastodon\Unimplemented::class,            [        R::POST]], // not supported
 			'/accounts/{id:\d+}'                 => [Module\Api\Mastodon\Accounts::class,                 [R::GET         ]],
 			'/accounts/{id:\d+}/statuses'        => [Module\Api\Mastodon\Accounts\Statuses::class,        [R::GET         ]],
+			'/accounts/{id:\d+}/featured_tags'   => [Module\Api\Mastodon\Unimplemented::class,            [R::GET         ]], // @todo
 			'/accounts/{id:\d+}/followers'       => [Module\Api\Mastodon\Accounts\Followers::class,       [R::GET         ]],
 			'/accounts/{id:\d+}/following'       => [Module\Api\Mastodon\Accounts\Following::class,       [R::GET         ]],
 			'/accounts/{id:\d+}/lists'           => [Module\Api\Mastodon\Accounts\Lists::class,           [R::GET         ]],
@@ -77,6 +78,7 @@ return [
 			'/accounts/search'                   => [Module\Api\Mastodon\Accounts\Search::class,          [R::GET         ]],
 			'/accounts/update_credentials'       => [Module\Api\Mastodon\Accounts\UpdateCredentials::class, [R::PATCH     ]],
 			'/accounts/verify_credentials'       => [Module\Api\Mastodon\Accounts\VerifyCredentials::class, [R::GET       ]],
+			'/accounts/{name}'                   => [Module\Api\Mastodon\Accounts::class,                 [R::GET         ]],
 			'/admin/accounts'                    => [Module\Api\Mastodon\Unimplemented::class,            [R::GET         ]], // not supported
 			'/admin/accounts/{id:\d+}'           => [Module\Api\Mastodon\Unimplemented::class,            [R::GET         ]], // not supported
 			'/admin/accounts/{id:\d+}/{action}'  => [Module\Api\Mastodon\Unimplemented::class,            [        R::POST]], // not supported
@@ -108,6 +110,7 @@ return [
 			'/instance'                          => [Module\Api\Mastodon\Instance::class,                 [R::GET         ]],
 			'/instance/activity'                 => [Module\Api\Mastodon\Unimplemented::class,            [R::GET         ]], // @todo
 			'/instance/peers'                    => [Module\Api\Mastodon\Instance\Peers::class,           [R::GET         ]],
+			'/instance/rules'                    => [Module\Api\Mastodon\Instance\Rules::class,           [R::GET         ]], // not supported
 			'/lists'                             => [Module\Api\Mastodon\Lists::class,                    [R::GET, R::POST]],
 			'/lists/{id:\d+}'                    => [Module\Api\Mastodon\Lists::class,                    [R::GET, R::PUT, R::DELETE]],
 			'/lists/{id:\d+}/accounts'           => [Module\Api\Mastodon\Lists\Accounts::class,           [R::GET, R::POST, R::DELETE]],
@@ -122,6 +125,7 @@ return [
 			'/polls/{id:\d+}'                    => [Module\Api\Mastodon\Unimplemented::class,            [R::GET         ]], // not supported
 			'/polls/{id:\d+}/votes'              => [Module\Api\Mastodon\Unimplemented::class,            [        R::POST]], // not supported
 			'/preferences'                       => [Module\Api\Mastodon\Preferences::class,              [R::GET         ]],
+			'/push/subscription'                 => [Module\Api\Mastodon\Unimplemented::class,            [R::GET, R::POST, R::PUT, R::DELETE]], // not supported
 			'/reports'                           => [Module\Api\Mastodon\Unimplemented::class,            [        R::POST]], // not supported
 			'/scheduled_statuses'                => [Module\Api\Mastodon\ScheduledStatuses::class,        [R::GET         ]], // Dummy, not supported
 			'/scheduled_statuses/{id:\d+}'       => [Module\Api\Mastodon\Unimplemented::class,            [R::GET, R::PUT, R::DELETE]], // not supported
@@ -140,6 +144,7 @@ return [
 			'/statuses/{id:\d+}/unmute'          => [Module\Api\Mastodon\Statuses\Unmute::class,          [        R::POST]],
 			'/statuses/{id:\d+}/pin'             => [Module\Api\Mastodon\Statuses\Pin::class,             [        R::POST]],
 			'/statuses/{id:\d+}/unpin'           => [Module\Api\Mastodon\Statuses\Unpin::class,           [        R::POST]],
+			'/streaming'                         => [Module\Api\Mastodon\Unimplemented::class,            [R::GET         ]],
 			'/suggestions'                       => [Module\Api\Mastodon\Suggestions::class,              [R::GET         ]],
 			'/suggestions/{id:\d+}'              => [Module\Api\Mastodon\Unimplemented::class,            [R::DELETE      ]], // not implemented
 			'/timelines/direct'                  => [Module\Api\Mastodon\Timelines\Direct::class,         [R::GET         ]],
@@ -160,6 +165,7 @@ return [
 		'/followers/list'                        => [Module\Api\Twitter\FollowersList::class,  [R::GET         ]],
 		'/friends/ids'                           => [Module\Api\Twitter\FriendsIds::class,     [R::GET         ]],
 		'/friends/list'                          => [Module\Api\Twitter\FriendsList::class,    [R::GET         ]],
+		'/meta'                                  => [Module\Api\Mastodon\Unimplemented::class, [R::POST        ]], // not supported
 		'/oembed'                                => [Module\Api\Mastodon\Unimplemented::class, [R::GET         ]],
 		'/proofs'                                => [Module\Api\Mastodon\Proofs::class,        [R::GET         ]], // Dummy, not supported
 	],


### PR DESCRIPTION
I had a look at the Mastodon routes: https://github.com/tootsuite/mastodon/blob/main/config/routes.rb

I discovered some API endpoints that had been undocumented or either we forgot to implement.
