### PR TITLE
Fix multiple display problems in conversations

### DIFF
--- a/include/conversation.php
+++ b/include/conversation.php
@@ -757,6 +757,10 @@ function conversation_add_children(array $parents, $block_authors, $order, $uid)
 	$items = [];
 
 	while ($row = Post::fetch($thread_items)) {
+		if (!empty($items[$row['uri-id']]) && ($row['uid'] == 0)) {
+			continue;
+		}
+
 		if ($max_comments > 0) {
 			if (($row['gravity'] == GRAVITY_COMMENT) && (++$commentcounter[$row['parent-uri-id']] > $max_comments)) {
 				continue;
@@ -765,7 +769,7 @@ function conversation_add_children(array $parents, $block_authors, $order, $uid)
 				continue;
 			}
 		}
-		$items[] = conversation_add_row_information($row, $activities[$row['uri-id']] ?? []);
+		$items[$row['uri-id']] = conversation_add_row_information($row, $activities[$row['uri-id']] ?? []);
 	}
 
 	DBA::close($thread_items);


### PR DESCRIPTION
This fixes several display problems:

- Under certain circumstances a reshared posts hadn't been marked as one
- The maximum number of comments had falsely been limited to about the half of the configured value
- The delivery values (how much contacts had been delivered, how much are outstanding) sometimes vanished
- Possibly this also fixes the problem that sometimes a comment wasn't visible after sending it.