### PR TITLE
Documentation: The list of supported clients had been reworked

### DIFF
--- a/doc/API-Mastodon.md
+++ b/doc/API-Mastodon.md
@@ -13,44 +13,21 @@ Authentication is the same as described in [Using the APIs](help/api#Authenticat
 
 ### Supported apps
 
-#### Android
-
-- [AndStatus](http://andstatus.org)
-- [B4X for Pleroma & Mastodon](https://github.com/AnywhereSoftware/B4X-Pleroma)
-- [Fedi](https://play.google.com/store/apps/details?id=com.fediverse.app)
-- [Husky](https://husky.fwgs.ru)
-- [Roma](https://play.google.com/store/apps/details?id=tech.bigfig.roma)
-- [Subway Tooter](https://github.com/tateisu/SubwayTooter)
-- [Tooot](https://tooot.app/)
-- [Tusky](https://tusky.app)
-- [Twidere](https://github.com/TwidereProject/)
-- [twitlatte](https://github.com/moko256/twitlatte)
-- [Yuito](https://github.com/accelforce/Yuito)
-
-#### iOS
-- [Amaroq](https://github.com/ReticentJohn/Amaroq/tree/master)
-- [B4X for Pleroma & Mastodon](https://github.com/AnywhereSoftware/B4X-Pleroma)
-- [Fedi](https://apps.apple.com/de/app/fedi-for-pleroma-and-mastodon/id1478806281)
-- [Roma](https://apps.apple.com/de/app/roma-for-pleroma-and-mastodon/id1445328699)
-- [StarPterano](https://apps.apple.com/de/app/starpterano/id1436972796) Uses an OAuth method where you have to manually copy and paste the provided code.
-- [Stella](https://apps.apple.com/us/app/stella-for-mastodon-twitter/id921372048?l=ms)
-- [Tooot](https://tooot.app/)
-- [Tootle](https://apps.apple.com/de/app/tootle-for-mastodon/id1236013466) entered hostname must match in upper/lower case. Currently crashes on "Status" type notifications.
-
-#### Desktop
-- [Whalebird](https://whalebird.social)
+For supported apps please have a look at the [FAQ](help/FAQ#clients)
 
 ### Unsupported apps
 
 #### Android
+
 - [Fedilab](https://framagit.org/tom79/fedilab) Automatically uses the legacy API, see issue: https://framagit.org/tom79/fedilab/-/issues/520
 - [Mammut](https://github.com/jamiesanson/Mammut) There are problems with the token request, see issue https://github.com/jamiesanson/Mammut/issues/19
 
 #### iOS
+
 - [Mast](https://github.com/Beesitech/Mast) Doesn't accept the entered instance name. Claims that it is invalid (Message is: "Not a valid instance (may be closed or dead)")
 - [Toot!](https://apps.apple.com/app/toot/id1229021451)
 
-#### Other
+#### Desktop
 
 - [Halycon](https://www.halcyon.social/) Doesn't load content, creates masses of HTTP requests
 - [Mastonaut](https://mastonaut.app/)

--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -183,25 +183,48 @@ Example: Friendica Support
 ### What friendica clients can I use?
 
 Friendica is using a [Twitter/GNU Social compatible API](help/api), which means you can use any Twitter/GNU Social client for your platform as long as you can change the API path in its settings.
-Since the 2021.06 release, Friendica also supports the Mastodon API.
+Since the 2021.06 release, Friendica also supports the [Mastodon API](help/API-Mastodon) which works with a lot of Mastodon clients.
 Here is a list of known working clients:
 
-* Android
-  * [Friendiqa](https://git.friendi.ca/lubuwest/Friendiqa) ([F-Droid](https://git.friendi.ca/lubuwest/Friendiqa#install), [Google Play](https://play.google.com/store/apps/details?id=org.qtproject.friendiqa))
-  * [Fedilab](https://fedilab.app) ([F-Droid](https://f-droid.org/app/fr.gouv.etalab.mastodon), [Google Play](https://play.google.com/store/apps/details?id=app.fedilab.android))
-  * [AndStatus](http://andstatus.org) ([F-Droid](https://f-droid.org/repository/browse/?fdid=org.andstatus.app), [Google Play](https://play.google.com/store/apps/details?id=org.andstatus.app))
-  * [Twidere](https://dimension.im/) ([F-Droid](https://f-droid.org/repository/browse/?fdid=org.mariotaku.twidere), [Google Play](https://play.google.com/store/apps/details?id=com.twidere.twiderex), [GitHub](https://github.com/TwidereProject/Twidere-Android))
-* SailfishOS
-  * [Friendly](https://openrepos.net/content/fabrixxm/friendly#comment-form)
-* Linux
-  * [Choqok](https://choqok.kde.org)
-* Windows
-  * [Friendica Mobile](https://www.microsoft.com/de-DE/store/p/friendica-mobile/9nblggh0fhmn?rtc=1) (Windows 10)
-  * [Husky](https://husky.fwgs.ru)
-  * [Subway Tooter](https://github.com/tateisu/SubwayTooter)
-  * [Tusky](https://tusky.app)
-  * [twitlatte](https://github.com/moko256/twitlatte)
-  * [Yuito](https://github.com/accelforce/Yuito)
+#### Android
+
+* [AndStatus](http://andstatus.org) ([F-Droid](https://f-droid.org/repository/browse/?fdid=org.andstatus.app), [Google Play](https://play.google.com/store/apps/details?id=org.andstatus.app))
+* [B4X for Pleroma & Mastodon](https://github.com/AnywhereSoftware/B4X-Pleroma)
+* [DiCa](https://dica.mixi.cool/) (Available at Google Play)
+* [Fedi](https://play.google.com/store/apps/details?id=com.fediverse.app)
+* [Fedilab](https://fedilab.app) ([F-Droid](https://f-droid.org/app/fr.gouv.etalab.mastodon), [Google Play](https://play.google.com/store/apps/details?id=app.fedilab.android))
+* [Friendiqa](https://git.friendi.ca/lubuwest/Friendiqa) ([F-Droid](https://git.friendi.ca/lubuwest/Friendiqa#install), [Google Play](https://play.google.com/store/apps/details?id=org.qtproject.friendiqa))
+* [Husky](https://husky.fwgs.ru)
+* [Roma](https://play.google.com/store/apps/details?id=tech.bigfig.roma)
+* [Subway Tooter](https://github.com/tateisu/SubwayTooter)
+* [Tooot](https://tooot.app/)
+* [Tusky](https://tusky.app)
+* [Twidere](https://dimension.im/) ([F-Droid](https://f-droid.org/repository/browse/?fdid=org.mariotaku.twidere), [Google Play](https://play.google.com/store/apps/details?id=com.twidere.twiderex), [GitHub](https://github.com/TwidereProject/Twidere-Android))
+* [twitlatte](https://github.com/moko256/twitlatte)
+* [Yuito](https://github.com/accelforce/Yuito)
+
+#### SailfishOS
+* [Friendly](https://openrepos.net/content/fabrixxm/friendly#comment-form)
+#### iOS
+
+* [Amaroq](https://github.com/ReticentJohn/Amaroq/tree/master)
+* [B4X for Pleroma & Mastodon](https://github.com/AnywhereSoftware/B4X-Pleroma)
+* [Fedi](https://apps.apple.com/de/app/fedi-for-pleroma-and-mastodon/id1478806281)
+* [Roma](https://apps.apple.com/de/app/roma-for-pleroma-and-mastodon/id1445328699)
+* [StarPterano](https://apps.apple.com/de/app/starpterano/id1436972796) Uses an OAuth method where you have to manually copy and paste the provided code.
+* [Stella](https://apps.apple.com/us/app/stella-for-mastodon-twitter/id921372048?l=ms)
+* [Tooot](https://tooot.app/)
+* [Tootle](https://apps.apple.com/de/app/tootle-for-mastodon/id1236013466) entered hostname must match in upper/lower case. Currently crashes on "Status" type notifications.
+
+#### Linux
+
+* [Choqok](https://choqok.kde.org)
+* [Whalebird](https://whalebird.social)
+* [TheDesk](https://ja.mstdn.wiki/TheDesk)
+* [Toot](https://toot.readthedocs.io/en/latest/)
+* [Tootle](https://github.com/bleakgrey/tootle)
+#### Windows
+* [Friendica Mobile](https://www.microsoft.com/de-DE/store/p/friendica-mobile/9nblggh0fhmn?rtc=1) (Windows 10)
 
 Depending on the features of the client you might encounter some glitches in usability, like being limited in the length of your postings to 140 characters and having no access to the [permission settings](help/Groups-and-Privacy).
 

--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -183,7 +183,7 @@ Example: Friendica Support
 ### What friendica clients can I use?
 
 Friendica is using a [Twitter/GNU Social compatible API](help/api), which means you can use any Twitter/GNU Social client for your platform as long as you can change the API path in its settings.
-Since the 2021.06 release, Friendica also supports the [Mastodon API](help/API-Mastodon) which works with a lot of Mastodon clients.
+Since the 2021.06 release, Friendica also supports the [Mastodon API](help/API-Mastodon) which works with many Mastodon clients.
 Here is a list of known working clients:
 
 #### Android
@@ -204,7 +204,9 @@ Here is a list of known working clients:
 * [Yuito](https://github.com/accelforce/Yuito)
 
 #### SailfishOS
+
 * [Friendly](https://openrepos.net/content/fabrixxm/friendly#comment-form)
+
 #### iOS
 
 * [Amaroq](https://github.com/ReticentJohn/Amaroq/tree/master)
@@ -223,7 +225,9 @@ Here is a list of known working clients:
 * [TheDesk](https://ja.mstdn.wiki/TheDesk)
 * [Toot](https://toot.readthedocs.io/en/latest/)
 * [Tootle](https://github.com/bleakgrey/tootle)
+
 #### Windows
+
 * [Friendica Mobile](https://www.microsoft.com/de-DE/store/p/friendica-mobile/9nblggh0fhmn?rtc=1) (Windows 10)
 
 Depending on the features of the client you might encounter some glitches in usability, like being limited in the length of your postings to 140 characters and having no access to the [permission settings](help/Groups-and-Privacy).

--- a/doc/de/FAQ.md
+++ b/doc/de/FAQ.md
@@ -193,33 +193,49 @@ Beispiel: Friendica Support
 ### Gibt es Clients für Friendica?
 
 Friendica verwendet eine [Twitter/GNU Social](help/api) kompatible API.
-Seit der Version 2021.06 unterstützt Friendica außerdem die Mastodon API.
 Das bedeutet, dass du jeden Twitter/GNU Social Client verwenden kannst in dem du den API Pfad entsprechend änderst.
+Seit der Version 2021.06 unterstützt Friendica außerdem die [Mastodon API](help/API-Mastodon) die mit vielen Mastodon-Clients läuft.
 
-Hier ist eine Liste von Clients bei denen dies möglich ist, bzw. die speziell für Friendica entwickelt werden:
+Hier ist eine Liste von Clients, die speziell für Friendica entwickelt werden oder die mit Friendica kompatibel sind:
 
-* Android
-  * [Friendiqa](https://git.friendi.ca/lubuwest/Friendiqa) (Gibt es im Google Playstore oder als [binary Repository](https://freunde.ma-nic.de/display/3e98eba8185a13c5bdbf3d1539646854) für F-Droid)
-  * [Fedilab](https://gitlab.com/tom79/mastalab) (Gibt es im F-Droid und dem Google Play Store)
-  * [DiCa](https://dica.mixi.cool/) (Gibt es bei Google Play)
-  * AndStatus
-  * Twidere
-  * Mustard and Mustard-Mod
-* SailfishOS
-  * [Friendly](https://openrepos.net/content/fabrixxm/friendly#comment-form)
-  * [Husky](https://husky.fwgs.ru)
-  * [Subway Tooter](https://github.com/tateisu/SubwayTooter)
-  * [Tusky](https://tusky.app)
-  * [twitlatte](https://github.com/moko256/twitlatte)
-  * [Yuito](https://github.com/accelforce/Yuito)
-* Linux
-  * Hotot
-  * Choqok
-* MacOS X
-  * Hotot
-* Windows
-  * [Friendica Mobile](https://www.microsoft.com/de-DE/store/p/friendica-mobile/9nblggh0fhmn?rtc=1) für Windows 10
-  * Hotot
+#### Android
+* [AndStatus](http://andstatus.org) ([F-Droid](https://f-droid.org/repository/browse/?fdid=org.andstatus.app), [Google Play](https://play.google.com/store/apps/details?id=org.andstatus.app))
+* [B4X for Pleroma & Mastodon](https://github.com/AnywhereSoftware/B4X-Pleroma)
+* [DiCa](https://dica.mixi.cool/) (Gibt es bei Google Play)
+* [Fedi](https://play.google.com/store/apps/details?id=com.fediverse.app)
+* [Fedilab](https://fedilab.app) ([F-Droid](https://f-droid.org/app/fr.gouv.etalab.mastodon), [Google Play](https://play.google.com/store/apps/details?id=app.fedilab.android))
+* [Friendiqa](https://git.friendi.ca/lubuwest/Friendiqa) (Gibt es im Google Playstore oder als [binary Repository](https://freunde.ma-nic.de/display/3e98eba8185a13c5bdbf3d1539646854) für F-Droid)
+* [Husky](https://husky.fwgs.ru)
+* [Roma](https://play.google.com/store/apps/details?id=tech.bigfig.roma)
+* [Subway Tooter](https://github.com/tateisu/SubwayTooter)
+* [Tooot](https://tooot.app/)
+* [Tusky](https://tusky.app)
+* [Twidere](https://dimension.im/) ([F-Droid](https://f-droid.org/repository/browse/?fdid=org.mariotaku.twidere), [Google Play](https://play.google.com/store/apps/details?id=com.twidere.twiderex), [GitHub](https://github.com/TwidereProject/Twidere-Android))
+* [twitlatte](https://github.com/moko256/twitlatte)
+* [Yuito](https://github.com/accelforce/Yuito)
+
+#### SailfishOS
+* [Friendly](https://openrepos.net/content/fabrixxm/friendly#comment-form)
+
+#### iOS
+- [Amaroq](https://github.com/ReticentJohn/Amaroq/tree/master)
+- [B4X for Pleroma & Mastodon](https://github.com/AnywhereSoftware/B4X-Pleroma)
+- [Fedi](https://apps.apple.com/de/app/fedi-for-pleroma-and-mastodon/id1478806281)
+- [Roma](https://apps.apple.com/de/app/roma-for-pleroma-and-mastodon/id1445328699)
+- [StarPterano](https://apps.apple.com/de/app/starpterano/id1436972796)
+- [Stella](https://apps.apple.com/us/app/stella-for-mastodon-twitter/id921372048?l=ms)
+- [Tooot](https://tooot.app/)
+- [Tootle](https://apps.apple.com/de/app/tootle-for-mastodon/id1236013466) Der eingegene Hostname muss in Groß-/Kleinschreibung mit dem Hostnamen des Systems übereinstimmen. Die aktuelle Version stürzt bei Benachrichtungen bom Typ "status" ab.
+
+#### Linux
+* [Choqok](https://choqok.kde.org)
+* [Whalebird](https://whalebird.social)
+* [TheDesk](https://ja.mstdn.wiki/TheDesk)
+* [Toot](https://toot.readthedocs.io/en/latest/)
+* [Tootle](https://github.com/bleakgrey/tootle)
+
+#### Windows
+* [Friendica Mobile](https://www.microsoft.com/de-DE/store/p/friendica-mobile/9nblggh0fhmn?rtc=1) für Windows 10
 
 Admin
 --------

--- a/doc/de/FAQ.md
+++ b/doc/de/FAQ.md
@@ -199,6 +199,7 @@ Seit der Version 2021.06 unterstützt Friendica außerdem die [Mastodon API](hel
 Hier ist eine Liste von Clients, die speziell für Friendica entwickelt werden oder die mit Friendica kompatibel sind:
 
 #### Android
+
 * [AndStatus](http://andstatus.org) ([F-Droid](https://f-droid.org/repository/browse/?fdid=org.andstatus.app), [Google Play](https://play.google.com/store/apps/details?id=org.andstatus.app))
 * [B4X for Pleroma & Mastodon](https://github.com/AnywhereSoftware/B4X-Pleroma)
 * [DiCa](https://dica.mixi.cool/) (Gibt es bei Google Play)
@@ -215,9 +216,11 @@ Hier ist eine Liste von Clients, die speziell für Friendica entwickelt werden o
 * [Yuito](https://github.com/accelforce/Yuito)
 
 #### SailfishOS
+
 * [Friendly](https://openrepos.net/content/fabrixxm/friendly#comment-form)
 
 #### iOS
+
 - [Amaroq](https://github.com/ReticentJohn/Amaroq/tree/master)
 - [B4X for Pleroma & Mastodon](https://github.com/AnywhereSoftware/B4X-Pleroma)
 - [Fedi](https://apps.apple.com/de/app/fedi-for-pleroma-and-mastodon/id1478806281)
@@ -228,6 +231,7 @@ Hier ist eine Liste von Clients, die speziell für Friendica entwickelt werden o
 - [Tootle](https://apps.apple.com/de/app/tootle-for-mastodon/id1236013466) Der eingegene Hostname muss in Groß-/Kleinschreibung mit dem Hostnamen des Systems übereinstimmen. Die aktuelle Version stürzt bei Benachrichtungen bom Typ "status" ab.
 
 #### Linux
+
 * [Choqok](https://choqok.kde.org)
 * [Whalebird](https://whalebird.social)
 * [TheDesk](https://ja.mstdn.wiki/TheDesk)
@@ -235,6 +239,7 @@ Hier ist eine Liste von Clients, die speziell für Friendica entwickelt werden o
 * [Tootle](https://github.com/bleakgrey/tootle)
 
 #### Windows
+
 * [Friendica Mobile](https://www.microsoft.com/de-DE/store/p/friendica-mobile/9nblggh0fhmn?rtc=1) für Windows 10
 
 Admin

--- a/doc/de/Home.md
+++ b/doc/de/Home.md
@@ -54,7 +54,7 @@ Friendica - Dokumentation und Ressourcen
 * [Class Autoloading](help/autoloader) (EN)
 * [Using Composer](help/Composer) (EN)
 * [Code-Referenz (mit doxygen generiert - setzt Cookies)](doc/html/)
-* [Twitter/GNU Social API Functions](help/api) (EN)
+* [API Dokumentation](help/api) (EN)
 * [Translation of Friendica](help/translations) (EN)
 * [Run tests](help/Tests) (EN)
 


### PR DESCRIPTION
The list of supported clients for the Mastodon API now is moved to the other list in the FAQ.