### PR TITLE
Transmit mediaType, preparation for header image

### DIFF
--- a/src/Object/Api/Mastodon/Account.php
+++ b/src/Object/Api/Mastodon/Account.php
@@ -26,6 +26,7 @@ use Friendica\BaseDataTransferObject;
 use Friendica\Collection\Api\Mastodon\Fields;
 use Friendica\Content\Text\BBCode;
 use Friendica\Database\DBA;
+use Friendica\DI;
 use Friendica\Model\Contact;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Proxy;
@@ -115,7 +116,7 @@ class Account extends BaseDataTransferObject
 		$this->url             = $publicContact['url'];
 		$this->avatar          = ($userContact['photo'] ?? $publicContact['photo']) ?: Proxy::proxifyUrl($userContact['avatar'] ?? $publicContact['avatar']);
 		$this->avatar_static   = $this->avatar;
-		$this->header          = Proxy::proxifyUrl($userContact['header'] ?? $publicContact['header'] ?? '');
+		$this->header          = Proxy::proxifyUrl($userContact['header'] ?? $publicContact['header'] ?? '') ?: DI::baseUrl() . '/images/blank.png'; 
 		$this->header_static   = $this->header;
 		$this->followers_count = $apcontact['followers_count'] ?? 0;
 		$this->following_count = $apcontact['following_count'] ?? 0;

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -391,6 +391,14 @@ class Transmitter
 
 		if (!empty($contact['header'])) {
 			$data['image'] = ['type' => 'Image', 'url' => $contact['header']];
+
+			$resourceid = Photo::ridFromURI($contact['header']);
+			if (!empty($resourceid)) {
+				$photo = Photo::selectFirst(['type'], ["resource-id" => $resourceid]);
+				if (!empty($photo['type'])) {
+					$data['image']['mediaType'] = $photo['type'];
+				}
+			}
 		}
 
 		$data['generator'] = self::getService();

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -379,8 +379,19 @@ class Transmitter
 			'owner' => $contact['url'],
 			'publicKeyPem' => $user['pubkey']];
 		$data['endpoints'] = ['sharedInbox' => DI::baseUrl() . '/inbox'];
-		$data['icon'] = ['type' => 'Image',
-			'url' => $contact['photo']];
+		$data['icon'] = ['type' => 'Image', 'url' => $contact['photo']];
+
+		$resourceid = Photo::ridFromURI($contact['photo']);
+		if (!empty($resourceid)) {
+			$photo = Photo::selectFirst(['type'], ["resource-id" => $resourceid]);
+			if (!empty($photo['type'])) {
+				$data['icon']['mediaType'] = $photo['type'];
+			}
+		}
+
+		if (!empty($contact['header'])) {
+			$data['image'] = ['type' => 'Image', 'url' => $contact['header']];
+		}
 
 		$data['generator'] = self::getService();
 


### PR DESCRIPTION
This is a preparation for transmitting the header image once we can upload it to our profiles.

Also we now transmit the "mediaType" field.