### PR TITLE
Context: use the correct "select functionality

### DIFF
--- a/src/Module/Api/Mastodon/Statuses/Context.php
+++ b/src/Module/Api/Mastodon/Statuses/Context.php
@@ -58,8 +58,8 @@ class Context extends BaseApi
 		$parents  = [];
 		$children = [];
 
-		$posts = Post::select(['uri-id', 'thr-parent-id'],
-			['parent-uri-id' => $parent['parent-uri-id'], 'gravity' => [GRAVITY_PARENT, GRAVITY_COMMENT]], [], false);
+		$posts = Post::selectPosts(['uri-id', 'thr-parent-id'],
+			['parent-uri-id' => $parent['parent-uri-id'], 'gravity' => [GRAVITY_PARENT, GRAVITY_COMMENT]], []);
 		while ($post = Post::fetch($posts)) {
 			if ($post['uri-id'] == $post['thr-parent-id']) {
 				continue;


### PR DESCRIPTION
This was one of the calls that used the binary parameter for the "post" table. It had to be switched to the new function that act as replacement for this parameter.