### PR TITLE
Allow a GuzzleResponse body to be queried more than once

### DIFF
--- a/mod/follow.php
+++ b/mod/follow.php
@@ -60,8 +60,7 @@ function follow_content(App $a)
 
 	$uid = local_user();
 
-	// Issue 4815: Silently removing a prefixing @
-	$url = ltrim(Strings::escapeTags(trim($_REQUEST['url'] ?? '')), '@!');
+	$url = Probe::cleanURI(trim($_REQUEST['url'] ?? ''));
 
 	// Issue 6874: Allow remote following from Peertube
 	if (strpos($url, 'acct:') === 0) {

--- a/src/Console/Contact.php
+++ b/src/Console/Contact.php
@@ -25,6 +25,7 @@ use Console_Table;
 use Friendica\App;
 use Friendica\Model\Contact as ContactModel;
 use Friendica\Model\User as UserModel;
+use Friendica\Network\Probe;
 use Friendica\Util\Temporal;
 use RuntimeException;
 use Seld\CliPrompt\CliPrompt;
@@ -152,6 +153,8 @@ HELP;
 				throw new RuntimeException('A contact URL must be specified.');
 			}
 		}
+
+		$url = Probe::cleanURI($url);
 
 		$contact = ContactModel::getByURLForUser($url, $user['uid']);
 		if (!empty($contact)) {

--- a/src/Module/Debug/Probe.php
+++ b/src/Module/Debug/Probe.php
@@ -44,6 +44,7 @@ class Probe extends BaseModule
 		$res  = '';
 
 		if (!empty($addr)) {
+			$addr = NetworkProbe::cleanURI($addr);
 			$res = NetworkProbe::uri($addr, '', 0);
 			$res = print_r($res, true);
 		}

--- a/src/Network/GuzzleResponse.php
+++ b/src/Network/GuzzleResponse.php
@@ -147,8 +147,8 @@ class GuzzleResponse extends Response implements IHTTPResult, ResponseInterface
 	}
 
 	/// @todo - fix mismatching use of "getBody()" as string here and parent "getBody()" as streaminterface
-	public function getBody()
+	public function getBody(): string
 	{
-		return parent::getBody()->getContents();
+		return (string) parent::getBody();
 	}
 }


### PR DESCRIPTION
- Using `StreamInterface->getContents` left the stream index at the end of the stream, which made every subsequent call to `getBody()` return empty string
- Using `StreamInterface->__toString()` magic method correctly seek the stream to the start before reading

Follow-up to #10619
Fixes #10623
Fixes #10624
Fixes #10625
Fixes #10626

Additionally, this PR adds probe support to `@user@domain.tld` search string format