### PR TITLE
Issue 10392: Avoid "Friendica can't display this page at the moment"

### DIFF
--- a/src/App/BaseURL.php
+++ b/src/App/BaseURL.php
@@ -232,7 +232,7 @@ class BaseURL
 	{
 		$parsed = @parse_url($url);
 
-		if (empty($parsed)) {
+		if (empty($parsed) || empty($parsed['host'])) {
 			return false;
 		}
 

--- a/src/Core/Console.php
+++ b/src/Core/Console.php
@@ -172,6 +172,8 @@ HELP;
 
 		Friendica\DI::init($this->dice);
 
+		Renderer::registerTemplateEngine('Friendica\Render\FriendicaSmartyEngine');
+
 		/** @var Console $subconsole */
 		$subconsole = $this->dice->create($className, [$subargs]);
 

--- a/src/Database/DBStructure.php
+++ b/src/Database/DBStructure.php
@@ -162,8 +162,6 @@ class DBStructure
 
 	public static function writeStructure()
 	{
-		Renderer::registerTemplateEngine('Friendica\Render\FriendicaSmartyEngine');
-
 		$tables = [];
 		foreach (self::definition(null) as $name => $definition) {
 			$indexes  = [[


### PR DESCRIPTION
Fixes #10392

The error `[Error] Friendica can't display this page at the moment, please contact the administrator.` is generated when the template system isn't initialized.

Also the notice `Undefined index: host in /var/www/friendica/src/App/BaseURL.php on line 239` is generated because in that issue the hostname was incomplete (only the hostname, no schema)