### PR TITLE
Avoid "DB Error" messages

### DIFF
--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -451,7 +451,7 @@ class BBCode
 		// Only send proxied pictures to API and for internal display
 		if (!in_array($simplehtml, [self::INTERNAL, self::API])) {
 			return $image;
-		} elseif ($uriid) {
+		} elseif ($uriid > 0) {
 			return Post\Link::getByLink($uriid, $image, $size);
 		} else {
 			return ProxyUtils::proxifyUrl($image, $size);

--- a/src/Model/Post/Link.php
+++ b/src/Model/Post/Link.php
@@ -23,6 +23,7 @@ namespace Friendica\Model\Post;
 
 use Friendica\Core\Logger;
 use Friendica\Core\System;
+use Friendica\Database\Database;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Util\Proxy;
@@ -52,7 +53,7 @@ class Link
 		} else {
 			$mime = self::fetchMimeType($url);
 
-			DBA::insert('post-link', ['uri-id' => $uri_id, 'url' => $url, 'mimetype' => $mime]);
+			DBA::insert('post-link', ['uri-id' => $uri_id, 'url' => $url, 'mimetype' => $mime], Database::INSERT_IGNORE);
 			$id = DBA::lastInsertId();
 			Logger::info('Inserted', ['id' => $id, 'uri-id' => $uri_id, 'url' => $url]);
 		}

--- a/src/Model/Post/UserNotification.php
+++ b/src/Model/Post/UserNotification.php
@@ -297,7 +297,7 @@ class UserNotification
 			$fields['target-uri-id'] = $item['uri-id'];
 		}
 
-		return DBA::insert('notification', $fields);
+		return DBA::insert('notification', $fields, Database::INSERT_IGNORE);
 	}
 
 	/**
@@ -318,7 +318,7 @@ class UserNotification
 			'created' => DateTimeFormat::utcNow(),
 		];
 
-		return DBA::insert('notification', $fields);
+		return DBA::insert('notification', $fields, Database::INSERT_IGNORE);
 	}
 
 	/**


### PR DESCRIPTION
This avoids some "Duplicate entry" messages in the log. Due to timing issues it can happen that two processes can insert the same entry.

Also it fixes a DB Error that occurs when a link entry is about to be inserted when we are previewing content.