### PR TITLE
AP: Support "discoverable"

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -1,6 +1,6 @@
 -- ------------------------------------------
 -- Friendica 2021.06-rc (Siberian Iris)
--- DB_UPDATE_VERSION 1423
+-- DB_UPDATE_VERSION 1424
 -- ------------------------------------------
 
 
@@ -340,6 +340,7 @@ CREATE TABLE IF NOT EXISTS `apcontact` (
 	`outbox` varchar(255) COMMENT '',
 	`sharedinbox` varchar(255) COMMENT '',
 	`manually-approve` boolean COMMENT '',
+	`discoverable` boolean COMMENT 'Mastodon extension: true if profile is published in their directory',
 	`nick` varchar(255) NOT NULL DEFAULT '' COMMENT '',
 	`name` varchar(255) COMMENT '',
 	`about` text COMMENT '',

--- a/doc/database/db_apcontact.md
+++ b/doc/database/db_apcontact.md
@@ -6,33 +6,34 @@ ActivityPub compatible contacts - used in the ActivityPub implementation
 Fields
 ------
 
-| Field            | Description                  | Type           | Null | Key | Default             | Extra |
-| ---------------- | ---------------------------- | -------------- | ---- | --- | ------------------- | ----- |
-| url              | URL of the contact           | varbinary(255) | NO   | PRI | NULL                |       |
-| uuid             |                              | varchar(255)   | YES  |     | NULL                |       |
-| type             |                              | varchar(20)    | NO   |     | NULL                |       |
-| following        |                              | varchar(255)   | YES  |     | NULL                |       |
-| followers        |                              | varchar(255)   | YES  |     | NULL                |       |
-| inbox            |                              | varchar(255)   | NO   |     | NULL                |       |
-| outbox           |                              | varchar(255)   | YES  |     | NULL                |       |
-| sharedinbox      |                              | varchar(255)   | YES  |     | NULL                |       |
-| manually-approve |                              | boolean        | YES  |     | NULL                |       |
-| nick             |                              | varchar(255)   | NO   |     |                     |       |
-| name             |                              | varchar(255)   | YES  |     | NULL                |       |
-| about            |                              | text           | YES  |     | NULL                |       |
-| photo            |                              | varchar(255)   | YES  |     | NULL                |       |
-| header           | Header picture               | varchar(255)   | YES  |     | NULL                |       |
-| addr             |                              | varchar(255)   | YES  |     | NULL                |       |
-| alias            |                              | varchar(255)   | YES  |     | NULL                |       |
-| pubkey           |                              | text           | YES  |     | NULL                |       |
-| subscribe        |                              | varchar(255)   | YES  |     | NULL                |       |
-| baseurl          | baseurl of the ap contact    | varchar(255)   | YES  |     | NULL                |       |
-| gsid             | Global Server ID             | int unsigned   | YES  |     | NULL                |       |
-| generator        | Name of the contact's system | varchar(255)   | YES  |     | NULL                |       |
-| following_count  | Number of following contacts | int unsigned   | YES  |     | 0                   |       |
-| followers_count  | Number of followers          | int unsigned   | YES  |     | 0                   |       |
-| statuses_count   | Number of posts              | int unsigned   | YES  |     | 0                   |       |
-| updated          |                              | datetime       | NO   |     | 0001-01-01 00:00:00 |       |
+| Field            | Description                                                         | Type           | Null | Key | Default             | Extra |
+| ---------------- | ------------------------------------------------------------------- | -------------- | ---- | --- | ------------------- | ----- |
+| url              | URL of the contact                                                  | varbinary(255) | NO   | PRI | NULL                |       |
+| uuid             |                                                                     | varchar(255)   | YES  |     | NULL                |       |
+| type             |                                                                     | varchar(20)    | NO   |     | NULL                |       |
+| following        |                                                                     | varchar(255)   | YES  |     | NULL                |       |
+| followers        |                                                                     | varchar(255)   | YES  |     | NULL                |       |
+| inbox            |                                                                     | varchar(255)   | NO   |     | NULL                |       |
+| outbox           |                                                                     | varchar(255)   | YES  |     | NULL                |       |
+| sharedinbox      |                                                                     | varchar(255)   | YES  |     | NULL                |       |
+| manually-approve |                                                                     | boolean        | YES  |     | NULL                |       |
+| discoverable     | Mastodon extension: true if profile is published in their directory | boolean        | YES  |     | NULL                |       |
+| nick             |                                                                     | varchar(255)   | NO   |     |                     |       |
+| name             |                                                                     | varchar(255)   | YES  |     | NULL                |       |
+| about            |                                                                     | text           | YES  |     | NULL                |       |
+| photo            |                                                                     | varchar(255)   | YES  |     | NULL                |       |
+| header           | Header picture                                                      | varchar(255)   | YES  |     | NULL                |       |
+| addr             |                                                                     | varchar(255)   | YES  |     | NULL                |       |
+| alias            |                                                                     | varchar(255)   | YES  |     | NULL                |       |
+| pubkey           |                                                                     | text           | YES  |     | NULL                |       |
+| subscribe        |                                                                     | varchar(255)   | YES  |     | NULL                |       |
+| baseurl          | baseurl of the ap contact                                           | varchar(255)   | YES  |     | NULL                |       |
+| gsid             | Global Server ID                                                    | int unsigned   | YES  |     | NULL                |       |
+| generator        | Name of the contact's system                                        | varchar(255)   | YES  |     | NULL                |       |
+| following_count  | Number of following contacts                                        | int unsigned   | YES  |     | 0                   |       |
+| followers_count  | Number of followers                                                 | int unsigned   | YES  |     | 0                   |       |
+| statuses_count   | Number of posts                                                     | int unsigned   | YES  |     | 0                   |       |
+| updated          |                                                                     | datetime       | NO   |     | 0001-01-01 00:00:00 |       |
 
 Indexes
 ------------

--- a/src/Model/APContact.php
+++ b/src/Model/APContact.php
@@ -284,6 +284,8 @@ class APContact
 			}
 		}
 
