### PR TITLE
Cleanup Mastodon Factories

### DIFF
--- a/src/Collection/Api/Mastodon/Mentions.php
+++ b/src/Collection/Api/Mastodon/Mentions.php
@@ -1,0 +1,18 @@
+<?php
+
+
+namespace Friendica\Collection\Api\Mastodon;
+
+use Friendica\BaseCollection;
+use Friendica\Object\Api\Mastodon\Mention;
+
+class Mentions extends BaseCollection
+{
+	/**
+	 * @return Mention
+	 */
+	public function current()
+	{
+		return parent::current();
+	}
+}

--- a/src/Collection/Api/Mastodon/Mentions.php
+++ b/src/Collection/Api/Mastodon/Mentions.php
@@ -10,7 +10,7 @@ class Mentions extends BaseCollection
 	/**
 	 * @return Mention
 	 */
-	public function current()
+	public function current(): Mention
 	{
 		return parent::current();
 	}

--- a/src/Collection/Api/Mastodon/Mentions.php
+++ b/src/Collection/Api/Mastodon/Mentions.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Friendica\Collection\Api\Mastodon;
 
 use Friendica\BaseCollection;

--- a/src/DI.php
+++ b/src/DI.php
@@ -288,14 +288,6 @@ abstract class DI
 	}
 
 	/**
-	 * @return Factory\Api\Mastodon\Field
-	 */
-	public static function mstdnField()
-	{
-		return self::$dice->create(Factory\Api\Mastodon\Field::class);
-	}
-
-	/**
 	 * @return Factory\Api\Mastodon\FollowRequest
 	 */
 	public static function mstdnFollowRequest()
@@ -328,27 +320,11 @@ abstract class DI
 	}
 
 	/**
-	 * @return Factory\Api\Mastodon\Mention
-	 */
-	public static function mstdnMention()
-	{
-		return self::$dice->create(Factory\Api\Mastodon\Mention::class);
-	}
-
-	/**
 	 * @return Factory\Api\Mastodon\Notification
 	 */
 	public static function mstdnNotification()
 	{
 		return self::$dice->create(Factory\Api\Mastodon\Notification::class);
-	}
-
-	/**
-	 * @return Factory\Api\Mastodon\Tag
-	 */
-	public static function mstdnTag()
-	{
-		return self::$dice->create(Factory\Api\Mastodon\Tag::class);
 	}
 
 	/**

--- a/src/Factory/Api/Mastodon/Account.php
+++ b/src/Factory/Api/Mastodon/Account.php
@@ -34,19 +34,19 @@ use Psr\Log\LoggerInterface;
 class Account extends BaseFactory
 {
 	/** @var BaseURL */
-	protected $baseUrl;
+	private $baseUrl;
 	/** @var ProfileField */
-	protected $profileField;
+	private $profileFieldRepo;
 	/** @var Field */
-	protected $mstdnField;
+	private $mstdnFieldFactory;
 
