### PR TITLE
Escape url tags before attempting to add missing mention links in Protocol\ActivityPub\Processor

### DIFF
--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -1207,20 +1207,24 @@ class Processor
 		// This prevents links to be added again to Pleroma-style mention links
 		$body = self::normalizeMentionLinks($body);
 
-		foreach ($tags as $tag) {
-			if (empty($tag['name']) || empty($tag['type']) || empty($tag['href']) || !in_array($tag['type'], ['Mention', 'Hashtag'])) {
-				continue;
+		$body = BBCode::performWithEscapedTags($body, ['url'], function ($body) use ($tags) {
+			foreach ($tags as $tag) {
+				if (empty($tag['name']) || empty($tag['type']) || empty($tag['href']) || !in_array($tag['type'], ['Mention', 'Hashtag'])) {
+					continue;
+				}
+
+				$hash = substr($tag['name'], 0, 1);
+				$name = substr($tag['name'], 1);
+				if (!in_array($hash, Tag::TAG_CHARACTER)) {
+					$hash = '';
+					$name = $tag['name'];
+				}
+
+				$body = str_replace($tag['name'], $hash . '[url=' . $tag['href'] . ']' . $name . '[/url]', $body);
 			}
 
-			$hash = substr($tag['name'], 0, 1);
-			$name = substr($tag['name'], 1);
-			if (!in_array($hash, Tag::TAG_CHARACTER)) {
-				$hash = '';
-				$name = $tag['name'];
-			}
-
-			$body = str_replace($tag['name'], $hash . '[url=' . $tag['href'] . ']' . $name . '[/url]', $body);
-		}
+			return $body;
+		});
 
 		return $body;
 	}

--- a/tests/src/Protocol/ActivityPub/ProcessorTest.php
+++ b/tests/src/Protocol/ActivityPub/ProcessorTest.php
@@ -70,6 +70,17 @@ class ProcessorTest extends TestCase
 					]
 				],
 			],
+			'issue-10617' => [
+				'expected' => '@[url=https://mastodon.technology/@sergey_m]sergey_m[/url]',
+				'body'     => '@[url=https://mastodon.technology/@sergey_m]sergey_m[/url]',
+				'tags'     => [
+					[
+						'type' => 'Mention',
+						'href' => 'https://mastodon.technology/@sergey_m',
+						'name' => '@sergey_m'
+					],
+				],
+			],
 		];
 	}
 


### PR DESCRIPTION
- Mastodon uses `@`-sign in profile URLs which wrongly triggered the mention link add in existing mentions links

Fixes #10617