### PR TITLE
Reduce batch size for photo processing to reduce memory usage

### DIFF
--- a/src/Database/PostUpdate.php
+++ b/src/Database/PostUpdate.php
@@ -740,7 +740,7 @@ class PostUpdate
 		Logger::info('Start', ['rest' => DBA::count('photo', $condition)]);
 
 		$rows = 0;
-		$photos = DBA::select('photo', [], $condition, ['limit' => 10000]);
+		$photos = DBA::select('photo', [], $condition, ['limit' => 100]);
 
 		if (DBA::errorNo() != 0) {
 			Logger::error('Database error', ['no' => DBA::errorNo(), 'message' => DBA::errorMessage()]);


### PR DESCRIPTION
This change addresses an issue I encountered in #10375. When trying to apply update 1384, the updater kept running out of memory until I reduced this down to a batch size of 100. The system in question had a memory limit of 512 MiB per php-fpm process and likely had large photos stored in the database.