### PR TITLE
API: Send "history" section for trends

### DIFF
--- a/src/Module/Api/Mastodon/Trends.php
+++ b/src/Module/Api/Mastodon/Trends.php
@@ -45,7 +45,8 @@ class Trends extends BaseApi
 		$tags = Tag::getGlobalTrendingHashtags(24, 20);
 		foreach ($tags as $tag) {
 			$tag['name'] = $tag['term'];
-			$hashtag = new \Friendica\Object\Api\Mastodon\Tag(DI::baseUrl(), $tag);
+			$history = [['day' => (string)time(), 'uses' => (string)$tag['score'], 'accounts' => (string)$tag['authors']]];
+			$hashtag = new \Friendica\Object\Api\Mastodon\Tag(DI::baseUrl(), $tag, $history);
 			$trending[] = $hashtag->toArray();
 		}
 

--- a/src/Object/Api/Mastodon/Tag.php
+++ b/src/Object/Api/Mastodon/Tag.php
@@ -35,6 +35,8 @@ class Tag extends BaseDataTransferObject
 	protected $name;
 	/** @var string */
 	protected $url = null;
+	/** @var array */
+	protected $history = [];
 
 	/**
 	 * Creates a hashtag record from an tag-view record.
@@ -43,9 +45,10 @@ class Tag extends BaseDataTransferObject
 	 * @param array   $tag     tag-view record
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
-	public function __construct(BaseURL $baseUrl, array $tag)
+	public function __construct(BaseURL $baseUrl, array $tag, array $history = [])
 	{
-		$this->name = strtolower($tag['name']);
-		$this->url  = $baseUrl . '/search?tag=' . urlencode($this->name);
+		$this->name    = strtolower($tag['name']);
+		$this->url     = $baseUrl . '/search?tag=' . urlencode($this->name);
+		$this->history = $history;
 	}
 }


### PR DESCRIPTION
Trending tags now work in Halcyon - after the history fields had been added.