### PR TITLE
Centralized functionality to update and publish profile changes

### DIFF
--- a/include/api.php
+++ b/include/api.php
@@ -42,6 +42,7 @@ use Friendica\Model\Mail;
 use Friendica\Model\Notification;
 use Friendica\Model\Photo;
 use Friendica\Model\Post;
+use Friendica\Model\Profile;
 use Friendica\Model\User;
 use Friendica\Model\Verb;
 use Friendica\Network\HTTPException;
@@ -4552,12 +4553,7 @@ function api_account_update_profile_image($type)
 	Contact::updateSelfFromUserID(api_user(), true);
 
 	// Update global directory in background
-	$url = DI::baseUrl() . '/profile/' . DI::app()->user['nickname'];
-	if ($url && strlen(DI::config()->get('system', 'directory'))) {
-		Worker::add(PRIORITY_LOW, "Directory", $url);
-	}
-
-	Worker::add(PRIORITY_LOW, 'ProfileUpdate', api_user());
+	Profile::publishUpdate(api_user());
 
 	// output for client
 	if ($data) {
@@ -4608,11 +4604,7 @@ function api_account_update_profile($type)
 		DBA::update('contact', ['about' => $_POST['description']], ['id' => $api_user['id']]);
 	}
 
-	Worker::add(PRIORITY_LOW, 'ProfileUpdate', $local_user);
-	// Update global directory in background
-	if ($api_user['url'] && strlen(DI::config()->get('system', 'directory'))) {
-		Worker::add(PRIORITY_LOW, "Directory", $api_user['url']);
-	}
+	Profile::publishUpdate($local_user);
 
 	return api_account_verify_credentials($type);
 }

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -725,6 +725,7 @@ class Contact
 				'thumb' => DI::baseUrl() . '/photo/avatar/' . $uid .'.' . $file_suffix];
 			DBA::update('profile', $fields, ['uid' => $uid]);
 		}
+
 		return $update;
 	}
 

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -623,6 +623,7 @@ class Contact
 	 *
 	 * @param int     $uid
 	 * @param boolean $update_avatar Force the avatar update
+	 * @return bool   "true" if updated
 	 * @throws HTTPException\InternalServerErrorException
 	 */
 	public static function updateSelfFromUserID($uid, $update_avatar = false)
@@ -632,20 +633,20 @@ class Contact
 			'photo', 'thumb', 'micro', 'addr', 'request', 'notify', 'poll', 'confirm', 'poco'];
 		$self = DBA::selectFirst('contact', $fields, ['uid' => $uid, 'self' => true]);
 		if (!DBA::isResult($self)) {
-			return;
+			return false;
 		}
 
 		$fields = ['nickname', 'page-flags', 'account-type', 'prvkey', 'pubkey'];
 		$user = DBA::selectFirst('user', $fields, ['uid' => $uid, 'account_expired' => false]);
 		if (!DBA::isResult($user)) {
-			return;
+			return false;
 		}
 
 		$fields = ['name', 'photo', 'thumb', 'about', 'address', 'locality', 'region',
 			'country-name', 'pub_keywords', 'xmpp', 'net-publish'];
 		$profile = DBA::selectFirst('profile', $fields, ['uid' => $uid]);
 		if (!DBA::isResult($profile)) {
-			return;
+			return false;
 		}
 
 		$file_suffix = 'jpg';
@@ -724,6 +725,7 @@ class Contact
 				'thumb' => DI::baseUrl() . '/photo/avatar/' . $uid .'.' . $file_suffix];
 			DBA::update('profile', $fields, ['uid' => $uid]);
 		}
+		return $update;
 	}
 
 	/**

--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -123,7 +123,7 @@ class Profile
 		}
 
 		if ($update) {
-			self::publishUpdate($uid);
+			self::publishUpdate($uid, ($old_owner['net-publish'] != $owner['net-publish']));
 		}
 
 		return true;
@@ -131,15 +131,17 @@ class Profile
 
 	/**
 	 * Publish a changed profile
-	 * @param int $uid 
+	 * @param int  $uid
+	 * @param bool $force Force publishing to the directory
 	 */
