### PR TITLE
Add hostname to Locks

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -1,6 +1,6 @@
 -- ------------------------------------------
 -- Friendica 2021.09-dev (Siberian Iris)
--- DB_UPDATE_VERSION 1433
+-- DB_UPDATE_VERSION 1435
 -- ------------------------------------------
 
 
@@ -735,10 +735,13 @@ CREATE TABLE IF NOT EXISTS `locks` (
 	`id` int unsigned NOT NULL auto_increment COMMENT 'sequential ID',
 	`name` varchar(128) NOT NULL DEFAULT '' COMMENT '',
 	`locked` boolean NOT NULL DEFAULT '0' COMMENT '',
-	`pid` int unsigned NOT NULL DEFAULT 0 COMMENT 'Process ID',
+	`pid` int unsigned NOT NULL DEFAULT 0 COMMENT 'The process id of the current worker',
+	`host-id` tinyint unsigned NOT NULL DEFAULT 0 COMMENT 'Host id',
 	`expires` datetime NOT NULL DEFAULT '0001-01-01 00:00:00' COMMENT 'datetime of cache expiration',
 	 PRIMARY KEY(`id`),
-	 INDEX `name_expires` (`name`,`expires`)
+	 INDEX `name_expires` (`name`,`expires`),
+	 INDEX `locked_hostid_pid_expires` (`locked`, `host-id`, `pid`, `expires`),
+		FOREIGN KEY (`host-id`) REFERENCES `host` (`id`) ON UPDATE RESTRICT ON DELETE CASCADE
 ) DEFAULT COLLATE utf8mb4_general_ci COMMENT='';
 
 --

--- a/src/Collection/Hosts.php
+++ b/src/Collection/Hosts.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Friendica\Collection;
+
+use Friendica\BaseCollection;
+use Friendica\Model;
+
+class Hosts extends BaseCollection
+{
+	/**
+	 * @return Model\Host
+	 */
+	public function current(): Model\Host
+	{
+		return parent::current();
+	}
+}

