### PR TITLE
Reliably display "like" and "share" notifications

### DIFF
--- a/mod/ping.php
+++ b/mod/ping.php
@@ -462,10 +462,10 @@ function ping_get_notifications($uid)
 				&& empty($result[$notification['parent']])
 			) {
 				// Should we condense the notifications or show them all?
-				if (DI::pConfig()->get(local_user(), 'system', 'detailed_notif')) {
-					$result[$notification["id"]] = $notification;
+				if (($notification['verb'] != Activity::POST) || DI::pConfig()->get(local_user(), 'system', 'detailed_notif')) {
+					$result[] = $notification;
 				} else {
-					$result[$notification['parent']] = $notification;
+					$result['p:' . $notification['parent']] = $notification;
 				}
 			}
 		}

--- a/src/Model/Notification.php
+++ b/src/Model/Notification.php
@@ -222,10 +222,17 @@ class Notification extends BaseModel
 				}
 			}
 
-			if (($notification['type'] == Post\UserNotification::NOTIF_SHARED) && !empty($item['causer-id'])) {
-				$causer = Contact::getById($item['causer-id'], ['id', 'name', 'url']);
+			if ($item['owner-id'] != $item['author-id']) {
+				$cid = $item['owner-id'];
+			}
+			if (!empty($item['causer-id']) && ($item['causer-id'] != $item['author-id'])) {
+				$cid = $item['causer-id'];
+			}
+
+			if (($notification['type'] == Post\UserNotification::NOTIF_SHARED) && !empty($cid)) {
+				$causer = Contact::getById($cid, ['id', 'name', 'url']);
 				if (empty($contact)) {
-					Logger::info('Causer not found', ['causer' => $item['causer-id']]);
+					Logger::info('Causer not found', ['causer' => $cid]);
 					return $message;
 				}
 			} elseif (in_array($notification['type'], [Post\UserNotification::NOTIF_COMMENT_PARTICIPATION, Post\UserNotification::NOTIF_ACTIVITY_PARTICIPATION])) {


### PR DESCRIPTION
Notifications on the desktop concerning a like or a shared post are now displayed reliably. 