-	public static function publishUpdate(int $uid)
+	public static function publishUpdate(int $uid, bool $force = false)
 	{
 		$owner = User::getOwnerDataById($uid);
 		if (empty($owner)) {
 			return;
 		}
-		if ($owner['net-publish']) {
+
+		if ($owner['net-publish'] || $force) {
 			// Update global directory in background
 			if (Search::getGlobalDirectory()) {
 				Worker::add(PRIORITY_LOW, 'Directory', $owner['url']);

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -1134,6 +1134,42 @@ class User
 	}
 
 	/**
+	 * Update a user entry and distribute the changes if needed
+	 *
+	 * @param array $fields
+	 * @param integer $uid
+	 * @return boolean
+	 */
+	public static function update(array $fields, int $uid): bool
+	{
+		$old_owner = self::getOwnerDataById($uid);
+		if (empty($old_owner)) {
+			return false;
+		}
+
+		if (!DBA::update('user', $fields, ['uid' => $uid])) {
+			return false;
+		}
+
+		$update = Contact::updateSelfFromUserID($uid);
+
+		$owner = self::getOwnerDataById($uid);
+		if (empty($owner)) {
+			return false;
+		}
+
+		if ($old_owner['name'] != $owner['name']) {
+			Profile::update(['name' => $owner['name']], $uid);
+		}
+
+		if ($update) {
+			Profile::publishUpdate($uid);
+		}
+
+		return true;
+	}
+
+	/**
 	 * Sets block state for a given user
 	 *
 	 * @param int  $uid   The user id

--- a/src/Module/Settings/Profile/Index.php
+++ b/src/Module/Settings/Profile/Index.php
@@ -86,8 +86,6 @@ class Index extends BaseSettings
 			return;
 		}
 
-		$namechanged = $profile['name'] != $name;
-
 		$about = Strings::escapeTags(trim($_POST['about']));
 		$address = Strings::escapeTags(trim($_POST['address']));
 		$locality = Strings::escapeTags(trim($_POST['locality']));
@@ -114,8 +112,7 @@ class Index extends BaseSettings
 
 		DI::profileField()->saveCollection($profileFields);
 
-		$result = DBA::update(
-			'profile',
+		$result = Profile::update(
 			[
 				'name'         => $name,
 				'about'        => $about,
@@ -130,26 +127,13 @@ class Index extends BaseSettings
 				'pub_keywords' => $pub_keywords,
 				'prv_keywords' => $prv_keywords,
 			],
-			['uid' => local_user()]
+			local_user()
 		);
 
 		if (!$result) {
 			notice(DI::l10n()->t('Profile couldn\'t be updated.'));
 			return;
 		}
-
-		if ($namechanged) {
-			DBA::update('user', ['username' => $name], ['uid' => local_user()]);
-		}
-
-		Contact::updateSelfFromUserID(local_user());
-
-		// Update global directory in background
-		if (Session::get('my_url') && strlen(DI::config()->get('system', 'directory'))) {
-			Worker::add(PRIORITY_LOW, 'Directory', Session::get('my_url'));
-		}
-
-		Worker::add(PRIORITY_LOW, 'ProfileUpdate', local_user());
 	}
 
 	public static function content(array $parameters = [])

--- a/src/Module/Settings/Profile/Photo/Crop.php
+++ b/src/Module/Settings/Profile/Photo/Crop.php
@@ -28,6 +28,7 @@ use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Contact;
 use Friendica\Model\Photo;
+use Friendica\Model\Profile;
 use Friendica\Module\BaseSettings;
 use Friendica\Network\HTTPException;
 
@@ -137,12 +138,9 @@ class Crop extends BaseSettings
 				Contact::updateSelfFromUserID(local_user(), true);
 
 				info(DI::l10n()->t('Shift-reload the page or clear browser cache if the new photo does not display immediately.'));
-				// Update global directory in background
-				if ($path && strlen(DI::config()->get('system', 'directory'))) {
-					Worker::add(PRIORITY_LOW, 'Directory', DI::baseUrl()->get() . '/' . $path);
-				}
 
-				Worker::add(PRIORITY_LOW, 'ProfileUpdate', local_user());
+				// Update global directory in background
+				Profile::publishUpdate(local_user());
 			} else {
 				notice(DI::l10n()->t('Unable to process image'));
 			}
@@ -183,9 +181,7 @@ class Crop extends BaseSettings
 			Contact::updateSelfFromUserID(local_user(), true);
 
 			// Update global directory in background
-			if (Session::get('my_url') && strlen(DI::config()->get('system', 'directory'))) {
-				Worker::add(PRIORITY_LOW, 'Directory', Session::get('my_url'));
-			}
+			Profile::publishUpdate(local_user());
 
 			info(DI::l10n()->t('Profile picture successfully updated.'));
 

--- a/update.php
+++ b/update.php
@@ -53,6 +53,7 @@ use Friendica\Model\ItemURI;
 use Friendica\Model\Notification;
 use Friendica\Model\Photo;
 use Friendica\Model\Post;
+use Friendica\Model\Profile;
 use Friendica\Model\Storage;
 use Friendica\Worker\Delivery;
 
@@ -98,8 +99,9 @@ function update_1298()
 					DBA::update('profile', [$translateKey => $key], ['id' => $data['id']]);
 					Logger::notice('Updated contact', ['action' => 'update', 'contact' => $data['id'], "$translateKey" => $key,
 						'was' => $data[$translateKey]]);
-					Worker::add(PRIORITY_LOW, 'ProfileUpdate', $data['id']);
+
 					Contact::updateSelfFromUserID($data['id']);
+					Profile::publishUpdate($data['id']);
 					$success++;
 				}
 			}
@@ -153,7 +155,9 @@ function update_1323()
 {
 	$users = DBA::select('user', ['uid']);
 	while ($user = DBA::fetch($users)) {
-		Contact::updateSelfFromUserID($user['uid']);
+		if (Contact::updateSelfFromUserID($user['uid'])) {
+			Profile::publishUpdate($user['uid']);
+		}
 	}
 	DBA::close($users);
 


### PR DESCRIPTION
Inspired by https://github.com/friendica/friendica/issues/10394#issuecomment-860922217 I had a look at how we update profile fields.

We hadn't got any centralized functionality either to perform the update nor to publish it to the directory.

Since this won't not only needed in the linked discussion but also for the new API, the functionality had now been moved to a central place.