### PR TITLE
Sanitize negative status count on APContact

### DIFF
--- a/src/Model/APContact.php
+++ b/src/Model/APContact.php
@@ -330,6 +330,11 @@ class APContact
 				$outbox = ActivityPub::fetchContent($apcontact['outbox']);
 			}
 			if (!empty($outbox['totalItems'])) {
+				// Mastodon seriously allows for this condition?
+				// Jul 20 2021 - See https://chaos.social/@m11 for a negative posts count
+				if ($outbox['totalItems'] < 0) {
+					$outbox['totalItems'] = 0;
+				}
 				$apcontact['statuses_count'] = $outbox['totalItems'];
 			}
 		}


### PR DESCRIPTION
Similar to PR #10499, Mastodon apparently has some counting flaws and
can present a negative status count for a user, causing Friendica to
fail (at least under PHP 8) with:

[20-Jul-2021 16:35:18 UTC] PHP Fatal error:  Uncaught PDOException: SQLSTATE[22003]: Numeric value out of range: 1264 Out of range value for column 'statuses_count' at row 1 in /home/friendicadev/friendica/src/Database/Database.php:560
Stack trace:
  thrown in /home/friendicadev/friendica/src/Database/Database.php on line 560

This change prevents values lower than 0 from being assigned to
statuses_count.