### PR TITLE
Fix for Mastodon falsely adding previews to mentions

### DIFF
--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -1264,6 +1264,39 @@ class BBCode
 	}
 
 	/**
+	 * Replace names in mentions with nicknames
+	 *
+	 * @param string $body
+	 * @return string Body with replaced mentions
+	 */
+	public static function setMentionsToNicknames(string $body):string
+	{
+		$regexp = "/([@!])\[url\=([^\[\]]*)\].*?\[\/url\]/ism";
+		return preg_replace_callback($regexp, ['self', 'mentionCallback'], $body);
+	}
+
+	/**
+	 * Callback function to replace a Friendica style mention in a mention with the nickname
+	 *
+	 * @param array $match Matching values for the callback
+	 * @return string Replaced mention
+	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
+	 */
+	private static function mentionCallback($match)
+	{
+		if (empty($match[2])) {
+			return '';
+		}
+
+		$data = Contact::getByURL($match[2], false, ['url', 'nick']);
+		if (empty($data['nick'])) {
+			return $match[0];
+		}
+
+		return $match[1] . '[url=' . $data['url'] . ']' . $data['nick'] . '[/url]';
+	}
+
+	/**
 	 * Converts a BBCode message for a given URI-ID to a HTML message
 	 *
 	 * BBcode 2 HTML was written by WAY2WEB.net

--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -1748,6 +1748,27 @@ class BBCode
 					}
 				}
 
+				// Handle mentions and hashtag links
+				if ($simple_html == self::DIASPORA) {
+					// The ! is converted to @ since Diaspora only understands the @
+					$text = preg_replace("/([@!])\[url\=(.*?)\](.*?)\[\/url\]/ism",
+						'@<a href="$2">$3</a>',
+						$text);
+				} elseif (in_array($simple_html, [self::OSTATUS, self::ACTIVITYPUB])) {
+					$text = preg_replace("/([@!])\[url\=(.*?)\](.*?)\[\/url\]/ism",
+						'<span class="h-card"><a href="$2" class="u-url mention">$1<span>$3</span></a></span>',
+						$text);
+					$text = preg_replace("/([#])\[url\=(.*?)\](.*?)\[\/url\]/ism",
+						'<a href="$2" class="mention hashtag" rel="tag">$1<span>$3</span></a>',
+						$text);
+				} elseif (in_array($simple_html, [self::INTERNAL, self::EXTERNAL, self::API])) {
+					$text = preg_replace("/([@!])\[url\=(.*?)\](.*?)\[\/url\]/ism",
+						'<bdi>$1<a href="$2" class="userinfo mention" title="$3">$3</a></bdi>',
+						$text);
+				} else {
+					$text = preg_replace("/([#@!])\[url\=(.*?)\](.*?)\[\/url\]/ism", '$1$3', $text);
+				}
+				
 				if (!$for_plaintext) {
 					if (in_array($simple_html, [self::OSTATUS, self::API, self::ACTIVITYPUB])) {
 						$text = preg_replace_callback("/\[url\](.*?)\[\/url\]/ism", 'self::convertUrlForActivityPubCallback', $text);
@@ -1756,24 +1777,6 @@ class BBCode
 				} else {
 					$text = preg_replace("(\[url\](.*?)\[\/url\])ism", " $1 ", $text);
 					$text = preg_replace_callback("&\[url=([^\[\]]*)\]\[img\](.*)\[\/img\]\[\/url\]&Usi", 'self::removePictureLinksCallback', $text);
-				}
-
-				// Remove all hashtag addresses
-				if ($simple_html && !in_array($simple_html, [self::DIASPORA, self::OSTATUS, self::ACTIVITYPUB])) {
-					$text = preg_replace("/([#@!])\[url\=(.*?)\](.*?)\[\/url\]/ism", '$1$3', $text);
-				} elseif ($simple_html == self::DIASPORA) {
-					// The ! is converted to @ since Diaspora only understands the @
-					$text = preg_replace("/([@!])\[url\=(.*?)\](.*?)\[\/url\]/ism",
-						'@<a href="$2">$3</a>',
-						$text);
-				} elseif (in_array($simple_html, [self::OSTATUS, self::ACTIVITYPUB])) {
-					$text = preg_replace("/([@!])\[url\=(.*?)\](.*?)\[\/url\]/ism",
-						'$1<span class="vcard"><a href="$2" class="url u-url mention" title="$3"><span class="fn nickname mention">$3</span></a></span>',
-						$text);
-				} elseif (!$simple_html) {
-					$text = preg_replace("/([@!])\[url\=(.*?)\](.*?)\[\/url\]/ism",
-						'<bdi>$1<a href="$2" class="userinfo mention" title="$3">$3</a></bdi>',
-						$text);
 				}
 
 				// Bookmarks in red - will be converted to bookmarks in friendica

--- a/src/Object/Api/Mastodon/Status.php
+++ b/src/Object/Api/Mastodon/Status.php
@@ -131,7 +131,7 @@ class Status extends BaseDataTransferObject
 		$this->muted = $userAttributes->muted;
 		$this->bookmarked = $userAttributes->bookmarked;
 		$this->pinned = $userAttributes->pinned;
-		$this->content = BBCode::convertForUriId($item['uri-id'], ($item['raw-body'] ?? $item['body']), BBCode::API);
+		$this->content = BBCode::convertForUriId($item['uri-id'], BBCode::setMentionsToNicknames($item['raw-body'] ?? $item['body']), BBCode::API);
 		$this->reblog = $reblog;
 		$this->application = $application->toArray();
 		$this->account = $account->toArray();

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -1356,12 +1356,12 @@ class Transmitter
 			return '';
 		}
 
-		$data = Contact::getByURL($match[1], false, ['url', 'alias', 'nick']);
+		$data = Contact::getByURL($match[1], false, ['url', 'nick']);
 		if (empty($data['nick'])) {
 			return $match[0];
 		}
 
-		return '[url=' . $data['url'] . ']@' . $data['nick'] . '[/url]';
+		return '@[url=' . $data['url'] . ']' . $data['nick'] . '[/url]';
 	}
 
 	/**

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -1344,27 +1344,6 @@ class Transmitter
 	}
 
 	/**
-	 * Callback function to replace a Friendica style mention in a mention that is used on AP
-	 *
-	 * @param array $match Matching values for the callback
-	 * @return string Replaced mention
-	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
-	 */
-	private static function mentionCallback($match)
-	{
-		if (empty($match[1])) {
-			return '';
-		}
-
-		$data = Contact::getByURL($match[1], false, ['url', 'nick']);
-		if (empty($data['nick'])) {
-			return $match[0];
-		}
-
-		return '@[url=' . $data['url'] . ']' . $data['nick'] . '[/url]';
-	}
-
-	/**
 	 * Callback function to replace a Friendica style mention in a mention for a summary
 	 *
 	 * @param array $match Matching values for the callback
@@ -1568,8 +1547,7 @@ class Transmitter
 		if ($type == 'Event') {
 			$data = array_merge($data, self::createEvent($item));
 		} else {
-			$regexp = "/[@!]\[url\=([^\[\]]*)\].*?\[\/url\]/ism";
-			$body = preg_replace_callback($regexp, ['self', 'mentionCallback'], $body);
+			$body = BBCode::setMentionsToNicknames($body);
 
 			$data['content'] = BBCode::convertForUriId($item['uri-id'], $body, BBCode::ACTIVITYPUB);
 		}
@@ -1579,8 +1557,7 @@ class Transmitter
 		// The contentMap does contain the unmodified HTML.
 		$language = self::getLanguage($item);
 		if (!empty($language)) {
-			$regexp = "/[@!]\[url\=([^\[\]]*)\].*?\[\/url\]/ism";
-			$richbody = preg_replace_callback($regexp, ['self', 'mentionCallback'], $item['body']);
+			$richbody = BBCode::setMentionsToNicknames($item['body']);
 			$richbody = BBCode::removeAttachment($richbody);
 
 			$data['contentMap'][$language] = BBCode::convertForUriId($item['uri-id'], $richbody, BBCode::EXTERNAL);


### PR DESCRIPTION
This fixes the problem that Mastodon sometimes generates previews for links to mentioned contacts. See for example the answer here: https://mastodon.technology/@darkblue/106620080773541058

This should be fixed now.