### PR TITLE
Quickfix for hashtags in author names in shared posts

### DIFF
--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -953,6 +953,10 @@ class BBCode
 	 */
 	public static function fetchShareAttributes($text)
 	{
+		// See Issue https://github.com/friendica/friendica/issues/10454
+		// Hashtags in usernames are expanded to links. This here is a quick fix. 
+		$text = preg_replace('/([@!#])\[url\=.*?\](.*?)\[\/url\]/ism', '$1$2', $text);
+
 		$attributes = [];
 		if (!preg_match("/(.*?)\[share(.*?)\](.*)\[\/share\]/ism", $text, $matches)) {
 			return $attributes;


### PR DESCRIPTION
This is a quickfix for #10454. Hashtags are expanded to links everywhere in the code, even in the author name field of a shared post.

This should be finally fixed at another place, but this is a working quickfix.