### PR TITLE
Unified avatar paths

### DIFF
--- a/include/conversation.php
+++ b/include/conversation.php
@@ -42,6 +42,7 @@ use Friendica\Object\Thread;
 use Friendica\Protocol\Activity;
 use Friendica\Util\Crypto;
 use Friendica\Util\DateTimeFormat;
+use Friendica\Util\Proxy;
 use Friendica\Util\Strings;
 use Friendica\Util\Temporal;
 use Friendica\Util\XML;
@@ -603,7 +604,7 @@ function conversation(App $a, array $items, $mode, $update, $preview = false, $o
 					'name' => $profile_name,
 					'sparkle' => $sparkle,
 					'lock' => false,
-					'thumb' => DI::baseUrl()->remove($item['author-avatar']),
+					'thumb' => DI::baseUrl()->remove(Contact::getAvatarUrlForUrl($item['author-link'], $item['uid'], Proxy::SIZE_THUMB)),
 					'title' => $title,
 					'body_html' => $body_html,
 					'tags' => $tags['tags'],

--- a/mod/ping.php
+++ b/mod/ping.php
@@ -33,6 +33,7 @@ use Friendica\Model\Post;
 use Friendica\Model\Verb;
 use Friendica\Protocol\Activity;
 use Friendica\Util\DateTimeFormat;
+use Friendica\Util\Proxy;
 use Friendica\Util\Temporal;
 use Friendica\Util\XML;
 
@@ -340,13 +341,9 @@ function ping_init(App $a)
 		usort($notifications, $sort_function);
 
 		array_walk($notifications, function (&$notification) {
-			if (empty($notification['photo'])) {
-				$contact = Contact::getByURL($notification['url'], false, ['micro', 'id', 'avatar']);
-				$notification['photo'] = Contact::getMicro($contact, $notification['photo']);
-			}
-
+			$notification['photo']     = Contact::getAvatarUrlForUrl($notification['url'], local_user(), Proxy::SIZE_MICRO);
 			$notification['timestamp'] = DateTimeFormat::local($notification['date']);
-			$notification['date'] = Temporal::getRelativeDate($notification['date']);
+			$notification['date']      = Temporal::getRelativeDate($notification['date']);
 		});
 	}
 

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -1501,10 +1501,10 @@ class Contact
 	{
 		if (!empty($contact)) {
 			$contact = self::checkAvatarCacheByArray($contact, $no_update);
-			if (!empty($contact[$field])) {
-				return $contact[$field];
-			} elseif (!empty($contact['id'])) {
+			if (!empty($contact['id'])) {
 				return self::getAvatarUrlForId($contact['id'], $size, $contact['updated'] ?? '');
+			} elseif (!empty($contact[$field])) {
+				return $contact[$field];
 			} elseif (!empty($contact['avatar'])) {
 				$avatar = $contact['avatar'];
 			}
@@ -1713,7 +1713,7 @@ class Contact
 		$condition = ["`nurl` = ? AND ((`uid` = ? AND `network` IN (?, ?)) OR `uid` = ?)",
 			Strings::normaliseLink($url), $uid, Protocol::FEED, Protocol::MAIL, 0];
 		$contact = self::selectFirst(['id', 'updated'], $condition);
-		return self::getAvatarUrlForId($contact['id'] ?? 0, $size, $contact['updated']);
+		return self::getAvatarUrlForId($contact['id'] ?? 0, $size, $contact['updated'] ?? '');
 	}
 
 	/**

--- a/src/Module/NoScrape.php
+++ b/src/Module/NoScrape.php
@@ -26,6 +26,7 @@ use Friendica\Core\Protocol;
 use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\DI;
+use Friendica\Model\Contact;
 use Friendica\Model\Profile;
 use Friendica\Model\User;
 
@@ -80,10 +81,8 @@ class NoScrape extends BaseModule
 		$keywords = str_replace(['#', ',', ' ', ',,'], ['', ' ', ',', ','], $keywords);
 		$keywords = explode(',', $keywords);
 
-		$contactPhoto = DBA::selectFirst('contact', ['photo'], ['self' => true, 'uid' => $profile['uid']]);
-
 		$json_info['fn']       = $profile['name'];
-		$json_info['photo']    = $contactPhoto["photo"];
+		$json_info['photo']    = Contact::getAvatarUrlForUrl($profile['url'], $profile['uid']);
 		$json_info['tags']     = $keywords;
 		$json_info['language'] = $profile['language'];
 

--- a/src/Module/Photo.php
+++ b/src/Module/Photo.php
@@ -191,6 +191,14 @@ class Photo extends BaseModule
 					$contact = Contact::getByURL($contact['url'], false, ['avatar', 'photo', 'xmpp', 'addr']);
 				}
 				if (!empty($contact['photo'])) {
+					// Fetch photo directly
+					$resourceid = MPhoto::ridFromURI($contact['photo']);
+					if (!empty($resourceid)) {
+						$photo = MPhoto::selectFirst([], ['resource-id' => $resourceid], ['order' => ['scale']]);
+						if (!empty($photo)) {
+							return $photo;
+						}
+					}
 					$url = $contact['photo'];
 				} elseif (!empty($contact['avatar'])) {
 					$url = $contact['avatar'];

--- a/src/Object/Post.php
+++ b/src/Object/Post.php
@@ -39,6 +39,7 @@ use Friendica\Model\User;
 use Friendica\Protocol\Activity;
 use Friendica\Util\Crypto;
 use Friendica\Util\DateTimeFormat;
+use Friendica\Util\Proxy;
 use Friendica\Util\Strings;
 use Friendica\Util\Temporal;
 
@@ -459,7 +460,7 @@ class Post
 			'profile_url'     => $profile_link,
 			'name'            => $profile_name,
 			'item_photo_menu_html' => item_photo_menu($item),
-			'thumb'           => DI::baseUrl()->remove($item['author-avatar']),
+			'thumb'           => DI::baseUrl()->remove(Contact::getAvatarUrlForUrl($item['author-link'], $item['uid'], Proxy::SIZE_THUMB)),
 			'osparkle'        => $osparkle,
 			'sparkle'         => $sparkle,
 			'title'           => $title,

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -331,7 +331,7 @@ class Transmitter
 				return [];
 			}
 
-			$fields = ['name', 'url', 'location', 'about', 'avatar', 'photo'];
+			$fields = ['id', 'name', 'url', 'location', 'about', 'avatar', 'photo', 'updated'];
 			$contact = DBA::selectFirst('contact', $fields, ['uid' => $uid, 'self' => true]);
 			if (!DBA::isResult($contact)) {
 				return [];
@@ -379,7 +379,7 @@ class Transmitter
 			'owner' => $contact['url'],
 			'publicKeyPem' => $user['pubkey']];
 		$data['endpoints'] = ['sharedInbox' => DI::baseUrl() . '/inbox'];
-		$data['icon'] = ['type' => 'Image', 'url' => $contact['photo']];
+		$data['icon'] = ['type' => 'Image', 'url' => Contact::getAvatarUrlForId($contact['id'], '', $contact['updated'])];
 
 		$resourceid = Photo::ridFromURI($contact['photo']);
 		if (!empty($resourceid)) {
@@ -390,7 +390,7 @@ class Transmitter
 		}
 
 		if (!empty($contact['header'])) {
-			$data['image'] = ['type' => 'Image', 'url' => $contact['header']];
+			$data['image'] = ['type' => 'Image', 'url' => Contact::getHeaderUrlForId($contact['id'], '', $contact['updated'])];
 
 			$resourceid = Photo::ridFromURI($contact['header']);
 			if (!empty($resourceid)) {


### PR DESCRIPTION
This is a preparation for work that can be finished in the next version. For the time being we stored every avatar picture for an active contact in our "photo" table. For this reason that table really got huge.

This PR changes the paths to the contact avatars to a new path structure where we can dynamically fetch the avatar picture from a local or remote resource without changing that path. So in the future we will be able adding an option to store or not store the cached contact avatar data in the photo table without a problem.