### PR TITLE
Fix noscrape publishing and pulling, added header

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -1,6 +1,6 @@
 -- ------------------------------------------
 -- Friendica 2021.06-rc (Siberian Iris)
--- DB_UPDATE_VERSION 1422
+-- DB_UPDATE_VERSION 1423
 -- ------------------------------------------
 
 
@@ -120,6 +120,7 @@ CREATE TABLE IF NOT EXISTS `contact` (
 	`photo` varchar(255) DEFAULT '' COMMENT 'Link to the profile photo of the contact',
 	`thumb` varchar(255) DEFAULT '' COMMENT 'Link to the profile photo (thumb size)',
 	`micro` varchar(255) DEFAULT '' COMMENT 'Link to the profile photo (micro size)',
+	`header` varchar(255) COMMENT 'Header picture',
 	`site-pubkey` text COMMENT '',
 	`issued-id` varchar(255) NOT NULL DEFAULT '' COMMENT '',
 	`dfrn-id` varchar(255) NOT NULL DEFAULT '' COMMENT '',
@@ -343,6 +344,7 @@ CREATE TABLE IF NOT EXISTS `apcontact` (
 	`name` varchar(255) COMMENT '',
 	`about` text COMMENT '',
 	`photo` varchar(255) COMMENT '',
+	`header` varchar(255) COMMENT 'Header picture',
 	`addr` varchar(255) COMMENT '',
 	`alias` varchar(255) COMMENT '',
 	`pubkey` text COMMENT '',
@@ -2256,6 +2258,7 @@ CREATE VIEW `owner-view` AS SELECT
 	`contact`.`photo` AS `photo`,
 	`contact`.`thumb` AS `thumb`,
 	`contact`.`micro` AS `micro`,
+	`contact`.`header` AS `header`,
 	`contact`.`site-pubkey` AS `site-pubkey`,
 	`contact`.`issued-id` AS `issued-id`,
 	`contact`.`dfrn-id` AS `dfrn-id`,

--- a/doc/database/db_apcontact.md
+++ b/doc/database/db_apcontact.md
@@ -21,6 +21,7 @@ Fields
 | name             |                              | varchar(255)   | YES  |     | NULL                |       |
 | about            |                              | text           | YES  |     | NULL                |       |
 | photo            |                              | varchar(255)   | YES  |     | NULL                |       |
+| header           | Header picture               | varchar(255)   | YES  |     | NULL                |       |
 | addr             |                              | varchar(255)   | YES  |     | NULL                |       |
 | alias            |                              | varchar(255)   | YES  |     | NULL                |       |
 | pubkey           |                              | text           | YES  |     | NULL                |       |

--- a/doc/database/db_contact.md
+++ b/doc/database/db_contact.md
@@ -30,6 +30,7 @@ Fields
 | photo                     | Link to the profile photo of the contact                  | varchar(255)       | YES  |     |                     |                |
 | thumb                     | Link to the profile photo (thumb size)                    | varchar(255)       | YES  |     |                     |                |
 | micro                     | Link to the profile photo (micro size)                    | varchar(255)       | YES  |     |                     |                |
+| header                    | Header picture                                            | varchar(255)       | YES  |     | NULL                |                |
 | site-pubkey               |                                                           | text               | YES  |     | NULL                |                |
 | issued-id                 |                                                           | varchar(255)       | NO   |     |                     |                |
 | dfrn-id                   |                                                           | varchar(255)       | NO   |     |                     |                |

--- a/mod/cal.php
+++ b/mod/cal.php
@@ -67,7 +67,7 @@ function cal_init(App $a)
 		return;
 	}
 
-	$a->profile = Profile::getByNickname($nick, $a->profile_uid);
+	$a->profile = Profile::getByNickname($nick);
 	if (empty($a->profile)) {
 		throw new HTTPException\NotFoundException(DI::l10n()->t('User not found.'));
 	}

--- a/mod/photos.php
+++ b/mod/photos.php
@@ -73,7 +73,7 @@ function photos_init(App $a) {
 		$a->profile_uid = $user['uid'];
 		$is_owner = (local_user() && (local_user() == $a->profile_uid));
 
-		$profile = Profile::getByNickname($nick, $a->profile_uid);
+		$profile = Profile::getByNickname($nick);
 
 		$account_type = Contact::getAccountType($profile);
 

--- a/mod/videos.php
+++ b/mod/videos.php
@@ -56,7 +56,7 @@ function videos_init(App $a)
 		$a->data['user'] = $user[0];
 		$a->profile_uid = $user[0]['uid'];
 
-		$profile = Profile::getByNickname($nick, $a->profile_uid);
+		$profile = Profile::getByNickname($nick);
 
 		$account_type = Contact::getAccountType($profile);
 

--- a/src/Core/Update.php
+++ b/src/Core/Update.php
@@ -213,6 +213,8 @@ class Update
 					if ($sendMail) {
 						self::updateSuccessful($stored, $current);
 					}
+				} else {
+					Logger::warning('Update lock could not be acquired');
 				}
 			}
 		}

