### PR TITLE
Lock before recreate / fix cache key misspelling

### DIFF
--- a/tests/src/App/ModuleTest.php
+++ b/tests/src/App/ModuleTest.php
@@ -184,6 +184,8 @@ class ModuleTest extends DatabaseTest
 		$cache->shouldReceive('set')->withAnyArgs()->andReturn(false)->atMost()->twice();
 
 		$lock = Mockery::mock(ILock::class);
+		$lock->shouldReceive('acquire')->andReturn(true);
+		$lock->shouldReceive('isLocked')->andReturn(false);
 
 		$router = (new App\Router([], __DIR__ . '/../../../static/routes.config.php', $l10n, $cache, $lock));
 

--- a/tests/src/App/ModuleTest.php
+++ b/tests/src/App/ModuleTest.php
@@ -25,6 +25,7 @@ use Friendica\App;
 use Friendica\Core\Cache\ICache;
 use Friendica\Core\Config\IConfig;
 use Friendica\Core\L10n;
+use Friendica\Core\Lock\ILock;
 use Friendica\LegacyModule;
 use Friendica\Module\HTTPException\PageNotFound;
 use Friendica\Module\WellKnown\HostMeta;
@@ -182,7 +183,9 @@ class ModuleTest extends DatabaseTest
 		$cache->shouldReceive('get')->with('lastRoutesFileModifiedTime')->andReturn('')->atMost()->once();
 		$cache->shouldReceive('set')->withAnyArgs()->andReturn(false)->atMost()->twice();
 
-		$router = (new App\Router([], __DIR__ . '/../../../static/routes.config.php', $l10n, $cache));
+		$lock = Mockery::mock(ILock::class);
+
+		$router = (new App\Router([], __DIR__ . '/../../../static/routes.config.php', $l10n, $cache, $lock));
 
 		$module = (new App\Module($name))->determineClass(new App\Arguments('', $command), $router, $config);
 

--- a/tests/src/App/RouterTest.php
+++ b/tests/src/App/RouterTest.php
@@ -57,6 +57,8 @@ class RouterTest extends TestCase
 		$this->cache->shouldReceive('set')->andReturn(false);
 
 		$this->lock = Mockery::mock(ILock::class);
+		$this->cache->shouldReceive('acquire')->andReturn(true);
+		$this->cache->shouldReceive('isLocked')->andReturn(false);
 	}
 
 	public function testGetModuleClass()

--- a/tests/src/App/RouterTest.php
+++ b/tests/src/App/RouterTest.php
@@ -24,6 +24,7 @@ namespace Friendica\Test\src\App;
 use Friendica\App\Router;
 use Friendica\Core\Cache\ICache;
 use Friendica\Core\L10n;
+use Friendica\Core\Lock\ILock;
 use Friendica\Module;
 use Friendica\Network\HTTPException\MethodNotAllowedException;
 use Friendica\Network\HTTPException\NotFoundException;
@@ -39,6 +40,10 @@ class RouterTest extends TestCase
 	 * @var ICache
 	 */
 	private $cache;
