### PR TITLE
Introduce IWritableStorage interface

### DIFF
--- a/doc/AddonStorageBackend.md
+++ b/doc/AddonStorageBackend.md
@@ -122,6 +122,14 @@ abstract class StorageTest
 
 There are two intended types of exceptions for storages
 
+### `ReferenceStorageExecption`
+
+This storage exception should be used in case the caller tries to use an invalid references.
+This could happen in case the caller tries to delete or update an unknown reference.
+The implementation of the storage backend must not ignore invalid references.
+
+Avoid throwing the common `StorageExecption` instead of the `ReferenceStorageException` at this particular situation!
+
 ### `StorageException`
 
 This is the common exception in case unexpected errors happen using the storage backend.
@@ -144,14 +152,6 @@ class ExampleStorage implements ISelectableStorage
 	}
 } 
 ```
-
-### `ReferenceStorageExecption`
-
-This storage exception should be used in case the caller tries to use an invalid references.
-This could happen in case the caller tries to delete or update an unknown reference.
-The implementation of the storage backend must not ignore invalid references.
-
-Avoid throwing the common `StorageExecption` instead of the `ReferenceStorageException` at this particular situation!
 
 ## Example
 

--- a/doc/AddonStorageBackend.md
+++ b/doc/AddonStorageBackend.md
@@ -10,12 +10,12 @@ A storage backend is implemented as a class, and the plugin register the class t
 
 The class must live in `Friendica\Addon\youraddonname` namespace, where `youraddonname` the folder name of your addon.
 
-The class must implement `Friendica\Model\Storage\IStorage` interface. All method in the interface must be implemented:
+The class must implement `Friendica\Model\Storage\ISelectableStorage` interface. All method in the interface must be implemented:
 
-namespace Friendica\Model\Storage;
+namespace Friendica\Model\ISelectableStorage;
 
 ```php
-interface IStorage
+interface ISelectableStorage
 {
 	public function get(string $reference);
 	public function put(string $data, string $reference = '');
@@ -79,7 +79,7 @@ Each label should be translatable
 	];
 
 
-See doxygen documentation of `IStorage` interface for details about each method.
+See doxygen documentation of `ISelectableStorage` interface for details about each method.
 
 ## Register a storage backend class
 
@@ -106,7 +106,7 @@ Add a new test class which's naming convention is `StorageClassTest`, which exte
 
 Override the two necessary instances:
 ```php
-use Friendica\Model\Storage\IStorage;
+use Friendica\Model\Storage\ISelectableStorage;
 
 abstract class StorageTest 
 {
@@ -114,13 +114,48 @@ abstract class StorageTest
 	abstract protected function getInstance();
 
 	// Assertion for the option array you return for your new StorageClass
-	abstract protected function assertOption(IStorage $storage);
+	abstract protected function assertOption(ISelectableStorage $storage);
 } 
 ```
 
+## Exception handling
+
+There are two intended types of exceptions for storages
+
+### `StorageException`
+
+This is the common exception in case unexpected errors happen using the storage backend.
+If there's a predecessor to this exception (e.g. you caught an exception and are throwing this execption), you should add the predecessor for transparency reasons.
+
+Example:
+
+```php
+use Friendica\Model\Storage\ISelectableStorage;
+
+class ExampleStorage implements ISelectableStorage 
+{
+	public function get(string $reference) : string
+	{
+		try {
+			throw new Exception('a real bad exception');
+		} catch (Exception $exception) {
+			throw new \Friendica\Model\Storage\StorageException(sprintf('The Example Storage throws an exception for reference %s', $reference), 500, $exception);
+		}
+	}
+} 
+```
+
+### `ReferenceStorageExecption`
+
+This storage exception should be used in case the caller tries to use an invalid references.
+This could happen in case the caller tries to delete or update an unknown reference.
+The implementation of the storage backend must not ignore invalid references.
+
+Avoid throwing the common `StorageExecption` instead of the `ReferenceStorageException` at this particular situation!
+
 ## Example
 
-Here an hypotetical addon which register an unusefull storage backend.
+Here an hypotetical addon which register a useless storage backend.
 Let's call it `samplestorage`.
 
 This backend will discard all data we try to save and will return always the same image when we ask for some data.
@@ -133,12 +168,12 @@ The file will be `addon/samplestorage/SampleStorageBackend.php`:
 <?php
 namespace Friendica\Addon\samplestorage;
 
-use Friendica\Model\Storage\IStorage;
+use Friendica\Model\Storage\ISelectableStorage;
 
 use Friendica\Core\Config\IConfig;
 use Friendica\Core\L10n;
 
