### PR TITLE
Sanitize negative followers count on APContact

### DIFF
--- a/src/Model/APContact.php
+++ b/src/Model/APContact.php
@@ -272,6 +272,11 @@ class APContact
 
 		if (!empty($apcontact['followers'])) {
 			$followers = ActivityPub::fetchContent($apcontact['followers']);
+			// Mastodon seriously allows for this condition? 
+			// Jul 14 2021 - See https://mastodon.online/@goes11 for a negative followers count
+			if ($followers['totalItems'] < 0) {
+			  $followers['totalItems'] = 0;
+			}
 			if (!empty($followers['totalItems'])) {
 				$apcontact['followers_count'] = $followers['totalItems'];
 			}

--- a/src/Model/APContact.php
+++ b/src/Model/APContact.php
@@ -275,7 +275,7 @@ class APContact
 			// Mastodon seriously allows for this condition? 
 			// Jul 14 2021 - See https://mastodon.online/@goes11 for a negative followers count
 			if ($followers['totalItems'] < 0) {
-			  $followers['totalItems'] = 0;
+				$followers['totalItems'] = 0;
 			}
 			if (!empty($followers['totalItems'])) {
 				$apcontact['followers_count'] = $followers['totalItems'];

--- a/src/Model/APContact.php
+++ b/src/Model/APContact.php
@@ -266,6 +266,11 @@ class APContact
 		if (!empty($apcontact['following'])) {
 			$following = ActivityPub::fetchContent($apcontact['following']);
 			if (!empty($following['totalItems'])) {
+				// Mastodon seriously allows for this condition? 
+				// Jul 14 2021 - See https://mastodon.social/@BLUW for a negative following count
+				if ($following['totalItems'] < 0) {
+					$following['totalItems'] = 0;
+				}
 				$apcontact['following_count'] = $following['totalItems'];
 			}
 		}

--- a/src/Model/APContact.php
+++ b/src/Model/APContact.php
@@ -272,12 +272,12 @@ class APContact
 
 		if (!empty($apcontact['followers'])) {
 			$followers = ActivityPub::fetchContent($apcontact['followers']);
-			// Mastodon seriously allows for this condition? 
-			// Jul 14 2021 - See https://mastodon.online/@goes11 for a negative followers count
-			if ($followers['totalItems'] < 0) {
-				$followers['totalItems'] = 0;
-			}
 			if (!empty($followers['totalItems'])) {
+				// Mastodon seriously allows for this condition? 
+				// Jul 14 2021 - See https://mastodon.online/@goes11 for a negative followers count
+				if ($followers['totalItems'] < 0) {
+					$followers['totalItems'] = 0;
+				}
 				$apcontact['followers_count'] = $followers['totalItems'];
 			}
 		}


### PR DESCRIPTION
Please see
https://github.com/friendica/friendica/issues/9498#issuecomment-818894106
and related discussion regarding this - it appears it's possible for AP
users, maybe just Mastodon users, to have a negative followers count.
This causes fatal errors in Friendica, so I think we should sanitize
this input.