### PR TITLE
Improved event storing / improved performance when fetching events

### DIFF
--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -1042,8 +1042,10 @@ class Item
 					$ev['id'] = $event['id'];
 				}
 
-				$item['event-id'] = Event::store($ev);
-				Logger::info('Event was stored', ['id' => $item['event-id']]);
+				$event_id = Event::store($ev);
+				$item = Event::getItemArrayForId($event_id, $item);
+
+				Logger::info('Event was stored', ['id' => $event_id]);
 			}
 		}
 

--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -1976,8 +1976,9 @@ class DFRN
 					}
 
 					$event_id = Event::store($ev);
-					Logger::log("Event ".$event_id." was stored", Logger::DEBUG);
-					return;
+					Logger::info('Event was stored', ['id' => $event_id]);
+
+					$item = Event::getItemArrayForId($event_id, $item);
 				}
 			}
 		}


### PR DESCRIPTION
The existing storing of events had been strange. We not only stored the events but also stored the associated item entry. But this had been from where we already had prepared items to be stored (when receiving event posts from DFRN or AP).

This now has been reworked. Possibly this also fixes the problem with events from Mobilizon that appeared to be from the system user.

Also the loading speed of the event page had been low. This is now fixed as well.