--- a/src/Core/Update.php
+++ b/src/Core/Update.php
@@ -130,6 +130,9 @@ class Update
 			if ($stored < $current || $force) {
 				DI::config()->load('database');
 
+				// Check for updates for the lock & host table itself (necessary before used for locks ..)
+				DBStructure::updateLockTable(DI::app()->getBasePath(), $verbose, true, false);
+
 				// Compare the current structure with the defined structure
 				// If the Lock is acquired, never release it automatically to avoid double updates
 				if (DI::lock()->acquire('dbupdate', 0, Cache\Duration::INFINITE)) {

--- a/src/Database/DBStructure.php
+++ b/src/Database/DBStructure.php
@@ -530,6 +530,37 @@ class DBStructure
 	}
 
 	/**
+	 * Explicit updates the Lock table
+	 * This is necessary in case of self-updating the lock table
+	 *
+	 * @param string  $basePath
+	 * @param boolean $verbose
+	 * @param boolean $action
+	 * @param boolean $install
+	 *
+	 * @throws Exception
+	 */
+	public static function updateLockTable(string $basePath, bool $verbose, bool $action, bool $install)
+	{
+		if (DBStructure::existsTable('host')) {
+			$lockTable = [['tables_in_friendica' => 'host']];
+		} else {
+			$lockTable = [];
+		}
+
+		$definition          = self::definition($basePath);
+		$lockTableDefinition = ['host' => $definition['host']];
+
+		self::update($basePath, $verbose, $action, $install, $lockTable, $lockTableDefinition);
+
+		$lockTable           = [['tables_in_friendica' => 'locks']];
+		$definition          = self::definition($basePath);
+		$lockTableDefinition = ['locks' => $definition['locks']];
+
+		self::update($basePath, $verbose, $action, $install, $lockTable, $lockTableDefinition);
+	}
+
+	/**
 	 * Updates DB structure and returns eventual errors messages
 	 *
 	 * @param string $basePath   The base path of this application
@@ -553,9 +584,14 @@ class DBStructure
 			DI::config()->set('system', 'maintenance_reason', DI::l10n()->t('%s: Database update', DateTimeFormat::utcNow() . ' ' . date('e')));
 		}
 
+		// If true, the update routine just updates the tables and no other steps, like initial values, views, ..
+		$straightUpdate = !is_null($tables) && !is_null($definition);
+
 		// ensure that all initial values exist. This test has to be done prior and after the structure check.
 		// Prior is needed if the specific tables already exists - after is needed when they had been created.
-		self::checkInitialValues();
+		if ($straightUpdate) {
+			self::checkInitialValues();
+		}
 
 		$errors = '';
 
@@ -901,9 +937,11 @@ class DBStructure
 			}
 		}
 
-		View::create(false, $action);
+		if ($straightUpdate) {
+			View::create(false, $action);
 
-		self::checkInitialValues();
+			self::checkInitialValues();
+		}
 
 		if ($action && !$install) {
 			if ($errors) {

--- a/src/Model/Host.php
+++ b/src/Model/Host.php
@@ -21,59 +21,12 @@
 
 namespace Friendica\Model;
 
-use Friendica\Core\Logger;
-use Friendica\Database\DBA;
+use Friendica\BaseModel;
 
-class Host
+/**
+ * @property string name
+ */
+class Host extends BaseModel
 {
-	/**
-	 * Get the id for a given hostname
-	 * When empty, the current hostname is used
-	 *
-	 * @param string $hostname
-	 *
-	 * @return integer host name id
-	 * @throws \Exception
-	 */
-	public static function getId(string $hostname = '')
-	{
-		if (empty($hostname)) {
-			$hostname = php_uname('n');
-		}
 
-		$hostname = strtolower($hostname);
-
-		$host = DBA::selectFirst('host', ['id'], ['name' => $hostname]);
-		if (!empty($host['id'])) {
-			return $host['id'];
-		}
-
-		DBA::replace('host', ['name' => $hostname]);
-
-		$host = DBA::selectFirst('host', ['id'], ['name' => $hostname]);
-		if (empty($host['id'])) {
-			Logger::warning('Host name could not be inserted', ['name' => $hostname]);
-			return 0;
-		}
-
-		return $host['id'];
-	}
-
-	/**
-	 * Get the hostname for a given id
-	 *
-	 * @param int $id
-	 *
-	 * @return string host name
-	 * @throws \Exception
-	 */
-	public static function getName(int $id)
-	{
-		$host = DBA::selectFirst('host', ['name'], ['id' => $id]);
-		if (!empty($host['name'])) {
-			return $host['name'];
-		}
-
-		return '';
-	}
 }

--- a/src/Repository/Host.php
+++ b/src/Repository/Host.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Friendica\Repository;
+
+use Exception;
+use Friendica\BaseRepository;
+use Friendica\Model;
+use Friendica\Collection;
+use Friendica\Network\HTTPException\InternalServerErrorException;
+use Friendica\Network\HTTPException\NotFoundException;
+
+class Host extends BaseRepository
+{
+	/**
+	 * Defines the environment variable, which includes the current node name instead of the detected hostname
+	 *
+	 * @var string
+	 *
+	 * @notice This is used for cluster environments, where the each node defines it own hostname.
+	 */
+	const ENV_VARIABLE = 'NODE_NAME';
+
+	protected static $table_name = 'host';
+
+	protected static $model_class = Model\Host::class;
+
+	protected static $collection_class = Collection\Hosts::class;
+
+	/**
+	 * @param array $data
+	 * @return Model\Host
+	 */
+	protected function create(array $data): Model\Host
+	{
+		return new Model\Host($this->dba, $this->logger, $data);
+	}
+
+	/**
+	 * @param array $server The $_SERVER variable
+	 *
+	 * @return Model\Host
+	 * @throws InternalServerErrorException
+	 * @throws Exception
+	 */
+	public function selectCurrentHost(array $server = []): Model\Host
+	{
+		$hostname = $server[self::ENV_VARIABLE] ?? null;
+
+		if (empty($hostname)) {
+			$hostname = gethostname();
+		}
+
+		// Trim whitespaces first to avoid getting an empty hostname
+		// For linux the hostname is read from file /proc/sys/kernel/hostname directly
+		$hostname = trim($hostname);
+		if (empty($hostname)) {
+			throw new InternalServerErrorException('Empty hostname is invalid.');
+		}
+
+		$hostname = strtolower($hostname);
+
+		$data = $this->dba->selectFirst(self::$table_name, ['id', 'name'], ['name' => $hostname]);
+		if (!empty($data['id'])) {
+			return $this->create($data);
+		} else {
+			$this->dba->replace(self::$table_name, ['name' => $hostname]);
+
+			return $this->selectFirst(['name' => $hostname]);
+		}
+	}
+
+	/**
+	 * @param array $condition
+	 * @return Model\Host
+	 * @throws NotFoundException
+	 */
+	public function selectFirst(array $condition): Model\Host
+	{
+		return parent::selectFirst($condition);
+	}
+
+	/**
+	 * @param array $condition
+	 * @param array $params
+	 * @return Collection\Hosts
+	 * @throws Exception
+	 */
+	public function select(array $condition = [], array $params = []): Collection\Hosts
+	{
+		return parent::select($condition, $params);
+	}
+
+	/**
+	 * @param array $condition
+	 * @param array $params
+	 * @param int|null $max_id
+	 * @param int|null $since_id
+	 * @param int $limit
+	 * @return Collection\Hosts
+	 * @throws Exception
+	 */
+	public function selectByBoundaries(array $condition = [], array $params = [], int $max_id = null, int $since_id = null, int $limit = self::LIMIT): Collection\Hosts
+	{
+		return parent::selectByBoundaries($condition, $params, $max_id, $since_id, $limit);
+	}
+}

--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -55,7 +55,7 @@
 use Friendica\Database\DBA;
 
 if (!defined('DB_UPDATE_VERSION')) {
-	define('DB_UPDATE_VERSION', 1433);
+	define('DB_UPDATE_VERSION', 1435);
 }
 
 return [
@@ -795,12 +795,15 @@ return [
 			"id" => ["type" => "int unsigned", "not null" => "1", "extra" => "auto_increment", "primary" => "1", "comment" => "sequential ID"],
 			"name" => ["type" => "varchar(128)", "not null" => "1", "default" => "", "comment" => ""],
 			"locked" => ["type" => "boolean", "not null" => "1", "default" => "0", "comment" => ""],
-			"pid" => ["type" => "int unsigned", "not null" => "1", "default" => "0", "comment" => "Process ID"],
+			"host-id" => ["type" => "tinyint unsigned", "not null" => "1", "default" => "0", "foreign" => ["host" => "id"], "comment" => "Host id"],
+			"pid" => ["type" => "int unsigned", "not null" => "1", "default" => "0", "comment" => "The process id of the worker"],
 			"expires" => ["type" => "datetime", "not null" => "1", "default" => DBA::NULL_DATETIME, "comment" => "datetime of cache expiration"],
 		],
 		"indexes" => [
 			"PRIMARY" => ["id"],
-			"name_expires" => ["name", "expires"]
+			"host-id" => ["host-id"],
+			"name_expires" => ["name", "expires"],
+			"locked_hostid_pid_expires" => ["locked", "host-id", "pid", "expires"],
 		]
 	],
 	"mail" => [

--- a/static/dependencies.config.php
+++ b/static/dependencies.config.php
@@ -227,4 +227,10 @@ return [
 			$_SERVER
 		],
 	],
+	Friendica\Model\Host::class => [
+		'instanceOf' => Friendica\Repository\Host::class,
+		'call' => [
+			['selectCurrentHost', [$_SERVER], Dice::CHAIN_CALL],
+		],
+	],
 ];