-	public function __construct(LoggerInterface $logger, BaseURL $baseURL, ProfileField $profileField, Field $mstdnField)
+	public function __construct(LoggerInterface $logger, BaseURL $baseURL, ProfileField $profileFieldRepo, Field $mstdnFieldFactory)
 	{
 		parent::__construct($logger);
 
-		$this->baseUrl      = $baseURL;
-		$this->profileField = $profileField;
-		$this->mstdnField   = $mstdnField;
+		$this->baseUrl           = $baseURL;
+		$this->profileFieldRepo  = $profileFieldRepo;
+		$this->mstdnFieldFactory = $mstdnFieldFactory;
 	}
 
 	/**
@@ -75,8 +75,8 @@ class Account extends BaseFactory
 
 		$self_contact = Contact::selectFirst(['uid'], ['nurl' => $publicContact['nurl'], 'self' => true]);
 		if (!empty($self_contact['uid'])) {
-			$profileFields = $this->profileField->select(['uid' => $self_contact['uid'], 'psid' => PermissionSet::PUBLIC]);
-			$fields        = $this->mstdnField->createFromProfileFields($profileFields);
+			$profileFields = $this->profileFieldRepo->select(['uid' => $self_contact['uid'], 'psid' => PermissionSet::PUBLIC]);
+			$fields        = $this->mstdnFieldFactory->createFromProfileFields($profileFields);
 		} else {
 			$fields = new Fields();
 		}
@@ -94,8 +94,8 @@ class Account extends BaseFactory
 	{
 		$publicContact = Contact::selectFirst([], ['uid' => $userId, 'self' => true]);
 
-		$profileFields = $this->profileField->select(['uid' => $userId, 'psid' => PermissionSet::PUBLIC]);
-		$fields        = $this->mstdnField->createFromProfileFields($profileFields);
+		$profileFields = $this->profileFieldRepo->select(['uid' => $userId, 'psid' => PermissionSet::PUBLIC]);
+		$fields        = $this->mstdnFieldFactory->createFromProfileFields($profileFields);
 
 		$apcontact     = APContact::getByURL($publicContact['url'], false);
 

--- a/src/Factory/Api/Mastodon/Application.php
+++ b/src/Factory/Api/Mastodon/Application.php
@@ -22,28 +22,41 @@
 namespace Friendica\Factory\Api\Mastodon;
 
 use Friendica\BaseFactory;
-use Friendica\Database\DBA;
+use Friendica\Database\Database;
+use Friendica\Network\HTTPException\InternalServerErrorException;
+use Psr\Log\LoggerInterface;
 
 class Application extends BaseFactory
 {
+	/** @var Database */
+	private $dba;
+
+	public function __construct(LoggerInterface $logger, Database $dba)
+	{
+		parent::__construct($logger);
+		$this->dba = $dba;
+	}
+
 	/**
 	 * @param int $id Application ID
+	 *
+	 * @return \Friendica\Object\Api\Mastodon\Application
+	 *
+	 * @throws InternalServerErrorException
 	 */
 	public function createFromApplicationId(int $id)
 	{
-		$application = DBA::selectFirst('application', ['client_id', 'client_secret', 'id', 'name', 'redirect_uri', 'website'], ['id' => $id]);
-		if (!DBA::isResult($application)) {
+		$application = $this->dba->selectFirst('application', ['client_id', 'client_secret', 'id', 'name', 'redirect_uri', 'website'], ['id' => $id]);
+		if (!$this->dba->isResult($application)) {
 			return [];
 		}
 
-		$object = new \Friendica\Object\Api\Mastodon\Application(
+		return new \Friendica\Object\Api\Mastodon\Application(
 			$application['name'],
 			$application['client_id'],
 			$application['client_secret'],
 			$application['id'],
 			$application['redirect_uri'],
 			$application['website']);
-
-		return $object->toArray();
 	}
 }

--- a/src/Factory/Api/Mastodon/Application.php
+++ b/src/Factory/Api/Mastodon/Application.php
@@ -44,11 +44,11 @@ class Application extends BaseFactory
 	 *
 	 * @throws InternalServerErrorException
 	 */
-	public function createFromApplicationId(int $id)
+	public function createFromApplicationId(int $id): \Friendica\Object\Api\Mastodon\Application
 	{
 		$application = $this->dba->selectFirst('application', ['client_id', 'client_secret', 'id', 'name', 'redirect_uri', 'website'], ['id' => $id]);
 		if (!$this->dba->isResult($application)) {
-			return [];
+			throw new InternalServerErrorException(sprintf("ID '%s' not found", $id));
 		}
 
 		return new \Friendica\Object\Api\Mastodon\Application(

--- a/src/Factory/Api/Mastodon/Attachment.php
+++ b/src/Factory/Api/Mastodon/Attachment.php
@@ -46,13 +46,11 @@ class Attachment extends BaseFactory
 	 * @param int $uriId Uri-ID of the attachments
 	 * @return array
 	 * @throws HTTPException\InternalServerErrorException
-	 * @throws \ImagickException
 	 */
-	public function createFromUriId(int $uriId)
+	public function createFromUriId(int $uriId): array
 	{
 		$attachments = [];
 		foreach (Post\Media::getByURIId($uriId, [Post\Media::AUDIO, Post\Media::VIDEO, Post\Media::IMAGE]) as $attachment) {
-
 			$filetype = !empty($attachment['mimetype']) ? strtolower(substr($attachment['mimetype'], 0, strpos($attachment['mimetype'], '/'))) : '';
 
 			if (($filetype == 'audio') || ($attachment['type'] == Post\Media::AUDIO)) {
@@ -70,19 +68,19 @@ class Attachment extends BaseFactory
 			$remote = $attachment['url'];
 			if ($type == 'image') {
 				if (Proxy::isLocalImage($attachment['url'])) {
-					$url = $attachment['url'];
+					$url     = $attachment['url'];
 					$preview = $attachment['preview'] ?? $url;
-					$remote = '';
+					$remote  = '';
 				} else {
-					$url = Proxy::proxifyUrl($attachment['url']);
+					$url     = Proxy::proxifyUrl($attachment['url']);
 					$preview = Proxy::proxifyUrl($attachment['url'], false, Proxy::SIZE_SMALL);
 				}
 			} else {
-				$url = Proxy::proxifyUrl($attachment['url']);
+				$url     = Proxy::proxifyUrl($attachment['url     ']);
 				$preview = Proxy::proxifyUrl($attachment['preview'] ?? '');
 			}
 
-			$object = new \Friendica\Object\Api\Mastodon\Attachment($attachment, $type, $url, $preview, $remote);
+			$object        = new \Friendica\Object\Api\Mastodon\Attachment($attachment, $type, $url, $preview, $remote);
 			$attachments[] = $object->toArray();
 		}
 
@@ -91,21 +89,21 @@ class Attachment extends BaseFactory
 
 	/**
 	 * @param int $id id of the photo
+	 *
 	 * @return array
 	 * @throws HTTPException\InternalServerErrorException
-	 * @throws \ImagickException
 	 */
-	public function createFromPhoto(int $id)
+	public function createFromPhoto(int $id): array
 	{
 		$photo = Photo::selectFirst(['resource-id', 'uid', 'id', 'title', 'type'], ['id' => $id]);
 		if (empty($photo)) {
-			return null;
+			return [];
 		}
 
 		$attachment = ['id' => $photo['id'], 'description' => $photo['title']];
 
-		$phototypes = Images::supportedTypes();
-		$ext = $phototypes[$photo['type']];
+		$photoTypes = Images::supportedTypes();
+		$ext        = $photoTypes[$photo['type']];
 
 		$url = $this->baseUrl . '/photo/' . $photo['resource-id'] . '-0.' . $ext;
 

--- a/src/Factory/Api/Mastodon/Attachment.php
+++ b/src/Factory/Api/Mastodon/Attachment.php
@@ -23,11 +23,9 @@ namespace Friendica\Factory\Api\Mastodon;
 
 use Friendica\App\BaseURL;
 use Friendica\BaseFactory;
-use Friendica\DI;
 use Friendica\Model\Photo;
 use Friendica\Network\HTTPException;
 use Friendica\Model\Post;
-use Friendica\Repository\ProfileField;
 use Friendica\Util\Images;
 use Friendica\Util\Proxy;
 use Psr\Log\LoggerInterface;
@@ -35,19 +33,13 @@ use Psr\Log\LoggerInterface;
 class Attachment extends BaseFactory
 {
 	/** @var BaseURL */
-	protected $baseUrl;
-	/** @var ProfileField */
-	protected $profileField;
-	/** @var Field */
-	protected $mstdnField;
+	private $baseUrl;
 
-	public function __construct(LoggerInterface $logger, BaseURL $baseURL, ProfileField $profileField, Field $mstdnField)
+	public function __construct(LoggerInterface $logger, BaseURL $baseURL)
 	{
 		parent::__construct($logger);
 
 		$this->baseUrl = $baseURL;
-		$this->profileField = $profileField;
-		$this->mstdnField = $mstdnField;
 	}
 
 	/**
@@ -115,11 +107,11 @@ class Attachment extends BaseFactory
 		$phototypes = Images::supportedTypes();
 		$ext = $phototypes[$photo['type']];
 
-		$url = DI::baseUrl() . '/photo/' . $photo['resource-id'] . '-0.' . $ext;
+		$url = $this->baseUrl . '/photo/' . $photo['resource-id'] . '-0.' . $ext;
 
 		$preview = Photo::selectFirst(['scale'], ["`resource-id` = ? AND `uid` = ? AND `scale` > ?", $photo['resource-id'], $photo['uid'], 0], ['order' => ['scale']]);
 		if (empty($scale)) {
-			$preview_url = DI::baseUrl() . '/photo/' . $photo['resource-id'] . '-' . $preview['scale'] . '.' . $ext;
+			$preview_url = $this->baseUrl . '/photo/' . $photo['resource-id'] . '-' . $preview['scale'] . '.' . $ext;
 		} else {
 			$preview_url = '';
 		}

--- a/src/Factory/Api/Mastodon/Card.php
+++ b/src/Factory/Api/Mastodon/Card.php
@@ -31,11 +31,12 @@ class Card extends BaseFactory
 {
 	/**
 	 * @param int $uriId Uri-ID of the item
+	 *
 	 * @return \Friendica\Object\Api\Mastodon\Card
 	 * @throws HTTPException\InternalServerErrorException
-	 * @throws \ImagickException
+	 * @throws \ImagickException*@throws \Exception
 	 */
-	public function createFromUriId(int $uriId)
+	public function createFromUriId(int $uriId): \Friendica\Object\Api\Mastodon\Card
 	{
 		$item = Post::selectFirst(['body'], ['uri-id' => $uriId]);
 		if (!empty($item['body'])) {

--- a/src/Factory/Api/Mastodon/Conversation.php
+++ b/src/Factory/Api/Mastodon/Conversation.php
@@ -24,6 +24,8 @@ namespace Friendica\Factory\Api\Mastodon;
 use Friendica\BaseFactory;
 use Friendica\Database\Database;
 use Friendica\Model\Contact;
+use Friendica\Network\HTTPException;
+use ImagickException;
 use Psr\Log\LoggerInterface;
 
 class Conversation extends BaseFactory
@@ -43,7 +45,10 @@ class Conversation extends BaseFactory
 		$this->mstdnAccountFactory = $mstdnAccountFactoryFactory;
 	}
 
-	public function CreateFromConvId(int $id)
+	/**
+	 * @throws ImagickException|HTTPException\InternalServerErrorException|HTTPException\NotFoundException
+	 */
+	public function CreateFromConvId(int $id): \Friendica\Object\Api\Mastodon\Conversation
 	{
 		$accounts    = [];
 		$unread      = false;

--- a/src/Factory/Api/Mastodon/Conversation.php
+++ b/src/Factory/Api/Mastodon/Conversation.php
@@ -22,12 +22,27 @@
 namespace Friendica\Factory\Api\Mastodon;
 
 use Friendica\BaseFactory;
-use Friendica\Database\DBA;
-use Friendica\DI;
+use Friendica\Database\Database;
 use Friendica\Model\Contact;
+use Psr\Log\LoggerInterface;
 
 class Conversation extends BaseFactory
 {
+	/** @var Database */
+	private $dba;
+	/** @var Status */
+	private $mstdnStatusFactory;
+	/** @var Account */
+	private $mstdnAccountFactory;
+
+	public function __construct(LoggerInterface $logger, Database $dba, Status $mstdnStatusFactory, Account $mstdnAccountFactoryFactory)
+	{
+		parent::__construct($logger);
+		$this->dba                 = $dba;
+		$this->mstdnStatusFactory  = $mstdnStatusFactory;
+		$this->mstdnAccountFactory = $mstdnAccountFactoryFactory;
+	}
+
 	public function CreateFromConvId(int $id)
 	{
 		$accounts    = [];
@@ -36,8 +51,8 @@ class Conversation extends BaseFactory
 
 		$ids = [];
 
-		$mails = DBA::select('mail', ['id', 'from-url', 'uid', 'seen'], ['convid' => $id], ['order' => ['id' => true]]);
-		while ($mail = DBA::fetch($mails)) {
+		$mails = $this->dba->select('mail', ['id', 'from-url', 'uid', 'seen'], ['convid' => $id], ['order' => ['id' => true]]);
+		while ($mail = $this->dba->fetch($mails)) {
 			if (!$mail['seen']) {
 				$unread = true;
 			}
@@ -50,10 +65,10 @@ class Conversation extends BaseFactory
 			$ids[] = $id;
 
 			if (empty($last_status)) {
-				$last_status = DI::mstdnStatus()->createFromMailId($mail['id']);
+				$last_status = $this->mstdnStatusFactory->createFromMailId($mail['id']);
 			}
 
-			$accounts[] = DI::mstdnAccount()->createFromContactId($id, 0);
+			$accounts[] = $this->mstdnAccountFactory->createFromContactId($id, 0);
 		}
 
 		return new \Friendica\Object\Api\Mastodon\Conversation($id, $accounts, $unread, $last_status);

--- a/src/Factory/Api/Mastodon/Emoji.php
+++ b/src/Factory/Api/Mastodon/Emoji.php
@@ -26,7 +26,7 @@ use Friendica\Collection\Api\Mastodon\Emojis;
 
 class Emoji extends BaseFactory
 {
-	public function create(string $shortcode, string $url)
+	public function create(string $shortcode, string $url): \Friendica\Object\Api\Mastodon\Emoji
 	{
 		return new \Friendica\Object\Api\Mastodon\Emoji($shortcode, $url);
 	}
@@ -35,7 +35,7 @@ class Emoji extends BaseFactory
 	 * @param array $smilies
 	 * @return Emojis
 	 */
-	public function createCollectionFromSmilies(array $smilies)
+	public function createCollectionFromSmilies(array $smilies): Emojis
 	{
 		$prototype = null;
 
@@ -47,7 +47,7 @@ class Emoji extends BaseFactory
 
 				if ($prototype === null) {
 					$prototype = $this->create($shortcode, $url);
-					$emojis[] = $prototype;
+					$emojis[]  = $prototype;
 				} else {
 					$emojis[] = \Friendica\Object\Api\Mastodon\Emoji::createFromPrototype($prototype, $shortcode, $url);
 				}

--- a/src/Factory/Api/Mastodon/Error.php
+++ b/src/Factory/Api/Mastodon/Error.php
@@ -21,21 +21,38 @@
 
 namespace Friendica\Factory\Api\Mastodon;
 
+use Friendica\App\Arguments;
 use Friendica\BaseFactory;
-use Friendica\Core\Logger;
+use Friendica\Core\L10n;
 use Friendica\Core\System;
-use Friendica\DI;
+use Psr\Log\LoggerInterface;
 
+/** @todo A Factory shouldn't return something to the frontpage, it's for creating content, not showing it */
 class Error extends BaseFactory
 {
+	/** @var Arguments */
+	private $args;
+	/** @var string[] The $_SERVER array */
+	private $server;
+	/** @var L10n */
+	private $l10n;
+	
+	public function __construct(LoggerInterface $logger, Arguments $args, L10n $l10n, array $server)
+	{
+		parent::__construct($logger);
+		$this->args = $args;
+		$this->server = $server;
+		$this->l10n = $l10n;
+	}
+
 	private function logError(int $errorno, string $error)
 	{
-		Logger::info('API Error', ['no' => $errorno, 'error' => $error, 'method' => $_SERVER['REQUEST_METHOD'] ?? '', 'command' => DI::args()->getQueryString(), 'user-agent' => $_SERVER['HTTP_USER_AGENT'] ?? '']);
+		$this->logger->info('API Error', ['no' => $errorno, 'error' => $error, 'method' => $this->server['REQUEST_METHOD'] ?? '', 'command' => $this->args->getQueryString(), 'user-agent' => $this->server['HTTP_USER_AGENT'] ?? '']);
 	}
 
 	public function RecordNotFound()
 	{
-		$error = DI::l10n()->t('Record not found');
+		$error = $this->l10n->t('Record not found');
 		$error_description = '';
 		$errorobj = New \Friendica\Object\Api\Mastodon\Error($error, $error_description);
 
@@ -45,7 +62,7 @@ class Error extends BaseFactory
 
 	public function UnprocessableEntity(string $error = '')
 	{
-		$error = $error ?: DI::l10n()->t('Unprocessable Entity');
+		$error = $error ?: $this->l10n->t('Unprocessable Entity');
 		$error_description = '';
 		$errorobj = New \Friendica\Object\Api\Mastodon\Error($error, $error_description);
 
@@ -55,7 +72,7 @@ class Error extends BaseFactory
 
 	public function Unauthorized(string $error = '')
 	{
-		$error = $error ?: DI::l10n()->t('Unauthorized');
+		$error = $error ?: $this->l10n->t('Unauthorized');
 		$error_description = '';
 		$errorobj = New \Friendica\Object\Api\Mastodon\Error($error, $error_description);
 
@@ -65,7 +82,7 @@ class Error extends BaseFactory
 
 	public function Forbidden(string $error = '')
 	{
-		$error = $error ?: DI::l10n()->t('Token is not authorized with a valid user or is missing a required scope');
+		$error = $error ?: $this->l10n->t('Token is not authorized with a valid user or is missing a required scope');
 		$error_description = '';
 		$errorobj = New \Friendica\Object\Api\Mastodon\Error($error, $error_description);
 
@@ -75,7 +92,7 @@ class Error extends BaseFactory
 
 	public function InternalError(string $error = '')
 	{
-		$error = $error ?: DI::l10n()->t('Internal Server Error');
+		$error = $error ?: $this->l10n->t('Internal Server Error');
 		$error_description = '';
 		$errorobj = New \Friendica\Object\Api\Mastodon\Error($error, $error_description);
 

--- a/src/Factory/Api/Mastodon/Error.php
+++ b/src/Factory/Api/Mastodon/Error.php
@@ -36,13 +36,13 @@ class Error extends BaseFactory
 	private $server;
 	/** @var L10n */
 	private $l10n;
-	
+
 	public function __construct(LoggerInterface $logger, Arguments $args, L10n $l10n, array $server)
 	{
 		parent::__construct($logger);
-		$this->args = $args;
+		$this->args   = $args;
 		$this->server = $server;
-		$this->l10n = $l10n;
+		$this->l10n   = $l10n;
 	}
 
 	private function logError(int $errorno, string $error)
@@ -52,51 +52,51 @@ class Error extends BaseFactory
 
 	public function RecordNotFound()
 	{
-		$error = $this->l10n->t('Record not found');
+		$error             = $this->l10n->t('Record not found');
 		$error_description = '';
-		$errorobj = New \Friendica\Object\Api\Mastodon\Error($error, $error_description);
+		$errorObj          = new \Friendica\Object\Api\Mastodon\Error($error, $error_description);
 
 		$this->logError(404, $error);
-		System::jsonError(404, $errorobj->toArray());
+		System::jsonError(404, $errorObj->toArray());
 	}
 
 	public function UnprocessableEntity(string $error = '')
 	{
-		$error = $error ?: $this->l10n->t('Unprocessable Entity');
+		$error             = $error ?: $this->l10n->t('Unprocessable Entity');
 		$error_description = '';
-		$errorobj = New \Friendica\Object\Api\Mastodon\Error($error, $error_description);
+		$errorObj          = new \Friendica\Object\Api\Mastodon\Error($error, $error_description);
 
 		$this->logError(422, $error);
-		System::jsonError(422, $errorobj->toArray());
+		System::jsonError(422, $errorObj->toArray());
 	}
 
 	public function Unauthorized(string $error = '')
 	{
-		$error = $error ?: $this->l10n->t('Unauthorized');
+		$error             = $error ?: $this->l10n->t('Unauthorized');
 		$error_description = '';
-		$errorobj = New \Friendica\Object\Api\Mastodon\Error($error, $error_description);
+		$errorObj          = new \Friendica\Object\Api\Mastodon\Error($error, $error_description);
 
 		$this->logError(401, $error);
-		System::jsonError(401, $errorobj->toArray());
+		System::jsonError(401, $errorObj->toArray());
 	}
 
 	public function Forbidden(string $error = '')
 	{
-		$error = $error ?: $this->l10n->t('Token is not authorized with a valid user or is missing a required scope');
+		$error             = $error ?: $this->l10n->t('Token is not authorized with a valid user or is missing a required scope');
 		$error_description = '';
-		$errorobj = New \Friendica\Object\Api\Mastodon\Error($error, $error_description);
+		$errorObj          = new \Friendica\Object\Api\Mastodon\Error($error, $error_description);
 
 		$this->logError(403, $error);
-		System::jsonError(403, $errorobj->toArray());
+		System::jsonError(403, $errorObj->toArray());
 	}
 
 	public function InternalError(string $error = '')
 	{
-		$error = $error ?: $this->l10n->t('Internal Server Error');
+		$error             = $error ?: $this->l10n->t('Internal Server Error');
 		$error_description = '';
-		$errorobj = New \Friendica\Object\Api\Mastodon\Error($error, $error_description);
+		$errorObj          = new \Friendica\Object\Api\Mastodon\Error($error, $error_description);
 
 		$this->logError(500, $error);
-		System::jsonError(500, $errorobj->toArray());
+		System::jsonError(500, $errorObj->toArray());
 	}
 }

--- a/src/Factory/Api/Mastodon/Field.php
+++ b/src/Factory/Api/Mastodon/Field.php
@@ -32,7 +32,7 @@ class Field extends BaseFactory
 {
 	/**
 	 * @param ProfileField $profileField
-	 * @return \Friendica\Api\Entity\Mastodon\Field
+	 * @return \Friendica\Object\Api\Mastodon\Field
 	 * @throws HTTPException\InternalServerErrorException
 	 */
 	public function createFromProfileField(ProfileField $profileField)

--- a/src/Factory/Api/Mastodon/Field.php
+++ b/src/Factory/Api/Mastodon/Field.php
@@ -35,7 +35,7 @@ class Field extends BaseFactory
 	 * @return \Friendica\Object\Api\Mastodon\Field
 	 * @throws HTTPException\InternalServerErrorException
 	 */
-	public function createFromProfileField(ProfileField $profileField)
+	public function createFromProfileField(ProfileField $profileField): \Friendica\Object\Api\Mastodon\Field
 	{
 		return new \Friendica\Object\Api\Mastodon\Field($profileField->label, BBCode::convert($profileField->value, false, BBCode::ACTIVITYPUB));
 	}
@@ -45,7 +45,7 @@ class Field extends BaseFactory
 	 * @return Fields
 	 * @throws HTTPException\InternalServerErrorException
 	 */
-	public function createFromProfileFields(ProfileFields $profileFields)
+	public function createFromProfileFields(ProfileFields $profileFields): Fields
 	{
 		$fields = [];
 

--- a/src/Factory/Api/Mastodon/FollowRequest.php
+++ b/src/Factory/Api/Mastodon/FollowRequest.php
@@ -32,7 +32,7 @@ use Psr\Log\LoggerInterface;
 class FollowRequest extends BaseFactory
 {
 	/** @var BaseURL */
-	protected $baseUrl;
+	private $baseUrl;
 
 	public function __construct(LoggerInterface $logger, BaseURL $baseURL)
 	{

--- a/src/Factory/Api/Mastodon/FollowRequest.php
+++ b/src/Factory/Api/Mastodon/FollowRequest.php
@@ -27,6 +27,7 @@ use Friendica\Model\APContact;
 use Friendica\Model\Contact;
 use Friendica\Model\Introduction;
 use Friendica\Network\HTTPException;
+use ImagickException;
 use Psr\Log\LoggerInterface;
 
 class FollowRequest extends BaseFactory
@@ -44,10 +45,9 @@ class FollowRequest extends BaseFactory
 	/**
 	 * @param Introduction $introduction
 	 * @return \Friendica\Object\Api\Mastodon\FollowRequest
-	 * @throws HTTPException\InternalServerErrorException
-	 * @throws \ImagickException
+	 * @throws ImagickException|HTTPException\InternalServerErrorException
 	 */
-	public function createFromIntroduction(Introduction $introduction)
+	public function createFromIntroduction(Introduction $introduction): \Friendica\Object\Api\Mastodon\FollowRequest
 	{
 		$cdata = Contact::getPublicAndUserContacID($introduction->{'contact-id'}, $introduction->uid);
 
@@ -57,10 +57,10 @@ class FollowRequest extends BaseFactory
 		}
 
 		$publicContact = Contact::getById($cdata['public']);
-		$userContact = Contact::getById($cdata['user']);
+		$userContact   = Contact::getById($cdata['user']);
 
-		$apcontact = APContact::getByURL($publicContact['url'], false);
+		$apContact = APContact::getByURL($publicContact['url'], false);
 
-		return new \Friendica\Object\Api\Mastodon\FollowRequest($this->baseUrl, $introduction->id, $publicContact, $apcontact, $userContact);
+		return new \Friendica\Object\Api\Mastodon\FollowRequest($this->baseUrl, $introduction->id, $publicContact, $apContact, $userContact);
 	}
 }

--- a/src/Factory/Api/Mastodon/ListEntity.php
+++ b/src/Factory/Api/Mastodon/ListEntity.php
@@ -23,6 +23,7 @@ namespace Friendica\Factory\Api\Mastodon;
 
 use Friendica\BaseFactory;
 use Friendica\Database\Database;
+use Friendica\Network\HTTPException\InternalServerErrorException;
 use Psr\Log\LoggerInterface;
 
 class ListEntity extends BaseFactory
@@ -36,7 +37,10 @@ class ListEntity extends BaseFactory
 		$this->dba = $dba;
 	}
 
-	public function createFromGroupId(int $id)
+	/**
+	 * @throws InternalServerErrorException
+	 */
+	public function createFromGroupId(int $id): \Friendica\Object\Api\Mastodon\ListEntity
 	{
 		$group = $this->dba->selectFirst('group', ['name'], ['id' => $id, 'deleted' => false]);
 		return new \Friendica\Object\Api\Mastodon\ListEntity($id, $group['name'] ?? '', 'list');

--- a/src/Factory/Api/Mastodon/ListEntity.php
+++ b/src/Factory/Api/Mastodon/ListEntity.php
@@ -22,13 +22,23 @@
 namespace Friendica\Factory\Api\Mastodon;
 
 use Friendica\BaseFactory;
-use Friendica\Database\DBA;
+use Friendica\Database\Database;
+use Psr\Log\LoggerInterface;
 
 class ListEntity extends BaseFactory
 {
+	/** @var Database */
+	private $dba;
+
+	public function __construct(LoggerInterface $logger, Database $dba)
+	{
+		parent::__construct($logger);
+		$this->dba = $dba;
+	}
+
 	public function createFromGroupId(int $id)
 	{
-		$group = DBA::selectFirst('group', ['name'], ['id' => $id, 'deleted' => false]);
+		$group = $this->dba->selectFirst('group', ['name'], ['id' => $id, 'deleted' => false]);
 		return new \Friendica\Object\Api\Mastodon\ListEntity($id, $group['name'] ?? '', 'list');
 	}
 }

--- a/src/Factory/Api/Mastodon/Mention.php
+++ b/src/Factory/Api/Mastodon/Mention.php
@@ -23,44 +23,37 @@ namespace Friendica\Factory\Api\Mastodon;
 
 use Friendica\App\BaseURL;
 use Friendica\BaseFactory;
+use Friendica\Collection\Api\Mastodon\Mentions;
 use Friendica\Model\Contact;
 use Friendica\Model\Tag;
 use Friendica\Network\HTTPException;
-use Friendica\Repository\ProfileField;
 use Psr\Log\LoggerInterface;
 
 class Mention extends BaseFactory
 {
 	/** @var BaseURL */
-	protected $baseUrl;
-	/** @var ProfileField */
-	protected $profileField;
-	/** @var Field */
-	protected $mstdnField;
+	private $baseUrl;
 
-	public function __construct(LoggerInterface $logger, BaseURL $baseURL, ProfileField $profileField, Field $mstdnField)
+	public function __construct(LoggerInterface $logger, BaseURL $baseURL)
 	{
 		parent::__construct($logger);
 
 		$this->baseUrl = $baseURL;
-		$this->profileField = $profileField;
-		$this->mstdnField = $mstdnField;
 	}
 
 	/**
 	 * @param int $uriId Uri-ID of the item
-	 * @return array
+	 * @return Mentions
 	 * @throws HTTPException\InternalServerErrorException
 	 * @throws \ImagickException
 	 */
 	public function createFromUriId(int $uriId)
 	{
-		$mentions = [];
+		$mentions = new Mentions();
 		$tags = Tag::getByURIId($uriId, [Tag::MENTION, Tag::EXCLUSIVE_MENTION, Tag::IMPLICIT_MENTION]);
 		foreach ($tags as $tag) {
 			$contact = Contact::getByURL($tag['url'], false);
-			$mention = new \Friendica\Object\Api\Mastodon\Mention($this->baseUrl, $tag, $contact);
-			$mentions[] = $mention->toArray();
+			$mentions->append(new \Friendica\Object\Api\Mastodon\Mention($this->baseUrl, $tag, $contact));
 		}
 		return $mentions;
 	}

--- a/src/Factory/Api/Mastodon/Mention.php
+++ b/src/Factory/Api/Mastodon/Mention.php
@@ -45,15 +45,14 @@ class Mention extends BaseFactory
 	 * @param int $uriId Uri-ID of the item
 	 * @return Mentions
 	 * @throws HTTPException\InternalServerErrorException
-	 * @throws \ImagickException
 	 */
-	public function createFromUriId(int $uriId)
+	public function createFromUriId(int $uriId): Mentions
 	{
 		$mentions = new Mentions();
-		$tags = Tag::getByURIId($uriId, [Tag::MENTION, Tag::EXCLUSIVE_MENTION, Tag::IMPLICIT_MENTION]);
+		$tags     = Tag::getByURIId($uriId, [Tag::MENTION, Tag::EXCLUSIVE_MENTION, Tag::IMPLICIT_MENTION]);
 		foreach ($tags as $tag) {
-			$contact = Contact::getByURL($tag['url'], false);
-			$mentions->append(new \Friendica\Object\Api\Mastodon\Mention($this->baseUrl, $tag, $contact));
+			$contact    = Contact::getByURL($tag['url'], false);
+			$mentions[] = new \Friendica\Object\Api\Mastodon\Mention($this->baseUrl, $tag, $contact);
 		}
 		return $mentions;
 	}

--- a/src/Factory/Api/Mastodon/Notification.php
+++ b/src/Factory/Api/Mastodon/Notification.php
@@ -37,13 +37,13 @@ class Notification extends BaseFactory
 	private $mstdnAccountFactory;
 	/** @var Status */
 	private $mstdnStatusFactory;
-	
+
 	public function __construct(LoggerInterface $logger, Database $dba, Account $mstdnAccountFactory, Status $mstdnStatusFactoryFactory)
 	{
 		parent::__construct($logger);
-		$this->dba = $dba;
+		$this->dba                 = $dba;
 		$this->mstdnAccountFactory = $mstdnAccountFactory;
-		$this->mstdnStatusFactory = $mstdnStatusFactoryFactory;
+		$this->mstdnStatusFactory  = $mstdnStatusFactoryFactory;
 	}
 
 	public function createFromNotificationId(int $id)
@@ -64,7 +64,7 @@ class Notification extends BaseFactory
 
 		if (($notification['vid'] == Verb::getID(Activity::FOLLOW)) && ($notification['type'] == Post\UserNotification::NOTIF_NONE)) {
 			$contact = Contact::getById($notification['actor-id'], ['pending']);
-			$type = $contact['pending'] ? $type = 'follow_request' : 'follow';
+			$type    = $contact['pending'] ? $type    = 'follow_request' : 'follow';
 		} elseif (($notification['vid'] == Verb::getID(Activity::ANNOUNCE)) &&
 			in_array($notification['type'], [Post\UserNotification::NOTIF_DIRECT_COMMENT, Post\UserNotification::NOTIF_DIRECT_THREAD_COMMENT])) {
 			$type = 'reblog';

--- a/src/Factory/Api/Mastodon/Relationship.php
+++ b/src/Factory/Api/Mastodon/Relationship.php
@@ -21,6 +21,7 @@
 
 namespace Friendica\Factory\Api\Mastodon;
 
+use Exception;
 use Friendica\Object\Api\Mastodon\Relationship as RelationshipEntity;
 use Friendica\BaseFactory;
 use Friendica\Model\Contact;
@@ -31,9 +32,9 @@ class Relationship extends BaseFactory
 	 * @param int $contactId Contact ID (public or user contact)
 	 * @param int $uid User ID
 	 * @return RelationshipEntity
-	 * @throws \Exception
+	 * @throws Exception
 	 */
-	public function createFromContactId(int $contactId, int $uid)
+	public function createFromContactId(int $contactId, int $uid): RelationshipEntity
 	{
 		$cdata = Contact::getPublicAndUserContacID($contactId, $uid);
 		if (!empty($cdata)) {

--- a/src/Factory/Api/Mastodon/Status.php
+++ b/src/Factory/Api/Mastodon/Status.php
@@ -73,7 +73,7 @@ class Status extends BaseFactory
 	 * @throws HTTPException\InternalServerErrorException
 	 * @throws ImagickException|HTTPException\NotFoundException
 	 */
-	public function createFromUriId(int $uriId, $uid = 0)
+	public function createFromUriId(int $uriId, $uid = 0): \Friendica\Object\Api\Mastodon\Status
 	{
 		$fields = ['uri-id', 'uid', 'author-id', 'author-link', 'starred', 'app', 'title', 'body', 'raw-body', 'created', 'network',
 			'thr-parent-id', 'parent-author-id', 'language', 'uri', 'plink', 'private', 'vid', 'gravity'];
@@ -163,9 +163,9 @@ class Status extends BaseFactory
 	 *
 	 * @return \Friendica\Object\Api\Mastodon\Status
 	 * @throws HTTPException\InternalServerErrorException
-	 * @throws ImagickException
+	 * @throws ImagickException|HTTPException\NotFoundException
 	 */
-	public function createFromMailId(int $id)
+	public function createFromMailId(int $id): \Friendica\Object\Api\Mastodon\Status
 	{
 		$item = ActivityPub\Transmitter::ItemArrayFromMail($id, true);
 		if (empty($item)) {

--- a/src/Factory/Api/Mastodon/Status.php
+++ b/src/Factory/Api/Mastodon/Status.php
@@ -21,44 +21,57 @@
 
 namespace Friendica\Factory\Api\Mastodon;
 
-use Friendica\App\BaseURL;
 use Friendica\BaseFactory;
 use Friendica\Content\ContactSelector;
 use Friendica\Content\Text\BBCode;
-use Friendica\Database\DBA;
-use Friendica\DI;
+use Friendica\Database\Database;
 use Friendica\Model\Post;
 use Friendica\Model\Verb;
 use Friendica\Network\HTTPException;
 use Friendica\Protocol\Activity;
 use Friendica\Protocol\ActivityPub;
-use Friendica\Repository\ProfileField;
+use ImagickException;
 use Psr\Log\LoggerInterface;
 
 class Status extends BaseFactory
 {
-	/** @var BaseURL */
-	protected $baseUrl;
-	/** @var ProfileField */
-	protected $profileField;
-	/** @var Field */
-	protected $mstdnField;
+	/** @var Database */
+	private $dba;
+	/** @var Account */
+	private $mstdnAccountFactory;
+	/** @var Mention */
+	private $mstdnMentionFactory;
+	/** @var Tag */
+	private $mstdnTagFactory;
+	/** @var Card */
+	private $mstdnCardFactory;
+	/** @var Attachment */
+	private $mstdnAttachementFactory;
+	/** @var Error */
+	private $mstdnErrorFactory;
 
-	public function __construct(LoggerInterface $logger, BaseURL $baseURL, ProfileField $profileField, Field $mstdnField)
+	public function __construct(LoggerInterface $logger, Database $dba,
+		Account $mstdnAccountFactory, Mention $mstdnMentionFactory,
+		Tag $mstdnTagFactory, Card $mstdnCardFactory,
+		Attachment $mstdnAttachementFactory, Error $mstdnErrorFactory)
 	{
 		parent::__construct($logger);
-
-		$this->baseUrl = $baseURL;
-		$this->profileField = $profileField;
-		$this->mstdnField = $mstdnField;
+		$this->dba                     = $dba;
+		$this->mstdnAccountFactory     = $mstdnAccountFactory;
+		$this->mstdnMentionFactory     = $mstdnMentionFactory;
+		$this->mstdnTagFactory         = $mstdnTagFactory;
+		$this->mstdnCardFactory        = $mstdnCardFactory;
+		$this->mstdnAttachementFactory = $mstdnAttachementFactory;
+		$this->mstdnErrorFactory       = $mstdnErrorFactory;
 	}
 
 	/**
 	 * @param int $uriId Uri-ID of the item
 	 * @param int $uid   Item user
+	 *
 	 * @return \Friendica\Object\Api\Mastodon\Status
 	 * @throws HTTPException\InternalServerErrorException
-	 * @throws \ImagickException
+	 * @throws ImagickException|HTTPException\NotFoundException
 	 */
 	public function createFromUriId(int $uriId, $uid = 0)
 	{
@@ -69,29 +82,53 @@ class Status extends BaseFactory
 			throw new HTTPException\NotFoundException('Item with URI ID ' . $uriId . 'not found' . ($uid ? ' for user ' . $uid : '.'));
 		}
 
-		$account = DI::mstdnAccount()->createFromContactId($item['author-id']);
+		$account = $this->mstdnAccountFactory->createFromContactId($item['author-id']);
 
 		$counts = new \Friendica\Object\Api\Mastodon\Status\Counts(
 			Post::countPosts(['thr-parent-id' => $uriId, 'gravity' => GRAVITY_COMMENT, 'deleted' => false], []),
-			Post::countPosts(['thr-parent-id' => $uriId, 'gravity' => GRAVITY_ACTIVITY, 'vid' => Verb::getID(Activity::ANNOUNCE), 'deleted' => false], []),
-			Post::countPosts(['thr-parent-id' => $uriId, 'gravity' => GRAVITY_ACTIVITY, 'vid' => Verb::getID(Activity::LIKE), 'deleted' => false], [])
+			Post::countPosts([
+				'thr-parent-id' => $uriId,
+				'gravity'       => GRAVITY_ACTIVITY,
+				'vid'           => Verb::getID(Activity::ANNOUNCE),
+				'deleted'       => false
+			], []),
+			Post::countPosts([
+				'thr-parent-id' => $uriId,
+				'gravity'       => GRAVITY_ACTIVITY,
+				'vid'           => Verb::getID(Activity::LIKE),
+				'deleted'       => false
+			], [])
 		);
 
 		$userAttributes = new \Friendica\Object\Api\Mastodon\Status\UserAttributes(
-			Post::exists(['thr-parent-id' => $uriId, 'uid' => $uid, 'origin' => true, 'gravity' => GRAVITY_ACTIVITY, 'vid' => Verb::getID(Activity::LIKE), 'deleted' => false]),
-			Post::exists(['thr-parent-id' => $uriId, 'uid' => $uid, 'origin' => true, 'gravity' => GRAVITY_ACTIVITY, 'vid' => Verb::getID(Activity::ANNOUNCE), 'deleted' => false]),
+			Post::exists([
+				'thr-parent-id' => $uriId,
+				'uid'           => $uid,
+				'origin'        => true,
+				'gravity'       => GRAVITY_ACTIVITY,
+				'vid'           => Verb::getID(Activity::LIKE)
+				, 'deleted'     => false
+			]),
+			Post::exists([
+				'thr-parent-id' => $uriId,
+				'uid'           => $uid,
+				'origin'        => true,
+				'gravity'       => GRAVITY_ACTIVITY,
+				'vid'           => Verb::getID(Activity::ANNOUNCE),
+				'deleted'       => false
+			]),
 			Post\ThreadUser::getIgnored($uriId, $uid),
 			(bool)($item['starred'] && ($item['gravity'] == GRAVITY_PARENT)),
 			Post\ThreadUser::getPinned($uriId, $uid)
 		);
 
-		$sensitive = DBA::exists('tag-view', ['uri-id' => $uriId, 'name' => 'nsfw']);
+		$sensitive   = $this->dba->exists('tag-view', ['uri-id' => $uriId, 'name' => 'nsfw']);
 		$application = new \Friendica\Object\Api\Mastodon\Application($item['app'] ?: ContactSelector::networkToName($item['network'], $item['author-link']));
 
-		$mentions    = DI::mstdnMention()->createFromUriId($uriId);
-		$tags        = DI::mstdnTag()->createFromUriId($uriId);
-		$card        = DI::mstdnCard()->createFromUriId($uriId);
-		$attachments = DI::mstdnAttachment()->createFromUriId($uriId);
+		$mentions    = $this->mstdnMentionFactory->createFromUriId($uriId)->getArrayCopy();
+		$tags        = $this->mstdnTagFactory->createFromUriId($uriId);
+		$card        = $this->mstdnCardFactory->createFromUriId($uriId);
+		$attachments = $this->mstdnAttachementFactory->createFromUriId($uriId);
 
 		$shared = BBCode::fetchShareAttributes($item['body']);
 		if (!empty($shared['guid'])) {
@@ -99,21 +136,21 @@ class Status extends BaseFactory
 
 			$shared_uri_id = $shared_item['uri-id'] ?? 0;
 
-			$mentions    = array_merge($mentions, DI::mstdnMention()->createFromUriId($shared_uri_id));
-			$tags        = array_merge($tags, DI::mstdnTag()->createFromUriId($shared_uri_id));
-			$attachments = array_merge($attachments, DI::mstdnAttachment()->createFromUriId($shared_uri_id));
+			$mentions    = array_merge($mentions, $this->mstdnMentionFactory->createFromUriId($shared_uri_id)->getArrayCopy());
+			$tags        = array_merge($tags, $this->mstdnTagFactory->createFromUriId($shared_uri_id));
+			$attachments = array_merge($attachments, $this->mstdnAttachementFactory->createFromUriId($shared_uri_id));
 
 			if (empty($card->toArray())) {
-				$card = DI::mstdnCard()->createFromUriId($shared_uri_id);
+				$card = $this->mstdnCardFactory->createFromUriId($shared_uri_id);
 			}
 		}
 
 
 		if ($item['vid'] == Verb::getID(Activity::ANNOUNCE)) {
-			$reshare = $this->createFromUriId($item['thr-parent-id'], $uid)->toArray();
-			$reshared_item = Post::selectFirst(['title', 'body'], ['uri-id' => $item['thr-parent-id'], 'uid' => [0, $uid]]);
+			$reshare       = $this->createFromUriId($item['thr-parent-id'], $uid)->toArray();
+			$reshared_item = Post::selectFirst(['title', 'body'], ['uri-id' => $item['thr-parent-id'],'uid' => [0, $uid]]);
 			$item['title'] = $reshared_item['title'] ?? $item['title'];
-			$item['body'] = $reshared_item['body'] ?? $item['body'];
+			$item['body']  = $reshared_item['body'] ?? $item['body'];
 		} else {
 			$reshare = [];
 		}
@@ -123,20 +160,21 @@ class Status extends BaseFactory
 
 	/**
 	 * @param int $uriId id of the mail
+	 *
 	 * @return \Friendica\Object\Api\Mastodon\Status
 	 * @throws HTTPException\InternalServerErrorException
-	 * @throws \ImagickException
+	 * @throws ImagickException
 	 */
 	public function createFromMailId(int $id)
 	{
 		$item = ActivityPub\Transmitter::ItemArrayFromMail($id, true);
 		if (empty($item)) {
-			DI::mstdnError()->RecordNotFound();
+			$this->mstdnErrorFactory->RecordNotFound();
 		}
 
-		$account = DI::mstdnAccount()->createFromContactId($item['author-id']);
+		$account = $this->mstdnAccountFactory->createFromContactId($item['author-id']);
 
-		$replies = DBA::count('mail', ['thr-parent-id' => $item['uri-id'], 'reply' => true]);
+		$replies = $this->dba->count('mail', ['thr-parent-id' => $item['uri-id'], 'reply' => true]);
 
 		$counts = new \Friendica\Object\Api\Mastodon\Status\Counts($replies, 0, 0);
 

--- a/src/Factory/Api/Mastodon/Tag.php
+++ b/src/Factory/Api/Mastodon/Tag.php
@@ -25,25 +25,18 @@ use Friendica\App\BaseURL;
 use Friendica\BaseFactory;
 use Friendica\Model\Tag as TagModel;
 use Friendica\Network\HTTPException;
-use Friendica\Repository\ProfileField;
 use Psr\Log\LoggerInterface;
 
 class Tag extends BaseFactory
 {
 	/** @var BaseURL */
-	protected $baseUrl;
-	/** @var ProfileField */
-	protected $profileField;
-	/** @var Field */
-	protected $mstdnField;
+	private $baseUrl;
 
-	public function __construct(LoggerInterface $logger, BaseURL $baseURL, ProfileField $profileField, Field $mstdnField)
+	public function __construct(LoggerInterface $logger, BaseURL $baseURL)
 	{
 		parent::__construct($logger);
 
 		$this->baseUrl = $baseURL;
-		$this->profileField = $profileField;
-		$this->mstdnField = $mstdnField;
 	}
 
 	/**

--- a/src/Factory/Api/Mastodon/Tag.php
+++ b/src/Factory/Api/Mastodon/Tag.php
@@ -43,14 +43,13 @@ class Tag extends BaseFactory
 	 * @param int $uriId Uri-ID of the item
 	 * @return array
 	 * @throws HTTPException\InternalServerErrorException
-	 * @throws \ImagickException
 	 */
-	public function createFromUriId(int $uriId)
+	public function createFromUriId(int $uriId): array
 	{
 		$hashtags = [];
-		$tags = TagModel::getByURIId($uriId, [TagModel::HASHTAG]);
+		$tags     = TagModel::getByURIId($uriId, [TagModel::HASHTAG]);
 		foreach ($tags as $tag) {
-			$hashtag = new \Friendica\Object\Api\Mastodon\Tag($this->baseUrl, $tag);
+			$hashtag    = new \Friendica\Object\Api\Mastodon\Tag($this->baseUrl, $tag);
 			$hashtags[] = $hashtag->toArray();
 		}
 		return $hashtags;

--- a/src/Module/Api/Mastodon/Apps.php
+++ b/src/Module/Api/Mastodon/Apps.php
@@ -80,6 +80,6 @@ class Apps extends BaseApi
 			DI::mstdnError()->InternalError();
 		}
 
-		System::jsonExit(DI::mstdnApplication()->createFromApplicationId(DBA::lastInsertId()));
+		System::jsonExit(DI::mstdnApplication()->createFromApplicationId(DBA::lastInsertId())->toArray());
 	}
 }

--- a/src/Object/Api/Mastodon/Error.php
+++ b/src/Object/Api/Mastodon/Error.php
@@ -40,7 +40,6 @@ class Error extends BaseDataTransferObject
 	 *
 	 * @param string $error
 	 * @param string error_description
-	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
 	public function __construct(string $error, string $error_description)
 	{

--- a/src/Object/Api/Mastodon/Notification.php
+++ b/src/Object/Api/Mastodon/Notification.php
@@ -21,7 +21,9 @@
 
 namespace Friendica\Object\Api\Mastodon;
 
+use Exception;
 use Friendica\BaseDataTransferObject;
+use Friendica\Network\HTTPException;
 use Friendica\Util\DateTimeFormat;
 
 /**
@@ -45,8 +47,7 @@ class Notification extends BaseDataTransferObject
 	/**
 	 * Creates a notification record
 	 *
-	 * @param array   $item
-	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
+	 * @throws HttpException\InternalServerErrorException|Exception
 	 */
 	public function __construct(int $id, string $type, string $created_at, Account $account = null, Status $status = null)
 	{

--- a/static/dependencies.config.php
+++ b/static/dependencies.config.php
@@ -221,5 +221,10 @@ return [
 	],
 	Network\IHTTPRequest::class => [
 		'instanceOf' => Network\HTTPRequest::class,
-	]
+	],
+	Factory\Api\Mastodon\Error::class => [
+		'constructParams' => [
+			$_SERVER
+		],
+	],
 ];


### PR DESCRIPTION
I reviewed the latest Mastodon Factories and found some code style issues I do want to address here:

- Unused properties (`ProfileField $profileField`, `Field $mstdnField`)
- Changed visibility from `protected` to `private` for method properties without further inheritance
- Unclear variable naming (added `Factory` or `Repo` postfix at some variables)
- Usage of `DI::` inside of already Dice-created instances (Dice already covers the Dependency Injection per constructor, so no need for using `DI::` again - it's like using an own injection process inside an injection process ...)
- Returning arrays instead of instances at factories (Factories are meant for dealing with instances, the caller is responsible for using it the way he needs to (like casting into an array))
- Marked the `Error` class for further refactoring (=> Factories are used for instance creation, not for showing frontend errors => I think there's a need for an own module class)