### PR TITLE
Add ExternalStorage dependency to StorageManager

### DIFF
--- a/src/Core/StorageManager.php
+++ b/src/Core/StorageManager.php
@@ -25,6 +25,7 @@ use Exception;
 use Friendica\Core\Config\IConfig;
 use Friendica\Database\Database;
 use Friendica\Model\Storage;
+use Friendica\Network\IHTTPRequest;
 use Psr\Log\LoggerInterface;
 
 
@@ -60,6 +61,8 @@ class StorageManager
 	private $logger;
 	/** @var L10n */
 	private $l10n;
+	/** @var IHTTPRequest */
+	private $httpRequest;
 
 	/** @var Storage\IStorage */
 	private $currentBackend;
@@ -70,12 +73,13 @@ class StorageManager
 	 * @param LoggerInterface $logger
 	 * @param L10n            $l10n
 	 */
-	public function __construct(Database $dba, IConfig $config, LoggerInterface $logger, L10n $l10n)
+	public function __construct(Database $dba, IConfig $config, LoggerInterface $logger, L10n $l10n, IHTTPRequest $httpRequest)
 	{
-		$this->dba      = $dba;
-		$this->config   = $config;
-		$this->logger   = $logger;
-		$this->l10n     = $l10n;
+		$this->dba         = $dba;
+		$this->config      = $config;
+		$this->logger      = $logger;
+		$this->l10n        = $l10n;
+		$this->httpRequest = $httpRequest;
 		$this->backends = $config->get('storage', 'backends', self::DEFAULT_BACKENDS);
 
 		$currentName = $this->config->get('storage', 'name', '');
@@ -127,7 +131,7 @@ class StorageManager
 						$this->backendInstances[$name] = new Storage\SystemResource();
 						break;
 					case Storage\ExternalResource::getName():
-						$this->backendInstances[$name] = new Storage\ExternalResource();
+						$this->backendInstances[$name] = new Storage\ExternalResource($this->httpRequest);
 						break;
 					default:
 						$data = [


### PR DESCRIPTION
- Since ExternalStorage isn't instantiated automatically by Dice, we have to provide the dependency manually in StorageManager->getByName
- This requires StorageManager to take one additional dependency
- Tests are updated with this additional dependency

Follow-up to #10435