### PR TITLE
Removal of duplicated photo entries for a contact

### DIFF
--- a/src/Module/Photo.php
+++ b/src/Module/Photo.php
@@ -214,7 +214,7 @@ class Photo extends BaseModule
 				If (($contact['uid'] != 0) && empty($contact['photo']) && empty($contact['avatar'])) {
 					$contact = Contact::getByURL($contact['url'], false, ['avatar', 'photo', 'xmpp', 'addr']);
 				}
-				if (!empty($contact['photo'])) {
+				if (!empty($contact['photo']) && !empty($contact['avatar'])) {
 					// Fetch photo directly
 					$resourceid = MPhoto::ridFromURI($contact['photo']);
 					if (!empty($resourceid)) {
@@ -223,7 +223,8 @@ class Photo extends BaseModule
 							return $photo;
 						}
 					}
-					$url = $contact['photo'];
+					// We continue with the avatar link when the photo link is invalid
+					$url = $contact['avatar'];
 				} elseif (!empty($contact['avatar'])) {
 					$url = $contact['avatar'];
 				} elseif ($customsize <= Proxy::PIXEL_MICRO) {

--- a/src/Worker/RemoveUnusedAvatars.php
+++ b/src/Worker/RemoveUnusedAvatars.php
@@ -103,7 +103,7 @@ class RemoveUnusedAvatars
 		Logger::notice('Contact fix done', ['total' => $total, 'updated1' => $updated1, 'updated2' => $updated2, 'deleted' => $deleted]);
 	}
 
-	public static function deleteDuplicates()
+	private static function deleteDuplicates()
 	{
 		$size = [4 => 'photo', 5 => 'thumb', 6 => 'micro'];
 


### PR DESCRIPTION
We now remove contact photos from the photo table when they are duplicates.

Also a check had been introduced that the system defaults to the "avatar" link when the "photo" link in the contact table is invalid.