### PR TITLE
An empty user id does not have children

### DIFF
--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -1505,6 +1505,10 @@ class User
 	 */
 	public static function identities($uid)
 	{
+		if (empty($uid)) {
+			return [];
+		}
+
 		$identities = [];
 
 		$user = DBA::selectFirst('user', ['uid', 'nickname', 'username', 'parent-uid'], ['uid' => $uid]);

--- a/src/Security/Authentication.php
+++ b/src/Security/Authentication.php
@@ -342,8 +342,10 @@ class Authentication
 			$this->dba->update('user', ['login_date' => DateTimeFormat::utcNow()], ['uid' => $user_record['uid']]);
 
 			// Set the login date for all identities of the user
-			$this->dba->update('user', ['login_date' => DateTimeFormat::utcNow()],
-				['parent-uid' => $masterUid, 'account_removed' => false]);
+			if (!empty($masterUid)) {
+				$this->dba->update('user', ['login_date' => DateTimeFormat::utcNow()],
+					['parent-uid' => $masterUid, 'account_removed' => false]);
+			}
 		}
 
 		if ($login_initial) {


### PR DESCRIPTION
While having a look at issue #10415 I saw on my system most users had got the same last login - which seemed suspicious. I realized that this had happened with users who had got no parent user - and the system user as well. That the system user got some login had been a short living problem during testing and was quickly fixed. (And is not a topic for this PR)

This PR just adds checks so that users with an empty parent-uid aren't treated as children of the system user.