### PR TITLE
Support HTTP OPTIONS requests

### DIFF
--- a/src/App/Module.php
+++ b/src/App/Module.php
@@ -267,11 +267,13 @@ class Module
 
 		if ($server['REQUEST_METHOD'] === Router::OPTIONS) {
 			header('HTTP/1.1 204 No Content');
-			header('access-control-allow-credentials: true');
-			header('access-control-allow-headers: Authorization,Content-Type');
-			header('access-control-allow-methods: ' . implode(',', Router::ALLOWED_METHODS));
-			header('access-control-allow-origin: *');
-			header('access-control-max-age: 86400');
+			header('Allow: ' . implode(',', Router::ALLOWED_METHODS));
+			// Deactivated until we know about possible side effects
+			// header('Access-Control-Allow-Credentials: true');
+			// header('Access-Control-Allow-Headers: Authorization,Content-Type');
+			// header('Access-Control-Allow-Methods: ' . implode(',', Router::ALLOWED_METHODS));
+			// header('Access-Control-Allow-Origin: ' . DI::baseUrl());
+			// header('Access-Control-Max-Age: 86400');
 			exit();
 		}
 

--- a/src/App/Module.php
+++ b/src/App/Module.php
@@ -265,6 +265,8 @@ class Module
 			$logger->debug('index.php: page not found.', ['request_uri' => $server['REQUEST_URI'], 'address' => $server['REMOTE_ADDR'], 'query' => $server['QUERY_STRING']]);
 		}
 
+		// @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/OPTIONS
+		// @todo Check allowed methods per requested path
 		if ($server['REQUEST_METHOD'] === Router::OPTIONS) {
 			header('HTTP/1.1 204 No Content');
 			header('Allow: ' . implode(',', Router::ALLOWED_METHODS));

--- a/src/App/Module.php
+++ b/src/App/Module.php
@@ -265,6 +265,16 @@ class Module
 			$logger->debug('index.php: page not found.', ['request_uri' => $server['REQUEST_URI'], 'address' => $server['REMOTE_ADDR'], 'query' => $server['QUERY_STRING']]);
 		}
 
+		if ($server['REQUEST_METHOD'] === Router::OPTIONS) {
+			header('HTTP/1.1 204 No Content');
+			header('access-control-allow-credentials: true');
+			header('access-control-allow-headers: Authorization,Content-Type');
+			header('access-control-allow-methods: ' . implode(',', Router::ALLOWED_METHODS));
+			header('access-control-allow-origin: *');
+			header('access-control-max-age: 86400');
+			exit();
+		}
+
 		$placeholder = '';
 
 		$profiler->set(microtime(true), 'ready');

--- a/src/App/Router.php
+++ b/src/App/Router.php
@@ -44,11 +44,12 @@ use Friendica\Network\HTTPException;
  */
 class Router
 {
-	const DELETE = 'DELETE';
-	const GET    = 'GET';
-	const PATCH  = 'PATCH';
-	const POST   = 'POST';
-	const PUT    = 'PUT';
+	const DELETE  = 'DELETE';
+	const GET     = 'GET';
+	const PATCH   = 'PATCH';
+	const POST    = 'POST';
+	const PUT     = 'PUT';
+	const OPTIONS = 'OPTIONS';
 
 	const ALLOWED_METHODS = [
 		self::DELETE,
@@ -56,6 +57,7 @@ class Router
 		self::PATCH,
 		self::POST,
 		self::PUT,
+		self::OPTIONS
 	];
 
 	/** @var RouteCollector */


### PR DESCRIPTION
Several Mastodon clients are performing "OPTIONS" requests, see here: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/OPTIONS

So we should support them.