### PR TITLE
Use temporary files for the URLResolver CookieJar

### DIFF
--- a/src/Factory/HTTPClientFactory.php
+++ b/src/Factory/HTTPClientFactory.php
@@ -103,7 +103,7 @@ class HTTPClientFactory extends BaseFactory
 		$resolver->setMaxResponseDataSize(1000000);
 		// Designate a temporary file that will store cookies during the session.
 		// Some websites test the browser for cookie support, so this enhances results.
-		$resolver->setCookieJar(get_temppath() . '/url_resolver.cookie', true);
+		$resolver->setCookieJar(tempnam(get_temppath(), 'resolver-cookie-'));
 
 		return new HTTPClient($logger, $this->profiler, $guzzle, $resolver);
 	}


### PR DESCRIPTION
Addresses https://github.com/friendica/friendica/issues/10475#issuecomment-905754227
FollowUp #10633 

We're now using a unique name for each HTTPClient instance, so concurrent workers doesn't share the same name