### PR TITLE
Rename API login-related methods to be more meaningful

### DIFF
--- a/include/api.php
+++ b/include/api.php
@@ -89,7 +89,7 @@ $called_api = [];
  */
 function api_user()
 {
-	$user = BaseApi::getCurrentUserID(true);
+	$user = BaseApi::getCachedCurrentUserIdFromRequest();
 	if (!empty($user)) {
 		return $user;
 	}
@@ -216,7 +216,7 @@ function api_login(App $a, bool $do_login = true)
 			if (!is_null($token)) {
 				$oauth1->loginUser($token->uid);
 				Session::set('allow_api', true);
-				return;
+				return true;
 			}
 			echo __FILE__.__LINE__.__FUNCTION__ . "<pre>";
 			var_dump($consumer, $token);
@@ -226,7 +226,7 @@ function api_login(App $a, bool $do_login = true)
 		}
 
 		if (!$do_login) {
-			return;
+			return false;
 		}
 
 		Logger::debug(API_LOG_PREFIX . 'failed', ['module' => 'api', 'action' => 'login', 'parameters' => $_SERVER]);
@@ -271,7 +271,7 @@ function api_login(App $a, bool $do_login = true)
 
 	if (!DBA::isResult($record)) {
 		if (!$do_login) {
-			return;
+			return false;
 		}
 		Logger::debug(API_LOG_PREFIX . 'failed', ['module' => 'api', 'action' => 'login', 'parameters' => $_SERVER]);
 		header('WWW-Authenticate: Basic realm="Friendica"');
@@ -288,6 +288,8 @@ function api_login(App $a, bool $do_login = true)
 	$_SESSION["allow_api"] = true;
 
 	Hook::callAll('logged_in', $a->user);
+
+	return true;
 }
 
 /**

--- a/src/Module/Api/BaseMastodon.php
+++ b/src/Module/Api/BaseMastodon.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Friendica\Module\Api;
+
+use Friendica\Module\BaseApi;
+
+/**
+ * Mastodon API-specific methods
+ */
+class BaseMastodon extends BaseApi
+{
+	/**
+	 * Get current application from the Bearer token
+	 *
+	 * This Mastodon-specific Application is unrelated with the local Friendica application model.
+	 *
+	 * @return array token
+	 */
+	protected static function getCurrentApplication(): array
+	{
+		return self::getCachedTokenByBearer();
+	}
+}

