### PR TITLE
Add the attachments to the $item for the prepare_body_content_filter hook

### DIFF
--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -2757,6 +2757,8 @@ class Item
 				$filter_reasons[] = DI::l10n()->t('Content warning: %s', $item['content-warning']);
 			}
 
+			$item['attachments'] = $attachments;
+
 			$hook_data = [
 				'item' => $item,
 				'filter_reasons' => $filter_reasons

--- a/src/Model/Post/Media.php
+++ b/src/Model/Post/Media.php
@@ -534,7 +534,7 @@ class Media
 	 *
 	 * @param int    $uri_id
 	 * @param string $guid
-	 * @param array  $links ist of links that shouldn't be added
+	 * @param array  $links list of links that shouldn't be added
 	 * @return array attachments
 	 */
 	public static function splitAttachments(int $uri_id, string $guid = '', array $links = [])


### PR DESCRIPTION
- Allows filtering on attachments that are added later to the post content

See discussion: https://social.diekershoff.de/display/f3ad7b1c-1961-1a08-88c7-4c2585352355

Required addon pendant: https://github.com/friendica/friendica-addons/pull/1157