-class SampleStorageBackend implements IStorage
+class SampleStorageBackend implements ISelectableStorage
 {
 	const NAME = 'Sample Storage';
 
@@ -270,7 +305,7 @@ function samplestorage_storage_instance(\Friendica\App $a, array $data)
 **Theoretically - until tests for Addons are enabled too - create a test class with the name `addon/tests/SampleStorageTest.php`:
 
 ```php
-use Friendica\Model\Storage\IStorage;
+use Friendica\Model\Storage\ISelectableStorage;
 use Friendica\Test\src\Model\Storage\StorageTest;
 
 class SampleStorageTest extends StorageTest 
@@ -284,7 +319,7 @@ class SampleStorageTest extends StorageTest
 	}
 
 	// Assertion for the option array you return for your new StorageClass
-	protected function assertOption(IStorage $storage)
+	protected function assertOption(ISelectableStorage $storage)
 	{
 		$this->assertEquals([
 			'filename' => [

--- a/doc/AddonStorageBackend.md
+++ b/doc/AddonStorageBackend.md
@@ -10,12 +10,12 @@ A storage backend is implemented as a class, and the plugin register the class t
 
 The class must live in `Friendica\Addon\youraddonname` namespace, where `youraddonname` the folder name of your addon.
 
-The class must implement `Friendica\Model\Storage\ISelectableStorage` interface. All method in the interface must be implemented:
+The class must implement `Friendica\Model\Storage\IWritableStorage` interface. All method in the interface must be implemented:
 
-namespace Friendica\Model\ISelectableStorage;
+namespace Friendica\Model\IWritableStorage;
 
 ```php
-interface ISelectableStorage
+interface IWritableStorage
 {
 	public function get(string $reference);
 	public function put(string $data, string $reference = '');
@@ -79,7 +79,7 @@ Each label should be translatable
 	];
 
 
-See doxygen documentation of `ISelectableStorage` interface for details about each method.
+See doxygen documentation of `IWritableStorage` interface for details about each method.
 
 ## Register a storage backend class
 
@@ -105,8 +105,9 @@ Each new Storage class should be added to the test-environment at [Storage Tests
 Add a new test class which's naming convention is `StorageClassTest`, which extend the `StorageTest` in the same directory.
 
 Override the two necessary instances:
+
 ```php
-use Friendica\Model\Storage\ISelectableStorage;
+use Friendica\Model\Storage\IWritableStorage;
 
 abstract class StorageTest 
 {
@@ -114,7 +115,7 @@ abstract class StorageTest
 	abstract protected function getInstance();
 
 	// Assertion for the option array you return for your new StorageClass
-	abstract protected function assertOption(ISelectableStorage $storage);
+	abstract protected function assertOption(IWritableStorage $storage);
 } 
 ```
 
@@ -138,9 +139,9 @@ If there's a predecessor to this exception (e.g. you caught an exception and are
 Example:
 
 ```php
-use Friendica\Model\Storage\ISelectableStorage;
+use Friendica\Model\Storage\IWritableStorage;
 
-class ExampleStorage implements ISelectableStorage 
+class ExampleStorage implements IWritableStorage 
 {
 	public function get(string $reference) : string
 	{
@@ -168,12 +169,12 @@ The file will be `addon/samplestorage/SampleStorageBackend.php`:
 <?php
 namespace Friendica\Addon\samplestorage;
 
-use Friendica\Model\Storage\ISelectableStorage;
+use Friendica\Model\Storage\IWritableStorage;
 
 use Friendica\Core\Config\IConfig;
 use Friendica\Core\L10n;
 
-class SampleStorageBackend implements ISelectableStorage
+class SampleStorageBackend implements IWritableStorage
 {
 	const NAME = 'Sample Storage';
 
@@ -305,7 +306,7 @@ function samplestorage_storage_instance(\Friendica\App $a, array $data)
 **Theoretically - until tests for Addons are enabled too - create a test class with the name `addon/tests/SampleStorageTest.php`:
 
 ```php
-use Friendica\Model\Storage\ISelectableStorage;
+use Friendica\Model\Storage\IWritableStorage;
 use Friendica\Test\src\Model\Storage\StorageTest;
 
 class SampleStorageTest extends StorageTest 
@@ -319,7 +320,7 @@ class SampleStorageTest extends StorageTest
 	}
 
 	// Assertion for the option array you return for your new StorageClass
-	protected function assertOption(ISelectableStorage $storage)
+	protected function assertOption(IWritableStorage $storage)
 	{
 		$this->assertEquals([
 			'filename' => [

--- a/src/Console/Storage.php
+++ b/src/Console/Storage.php
@@ -23,6 +23,7 @@ namespace Friendica\Console;
 
 use Asika\SimpleConsole\CommandArgsException;
 use Friendica\Core\StorageManager;
+use Friendica\Model\Storage\ReferenceStorageException;
 use Friendica\Model\Storage\StorageException;
 
 /**
@@ -127,20 +128,20 @@ HELP;
 
 	protected function doSet()
 	{
-		if (count($this->args) !== 2) {
+		if (count($this->args) !== 2 || empty($this->args[1])) {
 			throw new CommandArgsException('Invalid arguments');
 		}
 
-		$name  = $this->args[1];
-		$class = $this->storageManager->getWritableStorageByName($name);
+		$name = $this->args[1];
+		try {
+			$class = $this->storageManager->getWritableStorageByName($name);
 
-		if (is_null($class)) {
+			if (!$this->storageManager->setBackend($class)) {
+				$this->out($class . ' is not a valid backend storage class.');
+				return -1;
+			}
+		} catch (ReferenceStorageException $exception) {
 			$this->out($name . ' is not a registered backend.');
-			return -1;
-		}
-
-		if (!$this->storageManager->setBackend($class)) {
-			$this->out($class . ' is not a valid backend storage class.');
 			return -1;
 		}
 

--- a/src/Console/Storage.php
+++ b/src/Console/Storage.php
@@ -131,10 +131,10 @@ HELP;
 			throw new CommandArgsException('Invalid arguments');
 		}
 
-		$name = $this->args[1];
-		$class = $this->storageManager->getByName($name);
+		$name  = $this->args[1];
+		$class = $this->storageManager->getSelectableStorageByName($name);
 
-		if ($class === '') {
+		if (is_null($class)) {
 			$this->out($name . ' is not a registered backend.');
 			return -1;
 		}

--- a/src/Console/Storage.php
+++ b/src/Console/Storage.php
@@ -106,7 +106,7 @@ HELP;
 		$this->out(sprintf($rowfmt, 'Sel', 'Name'));
 		$this->out('-----------------------');
 		$isregisterd = false;
-		foreach ($this->storageManager->listBackends() as $name => $class) {
+		foreach ($this->storageManager->listBackends() as $name) {
 			$issel = ' ';
 			if ($current && $current::getName() == $name) {
 				$issel = '*';

--- a/src/Console/Storage.php
+++ b/src/Console/Storage.php
@@ -132,7 +132,7 @@ HELP;
 		}
 
 		$name  = $this->args[1];
-		$class = $this->storageManager->getSelectableStorageByName($name);
+		$class = $this->storageManager->getWritableStorageByName($name);
 
 		if (is_null($class)) {
 			$this->out($name . ' is not a registered backend.');

--- a/src/Core/StorageManager.php
+++ b/src/Core/StorageManager.php
@@ -215,7 +215,7 @@ class StorageManager
 	/**
 	 * Get registered backends
 	 *
-	 * @return Storage\IWritableStorage[]
+	 * @return string[]
 	 */
 	public function listBackends(): array
 	{

--- a/src/DI.php
+++ b/src/DI.php
@@ -387,11 +387,11 @@ abstract class DI
 	}
 
 	/**
-	 * @return Model\Storage\IStorage
+	 * @return Model\Storage\ISelectableStorage
 	 */
 	public static function storage()
 	{
-		return self::$dice->create(Model\Storage\IStorage::class);
+		return self::$dice->create(Model\Storage\ISelectableStorage::class);
 	}
 
 	//

--- a/src/DI.php
+++ b/src/DI.php
@@ -387,11 +387,11 @@ abstract class DI
 	}
 
 	/**
-	 * @return Model\Storage\ISelectableStorage
+	 * @return Model\Storage\IWritableStorage
 	 */
 	public static function storage()
 	{
-		return self::$dice->create(Model\Storage\ISelectableStorage::class);
+		return self::$dice->create(Model\Storage\IWritableStorage::class);
 	}
 
 	//

--- a/src/Model/Attach.php
+++ b/src/Model/Attach.php
@@ -25,6 +25,7 @@ use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\Database\DBStructure;
 use Friendica\DI;
+use Friendica\Model\Storage\InvalidClassStorageException;
 use Friendica\Model\Storage\ReferenceStorageException;
 use Friendica\Object\Image;
 use Friendica\Util\DateTimeFormat;
@@ -164,22 +165,20 @@ class Attach
 			return $item['data'];
 		}
 
-		$backendClass = DI::storageManager()->getByName($item['backend-class'] ?? '');
-		if (empty($backendClass)) {
+		try {
+			$backendClass = DI::storageManager()->getByName($item['backend-class'] ?? '');
+			$backendRef   = $item['backend-ref'];
+			return $backendClass->get($backendRef);
+		} catch (InvalidClassStorageException $storageException) {
 			// legacy data storage in 'data' column
 			$i = self::selectFirst(['data'], ['id' => $item['id']]);
 			if ($i === false) {
 				return null;
 			}
 			return $i['data'];
-		} else {
-			$backendRef = $item['backend-ref'];
-			try {
-				return $backendClass->get($backendRef);
-			} catch (ReferenceStorageException $referenceStorageException) {
-				DI::logger()->debug('No data found for item', ['item' => $item, 'exception' => $referenceStorageException]);
-				return '';
-			}
+		} catch (ReferenceStorageException $referenceStorageException) {
+			DI::logger()->debug('No data found for item', ['item' => $item, 'exception' => $referenceStorageException]);
+			return '';
 		}
 	}
 
@@ -284,11 +283,13 @@ class Attach
 			$items = self::selectToArray(['backend-class','backend-ref'], $conditions);
 
 			foreach($items as $item) {
-				$backend_class = DI::storageManager()->getWritableStorageByName($item['backend-class'] ?? '');
-				if (!empty($backend_class)) {
+				try {
+					$backend_class         = DI::storageManager()->getWritableStorageByName($item['backend-class'] ?? '');
 					$fields['backend-ref'] = $backend_class->put($img->asString(), $item['backend-ref'] ?? '');
-				} else {
-					$fields['data'] = $img->asString();
+				} catch (InvalidClassStorageException $storageException) {
+					DI::logger()->debug('Storage class not found.', ['conditions' => $conditions, 'exception' => $storageException]);
+				} catch (ReferenceStorageException $referenceStorageException) {
+					DI::logger()->debug('Item doesn\'t exist.', ['conditions' => $conditions, 'exception' => $referenceStorageException]);
 				}
 			}
 		}
@@ -316,13 +317,13 @@ class Attach
 		$items = self::selectToArray(['backend-class','backend-ref'], $conditions);
 
 		foreach($items as $item) {
-			$backend_class = DI::storageManager()->getWritableStorageByName($item['backend-class'] ?? '');
-			if (!empty($backend_class)) {
-				try {
-					$backend_class->delete($item['backend-ref'] ?? '');
-				} catch (ReferenceStorageException $referenceStorageException) {
-					DI::logger()->debug('Item doesn\'t exist.', ['conditions' => $conditions, 'exception' => $referenceStorageException]);
-				}
+			try {
+				$backend_class = DI::storageManager()->getWritableStorageByName($item['backend-class'] ?? '');
+				$backend_class->delete($item['backend-ref'] ?? '');
+			} catch (InvalidClassStorageException $storageException) {
+				DI::logger()->debug('Storage class not found.', ['conditions' => $conditions, 'exception' => $storageException]);
+			} catch (ReferenceStorageException $referenceStorageException) {
+				DI::logger()->debug('Item doesn\'t exist.', ['conditions' => $conditions, 'exception' => $referenceStorageException]);
 			}
 		}
 

--- a/src/Model/Attach.php
+++ b/src/Model/Attach.php
@@ -284,7 +284,7 @@ class Attach
 			$items = self::selectToArray(['backend-class','backend-ref'], $conditions);
 
 			foreach($items as $item) {
-				$backend_class = DI::storageManager()->getSelectableStorageByName($item['backend-class'] ?? '');
+				$backend_class = DI::storageManager()->getWritableStorageByName($item['backend-class'] ?? '');
 				if (!empty($backend_class)) {
 					$fields['backend-ref'] = $backend_class->put($img->asString(), $item['backend-ref'] ?? '');
 				} else {
@@ -316,7 +316,7 @@ class Attach
 		$items = self::selectToArray(['backend-class','backend-ref'], $conditions);
 
 		foreach($items as $item) {
-			$backend_class = DI::storageManager()->getSelectableStorageByName($item['backend-class'] ?? '');
+			$backend_class = DI::storageManager()->getWritableStorageByName($item['backend-class'] ?? '');
 			if (!empty($backend_class)) {
 				try {
 					$backend_class->delete($item['backend-ref'] ?? '');

--- a/src/Model/Photo.php
+++ b/src/Model/Photo.php
@@ -196,13 +196,8 @@ class Photo
 
 		try {
 			$backendClass = DI::storageManager()->getByName($photo['backend-class'] ?? '');
-			$image        = $backendClass->get($photo['backend-ref'] ?? '');
-
-			if ($image instanceof Image) {
-				return $image;
-			} else {
-				DI::logger()->info('Stored data is not an image', ['photo' => $photo]);
-			}
+			/// @todo refactoring this returning, because the storage returns a "string" which is casted in different ways - a check "instanceof Image" will fail!
+			return $backendClass->get($photo['backend-ref'] ?? '');
 		} catch (InvalidClassStorageException $storageException) {
 			try {
 				// legacy data storage in "data" column

--- a/src/Model/Photo.php
+++ b/src/Model/Photo.php
@@ -347,7 +347,7 @@ class Photo
 
 		if (DBA::isResult($existing_photo)) {
 			$backend_ref = (string)$existing_photo["backend-ref"];
-			$storage = DI::storageManager()->getSelectableStorageByName($existing_photo["backend-class"] ?? '');
+			$storage = DI::storageManager()->getWritableStorageByName($existing_photo["backend-class"] ?? '');
 		} else {
 			$storage = DI::storage();
 		}
@@ -411,7 +411,7 @@ class Photo
 		$photos = DBA::select('photo', ['id', 'backend-class', 'backend-ref'], $conditions);
 
 		while ($photo = DBA::fetch($photos)) {
-			$backend_class = DI::storageManager()->getSelectableStorageByName($photo['backend-class'] ?? '');
+			$backend_class = DI::storageManager()->getWritableStorageByName($photo['backend-class'] ?? '');
 			if (!empty($backend_class)) {
 				try {
 					$backend_class->delete($item['backend-ref'] ?? '');
@@ -448,7 +448,7 @@ class Photo
 			$photos = self::selectToArray(['backend-class', 'backend-ref'], $conditions);
 
 			foreach($photos as $photo) {
-				$backend_class = DI::storageManager()->getSelectableStorageByName($photo['backend-class'] ?? '');
+				$backend_class = DI::storageManager()->getWritableStorageByName($photo['backend-class'] ?? '');
 				if (!empty($backend_class)) {
 					$fields["backend-ref"] = $backend_class->put($img->asString(), $photo['backend-ref']);
 				} else {

--- a/src/Model/Photo.php
+++ b/src/Model/Photo.php
@@ -185,7 +185,7 @@ class Photo
 	 *
 	 * @param array $photo Photo data. Needs at least 'id', 'type', 'backend-class', 'backend-ref'
 	 *
-	 * @return \Friendica\Object\Image|string
+	 * @return \Friendica\Object\Image
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 * @throws \ImagickException
 	 * @throws StorageException
@@ -201,7 +201,7 @@ class Photo
 			// legacy data storage in "data" column
 			$i = self::selectFirst(['data'], ['id' => $photo['id']]);
 			if ($i === false) {
-				return '';
+				return null;
 			}
 			$data = $i['data'];
 		} else {
@@ -210,7 +210,7 @@ class Photo
 				$data = $backendClass->get($backendRef);
 			} catch (ReferenceStorageException $referenceStorageException) {
 				DI::logger()->debug('No data found for photo', ['photo' => $photo, 'exception' => $referenceStorageException]);
-				return '';
+				return null;
 			}
 		}
 		return $data;

--- a/src/Model/Storage/Database.php
+++ b/src/Model/Storage/Database.php
@@ -101,7 +101,7 @@ class Database implements ISelectableStorage
 	public function delete(string $reference)
 	{
 		try {
-			if (!$this->dba->delete('storage', ['id' => $reference])) {
+			if (!$this->dba->delete('storage', ['id' => $reference]) || $this->dba->affectedRows() === 0) {
 				throw new ReferenceStorageException(sprintf('Database storage failed to delete %s', $reference));
 			}
 		} catch (Exception $exception) {

--- a/src/Model/Storage/Database.php
+++ b/src/Model/Storage/Database.php
@@ -29,7 +29,7 @@ use Friendica\Database\Database as DBA;
  *
  * This class manage data stored in database table.
  */
-class Database implements ISelectableStorage
+class Database implements IWritableStorage
 {
 	const NAME = 'Database';
 

--- a/src/Model/Storage/Database.php
+++ b/src/Model/Storage/Database.php
@@ -57,7 +57,11 @@ class Database implements ISelectableStorage
 
 			return $result['data'];
 		} catch (Exception $exception) {
-			throw new StorageException(sprintf('Database storage failed to get %s', $reference), $exception->getCode(), $exception);
+			if ($exception instanceof ReferenceStorageException) {
+				throw $exception;
+			} else {
+				throw new StorageException(sprintf('Database storage failed to get %s', $reference), $exception->getCode(), $exception);
+			}
 		}
 	}
 
@@ -101,7 +105,11 @@ class Database implements ISelectableStorage
 				throw new ReferenceStorageException(sprintf('Database storage failed to delete %s', $reference));
 			}
 		} catch (Exception $exception) {
-			throw new StorageException(sprintf('Database storage failed to delete %s', $reference), $exception->getCode(), $exception);
+			if ($exception instanceof ReferenceStorageException) {
+				throw $exception;
+			} else {
+				throw new StorageException(sprintf('Database storage failed to delete %s', $reference), $exception->getCode(), $exception);
+			}
 		}
 	}
 

--- a/src/Model/Storage/ExternalResource.php
+++ b/src/Model/Storage/ExternalResource.php
@@ -52,12 +52,12 @@ class ExternalResource implements IStorage
 		try {
 			$fetchResult = HTTPSignature::fetchRaw($data->url, $data->uid, ['accept_content' => '']);
 		} catch (Exception $exception) {
-			throw new StorageException(sprintf('External resource failed to get %s', $reference), $exception->getCode(), $exception);
+			throw new ReferenceStorageException(sprintf('External resource failed to get %s', $reference), $exception->getCode(), $exception);
 		}
 		if ($fetchResult->isSuccess()) {
 			return $fetchResult->getBody();
 		} else {
-			throw new StorageException(sprintf('External resource failed to get %s', $reference), $fetchResult->getReturnCode(), new Exception($fetchResult->getBody()));
+			throw new ReferenceStorageException(sprintf('External resource failed to get %s', $reference), $fetchResult->getReturnCode(), new Exception($fetchResult->getBody()));
 		}
 	}
 

--- a/src/Model/Storage/ExternalResource.php
+++ b/src/Model/Storage/ExternalResource.php
@@ -21,9 +21,8 @@
 
 namespace Friendica\Model\Storage;
 
-use BadMethodCallException;
+use Exception;
 use Friendica\Util\HTTPSignature;
-use Friendica\Network\IHTTPRequest;
 
 /**
  * External resource storage class
@@ -35,64 +34,31 @@ class ExternalResource implements IStorage
 {
 	const NAME = 'ExternalResource';
 
-	/** @var IHTTPRequest */
-	private $httpRequest;
-
-	public function __construct(IHTTPRequest $httpRequest)
-	{
-		$this->httpRequest = $httpRequest;
-	}
-
 	/**
 	 * @inheritDoc
 	 */
-	public function get(string $reference)
+	public function get(string $reference): string
 	{
 		$data = json_decode($reference);
 		if (empty($data->url)) {
-			return "";
+			throw new ReferenceStorageException(sprintf('Invalid reference %s, cannot retrieve URL', $reference));
 		}
 
 		$parts = parse_url($data->url);
 		if (empty($parts['scheme']) || empty($parts['host'])) {
-			return "";
+			throw new ReferenceStorageException(sprintf('Invalid reference %s, cannot extract scheme and host', $reference));
 		}
 
-		$fetchResult = HTTPSignature::fetchRaw($data->url, $data->uid, ['accept_content' => '']);
+		try {
+			$fetchResult = HTTPSignature::fetchRaw($data->url, $data->uid, ['accept_content' => '']);
+		} catch (Exception $exception) {
+			throw new StorageException(sprintf('External resource failed to get %s', $reference), $exception->getCode(), $exception);
+		}
 		if ($fetchResult->isSuccess()) {
 			return $fetchResult->getBody();
 		} else {
-			return "";
+			throw new StorageException(sprintf('External resource failed to get %s', $reference), $fetchResult->getReturnCode(), new Exception($fetchResult->getBody()));
 		}
-	}
-
-	/**
-	 * @inheritDoc
-	 */
-	public function put(string $data, string $reference = '')
-	{
-		throw new BadMethodCallException();
-	}
-
-	public function delete(string $reference)
-	{
-		throw new BadMethodCallException();
-	}
-
-	/**
-	 * @inheritDoc
-	 */
-	public function getOptions()
-	{
-		return [];
-	}
-
-	/**
-	 * @inheritDoc
-	 */
-	public function saveOptions(array $data)
-	{
-		return [];
 	}
 
 	/**
@@ -106,7 +72,7 @@ class ExternalResource implements IStorage
 	/**
 	 * @inheritDoc
 	 */
-	public static function getName()
+	public static function getName(): string
 	{
 		return self::NAME;
 	}

--- a/src/Model/Storage/Filesystem.php
+++ b/src/Model/Storage/Filesystem.php
@@ -131,6 +131,8 @@ class Filesystem implements ISelectableStorage
 		if ($result === false) {
 			throw new StorageException(sprintf('Filesystem storage failed to get data to "%s". Check your write permissions', $file));
 		}
+
+		return $result;
 	}
 
 	/**

--- a/src/Model/Storage/Filesystem.php
+++ b/src/Model/Storage/Filesystem.php
@@ -36,7 +36,7 @@ use Friendica\Util\Strings;
  * Each new resource gets a value as reference and is saved in a
  * folder tree stucture created from that value.
  */
-class Filesystem implements ISelectableStorage
+class Filesystem implements IWritableStorage
 {
 	const NAME = 'Filesystem';
 

--- a/src/Model/Storage/Filesystem.php
+++ b/src/Model/Storage/Filesystem.php
@@ -127,7 +127,6 @@ class Filesystem implements IWritableStorage
 
 		$result = file_get_contents($file);
 
-		// just in case the result is REALLY false, not zero or empty or anything else, throw the exception
 		if ($result === false) {
 			throw new StorageException(sprintf('Filesystem storage failed to get data to "%s". Check your write permissions', $file));
 		}

--- a/src/Model/Storage/ISelectableStorage.php
+++ b/src/Model/Storage/ISelectableStorage.php
@@ -23,6 +23,9 @@ namespace Friendica\Model\Storage;
 
 /**
  * Interface for selectable storage backends
+ *
+ * Used for storages with CRUD functionality, mainly used for user data (e.g. photos, attachements).
+ * There's only one active, selectable storage possible and can be selected by the current administrator
  */
 interface ISelectableStorage extends IStorage
 {

--- a/src/Model/Storage/ISelectableStorage.php
+++ b/src/Model/Storage/ISelectableStorage.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * @copyright Copyright (C) 2010-2021, the Friendica project
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Friendica\Model\Storage;
+
+/**
+ * Interface for selectable storage backends
+ */
+interface ISelectableStorage extends IStorage
+{
+	/**
+	 * Put data in backend as $ref. If $ref is not defined a new reference is created.
+	 *
+	 * @param string $data      Data to save
+	 * @param string $reference Data reference. Optional.
+	 *
+	 * @return string Saved data reference
+	 *
+	 * @throws StorageException in case there's an unexpected error
+	 */
+	public function put(string $data, string $reference = ""): string;
+
+	/**
+	 * Remove data from backend
+	 *
+	 * @param string $reference Data reference
+	 *
+	 * @throws StorageException in case there's an unexpected error
+	 * @throws ReferenceStorageException in case the reference doesn't exist
+	 */
+	public function delete(string $reference);
+
+	/**
+	 * Get info about storage options
+	 *
+	 * @return array
+	 *
+	 * This method return an array with informations about storage options
+	 * from which the form presented to the user is build.
+	 *
+	 * The returned array is:
+	 *
+	 *    [
+	 *      'option1name' => [ ..info.. ],
+	 *      'option2name' => [ ..info.. ],
+	 *      ...
+	 *    ]
+	 *
+	 * An empty array can be returned if backend doesn't have any options
+	 *
+	 * The info array for each option MUST be as follows:
+	 *
+	 *    [
+	 *      'type',      // define the field used in form, and the type of data.
+	 *                   // one of 'checkbox', 'combobox', 'custom', 'datetime',
+	 *                   // 'input', 'intcheckbox', 'password', 'radio', 'richtext'
+	 *                   // 'select', 'select_raw', 'textarea'
+	 *
+	 *      'label',     // Translatable label of the field
+	 *      'value',     // Current value
+	 *      'help text', // Translatable description for the field
+	 *      extra data   // Optional. Depends on 'type':
+	 *                   // select: array [ value => label ] of choices
+	 *                   // intcheckbox: value of input element
+	 *                   // select_raw: prebuild html string of < option > tags
+	 *    ]
+	 *
+	 * See https://github.com/friendica/friendica/wiki/Quick-Template-Guide
+	 */
+	public function getOptions(): array;
+
+	/**
+	 * Validate and save options
+	 *
+	 * @param array $data Array [optionname => value] to be saved
+	 *
+	 * @return array  Validation errors: [optionname => error message]
+	 *
+	 * Return array must be empty if no error.
+	 */
+	public function saveOptions(array $data): array;
+}

--- a/src/Model/Storage/IStorage.php
+++ b/src/Model/Storage/IStorage.php
@@ -22,9 +22,7 @@
 namespace Friendica\Model\Storage;
 
 /**
- * Interface for storage backends
- *
- * @todo Split this interface into "IStorage" for get() operations (including Resource fetching) and "IUserStorage" for real user backends including put/delete/options
+ * Interface for basic storage backends
  */
 interface IStorage
 {
@@ -34,77 +32,11 @@ interface IStorage
 	 * @param string $reference Data reference
 	 *
 	 * @return string
+	 *
+	 * @throws StorageException in case there's an unexpected error
+	 * @throws ReferenceStorageException in case the reference doesn't exist
 	 */
-	public function get(string $reference);
-
-	/**
-	 * Put data in backend as $ref. If $ref is not defined a new reference is created.
-	 *
-	 * @param string $data      Data to save
-	 * @param string $reference Data reference. Optional.
-	 *
-	 * @return string Saved data reference
-	 */
-	public function put(string $data, string $reference = "");
-
-	/**
-	 * Remove data from backend
-	 *
-	 * @param string $reference Data reference
-	 *
-	 * @return boolean  True on success
-	 */
-	public function delete(string $reference);
-
-	/**
-	 * Get info about storage options
-	 *
-	 * @return array
-	 *
-	 * This method return an array with informations about storage options
-	 * from which the form presented to the user is build.
-	 *
-	 * The returned array is:
-	 *
-	 *    [
-	 *      'option1name' => [ ..info.. ],
-	 *      'option2name' => [ ..info.. ],
-	 *      ...
-	 *    ]
-	 *
-	 * An empty array can be returned if backend doesn't have any options
-	 *
-	 * The info array for each option MUST be as follows:
-	 *
-	 *    [
-	 *      'type',      // define the field used in form, and the type of data.
-	 *                   // one of 'checkbox', 'combobox', 'custom', 'datetime',
-	 *                   // 'input', 'intcheckbox', 'password', 'radio', 'richtext'
-	 *                   // 'select', 'select_raw', 'textarea'
-	 *
-	 *      'label',     // Translatable label of the field
-	 *      'value',     // Current value
-	 *      'help text', // Translatable description for the field
-	 *      extra data   // Optional. Depends on 'type':
-	 *                   // select: array [ value => label ] of choices
-	 *                   // intcheckbox: value of input element
-	 *                   // select_raw: prebuild html string of < option > tags
-	 *    ]
-	 *
-	 * See https://github.com/friendica/friendica/wiki/Quick-Template-Guide
-	 */
-	public function getOptions();
-
-	/**
-	 * Validate and save options
-	 *
-	 * @param array $data Array [optionname => value] to be saved
-	 *
-	 * @return array  Validation errors: [optionname => error message]
-	 *
-	 * Return array must be empty if no error.
-	 */
-	public function saveOptions(array $data);
+	public function get(string $reference): string;
 
 	/**
 	 * The name of the backend
@@ -118,5 +50,5 @@ interface IStorage
 	 *
 	 * @return string
 	 */
-	public static function getName();
+	public static function getName(): string;
 }

--- a/src/Model/Storage/IWritableStorage.php
+++ b/src/Model/Storage/IWritableStorage.php
@@ -25,7 +25,7 @@ namespace Friendica\Model\Storage;
  * Interface for writable storage backends
  *
  * Used for storages with CRUD functionality, mainly used for user data (e.g. photos, attachements).
- * There's only one active, writable storage possible. This type of storages are selectable by the current administrator
+ * There's only one active writable storage possible. This type of storage is selectable by the current administrator.
  */
 interface IWritableStorage extends IStorage
 {

--- a/src/Model/Storage/IWritableStorage.php
+++ b/src/Model/Storage/IWritableStorage.php
@@ -22,12 +22,12 @@
 namespace Friendica\Model\Storage;
 
 /**
- * Interface for selectable storage backends
+ * Interface for writable storage backends
  *
  * Used for storages with CRUD functionality, mainly used for user data (e.g. photos, attachements).
- * There's only one active, selectable storage possible and can be selected by the current administrator
+ * There's only one active, writable storage possible. This type of storages are selectable by the current administrator
  */
-interface ISelectableStorage extends IStorage
+interface IWritableStorage extends IStorage
 {
 	/**
 	 * Put data in backend as $ref. If $ref is not defined a new reference is created.

--- a/src/Model/Storage/InvalidClassStorageException.php
+++ b/src/Model/Storage/InvalidClassStorageException.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * @copyright Copyright (C) 2010-2021, the Friendica project
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Friendica\Model\Storage;
+
+/**
+ * Storage Exception in case of invalid storage class
+ */
+class InvalidClassStorageException extends StorageException
+{
+}

--- a/src/Model/Storage/ReferenceStorageException.php
+++ b/src/Model/Storage/ReferenceStorageException.php
@@ -21,11 +21,9 @@
 
 namespace Friendica\Model\Storage;
 
-use Exception;
-
 /**
  * Storage Exception in case of invalid references
  */
-class ReferenceStorageException extends Exception
+class ReferenceStorageException extends StorageException
 {
 }

--- a/src/Model/Storage/ReferenceStorageException.php
+++ b/src/Model/Storage/ReferenceStorageException.php
@@ -21,31 +21,11 @@
 
 namespace Friendica\Model\Storage;
 
-use Friendica\Core\L10n;
-use Psr\Log\LoggerInterface;
+use Exception;
 
 /**
- * A general storage class which loads common dependencies and implements common methods
+ * Storage Exception in case of invalid references
  */
-abstract class AbstractStorage implements IStorage
+class ReferenceStorageException extends Exception
 {
-	/** @var L10n */
-	protected $l10n;
-	/** @var LoggerInterface */
-	protected $logger;
-
-	/**
-	 * @param L10n            $l10n
-	 * @param LoggerInterface $logger
-	 */
-	public function __construct(L10n $l10n, LoggerInterface $logger)
-	{
-		$this->l10n   = $l10n;
-		$this->logger = $logger;
-	}
-
-	public function __toString()
-	{
-		return static::getName();
-	}
 }

--- a/src/Model/Storage/StorageException.php
+++ b/src/Model/Storage/StorageException.php
@@ -21,9 +21,11 @@
 
 namespace Friendica\Model\Storage;
 
+use Exception;
+
 /**
- * Storage Exception
+ * Storage Exception for unexpected failures
  */
-class StorageException extends \Exception
+class StorageException extends Exception
 {
 }

--- a/src/Model/Storage/SystemResource.php
+++ b/src/Model/Storage/SystemResource.php
@@ -21,8 +21,6 @@
 
 namespace Friendica\Model\Storage;
 
-use \BadMethodCallException;
-
 /**
  * System resource storage class
  *
@@ -39,45 +37,22 @@ class SystemResource implements IStorage
 	/**
 	 * @inheritDoc
 	 */
-	public function get(string $filename)
+	public function get(string $reference): string
 	{
-		$folder = dirname($filename);
+		$folder = dirname($reference);
 		if (!in_array($folder, self::VALID_FOLDERS)) {
-			return "";
+			throw new ReferenceStorageException(sprintf('System Resource is invalid for reference %s, no valid folder found', $reference));
 		}
-		if (!file_exists($filename)) {
-			return "";
+		if (!file_exists($reference)) {
+			throw new StorageException(sprintf('System Resource is invalid for reference %s, the file doesn\'t exist', $reference));
 		}
-		return file_get_contents($filename);
-	}
+		$content = file_get_contents($reference);
 
-	/**
-	 * @inheritDoc
-	 */
-	public function put(string $data, string $filename = '')
-	{
-		throw new BadMethodCallException();
-	}
+		if ($content === false) {
+			throw new StorageException(sprintf('Cannot get content for reference %s', $reference));
+		}
 
-	public function delete(string $filename)
-	{
-		throw new BadMethodCallException();
-	}
-
-	/**
-	 * @inheritDoc
-	 */
-	public function getOptions()
-	{
-		return [];
-	}
-
-	/**
-	 * @inheritDoc
-	 */
-	public function saveOptions(array $data)
-	{
-		return [];
+		return $content;
 	}
 
 	/**
@@ -91,7 +66,7 @@ class SystemResource implements IStorage
 	/**
 	 * @inheritDoc
 	 */
-	public static function getName()
+	public static function getName(): string
 	{
 		return self::NAME;
 	}

--- a/src/Module/Admin/Storage.php
+++ b/src/Module/Admin/Storage.php
@@ -96,7 +96,7 @@ class Storage extends BaseAdmin
 		$current_storage_backend = DI::storage();
 		$available_storage_forms = [];
 
-		foreach (DI::storageManager()->listBackends() as $name => $class) {
+		foreach (DI::storageManager()->listBackends() as $name) {
 
 			// build storage config form,
 			$storage_form_prefix = preg_replace('|[^a-zA-Z0-9]|', '', $name);

--- a/src/Module/Admin/Storage.php
+++ b/src/Module/Admin/Storage.php
@@ -23,7 +23,7 @@ namespace Friendica\Module\Admin;
 
 use Friendica\Core\Renderer;
 use Friendica\DI;
-use Friendica\Model\Storage\ISelectableStorage;
+use Friendica\Model\Storage\IWritableStorage;
 use Friendica\Module\BaseAdmin;
 use Friendica\Util\Strings;
 
@@ -37,8 +37,8 @@ class Storage extends BaseAdmin
 
 		$storagebackend = Strings::escapeTags(trim($parameters['name'] ?? ''));
 
-		/** @var ISelectableStorage $newstorage */
-		$newstorage = DI::storageManager()->getSelectableStorageByName($storagebackend);
+		/** @var IWritableStorage $newstorage */
+		$newstorage = DI::storageManager()->getWritableStorageByName($storagebackend);
 
 		// save storage backend form
 		$storage_opts        = $newstorage->getOptions();
@@ -68,8 +68,8 @@ class Storage extends BaseAdmin
 		}
 
 		if (!empty($_POST['submit_save_set'])) {
-			/** @var ISelectableStorage $newstorage */
-			$newstorage = DI::storageManager()->getSelectableStorageByName($storagebackend);
+			/** @var IWritableStorage $newstorage */
+			$newstorage = DI::storageManager()->getWritableStorageByName($storagebackend);
 
 			if (!DI::storageManager()->setBackend($newstorage)) {
 				notice(DI::l10n()->t('Invalid storage backend setting value.'));
@@ -92,7 +92,7 @@ class Storage extends BaseAdmin
 			$storage_form_prefix = preg_replace('|[^a-zA-Z0-9]|', '', $name);
 
 			$storage_form = [];
-			foreach (DI::storageManager()->getSelectableStorageByName($name)->getOptions() as $option => $info) {
+			foreach (DI::storageManager()->getWritableStorageByName($name)->getOptions() as $option => $info) {
 				$type = $info[0];
 				// Backward compatibilty with yesno field description
 				if ($type == 'yesno') {
@@ -111,7 +111,7 @@ class Storage extends BaseAdmin
 				'name'   => $name,
 				'prefix' => $storage_form_prefix,
 				'form'   => $storage_form,
-				'active' => $current_storage_backend instanceof ISelectableStorage && $name === $current_storage_backend::getName(),
+				'active' => $current_storage_backend instanceof IWritableStorage && $name === $current_storage_backend::getName(),
 			];
 		}
 
@@ -127,7 +127,7 @@ class Storage extends BaseAdmin
 			'$noconfig'              => DI::l10n()->t('This backend doesn\'t have custom settings'),
 			'$baseurl'               => DI::baseUrl()->get(true),
 			'$form_security_token'   => self::getFormSecurityToken("admin_storage"),
-			'$storagebackend'        => $current_storage_backend instanceof ISelectableStorage ? $current_storage_backend::getName() : DI::l10n()->t('Database (legacy)'),
+			'$storagebackend'        => $current_storage_backend instanceof IWritableStorage ? $current_storage_backend::getName() : DI::l10n()->t('Database (legacy)'),
 			'$availablestorageforms' => $available_storage_forms,
 		]);
 	}

--- a/src/Module/Photo.php
+++ b/src/Module/Photo.php
@@ -30,7 +30,11 @@ use Friendica\Model\Photo as MPhoto;
 use Friendica\Model\Post;
 use Friendica\Model\Profile;
 use Friendica\Model\Storage\ExternalResource;
+use Friendica\Model\Storage\ReferenceStorageException;
+use Friendica\Model\Storage\StorageException;
 use Friendica\Model\Storage\SystemResource;
+use Friendica\Network\HTTPException\InternalServerErrorException;
+use Friendica\Network\HTTPException\NotFoundException;
 use Friendica\Util\Proxy;
 use Friendica\Object\Image;
 use Friendica\Util\Images;
@@ -105,7 +109,11 @@ class Photo extends BaseModule
 		$cacheable = ($photo["allow_cid"] . $photo["allow_gid"] . $photo["deny_cid"] . $photo["deny_gid"] === "") && (isset($photo["cacheable"]) ? $photo["cacheable"] : true);
 
 		$stamp = microtime(true);
+
 		$imgdata = MPhoto::getImageDataForPhoto($photo);
+		if (empty($imgdata)) {
+			throw new NotFoundException();
+		}
 
 		// The mimetype for an external or system resource can only be known reliably after it had been fetched
 		if (in_array($photo['backend-class'], [ExternalResource::NAME, SystemResource::NAME])) {

--- a/src/Module/Settings/Profile/Photo/Crop.php
+++ b/src/Module/Settings/Profile/Photo/Crop.php
@@ -61,6 +61,10 @@ class Crop extends BaseSettings
 		$base_image = Photo::selectFirst([], ['resource-id' => $resource_id, 'uid' => local_user(), 'scale' => $scale]);
 		if (DBA::isResult($base_image)) {
 			$Image = Photo::getImageForPhoto($base_image);
+			if (empty($Image)) {
+				throw new HTTPException\InternalServerErrorException();
+			}
+
 			if ($Image->isValid()) {
 				// If setting for the default profile, unset the profile photo flag from any other photos I own
 				DBA::update('photo', ['profile' => 0], ['uid' => local_user()]);
@@ -188,6 +192,9 @@ class Crop extends BaseSettings
 		}
 
 		$Image = Photo::getImageForPhoto($photos[0]);
+		if (empty($Image)) {
+			throw new HTTPException\InternalServerErrorException();
+		}
 
 		$imagecrop = [
 			'resource-id' => $resource_id,

--- a/src/Util/HTTPSignature.php
+++ b/src/Util/HTTPSignature.php
@@ -28,6 +28,7 @@ use Friendica\DI;
 use Friendica\Model\APContact;
 use Friendica\Model\Contact;
 use Friendica\Model\User;
+use Friendica\Network\CurlResult;
 
 /**
  * Implements HTTP Signatures per draft-cavage-http-signatures-07.
@@ -408,7 +409,7 @@ class HTTPSignature
 	 *                         'nobody' => only return the header
 	 *                         'cookiejar' => path to cookie jar file
 	 *
-	 * @return object CurlResult
+	 * @return CurlResult|void CurlResult
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
 	public static function fetchRaw($request, $uid = 0, $opts = ['accept_content' => 'application/activity+json, application/ld+json'])

--- a/src/Util/HTTPSignature.php
+++ b/src/Util/HTTPSignature.php
@@ -409,7 +409,7 @@ class HTTPSignature
 	 *                         'nobody' => only return the header
 	 *                         'cookiejar' => path to cookie jar file
 	 *
-	 * @return CurlResult|void CurlResult
+	 * @return CurlResult CurlResult
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
 	public static function fetchRaw($request, $uid = 0, $opts = ['accept_content' => 'application/activity+json, application/ld+json'])

--- a/src/Worker/MoveStorage.php
+++ b/src/Worker/MoveStorage.php
@@ -34,7 +34,7 @@ class MoveStorage
 	public static function execute()
 	{
 		$current = DI::storage();
-		$moved = DI::storageManager()->move($current);
+		$moved   = DI::storageManager()->move($current);
 
 		if ($moved) {
 			Worker::add(PRIORITY_LOW, 'MoveStorage');

--- a/static/dependencies.config.php
+++ b/static/dependencies.config.php
@@ -44,7 +44,7 @@ use Friendica\Core\Session\ISession;
 use Friendica\Core\StorageManager;
 use Friendica\Database\Database;
 use Friendica\Factory;
-use Friendica\Model\Storage\ISelectableStorage;
+use Friendica\Model\Storage\IWritableStorage;
 use Friendica\Model\User\Cookie;
 use Friendica\Network;
 use Friendica\Util;
@@ -213,7 +213,7 @@ return [
 			$_SERVER, $_COOKIE
 		],
 	],
-	ISelectableStorage::class => [
+	IWritableStorage::class => [
 		'instanceOf' => StorageManager::class,
 		'call' => [
 			['getBackend', [], Dice::CHAIN_CALL],

--- a/static/dependencies.config.php
+++ b/static/dependencies.config.php
@@ -44,7 +44,7 @@ use Friendica\Core\Session\ISession;
 use Friendica\Core\StorageManager;
 use Friendica\Database\Database;
 use Friendica\Factory;
-use Friendica\Model\Storage\IStorage;
+use Friendica\Model\Storage\ISelectableStorage;
 use Friendica\Model\User\Cookie;
 use Friendica\Network;
 use Friendica\Util;
@@ -213,7 +213,7 @@ return [
 			$_SERVER, $_COOKIE
 		],
 	],
-	IStorage::class => [
+	ISelectableStorage::class => [
 		'instanceOf' => StorageManager::class,
 		'call' => [
 			['getBackend', [], Dice::CHAIN_CALL],

--- a/static/settings.config.php
+++ b/static/settings.config.php
@@ -203,4 +203,11 @@ return [
 	// Used in the admin settings to lock certain features
 	'featurelock' => [
 	],
+
+	// Storage backend configuration
+	'storage' => [
+		// name (String)
+		// The name of the current used backend (default is Database)
+		'name' => 'Database',
+	],
 ];

--- a/tests/Util/SampleStorageBackend.php
+++ b/tests/Util/SampleStorageBackend.php
@@ -22,14 +22,14 @@
 namespace Friendica\Test\Util;
 
 use Friendica\Core\Hook;
-use Friendica\Model\Storage\ISelectableStorage;
+use Friendica\Model\Storage\IWritableStorage;
 
 use Friendica\Core\L10n;
 
 /**
  * A backend storage example class
  */
-class SampleStorageBackend implements ISelectableStorage
+class SampleStorageBackend implements IWritableStorage
 {
 	const NAME = 'Sample Storage';
 

--- a/tests/Util/SampleStorageBackend.php
+++ b/tests/Util/SampleStorageBackend.php
@@ -22,14 +22,14 @@
 namespace Friendica\Test\Util;
 
 use Friendica\Core\Hook;
-use Friendica\Model\Storage\IStorage;
+use Friendica\Model\Storage\ISelectableStorage;
 
 use Friendica\Core\L10n;
 
 /**
  * A backend storage example class
  */
-class SampleStorageBackend implements IStorage
+class SampleStorageBackend implements ISelectableStorage
 {
 	const NAME = 'Sample Storage';
 
@@ -62,14 +62,14 @@ class SampleStorageBackend implements IStorage
 		$this->l10n = $l10n;
 	}
 
-	public function get(string $reference)
+	public function get(string $reference): string
 	{
 		// we return always the same image data. Which file we load is defined by
 		// a config key
-		return $this->data[$reference] ?? null;
+		return $this->data[$reference] ?? '';
 	}
 
-	public function put(string $data, string $reference = '')
+	public function put(string $data, string $reference = ''): string
 	{
 		if ($reference === '') {
 			$reference = 'sample';
@@ -89,12 +89,12 @@ class SampleStorageBackend implements IStorage
 		return true;
 	}
 
-	public function getOptions()
+	public function getOptions(): array
 	{
 		return $this->options;
 	}
 
-	public function saveOptions(array $data)
+	public function saveOptions(array $data): array
 	{
 		$this->options = $data;
 
@@ -107,7 +107,7 @@ class SampleStorageBackend implements IStorage
 		return self::NAME;
 	}
 
-	public static function getName()
+	public static function getName(): string
 	{
 		return self::NAME;
 	}
@@ -120,4 +120,3 @@ class SampleStorageBackend implements IStorage
 		Hook::register('storage_instance', __DIR__ . '/SampleStorageBackendInstance.php', 'create_instance');
 	}
 }
-

--- a/tests/src/Core/StorageManagerTest.php
+++ b/tests/src/Core/StorageManagerTest.php
@@ -178,7 +178,7 @@ class StorageManagerTest extends DatabaseTest
 		$storageManager = new StorageManager($this->dba, $this->config, $this->logger, $this->l10n, $this->httpRequest);
 
 		if ($userBackend) {
-			$storage = $storageManager->getSelectableStorageByName($name);
+			$storage = $storageManager->getWritableStorageByName($name);
 		} else {
 			$storage = $storageManager->getByName($name);
 		}
@@ -230,7 +230,7 @@ class StorageManagerTest extends DatabaseTest
 		self::assertNull($storageManager->getBackend());
 
 		if ($userBackend) {
-			$selBackend = $storageManager->getSelectableStorageByName($name);
+			$selBackend = $storageManager->getWritableStorageByName($name);
 			$storageManager->setBackend($selBackend);
 
 			self::assertInstanceOf($assert, $storageManager->getBackend());
@@ -287,7 +287,7 @@ class StorageManagerTest extends DatabaseTest
 		SampleStorageBackend::registerHook();
 		Hook::loadHooks();
 
-		self::assertTrue($storageManager->setBackend( $storageManager->getSelectableStorageByName(SampleStorageBackend::NAME)));
+		self::assertTrue($storageManager->setBackend( $storageManager->getWritableStorageByName(SampleStorageBackend::NAME)));
 		self::assertEquals(SampleStorageBackend::NAME, $this->config->get('storage', 'name'));
 
 		self::assertInstanceOf(SampleStorageBackend::class, $storageManager->getBackend());
@@ -314,7 +314,7 @@ class StorageManagerTest extends DatabaseTest
 		$this->loadFixture(__DIR__ . '/../../datasets/storage/database.fixture.php', $this->dba);
 
 		$storageManager = new StorageManager($this->dba, $this->config, $this->logger, $this->l10n);
-		$storage = $storageManager->getSelectableStorageByName($name);
+		$storage = $storageManager->getWritableStorageByName($name);
 		$storageManager->move($storage);
 
 		$photos = $this->dba->select('photo', ['backend-ref', 'backend-class', 'id', 'data']);
@@ -333,12 +333,12 @@ class StorageManagerTest extends DatabaseTest
 	/**
 	 * Test moving data to a WRONG storage
 	 */
-	public function testWrongSelectableStorage()
+	public function testWrongWritableStorage()
 	{
 		$this->expectException(\TypeError::class);
 
 		$storageManager = new StorageManager($this->dba, $this->config, $this->logger, $this->l10n);
-		$storage = $storageManager->getSelectableStorageByName(Storage\SystemResource::getName());
+		$storage = $storageManager->getWritableStorageByName(Storage\SystemResource::getName());
 		$storageManager->move($storage);
 	}
 }

--- a/tests/src/Core/StorageManagerTest.php
+++ b/tests/src/Core/StorageManagerTest.php
@@ -309,7 +309,7 @@ class StorageManagerTest extends DatabaseTest
 		$this->loadFixture(__DIR__ . '/../../datasets/storage/database.fixture.php', $this->dba);
 
 		$storageManager = new StorageManager($this->dba, $this->config, $this->logger, $this->l10n, $this->httpRequest);
-		$storage = $storageManager->getByName($name);
+		$storage = $storageManager->getSelectableStorageByName($name);
 		$storageManager->move($storage);
 
 		$photos = $this->dba->select('photo', ['backend-ref', 'backend-class', 'id', 'data']);
@@ -334,7 +334,7 @@ class StorageManagerTest extends DatabaseTest
 		$this->expectException(StorageException::class);
 
 		$storageManager = new StorageManager($this->dba, $this->config, $this->logger, $this->l10n, $this->httpRequest);
-		$storage = $storageManager->getByName(Storage\SystemResource::getName());
+		$storage = $storageManager->getSelectableStorageByName(Storage\SystemResource::getName());
 		$storageManager->move($storage);
 	}
 }

--- a/tests/src/Core/StorageManagerTest.php
+++ b/tests/src/Core/StorageManagerTest.php
@@ -34,7 +34,6 @@ use Friendica\Factory\ConfigFactory;
 use Friendica\Model\Config\Config;
 use Friendica\Model\Storage;
 use Friendica\Core\Session;
-use Friendica\Model\Storage\StorageException;
 use Friendica\Network\HTTPRequest;
 use Friendica\Test\DatabaseTest;
 use Friendica\Test\Util\Database\StaticDatabase;
@@ -47,6 +46,7 @@ use Friendica\Test\Util\SampleStorageBackend;
 
 class StorageManagerTest extends DatabaseTest
 {
+	use VFSTrait;
 	/** @var Database */
 	private $dba;
 	/** @var IConfig */
@@ -57,8 +57,6 @@ class StorageManagerTest extends DatabaseTest
 	private $l10n;
 	/** @var HTTPRequest */
 	private $httpRequest;
-
-	use VFSTrait;
 
 	protected function setUp(): void
 	{
@@ -82,6 +80,7 @@ class StorageManagerTest extends DatabaseTest
 
 		$configModel  = new Config($this->dba);
 		$this->config = new PreloadConfig($configCache, $configModel);
+		$this->config->set('storage', 'name', 'Database');
 
 		$this->l10n = \Mockery::mock(L10n::class);
 
@@ -101,67 +100,40 @@ class StorageManagerTest extends DatabaseTest
 	public function dataStorages()
 	{
 		return [
-			'empty'          => [
-				'name'        => '',
-				'assert'      => null,
-				'assertName'  => '',
-				'userBackend' => false,
+			'empty' => [
+				'name'       => '',
+				'valid'      => false,
+				'interface'  => Storage\IStorage::class,
+				'assert'     => null,
+				'assertName' => '',
 			],
-			'database'       => [
-				'name'        => Storage\Database::NAME,
-				'assert'      => Storage\Database::class,
-				'assertName'  => Storage\Database::NAME,
-				'userBackend' => true,
+			'database' => [
+				'name'       => Storage\Database::NAME,
+				'valid'      => true,
+				'interface'  => Storage\IWritableStorage::class,
+				'assert'     => Storage\Database::class,
+				'assertName' => Storage\Database::NAME,
 			],
-			'filesystem'     => [
-				'name'        => Storage\Filesystem::NAME,
-				'assert'      => Storage\Filesystem::class,
-				'assertName'  => Storage\Filesystem::NAME,
-				'userBackend' => true,
+			'filesystem' => [
+				'name'       => Storage\Filesystem::NAME,
+				'valid'      => true,
+				'interface'  => Storage\IWritableStorage::class,
+				'assert'     => Storage\Filesystem::class,
+				'assertName' => Storage\Filesystem::NAME,
 			],
 			'systemresource' => [
-				'name'        => Storage\SystemResource::NAME,
-				'assert'      => Storage\SystemResource::class,
-				'assertName'  => Storage\SystemResource::NAME,
-				// false here, because SystemResource isn't meant to be a user backend,
-				// it's for system resources only
-				'userBackend' => false,
+				'name'       => Storage\SystemResource::NAME,
+				'valid'      => true,
+				'interface'  => Storage\IStorage::class,
+				'assert'     => Storage\SystemResource::class,
+				'assertName' => Storage\SystemResource::NAME,
 			],
-			'invalid'        => [
+			'invalid' => [
 				'name'        => 'invalid',
+				'valid'       => false,
+				'interface'   => null,
 				'assert'      => null,
 				'assertName'  => '',
-				'userBackend' => false,
-			],
-		];
-	}
-
-	/**
-	 * Data array for legacy backends
-	 *
-	 * @todo 2020.09 After 2 releases, remove the legacy functionality and these data array with it
-	 *
-	 * @return array
-	 */
-	public function dataLegacyBackends()
-	{
-		return [
-			'legacyDatabase'          => [
-				'name'        => 'Friendica\Model\Storage\Database',
-				'assert'      => Storage\Database::class,
-				'assertName'  => Storage\Database::NAME,
-				'userBackend' => true,
-			],
-			'legacyFilesystem'       => [
-				'name'        => 'Friendica\Model\Storage\Filesystem',
-				'assert'      => Storage\Filesystem::class,
-				'assertName'  => Storage\Filesystem::NAME,
-				'userBackend' => true,
-			],
-			'legacySystemResource'     => [
-				'name'        => 'Friendica\Model\Storage\SystemResource',
-				'assert'      => Storage\SystemResource::class,
-				'assertName'  => Storage\SystemResource::NAME,
 				'userBackend' => false,
 			],
 		];
@@ -171,24 +143,27 @@ class StorageManagerTest extends DatabaseTest
 	 * Test the getByName() method
 	 *
 	 * @dataProvider dataStorages
-	 * @dataProvider dataLegacyBackends
 	 */
-	public function testGetByName($name, $assert, $assertName, $userBackend)
+	public function testGetByName($name, $valid, $interface, $assert, $assertName)
 	{
-		$storageManager = new StorageManager($this->dba, $this->config, $this->logger, $this->l10n, $this->httpRequest);
+		if (!$valid) {
+			$this->expectException(Storage\InvalidClassStorageException::class);
+		}
 
-		if ($userBackend) {
+		if ($interface === Storage\IWritableStorage::class) {
+			$this->config->set('storage', 'name', $name);
+		}
+
+		$storageManager = new StorageManager($this->dba, $this->config, $this->logger, $this->l10n);
+
+		if ($interface === Storage\IWritableStorage::class) {
 			$storage = $storageManager->getWritableStorageByName($name);
 		} else {
 			$storage = $storageManager->getByName($name);
 		}
 
-		if (!empty($assert)) {
-			self::assertInstanceOf(Storage\IStorage::class, $storage);
-			self::assertInstanceOf($assert, $storage);
-		} else {
-			self::assertNull($storage);
-		}
+		self::assertInstanceOf($interface, $storage);
+		self::assertInstanceOf($assert, $storage);
 		self::assertEquals($assertName, $storage);
 	}
 
@@ -197,15 +172,15 @@ class StorageManagerTest extends DatabaseTest
 	 *
 	 * @dataProvider dataStorages
 	 */
-	public function testIsValidBackend($name, $assert, $assertName, $userBackend)
+	public function testIsValidBackend($name, $valid, $interface, $assert, $assertName)
 	{
 		$storageManager = new StorageManager($this->dba, $this->config, $this->logger, $this->l10n);
 
 		// true in every of the backends
 		self::assertEquals(!empty($assertName), $storageManager->isValidBackend($name));
 
-		// if userBackend is set to true, filter out e.g. SystemRessource
-		self::assertEquals($userBackend, $storageManager->isValidBackend($name, true));
+		// if it's a IWritableStorage, the valid backend should return true, otherwise false
+		self::assertEquals($interface === Storage\IWritableStorage::class, $storageManager->isValidBackend($name, StorageManager::DEFAULT_BACKENDS));
 	}
 
 	/**
@@ -223,37 +198,35 @@ class StorageManagerTest extends DatabaseTest
 	 *
 	 * @dataProvider dataStorages
 	 */
-	public function testGetBackend($name, $assert, $assertName, $userBackend)
+	public function testGetBackend($name, $valid, $interface, $assert, $assertName)
 	{
+		if ($interface !== Storage\IWritableStorage::class) {
+			static::markTestSkipped('only works for IWritableStorage');
+		}
+
 		$storageManager = new StorageManager($this->dba, $this->config, $this->logger, $this->l10n);
 
-		self::assertNull($storageManager->getBackend());
+		$selBackend = $storageManager->getWritableStorageByName($name);
+		$storageManager->setBackend($selBackend);
 
-		if ($userBackend) {
-			$selBackend = $storageManager->getWritableStorageByName($name);
-			$storageManager->setBackend($selBackend);
-
-			self::assertInstanceOf($assert, $storageManager->getBackend());
-		}
+		self::assertInstanceOf($assert, $storageManager->getBackend());
 	}
 
 	/**
 	 * Test the method getBackend() with a pre-configured backend
 	 *
 	 * @dataProvider dataStorages
-	 * @dataProvider dataLegacyBackends
 	 */
-	public function testPresetBackend($name, $assert, $assertName, $userBackend)
+	public function testPresetBackend($name, $valid, $interface, $assert, $assertName)
 	{
 		$this->config->set('storage', 'name', $name);
+		if ($interface !== Storage\IWritableStorage::class) {
+			$this->expectException(Storage\InvalidClassStorageException::class);
+		}
 
 		$storageManager = new StorageManager($this->dba, $this->config, $this->logger, $this->l10n);
 
-		if ($userBackend) {
-			self::assertInstanceOf($assert, $storageManager->getBackend());
-		} else {
-			self::assertNull($storageManager->getBackend());
-		}
+		self::assertInstanceOf($assert, $storageManager->getBackend());
 	}
 
 	/**
@@ -266,7 +239,7 @@ class StorageManagerTest extends DatabaseTest
 	public function testRegisterUnregisterBackends()
 	{
 		/// @todo Remove dice once "Hook" is dynamic and mockable
-		$dice   = (new Dice())
+		$dice = (new Dice())
 			->addRules(include __DIR__ . '/../../../static/dependencies.config.php')
 			->addRule(Database::class, ['instanceOf' => StaticDatabase::class, 'shared' => true])
 			->addRule(ISession::class, ['instanceOf' => Session\Memory::class, 'shared' => true, 'call' => null]);
@@ -287,7 +260,7 @@ class StorageManagerTest extends DatabaseTest
 		SampleStorageBackend::registerHook();
 		Hook::loadHooks();
 
-		self::assertTrue($storageManager->setBackend( $storageManager->getWritableStorageByName(SampleStorageBackend::NAME)));
+		self::assertTrue($storageManager->setBackend($storageManager->getWritableStorageByName(SampleStorageBackend::NAME)));
 		self::assertEquals(SampleStorageBackend::NAME, $this->config->get('storage', 'name'));
 
 		self::assertInstanceOf(SampleStorageBackend::class, $storageManager->getBackend());
@@ -305,26 +278,25 @@ class StorageManagerTest extends DatabaseTest
 	 *
 	 * @dataProvider dataStorages
 	 */
-	public function testMoveStorage($name, $assert, $assertName, $userBackend)
+	public function testMoveStorage($name, $valid, $interface, $assert, $assertName)
 	{
-		if (!$userBackend) {
+		if ($interface !== Storage\IWritableStorage::class) {
 			self::markTestSkipped("No user backend");
 		}
 
 		$this->loadFixture(__DIR__ . '/../../datasets/storage/database.fixture.php', $this->dba);
 
 		$storageManager = new StorageManager($this->dba, $this->config, $this->logger, $this->l10n);
-		$storage = $storageManager->getWritableStorageByName($name);
+		$storage        = $storageManager->getWritableStorageByName($name);
 		$storageManager->move($storage);
 
 		$photos = $this->dba->select('photo', ['backend-ref', 'backend-class', 'id', 'data']);
 
 		while ($photo = $this->dba->fetch($photos)) {
-
 			self::assertEmpty($photo['data']);
 
 			$storage = $storageManager->getByName($photo['backend-class']);
-			$data = $storage->get($photo['backend-ref']);
+			$data    = $storage->get($photo['backend-ref']);
 
 			self::assertNotEmpty($data);
 		}
@@ -335,10 +307,11 @@ class StorageManagerTest extends DatabaseTest
 	 */
 	public function testWrongWritableStorage()
 	{
-		$this->expectException(\TypeError::class);
+		$this->expectException(Storage\InvalidClassStorageException::class);
+		$this->expectExceptionMessage('Backend SystemResource is not valid');
 
 		$storageManager = new StorageManager($this->dba, $this->config, $this->logger, $this->l10n);
-		$storage = $storageManager->getWritableStorageByName(Storage\SystemResource::getName());
+		$storage        = $storageManager->getWritableStorageByName(Storage\SystemResource::getName());
 		$storageManager->move($storage);
 	}
 }

--- a/tests/src/Model/Storage/DatabaseStorageTest.php
+++ b/tests/src/Model/Storage/DatabaseStorageTest.php
@@ -62,10 +62,7 @@ class DatabaseStorageTest extends StorageTest
 
 		$dba = new StaticDatabase($configCache, $profiler, $logger);
 
-		/** @var MockInterface|L10n $l10n */
-		$l10n = \Mockery::mock(L10n::class)->makePartial();
-
-		return new Database($dba, $logger, $l10n);
+		return new Database($dba);
 	}
 
 	protected function assertOption(IStorage $storage)

--- a/tests/src/Model/Storage/DatabaseStorageTest.php
+++ b/tests/src/Model/Storage/DatabaseStorageTest.php
@@ -21,16 +21,14 @@
 
 namespace Friendica\Test\src\Model\Storage;
 
-use Friendica\Core\L10n;
 use Friendica\Factory\ConfigFactory;
 use Friendica\Model\Storage\Database;
-use Friendica\Model\Storage\IStorage;
+use Friendica\Model\Storage\ISelectableStorage;
 use Friendica\Test\DatabaseTestTrait;
 use Friendica\Test\Util\Database\StaticDatabase;
 use Friendica\Test\Util\VFSTrait;
 use Friendica\Util\ConfigFileLoader;
 use Friendica\Util\Profiler;
-use Mockery\MockInterface;
 use Psr\Log\NullLogger;
 
 class DatabaseStorageTest extends StorageTest
@@ -65,7 +63,7 @@ class DatabaseStorageTest extends StorageTest
 		return new Database($dba);
 	}
 
-	protected function assertOption(IStorage $storage)
+	protected function assertOption(ISelectableStorage $storage)
 	{
 		self::assertEmpty($storage->getOptions());
 	}

--- a/tests/src/Model/Storage/DatabaseStorageTest.php
+++ b/tests/src/Model/Storage/DatabaseStorageTest.php
@@ -23,7 +23,7 @@ namespace Friendica\Test\src\Model\Storage;
 
 use Friendica\Factory\ConfigFactory;
 use Friendica\Model\Storage\Database;
-use Friendica\Model\Storage\ISelectableStorage;
+use Friendica\Model\Storage\IWritableStorage;
 use Friendica\Test\DatabaseTestTrait;
 use Friendica\Test\Util\Database\StaticDatabase;
 use Friendica\Test\Util\VFSTrait;
@@ -63,7 +63,7 @@ class DatabaseStorageTest extends StorageTest
 		return new Database($dba);
 	}
 
-	protected function assertOption(ISelectableStorage $storage)
+	protected function assertOption(IWritableStorage $storage)
 	{
 		self::assertEmpty($storage->getOptions());
 	}

--- a/tests/src/Model/Storage/FilesystemStorageTest.php
+++ b/tests/src/Model/Storage/FilesystemStorageTest.php
@@ -24,7 +24,7 @@ namespace Friendica\Test\src\Model\Storage;
 use Friendica\Core\Config\IConfig;
 use Friendica\Core\L10n;
 use Friendica\Model\Storage\Filesystem;
-use Friendica\Model\Storage\ISelectableStorage;
+use Friendica\Model\Storage\IWritableStorage;
 use Friendica\Model\Storage\StorageException;
 use Friendica\Test\Util\VFSTrait;
 use Friendica\Util\Profiler;
@@ -64,7 +64,7 @@ class FilesystemStorageTest extends StorageTest
 		return new Filesystem($this->config, $l10n);
 	}
 
-	protected function assertOption(ISelectableStorage $storage)
+	protected function assertOption(IWritableStorage $storage)
 	{
 		self::assertEquals([
 			'storagepath' => [

--- a/tests/src/Model/Storage/FilesystemStorageTest.php
+++ b/tests/src/Model/Storage/FilesystemStorageTest.php
@@ -50,7 +50,6 @@ class FilesystemStorageTest extends StorageTest
 
 	protected function getInstance()
 	{
-		$logger = new NullLogger();
 		$profiler = \Mockery::mock(Profiler::class);
 		$profiler->shouldReceive('startRecording');
 		$profiler->shouldReceive('stopRecording');
@@ -63,7 +62,7 @@ class FilesystemStorageTest extends StorageTest
 		             ->with('storage', 'filesystem_path', Filesystem::DEFAULT_BASE_FOLDER)
 		             ->andReturn($this->root->getChild('storage')->url());
 
-		return new Filesystem($this->config, $logger, $l10n);
+		return new Filesystem($this->config, $l10n);
 	}
 
 	protected function assertOption(IStorage $storage)

--- a/tests/src/Model/Storage/FilesystemStorageTest.php
+++ b/tests/src/Model/Storage/FilesystemStorageTest.php
@@ -24,13 +24,12 @@ namespace Friendica\Test\src\Model\Storage;
 use Friendica\Core\Config\IConfig;
 use Friendica\Core\L10n;
 use Friendica\Model\Storage\Filesystem;
-use Friendica\Model\Storage\IStorage;
+use Friendica\Model\Storage\ISelectableStorage;
 use Friendica\Model\Storage\StorageException;
 use Friendica\Test\Util\VFSTrait;
 use Friendica\Util\Profiler;
 use Mockery\MockInterface;
 use org\bovigo\vfs\vfsStream;
-use Psr\Log\NullLogger;
 
 class FilesystemStorageTest extends StorageTest
 {
@@ -65,7 +64,7 @@ class FilesystemStorageTest extends StorageTest
 		return new Filesystem($this->config, $l10n);
 	}
 
-	protected function assertOption(IStorage $storage)
+	protected function assertOption(ISelectableStorage $storage)
 	{
 		self::assertEquals([
 			'storagepath' => [

--- a/tests/src/Model/Storage/StorageTest.php
+++ b/tests/src/Model/Storage/StorageTest.php
@@ -22,6 +22,8 @@
 namespace Friendica\Test\src\Model\Storage;
 
 use Friendica\Model\Storage\IStorage;
+use Friendica\Model\Storage\ReferenceStorageException;
+use Friendica\Model\Storage\StorageException;
 use Friendica\Test\MockedTest;
 
 abstract class StorageTest extends MockedTest
@@ -62,7 +64,7 @@ abstract class StorageTest extends MockedTest
 
 		self::assertEquals('data12345', $instance->get($ref));
 
-		self::assertTrue($instance->delete($ref));
+		$instance->delete($ref);
 	}
 
 	/**
@@ -70,10 +72,11 @@ abstract class StorageTest extends MockedTest
 	 */
 	public function testInvalidDelete()
 	{
+		self::expectException(ReferenceStorageException::class);
+
 		$instance = $this->getInstance();
 
-		// Even deleting not existing references should return "true"
-		self::assertTrue($instance->delete(-1234456));
+		$instance->delete(-1234456);
 	}
 
 	/**
@@ -81,10 +84,11 @@ abstract class StorageTest extends MockedTest
 	 */
 	public function testInvalidGet()
 	{
+		self::expectException(ReferenceStorageException::class);
+
 		$instance = $this->getInstance();
 
-		// Invalid references return an empty string
-		self::assertEmpty($instance->get(-123456));
+		$instance->get(-123456);
 	}
 
 	/**

--- a/tests/src/Model/Storage/StorageTest.php
+++ b/tests/src/Model/Storage/StorageTest.php
@@ -21,17 +21,17 @@
 
 namespace Friendica\Test\src\Model\Storage;
 
+use Friendica\Model\Storage\ISelectableStorage;
 use Friendica\Model\Storage\IStorage;
 use Friendica\Model\Storage\ReferenceStorageException;
-use Friendica\Model\Storage\StorageException;
 use Friendica\Test\MockedTest;
 
 abstract class StorageTest extends MockedTest
 {
-	/** @return IStorage */
+	/** @return ISelectableStorage */
 	abstract protected function getInstance();
 
-	abstract protected function assertOption(IStorage $storage);
+	abstract protected function assertOption(ISelectableStorage $storage);
 
 	/**
 	 * Test if the instance is "really" implementing the interface

--- a/tests/src/Model/Storage/StorageTest.php
+++ b/tests/src/Model/Storage/StorageTest.php
@@ -21,17 +21,17 @@
 
 namespace Friendica\Test\src\Model\Storage;
 
-use Friendica\Model\Storage\ISelectableStorage;
+use Friendica\Model\Storage\IWritableStorage;
 use Friendica\Model\Storage\IStorage;
 use Friendica\Model\Storage\ReferenceStorageException;
 use Friendica\Test\MockedTest;
 
 abstract class StorageTest extends MockedTest
 {
-	/** @return ISelectableStorage */
+	/** @return IWritableStorage */
 	abstract protected function getInstance();
 
-	abstract protected function assertOption(ISelectableStorage $storage);
+	abstract protected function assertOption(IWritableStorage $storage);
 
 	/**
 	 * Test if the instance is "really" implementing the interface

--- a/update.php
+++ b/update.php
@@ -982,7 +982,7 @@ function update_1429()
 	return Update::SUCCESS;
 }
 
-function update_1433()
+function update_1434()
 {
 	$name = DI::config()->get('storage', 'name');
 

--- a/update.php
+++ b/update.php
@@ -981,3 +981,20 @@ function update_1429()
 
 	return Update::SUCCESS;
 }
+
+function update_1433()
+{
+	$name = DI::config()->get('storage', 'name');
+
+	// in case of an empty config, set "Database" as default storage backend
+	if (empty($name)) {
+		DI::config()->set('storage', 'name', Storage\Database::getName());
+	}
+
+	// In case of a Using deprecated storage class value, set the right name for it
+	if (stristr($name, 'Friendica\Model\Storage\\')) {
+		DI::config()->set('storage', 'name', substr($name, 24));
+	}
+
+	return Update::SUCCESS;
+}

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2021.09-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-08-16 06:14+0000\n"
+"POT-Creation-Date: 2021-08-16 23:28+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -40,10 +40,10 @@ msgstr ""
 #: include/api.php:4437 mod/photos.php:86 mod/photos.php:195 mod/photos.php:623
 #: mod/photos.php:1031 mod/photos.php:1048 mod/photos.php:1594
 #: src/Model/User.php:1112 src/Model/User.php:1120 src/Model/User.php:1128
-#: src/Module/Settings/Profile/Photo/Crop.php:97
-#: src/Module/Settings/Profile/Photo/Crop.php:113
-#: src/Module/Settings/Profile/Photo/Crop.php:129
-#: src/Module/Settings/Profile/Photo/Crop.php:175
+#: src/Module/Settings/Profile/Photo/Crop.php:101
+#: src/Module/Settings/Profile/Photo/Crop.php:117
+#: src/Module/Settings/Profile/Photo/Crop.php:133
+#: src/Module/Settings/Profile/Photo/Crop.php:179
 #: src/Module/Settings/Profile/Photo/Index.php:95
 #: src/Module/Settings/Profile/Photo/Index.php:101
 msgid "Profile Photos"
@@ -851,7 +851,7 @@ msgstr ""
 #: src/Module/Search/Directory.php:38 src/Module/Settings/Delegation.php:42
 #: src/Module/Settings/Delegation.php:70 src/Module/Settings/Display.php:43
 #: src/Module/Settings/Display.php:121
-#: src/Module/Settings/Profile/Photo/Crop.php:154
+#: src/Module/Settings/Profile/Photo/Crop.php:158
 #: src/Module/Settings/Profile/Photo/Index.php:112
 #: src/Module/Settings/UserExport.php:58 src/Module/Settings/UserExport.php:93
 #: src/Module/Settings/UserExport.php:199
@@ -969,7 +969,7 @@ msgid "Edit post"
 msgstr ""
 
 #: mod/editpost.php:91 mod/notes.php:56 src/Content/Text/HTML.php:885
-#: src/Module/Admin/Storage.php:120 src/Module/Filer/SaveTag.php:69
+#: src/Module/Admin/Storage.php:133 src/Module/Filer/SaveTag.php:69
 msgid "Save"
 msgstr ""
 
@@ -2716,7 +2716,7 @@ msgstr ""
 msgid "File upload failed."
 msgstr ""
 
-#: mod/wall_upload.php:233 src/Model/Photo.php:1002
+#: mod/wall_upload.php:233 src/Model/Photo.php:1013
 msgid "Wall Photos"
 msgstr ""
 
@@ -4689,39 +4689,17 @@ msgstr ""
 msgid "OpenWebAuth: %1$s welcomes %2$s"
 msgstr ""
 
-#: src/Model/Storage/Database.php:74
-#, php-format
-msgid "Database storage failed to update %s"
-msgstr ""
-
-#: src/Model/Storage/Database.php:82
-msgid "Database storage failed to insert data"
-msgstr ""
-
-#: src/Model/Storage/Filesystem.php:100
-#, php-format
-msgid ""
-"Filesystem storage failed to create \"%s\". Check you write permissions."
-msgstr ""
-
-#: src/Model/Storage/Filesystem.php:148
-#, php-format
-msgid ""
-"Filesystem storage failed to save data to \"%s\". Check your write "
-"permissions"
-msgstr ""
-
-#: src/Model/Storage/Filesystem.php:176
+#: src/Model/Storage/Filesystem.php:187
 msgid "Storage base path"
 msgstr ""
 
-#: src/Model/Storage/Filesystem.php:178
+#: src/Model/Storage/Filesystem.php:189
 msgid ""
 "Folder where uploaded files are saved. For maximum security, This should be "
 "a path outside web server folder tree"
 msgstr ""
 
-#: src/Model/Storage/Filesystem.php:191
+#: src/Model/Storage/Filesystem.php:202
 msgid "Enter a valid existing folder"
 msgstr ""
 
@@ -5004,7 +4982,7 @@ msgstr ""
 #: src/Module/Admin/Blocklist/Server.php:88 src/Module/Admin/Federation.php:159
 #: src/Module/Admin/Item/Delete.php:65 src/Module/Admin/Logs/Settings.php:80
 #: src/Module/Admin/Logs/View.php:64 src/Module/Admin/Queue.php:72
-#: src/Module/Admin/Site.php:498 src/Module/Admin/Storage.php:118
+#: src/Module/Admin/Site.php:498 src/Module/Admin/Storage.php:131
 #: src/Module/Admin/Summary.php:232 src/Module/Admin/Themes/Details.php:90
 #: src/Module/Admin/Themes/Index.php:111 src/Module/Admin/Tos.php:58
 #: src/Module/Admin/Users/Active.php:136 src/Module/Admin/Users/Blocked.php:137
@@ -6463,31 +6441,41 @@ msgstr ""
 msgid "Start Relocation"
 msgstr ""
 
-#: src/Module/Admin/Storage.php:72
+#: src/Module/Admin/Storage.php:45
+#, php-format
+msgid "Storage backend, %s is invalid."
+msgstr ""
+
+#: src/Module/Admin/Storage.php:71
+#, php-format
+msgid "Storage backend %s error: %s"
+msgstr ""
+
+#: src/Module/Admin/Storage.php:82 src/Module/Admin/Storage.php:85
 msgid "Invalid storage backend setting value."
 msgstr ""
 
-#: src/Module/Admin/Storage.php:119 src/Module/BaseAdmin.php:91
+#: src/Module/Admin/Storage.php:132 src/Module/BaseAdmin.php:91
 msgid "Storage"
 msgstr ""
 
-#: src/Module/Admin/Storage.php:121
+#: src/Module/Admin/Storage.php:134
 msgid "Save & Activate"
 msgstr ""
 
-#: src/Module/Admin/Storage.php:122
+#: src/Module/Admin/Storage.php:135
 msgid "Activate"
 msgstr ""
 
-#: src/Module/Admin/Storage.php:123
+#: src/Module/Admin/Storage.php:136
 msgid "Save & Reload"
 msgstr ""
 
-#: src/Module/Admin/Storage.php:124
+#: src/Module/Admin/Storage.php:137
 msgid "This backend doesn't have custom settings"
 msgstr ""
 
-#: src/Module/Admin/Storage.php:127
+#: src/Module/Admin/Storage.php:140
 msgid "Database (legacy)"
 msgstr ""
 
@@ -8700,17 +8688,17 @@ msgstr ""
 msgid "Visible to:"
 msgstr ""
 
-#: src/Module/Photo.php:94
+#: src/Module/Photo.php:98
 #, php-format
 msgid "The Photo with id %s is not available."
 msgstr ""
 
-#: src/Module/Photo.php:124
+#: src/Module/Photo.php:132
 #, php-format
 msgid "Invalid external resource with url %s."
 msgstr ""
 
-#: src/Module/Photo.php:126
+#: src/Module/Photo.php:134
 #, php-format
 msgid "Invalid photo with id %s."
 msgstr ""
@@ -9465,42 +9453,42 @@ msgid ""
 "contacts or the Friendica contacts in the selected groups.</p>"
 msgstr ""
 
-#: src/Module/Settings/Profile/Photo/Crop.php:102
-#: src/Module/Settings/Profile/Photo/Crop.php:118
-#: src/Module/Settings/Profile/Photo/Crop.php:134
+#: src/Module/Settings/Profile/Photo/Crop.php:106
+#: src/Module/Settings/Profile/Photo/Crop.php:122
+#: src/Module/Settings/Profile/Photo/Crop.php:138
 #: src/Module/Settings/Profile/Photo/Index.php:102
 #, php-format
 msgid "Image size reduction [%s] failed."
 msgstr ""
 
-#: src/Module/Settings/Profile/Photo/Crop.php:139
+#: src/Module/Settings/Profile/Photo/Crop.php:143
 msgid ""
 "Shift-reload the page or clear browser cache if the new photo does not "
 "display immediately."
 msgstr ""
 
-#: src/Module/Settings/Profile/Photo/Crop.php:144
+#: src/Module/Settings/Profile/Photo/Crop.php:148
 msgid "Unable to process image"
 msgstr ""
 
-#: src/Module/Settings/Profile/Photo/Crop.php:163
+#: src/Module/Settings/Profile/Photo/Crop.php:167
 msgid "Photo not found."
 msgstr ""
 
-#: src/Module/Settings/Profile/Photo/Crop.php:185
+#: src/Module/Settings/Profile/Photo/Crop.php:189
 msgid "Profile picture successfully updated."
 msgstr ""
 
-#: src/Module/Settings/Profile/Photo/Crop.php:208
-#: src/Module/Settings/Profile/Photo/Crop.php:212
+#: src/Module/Settings/Profile/Photo/Crop.php:215
+#: src/Module/Settings/Profile/Photo/Crop.php:219
 msgid "Crop Image"
 msgstr ""
 
-#: src/Module/Settings/Profile/Photo/Crop.php:209
+#: src/Module/Settings/Profile/Photo/Crop.php:216
 msgid "Please adjust the image cropping for optimum viewing."
 msgstr ""
 
-#: src/Module/Settings/Profile/Photo/Crop.php:211
+#: src/Module/Settings/Profile/Photo/Crop.php:218
 msgid "Use Image As Is"
 msgstr ""
 


### PR DESCRIPTION
This PR is another preparation for additional, selectable storages.

I extracted all methods for selectable storage backends (currently Filesystem & DB) from `IStorage` to `ISelectableStorage`. So all the `BadMethodCallException`s aren't necessary anymore. I split the corresponding `get` operations of the StorageManager as well. So there's no need for an extra parameter `userBackend` anymore. Instead you use either the `getByName()` method to geht ANY backend, or you use the `getSelectableByName()` to get a specific, selectable backend. No need for any other checks.

Another improvement is the error handling. The backend per se doesn't need to know what the caller tries to do with the content. Therefore it shouldn't decide if an error of the persistence-layer is "acceptable" or not, it just throws an exception in case the call isn't right (e.g. you want to delete something, which doesn't exist, or get something, which doesn't exist). The caller is now responsible to catch the exception and do whatever he needs to do :).

Therefore I created two exceptions, the `ReferenceStorageExecption` for exceptions, where the caller uses invalid references and the `StorageException` for "the rest".

I used this branch (with Filesystem backend) for a couple of days without any exception so far.