--- a/tests/src/Core/Lock/APCuCacheLockTest.php
+++ b/tests/src/Core/Lock/APCuCacheLockTest.php
@@ -40,6 +40,6 @@ class APCuCacheLockTest extends LockTest
 
 	protected function getInstance()
 	{
-		return new CacheLock(new APCuCache('localhost'));
+		return new CacheLock(new APCuCache('localhost'), $this->hostId);
 	}
 }

--- a/tests/src/Core/Lock/ArrayCacheLockTest.php
+++ b/tests/src/Core/Lock/ArrayCacheLockTest.php
@@ -28,7 +28,7 @@ class ArrayCacheLockTest extends LockTest
 {
 	protected function getInstance()
 	{
-		return new CacheLock(new ArrayCache('localhost'));
+		return new CacheLock(new ArrayCache('localhost'), $this->hostId);
 	}
 
 	/**

--- a/tests/src/Core/Lock/DatabaseLockDriverTest.php
+++ b/tests/src/Core/Lock/DatabaseLockDriverTest.php
@@ -23,6 +23,7 @@ namespace Friendica\Test\src\Core\Lock;
 
 use Friendica\Core\Lock\DatabaseLock;
 use Friendica\Factory\ConfigFactory;
+use Friendica\Model\Host;
 use Friendica\Test\DatabaseTestTrait;
 use Friendica\Test\Util\Database\StaticDatabase;
 use Friendica\Test\Util\VFSTrait;
@@ -62,7 +63,9 @@ class DatabaseLockDriverTest extends LockTest
 
 		$dba = new StaticDatabase($configCache, $profiler, $logger);
 
-		return new DatabaseLock($dba, $this->pid);
+		$host = new Host($dba, new NullLogger(), ['name' => 'test', 'id' => 1]);
+
+		return new DatabaseLock($dba, $host->id, $this->pid);
 	}
 
 	protected function tearDown(): void

--- a/tests/src/Core/Lock/LockTest.php
+++ b/tests/src/Core/Lock/LockTest.php
@@ -31,6 +31,9 @@ abstract class LockTest extends MockedTest
 	 */
 	protected $startTime = 1417011228;
 
+	/** @var string the test host */
+	protected $hostId = 1;
+
 	/**
 	 * @var ILock
 	 */

--- a/tests/src/Core/Lock/MemcacheCacheLockTest.php
+++ b/tests/src/Core/Lock/MemcacheCacheLockTest.php
@@ -53,7 +53,7 @@ class MemcacheCacheLockTest extends LockTest
 
 		try {
 			$cache = new MemcacheCache($host, $configMock);
-			$lock = new CacheLock($cache);
+			$lock = new CacheLock($cache, $this->hostId);
 		} catch (Exception $e) {
 			static::markTestSkipped('Memcache is not available');
 		}

--- a/tests/src/Core/Lock/MemcachedCacheLockTest.php
+++ b/tests/src/Core/Lock/MemcachedCacheLockTest.php
@@ -52,7 +52,7 @@ class MemcachedCacheLockTest extends LockTest
 
 		try {
 			$cache = new MemcachedCache($host, $configMock, $logger);
-			$lock = new CacheLock($cache);
+			$lock = new CacheLock($cache, $this->hostId);
 		} catch (Exception $e) {
 			static::markTestSkipped('Memcached is not available');
 		}

--- a/tests/src/Core/Lock/RedisCacheLockTest.php
+++ b/tests/src/Core/Lock/RedisCacheLockTest.php
@@ -62,7 +62,7 @@ class RedisCacheLockTest extends LockTest
 
 		try {
 			$cache = new RedisCache($host, $configMock);
-			$lock = new CacheLock($cache);
+			$lock = new CacheLock($cache, $this->hostId);
 		} catch (Exception $e) {
 			static::markTestSkipped('Redis is not available. Error: ' . $e->getMessage());
 		}

--- a/tests/src/Repository/HostRepositoryTest.php
+++ b/tests/src/Repository/HostRepositoryTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Friendica\Test\src\Repository;
+
+use Friendica\Database\Database;
+use Friendica\Network\HTTPException\InternalServerErrorException;
+use Friendica\Network\HTTPException\NotFoundException;
+use Friendica\Repository;
+use Friendica\Test\MockedTest;
+use Mockery\MockInterface;
+use Psr\Log\NullLogger;
+
+class HostRepositoryTest extends MockedTest
+{
+	/** @var Database|MockInterface */
+	private $dba;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+
+		$this->dba = \Mockery::mock(Database::class);
+	}
+
+	public function testInstance()
+	{
+		$hostRepo = new Repository\Host($this->dba, new NullLogger());
+
+		$this->assertInstanceOf(Repository\Host::class, $hostRepo);
+	}
+
+	public function testExistingHost()
+	{
+		$this->dba->shouldReceive('selectFirst')->andReturn(['id' => 1, 'name' => gethostname()])->once();
+
+		$hostRepo = new Repository\Host($this->dba, new NullLogger());
+		$host     = $hostRepo->selectCurrentHost();
+
+		$this->assertEquals(gethostname(), $host->name);
+		$this->assertEquals(1, $host->id);
+	}
+
+	public function testHostOverride()
+	{
+		$this->dba->shouldReceive('selectFirst')->andReturn(['id' => 1, 'name' => 'testserver.test'])->once();
+
+		$hostRepo = new Repository\Host($this->dba, new NullLogger());
+		$host     = $hostRepo->selectCurrentHost([Repository\Host::ENV_VARIABLE => 'testserver.test']);
+
+		$this->assertEquals('testserver.test', $host->name);
+		$this->assertEquals(1, $host->id);
+	}
+
+	public function testExceptionForEmptyHostname()
+	{
+		$this->expectException(InternalServerErrorException::class);
+		$this->expectExceptionMessage('Empty hostname is invalid.');
+
+		$hostRepo = new Repository\Host($this->dba, new NullLogger());
+		$hostRepo->selectCurrentHost([Repository\Host::ENV_VARIABLE => ' ']);
+	}
+
+	public function testNewHostname()
+	{
+		$this->dba->shouldReceive('selectFirst')->andReturn([])->once();
+		$this->dba->shouldReceive('replace')->once();
+		$this->dba->shouldReceive('selectFirst')->andReturn(['id' => 1, 'name' => gethostname()])->once();
+
+		$hostRepo = new Repository\Host($this->dba, new NullLogger());
+		$host     = $hostRepo->selectCurrentHost();
+
+		$this->assertEquals(gethostname(), $host->name);
+		$this->assertEquals(1, $host->id);
+	}
+
+	public function testBadInsert()
+	{
+		$this->expectException(NotFoundException::class);
+
+		$this->dba->shouldReceive('selectFirst')->andReturn([])->once();
+		$this->dba->shouldReceive('replace')->once();
+		$this->dba->shouldReceive('selectFirst')->andReturn([])->once();
+
+		$hostRepo = new Repository\Host($this->dba, new NullLogger());
+		$hostRepo->selectCurrentHost();
+	}
+}


### PR DESCRIPTION
Superseded #9114 

This should help with #9095 

We now add the hostname to each lock as well. The hostname is detected based on either uname -n or per environment variable NODE_NAME. This will have the effect that for normal setups, nothing changes except that in the db, there's now a new column "hostname" as well. But for cluster, we can now override this behaviour with "NODE_NAME" where each node can manually override this value with it's node-name-id .

And now the workers are ready for multi-nodes :-)

Still .. the update mechanism isn't ready, so draft only ...