### PR TITLE
Refactor Storage admin section

### DIFF
--- a/src/Module/Admin/Storage.php
+++ b/src/Module/Admin/Storage.php
@@ -116,6 +116,7 @@ class Storage extends BaseAdmin
 				'name'   => $name,
 				'prefix' => $storage_form_prefix,
 				'form'   => $storage_form,
+				'active' => $name === $current_storage_backend::getName(),
 			];
 		}
 
@@ -125,8 +126,10 @@ class Storage extends BaseAdmin
 			'$title'                 => DI::l10n()->t('Administration'),
 			'$page'                  => DI::l10n()->t('Storage'),
 			'$save'                  => DI::l10n()->t('Save'),
-			'$save_set'              => DI::l10n()->t('Save & Activate'),
-			'$clear'                 => DI::l10n()->t('Clear'),
+			'$save_activate'         => DI::l10n()->t('Save & Activate'),
+			'$activate'              => DI::l10n()->t('Activate'),
+			'$save_reload'           => DI::l10n()->t('Save & Reload'),
+			'$noconfig'              => DI::l10n()->t('This backend doesn\'t have custom settings'),
 			'$baseurl'               => DI::baseUrl()->get(true),
 			'$form_security_token'   => self::getFormSecurityToken("admin_storage"),
 			'$storagebackend'        => $current_storage_backend,

--- a/src/Module/Admin/Storage.php
+++ b/src/Module/Admin/Storage.php
@@ -124,8 +124,8 @@ class Storage extends BaseAdmin
 		return Renderer::replaceMacros($t, [
 			'$title'                 => DI::l10n()->t('Administration'),
 			'$page'                  => DI::l10n()->t('Storage'),
-			'$save'                  => DI::l10n()->t('Save Settings'),
-			'$save_set'              => DI::l10n()->t('Set Backend'),
+			'$save'                  => DI::l10n()->t('Save'),
+			'$save_set'              => DI::l10n()->t('Save & Activate'),
 			'$clear'                 => DI::l10n()->t('Clear'),
 			'$baseurl'               => DI::baseUrl()->get(true),
 			'$form_security_token'   => self::getFormSecurityToken("admin_storage"),

--- a/src/Module/Admin/Storage.php
+++ b/src/Module/Admin/Storage.php
@@ -111,9 +111,9 @@ class Storage extends BaseAdmin
 
 			if (count($storage_form) > 0) {
 				$available_storage_forms[] = [
-					'name' => $name,
+					'name'   => $name,
 					'prefix' => $storage_form_prefix,
-					'form' => $storage_form,
+					'form'   => $storage_form,
 				];
 			}
 		}

--- a/src/Module/Admin/Storage.php
+++ b/src/Module/Admin/Storage.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * @copyright Copyright (C) 2010-2021, the Friendica project
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Friendica\Module\Admin;
+
+use Friendica\Core\Renderer;
+use Friendica\DI;
+use Friendica\Module\BaseAdmin;
+use Friendica\Util\Strings;
+use Psr\Log\LogLevel;
+
+class Storage extends BaseAdmin
+{
+	public static function post(array $parameters = [])
+	{
+		self::checkAdminAccess();
+
+		self::checkFormSecurityTokenRedirectOnError('/admin/storage', 'admin_storage');
+
+		$storagebackend    = Strings::escapeTags(trim($_POST['storagebackend'] ?? ''));
+
+		// save storage backend form
+		if (DI::storageManager()->setBackend($storagebackend)) {
+			$storage_opts     = DI::storage()->getOptions();
+			$storage_form_prefix = preg_replace('|[^a-zA-Z0-9]|', '', $storagebackend);
+			$storage_opts_data   = [];
+			foreach ($storage_opts as $name => $info) {
+				$fieldname = $storage_form_prefix . '_' . $name;
+				switch ($info[0]) { // type
+					case 'checkbox':
+					case 'yesno':
+						$value = !empty($_POST[$fieldname]);
+						break;
+					default:
+						$value = $_POST[$fieldname] ?? '';
+				}
+				$storage_opts_data[$name] = $value;
+			}
+			unset($name);
+			unset($info);
+
+			$storage_form_errors = DI::storage()->saveOptions($storage_opts_data);
+			if (count($storage_form_errors)) {
+				foreach ($storage_form_errors as $name => $err) {
+					notice('Storage backend, ' . $storage_opts[$name][1] . ': ' . $err);
+				}
+				DI::baseUrl()->redirect('admin/storage');
+			}
+		} elseif (!empty($storagebackend)) {
+			notice(DI::l10n()->t('Invalid storage backend setting value.'));
+		}
+
+		DI::baseUrl()->redirect('admin/storage');
+	}
+
+	public static function content(array $parameters = [])
+	{
+		parent::content($parameters);
+
+		$current_storage_backend = DI::storage();
+		$available_storage_backends = [];
+
+		// show legacy option only if it is the current backend:
+		// once changed can't be selected anymore
+		if ($current_storage_backend == null) {
+			$available_storage_backends[''] = DI::l10n()->t('Database (legacy)');
+		}
+
+		foreach (DI::storageManager()->listBackends() as $name => $class) {
+			$available_storage_backends[$name] = $name;
+		}
+
+		// build storage config form,
+		$storage_form_prefix = preg_replace('|[^a-zA-Z0-9]|' ,'', $current_storage_backend);
+
+		$storage_form = [];
+		if (!is_null($current_storage_backend) && $current_storage_backend != '') {
+			foreach ($current_storage_backend->getOptions() as $name => $info) {
+				$type = $info[0];
+				// Backward compatibilty with yesno field description
+				if ($type == 'yesno') {
+					$type = 'checkbox';
+					// Remove translated labels Yes No from field info
+					unset($info[4]);
+				}
+
+				$info[0] = $storage_form_prefix . '_' . $name;
+				$info['type'] = $type;
+				$info['field'] = 'field_' . $type . '.tpl';
+				$storage_form[$name] = $info;
+			}
+		}
+
+		$t = Renderer::getMarkupTemplate('admin/storage.tpl');
+
+		return Renderer::replaceMacros($t, [
+			'$title' => DI::l10n()->t('Administration'),
+			'$page' => DI::l10n()->t('Storage'),
+			'$submit' => DI::l10n()->t('Save Settings'),
+			'$clear' => DI::l10n()->t('Clear'),
+			'$baseurl' => DI::baseUrl()->get(true),
+			'$form_security_token' => self::getFormSecurityToken("admin_storage"),
+			'$storagebackend'   => ['storagebackend', DI::l10n()->t('File storage backend'), $current_storage_backend, DI::l10n()->t('The backend used to store uploaded data. If you change the storage backend, you can manually move the existing files. If you do not do so, the files uploaded before the change will still be available at the old backend. Please see <a href="/help/Settings#1_2_3_1">the settings documentation</a> for more information about the choices and the moving procedure.'), $available_storage_backends],
+			'$storageform'      => $storage_form,
+		]);
+	}
+}

--- a/src/Module/Admin/Storage.php
+++ b/src/Module/Admin/Storage.php
@@ -35,7 +35,8 @@ class Storage extends BaseAdmin
 
 		self::checkFormSecurityTokenRedirectOnError('/admin/storage', 'admin_storage');
 
-		$storagebackend = Strings::escapeTags(trim($_POST['storagebackend'] ?? ''));
+		$storagebackend = Strings::escapeTags(trim($parameters['name'] ?? ''));
+
 		/** @var IStorage $newstorage */
 		$newstorage = DI::storageManager()->getByName($storagebackend);
 
@@ -66,8 +67,10 @@ class Storage extends BaseAdmin
 			DI::baseUrl()->redirect('admin/storage');
 		}
 
-		if (empty($storagebackend) || !DI::storageManager()->setBackend($storagebackend)) {
-			notice(DI::l10n()->t('Invalid storage backend setting value.'));
+		if (!empty($_POST['submit_save_set'])) {
+			if (empty($storagebackend) || !DI::storageManager()->setBackend($storagebackend)) {
+				notice(DI::l10n()->t('Invalid storage backend setting value.'));
+			}
 		}
 
 		DI::baseUrl()->redirect('admin/storage');
@@ -109,13 +112,11 @@ class Storage extends BaseAdmin
 				$storage_form[$option] = $info;
 			}
 
-			if (count($storage_form) > 0) {
-				$available_storage_forms[] = [
-					'name'   => $name,
-					'prefix' => $storage_form_prefix,
-					'form'   => $storage_form,
-				];
-			}
+			$available_storage_forms[] = [
+				'name'   => $name,
+				'prefix' => $storage_form_prefix,
+				'form'   => $storage_form,
+			];
 		}
 
 		$t = Renderer::getMarkupTemplate('admin/storage.tpl');
@@ -123,11 +124,12 @@ class Storage extends BaseAdmin
 		return Renderer::replaceMacros($t, [
 			'$title'                 => DI::l10n()->t('Administration'),
 			'$page'                  => DI::l10n()->t('Storage'),
-			'$submit'                => DI::l10n()->t('Save Settings'),
+			'$save'                  => DI::l10n()->t('Save Settings'),
+			'$save_set'              => DI::l10n()->t('Set Backend'),
 			'$clear'                 => DI::l10n()->t('Clear'),
 			'$baseurl'               => DI::baseUrl()->get(true),
 			'$form_security_token'   => self::getFormSecurityToken("admin_storage"),
-			'$storagebackend'        => ['storagebackend', DI::l10n()->t('File storage backend'), $current_storage_backend, DI::l10n()->t('The backend used to store uploaded data. If you change the storage backend, you can manually move the existing files. If you do not do so, the files uploaded before the change will still be available at the old backend. Please see <a href="/help/Settings#1_2_3_1">the settings documentation</a> for more information about the choices and the moving procedure.'), $available_storage_backends],
+			'$storagebackend'        => $current_storage_backend,
 			'$availablestorageforms' => $available_storage_forms,
 		]);
 	}

