### PR TITLE
API: The endpoints "followers" and "following" are swapped

### DIFF
--- a/src/Module/Api/Mastodon/Accounts/Followers.php
+++ b/src/Module/Api/Mastodon/Accounts/Followers.php
@@ -54,30 +54,30 @@ class Followers extends BaseApi
 		$request = self::getRequest([
 			'max_id'   => 0,  // Return results older than this id
 			'since_id' => 0,  // Return results newer than this id
-			'limit'    => 20, // Maximum number of results to return. Defaults to 20.
+			'limit'    => 40, // Maximum number of results to return. Defaults to 40.
 		]);
 
-		$params = ['order' => ['cid' => true], 'limit' => $request['limit']];
+		$params = ['order' => ['relation-cid' => true], 'limit' => $request['limit']];
 
-		$condition = ['relation-cid' => $id, 'follows' => true];
+		$condition = ['cid' => $id, 'follows' => true];
 
 		if (!empty($request['max_id'])) {
-			$condition = DBA::mergeConditions($condition, ["`cid` < ?", $request['max_id']]);
+			$condition = DBA::mergeConditions($condition, ["`relation-cid` < ?", $request['max_id']]);
 		}
 
 		if (!empty($request['since_id'])) {
-			$condition = DBA::mergeConditions($condition, ["`cid` > ?", $request['since_id']]);
+			$condition = DBA::mergeConditions($condition, ["`relation-cid` > ?", $request['since_id']]);
 		}
 
 		if (!empty($min_id)) {
-			$condition = DBA::mergeConditions($condition, ["`cid` > ?", $min_id]);
+			$condition = DBA::mergeConditions($condition, ["`relation-cid` > ?", $min_id]);
 
 			$params['order'] = ['cid'];
 		}
 
-		$followers = DBA::select('contact-relation', ['cid'], $condition, $parameters);
+		$followers = DBA::select('contact-relation', ['relation-cid'], $condition, $parameters);
 		while ($follower = DBA::fetch($followers)) {
-			$accounts[] = DI::mstdnAccount()->createFromContactId($follower['cid'], $uid);
+			$accounts[] = DI::mstdnAccount()->createFromContactId($follower['relation-cid'], $uid);
 		}
 		DBA::close($followers);
 

--- a/src/Module/Api/Mastodon/Accounts/Following.php
+++ b/src/Module/Api/Mastodon/Accounts/Following.php
@@ -57,27 +57,27 @@ class Following extends BaseApi
 			'limit'    => 40, // Maximum number of results to return. Defaults to 40.
 		]);
 
-		$params = ['order' => ['relation-cid' => true], 'limit' => $request['limit']];
+		$params = ['order' => ['cid' => true], 'limit' => $request['limit']];
 
-		$condition = ['cid' => $id, 'follows' => true];
+		$condition = ['relation-cid' => $id, 'follows' => true];
 
 		if (!empty($request['max_id'])) {
-			$condition = DBA::mergeConditions($condition, ["`relation-cid` < ?", $request['max_id']]);
+			$condition = DBA::mergeConditions($condition, ["`cid` < ?", $request['max_id']]);
 		}
 
 		if (!empty($request['since_id'])) {
-			$condition = DBA::mergeConditions($condition, ["`relation-cid` > ?", $request['since_id']]);
+			$condition = DBA::mergeConditions($condition, ["`cid` > ?", $request['since_id']]);
 		}
 
 		if (!empty($min_id)) {
-			$condition = DBA::mergeConditions($condition, ["`relation-cid` > ?", $min_id]);
+			$condition = DBA::mergeConditions($condition, ["`cid` > ?", $min_id]);
 
 			$params['order'] = ['cid'];
 		}
 
-		$followers = DBA::select('contact-relation', ['relation-cid'], $condition, $parameters);
+		$followers = DBA::select('contact-relation', ['cid'], $condition, $parameters);
 		while ($follower = DBA::fetch($followers)) {
-			$accounts[] = DI::mstdnAccount()->createFromContactId($follower['relation-cid'], $uid);
+			$accounts[] = DI::mstdnAccount()->createFromContactId($follower['cid'], $uid);
 		}
 		DBA::close($followers);
 

--- a/src/Module/Api/Mastodon/Timelines/Tag.php
+++ b/src/Module/Api/Mastodon/Timelines/Tag.php
@@ -47,6 +47,13 @@ class Tag extends BaseApi
 			DI::mstdnError()->UnprocessableEntity();
 		}
 
+		/**
+		 * @todo Respect missing parameters
+		 * @see https://github.com/tootsuite/mastodon/blob/main/app/controllers/api/v1/timelines/tag_controller.rb
+		 * 
+		 * There seem to be the parameters "any", "all", and "none".
+		 */
+
 		$request = self::getRequest([
 			'local'           => false, // If true, return only local statuses. Defaults to false.
 			'remote'          => false, // Show only remote statuses? Defaults to false.


### PR DESCRIPTION
This is a small fix. These two endpoints returned the opposite data.