### PR TITLE
Transmit preview link

### DIFF
--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -126,6 +126,7 @@ class Processor
 		$data['url'] = $attachment['url'];
 		$data['mimetype'] = $attachment['mediaType'];
 		$data['height'] = $attachment['height'] ?? null;
+		$data['width'] = $attachment['width'] ?? null;
 		$data['size'] = $attachment['size'] ?? null;
 		$data['preview'] = $attachment['image'] ?? null;
 		$data['description'] = $attachment['name'] ?? null;

--- a/src/Protocol/ActivityPub/Receiver.php
+++ b/src/Protocol/ActivityPub/Receiver.php
@@ -1112,14 +1112,6 @@ class Receiver
 						'image' => $pageImage,
 					];
 					break;
-				case 'as:Link':
-					$attachlist[] = [
-						'type' => str_replace('as:', '', JsonLD::fetchElement($attachment, '@type')),
-						'mediaType' => JsonLD::fetchElement($attachment, 'as:mediaType', '@value'),
-						'name' => JsonLD::fetchElement($attachment, 'as:name', '@value'),
-						'url' => JsonLD::fetchElement($attachment, 'as:href', '@id')
-					];
-					break;
 				case 'as:Image':
 					$mediaType = JsonLD::fetchElement($attachment, 'as:mediaType', '@value');
 					$imageFullUrl = JsonLD::fetchElement($attachment, 'as:url', '@id');
@@ -1181,7 +1173,10 @@ class Receiver
 						'type' => str_replace('as:', '', JsonLD::fetchElement($attachment, '@type')),
 						'mediaType' => JsonLD::fetchElement($attachment, 'as:mediaType', '@value'),
 						'name' => JsonLD::fetchElement($attachment, 'as:name', '@value'),
-						'url' => JsonLD::fetchElement($attachment, 'as:url', '@id')
+						'url' => JsonLD::fetchElement($attachment, 'as:url', '@id'),
+						'height' => JsonLD::fetchElement($attachment, 'as:height', '@value'),
+						'width' => JsonLD::fetchElement($attachment, 'as:width', '@value'),
+						'image' => JsonLD::fetchElement($attachment, 'as:image', '@id')
 					];
 			}
 		}

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -143,7 +143,7 @@ class Transmitter
 
 		return $success;
 	}
-	
+
 	/**
 	 * Collects a list of contacts of the given owner
 	 *
@@ -351,7 +351,7 @@ class Transmitter
 		}
 
 		$data['type'] = ActivityPub::ACCOUNT_TYPES[$user['account-type']];
-		
+
 		if ($uid != 0) {
 			$data['following'] = DI::baseUrl() . '/following/' . $user['nickname'];
 			$data['followers'] = DI::baseUrl() . '/followers/' . $user['nickname'];
@@ -720,10 +720,10 @@ class Transmitter
 	/**
 	 * Check if a given contact should be delivered via AP
 	 *
-	 * @param array $contact 
-	 * @param array $networks 
-	 * @return bool 
-	 * @throws Exception 
+	 * @param array $contact
+	 * @param array $networks
+	 * @return bool
+	 * @throws Exception
 	 */
 	private static function isAPContact(array $contact, array $networks)
 	{
@@ -1079,7 +1079,7 @@ class Transmitter
 				if (!empty($self['uid'])) {
 					$forum_item = Post::selectFirst(Item::DELIVER_FIELDLIST, ['uri-id' => $item['uri-id'], 'uid' => $self['uid']]);
 					if (DBA::isResult($forum_item)) {
-						$item = $forum_item; 
+						$item = $forum_item;
 					}
 				}
 			}
@@ -1298,10 +1298,24 @@ class Transmitter
 				}
 				$urls[] = $attachment['url'];
 
-				$attachments[] = ['type' => 'Document',
+				$attach = ['type' => 'Document',
 					'mediaType' => $attachment['mimetype'],
 					'url' => $attachment['url'],
 					'name' => $attachment['description']];
+				
+				if (!empty($attachment['height'])) {
+					$attach['height'] = $attachment['height'];
+				}
+
+				if (!empty($attachment['width'])) {
+					$attach['width'] = $attachment['width'];
+				}
+	
+				if (!empty($attachment['preview'])) {
+					$attach['image'] = $attachment['preview'];
+				}
+
+				$attachments[] = $attach;
 			}
 		}
 
@@ -1316,10 +1330,24 @@ class Transmitter
 				}
 				$urls[] = $attachment['url'];
 
-				$attachments[] = ['type' => 'Document',
+				$attach = ['type' => 'Document',
 					'mediaType' => $attachment['mimetype'],
 					'url' => $attachment['url'],
 					'name' => $attachment['description']];
+				
+				if (!empty($attachment['height'])) {
+					$attach['height'] = $attachment['height'];
+				}
+
+				if (!empty($attachment['width'])) {
+					$attach['width'] = $attachment['width'];
+				}
+
+				if (!empty($attachment['preview'])) {
+					$attach['image'] = $attachment['preview'];
+				}
+
+				$attachments[] = $attach;	
 			}
 			// Currently deactivated, since it creates side effects on Mastodon and Pleroma.
 			// It will be activated, once this cleared.
@@ -1550,7 +1578,7 @@ class Transmitter
 		 * This part is currently deactivated. The automated summary seems to be more
 		 * confusing than helping. But possibly we will find a better way.
 		 * So the code is left here for now as a reminder
-		 * 
+		 *
 		 * } elseif (($type == 'Article') && empty($data['summary'])) {
 		 * 		$regexp = "/[@!]\[url\=([^\[\]]*)\].*?\[\/url\]/ism";
 		 * 		$summary = preg_replace_callback($regexp, ['self', 'mentionAddrCallback'], $body);


### PR DESCRIPTION
We now transmit the link to the preview image as well. This is a follow up to the PRs for handling private images, but also the PRs for reducing the usage of the `Proxy` class.