### PR TITLE
Clarify XMPP profile field description

### DIFF
--- a/src/Module/Settings/Profile/Index.php
+++ b/src/Module/Settings/Profile/Index.php
@@ -241,7 +241,7 @@ class Index extends BaseSettings
 			'$postal_code' => ['postal_code', DI::l10n()->t('Postal/Zip Code:'), $profile['postal-code']],
 			'$country_name' => ['country_name', DI::l10n()->t('Country:'), $profile['country-name']],
 			'$age' => ((intval($profile['dob'])) ? '(' . DI::l10n()->t('Age: ') . DI::l10n()->tt('%d year old', '%d years old', Temporal::getAgeByTimezone($profile['dob'], $profile['timezone'])) . ')' : ''),
-			'$xmpp' => ['xmpp', DI::l10n()->t('XMPP (Jabber) address:'), $profile['xmpp'], DI::l10n()->t('The XMPP address will be propagated to your contacts so that they can follow you.')],
+			'$xmpp' => ['xmpp', DI::l10n()->t('XMPP (Jabber) address:'), $profile['xmpp'], DI::l10n()->t('The XMPP address will be published so that people can follow you there.')],
 			'$matrix' => ['matrix', DI::l10n()->t('Matrix (Element) address:'), $profile['matrix'], DI::l10n()->t('The Matrix address will be published so that people can follow you there.')],
 			'$homepage' => ['homepage', DI::l10n()->t('Homepage URL:'), $profile['homepage']],
 			'$pub_keywords' => ['pub_keywords', DI::l10n()->t('Public Keywords:'), $profile['pub_keywords'], DI::l10n()->t('(Used for suggesting potential friends, can be seen by others)')],

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2021.09-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-08-12 06:32+0000\n"
+"POT-Creation-Date: 2021-08-16 06:14+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -9422,9 +9422,7 @@ msgid "XMPP (Jabber) address:"
 msgstr ""
 
 #: src/Module/Settings/Profile/Index.php:244
-msgid ""
-"The XMPP address will be propagated to your contacts so that they can follow "
-"you."
+msgid "The XMPP address will be published so that people can follow you there."
 msgstr ""
 
 #: src/Module/Settings/Profile/Index.php:245


### PR DESCRIPTION
In PR #10588 the description of the XMPP profile field had been clarified, see here:

https://github.com/friendica/friendica/blob/bee04f86ee716aa9271a262ad6b8ceed26aa4a6e/src/Module/Settings/Profile/Index.php#L247

For unknown reasons that change had been reverted - so this PR reverts the revert.