### PR TITLE
Allow search for only locally published contacts

### DIFF
--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -2989,7 +2989,8 @@ class Contact
 		$search .= '%';
 
 		$results = DBA::p("SELECT * FROM `contact`
-			WHERE NOT `unsearchable` AND `network` IN (?, ?, ?, ?) AND
+			WHERE (NOT `unsearchable` OR `nurl` IN (SELECT `nurl` FROM `owner-view` where `publish` OR `net-publish`))
+				AND `network` IN (?, ?, ?, ?) AND
 				NOT `failed` AND `uid` = ? AND
 				(`addr` LIKE ? OR `name` LIKE ? OR `nick` LIKE ?) $extra_sql
 				ORDER BY `nurl` DESC LIMIT 1000",

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: 2021.06-rc\n"
+"Project-Id-Version: 2021.09-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-06-27 23:18-0400\n"
+"POT-Creation-Date: 2021-07-04 19:56+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -37,9 +37,9 @@ msgstr[1] ""
 msgid "Monthly posting limit of %d post reached. The post was rejected."
 msgstr ""
 
-#: include/api.php:4527 mod/photos.php:107 mod/photos.php:211
-#: mod/photos.php:639 mod/photos.php:1043 mod/photos.php:1060
-#: mod/photos.php:1609 src/Model/User.php:1105 src/Model/User.php:1113
+#: include/api.php:4527 mod/photos.php:106 mod/photos.php:210
+#: mod/photos.php:638 mod/photos.php:1042 mod/photos.php:1059
+#: mod/photos.php:1608 src/Model/User.php:1105 src/Model/User.php:1113
 #: src/Model/User.php:1121 src/Module/Settings/Profile/Photo/Crop.php:98
 #: src/Module/Settings/Profile/Photo/Crop.php:114
 #: src/Module/Settings/Profile/Photo/Crop.php:130
@@ -49,178 +49,178 @@ msgstr ""
 msgid "Profile Photos"
 msgstr ""
 
-#: include/conversation.php:195
+#: include/conversation.php:196
 #, php-format
 msgid "%1$s poked %2$s"
 msgstr ""
 
-#: include/conversation.php:227 src/Model/Item.php:2609
+#: include/conversation.php:228 src/Model/Item.php:2609
 msgid "event"
 msgstr ""
 
-#: include/conversation.php:230 include/conversation.php:239 mod/tagger.php:90
+#: include/conversation.php:231 include/conversation.php:240 mod/tagger.php:90
 msgid "status"
 msgstr ""
 
-#: include/conversation.php:235 mod/tagger.php:90 src/Model/Item.php:2611
+#: include/conversation.php:236 mod/tagger.php:90 src/Model/Item.php:2611
 msgid "photo"
 msgstr ""
 
-#: include/conversation.php:249 mod/tagger.php:123
+#: include/conversation.php:250 mod/tagger.php:123
 #, php-format
 msgid "%1$s tagged %2$s's %3$s with %4$s"
 msgstr ""
 
-#: include/conversation.php:564 mod/photos.php:1470 src/Object/Post.php:226
+#: include/conversation.php:565 mod/photos.php:1469 src/Object/Post.php:226
 msgid "Select"
 msgstr ""
 
-#: include/conversation.php:565 mod/photos.php:1471 mod/settings.php:636
+#: include/conversation.php:566 mod/photos.php:1470 mod/settings.php:636
 #: src/Module/Admin/Users/Active.php:139 src/Module/Admin/Users/Blocked.php:140
 #: src/Module/Admin/Users/Index.php:153 src/Module/Contact.php:894
 #: src/Module/Contact.php:1198
 msgid "Delete"
 msgstr ""
 
-#: include/conversation.php:600 src/Object/Post.php:453 src/Object/Post.php:454
+#: include/conversation.php:601 src/Object/Post.php:453 src/Object/Post.php:454
 #, php-format
 msgid "View %s's profile @ %s"
 msgstr ""
 
-#: include/conversation.php:613 src/Object/Post.php:441
+#: include/conversation.php:614 src/Object/Post.php:441
 msgid "Categories:"
 msgstr ""
 
-#: include/conversation.php:614 src/Object/Post.php:442
+#: include/conversation.php:615 src/Object/Post.php:442
 msgid "Filed under:"
 msgstr ""
 
-#: include/conversation.php:621 src/Object/Post.php:467
+#: include/conversation.php:622 src/Object/Post.php:467
 #, php-format
 msgid "%s from %s"
 msgstr ""
 
-#: include/conversation.php:636
+#: include/conversation.php:637
 msgid "View in context"
 msgstr ""
 
-#: include/conversation.php:638 include/conversation.php:1222
+#: include/conversation.php:639 include/conversation.php:1223
 #: mod/editpost.php:104 mod/message.php:204 mod/message.php:374
-#: mod/photos.php:1536 mod/wallmessage.php:155 src/Module/Item/Compose.php:159
+#: mod/photos.php:1535 mod/wallmessage.php:155 src/Module/Item/Compose.php:159
 #: src/Object/Post.php:501
 msgid "Please wait"
 msgstr ""
 
-#: include/conversation.php:702
+#: include/conversation.php:703
 msgid "remove"
 msgstr ""
 
-#: include/conversation.php:707
+#: include/conversation.php:708
 msgid "Delete Selected Items"
 msgstr ""
 
-#: include/conversation.php:742 include/conversation.php:745
-#: include/conversation.php:748 include/conversation.php:751
+#: include/conversation.php:743 include/conversation.php:746
+#: include/conversation.php:749 include/conversation.php:752
 #, php-format
 msgid "You had been addressed (%s)."
 msgstr ""
 
-#: include/conversation.php:754
+#: include/conversation.php:755
 #, php-format
 msgid "You are following %s."
 msgstr ""
 
-#: include/conversation.php:757
+#: include/conversation.php:758
 msgid "Tagged"
 msgstr ""
 
-#: include/conversation.php:770 include/conversation.php:1114
-#: include/conversation.php:1152
+#: include/conversation.php:771 include/conversation.php:1115
+#: include/conversation.php:1153
 #, php-format
 msgid "%s reshared this."
 msgstr ""
 
-#: include/conversation.php:772
+#: include/conversation.php:773
 msgid "Reshared"
 msgstr ""
 
-#: include/conversation.php:772
+#: include/conversation.php:773
 #, php-format
 msgid "Reshared by %s <%s>"
 msgstr ""
 
-#: include/conversation.php:775
+#: include/conversation.php:776
 #, php-format
 msgid "%s is participating in this thread."
 msgstr ""
 
-#: include/conversation.php:778
+#: include/conversation.php:779
 msgid "Stored"
 msgstr ""
 
-#: include/conversation.php:781
+#: include/conversation.php:782
 msgid "Global"
 msgstr ""
 
-#: include/conversation.php:784
+#: include/conversation.php:785
 msgid "Relayed"
 msgstr ""
 
-#: include/conversation.php:784
+#: include/conversation.php:785
 #, php-format
 msgid "Relayed by %s <%s>"
 msgstr ""
 
-#: include/conversation.php:787
+#: include/conversation.php:788
 msgid "Fetched"
 msgstr ""
 
-#: include/conversation.php:787
+#: include/conversation.php:788
 #, php-format
 msgid "Fetched because of %s <%s>"
 msgstr ""
 
-#: include/conversation.php:947 view/theme/frio/theme.php:323
+#: include/conversation.php:948 view/theme/frio/theme.php:323
 msgid "Follow Thread"
 msgstr ""
 
-#: include/conversation.php:948 src/Model/Contact.php:1002
+#: include/conversation.php:949 src/Model/Contact.php:1002
 msgid "View Status"
 msgstr ""
 
-#: include/conversation.php:949 include/conversation.php:971
+#: include/conversation.php:950 include/conversation.php:972
 #: src/Model/Contact.php:928 src/Model/Contact.php:994
 #: src/Model/Contact.php:1003 src/Module/Directory.php:166
 #: src/Module/Settings/Profile/Index.php:224
 msgid "View Profile"
 msgstr ""
 
-#: include/conversation.php:950 src/Model/Contact.php:1004
+#: include/conversation.php:951 src/Model/Contact.php:1004
 msgid "View Photos"
 msgstr ""
 
-#: include/conversation.php:951 src/Model/Contact.php:995
+#: include/conversation.php:952 src/Model/Contact.php:995
 #: src/Model/Contact.php:1005
 msgid "Network Posts"
 msgstr ""
 
-#: include/conversation.php:952 src/Model/Contact.php:996
+#: include/conversation.php:953 src/Model/Contact.php:996
 #: src/Model/Contact.php:1006
 msgid "View Contact"
 msgstr ""
 
-#: include/conversation.php:953 src/Model/Contact.php:1008
+#: include/conversation.php:954 src/Model/Contact.php:1008
 msgid "Send PM"
 msgstr ""
 
-#: include/conversation.php:954 src/Module/Admin/Blocklist/Contact.php:84
+#: include/conversation.php:955 src/Module/Admin/Blocklist/Contact.php:84
 #: src/Module/Admin/Users/Active.php:140 src/Module/Admin/Users/Index.php:154
 #: src/Module/Contact.php:633 src/Module/Contact.php:891
 #: src/Module/Contact.php:1173
 msgid "Block"
 msgstr ""
 
-#: include/conversation.php:955 src/Module/Contact.php:634
+#: include/conversation.php:956 src/Module/Contact.php:634
 #: src/Module/Contact.php:892 src/Module/Contact.php:1181
 #: src/Module/Notifications/Introductions.php:113
 #: src/Module/Notifications/Introductions.php:191
@@ -228,273 +228,273 @@ msgstr ""
 msgid "Ignore"
 msgstr ""
 
-#: include/conversation.php:959 src/Object/Post.php:428
+#: include/conversation.php:960 src/Object/Post.php:428
 msgid "Languages"
 msgstr ""
 
-#: include/conversation.php:963 src/Model/Contact.php:1009
+#: include/conversation.php:964 src/Model/Contact.php:1009
 msgid "Poke"
 msgstr ""
 
-#: include/conversation.php:968 mod/follow.php:146 src/Content/Widget.php:76
+#: include/conversation.php:969 mod/follow.php:146 src/Content/Widget.php:76
 #: src/Model/Contact.php:997 src/Model/Contact.php:1010
 #: view/theme/vier/theme.php:172
 msgid "Connect/Follow"
 msgstr ""
 
-#: include/conversation.php:1099
+#: include/conversation.php:1100
 #, php-format
 msgid "%s likes this."
 msgstr ""
 
-#: include/conversation.php:1102
+#: include/conversation.php:1103
 #, php-format
 msgid "%s doesn't like this."
 msgstr ""
 
-#: include/conversation.php:1105
+#: include/conversation.php:1106
 #, php-format
 msgid "%s attends."
 msgstr ""
 
-#: include/conversation.php:1108
+#: include/conversation.php:1109
 #, php-format
 msgid "%s doesn't attend."
 msgstr ""
 
-#: include/conversation.php:1111
+#: include/conversation.php:1112
 #, php-format
 msgid "%s attends maybe."
 msgstr ""
 
-#: include/conversation.php:1120
+#: include/conversation.php:1121
 msgid "and"
 msgstr ""
 
-#: include/conversation.php:1123
+#: include/conversation.php:1124
 #, php-format
 msgid "and %d other people"
 msgstr ""
 
-#: include/conversation.php:1131
+#: include/conversation.php:1132
 #, php-format
 msgid "<span  %1$s>%2$d people</span> like this"
 msgstr ""
 
-#: include/conversation.php:1132
+#: include/conversation.php:1133
 #, php-format
 msgid "%s like this."
 msgstr ""
 
-#: include/conversation.php:1135
+#: include/conversation.php:1136
 #, php-format
 msgid "<span  %1$s>%2$d people</span> don't like this"
 msgstr ""
 
-#: include/conversation.php:1136
+#: include/conversation.php:1137
 #, php-format
 msgid "%s don't like this."
 msgstr ""
 
-#: include/conversation.php:1139
+#: include/conversation.php:1140
 #, php-format
 msgid "<span  %1$s>%2$d people</span> attend"
 msgstr ""
 
-#: include/conversation.php:1140
+#: include/conversation.php:1141
 #, php-format
 msgid "%s attend."
 msgstr ""
 
-#: include/conversation.php:1143
+#: include/conversation.php:1144
 #, php-format
 msgid "<span  %1$s>%2$d people</span> don't attend"
 msgstr ""
 
-#: include/conversation.php:1144
+#: include/conversation.php:1145
 #, php-format
 msgid "%s don't attend."
 msgstr ""
 
-#: include/conversation.php:1147
+#: include/conversation.php:1148
 #, php-format
 msgid "<span  %1$s>%2$d people</span> attend maybe"
 msgstr ""
 
-#: include/conversation.php:1148
+#: include/conversation.php:1149
 #, php-format
 msgid "%s attend maybe."
 msgstr ""
 
-#: include/conversation.php:1151
+#: include/conversation.php:1152
 #, php-format
 msgid "<span  %1$s>%2$d people</span> reshared this"
 msgstr ""
 
-#: include/conversation.php:1181
+#: include/conversation.php:1182
 msgid "Visible to <strong>everybody</strong>"
 msgstr ""
 
-#: include/conversation.php:1182 src/Module/Item/Compose.php:153
+#: include/conversation.php:1183 src/Module/Item/Compose.php:153
 #: src/Object/Post.php:970
 msgid "Please enter a image/video/audio/webpage URL:"
 msgstr ""
 
-#: include/conversation.php:1183
+#: include/conversation.php:1184
 msgid "Tag term:"
 msgstr ""
 
-#: include/conversation.php:1184 src/Module/Filer/SaveTag.php:69
+#: include/conversation.php:1185 src/Module/Filer/SaveTag.php:69
 msgid "Save to Folder:"
 msgstr ""
 
-#: include/conversation.php:1185
+#: include/conversation.php:1186
 msgid "Where are you right now?"
 msgstr ""
 
-#: include/conversation.php:1186
+#: include/conversation.php:1187
 msgid "Delete item(s)?"
 msgstr ""
 
-#: include/conversation.php:1196
+#: include/conversation.php:1197
 msgid "New Post"
 msgstr ""
 
-#: include/conversation.php:1199
+#: include/conversation.php:1200
 msgid "Share"
 msgstr ""
 
-#: include/conversation.php:1200 mod/editpost.php:89 mod/photos.php:1382
+#: include/conversation.php:1201 mod/editpost.php:89 mod/photos.php:1381
 #: src/Module/Contact/Poke.php:154 src/Object/Post.php:961
 msgid "Loading..."
 msgstr ""
 
-#: include/conversation.php:1201 mod/editpost.php:90 mod/message.php:202
+#: include/conversation.php:1202 mod/editpost.php:90 mod/message.php:202
 #: mod/message.php:371 mod/wallmessage.php:153
 msgid "Upload photo"
 msgstr ""
 
-#: include/conversation.php:1202 mod/editpost.php:91
+#: include/conversation.php:1203 mod/editpost.php:91
 msgid "upload photo"
 msgstr ""
 
-#: include/conversation.php:1203 mod/editpost.php:92
+#: include/conversation.php:1204 mod/editpost.php:92
 msgid "Attach file"
 msgstr ""
 
-#: include/conversation.php:1204 mod/editpost.php:93
+#: include/conversation.php:1205 mod/editpost.php:93
 msgid "attach file"
 msgstr ""
 
-#: include/conversation.php:1205 src/Module/Item/Compose.php:145
+#: include/conversation.php:1206 src/Module/Item/Compose.php:145
 #: src/Object/Post.php:962
 msgid "Bold"
 msgstr ""
 
-#: include/conversation.php:1206 src/Module/Item/Compose.php:146
+#: include/conversation.php:1207 src/Module/Item/Compose.php:146
 #: src/Object/Post.php:963
 msgid "Italic"
 msgstr ""
 
-#: include/conversation.php:1207 src/Module/Item/Compose.php:147
+#: include/conversation.php:1208 src/Module/Item/Compose.php:147
 #: src/Object/Post.php:964
 msgid "Underline"
 msgstr ""
 
-#: include/conversation.php:1208 src/Module/Item/Compose.php:148
+#: include/conversation.php:1209 src/Module/Item/Compose.php:148
 #: src/Object/Post.php:965
 msgid "Quote"
 msgstr ""
 
-#: include/conversation.php:1209 src/Module/Item/Compose.php:149
+#: include/conversation.php:1210 src/Module/Item/Compose.php:149
 #: src/Object/Post.php:966
 msgid "Code"
 msgstr ""
 
-#: include/conversation.php:1210 src/Module/Item/Compose.php:150
+#: include/conversation.php:1211 src/Module/Item/Compose.php:150
 #: src/Object/Post.php:967
 msgid "Image"
 msgstr ""
 
-#: include/conversation.php:1211 src/Module/Item/Compose.php:151
+#: include/conversation.php:1212 src/Module/Item/Compose.php:151
 #: src/Object/Post.php:968
 msgid "Link"
 msgstr ""
 
-#: include/conversation.php:1212 src/Module/Item/Compose.php:152
+#: include/conversation.php:1213 src/Module/Item/Compose.php:152
 #: src/Object/Post.php:969
 msgid "Link or Media"
 msgstr ""
 
-#: include/conversation.php:1213
+#: include/conversation.php:1214
 msgid "Video"
 msgstr ""
 
-#: include/conversation.php:1214 mod/editpost.php:100
+#: include/conversation.php:1215 mod/editpost.php:100
 #: src/Module/Item/Compose.php:155
 msgid "Set your location"
 msgstr ""
 
-#: include/conversation.php:1215 mod/editpost.php:101
+#: include/conversation.php:1216 mod/editpost.php:101
 msgid "set location"
 msgstr ""
 
-#: include/conversation.php:1216 mod/editpost.php:102
+#: include/conversation.php:1217 mod/editpost.php:102
 msgid "Clear browser location"
 msgstr ""
 
-#: include/conversation.php:1217 mod/editpost.php:103
+#: include/conversation.php:1218 mod/editpost.php:103
 msgid "clear location"
 msgstr ""
 
-#: include/conversation.php:1219 mod/editpost.php:117
+#: include/conversation.php:1220 mod/editpost.php:117
 #: src/Module/Item/Compose.php:160
 msgid "Set title"
 msgstr ""
 
-#: include/conversation.php:1221 mod/editpost.php:119
+#: include/conversation.php:1222 mod/editpost.php:119
 #: src/Module/Item/Compose.php:161
 msgid "Categories (comma-separated list)"
 msgstr ""
 
-#: include/conversation.php:1223 mod/editpost.php:105
+#: include/conversation.php:1224 mod/editpost.php:105
 msgid "Permission settings"
 msgstr ""
 
-#: include/conversation.php:1224 mod/editpost.php:134 mod/events.php:578
-#: mod/photos.php:969 mod/photos.php:1335
+#: include/conversation.php:1225 mod/editpost.php:134 mod/events.php:578
+#: mod/photos.php:968 mod/photos.php:1334
 msgid "Permissions"
 msgstr ""
 
-#: include/conversation.php:1233 mod/editpost.php:114
+#: include/conversation.php:1234 mod/editpost.php:114
 msgid "Public post"
 msgstr ""
 
-#: include/conversation.php:1237 mod/editpost.php:125 mod/events.php:573
-#: mod/photos.php:1381 mod/photos.php:1438 mod/photos.php:1513
+#: include/conversation.php:1238 mod/editpost.php:125 mod/events.php:573
+#: mod/photos.php:1380 mod/photos.php:1437 mod/photos.php:1512
 #: src/Module/Item/Compose.php:154 src/Object/Post.php:971
 msgid "Preview"
 msgstr ""
 
-#: include/conversation.php:1241 mod/dfrn_request.php:642 mod/editpost.php:128
+#: include/conversation.php:1242 mod/dfrn_request.php:642 mod/editpost.php:128
 #: mod/fbrowser.php:105 mod/fbrowser.php:134 mod/follow.php:152
-#: mod/photos.php:1037 mod/photos.php:1143 mod/tagrm.php:37 mod/tagrm.php:129
+#: mod/photos.php:1036 mod/photos.php:1142 mod/tagrm.php:37 mod/tagrm.php:129
 #: mod/unfollow.php:100 src/Module/Contact.php:467
 #: src/Module/RemoteFollow.php:110
 msgid "Cancel"
 msgstr ""
 
-#: include/conversation.php:1248 mod/editpost.php:132 src/Model/Profile.php:524
+#: include/conversation.php:1249 mod/editpost.php:132 src/Model/Profile.php:510
 #: src/Module/Contact.php:344
 msgid "Message"
 msgstr ""
 
-#: include/conversation.php:1249 mod/editpost.php:133
+#: include/conversation.php:1250 mod/editpost.php:133
 #: src/Module/Settings/TwoFactor/Trusted.php:101
 msgid "Browser"
 msgstr ""
 
-#: include/conversation.php:1251 mod/editpost.php:136
+#: include/conversation.php:1252 mod/editpost.php:136
 msgid "Open Compose page"
 msgstr ""
 
@@ -826,8 +826,8 @@ msgstr ""
 #: mod/api.php:52 mod/api.php:57 mod/dfrn_confirm.php:78 mod/editpost.php:37
 #: mod/events.php:231 mod/follow.php:55 mod/follow.php:135 mod/item.php:185
 #: mod/item.php:190 mod/item.php:917 mod/message.php:69 mod/message.php:112
-#: mod/notes.php:44 mod/ostatus_subscribe.php:30 mod/photos.php:176
-#: mod/photos.php:922 mod/repair_ostatus.php:31 mod/settings.php:47
+#: mod/notes.php:44 mod/ostatus_subscribe.php:30 mod/photos.php:175
+#: mod/photos.php:921 mod/repair_ostatus.php:31 mod/settings.php:47
 #: mod/settings.php:65 mod/settings.php:475 mod/suggest.php:34
 #: mod/uimport.php:32 mod/unfollow.php:35 mod/unfollow.php:50
 #: mod/unfollow.php:82 mod/wall_attach.php:78 mod/wall_attach.php:81
@@ -897,7 +897,7 @@ msgstr ""
 #: mod/cal.php:72 mod/cal.php:133 src/Module/HoverCard.php:53
 #: src/Module/Profile/Common.php:41 src/Module/Profile/Common.php:53
 #: src/Module/Profile/Contacts.php:40 src/Module/Profile/Contacts.php:51
-#: src/Module/Profile/Status.php:58 src/Module/Register.php:258
+#: src/Module/Profile/Status.php:58 src/Module/Register.php:254
 msgid "User not found."
 msgstr ""
 
@@ -1115,11 +1115,11 @@ msgstr ""
 msgid "Invalid profile URL."
 msgstr ""
 
-#: mod/dfrn_request.php:355 src/Model/Contact.php:2233
+#: mod/dfrn_request.php:355 src/Model/Contact.php:2297
 msgid "Disallowed profile URL."
 msgstr ""
 
-#: mod/dfrn_request.php:361 src/Model/Contact.php:2238
+#: mod/dfrn_request.php:361 src/Model/Contact.php:2302
 #: src/Module/Friendica.php:80
 msgid "Blocked domain"
 msgstr ""
@@ -1166,8 +1166,8 @@ msgstr ""
 msgid "Please confirm your introduction/connection request to %s."
 msgstr ""
 
-#: mod/dfrn_request.php:600 mod/display.php:179 mod/photos.php:836
-#: mod/videos.php:129 src/Module/Conversation/Community.php:188
+#: mod/dfrn_request.php:600 mod/display.php:179 mod/photos.php:835
+#: mod/videos.php:128 src/Module/Conversation/Community.php:188
 #: src/Module/Debug/Probe.php:39 src/Module/Debug/WebFinger.php:38
 #: src/Module/Directory.php:49 src/Module/Search/Index.php:50
 #: src/Module/Search/Index.php:55
@@ -1329,7 +1329,7 @@ msgid "Description:"
 msgstr ""
 
 #: mod/events.php:563 src/Model/Event.php:84 src/Model/Event.php:111
-#: src/Model/Event.php:472 src/Model/Event.php:959 src/Model/Profile.php:434
+#: src/Model/Event.php:472 src/Model/Event.php:959 src/Model/Profile.php:420
 #: src/Module/Contact.php:654 src/Module/Directory.php:156
 #: src/Module/Notifications/Introductions.php:172
 #: src/Module/Profile/Profile.php:190
@@ -1345,8 +1345,8 @@ msgid "Share this event"
 msgstr ""
 
 #: mod/events.php:575 mod/message.php:205 mod/message.php:373
-#: mod/photos.php:951 mod/photos.php:1054 mod/photos.php:1339
-#: mod/photos.php:1380 mod/photos.php:1437 mod/photos.php:1512
+#: mod/photos.php:950 mod/photos.php:1053 mod/photos.php:1338
+#: mod/photos.php:1379 mod/photos.php:1436 mod/photos.php:1511
 #: src/Module/Admin/Item/Source.php:65 src/Module/Contact.php:612
 #: src/Module/Contact/Advanced.php:132 src/Module/Contact/Poke.php:155
 #: src/Module/Debug/ActivityPubConversion.php:141
@@ -1766,257 +1766,257 @@ msgstr ""
 msgid "Keep this window open until done."
 msgstr ""
 
-#: mod/photos.php:129 src/Module/BaseProfile.php:71
+#: mod/photos.php:128 src/Module/BaseProfile.php:71
 msgid "Photo Albums"
 msgstr ""
 
-#: mod/photos.php:130 mod/photos.php:1638
+#: mod/photos.php:129 mod/photos.php:1637
 msgid "Recent Photos"
 msgstr ""
 
-#: mod/photos.php:132 mod/photos.php:1105 mod/photos.php:1640
+#: mod/photos.php:131 mod/photos.php:1104 mod/photos.php:1639
 msgid "Upload New Photos"
 msgstr ""
 
-#: mod/photos.php:150 src/Module/BaseSettings.php:37
+#: mod/photos.php:149 src/Module/BaseSettings.php:37
 msgid "everybody"
 msgstr ""
 
-#: mod/photos.php:183
+#: mod/photos.php:182
 msgid "Contact information unavailable"
 msgstr ""
 
-#: mod/photos.php:222
+#: mod/photos.php:221
 msgid "Album not found."
 msgstr ""
 
-#: mod/photos.php:280
+#: mod/photos.php:279
 msgid "Album successfully deleted"
 msgstr ""
 
-#: mod/photos.php:282
+#: mod/photos.php:281
 msgid "Album was empty."
 msgstr ""
 
-#: mod/photos.php:314
+#: mod/photos.php:313
 msgid "Failed to delete the photo."
 msgstr ""
 
-#: mod/photos.php:589
+#: mod/photos.php:588
 msgid "a photo"
 msgstr ""
 
-#: mod/photos.php:589
+#: mod/photos.php:588
 #, php-format
 msgid "%1$s was tagged in %2$s by %3$s"
 msgstr ""
 
-#: mod/photos.php:672 mod/photos.php:675 mod/photos.php:702
+#: mod/photos.php:671 mod/photos.php:674 mod/photos.php:701
 #: mod/wall_upload.php:216 src/Module/Settings/Profile/Photo/Index.php:61
 #, php-format
 msgid "Image exceeds size limit of %s"
 msgstr ""
 
-#: mod/photos.php:678
+#: mod/photos.php:677
 msgid "Image upload didn't complete, please try again"
 msgstr ""
 
-#: mod/photos.php:681
+#: mod/photos.php:680
 msgid "Image file is missing"
 msgstr ""
 
-#: mod/photos.php:686
+#: mod/photos.php:685
 msgid ""
 "Server can't accept new file upload at this time, please contact your "
 "administrator"
 msgstr ""
 
-#: mod/photos.php:710
+#: mod/photos.php:709
 msgid "Image file is empty."
 msgstr ""
 
-#: mod/photos.php:725 mod/wall_upload.php:175
+#: mod/photos.php:724 mod/wall_upload.php:175
 #: src/Module/Settings/Profile/Photo/Index.php:70
 msgid "Unable to process image."
 msgstr ""
 
-#: mod/photos.php:754 mod/wall_upload.php:241
+#: mod/photos.php:753 mod/wall_upload.php:241
 #: src/Module/Settings/Profile/Photo/Index.php:97
 msgid "Image upload failed."
 msgstr ""
 
-#: mod/photos.php:841
+#: mod/photos.php:840
 msgid "No photos selected"
 msgstr ""
 
-#: mod/photos.php:907 mod/videos.php:182
+#: mod/photos.php:906 mod/videos.php:181
 msgid "Access to this item is restricted."
 msgstr ""
 
-#: mod/photos.php:961
+#: mod/photos.php:960
 msgid "Upload Photos"
 msgstr ""
 
-#: mod/photos.php:965 mod/photos.php:1050
+#: mod/photos.php:964 mod/photos.php:1049
 msgid "New album name: "
 msgstr ""
 
-#: mod/photos.php:966
+#: mod/photos.php:965
 msgid "or select existing album:"
 msgstr ""
 
-#: mod/photos.php:967
+#: mod/photos.php:966
 msgid "Do not show a status post for this upload"
 msgstr ""
 
-#: mod/photos.php:1033
+#: mod/photos.php:1032
 msgid "Do you really want to delete this photo album and all its photos?"
 msgstr ""
 
-#: mod/photos.php:1034 mod/photos.php:1055
+#: mod/photos.php:1033 mod/photos.php:1054
 msgid "Delete Album"
 msgstr ""
 
-#: mod/photos.php:1061
+#: mod/photos.php:1060
 msgid "Edit Album"
 msgstr ""
 
-#: mod/photos.php:1062
+#: mod/photos.php:1061
 msgid "Drop Album"
 msgstr ""
 
-#: mod/photos.php:1067
+#: mod/photos.php:1066
 msgid "Show Newest First"
 msgstr ""
 
-#: mod/photos.php:1069
+#: mod/photos.php:1068
 msgid "Show Oldest First"
 msgstr ""
 
-#: mod/photos.php:1090 mod/photos.php:1623
+#: mod/photos.php:1089 mod/photos.php:1622
 msgid "View Photo"
 msgstr ""
 
-#: mod/photos.php:1127
+#: mod/photos.php:1126
 msgid "Permission denied. Access to this item may be restricted."
 msgstr ""
 
-#: mod/photos.php:1129
+#: mod/photos.php:1128
 msgid "Photo not available"
 msgstr ""
 
-#: mod/photos.php:1139
+#: mod/photos.php:1138
 msgid "Do you really want to delete this photo?"
 msgstr ""
 
-#: mod/photos.php:1140 mod/photos.php:1340
+#: mod/photos.php:1139 mod/photos.php:1339
 msgid "Delete Photo"
 msgstr ""
 
-#: mod/photos.php:1231
+#: mod/photos.php:1230
 msgid "View photo"
 msgstr ""
 
-#: mod/photos.php:1233
+#: mod/photos.php:1232
 msgid "Edit photo"
 msgstr ""
 
-#: mod/photos.php:1234
+#: mod/photos.php:1233
 msgid "Delete photo"
 msgstr ""
 
-#: mod/photos.php:1235
+#: mod/photos.php:1234
 msgid "Use as profile photo"
 msgstr ""
 
-#: mod/photos.php:1242
+#: mod/photos.php:1241
 msgid "Private Photo"
 msgstr ""
 
-#: mod/photos.php:1248
+#: mod/photos.php:1247
 msgid "View Full Size"
 msgstr ""
 
-#: mod/photos.php:1308
+#: mod/photos.php:1307
 msgid "Tags: "
 msgstr ""
 
-#: mod/photos.php:1311
+#: mod/photos.php:1310
 msgid "[Select tags to remove]"
 msgstr ""
 
-#: mod/photos.php:1326
+#: mod/photos.php:1325
 msgid "New album name"
 msgstr ""
 
-#: mod/photos.php:1327
+#: mod/photos.php:1326
 msgid "Caption"
 msgstr ""
 
-#: mod/photos.php:1328
+#: mod/photos.php:1327
 msgid "Add a Tag"
 msgstr ""
 
-#: mod/photos.php:1328
+#: mod/photos.php:1327
 msgid "Example: @bob, @Barbara_Jensen, @jim@example.com, #California, #camping"
 msgstr ""
 
-#: mod/photos.php:1329
+#: mod/photos.php:1328
 msgid "Do not rotate"
 msgstr ""
 
-#: mod/photos.php:1330
+#: mod/photos.php:1329
 msgid "Rotate CW (right)"
 msgstr ""
 
-#: mod/photos.php:1331
+#: mod/photos.php:1330
 msgid "Rotate CCW (left)"
 msgstr ""
 
-#: mod/photos.php:1377 mod/photos.php:1434 mod/photos.php:1509
+#: mod/photos.php:1376 mod/photos.php:1433 mod/photos.php:1508
 #: src/Module/Contact.php:1104 src/Module/Item/Compose.php:142
 #: src/Object/Post.php:957
 msgid "This is you"
 msgstr ""
 
-#: mod/photos.php:1379 mod/photos.php:1436 mod/photos.php:1511
+#: mod/photos.php:1378 mod/photos.php:1435 mod/photos.php:1510
 #: src/Object/Post.php:495 src/Object/Post.php:959
 msgid "Comment"
 msgstr ""
 
-#: mod/photos.php:1533 src/Object/Post.php:348
+#: mod/photos.php:1532 src/Object/Post.php:348
 msgid "Like"
 msgstr ""
 
-#: mod/photos.php:1534 src/Object/Post.php:348
+#: mod/photos.php:1533 src/Object/Post.php:348
 msgid "I like this (toggle)"
 msgstr ""
 
-#: mod/photos.php:1535 src/Object/Post.php:349
+#: mod/photos.php:1534 src/Object/Post.php:349
 msgid "Dislike"
 msgstr ""
 
-#: mod/photos.php:1537 src/Object/Post.php:349
+#: mod/photos.php:1536 src/Object/Post.php:349
 msgid "I don't like this (toggle)"
 msgstr ""
 
-#: mod/photos.php:1559
+#: mod/photos.php:1558
 msgid "Map"
 msgstr ""
 
-#: mod/photos.php:1629 mod/videos.php:259
+#: mod/photos.php:1628 mod/videos.php:258
 msgid "View Album"
 msgstr ""
 
-#: mod/ping.php:285
+#: mod/ping.php:286
 msgid "{0} wants to be your friend"
 msgstr ""
 
-#: mod/ping.php:302
+#: mod/ping.php:303
 msgid "{0} requested registration"
 msgstr ""
 
-#: mod/ping.php:315
+#: mod/ping.php:316
 #, php-format
 msgid "{0} and %d others requested registration"
 msgstr ""
@@ -2917,19 +2917,19 @@ msgstr ""
 msgid "Disconnect/Unfollow"
 msgstr ""
 
-#: mod/videos.php:134
+#: mod/videos.php:133
 msgid "No videos selected"
 msgstr ""
 
-#: mod/videos.php:252
+#: mod/videos.php:251
 msgid "View Video"
 msgstr ""
 
-#: mod/videos.php:267
+#: mod/videos.php:266
 msgid "Recent Videos"
 msgstr ""
 
-#: mod/videos.php:269
+#: mod/videos.php:268
 msgid "Upload New Videos"
 msgstr ""
 
@@ -2956,7 +2956,7 @@ msgstr ""
 msgid "File upload failed."
 msgstr ""
 
-#: mod/wall_upload.php:233 src/Model/Photo.php:976
+#: mod/wall_upload.php:233 src/Model/Photo.php:985
 msgid "Wall Photos"
 msgstr ""
 
@@ -2984,7 +2984,7 @@ msgstr ""
 msgid "No system theme config value set."
 msgstr ""
 
-#: src/App/Module.php:241
+#: src/App/Module.php:240
 msgid "You must be logged in to use addons. "
 msgstr ""
 
@@ -3634,39 +3634,39 @@ msgstr ""
 msgid "last"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:942 src/Content/Text/BBCode.php:1609
-#: src/Content/Text/BBCode.php:1610
+#: src/Content/Text/BBCode.php:942 src/Content/Text/BBCode.php:1613
+#: src/Content/Text/BBCode.php:1614
 msgid "Image/photo"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:1068
+#: src/Content/Text/BBCode.php:1072
 #, php-format
 msgid ""
 "<a href=\"%1$s\" target=\"_blank\" rel=\"noopener noreferrer\">%2$s</a> %3$s"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:1093 src/Model/Item.php:3110
-#: src/Model/Item.php:3116 src/Model/Item.php:3117
+#: src/Content/Text/BBCode.php:1097 src/Model/Item.php:3137
+#: src/Model/Item.php:3143 src/Model/Item.php:3144
 msgid "Link to source"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:1527 src/Content/Text/HTML.php:951
+#: src/Content/Text/BBCode.php:1531 src/Content/Text/HTML.php:951
 msgid "Click to open/close"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:1558
+#: src/Content/Text/BBCode.php:1562
 msgid "$1 wrote:"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:1612 src/Content/Text/BBCode.php:1613
+#: src/Content/Text/BBCode.php:1616 src/Content/Text/BBCode.php:1617
 msgid "Encrypted content"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:1826
+#: src/Content/Text/BBCode.php:1830
 msgid "Invalid source protocol"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:1841
+#: src/Content/Text/BBCode.php:1845
 msgid "Invalid link protocol"
 msgstr ""
 
@@ -3678,7 +3678,7 @@ msgstr ""
 msgid "The end"
 msgstr ""
 
-#: src/Content/Text/HTML.php:893 src/Model/Profile.php:518
+#: src/Content/Text/HTML.php:893 src/Model/Profile.php:504
 #: src/Module/Contact.php:340
 msgid "Follow"
 msgstr ""
@@ -4644,60 +4644,60 @@ msgstr ""
 msgid "Forum"
 msgstr ""
 
-#: src/Model/Contact.php:2243
+#: src/Model/Contact.php:2307
 msgid "Connect URL missing."
 msgstr ""
 
-#: src/Model/Contact.php:2252
+#: src/Model/Contact.php:2316
 msgid ""
 "The contact could not be added. Please check the relevant network "
 "credentials in your Settings -> Social Networks page."
 msgstr ""
 
-#: src/Model/Contact.php:2293
+#: src/Model/Contact.php:2359
 msgid ""
 "This site is not configured to allow communications with other networks."
 msgstr ""
 
-#: src/Model/Contact.php:2294 src/Model/Contact.php:2307
+#: src/Model/Contact.php:2360 src/Model/Contact.php:2373
 msgid "No compatible communication protocols or feeds were discovered."
 msgstr ""
 
-#: src/Model/Contact.php:2305
+#: src/Model/Contact.php:2371
 msgid "The profile address specified does not provide adequate information."
 msgstr ""
 
-#: src/Model/Contact.php:2310
+#: src/Model/Contact.php:2376
 msgid "An author or name was not found."
 msgstr ""
 
-#: src/Model/Contact.php:2313
+#: src/Model/Contact.php:2379
 msgid "No browser URL could be matched to this address."
 msgstr ""
 
-#: src/Model/Contact.php:2316
+#: src/Model/Contact.php:2382
 msgid ""
 "Unable to match @-style Identity Address with a known protocol or email "
 "contact."
 msgstr ""
 
-#: src/Model/Contact.php:2317
+#: src/Model/Contact.php:2383
 msgid "Use mailto: in front of address to force email check."
 msgstr ""
 
-#: src/Model/Contact.php:2323
+#: src/Model/Contact.php:2389
 msgid ""
 "The profile address specified belongs to a network which has been disabled "
 "on this site."
 msgstr ""
 
-#: src/Model/Contact.php:2328
+#: src/Model/Contact.php:2394
 msgid ""
 "Limited profile. This person will be unable to receive direct/personal "
 "notifications from you."
 msgstr ""
 
-#: src/Model/Contact.php:2387
+#: src/Model/Contact.php:2453
 msgid "Unable to retrieve contact information."
 msgstr ""
 
@@ -4836,11 +4836,11 @@ msgstr ""
 msgid "Content warning: %s"
 msgstr ""
 
-#: src/Model/Item.php:3075
+#: src/Model/Item.php:3102
 msgid "bytes"
 msgstr ""
 
-#: src/Model/Item.php:3104 src/Model/Item.php:3105
+#: src/Model/Item.php:3131 src/Model/Item.php:3132
 msgid "View on separate page"
 msgstr ""
 
@@ -4848,76 +4848,76 @@ msgstr ""
 msgid "[no subject]"
 msgstr ""
 
-#: src/Model/Profile.php:422 src/Module/Profile/Profile.php:252
+#: src/Model/Profile.php:408 src/Module/Profile/Profile.php:252
 #: src/Module/Profile/Profile.php:254
 msgid "Edit profile"
 msgstr ""
 
-#: src/Model/Profile.php:424
+#: src/Model/Profile.php:410
 msgid "Change profile photo"
 msgstr ""
 
-#: src/Model/Profile.php:437 src/Module/Directory.php:161
+#: src/Model/Profile.php:423 src/Module/Directory.php:161
 #: src/Module/Profile/Profile.php:180
 msgid "Homepage:"
 msgstr ""
 
-#: src/Model/Profile.php:438 src/Module/Contact.php:658
+#: src/Model/Profile.php:424 src/Module/Contact.php:658
 #: src/Module/Notifications/Introductions.php:174
 msgid "About:"
 msgstr ""
 
-#: src/Model/Profile.php:439 src/Module/Contact.php:656
+#: src/Model/Profile.php:425 src/Module/Contact.php:656
 #: src/Module/Profile/Profile.php:176
 msgid "XMPP:"
 msgstr ""
 
-#: src/Model/Profile.php:520 src/Module/Contact.php:342
+#: src/Model/Profile.php:506 src/Module/Contact.php:342
 msgid "Unfollow"
 msgstr ""
 
-#: src/Model/Profile.php:522
+#: src/Model/Profile.php:508
 msgid "Atom feed"
 msgstr ""
 
-#: src/Model/Profile.php:530 src/Module/Contact.php:338
+#: src/Model/Profile.php:516 src/Module/Contact.php:338
 #: src/Module/Notifications/Introductions.php:186
 msgid "Network:"
 msgstr ""
 
-#: src/Model/Profile.php:560 src/Model/Profile.php:657
+#: src/Model/Profile.php:546 src/Model/Profile.php:643
 msgid "g A l F d"
 msgstr ""
 
-#: src/Model/Profile.php:561
+#: src/Model/Profile.php:547
 msgid "F d"
 msgstr ""
 
-#: src/Model/Profile.php:623 src/Model/Profile.php:708
+#: src/Model/Profile.php:609 src/Model/Profile.php:694
 msgid "[today]"
 msgstr ""
 
-#: src/Model/Profile.php:633
+#: src/Model/Profile.php:619
 msgid "Birthday Reminders"
 msgstr ""
 
-#: src/Model/Profile.php:634
+#: src/Model/Profile.php:620
 msgid "Birthdays this week:"
 msgstr ""
 
-#: src/Model/Profile.php:695
+#: src/Model/Profile.php:681
 msgid "[No description]"
 msgstr ""
 
-#: src/Model/Profile.php:721
+#: src/Model/Profile.php:707
 msgid "Event Reminders"
 msgstr ""
 
-#: src/Model/Profile.php:722
+#: src/Model/Profile.php:708
 msgid "Upcoming events the next 7 days:"
 msgstr ""
 
-#: src/Model/Profile.php:897
+#: src/Model/Profile.php:896
 #, php-format
 msgid "OpenWebAuth: %1$s welcomes %2$s"
 msgstr ""
@@ -8909,12 +8909,12 @@ msgstr ""
 msgid "Visible to:"
 msgstr ""
 
-#: src/Module/Photo.php:85
+#: src/Module/Photo.php:94
 #, php-format
 msgid "The Photo with id %s is not available."
 msgstr ""
 
-#: src/Module/Photo.php:104
+#: src/Module/Photo.php:122
 #, php-format
 msgid "Invalid photo with id %s."
 msgstr ""
@@ -8973,19 +8973,19 @@ msgstr ""
 
 #: src/Module/Profile/Profile.php:322 src/Module/Profile/Profile.php:325
 #: src/Module/Profile/Status.php:65 src/Module/Profile/Status.php:68
-#: src/Protocol/Feed.php:943 src/Protocol/OStatus.php:1256
+#: src/Protocol/Feed.php:944 src/Protocol/OStatus.php:1256
 #, php-format
 msgid "%s's timeline"
 msgstr ""
 
 #: src/Module/Profile/Profile.php:323 src/Module/Profile/Status.php:66
-#: src/Protocol/Feed.php:947 src/Protocol/OStatus.php:1260
+#: src/Protocol/Feed.php:948 src/Protocol/OStatus.php:1260
 #, php-format
 msgid "%s's posts"
 msgstr ""
 
 #: src/Module/Profile/Profile.php:324 src/Module/Profile/Status.php:67
-#: src/Protocol/Feed.php:950 src/Protocol/OStatus.php:1263
+#: src/Protocol/Feed.php:951 src/Protocol/OStatus.php:1263
 #, php-format
 msgid "%s's comments"
 msgstr ""
@@ -9088,39 +9088,39 @@ msgstr ""
 msgid "You have entered too much information."
 msgstr ""
 
-#: src/Module/Register.php:271
+#: src/Module/Register.php:270
 msgid "Please enter the identical mail address in the second field."
 msgstr ""
 
-#: src/Module/Register.php:298
+#: src/Module/Register.php:297
 msgid "The additional account was created."
 msgstr ""
 
-#: src/Module/Register.php:323
+#: src/Module/Register.php:322
 msgid ""
 "Registration successful. Please check your email for further instructions."
 msgstr ""
 
-#: src/Module/Register.php:327
+#: src/Module/Register.php:326
 #, php-format
 msgid ""
 "Failed to send email message. Here your accout details:<br> login: %s<br> "
 "password: %s<br><br>You can change your password after login."
 msgstr ""
 
-#: src/Module/Register.php:333
+#: src/Module/Register.php:332
 msgid "Registration successful."
 msgstr ""
 
-#: src/Module/Register.php:338 src/Module/Register.php:345
+#: src/Module/Register.php:337 src/Module/Register.php:344
 msgid "Your registration can not be processed."
 msgstr ""
 
-#: src/Module/Register.php:344
+#: src/Module/Register.php:343
 msgid "You have to leave a request note for the admin."
 msgstr ""
 
-#: src/Module/Register.php:390
+#: src/Module/Register.php:389
 msgid "Your registration is pending approval by the site owner."
 msgstr ""
 


### PR DESCRIPTION
With this PR it is possible to search for contacts that are only published to the local directory but not globally.

Also (and unrelated) the messages.po is updated.

See also here: https://github.com/friendica/friendica/issues/10464