+		$apcontact['discoverable'] = JsonLD::fetchElement($compacted, 'toot:discoverable', '@value');
+
 		// To-Do
 
 		// Unhandled

--- a/src/Protocol/ActivityPub.php
+++ b/src/Protocol/ActivityPub.php
@@ -65,9 +65,11 @@ class ActivityPub
 		'dfrn' => 'http://purl.org/macgirvin/dfrn/1.0/',
 		'diaspora' => 'https://diasporafoundation.org/ns/',
 		'litepub' => 'http://litepub.social/ns#',
+		'toot' => 'http://joinmastodon.org/ns#',
 		'manuallyApprovesFollowers' => 'as:manuallyApprovesFollowers',
 		'sensitive' => 'as:sensitive', 'Hashtag' => 'as:Hashtag',
-		'directMessage' => 'litepub:directMessage']];
+		'directMessage' => 'litepub:directMessage',
+		'discoverable' => 'toot:discoverable']];
 	const ACCOUNT_TYPES = ['Person', 'Organization', 'Service', 'Group', 'Application', 'Tombstone'];
 	/**
 	 * Checks if the web request is done for the AP protocol
@@ -165,6 +167,10 @@ class ActivityPub
 		$profile['manually-approve'] = $apcontact['manually-approve'];
 		$profile['baseurl'] = $apcontact['baseurl'];
 		$profile['gsid'] = $apcontact['gsid'];
+
+		if (!is_null($apcontact['discoverable'])) {
+			$profile['hide'] = !$apcontact['discoverable'];
+		}
 
 		// Remove all "null" fields
 		foreach ($profile as $field => $content) {

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -325,7 +325,7 @@ class Transmitter
 				return [];
 			}
 
-			$fields = ['locality', 'region', 'country-name'];
+			$fields = ['locality', 'region', 'country-name', 'net-publish'];
 			$profile = DBA::selectFirst('profile', $fields, ['uid' => $uid]);
 			if (!DBA::isResult($profile)) {
 				return [];
@@ -340,7 +340,7 @@ class Transmitter
 			$contact = User::getSystemAccount();
 			$user = ['guid' => '', 'nickname' => $contact['nick'], 'pubkey' => $contact['pubkey'],
 				'account-type' => $contact['contact-type'], 'page-flags' => User::PAGE_FLAGS_NORMAL];
-			$profile = ['locality' => '', 'region' => '', 'country-name' => ''];
+			$profile = ['locality' => '', 'region' => '', 'country-name' => '', 'net-publish' => false];
 		}
 
 		$data = ['@context' => ActivityPub::CONTEXT];
@@ -375,6 +375,7 @@ class Transmitter
 
 		$data['url'] = $contact['url'];
 		$data['manuallyApprovesFollowers'] = in_array($user['page-flags'], [User::PAGE_FLAGS_NORMAL, User::PAGE_FLAGS_PRVGROUP]);
+		$data['discoverable'] = $profile['net-publish'];
 		$data['publicKey'] = ['id' => $contact['url'] . '#main-key',
 			'owner' => $contact['url'],
 			'publicKeyPem' => $user['pubkey']];

--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -55,7 +55,7 @@
 use Friendica\Database\DBA;
 
 if (!defined('DB_UPDATE_VERSION')) {
-	define('DB_UPDATE_VERSION', 1423);
+	define('DB_UPDATE_VERSION', 1424);
 }
 
 return [
@@ -401,6 +401,7 @@ return [
 			"outbox" => ["type" => "varchar(255)", "comment" => ""],
 			"sharedinbox" => ["type" => "varchar(255)", "comment" => ""],
 			"manually-approve" => ["type" => "boolean", "comment" => ""],
+			"discoverable" => ["type" => "boolean", "comment" => "Mastodon extension: true if profile is published in their directory"],
 			"nick" => ["type" => "varchar(255)", "not null" => "1", "default" => "", "comment" => ""],
 			"name" => ["type" => "varchar(255)", "comment" => ""],
 			"about" => ["type" => "text", "comment" => ""],


### PR DESCRIPTION
Mastodon extended the AP protocol by adding a parameter that indicates if an account is discoverable - which is the same as our profile field "net-publish". So we should support it.