+	/**
+	 * @var ILock
+	 */
+	private $lock;
 
 	protected function setUp() : void
 	{
@@ -54,7 +59,7 @@ class RouterTest extends TestCase
 
 	public function testGetModuleClass()
 	{
-		$router = new Router(['REQUEST_METHOD' => Router::GET], '', $this->l10n, $this->cache);
+		$router = new Router(['REQUEST_METHOD' => Router::GET], '', $this->l10n, $this->cache, $this->lock);
 
 		$routeCollector = $router->getRouteCollector();
 		$routeCollector->addRoute([Router::GET], '/', 'IndexModuleClassName');
@@ -78,7 +83,7 @@ class RouterTest extends TestCase
 
 	public function testPostModuleClass()
 	{
-		$router = new Router(['REQUEST_METHOD' => Router::POST], '', $this->l10n, $this->cache);
+		$router = new Router(['REQUEST_METHOD' => Router::POST], '', $this->l10n, $this->cache, $this->lock);
 
 		$routeCollector = $router->getRouteCollector();
 		$routeCollector->addRoute([Router::POST], '/', 'IndexModuleClassName');
@@ -104,7 +109,7 @@ class RouterTest extends TestCase
 	{
 		$this->expectException(NotFoundException::class);
 
-		$router = new Router(['REQUEST_METHOD' => Router::GET], '', $this->l10n, $this->cache);
+		$router = new Router(['REQUEST_METHOD' => Router::GET], '', $this->l10n, $this->cache, $this->lock);
 
 		$router->getModuleClass('/unsupported');
 	}
@@ -113,7 +118,7 @@ class RouterTest extends TestCase
 	{
 		$this->expectException(NotFoundException::class);
 
-		$router = new Router(['REQUEST_METHOD' => Router::GET], '', $this->l10n, $this->cache);
+		$router = new Router(['REQUEST_METHOD' => Router::GET], '', $this->l10n, $this->cache, $this->lock);
 
 		$routeCollector = $router->getRouteCollector();
 		$routeCollector->addRoute([Router::GET], '/test', 'TestModuleClassName');
@@ -125,7 +130,7 @@ class RouterTest extends TestCase
 	{
 		$this->expectException(NotFoundException::class);
 
-		$router = new Router(['REQUEST_METHOD' => Router::GET], '', $this->l10n, $this->cache);
+		$router = new Router(['REQUEST_METHOD' => Router::GET], '', $this->l10n, $this->cache, $this->lock);
 
 		$routeCollector = $router->getRouteCollector();
 		$routeCollector->addRoute([Router::GET], '/optional[/option]', 'OptionalModuleClassName');
@@ -137,7 +142,7 @@ class RouterTest extends TestCase
 	{
 		$this->expectException(NotFoundException::class);
 
-		$router = new Router(['REQUEST_METHOD' => Router::GET], '', $this->l10n, $this->cache);
+		$router = new Router(['REQUEST_METHOD' => Router::GET], '', $this->l10n, $this->cache, $this->lock);
 
 		$routeCollector = $router->getRouteCollector();
 		$routeCollector->addRoute([Router::GET], '/variable/{var}', 'VariableModuleClassName');
@@ -149,7 +154,7 @@ class RouterTest extends TestCase
 	{
 		$this->expectException(MethodNotAllowedException::class);
 
-		$router = new Router(['REQUEST_METHOD' => Router::POST], '', $this->l10n, $this->cache);
+		$router = new Router(['REQUEST_METHOD' => Router::POST], '', $this->l10n, $this->cache, $this->lock);
 
 		$routeCollector = $router->getRouteCollector();
 		$routeCollector->addRoute([Router::GET], '/test', 'TestModuleClassName');
@@ -161,7 +166,7 @@ class RouterTest extends TestCase
 	{
 		$this->expectException(MethodNotAllowedException::class);
 
-		$router = new Router(['REQUEST_METHOD' => Router::GET], '', $this->l10n, $this->cache);
+		$router = new Router(['REQUEST_METHOD' => Router::GET], '', $this->l10n, $this->cache, $this->lock);
 
 		$routeCollector = $router->getRouteCollector();
 		$routeCollector->addRoute([Router::POST], '/test', 'TestModuleClassName');
@@ -203,7 +208,8 @@ class RouterTest extends TestCase
 			['REQUEST_METHOD' => Router::GET],
 			'',
 			$this->l10n,
-			$this->cache
+			$this->cache,
+			$this->lock
 		))->loadRoutes($routes);
 
 		self::assertEquals(Module\Home::class, $router->getModuleClass('/'));
@@ -219,7 +225,7 @@ class RouterTest extends TestCase
 	{
 		$router = (new Router([
 			'REQUEST_METHOD' => Router::POST
-		], '', $this->l10n, $this->cache))->loadRoutes($routes);
+		], '', $this->l10n, $this->cache, $this->lock))->loadRoutes($routes);
 
 		// Don't find GET
 		self::assertEquals(Module\WellKnown\NodeInfo::class, $router->getModuleClass('/post/it'));

--- a/tests/src/App/RouterTest.php
+++ b/tests/src/App/RouterTest.php
@@ -55,6 +55,8 @@ class RouterTest extends TestCase
 		$this->cache = Mockery::mock(ICache::class);
 		$this->cache->shouldReceive('get')->andReturn(null);
 		$this->cache->shouldReceive('set')->andReturn(false);
+
+		$this->lock = Mockery::mock(ILock::class);
 	}
 
 	public function testGetModuleClass()

--- a/tests/src/App/RouterTest.php
+++ b/tests/src/App/RouterTest.php
@@ -57,8 +57,8 @@ class RouterTest extends TestCase
 		$this->cache->shouldReceive('set')->andReturn(false);
 
 		$this->lock = Mockery::mock(ILock::class);
-		$this->cache->shouldReceive('acquire')->andReturn(true);
-		$this->cache->shouldReceive('isLocked')->andReturn(false);
+		$this->lock->shouldReceive('acquire')->andReturn(true);
+		$this->lock->shouldReceive('isLocked')->andReturn(false);
 	}
 
 	public function testGetModuleClass()


### PR DESCRIPTION
Avoid database issues with updating the same cache key by using a lock when recreating the router cache.

Also the cache key for the file time had been misspelled so the cache had been recreated all the time.