### PR TITLE
Fixes for #10389 - $third_party must remain 'false'

### DIFF
--- a/include/api.php
+++ b/include/api.php
@@ -257,7 +257,7 @@ function api_login(App $a, bool $do_login = true)
 	if ($addon_auth['authenticated'] && !empty($addon_auth['user_record'])) {
 		$record = $addon_auth['user_record'];
 	} else {
-		$user_id = User::authenticate(trim($user), trim($password), true);
+		$user_id = User::authenticate(trim($user), trim($password));
 		if ($user_id !== false) {
 			$record = DBA::selectFirst('user', [], ['uid' => $user_id]);
 		}

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -492,7 +492,7 @@ class User
 	 * @deprecated since version 3.6
 	 * @see        User::getIdFromPasswordAuthentication()
 	 */
-	public static function authenticate($user_info, $password, $third_party = false)
+	public static function authenticate($user_info, string $password, bool $third_party = false)
 	{
 		try {
 			return self::getIdFromPasswordAuthentication($user_info, $password, $third_party);
@@ -513,7 +513,7 @@ class User
 	 * @throws HTTPException\ForbiddenException
 	 * @throws HTTPException\NotFoundException
 	 */
-	public static function getIdFromPasswordAuthentication($user_info, $password, $third_party = false)
+	public static function getIdFromPasswordAuthentication($user_info, string $password, bool $third_party = false)
 	{
 		// Addons registered with the "authenticate" hook may create the user on the
 		// fly. `getAuthenticationInfo` will fail if the user doesn't exist yet. If


### PR DESCRIPTION
#10389: The following changes are done here:
- removed 'true' parameter as $third_party was misused as API setting
- added type-hints for parameter