--- a/src/Module/BaseAdmin.php
+++ b/src/Module/BaseAdmin.php
@@ -88,6 +88,7 @@ abstract class BaseAdmin extends BaseModule
 			]],
 			'configuration' => [DI::l10n()->t('Configuration'), [
 				'site'         => ['admin/site'        , DI::l10n()->t('Site')                    , 'site'],
+				'storage'      => ['admin/storage'     , DI::l10n()->t('Storage')                 , 'storage'],
 				'users'        => ['admin/users'       , DI::l10n()->t('Users')                   , 'users'],
 				'addons'       => ['admin/addons'      , DI::l10n()->t('Addons')                  , 'addons'],
 				'themes'       => ['admin/themes'      , DI::l10n()->t('Themes')                  , 'themes'],

--- a/static/routes.config.php
+++ b/static/routes.config.php
@@ -198,6 +198,8 @@ return [
 
 		'/site' => [Module\Admin\Site::class, [R::GET, R::POST]],
 
+		'/storage' => [Module\Admin\Storage::class, [R::GET, R::POST]],
+
 		'/themes'               => [Module\Admin\Themes\Index::class,   [R::GET, R::POST]],
 		'/themes/{theme}'       => [Module\Admin\Themes\Details::class, [R::GET, R::POST]],
 		'/themes/{theme}/embed' => [Module\Admin\Themes\Embed::class,   [R::GET, R::POST]],

--- a/static/routes.config.php
+++ b/static/routes.config.php
@@ -198,7 +198,8 @@ return [
 
 		'/site' => [Module\Admin\Site::class, [R::GET, R::POST]],
 
-		'/storage' => [Module\Admin\Storage::class, [R::GET, R::POST]],
+		'/storage'        => [Module\Admin\Storage::class, [R::GET, R::POST]],
+		'/storage/{name}' => [Module\Admin\Storage::class, [        R::POST]],
 
 		'/themes'               => [Module\Admin\Themes\Index::class,   [R::GET, R::POST]],
 		'/themes/{theme}'       => [Module\Admin\Themes\Details::class, [R::GET, R::POST]],

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2021.09-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-23 13:30+0000\n"
+"POT-Creation-Date: 2021-07-24 19:02+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -962,7 +962,7 @@ msgid "Edit post"
 msgstr ""
 
 #: mod/editpost.php:88 mod/notes.php:63 src/Content/Text/HTML.php:893
-#: src/Module/Filer/SaveTag.php:70
+#: src/Module/Admin/Storage.php:128 src/Module/Filer/SaveTag.php:70
 msgid "Save"
 msgstr ""
 
@@ -1096,7 +1096,7 @@ msgstr ""
 msgid "Basic"
 msgstr ""
 
-#: mod/events.php:582 src/Module/Admin/Site.php:573 src/Module/Contact.php:926
+#: mod/events.php:582 src/Module/Admin/Site.php:506 src/Module/Contact.php:926
 #: src/Module/Profile/Profile.php:245
 msgid "Advanced"
 msgstr ""
@@ -1933,7 +1933,7 @@ msgstr ""
 
 #: mod/settings.php:482 mod/settings.php:578 mod/settings.php:713
 #: src/Module/Admin/Addons/Index.php:69 src/Module/Admin/Features.php:87
-#: src/Module/Admin/Logs/Settings.php:82 src/Module/Admin/Site.php:568
+#: src/Module/Admin/Logs/Settings.php:82 src/Module/Admin/Site.php:501
 #: src/Module/Admin/Themes/Index.php:113 src/Module/Admin/Tos.php:66
 #: src/Module/Settings/Delegation.php:170 src/Module/Settings/Display.php:189
 msgid "Save Settings"
@@ -3275,7 +3275,7 @@ msgid "Information about this friendica instance"
 msgstr ""
 
 #: src/Content/Nav.php:270 src/Module/Admin/Tos.php:59
-#: src/Module/BaseAdmin.php:95 src/Module/Register.php:163
+#: src/Module/BaseAdmin.php:96 src/Module/Register.php:163
 #: src/Module/Tos.php:84
 msgid "Terms of Service"
 msgstr ""
@@ -3347,7 +3347,7 @@ msgstr ""
 msgid "Manage/edit friends and contacts"
 msgstr ""
 
-#: src/Content/Nav.php:303 src/Module/BaseAdmin.php:125
+#: src/Content/Nav.php:303 src/Module/BaseAdmin.php:126
 msgid "Admin"
 msgstr ""
 
@@ -4993,17 +4993,17 @@ msgstr ""
 #: src/Module/Admin/Blocklist/Server.php:88 src/Module/Admin/Federation.php:159
 #: src/Module/Admin/Item/Delete.php:65 src/Module/Admin/Logs/Settings.php:80
 #: src/Module/Admin/Logs/View.php:64 src/Module/Admin/Queue.php:72
-#: src/Module/Admin/Site.php:565 src/Module/Admin/Summary.php:232
-#: src/Module/Admin/Themes/Details.php:90 src/Module/Admin/Themes/Index.php:111
-#: src/Module/Admin/Tos.php:58 src/Module/Admin/Users/Active.php:136
-#: src/Module/Admin/Users/Blocked.php:137 src/Module/Admin/Users/Create.php:61
-#: src/Module/Admin/Users/Deleted.php:85 src/Module/Admin/Users/Index.php:149
-#: src/Module/Admin/Users/Pending.php:101
+#: src/Module/Admin/Site.php:498 src/Module/Admin/Storage.php:126
+#: src/Module/Admin/Summary.php:232 src/Module/Admin/Themes/Details.php:90
+#: src/Module/Admin/Themes/Index.php:111 src/Module/Admin/Tos.php:58
+#: src/Module/Admin/Users/Active.php:136 src/Module/Admin/Users/Blocked.php:137
+#: src/Module/Admin/Users/Create.php:61 src/Module/Admin/Users/Deleted.php:85
+#: src/Module/Admin/Users/Index.php:149 src/Module/Admin/Users/Pending.php:101
 msgid "Administration"
 msgstr ""
 
 #: src/Module/Admin/Addons/Details.php:112 src/Module/Admin/Addons/Index.php:68
-#: src/Module/BaseAdmin.php:92 src/Module/BaseSettings.php:87
+#: src/Module/BaseAdmin.php:93 src/Module/BaseSettings.php:87
 msgid "Addons"
 msgstr ""
 
@@ -5353,7 +5353,7 @@ msgstr ""
 msgid "Item marked for deletion."
 msgstr ""
 
-#: src/Module/Admin/Item/Delete.php:66 src/Module/BaseAdmin.php:105
+#: src/Module/Admin/Item/Delete.php:66 src/Module/BaseAdmin.php:106
 msgid "Delete Item"
 msgstr ""
 
@@ -5382,7 +5382,7 @@ msgstr ""
 msgid "The GUID of the item you want to delete."
 msgstr ""
 
-#: src/Module/Admin/Item/Source.php:57 src/Module/BaseAdmin.php:115
+#: src/Module/Admin/Item/Source.php:57 src/Module/BaseAdmin.php:116
 msgid "Item Source"
 msgstr ""
 
@@ -5445,8 +5445,8 @@ msgstr ""
 msgid "PHP log currently disabled."
 msgstr ""
 
-#: src/Module/Admin/Logs/Settings.php:81 src/Module/BaseAdmin.php:107
-#: src/Module/BaseAdmin.php:108
+#: src/Module/Admin/Logs/Settings.php:81 src/Module/BaseAdmin.php:108
+#: src/Module/BaseAdmin.php:109
 msgid "Logs"
 msgstr ""
 
@@ -5499,7 +5499,7 @@ msgid ""
 "%1$s is readable."
 msgstr ""
 
-#: src/Module/Admin/Logs/View.php:65 src/Module/BaseAdmin.php:109
+#: src/Module/Admin/Logs/View.php:65 src/Module/BaseAdmin.php:110
 msgid "View Logs"
 msgstr ""
 
@@ -5547,485 +5547,464 @@ msgstr ""
 msgid "Relocation started. Could take a while to complete."
 msgstr ""
 
-#: src/Module/Admin/Site.php:245
-msgid "Invalid storage backend setting value."
-msgstr ""
-
-#: src/Module/Admin/Site.php:436 src/Module/Settings/Display.php:134
+#: src/Module/Admin/Site.php:403 src/Module/Settings/Display.php:134
 msgid "No special theme for mobile devices"
 msgstr ""
 
-#: src/Module/Admin/Site.php:453 src/Module/Settings/Display.php:144
+#: src/Module/Admin/Site.php:420 src/Module/Settings/Display.php:144
 #, php-format
 msgid "%s - (Experimental)"
 msgstr ""
 
-#: src/Module/Admin/Site.php:465
+#: src/Module/Admin/Site.php:432
 msgid "No community page for local users"
 msgstr ""
 
-#: src/Module/Admin/Site.php:466
+#: src/Module/Admin/Site.php:433
 msgid "No community page"
 msgstr ""
 
-#: src/Module/Admin/Site.php:467
+#: src/Module/Admin/Site.php:434
 msgid "Public postings from users of this site"
 msgstr ""
 
-#: src/Module/Admin/Site.php:468
+#: src/Module/Admin/Site.php:435
 msgid "Public postings from the federated network"
 msgstr ""
 
-#: src/Module/Admin/Site.php:469
+#: src/Module/Admin/Site.php:436
 msgid "Public postings from local users and the federated network"
 msgstr ""
 
-#: src/Module/Admin/Site.php:475
+#: src/Module/Admin/Site.php:442
 msgid "Multi user instance"
 msgstr ""
 
-#: src/Module/Admin/Site.php:502
+#: src/Module/Admin/Site.php:469
 msgid "Closed"
 msgstr ""
 
-#: src/Module/Admin/Site.php:503
+#: src/Module/Admin/Site.php:470
 msgid "Requires approval"
 msgstr ""
 
-#: src/Module/Admin/Site.php:504
+#: src/Module/Admin/Site.php:471
 msgid "Open"
 msgstr ""
 
-#: src/Module/Admin/Site.php:508 src/Module/Install.php:215
+#: src/Module/Admin/Site.php:475 src/Module/Install.php:215
 msgid "No SSL policy, links will track page SSL state"
 msgstr ""
 
-#: src/Module/Admin/Site.php:509 src/Module/Install.php:216
+#: src/Module/Admin/Site.php:476 src/Module/Install.php:216
 msgid "Force all links to use SSL"
 msgstr ""
 
-#: src/Module/Admin/Site.php:510 src/Module/Install.php:217
+#: src/Module/Admin/Site.php:477 src/Module/Install.php:217
 msgid "Self-signed certificate, use SSL for local links only (discouraged)"
 msgstr ""
 
-#: src/Module/Admin/Site.php:514
+#: src/Module/Admin/Site.php:481
 msgid "Don't check"
 msgstr ""
 
-#: src/Module/Admin/Site.php:515
+#: src/Module/Admin/Site.php:482
 msgid "check the stable version"
 msgstr ""
 
-#: src/Module/Admin/Site.php:516
+#: src/Module/Admin/Site.php:483
 msgid "check the development version"
 msgstr ""
 
-#: src/Module/Admin/Site.php:520
+#: src/Module/Admin/Site.php:487
 msgid "none"
 msgstr ""
 
-#: src/Module/Admin/Site.php:521
+#: src/Module/Admin/Site.php:488
 msgid "Local contacts"
 msgstr ""
 
-#: src/Module/Admin/Site.php:522
+#: src/Module/Admin/Site.php:489
 msgid "Interactors"
 msgstr ""
 
-#: src/Module/Admin/Site.php:535
-msgid "Database (legacy)"
-msgstr ""
-
-#: src/Module/Admin/Site.php:566 src/Module/BaseAdmin.php:90
+#: src/Module/Admin/Site.php:499 src/Module/BaseAdmin.php:90
 msgid "Site"
 msgstr ""
 
-#: src/Module/Admin/Site.php:567
+#: src/Module/Admin/Site.php:500
 msgid "General Information"
 msgstr ""
 
-#: src/Module/Admin/Site.php:569
+#: src/Module/Admin/Site.php:502
 msgid "Republish users to directory"
 msgstr ""
 
-#: src/Module/Admin/Site.php:570 src/Module/Register.php:139
+#: src/Module/Admin/Site.php:503 src/Module/Register.php:139
 msgid "Registration"
 msgstr ""
 
-#: src/Module/Admin/Site.php:571
+#: src/Module/Admin/Site.php:504
 msgid "File upload"
 msgstr ""
 
-#: src/Module/Admin/Site.php:572
+#: src/Module/Admin/Site.php:505
 msgid "Policies"
 msgstr ""
 
-#: src/Module/Admin/Site.php:574
+#: src/Module/Admin/Site.php:507
 msgid "Auto Discovered Contact Directory"
 msgstr ""
 
-#: src/Module/Admin/Site.php:575
+#: src/Module/Admin/Site.php:508
 msgid "Performance"
 msgstr ""
 
-#: src/Module/Admin/Site.php:576
+#: src/Module/Admin/Site.php:509
 msgid "Worker"
 msgstr ""
 
-#: src/Module/Admin/Site.php:577
+#: src/Module/Admin/Site.php:510
 msgid "Message Relay"
 msgstr ""
 
-#: src/Module/Admin/Site.php:578
+#: src/Module/Admin/Site.php:511
 msgid ""
 "Use the command \"console relay\" in the command line to add or remove "
 "relays."
 msgstr ""
 
-#: src/Module/Admin/Site.php:579
+#: src/Module/Admin/Site.php:512
 msgid "The system is not subscribed to any relays at the moment."
 msgstr ""
 
-#: src/Module/Admin/Site.php:580
+#: src/Module/Admin/Site.php:513
 msgid "The system is currently subscribed to the following relays:"
 msgstr ""
 
-#: src/Module/Admin/Site.php:582
+#: src/Module/Admin/Site.php:515
 msgid "Relocate Instance"
 msgstr ""
 
-#: src/Module/Admin/Site.php:583
+#: src/Module/Admin/Site.php:516
 msgid ""
 "<strong>Warning!</strong> Advanced function. Could make this server "
 "unreachable."
 msgstr ""
 
-#: src/Module/Admin/Site.php:587
+#: src/Module/Admin/Site.php:520
 msgid "Site name"
 msgstr ""
 
-#: src/Module/Admin/Site.php:588
+#: src/Module/Admin/Site.php:521
 msgid "Sender Email"
 msgstr ""
 
-#: src/Module/Admin/Site.php:588
+#: src/Module/Admin/Site.php:521
 msgid ""
 "The email address your server shall use to send notification emails from."
 msgstr ""
 
-#: src/Module/Admin/Site.php:589
+#: src/Module/Admin/Site.php:522
 msgid "Name of the system actor"
 msgstr ""
 
-#: src/Module/Admin/Site.php:589
+#: src/Module/Admin/Site.php:522
 msgid ""
 "Name of the internal system account that is used to perform ActivityPub "
 "requests. This must be an unused username. If set, this can't be changed "
 "again."
 msgstr ""
 
-#: src/Module/Admin/Site.php:590
+#: src/Module/Admin/Site.php:523
 msgid "Banner/Logo"
 msgstr ""
 
-#: src/Module/Admin/Site.php:591
+#: src/Module/Admin/Site.php:524
 msgid "Email Banner/Logo"
 msgstr ""
 
-#: src/Module/Admin/Site.php:592
+#: src/Module/Admin/Site.php:525
 msgid "Shortcut icon"
 msgstr ""
 
-#: src/Module/Admin/Site.php:592
+#: src/Module/Admin/Site.php:525
 msgid "Link to an icon that will be used for browsers."
 msgstr ""
 
-#: src/Module/Admin/Site.php:593
+#: src/Module/Admin/Site.php:526
 msgid "Touch icon"
 msgstr ""
 
-#: src/Module/Admin/Site.php:593
+#: src/Module/Admin/Site.php:526
 msgid "Link to an icon that will be used for tablets and mobiles."
 msgstr ""
 
-#: src/Module/Admin/Site.php:594
+#: src/Module/Admin/Site.php:527
 msgid "Additional Info"
 msgstr ""
 
-#: src/Module/Admin/Site.php:594
+#: src/Module/Admin/Site.php:527
 #, php-format
 msgid ""
 "For public servers: you can add additional information here that will be "
 "listed at %s/servers."
 msgstr ""
 
-#: src/Module/Admin/Site.php:595
+#: src/Module/Admin/Site.php:528
 msgid "System language"
 msgstr ""
 
-#: src/Module/Admin/Site.php:596
+#: src/Module/Admin/Site.php:529
 msgid "System theme"
 msgstr ""
 
-#: src/Module/Admin/Site.php:596
+#: src/Module/Admin/Site.php:529
 msgid ""
 "Default system theme - may be over-ridden by user profiles - <a href=\"/"
 "admin/themes\" id=\"cnftheme\">Change default theme settings</a>"
 msgstr ""
 
-#: src/Module/Admin/Site.php:597
+#: src/Module/Admin/Site.php:530
 msgid "Mobile system theme"
 msgstr ""
 
-#: src/Module/Admin/Site.php:597
+#: src/Module/Admin/Site.php:530
 msgid "Theme for mobile devices"
 msgstr ""
 
-#: src/Module/Admin/Site.php:598 src/Module/Install.php:225
+#: src/Module/Admin/Site.php:531 src/Module/Install.php:225
 msgid "SSL link policy"
 msgstr ""
 
-#: src/Module/Admin/Site.php:598 src/Module/Install.php:227
+#: src/Module/Admin/Site.php:531 src/Module/Install.php:227
 msgid "Determines whether generated links should be forced to use SSL"
 msgstr ""
 
-#: src/Module/Admin/Site.php:599
+#: src/Module/Admin/Site.php:532
 msgid "Force SSL"
 msgstr ""
 
-#: src/Module/Admin/Site.php:599
+#: src/Module/Admin/Site.php:532
 msgid ""
 "Force all Non-SSL requests to SSL - Attention: on some systems it could lead "
 "to endless loops."
 msgstr ""
 
-#: src/Module/Admin/Site.php:600
+#: src/Module/Admin/Site.php:533
 msgid "Hide help entry from navigation menu"
 msgstr ""
 
-#: src/Module/Admin/Site.php:600
+#: src/Module/Admin/Site.php:533
 msgid ""
 "Hides the menu entry for the Help pages from the navigation menu. You can "
 "still access it calling /help directly."
 msgstr ""
 
-#: src/Module/Admin/Site.php:601
+#: src/Module/Admin/Site.php:534
 msgid "Single user instance"
 msgstr ""
 
-#: src/Module/Admin/Site.php:601
+#: src/Module/Admin/Site.php:534
 msgid "Make this instance multi-user or single-user for the named user"
 msgstr ""
 
-#: src/Module/Admin/Site.php:603
-msgid "File storage backend"
-msgstr ""
-
-#: src/Module/Admin/Site.php:603
-msgid ""
-"The backend used to store uploaded data. If you change the storage backend, "
-"you can manually move the existing files. If you do not do so, the files "
-"uploaded before the change will still be available at the old backend. "
-"Please see <a href=\"/help/Settings#1_2_3_1\">the settings documentation</a> "
-"for more information about the choices and the moving procedure."
-msgstr ""
-
-#: src/Module/Admin/Site.php:605
+#: src/Module/Admin/Site.php:536
 msgid "Maximum image size"
 msgstr ""
 
-#: src/Module/Admin/Site.php:605
+#: src/Module/Admin/Site.php:536
 msgid ""
 "Maximum size in bytes of uploaded images. Default is 0, which means no "
 "limits."
 msgstr ""
 
-#: src/Module/Admin/Site.php:606
+#: src/Module/Admin/Site.php:537
 msgid "Maximum image length"
 msgstr ""
 
-#: src/Module/Admin/Site.php:606
+#: src/Module/Admin/Site.php:537
 msgid ""
 "Maximum length in pixels of the longest side of uploaded images. Default is "
 "-1, which means no limits."
 msgstr ""
 
-#: src/Module/Admin/Site.php:607
+#: src/Module/Admin/Site.php:538
 msgid "JPEG image quality"
 msgstr ""
 
-#: src/Module/Admin/Site.php:607
+#: src/Module/Admin/Site.php:538
 msgid ""
 "Uploaded JPEGS will be saved at this quality setting [0-100]. Default is "
 "100, which is full quality."
 msgstr ""
 
-#: src/Module/Admin/Site.php:609
+#: src/Module/Admin/Site.php:540
 msgid "Register policy"
 msgstr ""
 
-#: src/Module/Admin/Site.php:610
+#: src/Module/Admin/Site.php:541
 msgid "Maximum Daily Registrations"
 msgstr ""
 
-#: src/Module/Admin/Site.php:610
+#: src/Module/Admin/Site.php:541
 msgid ""
 "If registration is permitted above, this sets the maximum number of new user "
 "registrations to accept per day.  If register is set to closed, this setting "
 "has no effect."
 msgstr ""
 
-#: src/Module/Admin/Site.php:611
+#: src/Module/Admin/Site.php:542
 msgid "Register text"
 msgstr ""
 
-#: src/Module/Admin/Site.php:611
+#: src/Module/Admin/Site.php:542
 msgid ""
 "Will be displayed prominently on the registration page. You can use BBCode "
 "here."
 msgstr ""
 
-#: src/Module/Admin/Site.php:612
+#: src/Module/Admin/Site.php:543
 msgid "Forbidden Nicknames"
 msgstr ""
 
-#: src/Module/Admin/Site.php:612
+#: src/Module/Admin/Site.php:543
 msgid ""
 "Comma separated list of nicknames that are forbidden from registration. "
 "Preset is a list of role names according RFC 2142."
 msgstr ""
 
-#: src/Module/Admin/Site.php:613
+#: src/Module/Admin/Site.php:544
 msgid "Accounts abandoned after x days"
 msgstr ""
 
-#: src/Module/Admin/Site.php:613
+#: src/Module/Admin/Site.php:544
 msgid ""
 "Will not waste system resources polling external sites for abandonded "
 "accounts. Enter 0 for no time limit."
 msgstr ""
 
-#: src/Module/Admin/Site.php:614
+#: src/Module/Admin/Site.php:545
 msgid "Allowed friend domains"
 msgstr ""
 
-#: src/Module/Admin/Site.php:614
+#: src/Module/Admin/Site.php:545
 msgid ""
 "Comma separated list of domains which are allowed to establish friendships "
 "with this site. Wildcards are accepted. Empty to allow any domains"
 msgstr ""
 
-#: src/Module/Admin/Site.php:615
+#: src/Module/Admin/Site.php:546
 msgid "Allowed email domains"
 msgstr ""
 
-#: src/Module/Admin/Site.php:615
+#: src/Module/Admin/Site.php:546
 msgid ""
 "Comma separated list of domains which are allowed in email addresses for "
 "registrations to this site. Wildcards are accepted. Empty to allow any "
 "domains"
 msgstr ""
 
-#: src/Module/Admin/Site.php:616
+#: src/Module/Admin/Site.php:547
 msgid "No OEmbed rich content"
 msgstr ""
 
-#: src/Module/Admin/Site.php:616
+#: src/Module/Admin/Site.php:547
 msgid ""
 "Don't show the rich content (e.g. embedded PDF), except from the domains "
 "listed below."
 msgstr ""
 
-#: src/Module/Admin/Site.php:617
+#: src/Module/Admin/Site.php:548
 msgid "Trusted third-party domains"
 msgstr ""
 
-#: src/Module/Admin/Site.php:617
+#: src/Module/Admin/Site.php:548
 msgid ""
 "Comma separated list of domains from which content is allowed to be embedded "
 "in posts like with OEmbed. All sub-domains of the listed domains are allowed "
 "as well."
 msgstr ""
 
-#: src/Module/Admin/Site.php:618
+#: src/Module/Admin/Site.php:549
 msgid "Block public"
 msgstr ""
 
-#: src/Module/Admin/Site.php:618
+#: src/Module/Admin/Site.php:549
 msgid ""
 "Check to block public access to all otherwise public personal pages on this "
 "site unless you are currently logged in."
 msgstr ""
 
-#: src/Module/Admin/Site.php:619
+#: src/Module/Admin/Site.php:550
 msgid "Force publish"
 msgstr ""
 
-#: src/Module/Admin/Site.php:619
+#: src/Module/Admin/Site.php:550
 msgid ""
 "Check to force all profiles on this site to be listed in the site directory."
 msgstr ""
 
-#: src/Module/Admin/Site.php:619
+#: src/Module/Admin/Site.php:550
 msgid "Enabling this may violate privacy laws like the GDPR"
 msgstr ""
 
-#: src/Module/Admin/Site.php:620
+#: src/Module/Admin/Site.php:551
 msgid "Global directory URL"
 msgstr ""
 
-#: src/Module/Admin/Site.php:620
+#: src/Module/Admin/Site.php:551
 msgid ""
 "URL to the global directory. If this is not set, the global directory is "
 "completely unavailable to the application."
 msgstr ""
 
-#: src/Module/Admin/Site.php:621
+#: src/Module/Admin/Site.php:552
 msgid "Private posts by default for new users"
 msgstr ""
 
-#: src/Module/Admin/Site.php:621
+#: src/Module/Admin/Site.php:552
 msgid ""
 "Set default post permissions for all new members to the default privacy "
 "group rather than public."
 msgstr ""
 
-#: src/Module/Admin/Site.php:622
+#: src/Module/Admin/Site.php:553
 msgid "Don't include post content in email notifications"
 msgstr ""
 
-#: src/Module/Admin/Site.php:622
+#: src/Module/Admin/Site.php:553
 msgid ""
 "Don't include the content of a post/comment/private message/etc. in the "
 "email notifications that are sent out from this site, as a privacy measure."
 msgstr ""
 
-#: src/Module/Admin/Site.php:623
+#: src/Module/Admin/Site.php:554
 msgid "Disallow public access to addons listed in the apps menu."
 msgstr ""
 
-#: src/Module/Admin/Site.php:623
+#: src/Module/Admin/Site.php:554
 msgid ""
 "Checking this box will restrict addons listed in the apps menu to members "
 "only."
 msgstr ""
 
-#: src/Module/Admin/Site.php:624
+#: src/Module/Admin/Site.php:555
 msgid "Don't embed private images in posts"
 msgstr ""
 
-#: src/Module/Admin/Site.php:624
+#: src/Module/Admin/Site.php:555
 msgid ""
 "Don't replace locally-hosted private photos in posts with an embedded copy "
 "of the image. This means that contacts who receive posts containing private "
 "photos will have to authenticate and load each image, which may take a while."
 msgstr ""
 
-#: src/Module/Admin/Site.php:625
+#: src/Module/Admin/Site.php:556
 msgid "Explicit Content"
 msgstr ""
 
-#: src/Module/Admin/Site.php:625
+#: src/Module/Admin/Site.php:556
 msgid ""
 "Set this to announce that your node is used mostly for explicit content that "
 "might not be suited for minors. This information will be published in the "
@@ -6034,234 +6013,234 @@ msgid ""
 "will be shown at the user registration page."
 msgstr ""
 
-#: src/Module/Admin/Site.php:626
+#: src/Module/Admin/Site.php:557
 msgid "Allow Users to set remote_self"
 msgstr ""
 
-#: src/Module/Admin/Site.php:626
+#: src/Module/Admin/Site.php:557
 msgid ""
 "With checking this, every user is allowed to mark every contact as a "
 "remote_self in the repair contact dialog. Setting this flag on a contact "
 "causes mirroring every posting of that contact in the users stream."
 msgstr ""
 
-#: src/Module/Admin/Site.php:627
+#: src/Module/Admin/Site.php:558
 msgid "Block multiple registrations"
 msgstr ""
 
-#: src/Module/Admin/Site.php:627
+#: src/Module/Admin/Site.php:558
 msgid "Disallow users to register additional accounts for use as pages."
 msgstr ""
 
-#: src/Module/Admin/Site.php:628
+#: src/Module/Admin/Site.php:559
 msgid "Disable OpenID"
 msgstr ""
 
-#: src/Module/Admin/Site.php:628
+#: src/Module/Admin/Site.php:559
 msgid "Disable OpenID support for registration and logins."
 msgstr ""
 
-#: src/Module/Admin/Site.php:629
+#: src/Module/Admin/Site.php:560
 msgid "No Fullname check"
 msgstr ""
 
-#: src/Module/Admin/Site.php:629
+#: src/Module/Admin/Site.php:560
 msgid ""
 "Allow users to register without a space between the first name and the last "
 "name in their full name."
 msgstr ""
 
-#: src/Module/Admin/Site.php:630
+#: src/Module/Admin/Site.php:561
 msgid "Community pages for visitors"
 msgstr ""
 
-#: src/Module/Admin/Site.php:630
+#: src/Module/Admin/Site.php:561
 msgid ""
 "Which community pages should be available for visitors. Local users always "
 "see both pages."
 msgstr ""
 
-#: src/Module/Admin/Site.php:631
+#: src/Module/Admin/Site.php:562
 msgid "Posts per user on community page"
 msgstr ""
 
-#: src/Module/Admin/Site.php:631
+#: src/Module/Admin/Site.php:562
 msgid ""
 "The maximum number of posts per user on the community page. (Not valid for "
 "\"Global Community\")"
 msgstr ""
 
-#: src/Module/Admin/Site.php:632
+#: src/Module/Admin/Site.php:563
 msgid "Disable OStatus support"
 msgstr ""
 
-#: src/Module/Admin/Site.php:632
+#: src/Module/Admin/Site.php:563
 msgid ""
 "Disable built-in OStatus (StatusNet, GNU Social etc.) compatibility. All "
 "communications in OStatus are public, so privacy warnings will be "
 "occasionally displayed."
 msgstr ""
 
-#: src/Module/Admin/Site.php:633
+#: src/Module/Admin/Site.php:564
 msgid "OStatus support can only be enabled if threading is enabled."
 msgstr ""
 
-#: src/Module/Admin/Site.php:635
+#: src/Module/Admin/Site.php:566
 msgid ""
 "Diaspora support can't be enabled because Friendica was installed into a sub "
 "directory."
 msgstr ""
 
-#: src/Module/Admin/Site.php:636
+#: src/Module/Admin/Site.php:567
 msgid "Enable Diaspora support"
 msgstr ""
 
-#: src/Module/Admin/Site.php:636
+#: src/Module/Admin/Site.php:567
 msgid "Provide built-in Diaspora network compatibility."
 msgstr ""
 
-#: src/Module/Admin/Site.php:637
+#: src/Module/Admin/Site.php:568
 msgid "Only allow Friendica contacts"
 msgstr ""
 
-#: src/Module/Admin/Site.php:637
+#: src/Module/Admin/Site.php:568
 msgid ""
 "All contacts must use Friendica protocols. All other built-in communication "
 "protocols disabled."
 msgstr ""
 
-#: src/Module/Admin/Site.php:638
+#: src/Module/Admin/Site.php:569
 msgid "Verify SSL"
 msgstr ""
 
-#: src/Module/Admin/Site.php:638
+#: src/Module/Admin/Site.php:569
 msgid ""
 "If you wish, you can turn on strict certificate checking. This will mean you "
 "cannot connect (at all) to self-signed SSL sites."
 msgstr ""
 
-#: src/Module/Admin/Site.php:639
+#: src/Module/Admin/Site.php:570
 msgid "Proxy user"
 msgstr ""
 
-#: src/Module/Admin/Site.php:640
+#: src/Module/Admin/Site.php:571
 msgid "Proxy URL"
 msgstr ""
 
-#: src/Module/Admin/Site.php:641
+#: src/Module/Admin/Site.php:572
 msgid "Network timeout"
 msgstr ""
 
-#: src/Module/Admin/Site.php:641
+#: src/Module/Admin/Site.php:572
 msgid "Value is in seconds. Set to 0 for unlimited (not recommended)."
 msgstr ""
 
-#: src/Module/Admin/Site.php:642
+#: src/Module/Admin/Site.php:573
 msgid "Maximum Load Average"
 msgstr ""
 
-#: src/Module/Admin/Site.php:642
+#: src/Module/Admin/Site.php:573
 #, php-format
 msgid ""
 "Maximum system load before delivery and poll processes are deferred - "
 "default %d."
 msgstr ""
 
-#: src/Module/Admin/Site.php:643
+#: src/Module/Admin/Site.php:574
 msgid "Maximum Load Average (Frontend)"
 msgstr ""
 
-#: src/Module/Admin/Site.php:643
+#: src/Module/Admin/Site.php:574
 msgid "Maximum system load before the frontend quits service - default 50."
 msgstr ""
 
-#: src/Module/Admin/Site.php:644
+#: src/Module/Admin/Site.php:575
 msgid "Minimal Memory"
 msgstr ""
 
-#: src/Module/Admin/Site.php:644
+#: src/Module/Admin/Site.php:575
 msgid ""
 "Minimal free memory in MB for the worker. Needs access to /proc/meminfo - "
 "default 0 (deactivated)."
 msgstr ""
 
-#: src/Module/Admin/Site.php:645
+#: src/Module/Admin/Site.php:576
 msgid "Periodically optimize tables"
 msgstr ""
 
-#: src/Module/Admin/Site.php:645
+#: src/Module/Admin/Site.php:576
 msgid "Periodically optimize tables like the cache and the workerqueue"
 msgstr ""
 
-#: src/Module/Admin/Site.php:647
+#: src/Module/Admin/Site.php:578
 msgid "Discover followers/followings from contacts"
 msgstr ""
 
-#: src/Module/Admin/Site.php:647
+#: src/Module/Admin/Site.php:578
 msgid ""
 "If enabled, contacts are checked for their followers and following contacts."
 msgstr ""
 
-#: src/Module/Admin/Site.php:648
+#: src/Module/Admin/Site.php:579
 msgid "None - deactivated"
 msgstr ""
 
-#: src/Module/Admin/Site.php:649
+#: src/Module/Admin/Site.php:580
 msgid ""
 "Local contacts - contacts of our local contacts are discovered for their "
 "followers/followings."
 msgstr ""
 
-#: src/Module/Admin/Site.php:650
+#: src/Module/Admin/Site.php:581
 msgid ""
 "Interactors - contacts of our local contacts and contacts who interacted on "
 "locally visible postings are discovered for their followers/followings."
 msgstr ""
 
-#: src/Module/Admin/Site.php:652
+#: src/Module/Admin/Site.php:583
 msgid "Synchronize the contacts with the directory server"
 msgstr ""
 
-#: src/Module/Admin/Site.php:652
+#: src/Module/Admin/Site.php:583
 msgid ""
 "if enabled, the system will check periodically for new contacts on the "
 "defined directory server."
 msgstr ""
 
-#: src/Module/Admin/Site.php:654
+#: src/Module/Admin/Site.php:585
 msgid "Days between requery"
 msgstr ""
 
-#: src/Module/Admin/Site.php:654
+#: src/Module/Admin/Site.php:585
 msgid "Number of days after which a server is requeried for his contacts."
 msgstr ""
 
-#: src/Module/Admin/Site.php:655
+#: src/Module/Admin/Site.php:586
 msgid "Discover contacts from other servers"
 msgstr ""
 
-#: src/Module/Admin/Site.php:655
+#: src/Module/Admin/Site.php:586
 msgid ""
 "Periodically query other servers for contacts. The system queries Friendica, "
 "Mastodon and Hubzilla servers."
 msgstr ""
 
-#: src/Module/Admin/Site.php:656
+#: src/Module/Admin/Site.php:587
 msgid "Search the local directory"
 msgstr ""
 
-#: src/Module/Admin/Site.php:656
+#: src/Module/Admin/Site.php:587
 msgid ""
 "Search the local directory instead of the global directory. When searching "
 "locally, every search will be executed on the global directory in the "
 "background. This improves the search results when the search is repeated."
 msgstr ""
 
-#: src/Module/Admin/Site.php:658
+#: src/Module/Admin/Site.php:589
 msgid "Publish server information"
 msgstr ""
 
-#: src/Module/Admin/Site.php:658
+#: src/Module/Admin/Site.php:589
 msgid ""
 "If enabled, general server and usage data will be published. The data "
 "contains the name and version of the server, number of users with public "
@@ -6269,50 +6248,50 @@ msgid ""
 "href=\"http://the-federation.info/\">the-federation.info</a> for details."
 msgstr ""
 
-#: src/Module/Admin/Site.php:660
+#: src/Module/Admin/Site.php:591
 msgid "Check upstream version"
 msgstr ""
 
-#: src/Module/Admin/Site.php:660
+#: src/Module/Admin/Site.php:591
 msgid ""
 "Enables checking for new Friendica versions at github. If there is a new "
 "version, you will be informed in the admin panel overview."
 msgstr ""
 
-#: src/Module/Admin/Site.php:661
+#: src/Module/Admin/Site.php:592
 msgid "Suppress Tags"
 msgstr ""
 
-#: src/Module/Admin/Site.php:661
+#: src/Module/Admin/Site.php:592
 msgid "Suppress showing a list of hashtags at the end of the posting."
 msgstr ""
 
-#: src/Module/Admin/Site.php:662
+#: src/Module/Admin/Site.php:593
 msgid "Clean database"
 msgstr ""
 
-#: src/Module/Admin/Site.php:662
+#: src/Module/Admin/Site.php:593
 msgid ""
 "Remove old remote items, orphaned database records and old content from some "
 "other helper tables."
 msgstr ""
 
-#: src/Module/Admin/Site.php:663
+#: src/Module/Admin/Site.php:594
 msgid "Lifespan of remote items"
 msgstr ""
 
-#: src/Module/Admin/Site.php:663
+#: src/Module/Admin/Site.php:594
 msgid ""
 "When the database cleanup is enabled, this defines the days after which "
 "remote items will be deleted. Own items, and marked or filed items are "
 "always kept. 0 disables this behaviour."
 msgstr ""
 
-#: src/Module/Admin/Site.php:664
+#: src/Module/Admin/Site.php:595
 msgid "Lifespan of unclaimed items"
 msgstr ""
 
-#: src/Module/Admin/Site.php:664
+#: src/Module/Admin/Site.php:595
 msgid ""
 "When the database cleanup is enabled, this defines the days after which "
 "unclaimed remote items (mostly content from the relay) will be deleted. "
@@ -6320,157 +6299,185 @@ msgid ""
 "items if set to 0."
 msgstr ""
 
-#: src/Module/Admin/Site.php:665
+#: src/Module/Admin/Site.php:596
 msgid "Lifespan of raw conversation data"
 msgstr ""
 
-#: src/Module/Admin/Site.php:665
+#: src/Module/Admin/Site.php:596
 msgid ""
 "The conversation data is used for ActivityPub and OStatus, as well as for "
 "debug purposes. It should be safe to remove it after 14 days, default is 90 "
 "days."
 msgstr ""
 
-#: src/Module/Admin/Site.php:666
+#: src/Module/Admin/Site.php:597
 msgid "Maximum numbers of comments per post"
 msgstr ""
 
-#: src/Module/Admin/Site.php:666
+#: src/Module/Admin/Site.php:597
 msgid "How much comments should be shown for each post? Default value is 100."
 msgstr ""
 
-#: src/Module/Admin/Site.php:667
+#: src/Module/Admin/Site.php:598
 msgid "Maximum numbers of comments per post on the display page"
 msgstr ""
 
-#: src/Module/Admin/Site.php:667
+#: src/Module/Admin/Site.php:598
 msgid ""
 "How many comments should be shown on the single view for each post? Default "
 "value is 1000."
 msgstr ""
 
-#: src/Module/Admin/Site.php:668
+#: src/Module/Admin/Site.php:599
 msgid "Temp path"
 msgstr ""
 
-#: src/Module/Admin/Site.php:668
+#: src/Module/Admin/Site.php:599
 msgid ""
 "If you have a restricted system where the webserver can't access the system "
 "temp path, enter another path here."
 msgstr ""
 
-#: src/Module/Admin/Site.php:669
+#: src/Module/Admin/Site.php:600
 msgid "Only search in tags"
 msgstr ""
 
-#: src/Module/Admin/Site.php:669
+#: src/Module/Admin/Site.php:600
 msgid "On large systems the text search can slow down the system extremely."
 msgstr ""
 
-#: src/Module/Admin/Site.php:671
+#: src/Module/Admin/Site.php:602
 msgid "New base url"
 msgstr ""
 
-#: src/Module/Admin/Site.php:671
+#: src/Module/Admin/Site.php:602
 msgid ""
 "Change base url for this server. Sends relocate message to all Friendica and "
 "Diaspora* contacts of all users."
 msgstr ""
 
-#: src/Module/Admin/Site.php:673
+#: src/Module/Admin/Site.php:604
 msgid "RINO Encryption"
 msgstr ""
 
-#: src/Module/Admin/Site.php:673
+#: src/Module/Admin/Site.php:604
 msgid "Encryption layer between nodes."
 msgstr ""
 
-#: src/Module/Admin/Site.php:673 src/Module/Admin/Site.php:679
+#: src/Module/Admin/Site.php:604 src/Module/Admin/Site.php:610
 #: src/Module/Contact.php:527 src/Module/Settings/TwoFactor/Index.php:118
 msgid "Disabled"
 msgstr ""
 
-#: src/Module/Admin/Site.php:673
+#: src/Module/Admin/Site.php:604
 msgid "Enabled"
 msgstr ""
 
-#: src/Module/Admin/Site.php:675
+#: src/Module/Admin/Site.php:606
 msgid "Maximum number of parallel workers"
 msgstr ""
 
-#: src/Module/Admin/Site.php:675
+#: src/Module/Admin/Site.php:606
 #, php-format
 msgid ""
 "On shared hosters set this to %d. On larger systems, values of %d are great. "
 "Default value is %d."
 msgstr ""
 
-#: src/Module/Admin/Site.php:676
+#: src/Module/Admin/Site.php:607
 msgid "Enable fastlane"
 msgstr ""
 
-#: src/Module/Admin/Site.php:676
+#: src/Module/Admin/Site.php:607
 msgid ""
 "When enabed, the fastlane mechanism starts an additional worker if processes "
 "with higher priority are blocked by processes of lower priority."
 msgstr ""
 
-#: src/Module/Admin/Site.php:678
+#: src/Module/Admin/Site.php:609
 msgid "Direct relay transfer"
 msgstr ""
 
-#: src/Module/Admin/Site.php:678
+#: src/Module/Admin/Site.php:609
 msgid ""
 "Enables the direct transfer to other servers without using the relay servers"
 msgstr ""
 
-#: src/Module/Admin/Site.php:679
+#: src/Module/Admin/Site.php:610
 msgid "Relay scope"
 msgstr ""
 
-#: src/Module/Admin/Site.php:679
+#: src/Module/Admin/Site.php:610
 msgid ""
 "Can be \"all\" or \"tags\". \"all\" means that every public post should be "
 "received. \"tags\" means that only posts with selected tags should be "
 "received."
 msgstr ""
 
-#: src/Module/Admin/Site.php:679
+#: src/Module/Admin/Site.php:610
 msgid "all"
 msgstr ""
 
-#: src/Module/Admin/Site.php:679
+#: src/Module/Admin/Site.php:610
 msgid "tags"
 msgstr ""
 
-#: src/Module/Admin/Site.php:680
+#: src/Module/Admin/Site.php:611
 msgid "Server tags"
 msgstr ""
 
-#: src/Module/Admin/Site.php:680
+#: src/Module/Admin/Site.php:611
 msgid "Comma separated list of tags for the \"tags\" subscription."
 msgstr ""
 
-#: src/Module/Admin/Site.php:681
+#: src/Module/Admin/Site.php:612
 msgid "Deny Server tags"
 msgstr ""
 
-#: src/Module/Admin/Site.php:681
+#: src/Module/Admin/Site.php:612
 msgid "Comma separated list of tags that are rejected."
 msgstr ""
 
-#: src/Module/Admin/Site.php:682
+#: src/Module/Admin/Site.php:613
 msgid "Allow user tags"
 msgstr ""
 
-#: src/Module/Admin/Site.php:682
+#: src/Module/Admin/Site.php:613
 msgid ""
 "If enabled, the tags from the saved searches will used for the \"tags\" "
 "subscription in addition to the \"relay_server_tags\"."
 msgstr ""
 
-#: src/Module/Admin/Site.php:685
+#: src/Module/Admin/Site.php:616
 msgid "Start Relocation"
+msgstr ""
+
+#: src/Module/Admin/Storage.php:72
+msgid "Invalid storage backend setting value."
+msgstr ""
+
+#: src/Module/Admin/Storage.php:90
+msgid "Database (legacy)"
+msgstr ""
+
+#: src/Module/Admin/Storage.php:127 src/Module/BaseAdmin.php:91
+msgid "Storage"
+msgstr ""
+
+#: src/Module/Admin/Storage.php:129
+msgid "Save & Activate"
+msgstr ""
+
+#: src/Module/Admin/Storage.php:130
+msgid "Activate"
+msgstr ""
+
+#: src/Module/Admin/Storage.php:131
+msgid "Save & Reload"
+msgstr ""
+
+#: src/Module/Admin/Storage.php:132
+msgid "This backend doesn't have custom settings"
 msgstr ""
 
 #: src/Module/Admin/Summary.php:53
@@ -6669,7 +6676,7 @@ msgid "Screenshot"
 msgstr ""
 
 #: src/Module/Admin/Themes/Details.php:91 src/Module/Admin/Themes/Index.php:112
-#: src/Module/BaseAdmin.php:93
+#: src/Module/BaseAdmin.php:94
 msgid "Themes"
 msgstr ""
 
@@ -6870,7 +6877,7 @@ msgid "Permanent deletion"
 msgstr ""
 
 #: src/Module/Admin/Users/Index.php:150 src/Module/Admin/Users/Index.php:160
-#: src/Module/BaseAdmin.php:91
+#: src/Module/BaseAdmin.php:92
 msgid "Users"
 msgstr ""
 
@@ -6997,67 +7004,67 @@ msgstr ""
 msgid "Configuration"
 msgstr ""
 
-#: src/Module/BaseAdmin.php:94 src/Module/BaseSettings.php:65
+#: src/Module/BaseAdmin.php:95 src/Module/BaseSettings.php:65
 msgid "Additional features"
 msgstr ""
 
-#: src/Module/BaseAdmin.php:97
+#: src/Module/BaseAdmin.php:98
 msgid "Database"
 msgstr ""
 
-#: src/Module/BaseAdmin.php:98
+#: src/Module/BaseAdmin.php:99
 msgid "DB updates"
 msgstr ""
 
-#: src/Module/BaseAdmin.php:99
+#: src/Module/BaseAdmin.php:100
 msgid "Inspect Deferred Workers"
 msgstr ""
 
-#: src/Module/BaseAdmin.php:100
+#: src/Module/BaseAdmin.php:101
 msgid "Inspect worker Queue"
 msgstr ""
 
-#: src/Module/BaseAdmin.php:102
+#: src/Module/BaseAdmin.php:103
 msgid "Tools"
 msgstr ""
 
-#: src/Module/BaseAdmin.php:103
+#: src/Module/BaseAdmin.php:104
 msgid "Contact Blocklist"
 msgstr ""
 
-#: src/Module/BaseAdmin.php:104
+#: src/Module/BaseAdmin.php:105
 msgid "Server Blocklist"
 msgstr ""
 
-#: src/Module/BaseAdmin.php:111
+#: src/Module/BaseAdmin.php:112
 msgid "Diagnostics"
 msgstr ""
 
-#: src/Module/BaseAdmin.php:112
+#: src/Module/BaseAdmin.php:113
 msgid "PHP Info"
 msgstr ""
 
-#: src/Module/BaseAdmin.php:113
+#: src/Module/BaseAdmin.php:114
 msgid "probe address"
 msgstr ""
 
-#: src/Module/BaseAdmin.php:114
+#: src/Module/BaseAdmin.php:115
 msgid "check webfinger"
 msgstr ""
 
-#: src/Module/BaseAdmin.php:116
+#: src/Module/BaseAdmin.php:117
 msgid "Babel"
 msgstr ""
 
-#: src/Module/BaseAdmin.php:117 src/Module/Debug/ActivityPubConversion.php:138
+#: src/Module/BaseAdmin.php:118 src/Module/Debug/ActivityPubConversion.php:138
 msgid "ActivityPub Conversion"
 msgstr ""
 
-#: src/Module/BaseAdmin.php:126
+#: src/Module/BaseAdmin.php:127
 msgid "Addon Features"
 msgstr ""
 
-#: src/Module/BaseAdmin.php:127
+#: src/Module/BaseAdmin.php:128
 msgid "User registrations waiting for confirmation"
 msgstr ""
 

--- a/view/templates/admin/site.tpl
+++ b/view/templates/admin/site.tpl
@@ -40,11 +40,6 @@
 		<div class="submit"><input type="submit" name="page_site" value="{{$submit}}"/></div>
 
 		<h2>{{$upload}}</h2>
-		{{include file="field_select.tpl" field=$storagebackend}}
-		{{foreach from=$storageform item=$field}}
-			{{include file=$field.field field=$field}}
-		{{/foreach}}
-		<hr>
 		{{include file="field_input.tpl" field=$maximagesize}}
 		{{include file="field_input.tpl" field=$maximagelength}}
 		{{include file="field_input.tpl" field=$jpegimagequality}}

--- a/view/templates/admin/storage.tpl
+++ b/view/templates/admin/storage.tpl
@@ -1,0 +1,15 @@
+<div id='adminpage'>
+	<h1>{{$title}} - {{$page}}</h1>
+
+	<form action="{{$baseurl}}/admin/storage" method="post">
+		<input type='hidden' name='form_security_token' value="{{$form_security_token}}">
+
+		{{include file="field_select.tpl" field=$storagebackend}}
+		{{foreach from=$storageform item=$field}}
+		{{include file=$field.field field=$field}}
+		{{/foreach}}
+
+		<div class="submit"><input type="submit" name="page_logs" value="{{$submit}}" /></div>
+
+	</form>
+</div>

--- a/view/templates/admin/storage.tpl
+++ b/view/templates/admin/storage.tpl
@@ -4,9 +4,18 @@
 	<form action="{{$baseurl}}/admin/storage" method="post">
 		<input type='hidden' name='form_security_token' value="{{$form_security_token}}">
 
+		<h2>Storage Backend</h2>
+
 		{{include file="field_select.tpl" field=$storagebackend}}
-		{{foreach from=$storageform item=$field}}
+		<div class="submit"><input type="submit" name="page_logs" value="{{$submit}}" /></div>
+
+		<h2>Storage Configuration</h2>
+
+		{{foreach from=$availablestorageforms item=$storage}}
+		<h3>{{$storage.name}}</h3>
+		{{foreach from=$storage.form item=$field}}
 		{{include file=$field.field field=$field}}
+		{{/foreach}}
 		{{/foreach}}
 
 		<div class="submit"><input type="submit" name="page_logs" value="{{$submit}}" /></div>

--- a/view/templates/admin/storage.tpl
+++ b/view/templates/admin/storage.tpl
@@ -1,24 +1,23 @@
 <div id='adminpage'>
 	<h1>{{$title}} - {{$page}}</h1>
 
-	<form action="{{$baseurl}}/admin/storage" method="post">
-		<input type='hidden' name='form_security_token' value="{{$form_security_token}}">
-
-		<h2>Storage Backend</h2>
-
-		{{include file="field_select.tpl" field=$storagebackend}}
-		<div class="submit"><input type="submit" name="page_storage" value="{{$submit}}" /></div>
+		<h2>Current Storage Backend: <b>{{$storagebackend}}</b></h2>
 
 		<h2>Storage Configuration</h2>
 
 		{{foreach from=$availablestorageforms item=$storage}}
+	<form action="{{$baseurl}}/admin/storage/{{$storage.prefix}}" method="post">
+		<input type='hidden' name='form_security_token' value="{{$form_security_token}}">
 		<h3>{{$storage.name}}</h3>
 		{{foreach from=$storage.form item=$field}}
 		{{include file=$field.field field=$field}}
 		{{/foreach}}
+
+		{{if $storage.form}}
+		<div class="submit"><input type="submit" name="submit_save" value="{{$save}}" /></div>
+		{{/if}}
+		<div class="submit"><input type="submit" name="submit_save_set" value="{{$save_set}}" /></div>
+	</form>
 		{{/foreach}}
 
-		<div class="submit"><input type="submit" name="page_storage" value="{{$submit}}" /></div>
-
-	</form>
 </div>

--- a/view/templates/admin/storage.tpl
+++ b/view/templates/admin/storage.tpl
@@ -9,14 +9,24 @@
 	<form action="{{$baseurl}}/admin/storage/{{$storage.prefix}}" method="post">
 		<input type='hidden' name='form_security_token' value="{{$form_security_token}}">
 		<h3>{{$storage.name}}</h3>
-		{{foreach from=$storage.form item=$field}}
-		{{include file=$field.field field=$field}}
-		{{/foreach}}
+		{{if $storage.form}}
+			{{foreach from=$storage.form item=$field}}
+				{{include file=$field.field field=$field}}
+			{{/foreach}}
+		{{else}}
+			{{$noconfig}}
+		{{/if}}
 
 		{{if $storage.form}}
-		<div class="submit"><input type="submit" name="submit_save" value="{{$save}}" /></div>
+		<input type="submit" name="submit_save" value="{{$save}}"/>
+		{{if $storage.active}}
+		<input type="submit" name="submit_save_set" value="{{$save_reload}}"/>
+		{{else}}
+		<input type="submit" name="submit_save_set" value="{{$save_activate}}"/>
 		{{/if}}
-		<div class="submit"><input type="submit" name="submit_save_set" value="{{$save_set}}" /></div>
+		{{else}}
+		<br /><input type="submit" name="submit_save_set" {{if $storage.active}}disabled="disabled"{{/if}} value="{{$activate}}"/>
+		{{/if}}
 	</form>
 		{{/foreach}}
 

--- a/view/templates/admin/storage.tpl
+++ b/view/templates/admin/storage.tpl
@@ -7,7 +7,7 @@
 		<h2>Storage Backend</h2>
 
 		{{include file="field_select.tpl" field=$storagebackend}}
-		<div class="submit"><input type="submit" name="page_logs" value="{{$submit}}" /></div>
+		<div class="submit"><input type="submit" name="page_storage" value="{{$submit}}" /></div>
 
 		<h2>Storage Configuration</h2>
 
@@ -18,7 +18,7 @@
 		{{/foreach}}
 		{{/foreach}}
 
-		<div class="submit"><input type="submit" name="page_logs" value="{{$submit}}" /></div>
+		<div class="submit"><input type="submit" name="page_storage" value="{{$submit}}" /></div>
 
 	</form>
 </div>

--- a/view/theme/frio/templates/admin/site.tpl
+++ b/view/theme/frio/templates/admin/site.tpl
@@ -100,11 +100,6 @@
 				</div>
 				<div id="admin-settings-upload-collapse" class="panel-collapse collapse" role="tabpanel" aria-labelledby="admin-settings-upload">
 					<div class="panel-body">
-						{{include file="field_select.tpl" field=$storagebackend}}
-						{{foreach from=$storageform item=$field}}
-							{{include file=$field.field field=$field}}
-						{{/foreach}}
-						<hr>
 						{{include file="field_input.tpl" field=$maximagesize}}
 						{{include file="field_input.tpl" field=$maximagelength}}
 						{{include file="field_input.tpl" field=$jpegimagequality}}

--- a/view/theme/frio/templates/admin/storage.tpl
+++ b/view/theme/frio/templates/admin/storage.tpl
@@ -9,27 +9,27 @@
 		<h2>Storage Backend</h2>
 
 		{{include file="field_select.tpl" field=$storagebackend}}
-		<input type="submit" name="page_site" class="btn btn-primary" value="{{$submit}}"/>
+		<input type="submit" name="page_storage" class="btn btn-primary" value="{{$submit}}"/>
 
 		<h2>Storage Configuration</h2>
 
 		{{foreach from=$availablestorageforms item=$storage}}
 		<div class="panel">
-			<div class="section-subtitle-wrapper panel-heading" role="tab" id="admin-settings-upload">
+			<div class="section-subtitle-wrapper panel-heading" role="tab" id="admin-settings-{{$storage.prefix}}">
 				<h3>
-					<a class="accordion-toggle collapsed" data-toggle="collapse" data-parent="#admin-settings" href="#admin-settings-upload-collapse" aria-expanded="false" aria-controls="admin-settings-upload-collapse">
+					<a class="accordion-toggle collapsed" data-toggle="collapse" data-parent="#admin-settings" href="#admin-settings-{{$storage.prefix}}-collapse" aria-expanded="false" aria-controls="admin-settings-{{$storage.prefix}}-collapse">
 						{{$storage.name}}
 					</a>
 				</h3>
 			</div>
-			<div id="admin-settings-upload-collapse" class="panel-collapse collapse" role="tabpanel" aria-labelledby="admin-settings-upload">
+			<div id="admin-settings-{{$storage.prefix}}-collapse" class="panel-collapse collapse" role="tabpanel" aria-labelledby="admin-settings-{{$storage.prefix}}">
 				<div class="panel-body">
 					{{foreach from=$storage.form item=$field}}
 					{{include file=$field.field field=$field}}
 					{{/foreach}}
 				</div>
 				<div class="panel-footer">
-					<input type="submit" name="page_site" class="btn btn-primary" value="{{$submit}}"/>
+					<input type="submit" name="page_storage" class="btn btn-primary" value="{{$submit}}"/>
 				</div>
 			</div>
 		</div>

--- a/view/theme/frio/templates/admin/storage.tpl
+++ b/view/theme/frio/templates/admin/storage.tpl
@@ -22,15 +22,25 @@
 			</div>
 			<div id="admin-settings-{{$storage.prefix}}-collapse" class="panel-collapse collapse" role="tabpanel" aria-labelledby="admin-settings-{{$storage.prefix}}">
 				<div class="panel-body">
-					{{foreach from=$storage.form item=$field}}
-					{{include file=$field.field field=$field}}
-					{{/foreach}}
+					{{if $storage.form}}
+						{{foreach from=$storage.form item=$field}}
+							{{include file=$field.field field=$field}}
+						{{/foreach}}
+					{{else}}
+						 {{$noconfig}}
+					{{/if}}
 				</div>
 				<div class="panel-footer">
 					{{if $storage.form}}
 					<input type="submit" name="submit_save" class="btn btn-primary" value="{{$save}}"/>
+						{{if $storage.active}}
+					<input type="submit" name="submit_save_set" class="btn btn-primary" value="{{$save_reload}}"/>
+						{{else}}
+					<input type="submit" name="submit_save_set" class="btn btn-primary" value="{{$save_activate}}"/>
+						{{/if}}
+					{{else}}
+					<input type="submit" name="submit_save_set" class="btn btn-primary" {{if $storage.active}}disabled="disabled"{{/if}} value="{{$activate}}"/>
 					{{/if}}
-					<input type="submit" name="submit_save_set" class="btn btn-primary" value="{{$save_set}}"/>
 				</div>
 			</div>
 		</div>

--- a/view/theme/frio/templates/admin/storage.tpl
+++ b/view/theme/frio/templates/admin/storage.tpl
@@ -1,0 +1,40 @@
+<link rel="stylesheet" href="view/theme/frio/css/mod_admin.css?v={{$smarty.const.FRIENDICA_VERSION}}" type="text/css" media="screen"/>
+
+<div id="adminpage" class="adminpage generic-page-wrapper">
+	<h1>{{$title}} - {{$page}}</h1>
+
+	<form action="{{$baseurl}}/admin/storage" method="post">
+		<input type='hidden' name='form_security_token' value="{{$form_security_token}}">
+
+		<h2>Storage Backend</h2>
+
+		{{include file="field_select.tpl" field=$storagebackend}}
+		<input type="submit" name="page_site" class="btn btn-primary" value="{{$submit}}"/>
+
+		<h2>Storage Configuration</h2>
+
+		{{foreach from=$availablestorageforms item=$storage}}
+		<div class="panel">
+			<div class="section-subtitle-wrapper panel-heading" role="tab" id="admin-settings-upload">
+				<h3>
+					<a class="accordion-toggle collapsed" data-toggle="collapse" data-parent="#admin-settings" href="#admin-settings-upload-collapse" aria-expanded="false" aria-controls="admin-settings-upload-collapse">
+						{{$storage.name}}
+					</a>
+				</h3>
+			</div>
+			<div id="admin-settings-upload-collapse" class="panel-collapse collapse" role="tabpanel" aria-labelledby="admin-settings-upload">
+				<div class="panel-body">
+					{{foreach from=$storage.form item=$field}}
+					{{include file=$field.field field=$field}}
+					{{/foreach}}
+				</div>
+				<div class="panel-footer">
+					<input type="submit" name="page_site" class="btn btn-primary" value="{{$submit}}"/>
+				</div>
+			</div>
+		</div>
+
+		{{/foreach}}
+
+	</form>
+</div>

--- a/view/theme/frio/templates/admin/storage.tpl
+++ b/view/theme/frio/templates/admin/storage.tpl
@@ -3,19 +3,17 @@
 <div id="adminpage" class="adminpage generic-page-wrapper">
 	<h1>{{$title}} - {{$page}}</h1>
 
-	<form action="{{$baseurl}}/admin/storage" method="post">
-		<input type='hidden' name='form_security_token' value="{{$form_security_token}}">
-
-		<h2>Storage Backend</h2>
-
-		{{include file="field_select.tpl" field=$storagebackend}}
-		<input type="submit" name="page_storage" class="btn btn-primary" value="{{$submit}}"/>
+	<div class="well well-lg">
+			Current Storage Backend: <b>{{$storagebackend}}</b>
+	</div>
 
 		<h2>Storage Configuration</h2>
 
 		{{foreach from=$availablestorageforms item=$storage}}
+	<form action="{{$baseurl}}/admin/storage/{{$storage.prefix}}" method="post">
+		<input type='hidden' name='form_security_token' value="{{$form_security_token}}">
 		<div class="panel">
-			<div class="section-subtitle-wrapper panel-heading" role="tab" id="admin-settings-{{$storage.prefix}}">
+			<div class="section-subtitle-wrapper panel-title" role="tab" id="admin-settings-{{$storage.prefix}}">
 				<h3>
 					<a class="accordion-toggle collapsed" data-toggle="collapse" data-parent="#admin-settings" href="#admin-settings-{{$storage.prefix}}-collapse" aria-expanded="false" aria-controls="admin-settings-{{$storage.prefix}}-collapse">
 						{{$storage.name}}
@@ -29,10 +27,14 @@
 					{{/foreach}}
 				</div>
 				<div class="panel-footer">
-					<input type="submit" name="page_storage" class="btn btn-primary" value="{{$submit}}"/>
+					{{if $storage.form}}
+					<input type="submit" name="submit_save" class="btn btn-primary" value="{{$save}}"/>
+					{{/if}}
+					<input type="submit" name="submit_save_set" class="btn btn-primary" value="{{$save_set}}"/>
 				</div>
 			</div>
 		</div>
+	</form>
 
 		{{/foreach}}
 


### PR DESCRIPTION
There was a design flaw at the storage configuration workflow.
It's just possible to edit the configuration of a storage **after** you activate it, so you need to activate it with default/blank settings before you can change it. This isn't what we want I guess ;-) ..

I found this issue during an upcoming addon "S3 Object Storage" ;-)

There's now a new admin page "Storage" at the section "Configuration", where all settings of all available backends are visibile. But the specific settings get only evaluated when activating the corresponding backend.

I tried it at my local node with different situations and it worked as expected.

Features:
- save settings for each storage type (including checks)
- save settings and activate for each storage type (including checks)

![grafik](https://user-images.githubusercontent.com/379654/126875721-5e9ca1f6-dd80-4d80-addb-32fc9e0c4f62.png)

![grafik](https://user-images.githubusercontent.com/379654/126875748-6c813add-48d8-4eb7-8e42-70386f178b2a.png)
