### PR TITLE
Create the Diaspora signature for the correct user

### DIFF
--- a/include/conversation.php
+++ b/include/conversation.php
@@ -717,7 +717,7 @@ function conversation_add_children(array $parents, $block_authors, $order, $uid)
 		$max_comments = DI::config()->get('system', 'max_display_comments', 1000);
 	}
 
-	$params = ['order' => ['uri-id' => true]];
+	$params = ['order' => ['uri-id' => true, 'uid' => true]];
 
 	$activities      = [];
 	$uriids          = [];

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -1061,13 +1061,7 @@ class Item
 
 		// Create Diaspora signature
 		if ($item['origin'] && empty($item['diaspora_signed_text']) && ($item['gravity'] != GRAVITY_PARENT)) {
-			if ($uid == 0) {
-				$sender_contact = Contact::getById($item['contact-id'], ['uid']);
-				$sender_uid = $sender_contact['uid'];
-			} else {
-				$sender_uid = $uid;
-			}
-			$signed = Diaspora::createCommentSignature($sender_uid, $item);
+			$signed = Diaspora::createCommentSignature($item);
 			if (!empty($signed)) {
 				$item['diaspora_signed_text'] = json_encode($signed);
 			}

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -1061,7 +1061,13 @@ class Item
 
 		// Create Diaspora signature
 		if ($item['origin'] && empty($item['diaspora_signed_text']) && ($item['gravity'] != GRAVITY_PARENT)) {
-			$signed = Diaspora::createCommentSignature($uid, $item);
+			if ($uid == 0) {
+				$sender_contact = Contact::getById($item['contact-id'], ['uid']);
+				$sender_uid = $sender_contact['uid'];
+			} else {
+				$sender_uid = $uid;
+			}
+			$signed = Diaspora::createCommentSignature($sender_uid, $item);
 			if (!empty($signed)) {
 				$item['diaspora_signed_text'] = json_encode($signed);
 			}

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -157,8 +157,8 @@ class User
 		$system['net-publish'] = false;
 
 		// Ensure that the user contains data
-		$user = DBA::selectFirst('user', ['prvkey'], ['uid' => 0]);
-		if (empty($user['prvkey'])) {
+		$user = DBA::selectFirst('user', ['prvkey', 'guid'], ['uid' => 0]);
+		if (empty($user['prvkey']) || empty($user['guid'])) {
 			$fields = [
 				'username' => $system['name'],
 				'nickname' => $system['nick'],
@@ -167,12 +167,17 @@ class User
 				'prvkey' => $system['prvkey'],
 				'spubkey' => $system['spubkey'],
 				'sprvkey' => $system['sprvkey'],
+				'guid' => System::createUUID(),
 				'verified' => true,
 				'page-flags' => User::PAGE_FLAGS_SOAPBOX,
 				'account-type' => User::ACCOUNT_TYPE_RELAY,
 			];
 
 			DBA::update('user', $fields, ['uid' => 0]);
+
+			$system['guid'] = $fields['guid'];
+		} else {
+			$system['guid'] = $user['guid'];
 		}
 
 		return $system;

--- a/src/Module/Xrd.php
+++ b/src/Module/Xrd.php
@@ -130,6 +130,25 @@ class Xrd extends BaseModule
 					'rel'      => 'http://ostatus.org/schema/1.0/subscribe',
 					'template' => DI::baseUrl()->get() . '/follow?url={uri}',
 				],
+				[
+					'rel'  => ActivityNamespace::FEED,
+					'type' => 'application/atom+xml',
+					'href' => $owner['poll'] ?? DI::baseUrl()->get(),
+				],
+				[
+					'rel'  => 'salmon',
+					'href' => DI::baseUrl()->get() . '/salmon/' . $owner['nickname'],
+				],
+				[
+					'rel'  => 'http://microformats.org/profile/hcard',
+					'type' => 'text/html',
+					'href' => DI::baseUrl()->get() . '/hcard/' . $owner['nickname'],
+				],
+				[
+					'rel'  => 'http://joindiaspora.com/seed_location',
+					'type' => 'text/html',
+					'href' => DI::baseUrl()->get(),
+				],
 			]
 		];
 		header('Access-Control-Allow-Origin: *');

--- a/src/Network/Probe.php
+++ b/src/Network/Probe.php
@@ -1412,6 +1412,8 @@ class Probe
 				$data["guid"] = $link["href"];
 			} elseif (($link["rel"] == "http://webfinger.net/rel/profile-page") && (($link["type"] ?? "") == "text/html") && !empty($link["href"])) {
 				$data["url"] = $link["href"];
+			} elseif (($link["rel"] == "http://webfinger.net/rel/profile-page") && empty($link["type"]) && !empty($link["href"])) {
+				$profile_url = $link["href"];
 			} elseif (($link["rel"] == ActivityNamespace::FEED) && !empty($link["href"])) {
 				$data["poll"] = $link["href"];
 			} elseif (($link["rel"] == ActivityNamespace::POCO) && !empty($link["href"])) {
@@ -1426,6 +1428,10 @@ class Probe
 					$data["pubkey"] = Crypto::rsaToPem($data["pubkey"]);
 				}
 			}
+		}
+
+		if (empty($data["url"]) && !empty($profile_url)) {
+			$data["url"] = $profile_url;
 		}
 
 		if (empty($data["url"]) || empty($hcard_url)) {

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -4051,13 +4051,18 @@ class Diaspora
 	 */
 	public static function createCommentSignature(array $item)
 	{
-		$contact = Contact::getById($item['author-id'], ['url']);
-		if (empty($contact['url'])) {
-			Logger::warning('Author Contact not found', ['author-id' => $item['author-id']]);
-			return false;
+		if (!empty($item['author-link'])) {
+			$url = $item['author-link'];
+		} else {
+			$contact = Contact::getById($item['author-id'], ['url']);
+			if (empty($contact['url'])) {
+				Logger::warning('Author Contact not found', ['author-id' => $item['author-id']]);
+				return false;
+			}
+			$url = $contact['url'];
 		}
 
-		$uid = User::getIdForURL($contact['url']);
+		$uid = User::getIdForURL($url);
 		if (empty($uid)) {
 			Logger::info('No owner post, so not storing signature', ['url' => $contact['url']]);
 			return false;

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -4044,14 +4044,25 @@ class Diaspora
 	/**
 	 * Creates the signature for Comments that are created on our system
 	 *
-	 * @param integer $uid  The user of that comment
 	 * @param array   $item Item array
 	 *
 	 * @return array Signed content
 	 * @throws \Exception
 	 */
-	public static function createCommentSignature($uid, array $item)
+	public static function createCommentSignature(array $item)
 	{
+		$contact = Contact::getById($item['author-id'], ['url']);
+		if (empty($contact['url'])) {
+			Logger::warning('Author Contact not found', ['author-id' => $item['author-id']]);
+			return false;
+		}
+
+		$uid = User::getIdForURL($contact['url']);
+		if (empty($uid)) {
+			Logger::info('No owner post, so not storing signature', ['url' => $contact['url']]);
+			return false;
+		}
+
 		$owner = User::getOwnerDataById($uid);
 		if (empty($owner)) {
 			Logger::info('No owner post, so not storing signature');


### PR DESCRIPTION
For Diaspora posts we have to create signed comments. This is done when the post is created. There had been the bug that the signed comments had been created for the uid "0" instead of the real user.

This is a workaround, a better solution might follow in the next time, but this will work.