### PR TITLE
Improved avatar handling (timestamps for caching)

### DIFF
--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -507,9 +507,9 @@ class Profile
 			$p['address'] = BBCode::convert($p['address']);
 		}
 
-		$p['photo'] = Contact::getAvatarUrlForId($cid);
+		$p['photo'] = Contact::getAvatarUrlForId($cid, ProxyUtils::SIZE_SMALL);
 
-		$p['url'] = Contact::magicLink($profile_url);
+		$p['url'] = Contact::magicLinkById($cid);
 
 		$tpl = Renderer::getMarkupTemplate('profile/vcard.tpl');
 		$o .= Renderer::replaceMacros($tpl, [

--- a/src/Object/Api/Mastodon/Account.php
+++ b/src/Object/Api/Mastodon/Account.php
@@ -28,6 +28,7 @@ use Friendica\Content\Text\BBCode;
 use Friendica\Database\DBA;
 use Friendica\Model\Contact;
 use Friendica\Util\DateTimeFormat;
+use Friendica\Util\Proxy;
 
 /**
  * Class Account
@@ -112,9 +113,9 @@ class Account extends BaseDataTransferObject
 
 		$this->note            = BBCode::convert($publicContact['about'], false);
 		$this->url             = $publicContact['url'];
-		$this->avatar          = $userContact['photo'] ?? '' ?: $publicContact['photo'] ?: Contact::getAvatarUrlForId($userContact['id'] ?? 0 ?: $publicContact['id']);
+		$this->avatar          = Contact::getAvatarUrlForId($userContact['id'] ?? 0 ?: $publicContact['id'], Proxy::SIZE_SMALL, $userContact['updated'] ?? '' ?: $publicContact['updated']);
 		$this->avatar_static   = $this->avatar;
-		$this->header          = Contact::getHeaderUrlForId($userContact['id'] ?? 0 ?: $publicContact['id']);
+		$this->header          = Contact::getHeaderUrlForId($userContact['id'] ?? 0 ?: $publicContact['id'], '', $userContact['updated'] ?? '' ?: $publicContact['updated']);
 		$this->header_static   = $this->header;
 		$this->followers_count = $apcontact['followers_count'] ?? 0;
 		$this->following_count = $apcontact['following_count'] ?? 0;


### PR DESCRIPTION
We are now adding a timestamp value to avatar picture URLs to prevent caching issues when avatars had been changed. For performance reasons we can provide the "updated" value to the functions. This avoids a query. 