### PR TITLE
API: Support for fetching mails with more "statuses" calls

### DIFF
--- a/src/Factory/Api/Mastodon/Status.php
+++ b/src/Factory/Api/Mastodon/Status.php
@@ -25,6 +25,7 @@ use Friendica\BaseFactory;
 use Friendica\Content\ContactSelector;
 use Friendica\Content\Text\BBCode;
 use Friendica\Database\Database;
+use Friendica\Database\DBA;
 use Friendica\Model\Post;
 use Friendica\Model\Verb;
 use Friendica\Network\HTTPException;
@@ -79,6 +80,10 @@ class Status extends BaseFactory
 			'thr-parent-id', 'parent-author-id', 'language', 'uri', 'plink', 'private', 'vid', 'gravity'];
 		$item = Post::selectFirst($fields, ['uri-id' => $uriId, 'uid' => [0, $uid]], ['order' => ['uid' => true]]);
 		if (!$item) {
+			$mail = DBA::selectFirst('mail', ['id'], ['uri-id' => $uriId, 'uid' => $uid]);
+			if ($mail) {
+				return $this->createFromMailId($mail['id']);
+			}
 			throw new HTTPException\NotFoundException('Item with URI ID ' . $uriId . ' not found' . ($uid ? ' for user ' . $uid : '.'));
 		}
 

--- a/src/Module/Api/Mastodon/Timelines/Direct.php
+++ b/src/Module/Api/Mastodon/Timelines/Direct.php
@@ -66,7 +66,7 @@ class Direct extends BaseApi
 			$params['order'] = ['uri-id'];
 		}
 
-		$mails = DBA::select('mail', ['id'], $condition, $params);
+		$mails = DBA::select('mail', ['id', 'uri-id'], $condition, $params);
 
 		$statuses = [];
 


### PR DESCRIPTION
In the future we should store mails in the post tables as well. This would make much things much easier.

In the meantime we need to implement some workarounds. Since we use the "uri-id"  field, there is no danger that a post and a mail will have the same value.