--- a/src/Module/Api/Friendica/Events/Index.php
+++ b/src/Module/Api/Friendica/Events/Index.php
@@ -35,7 +35,7 @@ class Index extends BaseApi
 {
 	public static function rawContent(array $parameters = [])
 	{
-		if (self::login(self::SCOPE_READ) === false) {
+		if (self::checkAllowedScope(self::SCOPE_READ) === false) {
 			throw new HTTPException\ForbiddenException();
 		}
 

--- a/src/Module/Api/Friendica/Events/Index.php
+++ b/src/Module/Api/Friendica/Events/Index.php
@@ -44,7 +44,7 @@ class Index extends BaseApi
 			'count'    => 0,
 		]);
 
-		$condition = ["`id` > ? AND `uid` = ?", $request['since_id'], self::$current_user_id];
+		$condition = ["`id` > ? AND `uid` = ?", $request['since_id'], self::getCachedCurrentUserIdFromRequest()];
 		$params = ['limit' => $request['count']];
 		$events = DBA::selectToArray('event', [], $condition, $params);
 

--- a/src/Module/Api/Friendica/Profile/Show.php
+++ b/src/Module/Api/Friendica/Profile/Show.php
@@ -37,7 +37,7 @@ class Show extends BaseApi
 {
 	public static function rawContent(array $parameters = [])
 	{
-		if (self::login(self::SCOPE_READ) === false) {
+		if (self::checkAllowedScope(self::SCOPE_READ) === false) {
 			throw new HTTPException\ForbiddenException();
 		}
 

--- a/src/Module/Api/Friendica/Profile/Show.php
+++ b/src/Module/Api/Friendica/Profile/Show.php
@@ -44,9 +44,9 @@ class Show extends BaseApi
 		// retrieve general information about profiles for user
 		$directory = DI::config()->get('system', 'directory');
 
-		$profile = Profile::getByUID(self::$current_user_id);
+		$profile = Profile::getByUID(self::getCachedCurrentUserIdFromRequest());
 		
-		$profileFields = DI::profileField()->select(['uid' => self::$current_user_id, 'psid' => PermissionSet::PUBLIC]);
+		$profileFields = DI::profileField()->select(['uid' => self::getCachedCurrentUserIdFromRequest(), 'psid' => PermissionSet::PUBLIC]);
 
 		$profile = self::formatProfile($profile, $profileFields);
 
@@ -58,7 +58,7 @@ class Show extends BaseApi
 		}
 
 		// return settings, authenticated user and profiles data
-		$self = Contact::selectFirst(['nurl'], ['uid' => self::$current_user_id, 'self' => true]);
+		$self = Contact::selectFirst(['nurl'], ['uid' => self::getCachedCurrentUserIdFromRequest(), 'self' => true]);
 
 		$result = [
 			'multi_profiles' => false,

--- a/src/Module/Api/Mastodon/Accounts.php
+++ b/src/Module/Api/Mastodon/Accounts.php
@@ -25,12 +25,12 @@ use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Contact;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 
 /**
  * @see https://docs.joinmastodon.org/methods/accounts/
  */
-class Accounts extends BaseApi
+class Accounts extends BaseMastodon
 {
 	/**
 	 * @param array $parameters

--- a/src/Module/Api/Mastodon/Accounts.php
+++ b/src/Module/Api/Mastodon/Accounts.php
@@ -56,7 +56,7 @@ class Accounts extends BaseApi
 			}
 		}
 
-		$account = DI::mstdnAccount()->createFromContactId($id, self::getCurrentUserID());
+		$account = DI::mstdnAccount()->createFromContactId($id, self::getCachedCurrentUserIdFromRequest());
 		System::jsonExit($account);
 	}
 }

--- a/src/Module/Api/Mastodon/Accounts/Block.php
+++ b/src/Module/Api/Mastodon/Accounts/Block.php
@@ -33,7 +33,7 @@ class Block extends BaseMastodon
 {
 	public static function post(array $parameters = [])
 	{
-		self::login(self::SCOPE_FOLLOW);
+		self::checkAllowedScope(self::SCOPE_FOLLOW);
 		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (empty($parameters['id'])) {

--- a/src/Module/Api/Mastodon/Accounts/Block.php
+++ b/src/Module/Api/Mastodon/Accounts/Block.php
@@ -34,7 +34,7 @@ class Block extends BaseApi
 	public static function post(array $parameters = [])
 	{
 		self::login(self::SCOPE_FOLLOW);
-		$uid = self::getCurrentUserID();
+		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (empty($parameters['id'])) {
 			DI::mstdnError()->UnprocessableEntity();

--- a/src/Module/Api/Mastodon/Accounts/Block.php
+++ b/src/Module/Api/Mastodon/Accounts/Block.php
@@ -24,12 +24,12 @@ namespace Friendica\Module\Api\Mastodon\Accounts;
 use Friendica\Core\System;
 use Friendica\DI;
 use Friendica\Model\Contact;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 
 /**
  * @see https://docs.joinmastodon.org/methods/accounts/
  */
-class Block extends BaseApi
+class Block extends BaseMastodon
 {
 	public static function post(array $parameters = [])
 	{

--- a/src/Module/Api/Mastodon/Accounts/Follow.php
+++ b/src/Module/Api/Mastodon/Accounts/Follow.php
@@ -34,13 +34,13 @@ class Follow extends BaseApi
 	public static function post(array $parameters = [])
 	{
 		self::login(self::SCOPE_FOLLOW);
-		$uid = self::getCurrentUserID();
+		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (empty($parameters['id'])) {
 			DI::mstdnError()->UnprocessableEntity();
 		}
 
-		$cid = Contact::follow($parameters['id'], self::getCurrentUserID());
+		$cid = Contact::follow($parameters['id'], self::getCachedCurrentUserIdFromRequest());
 
 		System::jsonExit(DI::mstdnRelationship()->createFromContactId($cid, $uid)->toArray());
 	}

--- a/src/Module/Api/Mastodon/Accounts/Follow.php
+++ b/src/Module/Api/Mastodon/Accounts/Follow.php
@@ -24,12 +24,12 @@ namespace Friendica\Module\Api\Mastodon\Accounts;
 use Friendica\Core\System;
 use Friendica\DI;
 use Friendica\Model\Contact;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 
 /**
  * @see https://docs.joinmastodon.org/methods/accounts/
  */
-class Follow extends BaseApi
+class Follow extends BaseMastodon
 {
 	public static function post(array $parameters = [])
 	{

--- a/src/Module/Api/Mastodon/Accounts/Follow.php
+++ b/src/Module/Api/Mastodon/Accounts/Follow.php
@@ -33,7 +33,7 @@ class Follow extends BaseMastodon
 {
 	public static function post(array $parameters = [])
 	{
-		self::login(self::SCOPE_FOLLOW);
+		self::checkAllowedScope(self::SCOPE_FOLLOW);
 		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (empty($parameters['id'])) {

--- a/src/Module/Api/Mastodon/Accounts/Followers.php
+++ b/src/Module/Api/Mastodon/Accounts/Followers.php
@@ -37,7 +37,7 @@ class Followers extends BaseMastodon
 	 */
 	public static function rawContent(array $parameters = [])
 	{
-		self::login(self::SCOPE_READ);
+		self::checkAllowedScope(self::SCOPE_READ);
 		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (empty($parameters['id'])) {

--- a/src/Module/Api/Mastodon/Accounts/Followers.php
+++ b/src/Module/Api/Mastodon/Accounts/Followers.php
@@ -38,7 +38,7 @@ class Followers extends BaseApi
 	public static function rawContent(array $parameters = [])
 	{
 		self::login(self::SCOPE_READ);
-		$uid = self::getCurrentUserID();
+		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (empty($parameters['id'])) {
 			DI::mstdnError()->UnprocessableEntity();

--- a/src/Module/Api/Mastodon/Accounts/Followers.php
+++ b/src/Module/Api/Mastodon/Accounts/Followers.php
@@ -24,12 +24,12 @@ namespace Friendica\Module\Api\Mastodon\Accounts;
 use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\DI;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 
 /**
  * @see https://docs.joinmastodon.org/methods/accounts/
  */
-class Followers extends BaseApi
+class Followers extends BaseMastodon
 {
 	/**
 	 * @param array $parameters

--- a/src/Module/Api/Mastodon/Accounts/Following.php
+++ b/src/Module/Api/Mastodon/Accounts/Following.php
@@ -24,12 +24,12 @@ namespace Friendica\Module\Api\Mastodon\Accounts;
 use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\DI;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 
 /**
  * @see https://docs.joinmastodon.org/methods/accounts/
  */
-class Following extends BaseApi
+class Following extends BaseMastodon
 {
 	/**
 	 * @param array $parameters

--- a/src/Module/Api/Mastodon/Accounts/Following.php
+++ b/src/Module/Api/Mastodon/Accounts/Following.php
@@ -38,7 +38,7 @@ class Following extends BaseApi
 	public static function rawContent(array $parameters = [])
 	{
 		self::login(self::SCOPE_READ);
-		$uid = self::getCurrentUserID();
+		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (empty($parameters['id'])) {
 			DI::mstdnError()->UnprocessableEntity();

--- a/src/Module/Api/Mastodon/Accounts/Following.php
+++ b/src/Module/Api/Mastodon/Accounts/Following.php
@@ -37,7 +37,7 @@ class Following extends BaseMastodon
 	 */
 	public static function rawContent(array $parameters = [])
 	{
-		self::login(self::SCOPE_READ);
+		self::checkAllowedScope(self::SCOPE_READ);
 		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (empty($parameters['id'])) {

--- a/src/Module/Api/Mastodon/Accounts/IdentityProofs.php
+++ b/src/Module/Api/Mastodon/Accounts/IdentityProofs.php
@@ -22,12 +22,12 @@
 namespace Friendica\Module\Api\Mastodon\Accounts;
 
 use Friendica\Core\System;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 
 /**
  * @see https://docs.joinmastodon.org/methods/accounts/
  */
-class IdentityProofs extends BaseApi
+class IdentityProofs extends BaseMastodon
 {
 	/**
 	 * @param array $parameters

--- a/src/Module/Api/Mastodon/Accounts/IdentityProofs.php
+++ b/src/Module/Api/Mastodon/Accounts/IdentityProofs.php
@@ -35,7 +35,7 @@ class IdentityProofs extends BaseMastodon
 	 */
 	public static function rawContent(array $parameters = [])
 	{
-		self::login(self::SCOPE_READ);
+		self::checkAllowedScope(self::SCOPE_READ);
 
 		System::jsonExit([]);
 	}

--- a/src/Module/Api/Mastodon/Accounts/Lists.php
+++ b/src/Module/Api/Mastodon/Accounts/Lists.php
@@ -25,12 +25,12 @@ use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Contact;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 
 /**
  * @see https://docs.joinmastodon.org/methods/accounts/
  */
-class Lists extends BaseApi
+class Lists extends BaseMastodon
 {
 	/**
 	 * @param array $parameters

--- a/src/Module/Api/Mastodon/Accounts/Lists.php
+++ b/src/Module/Api/Mastodon/Accounts/Lists.php
@@ -38,7 +38,7 @@ class Lists extends BaseMastodon
 	 */
 	public static function rawContent(array $parameters = [])
 	{
-		self::login(self::SCOPE_READ);
+		self::checkAllowedScope(self::SCOPE_READ);
 		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (empty($parameters['id'])) {

--- a/src/Module/Api/Mastodon/Accounts/Lists.php
+++ b/src/Module/Api/Mastodon/Accounts/Lists.php
@@ -39,7 +39,7 @@ class Lists extends BaseApi
 	public static function rawContent(array $parameters = [])
 	{
 		self::login(self::SCOPE_READ);
-		$uid = self::getCurrentUserID();
+		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (empty($parameters['id'])) {
 			DI::mstdnError()->UnprocessableEntity();

--- a/src/Module/Api/Mastodon/Accounts/Mute.php
+++ b/src/Module/Api/Mastodon/Accounts/Mute.php
@@ -24,12 +24,12 @@ namespace Friendica\Module\Api\Mastodon\Accounts;
 use Friendica\Core\System;
 use Friendica\DI;
 use Friendica\Model\Contact;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 
 /**
  * @see https://docs.joinmastodon.org/methods/accounts/
  */
-class Mute extends BaseApi
+class Mute extends BaseMastodon
 {
 	public static function post(array $parameters = [])
 	{

--- a/src/Module/Api/Mastodon/Accounts/Mute.php
+++ b/src/Module/Api/Mastodon/Accounts/Mute.php
@@ -34,7 +34,7 @@ class Mute extends BaseApi
 	public static function post(array $parameters = [])
 	{
 		self::login(self::SCOPE_FOLLOW);
-		$uid = self::getCurrentUserID();
+		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (empty($parameters['id'])) {
 			DI::mstdnError()->UnprocessableEntity();

--- a/src/Module/Api/Mastodon/Accounts/Mute.php
+++ b/src/Module/Api/Mastodon/Accounts/Mute.php
@@ -33,7 +33,7 @@ class Mute extends BaseMastodon
 {
 	public static function post(array $parameters = [])
 	{
-		self::login(self::SCOPE_FOLLOW);
+		self::checkAllowedScope(self::SCOPE_FOLLOW);
 		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (empty($parameters['id'])) {

--- a/src/Module/Api/Mastodon/Accounts/Note.php
+++ b/src/Module/Api/Mastodon/Accounts/Note.php
@@ -34,7 +34,7 @@ class Note extends BaseMastodon
 {
 	public static function post(array $parameters = [])
 	{
-		self::login(self::SCOPE_WRITE);
+		self::checkAllowedScope(self::SCOPE_WRITE);
 		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (empty($parameters['id'])) {

--- a/src/Module/Api/Mastodon/Accounts/Note.php
+++ b/src/Module/Api/Mastodon/Accounts/Note.php
@@ -25,12 +25,12 @@ use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Contact;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 
 /**
  * @see https://docs.joinmastodon.org/methods/accounts/
  */
-class Note extends BaseApi
+class Note extends BaseMastodon
 {
 	public static function post(array $parameters = [])
 	{

--- a/src/Module/Api/Mastodon/Accounts/Note.php
+++ b/src/Module/Api/Mastodon/Accounts/Note.php
@@ -35,7 +35,7 @@ class Note extends BaseApi
 	public static function post(array $parameters = [])
 	{
 		self::login(self::SCOPE_WRITE);
-		$uid = self::getCurrentUserID();
+		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (empty($parameters['id'])) {
 			DI::mstdnError()->UnprocessableEntity();

--- a/src/Module/Api/Mastodon/Accounts/Relationships.php
+++ b/src/Module/Api/Mastodon/Accounts/Relationships.php
@@ -38,7 +38,7 @@ class Relationships extends BaseApi
 	public static function rawContent(array $parameters = [])
 	{
 		self::login(self::SCOPE_READ);
-		$uid = self::getCurrentUserID();
+		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		$request = self::getRequest([
 			'id' => [],

--- a/src/Module/Api/Mastodon/Accounts/Relationships.php
+++ b/src/Module/Api/Mastodon/Accounts/Relationships.php
@@ -37,7 +37,7 @@ class Relationships extends BaseMastodon
 	 */
 	public static function rawContent(array $parameters = [])
 	{
-		self::login(self::SCOPE_READ);
+		self::checkAllowedScope(self::SCOPE_READ);
 		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		$request = self::getRequest([

--- a/src/Module/Api/Mastodon/Accounts/Relationships.php
+++ b/src/Module/Api/Mastodon/Accounts/Relationships.php
@@ -24,12 +24,12 @@ namespace Friendica\Module\Api\Mastodon\Accounts;
 use Friendica\Core\Logger;
 use Friendica\Core\System;
 use Friendica\DI;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 
 /**
  * @see https://docs.joinmastodon.org/methods/accounts/
  */
-class Relationships extends BaseApi
+class Relationships extends BaseMastodon
 {
 	/**
 	 * @param array $parameters

--- a/src/Module/Api/Mastodon/Accounts/Search.php
+++ b/src/Module/Api/Mastodon/Accounts/Search.php
@@ -40,7 +40,7 @@ class Search extends BaseMastodon
 	 */
 	public static function rawContent(array $parameters = [])
 	{
-		self::login(self::SCOPE_READ);
+		self::checkAllowedScope(self::SCOPE_READ);
 		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		$request = self::getRequest([

--- a/src/Module/Api/Mastodon/Accounts/Search.php
+++ b/src/Module/Api/Mastodon/Accounts/Search.php
@@ -26,13 +26,13 @@ use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Contact;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 use Friendica\Object\Search\ContactResult;
 
 /**
  * @see https://docs.joinmastodon.org/methods/accounts/
  */
-class Search extends BaseApi
+class Search extends BaseMastodon
 {
 	/**
 	 * @param array $parameters

--- a/src/Module/Api/Mastodon/Accounts/Search.php
+++ b/src/Module/Api/Mastodon/Accounts/Search.php
@@ -41,7 +41,7 @@ class Search extends BaseApi
 	public static function rawContent(array $parameters = [])
 	{
 		self::login(self::SCOPE_READ);
-		$uid = self::getCurrentUserID();
+		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		$request = self::getRequest([
 			'q'         => '',    // What to search for

--- a/src/Module/Api/Mastodon/Accounts/Statuses.php
+++ b/src/Module/Api/Mastodon/Accounts/Statuses.php
@@ -66,7 +66,7 @@ class Statuses extends BaseApi
 
 		$params = ['order' => ['uri-id' => true], 'limit' => $request['limit']];
 
-		$uid = self::getCurrentUserID();
+		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (!$uid) {
 			$condition = ['author-id' => $id, 'private' => [Item::PUBLIC, Item::UNLISTED],

--- a/src/Module/Api/Mastodon/Accounts/Statuses.php
+++ b/src/Module/Api/Mastodon/Accounts/Statuses.php
@@ -28,13 +28,13 @@ use Friendica\DI;
 use Friendica\Model\Item;
 use Friendica\Model\Post;
 use Friendica\Model\Verb;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 use Friendica\Protocol\Activity;
 
 /**
  * @see https://docs.joinmastodon.org/methods/accounts/
  */
-class Statuses extends BaseApi
+class Statuses extends BaseMastodon
 {
 	/**
 	 * @param array $parameters

--- a/src/Module/Api/Mastodon/Accounts/Unblock.php
+++ b/src/Module/Api/Mastodon/Accounts/Unblock.php
@@ -33,7 +33,7 @@ class Unblock extends BaseMastodon
 {
 	public static function post(array $parameters = [])
 	{
-		self::login(self::SCOPE_FOLLOW);
+		self::checkAllowedScope(self::SCOPE_FOLLOW);
 		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (empty($parameters['id'])) {

--- a/src/Module/Api/Mastodon/Accounts/Unblock.php
+++ b/src/Module/Api/Mastodon/Accounts/Unblock.php
@@ -34,7 +34,7 @@ class Unblock extends BaseApi
 	public static function post(array $parameters = [])
 	{
 		self::login(self::SCOPE_FOLLOW);
-		$uid = self::getCurrentUserID();
+		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (empty($parameters['id'])) {
 			DI::mstdnError()->UnprocessableEntity();

--- a/src/Module/Api/Mastodon/Accounts/Unblock.php
+++ b/src/Module/Api/Mastodon/Accounts/Unblock.php
@@ -24,12 +24,12 @@ namespace Friendica\Module\Api\Mastodon\Accounts;
 use Friendica\Core\System;
 use Friendica\DI;
 use Friendica\Model\Contact;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 
 /**
  * @see https://docs.joinmastodon.org/methods/accounts/
  */
-class Unblock extends BaseApi
+class Unblock extends BaseMastodon
 {
 	public static function post(array $parameters = [])
 	{

--- a/src/Module/Api/Mastodon/Accounts/Unfollow.php
+++ b/src/Module/Api/Mastodon/Accounts/Unfollow.php
@@ -34,7 +34,7 @@ class Unfollow extends BaseApi
 	public static function post(array $parameters = [])
 	{
 		self::login(self::SCOPE_FOLLOW);
-		$uid = self::getCurrentUserID();
+		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (empty($parameters['id'])) {
 			DI::mstdnError()->UnprocessableEntity();

--- a/src/Module/Api/Mastodon/Accounts/Unfollow.php
+++ b/src/Module/Api/Mastodon/Accounts/Unfollow.php
@@ -24,12 +24,12 @@ namespace Friendica\Module\Api\Mastodon\Accounts;
 use Friendica\Core\System;
 use Friendica\DI;
 use Friendica\Model\Contact;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 
 /**
  * @see https://docs.joinmastodon.org/methods/accounts/
  */
-class Unfollow extends BaseApi
+class Unfollow extends BaseMastodon
 {
 	public static function post(array $parameters = [])
 	{

--- a/src/Module/Api/Mastodon/Accounts/Unfollow.php
+++ b/src/Module/Api/Mastodon/Accounts/Unfollow.php
@@ -33,7 +33,7 @@ class Unfollow extends BaseMastodon
 {
 	public static function post(array $parameters = [])
 	{
-		self::login(self::SCOPE_FOLLOW);
+		self::checkAllowedScope(self::SCOPE_FOLLOW);
 		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (empty($parameters['id'])) {

--- a/src/Module/Api/Mastodon/Accounts/Unmute.php
+++ b/src/Module/Api/Mastodon/Accounts/Unmute.php
@@ -33,7 +33,7 @@ class Unmute extends BaseMastodon
 {
 	public static function post(array $parameters = [])
 	{
-		self::login(self::SCOPE_FOLLOW);
+		self::checkAllowedScope(self::SCOPE_FOLLOW);
 		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (empty($parameters['id'])) {

--- a/src/Module/Api/Mastodon/Accounts/Unmute.php
+++ b/src/Module/Api/Mastodon/Accounts/Unmute.php
@@ -34,7 +34,7 @@ class Unmute extends BaseApi
 	public static function post(array $parameters = [])
 	{
 		self::login(self::SCOPE_FOLLOW);
-		$uid = self::getCurrentUserID();
+		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (empty($parameters['id'])) {
 			DI::mstdnError()->UnprocessableEntity();

--- a/src/Module/Api/Mastodon/Accounts/Unmute.php
+++ b/src/Module/Api/Mastodon/Accounts/Unmute.php
@@ -24,12 +24,12 @@ namespace Friendica\Module\Api\Mastodon\Accounts;
 use Friendica\Core\System;
 use Friendica\DI;
 use Friendica\Model\Contact;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 
 /**
  * @see https://docs.joinmastodon.org/methods/accounts/
  */
-class Unmute extends BaseApi
+class Unmute extends BaseMastodon
 {
 	public static function post(array $parameters = [])
 	{

--- a/src/Module/Api/Mastodon/Accounts/UpdateCredentials.php
+++ b/src/Module/Api/Mastodon/Accounts/UpdateCredentials.php
@@ -33,7 +33,7 @@ class UpdateCredentials extends BaseApi
 	public static function patch(array $parameters = [])
 	{
 		self::login(self::SCOPE_WRITE);
-		$uid = self::getCurrentUserID();
+		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		$data = HTTPInputData::process();
 

--- a/src/Module/Api/Mastodon/Accounts/UpdateCredentials.php
+++ b/src/Module/Api/Mastodon/Accounts/UpdateCredentials.php
@@ -22,13 +22,13 @@
 namespace Friendica\Module\Api\Mastodon\Accounts;
 
 use Friendica\Core\Logger;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 use Friendica\Util\HTTPInputData;
 
 /**
  * @see https://docs.joinmastodon.org/methods/accounts/
  */
-class UpdateCredentials extends BaseApi
+class UpdateCredentials extends BaseMastodon
 {
 	public static function patch(array $parameters = [])
 	{

--- a/src/Module/Api/Mastodon/Accounts/UpdateCredentials.php
+++ b/src/Module/Api/Mastodon/Accounts/UpdateCredentials.php
@@ -32,7 +32,7 @@ class UpdateCredentials extends BaseMastodon
 {
 	public static function patch(array $parameters = [])
 	{
-		self::login(self::SCOPE_WRITE);
+		self::checkAllowedScope(self::SCOPE_WRITE);
 		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		$data = HTTPInputData::process();

--- a/src/Module/Api/Mastodon/Accounts/VerifyCredentials.php
+++ b/src/Module/Api/Mastodon/Accounts/VerifyCredentials.php
@@ -39,7 +39,7 @@ class VerifyCredentials extends BaseApi
 	public static function rawContent(array $parameters = [])
 	{
 		self::login(self::SCOPE_READ);
-		$uid = self::getCurrentUserID();
+		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		$self = User::getOwnerDataById($uid);
 		if (empty($self)) {

--- a/src/Module/Api/Mastodon/Accounts/VerifyCredentials.php
+++ b/src/Module/Api/Mastodon/Accounts/VerifyCredentials.php
@@ -25,12 +25,12 @@ use Friendica\Core\System;
 use Friendica\DI;
 use Friendica\Model\Contact;
 use Friendica\Model\User;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 
 /**
  * @see https://docs.joinmastodon.org/methods/accounts/
  */
-class VerifyCredentials extends BaseApi
+class VerifyCredentials extends BaseMastodon
 {
 	/**
 	 * @param array $parameters

--- a/src/Module/Api/Mastodon/Accounts/VerifyCredentials.php
+++ b/src/Module/Api/Mastodon/Accounts/VerifyCredentials.php
@@ -38,7 +38,7 @@ class VerifyCredentials extends BaseMastodon
 	 */
 	public static function rawContent(array $parameters = [])
 	{
-		self::login(self::SCOPE_READ);
+		self::checkAllowedScope(self::SCOPE_READ);
 		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		$self = User::getOwnerDataById($uid);

--- a/src/Module/Api/Mastodon/Announcements.php
+++ b/src/Module/Api/Mastodon/Announcements.php
@@ -22,12 +22,12 @@
 namespace Friendica\Module\Api\Mastodon;
 
 use Friendica\Core\System;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 
 /**
  * @see https://docs.joinmastodon.org/methods/announcements/
  */
-class Announcements extends BaseApi
+class Announcements extends BaseMastodon
 {
 	/**
 	 * @param array $parameters

--- a/src/Module/Api/Mastodon/Announcements.php
+++ b/src/Module/Api/Mastodon/Announcements.php
@@ -35,7 +35,7 @@ class Announcements extends BaseMastodon
 	 */
 	public static function rawContent(array $parameters = [])
 	{
-		self::login(self::SCOPE_READ);
+		self::checkAllowedScope(self::SCOPE_READ);
 
 		// @todo Possibly use the message from the pageheader addon for this
 		System::jsonExit([]);

--- a/src/Module/Api/Mastodon/Apps.php
+++ b/src/Module/Api/Mastodon/Apps.php
@@ -24,13 +24,13 @@ namespace Friendica\Module\Api\Mastodon;
 use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\DI;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 use Friendica\Util\Network;
 
 /**
  * Apps class to register new OAuth clients
  */
-class Apps extends BaseApi
+class Apps extends BaseMastodon
 {
 	/**
 	 * @param array $parameters

--- a/src/Module/Api/Mastodon/Apps/VerifyCredentials.php
+++ b/src/Module/Api/Mastodon/Apps/VerifyCredentials.php
@@ -32,7 +32,7 @@ class VerifyCredentials extends BaseMastodon
 {
 	public static function rawContent(array $parameters = [])
 	{
-		self::login(self::SCOPE_READ);
+		self::checkAllowedScope(self::SCOPE_READ);
 		$application = self::getCurrentApplication();
 
 		if (empty($application['id'])) {

--- a/src/Module/Api/Mastodon/Apps/VerifyCredentials.php
+++ b/src/Module/Api/Mastodon/Apps/VerifyCredentials.php
@@ -23,12 +23,12 @@ namespace Friendica\Module\Api\Mastodon\Apps;
 
 use Friendica\Core\System;
 use Friendica\DI;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 
 /**
  * @see https://docs.joinmastodon.org/methods/apps/
  */
-class VerifyCredentials extends BaseApi
+class VerifyCredentials extends BaseMastodon
 {
 	public static function rawContent(array $parameters = [])
 	{

--- a/src/Module/Api/Mastodon/Blocks.php
+++ b/src/Module/Api/Mastodon/Blocks.php
@@ -37,7 +37,7 @@ class Blocks extends BaseMastodon
 	 */
 	public static function rawContent(array $parameters = [])
 	{
-		self::login(self::SCOPE_READ);
+		self::checkAllowedScope(self::SCOPE_READ);
 		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (empty($parameters['id'])) {

--- a/src/Module/Api/Mastodon/Blocks.php
+++ b/src/Module/Api/Mastodon/Blocks.php
@@ -24,12 +24,12 @@ namespace Friendica\Module\Api\Mastodon;
 use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\DI;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 
 /**
  * @see https://docs.joinmastodon.org/methods/accounts/blocks/
  */
-class Blocks extends BaseApi
+class Blocks extends BaseMastodon
 {
 	/**
 	 * @param array $parameters

--- a/src/Module/Api/Mastodon/Blocks.php
+++ b/src/Module/Api/Mastodon/Blocks.php
@@ -38,7 +38,7 @@ class Blocks extends BaseApi
 	public static function rawContent(array $parameters = [])
 	{
 		self::login(self::SCOPE_READ);
-		$uid = self::getCurrentUserID();
+		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (empty($parameters['id'])) {
 			DI::mstdnError()->UnprocessableEntity();

--- a/src/Module/Api/Mastodon/Bookmarks.php
+++ b/src/Module/Api/Mastodon/Bookmarks.php
@@ -25,13 +25,13 @@ use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Post;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 use Friendica\Network\HTTPException;
 
 /**
  * @see https://docs.joinmastodon.org/methods/accounts/bookmarks/
  */
-class Bookmarks extends BaseApi
+class Bookmarks extends BaseMastodon
 {
 	/**
 	 * @param array $parameters

--- a/src/Module/Api/Mastodon/Bookmarks.php
+++ b/src/Module/Api/Mastodon/Bookmarks.php
@@ -40,7 +40,7 @@ class Bookmarks extends BaseApi
 	public static function rawContent(array $parameters = [])
 	{
 		self::login(self::SCOPE_READ);
-		$uid = self::getCurrentUserID();
+		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		$request = self::getRequest([
 			'limit'      => 20,    // Maximum number of results to return. Defaults to 20.

--- a/src/Module/Api/Mastodon/Bookmarks.php
+++ b/src/Module/Api/Mastodon/Bookmarks.php
@@ -39,7 +39,7 @@ class Bookmarks extends BaseMastodon
 	 */
 	public static function rawContent(array $parameters = [])
 	{
-		self::login(self::SCOPE_READ);
+		self::checkAllowedScope(self::SCOPE_READ);
 		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		$request = self::getRequest([

--- a/src/Module/Api/Mastodon/Conversations.php
+++ b/src/Module/Api/Mastodon/Conversations.php
@@ -34,7 +34,7 @@ class Conversations extends BaseApi
 	public static function delete(array $parameters = [])
 	{
 		self::login(self::SCOPE_WRITE);
-		$uid = self::getCurrentUserID();
+		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (!empty($parameters['id'])) {
 			DI::mstdnError()->UnprocessableEntity();
@@ -53,7 +53,7 @@ class Conversations extends BaseApi
 	public static function rawContent(array $parameters = [])
 	{
 		self::login(self::SCOPE_READ);
-		$uid = self::getCurrentUserID();
+		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		$request = self::getRequest([
 			'limit'    => 20, // Maximum number of results. Defaults to 20. Max 40.

--- a/src/Module/Api/Mastodon/Conversations.php
+++ b/src/Module/Api/Mastodon/Conversations.php
@@ -33,7 +33,7 @@ class Conversations extends BaseMastodon
 {
 	public static function delete(array $parameters = [])
 	{
-		self::login(self::SCOPE_WRITE);
+		self::checkAllowedScope(self::SCOPE_WRITE);
 		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (!empty($parameters['id'])) {
@@ -52,7 +52,7 @@ class Conversations extends BaseMastodon
 	 */
 	public static function rawContent(array $parameters = [])
 	{
-		self::login(self::SCOPE_READ);
+		self::checkAllowedScope(self::SCOPE_READ);
 		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		$request = self::getRequest([

--- a/src/Module/Api/Mastodon/Conversations.php
+++ b/src/Module/Api/Mastodon/Conversations.php
@@ -24,12 +24,12 @@ namespace Friendica\Module\Api\Mastodon;
 use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\DI;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 
 /**
  * @see https://docs.joinmastodon.org/methods/timelines/conversations/
  */
-class Conversations extends BaseApi
+class Conversations extends BaseMastodon
 {
 	public static function delete(array $parameters = [])
 	{

--- a/src/Module/Api/Mastodon/Conversations/Read.php
+++ b/src/Module/Api/Mastodon/Conversations/Read.php
@@ -34,7 +34,7 @@ class Read extends BaseApi
 	public static function post(array $parameters = [])
 	{
 		self::login(self::SCOPE_WRITE);
-		$uid = self::getCurrentUserID();
+		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (!empty($parameters['id'])) {
 			DI::mstdnError()->UnprocessableEntity();

--- a/src/Module/Api/Mastodon/Conversations/Read.php
+++ b/src/Module/Api/Mastodon/Conversations/Read.php
@@ -33,7 +33,7 @@ class Read extends BaseMastodon
 {
 	public static function post(array $parameters = [])
 	{
-		self::login(self::SCOPE_WRITE);
+		self::checkAllowedScope(self::SCOPE_WRITE);
 		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (!empty($parameters['id'])) {

--- a/src/Module/Api/Mastodon/Conversations/Read.php
+++ b/src/Module/Api/Mastodon/Conversations/Read.php
@@ -24,12 +24,12 @@ namespace Friendica\Module\Api\Mastodon\Conversations;
 use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\DI;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 
 /**
  * @see https://docs.joinmastodon.org/methods/timelines/conversations/
  */
-class Read extends BaseApi
+class Read extends BaseMastodon
 {
 	public static function post(array $parameters = [])
 	{

--- a/src/Module/Api/Mastodon/CustomEmojis.php
+++ b/src/Module/Api/Mastodon/CustomEmojis.php
@@ -24,13 +24,13 @@ namespace Friendica\Module\Api\Mastodon;
 use Friendica\Content\Smilies;
 use Friendica\Core\System;
 use Friendica\DI;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 use Friendica\Network\HTTPException;
 
 /**
  * @see https://docs.joinmastodon.org/methods/accounts/follow_requests
  */
-class CustomEmojis extends BaseApi
+class CustomEmojis extends BaseMastodon
 {
 	/**
 	 * @param array $parameters

--- a/src/Module/Api/Mastodon/Directory.php
+++ b/src/Module/Api/Mastodon/Directory.php
@@ -26,13 +26,13 @@ use Friendica\Core\Protocol;
 use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\DI;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 use Friendica\Network\HTTPException;
 
 /**
  * @see https://docs.joinmastodon.org/methods/instance/directory/
  */
-class Directory extends BaseApi
+class Directory extends BaseMastodon
 {
 	/**
 	 * @param array $parameters

--- a/src/Module/Api/Mastodon/Endorsements.php
+++ b/src/Module/Api/Mastodon/Endorsements.php
@@ -22,12 +22,12 @@
 namespace Friendica\Module\Api\Mastodon;
 
 use Friendica\Core\System;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 
 /**
  * @see https://docs.joinmastodon.org/methods/accounts/endorsements/
  */
-class Endorsements extends BaseApi
+class Endorsements extends BaseMastodon
 {
 	/**
 	 * @param array $parameters

--- a/src/Module/Api/Mastodon/Favourited.php
+++ b/src/Module/Api/Mastodon/Favourited.php
@@ -41,7 +41,7 @@ class Favourited extends BaseApi
 	public static function rawContent(array $parameters = [])
 	{
 		self::login(self::SCOPE_READ);
-		$uid = self::getCurrentUserID();
+		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		// @todo provide HTTP link header
 

--- a/src/Module/Api/Mastodon/Favourited.php
+++ b/src/Module/Api/Mastodon/Favourited.php
@@ -25,14 +25,14 @@ use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Post;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 use Friendica\Network\HTTPException;
 use Friendica\Protocol\Activity;
 
 /**
  * @see https://docs.joinmastodon.org/methods/accounts/favourites/
  */
-class Favourited extends BaseApi
+class Favourited extends BaseMastodon
 {
 	/**
 	 * @param array $parameters

--- a/src/Module/Api/Mastodon/Favourited.php
+++ b/src/Module/Api/Mastodon/Favourited.php
@@ -40,7 +40,7 @@ class Favourited extends BaseMastodon
 	 */
 	public static function rawContent(array $parameters = [])
 	{
-		self::login(self::SCOPE_READ);
+		self::checkAllowedScope(self::SCOPE_READ);
 		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		// @todo provide HTTP link header

--- a/src/Module/Api/Mastodon/Filters.php
+++ b/src/Module/Api/Mastodon/Filters.php
@@ -22,12 +22,12 @@
 namespace Friendica\Module\Api\Mastodon;
 
 use Friendica\Core\System;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 
 /**
  * @see https://docs.joinmastodon.org/methods/accounts/filters/
  */
-class Filters extends BaseApi
+class Filters extends BaseMastodon
 {
 	public static function post(array $parameters = [])
 	{

--- a/src/Module/Api/Mastodon/Filters.php
+++ b/src/Module/Api/Mastodon/Filters.php
@@ -31,7 +31,7 @@ class Filters extends BaseMastodon
 {
 	public static function post(array $parameters = [])
 	{
-		self::login(self::SCOPE_WRITE);
+		self::checkAllowedScope(self::SCOPE_WRITE);
 
 		self::unsupported('post');
 	}
@@ -42,7 +42,7 @@ class Filters extends BaseMastodon
 	 */
 	public static function rawContent(array $parameters = [])
 	{
-		self::login(self::SCOPE_READ);
+		self::checkAllowedScope(self::SCOPE_READ);
 
 		System::jsonExit([]);
 	}

--- a/src/Module/Api/Mastodon/FollowRequests.php
+++ b/src/Module/Api/Mastodon/FollowRequests.php
@@ -45,7 +45,7 @@ class FollowRequests extends BaseMastodon
 	 */
 	public static function post(array $parameters = [])
 	{
-		self::login(self::SCOPE_FOLLOW);
+		self::checkAllowedScope(self::SCOPE_FOLLOW);
 		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		$introduction = DI::intro()->selectFirst(['id' => $parameters['id'], 'uid' => $uid]);
@@ -83,7 +83,7 @@ class FollowRequests extends BaseMastodon
 	 */
 	public static function rawContent(array $parameters = [])
 	{
-		self::login(self::SCOPE_READ);
+		self::checkAllowedScope(self::SCOPE_READ);
 		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		$request = self::getRequest([

--- a/src/Module/Api/Mastodon/FollowRequests.php
+++ b/src/Module/Api/Mastodon/FollowRequests.php
@@ -46,7 +46,7 @@ class FollowRequests extends BaseApi
 	public static function post(array $parameters = [])
 	{
 		self::login(self::SCOPE_FOLLOW);
-		$uid = self::getCurrentUserID();
+		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		$introduction = DI::intro()->selectFirst(['id' => $parameters['id'], 'uid' => $uid]);
 
@@ -84,7 +84,7 @@ class FollowRequests extends BaseApi
 	public static function rawContent(array $parameters = [])
 	{
 		self::login(self::SCOPE_READ);
-		$uid = self::getCurrentUserID();
+		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		$request = self::getRequest([
 			'min_id' => 0,

--- a/src/Module/Api/Mastodon/FollowRequests.php
+++ b/src/Module/Api/Mastodon/FollowRequests.php
@@ -23,13 +23,13 @@ namespace Friendica\Module\Api\Mastodon;
 
 use Friendica\Core\System;
 use Friendica\DI;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 use Friendica\Network\HTTPException;
 
 /**
  * @see https://docs.joinmastodon.org/methods/accounts/follow_requests
  */
-class FollowRequests extends BaseApi
+class FollowRequests extends BaseMastodon
 {
 	/**
 	 * @param array $parameters

--- a/src/Module/Api/Mastodon/Instance.php
+++ b/src/Module/Api/Mastodon/Instance.php
@@ -22,13 +22,13 @@
 namespace Friendica\Module\Api\Mastodon;
 
 use Friendica\Core\System;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 use Friendica\Object\Api\Mastodon\Instance as InstanceEntity;
 
 /**
  * @see https://docs.joinmastodon.org/api/rest/instances/
  */
-class Instance extends BaseApi
+class Instance extends BaseMastodon
 {
 	/**
 	 * @param array $parameters

--- a/src/Module/Api/Mastodon/Instance/Peers.php
+++ b/src/Module/Api/Mastodon/Instance/Peers.php
@@ -24,14 +24,14 @@ namespace Friendica\Module\Api\Mastodon\Instance;
 use Friendica\Core\Protocol;
 use Friendica\Core\System;
 use Friendica\Database\DBA;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 use Friendica\Network\HTTPException;
 use Friendica\Util\Network;
 
 /**
  * Undocumented API endpoint that is implemented by both Mastodon and Pleroma
  */
-class Peers extends BaseApi
+class Peers extends BaseMastodon
 {
 	/**
 	 * @param array $parameters

--- a/src/Module/Api/Mastodon/Instance/Rules.php
+++ b/src/Module/Api/Mastodon/Instance/Rules.php
@@ -25,13 +25,13 @@ use Friendica\Content\Text\BBCode;
 use Friendica\Content\Text\HTML;
 use Friendica\Core\System;
 use Friendica\DI;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 use Friendica\Network\HTTPException;
 
 /**
  * Undocumented API endpoint
  */
-class Rules extends BaseApi
+class Rules extends BaseMastodon
 {
 	/**
 	 * @param array $parameters

--- a/src/Module/Api/Mastodon/Lists.php
+++ b/src/Module/Api/Mastodon/Lists.php
@@ -23,13 +23,13 @@ namespace Friendica\Module\Api\Mastodon;
 
 use Friendica\Core\System;
 use Friendica\DI;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 use Friendica\Model\Group;
 
 /**
  * @see https://docs.joinmastodon.org/methods/timelines/lists/
  */
-class Lists extends BaseApi
+class Lists extends BaseMastodon
 {
 	public static function delete(array $parameters = [])
 	{

--- a/src/Module/Api/Mastodon/Lists.php
+++ b/src/Module/Api/Mastodon/Lists.php
@@ -35,7 +35,7 @@ class Lists extends BaseApi
 	{
 		self::login(self::SCOPE_WRITE);
 
-		$uid = self::getCurrentUserID();
+		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (empty($parameters['id'])) {
 			DI::mstdnError()->UnprocessableEntity();
@@ -56,7 +56,7 @@ class Lists extends BaseApi
 	{
 		self::login(self::SCOPE_WRITE);
 
-		$uid   = self::getCurrentUserID();
+		$uid   = self::getCachedCurrentUserIdFromRequest();
 
 		$request = self::getRequest([
 			'title' => '',
@@ -97,7 +97,7 @@ class Lists extends BaseApi
 	public static function rawContent(array $parameters = [])
 	{
 		self::login(self::SCOPE_READ);
-		$uid = self::getCurrentUserID();
+		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (empty($parameters['id'])) {
 			$lists = [];

--- a/src/Module/Api/Mastodon/Lists.php
+++ b/src/Module/Api/Mastodon/Lists.php
@@ -33,7 +33,7 @@ class Lists extends BaseMastodon
 {
 	public static function delete(array $parameters = [])
 	{
-		self::login(self::SCOPE_WRITE);
+		self::checkAllowedScope(self::SCOPE_WRITE);
 
 		$uid = self::getCachedCurrentUserIdFromRequest();
 
@@ -54,7 +54,7 @@ class Lists extends BaseMastodon
 
 	public static function post(array $parameters = [])
 	{
-		self::login(self::SCOPE_WRITE);
+		self::checkAllowedScope(self::SCOPE_WRITE);
 
 		$uid   = self::getCachedCurrentUserIdFromRequest();
 
@@ -96,7 +96,7 @@ class Lists extends BaseMastodon
 	 */
 	public static function rawContent(array $parameters = [])
 	{
-		self::login(self::SCOPE_READ);
+		self::checkAllowedScope(self::SCOPE_READ);
 		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (empty($parameters['id'])) {

--- a/src/Module/Api/Mastodon/Lists/Accounts.php
+++ b/src/Module/Api/Mastodon/Lists/Accounts.php
@@ -50,7 +50,7 @@ class Accounts extends BaseApi
 	public static function rawContent(array $parameters = [])
 	{
 		self::login(self::SCOPE_READ);
-		$uid = self::getCurrentUserID();
+		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (empty($parameters['id'])) {
 			DI::mstdnError()->UnprocessableEntity();

--- a/src/Module/Api/Mastodon/Lists/Accounts.php
+++ b/src/Module/Api/Mastodon/Lists/Accounts.php
@@ -24,14 +24,14 @@ namespace Friendica\Module\Api\Mastodon\Lists;
 use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\DI;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 
 /**
  * @see https://docs.joinmastodon.org/methods/timelines/lists/#accounts-in-a-list
  *
  * Currently the output will be unordered since we use public contact ids in the api and not user contact ids.
  */
-class Accounts extends BaseApi
+class Accounts extends BaseMastodon
 {
 	public static function delete(array $parameters = [])
 	{

--- a/src/Module/Api/Mastodon/Lists/Accounts.php
+++ b/src/Module/Api/Mastodon/Lists/Accounts.php
@@ -49,7 +49,7 @@ class Accounts extends BaseMastodon
 	 */
 	public static function rawContent(array $parameters = [])
 	{
-		self::login(self::SCOPE_READ);
+		self::checkAllowedScope(self::SCOPE_READ);
 		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (empty($parameters['id'])) {

--- a/src/Module/Api/Mastodon/Markers.php
+++ b/src/Module/Api/Mastodon/Markers.php
@@ -31,7 +31,7 @@ class Markers extends BaseMastodon
 {
 	public static function post(array $parameters = [])
 	{
-		self::login(self::SCOPE_WRITE);
+		self::checkAllowedScope(self::SCOPE_WRITE);
 
 		self::unsupported('post');
 	}
@@ -42,7 +42,7 @@ class Markers extends BaseMastodon
 	 */
 	public static function rawContent(array $parameters = [])
 	{
-		self::login(self::SCOPE_READ);
+		self::checkAllowedScope(self::SCOPE_READ);
 
 		System::jsonExit([]);
 	}

--- a/src/Module/Api/Mastodon/Markers.php
+++ b/src/Module/Api/Mastodon/Markers.php
@@ -22,12 +22,12 @@
 namespace Friendica\Module\Api\Mastodon;
 
 use Friendica\Core\System;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 
 /**
  * @see https://docs.joinmastodon.org/methods/timelines/markers/
  */
-class Markers extends BaseApi
+class Markers extends BaseMastodon
 {
 	public static function post(array $parameters = [])
 	{

--- a/src/Module/Api/Mastodon/Media.php
+++ b/src/Module/Api/Mastodon/Media.php
@@ -35,7 +35,7 @@ class Media extends BaseApi
 	public static function post(array $parameters = [])
 	{
 		self::login(self::SCOPE_WRITE);
-		$uid = self::getCurrentUserID();
+		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		Logger::info('Photo post', ['request' => $_REQUEST, 'files' => $_FILES]);
 
@@ -56,7 +56,7 @@ class Media extends BaseApi
 	public static function put(array $parameters = [])
 	{
 		self::login(self::SCOPE_WRITE);
-		$uid = self::getCurrentUserID();
+		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		$request = self::getRequest([
 			'file'        => [], // The file to be attached, using multipart form data.
@@ -86,7 +86,7 @@ class Media extends BaseApi
 	public static function rawContent(array $parameters = [])
 	{
 		self::login(self::SCOPE_READ);
-		$uid = self::getCurrentUserID();
+		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (empty($parameters['id'])) {
 			DI::mstdnError()->UnprocessableEntity();

--- a/src/Module/Api/Mastodon/Media.php
+++ b/src/Module/Api/Mastodon/Media.php
@@ -25,12 +25,12 @@ use Friendica\Core\Logger;
 use Friendica\Core\System;
 use Friendica\DI;
 use Friendica\Model\Photo;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 
 /**
  * @see https://docs.joinmastodon.org/methods/statuses/media/
  */
-class Media extends BaseApi
+class Media extends BaseMastodon
 {
 	public static function post(array $parameters = [])
 	{

--- a/src/Module/Api/Mastodon/Media.php
+++ b/src/Module/Api/Mastodon/Media.php
@@ -34,7 +34,7 @@ class Media extends BaseMastodon
 {
 	public static function post(array $parameters = [])
 	{
-		self::login(self::SCOPE_WRITE);
+		self::checkAllowedScope(self::SCOPE_WRITE);
 		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		Logger::info('Photo post', ['request' => $_REQUEST, 'files' => $_FILES]);
@@ -55,7 +55,7 @@ class Media extends BaseMastodon
 
 	public static function put(array $parameters = [])
 	{
-		self::login(self::SCOPE_WRITE);
+		self::checkAllowedScope(self::SCOPE_WRITE);
 		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		$request = self::getRequest([
@@ -85,7 +85,7 @@ class Media extends BaseMastodon
 	 */
 	public static function rawContent(array $parameters = [])
 	{
-		self::login(self::SCOPE_READ);
+		self::checkAllowedScope(self::SCOPE_READ);
 		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (empty($parameters['id'])) {

--- a/src/Module/Api/Mastodon/Mutes.php
+++ b/src/Module/Api/Mastodon/Mutes.php
@@ -38,7 +38,7 @@ class Mutes extends BaseApi
 	public static function rawContent(array $parameters = [])
 	{
 		self::login(self::SCOPE_READ);
-		$uid = self::getCurrentUserID();
+		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (empty($parameters['id'])) {
 			DI::mstdnError()->UnprocessableEntity();

--- a/src/Module/Api/Mastodon/Mutes.php
+++ b/src/Module/Api/Mastodon/Mutes.php
@@ -37,7 +37,7 @@ class Mutes extends BaseMastodon
 	 */
 	public static function rawContent(array $parameters = [])
 	{
-		self::login(self::SCOPE_READ);
+		self::checkAllowedScope(self::SCOPE_READ);
 		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (empty($parameters['id'])) {

--- a/src/Module/Api/Mastodon/Mutes.php
+++ b/src/Module/Api/Mastodon/Mutes.php
@@ -24,12 +24,12 @@ namespace Friendica\Module\Api\Mastodon;
 use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\DI;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 
 /**
  * @see https://docs.joinmastodon.org/methods/accounts/mutes/
  */
-class Mutes extends BaseApi
+class Mutes extends BaseMastodon
 {
 	/**
 	 * @param array $parameters

--- a/src/Module/Api/Mastodon/Notifications.php
+++ b/src/Module/Api/Mastodon/Notifications.php
@@ -27,13 +27,13 @@ use Friendica\DI;
 use Friendica\Model\Contact;
 use Friendica\Model\Post;
 use Friendica\Model\Verb;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 use Friendica\Protocol\Activity;
 
 /**
  * @see https://docs.joinmastodon.org/methods/notifications/
  */
-class Notifications extends BaseApi
+class Notifications extends BaseMastodon
 {
 	/**
 	 * @param array $parameters

--- a/src/Module/Api/Mastodon/Notifications.php
+++ b/src/Module/Api/Mastodon/Notifications.php
@@ -41,7 +41,7 @@ class Notifications extends BaseMastodon
 	 */
 	public static function rawContent(array $parameters = [])
 	{
-		self::login(self::SCOPE_READ);
+		self::checkAllowedScope(self::SCOPE_READ);
 		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (!empty($parameters['id'])) {

--- a/src/Module/Api/Mastodon/Notifications.php
+++ b/src/Module/Api/Mastodon/Notifications.php
@@ -42,7 +42,7 @@ class Notifications extends BaseApi
 	public static function rawContent(array $parameters = [])
 	{
 		self::login(self::SCOPE_READ);
-		$uid = self::getCurrentUserID();
+		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (!empty($parameters['id'])) {
 			$id = $parameters['id'];

--- a/src/Module/Api/Mastodon/Notifications/Clear.php
+++ b/src/Module/Api/Mastodon/Notifications/Clear.php
@@ -33,7 +33,7 @@ class Clear extends BaseApi
 	public static function post(array $parameters = [])
 	{
 		self::login(self::SCOPE_WRITE);
-		$uid = self::getCurrentUserID();
+		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		DBA::update('notification', ['seen' => true], ['uid' => $uid]);
 

--- a/src/Module/Api/Mastodon/Notifications/Clear.php
+++ b/src/Module/Api/Mastodon/Notifications/Clear.php
@@ -32,7 +32,7 @@ class Clear extends BaseMastodon
 {
 	public static function post(array $parameters = [])
 	{
-		self::login(self::SCOPE_WRITE);
+		self::checkAllowedScope(self::SCOPE_WRITE);
 		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		DBA::update('notification', ['seen' => true], ['uid' => $uid]);

--- a/src/Module/Api/Mastodon/Notifications/Clear.php
+++ b/src/Module/Api/Mastodon/Notifications/Clear.php
@@ -23,12 +23,12 @@ namespace Friendica\Module\Api\Mastodon\Notifications;
 
 use Friendica\Core\System;
 use Friendica\Database\DBA;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 
 /**
  * @see https://docs.joinmastodon.org/methods/notifications/
  */
-class Clear extends BaseApi
+class Clear extends BaseMastodon
 {
 	public static function post(array $parameters = [])
 	{

--- a/src/Module/Api/Mastodon/Notifications/Dismiss.php
+++ b/src/Module/Api/Mastodon/Notifications/Dismiss.php
@@ -24,12 +24,12 @@ namespace Friendica\Module\Api\Mastodon\Notifications;
 use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\DI;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 
 /**
  * @see https://docs.joinmastodon.org/methods/notifications/
  */
-class Dismiss extends BaseApi
+class Dismiss extends BaseMastodon
 {
 	public static function post(array $parameters = [])
 	{

--- a/src/Module/Api/Mastodon/Notifications/Dismiss.php
+++ b/src/Module/Api/Mastodon/Notifications/Dismiss.php
@@ -34,7 +34,7 @@ class Dismiss extends BaseApi
 	public static function post(array $parameters = [])
 	{
 		self::login(self::SCOPE_WRITE);
-		$uid = self::getCurrentUserID();
+		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (empty($parameters['id'])) {
 			DI::mstdnError()->UnprocessableEntity();

--- a/src/Module/Api/Mastodon/Notifications/Dismiss.php
+++ b/src/Module/Api/Mastodon/Notifications/Dismiss.php
@@ -33,7 +33,7 @@ class Dismiss extends BaseMastodon
 {
 	public static function post(array $parameters = [])
 	{
-		self::login(self::SCOPE_WRITE);
+		self::checkAllowedScope(self::SCOPE_WRITE);
 		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (empty($parameters['id'])) {

--- a/src/Module/Api/Mastodon/Preferences.php
+++ b/src/Module/Api/Mastodon/Preferences.php
@@ -38,7 +38,7 @@ class Preferences extends BaseApi
 	public static function rawContent(array $parameters = [])
 	{
 		self::login(self::SCOPE_READ);
-		$uid = self::getCurrentUserID();
+		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		$user = User::getById($uid, ['language', 'allow_cid', 'allow_gid', 'deny_cid', 'deny_gid']);
 		if (!empty($user['allow_cid']) || !empty($user['allow_gid']) || !empty($user['deny_cid']) || !empty($user['deny_gid'])) {

--- a/src/Module/Api/Mastodon/Preferences.php
+++ b/src/Module/Api/Mastodon/Preferences.php
@@ -24,12 +24,12 @@ namespace Friendica\Module\Api\Mastodon;
 use Friendica\Core\System;
 use Friendica\DI;
 use Friendica\Model\User;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 
 /**
  * @see https://docs.joinmastodon.org/methods/accounts/preferences/
  */
-class Preferences extends BaseApi
+class Preferences extends BaseMastodon
 {
 	/**
 	 * @param array $parameters

--- a/src/Module/Api/Mastodon/Preferences.php
+++ b/src/Module/Api/Mastodon/Preferences.php
@@ -37,7 +37,7 @@ class Preferences extends BaseMastodon
 	 */
 	public static function rawContent(array $parameters = [])
 	{
-		self::login(self::SCOPE_READ);
+		self::checkAllowedScope(self::SCOPE_READ);
 		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		$user = User::getById($uid, ['language', 'allow_cid', 'allow_gid', 'deny_cid', 'deny_gid']);

--- a/src/Module/Api/Mastodon/Proofs.php
+++ b/src/Module/Api/Mastodon/Proofs.php
@@ -22,12 +22,12 @@
 namespace Friendica\Module\Api\Mastodon;
 
 use Friendica\Core\System;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 
 /**
  * @see https://docs.joinmastodon.org/methods/proofs/
  */
-class Proofs extends BaseApi
+class Proofs extends BaseMastodon
 {
 	/**
 	 * @param array $parameters

--- a/src/Module/Api/Mastodon/ScheduledStatuses.php
+++ b/src/Module/Api/Mastodon/ScheduledStatuses.php
@@ -22,12 +22,12 @@
 namespace Friendica\Module\Api\Mastodon;
 
 use Friendica\Core\System;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 
 /**
  * @see https://docs.joinmastodon.org/methods/statuses/scheduled_statuses/
  */
-class ScheduledStatuses extends BaseApi
+class ScheduledStatuses extends BaseMastodon
 {
 	/**
 	 * @param array $parameters

--- a/src/Module/Api/Mastodon/Search.php
+++ b/src/Module/Api/Mastodon/Search.php
@@ -29,13 +29,13 @@ use Friendica\DI;
 use Friendica\Model\Contact;
 use Friendica\Model\Post;
 use Friendica\Model\Tag;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 use Friendica\Object\Search\ContactResult;
 
 /**
  * @see https://docs.joinmastodon.org/methods/search/
  */
-class Search extends BaseApi
+class Search extends BaseMastodon
 {
 	/**
 	 * @param array $parameters

--- a/src/Module/Api/Mastodon/Search.php
+++ b/src/Module/Api/Mastodon/Search.php
@@ -44,7 +44,7 @@ class Search extends BaseApi
 	public static function rawContent(array $parameters = [])
 	{
 		self::login(self::SCOPE_READ);
-		$uid = self::getCurrentUserID();
+		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		$request = self::getRequest([
 			'account_id'         => 0,     // If provided, statuses returned will be authored only by this account

--- a/src/Module/Api/Mastodon/Search.php
+++ b/src/Module/Api/Mastodon/Search.php
@@ -43,7 +43,7 @@ class Search extends BaseMastodon
 	 */
 	public static function rawContent(array $parameters = [])
 	{
-		self::login(self::SCOPE_READ);
+		self::checkAllowedScope(self::SCOPE_READ);
 		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		$request = self::getRequest([

--- a/src/Module/Api/Mastodon/Statuses.php
+++ b/src/Module/Api/Mastodon/Statuses.php
@@ -43,7 +43,7 @@ class Statuses extends BaseMastodon
 {
 	public static function post(array $parameters = [])
 	{
-		self::login(self::SCOPE_WRITE);
+		self::checkAllowedScope(self::SCOPE_WRITE);
 		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		$request = self::getRequest([
@@ -194,7 +194,7 @@ class Statuses extends BaseMastodon
 
 	public static function delete(array $parameters = [])
 	{
-		self::login(self::SCOPE_READ);
+		self::checkAllowedScope(self::SCOPE_READ);
 		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (empty($parameters['id'])) {

--- a/src/Module/Api/Mastodon/Statuses.php
+++ b/src/Module/Api/Mastodon/Statuses.php
@@ -32,14 +32,14 @@ use Friendica\Model\Item;
 use Friendica\Model\Photo;
 use Friendica\Model\Post;
 use Friendica\Model\User;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 use Friendica\Protocol\Activity;
 use Friendica\Util\Images;
 
 /**
  * @see https://docs.joinmastodon.org/methods/statuses/
  */
-class Statuses extends BaseApi
+class Statuses extends BaseMastodon
 {
 	public static function post(array $parameters = [])
 	{

--- a/src/Module/Api/Mastodon/Statuses.php
+++ b/src/Module/Api/Mastodon/Statuses.php
@@ -44,7 +44,7 @@ class Statuses extends BaseApi
 	public static function post(array $parameters = [])
 	{
 		self::login(self::SCOPE_WRITE);
-		$uid = self::getCurrentUserID();
+		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		$request = self::getRequest([
 			'status'         => '',    // Text content of the status. If media_ids is provided, this becomes optional. Attaching a poll is optional while status is provided.
@@ -195,7 +195,7 @@ class Statuses extends BaseApi
 	public static function delete(array $parameters = [])
 	{
 		self::login(self::SCOPE_READ);
-		$uid = self::getCurrentUserID();
+		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (empty($parameters['id'])) {
 			DI::mstdnError()->UnprocessableEntity();
@@ -223,6 +223,6 @@ class Statuses extends BaseApi
 			DI::mstdnError()->UnprocessableEntity();
 		}
 
-		System::jsonExit(DI::mstdnStatus()->createFromUriId($parameters['id'], self::getCurrentUserID()));
+		System::jsonExit(DI::mstdnStatus()->createFromUriId($parameters['id'], self::getCachedCurrentUserIdFromRequest()));
 	}
 }

--- a/src/Module/Api/Mastodon/Statuses/Bookmark.php
+++ b/src/Module/Api/Mastodon/Statuses/Bookmark.php
@@ -36,7 +36,7 @@ class Bookmark extends BaseApi
 	public static function post(array $parameters = [])
 	{
 		self::login(self::SCOPE_WRITE);
-		$uid = self::getCurrentUserID();
+		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (empty($parameters['id'])) {
 			DI::mstdnError()->UnprocessableEntity();

--- a/src/Module/Api/Mastodon/Statuses/Bookmark.php
+++ b/src/Module/Api/Mastodon/Statuses/Bookmark.php
@@ -35,7 +35,7 @@ class Bookmark extends BaseMastodon
 {
 	public static function post(array $parameters = [])
 	{
-		self::login(self::SCOPE_WRITE);
+		self::checkAllowedScope(self::SCOPE_WRITE);
 		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (empty($parameters['id'])) {

--- a/src/Module/Api/Mastodon/Statuses/Bookmark.php
+++ b/src/Module/Api/Mastodon/Statuses/Bookmark.php
@@ -26,12 +26,12 @@ use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Item;
 use Friendica\Model\Post;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 
 /**
  * @see https://docs.joinmastodon.org/methods/statuses/
  */
-class Bookmark extends BaseApi
+class Bookmark extends BaseMastodon
 {
 	public static function post(array $parameters = [])
 	{

--- a/src/Module/Api/Mastodon/Statuses/Context.php
+++ b/src/Module/Api/Mastodon/Statuses/Context.php
@@ -25,12 +25,12 @@ use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Post;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 
 /**
  * @see https://docs.joinmastodon.org/methods/statuses/
  */
-class Context extends BaseApi
+class Context extends BaseMastodon
 {
 	/**
 	 * @param array $parameters

--- a/src/Module/Api/Mastodon/Statuses/Context.php
+++ b/src/Module/Api/Mastodon/Statuses/Context.php
@@ -38,7 +38,7 @@ class Context extends BaseApi
 	 */
 	public static function rawContent(array $parameters = [])
 	{
-		$uid = self::getCurrentUserID();
+		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (empty($parameters['id'])) {
 			DI::mstdnError()->UnprocessableEntity();

--- a/src/Module/Api/Mastodon/Statuses/Favourite.php
+++ b/src/Module/Api/Mastodon/Statuses/Favourite.php
@@ -36,7 +36,7 @@ class Favourite extends BaseApi
 	public static function post(array $parameters = [])
 	{
 		self::login(self::SCOPE_WRITE);
-		$uid = self::getCurrentUserID();
+		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (empty($parameters['id'])) {
 			DI::mstdnError()->UnprocessableEntity();

--- a/src/Module/Api/Mastodon/Statuses/Favourite.php
+++ b/src/Module/Api/Mastodon/Statuses/Favourite.php
@@ -26,12 +26,12 @@ use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Item;
 use Friendica\Model\Post;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 
 /**
  * @see https://docs.joinmastodon.org/methods/statuses/
  */
-class Favourite extends BaseApi
+class Favourite extends BaseMastodon
 {
 	public static function post(array $parameters = [])
 	{

--- a/src/Module/Api/Mastodon/Statuses/Favourite.php
+++ b/src/Module/Api/Mastodon/Statuses/Favourite.php
@@ -35,7 +35,7 @@ class Favourite extends BaseMastodon
 {
 	public static function post(array $parameters = [])
 	{
-		self::login(self::SCOPE_WRITE);
+		self::checkAllowedScope(self::SCOPE_WRITE);
 		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (empty($parameters['id'])) {

--- a/src/Module/Api/Mastodon/Statuses/FavouritedBy.php
+++ b/src/Module/Api/Mastodon/Statuses/FavouritedBy.php
@@ -24,13 +24,13 @@ namespace Friendica\Module\Api\Mastodon\Statuses;
 use Friendica\Core\System;
 use Friendica\DI;
 use Friendica\Model\Post;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 use Friendica\Protocol\Activity;
 
 /**
  * @see https://docs.joinmastodon.org/methods/statuses/
  */
-class FavouritedBy extends BaseApi
+class FavouritedBy extends BaseMastodon
 {
 	/**
 	 * @param array $parameters

--- a/src/Module/Api/Mastodon/Statuses/FavouritedBy.php
+++ b/src/Module/Api/Mastodon/Statuses/FavouritedBy.php
@@ -38,7 +38,7 @@ class FavouritedBy extends BaseApi
 	 */
 	public static function rawContent(array $parameters = [])
 	{
-		$uid = self::getCurrentUserID();
+		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (empty($parameters['id'])) {
 			DI::mstdnError()->UnprocessableEntity();

--- a/src/Module/Api/Mastodon/Statuses/Mute.php
+++ b/src/Module/Api/Mastodon/Statuses/Mute.php
@@ -25,12 +25,12 @@ use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Post;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 
 /**
  * @see https://docs.joinmastodon.org/methods/statuses/
  */
-class Mute extends BaseApi
+class Mute extends BaseMastodon
 {
 	public static function post(array $parameters = [])
 	{

--- a/src/Module/Api/Mastodon/Statuses/Mute.php
+++ b/src/Module/Api/Mastodon/Statuses/Mute.php
@@ -34,7 +34,7 @@ class Mute extends BaseMastodon
 {
 	public static function post(array $parameters = [])
 	{
-		self::login(self::SCOPE_WRITE);
+		self::checkAllowedScope(self::SCOPE_WRITE);
 		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (empty($parameters['id'])) {

--- a/src/Module/Api/Mastodon/Statuses/Mute.php
+++ b/src/Module/Api/Mastodon/Statuses/Mute.php
@@ -35,7 +35,7 @@ class Mute extends BaseApi
 	public static function post(array $parameters = [])
 	{
 		self::login(self::SCOPE_WRITE);
-		$uid = self::getCurrentUserID();
+		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (empty($parameters['id'])) {
 			DI::mstdnError()->UnprocessableEntity();

--- a/src/Module/Api/Mastodon/Statuses/Pin.php
+++ b/src/Module/Api/Mastodon/Statuses/Pin.php
@@ -35,7 +35,7 @@ class Pin extends BaseApi
 	public static function post(array $parameters = [])
 	{
 		self::login(self::SCOPE_WRITE);
-		$uid = self::getCurrentUserID();
+		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (empty($parameters['id'])) {
 			DI::mstdnError()->UnprocessableEntity();

--- a/src/Module/Api/Mastodon/Statuses/Pin.php
+++ b/src/Module/Api/Mastodon/Statuses/Pin.php
@@ -25,12 +25,12 @@ use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Post;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 
 /**
  * @see https://docs.joinmastodon.org/methods/statuses/
  */
-class Pin extends BaseApi
+class Pin extends BaseMastodon
 {
 	public static function post(array $parameters = [])
 	{

--- a/src/Module/Api/Mastodon/Statuses/Pin.php
+++ b/src/Module/Api/Mastodon/Statuses/Pin.php
@@ -34,7 +34,7 @@ class Pin extends BaseMastodon
 {
 	public static function post(array $parameters = [])
 	{
-		self::login(self::SCOPE_WRITE);
+		self::checkAllowedScope(self::SCOPE_WRITE);
 		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (empty($parameters['id'])) {

--- a/src/Module/Api/Mastodon/Statuses/Reblog.php
+++ b/src/Module/Api/Mastodon/Statuses/Reblog.php
@@ -28,12 +28,12 @@ use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Item;
 use Friendica\Model\Post;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 
 /**
  * @see https://docs.joinmastodon.org/methods/statuses/
  */
-class Reblog extends BaseApi
+class Reblog extends BaseMastodon
 {
 	public static function post(array $parameters = [])
 	{

--- a/src/Module/Api/Mastodon/Statuses/Reblog.php
+++ b/src/Module/Api/Mastodon/Statuses/Reblog.php
@@ -38,7 +38,7 @@ class Reblog extends BaseApi
 	public static function post(array $parameters = [])
 	{
 		self::login(self::SCOPE_WRITE);
-		$uid = self::getCurrentUserID();
+		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (empty($parameters['id'])) {
 			DI::mstdnError()->UnprocessableEntity();

--- a/src/Module/Api/Mastodon/Statuses/Reblog.php
+++ b/src/Module/Api/Mastodon/Statuses/Reblog.php
@@ -37,7 +37,7 @@ class Reblog extends BaseMastodon
 {
 	public static function post(array $parameters = [])
 	{
-		self::login(self::SCOPE_WRITE);
+		self::checkAllowedScope(self::SCOPE_WRITE);
 		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (empty($parameters['id'])) {

--- a/src/Module/Api/Mastodon/Statuses/RebloggedBy.php
+++ b/src/Module/Api/Mastodon/Statuses/RebloggedBy.php
@@ -38,7 +38,7 @@ class RebloggedBy extends BaseApi
 	 */
 	public static function rawContent(array $parameters = [])
 	{
-		$uid = self::getCurrentUserID();
+		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (empty($parameters['id'])) {
 			DI::mstdnError()->UnprocessableEntity();

--- a/src/Module/Api/Mastodon/Statuses/RebloggedBy.php
+++ b/src/Module/Api/Mastodon/Statuses/RebloggedBy.php
@@ -24,13 +24,13 @@ namespace Friendica\Module\Api\Mastodon\Statuses;
 use Friendica\Core\System;
 use Friendica\DI;
 use Friendica\Model\Post;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 use Friendica\Protocol\Activity;
 
 /**
  * @see https://docs.joinmastodon.org/methods/statuses/
  */
-class RebloggedBy extends BaseApi
+class RebloggedBy extends BaseMastodon
 {
 	/**
 	 * @param array $parameters

--- a/src/Module/Api/Mastodon/Statuses/Unbookmark.php
+++ b/src/Module/Api/Mastodon/Statuses/Unbookmark.php
@@ -26,12 +26,12 @@ use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Item;
 use Friendica\Model\Post;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 
 /**
  * @see https://docs.joinmastodon.org/methods/statuses/
  */
-class Unbookmark extends BaseApi
+class Unbookmark extends BaseMastodon
 {
 	public static function post(array $parameters = [])
 	{

--- a/src/Module/Api/Mastodon/Statuses/Unbookmark.php
+++ b/src/Module/Api/Mastodon/Statuses/Unbookmark.php
@@ -36,7 +36,7 @@ class Unbookmark extends BaseApi
 	public static function post(array $parameters = [])
 	{
 		self::login(self::SCOPE_WRITE);
-		$uid = self::getCurrentUserID();
+		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (empty($parameters['id'])) {
 			DI::mstdnError()->UnprocessableEntity();

--- a/src/Module/Api/Mastodon/Statuses/Unbookmark.php
+++ b/src/Module/Api/Mastodon/Statuses/Unbookmark.php
@@ -35,7 +35,7 @@ class Unbookmark extends BaseMastodon
 {
 	public static function post(array $parameters = [])
 	{
-		self::login(self::SCOPE_WRITE);
+		self::checkAllowedScope(self::SCOPE_WRITE);
 		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (empty($parameters['id'])) {

--- a/src/Module/Api/Mastodon/Statuses/Unfavourite.php
+++ b/src/Module/Api/Mastodon/Statuses/Unfavourite.php
@@ -35,7 +35,7 @@ class Unfavourite extends BaseMastodon
 {
 	public static function post(array $parameters = [])
 	{
-		self::login(self::SCOPE_WRITE);
+		self::checkAllowedScope(self::SCOPE_WRITE);
 		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (empty($parameters['id'])) {

--- a/src/Module/Api/Mastodon/Statuses/Unfavourite.php
+++ b/src/Module/Api/Mastodon/Statuses/Unfavourite.php
@@ -36,7 +36,7 @@ class Unfavourite extends BaseApi
 	public static function post(array $parameters = [])
 	{
 		self::login(self::SCOPE_WRITE);
-		$uid = self::getCurrentUserID();
+		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (empty($parameters['id'])) {
 			DI::mstdnError()->UnprocessableEntity();

--- a/src/Module/Api/Mastodon/Statuses/Unfavourite.php
+++ b/src/Module/Api/Mastodon/Statuses/Unfavourite.php
@@ -26,12 +26,12 @@ use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Item;
 use Friendica\Model\Post;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 
 /**
  * @see https://docs.joinmastodon.org/methods/statuses/
  */
-class Unfavourite extends BaseApi
+class Unfavourite extends BaseMastodon
 {
 	public static function post(array $parameters = [])
 	{

--- a/src/Module/Api/Mastodon/Statuses/Unmute.php
+++ b/src/Module/Api/Mastodon/Statuses/Unmute.php
@@ -35,7 +35,7 @@ class Unmute extends BaseApi
 	public static function post(array $parameters = [])
 	{
 		self::login(self::SCOPE_WRITE);
-		$uid = self::getCurrentUserID();
+		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (empty($parameters['id'])) {
 			DI::mstdnError()->UnprocessableEntity();

--- a/src/Module/Api/Mastodon/Statuses/Unmute.php
+++ b/src/Module/Api/Mastodon/Statuses/Unmute.php
@@ -34,7 +34,7 @@ class Unmute extends BaseMastodon
 {
 	public static function post(array $parameters = [])
 	{
-		self::login(self::SCOPE_WRITE);
+		self::checkAllowedScope(self::SCOPE_WRITE);
 		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (empty($parameters['id'])) {

--- a/src/Module/Api/Mastodon/Statuses/Unmute.php
+++ b/src/Module/Api/Mastodon/Statuses/Unmute.php
@@ -25,12 +25,12 @@ use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Post;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 
 /**
  * @see https://docs.joinmastodon.org/methods/statuses/
  */
-class Unmute extends BaseApi
+class Unmute extends BaseMastodon
 {
 	public static function post(array $parameters = [])
 	{

--- a/src/Module/Api/Mastodon/Statuses/Unpin.php
+++ b/src/Module/Api/Mastodon/Statuses/Unpin.php
@@ -34,7 +34,7 @@ class Unpin extends BaseMastodon
 {
 	public static function post(array $parameters = [])
 	{
-		self::login(self::SCOPE_WRITE);
+		self::checkAllowedScope(self::SCOPE_WRITE);
 		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (empty($parameters['id'])) {

--- a/src/Module/Api/Mastodon/Statuses/Unpin.php
+++ b/src/Module/Api/Mastodon/Statuses/Unpin.php
@@ -25,12 +25,12 @@ use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Post;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 
 /**
  * @see https://docs.joinmastodon.org/methods/statuses/
  */
-class Unpin extends BaseApi
+class Unpin extends BaseMastodon
 {
 	public static function post(array $parameters = [])
 	{

--- a/src/Module/Api/Mastodon/Statuses/Unpin.php
+++ b/src/Module/Api/Mastodon/Statuses/Unpin.php
@@ -35,7 +35,7 @@ class Unpin extends BaseApi
 	public static function post(array $parameters = [])
 	{
 		self::login(self::SCOPE_WRITE);
-		$uid = self::getCurrentUserID();
+		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (empty($parameters['id'])) {
 			DI::mstdnError()->UnprocessableEntity();

--- a/src/Module/Api/Mastodon/Statuses/Unreblog.php
+++ b/src/Module/Api/Mastodon/Statuses/Unreblog.php
@@ -37,7 +37,7 @@ class Unreblog extends BaseMastodon
 {
 	public static function post(array $parameters = [])
 	{
-		self::login(self::SCOPE_WRITE);
+		self::checkAllowedScope(self::SCOPE_WRITE);
 		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (empty($parameters['id'])) {

--- a/src/Module/Api/Mastodon/Statuses/Unreblog.php
+++ b/src/Module/Api/Mastodon/Statuses/Unreblog.php
@@ -38,7 +38,7 @@ class Unreblog extends BaseApi
 	public static function post(array $parameters = [])
 	{
 		self::login(self::SCOPE_WRITE);
-		$uid = self::getCurrentUserID();
+		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (empty($parameters['id'])) {
 			DI::mstdnError()->UnprocessableEntity();

--- a/src/Module/Api/Mastodon/Statuses/Unreblog.php
+++ b/src/Module/Api/Mastodon/Statuses/Unreblog.php
@@ -28,12 +28,12 @@ use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Item;
 use Friendica\Model\Post;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 
 /**
  * @see https://docs.joinmastodon.org/methods/statuses/
  */
-class Unreblog extends BaseApi
+class Unreblog extends BaseMastodon
 {
 	public static function post(array $parameters = [])
 	{

--- a/src/Module/Api/Mastodon/Suggestions.php
+++ b/src/Module/Api/Mastodon/Suggestions.php
@@ -37,7 +37,7 @@ class Suggestions extends BaseMastodon
 	 */
 	public static function rawContent(array $parameters = [])
 	{
-		self::login(self::SCOPE_READ);
+		self::checkAllowedScope(self::SCOPE_READ);
 		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		$request = self::getRequest([

--- a/src/Module/Api/Mastodon/Suggestions.php
+++ b/src/Module/Api/Mastodon/Suggestions.php
@@ -24,12 +24,12 @@ namespace Friendica\Module\Api\Mastodon;
 use Friendica\Core\System;
 use Friendica\DI;
 use Friendica\Model\Contact;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 
 /**
  * @see https://docs.joinmastodon.org/methods/accounts/suggestions/
  */
-class Suggestions extends BaseApi
+class Suggestions extends BaseMastodon
 {
 	/**
 	 * @param array $parameters

--- a/src/Module/Api/Mastodon/Suggestions.php
+++ b/src/Module/Api/Mastodon/Suggestions.php
@@ -38,7 +38,7 @@ class Suggestions extends BaseApi
 	public static function rawContent(array $parameters = [])
 	{
 		self::login(self::SCOPE_READ);
-		$uid = self::getCurrentUserID();
+		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		$request = self::getRequest([
 			'limit' => 40, // Maximum number of results to return. Defaults to 40.

--- a/src/Module/Api/Mastodon/Timelines/Direct.php
+++ b/src/Module/Api/Mastodon/Timelines/Direct.php
@@ -24,13 +24,13 @@ namespace Friendica\Module\Api\Mastodon\Timelines;
 use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\DI;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 use Friendica\Network\HTTPException;
 
 /**
  * @see https://docs.joinmastodon.org/methods/timelines/
  */
-class Direct extends BaseApi
+class Direct extends BaseMastodon
 {
 	/**
 	 * @param array $parameters

--- a/src/Module/Api/Mastodon/Timelines/Direct.php
+++ b/src/Module/Api/Mastodon/Timelines/Direct.php
@@ -38,7 +38,7 @@ class Direct extends BaseMastodon
 	 */
 	public static function rawContent(array $parameters = [])
 	{
-		self::login(self::SCOPE_READ);
+		self::checkAllowedScope(self::SCOPE_READ);
 		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		$request = self::getRequest([

--- a/src/Module/Api/Mastodon/Timelines/Direct.php
+++ b/src/Module/Api/Mastodon/Timelines/Direct.php
@@ -39,7 +39,7 @@ class Direct extends BaseApi
 	public static function rawContent(array $parameters = [])
 	{
 		self::login(self::SCOPE_READ);
-		$uid = self::getCurrentUserID();
+		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		$request = self::getRequest([
 			'max_id'   => 0,  // Return results older than id

--- a/src/Module/Api/Mastodon/Timelines/Home.php
+++ b/src/Module/Api/Mastodon/Timelines/Home.php
@@ -40,7 +40,7 @@ class Home extends BaseApi
 	public static function rawContent(array $parameters = [])
 	{
 		self::login(self::SCOPE_READ);
-		$uid = self::getCurrentUserID();
+		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		$request = self::getRequest([
 			'max_id'          => 0,     // Return results older than id

--- a/src/Module/Api/Mastodon/Timelines/Home.php
+++ b/src/Module/Api/Mastodon/Timelines/Home.php
@@ -25,13 +25,13 @@ use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Post;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 use Friendica\Network\HTTPException;
 
 /**
  * @see https://docs.joinmastodon.org/methods/timelines/
  */
-class Home extends BaseApi
+class Home extends BaseMastodon
 {
 	/**
 	 * @param array $parameters

--- a/src/Module/Api/Mastodon/Timelines/Home.php
+++ b/src/Module/Api/Mastodon/Timelines/Home.php
@@ -39,7 +39,7 @@ class Home extends BaseMastodon
 	 */
 	public static function rawContent(array $parameters = [])
 	{
-		self::login(self::SCOPE_READ);
+		self::checkAllowedScope(self::SCOPE_READ);
 		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		$request = self::getRequest([

--- a/src/Module/Api/Mastodon/Timelines/ListTimeline.php
+++ b/src/Module/Api/Mastodon/Timelines/ListTimeline.php
@@ -25,13 +25,13 @@ use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Post;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 use Friendica\Network\HTTPException;
 
 /**
  * @see https://docs.joinmastodon.org/methods/timelines/
  */
-class ListTimeline extends BaseApi
+class ListTimeline extends BaseMastodon
 {
 	/**
 	 * @param array $parameters

--- a/src/Module/Api/Mastodon/Timelines/ListTimeline.php
+++ b/src/Module/Api/Mastodon/Timelines/ListTimeline.php
@@ -40,7 +40,7 @@ class ListTimeline extends BaseApi
 	public static function rawContent(array $parameters = [])
 	{
 		self::login(self::SCOPE_READ);
-		$uid = self::getCurrentUserID();
+		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (empty($parameters['id'])) {
 			DI::mstdnError()->UnprocessableEntity();

--- a/src/Module/Api/Mastodon/Timelines/ListTimeline.php
+++ b/src/Module/Api/Mastodon/Timelines/ListTimeline.php
@@ -39,7 +39,7 @@ class ListTimeline extends BaseMastodon
 	 */
 	public static function rawContent(array $parameters = [])
 	{
-		self::login(self::SCOPE_READ);
+		self::checkAllowedScope(self::SCOPE_READ);
 		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (empty($parameters['id'])) {

--- a/src/Module/Api/Mastodon/Timelines/PublicTimeline.php
+++ b/src/Module/Api/Mastodon/Timelines/PublicTimeline.php
@@ -41,7 +41,7 @@ class PublicTimeline extends BaseApi
 	 */
 	public static function rawContent(array $parameters = [])
 	{
-		$uid = self::getCurrentUserID();
+		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		$request = self::getRequest([
 			'local'           => false, // Show only local statuses? Defaults to false.

--- a/src/Module/Api/Mastodon/Timelines/PublicTimeline.php
+++ b/src/Module/Api/Mastodon/Timelines/PublicTimeline.php
@@ -27,13 +27,13 @@ use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Item;
 use Friendica\Model\Post;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 use Friendica\Network\HTTPException;
 
 /**
  * @see https://docs.joinmastodon.org/methods/timelines/
  */
-class PublicTimeline extends BaseApi
+class PublicTimeline extends BaseMastodon
 {
 	/**
 	 * @param array $parameters

--- a/src/Module/Api/Mastodon/Timelines/Tag.php
+++ b/src/Module/Api/Mastodon/Timelines/Tag.php
@@ -26,13 +26,13 @@ use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Post;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 use Friendica\Network\HTTPException;
 
 /**
  * @see https://docs.joinmastodon.org/methods/timelines/
  */
-class Tag extends BaseApi
+class Tag extends BaseMastodon
 {
 	/**
 	 * @param array $parameters

--- a/src/Module/Api/Mastodon/Timelines/Tag.php
+++ b/src/Module/Api/Mastodon/Timelines/Tag.php
@@ -40,7 +40,7 @@ class Tag extends BaseMastodon
 	 */
 	public static function rawContent(array $parameters = [])
 	{
-		self::login(self::SCOPE_READ);
+		self::checkAllowedScope(self::SCOPE_READ);
 		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (empty($parameters['hashtag'])) {

--- a/src/Module/Api/Mastodon/Timelines/Tag.php
+++ b/src/Module/Api/Mastodon/Timelines/Tag.php
@@ -41,7 +41,7 @@ class Tag extends BaseApi
 	public static function rawContent(array $parameters = [])
 	{
 		self::login(self::SCOPE_READ);
-		$uid = self::getCurrentUserID();
+		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if (empty($parameters['hashtag'])) {
 			DI::mstdnError()->UnprocessableEntity();

--- a/src/Module/Api/Mastodon/Trends.php
+++ b/src/Module/Api/Mastodon/Trends.php
@@ -24,12 +24,12 @@ namespace Friendica\Module\Api\Mastodon;
 use Friendica\Core\System;
 use Friendica\DI;
 use Friendica\Model\Tag;
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 
 /**
  * @see https://docs.joinmastodon.org/methods/instance/trends/
  */
-class Trends extends BaseApi
+class Trends extends BaseMastodon
 {
 	/**
 	 * @param array $parameters

--- a/src/Module/Api/Mastodon/Unimplemented.php
+++ b/src/Module/Api/Mastodon/Unimplemented.php
@@ -21,12 +21,12 @@
 
 namespace Friendica\Module\Api\Mastodon;
 
-use Friendica\Module\BaseApi;
+use Friendica\Module\Api\BaseMastodon;
 
 /**
  * Dummy class for all currently unimplemented endpoints
  */
-class Unimplemented extends BaseApi
+class Unimplemented extends BaseMastodon
 {
 	/**
 	 * @param array $parameters

--- a/src/Module/Api/Twitter/ContactEndpoint.php
+++ b/src/Module/Api/Twitter/ContactEndpoint.php
@@ -39,7 +39,7 @@ abstract class ContactEndpoint extends BaseApi
 	{
 		parent::init($parameters);
 
-		if (!self::login(self::SCOPE_READ)) {
+		if (!self::checkAllowedScope(self::SCOPE_READ)) {
 			throw new HTTPException\UnauthorizedException();
 		}
 	}

--- a/src/Module/Api/Twitter/ContactEndpoint.php
+++ b/src/Module/Api/Twitter/ContactEndpoint.php
@@ -54,7 +54,7 @@ abstract class ContactEndpoint extends BaseApi
 	 */
 	protected static function getUid(int $contact_id = null, string $screen_name = null)
 	{
-		$uid = self::$current_user_id;
+		$uid = self::getCachedCurrentUserIdFromRequest();
 
 		if ($contact_id || $screen_name) {
 			// screen_name trumps user_id when both are provided
@@ -129,7 +129,7 @@ abstract class ContactEndpoint extends BaseApi
 	protected static function ids($rel, int $uid, int $cursor = -1, int $count = self::DEFAULT_COUNT, bool $stringify_ids = false)
 	{
 		$hide_friends = false;
-		if ($uid != self::$current_user_id) {
+		if ($uid != self::getCachedCurrentUserIdFromRequest()) {
 			$profile = Profile::getByUID($uid);
 			if (empty($profile)) {
 				throw new HTTPException\NotFoundException(DI::l10n()->t('Profile not found'));

--- a/src/Module/BaseApi.php
+++ b/src/Module/BaseApi.php
@@ -262,16 +262,6 @@ class BaseApi extends BaseModule
 	}
 
 	/**
-	 * Get current application from the Bearer token
-	 *
-	 * @return array token
-	 */
-	protected static function getCurrentApplication(): array
-	{
-		return self::getCachedTokenByBearer();
-	}
-
-	/**
 	 * Returns the current authentication token, either from local variable
 	 * or from the Bearer header if it hasn't been retrieved yet
 	 *

--- a/src/Module/BaseApi.php
+++ b/src/Module/BaseApi.php
@@ -170,23 +170,16 @@ class BaseApi extends BaseModule
 	}
 
 	/**
-	 * Log in user via OAuth1 or Simple HTTP Auth.
-	 *
-	 * Simple Auth allow username in form of <pre>user@server</pre>, ignoring server part
+	 * Check the logged in user is allowed to use the provided API scope. Aborts request if not logged or
+	 * insufficient scopes.
 	 *
 	 * @param string $scope the requested scope (read, write, follow)
 	 *
 	 * @throws HTTPException\ForbiddenException
 	 * @throws HTTPException\UnauthorizedException
 	 * @throws HTTPException\InternalServerErrorException
-	 * @hook  'authenticate'
-	 *               array $addon_auth
-	 *               'username' => username from login form
-	 *               'password' => password from login form
-	 *               'authenticated' => return status,
-	 *               'user_record' => return authenticated user record
 	 */
-	protected static function login(string $scope)
+	protected static function checkAllowedScope(string $scope)
 	{
 		if (!self::getCachedCurrentUserIdFromRequest()) {
 			Logger::debug(API_LOG_PREFIX . 'failed', ['module' => 'api', 'action' => 'login', 'parameters' => $_SERVER]);


### PR DESCRIPTION
Follow-up to #10367 

This PR is the result of what I was talking about in https://github.com/friendica/friendica/pull/10367#discussion_r645662823

By renaming BaseApi methods so that they would have only one purpose not affected by a parameter flag, I was able to remove redundant code, move poorly-scoped variables and overall make the class more self-explanatory.

The extension of this PR would be to remove the `$dologin` parameter from the `api_login` function but it is still used in most legacy API functions.