### PR TITLE
Add a profile entry if missing

### DIFF
--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -391,7 +391,12 @@ class User
 			if (!DBA::exists('user', ['uid' => $uid]) || !$repairMissing) {
 				return false;
 			}
-			Contact::createSelfFromUserId($uid);
+			if (!DBA::exists('contact', ['uid' => $uid, 'self' => true])) {
+				Contact::createSelfFromUserId($uid);
+			}
+			if (!DBA::exists('profile', ['uid' => $uid])) {
+				DBA::insert('profile', ['uid' => $uid]);
+			}
 			$owner = self::getOwnerDataById($uid, false);
 		}
 

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -391,11 +391,11 @@ class User
 			if (!DBA::exists('user', ['uid' => $uid]) || !$repairMissing) {
 				return false;
 			}
-			if (!DBA::exists('contact', ['uid' => $uid, 'self' => true])) {
-				Contact::createSelfFromUserId($uid);
-			}
 			if (!DBA::exists('profile', ['uid' => $uid])) {
 				DBA::insert('profile', ['uid' => $uid]);
+			}
+			if (!DBA::exists('contact', ['uid' => $uid, 'self' => true])) {
+				Contact::createSelfFromUserId($uid);
 			}
 			$owner = self::getOwnerDataById($uid, false);
 		}


### PR DESCRIPTION
A user had an issue where the user entry had vanished during the update (for unknown reasons). He still does have issues after manually restoring the user entry.

The owner view doesn't return content, which means that most likely the profile entry for this user doesn't exist as well.