### PR TITLE
Add Exception for unexpected case

### DIFF
--- a/src/Model/APContact.php
+++ b/src/Model/APContact.php
@@ -28,6 +28,7 @@ use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\Database\DBStructure;
 use Friendica\DI;
+use Friendica\Network\HTTPException;
 use Friendica\Network\Probe;
 use Friendica\Protocol\ActivityNamespace;
 use Friendica\Protocol\ActivityPub;
@@ -178,8 +179,12 @@ class APContact
 		}
 
 		if (Network::isLocalLink($url) && ($local_uid = User::getIdForURL($url))) {
-			$data  = Transmitter::getProfile($local_uid);
-			$local_owner = User::getOwnerDataById($local_uid);
+			try {
+				$data = Transmitter::getProfile($local_uid);
+				$local_owner = User::getOwnerDataById($local_uid);
+			} catch(HTTPException\NotFoundException $e) {
+				$data = null;
+			}
 		}
 
 		if (empty($data)) {

--- a/src/Module/Friendica.php
+++ b/src/Module/Friendica.php
@@ -29,6 +29,7 @@ use Friendica\Core\System;
 use Friendica\Database\PostUpdate;
 use Friendica\DI;
 use Friendica\Model\User;
+use Friendica\Network\HTTPException;
 use Friendica\Protocol\ActivityPub;
 
 /**
@@ -112,11 +113,13 @@ class Friendica extends BaseModule
 	public static function rawContent(array $parameters = [])
 	{
 		if (ActivityPub::isRequest()) {
-			$data = ActivityPub\Transmitter::getProfile(0);
-			if (!empty($data)) {
+			try {
+				$data = ActivityPub\Transmitter::getProfile(0);
 				header('Access-Control-Allow-Origin: *');
 				header('Cache-Control: max-age=23200, stale-while-revalidate=23200');
 				System::jsonExit($data, 'application/activity+json');
+			} catch (HTTPException\NotFoundException $e) {
+				System::jsonError(404, ['error' => 'Record not found']);
 			}
 		}
 

--- a/src/Module/Profile/Profile.php
+++ b/src/Module/Profile/Profile.php
@@ -52,12 +52,13 @@ class Profile extends BaseProfile
 		if (ActivityPub::isRequest()) {
 			$user = DBA::selectFirst('user', ['uid'], ['nickname' => $parameters['nickname']]);
 			if (DBA::isResult($user)) {
-				// The function returns an empty array when the account is removed, expired or blocked
-				$data = ActivityPub\Transmitter::getProfile($user['uid']);
-				if (!empty($data)) {
+				try {
+					$data = ActivityPub\Transmitter::getProfile($user['uid']);
 					header('Access-Control-Allow-Origin: *');
 					header('Cache-Control: max-age=23200, stale-while-revalidate=23200');
 					System::jsonExit($data, 'application/activity+json');
+				} catch (HTTPException\NotFoundException $e) {
+					System::jsonError(404, ['error' => 'Record not found']);
 				}
 			}
 


### PR DESCRIPTION
- Address https://github.com/friendica/friendica/issues/10473#issuecomment-882781552
- Address https://github.com/friendica/friendica/issues/10474#issuecomment-882696860

This PR is about whether execution should go forward when `User::getOwnerDataById` doesn't return an owner array. Is there a good reason to proceed when the return is `false`?