--- a/src/Model/APContact.php
+++ b/src/Model/APContact.php
@@ -211,6 +211,11 @@ class APContact
 			$apcontact['photo'] = JsonLD::fetchElement($compacted['as:icon'], 'as:url', '@id');
 		}
 
+		$apcontact['header'] = JsonLD::fetchElement($compacted, 'as:image', '@id');
+		if (is_array($apcontact['header']) || !empty($compacted['as:image']['as:url']['@id'])) {
+			$apcontact['header'] = JsonLD::fetchElement($compacted['as:image'], 'as:url', '@id');
+		}
+
 		if (empty($apcontact['alias'])) {
 			$apcontact['alias'] = JsonLD::fetchElement($compacted, 'as:url', '@id');
 			if (is_array($apcontact['alias'])) {

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -1103,7 +1103,7 @@ class Contact
 		if (($uid == 0) && (empty($data['network']) || ($data['network'] == Protocol::PHANTOM))) {
 			// Fetch data for the public contact via the first found personal contact
 			/// @todo Check if this case can happen at all (possibly with mail accounts?)
-			$fields = ['name', 'nick', 'url', 'addr', 'alias', 'avatar', 'contact-type',
+			$fields = ['name', 'nick', 'url', 'addr', 'alias', 'avatar', 'header', 'contact-type',
 				'keywords', 'location', 'about', 'unsearchable', 'batch', 'notify', 'poll',
 				'request', 'confirm', 'poco', 'subscribe', 'network', 'baseurl', 'gsid'];
 
@@ -1949,8 +1949,8 @@ class Contact
 		// These fields aren't updated by this routine:
 		// 'xmpp', 'sensitive'
 
-		$fields = ['uid', 'avatar', 'name', 'nick', 'location', 'keywords', 'about', 'subscribe', 'manually-approve',
-			'unsearchable', 'url', 'addr', 'batch', 'notify', 'poll', 'request', 'confirm', 'poco',
+		$fields = ['uid', 'avatar', 'header', 'name', 'nick', 'location', 'keywords', 'about', 'subscribe',
+			'manually-approve', 'unsearchable', 'url', 'addr', 'batch', 'notify', 'poll', 'request', 'confirm', 'poco',
 			'network', 'alias', 'baseurl', 'gsid', 'forum', 'prv', 'contact-type', 'pubkey', 'last-item'];
 		$contact = DBA::selectFirst('contact', $fields, ['id' => $id]);
 		if (!DBA::isResult($contact)) {

--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -283,24 +283,17 @@ class Profile
 	}
 
 	/**
-	 * Get all profile data of a local user
-	 *
-	 * If the viewer is an authenticated remote viewer, the profile displayed is the
-	 * one that has been configured for his/her viewing in the Contact manager.
-	 * Passing a non-zero profile ID can also allow a preview of a selected profile
-	 * by the owner
+	 * Get the profile for the given nick name
 	 *
 	 * Includes all available profile data
 	 *
 	 * @param string $nickname   nick
-	 * @param int    $uid        uid
-	 * @param int    $profile_id ID of the profile
 	 * @return array
 	 * @throws \Exception
 	 */
-	public static function getByNickname($nickname, $uid = 0)
+	public static function getByNickname($nickname)
 	{
-		$profile = DBA::selectFirst('owner-view', [], ['nickname' => $nickname, 'uid' => $uid]);
+		$profile = DBA::selectFirst('owner-view', [], ['nickname' => $nickname]);
 		return $profile;
 	}
 

--- a/src/Module/NoScrape.php
+++ b/src/Module/NoScrape.php
@@ -50,7 +50,7 @@ class NoScrape extends BaseModule
 			System::jsonError(403, 'Authentication required');
 		}
 
-		$profile = Profile::getByNickname($which, local_user());
+		$profile = Profile::getByNickname($which);
 
 		if (empty($profile['uid'])) {
 			System::jsonError(404, 'Profile not found');

--- a/src/Network/Probe.php
+++ b/src/Network/Probe.php
@@ -87,8 +87,8 @@ class Probe
 	 */
 	private static function rearrangeData($data)
 	{
-		$fields = ["name", "nick", "guid", "url", "addr", "alias", "photo", "account-type",
-				"community", "keywords", "location", "about", "hide",
+		$fields = ["name", "nick", "guid", "url", "addr", "alias", "photo", "header",
+				"account-type", "community", "keywords", "location", "about", "hide",
 				"batch", "notify", "poll", "request", "confirm", "subscribe", "poco",
 				"following", "followers", "inbox", "outbox", "sharedinbox",
 				"priority", "network", "pubkey", "manually-approve", "baseurl", "gsid"];
@@ -1016,18 +1016,18 @@ class Probe
 		$curlResult = DI::httpRequest()->get($noscrape_url);
 		if ($curlResult->isTimeout()) {
 			self::$istimeout = true;
-			return [];
+			return $data;
 		}
 		$content = $curlResult->getBody();
 		if (!$content) {
 			Logger::info('Empty body', ['url' => $noscrape_url]);
-			return [];
+			return $data;
 		}
 
 		$json = json_decode($content, true);
 		if (!is_array($json)) {
 			Logger::info('No json data', ['url' => $noscrape_url]);
-			return [];
+			return $data;
 		}
 
 		if (!empty($json["fn"])) {
@@ -2222,7 +2222,7 @@ class Probe
 
 		$data = ['name' => $profile['name'], 'nick' => $profile['nick'], 'guid' => $approfile['diaspora:guid'] ?? '',
 			'url' => $profile['url'], 'addr' => $profile['addr'], 'alias' => $profile['alias'],
-			'photo' => $profile['photo'], 'account-type' => $profile['contact-type'],
+			'photo' => $profile['photo'], 'header' => $profile['header'], 'account-type' => $profile['contact-type'],
 			'community' => ($profile['contact-type'] == User::ACCOUNT_TYPE_COMMUNITY),
 			'keywords' => $profile['keywords'], 'location' => $profile['location'], 'about' => $profile['about'], 
 			'hide' => !$profile['net-publish'], 'batch' => '', 'notify' => $profile['notify'],

--- a/src/Object/Api/Mastodon/Account.php
+++ b/src/Object/Api/Mastodon/Account.php
@@ -114,9 +114,8 @@ class Account extends BaseDataTransferObject
 		$this->url             = $publicContact['url'];
 		$this->avatar          = $userContact['avatar'] ?? $publicContact['avatar'];
 		$this->avatar_static   = $userContact['avatar'] ?? $publicContact['avatar'];
-		// No header picture in Friendica
-		$this->header          = '';
-		$this->header_static   = '';
+		$this->header          = ($userContact['header'] ?? $publicContact['header']) ?? '';
+		$this->header_static   = ($userContact['header'] ?? $publicContact['header']) ?? '';
 		$this->followers_count = $apcontact['followers_count'] ?? 0;
 		$this->following_count = $apcontact['following_count'] ?? 0;
 		$this->statuses_count  = $apcontact['statuses_count'] ?? 0;

--- a/src/Protocol/ActivityPub.php
+++ b/src/Protocol/ActivityPub.php
@@ -151,6 +151,7 @@ class ActivityPub
 		$profile['outbox'] = $apcontact['outbox'];
 		$profile['sharedinbox'] = $apcontact['sharedinbox'];
 		$profile['photo'] = $apcontact['photo'];
+		$profile['header'] = $apcontact['header'];
 		$profile['account-type'] = self::getAccountType($apcontact);
 		$profile['community'] = ($profile['account-type'] == User::ACCOUNT_TYPE_COMMUNITY);
 		// $profile['keywords']

--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -55,7 +55,7 @@
 use Friendica\Database\DBA;
 
 if (!defined('DB_UPDATE_VERSION')) {
-	define('DB_UPDATE_VERSION', 1422);
+	define('DB_UPDATE_VERSION', 1423);
 }
 
 return [
@@ -177,6 +177,7 @@ return [
 			"photo" => ["type" => "varchar(255)", "default" => "", "comment" => "Link to the profile photo of the contact"],
 			"thumb" => ["type" => "varchar(255)", "default" => "", "comment" => "Link to the profile photo (thumb size)"],
 			"micro" => ["type" => "varchar(255)", "default" => "", "comment" => "Link to the profile photo (micro size)"],
+			"header" => ["type" => "varchar(255)", "comment" => "Header picture"],
 			"site-pubkey" => ["type" => "text", "comment" => ""],
 			"issued-id" => ["type" => "varchar(255)", "not null" => "1", "default" => "", "comment" => ""],
 			"dfrn-id" => ["type" => "varchar(255)", "not null" => "1", "default" => "", "comment" => ""],
@@ -404,6 +405,7 @@ return [
 			"name" => ["type" => "varchar(255)", "comment" => ""],
 			"about" => ["type" => "text", "comment" => ""],
 			"photo" => ["type" => "varchar(255)", "comment" => ""],
+			"header" => ["type" => "varchar(255)", "comment" => "Header picture"],
 			"addr" => ["type" => "varchar(255)", "comment" => ""],
 			"alias" => ["type" => "varchar(255)", "comment" => ""],
 			"pubkey" => ["type" => "text", "comment" => ""],

--- a/static/dbview.config.php
+++ b/static/dbview.config.php
@@ -723,6 +723,7 @@
 			"photo" => ["contact", "photo"],
 			"thumb" => ["contact", "thumb"],
 			"micro" => ["contact", "micro"],
+			"header" => ["contact", "header"],
 			"site-pubkey" => ["contact", "site-pubkey"],
 			"issued-id" => ["contact", "issued-id"],
 			"dfrn-id" => ["contact", "dfrn-id"],


### PR DESCRIPTION
This PR started with adding the "header" field, then I realized that we currently don't recognize Friendica systems as Friendica systems. And interestingly the fetching of the noscrape endpoint contained a problem when the endpoint couldn't be pulled. Also the publishing of the noscrape endpoint had a problem when fetching the profile data.

This is all fixed now.